### PR TITLE
P0305R1 Selection statements with initializer

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -772,7 +772,7 @@ is local to the
 \grammarterm{handler}.
 
 \pnum
-Names declared in the \grammarterm{for-init-statement}, the \grammarterm{for-range-declaration}, and in the
+Names declared in the \grammarterm{init-statement}, the \grammarterm{for-range-declaration}, and in the
 \grammarterm{condition} of \tcode{if}, \tcode{while}, \tcode{for}, and
 \tcode{switch} statements are local to the \tcode{if}, \tcode{while},
 \tcode{for}, or \tcode{switch} statement (including the controlled

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1538,8 +1538,8 @@ auto glambda = [](int i, auto a) { return i; }; // OK: a generic lambda
 The type of a variable declared using \tcode{auto} or \tcode{decltype(auto)} is
 deduced from its initializer. This use is allowed when declaring variables in a
 block~(\ref{stmt.block}), in
-namespace scope~(\ref{basic.scope.namespace}), and in a
-\nonterminal{for-init-statement}~(\ref{stmt.for}).
+namespace scope~(\ref{basic.scope.namespace}), and in an
+\nonterminal{init-statement}~(Clause~\ref{stmt.stmt}).
 \tcode{auto} or \tcode{decltype(auto)} shall appear as one of the
 \grammarterm{decl-specifier}{s} in the
 \grammarterm{decl-specifier-seq} and the

--- a/source/grammar.tex
+++ b/source/grammar.tex
@@ -840,6 +840,15 @@ naming a class is also a
     attribute-specifier-seq\opt jump-statement\br
     declaration-statement\br
     attribute-specifier-seq\opt try-block
+
+\nontermdef{init-statement}\br
+    expression-statement\br
+    simple-declaration
+
+\nontermdef{condition}\br
+    expression\br
+    attribute-specifier-seq\opt decl-specifier-seq declarator \terminal{=} initializer-clause\br
+    attribute-specifier-seq\opt decl-specifier-seq declarator braced-init-list
 \end{bnf}
 
 \begin{bnf}
@@ -867,30 +876,17 @@ naming a class is also a
 
 \begin{bnf}
 \nontermdef{selection-statement}\br
-    \terminal{if (} condition \terminal{)} statement\br
-    \terminal{if (} condition \terminal{)} statement \terminal{else} statement\br
-    \terminal{switch (} condition \terminal{)} statement
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{condition}\br
-    expression\br
-    attribute-specifier-seq\opt decl-specifier-seq declarator \terminal{=} initializer-clause\br
-    attribute-specifier-seq\opt decl-specifier-seq declarator braced-init-list
+    \terminal{if (} init-statement\opt condition \terminal{)} statement\br
+    \terminal{if (} init-statement\opt condition \terminal{)} statement \terminal{else} statement\br
+    \terminal{switch (} init-statement\opt condition \terminal{)} statement
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{iteration-statement}\br
     \terminal{while (} condition \terminal{)} statement\br
     \terminal{do} statement \terminal{while (} expression \terminal{) ;}\br
-    \terminal{for (} for-init-statement condition\opt{} \terminal{;} expression\opt{} \terminal{)} statement\br
+    \terminal{for (} init-statement condition\opt{} \terminal{;} expression\opt{} \terminal{)} statement\br
     \terminal{for (} for-range-declaration \terminal{:} for-range-initializer \terminal{)} statement
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{for-init-statement}\br
-    expression-statement\br
-    simple-declaration
 \end{bnf}
 
 \begin{bnf}

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -20,6 +20,10 @@ Except as indicated, statements are executed in sequence.
     attribute-specifier-seq\opt jump-statement\br
     declaration-statement\br
     attribute-specifier-seq\opt try-block
+
+\nontermdef{init-statement}\br
+    expression-statement\br
+    simple-declaration
 \end{bnf}
 
 The optional \grammarterm{attribute-specifier-seq} appertains to the respective statement.
@@ -128,9 +132,9 @@ Selection statements choose one of several flows of control.
 %
 \begin{bnf}
 \nontermdef{selection-statement}\br
-    \terminal{if (} condition \terminal{)} statement\br
-    \terminal{if (} condition \terminal{)} statement \terminal{else} statement\br
-    \terminal{switch (} condition \terminal{)} statement
+    \terminal{if (} init-statement\opt condition \terminal{)} statement\br
+    \terminal{if (} init-statement\opt condition \terminal{)} statement \terminal{else} statement\br
+    \terminal{switch (} init-statement\opt condition \terminal{)} statement
 \end{bnf}
 
 \begin{bnf}
@@ -141,6 +145,9 @@ Selection statements choose one of several flows of control.
 \end{bnf}
 
 See~\ref{dcl.meaning} for the optional \grammarterm{attribute-specifier-seq} in a condition.
+\begin{note}
+An \grammarterm{init-statement} ends with a semicolon.
+\end{note}
 In Clause~\ref{stmt.stmt}, the term \term{substatement} refers to
 the contained \grammarterm{}{statement} or \grammarterm{}{statement}{s} that appear
 in the syntax notation.
@@ -245,6 +252,41 @@ not executed. In the second form of \tcode{if} statement
 an \tcode{else} part.\footnote{In other words, the \tcode{else} is associated with the nearest un-elsed
 \tcode{if}.}
 
+\pnum
+An \tcode{if} statement of the form
+
+\begin{ncbnf}
+\terminal{if (} init-statement condition \terminal{)} statement
+\end{ncbnf}
+
+is equivalent to
+
+\begin{ncbnftab}
+\terminal{\{}\br
+\>init-statement\br
+\>\terminal{if (} condition \terminal{)} statement\br
+\terminal{\}}
+\end{ncbnftab}
+
+and an \tcode{if} statement of the form
+
+\begin{ncbnf}
+\terminal{if (} init-statement condition \terminal{)} statement \terminal{else} statement
+\end{ncbnf}
+
+is equivalent to
+
+\begin{ncbnftab}
+\terminal{\{}\br
+\>init-statement\br
+\>\terminal{if (} condition \terminal{)} statement \terminal{else} statement\br
+\terminal{\}}
+\end{ncbnftab}
+
+except that names declared in the \grammarterm{init-statement} are in
+the same declarative region as those declared in the
+\grammarterm{condition}.
+
 \rSec2[stmt.switch]{The \tcode{switch} statement}%
 \indextext{statement!\idxcode{switch}}
 
@@ -315,6 +357,26 @@ Declarations can appear in the substatement of a
 \end{note}%
 \indextext{statement!selection|)}
 
+\pnum
+A \tcode{switch} statement of the form
+
+\begin{ncbnf}
+\terminal{switch (} init-statement condition \terminal{)} statement
+\end{ncbnf}
+
+is equivalent to
+
+\begin{ncbnftab}
+\terminal{\{}\br
+\>init-statement\br
+\>\terminal{switch (} condition \terminal{)} statement\br
+\terminal{\}}
+\end{ncbnftab}
+
+except that names declared in the \grammarterm{init-statement} are in
+the same declarative region as those declared in the
+\grammarterm{condition}.
+
 \rSec1[stmt.iter]{Iteration statements}%
 \indextext{statement!iteration|(}
 
@@ -329,14 +391,8 @@ Iteration statements specify looping.
 \nontermdef{iteration-statement}\br
     \terminal{while (} condition \terminal{)} statement\br
     \terminal{do} statement \terminal{while (} expression \terminal{) ;}\br
-    \terminal{for (} for-init-statement condition\opt{} \terminal{;} expression\opt{} \terminal{)} statement\br
+    \terminal{for (} init-statement condition\opt{} \terminal{;} expression\opt{} \terminal{)} statement\br
     \terminal{for (} for-range-declaration \terminal{:} for-range-initializer \terminal{)} statement
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{for-init-statement}\br
-    expression-statement\br
-    simple-declaration
 \end{bnf}
 
 \begin{bnf}
@@ -352,7 +408,7 @@ Iteration statements specify looping.
 See~\ref{dcl.meaning} for the optional \grammarterm{attribute-specifier-seq} in a
 \grammarterm{for-range-declaration}.
 \begin{note}
-A \grammarterm{for-init-statement} ends with a semicolon.
+An \grammarterm{init-statement} ends with a semicolon.
 \end{note}
 
 \pnum
@@ -464,14 +520,14 @@ place after each execution of the statement.
 The \tcode{for} statement
 
 \begin{ncbnf}
-\terminal{for (} for-init-statement condition\opt{} \terminal{;} expression\opt{} \terminal{)} statement
+\terminal{for (} init-statement condition\opt{} \terminal{;} expression\opt{} \terminal{)} statement
 \end{ncbnf}
 
 is equivalent to
 
 \begin{ncbnftab}
 \terminal{\{}\br
-\>for-init-statement\br
+\>init-statement\br
 \>\terminal{while (} condition \terminal{) \{}\br
 \>\>statement\br
 \>\>expression \terminal{;}\br
@@ -479,7 +535,7 @@ is equivalent to
 \terminal{\}}
 \end{ncbnftab}
 
-except that names declared in the \grammarterm{for-init-statement} are in
+except that names declared in the \grammarterm{init-statement} are in
 the same declarative region as those declared in the
 \grammarterm{condition}, and except that a
 \indextext{statement!\tcode{continue}~in \tcode{for}}%
@@ -504,7 +560,7 @@ equivalent to \tcode{while(true)}.
 \pnum
 \indextext{statement!declaration~in \tcode{for}}%
 \indextext{\idxcode{for}!scope~of declaration~in}%
-If the \grammarterm{for-init-statement} is a declaration, the scope of the
+If the \grammarterm{init-statement} is a declaration, the scope of the
 name(s) declared extends to the end of the \tcode{for} statement.
 \begin{example}
 

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -24,9 +24,75 @@ Except as indicated, statements are executed in sequence.
 \nontermdef{init-statement}\br
     expression-statement\br
     simple-declaration
+
+\nontermdef{condition}\br
+    expression\br
+    attribute-specifier-seq\opt decl-specifier-seq declarator \terminal{=} initializer-clause\br
+    attribute-specifier-seq\opt decl-specifier-seq declarator braced-init-list
 \end{bnf}
 
 The optional \grammarterm{attribute-specifier-seq} appertains to the respective statement.
+
+\pnum
+\indextext{\idxgram{condition}{s}!rules~for}%
+The rules for \grammarterm{}{condition}{s} apply both to
+\grammarterm{selection-statement}{s} and to the \tcode{for} and \tcode{while}
+statements~(\ref{stmt.iter}). The \grammarterm{}{declarator} shall not
+specify a function or an array. The \grammarterm{decl-specifier-seq} shall not
+define a class or enumeration. If the \tcode{auto} \nonterminal{type-specifier} appears in
+the \nonterminal{decl-specifier-seq},
+the type of the identifier being declared is deduced from the initializer as described in~\ref{dcl.spec.auto}.
+
+\pnum
+\indextext{statement!declaration in \tcode{if}}%
+\indextext{statement!declaration in \tcode{switch}}%
+A name introduced by a declaration in a \grammarterm{}{condition} (either
+introduced by the \grammarterm{decl-specifier-seq} or the
+\grammarterm{}{declarator} of the condition) is in scope from its point of
+declaration until the end of the substatements controlled by the
+condition. If the name is re-declared in the outermost block of a
+substatement controlled by the condition, the declaration that
+re-declares the name is ill-formed.
+\begin{example}
+
+\begin{codeblock}
+if (int x = f()) {
+  int x;            // ill-formed, redeclaration of \tcode{x}
+}
+else {
+  int x;            // ill-formed, redeclaration of \tcode{x}
+}
+\end{codeblock}
+\end{example}
+
+\pnum
+The value of a \grammarterm{}{condition} that is an initialized declaration
+in a statement other than a \tcode{switch} statement is the value of the
+declared variable
+contextually converted to \tcode{bool} (Clause~\ref{conv}).
+If that
+conversion is ill-formed, the program is ill-formed. The value of a
+\grammarterm{}{condition} that is an initialized declaration in a
+\tcode{switch} statement is the value of the declared variable if it has
+integral or enumeration type, or of that variable implicitly converted
+to integral or enumeration type otherwise. The value of a
+\grammarterm{}{condition} that is an expression is the value of the
+expression, contextually converted to \tcode{bool}
+for statements other
+than \tcode{switch};
+if that conversion is ill-formed, the program is
+ill-formed. The value of the condition will be referred to as simply
+``the condition'' where the usage is unambiguous.
+
+\pnum
+If a \grammarterm{}{condition} can be syntactically resolved as either an
+expression or the declaration of a block-scope name, it is interpreted as a
+declaration.
+
+\pnum
+In the \grammarterm{decl-specifier-seq} of a \grammarterm{condition}, each
+\grammarterm{decl-specifier} shall be either a \grammarterm{type-specifier}
+or \tcode{constexpr}.
 
 \rSec1[stmt.label]{Labeled statement}%
 \indextext{statement!labeled}
@@ -137,13 +203,6 @@ Selection statements choose one of several flows of control.
     \terminal{switch (} init-statement\opt condition \terminal{)} statement
 \end{bnf}
 
-\begin{bnf}
-\nontermdef{condition}\br
-    expression\br
-    attribute-specifier-seq\opt decl-specifier-seq declarator \terminal{=} initializer-clause\br
-    attribute-specifier-seq\opt decl-specifier-seq declarator braced-init-list
-\end{bnf}
-
 See~\ref{dcl.meaning} for the optional \grammarterm{attribute-specifier-seq} in a condition.
 \begin{note}
 An \grammarterm{init-statement} ends with a semicolon.
@@ -175,67 +234,6 @@ if (x) {
 
 Thus after the \tcode{if} statement, \tcode{i} is no longer in scope.
 \end{example}
-
-\pnum
-\indextext{\idxgram{condition}{s}!rules~for}%
-The rules for \grammarterm{}{condition}{s} apply both to
-\grammarterm{selection-statement}{s} and to the \tcode{for} and \tcode{while}
-statements~(\ref{stmt.iter}). The \grammarterm{}{declarator} shall not
-specify a function or an array. The \grammarterm{decl-specifier-seq} shall not
-define a class or enumeration. If the \tcode{auto} \nonterminal{type-specifier} appears in
-the \nonterminal{decl-specifier-seq},
-the type of the identifier being declared is deduced from the initializer as described in~\ref{dcl.spec.auto}.
-
-\pnum
-\indextext{statement!declaration in \tcode{if}}%
-\indextext{statement!declaration in \tcode{switch}}%
-A name introduced by a declaration in a \grammarterm{}{condition} (either
-introduced by the \grammarterm{decl-specifier-seq} or the
-\grammarterm{}{declarator} of the condition) is in scope from its point of
-declaration until the end of the substatements controlled by the
-condition. If the name is re-declared in the outermost block of a
-substatement controlled by the condition, the declaration that
-re-declares the name is ill-formed.
-\begin{example}
-
-\begin{codeblock}
-if (int x = f()) {
-  int x;            // ill-formed, redeclaration of \tcode{x}
-}
-else {
-  int x;            // ill-formed, redeclaration of \tcode{x}
-}
-\end{codeblock}
-\end{example}
-
-\pnum
-The value of a \grammarterm{}{condition} that is an initialized declaration
-in a statement other than a \tcode{switch} statement is the value of the
-declared variable
-contextually converted to \tcode{bool} (Clause~\ref{conv}).
-If that
-conversion is ill-formed, the program is ill-formed. The value of a
-\grammarterm{}{condition} that is an initialized declaration in a
-\tcode{switch} statement is the value of the declared variable if it has
-integral or enumeration type, or of that variable implicitly converted
-to integral or enumeration type otherwise. The value of a
-\grammarterm{}{condition} that is an expression is the value of the
-expression, contextually converted to \tcode{bool}
-for statements other
-than \tcode{switch};
-if that conversion is ill-formed, the program is
-ill-formed. The value of the condition will be referred to as simply
-``the condition'' where the usage is unambiguous.
-
-\pnum
-If a \grammarterm{}{condition} can be syntactically resolved as either an
-expression or the declaration of a block-scope name, it is interpreted as a
-declaration.
-
-\pnum
-In the \grammarterm{decl-specifier-seq} of a \grammarterm{condition}, each
-\grammarterm{decl-specifier} shall be either a \grammarterm{type-specifier}
-or \tcode{constexpr}.
 
 \rSec2[stmt.if]{The \tcode{if} statement}%
 \indextext{statement!\idxcode{if}}


### PR DESCRIPTION
Apply CWG Motion 18: P0305R1, "Selection statements with initializer".

Editorially moves the grammar production *condition* up to the top of Clause 6, along with the moved *init-statement*.

Do not merge until CWG Motion 12 (P0292R2, "if constexpr") has been applied, since the present application will need to be rebased first.