### PR TITLE
[macros] Disable italic correction for monospaced italics

### DIFF
--- a/source/macros.tex
+++ b/source/macros.tex
@@ -203,7 +203,7 @@
 \newcommand{\impdefx}[1]{\indeximpldef{#1}\EXPO{implementation-defined}}
 \newcommand{\notdef}{\EXPO{not defined}}
 
-\newcommand{\UNSP}[1]{\textit{\texttt{#1}}}
+\newcommand{\UNSP}[1]{{\itshape\ttfamily #1}}
 \newcommand{\unspec}{\UNSP{unspecified}}
 \newlength{\unspecwidth}
 \newcommand{\unspecaligned}{%


### PR DESCRIPTION
This helps align code columns vertically in the presence of italics.