### PR TITLE
[class.member.lookup] 'overloading resolution' sounds odd - every oth…

### DIFF
--- a/source/derived.tex
+++ b/source/derived.tex
@@ -916,11 +916,13 @@ function with a deleted definition.%
 \indextext{class!abstract}
 
 \pnum
+\enternote
 The abstract class mechanism supports the notion of a general concept,
 such as a \tcode{shape}, of which only more concrete variants, such as
 \tcode{circle} and \tcode{square}, can actually be used. An abstract
 class can also be used to define an interface for which derived classes
 provide a variety of implementations.
+\exitnote
 
 \pnum
 An \term{abstract class} is a class that can be used only

--- a/source/derived.tex
+++ b/source/derived.tex
@@ -425,9 +425,9 @@ $S(x,D)$ is discarded in the first merge step.
 \exitexample
 
 \pnum
-\indextext{access~control!overloading~resolution~and}%
+\indextext{access~control!overload~resolution~and}%
 If the name of an overloaded function is unambiguously found,
-overloading resolution~(\ref{over.match}) also takes place before access
+overload resolution~(\ref{over.match}) also takes place before access
 control.
 \indextext{example!scope~resolution operator}%
 \indextext{example!explicit~qualification}%


### PR DESCRIPTION
…er reference to the process calls it 'overload resolution'