### PR TITLE
[dcl.init.ref] Replace normative note with actual note.

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -3324,8 +3324,9 @@ void f() {
 \pnum
 A reference cannot be changed to refer to another object after initialization.
 \indextext{assignment!reference}%
-Note that initialization of a reference is treated very differently from assignment
-to it.
+\enternote
+Assignment to a reference assigns to the object referred to by the reference (\ref{expr.ass}).
+\exitnote
 \indextext{argument~passing!reference~and}%
 Argument passing (\ref{expr.call})
 \indextext{\idxcode{return}!reference~and}%


### PR DESCRIPTION
This rewording removes the subjective emphasis "very" from the normative text.