### PR TITLE
[diff.basic] Fix format and inexact wording

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -155,7 +155,7 @@ Because \tcode{const} objects may be used as values during translation in
 \Cpp, this feature urges programmers to provide an explicit initializer
 for each \tcode{const} object.
 This feature allows the user to put \tcode{const} objects in headers or source files that are included
-in more than one translation units.
+in more than one translation unit.
 \effect
 Change to semantics of well-defined feature.
 \difficulty

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -152,9 +152,9 @@ The latter is probably rare.
 declared \tcode{extern}, has internal linkage, while in C it would have external linkage
 \rationale
 Because \tcode{const} objects may be used as values during translation in
-\Cpp, this feature urges programmers to provide explicit initializer
+\Cpp, this feature urges programmers to provide an explicit initializer
 for each \tcode{const} object.
-This feature allows the user to put \tcode{const} objects in headers that are included
+This feature allows the user to put \tcode{const} objects in headers or source files that are included
 in more than one translation units.
 \effect
 Change to semantics of well-defined feature.

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -151,11 +151,11 @@ The latter is probably rare.
 \change A name of file scope that is explicitly declared \tcode{const}, and not explicitly
 declared \tcode{extern}, has internal linkage, while in C it would have external linkage
 \rationale
-Because \tcode{const} objects can be used as compile-time values in
+Because \tcode{const} objects may be used as values during translation in
 \Cpp, this feature urges programmers to provide explicit initializer
-values for each \tcode{const}.
-This feature allows the user to put \tcode{const}objects in header files that are included
-in many compilation units.
+for each \tcode{const} object.
+This feature allows the user to put \tcode{const} objects in headers that are included
+in more than one translation units.
 \effect
 Change to semantics of well-defined feature.
 \difficulty

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -154,7 +154,7 @@ declared \tcode{extern}, has internal linkage, while in C it would have external
 Because \tcode{const} objects may be used as values during translation in
 \Cpp, this feature urges programmers to provide an explicit initializer
 for each \tcode{const} object.
-This feature allows the user to put \tcode{const} objects in headers or source files that are included
+This feature allows the user to put \tcode{const} objects in source files that are included
 in more than one translation unit.
 \effect
 Change to semantics of well-defined feature.


### PR DESCRIPTION
Though Annex C is informative, it's better to keep the terminology similar to normative text, which is easier to refer.