### PR TITLE
Remove redundant constraint in [class.static.data]

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1207,10 +1207,9 @@ or indirectly within unnamed classes shall not contain \tcode{static}
 data members.
 
 \pnum
-\indextext{restriction!static@\tcode{static} member local~class}%
-\tcode{Static} data members of a class in namespace scope have
-the linkage of that class~(\ref{basic.link}). A local class shall not have \tcode{static}
-data members.
+\enternote
+Static data members of a class in namespace scope have the linkage of that class~(\ref{basic.link}). A local class cannot have static data members~(\ref{class.local}).
+\exitnote
 
 \pnum
 \tcode{Static} data members are initialized and destroyed exactly like
@@ -1637,6 +1636,7 @@ A class nested within
 a local class is a local class.
 
 \pnum
+\indextext{restriction!static@\tcode{static} member local~class}%
 A local class shall not have static data members.
 
 \rSec1[class.nested.type]{Nested type names}


### PR DESCRIPTION
The fact that local classes shall not have static data members is already stated in [class.local]/4 with the exact same wording.