### PR TITLE
instantiation -> specialization in [refwrap]

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -7349,7 +7349,7 @@ If \tcode{T} is a function type, \tcode{result_type} shall be a synonym for the
 return type of \tcode{T}.
 
 \pnum\indexlibrary{\idxcode{unary_function}}%
-The template instantiation \tcode{reference_wrapper<T>} shall
+The template specialization \tcode{reference_wrapper<T>} shall
 define a nested type named \tcode{argument_type} as a synonym for \tcode{T1}
 only if the type \tcode{T} is any of the
 following:


### PR DESCRIPTION
To match the wording of http://cplusplus.github.io/LWG/lwg-active.html#2106 (The wording of 2106 is taken from here, but we decided to use the term "specialization".
