### PR TITLE
[localization] Change bold-slanted font, removes warning

### DIFF
--- a/source/locales.tex
+++ b/source/locales.tex
@@ -1006,14 +1006,14 @@ template <class charT> bool isblank (charT c, const locale& loc);
 
 \pnum
 Each of these functions
-\tcode{is\textbf{\textit{F}}}
+\tcode{is\textit{F}}
 returns the result of the expression:
 
 \begin{codeblock}
-use_facet< ctype<charT> >(loc).is(ctype_base::@\textbf{\textit{F}}@, c)
+use_facet< ctype<charT> >(loc).is(ctype_base::@\textit{F}@, c)
 \end{codeblock}
 
-where \textbf{\textit{F}} is the
+where \tcode{\textit{F}} is the
 \tcode{ctype_base::mask}
 value corresponding to that function~(\ref{category.ctype}).\footnote{When
 used in a loop, it is faster to cache the
@@ -1514,7 +1514,7 @@ virtual function.
 namespace std {
   class ctype_base {
   public:
-    typedef @\textbf{\textit{T}}@ mask;
+    typedef @\textit{T}@ mask;
 
     // numeric values are for exposition only.
     static const mask space = 1 << 0;
@@ -5289,10 +5289,10 @@ pattern      neg_format()    const;
 \end{codeblock}
 
 \pnum
-Each of these functions \tcode{F}
+Each of these functions \tcode{\textit{F}}
 returns the result of calling the corresponding
 virtual member function
-\tcode{do_}\textbf\textit{{F}}\tcode{()}.
+\tcode{do_\textit{F}()}.
 
 \rSec4[locale.moneypunct.virtuals]{\tcode{moneypunct} virtual functions}
 


### PR DESCRIPTION
There is no "bold italic teletype" font. This produces a LaTeX warning and a font replacement.

The next best thing is "bold slanted teletype", which this change introduces.