### PR TITLE
Delete the notionally redundant 'update' when describing actions upon ...

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -482,7 +482,7 @@ sequence of adjacent bit-fields all having non-zero width. \enternote Various
 features of the language, such as references and virtual functions, might
 involve additional memory locations that are not accessible to programs but are
 managed by the implementation. \exitnote Two or more threads of
-execution~(\ref{intro.multithread}) can update and access separate memory
+execution~(\ref{intro.multithread}) can access separate memory
 locations without interfering with each other.
 
 \pnum


### PR DESCRIPTION
... independent memory locations.  The definition of 'access' includes modifying a location per 1.3.1/access, so we don't need to state 'update and access' we should be able to just state 'access'

(p.s. My first pull request - please let me know if I'm not doing this right or I should be doing something better.  Thank you!)