### PR TITLE
[support.runtime] Clarify va_start requirements

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -3378,7 +3378,7 @@ is overloaded for the type of
 \tcode{parmN}.}
 If the parameter
 \tcode{parmN}
-is of a reference type, or of a type that is not compatible with the
+is of a reference type, or of a type that is not the same as the
 type that results when passing an argument for which there is no
 parameter, the behavior is undefined.
 


### PR DESCRIPTION
"Compatible" is a bit of an ambiguous phrase, use "the same" instead, as that is the intention of the wording.
