### PR TITLE
[c.files] cinttypes synopsis refers to SCNX* macros which do not exist

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -10054,8 +10054,8 @@ macros defined by \tcode{<cinttypes>} are provided unconditionally. In particula
 \cspan{\macros}   \\
 \cspan{\tcode{PRI\{d i o u x X\}[FAST LEAST]\{8 16 32 64\}}} \\
 \cspan{\tcode{PRI\{d i o u x X\}\{MAX PTR\}}} \\
-\cspan{\tcode{SCN\{d i o u x X\}[FAST LEAST]\{8 16 32 64\}}} \\
-\cspan{\tcode{SCN\{d i o u x X\}\{MAX PTR\}}} \\ \rowsep
+\cspan{\tcode{SCN\{d i o u x\}[FAST LEAST]\{8 16 32 64\}}} \\
+\cspan{\tcode{SCN\{d i o u x\}\{MAX PTR\}}} \\ \rowsep
 \types  & \tcode{imaxdiv_t} &&\\ \rowsep
 \cspan{\functions}  \\
 \tcode{abs} &


### PR DESCRIPTION
This addresses #596 by removing the uppercase X from the SCN* rows of Table 134