### PR TITLE
[expr.const] adjust note

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4849,8 +4849,7 @@ is an expression of integral or
 unscoped enumeration type, implicitly converted to a prvalue, where the converted expression is a core constant expression.
 \enternote
 Such expressions may be
-used as array bounds~(\ref{dcl.array}, \ref{expr.new}),
-as bit-field lengths~(\ref{class.bit}), as enumerator
+used as bit-field lengths~(\ref{class.bit}), as enumerator
 initializers if the underlying type is not fixed~(\ref{dcl.enum}),
 and as alignments~(\ref{dcl.align}).
 \exitnote


### PR DESCRIPTION
Array bounds now use "converted constant expressions of type std::size_t", not integral constant expressions.