### PR TITLE
 [string.cons] Adjust wording to match [sequence.reqmts]

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -1326,16 +1326,12 @@ template<class InputIterator>
 
 \begin{itemdescr}
 \pnum
-\effects
-If \tcode{InputIterator} is an integral type,
-equivalent to
-
-\begin{codeblock}
-basic_string(static_cast<size_type>(begin), static_cast<value_type>(end), a)
-\end{codeblock}
+\notes
+If \tcode{InputIterator} does not qualify as an input iterator, 
+then this constructor shall not participate in overload resolution.
 
 \pnum
-Otherwise constructs a string from the values in the range [\tcode{begin}, \tcode{end}),
+\effects Constructs a string from the values in the range [\tcode{begin}, \tcode{end}),
 as indicated in the Sequence Requirements table
 (see~\ref{sequence.reqmts}).
 %


### PR DESCRIPTION
[LWG 1234](http://cplusplus.github.io/LWG/lwg-defects.html#1234) changed 23.2.3 [sequence.reqmts]/14+15 to say "shall not participate in overload resolution". 21.4.2[string.cons]/13 should be reworded accordingly.