### PR TITLE
[alg.random.sample] reword and add cross-reference

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -2983,14 +2983,14 @@ template<class PopulationIterator, class SampleIterator,
 \requires
 \begin{itemize}
 \item
-\tcode{PopulationIterator} shall meet the requirements of an \tcode{InputIterator} type.
+\tcode{PopulationIterator} shall satisfy the requirements of an input iterator~(\ref{input.iterators}).
 \item
-\tcode{SampleIterator} shall meet the requirements of an \tcode{OutputIterator} type.
+\tcode{SampleIterator} shall satisfy the requirements of an output iterator~(\ref{output.iterators}).
 \item
-\tcode{SampleIterator} shall meet the additional requirements of a \tcode{RandomAccessIterator} type
-unless \tcode{PopulationIterator} meets the additional requirements of a \tcode{ForwardIterator} type.
+\tcode{SampleIterator} shall satisfy the additional requirements of a random access iterator~(\ref{random.access.iterators}).
+unless \tcode{PopulationIterator} satisfies the additional requirements of a forward iterator~(\ref{forward.iterators}).
 \item
-\tcode{PopulationIterator}'s value type shall be writable to \tcode{out}.
+\tcode{PopulationIterator}'s value type shall be writable~(\ref{iterator.requirements.general}) to \tcode{out}.
 \item
 \tcode{Distance} shall be an integer type.
 \item
@@ -3022,8 +3022,8 @@ The end of the resulting sample range.
 \remarks
 \begin{itemize}
 \item
-Stable if and only if \tcode{PopulationIterator} meets the
-requirements of a \tcode{ForwardIterator} type.
+Stable if and only if \tcode{PopulationIterator} satisfies the
+requirements of a forward iterator.
 \item
 To the extent that the implementation of this function makes use of
 random numbers, the object \tcode{g} shall serve as the


### PR DESCRIPTION
MeowIterator is not a named requirement, so reworded as "shall satisfy
the requirements of a meow iterator", consistent with the wording in
[algorithm.general]/5. Added cross-references to [meow.iterators], and
to [iterator.requirements.general] for "writable".

Partially addresses #697 and #696.