### PR TITLE
Editorial(?) changes in [conversions]

### DIFF
--- a/source/locales.tex
+++ b/source/locales.tex
@@ -1345,7 +1345,7 @@ template<class Codecvt,
     std::streambuf *bufptr;         // \expos
     Codecvt *cvtptr;                // \expos
     state_type cvtstate;            // \expos
-    };
+  };
 }
 \end{codeblock}
 


### PR DESCRIPTION
(Originally submitted as [pull request #22](https://github.com/cplusplus/draft/pull/22), now resubmitted from a separate branch so I can push other changes without mixing them up.)

The types `byte_string` and `wide_string` should be in a fixed-width typeface.

`Codecvt` is a class not a template, so `Codecvt<Elem, char, std::mbstate_t>` is ill-formed, it should be just `Codecvt` (same problem in [conversions.string] and [conversions.buffer].)

The example in [conversions.string] supposes the existence of some facet called `codecvt_utf8`, which is in the standard library now so there's no need to word it that way. Just use `std::codecvt_utf8`.

http://cplusplus.github.com/LWG/lwg-defects.html#991 changed the string types to use allocators, but didn't update the definitions so they don't match the class synopsis (are those definitions even necessary? They don't add anything that isn't already defined in the class definition in paragraph 2).

Re-indent an example in [conversions.buffer]

There are also lots of redundant `std::` qualifications in that clause, which I didn't remove to keep the patch simpler.

If any of these doesn't qualify as editorial changes let me know and I'll request LWG issues and send a new pull request without those parts.
