### PR TITLE
Making identifier label into a definition.

### DIFF
--- a/source/statements.tex
+++ b/source/statements.tex
@@ -39,7 +39,8 @@ A statement can be labeled.
     attribute-specifier-seq\opt \terminal{default :} statement
 \end{bnf}
 
-The optional \grammarterm{attribute-specifier-seq} appertains to the label. An identifier label declares the identifier. The only use of an
+The optional \grammarterm{attribute-specifier-seq} appertains to the label. An
+\defn{identifier label} declares the identifier. The only use of an
 identifier label is as the target of a
 \indextext{statement!\idxcode{goto}}%
 \tcode{goto}.


### PR DESCRIPTION
Changed identifier label into a definition; it is used by the resolution to CWG 2163.