### PR TITLE
[string.view.comparison] Fix index for basic_string_view operators

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -5363,6 +5363,7 @@ template<class charT, class traits>
 \exitexample
 
 \indexlibrary{\idxcode{operator==}!\idxcode{basic_string_view}}%
+\indexlibrary{\idxcode{basic_string_view}!\idxcode{operator==}}%
 \begin{itemdecl}
 template<class charT, class traits>
   constexpr bool operator==(basic_string_view<charT, traits> lhs,
@@ -5376,6 +5377,7 @@ template<class charT, class traits>
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator!=}!\idxcode{basic_string_view}}%
+\indexlibrary{\idxcode{basic_string_view}!\idxcode{operator!=}}%
 \begin{itemdecl}
 template<class charT, class traits>
   constexpr bool operator!=(basic_string_view<charT, traits> lhs,
@@ -5389,6 +5391,7 @@ template<class charT, class traits>
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator<}!\idxcode{basic_string_view}}%
+\indexlibrary{\idxcode{basic_string_view}!\idxcode{operator<}}%
 \begin{itemdecl}
 template<class charT, class traits>
   constexpr bool operator< (basic_string_view<charT, traits> lhs,
@@ -5402,6 +5405,7 @@ template<class charT, class traits>
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator>}!\idxcode{basic_string_view}}%
+\indexlibrary{\idxcode{basic_string_view}!\idxcode{operator>}}%
 \begin{itemdecl}
 template<class charT, class traits>
   constexpr bool operator> (basic_string_view<charT, traits> lhs,
@@ -5415,6 +5419,7 @@ template<class charT, class traits>
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator<=}!\idxcode{basic_string_view}}%
+\indexlibrary{\idxcode{basic_string_view}!\idxcode{operator<=}}%
 \begin{itemdecl}
 template<class charT, class traits>
   constexpr bool operator<=(basic_string_view<charT, traits> lhs,
@@ -5428,6 +5433,7 @@ template<class charT, class traits>
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator>=}!\idxcode{basic_string_view}}%
+\indexlibrary{\idxcode{basic_string_view}!\idxcode{operator>=}}%
 \begin{itemdecl}
 template<class charT, class traits>
   constexpr bool operator>=(basic_string_view<charT, traits> lhs,
@@ -5442,7 +5448,8 @@ template<class charT, class traits>
 
 \rSec2[string.view.io]{Inserters and extractors}
 
-\indexlibrary{\idxcode{operator<<}!\idxcode{basic_string_view}}%
+\indexlibrary{\idxcode{operator\shl}!\idxcode{basic_string_view}}%
+\indexlibrary{\idxcode{basic_string_view}!\idxcode{operator\shl}}%
 \begin{itemdecl}
 template<class charT, class traits>
   basic_ostream<charT, traits>&


### PR DESCRIPTION
The first issue is that operator<< does not group in the index with
other definitions for operator<<, which use an index key of
operator\shl.

The second issue is that operator<< was the only operator indexed
under the 'basic_string_view' key, where the precedent fro basic_string
and other types is that the free-function operators are still indexed
under their respective class entry.