### PR TITLE
[intro.object] For object names, don't refer to 'name' grammar rule, …

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -540,7 +540,7 @@ created by a \grammarterm{definition}~(\ref{basic.def}), by a
 \grammarterm{new-expression}~(\ref{expr.new}) or by the
 implementation~(\ref{class.temporary}) when needed. The properties of an
 object are determined when the object is created. An object can have a
-\grammarterm{name}~(Clause~\ref{basic}). An object has a \term{storage
+\term{name}~(Clause~\ref{basic}). An object has a \term{storage
 duration}~(\ref{basic.stc}) which influences its
 \term{lifetime}~(\ref{basic.life}). An object has a
 \term{type}~(\ref{basic.types}). The term \defn{object type} refers to


### PR DESCRIPTION
…because that one is from [path.generic].