### PR TITLE
Swap effects of `basic_regex::operator=` and `assign`

### DIFF
--- a/source/regex.tex
+++ b/source/regex.tex
@@ -1633,7 +1633,11 @@ basic_regex& operator=(const basic_regex& e);
 
 \begin{itemdescr}
 \pnum
-\effects  returns \tcode{assign(e)}.
+\effects  copies \tcode{e} into \tcode{*this} and returns \tcode{*this}.
+
+\pnum\postconditions
+\tcode{flags()} and \tcode{mark_count()} return
+\tcode{e.flags()} and \tcode{e.mark_count()}, respectively.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_regex}!\idxcode{operator=}}%
@@ -1644,7 +1648,12 @@ basic_regex& operator=(basic_regex&& e) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects  returns \tcode{assign(std::move(e))}.
+\effects  move assigns from \tcode{e} into \tcode{*this} and returns \tcode{*this}.
+
+\pnum
+\postconditions \tcode{flags()} and \tcode{mark_count()} return the values that
+\tcode{e.flags()} and \tcode{e.mark_count()}, respectively, had before assignment.
+\tcode{e} is in a valid state with unspecified value.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_regex}!\idxcode{operator=}}%
@@ -1692,11 +1701,10 @@ basic_regex& assign(const basic_regex& that);
 
 \begin{itemdescr}
 \pnum
-\effects  copies \tcode{that} into \tcode{*this} and returns \tcode{*this}.
+\effects  Equivalent to \tcode{*this = that}.
 
-\pnum\postconditions
-\tcode{flags()} and \tcode{mark_count()} return
-\tcode{that.flags()} and \tcode{that.mark_count()}, respectively.
+\pnum
+\returns  \tcode{*this}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_regex}!\idxcode{assign}}%
@@ -1707,12 +1715,10 @@ basic_regex& assign(basic_regex&& that) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects  move assigns from \tcode{that} into \tcode{*this} and returns \tcode{*this}.
+\effects  Equivalent to \tcode{*this = std::move(that)}.
 
 \pnum
-\postconditions \tcode{flags()} and \tcode{mark_count()} return the values that
-\tcode{that.flags()} and \tcode{that.mark_count()}, respectively, had before assignment.
-\tcode{that} is in a valid state with unspecified value.
+\returns  \tcode{*this}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_regex}!\idxcode{assign}}%


### PR DESCRIPTION
Currently, `basic_regex::operator=` is defined in terms of assign. This is different from what `basic_string` (and possibly others) do.
Swap the descriptions so that `assign` is now defined in terms of `operator=`. No functional change to either is intended.