### PR TITLE
Fixes unformatted "N" in "array of N T".

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3493,7 +3493,7 @@ those two points is the same type. The declared type of an array object
 might be an array of unknown size and therefore be incomplete at one
 point in a translation unit and complete later on; the array types at
 those two points (``array of unknown bound of \tcode{T}'' and ``array of
-N \tcode{T}'') are different types. The type of a pointer to array of
+\tcode{N} \tcode{T}'') are different types. The type of a pointer to array of
 unknown size, or of a type defined by a \tcode{typedef} declaration to
 be an array of unknown size, cannot be completed. \enterexample
 

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -2067,7 +2067,8 @@ h({ 1, 2, 3 });             // OK: identity conversion
 \exitexample
 
 \pnum
-Otherwise, if the parameter type is ``array of N \tcode{X}''\footnote{Since there are
+Otherwise, if the parameter type is ``array of \tcode{N} \tcode{X}''\footnote{
+Since there are
 no parameters of array type, this will only occur as the underlying type of a reference
 parameter.}, if the initializer list has exactly \tcode{N} elements or if it has fewer
 than \tcode{N} elements and \tcode{X} is default-constructible, and if all the elements


### PR DESCRIPTION
Found another place with the same issue.  I believe code formatting
should be used for these cases, because an italics N is usually
followed by definition of the N.

Closes: #215
