### PR TITLE
[valarray.members] add valarray index entry for named member functions

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -7429,6 +7429,7 @@ void swap(valarray& v) noexcept;
 \end{itemdescr}
 
 \indexlibrary{\idxcode{length}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{valarray}!\idxcode{length}}%
 \begin{itemdecl}
 size_t size() const;
 \end{itemdecl}
@@ -7442,6 +7443,7 @@ size_t size() const;
 \end{itemdescr}
 
 \indexlibrary{\idxcode{sum}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{valarray}!\idxcode{sum}}%
 \begin{itemdecl}
 T sum() const;
 \end{itemdecl}
@@ -7466,6 +7468,7 @@ all other elements of the array in an unspecified order.%
 \end{itemdescr}
 
 \indexlibrary{\idxcode{min}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{valarray}!\idxcode{min}}%
 \begin{itemdecl}
 T min() const;
 \end{itemdecl}
@@ -7483,6 +7486,7 @@ lengths, the determination is made using
 \end{itemdescr}
 
 \indexlibrary{\idxcode{max}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{valarray}!\idxcode{max}}%
 \begin{itemdecl}
 T max() const;
 \end{itemdecl}
@@ -7500,6 +7504,7 @@ lengths, the determination is made using
 \end{itemdescr}
 
 \indexlibrary{\idxcode{shift}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{valarray}!\idxcode{shift}}%
 \begin{itemdecl}
 valarray shift(int n) const;
 \end{itemdecl}
@@ -7533,6 +7538,7 @@ of the first element of the argument; etc.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{cshift}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{valarray}!\idxcode{cshift}}%
 \begin{itemdecl}
 valarray cshift(int n) const;
 \end{itemdecl}
@@ -7547,6 +7553,7 @@ that is a circular shift of \tcode{*this}. If element zero is taken as the leftm
 \end{itemdescr}
 
 \indexlibrary{\idxcode{apply}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{valarray}!\idxcode{apply}}%
 \begin{itemdecl}
 valarray apply(T func(T)) const;
 valarray apply(T func(const T&)) const;
@@ -7561,6 +7568,7 @@ corresponding element of the array.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{resize}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{valarray}!\idxcode{resize}}%
 \begin{itemdecl}
 void resize(size_t sz, T c = T());
 \end{itemdecl}


### PR DESCRIPTION
The index currently lists the named member-functions of valarray as
if they were free functions - this adds the corresponding entry under
the valarray listing in the index, alongside the existing entries for
the many operator functions.