### PR TITLE
Fix incorrect variable references

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1821,12 +1821,12 @@ If \tcode{n == 0}, the return value is unspecified.
 \tcode{X u = std::move(a);} &
                             &
   Shall not exit via an exception.\br
-  post: \tcode{a1} equals the prior value of \tcode{a}. & \\ \rowsep
+  post: \tcode{u} is equal to the prior value of \tcode{a}. & \\ \rowsep
 
 \tcode{X u(std::move(b));}  &
                             &
   Shall not exit via an exception.\br
-  post: \tcode{a} equals the prior value of \tcode{X(b)}. & \\ \rowsep
+  post: \tcode{u} is equal to the prior value of \tcode{X(b)}. & \\ \rowsep
 
 \tcode{a.construct(c, args)}&
   (not used)                &


### PR DESCRIPTION
Two move operations for the allocators refer to `a` or `a1`, though the code uses `u`.  Fix the description to match the code.
Also, change the phrase "equals" to "is equal to", which matches other uses in the standard (see [unique.ptr]/4.1 for an example).