### PR TITLE
Fix misuse of cv-unqualified as a grammar term

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3577,7 +3577,7 @@ types~(\ref{basic.type.qualifier}) are collectively called
 \indextext{scalar~type}%
 \term{scalar types}. Scalar types,
 POD classes (Clause~\ref{class}), arrays of such types and
-\grammarterm{cv-qualified} versions of these
+cv-qualified versions of these
 types~(\ref{basic.type.qualifier}) are collectively called
 \indextext{type!POD}%
 \term{POD types}.


### PR DESCRIPTION
cv-unqualified is not a grammar term in this context, similar to other uses in the same paragraph.