### PR TITLE
[gram] Change "syntax" to "grammar".

### DIFF
--- a/source/grammar.tex
+++ b/source/grammar.tex
@@ -5,7 +5,7 @@
 \pnum
 \indextext{grammar}%
 \indextext{summary!syntax}%
-This summary of \Cpp\  syntax is intended to be an aid to comprehension.
+This summary of \Cpp\  grammar is intended to be an aid to comprehension.
 It is not an exact statement of the language.
 In particular, the grammar described here accepts
 a superset of valid \Cpp\  constructs.


### PR DESCRIPTION
Annex A is a summary of grammar, but not only syntactic grammar. Even in contexts without need of grammatical disambiguation, pure syntactically handling (reduction merely based on parsing of the token stream without semantic information) of several context-sensitive constructs (e.g. _constant-expression_ and several kinds of _type-id_) has already been insufficient. Since the remained difference is acknowledged in the same paragraph, I think my change is also editorial. (On the contrary, ISO C may have more problems because it uses "syntax" everywhere.)

However, I have no idea to change `\indextext{summary!syntax}` ...
