### PR TITLE
Fix formatting of INVOKE

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -10170,10 +10170,10 @@ needed when only explicit conversions are desired among the template arguments.
  \tcode{Fn} and all types in the parameter pack \tcode{ArgTypes} shall
  be complete types, (possibly cv-qualified) \tcode{void}, or arrays of
  unknown bound. &
- If the expression \tcode{INVOKE(declval<Fn>(), declval<ArgTypes>()...)}
+ If the expression \tcode{\textit{INVOKE}(declval<Fn>(), declval<ArgTypes>()...)}
  is well formed when treated as an unevaluated operand (Clause~\ref{expr}),
  the member typedef \tcode{type} shall name the type
- \tcode{decltype(INVOKE(declval<Fn>(),} \tcode{declval<ArgTypes>()...))};
+ \tcode{decltype(\textit{INVOKE}(declval<Fn>(),} \tcode{declval<ArgTypes>()...))};
  otherwise, there shall be no member \tcode{type}. Access checking is
  performed as if in a context unrelated to \tcode{Fn} and
  \tcode{ArgTypes}. Only the validity of the immediate context of the


### PR DESCRIPTION
Makes the formatting of INVOKE consistent as all-caps/italic/code.
