### PR TITLE
[macros,gram] Simplify definition of non-copying grammar environments

### DIFF
--- a/source/grammar.tex
+++ b/source/grammar.tex
@@ -25,35 +25,35 @@ class~(Clause \ref{class}), enumeration~(\ref{dcl.enum}), and
 \tcode{template}~(Clause \ref{temp})
 declarations.
 
-\begin{bnf}
+\begin{ncbnf}
 typedef-name:\br
 	identifier
-\end{bnf}
+\end{ncbnf}
 
-\begin{bnf}
+\begin{ncbnf}
 namespace-name:\br
 	identifier\br
 	namespace-alias
 
 namespace-alias:\br
 	identifier
-\end{bnf}
+\end{ncbnf}
 
-\begin{bnf}
+\begin{ncbnf}
 class-name:\br
 	identifier\br
 	simple-template-id
-\end{bnf}
+\end{ncbnf}
 
-\begin{bnf}
+\begin{ncbnf}
 enum-name:\br
 	identifier
-\end{bnf}
+\end{ncbnf}
 
-\begin{bnf}
+\begin{ncbnf}
 template-name:\br
 	identifier
-\end{bnf}
+\end{ncbnf}
 
 Note that a
 \grammarterm{typedef-name}\ 

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -416,29 +416,12 @@
 }
 
 % non-copied versions of bnf environments
-\newenvironment{ncbnftab}
-{
- \begin{bnftab}
-}
-{
- \end{bnftab}
-}
-
-\newenvironment{ncsimplebnf}
-{
- \begin{simplebnf}
-}
-{
- \end{simplebnf}
-}
-
-\newenvironment{ncbnf}
-{
- \begin{bnf}
-}
-{
- \end{bnf}
-}
+\let\ncbnftab\bnftab
+\let\endncbnftab\endbnftab
+\let\ncsimplebnf\simplebnf
+\let\endncsimplebnf\endsimplebnf
+\let\ncbnf\bnf
+\let\endncbnf\endbnf
 
 %%--------------------------------------------------
 %% Drawing environment

--- a/tools/grambase.tex
+++ b/tools/grambase.tex
@@ -25,35 +25,35 @@ class~(Clause \ref{class}), enumeration~(\ref{dcl.enum}), and
 \tcode{template}~(Clause \ref{temp})
 declarations.
 
-\begin{bnf}
+\begin{ncbnf}
 typedef-name:\br
 	identifier
-\end{bnf}
+\end{ncbnf}
 
-\begin{bnf}
+\begin{ncbnf}
 namespace-name:\br
 	identifier\br
 	namespace-alias
 
 namespace-alias:\br
 	identifier
-\end{bnf}
+\end{ncbnf}
 
-\begin{bnf}
+\begin{ncbnf}
 class-name:\br
 	identifier\br
 	simple-template-id
-\end{bnf}
+\end{ncbnf}
 
-\begin{bnf}
+\begin{ncbnf}
 enum-name:\br
 	identifier
-\end{bnf}
+\end{ncbnf}
 
-\begin{bnf}
+\begin{ncbnf}
 template-name:\br
 	identifier
-\end{bnf}
+\end{ncbnf}
 
 Note that a
 \grammarterm{typedef-name}\ 


### PR DESCRIPTION
This avoids having one environment depend on another, which makes extraction impossible.