### PR TITLE
Fix typo in example of shared_from_this

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -6711,7 +6711,7 @@ int main() {
   shared_ptr<X> p(new X);
   shared_ptr<X> q = p->shared_from_this();
   assert(p == q);
-  assert(!(p < q ) && !(q < p)); // p and q share ownership
+  assert(!p.owner_before(q) && !q.owner_before(p)); // p and q share ownership
 }
 \end{codeblock}
 \exitexample


### PR DESCRIPTION
Shared ownership is properly indicated by testing `p.owner_before(q)`, not merely `p < q`.