### PR TITLE
Add cross-references for iterator categories.

### DIFF
--- a/source/regex.tex
+++ b/source/regex.tex
@@ -111,15 +111,15 @@ defining types and functions for the character container
 type \tcode{charT}; \tcode{u} is an object of
 type \tcode{X}; \tcode{v} is an object of type \tcode{const 
 X}; \tcode{p} is a value of type \tcode{const charT*}; \tcode{I1}
-and \tcode{I2} are Input Iterators;
-\tcode{F1} and \tcode{F2} are forward iterators; 
+and \tcode{I2} are input iterators~(\ref{input.iterators});
+\tcode{F1} and \tcode{F2} are forward iterators~(\ref{forward.iterators}); 
 \tcode{c} is a value of type \tcode{const charT};
 \tcode{s} is an object of type \tcode{X::string_type}; 
 \tcode{cs} is an object of type \tcode{const X::string_type}; 
 \tcode{b} is a value of  type \tcode{bool}; 
 \tcode{I} is a value of type \tcode{int}; 
 \tcode{cl} is an object of type \tcode{X::char_class_type},
-and loc is an object of type \tcode{X::locale_type}.
+and \tcode{loc} is an object of type \tcode{X::locale_type}.
 
 \begin{libreqtab3}
   {Regular expression traits class requirements} 
@@ -246,7 +246,7 @@ and loc is an object of type \tcode{X::locale_type}.
 \enternote
 Class template \tcode{regex_traits} satisfies the requirements for a
 regular expression traits class when it is specialized for
-\tcode{char} or \tcode{wchar_t}.  This Class template is described in
+\tcode{char} or \tcode{wchar_t}.  This class template is described in
 the header \tcode{<regex>}, and is described in Clause~\ref{re.traits}.
 \exitnote
 


### PR DESCRIPTION
Also fix typeface and capitalization.
