### PR TITLE
[utility,iterator] Apply p0174r2 deprecating vestigial library compon…

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -1628,3 +1628,404 @@ template <class Predicate>
 \begin{itemdescr}
 \pnum \returns \tcode{binary_negate<Predicate>(pred)}.
 \end{itemdescr}
+
+\rSec1[depr.default.allocator]{The default allocator}
+
+\pnum
+The following members and explicit class template specialization are defined in
+addition to those specified in \ref{default.allocator}:
+
+\indexlibrary{\idxcode{allocator}}%
+\begin{codeblock}
+namespace std {
+  // specialize for \tcode{void}:
+  template <> class allocator<void> {
+  public:
+    using value_type    = void;
+    using pointer       = void*;
+    using const_pointer = const void*;
+    // reference-to-\tcode{void} members are impossible.
+
+    template <class U> struct rebind { using other = allocator<U>; };
+  };
+
+  template <class T> class allocator {
+   public:
+    using size_type       = size_t;
+    using difference_type = ptrdiff_t;
+    using pointer         = T*;
+    using const_pointer   = const T*;
+    using reference       = T&;
+    using const_reference = const T&;
+    template <class U> struct rebind { using other = allocator<U>; };
+
+    T* address(T& x) const noexcept;
+    const T* address(const T& x) const noexcept;
+
+    T* allocate(size_t n, const void* hint);
+
+    template<class U, class... Args>
+      void construct(U* p, Args&&... args);
+    template <class U>
+      void destroy(U* p);
+
+    size_t max_size() const noexcept;
+  };
+}
+\end{codeblock}
+
+\indexlibrary{\idxcode{allocator}!\idxcode{address}}
+\indexlibrary{\idxcode{address}!\idxcode{allocator}}
+\begin{itemdecl}
+T* address(T& x) const noexcept;
+const T* address(const T& x) const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+The actual address of the object referenced by \tcode{x}, even in the presence of an
+overloaded operator\&.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{allocator}!\idxcode{allocate}}
+\indexlibrary{\idxcode{allocate}!\idxcode{allocator}}
+\begin{itemdecl}
+T* allocate(size_t n, const void* hint);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+A pointer to the initial element of an array of storage of size \tcode{n}
+\tcode{* sizeof(T)}, aligned appropriately for objects of type \tcode{T}.
+It is \impldef{support for over-aligned types} whether over-aligned types are
+supported~(\ref{basic.align}).
+
+\pnum
+\remark
+the storage is obtained by calling \tcode{::operator new(std::size_t)}~(\ref{new.delete}),
+but it is unspecified when or how often this function is called.
+
+\pnum
+\throws
+\tcode{bad_alloc} if the storage cannot be obtained.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{allocator}!\idxcode{construct}}
+\indexlibrary{\idxcode{construct}!\idxcode{allocator}}
+\begin{itemdecl}
+template <class U, class... Args>
+  void construct(U* p, Args&&... args);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+As if by: \tcode{::new((void *)p) U(std::forward<Args>(args)...);}
+\end{itemdescr}
+
+\indexlibrary{\idxcode{allocator}!\idxcode{destroy}}
+\indexlibrary{\idxcode{destroy}!\idxcode{allocator}}
+\begin{itemdecl}
+template <class U>
+  void destroy(U* p);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+As if by \tcode{p->\~{}U()}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{allocator}!\idxcode{max_size}}
+\indexlibrary{\idxcode{max_size}!\idxcode{allocator}}
+\begin{itemdecl}
+size_t max_size() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+The largest value \textit{N} for which the call \tcode{allocate(N, 0)}
+might succeed.
+\end{itemdescr}
+
+\rSec1[depr.storage.iterator]{Raw storage iterator}
+
+\pnum
+The header \tcode{<memory>} has the following addition:
+
+\indexlibrary{\idxcode{raw_storage_iterator}}%
+\begin{codeblock}
+namespace std {
+  template <class OutputIterator, class T>
+  class raw_storage_iterator {
+  public:
+    using iterator_category = output_iterator_tag;
+    using value_type        = void;
+    using difference_type   = void;
+    using pointer           = void;
+    using reference         = void;
+
+    explicit raw_storage_iterator(OutputIterator x);
+
+    raw_storage_iterator& operator*();
+    raw_storage_iterator& operator=(const T& element);
+    raw_storage_iterator& operator=(T&& element);
+    raw_storage_iterator& operator++();
+    raw_storage_iterator  operator++(int);
+    OutputIterator base() const;
+  };
+}
+\end{codeblock}
+
+\pnum
+\tcode{raw_storage_iterator} is provided to enable algorithms to store their
+results into uninitialized memory. The template parameter
+\tcode{OutputIterator} is required to have its \tcode{operator*} return an
+object for which \tcode{operator\&} is defined and returns a pointer to
+\tcode{T}, and is also required to satisfy the requirements of an output
+iterator~(\ref{output.iterators}).
+
+\indexlibrary{\idxcode{raw_storage_iterator}!constructor}%
+\begin{itemdecl}
+explicit raw_storage_iterator(OutputIterator x);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Initializes the iterator to point to the same value to which \tcode{x} points.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{raw_storage_iterator}!\idxcode{operator*}}
+\indexlibrary{\idxcode{operator*}!\idxcode{raw_storage_iterator}}
+\begin{itemdecl}
+raw_storage_iterator& operator*();
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\tcode{*this}
+\end{itemdescr}
+
+\indexlibrary{\idxcode{raw_storage_iterator}!\idxcode{operator=}}
+\indexlibrary{\idxcode{operator=}!\idxcode{raw_storage_iterator}}
+\begin{itemdecl}
+raw_storage_iterator& operator=(const T& element);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\requires
+\tcode{T} shall be \tcode{CopyConstructible}.
+
+\pnum
+\effects
+Constructs a value from \tcode{element} at the location to which the iterator points.
+
+\pnum
+\returns
+A reference to the iterator.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{raw_storage_iterator}!\idxcode{operator=}}
+\indexlibrary{\idxcode{operator=}!\idxcode{raw_storage_iterator}}
+\begin{itemdecl}
+raw_storage_iterator& operator=(T&& element);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\requires
+\tcode{T} shall be \tcode{MoveConstructible}.
+
+\pnum
+\effects
+Constructs a value from \tcode{std::move(element)} at the location to which
+the iterator points.
+
+\pnum
+\returns
+A reference to the iterator.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{raw_storage_iterator}!\idxcode{operator++}}
+\indexlibrary{\idxcode{operator++}!\idxcode{raw_storage_iterator}}
+\begin{itemdecl}
+raw_storage_iterator& operator++();
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Pre-increment:  advances the iterator and returns a reference to the updated iterator.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{raw_storage_iterator}!\idxcode{operator++}}
+\indexlibrary{\idxcode{operator++}!\idxcode{raw_storage_iterator}}
+\begin{itemdecl}
+raw_storage_iterator operator++(int);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Post-increment:  advances the iterator and returns the old value of the iterator.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{raw_storage_iterator}!\idxcode{base}}
+\indexlibrary{\idxcode{base}!\idxcode{raw_storage_iterator}}
+\begin{itemdecl}
+OutputIterator base() const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+An iterator of type \tcode{OutputIterator} that points to the same value as
+\tcode{*this} points to.
+\end{itemdescr}
+
+\rSec1[depr.temporary.buffer]{Temporary buffers}
+
+\pnum
+The header \tcode{<memory>} has the following additions:
+
+\begin{codeblock}
+namespace std {
+  template <class T>
+    pair<T*, ptrdiff_t> get_temporary_buffer(ptrdiff_t n) noexcept;
+  template <class T>
+    void return_temporary_buffer(T* p);
+}
+\end{codeblock}
+
+\indexlibrary{\idxcode{get_temporary_buffer}}%
+\begin{itemdecl}
+template <class T>
+  pair<T*, ptrdiff_t> get_temporary_buffer(ptrdiff_t n) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Obtains a pointer to uninitialized, contiguous storage for $N$ adjacent
+objects of type \tcode{T}, for some non-negative number $N$.
+It is \impldef{support for over-aligned types} whether over-aligned types are
+supported~(\ref{basic.align}).
+
+\pnum
+\remarks
+Calling \tcode{get_temporary_buffer} with a positive number \tcode{n} is
+a non-binding request to return storage for \tcode{n} objects of type \tcode{T}.
+In this case, an implementation is permitted to return instead storage for
+a non-negative number $N$ of such objects,
+where \tcode{$N$ != n} (including \tcode{$N$ == 0}).
+\begin{note} The request is non-binding to allow latitude for
+implementation-specific optimizations of its memory management. \end{note}
+
+\pnum
+\returns
+If \tcode{n <= 0} or if no storage could be obtained,
+returns a pair \tcode{P} such that
+\tcode{P.first} is a null pointer value and \tcode{P.second == 0};
+otherwise returns a pair \tcode{P} such that
+\tcode{P.first} refers to the address of the uninitialized storage and
+\tcode{P.second} refers to its capacity $N$ (in the units of \tcode{sizeof(T)}).
+\end{itemdescr}
+
+\indexlibrary{\idxcode{return_temporary_buffer}}%
+\begin{itemdecl}
+template <class T> void return_temporary_buffer(T* p);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Deallocates the storage referenced by \tcode{p}.
+
+\pnum
+\requires
+\tcode{p} shall be a pointer value returned by an earlier call to
+\tcode{get_temporary_buffer} that has not been invalidated by
+an intervening call to \tcode{return_temporary_buffer(T*)}.
+
+\pnum
+\throws
+Nothing.
+\end{itemdescr}
+
+\rSec1[depr.meta.types]{Deprecated Type Traits}
+
+\pnum
+The header \tcode{<type_traits>} has the following addition:
+
+\indexlibrary{\idxcode{is_literal_type}}%
+\begin{codeblock}
+namespace std {
+  template <class T> struct is_literal_type;
+
+  template <class T> constexpr bool is_literal_type_v = is_literal_type<T>::value;
+}
+\end{codeblock}
+
+\pnum
+\requires
+\tcode{remove_all_extents_t<T>} shall be a complete type or (possibly
+cv-qualified) \tcode{void}.
+
+\pnum
+\effects
+\tcode{is_literal_type} has a base-characteristic of \tcode{true_type} if
+\tcode{T} is a literal type~(\ref{basic.types}, and a base-characteristic of
+\tcode{false_type} otherwise.
+
+\rSec1[depr.iterator.primitives]{Deprecated Iterator primitives}
+
+\rSec2[depr.iterator.basic]{Basic iterator}
+
+\pnum
+The header \tcode{<iterator>} has the following addition:
+
+\indexlibrary{\idxcode{iterator}}%
+\begin{codeblock}
+namespace std {
+  template<class Category, class T, class Distance = ptrdiff_t,
+    class Pointer = T*, class Reference = T&>
+  struct iterator {
+    using iterator_category = Category;
+    using value_type        = T;
+    using difference_type   = Distance;
+    using pointer           = Pointer;
+    using reference         = Reference;
+  };
+}
+\end{codeblock}
+
+\pnum
+The
+\tcode{iterator}
+template may be used as a base class to ease the definition of required types
+for new iterators.
+
+\pnum
+\begin{note} If the new iterator type is a class template, then these aliases
+will not be visible from within the iterator class's template definition, but
+only to callers of that class.\end{note}
+ 
+\pnum
+\begin{example}
+If a \Cpp program wants to define a bidirectional iterator for some data
+structure containing \tcode{double} and such that it works on a large memory
+model of the implementation, it can do so with:
+
+\begin{codeblock}
+class MyIterator :
+  public iterator<bidirectional_iterator_tag, double, long, T*, T&> {
+  // code implementing \tcode{++}, etc.
+};
+\end{codeblock}
+\end{example}

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -687,9 +687,6 @@ namespace std {
   template<class Iterator> struct iterator_traits;
   template<class T> struct iterator_traits<T*>;
 
-  template<class Category, class T, class Distance = ptrdiff_t,
-       class Pointer = T*, class Reference = T&> struct iterator;
-
   struct input_iterator_tag { };
   struct output_iterator_tag { };
   struct forward_iterator_tag: public input_iterator_tag { };
@@ -966,28 +963,6 @@ void reverse(BidirectionalIterator first, BidirectionalIterator last) {
 \end{codeblock}
 \end{example}
 
-\rSec2[iterator.basic]{Basic iterator}
-
-\pnum
-The
-\tcode{iterator}
-template may be used as a base class to ease the definition of required types
-for new iterators.
-
-\begin{codeblock}
-namespace std {
-  template<class Category, class T, class Distance = ptrdiff_t,
-    class Pointer = T*, class Reference = T&>
-  struct iterator {
-    using iterator_category = Category;
-    using value_type        = T;
-    using difference_type   = Distance;
-    using pointer           = Pointer;
-    using reference         = Reference;
-  };
-}
-\end{codeblock}
-
 \rSec2[std.iterator.tags]{Standard iterator tags}
 
 \pnum
@@ -1051,11 +1026,6 @@ template<class T> struct iterator_traits<BinaryTreeIterator<T> > {
   using reference         = T&;
 };
 \end{codeblock}
-
-Typically, however, it would be easier to derive
-\tcode{BinaryTreeIterator<T>}
-from
-\tcode{iterator<bidirectional_iterator_tag,T,ptrdiff_t,T*,T\&>}.
 \end{example}
 
 \pnum
@@ -1085,26 +1055,6 @@ void evolve(RandomAccessIterator first, RandomAccessIterator last,
   // more efficient, but less generic algorithm
 }
 \end{codeblock}
-\end{example}
-
-\pnum
-\begin{example}
-If a \Cpp program wants to define a bidirectional iterator for some data structure containing
-\tcode{double}
-and such that it
-works on a large memory model of the implementation, it can do so with:
-
-\begin{codeblock}
-class MyIterator :
-  public iterator<bidirectional_iterator_tag, double, long, T*, T&> {
-  // code implementing \tcode{++}, etc.
-};
-\end{codeblock}
-
-\pnum
-Then there is no need to specialize the
-\tcode{iterator_traits}
-template.
 \end{example}
 
 \rSec2[iterator.operations]{Iterator operations}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -4634,20 +4634,10 @@ namespace std {
 
   // \ref{default.allocator}, the default allocator:
   template <class T> class allocator;
-  template <> class allocator<void>;
   template <class T, class U>
     bool operator==(const allocator<T>&, const allocator<U>&) noexcept;
   template <class T, class U>
     bool operator!=(const allocator<T>&, const allocator<U>&) noexcept;
-
-  // \ref{storage.iterator}, raw storage iterator:
-  template <class OutputIterator, class T> class raw_storage_iterator;
-
-  // \ref{temporary.buffer}, temporary buffers:
-  template <class T>
-    pair<T*, ptrdiff_t> get_temporary_buffer(ptrdiff_t n) noexcept;
-  template <class T>
-    void return_temporary_buffer(T* p);
 
   // \ref{specialized.algorithms}, specialized algorithms:
   template <class T> constexpr T* addressof(T& r) noexcept;
@@ -5498,28 +5488,9 @@ allocator completeness requirements~\ref{allocator.requirements.completeness}.
 \indexlibrary{\idxcode{allocator}}%
 \begin{codeblock}
 namespace std {
-  template <class T> class allocator;
-
-  // specialize for \tcode{void}:
-  template <> class allocator<void> {
-  public:
-    using pointer       = void*;
-    using const_pointer = const void*;
-    // reference-to-\tcode{void} members are impossible.
-    using value_type    = void;
-    template <class U> struct rebind { using other = allocator<U>; };
-  };
-
   template <class T> class allocator {
    public:
     using value_type      = T;
-    using size_type       = size_t;
-    using difference_type = ptrdiff_t;
-    using pointer         = T*;
-    using const_pointer   = const T*;
-    using reference       = T&;
-    using const_reference = const T&;
-    template <class U> struct rebind { using other = allocator<U>; };
     using propagate_on_container_move_assignment = true_type;
     using is_always_equal = true_type;
 
@@ -5528,18 +5499,8 @@ namespace std {
     template <class U> allocator(const allocator<U>&) noexcept;
    ~allocator();
 
-    pointer address(reference x) const noexcept;
-    const_pointer address(const_reference x) const noexcept;
-
-    pointer allocate(
-      size_type, allocator<void>::const_pointer hint = 0);
-    void deallocate(pointer p, size_type n);
-    size_type max_size() const noexcept;
-
-    template<class U, class... Args>
-      void construct(U* p, Args&&... args);
-    template <class U>
-      void destroy(U* p);
+    T* allocate(size_t n);
+    void deallocate(T* p, size_t n);
   };
 }
 \end{codeblock}
@@ -5553,43 +5514,13 @@ functions from different threads. Calls to these functions that allocate or deal
 particular unit of storage shall occur in a single total order, and each such
 deallocation call shall happen before the next allocation (if any) in this order.
 
-\indexlibrary{\idxcode{address}!\idxcode{allocator}}
-\indexlibrary{\idxcode{allocator}!\idxcode{address}}
-\begin{itemdecl}
-pointer address(reference x) const noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-The actual address of the object referenced by \tcode{x}, even in the presence of an
-overloaded operator\&.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{address}!\idxcode{allocator}}
-\indexlibrary{\idxcode{allocator}!\idxcode{address}}
-\begin{itemdecl}
-const_pointer address(const_reference x) const noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-The actual address of the object referenced by \tcode{x}, even in the presence of an
-overloaded operator\&.
-\end{itemdescr}
-
 \indexlibrary{\idxcode{allocate}!\idxcode{allocator}}
 \indexlibrary{\idxcode{allocator}!\idxcode{allocate}}
 \begin{itemdecl}
-pointer allocate(size_type n, allocator<void>::const_pointer hint = 0);
+T* allocate(size_t n);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\begin{note} In a container member function, the address of an adjacent
-element is often a good choice to pass for the \tcode{hint} argument. \end{note}
-
 \pnum
 \returns
 A pointer to the initial element of an array of storage of size \tcode{n}
@@ -5601,8 +5532,7 @@ supported~(\ref{basic.align}).
 \remark
 the storage is obtained by calling \tcode{::operator
 new(std::size_t)}~(\ref{new.delete}), but it is unspecified when or how often this
-function is called. The use of \tcode{hint} is unspecified, but intended as an aid to
-locality if an implementation so desires.
+function is called.
 
 \pnum
 \throws
@@ -5612,7 +5542,7 @@ locality if an implementation so desires.
 \indexlibrary{\idxcode{deallocate}!\idxcode{allocator}}
 \indexlibrary{\idxcode{allocator}!\idxcode{deallocate}}
 \begin{itemdecl}
-void deallocate(pointer p, size_type n);
+void deallocate(T* p, size_t n);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5633,50 +5563,13 @@ Uses
 when this function is called.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{max_size}!\idxcode{allocator}}
-\indexlibrary{\idxcode{allocator}!\idxcode{max_size}}
-\begin{itemdecl}
-size_type max_size() const noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-The largest value \textit{N} for which the call \tcode{allocate(N, 0)}
-might succeed.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{allocator}!constructor}%
-\begin{itemdecl}
-template <class U, class... Args>
-  void construct(U* p, Args&&... args);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-As if by: \tcode{::new((void *)p) U(std::forward<Args>(args)...);}
-\end{itemdescr}
-
-\indexlibrary{\idxcode{allocator}!destructor}%
-\begin{itemdecl}
-template <class U>
-  void destroy(U* p);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-As if by \tcode{p->\~{}U()}.
-\end{itemdescr}
-
 \rSec3[allocator.globals]{\tcode{allocator} globals}
 
 \indexlibrary{\idxcode{operator==}!\idxcode{allocator}}%
 \indexlibrary{\idxcode{allocator}!\idxcode{operator==}}%
 \begin{itemdecl}
-template <class T1, class T2>
-  bool operator==(const allocator<T1>&, const allocator<T2>&) noexcept;
+template <class T, class U>
+  bool operator==(const allocator<T>&, const allocator<U>&) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5688,205 +5581,14 @@ template <class T1, class T2>
 \indexlibrary{\idxcode{operator"!=}!\idxcode{allocator}}%
 \indexlibrary{\idxcode{allocator}!\idxcode{operator"!=}}%
 \begin{itemdecl}
-template <class T1, class T2>
-  bool operator!=(const allocator<T1>&, const allocator<T2>&) noexcept;
+template <class T, class U>
+  bool operator!=(const allocator<T>&, const allocator<U>&) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \returns
 \tcode{false}.
-\end{itemdescr}
-
-\rSec2[storage.iterator]{Raw storage iterator}
-
-\pnum
-\tcode{raw_storage_iterator} is provided to enable algorithms to store their
-results into uninitialized memory. The template parameter
-\tcode{OutputIterator} is required to have its \tcode{operator*} return an
-object for which \tcode{operator\&} is defined and returns a pointer to
-\tcode{T}, and is also required to satisfy the requirements of an output
-iterator~(\ref{output.iterators}).
-
-\begin{codeblock}
-namespace std {
-  template <class OutputIterator, class T>
-  class raw_storage_iterator {
-  public:
-    using iterator_category = output_iterator_tag;
-    using value_type        = void;
-    using difference_type   = void;
-    using pointer           = void;
-    using reference         = void;
-
-    explicit raw_storage_iterator(OutputIterator x);
-
-    raw_storage_iterator& operator*();
-    raw_storage_iterator& operator=(const T& element);
-    raw_storage_iterator& operator=(T&& element);
-    raw_storage_iterator& operator++();
-    raw_storage_iterator  operator++(int);
-    OutputIterator base() const;
-  };
-}
-\end{codeblock}
-
-\indexlibrary{\idxcode{raw_storage_iterator}!constructor}%
-\begin{itemdecl}
-explicit raw_storage_iterator(OutputIterator x);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-Initializes the iterator to point to the same value to which \tcode{x} points.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{operator*}!\idxcode{raw_storage_iterator}}
-\indexlibrary{\idxcode{raw_storage_iterator}!\idxcode{operator*}}
-\begin{itemdecl}
-raw_storage_iterator& operator*();
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-\tcode{*this}
-\end{itemdescr}
-
-\indexlibrary{\idxcode{operator=}!\idxcode{raw_storage_iterator}}
-\indexlibrary{\idxcode{raw_storage_iterator}!\idxcode{operator=}}
-\begin{itemdecl}
-raw_storage_iterator& operator=(const T& element);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\requires
-\tcode{T} shall be \tcode{CopyConstructible}.
-
-\pnum
-\effects
-Constructs a value from \tcode{element} at the location to which the iterator points.
-
-\pnum
-\returns
-A reference to the iterator.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{operator=}!\idxcode{raw_storage_iterator}}
-\indexlibrary{\idxcode{raw_storage_iterator}!\idxcode{operator=}}
-\begin{itemdecl}
-raw_storage_iterator& operator=(T&& element);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\requires
-\tcode{T} shall be \tcode{MoveConstructible}.
-
-\pnum
-\effects
-Constructs a value from \tcode{std::move(element)} at the location to which
-the iterator points.
-
-\pnum
-\returns
-A reference to the iterator.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{operator++}!\idxcode{raw_storage_iterator}}
-\indexlibrary{\idxcode{raw_storage_iterator}!\idxcode{operator++}}
-\begin{itemdecl}
-raw_storage_iterator& operator++();
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-Pre-increment:  advances the iterator and returns a reference to the updated iterator.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{operator++}!\idxcode{raw_storage_iterator}}
-\indexlibrary{\idxcode{raw_storage_iterator}!\idxcode{operator++}}
-\begin{itemdecl}
-raw_storage_iterator operator++(int);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-Post-increment:  advances the iterator and returns the old value of the iterator.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{base}!\idxcode{raw_storage_iterator}}
-\indexlibrary{\idxcode{raw_storage_iterator}!\idxcode{base}}
-\begin{itemdecl}
-OutputIterator base() const;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-An iterator of type \tcode{OutputIterator} that points to the same value as
-\tcode{*this} points to.
-\end{itemdescr}
-
-\rSec2[temporary.buffer]{Temporary buffers}
-
-\indexlibrary{\idxcode{get_temporary_buffer}}%
-\begin{itemdecl}
-template <class T>
-  pair<T*, ptrdiff_t> get_temporary_buffer(ptrdiff_t n) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-Obtains a pointer to uninitialized, contiguous storage for $N$ adjacent
-objects of type \tcode{T}, for some non-negative number $N$.
-It is \impldef{support for over-aligned types} whether over-aligned types are
-supported~(\ref{basic.align}).
-
-\pnum
-\remarks
-Calling \tcode{get_temporary_buffer} with a positive number \tcode{n} is
-a non-binding request to return storage for \tcode{n} objects of type \tcode{T}.
-In this case, an implementation is permitted to return instead storage for
-a non-negative number $N$ of such objects,
-where \tcode{$N$ != n} (including \tcode{$N$ == 0}).
-\begin{note} The request is non-binding to allow latitude for
-implementation-specific optimizations of its memory management. \end{note}
-
-\pnum
-\returns
-If \tcode{n <= 0} or if no storage could be obtained,
-returns a pair \tcode{P} such that
-\tcode{P.first} is a null pointer value and \tcode{P.second == 0};
-otherwise returns a pair \tcode{P} such that
-\tcode{P.first} refers to the address of the uninitialized storage and
-\tcode{P.second} refers to its capacity $N$ (in the units of \tcode{sizeof(T)}).
-\end{itemdescr}
-
-\indexlibrary{\idxcode{return_temporary_buffer}}%
-\begin{itemdecl}
-template <class T> void return_temporary_buffer(T* p);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-Deallocates the storage referenced by \tcode{p}.
-
-\pnum
-\requires
-\tcode{p} shall be a pointer value returned by an earlier call to
-\tcode{get_temporary_buffer} that has not been invalidated by
-an intervening call to \tcode{return_temporary_buffer(T*)}.
-
-\pnum
-\throws
-Nothing.
 \end{itemdescr}
 
 \rSec2[specialized.algorithms]{Specialized algorithms}
@@ -12873,7 +12575,6 @@ namespace std {
   template <class T> struct is_trivially_copyable;
   template <class T> struct is_standard_layout;
   template <class T> struct is_pod;
-  template <class T> struct is_literal_type;
   template <class T> struct is_empty;
   template <class T> struct is_polymorphic;
   template <class T> struct is_abstract;
@@ -13096,8 +12797,6 @@ namespace std {
     = is_standard_layout<T>::value;
   template <class T> constexpr bool is_pod_v
     = is_pod<T>::value;
-  template <class T> constexpr bool is_literal_type_v
-    = is_literal_type<T>::value;
   template <class T> constexpr bool is_empty_v
     = is_empty<T>::value;
   template <class T> constexpr bool is_polymorphic_v
@@ -13420,12 +13119,6 @@ notwithstanding the restrictions of~\ref{declval}.
  \tcode{T} is a POD type~(\ref{basic.types})                                &
  \tcode{remove_all_extents_t<T>} shall be a complete
  type or (possibly cv-qualified) \tcode{void}.                \\ \rowsep
-
-\tcode{template <class T>}\br
- \tcode{struct is_literal_type;}        &
- \tcode{T} is a literal type~(\ref{basic.types})  &
- \tcode{remove_all_extents_t<T>} shall be a complete type or
- (possibly cv-qualified) \tcode{void}.                               \\ \rowsep
 
 \tcode{template <class T>}\br
  \tcode{struct is_empty;}               &

--- a/source/xref.tex
+++ b/source/xref.tex
@@ -460,6 +460,7 @@ defns.well.formed\quad\ref{defns.well.formed}\\
 denorm.style\quad\ref{denorm.style}\\
 depr\quad\ref{depr}\\
 depr.c.headers\quad\ref{depr.c.headers}\\
+depr.default.allocator\quad\ref{depr.default.allocator}\\
 depr.except.spec\quad\ref{depr.except.spec}\\
 depr.func.adaptor.binding\quad\ref{depr.func.adaptor.binding}\\
 depr.func.adaptor.typedefs\quad\ref{depr.func.adaptor.typedefs}\\
@@ -467,10 +468,14 @@ depr.impldec\quad\ref{depr.impldec}\\
 depr.istrstream\quad\ref{depr.istrstream}\\
 depr.istrstream.cons\quad\ref{depr.istrstream.cons}\\
 depr.istrstream.members\quad\ref{depr.istrstream.members}\\
+depr.iterator.basic\quad\ref{depr.iterator.basic}\\
+depr.iterator.primitives\quad\ref{depr.iterator.primitives}\\
+depr.meta.types\quad\ref{depr.meta.types}\\
 depr.negators\quad\ref{depr.negators}\\
 depr.ostrstream\quad\ref{depr.ostrstream}\\
 depr.ostrstream.cons\quad\ref{depr.ostrstream.cons}\\
 depr.ostrstream.members\quad\ref{depr.ostrstream.members}\\
+depr.storage.iterator\quad\ref{depr.storage.iterator}\\
 depr.str.strstreams\quad\ref{depr.str.strstreams}\\
 depr.strstream\quad\ref{depr.strstream}\\
 depr.strstream.cons\quad\ref{depr.strstream.cons}\\
@@ -480,6 +485,7 @@ depr.strstreambuf\quad\ref{depr.strstreambuf}\\
 depr.strstreambuf.cons\quad\ref{depr.strstreambuf.cons}\\
 depr.strstreambuf.members\quad\ref{depr.strstreambuf.members}\\
 depr.strstreambuf.virtuals\quad\ref{depr.strstreambuf.virtuals}\\
+depr.temporary.buffer\quad\ref{depr.temporary.buffer}\\
 depr.uncaught\quad\ref{depr.uncaught}\\
 depr.weak.result_type\quad\ref{depr.weak.result_type}\\
 deque\quad\ref{deque}\\
@@ -915,7 +921,6 @@ istringstream\quad\ref{istringstream}\\
 istringstream.assign\quad\ref{istringstream.assign}\\
 istringstream.cons\quad\ref{istringstream.cons}\\
 istringstream.members\quad\ref{istringstream.members}\\
-iterator.basic\quad\ref{iterator.basic}\\
 iterator.container\quad\ref{iterator.container}\\
 iterator.iterators\quad\ref{iterator.iterators}\\
 iterator.operations\quad\ref{iterator.operations}\\
@@ -1519,7 +1524,6 @@ stmt.select\quad\ref{stmt.select}\\
 stmt.stmt\quad\ref{stmt.stmt}\\
 stmt.switch\quad\ref{stmt.switch}\\
 stmt.while\quad\ref{stmt.while}\\
-storage.iterator\quad\ref{storage.iterator}\\
 stream.buffers\quad\ref{stream.buffers}\\
 stream.buffers.overview\quad\ref{stream.buffers.overview}\\
 stream.iterators\quad\ref{stream.iterators}\\
@@ -1715,7 +1719,6 @@ template.slice.array\quad\ref{template.slice.array}\\
 template.slice.array.overview\quad\ref{template.slice.array.overview}\\
 template.valarray\quad\ref{template.valarray}\\
 template.valarray.overview\quad\ref{template.valarray.overview}\\
-temporary.buffer\quad\ref{temporary.buffer}\\
 terminate\quad\ref{terminate}\\
 terminate.handler\quad\ref{terminate.handler}\\
 thread\quad\ref{thread}\\


### PR DESCRIPTION
…ents

Moves text (with minor tweaks, per p0174r2) to Annex D
for deprecation, and updates the indices accordingly.

A drive-by fix in allocator so that operator==/!= in
the synopsis use the same parameter names in the
definition.

Fix use of 'reference' with 'T&' in std::allocator as an
editorial fix missed by the original paper.