### PR TITLE
Make universal-character-name \grammarterm'd

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -69,11 +69,11 @@ characters}.
 Any
 source file character not in the basic source character
 set~(\ref{lex.charset}) is replaced by the
-\indextext{universal character name}universal-character-name that
+\indextext{universal character name}\grammarterm{universal-character-name} that
 designates that character. (An implementation may use any internal
 encoding, so long as an actual extended character encountered in the
 source file, and the same extended character expressed in the source
-file as a universal-character-name (e.g., using the \tcode{\textbackslash
+file as a \grammarterm{universal-character-name} (e.g., using the \tcode{\textbackslash
 uXXXX} notation), are handled equivalently
 except where this replacement is reverted in a raw string literal.)
 
@@ -85,7 +85,7 @@ backslash on any physical source line shall be eligible for being part
 of such a splice.
 Except for splices reverted in a raw string literal, if a splice results in
 a character sequence that matches the
-syntax of a universal-character-name, the behavior is
+syntax of a \grammarterm{universal-character-name}, the behavior is
 undefined. A source file that is not empty and that does not end in a new-line
 character, or that ends in a new-line character immediately preceded by a
 backslash character before any such splicing takes place,
@@ -116,14 +116,14 @@ directive.
 \item Preprocessing directives are executed, macro invocations are
 expanded, and \tcode{_Pragma} unary operator expressions are executed.
 If a character sequence that matches the syntax of a
-universal-character-name is produced by token
+\grammarterm{universal-character-name} is produced by token
 concatenation~(\ref{cpp.concat}), the behavior is undefined. A
 \tcode{\#include} preprocessing directive causes the named header or
 source file to be processed from phase 1 through phase 4, recursively.
 All preprocessing directives are then deleted.
 
 \item Each source character set member in a character literal or a string
-literal, as well as each escape sequence and universal-character-name in a
+literal, as well as each escape sequence and \grammarterm{universal-character-name} in a
 character literal or a non-raw string literal, is converted to the corresponding
 member of the execution character set~(\ref{lex.ccon}, \ref{lex.string}); if
 there is no corresponding member, it is converted to an \impldef{converting
@@ -211,22 +211,22 @@ other characters.
     \terminal{\textbackslash U} hex-quad hex-quad
 \end{bnf}
 
-The character designated by the universal-character-name \tcode{\textbackslash
+The character designated by the \grammarterm{universal-character-name} \tcode{\textbackslash
 UNNNNNNNN} is that character whose character short name in ISO/IEC 10646 is
-\tcode{NNNNNNNN}; the character designated by the universal-character-name
+\tcode{NNNNNNNN}; the character designated by the \grammarterm{universal-character-name}
 \tcode{\textbackslash uNNNN} is that character whose character short name in
 ISO/IEC 10646 is \tcode{0000NNNN}. If the hexadecimal value for a
-universal-character-name corresponds to a surrogate code point (in the
+\grammarterm{universal-character-name} corresponds to a surrogate code point (in the
 range 0xD800--0xDFFF, inclusive), the program is ill-formed. Additionally, if
-the hexadecimal value for a universal-character-name outside
+the hexadecimal value for a \grammarterm{universal-character-name} outside
 the \grammarterm{c-char-sequence}, \grammarterm{s-char-sequence}, or
 \grammarterm{r-char-sequence} of
 a character or
 string literal corresponds to a control character (in either of the
 ranges 0x00--0x1F or 0x7F--0x9F, both inclusive) or to a character in the basic
-source character set, the program is ill-formed.\footnote{A sequence of characters resembling a universal-character-name in an
+source character set, the program is ill-formed.\footnote{A sequence of characters resembling a \grammarterm{universal-character-name} in an
 \grammarterm{r-char-sequence}~(\ref{lex.string}) does not form a
-universal-character-name.}
+\grammarterm{universal-character-name}.}
 
 \pnum
 The \term{basic execution character set} and the \term{basic
@@ -300,7 +300,7 @@ given character:
 and initial double quote of a raw string literal, such as \tcode{R"}, the next preprocessing
 token shall be a raw string literal. Between the initial and final
 double quote characters of the raw string, any transformations performed in phases
-1 and 2 (universal-character-names and line splicing) are reverted; this reversion
+1 and 2 (\grammarterm{universal-character-name}{s} and line splicing) are reverted; this reversion
 shall apply before any \grammarterm{d-char}, \grammarterm{r-char}, or delimiting
 parenthesis is identified. The raw string literal is defined as the shortest sequence
 of characters that matches the raw-string pattern
@@ -546,18 +546,18 @@ token.%
 \indextext{name!length~of}%
 \indextext{name}%
 An identifier is an arbitrarily long sequence of letters and digits.
-Each universal-character-name in an identifier shall designate a
+Each \grammarterm{universal-character-name} in an identifier shall designate a
 character whose encoding in ISO 10646 falls into one of the ranges
 specified in~\ref{charname.allowed}.
-The initial element shall not be a universal-character-name
+The initial element shall not be a \grammarterm{universal-character-name}
 designating a character whose encoding falls into one of the ranges
 specified in~\ref{charname.disallowed}.
 Upper- and lower-case letters are
 different. All characters are significant.\footnote{On systems in which linkers cannot accept extended
-characters, an encoding of the universal-character-name may be used in
+characters, an encoding of the \grammarterm{universal-character-name} may be used in
 forming valid external identifiers. For example, some otherwise unused
 character or sequence of characters may be used to encode the
-\tcode{\textbackslash u} in a universal-character-name. Extended
+\tcode{\textbackslash u} in a \grammarterm{universal-character-name}. Extended
 characters may produce a long external identifier, but \Cpp does not
 place a translation limit on significant characters for external
 identifiers. In \Cpp, upper- and lower-case letters are considered
@@ -1198,14 +1198,14 @@ the program is ill-formed.
 \end{note}
 
 \pnum
-A universal-character-name is translated to the encoding, in the appropriate
+A \grammarterm{universal-character-name} is translated to the encoding, in the appropriate
 execution character set, of the character named. If there is no such
-encoding, the universal-character-name is translated to an
+encoding, the \grammarterm{universal-character-name} is translated to an
 \impldef{encoding of universal character name not in execution character set} encoding.
-\begin{note} In translation phase 1, a universal-character-name is introduced whenever an
+\begin{note} In translation phase 1, a \grammarterm{universal-character-name} is introduced whenever an
 actual extended
 character is encountered in the source text. Therefore, all extended
-characters are described in terms of universal-character-names. However,
+characters are described in terms of \grammarterm{universal-character-name}{s}. However,
 the actual compiler implementation may use its own native character set,
 so long as the same results are obtained. \end{note}
 
@@ -1580,30 +1580,30 @@ string literal so that programs that scan a string can find its end.
 
 \pnum
 \indextext{encoding!multibyte}%
-Escape sequences and universal-character-names in non-raw string literals
+Escape sequences and \grammarterm{universal-character-name}{s} in non-raw string literals
 have the same meaning as in character literals~(\ref{lex.ccon}), except that
 the single quote \tcode{'} is representable either by itself or by the escape sequence
 \tcode{\textbackslash'}, and the double quote \tcode{"} shall be preceded by a
 \tcode{\textbackslash},
-and except that a universal-character-name in a
+and except that a \grammarterm{universal-character-name} in a
 \tcode{char16_t} string literal may yield a surrogate pair.
 \indextext{string!\idxcode{sizeof}}%
-In a narrow string literal, a universal-character-name may map to more
+In a narrow string literal, a \grammarterm{universal-character-name} may map to more
 than one \tcode{char} element due to \term{multibyte encoding}. The
 size of a \tcode{char32_t} or wide string literal is the total number of
-escape sequences, universal-character-names, and other characters, plus
+escape sequences, \grammarterm{universal-character-name}{s}, and other characters, plus
 one for the terminating \tcode{U'\textbackslash 0'} or
 \tcode{L'\textbackslash 0'}. The size of a \tcode{char16_t} string
 literal is the total number of escape sequences,
-universal-character-names, and other characters, plus one for each
+\grammarterm{universal-character-name}{s}, and other characters, plus one for each
 character requiring a surrogate pair, plus one for the terminating
 \tcode{u'\textbackslash 0'}. \begin{note} The size of a \tcode{char16_t}
 string literal is the number of code units, not the number of
 characters. \end{note} Within \tcode{char32_t} and \tcode{char16_t}
-literals, any universal-character-names shall be within the range
+literals, any \grammarterm{universal-character-name}{s} shall be within the range
 \tcode{0x0} to \tcode{0x10FFFF}. The size of a narrow string literal is
 the total number of escape sequences and other characters, plus at least
-one for the multibyte encoding of each universal-character-name, plus
+one for the multibyte encoding of each \grammarterm{universal-character-name}, plus
 one for the terminating \tcode{'\textbackslash 0'}.
 
 \pnum


### PR DESCRIPTION
Fixes #296