### PR TITLE
[support.types] Remove "field", which is not a defined term in C++

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -91,8 +91,8 @@ is overloaded for any of the types involved.}
 The expression \tcode{offsetof}(\textit{type}, \grammarterm{member-designator})
 is never type-dependent~(\ref{temp.dep.expr}) and it is
 value-dependent~(\ref{temp.dep.constexpr}) if and only if \textit{type} is
-dependent. The result of applying the \tcode{offsetof} macro to a field that
-is a static data member or a function member is undefined.
+dependent. The result of applying the \tcode{offsetof} macro to
+a static data member or a function member is undefined.
 No operation invoked by the \tcode{offsetof} macro shall throw an exception and
 \tcode{noexcept(offsetof(type, member-designator))} shall be \tcode{true}.
 


### PR DESCRIPTION
Remove the use of "field" from [support.types] p4 "The result of applying the offsetof macro to a field that is a static data member or a function member is undefined.", because
- the Standard does not define the term, or
- the usual meaning of "field" in OPP does not include member functions but this sentence says "a field that is **a static data member or a function member**".