### PR TITLE
Add character map and change minimum font size

### DIFF
--- a/source/std.tex
+++ b/source/std.tex
@@ -29,6 +29,7 @@
 \usepackage{multicol}
 \usepackage{xspace}
 \usepackage{fixme}
+\usepackage{cmap}
 \usepackage{lmodern}
 \usepackage[T1]{fontenc}
 \usepackage[pdftex, final]{graphicx}
@@ -47,6 +48,8 @@
             plainpages=false
            ]{hyperref}
 \usepackage{memhfixc}     % fix interactions between hyperref and memoir
+
+\renewcommand\RSsmallest{5.5pt}
 
 \input{layout}
 \input{styles}


### PR DESCRIPTION
Several improvements here:

* package cmap adds a character map to the PDF to make it searchable.
* <s>package microtype adds micro typography (margin protrusion and microscopic glyph reshaping) which improve looks and increase the quality of justification</s>.
* Lowering the minimum font size from 6pt to 5.5pt allows the `\Cpp` logotype to appear correctly in footnotes. Currently it produces a warning and the pluses are too large.