### PR TITLE
[macros] Add space into \range, reflow [alg.transform]

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -1581,12 +1581,12 @@ or
 \requires
 \tcode{op} and \tcode{binary_op}
 shall not invalidate iterators or subranges, or modify elements in the ranges
-\crange{first1}{last1},
-\crange{first2}{first2 + (last1 - first1)},
-and
-\crange{result}
-{result + (last1 - first1)}.\footnote{The use of fully
+\begin{itemize}
+\item \crange{first1}{last1},
+\item \crange{first2}{first2 + (last1 - first1)}, and
+\item \crange{result}{result + (last1 - first1)}.\footnote{The use of fully
 closed ranges is intentional.}
+\end{itemize}
 
 \pnum
 \returns

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -234,7 +234,7 @@
 \newcommand{\mname}[1]{\tcode{\unun\ungap#1\ungap\unun}}
 
 %% Ranges
-\newcommand{\Range}[4]{\tcode{#1\brk{}#3,\brk{}#4\brk{}#2}\xspace}
+\newcommand{\Range}[4]{\tcode{#1#3,~\brk{}#4#2}\xspace}
 \newcommand{\crange}[2]{\Range{[}{]}{#1}{#2}}
 \newcommand{\brange}[2]{\Range{(}{]}{#1}{#2}}
 \newcommand{\orange}[2]{\Range{(}{)}{#1}{#2}}


### PR DESCRIPTION
The usual typographic convention is to have a space after (but not before) a comma. This change inserts a comma into the `\range` macro to print ranges as `[a, b)` rather than the current `[a,b)`.

This has about 90 pdfdiffs, all looking like improvements.