### PR TITLE
Fix formatting of DECAY_COPY

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -270,7 +270,7 @@ for the current execution agent.
 
 \pnum
 In several places in this Clause the operation
-\defnx{DECAY_COPY(x)}{DECAY_COPY} is used. All
+\indexdefn{DECAY_COPY}{\tcode{\textit{DECAY_COPY}(x)}} is used. All
 such uses mean call the function \tcode{decay_copy(x)} and use the
 result, where \tcode{decay_copy} is defined as follows:
 


### PR DESCRIPTION
Makes the formatting of DECAY_COPY consistent as all-caps/italic/code.