### PR TITLE
Replace 'prototype' with 'declaration'

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -456,7 +456,7 @@ The detailed specifications each contain the following elements:%
 
 \begin{itemize}
 \item name and brief description
-\item synopsis (class definition or function prototype, as appropriate)
+\item synopsis (class definition or function declaration, as appropriate)
 \item restrictions on template arguments, if any
 \item description of class invariants
 \item description of function semantics
@@ -1095,7 +1095,7 @@ standard library, even if C grants license for implementation as functions.
 
 \pnum
 Names that are defined as functions in C shall be defined as functions in the
-\Cpp standard library.\footnote{ This disallows the practice, allowed in C, of
+\Cpp standard library.\footnote{This disallows the practice, allowed in C, of
 providing a masking macro in addition to the function prototype. The only way to
 achieve equivalent inline behavior in \Cpp is to provide a definition as an
 extern inline function.}

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -1211,7 +1211,7 @@ bool isctype(charT c, char_class_type f) const;
 classification represented by \tcode{f}.
 
 \pnum
-\returns Given the following function prototype:
+\returns Given the following function declaration:
 \begin{codeblock}
 // for exposition only
 template<class C>

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -9692,7 +9692,7 @@ static_assert( is_final<U2>::value, "Error!");
 \exitexample
 
 \pnum
-Given the following function prototype:
+Given the following function declaration:
 \begin{codeblock}
 template <class T>
   add_rvalue_reference_t<T> create() noexcept;
@@ -9849,7 +9849,7 @@ is_base_of<int, int>::value     // false
 \exitexample
 
 \pnum
-Given the following function prototype:
+Given the following function declaration:
 
 \begin{codeblock}
 template <class T>


### PR DESCRIPTION
There is no term "prototype" in C++; it should not be used by the library.
