### PR TITLE
[algorithms] Uniform notation of distance(first, last) to (last - first)

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -1201,11 +1201,11 @@ begin}, such that \tcode{equal(first1, last1, begin)} returns \tcode{true} or
 \complexity No applications of the corresponding predicate if \tcode{ForwardIterator1}
 and \tcode{ForwardIter\-ator2} meet the requirements of random access iterators and
 \tcode{last1 - first1 != last2 - first2}.
-Otherwise, exactly \tcode{distance(first1, last1)} applications of the
+Otherwise, exactly \tcode{last1 - first1} applications of the
 corresponding predicate if \tcode{equal(\brk{}first1, last1, first2, last2)}
 would return \tcode{true} if \tcode{pred} was not given in the argument list
 or \tcode{equal(first1, last1, first2, last2, pred)} would return \tcode{true} if pred was given in the argument list; otherwise, at
-worst \bigoh{N^2}, where $N$ has the value \tcode{distance(first1, last1)}.
+worst \bigoh{N^2}, where $N$ has the value \tcode{last1 - first1}.
 \end{itemdescr}
 
 \rSec2[alg.search]{Search}
@@ -2441,7 +2441,7 @@ is
 if there exists an integer
 \tcode{n}
 such that for all
-\tcode{0 <= i < distance(start, finish)},
+\tcode{0 <= i < (finish - start)},
 \tcode{f(*(start + i))}
 is true if and only if
 \tcode{i < n}.
@@ -2667,7 +2667,7 @@ template<class ForwardIterator, class Compare>
 
 \begin{itemdescr}
 \pnum
-\returns If \tcode{distance(first, last) < 2}, returns
+\returns If \tcode{(last - first) < 2}, returns
 \tcode{last}. Otherwise, returns
 the last iterator \tcode{i} in \crange{first}{last} for which the
 range \range{first}{i} is sorted.
@@ -3538,7 +3538,7 @@ comparisons (where
 
 \begin{itemdescr}
 \pnum
-\returns If \tcode{distance(first, last) < 2}, returns
+\returns If \tcode{(last - first) < 2}, returns
 \tcode{last}. Otherwise, returns
 the last iterator \tcode{i} in \crange{first}{last} for which the
 range \range{first}{i} is a heap.
@@ -3788,7 +3788,7 @@ the first iterator in \range{first}{last} such that no iterator in the range ref
 \complexity
 At most
 $max(\lfloor{\frac{3}{2}} (N-1)\rfloor, 0)$
-applications of the corresponding predicate, where $N$ is \tcode{distance(first, last)}.
+applications of the corresponding predicate, where $N$ is \tcode{last - first}.
 \end{itemdescr}
 
 \rSec2[alg.lex.comparison]{Lexicographical comparison}


### PR DESCRIPTION
As allowed in 25.1 [algorithms.general] p12, to express the same things
as same.

For is_permutation, it is really bad because last1 - first1 is used in the previous line.
Others are just for consistency.
