### PR TITLE
[namespace.udecl]/17 Fix the note and comment to better reflect that …

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2937,10 +2937,10 @@ struct D : B, C {
 };
 
 void f(D* d) {
-  d->x();    // ambiguous: selected overload \tcode{x()} from the result of name lookup of \tcode{x} in implicit naming class \tcode{D}
-             // (i.e. \{A::x(), C::x(int), D::x(double)\}) is a direct member of class \tcode{A} which is an ambiguous base 
-             // of the naming class \tcode{D}
-  d->C::x(); // OK
+  d->x();    // ambiguous: while member lookup of \tcode{x} in implicit naming class \tcode{D} is unambiguous, the selected 
+             // overload of \tcode{x} is a direct member of \tcode{A}, which is an ambiguous base of the naming class \tcode{D}
+  d->C::x(); // OK: the selected \tcode{x} is a direct member of \tcode{A} which is an unambiguous base of the naming class \tcode{C}
+             // which in turn is an unambiguous base of the object expression's type \tcode{D}
 }
 \end{codeblock}
 \exitnote

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2921,7 +2921,7 @@ class where the \grammarterm{using-declaration} is specified. \enternote
 Because a \grammarterm{using-declaration} designates a base class member
 (and not a member subobject or a member function of a base class
 subobject), a \grammarterm{using-declaration} cannot be used to resolve
-inherited member ambiguities. For example,
+inherited member ambiguities by itself. For example,
 
 \begin{codeblock}
 struct A { int x(); };
@@ -2935,8 +2935,12 @@ struct D : B, C {
   using C::x;
   int x(double);
 };
-int f(D* d) {
-  return d->x();    // ambiguous: \tcode{B::x} or \tcode{C::x}
+
+void f(D* d) {
+  d->x();    // ambiguous: selected overload \tcode{x()} from the result of name lookup of \tcode{x} in implicit naming class \tcode{D}
+             // (i.e. \{A::x(), C::x(int), D::x(double)\}) is a direct member of class \tcode{A} which is an ambiguous base 
+             // of the naming class \tcode{D}
+  d->C::x(); // OK
 }
 \end{codeblock}
 \exitnote


### PR DESCRIPTION
…while using declarations can aid in resolving certain member-lookup ambiguities, they are not always sufficient.

I admittedly got a little carried away by my prior attempt at this - hopefully this one is more restrained (pls let me know if the comment is still too wordy, and whether you want me to truncate it further or have suggestions)

![2016-06-11 10_25_51-f__c -draft_draft_source_declarations tex - texstudio](https://cloud.githubusercontent.com/assets/815934/15985813/ff87594e-2fbe-11e6-9c6f-274ba00d187c.png)
