### PR TITLE
Typographic fixes, spacing after \opt

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -30,7 +30,7 @@ make \grammarterm{class-name}{s}. An object of a class consists of a
 
 \begin{bnf}
 \nontermdef{class-specifier}\br
-    class-head \terminal{\{} member-specification\opt \terminal{\}}
+    class-head \terminal{\{} member-specification\opt{} \terminal{\}}
 \end{bnf}
 
 \begin{bnf}
@@ -453,7 +453,7 @@ ignored. A \grammarterm{typedef-name} shall not be used as the
 
 \begin{bnf}
 \nontermdef{member-declaration}\br
-    attribute-specifier-seq\opt decl-specifier-seq\opt member-declarator-list\opt \terminal{;}\br
+    attribute-specifier-seq\opt decl-specifier-seq\opt member-declarator-list\opt{} \terminal{;}\br
     function-definition\br
     using-declaration\br
     static_assert-declaration\br
@@ -472,7 +472,7 @@ ignored. A \grammarterm{typedef-name} shall not be used as the
 \nontermdef{member-declarator}\br
     declarator virt-specifier-seq\opt pure-specifier\opt\br
     declarator brace-or-equal-initializer\opt\br
-    identifier\opt attribute-specifier-seq\opt \terminal{:} constant-expression
+    identifier\opt attribute-specifier-seq\opt{} \terminal{:} constant-expression
 \end{bnf}
 
 \begin{bnf}
@@ -1398,7 +1398,7 @@ union U {
 A \grammarterm{member-declarator} of the form
 
 \begin{ncbnftab}
-identifier\opt  attribute-specifier-seq\opt \terminal{:} constant-expression
+identifier\opt  attribute-specifier-seq\opt{} \terminal{:} constant-expression
 \end{ncbnftab}
 
 \indextext{\idxcode{:}!field declaration}%

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -50,12 +50,12 @@ the form
 
 \begin{bnf}
 \nontermdef{alias-declaration}\br
-    \terminal{using} identifier attribute-specifier-seq\opt \terminal{=} type-id \terminal{;}
+    \terminal{using} identifier attribute-specifier-seq\opt{} \terminal{=} type-id \terminal{;}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{simple-declaration}\br
-    decl-specifier-seq init-declarator-list\opt \terminal{;}\br
+    decl-specifier-seq init-declarator-list\opt{} \terminal{;}\br
     attribute-specifier-seq decl-specifier-seq init-declarator-list \terminal{;}
 \end{bnf}
 
@@ -91,7 +91,7 @@ A
 \grammarterm{nodeclspec-function-declaration} of the form
 
 \begin{ncsimplebnf}
-attribute-specifier-seq\opt decl-specifier-seq\opt init-declarator-list\opt \terminal{;}
+attribute-specifier-seq\opt decl-specifier-seq\opt init-declarator-list\opt{} \terminal{;}
 \end{ncsimplebnf}
 
 is divided into three parts.
@@ -1786,7 +1786,7 @@ constants. Its name becomes an \grammarterm{enum-name}, within its scope.
 
 \begin{bnf}
 \nontermdef{enum-specifier}\br
-    enum-head \terminal{\{} enumerator-list\opt \terminal{\}}\br
+    enum-head \terminal{\{} enumerator-list\opt{} \terminal{\}}\br
     enum-head \terminal{\{} enumerator-list \terminal{, \}}
 \end{bnf}
 
@@ -1799,7 +1799,7 @@ constants. Its name becomes an \grammarterm{enum-name}, within its scope.
 
 \begin{bnf}
 \nontermdef{opaque-enum-declaration}\br
-    enum-key attribute-specifier-seq\opt identifier enum-base\opt \terminal{;}
+    enum-key attribute-specifier-seq\opt identifier enum-base\opt{} \terminal{;}
 \end{bnf}
 
 \begin{bnf}
@@ -2138,7 +2138,7 @@ is
 
 \begin{bnf}
 \nontermdef{unnamed-namespace-definition}\br
-        \terminal{inline\opt} \terminal{namespace} attribute-specifier-seq\opt \terminal{\{} namespace-body \terminal{\}}
+        \terminal{inline\opt} \terminal{namespace} attribute-specifier-seq\opt{} \terminal{\{} namespace-body \terminal{\}}
 \end{bnf}
 
 \begin{bnf}
@@ -2291,7 +2291,7 @@ An \grammarterm{unnamed-namespace-definition} behaves as if it were
 replaced by
 
 \begin{ncsimplebnf}
-\terminal{inline}\opt \terminal{namespace} \uniquens{} \terminal{\{ /* empty body */ \}}\br
+\terminal{inline}\opt{} \terminal{namespace} \uniquens{} \terminal{\{ /* empty body */ \}}\br
 \terminal{using namespace} \uniquens{} \terminal{;}\br
 \terminal{namespace} \uniquens{} \terminal{\{} namespace-body \terminal{\}}
 \end{ncsimplebnf}
@@ -2954,7 +2954,7 @@ specifies a dependent name~(\ref{temp.dep}), the name introduced by the
 
 \begin{bnf}
 \nontermdef{using-directive}\br
-    attribute-specifier-seq\opt \terminal{using  namespace} nested-name-specifier\opt namespace-name \terminal{;}
+    attribute-specifier-seq\opt{} \terminal{using  namespace} nested-name-specifier\opt namespace-name \terminal{;}
 \end{bnf}
 
 \pnum
@@ -3207,7 +3207,7 @@ be achieved using a \grammarterm{linkage-specification}:
 %
 \begin{bnf}
 \nontermdef{linkage-specification}\br
-    \terminal{extern} string-literal \terminal{\{} declaration-seq\opt \terminal{\}}\br
+    \terminal{extern} string-literal \terminal{\{} declaration-seq\opt{} \terminal{\}}\br
     \terminal{extern} string-literal declaration
 \end{bnf}
 
@@ -3449,8 +3449,8 @@ such as types, variables, names, blocks, or translation units.
 
 \begin{bnf}
 \nontermdef{alignment-specifier}\br
-  \terminal{alignas (} type-id \terminal{...}\opt \terminal{)}\br
-  \terminal{alignas (} constant-expression \terminal{...}\opt \terminal{)}
+  \terminal{alignas (} type-id \terminal{...}\opt{} \terminal{)}\br
+  \terminal{alignas (} constant-expression \terminal{...}\opt{} \terminal{)}
 \end{bnf}
 
 \begin{bnf}
@@ -3484,7 +3484,7 @@ such as types, variables, names, blocks, or translation units.
 
 \begin{bnf}
 \nontermdef{attribute-argument-clause}\br
-    \terminal{(} balanced-token-seq\opt \terminal{)}
+    \terminal{(} balanced-token-seq\opt{} \terminal{)}
 \end{bnf}
 
 \begin{bnf}
@@ -3495,9 +3495,9 @@ such as types, variables, names, blocks, or translation units.
 
 \begin{bnf}
 \nontermdef{balanced-token}\br
-    \terminal{(} balanced-token-seq\opt \terminal{)}\br
-    \terminal{[} balanced-token-seq\opt \terminal{]}\br
-    \terminal{\{} balanced-token-seq\opt \terminal{\}}\br
+    \terminal{(} balanced-token-seq\opt{} \terminal{)}\br
+    \terminal{[} balanced-token-seq\opt{} \terminal{]}\br
+    \terminal{\{} balanced-token-seq\opt{} \terminal{\}}\br
     \textnormal{any \grammarterm{token} other than a parenthesis, a bracket, or a brace}
 \end{bnf}
 

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -121,7 +121,7 @@ Declarators have the syntax
 \nontermdef{noptr-declarator}\br
     declarator-id attribute-specifier-seq\opt\br
     noptr-declarator parameters-and-qualifiers\br
-    noptr-declarator \terminal{[} constant-expression\opt \terminal{]} attribute-specifier-seq\opt\br
+    noptr-declarator \terminal{[} constant-expression\opt{} \terminal{]} attribute-specifier-seq\opt\br
     \terminal{(} ptr-declarator \terminal{)}
 \end{bnf}
 
@@ -218,7 +218,7 @@ of that type that omits the name of the entity.
 \begin{bnf}
 \nontermdef{noptr-abstract-declarator}\br
     noptr-abstract-declarator\opt parameters-and-qualifiers\br
-    noptr-abstract-declarator\opt \terminal{[} constant-expression\opt{} \terminal{]} attribute-specifier-seq\opt\br
+    noptr-abstract-declarator\opt{} \terminal{[} constant-expression\opt{} \terminal{]} attribute-specifier-seq\opt\br
     \terminal{(} ptr-abstract-declarator \terminal{)}
 \end{bnf}
 
@@ -231,7 +231,7 @@ of that type that omits the name of the entity.
 \begin{bnf}
 \nontermdef{noptr-abstract-pack-declarator}\br
     noptr-abstract-pack-declarator parameters-and-qualifiers\br
-    noptr-abstract-pack-declarator \terminal{[} constant-expression\opt\ \terminal{]} attribute-specifier-seq\opt\br
+    noptr-abstract-pack-declarator \terminal{[} constant-expression\opt{} \terminal{]} attribute-specifier-seq\opt\br
     \terminal{...}
 \end{bnf}
 
@@ -579,7 +579,7 @@ where
 has the form
 
 \begin{ncsimplebnf}
-\terminal{*} attribute-specifier-seq\opt cv-qualifier-seq\opt \terminal{D1}
+\terminal{*} attribute-specifier-seq\opt cv-qualifier-seq\opt{} \terminal{D1}
 \end{ncsimplebnf}
 
 and the type of the identifier in the declaration
@@ -693,8 +693,8 @@ where
 has either of the forms
 
 \begin{ncsimplebnf}
-\terminal{\&} attribute-specifier-seq\opt \terminal{D1}\br
-\terminal{\&\&} attribute-specifier-seq\opt \terminal{D1}
+\terminal{\&} attribute-specifier-seq\opt{} \terminal{D1}\br
+\terminal{\&\&} attribute-specifier-seq\opt{} \terminal{D1}
 \end{ncsimplebnf}
 
 and the type of the identifier in the declaration
@@ -999,7 +999,7 @@ where
 has the form
 
 \begin{ncsimplebnf}
-\terminal{D1 [} constant-expression\opt \terminal{]} attribute-specifier-seq\opt
+\terminal{D1 [} constant-expression\opt{} \terminal{]} attribute-specifier-seq\opt
 \end{ncsimplebnf}
 
 and the type of the identifier in the declaration
@@ -1376,7 +1376,7 @@ A type of either form is a \term{function type}.\footnote{As indicated by syntax
 \indextext{declaration!function}%
 \begin{bnf}
 \nontermdef{parameter-declaration-clause}\br
-parameter-declaration-list\opt \terminal{...}\opt\br
+parameter-declaration-list\opt{} \terminal{...}\opt\br
     parameter-declaration-list \terminal{, ...}
 \end{bnf}
 
@@ -1391,7 +1391,7 @@ parameter-declaration-list\opt \terminal{...}\opt\br
     attribute-specifier-seq\opt decl-specifier-seq declarator\br
     attribute-specifier-seq\opt decl-specifier-seq declarator \terminal{=} initializer-clause\br
     attribute-specifier-seq\opt decl-specifier-seq abstract-declarator\opt\br
-    attribute-specifier-seq\opt decl-specifier-seq abstract-declarator\opt \terminal{=} initializer-clause
+    attribute-specifier-seq\opt decl-specifier-seq abstract-declarator\opt{} \terminal{=} initializer-clause
 \end{bnf}
 
 The optional \grammarterm{attribute-specifier-seq} in a \grammarterm{parameter-declaration}
@@ -2194,7 +2194,7 @@ void f(const char* s = __func__);  // error: \tcode{__func__} is undeclared
 A function definition of the form:
 
 \begin{ncbnf}
-    attribute-specifier-seq\opt decl-specifier-seq\opt declarator virt-specifier-seq\opt \terminal{ = default ;}
+    attribute-specifier-seq\opt decl-specifier-seq\opt declarator virt-specifier-seq\opt{} \terminal{ = default ;}
 \end{ncbnf}
 
 is called an \grammarterm{explicitly-defaulted} definition.
@@ -2296,7 +2296,7 @@ nontrivial1::nontrivial1() = default;           // not first declaration
 A function definition of the form:
 
 \begin{ncbnf}
-    attribute-specifier-seq\opt decl-specifier-seq\opt declarator virt-specifier-seq\opt \terminal{ = delete ;}
+    attribute-specifier-seq\opt decl-specifier-seq\opt declarator virt-specifier-seq\opt{} \terminal{ = delete ;}
 \end{ncbnf}
 
 is called a \term{deleted definition}. A function with a

--- a/source/derived.tex
+++ b/source/derived.tex
@@ -31,7 +31,7 @@ the notation:
 \begin{bnf}
 \nontermdef{base-specifier}\br
     attribute-specifier-seq\opt base-type-specifier\br
-    attribute-specifier-seq\opt \terminal{virtual} access-specifier\opt base-type-specifier\br
+    attribute-specifier-seq\opt{} \terminal{virtual} access-specifier\opt base-type-specifier\br
     attribute-specifier-seq\opt access-specifier \terminal{virtual}\opt base-type-specifier
 \end{bnf}
 

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -676,7 +676,7 @@ or implicitly.
 
 \begin{bnf}
 \nontermdef{dynamic-exception-specification}\br
-    \terminal{throw (} type-id-list\opt \terminal{)}
+    \terminal{throw (} type-id-list\opt{} \terminal{)}
 \end{bnf}
 
 \begin{bnf}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -588,7 +588,7 @@ void abssort(float* x, unsigned N) {
 
 \begin{bnf}
 \nontermdef{lambda-introducer}\br
-    \terminal{[} lambda-capture\opt \terminal{]}
+    \terminal{[} lambda-capture\opt{} \terminal{]}
 \end{bnf}
 
 \begin{bnf}
@@ -1261,9 +1261,9 @@ Postfix expressions group left-to-right.
 \nontermdef{postfix-expression}\br
     primary-expression\br
     postfix-expression \terminal{[} expr-or-braced-init-list \terminal{]}\br
-    postfix-expression \terminal{(} expression-list\opt \terminal{)}\br
-    simple-type-specifier \terminal{(} expression-list\opt \terminal{)}\br
-    typename-specifier \terminal{(} expression-list\opt \terminal{)}\br
+    postfix-expression \terminal{(} expression-list\opt{} \terminal{)}\br
+    simple-type-specifier \terminal{(} expression-list\opt{} \terminal{)}\br
+    typename-specifier \terminal{(} expression-list\opt{} \terminal{)}\br
     simple-type-specifier braced-init-list\br
     typename-specifier braced-init-list\br
     postfix-expression \terminal{. template}\opt id-expression\br
@@ -2819,8 +2819,8 @@ object created by the \grammarterm{new-expression} has a cv-qualified type.
 
 \begin{bnf}
 \nontermdef{new-expression}\br
-    \terminal{::}\opt \terminal{new} new-placement\opt new-type-id new-initializer\opt \br
-    \terminal{::}\opt \terminal{new} new-placement\opt \terminal{(} type-id \terminal{)} new-initializer\opt
+    \terminal{::}\opt{} \terminal{new} new-placement\opt new-type-id new-initializer\opt \br
+    \terminal{::}\opt{} \terminal{new} new-placement\opt{} \terminal{(} type-id \terminal{)} new-initializer\opt
 \end{bnf}
 
 \indextext{\idxcode{new}!storage allocation}%
@@ -2849,7 +2849,7 @@ object created by the \grammarterm{new-expression} has a cv-qualified type.
 
 \begin{bnf}
 \nontermdef{new-initializer}\br
-    \terminal{(} expression-list\opt \terminal{)}\br
+    \terminal{(} expression-list\opt{} \terminal{)}\br
     braced-init-list
 \end{bnf}
 
@@ -3325,8 +3325,8 @@ object~(\ref{intro.object}) or array created by a
 
 \begin{bnf}
 \nontermdef{delete-expression}\br
-    \terminal{::}\opt \terminal{delete} cast-expression\br
-    \terminal{::}\opt \terminal{delete [ ]} cast-expression
+    \terminal{::}\opt{} \terminal{delete} cast-expression\br
+    \terminal{::}\opt{} \terminal{delete [ ]} cast-expression
 \end{bnf}
 
 The first alternative is for non-array objects, and the second is for arrays. Whenever

--- a/source/grammar.tex
+++ b/source/grammar.tex
@@ -276,7 +276,7 @@ naming a class is also a
 
 \begin{bnf}
 \nontermdef{character-literal}\br
-    encoding-prefix\opt \terminal{'} c-char-sequence \terminal{'}
+    encoding-prefix\opt{} \terminal{'} c-char-sequence \terminal{'}
 \end{bnf}
 
 \begin{bnf}
@@ -332,7 +332,7 @@ naming a class is also a
 
 \begin{bnf}
 \nontermdef{fractional-constant}\br
-    digit-sequence\opt \terminal{.} digit-sequence\br
+    digit-sequence\opt{} \terminal{.} digit-sequence\br
     digit-sequence \terminal{.}
 \end{bnf}
 
@@ -360,8 +360,8 @@ naming a class is also a
 
 \begin{bnf}
 \nontermdef{string-literal}\br
-    encoding-prefix\opt \terminal{"} s-char-sequence\opt \terminal{"}\br
-    encoding-prefix\opt \terminal{R} raw-string
+    encoding-prefix\opt{} \terminal{"} s-char-sequence\opt{} \terminal{"}\br
+    encoding-prefix\opt{} \terminal{R} raw-string
 \end{bnf}
 
 \begin{bnf}
@@ -380,7 +380,7 @@ naming a class is also a
 
 \begin{bnf}
 \nontermdef{raw-string}\br
-    \terminal{"} d-char-sequence\opt \terminal{(} r-char-sequence\opt \terminal{)} d-char-sequence\opt \terminal{"}
+    \terminal{"} d-char-sequence\opt{} \terminal{(} r-char-sequence\opt{} \terminal{)} d-char-sequence\opt{} \terminal{"}
 \end{bnf}
 
 \begin{bnf}
@@ -516,7 +516,7 @@ naming a class is also a
 
 \begin{bnf}
 \nontermdef{lambda-introducer}\br
-    \terminal{[} lambda-capture\opt \terminal{]}
+    \terminal{[} lambda-capture\opt{} \terminal{]}
 \end{bnf}
 
 \begin{bnf}
@@ -581,9 +581,9 @@ naming a class is also a
 \nontermdef{postfix-expression}\br
     primary-expression\br
     postfix-expression \terminal{[} expr-or-braced-init-list \terminal{]}\br
-    postfix-expression \terminal{(} expression-list\opt \terminal{)}\br
-    simple-type-specifier \terminal{(} expression-list\opt \terminal{)}\br
-    typename-specifier \terminal{(} expression-list\opt \terminal{)}\br
+    postfix-expression \terminal{(} expression-list\opt{} \terminal{)}\br
+    simple-type-specifier \terminal{(} expression-list\opt{} \terminal{)}\br
+    typename-specifier \terminal{(} expression-list\opt{} \terminal{)}\br
     simple-type-specifier braced-init-list\br
     typename-specifier braced-init-list\br
     postfix-expression \terminal{. template}\opt id-expression\br
@@ -635,8 +635,8 @@ naming a class is also a
 
 \begin{bnf}
 \nontermdef{new-expression}\br
-    \terminal{::}\opt \terminal{new} new-placement\opt new-type-id new-initializer\opt \br
-    \terminal{::}\opt \terminal{new} new-placement\opt \terminal{(} type-id \terminal{)} new-initializer\opt
+    \terminal{::}\opt{} \terminal{new} new-placement\opt new-type-id new-initializer\opt \br
+    \terminal{::}\opt{} \terminal{new} new-placement\opt{} \terminal{(} type-id \terminal{)} new-initializer\opt
 \end{bnf}
 
 \begin{bnf}
@@ -663,14 +663,14 @@ naming a class is also a
 
 \begin{bnf}
 \nontermdef{new-initializer}\br
-    \terminal{(} expression-list\opt \terminal{)}\br
+    \terminal{(} expression-list\opt{} \terminal{)}\br
     braced-init-list
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{delete-expression}\br
-    \terminal{::}\opt \terminal{delete} cast-expression\br
-    \terminal{::}\opt \terminal{delete [ ]} cast-expression
+    \terminal{::}\opt{} \terminal{delete} cast-expression\br
+    \terminal{::}\opt{} \terminal{delete [ ]} cast-expression
 \end{bnf}
 
 \begin{bnf}
@@ -810,18 +810,18 @@ naming a class is also a
 \begin{bnf}
 \nontermdef{labeled-statement}\br
     attribute-specifier-seq\opt identifier \terminal{:} statement\br
-    attribute-specifier-seq\opt \terminal{case} constant-expression \terminal{:} statement\br
-    attribute-specifier-seq\opt \terminal{default :} statement
+    attribute-specifier-seq\opt{} \terminal{case} constant-expression \terminal{:} statement\br
+    attribute-specifier-seq\opt{} \terminal{default :} statement
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{expression-statement}\br
-    expression\opt \terminal{;}
+    expression\opt{} \terminal{;}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{compound-statement}\br
-    \terminal{\{} statement-seq\opt \terminal{\}}
+    \terminal{\{} statement-seq\opt{} \terminal{\}}
 \end{bnf}
 
 \begin{bnf}
@@ -848,7 +848,7 @@ naming a class is also a
 \nontermdef{iteration-statement}\br
     \terminal{while (} condition \terminal{)} statement\br
     \terminal{do} statement \terminal{while (} expression \terminal{) ;}\br
-    \terminal{for (} for-init-statement condition\opt \terminal{;} expression\opt \terminal{)} statement\br
+    \terminal{for (} for-init-statement condition\opt{} \terminal{;} expression\opt{} \terminal{)} statement\br
     \terminal{for (} for-range-declaration \terminal{:} for-range-initializer \terminal{)} statement
 \end{bnf}
 
@@ -872,7 +872,7 @@ naming a class is also a
 \nontermdef{jump-statement}\br
     \terminal{break ;}\br
     \terminal{continue ;}\br
-    \terminal{return} expr-or-braced-init-list\opt \terminal{;}\br
+    \terminal{return} expr-or-braced-init-list\opt{} \terminal{;}\br
     \terminal{goto} identifier \terminal{;}
 \end{bnf}
 
@@ -922,12 +922,12 @@ naming a class is also a
 
 \begin{bnf}
 \nontermdef{alias-declaration}\br
-    \terminal{using} identifier attribute-specifier-seq\opt \terminal{=} type-id \terminal{;}
+    \terminal{using} identifier attribute-specifier-seq\opt{} \terminal{=} type-id \terminal{;}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{simple-declaration}\br
-    decl-specifier-seq init-declarator-list\opt \terminal{;}\br
+    decl-specifier-seq init-declarator-list\opt{} \terminal{;}\br
     attribute-specifier-seq decl-specifier-seq init-declarator-list \terminal{;}
 \end{bnf}
 
@@ -1060,7 +1060,7 @@ naming a class is also a
 
 \begin{bnf}
 \nontermdef{enum-specifier}\br
-    enum-head \terminal{\{} enumerator-list\opt \terminal{\}}\br
+    enum-head \terminal{\{} enumerator-list\opt{} \terminal{\}}\br
     enum-head \terminal{\{} enumerator-list \terminal{, \}}
 \end{bnf}
 
@@ -1073,7 +1073,7 @@ naming a class is also a
 
 \begin{bnf}
 \nontermdef{opaque-enum-declaration}\br
-    enum-key attribute-specifier-seq\opt identifier enum-base\opt \terminal{;}
+    enum-key attribute-specifier-seq\opt identifier enum-base\opt{} \terminal{;}
 \end{bnf}
 
 \begin{bnf}
@@ -1125,7 +1125,7 @@ naming a class is also a
 
 \begin{bnf}
 \nontermdef{unnamed-namespace-definition}\br
-        \terminal{inline\opt} \terminal{namespace} attribute-specifier-seq\opt \terminal{\{} namespace-body \terminal{\}}
+        \terminal{inline\opt} \terminal{namespace} attribute-specifier-seq\opt{} \terminal{\{} namespace-body \terminal{\}}
 \end{bnf}
 
 \begin{bnf}
@@ -1166,7 +1166,7 @@ naming a class is also a
 
 \begin{bnf}
 \nontermdef{using-directive}\br
-    attribute-specifier-seq\opt \terminal{using  namespace} nested-name-specifier\opt namespace-name \terminal{;}
+    attribute-specifier-seq\opt{} \terminal{using  namespace} nested-name-specifier\opt namespace-name \terminal{;}
 \end{bnf}
 
 \begin{bnf}
@@ -1176,7 +1176,7 @@ naming a class is also a
 
 \begin{bnf}
 \nontermdef{linkage-specification}\br
-    \terminal{extern} string-literal \terminal{\{} declaration-seq\opt \terminal{\}}\br
+    \terminal{extern} string-literal \terminal{\{} declaration-seq\opt{} \terminal{\}}\br
     \terminal{extern} string-literal declaration
 \end{bnf}
 
@@ -1193,8 +1193,8 @@ naming a class is also a
 
 \begin{bnf}
 \nontermdef{alignment-specifier}\br
-  \terminal{alignas (} type-id \terminal{...}\opt \terminal{)}\br
-  \terminal{alignas (} constant-expression \terminal{...}\opt \terminal{)}
+  \terminal{alignas (} type-id \terminal{...}\opt{} \terminal{)}\br
+  \terminal{alignas (} constant-expression \terminal{...}\opt{} \terminal{)}
 \end{bnf}
 
 \begin{bnf}
@@ -1228,7 +1228,7 @@ naming a class is also a
 
 \begin{bnf}
 \nontermdef{attribute-argument-clause}\br
-    \terminal{(} balanced-token-seq\opt \terminal{)}
+    \terminal{(} balanced-token-seq\opt{} \terminal{)}
 \end{bnf}
 
 \begin{bnf}
@@ -1239,9 +1239,9 @@ naming a class is also a
 
 \begin{bnf}
 \nontermdef{balanced-token}\br
-    \terminal{(} balanced-token-seq\opt \terminal{)}\br
-    \terminal{[} balanced-token-seq\opt \terminal{]}\br
-    \terminal{\{} balanced-token-seq\opt \terminal{\}}\br
+    \terminal{(} balanced-token-seq\opt{} \terminal{)}\br
+    \terminal{[} balanced-token-seq\opt{} \terminal{]}\br
+    \terminal{\{} balanced-token-seq\opt{} \terminal{\}}\br
     \textnormal{any \grammarterm{token} other than a parenthesis, a bracket, or a brace}
 \end{bnf}
 
@@ -1274,7 +1274,7 @@ naming a class is also a
 \nontermdef{noptr-declarator}\br
     declarator-id attribute-specifier-seq\opt\br
     noptr-declarator parameters-and-qualifiers\br
-    noptr-declarator \terminal{[} constant-expression\opt \terminal{]} attribute-specifier-seq\opt\br
+    noptr-declarator \terminal{[} constant-expression\opt{} \terminal{]} attribute-specifier-seq\opt\br
     \terminal{(} ptr-declarator \terminal{)}
 \end{bnf}
 
@@ -1340,7 +1340,7 @@ naming a class is also a
 \begin{bnf}
 \nontermdef{noptr-abstract-declarator}\br
     noptr-abstract-declarator\opt parameters-and-qualifiers\br
-    noptr-abstract-declarator\opt \terminal{[} constant-expression\opt{} \terminal{]} attribute-specifier-seq\opt\br
+    noptr-abstract-declarator\opt{} \terminal{[} constant-expression\opt{} \terminal{]} attribute-specifier-seq\opt\br
     \terminal{(} ptr-abstract-declarator \terminal{)}
 \end{bnf}
 
@@ -1353,13 +1353,13 @@ naming a class is also a
 \begin{bnf}
 \nontermdef{noptr-abstract-pack-declarator}\br
     noptr-abstract-pack-declarator parameters-and-qualifiers\br
-    noptr-abstract-pack-declarator \terminal{[} constant-expression\opt\ \terminal{]} attribute-specifier-seq\opt\br
+    noptr-abstract-pack-declarator \terminal{[} constant-expression\opt{} \terminal{]} attribute-specifier-seq\opt\br
     \terminal{...}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{parameter-declaration-clause}\br
-parameter-declaration-list\opt \terminal{...}\opt\br
+parameter-declaration-list\opt{} \terminal{...}\opt\br
     parameter-declaration-list \terminal{, ...}
 \end{bnf}
 
@@ -1374,7 +1374,7 @@ parameter-declaration-list\opt \terminal{...}\opt\br
     attribute-specifier-seq\opt decl-specifier-seq declarator\br
     attribute-specifier-seq\opt decl-specifier-seq declarator \terminal{=} initializer-clause\br
     attribute-specifier-seq\opt decl-specifier-seq abstract-declarator\opt\br
-    attribute-specifier-seq\opt decl-specifier-seq abstract-declarator\opt \terminal{=} initializer-clause
+    attribute-specifier-seq\opt decl-specifier-seq abstract-declarator\opt{} \terminal{=} initializer-clause
 \end{bnf}
 
 \begin{bnf}
@@ -1436,7 +1436,7 @@ function-body:\br
 
 \begin{bnf}
 \nontermdef{class-specifier}\br
-    class-head \terminal{\{} member-specification\opt \terminal{\}}
+    class-head \terminal{\{} member-specification\opt{} \terminal{\}}
 \end{bnf}
 
 \begin{bnf}
@@ -1470,7 +1470,7 @@ function-body:\br
 
 \begin{bnf}
 \nontermdef{member-declaration}\br
-    attribute-specifier-seq\opt decl-specifier-seq\opt member-declarator-list\opt \terminal{;}\br
+    attribute-specifier-seq\opt decl-specifier-seq\opt member-declarator-list\opt{} \terminal{;}\br
     function-definition\br
     using-declaration\br
     static_assert-declaration\br
@@ -1489,7 +1489,7 @@ function-body:\br
 \nontermdef{member-declarator}\br
     declarator virt-specifier-seq\opt pure-specifier\opt\br
     declarator brace-or-equal-initializer\opt\br
-    identifier\opt attribute-specifier-seq\opt \terminal{:} constant-expression
+    identifier\opt attribute-specifier-seq\opt{} \terminal{:} constant-expression
 \end{bnf}
 
 \begin{bnf}
@@ -1525,7 +1525,7 @@ function-body:\br
 \begin{bnf}
 \nontermdef{base-specifier}\br
     attribute-specifier-seq\opt base-type-specifier\br
-    attribute-specifier-seq\opt \terminal{virtual} access-specifier\opt base-type-specifier\br
+    attribute-specifier-seq\opt{} \terminal{virtual} access-specifier\opt base-type-specifier\br
     attribute-specifier-seq\opt access-specifier \terminal{virtual}\opt base-type-specifier
 \end{bnf}
 
@@ -1577,7 +1577,7 @@ function-body:\br
 
 \begin{bnf}
 \nontermdef{mem-initializer}\br
-    mem-initializer-id \terminal{(} expression-list\opt \terminal{)}\br
+    mem-initializer-id \terminal{(} expression-list\opt{} \terminal{)}\br
     mem-initializer-id braced-init-list
 \end{bnf}
 
@@ -1632,9 +1632,9 @@ function-body:\br
 \begin{bnf}
 \nontermdef{type-parameter}\br
   type-parameter-key \terminal{...}\opt identifier\opt\br
-  type-parameter-key identifier\opt \terminal{=} type-id\br
+  type-parameter-key identifier\opt{} \terminal{=} type-id\br
   \terminal{template <} template-parameter-list \terminal{>} type-parameter-key \terminal{...}\opt identifier\opt\br
-  \terminal{template <} template-parameter-list \terminal{>} type-parameter-key identifier\opt \terminal{=} id-expression
+  \terminal{template <} template-parameter-list \terminal{>} type-parameter-key identifier\opt{} \terminal{=} id-expression
 \end{bnf}
 
 \begin{bnf}
@@ -1645,14 +1645,14 @@ function-body:\br
 
 \begin{bnf}
 \nontermdef{simple-template-id}\br
-  template-name \terminal{<} template-argument-list\opt \terminal{>}
+  template-name \terminal{<} template-argument-list\opt{} \terminal{>}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{template-id}\br
   simple-template-id\br
-  operator-function-id \terminal{<} template-argument-list\opt \terminal{>}\br
-  literal-operator-id \terminal{<} template-argument-list\opt \terminal{>}
+  operator-function-id \terminal{<} template-argument-list\opt{} \terminal{>}\br
+  literal-operator-id \terminal{<} template-argument-list\opt{} \terminal{>}
 \end{bnf}
 
 \begin{bnf}
@@ -1726,7 +1726,7 @@ function-body:\br
 
 \begin{bnf}
 \nontermdef{dynamic-exception-specification}\br
-    \terminal{throw (} type-id-list\opt \terminal{)}
+    \terminal{throw (} type-id-list\opt{} \terminal{)}
 \end{bnf}
 
 \begin{bnf}
@@ -1799,7 +1799,7 @@ function-body:\br
 \nontermdef{control-line}\br
 \>\terminal{\# include}\>\>pp-tokens new-line\br
 \>\terminal{\# define}\>\>identifier replacement-list new-line\br
-\>\terminal{\# define}\>\>identifier lparen identifier-list\opt \terminal{)} replacement-list new-line\br
+\>\terminal{\# define}\>\>identifier lparen identifier-list\opt{} \terminal{)} replacement-list new-line\br
 \>\terminal{\# define}\>\>identifier lparen \terminal{... )} replacement-list new-line\br
 \>\terminal{\# define}\>\>identifier lparen identifier-list, \terminal{... )} replacement-list new-line\br
 \>\terminal{\# undef}\>\>identifier new-line\br
@@ -1811,7 +1811,7 @@ function-body:\br
 
 \begin{bnf}
 \nontermdef{text-line}\br
-    pp-tokens\opt{} new-line
+    pp-tokens\opt new-line
 \end{bnf}
 
 \begin{bnf}

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -432,7 +432,7 @@ An optional terminal or non-terminal symbol is indicated by the subscript
 ``\opt'', so
 
 \begin{ncbnf}
-\terminal{\{} expression\opt \terminal{\}}
+\terminal{\{} expression\opt{} \terminal{\}}
 \end{ncbnf}
 
 indicates an optional expression enclosed in braces.%

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -306,7 +306,7 @@ parenthesis is identified. The raw string literal is defined as the shortest seq
 of characters that matches the raw-string pattern
 
 \begin{ncbnf}
-encoding-prefix\opt \terminal{R} raw-string
+encoding-prefix\opt{} \terminal{R} raw-string
 \end{ncbnf}
 
 \item Otherwise, if the next three characters are \tcode{<::} and the subsequent character
@@ -983,7 +983,7 @@ that cannot be represented by any of the allowed types.
 \indextext{literal!character}%
 \begin{bnf}
 \nontermdef{character-literal}\br
-    encoding-prefix\opt \terminal{'} c-char-sequence \terminal{'}
+    encoding-prefix\opt{} \terminal{'} c-char-sequence \terminal{'}
 \end{bnf}
 
 \begin{bnf}
@@ -1208,7 +1208,7 @@ so long as the same results are obtained. \exitnote
 
 \begin{bnf}
 \nontermdef{fractional-constant}\br
-    digit-sequence\opt \terminal{.} digit-sequence\br
+    digit-sequence\opt{} \terminal{.} digit-sequence\br
     digit-sequence \terminal{.}
 \end{bnf}
 
@@ -1277,8 +1277,8 @@ values for its type, the program is ill-formed.
 \indextext{literal!string}%
 \begin{bnf}
 \nontermdef{string-literal}\br
-    encoding-prefix\opt \terminal{"} s-char-sequence\opt \terminal{"}\br
-    encoding-prefix\opt \terminal{R} raw-string
+    encoding-prefix\opt{} \terminal{"} s-char-sequence\opt{} \terminal{"}\br
+    encoding-prefix\opt{} \terminal{R} raw-string
 \end{bnf}
 
 \begin{bnf}
@@ -1297,7 +1297,7 @@ values for its type, the program is ill-formed.
 
 \begin{bnf}
 \nontermdef{raw-string}\br
-    \terminal{"} d-char-sequence\opt \terminal{(} r-char-sequence\opt \terminal{)} d-char-sequence\opt \terminal{"}
+    \terminal{"} d-char-sequence\opt{} \terminal{(} r-char-sequence\opt{} \terminal{)} d-char-sequence\opt{} \terminal{"}
 \end{bnf}
 
 \begin{bnf}

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -659,7 +659,7 @@ contexts.
 In a function call~(\ref{expr.call})
 
 \begin{ncsimplebnf}
-postfix-expression \terminal{(} expression-list\opt \terminal{)}
+postfix-expression \terminal{(} expression-list\opt{} \terminal{)}
 \end{ncsimplebnf}
 
 if the \grammarterm{postfix-expression} denotes a set of overloaded functions and/or
@@ -830,7 +830,7 @@ In addition, for each non-explicit conversion function declared in \tcode{T} of 
 form
 
 \begin{ncsimplebnf}
-\terminal{operator} conversion-type-id \terminal{(\,)} cv-qualifier ref-qualifier\opt exception-specification\opt attribute-specifier-seq\opt \terminal{;}
+\terminal{operator} conversion-type-id \terminal{(\,)} cv-qualifier ref-qualifier\opt exception-specification\opt attribute-specifier-seq\opt{} \terminal{;}
 \end{ncsimplebnf}
 
 where
@@ -3061,7 +3061,7 @@ It can have default arguments.
 It implements the function call syntax
 
 \begin{ncsimplebnf}
-postfix-expression \terminal{(} expression-list\opt \terminal{)}
+postfix-expression \terminal{(} expression-list\opt{} \terminal{)}
 \end{ncsimplebnf}
 
 where the

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -85,7 +85,7 @@ within what would otherwise be an invocation of a function-like macro.
 \nontermdef{control-line}\br
 \>\terminal{\# include}\>\>pp-tokens new-line\br
 \>\terminal{\# define}\>\>identifier replacement-list new-line\br
-\>\terminal{\# define}\>\>identifier lparen identifier-list\opt \terminal{)} replacement-list new-line\br
+\>\terminal{\# define}\>\>identifier lparen identifier-list\opt{} \terminal{)} replacement-list new-line\br
 \>\terminal{\# define}\>\>identifier lparen \terminal{... )} replacement-list new-line\br
 \>\terminal{\# define}\>\>identifier lparen identifier-list, \terminal{... )} replacement-list new-line\br
 \>\terminal{\# undef}\>\>identifier new-line\br
@@ -97,7 +97,7 @@ within what would otherwise be an invocation of a function-like macro.
 
 \begin{bnf}
 \nontermdef{text-line}\br
-    pp-tokens\opt{} new-line
+    pp-tokens\opt new-line
 \end{bnf}
 
 \begin{bnf}
@@ -680,7 +680,7 @@ specified below.
 A preprocessing directive of the form
 
 \begin{ncsimplebnf}
-\terminal{\# define} identifier lparen identifier-list\opt \terminal{)} replacement-list new-line\br
+\terminal{\# define} identifier lparen identifier-list\opt{} \terminal{)} replacement-list new-line\br
 \terminal{\# define} identifier lparen \terminal{...} \terminal{)} replacement-list new-line\br
 \terminal{\# define} identifier lparen identifier-list \terminal{, ...} \terminal{)} replacement-list new-line\br
 \end{ncsimplebnf}
@@ -1157,7 +1157,7 @@ the behavior is undefined.
 A preprocessing directive of the form
 
 \begin{ncsimplebnf}
-\terminal{\# line} digit-sequence \terminal{"} s-char-sequence\opt \terminal{"} new-line
+\terminal{\# line} digit-sequence \terminal{"} s-char-sequence\opt{} \terminal{"} new-line
 \end{ncsimplebnf}
 
 sets the presumed line number similarly and changes the

--- a/source/special.tex
+++ b/source/special.tex
@@ -1554,7 +1554,7 @@ which has the form
 
 \begin{bnf}
 \nontermdef{mem-initializer}\br
-    mem-initializer-id \terminal{(} expression-list\opt \terminal{)}\br
+    mem-initializer-id \terminal{(} expression-list\opt{} \terminal{)}\br
     mem-initializer-id braced-init-list
 \end{bnf}
 

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -35,8 +35,8 @@ A statement can be labeled.
 \begin{bnf}
 \nontermdef{labeled-statement}\br
     attribute-specifier-seq\opt identifier \terminal{:} statement\br
-    attribute-specifier-seq\opt \terminal{case} constant-expression \terminal{:} statement\br
-    attribute-specifier-seq\opt \terminal{default :} statement
+    attribute-specifier-seq\opt{} \terminal{case} constant-expression \terminal{:} statement\br
+    attribute-specifier-seq\opt{} \terminal{default :} statement
 \end{bnf}
 
 The optional \grammarterm{attribute-specifier-seq} appertains to the label. An identifier label declares the identifier. The only use of an
@@ -65,7 +65,7 @@ Expression statements have the form
 
 \begin{bnf}
 \nontermdef{expression-statement}\br
-    expression\opt \terminal{;}
+    expression\opt{} \terminal{;}
 \end{bnf}
 
 The expression is
@@ -97,7 +97,7 @@ provided.
 
 \begin{bnf}
 \nontermdef{compound-statement}\br
-    \terminal{\{} statement-seq\opt \terminal{\}}
+    \terminal{\{} statement-seq\opt{} \terminal{\}}
 \end{bnf}
 
 \begin{bnf}
@@ -323,7 +323,7 @@ Iteration statements specify looping.
 \nontermdef{iteration-statement}\br
     \terminal{while (} condition \terminal{)} statement\br
     \terminal{do} statement \terminal{while (} expression \terminal{) ;}\br
-    \terminal{for (} for-init-statement condition\opt \terminal{;} expression\opt \terminal{)} statement\br
+    \terminal{for (} for-init-statement condition\opt{} \terminal{;} expression\opt{} \terminal{)} statement\br
     \terminal{for (} for-range-declaration \terminal{:} for-range-initializer \terminal{)} statement
 \end{bnf}
 
@@ -458,7 +458,7 @@ place after each execution of the statement.
 The \tcode{for} statement
 
 \begin{ncbnf}
-\terminal{for (} for-init-statement condition\opt \terminal{;} expression\opt \terminal{)} statement
+\terminal{for (} for-init-statement condition\opt{} \terminal{;} expression\opt{} \terminal{)} statement
 \end{ncbnf}
 
 is equivalent to
@@ -607,7 +607,7 @@ Jump statements unconditionally transfer control.
 \nontermdef{jump-statement}\br
     \terminal{break ;}\br
     \terminal{continue ;}\br
-    \terminal{return} expr-or-braced-init-list\opt \terminal{;}\br
+    \terminal{return} expr-or-braced-init-list\opt{} \terminal{;}\br
     \terminal{goto} identifier \terminal{;}
 \end{bnf}
 

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -161,9 +161,9 @@ is:
 \begin{bnf}
 \nontermdef{type-parameter}\br
   type-parameter-key \terminal{...}\opt identifier\opt\br
-  type-parameter-key identifier\opt \terminal{=} type-id\br
+  type-parameter-key identifier\opt{} \terminal{=} type-id\br
   \terminal{template <} template-parameter-list \terminal{>} type-parameter-key \terminal{...}\opt identifier\opt\br
-  \terminal{template <} template-parameter-list \terminal{>} type-parameter-key identifier\opt \terminal{=} id-expression
+  \terminal{template <} template-parameter-list \terminal{>} type-parameter-key identifier\opt{} \terminal{=} id-expression
 \end{bnf}
 
 \begin{bnf}
@@ -530,14 +530,14 @@ A template specialization~(\ref{temp.spec}) can be referred to by a
 
 \begin{bnf}
 \nontermdef{simple-template-id}\br
-  template-name \terminal{<} template-argument-list\opt \terminal{>}
+  template-name \terminal{<} template-argument-list\opt{} \terminal{>}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{template-id}\br
   simple-template-id\br
-  operator-function-id \terminal{<} template-argument-list\opt \terminal{>}\br
-  literal-operator-id \terminal{<} template-argument-list\opt \terminal{>}
+  operator-function-id \terminal{<} template-argument-list\opt{} \terminal{>}\br
+  literal-operator-id \terminal{<} template-argument-list\opt{} \terminal{>}
 \end{bnf}
 
 \begin{bnf}
@@ -3503,7 +3503,7 @@ as described in this subclause.
 In an expression of the form:
 
 \begin{ncbnftab}
-postfix-expression \terminal{(} expression-list\opt \terminal{)}
+postfix-expression \terminal{(} expression-list\opt{} \terminal{)}
 \end{ncbnftab}
 
 where the
@@ -3984,9 +3984,9 @@ or
 is dependent, even if any subexpression is type-dependent:
 
 \begin{ncbnftab}
-simple-type-specifier \terminal{(} expression-list\opt \terminal{)}\br
+simple-type-specifier \terminal{(} expression-list\opt{} \terminal{)}\br
 \terminal{::\opt new} new-placement\opt new-type-id new-initializer\opt\br
-\terminal{::\opt new} new-placement\opt \terminal{(} type-id \terminal{)} new-initializer\opt\br
+\terminal{::\opt new} new-placement\opt{} \terminal{(} type-id \terminal{)} new-initializer\opt\br
 \terminal{dynamic_cast <} type-id \terminal{> (} expression \terminal{)}\br
 \terminal{static_cast <} type-id \terminal{> (} expression \terminal{)}\br
 \terminal{const_cast <} type-id \terminal{> (} expression \terminal{)}\br
@@ -4117,7 +4117,7 @@ or
 is value-dependent:
 
 \begin{ncbnftab}
-simple-type-specifier \terminal{(} expression-list\opt \terminal{)}\br
+simple-type-specifier \terminal{(} expression-list\opt{} \terminal{)}\br
 \terminal{static_cast <} type-id \terminal{> (} expression \terminal{)}\br
 \terminal{const_cast <} type-id \terminal{> (} expression \terminal{)}\br
 \terminal{reinterpret_cast <} type-id \terminal{> (} expression \terminal{)}\br


### PR DESCRIPTION
* occurrences of "\opt \terminal{" apparently always require "\opt{}" to not eat
  the intervening space (despite the \xspace in the definition of \opt)

* cleaned up two occurrences of "\opt\ " (in

    noptr-abstract-pack-declarator \terminal{[} constant-expression\opt\ \terminal{]} attribute-specifier-seq\opt\br

  in declarators.tex and grammar.tex) to consistenly use "\opt{}" instead

* cleaned up two occurrences of "\opt{}" (in

    pp-tokens\opt{} new-line

  in grammar.tex and preprocessor.tex) that did not need the "{}"