### PR TITLE
basic_string::replace description : fix missing words.

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -2777,6 +2777,7 @@ basic_string& replace(const_iterator i1, const_iterator i2,
 \effects Calls \tcode{replace(i1 - begin(), i2 - i1, il.begin(), il.size())}.
 
 \pnum
+\returns
 \tcode{*this}.
 \end{itemdescr}
 


### PR DESCRIPTION
add missing "Returns:"
