### PR TITLE
[func.wrap.func.con] Fix error in note

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -8823,7 +8823,7 @@ Otherwise, \tcode{*this} targets a copy of \tcode{f}
 initialized with \tcode{std::move(f)}.
 \enternote Implementations are encouraged to avoid the use of
 dynamically allocated memory for small callable objects, for example,
-where \tcode{f}'s target is an object holding only a pointer or
+where \tcode{f} is an object holding only a pointer or
 reference to an object and a member function pointer. \exitnote
 
 \pnum


### PR DESCRIPTION
This note should be talking about the callable object being wrapped, i.e., f, rather than its "target", which makes no sense for arbitrary callable objects. This seems to be a copy/paste error from the very similar note in the copy constructor's description a few paragraphs above.