### PR TITLE
[18-28] Fix index entry for constructors

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -3005,8 +3005,7 @@ namespace std {
 
 \rSec3[deque.cons]{\tcode{deque} constructors, copy, and assignment}
 
-\indexlibrary{\idxcode{deque}!\idxcode{deque}}%
-\indexlibrary{\idxcode{deque}!\idxcode{deque}}%
+\indexlibrary{\idxcode{deque}!constructor}%
 \begin{itemdecl}
 explicit deque(const Allocator&);
 \end{itemdecl}
@@ -3023,8 +3022,7 @@ using the specified allocator.
 Constant.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{deque}!\idxcode{deque}}%
-\indexlibrary{\idxcode{deque}!\idxcode{deque}}%
+\indexlibrary{\idxcode{deque}!constructor}%
 \begin{itemdecl}
 explicit deque(size_type n, const Allocator& = Allocator());
 \end{itemdecl}
@@ -3041,8 +3039,7 @@ explicit deque(size_type n, const Allocator& = Allocator());
 \complexity Linear in \tcode{n}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{deque}!\idxcode{deque}}%
-\indexlibrary{\idxcode{deque}!\idxcode{deque}}%
+\indexlibrary{\idxcode{deque}!constructor}%
 \begin{itemdecl}
 deque(size_type n, const T& value, const Allocator& = Allocator());
 \end{itemdecl}
@@ -3063,8 +3060,7 @@ using the specified allocator.
 Linear in \tcode{n}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{deque}!\idxcode{deque}}%
-\indexlibrary{\idxcode{deque}!\idxcode{deque}}%
+\indexlibrary{\idxcode{deque}!constructor}%
 \begin{itemdecl}
 template <class InputIterator>
   deque(InputIterator first, InputIterator last, const Allocator& = Allocator());
@@ -3412,8 +3408,7 @@ of \tcode{forward_list} is referenced.
 
 \rSec3[forwardlist.cons]{\tcode{forward_list} constructors, copy, assignment}
 
-\indexlibrary{\idxcode{forward_list}!\idxcode{forward_list}}%
-\indexlibrary{\idxcode{forward_list}!\idxcode{forward_list}}%
+\indexlibrary{\idxcode{forward_list}!constructor}%
 \begin{itemdecl}
 explicit forward_list(const Allocator&);
 \end{itemdecl}
@@ -3426,8 +3421,7 @@ explicit forward_list(const Allocator&);
 \complexity Constant.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{forward_list}!\idxcode{forward_list}}%
-\indexlibrary{\idxcode{forward_list}!\idxcode{forward_list}}%
+\indexlibrary{\idxcode{forward_list}!constructor}%
 \begin{itemdecl}
 explicit forward_list(size_type n, const Allocator& = Allocator());
 \end{itemdecl}
@@ -3444,8 +3438,7 @@ default-inserted elements using the specified allocator.
 \complexity Linear in \tcode{n}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{forward_list}!\idxcode{forward_list}}%
-\indexlibrary{\idxcode{forward_list}!\idxcode{forward_list}}%
+\indexlibrary{\idxcode{forward_list}!constructor}%
 \begin{itemdecl}
 forward_list(size_type n, const T& value, const Allocator& = Allocator());
 \end{itemdecl}
@@ -3461,8 +3454,7 @@ forward_list(size_type n, const T& value, const Allocator& = Allocator());
 \complexity Linear in \tcode{n}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{forward_list}!\idxcode{forward_list}}%
-\indexlibrary{\idxcode{forward_list}!\idxcode{forward_list}}%
+\indexlibrary{\idxcode{forward_list}!constructor}%
 \begin{itemdecl}
 template <class InputIterator>
   forward_list(InputIterator first, InputIterator last, const Allocator& = Allocator());
@@ -4155,8 +4147,7 @@ of \tcode{list} is referenced.
 
 \rSec3[list.cons]{\tcode{list} constructors, copy, and assignment}
 
-\indexlibrary{\idxcode{list}!\idxcode{list}}%
-\indexlibrary{\idxcode{list}!\idxcode{list}}%
+\indexlibrary{\idxcode{list}!constructor}%
 \begin{itemdecl}
 explicit list(const Allocator&);
 \end{itemdecl}
@@ -4171,8 +4162,7 @@ Constructs an empty list, using the specified allocator.
 Constant.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{list}!\idxcode{list}}%
-\indexlibrary{\idxcode{list}!\idxcode{list}}%
+\indexlibrary{\idxcode{list}!constructor}%
 \begin{itemdecl}
 explicit list(size_type n, const Allocator& = Allocator());
 \end{itemdecl}
@@ -4191,8 +4181,7 @@ Linear in
 \tcode{n}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{list}!\idxcode{list}}%
-\indexlibrary{\idxcode{list}!\idxcode{list}}%
+\indexlibrary{\idxcode{list}!constructor}%
 \begin{itemdecl}
 list(size_type n, const T& value, const Allocator& = Allocator());
 \end{itemdecl}
@@ -4217,8 +4206,7 @@ Linear in
 \tcode{n}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{list}!\idxcode{list}}%
-\indexlibrary{\idxcode{list}!\idxcode{list}}%
+\indexlibrary{\idxcode{list}!constructor}%
 \begin{itemdecl}
 template <class InputIterator>
   list(InputIterator first, InputIterator last, const Allocator& = Allocator());
@@ -4834,7 +4822,7 @@ of \tcode{vector} is referenced.
 
 \rSec3[vector.cons]{\tcode{vector} constructors, copy, and assignment}
 
-\indexlibrary{\idxcode{vector}!\tcode{vector}}
+\indexlibrary{\idxcode{vector}!constructor}
 \begin{itemdecl}
 explicit vector(const Allocator&);
 \end{itemdecl}
@@ -4848,7 +4836,7 @@ specified allocator.
 \complexity Constant.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{vector}!\tcode{vector}}
+\indexlibrary{\idxcode{vector}!constructor}
 \begin{itemdecl}
 explicit vector(size_type n, const Allocator& = Allocator());
 \end{itemdecl}
@@ -4865,7 +4853,7 @@ default-inserted elements using the specified allocator.
 \complexity Linear in \tcode{n}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{vector}!\tcode{vector}}
+\indexlibrary{\idxcode{vector}!constructor}
 \begin{itemdecl}
 vector(size_type n, const T& value,
        const Allocator& = Allocator());
@@ -4884,7 +4872,7 @@ copies of \tcode{value}, using the specified allocator.
 \complexity Linear in \tcode{n}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{vector}!\tcode{vector}}
+\indexlibrary{\idxcode{vector}!constructor}
 \begin{itemdecl}
 template <class InputIterator>
   vector(InputIterator first, InputIterator last,
@@ -5727,8 +5715,7 @@ namespace std {
 \indexlibrary{\idxcode{map}!\idxcode{operator==}}%
 \indexlibrary{\idxcode{map}!\idxcode{operator<}}
 
-\indexlibrary{\idxcode{map}!\idxcode{map}}%
-\indexlibrary{\idxcode{map}!\idxcode{map}}%
+\indexlibrary{\idxcode{map}!constructor}%
 \begin{itemdecl}
 explicit map(const Compare& comp, const Allocator& = Allocator());
 \end{itemdecl}
@@ -6217,8 +6204,7 @@ namespace std {
 
 \rSec3[multimap.cons]{\tcode{multimap} constructors}
 
-\indexlibrary{\idxcode{multimap}!\idxcode{multimap}}%
-\indexlibrary{\idxcode{multimap}!\idxcode{multimap}}%
+\indexlibrary{\idxcode{multimap}!constructor}%
 \begin{itemdecl}
 explicit multimap(const Compare& comp, const Allocator& = Allocator());
 \end{itemdecl}
@@ -6235,8 +6221,7 @@ using the specified comparison object and allocator.
 Constant.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{multimap}!\idxcode{multimap}}%
-\indexlibrary{\idxcode{multimap}!\idxcode{multimap}}%
+\indexlibrary{\idxcode{multimap}!constructor}%
 \begin{itemdecl}
 template <class InputIterator>
   multimap(InputIterator first, InputIterator last,
@@ -6499,8 +6484,7 @@ namespace std {
 
 \rSec3[set.cons]{\tcode{set} constructors, copy, and assignment}
 
-\indexlibrary{\idxcode{set}!\idxcode{set}}%
-\indexlibrary{\idxcode{set}!\idxcode{set}}%
+\indexlibrary{\idxcode{set}!constructor}%
 \begin{itemdecl}
 explicit set(const Compare& comp, const Allocator& = Allocator());
 \end{itemdecl}
@@ -6515,8 +6499,7 @@ Constructs an empty set using the specified comparison objects and allocator.
 Constant.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{set}!\idxcode{set}}%
-\indexlibrary{\idxcode{set}!\idxcode{set}}%
+\indexlibrary{\idxcode{set}!constructor}%
 \begin{itemdecl}
 template <class InputIterator>
   set(InputIterator first, InputIterator last,
@@ -6754,8 +6737,7 @@ namespace std {
 
 \rSec3[multiset.cons]{\tcode{multiset} constructors}
 
-\indexlibrary{\idxcode{multiset}!\idxcode{multiset}}%
-\indexlibrary{\idxcode{multiset}!\idxcode{multiset}}%
+\indexlibrary{\idxcode{multiset}!constructor}%
 \begin{itemdecl}
 explicit multiset(const Compare& comp, const Allocator& = Allocator());
 \end{itemdecl}
@@ -6770,8 +6752,7 @@ Constructs an empty set using the specified comparison object and allocator.
 Constant.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{multiset}!\idxcode{multiset}}%
-\indexlibrary{\idxcode{multiset}!\idxcode{multiset}}%
+\indexlibrary{\idxcode{multiset}!constructor}%
 \begin{itemdecl}
 template <class InputIterator>
   multiset(InputIterator first, InputIterator last,
@@ -7157,7 +7138,7 @@ namespace std {
 
 \rSec3[unord.map.cnstr]{\tcode{unordered_map} constructors}
 
-\indexlibrary{\idxcode{unordered_map}!\idxcode{unordered_map}}%
+\indexlibrary{\idxcode{unordered_map}!constructor}%
 \begin{itemdecl}
 unordered_map() : unordered_map(size_type(@\seebelow@)) { }
 explicit unordered_map(size_type n,
@@ -7179,7 +7160,7 @@ the number of buckets is \impldef{default number of buckets in
 \complexity Constant.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{unordered_map}!\idxcode{unordered_map}}%
+\indexlibrary{\idxcode{unordered_map}!constructor}%
 \begin{itemdecl}
 template <class InputIterator>
   unordered_map(InputIterator f, InputIterator l,
@@ -7637,7 +7618,7 @@ namespace std {
 
 \rSec3[unord.multimap.cnstr]{\tcode{unordered_multimap} constructors}
 
-\indexlibrary{\idxcode{unordered_multimap}!\idxcode{unordered_multimap}}%
+\indexlibrary{\idxcode{unordered_multimap}!constructor}%
 \begin{itemdecl}
 unordered_multimap() : unordered_multimap(size_type(@\seebelow@)) { }
 explicit unordered_multimap(size_type n,
@@ -7659,7 +7640,7 @@ the number of buckets is \impldef{default number of buckets in
 \complexity Constant.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{unordered_multimap}!\idxcode{unordered_multimap}}%
+\indexlibrary{\idxcode{unordered_multimap}!constructor}%
 \begin{itemdecl}
 template <class InputIterator>
   unordered_multimap(InputIterator f, InputIterator l,
@@ -7919,7 +7900,7 @@ namespace std {
 
 \rSec3[unord.set.cnstr]{\tcode{unordered_set} constructors}
 
-\indexlibrary{\idxcode{unordered_set}!\idxcode{unordered_set}}%
+\indexlibrary{\idxcode{unordered_set}!constructor}%
 \begin{itemdecl}
 unordered_set() : unordered_set(size_type(@\seebelow@)) { }
 explicit unordered_set(size_type n,
@@ -7941,7 +7922,7 @@ the number of buckets is \impldef{default number of buckets in
 \complexity Constant.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{unordered_set}!\idxcode{unordered_set}}%
+\indexlibrary{\idxcode{unordered_set}!constructor}%
 \begin{itemdecl}
 template <class InputIterator>
   unordered_set(InputIterator f, InputIterator l,
@@ -8172,7 +8153,7 @@ namespace std {
 
 \rSec3[unord.multiset.cnstr]{\tcode{unordered_multiset} constructors}
 
-\indexlibrary{\idxcode{unordered_multiset}!\idxcode{unordered_multiset}}%
+\indexlibrary{\idxcode{unordered_multiset}!constructor}%
 \begin{itemdecl}
 unordered_multiset() : unordered_multiset(size_type(@\seebelow@)) { }
 explicit unordered_multiset(size_type n,
@@ -8194,7 +8175,7 @@ the number of buckets is \impldef{default number of buckets in
 \complexity Constant.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{unordered_multiset}!\idxcode{unordered_multiset}}%
+\indexlibrary{\idxcode{unordered_multiset}!constructor}%
 \begin{itemdecl}
 template <class InputIterator>
   unordered_multiset(InputIterator f, InputIterator l,
@@ -8650,7 +8631,7 @@ namespace std {
 
 \rSec3[priqueue.cons]{\tcode{priority_queue} constructors}
 
-\indexlibrary{\idxcode{priority_queue}!\idxcode{priority_queue}}%
+\indexlibrary{\idxcode{priority_queue}!constructor}%
 \begin{itemdecl}
 priority_queue(const Compare& x, const Container& y);
 explicit priority_queue(const Compare& x = Compare(), Container&& y = Container());
@@ -8672,7 +8653,7 @@ calls
 \tcode{make_heap(c.begin(), c.end(), comp)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{priority_queue}!\idxcode{priority_queue}}%
+\indexlibrary{\idxcode{priority_queue}!constructor}%
 \begin{itemdecl}
 template <class InputIterator>
   priority_queue(InputIterator first, InputIterator last,
@@ -8708,6 +8689,7 @@ and finally calls
 If \tcode{uses_allocator<container_type, Alloc>::value} is \tcode{false}
 the constructors in this subclause shall not participate in overload resolution.
 
+\indexlibrary{\idxcode{priority_queue}!constructor}%
 \begin{itemdecl}
 template <class Alloc> explicit priority_queue(const Alloc& a);
 \end{itemdecl}
@@ -8717,6 +8699,7 @@ template <class Alloc> explicit priority_queue(const Alloc& a);
 \effects\ Initializes \tcode{c} with \tcode{a} and value-initializes \tcode{comp}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{priority_queue}!constructor}%
 \begin{itemdecl}
 template <class Alloc> priority_queue(const Compare& compare, const Alloc& a);
 \end{itemdecl}
@@ -8726,6 +8709,7 @@ template <class Alloc> priority_queue(const Compare& compare, const Alloc& a);
 \effects\ Initializes \tcode{c} with \tcode{a} and initializes \tcode{comp} with \tcode{compare}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{priority_queue}!constructor}%
 \begin{itemdecl}
 template <class Alloc>
   priority_queue(const Compare& compare, const Container& cont, const Alloc& a);
@@ -8738,6 +8722,7 @@ argument, and initializes \tcode{comp} with \tcode{compare};
 calls \tcode{make_heap(c.begin(), c.end(), comp)}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{priority_queue}!constructor}%
 \begin{itemdecl}
 template <class Alloc>
   priority_queue(const Compare& compare, Container&& cont, const Alloc& a);
@@ -8750,6 +8735,7 @@ as the second argument, and initializes \tcode{comp} with \tcode{compare};
 calls \tcode{make_heap(c.begin(), c.end(), comp)}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{priority_queue}!constructor}%
 \begin{itemdecl}
 template <class Alloc> priority_queue(const priority_queue& q, const Alloc& a);
 \end{itemdecl}
@@ -8760,6 +8746,7 @@ template <class Alloc> priority_queue(const priority_queue& q, const Alloc& a);
 the second argument, and initializes \tcode{comp} with \tcode{q.comp}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{priority_queue}!constructor}%
 \begin{itemdecl}
 template <class Alloc> priority_queue(priority_queue&& q, const Alloc& a);
 \end{itemdecl}
@@ -8934,6 +8921,7 @@ namespace std {
 
 \rSec3[stack.cons]{\tcode{stack} constructors}
 
+\indexlibrary{\idxcode{stack}!constructor}%
 \begin{itemdecl}
 explicit stack(const Container& cont);
 \end{itemdecl}
@@ -8943,6 +8931,7 @@ explicit stack(const Container& cont);
 \effects Initializes \tcode{c} with \tcode{cont}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{stack}!constructor}%
 \begin{itemdecl}
 explicit stack(Container&& cont = Container());
 \end{itemdecl}
@@ -8958,6 +8947,7 @@ explicit stack(Container&& cont = Container());
 If \tcode{uses_allocator<container_type, Alloc>::value} is \tcode{false}
 the constructors in this subclause shall not participate in overload resolution.
 
+\indexlibrary{\idxcode{stack}!constructor}%
 \begin{itemdecl}
 template <class Alloc> explicit stack(const Alloc& a);
 \end{itemdecl}
@@ -8967,6 +8957,7 @@ template <class Alloc> explicit stack(const Alloc& a);
 \effects\ Initializes \tcode{c} with \tcode{a}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{stack}!constructor}%
 \begin{itemdecl}
 template <class Alloc> stack(const container_type& cont, const Alloc& a);
 \end{itemdecl}
@@ -8977,6 +8968,7 @@ template <class Alloc> stack(const container_type& cont, const Alloc& a);
 second argument.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{stack}!constructor}%
 \begin{itemdecl}
 template <class Alloc> stack(container_type&& cont, const Alloc& a);
 \end{itemdecl}
@@ -8987,6 +8979,7 @@ template <class Alloc> stack(container_type&& cont, const Alloc& a);
 as the second argument.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{stack}!constructor}%
 \begin{itemdecl}
 template <class Alloc> stack(const stack& s, const Alloc& a);
 \end{itemdecl}
@@ -8997,6 +8990,7 @@ template <class Alloc> stack(const stack& s, const Alloc& a);
 as the second argument.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{stack}!constructor}%
 \begin{itemdecl}
 template <class Alloc> stack(stack&& s, const Alloc& a);
 \end{itemdecl}

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -54,7 +54,7 @@ These exceptions are related by inheritance.
 \indexlibrary{\idxcode{domain_error}}%
 \indexlibrary{\idxcode{invalid_argument}}%
 \indexlibrary{\idxcode{length_error}}%
-\indexlibrary{\idxcode{out_of_range_error}}%
+\indexlibrary{\idxcode{out_of_range}}%
 \indexlibrary{\idxcode{runtime_error}}%
 \indexlibrary{\idxcode{range_error}}%
 \indexlibrary{\idxcode{overflow_error}}%
@@ -95,7 +95,7 @@ exceptions to report errors presumably detectable before
 the program executes, such as violations of logical preconditions or class
 invariants.
 
-\indexlibrary{\idxcode{logic_error}!\tcode{logic_error}}%
+\indexlibrary{\idxcode{logic_error}!constructor}%
 \begin{itemdecl}
 logic_error(const string& what_arg);
 \end{itemdecl}
@@ -111,7 +111,7 @@ Constructs an object of class
 \tcode{strcmp(what(), what_arg.c_str()) == 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{logic_error}!\tcode{logic_error}}%
+\indexlibrary{\idxcode{logic_error}!constructor}%
 \begin{itemdecl}
 logic_error(const char* what_arg);
 \end{itemdecl}
@@ -146,7 +146,7 @@ The class
 defines the type of objects thrown as
 exceptions by the implementation to report domain errors.
 
-\indexlibrary{\idxcode{domain_error}!\tcode{domain_error}}%
+\indexlibrary{\idxcode{domain_error}!constructor}%
 \begin{itemdecl}
 domain_error(const string& what_arg);
 \end{itemdecl}
@@ -162,7 +162,7 @@ Constructs an object of class
 \tcode{strcmp(what(), what_arg.c_str()) == 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{domain_error}!\tcode{domain_error}}%
+\indexlibrary{\idxcode{domain_error}!constructor}%
 \begin{itemdecl}
 domain_error(const char* what_arg);
 \end{itemdecl}
@@ -196,7 +196,7 @@ The class
 \tcode{invalid_argument}
 defines the type of objects thrown as exceptions to report an invalid argument.
 
-\indexlibrary{\idxcode{invalid_argument}!\tcode{invalid_argument}}%
+\indexlibrary{\idxcode{invalid_argument}!constructor}%
 \begin{itemdecl}
 invalid_argument(const string& what_arg);
 \end{itemdecl}
@@ -212,7 +212,7 @@ Constructs an object of class
 \tcode{strcmp(what(), what_arg.c_str()) == 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{invalid_argument}!\tcode{invalid_argument}}%
+\indexlibrary{\idxcode{invalid_argument}!constructor}%
 \begin{itemdecl}
 invalid_argument(const char* what_arg);
 \end{itemdecl}
@@ -248,7 +248,7 @@ defines the type of objects thrown as exceptions
 to report an attempt to produce
 an object whose length exceeds its maximum allowable size.
 
-\indexlibrary{\idxcode{length_error}!\tcode{length_error}}%
+\indexlibrary{\idxcode{length_error}!constructor}%
 \begin{itemdecl}
 length_error(const string& what_arg);
 \end{itemdecl}
@@ -264,7 +264,7 @@ Constructs an object of class
 \tcode{strcmp(what(), what_arg.c_str()) == 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{length_error}!\tcode{length_error}}%
+\indexlibrary{\idxcode{length_error}!constructor}%
 \begin{itemdecl}
 length_error(const char* what_arg);
 \end{itemdecl}
@@ -300,7 +300,7 @@ defines the type of objects thrown as exceptions to report an
 argument value not in its expected range.
 \indextext{argument}
 
-\indexlibrary{\idxcode{out_of_range}!\tcode{out_of_range}}%
+\indexlibrary{\idxcode{out_of_range}!constructor}%
 \begin{itemdecl}
 out_of_range(const string& what_arg);
 \end{itemdecl}
@@ -316,7 +316,7 @@ Constructs an object of class
 \tcode{strcmp(what(), what_arg.c_str()) == 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{out_of_range}!\tcode{out_of_range}}%
+\indexlibrary{\idxcode{out_of_range}!constructor}%
 \begin{itemdecl}
 out_of_range(const char* what_arg);
 \end{itemdecl}
@@ -351,7 +351,7 @@ The class
 defines the type of objects thrown as exceptions to report errors presumably detectable only
 when the program executes.
 
-\indexlibrary{\idxcode{runtime_error}!\tcode{runtime_error}}%
+\indexlibrary{\idxcode{runtime_error}!constructor}%
 \begin{itemdecl}
 runtime_error(const string& what_arg);
 \end{itemdecl}
@@ -367,7 +367,7 @@ Constructs an object of class
 \tcode{strcmp(what(), what_arg.c_str()) == 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{runtime_error}!\tcode{runtime_error}}%
+\indexlibrary{\idxcode{runtime_error}!constructor}%
 \begin{itemdecl}
 runtime_error(const char* what_arg);
 \end{itemdecl}
@@ -402,7 +402,7 @@ The class
 defines the type of objects thrown as exceptions to report range errors
 in internal computations.
 
-\indexlibrary{\idxcode{range_error}!\tcode{range_error}}%
+\indexlibrary{\idxcode{range_error}!constructor}%
 \begin{itemdecl}
 range_error(const string& what_arg);
 \end{itemdecl}
@@ -418,7 +418,7 @@ Constructs an object of class
 \tcode{strcmp(what(), what_arg.c_str()) == 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{range_error}!\tcode{range_error}}%
+\indexlibrary{\idxcode{range_error}!constructor}%
 \begin{itemdecl}
 range_error(const char* what_arg);
 \end{itemdecl}
@@ -452,7 +452,7 @@ The class
 \tcode{overflow_error}
 defines the type of objects thrown as exceptions to report an arithmetic overflow error.
 
-\indexlibrary{\idxcode{overflow_error}!\tcode{overflow_error}}%
+\indexlibrary{\idxcode{overflow_error}!constructor}%
 \begin{itemdecl}
 overflow_error(const string& what_arg);
 \end{itemdecl}
@@ -468,7 +468,7 @@ Constructs an object of class
 \tcode{strcmp(what(), what_arg.c_str()) == 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{overflow_error}!\tcode{overflow_error}}%
+\indexlibrary{\idxcode{overflow_error}!constructor}%
 \begin{itemdecl}
 overflow_error(const char* what_arg);
 \end{itemdecl}
@@ -502,7 +502,7 @@ The class
 \tcode{underflow_error}
 defines the type of objects thrown as exceptions to report an arithmetic underflow error.
 
-\indexlibrary{\idxcode{underflow_error}!\tcode{underflow_error}}%
+\indexlibrary{\idxcode{underflow_error}!constructor}%
 \begin{itemdecl}
 underflow_error(const string& what_arg);
 \end{itemdecl}
@@ -518,7 +518,7 @@ Constructs an object of class
 \tcode{strcmp(what(), what_arg.c_str()) == 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{underflow_error}!\tcode{underflow_error}}%
+\indexlibrary{\idxcode{underflow_error}!constructor}%
 \begin{itemdecl}
 underflow_error(const char* what_arg);
 \end{itemdecl}
@@ -1126,8 +1126,7 @@ namespace std {
 
 \rSec3[syserr.errcode.constructors]{Class \tcode{error_code} constructors}
 
-\indexlibrary{\idxcode{error_code}!\idxcode{error_code}}
-\indexlibrary{\idxcode{error_code}!\idxcode{error_code}}
+\indexlibrary{\idxcode{error_code}!constructor}
 \begin{itemdecl}
 error_code() noexcept;
 \end{itemdecl}
@@ -1140,8 +1139,7 @@ error_code() noexcept;
 \postconditions \tcode{val_ == 0} and \tcode{cat_ == \&system_category()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{error_code}!\idxcode{error_code}}
-\indexlibrary{\idxcode{error_code}!\idxcode{error_code}}
+\indexlibrary{\idxcode{error_code}!constructor}
 \begin{itemdecl}
 error_code(int val, const error_category& cat) noexcept;
 \end{itemdecl}
@@ -1154,8 +1152,7 @@ error_code(int val, const error_category& cat) noexcept;
 \postconditions \tcode{val_ == val} and \tcode{cat_ == \&cat}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{error_code}!\idxcode{error_code}}
-\indexlibrary{\idxcode{error_code}!\idxcode{error_code}}
+\indexlibrary{\idxcode{error_code}!constructor}
 \begin{itemdecl}
 template <class ErrorCodeEnum>
   error_code(ErrorCodeEnum e) noexcept;
@@ -1631,8 +1628,7 @@ namespace std {
 
 \rSec3[syserr.syserr.members]{Class \tcode{system_error} members}
 
-\indexlibrary{\idxcode{system_error}!\idxcode{system_error}}
-\indexlibrary{\idxcode{system_error}!\idxcode{system_error}}
+\indexlibrary{\idxcode{system_error}!constructor}
 \begin{itemdecl}
 system_error(error_code ec, const string& what_arg);
 \end{itemdecl}
@@ -1647,8 +1643,7 @@ system_error(error_code ec, const string& what_arg);
 \tcode{string(what()).find(what_arg) != string::npos}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{system_error}!\idxcode{system_error}}
-\indexlibrary{\idxcode{system_error}!\idxcode{system_error}}
+\indexlibrary{\idxcode{system_error}!constructor}
 \begin{itemdecl}
 system_error(error_code ec, const char* what_arg);
 \end{itemdecl}
@@ -1663,8 +1658,7 @@ system_error(error_code ec, const char* what_arg);
 \tcode{string(what()).find(what_arg) != string::npos}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{system_error}!\idxcode{system_error}}
-\indexlibrary{\idxcode{system_error}!\idxcode{system_error}}
+\indexlibrary{\idxcode{system_error}!constructor}
 \begin{itemdecl}
 system_error(error_code ec);
 \end{itemdecl}
@@ -1677,8 +1671,7 @@ system_error(error_code ec);
 \postconditions \tcode{code() == ec}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{system_error}!\idxcode{system_error}}
-\indexlibrary{\idxcode{system_error}!\idxcode{system_error}}
+\indexlibrary{\idxcode{system_error}!constructor}
 \begin{itemdecl}
 system_error(int ev, const error_category& ecat,
   const string& what_arg);
@@ -1694,8 +1687,7 @@ system_error(int ev, const error_category& ecat,
 \tcode{string(what()).find(what_arg) != string::npos}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{system_error}!\idxcode{system_error}}
-\indexlibrary{\idxcode{system_error}!\idxcode{system_error}}
+\indexlibrary{\idxcode{system_error}!constructor}
 \begin{itemdecl}
 system_error(int ev, const error_category& ecat,
   const char* what_arg);
@@ -1711,8 +1703,7 @@ system_error(int ev, const error_category& ecat,
 \tcode{string(what()).find(what_arg) != string::npos}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{system_error}!\idxcode{system_error}}
-\indexlibrary{\idxcode{system_error}!\idxcode{system_error}}
+\indexlibrary{\idxcode{system_error}!constructor}
 \begin{itemdecl}
 system_error(int ev, const error_category& ecat);
 \end{itemdecl}

--- a/source/future.tex
+++ b/source/future.tex
@@ -231,7 +231,7 @@ if \tcode{pend} is not a null pointer, or \tcode{gend}.
 
 \rSec3[depr.strstreambuf.cons]{\tcode{strstreambuf} constructors}
 
-\indexlibrary{\idxcode{strstreambuf}!\tcode{strstreambuf}}%
+\indexlibrary{\idxcode{strstreambuf}!constructor}%
 \begin{itemdecl}
 explicit strstreambuf(streamsize alsize_arg = 0);
 \end{itemdecl}
@@ -255,7 +255,7 @@ The postconditions of this function are indicated in Table~\ref{tab:future.strst
 \tcode{pfree}	&	a null pointer		\\
 \end{libtab2}
 
-\indexlibrary{\idxcode{strstreambuf}}%
+\indexlibrary{\idxcode{strstreambuf}!constructor}%
 \begin{itemdecl}
 strstreambuf(void* (*palloc_arg)(size_t), void (*pfree_arg)(void*));
 \end{itemdecl}
@@ -281,6 +281,7 @@ The postconditions of this function are indicated in Table~\ref{tab:future.strst
 \end{itemdescr}
 
 \indextext{unspecified}%
+\indexlibrary{\idxcode{strstreambuf}!constructor}%
 \begin{itemdecl}
 strstreambuf(char* gnext_arg, streamsize n, char* pbeg_arg = 0);
 strstreambuf(signed char* gnext_arg, streamsize n,
@@ -786,7 +787,7 @@ For the sake of exposition, the maintained data is presented here as:
 
 \rSec3[depr.istrstream.cons]{\tcode{istrstream} constructors}
 
-\indexlibrary{\idxcode{istrstream}!\idxcode{istrstream}}%
+\indexlibrary{\idxcode{istrstream}!constructor}%
 \begin{itemdecl}
 explicit istrstream(const char* s);
 explicit istrstream(char* s);
@@ -885,7 +886,7 @@ For the sake of exposition, the maintained data is presented here as:
 
 \rSec3[depr.ostrstream.cons]{\tcode{ostrstream} constructors}
 
-\indexlibrary{\idxcode{ostrstream}!\idxcode{ostrstream}}%
+\indexlibrary{\idxcode{ostrstream}!constructor}%
 \begin{itemdecl}
     ostrstream();
 \end{itemdecl}
@@ -1036,7 +1037,7 @@ For the sake of exposition, the maintained data is presented here as:
 
 \rSec3[depr.strstream.cons]{\tcode{strstream} constructors}
 
-\indexlibrary{\idxcode{strstream}!\idxcode{strstream}}%
+\indexlibrary{\idxcode{strstream}!constructor}%
 \begin{itemdecl}
 strstream();
 \end{itemdecl}
@@ -1050,7 +1051,7 @@ initializing the base class with
 \tcode{iostream(\&sb)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{strstream}!\idxcode{strstream}}%
+\indexlibrary{\idxcode{strstream}!constructor}%
 \begin{itemdecl}
 strstream(char* s, int n,
           ios_base::openmode mode = ios_base::in|ios_base::out);

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -908,7 +908,7 @@ reported by the operating system. Errors arising from within the stream library 
 typically be reported as \tcode{error_code(io_errc::stream,
 iostream_category())}. \exitnote
 
-\indexlibrary{\idxcode{failure}!\idxcode{ios_base::failure}}%
+\indexlibrary{\idxcode{ios_base::failure}!constructor}%
 \begin{itemdecl}
 explicit failure(const string& msg, const error_code& ec = io_errc::stream);
 \end{itemdecl}
@@ -920,7 +920,7 @@ Constructs an object of class
 \tcode{failure} by constructing the base class with \tcode{msg} and \tcode{ec}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{failure}!\idxcode{ios_base::failure}}%
+\indexlibrary{\idxcode{ios_base::failure}!constructor}%
 \begin{itemdecl}
 explicit failure(const char* msg, const error_code& ec = io_errc::stream);
 \end{itemdecl}
@@ -1122,7 +1122,7 @@ constructor and destructor calls for class
 initialized to zero.
 \end{itemize}
 
-\indexlibrary{\idxcode{Init}!\idxcode{ios_base::Init}}%
+\indexlibrary{\idxcode{ios_base::Init}!constructor}%
 \begin{itemdecl}
 Init();
 \end{itemdecl}
@@ -1558,7 +1558,7 @@ A function registered twice will be called twice.
 
 \rSec3[ios.base.cons]{\tcode{ios_base} constructors/destructor}
 
-\indexlibrary{\idxcode{ios_base}!\idxcode{ios_base}}%
+\indexlibrary{\idxcode{ios_base}!constructor}%
 \begin{itemdecl}
 ios_base();
 \end{itemdecl}
@@ -1807,7 +1807,7 @@ namespace std {
 
 \rSec3[basic.ios.cons]{\tcode{basic_ios} constructors}
 
-\indexlibrary{\idxcode{basic_ios}!\idxcode{basic_ios}}%
+\indexlibrary{\idxcode{basic_ios}!constructor}%
 \begin{itemdecl}
 explicit basic_ios(basic_streambuf<charT, traits>* sb);
 \end{itemdecl}
@@ -3014,7 +3014,7 @@ a character
 
 \rSec3[streambuf.cons]{\tcode{basic_streambuf} constructors}
 
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!constructor}%
 \begin{itemdecl}
 basic_streambuf();
 \end{itemdecl}
@@ -4327,7 +4327,7 @@ a failure indication.
 
 \rSec4[istream.cons]{\tcode{basic_istream} constructors}
 
-\indexlibrary{\idxcode{basic_istream}!\idxcode{basic_istream}}%
+\indexlibrary{\idxcode{basic_istream}!constructor}%
 \begin{itemdecl}
 explicit basic_istream(basic_streambuf<charT, traits>* sb);
 \end{itemdecl}
@@ -5668,7 +5668,6 @@ The class template
 \tcode{basic_iostream}
 inherits a number of functions that allow reading input and writing output to
 sequences controlled by a stream buffer.
-\indexlibrary{\idxcode{basic_iostream}!\idxcode{basic_iostream}}%
 
 \rSec4[iostream.cons]{\tcode{basic_iostream} constructors}
 
@@ -5927,7 +5926,7 @@ it does not throw anything and treat as an error.
 
 \rSec3[ostream.cons]{\tcode{basic_ostream} constructors}
 
-\indexlibrary{\idxcode{basic_ostream}!\idxcode{basic_ostream}}%
+\indexlibrary{\idxcode{basic_ostream}!constructor}%
 \begin{itemdecl}
 explicit basic_ostream(basic_streambuf<charT, traits>* sb);
 \end{itemdecl}
@@ -7404,7 +7403,7 @@ set if the output sequence can be written.
 
 \rSec3[stringbuf.cons]{\tcode{basic_stringbuf}  constructors}
 
-\indexlibrary{\idxcode{basic_stringbuf}!\idxcode{basic_stringbuf}}%
+\indexlibrary{\idxcode{basic_stringbuf}!constructor}%
 \begin{itemdecl}
 explicit basic_stringbuf(
   ios_base::openmode which = ios_base::in | ios_base::out);
@@ -7905,7 +7904,7 @@ For the sake of exposition, the maintained data is presented here as:
 
 \rSec3[istringstream.cons]{\tcode{basic_istringstream} constructors}
 
-\indexlibrary{\idxcode{basic_istringstream}!\idxcode{basic_istringstream}}%
+\indexlibrary{\idxcode{basic_istringstream}!constructor}%
 \begin{itemdecl}
 explicit basic_istringstream(ios_base::openmode which = ios_base::in);
 \end{itemdecl}
@@ -8097,7 +8096,7 @@ For the sake of exposition, the maintained data is presented here as:
 
 \rSec3[ostringstream.cons]{\tcode{basic_ostringstream} constructors}
 
-\indexlibrary{\idxcode{basic_ostringstream}!\idxcode{basic_ostringstream}}%
+\indexlibrary{\idxcode{basic_ostringstream}!constructor}%
 \begin{itemdecl}
 explicit basic_ostringstream(
   ios_base::openmode which = ios_base::out);
@@ -8291,7 +8290,7 @@ For the sake of exposition, the maintained data is presented here as
 
 \rSec3[stringstream.cons]{basic_stringstream constructors}
 
-\indexlibrary{\idxcode{basic_stringstream}!\idxcode{basic_stringstream}}%
+\indexlibrary{\idxcode{basic_stringstream}!constructor}%
 \begin{itemdecl}
 explicit basic_stringstream(
   ios_base::openmode which = ios_base::out | ios_base::in);
@@ -8590,7 +8589,7 @@ const codecvt<charT, char, typename traits::state_type>& a_codecvt =
 
 \rSec3[filebuf.cons]{\tcode{basic_filebuf} constructors}
 
-\indexlibrary{\idxcode{basic_filebuf}!\idxcode{basic_filebuf}}%
+\indexlibrary{\idxcode{basic_filebuf}!constructor}%
 \begin{itemdecl}
 basic_filebuf();
 \end{itemdecl}
@@ -9313,7 +9312,7 @@ For the sake of exposition, the maintained data is presented here as:
 
 \rSec3[ifstream.cons]{\tcode{basic_ifstream} constructors}
 
-\indexlibrary{\idxcode{basic_ifstream}!\idxcode{basic_ifstream}}%
+\indexlibrary{\idxcode{basic_ifstream}!constructor}%
 \begin{itemdecl}
 basic_ifstream();
 \end{itemdecl}
@@ -9553,7 +9552,7 @@ For the sake of exposition, the maintained data is presented here as:
 
 \rSec3[ofstream.cons]{\tcode{basic_ofstream} constructors}
 
-\indexlibrary{\idxcode{basic_ofstream}!\idxcode{basic_ofstream}}%
+\indexlibrary{\idxcode{basic_ofstream}!constructor}%
 \begin{itemdecl}
 basic_ofstream();
 \end{itemdecl}
@@ -9797,7 +9796,7 @@ For the sake of exposition, the maintained data is presented here as:
 
 \rSec3[fstream.cons]{\tcode{basic_fstream} constructors}
 
-\indexlibrary{\idxcode{basic_fstream}!\idxcode{basic_fstream}}%
+\indexlibrary{\idxcode{basic_fstream}!constructor}%
 \begin{itemdecl}
 basic_fstream();
 \end{itemdecl}

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1322,7 +1322,7 @@ are referenced in a way that requires instantiation~(\ref{temp.inst}).
 
 \rSec4[reverse.iter.cons]{\tcode{reverse_iterator} constructor}
 
-\indexlibrary{\idxcode{reverse_iterator}!\tcode{reverse_iterator}}%
+\indexlibrary{\idxcode{reverse_iterator}!constructor}%
 \begin{itemdecl}
 constexpr reverse_iterator();
 \end{itemdecl}
@@ -1803,7 +1803,7 @@ namespace std {
 
 \rSec4[back.insert.iter.cons]{\tcode{back_insert_iterator} constructor}
 
-\indexlibrary{\idxcode{back_insert_iterator}!\idxcode{back_insert_iterator}}%
+\indexlibrary{\idxcode{back_insert_iterator}!constructor}%
 \begin{itemdecl}
 explicit back_insert_iterator(Container& x);
 \end{itemdecl}
@@ -1925,7 +1925,7 @@ namespace std {
 
 \rSec4[front.insert.iter.cons]{\tcode{front_insert_iterator} constructor}
 
-\indexlibrary{\idxcode{front_insert_iterator}!\idxcode{front_insert_iterator}}%
+\indexlibrary{\idxcode{front_insert_iterator}!constructor}%
 \begin{itemdecl}
 explicit front_insert_iterator(Container& x);
 \end{itemdecl}
@@ -2048,7 +2048,7 @@ namespace std {
 
 \rSec4[insert.iter.cons]{\tcode{insert_iterator} constructor}
 
-\indexlibrary{\idxcode{insert_iterator}!\idxcode{insert_iterator}}%
+\indexlibrary{\idxcode{insert_iterator}!constructor}%
 \begin{itemdecl}
 insert_iterator(Container& x, typename Container::iterator i);
 \end{itemdecl}
@@ -2259,7 +2259,7 @@ or a Random Access Iterator~(\ref{random.access.iterators}), respectively.
 
 \rSec4[move.iter.op.const]{\tcode{move_iterator} constructors}
 
-\indexlibrary{\idxcode{move_iterator}!\idxcode{move_iterator}}%
+\indexlibrary{\idxcode{move_iterator}!constructor}%
 \begin{itemdecl}
 constexpr move_iterator();
 \end{itemdecl}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -507,7 +507,7 @@ namespace std {
 
 \rSec2[complex.members]{\tcode{complex} member functions}
 
-\indexlibrary{\idxcode{complex}!\idxcode{complex}}%
+\indexlibrary{\idxcode{complex}!constructor}%
 \begin{itemdecl}
 template<class T> constexpr complex(const T& re = T(), const T& im = T());
 \end{itemdecl}
@@ -6736,7 +6736,7 @@ as
 
 \rSec3[valarray.cons]{\tcode{valarray} constructors}
 
-\indexlibrary{\idxcode{valarray}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{valarray}!constructor}%
 \begin{itemdecl}
 valarray();
 \end{itemdecl}
@@ -6757,7 +6757,7 @@ After initialization, the length of an empty array can be increased with the
 member function.}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{valarray}!\idxcode{constructor}}%
+\indexlibrary{\idxcode{valarray}!constructor}%
 \begin{itemdecl}
 explicit valarray(size_t);
 \end{itemdecl}
@@ -6768,7 +6768,7 @@ The array created by this constructor has a length equal to the value of the arg
 The elements of the array are value-initialized~(\ref{dcl.init}).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{valarray}!\idxcode{constructor}}%
+\indexlibrary{\idxcode{valarray}!constructor}%
 \begin{itemdecl}
 valarray(const T&, size_t);
 \end{itemdecl}
@@ -6780,7 +6780,7 @@ argument.
 The elements of the array are initialized with the value of the first argument.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{valarray}!\idxcode{constructor}}%
+\indexlibrary{\idxcode{valarray}!constructor}%
 \begin{itemdecl}
 valarray(const T*, size_t);
 \end{itemdecl}
@@ -6802,7 +6802,7 @@ pointed to by the first argument, the behavior is undefined.%
 \indextext{undefined}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{valarray}!\idxcode{constructor}}%
+\indexlibrary{\idxcode{valarray}!constructor}%
 \begin{itemdecl}
 valarray(const valarray&);
 \end{itemdecl}
@@ -6819,7 +6819,7 @@ shall implement a copy-on-reference mechanism to ensure that arrays are
 conceptually distinct.}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{valarray}!\idxcode{constructor}}%
+\indexlibrary{\idxcode{valarray}!constructor}%
 \begin{itemdecl}
 valarray(valarray&& v) noexcept;
 \end{itemdecl}
@@ -6835,7 +6835,7 @@ elements of the argument array.
 \complexity Constant.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{valarray}!\idxcode{constructor}}%
+\indexlibrary{\idxcode{valarray}!constructor}%
 \begin{itemdecl}
 valarray(initializer_list<T> il);
 \end{itemdecl}
@@ -6845,7 +6845,7 @@ valarray(initializer_list<T> il);
 \effects Same as \tcode{valarray(il.begin(), il.size())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{valarray}!\idxcode{constructor}}%
+\indexlibrary{\idxcode{valarray}!constructor}%
 \begin{itemdecl}
 valarray(const slice_array<T>&);
 valarray(const gslice_array<T>&);
@@ -7822,7 +7822,7 @@ August, 1988.}
 
 \rSec3[cons.slice]{\tcode{slice} constructors}
 
-\indexlibrary{\idxcode{slice}!\idxcode{slice}}%
+\indexlibrary{\idxcode{slice}!constructor}%
 \begin{itemdecl}
 slice();
 slice(size_t start, size_t length, size_t stride);

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -1486,7 +1486,6 @@ The static constant members are provided as synonyms for the constants
 declared in namespace \tcode{regex_constants}.
 
 \rSec2[re.regex.construct]{\tcode{basic_regex} constructors}
-\indexlibrary{\idxcode{basic_regex}!\idxcode{basic_regex}}%
 
 \indexlibrary{\idxcode{basic_regex}!constructor}%
 \begin{itemdecl}
@@ -1499,7 +1498,7 @@ basic_regex();
 does not match any character sequence.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_regex}!\idxcode{basic_regex}}%
+\indexlibrary{\idxcode{basic_regex}!constructor}%
 \begin{itemdecl}
 explicit basic_regex(const charT* p, flag_type f = regex_constants::ECMAScript);
 \end{itemdecl}
@@ -1524,7 +1523,7 @@ designated by \textit{p}, and interpreted according to the flags \textit{f}.
 within the expression.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_regex}!\idxcode{basic_regex}}%
+\indexlibrary{\idxcode{basic_regex}!constructor}%
 \begin{itemdecl}
 basic_regex(const charT* p, size_t len, flag_type f);
 \end{itemdecl}
@@ -1548,7 +1547,7 @@ interpreted according the flags specified in \textit{f}.
 within the expression.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_regex}!\idxcode{basic_regex}}%
+\indexlibrary{\idxcode{basic_regex}!constructor}%
 \begin{itemdecl}
 basic_regex(const basic_regex& e); 
 \end{itemdecl}
@@ -1563,7 +1562,7 @@ the object \tcode{e}.
 \tcode{e.flags()} and \tcode{e.mark_count()}, respectively.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_regex}!\idxcode{basic_regex}}%
+\indexlibrary{\idxcode{basic_regex}!constructor}%
 \begin{itemdecl}
 basic_regex(basic_regex&& e) noexcept;
 \end{itemdecl}
@@ -1578,7 +1577,7 @@ basic_regex(basic_regex&& e) noexcept;
 \tcode{e} is in a valid state with unspecified value.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_regex}!\idxcode{basic_regex}}%
+\indexlibrary{\idxcode{basic_regex}!constructor}%
 \begin{itemdecl}
 template <class ST, class SA>
   explicit basic_regex(const basic_string<charT, ST, SA>& s,
@@ -1601,7 +1600,7 @@ flags specified in \tcode{f}.
 within the expression.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_regex}!\idxcode{basic_regex}}%
+\indexlibrary{\idxcode{basic_regex}!constructor}%
 \begin{itemdecl}
 template <class ForwardIterator>
   basic_regex(ForwardIterator first, ForwardIterator last,
@@ -2685,7 +2684,7 @@ In all \tcode{match_results} constructors, a copy of the \tcode{Allocator} argum
 shall be used for any memory allocation performed by the constructor
 or member functions during the lifetime of the object.
 
-\indexlibrary{\idxcode{match_results}!\idxcode{match_results}}%
+\indexlibrary{\idxcode{match_results}!constructor}%
 \begin{itemdecl}
 match_results(const Allocator& a = Allocator()); 
 \end{itemdecl}
@@ -2700,7 +2699,7 @@ match_results(const Allocator& a = Allocator());
 \tcode{size()} returns \tcode{0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{match_results}!\idxcode{match_results}}%
+\indexlibrary{\idxcode{match_results}!constructor}%
 \begin{itemdecl}
 match_results(const match_results& m); 
 \end{itemdecl}
@@ -2711,7 +2710,7 @@ match_results(const match_results& m);
 copy of \tcode{m}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{match_results}!\idxcode{match_results}}%
+\indexlibrary{\idxcode{match_results}!constructor}%
 \begin{itemdecl}
 match_results(match_results&& m) noexcept;
 \end{itemdecl}
@@ -3715,7 +3714,7 @@ matched consists only of an assertion (such as \verb|'^'|, \verb|'$'|,
 
 \rSec3[re.regiter.cnstr]{\tcode{regex_iterator} constructors}
 
-\indexlibrary{\idxcode{regex_iterator}!\idxcode{regex_iterator}}%
+\indexlibrary{\idxcode{regex_iterator}!constructor}%
 \begin{itemdecl}
 regex_iterator(); 
 \end{itemdecl}
@@ -3724,7 +3723,7 @@ regex_iterator();
 \pnum\effects  Constructs an end-of-sequence iterator.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{regex_iterator}!\idxcode{regex_iterator}}%
+\indexlibrary{\idxcode{regex_iterator}!constructor}%
 \begin{itemdecl}
 regex_iterator(BidirectionalIterator a, BidirectionalIterator b, 
                const regex_type& re, 
@@ -4029,7 +4028,7 @@ The \textit{current match} is \tcode{(*position).prefix()} if \tcode{subs[N] == 
 
 \rSec3[re.tokiter.cnstr]{\tcode{regex_token_iterator} constructors}
 
-\indexlibrary{\idxcode{regex_token_iterator}!\idxcode{regex_token_iterator}}%
+\indexlibrary{\idxcode{regex_token_iterator}!constructor}%
 \begin{itemdecl}
 regex_token_iterator(); 
 \end{itemdecl}
@@ -4039,7 +4038,7 @@ regex_token_iterator();
 \effects  Constructs the end-of-sequence iterator.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{regex_token_iterator}!\idxcode{regex_token_iterator}}%
+\indexlibrary{\idxcode{regex_token_iterator}!constructor}%
 \begin{itemdecl}
 regex_token_iterator(BidirectionalIterator a, BidirectionalIterator b, 
                     const regex_type& re, 

--- a/source/support.tex
+++ b/source/support.tex
@@ -2089,7 +2089,7 @@ The class
 defines the type of objects thrown as
 exceptions by the implementation to report a failure to allocate storage.
 
-\indexlibrary{\idxcode{bad_alloc}!\idxcode{bad_alloc}}%
+\indexlibrary{\idxcode{bad_alloc}!constructor}%
 \begin{itemdecl}
 bad_alloc() noexcept;
 \end{itemdecl}
@@ -2102,7 +2102,7 @@ Constructs an object of class
 \end{itemdescr}
 
 \indextext{implementation-defined}%
-\indexlibrary{\idxcode{bad_alloc}!\idxcode{bad_alloc}}%
+\indexlibrary{\idxcode{bad_alloc}!constructor}%
 \indexlibrary{\idxcode{operator=}!\idxcode{bad_alloc}}%
 \begin{itemdecl}
 bad_alloc(const bad_alloc&) noexcept;
@@ -2153,7 +2153,7 @@ exceptions by the implementation to report an attempt to allocate an array of si
 less than zero or
 greater than an implementation-defined limit~(\ref{expr.new}).
 
-\indexlibrary{\idxcode{bad_array_new_length}!\idxcode{bad_array_new_length}}%
+\indexlibrary{\idxcode{bad_array_new_length}!constructor}%
 \begin{itemdecl}
 bad_array_new_length() noexcept;
 \end{itemdecl}
@@ -2461,7 +2461,7 @@ as exceptions by the implementation to report the execution of an invalid
 expression~(\ref{expr.dynamic.cast}).
 
 \indextext{cast!dynamic}%
-\indexlibrary{\idxcode{bad_cast}!\tcode{bad_cast}}%
+\indexlibrary{\idxcode{bad_cast}!constructor}%
 \begin{itemdecl}
 bad_cast() noexcept;
 \end{itemdecl}
@@ -2473,7 +2473,7 @@ Constructs an object of class
 \tcode{bad_cast}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{bad_cast}!\tcode{bad_cast}}%
+\indexlibrary{\idxcode{bad_cast}!constructor}%
 \indexlibrary{\idxcode{operator=}!\idxcode{bad_cast}}%
 \begin{itemdecl}
 bad_cast(const bad_cast&) noexcept;
@@ -2529,7 +2529,7 @@ in a
 \grammarterm{typeid}
 expression~(\ref{expr.typeid}).
 
-\indexlibrary{\idxcode{bad_typeid}!\tcode{bad_typeid}}%
+\indexlibrary{\idxcode{bad_typeid}!constructor}%
 \begin{itemdecl}
 bad_typeid() noexcept;
 \end{itemdecl}
@@ -2541,7 +2541,7 @@ Constructs an object of class
 \tcode{bad_typeid}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{bad_typeid}!\tcode{bad_typeid}}%
+\indexlibrary{\idxcode{bad_typeid}!constructor}%
 \indexlibrary{\idxcode{operator=}!\idxcode{bad_typeid}}%
 \begin{itemdecl}
 bad_typeid(const bad_typeid&) noexcept;
@@ -2661,6 +2661,7 @@ Constructs an object of class
 \tcode{exception}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{exception}!constructor}%
 \indexlibrary{\idxcode{operator=}!\idxcode{exception}}%
 \begin{itemdecl}
 exception(const exception& rhs) noexcept;
@@ -2734,7 +2735,7 @@ The class
 defines the type of objects thrown as
 described in~(\ref{except.unexpected}).
 
-\indexlibrary{\idxcode{bad_exception}!\tcode{bad_exception}}%
+\indexlibrary{\idxcode{bad_exception}!constructor}%
 \begin{itemdecl}
 bad_exception() noexcept;
 \end{itemdecl}
@@ -2746,7 +2747,7 @@ Constructs an object of class
 \tcode{bad_exception}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{bad_exception}!\tcode{bad_exception}}%
+\indexlibrary{\idxcode{bad_exception}!constructor}%
 \indexlibrary{\idxcode{operator=}!\idxcode{bad_exception}}%
 \begin{itemdecl}
 bad_exception(const bad_exception&) noexcept;
@@ -3020,8 +3021,7 @@ for later use.
 polymorphic class. Its presence can be tested for with \tcode{dynamic_cast}.
 \exitnote
 
-\indexlibrary{\idxcode{nested_exception}!\idxcode{nested_exception}}
-\indexlibrary{\idxcode{nested_exception}!\idxcode{nested_exception}}
+\indexlibrary{\idxcode{nested_exception}!constructor}
 \begin{itemdecl}
 nested_exception() noexcept;
 \end{itemdecl}
@@ -3242,8 +3242,7 @@ If an explicit specialization or partial specialization of
 
 \rSec2[support.initlist.cons]{Initializer list constructors}
 
-\indexlibrary{\idxcode{initializer_list}!\idxcode{initializer_list}}
-\indexlibrary{\idxcode{initializer_list}!\idxcode{initializer_list}}
+\indexlibrary{\idxcode{initializer_list}!constructor}
 \begin{itemdecl}
 constexpr initializer_list() noexcept;
 \end{itemdecl}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -591,8 +591,7 @@ be a \tcode{constexpr} function if and only if all required element-wise
 initializations for copy and move, respectively, would satisfy the
 requirements for a \tcode{constexpr} function.
 
-\indexlibrary{\idxcode{pair}!\idxcode{pair}}
-\indexlibrary{\idxcode{pair}!\idxcode{pair}}
+\indexlibrary{\idxcode{pair}!constructor}
 \begin{itemdecl}
 constexpr pair();
 \end{itemdecl}
@@ -611,8 +610,7 @@ This constructor shall not participate in overload resolution unless
 with default template arguments. \exitnote
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pair}!\idxcode{pair}}
-\indexlibrary{\idxcode{pair}!\idxcode{pair}}
+\indexlibrary{\idxcode{pair}!constructor}
 \begin{itemdecl}
 @\EXPLICIT@ constexpr pair(const T1& x, const T2& y);
 \end{itemdecl}
@@ -632,8 +630,7 @@ The constructor is explicit if and only if
 \tcode{is_convertible<const second_type\&, second_type>::value} is \tcode{false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pair}!\idxcode{pair}}
-\indexlibrary{\idxcode{pair}!\idxcode{pair}}
+\indexlibrary{\idxcode{pair}!constructor}
 \begin{itemdecl}
 template<class U, class V> @\EXPLICIT@ constexpr pair(U&& x, V&& y);
 \end{itemdecl}
@@ -655,8 +652,7 @@ The constructor is explicit if and only if
 \tcode{is_convertible<V\&\&, second_type>::value} is \tcode{false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pair}!\idxcode{pair}}
-\indexlibrary{\idxcode{pair}!\idxcode{pair}}
+\indexlibrary{\idxcode{pair}!constructor}
 \begin{itemdecl}
 template<class U, class V> @\EXPLICIT@ constexpr pair(const pair<U, V>& p);
 \end{itemdecl}
@@ -675,8 +671,7 @@ The constructor is explicit if and only if
 \tcode{is_convertible<const V\&, second_type>::value} is \tcode{false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pair}!\idxcode{pair}}
-\indexlibrary{\idxcode{pair}!\idxcode{pair}}
+\indexlibrary{\idxcode{pair}!constructor}
 \begin{itemdecl}
 template<class U, class V> @\EXPLICIT@ constexpr pair(pair<U, V>&& p);
 \end{itemdecl}
@@ -698,8 +693,7 @@ The constructor is explicit if and only if
 \tcode{is_convertible<V\&\&, second_type>::value} is \tcode{false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pair}!\idxcode{pair}}
-\indexlibrary{\idxcode{pair}!\idxcode{pair}}
+\indexlibrary{\idxcode{pair}!constructor}
 \begin{itemdecl}
 template<class... Args1, class... Args2>
   pair(piecewise_construct_t,
@@ -1254,7 +1248,7 @@ In the constructor descriptions that follow, let $i$ be in the range
 $U_i$ be the $i^{th}$ type in a template parameter pack named \tcode{UTypes}, where indexing
 is zero-based.
 
-\indexlibrary{\idxcode{tuple}!\idxcode{tuple}}%
+\indexlibrary{\idxcode{tuple}!constructor}%
 \begin{itemdecl}
 constexpr tuple();
 \end{itemdecl}
@@ -3879,7 +3873,7 @@ error is associated with exceptions of type
 
 \rSec2[bitset.cons]{\tcode{bitset} constructors}
 
-\indexlibrary{\idxcode{bitset}!\idxcode{bitset}}%
+\indexlibrary{\idxcode{bitset}!constructor}%
 \begin{itemdecl}
 constexpr bitset() noexcept;
 \end{itemdecl}
@@ -3892,8 +3886,7 @@ Constructs an object of class
 initializing all bits to zero.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{bitset}!\idxcode{bitset}}
-\indexlibrary{\idxcode{bitset}!\idxcode{bitset}}
+\indexlibrary{\idxcode{bitset}!constructor}
 \begin{itemdecl}
 constexpr bitset(unsigned long long val) noexcept;
 \end{itemdecl}
@@ -3910,8 +3903,7 @@ representation~(\ref{basic.types}) of \tcode{unsigned long long}.
 If \tcode{M < N}, the remaining bit positions are initialized to zero.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{bitset}!\idxcode{bitset}}
-\indexlibrary{\idxcode{bitset}!\idxcode{bitset}}
+\indexlibrary{\idxcode{bitset}!constructor}
 \begin{itemdecl}
 template <class charT, class traits, class Allocator>
 explicit
@@ -3966,8 +3958,7 @@ Subsequent decreasing character positions correspond to increasing bit positions
 If \tcode{M < N}, remaining bit positions are initialized to zero.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{bitset}!\idxcode{bitset}}
-\indexlibrary{\idxcode{bitset}!\idxcode{bitset}}
+\indexlibrary{\idxcode{bitset}!constructor}
 \begin{itemdecl}
 template <class charT>
   explicit bitset(
@@ -5446,7 +5437,8 @@ static void deallocate(Alloc& a, pointer p, size_type n);
 \throws Nothing.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{allocator_traits}!constructor}%
+\indexlibrary{\idxcode{allocator_traits}!\idxcode{construct}}%
+\indexlibrary{\idxcode{construct}!\idxcode{allocator_traits}}%
 \begin{itemdecl}
 template <class T, class... Args>
   static void construct(Alloc& a, T* p, Args&&... args);
@@ -5459,7 +5451,8 @@ if that call is well-formed;
 otherwise, invokes \tcode{::new (static_cast<void*>(p)) T(std::forward<Args>(args)...)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{allocator_traits}!destructor}%
+\indexlibrary{\idxcode{allocator_traits}!\idxcode{destroy}}%
+\indexlibrary{\idxcode{destroy}!\idxcode{allocator_traits}}%
 \begin{itemdecl}
 template <class T>
   static void destroy(Alloc& a, T* p);
@@ -6214,8 +6207,7 @@ namespace std {
 }
 \end{codeblock}
 
-\indexlibrary{\idxcode{default_delete}!\idxcode{default_delete}}
-\indexlibrary{\idxcode{default_delete}!\idxcode{default_delete}}
+\indexlibrary{\idxcode{default_delete}!constructor}
 \begin{itemdecl}
 template <class U> default_delete(const default_delete<U>& other) noexcept;
 \end{itemdecl}
@@ -6256,7 +6248,7 @@ namespace std {
 }
 \end{codeblock}
 
-\indexlibrary{\idxcode{default_delete}!\idxcode{default_delete}}
+\indexlibrary{\idxcode{default_delete}!constructor}
 \begin{itemdecl}
 template <class U> default_delete(const default_delete<U[]>& other) noexcept;
 \end{itemdecl}
@@ -6370,8 +6362,7 @@ may be used as \tcode{unique_ptr<T, D>::pointer}. \exitexample
 
 \rSec4[unique.ptr.single.ctor]{\tcode{unique_ptr} constructors}
 
-\indexlibrary{\idxcode{unique_ptr}!\idxcode{unique_ptr}}
-\indexlibrary{\idxcode{unique_ptr}!\idxcode{unique_ptr}}
+\indexlibrary{\idxcode{unique_ptr}!constructor}
 \begin{itemdecl}
 constexpr unique_ptr() noexcept;
 \end{itemdecl}
@@ -6395,8 +6386,7 @@ returns a reference to the stored deleter.
 for the template argument \tcode{D}, the program is ill-formed.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{unique_ptr}!\idxcode{unique_ptr}}
-\indexlibrary{\idxcode{unique_ptr}!\idxcode{unique_ptr}}
+\indexlibrary{\idxcode{unique_ptr}!constructor}
 \begin{itemdecl}
 explicit unique_ptr(pointer p) noexcept;
 \end{itemdecl}
@@ -6421,8 +6411,7 @@ returns a reference to the stored deleter.
 for the template argument \tcode{D}, the program is ill-formed.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{unique_ptr}!\idxcode{unique_ptr}}
-\indexlibrary{\idxcode{unique_ptr}!\idxcode{unique_ptr}}
+\indexlibrary{\idxcode{unique_ptr}!constructor}
 \begin{itemdecl}
 unique_ptr(pointer p, @\seebelow@ d1) noexcept;
 unique_ptr(pointer p, @\seebelow@ d2) noexcept;
@@ -7277,7 +7266,7 @@ namespace std {
 An exception of type \tcode{bad_weak_ptr} is thrown by the \tcode{shared_ptr}
 constructor taking a \tcode{weak_ptr}.
 
-\indexlibrary{\idxcode{bad_weak_ptr}!\idxcode{bad_weak_ptr}}%
+\indexlibrary{\idxcode{bad_weak_ptr}!constructor}%
 \indexlibrary{\idxcode{bad_weak_ptr}!\idxcode{what}}%
 \indexlibrary{\idxcode{what}!\idxcode{bad_weak_ptr}}%
 \begin{itemdecl}
@@ -7454,7 +7443,7 @@ if (p != nullptr && p->weak_this.expired())
 The assignment to the \tcode{weak_this} member is not atomic and
 conflicts with any potentially concurrent access to the same object~(\ref{intro.multithread}).
 
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{shared_ptr}}%
+\indexlibrary{\idxcode{shared_ptr}!constructor}%
 \begin{itemdecl}
 constexpr shared_ptr() noexcept;
 \end{itemdecl}
@@ -10996,7 +10985,7 @@ around a reference to an object or function of type \tcode{T}.
 
 \rSec3[refwrap.const]{\tcode{reference_wrapper} construct/copy/destroy}
 
-\indexlibrary{\idxcode{reference_wrapper}!\idxcode{reference_wrapper}}%
+\indexlibrary{\idxcode{reference_wrapper}!constructor}%
 \begin{itemdecl}
 reference_wrapper(T& t) noexcept;
 \end{itemdecl}
@@ -11007,7 +10996,7 @@ reference_wrapper(T& t) noexcept;
 reference to \tcode{t}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{reference_wrapper}!\idxcode{reference_wrapper}}%
+\indexlibrary{\idxcode{reference_wrapper}!constructor}%
 \begin{itemdecl}
 reference_wrapper(const reference_wrapper& x) noexcept;
 \end{itemdecl}
@@ -11963,7 +11952,7 @@ namespace std {
 
 \rSec4[func.wrap.badcall.const]{\tcode{bad_function_call} constructor}
 
-\indexlibrary{\idxcode{bad_function_call}!\idxcode{bad_function_call}}%
+\indexlibrary{\idxcode{bad_function_call}!constructor}%
 \begin{itemdecl}
 bad_function_call() noexcept;
 \end{itemdecl}
@@ -12082,7 +12071,7 @@ to the requirements for Allocator (Table~\ref{allocator.requirements}). A copy o
 allocator argument is used to allocate memory, if necessary, for the internal data
 structures of the constructed \tcode{function} object.
 
-\indexlibrary{\idxcode{function}!\idxcode{function}}
+\indexlibrary{\idxcode{function}!constructor}
 \begin{itemdecl}
 function() noexcept;
 template <class A> function(allocator_arg_t, const A& a) noexcept;
@@ -12092,8 +12081,7 @@ template <class A> function(allocator_arg_t, const A& a) noexcept;
 \pnum\postcondition \tcode{!*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{function}!\idxcode{function}}
-\indexlibrary{\idxcode{function}!\idxcode{function}}
+\indexlibrary{\idxcode{function}!constructor}
 \begin{itemdecl}
 function(nullptr_t) noexcept;
 template <class A> function(allocator_arg_t, const A& a, nullptr_t) noexcept;
@@ -12104,8 +12092,7 @@ template <class A> function(allocator_arg_t, const A& a, nullptr_t) noexcept;
 \postcondition \tcode{!*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{function}!\idxcode{function}}
-\indexlibrary{\idxcode{function}!\idxcode{function}}
+\indexlibrary{\idxcode{function}!constructor}
 \begin{itemdecl}
 function(const function& f);
 template <class A> function(allocator_arg_t, const A& a, const function& f);
@@ -12127,8 +12114,7 @@ dynamically allocated memory for small callable objects, for example, where
 to an object and a member function pointer. \exitnote
 \end{itemdescr}
 
-\indexlibrary{\idxcode{function}!\idxcode{function}}
-\indexlibrary{\idxcode{function}!\idxcode{function}}
+\indexlibrary{\idxcode{function}!constructor}
 \begin{itemdecl}
 function(function&& f);
 template <class A> function(allocator_arg_t, const A& a, function&& f);
@@ -12153,8 +12139,7 @@ where \tcode{f}'s target is an object holding only a pointer or reference
 to an object and a member function pointer. \exitnote
 \end{itemdescr}
 
-\indexlibrary{\idxcode{function}!\idxcode{function}}
-\indexlibrary{\idxcode{function}!\idxcode{function}}
+\indexlibrary{\idxcode{function}!constructor}
 \begin{itemdecl}
 template<class F> function(F f);
 template <class F, class A> function(allocator_arg_t, const A& a, F f);


### PR DESCRIPTION
The preferred way to list constructors in the index is under the
non-code font term 'constructor', but many classes retain old
text that lists the constructor under the class name as the same
class name, in a code font.  Worse, there are quite a few classes
that have fallen into a hybrid approach, with both listings, which
can be confusing. This change-set should catch every constructor
indexed in the old style and consistently transform it to the new.

One additional fix is that allocator_traits mis-indexed the static
member functions 'construct' and 'destroy' as the plain-text
constructor and destructor.  This patch correctly indexes them as
their correct name, in a code-font.