### PR TITLE
[allocator.adaptor] consolidate memory utilities

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -21,12 +21,12 @@ These utilities are summarized in Table~\ref{tab:util.lib.summary}.
                             &                                   & \tcode{<cstring>}     \\ \rowsep
 \ref{smartptr}              & Smart pointers                    & \tcode{<memory>}      \\ \rowsep
 \ref{memory.resource}       & Memory resources                  & \tcode{<memory_resource>} \\ \rowsep
+\ref{allocator.adaptor}     & Scoped allocators                 & \tcode{<scoped_allocator>} \\ \rowsep
 \ref{function.objects}      & Function objects                  & \tcode{<functional>}  \\ \rowsep
 \ref{meta}                  & Type traits                       & \tcode{<type_traits>} \\ \rowsep
 \ref{ratio}                 & Compile-time rational arithmetic  & \tcode{<ratio>}       \\ \rowsep
 \ref{time}                  & Time utilities                    & \tcode{<chrono>}      \\
                             &                                   & \tcode{<ctime>}       \\ \rowsep
-\ref{allocator.adaptor}     & Scoped allocators                 & \tcode{<scoped_allocator>} \\ \rowsep
 \ref{type.index}            & Type indexes                      & \tcode{<typeindex>}   \\ \rowsep
 \ref{execpol}               & Execution policies                & \tcode{<execution_policy>} \\
 \end{libsumtab}
@@ -10030,6 +10030,605 @@ bool do_is_equal(const memory_resource& other) const noexcept;
 \end{itemdescr}
 
 
+\rSec1[allocator.adaptor]{Class template \tcode{scoped_allocator_adaptor}}
+
+\rSec2[allocator.adaptor.syn]{Header \tcode{<scoped_allocator>} synopsis}
+
+\indexlibrary{\idxhdr{scoped_allocator}}%
+\begin{codeblock}
+  // scoped allocator adaptor
+  template <class OuterAlloc, class... InnerAlloc>
+    class scoped_allocator_adaptor;
+  template <class OuterA1, class OuterA2, class... InnerAllocs>
+    bool operator==(const scoped_allocator_adaptor<OuterA1, InnerAllocs...>& a,
+                    const scoped_allocator_adaptor<OuterA2, InnerAllocs...>& b) noexcept;
+  template <class OuterA1, class OuterA2, class... InnerAllocs>
+    bool operator!=(const scoped_allocator_adaptor<OuterA1, InnerAllocs...>& a,
+                    const scoped_allocator_adaptor<OuterA2, InnerAllocs...>& b) noexcept;
+\end{codeblock}
+
+\pnum
+The class template \tcode{scoped_allocator_adaptor} is an allocator template that
+specifies the memory resource (the outer allocator) to be used by a container (as any
+other allocator does) and also specifies an inner allocator resource to be passed to the
+constructor of every element within the container. This adaptor is instantiated with one
+outer and zero or more inner allocator types. If instantiated with only one allocator
+type, the inner allocator becomes the \tcode{scoped_allocator_adaptor} itself, thus
+using the same allocator resource for the container and every element within the
+container and, if the elements themselves are containers, each of their elements
+recursively. If instantiated with more than one allocator, the first allocator is the
+outer allocator for use by the container, the second allocator is passed to the
+constructors of the container's elements, and, if the elements themselves are
+containers, the third allocator is passed to the elements' elements, and so on. If
+containers are nested to a depth greater than the number of allocators, the last
+allocator is used repeatedly, as in the single-allocator case, for any remaining
+recursions. \enternote The \tcode{scoped_allocator_adaptor} is derived from the outer
+allocator type so it can be substituted for the outer allocator type in most
+expressions. \exitnote
+
+\begin{codeblock}
+namespace std {
+  template <class OuterAlloc, class... InnerAllocs>
+    class scoped_allocator_adaptor : public OuterAlloc {
+  private:
+    using OuterTraits = allocator_traits<OuterAlloc>; // \expos
+    scoped_allocator_adaptor<InnerAllocs...> inner;   // \expos
+  public:
+    using outer_allocator_type = OuterAlloc;
+    using inner_allocator_type = @\seebelow@;
+
+    using value_type           = typename OuterTraits::value_type;
+    using size_type            = typename OuterTraits::size_type;
+    using difference_type      = typename OuterTraits::difference_type;
+    using pointer              = typename OuterTraits::pointer;
+    using const_pointer        = typename OuterTraits::const_pointer;
+    using void_pointer         = typename OuterTraits::void_pointer;
+    using const_void_pointer   = typename OuterTraits::const_void_pointer;
+
+    using propagate_on_container_copy_assignment = @\seebelow@;
+    using propagate_on_container_move_assignment = @\seebelow@;
+    using propagate_on_container_swap            = @\seebelow@;
+    using is_always_equal                        = @\seebelow@;
+
+    template <class Tp>
+      struct rebind {
+        using other = scoped_allocator_adaptor<
+          OuterTraits::template rebind_alloc<Tp>, InnerAllocs...>;
+      };
+
+    scoped_allocator_adaptor();
+    template <class OuterA2>
+      scoped_allocator_adaptor(OuterA2&& outerAlloc,
+                               const InnerAllocs&... innerAllocs) noexcept;
+
+    scoped_allocator_adaptor(const scoped_allocator_adaptor& other) noexcept;
+    scoped_allocator_adaptor(scoped_allocator_adaptor&& other) noexcept;
+
+    template <class OuterA2>
+      scoped_allocator_adaptor(
+        const scoped_allocator_adaptor<OuterA2, InnerAllocs...>& other) noexcept;
+    template <class OuterA2>
+      scoped_allocator_adaptor(
+        scoped_allocator_adaptor<OuterA2, InnerAllocs...>&& other) noexcept;
+
+    scoped_allocator_adaptor& operator=(const scoped_allocator_adaptor&) = default;
+    scoped_allocator_adaptor& operator=(scoped_allocator_adaptor&&) = default;
+
+    ~scoped_allocator_adaptor();
+
+    inner_allocator_type& inner_allocator() noexcept;
+    const inner_allocator_type& inner_allocator() const noexcept;
+    outer_allocator_type& outer_allocator() noexcept;
+    const outer_allocator_type& outer_allocator() const noexcept;
+
+    pointer allocate(size_type n);
+    pointer allocate(size_type n, const_void_pointer hint);
+    void deallocate(pointer p, size_type n);
+    size_type max_size() const;
+
+    template <class T, class... Args>
+      void construct(T* p, Args&&... args);
+    template <class T1, class T2, class... Args1, class... Args2>
+      void construct(pair<T1, T2>* p, piecewise_construct_t,
+                     tuple<Args1...> x, tuple<Args2...> y);
+    template <class T1, class T2>
+      void construct(pair<T1, T2>* p);
+    template <class T1, class T2, class U, class V>
+      void construct(pair<T1, T2>* p, U&& x, V&& y);
+    template <class T1, class T2, class U, class V>
+      void construct(pair<T1, T2>* p, const pair<U, V>& x);
+    template <class T1, class T2, class U, class V>
+      void construct(pair<T1, T2>* p, pair<U, V>&& x);
+
+    template <class T>
+      void destroy(T* p);
+
+    scoped_allocator_adaptor select_on_container_copy_construction() const;
+  };
+
+  template <class OuterA1, class OuterA2, class... InnerAllocs>
+    bool operator==(const scoped_allocator_adaptor<OuterA1, InnerAllocs...>& a,
+                    const scoped_allocator_adaptor<OuterA2, InnerAllocs...>& b) noexcept;
+  template <class OuterA1, class OuterA2, class... InnerAllocs>
+    bool operator!=(const scoped_allocator_adaptor<OuterA1, InnerAllocs...>& a,
+                    const scoped_allocator_adaptor<OuterA2, InnerAllocs...>& b) noexcept;
+}
+\end{codeblock}
+
+\rSec2[allocator.adaptor.types]{Scoped allocator adaptor member types}
+
+\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{inner_allocator_type}}%
+\indexlibrary{\idxcode{inner_allocator_type}!\idxcode{scoped_allocator_adaptor}}%
+\begin{itemdecl}
+using inner_allocator_type = @\seebelow@;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\ctype \tcode{scoped_allocator_adaptor<OuterAlloc>} if \tcode{sizeof...(InnerAllocs)} is
+zero; otherwise,\\ \tcode{scoped_allocator_adaptor<InnerAllocs...>}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{propagate_on_container_copy_assignment}}%
+\indexlibrary{\idxcode{propagate_on_container_copy_assignment}!\idxcode{scoped_allocator_adaptor}}%
+\begin{itemdecl}
+using propagate_on_container_copy_assignment = @\seebelow@;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\ctype \tcode{true_type} if
+\tcode{allocator_traits<A>::propagate_on_container_copy_assignment::value} is
+\tcode{true} for any \tcode{A} in the set of \tcode{OuterAlloc} and
+\tcode{InnerAllocs...}; otherwise, \tcode{false_type}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{propagate_on_container_move_assignment}}%
+\indexlibrary{\idxcode{propagate_on_container_move_assignment}!\idxcode{scoped_allocator_adaptor}}%
+\begin{itemdecl}
+using propagate_on_container_move_assignment = @\seebelow@;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\ctype \tcode{true_type} if
+\tcode{allocator_traits<A>::propagate_on_container_move_assignment::value} is
+\tcode{true} for any \tcode{A} in the set of \tcode{OuterAlloc} and
+\tcode{InnerAllocs...}; otherwise, \tcode{false_type}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{propagate_on_container_swap}}%
+\indexlibrary{\idxcode{propagate_on_container_swap}!\idxcode{scoped_allocator_adaptor}}%
+\begin{itemdecl}
+using propagate_on_container_swap = @\seebelow@;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\ctype \tcode{true_type} if
+\tcode{allocator_traits<A>::propagate_on_container_swap::value} is
+\tcode{true} for any \tcode{A} in the set of \tcode{OuterAlloc} and
+\tcode{InnerAllocs...}; otherwise, \tcode{false_type}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{is_always_equal}}%
+\indexlibrary{\idxcode{is_always_equal}!\idxcode{scoped_allocator_adaptor}}%
+\begin{itemdecl}
+using is_always_equal = @\seebelow@;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\ctype \tcode{true_type} if
+\tcode{allocator_traits<A>::is_always_equal::value} is
+\tcode{true} for every \tcode{A} in the set of \tcode{OuterAlloc} and
+\tcode{InnerAllocs...}; otherwise, \tcode{false_type}.
+\end{itemdescr}
+
+\rSec2[allocator.adaptor.cnstr]{Scoped allocator adaptor constructors}
+
+\indexlibrary{\idxcode{scoped_allocator_adaptor}!constructor}%
+\begin{itemdecl}
+scoped_allocator_adaptor();
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Value-initializes the \tcode{OuterAlloc} base class and the \tcode{inner} allocator
+object.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{scoped_allocator_adaptor}!constructor}%
+\begin{itemdecl}
+template <class OuterA2>
+  scoped_allocator_adaptor(OuterA2&& outerAlloc,
+                           const InnerAllocs&... innerAllocs) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\requires \tcode{OuterAlloc} shall be constructible from \tcode{OuterA2}.
+
+\pnum
+\effects Initializes the \tcode{OuterAlloc} base class with
+\tcode{std::forward<OuterA2>(outerAlloc)} and \tcode{inner} with \tcode{innerAllocs...}
+(hence recursively initializing each allocator within the adaptor with the corresponding
+allocator from the argument list).
+\end{itemdescr}
+
+\indexlibrary{\idxcode{scoped_allocator_adaptor}!constructor}%
+\begin{itemdecl}
+scoped_allocator_adaptor(const scoped_allocator_adaptor& other) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Initializes each allocator within the adaptor with the corresponding allocator
+from \tcode{other}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{scoped_allocator_adaptor}!constructor}%
+\begin{itemdecl}
+scoped_allocator_adaptor(scoped_allocator_adaptor&& other) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Move constructs each allocator within the adaptor with the corresponding allocator
+from \tcode{other}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{scoped_allocator_adaptor}!constructor}%
+\begin{itemdecl}
+template <class OuterA2>
+  scoped_allocator_adaptor(const scoped_allocator_adaptor<OuterA2,
+                                                          InnerAllocs...>& other) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\requires \tcode{OuterAlloc} shall be constructible from \tcode{OuterA2}.
+
+\pnum
+\effects Initializes each allocator within the adaptor with the corresponding allocator
+from \tcode{other}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{scoped_allocator_adaptor}!constructor}%
+\begin{itemdecl}
+template <class OuterA2>
+  scoped_allocator_adaptor(scoped_allocator_adaptor<OuterA2,
+                                                    InnerAllocs...>&& other) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\requires \tcode{OuterAlloc} shall be constructible from \tcode{OuterA2}.
+
+\pnum
+\effects Initializes each allocator within the adaptor with the corresponding allocator rvalue
+from \tcode{other}.
+\end{itemdescr}
+
+\rSec2[allocator.adaptor.members]{Scoped allocator adaptor members}
+
+\pnum
+In the \tcode{construct} member functions,
+\textit{OUTERMOST(x)} is \tcode{x} if \tcode{x} does not have an
+\tcode{outer_allocator()} member function and \\
+\textit{OUTERMOST(x.outer_allocator())}
+otherwise;
+\textit{OUTERMOST_ALLOC_TRAITS(x)} is \\
+\tcode{allocator_traits<decltype(\textit{OUTERMOST}(x))>}.
+\enternote \textit{OUTERMOST}(x) and \\
+\textit{OUTERMOST_ALLOC_TRAITS}(x) are recursive operations. It
+is incumbent upon the definition of \tcode{outer_allocator()} to ensure that the
+recursion terminates. It will terminate for all instantiations of \\
+\tcode{scoped_allocator_adaptor}. \exitnote
+
+\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{inner_allocator}}%
+\indexlibrary{\idxcode{inner_allocator}!\idxcode{scoped_allocator_adaptor}}%
+\begin{itemdecl}
+inner_allocator_type& inner_allocator() noexcept;
+const inner_allocator_type& inner_allocator() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns \tcode{*this} if \tcode{sizeof...(InnerAllocs)} is zero; otherwise,
+\tcode{inner}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{outer_allocator}}%
+\indexlibrary{\idxcode{outer_allocator}!\idxcode{scoped_allocator_adaptor}}%
+\begin{itemdecl}
+outer_allocator_type& outer_allocator() noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns \tcode{static_cast<OuterAlloc\&>(*this)}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{outer_allocator}}%
+\indexlibrary{\idxcode{outer_allocator}!\idxcode{scoped_allocator_adaptor}}%
+\begin{itemdecl}
+const outer_allocator_type& outer_allocator() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns \tcode{static_cast<const OuterAlloc\&>(*this)}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{allocate}}%
+\indexlibrary{\idxcode{allocate}!\idxcode{scoped_allocator_adaptor}}%
+\begin{itemdecl}
+pointer allocate(size_type n);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns \tcode{allocator_traits<OuterAlloc>::allocate(outer_allocator(), n)}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{allocate}}%
+\indexlibrary{\idxcode{allocate}!\idxcode{scoped_allocator_adaptor}}%
+\begin{itemdecl}
+pointer allocate(size_type n, const_void_pointer hint);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns \tcode{allocator_traits<OuterAlloc>::allocate(outer_allocator(), n, hint)}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{deallocate}}%
+\indexlibrary{\idxcode{deallocate}!\idxcode{scoped_allocator_adaptor}}%
+\begin{itemdecl}
+void deallocate(pointer p, size_type n) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects As if by:
+\tcode{allocator_traits<OuterAlloc>::deallocate(outer_allocator(), p, n);}
+\end{itemdescr}
+
+\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{max_size}}%
+\indexlibrary{\idxcode{max_size}!\idxcode{scoped_allocator_adaptor}}%
+\begin{itemdecl}
+size_type max_size() const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns \tcode{allocator_traits<OuterAlloc>::max_size(outer_allocator())}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{construct}}%
+\indexlibrary{\idxcode{construct}!\idxcode{scoped_allocator_adaptor}}%
+\begin{itemdecl}
+template <class T, class... Args>
+  void construct(T* p, Args&&... args);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+
+\begin{itemize}
+\item If \tcode{uses_allocator<T, inner_allocator_type>::value} is \tcode{false} and
+\tcode{is_constructible<T, Args...>::value} is \tcode{true}, calls
+\textit{OUTERMOST_ALLOC_TRAITS}(\tcode{*this})\tcode{::construct(\\
+\textit{OUTERMOST}(*this), p, std::forward<Args>(args)...)}.
+
+\item Otherwise, if \tcode{uses_allocator<T, inner_allocator_type>::value} is \tcode{true} and
+\tcode{is_construc\-tible<T, allocator_arg_t, inner_allocator_type\&, Args...>::value} is \tcode{true}, calls
+\textit{OUTERMOST_ALLOC_TRAITS}(\tcode{*this})\tcode{::construct(\textit{OUTERMOST}(*this),
+p, allocator_arg,\\inner_allocator(), std::forward<Args>(args)...)}.
+
+\item Otherwise, if \tcode{uses_allocator<T, inner_allocator_type>::value} is \tcode{true} and
+\tcode{is_construct\-ible<T, Args..., inner_allocator_type\&>::value} is \tcode{true}, calls
+\textit{OUTERMOST_ALLOC_TRAITS}(*this)::
+\tcode{construct(\textit{OUTERMOST}(*this), p, std::forward<Args>(args)...,\\inner_allocator())}.
+
+\item Otherwise, the program is ill-formed. \enternote An error will result if
+\tcode{uses_allocator} evaluates to true but the specific constructor does not take an
+allocator. This definition prevents a silent failure to pass an inner allocator to a
+contained element. \exitnote
+\end{itemize}
+\end{itemdescr}
+
+\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{construct}}%
+\indexlibrary{\idxcode{construct}!\idxcode{scoped_allocator_adaptor}}%
+\begin{itemdecl}
+template <class T1, class T2, class... Args1, class... Args2>
+  void construct(pair<T1, T2>* p, piecewise_construct_t,
+                 tuple<Args1...> x, tuple<Args2...> y);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\requires all of the types in \tcode{Args1} and \tcode{Args2} shall be
+\tcode{CopyConstructible} (Table~\ref{copyconstructible}).
+
+\pnum
+\effects Constructs a \tcode{tuple} object \tcode{xprime} from \tcode{x} by the
+following rules:
+
+\begin{itemize}
+\item If \tcode{uses_allocator<T1, inner_allocator_type>::value} is \tcode{false} and
+\tcode{is_constructible<T1,
+Args1...>::value} is \tcode{true}, then \tcode{xprime} is \tcode{x}.
+
+\item Otherwise, if \tcode{uses_allocator<T1, inner_allocator_type>::value} is \tcode{true}
+and
+\tcode{is_construct\-ible<T1, allocator_arg_t, inner_allocator_type\&, Args1...>::value}
+is
+\tcode{true}, then \tcode{xprime} is
+\tcode{tuple_cat(tuple<allocator_arg_t, inner_allocator_type\&>(
+allocator_arg, inner_allocator()), std::move(x))}.
+
+\item Otherwise, if \tcode{uses_allocator<T1, inner_allocator_type>::value} is
+\tcode{true} and
+\tcode{is_construct\-ible<T1, Args1..., inner_allocator_type\&>::value} is \tcode{true},
+then \tcode{xprime} is
+\tcode{tuple_cat(std::move(x), tuple<inner_allocator_type\&>(inner_allocator()))}.
+
+\item Otherwise, the program is ill-formed.
+\end{itemize}
+
+and constructs a \tcode{tuple} object \tcode{yprime} from \tcode{y} by the following rules:
+
+\begin{itemize}
+\item If \tcode{uses_allocator<T2, inner_allocator_type>::value} is \tcode{false} and
+\tcode{is_constructible<T2,
+Args2...>::value} is \tcode{true}, then \tcode{yprime} is \tcode{y}.
+
+\item Otherwise, if \tcode{uses_allocator<T2, inner_allocator_type>::value} is \tcode{true}
+and
+\tcode{is_construct\-ible<T2, allocator_arg_t, inner_allocator_type\&, Args2...>::value}
+is
+\tcode{true}, then \tcode{yprime} is
+\tcode{tuple_cat(tuple<allocator_arg_t, inner_allocator_type\&>(
+allocator_arg, inner_allocator()), std::move(y))}.
+
+\item Otherwise, if \tcode{uses_allocator<T2, inner_allocator_type>::value} is
+\tcode{true} and
+\tcode{is_construct\-ible<T2, Args2..., inner_allocator_type\&>::value} is \tcode{true},
+then \tcode{yprime} is
+\tcode{tuple_cat(std::move(y), tuple<inner_allocator_type\&>(inner_allocator()))}.
+
+\item Otherwise, the program is ill-formed.
+\end{itemize}
+
+then calls \tcode{\textit{OUTERMOST_ALLOC_TRAITS}(*this)::construct(\textit{OUTERMOST}(*this), p,\\
+piecewise_construct, std::move(xprime), std::move(yprime))}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{construct}}%
+\indexlibrary{\idxcode{construct}!\idxcode{scoped_allocator_adaptor}}%
+\begin{itemdecl}
+template <class T1, class T2>
+  void construct(pair<T1, T2>* p);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Equivalent to:
+\begin{codeblock}
+this->construct(p, piecewise_construct, tuple<>(), tuple<>());
+\end{codeblock}
+\end{itemdescr}
+
+\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{construct}}%
+\indexlibrary{\idxcode{construct}!\idxcode{scoped_allocator_adaptor}}%
+\begin{itemdecl}
+template <class T1, class T2, class U, class V>
+  void construct(pair<T1, T2>* p, U&& x, V&& y);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Equivalent to:
+\begin{codeblock}
+this->construct(p, piecewise_construct,
+                forward_as_tuple(std::forward<U>(x)),
+                forward_as_tuple(std::forward<V>(y)));
+\end{codeblock}
+\end{itemdescr}
+
+\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{construct}}%
+\indexlibrary{\idxcode{construct}!\idxcode{scoped_allocator_adaptor}}%
+\begin{itemdecl}
+template <class T1, class T2, class U, class V>
+  void construct(pair<T1, T2>* p, const pair<U, V>& x);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Equivalent to:
+\begin{codeblock}
+this->construct(p, piecewise_construct,
+                forward_as_tuple(x.first),
+                forward_as_tuple(x.second));
+\end{codeblock}
+\end{itemdescr}
+
+\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{construct}}%
+\indexlibrary{\idxcode{construct}!\idxcode{scoped_allocator_adaptor}}%
+\begin{itemdecl}
+template <class T1, class T2, class U, class V>
+  void construct(pair<T1, T2>* p, pair<U, V>&& x);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Equivalent to:
+\begin{codeblock}
+this->construct(p, piecewise_construct,
+                forward_as_tuple(std::forward<U>(x.first)),
+                forward_as_tuple(std::forward<V>(x.second)));
+\end{codeblock}
+\end{itemdescr}
+
+\indexlibrary{\idxcode{scoped_allocator_adaptor}!destructor}%
+\begin{itemdecl}
+template <class T>
+  void destroy(T* p);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Calls \tcode{\textit{OUTERMOST_ALLOC_TRAITS}(*this)::destroy(\textit{OUTERMOST}(*this), p)}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{select_on_container_copy_construction}}%
+\indexlibrary{\idxcode{select_on_container_copy_construction}!\idxcode{scoped_allocator_adaptor}}%
+\begin{itemdecl}
+scoped_allocator_adaptor select_on_container_copy_construction() const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns A new \tcode{scoped_allocator_adaptor} object where each allocator \tcode{A} in the
+adaptor is initialized from the result of calling
+\tcode{allocator_traits<A>::select_on_container_copy_construction()} on the
+corresponding allocator in \tcode{*this}.
+\end{itemdescr}
+
+\rSec2[scoped.adaptor.operators]{Scoped allocator operators}
+
+\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{operator==}}%
+\indexlibrary{\idxcode{operator==}!\idxcode{scoped_allocator_adaptor}}%
+\begin{itemdecl}
+template <class OuterA1, class OuterA2, class... InnerAllocs>
+  bool operator==(const scoped_allocator_adaptor<OuterA1, InnerAllocs...>& a,
+                  const scoped_allocator_adaptor<OuterA2, InnerAllocs...>& b) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns \tcode{a.outer_allocator() == b.outer_allocator()} if
+\tcode{sizeof...(InnerAllocs)} is zero;
+otherwise, \tcode{a.outer_allocator() == b.outer_allocator()}
+\tcode{\&\&} \tcode{a.inner_allocator() == b.inner_allocator()}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{operator"!=}}%
+\indexlibrary{\idxcode{operator"!=}!\idxcode{scoped_allocator_adaptor}}%
+\begin{itemdecl}
+template <class OuterA1, class OuterA2, class... InnerAllocs>
+  bool operator!=(const scoped_allocator_adaptor<OuterA1, InnerAllocs...>& a,
+                  const scoped_allocator_adaptor<OuterA2, InnerAllocs...>& b) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns \tcode{!(a == b)}.
+\end{itemdescr}
+
 \rSec1[function.objects]{Function objects}
 
 \pnum
@@ -15777,605 +16376,6 @@ races~(\ref{res.on.data.races}).
 
 \xref
 ISO C Clause 7.12, Amendment 1 Clause 4.6.4.
-
-\rSec1[allocator.adaptor]{Class template \tcode{scoped_allocator_adaptor}}
-
-\rSec2[allocator.adaptor.syn]{Header \tcode{<scoped_allocator>} synopsis}
-
-\indexlibrary{\idxhdr{scoped_allocator}}%
-\begin{codeblock}
-  // scoped allocator adaptor
-  template <class OuterAlloc, class... InnerAlloc>
-    class scoped_allocator_adaptor;
-  template <class OuterA1, class OuterA2, class... InnerAllocs>
-    bool operator==(const scoped_allocator_adaptor<OuterA1, InnerAllocs...>& a,
-                    const scoped_allocator_adaptor<OuterA2, InnerAllocs...>& b) noexcept;
-  template <class OuterA1, class OuterA2, class... InnerAllocs>
-    bool operator!=(const scoped_allocator_adaptor<OuterA1, InnerAllocs...>& a,
-                    const scoped_allocator_adaptor<OuterA2, InnerAllocs...>& b) noexcept;
-\end{codeblock}
-
-\pnum
-The class template \tcode{scoped_allocator_adaptor} is an allocator template that
-specifies the memory resource (the outer allocator) to be used by a container (as any
-other allocator does) and also specifies an inner allocator resource to be passed to the
-constructor of every element within the container. This adaptor is instantiated with one
-outer and zero or more inner allocator types. If instantiated with only one allocator
-type, the inner allocator becomes the \tcode{scoped_allocator_adaptor} itself, thus
-using the same allocator resource for the container and every element within the
-container and, if the elements themselves are containers, each of their elements
-recursively. If instantiated with more than one allocator, the first allocator is the
-outer allocator for use by the container, the second allocator is passed to the
-constructors of the container's elements, and, if the elements themselves are
-containers, the third allocator is passed to the elements' elements, and so on. If
-containers are nested to a depth greater than the number of allocators, the last
-allocator is used repeatedly, as in the single-allocator case, for any remaining
-recursions. \enternote The \tcode{scoped_allocator_adaptor} is derived from the outer
-allocator type so it can be substituted for the outer allocator type in most
-expressions. \exitnote
-
-\begin{codeblock}
-namespace std {
-  template <class OuterAlloc, class... InnerAllocs>
-    class scoped_allocator_adaptor : public OuterAlloc {
-  private:
-    using OuterTraits = allocator_traits<OuterAlloc>; // \expos
-    scoped_allocator_adaptor<InnerAllocs...> inner;   // \expos
-  public:
-    using outer_allocator_type = OuterAlloc;
-    using inner_allocator_type = @\seebelow@;
-
-    using value_type           = typename OuterTraits::value_type;
-    using size_type            = typename OuterTraits::size_type;
-    using difference_type      = typename OuterTraits::difference_type;
-    using pointer              = typename OuterTraits::pointer;
-    using const_pointer        = typename OuterTraits::const_pointer;
-    using void_pointer         = typename OuterTraits::void_pointer;
-    using const_void_pointer   = typename OuterTraits::const_void_pointer;
-
-    using propagate_on_container_copy_assignment = @\seebelow@;
-    using propagate_on_container_move_assignment = @\seebelow@;
-    using propagate_on_container_swap            = @\seebelow@;
-    using is_always_equal                        = @\seebelow@;
-
-    template <class Tp>
-      struct rebind {
-        using other = scoped_allocator_adaptor<
-          OuterTraits::template rebind_alloc<Tp>, InnerAllocs...>;
-      };
-
-    scoped_allocator_adaptor();
-    template <class OuterA2>
-      scoped_allocator_adaptor(OuterA2&& outerAlloc,
-                               const InnerAllocs&... innerAllocs) noexcept;
-
-    scoped_allocator_adaptor(const scoped_allocator_adaptor& other) noexcept;
-    scoped_allocator_adaptor(scoped_allocator_adaptor&& other) noexcept;
-
-    template <class OuterA2>
-      scoped_allocator_adaptor(
-        const scoped_allocator_adaptor<OuterA2, InnerAllocs...>& other) noexcept;
-    template <class OuterA2>
-      scoped_allocator_adaptor(
-        scoped_allocator_adaptor<OuterA2, InnerAllocs...>&& other) noexcept;
-
-    scoped_allocator_adaptor& operator=(const scoped_allocator_adaptor&) = default;
-    scoped_allocator_adaptor& operator=(scoped_allocator_adaptor&&) = default;
-
-    ~scoped_allocator_adaptor();
-
-    inner_allocator_type& inner_allocator() noexcept;
-    const inner_allocator_type& inner_allocator() const noexcept;
-    outer_allocator_type& outer_allocator() noexcept;
-    const outer_allocator_type& outer_allocator() const noexcept;
-
-    pointer allocate(size_type n);
-    pointer allocate(size_type n, const_void_pointer hint);
-    void deallocate(pointer p, size_type n);
-    size_type max_size() const;
-
-    template <class T, class... Args>
-      void construct(T* p, Args&&... args);
-    template <class T1, class T2, class... Args1, class... Args2>
-      void construct(pair<T1, T2>* p, piecewise_construct_t,
-                     tuple<Args1...> x, tuple<Args2...> y);
-    template <class T1, class T2>
-      void construct(pair<T1, T2>* p);
-    template <class T1, class T2, class U, class V>
-      void construct(pair<T1, T2>* p, U&& x, V&& y);
-    template <class T1, class T2, class U, class V>
-      void construct(pair<T1, T2>* p, const pair<U, V>& x);
-    template <class T1, class T2, class U, class V>
-      void construct(pair<T1, T2>* p, pair<U, V>&& x);
-
-    template <class T>
-      void destroy(T* p);
-
-    scoped_allocator_adaptor select_on_container_copy_construction() const;
-  };
-
-  template <class OuterA1, class OuterA2, class... InnerAllocs>
-    bool operator==(const scoped_allocator_adaptor<OuterA1, InnerAllocs...>& a,
-                    const scoped_allocator_adaptor<OuterA2, InnerAllocs...>& b) noexcept;
-  template <class OuterA1, class OuterA2, class... InnerAllocs>
-    bool operator!=(const scoped_allocator_adaptor<OuterA1, InnerAllocs...>& a,
-                    const scoped_allocator_adaptor<OuterA2, InnerAllocs...>& b) noexcept;
-}
-\end{codeblock}
-
-\rSec2[allocator.adaptor.types]{Scoped allocator adaptor member types}
-
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{inner_allocator_type}}%
-\indexlibrary{\idxcode{inner_allocator_type}!\idxcode{scoped_allocator_adaptor}}%
-\begin{itemdecl}
-using inner_allocator_type = @\seebelow@;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\ctype \tcode{scoped_allocator_adaptor<OuterAlloc>} if \tcode{sizeof...(InnerAllocs)} is
-zero; otherwise,\\ \tcode{scoped_allocator_adaptor<InnerAllocs...>}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{propagate_on_container_copy_assignment}}%
-\indexlibrary{\idxcode{propagate_on_container_copy_assignment}!\idxcode{scoped_allocator_adaptor}}%
-\begin{itemdecl}
-using propagate_on_container_copy_assignment = @\seebelow@;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\ctype \tcode{true_type} if
-\tcode{allocator_traits<A>::propagate_on_container_copy_assignment::value} is
-\tcode{true} for any \tcode{A} in the set of \tcode{OuterAlloc} and
-\tcode{InnerAllocs...}; otherwise, \tcode{false_type}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{propagate_on_container_move_assignment}}%
-\indexlibrary{\idxcode{propagate_on_container_move_assignment}!\idxcode{scoped_allocator_adaptor}}%
-\begin{itemdecl}
-using propagate_on_container_move_assignment = @\seebelow@;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\ctype \tcode{true_type} if
-\tcode{allocator_traits<A>::propagate_on_container_move_assignment::value} is
-\tcode{true} for any \tcode{A} in the set of \tcode{OuterAlloc} and
-\tcode{InnerAllocs...}; otherwise, \tcode{false_type}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{propagate_on_container_swap}}%
-\indexlibrary{\idxcode{propagate_on_container_swap}!\idxcode{scoped_allocator_adaptor}}%
-\begin{itemdecl}
-using propagate_on_container_swap = @\seebelow@;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\ctype \tcode{true_type} if
-\tcode{allocator_traits<A>::propagate_on_container_swap::value} is
-\tcode{true} for any \tcode{A} in the set of \tcode{OuterAlloc} and
-\tcode{InnerAllocs...}; otherwise, \tcode{false_type}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{is_always_equal}}%
-\indexlibrary{\idxcode{is_always_equal}!\idxcode{scoped_allocator_adaptor}}%
-\begin{itemdecl}
-using is_always_equal = @\seebelow@;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\ctype \tcode{true_type} if
-\tcode{allocator_traits<A>::is_always_equal::value} is
-\tcode{true} for every \tcode{A} in the set of \tcode{OuterAlloc} and
-\tcode{InnerAllocs...}; otherwise, \tcode{false_type}.
-\end{itemdescr}
-
-\rSec2[allocator.adaptor.cnstr]{Scoped allocator adaptor constructors}
-
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!constructor}%
-\begin{itemdecl}
-scoped_allocator_adaptor();
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects Value-initializes the \tcode{OuterAlloc} base class and the \tcode{inner} allocator
-object.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!constructor}%
-\begin{itemdecl}
-template <class OuterA2>
-  scoped_allocator_adaptor(OuterA2&& outerAlloc,
-                           const InnerAllocs&... innerAllocs) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\requires \tcode{OuterAlloc} shall be constructible from \tcode{OuterA2}.
-
-\pnum
-\effects Initializes the \tcode{OuterAlloc} base class with
-\tcode{std::forward<OuterA2>(outerAlloc)} and \tcode{inner} with \tcode{innerAllocs...}
-(hence recursively initializing each allocator within the adaptor with the corresponding
-allocator from the argument list).
-\end{itemdescr}
-
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!constructor}%
-\begin{itemdecl}
-scoped_allocator_adaptor(const scoped_allocator_adaptor& other) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects Initializes each allocator within the adaptor with the corresponding allocator
-from \tcode{other}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!constructor}%
-\begin{itemdecl}
-scoped_allocator_adaptor(scoped_allocator_adaptor&& other) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects Move constructs each allocator within the adaptor with the corresponding allocator
-from \tcode{other}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!constructor}%
-\begin{itemdecl}
-template <class OuterA2>
-  scoped_allocator_adaptor(const scoped_allocator_adaptor<OuterA2,
-                                                          InnerAllocs...>& other) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\requires \tcode{OuterAlloc} shall be constructible from \tcode{OuterA2}.
-
-\pnum
-\effects Initializes each allocator within the adaptor with the corresponding allocator
-from \tcode{other}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!constructor}%
-\begin{itemdecl}
-template <class OuterA2>
-  scoped_allocator_adaptor(scoped_allocator_adaptor<OuterA2,
-                                                    InnerAllocs...>&& other) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\requires \tcode{OuterAlloc} shall be constructible from \tcode{OuterA2}.
-
-\pnum
-\effects Initializes each allocator within the adaptor with the corresponding allocator rvalue
-from \tcode{other}.
-\end{itemdescr}
-
-\rSec2[allocator.adaptor.members]{Scoped allocator adaptor members}
-
-\pnum
-In the \tcode{construct} member functions,
-\textit{OUTERMOST(x)} is \tcode{x} if \tcode{x} does not have an
-\tcode{outer_allocator()} member function and \\
-\textit{OUTERMOST(x.outer_allocator())}
-otherwise;
-\textit{OUTERMOST_ALLOC_TRAITS(x)} is \\
-\tcode{allocator_traits<decltype(\textit{OUTERMOST}(x))>}.
-\enternote \textit{OUTERMOST}(x) and \\
-\textit{OUTERMOST_ALLOC_TRAITS}(x) are recursive operations. It
-is incumbent upon the definition of \tcode{outer_allocator()} to ensure that the
-recursion terminates. It will terminate for all instantiations of \\
-\tcode{scoped_allocator_adaptor}. \exitnote
-
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{inner_allocator}}%
-\indexlibrary{\idxcode{inner_allocator}!\idxcode{scoped_allocator_adaptor}}%
-\begin{itemdecl}
-inner_allocator_type& inner_allocator() noexcept;
-const inner_allocator_type& inner_allocator() const noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{*this} if \tcode{sizeof...(InnerAllocs)} is zero; otherwise,
-\tcode{inner}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{outer_allocator}}%
-\indexlibrary{\idxcode{outer_allocator}!\idxcode{scoped_allocator_adaptor}}%
-\begin{itemdecl}
-outer_allocator_type& outer_allocator() noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{static_cast<OuterAlloc\&>(*this)}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{outer_allocator}}%
-\indexlibrary{\idxcode{outer_allocator}!\idxcode{scoped_allocator_adaptor}}%
-\begin{itemdecl}
-const outer_allocator_type& outer_allocator() const noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{static_cast<const OuterAlloc\&>(*this)}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{allocate}}%
-\indexlibrary{\idxcode{allocate}!\idxcode{scoped_allocator_adaptor}}%
-\begin{itemdecl}
-pointer allocate(size_type n);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{allocator_traits<OuterAlloc>::allocate(outer_allocator(), n)}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{allocate}}%
-\indexlibrary{\idxcode{allocate}!\idxcode{scoped_allocator_adaptor}}%
-\begin{itemdecl}
-pointer allocate(size_type n, const_void_pointer hint);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{allocator_traits<OuterAlloc>::allocate(outer_allocator(), n, hint)}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{deallocate}}%
-\indexlibrary{\idxcode{deallocate}!\idxcode{scoped_allocator_adaptor}}%
-\begin{itemdecl}
-void deallocate(pointer p, size_type n) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects As if by:
-\tcode{allocator_traits<OuterAlloc>::deallocate(outer_allocator(), p, n);}
-\end{itemdescr}
-
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{max_size}}%
-\indexlibrary{\idxcode{max_size}!\idxcode{scoped_allocator_adaptor}}%
-\begin{itemdecl}
-size_type max_size() const;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{allocator_traits<OuterAlloc>::max_size(outer_allocator())}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{construct}}%
-\indexlibrary{\idxcode{construct}!\idxcode{scoped_allocator_adaptor}}%
-\begin{itemdecl}
-template <class T, class... Args>
-  void construct(T* p, Args&&... args);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-
-\begin{itemize}
-\item If \tcode{uses_allocator<T, inner_allocator_type>::value} is \tcode{false} and
-\tcode{is_constructible<T, Args...>::value} is \tcode{true}, calls
-\textit{OUTERMOST_ALLOC_TRAITS}(\tcode{*this})\tcode{::construct(\\
-\textit{OUTERMOST}(*this), p, std::forward<Args>(args)...)}.
-
-\item Otherwise, if \tcode{uses_allocator<T, inner_allocator_type>::value} is \tcode{true} and
-\tcode{is_construc\-tible<T, allocator_arg_t, inner_allocator_type\&, Args...>::value} is \tcode{true}, calls
-\textit{OUTERMOST_ALLOC_TRAITS}(\tcode{*this})\tcode{::construct(\textit{OUTERMOST}(*this),
-p, allocator_arg,\\inner_allocator(), std::forward<Args>(args)...)}.
-
-\item Otherwise, if \tcode{uses_allocator<T, inner_allocator_type>::value} is \tcode{true} and
-\tcode{is_construct\-ible<T, Args..., inner_allocator_type\&>::value} is \tcode{true}, calls
-\textit{OUTERMOST_ALLOC_TRAITS}(*this)::
-\tcode{construct(\textit{OUTERMOST}(*this), p, std::forward<Args>(args)...,\\inner_allocator())}.
-
-\item Otherwise, the program is ill-formed. \enternote An error will result if
-\tcode{uses_allocator} evaluates to true but the specific constructor does not take an
-allocator. This definition prevents a silent failure to pass an inner allocator to a
-contained element. \exitnote
-\end{itemize}
-\end{itemdescr}
-
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{construct}}%
-\indexlibrary{\idxcode{construct}!\idxcode{scoped_allocator_adaptor}}%
-\begin{itemdecl}
-template <class T1, class T2, class... Args1, class... Args2>
-  void construct(pair<T1, T2>* p, piecewise_construct_t,
-                 tuple<Args1...> x, tuple<Args2...> y);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\requires all of the types in \tcode{Args1} and \tcode{Args2} shall be
-\tcode{CopyConstructible} (Table~\ref{copyconstructible}).
-
-\pnum
-\effects Constructs a \tcode{tuple} object \tcode{xprime} from \tcode{x} by the
-following rules:
-
-\begin{itemize}
-\item If \tcode{uses_allocator<T1, inner_allocator_type>::value} is \tcode{false} and
-\tcode{is_constructible<T1,
-Args1...>::value} is \tcode{true}, then \tcode{xprime} is \tcode{x}.
-
-\item Otherwise, if \tcode{uses_allocator<T1, inner_allocator_type>::value} is \tcode{true}
-and
-\tcode{is_construct\-ible<T1, allocator_arg_t, inner_allocator_type\&, Args1...>::value}
-is
-\tcode{true}, then \tcode{xprime} is
-\tcode{tuple_cat(tuple<allocator_arg_t, inner_allocator_type\&>(
-allocator_arg, inner_allocator()), std::move(x))}.
-
-\item Otherwise, if \tcode{uses_allocator<T1, inner_allocator_type>::value} is
-\tcode{true} and
-\tcode{is_construct\-ible<T1, Args1..., inner_allocator_type\&>::value} is \tcode{true},
-then \tcode{xprime} is
-\tcode{tuple_cat(std::move(x), tuple<inner_allocator_type\&>(inner_allocator()))}.
-
-\item Otherwise, the program is ill-formed.
-\end{itemize}
-
-and constructs a \tcode{tuple} object \tcode{yprime} from \tcode{y} by the following rules:
-
-\begin{itemize}
-\item If \tcode{uses_allocator<T2, inner_allocator_type>::value} is \tcode{false} and
-\tcode{is_constructible<T2,
-Args2...>::value} is \tcode{true}, then \tcode{yprime} is \tcode{y}.
-
-\item Otherwise, if \tcode{uses_allocator<T2, inner_allocator_type>::value} is \tcode{true}
-and
-\tcode{is_construct\-ible<T2, allocator_arg_t, inner_allocator_type\&, Args2...>::value}
-is
-\tcode{true}, then \tcode{yprime} is
-\tcode{tuple_cat(tuple<allocator_arg_t, inner_allocator_type\&>(
-allocator_arg, inner_allocator()), std::move(y))}.
-
-\item Otherwise, if \tcode{uses_allocator<T2, inner_allocator_type>::value} is
-\tcode{true} and
-\tcode{is_construct\-ible<T2, Args2..., inner_allocator_type\&>::value} is \tcode{true},
-then \tcode{yprime} is
-\tcode{tuple_cat(std::move(y), tuple<inner_allocator_type\&>(inner_allocator()))}.
-
-\item Otherwise, the program is ill-formed.
-\end{itemize}
-
-then calls \tcode{\textit{OUTERMOST_ALLOC_TRAITS}(*this)::construct(\textit{OUTERMOST}(*this), p,\\
-piecewise_construct, std::move(xprime), std::move(yprime))}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{construct}}%
-\indexlibrary{\idxcode{construct}!\idxcode{scoped_allocator_adaptor}}%
-\begin{itemdecl}
-template <class T1, class T2>
-  void construct(pair<T1, T2>* p);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects Equivalent to:
-\begin{codeblock}
-this->construct(p, piecewise_construct, tuple<>(), tuple<>());
-\end{codeblock}
-\end{itemdescr}
-
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{construct}}%
-\indexlibrary{\idxcode{construct}!\idxcode{scoped_allocator_adaptor}}%
-\begin{itemdecl}
-template <class T1, class T2, class U, class V>
-  void construct(pair<T1, T2>* p, U&& x, V&& y);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects Equivalent to:
-\begin{codeblock}
-this->construct(p, piecewise_construct,
-                forward_as_tuple(std::forward<U>(x)),
-                forward_as_tuple(std::forward<V>(y)));
-\end{codeblock}
-\end{itemdescr}
-
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{construct}}%
-\indexlibrary{\idxcode{construct}!\idxcode{scoped_allocator_adaptor}}%
-\begin{itemdecl}
-template <class T1, class T2, class U, class V>
-  void construct(pair<T1, T2>* p, const pair<U, V>& x);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects Equivalent to:
-\begin{codeblock}
-this->construct(p, piecewise_construct,
-                forward_as_tuple(x.first),
-                forward_as_tuple(x.second));
-\end{codeblock}
-\end{itemdescr}
-
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{construct}}%
-\indexlibrary{\idxcode{construct}!\idxcode{scoped_allocator_adaptor}}%
-\begin{itemdecl}
-template <class T1, class T2, class U, class V>
-  void construct(pair<T1, T2>* p, pair<U, V>&& x);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects Equivalent to:
-\begin{codeblock}
-this->construct(p, piecewise_construct,
-                forward_as_tuple(std::forward<U>(x.first)),
-                forward_as_tuple(std::forward<V>(x.second)));
-\end{codeblock}
-\end{itemdescr}
-
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!destructor}%
-\begin{itemdecl}
-template <class T>
-  void destroy(T* p);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects Calls \tcode{\textit{OUTERMOST_ALLOC_TRAITS}(*this)::destroy(\textit{OUTERMOST}(*this), p)}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{select_on_container_copy_construction}}%
-\indexlibrary{\idxcode{select_on_container_copy_construction}!\idxcode{scoped_allocator_adaptor}}%
-\begin{itemdecl}
-scoped_allocator_adaptor select_on_container_copy_construction() const;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns A new \tcode{scoped_allocator_adaptor} object where each allocator \tcode{A} in the
-adaptor is initialized from the result of calling
-\tcode{allocator_traits<A>::select_on_container_copy_construction()} on the
-corresponding allocator in \tcode{*this}.
-\end{itemdescr}
-
-\rSec2[scoped.adaptor.operators]{Scoped allocator operators}
-
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{operator==}}%
-\indexlibrary{\idxcode{operator==}!\idxcode{scoped_allocator_adaptor}}%
-\begin{itemdecl}
-template <class OuterA1, class OuterA2, class... InnerAllocs>
-  bool operator==(const scoped_allocator_adaptor<OuterA1, InnerAllocs...>& a,
-                  const scoped_allocator_adaptor<OuterA2, InnerAllocs...>& b) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{a.outer_allocator() == b.outer_allocator()} if
-\tcode{sizeof...(InnerAllocs)} is zero;
-otherwise, \tcode{a.outer_allocator() == b.outer_allocator()}
-\tcode{\&\&} \tcode{a.inner_allocator() == b.inner_allocator()}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{operator"!=}}%
-\indexlibrary{\idxcode{operator"!=}!\idxcode{scoped_allocator_adaptor}}%
-\begin{itemdecl}
-template <class OuterA1, class OuterA2, class... InnerAllocs>
-  bool operator!=(const scoped_allocator_adaptor<OuterA1, InnerAllocs...>& a,
-                  const scoped_allocator_adaptor<OuterA2, InnerAllocs...>& b) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{!(a == b)}.
-\end{itemdescr}
 
 \rSec1[type.index]{Class \tcode{type_index}}
 


### PR DESCRIPTION
This patch simply moves the scoped allocator clause to
be adjacent to the other memory and allocator clauses
for a more consistent sub-organization of clause 20.

The patch looks pretty awful thanks to the diff
algorithm treating it a lot of interspersed edits,
where in fact is way a single cut/paste for the
bulk of the test (plus a second one-liner for the
clause 20 table of contents).