### PR TITLE
[dcl.attr] Fix wrong source encoding

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3832,10 +3832,10 @@ to the name or entity. \exitnote
 
 \pnum
 The \grammarterm{attribute-token} \tcode{fallthrough}
-may be applied to a null statement~(\ref{stmt.expr});
+may be applied to a null statement~(\ref{stmt.expr});
 \indextext{statement!fallthrough}
 such a statement is a fallthrough statement.
-The \grammarterm{attribute­token} \tcode{fallthrough}
+The \grammarterm{attribute-token} \tcode{fallthrough}
 shall appear at most once in each \grammarterm{attribute-list} and
 no \grammarterm{attribute-argument-clause} shall be present.
 A fallthrough statement may only appear within
@@ -3843,7 +3843,7 @@ an enclosing \tcode{switch} statement~(\ref{stmt.switch}).
 The next statement that would be executed after a fallthrough statement
 shall be a labeled statement whose label is a case label or
 default label for the same \tcode{switch} statement.
-The program is ill­formed if there is no such statement.
+The program is ill-formed if there is no such statement.
 
 \pnum
 \enternote
@@ -3859,17 +3859,17 @@ if a fallthrough statement is not dynamically reachable.
 \enterexample
 \begin{codeblock}
 void f(int n) {
-  void g(), h(), i();
+  void g(), h(), i();
   switch (n) {
   case 1:
   case 2:
-    g();
-    [[fallthrough]];
+    g();
+    [[fallthrough]];
   case 3: // warning on fallthrough discouraged
-    h();
+    h();
   case 4: // implementation may warn on fallthrough
-    i();
-    [[fallthrough]]; // ill­formed
+    i();
+    [[fallthrough]]; // ill-formed
   }
 }
 \end{codeblock}
@@ -3908,8 +3908,8 @@ after the first declaration that marks it.
 \begin{codeblock}
 [[maybe_unused]] void f([[maybe_unused]] bool thing1,
                         [[maybe_unused]] bool thing2) {
-  [[maybe_unused]] bool b = thing1 && thing2;
-  assert(b);
+  [[maybe_unused]] bool b = thing1 && thing2;
+  assert(b);
 }
 \end{codeblock}
 Implementations are encouraged not to warn that \tcode{b} is unused,
@@ -3932,7 +3932,7 @@ A nodiscard call is a function call expression that
 calls a function previously declared \tcode{nodiscard}, or
 whose return type is a possibly cv-qualified class or enumeration type
 marked \tcode{nodiscard}. Appearance of a nodiscard call as
-a potentially-evaluated discarded­value expression (Clause~\ref{expr})
+a potentially-evaluated discarded-value expression (Clause~\ref{expr})
 is discouraged unless explicitly cast to \tcode{void}.
 Implementations are encouraged to issue a warning in such cases.
 This is typically because discarding the return value
@@ -3942,15 +3942,15 @@ of a nodiscard call has surprising consequences.
 \pnum
 \enterexample
 \begin{codeblock}
-struct [[nodiscard]] error_info { /*...*/ };
-error_info enable_missile_safety_mode();
-void launch_missiles();
+struct [[nodiscard]] error_info { /*...*/ };
+error_info enable_missile_safety_mode();
+void launch_missiles();
 void test_missiles() {
-  enable_missile_safety_mode(); // warning encouraged
-  launch_missiles();
+  enable_missile_safety_mode(); // warning encouraged
+  launch_missiles();
 }
-error_info &foo();
-void f() { foo(); } // reference type, warning not encouraged
+error_info &foo();
+void f() { foo(); } // reference type, warning not encouraged
 \end{codeblock}
 \exitexample
 


### PR DESCRIPTION
Please always check that your source code uses only basic characters:

    grep -P -n "[\x80-\xFF]" *.tex