### PR TITLE
[defns.const.subexpr] Remove superfluous words

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -357,8 +357,7 @@ and \tcode{x.front()} can be called only if \tcode{x.empty()} returns
 an expression whose evaluation as subexpression of a
 \grammarterm{conditional-expression}
 \tcode{CE}~(\ref{expr.cond}) would not prevent \tcode{CE}
-from being a core constant expression~(\ref{expr.const}).
-\tcode{false}. \exitexample
+from being a core constant expression~(\ref{expr.const})
 
 \rSec1[defns.additional]{Additional definitions}
 


### PR DESCRIPTION
It seems that this `\tcode{false}. \exitexample` is wrongly copied from the pevious section, i.e. 17.3.27 [defns.valid].

I also removed the full stop, because most definitions in section 1.3 [intro.defs] and 17.3 [deﬁnitions] do not use full stop ([defns.well.formed] and [defns.referenceable] being the only two exceptions).