### PR TITLE
[tuple.general] Fix return type of forward_as_tuple

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -892,7 +892,7 @@ namespace std {
   template <class... Types>
     constexpr tuple<@\textit{VTypes}@...> make_tuple(Types&&...);
   template <class... Types>
-    tuple<@\textit{Types}@...> forward_as_tuple(Types&&...) noexcept;
+    tuple<Types&&...> forward_as_tuple(Types&&...) noexcept;
 
   template<class... Types>
     tuple<Types&...> tie(Types&...) noexcept;


### PR DESCRIPTION
In [tuple.general], change the return type of `forward_as_tuple`
from `tuple<Types...>`, 'Types' in italic monoface, to
`tuple<Types&&...>` in normal monoface, as it appears in
[tuple.creation].
