### PR TITLE
[inclusive.scan] Add missing template parameter.

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -8718,7 +8718,7 @@ namespace std {
     OutputIterator inclusive_scan(InputIterator first, InputIterator last,
                                   OutputIterator result,
                                   BinaryOperation binary_op);
-  template<class InputIterator, class OutputIterator, class BinaryOperation>
+  template<class InputIterator, class OutputIterator, class BinaryOperation, class T>
     OutputIterator inclusive_scan(InputIterator first, InputIterator last,
                                   OutputIterator result,
                                   BinaryOperation binary_op, T init);
@@ -8731,7 +8731,7 @@ namespace std {
                                   InputIterator first, InputIterator last,
                                   OutputIterator result,
                                   BinaryOperation binary_op);
-  template<class ExecutionPolicy, class InputIterator, class OutputIterator, class BinaryOperation>
+  template<class ExecutionPolicy, class InputIterator, class OutputIterator, class BinaryOperation, class T>
     OutputIterator inclusive_scan(ExecutionPolicy&& exec, // see \ref{algorithms.parallel.overloads}
                                   InputIterator first, InputIterator last,
                                   OutputIterator result,
@@ -9127,7 +9127,7 @@ template<class InputIterator, class OutputIterator, class BinaryOperation>
   OutputIterator inclusive_scan(InputIterator first, InputIterator last,
                                 OutputIterator result,
                                 BinaryOperation binary_op);
-template<class InputIterator, class OutputIterator, class BinaryOperation>
+template<class InputIterator, class OutputIterator, class BinaryOperation, class T>
   OutputIterator inclusive_scan(InputIterator first, InputIterator last,
                                 OutputIterator result,
                                 BinaryOperation binary_op, T init);


### PR DESCRIPTION
The `T init` overload for `inclusive_scan` is missing a template parameter `class T`. Also fixed the `<numeric>` synopsis in [numeric.ops.overview].