### PR TITLE
[class.member.lookup] 'overloading resolution' sounds odd - every oth…

### DIFF
--- a/source/derived.tex
+++ b/source/derived.tex
@@ -425,9 +425,9 @@ $S(x,D)$ is discarded in the first merge step.
 \exitexample
 
 \pnum
-\indextext{access~control!overloading~resolution~and}%
+\indextext{access~control!overload~resolution~and}%
 If the name of an overloaded function is unambiguously found,
-overloading resolution~(\ref{over.match}) also takes place before access
+overload resolution~(\ref{over.match}) also takes place before access
 control.
 \indextext{example!scope~resolution operator}%
 \indextext{example!explicit~qualification}%


### PR DESCRIPTION
…er reference to the process uses 'overload resolution'