### PR TITLE
Travis CI: Fail build if regenerated xref and grammar files don't match those in repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,11 @@ script:
   - popd
   # Check to see if generated files are out-dated
   - pushd source
-  - ../tools/makegram && git status --porcelain grammar.tex
-  - ../tools/makexref && git status --porcelain xref.tex
+  - ../tools/makegram && GRAMMAR_CHANGED=$(git status --porcelain grammar.tex); if [ ! -z "$GRAMMAR_CHANGED" ]; then echo "$GRAMMAR_CHANGED"; false; fi
+  - ../tools/makexref && XREF_CHANGED=$(git status --porcelain xref.tex); if [ ! -z "$XREF_CHANGED" ]; then echo "$XREF_CHANGED"; false; fi
   - for FIGURE in *.dot; do
       dot -o$(basename $FIGURE .dot).pdf -Tpdf $FIGURE;
-      git status --porcelain $(basename $FIGURE .dot).pdf;
+      FIG_CHANGED=$(git status --porcelain $(basename $FIGURE .dot).pdf); if [ ! -z "$FIG_CHANGED" ]; then echo "$FIG_CHANGED"; false; fi;
     done
   - popd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,18 @@ script:
   - popd
   # Check to see if generated files are out-dated
   - pushd source
-  - ../tools/makegram && GRAMMAR_CHANGED=$(git status --porcelain grammar.tex); if [ ! -z "$GRAMMAR_CHANGED" ]; then echo "$GRAMMAR_CHANGED"; false; fi
-  - ../tools/makexref && XREF_CHANGED=$(git status --porcelain xref.tex); if [ ! -z "$XREF_CHANGED" ]; then echo "$XREF_CHANGED"; false; fi
+  - ../tools/makegram &&
+    GRAMMAR_CHANGED=$(git status --porcelain grammar.tex);
+    if [ ! -z "$GRAMMAR_CHANGED" ]; then
+      echo "$GRAMMAR_CHANGED";
+      false;
+    fi
+  - ../tools/makexref &&
+    XREF_CHANGED=$(git status --porcelain xref.tex);
+    if [ ! -z "$XREF_CHANGED" ]; then
+      echo "$XREF_CHANGED";
+      false;
+    fi
   # Ignoring changed figure PDFs as the metadata will change each time they're regenerated
   #- for FIGURE in *.dot; do
   #    dot -o$(basename $FIGURE .dot).pdf -Tpdf $FIGURE;

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,10 +40,11 @@ script:
   - pushd source
   - ../tools/makegram && GRAMMAR_CHANGED=$(git status --porcelain grammar.tex); if [ ! -z "$GRAMMAR_CHANGED" ]; then echo "$GRAMMAR_CHANGED"; false; fi
   - ../tools/makexref && XREF_CHANGED=$(git status --porcelain xref.tex); if [ ! -z "$XREF_CHANGED" ]; then echo "$XREF_CHANGED"; false; fi
-  - for FIGURE in *.dot; do
-      dot -o$(basename $FIGURE .dot).pdf -Tpdf $FIGURE;
-      FIG_CHANGED=$(git status --porcelain $(basename $FIGURE .dot).pdf); if [ ! -z "$FIG_CHANGED" ]; then echo "$FIG_CHANGED"; false; fi;
-    done
+  # Ignoring changed figure PDFs as the metadata will change each time they're regenerated
+  #- for FIGURE in *.dot; do
+  #    dot -o$(basename $FIGURE .dot).pdf -Tpdf $FIGURE;
+  #    FIG_CHANGED=$(git status --porcelain $(basename $FIGURE .dot).pdf); if [ ! -z "$FIG_CHANGED" ]; then echo "$FIG_CHANGED"; false; fi;
+  #  done
   - popd
 
 sudo: false


### PR DESCRIPTION
This patch causes the Travis CI builds to fail if they detect that the newly generated grammar and xref files differ from those committed to the git repository.

Figure PDFs are currently ignored as regenerated PDFs will always differ from the committed PDFs due to changed metadata (build date/time, primarily). If a better solution for diffing the PDFs is found, we can add this test in the future.

This PR follows the discussion near the end of https://github.com/cplusplus/draft/pull/635.