### PR TITLE
[unord.req] Clarify the complexity of clear() method

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -2161,7 +2161,7 @@ the number of elements erased.
    Post: \tcode{a.empty()} returns \tcode{true}%
     \indextext{unordered associative containers!\idxcode{clear}}%
     \indextext{\idxcode{clear}!unordered associative containers}%
-& Linear.
+& Linear in \tcode{a.size()}.
 \\ \rowsep
 %
 \tcode{b.find(k)}


### PR DESCRIPTION
From the current formulation it is not very clear, whether the complexity of unordered containers' `clear()` method is linear in the number of buckets, in the number of elements, or both. Obviously, it should be linear just in the number of elements. If it would be also linear in the number of buckets, then `c.clear()` would be less efficient then calling `c.erase(c.begin(), c.end())`, which does not make any sense.