### PR TITLE
Replaced "encoding schemes" with "encoding forms"

### DIFF
--- a/source/locales.tex
+++ b/source/locales.tex
@@ -2358,9 +2358,9 @@ convert the implementation-defined native character set.
 implements a degenerate conversion;
 it does not convert at all.
 The specialization \tcode{codecvt<char16_t,} \tcode{char, mbstate_t>}
-converts between the UTF-16 and UTF-8 encoding schemes, and
+converts between the UTF-16 and UTF-8 encoding forms, and
 the specialization \tcode{codecvt} \tcode{<char32_t, char, mbstate_t>}
-converts between the UTF-32 and UTF-8 encoding schemes.
+converts between the UTF-32 and UTF-8 encoding forms.
 \tcode{codecvt<wchar_t,char,mbstate_t>}
 converts between the native character sets for narrow and wide characters.
 Specializations on


### PR DESCRIPTION
Adopted the correct term, formally defined in ISO/IEC 10646. Please notice that the term "encoding form" is also used with this meaning in [intro.memory]/1.
