### PR TITLE
[algorithms] Fix for a note for conditions of strict-weak-ordering

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -2403,6 +2403,7 @@ implies
 \tcode{equiv(a, b) \&\& equiv(b, c)}
 implies
 \tcode{equiv(a, c)}
+\end{itemize}
 \enternote
 Under these conditions, it can be shown that
 \begin{itemize}
@@ -2416,9 +2417,8 @@ classes determined by
 \tcode{equiv}
 \item
 The induced relation is a strict total ordering.
+\end{itemize}
 \exitnote
-\end{itemize}
-\end{itemize}
 
 \pnum
 A sequence is


### PR DESCRIPTION
Make the note for both two conditions, not for just the latter of two, as the note says "Under these conditions...".

This changes numbering of the items in the note from "(4.2.1) ..." to "(4.3) ...".