### PR TITLE
[expr.sizeof] redundant wording

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2665,8 +2665,8 @@ which is an unevaluated operand (Clause~\ref{expr}), or a parenthesized
 \grammarterm{type-id}.
 \indextext{type!incomplete}%
 The \tcode{sizeof} operator shall not be applied to an expression that
-has function or incomplete type, to an enumeration type whose underlying type is not fixed before all
-its enumerators have been declared, to the parenthesized name of such
+has function or incomplete type, 
+to the parenthesized name of such
 types, or to a glvalue that designates a bit-field.
 \tcode{sizeof(char)}, \tcode{sizeof(signed char)} and
 \tcode{sizeof(unsigned char)} are \tcode{1}. The result of


### PR DESCRIPTION
N4296 5.3.3 [expr.sizeof] says
>The sizeof operator shall not be applied to an expression that has function or incomplete type, to an enumeration type whose underlying type is not fixed before all its enumerators have been declared, to the parenthesized name of such types, or to a glvalue that designates a bit-field.

Now that "an enumeration type whose underlying type is not fixed before all its enumerators have been declared" is considered as an incomplete type (7.2[dcl.enum]p6), `to an enumeration type whose underlying type is not fixed before all its enumerators have been declared` become redundant.