### PR TITLE
[cpp.predefined] Use \xname in index entry for __cplusplus.

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1238,7 +1238,7 @@ The following macro names shall be defined by the implementation:
 
 \begin{description}
 
-\indextext{\idxcode{\unun cplusplus}}%
+\indextext{\idxcode{\xname{cplusplus}}}%
 \item \tcode{\xname{cplusplus}}\\
 The name \tcode{\,\xname{cplusplus}} is defined
 to the value


### PR DESCRIPTION
To be consistent, and so that we don't miss an \ungap.