### PR TITLE
[utility] Add index_sequence et al to the library index.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -132,7 +132,11 @@ namespace std {
   struct piecewise_construct_t { };
   constexpr piecewise_construct_t piecewise_construct = piecewise_construct_t();
   template <class... Types> class tuple;  // defined in \tcode{<tuple>}
-
+@
+\indexlibrary{\idxcode{index_sequence}}%
+\indexlibrary{\idxcode{make_index_sequence}}%
+\indexlibrary{\idxcode{index_sequence_for}}%
+@
   // \ref{intseq}, Compile-time integer sequences
   template<class T, T...> struct integer_sequence;
   template<size_t... I>


### PR DESCRIPTION
These alias templates do not have separate descriptions, they are entirely specified by the definitions in the synopsis, but they are missing from the index of library names.

I don't know if there's a better way to do this than closing the codeblock and re-opening it.
