### PR TITLE
[cpp.replace] Remove a bogus grammar term

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -592,18 +592,15 @@ where all white-space separations are considered identical.
 An identifier currently defined as an
 \indextext{object-like macro|see{macro, object-like}}%
 \indextext{macro!object-like}%
-\grammarterm{object-like}
-macro may be redefined by another
+object-like macro (see below) may be redefined by another
 \tcode{\#define}
 preprocessing directive provided that the second definition is an
 object-like macro definition and the two replacement lists
 are identical, otherwise the program is ill-formed.
-Likewise, an identifier currently defined as
-a
+Likewise, an identifier currently defined as a
 \indextext{function-like macro|see{macro, function-like}}%
 \indextext{macro!function-like}%
-\grammarterm{function-like}
-macro may be redefined by another
+function-like macro (see below) may be redefined by another
 \tcode{\#define}
 preprocessing directive provided that the second definition is a
 function-like macro definition that has the same number and spelling
@@ -668,7 +665,7 @@ A preprocessing directive of the form
 
 defines an
 \indextext{macro!object-like}%
-\grammarterm{object-like macro} that
+\defn{object-like macro} that
 causes each subsequent instance of the macro name\footnote{Since, by macro-replacement time,
 all character literals and string literals are preprocessing tokens,
 not sequences possibly containing identifier-like subsequences
@@ -692,7 +689,7 @@ A preprocessing directive of the form
 \end{ncsimplebnf}
 
 \indextext{macro!function-like}%
-defines a \grammarterm{function-like macro}
+defines a \defn{function-like macro}
 with parameters, whose use is
 similar syntactically to a function call.
 The parameters


### PR DESCRIPTION
function-like and object-like were being defined as grammar terms when they are not, and this is confusing with the term of art definitions in p10.