### PR TITLE
[util.smartptr.shared.const]

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -5576,7 +5576,7 @@ constexpr shared_ptr() noexcept;
 \begin{itemdescr}
 \pnum\effects  Constructs an \textit{empty} \tcode{shared_ptr} object.
 
-\pnum\postconditions  \tcode{use_count() == 0 \&\& get() == 0}.
+\pnum\postconditions  \tcode{use_count() == 0 \&\& get() == nullptr}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{shared_ptr}!constructor}%
@@ -5691,7 +5691,7 @@ template<class Y> shared_ptr(shared_ptr<Y>&& r) noexcept;
 
 \pnum
 \postconditions \tcode{*this} shall contain the old value of
-\tcode{r}. \tcode{r} shall be \textit{empty}. \tcode{r.get() == 0.}
+\tcode{r}. \tcode{r} shall be \textit{empty}. \tcode{r.get() == nullptr.}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{shared_ptr}!constructor}%
@@ -5729,7 +5729,7 @@ and shall not throw exceptions.
 \pnum\effects  Constructs a \tcode{shared_ptr} object that stores and \textit{owns}
 \tcode{r.release()}.
 
-\pnum\postconditions  \tcode{use_count() == 1} \tcode{\&\&} \tcode{r.get() == 0}.
+\pnum\postconditions  \tcode{use_count() == 1} \tcode{\&\&} \tcode{r.get() == nullptr}.
 
 \pnum\throws  \tcode{bad_alloc}, or an \impldef{exception type when \tcode{shared_ptr}
 constructor fails} exception when a
@@ -5967,7 +5967,7 @@ bool unique() const noexcept;
 
 \pnum \enternote \tcode{unique()} may be faster than \tcode{use_count()}.  If you are
 using \tcode{unique()} to implement copy on write, do not rely on a
-specific value when \tcode{get() == 0}. \exitnote
+specific value when \tcode{get() == nullptr}. \exitnote
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator bool}!\idxcode{shared_ptr}}%


### PR DESCRIPTION
[util.smartptr.shared.obs]
Replace literal 0 with nullptr.
