### PR TITLE
[expr.new] Avoid "heap allocation"

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3024,7 +3024,7 @@ by \tcode{e1}.
 \enterexample
 \begin{codeblock}
   void mergeable(int x) {
-    // These heap allocations are safe for merging:
+    // These allocations are safe for merging:
     std::unique_ptr<char[]> a{new (std::nothrow) char[8]};
     std::unique_ptr<char[]> b{new (std::nothrow) char[8]};
     std::unique_ptr<char[]> c{new (std::nothrow) char[x]};


### PR DESCRIPTION
The term "heap allocation" is not normatively defined, and the term "heap" has other meaning in the standard. Here "heap allocation" is typical implementation details, likely close to "free store". To clarify the intent, it would be better never used at all, even in an example.
