### PR TITLE
[iterators, locales] Apply \placeholder macro

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -2231,10 +2231,10 @@ namespace std {
 
 \pnum
 Let \placeholder{R} be \tcode{iterator_traits<Iterator>::reference}.
-If \tcode{is_reference<}\placeholder{R}\tcode{>::value} is \tcode{true},
+If \tcode{is_reference<\placeholder{R}>::value} is \tcode{true},
 the template specialization \tcode{move_iterator<Iterator>} shall define
 the nested type named \tcode{reference} as a synonym for
-\tcode{remove_reference<}\placeholder{R}\tcode{>::type\&\&},
+\tcode{remove_reference<\placeholder{R}>::type\&\&},
 otherwise as a synonym for \placeholder{R}.
 
 \rSec3[move.iter.requirements]{\tcode{move_iterator} requirements}

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -1006,14 +1006,14 @@ template <class charT> bool isblank (charT c, const locale& loc);
 
 \pnum
 Each of these functions
-\tcode{is\textit{F}}
+\tcode{is\placeholder{F}}
 returns the result of the expression:
 
 \begin{codeblock}
-use_facet< ctype<charT> >(loc).is(ctype_base::@\textit{F}@, c)
+use_facet< ctype<charT> >(loc).is(ctype_base::@\placeholder{F}@, c)
 \end{codeblock}
 
-where \tcode{\textit{F}} is the
+where \tcode{\placeholder{F}} is the
 \tcode{ctype_base::mask}
 value corresponding to that function~(\ref{category.ctype}).\footnote{When
 used in a loop, it is faster to cache the
@@ -1514,7 +1514,7 @@ virtual function.
 namespace std {
   class ctype_base {
   public:
-    typedef @\textit{T}@ mask;
+    typedef @\placeholder{T}@ mask;
 
     // numeric values are for exposition only.
     static const mask space = 1 << 0;
@@ -5289,10 +5289,10 @@ pattern      neg_format()    const;
 \end{codeblock}
 
 \pnum
-Each of these functions \tcode{\textit{F}}
+Each of these functions \tcode{\placeholder{F}}
 returns the result of calling the corresponding
 virtual member function
-\tcode{do_\textit{F}()}.
+\tcode{do_\placeholder{F}()}.
 
 \rSec4[locale.moneypunct.virtuals]{\tcode{moneypunct} virtual functions}
 


### PR DESCRIPTION
See also issues #319 and #326 and PRs #553 and #350.

Before:

![image](https://cloud.githubusercontent.com/assets/6378233/11741909/dbf93548-9ff3-11e5-91d0-f8b11c5315fe.png)

After:

![image](https://cloud.githubusercontent.com/assets/6378233/11741852/7c8fc888-9ff3-11e5-8427-fae995ad6d4a.png)

The above is the *only* diffpdf diff caused by this PR.
