### PR TITLE
[optional] Editorial fix

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2525,7 +2525,7 @@ assignment of the form \tcode{o = \{\}} is unambiguous. \exitnote
 \indexlibrary{\idxcode{optional}!\idxcode{emplace}}%
 \indexlibrary{\idxcode{emplace}!\idxcode{optional}}%
 \begin{itemdecl}
-template <class... Args> void optional<T>::emplace(Args&&... args);
+template <class... Args> void emplace(Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2552,7 +2552,7 @@ has been destroyed.
 \indexlibrary{\idxcode{optional}!\idxcode{emplace}}%
 \indexlibrary{\idxcode{emplace}!\idxcode{optional}}%
 \begin{itemdecl}
-template <class U, class... Args> void optional<T>::emplace(initializer_list<U> il, Args&&... args);
+template <class U, class... Args> void emplace(initializer_list<U> il, Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2586,7 +2586,7 @@ has been destroyed.
 \indexlibrary{\idxcode{optional}!\idxcode{swap}}%
 \indexlibrary{\idxcode{swap}!\idxcode{optional}}%
 \begin{itemdecl}
-void optional<T>::swap(optional<T>& rhs) noexcept(@\seebelow@);
+void swap(optional<T>& rhs) noexcept(@\seebelow@);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2635,8 +2635,8 @@ the exception safety guarantee of \tcode{T}'s move constructor.
 \indexlibrary{\idxcode{optional}!\idxcode{operator->}}%
 \indexlibrary{\idxcode{operator->}!\idxcode{optional}}%
 \begin{itemdecl}
-constexpr const T* optional<T>::operator->() const;
-T* optional<T>::operator->();
+constexpr const T* operator->() const;
+T* operator->();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2657,8 +2657,8 @@ T* optional<T>::operator->();
 \indexlibrary{\idxcode{optional}!\idxcode{operator*}}%
 \indexlibrary{\idxcode{operator*}!\idxcode{optional}}%
 \begin{itemdecl}
-constexpr const T& optional<T>::operator*() const;
-T& optional<T>::operator*();
+constexpr const T& operator*() const;
+T& operator*();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2678,7 +2678,7 @@ T& optional<T>::operator*();
 \indexlibrary{\idxcode{optional}!\idxcode{operator bool}}%
 \indexlibrary{\idxcode{operator bool}!\idxcode{optional}}%
 \begin{itemdecl}
-constexpr explicit optional<T>::operator bool() const noexcept;
+constexpr explicit operator bool() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2692,8 +2692,8 @@ constexpr explicit optional<T>::operator bool() const noexcept;
 \indexlibrary{\idxcode{optional}!\idxcode{value}}%
 \indexlibrary{\idxcode{value}!\idxcode{optional}}%
 \begin{itemdecl}
-constexpr const T& optional<T>::value() const;
-T& optional<T>::value();
+constexpr const T& value() const;
+T& value();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2710,7 +2710,7 @@ T& optional<T>::value();
 \indexlibrary{\idxcode{optional}!\idxcode{value_or}}%
 \indexlibrary{\idxcode{value_or}!\idxcode{optional}}%
 \begin{itemdecl}
-template <class U> constexpr T optional<T>::value_or(U&& v) const&;
+template <class U> constexpr T value_or(U&& v) const&;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2742,7 +2742,7 @@ function.
 \indexlibrary{\idxcode{optional}!\idxcode{value_or}}%
 \indexlibrary{\idxcode{value_or}!\idxcode{optional}}%
 \begin{itemdecl}
-template <class U> T optional<T>::value_or(U&& v) &&;
+template <class U> T value_or(U&& v) &&;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
The rest of the standard does not qualify the member functions in the declarations accompanying the detailed function descriptions. Use the same style for std::optional too.
