### PR TITLE
[namespace.udecl] tweak the example in para 17 so that the comment is…

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2920,12 +2920,13 @@ visible in the scope of at least one of the direct base classes of the
 class where the \grammarterm{using-declaration} is specified. \enternote
 Because a \grammarterm{using-declaration} designates a base class member
 (and not a member subobject or a member function of a base class
-subobject), a \grammarterm{using-declaration} cannot be used to resolve
+subobject), a \grammarterm{using-declaration} cannot be used to resolve all
 inherited member ambiguities. For example,
 
 \begin{codeblock}
-struct A { int x(); };
-struct B : A { };
+struct A { int x(); int y(); int z(); };
+struct A1 : A { int y(); int z(); };
+struct B : A, A1 { using A1::z; };
 struct C : A {
   using A::x;
   int x(int);
@@ -2935,8 +2936,26 @@ struct D : B, C {
   using C::x;
   int x(double);
 };
-int f(D* d) {
-  return d->x();    // ambiguous: \tcode{B::x} or \tcode{C::x}
+
+void f(D* d) {
+   // Below, the 'naming-class' refers to the class in which lookup for \tcode{x} begins, the 'declaring-class' is 
+   // the class that has the selected \tcode{x} as its direct member (i.e ignoring using-declarations), 
+   // and the 'object-class' is the class of the object expression
+   
+   d->x();       // ambiguous: declaring-class \tcode{A} is an ambiguous base of the implicit naming-class \tcode{D}
+   d->A::x();    // ambiguous: naming-class \tcode{A} is an ambiguous base of the object-class \tcode{D}
+   d->C::A::x(); // ambiguous: same reason as line directly above (naming-class is still \tcode{A})
+   d->C::x();    // OK: declaring-class \tcode{A} is an unambiguous base of the naming-class \tcode{C}, which is 
+                 // an unambigous base of the object-class \tcode{D}            
+   d->C::x(3);   // OK: naming-class and declaring-class \tcode{C} is an umambiguous base of the object-class \tcode{D}  
+   d->B::x();    // ambiguous: declaring-class \tcode{A} is an ambiguous base of the naming-class \tcode{B}
+   d->A1::x();   // OK: declaring-class \tcode{A} is an unambiguous base of the naming-class \tcode{A1} which is 
+                 // an unambiguous base of the object-class \tcode{D}
+   d->B::y();    // ambiguous: member lookup ambiguity when merging lookup sets of \tcode{B}'s direct base subobjects 
+   d->B::z();    // OK: using-declaration resolves member lookup ambiguity in favor of \tcode{A1::z} which hides \tcode{A::z} 
+                 // (same signature); and, declaring-class \tcode{A1} is an unambiguous base of naming-class \tcode{B} 
+                 // which is an unambiguous base of object-class \tcode{D}
+   d->z();       // ambiguous: member name lookup ambiguity when merging lookup sets from \tcode{B} and \tcode{C} subobjects
 }
 \end{codeblock}
 \exitnote


### PR DESCRIPTION
… clear as to the reason for the ambiguity

  - the current comment could be interpreted as suggesting that the result of member-name-lookup (i.e. the declaration-set of S(x,D)) is ambiguous, which is certainly not the case -- the reason for the ambiguity is specified in [expr.ref]/5 -- and hopefully better reflected in the new comment.
  - add some additional examples that highlight the nuances of how the wording rejects or resolves certain member  ambiguity.