### PR TITLE
Move removal of bool++ from C++14 compatibility annex to C++17 annex

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1369,17 +1369,6 @@ might match a predefined usual (non-placement)
 program is ill-formed, as it was for class member allocation functions and
 deallocation functions~(\ref{expr.new}).
 
-\rSec2[diff.cpp11.expr]{Clause \ref{expr}: expressions}
-
-\ref{expr.post.incr}, \ref{expr.pre.incr}
-\change
-Remove increment operator with \tcode{bool} operand.
-\rationale Obsolete feature with occasionally surprising semantics.
-\effect A valid \CppXIV expression utilizing the increment operator on
-a \tcode{bool} lvalue is ill-formed in this International Standard.
-Note that this might occur when the lvalue has a type given by a template
-parameter.
-
 \rSec2[diff.cpp11.dcl.dcl]{Clause \ref{dcl.dcl}: declarations}
 
 \ref{dcl.constexpr}
@@ -1487,6 +1476,17 @@ semantics in this International Standard. Implementations may choose to
 translate trigraphs as specified in \CppXIV if they appear outside of a raw
 string literal, as part of the implementation-defined mapping from physical
 source file characters to the basic source character set.
+
+\rSec2[diff.cpp14.expr]{Clause \ref{expr}: expressions}
+
+\ref{expr.post.incr}, \ref{expr.pre.incr}
+\change
+Remove increment operator with \tcode{bool} operand.
+\rationale Obsolete feature with occasionally surprising semantics.
+\effect A valid \CppXIV expression utilizing the increment operator on
+a \tcode{bool} lvalue is ill-formed in this International Standard.
+Note that this might occur when the lvalue has a type given by a template
+parameter.
 
 \rSec2[diff.cpp14.dcl.dcl]{Clause \ref{dcl.dcl}: declarations}
 


### PR DESCRIPTION
This change was clearly introduced in C++17, at the same meeting
as removing the meaning of the register keyword.  I can see no
Core issue tied to this removal being resolved as a DR against
14 or earlier.

I have confirmed that paper p0002r1 applied this to the C++17
annex, but was listed as a change in annex D rather than clause
5 - the latter change seeming the consistent editorial policy
for removed Core features, so retained.