### PR TITLE
[intseq] consolidate <utility> docs

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -10,11 +10,11 @@ These utilities are summarized in Table~\ref{tab:util.lib.summary}.
 
 \begin{libsumtab}{General utilities library summary}{tab:util.lib.summary}
 \ref{utility}               & Utility components                & \tcode{<utility>}     \\ \rowsep
+\ref{intseq}                & Compile-time integer sequences    & \tcode{<utility>}     \\ \rowsep
 \ref{pairs}                 & Pairs                             & \tcode{<utility>}     \\ \rowsep
 \ref{tuple}                 & Tuples                            & \tcode{<tuple>}       \\ \rowsep
 \ref{optional}              & Optional objects                  & \tcode{<optional>}    \\ \rowsep
 \ref{any}                   & Storage for any type              & \tcode{<any>}         \\ \rowsep
-\ref{intseq}                & Compile-time integer sequences    & \tcode{<utility>}     \\ \rowsep
 \ref{template.bitset}       & Fixed-size sequences of bits      & \tcode{<bitset>}      \\ \rowsep
                             &                                   & \tcode{<memory>}      \\
 \ref{memory}                & Memory                            & \tcode{<cstdlib>}     \\
@@ -85,6 +85,24 @@ namespace std {
   template <class T>
     add_rvalue_reference_t<T> declval() noexcept;  // as unevaluated operand
 
+@
+\indexlibrary{\idxcode{index_sequence}}%
+\indexlibrary{\idxcode{make_index_sequence}}%
+\indexlibrary{\idxcode{index_sequence_for}}%
+@
+  // \ref{intseq}, Compile-time integer sequences
+  template<class T, T...> struct integer_sequence;
+  template<size_t... I>
+    using index_sequence = integer_sequence<size_t, I...>;
+
+  template<class T, T N>
+    using make_integer_sequence = integer_sequence<T, @\seebelow{}@>;
+  template<size_t N>
+    using make_index_sequence = make_integer_sequence<size_t, N>;
+
+  template<class... T>
+    using index_sequence_for = make_index_sequence<sizeof...(T)>;
+
   // \ref{pairs}, pairs:
   template <class T1, class T2> struct pair;
 
@@ -147,23 +165,6 @@ namespace std {
   struct piecewise_construct_t { };
   constexpr piecewise_construct_t piecewise_construct{};
   template <class... Types> class tuple;  // defined in \tcode{<tuple>}
-@
-\indexlibrary{\idxcode{index_sequence}}%
-\indexlibrary{\idxcode{make_index_sequence}}%
-\indexlibrary{\idxcode{index_sequence_for}}%
-@
-  // \ref{intseq}, Compile-time integer sequences
-  template<class T, T...> struct integer_sequence;
-  template<size_t... I>
-    using index_sequence = integer_sequence<size_t, I...>;
-
-  template<class T, T N>
-    using make_integer_sequence = integer_sequence<T, @\seebelow{}@>;
-  template<size_t N>
-    using make_index_sequence = make_integer_sequence<size_t, N>;
-
-  template<class... T>
-    using index_sequence_for = make_index_sequence<sizeof...(T)>;
 }
 \end{codeblock}
 
@@ -462,6 +463,72 @@ declares a function template \tcode{convert} which only participates in overload
 type \tcode{From} can be explicitly converted to type \tcode{To}. For another example see class
 template \tcode{common_type}~(\ref{meta.trans.other}).
 \exitexample
+\end{itemdescr}
+
+\rSec1[intseq]{Compile-time integer sequences}
+
+\rSec2[intseq.general]{In general}
+
+\pnum
+The library provides a class template that can represent an integer sequence.
+When used as an argument to a function template the parameter pack defining the
+sequence can be deduced and used in a pack expansion.
+
+\pnum
+\enterexample
+
+\begin{codeblock}
+template<class F, class Tuple, std::size_t... I>
+  decltype(auto) apply_impl(F&& f, Tuple&& t, index_sequence<I...>) {
+    return std::forward<F>(f)(std::get<I>(std::forward<Tuple>(t))...);
+  }
+
+template<class F, class Tuple>
+  decltype(auto) apply(F&& f, Tuple&& t) {
+    using Indices = make_index_sequence<std::tuple_size<std::decay_t<Tuple>>::value>;
+    return apply_impl(std::forward<F>(f), std::forward<Tuple>(t), Indices());
+  }
+\end{codeblock}
+
+\exitexample
+\enternote
+The \tcode{index_sequence} alias template is provided for the common case of
+an integer sequence of type \tcode{size_t}.
+\exitnote
+
+\rSec2[intseq.intseq]{Class template \tcode{integer_sequence}}
+
+\indexlibrary{\idxcode{integer_sequence}}%
+\begin{codeblock}
+namespace std {
+  template<class T, T... I>
+  struct integer_sequence {
+    typedef T value_type;
+    static constexpr size_t size() noexcept { return sizeof...(I); }
+  };
+}
+\end{codeblock}
+
+\pnum
+\tcode{T} shall be an integer type.
+
+\rSec2[intseq.make]{Alias template \tcode{make_integer_sequence}}
+
+\indexlibrary{\idxcode{make_integer_sequence}}%
+\begin{itemdecl}
+template<class T, T N>
+  using make_integer_sequence = integer_sequence<T, @\seebelow{}@>;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+If \tcode{N} is negative the program is ill-formed. The alias template
+\tcode{make_integer_sequence} denotes a specialization of
+\tcode{integer_sequence} with \tcode{N} template non-type arguments.
+The type \tcode{make_integer_sequence<T, N>} denotes the type
+\tcode{integer_sequence<T, 0, 1, ..., N-1>}.
+\enternote \tcode{make_integer_sequence<int, 0>} denotes the type
+\tcode{integer_sequence<int>} \exitnote
 \end{itemdescr}
 
 \rSec1[pairs]{Pairs}
@@ -3648,73 +3715,6 @@ bool is_string(const any& operand) {
 }
 \end{codeblock}
 \exitexample
-\end{itemdescr}
-
-
-\rSec1[intseq]{Compile-time integer sequences}
-
-\rSec2[intseq.general]{In general}
-
-\pnum
-The library provides a class template that can represent an integer sequence.
-When used as an argument to a function template the parameter pack defining the
-sequence can be deduced and used in a pack expansion.
-
-\pnum
-\enterexample
-
-\begin{codeblock}
-template<class F, class Tuple, std::size_t... I>
-  decltype(auto) apply_impl(F&& f, Tuple&& t, index_sequence<I...>) {
-    return std::forward<F>(f)(std::get<I>(std::forward<Tuple>(t))...);
-  }
-
-template<class F, class Tuple>
-  decltype(auto) apply(F&& f, Tuple&& t) {
-    using Indices = make_index_sequence<std::tuple_size<std::decay_t<Tuple>>::value>;
-    return apply_impl(std::forward<F>(f), std::forward<Tuple>(t), Indices());
-  }
-\end{codeblock}
-
-\exitexample
-\enternote
-The \tcode{index_sequence} alias template is provided for the common case of
-an integer sequence of type \tcode{size_t}.
-\exitnote
-
-\rSec2[intseq.intseq]{Class template \tcode{integer_sequence}}
-
-\indexlibrary{\idxcode{integer_sequence}}%
-\begin{codeblock}
-namespace std {
-  template<class T, T... I>
-  struct integer_sequence {
-    typedef T value_type;
-    static constexpr size_t size() noexcept { return sizeof...(I); }
-  };
-}
-\end{codeblock}
-
-\pnum
-\tcode{T} shall be an integer type.
-
-\rSec2[intseq.make]{Alias template \tcode{make_integer_sequence}}
-
-\indexlibrary{\idxcode{make_integer_sequence}}%
-\begin{itemdecl}
-template<class T, T N>
-  using make_integer_sequence = integer_sequence<T, @\seebelow{}@>;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-If \tcode{N} is negative the program is ill-formed. The alias template
-\tcode{make_integer_sequence} denotes a specialization of
-\tcode{integer_sequence} with \tcode{N} template non-type arguments.
-The type \tcode{make_integer_sequence<T, N>} denotes the type
-\tcode{integer_sequence<T, 0, 1, ..., N-1>}.
-\enternote \tcode{make_integer_sequence<int, 0>} denotes the type
-\tcode{integer_sequence<int>} \exitnote
 \end{itemdescr}
 
 \rSec1[template.bitset]{Class template \tcode{bitset}}%


### PR DESCRIPTION
This change consolidates some of the sprawl occurring in clause 20,
by moving the integer sequence utilities, which are part of the \<utility>
header, adjacent to the rest of the \<utility> documentation, between
the main \<utility> doc and pair, while retaining the pair doc as a
separate subsection adjacent to \<tuple>.

Considered making the integer sequences a subsection nested in 2.2,
but decided that it must have been pulled out into its own separate
sub-clause for a reason.