### PR TITLE
Library N3658 Compile-time integer sequences

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -115,6 +115,19 @@ namespace std {
   struct piecewise_construct_t { };
   constexpr piecewise_construct_t piecewise_construct = piecewise_construct_t();
   template <class... Types> class tuple;  // defined in \tcode{<tuple>}
+
+  // \ref{intseq}, Compile-time integer sequences
+  template<class T, T...> struct integer_sequence;
+  template<size_t... I>
+    using index_sequence = integer_sequence<size_t, I...>;
+
+  template<class T, T N>
+    using make_integer_sequence = integer_sequence<T, see below>;
+  template<size_t N>
+    using make_index_sequence = make_integer_sequence<size_t, N>;
+
+  template<class... T>
+    using index_sequence_for = make_index_sequence<sizeof...(T)>;
 }
 \end{codeblock}
 
@@ -1823,6 +1836,68 @@ noexcept(x.swap(y))
 
 \pnum
 \effects \tcode{x.swap(y)}
+\end{itemdescr}
+
+\rSec1[intseq]{Compile-time integer sequences}
+
+\rSec2[intseq.general]{In general}
+
+\pnum
+The library provides a class template that can represent an integer sequence.
+When used as an argument to a function template the parameter pack defining the
+sequence can be deduced and used in a pack expansion.
+
+\pnum
+\enterexample
+
+\begin{codeblock}
+template<class F, class Tuple, std::size_t... I>
+  auto apply_impl(F&& f, Tuple&& t, index_sequence<I...>) {
+    return std::forward<F>(f)(std::get<I>(std::forward<Tuple>(t))...);
+  }
+
+template<class F, class Tuple>
+  auto apply(F&& f, Tuple&& t) {
+    using Indices = make_index_sequence<std::tuple_size<Tuple>::value>;
+    return apply_impl(std::forward<F>(f), std::forward<Tuple>(t), Indices());
+  }
+\end{codeblock}
+
+\exitexample
+
+\rSec2[intseq.intseq]{Class template \tcode{integer_sequence}}
+
+\indexlibrary{\idxcode{integer_sequence}}%
+\begin{codeblock}
+namespace std {
+  template<class T, T... I>
+  struct integer_sequence {
+    typedef T value_type;
+    static constexpr size_t size() noexcept { return sizeof...(I); }
+  };
+}
+\end{codeblock}
+
+\pnum
+T shall be an integer type.
+
+\rSec2[intseq.make]{Alias template \tcode{make_integer_sequence}}
+
+\indexlibrary{\idxcode{make_integer_sequence}}%
+\begin{itemdecl}
+template<class T, T N>
+  using make_integer_sequence = integer_sequence<T, see below>;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+If \tcode{N} is negative the program is ill-formed. The alias template
+\tcode{make_integer_sequence} denotes a specialization of
+\tcode{integer_sequence} with \tcode{N} template non-type arguments.
+The type \tcode{make_integer_sequence<T, N>} denotes the type
+\tcode{integer_sequence<T, 0, 1, ..., N-1>}.
+\enternote \tcode{make_integer_sequence<int, 0>} denotes the type
+\tcode{integer_sequence<int>} \exitnote
 \end{itemdescr}
 
 \rSec1[template.bitset]{Class template \tcode{bitset}}%

--- a/source/xref.tex
+++ b/source/xref.tex
@@ -716,6 +716,10 @@ intro.object\quad\ref{intro.object}\\
 intro.refs\quad\ref{intro.refs}\\
 intro.scope\quad\ref{intro.scope}\\
 intro.structure\quad\ref{intro.structure}\\
+intseq\quad\ref{intseq}\\
+intseq.general\quad\ref{intseq.general}\\
+intseq.intseq\quad\ref{intseq.intseq}\\
+intseq.make\quad\ref{intseq.make}\\
 invalid.argument\quad\ref{invalid.argument}\\
 ios\quad\ref{ios}\\
 ios.base\quad\ref{ios.base}\\


### PR DESCRIPTION
Includes editorial change to simplify the example with return type
deduction (as discussed by LWG) so depends on [N3638](http://isocpp.org/files/papers/N3638.html).
