### PR TITLE
Add name "high" to locale::narrow in [category.ctype]

### DIFF
--- a/source/locales.tex
+++ b/source/locales.tex
@@ -1564,7 +1564,7 @@ namespace std {
     charT        widen(char c) const;
     const char*  widen(const char* low, const char* high, charT* to) const;
     char         narrow(charT c, char dfault) const;
-    const charT* narrow(const charT* low, const charT*, char dfault,
+    const charT* narrow(const charT* low, const charT* high, char dfault,
                         char* to) const;
 
     static locale::id id;
@@ -1704,7 +1704,7 @@ or
 \indexlibrary{\idxcode{narrow}!\idxcode{ctype}}%
 \begin{itemdecl}
 char         narrow(charT c, char dfault) const;
-const charT* narrow(const charT* low, const charT*, char dfault,
+const charT* narrow(const charT* low, const charT* high, char dfault,
                     char* to) const;
 \end{itemdecl}
 


### PR DESCRIPTION
In [locale.ctype.members], the returns clause for locale::narrow refers
to "high". For correct binding, the corresponding parameter should be
named as such.