### PR TITLE
[support.runtime] Fix name of stdarg.h in index

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -3365,7 +3365,7 @@ The restrictions that ISO C places on the second parameter to the
 \indexlibrary{\idxcode{va_start}}%
 \tcode{va_start()}
 macro in header
-\indexlibrary{\idxhdr{staarg.h}}%
+\indexlibrary{\idxhdr{stdarg.h}}%
 \tcode{<stdarg.h>}
 are different in this International Standard.
 The parameter


### PR DESCRIPTION
Simple typo where the index (but not the main text) refers to <stdarg.h> as <staarg.h>.