### PR TITLE
[unique.ptr.special] prefer use of common_type_t

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -7106,8 +7106,8 @@ template <class T1, class D1, class T2, class D2>
 
 \begin{itemdescr}
 \pnum
-\requires Let \tcode{\placeholder{CT}} denote \tcode{common_type<unique_ptr<T1, D1>::pointer},
-\tcode{unique_ptr<T2, D2>::poin\-ter>::type}. Then the specialization
+\requires Let \tcode{\placeholder{CT}} denote \tcode{common_type_t<typename unique_ptr<T1, D1>::pointer,
+typename unique_ptr<T2, D2>::pointer>}. Then the specialization
 \tcode{less<\placeholder{CT}>} shall be a function object type~(\ref{function.objects}) that
 induces a strict weak ordering~(\ref{alg.sorting}) on the pointer values.
 


### PR DESCRIPTION
The preferred style since C++14 is to use the _t alias
rather than the trait::type formulation for transformation
traits.  As a second fix, the types in the common_type
instantiation are, in turn, dependant types so require a
leading typename keyword.  I double-checked elsewhere and
we are consistent to use typename where requrired inside
other expressions, even though it is frequently omitted
when the named type is used within the surrounding
English text.