### PR TITLE
[Containers] Fix minor typo, etc.

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -1884,7 +1884,7 @@ from \tcode{[i, j)} into it.
 \tcode{a = il}
 &   \tcode{X\&}
 &   \requires\ \tcode{value_type} is
-CopyInsertable into \tcode{X}
+\tcode{CopyInsertable} into \tcode{X}
 and \tcode{CopyAssignable}.\br
     \effects\ Assigns the range \range{il.begin()}{il.end()} into \tcode{a}. All
     existing elements of \tcode{a} are either assigned to or destroyed.
@@ -5158,7 +5158,7 @@ namespace std {
    ~vector();
     vector<bool,Allocator>& operator=(const vector<bool,Allocator>& x);
     vector<bool,Allocator>& operator=(vector<bool,Allocator>&& x);
-    vector operator=(initializer_list<bool>);
+    vector& operator=(initializer_list<bool>);
     template <class InputIterator>
       void assign(InputIterator first, InputIterator last);
     void assign(size_type n, const bool& t);
@@ -7586,7 +7586,7 @@ namespace std {
       const allocator_type& a = allocator_type());
     ~unordered_multiset();
     unordered_multiset& operator=(const unordered_multiset&);
-    unordered_multiset operator=(unordered_multiset&&);
+    unordered_multiset& operator=(unordered_multiset&&);
     unordered_multiset& operator=(initializer_list<value_type>);
     allocator_type get_allocator() const noexcept;
 


### PR DESCRIPTION
[unord.req] Use code font for CopyInsertable at Expression "a = il" in Table 103.
[vector.overview] Add missing ampersand to an operator=(initializer_list)'s return value.
[unord.multiset.overview] Add missing ampersand to an operator=(unordered_multiset&&)'s return value.
