### PR TITLE
[unique.ptr.runtime.ctor] Fix format

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -5245,7 +5245,7 @@ where \tcode{UP} is \tcode{unique_ptr<U, E>}:
 
 \begin{itemize}
 \item \tcode{U} is an array type, and
-\item \tcode{pointer} is the same type as {element_type*}, and
+\item \tcode{pointer} is the same type as \tcode{element_type*}, and
 \item \tcode{UP::pointer} is the same type as \tcode{UP::element_type*}, and
 \item \tcode{UP::element_type(*)[]} is convertible to \tcode{element_type(*)[]}, and
 \item either \tcode{D} is a reference type and \tcode{E} is the same type as \tcode{D},


### PR DESCRIPTION
Add missing `\tcode` in [unique.ptr.runtime.ctor]/2.2.
