### PR TITLE
[class.conv.fct] Remove text "If a conversion function is a member function"

### DIFF
--- a/source/special.tex
+++ b/source/special.tex
@@ -776,7 +776,7 @@ to the type specified by the
 Such functions are called conversion functions.
 No return type can be specified.
 \indextext{conversion!type~of}%
-If a conversion function is a member function, the type of the conversion function~(\ref{dcl.fct}) is
+The type of a conversion function~(\ref{dcl.fct}) is
 ``function taking no parameter returning
 \grammarterm{conversion-type-id}''.
 A conversion function is never used to convert a (possibly cv-qualified) object


### PR DESCRIPTION
A conversion function is always a member function, as stated in this same paragraph ([class.conv.fct]/1). This text was incorporated from N2773 (Proposed Wording for Concepts) which added "associated functions" as non-member conversion functions, and should have been removed when the other Concepts wording was removed in N2960. See http://stackoverflow.com/a/23273284/923854 for more detail.

I believe the change is editorial. Since the premise of the conditional "If a conversion function is a member function" is necessarily true, the consequent is always true. Removing the text thus does not change the normative meaning of the standard, leaving it in place can only cause confusion.