### PR TITLE
Fix for issue #80, [cpp.scope] ends in an unmatched "— end note ]"

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -867,16 +867,17 @@ It is ignored if the specified identifier is not currently defined as
 a macro name.
 
 \pnum
-\enternote
+\enterexample
 The simplest use of this facility is to define a ``manifest constant,''
 as in
 \begin{codeblock}
 #define TABSIZE 100
 int table[TABSIZE];
 \end{codeblock}
-\exitnote
+\exitexample
 
 \pnum
+\enterexample
 The following defines a function-like
 macro whose value is the maximum of its arguments.
 It has the advantages of working for any compatible types of the arguments
@@ -896,8 +897,10 @@ as it has none.
 
 The parentheses ensure that the arguments and
 the resulting expression are bound properly.
+\exitexample
 
 \pnum
+\enterexample
 To illustrate the rules for redefinition and reexamination,
 the sequence
 
@@ -932,8 +935,10 @@ f(2 * (2+(3,4)-0,1)) | f(2 * (@$\sim$@ 5)) & f(2 * (0,1))^m(0,1);
 int i[] = { 1, 23, 4, 5, };
 char c[2][6] = { "hello", "" };
 \end{codeblock}
+\exitexample
 
 \pnum
+\enterexample
 To illustrate the rules for creating character string literals
 and concatenating tokens,
 the sequence
@@ -982,8 +987,10 @@ Space around the
 and
 \tcode{\#\#}
 tokens in the macro definition is optional.
+\exitexample
 
 \pnum
+\enterexample
 To illustrate the rules for placemarker preprocessing tokens, the sequence
 
 \begin{codeblock}
@@ -998,8 +1005,10 @@ results in
 int j[] = { 123, 45, 67, 89,
   10, 11, 12, };
 \end{codeblock}
+\exitexample
 
 \pnum
+\enterexample
 To demonstrate the redefinition rules,
 the following sequence is valid.
 
@@ -1020,8 +1029,10 @@ But the following redefinitions are invalid:
 #define FUNC_LIKE(b) ( a )   // different parameter usage
 #define FUNC_LIKE(b) ( b )   // different parameter spelling
 \end{codeblock}
+\exitexample
 
 \pnum
+\enterexample
 Finally, to show the variable argument list macro facilities:
 
 \begin{codeblock}
@@ -1043,7 +1054,7 @@ puts("The first, second, and third items.");
 ((x>y) ? puts("x>y") : printf("x is %d but y is %d", x, y));
   
 \end{codeblock}
-\exitnote%
+\exitexample
 \indextext{macro!replacement|)}
 
 \rSec1[cpp.line]{Line control}%


### PR DESCRIPTION
This fixes #80 by marking each para with enter/exit example, such that you no longer need to scroll back a page or two to see whether the text you're reading is normative.
