### PR TITLE
Fix caption for Table 71

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -1438,7 +1438,7 @@ the member has no effect.
 \tcode{*this}
 
 \begin{libefftabvalue}
-{\tcode{operator=(const basic_string<charT, traits, Allocator>\&\&)} effects}
+{\tcode{operator=(basic_string<charT, traits, Allocator>\&\&)} effects}
 {tab:strings.op=rv}
 \tcode{data()}      &
 points at the array whose first


### PR DESCRIPTION
The parameter should be a non-const rvalue reference
