### PR TITLE
 Library N3671, Making non-modifying sequence operations more robust

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -96,12 +96,34 @@ namespace std {
                InputIterator2 first2, BinaryPredicate pred);
 
   template<class InputIterator1, class InputIterator2>
+    pair<InputIterator1, InputIterator2>
+      mismatch(InputIterator1 first1, InputIterator1 last1,
+               InputIterator2 first2, InputIterator2 last2);
+
+  template
+   <class InputIterator1, class InputIterator2, class BinaryPredicate>
+    pair<InputIterator1, InputIterator2>
+      mismatch(InputIterator1 first1, InputIterator1 last1,
+               InputIterator2 first2, InputIterator2 last2,
+               BinaryPredicate pred);
+
+  template<class InputIterator1, class InputIterator2>
     bool equal(InputIterator1 first1, InputIterator1 last1,
                InputIterator2 first2);
   template
    <class InputIterator1, class InputIterator2, class BinaryPredicate>
     bool equal(InputIterator1 first1, InputIterator1 last1,
                InputIterator2 first2, BinaryPredicate pred);
+
+  template<class InputIterator1, class InputIterator2>
+    bool equal(InputIterator1 first1, InputIterator1 last1,
+               InputIterator2 first2, InputIterator2 last2);
+
+  template
+   <class InputIterator1, class InputIterator2, class BinaryPredicate>
+    bool equal(InputIterator1 first1, InputIterator1 last1,
+               InputIterator2 first2, InputIterator2 last2,
+               BinaryPredicate pred);
 
   template<class ForwardIterator1, class ForwardIterator2>
     bool is_permutation(ForwardIterator1 first1, ForwardIterator1 last1,
@@ -110,6 +132,16 @@ namespace std {
                    class BinaryPredicate>
     bool is_permutation(ForwardIterator1 first1, ForwardIterator1 last1,
                         ForwardIterator2 first2, BinaryPredicate pred);
+
+  template<class ForwardIterator1, class ForwardIterator2>
+    bool is_permutation(ForwardIterator1 first1, ForwardIterator1 last1,
+                        ForwardIterator2 first2, ForwardIterator2 last2);
+
+  template<class ForwardIterator1, class ForwardIterator2,
+                      class BinaryPredicate>
+    bool is_permutation(ForwardIterator1 first1, ForwardIterator1 last1,
+                        ForwardIterator2 first2, ForwardIterator2 last2,
+                        BinaryPredicate pred);
 
   template<class ForwardIterator1, class ForwardIterator2>
     ForwardIterator1 search(
@@ -1004,9 +1036,25 @@ template<class InputIterator1, class InputIterator2,
   pair<InputIterator1, InputIterator2>
       mismatch(InputIterator1 first1, InputIterator1 last1,
                InputIterator2 first2, BinaryPredicate pred);
+
+template<class InputIterator1, class InputIterator2>
+  pair<InputIterator1, InputIterator2>
+    mismatch(InputIterator1 first1, InputIterator1 last1,
+             InputIterator2 first2, InputIterator2 last2);
+
+template <class InputIterator1, class InputIterator2,
+           class BinaryPredicate>
+  pair<InputIterator1, InputIterator2>
+    mismatch(InputIterator1 first1, InputIterator1 last1,
+             InputIterator2 first2, InputIterator2 last2,
+             BinaryPredicate pred);
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+\remarks If \tcode{last2} was not given in the argument list, it denotes
+\tcode{first2 + (last1 - first1)} below.
+
 \pnum
 \returns
 A pair of iterators
@@ -1021,13 +1069,16 @@ is the first iterator
 in the range \range{first1}{last1}
 for which the following corresponding conditions hold:
 
-\begin{codeblock}
-!(*i == *(first2 + (i - first1)))
-pred(*i, *(first2 + (i - first1))) == false
-\end{codeblock}
+\begin{itemize}
+\item \tcode{j} is in the range \tcode{[first2, last2)}.
+\item \tcode{!(*i == *(first2 + (i - first1)))}
+\item \tcode{pred(*i, *(first2 + (i - first1))) == false}
+\end{itemize}
 
-Returns the pair \tcode{last1} and
-\tcode{first2 + (last1 - first1)}
+Returns the pair
+\tcode{first1 + min(last1 - first1, last2 - first2)}
+and
+\tcode{first2 + min(last1 - first1, last2 - first2)}
 if such an iterator
 \tcode{i}
 is not found.
@@ -1051,11 +1102,30 @@ template<class InputIterator1, class InputIterator2,
           class BinaryPredicate>
   bool equal(InputIterator1 first1, InputIterator1 last1,
              InputIterator2 first2, BinaryPredicate pred);
+
+template<class InputIterator1, class InputIterator2>
+  bool equal(InputIterator1 first1, InputIterator1 last1,
+             InputIterator2 first2, InputIterator2 last2);
+
+template<class InputIterator1, class InputIterator2,
+           class BinaryPredicate>
+  bool equal(InputIterator1 first1, InputIterator1 last1,
+             InputIterator2 first2, InputIterator2 last2,
+             BinaryPredicate pred);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
+\remarks If \tcode{last2} was not given in the argument list, it denotes
+\tcode{first2 + (last1 - first1)} below.
+
+\pnum
 \returns
+If
+\tcode{last1 - first1 != last2 - first2},
+return
+\tcode{false}.
+Otherwise return
 \tcode{true}
 if for every iterator
 \tcode{i}
@@ -1067,8 +1137,14 @@ Otherwise, returns
 
 \pnum
 \complexity
-At most
-\tcode{last1 - first1}
+No applications of the corresponding predicate if
+\tcode{InputIterator1}
+and
+\tcode{InputIterator2}
+meet the requirements of random access iterators and
+\tcode{last1 - first1 != last2 - first2}.
+Otherwise, at most
+\tcode{min(last1 - first1, last2 - first2)}
 applications of the corresponding predicate.
 \end{itemdescr}
 
@@ -1083,6 +1159,14 @@ template<class ForwardIterator1, class ForwardIterator2,
                  class BinaryPredicate>
   bool is_permutation(ForwardIterator1 first1, ForwardIterator1 last1,
                       ForwardIterator2 first2, BinaryPredicate pred);
+template<class ForwardIterator1, class ForwardIterator2>
+  bool is_permutation(ForwardIterator1 first1, ForwardIterator1 last1,
+                      ForwardIterator2 first2, ForwardIterator2 last2);
+template<class ForwardIterator1, class ForwardIterator2,
+                 class BinaryPredicate>
+  bool is_permutation(ForwardIterator1 first1, ForwardIterator1 last1,
+                      ForwardIterator2 first2, ForwardIterator2 last2,
+                      BinaryPredicate pred);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1091,17 +1175,25 @@ template<class ForwardIterator1, class ForwardIterator2,
 value type. The comparison function shall be an equivalence relation.
 
 \pnum
-\returns \tcode{true} if there exists a permutation of the elements in the
+\remarks If \tcode{last2} was not given in the argument list, it denotes
+\tcode{first2 + (last1 - first1)} below.
+
+\pnum
+\returns If \tcode{last1 - first1 != last2 - first2}, return \tcode{false}.
+Otherwise return \tcode{true} if there exists a permutation of the elements in the
 range \range{first2}{first2 + (last1 - first1)}, beginning with \tcode{ForwardIterator2
 begin}, such that \tcode{equal(first1, last1, begin)} returns \tcode{true} or 
 \tcode{equal(first1, last1, begin, pred)} returns \tcode{true}; otherwise, returns
 \tcode{false}.
 
 \pnum
-\complexity Exactly \tcode{distance(first1, last1)} applications of the
-corresponding predicate if \tcode{equal(\brk{}first1, last1, first2)}
-would return \tcode{true}
-or \tcode{equal(first1, last1, first2, pred)} would return \tcode{true}; otherwise, at
+\complexity No applications of the corresponding predicate if \tcode{ForwardIterator1}
+and \tcode{ForwardIter\-ator2} meet the requirements of random access iterators and
+\tcode{last1 - first1 != last2 - first2}.
+Otherwise, exactly \tcode{distance(first1, last1)} applications of the
+corresponding predicate if \tcode{equal(\brk{}first1, last1, first2, last2)}
+would return \tcode{true} if \tcode{pred} was not given in the argument list
+or \tcode{equal(first1, last1, first2, last2, pred)} would return \tcode{true} if pred was given in the argument list; otherwise, at
 worst \bigoh{N^2}, where $N$ has the value \tcode{distance(first1, last1)}.
 \end{itemdescr}
 


### PR DESCRIPTION
I haven't made this change, but I think for consistency with the existing wording the new text added to the _Returns_ paragraphs should be altered to say 

> [...] returns `false`; otherwise returns `true` if [...]  

instead of

> [...] return `false`. Otherwise return `true` if [...]
