### PR TITLE
[thread.lock.shared.cons] fix typos

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -2308,7 +2308,7 @@ shared_lock(shared_lock&& sl) noexcept;
 
 \begin{itemdescr}
 \pnum
-\postconditions \tcode{pm == \&sl_p.pm} and \tcode{owns == sl_p.owns} (where
+\postconditions \tcode{pm == sl_p.pm} and \tcode{owns == sl_p.owns} (where
 \tcode{sl_p} is the state of \tcode{sl} just prior to this construction),
 \tcode{sl.pm == nullptr} and \tcode{sl.owns == false}.
 \end{itemdescr}
@@ -2323,7 +2323,7 @@ shared_lock& operator=(shared_lock&& sl) noexcept;
 \effects If \tcode{owns} calls \tcode{pm->unlock_shared()}.
 
 \pnum
-\postconditions \tcode{pm == \&sl_p.pm} and \tcode{owns == sl_p.owns} (where
+\postconditions \tcode{pm == sl_p.pm} and \tcode{owns == sl_p.owns} (where
 \tcode{sl_p} is the state of \tcode{sl} just prior to this assignment),
 \tcode{sl.pm == nullptr} and \tcode{sl.owns == false}.
 \end{itemdescr}


### PR DESCRIPTION
From stl@

Too trivial for a library issue IMO.