### PR TITLE
Fixed typo

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -4695,7 +4695,7 @@ in this International Standard or by the implementation, the behaviour is undefi
 \tcode{future<result_of_t<decay_t<F>(decay_t<Args>...)>{>}} that refers
 to the shared state created by this call to \tcode{async}.
 \enternote If a future obtained from std::async is moved outside the local scope,
-other code that uses the future must be aware that the future’s destructor may
+other code that uses the future must be aware that the future's destructor may
 block for the shared state to become ready. \exitnote
 
 \pnum


### PR DESCRIPTION
Replaced `’` resulting in artifact in the pdf by `'`.
