### PR TITLE
[atomics] Reword table headers, removing mention of "inttypes.h"

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -612,9 +612,9 @@ corresponding specialization. If it is a base class, it shall support the same
 member functions as the corresponding specialization.
 
 \begin{floattablebase}
-{\tcode{atomic} integral typedefs}{tab:atomics.integral}{ll}{ht}
+{Named atomic types}{tab:atomics.integral}{ll}{ht}
 \hline
-\textbf{Named type}     & \textbf{Integral argument type} \\ \hline
+\textbf{Named atomic type} & \textbf{Corresponding non-atomic type} \\ \hline
 \tcode{atomic_char}     & \tcode{char}                    \\
 \tcode{atomic_schar}    & \tcode{signed char}             \\
 \tcode{atomic_uchar}    & \tcode{unsigned char}           \\
@@ -633,13 +633,13 @@ member functions as the corresponding specialization.
 \end{floattablebase}
 
 \pnum
-There shall be atomic typedefs corresponding to the typedefs in the header \tcode{<inttypes.h>} as
+There shall be atomic typedefs corresponding to non-atomic typedefs as
 specified in Table~\ref{tab:atomics.typedefs}.
 
 \begin{floattablebase}
-{\tcode{atomic} \tcode{<inttypes.h>} typedefs}{tab:atomics.typedefs}{ll}{ht}
+{Atomic typedefs}{tab:atomics.typedefs}{ll}{ht}
 \hline
-\textbf{Atomic typedef}   & \textbf{\tcode{<inttypes.h>} type}  \\ \hline
+\textbf{Atomic typedef} & \textbf{Corresponding non-atomic typedef} \\ \hline
 \tcode{atomic_int_least8_t}   & \tcode{int_least8_t}    \\
 \tcode{atomic_uint_least8_t}  & \tcode{uint_least8_t}   \\
 \tcode{atomic_int_least16_t}  & \tcode{int_least16_t}   \\


### PR DESCRIPTION
`inttypes.h` is not the primary header that defines `int_least8_t` etc. That's `cstdint`. The only new thing `inttypes.h` adds is `idivmax_t`, but we don't have an atomic version of that.