### PR TITLE
remove unnecessary `<T>` from `valarray`.

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -6885,7 +6885,7 @@ The value of \tcode{v} after the assignment is not specified.
 \indexlibrary{\idxcode{operator=}!\idxcode{valarray}}%
 \indexlibrary{\idxcode{valarray}!\idxcode{operator=}}%
 \begin{itemdecl}
-valarray<T>& operator=(initializer_list<T> il);
+valarray& operator=(initializer_list<T> il);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -6612,57 +6612,57 @@ namespace std {
     ~valarray();
 
     // \ref{valarray.assign} assignment:
-    valarray<T>& operator=(const valarray<T>&);
-    valarray<T>& operator=(valarray<T>&&) noexcept;
+    valarray& operator=(const valarray&);
+    valarray& operator=(valarray&&) noexcept;
     valarray& operator=(initializer_list<T>);
-    valarray<T>& operator=(const T&);
-    valarray<T>& operator=(const slice_array<T>&);
-    valarray<T>& operator=(const gslice_array<T>&);
-    valarray<T>& operator=(const mask_array<T>&);
-    valarray<T>& operator=(const indirect_array<T>&);
+    valarray& operator=(const T&);
+    valarray& operator=(const slice_array<T>&);
+    valarray& operator=(const gslice_array<T>&);
+    valarray& operator=(const mask_array<T>&);
+    valarray& operator=(const indirect_array<T>&);
 
     // \ref{valarray.access} element access:
     const T&          operator[](size_t) const;
     T&                operator[](size_t);
 
     // \ref{valarray.sub} subset operations:
-    valarray<T>       operator[](slice) const;
+    valarray          operator[](slice) const;
     slice_array<T>    operator[](slice);
-    valarray<T>       operator[](const gslice&) const;
+    valarray          operator[](const gslice&) const;
     gslice_array<T>   operator[](const gslice&);
-    valarray<T>       operator[](const valarray<bool>&) const;
+    valarray          operator[](const valarray<bool>&) const;
     mask_array<T>     operator[](const valarray<bool>&);
-    valarray<T>       operator[](const valarray<size_t>&) const;
+    valarray          operator[](const valarray<size_t>&) const;
     indirect_array<T> operator[](const valarray<size_t>&);
 
     // \ref{valarray.unary} unary operators:
-    valarray<T> operator+() const;
-    valarray<T> operator-() const;
-    valarray<T> operator~() const;
+    valarray operator+() const;
+    valarray operator-() const;
+    valarray operator~() const;
     valarray<bool> operator!() const;
 
     // \ref{valarray.cassign} computed assignment:
-    valarray<T>& operator*= (const T&);
-    valarray<T>& operator/= (const T&);
-    valarray<T>& operator%= (const T&);
-    valarray<T>& operator+= (const T&);
-    valarray<T>& operator-= (const T&);
-    valarray<T>& operator^= (const T&);
-    valarray<T>& operator&= (const T&);
-    valarray<T>& operator|= (const T&);
-    valarray<T>& operator<<=(const T&);
-    valarray<T>& operator>>=(const T&);
+    valarray& operator*= (const T&);
+    valarray& operator/= (const T&);
+    valarray& operator%= (const T&);
+    valarray& operator+= (const T&);
+    valarray& operator-= (const T&);
+    valarray& operator^= (const T&);
+    valarray& operator&= (const T&);
+    valarray& operator|= (const T&);
+    valarray& operator<<=(const T&);
+    valarray& operator>>=(const T&);
 
-    valarray<T>& operator*= (const valarray<T>&);
-    valarray<T>& operator/= (const valarray<T>&);
-    valarray<T>& operator%= (const valarray<T>&);
-    valarray<T>& operator+= (const valarray<T>&);
-    valarray<T>& operator-= (const valarray<T>&);
-    valarray<T>& operator^= (const valarray<T>&);
-    valarray<T>& operator|= (const valarray<T>&);
-    valarray<T>& operator&= (const valarray<T>&);
-    valarray<T>& operator<<=(const valarray<T>&);
-    valarray<T>& operator>>=(const valarray<T>&);
+    valarray& operator*= (const valarray&);
+    valarray& operator/= (const valarray&);
+    valarray& operator%= (const valarray&);
+    valarray& operator+= (const valarray&);
+    valarray& operator-= (const valarray&);
+    valarray& operator^= (const valarray&);
+    valarray& operator|= (const valarray&);
+    valarray& operator&= (const valarray&);
+    valarray& operator<<=(const valarray&);
+    valarray& operator>>=(const valarray&);
 
     // \ref{valarray.members} member functions:
     void swap(valarray&) noexcept;
@@ -6673,10 +6673,10 @@ namespace std {
     T min() const;
     T max() const;
 
-    valarray<T> shift (int) const;
-    valarray<T> cshift(int) const;
-    valarray<T> apply(T func(T)) const;
-    valarray<T> apply(T func(const T&)) const;
+    valarray shift (int) const;
+    valarray cshift(int) const;
+    valarray apply(T func(T)) const;
+    valarray apply(T func(const T&)) const;
     void resize(size_t sz, T c = T());
   };
 }
@@ -6779,7 +6779,7 @@ pointed to by the first argument, the behavior is undefined.%
 
 \indexlibrary{\idxcode{valarray}!\idxcode{constructor}}%
 \begin{itemdecl}
-valarray(const valarray<T>&);
+valarray(const valarray&);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6796,7 +6796,7 @@ conceptually distinct.}
 
 \indexlibrary{\idxcode{valarray}!\idxcode{constructor}}%
 \begin{itemdecl}
-valarray(valarray<T>&& v) noexcept;
+valarray(valarray&& v) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6851,7 +6851,7 @@ an implementation may return all allocated memory.
 
 \indexlibrary{\idxcode{operator=}!\idxcode{valarray}}%
 \begin{itemdecl}
-valarray<T>& operator=(const valarray<T>& v);
+valarray& operator=(const valarray& v);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6870,7 +6870,7 @@ as if by calling \tcode{resize(v.size())}, before performing the assignment.
 
 \indexlibrary{\idxcode{operator=}!\idxcode{valarray}}%
 \begin{itemdecl}
-valarray<T>& operator=(valarray<T>&& v) noexcept;
+valarray& operator=(valarray&& v) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6899,7 +6899,7 @@ valarray& operator=(initializer_list<T> il);
 
 \indexlibrary{\idxcode{operator=}!\idxcode{valarray}}%
 \begin{itemdecl}
-valarray<T>& operator=(const T&);
+valarray& operator=(const T&);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6912,10 +6912,10 @@ array to be assigned the value of the argument.
 \indexlibrary{\idxcode{operator=}!\idxcode{valarray}}%
 \indexlibrary{\idxcode{valarray}!\idxcode{operator=}}%
 \begin{itemdecl}
-valarray<T>& operator=(const slice_array<T>&);
-valarray<T>& operator=(const gslice_array<T>&);
-valarray<T>& operator=(const mask_array<T>&);
-valarray<T>& operator=(const indirect_array<T>&);
+valarray& operator=(const slice_array<T>&);
+valarray& operator=(const gslice_array<T>&);
+valarray& operator=(const mask_array<T>&);
+valarray& operator=(const indirect_array<T>&);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7032,7 +7032,7 @@ In each case the selected element(s) must exist.
 
 \indexlibrary{\idxcode{operator[]}!\idxcode{valarray}}%
 \begin{itemdecl}
-valarray<T> operator[](slice slicearr) const;
+valarray operator[](slice slicearr) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7067,7 +7067,7 @@ v0[slice(2, 5, 3)] = v1;
 
 \indexlibrary{\idxcode{operator[]}!\idxcode{valarray}}%
 \begin{itemdecl}
-valarray<T> operator[](const gslice& gslicearr) const;
+valarray operator[](const gslice& gslicearr) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7109,7 +7109,7 @@ v0[gslice(3, len, str)] = v1;
 
 \indexlibrary{\idxcode{operator[]}!\idxcode{valarray}}%
 \begin{itemdecl}
-valarray<T> operator[](const valarray<bool>& boolarr) const;
+valarray operator[](const valarray<bool>& boolarr) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7147,7 +7147,7 @@ v0[valarray<bool>(vb, 6)] = v1;
 
 \indexlibrary{\idxcode{operator[]}!\idxcode{valarray}}%
 \begin{itemdecl}
-valarray<T> operator[](const valarray<size_t>& indarr) const;
+valarray operator[](const valarray<size_t>& indarr) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7190,9 +7190,9 @@ v0[valarray<size_t>(vi, 5)] = v1;
 \indexlibrary{\idxcode{operator\~{}}!\idxcode{valarray}}%
 \indexlibrary{\idxcode{operator"!}!\idxcode{valarray}}%
 \begin{itemdecl}
-valarray<T> operator+() const;
-valarray<T> operator-() const;
-valarray<T> operator~() const;
+valarray operator+() const;
+valarray operator-() const;
+valarray operator~() const;
 valarray<bool> operator!() const;
 \end{itemdecl}
 
@@ -7224,16 +7224,16 @@ applying the indicated operator to the corresponding element of the array.
 \indexlibrary{\idxcode{operator\shl=}!\idxcode{valarray}}%
 \indexlibrary{\idxcode{operator\shr=}!\idxcode{valarray}}%
 \begin{itemdecl}
-valarray<T>& operator*= (const valarray<T>&);
-valarray<T>& operator/= (const valarray<T>&);
-valarray<T>& operator%= (const valarray<T>&);
-valarray<T>& operator+= (const valarray<T>&);
-valarray<T>& operator-= (const valarray<T>&);
-valarray<T>& operator^= (const valarray<T>&);
-valarray<T>& operator&= (const valarray<T>&);
-valarray<T>& operator|= (const valarray<T>&);
-valarray<T>& operator<<=(const valarray<T>&);
-valarray<T>& operator>>=(const valarray<T>&);
+valarray& operator*= (const valarray&);
+valarray& operator/= (const valarray&);
+valarray& operator%= (const valarray&);
+valarray& operator+= (const valarray&);
+valarray& operator-= (const valarray&);
+valarray& operator^= (const valarray&);
+valarray& operator&= (const valarray&);
+valarray& operator|= (const valarray&);
+valarray& operator<<=(const valarray&);
+valarray& operator>>=(const valarray&);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7281,16 +7281,16 @@ hand side, the resulting behavior is undefined.
 \indexlibrary{\idxcode{operator\shr=}!\idxcode{valarray}}%
 \indexlibrary{\idxcode{valarray}!\idxcode{operator\shr=}}%
 \begin{itemdecl}
-valarray<T>& operator*= (const T&);
-valarray<T>& operator/= (const T&);
-valarray<T>& operator%= (const T&);
-valarray<T>& operator+= (const T&);
-valarray<T>& operator-= (const T&);
-valarray<T>& operator^= (const T&);
-valarray<T>& operator&= (const T&);
-valarray<T>& operator|= (const T&);
-valarray<T>& operator<<=(const T&);
-valarray<T>& operator>>=(const T&);
+valarray& operator*= (const T&);
+valarray& operator/= (const T&);
+valarray& operator%= (const T&);
+valarray& operator+= (const T&);
+valarray& operator-= (const T&);
+valarray& operator^= (const T&);
+valarray& operator&= (const T&);
+valarray& operator|= (const T&);
+valarray& operator<<=(const T&);
+valarray& operator>>=(const T&);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7402,7 +7402,7 @@ lengths, the determination is made using
 
 \indexlibrary{\idxcode{shift}!\idxcode{valarray}}%
 \begin{itemdecl}
-valarray<T> shift(int n) const;
+valarray shift(int n) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7433,7 +7433,7 @@ of the first element of the argument; etc.
 \exitexample
 \indexlibrary{\idxcode{cshift}!\idxcode{valarray}}%
 \begin{itemdecl}
-valarray<T> cshift(int n) const;
+valarray cshift(int n) const;
 \end{itemdecl}
 
 \pnum
@@ -7446,8 +7446,8 @@ that is a circular shift of \tcode{*this}. If element zero is taken as the leftm
 
 \indexlibrary{\idxcode{apply}!\idxcode{valarray}}%
 \begin{itemdecl}
-valarray<T> apply(T func(T)) const;
-valarray<T> apply(T func(const T&)) const;
+valarray apply(T func(T)) const;
+valarray apply(T func(const T&)) const;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
add `<T>` of return type for consistency.