### PR TITLE
[cstdint] Fix macro name patterns

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -1249,8 +1249,8 @@ namespace std {
 The header also defines numerous macros of the form:
 
 \begin{codeblock}
-  INT_[FAST LEAST]{8 16 32 64}_MIN
-  [U]INT_[FAST LEAST]{8 16 32 64}_MAX
+  INT[_FAST _LEAST]{8 16 32 64}_MIN
+  [U]INT[_FAST _LEAST]{8 16 32 64}_MAX
   INT{MAX PTR}_MIN
   [U]INT{MAX PTR}_MAX
   {PTRDIFF SIG_ATOMIC WCHAR WINT}{_MAX _MIN}


### PR DESCRIPTION
Min/max value macro names for exact-width integer types are like
INT8_MIN, not INT_8_MIN.