### PR TITLE
Library N3657, Adding heterogeneous comparison lookup to associative containers

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -1232,6 +1232,8 @@ In Table~\ref{tab:containers.associative.requirements},
 when \tcode{X} supports unique keys,
 \tcode{a_eq} denotes a value of \tcode{X}
 when \tcode{X} supports multiple keys,
+\tcode{a_tran} denotes a value of \tcode{X} when the type
+\tcode{X::key_compare::is_transparent} exists,
 \tcode{u} denotes an identifier,
 \tcode{i} and \tcode{j}
 satisfy input iterator requirements and refer to elements
@@ -1244,7 +1246,15 @@ denotes a valid range,
 \tcode{il} designates an object of type \tcode{initializer_list<value_type>},
 \tcode{t} denotes a value of \tcode{X::value_type},
 \tcode{k} denotes a value of \tcode{X::key_type}
-and \tcode{c} denotes a value of type \tcode{X::key_compare}.
+and \tcode{c} denotes a value of type \tcode{X::key_compare};
+\tcode{kl} is a value such that \tcode{a} is partitioned~(\ref{alg.sorting})
+with respect to \tcode{c(r, kl)}, with \tcode{r} the key value of \tcode{e}
+and \tcode{e} in \tcode{a};
+\tcode{ku} is a value such that \tcode{a} is partitioned with respect to
+\tcode{!c(ku, r)};
+\tcode{ke} is a value such that \tcode{a} is partitioned with respect to
+\tcode{c(r, ke)} and \tcode{!c(ke, r)}, with \tcode{c(r, ke)} implying
+\tcode{!c(ke, r)}.
 \tcode{A} denotes the storage allocator used by \tcode{X}, if any, or \tcode{std::allocator<X::value_type>} otherwise, and \tcode{m} denotes an allocator of a type convertible to \tcode{A}.
 
 \begin{libreqtab4b}
@@ -1468,16 +1478,39 @@ and \tcode{c} denotes a value of type \tcode{X::key_compare}.
  to \tcode{k}, or \tcode{a.end()} if such an element is not found    &
  logarithmic            \\ \rowsep
 
+\tcode{a_tran.}\br
+ \tcode{find(ke)}       &
+ \tcode{iterator}; \tcode{const_iterator} for constant \tcode{a_tran}.  &
+ returns an iterator pointing to an element with key \tcode{r} such that
+ \tcode{!c(r, ke) \&\& !c(ke, r)}, or \tcode{a_tran.end()} if such an element
+ is not found    &
+ logarithmic            \\ \rowsep
+
 \tcode{a.count(k)}        &
  \tcode{size_type}        &
  returns the number of elements with key equivalent to \tcode{k}    &
  $\log (\mathrm{a.size}()) + \mathrm{a.count}(k)$   \\ \rowsep
+
+\tcode{a_tran.}\br
+ \tcode{count(ke)}        &
+ \tcode{size_type}        &
+ returns the number of elements with key \tcode{r} such that
+ \tcode{!c(r, ke) \&\& !c(ke, r)}    &
+ $\log (\mathrm{a\_tran.size}()) + \mathrm{a\_tran.count}(k)$   \\ \rowsep
 
 \tcode{a.lower_bound(k)}   &
  \tcode{iterator}; \tcode{const_iterator} for constant \tcode{a}.  &
  returns an iterator pointing to the first element with
  key not less than \tcode{k},
  or \tcode{a.end()} if such an element is not found.   &
+ logarithmic            \\ \rowsep
+
+\tcode{a_tran.}\br
+ \tcode{lower_bound(kl)}   &
+ \tcode{iterator}; \tcode{const_iterator} for constant \tcode{a_tran}.  &
+ returns an iterator pointing to the first element with
+ key \tcode{r} such that \tcode{!c(r, kl)},
+ or \tcode{a_tran.end()} if such an element is not found.   &
  logarithmic            \\ \rowsep
 
 \tcode{a.upper_bound(k)}       &
@@ -1487,10 +1520,26 @@ and \tcode{c} denotes a value of type \tcode{X::key_compare}.
  or \tcode{a.end()} if such an element is not found.   &
  logarithmic                    \\ \rowsep
 
+\tcode{a_tran.}\br
+ \tcode{upper_bound(ku)}       &
+ \tcode{iterator}; \tcode{const_iterator} for constant \tcode{a_tran}.  &
+ returns an iterator pointing to the first element with
+ key \tcode{r} such that \tcode{c(ku, r)},
+ or \tcode{a_tran.end()} if such an element is not found.   &
+ logarithmic                    \\ \rowsep
+
 \tcode{a.equal_range(k)}       &
  \tcode{pair<iterator, iterator>};
  \tcode{pair<const_iterator, const_iterator>} for constant \tcode{a}.     &
  equivalent to \tcode{make_pair(a.lower_bound(k), a.upper_bound(k))}.    &
+ logarithmic                    \\ \rowsep
+
+\tcode{a_tran.}\br
+ \tcode{equal_range(ke)}       &
+ \tcode{pair<iterator, iterator>};
+ \tcode{pair<const_iterator, const_iterator>} for constant \tcode{a_tran}.     &
+ equivalent to \tcode{make_pair(}\br
+ \tcode{a_tran.lower_bound(ke), a_tran.upper_bound(ke))}.    &
  logarithmic                    \\
 \end{libreqtab4b}
 
@@ -1535,6 +1584,11 @@ the target container shall then use the comparison object from the container
 being copied,
 as if that comparison object had been passed to the target container in
 its constructor.
+
+\pnum
+The member function templates \tcode{find}, \tcode{count}, \tcode{lower_bound},
+\tcode{upper_bound}, and \tcode{equal_range} shall not participate in overload
+resolution unless the type \tcode{Compare::is_transparent} exists.
 
 \indextext{associative containers!exception safety}%
 \indextext{associative containers!requirements}%
@@ -5558,17 +5612,30 @@ namespace std {
     // \ref{map.ops}, map operations:
     iterator       find(const key_type& x);
     const_iterator find(const key_type& x) const;
+    template <class K> iterator       find(const K& x);
+    template <class K> const_iterator find(const K& x) const;
+
     size_type      count(const key_type& x) const;
+    template <class K> size_type count(const K& x) const;
 
     iterator       lower_bound(const key_type& x);
     const_iterator lower_bound(const key_type& x) const;
+    template <class K> iterator       lower_bound(const K& x);
+    template <class K> const_iterator lower_bound(const K& x) const;
+
     iterator       upper_bound(const key_type& x);
     const_iterator upper_bound(const key_type& x) const;
+    template <class K> iterator       upper_bound(const K& x);
+    template <class K> const_iterator upper_bound(const K& x) const;
 
     pair<iterator,iterator>
       equal_range(const key_type& x);
     pair<const_iterator,const_iterator>
       equal_range(const key_type& x) const;
+    template <class K>
+      pair<iterator, iterator>             equal_range(const K& x);
+    template <class K>
+      pair<const_iterator, const_iterator> equal_range(const K& x) const;
   };
 
   template <class Key, class T, class Compare, class Allocator>
@@ -5965,17 +6032,30 @@ namespace std {
     // map operations:
     iterator       find(const key_type& x);
     const_iterator find(const key_type& x) const;
+    template <class K> iterator       find(const K& x);
+    template <class K> const_iterator find(const K& x) const;
+
     size_type      count(const key_type& x) const;
+    template <class K> size_type count(const K& x) const;
 
     iterator       lower_bound(const key_type& x);
     const_iterator lower_bound(const key_type& x) const;
+    template <class K> iterator       lower_bound(const K& x);
+    template <class K> const_iterator lower_bound(const K& x) const;
+
     iterator       upper_bound(const key_type& x);
     const_iterator upper_bound(const key_type& x) const;
+    template <class K> iterator       upper_bound(const K& x);
+    template <class K> const_iterator upper_bound(const K& x) const;
 
     pair<iterator,iterator>
       equal_range(const key_type& x);
     pair<const_iterator,const_iterator>
       equal_range(const key_type& x) const;
+    template <class K>
+      pair<iterator, iterator>             equal_range(const K& x);
+    template <class K>
+      pair<const_iterator, const_iterator> equal_range(const K& x) const;
   };
 
   template <class Key, class T, class Compare, class Allocator>
@@ -6267,17 +6347,28 @@ namespace std {
     // set operations:
     iterator        find(const key_type& x);
     const_iterator  find(const key_type& x) const;
+    template <class K> iterator       find(const K& x);
+    template <class K> const_iterator find(const K& x) const;
 
     size_type count(const key_type& x) const;
+    template <class K> size_type count(const K& x) const;
 
     iterator        lower_bound(const key_type& x);
     const_iterator  lower_bound(const key_type& x) const;
+    template <class K> iterator       lower_bound(const K& x);
+    template <class K> const_iterator lower_bound(const K& x) const;
 
     iterator        upper_bound(const key_type& x);
     const_iterator  upper_bound(const key_type& x) const;
+    template <class K> iterator       upper_bound(const K& x);
+    template <class K> const_iterator upper_bound(const K& x) const;
 
     pair<iterator,iterator>             equal_range(const key_type& x);
     pair<const_iterator,const_iterator> equal_range(const key_type& x) const;
+    template <class K>
+      pair<iterator, iterator>             equal_range(const K& x);
+    template <class K>
+      pair<const_iterator, const_iterator> equal_range(const K& x) const;
   };
 
   template <class Key, class Compare, class Allocator>
@@ -6509,17 +6600,28 @@ namespace std {
     // set operations:
     iterator        find(const key_type& x);
     const_iterator  find(const key_type& x) const;
+    template <class K> iterator       find(const K& x);
+    template <class K> const_iterator find(const K& x) const;
 
     size_type count(const key_type& x) const;
+    template <class K> size_type count(const K& x) const;
 
     iterator        lower_bound(const key_type& x);
     const_iterator  lower_bound(const key_type& x) const;
+    template <class K> iterator       lower_bound(const K& x);
+    template <class K> const_iterator lower_bound(const K& x) const;
 
     iterator        upper_bound(const key_type& x);
     const_iterator  upper_bound(const key_type& x) const;
+    template <class K> iterator       upper_bound(const K& x);
+    template <class K> const_iterator upper_bound(const K& x) const;
 
     pair<iterator,iterator>             equal_range(const key_type& x);
     pair<const_iterator,const_iterator> equal_range(const key_type& x) const;
+    template <class K>
+      pair<iterator, iterator>             equal_range(const K& x);
+    template <class K>
+      pair<const_iterator, const_iterator> equal_range(const K& x) const;
   };
 
   template <class Key, class Compare, class Allocator>

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -7307,6 +7307,8 @@ template <class T = void> struct negate {
 template <> struct plus<void> {
   template <class T, class U> auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) + std::forward<U>(u));
+
+  typedef @\unspec@ is_transparent;
 };
 \end{itemdecl}
 
@@ -7320,6 +7322,8 @@ template <> struct plus<void> {
 template <> struct minus<void> {
   template <class T, class U> auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) - std::forward<U>(u));
+
+  typedef @\unspec@ is_transparent;
 };
 \end{itemdecl}
 
@@ -7333,6 +7337,8 @@ template <> struct minus<void> {
 template <> struct multiplies<void> {
   template <class T, class U> auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) * std::forward<U>(u));
+
+  typedef @\unspec@ is_transparent;
 };
 \end{itemdecl}
 
@@ -7346,6 +7352,8 @@ template <> struct multiplies<void> {
 template <> struct divides<void> {
   template <class T, class U> auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) / std::forward<U>(u));
+
+  typedef @\unspec@ is_transparent;
 };
 \end{itemdecl}
 
@@ -7359,6 +7367,8 @@ template <> struct divides<void> {
 template <> struct modulus<void> {
   template <class T, class U> auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) % std::forward<U>(u));
+
+  typedef @\unspec@ is_transparent;
 };
 \end{itemdecl}
 
@@ -7372,6 +7382,8 @@ template <> struct modulus<void> {
 template <> struct negate<void> {
   template <class T> auto operator()(T&& t) const
     -> decltype(-std::forward<T>(t));
+
+  typedef @\unspec@ is_transparent;
 };
 \end{itemdecl}
 
@@ -7482,6 +7494,8 @@ template <class T = void> struct less_equal {
 template <> struct equal_to<void> {
   template <class T, class U> auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) == std::forward<U>(u));
+
+  typedef @\unspec@ is_transparent;
 };
 \end{itemdecl}
 
@@ -7495,6 +7509,8 @@ template <> struct equal_to<void> {
 template <> struct not_equal_to<void> {
   template <class T, class U> auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) != std::forward<U>(u));
+
+  typedef @\unspec@ is_transparent;
 };
 \end{itemdecl}
 
@@ -7508,6 +7524,8 @@ template <> struct not_equal_to<void> {
 template <> struct greater<void> {
   template <class T, class U> auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) > std::forward<U>(u));
+
+  typedef @\unspec@ is_transparent;
 };
 \end{itemdecl}
 
@@ -7521,6 +7539,8 @@ template <> struct greater<void> {
 template <> struct less<void> {
   template <class T, class U> auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) < std::forward<U>(u));
+
+  typedef @\unspec@ is_transparent;
 };
 \end{itemdecl}
 
@@ -7534,6 +7554,8 @@ template <> struct less<void> {
 template <> struct greater_equal<void> {
   template <class T, class U> auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) >= std::forward<U>(u));
+
+  typedef @\unspec@ is_transparent;
 };
 \end{itemdecl}
 
@@ -7547,6 +7569,8 @@ template <> struct greater_equal<void> {
 template <> struct less_equal<void> {
   template <class T, class U> auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) <= std::forward<U>(u));
+
+  typedef @\unspec@ is_transparent;
 };
 \end{itemdecl}
 
@@ -7616,6 +7640,8 @@ template <class T = void> struct logical_not {
 template <> struct logical_and<void> {
   template <class T, class U> auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) && std::forward<U>(u));
+
+  typedef @\unspec@ is_transparent;
 };
 \end{itemdecl}
 
@@ -7629,6 +7655,8 @@ template <> struct logical_and<void> {
 template <> struct logical_or<void> {
   template <class T, class U> auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) || std::forward<U>(u));
+
+  typedef @\unspec@ is_transparent;
 };
 \end{itemdecl}
 
@@ -7642,6 +7670,8 @@ template <> struct logical_or<void> {
 template <> struct logical_not<void> {
   template <class T> auto operator()(T&& t) const
     -> decltype(!std::forward<T>(t));
+
+  typedef @\unspec@ is_transparent;
 };
 \end{itemdecl}
 
@@ -7721,6 +7751,8 @@ template <class T = void> struct bit_not {
 template <> struct bit_and<void> {
   template <class T, class U> auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) & std::forward<U>(u));
+
+  typedef @\unspec@ is_transparent;
 };
 \end{itemdecl}
 
@@ -7734,6 +7766,8 @@ template <> struct bit_and<void> {
 template <> struct bit_or<void> {
   template <class T, class U> auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) | std::forward<U>(u));
+
+  typedef @\unspec@ is_transparent;
 };
 \end{itemdecl}
 
@@ -7747,6 +7781,8 @@ template <> struct bit_or<void> {
 template <> struct bit_xor<void> {
   template <class T, class U> auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) ^ std::forward<U>(u));
+
+  typedef @\unspec@ is_transparent;
 };
 \end{itemdecl}
 
@@ -7760,6 +7796,8 @@ template <> struct bit_xor<void> {
 template <> struct bit_not<void> {
   template <class T> auto operator()(T&& t) const
     -> decltype(~std::forward<T>(t));
+
+  typedef @\unspec@ is_transparent;
 };
 \end{itemdecl}
 


### PR DESCRIPTION
[associative.reqmts] Define heterogeneous lookup requirements.
[map.overview] Add new member function templates to class synopsis.
[multimap.overview] Add new member function templates to class synopsis.
[set.overview] Add new member function templates to class synopsis.
[multiset.overview] Add new member function templates to class synopsis.
[arithmetic.operations] Add typedef to void specializations.
[comparisons] Add typedef to void specializations.
[logical.operations] Add typedef to void specializations.
[bitwise.operations] Add typedef to void specializations.
