### PR TITLE
[func.wrap.func.targ] Use 'class' not 'typename'

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -8168,8 +8168,8 @@ namespace std {
 
     // \ref{func.wrap.func.targ}, function target access:
     const std::type_info& target_type() const noexcept;
-    template <typename T>       T* target() noexcept;
-    template <typename T> const T* target() const noexcept;
+    template<class T>       T* target() noexcept;
+    template<class T> const T* target() const noexcept;
 
   };
 
@@ -8477,8 +8477,8 @@ const std::type_info& target_type() const noexcept;
 \indexlibrary{\idxcode{function}!\idxcode{target}}%
 \indexlibrary{\idxcode{target}!\idxcode{function}}%
 \begin{itemdecl}
-template<typename T>       T* target() noexcept;
-template<typename T> const T* target() const noexcept;
+template<class T>       T* target() noexcept;
+template<class T> const T* target() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8488,7 +8488,7 @@ Callable~(\ref{func.wrap.func}) for parameter types
 \tcode{ArgTypes}
 and return type \tcode{R}.
 
-\pnum\returns If \tcode{target_}type() == typeid(T)
+\pnum\returns If \tcode{target_type() == typeid(T)}
 a pointer to the stored function target; otherwise a null pointer.
 \end{itemdescr}
 


### PR DESCRIPTION
The rest of the library always uses `class` in template parameter lists,
so change the only occurrence of `typename` to be consistent.
Also fix `tcode{}` markup to include entire expression.
