### PR TITLE
[dcl.enum] This is not where layout-compatible is defined

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -757,7 +757,8 @@ The common initial sequence of \tcode{A} and \tcode{E} is empty.
 \exitexample
 
 \pnum
-Two standard-layout struct (Clause~\ref{class}) types are layout-compatible if
+Two standard-layout struct (Clause~\ref{class}) types are
+\defnx{layout-compatible classes}{layout-compatible!class} if
 their common initial sequence comprises all members and bit-fields of
 both classes~(\ref{basic.types}).
 

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2017,8 +2017,8 @@ expression of enumeration type from having a value that falls outside
 this range.}
 
 \pnum
-Two enumeration types are \defn{layout-compatible} if they have the same
-underlying type.
+Two enumeration types are \defnx{layout-compatible enumerations}{layout-compatible!enumeration}
+if they have the same underlying type.
 
 \pnum
 The value of an enumerator or an object of an unscoped enumeration type is


### PR DESCRIPTION
There's a spurious definition of layout-compatible hiding in dcl.enum when it really lives in basic.types.