### PR TITLE
[time] formatting fixes

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -9864,7 +9864,6 @@ template <class Clock, class Duration1, class Duration2>
                    const time_point<Clock, Duration2>& rhs);
 
 // \ref{time.point.cast}, time_point_cast
-
 template <class ToDuration, class Clock, class Duration>
   time_point<Clock, ToDuration> time_point_cast(const time_point<Clock, Duration>& t);
 
@@ -9881,7 +9880,7 @@ class high_resolution_clock;
 
 \pnum
 A clock is a bundle consisting of a \tcode{duration}, a
-\tcode{time_point}, and a function \tcode{now()} to get the current time_point.
+\tcode{time_point}, and a function \tcode{now()} to get the current \tcode{time_point}.
 The origin of the clock's \tcode{time_point} is referred to as the clock's \defn{epoch}.
  A clock shall meet the requirements in Table~\ref{tab:time.clock}.
 
@@ -9958,7 +9957,7 @@ that operations on these types will not throw exceptions. \exitnote
 
 \item the function \tcode{TC::now()} does not throw exceptions, and
 
-\item the type \tcode{TC::time_point::clock} meets the TrivialClock
+\item the type \tcode{TC::time_point::clock} meets the \tcode{TrivialClock}
 requirements, recursively.
 \end{itemize}
 


### PR DESCRIPTION
remove stray blank line in [time.syn] and use fixed-width typeface for `time_point` and `TrivialClock`
