### PR TITLE
Editorial fix in [namespace.def]

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2125,7 +2125,7 @@ is
 
 \pnum
 The \grammarterm{identifier} in an \grammarterm{original-namespace-definition}
-shall not have been previously defined in the declarative region in
+shall not have been previously declared in the declarative region in
 which the \grammarterm{original-namespace-definition} appears. The
 \grammarterm{identifier} in an \grammarterm{original-namespace-definition} is
 the name of the namespace. Subsequently in that declarative region, it


### PR DESCRIPTION
An identifier makes an entity defined only through several known kind of declarations. Here the word "defined" would make "typedef int X; namespace X{}" unintentionally well-formed, because the name "X" is introduced by a non-definition(typedef declaration) and nothing named "X" is defined previous the namespace definition.
