### PR TITLE
[ext.manip] fix typo in put_money description

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -7082,7 +7082,7 @@ specialization of the \tcode{basic_string} template (Clause~\ref{strings}).
 \pnum
 \returns An object of unspecified type such that if
 \tcode{out} is an object of type \tcode{basic_ostream<charT, traits>}
-then the expression \tcode{out \shl\ put_money(mon, intl)} behaves as a formatted input function that calls
+then the expression \tcode{out \shl\ put_money(mon, intl)} behaves as a formatted output function~(\ref{ostream.formatted.reqmts}) that calls
 \tcode{f(out, mon, intl)}, where the function \tcode{f} is defined as:
 
 \begin{codeblock}


### PR DESCRIPTION
There's no way `os << put_money(...)` could be a formatted *input* function; presumably a formatted *output* function is meant. Also add cross reference to [ostream.formatted.reqmts].