### PR TITLE
ranlux48 : fix typo

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -3654,7 +3654,7 @@ typedef discard_block_engine<ranlux24_base, 223, 23>
 \indextext{engines with predefined parameters!\idxcode{ranlux48}}%
 \begin{itemdecl}
 typedef discard_block_engine<ranlux48_base, 389, 11>
-       ranlux48@
+       ranlux48;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
fix typo in std::ranlux48 definition.
