### PR TITLE
[macros] Make \Cpp work in PDF bookmarks again

### DIFF
--- a/source/macros.tex
+++ b/source/macros.tex
@@ -116,7 +116,7 @@
 
 %%--------------------------------------------------
 %% Macros for funky text
-\newcommand{\Cpp}{C\kern-0.05em\protect\raisebox{.35ex}{\textsmaller[2]{+\kern-0.05em+}}\xspace}
+\newcommand{\Cpp}{\texorpdfstring{C\kern-0.05em\protect\raisebox{.35ex}{\textsmaller[2]{+\kern-0.05em+}}}{C++}\xspace}
 \newcommand{\CppIII}{\Cpp 2003\xspace}
 \newcommand{\CppXI}{\Cpp 2011\xspace}
 \newcommand{\CppXIV}{\Cpp 2014\xspace}


### PR DESCRIPTION
No PDF diffs

This change allows the `\Cpp` macro to be used in PDF bookmarks once again following PR #579.