### PR TITLE
[18-27] Remove tcode from index entries

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -3085,7 +3085,7 @@ using the specified allocator.
 
 \rSec3[deque.capacity]{\tcode{deque} capacity}
 
-\indexlibrary{\idxcode{resize}!\tcode{deque}}%
+\indexlibrary{\idxcode{resize}!\idxcode{deque}}%
 \begin{itemdecl}
 void resize(size_type sz);
 \end{itemdecl}
@@ -3100,7 +3100,7 @@ appends \tcode{sz - size()} default-inserted elements to the sequence.
 \requires \tcode{T} shall be \tcode{MoveInsertable} and \tcode{DefaultInsertable} into \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{resize}!\tcode{deque}}%
+\indexlibrary{\idxcode{resize}!\idxcode{deque}}%
 \begin{itemdecl}
 void resize(size_type sz, const T& c);
 \end{itemdecl}
@@ -3136,10 +3136,10 @@ but does not change the size of the sequence. \enternote The request is non-bind
 
 \rSec3[deque.modifiers]{\tcode{deque} modifiers}
 
-\indexlibrary{\idxcode{insert}!\tcode{deque}}%
-\indexlibrary{insert@\tcode{push_front}!\tcode{deque}}%
-\indexlibrary{insert@\tcode{push_back}!\tcode{deque}}%
-\indexlibrary{insert@\tcode{emplace}!\tcode{deque}}%
+\indexlibrary{\idxcode{insert}!\idxcode{deque}}%
+\indexlibrary{insert@\idxcode{push_front}!\idxcode{deque}}%
+\indexlibrary{insert@\idxcode{push_back}!\idxcode{deque}}%
+\indexlibrary{insert@\idxcode{emplace}!\idxcode{deque}}%
 \begin{itemdecl}
 iterator insert(const_iterator position, const T& x);
 iterator insert(const_iterator position, T&& x);
@@ -3189,7 +3189,7 @@ and causes a single call to a constructor of
 \tcode{T}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{erase}!\tcode{deque}}%
+\indexlibrary{\idxcode{erase}!\idxcode{deque}}%
 \begin{itemdecl}
 iterator erase(const_iterator position);
 iterator erase(const_iterator first, const_iterator last);
@@ -4240,7 +4240,7 @@ Linear in
 
 \rSec3[list.capacity]{\tcode{list} capacity}
 
-\indexlibrary{\idxcode{resize}!\tcode{list}}%
+\indexlibrary{\idxcode{resize}!\idxcode{list}}%
 \begin{itemdecl}
 void resize(size_type sz);
 \end{itemdecl}
@@ -4265,7 +4265,7 @@ erase(it, end());
 \tcode{DefaultInsertable} into \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{resize}!\tcode{list}}%
+\indexlibrary{\idxcode{resize}!\idxcode{list}}%
 \begin{itemdecl}
 void resize(size_type sz, const T& c);
 \end{itemdecl}
@@ -4292,7 +4292,7 @@ else
 
 \rSec3[list.modifiers]{\tcode{list} modifiers}
 
-\indexlibrary{\idxcode{insert}!\tcode{list}}%
+\indexlibrary{\idxcode{insert}!\idxcode{list}}%
 \begin{itemdecl}
 iterator insert(const_iterator position, const T& x);
 iterator insert(const_iterator position, T&& x);
@@ -4327,7 +4327,7 @@ constructor or move constructor of \tcode{T} is exactly equal
 to the number of elements inserted.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{erase}!\tcode{list}}%
+\indexlibrary{\idxcode{erase}!\idxcode{list}}%
 \begin{itemdecl}
 iterator erase(const_iterator position);
 iterator erase(const_iterator first, const_iterator last);
@@ -4368,7 +4368,7 @@ lists whose allocators compare equal.}
 another. The behavior of splice operations is undefined if \tcode{get_allocator() !=
 x.get_allocator()}.
 
-\indexlibrary{\idxcode{splice}!\tcode{list}}%
+\indexlibrary{\idxcode{splice}!\idxcode{list}}%
 \begin{itemdecl}
 void splice(const_iterator position, list& x);
 void splice(const_iterator position, list&& x);
@@ -4502,7 +4502,7 @@ Constant time if
 otherwise, linear time.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{remove}!\tcode{list}}%
+\indexlibrary{\idxcode{remove}!\idxcode{list}}%
 \begin{itemdecl}
 void remove(const T& value);
 template <class Predicate> void remove_if(Predicate pred);
@@ -4532,7 +4532,7 @@ Exactly
 applications of the corresponding predicate.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{unique}!\tcode{list}}%
+\indexlibrary{\idxcode{unique}!\idxcode{list}}%
 \begin{itemdecl}
 void unique();
 template <class BinaryPredicate> void unique(BinaryPredicate binary_pred);
@@ -4565,7 +4565,7 @@ applications of the corresponding predicate,
 otherwise no applications of the predicate.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{merge}!\tcode{list}}%
+\indexlibrary{\idxcode{merge}!\idxcode{list}}%
 \begin{itemdecl}
 void merge(list& x);
 void merge(list&& x);
@@ -4607,7 +4607,7 @@ otherwise, no applications of \tcode{comp} are performed.
 If an exception is thrown other than by a comparison there are no effects.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{reverse}!\tcode{list}}%
+\indexlibrary{\idxcode{reverse}!\idxcode{list}}%
 \begin{itemdecl}
 void reverse() noexcept;
 \end{itemdecl}
@@ -4623,7 +4623,7 @@ Does not affect the validity of iterators and references.
 Linear time.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sort}!\tcode{list}}%
+\indexlibrary{\idxcode{sort}!\idxcode{list}}%
 \begin{itemdecl}
 void sort();
 template <class Compare> void sort(Compare comp);
@@ -4822,8 +4822,8 @@ namespace std {
       noexcept(noexcept(x.swap(y)));
 }
 \end{codeblock}%
-\indexlibrary{\idxcode{vector}!\tcode{operator==}}%
-\indexlibrary{\idxcode{vector}!\tcode{operator<}}
+\indexlibrary{\idxcode{vector}!\idxcode{operator==}}%
+\indexlibrary{\idxcode{vector}!\idxcode{operator<}}
 
 \pnum
 An incomplete type \tcode{T} may be used when instantiating \tcode{vector}
@@ -8772,7 +8772,7 @@ as the second argument, and initializes \tcode{comp} with \tcode{std::move(q.com
 
 \rSec3[priqueue.members]{\tcode{priority_queue} members}
 
-\indexlibrary{\idxcode{push}!\tcode{priority_queue}}%
+\indexlibrary{\idxcode{push}!\idxcode{priority_queue}}%
 \begin{itemdecl}
 void push(const value_type& x);
 \end{itemdecl}
@@ -8787,7 +8787,7 @@ push_heap(c.begin(), c.end(), comp);
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{push}!\tcode{priority_queue}}%
+\indexlibrary{\idxcode{push}!\idxcode{priority_queue}}%
 \begin{itemdecl}
 void push(value_type&& x);
 \end{itemdecl}
@@ -8819,7 +8819,7 @@ push_heap(c.begin(), c.end(), comp);
 \end{itemdescr}
 
 
-\indexlibrary{\idxcode{pop}!\tcode{priority_queue}}%
+\indexlibrary{\idxcode{pop}!\idxcode{priority_queue}}%
 \begin{itemdecl}
 void pop();
 \end{itemdecl}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -4534,7 +4534,7 @@ implementation-dependent operations.}
 None.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator bool}!\tcode{basic_istream}}%
+\indexlibrary{\idxcode{operator bool}!\idxcode{basic_istream}}%
 \begin{itemdecl}
 explicit operator bool() const;
 \end{itemdecl}

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1368,7 +1368,7 @@ with
 
 \rSec4[reverse.iter.op=]{\tcode{reverse_iterator::operator=}}
 
-\indexlibrary{\idxcode{operator=}!\tcode{reverse_iterator}}%
+\indexlibrary{\idxcode{operator=}!\idxcode{reverse_iterator}}%
 \begin{itemdecl}
 template <class U>
 constexpr reverse_iterator&

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -794,8 +794,8 @@ Details of the contents of the resulting string are otherwise implementation-def
 
 \rSec3[locale.operators]{\tcode{locale} operators}
 
-\indexlibrary{\idxcode{locale}!\idxcode{operators==}}%
-\indexlibrary{\idxcode{operators==}!\idxcode{locale}}%
+\indexlibrary{\idxcode{locale}!\idxcode{operator==}}%
+\indexlibrary{\idxcode{operator==}!\idxcode{locale}}%
 \begin{itemdecl}
 bool operator==(const locale& other) const;
 \end{itemdecl}

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -1311,7 +1311,7 @@ is pointed at by \tcode{s}                                                      
 \remarks
 Uses
 \tcode{traits::length()}.
-\indexlibrary{\idxcode{length}!\tcode{char_traits}}%
+\indexlibrary{\idxcode{length}!\idxcode{char_traits}}%
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_string}!constructor}%
@@ -1474,7 +1474,7 @@ basic_string& operator=(const charT* s);
 \pnum
 \remarks
 Uses
-\indexlibrary{\idxcode{length}!\tcode{char_traits}}%
+\indexlibrary{\idxcode{length}!\idxcode{char_traits}}%
 \tcode{traits::length()}.
 \end{itemdescr}
 
@@ -2178,7 +2178,7 @@ basic_string& assign(initializer_list<charT> il);
 \end{itemdescr}
 
 
-\indexlibrary{\idxcode{length}!\tcode{char_traits}}%
+\indexlibrary{\idxcode{length}!\idxcode{char_traits}}%
 \begin{itemdecl}
 basic_string& assign(size_type n, charT c);
 \end{itemdecl}
@@ -2801,10 +2801,10 @@ contains the same sequence of characters that was in \tcode{s},
 
 \rSec4[string.accessors]{\tcode{basic_string} accessors}
 
-\indexlibrary{\idxcode{c_str}!\tcode{basic_string}}%
-\indexlibrary{\idxcode{data}!\tcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\tcode{c_str}}%
-\indexlibrary{\idxcode{basic_string}!\tcode{data}}%
+\indexlibrary{\idxcode{c_str}!\idxcode{basic_string}}%
+\indexlibrary{\idxcode{data}!\idxcode{basic_string}}%
+\indexlibrary{\idxcode{basic_string}!\idxcode{c_str}}%
+\indexlibrary{\idxcode{basic_string}!\idxcode{data}}%
 \begin{itemdecl}
 const charT* c_str() const noexcept;
 const charT* data() const noexcept;
@@ -2823,8 +2823,8 @@ const charT* data() const noexcept;
 The program shall not alter any of the values stored in the character array.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{data}!\tcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\tcode{data}}%
+\indexlibrary{\idxcode{data}!\idxcode{basic_string}}%
+\indexlibrary{\idxcode{basic_string}!\idxcode{data}}%
 \begin{itemdecl}
 charT* data() noexcept;
 \end{itemdecl}
@@ -2877,7 +2877,7 @@ the following conditions hold:
 \tcode{pos <= xpos} and
 \tcode{xpos + str.size() <= size()};
 \item
-\indexlibrary{\idxcode{eq}!\tcode{char_traits}}%
+\indexlibrary{\idxcode{eq}!\idxcode{char_traits}}%
 \tcode{traits::eq(at(xpos + I), str.at(I))}
 for all elements \tcode{I} of the string controlled by \tcode{str}.
 \end{itemize}
@@ -2955,7 +2955,7 @@ the following conditions hold:
 and
 \tcode{xpos + str.size() <= size()};
 \item
-\indexlibrary{\idxcode{eq}!\tcode{char_traits}}%
+\indexlibrary{\idxcode{eq}!\idxcode{char_traits}}%
 \tcode{traits::eq(at(xpos + I), str.at(I))}
 for all elements \tcode{I} of the string controlled by \tcode{str}.
 \end{itemize}
@@ -3034,7 +3034,7 @@ the following conditions hold:
 and
 \tcode{xpos < size()};
 \item
-\indexlibrary{\idxcode{eq}!\tcode{char_traits}}%
+\indexlibrary{\idxcode{eq}!\idxcode{char_traits}}%
 \tcode{traits::eq(at(xpos), str.at(I))}
 for some element \tcode{I} of the string controlled by \tcode{str}.
 \end{itemize}
@@ -3114,7 +3114,7 @@ the following conditions hold:
 and
 \tcode{xpos < size()};
 \item
-\indexlibrary{\idxcode{eq}!\tcode{char_traits}}%
+\indexlibrary{\idxcode{eq}!\idxcode{char_traits}}%
 \tcode{traits::eq(at(xpos), str.at(I))}
 for some element \tcode{I} of the string controlled by \tcode{str}.
 \end{itemize}
@@ -3193,7 +3193,7 @@ the following conditions hold:
 and
 \tcode{xpos < size()};
 \item
-\indexlibrary{\idxcode{eq}!\tcode{char_traits}}%
+\indexlibrary{\idxcode{eq}!\idxcode{char_traits}}%
 \tcode{traits::eq(at(xpos), str.at(I))}
 for no element \tcode{I} of the string controlled by \tcode{str}.
 \end{itemize}
@@ -3273,7 +3273,7 @@ the following conditions hold:
 and
 \tcode{xpos < size()};
 \item
-\indexlibrary{\idxcode{eq}!\tcode{char_traits}}%
+\indexlibrary{\idxcode{eq}!\idxcode{char_traits}}%
 \tcode{traits::eq(at(xpos), str.at(I))}
 for no element \tcode{I} of the string
 controlled by \tcode{str}.
@@ -3709,7 +3709,7 @@ elements of \tcode{charT}.
 \tcode{lhs.compare(rhs) == 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{length}!\tcode{char_traits}}%
+\indexlibrary{\idxcode{length}!\idxcode{char_traits}}%
 \rSec3[string::op!=]{\tcode{operator!=}}
 
 \indexlibrary{\idxcode{basic_string}!\idxcode{operator"!=}}%

--- a/source/support.tex
+++ b/source/support.tex
@@ -1557,7 +1557,7 @@ delete}.
 
 \rSec3[new.delete.single]{Single-object forms}
 
-\indexlibrary{\idxcode{new}!\tcode{operator}}%
+\indexlibrary{\idxcode{new}!\idxcode{operator}}%
 \begin{itemdecl}
 void* operator new(std::size_t size);
 \end{itemdecl}
@@ -2005,7 +2005,7 @@ void* operator new[](std::size_t size, void* ptr) noexcept;
 Intentionally performs no other action.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{new}!\tcode{operator}}%
+\indexlibrary{\idxcode{new}!\idxcode{operator}}%
 \begin{itemdecl}
 void operator delete(void* ptr, void*) noexcept;
 \end{itemdecl}
@@ -2103,7 +2103,7 @@ Constructs an object of class
 
 \indextext{implementation-defined}%
 \indexlibrary{\idxcode{bad_alloc}!\idxcode{bad_alloc}}%
-\indexlibrary{\idxcode{operator=}!\tcode{bad_alloc}}%
+\indexlibrary{\idxcode{operator=}!\idxcode{bad_alloc}}%
 \begin{itemdecl}
 bad_alloc(const bad_alloc&) noexcept;
 bad_alloc& operator=(const bad_alloc&) noexcept;
@@ -2116,7 +2116,7 @@ Copies an object of class
 \tcode{bad_alloc}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{what}!\tcode{bad_alloc}}%
+\indexlibrary{\idxcode{what}!\idxcode{bad_alloc}}%
 \begin{itemdecl}
 virtual const char* what() const noexcept;
 \end{itemdecl}
@@ -2163,7 +2163,7 @@ bad_array_new_length() noexcept;
 \effects constructs an object of class \tcode{bad_array_new_length}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{what}!\tcode{bad_array_new_length}}%
+\indexlibrary{\idxcode{what}!\idxcode{bad_array_new_length}}%
 \begin{itemdecl}
 virtual const char* what() const noexcept;
 \end{itemdecl}
@@ -2357,7 +2357,7 @@ The names, encoding rule, and collating sequence for types are all unspecified
 \indextext{unspecified}%
 and may differ between programs.
 
-\indexlibrary{\idxcode{operator==}!\tcode{type_info}}%
+\indexlibrary{\idxcode{operator==}!\idxcode{type_info}}%
 \begin{itemdecl}
 bool operator==(const type_info& rhs) const noexcept;
 \end{itemdecl}
@@ -2373,7 +2373,7 @@ Compares the current object with \tcode{rhs}.
 if the two values describe the same type.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\tcode{type_info}}%
+\indexlibrary{\idxcode{operator"!=}!\idxcode{type_info}}%
 \begin{itemdecl}
 bool operator!=(const type_info& rhs) const noexcept;
 \end{itemdecl}
@@ -2384,7 +2384,7 @@ bool operator!=(const type_info& rhs) const noexcept;
 \tcode{!(*this == rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{before}!\tcode{type_info}}%
+\indexlibrary{\idxcode{before}!\idxcode{type_info}}%
 \begin{itemdecl}
 bool before(const type_info& rhs) const noexcept;
 \end{itemdecl}
@@ -2402,7 +2402,7 @@ if
 precedes \tcode{rhs} in the implementation's collation order.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{hash_code}!\tcode{type_info}}%
+\indexlibrary{\idxcode{hash_code}!\idxcode{type_info}}%
 \begin{itemdecl}
 size_t hash_code() const noexcept;
 \end{itemdecl}
@@ -2419,7 +2419,7 @@ objects which compare equal.
 \end{itemdescr}
 
 
-\indexlibrary{\idxcode{name}!\tcode{type_info}}%
+\indexlibrary{\idxcode{name}!\idxcode{type_info}}%
 \begin{itemdecl}
 const char* name() const noexcept;
 \end{itemdecl}
@@ -2474,7 +2474,7 @@ Constructs an object of class
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bad_cast}!\tcode{bad_cast}}%
-\indexlibrary{\idxcode{operator=}!\tcode{bad_cast}}%
+\indexlibrary{\idxcode{operator=}!\idxcode{bad_cast}}%
 \begin{itemdecl}
 bad_cast(const bad_cast&) noexcept;
 bad_cast& operator=(const bad_cast&) noexcept;
@@ -2487,7 +2487,7 @@ Copies an object of class
 \tcode{bad_cast}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{what}!\tcode{bad_cast}}%
+\indexlibrary{\idxcode{what}!\idxcode{bad_cast}}%
 \begin{itemdecl}
 virtual const char* what() const noexcept;
 \end{itemdecl}
@@ -2542,7 +2542,7 @@ Constructs an object of class
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bad_typeid}!\tcode{bad_typeid}}%
-\indexlibrary{\idxcode{operator=}!\tcode{bad_typeid}}%
+\indexlibrary{\idxcode{operator=}!\idxcode{bad_typeid}}%
 \begin{itemdecl}
 bad_typeid(const bad_typeid&) noexcept;
 bad_typeid& operator=(const bad_typeid&) noexcept;
@@ -2555,7 +2555,7 @@ Copies an object of class
 \tcode{bad_typeid}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{what}!\tcode{bad_typeid}}%
+\indexlibrary{\idxcode{what}!\idxcode{bad_typeid}}%
 \begin{itemdecl}
 virtual const char* what() const noexcept;
 \end{itemdecl}
@@ -2692,7 +2692,7 @@ Destroys an object of class
 \tcode{exception}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{what}!\tcode{exception}}%
+\indexlibrary{\idxcode{what}!\idxcode{exception}}%
 \begin{itemdecl}
 virtual const char* what() const noexcept;
 \end{itemdecl}
@@ -2747,7 +2747,7 @@ Constructs an object of class
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bad_exception}!\tcode{bad_exception}}%
-\indexlibrary{\idxcode{operator=}!\tcode{bad_exception}}%
+\indexlibrary{\idxcode{operator=}!\idxcode{bad_exception}}%
 \begin{itemdecl}
 bad_exception(const bad_exception&) noexcept;
 bad_exception& operator=(const bad_exception&) noexcept;
@@ -2760,7 +2760,7 @@ Copies an object of class
 \tcode{bad_exception}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{what}!\tcode{bad_exception}}%
+\indexlibrary{\idxcode{what}!\idxcode{bad_exception}}%
 \begin{itemdecl}
 virtual const char* what() const noexcept;
 \end{itemdecl}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -834,7 +834,7 @@ is_nothrow_swappable_v<second_type>
 
 \rSec2[pairs.spec]{Specialized algorithms}
 
-\indexlibrary{\idxcode{operator==}!\tcode{pair}}%
+\indexlibrary{\idxcode{operator==}!\idxcode{pair}}%
 \begin{itemdecl}
 template <class T1, class T2>
   constexpr bool operator==(const pair<T1, T2>& x, const pair<T1, T2>& y);
@@ -846,7 +846,7 @@ template <class T1, class T2>
 \tcode{x.first == y.first \&\& x.second == y.second}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\tcode{pair}}%
+\indexlibrary{\idxcode{operator<}!\idxcode{pair}}%
 \begin{itemdecl}
 template <class T1, class T2>
   constexpr bool operator<(const pair<T1, T2>& x, const pair<T1, T2>& y);
@@ -858,7 +858,7 @@ template <class T1, class T2>
 \tcode{x.first < y.first || (!(y.first < x.first) \&\& x.second < y.second)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\tcode{pair}}%
+\indexlibrary{\idxcode{operator"!=}!\idxcode{pair}}%
 \begin{itemdecl}
 template <class T1, class T2>
   constexpr bool operator!=(const pair<T1, T2>& x, const pair<T1, T2>& y);
@@ -869,7 +869,7 @@ template <class T1, class T2>
 \returns \tcode{!(x == y)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>}!\tcode{pair}}%
+\indexlibrary{\idxcode{operator>}!\idxcode{pair}}%
 \begin{itemdecl}
 template <class T1, class T2>
   constexpr bool operator>(const pair<T1, T2>& x, const pair<T1, T2>& y);
@@ -880,7 +880,7 @@ template <class T1, class T2>
 \returns \tcode{y < x}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>=}!\tcode{pair}}%
+\indexlibrary{\idxcode{operator>=}!\idxcode{pair}}%
 \begin{itemdecl}
 template <class T1, class T2>
   constexpr bool operator>=(const pair<T1, T2>& x, const pair<T1, T2>& y);
@@ -891,7 +891,7 @@ template <class T1, class T2>
 \returns \tcode{!(x < y)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<=}!\tcode{pair}}%
+\indexlibrary{\idxcode{operator<=}!\idxcode{pair}}%
 \begin{itemdecl}
 template <class T1, class T2>
   constexpr bool operator<=(const pair<T1, T2>& x, const pair<T1, T2>& y);
@@ -903,7 +903,7 @@ template <class T1, class T2>
 \end{itemdescr}
 
 
-\indexlibrary{\idxcode{swap}!\tcode{pair}}%
+\indexlibrary{\idxcode{swap}!\idxcode{pair}}%
 \begin{itemdecl}
 template<class T1, class T2> void swap(pair<T1, T2>& x, pair<T1, T2>& y)
   noexcept(noexcept(x.swap(y)));
@@ -4193,7 +4193,7 @@ and initializes it with
 \tcode{x.flip()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{flip}!\tcode{bitset}}%
+\indexlibrary{\idxcode{flip}!\idxcode{bitset}}%
 \begin{itemdecl}
 bitset<N>& flip() noexcept;
 \end{itemdecl}
@@ -6039,7 +6039,7 @@ storage by calling \tcode{::operator new()}~(\ref{support.dynamic}).
 \pnum
 The function \tcode{free()}\indexlibrary{\idxcode{free}} does not attempt to
 deallocate storage by calling
-\tcode{::operator delete()}\indexlibrary{\idxcode{delete}!\tcode{operator}}.
+\tcode{::operator delete()}\indexlibrary{\idxcode{delete}!\idxcode{operator}}.
 
 \xref
 ISO C Clause 7.11.2.


### PR DESCRIPTION
Several old index entries use '\tcode' to force a code
font on their sub-entry.  This is no longer necessary,
as the LaTeX scripts produce the correct font for an
'\idxcode' entry.  However, using '\tcode' inconsistently
will produce duplicate entries, and entries that do not
sort correctly.  This change set consistently applies
'\idxcode' in preference to '\tcode' to eliminate the
redundant and mis-sorted entries.

Note that this change-set does NOT change '\tcode'
entries for constructors, as those are handled separely
by https://github.com/cplusplus/draft/pull/740