### PR TITLE
[library] Fix index entry

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2664,7 +2664,7 @@ It is unspecified whether any function signature or class described in
 Clauses~\ref{\firstlibchapter} through~\ref{\lastlibchapter} and Annex~\ref{depr} is a
 \tcode{friend}
 of another class in the \Cpp standard library.
-\indextext{specifier!\tcode{friend}}
+\indextext{specifier!\idxcode{friend}}
 
 \rSec3[derivation]{Derived classes}
 


### PR DESCRIPTION
`\idxcode` is necessary for correct collation of text with fancy formatting.

(Without this change, the index entry for "specifier, friend" is broken.)