### PR TITLE
Change "typename decay<F>::type" to "decay_t<F>"

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -8859,7 +8859,7 @@ template<class F> function& operator=(F&& f);
 \pnum\returns \tcode{*this}
 
 \pnum\remarks This assignment operator shall not participate in overload
-resolution unless \tcode{declval<typename decay<F>::type\&>()} is
+resolution unless \tcode{declval<decay_t<F>\&>()} is
 Callable~(\ref{func.wrap.func}) for argument types \tcode{ArgTypes...} and
 return type \tcode{R}.
 \end{itemdescr}


### PR DESCRIPTION
Looks like this one was overlooked when `decay_t` (and the other `_t` helpers) were introduced.