### PR TITLE
function::swap : remove noexcept.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -8467,7 +8467,7 @@ namespace std {
     ~function();
 
     // \ref{func.wrap.func.mod}, function modifiers:
-    void swap(function&) noexcept;
+    void swap(function&);
     template<class F, class A> void assign(F&&, const A&);
 
     // \ref{func.wrap.func.cap}, function capacity:
@@ -8717,7 +8717,7 @@ template<class F> function& operator=(reference_wrapper<F> f) noexcept;
 \indexlibrary{\idxcode{function}!\idxcode{swap}}%
 \indexlibrary{\idxcode{swap}!\idxcode{function}}%
 \begin{itemdecl}
-void swap(function& other) noexcept;
+void swap(function& other);
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Member function version `function::swap()` has `noexcept`. But non member function version `swap(function, function)` doesn't have `noexcept`.
I think member function version is mistake, unnecessary `noexcept`. Because copy (or move) constructor of target function object may throw exception.

`function` constructor specification is follow:

```
function(const function& f);
template <class A> function(allocator_arg_t, const A& a, const function& f);

Postconditions: !*this if !f; otherwise, *this targets a copy of f.target().

Throws: shall not throw exceptions if f’s target is a callable object passed via reference_wrapper or
a function pointer. Otherwise, may throw bad_alloc or any exception thrown by the copy constructor
of the stored callable object. [Note: Implementations are encouraged to avoid the use of dynamically
allocated memory for small callable objects, for example, where f’s target is an object holding only a
pointer or reference to an object and a member function pointer. —end note ]
```
