### PR TITLE
Typographic fixes in [strings]

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -6,7 +6,7 @@
 \pnum
 This Clause describes components for manipulating sequences of
 any non-array POD~(\ref{basic.types}) type.
-In this Clause such types are called \term{char-like types}\indextext{char-like type},
+In this Clause such types are called \term{char-like types},\indextext{char-like type}
 and objects of
 char-like types are called \term{char-like objects}\indextext{char-like object} or
 simply \term{characters}.

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -1363,7 +1363,7 @@ Table~\ref{tab:strings.ctr.6}. The stored allocator is constructed from
 unspecified value.
 
 \begin{libefftabvalue}
-{\tcode{basic_string(const basic_string\&, const Allocator\&)} and
+{\tcode{basic_string(const basic_string\&, const Allocator\&)}\protect\linebreak and
 \tcode{basic_string(basic_string\&\&, const Allocator\&)} effects}
 {tab:strings.ctr.6}
 \tcode{data()}      &


### PR DESCRIPTION
Two unrelated fixes:
* spacing around an `\indextext`.
* line breaking in a table caption, which fixes the corresponding entry in the List of Tables.