### PR TITLE
Library N3642, User-defined Literals for Standard Library Types

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -797,6 +797,18 @@ namespace std {
   template <> struct hash<u16string>;
   template <> struct hash<u32string>;
   template <> struct hash<wstring>;
+
+inline namespace literals {
+inline namespace string_literals {
+
+  // \ref{basic.string.literals}, suffix for basic_string literals:
+  string    operator "" s(const char *str, size_t len);
+  u16string operator "" s(const char16_t *str, size_t len);
+  u32string operator "" s(const char32_t *str, size_t len);
+  wstring   operator "" s(const wchar_t *str, size_t len);
+
+}
+}
 }
 \end{codeblock}
 
@@ -4355,6 +4367,48 @@ template <> struct hash<wstring>;
 \tcode{hash}~(\ref{unord.hash}).
 \end{itemdescr}
 
+\rSec1[basic.string.literals]{Suffix for \tcode{basic_string} literals}
+
+\begin{itemdecl}
+string operator "" s(const char* str, size_t len);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\tcode{string\{str,len\}}
+\end{itemdescr}
+
+\begin{itemdecl}
+u16string operator "" s(const char16_t* str, size_t len);
+\end{itemdecl}
+\begin{itemdescr}
+\pnum
+\returns
+\tcode{u16string\{str,len\}}
+\end{itemdescr}
+
+\begin{itemdecl}
+u32string operator "" s(const char32_t* str, size_t len);
+\end{itemdecl}
+\begin{itemdescr}
+\pnum
+\returns
+\tcode{u32string\{str,len\}}
+\end{itemdescr}
+
+\begin{itemdecl}
+wstring operator "" s(const wchar_t* str, size_t len);
+\end{itemdecl}
+\begin{itemdescr}
+\pnum
+\returns
+\tcode{wstring\{str,len\}}
+\end{itemdescr}
+
+\pnum \enternote
+The same suffix \tcode{s} is used for \tcode{chrono::duration} literals denoting seconds but there is no conflict, since duration suffixes apply to numbers and string literal suffixes apply to character array literals.
+\exitnote
 
 \rSec1[c.strings]{Null-terminated sequence utilities}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -10158,6 +10158,26 @@ class steady_clock;
 class high_resolution_clock;
 
 }  // namespace chrono
+
+inline namespace literals {
+inline namespace chrono_literals {
+
+// ~\ref{time.duration.literals}, suffixes for duration literals
+constexpr chrono::hours                                 operator "" h(unsigned long long);
+constexpr chrono::duration<@\unspec@, ratio<3600,1>> operator "" h(long double);
+constexpr chrono::minutes                               operator "" min(unsigned long long);
+constexpr chrono::duration<@\unspec@, ratio<60,1>>   operator "" min(long double);
+constexpr chrono::seconds                               operator "" s(unsigned long long);
+constexpr chrono::duration<@\unspec@>                operator "" s(long double);
+constexpr chrono::milliseconds                          operator "" ms(unsigned long long);
+constexpr chrono::duration<@\unspec@, milli>         operator "" ms(long double);
+constexpr chrono::microseconds                          operator "" us(unsigned long long);
+constexpr chrono::duration<@\unspec@, micro>         operator "" us(long double);
+constexpr chrono::nanoseconds                           operator "" ns(unsigned long long);
+constexpr chrono::duration<@\unspec@, nano>          operator "" ns(long double);
+
+}  // namespace chrono_literals
+}  // namespace literals
 }  // namespace std
 \end{codeblock}
 
@@ -10978,6 +10998,108 @@ are done with \tcode{static_cast}. It avoids multiplications and divisions when
 it is known at compile time that one or more arguments is 1. Intermediate
 computations are carried out in the widest representation and only converted to
 the destination representation at the final step.
+\end{itemdescr}
+
+\rSec3[time.duration.literals]{Suffixes for duration literals}
+
+\pnum
+This section describes literal suffixes for constructing duration literals. The
+suffixes \tcode{h}, \tcode{min}, \tcode{s}, \tcode{ms}, \tcode{us}, \tcode{ns}
+denote duration values of the corresponding types \tcode{hours}, \tcode{minutes},
+\tcode{seconds}, \tcode{miliseconds}, \tcode{microseconds}, and \tcode{nanoseconds}
+respectively if they are applied to integral literals.
+
+\pnum
+If any of these suffixes are applied to a floating point literal the result is a
+\tcode{chrono::duration} literal with an unspecified floating point representation.
+
+\pnum
+If any of these suffixes are applied to an integer literal and the resulting
+\tcode{chrono::duration} value cannot be represented in the result type because
+of overflow, the program is ill-formed.
+
+\pnum
+\enterexample
+The following code shows some duration literals.
+\begin{codeblock}
+using namespace std::chrono_literals;
+auto constexpr aday=24h;
+auto constexpr lesson=45min;
+auto constexpr halfanhour=0.5h;
+\end{codeblock}
+\exitexample
+
+\begin{itemdecl}
+constexpr chrono::hours                                 operator "" h(unsigned long long hours);
+constexpr chrono::duration<@\unspec@, ratio<3600,1>> operator "" h(long double hours);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+A \tcode{duration} literal representing \tcode{hours} hours.
+\end{itemdescr}
+
+\begin{itemdecl}
+constexpr chrono::minutes                             operator "" min(unsigned long long minutes);
+constexpr chrono::duration<@\unspec@, ratio<60,1>> operator "" min(long double minutes);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+A \tcode{duration} literal representing \tcode{minutes} minutes.
+\end{itemdescr}
+
+\begin{itemdecl}
+constexpr chrono::seconds                operator "" s(unsigned long long sec);
+constexpr chrono::duration<@\unspec@> operator "" s(long double sec);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+A \tcode{duration} literal representing \tcode{sec} seconds.
+
+\pnum
+\enternote
+The same suffix \tcode{s} is used for \tcode{basic_string} but there is no
+conflict, since duration suffixes apply to numbers and string literal suffixes
+apply to character array literals.
+\exitnote
+\end{itemdescr}
+
+\begin{itemdecl}
+constexpr chrono::milliseconds                  operator "" ms(unsigned long long msec);
+constexpr chrono::duration<@\unspec@, milli> operator "" ms(long double msec);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+A \tcode{duration} literal representing \tcode{msec} milliseconds.
+\end{itemdescr}
+
+\begin{itemdecl}
+constexpr chrono::microseconds                  operator "" us(unsigned long long usec);
+constexpr chrono::duration<@\unspec@, micro> operator "" us(long double usec);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+A \tcode{duration} literal representing \tcode{usec} microseconds.
+\end{itemdescr}
+
+\begin{itemdecl}
+constexpr chrono::nanoseconds                  operator "" ns(unsigned long long nsec);
+constexpr chrono::duration<@\unspec@, nano> operator "" ns(long double nsec);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+A \tcode{duration} literal representing \tcode{nsec} nanoseconds.
 \end{itemdescr}
 
 \rSec2[time.point]{Class template \tcode{time_point}}

--- a/source/xref.tex
+++ b/source/xref.tex
@@ -173,6 +173,7 @@ basic.stc.static\quad\ref{basic.stc.static}\\
 basic.stc.thread\quad\ref{basic.stc.thread}\\
 basic.string\quad\ref{basic.string}\\
 basic.string.hash\quad\ref{basic.string.hash}\\
+basic.string.literals\quad\ref{basic.string.literals}\\
 basic.type.qualifier\quad\ref{basic.type.qualifier}\\
 basic.types\quad\ref{basic.types}\\
 bidirectional.iterators\quad\ref{bidirectional.iterators}\\
@@ -1534,6 +1535,7 @@ time.duration.arithmetic\quad\ref{time.duration.arithmetic}\\
 time.duration.cast\quad\ref{time.duration.cast}\\
 time.duration.comparisons\quad\ref{time.duration.comparisons}\\
 time.duration.cons\quad\ref{time.duration.cons}\\
+time.duration.literals\quad\ref{time.duration.literals}\\
 time.duration.nonmember\quad\ref{time.duration.nonmember}\\
 time.duration.observer\quad\ref{time.duration.observer}\\
 time.duration.special\quad\ref{time.duration.special}\\


### PR DESCRIPTION
Changes relative to the proposal:
- Re-ordered the `basic_string` literals so they are listed in the
  order `char`, `char16_t`, `char32_t` and `wchar_t`. This matches the other
  functions in Clause 21.
- Changed `const char *str` to `const char* str` for consistency with
  asterisk placement in `basic_string` itself.
- Changed `operator""` to `operator ""` for consistency with core wording.
- Added whitespace to duration literal declarations so they are aligned
- Changed section title to "Suffixes for duration literals" instead of
  "Suffix for duration literals"
- Use `string`, `u16string` etc. typedefs for `basic_string`
