### PR TITLE
Remove two redundant bullets.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -467,12 +467,6 @@ that class, or
 
 \item to form a pointer to member~(\ref{expr.unary.op}), or
 
-\item in a \grammarterm{mem-initializer} for a constructor for that class
-or for a class derived from that class~(\ref{class.base.init}), or
-
-\item in a \grammarterm{brace-or-equal-initializer} for a non-static data member
-of that class or of a class derived from that class~(\ref{class.base.init}), or
-
 \item if that \grammarterm{id-expression} denotes a non-static data member
 and it appears in an unevaluated operand.
 \enterexample


### PR DESCRIPTION
These cases can never happen, because [class.mfct.non-static]p3 transforms these cases into implicit member accesses, which are handled by the first bullet. OK'd by Mike.
