### PR TITLE
[diff.expr] replace "declare" with "define"

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -250,16 +250,16 @@ widespread commercially.
 Common.
 
 \ref{expr.sizeof}, \ref{expr.cast}
-\change Types must be declared in declarations, not in expressions
-In C, a sizeof expression or cast expression may create a new type.
+\change Types must be defined in declarations, not in expressions\\
+In C, a sizeof expression or cast expression may define a new type.
 For example,
 \begin{codeblock}
 p = (void*)(struct x {int i;} *)0;
 \end{codeblock}
-declares a new type, struct x .
+defines a new type, struct \tcode{x} .
 \rationale
 This prohibition helps to clarify the location of
-declarations in the source code.
+definitions in the source code.
 \effect
 Deletion of a semantically well-defined feature.
 \difficulty


### PR DESCRIPTION
It is always legal in C++ to declare new types in a sizeof expression or cast expression, but you can't *define* a new type in an expression.