### PR TITLE
Adding a note about what a member subobject is

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -499,8 +499,9 @@ full set of members of the class; no member can be added elsewhere.
 Members of a class are data members, member
 functions~(\ref{class.mfct}), nested types, and enumerators. Data
 members and member functions are static or non-static;
-see~\ref{class.static}. Nested types are
-classes~(\ref{class.name},~\ref{class.nest}) and
+see~\ref{class.static}. \enternote A non-static data member of non-reference
+type is a member subobject of a class object~(\ref{intro.object}).\exitnote
+Nested types are classes~(\ref{class.name},~\ref{class.nest}) and
 enumerations~(\ref{dcl.enum}) defined in the class, and arbitrary types
 declared as members by use of a typedef declaration~(\ref{dcl.typedef}).
 The enumerators of an unscoped enumeration~(\ref{dcl.enum}) defined in the class


### PR DESCRIPTION
1.8 defines member subobject and has an x-ref to 9.2, but 9.2 never mentions what a member subobject is. This note clarifies what is normatively stated elsewhere.