### PR TITLE
[meta.trans.other] Reformat Other Transformations table

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -14165,13 +14165,13 @@ assert((is_same<remove_all_extents_t<int[][3]>, int>::value));
 
 \rSec3[meta.trans.other]{Other transformations}
 
-\begin{libreqtab3d}{Other transformations}{tab:type-traits.other}
+\begin{libreqtab2a}{Other transformations}{tab:type-traits.other}
 \\ \topline
-\lhdr{Template} &   \chdr{Condition}    &   \rhdr{Comments} \\ \capsep
+\lhdr{Template}   &   \rhdr{Comments} \\ \capsep
 \endfirsthead
 \continuedcaption\\
 \topline
-\lhdr{Template} &   \chdr{Condition}    &   \rhdr{Comments} \\ \capsep
+\lhdr{Template}   &   \rhdr{Comments} \\ \capsep
 \endhead
 
 \tcode{template <std::size_t Len,\br
@@ -14179,35 +14179,32 @@ assert((is_same<remove_all_extents_t<int[][3]>, int>::value));
  = \textit{default-alignment}>\br
  struct aligned_storage;}
  &
- \tcode{Len} shall not be zero.
- \tcode{Align} shall be equal
- to \tcode{alignof(T)} for some type \tcode{T}
- or to \textit{default-alignment}.
- &
  The value of \textit{default-alignment} shall be the most
  stringent alignment requirement for any \Cpp object type whose size
  is no greater than \tcode{Len}~(\ref{basic.types}).
  The member typedef \tcode{type} shall be a POD type
  suitable for use as uninitialized storage for any object whose size
- is at most \textit{Len} and whose alignment is a divisor of \textit{Align}. \\ \rowsep
+ is at most \textit{Len} and whose alignment is a divisor of \textit{Align}.\br
+ \requires \tcode{Len} shall not be zero. \tcode{Align} shall be equal to
+ \tcode{alignof(T)} for some type \tcode{T} or to \textit{default-alignment}.\\ \rowsep
 
 \tcode{template <std::size_t Len,\br
   class... Types>\br
   struct aligned_union;}
   &
-  At least one type is provided.
-  &
   The member typedef \tcode{type} shall be a POD type suitable for use as
   uninitialized storage for any object whose type is listed in \tcode{Types};
   its size shall be at least \tcode{Len}. The static member \tcode{alignment_value}
   shall be an integral constant of type \tcode{std::size_t} whose value is the
-  strictest alignment of all types listed in \tcode{Types}.
+  strictest alignment of all types listed in \tcode{Types}.\br
+ \requires At least one type is provided.
   \\ \rowsep
 
-\tcode{template <class T> struct} \tcode{decay;} &   &
- Let \tcode{U} be \tcode{remove_reference_t<T>}. If \tcode{is_array<U>::value}
- is \tcode{true}, the member typedef \tcode{type} shall equal
- \tcode{remove_extent_t<U>*}. If \tcode{is_function<U>::value} is \tcode{true},
+\tcode{template <class T>\br struct decay;}
+ &
+ Let \tcode{U} be \tcode{remove_reference_t<T>}. If \tcode{is_array_v<U>} is
+ \tcode{true}, the member typedef \tcode{type} shall equal
+ \tcode{remove_extent_t<U>*}. If \tcode{is_function_v<U>} is \tcode{true},
  the member typedef \tcode{type} shall equal \tcode{add_pointer_t<U>}. Otherwise
  the member typedef \tcode{type} equals \tcode{remove_cv_t<U>}.
  \enternote This behavior is similar to the lvalue-to-rvalue~(\ref{conv.lval}),
@@ -14217,42 +14214,44 @@ assert((is_same<remove_all_extents_t<int[][3]>, int>::value));
  argument passing. \exitnote
  \\ \rowsep
 
-\tcode{template <bool B, class T = void>} \tcode{struct enable_if;} & &
+\tcode{template <bool B, class T = void>} \tcode{struct enable_if;}
+ &
  If \tcode{B} is \tcode{true}, the member typedef \tcode{type}
  shall equal \tcode{T}; otherwise, there shall be no member
  \tcode{type}. \\ \rowsep
 
-\tcode{template <bool B, class T,} \tcode{class F> struct conditional}; & &
- If \tcode{B} is \tcode{true}, the member typedef \tcode{type}
- shall equal \tcode{T}.
- If \tcode{B} is \tcode{false}, the member typedef \tcode{type}
- shall equal \tcode{F}. \\ \rowsep
+\tcode{template <bool B, class T,}
+ \tcode{class F>}\br
+ \tcode{struct conditional};
+ &
+ If \tcode{B} is \tcode{true},  the member typedef \tcode{type} shall equal \tcode{T}.
+ If \tcode{B} is \tcode{false}, the member typedef \tcode{type} shall equal \tcode{F}. \\ \rowsep
 
- \tcode{template <class... T>} \tcode{struct common_type;} & &
+ \tcode{template <class... T>} \tcode{struct common_type;}
+ &
  The member typedef \tcode{type} shall be defined or omitted as specified below.
-If it is omitted, there shall be no member \tcode{type}. All types in
-the parameter pack \tcode{T} shall be complete or (possibly \cv) \tcode{void}. A
-program may specialize this trait if at least one template parameter in the
-specialization is a user-defined type. \enternote Such specializations are
-needed when only explicit conversions are desired among the template arguments.
-\exitnote \\ \rowsep
+ If it is omitted, there shall be no member \tcode{type}. All types in
+ the parameter pack \tcode{T} shall be complete or (possibly \cv) \tcode{void}.
+ A program may specialize this trait if at least one template parameter in the
+ specialization is a user-defined type. \enternote Such specializations are
+ needed when only explicit conversions are desired among the template arguments.
+ \exitnote \\ \rowsep
 
 \tcode{template <class T>}\br
- \tcode{struct underlying_type;}  &
- \tcode{T} shall be a complete enumeration type~(\ref{dcl.enum}) &
+ \tcode{struct underlying_type;}
+ &
  The member typedef \tcode{type} shall name the underlying type
- of \tcode{T}. \\ \rowsep
+ of \tcode{T}.\br
+ \requires \tcode{T} shall be a complete enumeration type~(\ref{dcl.enum}) \\ \rowsep
 
 \tcode{template <class Fn,}\br
- \tcode{class... ArgTypes> struct}
- \tcode{result_of<Fn(ArgTypes...)>;}  &
- \tcode{Fn} and all types in the parameter pack \tcode{ArgTypes} shall
- be complete types, (possibly cv-qualified) \tcode{void}, or arrays of
- unknown bound. &
+ \tcode{class... ArgTypes>}
+ \tcode{struct result_of<Fn(ArgTypes...)>;}
+ &
  If the expression \tcode{\textit{INVOKE}(declval<Fn>(), declval<ArgTypes>()...)}
  is well formed when treated as an unevaluated operand (Clause~\ref{expr}),
  the member typedef \tcode{type} shall name the type
- \tcode{decltype(\textit{INVOKE}(declval<Fn>(),} \tcode{declval<ArgTypes>()...))};
+ \tcode{decltype(\textit{INVOKE}(declval<Fn>(), declval<ArgTypes>()...))};
  otherwise, there shall be no member \tcode{type}. Access checking is
  performed as if in a context unrelated to \tcode{Fn} and
  \tcode{ArgTypes}. Only the validity of the immediate context of the
@@ -14263,8 +14262,11 @@ needed when only explicit conversions are desired among the template arguments.
  template specializations, the generation of implicitly-defined
  functions, and so on. Such side effects are not in the ``immediate
  context'' and can result in the program being ill-formed.
- \exitnote \\
- \end{libreqtab3d}
+ \exitnote \br
+ \requires \tcode{Fn} and all types in the parameter pack \tcode{ArgTypes} shall
+ be complete types, (possibly cv-qualified) \tcode{void}, or arrays of
+ unknown bound.\\
+\end{libreqtab2a}
 
 \pnum
 \enternote A typical implementation would define \tcode{aligned_storage} as:


### PR DESCRIPTION
This PR applies the change recommended by https://github.com/cplusplus/draft/issues/629.

So far, I like the change giving the descriptions more room to
breathe, but for come reason the first column has become a
little narrower, which is messing with the format a little.

Generally, I think this looks like a good fix, but may use a
little more polish to get the presentation just right.