### PR TITLE
[c.limits] Remove an incorrect note about type of constant macros

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -1082,9 +1082,7 @@ Table~\ref{tab:support.hdr.climits} describes the header
 
 \pnum
 The contents are the same as the Standard C library header
-\tcode{<limits.h>}. \enternote The types of the
-constants defined by macros in \tcode{<climits>} are not
-required to match the types to which the macros refer.\exitnote
+\tcode{<limits.h>}.
 
 \pnum
 Table~\ref{tab:support.hdr.cfloat} describes the header


### PR DESCRIPTION
The note implies that the types of constant macros defined in \<climits>
may differ from that of C, but no nomative rule say so, and there is no
reason to allow such incompatibilities.

The note was added as the resolution of LWG issue #416.
http://www.open-std.org/jtc1/sc22/wg21/docs/lwg-defects.html#416
But the analysis, which based on rules of integer constants, was wrong:
The type of constant macros are defined in C99 (5.2.4.2.1 p1) by rules
of integer promotions. So LONG_MAX always has type long (integer
promotions has no effect for long), even if the actual range of long and
int are equal. That should hold in C++, too.

--
Please note that there is no such note for constant macros defined in
\<cstdint>.

FYI, the tyepes of the constant macros are defined in C99 5.2.4.2.1, p1.
> The values of these constants shall be ... . Moreover, except for
> CHAR_BIT and MB_LEN_MAX, the following shall be replaced by
> expressions that have the same type as would an expression that is an
> object of the corresponding type converted according to the integer
> promotions.

Integer promotions are defined as following in C99 6.3.1.1 p2.
> The following may be used in an expression wherever an int or unsigned
> int may be used:
>   - An object or expression with an integer type whose integer
>     conversion rank is less than or equal to the rank of int and
>     unsigned int.
>   - A bit-field of type _Bool, int, signed int, or unsigned int.
> If an int can represent all values of the original type (as restricted
> by the width, for a bit-field), the value is converted to an int;
> otherwise, it is converted to an unsigned int. These are called the
> integer promotions. All other types are unchanged by the integer
> promotions.

--
I'm posting this here as an editorial issue because it is only a removal
of a "Note:"  But I also have feeling that this should go as a LWG issue
because it reverts the resolution of an old LWG isseue. Please let me
know if someone know which is preferable.
