### PR TITLE
[19-26] Consistent use of _v

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -5552,7 +5552,7 @@ assignment operator, or move assignment operator of
 \tcode{T} or by any \tcode{InputIterator} operation
 there are no effects.
 If an exception is thrown while inserting a single element at the end and
-\tcode{T} is \tcode{CopyInsertable} or \tcode{is_nothrow_move_constructible<T>::value}
+\tcode{T} is \tcode{CopyInsertable} or \tcode{is_nothrow_move_constructible_v<T>}
 is \tcode{true}, there are no effects.
 Otherwise, if an exception is thrown by the move constructor of a non-\tcode{CopyInsertable}
 \tcode{T}, the effects are unspecified.
@@ -6041,7 +6041,7 @@ namespace std {
     map& operator=(const map& x);
     map& operator=(map&& x)
       noexcept(allocator_traits<Allocator>::is_always_equal::value &&
-               is_nothrow_move_assignable<Compare>::value);
+               is_nothrow_move_assignable_v<Compare>);
     map& operator=(initializer_list<value_type>);
     allocator_type get_allocator() const noexcept;
 
@@ -6294,7 +6294,7 @@ equivalent to \tcode{return emplace_hint(position, std::forward<P>(x))}.
 \pnum
 \remarks
 These signatures shall not participate in overload resolution
-unless \tcode{std::is_constructible<value_type, P\&\&>::value} is
+unless \tcode{std::is_constructible_v<value_type, P\&\&>} is
 \tcode{true}.
 \end{itemdescr}
 
@@ -6382,7 +6382,7 @@ template <class M> iterator insert_or_assign(const_iterator hint, const key_type
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{is_assignable<mapped_type\&, M\&\&>::value} shall be \tcode{true}.
+\tcode{is_assignable_v<mapped_type\&, M\&\&>} shall be \tcode{true}.
 \tcode{value_type} shall be \tcode{EmplaceConstructible} into \tcode{map}
 from \tcode{k}, \tcode{forward<M>(obj)}.
 
@@ -6418,7 +6418,7 @@ template <class M> iterator insert_or_assign(const_iterator hint, key_type&& k, 
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{is_assignable<mapped_type\&, M\&\&>::value} shall be \tcode{true}.
+\tcode{is_assignable_v<mapped_type\&, M\&\&>} shall be \tcode{true}.
 \tcode{value_type} shall be \tcode{EmplaceConstructible} into \tcode{map}
 from \tcode{move(k)}, \tcode{forward<M>(obj)}.
 
@@ -6570,7 +6570,7 @@ namespace std {
     multimap& operator=(const multimap& x);
     multimap& operator=(multimap&& x)
       noexcept(allocator_traits<Allocator>::is_always_equal::value &&
-               is_nothrow_move_assignable<Compare>::value);
+               is_nothrow_move_assignable_v<Compare>);
     multimap& operator=(initializer_list<value_type>);
     allocator_type get_allocator() const noexcept;
 
@@ -6756,7 +6756,7 @@ equivalent to \tcode{return emplace_hint(position, std::forward<P>(x))}.
 \pnum
 \remarks
 These signatures shall not participate in overload resolution
-unless \tcode{std::is_constructible<value_type, P\&\&>::value} is
+unless \tcode{std::is_constructible_v<value_type, P\&\&>} is
 \tcode{true}.
 \end{itemdescr}
 
@@ -6868,7 +6868,7 @@ namespace std {
     set& operator=(const set& x);
     set& operator=(set&& x)
       noexcept(allocator_traits<Allocator>::is_always_equal::value &&
-               is_nothrow_move_assignable<Compare>::value);
+               is_nothrow_move_assignable_v<Compare>);
     set& operator=(initializer_list<value_type>);
     allocator_type get_allocator() const noexcept;
 
@@ -7136,7 +7136,7 @@ namespace std {
     multiset& operator=(const multiset& x);
     multiset& operator=(multiset&& x)
       noexcept(allocator_traits<Allocator>::is_always_equal::value &&
-               is_nothrow_move_assignable<Compare>::value);
+               is_nothrow_move_assignable_v<Compare>);
     multiset& operator=(initializer_list<value_type>);
     allocator_type get_allocator() const noexcept;
 
@@ -7549,8 +7549,8 @@ namespace std {
     unordered_map& operator=(const unordered_map&);
     unordered_map& operator=(unordered_map&&)
       noexcept(allocator_traits<Allocator>::is_always_equal::value &&
-               is_nothrow_move_assignable<Hash>::value &&
-               is_nothrow_move_assignable<Pred>::value);
+               is_nothrow_move_assignable_v<Hash> &&
+               is_nothrow_move_assignable_v<Pred>);
     unordered_map& operator=(initializer_list<value_type>);
     allocator_type get_allocator() const noexcept;
 
@@ -7784,7 +7784,7 @@ template <class P>
 
 \pnum
 \remarks This signature shall not participate in overload resolution
-unless \tcode{std::is_constructible<value_type, P\&\&>::value} is \tcode{true}.
+unless \tcode{std::is_constructible_v<value_type, P\&\&>} is \tcode{true}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{unordered_map}!\idxcode{insert}}%
@@ -7801,7 +7801,7 @@ template <class P>
 
 \pnum
 \remarks This signature shall not participate in overload resolution
-unless \tcode{std::is_constructible<value_type, P\&\&>::value} is \tcode{true}.
+unless \tcode{std::is_constructible_v<value_type, P\&\&>} is \tcode{true}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{try_emplace}!\idxcode{unordered_map}}%
@@ -7888,7 +7888,7 @@ template <class M> iterator insert_or_assign(const_iterator hint, const key_type
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{is_assignable<mapped_type\&, M\&\&>::value} shall be \tcode{true}.
+\tcode{is_assignable_v<mapped_type\&, M\&\&>} shall be \tcode{true}.
 \tcode{value_type} shall be \tcode{EmplaceConstructible} into \tcode{unordered_map}
 from \tcode{k}, \tcode{forward<M>(obj)}.
 
@@ -7924,7 +7924,7 @@ template <class M> iterator insert_or_assign(const_iterator hint, key_type&& k, 
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{is_assignable<mapped_type\&, M\&\&>::value} shall be \tcode{true}.
+\tcode{is_assignable_v<mapped_type\&, M\&\&>} shall be \tcode{true}.
 \tcode{value_type} shall be \tcode{EmplaceConstructible} into \tcode{unordered_map}
 from \tcode{move(k)}, \tcode{forward<M>(obj)}.
 
@@ -8066,8 +8066,8 @@ namespace std {
     unordered_multimap& operator=(const unordered_multimap&);
     unordered_multimap& operator=(unordered_multimap&&)
       noexcept(allocator_traits<Allocator>::is_always_equal::value &&
-               is_nothrow_move_assignable<Hash>::value &&
-               is_nothrow_move_assignable<Pred>::value);
+               is_nothrow_move_assignable_v<Hash> &&
+               is_nothrow_move_assignable_v<Pred>);
     unordered_multimap& operator=(initializer_list<value_type>);
     allocator_type get_allocator() const noexcept;
 
@@ -8237,7 +8237,7 @@ template <class P>
 
 \pnum
 \remarks This signature shall not participate in overload resolution
-unless \tcode{std::is_constructible<value_type, P\&\&>::value} is \tcode{true}.
+unless \tcode{std::is_constructible_v<value_type, P\&\&>} is \tcode{true}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{unordered_multimap}!\idxcode{insert}}%
@@ -8254,7 +8254,7 @@ template <class P>
 
 \pnum
 \remarks This signature shall not participate in overload resolution
-unless \tcode{std::is_constructible<value_type, P\&\&>::value} is \tcode{true}.
+unless \tcode{std::is_constructible_v<value_type, P\&\&>} is \tcode{true}.
 \end{itemdescr}
 
 \rSec3[unord.multimap.swap]{\tcode{unordered_multimap} swap}
@@ -8367,8 +8367,8 @@ namespace std {
     unordered_set& operator=(const unordered_set&);
     unordered_set& operator=(unordered_set&&)
       noexcept(allocator_traits<Allocator>::is_always_equal::value &&
-               is_nothrow_move_assignable<Hash>::value &&
-               is_nothrow_move_assignable<Pred>::value);
+               is_nothrow_move_assignable_v<Hash> &&
+               is_nothrow_move_assignable_v<Pred>);
     unordered_set& operator=(initializer_list<value_type>);
     allocator_type get_allocator() const noexcept;
 
@@ -8635,8 +8635,8 @@ namespace std {
     unordered_multiset& operator=(const unordered_multiset&);
     unordered_multiset& operator=(unordered_multiset&&)
       noexcept(allocator_traits<Allocator>::is_always_equal::value &&
-               is_nothrow_move_assignable<Hash>::value &&
-               is_nothrow_move_assignable<Pred>::value);
+               is_nothrow_move_assignable_v<Hash> &&
+               is_nothrow_move_assignable_v<Pred>);
     unordered_multiset& operator=(initializer_list<value_type>);
     allocator_type get_allocator() const noexcept;
 
@@ -8987,7 +8987,7 @@ explicit queue(Container&& cont = Container());
 \rSec3[queue.cons.alloc]{\tcode{queue} constructors with allocators}
 
 \pnum
-If \tcode{uses_allocator<container_type, Alloc>::value} is \tcode{false}
+If \tcode{uses_allocator_v<container_type, Alloc>} is \tcode{false}
 the constructors in this subclause shall not participate in overload resolution.
 
 \begin{itemdecl}
@@ -9269,7 +9269,7 @@ and finally calls
 \rSec3[priqueue.cons.alloc]{\tcode{priority_queue} constructors with allocators}
 
 \pnum
-If \tcode{uses_allocator<container_type, Alloc>::value} is \tcode{false}
+If \tcode{uses_allocator_v<container_type, Alloc>} is \tcode{false}
 the constructors in this subclause shall not participate in overload resolution.
 
 \indexlibrary{\idxcode{priority_queue}!constructor}%
@@ -9527,7 +9527,7 @@ explicit stack(Container&& cont = Container());
 \rSec3[stack.cons.alloc]{\tcode{stack} constructors with allocators}
 
 \pnum
-If \tcode{uses_allocator<container_type, Alloc>::value} is \tcode{false}
+If \tcode{uses_allocator_v<container_type, Alloc>} is \tcode{false}
 the constructors in this subclause shall not participate in overload resolution.
 
 \indexlibrary{\idxcode{stack}!constructor}%

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -1253,7 +1253,7 @@ template <class ErrorCodeEnum>
 
 \pnum
 \remarks This constructor shall not participate in overload resolution unless\linebreak
-\tcode{is_error_code_enum<ErrorCodeEnum>::value} is \tcode{true}.
+\tcode{is_error_code_enum_v<ErrorCodeEnum>} is \tcode{true}.
 \end{itemdescr}
 
 \rSec3[syserr.errcode.modifiers]{Class \tcode{error_code} modifiers}
@@ -1285,7 +1285,7 @@ template <class ErrorCodeEnum>
 
 \pnum
 \remarks This operator shall not participate in overload resolution unless\linebreak
-\tcode{is_error_code_enum<ErrorCodeEnum>::value} is \tcode{true}.
+\tcode{is_error_code_enum_v<ErrorCodeEnum>} is \tcode{true}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{clear}!\idxcode{error_code}}
@@ -1484,7 +1484,7 @@ template <class ErrorConditionEnum>
 
 \pnum
 \remarks This constructor shall not participate in overload resolution unless\linebreak
-\tcode{is_error_condition_enum<ErrorConditionEnum>::value} is \tcode{true}.
+\tcode{is_error_condition_enum_v<ErrorConditionEnum>} is \tcode{true}.
 \end{itemdescr}
 
 
@@ -1517,7 +1517,7 @@ template <class ErrorConditionEnum>
 
 \pnum
 \remarks This operator shall not participate in overload resolution unless\linebreak
-\tcode{is_error_condition_enum<ErrorConditionEnum>::value} is \tcode{true}.
+\tcode{is_error_condition_enum_v<ErrorConditionEnum>} is \tcode{true}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{clear}!\idxcode{error_condition}}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -10320,7 +10320,7 @@ for the functions \tcode{abs}, \tcode{labs}, \tcode{llabs},
 \pnum
 \remarks
 If \tcode{abs()} is called with an argument of type \tcode{X}
-for which \tcode{is_unsigned<X>::value} is \tcode{true} and
+for which \tcode{is_unsigned_v<X>} is \tcode{true} and
 if \tcode{X} cannot be converted to \tcode{int}
 by integral promotion~(\ref{conv.prom}), the program is ill-formed.
 \begin{note}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -74,7 +74,7 @@ namespace std {
     constexpr remove_reference_t<T>&& move(T&&) noexcept;
   template <class T>
     constexpr conditional_t<
-    !is_nothrow_move_constructible<T>::value && is_copy_constructible<T>::value,
+    !is_nothrow_move_constructible_v<T> && is_copy_constructible_v<T>,
     const T&, T&&> move_if_noexcept(T& x) noexcept;
 
   // \ref{utility.as_const}, as_const:
@@ -266,13 +266,12 @@ template <class T> void swap(T& a, T& b) noexcept(@\seebelow@);
 \begin{itemdescr}
 \pnum
 \remarks This function shall not participate in overload resolution
-unless \tcode{is_move_constructible<T>::value} is \tcode{true} and
-\tcode{is_move_assignable<T>::value} is \tcode{true}.
+unless \tcode{is_move_constructible_v<T>} is \tcode{true} and
+\tcode{is_move_assignable_v<T>} is \tcode{true}.
 The expression inside \tcode{noexcept} is equivalent to:
 
 \begin{codeblock}
-is_nothrow_move_constructible<T>::value &&
-is_nothrow_move_assignable<T>::value
+is_nothrow_move_constructible_v<T> && is_nothrow_move_assignable_v<T>
 \end{codeblock}
 
 \pnum
@@ -428,7 +427,7 @@ which moves the value from \tcode{a}.
 \indexlibrary{\idxcode{move_if_noexcept}}%
 \begin{itemdecl}
 template <class T> constexpr conditional_t<
-  !is_nothrow_move_constructible<T>::value && is_copy_constructible<T>::value,
+  !is_nothrow_move_constructible_v<T> && is_copy_constructible_v<T>,
   const T&, T&&> move_if_noexcept(T& x) noexcept;
 \end{itemdecl}
 
@@ -515,7 +514,7 @@ template<class F, class Tuple, std::size_t... I>
 
 template<class F, class Tuple>
   decltype(auto) apply(F&& f, Tuple&& t) {
-    using Indices = make_index_sequence<std::tuple_size<std::decay_t<Tuple>>::value>;
+    using Indices = make_index_sequence<std::tuple_size_v<std::decay_t<Tuple>>>;
     return apply_impl(std::forward<F>(f), std::forward<Tuple>(t), Indices());
   }
 \end{codeblock}
@@ -634,8 +633,8 @@ Value-initializes \tcode{first} and \tcode{second}.
 \pnum
 \remarks
 This constructor shall not participate in overload resolution unless
-\tcode{is_default_constructible<first_type>::value} is \tcode{true} and
-\tcode{is_default_constructible<second_type>::value} is \tcode{true}.
+\tcode{is_default_constructible_v<first_type>} is \tcode{true} and
+\tcode{is_default_constructible_v<second_type>} is \tcode{true}.
 \begin{note} This behaviour can be implemented by a constructor template
 with default template arguments. \end{note}
 \end{itemdescr}
@@ -653,11 +652,11 @@ with \tcode{y}.
 
 \pnum
 \remarks This constructor shall not participate in overload resolution
-unless \tcode{is_copy_constructible<first_type>::value} is \tcode{true} and
-\tcode{is_copy_constructible<second_type>::value} is \tcode{true}.
+unless \tcode{is_copy_constructible_v<first_type>} is \tcode{true} and
+\tcode{is_copy_constructible_v<second_type>} is \tcode{true}.
 The constructor is explicit if and only if
-\tcode{is_convertible<const first_type\&, first_type>::value} is \tcode{false} or
-\tcode{is_convertible<const second_type\&, second_type>::value} is \tcode{false}.
+\tcode{is_convertible_v<const first_type\&, first_type>} is \tcode{false} or
+\tcode{is_convertible_v<const second_type\&, second_type>} is \tcode{false}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{pair}!constructor}
@@ -675,11 +674,11 @@ with \tcode{std::forward<\brk{}V>(y)}.
 \pnum
 \remarks
 This constructor shall not participate in overload resolution unless
-\tcode{is_constructible<first_type, U\&\&>::value} is \tcode{true} and
-\tcode{is_constructible<second_type, V\&\&>::value} is \tcode{true}.
+\tcode{is_constructible_v<first_type, U\&\&>} is \tcode{true} and
+\tcode{is_constructible_v<second_type, V\&\&>} is \tcode{true}.
 The constructor is explicit if and only if
-\tcode{is_convertible<U\&\&, first_type>::value} is \tcode{false} or
-\tcode{is_convertible<V\&\&, second_type>::value} is \tcode{false}.
+\tcode{is_convertible_v<U\&\&, first_type>} is \tcode{false} or
+\tcode{is_convertible_v<V\&\&, second_type>} is \tcode{false}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{pair}!constructor}
@@ -694,11 +693,11 @@ The constructor initializes members from the corresponding members of the argume
 
 \pnum
 \remarks This constructor shall not participate in overload resolution unless
-\tcode{is_constructible<first_type, const U\&>::value} is \tcode{true} and
-\tcode{is_constructible<second_type, const V\&>::value} is \tcode{true}.
+\tcode{is_constructible_v<first_type, const U\&>} is \tcode{true} and
+\tcode{is_constructible_v<second_type, const V\&>} is \tcode{true}.
 The constructor is explicit if and only if
-\tcode{is_convertible<const U\&, first_type>::value} is \tcode{false} or
-\tcode{is_convertible<const V\&, second_type>::value} is \tcode{false}.
+\tcode{is_convertible_v<const U\&, first_type>} is \tcode{false} or
+\tcode{is_convertible_v<const V\&, second_type>} is \tcode{false}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{pair}!constructor}
@@ -716,11 +715,11 @@ and \tcode{second} with
 
 \pnum
 \remarks This constructor shall not participate in overload resolution unless
-\tcode{is_constructible<first_type, U\&\&>::value} is \tcode{true} and
-\tcode{is_constructible<second_type, V\&\&>::value} is \tcode{true}.
+\tcode{is_constructible_v<first_type, U\&\&>} is \tcode{true} and
+\tcode{is_constructible_v<second_type, V\&\&>} is \tcode{true}.
 The constructor is explicit if and only if
-\tcode{is_convertible<U\&\&, first_type>::value} is \tcode{false} or
-\tcode{is_convertible<V\&\&, second_type>::value} is \tcode{false}.
+\tcode{is_convertible_v<U\&\&, first_type>} is \tcode{false} or
+\tcode{is_convertible_v<V\&\&, second_type>} is \tcode{false}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{pair}!constructor}
@@ -732,8 +731,8 @@ template<class... Args1, class... Args2>
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{is_constructible<first_type, Args1\&\&...>::value} is \tcode{true}
-and \tcode{is_con\-structible<second_type, Args2\&\&...>::value} is \tcode{true}.
+\requires \tcode{is_constructible_v<first_type, Args1\&\&...>} is \tcode{true}
+and \tcode{is_constructible_v<second_type, Args2\&\&...>} is \tcode{true}.
 
 \pnum
 \effects The constructor initializes \tcode{first} with arguments of types
@@ -754,8 +753,8 @@ pair& operator=(const pair& p);
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{is_copy_assignable<first_type>::value} is \tcode{true}
-and \tcode{is_copy_assignable<second_type>::value} is \tcode{true}.
+\requires \tcode{is_copy_assignable_v<first_type>} is \tcode{true}
+and \tcode{is_copy_assignable_v<second_type>} is \tcode{true}.
 
 \pnum
 \effects Assigns \tcode{p.first} to \tcode{first} and \tcode{p.second} to \tcode{second}.
@@ -772,8 +771,8 @@ template<class U, class V> pair& operator=(const pair<U, V>& p);
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{is_assignable<first_type\&, const U\&>::value} is \tcode{true}
-and \tcode{is_assignable<second_type\&, const V\&>::value} is \tcode{true}.
+\requires \tcode{is_assignable_v<first_type\&, const U\&>} is \tcode{true}
+and \tcode{is_assignable_v<second_type\&, const V\&>} is \tcode{true}.
 
 \pnum
 \effects Assigns \tcode{p.first} to \tcode{first} and \tcode{p.second} to \tcode{second}.
@@ -793,13 +792,12 @@ pair& operator=(pair&& p) noexcept(@\seebelow@);
 \remarks The expression inside \tcode{noexcept} is equivalent to:
 
 \begin{codeblock}
-is_nothrow_move_assignable<T1>::value &&
-is_nothrow_move_assignable<T2>::value
+is_nothrow_move_assignable_v<T1> && is_nothrow_move_assignable_v<T2>
 \end{codeblock}
 
 \pnum
-\requires \tcode{is_move_assignable<first_type>::value} is \tcode{true}
-and \tcode{is_move_assignable<second_type>::value} is \tcode{true}.
+\requires \tcode{is_move_assignable_v<first_type>} is \tcode{true}
+and \tcode{is_move_assignable_v<second_type>} is \tcode{true}.
 
 \pnum
 \effects
@@ -818,8 +816,8 @@ template<class U, class V> pair& operator=(pair<U, V>&& p);
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{is_assignable<first_type\&, U\&\&>::value} is \tcode{true}
-and \tcode{is_assignable<second_type\&, V\&\&>::value} is \tcode{true}.
+\requires \tcode{is_assignable_v<first_type\&, U\&\&>} is \tcode{true}
+and \tcode{is_assignable_v<second_type\&, V\&\&>} is \tcode{true}.
 
 \pnum
 \effects
@@ -1293,7 +1291,7 @@ constexpr tuple();
 \pnum
 \remarks
 This constructor shall not participate in overload resolution unless
-\tcode{is_default_construct\-ible<$T_i$>::value} is \tcode{true} for all $i$.
+\tcode{is_default_construct\-ible_v<$T_i$>} is \tcode{true} for all $i$.
 \begin{note} This behaviour can be implemented by a constructor template
 with default template arguments. \end{note}
 \end{itemdescr}
@@ -1310,9 +1308,9 @@ corresponding parameter.
 
 \pnum
 \remarks This constructor shall not participate in overload resolution unless
-\tcode{sizeof...(Types) >= 1} and \tcode{is_copy_constructible<$T_i$>::value}
+\tcode{sizeof...(Types) >= 1} and \tcode{is_copy_constructible_v<$T_i$>}
 is \tcode{true} for all $i$. The constructor is explicit if and only if
-\tcode{is_convertible<const $T_i$\&, $T_i$>::value} is \tcode{false}
+\tcode{is_convertible_v<const $T_i$\&, $T_i$>} is \tcode{false}
 for at least one $i$.
 \end{itemdescr}
 
@@ -1330,9 +1328,9 @@ corresponding value in \tcode{std::for\-ward<UTypes>(u)}.
 \pnum
 \remarks This constructor shall not participate in overload resolution unless
 \tcode{sizeof...(Types)} \tcode{==} \tcode{sizeof...(UTypes)} and
-\tcode{sizeof...(Types) >= 1} and \tcode{is_constructible<$T_i$, $U_i$\&\&>::value}
+\tcode{sizeof...(Types) >= 1} and \tcode{is_constructible_v<$T_i$, $U_i$\&\&>}
 is \tcode{true} for all $i$. The constructor is explicit if and only if
-\tcode{is_convertible<$U_i$\&\&, $T_i$>::value} is \tcode{false}
+\tcode{is_convertible_v<$U_i$\&\&, $T_i$>} is \tcode{false}
 for at least one $i$.
 \end{itemdescr}
 
@@ -1343,7 +1341,7 @@ tuple(const tuple& u) = default;
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{is_copy_constructible<$T_i$>::value} is \tcode{true} for all $i$.
+\requires \tcode{is_copy_constructible_v<$T_i$>} is \tcode{true} for all $i$.
 
 \pnum
 \effects Initializes each element of \tcode{*this} with the
@@ -1357,7 +1355,7 @@ tuple(tuple&& u) = default;
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{is_move_constructible<$T_i$>::value} is \tcode{true} for all $i$.
+\requires \tcode{is_move_constructible_v<$T_i$>} is \tcode{true} for all $i$.
 
 \pnum
 \effects For all $i$, initializes the $i^{th}$ element of \tcode{*this} with
@@ -1380,7 +1378,7 @@ with the corresponding element of \tcode{u}.
 \item
 \tcode{sizeof...(Types)} \tcode{==} \tcode{sizeof...(UTypes)} and
 \item
-\tcode{is_constructible<$T_i$, const $U_i$\&>::value} is \tcode{true} for all $i$, and
+\tcode{is_constructible_v<$T_i$, const $U_i$\&>} is \tcode{true} for all $i$, and
 \item
 \tcode{sizeof...(Types) != 1}, or
 (when \tcode{Types...} expands to \tcode{T} and \tcode{UTypes...} expands to \tcode{U})\linebreak
@@ -1388,7 +1386,7 @@ with the corresponding element of \tcode{u}.
 is \tcode{true}.
 \end{itemize}
 The constructor is explicit if and only if
-\tcode{is_convertible<const $U_i$\&, $T_i$>::value} is \tcode{false}
+\tcode{is_convertible_v<const $U_i$\&, $T_i$>} is \tcode{false}
 for at least one $i$.
 \end{itemdescr}
 
@@ -1410,7 +1408,7 @@ initializes the $i^{th}$ element of \tcode{*this} with
 \item
 \tcode{sizeof...(Types)} \tcode{==} \tcode{sizeof...(UTypes)}, and
 \item
-\tcode{is_constructible<$T_i$, $U_i$\&\&>::value} is \tcode{true} for all $i$, and
+\tcode{is_constructible_v<$T_i$, $U_i$\&\&>} is \tcode{true} for all $i$, and
 \item
 \tcode{sizeof...(Types) != 1}, or
 (when \tcode{Types...} expands to \tcode{T} and \tcode{UTypes...} expands to \tcode{U})\linebreak
@@ -1418,7 +1416,7 @@ initializes the $i^{th}$ element of \tcode{*this} with
 is \tcode{true}.
 \end{itemize}
 The constructor is explicit if and only if
-\tcode{is_convertible<$U_i$\&\&, $T_i$>::value} is \tcode{false}
+\tcode{is_convertible_v<$U_i$\&\&, $T_i$>} is \tcode{false}
 for at least one $i$.
 \end{itemdescr}
 
@@ -1436,13 +1434,13 @@ second element with \tcode{u.second}.
 \pnum
 \remarks This constructor shall not participate in overload resolution unless
 \tcode{sizeof...(Types) == 2},
-\tcode{is_constructible<$T_0$, const U1\&>::value} is \tcode{true}, and
-\tcode{is_constructible<$T_1$, const U2\&>::value} is \tcode{true}.
+\tcode{is_constructible_v<$T_0$, const U1\&>} is \tcode{true} and
+\tcode{is_constructible_v<$T_1$, const U2\&>} is \tcode{true}.
 
 \pnum
 The constructor is explicit if and only if
-\tcode{is_convertible<const U1\&, $T_0$>::value} is \tcode{false} or
-\tcode{is_convertible<const U2\&, $T_1$>::value} is \tcode{false}.
+\tcode{is_convertible_v<const U1\&, $T_0$>} is \tcode{false} or
+\tcode{is_convertible_v<const U2\&, $T_1$>} is \tcode{false}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{tuple}!constructor}%
@@ -1460,13 +1458,13 @@ second element with \tcode{std::forward<U2>(u.second)}.
 \pnum
 \remarks This constructor shall not participate in overload resolution unless
 \tcode{sizeof...(Types) == 2},
-\tcode{is_constructible<$T_0$, U1\&\&>::value} is \tcode{true} and
-\tcode{is_constructible<$T_1$, U2\&\&>::value} is \tcode{true}.
+\tcode{is_constructible_v<$T_0$, U1\&\&>} is \tcode{true} and
+\tcode{is_constructible_v<$T_1$, U2\&\&>} is \tcode{true}.
 
 \pnum
 The constructor is explicit if and only if
-\tcode{is_convertible<U1\&\&, $T_0$>::value} is \tcode{false} or
-\tcode{is_convertible<U2\&\&, $T_1$>::value} is \tcode{false}.
+\tcode{is_convertible_v<U1\&\&, $T_0$>} is \tcode{false} or
+\tcode{is_convertible_v<U2\&\&, $T_1$>} is \tcode{false}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{tuple}!constructor}%
@@ -1518,7 +1516,7 @@ tuple& operator=(const tuple& u);
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{is_copy_assignable<$T_i$>::value} is \tcode{true} for all $i$.
+\requires \tcode{is_copy_assignable_v<$T_i$>} is \tcode{true} for all $i$.
 
 \pnum
 \effects  Assigns each element of \tcode{u} to the corresponding
@@ -1540,13 +1538,13 @@ tuple& operator=(tuple&& u) noexcept(@\seebelow@);
 following expressions:
 
 \begin{codeblock}
-is_nothrow_move_assignable<@$T_i$@>::value
+is_nothrow_move_assignable_v<@$T_i$@>
 \end{codeblock}
 
 where $T_i$ is the $i^{th}$ type in \tcode{Types}.
 
 \pnum
-\requires \tcode{is_move_assignable<$T_i$>::value} is \tcode{true} for all $i$.
+\requires \tcode{is_move_assignable_v<$T_i$>} is \tcode{true} for all $i$.
 
 \pnum
 \effects For all $i$, assigns \tcode{std::forward<$T_i$>(get<$i$>(u))} to
@@ -1567,7 +1565,7 @@ template <class... UTypes>
 \pnum
 \requires
 \tcode{sizeof...(Types) == sizeof...(UTypes)} and
-\tcode{is_assignable<$T_i$\&, const $U_i$\&>::value} is \tcode{true} for all $i$.
+\tcode{is_assignable_v<$T_i$\&, const $U_i$\&>} is \tcode{true} for all $i$.
 
 \pnum
 \effects  Assigns each element of \tcode{u} to the corresponding element
@@ -1587,7 +1585,7 @@ template <class... UTypes>
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{is_assignable<Ti\&, Ui\&\&>::value == true} for all \tcode{i}.
+\tcode{is_assignable_v<Ti\&, Ui\&\&> == true} for all \tcode{i}.
 \tcode{sizeof...(Types)} \tcode{==}\\\tcode{sizeof...(UTypes)}.
 
 \pnum
@@ -1608,8 +1606,8 @@ template <class U1, class U2> tuple& operator=(const pair<U1, U2>& u);
 \begin{itemdescr}
 \pnum
 \requires \tcode{sizeof...(Types) == 2}.
-\tcode{is_assignable<$T_0$\&, const U1\&>::value} is \tcode{true} for the first type $T_0$ in
-\tcode{Types} and \tcode{is_assignable<$T_1$\&, const U2\&>::value} is \tcode{true} for the
+\tcode{is_assignable_v<$T_0$\&, const U1\&>} is \tcode{true} for the first type $T_0$ in
+\tcode{Types} and \tcode{is_assignable_v<$T_1$\&, const U2\&>} is \tcode{true} for the
 second type $T_1$ in \tcode{Types}.
 
 \pnum
@@ -1630,8 +1628,8 @@ template <class U1, class U2> tuple& operator=(pair<U1, U2>&& u);
 \begin{itemdescr}
 \pnum
 \requires \tcode{sizeof...(Types) == 2}.
-\tcode{is_assignable<$T_0$\&, U1\&\&>::value} is \tcode{true} for the first type $T_0$ in
-\tcode{Types} and \tcode{is_assignable<$T_1$\&, U2\&\&>::value} is \tcode{true} for the second
+\tcode{is_assignable_v<$T_0$\&, U1\&\&>} is \tcode{true} for the first type $T_0$ in
+\tcode{Types} and \tcode{is_assignable_v<$T_1$\&, U2\&\&>} is \tcode{true} for the second
 type $T_1$ in \tcode{Types}.
 
 \pnum
@@ -1782,8 +1780,8 @@ cv-qualifier-seq and $Args_i$ is the parameter pack representing the element
 types in $U_i$. Let ${A_{ik}}$ be the ${k_i}^{th}$ type in $Args_i$. For all
 $A_{ik}$ the following requirements shall be satisfied: If $T_i$ is
 deduced as an lvalue reference type, then
-\tcode{is_constructible<$A_{ik}$, $cv_i$ $A_{ik}$\&>::value == true}, otherwise
-\tcode{is_constructible<$A_{ik}$, $cv_i A_{ik}$\&\&>::value == true}.
+\tcode{is_constructible_v<$A_{ik}$, $cv_i$ $A_{ik}$\&> == true}, otherwise
+\tcode{is_constructible_v<$A_{ik}$, $cv_i A_{ik}$\&\&> == true}.
 
 \pnum
 \remarks The types in \tcode{\placeholder{Ctypes}} shall be equal to the ordered
@@ -6818,7 +6816,7 @@ is convertible from \tcode{Alloc}. Meets the BinaryTypeTrait
 requirements~(\ref{meta.rqmts}). The implementation shall provide a definition that is
 derived from \tcode{true_type} if the \grammarterm{qualified-id} \tcode{T::allocator_type}
 is valid and denotes a type~(\ref{temp.deduct}) and
-\tcode{is_convertible<Alloc, T::allocator_type>::value != false}, otherwise it shall be
+\tcode{is_convertible_v<Alloc, T::allocator_type> != false}, otherwise it shall be
 derived from \tcode{false_type}. A program may specialize this template to derive from
 \tcode{true_type} for a user-defined type \tcode{T} that does not have a nested
 \tcode{allocator_type} but nonetheless can be constructed with an allocator where
@@ -6841,21 +6839,21 @@ construction of an object \tcode{obj} of type \tcode{T}, using constructor argum
 \tcode{alloc} of type \tcode{Alloc}, according to the following rules:
 
 \begin{itemize}
-\item if \tcode{uses_allocator<T, Alloc>::value} is \tcode{false} and
-\tcode{is_constructible<T, V1, V2, ..., VN>::value} is \tcode{true}, then \tcode{obj} is
+\item if \tcode{uses_allocator_v<T, Alloc>} is \tcode{false} and
+\tcode{is_constructible_v<T, V1, V2, ..., VN>} is \tcode{true}, then \tcode{obj} is
 initialized as \tcode{obj(v1, v2, ..., vN)};
 
-\item otherwise, if \tcode{uses_allocator<T, Alloc>::value} is \tcode{true} and
-\tcode{is_constructible<T, allocator_arg_t, Alloc,} \tcode{V1, V2, ..., VN>::value} is
+\item otherwise, if \tcode{uses_allocator_v<T, Alloc>} is \tcode{true} and
+\tcode{is_constructible_v<T, allocator_arg_t, Alloc,} \tcode{V1, V2, ..., VN>} is
 \tcode{true}, then \tcode{obj} is initialized as \tcode{obj(allocator_arg, alloc, v1,
 v2, ..., vN)};
 
-\item otherwise, if \tcode{uses_allocator<T, Alloc>::value} is \tcode{true} and
-\tcode{is_constructible<T, V1, V2, ..., VN, Alloc>::value} is \tcode{true}, then
+\item otherwise, if \tcode{uses_allocator_v<T, Alloc>} is \tcode{true} and
+\tcode{is_constructible_v<T, V1, V2, ..., VN, Alloc>} is \tcode{true}, then
 \tcode{obj} is initialized as \tcode{obj(v1, v2, ..., vN, alloc)};
 
 \item otherwise, the request for uses-allocator construction is ill-formed. \begin{note}
-An error will result if \tcode{uses_allocator<T, Alloc>::value} is \tcode{true} but the
+An error will result if \tcode{uses_allocator_v<T, Alloc>} is \tcode{true} but the
 specific constructor does not take an allocator. This definition prevents a silent
 failure to pass the allocator to an element. \end{note}
 \end{itemize}
@@ -8202,7 +8200,7 @@ of type \tcode{E} shall be well-formed and shall not throw an exception.
 \begin{itemize}
 \item \tcode{unique_ptr<U, E>::pointer} is implicitly convertible to \tcode{pointer}, and
 \item \tcode{U} is not an array type, and
-\item \tcode{is_assignable<D\&, E\&\&>::value} is \tcode{true}.
+\item \tcode{is_assignable_v<D\&, E\&\&>} is \tcode{true}.
 \end{itemize}
 
 \pnum
@@ -8509,7 +8507,7 @@ where \tcode{UP} is \tcode{unique_ptr<U, E>}:
 \item \tcode{pointer} is the same type as \tcode{element_type*}, and
 \item \tcode{UP::pointer} is the same type as \tcode{UP::element_type*}, and
 \item \tcode{UP::element_type(*)[]} is convertible to \tcode{element_type(*)[]}, and
-\item \tcode{is_assignable<D\&, E\&\&>::value} is \tcode{true}.
+\item \tcode{is_assignable_v<D\&, E\&\&>} is \tcode{true}.
 \end{itemize}
 
 \begin{note}
@@ -11967,18 +11965,18 @@ template <class T, class... Args>
 \effects
 
 \begin{itemize}
-\item If \tcode{uses_allocator<T, inner_allocator_type>::value} is \tcode{false} and
-\tcode{is_constructible<T, Args...>::value} is \tcode{true}, calls
+\item If \tcode{uses_allocator_v<T, inner_allocator_type>} is \tcode{false} and
+\tcode{is_constructible_v<T, Args...>} is \tcode{true}, calls
 \textit{OUTERMOST_ALLOC_TRAITS}(\tcode{*this})\tcode{::construct(\\
 \textit{OUTERMOST}(*this), p, std::forward<Args>(args)...)}.
 
-\item Otherwise, if \tcode{uses_allocator<T, inner_allocator_type>::value} is \tcode{true} and
-\tcode{is_construc\-tible<T, allocator_arg_t, inner_allocator_type\&, Args...>::value} is \tcode{true}, calls
+\item Otherwise, if \tcode{uses_allocator_v<T, inner_allocator_type>} is \tcode{true} and
+\tcode{is_construc\-tible_v<T, allocator_arg_t, inner_allocator_type\&, Args...>} is \tcode{true}, calls
 \textit{OUTERMOST_ALLOC_TRAITS}(\tcode{*this})\tcode{::construct(\textit{OUTERMOST}(*this),
 p, allocator_arg,\\inner_allocator(), std::forward<Args>(args)...)}.
 
-\item Otherwise, if \tcode{uses_allocator<T, inner_allocator_type>::value} is \tcode{true} and
-\tcode{is_construct\-ible<T, Args..., inner_allocator_type\&>::value} is \tcode{true}, calls
+\item Otherwise, if \tcode{uses_allocator_v<T, inner_allocator_type>} is \tcode{true} and
+\tcode{is_construct\-ible_v<T, Args..., inner_allocator_type\&>} is \tcode{true}, calls
 \textit{OUTERMOST_ALLOC_TRAITS}(*this)::
 \tcode{construct(\textit{OUTERMOST}(*this), p, std::forward<Args>(args)...,\\inner_allocator())}.
 
@@ -12007,21 +12005,21 @@ template <class T1, class T2, class... Args1, class... Args2>
 following rules:
 
 \begin{itemize}
-\item If \tcode{uses_allocator<T1, inner_allocator_type>::value} is \tcode{false} and
-\tcode{is_constructible<T1,
-Args1...>::value} is \tcode{true}, then \tcode{xprime} is \tcode{x}.
+\item If \tcode{uses_allocator_v<T1, inner_allocator_type>} is \tcode{false} and
+\tcode{is_constructible_v<T1, Args1...>} is \tcode{true},
+then \tcode{xprime} is \tcode{x}.
 
-\item Otherwise, if \tcode{uses_allocator<T1, inner_allocator_type>::value} is \tcode{true}
+\item Otherwise, if \tcode{uses_allocator_v<T1, inner_allocator_type>} is \tcode{true}
 and
-\tcode{is_construct\-ible<T1, allocator_arg_t, inner_allocator_type\&, Args1...>::value}
+\tcode{is_construct\-ible_v<T1, allocator_arg_t, inner_allocator_type\&, Args1...>}
 is
 \tcode{true}, then \tcode{xprime} is
 \tcode{tuple_cat(tuple<allocator_arg_t, inner_allocator_type\&>(
 allocator_arg, inner_allocator()), std::move(x))}.
 
-\item Otherwise, if \tcode{uses_allocator<T1, inner_allocator_type>::value} is
+\item Otherwise, if \tcode{uses_allocator_v<T1, inner_allocator_type>} is
 \tcode{true} and
-\tcode{is_construct\-ible<T1, Args1..., inner_allocator_type\&>::value} is \tcode{true},
+\tcode{is_construct\-ible_v<T1, Args1..., inner_allocator_type\&>} is \tcode{true},
 then \tcode{xprime} is
 \tcode{tuple_cat(std::move(x), tuple<inner_allocator_type\&>(inner_allocator()))}.
 
@@ -12031,21 +12029,21 @@ then \tcode{xprime} is
 and constructs a \tcode{tuple} object \tcode{yprime} from \tcode{y} by the following rules:
 
 \begin{itemize}
-\item If \tcode{uses_allocator<T2, inner_allocator_type>::value} is \tcode{false} and
-\tcode{is_constructible<T2,
-Args2...>::value} is \tcode{true}, then \tcode{yprime} is \tcode{y}.
+\item If \tcode{uses_allocator_v<T2, inner_allocator_type>} is \tcode{false} and
+\tcode{is_constructible_v<T2,
+Args2...>} is \tcode{true}, then \tcode{yprime} is \tcode{y}.
 
-\item Otherwise, if \tcode{uses_allocator<T2, inner_allocator_type>::value} is \tcode{true}
+\item Otherwise, if \tcode{uses_allocator_v<T2, inner_allocator_type>} is \tcode{true}
 and
-\tcode{is_construct\-ible<T2, allocator_arg_t, inner_allocator_type\&, Args2...>::value}
+\tcode{is_construct\-ible_v<T2, allocator_arg_t, inner_allocator_type\&, Args2...>}
 is
 \tcode{true}, then \tcode{yprime} is
 \tcode{tuple_cat(tuple<allocator_arg_t, inner_allocator_type\&>(
 allocator_arg, inner_allocator()), std::move(y))}.
 
-\item Otherwise, if \tcode{uses_allocator<T2, inner_allocator_type>::value} is
+\item Otherwise, if \tcode{uses_allocator_v<T2, inner_allocator_type>} is
 \tcode{true} and
-\tcode{is_construct\-ible<T2, Args2..., inner_allocator_type\&>::value} is \tcode{true},
+\tcode{is_construct\-ible_v<T2, Args2..., inner_allocator_type\&>} is \tcode{true},
 then \tcode{yprime} is
 \tcode{tuple_cat(std::move(y), tuple<inner_allocator_type\&>(inner_allocator()))}.
 
@@ -12436,7 +12434,7 @@ Define \tcode{\textit{INVOKE}(f, t1, t2, ..., tN)} as follows:
 \begin{itemize}
 \item \tcode{(t1.*f)(t2, ..., tN)} when \tcode{f} is a pointer to a
 member function of a class \tcode{T}
-and \tcode{is_base_of<T, decay_t<decltype(t1)>>::value} is \tcode{true};
+and \tcode{is_base_of_v<T, decay_t<decltype(t1)>>} is \tcode{true};
 
 \item \tcode{(t1.get().*f)(t2, ..., tN)} when \tcode{f} is a pointer to a
 member function of a class \tcode{T}
@@ -12448,7 +12446,7 @@ and \tcode{t1} does not satisfy the previous two items;
 
 \item \tcode{t1.*f} when \tcode{N == 1} and \tcode{f} is a pointer to
 data member of a class \tcode{T}
-and \tcode{is_base_of<T, decay_t<decltype(t1)>>::value} is \tcode{true};
+and \tcode{is_base_of_v<T, decay_t<decltype(t1)>>} is \tcode{true};
     
 \item \tcode{t1.get().*f} when \tcode{N == 1} and \tcode{f} is a pointer to
 data member of a class \tcode{T}
@@ -13403,8 +13401,8 @@ template<class F, class... BoundArgs>
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{is_constructible<FD, F>::value} shall be \tcode{true}. For each \tcode{Ti}
-in \tcode{BoundArgs}, \tcode{is_cons\-tructible<TiD, Ti>::value} shall be \tcode{true}.
+\tcode{is_constructible_v<FD, F>} shall be \tcode{true}. For each \tcode{Ti}
+in \tcode{BoundArgs}, \tcode{is_cons\-tructible_v<TiD, Ti>} shall be \tcode{true}.
 \tcode{\textit{INVOKE} (fd, w1, w2, ...,
 wN)}~(\ref{func.require}) shall be a valid expression for some
 values \textit{w1, w2, ..., wN}, where
@@ -13442,8 +13440,8 @@ template<class R, class F, class... BoundArgs>
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{is_constructible<FD, F>::value} shall be \tcode{true}. For each \tcode{Ti}
-in \tcode{BoundArgs}, \tcode{is_con\-structible<TiD, Ti>::value} shall be \tcode{true}.
+\tcode{is_constructible_v<FD, F>} shall be \tcode{true}. For each \tcode{Ti}
+in \tcode{BoundArgs}, \tcode{is_con\-structible_v<TiD, Ti>} shall be \tcode{true}.
 \tcode{\textit{INVOKE}(fd, w1, w2, ..., wN)} shall be  a valid
 expression for some
 values \textit{w1, w2, ..., wN}, where
@@ -13486,12 +13484,12 @@ the call to \tcode{bind} and the
 \item if \tcode{TiD} is \tcode{reference_wrapper<T>}, the
 argument is \tcode{tid.get()} and its type \tcode{Vi} is \tcode{T\&};
 
-\item if the value of \tcode{is_bind_expression<TiD>::value}
+\item if the value of \tcode{is_bind_expression_v<TiD>}
 is \tcode{true}, the argument is \tcode{tid(std::forward<Uj>(\brk{}uj)...)}  and its
 type \tcode{Vi} is
 \tcode{result_of_t<TiD \textit{cv} \& (Uj\&\&...)>\&\&};
 
-\item if the value \tcode{j} of \tcode{is_placeholder<TiD>::value}
+\item if the value \tcode{j} of \tcode{is_placeholder_v<TiD>}
 is not zero, the  argument is \tcode{std::forward<Uj>(uj)}
 and its type \tcode{Vi}
 is \tcode{Uj\&\&};
@@ -15072,7 +15070,7 @@ notwithstanding the restrictions of~\ref{declval}.
  \tcode{T} is a class type, but not a union type, with no non-static data
  members other than bit-fields of length 0, no virtual member functions,
  no virtual base classes, and no base class \tcode{B} for
- which \tcode{is_empty<B>::value} is false. &
+ which \tcode{is_empty_v<B>} is false. &
  If \tcode{T} is a non-union class type, \tcode{T} shall be a complete type.                               \\ \rowsep
 
 \tcode{template <class T>}\br
@@ -15094,20 +15092,20 @@ notwithstanding the restrictions of~\ref{declval}.
 
 \tcode{template <class T>}\br
   \tcode{struct is_signed;}              &
-  If \tcode{is_arithmetic<T>::value} is \tcode{true}, the same result as
+  If \tcode{is_arithmetic_v<T>} is \tcode{true}, the same result as
   \tcode{bool_constant<T(-1) < T(0)>::value};
   otherwise, \tcode{false}   &   \\  \rowsep
 
 \tcode{template <class T>}\br
   \tcode{struct is_unsigned;}            &
-  If \tcode{is_arithmetic<T>::value} is \tcode{true}, the same result as
+  If \tcode{is_arithmetic_v<T>} is \tcode{true}, the same result as
   \tcode{bool_constant<T(0) < T(-1)>::value};
   otherwise, \tcode{false}   &   \\  \rowsep
 
 \tcode{template <class T, class... Args>}\br
  \tcode{struct is_constructible;}   &
  For a function type \tcode{T},
- \tcode{is_constructible<T, Args...>::value} is \tcode{false},
+ \tcode{is_constructible_v<T, Args...>} is \tcode{false},
  otherwise \seebelow                &
  \tcode{T} and all types in the parameter pack \tcode{Args}
  shall be complete types, (possibly cv-qualified) \tcode{void},
@@ -15115,21 +15113,21 @@ notwithstanding the restrictions of~\ref{declval}.
 
 \tcode{template <class T>}\br
   \tcode{struct is_default_constructible;} &
-  \tcode{is_constructible<T>::value} is \tcode{true}. &
+  \tcode{is_constructible_v<T>} is \tcode{true}. &
   \tcode{T} shall be a complete type, (possibly cv-qualified) \tcode{void},
   or an array of unknown bound. \\ \rowsep
 
 \tcode{template <class T>}\br
   \tcode{struct is_copy_constructible;} &
   For a referenceable type \tcode{T}, the same result as
-  \tcode{is_constructible<T, const T\&>::value}, otherwise \tcode{false}. &
+  \tcode{is_constructible_v<T, const T\&>}, otherwise \tcode{false}. &
   \tcode{T} shall be a complete type, (possibly cv-qualified) \tcode{void},
   or an array of unknown bound. \\ \rowsep
 
 \tcode{template <class T>}\br
   \tcode{struct is_move_constructible;} &
   For a referenceable type \tcode{T}, the same result as
-  \tcode{is_constructible<T, T\&\&>::value}, otherwise \tcode{false}. &
+  \tcode{is_constructible_v<T, T\&\&>}, otherwise \tcode{false}. &
   \tcode{T} shall be a complete type, (possibly cv-qualified) \tcode{void},
   or an array of unknown bound. \\ \rowsep
 
@@ -15150,14 +15148,14 @@ notwithstanding the restrictions of~\ref{declval}.
 \tcode{template <class T>}\br
   \tcode{struct is_copy_assignable;} &
   For a referenceable type \tcode{T}, the same result as
-  \tcode{is_assignable<T\&, const T\&>::value}, otherwise \tcode{false}. &
+  \tcode{is_assignable_v<T\&, const T\&>}, otherwise \tcode{false}. &
   \tcode{T} shall be a complete type, (possibly cv-qualified) \tcode{void},
   or an array of unknown bound. \\ \rowsep
 
 \tcode{template <class T>}\br
   \tcode{struct is_move_assignable;} &
   For a referenceable type \tcode{T}, the same result as
-  \tcode{is_assignable<T\&, T\&\&>::value}, otherwise \tcode{false}. &
+  \tcode{is_assignable_v<T\&, T\&\&>}, otherwise \tcode{false}. &
   \tcode{T} shall be a complete type, (possibly cv-qualified) \tcode{void},
   or an array of unknown bound. \\ \rowsep
 
@@ -15187,7 +15185,7 @@ notwithstanding the restrictions of~\ref{declval}.
 \tcode{template <class T>}\br
   \tcode{struct is_swappable;} &
   For a referenceable type \tcode{T},
-  the same result as \tcode{is_swappable_with<T\&, T\&>::value},
+  the same result as \tcode{is_swappable_with_v<T\&, T\&>},
   otherwise \tcode{false}. &
   \tcode{T} shall be a complete type,
   (possibly cv-qualified) \tcode{void}, or
@@ -15209,8 +15207,8 @@ notwithstanding the restrictions of~\ref{declval}.
 \tcode{template <class T, class... Args>}\br
   \tcode{struct}\br
   \tcode{is_trivially_constructible;} &
-  \tcode{is_constructible<T,}\br
-  \tcode{Args...>::value} is \tcode{true} and the variable
+  \tcode{is_constructible_v<T,}\br
+  \tcode{Args...>} is \tcode{true} and the variable
   definition for \tcode{is_constructible}, as defined below, is known to call
   no operation that is not trivial (~\ref{basic.types},~\ref{special}). &
   \tcode{T} and all types in the parameter pack \tcode{Args} shall be complete types,
@@ -15218,7 +15216,7 @@ notwithstanding the restrictions of~\ref{declval}.
 
 \tcode{template <class T>}\br
  \tcode{struct is_trivially_default_constructible;} &
- \tcode{is_trivially_constructible<T>::value} is \tcode{true}. &
+ \tcode{is_trivially_constructible_v<T>} is \tcode{true}. &
  \tcode{T} shall be a complete type,
  (possibly cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
@@ -15226,7 +15224,7 @@ notwithstanding the restrictions of~\ref{declval}.
 \tcode{template <class T>}\br
  \tcode{struct is_trivially_copy_constructible;}      &
   For a referenceable type \tcode{T}, the same result as
- \tcode{is_trivially_constructible<T, const T\&>::value}, otherwise \tcode{false}. &
+ \tcode{is_trivially_constructible_v<T, const T\&>}, otherwise \tcode{false}. &
   \tcode{T} shall be a complete type,
  (possibly cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
@@ -15234,14 +15232,14 @@ notwithstanding the restrictions of~\ref{declval}.
 \tcode{template <class T>}\br
  \tcode{struct is_trivially_move_constructible;}      &
   For a referenceable type \tcode{T}, the same result as
- \tcode{is_trivially_constructible<T, T\&\&>::value}, otherwise \tcode{false}. &
+ \tcode{is_trivially_constructible_v<T, T\&\&>}, otherwise \tcode{false}. &
   \tcode{T} shall be a complete type,
  (possibly cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
 \tcode{template <class T, class U>}\br
   \tcode{struct is_trivially_assignable;} &
-  \tcode{is_assignable<T, U>::value} is \tcode{true} and the assignment, as defined by
+  \tcode{is_assignable_v<T, U>} is \tcode{true} and the assignment, as defined by
   \tcode{is_assignable}, is known to call no operation that is not trivial
   (\ref{basic.types},~\ref{special}). &
   \tcode{T} and \tcode{U} shall be complete types, (possibly cv-qualified) \tcode{void},
@@ -15250,7 +15248,7 @@ notwithstanding the restrictions of~\ref{declval}.
 \tcode{template <class T>}\br
  \tcode{struct is_trivially_copy_assignable;} &
   For a referenceable type \tcode{T}, the same result as
- \tcode{is_trivially_assignable<T\&, const T\&>::value}, otherwise \tcode{false}. &
+ \tcode{is_trivially_assignable_v<T\&, const T\&>}, otherwise \tcode{false}. &
  \tcode{T} shall be a complete type,
  (possibly cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
@@ -15258,13 +15256,13 @@ notwithstanding the restrictions of~\ref{declval}.
 \tcode{template <class T>}\br
  \tcode{struct is_trivially_move_assignable;} &
   For a referenceable type \tcode{T}, the same result as
- \tcode{is_trivially_assignable<T\&, T\&\&>::value}, otherwise \tcode{false}. &
+ \tcode{is_trivially_assignable_v<T\&, T\&\&>}, otherwise \tcode{false}. &
  \tcode{T} shall be a complete type,
  (possibly cv-qualified) \tcode{void}, or an array of unknown bound.                \\ \rowsep
 
 \tcode{template <class T>}\br
  \tcode{struct is_trivially_destructible;} &
- \tcode{is_destructible<T>::value} is \tcode{true} and the indicated destructor is known
+ \tcode{is_destructible_v<T>} is \tcode{true} and the indicated destructor is known
  to be trivial. &
  \tcode{T} shall be a complete type,
  (possibly cv-qualified) \tcode{void}, or an array of unknown
@@ -15272,7 +15270,7 @@ notwithstanding the restrictions of~\ref{declval}.
 
 \tcode{template <class T, class... Args>}\br
  \tcode{struct is_nothrow_constructible;}   &
- \tcode{is_constructible<T,} \tcode{ Args...>::value} is \tcode{true}
+ \tcode{is_constructible_v<T,} \tcode{ Args...>} is \tcode{true}
  and the
  variable definition for \tcode{is_constructible}, as defined below, is known not to
  throw any exceptions~(\ref{expr.unary.noexcept}).
@@ -15283,7 +15281,7 @@ notwithstanding the restrictions of~\ref{declval}.
 
 \tcode{template <class T>}\br
  \tcode{struct is_nothrow_default_constructible;} &
- \tcode{is_nothrow_constructible<T>::value} is \tcode{true}.  &
+ \tcode{is_nothrow_constructible_v<T>} is \tcode{true}.  &
  \tcode{T} shall be a complete type,
  (possibly cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
@@ -15291,7 +15289,7 @@ notwithstanding the restrictions of~\ref{declval}.
 \tcode{template <class T>}\br
  \tcode{struct is_nothrow_copy_constructible;}      &
   For a referenceable type \tcode{T}, the same result as
- \tcode{is_nothrow_constructible<T, const T\&>::value}, otherwise \tcode{false}. &
+ \tcode{is_nothrow_constructible_v<T, const T\&>}, otherwise \tcode{false}. &
  \tcode{T} shall be a complete type,
  (possibly cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
@@ -15299,13 +15297,13 @@ notwithstanding the restrictions of~\ref{declval}.
 \tcode{template <class T>}\br
  \tcode{struct is_nothrow_move_constructible;}      &
   For a referenceable type \tcode{T}, the same result as
- \tcode{is_nothrow_constructible<T, T\&\&>::value}, otherwise \tcode{false}. &
+ \tcode{is_nothrow_constructible_v<T, T\&\&>}, otherwise \tcode{false}. &
  \tcode{T} shall be a complete type,
  (possibly cv-qualified) \tcode{void}, or an array of unknown bound.                \\ \rowsep
 
 \tcode{template <class T, class U>}\br
   \tcode{struct is_nothrow_assignable;} &
-  \tcode{is_assignable<T, U>::value} is \tcode{true} and the assignment is known not to
+  \tcode{is_assignable_v<T, U>} is \tcode{true} and the assignment is known not to
   throw any exceptions~(\ref{expr.unary.noexcept}). &
   \tcode{T} and \tcode{U} shall be complete types, (possibly cv-qualified) \tcode{void},
   or arrays of unknown bound. \\ \rowsep
@@ -15313,7 +15311,7 @@ notwithstanding the restrictions of~\ref{declval}.
 \tcode{template <class T>}\br
  \tcode{struct is_nothrow_copy_assignable;} &
   For a referenceable type \tcode{T}, the same result as
- \tcode{is_nothrow_assignable<T\&, const T\&>::value}, otherwise \tcode{false}. &
+ \tcode{is_nothrow_assignable_v<T\&, const T\&>}, otherwise \tcode{false}. &
  \tcode{T} shall be a complete type,
  (possibly cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
@@ -15321,14 +15319,14 @@ notwithstanding the restrictions of~\ref{declval}.
 \tcode{template <class T>}\br
   \tcode{struct is_nothrow_move_assignable;} &
   For a referenceable type \tcode{T}, the same result as
-  \tcode{is_nothrow_assignable<T\&, T\&\&>::value}, otherwise \tcode{false}. &
+  \tcode{is_nothrow_assignable_v<T\&, T\&\&>}, otherwise \tcode{false}. &
  \tcode{T} shall be a complete type,
  (possibly cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
 \tcode{template <class T, class U>}\br
   \tcode{struct is_nothrow_swappable_with;} &
-  \tcode{is_swappable_with<T, U>::value} is \tcode{true} and
+  \tcode{is_swappable_with_v<T, U>} is \tcode{true} and
   each \tcode{swap} expression of the definition of
   \tcode{is_swappable_with<T, U>} is known not to throw
   any exceptions~(\ref{expr.unary.noexcept}). &
@@ -15339,7 +15337,7 @@ notwithstanding the restrictions of~\ref{declval}.
 \tcode{template <class T>}\br
   \tcode{struct is_nothrow_swappable;} &
   For a referenceable type \tcode{T},
-  the same result as \tcode{is_nothrow_swappable_with<T\&, T\&>::value},
+  the same result as \tcode{is_nothrow_swappable_with_v<T\&, T\&>},
   otherwise \tcode{false}. &
   \tcode{T} shall be a complete type,
   (possibly cv-qualified) \tcode{void}, or
@@ -15347,7 +15345,7 @@ notwithstanding the restrictions of~\ref{declval}.
 
 \tcode{template <class T>}\br
   \tcode{struct is_nothrow_destructible;} &
-  \tcode{is_destructible<T>::value} is \tcode{true} and the indicated destructor is known
+  \tcode{is_destructible_v<T>} is \tcode{true} and the indicated destructor is known
   not to throw any exceptions~(\ref{expr.unary.noexcept}). &
   \tcode{T} shall be a complete type,
   (possibly cv-qualified) \tcode{void}, or an array of unknown
@@ -15371,11 +15369,11 @@ notwithstanding the restrictions of~\ref{declval}.
 \pnum
 \begin{example}
 \begin{codeblock}
-is_const<const volatile int>::value     // true
-is_const<const int*>::value             // false
-is_const<const int&>::value             // false
-is_const<int[3]>::value                 // false
-is_const<const int[3]>::value           // true
+is_const_v<const volatile int>     // true
+is_const_v<const int*>             // false
+is_const_v<const int&>             // false
+is_const_v<int[3]>                 // false
+is_const_v<const int[3]>           // true
 \end{codeblock}
 \end{example}
 
@@ -15398,10 +15396,10 @@ union U1 { };
 union U2 final { };
 
 // the following assertions hold:
-static_assert(!is_final<int>::value, "Error!");
-static_assert( is_final<P>::value, "Error!");
-static_assert(!is_final<U1>::value, "Error!");
-static_assert( is_final<U2>::value, "Error!");
+static_assert(!is_final_v<int>, "Error!");
+static_assert( is_final_v<P>,  "Error!");
+static_assert(!is_final_v<U1>, "Error!");
+static_assert( is_final_v<U2>, "Error!");
 \end{codeblock}
 \end{example}
 
@@ -15485,9 +15483,9 @@ Each of these templates shall be a \tcode{UnaryTypeTrait}~(\ref{meta.rqmts}) wit
 \begin{example}
 \begin{codeblock}
 // the following assertions hold:
-assert(rank<int>::value == 0);
-assert(rank<int[2]>::value == 1);
-assert(rank<int[][4]>::value == 2);
+assert(rank_v<int> == 0);
+assert(rank_v<int[2]> == 1);
+assert(rank_v<int[][4]> == 2);
 \end{codeblock}
 \end{example}
 
@@ -15495,14 +15493,14 @@ assert(rank<int[][4]>::value == 2);
 \begin{example}
 \begin{codeblock}
  // the following assertions hold:
-assert(extent<int>::value == 0);
-assert(extent<int[2]>::value == 2);
-assert(extent<int[2][4]>::value == 2);
-assert(extent<int[][4]>::value == 0);
-assert((extent<int, 1>::value) == 0);
-assert((extent<int[2], 1>::value) == 0);
-assert((extent<int[2][4], 1>::value) == 4);
-assert((extent<int[][4], 1>::value) == 4);
+assert(extent_v<int> == 0);
+assert(extent_v<int[2]> == 2);
+assert(extent_v<int[2][4]> == 2);
+assert(extent_v<int[][4]> == 0);
+assert((extent_v<int, 1>) == 0);
+assert((extent_v<int[2], 1>) == 0);
+assert((extent_v<int[2][4], 1>) == 4);
+assert((extent_v<int[][4], 1>) == 4);
 \end{codeblock}
 \end{example}
 
@@ -15565,7 +15563,7 @@ with a BaseCharacteristic of
 \tcode{template <class Fn, class... ArgTypes, class R>}\br
  \tcode{struct is_nothrow_callable<}\br
  \tcode{Fn(ArgTypes...), R>;}              &
- \tcode{is_callable<}\br\tcode{Fn(ArgTypes...), R>::value} is \tcode{true} and
+ \tcode{is_callable_v<}\br\tcode{Fn(ArgTypes...), R>} is \tcode{true} and
  the expression \tcode{\textit{INVOKE}(declval<Fn>(), declval<ArgTypes>()..., R)}
  is known not to throw any exceptions                                 &
  \tcode{Fn}, \tcode{R}, and all types in the parameter pack \tcode{ArgTypes}
@@ -15589,14 +15587,14 @@ struct B1 : B {};
 struct B2 : B {};
 struct D : private B1, private B2 {};
 
-is_base_of<B, D>::value         // true
-is_base_of<const B, D>::value   // true
-is_base_of<B, const D>::value   // true
-is_base_of<B, const B>::value   // true
-is_base_of<D, B>::value         // false
-is_base_of<B&, D&>::value       // false
-is_base_of<B[3], D[3]>::value   // false
-is_base_of<int, int>::value     // false
+is_base_of_v<B, D>         // true
+is_base_of_v<const B, D>   // true
+is_base_of_v<B, const D>   // true
+is_base_of_v<B, const B>   // true
+is_base_of_v<D, B>         // false
+is_base_of_v<B&, D&>       // false
+is_base_of_v<B[3], D[3]>   // false
+is_base_of_v<int, int>     // false
 \end{codeblock}
 \end{example}
 
@@ -15790,10 +15788,10 @@ Each of the templates in this subclause shall be a
 \begin{example}
 \begin{codeblock}
 // the following assertions hold:
-assert((is_same<remove_extent_t<int>, int>::value));
-assert((is_same<remove_extent_t<int[2]>, int>::value));
-assert((is_same<remove_extent_t<int[2][3]>, int[3]>::value));
-assert((is_same<remove_extent_t<int[][3]>, int[3]>::value));
+assert((is_same_v<remove_extent_t<int>, int>));
+assert((is_same_v<remove_extent_t<int[2]>, int>));
+assert((is_same_v<remove_extent_t<int[2][3]>, int[3]>));
+assert((is_same_v<remove_extent_t<int[][3]>, int[3]>));
 \end{codeblock}
 \end{example}
 
@@ -15801,10 +15799,10 @@ assert((is_same<remove_extent_t<int[][3]>, int[3]>::value));
 \begin{example}
 \begin{codeblock}
 // the following assertions hold:
-assert((is_same<remove_all_extents_t<int>, int>::value));
-assert((is_same<remove_all_extents_t<int[2]>, int>::value));
-assert((is_same<remove_all_extents_t<int[2][3]>, int>::value));
-assert((is_same<remove_all_extents_t<int[][3]>, int>::value));
+assert((is_same_v<remove_all_extents_t<int>, int>));
+assert((is_same_v<remove_all_extents_t<int[2]>, int>));
+assert((is_same_v<remove_all_extents_t<int[2][3]>, int>));
+assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
 \end{codeblock}
 \end{example}
 
@@ -16001,12 +15999,12 @@ using PMD = char  S::*;
 the following assertions will hold:
 
 \begin{codeblock}
-static_assert(is_same<result_of_t<S(int)>, short>::value, "Error!");
-static_assert(is_same<result_of_t<S&(unsigned char, int&)>, double>::value, "Error!");
-static_assert(is_same<result_of_t<PF1()>, bool>::value, "Error!");
-static_assert(is_same<result_of_t<PMF(unique_ptr<S>, int)>, void>::value, "Error!");
-static_assert(is_same<result_of_t<PMD(S)>, char&&>::value, "Error!");
-static_assert(is_same<result_of_t<PMD(const S*)>, const char&>::value, "Error!");
+static_assert(is_same_v<result_of_t<S(int)>, short>, "Error!");
+static_assert(is_same_v<result_of_t<S&(unsigned char, int&)>, double>, "Error!");
+static_assert(is_same_v<result_of_t<PF1()>, bool>, "Error!");
+static_assert(is_same_v<result_of_t<PMF(unique_ptr<S>, int)>, void>, "Error!");
+static_assert(is_same_v<result_of_t<PMD(S)>, char&&>, "Error!");
+static_assert(is_same_v<result_of_t<PMD(const S*)>, const char&>, "Error!");
 \end{codeblock}
 \end{example}
 
@@ -16288,7 +16286,7 @@ template <class R1, class R2> struct ratio_equal
 \indexlibrary{\idxcode{ratio_not_equal}}
 \begin{itemdecl}
 template <class R1, class R2> struct ratio_not_equal
-  : bool_constant<!ratio_equal<R1, R2>::value> { };
+  : bool_constant<!ratio_equal_v<R1, R2>> { };
 \end{itemdecl}
 
 \indexlibrary{\idxcode{ratio_less}}
@@ -16309,19 +16307,19 @@ compute this relationship to avoid overflow. If overflow occurs, the program is 
 \indexlibrary{\idxcode{ratio_less_equal}}
 \begin{itemdecl}
 template <class R1, class R2> struct ratio_less_equal
-  : bool_constant<!ratio_less<R2, R1>::value> { };
+  : bool_constant<!ratio_less_v<R2, R1>> { };
 \end{itemdecl}
 
 \indexlibrary{\idxcode{ratio_greater}}
 \begin{itemdecl}
 template <class R1, class R2> struct ratio_greater
-  : bool_constant<ratio_less<R2, R1>::value> { };
+  : bool_constant<ratio_less_v<R2, R1>> { };
 \end{itemdecl}
 
 \indexlibrary{\idxcode{ratio_greater_equal}}
 \begin{itemdecl}
 template <class R1, class R2> struct ratio_greater_equal
-  : bool_constant<!ratio_less<R1, R2>::value> { };
+  : bool_constant<!ratio_less_v<R1, R2>> { };
 \end{itemdecl}
 
 \rSec2[ratio.si]{SI types for \tcode{ratio}}
@@ -16622,13 +16620,13 @@ template <class Rep> struct treat_as_floating_point
 The \tcode{duration} template uses the \tcode{treat_as_floating_point} trait to
 help determine if a \tcode{duration} object can be converted to another
 \tcode{duration} with a different tick \tcode{period}. If
-\tcode{treat_as_floating_point<Rep>::value} is true, then implicit conversions
+\tcode{treat_as_floating_point_v<Rep>} is true, then implicit conversions
 are allowed among \tcode{duration}s. Otherwise, the implicit convertibility
 depends on the tick \tcode{period}s of the \tcode{duration}s.
 \begin{note}
 The intention of this trait is to indicate whether a given class behaves like a floating-point
 type, and thus allows division of one value by another with acceptable loss of precision. If
-\tcode{treat_as_floating_point<Rep>::value} is \tcode{false}, \tcode{Rep} will be treated as
+\tcode{treat_as_floating_point_v<Rep>} is \tcode{false}, \tcode{Rep} will be treated as
 if it behaved like an integral type for the purpose of these conversions.
 \end{note}
 
@@ -16836,8 +16834,8 @@ template <class Rep2>
 resolution unless
 \tcode{Rep2} is implicitly convertible to \tcode{rep} and
 \begin{itemize}
-\item \tcode{treat_as_floating_point<rep>::value} is \tcode{true} or
-\item \tcode{treat_as_floating_point<Rep2>::value} is \tcode{false}.
+\item \tcode{treat_as_floating_point_v<rep>} is \tcode{true} or
+\item \tcode{treat_as_floating_point_v<Rep2>} is \tcode{false}.
 \end{itemize}
 \begin{example}
 \begin{codeblock}
@@ -16863,9 +16861,9 @@ template <class Rep2, class Period2>
 \pnum
 \remarks This constructor shall not participate in overload resolution unless
 no overflow is induced in the conversion and
-\tcode{treat_as_floating_point<rep>::value} is \tcode{true} or both
+\tcode{treat_as_floating_point_v<rep>} is \tcode{true} or both
 \tcode{ratio_divide<Period2, period>::den} is \tcode{1} and
-\tcode{treat_as_floating_point<Rep2>::value} is \tcode{false}. \begin{note} This
+\tcode{treat_as_floating_point_v<Rep2>} is \tcode{false}. \begin{note} This
 requirement prevents implicit truncation error when converting between
 integral-based \tcode{duration} types. Such a construction could easily lead to
 confusion about the value of the \tcode{duration}. \end{note}
@@ -17390,7 +17388,7 @@ template <class ToDuration, class Rep, class Period>
 \pnum
 \remarks This function shall not participate in overload resolution
 unless \tcode{ToDuration} is a specialization of \tcode{duration},
-and \tcode{treat_as_floating_point<typename ToDuration::rep>::value}
+and \tcode{treat_as_floating_point_v<typename ToDuration::rep>}
 is \tcode{false}.
 
 \pnum
@@ -17868,7 +17866,7 @@ template <class ToDuration, class Clock, class Duration>
 \pnum
 \remarks This function shall not participate in overload resolution
 unless \tcode{ToDuration} is a specialization of \tcode{duration}, and
-\tcode{treat_as_floating_point<typename ToDuration::rep>::value} is \tcode{false}.
+\tcode{treat_as_floating_point_v<typename ToDuration::rep>} is \tcode{false}.
 
 \pnum
 \returns \tcode{time_point<Clock, ToDuration>(round<ToDuration>(tp.time_since_epoch()))}.


### PR DESCRIPTION
The library clauses have started to make inconsistent use of the _v
variable templates for traits, in preferene to directly querying
trait::value.  This change set applies that change consistently over
all existing wording, where there is a choice of which form might
be used.  It does not make any changes where the _v variable is not
aviable, or is being defined in terms of the corresponding ::value.

This may want a second pass by someone better able to pay attention
to desirable line-breaking.