### PR TITLE
Revert 'editorial' change to definition of literal type

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3543,7 +3543,7 @@ A type is a \defn{literal type} if it is:
 
 \begin{itemize}
 \item a scalar type; or
-\item a reference type referring to a literal type; or
+\item a reference type; or
 \item an array of literal type; or
 \item a class type (Clause~\ref{class}) that
 has all of the following properties:


### PR DESCRIPTION
Restore the more liberal definition of 'literal type', as we discussed over email.
