### PR TITLE
[bad.cast], [bad.exception] nest index entries consistently

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -2496,7 +2496,7 @@ virtual const char* what() const noexcept;
 \pnum
 \returns
 An \impldef{return value of \tcode{bad_cast::what}} \ntbs.%
-\indexlibrary{\idxcode{bad_cast::what}!implementation-defined}
+\indexlibrary{\idxcode{bad_cast}!\idxcode{bad_cast::what}!implementation-defined}
 
 \pnum
 \remarks
@@ -2770,7 +2770,7 @@ virtual const char* what() const noexcept;
 \pnum
 \returns
 An \impldef{return value of \tcode{bad_exception::what}} \ntbs.%
-\indexlibrary{\idxcode{bad_exception::what}!implementation-defined}
+\indexlibrary{\idxcode{bad_exception}!\idxcode{bad_exception::what}!implementation-defined}
 
 \pnum
 \remarks


### PR DESCRIPTION
This adjusts the index entries for `bad_cast::what` and `bad_exception::what` to be nested consistently with `bad_alloc::what` and `bad_array_new_length::what`

![diff](https://cloud.githubusercontent.com/assets/1254480/15930796/b4b74014-2e4c-11e6-8085-9117e919f6d1.png)
