### PR TITLE
Re-synchronize generated grammar.tex with grambase.tex.

### DIFF
--- a/tools/grambase.tex
+++ b/tools/grambase.tex
@@ -3,8 +3,8 @@
 \begin{paras}
 
 \pnum
-\index{grammar}%
-\index{summary, syntax}%
+\indextext{grammar}%
+\indextext{summary!syntax}%
 This summary of \Cpp\  syntax is intended to be an aid to comprehension.
 It is not an exact statement of the language.
 In particular, the grammar described here accepts
@@ -17,7 +17,7 @@ to weed out syntactically valid but meaningless constructs.
 \rSec1[gram.key]{Keywords}
 
 \pnum
-\index{keyword}%
+\indextext{keyword}%
 New context-dependent keywords are introduced into a program by
 \tcode{typedef}~(\ref{dcl.typedef}),
 \tcode{namespace}~(\ref{namespace.def}),


### PR DESCRIPTION
Last year, I submitted some changes to grammar.tex to fix some index entries, but I did not realize that grammar.tex is a file generated by tools/makegram.

This patch makes the same changes in tools/grambase.tex, so that grammar.tex corresponds once more to the output of tools/makegram.