### PR TITLE
[file.streams] Change sub-clauses to rSec2, similar to [string.streams]

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -8456,7 +8456,7 @@ typically holds multibyte character sequences and the \tcode{basic_filebuf}
 object converts those multibyte sequences into wide character sequences.
 \exitnote
 
-\rSec3[filebuf]{Class template \tcode{basic_filebuf}}
+\rSec2[filebuf]{Class template \tcode{basic_filebuf}}
 
 \indexlibrary{\idxcode{basic_filebuf}}%
 \begin{codeblock}
@@ -9224,7 +9224,7 @@ This in turn may require the implementation to be able to reconstruct
 the original contents of the file.
 \end{itemdescr}
 
-\rSec3[ifstream]{Class template \tcode{basic_ifstream}}
+\rSec2[ifstream]{Class template \tcode{basic_ifstream}}
 
 \indexlibrary{\idxcode{basic_ifstream}}%
 \begin{codeblock}
@@ -9464,7 +9464,7 @@ calls
 \tcode{ios_base::failure}~(\ref{iostate.flags})).
 \end{itemdescr}
 
-\rSec3[ofstream]{Class template \tcode{basic_ofstream}}
+\rSec2[ofstream]{Class template \tcode{basic_ofstream}}
 
 \indexlibrary{\idxcode{basic_ofstream}}%
 \begin{codeblock}
@@ -9701,7 +9701,7 @@ void open(const string& s, ios_base::openmode mode = ios_base::out);
 \effects calls \tcode{open(s.c_str(), mode);}
 \end{itemdescr}
 
-\rSec3[fstream]{Class template \tcode{basic_fstream}}
+\rSec2[fstream]{Class template \tcode{basic_fstream}}
 
 \indexlibrary{\idxcode{basic_fstream}}%
 \begin{codeblock}
@@ -9947,7 +9947,7 @@ calls
 \tcode{ios_base::failure}).
 \end{itemdescr}
 
-\rSec2[c.files]{C library files}
+\rSec1[c.files]{C library files}
 
 \pnum
 Table~\ref{tab:iostreams.hdr.cstdio} describes header \tcode{<cstdio>}.

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -30,9 +30,9 @@ as summarized in Table~\ref{tab:iostreams.lib.summary}.
                         &    & \tcode{<ostream>} \\
                         &    & \tcode{<iomanip>} \\ \rowsep
 \ref{string.streams}    & String streams         & \tcode{<sstream>} \\ \rowsep
-\ref{file.streams}      & File streams           & \tcode{<fstream>} \\
-                        &    & \tcode{<cstdio>}  \\
-                        &    & \tcode{<cinttypes>} \\
+\ref{file.streams}      & File streams           & \tcode{<fstream>} \\ \rowsep
+\ref{c.files}           & C library files        & \tcode{<cstdio>}  \\
+                        &                        & \tcode{<cinttypes>} \\
 \end{libsumtab}
 
 \pnum
@@ -381,6 +381,15 @@ namespace std {
   extern wostream wclog;
 }
 \end{codeblock}
+
+\pnum
+In this Clause, the type name \tcode{FILE} refers to
+the type
+\tcode{FILE}
+declared in
+\tcode{<cstdio>}
+\indexlibrary{\idxhdr{cstdio}}%
+(\ref{c.files}).
 
 \pnum
 The header
@@ -8393,7 +8402,7 @@ Calls
 
 \rSec1[file.streams]{File-based streams}
 
-\rSec2[fstreams]{File streams}
+\rSec2[fstreams]{Overview}
 
 \pnum
 The header
@@ -8439,15 +8448,6 @@ namespace std {
   typedef basic_fstream<wchar_t> wfstream;
 }
 \end{codeblock}
-
-\pnum
-In this subclause, the type name \tcode{FILE} refers to
-the type
-\tcode{FILE}
-declared in
-\tcode{<cstdio>}
-\indexlibrary{\idxhdr{cstdio}}%
-(\ref{c.files}).
 
 \pnum
 \enternote The class template \tcode{basic_filebuf} treats a file as a source or


### PR DESCRIPTION
[string.streams] and [file.streams] follow very similar structure (an introduction followed by streambuf, input stream, output stream and bidirectional stream class templates) but are nested entirely differently. Under [fstreams] we have an entirely flat hierarchy where the definition of `basic_streambuf` is at the same level as its own members.

This change makes [file.streams] consistent with [string.streams] by promoting [filebuf], [ifstream], [ofstream] and [fstream] to `rSec2`.

Also promote [c.files] to `rSec1`, I don't think `<cstdint>` should be nested underneath the sub-clause for `basic_fstreambuf` and `basic_fstream` etc.