### PR TITLE
[associative] Remove redundant template arguments.

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -5493,8 +5493,8 @@ namespace std {
     template <class InputIterator>
       map(InputIterator first, InputIterator last,
           const Compare& comp = Compare(), const Allocator& = Allocator());
-    map(const map<Key,T,Compare,Allocator>& x);
-    map(map<Key,T,Compare,Allocator>&& x);
+    map(const map& x);
+    map(map&& x);
     explicit map(const Allocator&);
     map(const map&, const Allocator&);
     map(map&&, const Allocator&);
@@ -5502,10 +5502,8 @@ namespace std {
       const Compare& = Compare(),
       const Allocator& = Allocator());
    ~map();
-    map<Key,T,Compare,Allocator>&
-      operator=(const map<Key,T,Compare,Allocator>& x);
-    map<Key,T,Compare,Allocator>&
-      operator=(map<Key,T,Compare,Allocator>&& x);
+    map& operator=(const map& x);
+    map& operator=(map&& x);
     map& operator=(initializer_list<value_type>);
     allocator_type get_allocator() const noexcept;
 
@@ -5551,7 +5549,7 @@ namespace std {
     iterator  erase(const_iterator position);
     size_type erase(const key_type& x);
     iterator  erase(const_iterator first, const_iterator last);
-    void swap(map<Key,T,Compare,Allocator>&);
+    void swap(map&);
     void clear() noexcept;
 
     // observers:
@@ -5909,8 +5907,8 @@ namespace std {
       multimap(InputIterator first, InputIterator last,
                const Compare& comp = Compare(),
                const Allocator& = Allocator());
-    multimap(const multimap<Key,T,Compare,Allocator>& x);
-    multimap(multimap<Key,T,Compare,Allocator>&& x);
+    multimap(const multimap& x);
+    multimap(multimap&& x);
     explicit multimap(const Allocator&);
     multimap(const multimap&, const Allocator&);
     multimap(multimap&&, const Allocator&);
@@ -5918,10 +5916,8 @@ namespace std {
       const Compare& = Compare(),
       const Allocator& = Allocator());
    ~multimap();
-    multimap<Key,T,Compare,Allocator>&
-      operator=(const multimap<Key,T,Compare,Allocator>& x);
-    multimap<Key,T,Compare,Allocator>&
-      operator=(multimap<Key,T,Compare,Allocator>&& x);
+    multimap& operator=(const multimap& x);
+    multimap& operator=(multimap&& x);
     multimap& operator=(initializer_list<value_type>);
     allocator_type get_allocator() const noexcept;
 
@@ -5960,7 +5956,7 @@ namespace std {
     iterator  erase(const_iterator position);
     size_type erase(const key_type& x);
     iterator  erase(const_iterator first, const_iterator last);
-    void swap(multimap<Key,T,Compare,Allocator>&);
+    void swap(multimap&);
     void clear() noexcept;
 
     // observers:
@@ -6213,8 +6209,8 @@ namespace std {
     template <class InputIterator>
       set(InputIterator first, InputIterator last,
           const Compare& comp = Compare(), const Allocator& = Allocator());
-    set(const set<Key,Compare,Allocator>& x);
-    set(set<Key,Compare,Allocator>&& x);
+    set(const set& x);
+    set(set&& x);
     explicit set(const Allocator&);
     set(const set&, const Allocator&);
     set(set&&, const Allocator&);
@@ -6222,10 +6218,8 @@ namespace std {
       const Compare& = Compare(),
       const Allocator& = Allocator());
    ~set();
-    set<Key,Compare,Allocator>& operator=
-      (const set<Key,Compare,Allocator>& x);
-    set<Key,Compare,Allocator>& operator=
-      (set<Key,Compare,Allocator>&& x);
+    set& operator=(const set& x);
+    set& operator=(set&& x);
     set& operator=(initializer_list<value_type>);
     allocator_type get_allocator() const noexcept;
 
@@ -6264,7 +6258,7 @@ namespace std {
     iterator  erase(const_iterator position);
     size_type erase(const key_type& x);
     iterator  erase(const_iterator first, const_iterator last);
-    void swap(set<Key,Compare,Allocator>&);
+    void swap(set&);
     void clear() noexcept;
 
     // observers:
@@ -6457,8 +6451,8 @@ namespace std {
       multiset(InputIterator first, InputIterator last,
                const Compare& comp = Compare(),
                const Allocator& = Allocator());
-    multiset(const multiset<Key,Compare,Allocator>& x);
-    multiset(multiset<Key,Compare,Allocator>&& x);
+    multiset(const multiset& x);
+    multiset(multiset&& x);
     explicit multiset(const Allocator&);
     multiset(const multiset&, const Allocator&);
     multiset(multiset&&, const Allocator&);
@@ -6466,10 +6460,8 @@ namespace std {
       const Compare& = Compare(),
       const Allocator& = Allocator());
    ~multiset();
-    multiset<Key,Compare,Allocator>&
-        operator=(const multiset<Key,Compare,Allocator>& x);
-    multiset<Key,Compare,Allocator>&
-        operator=(multiset<Key,Compare,Allocator>&& x);
+    multiset& operator=(const multiset& x);
+    multiset& operator=(multiset&& x);
     multiset& operator=(initializer_list<value_type>);
     allocator_type get_allocator() const noexcept;
 
@@ -6508,7 +6500,7 @@ namespace std {
     iterator  erase(const_iterator position);
     size_type erase(const key_type& x);
     iterator  erase(const_iterator first, const_iterator last);
-    void swap(multiset<Key,Compare,Allocator>&);
+    void swap(multiset&);
     void clear() noexcept;
 
     // observers:


### PR DESCRIPTION
This removes redundant template arguments from [map.overview],
[multimap.overview], [set.overview] and [multiset.overview].

This is consistent with other member functions that rely on the injected
class name and I find it much easier to read the class synopses without
the clutter of the explicit template argument lists.
e.g. it's much easier to see that 

```
map& operator=(map&& x);
```

is a move assignment operator rather than

```
map<Key,T,Compare,Allocator>&
  operator=(map<Key,T,Compare,Allocator>&& x);
```
