### PR TITLE
[dcl.spec.auto] Add 'The' to heading

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1560,7 +1560,7 @@ enum E x = E::a;                // OK
 \end{codeblock}
 \end{example}
 
-\rSec3[dcl.spec.auto]{\tcode{auto} specifier}%
+\rSec3[dcl.spec.auto]{The \tcode{auto} specifier}%
 \indextext{type specifier!\idxcode{auto}}
 
 \pnum


### PR DESCRIPTION
We use a leading article for many other sections, and this implements the common style advice to not start a sentence or heading with a symbol.