### PR TITLE
[18-30] Replace typedefs with alias

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -2639,17 +2639,18 @@ namespace std {
   template <class T, size_t N>
   struct array {
     //  types:
-    typedef T&                                    reference;
-    typedef const T&                              const_reference;
-    typedef @\impdefx{type of \tcode{array::iterator}}\itcorr[-1]@                iterator;
-    typedef @\impdefx{type of \tcode{array::const_iterator}}\itcorr[-1]@                const_iterator;
-    typedef size_t                                size_type;
-    typedef ptrdiff_t                             difference_type;
-    typedef T                                     value_type;
-    typedef T*                                    pointer;
-    typedef const T*                              const_pointer;
-    typedef std::reverse_iterator<iterator>       reverse_iterator;
-    typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
+    using value_type             = T;
+    using pointer                = T*;
+    using const_pointer          = const T*;
+    using reference              = T&;
+    using const_reference        = const T&;
+    using size_type              = size_t;
+    using difference_type        = ptrdiff_t;
+    using iterator               = @\impdefx{type of \tcode{array::iterator}}@;
+    using const_iterator         = @\impdefx{type of \tcode{array::const_iterator}}@;
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
 
     T       elems[N];           // \expos
 
@@ -2885,18 +2886,18 @@ namespace std {
   class deque {
   public:
     // types:
-    typedef value_type&                                         reference;
-    typedef const value_type&                                   const_reference;
-    typedef @\impdefnc@                              iterator;        // see \ref{container.requirements}
-    typedef @\impdefnc@                              const_iterator;  // see \ref{container.requirements}
-    typedef @\impdefnc@                              size_type;       // see \ref{container.requirements}
-    typedef @\impdefnc@                              difference_type; // see \ref{container.requirements}
-    typedef T                                                   value_type;
-    typedef Allocator                                           allocator_type;
-    typedef typename allocator_traits<Allocator>::pointer       pointer;
-    typedef typename allocator_traits<Allocator>::const_pointer const_pointer;
-    typedef std::reverse_iterator<iterator>                     reverse_iterator;
-    typedef std::reverse_iterator<const_iterator>               const_reverse_iterator;
+    using value_type             = T;
+    using allocator_type         = Allocator;
+    using pointer                = typename allocator_traits<Allocator>::pointer;
+    using const_pointer          = typename allocator_traits<Allocator>::const_pointer;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using size_type              = @\impdef@; // see \ref{container.requirements}
+    using difference_type        = @\impdef@; // see \ref{container.requirements}
+    using iterator               = @\impdef@; // see \ref{container.requirements}
+    using const_iterator         = @\impdef@; // see \ref{container.requirements}
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
     // \ref{deque.cons}, construct/copy/destroy:
     deque() : deque(Allocator()) { }
@@ -3273,16 +3274,16 @@ namespace std {
   class forward_list {
   public:
     // types:
-    typedef value_type&                                         reference;
-    typedef const value_type&                                   const_reference;
-    typedef @\impdefnc@                              iterator;        // see \ref{container.requirements}
-    typedef @\impdefnc@                              const_iterator;  // see \ref{container.requirements}
-    typedef @\impdefnc@                              size_type;       // see \ref{container.requirements}
-    typedef @\impdefnc@                              difference_type; // see \ref{container.requirements}
-    typedef T                                                   value_type;
-    typedef Allocator                                           allocator_type;
-    typedef typename allocator_traits<Allocator>::pointer       pointer;
-    typedef typename allocator_traits<Allocator>::const_pointer const_pointer;
+    using value_type      = T;
+    using allocator_type  = Allocator;
+    using pointer         = typename allocator_traits<Allocator>::pointer;
+    using const_pointer   = typename allocator_traits<Allocator>::const_pointer;
+    using reference       = value_type&;
+    using const_reference = const value_type&;
+    using size_type       = @\impdef@; // see \ref{container.requirements}
+    using difference_type = @\impdef@; // see \ref{container.requirements}
+    using iterator        = @\impdef@; // see \ref{container.requirements}
+    using const_iterator  = @\impdef@; // see \ref{container.requirements}
 
     // \ref{forwardlist.cons}, construct/copy/destroy:
     forward_list() : forward_list(Allocator()) { }
@@ -4008,18 +4009,18 @@ namespace std {
   class list {
   public:
     // types:
-    typedef value_type&                                         reference;
-    typedef const value_type&                                   const_reference;
-    typedef @\impdefnc@                              iterator;        // see \ref{container.requirements}
-    typedef @\impdefnc@                              const_iterator;  // see \ref{container.requirements}
-    typedef @\impdefnc@                              size_type;       // see \ref{container.requirements}
-    typedef @\impdefnc@                              difference_type; // see \ref{container.requirements}
-    typedef T                                                   value_type;
-    typedef Allocator                                           allocator_type;
-    typedef typename allocator_traits<Allocator>::pointer       pointer;
-    typedef typename allocator_traits<Allocator>::const_pointer const_pointer;
-    typedef std::reverse_iterator<iterator>                     reverse_iterator;
-    typedef std::reverse_iterator<const_iterator>               const_reverse_iterator;
+    using value_type             = T;
+    using allocator_type         = Allocator;
+    using pointer                = typename allocator_traits<Allocator>::pointer;
+    using const_pointer          = typename allocator_traits<Allocator>::const_pointer;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using size_type              = @\impdef@; // see \ref{container.requirements}
+    using difference_type        = @\impdef@; // see \ref{container.requirements}
+    using iterator               = @\impdef@; // see \ref{container.requirements}
+    using const_iterator         = @\impdef@; // see \ref{container.requirements}
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
     // \ref{list.cons}, construct/copy/destroy:
     list() : list(Allocator()) { }
@@ -4705,18 +4706,18 @@ namespace std {
   class vector {
   public:
     // types:
-    typedef value_type&                                         reference;
-    typedef const value_type&                                   const_reference;
-    typedef @\impdefnc@                              iterator;        // see \ref{container.requirements}
-    typedef @\impdefnc@                              const_iterator;  // see \ref{container.requirements}
-    typedef @\impdefnc@                              size_type;       // see \ref{container.requirements}
-    typedef @\impdefnc@                              difference_type; // see \ref{container.requirements}
-    typedef T                                                   value_type;
-    typedef Allocator                                           allocator_type;
-    typedef typename allocator_traits<Allocator>::pointer       pointer;
-    typedef typename allocator_traits<Allocator>::const_pointer const_pointer;
-    typedef std::reverse_iterator<iterator>                     reverse_iterator;
-    typedef std::reverse_iterator<const_iterator>               const_reverse_iterator;
+    using value_type             = T;
+    using allocator_type         = Allocator;
+    using pointer                = typename allocator_traits<Allocator>::pointer;
+    using const_pointer          = typename allocator_traits<Allocator>::const_pointer;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using size_type              = @\impdef@; // see \ref{container.requirements}
+    using difference_type        = @\impdef@; // see \ref{container.requirements}
+    using iterator               = @\impdef@; // see \ref{container.requirements}
+    using const_iterator         = @\impdef@; // see \ref{container.requirements}
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
     // \ref{vector.cons}, construct/copy/destroy:
     vector() noexcept(noexcept(Allocator())) : vector(Allocator()) { }
@@ -5173,17 +5174,17 @@ namespace std {
   class vector<bool, Allocator> {
   public:
     // types:
-    typedef bool                                  const_reference;
-    typedef @\impdefnc@                iterator;        // see \ref{container.requirements}
-    typedef @\impdefnc@                const_iterator;  // see \ref{container.requirements}
-    typedef @\impdefnc@                size_type;       // see \ref{container.requirements}
-    typedef @\impdefnc@                difference_type; // see \ref{container.requirements}
-    typedef bool                                  value_type;
-    typedef Allocator                             allocator_type;
-    typedef @\impdefnc@                pointer;
-    typedef @\impdefnc@                const_pointer;
-    typedef std::reverse_iterator<iterator>       reverse_iterator;
-    typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
+    using value_type             = bool;
+    using allocator_type         = Allocator;
+    using pointer                = @\impdef@;
+    using const_pointer          = @\impdef@;
+    using const_reference        = bool;
+    using size_type              = @\impdef@; // see \ref{container.requirements}
+    using difference_type        = @\impdef@; // see \ref{container.requirements}
+    using iterator               = @\impdef@; // see \ref{container.requirements}
+    using const_iterator         = @\impdef@; // see \ref{container.requirements}
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
     // bit reference:
     class reference {
@@ -5542,24 +5543,24 @@ namespace std {
   class map {
   public:
     // types:
-    typedef Key                                                 key_type;
-    typedef T                                                   mapped_type;
-    typedef pair<const Key, T>                                  value_type;
-    typedef Compare                                             key_compare;
-    typedef Allocator                                           allocator_type;
-    typedef value_type&                                         reference;
-    typedef const value_type&                                   const_reference;
-    typedef @\impdefnc@                              iterator;        // see \ref{container.requirements}
-    typedef @\impdefnc@                              const_iterator;  // see \ref{container.requirements}
-    typedef @\impdefnc@                              size_type;       // see \ref{container.requirements}
-    typedef @\impdefnc@                              difference_type; // see \ref{container.requirements}
-    typedef typename allocator_traits<Allocator>::pointer       pointer;
-    typedef typename allocator_traits<Allocator>::const_pointer const_pointer;
-    typedef std::reverse_iterator<iterator>                     reverse_iterator;
-    typedef std::reverse_iterator<const_iterator>               const_reverse_iterator;
+    using key_type               = Key;
+    using mapped_type            = T;
+    using value_type             = pair<const Key, T>;
+    using key_compare            = Compare;
+    using allocator_type         = Allocator;
+    using pointer                = typename allocator_traits<Allocator>::pointer;
+    using const_pointer          = typename allocator_traits<Allocator>::const_pointer;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using size_type              = @\impdef@; // see \ref{container.requirements}
+    using difference_type        = @\impdef@; // see \ref{container.requirements}
+    using iterator               = @\impdef@; // see \ref{container.requirements}
+    using const_iterator         = @\impdef@; // see \ref{container.requirements}
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
     class value_compare {
-    friend class map;
+      friend class map;
     protected:
       Compare comp;
       value_compare(Compare c) : comp(c) {}
@@ -6056,24 +6057,24 @@ namespace std {
   class multimap {
   public:
     // types:
-    typedef Key                                                 key_type;
-    typedef T                                                   mapped_type;
-    typedef pair<const Key,T>                                   value_type;
-    typedef Compare                                             key_compare;
-    typedef Allocator                                           allocator_type;
-    typedef value_type&                                         reference;
-    typedef const value_type&                                   const_reference;
-    typedef @\impdefnc@                              iterator;        // see \ref{container.requirements}
-    typedef @\impdefnc@                              const_iterator;  // see \ref{container.requirements}
-    typedef @\impdefnc@                              size_type;       // see \ref{container.requirements}
-    typedef @\impdefnc@                              difference_type; // see \ref{container.requirements}
-    typedef typename allocator_traits<Allocator>::pointer       pointer;
-    typedef typename allocator_traits<Allocator>::const_pointer const_pointer;
-    typedef std::reverse_iterator<iterator>                     reverse_iterator;
-    typedef std::reverse_iterator<const_iterator>               const_reverse_iterator;
+    using key_type               = Key;
+    using mapped_type            = T;
+    using value_type             = pair<const Key, T>;
+    using key_compare            = Compare;
+    using allocator_type         = Allocator;
+    using pointer                = typename allocator_traits<Allocator>::pointer;
+    using const_pointer          = typename allocator_traits<Allocator>::const_pointer;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using size_type              = @\impdef@; // see \ref{container.requirements}
+    using difference_type        = @\impdef@; // see \ref{container.requirements}
+    using iterator               = @\impdef@; // see \ref{container.requirements}
+    using const_iterator         = @\impdef@; // see \ref{container.requirements}
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
     class value_compare {
-    friend class multimap;
+      friend class multimap;
     protected:
       Compare comp;
       value_compare(Compare c) : comp(c) { }
@@ -6353,21 +6354,21 @@ namespace std {
   class set {
   public:
     // types:
-    typedef Key                                                 key_type;
-    typedef Key                                                 value_type;
-    typedef Compare                                             key_compare;
-    typedef Compare                                             value_compare;
-    typedef Allocator                                           allocator_type;
-    typedef value_type&                                         reference;
-    typedef const value_type&                                   const_reference;
-    typedef @\impdefnc@                              iterator;        // see \ref{container.requirements}
-    typedef @\impdefnc@                              const_iterator;  // see \ref{container.requirements}
-    typedef @\impdefnc@                              size_type;       // see \ref{container.requirements}
-    typedef @\impdefnc@                              difference_type; // see \ref{container.requirements}
-    typedef typename allocator_traits<Allocator>::pointer       pointer;
-    typedef typename allocator_traits<Allocator>::const_pointer const_pointer;
-    typedef std::reverse_iterator<iterator>                     reverse_iterator;
-    typedef std::reverse_iterator<const_iterator>               const_reverse_iterator;
+    using key_type               = Key;
+    using key_compare            = Compare;
+    using value_type             = Key;
+    using value_compare          = Compare;
+    using allocator_type         = Allocator;
+    using pointer                = typename allocator_traits<Allocator>::pointer;
+    using const_pointer          = typename allocator_traits<Allocator>::const_pointer;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using size_type              = @\impdef@; // see \ref{container.requirements}
+    using difference_type        = @\impdef@; // see \ref{container.requirements}
+    using iterator               = @\impdef@; // see \ref{container.requirements}
+    using const_iterator         = @\impdef@; // see \ref{container.requirements}
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
     // \ref{set.cons}, construct/copy/destroy:
     set() : set(Compare()) { }
@@ -6608,21 +6609,21 @@ namespace std {
   class multiset {
   public:
     // types:
-    typedef Key                                                 key_type;
-    typedef Key                                                 value_type;
-    typedef Compare                                             key_compare;
-    typedef Compare                                             value_compare;
-    typedef Allocator                                           allocator_type;
-    typedef value_type&                                         reference;
-    typedef const value_type&                                   const_reference;
-    typedef @\impdefnc@                              iterator;        // see \ref{container.requirements}
-    typedef @\impdefnc@                              const_iterator;  // see \ref{container.requirements}
-    typedef @\impdefnc@                              size_type;       // see \ref{container.requirements}
-    typedef @\impdefnc@                              difference_type; // see \ref{container.requirements}
-    typedef typename allocator_traits<Allocator>::pointer       pointer;
-    typedef typename allocator_traits<Allocator>::const_pointer const_pointer;
-    typedef std::reverse_iterator<iterator>                     reverse_iterator;
-    typedef std::reverse_iterator<const_iterator>               const_reverse_iterator;
+    using key_type               = Key;
+    using key_compare            = Compare;
+    using value_type             = Key;
+    using value_compare          = Compare;
+    using allocator_type         = Allocator;
+    using pointer                = typename allocator_traits<Allocator>::pointer;
+    using const_pointer          = typename allocator_traits<Allocator>::const_pointer;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using size_type              = @\impdef@; // see \ref{container.requirements}
+    using difference_type        = @\impdef@; // see \ref{container.requirements}
+    using iterator               = @\impdef@; // see \ref{container.requirements}
+    using const_iterator         = @\impdef@; // see \ref{container.requirements}
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
     // \ref{multiset.cons}, construct/copy/destroy:
     multiset() : multiset(Compare()) { }
@@ -6985,23 +6986,23 @@ namespace std {
   class unordered_map {
   public:
     // types:
-    typedef Key                                                 key_type;
-    typedef std::pair<const Key, T>                             value_type;
-    typedef T                                                   mapped_type;
-    typedef Hash                                                hasher;
-    typedef Pred                                                key_equal;
-    typedef Allocator                                           allocator_type;
-    typedef typename allocator_traits<Allocator>::pointer       pointer;
-    typedef typename allocator_traits<Allocator>::const_pointer const_pointer;
-    typedef value_type&                                         reference;
-    typedef const value_type&                                   const_reference;
-    typedef @\impdefnc@                              size_type;
-    typedef @\impdefnc@                              difference_type;
+    using key_type             = Key;
+    using mapped_type          = T;
+    using value_type           = pair<const Key, T>;
+    using hasher               = Hash;
+    using key_equal            = Pred;
+    using allocator_type       = Allocator;
+    using pointer              = typename allocator_traits<Allocator>::pointer;
+    using const_pointer        = typename allocator_traits<Allocator>::const_pointer;
+    using reference            = value_type&;
+    using const_reference      = const value_type&;
+    using size_type            = @\impdef@; // see \ref{container.requirements}
+    using difference_type      = @\impdef@; // see \ref{container.requirements}
 
-    typedef @\impdefnc@                              iterator;
-    typedef @\impdefnc@                              const_iterator;
-    typedef @\impdefnc@                              local_iterator;
-    typedef @\impdefnc@                              const_local_iterator;
+    using iterator             = @\impdef@; // see \ref{container.requirements}
+    using const_iterator       = @\impdef@; // see \ref{container.requirements}
+    using local_iterator       = @\impdef@; // see \ref{container.requirements}
+    using const_local_iterator = @\impdef@; // see \ref{container.requirements}
 
     // \ref{unord.map.cnstr}, construct/copy/destroy:
     unordered_map();
@@ -7487,23 +7488,23 @@ namespace std {
   class unordered_multimap {
   public:
     // types:
-    typedef Key                                                 key_type;
-    typedef std::pair<const Key, T>                             value_type;
-    typedef T                                                   mapped_type;
-    typedef Hash                                                hasher;
-    typedef Pred                                                key_equal;
-    typedef Allocator                                           allocator_type;
-    typedef typename allocator_traits<Allocator>::pointer       pointer;
-    typedef typename allocator_traits<Allocator>::const_pointer const_pointer;
-    typedef value_type&                                         reference;
-    typedef const value_type&                                   const_reference;
-    typedef @\impdefnc@                              size_type;
-    typedef @\impdefnc@                              difference_type;
+    using key_type             = Key;
+    using mapped_type          = T;
+    using value_type           = pair<const Key, T>;
+    using hasher               = Hash;
+    using key_equal            = Pred;
+    using allocator_type       = Allocator;
+    using pointer              = typename allocator_traits<Allocator>::pointer;
+    using const_pointer        = typename allocator_traits<Allocator>::const_pointer;
+    using reference            = value_type&;
+    using const_reference      = const value_type&;
+    using size_type            = @\impdef@; // see \ref{container.requirements}
+    using difference_type      = @\impdef@; // see \ref{container.requirements}
 
-    typedef @\impdefnc@                              iterator;
-    typedef @\impdefnc@                              const_iterator;
-    typedef @\impdefnc@                              local_iterator;
-    typedef @\impdefnc@                              const_local_iterator;
+    using iterator             = @\impdef@; // see \ref{container.requirements}
+    using const_iterator       = @\impdef@; // see \ref{container.requirements}
+    using local_iterator       = @\impdef@; // see \ref{container.requirements}
+    using const_local_iterator = @\impdef@; // see \ref{container.requirements}
 
     // \ref{unord.multimap.cnstr}, construct/copy/destroy:
     unordered_multimap();
@@ -7773,22 +7774,22 @@ namespace std {
   class unordered_set {
   public:
     // types:
-    typedef Key                                                 key_type;
-    typedef Key                                                 value_type;
-    typedef Hash                                                hasher;
-    typedef Pred                                                key_equal;
-    typedef Allocator                                           allocator_type;
-    typedef typename allocator_traits<Allocator>::pointer       pointer;
-    typedef typename allocator_traits<Allocator>::const_pointer const_pointer;
-    typedef value_type&                                         reference;
-    typedef const value_type&                                   const_reference;
-    typedef @\impdefnc@                              size_type;
-    typedef @\impdefnc@                              difference_type;
+    using key_type             = Key;
+    using value_type           = Key;
+    using hasher               = Hash;
+    using key_equal            = Pred;
+    using allocator_type       = Allocator;
+    using pointer              = typename allocator_traits<Allocator>::pointer;
+    using const_pointer        = typename allocator_traits<Allocator>::const_pointer;
+    using reference            = value_type&;
+    using const_reference      = const value_type&;
+    using size_type            = @\impdef@; // see \ref{container.requirements}
+    using difference_type      = @\impdef@; // see \ref{container.requirements}
 
-    typedef @\impdefnc@                              iterator;
-    typedef @\impdefnc@                              const_iterator;
-    typedef @\impdefnc@                              local_iterator;
-    typedef @\impdefnc@                              const_local_iterator;
+    using iterator             = @\impdef@; // see \ref{container.requirements}
+    using const_iterator       = @\impdef@; // see \ref{container.requirements}
+    using local_iterator       = @\impdef@; // see \ref{container.requirements}
+    using const_local_iterator = @\impdef@; // see \ref{container.requirements}
 
     // \ref{unord.set.cnstr}, construct/copy/destroy:
     unordered_set();
@@ -8026,22 +8027,22 @@ namespace std {
   class unordered_multiset {
   public:
     // types:
-    typedef Key                                                 key_type;
-    typedef Key                                                 value_type;
-    typedef Hash                                                hasher;
-    typedef Pred                                                key_equal;
-    typedef Allocator                                           allocator_type;
-    typedef typename allocator_traits<Allocator>::pointer       pointer;
-    typedef typename allocator_traits<Allocator>::const_pointer const_pointer;
-    typedef value_type&                                         reference;
-    typedef const value_type&                                   const_reference;
-    typedef @\impdefnc@                              size_type;
-    typedef @\impdefnc@                              difference_type;
+    using key_type             = Key;
+    using value_type           = Key;
+    using hasher               = Hash;
+    using key_equal            = Pred;
+    using allocator_type       = Allocator;
+    using pointer              = typename allocator_traits<Allocator>::pointer;
+    using const_pointer        = typename allocator_traits<Allocator>::const_pointer;
+    using reference            = value_type&;
+    using const_reference      = const value_type&;
+    using size_type            = @\impdef@; // see \ref{container.requirements}
+    using difference_type      = @\impdef@; // see \ref{container.requirements}
 
-    typedef @\impdefnc@                              iterator;
-    typedef @\impdefnc@                              const_iterator;
-    typedef @\impdefnc@                              local_iterator;
-    typedef @\impdefnc@                              const_local_iterator;
+    using iterator             = @\impdef@; // see \ref{container.requirements}
+    using const_iterator       = @\impdef@; // see \ref{container.requirements}
+    using local_iterator       = @\impdef@; // see \ref{container.requirements}
+    using const_local_iterator = @\impdef@; // see \ref{container.requirements}
 
     // \ref{unord.multiset.cnstr}, construct/copy/destroy:
     unordered_multiset();
@@ -8345,11 +8346,11 @@ namespace std {
   template <class T, class Container = deque<T>>
   class queue {
   public:
-    typedef typename Container::value_type            value_type;
-    typedef typename Container::reference             reference;
-    typedef typename Container::const_reference       const_reference;
-    typedef typename Container::size_type             size_type;
-    typedef          Container                        container_type;
+    using value_type      = typename Container::value_type;
+    using reference       = typename Container::reference;
+    using const_reference = typename Container::const_reference;
+    using size_type       = typename Container::size_type;
+    using container_type  =          Container;
 
   protected:
     Container c;
@@ -8597,11 +8598,11 @@ namespace std {
     class Compare = less<typename Container::value_type>>
   class priority_queue {
   public:
-    typedef typename Container::value_type            value_type;
-    typedef typename Container::reference             reference;
-    typedef typename Container::const_reference       const_reference;
-    typedef typename Container::size_type             size_type;
-    typedef          Container                        container_type;
+    using value_type      = typename Container::value_type;
+    using reference       = typename Container::reference;
+    using const_reference = typename Container::const_reference;
+    using size_type       = typename Container::size_type;
+    using container_type  = Container;
 
   protected:
     Container c;
@@ -8879,11 +8880,11 @@ namespace std {
   template <class T, class Container = deque<T>>
   class stack {
   public:
-    typedef typename Container::value_type            value_type;
-    typedef typename Container::reference             reference;
-    typedef typename Container::const_reference       const_reference;
-    typedef typename Container::size_type             size_type;
-    typedef          Container                        container_type;
+    using value_type      = typename Container::value_type;
+    using reference       = typename Container::reference;
+    using const_reference = typename Container::const_reference;
+    using size_type       = typename Container::size_type;
+    using container_type  = Container;
 
   protected:
     Container c;

--- a/source/future.tex
+++ b/source/future.tex
@@ -155,8 +155,8 @@ namespace std {
     virtual streambuf* setbuf(char* s, streamsize n);
 
   private:
-    typedef T1 strstate;              // \expos
-    static const strstate allocated;  //  \expos
+    using strstate = T1;              // \expos
+    static const strstate allocated;  // \expos
     static const strstate constant;   // \expos
     static const strstate dynamic;    // \expos
     static const strstate frozen;     // \expos
@@ -996,10 +996,10 @@ namespace std {
     : public basic_iostream<char> {
   public:
     // Types
-    typedef char                                char_type;
-    typedef typename char_traits<char>::int_type int_type;
-    typedef typename char_traits<char>::pos_type pos_type;
-    typedef typename char_traits<char>::off_type off_type;
+    using char_type = char;
+    using int_type  = char_traits<char>::int_type;
+    using pos_type  = char_traits<char>::pos_type;
+    using off_type  = char_traits<char>::off_type;
 
     // constructors/destructor
     strstream();
@@ -1150,7 +1150,7 @@ int pcount() const;
 
 \indexlibrary{\idxcode{unexpected_handler}}%
 \begin{itemdecl}
-typedef void (*unexpected_handler)();
+using unexpected_handler = void (*)();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1271,7 +1271,7 @@ then \tcode{result_type} shall be a synonym for \tcode{T::result_type};
 To enable old function adaptors to manipulate function objects
 that take one or two arguments,
 many of the function objects in this standard
-correspondingly provide typedefs
+correspondingly provide \grammarterm{typedef-name}{s}
 \tcode{argument_type} and \tcode{result_type}
 for function objects that take one argument and
 \tcode{first_argument_type}, \tcode{second_argument_type}, and \tcode{result_type}
@@ -1287,147 +1287,147 @@ The following member names are defined in addition to names specified in Clause~
 \begin{codeblock}
 namespace std {
   template<class T> struct owner_less<shared_ptr<T> > {
-    typedef bool result_type;
-    typedef shared_ptr<T> first_argument_type;
-    typedef shared_ptr<T> second_argument_type;
+    using result_type          = bool;
+    using first_argument_type  = shared_ptr<T>;
+    using second_argument_type = shared_ptr<T>;
   };
 
   template<class T> struct owner_less<weak_ptr<T> > {
-    typedef bool result_type;
-    typedef weak_ptr<T> first_argument_type;
-    typedef weak_ptr<T> second_argument_type;
+    using result_type          = bool;
+    using first_argument_type  = weak_ptr<T>;
+    using second_argument_type = weak_ptr<T>;
   };
 
   template <class T> class reference_wrapper {
   public :
-    typedef @\seebelow@ result_type;              // not always defined
-    typedef @\seebelow@ argument_type;            // not always defined
-    typedef @\seebelow@ first_argument_type;      // not always defined
-    typedef @\seebelow@ second_argument_type;     // not always defined
+    using result_type          = @\seebelow@; // not always defined
+    using argument_type        = @\seebelow@; // not always defined
+    using first_argument_type  = @\seebelow@; // not always defined
+    using second_argument_type = @\seebelow@; // not always defined
   };
 
   template <class T> struct plus {
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef T result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = T;
   };
 
   template <class T> struct minus {
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef T result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = T;
   };
 
   template <class T> struct multiplies {
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef T result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = T;
   };
 
   template <class T> struct divides {
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef T result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = T;
   };
 
   template <class T> struct modulus {
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef T result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = T;
   };
 
   template <class T> struct negate {
-    typedef T argument_type;
-    typedef T result_type;
+    using argument_type = T;
+    using result_type   = T;
   };
 
   template <class T> struct equal_to {
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef bool result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = bool;
   };
 
   template <class T> struct not_equal_to {
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef bool result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = bool;
   };
 
   template <class T> struct greater {
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef bool result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = bool;
   };
 
   template <class T> struct less {
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef bool result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = bool;
   };
 
   template <class T> struct greater_equal {
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef bool result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = bool;
   };
 
   template <class T> struct less_equal {
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef bool result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = bool;
   };
 
   template <class T> struct logical_and {
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef bool result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = bool;
   };
 
   template <class T> struct logical_or {
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef bool result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = bool;
   };
 
   template <class T> struct logical_not {
-    typedef T argument_type;
-    typedef bool result_type;
+    using argument_type = T;
+    using result_type   = bool;
   };
 
   template <class T> struct bit_and {
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef T result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = T;
   };
 
   template <class T> struct bit_or {
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef T result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = T;
   };
 
   template <class T> struct bit_xor {
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef T result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = T;
   };
 
   template <class T> struct bit_not {
-    typedef T argument_type;
-    typedef T result_type;
+    using argument_type = T;
+    using result_type   = T;
   };
 
   template<class R, class T1>
   class function<R(T1)> {
   public:
-    typedef T1 argument_type;
+    using argument_type = T1;
   };
 
   template<class R, class T1, class T2>
   class function<R(T1, T2)> {
   public:
-    typedef T1 first_argument_type;
-    typedef T2 second_argument_type;
+    using first_argument_type  = T1;
+    using second_argument_type = T2;
   };
 }
 \end{codeblock}
@@ -1525,17 +1525,17 @@ namespace std {
   template <class Key, class T, class Compare, class Allocator>
   class map<Key, T, Compare, Allocator>::value_compare {
   public:
-    typedef bool result_type;
-    typedef value_type first_argument_type;
-    typedef value_type second_argument_type;
+    using result_type          = bool;
+    using first_argument_type  = value_type;
+    using second_argument_type = value_type;
   };
 
   template <class Key, class T, class Compare, class Allocator>
   class multimap<Key, T, Compare, Allocator>::value_compare {
   public:
-    typedef bool result_type;
-    typedef value_type first_argument_type;
-    typedef value_type second_argument_type;
+    using result_type          = bool;
+    using first_argument_type  = value_type;
+    using second_argument_type = value_type;
   };
 }
 \end{codeblock}
@@ -1568,8 +1568,8 @@ class unary_negate {
 public:
   constexpr explicit unary_negate(const Predicate& pred);
   constexpr bool operator()(const typename Predicate::argument_type& x) const;
-  typedef typename Predicate::argument_type argument_type;
-  typedef bool result_type;
+  using argument_type = typename Predicate::argument_type;
+  using result_type   = bool;
 };
 \end{codeblock}
 
@@ -1600,9 +1600,10 @@ public:
   constexpr explicit binary_negate(const Predicate& pred);
   constexpr bool operator()(const typename Predicate::first_argument_type& x,
                             const typename Predicate::second_argument_type& y) const;
-  typedef typename Predicate::first_argument_type first_argument_type;
-  typedef typename Predicate::second_argument_type second_argument_type;
-  typedef bool result_type;
+  using first_argument_type  = typename Predicate::first_argument_type;
+  using second_argument_type = typename Predicate::second_argument_type;
+  using result_type          = bool;
+
 };
 \end{codeblock}
 

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -202,42 +202,42 @@ namespace std {
   template <class charT, class traits = char_traits<charT> >
     class ostreambuf_iterator;
 
-  typedef basic_ios<char>       ios;
-  typedef basic_ios<wchar_t>    wios;
+  using ios  = basic_ios<char>;
+  using wios = basic_ios<wchar_t>;
 
-  typedef basic_streambuf<char> streambuf;
-  typedef basic_istream<char>   istream;
-  typedef basic_ostream<char>   ostream;
-  typedef basic_iostream<char>  iostream;
+  using streambuf = basic_streambuf<char>;
+  using istream   = basic_istream<char>;
+  using ostream   = basic_ostream<char>;
+  using iostream  = basic_iostream<char>;
 
-  typedef basic_stringbuf<char>     stringbuf;
-  typedef basic_istringstream<char> istringstream;
-  typedef basic_ostringstream<char> ostringstream;
-  typedef basic_stringstream<char>  stringstream;
+  using stringbuf     = basic_stringbuf<char>;
+  using istringstream = basic_istringstream<char>;
+  using ostringstream = basic_ostringstream<char>;
+  using stringstream  = basic_stringstream<char>;
 
-  typedef basic_filebuf<char>  filebuf;
-  typedef basic_ifstream<char> ifstream;
-  typedef basic_ofstream<char> ofstream;
-  typedef basic_fstream<char>  fstream;
+  using filebuf  = basic_filebuf<char>;
+  using ifstream = basic_ifstream<char>;
+  using ofstream = basic_ofstream<char>;
+  using fstream  = basic_fstream<char>;
 
-  typedef basic_streambuf<wchar_t> wstreambuf;
-  typedef basic_istream<wchar_t>   wistream;
-  typedef basic_ostream<wchar_t>   wostream;
-  typedef basic_iostream<wchar_t>  wiostream;
+  using wstreambuf = basic_streambuf<wchar_t>;
+  using wistream   = basic_istream<wchar_t>;
+  using wostream   = basic_ostream<wchar_t>;
+  using wiostream  = basic_iostream<wchar_t>;
 
-  typedef basic_stringbuf<wchar_t>     wstringbuf;
-  typedef basic_istringstream<wchar_t> wistringstream;
-  typedef basic_ostringstream<wchar_t> wostringstream;
-  typedef basic_stringstream<wchar_t>  wstringstream;
+  using wstringbuf     = basic_stringbuf<wchar_t>;
+  using wistringstream = basic_istringstream<wchar_t>;
+  using wostringstream = basic_ostringstream<wchar_t>;
+  using wstringstream  = basic_stringstream<wchar_t>;
 
-  typedef basic_filebuf<wchar_t>  wfilebuf;
-  typedef basic_ifstream<wchar_t> wifstream;
-  typedef basic_ofstream<wchar_t> wofstream;
-  typedef basic_fstream<wchar_t>  wfstream;
+  using wfilebuf  = basic_filebuf<wchar_t>;
+  using wifstream = basic_ifstream<wchar_t>;
+  using wofstream = basic_ofstream<wchar_t>;
+  using wfstream  = basic_fstream<wchar_t>;
 
   template <class state> class fpos;
-  typedef fpos<char_traits<char>::state_type>    streampos;
-  typedef fpos<char_traits<wchar_t>::state_type> wstreampos;
+  using streampos  = fpos<char_traits<char>::state_type>;
+  using wstreampos = fpos<char_traits<wchar_t>::state_type>;
 }
 \end{codeblock}
 
@@ -311,7 +311,7 @@ and
 \tcode{basic_fstream}.
 
 \pnum
-Other typedefs define instances of
+Other \grammarterm{typedef-name}{s} define instances of
 class templates
 specialized for
 \tcode{char}
@@ -346,13 +346,12 @@ types.
 One way to do this might be
 \begin{codeblock}
 template<class stateT> class fpos { ... };      // depends on nothing
-typedef ... _STATE;             // implementation private declaration of \tcode{stateT}
+using _STATE = ... ;             // implementation private declaration of \tcode{stateT}
 
-typedef fpos<_STATE> streampos;
+using streampos = fpos<_STATE>;
 
 template<> struct char_traits<char> {
-  typedef streampos
-  pos_type;
+  using pos_type = streampos;
 }
 \end{codeblock}
 \exitnote
@@ -618,8 +617,8 @@ declared in
 #include <iosfwd>
 
 namespace std {
-  typedef @\impdef@ streamoff;
-  typedef @\impdef@ streamsize;
+  using streamoff  = @\impdef@;
+  using streamsize = @\impdef@;
   template <class stateT> class fpos;
 
   class ios_base;
@@ -685,7 +684,7 @@ namespace std {
 
 \indexlibrary{\idxcode{streamoff}}%
 \begin{itemdecl}
-typedef @\impdef@ streamoff;
+using streamoff = @\impdef@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -696,7 +695,7 @@ sufficient size to represent the maximum possible file size for the operating sy
 
 \indexlibrary{\idxcode{streamsize}}%
 \begin{itemdecl}
-typedef @\impdef@ streamsize;
+using streamsize = @\impdef@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -731,7 +730,7 @@ namespace std {
     class failure; // see below
 
     // \ref{ios::fmtflags}, \tcode{fmtflags}:
-    typedef @\textit{T1}@ fmtflags;
+    using fmtflags = @\textit{T1}@;
     static constexpr fmtflags boolalpha = @\unspec@;
     static constexpr fmtflags dec = @\unspec@;
     static constexpr fmtflags fixed = @\unspec@;
@@ -752,14 +751,14 @@ namespace std {
     static constexpr fmtflags floatfield = @\seebelow@;
 
     // \ref{ios::iostate}, \tcode{iostate}:
-    typedef @\textit{T2}@ iostate;
+    using iostate = @\textit{T2}@;
     static constexpr iostate badbit = @\unspec@;
     static constexpr iostate eofbit = @\unspec@;
     static constexpr iostate failbit = @\unspec@;
     static constexpr iostate goodbit = @\seebelow@;
 
     // \ref{ios::openmode}, \tcode{openmode}:
-    typedef @\textit{T3}@ openmode;
+    using openmode = @\textit{T3}@;
     static constexpr openmode app = @\unspec@;
     static constexpr openmode ate = @\unspec@;
     static constexpr openmode binary = @\unspec@;
@@ -768,7 +767,7 @@ namespace std {
     static constexpr openmode trunc = @\unspec@;
 
     // \ref{ios::seekdir}, \tcode{seekdir}:
-    typedef @\textit{T4}@ seekdir;
+    using seekdir = @\textit{T4}@;
     static constexpr seekdir beg = @\unspec@;
     static constexpr seekdir cur = @\unspec@;
     static constexpr seekdir end = @\unspec@;
@@ -801,7 +800,7 @@ namespace std {
 
     // \ref{ios.base.callback}, callbacks;
     enum event { erase_event, imbue_event, copyfmt_event };
-    typedef void (*event_callback)(event, ios_base&, int index);
+    using event_callback = void (*)(event, ios_base&, int index);
     void register_callback(event_callback fn, int index);
 
     ios_base(const ios_base&) = delete;
@@ -937,7 +936,7 @@ Constructs an object of class
 
 \indexlibrary{\idxcode{fmtflags}!\idxcode{ios_base}}%
 \begin{itemdecl}
-typedef @\textit{T1}@ fmtflags;
+using fmtflags = @\textit{T1}@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1001,7 +1000,7 @@ also defines the constants indicated in Table~\ref{tab:iostreams.fmtflags.consta
 \indexlibrary{\idxcode{iostate}!\idxcode{ios_base}}%
 \indexlibrary{\idxcode{ios_base}!\idxcode{iostate}}%
 \begin{itemdecl}
-typedef @\textit{T2}@ iostate;
+using iostate = @\textit{T2}@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1037,7 +1036,7 @@ the value zero.
 
 \indexlibrary{\idxcode{openmode}!\idxcode{ios_base}}%
 \begin{itemdecl}
-typedef @\textit{T3}@ openmode;
+using openmode = @\textit{T3}@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1067,7 +1066,7 @@ It contains the elements indicated in Table~\ref{tab:iostreams.openmode.effects}
 
 \indexlibrary{\idxcode{seekdir}!\idxcode{ios_base}}%
 \begin{itemdecl}
-typedef @\textit{T4}@ seekdir;
+using seekdir = @\textit{T4}@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1750,11 +1749,11 @@ namespace std {
   template <class charT, class traits = char_traits<charT> >
   class basic_ios : public ios_base {
   public:
-    typedef charT                     char_type;
-    typedef typename traits::int_type int_type;
-    typedef typename traits::pos_type pos_type;
-    typedef typename traits::off_type off_type;
-    typedef traits                    traits_type;
+    using char_type   = charT;
+    using int_type    = typename traits::int_type;
+    using pos_type    = typename traits::pos_type;
+    using off_type    = typename traits::off_type;
+    using traits_type = traits;
 
     // \ref{iostate.flags}, flags functions:
     explicit operator bool() const;
@@ -2788,8 +2787,8 @@ The object's \tcode{default_error_condition} and \tcode{equivalent} virtual func
 namespace std {
   template <class charT, class traits = char_traits<charT> >
     class basic_streambuf;
-  typedef basic_streambuf<char>     streambuf;
-  typedef basic_streambuf<wchar_t> wstreambuf;
+  using streambuf  = basic_streambuf<char>;
+  using wstreambuf = basic_streambuf<wchar_t>;
 }
 \end{codeblock}
 
@@ -2908,11 +2907,11 @@ namespace std {
   template <class charT, class traits = char_traits<charT> >
   class basic_streambuf {
   public:
-    typedef charT                     char_type;
-    typedef typename traits::int_type int_type;
-    typedef typename traits::pos_type pos_type;
-    typedef typename traits::off_type off_type;
-    typedef traits                    traits_type;
+    using char_type   = charT;
+    using int_type    = typename traits::int_type;
+    using pos_type    = typename traits::pos_type;
+    using off_type    = typename traits::off_type;
+    using traits_type = traits;
 
     virtual ~basic_streambuf();
 
@@ -4076,13 +4075,13 @@ Returns
 namespace std {
   template <class charT, class traits = char_traits<charT> >
     class basic_istream;
-  typedef basic_istream<char>     istream;
-  typedef basic_istream<wchar_t> wistream;
+  using istream  = basic_istream<char>;
+  using wistream = basic_istream<wchar_t>;
 
   template <class charT, class traits = char_traits<charT> >
     class basic_iostream;
-  typedef basic_iostream<char>    iostream;
-  typedef basic_iostream<wchar_t> wiostream;
+  using iostream  = basic_iostream<char>;
+  using wiostream = basic_iostream<wchar_t>;
 
   template <class charT, class traits>
     basic_istream<charT, traits>& ws(basic_istream<charT, traits>& is);
@@ -4105,8 +4104,8 @@ namespace std {
 namespace std {
   template <class charT, class traits = char_traits<charT> >
     class basic_ostream;
-  typedef basic_ostream<char>     ostream;
-  typedef basic_ostream<wchar_t> wostream;
+  using ostream  = basic_ostream<char>;
+  using wostream = basic_ostream<wchar_t>;
 
   template <class charT, class traits>
     basic_ostream<charT, traits>& endl(basic_ostream<charT, traits>& os);
@@ -4174,11 +4173,11 @@ namespace std {
     : virtual public basic_ios<charT, traits> {
   public:
     // types (inherited from \tcode{basic_ios} (\ref{ios})):
-    typedef charT                     char_type;
-    typedef typename traits::int_type int_type;
-    typedef typename traits::pos_type pos_type;
-    typedef typename traits::off_type off_type;
-    typedef traits                    traits_type;
+    using char_type   = charT;
+    using int_type    = typename traits::int_type;
+    using pos_type    = typename traits::pos_type;
+    using off_type    = typename traits::off_type;
+    using traits_type = traits;
 
     // \ref{istream.cons}, constructor/destructor:
     explicit basic_istream(basic_streambuf<charT, traits>* sb);
@@ -4415,7 +4414,7 @@ Exchanges the values returned by \tcode{gcount()} and
 namespace std {
   template <class charT, class traits = char_traits<charT> >
   class basic_istream<charT, traits>::sentry {
-    typedef traits traits_type;
+    using traits_type = traits;
     bool ok_; // \expos
   public:
     explicit sentry(basic_istream<charT, traits>& is, bool noskipws = false);
@@ -4611,7 +4610,7 @@ These extractors behave as formatted input functions (as described in~\ref{istre
 conversion occurs as if performed by the following code fragment:
 
 \begin{codeblock}
-typedef num_get< charT, istreambuf_iterator<charT, traits> > numget;
+using numget = num_get< charT, istreambuf_iterator<charT, traits> >;
 iostate err = iostate::goodbit;
 use_facet< numget >(loc).get(*this, 0, *this, err, val);
 setstate(err);
@@ -4648,7 +4647,7 @@ operator>>(short& val);
 The conversion occurs as if performed by the following code fragment
 (using the same notation as for the preceding code fragment):
 \begin{codeblock}
-typedef num_get<charT, istreambuf_iterator<charT, traits> > numget;
+using numget = num_get<charT, istreambuf_iterator<charT, traits> >;
 iostate err = ios_base::goodbit;
 long lval;
 use_facet<numget>(loc).get(*this, 0, *this, err, lval);
@@ -4675,7 +4674,7 @@ operator>>(int& val);
 The conversion occurs as if performed by the following code fragment
 (using the same notation as for the preceding code fragment):
 \begin{codeblock}
-typedef num_get<charT, istreambuf_iterator<charT, traits> > numget;
+using numget = num_get<charT, istreambuf_iterator<charT, traits> >;
 iostate err = ios_base::goodbit;
 long lval;
 use_facet<numget>(loc).get(*this, 0, *this, err, lval);
@@ -5639,11 +5638,11 @@ namespace std {
     : public basic_istream<charT, traits>,
       public basic_ostream<charT, traits> {
   public:
-    typedef charT                     char_type;
-    typedef typename traits::int_type int_type;
-    typedef typename traits::pos_type pos_type;
-    typedef typename traits::off_type off_type;
-    typedef traits                    traits_type;
+    using char_type   = charT;
+    using int_type    = typename traits::int_type;
+    using pos_type    = typename traits::pos_type;
+    using off_type    = typename traits::off_type;
+    using traits_type = traits;
 
     // \ref{iostream.cons}, constructor:
     explicit basic_iostream(basic_streambuf<charT, traits>* sb);
@@ -5787,11 +5786,11 @@ namespace std {
     : virtual public basic_ios<charT, traits> {
   public:
     // types (inherited from \tcode{basic_ios} (\ref{ios})):
-    typedef charT                     char_type;
-    typedef typename traits::int_type int_type;
-    typedef typename traits::pos_type pos_type;
-    typedef typename traits::off_type off_type;
-    typedef traits                    traits_type;
+    using char_type   = charT;
+    using int_type    = typename traits::int_type;
+    using pos_type    = typename traits::pos_type;
+    using off_type    = typename traits::off_type;
+    using traits_type = traits;
 
     // \ref{ostream.cons}, constructor/destructor:
     explicit basic_ostream(basic_streambuf<char_type, traits>* sb);
@@ -7052,8 +7051,8 @@ then the expression \tcode{in \shr\ get_money(mon, intl)} behaves as if it calle
 \begin{codeblock}
 template <class charT, class traits, class moneyT>
 void f(basic_ios<charT, traits>& str, moneyT& mon, bool intl) {
-  typedef istreambuf_iterator<charT, traits> Iter;
-  typedef money_get<charT, Iter> MoneyGet;
+  using Iter     = istreambuf_iterator<charT, traits>;
+  using MoneyGet = money_get<charT, Iter>;
 
   ios_base::iostate err = ios_base::goodbit;
   const MoneyGet &mg = use_facet<MoneyGet>(str.getloc());
@@ -7088,8 +7087,8 @@ then the expression \tcode{out \shl\ put_money(mon, intl)} behaves as a formatte
 \begin{codeblock}
 template <class charT, class traits, class moneyT>
 void f(basic_ios<charT, traits>& str, const moneyT& mon, bool intl) {
-  typedef ostreambuf_iterator<charT, traits> Iter;
-  typedef money_put<charT, Iter> MoneyPut;
+  using Iter     = ostreambuf_iterator<charT, traits>;
+  using MoneyPut = money_put<charT, Iter>;
 
   const MoneyPut& mp = use_facet<MoneyPut>(str.getloc());
   const Iter end = mp.put(Iter(str.rdbuf()), intl, str, str.fill(), mon);
@@ -7122,8 +7121,8 @@ defined as:
 \begin{codeblock}
 template <class charT, class traits>
 void f(basic_ios<charT, traits>& str, struct tm* tmb, const charT* fmt) {
-  typedef istreambuf_iterator<charT, traits> Iter;
-  typedef time_get<charT, Iter> TimeGet;
+  using Iter    = istreambuf_iterator<charT, traits>;
+  using TimeGet = time_get<charT, Iter>;
 
   ios_base::iostate err = ios_base::goodbit;
   const TimeGet& tg = use_facet<TimeGet>(str.getloc());
@@ -7161,8 +7160,8 @@ function \tcode{f} is defined as:
 \begin{codeblock}
 template <class charT, class traits>
 void f(basic_ios<charT, traits>& str, const struct tm* tmb, const charT* fmt) {
-  typedef ostreambuf_iterator<charT, traits> Iter;
-  typedef time_put<charT, Iter> TimePut;
+  using Iter    = ostreambuf_iterator<charT, traits>;
+  using TimePut = time_put<charT, Iter>;
 
   const TimePut& tp = use_facet<TimePut>(str.getloc());
   const Iter end = tp.put(Iter(str.rdbuf()), str, str.fill(), tmb,
@@ -7298,27 +7297,27 @@ namespace std {
             class Allocator = allocator<charT> >
     class basic_stringbuf;
 
-  typedef basic_stringbuf<char>     stringbuf;
-  typedef basic_stringbuf<wchar_t> wstringbuf;
+  using stringbuf  = basic_stringbuf<char>;
+  using wstringbuf = basic_stringbuf<wchar_t>;
 
   template <class charT, class traits = char_traits<charT>,
             class Allocator = allocator<charT> >
     class basic_istringstream;
 
-  typedef basic_istringstream<char>     istringstream;
-  typedef basic_istringstream<wchar_t> wistringstream;
+  using istringstream  = basic_istringstream<char>;
+  using wistringstream = basic_istringstream<wchar_t>;
 
   template <class charT, class traits = char_traits<charT>,
             class Allocator = allocator<charT> >
     class basic_ostringstream;
-  typedef basic_ostringstream<char>     ostringstream;
-  typedef basic_ostringstream<wchar_t> wostringstream;
+  using ostringstream  = basic_ostringstream<char>;
+  using wostringstream = basic_ostringstream<wchar_t>;
 
   template <class charT, class traits = char_traits<charT>,
             class Allocator = allocator<charT> >
     class basic_stringstream;
-  typedef basic_stringstream<char>     stringstream;
-  typedef basic_stringstream<wchar_t> wstringstream;
+  using stringstream  = basic_stringstream<char>;
+  using wstringstream = basic_stringstream<wchar_t>;
 }
 \end{codeblock}
 
@@ -7331,12 +7330,12 @@ namespace std {
   class basic_stringbuf
     : public basic_streambuf<charT, traits> {
   public:
-    typedef charT                     char_type;
-    typedef typename traits::int_type int_type;
-    typedef typename traits::pos_type pos_type;
-    typedef typename traits::off_type off_type;
-    typedef traits                    traits_type;
-    typedef Allocator                 allocator_type;
+    using char_type      = charT;
+    using int_type       = typename traits::int_type;
+    using pos_type       = typename traits::pos_type;
+    using off_type       = typename traits::off_type;
+    using traits_type    = traits;
+    using allocator_type = Allocator;
 
     // \ref{stringbuf.cons}, constructors:
     explicit basic_stringbuf(
@@ -7854,12 +7853,12 @@ namespace std {
   class basic_istringstream
     : public basic_istream<charT, traits> {
   public:
-    typedef charT                     char_type;
-    typedef typename traits::int_type int_type;
-    typedef typename traits::pos_type pos_type;
-    typedef typename traits::off_type off_type;
-    typedef traits                    traits_type;
-    typedef Allocator                 allocator_type;
+    using char_type      = charT;
+    using int_type       = typename traits::int_type;
+    using pos_type       = typename traits::pos_type;
+    using off_type       = typename traits::off_type;
+    using traits_type    = traits;
+    using allocator_type = Allocator;
 
     // \ref{istringstream.cons}, constructors:
     explicit basic_istringstream(
@@ -8046,12 +8045,12 @@ namespace std {
   class basic_ostringstream
     : public basic_ostream<charT, traits> {
   public:
-    typedef charT                     char_type;
-    typedef typename traits::int_type int_type;
-    typedef typename traits::pos_type pos_type;
-    typedef typename traits::off_type off_type;
-    typedef traits                    traits_type;
-    typedef Allocator                 allocator_type;
+    using char_type      = charT;
+    using int_type       = typename traits::int_type;
+    using pos_type       = typename traits::pos_type;
+    using off_type       = typename traits::off_type;
+    using traits_type    = traits;
+    using allocator_type = Allocator;
 
     // \ref{ostringstream.cons}, constructors:
     explicit basic_ostringstream(
@@ -8239,12 +8238,12 @@ namespace std {
   class basic_stringstream
     : public basic_iostream<charT, traits> {
   public:
-    typedef charT                     char_type;
-    typedef typename traits::int_type int_type;
-    typedef typename traits::pos_type pos_type;
-    typedef typename traits::off_type off_type;
-    typedef traits                    traits_type;
-    typedef Allocator                 allocator_type;
+    using char_type      = charT;
+    using int_type       = typename traits::int_type;
+    using pos_type       = typename traits::pos_type;
+    using off_type       = typename traits::off_type;
+    using traits_type    = traits;
+    using allocator_type = Allocator;
 
     // \ref{stringstream.cons}, constructors:
     explicit basic_stringstream(
@@ -8456,23 +8455,23 @@ reading and writing files.
 namespace std {
   template <class charT, class traits = char_traits<charT> >
     class basic_filebuf;
-  typedef basic_filebuf<char>    filebuf;
-  typedef basic_filebuf<wchar_t> wfilebuf;
+  using filebuf  = basic_filebuf<char>;
+  using wfilebuf = basic_filebuf<wchar_t>;
 
   template <class charT, class traits = char_traits<charT> >
     class basic_ifstream;
-  typedef basic_ifstream<char>    ifstream;
-  typedef basic_ifstream<wchar_t> wifstream;
+  using ifstream  = basic_ifstream<char>;
+  using wifstream = basic_ifstream<wchar_t>;
 
   template <class charT, class traits = char_traits<charT> >
     class basic_ofstream;
-  typedef basic_ofstream<char>    ofstream;
-  typedef basic_ofstream<wchar_t> wofstream;
+  using ofstream  = basic_ofstream<char>;
+  using wofstream = basic_ofstream<wchar_t>;
 
   template <class charT, class traits = char_traits<charT> >
     class basic_fstream;
-  typedef basic_fstream<char>     fstream;
-  typedef basic_fstream<wchar_t> wfstream;
+  using fstream  = basic_fstream<char>;
+  using wfstream = basic_fstream<wchar_t>;
 }
 \end{codeblock}
 
@@ -8492,11 +8491,11 @@ namespace std {
   class basic_filebuf
     : public basic_streambuf<charT, traits> {
   public:
-    typedef charT                     char_type;
-    typedef typename traits::int_type int_type;
-    typedef typename traits::pos_type pos_type;
-    typedef typename traits::off_type off_type;
-    typedef traits                    traits_type;
+    using char_type   = charT;
+    using int_type    = typename traits::int_type;
+    using pos_type    = typename traits::pos_type;
+    using off_type    = typename traits::off_type;
+    using traits_type = traits;
 
     // \ref{filebuf.cons}, constructors/destructor:
     basic_filebuf();
@@ -9260,11 +9259,11 @@ namespace std {
   class basic_ifstream
     : public basic_istream<charT, traits> {
   public:
-    typedef charT                     char_type;
-    typedef typename traits::int_type int_type;
-    typedef typename traits::pos_type pos_type;
-    typedef typename traits::off_type off_type;
-    typedef traits                    traits_type;
+    using char_type   = charT;
+    using int_type    = typename traits::int_type;
+    using pos_type    = typename traits::pos_type;
+    using off_type    = typename traits::off_type;
+    using traits_type = traits;
 
     // \ref{ifstream.cons}, constructors:
     basic_ifstream();
@@ -9501,11 +9500,11 @@ namespace std {
   class basic_ofstream
     : public basic_ostream<charT, traits> {
   public:
-    typedef charT                     char_type;
-    typedef typename traits::int_type int_type;
-    typedef typename traits::pos_type pos_type;
-    typedef typename traits::off_type off_type;
-    typedef traits                    traits_type;
+    using char_type   = charT;
+    using int_type    = typename traits::int_type;
+    using pos_type    = typename traits::pos_type;
+    using off_type    = typename traits::off_type;
+    using traits_type = traits;
 
     // \ref{ofstream.cons}, constructors:
     basic_ofstream();
@@ -9739,11 +9738,11 @@ namespace std {
   class basic_fstream
     : public basic_iostream<charT, traits> {
   public:
-    typedef charT                     char_type;
-    typedef typename traits::int_type int_type;
-    typedef typename traits::pos_type pos_type;
-    typedef typename traits::off_type off_type;
-    typedef traits                    traits_type;
+    using char_type   = charT;
+    using int_type    = typename traits::int_type;
+    using pos_type    = typename traits::pos_type;
+    using off_type    = typename traits::off_type;
+    using traits_type = traits;
 
     // \ref{fstream.cons}, constructors:
     basic_fstream();
@@ -10285,7 +10284,7 @@ namespace std::filesystem {
   enum class copy_options;
   enum class directory_options;
 
-  typedef chrono::time_point<@\textit{trivial-clock}@> file_time_type;
+  using file_time_type = chrono::time_point<@\textit{trivial-clock}@>;
 
   // \ref{fs.op.funcs}, filesystem operations:
   path absolute(const path& p, const path& base = current_path());
@@ -10505,8 +10504,8 @@ system or for a particular file system.
 namespace std::filesystem {
   class path {
   public:
-    typedef @\seebelow@ value_type;
-    typedef basic_string<value_type> string_type;
+    using value_type  = @\seebelow@;
+    using string_type = basic_string<value_type>;
     static constexpr value_type preferred_separator = @\seebelow@;
 
     // \ref{path.construct}, constructors and destructor:
@@ -10620,7 +10619,7 @@ namespace std::filesystem {
 
     // \ref{path.itr}, iterators:
     class iterator;
-    typedef iterator const_iterator;
+    using const_iterator = iterator;
 
     iterator begin() const;
     iterator end() const;
@@ -12563,11 +12562,11 @@ directory.
 namespace std::filesystem {
   class directory_iterator {
   public:
-    typedef directory_entry        value_type;
-    typedef ptrdiff_t              difference_type;
-    typedef const directory_entry* pointer;
-    typedef const directory_entry& reference;
-    typedef input_iterator_tag     iterator_category;
+    using iterator_category = input_iterator_tag;
+    using value_type        = directory_entry;
+    using difference_type   = ptrdiff_t;
+    using pointer           = const directory_entry*;
+    using reference         = const directory_entry&;
 
     // \ref{directory_iterator.members}, member functions:
     directory_iterator() noexcept;
@@ -12768,11 +12767,11 @@ directory and its sub-directories.
 namespace std::filesystem {
   class recursive_directory_iterator {
   public:
-    typedef directory_entry        value_type;
-    typedef ptrdiff_t              difference_type;
-    typedef const directory_entry* pointer;
-    typedef const directory_entry& reference;
-    typedef input_iterator_tag     iterator_category;
+    using iterator_category = input_iterator_tag;
+    using value_type        = directory_entry;
+    using difference_type   = ptrdiff_t;
+    using pointer           = const directory_entry*;
+    using reference         = const directory_entry&;
 
     // \ref{rec.dir.itr.members}, constructors and destructor:
     recursive_directory_iterator() noexcept;

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -905,11 +905,11 @@ types \tcode{difference_type}, \tcode{value_type}, \tcode{pointer},
 shall have the following as publicly accessible members
 and shall have no other members:
 \begin{codeblock}
-  typedef typename Iterator::difference_type difference_type;
-  typedef typename Iterator::value_type value_type;
-  typedef typename Iterator::pointer pointer;
-  typedef typename Iterator::reference reference;
-  typedef typename Iterator::iterator_category iterator_category;
+  using difference_type   = typename Iterator::difference_type;
+  using value_type        = typename Iterator::value_type;
+  using pointer           = typename Iterator::pointer;
+  using reference         = typename Iterator::reference;
+  using iterator_category = typename Iterator::iterator_category;
 \end{codeblock}
 Otherwise, \tcode{iterator_traits<Iterator>}
 shall have no members.
@@ -920,11 +920,11 @@ It is specialized for pointers as
 \begin{codeblock}
 namespace std {
   template<class T> struct iterator_traits<T*> {
-    typedef ptrdiff_t difference_type;
-    typedef T value_type;
-    typedef T* pointer;
-    typedef T& reference;
-    typedef random_access_iterator_tag iterator_category;
+    using difference_type   = ptrdiff_t;
+    using value_type        = T;
+    using pointer           = T*;
+    using reference         = T&;
+    using iterator_category = random_access_iterator_tag;
   };
 }
 \end{codeblock}
@@ -934,11 +934,11 @@ and for pointers to const as
 \begin{codeblock}
 namespace std {
   template<class T> struct iterator_traits<const T*> {
-    typedef ptrdiff_t difference_type;
-    typedef T value_type;
-    typedef const T* pointer;
-    typedef const T& reference;
-    typedef random_access_iterator_tag iterator_category;
+    using difference_type   = ptrdiff_t;
+    using value_type        = T;
+    using pointer           = const T*;
+    using reference         = const T&;
+    using iterator_category = random_access_iterator_tag;
   };
 }
 \end{codeblock}
@@ -979,11 +979,11 @@ namespace std {
   template<class Category, class T, class Distance = ptrdiff_t,
     class Pointer = T*, class Reference = T&>
   struct iterator {
-    typedef T         value_type;
-    typedef Distance  difference_type;
-    typedef Pointer   pointer;
-    typedef Reference reference;
-    typedef Category  iterator_category;
+    using iterator_category = Category;
+    using value_type        = T;
+    using difference_type   = Distance;
+    using pointer           = Pointer;
+    using reference         = Reference;
   };
 }
 \end{codeblock}
@@ -1044,11 +1044,11 @@ template:
 
 \begin{codeblock}
 template<class T> struct iterator_traits<BinaryTreeIterator<T> > {
-  typedef std::ptrdiff_t difference_type;
-  typedef T value_type;
-  typedef T* pointer;
-  typedef T& reference;
-  typedef bidirectional_iterator_tag iterator_category;
+  using iterator_category = bidirectional_iterator_tag;
+  using difference_type   = std::ptrdiff_t;
+  using value_type        = T;
+  using pointer           = T*;
+  using reference         = T&;
 };
 \end{codeblock}
 
@@ -1223,12 +1223,12 @@ namespace std {
   template <class Iterator>
   class reverse_iterator {
   public:
-    typedef Iterator                                              iterator_type;
-    typedef typename iterator_traits<Iterator>::iterator_category iterator_category;
-    typedef typename iterator_traits<Iterator>::value_type        value_type;
-    typedef typename iterator_traits<Iterator>::difference_type   difference_type;
-    typedef typename iterator_traits<Iterator>::pointer           pointer;
-    typedef typename iterator_traits<Iterator>::reference         reference;
+    using iterator_type     = Iterator;
+    using iterator_category = typename iterator_traits<Iterator>::iterator_category;
+    using value_type        = typename iterator_traits<Iterator>::value_type;
+    using difference_type   = typename iterator_traits<Iterator>::difference_type;
+    using pointer           = typename iterator_traits<Iterator>::pointer;
+    using reference         = typename iterator_traits<Iterator>::reference;
 
     constexpr reverse_iterator();
     constexpr explicit reverse_iterator(Iterator x);
@@ -1778,12 +1778,13 @@ namespace std {
     Container* container;
 
   public:
-    typedef output_iterator_tag iterator_category;
-    typedef void value_type;
-    typedef void difference_type;
-    typedef void pointer;
-    typedef void reference;
-    typedef Container container_type;
+    using iterator_category = output_iterator_tag;
+    using value_type        = void;
+    using difference_type   = void;
+    using pointer           = void;
+    using reference         = void;
+    using container_type    = Container;
+
     explicit back_insert_iterator(Container& x);
     back_insert_iterator& operator=(const typename Container::value_type& value);
     back_insert_iterator& operator=(typename Container::value_type&& value);
@@ -1899,12 +1900,13 @@ namespace std {
     Container* container;
 
   public:
-    typedef output_iterator_tag iterator_category;
-    typedef void value_type;
-    typedef void difference_type;
-    typedef void pointer;
-    typedef void reference;
-    typedef Container container_type;
+    using iterator_category = output_iterator_tag;
+    using value_type        = void;
+    using difference_type   = void;
+    using pointer           = void;
+    using reference         = void;
+    using container_type    = Container;
+
     explicit front_insert_iterator(Container& x);
     front_insert_iterator& operator=(const typename Container::value_type& value);
     front_insert_iterator& operator=(typename Container::value_type&& value);
@@ -2021,12 +2023,13 @@ namespace std {
     typename Container::iterator iter;
 
   public:
-    typedef output_iterator_tag iterator_category;
-    typedef void value_type;
-    typedef void difference_type;
-    typedef void pointer;
-    typedef void reference;
-    typedef Container container_type;
+    using iterator_category = output_iterator_tag;
+    using value_type        = void;
+    using difference_type   = void;
+    using pointer           = void;
+    using reference         = void;
+    using container_type    = Container;
+
     insert_iterator(Container& x, typename Container::iterator i);
     insert_iterator& operator=(const typename Container::value_type& value);
     insert_iterator& operator=(typename Container::value_type&& value);
@@ -2172,12 +2175,12 @@ namespace std {
   template <class Iterator>
   class move_iterator {
   public:
-    typedef Iterator                                              iterator_type;
-    typedef typename iterator_traits<Iterator>::difference_type   difference_type;
-    typedef Iterator                                              pointer;
-    typedef typename iterator_traits<Iterator>::value_type        value_type;
-    typedef typename iterator_traits<Iterator>::iterator_category iterator_category;
-    typedef @\seebelownc@                                             reference;
+    using iterator_type     = Iterator;
+    using iterator_category = typename iterator_traits<Iterator>::iterator_category;
+    using value_type        = typename iterator_traits<Iterator>::value_type;
+    using difference_type   = typename iterator_traits<Iterator>::difference_type;
+    using pointer           = Iterator;
+    using reference         = @\seebelow@;
 
     constexpr move_iterator();
     constexpr explicit move_iterator(Iterator i);
@@ -2680,14 +2683,15 @@ namespace std {
       class Distance = ptrdiff_t>
   class istream_iterator {
   public:
-    typedef input_iterator_tag iterator_category;
-    typedef T value_type;
-    typedef Distance difference_type;
-    typedef const T* pointer;
-    typedef const T& reference;
-    typedef charT char_type;
-    typedef traits traits_type;
-    typedef basic_istream<charT,traits> istream_type;
+    using iterator_category = input_iterator_tag;
+    using value_type        = T;
+    using difference_type   = Distance;
+    using pointer           = const T*;
+    using reference         = const T&;
+    using char_type         = charT;
+    using traits_type       = traits;
+    using istream_type      = basic_istream<charT,traits>;
+
     @\seebelow@ istream_iterator();
     istream_iterator(istream_type& s);
     istream_iterator(const istream_iterator& x) = default;
@@ -2899,14 +2903,15 @@ namespace std {
   template <class T, class charT = char, class traits = char_traits<charT> >
   class ostream_iterator {
   public:
-    typedef output_iterator_tag iterator_category;
-    typedef void value_type;
-    typedef void difference_type;
-    typedef void pointer;
-    typedef void reference;
-    typedef charT char_type;
-    typedef traits traits_type;
-    typedef basic_ostream<charT,traits> ostream_type;
+    using iterator_category = output_iterator_tag;
+    using value_type        = void;
+    using difference_type   = void;
+    using pointer           = void;
+    using reference         = void;
+    using char_type         = charT;
+    using traits_type       = traits;
+    using ostream_type      = basic_ostream<charT,traits>;
+
     ostream_iterator(ostream_type& s);
     ostream_iterator(ostream_type& s, const charT* delimiter);
     ostream_iterator(const ostream_iterator& x);
@@ -3065,16 +3070,16 @@ namespace std {
   template<class charT, class traits = char_traits<charT> >
   class istreambuf_iterator {
   public:
-    typedef input_iterator_tag            iterator_category;
-    typedef charT                         value_type;
-    typedef typename traits::off_type     difference_type;
-    typedef @\unspecnc@                   pointer;
-    typedef charT                         reference;
-    typedef charT                         char_type;
-    typedef traits                        traits_type;
-    typedef typename traits::int_type     int_type;
-    typedef basic_streambuf<charT,traits> streambuf_type;
-    typedef basic_istream<charT,traits>   istream_type;
+    using iterator_category = input_iterator_tag;
+    using value_type        = charT;
+    using difference_type   = typename traits::off_type;
+    using pointer           = @\unspec@;
+    using reference         = charT;
+    using char_type         = charT;
+    using traits_type       = traits;
+    using int_type          = typename traits::int_type;
+    using streambuf_type    = basic_streambuf<charT,traits>;
+    using istream_type      = basic_istream<charT,traits>;
 
     class proxy;                          // \expos
 
@@ -3289,15 +3294,15 @@ namespace std {
   template <class charT, class traits = char_traits<charT> >
   class ostreambuf_iterator {
   public:
-    typedef output_iterator_tag           iterator_category;
-    typedef void                          value_type;
-    typedef void                          difference_type;
-    typedef void                          pointer;
-    typedef void                          reference;
-    typedef charT                         char_type;
-    typedef traits                        traits_type;
-    typedef basic_streambuf<charT,traits> streambuf_type;
-    typedef basic_ostream<charT,traits>   ostream_type;
+    using iterator_category = output_iterator_tag;
+    using value_type        = void;
+    using difference_type   = void;
+    using pointer           = void;
+    using reference         = void;
+    using char_type         = charT;
+    using traits_type       = traits;
+    using streambuf_type    = basic_streambuf<charT,traits>;
+    using ostream_type      = basic_ostream<charT,traits>;
 
     ostreambuf_iterator(ostream_type& s) noexcept;
     ostreambuf_iterator(streambuf_type* s) noexcept;

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -120,7 +120,7 @@ namespace std {
     // types:
     class facet;
     class id;
-    typedef int category;
+    using category = int;
     static const category   // values assigned here are for exposition only
       none     = 0,
       collate  = 0x010, ctype    = 0x020,
@@ -285,7 +285,7 @@ implementations are not required to avoid data races on it~(\ref{res.on.data.rac
 \indexlibrary{\idxcode{locale}!\idxcode{category}}%
 \indexlibrary{\idxcode{category}!\idxcode{locale}}%
 \begin{itemdecl}
-typedef int category;
+using category = int;
 \end{itemdecl}
 
 \pnum
@@ -1075,10 +1075,10 @@ template<class Codecvt, class Elem = wchar_t,
     class Wide_alloc = std::allocator<Elem>,
     class Byte_alloc = std::allocator<char> > class wstring_convert {
   public:
-    typedef std::basic_string<char, char_traits<char>, Byte_alloc> byte_string;
-    typedef std::basic_string<Elem, char_traits<Elem>, Wide_alloc> wide_string;
-    typedef typename Codecvt::state_type state_type;
-    typedef typename wide_string::traits_type::int_type int_type;
+    using byte_string = std::basic_string<char, char_traits<char>, Byte_alloc>;
+    using wide_string = std::basic_string<Elem, char_traits<Elem>, Wide_alloc>;
+    using state_type  = typename Codecvt::state_type;
+    using int_type    = typename wide_string::traits_type::int_type;
 
     explicit wstring_convert(Codecvt* pcvt = new Codecvt);
     wstring_convert(Codecvt* pcvt, state_type state);
@@ -1139,7 +1139,7 @@ An object of this class template stores:
 \indexlibrary{\idxcode{byte_string}!\idxcode{wstring_convert}}%
 \indexlibrary{\idxcode{wstring_convert}!\idxcode{byte_string}}%
 \begin{itemdecl}
-typedef std::basic_string<char, char_traits<char>, Byte_alloc> byte_string;
+using byte_string = std::basic_string<char, char_traits<char>, Byte_alloc>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1200,7 +1200,7 @@ Otherwise, the member function throws an object of class \tcode{std::range_error
 \indexlibrary{\idxcode{int_type}!\idxcode{wstring_convert}}%
 \indexlibrary{\idxcode{wstring_convert}!\idxcode{int_type}}%
 \begin{itemdecl}
-typedef typename wide_string::traits_type::int_type int_type;
+using int_type = typename wide_string::traits_type::int_type;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1221,7 +1221,7 @@ returns \tcode{cvtstate}.
 \indexlibrary{\idxcode{state_type}!\idxcode{wstring_convert}}%
 \indexlibrary{\idxcode{wstring_convert}!\idxcode{state_type}}%
 \begin{itemdecl}
-typedef typename Codecvt::state_type state_type;
+using state_type = typename Codecvt::state_type;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1270,7 +1270,7 @@ Otherwise, the member function shall throw an object of class \tcode{std::range_
 \indexlibrary{\idxcode{wide_string}!\idxcode{wstring_convert}}%
 \indexlibrary{\idxcode{wstring_convert}!\idxcode{wide_string}}%
 \begin{itemdecl}
-typedef std::basic_string<Elem, char_traits<Elem>, Wide_alloc> wide_string;
+using wide_string = std::basic_string<Elem, char_traits<Elem>, Wide_alloc>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1339,7 +1339,7 @@ template<class Codecvt,
   class wbuffer_convert
     : public std::basic_streambuf<Elem, Tr> {
   public:
-    typedef typename Codecvt::state_type state_type;
+    using state_type = typename Codecvt::state_type;
 
     explicit wbuffer_convert(std::streambuf* bytebuf = 0,
                              Codecvt* pcvt = new Codecvt,
@@ -1421,7 +1421,7 @@ std::streambuf* rdbuf(std::streambuf* bytebuf);
 \indexlibrary{\idxcode{state_type}!\idxcode{wbuffer_convert}}%
 \indexlibrary{\idxcode{wbuffer_convert}!\idxcode{state_type}}%
 \begin{itemdecl}
-typedef typename Codecvt::state_type state_type;
+using state_type = typename Codecvt::state_type;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1514,7 +1514,7 @@ virtual function.
 namespace std {
   class ctype_base {
   public:
-    typedef @\placeholder{T}@ mask;
+    using mask = @\placeholder{T}@;
 
     // numeric values are for exposition only.
     static const mask space = 1 << 0;
@@ -1546,7 +1546,7 @@ namespace std {
   template <class charT>
   class ctype : public locale::facet, public ctype_base {
   public:
-    typedef charT char_type;
+    using char_type = charT;
 
     explicit ctype(size_t refs = 0);
 
@@ -1971,7 +1971,7 @@ namespace std {
   template <class charT>
   class ctype_byname : public ctype<charT> {
   public:
-    typedef typename ctype<charT>::mask mask;
+    using mask = typename ctype<charT>::mask;
     explicit ctype_byname(const char*, size_t refs = 0);
     explicit ctype_byname(const string&, size_t refs = 0);
   protected:
@@ -1988,7 +1988,7 @@ namespace std {
   template <> class ctype<char>
     : public locale::facet, public ctype_base {
   public:
-    typedef char char_type;
+    using char_type = char;
 
     explicit ctype(const mask* tab = 0, bool del = false,
                    size_t refs = 0);
@@ -2314,9 +2314,9 @@ namespace std {
   template <class internT, class externT, class stateT>
   class codecvt : public locale::facet, public codecvt_base {
   public:
-    typedef internT  intern_type;
-    typedef externT  extern_type;
-    typedef stateT state_type;
+    using intern_type = internT;
+    using extern_type = externT;
+    using state_type  = stateT;
 
     explicit codecvt(size_t refs = 0);
 
@@ -2839,8 +2839,8 @@ namespace std {
   template <class charT, class InputIterator = istreambuf_iterator<charT> >
   class num_get : public locale::facet {
   public:
-    typedef charT            char_type;
-    typedef InputIterator    iter_type;
+    using char_type = charT;
+    using iter_type = InputIterator;
 
     explicit num_get(size_t refs = 0);
 
@@ -3256,8 +3256,8 @@ namespace std {
   template <class charT, class OutputIterator = ostreambuf_iterator<charT> >
   class num_put : public locale::facet {
   public:
-    typedef charT            char_type;
-    typedef OutputIterator   iter_type;
+    using char_type = charT;
+    using iter_type = OutputIterator;
 
     explicit num_put(size_t refs = 0);
 
@@ -3619,8 +3619,8 @@ namespace std {
   template <class charT>
   class numpunct : public locale::facet {
   public:
-    typedef charT               char_type;
-    typedef basic_string<charT> string_type;
+    using char_type   = charT;
+    using string_type = basic_string<charT>;
 
     explicit numpunct(size_t refs = 0);
 
@@ -3845,8 +3845,9 @@ namespace std {
   class numpunct_byname : public numpunct<charT> {
   // this class is specialized for \tcode{char} and \tcode{wchar_t}.
   public:
-    typedef charT                char_type;
-    typedef basic_string<charT>  string_type;
+    using char_type   = charT;
+    using string_type = basic_string<charT>;
+
     explicit numpunct_byname(const char*, size_t refs = 0);
     explicit numpunct_byname(const string&, size_t refs = 0);
   protected:
@@ -3865,8 +3866,8 @@ namespace std {
   template <class charT>
   class collate : public locale::facet {
   public:
-    typedef charT               char_type;
-    typedef basic_string<charT> string_type;
+    using char_type   = charT;
+    using string_type = basic_string<charT>;
 
     explicit collate(size_t refs = 0);
 
@@ -4019,7 +4020,8 @@ namespace std {
   template <class charT>
   class collate_byname : public collate<charT> {
   public:
-    typedef basic_string<charT> string_type;
+    using string_type = basic_string<charT>;
+
     explicit collate_byname(const char*, size_t refs = 0);
     explicit collate_byname(const string&, size_t refs = 0);
   protected:
@@ -4065,8 +4067,8 @@ namespace std {
   template <class charT, class InputIterator = istreambuf_iterator<charT> >
   class time_get : public locale::facet, public time_base {
   public:
-    typedef charT            char_type;
-    typedef InputIterator    iter_type;
+    using char_type = charT;
+    using iter_type = InputIterator;
 
     explicit time_get(size_t refs = 0);
 
@@ -4487,8 +4489,8 @@ namespace std {
   template <class charT, class InputIterator = istreambuf_iterator<charT> >
   class time_get_byname : public time_get<charT, InputIterator> {
   public:
-    typedef time_base::dateorder dateorder;
-    typedef InputIterator        iter_type;
+    using dateorder = time_base::dateorder;
+    using iter_type = InputIterator;
 
     explicit time_get_byname(const char*, size_t refs = 0);
     explicit time_get_byname(const string&, size_t refs = 0);
@@ -4506,8 +4508,8 @@ namespace std {
   template <class charT, class OutputIterator = ostreambuf_iterator<charT> >
   class time_put : public locale::facet {
   public:
-    typedef charT            char_type;
-    typedef OutputIterator   iter_type;
+    using char_type = charT;
+    using iter_type = OutputIterator;
 
     explicit time_put(size_t refs = 0);
 
@@ -4642,8 +4644,8 @@ namespace std {
   class time_put_byname : public time_put<charT, OutputIterator>
   {
   public:
-    typedef charT          char_type;
-    typedef OutputIterator iter_type;
+    using char_type = charT;
+    using iter_type = OutputIterator;
 
     explicit time_put_byname(const char*, size_t refs = 0);
     explicit time_put_byname(const string&, size_t refs = 0);
@@ -4688,9 +4690,9 @@ namespace std {
     class InputIterator = istreambuf_iterator<charT> >
   class money_get : public locale::facet {
   public:
-    typedef charT               char_type;
-    typedef InputIterator       iter_type;
-    typedef basic_string<charT> string_type;
+    using char_type   = charT;
+    using iter_type   = InputIterator;
+    using string_type = basic_string<charT>;
 
     explicit money_get(size_t refs = 0);
 
@@ -4920,9 +4922,9 @@ namespace std {
     class OutputIterator = ostreambuf_iterator<charT> >
   class money_put : public locale::facet {
   public:
-    typedef charT               char_type;
-    typedef OutputIterator      iter_type;
-    typedef basic_string<charT> string_type;
+    using char_type   = charT;
+    using iter_type   = OutputIterator;
+    using string_type = basic_string<charT>;
 
     explicit money_put(size_t refs = 0);
 
@@ -5078,8 +5080,8 @@ namespace std {
   template <class charT, bool International = false>
   class moneypunct : public locale::facet, public money_base {
   public:
-    typedef charT char_type;
-    typedef basic_string<charT> string_type;
+    using char_type   = charT;
+    using string_type = basic_string<charT>;
 
     explicit moneypunct(size_t refs = 0);
 
@@ -5424,8 +5426,8 @@ namespace std {
   template <class charT, bool Intl = false>
   class moneypunct_byname : public moneypunct<charT, Intl> {
   public:
-    typedef money_base::pattern pattern;
-    typedef basic_string<charT> string_type;
+    using pattern     = money_base::pattern;
+    using string_type = basic_string<charT>;
 
     explicit moneypunct_byname(const char*, size_t refs = 0);
     explicit moneypunct_byname(const string&, size_t refs = 0);
@@ -5449,14 +5451,14 @@ implements retrieval of strings from message catalogs.
 namespace std {
   class messages_base {
   public:
-    typedef @\textit{unspecified signed integer type}@ catalog;
+    using catalog = @\textit{unspecified signed integer type}@;
   };
 
   template <class charT>
   class messages : public locale::facet, public messages_base {
   public:
-    typedef charT char_type;
-    typedef basic_string<charT> string_type;
+    using char_type   = charT;
+    using string_type = basic_string<charT>;
 
     explicit messages(size_t refs = 0);
 
@@ -5608,8 +5610,8 @@ namespace std {
   template <class charT>
   class messages_byname : public messages<charT> {
   public:
-    typedef messages_base::catalog catalog;
-    typedef basic_string<charT>    string_type;
+    using catalog     = messages_base::catalog;
+    using string_type = basic_string<charT>;
 
     explicit messages_byname(const char*, size_t refs = 0);
     explicit messages_byname(const string&, size_t refs = 0);
@@ -5783,7 +5785,7 @@ std::locale::id My::JCtype::id; // the static \tcode{JCtype} member declared abo
 
 int main() {
   using namespace std;
-  typedef ctype<wchar_t> wctype;
+  using wctype = ctype<wchar_t>;
   locale loc(locale(""),        // the user's preferred locale ...
          new My::JCtype);       // and a new feature ...
   wchar_t c = use_facet<wctype>(loc).widen('!');
@@ -5813,7 +5815,7 @@ facet interface:
 #include <string>
 namespace My {
   using namespace std;
-  typedef numpunct_byname<char> cnumpunct;
+  using cnumpunct = numpunct_byname<char>;
   class BoolNames : public cnumpunct {
   protected:
     string do_truename()  const { return "Oui Oui!"; }

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -152,8 +152,8 @@ does not have any ordering operators.
 \begin{codeblock}
 namespace std {
   // types
-  typedef @\textit{object type}@  fenv_t;
-  typedef @\textit{integer type}@ fexcept_t;
+  using fenv_t    = @\textit{object type}@;
+  using fexcept_t = @\textit{integer type}@;
 
   // functions
   int feclearexcept(int except);
@@ -380,7 +380,7 @@ namespace std {
   template<class T>
   class complex {
   public:
-    typedef T value_type;
+    using value_type = T;
 
     constexpr complex(const T& re = T(), const T& im = T());
     constexpr complex(const complex&);
@@ -424,7 +424,7 @@ number.
 namespace std {
   template<> class complex<float> {
   public:
-    typedef float value_type;
+    using value_type = float;
 
     constexpr complex(float re = 0.0f, float im = 0.0f);
     constexpr explicit complex(const complex<double>&);
@@ -451,7 +451,7 @@ namespace std {
 
   template<> class complex<double> {
   public:
-    typedef double value_type;
+    using value_type = double;
 
     constexpr complex(double re = 0.0, double im = 0.0);
     constexpr complex(const complex<float>&);
@@ -478,7 +478,7 @@ namespace std {
 
   template<> class complex<long double> {
   public:
-    typedef long double value_type;
+    using value_type = long double;
 
     constexpr complex(long double re = 0.0L, long double im = 0.0L);
     constexpr complex(const complex<float>&);
@@ -2484,7 +2484,7 @@ with the identical name, type, and semantics.
 \pnum
 \tcode{P} shall have a declaration of the form
 \begin{codeblock}
-typedef  D  distribution_type;
+using distribution_type =  D;
 \end{codeblock}
 
 \indextext{requirements!random number distribution|)}%
@@ -2538,16 +2538,17 @@ namespace std {
    class shuffle_order_engine;
 
  // \ref{rand.predef}, engines and engine adaptors with predefined parameters
- typedef @\seebelow@ minstd_rand0;
- typedef @\seebelow@ minstd_rand;
- typedef @\seebelow@ mt19937;
- typedef @\seebelow@ mt19937_64;
- typedef @\seebelow@ ranlux24_base;
- typedef @\seebelow@ ranlux48_base;
- typedef @\seebelow@ ranlux24;
- typedef @\seebelow@ ranlux48;
- typedef @\seebelow@ knuth_b;
- typedef @\seebelow@ default_random_engine;
+ using minstd_rand0  = @\seebelow@;
+ using minstd_rand   = @\seebelow@;
+ using mt19937       = @\seebelow@;
+ using mt19937_64    = @\seebelow@;
+ using ranlux24_base = @\seebelow@;
+ using ranlux48_base = @\seebelow@;
+ using ranlux24      = @\seebelow@;
+ using ranlux48      = @\seebelow@;
+ using knuth_b       = @\seebelow@;
+
+ using default_random_engine = @\seebelow@;
 
  // \ref{rand.device}, class random_device
  class random_device;
@@ -2753,7 +2754,7 @@ template<class UIntType, UIntType a, UIntType c, UIntType m>
 {
 public:
  // types
- typedef UIntType result_type;
+ using result_type = UIntType;
 
  // engine characteristics
  static constexpr result_type multiplier = a;
@@ -2920,7 +2921,7 @@ template<class UIntType, size_t w, size_t n, size_t m, size_t r,
 {
 public:
  // types
- typedef UIntType result_type;
+ using result_type = UIntType;
 
  // engine characteristics
  static constexpr size_t word_size = w;
@@ -3098,7 +3099,7 @@ template<class UIntType, size_t w, size_t s, size_t r>
 {
 public:
  // types
- typedef UIntType result_type;
+ using result_type = UIntType;
 
  // engine characteristics
  static constexpr size_t word_size = w;
@@ -3291,7 +3292,7 @@ template<class Engine, size_t p, size_t r>
 {
 public:
  // types
- typedef typename Engine::result_type result_type;
+ using result_type = typename Engine::result_type;
 
  // engine characteristics
  static constexpr size_t block_size = p;
@@ -3445,7 +3446,7 @@ class independent_bits_engine
 {
 public:
  // types
- typedef UIntType result_type;
+ using result_type = UIntType;
 
  // engine characteristics
  static constexpr result_type min() { return 0; }
@@ -3544,7 +3545,7 @@ template<class Engine, size_t k>
 {
 public:
  // types
- typedef typename Engine::result_type result_type;
+ using result_type = typename Engine::result_type;
 
  // engine characteristics
  static constexpr size_t table_size = k;
@@ -3619,8 +3620,8 @@ with values returned by successive invocations of \tcode{e()}.%
 \indexlibrary{\idxcode{minstd_rand0}}%
 \indextext{engines with predefined parameters!\idxcode{minstd_rand0}}%
 \begin{itemdecl}
-typedef linear_congruential_engine<uint_fast32_t, 16807, 0, 2147483647>
-       minstd_rand0;
+using minstd_rand0 =
+      linear_congruential_engine<uint_fast32_t, 16807, 0, 2147483647>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3634,8 +3635,8 @@ typedef linear_congruential_engine<uint_fast32_t, 16807, 0, 2147483647>
 \indexlibrary{\idxcode{minstd_rand}}%
 \indextext{engines with predefined parameters!\idxcode{minstd_rand}}%
 \begin{itemdecl}
-typedef linear_congruential_engine<uint_fast32_t, 48271, 0, 2147483647>
-       minstd_rand;
+using minstd_rand =
+      linear_congruential_engine<uint_fast32_t, 48271, 0, 2147483647>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3649,9 +3650,9 @@ typedef linear_congruential_engine<uint_fast32_t, 48271, 0, 2147483647>
 \indexlibrary{\idxcode{mt19937}}%
 \indextext{engines with predefined parameters!\idxcode{mt19937}}%
 \begin{itemdecl}
-typedef mersenne_twister_engine<uint_fast32_t,
-       32,624,397,31,0x9908b0df,11,0xffffffff,7,0x9d2c5680,15,0xefc60000,18,1812433253>
-       mt19937;
+using mt19937 =
+      mersenne_twister_engine<uint_fast32_t,
+       32,624,397,31,0x9908b0df,11,0xffffffff,7,0x9d2c5680,15,0xefc60000,18,1812433253>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3665,13 +3666,13 @@ typedef mersenne_twister_engine<uint_fast32_t,
 \indexlibrary{\idxcode{mt19937_64}}%
 \indextext{engines with predefined parameters!\idxcode{mt19937_64}}%
 \begin{itemdecl}
-typedef mersenne_twister_engine<uint_fast64_t,
+using mt19937_64 =
+      mersenne_twister_engine<uint_fast64_t,
        64,312,156,31,0xb5026f5aa96619e9,29,
        0x5555555555555555,17,
        0x71d67fffeda60000,37,
        0xfff7eee000000000,43,
-       6364136223846793005>
-       mt19937_64;
+       6364136223846793005>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3685,8 +3686,8 @@ typedef mersenne_twister_engine<uint_fast64_t,
 \indexlibrary{\idxcode{ranlux24_base}}%
 \indextext{engines with predefined parameters!\idxcode{ranlux24_base}}%
 \begin{itemdecl}
-typedef subtract_with_carry_engine<uint_fast32_t, 24, 10, 24>
-       ranlux24_base;
+using ranlux24_base =
+      subtract_with_carry_engine<uint_fast32_t, 24, 10, 24>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3701,8 +3702,8 @@ typedef subtract_with_carry_engine<uint_fast32_t, 24, 10, 24>
 \indexlibrary{\idxcode{ranlux48_base}}%
 \indextext{engines with predefined parameters!\idxcode{ranlux48_base}}%
 \begin{itemdecl}
-typedef subtract_with_carry_engine<uint_fast64_t, 48, 5, 12>
-       ranlux48_base;
+using ranlux48_base =
+      subtract_with_carry_engine<uint_fast64_t, 48, 5, 12>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3717,8 +3718,7 @@ typedef subtract_with_carry_engine<uint_fast64_t, 48, 5, 12>
 \indexlibrary{\idxcode{ranlux24}}%
 \indextext{engines with predefined parameters!\idxcode{ranlux24}}%
 \begin{itemdecl}
-typedef discard_block_engine<ranlux24_base, 223, 23>
-       ranlux24;
+using ranlux24 = discard_block_engine<ranlux24_base, 223, 23>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3733,8 +3733,7 @@ typedef discard_block_engine<ranlux24_base, 223, 23>
 \indexlibrary{\idxcode{ranlux48}}%
 \indextext{engines with predefined parameters!\idxcode{ranlux48}}%
 \begin{itemdecl}
-typedef discard_block_engine<ranlux48_base, 389, 11>
-       ranlux48;
+using ranlux48 = discard_block_engine<ranlux48_base, 389, 11>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3749,8 +3748,7 @@ typedef discard_block_engine<ranlux48_base, 389, 11>
 \indexlibrary{\idxcode{knuth_b}}%
 \indextext{engines with predefined parameters!\idxcode{knuth_b}}%
 \begin{itemdecl}
-typedef shuffle_order_engine<minstd_rand0,256>
-       knuth_b;
+using knuth_b = shuffle_order_engine<minstd_rand0,256>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3764,8 +3762,7 @@ typedef shuffle_order_engine<minstd_rand0,256>
 \indexlibrary{\idxcode{default_random_engine}}%
 \indextext{engines with predefined parameters!\idxcode{default_random_engine}}%
 \begin{itemdecl}
-typedef @\textit{implementation-defined}@
-       default_random_engine;
+using default_random_engine = @\textit{implementation-defined}@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3821,7 +3818,7 @@ class random_device
 {
 public:
  // types
- typedef unsigned int result_type;
+ using result_type = unsigned int;
 
  // generator characteristics
  static constexpr result_type min() { return numeric_limits<result_type>::min(); }
@@ -3927,7 +3924,7 @@ class seed_seq
 {
 public:
  // types
- typedef uint_least32_t result_type;
+ using result_type = uint_least32_t;
 
  // constructors
  seed_seq();
@@ -4293,8 +4290,8 @@ template<class IntType = int>
 {
 public:
  // types
- typedef IntType result_type;
- typedef @\textit{unspecified}@ param_type;
+ using result_type = IntType;
+ using param_type  = @\unspec@;
 
  // constructors and reset functions
  explicit uniform_int_distribution(IntType a = 0, IntType b = numeric_limits<IntType>::max());
@@ -4383,8 +4380,8 @@ template<class RealType = double>
 {
 public:
  // types
- typedef RealType result_type;
- typedef @\textit{unspecified}@ param_type;
+ using result_type = RealType;
+ using param_type  = @\unspec@;
 
  // constructors and reset functions
  explicit uniform_real_distribution(RealType a = 0.0, RealType b = 1.0);
@@ -4487,8 +4484,8 @@ class bernoulli_distribution
 {
 public:
  // types
- typedef bool result_type;
- typedef @\textit{unspecified}@ param_type;
+ using result_type = bool;
+ using param_type  = @\unspec@;
 
  // constructors and reset functions
  explicit bernoulli_distribution(double p = 0.5);
@@ -4562,8 +4559,8 @@ template<class IntType = int>
 {
 public:
  // types
- typedef IntType result_type;
- typedef @\textit{unspecified}@ param_type;
+ using result_type = IntType;
+ using param_type  = @\unspec@;
 
  // constructors and reset functions
  explicit binomial_distribution(IntType t = 1, double p = 0.5);
@@ -4648,8 +4645,8 @@ template<class IntType = int>
 {
 public:
  // types
- typedef IntType result_type;
- typedef @\textit{unspecified}@ param_type;
+ using result_type = IntType;
+ using param_type  = @\unspec@;
 
  // constructors and reset functions
  explicit geometric_distribution(double p = 0.5);
@@ -4727,8 +4724,8 @@ template<class IntType = int>
 {
 public:
  // types
- typedef IntType result_type;
- typedef @\textit{unspecified}@ param_type;
+ using result_type = IntType;
+ using param_type  = @\unspec@;
 
  // constructor and reset functions
  explicit negative_binomial_distribution(IntType k = 1, double p = 0.5);
@@ -4834,8 +4831,8 @@ template<class IntType = int>
 {
 public:
  // types
- typedef IntType result_type;
- typedef @\textit{unspecified}@ param_type;
+ using result_type = IntType;
+ using param_type  = @\unspec@;
 
  // constructors and reset functions
  explicit poisson_distribution(double mean = 1.0);
@@ -4910,8 +4907,8 @@ template<class RealType = double>
 {
 public:
  // types
- typedef RealType result_type;
- typedef @\textit{unspecified}@ param_type;
+ using result_type = RealType;
+ using param_type  = @\unspec@;
 
  // constructors and reset functions
  explicit exponential_distribution(RealType lambda = 1.0);
@@ -4986,8 +4983,8 @@ template<class RealType = double>
 {
 public:
  // types
- typedef RealType result_type;
- typedef @\textit{unspecified}@ param_type;
+ using result_type = RealType;
+ using param_type  = @\unspec@;
 
  // constructors and reset functions
  explicit gamma_distribution(RealType alpha = 1.0, RealType beta = 1.0);
@@ -5076,8 +5073,8 @@ template<class RealType = double>
 {
 public:
  // types
- typedef RealType result_type;
- typedef @\textit{unspecified}@ param_type;
+ using result_type = RealType;
+ using param_type  = @\unspec@;
 
  // constructor and reset functions
  explicit weibull_distribution(RealType a = 1.0, RealType b = 1.0);
@@ -5173,8 +5170,8 @@ template<class RealType = double>
 {
 public:
  // types
- typedef RealType result_type;
- typedef @\textit{unspecified}@ param_type;
+ using result_type = RealType;
+ using param_type  = @\unspec@;
 
  // constructor and reset functions
  explicit extreme_value_distribution(RealType a = 0.0, RealType b = 1.0);
@@ -5287,8 +5284,8 @@ template<class RealType = double>
 {
 public:
  // types
- typedef RealType result_type;
- typedef @\textit{unspecified}@ param_type;
+ using result_type = RealType;
+ using param_type  = @\unspec@;
 
  // constructors and reset functions
  explicit normal_distribution(RealType mean = 0.0, RealType stddev = 1.0);
@@ -5381,8 +5378,8 @@ template<class RealType = double>
 {
 public:
  // types
- typedef RealType result_type;
- typedef @\textit{unspecified}@ param_type;
+ using result_type = RealType;
+ using param_type  = @\unspec@;
 
  // constructor and reset functions
  explicit lognormal_distribution(RealType m = 0.0, RealType s = 1.0);
@@ -5470,8 +5467,8 @@ template<class RealType = double>
 {
 public:
  // types
- typedef RealType result_type;
- typedef @\textit{unspecified}@ param_type;
+ using result_type = RealType;
+ using param_type  = @\unspec@;
 
  // constructor and reset functions
  explicit chi_squared_distribution(RealType n = 1);
@@ -5545,8 +5542,8 @@ template<class RealType = double>
 {
 public:
  // types
- typedef RealType result_type;
- typedef @\textit{unspecified}@ param_type;
+ using result_type = RealType;
+ using param_type  = @\unspec@;
 
  // constructor and reset functions
  explicit cauchy_distribution(RealType a = 0.0, RealType b = 1.0);
@@ -5640,8 +5637,8 @@ template<class RealType = double>
 {
 public:
  // types
- typedef RealType result_type;
- typedef @\textit{unspecified}@ param_type;
+ using result_type = RealType;
+ using param_type  = @\unspec@;
 
  // constructor and reset functions
  explicit fisher_f_distribution(RealType m = 1, RealType n = 1);
@@ -5732,8 +5729,8 @@ template<class RealType = double>
 {
 public:
  // types
- typedef RealType result_type;
- typedef @\textit{unspecified}@ param_type;
+ using result_type = RealType;
+ using param_type  = @\unspec@;
 
  // constructor and reset functions
  explicit student_t_distribution(RealType n = 1);
@@ -5834,8 +5831,8 @@ template<class IntType = int>
 {
 public:
  // types
- typedef IntType result_type;
- typedef @\textit{unspecified}@ param_type;
+ using result_type = IntType;
+ using param_type  = @\unspec@;
 
  // constructor and reset functions
  discrete_distribution();
@@ -6012,8 +6009,8 @@ template<class RealType = double>
 {
 public:
  // types
- typedef RealType result_type;
- typedef @\textit{unspecified}@ param_type;
+ using result_type = RealType;
+ using param_type  = @\unspec@;
 
  // constructor and reset functions
  piecewise_constant_distribution();
@@ -6237,8 +6234,8 @@ template<class RealType = double>
 {
 public:
  // types
- typedef RealType result_type;
- typedef @\textit{unspecified}@ param_type;
+ using result_type = RealType;
+ using param_type  = @\unspec@;
 
  // constructor and reset functions
  piecewise_linear_distribution();
@@ -6623,7 +6620,7 @@ Note that the exception is not mandated.
 namespace std {
   template<class T> class valarray {
   public:
-    typedef T value_type;
+    using value_type = T;
 
     // \ref{valarray.cons} construct/destroy:
     valarray();
@@ -7874,7 +7871,7 @@ by a \tcode{slice} object.
 namespace std {
   template <class T> class slice_array {
   public:
-    typedef T value_type;
+    using value_type = T;
 
     void operator=  (const valarray<T>&) const;
     void operator*= (const valarray<T>&) const;
@@ -8165,7 +8162,7 @@ are linear in the number of strides.
 namespace std {
   template <class T> class gslice_array {
   public:
-    typedef T value_type;
+    using value_type = T;
 
     void operator=  (const valarray<T>&) const;
     void operator*= (const valarray<T>&) const;
@@ -8298,7 +8295,7 @@ object refers.
 namespace std {
   template <class T> class mask_array {
   public:
-    typedef T value_type;
+    using value_type = T;
 
     void operator=  (const valarray<T>&) const;
     void operator*= (const valarray<T>&) const;
@@ -8426,7 +8423,7 @@ object refers.
 namespace std {
   template <class T> class indirect_array {
   public:
-    typedef T value_type;
+    using value_type = T;
 
     void operator=  (const valarray<T>&) const;
     void operator*= (const valarray<T>&) const;

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -92,7 +92,7 @@ satisfies these requirements.  \exitnote
 The class template \tcode{basic_regex}, defined in
 Clause~\ref{re.regex}, needs a set of related types and
 functions to complete the definition of its semantics. These types
-and functions are provided as a set of member typedefs and functions
+and functions are provided as a set of member \grammarterm{typedef-name}{s} and functions
 in the template parameter \tcode{traits} used by the \tcode{basic_regex} class
 template. This subclause defines the semantics of these
 members.
@@ -276,8 +276,8 @@ namespace std {
   // \ref{re.regex}, class template basic_regex:
   template <class charT, class traits = regex_traits<charT> > class basic_regex;
 
-  typedef basic_regex<char>    regex;
-  typedef basic_regex<wchar_t> wregex;
+  using regex  = basic_regex<char>;
+  using wregex = basic_regex<wchar_t>;
 
   // \ref{re.regex.swap}, basic_regex swap:
   template <class charT, class traits>
@@ -287,10 +287,10 @@ namespace std {
   template <class BidirectionalIterator> 
     class sub_match;
 
-  typedef sub_match<const char*>             csub_match;
-  typedef sub_match<const wchar_t*>          wcsub_match;
-  typedef sub_match<string::const_iterator>  ssub_match;
-  typedef sub_match<wstring::const_iterator> wssub_match;
+  using csub_match  = sub_match<const char*>;
+  using wcsub_match = sub_match<const wchar_t*>;
+  using ssub_match  = sub_match<string::const_iterator>;
+  using wssub_match = sub_match<wstring::const_iterator>;
 
   // \ref{re.submatch.op}, sub_match non-member operators:
   template <class BiIter>
@@ -454,10 +454,10 @@ namespace std {
             class Allocator = allocator<sub_match<BidirectionalIterator> > >
     class match_results;
 
-  typedef match_results<const char*>             cmatch;
-  typedef match_results<const wchar_t*>          wcmatch;
-  typedef match_results<string::const_iterator>  smatch;
-  typedef match_results<wstring::const_iterator> wsmatch;
+  using cmatch  = match_results<const char*>;
+  using wcmatch = match_results<const wchar_t*>;
+  using smatch  = match_results<string::const_iterator>;
+  using wsmatch = match_results<wstring::const_iterator>;
 
   // match_results comparisons
   template <class BidirectionalIterator, class Allocator>
@@ -619,10 +619,10 @@ namespace std {
             class traits = regex_traits<charT> >
     class regex_iterator;
 
-  typedef regex_iterator<const char*>             cregex_iterator;
-  typedef regex_iterator<const wchar_t*>          wcregex_iterator;
-  typedef regex_iterator<string::const_iterator>  sregex_iterator;
-  typedef regex_iterator<wstring::const_iterator> wsregex_iterator;
+  using cregex_iterator  = regex_iterator<const char*>;
+  using wcregex_iterator = regex_iterator<const wchar_t*>;
+  using sregex_iterator  = regex_iterator<string::const_iterator>;
+  using wsregex_iterator = regex_iterator<wstring::const_iterator>;
 
   // \ref{re.tokiter}, class template regex_token_iterator:
   template <class BidirectionalIterator, 
@@ -631,10 +631,10 @@ namespace std {
             class traits = regex_traits<charT> >
     class regex_token_iterator;
 
-  typedef regex_token_iterator<const char*>             cregex_token_iterator;
-  typedef regex_token_iterator<const wchar_t*>          wcregex_token_iterator;
-  typedef regex_token_iterator<string::const_iterator>  sregex_token_iterator;
-  typedef regex_token_iterator<wstring::const_iterator> wsregex_token_iterator;
+  using cregex_token_iterator  = regex_token_iterator<const char*>;
+  using wcregex_token_iterator = regex_token_iterator<const wchar_t*>;
+  using sregex_token_iterator  = regex_token_iterator<string::const_iterator>;
+  using wsregex_token_iterator = regex_token_iterator<wstring::const_iterator>;
 
   namespace pmr {
     template <class BidirectionalIterator>
@@ -642,10 +642,10 @@ namespace std {
         std::match_results<BidirectionalIterator,
                            polymorphic_allocator<sub_match<BidirectionalIterator>>>;
 
-    typedef match_results<const char*> cmatch;
-    typedef match_results<const wchar_t*> wcmatch;
-    typedef match_results<string::const_iterator> smatch;
-    typedef match_results<wstring::const_iterator> wsmatch;
+    using cmatch  = match_results<const char*>;
+    using wcmatch = match_results<const wchar_t*>;
+    using smatch  = match_results<string::const_iterator>;
+    using wsmatch = match_results<wstring::const_iterator>;
   }
 }
 \end{codeblock}
@@ -665,7 +665,7 @@ constants of these types.
 \indexlibrary{\idxcode{regex_constants}!\idxcode{syntax_option_type}}%
 \begin{codeblock}
 namespace std::regex_constants {
-  typedef @\textit{T1}@ syntax_option_type;
+  using syntax_option_type = @\textit{T1}@;
   constexpr syntax_option_type icase = @\unspec@;
   constexpr syntax_option_type nosubs = @\unspec@;
   constexpr syntax_option_type optimize = @\unspec@;
@@ -798,7 +798,7 @@ option in POSIX.
 \indexlibrary{\idxcode{format_first_only}}%
 \begin{codeblock}
 namespace std::regex_constants {
-  typedef @\textit{T2}@ match_flag_type;
+  using match_flag_type = @\textit{T2}@;
   constexpr match_flag_type match_default = {};
   constexpr match_flag_type match_not_bol = @\unspec@;
   constexpr match_flag_type match_not_eol = @\unspec@;
@@ -920,7 +920,7 @@ first occurrence of the regular expression shall be replaced.
 \indexlibrary{\idxcode{regex_constants}!\idxcode{error_type}}%
 \begin{codeblock}
 namespace std::regex_constants {
-  typedef @\textit{T3}@ error_type;
+  using error_type = @\textit{T3}@;
   constexpr error_type error_collate = @\unspec@;
   constexpr error_type error_ctype = @\unspec@;
   constexpr error_type error_escape = @\unspec@;
@@ -1050,10 +1050,10 @@ namespace std {
   template <class charT>
   struct regex_traits {
   public:
-     typedef charT                        char_type;
-     typedef std::basic_string<char_type> string_type;
-     typedef std::locale                  locale_type;
-     typedef @{\itshape bitmask_type}@                 char_class_type;
+     using char_type       = charT;
+     using string_type     = std::basic_string<char_type>;
+     using locale_type     = std::locale;
+     using char_class_type = @{\itshape bitmask_type}@;
 
      regex_traits();
      static std::size_t length(const char_type* p);
@@ -1089,7 +1089,7 @@ requirements for a regular expression traits class~(\ref{re.req}).
 \indexlibrary{\idxcode{regex_traits}!\idxcode{char_class_type}}%
 \indexlibrary{\idxcode{char_class_type}!\idxcode{regex_traits}}%
 \begin{itemdecl}
-typedef @\textit{bitmask_type}@                 char_class_type; 
+using char_class_type = @\textit{bitmask_type}@; 
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1372,11 +1372,11 @@ namespace std {
   class basic_regex {
   public:
     // types:
-    typedef          charT                                value_type;
-    typedef          traits                               traits_type;
-    typedef typename traits::string_type                  string_type;
-    typedef          regex_constants::syntax_option_type  flag_type;
-    typedef typename traits::locale_type                  locale_type;
+    using value_type  =          charT;
+    using traits_type =          traits;
+    using string_type = typename traits::string_type;
+    using flag_type   =          regex_constants::syntax_option_type;
+    using locale_type = typename traits::locale_type;
 
     // \ref{re.regex.const}, constants:
     static constexpr regex_constants::syntax_option_type
@@ -1918,12 +1918,12 @@ namespace std {
   template <class BidirectionalIterator>
   class sub_match : public std::pair<BidirectionalIterator, BidirectionalIterator> {
   public:
-     typedef typename iterator_traits<BidirectionalIterator>::
-       value_type                                               value_type;
-     typedef typename iterator_traits<BidirectionalIterator>::
-       difference_type                                          difference_type;
-     typedef BidirectionalIterator                              iterator;
-     typedef basic_string<value_type>                           string_type;
+     using value_type      =
+             typename iterator_traits<BidirectionalIterator>::value_type;
+     using difference_type =
+             typename iterator_traits<BidirectionalIterator>::difference_type;
+     using iterator        = BidirectionalIterator;
+     using string_type     = basic_string<value_type>;
 
      bool matched;
 
@@ -2605,18 +2605,18 @@ namespace std {
             class Allocator = allocator<sub_match<BidirectionalIterator>>>
   class match_results {
   public: 
-     typedef sub_match<BidirectionalIterator>                       value_type;
-     typedef const value_type&                                      const_reference;
-     typedef value_type&                                            reference;
-     typedef @{\impdef}@                                 const_iterator;
-     typedef const_iterator                                         iterator;
-     typedef typename
-      iterator_traits<BidirectionalIterator>::difference_type       difference_type;
-     typedef typename allocator_traits<Allocator>::size_type        size_type;
-     typedef Allocator                                              allocator_type;
-     typedef typename iterator_traits<BidirectionalIterator>::
-       value_type                                                   char_type;
-     typedef basic_string<char_type>                                string_type;
+     using value_type      = sub_match<BidirectionalIterator>;
+     using const_reference = const value_type&;
+     using reference       = value_type&;
+     using const_iterator  = @{\impdef}@;
+     using iterator        = const_iterator;
+     using difference_type =
+             typename iterator_traits<BidirectionalIterator>::difference_type;
+     using size_type       = typename allocator_traits<Allocator>::size_type;
+     using allocator_type  = Allocator;
+     using char_type       =
+             typename iterator_traits<BidirectionalIterator>::value_type;
+     using string_type     = basic_string<char_type>;
 
      // \ref{re.results.const}, construct/copy/destroy:
      explicit match_results(const Allocator& a = Allocator());
@@ -3670,13 +3670,13 @@ namespace std {
               class traits = regex_traits<charT> >
   class regex_iterator {
   public:
-     typedef basic_regex<charT, traits>           regex_type;
-     typedef match_results<BidirectionalIterator> value_type;
-     typedef std::ptrdiff_t                       difference_type;
-     typedef const value_type*                    pointer;
-     typedef const value_type&                    reference;
-     typedef std::forward_iterator_tag            iterator_category;
-   
+     using regex_type        = basic_regex<charT, traits>;
+     using iterator_category = std::forward_iterator_tag;
+     using value_type        = match_results<BidirectionalIterator>;
+     using difference_type   = std::ptrdiff_t;
+     using pointer           = const value_type*;
+     using reference         = const value_type&;
+
      regex_iterator();
      regex_iterator(BidirectionalIterator a, BidirectionalIterator b, 
                     const regex_type& re, 
@@ -3937,12 +3937,12 @@ namespace std {
               class traits = regex_traits<charT> >
   class regex_token_iterator  {
   public:
-    typedef basic_regex<charT, traits>       regex_type;
-    typedef sub_match<BidirectionalIterator> value_type;
-    typedef std::ptrdiff_t                   difference_type;
-    typedef const value_type*                pointer;
-    typedef const value_type&                reference;
-    typedef std::forward_iterator_tag        iterator_category;
+    using regex_type        = basic_regex<charT, traits>;
+    using iterator_category = std::forward_iterator_tag;
+    using value_type        = sub_match<BidirectionalIterator>;
+    using difference_type   = std::ptrdiff_t;
+    using pointer           = const value_type*;
+    using reference         = const value_type&;
 
     regex_token_iterator();
     regex_token_iterator(BidirectionalIterator a, BidirectionalIterator b, 
@@ -3996,13 +3996,13 @@ namespace std {
     regex_token_iterator& operator++();
     regex_token_iterator operator++(int);
   private:
-    typedef
-      regex_iterator<BidirectionalIterator, charT, traits> position_iterator; // \expos
-    position_iterator position;                                               // \expos
-    const value_type* result;                                                 // \expos
-    value_type suffix;                                                        // \expos
-    std::size_t N;                                                            // \expos
-    std::vector<int> subs;                                                    // \expos
+    using position_iterator =
+          regex_iterator<BidirectionalIterator, charT, traits>; // \expos
+    position_iterator position;                                 // \expos
+    const value_type* result;                                   // \expos
+    value_type suffix;                                          // \expos
+    std::size_t N;                                              // \expos
+    std::vector<int> subs;                                      // \expos
   };
 }
 \end{codeblock}

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -46,13 +46,11 @@ that satisfy those requirements.
 
 \pnum
 Most classes specified in Clauses~\ref{string.classes}
-and~\ref{input.output} need a set of related types and functions
-to complete the definition of their semantics.
-These types and functions are provided as a set of member typedefs
-and functions in the template parameter `traits' used by each such
-template.
-This subclause defines the semantics of these
-members.
+and~\ref{input.output} need a set of related types and functions to complete
+the definition of their semantics.  These types and functions are provided as a
+set of member \grammarterm{typedef-name}{s} and functions in the template
+parameter `traits' used by each such template.  This subclause defines the
+semantics of these members.
 
 \pnum
 To specialize those templates to generate a string or
@@ -211,7 +209,7 @@ as a basis for explicit specializations.
 \indexlibrary{\idxcode{char_type}!\idxcode{char_traits}}%
 \indexlibrary{\idxcode{char_traits}!\idxcode{char_type}}%
 \begin{itemdecl}
-typedef CHAR_T char_type;
+using char_type = CHAR_T;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -225,7 +223,7 @@ in the implementation of the library classes defined in~\ref{string.classes} and
 \indexlibrary{\idxcode{int_type}!\idxcode{char_traits}}%
 \indexlibrary{\idxcode{char_traits}!\idxcode{int_type}}%
 \begin{itemdecl}
-typedef INT_T int_type;
+using int_type = INT_T;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -256,8 +254,8 @@ then some iostreams operations may give surprising results.}
 \indexlibrary{\idxcode{pos_type}!\idxcode{char_traits}}%
 \indexlibrary{\idxcode{char_traits}!\idxcode{pos_type}}%
 \begin{itemdecl}
-typedef @\impdef@ off_type;
-typedef @\impdef@ pos_type;
+using off_type = @\impdef@;
+using pos_type = @\impdef@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -273,7 +271,7 @@ are described in~\ref{iostreams.limits.pos} and \ref{iostream.forward}.
 \indexlibrary{\idxcode{state_type}!\idxcode{char_traits}}%
 \indexlibrary{\idxcode{char_traits}!\idxcode{state_type}}%
 \begin{itemdecl}
-typedef STATE_T state_type;
+using state_type = STATE_T;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -320,11 +318,11 @@ Clause~\ref{char.traits.require}.
 \begin{codeblock}
 namespace std {
   template<> struct char_traits<char> {
-    typedef char        char_type;
-    typedef int         int_type;
-    typedef streamoff   off_type;
-    typedef streampos   pos_type;
-    typedef mbstate_t   state_type;
+    using char_type  = char;
+    using int_type   = int;
+    using off_type   = streamoff;
+    using pos_type   = streampos;
+    using state_type = mbstate_t;
 
     static void assign(char_type& c1, const char_type& c2) noexcept;
     static constexpr bool eq(char_type c1, char_type c2) noexcept;
@@ -404,11 +402,11 @@ shall return
 \begin{codeblock}
 namespace std {
   template<> struct char_traits<char16_t> {
-    typedef char16_t        char_type;
-    typedef uint_least16_t  int_type;
-    typedef streamoff       off_type;
-    typedef u16streampos    pos_type;
-    typedef mbstate_t       state_type;
+    using char_type  = char16_t;
+    using int_type   = uint_least16_t;
+    using off_type   = streamoff;
+    using pos_type   = u16streampos;
+    using state_type = mbstate_t;
 
     static void assign(char_type& c1, const char_type& c2) noexcept;
     static constexpr bool eq(char_type c1, char_type c2) noexcept;
@@ -454,11 +452,11 @@ as a valid UTF-16 code unit.
 \begin{codeblock}
 namespace std {
   template<> struct char_traits<char32_t> {
-    typedef char32_t        char_type;
-    typedef uint_least32_t  int_type;
-    typedef streamoff       off_type;
-    typedef u32streampos    pos_type;
-    typedef mbstate_t       state_type;
+    using char_type  = char32_t;
+    using int_type   = uint_least32_t;
+    using off_type   = streamoff;
+    using pos_type   = u32streampos;
+    using state_type = mbstate_t;
 
     static void assign(char_type& c1, const char_type& c2) noexcept;
     static constexpr bool eq(char_type c1, char_type c2) noexcept;
@@ -504,11 +502,11 @@ code point.
 \begin{codeblock}
 namespace std {
   template<> struct char_traits<wchar_t> {
-    typedef wchar_t      char_type;
-    typedef wint_t       int_type;
-    typedef streamoff    off_type;
-    typedef wstreampos   pos_type;
-    typedef mbstate_t    state_type;
+    using char_type  = wchar_t;
+    using int_type   = wint_t;
+    using off_type   = streamoff;
+    using pos_type   = wstreampos;
+    using state_type = mbstate_t;
 
     static void assign(char_type& c1, const char_type& c2) noexcept;
     static constexpr bool eq(char_type c1, char_type c2) noexcept;
@@ -584,7 +582,7 @@ shall return
 The header \tcode{<string>} defines the
 \tcode{basic_string} class template for manipulating
 varying-length sequences of char-like objects and four
-typedefs, \tcode{string},
+\grammarterm{typedef-name}{s}, \tcode{string},
 \tcode{u16string},
 \tcode{u32string},
 and \tcode{wstring}, that name
@@ -752,10 +750,10 @@ namespace std {
               basic_string<charT,traits,Allocator>& str);
 
   // \tcode{basic_string} typedef names
-  typedef basic_string<char> string;
-  typedef basic_string<char16_t> u16string;
-  typedef basic_string<char32_t> u32string;
-  typedef basic_string<wchar_t> wstring;
+  using string    = basic_string<char>;
+  using u16string = basic_string<char16_t>;
+  using u32string = basic_string<char32_t>;
+  using wstring   = basic_string<wchar_t>;
 
   // \ref{string.conversions}, numeric conversions:
   int stoi(const string& str, size_t* idx = 0, int base = 10);
@@ -806,10 +804,10 @@ namespace std {
       using basic_string =
         std::basic_string<charT, traits, polymorphic_allocator<charT>>;
 
-    typedef basic_string<char> string;
-    typedef basic_string<char16_t> u16string;
-    typedef basic_string<char32_t> u32string;
-    typedef basic_string<wchar_t> wstring;
+    using string    = basic_string<char>;
+    using u16string = basic_string<char16_t>;
+    using u32string = basic_string<char32_t>;
+    using wstring   = basic_string<wchar_t>;
   }
 
   inline namespace literals {
@@ -885,22 +883,21 @@ namespace std {
   class basic_string {
   public:
     // types:
-    typedef          traits                                         traits_type;
-    typedef typename traits::char_type                              value_type;
-    typedef          Allocator                                      allocator_type;
-    typedef typename allocator_traits<Allocator>::size_type         size_type;
-    typedef typename allocator_traits<Allocator>::difference_type   difference_type;
+    using traits_type            =          traits;
+    using value_type             = typename traits::char_type;
+    using allocator_type         = Allocator;
+    using size_type              = typename allocator_traits<Allocator>::size_type;
+    using difference_type        = typename allocator_traits<Allocator>::difference_type;
+    using pointer                = typename allocator_traits<Allocator>::pointer;
+    using const_pointer          = typename allocator_traits<Allocator>::const_pointer;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
 
-    typedef value_type&                                             reference;
-    typedef const value_type&                                       const_reference;
-    typedef typename allocator_traits<Allocator>::pointer           pointer;
-    typedef typename allocator_traits<Allocator>::const_pointer     const_pointer;
-
-    typedef @\impdefnc@                iterator;       // See \ref{container.requirements}
-    typedef @\impdefnc@                const_iterator; // See \ref{container.requirements}
-    typedef std::reverse_iterator<iterator>       reverse_iterator;
-    typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
-    static const size_type npos = -1;
+    using iterator               = @\impdef@; // See \ref{container.requirements}
+    using const_iterator         = @\impdef@; // See \ref{container.requirements}
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+    static const size_type npos  = -1;
 
     // \ref{string.cons}, construct/copy/destroy:
     basic_string() noexcept(noexcept(Allocator())) : basic_string(Allocator()) { }
@@ -4434,10 +4431,10 @@ namespace std {
                  basic_string_view<charT, traits> str);
 
   // \tcode{basic_string_view} typedef names
-  typedef basic_string_view<char> string_view;
-  typedef basic_string_view<char16_t> u16string_view;
-  typedef basic_string_view<char32_t> u32string_view;
-  typedef basic_string_view<wchar_t> wstring_view;
+  using string_view    = basic_string_view<char>;
+  using u16string_view = basic_string_view<char16_t>;
+  using u32string_view = basic_string_view<char32_t>;
+  using wstring_view   = basic_string_view<wchar_t>;
 
   // \ref{string.view.hash}, hash support
   template<class T> struct hash;
@@ -4460,18 +4457,18 @@ template<class charT, class traits = char_traits<charT>>
 class basic_string_view {
 public:
   // types
-  typedef traits traits_type;
-  typedef charT value_type;
-  typedef charT* pointer;
-  typedef const charT* const_pointer;
-  typedef charT& reference;
-  typedef const charT& const_reference;
-  typedef @\impdefx{type of \tcode{basic_string_view::const_iterator}}@ const_iterator; // see \ref{string.view.iterators}
-  typedef const_iterator iterator;@\footnote{Because \tcode{basic_string_view} refers to a constant sequence, \tcode{iterator} and \tcode{const_iterator} are the same type.}@
-  typedef reverse_iterator<const_iterator> const_reverse_iterator;
-  typedef const_reverse_iterator reverse_iterator;
-  typedef size_t size_type;
-  typedef ptrdiff_t difference_type;
+  using traits_type            = traits;
+  using value_type             = charT;
+  using pointer                = charT*;
+  using const_pointer          = const charT*;
+  using reference              = charT&;
+  using const_reference        = const charT&;
+  using const_iterator         = @\impdefx{type of \tcode{basic_string_view::const_iterator}}@; // see \ref{string.view.iterators}
+  using iterator               = const_iterator;@\footnote{Because \tcode{basic_string_view} refers to a constant sequence, \tcode{iterator} and \tcode{const_iterator} are the same type.}@
+  using const_reverse_iterator = reverse_iterator<const_iterator>;
+  using reverse_iterator       = const_reverse_iterator;
+  using size_type              = size_t;
+  using difference_type        = ptrdiff_t;
   static constexpr size_type npos = size_type(-1);
 
   // \ref{string.view.cons}, construction and assignment
@@ -4643,7 +4640,7 @@ Constructs a \tcode{basic_string_view}, with the postconditions in table~\ref{ta
 \rSec3[string.view.iterators]{Iterator support}
 
 \begin{itemdecl}
-typedef @\impdef@ const_iterator;
+using const_iterator = @\impdef@;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/support.tex
+++ b/source/support.tex
@@ -129,7 +129,7 @@ requirement is supported in every context.
 
 \begin{codeblock}
 namespace std {
-  typedef decltype(nullptr) nullptr_t;
+  using nullptr_t = decltype(nullptr);
 }
 \end{codeblock}
 
@@ -1207,41 +1207,41 @@ The contents are the same as the Standard C library header
 
 \begin{codeblock}
 namespace std {
-  typedef @\textit{signed integer type}@ int8_t;   // optional
-  typedef @\textit{signed integer type}@ int16_t;  // optional
-  typedef @\textit{signed integer type}@ int32_t;  // optional
-  typedef @\textit{signed integer type}@ int64_t;  // optional
+  using int8_t         = @\textit{signed integer type}@;  // optional
+  using int16_t        = @\textit{signed integer type}@;  // optional
+  using int32_t        = @\textit{signed integer type}@;  // optional
+  using int64_t        = @\textit{signed integer type}@;  // optional
 
-  typedef @\textit{signed integer type}@ int_fast8_t;
-  typedef @\textit{signed integer type}@ int_fast16_t;
-  typedef @\textit{signed integer type}@ int_fast32_t;
-  typedef @\textit{signed integer type}@ int_fast64_t;
+  using int_fast8_t    = @\textit{signed integer type}@;
+  using int_fast16_t   = @\textit{signed integer type}@;
+  using int_fast32_t   = @\textit{signed integer type}@;
+  using int_fast64_t   = @\textit{signed integer type}@;
 
-  typedef @\textit{signed integer type}@ int_least8_t;
-  typedef @\textit{signed integer type}@ int_least16_t;
-  typedef @\textit{signed integer type}@ int_least32_t;
-  typedef @\textit{signed integer type}@ int_least64_t;
+  using int_least8_t   = @\textit{signed integer type}@;
+  using int_least16_t  = @\textit{signed integer type}@;
+  using int_least32_t  = @\textit{signed integer type}@;
+  using int_least64_t  = @\textit{signed integer type}@;
 
-  typedef @\textit{signed integer type}@ intmax_t;
-  typedef @\textit{signed integer type}@ intptr_t;         // optional
+  using intmax_t       = @\textit{signed integer type}@;
+  using intptr_t       = @\textit{signed integer type}@;   // optional
 
-  typedef @\textit{unsigned integer type}@ uint8_t;        // optional
-  typedef @\textit{unsigned integer type}@ uint16_t;       // optional
-  typedef @\textit{unsigned integer type}@ uint32_t;       // optional
-  typedef @\textit{unsigned integer type}@ uint64_t;       // optional
+  using uint8_t        = @\textit{unsigned integer type}@; // optional
+  using uint16_t       = @\textit{unsigned integer type}@; // optional
+  using uint32_t       = @\textit{unsigned integer type}@; // optional
+  using uint64_t       = @\textit{unsigned integer type}@; // optional
 
-  typedef @\textit{unsigned integer type}@ uint_fast8_t;
-  typedef @\textit{unsigned integer type}@ uint_fast16_t;
-  typedef @\textit{unsigned integer type}@ uint_fast32_t;
-  typedef @\textit{unsigned integer type}@ uint_fast64_t;
+  using uint_fast8_t   = @\textit{unsigned integer type}@;
+  using uint_fast16_t  = @\textit{unsigned integer type}@;
+  using uint_fast32_t  = @\textit{unsigned integer type}@;
+  using uint_fast64_t  = @\textit{unsigned integer type}@;
 
-  typedef @\textit{unsigned integer type}@ uint_least8_t;
-  typedef @\textit{unsigned integer type}@ uint_least16_t;
-  typedef @\textit{unsigned integer type}@ uint_least32_t;
-  typedef @\textit{unsigned integer type}@ uint_least64_t;
+  using uint_least8_t  = @\textit{unsigned integer type}@;
+  using uint_least16_t = @\textit{unsigned integer type}@;
+  using uint_least32_t = @\textit{unsigned integer type}@;
+  using uint_least64_t = @\textit{unsigned integer type}@;
 
-  typedef @\textit{unsigned integer type}@ uintmax_t;
-  typedef @\textit{unsigned integer type}@ uintptr_t;      // optional
+  using uintmax_t      = @\textit{unsigned integer type}@;
+  using uintptr_t      = @\textit{unsigned integer type}@; // optional
 } // namespace std
 \end{codeblock}
 
@@ -1518,7 +1518,7 @@ namespace std {
   class bad_array_new_length;
   struct nothrow_t {};
   extern const nothrow_t nothrow;
-  typedef void (*new_handler)();
+  using new_handler = void (*)();
   new_handler get_new_handler() noexcept;
   new_handler set_new_handler(new_handler new_p) noexcept;
 
@@ -2185,7 +2185,7 @@ suitable for conversion and display as a
 
 \indexlibrary{\idxcode{new_handler}}%
 \begin{itemdecl}
-typedef void (*new_handler)();
+using new_handler = void (*)();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2590,12 +2590,12 @@ namespace std {
   class bad_exception;
   class nested_exception;
 
-  typedef void (*unexpected_handler)();
+  using unexpected_handler = void (*)();
   unexpected_handler get_unexpected() noexcept;
   unexpected_handler set_unexpected(unexpected_handler f) noexcept;
   [[noreturn]] void unexpected();
 
-  typedef void (*terminate_handler)();
+  using terminate_handler = void (*)();
   terminate_handler get_terminate() noexcept;
   terminate_handler set_terminate(terminate_handler f) noexcept;
   [[noreturn]] void terminate() noexcept;
@@ -2604,7 +2604,7 @@ namespace std {
   // \ref{depr.uncaught}, uncaught_exception (deprecated)
   bool uncaught_exception() noexcept;
 
-  typedef @\unspec@ exception_ptr;
+  using exception_ptr = @\unspec@;
 
   exception_ptr current_exception() noexcept;
   [[noreturn]] void rethrow_exception(exception_ptr p);
@@ -2784,7 +2784,7 @@ suitable for conversion and display as a
 
 \indexlibrary{\idxcode{terminate_handler}}%
 \begin{itemdecl}
-typedef void (*terminate_handler)();
+using terminate_handler = void (*)();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2889,7 +2889,7 @@ throwing an exception can result in a call of\\
 
 \indexlibrary{\idxcode{exception_ptr}}
 \begin{itemdecl}
-typedef @\unspec@ exception_ptr;
+using exception_ptr = @\unspec@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3114,7 +3114,7 @@ namespace std {
 namespace std {
   class exception_list : public exception {
   public:
-    typedef @\unspec@ iterator;
+    using iterator = @\unspec@;
 
     size_t size() const noexcept;
     iterator begin() const noexcept;
@@ -3207,13 +3207,13 @@ support functions related to list-initialization~(see \ref{dcl.init.list}).
 namespace std {
   template<class E> class initializer_list {
   public:
-    typedef E value_type;
-    typedef const E& reference;
-    typedef const E& const_reference;
-    typedef size_t size_type;
+    using value_type      = E;
+    using reference       = const E&;
+    using const_reference = const E&;
+    using size_type       = size_t;
 
-    typedef const E* iterator;
-    typedef const E* const_iterator;
+    using iterator        = const E*;
+    using const_iterator  = const E*;
 
     constexpr initializer_list() noexcept;
 

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -327,7 +327,7 @@ namespace std {
   public:
     // types:
     class id;
-    typedef @\impdef@ native_handle_type; // See~\ref{thread.req.native}
+    using native_handle_type = @\impdef@; // See~\ref{thread.req.native}
 
     // construct/copy/destroy:
     thread() noexcept;
@@ -1039,7 +1039,7 @@ namespace std {
     bool try_lock();
     void unlock();
 
-    typedef @\impdef@ native_handle_type; // See~\ref{thread.req.native}
+    using native_handle_type = @\impdef@; // See~\ref{thread.req.native}
     native_handle_type native_handle();                // See~\ref{thread.req.native}
   };
 }
@@ -1093,7 +1093,7 @@ namespace std {
     bool try_lock() noexcept;
     void unlock();
 
-    typedef @\impdef@ native_handle_type; // See~\ref{thread.req.native}
+    using native_handle_type = @\impdef@; // See~\ref{thread.req.native}
     native_handle_type native_handle();                // See~\ref{thread.req.native}
   };
 }
@@ -1232,7 +1232,7 @@ namespace std {
       bool try_lock_until(const chrono::time_point<Clock, Duration>& abs_time);
     void unlock();
 
-    typedef @\impdef@ native_handle_type; // See~\ref{thread.req.native}
+    using native_handle_type = @\impdef@; // See~\ref{thread.req.native}
     native_handle_type native_handle();                // See~\ref{thread.req.native}
   };
 }
@@ -1282,7 +1282,7 @@ namespace std {
       bool try_lock_until(const chrono::time_point<Clock, Duration>& abs_time);
     void unlock();
 
-    typedef @\impdef@ native_handle_type; // See~\ref{thread.req.native}
+    using native_handle_type = @\impdef@; // See~\ref{thread.req.native}
     native_handle_type native_handle();                // See~\ref{thread.req.native}
   };
 }
@@ -1453,8 +1453,8 @@ namespace std {
      bool try_lock_shared();
      void unlock_shared();
 
-     typedef @\impdef@ native_handle_type; // See \ref{thread.req.native}
-     native_handle_type native_handle(); // See \ref{thread.req.native}
+     using native_handle_type = @\impdef@; // See~\ref{thread.req.native}
+     native_handle_type native_handle();                // See~\ref{thread.req.native}
   };
 }
 \end{codeblock}
@@ -1659,7 +1659,7 @@ namespace std {
   template <class... MutexTypes>
   class lock_guard {
   public:
-    typedef Mutex mutex_type;  // If \tcode{MutexTypes...} consists of the single type \tcode{Mutex}
+    using mutex_type = Mutex;  // If \tcode{MutexTypes...} consists of the single type \tcode{Mutex}
 
     explicit lock_guard(MutexTypes&... m);
     lock_guard(MutexTypes&... m, adopt_lock_t);
@@ -1738,7 +1738,7 @@ namespace std {
   template <class Mutex>
   class unique_lock {
   public:
-    typedef Mutex mutex_type;
+    using mutex_type = Mutex;
 
     // \ref{thread.lock.unique.cons}, construct/copy/destroy:
     unique_lock() noexcept;
@@ -2172,7 +2172,7 @@ namespace std {
 template <class Mutex>
 class shared_lock {
 public:
-  typedef Mutex mutex_type;
+  using mutex_type = Mutex;
 
   // Shared locking
   shared_lock() noexcept;
@@ -2865,7 +2865,7 @@ namespace std {
                     const chrono::duration<Rep, Period>& rel_time,
                     Predicate pred);
 
-    typedef @\impdef@ native_handle_type; // See~\ref{thread.req.native}
+    using native_handle_type = @\impdef@; // See~\ref{thread.req.native}
     native_handle_type native_handle();                // See~\ref{thread.req.native}
   };
 }

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -503,7 +503,7 @@ an integer sequence of type \tcode{size_t}.
 namespace std {
   template<class T, T... I>
   struct integer_sequence {
-    typedef T value_type;
+    using value_type = T;
     static constexpr size_t size() noexcept { return sizeof...(I); }
   };
 }
@@ -554,8 +554,8 @@ and~\ref{tuple.elem}).%
 namespace std {
   template <class T1, class T2>
   struct pair {
-    typedef T1 first_type;
-    typedef T2 second_type;
+    using first_type  = T1;
+    using second_type = T2;
 
     T1 first;
     T2 second;
@@ -1819,7 +1819,7 @@ class tuple_size<tuple<Types...>>
 template <size_t I, class... Types>
 class tuple_element<I, tuple<Types...>> {
 public:
-  typedef TI type;
+  using type = TI;
 };
 \end{itemdecl}
 
@@ -2209,7 +2209,7 @@ a reference type, or for possibly cv-qualified types \tcode{in_place_t} or
 \begin{codeblock}
 template <class T> class optional {
 public:
-  typedef T value_type;
+  using value_type = T;
 
   // \ref{optional.object.ctor}, constructors
   constexpr optional() noexcept;
@@ -4871,9 +4871,9 @@ attributes of pointer-like types.
 \begin{codeblock}
 namespace std {
   template <class Ptr> struct pointer_traits {
-    typedef Ptr @\itcorr@      pointer;
-    typedef @\seebelow@ element_type;
-    typedef @\seebelow@ difference_type;
+    using pointer         = Ptr;
+    using element_type    = @\seebelow@;
+    using difference_type = @\seebelow@;
 
     template <class U> using rebind = @\seebelow@;
 
@@ -4881,9 +4881,9 @@ namespace std {
   };
 
   template <class T> struct pointer_traits<T*> {
-    typedef T*        pointer;
-    typedef T         element_type;
-    typedef ptrdiff_t difference_type;
+    using pointer         = T*;
+    using element_type    = T;
+    using difference_type = ptrdiff_t;
 
     template <class U> using rebind = U*;
 
@@ -4897,7 +4897,7 @@ namespace std {
 \indexlibrary{\idxcode{pointer_traits}!\idxcode{element_type}}%
 \indexlibrary{\idxcode{element_type}!\idxcode{pointer_traits}}%
 \begin{itemdecl}
-typedef @\seebelow@ element_type;
+using element_type = @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4913,7 +4913,7 @@ ill-formed.
 \indexlibrary{\idxcode{pointer_traits}!\idxcode{difference_type}}%
 \indexlibrary{\idxcode{difference_type}!\idxcode{pointer_traits}}%
 \begin{itemdecl}
-typedef @\seebelow@ difference_type;
+using difference_type = @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5213,22 +5213,22 @@ a derived class from an allocator. \exitnote
 \begin{codeblock}
 namespace std {
   template <class Alloc> struct allocator_traits {
-    typedef Alloc allocator_type;
+    using allocator_type     = Alloc;
 
-    typedef typename Alloc::value_type value_type;
+    using value_type         = typename Alloc::value_type;
 
-    typedef @\seebelow@ pointer;
-    typedef @\seebelow@ const_pointer;
-    typedef @\seebelow@ void_pointer;
-    typedef @\seebelow@ const_void_pointer;
+    using pointer            = @\seebelow@;
+    using const_pointer      = @\seebelow@;
+    using void_pointer       = @\seebelow@;
+    using const_void_pointer = @\seebelow@;
 
-    typedef @\seebelow@ difference_type;
-    typedef @\seebelow@ size_type;
+    using difference_type    = @\seebelow@;
+    using size_type          = @\seebelow@;
 
-    typedef @\seebelow@ propagate_on_container_copy_assignment;
-    typedef @\seebelow@ propagate_on_container_move_assignment;
-    typedef @\seebelow@ propagate_on_container_swap;
-    typedef @\seebelow@ is_always_equal;
+    using propagate_on_container_copy_assignment = @\seebelow@;
+    using propagate_on_container_move_assignment = @\seebelow@;
+    using propagate_on_container_swap            = @\seebelow@;
+    using is_always_equal                        = @\seebelow@;
 
     template <class T> using rebind_alloc = @\seebelow@;
     template <class T> using rebind_traits = allocator_traits<rebind_alloc<T>>;
@@ -5256,7 +5256,7 @@ namespace std {
 \indexlibrary{\idxcode{allocator_traits}!\idxcode{pointer}}%
 \indexlibrary{\idxcode{pointer}!\idxcode{allocator_traits}}%
 \begin{itemdecl}
-typedef @\seebelow@ pointer;
+using pointer = @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5269,7 +5269,7 @@ type~(\ref{temp.deduct}); otherwise, \tcode{value_type*}.
 \indexlibrary{\idxcode{allocator_traits}!\idxcode{const_pointer}}%
 \indexlibrary{\idxcode{const_pointer}!\idxcode{allocator_traits}}%
 \begin{itemdecl}
-typedef @\seebelow@ const_pointer;
+using const_pointer = @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5283,7 +5283,7 @@ type~(\ref{temp.deduct}); otherwise,
 \indexlibrary{\idxcode{allocator_traits}!\idxcode{void_pointer}}%
 \indexlibrary{\idxcode{void_pointer}!\idxcode{allocator_traits}}%
 \begin{itemdecl}
-typedef @\seebelow@ void_pointer;
+using void_pointer = @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5297,7 +5297,7 @@ type~(\ref{temp.deduct}); otherwise,
 \indexlibrary{\idxcode{allocator_traits}!\idxcode{const_void_pointer}}%
 \indexlibrary{\idxcode{const_void_pointer}!\idxcode{allocator_traits}}%
 \begin{itemdecl}
-typedef @\seebelow@ const_void_pointer;
+using const_void_pointer = @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5311,7 +5311,7 @@ type~(\ref{temp.deduct}); otherwise,
 \indexlibrary{\idxcode{allocator_traits}!\idxcode{difference_type}}%
 \indexlibrary{\idxcode{difference_type}!\idxcode{allocator_traits}}%
 \begin{itemdecl}
-typedef @\seebelow@ difference_type;
+using difference_type = @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5325,7 +5325,7 @@ type~(\ref{temp.deduct}); otherwise,
 \indexlibrary{\idxcode{allocator_traits}!\idxcode{size_type}}%
 \indexlibrary{\idxcode{size_type}!\idxcode{allocator_traits}}%
 \begin{itemdecl}
-typedef @\seebelow@ size_type;
+using size_type = @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5339,7 +5339,7 @@ type~(\ref{temp.deduct}); otherwise,
 \indexlibrary{\idxcode{allocator_traits}!\idxcode{propagate_on_container_copy_assignment}}%
 \indexlibrary{\idxcode{propagate_on_container_copy_assignment}!\idxcode{allocator_traits}}%
 \begin{itemdecl}
-typedef @\seebelow@ propagate_on_container_copy_assignment;
+using propagate_on_container_copy_assignment = @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5353,7 +5353,7 @@ type~(\ref{temp.deduct}); otherwise
 \indexlibrary{\idxcode{allocator_traits}!\idxcode{propagate_on_container_move_assignment}}%
 \indexlibrary{\idxcode{propagate_on_container_move_assignment}!\idxcode{allocator_traits}}%
 \begin{itemdecl}
-typedef @\seebelow@ propagate_on_container_move_assignment;
+using propagate_on_container_move_assignment = @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5367,7 +5367,7 @@ type~(\ref{temp.deduct}); otherwise
 \indexlibrary{\idxcode{allocator_traits}!\idxcode{propagate_on_container_swap}}%
 \indexlibrary{\idxcode{propagate_on_container_swap}!\idxcode{allocator_traits}}%
 \begin{itemdecl}
-typedef @\seebelow@ propagate_on_container_swap;
+using propagate_on_container_swap = @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5381,7 +5381,7 @@ type~(\ref{temp.deduct}); otherwise
 \indexlibrary{\idxcode{allocator_traits}!\idxcode{is_always_equal}}%
 \indexlibrary{\idxcode{is_always_equal}!\idxcode{allocator_traits}}%
 \begin{itemdecl}
-typedef @\seebelow@ is_always_equal;
+using is_always_equal = @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5509,25 +5509,25 @@ namespace std {
   // specialize for \tcode{void}:
   template <> class allocator<void> {
   public:
-    typedef void*   pointer;
-    typedef const void* const_pointer;
+    using pointer       = void*;
+    using const_pointer = const void*;
     // reference-to-\tcode{void} members are impossible.
-    typedef void  value_type;
-    template <class U> struct rebind { typedef allocator<U> other; };
+    using value_type    = void;
+    template <class U> struct rebind { using other = allocator<U>; };
   };
 
   template <class T> class allocator {
    public:
-    typedef size_t    size_type;
-    typedef ptrdiff_t difference_type;
-    typedef T*        pointer;
-    typedef const T*  const_pointer;
-    typedef T&        reference;
-    typedef const T&  const_reference;
-    typedef T         value_type;
-    template <class U> struct rebind { typedef allocator<U> other; };
-    typedef true_type propagate_on_container_move_assignment;
-    typedef true_type is_always_equal;
+    using value_type      = T;
+    using size_type       = size_t;
+    using difference_type = ptrdiff_t;
+    using pointer         = T*;
+    using const_pointer   = const T*;
+    using reference       = T&;
+    using const_reference = const T&;
+    template <class U> struct rebind { using other = allocator<U>; };
+    using propagate_on_container_move_assignment = true_type;
+    using is_always_equal = true_type;
 
     allocator() noexcept;
     allocator(const allocator&) noexcept;
@@ -5719,11 +5719,11 @@ namespace std {
   template <class OutputIterator, class T>
   class raw_storage_iterator {
   public:
-    typedef output_iterator_tag iterator_category;
-    typedef void value_type;
-    typedef void difference_type;
-    typedef void pointer;
-    typedef void reference;
+    using iterator_category = output_iterator_tag;
+    using value_type        = void;
+    using difference_type   = void;
+    using pointer           = void;
+    using reference         = void;
 
     explicit raw_storage_iterator(OutputIterator x);
 
@@ -6295,9 +6295,9 @@ unless \tcode{U(*)[]} is convertible to \tcode{T(*)[]}.
 namespace std {
   template <class T, class D = default_delete<T>> class unique_ptr {
   public:
-    typedef @\seebelow@ pointer;
-    typedef T element_type;
-    typedef D deleter_type;
+    using pointer      = @\seebelow@;
+    using element_type = T;
+    using deleter_type = D;
 
     // \ref{unique.ptr.single.ctor}, constructors
     constexpr unique_ptr() noexcept;
@@ -6816,9 +6816,9 @@ deleters of \tcode{*this} and \tcode{u}.
 namespace std {
   template <class T, class D> class unique_ptr<T[], D> {
   public:
-    typedef @\seebelow@ pointer;
-    typedef T element_type;
-    typedef D deleter_type;
+    using pointer      = @\seebelow@;
+    using element_type = T;
+    using deleter_type = D;
 
     // \ref{unique.ptr.runtime.ctor}, constructors
     constexpr unique_ptr() noexcept;
@@ -7304,7 +7304,7 @@ the object, or otherwise releasing the resources associated with the stored poin
 namespace std {
   template<class T> class shared_ptr {
   public:
-    typedef T element_type;
+    using element_type = T;
 
     // \ref{util.smartptr.shared.const}, constructors:
     constexpr shared_ptr() noexcept;
@@ -8169,7 +8169,7 @@ function \tcode{lock}.
 namespace std {
   template<class T> class weak_ptr {
   public:
-    typedef T element_type;
+    using element_type = T;
 
     // \ref{util.smartptr.weak.const}, constructors
     constexpr weak_ptr() noexcept;
@@ -8424,7 +8424,7 @@ namespace std {
     template<class T, class U>
       bool operator()(weak_ptr<T> const&, weak_ptr<U> const&) const;
 
-    typedef @\unspec@ is_transparent;
+    using is_transparent = @\unspec@;
   };
 }
 \end{codeblock}
@@ -9012,7 +9012,7 @@ class polymorphic_allocator {
   memory_resource* memory_rsrc; // \expos
 
 public:
-  typedef Tp value_type;
+  using value_type = Tp;
 
   // \ref{memory.polymorphic.allocator.ctor}, constructors:
   polymorphic_allocator() noexcept;
@@ -10366,7 +10366,7 @@ namespace std {
   template <class T> class reference_wrapper {
   public :
     // types
-    typedef T type;
+    using type = T;
 
     // construct/copy/destroy
     reference_wrapper(T&) noexcept;
@@ -10602,7 +10602,7 @@ template <> struct plus<void> {
   template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) + std::forward<U>(u));
 
-  typedef @\unspec@ is_transparent;
+  using is_transparent = @\unspec@;
 };
 \end{itemdecl}
 
@@ -10617,7 +10617,7 @@ template <> struct minus<void> {
   template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) - std::forward<U>(u));
 
-  typedef @\unspec@ is_transparent;
+  using is_transparent = @\unspec@;
 };
 \end{itemdecl}
 
@@ -10632,7 +10632,7 @@ template <> struct multiplies<void> {
   template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) * std::forward<U>(u));
 
-  typedef @\unspec@ is_transparent;
+  using is_transparent = @\unspec@;
 };
 \end{itemdecl}
 
@@ -10647,7 +10647,7 @@ template <> struct divides<void> {
   template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) / std::forward<U>(u));
 
-  typedef @\unspec@ is_transparent;
+  using is_transparent = @\unspec@;
 };
 \end{itemdecl}
 
@@ -10662,7 +10662,7 @@ template <> struct modulus<void> {
   template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) % std::forward<U>(u));
 
-  typedef @\unspec@ is_transparent;
+  using is_transparent = @\unspec@;
 };
 \end{itemdecl}
 
@@ -10677,7 +10677,7 @@ template <> struct negate<void> {
   template <class T> constexpr auto operator()(T&& t) const
     -> decltype(-std::forward<T>(t));
 
-  typedef @\unspec@ is_transparent;
+  using is_transparent = @\unspec@;
 };
 \end{itemdecl}
 
@@ -10771,7 +10771,7 @@ template <> struct equal_to<void> {
   template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) == std::forward<U>(u));
 
-  typedef @\unspec@ is_transparent;
+  using is_transparent = @\unspec@;
 };
 \end{itemdecl}
 
@@ -10786,7 +10786,7 @@ template <> struct not_equal_to<void> {
   template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) != std::forward<U>(u));
 
-  typedef @\unspec@ is_transparent;
+  using is_transparent = @\unspec@;
 };
 \end{itemdecl}
 
@@ -10801,7 +10801,7 @@ template <> struct greater<void> {
   template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) > std::forward<U>(u));
 
-  typedef @\unspec@ is_transparent;
+  using is_transparent = @\unspec@;
 };
 \end{itemdecl}
 
@@ -10816,7 +10816,7 @@ template <> struct less<void> {
   template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) < std::forward<U>(u));
 
-  typedef @\unspec@ is_transparent;
+  using is_transparent = @\unspec@;
 };
 \end{itemdecl}
 
@@ -10831,7 +10831,7 @@ template <> struct greater_equal<void> {
   template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) >= std::forward<U>(u));
 
-  typedef @\unspec@ is_transparent;
+  using is_transparent = @\unspec@;
 };
 \end{itemdecl}
 
@@ -10846,7 +10846,7 @@ template <> struct less_equal<void> {
   template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) <= std::forward<U>(u));
 
-  typedef @\unspec@ is_transparent;
+  using is_transparent = @\unspec@;
 };
 \end{itemdecl}
 
@@ -10913,7 +10913,7 @@ template <> struct logical_and<void> {
   template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) && std::forward<U>(u));
 
-  typedef @\unspec@ is_transparent;
+  using is_transparent = @\unspec@;
 };
 \end{itemdecl}
 
@@ -10928,7 +10928,7 @@ template <> struct logical_or<void> {
   template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) || std::forward<U>(u));
 
-  typedef @\unspec@ is_transparent;
+  using is_transparent = @\unspec@;
 };
 \end{itemdecl}
 
@@ -10943,7 +10943,7 @@ template <> struct logical_not<void> {
   template <class T> constexpr auto operator()(T&& t) const
     -> decltype(!std::forward<T>(t));
 
-  typedef @\unspec@ is_transparent;
+  using is_transparent = @\unspec@;
 };
 \end{itemdecl}
 
@@ -11013,7 +11013,7 @@ template <> struct bit_and<void> {
   template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) & std::forward<U>(u));
 
-  typedef @\unspec@ is_transparent;
+  using is_transparent = @\unspec@;
 };
 \end{itemdecl}
 
@@ -11028,7 +11028,7 @@ template <> struct bit_or<void> {
   template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) | std::forward<U>(u));
 
-  typedef @\unspec@ is_transparent;
+  using is_transparent = @\unspec@;
 };
 \end{itemdecl}
 
@@ -11043,7 +11043,7 @@ template <> struct bit_xor<void> {
   template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) ^ std::forward<U>(u));
 
-  typedef @\unspec@ is_transparent;
+  using is_transparent = @\unspec@;
 };
 \end{itemdecl}
 
@@ -11058,7 +11058,7 @@ template <> struct bit_not<void> {
   template <class T> constexpr auto operator()(T&& t) const
     -> decltype(~std::forward<T>(t));
 
-  typedef @\unspec@ is_transparent;
+  using is_transparent = @\unspec@;
 };
 \end{itemdecl}
 
@@ -11388,7 +11388,7 @@ namespace std {
   template<class R, class... ArgTypes>
   class function<R(ArgTypes...)> {
   public:
-    typedef R result_type;
+    using result_type = R;
 
     // \ref{func.wrap.func.con}, construct/copy/destroy:
     function() noexcept;
@@ -12252,8 +12252,8 @@ namespace std {
 
   template <bool B>
     using bool_constant = integral_constant<bool, B>;
-  typedef bool_constant<true> true_type;
-  typedef bool_constant<false> false_type;
+  using true_type  = bool_constant<true>;
+  using false_type = bool_constant<false>;
 
   // \ref{meta.unary.cat}, primary type categories:
   template <class T> struct is_void;
@@ -12625,8 +12625,8 @@ namespace std {
   template <class T, T v>
   struct integral_constant {
     static constexpr T value = v;
-    typedef T value_type;
-    typedef integral_constant<T, v> type;
+    using value_type = T;
+    using type       = integral_constant<T, v>;
     constexpr operator value_type() const noexcept { return value; }
     constexpr value_type operator()() const noexcept { return value; }
   };
@@ -12636,7 +12636,8 @@ namespace std {
 \pnum
 The class template \tcode{integral_constant},
 alias template \tcode{bool_constant}, and
-its associated typedefs \tcode{true_type} and \tcode{false_type}
+its associated \grammarterm{typedef-name}{s}
+\tcode{true_type} and \tcode{false_type}
 are used as base classes to define
 the interface for various type traits.
 
@@ -13726,8 +13727,8 @@ Otherwise, there shall be no member \tcode{type}.
 \enterexample
 Given these definitions:
 \begin{codeblock}
-typedef bool (&PF1)();
-typedef short (*PF2)(long);
+using PF1 = bool  (&)();
+using PF2 = short (*)(long);
 
 struct S {
   operator PF2() const;
@@ -13736,8 +13737,8 @@ struct S {
   char data;
 };
 
-typedef void (S::*PMF)(long) const;
-typedef char S::*PMD;
+using PMF = void (S::*)(long) const;
+using PMD = char  S::*;
 \end{codeblock}
 
 the following assertions will hold:
@@ -13881,26 +13882,26 @@ namespace std {
   template <class R1, class R2> struct ratio_greater_equal;
 
   // \ref{ratio.si}, convenience SI typedefs
-  typedef ratio<1, 1'000'000'000'000'000'000'000'000> yocto;  // \seebelow
-  typedef ratio<1,     1'000'000'000'000'000'000'000> zepto;  // \seebelow
-  typedef ratio<1,         1'000'000'000'000'000'000> atto;
-  typedef ratio<1,             1'000'000'000'000'000> femto;
-  typedef ratio<1,                 1'000'000'000'000> pico;
-  typedef ratio<1,                     1'000'000'000> nano;
-  typedef ratio<1,                         1'000'000> micro;
-  typedef ratio<1,                             1'000> milli;
-  typedef ratio<1,                               100> centi;
-  typedef ratio<1,                                10> deci;
-  typedef ratio<                               10, 1> deca;
-  typedef ratio<                              100, 1> hecto;
-  typedef ratio<                            1'000, 1> kilo;
-  typedef ratio<                        1'000'000, 1> mega;
-  typedef ratio<                    1'000'000'000, 1> giga;
-  typedef ratio<                1'000'000'000'000, 1> tera;
-  typedef ratio<            1'000'000'000'000'000, 1> peta;
-  typedef ratio<        1'000'000'000'000'000'000, 1> exa;
-  typedef ratio<    1'000'000'000'000'000'000'000, 1> zetta;  // \seebelow
-  typedef ratio<1'000'000'000'000'000'000'000'000, 1> yotta;  // \seebelow
+  using yocto = ratio<1, 1'000'000'000'000'000'000'000'000>;  // \seebelow
+  using zepto = ratio<1,     1'000'000'000'000'000'000'000>;  // \seebelow
+  using atto  = ratio<1,         1'000'000'000'000'000'000>;
+  using femto = ratio<1,             1'000'000'000'000'000>;
+  using pico  = ratio<1,                 1'000'000'000'000>;
+  using nano  = ratio<1,                     1'000'000'000>;
+  using micro = ratio<1,                         1'000'000>;
+  using milli = ratio<1,                             1'000>;
+  using centi = ratio<1,                               100>;
+  using deci  = ratio<1,                                10>;
+  using deca  = ratio<                               10, 1>;
+  using hecto = ratio<                              100, 1>;
+  using kilo  = ratio<                            1'000, 1>;
+  using mega  = ratio<                        1'000'000, 1>;
+  using giga  = ratio<                    1'000'000'000, 1>;
+  using tera  = ratio<                1'000'000'000'000, 1>;
+  using peta  = ratio<            1'000'000'000'000'000, 1>;
+  using exa   = ratio<        1'000'000'000'000'000'000, 1>;
+  using zetta = ratio<    1'000'000'000'000'000'000'000, 1>;  // \seebelow
+  using yotta = ratio<1'000'000'000'000'000'000'000'000, 1>;  // \seebelow
 
   // \ref{ratio.arithmetic}, ratio comparison
   template <class R1, class R2> constexpr bool ratio_equal_v
@@ -13927,7 +13928,7 @@ namespace std {
   public:
     static constexpr intmax_t num;
     static constexpr intmax_t den;
-    typedef ratio<num, den> type;
+    using type = ratio<num, den>;
   };
 }
 \end{codeblock}
@@ -14069,10 +14070,11 @@ template <class R1, class R2> struct ratio_greater_equal
 \rSec2[ratio.si]{SI types for \tcode{ratio}}
 
 \pnum
-For each of the typedefs \tcode{yocto}, \tcode{zepto}, \tcode{zetta}, and \tcode{yotta},
-if both of the constants used in its specification are representable by
-\tcode{intmax_t}, the typedef shall be defined; if either of the constants is not
-representable by \tcode{intmax_t}, the typedef shall not be defined.
+For each of the \grammarterm{typedef-name}{s} \tcode{yocto}, \tcode{zepto},
+\tcode{zetta}, and \tcode{yotta},vif both of the constants used in its
+specification are representable byv\tcode{intmax_t}, the typedef shall be
+defined; if either of the constants is not representable by \tcode{intmax_t},
+the typedef shall not be defined.
 
 \rSec1[time]{Time utilities}
 
@@ -14169,12 +14171,12 @@ template <class ToDuration, class Rep, class Period>
   constexpr ToDuration round(const duration<Rep, Period>& d);
 
 // convenience typedefs
-typedef duration<@\term{signed integer type of at least 64 bits},@        nano> nanoseconds;
-typedef duration<@\term{signed integer type of at least 55 bits},@       micro> microseconds;
-typedef duration<@\term{signed integer type of at least 45 bits},@       milli> milliseconds;
-typedef duration<@\term{signed integer type of at least 35 bits}@             > seconds;
-typedef duration<@\term{signed integer type of at least 29 bits},@ ratio<  60>> minutes;
-typedef duration<@\term{signed integer type of at least 23 bits},@ ratio<3600>> hours;
+using nanoseconds  = duration<@\term{signed integer type of at least 64 bits}@, nano>;
+using microseconds = duration<@\term{signed integer type of at least 55 bits}@, micro>;
+using milliseconds = duration<@\term{signed integer type of at least 45 bits}@, milli>;
+using seconds      = duration<@\term{signed integer type of at least 35 bits}@>;
+using minutes      = duration<@\term{signed integer type of at least 29 bits}@, ratio<  60>>;
+using hours        = duration<@\term{signed integer type of at least 23 bits}@, ratio<3600>>;
 
 // \ref{time.point.nonmember}, time_point arithmetic
 template <class Clock, class Duration1, class Rep2, class Period2>
@@ -14444,7 +14446,7 @@ static constexpr Rep max();
 \begin{itemdecl}
 template <class Rep1, class Period1, class Rep2, class Period2>
 struct common_type<chrono::duration<Rep1, Period1>, chrono::duration<Rep2, Period2>> {
-  typedef chrono::duration<common_type_t<Rep1, Rep2>, @\seebelow@> type;
+  using type = chrono::duration<common_type_t<Rep1, Rep2>, @\seebelow@>;
 };
 \end{itemdecl}
 
@@ -14468,7 +14470,7 @@ floating-point durations may have round-off errors. \exitnote
 \begin{itemdecl}
 template <class Clock, class Duration1, class Duration2>
 struct common_type<chrono::time_point<Clock, Duration1>, chrono::time_point<Clock, Duration2>> {
-  typedef chrono::time_point<Clock, common_type_t<Duration1, Duration2>> type;
+  using type = chrono::time_point<Clock, common_type_t<Duration1, Duration2>>;
 };
 \end{itemdecl}
 
@@ -14488,8 +14490,8 @@ of seconds. It is expressed as a rational constant using the template \tcode{rat
 template <class Rep, class Period = ratio<1>>
 class duration {
 public:
-  typedef Rep    rep;
-  typedef Period period;
+  using rep    = Rep;
+  using period = Period;
 private:
   rep rep_;  // \expos
 public:
@@ -15267,10 +15269,10 @@ otherwise return \tcode{-d}.
 template <class Clock, class Duration = typename Clock::duration>
 class time_point {
 public:
-  typedef Clock                     clock;
-  typedef Duration                  duration;
-  typedef typename duration::rep    rep;
-  typedef typename duration::period period;
+  using clock    = Clock;
+  using duration = Duration;
+  using rep      = typename duration::rep;
+  using period   = typename duration::period;
 private:
   duration d_;  // \expos
 
@@ -15631,11 +15633,11 @@ realtime clock.
 \begin{codeblock}
 class system_clock {
 public:
-  typedef @\seebelow@                     @\itcorr[-1]@   rep;
-  typedef ratio<@\unspecnc,@ @\unspec{}@> @\itcorr[-1]@ period;
-  typedef chrono::duration<rep, period>    duration;
-  typedef chrono::time_point<system_clock> time_point;
-  static constexpr bool is_steady =        @\unspec;@
+  using rep        = @\seebelow@;
+  using period     = ratio<@\unspecnc@, @\unspec{}@>;
+  using duration   = chrono::duration<rep, period>;
+  using time_point = chrono::time_point<system_clock>;
+  static constexpr bool is_steady = @\unspec;@
 
   static time_point now() noexcept;
 
@@ -15648,7 +15650,7 @@ public:
 \indexlibrary{\idxcode{rep}!\idxcode{system_clock}}%
 \indexlibrary{\idxcode{system_clock}!\idxcode{rep}}%
 \begin{itemdecl}
-typedef @\unspec@ system_clock::rep;
+using system_clock::rep = @\unspec@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -15697,11 +15699,11 @@ a steady rate relative to real time. That is, the clock may not be adjusted.
 \begin{codeblock}
 class steady_clock {
 public:
-  typedef @\unspec{}@                      @\itcorr[-1]@         rep;
-  typedef ratio<@\unspecnc,@ @\unspec{}@>  @\itcorr[-1]@         period;
-  typedef chrono::duration<rep, period>             duration;
-  typedef chrono::time_point<@\unspecnc,@ duration> time_point;
-  static constexpr bool is_steady =                 true;
+  using rep        = @\unspec@;
+  using period     = ratio<@\unspecnc@, @\unspec{}@>;
+  using duration   = chrono::duration<rep, period>;
+  using time_point = chrono::time_point<@\unspecnc@, duration>;
+  static constexpr bool is_steady = true;
 
   static time_point now() noexcept;
 };
@@ -15717,11 +15719,11 @@ shortest tick period. \tcode{high_resolution_clock} may be a synonym for
 \begin{codeblock}
 class high_resolution_clock {
 public:
-  typedef @\unspec{}@                      @\itcorr[-1]@         rep;
-  typedef ratio<@\unspecnc,@ @\unspec{}@>  @\itcorr[-1]@         period;
-  typedef chrono::duration<rep, period>             duration;
-  typedef chrono::time_point<@\unspecnc,@ duration> time_point;
-  static constexpr bool is_steady =                 @\unspec@;
+  using rep        = @\unspec@;
+  using period     = ratio<@\unspecnc@, @\unspec{}@>;
+  using duration   = chrono::duration<rep, period>;
+  using time_point = chrono::time_point<@\unspecnc@, duration>;
+  static constexpr bool is_steady = @\unspec@;
 
   static time_point now() noexcept;
 };
@@ -15817,29 +15819,29 @@ namespace std {
   template <class OuterAlloc, class... InnerAllocs>
     class scoped_allocator_adaptor : public OuterAlloc {
   private:
-    typedef allocator_traits<OuterAlloc> OuterTraits; // \expos
+    using OuterTraits = allocator_traits<OuterAlloc>; // \expos
     scoped_allocator_adaptor<InnerAllocs...> inner;   // \expos
   public:
-    typedef OuterAlloc outer_allocator_type;
-    typedef @\seebelow@ inner_allocator_type;
+    using outer_allocator_type = OuterAlloc;
+    using inner_allocator_type = @\seebelow@;
 
-    typedef typename OuterTraits::value_type value_type;
-    typedef typename OuterTraits::size_type size_type;
-    typedef typename OuterTraits::difference_type difference_type;
-    typedef typename OuterTraits::pointer pointer;
-    typedef typename OuterTraits::const_pointer const_pointer;
-    typedef typename OuterTraits::void_pointer void_pointer;
-    typedef typename OuterTraits::const_void_pointer const_void_pointer;
+    using value_type           = typename OuterTraits::value_type;
+    using size_type            = typename OuterTraits::size_type;
+    using difference_type      = typename OuterTraits::difference_type;
+    using pointer              = typename OuterTraits::pointer;
+    using const_pointer        = typename OuterTraits::const_pointer;
+    using void_pointer         = typename OuterTraits::void_pointer;
+    using const_void_pointer   = typename OuterTraits::const_void_pointer;
 
-    typedef @\seebelow@ propagate_on_container_copy_assignment;
-    typedef @\seebelow@ propagate_on_container_move_assignment;
-    typedef @\seebelow@ propagate_on_container_swap;
-    typedef @\seebelow@ is_always_equal;
+    using propagate_on_container_copy_assignment = @\seebelow@;
+    using propagate_on_container_move_assignment = @\seebelow@;
+    using propagate_on_container_swap            = @\seebelow@;
+    using is_always_equal                        = @\seebelow@;
 
     template <class Tp>
       struct rebind {
-        typedef scoped_allocator_adaptor<
-          OuterTraits::template rebind_alloc<Tp>, InnerAllocs...> other;
+        using other = scoped_allocator_adaptor<
+          OuterTraits::template rebind_alloc<Tp>, InnerAllocs...>;
       };
 
     scoped_allocator_adaptor();
@@ -15906,7 +15908,7 @@ namespace std {
 \indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{inner_allocator_type}}%
 \indexlibrary{\idxcode{inner_allocator_type}!\idxcode{scoped_allocator_adaptor}}%
 \begin{itemdecl}
-typedef @\seebelow@ inner_allocator_type;
+using inner_allocator_type = @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -15918,7 +15920,7 @@ zero; otherwise,\\ \tcode{scoped_allocator_adaptor<InnerAllocs...>}.
 \indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{propagate_on_container_copy_assignment}}%
 \indexlibrary{\idxcode{propagate_on_container_copy_assignment}!\idxcode{scoped_allocator_adaptor}}%
 \begin{itemdecl}
-typedef @\seebelow@ propagate_on_container_copy_assignment;
+using propagate_on_container_copy_assignment = @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -15932,7 +15934,7 @@ typedef @\seebelow@ propagate_on_container_copy_assignment;
 \indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{propagate_on_container_move_assignment}}%
 \indexlibrary{\idxcode{propagate_on_container_move_assignment}!\idxcode{scoped_allocator_adaptor}}%
 \begin{itemdecl}
-typedef @\seebelow@ propagate_on_container_move_assignment;
+using propagate_on_container_move_assignment = @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -15946,7 +15948,7 @@ typedef @\seebelow@ propagate_on_container_move_assignment;
 \indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{propagate_on_container_swap}}%
 \indexlibrary{\idxcode{propagate_on_container_swap}!\idxcode{scoped_allocator_adaptor}}%
 \begin{itemdecl}
-typedef @\seebelow@ propagate_on_container_swap;
+using propagate_on_container_swap = @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -15960,7 +15962,7 @@ typedef @\seebelow@ propagate_on_container_swap;
 \indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{is_always_equal}}%
 \indexlibrary{\idxcode{is_always_equal}!\idxcode{scoped_allocator_adaptor}}%
 \begin{itemdecl}
-typedef @\seebelow@ is_always_equal;
+using is_always_equal = @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
This set of changes replace (almost) all use of 'typedef' in the library with a type alias instead:
   typedef Original NewName;   ->    using NewName = Original;

Attention was paid to retaining table-like formatting where present, which is worth reviewing in case I made idiosyncratic choices.

Clause 20 has NOT been applied, as that clause is churning a bit at the moment, and I don't want a conflict there to hold up a this review.  The most likely conflict is my own pull request:
   https://github.com/cplusplus/draft/pull/683
I will happily rebase and complete the work once that branch lands (or is deferred again until this branch completes)

A second set of changes that should follow are to update the text that refers to typedefs to perhaps use a term more consistent with the type alias syntax applied here - but I defer to the project editors to suggest such phrasing.