### PR TITLE
Uniform "ones' complement" and "two's complement"

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3802,8 +3802,8 @@ and 1, in which the values represented by successive bits are additive,
 begin with 1, and are multiplied by successive integral power of 2,
 except perhaps for the bit with the highest position. (Adapted from the
 \doccite{American National Dictionary for Information Processing Systems}.)}
-\enterexample this International Standard permits 2's complement, 1's
-complement and signed magnitude representations for integral types.
+\enterexample this International Standard permits two's complement,
+ones' complement and signed magnitude representations for integral types.
 \exitexample
 
 \pnum

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1984,7 +1984,7 @@ the enumeration are the values of the underlying type. Otherwise,
 for an enumeration where $e_\mathit{min}$ is the smallest enumerator and
 $e_\mathit{max}$ is the largest, the values of the enumeration are the
 values in the range $b_{min}$ to $b_{max}$, defined as follows: Let $K$
-be 1 for a two's complement representation and 0 for a one's complement
+be 1 for a two's complement representation and 0 for a ones' complement
 or sign-magnitude representation. $b_{max}$ is the smallest value
 greater than or equal to $max(|e_{min}| - K, |e_{max}|)$ and equal to
 $2^M-1$, where $M$ is a non-negative integer. $b_{min}$ is zero if

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2527,8 +2527,8 @@ Expressions with unary operators group right-to-left.
 \indextext{\idxcode{+}|see{operator, unary~plus}}%
 \indextext{operator!logical negation}%
 \indextext{\idxcode{"!}|see{operator, logical~negation}}%
-\indextext{operator!one's~complement}%
-\indextext{~@\tcode{\tilde}|see{operator, one's~complement}}%
+\indextext{operator!ones'~complement}%
+\indextext{~@\tcode{\tilde}|see{operator, ones'~complement}}%
 \indextext{operator!increment}%
 \indextext{operator!decrement}%
 %
@@ -2655,9 +2655,9 @@ if the converted operand is \tcode{false} and \tcode{false} otherwise.
 The type of the result is \tcode{bool}.
 
 \pnum
-\indextext{operator!one's~complement}%
+\indextext{operator!ones'~complement}%
 The operand of \tcode{\~{}} shall have integral or unscoped enumeration type; the
-result is the one's complement of its operand. Integral promotions are
+result is the ones' complement of its operand. Integral promotions are
 performed. The type of the result is the type of the promoted operand.
 There is an ambiguity
 in the grammar when \tcode{\~{}} is followed by


### PR DESCRIPTION
"one's complement" is inconsistent with the C standard.
"1's complement" and "2's complement" are also inconsistent.

FYI, I found that there was a lengthy discussion on Wikipedia at 2011
about "one's complement". The C++ standard was mentioned as a notable
use of "one's complement". There seems no consensus in the discussion,
but the main article has been settled as "ones' complement" for years
since then.
https://en.wikipedia.org/wiki/Ones'_complement
https://en.wikipedia.org/wiki/Wikipedia_talk:WikiProject_Computer_science/Archive_10#Ones.27_complement_or_one.27s_complement.3F

For me, a quote from "Art of Computer Programming, Volume 2" by
Donald E. Knuth is convincing.
https://books.google.com/books?id=Zu-HAwAAQBAJ&pg=PT343
> ... A two's complement number is complemented with respect to a single
> power of 2, while ones' complement number is complemented with respect
> to a long sequence of 1s. ...

While it is still debatable in general, I think inconsistency with the
C standard is enough for the C++ standard to justify this change.
