### PR TITLE
[terminate] Fix typo "terminate_handleri"

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -2803,7 +2803,7 @@ May also be called directly by the program.
 
 \pnum
 \effects
-Calls a \tcode{terminate_handleri} function. It is unspecified which
+Calls a \tcode{terminate_handler} function. It is unspecified which
 \tcode{terminate_handler} function will be called if an exception is active
 during a call to \tcode{set_terminate}.
 Otherwise calls the current \tcode{terminate_handler} function. \enternote A


### PR DESCRIPTION
There seems to be a typo in the application of LWG2111 to the WP.