### PR TITLE
Correct pasto in 14.7.3 example

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -5094,9 +5094,9 @@ template<> enum A<int>::E : int { eint };         // OK
 template<> enum class A<int>::S : int { sint };   // OK
 template<class T> enum A<T>::E : T { eT };
 template<class T> enum class A<T>::S : T { sT };
-template<> enum A<char>::E : int { echar };       // ill-formed, \tcode{A<char>::E} was instantiated
-                                                  // when \tcode{A<char>} was instantiated
-template<> enum class A<char>::S : int { schar }; // OK
+template<> enum A<char>::E : char { echar };       // ill-formed, \tcode{A<char>::E} was instantiated
+                                                   // when \tcode{A<char>} was instantiated
+template<> enum class A<char>::S : char { schar }; // OK
 \end{codeblock}
 \exitexample
 


### PR DESCRIPTION
Roger Orr asked me to explain how the specialization of A<char>::S could be ill-formed with an int underlying type; the answer is that the underlying type was a copy/paste error in the example.  This patch fixes that error.

This change seems to be on the border of editorial and technical; my guess was that since I wrote the example in the first place I can correct an obvious error, but I'm happy to take it to Core if that seems more appropriate to you.
