### PR TITLE
[sequences.general] Promote header synopses to rSec2

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -2413,7 +2413,8 @@ The headers \tcode{<array>}, \tcode{<deque>}, \tcode{<forward_list>},
 \tcode{<list>}, and \tcode{<vector>} define class templates that meet the
 requirements for sequence containers.
 
-\synopsis{Header \tcode{<array>} synopsis}%
+\rSec2[array.syn]{Header \tcode{<array>} synopsis}
+
 \indexlibrary{\idxhdr{array}}%
 \begin{codeblock}
 #include <initializer_list>
@@ -2452,7 +2453,8 @@ namespace std {
 }
 \end{codeblock}
 
-\synopsis{Header \tcode{<deque>} synopsis}%
+\rSec2[deque.syn]{Header \tcode{<deque>} synopsis}
+
 \indexlibrary{\idxhdr{deque}}
 
 \begin{codeblock}
@@ -2478,7 +2480,8 @@ namespace std {
 }
 \end{codeblock}
 
-\synopsis{Header \tcode{<forward_list>} synopsis}%
+\rSec2[forward_list.syn]{Header \tcode{<forward_list>} synopsis}
+
 \indexlibrary{\idxhdr{forward_list}}
 
 \begin{codeblock}
@@ -2504,7 +2507,8 @@ namespace std {
 }
 \end{codeblock}
 
-\synopsis{Header \tcode{<list>} synopsis}%
+\rSec2[list.syn]{Header \tcode{<list>} synopsis}
+
 \indexlibrary{\idxhdr{list}}
 
 \begin{codeblock}
@@ -2530,7 +2534,8 @@ namespace std {
 }
 \end{codeblock}
 
-\synopsis{Header \tcode{<vector>} synopsis}%
+\rSec2[vector.syn]{Header \tcode{<vector>} synopsis}
+
 \indexlibrary{\idxhdr{vector}}
 
 \begin{codeblock}


### PR DESCRIPTION
In #357 @tkoeppe suggested this change. It would be more consistent with the rest of Clause 23, although it makes 23.3.1 [sequences.general] a rather weedy subclause.