### PR TITLE
[deque.overview] deque should not reference vector

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -2862,12 +2862,11 @@ where indexing is zero-based.
 A
 \indexlibrary{\idxcode{deque}}%
 \tcode{deque}
-is a sequence container that, like a
-\tcode{vector}~(\ref{vector}), supports random access iterators.
+is a sequence container that supports random access iterators (\ref{random.access.iterators}).
 In addition, it supports constant time insert and erase operations at the beginning or the end;
 insert and erase in the middle take linear time.
 That is, a deque is especially optimized for pushing and popping elements at the beginning and end.
-As with vectors, storage management is handled automatically.
+Storage management is handled automatically.
 
 \pnum
 A


### PR DESCRIPTION
Deque introduces itself in terms of vector, to describe the idea of
random access iterators.  This is perhaps more confusing that simply
directing the reader to the clause for random access iterators.  For
C++17 we introduce the category of contiguous iterators for vector,
array, and string, and we do not want to confuse the reader into bad
assumptions.  Meanwhile, the notion of iterators is much more widely
understood than in 1998, so pointing directly to the appropriate
clause is more likely to help the reader than a potentially misleading analogy.