### PR TITLE
[lib-intro, utilities] Apply \placeholder macro

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1090,8 +1090,8 @@ additional headers, as shown in Table~\ref{tab:cpp.c.headers}.
 
 \pnum
 Except as noted in Clauses~\ref{\firstlibchapter} through~\ref{\lastlibchapter}
-and Annex~\ref{depr}, the contents of each header \tcode{c\textit{name}} shall
-be the same as that of the corresponding header \tcode{\textit{name}.h}, as
+and Annex~\ref{depr}, the contents of each header \tcode{c\placeholder{name}} shall
+be the same as that of the corresponding header \tcode{\placeholder{name}.h}, as
 specified in the C standard library~(\ref{intro.refs}) or the C Unicode TR, as
 appropriate, as if by inclusion. In the \Cpp standard library, however, the
 declarations (except for names which are defined as macros in C) are within
@@ -1123,7 +1123,7 @@ standard header \tcode{<iso646.h>} or \tcode{<ciso646>} has no effect.}
 
 \pnum
 \ref{depr.c.headers}, C standard library headers, describes the effects of using
-the \tcode{\textit{name}.h} (C header) form in a \Cpp program.\footnote{ The
+the \tcode{\placeholder{name}.h} (C header) form in a \Cpp program.\footnote{ The
 \tcode{".h"} headers dump all their names into the global namespace, whereas the
 newer forms keep their names in namespace \tcode{std}. Therefore, the newer
 forms are the preferred forms for all uses except for \Cpp programs which are

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1000,7 +1000,7 @@ namespace std {
   const @\unspec@ ignore;
 
   template <class... Types>
-    constexpr tuple<@\textit{VTypes}@...> make_tuple(Types&&...);
+    constexpr tuple<@\placeholder{VTypes}@...> make_tuple(Types&&...);
   template <class... Types>
     constexpr tuple<Types&&...> forward_as_tuple(Types&&...) noexcept;
 
@@ -1008,7 +1008,7 @@ namespace std {
     constexpr tuple<Types&...> tie(Types&...) noexcept;
 
   template <class... Tuples>
-    constexpr tuple<@\textit{Ctypes}@...> tuple_cat(Tuples&&...);
+    constexpr tuple<@\placeholder{Ctypes}@...> tuple_cat(Tuples&&...);
 
   // \ref{tuple.helper}, tuple helper classes:
   template <class T> class tuple_size;  // undefined
@@ -1561,7 +1561,7 @@ in a template parameter pack named \tcode{UTypes}, where indexing is zero-based.
 \indexlibrary{\idxcode{tuple}!\idxcode{make_tuple}}%
 \begin{itemdecl}
 template<class... Types>
-  constexpr tuple<@\textit{VTypes}@...> make_tuple(Types&&... t);
+  constexpr tuple<@\placeholder{VTypes}@...> make_tuple(Types&&... t);
 \end{itemdecl}
 
 \begin{itemdescr} \pnum Let \tcode{$U_i$} be \tcode{decay_t<$T_i$>} for each
@@ -1639,7 +1639,7 @@ tie(i, ignore, s) = make_tuple(42, 3.14, "C++");
 \indexlibrary{\idxcode{tuple_cat}}
 \begin{itemdecl}
 template <class... Tuples>
-  constexpr tuple<@\textit{CTypes}@...> tuple_cat(Tuples&&... tpls);
+  constexpr tuple<@\placeholder{CTypes}@...> tuple_cat(Tuples&&... tpls);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1660,7 +1660,7 @@ deduced as an lvalue reference type, then
 \tcode{is_constructible<$A_{ik}$, $cv_i A_{ik}$\&\&>::value == true}.
 
 \pnum
-\remarks The types in \tcode{\textit{Ctypes}} shall be equal to the ordered
+\remarks The types in \tcode{\placeholder{Ctypes}} shall be equal to the ordered
 sequence of the extended types
 \tcode{$Args_0$..., $Args_1$...,} ... \tcode{$Args_{n-1}$...}, where $n$ is
 equal to \tcode{sizeof...(Tuples)}. Let \tcode{$e_i$...} be the $i^{th}$


### PR DESCRIPTION
No diffpdf diff.

Note that I'm not touching any of the `\tcode{\textit{INVOKE}}` instances.

@zygoloid, @jwakely: maybe you can also take a look at  [character.seq]/(1.3) for use of placeholders and italics and macros.