### PR TITLE
[atomics.types.operations.req] Hyphenate "non member".

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -725,8 +725,8 @@ In the following operation definitions:
 \item an \textit{M} refers to type of the other argument for arithmetic operations. For
 integral atomic types, \textit{M} is \textit{C}. For atomic address types, \textit{M} is
 \tcode{std::ptrdiff_t}.
-\item the non member functions not ending in \tcode{_explicit} have the semantics of their
-corresponding \tcode{_explicit} with \tcode{memory_order} arguments of
+\item the non-member functions not ending in \tcode{_explicit} have the semantics of their
+corresponding \tcode{_explicit} functions with \tcode{memory_order} arguments of
 \tcode{memory_order_seq_cst}.
 \end{itemize}
 


### PR DESCRIPTION
The hyphenation is necessary.

I also think we should change "their corresponding `_explicit`" to "their corresponding `_explicit` functions".
