### PR TITLE
[support.dynamic] LWG2458 remove correct signatures

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -1523,15 +1523,13 @@ namespace std {
 void* operator new(std::size_t size);
 void* operator new(std::size_t size, const std::nothrow_t&) noexcept;
 void  operator delete(void* ptr) noexcept;
+void  operator delete(void* ptr, const std::nothrow_t&) noexcept;
 void  operator delete(void* ptr, std::size_t size) noexcept;
-void  operator delete(void* ptr, std::size_t size,
-                      const std::nothrow_t&) noexcept;
 void* operator new[](std::size_t size);
 void* operator new[](std::size_t size, const std::nothrow_t&) noexcept;
 void  operator delete[](void* ptr) noexcept;
+void  operator delete[](void* ptr, const std::nothrow_t&) noexcept;
 void  operator delete[](void* ptr, std::size_t size) noexcept;
-void  operator delete[](void* ptr, std::size_t size,
-                        const std::nothrow_t&) noexcept;
 
 void* operator new  (std::size_t size, void* ptr) noexcept;
 void* operator new[](std::size_t size, void* ptr) noexcept;


### PR DESCRIPTION
97e974390f5de39244b9178a27b729ae6bb5ce6c removed the wrong signatures, this puts them back and removes the ones actually removed by LWG 2458