### PR TITLE
[unord.set.overview] Remove bogus template parameters.

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -7427,12 +7427,12 @@ namespace std {
     void swap(unordered_set<Key, Hash, Pred, Alloc>& x,
               unordered_set<Key, Hash, Pred, Alloc>& y);
 
-  template <class Key, class T, class Hash, class Pred, class Alloc>
-    bool operator==(const unordered_set<Key, T, Hash, Pred, Alloc>& a,
-                    const unordered_set<Key, T, Hash, Pred, Alloc>& b);
-  template <class Key, class T, class Hash, class Pred, class Alloc>
-    bool operator!=(const unordered_set<Key, T, Hash, Pred, Alloc>& a,
-                    const unordered_set<Key, T, Hash, Pred, Alloc>& b);
+  template <class Key, class Hash, class Pred, class Alloc>
+    bool operator==(const unordered_set<Key, Hash, Pred, Alloc>& a,
+                    const unordered_set<Key, Hash, Pred, Alloc>& b);
+  template <class Key, class Hash, class Pred, class Alloc>
+    bool operator!=(const unordered_set<Key, Hash, Pred, Alloc>& a,
+                    const unordered_set<Key, Hash, Pred, Alloc>& b);
 }
 \end{codeblock}
 
@@ -7645,12 +7645,12 @@ namespace std {
   template <class Key, class Hash, class Pred, class Alloc>
     void swap(unordered_multiset<Key, Hash, Pred, Alloc>& x,
               unordered_multiset<Key, Hash, Pred, Alloc>& y);
-    template <class Key, class T, class Hash, class Pred, class Alloc>
-      bool operator==(const unordered_multiset<Key, T, Hash, Pred, Alloc>& a,
-                      const unordered_multiset<Key, T, Hash, Pred, Alloc>& b);
-    template <class Key, class T, class Hash, class Pred, class Alloc>
-      bool operator!=(const unordered_multiset<Key, T, Hash, Pred, Alloc>& a,
-                      const unordered_multiset<Key, T, Hash, Pred, Alloc>& b);
+    template <class Key, class Hash, class Pred, class Alloc>
+      bool operator==(const unordered_multiset<Key, Hash, Pred, Alloc>& a,
+                      const unordered_multiset<Key, Hash, Pred, Alloc>& b);
+    template <class Key, class Hash, class Pred, class Alloc>
+      bool operator!=(const unordered_multiset<Key, Hash, Pred, Alloc>& a,
+                      const unordered_multiset<Key, Hash, Pred, Alloc>& b);
 }
 \end{codeblock}
 


### PR DESCRIPTION
[unord.multiset.overview] Remove bogus template parameters.

Noticed by Alan Talbot
