### PR TITLE
[string.cons] Remove redundant template argument lists.

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -1144,8 +1144,8 @@ The postconditions of this function are indicated in Table~\ref{tab:strings.ctr.
 
 \indexlibrary{\idxcode{basic_string}!constructor}%
 \begin{itemdecl}
-basic_string(const basic_string<charT,traits,Allocator>& str);
-basic_string(basic_string<charT,traits,Allocator>&& str) noexcept;
+basic_string(const basic_string& str);
+basic_string(basic_string&& str) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1170,7 +1170,7 @@ whose first element is pointed at by \tcode{str.data()} \\
 
 \indexlibrary{\idxcode{basic_string}!constructor}%
 \begin{itemdecl}
-basic_string(const basic_string<charT,traits,Allocator>& str,
+basic_string(const basic_string& str,
              size_type pos, size_type n = npos,
              const Allocator& a = Allocator());
 \end{itemdecl}
@@ -1373,8 +1373,7 @@ element is pointed at by the original value of \tcode{str.data()}. \\
 \indexlibrary{\idxcode{operator=}!\idxcode{basic_string}}%
 \indexlibrary{\idxcode{basic_string}!\idxcode{operator=}}%
 \begin{itemdecl}
-basic_string<charT,traits,Allocator>&
-  operator=(const basic_string<charT,traits,Allocator>& str);
+basic_string& operator=(const basic_string& str);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1398,7 +1397,7 @@ the member has no effect.
 \tcode{*this}
 
 \begin{libefftabvalue}
-{\tcode{operator=(const basic_string<charT, traits, Allocator>\&)} effects}
+{\tcode{operator=(const basic_string\&)} effects}
 {tab:strings.op=}
 \tcode{data()}      &
 points at the first element of an allocated copy of the array whose first
@@ -1411,8 +1410,7 @@ element is pointed at by \tcode{str.data()}                                     
 \indexlibrary{\idxcode{operator=}!\idxcode{basic_string}}%
 \indexlibrary{\idxcode{basic_string}!\idxcode{operator=}}%
 \begin{itemdecl}
-basic_string<charT,traits,Allocator>&
-  operator=(basic_string<charT,traits,Allocator>&& str) noexcept;
+basic_string& operator=(basic_string&& str) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1438,7 +1436,7 @@ the member has no effect.
 \tcode{*this}
 
 \begin{libefftabvalue}
-{\tcode{operator=(basic_string<charT, traits, Allocator>\&\&)} effects}
+{\tcode{operator=(basic_string\&\&)} effects}
 {tab:strings.op=rv}
 \tcode{data()}      &
 points at the array whose first
@@ -1451,14 +1449,13 @@ element was pointed at by \tcode{str.data()}                                    
 \indexlibrary{\idxcode{operator=}!\idxcode{basic_string}}%
 \indexlibrary{\idxcode{basic_string}!\idxcode{operator=}}%
 \begin{itemdecl}
-basic_string<charT,traits,Allocator>&
-  operator=(const charT* s);
+basic_string& operator=(const charT* s);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{*this = basic_string<charT,traits,Allocator>(s)}.
+\tcode{*this = basic_string(s)}.
 
 \pnum
 \notes
@@ -1470,13 +1467,13 @@ Uses
 \indexlibrary{\idxcode{operator=}!\idxcode{basic_string}}%
 \indexlibrary{\idxcode{basic_string}!\idxcode{operator=}}%
 \begin{itemdecl}
-basic_string<charT,traits,Allocator>& operator=(charT c);
+basic_string& operator=(charT c);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{*this = basic_string<charT,traits,Allocator>(1,c)}.
+\tcode{*this = basic_string(1,c)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator=}!\idxcode{basic_string}}%
@@ -2428,8 +2425,7 @@ iterator insert(const_iterator p, initializer_list<charT> il);
 \indexlibrary{\idxcode{basic_string}!\idxcode{erase}}%
 \indexlibrary{\idxcode{erase}!\idxcode{basic_string}}%
 \begin{itemdecl}
-basic_string<charT,traits,Allocator>&
-  erase(size_type pos = 0, size_type n = npos);
+basic_string& erase(size_type pos = 0, size_type n = npos);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2822,7 +2818,7 @@ by \tcode{s}.
 \indexlibrary{\idxcode{basic_string}!\idxcode{swap}}%
 \indexlibrary{\idxcode{swap}!\idxcode{basic_string}}%
 \begin{itemdecl}
-void swap(basic_string<charT,traits,Allocator>& s);
+void swap(basic_string& s);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2926,7 +2922,7 @@ size_type find(const charT* s, size_type pos, size_type n) const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{find(basic_string<charT,traits,Allocator>(s,n),pos)}.
+\tcode{find(basic_string(s,n),pos)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{find}!\idxcode{basic_string}}%
@@ -2954,7 +2950,7 @@ size_type find(charT c, size_type pos = 0) const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{find(basic_string<charT,traits,Allocator>(1,c), pos)}.
+\tcode{find(basic_string(1,c), pos)}.
 \end{itemdescr}
 
 \rSec3[string::rfind]{\tcode{basic_string::rfind}}
@@ -3032,7 +3028,7 @@ size_type rfind(charT c, size_type pos = npos) const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{rfind(basic_string<charT,traits,Allocator>(1,c),pos)}.
+\tcode{rfind(basic_string(1,c),pos)}.
 \end{itemdescr}
 
 \rSec3[string::find.first.of]{\tcode{basic_string::find_first_of}}
@@ -3112,7 +3108,7 @@ size_type find_first_of(charT c, size_type pos = 0) const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{find_first_of(basic_string<charT,traits,Allocator>(1,c), pos)}.
+\tcode{find_first_of(basic_string(1,c), pos)}.
 \end{itemdescr}
 
 \rSec3[string::find.last.of]{\tcode{basic_string::find_last_of}}
@@ -3191,7 +3187,7 @@ size_type find_last_of(charT c, size_type pos = npos) const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{find_last_of(basic_string<charT,traits,Allocator>(1,c),pos)}.
+\tcode{find_last_of(basic_string(1,c),pos)}.
 \end{itemdescr}
 
 \rSec3[string::find.first.not.of]{\tcode{basic_string::find_first_not_of}}
@@ -3360,8 +3356,7 @@ size_type find_last_not_of(charT c, size_type pos = npos) const;
 \indexlibrary{\idxcode{basic_string}!\idxcode{substr}}%
 \indexlibrary{\idxcode{substr}!\idxcode{basic_string}}%
 \begin{itemdecl}
-basic_string<charT,traits,Allocator>
-  substr(size_type pos = 0, size_type n = npos) const;
+basic_string substr(size_type pos = 0, size_type n = npos) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3382,7 +3377,7 @@ Determines the effective length \tcode{rlen} of the string to copy as the smalle
 
 \pnum
 \returns
-\tcode{basic_string<charT,traits,Allocator>(data()+pos,rlen)}.
+\tcode{basic_string(data()+pos,rlen)}.
 \end{itemdescr}
 
 \rSec3[string::compare]{\tcode{basic_string::compare}}


### PR DESCRIPTION
Another tidy-up of explicit template argument lists that aren't necessary and IMHO it's easier to read the signatures without them.
