### PR TITLE
Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,64 @@
+#
+# Builds the C++ standard document on Travis CI <https://travis-ci.org/cpluscplus/draft>
+#
+
+env:
+  - BUILD_TYPE=latexmk   # build using latexmk
+  - BUILD_TYPE=make      # build using Makefile
+  - BUILD_TYPE=manual    # build manually
+  - BUILD_TYPE=complete  # build manually and regenerate figures, grammer, and cross-references
+
+script:
+  # Build std.pdf
+  - pushd source
+  - if [ "$BUILD_TYPE" = "latexmk" ]; then
+      latexmk -pdf std;
+    fi
+  - if [ "$BUILD_TYPE" = "make" ]; then
+      make -j2;
+    fi
+  - if [ "$BUILD_TYPE" = "complete" ]; then
+      for FIGURE in *.dot; do
+        dot -o$(basename $FIGURE .dot).pdf -Tpdf $FIGURE;
+      done;
+      ../tools/makegram;
+      ../tools/makexref;
+    fi
+  - if [ "$BUILD_TYPE" = "manual" -o "$BUILD_TYPE" = "complete" ]; then
+      pdflatex std;
+      pdflatex std;
+      pdflatex std;
+      makeindex generalindex;
+      makeindex libraryindex;
+      makeindex grammarindex;
+      makeindex impldefindex;
+      pdflatex std;
+      pdflatex std;
+    fi
+  - popd
+  # Check to see if generated files are out-dated
+  - pushd source
+  - ../tools/makegram && git status --porcelain grammar.tex
+  - ../tools/makexref && git status --porcelain xref.tex
+  - for FIGURE in *.dot; do
+      dot -o$(basename $FIGURE .dot).pdf -Tpdf $FIGURE;
+      git status --porcelain $(basename $FIGURE .dot).pdf;
+    done
+  - popd
+
+sudo: false
+
+addons:
+  apt:
+    packages:
+    - latexmk
+    - poppler-utils
+    - texlive-binaries
+    - texlive-fonts-recommended
+    - texlive-latex-base
+    - texlive-latex-extra
+    - texlive-latex-recommended
+    - texlive-binaries
+    - graphviz
+    - lmodern
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,4 +61,3 @@ addons:
     - texlive-binaries
     - graphviz
     - lmodern
-


### PR DESCRIPTION
This allows the PDF to be built using [Travis CI](https://travis-ci.org/godbyk/draft). Handy for catching syntax errors in pull requests.

The build script could be expanded to add other checks in the future, too (for example, raise errors on too overfull lines, missing cross-reference labels).