### PR TITLE
Format 'new expression' consistently as non-code

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -2325,7 +2325,7 @@ struct onlydouble {
 \exitexample
 
 \enterexample One can prevent use of a
-class in certain \tcode{new} expressions by using deleted definitions
+class in certain new expressions by using deleted definitions
 of a user-declared \tcode{operator new} for that class.
 
 \begin{codeblock}

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -911,7 +911,7 @@ Several contexts in \Cpp  cause evaluation of a function call, even
 though no corresponding function call syntax appears in the translation
 unit.
 \enterexample
-Evaluation of a \tcode{new} expression invokes one or more allocation
+Evaluation of a new expression invokes one or more allocation
 and constructor functions; see~\ref{expr.new}. For another example,
 invocation of a conversion function~(\ref{class.conv.fct}) can arise in
 contexts in which no function call syntax appears.


### PR DESCRIPTION
zygoloid: "It's semantic rather than syntactic, so no `\tcode`."
