### PR TITLE
weibull_distribution : add missing semicolon

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -4989,7 +4989,7 @@ public:
  typedef @\textit{unspecified}@ param_type;
 
  // constructor and reset functions
- explicit weibull_distribution(RealType a = 1.0, RealType b = 1.0)
+ explicit weibull_distribution(RealType a = 1.0, RealType b = 1.0);
  explicit weibull_distribution(const param_type& parm);
  void reset();
 


### PR DESCRIPTION
Add missing semicolon in 26.5.8.4.4 Class template weibull_distribution.
