### PR TITLE
[diff.cpp11] Supply a compatibility note for CWG1560

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1369,6 +1369,40 @@ might match a predefined usual (non-placement)
 program is ill-formed, as it was for class member allocation functions and
 deallocation functions~(\ref{expr.new}).
 
+\rSec2[diff.cpp11.expr]{Clause \ref{expr}: expressions}
+
+\ref{expr.cond}
+\change A conditional expression with a throw expression as its second or third
+operand keeps the type and value category of the other operand.
+\rationale Formerly mandated conversions (lvalue-to-rvalue (\ref{conv.lval}),
+array-to-pointer (\ref{conv.array}), and function-to-pointer (\ref{conv.func})
+standard conversions), especially the creation of the temporary due to
+lvalue-to-rvalue conversion, were considered gratuitous and surprising.
+\effect Valid \CppXI code that relies on the conversions may behave differently
+in this International Standard:
+
+\begin{codeblock}
+struct S {
+  int x = 1;
+  void mf() { x = 2; }
+};
+int f(bool cond) {
+  S s;
+  (cond ? s : throw 0).mf();
+  return s.x;
+}
+\end{codeblock}
+
+In \CppXI, \tcode{f(true)} returns \tcode{1}. In this International Standard,
+it returns \tcode{2}.
+
+\begin{codeblock}
+sizeof(true ? "" : throw 0)
+\end{codeblock}
+
+In \CppXI, the expression yields \tcode{sizeof(const char*)}. In this
+International Standard, it yields \tcode{sizeof(const char[1])}.
+
 \rSec2[diff.cpp11.dcl.dcl]{Clause \ref{dcl.dcl}: declarations}
 
 \ref{dcl.constexpr}


### PR DESCRIPTION
CWG1560: Gratuitous lvalue-to-rvalue conversion in
  conditional-expression with throw-expression operand
http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#1560
The change had been made between C++11 and C++14.