### PR TITLE
[futures.async] Remove redundant Remarks clause.

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -4051,10 +4051,6 @@ implementation is unable to start a new thread.
 \item \tcode{resource_unavailable_try_again} --- if \tcode{policy} is
 \tcode{launch::async} and the system is unable to start a new thread.
 \end{itemize}
-
-\pnum
-\remarks The first signature shall not participate in overload resolution if
-\tcode{decay<F>::type} is \tcode{std::\brk{}launch}.
 \end{itemdescr}
 
 \pnum


### PR DESCRIPTION
With the acceptance of [N3436](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3436.html) into the WP the SFINAE constraint
added by the resolution of [LWG 1315](http://cplusplus.github.com/LWG/lwg-closed.html#1315) is no longer required
