### PR TITLE
Use textual angle brackets rather than relational operators

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -118,29 +118,29 @@ defined.
 
 \indexdefn{access}%
 \definition{access}{defns.access}
-<execution-time action> to read or modify the value of an object
+\defncontext{execution-time action} to read or modify the value of an object
 
 \indexdefn{argument}%
 \indexdefn{argument!function call expression}
 \definition{argument}{defns.argument}
-<function call expression> expression in the
+\defncontext{function call expression} expression in the
 comma-separated list bounded by the parentheses~(\ref{expr.call})
 
 \indexdefn{argument}%
 \indexdefn{argument!function-like macro}%
 \definition{argument}{defns.argument.macro}
-<function-like macro> sequence of preprocessing tokens in the
+\defncontext{function-like macro} sequence of preprocessing tokens in the
 comma-separated list bounded by the parentheses~(\ref{cpp.replace})
 
 \indexdefn{argument}%
 \indexdefn{argument!throw expression}%
 \definition{argument}{defns.argument.throw}
-<throw expression> the operand of \tcode{throw}~(\ref{expr.throw})
+\defncontext{throw expression} the operand of \tcode{throw}~(\ref{expr.throw})
 
 \indexdefn{argument}%
 \indexdefn{argument!template instantiation}%
 \definition{argument}{defns.argument.templ}
-<template instantiation>
+\defncontext{template instantiation}
 \grammarterm{constant-expression},
 \grammarterm{type-id}, or
 \grammarterm{id-expression} in the comma-separated
@@ -159,7 +159,7 @@ implementation's output messages
 
 \indexdefn{type!dynamic}%
 \definition{dynamic type}{defns.dynamic.type}
-<glvalue> type of the most derived object~(\ref{intro.object}) to which the
+\defncontext{glvalue} type of the most derived object~(\ref{intro.object}) to which the
 glvalue refers\\
 \enterexample
 if a pointer~(\ref{dcl.ptr}) \tcode{p} whose static type is ``pointer to
@@ -171,7 +171,7 @@ treated similarly.
 
 \indexdefn{type!dynamic}%
 \definition{dynamic type}{defns.dynamic.type.prvalue}
-<prvalue> static type of the prvalue expression
+\defncontext{prvalue} static type of the prvalue expression
 
 \indexdefn{program!ill-formed}%
 \definition{ill-formed program}{defns.ill.formed}
@@ -203,53 +203,53 @@ set~(\ref{lex.charset}).\exitnote
 \indexdefn{parameter!function}%
 \indexdefn{parameter!catch clause}%
 \definition{parameter}{defns.parameter}
-<function or catch clause> object or reference declared as part of a function declaration or
+\defncontext{function or catch clause} object or reference declared as part of a function declaration or
 definition or in the catch clause of an exception handler that
 acquires a value on entry to the function or handler
 
 \indexdefn{parameter}%
 \indexdefn{parameter!function-like macro}%
 \definition{parameter}{defns.parameter.macro}
-<function-like macro> identifier from
+\defncontext{function-like macro} identifier from
 the comma-separated list bounded by the parentheses immediately
 following the macro name
 
 \indexdefn{parameter}%
 \indexdefn{parameter!template}%
 \definition{parameter}{defns.parameter.templ}
-<template> \grammarterm{template-parameter}
+\defncontext{template} \grammarterm{template-parameter}
 
 \indexdefn{signature}%
 \definition{signature}{defns.signature}
-<function> name, parameter type list~(\ref{dcl.fct}), and enclosing namespace (if any)\\
+\defncontext{function} name, parameter type list~(\ref{dcl.fct}), and enclosing namespace (if any)\\
 \enternote Signatures are used as a basis for
 name mangling and linking.\exitnote
 
 \indexdefn{signature}%
 \definition{signature}{defns.signature.templ}
-<function template> name, parameter type list~(\ref{dcl.fct}), enclosing namespace (if any),
+\defncontext{function template} name, parameter type list~(\ref{dcl.fct}), enclosing namespace (if any),
 return type, and template parameter list
 
 \indexdefn{signature}%
 \definition{signature}{defns.signature.spec}
-<function template specialization> signature of the template of which it is a specialization
+\defncontext{function template specialization} signature of the template of which it is a specialization
 and its template arguments (whether explicitly specified or deduced)
 
 \indexdefn{signature}%
 \definition{signature}{defns.signature.member}
-<class member function> name, parameter type list~(\ref{dcl.fct}), class of which the
+\defncontext{class member function} name, parameter type list~(\ref{dcl.fct}), class of which the
 function is a member, \cv-qualifiers (if any),
 and \grammarterm{ref-qualifier} (if any)
 
 \indexdefn{signature}%
 \definition{signature}{defns.signature.member.templ}
-<class member function template> name, parameter type list~(\ref{dcl.fct}), class of which the
+\defncontext{class member function template} name, parameter type list~(\ref{dcl.fct}), class of which the
 function is a member, \cv-qualifiers (if any),
 \grammarterm{ref-qualifier} (if any), return type, and template parameter list
 
 \indexdefn{signature}%
 \definition{signature}{defns.signature.member.spec}
-<class member function template specialization> signature of the member function template
+\defncontext{class member function template specialization} signature of the member function template
 of which it is a specialization and its template arguments (whether explicitly specified or deduced)
 
 \indexdefn{type!static}%

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -137,7 +137,7 @@ satisfied before it can continue execution\footnote{This definition is taken fro
 
 \definition{character}{defns.character}
 \indexdefn{character}%
-<Clauses~\ref{strings}, \ref{localization}, \ref{input.output}, and~\ref{re}>
+\defncontext{Clauses~\ref{strings}, \ref{localization}, \ref{input.output}, and~\ref{re}}
 any object which,
 when treated sequentially,
 can represent text\\
@@ -190,14 +190,14 @@ blocked waiting for one or more of the others to satisfy some condition
 
 \definition{default behavior}{defns.default.behavior.impl}
 \indexdefn{behavior!default}%
-<implementation>
+\defncontext{implementation}
 any specific behavior provided by the implementation,
 within the scope of the
 \term{required behavior}
 
 \definition{default behavior}{defns.default.behavior.func}
 \indexdefn{behavior!default}%
-<specification>
+\defncontext{specification}
 a description of
 \term{replacement function}
 and

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -504,3 +504,4 @@
 \newcommand{\definition}[2]{%
 \subsection[#1]{\hfill[#2]}\vspace{-.3\onelineskip}\label{#2}\textbf{#1}\\%
 }
+\newcommand{\defncontext}[1]{\textlangle#1\textrangle}

--- a/source/std.tex
+++ b/source/std.tex
@@ -17,6 +17,7 @@
 \usepackage{ltcaption}    % fix captions for long tables
 \usepackage{booktabs}     % fancy tables
 \usepackage{relsize}      % provide relative font size changes
+\usepackage{textcomp}     % provide \text{l,r}angle
 \usepackage{underscore}   % remove special status of '_' in ordinary text
 \usepackage{verbatim}     % improved verbatim environment
 \usepackage{parskip}      % handle non-indented paragraphs "properly"


### PR DESCRIPTION
Angle brackets look better than less-than/greater-than operators when used to typeset parentheticals.