### PR TITLE
[dcl.type.cv]/6 "program behavior" vs "behavior"

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1181,7 +1181,7 @@ What constitutes an access to an object that has volatile-qualified type is
 implementation-defined.
 If an attempt is made to refer to an object defined with a
 volatile-qualified type through the use of a glvalue with a
-non-volatile-qualified type, the program behavior is undefined.
+non-volatile-qualified type, the behavior is undefined.
 
 \pnum
 \indextext{type~specifier!\idxcode{volatile}}%


### PR DESCRIPTION
[dcl.type.cv]/6 reads

> If an attempt is made to refer to an object defined with a volatile-qualified type through the use of a glvalue with a non-volatile-qualified type, the program behavior is undefined.

This is probably meant to use the idiomatic phrase "the behavior is undefined".