### PR TITLE
[container.requirements.general] Remove type Q.

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -567,8 +567,7 @@ with a \tcode{value_type} of \tcode{T} using allocator of type \tcode{A}, \tcode
 variable,
 \tcode{a} and \tcode{b} denote non-const lvalues of type \tcode{X},
 \tcode{t} denotes an lvalue or a const rvalue of type \tcode{X}, \tcode{rv} denotes a
-non-const rvalue of type \tcode{X}, \tcode{m} is a value of type \tcode{A}, and \tcode{Q} is an
-allocator type.
+non-const rvalue of type \tcode{X}, and \tcode{m} is a value of type \tcode{A}.
 
 \begin{libreqtab4a}
 {Allocator-aware container requirements}


### PR DESCRIPTION
The type Q is not referred to in Table 99, or anywhere else in Clause
23, so should be removed.
