### PR TITLE
Fix typo in [ios.members.static]

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -1369,7 +1369,7 @@ c = fgetc(f);
 \end{codeblock}
 is the same as the effect of
 \begin{codeblock}
-c = str.rdbuf()->sbumpc(c);
+c = str.rdbuf()->sbumpc();
 \end{codeblock}
 for any sequences of characters; and the effect of pushing back a character \tcode{c} by
 \begin{codeblock}


### PR DESCRIPTION
No argument should be used to call 'sbumpc'.
