### PR TITLE
[util.smartptr.enab] make p6 appear in its own line

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -8504,6 +8504,7 @@ enable_shared_from_this<T>& operator=(const enable_shared_from_this<T>&) noexcep
 
 \begin{itemdescr}
 \pnum\returns  \tcode{*this}.
+
 \pnum\enternote \tcode{weak_this} is not changed. \exitnote
 \end{itemdescr}
 


### PR DESCRIPTION
Currently p6 appears in the same line as p5.