### PR TITLE
[input.output,strings,utilities] Don't format informative 'see below' as code

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -15009,8 +15009,8 @@ namespace std {
   intmax_t wcstoimax(const wchar_t* nptr, wchar_t** endptr, int base);
   uintmax_t wcstoumax(const wchar_t* nptr, wchar_t** endptr, int base);
 
-  intmax_t abs(intmax_t);  // optional, \seebelow
-  imaxdiv_t div(intmax_t, intmax_t);  // optional, \seebelow
+  intmax_t abs(intmax_t);  // optional, see below
+  imaxdiv_t div(intmax_t, intmax_t);  // optional, see below
 }
 
 #define PRIdN @\seebelow@

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -4812,7 +4812,7 @@ namespace std {
   template<class charT, class traits>
     constexpr bool operator>=(basic_string_view<charT, traits> x,
                               basic_string_view<charT, traits> y) noexcept;
-  // \seebelow, sufficient additional overloads of comparison functions
+  // see \ref{string.view.comparison}, sufficient additional overloads of comparison functions
 
   // \ref{string.view.io}, inserters and extractors
   template<class charT, class traits>

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16139,8 +16139,8 @@ namespace std {
   template <class R1, class R2> struct ratio_greater_equal;
 
   // \ref{ratio.si}, convenience SI typedefs
-  using yocto = ratio<1, 1'000'000'000'000'000'000'000'000>;  // \seebelow
-  using zepto = ratio<1,     1'000'000'000'000'000'000'000>;  // \seebelow
+  using yocto = ratio<1, 1'000'000'000'000'000'000'000'000>;  // see below
+  using zepto = ratio<1,     1'000'000'000'000'000'000'000>;  // see below
   using atto  = ratio<1,         1'000'000'000'000'000'000>;
   using femto = ratio<1,             1'000'000'000'000'000>;
   using pico  = ratio<1,                 1'000'000'000'000>;
@@ -16157,8 +16157,8 @@ namespace std {
   using tera  = ratio<                1'000'000'000'000, 1>;
   using peta  = ratio<            1'000'000'000'000'000, 1>;
   using exa   = ratio<        1'000'000'000'000'000'000, 1>;
-  using zetta = ratio<    1'000'000'000'000'000'000'000, 1>;  // \seebelow
-  using yotta = ratio<1'000'000'000'000'000'000'000'000, 1>;  // \seebelow
+  using zetta = ratio<    1'000'000'000'000'000'000'000, 1>;  // see below
+  using yotta = ratio<1'000'000'000'000'000'000'000'000, 1>;  // see below
 
   // \ref{ratio.arithmetic}, ratio comparison
   template <class R1, class R2> constexpr bool ratio_equal_v


### PR DESCRIPTION
Fixes Issue #805.