### PR TITLE
Fix error in example in 5.1.2 p17

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -819,7 +819,7 @@ void g() {
     int arr[N];             // OK: not an odr-use, refers to automatic variable
     f(&N);                  // OK: causes \tcode{N} to be captured; \tcode{\&N} points to the
                             // corresponding member of the closure type
-  }
+  };
 }
 \end{codeblock}
 \exitexample


### PR DESCRIPTION
Missing semi-colon after the lambda expression
