### PR TITLE
[expr.prim.lambda] Fix the capture list in code example

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -691,7 +691,7 @@ type specified by the
 auto x1 = [](int i){ return i; };     // OK: return type is \tcode{int}
 auto x2 = []{ return { 1, 2 }; };     // error: deducing return type from \grammarterm{braced-init-list}
 int j;
-auto x3 = []()->auto&& { return j; }; // OK: return type is \tcode{int\&}
+auto x3 = [&]()->auto&& { return j; }; // OK: return type is \tcode{int\&}
 \end{codeblock}
 \exitexample
 


### PR DESCRIPTION
proposed change for issue #609 : adding a default capture to the example in 5.1.2.4.