### PR TITLE
[valarray.syn]'s footnote references wrong section

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -6544,7 +6544,7 @@ const member functions of
 are also applicable to this type.
 This return type shall not add
 more than two levels of template nesting over the most deeply nested
-argument type.\footnote{Clause~\ref{limits} recommends a minimum number
+argument type.\footnote{Clause~\ref{implimits} recommends a minimum number
 of recursively nested template
 instantiations.
 This requirement thus indirectly suggests a minimum

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -6544,7 +6544,7 @@ const member functions of
 are also applicable to this type.
 This return type shall not add
 more than two levels of template nesting over the most deeply nested
-argument type.\footnote{Clause~\ref{implimits} recommends a minimum number
+argument type.\footnote{Annex~\ref{implimits} recommends a minimum number
 of recursively nested template
 instantiations.
 This requirement thus indirectly suggests a minimum


### PR DESCRIPTION
N4296 26.6.1 footnote 281 says
>Clause 18.3.2 recommends a minimum number of recursively nested template instantiations. This requirement thus indirectly suggests a minimum allowable complexity for valarray expressions. 

"Clause 18.3.2" should be "Clause B"