### PR TITLE
[func.default.traits] remove crossref to [unord]

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -14392,7 +14392,7 @@ namespace std {
 The class template \tcode{default_order} provides a trait that users can
 specialize for user-defined types to provide a strict weak ordering for that
 type, which the library can use where a default strict weak order is needed.
-For example, the associative containers (\ref{associative}, \ref{unord}) and
+For example, the associative containers (\ref{associative}) and
 \tcode{priority_queue} (\ref{priority.queue}) use this trait.
 
 \pnum


### PR DESCRIPTION
The *unordered* associative containers do not use default_*order*.