### PR TITLE
[defns.const.subexpr] Place defintition in alphabetical order

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -247,21 +247,13 @@ a class member function~(\ref{class.mfct}) other than a constructor,
 assignment operator, or destructor
 that alters the state of an object of the class
 
-\definition{move construction}{defns.move.constr}
-\indexdefn{construction!move}%
-direct-initialization of an object of some type with an rvalue of the same type
-
 \definition{move assignment}{defns.move.assign}
 \indexdefn{assignment!move}%
 assignment of an rvalue of some object type to a modifiable lvalue of the same type
 
-\definition{object state}{defns.obj.state}
-\indexdefn{state!object}%
-the current value of all non-static class members of an object~(\ref{class.mem})\\
-\enternote
-The state of an object can be obtained by using one or more
-\term{observer functions}.
-\exitnote
+\definition{move construction}{defns.move.constr}
+\indexdefn{construction!move}%
+direct-initialization of an object of some type with an rvalue of the same type
 
 \definition{NTCTS}{defns.ntcts}
 \indexdefn{NTCTS}%
@@ -271,6 +263,14 @@ a sequence of values that have
 that precede the terminating null character type
 value
 \tcode{charT()}
+
+\definition{object state}{defns.obj.state}
+\indexdefn{state!object}%
+the current value of all non-static class members of an object~(\ref{class.mem})\\
+\enternote
+The state of an object can be obtained by using one or more
+\term{observer functions}.
+\exitnote
 
 \definition{observer function}{defns.observer}
 \indexdefn{function!observer}%

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -183,6 +183,13 @@ strings are referred to as the
 \term{string component}.
 \exitnote
 
+\definition{constant subexpression}{defns.const.subexpr}
+\indexdefn{constant subexpression}%
+an expression whose evaluation as subexpression of a
+\grammarterm{conditional-expression}
+\tcode{CE}~(\ref{expr.cond}) would not prevent \tcode{CE}
+from being a core constant expression~(\ref{expr.const})
+
 \definition{deadlock}{defns.deadlock}
 \indexdefn{deadlock}%
 one or more threads are unable to continue execution because each is
@@ -351,13 +358,6 @@ met and operations on the object behave as specified for its type\\
 valid but unspecified state, \tcode{x.empty()} can be called unconditionally,
 and \tcode{x.front()} can be called only if \tcode{x.empty()} returns
 \tcode{false}. \exitexample
-
-\definition{constant subexpression}{defns.const.subexpr}
-\indexdefn{constant subexpression}%
-an expression whose evaluation as subexpression of a
-\grammarterm{conditional-expression}
-\tcode{CE}~(\ref{expr.cond}) would not prevent \tcode{CE}
-from being a core constant expression~(\ref{expr.const})
 
 \rSec1[defns.additional]{Additional definitions}
 


### PR DESCRIPTION
The defintions introduced in clauses 1.3 and 17.3 are
ordered alphabetically, other than the trailing
definition for 'constant subexpression', that I am
guessing was added at a later date.  This change
simply moves it into the correctly sorted place in
the sequence.