### PR TITLE
Fixed up several wording and variable naming issues in requirements tables

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -1761,25 +1761,24 @@ are sometimes required to be \tcode{CopyAssignable} even though the associated
 \indextext{unordered associative containers!unique keys}%
 \indextext{unordered associative containers!equivalent keys}%
 \indextext{requirements!container}%
-In table~\ref{tab:HashRequirements}:
-\tcode{X} is an unordered associative container class, \tcode{a} is an
-object of type \tcode{X}, \tcode{b} is a possibly const object of
-type \tcode{X}, \tcode{a_uniq} is an object of type \tcode{X}
-when \tcode{X} supports unique keys, \tcode{a_eq} is an object of
-type \tcode{X} when \tcode{X} supports equivalent keys, \tcode{i}
-and \tcode{j} are input iterators that refer
-to \tcode{value_type}, \tcode{[i, j)} is a valid range,
-\tcode{p} and \tcode{q2} are valid const iterators to \tcode{a},
-\tcode{q} and \tcode{q1} are valid dereferenceable const iterators to \tcode{a},
-\tcode{[q1, q2)} is a valid range in \tcode{a},
+In Table~\ref{tab:HashRequirements}:
+\tcode{X} denotes an unordered associative container class,
+\tcode{a} denotes a value of type \tcode{X},
+\tcode{b} denotes a possibly const value of type \tcode{X},
+\tcode{a_uniq} denotes a value of type \tcode{X} when \tcode{X} supports unique keys,
+\tcode{a_eq} denotes a value of type \tcode{X} when \tcode{X} supports equivalent keys,
+\tcode{i} and \tcode{j} denote input iterators that refer to \tcode{value_type},
+\tcode{[i, j)} denotes a valid range,
+\tcode{p} and \tcode{q2} denote valid const iterators to \tcode{a},
+\tcode{q} and \tcode{q1} denote valid dereferenceable const iterators to \tcode{a},
+\tcode{[q1, q2)} denotes a valid range in \tcode{a},
 \tcode{il} designates an object of type \tcode{initializer_list<value_type>},
-\tcode{t} is a value of
-type \tcode{X::value_type}, \tcode{k} is a value of
-type \tcode{key_type}, \tcode{hf} is a possibly const value of
-type \tcode{hasher}, \tcode{eq} is a possibly const value of
-type \tcode{key_equal}, \tcode{n} is a value of
-type \tcode{size_type}, and \tcode{z} is a value of
-type \tcode{float}.
+\tcode{t} denotes a value of type \tcode{X::value_type},
+\tcode{k} denotes a value of type \tcode{key_type},
+\tcode{hf} denotes a possibly const value of type \tcode{hasher},
+\tcode{eq} denotes a possibly const value of type \tcode{key_equal},
+\tcode{n} denotes a value of type \tcode{size_type},
+and \tcode{z} denotes a value of type \tcode{float}.
 
 \begin{libreqtab4d}
   {Unordered associative container requirements (in addition to container)}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -740,8 +740,9 @@ end of the sequence.
 In Tables~\ref{tab:containers.sequence.requirements}
 and \ref{tab:containers.sequence.optional}, \tcode{X}
 denotes a sequence container class,
-\tcode{a} denotes a value of type \tcode{X} containing elements of type \tcode{T}, \tcode{A}
-denotes \tcode{X::allocator_type} if it exists and \tcode{std::allocator<T>} if it
+\tcode{a} denotes a value of type \tcode{X} containing elements of type \tcode{T},
+\tcode{u} denotes the name of a variable being declared,
+\tcode{A} denotes \tcode{X::allocator_type} if it exists and \tcode{std::allocator<T>} if it
 doesn't,
 \tcode{i} and \tcode{j}
 denote iterators satisfying input iterator requirements
@@ -779,7 +780,7 @@ The complexities of the expressions are sequence dependent.
                         &                       &   \rhdr{pre-/post-condition}   \\ \capsep
 \endhead
 \tcode{X(n, t)}\br
-\tcode{X a(n, t)}   &
+\tcode{X u(n, t)}   &
                 &
  \requires \tcode{T} shall be
  \tcode{CopyInsertable} into \tcode{X}.\br
@@ -787,7 +788,7 @@ The complexities of the expressions are sequence dependent.
  Constructs a sequence container with \tcode{n} copies of \tcode{t}  \\ \rowsep
 
 \tcode{X(i, j)}\br
-\tcode{X a(i, j)}   &
+\tcode{X u(i, j)}   &
                     &
  \requires\ \tcode{T} shall be \tcode{EmplaceConstructible} into \tcode{X} from \tcode{*i}.
  For \tcode{vector}, if the iterator does

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -740,7 +740,7 @@ end of the sequence.
 In Tables~\ref{tab:containers.sequence.requirements}
 and \ref{tab:containers.sequence.optional}, \tcode{X}
 denotes a sequence container class,
-\tcode{a} denotes a value of \tcode{X} containing elements of type \tcode{T}, \tcode{A}
+\tcode{a} denotes a value of type \tcode{X} containing elements of type \tcode{T}, \tcode{A}
 denotes \tcode{X::allocator_type} if it exists and \tcode{std::allocator<T>} if it
 doesn't,
 \tcode{i} and \tcode{j}
@@ -750,7 +750,7 @@ and refer to elements implicitly convertible to \tcode{value_type},
 denotes a valid range,
 \tcode{il} designates an object of type \tcode{initializer_list<value_type>},
 \tcode{n}
-denotes a value of \tcode{X::size_type},
+denotes a value of type \tcode{X::size_type},
 \tcode{p} denotes a valid const iterator to
 \tcode{a}, \tcode{q}
 denotes a valid dereferenceable const iterator to
@@ -1247,12 +1247,12 @@ are required to be \tcode{CopyAssignable} even though the associated
 \pnum
 In Table~\ref{tab:containers.associative.requirements},
 \tcode{X} denotes an associative container class,
-\tcode{a} denotes a value of \tcode{X},
-\tcode{a_uniq} denotes a value of \tcode{X}
+\tcode{a} denotes a value of type \tcode{X},
+\tcode{a_uniq} denotes a value of type \tcode{X}
 when \tcode{X} supports unique keys,
-\tcode{a_eq} denotes a value of \tcode{X}
+\tcode{a_eq} denotes a value of type \tcode{X}
 when \tcode{X} supports multiple keys,
-\tcode{a_tran} denotes a value of \tcode{X} when the qualified-id
+\tcode{a_tran} denotes a value of type \tcode{X} when the qualified-id
 \tcode{X::key_compare::is_transparent} is valid
 and denotes a type~(\ref{temp.deduct}),
 \tcode{i} and \tcode{j}
@@ -1264,8 +1264,8 @@ denotes a valid range,
 \tcode{q} denotes a valid dereferenceable const iterator to \tcode{a},
 \tcode{[q1, q2)} denotes a valid range of const iterators in \tcode{a},
 \tcode{il} designates an object of type \tcode{initializer_list<value_type>},
-\tcode{t} denotes a value of \tcode{X::value_type},
-\tcode{k} denotes a value of \tcode{X::key_type}
+\tcode{t} denotes a value of type \tcode{X::value_type},
+\tcode{k} denotes a value of type \tcode{X::key_type}
 and \tcode{c} denotes a value of type \tcode{X::key_compare};
 \tcode{kl} is a value such that \tcode{a} is partitioned~(\ref{alg.sorting})
 with respect to \tcode{c(r, kl)}, with \tcode{r} the key value of \tcode{e}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -1249,6 +1249,7 @@ are required to be \tcode{CopyAssignable} even though the associated
 In Table~\ref{tab:containers.associative.requirements},
 \tcode{X} denotes an associative container class,
 \tcode{a} denotes a value of type \tcode{X},
+\tcode{u} denotes the name of a variable being declared,
 \tcode{a_uniq} denotes a value of type \tcode{X}
 when \tcode{X} supports unique keys,
 \tcode{a_eq} denotes a value of type \tcode{X}
@@ -1324,14 +1325,14 @@ and \tcode{e} in \tcode{a};
  compile time                       \\ \rowsep
 
 \tcode{X(c)}\br
-\tcode{X a(c);}                         &
+\tcode{X u(c);}                         &
                                         &
   \requires\ \tcode{key_compare} is \tcode{CopyConstructible}.\br
   \effects\ Constructs an empty container.
   Uses a copy of \tcode{c} as a comparison object.  &
  constant                               \\ \rowsep
 
-\tcode{X()}\br\tcode{X a;}                      &
+\tcode{X()}\br\tcode{X u;}                      &
                                                 &
   \requires\ \tcode{key_compare} is \tcode{DefaultConstructible}.\br
   \effects\ Constructs an empty container.
@@ -1339,7 +1340,7 @@ and \tcode{e} in \tcode{a};
   constant                                       \\ \rowsep
 
 \tcode{X(i,j,c)}\br
-\tcode{X~a(i,j,c);}     &
+\tcode{X~u(i,j,c);}     &
                         &
   \requires\ \tcode{key_compare} is \tcode{CopyConstructible}.
   \tcode{value_type} is \tcode{EmplaceConstructible} into \tcode{X} from \tcode{*i}.\br
@@ -1348,7 +1349,7 @@ and \tcode{e} in \tcode{a};
   $N \log N$ in general ($N$ has the value \tcode{distance(i, j)});
   linear if \tcode{[i, j)} is sorted with \tcode{value_comp()} \\ \rowsep
 
-\tcode{X(i,j)} \tcode{X~a(i,j);}    &
+\tcode{X(i,j)} \tcode{X~u(i,j);}    &
                                     &
   \requires\ \tcode{key_compare} is \tcode{DefaultConstructible}.
   \tcode{value_type} is \tcode{EmplaceConstructible} into \tcode{X} from \tcode{*i}.\br

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1641,7 +1641,6 @@ and \tcode{std::forward}, respectively.
 \tcode{Y}       &   the corresponding Allocator class for type \tcode{U}    \\ \rowsep
 \tcode{XX}      &   the type \tcode{allocator_traits<X>}    \\ \rowsep
 \tcode{YY}      &   the type \tcode{allocator_traits<Y>}    \\ \rowsep
-\tcode{t}       &   a value of type \tcode{const T\&}   \\ \rowsep
 \tcode{a, a1, a2}   &   values of type \tcode{X\&}      \\ \rowsep
 \tcode{b}       &   a value of type \tcode{Y}           \\ \rowsep
 \tcode{c}       &   a pointer of type \tcode{C*} through which indirection is valid \\ \rowsep

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1641,6 +1641,7 @@ and \tcode{std::forward}, respectively.
 \tcode{XX}      &   the type \tcode{allocator_traits<X>}    \\ \rowsep
 \tcode{YY}      &   the type \tcode{allocator_traits<Y>}    \\ \rowsep
 \tcode{a, a1, a2}   &   lvalues of type \tcode{X}      \\ \rowsep
+\tcode{u}       &   the name of a variable being declared      \\ \rowsep
 \tcode{b}       &   a value of type \tcode{Y}           \\ \rowsep
 \tcode{c}       &   a pointer of type \tcode{C*} through which indirection is valid \\ \rowsep
 \tcode{p}       &   a value of type \tcode{XX::pointer}, obtained
@@ -1649,9 +1650,9 @@ by calling \tcode{a1.allocate}, where \tcode{a1 == a}   \\ \rowsep
 obtained by conversion from a value \tcode{p}.          \\ \rowsep
 \tcode{w}       &   a value of type \tcode{XX::void_pointer} obtained by
   conversion from a value \tcode{p}  \\ \rowsep
-\tcode{z}       &   a value of type \tcode{XX::const_void_pointer} obtained by
+\tcode{x}       &   a value of type \tcode{XX::const_void_pointer} obtained by
   conversion from a value \tcode{q} or a value \tcode{w}  \\ \rowsep
-\tcode{u}       &   a value of type \tcode{XX:const_void_pointer} obtained by
+\tcode{y}       &   a value of type \tcode{XX:const_void_pointer} obtained by
 conversion from a result value of \tcode{YY::allocate}, or else a value of
 type (possibly \tcode{const}) \tcode{std::nullptr_t}. \\ \rowsep
 \tcode{n}       &   a value of type \tcode{XX::size_type}.   \\ \rowsep
@@ -1729,9 +1730,9 @@ type (possibly \tcode{const}) \tcode{std::nullptr_t}. \\ \rowsep
   \tcode{X::pointer}                &
   \tcode{static_cast<X::pointer>(w)} \tcode{== p} & \\ \rowsep
 
-\tcode{static_cast<X} \tcode{::const_pointer>(z)}  &
+\tcode{static_cast<X} \tcode{::const_pointer>(x)}  &
   \tcode{X::const_pointer}                &
-  \tcode{static_cast<X} \tcode{::const_pointer>(z)} \tcode{== q} & \\ \rowsep
+  \tcode{static_cast<X} \tcode{::const_pointer>(x)} \tcode{== q} & \\ \rowsep
 
 \tcode{a.allocate(n)}   &   \tcode{X::pointer}  &
 Memory is allocated for \tcode{n} objects of type \tcode{T} but objects
@@ -1740,9 +1741,9 @@ are not constructed. \tcode{allocate} may raise an appropriate exception.\footno
 If \tcode{n == 0}, the return value is unspecified.
 \exitnote              &  \\ \rowsep
 
-\tcode{a.allocate(n, u)}    &
+\tcode{a.allocate(n, y)}    &
   \tcode{X::pointer}        &
-  Same as \tcode{a.allocate(n)}. The use of \tcode{u} is unspecified, but
+  Same as \tcode{a.allocate(n)}. The use of \tcode{y} is unspecified, but
     it is intended as an aid to locality. &
   \tcode{a.allocate(n)}     \\ \rowsep
 
@@ -1776,24 +1777,24 @@ If \tcode{n == 0}, the return value is unspecified.
   \tcode{bool}              &
   same as \tcode{!(a == b)} & \\ \rowsep
 
-\tcode{X a1(a)};            \br
-\tcode{X a1 = a;}           &
+\tcode{X u(a)};            \br
+\tcode{X u = a;}           &
                             &
   Shall not exit via an exception.\br
   post: \tcode{a1 == a}     & \\ \rowsep
 
-\tcode{X a(b);}             &
+\tcode{X u(b);}             &
                             &
   Shall not exit via an exception.\br
   post: \tcode{Y(a) == b}, \tcode{a == X(b)} &  \\ \rowsep
 
-\tcode{X a1(move(a));}      \br
-\tcode{X a1 = move(a);}     &
+\tcode{X u(move(a));}      \br
+\tcode{X u = move(a);}     &
                             &
   Shall not exit via an exception.\br
   post: \tcode{a1} equals the prior value of \tcode{a}. & \\ \rowsep
 
-\tcode{X a(move(b));}       &
+\tcode{X u(move(b));}       &
                             &
   Shall not exit via an exception.\br
   post: \tcode{a} equals the prior value of \tcode{X(b)}. & \\ \rowsep

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1643,7 +1643,6 @@ and \tcode{std::forward}, respectively.
 \tcode{YY}      &   the type \tcode{allocator_traits<Y>}    \\ \rowsep
 \tcode{t}       &   a value of type \tcode{const T\&}   \\ \rowsep
 \tcode{a, a1, a2}   &   values of type \tcode{X\&}      \\ \rowsep
-\tcode{a3}      &   an rvalue of type \tcode{X}      \\ \rowsep
 \tcode{b}       &   a value of type \tcode{Y}           \\ \rowsep
 \tcode{c}       &   a pointer of type \tcode{C*} through which indirection is valid \\ \rowsep
 \tcode{p}       &   a value of type \tcode{XX::pointer}, obtained

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1640,7 +1640,7 @@ and \tcode{std::forward}, respectively.
 \tcode{Y}       &   the corresponding Allocator class for type \tcode{U}    \\ \rowsep
 \tcode{XX}      &   the type \tcode{allocator_traits<X>}    \\ \rowsep
 \tcode{YY}      &   the type \tcode{allocator_traits<Y>}    \\ \rowsep
-\tcode{a, a1, a2}   &   values of type \tcode{X\&}      \\ \rowsep
+\tcode{a, a1, a2}   &   lvalues of type \tcode{X}      \\ \rowsep
 \tcode{b}       &   a value of type \tcode{Y}           \\ \rowsep
 \tcode{c}       &   a pointer of type \tcode{C*} through which indirection is valid \\ \rowsep
 \tcode{p}       &   a value of type \tcode{XX::pointer}, obtained

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1652,11 +1652,6 @@ obtained by conversion from a value \tcode{p}.          \\ \rowsep
   conversion from a value \tcode{p}  \\ \rowsep
 \tcode{z}       &   a value of type \tcode{XX::const_void_pointer} obtained by
   conversion from a value \tcode{q} or a value \tcode{w}  \\ \rowsep
-\tcode{r}       &   a value of type \tcode{T\&}
-obtained by the expression \tcode{*p}.                  \\ \rowsep
-\tcode{s}       &   a value of type \tcode{const T\&}
-obtained by the expression \tcode{*q} or by conversion from
-a value \tcode{r}.                                      \\ \rowsep
 \tcode{u}       &   a value of type \tcode{XX:const_void_pointer} obtained by
 conversion from a result value of \tcode{YY::allocate}, or else a value of
 type (possibly \tcode{const}) \tcode{std::nullptr_t}. \\ \rowsep

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1636,7 +1636,6 @@ and \tcode{std::forward}, respectively.
 \lhdr{Variable} &   \rhdr{Definition}   \\  \capsep
 \endhead
 \tcode{T, U, C}    &   any non-const object type~(\ref{basic.types})       \\ \rowsep
-\tcode{V}       &   a type convertible to \tcode{T}         \\ \rowsep
 \tcode{X}       &   an Allocator class for type \tcode{T}   \\ \rowsep
 \tcode{Y}       &   the corresponding Allocator class for type \tcode{U}    \\ \rowsep
 \tcode{XX}      &   the type \tcode{allocator_traits<X>}    \\ \rowsep
@@ -1655,7 +1654,6 @@ obtained by conversion from a value \tcode{p}.          \\ \rowsep
 \tcode{u}       &   a value of type \tcode{XX:const_void_pointer} obtained by
 conversion from a result value of \tcode{YY::allocate}, or else a value of
 type (possibly \tcode{const}) \tcode{std::nullptr_t}. \\ \rowsep
-\tcode{v}       &   a value of type \tcode{V}               \\ \rowsep
 \tcode{n}       &   a value of type \tcode{XX::size_type}.   \\ \rowsep
 \tcode{Args}    &   a template parameter pack               \\ \rowsep
 \tcode{args}    &   a function parameter pack with the pattern \tcode{Args\&\&} \\


### PR DESCRIPTION
Table 27 in [allocator.requirements] defines variables a and a1 to have
type X&, so it doesn't make sense to re-use those names in Table 28 when
declaring a new variable of type X. Instead, use a name not used
elsewhere.