### PR TITLE
[18-20,27] Prefer to use 'override' where appropriate

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -144,15 +144,16 @@ namespace std {
     int   pcount();
 
   protected:
-    virtual int_type overflow (int_type c = EOF);
-    virtual int_type pbackfail(int_type c = EOF);
-    virtual int_type underflow();
-    virtual pos_type seekoff(off_type off, ios_base::seekdir way,
-                             ios_base::openmode which
-                               = ios_base::in | ios_base::out);
-    virtual pos_type seekpos(pos_type sp, ios_base::openmode which
-                               = ios_base::in | ios_base::out);
-    virtual streambuf* setbuf(char* s, streamsize n);
+    int_type overflow (int_type c = EOF) override;
+    int_type pbackfail(int_type c = EOF) override;
+    int_type underflow() override;
+    pos_type seekoff(off_type off, ios_base::seekdir way,
+                     ios_base::openmode which
+                      = ios_base::in | ios_base::out) override;
+    pos_type seekpos(pos_type sp,
+                     ios_base::openmode which
+                      = ios_base::in | ios_base::out) override;
+    streambuf* setbuf(char* s, streamsize n) override;
 
   private:
     using strstate = T1;              // \expos
@@ -443,7 +444,7 @@ pointer for the output sequence, \tcode{pnext} - \tcode{pbeg}.
 
 \indexlibrary{\idxcode{overflow}!\idxcode{strstreambuf}}%
 \begin{itemdecl}
-int_type overflow(int_type c = EOF);
+int_type overflow(int_type c = EOF) override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -520,7 +521,7 @@ the function cannot extend the array (reallocate it with greater length) to make
 
 \indexlibrary{\idxcode{pbackfail}!\idxcode{strstreambuf}}%
 \begin{itemdecl}
-int_type pbackfail(int_type c = EOF);
+int_type pbackfail(int_type c = EOF) override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -576,7 +577,7 @@ positions available as a result of any call.
 
 \indexlibrary{\idxcode{underflow}!\idxcode{strstreambuf}}%
 \begin{itemdecl}
-int_type underflow();
+int_type underflow() override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -616,7 +617,7 @@ result of any call.
 
 \indexlibrary{\idxcode{seekoff}!\idxcode{strstreambuf}}%
 \begin{itemdecl}
-pos_type seekoff(off_type off, seekdir way, openmode which = in | out);
+pos_type seekoff(off_type off, seekdir way, openmode which = in | out) override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -682,7 +683,7 @@ the return value is
 \indexlibrary{\idxcode{seekpos}!\idxcode{strstreambuf}}%
 \begin{itemdecl}
 pos_type seekpos(pos_type sp, ios_base::openmode which
-                  = ios_base::in | ios_base::out);
+                  = ios_base::in | ios_base::out) override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -737,7 +738,7 @@ the return value is
 
 \indexlibrary{\idxcode{setbuf}!\idxcode{strstreambuf}}%
 \begin{itemdecl}
-streambuf<char>* setbuf(char* s, streamsize n);
+streambuf<char>* setbuf(char* s, streamsize n) override;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -7358,17 +7358,17 @@ namespace std {
 
   protected:
     // \ref{stringbuf.virtuals}, overridden virtual functions:
-    virtual int_type   underflow();
-    virtual int_type   pbackfail(int_type c = traits::eof());
-    virtual int_type   overflow (int_type c = traits::eof());
-    virtual  basic_streambuf<charT, traits>* setbuf(charT*, streamsize);
+    int_type underflow() override;
+    int_type pbackfail(int_type c = traits::eof()) override;
+    int_type overflow (int_type c = traits::eof()) override;
+    basic_streambuf<charT, traits>* setbuf(charT*, streamsize) override;
 
-    virtual pos_type seekoff(off_type off, ios_base::seekdir way,
-                             ios_base::openmode which
-                               = ios_base::in | ios_base::out);
-    virtual pos_type seekpos(pos_type sp,
-                             ios_base::openmode which
-                               = ios_base::in | ios_base::out);
+    pos_type seekoff(off_type off, ios_base::seekdir way,
+                     ios_base::openmode which
+                      = ios_base::in | ios_base::out) override;
+    pos_type seekpos(pos_type sp,
+                     ios_base::openmode which
+                      = ios_base::in | ios_base::out) override;
 
   private:
     ios_base::openmode mode;  // \expos
@@ -7581,7 +7581,7 @@ true, \tcode{eback()} points to the first underlying character, and both \tcode{
 
 \indexlibrary{\idxcode{underflow}!\idxcode{basic_stringbuf}}%
 \begin{itemdecl}
-int_type underflow();
+int_type underflow() override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7598,7 +7598,7 @@ to be part of the input sequence.
 
 \indexlibrary{\idxcode{pbackfail}!\idxcode{basic_stringbuf}}%
 \begin{itemdecl}
-int_type pbackfail(int_type c = traits::eof());
+int_type pbackfail(int_type c = traits::eof()) override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7670,7 +7670,7 @@ unspecified which way is chosen.
 
 \indexlibrary{\idxcode{overflow}!\idxcode{basic_stringbuf}}%
 \begin{itemdecl}
-int_type overflow(int_type c = traits::eof());
+int_type overflow(int_type c = traits::eof()) override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7734,7 +7734,7 @@ to point just past the new write position.
 \begin{itemdecl}
 pos_type seekoff(off_type off, ios_base::seekdir way,
                  ios_base::openmode which
-                   = ios_base::in | ios_base::out);
+                   = ios_base::in | ios_base::out) override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7808,7 +7808,7 @@ the return value is
 \begin{itemdecl}
 pos_type seekpos(pos_type sp,
                  ios_base::openmode which
-                   = ios_base::in | ios_base::out);
+                   = ios_base::in | ios_base::out) override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8519,22 +8519,22 @@ namespace std {
 
   protected:
     // \ref{filebuf.virtuals}, overridden virtual functions:
-    virtual streamsize showmanyc();
-    virtual int_type underflow();
-    virtual int_type uflow();
-    virtual int_type pbackfail(int_type c = traits::eof());
-    virtual int_type overflow (int_type c = traits::eof());
+    streamsize showmanyc() override;
+    int_type underflow() override;
+    int_type uflow() override;
+    int_type pbackfail(int_type c = traits::eof()) override;
+    int_type overflow (int_type c = traits::eof()) override;
 
-    virtual basic_streambuf<charT, traits>* setbuf(char_type* s,
-                                                   streamsize n);
-    virtual pos_type seekoff(off_type off, ios_base::seekdir way,
-                             ios_base::openmode which
-                               = ios_base::in | ios_base::out);
-    virtual pos_type seekpos(pos_type sp,
-                             ios_base::openmode which
-                               = ios_base::in | ios_base::out);
-    virtual int      sync();
-    virtual void     imbue(const locale& loc);
+    basic_streambuf<charT, traits>* setbuf(char_type* s,
+                                           streamsize n) override;
+    pos_type seekoff(off_type off, ios_base::seekdir way,
+                     ios_base::openmode which
+                      = ios_base::in | ios_base::out) override;
+    pos_type seekpos(pos_type sp,
+                     ios_base::openmode which
+                      = ios_base::in | ios_base::out) override;
+    int      sync() override;
+    void     imbue(const locale& loc) override;
   };
 
   template <class charT, class traits>
@@ -8870,7 +8870,7 @@ on success, a null pointer otherwise.
 
 \indexlibrary{\idxcode{showmanyc}!\idxcode{basic_filebuf}}%
 \begin{itemdecl}
-streamsize showmanyc();
+streamsize showmanyc() override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8890,7 +8890,7 @@ sequence.
 
 \indexlibrary{\idxcode{underflow}!\idxcode{basic_filebuf}}%
 \begin{itemdecl}
-int_type underflow();
+int_type underflow() override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8933,7 +8933,7 @@ retry with a larger
 
 \indexlibrary{\idxcode{uflow}!\idxcode{basic_filebuf}}%
 \begin{itemdecl}
-int_type uflow();
+int_type uflow() override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8948,7 +8948,7 @@ with the same method as used by
 
 \indexlibrary{\idxcode{pbackfail}!\idxcode{basic_filebuf}}%
 \begin{itemdecl}
-int_type pbackfail(int_type c = traits::eof());
+int_type pbackfail(int_type c = traits::eof()) override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9024,7 +9024,7 @@ The function can alter the number of putback positions available as a result of 
 
 \indexlibrary{\idxcode{overflow}!\idxcode{basic_filebuf}}%
 \begin{itemdecl}
-int_type overflow(int_type c = traits::eof());
+int_type overflow(int_type c = traits::eof()) override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9071,7 +9071,7 @@ the function always fails.
 
 \indexlibrary{\idxcode{setbuf}!\idxcode{basic_filebuf}}%
 \begin{itemdecl}
-basic_streambuf* setbuf(char_type* s, streamsize n);
+basic_streambuf* setbuf(char_type* s, streamsize n) override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9095,7 +9095,7 @@ and output to the file should appear as soon as possible.
 \begin{itemdecl}
 pos_type seekoff(off_type off, ios_base::seekdir way,
                  ios_base::openmode which
-                   = ios_base::in | ios_base::out);
+                   = ios_base::in | ios_base::out) override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9162,7 +9162,7 @@ returns
 \begin{itemdecl}
 pos_type seekpos(pos_type sp,
                  ios_base::openmode which
-                   = ios_base::in | ios_base::out);
+                   = ios_base::in | ios_base::out) override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9209,7 +9209,7 @@ Otherwise returns
 
 \indexlibrary{\idxcode{sync}!\idxcode{basic_filebuf}}%
 \begin{itemdecl}
-int sync();
+int sync() override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9225,7 +9225,7 @@ If a get area exists, the effect is \impldef{effect of calling
 
 \indexlibrary{\idxcode{imbue}!\idxcode{basic_filebuf}}%
 \begin{itemdecl}
-void imbue(const locale& loc);
+void imbue(const locale& loc) override;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/support.tex
+++ b/source/support.tex
@@ -2078,7 +2078,7 @@ namespace std {
     bad_alloc() noexcept;
     bad_alloc(const bad_alloc&) noexcept;
     bad_alloc& operator=(const bad_alloc&) noexcept;
-    virtual const char* what() const noexcept;
+    const char* what() const noexcept override;
   };
 }
 \end{codeblock}
@@ -2118,7 +2118,7 @@ Copies an object of class
 \indexlibrary{\idxcode{what}!\idxcode{bad_alloc}}%
 \indexlibrary{\idxcode{bad_alloc}!\idxcode{what}}%
 \begin{itemdecl}
-virtual const char* what() const noexcept;
+const char* what() const noexcept override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2141,7 +2141,7 @@ namespace std {
   class bad_array_new_length : public bad_alloc {
   public:
     bad_array_new_length() noexcept;
-    virtual const char* what() const noexcept;
+    const char* what() const noexcept override;
   };
 }
 \end{codeblock}
@@ -2165,7 +2165,7 @@ bad_array_new_length() noexcept;
 \indexlibrary{\idxcode{bad_array_new_length}!\idxcode{what}}%
 \indexlibrary{\idxcode{what}!\idxcode{bad_array_new_length}}%
 \begin{itemdecl}
-virtual const char* what() const noexcept;
+const char* what() const noexcept override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2446,7 +2446,7 @@ namespace std {
     bad_cast() noexcept;
     bad_cast(const bad_cast&) noexcept;
     bad_cast& operator=(const bad_cast&) noexcept;
-    virtual const char* what() const noexcept;
+    const char* what() const noexcept override;
   };
 }
 \end{codeblock}
@@ -2489,7 +2489,7 @@ Copies an object of class
 \indexlibrary{\idxcode{bad_cast}!\idxcode{what}}%
 \indexlibrary{\idxcode{what}!\idxcode{bad_cast}}%
 \begin{itemdecl}
-virtual const char* what() const noexcept;
+const char* what() const noexcept override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2514,7 +2514,7 @@ namespace std {
     bad_typeid() noexcept;
     bad_typeid(const bad_typeid&) noexcept;
     bad_typeid& operator=(const bad_typeid&) noexcept;
-    virtual const char* what() const noexcept;
+    const char* what() const noexcept override;
   };
 }
 \end{codeblock}
@@ -2557,7 +2557,7 @@ Copies an object of class
 \indexlibrary{\idxcode{bad_typeid}!\idxcode{what}}%
 \indexlibrary{\idxcode{what}!\idxcode{bad_typeid}}%
 \begin{itemdecl}
-virtual const char* what() const noexcept;
+const char* what() const noexcept override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2722,7 +2722,7 @@ namespace std {
     bad_exception() noexcept;
     bad_exception(const bad_exception&) noexcept;
     bad_exception& operator=(const bad_exception&) noexcept;
-    virtual const char* what() const noexcept;
+    const char* what() const noexcept override;
   };
 }
 \end{codeblock}
@@ -2762,7 +2762,7 @@ Copies an object of class
 \indexlibrary{\idxcode{bad_exception}!\idxcode{what}}%
 \indexlibrary{\idxcode{what}!\idxcode{bad_exception}}%
 \begin{itemdecl}
-virtual const char* what() const noexcept;
+const char* what() const noexcept override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3118,7 +3118,7 @@ namespace std {
     iterator begin() const noexcept;
     iterator end() const noexcept;
 
-    virtual const char* what() const noexcept;
+    const char* what() const noexcept override;
   };
 }
 \end{codeblock}
@@ -3178,7 +3178,7 @@ An iterator that is the past-the-end value of the owned sequence.
 \indexlibrary{\idxcode{exception_list}!\idxcode{what}}
 \indexlibrary{\idxcode{what}!\idxcode{exception_list}}
 \begin{itemdecl}
-virtual const char* what() const noexcept;
+const char* what() const noexcept override;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -3351,7 +3351,7 @@ namespace std {
 \begin{codeblock}
 class bad_any_cast : public bad_cast {
 public:
-  virtual const char* what() const noexcept;
+  const char* what() const noexcept override;
 };
 \end{codeblock}
 
@@ -9553,10 +9553,10 @@ public:
   pool_options options() const;
 
 protected:
-  virtual void *do_allocate(size_t bytes, size_t alignment);
-  virtual void do_deallocate(void *p, size_t bytes, size_t alignment);
+  void *do_allocate(size_t bytes, size_t alignment) override;
+  void do_deallocate(void *p, size_t bytes, size_t alignment) override;
 
-  virtual bool do_is_equal(const memory_resource &other) const noexcept;
+  bool do_is_equal(const memory_resource &other) const noexcept override;
 };
 
 class unsynchronized_pool_resource : public memory_resource {
@@ -9582,10 +9582,10 @@ public:
   pool_options options() const;
 
 protected:
-  virtual void *do_allocate(size_t bytes, size_t alignment);
-  virtual void do_deallocate(void *p, size_t bytes, size_t alignment);
+  void *do_allocate(size_t bytes, size_t alignment) override;
+  void do_deallocate(void *p, size_t bytes, size_t alignment) override;
 
-  virtual bool do_is_equal(const memory_resource &other) const noexcept;
+  bool do_is_equal(const memory_resource &other) const noexcept override;
 };
 \end{codeblock}
 
@@ -9737,7 +9737,7 @@ and sizes may be rounded to unspecified granularity.
 \indexlibrary{\idxcode{do_allocate}!\idxcode{synchronized_pool_resource}}%
 \indexlibrary{\idxcode{do_allocate}!\idxcode{unsynchronized_pool_resource}}%
 \begin{itemdecl}
-virtual void* do_allocate(size_t bytes, size_t alignment);
+void* do_allocate(size_t bytes, size_t alignment) override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9766,7 +9766,7 @@ Nothing unless \tcode{upstream_resource()->allocate()} throws.
 \indexlibrary{\idxcode{do_deallocate}!\idxcode{synchronized_pool_resource}}%
 \indexlibrary{\idxcode{do_deallocate}!\idxcode{unsynchronized_pool_resource}}%
 \begin{itemdecl}
-virtual void do_deallocate(void* p, size_t bytes, size_t alignment);
+void do_deallocate(void* p, size_t bytes, size_t alignment) override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9784,7 +9784,7 @@ Nothing.
 \indexlibrary{\idxcode{unsynchronized_pool_resource}!\idxcode{do_is_equal}}%
 \indexlibrary{\idxcode{do_is_equal}!\idxcode{unsynchronized_pool_resource}}%
 \begin{itemdecl}
-virtual bool unsynchronized_pool_resource::do_is_equal(const memory_resource& other) const noexcept;
+bool unsynchronized_pool_resource::do_is_equal(const memory_resource& other) const noexcept override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9796,7 +9796,7 @@ virtual bool unsynchronized_pool_resource::do_is_equal(const memory_resource& ot
 \indexlibrary{\idxcode{synchronized_pool_resource}!\idxcode{do_is_equal}}%
 \indexlibrary{\idxcode{do_is_equal}!\idxcode{synchronized_pool_resource}}%
 \begin{itemdecl}
-virtual bool synchronized_pool_resource::do_is_equal(const memory_resource& other) const noexcept;
+bool synchronized_pool_resource::do_is_equal(const memory_resource& other) const noexcept override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9867,10 +9867,10 @@ public:
   memory_resource *upstream_resource() const;
 
 protected:
-  virtual void *do_allocate(size_t bytes, size_t alignment);
-  virtual void do_deallocate(void *p, size_t bytes, size_t alignment);
+  void *do_allocate(size_t bytes, size_t alignment) override;
+  void do_deallocate(void *p, size_t bytes, size_t alignment) override;
 
-  virtual bool do_is_equal(const memory_resource &other) const noexcept;
+  bool do_is_equal(const memory_resource &other) const noexcept override;
 };
 \end{codeblock}
 
@@ -9962,7 +9962,7 @@ The value of \tcode{upstream_rsrc}.
 
 \indexlibrary{\idxcode{monotonic_buffer_resource}!\idxcode{do_allocate}}%
 \begin{itemdecl}
-void* do_allocate(size_t bytes, size_t alignment);
+void* do_allocate(size_t bytes, size_t alignment) override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9992,7 +9992,7 @@ Nothing unless \tcode{upstream_rsrc->allocate()} throws.
 
 \indexlibrary{\idxcode{monotonic_buffer_resource}!\idxcode{do_deallocate}}%
 \begin{itemdecl}
-void do_deallocate(void* p, size_t bytes, size_t alignment);
+void do_deallocate(void* p, size_t bytes, size_t alignment) override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10011,7 +10011,7 @@ Memory used by this resource increases monotonically until its destruction.
 
 \indexlibrary{\idxcode{monotonic_buffer_resource}!\idxcode{do_is_equal}}%
 \begin{itemdecl}
-bool do_is_equal(const memory_resource& other) const noexcept;
+bool do_is_equal(const memory_resource& other) const noexcept override;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
This patch makes consistent use of the 'override' contextual
keyword for every member function (other than destructors)
that overrides a virtual function in one of its base classes.

In general, this came down to one of three cases:
1) the 'what' function for an exception class
2) the allocation functions of a memory resource
3) the implementation methods of a stream buffer.

As far as I can tell, all other virtual function declarations
in the standard library are intended as customization points
for users, and are not overriden in the standard itself.

This pull request addresses https://github.com/cplusplus/draft/issues/751