### PR TITLE
[meta.rel] Fix for for INVOKE in table 54

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -13288,7 +13288,7 @@ with a BaseCharacteristic of
 
 \tcode{template <class Fn, class... ArgTypes, class R>}\br
  \tcode{struct is_callable<Fn(ArgTypes...), R>;}                      &
- The expression \tcode{INVOKE(declval<Fn>(), declval<ArgTypes>()..., R)}
+ The expression \tcode{\textit{INVOKE}(declval<Fn>(), declval<ArgTypes>()..., R)}
  is well formed when treated as an unevaluated operand                &
  \tcode{Fn}, \tcode{R}, and all types in the parameter pack \tcode{ArgTypes}
  shall be complete types, (possibly cv-qualified) \tcode{void}, or
@@ -13297,7 +13297,7 @@ with a BaseCharacteristic of
 \tcode{template <class Fn, class... ArgTypes, class R>}\br
  \tcode{struct is_nothrow_callable<Fn(ArgTypes...), R>;}              &
  \tcode{is_callable<Fn(ArgTypes...), R>::value} is \tcode{true} and
- the expression \tcode{INVOKE(declval<Fn>(), declval<ArgTypes>()..., R)}
+ the expression \tcode{\textit{INVOKE}(declval<Fn>(), declval<ArgTypes>()..., R)}
  is known not to throw any exceptions                                 &
  \tcode{Fn}, \tcode{R}, and all types in the parameter pack \tcode{ArgTypes}
  shall be complete types, (possibly cv-qualified) \tcode{void}, or


### PR DESCRIPTION
Fix the font for the use of INVOKE in the two new additions
to table 54, is_callable and is_nothrow_callable.  Considered
adding a new \invoke command and applying that consistently,
but decided I am not a LaTeX hacker yet, and took the easy
way out.