### PR TITLE
[thread.condition.condvar] Replace references to timed_wait

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -2200,8 +2200,8 @@ is locked by the calling thread, and either
 \begin{itemize}
 \item no other thread is waiting on this \tcode{condition_variable} object or
 \item \tcode{lock.mutex()} returns the same value for each of the \tcode{lock}
-arguments supplied by all concurrently waiting (via \tcode{wait} or
-\tcode{timed_wait}) threads.
+arguments supplied by all concurrently waiting (via \tcode{wait},
+\tcode{wait_for}, or \tcode{wait_until}) threads.
 \end{itemize}
 
 \pnum\effects
@@ -2242,8 +2242,8 @@ locked by the calling thread, and either
 \begin{itemize}
 \item no other thread is waiting on this \tcode{condition_variable} object or
 \item \tcode{lock.mutex()} returns the same value for each of the \tcode{lock}
-arguments supplied by all concurrently waiting (via \tcode{wait} or
-\tcode{timed_wait}) threads.
+arguments supplied by all concurrently waiting (via \tcode{wait},
+\tcode{wait_for}, or \tcode{wait_until}) threads.
 \end{itemize}
 
 \pnum
@@ -2386,8 +2386,8 @@ locked by the calling thread, and either
 \begin{itemize}
 \item no other thread is waiting on this \tcode{condition_variable} object or
 \item \tcode{lock.mutex()} returns the same value for each of the \tcode{lock}
-arguments supplied by all concurrently waiting (via \tcode{wait} or
-\tcode{timed_wait}) threads.
+arguments supplied by all concurrently waiting (via \tcode{wait},
+\tcode{wait_for}, or \tcode{wait_until}) threads.
 \end{itemize}
 
 \pnum\effects


### PR DESCRIPTION
There is no `timed_wait` function
