### PR TITLE
[intro.refs] Fixed consistency of 'EMCA' and 'technology'

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -57,7 +57,7 @@ For undated references, the latest edition of the referenced document
 
 \begin{itemize}
 \item Ecma International, \doccite{ECMAScript Language Specification},
-Standard Ecma-262, third edition, 1999.
+Standard EMCA-262, third edition, 1999.
 \item ISO/IEC 2382 (all parts), \doccite{Information technology ---
 Vocabulary}
 \item ISO/IEC 9899:1999, \doccite{Programming languages --- C}
@@ -67,7 +67,7 @@ Technical Corrigendum 1}
 Technical Corrigendum 2}
 \item ISO/IEC 9899:1999/Cor.3:2007(E), \doccite{Programming languages --- C,
 Technical Corrigendum 3}
-\item ISO/IEC 9945:2003, \doccite{Information Technology --- Portable
+\item ISO/IEC 9945:2003, \doccite{Information technology --- Portable
 Operating System Interface (POSIX)}
 \item ISO/IEC 10646-1:1993, \doccite{Information technology ---
 Universal Multiple-Octet Coded Character Set (UCS) --- Part 1:
@@ -96,7 +96,7 @@ The operating system interface described in ISO/IEC 9945:2003 is
 hereinafter called \defn{POSIX}.
 
 \pnum
-The ECMAScript Language Specification described in Standard Ecma-262 is
+The ECMAScript Language Specification described in Standard EMCA-262 is
 hereinafter called \defn{ECMA-262}.
 \indextext{references!normative|)}
 


### PR DESCRIPTION
Fixed consistency of capitalisation of 'EMCA' and 'technology' in the [intro.refs] standards section; ECMA (when referring to the standard number) is capitalised throughout, while the official name of ISO/IEC 9945:2003 should be "Information technology...", in line with the other standards.