### PR TITLE
[meta.unary.prop] Consistent formatting for 'void'

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2200,7 +2200,7 @@ namespace std {
 
 \pnum
 A program that necessitates the instantiation of template \tcode{optional} for
-a reference type, or for possibly \cv-qualified types \tcode{in_place_t} or
+a reference type, or for possibly cv-qualified types \tcode{in_place_t} or
 \tcode{nullopt_t} is ill-formed.
 
 \rSec2[optional.object]{\tcode{optional} for object types}
@@ -4953,7 +4953,7 @@ static pointer pointer_traits<T*>::pointer_to(@\seebelow@ r) noexcept;
 
 \begin{itemdescr}
 \pnum
-\remark If \tcode{element_type} is (possibly \cv-qualified) \tcode{void}, the type of
+\remark If \tcode{element_type} is (possibly cv-qualified) \tcode{void}, the type of
 \tcode{r} is unspecified; otherwise, it is \tcode{element_type\&}.
 
 \pnum
@@ -7781,7 +7781,7 @@ T& operator*() const noexcept;
 
 \pnum\returns  \tcode{*get()}.
 
-\pnum\remarks When \tcode{T} is (possibly \cv-qualified) \tcode{void},
+\pnum\remarks When \tcode{T} is (possibly cv-qualified) \tcode{void},
 it is unspecified whether this
 member function is declared. If it is declared, it is unspecified what its
 return type is, except that the declaration (although not necessarily the
@@ -12798,31 +12798,31 @@ notwithstanding the restrictions of~\ref{declval}.
  \tcode{struct is_trivial;}                 &
  \tcode{T} is a trivial type~(\ref{basic.types})     &
  \tcode{remove_all_extents_t<T>} shall be a complete
- type or (possibly \cv-qualified) \tcode{void}.                \\ \rowsep
+ type or (possibly cv-qualified) \tcode{void}.                \\ \rowsep
 
 \tcode{template <class T>}\br
  \tcode{struct is_trivially_copyable;}      &
  \tcode{T} is a trivially copyable type~(\ref{basic.types}) &
  \tcode{remove_all_extents_t<T>} shall be a complete type or
- (possibly \cv-qualified) \tcode{void}.                               \\ \rowsep
+ (possibly cv-qualified) \tcode{void}.                               \\ \rowsep
 
 \tcode{template <class T>}\br
  \tcode{struct is_standard_layout;}                 &
  \tcode{T} is a standard-layout type~(\ref{basic.types})   &
  \tcode{remove_all_extents_t<T>} shall be a complete
- type or (possibly \cv-qualified) \tcode{void}.                \\ \rowsep
+ type or (possibly cv-qualified) \tcode{void}.                \\ \rowsep
 
 \tcode{template <class T>}\br
  \tcode{struct is_pod;}                 &
  \tcode{T} is a POD type~(\ref{basic.types})                                &
  \tcode{remove_all_extents_t<T>} shall be a complete
- type or (possibly \cv-qualified) \tcode{void}.                \\ \rowsep
+ type or (possibly cv-qualified) \tcode{void}.                \\ \rowsep
 
 \tcode{template <class T>}\br
  \tcode{struct is_literal_type;}        &
  \tcode{T} is a literal type~(\ref{basic.types})  &
  \tcode{remove_all_extents_t<T>} shall be a complete type or
- (possibly \cv-qualified) \tcode{void}.                               \\ \rowsep
+ (possibly cv-qualified) \tcode{void}.                               \\ \rowsep
 
 \tcode{template <class T>}\br
  \tcode{struct is_empty;}               &
@@ -12867,27 +12867,27 @@ notwithstanding the restrictions of~\ref{declval}.
  \tcode{is_constructible<T, Args...>::value} is \tcode{false},
  otherwise \seebelow                &
  \tcode{T} and all types in the parameter pack \tcode{Args}
- shall be complete types, (possibly \cv-qualified) \tcode{void},
+ shall be complete types, (possibly cv-qualified) \tcode{void},
  or arrays of unknown bound.  \\ \rowsep
 
 \tcode{template <class T>}\br
   \tcode{struct is_default_constructible;} &
   \tcode{is_constructible<T>::value} is \tcode{true}. &
-  \tcode{T} shall be a complete type, (possibly \cv-qualified) \tcode{void},
+  \tcode{T} shall be a complete type, (possibly cv-qualified) \tcode{void},
   or an array of unknown bound. \\ \rowsep
 
 \tcode{template <class T>}\br
   \tcode{struct is_copy_constructible;} &
   For a referenceable type \tcode{T}, the same result as
   \tcode{is_constructible<T, const T\&>::value}, otherwise \tcode{false}. &
-  \tcode{T} shall be a complete type, (possibly \cv-qualified) \tcode{void},
+  \tcode{T} shall be a complete type, (possibly cv-qualified) \tcode{void},
   or an array of unknown bound. \\ \rowsep
 
 \tcode{template <class T>}\br
   \tcode{struct is_move_constructible;} &
   For a referenceable type \tcode{T}, the same result as
   \tcode{is_constructible<T, T\&\&>::value}, otherwise \tcode{false}. &
-  \tcode{T} shall be a complete type, (possibly \cv-qualified) \tcode{void},
+  \tcode{T} shall be a complete type, (possibly cv-qualified) \tcode{void},
   or an array of unknown bound. \\ \rowsep
 
 \tcode{template <class T, class U>}\br
@@ -12901,21 +12901,21 @@ notwithstanding the restrictions of~\ref{declval}.
   specializations and function template specializations, the generation of
   implicitly-defined functions, and so on. Such side effects are not in the ``immediate
   context'' and can result in the program being ill-formed. \exitnote &
-  \tcode{T} and \tcode{U} shall be complete types, (possibly \cv-qualified) \tcode{void},
+  \tcode{T} and \tcode{U} shall be complete types, (possibly cv-qualified) \tcode{void},
   or arrays of unknown bound. \\ \rowsep
 
 \tcode{template <class T>}\br
   \tcode{struct is_copy_assignable;} &
   For a referenceable type \tcode{T}, the same result as
   \tcode{is_assignable<T\&, const T\&>::value}, otherwise \tcode{false}. &
-  \tcode{T} shall be a complete type, (possibly \cv-qualified) \tcode{void},
+  \tcode{T} shall be a complete type, (possibly cv-qualified) \tcode{void},
   or an array of unknown bound. \\ \rowsep
 
 \tcode{template <class T>}\br
   \tcode{struct is_move_assignable;} &
   For a referenceable type \tcode{T}, the same result as
   \tcode{is_assignable<T\&, T\&\&>::value}, otherwise \tcode{false}. &
-  \tcode{T} shall be a complete type, (possibly \cv-qualified) \tcode{void},
+  \tcode{T} shall be a complete type, (possibly cv-qualified) \tcode{void},
   or an array of unknown bound. \\ \rowsep
 
 \tcode{template <class T, class U>}\br
@@ -12938,7 +12938,7 @@ notwithstanding the restrictions of~\ref{declval}.
   can result in the program being ill-formed.
   \exitnote &
   \tcode{T} and \tcode{U} shall be complete types,
-  (possibly \cv-qualified) \tcode{void}, or
+  (possibly cv-qualified) \tcode{void}, or
   arrays of unknown bound.  \\ \rowsep
 
 \tcode{template <class T>}\br
@@ -12947,7 +12947,7 @@ notwithstanding the restrictions of~\ref{declval}.
   the same result as \tcode{is_swappable_with<T\&, T\&>::value},
   otherwise \tcode{false}. &
   \tcode{T} shall be a complete type,
-  (possibly \cv-qualified) \tcode{void}, or
+  (possibly cv-qualified) \tcode{void}, or
   an array of unknown bound. \\ \rowsep
 
 \tcode{template <class T>}\br
@@ -12960,7 +12960,7 @@ notwithstanding the restrictions of~\ref{declval}.
   when treated as an unevaluated operand (Clause~\ref{expr}), \br then
   \tcode{is_destructible<T>::value} is \tcode{true},
   otherwise it is \tcode{false}. &
-  \tcode{T} shall be a complete type, (possibly \cv-qualified) \tcode{void},
+  \tcode{T} shall be a complete type, (possibly cv-qualified) \tcode{void},
   or an array of unknown bound. \\ \rowsep
 
 \tcode{template <class T, class... Args>}\br
@@ -12971,13 +12971,13 @@ notwithstanding the restrictions of~\ref{declval}.
   definition for \tcode{is_constructible}, as defined below, is known to call
   no operation that is not trivial (~\ref{basic.types},~\ref{special}). &
   \tcode{T} and all types in the parameter pack \tcode{Args} shall be complete types,
-  (possibly \cv-qualified) \tcode{void}, or arrays of unknown bound. \\ \rowsep
+  (possibly cv-qualified) \tcode{void}, or arrays of unknown bound. \\ \rowsep
 
 \tcode{template <class T>}\br
  \tcode{struct is_trivially_default_constructible;} &
  \tcode{is_trivially_constructible<T>::value} is \tcode{true}. &
  \tcode{T} shall be a complete type,
- (possibly \cv-qualified) \tcode{void}, or an array of unknown
+ (possibly cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
 \tcode{template <class T>}\br
@@ -12985,7 +12985,7 @@ notwithstanding the restrictions of~\ref{declval}.
   For a referenceable type \tcode{T}, the same result as
  \tcode{is_trivially_constructible<T, const T\&>::value}, otherwise \tcode{false}. &
   \tcode{T} shall be a complete type,
- (possibly \cv-qualified) \tcode{void}, or an array of unknown
+ (possibly cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
 \tcode{template <class T>}\br
@@ -12993,7 +12993,7 @@ notwithstanding the restrictions of~\ref{declval}.
   For a referenceable type \tcode{T}, the same result as
  \tcode{is_trivially_constructible<T, T\&\&>::value}, otherwise \tcode{false}. &
   \tcode{T} shall be a complete type,
- (possibly \cv-qualified) \tcode{void}, or an array of unknown
+ (possibly cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
 \tcode{template <class T, class U>}\br
@@ -13001,7 +13001,7 @@ notwithstanding the restrictions of~\ref{declval}.
   \tcode{is_assignable<T, U>::value} is \tcode{true} and the assignment, as defined by
   \tcode{is_assignable}, is known to call no operation that is not trivial
   (\ref{basic.types},~\ref{special}). &
-  \tcode{T} and \tcode{U} shall be complete types, (possibly \cv-qualified) \tcode{void},
+  \tcode{T} and \tcode{U} shall be complete types, (possibly cv-qualified) \tcode{void},
   or arrays of unknown bound. \\ \rowsep
 
 \tcode{template <class T>}\br
@@ -13009,7 +13009,7 @@ notwithstanding the restrictions of~\ref{declval}.
   For a referenceable type \tcode{T}, the same result as
  \tcode{is_trivially_assignable<T\&, const T\&>::value}, otherwise \tcode{false}. &
  \tcode{T} shall be a complete type,
- (possibly \cv-qualified) \tcode{void}, or an array of unknown
+ (possibly cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
 \tcode{template <class T>}\br
@@ -13017,14 +13017,14 @@ notwithstanding the restrictions of~\ref{declval}.
   For a referenceable type \tcode{T}, the same result as
  \tcode{is_trivially_assignable<T\&, T\&\&>::value}, otherwise \tcode{false}. &
  \tcode{T} shall be a complete type,
- (possibly \cv-qualified) \tcode{void}, or an array of unknown bound.                \\ \rowsep
+ (possibly cv-qualified) \tcode{void}, or an array of unknown bound.                \\ \rowsep
 
 \tcode{template <class T>}\br
  \tcode{struct is_trivially_destructible;} &
  \tcode{is_destructible<T>::value} is \tcode{true} and the indicated destructor is known
  to be trivial. &
  \tcode{T} shall be a complete type,
- (possibly \cv-qualified) \tcode{void}, or an array of unknown
+ (possibly cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
 \tcode{template <class T, class... Args>}\br
@@ -13035,14 +13035,14 @@ notwithstanding the restrictions of~\ref{declval}.
  throw any exceptions~(\ref{expr.unary.noexcept}).
  &
  \tcode{T} and all types in the parameter pack \tcode{Args}
- shall be complete types, (possibly \cv-qualified) \tcode{void},
+ shall be complete types, (possibly cv-qualified) \tcode{void},
  or arrays of unknown bound.  \\ \rowsep
 
 \tcode{template <class T>}\br
  \tcode{struct is_nothrow_default_constructible;} &
  \tcode{is_nothrow_constructible<T>::value} is \tcode{true}.  &
  \tcode{T} shall be a complete type,
- (possibly \cv-qualified) \tcode{void}, or an array of unknown
+ (possibly cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
 \tcode{template <class T>}\br
@@ -13050,7 +13050,7 @@ notwithstanding the restrictions of~\ref{declval}.
   For a referenceable type \tcode{T}, the same result as
  \tcode{is_nothrow_constructible<T, const T\&>::value}, otherwise \tcode{false}. &
  \tcode{T} shall be a complete type,
- (possibly \cv-qualified) \tcode{void}, or an array of unknown
+ (possibly cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
 \tcode{template <class T>}\br
@@ -13058,13 +13058,13 @@ notwithstanding the restrictions of~\ref{declval}.
   For a referenceable type \tcode{T}, the same result as
  \tcode{is_nothrow_constructible<T, T\&\&>::value}, otherwise \tcode{false}. &
  \tcode{T} shall be a complete type,
- (possibly \cv-qualified) \tcode{void}, or an array of unknown bound.                \\ \rowsep
+ (possibly cv-qualified) \tcode{void}, or an array of unknown bound.                \\ \rowsep
 
 \tcode{template <class T, class U>}\br
   \tcode{struct is_nothrow_assignable;} &
   \tcode{is_assignable<T, U>::value} is \tcode{true} and the assignment is known not to
   throw any exceptions~(\ref{expr.unary.noexcept}). &
-  \tcode{T} and \tcode{U} shall be complete types, (possibly \cv-qualified) \tcode{void},
+  \tcode{T} and \tcode{U} shall be complete types, (possibly cv-qualified) \tcode{void},
   or arrays of unknown bound. \\ \rowsep
 
 \tcode{template <class T>}\br
@@ -13072,7 +13072,7 @@ notwithstanding the restrictions of~\ref{declval}.
   For a referenceable type \tcode{T}, the same result as
  \tcode{is_nothrow_assignable<T\&, const T\&>::value}, otherwise \tcode{false}. &
  \tcode{T} shall be a complete type,
- (possibly \cv-qualified) \tcode{void}, or an array of unknown
+ (possibly cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
 \tcode{template <class T>}\br
@@ -13080,7 +13080,7 @@ notwithstanding the restrictions of~\ref{declval}.
   For a referenceable type \tcode{T}, the same result as
   \tcode{is_nothrow_assignable<T\&, T\&\&>::value}, otherwise \tcode{false}. &
  \tcode{T} shall be a complete type,
- (possibly \cv-qualified) \tcode{void}, or an array of unknown
+ (possibly cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
 \tcode{template <class T, class U>}\br
@@ -13090,7 +13090,7 @@ notwithstanding the restrictions of~\ref{declval}.
   \tcode{is_swappable_with<T, U>} is known not to throw
   any exceptions~(\ref{expr.unary.noexcept}). &
   \tcode{T} and \tcode{U} shall be complete types,
-  (possibly \cv-qualified) \tcode{void}, or
+  (possibly cv-qualified) \tcode{void}, or
   arrays of unknown bound. \\ \rowsep
 
 \tcode{template <class T>}\br
@@ -13099,7 +13099,7 @@ notwithstanding the restrictions of~\ref{declval}.
   the same result as \tcode{is_nothrow_swappable_with<T\&, T\&>::value},
   otherwise \tcode{false}. &
   \tcode{T} shall be a complete type,
-  (possibly \cv-qualified) \tcode{void}, or
+  (possibly cv-qualified) \tcode{void}, or
   an array of unknown bound. \\ \rowsep
 
 \tcode{template <class T>}\br
@@ -13107,7 +13107,7 @@ notwithstanding the restrictions of~\ref{declval}.
   \tcode{is_destructible<T>::value} is \tcode{true} and the indicated destructor is known
   not to throw any exceptions~(\ref{expr.unary.noexcept}). &
   \tcode{T} shall be a complete type,
-  (possibly \cv-qualified) \tcode{void}, or an array of unknown
+  (possibly cv-qualified) \tcode{void}, or an array of unknown
   bound.                \\ \rowsep
 
 \tcode{template <class T>}\br
@@ -13282,14 +13282,14 @@ with a BaseCharacteristic of
  \seebelow                                  &
  \tcode{From} and \tcode{To} shall be complete
  types, arrays of unknown
- bound, or (possibly \cv-qualified) \tcode{void} types.                \\ \rowsep
+ bound, or (possibly cv-qualified) \tcode{void} types.                \\ \rowsep
 
 \tcode{template <class Fn, class... ArgTypes, class R>}\br
  \tcode{struct is_callable<Fn(ArgTypes...), R>;}                      &
  The expression \tcode{INVOKE(declval<Fn>(), declval<ArgTypes>()..., R)}
  is well formed when treated as an unevaluated operand                &
  \tcode{Fn}, \tcode{R}, and all types in the parameter pack \tcode{ArgTypes}
- shall be complete types, (possibly \cv-qualified) \tcode{void}, or
+ shall be complete types, (possibly cv-qualified) \tcode{void}, or
  arrays of unknown bound.                                             \\ \rowsep
 
 \tcode{template <class Fn, class... ArgTypes, class R>}\br
@@ -13298,7 +13298,7 @@ with a BaseCharacteristic of
  the expression \tcode{INVOKE(declval<Fn>(), declval<ArgTypes>()..., R)}
  is known not to throw any exceptions                                 &
  \tcode{Fn}, \tcode{R}, and all types in the parameter pack \tcode{ArgTypes}
- shall be complete types, (possibly \cv-qualified) \tcode{void}, or
+ shall be complete types, (possibly cv-qualified) \tcode{void}, or
  arrays of unknown bound.                                             \\
 \end{libreqtab3f}
 
@@ -13461,32 +13461,32 @@ Each of the templates in this subclause shall be a
 \endhead
 \tcode{template <class T>}\br
  \tcode{struct make_signed;} &
- If \tcode{T} names a (possibly \cv-qualified) signed integer
+ If \tcode{T} names a (possibly cv-qualified) signed integer
  type~(\ref{basic.fundamental}) then the member typedef
  \tcode{type} shall name the type \tcode{T}; otherwise,
- if \tcode{T} names a (possibly \cv-qualified) unsigned integer
+ if \tcode{T} names a (possibly cv-qualified) unsigned integer
  type then \tcode{type} shall name the corresponding
  signed integer type, with the same cv-qualifiers as \tcode{T};
  otherwise, \tcode{type} shall name the signed integer type with smallest
  rank~(\ref{conv.rank}) for which
  \tcode{sizeof(T) == sizeof(type)}, with the same
  cv-qualifiers as \tcode{T}.\br
- \requires \tcode{T} shall be a (possibly \cv-qualified)
+ \requires \tcode{T} shall be a (possibly cv-qualified)
  integral type or enumeration
  but not a \tcode{bool} type.\\ \rowsep
 \tcode{template <class T>}\br
  \tcode{struct make_unsigned;} &
- If \tcode{T} names a (possibly \cv-qualified) unsigned integer
+ If \tcode{T} names a (possibly cv-qualified) unsigned integer
  type~(\ref{basic.fundamental}) then the member typedef
  \tcode{type} shall name the type \tcode{T}; otherwise,
- if \tcode{T} names a (possibly \cv-qualified) signed integer
+ if \tcode{T} names a (possibly cv-qualified) signed integer
  type then \tcode{type} shall name the corresponding
  unsigned integer type, with the same cv-qualifiers as \tcode{T};
  otherwise, \tcode{type} shall name the unsigned integer type with smallest
  rank~(\ref{conv.rank}) for which
  \tcode{sizeof(T) == sizeof(type)}, with the same
  cv-qualifiers as \tcode{T}.\br
- \requires \tcode{T} shall be a (possibly \cv-qualified)
+ \requires \tcode{T} shall be a (possibly cv-qualified)
  integral type or enumeration
  but not a \tcode{bool} type.\\
 \end{libreqtab2a}
@@ -13548,13 +13548,13 @@ assert((is_same<remove_all_extents_t<int[][3]>, int>::value));
 \endhead
 \tcode{template <class T>\br
  struct remove_pointer;}                    &
- If \tcode{T} has type ``(possibly \cv-qualified) pointer
+ If \tcode{T} has type ``(possibly cv-qualified) pointer
  to \tcode{T1}'' then the member typedef \tcode{type}
  shall name \tcode{T1}; otherwise, it shall name \tcode{T}.\\ \rowsep
 \tcode{template <class T>\br
  struct add_pointer;}                       &
  If \tcode{T} names a referenceable type or a
- (possibly \cv-qualified) \tcode{void} type then
+ (possibly cv-qualified) \tcode{void} type then
  the member typedef \tcode{type} shall name the same type as
  \tcode{remove_reference_t<T>*};
  otherwise, \tcode{type} shall name \tcode{T}.             \\
@@ -13645,7 +13645,7 @@ needed when only explicit conversions are desired among the template arguments.
  \tcode{class... ArgTypes> struct}
  \tcode{result_of<Fn(ArgTypes...)>;}  &
  \tcode{Fn} and all types in the parameter pack \tcode{ArgTypes} shall
- be complete types, (possibly \cv-qualified) \tcode{void}, or arrays of
+ be complete types, (possibly cv-qualified) \tcode{void}, or arrays of
  unknown bound. &
  If the expression \tcode{\textit{INVOKE}(declval<Fn>(), declval<ArgTypes>()...)}
  is well formed when treated as an unevaluated operand (Clause~\ref{expr}),

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2200,7 +2200,7 @@ namespace std {
 
 \pnum
 A program that necessitates the instantiation of template \tcode{optional} for
-a reference type, or for possibly cv-qualified types \tcode{in_place_t} or
+a reference type, or for possibly \cv-qualified types \tcode{in_place_t} or
 \tcode{nullopt_t} is ill-formed.
 
 \rSec2[optional.object]{\tcode{optional} for object types}
@@ -4953,7 +4953,7 @@ static pointer pointer_traits<T*>::pointer_to(@\seebelow@ r) noexcept;
 
 \begin{itemdescr}
 \pnum
-\remark If \tcode{element_type} is (possibly cv-qualified) \tcode{void}, the type of
+\remark If \tcode{element_type} is (possibly \cv-qualified) \tcode{void}, the type of
 \tcode{r} is unspecified; otherwise, it is \tcode{element_type\&}.
 
 \pnum
@@ -12798,31 +12798,31 @@ notwithstanding the restrictions of~\ref{declval}.
  \tcode{struct is_trivial;}                 &
  \tcode{T} is a trivial type~(\ref{basic.types})     &
  \tcode{remove_all_extents_t<T>} shall be a complete
- type or (possibly cv-qualified) void.                \\ \rowsep
+ type or (possibly \cv-qualified) \tcode{void}.                \\ \rowsep
 
 \tcode{template <class T>}\br
  \tcode{struct is_trivially_copyable;}      &
  \tcode{T} is a trivially copyable type~(\ref{basic.types}) &
  \tcode{remove_all_extents_t<T>} shall be a complete type or
- (possibly cv-qualified) \tcode{void}.                               \\ \rowsep
+ (possibly \cv-qualified) \tcode{void}.                               \\ \rowsep
 
 \tcode{template <class T>}\br
  \tcode{struct is_standard_layout;}                 &
  \tcode{T} is a standard-layout type~(\ref{basic.types})   &
  \tcode{remove_all_extents_t<T>} shall be a complete
- type or (possibly cv-qualified) void.                \\ \rowsep
+ type or (possibly \cv-qualified) \tcode{void}.                \\ \rowsep
 
 \tcode{template <class T>}\br
  \tcode{struct is_pod;}                 &
  \tcode{T} is a POD type~(\ref{basic.types})                                &
  \tcode{remove_all_extents_t<T>} shall be a complete
- type or (possibly cv-qualified) void.                \\ \rowsep
+ type or (possibly \cv-qualified) \tcode{void}.                \\ \rowsep
 
 \tcode{template <class T>}\br
  \tcode{struct is_literal_type;}        &
  \tcode{T} is a literal type~(\ref{basic.types})  &
  \tcode{remove_all_extents_t<T>} shall be a complete type or
- (possibly cv-qualified) \tcode{void}.                               \\ \rowsep
+ (possibly \cv-qualified) \tcode{void}.                               \\ \rowsep
 
 \tcode{template <class T>}\br
  \tcode{struct is_empty;}               &
@@ -12867,7 +12867,7 @@ notwithstanding the restrictions of~\ref{declval}.
  \tcode{is_constructible<T, Args...>::value} is \tcode{false},
  otherwise \seebelow                &
  \tcode{T} and all types in the parameter pack \tcode{Args}
- shall be complete types, (possibly cv-qualified) \tcode{void},
+ shall be complete types, (possibly \cv-qualified) \tcode{void},
  or arrays of unknown bound.  \\ \rowsep
 
 \tcode{template <class T>}\br
@@ -12901,7 +12901,7 @@ notwithstanding the restrictions of~\ref{declval}.
   specializations and function template specializations, the generation of
   implicitly-defined functions, and so on. Such side effects are not in the ``immediate
   context'' and can result in the program being ill-formed. \exitnote &
-  \tcode{T} and \tcode{U} shall be complete types, (possibly cv-qualified) \tcode{void},
+  \tcode{T} and \tcode{U} shall be complete types, (possibly \cv-qualified) \tcode{void},
   or arrays of unknown bound. \\ \rowsep
 
 \tcode{template <class T>}\br
@@ -12971,13 +12971,13 @@ notwithstanding the restrictions of~\ref{declval}.
   definition for \tcode{is_constructible}, as defined below, is known to call
   no operation that is not trivial (~\ref{basic.types},~\ref{special}). &
   \tcode{T} and all types in the parameter pack \tcode{Args} shall be complete types,
-  (possibly cv-qualified) \tcode{void}, or arrays of unknown bound. \\ \rowsep
+  (possibly \cv-qualified) \tcode{void}, or arrays of unknown bound. \\ \rowsep
 
 \tcode{template <class T>}\br
  \tcode{struct is_trivially_default_constructible;} &
  \tcode{is_trivially_constructible<T>::value} is \tcode{true}. &
  \tcode{T} shall be a complete type,
- (possibly cv-qualified) void, or an array of unknown
+ (possibly \cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
 \tcode{template <class T>}\br
@@ -12985,7 +12985,7 @@ notwithstanding the restrictions of~\ref{declval}.
   For a referenceable type \tcode{T}, the same result as
  \tcode{is_trivially_constructible<T, const T\&>::value}, otherwise \tcode{false}. &
   \tcode{T} shall be a complete type,
- (possibly cv-qualified) void, or an array of unknown
+ (possibly \cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
 \tcode{template <class T>}\br
@@ -12993,7 +12993,7 @@ notwithstanding the restrictions of~\ref{declval}.
   For a referenceable type \tcode{T}, the same result as
  \tcode{is_trivially_constructible<T, T\&\&>::value}, otherwise \tcode{false}. &
   \tcode{T} shall be a complete type,
- (possibly cv-qualified) void, or an array of unknown
+ (possibly \cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
 \tcode{template <class T, class U>}\br
@@ -13001,7 +13001,7 @@ notwithstanding the restrictions of~\ref{declval}.
   \tcode{is_assignable<T, U>::value} is \tcode{true} and the assignment, as defined by
   \tcode{is_assignable}, is known to call no operation that is not trivial
   (\ref{basic.types},~\ref{special}). &
-  \tcode{T} and \tcode{U} shall be complete types, (possibly cv-qualified) \tcode{void},
+  \tcode{T} and \tcode{U} shall be complete types, (possibly \cv-qualified) \tcode{void},
   or arrays of unknown bound. \\ \rowsep
 
 \tcode{template <class T>}\br
@@ -13009,7 +13009,7 @@ notwithstanding the restrictions of~\ref{declval}.
   For a referenceable type \tcode{T}, the same result as
  \tcode{is_trivially_assignable<T\&, const T\&>::value}, otherwise \tcode{false}. &
  \tcode{T} shall be a complete type,
- (possibly cv-qualified) void, or an array of unknown
+ (possibly \cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
 \tcode{template <class T>}\br
@@ -13017,14 +13017,14 @@ notwithstanding the restrictions of~\ref{declval}.
   For a referenceable type \tcode{T}, the same result as
  \tcode{is_trivially_assignable<T\&, T\&\&>::value}, otherwise \tcode{false}. &
  \tcode{T} shall be a complete type,
- (possibly cv-qualified) void, or an array of unknown bound.                \\ \rowsep
+ (possibly \cv-qualified) \tcode{void}, or an array of unknown bound.                \\ \rowsep
 
 \tcode{template <class T>}\br
  \tcode{struct is_trivially_destructible;} &
  \tcode{is_destructible<T>::value} is \tcode{true} and the indicated destructor is known
  to be trivial. &
  \tcode{T} shall be a complete type,
- (possibly cv-qualified) void, or an array of unknown
+ (possibly \cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
 \tcode{template <class T, class... Args>}\br
@@ -13035,14 +13035,14 @@ notwithstanding the restrictions of~\ref{declval}.
  throw any exceptions~(\ref{expr.unary.noexcept}).
  &
  \tcode{T} and all types in the parameter pack \tcode{Args}
- shall be complete types, (possibly cv-qualified) \tcode{void},
+ shall be complete types, (possibly \cv-qualified) \tcode{void},
  or arrays of unknown bound.  \\ \rowsep
 
 \tcode{template <class T>}\br
  \tcode{struct is_nothrow_default_constructible;} &
  \tcode{is_nothrow_constructible<T>::value} is \tcode{true}.  &
  \tcode{T} shall be a complete type,
- (possibly cv-qualified) void, or an array of unknown
+ (possibly \cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
 \tcode{template <class T>}\br
@@ -13050,7 +13050,7 @@ notwithstanding the restrictions of~\ref{declval}.
   For a referenceable type \tcode{T}, the same result as
  \tcode{is_nothrow_constructible<T, const T\&>::value}, otherwise \tcode{false}. &
  \tcode{T} shall be a complete type,
- (possibly cv-qualified) void, or an array of unknown
+ (possibly \cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
 \tcode{template <class T>}\br
@@ -13058,13 +13058,13 @@ notwithstanding the restrictions of~\ref{declval}.
   For a referenceable type \tcode{T}, the same result as
  \tcode{is_nothrow_constructible<T, T\&\&>::value}, otherwise \tcode{false}. &
  \tcode{T} shall be a complete type,
- (possibly cv-qualified) void, or an array of unknown bound.                \\ \rowsep
+ (possibly \cv-qualified) \tcode{void}, or an array of unknown bound.                \\ \rowsep
 
 \tcode{template <class T, class U>}\br
   \tcode{struct is_nothrow_assignable;} &
   \tcode{is_assignable<T, U>::value} is \tcode{true} and the assignment is known not to
   throw any exceptions~(\ref{expr.unary.noexcept}). &
-  \tcode{T} and \tcode{U} shall be complete types, (possibly cv-qualified) \tcode{void},
+  \tcode{T} and \tcode{U} shall be complete types, (possibly \cv-qualified) \tcode{void},
   or arrays of unknown bound. \\ \rowsep
 
 \tcode{template <class T>}\br
@@ -13072,7 +13072,7 @@ notwithstanding the restrictions of~\ref{declval}.
   For a referenceable type \tcode{T}, the same result as
  \tcode{is_nothrow_assignable<T\&, const T\&>::value}, otherwise \tcode{false}. &
  \tcode{T} shall be a complete type,
- (possibly cv-qualified) void, or an array of unknown
+ (possibly \cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
 \tcode{template <class T>}\br
@@ -13080,7 +13080,7 @@ notwithstanding the restrictions of~\ref{declval}.
   For a referenceable type \tcode{T}, the same result as
   \tcode{is_nothrow_assignable<T\&, T\&\&>::value}, otherwise \tcode{false}. &
  \tcode{T} shall be a complete type,
- (possibly cv-qualified) void, or an array of unknown
+ (possibly \cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
 \tcode{template <class T, class U>}\br
@@ -13099,7 +13099,7 @@ notwithstanding the restrictions of~\ref{declval}.
   the same result as \tcode{is_nothrow_swappable_with<T\&, T\&>::value},
   otherwise \tcode{false}. &
   \tcode{T} shall be a complete type,
-  (possibly \cv-qualified) void, or
+  (possibly \cv-qualified) \tcode{void}, or
   an array of unknown bound. \\ \rowsep
 
 \tcode{template <class T>}\br
@@ -13107,7 +13107,7 @@ notwithstanding the restrictions of~\ref{declval}.
   \tcode{is_destructible<T>::value} is \tcode{true} and the indicated destructor is known
   not to throw any exceptions~(\ref{expr.unary.noexcept}). &
   \tcode{T} shall be a complete type,
-  (possibly cv-qualified) void, or an array of unknown
+  (possibly \cv-qualified) \tcode{void}, or an array of unknown
   bound.                \\ \rowsep
 
 \tcode{template <class T>}\br
@@ -13282,14 +13282,14 @@ with a BaseCharacteristic of
  \seebelow                                  &
  \tcode{From} and \tcode{To} shall be complete
  types, arrays of unknown
- bound, or (possibly cv-qualified) \tcode{void} types.                \\ \rowsep
+ bound, or (possibly \cv-qualified) \tcode{void} types.                \\ \rowsep
 
 \tcode{template <class Fn, class... ArgTypes, class R>}\br
  \tcode{struct is_callable<Fn(ArgTypes...), R>;}                      &
  The expression \tcode{INVOKE(declval<Fn>(), declval<ArgTypes>()..., R)}
  is well formed when treated as an unevaluated operand                &
  \tcode{Fn}, \tcode{R}, and all types in the parameter pack \tcode{ArgTypes}
- shall be complete types, (possibly cv-qualified) \tcode{void}, or
+ shall be complete types, (possibly \cv-qualified) \tcode{void}, or
  arrays of unknown bound.                                             \\ \rowsep
 
 \tcode{template <class Fn, class... ArgTypes, class R>}\br
@@ -13298,7 +13298,7 @@ with a BaseCharacteristic of
  the expression \tcode{INVOKE(declval<Fn>(), declval<ArgTypes>()..., R)}
  is known not to throw any exceptions                                 &
  \tcode{Fn}, \tcode{R}, and all types in the parameter pack \tcode{ArgTypes}
- shall be complete types, (possibly cv-qualified) \tcode{void}, or
+ shall be complete types, (possibly \cv-qualified) \tcode{void}, or
  arrays of unknown bound.                                             \\
 \end{libreqtab3f}
 
@@ -13461,32 +13461,32 @@ Each of the templates in this subclause shall be a
 \endhead
 \tcode{template <class T>}\br
  \tcode{struct make_signed;} &
- If \tcode{T} names a (possibly cv-qualified) signed integer
+ If \tcode{T} names a (possibly \cv-qualified) signed integer
  type~(\ref{basic.fundamental}) then the member typedef
  \tcode{type} shall name the type \tcode{T}; otherwise,
- if \tcode{T} names a (possibly cv-qualified) unsigned integer
+ if \tcode{T} names a (possibly \cv-qualified) unsigned integer
  type then \tcode{type} shall name the corresponding
  signed integer type, with the same cv-qualifiers as \tcode{T};
  otherwise, \tcode{type} shall name the signed integer type with smallest
  rank~(\ref{conv.rank}) for which
  \tcode{sizeof(T) == sizeof(type)}, with the same
  cv-qualifiers as \tcode{T}.\br
- \requires \tcode{T} shall be a (possibly cv-qualified)
+ \requires \tcode{T} shall be a (possibly \cv-qualified)
  integral type or enumeration
  but not a \tcode{bool} type.\\ \rowsep
 \tcode{template <class T>}\br
  \tcode{struct make_unsigned;} &
- If \tcode{T} names a (possibly cv-qualified) unsigned integer
+ If \tcode{T} names a (possibly \cv-qualified) unsigned integer
  type~(\ref{basic.fundamental}) then the member typedef
  \tcode{type} shall name the type \tcode{T}; otherwise,
- if \tcode{T} names a (possibly cv-qualified) signed integer
+ if \tcode{T} names a (possibly \cv-qualified) signed integer
  type then \tcode{type} shall name the corresponding
  unsigned integer type, with the same cv-qualifiers as \tcode{T};
  otherwise, \tcode{type} shall name the unsigned integer type with smallest
  rank~(\ref{conv.rank}) for which
  \tcode{sizeof(T) == sizeof(type)}, with the same
  cv-qualifiers as \tcode{T}.\br
- \requires \tcode{T} shall be a (possibly cv-qualified)
+ \requires \tcode{T} shall be a (possibly \cv-qualified)
  integral type or enumeration
  but not a \tcode{bool} type.\\
 \end{libreqtab2a}
@@ -13548,13 +13548,13 @@ assert((is_same<remove_all_extents_t<int[][3]>, int>::value));
 \endhead
 \tcode{template <class T>\br
  struct remove_pointer;}                    &
- If \tcode{T} has type ``(possibly cv-qualified) pointer
+ If \tcode{T} has type ``(possibly \cv-qualified) pointer
  to \tcode{T1}'' then the member typedef \tcode{type}
  shall name \tcode{T1}; otherwise, it shall name \tcode{T}.\\ \rowsep
 \tcode{template <class T>\br
  struct add_pointer;}                       &
  If \tcode{T} names a referenceable type or a
- (possibly cv-qualified) \tcode{void} type then
+ (possibly \cv-qualified) \tcode{void} type then
  the member typedef \tcode{type} shall name the same type as
  \tcode{remove_reference_t<T>*};
  otherwise, \tcode{type} shall name \tcode{T}.             \\
@@ -13645,7 +13645,7 @@ needed when only explicit conversions are desired among the template arguments.
  \tcode{class... ArgTypes> struct}
  \tcode{result_of<Fn(ArgTypes...)>;}  &
  \tcode{Fn} and all types in the parameter pack \tcode{ArgTypes} shall
- be complete types, (possibly cv-qualified) \tcode{void}, or arrays of
+ be complete types, (possibly \cv-qualified) \tcode{void}, or arrays of
  unknown bound. &
  If the expression \tcode{\textit{INVOKE}(declval<Fn>(), declval<ArgTypes>()...)}
  is well formed when treated as an unevaluated operand (Clause~\ref{expr}),


### PR DESCRIPTION
This patch addresses https://github.com/cplusplus/draft/issues/544.
Update all use of 'void' in type traits tables to use the codified
form \tcode{void}.  There was one use of the phrase "void types"
that I deliberately chose to not touch.

A second issue I stumbled over in this edit was inconsistent use
of cv-qualified vs. \cv-qualfied.  The latter seemed preferable,
so I applied that formatting consistently through this file for
all uses of cv-qualified that were not otherwise participating
in mark-up.