### PR TITLE
[tuple.helper] prefer to use tuple_element_t

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1796,18 +1796,18 @@ template <size_t I, class T> class tuple_element<I, const volatile T>;
 
 \begin{itemdescr}
 \pnum
-Let \tcode{\placeholder{TE}} denote \tcode{tuple_element<I, T>} of the \cv-unqualified type \tcode{T}. Then
+Let \tcode{\placeholder{TE}} denote \tcode{tuple_element_t<I, T>} of the \cv-unqualified type \tcode{T}. Then
 each of the three templates shall meet the \tcode{TransformationTrait}
 requirements~(\ref{meta.rqmts}) with a member typedef \tcode{type} that names the following
 type:
 
 \begin{itemize}
 \item
-for the first specialization, \tcode{add_const_t<\placeholder{TE}::type>},
+for the first specialization, \tcode{add_const_t<\placeholder{TE}>},
 \item
-for the second specialization, \tcode{add_volatile_t<\placeholder{TE}::type>}, and
+for the second specialization, \tcode{add_volatile_t<\placeholder{TE}>}, and
 \item
-for the third specialization, \tcode{add_cv_t<\placeholder{TE}::type>}.
+for the third specialization, \tcode{add_cv_t<\placeholder{TE}>}.
 \end{itemize}
 
 \pnum


### PR DESCRIPTION
Prefer to use the _t alias to the old trait::type formulation
when specifying the place-holder name for defining
tuple_element of a cv-qualified type.  This neatly sidesteps
the question of whether there is a missing typename in the
subsequent usage, or whether that would be implied in the
use of the place-holder.