### PR TITLE
[tuple.assign] Fix typo

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1455,7 +1455,7 @@ template <class... UTypes>
 \tcode{sizeof...(Types)} \tcode{==}\\\tcode{sizeof...(UTypes)}.
 
 \pnum
-\effects For all $i$, assigns \tcode{std::forward<$U_i$>(get<$i$)>(u))} to
+\effects For all $i$, assigns \tcode{std::forward<$U_i$>(get<$i$>(u))} to
 \tcode{get<$i$>(*this)}.
 
 \pnum


### PR DESCRIPTION
Fixed redundant ')'.