### PR TITLE
Replaced \note with \remark and \notes with \remarks.

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -1532,7 +1532,7 @@ exactly
 times.
 
 \pnum
-\notes
+\remarks
 If \tcode{f} returns a result, the result is ignored.
 \end{itemdescr}
 
@@ -2428,7 +2428,7 @@ applications of
 \tcode{op} or \tcode{binary_op}.
 
 \pnum
-\notes
+\remarks
 \tcode{result} may be equal to \tcode{first}
 in case of unary transform,
 or to \tcode{first1} or \tcode{first2}
@@ -2902,7 +2902,7 @@ into position
 \returns \tcode{first + (last - middle)}.
 
 \pnum
-\notes
+\remarks
 This is a left rotate.
 
 \pnum
@@ -3065,7 +3065,7 @@ Exactly
 swaps.
 
 \pnum
-\notes
+\remarks
 To the extent that the implementation of this function makes use of random
 numbers, the object \tcode{g} shall serve as the implementation's source of
 randomness.
@@ -4026,7 +4026,7 @@ At most
 comparisons.
 
 \pnum
-\notes If \range{first1}{last1} contains $m$ elements that are equivalent to
+\remarks If \range{first1}{last1} contains $m$ elements that are equivalent to
 each other and \range{first2}{last2} contains $n$ elements that are equivalent
 to them, then all $m$ elements from the first range shall be copied to the output
 range, in order, and then $\max(n - m, 0)$ elements from the second range shall
@@ -4073,7 +4073,7 @@ At most
 comparisons.
 
 \pnum
-\notes If \range{first1}{last1} contains $m$ elements that are equivalent to
+\remarks If \range{first1}{last1} contains $m$ elements that are equivalent to
 each other and \range{first2}{last2} contains $n$ elements that are equivalent
 to them, the first $\min(m, n)$ elements shall be copied from the first range
 to the output range, in order.
@@ -4124,7 +4124,7 @@ At most
 comparisons.
 
 \pnum
-\notes
+\remarks
 If
 \range{first1}{last1}
 contains $m$
@@ -4187,7 +4187,7 @@ At most
 comparisons.
 
 \pnum
-\notes
+\remarks
 If \range{first1}{last1} contains $m$ elements that are equivalent to each other and
 \range{first2}{last2} contains $n$ elements that are equivalent to them, then
 $|m - n|$ of those elements shall be copied to the output range: the last
@@ -4441,7 +4441,7 @@ For the first form, type \tcode{T} shall be
 The smaller value.
 
 \pnum
-\notes
+\remarks
 Returns the first argument when the arguments are equivalent.
 
 \pnum
@@ -4491,7 +4491,7 @@ For the first form, type \tcode{T} shall be
 The larger value.
 
 \pnum
-\notes
+\remarks
 Returns the first argument when the arguments are equivalent.
 
 \pnum
@@ -4544,7 +4544,7 @@ than \tcode{a}, and
 \tcode{pair<const T\&, const T\&>(a, b)} otherwise.
 
 \pnum
-\notes
+\remarks
 Returns \tcode{pair<const T\&, const T\&>(a, b)} when the arguments are equivalent.
 
 \pnum
@@ -4744,7 +4744,7 @@ At most
 applications of the corresponding comparison.
 
 \pnum
-\notes
+\remarks
 If two sequences have the same number of elements and their corresponding
 elements are equivalent, then neither sequence is lexicographically
 less than the other.

--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -1053,7 +1053,7 @@ different from \tcode{expected} or there are concurrent modifications to the
 atomic object.
 
 \pnum
-\note
+\remark
 A weak compare-and-exchange operation may fail spuriously. That is, even when
 the contents of memory referred to by \tcode{expected} and \tcode{object} are
 equal, it may return false and store back to \tcode{expected} the same memory
@@ -1132,7 +1132,7 @@ These operations are atomic read-modify-write operations~(\ref{intro.multithread
 \returns Atomically, the value pointed to by \tcode{object} or by \tcode{this} immediately before the effects.
 
 \pnum
-\note For signed integer types, arithmetic is defined to use two's complement
+\remark For signed integer types, arithmetic is defined to use two's complement
 representation. There are no undefined results. For address types, the result may be an
 undefined address, but the operations otherwise have no undefined behavior.
 \end{itemdescr}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -3170,7 +3170,7 @@ deque invalidates all the iterators to the deque, but has no effect on
 the validity of references to elements of the deque.
 
 \pnum
-\notes
+\remarks
 If an exception is thrown other than by the
 copy constructor, move constructor,
 assignment operator, or move assignment operator of
@@ -4316,7 +4316,7 @@ void push_back(T&& x);
 
 \begin{itemdescr}
 \pnum
-\notes
+\remarks
 Does not affect the validity of iterators and references.
 If an exception is thrown there are no effects.
 
@@ -4976,7 +4976,7 @@ max_size()}.\footnote{\tcode{reserve()} uses \tcode{Allocator::allocate()} which
 may throw an appropriate exception.}
 
 \pnum
-\notes
+\remarks
 Reallocation invalidates all the references, pointers, and iterators
 referring to the elements in the sequence.
 No reallocation shall take place during insertions that happen
@@ -5000,7 +5000,7 @@ void shrink_to_fit();
 \complexity Linear in the size of the sequence.
 
 \pnum
-\notes \tcode{shrink_to_fit} is a non-binding request to reduce \tcode{capacity()} to \tcode{size()}. \enternote The request is non-binding to allow latitude for implementation-specific optimizations. \exitnote
+\remarks \tcode{shrink_to_fit} is a non-binding request to reduce \tcode{capacity()} to \tcode{size()}. \enternote The request is non-binding to allow latitude for implementation-specific optimizations. \exitnote
 If an exception is thrown other than by the move constructor of a non-\tcode{CopyInsertable} \tcode{T} there are no effects.
 \end{itemdescr}
 
@@ -5041,7 +5041,7 @@ appends \tcode{sz - size()} default-inserted elements to the sequence.
 \tcode{MoveInsertable} and \tcode{DefaultInsertable} into \tcode{*this}.
 
 \pnum
-\notes If an exception is thrown other than by the move constructor of a non-\tcode{CopyInsertable}
+\remarks If an exception is thrown other than by the move constructor of a non-\tcode{CopyInsertable}
 \tcode{T} there are no effects.
 \end{itemdescr}
 
@@ -5061,7 +5061,7 @@ appends \tcode{sz - size()} copies of \tcode{c} to the sequence.
 \tcode{CopyInsertable} into \tcode{*this}.
 
 \pnum
-\notes If an exception is thrown there are no effects.
+\remarks If an exception is thrown there are no effects.
 \end{itemdescr}
 
 \rSec3[vector.data]{\tcode{vector} data}
@@ -5102,7 +5102,7 @@ void push_back(T&& x);
 
 \begin{itemdescr}
 \pnum
-\notes
+\remarks
 Causes reallocation if the new size is greater than the old capacity.
 If no reallocation happens, all the iterators and references before the insertion point remain valid.
 If an exception is thrown other than by

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -1047,7 +1047,7 @@ const error_category& generic_category() noexcept;
 All calls to this function shall return references to the same object.
 
 \pnum
-\notes The object's \tcode{default_error_condition} and \tcode{equivalent} virtual functions shall behave as specified for the class \tcode{error_category}. The object's \tcode{name} virtual function shall return a pointer to the string \tcode{"generic"}.
+\remarks The object's \tcode{default_error_condition} and \tcode{equivalent} virtual functions shall behave as specified for the class \tcode{error_category}. The object's \tcode{name} virtual function shall return a pointer to the string \tcode{"generic"}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{system_category}}
@@ -1061,7 +1061,7 @@ const error_category& system_category() noexcept;
 All calls to this function shall return references to the same object.
 
 \pnum
-\notes The object's \tcode{equivalent} virtual functions shall behave as specified for
+\remarks The object's \tcode{equivalent} virtual functions shall behave as specified for
 class \tcode{error_category}. The object's \tcode{name} virtual function shall return a
 pointer to the string \tcode{"system"}. The object's \tcode{default_error_condition}
 virtual function shall behave as follows:

--- a/source/future.tex
+++ b/source/future.tex
@@ -419,7 +419,7 @@ Calls
 then returns the beginning pointer for the input sequence, \tcode{gbeg}.
 
 \pnum
-\notes
+\remarks
 The return value can be a null pointer.
 \end{itemdescr}
 
@@ -477,7 +477,7 @@ Returns
 to indicate failure.
 
 \pnum
-\notes
+\remarks
 The function can alter the number of write positions available as a
 result of any call.
 
@@ -565,7 +565,7 @@ Returns
 to indicate failure.
 
 \pnum
-\notes
+\remarks
 If the function can succeed in more than one of these ways, it is
 unspecified which way is chosen.
 \indextext{unspecified}%
@@ -608,7 +608,7 @@ Returns
 to indicate failure.
 
 \pnum
-\notes
+\remarks
 The function can alter the number of read positions available as a
 result of any call.
 \end{itemdescr}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -1515,7 +1515,7 @@ On failure a valid
 initialized to 0.
 
 \pnum
-\notes
+\remarks
 After a subsequent call to
 \tcode{pword(int)}
 for the same object, the earlier return value may no longer be valid.
@@ -1552,7 +1552,7 @@ The function
 \tcode{fn}
 shall not throw exceptions.
 
-\notes
+\remarks
 Identical pairs are not merged.
 A function registered twice will be called twice.
 \end{itemdescr}
@@ -1847,7 +1847,7 @@ behavior is undefined.
 
 \begin{itemdescr}
 \pnum
-\notes
+\remarks
 The destructor does not destroy
 \tcode{rdbuf()}.
 \end{itemdescr}
@@ -3042,7 +3042,7 @@ at the time of construction.
 \end{itemize}
 
 \pnum
-\notes
+\remarks
 Once the
 \tcode{getloc()}
 member is initialized, results of calling locale member functions,
@@ -3506,7 +3506,7 @@ void imbue(const locale&);
 Change any translations based on locale.
 
 \pnum
-\notes
+\remarks
 Allows the derived class to be informed of changes in locale at the
 time they occur.
 Between invocations of this function a class derived
@@ -3654,7 +3654,7 @@ but that they will return ``immediately.''}
 Returns zero.
 
 \pnum
-\notes
+\remarks
 Uses
 \tcode{traits::eof()}.
 \end{itemdescr}
@@ -3689,7 +3689,7 @@ and
 by overriding these definitions from the base class.}
 
 \pnum
-\notes
+\remarks
 Uses
 \tcode{traits::eof()}.
 \end{itemdescr}
@@ -3701,7 +3701,7 @@ int_type underflow();
 
 \begin{itemdescr}
 \pnum
-\notes
+\remarks
 The public members of
 \tcode{basic_streambuf}
 call this virtual function only if
@@ -3865,7 +3865,7 @@ int_type pbackfail(int_type c = traits::eof());
 
 \begin{itemdescr}
 \pnum
-\notes
+\remarks
 The public functions of
 \tcode{basic_streambuf}
 call this virtual function only when
@@ -3983,7 +3983,7 @@ otherwise, the sequence consisting of \tcode{c}.
 \end{enumeratea}
 
 \pnum
-\notes
+\remarks
 The member functions
 \tcode{sputc()}
 and
@@ -4372,7 +4372,7 @@ Destroys an object of class
 \tcode{basic_istream}.
 
 \pnum
-\notes
+\remarks
 Does not perform any operations of
 \tcode{rdbuf()}.
 \end{itemdescr}
@@ -4488,7 +4488,7 @@ the function calls
 \tcode{ios_base::failure}).
 
 \pnum
-\notes
+\remarks
 The constructor
 \tcode{explicit sentry(basic_istream<charT,traits>\& is, bool noskipws = false)}
 uses the currently imbued locale in \tcode{is},
@@ -5289,7 +5289,7 @@ for the next available input character \tcode{c}
 \end{itemize}
 
 \pnum
-\notes
+\remarks
 The last condition will never occur if
 \tcode{traits::eq_int_type(delim, traits::eof())}.
 
@@ -5718,7 +5718,7 @@ Destroys an object of class
 \tcode{basic_iostream}.
 
 \pnum
-\notes
+\remarks
 Does not perform any operations on
 \tcode{rdbuf()}.
 \end{itemdescr}
@@ -5954,7 +5954,7 @@ Destroys an object of class
 \tcode{basic_ostream}.
 
 \pnum
-\notes
+\remarks
 Does not perform any operations on
 \tcode{rdbuf()}.
 \end{itemdescr}
@@ -7658,7 +7658,7 @@ Returns:
 to indicate failure.
 
 \pnum
-\notes
+\remarks
 If the function can succeed in more than one of these ways, it is
 unspecified which way is chosen.
 \indextext{unspecified}%
@@ -7701,7 +7701,7 @@ Signals success by returning a value other than
 \end{itemize}
 
 \pnum
-\notes
+\remarks
 The function can alter the number of write positions available as a
 result of any call.
 
@@ -8872,7 +8872,7 @@ Behaves the same as
 \indexlibrary{\idxcode{showmanyc}!\idxcode{basic_streambuf}}%
 
 \pnum
-\notes
+\remarks
 An
 implementation might well provide an overriding definition for this function
 signature if it can determine that more characters can be read from the input
@@ -8999,7 +8999,7 @@ Returns:
 to indicate failure.
 
 \pnum
-\notes
+\remarks
 If
 \tcode{is_open() == false},
 the function always fails.
@@ -9114,7 +9114,7 @@ otherwise call
 \tcode{std::fseek(file, 0, whence)}.
 
 \pnum
-\notes
+\remarks
 ``The last operation was output'' means either
 the last virtual operation was overflow or
 the put buffer is non-empty.
@@ -9234,7 +9234,7 @@ to be converted according to \tcode{loc} until another call of
 \tcode{imbue}.
 
 \pnum
-\note
+\remark
 This may require reconversion of previously converted characters.
 This in turn may require the implementation to be able to reconstruct
 the original contents of the file.

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -499,7 +499,7 @@ preconditions, there will be no ``Requires'' paragraph.}
 \item \returns a description of the value(s) returned by the function
 \item \throws any exceptions thrown by the function, and the conditions that would cause the exception
 \item \complexity the time and/or space complexity of the function
-\item \notes additional semantic constraints on the function
+\item \remarks additional semantic constraints on the function
 \item \errors the error conditions for error codes reported by the function.
 \item \realnotes non-normative comments about the function
 \end{itemize}
@@ -510,7 +510,7 @@ Whenever the \effects element specifies that the semantics of some function
 interpreted as follows. If \tcode{F}'s semantics specifies a \requires element, then
 that requirement is logically imposed prior to the \techterm{equivalent-to} semantics.
 Next, the semantics of the code sequence are determined by the \requires, \effects,
-\postconditions, \returns, \throws, \complexity, \notes, \errors, and \realnotes
+\postconditions, \returns, \throws, \complexity, \remarks, \errors, and \realnotes
 specified for the function invocations contained in the code sequence. The value
 returned from \tcode{F} is specified by \tcode{F}'s \returns element, or if \tcode{F}
 has no \returns element, a non-\tcode{void} return from \tcode{F} is specified by the

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -618,7 +618,7 @@ with that name.
 if the argument is not valid, or is null.
 
 \pnum
-\notes
+\remarks
 The set of valid string argument values is \tcode{"C"}, \tcode{""},
 and any \impldef{locale names} values.
 \end{itemdescr}
@@ -654,7 +654,7 @@ argument, which instead implement the same semantics as
 if the argument is not valid, or is null.
 
 \pnum
-\notes
+\remarks
 The locale has a name if and only if
 \tcode{other}
 has a name.
@@ -686,7 +686,7 @@ If \tcode{f}
 is null, the resulting object is a copy of \tcode{other}.
 
 \pnum
-\notes
+\remarks
 The resulting locale has no name.
 \end{itemdescr}
 
@@ -704,7 +704,7 @@ except those that implement
 which are instead incorporated from the second argument.
 
 \pnum
-\notes
+\remarks
 The resulting locale has a name if and only if the first two arguments
 have names.
 \end{itemdescr}
@@ -766,7 +766,7 @@ if
 is false.
 
 \pnum
-\notes
+\remarks
 The resulting locale has no name.
 \end{itemdescr}
 
@@ -839,7 +839,7 @@ Compares two strings according to the
 facet.
 
 \pnum
-\notes
+\remarks
 This member operator template (and therefore
 \tcode{locale}
 itself) satisfies requirements for a comparator predicate template argument
@@ -922,7 +922,7 @@ A locale that implements the classic \tcode{"C"} locale semantics, equivalent
 to the value \tcode{locale("C")}.
 
 \pnum
-\notes
+\remarks
 This locale, its facets, and their member functions, do not change
 with time.
 \end{itemdescr}
@@ -956,7 +956,7 @@ is
 \tcode{false}.
 
 \pnum
-\notes
+\remarks
 The reference returned remains valid at least as long as any copy of
 \tcode{loc} exists.
 \end{itemdescr}
@@ -2582,7 +2582,7 @@ must be able to translate characters one internal character at a time.
 \enternote As a result of operations on \tcode{state}, it can return \tcode{ok} or \tcode{partial} and set \tcode{from_next == from} and \tcode{to_next != to}. \exitnote
 
 \pnum
-\notes
+\remarks
 Its operations on \tcode{state} are unspecified.
 \enternote
 This argument can be used, for example, to maintain
@@ -4468,7 +4468,7 @@ In such cases the values of those \tcode{struct tm} members are unspecified
 and may be outside their valid range.
 
 \pnum
-\note It is unspecified whether multiple calls to
+\remark It is unspecified whether multiple calls to
 \tcode{do_get()} with the
 address of the same \tcode{struct tm} object will update the current contents of
 the object or simply overwrite its members. Portable programs must zero
@@ -5029,7 +5029,7 @@ Calls
 \tcode{str.width(0)}.
 
 \pnum
-\notes
+\remarks
 % issues 22-021, 22-030, 22-034 from 97-0058/N1096, 97-0036/N1074
 The currency symbol is generated if and only if
 \tcode{(str.flags() \& str.showbase)}
@@ -5552,7 +5552,7 @@ The result can be used until it is passed to
 Returns a value less than 0 if no such catalog can be opened.
 
 \pnum
-\notes
+\remarks
 The locale argument \tcode{loc}
 is used for character set code conversion when retrieving
 messages, if needed.
@@ -5597,7 +5597,7 @@ and not yet closed.
 Releases unspecified resources associated with  \tcode{cat}.
 
 \pnum
-\notes
+\remarks
 The limit on such resources, if any, is implementation-defined.
 \end{itemdescr}
 

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -167,8 +167,6 @@
 \newcommand{\complexity}{\Fundesc{Complexity}}
 \newcommand{\remark}{\Fundesc{Remark}}
 \newcommand{\remarks}{\Fundesc{Remarks}}
-\newcommand{\note}{\remark}
-\newcommand{\notes}{\remarks}
 \newcommand{\realnote}{\Fundesc{Note}}
 \newcommand{\realnotes}{\Fundesc{Notes}}
 \newcommand{\errors}{\Fundesc{Error conditions}}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -719,7 +719,7 @@ template<class T> complex<T> operator+(const complex<T>& lhs);
 
 \begin{itemdescr}
 \pnum
-\notes
+\remarks
 unary operator.
 
 \pnum
@@ -747,7 +747,7 @@ template<class T> complex<T> operator-(const complex<T>& lhs);
 
 \begin{itemdescr}
 \pnum
-\notes
+\remarks
 unary operator.
 
 \pnum
@@ -813,7 +813,7 @@ template<class T> constexpr bool operator==(const T& lhs, const complex<T>& rhs)
 \tcode{lhs.real() == rhs.real() \&\& lhs.imag() == rhs.imag()}.
 
 \pnum
-\notes
+\remarks
 The imaginary part is assumed to be
 \tcode{T()},
 or 0.0, for the
@@ -872,7 +872,7 @@ If bad input is encountered, calls
 \tcode{is}.
 
 \pnum
-\notes
+\remarks
 This extraction is performed as a series of simpler
 extractions.
 Therefore, the skipping of whitespace is specified to be
@@ -1154,7 +1154,7 @@ template<class T> complex<T> log(const complex<T>& x);
 
 \begin{itemdescr}
 \pnum
-\notes
+\remarks
 The branch cuts are along the negative real axis.
 
 \pnum
@@ -1171,7 +1171,7 @@ template<class T> complex<T> log10(const complex<T>& x);
 
 \begin{itemdescr}
 \pnum
-\notes
+\remarks
 The branch cuts are along the negative real axis.
 
 \pnum
@@ -1189,7 +1189,7 @@ template<class T> complex<T> pow(const T& x, const complex<T>& y);
 
 \begin{itemdescr}
 \pnum
-\notes
+\remarks
 The branch cuts are along the negative real axis.
 
 \pnum
@@ -1231,7 +1231,7 @@ template<class T> complex<T> sqrt(const complex<T>& x);
 
 \begin{itemdescr}
 \pnum
-\notes
+\remarks
 The branch cuts are along the negative real axis.
 
 \pnum
@@ -3769,7 +3769,7 @@ typedef @\textit{implementation-defined}@
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\note
+\pnum\remark
 The choice of engine type
 named by this \tcode{typedef}
 is implementation-defined.
@@ -9040,7 +9040,7 @@ shall neither modify elements nor invalidate iterators or subranges.\footnote{Th
 }
 
 \pnum
-\notes
+\remarks
 \tcode{result}
 may be equal to
 \tcode{first}.
@@ -9329,7 +9329,7 @@ shall neither modify elements nor invalidate iterators or
 subranges.\footnote{The use of fully closed ranges is intentional.}
 
 \pnum
-\notes
+\remarks
 \tcode{result}
 may be equal to
 \tcode{first}.

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -1199,7 +1199,7 @@ the character sequence. If the name
 is not recognized then returns \tcode{char_class_type()}.
 
 \pnum
-\notes  For \tcode{regex_traits<char>}, at least the narrow character names
+\remarks  For \tcode{regex_traits<char>}, at least the narrow character names
 in Table~\ref{tab:re.traits.classnames} shall be recognized.
 For \tcode{regex_traits<wchar_t>}, at least the wide character names
 in Table~\ref{tab:re.traits.classnames} shall be recognized.

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -1311,7 +1311,7 @@ is pointed at by \tcode{s}                                                      
 \end{libefftabvalue}
 
 \pnum
-\notes
+\remarks
 Uses
 \tcode{traits::length()}.
 \indexlibrary{\idxcode{length}!\tcode{char_traits}}%
@@ -1478,7 +1478,7 @@ basic_string& operator=(const charT* s);
 \tcode{*this = basic_string(s)}.
 
 \pnum
-\notes
+\remarks
 Uses
 \indexlibrary{\idxcode{length}!\tcode{char_traits}}%
 \tcode{traits::length()}.
@@ -1738,7 +1738,7 @@ void shrink_to_fit();
 
 \begin{itemdescr}
 \pnum
-\notes \tcode{shrink_to_fit} is a non-binding request to reduce
+\remarks \tcode{shrink_to_fit} is a non-binding request to reduce
 \tcode{capacity()} to \tcode{size()}. \enternote The request is non-binding to
 allow latitude for implementation-specific optimizations. \exitnote
 \end{itemdescr}
@@ -2895,7 +2895,7 @@ Otherwise, returns
 \tcode{npos}.
 
 \pnum
-\notes
+\remarks
 Uses
 \tcode{traits::eq()}.
 \end{itemdescr}
@@ -2973,7 +2973,7 @@ Otherwise, returns
 \tcode{npos}.
 
 \pnum
-\notes
+\remarks
 Uses
 \tcode{traits::eq()}.
 \end{itemdescr}
@@ -3052,7 +3052,7 @@ Otherwise, returns
 \tcode{npos}.
 
 \pnum
-\notes
+\remarks
 Uses
 \tcode{traits::eq()}.
 \end{itemdescr}
@@ -3132,7 +3132,7 @@ Otherwise, returns
 \tcode{npos}.
 
 \pnum
-\notes
+\remarks
 Uses
 \tcode{traits::eq()}.
 \end{itemdescr}
@@ -3211,7 +3211,7 @@ Otherwise, returns
 \tcode{npos}.
 
 \pnum
-\notes
+\remarks
 Uses
 \tcode{traits::eq()}.
 \end{itemdescr}
@@ -3292,7 +3292,7 @@ Otherwise, returns
 \tcode{npos}.
 
 \pnum
-\notes
+\remarks
 Uses
 \tcode{traits::eq()}.
 \end{itemdescr}
@@ -3542,7 +3542,7 @@ template<class charT, class traits, class Allocator>
 \tcode{basic_string<charT,traits,Allocator>(lhs) + rhs}.
 
 \pnum
-\notes
+\remarks
 Uses
 \tcode{traits::length()}.
 \end{itemdescr}
@@ -3562,7 +3562,7 @@ template<class charT, class traits, class Allocator>
 \tcode{std::move(rhs.insert(0, lhs))}.
 
 \pnum
-\notes
+\remarks
 Uses
 \tcode{traits::length()}.
 \end{itemdescr}
@@ -3612,7 +3612,7 @@ template<class charT, class traits, class Allocator>
 \tcode{lhs + basic_string<charT,traits,Allocator>(rhs)}.
 
 \pnum
-\notes
+\remarks
 Uses
 \tcode{traits::length()}.
 \end{itemdescr}
@@ -3632,7 +3632,7 @@ template<class charT, class traits, class Allocator>
 \tcode{std::move(lhs.append(rhs))}.
 
 \pnum
-\notes
+\remarks
 Uses
 \tcode{traits::length()}.
 \end{itemdescr}

--- a/source/support.tex
+++ b/source/support.tex
@@ -1730,7 +1730,7 @@ If \tcode{ptr} is null, does nothing. Otherwise, reclaims the
 storage allocated by the earlier call to \tcode{operator new}.
 
 \pnum
-\notes
+\remarks
 It is unspecified under what conditions part or all of such
 \indextext{unspecified}%
 reclaimed storage will be allocated by subsequent
@@ -1976,7 +1976,7 @@ void* operator new(std::size_t size, void* ptr) noexcept;
 \tcode{ptr}.
 
 \pnum
-\notes
+\remarks
 Intentionally performs no other action.
 
 \pnum
@@ -2001,7 +2001,7 @@ void* operator new[](std::size_t size, void* ptr) noexcept;
 \tcode{ptr}.
 
 \pnum
-\notes
+\remarks
 Intentionally performs no other action.
 \end{itemdescr}
 
@@ -2021,7 +2021,7 @@ If an implementation has strict pointer safety~(\ref{basic.stc.dynamic.safety})
 then \tcode{ptr} shall be a safely-derived pointer.
 
 \pnum
-\notes
+\remarks
 Default function called when any part of the initialization in a
 placement \grammarterm{new-expression} that invokes the library's
 non-array placement operator new
@@ -2044,7 +2044,7 @@ If an implementation has strict pointer safety~(\ref{basic.stc.dynamic.safety})
 then \tcode{ptr} shall be a safely-derived pointer.
 
 \pnum
-\notes
+\remarks
 Default function called when any part of the initialization in a
 placement \grammarterm{new-expression} that invokes the library's
 array placement operator new
@@ -2428,7 +2428,7 @@ An \impldef{return value of \tcode{type_info::name()}} \ntbs.
 \indexlibrary{\idxcode{type_info::name}!implementation-defined}
 
 \pnum
-\notes
+\remarks
 The message may be a null-terminated multibyte string~(\ref{multibyte.strings}),
 suitable for conversion and display as a
 \tcode{wstring}~(\ref{string.classes}, \ref{locale.codecvt})
@@ -2496,7 +2496,7 @@ An \impldef{return value of \tcode{bad_cast::what}} \ntbs.%
 \indexlibrary{\idxcode{bad_cast::what}!implementation-defined}
 
 \pnum
-\notes
+\remarks
 The message may be a null-terminated multibyte string~(\ref{multibyte.strings}),
 suitable for conversion and display as a
 \tcode{wstring}~(\ref{string.classes}, \ref{locale.codecvt})
@@ -2564,7 +2564,7 @@ An \impldef{return value of \tcode{bad_typeid::what}} \ntbs.%
 \indextext{\idxcode{bad_typeid::what}!implementation-defined}
 
 \pnum
-\notes
+\remarks
 The message may be a null-terminated multibyte string~(\ref{multibyte.strings}),
 suitable for conversion and display as a
 \tcode{wstring}~(\ref{string.classes}, \ref{locale.codecvt})
@@ -2701,7 +2701,7 @@ virtual const char* what() const noexcept;
 An \impldef{result of \tcode{exception::what}} \ntbs.
 
 \pnum
-\notes
+\remarks
 The message may be a null-terminated multibyte string~(\ref{multibyte.strings}),
 suitable for conversion and display as a
 \tcode{wstring}~(\ref{string.classes}, \ref{locale.codecvt}).
@@ -2769,7 +2769,7 @@ An \impldef{return value of \tcode{bad_exception::what}} \ntbs.%
 \indexlibrary{\idxcode{bad_exception::what}!implementation-defined}
 
 \pnum
-\notes
+\remarks
 The message may be a null-terminated multibyte string~(\ref{multibyte.strings}),
 suitable for conversion and display as a
 \tcode{wstring}~(\ref{string.classes}, \ref{locale.codecvt}).
@@ -2876,7 +2876,7 @@ int uncaught_exceptions() noexcept;
 The number of uncaught exceptions~(\ref{except.uncaught}).
 
 \pnum
-\notes
+\remarks
 When \tcode{uncaught_exceptions() > 0},
 throwing an exception can result in a call of\\
 \tcode{std::terminate()}~(\ref{except.terminate}).

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -2960,7 +2960,7 @@ or a call to \tcode{notify_all()}, or spuriously.
 \end{itemize}
 
 \pnum
-\notes
+\remarks
 If the function fails to meet the postcondition, \tcode{std::terminate()}
 shall be called~(\ref{except.terminate}).
 \enternote This can happen if the re-locking of the mutex throws an exception. \exitnote
@@ -3000,7 +3000,7 @@ while (!pred())
 \end{codeblock}
 
 \pnum
-\notes
+\remarks
 If the function fails to meet the postcondition, \tcode{std::terminate()}
 shall be called~(\ref{except.terminate}).
 \enternote This can happen if the re-locking of the mutex throws an exception. \exitnote
@@ -3052,7 +3052,7 @@ If the function exits via an exception, \tcode{lock.lock()} shall be called prio
 \end{itemize}
 
 \pnum
-\notes
+\remarks
 If the function fails to meet the postcondition, \tcode{std::terminate()}
 shall be called~(\ref{except.terminate}).
 \enternote This can happen if the re-locking of the mutex throws an exception. \exitnote
@@ -3102,7 +3102,7 @@ the relative timeout~(\ref{thread.req.timing}) specified by \tcode{rel_time} exp
 otherwise \tcode{cv_status::no_timeout}.
 
 \pnum
-\notes
+\remarks
 If the function fails to meet the postcondition, \tcode{std::terminate()}
 shall be called~(\ref{except.terminate}).
 \enternote This can happen if the re-locking of the mutex throws an exception. \exitnote
@@ -3148,7 +3148,7 @@ return true;
 \end{codeblock}
 
 \pnum
-\notes
+\remarks
 If the function fails to meet the postcondition, \tcode{std::terminate()}
 shall be called~(\ref{except.terminate}).
 \enternote This can happen if the re-locking of the mutex throws an exception. \exitnote
@@ -3201,7 +3201,7 @@ return wait_until(lock, chrono::steady_clock::now() + rel_time, std::move(pred))
 timeout has already expired. \exitnote
 
 \pnum
-\notes
+\remarks
 If the function fails to meet the postcondition, \tcode{std::terminate()}
 shall be called~(\ref{except.terminate}).
 \enternote This can happen if the re-locking of the mutex throws an exception. \exitnote
@@ -3349,7 +3349,7 @@ a call to \tcode{notify_all()}, or spuriously.
 \end{itemize}
 
 \pnum
-\notes
+\remarks
 If the function fails to meet the postcondition, \tcode{std::terminate()}
 shall be called~(\ref{except.terminate}).
 \enternote This can happen if the re-locking of the mutex throws an exception. \exitnote
@@ -3403,7 +3403,7 @@ If the function exits via an exception, \tcode{lock.lock()} shall be called prio
 \end{itemize}
 
 \pnum
-\notes
+\remarks
 If the function fails to meet the postcondition, \tcode{std::terminate()}
 shall be called~(\ref{except.terminate}).
 \enternote This can happen if the re-locking of the mutex throws an exception. \exitnote
@@ -3442,7 +3442,7 @@ the relative timeout~(\ref{thread.req.timing}) specified by \tcode{rel_time} exp
 otherwise \tcode{cv_status::no_timeout}.
 
 \pnum
-\notes
+\remarks
 If the function fails to meet the postcondition, \tcode{std::terminate()}
 shall be called~(\ref{except.terminate}).
 \enternote This can happen if the re-locking of the mutex throws an exception. \exitnote

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -447,10 +447,10 @@ template <class T>
 
 \begin{itemdescr}
 \pnum
-\notes If this function is odr-used~(\ref{basic.def.odr}), the program is ill-formed.
+\remarks If this function is odr-used~(\ref{basic.def.odr}), the program is ill-formed.
 
 \pnum
-\notes The template parameter \tcode{T} of \tcode{declval} may be an incomplete type.
+\remarks The template parameter \tcode{T} of \tcode{declval} may be an incomplete type.
 
 \enterexample
 \begin{codeblock}
@@ -579,7 +579,7 @@ The constructor initializes \tcode{first} with
 with \tcode{std::forward<\brk{}V>(y)}.
 
 \pnum
-\notes
+\remarks
 This constructor shall not participate in overload resolution unless
 \tcode{is_constructible<first_type, U\&\&>::value} is \tcode{true} and
 \tcode{is_constructible<second_type, V\&\&>::value} is \tcode{true}.
@@ -5604,7 +5604,7 @@ It is \impldef{support for over-aligned types} whether over-aligned types are
 supported~(\ref{basic.align}).
 
 \pnum
-\note
+\remark
 the storage is obtained by calling \tcode{::operator
 new(std::size_t)}~(\ref{new.delete}), but it is unspecified when or how often this
 function is called. The use of \tcode{hint} is unspecified, but intended as an aid to
@@ -5633,7 +5633,7 @@ to the invocation of allocate which returned \tcode{p}.
 Deallocates the storage referenced by \tcode{p} .
 
 \pnum
-\notes
+\remarks
 Uses
 \tcode{::operator delete(void*, std::size_t)}~(\ref{new.delete}), but it is unspecified
 when this function is called.
@@ -6237,7 +6237,7 @@ void operator()(T* ptr) const;
 \effects calls \tcode{delete} on \tcode{ptr}.
 
 \pnum
-\notes If \tcode{T} is an incomplete type, the program is ill-formed.
+\remarks If \tcode{T} is an incomplete type, the program is ill-formed.
 \end{itemdescr}
 
 \rSec4[unique.ptr.dltr.dflt1]{\tcode{default_delete<T[]>}}
@@ -6263,7 +6263,7 @@ template <class U> default_delete(const default_delete<U[]>& other) noexcept;
 constructs a \tcode{default_delete} object from another \tcode{default_delete<U[]>} object.
 
 \pnum
-\notes
+\remarks
 This constructor shall not participate in overload resolution unless \tcode{U(*)[]} is
 convertible to \tcode{T(*)[]}.
 \end{itemdescr}
@@ -6280,7 +6280,7 @@ template <class U> void operator()(U* ptr) const;
 calls \tcode{delete[]} on \tcode{ptr}.
 
 \pnum
-\notes If U is an incomplete type, the program is ill-formed.
+\remarks If U is an incomplete type, the program is ill-formed.
 This function shall not participate in overload resolution
 unless \tcode{U(*)[]} is convertible to \tcode{T(*)[]}.
 \end{itemdescr}
@@ -6387,7 +6387,7 @@ nothing, value-initializing the stored pointer and the stored deleter.
 returns a reference to the stored deleter.
 
 \pnum
-\notes If this constructor is instantiated with a pointer type or reference type
+\remarks If this constructor is instantiated with a pointer type or reference type
 for the template argument \tcode{D}, the program is ill-formed.
 \end{itemdescr}
 
@@ -6413,7 +6413,7 @@ value-initializing the stored deleter.
 returns a reference to the stored deleter.
 
 \pnum
-\notes If this constructor is instantiated with a pointer type or reference type
+\remarks If this constructor is instantiated with a pointer type or reference type
 for the template argument \tcode{D}, the program is ill-formed.
 \end{itemdescr}
 
@@ -7780,7 +7780,7 @@ T& operator*() const noexcept;
 
 \pnum\returns  \tcode{*get()}.
 
-\pnum\notes When \tcode{T} is (possibly \cv-qualified) \tcode{void},
+\pnum\remarks When \tcode{T} is (possibly \cv-qualified) \tcode{void},
 it is unspecified whether this
 member function is declared. If it is declared, it is unspecified what its
 return type is, except that the declaration (although not necessarily the
@@ -7896,7 +7896,7 @@ the address of the newly constructed object of type \tcode{T}.
 \tcode{A::allocate} or from the constructor of \tcode{T}.
 
 \pnum
-\notes Implementations should
+\remarks Implementations should
 perform no more than one memory allocation. \enternote This provides
 efficiency equivalent to an intrusive smart pointer. \exitnote
 
@@ -8282,7 +8282,7 @@ template<class Y> weak_ptr& operator=(const shared_ptr<Y>& r) noexcept;
 \begin{itemdescr}
 \pnum\effects  Equivalent to \tcode{weak_ptr(r).swap(*this)}.
 
-\pnum\notes  The implementation may meet the effects (and the
+\pnum\remarks  The implementation may meet the effects (and the
 implied guarantees) via different means, without creating a temporary.
 
 \pnum\returns  \tcode{*this}.
@@ -11103,7 +11103,7 @@ exception if and only if the corresponding constructor of \tcode{FD} or of any o
 \tcode{fd} or of one of the values \tcode{tid} throws an exception.
 
 \pnum
-\notes The return type shall satisfy the requirements of \tcode{MoveConstructible}. If all
+\remarks The return type shall satisfy the requirements of \tcode{MoveConstructible}. If all
 of \tcode{FD} and \tcode{TiD} satisfy the requirements of \tcode{CopyConstructible}, then the
 return type shall satisfy the requirements of \tcode{CopyConstructible}. \enternote This implies
 that all of \tcode{FD} and \tcode{TiD} are \tcode{MoveConstructible}. \exitnote
@@ -11144,7 +11144,7 @@ exception if and only if the corresponding constructor of \tcode{FD} or of any o
 \tcode{fd} or of one of the values \tcode{tid} throws an exception.
 
 \pnum
-\notes The return type shall satisfy the requirements of \tcode{MoveConstructible}. If all
+\remarks The return type shall satisfy the requirements of \tcode{MoveConstructible}. If all
 of \tcode{FD} and \tcode{TiD} satisfy the requirements of \tcode{CopyConstructible}, then the
 return type shall satisfy the requirements of \tcode{CopyConstructible}. \enternote This implies
 that all of \tcode{FD} and \tcode{TiD} are \tcode{MoveConstructible}. \exitnote
@@ -14418,14 +14418,14 @@ public:
 \requires \tcode{Rep} shall be an arithmetic type or a class emulating an arithmetic type.
 
 \pnum
-\notes If \tcode{duration} is instantiated with a \tcode{duration} type for the template
+\remarks If \tcode{duration} is instantiated with a \tcode{duration} type for the template
 argument \tcode{Rep}, the program is ill-formed.
 
 \pnum
-\notes If \tcode{Period} is not a specialization of \tcode{ratio}, the program is ill-formed.
+\remarks If \tcode{Period} is not a specialization of \tcode{ratio}, the program is ill-formed.
 
 \pnum
-\notes If \tcode{Period::num} is not positive, the program is ill-formed.
+\remarks If \tcode{Period::num} is not positive, the program is ill-formed.
 
 \pnum
 \requires Members of \tcode{duration} shall not throw exceptions other than


### PR DESCRIPTION
This is a single commit extracted from PR #238 which seems abandoned. This commit had been deemed useful, so I copied it and rebased it so it can be applied.

No PDF diffs.