### PR TITLE
Library N3662, C++ Dynamic Arrays

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -19,6 +19,7 @@ Table~\ref{tab:containers.lib.summary}.
 \ref{container.requirements} & Requirements                     &                           \\ \rowsep
 \ref{sequences}              & Sequence containers              & \tcode{<array>}         \\
                              &                                  & \tcode{<deque>}         \\
+                             &                                  & \tcode{<dynarray>}  \\
                              &                                  & \tcode{<forward_list>}  \\
                              &                                  & \tcode{<list>}          \\
                              &                                  & \tcode{<vector>}        \\ \rowsep
@@ -998,6 +999,7 @@ time.
  \tcode{basic_string},
  \tcode{array},
  \tcode{deque},
+ \tcode{dynarray},
  \tcode{forward_list},
  \tcode{list},
  \tcode{vector}
@@ -1011,6 +1013,7 @@ time.
  \tcode{basic_string},
  \tcode{array},
  \tcode{deque},
+ \tcode{dynarray},
  \tcode{list},
  \tcode{vector}
  \\ \rowsep
@@ -1107,6 +1110,7 @@ time.
  \tcode{basic_string},
  \tcode{array},
  \tcode{deque},
+ \tcode{dynarray},
  \tcode{vector}
  \\ \rowsep
 
@@ -1116,6 +1120,7 @@ time.
  \tcode{basic_string},
  \tcode{array},
  \tcode{deque},
+ \tcode{dynarray},
  \tcode{vector}
  \\
 
@@ -2272,7 +2277,7 @@ function or comparison function, the \tcode{rehash()} function has no effect.
 \rSec2[sequences.general]{In general}
 
 \pnum
-The headers \tcode{<array>}, \tcode{<deque>}, \tcode{<forward_list>},
+The headers \tcode{<array>}, \tcode{<deque>}, \tcode{dynarray}, \tcode{<forward_list>},
 \tcode{<list>}, and \tcode{<vector>} define template classes that meet the
 requirements for sequence containers.
 
@@ -2340,6 +2345,33 @@ namespace std {
     bool operator<=(const deque<T,Allocator>& x, const deque<T,Allocator>& y);
   template <class T, class Allocator>
     void swap(deque<T,Allocator>& x, deque<T,Allocator>& y);
+}
+\end{codeblock}
+
+\synopsis{Header \tcode{<dynarray>} synopsis}%
+\indexlibrary{\idxhdr{dynarray}}%
+\begin{codeblock}
+#include <initializer_list>
+
+namespace std {
+  template <class T > class dynarray;
+
+  template <class Type, class Alloc>
+    struct uses_allocator<dynarray<Type>, Alloc>;
+
+  template <class T>
+    bool operator==(const dynarray<T>& x, const dynarray<T>& y);
+  template <class T>
+    bool operator<(const dynarray<T>& x, const dynarray<T>& y);
+  template <class T>
+    bool operator!=(const dynarray<T>& x, const dynarray<T>& y);
+  template <class T>
+    bool operator>(const dynarray<T>& x, const dynarray<T>& y);
+  template <class T>
+    bool operator>=(const dynarray<T>& x, const dynarray<T>& y);
+  template <class T>
+    bool operator<=(const dynarray<T>& x, const dynarray<T>& y);
+
 }
 \end{codeblock}
 
@@ -3124,6 +3156,251 @@ template <class T, class Allocator>
 \begin{codeblock}
 x.swap(y);
 \end{codeblock}
+\end{itemdescr}
+
+\rSec2[dynarray]{Class template \tcode{dynarray}}
+\indexlibrary{\idxcode{dynarray}}%
+
+\rSec3[dynarray.overview]{Class template \tcode{dynarray} overview}
+
+\pnum
+\indextext{\idxcode{dynarray}!contiguous storage}%
+The header \tcode{<dynarray>} defines a class template for storing sequences
+of objects where the size is fixed at construction. A \tcode{dynarray}
+supports random access iterators. An instance of \tcode{dynarray<T>} stores
+elements of type \tcode{T}. The elements of a \tcode{dynarray} are stored
+contiguously, meaning that if \tcode{d} is a \tcode{dynarray<T>} then it
+obeys the identity \verb|&d[n] == &d[0] + n| for all \tcode{0 <= n < d.size()}.
+
+\pnum
+Unless otherwise specified, all \tcode{dynarray} operations have the same
+requirements and semantics as specified in~\ref{container.requirements}.
+
+\pnum
+All operations except construction, destruction, and \tcode{fill} shall have
+constant-time complexity.
+
+\begin{codeblock}
+namespace std {
+  template <class T>
+  class dynarray {
+  public:
+    // types:
+    typedef       T                               value_type;
+    typedef       T&                              reference;
+    typedef const T&                              const_reference;
+    typedef       T*                              pointer;
+    typedef const T*                              const_pointer;
+    typedef @\impdef@                iterator;       // See \ref{container.requirements}
+    typedef @\impdef@                const_iterator; // See \ref{container.requirements}
+    typedef reverse_iterator<iterator>            reverse_iterator;
+    typedef reverse_iterator<const_iterator>      const_reverse_iterator;
+    typedef size_t                                size_type;
+    typedef ptrdiff_t                             difference_type;
+
+    // \ref{dynarray.cons} construct/copy/destroy:
+    explicit dynarray(size_type c);
+    template <class Alloc>
+      dynarray(size_type c, const Alloc& alloc);
+    dynarray(size_type c, const T& v);
+    template <class Alloc>
+      dynarray(size_type c, const T& v, const Alloc& alloc);
+    dynarray(const dynarray& d);
+    template <class Alloc>
+      dynarray(const dynarray& d, const Alloc& alloc);
+    dynarray(initializer_list<T>);
+    template <class Alloc>
+      dynarray(initializer_list<T>, const Alloc& alloc);
+    dynarray& operator=(const dynarray&) = delete;
+    ~dynarray();
+
+    // iterators:
+    iterator       begin()        noexcept;
+    const_iterator begin()  const noexcept;
+    const_iterator cbegin() const noexcept;
+    iterator       end()          noexcept;
+    const_iterator end()    const noexcept;
+    const_iterator cend()   const noexcept;
+
+    reverse_iterator       rbegin()        noexcept;
+    const_reverse_iterator rbegin()  const noexcept;
+    const_reverse_iterator crbegin() const noexcept;
+    reverse_iterator       rend()          noexcept;
+    const_reverse_iterator rend()    const noexcept;
+    const_reverse_iterator crend()   const noexcept;
+
+    // capacity:
+    size_type size()     const noexcept;
+    size_type max_size() const noexcept;
+    bool      empty()    const noexcept;
+
+    // element access:
+    reference       operator[](size_type n);
+    const_reference operator[](size_type n) const;
+
+    reference       front();
+    const_reference front() const;
+    reference       back();
+    const_reference back()  const;
+
+    const_reference at(size_type n) const;
+    reference       at(size_type n);
+
+    // \ref{dynarray.data} data access:
+    T*       data()       noexcept;
+    const T* data() const noexcept;
+
+    // \ref{dynarray.mutate} mutating member functions:
+    void fill(const T& v);
+  };
+
+} // namespace std
+\end{codeblock}
+
+\rSec3[dynarray.cons]{\tcode{dynarray} constructor and destructor}
+
+\indexlibrary{\idxcode{dynarray}!\idxcode{dynarray}}%
+\indexlibrary{\idxcode{dynarray}!\idxcode{dynarray}}%
+\begin{itemdecl}
+explicit forward_list(size_type c);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Allocates storage for \tcode{c} elements. May or may not invoke the
+global \tcode{operator new}. The \tcode{c} elements of the \tcode{dynarray}
+are default-initialized~(\ref{dcl.init}).
+
+\pnum
+\throws \tcode{std::bad_array_length} when the size requested is larger than
+implementable. \tcode{std::bad_alloc} when there is insufficient memory.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{dynarray}!\idxcode{dynarray}}%
+\indexlibrary{\idxcode{dynarray}!\idxcode{dynarray}}%
+\begin{itemdecl}
+dynarray(size_type c, const T& v);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\requires \tcode{T} shall meet the \tcode{CopyConstructible} requirements.
+
+\pnum
+\effects Allocates storage for \tcode{c} elements. May or may not invoke the
+global \tcode{operator new}. The \tcode{c} elements of the \tcode{dynarray}
+are direct-initialized~(\ref{dcl.init}) with argument \tcode{v}.
+
+\pnum
+\throws \tcode{std::bad_array_length} when the size requested is larger than
+implementable. \tcode{std::bad_alloc} when there is insufficient memory.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{dynarray}!\idxcode{dynarray}}%
+\indexlibrary{\idxcode{dynarray}!\idxcode{dynarray}}%
+\begin{itemdecl}
+dynarray(const dynarray& d);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\requires \tcode{T} shall meet the \tcode{CopyConstructible} requirements.
+
+\pnum
+\throws \tcode{std::bad_alloc} when there is insufficient memory.
+
+\pnum
+\effects Allocates storage for \tcode{d.size()} elements. The \tcode{d.size()}
+elements of the \tcode{dynarray} are direct-initialized~(\ref{dcl.init}) with
+the corresponding elements of \tcode{d}. May or may not invoke the global
+\tcode{operator new}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{dynarray}!\idxcode{dynarray}}%
+\indexlibrary{\idxcode{dynarray}!\idxcode{dynarray}}%
+\begin{itemdecl}
+template <class Alloc>
+  dynarray(size_type c, const Alloc& alloc);
+template <class Alloc>
+  dynarray(size_type c, const T& v, const Alloc& alloc);
+template <class Alloc>
+  dynarray(const dynarray& d, const Alloc& alloc);
+template <class Alloc>
+  dynarray(initializer_list<T>, const Alloc& alloc);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\requires \tcode{Alloc} shall meet the requirements for an
+Allocator~(\ref{allocator.requirements}).
+
+\pnum
+\effects Equivalent to the preceding constructors except that each element is
+constructed with uses-allocator construction~(\ref{allocator.uses.construction}).
+\end{itemdescr}
+
+\indexlibrary{\idxcode{dynarray}!destructor}%
+\begin{itemdecl}
+~dynarray();
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Invokes the global \tcode{operator delete} if and only if the
+constructor invoked the global \tcode{operator new}.
+\end{itemdescr}
+
+\rSec3[dynarray.data]{\tcode{dynarray::data}}
+
+\indexlibrary{\idxcode{dynarray}!\idxcode{data}}%
+\indexlibrary{\idxcode{data}!\idxcode{dynarray}}%
+\begin{itemdecl}
+T* data() noexcept;
+const T* data() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns A pointer to the contiguous storage containing the elements.
+\end{itemdescr}
+
+\rSec3[dynarray.mutate]{Mutating operations}
+
+\indexlibrary{\idxcode{dynarray}!\idxcode{fill}}%
+\indexlibrary{\idxcode{fill}!\idxcode{dynarray}}%
+\begin{itemdecl}
+void fill(const T& v);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects \tcode{fill_n(begin(), size(), v);}
+\end{itemdescr}
+
+\rSec3[dynarray.zero]{Zero sized \tcode{dynarray}s}
+
+\indextext{\idxcode{dynarray}!zero sized}%
+\pnum
+\tcode{dynarray} shall provide support for the special case of construction
+with a size of zero. In the case that the size is zero,
+\tcode{begin() == end() ==} unique value. The return value of \tcode{data()}
+is unspecified. The effect of calling \tcode{front()} or \tcode{back()} for a
+zero-sized \tcode{dynarray} is undefined.
+
+\rSec3[dynarray.traits]{Traits}
+
+\indexlibrary{\idxcode{uses_allocator}}%
+\begin{itemdecl}
+template <class Type, class Alloc>
+  struct uses_allocator<dynarray<Type>, Alloc> : true_type { };
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\requires \tcode{Alloc} shall be an Allocator~(\ref{allocator.requirements}).
+\enternote Specialization of this trait informs other library components that
+\tcode{dynarray} can be constructed with an allocator, even though it does not
+have a nested \tcode{allocator_type}. \exitnote
 \end{itemdescr}
 
 \rSec2[forwardlist]{Class template \tcode{forward_list}}

--- a/source/xref.tex
+++ b/source/xref.tex
@@ -510,6 +510,13 @@ diff.special\quad\ref{diff.special}\\
 diff.stat\quad\ref{diff.stat}\\
 diff.wchar.t\quad\ref{diff.wchar.t}\\
 domain.error\quad\ref{domain.error}\\
+dynarray\quad\ref{dynarray}\\
+dynarray.cons\quad\ref{dynarray.cons}\\
+dynarray.data\quad\ref{dynarray.data}\\
+dynarray.mutate\quad\ref{dynarray.mutate}\\
+dynarray.overview\quad\ref{dynarray.overview}\\
+dynarray.traits\quad\ref{dynarray.traits}\\
+dynarray.zero\quad\ref{dynarray.zero}\\
 \par \textbf{E}\par
 enumerated.types\quad\ref{enumerated.types}\\
 equal.range\quad\ref{equal.range}\\


### PR DESCRIPTION
Includes the following editorial fixes relative to the proposal:
- Remove Allocator template parameter from comparison operators.
- Use `template <class T>` instead of `template< typename T >`.
- Declare member types public.
- Refer to 23.2 for implementation-defined iterator types.
- Add `explicit` keyword to first declaration in [dynarray.cons].
