### PR TITLE
[basic.stc.dynamic] Don't italicize "deallocated storage".

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3030,7 +3030,7 @@ If the argument given to a deallocation function in the standard library
 is a pointer that is not the null pointer value~(\ref{conv.ptr}), the
 deallocation function shall deallocate the storage referenced by the
 pointer, rendering invalid all pointers referring to any part of the
-\term{deallocated storage}.
+deallocated storage.
 \indextext{object!undefined deleted}%
 Indirection through an invalid pointer value and passing an invalid
 pointer value to a deallocation function have undefined behavior. Any


### PR DESCRIPTION
Fixes #268.
