### PR TITLE
[diff] Use paragraph numbering for changes.

### DIFF
--- a/source/grammar.tex
+++ b/source/grammar.tex
@@ -35,9 +35,6 @@ namespace-name:\br
 	identifier\br
 	namespace-alias
 
-original-namespace-name:\br
-	identifier
-
 namespace-alias:\br
 	identifier
 \end{bnf}

--- a/source/grammar.tex
+++ b/source/grammar.tex
@@ -32,7 +32,7 @@ typedef-name:\br
 
 \begin{bnf}
 namespace-name:\br
-	original-namespace-name\br
+	identifier\br
 	namespace-alias
 
 original-namespace-name:\br

--- a/tools/grambase.tex
+++ b/tools/grambase.tex
@@ -35,9 +35,6 @@ namespace-name:\br
 	identifier\br
 	namespace-alias
 
-original-namespace-name:\br
-	identifier
-
 namespace-alias:\br
 	identifier
 \end{bnf}

--- a/tools/grambase.tex
+++ b/tools/grambase.tex
@@ -32,7 +32,7 @@ typedef-name:\br
 
 \begin{bnf}
 namespace-name:\br
-	original-namespace-name\br
+	identifier\br
 	namespace-alias
 
 original-namespace-name:\br


### PR DESCRIPTION
Since changes in this chapter are currently not numbered, we have to cite them like:

  "In C++, the type of an enumerator is its enumeration. For more info see [diff.dcl] and scroll down a few pages past other stuff until you get to the bit about enums."

With the added numbering, we can instead say:

  "In C++, the type of an enumerator is its enumeration. For more info see [diff.dcl]p7."