### PR TITLE
[dcl.init.aggr] Fix an example in extended init.

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -2899,7 +2899,7 @@ with 3.
 \begin{codeblock}
 struct base1 { int b1, b2 = 42; };
 struct base2 {
-  B() {
+  base2() {
     b3 = 42;
   }
   int b3;


### PR DESCRIPTION
The example is modified from the old example, which used the name `B`; the constructor name should be `base2` here.