### PR TITLE
fix typo

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -566,7 +566,7 @@ In Table~\ref{tab:containers.allocatoraware}, \tcode{X} denotes an allocator-awa
 with a \tcode{value_type} of \tcode{T} using allocator of type \tcode{A}, \tcode{u} denotes a
 variable,
 \tcode{a} and \tcode{b} denote non-const lvalues of type \tcode{X},
-\tcode{t} denotes an lvalue or a const rvalue of type X\tcode{}, \tcode{rv} denotes a
+\tcode{t} denotes an lvalue or a const rvalue of type \tcode{X}, \tcode{rv} denotes a
 non-const rvalue of type \tcode{X}, \tcode{m} is a value of type \tcode{A}, and \tcode{Q} is an
 allocator type.
 


### PR DESCRIPTION
X\tcode{} should be \tcode{X}
