### PR TITLE
Remove incorrect "shall"

### DIFF
--- a/source/regex.tex
+++ b/source/regex.tex
@@ -2551,7 +2551,7 @@ by the member functions of class template \tcode{match_results}.
 \indextext{requirements!container}%
 \indextext{requirements!sequence}%
 \indextext{\idxcode{match_results}!as sequence}%
-The class template \tcode{match_results} shall satisfy the requirements of an
+The class template \tcode{match_results} satisfies the requirements of an
 allocator-aware container and of a sequence container, as specified
 in~\ref{sequence.reqmts}, except that only operations defined for const-qualified
 sequence containers are supported.


### PR DESCRIPTION
while looking at LWG issue #2589, I noticed that L2554 says "`match_results` shall satisfy the ...".
In general, we use "shall" to place requirements on user code, not on library code.
Change to just say "satisfies", rather than "shall satisfy"