### PR TITLE
[lib.complex.member.ops] fix operator declarations

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -618,7 +618,7 @@ and stores the result in
 
 \indexlibrary{\idxcode{operator+=}!\idxcode{complex}}%
 \begin{itemdecl}
-complex<T>& operator+=(const complex<T>& rhs);
+template<class X> complex<T>& operator+=(const complex<X>& rhs);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -636,7 +636,7 @@ and stores the sum in
 
 \indexlibrary{\idxcode{operator-=}!\idxcode{complex}}%
 \begin{itemdecl}
-complex<T>& operator-=(const complex<T>& rhs);
+template<class X> complex<T>& operator-=(const complex<X>& rhs);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -654,7 +654,7 @@ and stores the difference in
 
 \indexlibrary{\idxcode{operator*=}!\idxcode{complex}}%
 \begin{itemdecl}
-complex<T>& operator*=(const complex<T>& rhs);
+template<class X> complex<T>& operator*=(const complex<X>& rhs);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -671,7 +671,7 @@ and stores the product in
 
 \indexlibrary{\idxcode{operator/=}!\idxcode{complex}}%
 \begin{itemdecl}
-complex<T>& operator/=(const complex<T>& rhs);
+template<class X> complex<T>& operator/=(const complex<X>& rhs);
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
In 26.4.2 (class definition), four arithmetic operators which take a complex argument are declared as member templates.
