### PR TITLE
[class.mem] Convert nonstatic to non-static since the hyphenated use …

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1230,10 +1230,9 @@ or indirectly within unnamed classes shall not contain \tcode{static}
 data members.
 
 \pnum
-\indextext{restriction!static@\tcode{static} member local~class}%
-\tcode{Static} data members of a class in namespace scope have
-the linkage of that class~(\ref{basic.link}). A local class shall not have \tcode{static}
-data members.
+\enternote
+Static data members of a class in namespace scope have the linkage of that class~(\ref{basic.link}). A local class cannot have static data members~(\ref{class.local}).
+\exitnote
 
 \pnum
 \tcode{Static} data members are initialized and destroyed exactly like
@@ -1660,6 +1659,7 @@ A class nested within
 a local class is a local class.
 
 \pnum
+\indextext{restriction!static@\tcode{static} member local~class}%
 A local class shall not have static data members.
 
 \rSec1[class.nested.type]{Nested type names}

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -653,7 +653,7 @@ of the \tcode{tword} member of the \tcode{right} subtree of \tcode{s}.
 
 \pnum
 \indextext{layout!class~object}%
-Nonstatic data members of a (non-union) class
+Non-static data members of a (non-union) class
 with the same access control (Clause~\ref{class.access})
 are allocated so that later
 members have higher addresses within a class object.
@@ -856,8 +856,8 @@ fvc S::* pmfv3 = &S::memfunc3;
 Also see~\ref{temp.arg}.
 \exitnote
 
-\rSec2[class.mfct.non-static]{Nonstatic member functions}%
-\indextext{member function!nonstatic}
+\rSec2[class.mfct.non-static]{Non-static member functions}%
+\indextext{member function!non-static}
 
 \pnum
 A \grammarterm{non-static} member function may be called for an object of

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3066,7 +3066,7 @@ new (int (*[10])());
 \end{codeblock}
 
 allocates an array of \tcode{10} pointers to functions (taking no
-argument and returning \tcode{int}.
+argument and returning \tcode{int}).
 \exitexample 
 \exitnote 
 


### PR DESCRIPTION
…is the more common term.

(We use non-static data member later in this same paragraph, too.)