### PR TITLE
Adding a bullet to [except.terminate] for condition variables

### DIFF
--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -1305,7 +1305,12 @@ an exception~(\ref{thread.thread.constr}), or
 \item%
 when the destructor or the copy assignment operator is invoked on an object
 of type \tcode{std::thread} that refers to a joinable thread
-(\ref{thread.thread.destr},~\ref{thread.thread.assign}).
+(\ref{thread.thread.destr},~\ref{thread.thread.assign}), or
+
+\item%
+when a call to a \tcode{wait()}, \tcode{wait_until()}, or \tcode{wait_for()}
+function on a condition variable~(\ref{thread.condition.condvar},~\ref{thread.condition.condvarany})
+fails to meet a postcondition.
 
 \end{itemize}
 


### PR DESCRIPTION
Pull request for updating the list of situations in which std::terminate() is called to include condition variables.