### PR TITLE
linear_congruential_engine : fix typo

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -2679,8 +2679,8 @@ public:
  static constexpr result_type multiplier = a;
  static constexpr result_type increment = c;
  static constexpr result_type modulus = m;
- static constexpr result_type min() { return c == 0u ? 1u: 0u };
- static constexpr result_type max() { return m - 1u };
+ static constexpr result_type min() { return c == 0u ? 1u: 0u; }
+ static constexpr result_type max() { return m - 1u; }
  static constexpr result_type default_seed = 1u;
 
  // constructors and seeding functions


### PR DESCRIPTION
fix semicolon position in linear_congruential_engine class template.
