### PR TITLE
[tuple.general] Fix forward_as_tuple signature.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -892,7 +892,7 @@ namespace std {
   template <class... Types>
     constexpr tuple<@\textit{VTypes}@...> make_tuple(Types&&...);
   template <class... Types>
-    tuple<@\textit{Types}@...> forward_as_tuple(Types&&...) noexcept;
+    tuple<Types&&...> forward_as_tuple(Types&&...) noexcept;
 
   template<class... Types>
     tuple<Types&...> tie(Types&...) noexcept;


### PR DESCRIPTION
Make the signature in the synopsis match the definition in
[tuple.creation].
