### PR TITLE
23.2.5[unord.req]p12 should refer to key_eq(), not key_equal()

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -2329,7 +2329,7 @@ such that
 \tcode{is_permutation(Ea1, Ea2, Eb1, Eb2)} returns \tcode{true}. For
 \tcode{unordered_set} and \tcode{unordered_map}, the complexity of
 \tcode{operator==} (i.e., the number of calls to the \tcode{==} operator
-of the \tcode{value_type}, to the predicate returned by \tcode{key_equal()},
+of the \tcode{value_type}, to the predicate returned by \tcode{key_eq()},
 and to the hasher returned by \tcode{hash_function()}) is proportional to
 $N$ in the average case and to $N^2$ in the worst case, where $N$ is
 a.size(). For \tcode{unordered_multiset} and \tcode{unordered_multimap},


### PR DESCRIPTION
fix for #736 