### PR TITLE
Consistency cleanups in [containers]: Whitespace

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -983,13 +983,13 @@ shall not participate in overload resolution.
 
 \begin{codeblock}
 template <class InputIterator>          // such as insert()
-rt fx1(const_iterator p, InputIterator first, InputIterator last);
+  rt fx1(const_iterator p, InputIterator first, InputIterator last);
 
 template <class InputIterator>          // such as append(), assign()
-rt fx2(InputIterator first, InputIterator last);
+  rt fx2(InputIterator first, InputIterator last);
 
 template <class InputIterator>          // such as replace()
-rt fx3(const_iterator i1, const_iterator i2, InputIterator first, InputIterator last);
+  rt fx3(const_iterator i1, const_iterator i2, InputIterator first, InputIterator last);
 \end{codeblock}
 
 are called with a type \tcode{InputIterator} that does not qualify as an input
@@ -2400,19 +2400,19 @@ sequence containers.
 namespace std {
   template <class T, size_t N> struct array;
   template <class T, size_t N>
-    bool operator==(const array<T,N>& x, const array<T,N>& y);
+    bool operator==(const array<T, N>& x, const array<T, N>& y);
   template <class T, size_t N>
-    bool operator!=(const array<T,N>& x, const array<T,N>& y);
+    bool operator!=(const array<T, N>& x, const array<T, N>& y);
   template <class T, size_t N>
-    bool operator<(const array<T,N>& x, const array<T,N>& y);
+    bool operator< (const array<T, N>& x, const array<T, N>& y);
   template <class T, size_t N>
-    bool operator>(const array<T,N>& x, const array<T,N>& y);
+    bool operator> (const array<T, N>& x, const array<T, N>& y);
   template <class T, size_t N>
-    bool operator<=(const array<T,N>& x, const array<T,N>& y);
+    bool operator<=(const array<T, N>& x, const array<T, N>& y);
   template <class T, size_t N>
-    bool operator>=(const array<T,N>& x, const array<T,N>& y);
+    bool operator>=(const array<T, N>& x, const array<T, N>& y);
   template <class T, size_t N>
-    void swap(array<T,N>& x, array<T,N>& y) noexcept(noexcept(x.swap(y)));
+    void swap(array<T, N>& x, array<T, N>& y) noexcept(noexcept(x.swap(y)));
 
   template <class T> class tuple_size;
   template <size_t I, class T> class tuple_element;
@@ -2438,19 +2438,19 @@ namespace std {
 namespace std {
   template <class T, class Allocator = allocator<T> > class deque;
   template <class T, class Allocator>
-    bool operator==(const deque<T,Allocator>& x, const deque<T,Allocator>& y);
+    bool operator==(const deque<T, Allocator>& x, const deque<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator<(const deque<T,Allocator>& x, const deque<T,Allocator>& y);
+    bool operator< (const deque<T, Allocator>& x, const deque<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator!=(const deque<T,Allocator>& x, const deque<T,Allocator>& y);
+    bool operator!=(const deque<T, Allocator>& x, const deque<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator>(const deque<T,Allocator>& x, const deque<T,Allocator>& y);
+    bool operator> (const deque<T, Allocator>& x, const deque<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator>=(const deque<T,Allocator>& x, const deque<T,Allocator>& y);
+    bool operator>=(const deque<T, Allocator>& x, const deque<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator<=(const deque<T,Allocator>& x, const deque<T,Allocator>& y);
+    bool operator<=(const deque<T, Allocator>& x, const deque<T, Allocator>& y);
   template <class T, class Allocator>
-    void swap(deque<T,Allocator>& x, deque<T,Allocator>& y)
+    void swap(deque<T, Allocator>& x, deque<T, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 }
 \end{codeblock}
@@ -2464,19 +2464,19 @@ namespace std {
 namespace std {
   template <class T, class Allocator = allocator<T> > class forward_list;
   template <class T, class Allocator>
-    bool operator==(const forward_list<T,Allocator>& x, const forward_list<T,Allocator>& y);
+    bool operator==(const forward_list<T, Allocator>& x, const forward_list<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator< (const forward_list<T,Allocator>& x, const forward_list<T,Allocator>& y);
+    bool operator< (const forward_list<T, Allocator>& x, const forward_list<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator!=(const forward_list<T,Allocator>& x, const forward_list<T,Allocator>& y);
+    bool operator!=(const forward_list<T, Allocator>& x, const forward_list<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator> (const forward_list<T,Allocator>& x, const forward_list<T,Allocator>& y);
+    bool operator> (const forward_list<T, Allocator>& x, const forward_list<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator>=(const forward_list<T,Allocator>& x, const forward_list<T,Allocator>& y);
+    bool operator>=(const forward_list<T, Allocator>& x, const forward_list<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator<=(const forward_list<T,Allocator>& x, const forward_list<T,Allocator>& y);
+    bool operator<=(const forward_list<T, Allocator>& x, const forward_list<T, Allocator>& y);
   template <class T, class Allocator>
-    void swap(forward_list<T,Allocator>& x, forward_list<T,Allocator>& y)
+    void swap(forward_list<T, Allocator>& x, forward_list<T, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 }
 \end{codeblock}
@@ -2490,19 +2490,19 @@ namespace std {
 namespace std {
   template <class T, class Allocator = allocator<T> > class list;
   template <class T, class Allocator>
-    bool operator==(const list<T,Allocator>& x, const list<T,Allocator>& y);
+    bool operator==(const list<T, Allocator>& x, const list<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator< (const list<T,Allocator>& x, const list<T,Allocator>& y);
+    bool operator< (const list<T, Allocator>& x, const list<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator!=(const list<T,Allocator>& x, const list<T,Allocator>& y);
+    bool operator!=(const list<T, Allocator>& x, const list<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator> (const list<T,Allocator>& x, const list<T,Allocator>& y);
+    bool operator> (const list<T, Allocator>& x, const list<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator>=(const list<T,Allocator>& x, const list<T,Allocator>& y);
+    bool operator>=(const list<T, Allocator>& x, const list<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator<=(const list<T,Allocator>& x, const list<T,Allocator>& y);
+    bool operator<=(const list<T, Allocator>& x, const list<T, Allocator>& y);
   template <class T, class Allocator>
-    void swap(list<T,Allocator>& x, list<T,Allocator>& y)
+    void swap(list<T, Allocator>& x, list<T, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 }
 \end{codeblock}
@@ -2516,19 +2516,19 @@ namespace std {
 namespace std {
   template <class T, class Allocator = allocator<T> > class vector;
   template <class T, class Allocator>
-    bool operator==(const vector<T,Allocator>& x,const vector<T,Allocator>& y);
+    bool operator==(const vector<T, Allocator>& x, const vector<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator< (const vector<T,Allocator>& x,const vector<T,Allocator>& y);
+    bool operator< (const vector<T, Allocator>& x, const vector<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator!=(const vector<T,Allocator>& x,const vector<T,Allocator>& y);
+    bool operator!=(const vector<T, Allocator>& x, const vector<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator> (const vector<T,Allocator>& x,const vector<T,Allocator>& y);
+    bool operator> (const vector<T, Allocator>& x, const vector<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator>=(const vector<T,Allocator>& x,const vector<T,Allocator>& y);
+    bool operator>=(const vector<T, Allocator>& x, const vector<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator<=(const vector<T,Allocator>& x,const vector<T,Allocator>& y);
+    bool operator<=(const vector<T, Allocator>& x, const vector<T, Allocator>& y);
   template <class T, class Allocator>
-    void swap(vector<T,Allocator>& x, vector<T,Allocator>& y)
+    void swap(vector<T, Allocator>& x, vector<T, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 
   template <class Allocator> class vector<bool,Allocator>;
@@ -2670,7 +2670,8 @@ respectively.
 \indexlibrary{\idxcode{array}!\idxcode{swap}}%
 \indexlibrary{\idxcode{swap}!\idxcode{array}}%
 \begin{itemdecl}
-template <class T, size_t N> void swap(array<T,N>& x, array<T,N>& y) noexcept(noexcept(x.swap(y)));
+template <class T, size_t N>
+  void swap(array<T, N>& x, array<T, N>& y) noexcept(noexcept(x.swap(y)));
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2688,7 +2689,7 @@ x.swap(y);
 \indexlibrary{\idxcode{array}!\idxcode{size}}%
 \indexlibrary{\idxcode{size}!\idxcode{array}}%
 \begin{itemdecl}
-template <class T, size_t N> constexpr size_type array<T,N>::size() const noexcept;
+template <class T, size_t N> constexpr size_type array<T, N>::size() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2764,8 +2765,7 @@ which is equivalent to \tcode{noexcept(true)}.
 \indexlibrary{\idxcode{tuple_size}}%
 \begin{itemdecl}
 template <class T, size_t N>
-struct tuple_size<array<T, N>>
-  : integral_constant<size_t, N> { };
+  struct tuple_size<array<T, N>> : integral_constant<size_t, N> { };
 \end{itemdecl}
 
 \indexlibrary{\idxcode{tuple_element}}%
@@ -2785,7 +2785,7 @@ tuple_element<I, array<T, N> >::type
 \indexlibrary{\idxcode{get}!\idxcode{array}}%
 \begin{itemdecl}
 template <size_t I, class T, size_t N>
-constexpr T& get(array<T, N>& a) noexcept;
+  constexpr T& get(array<T, N>& a) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2801,7 +2801,7 @@ where indexing is zero-based.
 \indexlibrary{\idxcode{get}!\idxcode{array}}%
 \begin{itemdecl}
 template <size_t I, class T, size_t N>
-constexpr T&& get(array<T, N>&& a) noexcept;
+  constexpr T&& get(array<T, N>&& a) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2813,7 +2813,7 @@ constexpr T&& get(array<T, N>&& a) noexcept;
 \indexlibrary{\idxcode{get}!\idxcode{array}}%
 \begin{itemdecl}
 template <size_t I, class T, size_t N>
-constexpr const T& get(const array<T, N>& a) noexcept;
+  constexpr const T& get(const array<T, N>& a) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2955,21 +2955,21 @@ namespace std {
   };
 
   template <class T, class Allocator>
-    bool operator==(const deque<T,Allocator>& x, const deque<T,Allocator>& y);
+    bool operator==(const deque<T, Allocator>& x, const deque<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator< (const deque<T,Allocator>& x, const deque<T,Allocator>& y);
+    bool operator< (const deque<T, Allocator>& x, const deque<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator!=(const deque<T,Allocator>& x, const deque<T,Allocator>& y);
+    bool operator!=(const deque<T, Allocator>& x, const deque<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator> (const deque<T,Allocator>& x, const deque<T,Allocator>& y);
+    bool operator> (const deque<T, Allocator>& x, const deque<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator>=(const deque<T,Allocator>& x, const deque<T,Allocator>& y);
+    bool operator>=(const deque<T, Allocator>& x, const deque<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator<=(const deque<T,Allocator>& x, const deque<T,Allocator>& y);
+    bool operator<=(const deque<T, Allocator>& x, const deque<T, Allocator>& y);
 
   // specialized algorithms:
   template <class T, class Allocator>
-    void swap(deque<T,Allocator>& x, deque<T,Allocator>& y)
+    void swap(deque<T, Allocator>& x, deque<T, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 }
 \end{codeblock}
@@ -3015,8 +3015,7 @@ explicit deque(size_type n, const Allocator& = Allocator());
 \indexlibrary{\idxcode{deque}!\idxcode{deque}}%
 \indexlibrary{\idxcode{deque}!\idxcode{deque}}%
 \begin{itemdecl}
-deque(size_type n, const T& value,
-      const Allocator& = Allocator());
+deque(size_type n, const T& value, const Allocator& = Allocator());
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3039,8 +3038,7 @@ Linear in \tcode{n}.
 \indexlibrary{\idxcode{deque}!\idxcode{deque}}%
 \begin{itemdecl}
 template <class InputIterator>
-  deque(InputIterator first, InputIterator last,
-        const Allocator& = Allocator());
+  deque(InputIterator first, InputIterator last, const Allocator& = Allocator());
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3198,7 +3196,7 @@ assignment operator, or move assignment operator of
 \indexlibrary{\idxcode{deque}!\idxcode{swap}}%
 \begin{itemdecl}
 template <class T, class Allocator>
-  void swap(deque<T,Allocator>& x, deque<T,Allocator>& y)
+  void swap(deque<T, Allocator>& x, deque<T, Allocator>& y)
     noexcept(noexcept(x.swap(y)));
 \end{itemdecl}
 
@@ -3358,21 +3356,21 @@ namespace std {
 
   // Comparison operators
   template <class T, class Allocator>
-    bool operator==(const forward_list<T,Allocator>& x, const forward_list<T,Allocator>& y);
+    bool operator==(const forward_list<T, Allocator>& x, const forward_list<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator< (const forward_list<T,Allocator>& x, const forward_list<T,Allocator>& y);
+    bool operator< (const forward_list<T, Allocator>& x, const forward_list<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator!=(const forward_list<T,Allocator>& x, const forward_list<T,Allocator>& y);
+    bool operator!=(const forward_list<T, Allocator>& x, const forward_list<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator> (const forward_list<T,Allocator>& x, const forward_list<T,Allocator>& y);
+    bool operator> (const forward_list<T, Allocator>& x, const forward_list<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator>=(const forward_list<T,Allocator>& x, const forward_list<T,Allocator>& y);
+    bool operator>=(const forward_list<T, Allocator>& x, const forward_list<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator<=(const forward_list<T,Allocator>& x, const forward_list<T,Allocator>& y);
+    bool operator<=(const forward_list<T, Allocator>& x, const forward_list<T, Allocator>& y);
 
   // \ref{forwardlist.spec}, specialized algorithms:
   template <class T, class Allocator>
-    void swap(forward_list<T,Allocator>& x, forward_list<T,Allocator>& y)
+    void swap(forward_list<T, Allocator>& x, forward_list<T, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 }
 \end{codeblock}
@@ -3928,7 +3926,7 @@ Does not affect the validity of iterators and references.
 \indexlibrary{\idxcode{forward_list}!\idxcode{swap}}%
 \begin{itemdecl}
 template <class T, class Allocator>
-  void swap(forward_list<T,Allocator>& x, forward_list<T,Allocator>& y)
+  void swap(forward_list<T, Allocator>& x, forward_list<T, Allocator>& y)
     noexcept(noexcept(x.swap(y)));
 \end{itemdecl}
 
@@ -4096,21 +4094,21 @@ namespace std {
   };
 
   template <class T, class Allocator>
-    bool operator==(const list<T,Allocator>& x, const list<T,Allocator>& y);
+    bool operator==(const list<T, Allocator>& x, const list<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator< (const list<T,Allocator>& x, const list<T,Allocator>& y);
+    bool operator< (const list<T, Allocator>& x, const list<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator!=(const list<T,Allocator>& x, const list<T,Allocator>& y);
+    bool operator!=(const list<T, Allocator>& x, const list<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator> (const list<T,Allocator>& x, const list<T,Allocator>& y);
+    bool operator> (const list<T, Allocator>& x, const list<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator>=(const list<T,Allocator>& x, const list<T,Allocator>& y);
+    bool operator>=(const list<T, Allocator>& x, const list<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator<=(const list<T,Allocator>& x, const list<T,Allocator>& y);
+    bool operator<=(const list<T, Allocator>& x, const list<T, Allocator>& y);
 
   // specialized algorithms:
   template <class T, class Allocator>
-    void swap(list<T,Allocator>& x, list<T,Allocator>& y)
+    void swap(list<T, Allocator>& x, list<T, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 }
 \end{codeblock}
@@ -4156,8 +4154,7 @@ Linear in
 \indexlibrary{\idxcode{list}!\idxcode{list}}%
 \indexlibrary{\idxcode{list}!\idxcode{list}}%
 \begin{itemdecl}
-list(size_type n, const T& value,
-     const Allocator& = Allocator());
+list(size_type n, const T& value, const Allocator& = Allocator());
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4184,8 +4181,7 @@ Linear in
 \indexlibrary{\idxcode{list}!\idxcode{list}}%
 \begin{itemdecl}
 template <class InputIterator>
-list(InputIterator first, InputIterator last,
-     const Allocator& = Allocator());
+  list(InputIterator first, InputIterator last, const Allocator& = Allocator());
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4467,7 +4463,7 @@ otherwise, linear time.
 
 \indexlibrary{\idxcode{remove}!\tcode{list}}%
 \begin{itemdecl}
-                           void remove(const T& value);
+void remove(const T& value);
 template <class Predicate> void remove_if(Predicate pred);
 \end{itemdecl}
 
@@ -4497,7 +4493,7 @@ applications of the corresponding predicate.
 
 \indexlibrary{\idxcode{unique}!\tcode{list}}%
 \begin{itemdecl}
-                                 void unique();
+void unique();
 template <class BinaryPredicate> void unique(BinaryPredicate binary_pred);
 \end{itemdecl}
 
@@ -4530,8 +4526,8 @@ otherwise no applications of the predicate.
 
 \indexlibrary{\idxcode{merge}!\tcode{list}}%
 \begin{itemdecl}
-void                          merge(list& x);
-void                          merge(list&& x);
+void merge(list& x);
+void merge(list&& x);
 template <class Compare> void merge(list& x, Compare comp);
 template <class Compare> void merge(list&& x, Compare comp);
 \end{itemdecl}
@@ -4588,7 +4584,7 @@ Linear time.
 
 \indexlibrary{\idxcode{sort}!\tcode{list}}%
 \begin{itemdecl}
-                         void sort();
+void sort();
 template <class Compare> void sort(Compare comp);
 \end{itemdecl}
 
@@ -4625,7 +4621,7 @@ comparisons, where
 \indexlibrary{\idxcode{list}!\idxcode{swap}}%
 \begin{itemdecl}
 template <class T, class Allocator>
-  void swap(list<T,Allocator>& x, list<T,Allocator>& y)
+  void swap(list<T, Allocator>& x, list<T, Allocator>& y)
     noexcept(noexcept(x.swap(y)));
 \end{itemdecl}
 
@@ -4690,8 +4686,7 @@ namespace std {
     explicit vector(size_type n, const Allocator& = Allocator());
     vector(size_type n, const T& value, const Allocator& = Allocator());
     template <class InputIterator>
-      vector(InputIterator first, InputIterator last,
-             const Allocator& = Allocator());
+      vector(InputIterator first, InputIterator last, const Allocator& = Allocator());
     vector(const vector& x);
     vector(vector&&) noexcept;
     vector(const vector&, const Allocator&);
@@ -4745,8 +4740,8 @@ namespace std {
     const_reference back() const;
 
     // \ref{vector.data}, data access
-    T*         data() noexcept;
-    const T*  data() const noexcept;
+    T*       data() noexcept;
+    const T* data() const noexcept;
 
     // \ref{vector.modifiers}, modifiers:
     template <class... Args> void emplace_back(Args&&... args);
@@ -4756,12 +4751,11 @@ namespace std {
 
     template <class... Args> iterator emplace(const_iterator position, Args&&... args);
     iterator insert(const_iterator position, const T& x);
-    iterator     insert(const_iterator position, T&& x);
-    iterator     insert(const_iterator position, size_type n, const T& x);
+    iterator insert(const_iterator position, T&& x);
+    iterator insert(const_iterator position, size_type n, const T& x);
     template <class InputIterator>
-        iterator insert(const_iterator position,
-                        InputIterator first, InputIterator last);
-    iterator     insert(const_iterator position, initializer_list<T> il);
+      iterator insert(const_iterator position, InputIterator first, InputIterator last);
+    iterator insert(const_iterator position, initializer_list<T> il);
     iterator erase(const_iterator position);
     iterator erase(const_iterator first, const_iterator last);
     void     swap(vector&)
@@ -4771,21 +4765,21 @@ namespace std {
   };
 
   template <class T, class Allocator>
-    bool operator==(const vector<T,Allocator>& x, const vector<T,Allocator>& y);
+    bool operator==(const vector<T, Allocator>& x, const vector<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator< (const vector<T,Allocator>& x, const vector<T,Allocator>& y);
+    bool operator< (const vector<T, Allocator>& x, const vector<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator!=(const vector<T,Allocator>& x, const vector<T,Allocator>& y);
+    bool operator!=(const vector<T, Allocator>& x, const vector<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator> (const vector<T,Allocator>& x, const vector<T,Allocator>& y);
+    bool operator> (const vector<T, Allocator>& x, const vector<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator>=(const vector<T,Allocator>& x, const vector<T,Allocator>& y);
+    bool operator>=(const vector<T, Allocator>& x, const vector<T, Allocator>& y);
   template <class T, class Allocator>
-    bool operator<=(const vector<T,Allocator>& x, const vector<T,Allocator>& y);
+    bool operator<=(const vector<T, Allocator>& x, const vector<T, Allocator>& y);
 
   // \ref{vector.special}, specialized algorithms:
   template <class T, class Allocator>
-    void swap(vector<T,Allocator>& x, vector<T,Allocator>& y)
+    void swap(vector<T, Allocator>& x, vector<T, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 }
 \end{codeblock}%
@@ -5110,7 +5104,7 @@ assignment operator, or move assignment operator of
 \indexlibrary{\idxcode{vector}!\idxcode{swap}}%
 \begin{itemdecl}
 template <class T, class Allocator>
-  void swap(vector<T,Allocator>& x, vector<T,Allocator>& y)
+  void swap(vector<T, Allocator>& x, vector<T, Allocator>& y)
     noexcept(noexcept(x.swap(y)));
 \end{itemdecl}
 
@@ -5168,14 +5162,14 @@ namespace std {
     template <class InputIterator>
       vector(InputIterator first, InputIterator last,
              const Allocator& = Allocator());
-    vector(const vector<bool,Allocator>& x);
-    vector(vector<bool,Allocator>&& x);
+    vector(const vector<bool, Allocator>& x);
+    vector(vector<bool, Allocator>&& x);
     vector(const vector&, const Allocator&);
     vector(vector&&, const Allocator&);
     vector(initializer_list<bool>, const Allocator& = Allocator()));
    ~vector();
-    vector<bool,Allocator>& operator=(const vector<bool,Allocator>& x);
-    vector<bool,Allocator>& operator=(vector<bool,Allocator>&& x);
+    vector<bool, Allocator>& operator=(const vector<bool, Allocator>& x);
+    vector<bool, Allocator>& operator=(vector<bool, Allocator>&& x);
     vector& operator=(initializer_list<bool>);
     template <class InputIterator>
       void assign(InputIterator first, InputIterator last);
@@ -5225,13 +5219,13 @@ namespace std {
     iterator insert(const_iterator position, const bool& x);
     iterator insert (const_iterator position, size_type n, const bool& x);
     template <class InputIterator>
-        iterator insert(const_iterator position,
-                        InputIterator first, InputIterator last);
+      iterator insert(const_iterator position,
+                      InputIterator first, InputIterator last);
     iterator insert(const_iterator position, initializer_list<bool> il);
 
     iterator erase(const_iterator position);
     iterator erase(const_iterator first, const_iterator last);
-    void swap(vector<bool,Allocator>&);
+    void swap(vector<bool, Allocator>&);
     static void swap(reference x, reference y) noexcept;
     void flip() noexcept;       // flips all bits
     void clear() noexcept;
@@ -5320,52 +5314,52 @@ namespace std {
             class Allocator = allocator<pair<const Key, T> > >
     class map;
   template <class Key, class T, class Compare, class Allocator>
-    bool operator==(const map<Key,T,Compare,Allocator>& x,
-                    const map<Key,T,Compare,Allocator>& y);
+    bool operator==(const map<Key, T, Compare, Allocator>& x,
+                    const map<Key, T, Compare, Allocator>& y);
   template <class Key, class T, class Compare, class Allocator>
-    bool operator< (const map<Key,T,Compare,Allocator>& x,
-                    const map<Key,T,Compare,Allocator>& y);
+    bool operator< (const map<Key, T, Compare, Allocator>& x,
+                    const map<Key, T, Compare, Allocator>& y);
   template <class Key, class T, class Compare, class Allocator>
-    bool operator!=(const map<Key,T,Compare,Allocator>& x,
-                    const map<Key,T,Compare,Allocator>& y);
+    bool operator!=(const map<Key, T, Compare, Allocator>& x,
+                    const map<Key, T, Compare, Allocator>& y);
   template <class Key, class T, class Compare, class Allocator>
-    bool operator> (const map<Key,T,Compare,Allocator>& x,
-                    const map<Key,T,Compare,Allocator>& y);
+    bool operator> (const map<Key, T, Compare, Allocator>& x,
+                    const map<Key, T, Compare, Allocator>& y);
   template <class Key, class T, class Compare, class Allocator>
-    bool operator>=(const map<Key,T,Compare,Allocator>& x,
-                    const map<Key,T,Compare,Allocator>& y);
+    bool operator>=(const map<Key, T, Compare, Allocator>& x,
+                    const map<Key, T, Compare, Allocator>& y);
   template <class Key, class T, class Compare, class Allocator>
-    bool operator<=(const map<Key,T,Compare,Allocator>& x,
-                    const map<Key,T,Compare,Allocator>& y);
+    bool operator<=(const map<Key, T, Compare, Allocator>& x,
+                    const map<Key, T, Compare, Allocator>& y);
   template <class Key, class T, class Compare, class Allocator>
-    void swap(map<Key,T,Compare,Allocator>& x,
-              map<Key,T,Compare,Allocator>& y)
+    void swap(map<Key, T, Compare, Allocator>& x,
+              map<Key, T, Compare, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 
   template <class Key, class T, class Compare = less<Key>,
             class Allocator = allocator<pair<const Key, T> > >
     class multimap;
   template <class Key, class T, class Compare, class Allocator>
-    bool operator==(const multimap<Key,T,Compare,Allocator>& x,
-                    const multimap<Key,T,Compare,Allocator>& y);
+    bool operator==(const multimap<Key, T, Compare, Allocator>& x,
+                    const multimap<Key, T, Compare, Allocator>& y);
   template <class Key, class T, class Compare, class Allocator>
-    bool operator< (const multimap<Key,T,Compare,Allocator>& x,
-                    const multimap<Key,T,Compare,Allocator>& y);
+    bool operator< (const multimap<Key, T, Compare, Allocator>& x,
+                    const multimap<Key, T, Compare, Allocator>& y);
   template <class Key, class T, class Compare, class Allocator>
-    bool operator!=(const multimap<Key,T,Compare,Allocator>& x,
-                    const multimap<Key,T,Compare,Allocator>& y);
+    bool operator!=(const multimap<Key, T, Compare, Allocator>& x,
+                    const multimap<Key, T, Compare, Allocator>& y);
   template <class Key, class T, class Compare, class Allocator>
-    bool operator> (const multimap<Key,T,Compare,Allocator>& x,
-                    const multimap<Key,T,Compare,Allocator>& y);
+    bool operator> (const multimap<Key, T, Compare, Allocator>& x,
+                    const multimap<Key, T, Compare, Allocator>& y);
   template <class Key, class T, class Compare, class Allocator>
-    bool operator>=(const multimap<Key,T,Compare,Allocator>& x,
-                    const multimap<Key,T,Compare,Allocator>& y);
+    bool operator>=(const multimap<Key, T, Compare, Allocator>& x,
+                    const multimap<Key, T, Compare, Allocator>& y);
   template <class Key, class T, class Compare, class Allocator>
-    bool operator<=(const multimap<Key,T,Compare,Allocator>& x,
-                    const multimap<Key,T,Compare,Allocator>& y);
+    bool operator<=(const multimap<Key, T, Compare, Allocator>& x,
+                    const multimap<Key, T, Compare, Allocator>& y);
   template <class Key, class T, class Compare, class Allocator>
-    void swap(multimap<Key,T,Compare,Allocator>& x,
-              multimap<Key,T,Compare,Allocator>& y)
+    void swap(multimap<Key, T, Compare, Allocator>& x,
+              multimap<Key, T, Compare, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 }
 \end{codeblock}
@@ -5382,52 +5376,52 @@ namespace std {
             class Allocator = allocator<Key> >
     class set;
   template <class Key, class Compare, class Allocator>
-    bool operator==(const set<Key,Compare,Allocator>& x,
-                    const set<Key,Compare,Allocator>& y);
+    bool operator==(const set<Key, Compare, Allocator>& x,
+                    const set<Key, Compare, Allocator>& y);
   template <class Key, class Compare, class Allocator>
-    bool operator< (const set<Key,Compare,Allocator>& x,
-                    const set<Key,Compare,Allocator>& y);
+    bool operator< (const set<Key, Compare, Allocator>& x,
+                    const set<Key, Compare, Allocator>& y);
   template <class Key, class Compare, class Allocator>
-    bool operator!=(const set<Key,Compare,Allocator>& x,
-                    const set<Key,Compare,Allocator>& y);
+    bool operator!=(const set<Key, Compare, Allocator>& x,
+                    const set<Key, Compare, Allocator>& y);
   template <class Key, class Compare, class Allocator>
-    bool operator> (const set<Key,Compare,Allocator>& x,
-                    const set<Key,Compare,Allocator>& y);
+    bool operator> (const set<Key, Compare, Allocator>& x,
+                    const set<Key, Compare, Allocator>& y);
   template <class Key, class Compare, class Allocator>
-    bool operator>=(const set<Key,Compare,Allocator>& x,
-                    const set<Key,Compare,Allocator>& y);
+    bool operator>=(const set<Key, Compare, Allocator>& x,
+                    const set<Key, Compare, Allocator>& y);
   template <class Key, class Compare, class Allocator>
-    bool operator<=(const set<Key,Compare,Allocator>& x,
-                    const set<Key,Compare,Allocator>& y);
+    bool operator<=(const set<Key, Compare, Allocator>& x,
+                    const set<Key, Compare, Allocator>& y);
   template <class Key, class Compare, class Allocator>
-    void swap(set<Key,Compare,Allocator>& x,
-              set<Key,Compare,Allocator>& y)
+    void swap(set<Key, Compare, Allocator>& x,
+              set<Key, Compare, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 
   template <class Key, class Compare = less<Key>,
             class Allocator = allocator<Key> >
     class multiset;
   template <class Key, class Compare, class Allocator>
-    bool operator==(const multiset<Key,Compare,Allocator>& x,
-                    const multiset<Key,Compare,Allocator>& y);
+    bool operator==(const multiset<Key, Compare, Allocator>& x,
+                    const multiset<Key, Compare, Allocator>& y);
   template <class Key, class Compare, class Allocator>
-    bool operator< (const multiset<Key,Compare,Allocator>& x,
-                    const multiset<Key,Compare,Allocator>& y);
+    bool operator< (const multiset<Key, Compare, Allocator>& x,
+                    const multiset<Key, Compare, Allocator>& y);
   template <class Key, class Compare, class Allocator>
-    bool operator!=(const multiset<Key,Compare,Allocator>& x,
-                    const multiset<Key,Compare,Allocator>& y);
+    bool operator!=(const multiset<Key, Compare, Allocator>& x,
+                    const multiset<Key, Compare, Allocator>& y);
   template <class Key, class Compare, class Allocator>
-    bool operator> (const multiset<Key,Compare,Allocator>& x,
-                    const multiset<Key,Compare,Allocator>& y);
+    bool operator> (const multiset<Key, Compare, Allocator>& x,
+                    const multiset<Key, Compare, Allocator>& y);
   template <class Key, class Compare, class Allocator>
-    bool operator>=(const multiset<Key,Compare,Allocator>& x,
-                    const multiset<Key,Compare,Allocator>& y);
+    bool operator>=(const multiset<Key, Compare, Allocator>& x,
+                    const multiset<Key, Compare, Allocator>& y);
   template <class Key, class Compare, class Allocator>
-    bool operator<=(const multiset<Key,Compare,Allocator>& x,
-                    const multiset<Key,Compare,Allocator>& y);
+    bool operator<=(const multiset<Key, Compare, Allocator>& x,
+                    const multiset<Key, Compare, Allocator>& y);
   template <class Key, class Compare, class Allocator>
-    void swap(multiset<Key,Compare,Allocator>& x,
-              multiset<Key,Compare,Allocator>& y)
+    void swap(multiset<Key, Compare, Allocator>& x,
+              multiset<Key, Compare, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 }
 \end{codeblock}
@@ -5514,8 +5508,7 @@ namespace std {
 
     // \ref{map.cons}, construct/copy/destroy:
     map() : map(Compare()) { }
-    explicit map(const Compare& comp,
-                 const Allocator& = Allocator());
+    explicit map(const Compare& comp, const Allocator& = Allocator());
     template <class InputIterator>
       map(InputIterator first, InputIterator last,
           const Compare& comp = Compare(), const Allocator& = Allocator());
@@ -5528,8 +5521,8 @@ namespace std {
       const Compare& = Compare(),
       const Allocator& = Allocator());
     template <class InputIterator>
-    map(InputIterator first, InputIterator last, const Allocator& a)
-      : map(first, last, Compare(), a) { }
+      map(InputIterator first, InputIterator last, const Allocator& a)
+        : map(first, last, Compare(), a) { }
     map(initializer_list<value_type> il, const Allocator& a)
       : map(il, Compare(), a) { }
    ~map();
@@ -5601,13 +5594,13 @@ namespace std {
     iterator  erase(const_iterator position);
     size_type erase(const key_type& x);
     iterator  erase(const_iterator first, const_iterator last);
-    void swap(map&)
+    void      swap(map&)
       noexcept(allocator_traits<Allocator>::is_always_equal::value &&
-               noexcept(swap(declval<Compare&>(),declval<Compare&>())));
-    void clear() noexcept;
+               noexcept(swap(declval<Compare&>(), declval<Compare&>())));
+    void      clear() noexcept;
 
     // observers:
-    key_compare   key_comp() const;
+    key_compare key_comp() const;
     value_compare value_comp() const;
 
     // map operations:
@@ -5640,28 +5633,28 @@ namespace std {
   };
 
   template <class Key, class T, class Compare, class Allocator>
-    bool operator==(const map<Key,T,Compare,Allocator>& x,
-                    const map<Key,T,Compare,Allocator>& y);
+    bool operator==(const map<Key, T, Compare, Allocator>& x,
+                    const map<Key, T, Compare, Allocator>& y);
   template <class Key, class T, class Compare, class Allocator>
-    bool operator< (const map<Key,T,Compare,Allocator>& x,
-                    const map<Key,T,Compare,Allocator>& y);
+    bool operator< (const map<Key, T, Compare, Allocator>& x,
+                    const map<Key, T, Compare, Allocator>& y);
   template <class Key, class T, class Compare, class Allocator>
-    bool operator!=(const map<Key,T,Compare,Allocator>& x,
-                    const map<Key,T,Compare,Allocator>& y);
+    bool operator!=(const map<Key, T, Compare, Allocator>& x,
+                    const map<Key, T, Compare, Allocator>& y);
   template <class Key, class T, class Compare, class Allocator>
-    bool operator> (const map<Key,T,Compare,Allocator>& x,
-                    const map<Key,T,Compare,Allocator>& y);
+    bool operator> (const map<Key, T, Compare, Allocator>& x,
+                    const map<Key, T, Compare, Allocator>& y);
   template <class Key, class T, class Compare, class Allocator>
-    bool operator>=(const map<Key,T,Compare,Allocator>& x,
-                    const map<Key,T,Compare,Allocator>& y);
+    bool operator>=(const map<Key, T, Compare, Allocator>& x,
+                    const map<Key, T, Compare, Allocator>& y);
   template <class Key, class T, class Compare, class Allocator>
-    bool operator<=(const map<Key,T,Compare,Allocator>& x,
-                    const map<Key,T,Compare,Allocator>& y);
+    bool operator<=(const map<Key, T, Compare, Allocator>& x,
+                    const map<Key, T, Compare, Allocator>& y);
 
   // specialized algorithms:
   template <class Key, class T, class Compare, class Allocator>
-    void swap(map<Key,T,Compare,Allocator>& x,
-              map<Key,T,Compare,Allocator>& y)
+    void swap(map<Key, T, Compare, Allocator>& x,
+              map<Key, T, Compare, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 }
 \end{codeblock}
@@ -5674,8 +5667,7 @@ namespace std {
 \indexlibrary{\idxcode{map}!\idxcode{map}}%
 \indexlibrary{\idxcode{map}!\idxcode{map}}%
 \begin{itemdecl}
-explicit map(const Compare& comp,
-             const Allocator& = Allocator());
+explicit map(const Compare& comp, const Allocator& = Allocator());
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5896,8 +5888,8 @@ respectively.
 \indexlibrary{\idxcode{map}!\idxcode{swap}}%
 \begin{itemdecl}
 template <class Key, class T, class Compare, class Allocator>
-  void swap(map<Key,T,Compare,Allocator>& x,
-            map<Key,T,Compare,Allocator>& y)
+  void swap(map<Key, T, Compare, Allocator>& x,
+            map<Key, T, Compare, Allocator>& y)
     noexcept(noexcept(x.swap(y)));
 \end{itemdecl}
 
@@ -5998,8 +5990,7 @@ namespace std {
 
     // construct/copy/destroy:
     multimap() : multimap(Compare()) { }
-    explicit multimap(const Compare& comp,
-                      const Allocator& = Allocator());
+    explicit multimap(const Compare& comp, const Allocator& = Allocator());
     template <class InputIterator>
       multimap(InputIterator first, InputIterator last,
                const Compare& comp = Compare(),
@@ -6013,8 +6004,8 @@ namespace std {
       const Compare& = Compare(),
       const Allocator& = Allocator());
     template <class InputIterator>
-    multimap(InputIterator first, InputIterator last, const Allocator& a)
-      : multimap(first, last, Compare(), a) { }
+      multimap(InputIterator first, InputIterator last, const Allocator& a)
+        : multimap(first, last, Compare(), a) { }
     multimap(initializer_list<value_type> il, const Allocator& a)
       : multimap(il, Compare(), a) { }
    ~multimap();
@@ -6042,9 +6033,9 @@ namespace std {
     const_reverse_iterator crend() const noexcept;
 
     // capacity:
-    bool           empty() const noexcept;
-    size_type      size() const noexcept;
-    size_type      max_size() const noexcept;
+    bool      empty() const noexcept;
+    size_type size() const noexcept;
+    size_type max_size() const noexcept;
 
     // modifiers:
     template <class... Args> iterator emplace(Args&&... args);
@@ -6062,14 +6053,14 @@ namespace std {
     iterator  erase(const_iterator position);
     size_type erase(const key_type& x);
     iterator  erase(const_iterator first, const_iterator last);
-    void swap(multimap&)
+    void      swap(multimap&)
       noexcept(allocator_traits<Allocator>::is_always_equal::value &&
-               noexcept(swap(declval<Compare&>(),declval<Compare&>())));
-    void clear() noexcept;
+               noexcept(swap(declval<Compare&>(), declval<Compare&>())));
+    void      clear() noexcept;
 
     // observers:
-    key_compare    key_comp() const;
-    value_compare  value_comp() const;
+    key_compare key_comp() const;
+    value_compare value_comp() const;
 
     // map operations:
     iterator       find(const key_type& x);
@@ -6101,28 +6092,28 @@ namespace std {
   };
 
   template <class Key, class T, class Compare, class Allocator>
-    bool operator==(const multimap<Key,T,Compare,Allocator>& x,
-                    const multimap<Key,T,Compare,Allocator>& y);
+    bool operator==(const multimap<Key, T, Compare, Allocator>& x,
+                    const multimap<Key, T, Compare, Allocator>& y);
   template <class Key, class T, class Compare, class Allocator>
-    bool operator< (const multimap<Key,T,Compare,Allocator>& x,
-                    const multimap<Key,T,Compare,Allocator>& y);
+    bool operator< (const multimap<Key, T, Compare, Allocator>& x,
+                    const multimap<Key, T, Compare, Allocator>& y);
   template <class Key, class T, class Compare, class Allocator>
-    bool operator!=(const multimap<Key,T,Compare,Allocator>& x,
-                    const multimap<Key,T,Compare,Allocator>& y);
+    bool operator!=(const multimap<Key, T, Compare, Allocator>& x,
+                    const multimap<Key, T, Compare, Allocator>& y);
   template <class Key, class T, class Compare, class Allocator>
-    bool operator> (const multimap<Key,T,Compare,Allocator>& x,
-                    const multimap<Key,T,Compare,Allocator>& y);
+    bool operator> (const multimap<Key, T, Compare, Allocator>& x,
+                    const multimap<Key, T, Compare, Allocator>& y);
   template <class Key, class T, class Compare, class Allocator>
-    bool operator>=(const multimap<Key,T,Compare,Allocator>& x,
-                    const multimap<Key,T,Compare,Allocator>& y);
+    bool operator>=(const multimap<Key, T, Compare, Allocator>& x,
+                    const multimap<Key, T, Compare, Allocator>& y);
   template <class Key, class T, class Compare, class Allocator>
-    bool operator<=(const multimap<Key,T,Compare,Allocator>& x,
-                    const multimap<Key,T,Compare,Allocator>& y);
+    bool operator<=(const multimap<Key, T, Compare, Allocator>& x,
+                    const multimap<Key, T, Compare, Allocator>& y);
 
   // specialized algorithms:
   template <class Key, class T, class Compare, class Allocator>
-    void swap(multimap<Key,T,Compare,Allocator>& x,
-              multimap<Key,T,Compare,Allocator>& y)
+    void swap(multimap<Key, T, Compare, Allocator>& x,
+              multimap<Key, T, Compare, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 }
 \end{codeblock}%
@@ -6134,8 +6125,7 @@ namespace std {
 \indexlibrary{\idxcode{multimap}!\idxcode{multimap}}%
 \indexlibrary{\idxcode{multimap}!\idxcode{multimap}}%
 \begin{itemdecl}
-explicit multimap(const Compare& comp,
-                  const Allocator& = Allocator());
+explicit multimap(const Compare& comp, const Allocator& = Allocator());
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6213,8 +6203,8 @@ unless \tcode{std::is_constructible<value_type, P\&\&>::value} is
 \indexlibrary{\idxcode{multimap}!\idxcode{swap}}%
 \begin{itemdecl}
 template <class Key, class T, class Compare, class Allocator>
-  void swap(multimap<Key,T,Compare,Allocator>& x,
-            multimap<Key,T,Compare,Allocator>& y)
+  void swap(multimap<Key, T, Compare, Allocator>& x,
+            multimap<Key, T, Compare, Allocator>& y)
     noexcept(noexcept(x.swap(y)));
 \end{itemdecl}
 
@@ -6295,8 +6285,7 @@ namespace std {
 
     // \ref{set.cons}, construct/copy/destroy:
     set() : set(Compare()) { }
-    explicit set(const Compare& comp,
-                 const Allocator& = Allocator());
+    explicit set(const Compare& comp, const Allocator& = Allocator());
     template <class InputIterator>
       set(InputIterator first, InputIterator last,
           const Compare& comp = Compare(), const Allocator& = Allocator());
@@ -6305,12 +6294,11 @@ namespace std {
     explicit set(const Allocator&);
     set(const set&, const Allocator&);
     set(set&&, const Allocator&);
-    set(initializer_list<value_type>,
-      const Compare& = Compare(),
-      const Allocator& = Allocator());
+    set(initializer_list<value_type>, const Compare& = Compare(),
+        const Allocator& = Allocator());
     template <class InputIterator>
-    set(InputIterator first, InputIterator last, const Allocator& a)
-      : set(first, last, Compare(), a) { }
+      set(InputIterator first, InputIterator last, const Allocator& a)
+        : set(first, last, Compare(), a) { }
     set(initializer_list<value_type> il, const Allocator& a)
       : set(il, Compare(), a) { }
    ~set();
@@ -6338,9 +6326,9 @@ namespace std {
     const_reverse_iterator crend() const noexcept;
 
     // capacity:
-    bool          empty() const noexcept;
-    size_type     size() const noexcept;
-    size_type     max_size() const noexcept;
+    bool      empty() const noexcept;
+    size_type size() const noexcept;
+    size_type max_size() const noexcept;
 
     // modifiers:
     template <class... Args> pair<iterator, bool> emplace(Args&&... args);
@@ -6356,36 +6344,36 @@ namespace std {
     iterator  erase(const_iterator position);
     size_type erase(const key_type& x);
     iterator  erase(const_iterator first, const_iterator last);
-    void swap(set&)
+    void      swap(set&)
       noexcept(allocator_traits<Allocator>::is_always_equal::value &&
-               noexcept(swap(declval<Compare&>(),declval<Compare&>())));
-    void clear() noexcept;
+               noexcept(swap(declval<Compare&>(), declval<Compare&>())));
+    void      clear() noexcept;
 
     // observers:
-    key_compare   key_comp() const;
+    key_compare key_comp() const;
     value_compare value_comp() const;
 
     // set operations:
-    iterator        find(const key_type& x);
-    const_iterator  find(const key_type& x) const;
+    iterator       find(const key_type& x);
+    const_iterator find(const key_type& x) const;
     template <class K> iterator       find(const K& x);
     template <class K> const_iterator find(const K& x) const;
 
-    size_type count(const key_type& x) const;
+    size_type      count(const key_type& x) const;
     template <class K> size_type count(const K& x) const;
 
-    iterator        lower_bound(const key_type& x);
-    const_iterator  lower_bound(const key_type& x) const;
+    iterator       lower_bound(const key_type& x);
+    const_iterator lower_bound(const key_type& x) const;
     template <class K> iterator       lower_bound(const K& x);
     template <class K> const_iterator lower_bound(const K& x) const;
 
-    iterator        upper_bound(const key_type& x);
-    const_iterator  upper_bound(const key_type& x) const;
+    iterator       upper_bound(const key_type& x);
+    const_iterator upper_bound(const key_type& x) const;
     template <class K> iterator       upper_bound(const K& x);
     template <class K> const_iterator upper_bound(const K& x) const;
 
-    pair<iterator,iterator>             equal_range(const key_type& x);
-    pair<const_iterator,const_iterator> equal_range(const key_type& x) const;
+    pair<iterator,iterator>                equal_range(const key_type& x);
+    pair<const_iterator, const_iterator>   equal_range(const key_type& x) const;
     template <class K>
       pair<iterator, iterator>             equal_range(const K& x);
     template <class K>
@@ -6393,28 +6381,28 @@ namespace std {
   };
 
   template <class Key, class Compare, class Allocator>
-    bool operator==(const set<Key,Compare,Allocator>& x,
-                    const set<Key,Compare,Allocator>& y);
+    bool operator==(const set<Key, Compare, Allocator>& x,
+                    const set<Key, Compare, Allocator>& y);
   template <class Key, class Compare, class Allocator>
-    bool operator< (const set<Key,Compare,Allocator>& x,
-                    const set<Key,Compare,Allocator>& y);
+    bool operator< (const set<Key, Compare, Allocator>& x,
+                    const set<Key, Compare, Allocator>& y);
   template <class Key, class Compare, class Allocator>
-    bool operator!=(const set<Key,Compare,Allocator>& x,
-                    const set<Key,Compare,Allocator>& y);
+    bool operator!=(const set<Key, Compare, Allocator>& x,
+                    const set<Key, Compare, Allocator>& y);
   template <class Key, class Compare, class Allocator>
-    bool operator> (const set<Key,Compare,Allocator>& x,
-                    const set<Key,Compare,Allocator>& y);
+    bool operator> (const set<Key, Compare, Allocator>& x,
+                    const set<Key, Compare, Allocator>& y);
   template <class Key, class Compare, class Allocator>
-    bool operator>=(const set<Key,Compare,Allocator>& x,
-                    const set<Key,Compare,Allocator>& y);
+    bool operator>=(const set<Key, Compare, Allocator>& x,
+                    const set<Key, Compare, Allocator>& y);
   template <class Key, class Compare, class Allocator>
-    bool operator<=(const set<Key,Compare,Allocator>& x,
-                    const set<Key,Compare,Allocator>& y);
+    bool operator<=(const set<Key, Compare, Allocator>& x,
+                    const set<Key, Compare, Allocator>& y);
 
   // specialized algorithms:
   template <class Key, class Compare, class Allocator>
-    void swap(set<Key,Compare,Allocator>& x,
-              set<Key,Compare,Allocator>& y)
+    void swap(set<Key, Compare, Allocator>& x,
+              set<Key, Compare, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 }
 \end{codeblock}%
@@ -6426,8 +6414,7 @@ namespace std {
 \indexlibrary{\idxcode{set}!\idxcode{set}}%
 \indexlibrary{\idxcode{set}!\idxcode{set}}%
 \begin{itemdecl}
-explicit set(const Compare& comp,
-             const Allocator& = Allocator());
+explicit set(const Compare& comp, const Allocator& = Allocator());
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6478,8 +6465,8 @@ where $N$ is
 \indexlibrary{\idxcode{set}!\idxcode{swap}}%
 \begin{itemdecl}
 template <class Key, class Compare, class Allocator>
-  void swap(set<Key,Compare,Allocator>& x,
-            set<Key,Compare,Allocator>& y)
+  void swap(set<Key, Compare, Allocator>& x,
+            set<Key, Compare, Allocator>& y)
     noexcept(noexcept(x.swap(y)));
 \end{itemdecl}
 
@@ -6559,23 +6546,20 @@ namespace std {
 
     // construct/copy/destroy:
     multiset() : multiset(Compare()) { }
-    explicit multiset(const Compare& comp,
-                      const Allocator& = Allocator());
+    explicit multiset(const Compare& comp, const Allocator& = Allocator());
     template <class InputIterator>
       multiset(InputIterator first, InputIterator last,
-               const Compare& comp = Compare(),
-               const Allocator& = Allocator());
+               const Compare& comp = Compare(), const Allocator& = Allocator());
     multiset(const multiset& x);
     multiset(multiset&& x);
     explicit multiset(const Allocator&);
     multiset(const multiset&, const Allocator&);
     multiset(multiset&&, const Allocator&);
-    multiset(initializer_list<value_type>,
-      const Compare& = Compare(),
-      const Allocator& = Allocator());
+    multiset(initializer_list<value_type>, const Compare& = Compare(),
+             const Allocator& = Allocator());
     template <class InputIterator>
-    multiset(InputIterator first, InputIterator last, const Allocator& a)
-      : multiset(first, last, Compare(), a) { }
+      multiset(InputIterator first, InputIterator last, const Allocator& a)
+        : multiset(first, last, Compare(), a) { }
     multiset(initializer_list<value_type> il, const Allocator& a)
       : multiset(il, Compare(), a) { }
    ~multiset();
@@ -6603,9 +6587,9 @@ namespace std {
     const_reverse_iterator crend() const noexcept;
 
     // capacity:
-    bool          empty() const noexcept;
-    size_type     size() const noexcept;
-    size_type     max_size() const noexcept;
+    bool      empty() const noexcept;
+    size_type size() const noexcept;
+    size_type max_size() const noexcept;
 
     // modifiers:
     template <class... Args> iterator emplace(Args&&... args);
@@ -6621,18 +6605,18 @@ namespace std {
     iterator  erase(const_iterator position);
     size_type erase(const key_type& x);
     iterator  erase(const_iterator first, const_iterator last);
-    void swap(multiset&)
+    void      swap(multiset&)
       noexcept(allocator_traits<Allocator>::is_always_equal::value &&
-               noexcept(swap(declval<Compare&>(),declval<Compare&>())));
-    void clear() noexcept;
+               noexcept(swap(declval<Compare&>(), declval<Compare&>())));
+    void      clear() noexcept;
 
     // observers:
-    key_compare   key_comp() const;
+    key_compare key_comp() const;
     value_compare value_comp() const;
 
     // set operations:
-    iterator        find(const key_type& x);
-    const_iterator  find(const key_type& x) const;
+    iterator       find(const key_type& x);
+    const_iterator find(const key_type& x) const;
     template <class K> iterator       find(const K& x);
     template <class K> const_iterator find(const K& x) const;
 
@@ -6658,28 +6642,28 @@ namespace std {
   };
 
   template <class Key, class Compare, class Allocator>
-    bool operator==(const multiset<Key,Compare,Allocator>& x,
-                    const multiset<Key,Compare,Allocator>& y);
+    bool operator==(const multiset<Key, Compare, Allocator>& x,
+                    const multiset<Key, Compare, Allocator>& y);
   template <class Key, class Compare, class Allocator>
-    bool operator< (const multiset<Key,Compare,Allocator>& x,
-                    const multiset<Key,Compare,Allocator>& y);
+    bool operator< (const multiset<Key, Compare, Allocator>& x,
+                    const multiset<Key, Compare, Allocator>& y);
   template <class Key, class Compare, class Allocator>
-    bool operator!=(const multiset<Key,Compare,Allocator>& x,
-                    const multiset<Key,Compare,Allocator>& y);
+    bool operator!=(const multiset<Key, Compare, Allocator>& x,
+                    const multiset<Key, Compare, Allocator>& y);
   template <class Key, class Compare, class Allocator>
-    bool operator> (const multiset<Key,Compare,Allocator>& x,
-                    const multiset<Key,Compare,Allocator>& y);
+    bool operator> (const multiset<Key, Compare, Allocator>& x,
+                    const multiset<Key, Compare, Allocator>& y);
   template <class Key, class Compare, class Allocator>
-    bool operator>=(const multiset<Key,Compare,Allocator>& x,
-                    const multiset<Key,Compare,Allocator>& y);
+    bool operator>=(const multiset<Key, Compare, Allocator>& x,
+                    const multiset<Key, Compare, Allocator>& y);
   template <class Key, class Compare, class Allocator>
-    bool operator<=(const multiset<Key,Compare,Allocator>& x,
-                    const multiset<Key,Compare,Allocator>& y);
+    bool operator<=(const multiset<Key, Compare, Allocator>& x,
+                    const multiset<Key, Compare, Allocator>& y);
 
   // specialized algorithms:
   template <class Key, class Compare, class Allocator>
-    void swap(multiset<Key,Compare,Allocator>& x,
-              multiset<Key,Compare,Allocator>& y)
+    void swap(multiset<Key, Compare, Allocator>& x,
+              multiset<Key, Compare, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 }
 \end{codeblock}%
@@ -6691,8 +6675,7 @@ namespace std {
 \indexlibrary{\idxcode{multiset}!\idxcode{multiset}}%
 \indexlibrary{\idxcode{multiset}!\idxcode{multiset}}%
 \begin{itemdecl}
-explicit multiset(const Compare& comp,
-                  const Allocator& = Allocator());
+explicit multiset(const Compare& comp, const Allocator& = Allocator());
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6743,8 +6726,8 @@ where $N$ is
 \indexlibrary{\idxcode{multiset}!\idxcode{swap}}%
 \begin{itemdecl}
 template <class Key, class Compare, class Allocator>
-  void swap(multiset<Key,Compare,Allocator>& x,
-            multiset<Key,Compare,Allocator>& y)
+  void swap(multiset<Key, Compare, Allocator>& x,
+            multiset<Key, Compare, Allocator>& y)
     noexcept(noexcept(x.swap(y)));
 \end{itemdecl}
 
@@ -6774,7 +6757,6 @@ The header \tcode{<unordered_map>} defines the class templates
 #include <initializer_list>
 
 namespace std {
-
   // \ref{unord.map}, class template unordered_map:
   template <class Key,
             class T,
@@ -6824,7 +6806,6 @@ namespace std {
 #include <initializer_list>
 
 namespace std {
-
   // \ref{unord.set}, class template unordered_set:
   template <class Key,
             class Hash = hash<Key>,
@@ -6892,8 +6873,8 @@ is additional semantic information.
 namespace std {
   template <class Key,
             class T,
-            class Hash  = hash<Key>,
-            class Pred  = std::equal_to<Key>,
+            class Hash = hash<Key>,
+            class Pred = std::equal_to<Key>,
             class Allocator = std::allocator<std::pair<const Key, T> > >
   class unordered_map
   {
@@ -6945,15 +6926,15 @@ namespace std {
       : unordered_map(n, hf, key_equal(), a) { }
     template <class InputIterator>
       unordered_map(InputIterator f, InputIterator l, size_type n, const allocator_type& a)
-      : unordered_map(f, l, n, hasher(), key_equal(), a) { }
+        : unordered_map(f, l, n, hasher(), key_equal(), a) { }
     template <class InputIterator>
       unordered_map(InputIterator f, InputIterator l, size_type n, const hasher& hf,
-      const allocator_type& a)
-      : unordered_map(f, l, n, hf, key_equal(), a) { }
+                    const allocator_type& a)
+        : unordered_map(f, l, n, hf, key_equal(), a) { }
     unordered_map(initializer_list<value_type> il, size_type n, const allocator_type& a)
       : unordered_map(il, n, hasher(), key_equal(), a) { }
     unordered_map(initializer_list<value_type> il, size_type n, const hasher& hf,
-    const allocator_type& a)
+                  const allocator_type& a)
       : unordered_map(il, n, hf, key_equal(), a) { }
     ~unordered_map();
     unordered_map& operator=(const unordered_map&);
@@ -7006,15 +6987,14 @@ namespace std {
     template <class M>
       iterator insert_or_assign(const_iterator hint, key_type&& k, M&& obj);
 
-    iterator erase(const_iterator position);
+    iterator  erase(const_iterator position);
     size_type erase(const key_type& k);
-    iterator erase(const_iterator first, const_iterator last);
-    void clear() noexcept;
-
-    void swap(unordered_map&)
+    iterator  erase(const_iterator first, const_iterator last);
+    void      swap(unordered_map&)
       noexcept(allocator_traits<Allocator>::is_always_equal::value &&
-               noexcept(swap(declval<Hash&>(),declval<Hash&>())) &&
-               noexcept(swap(declval<Pred&>(),declval<Pred&>())));
+               noexcept(swap(declval<Hash&>(), declval<Hash&>())) &&
+               noexcept(swap(declval<Pred&>(), declval<Pred&>())));
+    void      clear() noexcept;
 
     // observers
     hasher hash_function() const;
@@ -7023,7 +7003,7 @@ namespace std {
     // lookup
     iterator       find(const key_type& k);
     const_iterator find(const key_type& k) const;
-    size_type count(const key_type& k) const;
+    size_type      count(const key_type& k) const;
     std::pair<iterator, iterator>             equal_range(const key_type& k);
     std::pair<const_iterator, const_iterator> equal_range(const key_type& k) const;
 
@@ -7321,8 +7301,8 @@ there is additional semantic information.
 namespace std {
   template <class Key,
             class T,
-            class Hash  = hash<Key>,
-            class Pred  = std::equal_to<Key>,
+            class Hash = hash<Key>,
+            class Pred = std::equal_to<Key>,
             class Allocator = std::allocator<std::pair<const Key, T> > >
   class unordered_multimap
   {
@@ -7374,15 +7354,15 @@ namespace std {
       : unordered_multimap(n, hf, key_equal(), a) { }
     template <class InputIterator>
       unordered_multimap(InputIterator f, InputIterator l, size_type n, const allocator_type& a)
-      : unordered_multimap(f, l, n, hasher(), key_equal(), a) { }
+        : unordered_multimap(f, l, n, hasher(), key_equal(), a) { }
     template <class InputIterator>
       unordered_multimap(InputIterator f, InputIterator l, size_type n, const hasher& hf, 
-      const allocator_type& a)
-      : unordered_multimap(f, l, n, hf, key_equal(), a) { }
+                         const allocator_type& a)
+        : unordered_multimap(f, l, n, hf, key_equal(), a) { }
     unordered_multimap(initializer_list<value_type> il, size_type n, const allocator_type& a)
       : unordered_multimap(il, n, hasher(), key_equal(), a) { }
     unordered_multimap(initializer_list<value_type> il, size_type n, const hasher& hf, 
-    const allocator_type& a)
+                       const allocator_type& a)
       : unordered_multimap(il, n, hf, key_equal(), a) { }
     ~unordered_multimap();
     unordered_multimap& operator=(const unordered_multimap&);
@@ -7418,15 +7398,14 @@ namespace std {
     template <class InputIterator> void insert(InputIterator first, InputIterator last);
     void insert(initializer_list<value_type>);
 
-    iterator erase(const_iterator position);
+    iterator  erase(const_iterator position);
     size_type erase(const key_type& k);
-    iterator erase(const_iterator first, const_iterator last);
-    void clear() noexcept;
-
-    void swap(unordered_multimap&)
+    iterator  erase(const_iterator first, const_iterator last);
+    void      swap(unordered_multimap&)
       noexcept(allocator_traits<Allocator>::is_always_equal::value &&
-               noexcept(swap(declval<Hash&>(),declval<Hash&>())) &&
-               noexcept(swap(declval<Pred&>(),declval<Pred&>())));
+               noexcept(swap(declval<Hash&>(), declval<Hash&>())) &&
+               noexcept(swap(declval<Pred&>(), declval<Pred&>())));
+    void      clear() noexcept;
 
     // observers
     hasher hash_function() const;
@@ -7435,7 +7414,7 @@ namespace std {
     // lookup
     iterator       find(const key_type& k);
     const_iterator find(const key_type& k) const;
-    size_type count(const key_type& k) const;
+    size_type      count(const key_type& k) const;
     std::pair<iterator, iterator>             equal_range(const key_type& k);
     std::pair<const_iterator, const_iterator> equal_range(const key_type& k) const;
 
@@ -7606,8 +7585,8 @@ is additional semantic information.
 \begin{codeblock}
 namespace std {
   template <class Key,
-            class Hash  = hash<Key>,
-            class Pred  = std::equal_to<Key>,
+            class Hash = hash<Key>,
+            class Pred = std::equal_to<Key>,
             class Allocator = std::allocator<Key> >
   class unordered_set
   {
@@ -7658,15 +7637,15 @@ namespace std {
       : unordered_set(n, hf, key_equal(), a) { }
     template <class InputIterator>
       unordered_set(InputIterator f, InputIterator l, size_type n, const allocator_type& a)
-      : unordered_set(f, l, n, hasher(), key_equal(), a) { }
+        : unordered_set(f, l, n, hasher(), key_equal(), a) { }
     template <class InputIterator>
       unordered_set(InputIterator f, InputIterator l, size_type n, const hasher& hf,
-      const allocator_type& a)
+                    const allocator_type& a)
       : unordered_set(f, l, n, hf, key_equal(), a) { }
     unordered_set(initializer_list<value_type> il, size_type n, const allocator_type& a)
       : unordered_set(il, n, hasher(), key_equal(), a) { }
     unordered_set(initializer_list<value_type> il, size_type n, const hasher& hf,
-    const allocator_type& a)
+                  const allocator_type& a)
       : unordered_set(il, n, hf, key_equal(), a) { }
     ~unordered_set();
     unordered_set& operator=(const unordered_set&);
@@ -7700,15 +7679,14 @@ namespace std {
     template <class InputIterator> void insert(InputIterator first, InputIterator last);
     void insert(initializer_list<value_type>);
 
-    iterator erase(const_iterator position);
+    iterator  erase(const_iterator position);
     size_type erase(const key_type& k);
-    iterator erase(const_iterator first, const_iterator last);
-    void clear() noexcept;
-
-    void swap(unordered_set&)
+    iterator  erase(const_iterator first, const_iterator last);
+    void      swap(unordered_set&)
       noexcept(allocator_traits<Allocator>::is_always_equal::value &&
-               noexcept(swap(declval<Hash&>(),declval<Hash&>())) &&
-               noexcept(swap(declval<Pred&>(),declval<Pred&>())));
+               noexcept(swap(declval<Hash&>(), declval<Hash&>())) &&
+               noexcept(swap(declval<Pred&>(), declval<Pred&>())));
+    void      clear() noexcept;
 
     // observers
     hasher hash_function() const;
@@ -7717,7 +7695,7 @@ namespace std {
     // lookup
     iterator       find(const key_type& k);
     const_iterator find(const key_type& k) const;
-    size_type count(const key_type& k) const;
+    size_type      count(const key_type& k) const;
     std::pair<iterator, iterator>             equal_range(const key_type& k);
     std::pair<const_iterator, const_iterator> equal_range(const key_type& k) const;
 
@@ -7858,8 +7836,8 @@ is additional semantic information.
 \begin{codeblock}
 namespace std {
   template <class Key,
-            class Hash  = hash<Key>,
-            class Pred  = std::equal_to<Key>,
+            class Hash = hash<Key>,
+            class Pred = std::equal_to<Key>,
             class Allocator = std::allocator<Key> >
   class unordered_multiset
   {
@@ -7910,15 +7888,15 @@ namespace std {
       : unordered_multiset(n, hf, key_equal(), a) { }
     template <class InputIterator>
       unordered_multiset(InputIterator f, InputIterator l, size_type n, const allocator_type& a)
-      : unordered_multiset(f, l, n, hasher(), key_equal(), a) { }
+        : unordered_multiset(f, l, n, hasher(), key_equal(), a) { }
     template <class InputIterator>
       unordered_multiset(InputIterator f, InputIterator l, size_type n, const hasher& hf, 
-      const allocator_type& a)
+                         const allocator_type& a)
       : unordered_multiset(f, l, n, hf, key_equal(), a) { }
     unordered_multiset(initializer_list<value_type> il, size_type n, const allocator_type& a)
       : unordered_multiset(il, n, hasher(), key_equal(), a) { }
     unordered_multiset(initializer_list<value_type> il, size_type n, const hasher& hf, 
-    const allocator_type& a)
+                       const allocator_type& a)
       : unordered_multiset(il, n, hf, key_equal(), a) { }
     ~unordered_multiset();
     unordered_multiset& operator=(const unordered_multiset&);
@@ -7952,15 +7930,14 @@ namespace std {
     template <class InputIterator> void insert(InputIterator first, InputIterator last);
     void insert(initializer_list<value_type>);
 
-    iterator erase(const_iterator position);
+    iterator  erase(const_iterator position);
     size_type erase(const key_type& k);
-    iterator erase(const_iterator first, const_iterator last);
-    void clear() noexcept;
-
-    void swap(unordered_multiset&)
+    iterator  erase(const_iterator first, const_iterator last);
+    void      swap(unordered_multiset&)
       noexcept(allocator_traits<Allocator>::is_always_equal::value &&
-               noexcept(swap(declval<Hash&>(),declval<Hash&>())) &&
-               noexcept(swap(declval<Pred&>(),declval<Pred&>())));
+               noexcept(swap(declval<Hash&>(), declval<Hash&>())) &&
+               noexcept(swap(declval<Pred&>(), declval<Pred&>())));
+    void      clear() noexcept;
 
     // observers
     hasher hash_function() const;
@@ -7969,7 +7946,7 @@ namespace std {
     // lookup
     iterator       find(const key_type& k);
     const_iterator find(const key_type& k) const;
-    size_type count(const key_type& k) const;
+    size_type      count(const key_type& k) const;
     std::pair<iterator, iterator>             equal_range(const key_type& k);
     std::pair<const_iterator, const_iterator> equal_range(const key_type& k) const;
 
@@ -8105,24 +8082,23 @@ exception is thrown by the swap of the adaptor's \tcode{Container} or
 #include <initializer_list>
 
 namespace std {
-
   template <class T, class Container = deque<T> > class queue;
   template <class T, class Container = vector<T>,
-    class Compare = less<typename Container::value_type> >
-      class priority_queue;
+            class Compare = less<typename Container::value_type> >
+    class priority_queue;
 
   template <class T, class Container>
-    bool operator==(const queue<T, Container>& x,const queue<T, Container>& y);
+    bool operator==(const queue<T, Container>& x, const queue<T, Container>& y);
   template <class T, class Container>
-    bool operator< (const queue<T, Container>& x,const queue<T, Container>& y);
+    bool operator< (const queue<T, Container>& x, const queue<T, Container>& y);
   template <class T, class Container>
-    bool operator!=(const queue<T, Container>& x,const queue<T, Container>& y);
+    bool operator!=(const queue<T, Container>& x, const queue<T, Container>& y);
   template <class T, class Container>
-    bool operator> (const queue<T, Container>& x,const queue<T, Container>& y);
+    bool operator> (const queue<T, Container>& x, const queue<T, Container>& y);
   template <class T, class Container>
-    bool operator>=(const queue<T, Container>& x,const queue<T, Container>& y);
+    bool operator>=(const queue<T, Container>& x, const queue<T, Container>& y);
   template <class T, class Container>
-    bool operator<=(const queue<T, Container>& x,const queue<T, Container>& y);
+    bool operator<=(const queue<T, Container>& x, const queue<T, Container>& y);
 
   template <class T, class Container>
     void swap(queue<T, Container>& x, queue<T, Container>& y) noexcept(noexcept(x.swap(y)));
@@ -8162,6 +8138,7 @@ namespace std {
     typedef typename Container::const_reference       const_reference;
     typedef typename Container::size_type             size_type;
     typedef          Container                        container_type;
+
   protected:
     Container c;
 
@@ -8182,8 +8159,8 @@ namespace std {
     const_reference   back() const      { return c.back(); }
     void push(const value_type& x)      { c.push_back(x); }
     void push(value_type&& x)           { c.push_back(std::move(x)); }
-    template <class... Args> void emplace(Args&&... args)
-      { c.emplace_back(std::forward<Args>(args)...); }
+    template <class... Args>
+      void emplace(Args&&... args)      { c.emplace_back(std::forward<Args>(args)...); }
     void pop()                          { c.pop_front(); }
     void swap(queue& q) noexcept(noexcept(swap(c, q.c)))
       { using std::swap; swap(c, q.c); }
@@ -8238,8 +8215,7 @@ If \tcode{uses_allocator<container_type, Alloc>::value} is \tcode{false}
 the constructors in this subclause shall not participate in overload resolution.
 
 \begin{itemdecl}
-template <class Alloc>
-  explicit queue(const Alloc& a);
+template <class Alloc> explicit queue(const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8248,8 +8224,7 @@ template <class Alloc>
 \end{itemdescr}
 
 \begin{itemdecl}
-template <class Alloc>
-  queue(const container_type& cont, const Alloc& a);
+template <class Alloc> queue(const container_type& cont, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8259,8 +8234,7 @@ as the second argument.
 \end{itemdescr}
 
 \begin{itemdecl}
-template <class Alloc>
-  queue(container_type&& cont, const Alloc& a);
+template <class Alloc> queue(container_type&& cont, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8270,8 +8244,7 @@ as the second argument.
 \end{itemdescr}
 
 \begin{itemdecl}
-template <class Alloc>
-  queue(const queue& q, const Alloc& a);
+template <class Alloc> queue(const queue& q, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8281,8 +8254,7 @@ second argument.
 \end{itemdescr}
 
 \begin{itemdecl}
-template <class Alloc>
-  queue(queue&& q, const Alloc& a);
+template <class Alloc> queue(queue&& q, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8296,8 +8268,7 @@ as the second argument.
 \indexlibrary{\idxcode{operator==}!\idxcode{queue}}%
 \begin{itemdecl}
 template <class T, class Container>
-    bool operator==(const queue<T, Container>& x,
-                    const queue<T, Container>& y);
+  bool operator==(const queue<T, Container>& x, const queue<T, Container>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8309,8 +8280,7 @@ template <class T, class Container>
 \indexlibrary{\idxcode{operator"!=}!\idxcode{queue}}%
 \begin{itemdecl}
 template <class T, class Container>
-    bool operator!=(const queue<T, Container>& x,
-                    const queue<T, Container>& y);
+  bool operator!=(const queue<T, Container>& x,  const queue<T, Container>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8322,8 +8292,7 @@ template <class T, class Container>
 \indexlibrary{\idxcode{operator<}!\idxcode{queue}}%
 \begin{itemdecl}
 template <class T, class Container>
-    bool operator< (const queue<T, Container>& x,
-                    const queue<T, Container>& y);
+  bool operator< (const queue<T, Container>& x, const queue<T, Container>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8335,8 +8304,7 @@ template <class T, class Container>
 \indexlibrary{\idxcode{operator<=}!\idxcode{queue}}%
 \begin{itemdecl}
 template <class T, class Container>
-    bool operator<=(const queue<T, Container>& x,
-                    const queue<T, Container>& y);
+  bool operator<=(const queue<T, Container>& x, const queue<T, Container>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8348,8 +8316,7 @@ template <class T, class Container>
 \indexlibrary{\idxcode{operator>}!\idxcode{queue}}%
 \begin{itemdecl}
 template <class T, class Container>
-    bool operator> (const queue<T, Container>& x,
-                    const queue<T, Container>& y);
+  bool operator> (const queue<T, Container>& x, const queue<T, Container>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8418,6 +8385,7 @@ namespace std {
     typedef typename Container::const_reference       const_reference;
     typedef typename Container::size_type             size_type;
     typedef          Container                        container_type;
+
   protected:
     Container c;
     Compare comp;
@@ -8433,10 +8401,8 @@ namespace std {
              const Compare& x = Compare(), Container&& = Container());
     template <class Alloc> explicit priority_queue(const Alloc&);
     template <class Alloc> priority_queue(const Compare&, const Alloc&);
-    template <class Alloc> priority_queue(const Compare&,
-      const Container&, const Alloc&);
-    template <class Alloc> priority_queue(const Compare&,
-      Container&&, const Alloc&);
+    template <class Alloc> priority_queue(const Compare&, const Container&, const Alloc&);
+    template <class Alloc> priority_queue(const Compare&, Container&&, const Alloc&);
     template <class Alloc> priority_queue(const priority_queue&, const Alloc&);
     template <class Alloc> priority_queue(priority_queue&&, const Alloc&);
 
@@ -8447,11 +8413,12 @@ namespace std {
     void push(value_type&& x);
     template <class... Args> void emplace(Args&&... args);
     void pop();
-    void swap(priority_queue& q) noexcept(
-        noexcept(swap(c, q.c)) && noexcept(swap(comp, q.comp)))
+    void swap(priority_queue& q) noexcept(noexcept(swap(c, q.c)) && noexcept(swap(comp, q.comp)))
       { using std::swap; swap(c, q.c); swap(comp, q.comp); }
   };
+
   // no equality is provided
+
   template <class T, class Container, class Compare>
     void swap(priority_queue<T, Container, Compare>& x,
               priority_queue<T, Container, Compare>& y) noexcept(noexcept(x.swap(y)));
@@ -8525,8 +8492,7 @@ If \tcode{uses_allocator<container_type, Alloc>::value} is \tcode{false}
 the constructors in this subclause shall not participate in overload resolution.
 
 \begin{itemdecl}
-template <class Alloc>
-  explicit priority_queue(const Alloc& a);
+template <class Alloc> explicit priority_queue(const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8535,8 +8501,7 @@ template <class Alloc>
 \end{itemdescr}
 
 \begin{itemdecl}
-template <class Alloc>
-  priority_queue(const Compare& compare, const Alloc& a);
+template <class Alloc> priority_queue(const Compare& compare, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8567,8 +8532,7 @@ as the second argument, and initializes \tcode{comp} with \tcode{compare}.
 \end{itemdescr}
 
 \begin{itemdecl}
-template <class Alloc>
-  priority_queue(const priority_queue& q, const Alloc& a);
+template <class Alloc> priority_queue(const priority_queue& q, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8578,8 +8542,7 @@ the second argument, and initializes \tcode{comp} with \tcode{q.comp}.
 \end{itemdescr}
 
 \begin{itemdecl}
-template <class Alloc>
-  priority_queue(priority_queue&& q, const Alloc& a);
+template <class Alloc> priority_queue(priority_queue&& q, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8688,20 +8651,19 @@ can be used.
 #include <initializer_list>
 
 namespace std {
-
   template <class T, class Container = deque<T> > class stack;
   template <class T, class Container>
-    bool operator==(const stack<T, Container>& x,const stack<T, Container>& y);
+    bool operator==(const stack<T, Container>& x, const stack<T, Container>& y);
   template <class T, class Container>
-    bool operator< (const stack<T, Container>& x,const stack<T, Container>& y);
+    bool operator< (const stack<T, Container>& x, const stack<T, Container>& y);
   template <class T, class Container>
-    bool operator!=(const stack<T, Container>& x,const stack<T, Container>& y);
+    bool operator!=(const stack<T, Container>& x, const stack<T, Container>& y);
   template <class T, class Container>
-    bool operator> (const stack<T, Container>& x,const stack<T, Container>& y);
+    bool operator> (const stack<T, Container>& x, const stack<T, Container>& y);
   template <class T, class Container>
-    bool operator>=(const stack<T, Container>& x,const stack<T, Container>& y);
+    bool operator>=(const stack<T, Container>& x, const stack<T, Container>& y);
   template <class T, class Container>
-    bool operator<=(const stack<T, Container>& x,const stack<T, Container>& y);
+    bool operator<=(const stack<T, Container>& x, const stack<T, Container>& y);
   template <class T, class Container>
     void swap(stack<T, Container>& x, stack<T, Container>& y) noexcept(noexcept(x.swap(y)));
 }
@@ -8719,6 +8681,7 @@ namespace std {
     typedef typename Container::const_reference       const_reference;
     typedef typename Container::size_type             size_type;
     typedef          Container                        container_type;
+
   protected:
     Container c;
 
@@ -8737,8 +8700,8 @@ namespace std {
     const_reference   top() const       { return c.back(); }
     void push(const value_type& x)      { c.push_back(x); }
     void push(value_type&& x)           { c.push_back(std::move(x)); }
-    template <class... Args> void emplace(Args&&... args)
-      { c.emplace_back(std::forward<Args>(args)...); }
+    template <class... Args>
+      void emplace(Args&&... args)      { c.emplace_back(std::forward<Args>(args)...); }
     void pop()                          { c.pop_back(); }
     void swap(stack& s) noexcept(noexcept(swap(c, s.c)))
       { using std::swap; swap(c, s.c); }
@@ -8792,8 +8755,7 @@ If \tcode{uses_allocator<container_type, Alloc>::value} is \tcode{false}
 the constructors in this subclause shall not participate in overload resolution.
 
 \begin{itemdecl}
-template <class Alloc>
-  explicit stack(const Alloc& a);
+template <class Alloc> explicit stack(const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8802,8 +8764,7 @@ template <class Alloc>
 \end{itemdescr}
 
 \begin{itemdecl}
-template <class Alloc>
-  stack(const container_type& cont, const Alloc& a);
+template <class Alloc> stack(const container_type& cont, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8813,8 +8774,7 @@ second argument.
 \end{itemdescr}
 
 \begin{itemdecl}
-template <class Alloc>
-  stack(container_type&& cont, const Alloc& a);
+template <class Alloc> stack(container_type&& cont, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8824,8 +8784,7 @@ as the second argument.
 \end{itemdescr}
 
 \begin{itemdecl}
-template <class Alloc>
-  stack(const stack& s, const Alloc& a);
+template <class Alloc> stack(const stack& s, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8835,8 +8794,7 @@ as the second argument.
 \end{itemdescr}
 
 \begin{itemdecl}
-template <class Alloc>
-  stack(stack&& s, const Alloc& a);
+template <class Alloc> stack(stack&& s, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8850,8 +8808,7 @@ as the second argument.
 \indexlibrary{\idxcode{operator==}!\idxcode{stack}}%
 \begin{itemdecl}
 template <class T, class Container>
-    bool operator==(const stack<T, Container>& x,
-                    const stack<T, Container>& y);
+  bool operator==(const stack<T, Container>& x, const stack<T, Container>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8863,8 +8820,7 @@ template <class T, class Container>
 \indexlibrary{\idxcode{operator"!=}!\idxcode{stack}}%
 \begin{itemdecl}
 template <class T, class Container>
-    bool operator!=(const stack<T, Container>& x,
-                    const stack<T, Container>& y);
+  bool operator!=(const stack<T, Container>& x, const stack<T, Container>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8876,8 +8832,7 @@ template <class T, class Container>
 \indexlibrary{\idxcode{operator<}!\idxcode{stack}}%
 \begin{itemdecl}
 template <class T, class Container>
-    bool operator< (const stack<T, Container>& x,
-                    const stack<T, Container>& y);
+  bool operator< (const stack<T, Container>& x, const stack<T, Container>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8889,8 +8844,7 @@ template <class T, class Container>
 \indexlibrary{\idxcode{operator<=}!\idxcode{stack}}%
 \begin{itemdecl}
 template <class T, class Container>
-    bool operator<=(const stack<T, Container>& x,
-                    const stack<T, Container>& y);
+  bool operator<=(const stack<T, Container>& x, const stack<T, Container>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8902,8 +8856,7 @@ template <class T, class Container>
 \indexlibrary{\idxcode{operator>}!\idxcode{stack}}%
 \begin{itemdecl}
 template <class T, class Container>
-    bool operator> (const stack<T, Container>& x,
-                    const stack<T, Container>& y);
+  bool operator> (const stack<T, Container>& x, const stack<T, Container>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8915,8 +8868,7 @@ template <class T, class Container>
 \indexlibrary{\idxcode{operator>=}!\idxcode{stack}}%
 \begin{itemdecl}
 template <class T, class Container>
-    bool operator>=(const stack<T, Container>& x,
-                    const stack<T, Container>& y);
+    bool operator>=(const stack<T, Container>& x, const stack<T, Container>& y);
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
 Addresses Issue #400

This part of the clean-up changes only whitespace
* inserted before commas: `foo<A,B>` becomes `foo<A, B>`
* removed after namespace braces
* improved indentation consistency (e.g. in the groupings with `erase` and `swap`)
* removed some extraneous linebreaks for things that fit well on one line (mostly in the member function declarations that lead the descriptions)