### PR TITLE
fix minor typo

### DIFF
--- a/source/locales.tex
+++ b/source/locales.tex
@@ -75,17 +75,17 @@ namespace std {
   class time_base;
   template <class charT, class InputIterator = istreambuf_iterator<charT> >
     class time_get;
-  template <class charT, class InputIterator> = istreambuf_iterator<charT> >
+  template <class charT, class InputIterator = istreambuf_iterator<charT> >
     class time_get_byname;
-  template <class charT, class OutputIterator> = ostreambuf_iterator<charT> >
+  template <class charT, class OutputIterator = ostreambuf_iterator<charT> >
     class time_put;
-  template <class charT, class OutputIterator> = ostreambuf_iterator<charT> >
+  template <class charT, class OutputIterator = ostreambuf_iterator<charT> >
     class time_put_byname;
 
   // \ref{category.monetary}, money:
   class money_base;
-  template <class charT, class InputIterator = istreambuf_iterator<charT> > >  class money_get;
-  template <class charT, class OutputIterator = ostreambuf_iterator<charT> > > class money_put;
+  template <class charT, class InputIterator = istreambuf_iterator<charT> >  class money_get;
+  template <class charT, class OutputIterator = ostreambuf_iterator<charT> > class money_put;
   template <class charT, bool Intl = false> class moneypunct;
   template <class charT, bool Intl = false> class moneypunct_byname;
 


### PR DESCRIPTION
Fix trivial typos in header <locale> synopsis. (Remove extra '>'s.)
