### PR TITLE
Fix wrong reference

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -906,7 +906,7 @@ Valid \CppIII code that uses integer division rounds the result toward 0 or
 toward negative infinity, whereas this International Standard always rounds
 the result toward 0.
 
-\ref{expr.log.or}
+\ref{expr.log.and}
 \change \tcode{\&\&} is valid in a \grammarterm{type-name}
 \rationale Required for new features.
 \effect 


### PR DESCRIPTION
Change for `&&` in [diff.cpp03.expr] should refer to [expr.log.and] rather than [expr.log.or].
