### PR TITLE
Refine "Index of library names" for operator<< and operator>>

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -4564,7 +4564,8 @@ If no exception has been thrown, it returns
 
 \rSec4[istream.formatted.arithmetic]{Arithmetic extractors}
 
-\indexlibrary{\idxcode{operator\shr}!\idxcode{istream}}%
+\indexlibrary{\idxcode{operator\shr}!\idxcode{basic_istream}}%
+\indexlibrary{\idxcode{basic_istream}!\idxcode{operator\shr}}%
 \begin{itemdecl}
 operator>>(unsigned short& val);
 operator>>(unsigned int& val);
@@ -4615,7 +4616,8 @@ so that it does not need to depend directly on
 \tcode{istream}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shr}!\idxcode{istream}}%
+\indexlibrary{\idxcode{operator\shr}!\idxcode{basic_istream}}%
+\indexlibrary{\idxcode{basic_istream}!\idxcode{operator\shr}}%
 \begin{itemdecl}
 operator>>(short& val);
 \end{itemdecl}
@@ -4641,7 +4643,8 @@ setstate(err);
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shr}!\idxcode{istream}}%
+\indexlibrary{\idxcode{operator\shr}!\idxcode{basic_istream}}%
+\indexlibrary{\idxcode{basic_istream}!\idxcode{operator\shr}}%
 \begin{itemdecl}
 operator>>(int& val);
 \end{itemdecl}
@@ -4670,6 +4673,7 @@ setstate(err);
 \rSec4[istream::extractors]{\tcode{basic_istream::operator\shr}}
 
 \indexlibrary{\idxcode{operator\shr}!\idxcode{basic_istream}}%
+\indexlibrary{\idxcode{basic_istream}!\idxcode{operator\shr}}%
 \begin{itemdecl}
 basic_istream<charT,traits>& operator>>
     (basic_istream<charT,traits>& (*pf)(basic_istream<charT,traits>&));
@@ -4689,7 +4693,8 @@ This extractor does not behave as a formatted input function
 \indexlibrary{\idxcode{ws}}}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shr}!\idxcode{istream}}%
+\indexlibrary{\idxcode{operator\shr}!\idxcode{basic_istream}}%
+\indexlibrary{\idxcode{basic_istream}!\idxcode{operator\shr}}%
 \begin{itemdecl}
 basic_istream<charT,traits>& operator>>
     (basic_ios<charT,traits>& (*pf)(basic_ios<charT,traits>&));
@@ -4708,7 +4713,8 @@ This extractor does not behave as a formatted input function
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shr}!\idxcode{istream}}%
+\indexlibrary{\idxcode{operator\shr}!\idxcode{basic_istream}}%
+\indexlibrary{\idxcode{basic_istream}!\idxcode{operator\shr}}%
 \begin{itemdecl}
 basic_istream<charT,traits>& operator>>
     (ios_base& (*pf)(ios_base&));
@@ -4728,7 +4734,8 @@ This extractor does not behave as a formatted input function
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shr}!\idxcode{istream}}%
+\indexlibrary{\idxcode{operator\shr}!\idxcode{basic_istream}}%
+\indexlibrary{\idxcode{basic_istream}!\idxcode{operator\shr}}%
 \begin{itemdecl}
 template<class charT, class traits>
   basic_istream<charT,traits>& operator>>(basic_istream<charT,traits>& in,
@@ -4802,7 +4809,8 @@ which may throw
 \tcode{in}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shr}!\idxcode{istream}}%
+\indexlibrary{\idxcode{operator\shr}!\idxcode{basic_istream}}%
+\indexlibrary{\idxcode{basic_istream}!\idxcode{operator\shr}}%
 \begin{itemdecl}
 template<class charT, class traits>
   basic_istream<charT,traits>& operator>>(basic_istream<charT,traits>& in,
@@ -4832,7 +4840,8 @@ Otherwise, the function calls
 \tcode{in}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shr}!\idxcode{istream}}%
+\indexlibrary{\idxcode{operator\shr}!\idxcode{basic_istream}}%
+\indexlibrary{\idxcode{basic_istream}!\idxcode{operator\shr}}%
 \begin{itemdecl}
 basic_istream<charT,traits>& operator>>
   (basic_streambuf<charT,traits>* sb);
@@ -5722,8 +5731,8 @@ void swap(basic_iostream& rhs);
 
 \rSec3[istream.rvalue]{Rvalue stream extraction}
 
-\indexlibrary{\idxcode{operator\shl}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{operator\shl}}%
+\indexlibrary{\idxcode{operator\shr}!\idxcode{basic_istream}}%
+\indexlibrary{\idxcode{basic_istream}!\idxcode{operator\shr}}%
 \begin{itemdecl}
 template <class charT, class traits, class T>
   basic_istream<charT, traits>&
@@ -6187,6 +6196,7 @@ character sequence.
 \rSec4[ostream.inserters.arithmetic]{Arithmetic inserters}
 
 \indexlibrary{\idxcode{operator\shl}!\idxcode{basic_ostream}}%
+\indexlibrary{\idxcode{basic_ostream}!\idxcode{operator\shl}}%
 \begin{itemdecl}
 operator<<(bool val);
 operator<<(short val);
@@ -6315,6 +6325,7 @@ which may throw an exception, and returns.
 \rSec4[ostream.inserters]{\tcode{basic_ostream::operator\shl}}
 
 \indexlibrary{\idxcode{operator\shl}!\idxcode{basic_ostream}}%
+\indexlibrary{\idxcode{basic_ostream}!\idxcode{operator\shl}}%
 \begin{itemdecl}
 basic_ostream<charT,traits>& operator<<
     (basic_ostream<charT,traits>& (*pf)(basic_ostream<charT,traits>&));

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -812,7 +812,8 @@ template<class T> constexpr bool operator!=(const T& lhs, const complex<T>& rhs)
 \tcode{rhs.real() != lhs.real() || rhs.imag() != lhs.imag()}.
 \end{itemdescr}
 
-\indexlibrary{operator>>@\tcode{operator\shr}!\idxcode{complex}}%
+\indexlibrary{\idxcode{operator\shr}!\idxcode{complex}}%
+\indexlibrary{\idxcode{complex}!\idxcode{operator\shr}}%
 \begin{itemdecl}
 template<class T, class charT, class traits>
 basic_istream<charT, traits>&
@@ -855,7 +856,8 @@ Therefore, the skipping of whitespace is specified to be
 the same for each of the simpler extractions.
 \end{itemdescr}
 
-\indexlibrary{operator<<@\tcode{operator\shl}!\idxcode{complex}}%
+\indexlibrary{\idxcode{operator\shl}!\idxcode{complex}}%
+\indexlibrary{\idxcode{complex}!\idxcode{operator\shl}}%
 \begin{itemdecl}
 template<class T, class charT, class traits>
 basic_ostream<charT, traits>&
@@ -7230,7 +7232,9 @@ applying the indicated operator to the corresponding element of the array.
 \indexlibrary{\idxcode{operator\&=}!\idxcode{valarray}}%
 \indexlibrary{\idxcode{operator"|=}!\idxcode{valarray}}%
 \indexlibrary{\idxcode{operator\shl=}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{valarray}!\idxcode{operator\shl=}}%
 \indexlibrary{\idxcode{operator\shr=}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{valarray}!\idxcode{operator\shr=}}%
 \begin{itemdecl}
 valarray& operator*= (const valarray&);
 valarray& operator/= (const valarray&);
@@ -7492,7 +7496,9 @@ Resizing invalidates all pointers and references to elements in the array.
 \indexlibrary{\idxcode{operator\&}!\idxcode{valarray}}%
 \indexlibrary{\idxcode{operator"|}!\idxcode{valarray}}%
 \indexlibrary{\idxcode{operator\shl}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{valarray}!\idxcode{operator\shl}}%
 \indexlibrary{\idxcode{operator\shr}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{valarray}!\idxcode{operator\shr}}%
 \indexlibrary{\idxcode{operator\&\&}!\idxcode{valarray}}%
 \indexlibrary{\idxcode{operator"|"|}!\idxcode{valarray}}%
 \begin{itemdecl}
@@ -7928,7 +7934,9 @@ object refers.
 \indexlibrary{\idxcode{operator\&=}!\idxcode{slice_array}}%
 \indexlibrary{\idxcode{operator"|=}!\idxcode{slice_array}}%
 \indexlibrary{\idxcode{operator\shl=}!\idxcode{slice_array}}%
+\indexlibrary{\idxcode{slice_array}!\idxcode{operator\shl=}}%
 \indexlibrary{\idxcode{operator\shr=}!\idxcode{slice_array}}%
+\indexlibrary{\idxcode{slice_array}!\idxcode{operator\shr=}}%
 \begin{itemdecl}
 void operator*= (const valarray<T>&) const;
 void operator/= (const valarray<T>&) const;
@@ -8214,7 +8222,9 @@ refers.
 \indexlibrary{\idxcode{operator\&=}!\idxcode{gslice_array}}%
 \indexlibrary{\idxcode{operator"|=}!\idxcode{gslice_array}}%
 \indexlibrary{\idxcode{operator\shl=}!\idxcode{gslice_array}}%
+\indexlibrary{\idxcode{gslice_array}!\idxcode{operator\shl=}}%
 \indexlibrary{\idxcode{operator\shr=}!\idxcode{gslice_array}}%
+\indexlibrary{\idxcode{gslice_array}!\idxcode{operator\shr=}}%
 \begin{itemdecl}
 void operator*= (const valarray<T>&) const;
 void operator/= (const valarray<T>&) const;
@@ -8342,7 +8352,9 @@ object to which it refers.
 \indexlibrary{\idxcode{operator\&=}!\idxcode{mask_array}}%
 \indexlibrary{\idxcode{operator"|=}!\idxcode{mask_array}}%
 \indexlibrary{\idxcode{operator\shl=}!\idxcode{mask_array}}%
+\indexlibrary{\idxcode{mask_array}!\idxcode{operator\shl=}}%
 \indexlibrary{\idxcode{operator\shr=}!\idxcode{mask_array}}%
+\indexlibrary{\idxcode{mask_array}!\idxcode{operator\shr=}}%
 \begin{itemdecl}
 void operator*= (const valarray<T>&) const;
 void operator/= (const valarray<T>&) const;
@@ -8487,7 +8499,9 @@ indirection.
 \indexlibrary{\idxcode{operator\&=}!\idxcode{indirect_array}}%
 \indexlibrary{\idxcode{operator"|=}!\idxcode{indirect_array}}%
 \indexlibrary{\idxcode{operator\shl=}!\idxcode{indirect_array}}%
+\indexlibrary{\idxcode{indirect_array}!\idxcode{operator\shl=}}%
 \indexlibrary{\idxcode{operator\shr=}!\idxcode{indirect_array}}%
+\indexlibrary{\idxcode{indirect_array}!\idxcode{operator\shr=}}%
 \begin{itemdecl}
 void operator*= (const valarray<T>&) const;
 void operator/= (const valarray<T>&) const;

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -2527,8 +2527,8 @@ template <class BiIter>
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_ostream}}%
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator<<}}%
-\indexlibrary{\idxcode{operator<<}!\idxcode{sub_match}}%
+\indexlibrary{\idxcode{sub_match}!\idxcode{operator\shl}}%
+\indexlibrary{\idxcode{operator\shl}!\idxcode{sub_match}}%
 \begin{itemdecl}
 template <class charT, class ST, class BiIter>
   basic_ostream<charT, ST>&

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2401,7 +2401,8 @@ for which the corresponding bit in \tcode{rhs} is set, and leaves all other bits
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{operator<<=@\tcode{operator\shl=}!\idxcode{bitset}}%
+\indexlibrary{\idxcode{operator\shl=}!\idxcode{bitset}}%
+\indexlibrary{\idxcode{bitset}!\idxcode{operator\shl=}}%
 \begin{itemdecl}
 bitset<N>& operator<<=(size_t pos) noexcept;
 \end{itemdecl}
@@ -2426,7 +2427,8 @@ value of the bit at position \tcode{I - pos}.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{operator>>=@\tcode{operator\shr=}!\idxcode{bitset}}%
+\indexlibrary{\idxcode{operator\shr=}!\idxcode{bitset}}%
+\indexlibrary{\idxcode{bitset}!\idxcode{operator\shr=}}%
 \begin{itemdecl}
 bitset<N>& operator>>=(size_t pos) noexcept;
 \end{itemdecl}
@@ -2771,7 +2773,8 @@ bool none() const noexcept;
 \returns \tcode{count() == 0}
 \end{itemdescr}
 
-\indexlibrary{operator<<@\tcode{operator\shl}!\idxcode{bitset}}%
+\indexlibrary{\idxcode{operator\shl}!\idxcode{bitset}}%
+\indexlibrary{\idxcode{bitset}!\idxcode{operator\shl}}%
 \begin{itemdecl}
 bitset<N> operator<<(size_t pos) const noexcept;
 \end{itemdecl}
@@ -2782,7 +2785,8 @@ bitset<N> operator<<(size_t pos) const noexcept;
 \tcode{bitset<N>(*this) \shl= pos}.
 \end{itemdescr}
 
-\indexlibrary{operator>>@\tcode{operator\shr}!\idxcode{bitset}}%
+\indexlibrary{\idxcode{operator\shr}!\idxcode{bitset}}%
+\indexlibrary{\idxcode{bitset}!\idxcode{operator\shr}}%
 \begin{itemdecl}
 bitset<N> operator>>(size_t pos) const noexcept;
 \end{itemdecl}
@@ -2893,7 +2897,8 @@ bitset<N> operator^(const bitset<N>& lhs, const bitset<N>& rhs) noexcept;
 \tcode{bitset<N>(lhs) \^{}= rhs}.
 \end{itemdescr}
 
-\indexlibrary{operator>>@\tcode{operator\shr}!\idxcode{bitset}}%
+\indexlibrary{\idxcode{operator\shr}!\idxcode{bitset}}%
+\indexlibrary{\idxcode{bitset}!\idxcode{operator\shr}}%
 \begin{itemdecl}
 template <class charT, class traits, size_t N>
   basic_istream<charT, traits>&
@@ -2938,7 +2943,8 @@ If no characters are stored in \tcode{str}, calls
 \tcode{is}.
 \end{itemdescr}
 
-\indexlibrary{operator<<@\tcode{operator\shl}!\idxcode{bitset}}%
+\indexlibrary{\idxcode{operator\shl}!\idxcode{bitset}}%
+\indexlibrary{\idxcode{bitset}!\idxcode{operator\shl}}%
 \begin{itemdecl}
 template <class charT, class traits, size_t N>
   basic_ostream<charT, traits>&
@@ -6422,8 +6428,8 @@ the deleter until all \tcode{weak_ptr} instances that share ownership with
 
 \rSec4[util.smartptr.shared.io]{\tcode{shared_ptr} I/O}
 
-\indexlibrary{\idxcode{operator<<}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{operator<<}}%
+\indexlibrary{\idxcode{operator\shl}!\idxcode{shared_ptr}}%
+\indexlibrary{\idxcode{shared_ptr}!\idxcode{operator\shl}}%
 \begin{itemdecl}
 template<class E, class T, class Y>
   basic_ostream<E, T>& operator<< (basic_ostream<E, T>& os, shared_ptr<Y> const& p);


### PR DESCRIPTION
- Fix index entry for `basic_istream::operator>>`.
- Use `basic_istream` instead of `istream`.
- Use `operator\sh[lr]` instead of `operator(<<|>>)`.
- Add `class-name!function-name` entry in addition to `function-name!class-name`.
