### PR TITLE
[temp.friend] Fix minor typo.

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -2024,7 +2024,7 @@ because the friend
 \tcode{preempt}
 has an explicit
 \grammarterm{template-argument}
-\tcode{<T>},
+\tcode{T},
 each specialization of the
 \tcode{task}
 class template has the appropriate specialization of the function


### PR DESCRIPTION
Angle brackets should not be contained in a template-argument.
