### PR TITLE
"free functions" to "non member functions"

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -751,7 +751,7 @@ In the following operation definitions:
 \item an \textit{M} refers to type of the other argument for arithmetic operations. For
 integral atomic types, \textit{M} is \textit{C}. For atomic address types, \textit{M} is
 \tcode{std::ptrdiff_t}.
-\item the free functions not ending in \tcode{_explicit} have the semantics of their
+\item the non member functions not ending in \tcode{_explicit} have the semantics of their
 corresponding \tcode{_explicit} with \tcode{memory_order} arguments of
 \tcode{memory_order_seq_cst}.
 \end{itemize}


### PR DESCRIPTION
fix minor mistake word.
