### PR TITLE
[re.regiter.incr] fix typo

### DIFF
--- a/source/regex.tex
+++ b/source/regex.tex
@@ -3793,11 +3793,11 @@ In all cases in which the call to \tcode{regex_search} returns \tcode{true},
 \tcode{match.prefix().first} shall be equal to the previous value of
 \tcode{match[0].second}, and for each index \tcode{i} in the half-open range
 \tcode{[0, match.size())} for which \tcode{match[i].matched} is true,
-\tcode{match[i].position()}
+\tcode{match.position(i)}
 shall return \tcode{distance(begin, match[i].\brk{}first)}.
 
 \pnum
-\enternote This means that \tcode{match[i].position()} gives the
+\enternote This means that \tcode{match.position(i)} gives the
 offset from the beginning of the target sequence, which is often not
 the same as the offset from the sequence passed in the call
 to \tcode{regex_search}. \exitnote


### PR DESCRIPTION
The fuction position() is a member of the match_results, not a member of the sub_match.
