### PR TITLE
Consistency cleanups in [containers] (cf. Issue #400): Ordering, whitespace

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -2627,9 +2627,9 @@ namespace std {
     const_reverse_iterator crend() const noexcept;
 
     // capacity:
+    constexpr bool      empty() const noexcept;
     constexpr size_type size() const noexcept;
     constexpr size_type max_size() const noexcept;
-    constexpr bool      empty() const noexcept;
 
     // element access:
     reference                 operator[](size_type n);
@@ -2911,12 +2911,12 @@ namespace std {
     const_reverse_iterator crend() const noexcept;
 
     // \ref{deque.capacity}, capacity:
+    bool      empty() const noexcept;
     size_type size() const noexcept;
     size_type max_size() const noexcept;
     void      resize(size_type sz);
     void      resize(size_type sz, const T& c);
     void      shrink_to_fit();
-    bool      empty() const noexcept;
 
     // element access:
     reference       operator[](size_type n);
@@ -4721,12 +4721,12 @@ namespace std {
     const_reverse_iterator crend() const noexcept;
 
     // \ref{vector.capacity}, capacity:
+    bool      empty() const noexcept;
     size_type size() const noexcept;
     size_type max_size() const noexcept;
+    size_type capacity() const noexcept;
     void      resize(size_type sz);
     void      resize(size_type sz, const T& c);
-    size_type capacity() const noexcept;
-    bool      empty() const noexcept;
     void      reserve(size_type n);
     void      shrink_to_fit();
 
@@ -5194,11 +5194,11 @@ namespace std {
     const_reverse_iterator crend() const noexcept;
 
     // capacity:
+    bool      empty() const noexcept;
     size_type size() const noexcept;
     size_type max_size() const noexcept;
-    void      resize(size_type sz, bool c = false);
     size_type capacity() const noexcept;
-    bool      empty() const noexcept;
+    void      resize(size_type sz, bool c = false);
     void      reserve(size_type n);
     void      shrink_to_fit();
 
@@ -5623,10 +5623,8 @@ namespace std {
     template <class K> iterator       upper_bound(const K& x);
     template <class K> const_iterator upper_bound(const K& x) const;
 
-    pair<iterator,iterator>
-      equal_range(const key_type& x);
-    pair<const_iterator,const_iterator>
-      equal_range(const key_type& x) const;
+    pair<iterator, iterator>               equal_range(const key_type& x);
+    pair<const_iterator, const_iterator>   equal_range(const key_type& x) const;
     template <class K>
       pair<iterator, iterator>             equal_range(const K& x);
     template <class K>
@@ -6082,10 +6080,8 @@ namespace std {
     template <class K> iterator       upper_bound(const K& x);
     template <class K> const_iterator upper_bound(const K& x) const;
 
-    pair<iterator,iterator>
-      equal_range(const key_type& x);
-    pair<const_iterator,const_iterator>
-      equal_range(const key_type& x) const;
+    pair<iterator, iterator>               equal_range(const key_type& x);
+    pair<const_iterator, const_iterator>   equal_range(const key_type& x) const;
     template <class K>
       pair<iterator, iterator>             equal_range(const K& x);
     template <class K>
@@ -6373,7 +6369,7 @@ namespace std {
     template <class K> iterator       upper_bound(const K& x);
     template <class K> const_iterator upper_bound(const K& x) const;
 
-    pair<iterator,iterator>                equal_range(const key_type& x);
+    pair<iterator, iterator>               equal_range(const key_type& x);
     pair<const_iterator, const_iterator>   equal_range(const key_type& x) const;
     template <class K>
       pair<iterator, iterator>             equal_range(const K& x);
@@ -6621,21 +6617,21 @@ namespace std {
     template <class K> iterator       find(const K& x);
     template <class K> const_iterator find(const K& x) const;
 
-    size_type count(const key_type& x) const;
+    size_type      count(const key_type& x) const;
     template <class K> size_type count(const K& x) const;
 
-    iterator        lower_bound(const key_type& x);
-    const_iterator  lower_bound(const key_type& x) const;
+    iterator       lower_bound(const key_type& x);
+    const_iterator lower_bound(const key_type& x) const;
     template <class K> iterator       lower_bound(const K& x);
     template <class K> const_iterator lower_bound(const K& x) const;
 
-    iterator        upper_bound(const key_type& x);
-    const_iterator  upper_bound(const key_type& x) const;
+    iterator       upper_bound(const key_type& x);
+    const_iterator upper_bound(const key_type& x) const;
     template <class K> iterator       upper_bound(const K& x);
     template <class K> const_iterator upper_bound(const K& x) const;
 
-    pair<iterator,iterator>             equal_range(const key_type& x);
-    pair<const_iterator,const_iterator> equal_range(const key_type& x) const;
+    pair<iterator, iterator>               equal_range(const key_type& x);
+    pair<const_iterator, const_iterator>   equal_range(const key_type& x) const;
     template <class K>
       pair<iterator, iterator>             equal_range(const K& x);
     template <class K>
@@ -6946,11 +6942,6 @@ namespace std {
     unordered_map& operator=(initializer_list<value_type>);
     allocator_type get_allocator() const noexcept;
 
-    // size and capacity
-    bool empty() const noexcept;
-    size_type size() const noexcept;
-    size_type max_size() const noexcept;
-
     // iterators
     iterator       begin() noexcept;
     const_iterator begin() const noexcept;
@@ -6958,6 +6949,11 @@ namespace std {
     const_iterator end() const noexcept;
     const_iterator cbegin() const noexcept;
     const_iterator cend() const noexcept;
+
+    // size and capacity
+    bool      empty() const noexcept;
+    size_type size() const noexcept;
+    size_type max_size() const noexcept;
 
     // modifiers
     template <class... Args> pair<iterator, bool> emplace(Args&&... args);
@@ -7374,11 +7370,6 @@ namespace std {
     unordered_multimap& operator=(initializer_list<value_type>);
     allocator_type get_allocator() const noexcept;
 
-    // size and capacity
-    bool empty() const noexcept;
-    size_type size() const noexcept;
-    size_type max_size() const noexcept;
-
     // iterators
     iterator       begin() noexcept;
     const_iterator begin() const noexcept;
@@ -7386,6 +7377,11 @@ namespace std {
     const_iterator end() const noexcept;
     const_iterator cbegin() const noexcept;
     const_iterator cend() const noexcept;
+
+    // size and capacity
+    bool      empty() const noexcept;
+    size_type size() const noexcept;
+    size_type max_size() const noexcept;
 
     // modifiers
     template <class... Args> iterator emplace(Args&&... args);
@@ -7657,11 +7653,6 @@ namespace std {
     unordered_set& operator=(initializer_list<value_type>);
     allocator_type get_allocator() const noexcept;
 
-    // size and capacity
-    bool empty() const noexcept;
-    size_type size() const noexcept;
-    size_type max_size() const noexcept;
-
     // iterators
     iterator       begin() noexcept;
     const_iterator begin() const noexcept;
@@ -7669,6 +7660,11 @@ namespace std {
     const_iterator end() const noexcept;
     const_iterator cbegin() const noexcept;
     const_iterator cend() const noexcept;
+
+    // size and capacity
+    bool      empty() const noexcept;
+    size_type size() const noexcept;
+    size_type max_size() const noexcept;
 
     // modifiers
     template <class... Args> pair<iterator, bool> emplace(Args&&... args);
@@ -7908,11 +7904,6 @@ namespace std {
     unordered_multiset& operator=(initializer_list<value_type>);
     allocator_type get_allocator() const noexcept;
 
-    // size and capacity
-    bool empty() const noexcept;
-    size_type size() const noexcept;
-    size_type max_size() const noexcept;
-
     // iterators
     iterator       begin() noexcept;
     const_iterator begin() const noexcept;
@@ -7920,6 +7911,11 @@ namespace std {
     const_iterator end() const noexcept;
     const_iterator cbegin() const noexcept;
     const_iterator cend() const noexcept;
+
+    // size and capacity
+    bool      empty() const noexcept;
+    size_type size() const noexcept;
+    size_type max_size() const noexcept;
 
     // modifiers
     template <class... Args> iterator emplace(Args&&... args);
@@ -8414,7 +8410,8 @@ namespace std {
     void push(value_type&& x);
     template <class... Args> void emplace(Args&&... args);
     void pop();
-    void swap(priority_queue& q) noexcept(noexcept(swap(c, q.c)) && noexcept(swap(comp, q.comp)))
+    void swap(priority_queue& q) noexcept(noexcept(swap(c, q.c)) &&
+                                          noexcept(swap(comp, q.comp)))
       { using std::swap; swap(c, q.c); swap(comp, q.comp); }
   };
 


### PR DESCRIPTION
Addresses Issue #400

This part of the clean-up changes whitespace and ordering of members in the synopses.

Specifically:
* Add linebreak in `swap(priority_queue&)` as requested in the previous PR
* Add missing spaces after commas as requested in the previous PR
* Align `equal_range` members consistently
* Order `empty`, `size`, `max_size` members consistently in that order, and move "iterators" above "capacity" consistently.