### PR TITLE
[18,20] Consistent indexing of simple exception types

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3130,7 +3130,7 @@ negative value afterwards.} is less than zero;
 
 \item
 its value is such that the size of the allocated object would exceed the
-implementation-defined limit (annex~\ref{implimits}); or
+\impldef{maximum size of an allocated object} limit (annex~\ref{implimits}); or
 
 \item
 the \grammarterm{new-initializer} is a \grammarterm{braced-init-list} and the

--- a/source/support.tex
+++ b/source/support.tex
@@ -2101,7 +2101,6 @@ Constructs an object of class
 \tcode{bad_alloc}.
 \end{itemdescr}
 
-\indextext{implementation-defined}%
 \indexlibrary{\idxcode{bad_alloc}!constructor}%
 \indexlibrary{\idxcode{operator=}!\idxcode{bad_alloc}}%
 \begin{itemdecl}
@@ -2117,6 +2116,7 @@ Copies an object of class
 \end{itemdescr}
 
 \indexlibrary{\idxcode{what}!\idxcode{bad_alloc}}%
+\indexlibrary{\idxcode{bad_alloc}!\idxcode{what}}%
 \begin{itemdecl}
 virtual const char* what() const noexcept;
 \end{itemdecl}
@@ -2124,7 +2124,6 @@ virtual const char* what() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\indexlibrary{\idxcode{bad_alloc}!\idxcode{what}!implementation-defined}%
 An \impldef{return value of \tcode{bad_alloc::what}} \ntbs.
 
 \pnum
@@ -2151,7 +2150,7 @@ namespace std {
 The class \tcode{bad_array_new_length} defines the type of objects thrown as
 exceptions by the implementation to report an attempt to allocate an array of size
 less than zero or
-greater than an implementation-defined limit~(\ref{expr.new}).
+greater than an \impldef{maximum size of an allocated object} limit~(\ref{expr.new}).
 
 \indexlibrary{\idxcode{bad_array_new_length}!constructor}%
 \begin{itemdecl}
@@ -2163,6 +2162,7 @@ bad_array_new_length() noexcept;
 \effects constructs an object of class \tcode{bad_array_new_length}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{bad_array_new_length}!\idxcode{what}}%
 \indexlibrary{\idxcode{what}!\idxcode{bad_array_new_length}}%
 \begin{itemdecl}
 virtual const char* what() const noexcept;
@@ -2171,7 +2171,6 @@ virtual const char* what() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\indexlibrary{\idxcode{bad_array_new_length}!\idxcode{what}!implementation-defined}%
 An \impldef{return value of \tcode{bad_array_new_length::what}} \ntbs.
 
 \pnum
@@ -2419,6 +2418,7 @@ objects which compare equal.
 \end{itemdescr}
 
 
+\indexlibrary{\idxcode{type_info}!\idxcode{name}}%
 \indexlibrary{\idxcode{name}!\idxcode{type_info}}%
 \begin{itemdecl}
 const char* name() const noexcept;
@@ -2428,7 +2428,6 @@ const char* name() const noexcept;
 \pnum
 \returns
 An \impldef{return value of \tcode{type_info::name()}} \ntbs.
-\indexlibrary{\idxcode{type_info}!\idxcode{name}!implementation-defined}
 
 \pnum
 \remarks
@@ -2457,10 +2456,10 @@ The class
 \tcode{bad_cast}
 defines the type of objects thrown
 as exceptions by the implementation to report the execution of an invalid
+\indextext{cast!dynamic}%
 \grammarterm{dynamic-cast}
 expression~(\ref{expr.dynamic.cast}).
 
-\indextext{cast!dynamic}%
 \indexlibrary{\idxcode{bad_cast}!constructor}%
 \begin{itemdecl}
 bad_cast() noexcept;
@@ -2487,6 +2486,7 @@ Copies an object of class
 \tcode{bad_cast}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{bad_cast}!\idxcode{what}}%
 \indexlibrary{\idxcode{what}!\idxcode{bad_cast}}%
 \begin{itemdecl}
 virtual const char* what() const noexcept;
@@ -2495,8 +2495,7 @@ virtual const char* what() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-An \impldef{return value of \tcode{bad_cast::what}} \ntbs.%
-\indexlibrary{\idxcode{bad_cast}!\idxcode{what}!implementation-defined}
+An \impldef{return value of \tcode{bad_cast::what}} \ntbs.
 
 \pnum
 \remarks
@@ -2555,6 +2554,7 @@ Copies an object of class
 \tcode{bad_typeid}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{bad_typeid}!\idxcode{what}}%
 \indexlibrary{\idxcode{what}!\idxcode{bad_typeid}}%
 \begin{itemdecl}
 virtual const char* what() const noexcept;
@@ -2563,8 +2563,7 @@ virtual const char* what() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-An \impldef{return value of \tcode{bad_typeid::what}} \ntbs.%
-\indextext{\idxcode{bad_typeid}!\idxcode{what}!implementation-defined}
+An \impldef{return value of \tcode{bad_typeid::what}} \ntbs.
 
 \pnum
 \remarks
@@ -2680,7 +2679,6 @@ object.
 then \tcode{strcmp(what(), rhs.what())} shall equal 0.
 \end{itemdescr}
 
-\indextext{implementation-defined}%
 \indexlibrary{\idxcode{exception}!destructor}%
 \begin{itemdecl}
 virtual ~exception();
@@ -2693,6 +2691,7 @@ Destroys an object of class
 \tcode{exception}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{exception}!\idxcode{what}}%
 \indexlibrary{\idxcode{what}!\idxcode{exception}}%
 \begin{itemdecl}
 virtual const char* what() const noexcept;
@@ -2701,8 +2700,7 @@ virtual const char* what() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\indextext{exception::what~message@\tcode{exception::what}~message!implementation-defined}%
-An \impldef{result of \tcode{exception::what}} \ntbs.
+An \impldef{return value of \tcode{exception::what}} \ntbs.
 
 \pnum
 \remarks
@@ -2761,6 +2759,7 @@ Copies an object of class
 \tcode{bad_exception}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{bad_exception}!\idxcode{what}}%
 \indexlibrary{\idxcode{what}!\idxcode{bad_exception}}%
 \begin{itemdecl}
 virtual const char* what() const noexcept;
@@ -2769,8 +2768,7 @@ virtual const char* what() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-An \impldef{return value of \tcode{bad_exception::what}} \ntbs.%
-\indexlibrary{\idxcode{bad_exception}!\idxcode{what}!implementation-defined}
+An \impldef{return value of \tcode{bad_exception::what}} \ntbs.
 
 \pnum
 \remarks
@@ -3187,7 +3185,6 @@ virtual const char* what() const noexcept;
 \pnum
 \returns
 An \impldef{return value of \tcode{exception_list::what}} \ntbs.
-\indexlibrary{\idxcode{exception_list}!\idxcode{what}!implementation-defined}
 \end{itemdescr}
 
 \rSec1[support.initlist]{Initializer lists}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2909,6 +2909,8 @@ public:
 The class \tcode{bad_optional_access} defines the type of objects thrown as exceptions to report the situation where an attempt is made to access the value of an optional object that does not contain a value.
 
 \indexlibrary{\idxcode{bad_optional_access}!constructor}%
+\indexlibrary{\idxcode{bad_optional_access}!\idxcode{what}}%
+\indexlibrary{\idxcode{what}!\idxcode{bad_optional_access}}%
 \begin{itemdecl}
 bad_optional_access();
 \end{itemdecl}
@@ -3345,6 +3347,7 @@ namespace std {
 
 \rSec2[any.bad_any_cast]{Class \tcode{bad_any_cast}}
 
+\indexlibrary{\idxcode{bad_any_cast}}%
 \begin{codeblock}
 class bad_any_cast : public bad_cast {
 public:
@@ -3353,7 +3356,7 @@ public:
 \end{codeblock}
 
 \pnum
-Objects of type \tcode{bad_any_cast} are thrown by a failed \tcode{any_cast}.
+Objects of type \tcode{bad_any_cast} are thrown by a failed \tcode{any_cast}~(\ref{any.nonmembers}).
 
 \rSec2[any.class]{Class \tcode{any}}
 
@@ -7251,7 +7254,6 @@ The second function template returns \tcode{!(nullptr < x)}.
 \rSec2[util.smartptr]{Shared-ownership pointers}
 
 \rSec3[util.smartptr.weakptr]{Class \tcode{bad_weak_ptr}}
-\indexlibrary{exception!\idxcode{bad_weak_ptr}}%
 \indexlibrary{\idxcode{bad_weak_ptr}}%
 \begin{codeblock}
 namespace std {
@@ -7275,7 +7277,7 @@ bad_weak_ptr() noexcept;
 
 \begin{itemdescr}
 \pnum\postconditions  \tcode{what()} returns an
-\impldef{string returned by \tcode{what()} for \tcode{bad_weak_ptr}} NTBS.
+\impldef{return value of \tcode{bad_weak_ptr::what}} \ntbs.
 
 \end{itemdescr}
 
@@ -11933,8 +11935,7 @@ This subclause describes a polymorphic wrapper class that
 encapsulates arbitrary callable objects.
 
 \rSec3[func.wrap.badcall]{Class \tcode{bad_function_call}}%
-\indexlibrary{\idxcode{bad_function_call}}%
-\indexlibrary{exception!\idxcode{bad_function_call}}
+\indexlibrary{\idxcode{bad_function_call}}
 
 \pnum
 An exception of type \tcode{bad_function_call} is thrown by
@@ -11954,6 +11955,8 @@ namespace std {
 \rSec4[func.wrap.badcall.const]{\tcode{bad_function_call} constructor}
 
 \indexlibrary{\idxcode{bad_function_call}!constructor}%
+\indexlibrary{\idxcode{bad_function_call}!\idxcode{what}}%
+\indexlibrary{\idxcode{what}!\idxcode{bad_function_call}}%
 \begin{itemdecl}
 bad_function_call() noexcept;
 \end{itemdecl}
@@ -11964,7 +11967,7 @@ bad_function_call() noexcept;
 
 \begin{itemdescr}
 \pnum\postcondition  \tcode{what()} returns an
-\impldef{string returned by \tcode{what()} for \tcode{bad_weak_ptr}} NTBS.
+\impldef{return value of \tcode{bad_function_call::what}} \ntbs.
 \end{itemdescr}
 
 \rSec3[func.wrap.func]{Class template \tcode{function}}


### PR DESCRIPTION
Appply a simple, consistent pattern to the index entries, including
th index of implementation defined behaviors, for the library types
that derive from std::exception.

In some cases this means adding entries, in others removing extra
nested implementation-defined entries that are redundant since the
addition of the index of implementatio defined behaviors.

A few cross-references were added or corrected as part of this
process.

Further work to make the presentation and specification of these
types probably requires LWG issues.  In particular, bad_any_cast
is woefully underspecified.