### PR TITLE
Editorial fixes in [streambuf]

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -3933,12 +3933,14 @@ Is is unspecified whether the function calls \tcode{overflow()} when \tcode{pptr
 \pnum
 \returns
 The number of characters written.
+\end{itemdescr}
 
 \indexlibrary{\idxcode{overflow}!\idxcode{basic_streambuf}}%
 \begin{itemdecl}
 int_type overflow(int_type c = traits::eof());
 \end{itemdecl}
 
+\begin{itemdescr}
 \pnum
 \effects
 Consumes some initial subsequence of the characters of the


### PR DESCRIPTION
The first change fixes some bad grammar and missing formatting, the second closes one itemdescr before starting the next, so the `overflow` signature is left-aligned instead of being aligned with the text.
