### PR TITLE
Fix typography of "C." (spacing)

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -108,7 +108,7 @@ int i;
 is valid in C, invalid in \Cpp.
 This makes it impossible to define
 mutually referential file-local static objects, if initializers are
-restricted to the syntactic forms of C.
+restricted to the syntactic forms of C\@.
 For example,
 
 \begin{codeblock}
@@ -788,7 +788,7 @@ Seldom.
 \change Whether \mname{STDC} is defined and if so, what its value is, are
 implementation-defined
 \rationale
-\Cpp is not identical to ISO C.
+\Cpp is not identical to ISO C\@.
 Mandating that \mname{STDC}
 be defined would require that translators make an incorrect claim.
 Each implementation must choose the behavior that will be most

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -403,7 +403,7 @@ implementations.
 \pnum
 Annex~\ref{diff} summarizes the evolution of \Cpp  since its first
 published description, and explains in detail the differences between
-\Cpp  and C. Certain features of \Cpp  exist solely for compatibility
+\Cpp  and C\@. Certain features of \Cpp  exist solely for compatibility
 purposes; Annex~\ref{depr} describes those features.
 
 \pnum


### PR DESCRIPTION
Small typographic improvement: Whenever the text `C.` occurs in mid-paragraph, it is treated as an initial, not an end-of-sentence. This change adds appropriate end-of-sentence spacing.
