### PR TITLE
Unify the spelling of one-definition rule to be consistent.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -242,7 +242,7 @@ an incomplete type~(\ref{basic.types}).
 \indextext{class!definition}%
 \indextext{enumerator!definition}%
 \indextext{one-definition~rule|(}%
-\rSec1[basic.def.odr]{One definition rule}
+\rSec1[basic.def.odr]{One-definition rule}
 
 \pnum
 No translation unit shall contain more than one definition of any

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -1243,7 +1243,7 @@ are constant iterators. It is unspecified whether or not
 and
 \tcode{const_iterator}
 are the same type.
-\enternote \tcode{iterator} and \tcode{const_iterator} have identical semantics in this case, and \tcode{iterator} is convertible to \tcode{const_iterator}. Users can avoid violating the One Definition Rule by always using \tcode{const_iterator} in their function parameter lists. \exitnote
+\enternote \tcode{iterator} and \tcode{const_iterator} have identical semantics in this case, and \tcode{iterator} is convertible to \tcode{const_iterator}. Users can avoid violating the one-definition rule by always using \tcode{const_iterator} in their function parameter lists. \exitnote
 
 \pnum
 The associative containers meet all the requirements of Allocator-aware
@@ -1744,7 +1744,7 @@ iterators. It is unspecified whether or not \tcode{iterator} and
 \tcode{const_iterator} are the same type.
 \enternote \tcode{iterator} and \tcode{const_iterator} have identical
 semantics in this case, and \tcode{iterator} is convertible to
-\tcode{const_iterator}. Users can avoid violating the One Definition Rule
+\tcode{const_iterator}. Users can avoid violating the one-definition rule
 by always using \tcode{const_iterator} in their function parameter lists.
 \exitnote
 

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -289,7 +289,7 @@ possible behaviors is usually delineated by this International Standard.
 \indexdefn{program!well-formed}%
 \definition{well-formed program}{defns.well.formed}
 \Cpp  program constructed according to the syntax rules, diagnosable
-semantic rules, and the One Definition Rule~(\ref{basic.def.odr}).%
+semantic rules, and the one-definition rule ~(\ref{basic.def.odr}).%
 \indextext{definitions|)}
 
 \rSec1[intro.compliance]{Implementation compliance}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -119,11 +119,11 @@ A template, a template explicit specialization~(\ref{temp.expl.spec}), and a cla
 template partial specialization shall not have C linkage. Use of a linkage specification
 other than C or C++ with any of these constructs is conditionally-supported, with
 \impldef{semantics of linkage specification on templates} semantics.
-Template definitions shall obey the one definition rule~(\ref{basic.def.odr}).
+Template definitions shall obey the one-definition rule~(\ref{basic.def.odr}).
 \enternote
 Default arguments for function templates and for member functions of
 class templates are considered definitions for the purpose of template
-instantiation~(\ref{temp.decls}) and must also obey the one definition rule.
+instantiation~(\ref{temp.decls}) and must also obey the one-definition rule.
 \exitnote
 
 \pnum
@@ -2563,8 +2563,8 @@ void h(int* p) {
 \exitexample
 
 \pnum
-Such specializations are distinct functions and do not violate the one
-definition rule~(\ref{basic.def.odr}).
+Such specializations are distinct functions and do not violate the one-definition
+rule~(\ref{basic.def.odr}).
 
 \pnum
 The signature of a function template
@@ -2615,7 +2615,7 @@ For example, a template type parameter can be used in the
 Two expressions involving template parameters are considered
 \term{equivalent}
 if two function definitions containing the expressions would satisfy
-the one definition rule~(\ref{basic.def.odr}), except that the tokens used
+the one-definition rule~(\ref{basic.def.odr}), except that the tokens used
 to name the template parameters may differ as long as a token used to
 name a template parameter in one expression is replaced by another token
 that names the same template parameter in the other expression. For
@@ -4285,7 +4285,7 @@ within a translation unit.
 A specialization for any template may have points of instantiation in multiple
 translation units.
 If two different points of instantiation give a template specialization
-different meanings according to the one definition rule~(\ref{basic.def.odr}),
+different meanings according to the one-definition rule~(\ref{basic.def.odr}),
 the program is ill-formed, no diagnostic required.
 
 \rSec3[temp.dep.candidate]{Candidate functions}


### PR DESCRIPTION
Consistency is better than inconsistency, and the general consensus on the editorial list was to hyphenate one-definition to clarify ambiguity.