### PR TITLE
[class.expl.init] Fix sample for copy-list-initialization

### DIFF
--- a/source/special.tex
+++ b/source/special.tex
@@ -1448,9 +1448,8 @@ complex e;                      // initialize by a call of
 complex f = 3;                  // construct \tcode{complex(3)} using
                                 // \tcode{complex(double)}
                                 // copy/move it into \tcode{f}
-complex g = { 1, 2 };           // construct \tcode{complex(1, 2)}
-                                // using \tcode{complex(double, double)}
-                                // and copy/move it into \tcode{g}
+complex g = { 1, 2 };           // initialize by a call of
+                                // \tcode{complex(double, double)}
 \end{codeblock}
 \exitexample
 \enternote


### PR DESCRIPTION
Fix comment stating a copy operation of temporary occurs at a
copy-list-initialization expression, potentially misleading correct
interpretation of list-initialization rules.

For background discussion see
http://stackoverflow.com/q/13693871/1000282
