### PR TITLE
[algorithms] [numeric.ops] Crossref "writable"

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -2495,7 +2495,7 @@ The results of the expressions
 \tcode{*first}
 and
 \tcode{new_value}
-shall be writable to the
+shall be writable~(\ref{iterator.requirements.general}) to the
 \tcode{result}
 output iterator.
 The ranges
@@ -2550,7 +2550,7 @@ template<class OutputIterator, class Size, class T>
 \requires
 The expression
 \tcode{value}
-shall be writable to the output iterator. The type
+shall be writable~(\ref{iterator.requirements.general}) to the output iterator. The type
 \tcode{Size}
 shall be convertible to an integral type~(\ref{conv.integral}, \ref{class.conv}).
 
@@ -3184,7 +3184,7 @@ template <class InputIterator, class OutputIterator1,
 \begin{itemdescr}
 \pnum
 \requires \tcode{InputIterator}'s value type shall be \tcode{CopyAssignable}, and shall be
-writable to the \tcode{out_true} and \tcode{out_false} \tcode{OutputIterator}s, and shall be
+writable~(\ref{iterator.requirements.general}) to the \tcode{out_true} and \tcode{out_false} \tcode{OutputIterator}s, and shall be
 convertible to \tcode{Predicate}'s argument type. The input range shall not overlap with
 either of the output ranges.
 

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -9030,7 +9030,7 @@ the binary operation.
 \tcode{InputIterator}'s value type shall be constructible from the type of \tcode{*first}.
 The result of the expression \tcode{acc + *i} or \tcode{binary_op(acc, *i)} shall be
 implicitly convertible to \tcode{InputIterator}'s value type. \tcode{acc}
-shall be writable to the \tcode{result} output iterator.
+shall be writable~(\ref{iterator.requirements.general}) to the \tcode{result} output iterator.
 In the ranges
 \crange{first}{last}
 and
@@ -9318,7 +9318,7 @@ to \tcode{*(result + (i - first))}, and move assigns from \tcode{val} to \tcode{
 \requires
 \tcode{InputIterator}'s value type shall be \tcode{MoveAssignable} (Table~\ref{moveassignable})
 and shall be constructible from the type of \tcode{*first}. \tcode{acc} shall be
-writable to the \tcode{result} output iterator. The result of the expression \tcode{val - acc}
+writable~(\ref{iterator.requirements.general}) to the \tcode{result} output iterator. The result of the expression \tcode{val - acc}
 or \tcode{binary_op(val, acc)} shall be writable to the \tcode{result} output iterator.
 In the ranges
 \crange{first}{last}


### PR DESCRIPTION
Add cross-references to [iterator.requirements.general] for "writable"
for [alg.replace], [alg.fill], [alg.partitions], [partial.sum] and
[adjacent.difference].

Fixes #697.