### PR TITLE
Local definition of "char-like type" from Clause 21 referenced in Cla…

### DIFF
--- a/source/regex.tex
+++ b/source/regex.tex
@@ -12,7 +12,7 @@ searching.
 
 \pnum
 The following subclauses describe a basic regular expression class template and its
-traits that can handle char-like template arguments,
+traits that can handle char-like~(\ref{strings.general}) template arguments,
 two specializations of this class template that handle sequences of \tcode{char} and \tcode{wchar_t},
 a class template that holds the
 result of a regular expression match, a series of algorithms that allow a character

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -6,7 +6,7 @@
 \pnum
 This Clause describes components for manipulating sequences of
 any non-array POD~(\ref{basic.types}) type.
-In this Clause such types are called \term{char-like types},\indextext{char-like type}
+Such types are called \term{char-like types},\indextext{char-like type}
 and objects of
 char-like types are called \term{char-like objects}\indextext{char-like object} or
 simply \term{characters}.


### PR DESCRIPTION
…use 28

...so drop "In this Clause" from the definition in [strings.general] and add a
reference to the first use in [re.general].

See <https://groups.google.com/a/isocpp.org/forum/#!topic/std-discussion/dGc1exSnPps>
"Local definition of "char-like type" from Clause 21 referenced in Clause 28"
for a discussion of this (presumably editorial) issue.