### PR TITLE
[strings,containers] Add iterators to index of implemenetation define…

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -2646,8 +2646,8 @@ namespace std {
     using const_reference        = const T&;
     using size_type              = size_t;
     using difference_type        = ptrdiff_t;
-    using iterator               = @\impdefx{type of \tcode{array::iterator}}@;
-    using const_iterator         = @\impdefx{type of \tcode{array::const_iterator}}@;
+    using iterator               = @\impdefx{type of \tcode{array::iterator}}@; // see \ref{container.requirements}
+    using const_iterator         = @\impdefx{type of \tcode{array::const_iterator}}@; // see \ref{container.requirements}
     using reverse_iterator       = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
@@ -2894,8 +2894,8 @@ namespace std {
     using const_reference        = const value_type&;
     using size_type              = @\impdef@; // see \ref{container.requirements}
     using difference_type        = @\impdef@; // see \ref{container.requirements}
-    using iterator               = @\impdef@; // see \ref{container.requirements}
-    using const_iterator         = @\impdef@; // see \ref{container.requirements}
+    using iterator               = @\impdefx{type of \tcode{deque::iterator}}@; // see \ref{container.requirements}
+    using const_iterator         = @\impdefx{type of \tcode{deque::const_iterator}}@; // see \ref{container.requirements}
     using reverse_iterator       = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
@@ -3278,8 +3278,8 @@ namespace std {
     using const_reference = const value_type&;
     using size_type       = @\impdef@; // see \ref{container.requirements}
     using difference_type = @\impdef@; // see \ref{container.requirements}
-    using iterator        = @\impdef@; // see \ref{container.requirements}
-    using const_iterator  = @\impdef@; // see \ref{container.requirements}
+    using iterator        = @\impdefx{type of \tcode{forward_list::iterator}}@; // see \ref{container.requirements}
+    using const_iterator  = @\impdefx{type of \tcode{forward_list::const_iterator}}@; // see \ref{container.requirements}
 
     // \ref{forwardlist.cons}, construct/copy/destroy:
     forward_list() : forward_list(Allocator()) { }
@@ -4009,8 +4009,8 @@ namespace std {
     using const_reference        = const value_type&;
     using size_type              = @\impdef@; // see \ref{container.requirements}
     using difference_type        = @\impdef@; // see \ref{container.requirements}
-    using iterator               = @\impdef@; // see \ref{container.requirements}
-    using const_iterator         = @\impdef@; // see \ref{container.requirements}
+    using iterator               = @\impdefx{type of \tcode{list::iterator}}@; // see \ref{container.requirements}
+    using const_iterator         = @\impdefx{type of \tcode{list::const_iterator}}@; // see \ref{container.requirements}
     using reverse_iterator       = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
@@ -4702,8 +4702,8 @@ namespace std {
     using const_reference        = const value_type&;
     using size_type              = @\impdef@; // see \ref{container.requirements}
     using difference_type        = @\impdef@; // see \ref{container.requirements}
-    using iterator               = @\impdef@; // see \ref{container.requirements}
-    using const_iterator         = @\impdef@; // see \ref{container.requirements}
+    using iterator               = @\impdefx{type of \tcode{vector::iterator}}@; // see \ref{container.requirements}
+    using const_iterator         = @\impdefx{type of \tcode{vector::const_iterator}}@; // see \ref{container.requirements}
     using reverse_iterator       = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
@@ -5169,8 +5169,8 @@ namespace std {
     using const_reference        = bool;
     using size_type              = @\impdef@; // see \ref{container.requirements}
     using difference_type        = @\impdef@; // see \ref{container.requirements}
-    using iterator               = @\impdef@; // see \ref{container.requirements}
-    using const_iterator         = @\impdef@; // see \ref{container.requirements}
+    using iterator               = @\impdefx{type of \tcode{vector<bool>::iterator}}@; // see \ref{container.requirements}
+    using const_iterator         = @\impdefx{type of \tcode{vector<bool>::const_iterator}}@; // see \ref{container.requirements}
     using reverse_iterator       = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
@@ -5542,8 +5542,8 @@ namespace std {
     using const_reference        = const value_type&;
     using size_type              = @\impdef@; // see \ref{container.requirements}
     using difference_type        = @\impdef@; // see \ref{container.requirements}
-    using iterator               = @\impdef@; // see \ref{container.requirements}
-    using const_iterator         = @\impdef@; // see \ref{container.requirements}
+    using iterator               = @\impdefx{type of \tcode{map::iterator}}@; // see \ref{container.requirements}
+    using const_iterator         = @\impdefx{type of \tcode{map::const_iterator}}@; // see \ref{container.requirements}
     using reverse_iterator       = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
@@ -6055,8 +6055,8 @@ namespace std {
     using const_reference        = const value_type&;
     using size_type              = @\impdef@; // see \ref{container.requirements}
     using difference_type        = @\impdef@; // see \ref{container.requirements}
-    using iterator               = @\impdef@; // see \ref{container.requirements}
-    using const_iterator         = @\impdef@; // see \ref{container.requirements}
+    using iterator               = @\impdefx{type of \tcode{multimap::iterator}}@; // see \ref{container.requirements}
+    using const_iterator         = @\impdefx{type of \tcode{multimap::const_iterator}}@; // see \ref{container.requirements}
     using reverse_iterator       = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
@@ -6350,8 +6350,8 @@ namespace std {
     using const_reference        = const value_type&;
     using size_type              = @\impdef@; // see \ref{container.requirements}
     using difference_type        = @\impdef@; // see \ref{container.requirements}
-    using iterator               = @\impdef@; // see \ref{container.requirements}
-    using const_iterator         = @\impdef@; // see \ref{container.requirements}
+    using iterator               = @\impdefx{type of \tcode{set::iterator}}@; // see \ref{container.requirements}
+    using const_iterator         = @\impdefx{type of \tcode{set::const_iterator}}@; // see \ref{container.requirements}
     using reverse_iterator       = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
@@ -6603,8 +6603,8 @@ namespace std {
     using const_reference        = const value_type&;
     using size_type              = @\impdef@; // see \ref{container.requirements}
     using difference_type        = @\impdef@; // see \ref{container.requirements}
-    using iterator               = @\impdef@; // see \ref{container.requirements}
-    using const_iterator         = @\impdef@; // see \ref{container.requirements}
+    using iterator               = @\impdefx{type of \tcode{multiset::iterator}}@; // see \ref{container.requirements}
+    using const_iterator         = @\impdefx{type of \tcode{multiset::const_iterator}}@; // see \ref{container.requirements}
     using reverse_iterator       = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
@@ -6980,10 +6980,10 @@ namespace std {
     using size_type            = @\impdef@; // see \ref{container.requirements}
     using difference_type      = @\impdef@; // see \ref{container.requirements}
 
-    using iterator             = @\impdef@; // see \ref{container.requirements}
-    using const_iterator       = @\impdef@; // see \ref{container.requirements}
-    using local_iterator       = @\impdef@; // see \ref{container.requirements}
-    using const_local_iterator = @\impdef@; // see \ref{container.requirements}
+    using iterator             = @\impdefx{type of \tcode{unordered_map::iterator}}@; // see \ref{container.requirements}
+    using const_iterator       = @\impdefx{type of \tcode{unordered_map::const_iterator}}@; // see \ref{container.requirements}
+    using local_iterator       = @\impdefx{type of \tcode{unordered_map::local_iterator}}@; // see \ref{container.requirements}
+    using const_local_iterator = @\impdefx{type of \tcode{unordered_map::const_local_iterator}}@; // see \ref{container.requirements}
 
     // \ref{unord.map.cnstr}, construct/copy/destroy:
     unordered_map();
@@ -7482,10 +7482,10 @@ namespace std {
     using size_type            = @\impdef@; // see \ref{container.requirements}
     using difference_type      = @\impdef@; // see \ref{container.requirements}
 
-    using iterator             = @\impdef@; // see \ref{container.requirements}
-    using const_iterator       = @\impdef@; // see \ref{container.requirements}
-    using local_iterator       = @\impdef@; // see \ref{container.requirements}
-    using const_local_iterator = @\impdef@; // see \ref{container.requirements}
+    using iterator             = @\impdefx{type of \tcode{unordered_multimap::iterator}}@; // see \ref{container.requirements}
+    using const_iterator       = @\impdefx{type of \tcode{unordered_multimap::const_iterator}}@; // see \ref{container.requirements}
+    using local_iterator       = @\impdefx{type of \tcode{unordered_multimap::local_iterator}}@; // see \ref{container.requirements}
+    using const_local_iterator = @\impdefx{type of \tcode{unordered_multimap::const_local_iterator}}@; // see \ref{container.requirements}
 
     // \ref{unord.multimap.cnstr}, construct/copy/destroy:
     unordered_multimap();
@@ -7767,10 +7767,10 @@ namespace std {
     using size_type            = @\impdef@; // see \ref{container.requirements}
     using difference_type      = @\impdef@; // see \ref{container.requirements}
 
-    using iterator             = @\impdef@; // see \ref{container.requirements}
-    using const_iterator       = @\impdef@; // see \ref{container.requirements}
-    using local_iterator       = @\impdef@; // see \ref{container.requirements}
-    using const_local_iterator = @\impdef@; // see \ref{container.requirements}
+    using iterator             = @\impdefx{type of \tcode{unordered_set::iterator}}@; // see \ref{container.requirements}
+    using const_iterator       = @\impdefx{type of \tcode{unordered_set::const_iterator}}@; // see \ref{container.requirements}
+    using local_iterator       = @\impdefx{type of \tcode{unordered_set::local_iterator}}@; // see \ref{container.requirements}
+    using const_local_iterator = @\impdefx{type of \tcode{unordered_set::const_local_iterator}}@; // see \ref{container.requirements}
 
     // \ref{unord.set.cnstr}, construct/copy/destroy:
     unordered_set();
@@ -8020,10 +8020,10 @@ namespace std {
     using size_type            = @\impdef@; // see \ref{container.requirements}
     using difference_type      = @\impdef@; // see \ref{container.requirements}
 
-    using iterator             = @\impdef@; // see \ref{container.requirements}
-    using const_iterator       = @\impdef@; // see \ref{container.requirements}
-    using local_iterator       = @\impdef@; // see \ref{container.requirements}
-    using const_local_iterator = @\impdef@; // see \ref{container.requirements}
+    using iterator             = @\impdefx{type of \tcode{unordered_multiset::iterator}}@; // see \ref{container.requirements}
+    using const_iterator       = @\impdefx{type of \tcode{unordered_multiset::const_iterator}}@; // see \ref{container.requirements}
+    using local_iterator       = @\impdefx{type of \tcode{unordered_multiset::local_iterator}}@; // see \ref{container.requirements}
+    using const_local_iterator = @\impdefx{type of \tcode{unordered_multiset::const_local_iterator}}@; // see \ref{container.requirements}
 
     // \ref{unord.multiset.cnstr}, construct/copy/destroy:
     unordered_multiset();

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -893,8 +893,8 @@ namespace std {
     using reference              = value_type&;
     using const_reference        = const value_type&;
 
-    using iterator               = @\impdef@; // See \ref{container.requirements}
-    using const_iterator         = @\impdef@; // See \ref{container.requirements}
+    using iterator               = @\impdefx{type of \tcode{basic_string::iterator}}@; // see \ref{container.requirements}
+    using const_iterator         = @\impdefx{type of \tcode{basic_string::const_iterator}}@; // see \ref{container.requirements}
     using reverse_iterator       = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
     static const size_type npos  = -1;
@@ -4640,7 +4640,7 @@ Constructs a \tcode{basic_string_view}, with the postconditions in table~\ref{ta
 \rSec3[string.view.iterators]{Iterator support}
 
 \begin{itemdecl}
-using const_iterator = @\impdef@;
+using const_iterator = @\impdefx{type of \tcode{basic_string_view::const_iterator}}@;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Add iterators to index of implemenetation defined behavior

This patch slavishly copies the tag used for array::iterator, without
understanding if a better markup might be available.  One consequence
is that we get two entries for basic_string_view::const_iterator.
Another is that the index around type names appears as two sorted
subsequences, rather than one sorted sequence.

An additional patch will follow for the remaining implementation-defined
types that are not present in the index, once the preferred markup is
reviewed in this pull request.