### PR TITLE
[priqueue.special] fix typo

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -8360,7 +8360,7 @@ c.pop_back();
 \indexlibrary{\idxcode{swap}!\idxcode{priority_queue}}%
 \indexlibrary{\idxcode{priority_queue}!\idxcode{swap}}%
 \begin{itemdecl}
-template <class T, class Container, Compare>
+template <class T, class Container, class Compare>
   void swap(priority_queue<T, Container, Compare>& x,
             priority_queue<T, Container, Compare>& y) noexcept(noexcept(x.swap(y)));
 \end{itemdecl}


### PR DESCRIPTION
N4140 23.6.4.4 [priqueue.special] says `template <class T, class Container, Compare>`. It should say `template <class T, class Container, class Compare>`.