### PR TITLE
[reverse.iter.requirements] Avoid saying 'global operators'

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1311,7 +1311,7 @@ if any of the members
 \tcode{operator+=}~(\ref{reverse.iter.op+=}),
 \tcode{operator-=}~(\ref{reverse.iter.op-=}),
 \tcode{operator\,[]}~(\ref{reverse.iter.opindex}),
-or the global operators
+or the non-member operators
 \tcode{operator<}~(\ref{reverse.iter.op<}),
 \tcode{operator>}~(\ref{reverse.iter.op>}),\\
 \tcode{operator\,<=}~(\ref{reverse.iter.op<=}),


### PR DESCRIPTION
N4296 24.5.1.2/2 says
>Additionally, Iterator shall meet the requirements of a Random Access Iterator (24.2.7) if any of the members operator+ (24.5.1.3.8), operator- (24.5.1.3.10), operator+= (24.5.1.3.9), operator-= (24.5.1.3.11), operator \[] (24.5.1.3.12), or the global operators operator< (24.5.1.3.14), operator> (24.5.1.3.16), operator <= (24.5.1.3.18), operator>= (24.5.1.3.17), operator- (24.5.1.3.19) or operator+ (24.5.1.3.20) are referenced in a way that requires instantiation (14.7.1).

The operator<, operator>, operator <=, etc mentioned here do not live in the global namespace, but the current wording can be read as implying so.