### PR TITLE
[diff.library] add missing NULL <cstdio> to Table 149

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1554,7 +1554,7 @@ declarations, or behavior from the Standard C library
 noted in other subclauses (\ref{headers}, \ref{support.types}, \ref{c.strings}).
 
 \pnum
-The \Cpp standard library provides 57 standard macros from the C library,
+The \Cpp standard library provides 51 standard macros from the C library,
 as shown in Table~\ref{tab:diff.standard.macros}.
 
 \pnum
@@ -1571,78 +1571,79 @@ All such definitions are equivalent (\ref{basic.def.odr}).
 
 \tcode{assert}    &
 \tcode{HUGE_VAL}  &
+\tcode{NULL <cstdlib>}  &
+\tcode{SIGILL}    &
+\tcode{va_copy}   \\
+
+\tcode{BUFSIZ}    &
+\tcode{LC_ALL}    &
 \tcode{NULL <cstring>}  &
 \tcode{SIGINT}    &
 \tcode{va_end}    \\
 
-\tcode{BUFSIZ}    &
-\tcode{LC_ALL}    &
+\tcode{CLOCKS_PER_SEC}  &
+\tcode{LC_COLLATE}  &
 \tcode{NULL <ctime>}  &
 \tcode{SIGSEGV} &
 \tcode{va_start}  \\
 
-\tcode{CLOCKS_PER_SEC}  &
-\tcode{LC_COLLATE}  &
+\tcode{EDOM}    &
+\tcode{LC_CTYPE}  &
 \tcode{NULL <cwchar>} &
 \tcode{SIGTERM} &
 \tcode{WCHAR_MAX} \\
 
-\tcode{EDOM}    &
-\tcode{LC_CTYPE}  &
+\tcode{EILSEQ}    &
+\tcode{LC_MONETARY} &
 \tcode{offsetof}  &
 \tcode{SIG_DFL} &
 \tcode{WCHAR_MIN} \\
 
-\tcode{EILSEQ}    &
-\tcode{LC_MONETARY} &
+\tcode{EOF}     &
+\tcode{LC_NUMERIC}  &
 \tcode{RAND_MAX}  &
 \tcode{SIG_ERR} &
 \tcode{WEOF <cwchar>} \\
 
-\tcode{EOF}     &
-\tcode{LC_NUMERIC}  &
+\tcode{ERANGE}    &
+\tcode{LC_TIME} &
 \tcode{SEEK_CUR}  &
 \tcode{SIG_IGN} &
 \tcode{WEOF <cwctype>}  \\
 
-\tcode{ERANGE}    &
-\tcode{LC_TIME} &
+\tcode{errno}   &
+\tcode{L_tmpnam}  &
 \tcode{SEEK_END}  &
 \tcode{stderr}    &
 \tcode{_IOFBF}    \\
 
-\tcode{errno}   &
-\tcode{L_tmpnam}  &
+\tcode{EXIT_FAILURE}  &
+\tcode{MB_CUR_MAX}  &
 \tcode{SEEK_SET}  &
 \tcode{stdin}   &
 \tcode{_IOLBF}    \\
 
-\tcode{EXIT_FAILURE}  &
-\tcode{MB_CUR_MAX}  &
+\tcode{EXIT_SUCCESS}  &
+\tcode{NULL <clocale>}  &
 \tcode{setjmp}    &
 \tcode{stdout}    &
 \tcode{_IONBF}    \\
 
-\tcode{EXIT_SUCCESS}  &
-\tcode{NULL <clocale>}  &
+\tcode{FILENAME_MAX}  &
+\tcode{NULL <cstddef>}  &
 \tcode{SIGABRT} &
 \tcode{TMP_MAX} & \\
 
-\tcode{FILENAME_MAX}  &
-\tcode{NULL <cstddef>}  &
+\tcode{FOPEN_MAX} &
+\tcode{NULL <cstdio>}  &
 \tcode{SIGFPE}    &
 \tcode{va_arg}    & \\
-
-\tcode{FOPEN_MAX} &
-\tcode{NULL <cstdlib>}  &
-\tcode{SIGILL}    &
-\tcode{va_copy}   & \\
 
 
 \end{floattable}
 
 \pnum
-The \Cpp standard library provides 57 standard values from the C library,
+The \Cpp standard library provides 45 standard values from the C library,
 as shown in Table~\ref{tab:diff.standard.values}.
 
 \begin{floattable}{Standard values}{tab:diff.standard.values}
@@ -1696,7 +1697,7 @@ as shown in Table~\ref{tab:diff.standard.values}.
 \end{floattable}
 
 \pnum
-The \Cpp standard library provides 20 standard types from the C library,
+The \Cpp standard library provides 15 standard types from the C library,
 as shown in Table~\ref{tab:diff.standard.types}.
 
 \begin{floattable}{Standard types}{tab:diff.standard.types}


### PR DESCRIPTION
Add `NULL <cstdio>` and reflow Table 149 to maintain alphabetical order (for issue #586)