### PR TITLE
Fix link in basic_ostream::flush() description

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -6632,7 +6632,7 @@ basic_ostream& flush();
 
 \begin{itemdescr}
 \pnum
-\effects Behaves as an unformatted output function (as described in~\ref{ostream.formatted.reqmts}, paragraph 1).
+\effects Behaves as an unformatted output function (as described in~\ref{ostream.unformatted}, paragraph 1).
 If
 \tcode{rdbuf()}
 is not a null pointer,


### PR DESCRIPTION
`flush()` "behaves as an unformatted output function", but the link is to [ostream.formatted.reqmts]. It should link to [ostream.unformatted] like others in the same section. (Originally reported as #438.)