### PR TITLE
Remove 'all' from the left argument

### DIFF
--- a/source/locales.tex
+++ b/source/locales.tex
@@ -313,7 +313,7 @@ member bitmask constant
 is defined such that the expression
 
 \begin{codeblock}
-(collate | ctype | monetary | numeric | time | messages | all) == all
+(collate | ctype | monetary | numeric | time | messages) == all
 \end{codeblock}
 
 is


### PR DESCRIPTION
'all' parameter should be removed from the left parameter pack to make right semantics of this expression