### PR TITLE
[class] Hyphenate "standard-layout"

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -175,8 +175,8 @@ A \term{POD struct}\footnote{The acronym POD stands for ``plain old data''.}
 is a non-union class that is both a trivial class and a
 standard-layout class, and has no non-static data members of type non-POD struct,
 non-POD union (or array of such types). Similarly, a
-\term{POD union} is a union that is both a trivial class and a standard
-layout class, and has no non-static data members of type non-POD struct, non-POD
+\term{POD union} is a union that is both a trivial class and a standard-layout
+class, and has no non-static data members of type non-POD struct, non-POD
 union (or array of such types). A \term{POD class} is a
 class that is either a POD struct or a POD union.
 


### PR DESCRIPTION
This should be hyphenated for consistency with the rest of the standard, including earlier in the same paragraph.
