### PR TITLE
[utility,containers] Apply p0181r1, a default order

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -5343,7 +5343,7 @@ The header \tcode{<map>} defines the class templates \tcode{map} and
 
 namespace std {
   // \ref{map}, class template map:
-  template <class Key, class T, class Compare = less<Key>,
+  template <class Key, class T, class Compare = default_order_t<Key>,
             class Allocator = allocator<pair<const Key, T>>>
     class map;
   template <class Key, class T, class Compare, class Allocator>
@@ -5370,7 +5370,7 @@ namespace std {
       noexcept(noexcept(x.swap(y)));
 
   // \ref{multimap}, class template multimap:
-  template <class Key, class T, class Compare = less<Key>,
+  template <class Key, class T, class Compare = default_order_t<Key>,
             class Allocator = allocator<pair<const Key, T>>>
     class multimap;
   template <class Key, class T, class Compare, class Allocator>
@@ -5397,11 +5397,11 @@ namespace std {
       noexcept(noexcept(x.swap(y)));
 
   namespace pmr {
-    template <class Key, class T, class Compare = less<Key>>
+    template <class Key, class T, class Compare = default_order_t<Key>>
       using map = std::map<Key, T, Compare,
                            polymorphic_allocator<pair<const Key, T>>>;
 
-    template <class Key, class T, class Compare = less<Key>>
+    template <class Key, class T, class Compare = default_order_t<Key>>
       using multimap = std::multimap<Key, T, Compare,
                                      polymorphic_allocator<pair<const Key, T>>>;
   }
@@ -5416,7 +5416,7 @@ namespace std {
 
 namespace std {
   // \ref{set}, class template set:
-  template <class Key, class Compare = less<Key>,
+  template <class Key, class Compare = default_order_t<Key>,
             class Allocator = allocator<Key>>
     class set;
   template <class Key, class Compare, class Allocator>
@@ -5443,7 +5443,7 @@ namespace std {
       noexcept(noexcept(x.swap(y)));
 
   // \ref{set}, class template multiset:
-  template <class Key, class Compare = less<Key>,
+  template <class Key, class Compare = default_order_t<Key>,
             class Allocator = allocator<Key>>
     class multiset;
   template <class Key, class Compare, class Allocator>
@@ -5470,11 +5470,11 @@ namespace std {
       noexcept(noexcept(x.swap(y)));
 
   namespace pmr {
-    template <class Key, class Compare = less<Key>>
+    template <class Key, class Compare = default_order_t<Key>>
       using set = std::set<Key, Compare,
                            polymorphic_allocator<Key>>;
 
-    template <class Key, class Compare = less<Key>>
+    template <class Key, class Compare = default_order_t<Key>>
       using multiset = std::multiset<Key, Compare,
                                      polymorphic_allocator<Key>>;
   }
@@ -5526,7 +5526,7 @@ or for operations where there is additional semantic information.
 
 \begin{codeblock}
 namespace std {
-  template <class Key, class T, class Compare = less<Key>,
+  template <class Key, class T, class Compare = default_order_t<Key>,
             class Allocator = allocator<pair<const Key, T>>>
   class map {
   public:
@@ -6039,7 +6039,7 @@ or for operations where there is additional semantic information.
 
 \begin{codeblock}
 namespace std {
-  template <class Key, class T, class Compare = less<Key>,
+  template <class Key, class T, class Compare = default_order_t<Key>,
             class Allocator = allocator<pair<const Key, T>>>
   class multimap {
   public:
@@ -6334,7 +6334,7 @@ and for operations where there is additional semantic information.
 
 \begin{codeblock}
 namespace std {
-  template <class Key, class Compare = less<Key>,
+  template <class Key, class Compare = default_order_t<Key>,
             class Allocator = allocator<Key>>
   class set {
   public:
@@ -6587,7 +6587,7 @@ and for operations where there is additional semantic information.
 
 \begin{codeblock}
 namespace std {
-  template <class Key, class Compare = less<Key>,
+  template <class Key, class Compare = default_order_t<Key>,
             class Allocator = allocator<Key>>
   class multiset {
   public:
@@ -8253,7 +8253,7 @@ exception is thrown by the swap of the adaptor's \tcode{Container} or
 namespace std {
   template <class T, class Container = deque<T>> class queue;
   template <class T, class Container = vector<T>,
-            class Compare = less<typename Container::value_type>>
+            class Compare = default_order_t<typename Container::value_type>>
     class priority_queue;
 
   template <class T, class Container>
@@ -8576,7 +8576,7 @@ object defines a strict weak ordering~(\ref{alg.sorting}).
 \begin{codeblock}
 namespace std {
   template <class T, class Container = vector<T>,
-    class Compare = less<typename Container::value_type>>
+    class Compare = default_order_t<typename Container::value_type>>
   class priority_queue {
   public:
     using value_type      = typename Container::value_type;

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -10800,7 +10800,14 @@ namespace std {
 
   template<class T> struct hash<T*>;
 
-  // \ref{func.bind}, function object binders
+  // \ref{func.default.traits}, default functor traits:
+  template <class T = void>
+  struct default_order;
+
+  template <class T = void>
+  using default_order_t = typename default_order<T>::type; 
+
+  // \ref{func.bind}, function object binders:
   template <class T> constexpr bool is_bind_expression_v
     = is_bind_expression<T>::value;
   template <class T> constexpr int is_placeholder_v
@@ -12774,6 +12781,49 @@ The template specializations shall meet the requirements of class template
 \tcode{hash}~(\ref{unord.hash}).
 \end{itemdescr}
 
+\rSec2[func.default.traits]{Default Functor Traits}
+
+\indexlibrary{\idxcode{default_order}}%
+\begin{codeblock}
+namespace std {
+  template <class T = void>
+  struct default_order {
+      using type = less<T>;
+  };
+}
+\end{codeblock}
+
+\pnum
+The class template \tcode{default_order} provides a trait that users can
+specialize for user-defined types to provide a strict weak ordering for that
+type, which the library can use where a default strict weak order is needed.
+For example, the associative containers and \tcode{priority_queue} use this
+trait.
+
+\pnum
+\begin{example}
+\begin{codeblock}
+namespace sales {
+  struct account {
+    int id;
+    std::string name;
+  };
+
+  struct order_accounts {
+    bool operator()(const Account& lhs, const Account& rhs) const {
+      return lhs.id < rhs.id;
+    }
+  };
+}
+
+namespace std {
+  template<>
+  struct default_order<sales::account> {
+    using type = sales::order_accounts;
+  };
+}
+\end{codeblock}
+\end{example}
 
 \rSec1[meta]{Metaprogramming and type traits}
 

--- a/source/xref.tex
+++ b/source/xref.tex
@@ -749,6 +749,7 @@ func.bind.isbind\quad\ref{func.bind.isbind}\\
 func.bind.isplace\quad\ref{func.bind.isplace}\\
 func.bind.place\quad\ref{func.bind.place}\\
 func.def\quad\ref{func.def}\\
+func.default.traits\quad\ref{func.default.traits}\\
 func.invoke\quad\ref{func.invoke}\\
 func.memfn\quad\ref{func.memfn}\\
 func.not_fn\quad\ref{func.not_fn}\\


### PR DESCRIPTION
Added support to pmr container typedefs which were missed in the proposal
as it was based off an earlier draft, but were always inteded to be
included.  Could back that part out if we prefer to handle as a technical
issue against the CD.