### PR TITLE
[macros] Replace cooked underscore with raw version

### DIFF
--- a/source/macros.tex
+++ b/source/macros.tex
@@ -228,7 +228,7 @@
 
 %% Double underscore
 \newcommand{\ungap}{\kern.5pt}
-\newcommand{\unun}{\_\ungap\_}
+\newcommand{\unun}{\textunderscore\ungap\textunderscore}
 \newcommand{\xname}[1]{\tcode{\unun\ungap#1}}
 \newcommand{\mname}[1]{\tcode{\unun\ungap#1\ungap\unun}}
 


### PR DESCRIPTION
This aids collation for situations where the index entry contains underscores. The `underscore` package changes the underscore command (`\_`) to do something fairly complex (e.g. adding a hyphenation hint), which isn't easy to index.

No visual diffs.