### PR TITLE
[time.duration.comparisons] Fix index entry for duration operator<

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -15613,8 +15613,8 @@ template <class Rep1, class Period1, class Rep2, class Period2>
 \returns \tcode{!(rhs < lhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>}!\idxcode{idxl}}%
-\indexlibrary{\idxcode{idxl}!\idxcode{operator>}}%
+\indexlibrary{\idxcode{operator>}!\idxcode{duration}}%
+\indexlibrary{\idxcode{duration}!\idxcode{operator>}}%
 \begin{itemdecl}
 template <class Rep1, class Period1, class Rep2, class Period2>
   constexpr bool operator>(const duration<Rep1, Period1>& lhs, const duration<Rep2, Period2>& rhs);


### PR DESCRIPTION
The index entry for 'operator<' of the 'duration' class template is
associated with an unknown 'idxl' type, instead of 'duration'.