### PR TITLE
[{i,o}stream.manip] Remove redundant "namespace std"

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -5576,10 +5576,8 @@ In case of failure, the function calls \tcode{setstate(\brk{}failbit)} (which ma
 
 \indexlibrary{\idxcode{ws}}%
 \begin{itemdecl}
-namespace std {
-  template <class charT, class traits>
-    basic_istream<charT,traits>& ws(basic_istream<charT,traits>& is);
-}
+template <class charT, class traits>
+  basic_istream<charT,traits>& ws(basic_istream<charT,traits>& is);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6657,10 +6655,8 @@ Otherwise, if the sentry object returns \tcode{false}, does nothing.
 
 \indexlibrary{\idxcode{endl}}%
 \begin{itemdecl}
-namespace std {
-  template <class charT, class traits>
-    basic_ostream<charT,traits>& endl(basic_ostream<charT,traits>& os);
-}
+template <class charT, class traits>
+  basic_ostream<charT,traits>& endl(basic_ostream<charT,traits>& os);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6678,10 +6674,8 @@ then
 
 \indexlibrary{\idxcode{ends}}%
 \begin{itemdecl}
-namespace std {
-  template <class charT, class traits>
-    basic_ostream<charT,traits>& ends(basic_ostream<charT,traits>& os);
-}
+template <class charT, class traits>
+  basic_ostream<charT,traits>& ends(basic_ostream<charT,traits>& os);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6698,10 +6692,8 @@ calls
 
 \indexlibrary{\idxcode{flush}}%
 \begin{itemdecl}
-namespace std {
-  template <class charT, class traits>
-    basic_ostream<charT,traits>& flush(basic_ostream<charT,traits>& os);
-}
+template <class charT, class traits>
+  basic_ostream<charT,traits>& flush(basic_ostream<charT,traits>& os);
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Fixes [issue 416](https://github.com/cplusplus/draft/issues/416). 
