### PR TITLE
Replace 'prototype' with 'declaration'

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -754,14 +754,14 @@ that statement nor in the outermost block (or, for the \tcode{if}
 statement, any of the outermost blocks) of the controlled statement;
 see~\ref{stmt.select}.
 
-\rSec2[basic.scope.proto]{Function prototype scope}
+\rSec2[basic.scope.proto]{Function declaration scope}
 
 \pnum
-\indextext{scope!function~prototype}%
-\indextext{function~prototype}%
+\indextext{scope!function~declaration}%
+\indextext{function~declaration}%
 In a function declaration, or in any function declarator except the
 declarator of a function definition~(\ref{dcl.fct.def}), names of
-parameters (if supplied) have function prototype scope, which terminates
+parameters (if supplied) have function declaration scope, which terminates
 at the end of the nearest enclosing function declarator.
 
 \rSec2[basic.funscope]{Function scope}

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -456,7 +456,7 @@ The detailed specifications each contain the following elements:%
 
 \begin{itemize}
 \item name and brief description
-\item synopsis (class definition or function prototype, as appropriate)
+\item synopsis (class definition or function declaration, as appropriate)
 \item restrictions on template arguments, if any
 \item description of class invariants
 \item description of function semantics
@@ -1095,7 +1095,7 @@ standard library, even if C grants license for implementation as functions.
 
 \pnum
 Names that are defined as functions in C shall be defined as functions in the
-\Cpp standard library.\footnote{ This disallows the practice, allowed in C, of
+\Cpp standard library.\footnote{This disallows the practice, allowed in C, of
 providing a masking macro in addition to the function prototype. The only way to
 achieve equivalent inline behavior in \Cpp is to provide a definition as an
 extern inline function.}

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -1211,7 +1211,7 @@ bool isctype(charT c, char_class_type f) const;
 classification represented by \tcode{f}.
 
 \pnum
-\returns Given the following function prototype:
+\returns Given the following function declaration:
 \begin{codeblock}
 // for exposition only
 template<class C>

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -9692,7 +9692,7 @@ static_assert( is_final<U2>::value, "Error!");
 \exitexample
 
 \pnum
-Given the following function prototype:
+Given the following function declaration:
 \begin{codeblock}
 template <class T>
   add_rvalue_reference_t<T> create() noexcept;
@@ -9849,7 +9849,7 @@ is_base_of<int, int>::value     // false
 \exitexample
 
 \pnum
-Given the following function prototype:
+Given the following function declaration:
 
 \begin{codeblock}
 template <class T>


### PR DESCRIPTION
The term "prototype" is an archaism from C that isn't part of C++. We should remove the remaining mention of it.
