### PR TITLE
Simplify the wording of static_pointer_cast<> and friends.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -6308,20 +6308,11 @@ template<class T, class U> shared_ptr<T> static_pointer_cast(const shared_ptr<U>
 \pnum\requires  The expression \tcode{static_cast<T*>(r.get())} shall
 be well formed.
 
-\pnum\returns  If \tcode{r} is \textit{empty}, an \textit{empty}
-\tcode{shared_ptr<T>}; otherwise, a \tcode{shared_ptr<T>} object that
-stores \tcode{static_cast<T*>(r.get())} and \textit{shares ownership}
-with \tcode{r}.
+\pnum\returns  \code{shared_ptr<T>(r, static_cast<T*>(r.get()))}.
 
 \pnum
 \postconditions \tcode{w.get() == static_cast<T*>(r.get())} and
 \tcode{w.use_count() == r.use_count()}, where \tcode{w} is the return value.
-
-\pnum
-\enternote The seemingly equivalent expression
-\tcode{shared_ptr<T>(static_cast<T*>(r.get()))}
-will eventually result in undefined behavior, attempting to delete the
-same object twice. \exitnote
 \end{itemdescr}
 
 \indexlibrary{\idxcode{shared_ptr}!\idxcode{dynamic_pointer_cast}}%
@@ -6345,11 +6336,12 @@ shall be well formed and shall have well defined behavior.
 
 \pnum
 \postcondition \tcode{w.get() == dynamic_cast<T*>(r.get())}, where \tcode{w} is the return value.
+\end{itemdescr}
 
 \pnum \enternote  The seemingly equivalent expression
-\tcode{shared_ptr<T>(dynamic_cast<T*>(r.get()))} will eventually result in
-undefined behavior, attempting to delete the same object twice. \exitnote
-\end{itemdescr}
+\tcode{shared_ptr<T>(r, dynamic_cast<T*>(r.get()))} fails to return an
+\textit{empty} \tcode{shared_ptr<T>} object when \tcode{r} is not \textit{empty} but
+\tcode{dynamic_cast<T*>(r.get())} is zero. \exitnote
 
 \indexlibrary{\idxcode{shared_ptr}!\idxcode{const_pointer_cast}}%
 \indexlibrary{\idxcode{const_pointer_cast}!\idxcode{shared_ptr}}%
@@ -6361,17 +6353,11 @@ template<class T, class U> shared_ptr<T> const_pointer_cast(const shared_ptr<U>&
 \pnum\requires  The expression \tcode{const_cast<T*>(r.get())} shall
 be well formed.
 
-\pnum\returns  If \tcode{r} is empty, an empty \tcode{shared_ptr<T>}; otherwise, a
-\tcode{shared_ptr<T>} object that stores \tcode{const_cast<T*>(r.get())} and shares
-ownership with \tcode{r}.
+\pnum\returns  \code{shared_ptr<T>(r, const_cast<T*>(r.get()))}.
 
 \pnum
 \postconditions \tcode{w.get() == const_cast<T*>(r.get())} and
 \tcode{w.use_count() == r.use_count()}, where \tcode{w} is the return value.
-
-\pnum \enternote The seemingly equivalent expression
-\tcode{shared_ptr<T>(const_cast<T*>(r.get()))} will eventually result in
-undefined behavior, attempting to delete the same object twice. \exitnote
 \end{itemdescr}
 
 \rSec4[util.smartptr.getdeleter]{get_deleter}


### PR DESCRIPTION
Is this actually a correct paraphrase, or am I missing some subtlety of the current wording?
I'm assuming that if X is empty, and Y shares ownership with X, then Y is empty.
