### PR TITLE
[thread.threads] Add lock tags to index of library names.

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -1323,6 +1323,12 @@ unlocking the lockable object under both normal and exceptional circumstances. \
 Some lock constructors take tag types which describe what should be done with the lockable
 object during the lock's construction.
 
+\indexlibrary{\idxcode{defer_lock_t}}%
+\indexlibrary{\idxcode{try_to_lock_t}}%
+\indexlibrary{\idxcode{adopt_lock_t}}%
+\indexlibrary{\idxcode{defer_lock}}%
+\indexlibrary{\idxcode{try_to_lock}}%
+\indexlibrary{\idxcode{adopt_lock}}%
 \begin{codeblock}
 namespace std {
   struct defer_lock_t  { };     // do not acquire ownership of the mutex


### PR DESCRIPTION
Reported by Geoffrey Romer.

Fixes #76
