### PR TITLE
Editorial: fix typo

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -3615,7 +3615,7 @@ Futures, promises, and tasks defined in this clause reference such shared state.
 as used by \tcode{async} when \tcode{policy} is \tcode{launch::deferred}. \exitnote
 
 \pnum
-An \defn{asynchronous return object} is an object that reads results from an
+An \defn{asynchronous return object} is an object that reads results from a
 shared state. A \defn{waiting function} of an asynchronous return object is one
 that potentially blocks to wait for the shared state to be made
 ready.


### PR DESCRIPTION
'an shared state' -> 'a shared state'
