### PR TITLE
[clause 27] Index all member functions in clause 27

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -936,6 +936,7 @@ Constructs an object of class
 \rSec4[ios::fmtflags]{Type \tcode{ios_base::fmtflags}}
 
 \indexlibrary{\idxcode{fmtflags}!\idxcode{ios_base}}%
+\indexlibrary{\idxcode{ios_base}!\idxcode{fmtflags}}%
 \begin{itemdecl}
 using fmtflags = @\textit{T1}@;
 \end{itemdecl}
@@ -998,8 +999,8 @@ also defines the constants indicated in Table~\ref{tab:iostreams.fmtflags.consta
 
 \rSec4[ios::iostate]{Type \tcode{ios_base::iostate}}
 
-\indexlibrary{\idxcode{iostate}!\idxcode{ios_base}}%
 \indexlibrary{\idxcode{ios_base}!\idxcode{iostate}}%
+\indexlibrary{\idxcode{iostate}!\idxcode{ios_base}}%
 \begin{itemdecl}
 using iostate = @\textit{T2}@;
 \end{itemdecl}
@@ -1036,6 +1037,7 @@ the value zero.
 \rSec4[ios::openmode]{Type \tcode{ios_base::openmode}}
 
 \indexlibrary{\idxcode{openmode}!\idxcode{ios_base}}%
+\indexlibrary{\idxcode{ios_base}!\idxcode{openmode}}%
 \begin{itemdecl}
 using openmode = @\textit{T3}@;
 \end{itemdecl}
@@ -1066,6 +1068,7 @@ It contains the elements indicated in Table~\ref{tab:iostreams.openmode.effects}
 \rSec4[ios::seekdir]{Type \tcode{ios_base::seekdir}}
 
 \indexlibrary{\idxcode{seekdir}!\idxcode{ios_base}}%
+\indexlibrary{\idxcode{ios_base}!\idxcode{seekdir}}%
 \begin{itemdecl}
 using seekdir = @\textit{T4}@;
 \end{itemdecl}
@@ -1163,6 +1166,7 @@ calls
 \rSec3[fmtflags.state]{\tcode{ios_base} state functions}
 
 \indexlibrary{\idxcode{flags}!\idxcode{ios_base}}%
+\indexlibrary{\idxcode{ios_base}!\idxcode{flags}}%
 \begin{itemdecl}
 fmtflags flags() const;
 \end{itemdecl}
@@ -1173,8 +1177,8 @@ fmtflags flags() const;
 The format control information for both input and output.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{fmtflags}!\idxcode{ios_base}}%
 \indexlibrary{\idxcode{ios_base}!\idxcode{fmtflags}}%
+\indexlibrary{\idxcode{fmtflags}!\idxcode{ios_base}}%
 \begin{itemdecl}
 fmtflags flags(fmtflags fmtfl);
 \end{itemdecl}
@@ -1191,6 +1195,7 @@ The previous value of
 \end{itemdescr}
 
 \indexlibrary{\idxcode{setf}!\idxcode{ios_base}}%
+\indexlibrary{\idxcode{ios_base}!\idxcode{setf}}%
 \begin{itemdecl}
 fmtflags setf(fmtflags fmtfl);
 \end{itemdecl}
@@ -1230,6 +1235,7 @@ The previous value of
 \end{itemdescr}
 
 \indexlibrary{\idxcode{unsetf}!\idxcode{ios_base}}%
+\indexlibrary{\idxcode{ios_base}!\idxcode{unsetf}}%
 \begin{itemdecl}
 void unsetf(fmtflags mask);
 \end{itemdecl}
@@ -1242,6 +1248,7 @@ Clears \tcode{mask} in
 \end{itemdescr}
 
 \indexlibrary{\idxcode{precision}!\idxcode{ios_base}}%
+\indexlibrary{\idxcode{ios_base}!\idxcode{precision}}%
 \begin{itemdecl}
 streamsize precision() const;
 \end{itemdecl}
@@ -1271,6 +1278,7 @@ The previous value of
 \end{itemdescr}
 
 \indexlibrary{\idxcode{width}!\idxcode{ios_base}}%
+\indexlibrary{\idxcode{ios_base}!\idxcode{width}}%
 \begin{itemdecl}
 streamsize width() const;
 \end{itemdecl}
@@ -1282,8 +1290,8 @@ The minimum field width (number of characters) to generate on certain output
 conversions.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{streamsize}!\idxcode{ios_base}}%
-\indexlibrary{\idxcode{ios_base}!\idxcode{streamsize}}%
+\indexlibrary{\idxcode{width}!\idxcode{ios_base}}%
+\indexlibrary{\idxcode{ios_base}!\idxcode{width}}%
 \begin{itemdecl}
 streamsize width(streamsize wide);
 \end{itemdecl}
@@ -1302,6 +1310,7 @@ The previous value of
 \rSec3[ios.base.locales]{\tcode{ios_base} functions}
 
 \indexlibrary{\idxcode{imbue}!\idxcode{ios_base}}%
+\indexlibrary{\idxcode{ios_base}!\idxcode{imbue}}%
 \begin{itemdecl}
 locale imbue(const locale& loc);
 \end{itemdecl}
@@ -1331,6 +1340,7 @@ The previous value of
 \end{itemdescr}
 
 \indexlibrary{\idxcode{getloc}!\idxcode{ios_base}}%
+\indexlibrary{\idxcode{ios_base}!\idxcode{getloc}}%
 \begin{itemdecl}
 locale getloc() const;
 \end{itemdecl}
@@ -1348,6 +1358,7 @@ perform locale-dependent input and output operations.
 \rSec3[ios.members.static]{\tcode{ios_base} static members}
 
 \indexlibrary{\idxcode{sync_with_stdio}!\idxcode{ios_base}}%
+\indexlibrary{\idxcode{ios_base}!\idxcode{sync_with_stdio}}%
 \begin{itemdecl}
 bool sync_with_stdio(bool sync = true);
 \end{itemdecl}
@@ -1410,6 +1421,7 @@ buffer.
 \rSec3[ios.base.storage]{\tcode{ios_base} storage functions}
 
 \indexlibrary{\idxcode{xalloc}!\idxcode{ios_base}}%
+\indexlibrary{\idxcode{ios_base}!\idxcode{xalloc}}%
 \begin{itemdecl}
 static int xalloc();
 \end{itemdecl}
@@ -1427,6 +1439,7 @@ race~(\ref{intro.multithread}).
 \end{itemdescr}
 
 \indexlibrary{\idxcode{iword}!\idxcode{ios_base}}%
+\indexlibrary{\idxcode{ios_base}!\idxcode{iword}}%
 \begin{itemdecl}
 long& iword(int idx);
 \end{itemdecl}
@@ -1473,6 +1486,7 @@ initialized to 0.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{pword}!\idxcode{ios_base}}%
+\indexlibrary{\idxcode{ios_base}!\idxcode{pword}}%
 \begin{itemdecl}
 void*& pword(int idx);
 \end{itemdecl}
@@ -1525,6 +1539,7 @@ for the same object, the earlier return value may no longer be valid.
 \rSec3[ios.base.callback]{\tcode{ios_base} callbacks}
 
 \indexlibrary{\idxcode{register_callback}!\idxcode{ios_base}}%
+\indexlibrary{\idxcode{ios_base}!\idxcode{register_callback}}%
 \begin{itemdecl}
 void register_callback(event_callback fn, int index);
 \end{itemdecl}
@@ -1617,6 +1632,7 @@ namespace std {
 \rSec3[fpos.members]{\tcode{fpos} members}
 
 \indexlibrary{\idxcode{state}!\idxcode{fpos}}%
+\indexlibrary{\idxcode{fpos}!\idxcode{state}}%
 \begin{itemdecl}
 void state(stateT s);
 \end{itemdecl}
@@ -1892,6 +1908,7 @@ The postconditions of this function are indicated in Table~\ref{tab:iostreams.ba
 \rSec3[basic.ios.members]{Member functions}
 
 \indexlibrary{\idxcode{tie}!\idxcode{basic_ios}}%
+\indexlibrary{\idxcode{basic_ios}!\idxcode{tie}}%
 \begin{itemdecl}
 basic_ostream<charT, traits>* tie() const;
 \end{itemdecl}
@@ -1928,6 +1945,7 @@ The previous value of
 \end{itemdescr}
 
 \indexlibrary{\idxcode{rdbuf}!\idxcode{basic_ios}}%
+\indexlibrary{\idxcode{basic_ios}!\idxcode{rdbuf}}%
 \begin{itemdecl}
 basic_streambuf<charT, traits>* rdbuf() const;
 \end{itemdecl}
@@ -1963,6 +1981,7 @@ The previous value of
 \end{itemdescr}
 
 \indexlibrary{\idxcode{imbue}!\idxcode{basic_ios}}%
+\indexlibrary{\idxcode{basic_ios}!\idxcode{imbue}}%
 \begin{itemdecl}
 locale imbue(const locale& loc);
 \end{itemdecl}
@@ -1985,6 +2004,7 @@ The prior value of
 \end{itemdescr}
 
 \indexlibrary{\idxcode{narrow}!\idxcode{basic_ios}}%
+\indexlibrary{\idxcode{basic_ios}!\idxcode{narrow}}%
 \begin{itemdecl}
 char narrow(char_type c, char dfault) const;
 \end{itemdecl}
@@ -1996,6 +2016,7 @@ char narrow(char_type c, char dfault) const;
 \end{itemdescr}
 
 \indexlibrary{\idxcode{widen}!\idxcode{basic_ios}}%
+\indexlibrary{\idxcode{basic_ios}!\idxcode{widen}}%
 \begin{itemdecl}
 char_type widen(char c) const;
 \end{itemdecl}
@@ -2007,6 +2028,7 @@ char_type widen(char c) const;
 \end{itemdescr}
 
 \indexlibrary{\idxcode{fill}!\idxcode{basic_ios}}%
+\indexlibrary{\idxcode{basic_ios}!\idxcode{fill}}%
 \begin{itemdecl}
 char_type fill() const;
 \end{itemdecl}
@@ -2036,6 +2058,7 @@ The previous value of
 \end{itemdescr}
 
 \indexlibrary{\idxcode{copyfmt}!\idxcode{basic_ios}}%
+\indexlibrary{\idxcode{basic_ios}!\idxcode{copyfmt}}%
 \begin{itemdecl}
 basic_ios& copyfmt(const basic_ios& rhs);
 \end{itemdecl}
@@ -2171,6 +2194,7 @@ pointed to by \tcode{sb} with this stream without calling
 \rSec3[iostate.flags]{\tcode{basic_ios} flags functions}
 
 \indexlibrary{\idxcode{operator bool}!\idxcode{basic_ios}}%
+\indexlibrary{\idxcode{basic_ios}!\idxcode{operator bool}}%
 \begin{itemdecl}
 explicit operator bool() const;
 \end{itemdecl}
@@ -2181,6 +2205,7 @@ explicit operator bool() const;
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator"!}!\idxcode{basic_ios}}%
+\indexlibrary{\idxcode{basic_ios}!\idxcode{operator"!}}%
 \begin{itemdecl}
 bool operator!() const;
 \end{itemdecl}
@@ -2192,6 +2217,7 @@ bool operator!() const;
 \end{itemdescr}
 
 \indexlibrary{\idxcode{rdstate}!\idxcode{basic_ios}}%
+\indexlibrary{\idxcode{basic_ios}!\idxcode{rdstate}}%
 \begin{itemdecl}
 iostate rdstate() const;
 \end{itemdecl}
@@ -2203,6 +2229,7 @@ The error state of the stream buffer.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{clear}!\idxcode{basic_ios}}%
+\indexlibrary{\idxcode{basic_ios}!\idxcode{clear}}%
 \begin{itemdecl}
 void clear(iostate state = goodbit);
 \end{itemdecl}
@@ -2230,6 +2257,7 @@ argument values.%
 \end{itemdescr}
 
 \indexlibrary{\idxcode{setstate}!\idxcode{basic_ios}}%
+\indexlibrary{\idxcode{basic_ios}!\idxcode{setstate}}%
 \begin{itemdecl}
 void setstate(iostate state);
 \end{itemdecl}
@@ -2244,6 +2272,7 @@ Calls
 \end{itemdescr}
 
 \indexlibrary{\idxcode{good}!\idxcode{basic_ios}}%
+\indexlibrary{\idxcode{basic_ios}!\idxcode{good}}%
 \begin{itemdecl}
 bool good() const;
 \end{itemdecl}
@@ -2255,6 +2284,7 @@ bool good() const;
 \end{itemdescr}
 
 \indexlibrary{\idxcode{eof}!\idxcode{basic_ios}}%
+\indexlibrary{\idxcode{basic_ios}!\idxcode{eof}}%
 \begin{itemdecl}
 bool eof() const;
 \end{itemdecl}
@@ -2270,6 +2300,7 @@ is set in
 \end{itemdescr}
 
 \indexlibrary{\idxcode{fail}!\idxcode{basic_ios}}%
+\indexlibrary{\idxcode{basic_ios}!\idxcode{fail}}%
 \begin{itemdecl}
 bool fail() const;
 \end{itemdecl}
@@ -2291,6 +2322,7 @@ is historical practice.}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bad}!\idxcode{basic_ios}}%
+\indexlibrary{\idxcode{basic_ios}!\idxcode{bad}}%
 \begin{itemdecl}
 bool bad() const;
 \end{itemdecl}
@@ -2306,6 +2338,7 @@ is set in
 \end{itemdescr}
 
 \indexlibrary{\idxcode{exceptions}!\idxcode{basic_ios}}%
+\indexlibrary{\idxcode{basic_ios}!\idxcode{exceptions}}%
 \begin{itemdecl}
 iostate exceptions() const;
 \end{itemdecl}
@@ -3092,6 +3125,7 @@ None.
 \rSec4[streambuf.locales]{Locales}
 
 \indexlibrary{\idxcode{pubimbue}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{pubimbue}}%
 \begin{itemdecl}
 locale pubimbue(const locale& loc);
 \end{itemdecl}
@@ -3113,6 +3147,7 @@ Previous value of
 \end{itemdescr}
 
 \indexlibrary{\idxcode{getloc}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{getloc}}%
 \begin{itemdecl}
 locale getloc() const;
 \end{itemdecl}
@@ -3138,6 +3173,7 @@ then it returns the previous value.
 \rSec4[streambuf.buffer]{Buffer management and positioning}
 
 \indexlibrary{\idxcode{pubsetbuf}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{pubsetbuf}}%
 \begin{itemdecl}
 basic_streambuf* pubsetbuf(char_type* s, streamsize n);
 \end{itemdecl}
@@ -3149,6 +3185,7 @@ basic_streambuf* pubsetbuf(char_type* s, streamsize n);
 \end{itemdescr}
 
 \indexlibrary{\idxcode{pubseekoff}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{pubseekoff}}%
 \begin{itemdecl}
 pos_type pubseekoff(off_type off, ios_base::seekdir way,
                     ios_base::openmode which
@@ -3162,6 +3199,7 @@ pos_type pubseekoff(off_type off, ios_base::seekdir way,
 \end{itemdescr}
 
 \indexlibrary{\idxcode{pubseekpos}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{pubseekpos}}%
 \begin{itemdecl}
 pos_type pubseekpos(pos_type sp,
                     ios_base::openmode which
@@ -3175,6 +3213,7 @@ pos_type pubseekpos(pos_type sp,
 \end{itemdescr}
 
 \indexlibrary{\idxcode{pubsync}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{pubsync}}%
 \begin{itemdecl}
 int pubsync();
 \end{itemdecl}
@@ -3188,6 +3227,7 @@ int pubsync();
 \rSec4[streambuf.pub.get]{Get area}
 
 \indexlibrary{\idxcode{in_avail}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{in_avail}}%
 \begin{itemdecl}
 streamsize in_avail();
 \end{itemdecl}
@@ -3202,6 +3242,7 @@ Otherwise returns
 \end{itemdescr}
 
 \indexlibrary{\idxcode{snextc}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{snextc}}%
 \begin{itemdecl}
 int_type snextc();
 \end{itemdecl}
@@ -3223,6 +3264,7 @@ Otherwise, returns
 \end{itemdescr}
 
 \indexlibrary{\idxcode{sbumpc}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{sbumpc}}%
 \begin{itemdecl}
 int_type sbumpc();
 \end{itemdecl}
@@ -3239,6 +3281,7 @@ and increments the next pointer for the input sequence.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{sgetc}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{sgetc}}%
 \begin{itemdecl}
 int_type sgetc();
 \end{itemdecl}
@@ -3254,6 +3297,7 @@ Otherwise, returns
 \end{itemdescr}
 
 \indexlibrary{\idxcode{sgetn}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{sgetn}}%
 \begin{itemdecl}
 streamsize sgetn(char_type* s, streamsize n);
 \end{itemdecl}
@@ -3267,6 +3311,7 @@ streamsize sgetn(char_type* s, streamsize n);
 \rSec4[streambuf.pub.pback]{Putback}
 
 \indexlibrary{\idxcode{sputbackc}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{sputbackc}}%
 \begin{itemdecl}
 int_type sputbackc(char_type c);
 \end{itemdecl}
@@ -3285,6 +3330,7 @@ returns
 \end{itemdescr}
 
 \indexlibrary{\idxcode{sungetc}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{sungetc}}%
 \begin{itemdecl}
 int_type sungetc();
 \end{itemdecl}
@@ -3303,6 +3349,7 @@ returns
 \rSec4[streambuf.pub.put]{Put area}
 
 \indexlibrary{\idxcode{sputc}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{sputc}}%
 \begin{itemdecl}
 int_type sputc(char_type c);
 \end{itemdecl}
@@ -3320,6 +3367,7 @@ returns
 \end{itemdescr}
 
 \indexlibrary{\idxcode{sputn}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{sputn}}%
 \begin{itemdecl}
 streamsize sputn(const char_type* s, streamsize n);
 \end{itemdecl}
@@ -3377,6 +3425,7 @@ and \tcode{*this}.
 \rSec4[streambuf.get.area]{Get area access}
 
 \indexlibrary{\idxcode{eback}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{eback}}%
 \begin{itemdecl}
 char_type* eback() const;
 \end{itemdecl}
@@ -3388,6 +3437,7 @@ The beginning pointer for the input sequence.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{gptr}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{gptr}}%
 \begin{itemdecl}
 char_type* gptr() const;
 \end{itemdecl}
@@ -3399,6 +3449,7 @@ The next pointer for the input sequence.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{egptr}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{egptr}}%
 \begin{itemdecl}
 char_type* egptr() const;
 \end{itemdecl}
@@ -3410,6 +3461,7 @@ The end pointer for the input sequence.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{gbump}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{gbump}}%
 \begin{itemdecl}
 void gbump(int n);
 \end{itemdecl}
@@ -3421,6 +3473,7 @@ Adds \tcode{n} to the next pointer for the input sequence.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{setg}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{setg}}%
 \begin{itemdecl}
 void setg(char_type* gbeg, char_type* gnext, char_type* gend);
 \end{itemdecl}
@@ -3437,6 +3490,7 @@ and
 \rSec4[streambuf.put.area]{Put area access}
 
 \indexlibrary{\idxcode{pbase}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{pbase}}%
 \begin{itemdecl}
 char_type* pbase() const;
 \end{itemdecl}
@@ -3448,6 +3502,7 @@ The beginning pointer for the output sequence.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{pptr}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{pptr}}%
 \begin{itemdecl}
 char_type* pptr() const;
 \end{itemdecl}
@@ -3459,6 +3514,7 @@ The next pointer for the output sequence.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{epptr}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{epptr}}%
 \begin{itemdecl}
 char_type* epptr() const;
 \end{itemdecl}
@@ -3470,6 +3526,7 @@ The end pointer for the output sequence.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{pbump}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{pbump}}%
 \begin{itemdecl}
 void pbump(int n);
 \end{itemdecl}
@@ -3481,6 +3538,7 @@ Adds \tcode{n} to the next pointer for the output sequence.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{setp}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{setp}}%
 \begin{itemdecl}
 void setp(char_type* pbeg, char_type* pend);
 \end{itemdecl}
@@ -3499,6 +3557,7 @@ and
 \rSec4[streambuf.virt.locales]{Locales}
 
 \indexlibrary{\idxcode{imbue}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{imbue}}%
 \begin{itemdecl}
 void imbue(const locale&);
 \end{itemdecl}
@@ -3524,6 +3583,7 @@ Does nothing.
 \rSec4[streambuf.virt.buffer]{Buffer management and positioning}
 
 \indexlibrary{\idxcode{setbuf}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{setbuf}}%
 \begin{itemdecl}
 basic_streambuf* setbuf(char_type* s, streamsize n);
 \end{itemdecl}
@@ -3545,6 +3605,7 @@ Returns
 \end{itemdescr}
 
 \indexlibrary{\idxcode{seekoff}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{seekoff}}%
 \begin{itemdecl}
 pos_type seekoff(off_type off, ios_base::seekdir way,
                  ios_base::openmode which
@@ -3568,6 +3629,7 @@ Returns
 \end{itemdescr}
 
 \indexlibrary{\idxcode{seekpos}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{seekpos}}%
 \begin{itemdecl}
 pos_type seekpos(pos_type sp,
                  ios_base::openmode which
@@ -3591,6 +3653,7 @@ Returns
 \end{itemdescr}
 
 \indexlibrary{\idxcode{sync}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{sync}}%
 \begin{itemdecl}
 int sync();
 \end{itemdecl}
@@ -3621,6 +3684,7 @@ Returns zero.
 \rSec4[streambuf.virt.get]{Get area}
 
 \indexlibrary{\idxcode{showmanyc}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{showmanyc}}%
 \begin{itemdecl}
 streamsize showmanyc();@\footnote{\textrm{The morphemes of \tcode{showmanyc}\
 are ``es-how-many-see'', not ``show-manic''.}}@
@@ -3663,6 +3727,7 @@ Uses
 \end{itemdescr}
 
 \indexlibrary{\idxcode{xsgetn}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{xsgetn}}%
 \begin{itemdecl}
 streamsize xsgetn(char_type* s, streamsize n);
 \end{itemdecl}
@@ -3698,6 +3763,7 @@ Uses
 \end{itemdescr}
 
 \indexlibrary{\idxcode{underflow}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{underflow}}%
 \begin{itemdecl}
 int_type underflow();
 \end{itemdecl}
@@ -3826,6 +3892,7 @@ Returns
 \end{itemdescr}
 
 \indexlibrary{\idxcode{uflow}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{uflow}}%
 \begin{itemdecl}
 int_type uflow();
 \end{itemdecl}
@@ -3862,6 +3929,7 @@ to indicate failure.
 \rSec4[streambuf.virt.pback]{Putback}
 
 \indexlibrary{\idxcode{pbackfail}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{pbackfail}}%
 \begin{itemdecl}
 int_type pbackfail(int_type c = traits::eof());
 \end{itemdecl}
@@ -3933,6 +4001,7 @@ Returns
 \rSec4[streambuf.virt.put]{Put area}
 
 \indexlibrary{\idxcode{xsputn}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{xsputn}}%
 \begin{itemdecl}
 streamsize xsputn(const char_type* s, streamsize n);
 \end{itemdecl}
@@ -3958,6 +4027,7 @@ The number of characters written.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{overflow}!\idxcode{basic_streambuf}}%
+\indexlibrary{\idxcode{basic_streambuf}!\idxcode{overflow}}%
 \begin{itemdecl}
 int_type overflow(int_type c = traits::eof());
 \end{itemdecl}
@@ -4335,7 +4405,8 @@ a failure indication.
 explicit basic_istream(basic_streambuf<charT, traits>* sb);
 \end{itemdecl}
 
-\indexlibrary{\idxcode{init}!\idxcode{basic_ios}}%
+\indexlibrary{\idxcode{init}!\idxcode{basic_istream}}%
+\indexlibrary{\idxcode{basic_istream}!\idxcode{init}}%
 \begin{itemdescr}
 \pnum
 \effects
@@ -4438,6 +4509,7 @@ operations.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{sentry}!constructor}%
+\indexlibrary{\idxcode{basic_istream::sentry}!constructor}%
 \begin{itemdecl}
 explicit sentry(basic_istream<charT, traits>& is, bool noskipws = false);
 \end{itemdecl}
@@ -4526,7 +4598,8 @@ can also perform additional
 implementation-dependent operations.}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_istream}!destructor}%
+\indexlibrary{\idxcode{sentry}!destructor}%
+\indexlibrary{\idxcode{basic_istream::sentry}!destructor}%
 \begin{itemdecl}
 ~sentry();
 \end{itemdecl}
@@ -4537,7 +4610,8 @@ implementation-dependent operations.}
 None.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator bool}!\idxcode{basic_istream}}%
+\indexlibrary{\idxcode{operator bool}!\idxcode{basic_istream::sentry}}%
+\indexlibrary{\idxcode{basic_istream::sentry}!\idxcode{operator bool}}%
 \begin{itemdecl}
 explicit operator bool() const;
 \end{itemdecl}
@@ -4963,6 +5037,7 @@ object
 is destroyed before leaving the unformatted input function.
 
 \indexlibrary{\idxcode{gcount}!\idxcode{basic_istream}}%
+\indexlibrary{\idxcode{basic_istream}!\idxcode{gcount}}%
 \begin{itemdecl}
 streamsize gcount() const;
 \end{itemdecl}
@@ -4981,6 +5056,7 @@ extracted by the last unformatted input member function called for the object.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{get}!\idxcode{basic_istream}}%
+\indexlibrary{\idxcode{basic_istream}!\idxcode{get}}%
 \begin{itemdecl}
 int_type get();
 \end{itemdecl}
@@ -5157,6 +5233,7 @@ Value returned by the call.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{getline}!\idxcode{basic_istream}}%
+\indexlibrary{\idxcode{basic_istream}!\idxcode{getline}}%
 \begin{itemdecl}
 basic_istream<charT, traits>& getline(char_type* s, streamsize n,
                                       char_type delim);
@@ -5251,6 +5328,7 @@ int main() {
 \end{itemdescr}
 
 \indexlibrary{\idxcode{getline}!\idxcode{basic_istream}}%
+\indexlibrary{\idxcode{basic_istream}!\idxcode{getline}}%
 \begin{itemdecl}
 basic_istream<charT, traits>& getline(char_type* s, streamsize n);
 \end{itemdecl}
@@ -5262,6 +5340,7 @@ basic_istream<charT, traits>& getline(char_type* s, streamsize n);
 \end{itemdescr}
 
 \indexlibrary{\idxcode{ignore}!\idxcode{basic_istream}}%
+\indexlibrary{\idxcode{basic_istream}!\idxcode{ignore}}%
 \begin{itemdecl}
 basic_istream<charT, traits>&
     ignore(streamsize n = 1, int_type delim = traits::eof());
@@ -5303,6 +5382,7 @@ The last condition will never occur if
 \end{itemdescr}
 
 \indexlibrary{\idxcode{peek}!\idxcode{basic_istream}}%
+\indexlibrary{\idxcode{basic_istream}!\idxcode{peek}}%
 \begin{itemdecl}
 int_type peek();
 \end{itemdecl}
@@ -5327,6 +5407,7 @@ Otherwise, returns
 \end{itemdescr}
 
 \indexlibrary{\idxcode{read}!\idxcode{basic_istream}}%
+\indexlibrary{\idxcode{basic_istream}!\idxcode{read}}%
 \begin{itemdecl}
 basic_istream<charT, traits>& read(char_type* s, streamsize n);
 \end{itemdecl}
@@ -5366,6 +5447,7 @@ which may throw
 \end{itemdescr}
 
 \indexlibrary{\idxcode{readsome}!\idxcode{basic_istream}}%
+\indexlibrary{\idxcode{basic_istream}!\idxcode{readsome}}%
 \begin{itemdecl}
 streamsize readsome(char_type* s, streamsize n);
 \end{itemdecl}
@@ -5409,6 +5491,7 @@ The number of characters extracted.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{putback}!\idxcode{basic_istream}}%
+\indexlibrary{\idxcode{basic_istream}!\idxcode{putback}}%
 \begin{itemdecl}
 basic_istream<charT, traits>& putback(char_type c);
 \end{itemdecl}
@@ -5452,6 +5535,7 @@ is 0.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{unget}!\idxcode{basic_istream}}%
+\indexlibrary{\idxcode{basic_istream}!\idxcode{unget}}%
 \begin{itemdecl}
 basic_istream<charT, traits>& unget();
 \end{itemdecl}
@@ -5495,6 +5579,7 @@ is 0.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{sync}!\idxcode{basic_istream}}%
+\indexlibrary{\idxcode{basic_istream}!\idxcode{sync}}%
 \begin{itemdecl}
 int sync();
 \end{itemdecl}
@@ -5576,8 +5661,8 @@ In case of failure, the function calls
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{get}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{get}}%
+\indexlibrary{\idxcode{seekg}!\idxcode{basic_istream}}%
+\indexlibrary{\idxcode{basic_istream}!\idxcode{seekg}}%
 \begin{itemdecl}
 basic_istream<charT, traits>& seekg(off_type off, ios_base::seekdir dir);
 \end{itemdecl}
@@ -5935,7 +6020,8 @@ it does not throw anything and treat as an error.
 explicit basic_ostream(basic_streambuf<charT, traits>* sb);
 \end{itemdecl}
 
-\indexlibrary{\idxcode{init}!\idxcode{basic_ios}}%
+\indexlibrary{\idxcode{init}!\idxcode{basic_ostream}}%
+\indexlibrary{\idxcode{basic_ostream}!\idxcode{init}}%
 \begin{itemdescr}
 \pnum
 \effects
@@ -6029,7 +6115,7 @@ The class
 defines a class that is responsible for doing exception safe prefix and suffix
 operations.
 
-\indexlibrary{\idxcode{sentry}!constructor}%
+\indexlibrary{\idxcode{basic_ostream::sentry}!constructor}%
 \begin{itemdecl}
 explicit sentry(basic_ostream<charT, traits>& os);
 \end{itemdecl}
@@ -6066,7 +6152,7 @@ can also perform additional
 implementation-dependent operations.}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_ostream}!destructor}%
+\indexlibrary{\idxcode{basic_ostream::sentry}!destructor}%
 \begin{itemdecl}
 ~sentry();
 \end{itemdecl}
@@ -6084,7 +6170,8 @@ calls
 \end{itemdescr}
 
 \indexlibrary{\idxcode{flush}}%
-\indexlibrary{\idxcode{operator bool}!\idxcode{basic_ostream}}%
+\indexlibrary{\idxcode{operator bool}!\idxcode{basic_ostream::sentry}}%
+\indexlibrary{\idxcode{basic_ostream::sentry}!\idxcode{operator bool}}%
 \begin{itemdecl}
 explicit operator bool() const;
 \end{itemdecl}
@@ -6103,7 +6190,7 @@ Each seek member function begins execution by constructing an object of class \t
 It returns by destroying the \tcode{sentry} object.
 
 \indexlibrary{\idxcode{tellp}!\idxcode{basic_ostream}}%
-\indexlibrary{\idxcode{seekp}!\idxcode{basic_ostream}}%
+\indexlibrary{\idxcode{basic_ostream}!\idxcode{tellp}}%
 \begin{itemdecl}
 pos_type tellp();
 \end{itemdecl}
@@ -6601,6 +6688,7 @@ sentry object, then, if no exception was thrown, returning the value
 specified for the unformatted output function.
 
 \indexlibrary{\idxcode{put}!\idxcode{basic_ostream}}%
+\indexlibrary{\idxcode{basic_ostream}!\idxcode{put}}%
 \begin{itemdecl}
 basic_ostream<charT, traits>& put(char_type c);
 \end{itemdecl}
@@ -6628,6 +6716,7 @@ Otherwise, calls
 \end{itemdescr}
 
 \indexlibrary{\idxcode{write}!\idxcode{basic_ostream}}%
+\indexlibrary{\idxcode{basic_ostream}!\idxcode{write}}%
 \begin{itemdecl}
 basic_ostream& write(const char_type* s, streamsize n);
 \end{itemdecl}
@@ -6661,6 +6750,7 @@ which may throw
 \end{itemdescr}
 
 \indexlibrary{\idxcode{flush}!\idxcode{basic_ostream}}%
+\indexlibrary{\idxcode{basic_ostream}!\idxcode{flush}}%
 \begin{itemdecl}
 basic_ostream& flush();
 \end{itemdecl}
@@ -6826,7 +6916,7 @@ then the expression
 \tcode{in \shr\ setiosflags(mask)}
 behaves as if it called
 \tcode{f(in, mask)}, where the function \tcode{f} is defined as:
-\indexlibrary{\idxcode{fmtflags}!\idxcode{ios}}%
+\indexlibrary{\idxcode{fmtflags}!\idxcode{ios_base}}%
 
 \begin{codeblock}
 void f(ios_base& str, ios_base::fmtflags mask) {
@@ -7530,6 +7620,7 @@ template <class charT, class traits, class Allocator>
 \rSec3[stringbuf.members]{Member functions}
 
 \indexlibrary{\idxcode{str}!\idxcode{basic_stringbuf}}%
+\indexlibrary{\idxcode{basic_stringbuf}!\idxcode{str}}%
 \begin{itemdecl}
 basic_string<charT, traits, Allocator> str() const;
 \end{itemdecl}
@@ -7582,6 +7673,7 @@ true, \tcode{eback()} points to the first underlying character, and both \tcode{
 \rSec3[stringbuf.virtuals]{Overridden virtual functions}
 
 \indexlibrary{\idxcode{underflow}!\idxcode{basic_stringbuf}}%
+\indexlibrary{\idxcode{basic_stringbuf}!\idxcode{underflow}}%
 \begin{itemdecl}
 int_type underflow() override;
 \end{itemdecl}
@@ -7599,6 +7691,7 @@ to be part of the input sequence.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{pbackfail}!\idxcode{basic_stringbuf}}%
+\indexlibrary{\idxcode{basic_stringbuf}!\idxcode{pbackfail}}%
 \begin{itemdecl}
 int_type pbackfail(int_type c = traits::eof()) override;
 \end{itemdecl}
@@ -7671,6 +7764,7 @@ unspecified which way is chosen.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{overflow}!\idxcode{basic_stringbuf}}%
+\indexlibrary{\idxcode{basic_stringbuf}!\idxcode{overflow}}%
 \begin{itemdecl}
 int_type overflow(int_type c = traits::eof()) override;
 \end{itemdecl}
@@ -7733,6 +7827,7 @@ to point just past the new write position.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{seekoff}!\idxcode{basic_stringbuf}}%
+\indexlibrary{\idxcode{basic_stringbuf}!\idxcode{seekoff}}%
 \begin{itemdecl}
 pos_type seekoff(off_type off, ios_base::seekdir way,
                  ios_base::openmode which
@@ -7807,6 +7902,7 @@ the return value is
 \end{itemdescr}
 
 \indexlibrary{\idxcode{seekpos}!\idxcode{basic_stringbuf}}%
+\indexlibrary{\idxcode{basic_stringbuf}!\idxcode{seekpos}}%
 \begin{itemdecl}
 pos_type seekpos(pos_type sp,
                  ios_base::openmode which
@@ -8004,6 +8100,7 @@ template <class charT, class traits, class Allocator>
 \rSec3[istringstream.members]{Member functions}
 
 \indexlibrary{\idxcode{rdbuf}!\idxcode{basic_istringstream}}%
+\indexlibrary{\idxcode{basic_istringstream}!\idxcode{rdbuf}}%
 \begin{itemdecl}
 basic_stringbuf<charT, traits, Allocator>* rdbuf() const;
 \end{itemdecl}
@@ -8015,6 +8112,7 @@ basic_stringbuf<charT, traits, Allocator>* rdbuf() const;
 \end{itemdescr}
 
 \indexlibrary{\idxcode{str}!\idxcode{basic_istringstream}}%
+\indexlibrary{\idxcode{basic_istringstream}!\idxcode{str}}%
 \begin{itemdecl}
 basic_string<charT, traits, Allocator> str() const;
 \end{itemdecl}
@@ -8197,6 +8295,7 @@ template <class charT, class traits, class Allocator>
 \rSec3[ostringstream.members]{Member functions}
 
 \indexlibrary{\idxcode{rdbuf}!\idxcode{basic_ostringstream}}%
+\indexlibrary{\idxcode{basic_ostringstream}!\idxcode{rdbuf}}%
 \begin{itemdecl}
 basic_stringbuf<charT, traits, Allocator>* rdbuf() const;
 \end{itemdecl}
@@ -8208,6 +8307,7 @@ basic_stringbuf<charT, traits, Allocator>* rdbuf() const;
 \end{itemdescr}
 
 \indexlibrary{\idxcode{str}!\idxcode{basic_ostringstream}}%
+\indexlibrary{\idxcode{basic_ostringstream}!\idxcode{str}}%
 \begin{itemdecl}
 basic_string<charT, traits, Allocator> str() const;
 \end{itemdecl}
@@ -8395,6 +8495,7 @@ template <class charT, class traits, class Allocator>
 \rSec3[stringstream.members]{Member functions}
 
 \indexlibrary{\idxcode{rdbuf}!\idxcode{basic_stringstream}}%
+\indexlibrary{\idxcode{basic_stringstream}!\idxcode{rdbuf}}%
 \begin{itemdecl}
 basic_stringbuf<charT, traits, Allocator>* rdbuf() const;
 \end{itemdecl}
@@ -8406,6 +8507,7 @@ basic_stringbuf<charT, traits, Allocator>* rdbuf() const;
 \end{itemdescr}
 
 \indexlibrary{\idxcode{str}!\idxcode{basic_stringstream}}%
+\indexlibrary{\idxcode{basic_stringstream}!\idxcode{str}}%
 \begin{itemdecl}
 basic_string<charT, traits, Allocator> str() const;
 \end{itemdecl}
@@ -8713,6 +8815,7 @@ template <class charT, class traits>
 \rSec3[filebuf.members]{Member functions}
 
 \indexlibrary{\idxcode{is_open}!\idxcode{basic_filebuf}}%
+\indexlibrary{\idxcode{basic_filebuf}!\idxcode{is_open}}%
 \begin{itemdecl}
 bool is_open() const;
 \end{itemdecl}
@@ -8728,6 +8831,7 @@ call to close.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{open}!\idxcode{basic_filebuf}}%
+\indexlibrary{\idxcode{basic_filebuf}!\idxcode{open}}%
 \begin{itemdecl}
 basic_filebuf<charT, traits>* open(const char* s,
                                    ios_base::openmode mode);
@@ -8809,6 +8913,7 @@ if successful, a null pointer otherwise.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{open}!\idxcode{basic_filebuf}}%
+\indexlibrary{\idxcode{basic_filebuf}!\idxcode{open}}%
 \begin{itemdecl}
 basic_filebuf<charT, traits>* open(const string& s,
                                    ios_base::openmode mode);
@@ -8820,6 +8925,7 @@ basic_filebuf<charT, traits>* open(const string& s,
 \end{itemdescr}
 
 \indexlibrary{\idxcode{close}!\idxcode{basic_filebuf}}%
+\indexlibrary{\idxcode{basic_filebuf}!\idxcode{close}}%
 \begin{itemdecl}
 basic_filebuf<charT, traits>* close();
 \end{itemdecl}
@@ -8871,6 +8977,7 @@ on success, a null pointer otherwise.
 \rSec3[filebuf.virtuals]{Overridden virtual functions}
 
 \indexlibrary{\idxcode{showmanyc}!\idxcode{basic_filebuf}}%
+\indexlibrary{\idxcode{basic_filebuf}!\idxcode{showmanyc}}%
 \begin{itemdecl}
 streamsize showmanyc() override;
 \end{itemdecl}
@@ -8891,6 +8998,7 @@ sequence.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{underflow}!\idxcode{basic_filebuf}}%
+\indexlibrary{\idxcode{basic_filebuf}!\idxcode{underflow}}%
 \begin{itemdecl}
 int_type underflow() override;
 \end{itemdecl}
@@ -8934,6 +9042,7 @@ retry with a larger
 \end{itemdescr}
 
 \indexlibrary{\idxcode{uflow}!\idxcode{basic_filebuf}}%
+\indexlibrary{\idxcode{basic_filebuf}!\idxcode{uflow}}%
 \begin{itemdecl}
 int_type uflow() override;
 \end{itemdecl}
@@ -8949,6 +9058,7 @@ with the same method as used by
 \end{itemdescr}
 
 \indexlibrary{\idxcode{pbackfail}!\idxcode{basic_filebuf}}%
+\indexlibrary{\idxcode{basic_filebuf}!\idxcode{pbackfail}}%
 \begin{itemdecl}
 int_type pbackfail(int_type c = traits::eof()) override;
 \end{itemdecl}
@@ -9025,6 +9135,7 @@ The function can alter the number of putback positions available as a result of 
 \end{itemdescr}
 
 \indexlibrary{\idxcode{overflow}!\idxcode{basic_filebuf}}%
+\indexlibrary{\idxcode{basic_filebuf}!\idxcode{overflow}}%
 \begin{itemdecl}
 int_type overflow(int_type c = traits::eof()) override;
 \end{itemdecl}
@@ -9072,6 +9183,7 @@ the function always fails.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{setbuf}!\idxcode{basic_filebuf}}%
+\indexlibrary{\idxcode{basic_filebuf}!\idxcode{setbuf}}%
 \begin{itemdecl}
 basic_streambuf* setbuf(char_type* s, streamsize n) override;
 \end{itemdecl}
@@ -9094,6 +9206,7 @@ and output to the file should appear as soon as possible.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{seekoff}!\idxcode{basic_filebuf}}%
+\indexlibrary{\idxcode{basic_filebuf}!\idxcode{seekoff}}%
 \begin{itemdecl}
 pos_type seekoff(off_type off, ios_base::seekdir way,
                  ios_base::openmode which
@@ -9161,6 +9274,7 @@ returns
 \end{itemdescr}
 
 \indexlibrary{\idxcode{seekpos}!\idxcode{basic_filebuf}}%
+\indexlibrary{\idxcode{basic_filebuf}!\idxcode{seekpos}}%
 \begin{itemdecl}
 pos_type seekpos(pos_type sp,
                  ios_base::openmode which
@@ -9210,6 +9324,7 @@ Otherwise returns
 \end{itemdescr}
 
 \indexlibrary{\idxcode{sync}!\idxcode{basic_filebuf}}%
+\indexlibrary{\idxcode{basic_filebuf}!\idxcode{sync}}%
 \begin{itemdecl}
 int sync() override;
 \end{itemdecl}
@@ -9226,6 +9341,7 @@ If a get area exists, the effect is \impldef{effect of calling
 \end{itemdescr}
 
 \indexlibrary{\idxcode{imbue}!\idxcode{basic_filebuf}}%
+\indexlibrary{\idxcode{basic_filebuf}!\idxcode{imbue}}%
 \begin{itemdecl}
 void imbue(const locale& loc) override;
 \end{itemdecl}
@@ -9427,6 +9543,7 @@ template <class charT, class traits>
 \rSec3[ifstream.members]{Member functions}
 
 \indexlibrary{\idxcode{rdbuf}!\idxcode{basic_ifstream}}%
+\indexlibrary{\idxcode{basic_ifstream}!\idxcode{rdbuf}}%
 \begin{itemdecl}
 basic_filebuf<charT, traits>* rdbuf() const;
 \end{itemdecl}
@@ -9438,6 +9555,7 @@ basic_filebuf<charT, traits>* rdbuf() const;
 \end{itemdescr}
 
 \indexlibrary{\idxcode{is_open}!\idxcode{basic_ifstream}}%
+\indexlibrary{\idxcode{basic_ifstream}!\idxcode{is_open}}%
 \begin{itemdecl}
 bool is_open() const;
 \end{itemdecl}
@@ -9449,6 +9567,7 @@ bool is_open() const;
 \end{itemdescr}
 
 \indexlibrary{\idxcode{open}!\idxcode{basic_ifstream}}%
+\indexlibrary{\idxcode{basic_ifstream}!\idxcode{open}}%
 \begin{itemdecl}
 void open(const char* s, ios_base::openmode mode = ios_base::in);
 \end{itemdecl}
@@ -9467,6 +9586,7 @@ otherwise calls
 \end{itemdescr}
 
 \indexlibrary{\idxcode{open}!\idxcode{basic_ifstream}}%
+\indexlibrary{\idxcode{basic_ifstream}!\idxcode{open}}%
 \begin{itemdecl}
 void open(const string& s, ios_base::openmode mode = ios_base::in);
 \end{itemdecl}
@@ -9477,6 +9597,7 @@ void open(const string& s, ios_base::openmode mode = ios_base::in);
 \end{itemdescr}
 
 \indexlibrary{\idxcode{close}!\idxcode{basic_ifstream}}%
+\indexlibrary{\idxcode{basic_ifstream}!\idxcode{close}}%
 \begin{itemdecl}
 void close();
 \end{itemdecl}
@@ -9667,6 +9788,7 @@ template <class charT, class traits>
 \rSec3[ofstream.members]{Member functions}
 
 \indexlibrary{\idxcode{rdbuf}!\idxcode{basic_ofstream}}%
+\indexlibrary{\idxcode{basic_ofstream}!\idxcode{rdbuf}}%
 \begin{itemdecl}
 basic_filebuf<charT, traits>* rdbuf() const;
 \end{itemdecl}
@@ -9678,6 +9800,7 @@ basic_filebuf<charT, traits>* rdbuf() const;
 \end{itemdescr}
 
 \indexlibrary{\idxcode{is_open}!\idxcode{basic_ofstream}}%
+\indexlibrary{\idxcode{basic_ofstream}!\idxcode{is_open}}%
 \begin{itemdecl}
 bool is_open() const;
 \end{itemdecl}
@@ -9689,6 +9812,7 @@ bool is_open() const;
 \end{itemdescr}
 
 \indexlibrary{\idxcode{open}!\idxcode{basic_ofstream}}%
+\indexlibrary{\idxcode{basic_ofstream}!\idxcode{open}}%
 \begin{itemdecl}
 void open(const char* s, ios_base::openmode mode = ios_base::out);
 \end{itemdecl}
@@ -9707,6 +9831,7 @@ otherwise calls
 \end{itemdescr}
 
 \indexlibrary{\idxcode{close}!\idxcode{basic_ofstream}}%
+\indexlibrary{\idxcode{basic_ofstream}!\idxcode{close}}%
 \begin{itemdecl}
 void close();
 \end{itemdecl}
@@ -9723,6 +9848,7 @@ and, if that function fails (returns a null pointer), calls
 \end{itemdescr}
 
 \indexlibrary{\idxcode{open}!\idxcode{basic_ofstream}}%
+\indexlibrary{\idxcode{basic_ofstream}!\idxcode{open}}%
 \begin{itemdecl}
 void open(const string& s, ios_base::openmode mode = ios_base::out);
 \end{itemdecl}
@@ -9914,7 +10040,8 @@ template <class charT, class traits>
 
 \rSec3[fstream.members]{Member functions}
 
-\indexlibrary{\idxcode{rdbuf}!\idxcode{basic_filebuf}}%
+\indexlibrary{\idxcode{rdbuf}!\idxcode{basic_fstream}}%
+\indexlibrary{\idxcode{basic_fstream}!\idxcode{rdbuf}}%
 \begin{itemdecl}
 basic_filebuf<charT, traits>* rdbuf() const;
 \end{itemdecl}
@@ -9925,7 +10052,8 @@ basic_filebuf<charT, traits>* rdbuf() const;
 \tcode{const_cast<basic_filebuf<charT, traits>*>(\&sb)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{is_open}!\idxcode{basic_filebuf}}%
+\indexlibrary{\idxcode{is_open}!\idxcode{basic_fstream}}%
+\indexlibrary{\idxcode{basic_fstream}!\idxcode{is_open}}%
 \begin{itemdecl}
 bool is_open() const;
 \end{itemdecl}
@@ -9936,7 +10064,8 @@ bool is_open() const;
 \tcode{rdbuf()->is_open()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{open}!\idxcode{basic_filebuf}}%
+\indexlibrary{\idxcode{open}!\idxcode{basic_fstream}}%
+\indexlibrary{\idxcode{basic_fstream}!\idxcode{open}}%
 \begin{itemdecl}
 void open(
   const char* s,
@@ -9955,7 +10084,8 @@ otherwise calls
 \tcode{ios_base::failure})~(\ref{iostate.flags}).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{open}!\idxcode{basic_filebuf}}%
+\indexlibrary{\idxcode{open}!\idxcode{basic_fstream}}%
+\indexlibrary{\idxcode{basic_fstream}!\idxcode{open}}%
 \begin{itemdecl}
 void open(
   const string& s,
@@ -9967,7 +10097,8 @@ void open(
 \effects Calls \tcode{open(s.c_str(), mode)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{close}!\idxcode{basic_filebuf}}%
+\indexlibrary{\idxcode{close}!\idxcode{basic_fstream}}%
+\indexlibrary{\idxcode{basic_fstream}!\idxcode{open}}%
 \begin{itemdecl}
 void close();
 \end{itemdecl}
@@ -10521,7 +10652,7 @@ handle errors as follows, unless otherwise specified:
 
 \rSec2[class.path]{Class \tcode{path}}
 
-\indexlibrary{\idxcode{path}}
+\indexlibrary{\idxcode{path}}%
 \pnum
 An object of class \tcode{path} represents a path~(\ref{fs.def.path})
 and contains a pathname~(\ref{fs.def.pathname}).
@@ -10916,6 +11047,7 @@ shall not be null pointers.
 
 \rSec4[path.construct]{\tcode{path} constructors}
 
+\indexlibrary{\idxcode{path}!constructor}%
 \begin{itemdecl}
 path() noexcept;
 \end{itemdecl}
@@ -10928,6 +11060,7 @@ path() noexcept;
 \postconditions \tcode{empty() == true}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{path}!constructor}%
 \begin{itemdecl}
 path(const path& p);
 path(path&& p) noexcept;
@@ -10941,6 +11074,7 @@ Constructs an object of class \tcode{path} with
 In the second form, \tcode{p} is left in a valid but unspecified state.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{path}!constructor}%
 \begin{itemdecl}
 path(string_type&& source);
 \end{itemdecl}
@@ -10953,6 +11087,7 @@ Constructs an object of class \tcode{path} with
 \tcode{source} is left in a valid but unspecified state.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{path}!constructor}%
 \begin{itemdecl}
 template <class Source>
   path(const Source& source);
@@ -10967,6 +11102,7 @@ template <class InputIterator>
   converting format and encoding if required~(\ref{path.cvt}).
 \end{itemdescr}
 
+\indexlibrary{\idxcode{path}!constructor}%
 \begin{itemdecl}
 template <class Source>
   path(const Source& source, const locale& loc);
@@ -11027,6 +11163,8 @@ converted to their Unicode representation.
 
 \rSec4[path.assign]{\tcode{path} assignments}
 
+\indexlibrary{\idxcode{operator=}!\idxcode{path}}%
+\indexlibrary{\idxcode{path}!\idxcode{operator=}}%
 \begin{itemdecl}
 path& operator=(const path& p);
 \end{itemdecl}
@@ -11041,6 +11179,8 @@ original value of \tcode{p.pathname}.
 \returns \tcode{*this}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{operator=}!\idxcode{path}}%
+\indexlibrary{\idxcode{path}!\idxcode{operator=}}%
 \begin{itemdecl}
 path& operator=(path&& p) noexcept;
 \end{itemdecl}
@@ -11057,6 +11197,10 @@ valid but unspecified state.
 \returns \tcode{*this}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{operator=}!\idxcode{path}}%
+\indexlibrary{\idxcode{path}!\idxcode{operator=}}%
+\indexlibrary{\idxcode{assign}!\idxcode{path}}%
+\indexlibrary{\idxcode{path}!\idxcode{assign}}%
 \begin{itemdecl}
 path& operator=(string_type&& source);
 path& assign(string_type&& source);
@@ -11071,6 +11215,10 @@ path& assign(string_type&& source);
 \returns \tcode{*this}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{operator=}!\idxcode{path}}%
+\indexlibrary{\idxcode{path}!\idxcode{operator=}}%
+\indexlibrary{\idxcode{assign}!\idxcode{path}}%
+\indexlibrary{\idxcode{path}!\idxcode{assign}}%
 \begin{itemdecl}
 template <class Source>
   path& operator=(const Source& source);
@@ -11096,7 +11244,8 @@ converting format and encoding if required (\ref{path.cvt}).
 The append operations use \tcode{operator/=} to denote their semantic effect of appending
 \grammarterm{preferred-separator} when needed.
 
-\indexlibrary{\idxcode{path}!\idxcode{operator/=}}
+\indexlibrary{\idxcode{operator/=}!\idxcode{path}}%
+\indexlibrary{\idxcode{path}!\idxcode{operator/=}}%
 \begin{itemdecl}
 path& operator/=(const path& p);
 \end{itemdecl}
@@ -11118,8 +11267,8 @@ Then appends \tcode{p.native()} to \tcode{pathname}.
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{append}}
-\indexlibrary{\idxcode{append}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{append}}%
+\indexlibrary{\idxcode{append}!\idxcode{path}}%
 \begin{itemdecl}
 template <class Source>
   path& operator/=(const Source& source);
@@ -11149,6 +11298,10 @@ Then appends the effective range of \tcode{source} (\ref{path.req})
 
 \rSec4[path.concat]{\tcode{path} concatenation}
 
+\indexlibrary{\idxcode{operator+=}!\idxcode{path}}%
+\indexlibrary{\idxcode{path}!\idxcode{operator+=}}%
+\indexlibrary{\idxcode{concat}!\idxcode{path}}%
+\indexlibrary{\idxcode{path}!\idxcode{concat}}%
 \begin{itemdecl}
 path& operator+=(const path& x);
 path& operator+=(const string_type& x);
@@ -11188,8 +11341,8 @@ If the value type of \tcode{\textit{effective-argument}} would not be \tcode{pat
 
 \rSec4[path.modifiers]{\tcode{path} modifiers}
 
-\indexlibrary{\idxcode{path}!\idxcode{clear}}
-\indexlibrary{\idxcode{clear}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{clear}}%
+\indexlibrary{\idxcode{clear}!\idxcode{path}}%
 \begin{itemdecl}
 void clear() noexcept;
 \end{itemdecl}
@@ -11199,8 +11352,8 @@ void clear() noexcept;
 \postcondition \tcode{empty() == true}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{make_preferred}}
-\indexlibrary{\idxcode{make_preferred}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{make_preferred}}%
+\indexlibrary{\idxcode{make_preferred}!\idxcode{path}}%
 \begin{itemdecl}
 path& make_preferred();
 \end{itemdecl}
@@ -11236,8 +11389,8 @@ output is:
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{remove_filename}}
-\indexlibrary{\idxcode{remove_filename}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{remove_filename}}%
+\indexlibrary{\idxcode{remove_filename}!\idxcode{path}}%
 \begin{itemdecl}
 path& remove_filename();
 \end{itemdecl}
@@ -11258,8 +11411,8 @@ std::cout << path("/").remove_filename();     // outputs \tcode{""}
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{replace_filename}}
-\indexlibrary{\idxcode{replace_filename}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{replace_filename}}%
+\indexlibrary{\idxcode{replace_filename}!\idxcode{path}}%
 \begin{itemdecl}
 path& replace_filename(const path& replacement);
 \end{itemdecl}
@@ -11284,8 +11437,8 @@ std::cout << path("/").replace_filename("bar");     // outputs \tcode{"bar"}
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{replace_extension}}
-\indexlibrary{\idxcode{replace_extension}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{replace_extension}}%
+\indexlibrary{\idxcode{replace_extension}!\idxcode{path}}%
 \begin{itemdecl}
 path& replace_extension(const path& replacement = path());
 \end{itemdecl}
@@ -11306,8 +11459,8 @@ path& replace_extension(const path& replacement = path());
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{swap}}
-\indexlibrary{\idxcode{swap}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{swap}}%
+\indexlibrary{\idxcode{swap}!\idxcode{path}}%
 \begin{itemdecl}
 void swap(path& rhs) noexcept;
 \end{itemdecl}
@@ -11326,8 +11479,8 @@ void swap(path& rhs) noexcept;
 \pnum
 The string returned by all native format observers is in the native pathname format~(\ref{fs.def.native}).
 
-\indexlibrary{\idxcode{path}!\idxcode{native}}
-\indexlibrary{\idxcode{native}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{native}}%
+\indexlibrary{\idxcode{native}!\idxcode{path}}%
 \begin{itemdecl}
 const string_type& native() const noexcept;
 \end{itemdecl}
@@ -11337,8 +11490,8 @@ const string_type& native() const noexcept;
 \returns \tcode{pathname}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{c_str}}
-\indexlibrary{\idxcode{c_str}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{c_str}}%
+\indexlibrary{\idxcode{c_str}!\idxcode{path}}%
 \begin{itemdecl}
 const value_type* c_str() const noexcept;
 \end{itemdecl}
@@ -11348,7 +11501,7 @@ const value_type* c_str() const noexcept;
 \returns \tcode{pathname.c_str()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{operator string_type}}
+\indexlibrary{\idxcode{path}!\idxcode{operator string_type}}%
 \begin{itemdecl}
 operator string_type() const;
 \end{itemdecl}
@@ -11380,11 +11533,11 @@ be performed by \tcode{a}. Conversion, if any, is specified by
 \ref{path.cvt}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{string}}
-\indexlibrary{\idxcode{path}!\idxcode{wstring}}
-\indexlibrary{\idxcode{path}!\idxcode{u8string}}
-\indexlibrary{\idxcode{path}!\idxcode{u16string}}
-\indexlibrary{\idxcode{path}!\idxcode{u32string}}
+\indexlibrary{\idxcode{path}!\idxcode{string}}%
+\indexlibrary{\idxcode{path}!\idxcode{wstring}}%
+\indexlibrary{\idxcode{path}!\idxcode{u8string}}%
+\indexlibrary{\idxcode{path}!\idxcode{u16string}}%
+\indexlibrary{\idxcode{path}!\idxcode{u32string}}%
 \begin{itemdecl}
 std::string string() const;
 std::wstring wstring() const;
@@ -11435,11 +11588,11 @@ be performed by \tcode{a}. Conversion, if any, is specified by
 \ref{path.cvt}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{generic_string}}
-\indexlibrary{\idxcode{path}!\idxcode{generic_wstring}}
-\indexlibrary{\idxcode{path}!\idxcode{generic_u8string}}
-\indexlibrary{\idxcode{path}!\idxcode{generic_u16string}}
-\indexlibrary{\idxcode{path}!\idxcode{generic_u32string}}
+\indexlibrary{\idxcode{path}!\idxcode{generic_string}}%
+\indexlibrary{\idxcode{path}!\idxcode{generic_wstring}}%
+\indexlibrary{\idxcode{path}!\idxcode{generic_u8string}}%
+\indexlibrary{\idxcode{path}!\idxcode{generic_u16string}}%
+\indexlibrary{\idxcode{path}!\idxcode{generic_u32string}}%
 \begin{itemdecl}
 std::string generic_string() const;
 std::wstring generic_wstring() const;
@@ -11506,8 +11659,8 @@ int compare(const value_type* s) const
 
 \rSec4[path.decompose]{\tcode{path} decomposition}
 
-\indexlibrary{\idxcode{path}!\idxcode{root_name}}
-\indexlibrary{\idxcode{root_name}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{root_name}}%
+\indexlibrary{\idxcode{root_name}!\idxcode{path}}%
 \begin{itemdecl}
 path root_name() const;
 \end{itemdecl}
@@ -11517,8 +11670,8 @@ path root_name() const;
 \returns \grammarterm{root-name}, if \tcode{pathname} includes \grammarterm{root-name}, otherwise \tcode{path()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{root_directory}}
-\indexlibrary{\idxcode{root_directory}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{root_directory}}%
+\indexlibrary{\idxcode{root_directory}!\idxcode{path}}%
 \begin{itemdecl}
 path root_directory() const;
 \end{itemdecl}
@@ -11528,8 +11681,8 @@ path root_directory() const;
 \returns \grammarterm{root-directory}, if \tcode{pathname} includes \grammarterm{root-directory}, otherwise \tcode{path()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{root_path}}
-\indexlibrary{\idxcode{root_path}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{root_path}}%
+\indexlibrary{\idxcode{root_path}!\idxcode{path}}%
 \begin{itemdecl}
 path root_path() const;
 \end{itemdecl}
@@ -11539,8 +11692,8 @@ path root_path() const;
 \returns \tcode{root_name() / root_directory()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{relative_path}}
-\indexlibrary{\idxcode{relative_path}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{relative_path}}%
+\indexlibrary{\idxcode{relative_path}!\idxcode{path}}%
 \begin{itemdecl}
 path relative_path() const;
 \end{itemdecl}
@@ -11551,8 +11704,8 @@ path relative_path() const;
 with the first \grammarterm{filename} after \grammarterm{root-path}. Otherwise, \tcode{path()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{parent_path}}
-\indexlibrary{\idxcode{parent_path}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{parent_path}}%
+\indexlibrary{\idxcode{parent_path}!\idxcode{path}}%
 \begin{itemdecl}
 path parent_path() const;
 \end{itemdecl}
@@ -11565,8 +11718,8 @@ where \tcode{\textit{pp}} is constructed as if by
   \range{begin()}{--end()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{filename}}
-\indexlibrary{\idxcode{filename}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{filename}}%
+\indexlibrary{\idxcode{filename}!\idxcode{path}}%
 \begin{itemdecl}
 path filename() const;
 \end{itemdecl}
@@ -11586,8 +11739,8 @@ std::cout << path("..").filename();           // outputs ".."
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{stem}}
-\indexlibrary{\idxcode{stem}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{stem}}%
+\indexlibrary{\idxcode{stem}!\idxcode{path}}%
 \begin{itemdecl}
 path stem() const;
 \end{itemdecl}
@@ -11614,8 +11767,8 @@ for (; !p.extension().empty(); p = p.stem())
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{extension}}
-\indexlibrary{\idxcode{extension}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{extension}}%
+\indexlibrary{\idxcode{extension}!\idxcode{path}}%
 \begin{itemdecl}
 path extension() const;
 \end{itemdecl}
@@ -11648,8 +11801,8 @@ std::cout << path("/foo/bar.txt").extension(); // outputs ".txt"
 
 \rSec4[path.query]{\tcode{path} query}
 
-\indexlibrary{\idxcode{path}!\idxcode{empty}}
-\indexlibrary{\idxcode{empty}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{empty}}%
+\indexlibrary{\idxcode{empty}!\idxcode{path}}%
 \begin{itemdecl}
 bool empty() const noexcept;
 \end{itemdecl}
@@ -11659,8 +11812,8 @@ bool empty() const noexcept;
 \returns \tcode{pathname.empty()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{has_root_path}}
-\indexlibrary{\idxcode{has_root_path}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{has_root_path}}%
+\indexlibrary{\idxcode{has_root_path}!\idxcode{path}}%
 \begin{itemdecl}
 bool has_root_path() const;
 \end{itemdecl}
@@ -11670,8 +11823,8 @@ bool has_root_path() const;
 \returns \tcode{!root_path().empty()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{has_root_name}}
-\indexlibrary{\idxcode{has_root_name}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{has_root_name}}%
+\indexlibrary{\idxcode{has_root_name}!\idxcode{path}}%
 \begin{itemdecl}
 bool has_root_name() const;
 \end{itemdecl}
@@ -11681,8 +11834,8 @@ bool has_root_name() const;
 \returns \tcode{!root_name().empty()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{has_root_directory}}
-\indexlibrary{\idxcode{has_root_directory}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{has_root_directory}}%
+\indexlibrary{\idxcode{has_root_directory}!\idxcode{path}}%
 \begin{itemdecl}
 bool has_root_directory() const;
 \end{itemdecl}
@@ -11692,8 +11845,8 @@ bool has_root_directory() const;
 \returns \tcode{!root_directory().empty()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{has_relative_path}}
-\indexlibrary{\idxcode{has_relative_path}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{has_relative_path}}%
+\indexlibrary{\idxcode{has_relative_path}!\idxcode{path}}%
 \begin{itemdecl}
 bool has_relative_path() const;
 \end{itemdecl}
@@ -11703,8 +11856,8 @@ bool has_relative_path() const;
 \returns \tcode{!relative_path().empty()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{has_parent_path}}
-\indexlibrary{\idxcode{has_parent_path}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{has_parent_path}}%
+\indexlibrary{\idxcode{has_parent_path}!\idxcode{path}}%
 \begin{itemdecl}
 bool has_parent_path() const;
 \end{itemdecl}
@@ -11714,8 +11867,8 @@ bool has_parent_path() const;
 \returns \tcode{!parent_path().empty()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{has_filename}}
-\indexlibrary{\idxcode{has_filename}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{has_filename}}%
+\indexlibrary{\idxcode{has_filename}!\idxcode{path}}%
 \begin{itemdecl}
 bool has_filename() const;
 \end{itemdecl}
@@ -11725,8 +11878,8 @@ bool has_filename() const;
 \returns \tcode{!filename().empty()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{has_stem}}
-\indexlibrary{\idxcode{has_stem}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{has_stem}}%
+\indexlibrary{\idxcode{has_stem}!\idxcode{path}}%
 \begin{itemdecl}
 bool has_stem() const;
 \end{itemdecl}
@@ -11736,8 +11889,8 @@ bool has_stem() const;
 \returns \tcode{!stem().empty()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{has_extension}}
-\indexlibrary{\idxcode{has_extension}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{has_extension}}%
+\indexlibrary{\idxcode{has_extension}!\idxcode{path}}%
 \begin{itemdecl}
 bool has_extension() const;
 \end{itemdecl}
@@ -11747,8 +11900,8 @@ bool has_extension() const;
 \returns \tcode{!extension().empty()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{is_absolute}}
-\indexlibrary{\idxcode{is_absolute}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{is_absolute}}%
+\indexlibrary{\idxcode{is_absolute}!\idxcode{path}}%
 \begin{itemdecl}
 bool is_absolute() const;
 \end{itemdecl}
@@ -11764,8 +11917,8 @@ bool is_absolute() const;
 operating systems. \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{is_relative}}
-\indexlibrary{\idxcode{is_relative}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{is_relative}}%
+\indexlibrary{\idxcode{is_relative}!\idxcode{path}}%
 \begin{itemdecl}
 bool is_relative() const;
 \end{itemdecl}
@@ -11777,8 +11930,8 @@ bool is_relative() const;
 
 \rSec4[path.gen]{\tcode{path} generation}
 
-\indexlibrary{\idxcode{path}!\idxcode{lexically_normal}}
-\indexlibrary{\idxcode{lexically_normal}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{lexically_normal}}%
+\indexlibrary{\idxcode{lexically_normal}!\idxcode{path}}%
 \begin{itemdecl}
 path lexically_normal() const;
 \end{itemdecl}
@@ -11803,8 +11956,8 @@ but that does not affect \tcode{path} equality.
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{lexically_relative}}
-\indexlibrary{\idxcode{lexically_relative}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{lexically_relative}}%
+\indexlibrary{\idxcode{lexically_relative}!\idxcode{path}}%
 \begin{itemdecl}
 path lexically_relative(const path& base) const;
 \end{itemdecl}
@@ -11864,8 +12017,8 @@ but that does not affect \tcode{path} equality.
   \tcode{*this}, \tcode{base}, or both. \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{lexically_proximate}}
-\indexlibrary{\idxcode{lexically_proximate}!\idxcode{path}}
+\indexlibrary{\idxcode{path}!\idxcode{lexically_proximate}}%
+\indexlibrary{\idxcode{lexically_proximate}!\idxcode{path}}%
 \begin{itemdecl}
 path lexically_proximate(const path& base) const;
 \end{itemdecl}
@@ -11886,7 +12039,7 @@ path lexically_proximate(const path& base) const;
 
 \rSec3[path.itr]{\tcode{path} iterators}
 
-\indexlibrary{\idxcode{path}!\idxcode{iterator}}
+\indexlibrary{\idxcode{path}!\idxcode{iterator}}%
 \pnum
 Path iterators iterate over the elements of \tcode{pathname}
 in the generic format~(\ref{path.generic}).
@@ -11919,6 +12072,8 @@ characters are present.
 \pnum
 The backward traversal order is the reverse of forward traversal.
 
+\indexlibrary{\idxcode{begin}!\idxcode{path}}%
+\indexlibrary{\idxcode{path}!\idxcode{begin}}%
 \begin{itemdecl}
 iterator begin() const;
 \end{itemdecl}
@@ -11929,6 +12084,8 @@ iterator begin() const;
 list above. If no elements are present, the end iterator.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{end}!\idxcode{path}}%
+\indexlibrary{\idxcode{path}!\idxcode{end}}%
 \begin{itemdecl}
 iterator end() const;
 \end{itemdecl}
@@ -11940,7 +12097,7 @@ iterator end() const;
 
 \rSec3[path.non-member]{\tcode{path} non-member functions}
 
-\indexlibrary{\idxcode{swap}!\idxcode{path}}
+\indexlibrary{\idxcode{swap}!\idxcode{path}}%
 \begin{itemdecl}
 void swap(path& lhs, path& rhs) noexcept;
 \end{itemdecl}
@@ -11950,7 +12107,7 @@ void swap(path& lhs, path& rhs) noexcept;
 \effects As if by \tcode{lhs.swap(rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{hash_value}!\idxcode{path}}
+\indexlibrary{\idxcode{hash_value}!\idxcode{path}}%
 \begin{itemdecl}
 size_t hash_value (const path& p) noexcept;
 \end{itemdecl}
@@ -11961,7 +12118,8 @@ size_t hash_value (const path& p) noexcept;
   for two paths, \tcode{p1 == p2} then \tcode{hash_value(p1) == hash_value(p2)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{path}}
+\indexlibrary{\idxcode{operator<}!\idxcode{path}}%
+\indexlibrary{\idxcode{path}!\idxcode{operator<}}%
 \begin{itemdecl}
 bool operator< (const path& lhs, const path& rhs) noexcept;
 \end{itemdecl}
@@ -11971,7 +12129,8 @@ bool operator< (const path& lhs, const path& rhs) noexcept;
 \returns \tcode{lhs.compare(rhs) < 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{path}}
+\indexlibrary{\idxcode{operator<=}!\idxcode{path}}%
+\indexlibrary{\idxcode{path}!\idxcode{operator<=}}%
 \begin{itemdecl}
 bool operator<=(const path& lhs, const path& rhs) noexcept;
 \end{itemdecl}
@@ -11981,7 +12140,8 @@ bool operator<=(const path& lhs, const path& rhs) noexcept;
 \returns \tcode{!(rhs < lhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>}!\idxcode{path}}
+\indexlibrary{\idxcode{operator>}!\idxcode{path}}%
+\indexlibrary{\idxcode{path}!\idxcode{operator>}}%
 \begin{itemdecl}
 bool operator> (const path& lhs, const path& rhs) noexcept;
 \end{itemdecl}
@@ -11991,7 +12151,8 @@ bool operator> (const path& lhs, const path& rhs) noexcept;
 \returns \tcode{rhs < lhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{path}}
+\indexlibrary{\idxcode{operator>=}!\idxcode{path}}%
+\indexlibrary{\idxcode{path}!\idxcode{operator>=}}%
 \begin{itemdecl}
 bool operator>=(const path& lhs, const path& rhs) noexcept;
 \end{itemdecl}
@@ -12001,7 +12162,8 @@ bool operator>=(const path& lhs, const path& rhs) noexcept;
 \returns \tcode{!(lhs < rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{path}}
+\indexlibrary{\idxcode{operator==}!\idxcode{path}}%
+\indexlibrary{\idxcode{path}!\idxcode{operator==}}%
 \begin{itemdecl}
 bool operator==(const path& lhs, const path& rhs) noexcept;
 \end{itemdecl}
@@ -12028,6 +12190,8 @@ Programmers wishing to determine if two paths are ``the same'' must decide if
   file'', and choose the appropriate function accordingly. \end{note}
 \end{itemdescr}
 
+\indexlibrary{\idxcode{operator"!=}!\idxcode{path}}%
+\indexlibrary{\idxcode{path}!\idxcode{operator"!=}}%
 \begin{itemdecl}
 bool operator!=(const path& lhs, const path& rhs) noexcept;
 \end{itemdecl}
@@ -12037,6 +12201,8 @@ bool operator!=(const path& lhs, const path& rhs) noexcept;
 \returns \tcode{!(lhs == rhs)}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{operator/}!\idxcode{path}}%
+\indexlibrary{\idxcode{path}!\idxcode{operator/}}%
 \begin{itemdecl}
 path operator/ (const path& lhs, const path& rhs);
 \end{itemdecl}
@@ -12048,6 +12214,8 @@ path operator/ (const path& lhs, const path& rhs);
 
 \rSec4[path.io]{\tcode{path} inserter and extractor}
 
+\indexlibrary{\idxcode{operator\shl}!\idxcode{path}}%
+\indexlibrary{\idxcode{path}!\idxcode{operator\shl}}%
 \begin{itemdecl}
 template <class charT, class traits>
   basic_ostream<charT, traits>&
@@ -12063,6 +12231,8 @@ template <class charT, class traits>
 \returns \tcode{os}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{operator\shr}!\idxcode{path}}%
+\indexlibrary{\idxcode{path}!\idxcode{operator\shr}}%
 \begin{itemdecl}
 template <class charT, class traits>
   basic_istream<charT, traits>&
@@ -12151,7 +12321,7 @@ For Windows-based operating systems a conversion from UTF-8 to
 
 \rSec2[class.filesystem_error]{Class \tcode{filesystem_error}}
 
-\indexlibrary{\idxcode{filesystem_error}}
+\indexlibrary{\idxcode{filesystem_error}}%
 \begin{codeblock}
 namespace std::filesystem {
   class filesystem_error : public system_error {
@@ -12179,6 +12349,7 @@ sub-clause.
  Constructors are provided that store zero, one, or two paths associated with
 an error.
 
+\indexlibrary{\idxcode{filesystem_error}!constructor}%
 \begin{itemdecl}
 filesystem_error(const string& what_arg, error_code ec);
 \end{itemdecl}
@@ -12200,6 +12371,7 @@ Table~\ref{tab:filesystem_error.1}.
 \end{floattable}
 \end{itemdescr}
 
+\indexlibrary{\idxcode{filesystem_error}!constructor}%
 \begin{itemdecl}
 filesystem_error(const string& what_arg, const path& p1, error_code ec);
 \end{itemdecl}
@@ -12221,6 +12393,7 @@ Table~\ref{tab:filesystem_error.2}.
 \end{floattable}
 \end{itemdescr}
 
+\indexlibrary{\idxcode{filesystem_error}!constructor}%
 \begin{itemdecl}
 filesystem_error(const string& what_arg, const path& p1, const path& p2, error_code ec);
 \end{itemdecl}
@@ -12242,8 +12415,8 @@ Table~\ref{tab:filesystem_error.3}.
 \end{floattable}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{filesystem_error}!\idxcode{path1}}
-\indexlibrary{\idxcode{path1}!\idxcode{filesystem_error}}
+\indexlibrary{\idxcode{filesystem_error}!\idxcode{path1}}%
+\indexlibrary{\idxcode{path1}!\idxcode{filesystem_error}}%
 \begin{itemdecl}
 const path& path1() const noexcept;
 \end{itemdecl}
@@ -12254,8 +12427,8 @@ const path& path1() const noexcept;
   constructor, or, if none, an empty path.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{filesystem_error}!\idxcode{path2}}
-\indexlibrary{\idxcode{path2}!\idxcode{filesystem_error}}
+\indexlibrary{\idxcode{filesystem_error}!\idxcode{path2}}%
+\indexlibrary{\idxcode{path2}!\idxcode{filesystem_error}}%
 \begin{itemdecl}
 const path& path2() const noexcept;
 \end{itemdecl}
@@ -12266,8 +12439,8 @@ const path& path2() const noexcept;
   constructor, or, if none, an empty path.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{filesystem_error}!\idxcode{what}}
-\indexlibrary{\idxcode{what}!\idxcode{filesystem_error}}
+\indexlibrary{\idxcode{filesystem_error}!\idxcode{what}}%
+\indexlibrary{\idxcode{what}!\idxcode{filesystem_error}}%
 \begin{itemdecl}
 const char* what() const noexcept;
 \end{itemdecl}
@@ -12284,7 +12457,7 @@ const char* what() const noexcept;
 
 \rSec3[enum.file_type]{Enum class \tcode{file_type}}
 
-\indexlibrary{\idxcode{file_type}}
+\indexlibrary{\idxcode{file_type}}%
 \pnum
 This enum class specifies constants used to identify file types,
 with the meanings listed in Table~\ref{tab:enum.file_type}.
@@ -12319,7 +12492,7 @@ The file does exist, but is of an operating system dependent type not
 
 \rSec3[enum.copy_options]{Enum class \tcode{copy_options}}
 
-\indexlibrary{\idxcode{copy_options}}
+\indexlibrary{\idxcode{copy_options}}%
 \pnum
 The \tcode{enum class} type \tcode{copy_options}
 is a bitmask type~(\ref{bitmask.types}) that specifies bitmask constants used to control the semantics of
@@ -12376,7 +12549,7 @@ group results in undefined behavior.
 
 \rSec3[enum.perms]{Enum class \tcode{perms}}
 
-\indexlibrary{\idxcode{perms}}
+\indexlibrary{\idxcode{perms}}%
 \pnum
 The \tcode{enum class} type \tcode{perms}
 is a bitmask type~(\ref{bitmask.types}) that specifies bitmask constants used to identify file
@@ -12445,7 +12618,7 @@ permissions, with the meanings listed in Table~\ref{tab:enum.perms}.
 
 \rSec3[enum.directory_options]{Enum class \tcode{directory_options}}
 
-\indexlibrary{\idxcode{directory_options}}
+\indexlibrary{\idxcode{directory_options}}%
 \pnum
 The \tcode{enum class} type \tcode{directory_options} is a bitmask
   type~(\ref{bitmask.types}) that specifies bitmask constants used to identify
@@ -12472,7 +12645,7 @@ Skip directories that would otherwise result in permission denied. \\
 
 \rSec2[class.file_status]{Class \tcode{file_status}}
 
-\indexlibrary{\idxcode{file_status}}
+\indexlibrary{\idxcode{file_status}}%
 \begin{codeblock}
 namespace std::filesystem {
   class file_status {
@@ -12504,6 +12677,7 @@ An object of type \tcode{file_status} stores information about the type
 and permissions of a file.
 \rSec3[file_status.cons]{\tcode{file_status} constructors}
 
+\indexlibrary{\idxcode{file_status}!constructor}%
 \begin{itemdecl}
 explicit file_status() noexcept;
 \end{itemdecl}
@@ -12513,6 +12687,7 @@ explicit file_status() noexcept;
 \postconditions \tcode{type() == file_type::none} and \tcode{permissions() == perms::unknown}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{file_status}!constructor}%
 \begin{itemdecl}
 explicit file_status(file_type ft, perms prms = perms::unknown) noexcept;
 \end{itemdecl}
@@ -12524,6 +12699,8 @@ explicit file_status(file_type ft, perms prms = perms::unknown) noexcept;
 
 \rSec3[file_status.obs]{\tcode{file_status} observers}
 
+\indexlibrary{\idxcode{file_status}!\idxcode{type}}%
+\indexlibrary{\idxcode{type}!\idxcode{file_status}}%
 \begin{itemdecl}
 file_type type() const noexcept;
 \end{itemdecl}
@@ -12534,6 +12711,9 @@ file_type type() const noexcept;
   \tcode{operator=}, or \tcode{type(file_type)} function.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{file_status}!\idxcode{permissions}}%
+\indexlibrary{\idxcode{permissions}!\idxcode{file_status}}%
+\begin{itemdecl}
 \begin{itemdecl}
 perms permissions() const noexcept;
 \end{itemdecl}
@@ -12546,6 +12726,8 @@ perms permissions() const noexcept;
 
 \rSec3[file_status.mods]{\tcode{file_status} modifiers}
 
+\indexlibrary{\idxcode{file_status}!\idxcode{type}}%
+\indexlibrary{\idxcode{type}!\idxcode{file_status}}%
 \begin{itemdecl}
 void type(file_type ft) noexcept;
 \end{itemdecl}
@@ -12555,6 +12737,8 @@ void type(file_type ft) noexcept;
 \postconditions \tcode{type() == ft}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{file_status}!\idxcode{permissions}}%
+\indexlibrary{\idxcode{permissions}!\idxcode{file_status}}%
 \begin{itemdecl}
 void permissions(perms prms) noexcept;
 \end{itemdecl}
@@ -12610,6 +12794,7 @@ A \tcode{directory_entry} object stores a \tcode{path} object.
 
 \rSec3[directory_entry.cons]{\tcode{directory_entry} constructors}
 
+\indexlibrary{\idxcode{directory_entry}!constructor}%
 \begin{itemdecl}
 explicit directory_entry(const path& p);
 \end{itemdecl}
@@ -12624,6 +12809,8 @@ explicit directory_entry(const path& p);
 
 \rSec3[directory_entry.mods]{\tcode{directory_entry} modifiers}
 
+\indexlibrary{\idxcode{directory_entry}!\idxcode{assign}}%
+\indexlibrary{\idxcode{assign}!\idxcode{directory_entry}}%
 \begin{itemdecl}
 void assign(const path& p);
 \end{itemdecl}
@@ -12633,6 +12820,8 @@ void assign(const path& p);
 \postcondition \tcode{path() == p}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{directory_entry}!\idxcode{replace_filename}}%
+\indexlibrary{\idxcode{replace_filename}!\idxcode{directory_entry}}%
 \begin{itemdecl}
 void replace_filename(const path& p);
 \end{itemdecl}
@@ -12646,6 +12835,8 @@ void replace_filename(const path& p);
 
 \rSec3[directory_entry.obs]{\tcode{directory_entry} observers}
 
+\indexlibrary{\idxcode{directory_entry}!\idxcode{path}}%
+\indexlibrary{\idxcode{path}!\idxcode{directory_entry}}%
 \begin{itemdecl}
 const path& path() const noexcept;
 operator const path&() const noexcept;
@@ -12656,6 +12847,8 @@ operator const path&() const noexcept;
 \returns \tcode{pathobject}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{directory_entry}!\idxcode{status}}%
+\indexlibrary{\idxcode{status}!\idxcode{directory_entry}}%
 \begin{itemdecl}
 file_status status() const;
 file_status status(error_code& ec) const noexcept;
@@ -12669,6 +12862,8 @@ file_status status(error_code& ec) const noexcept;
 \throws As specified in Error reporting~(\ref{fs.err.report}).
 \end{itemdescr}
 
+\indexlibrary{\idxcode{directory_entry}!\idxcode{symlink_status}}%
+\indexlibrary{\idxcode{symlink_status}!\idxcode{directory_entry}}%
 \begin{itemdecl}
 file_status  symlink_status() const;
 file_status  symlink_status(error_code& ec) const noexcept;
@@ -12682,6 +12877,8 @@ file_status  symlink_status(error_code& ec) const noexcept;
 \throws As specified in Error reporting~(\ref{fs.err.report}).
 \end{itemdescr}
 
+\indexlibrary{\idxcode{directory_entry}!\idxcode{operator==}}%
+\indexlibrary{\idxcode{operator==}!\idxcode{directory_entry}}%
 \begin{itemdecl}
 bool operator==(const directory_entry& rhs) const noexcept;
 \end{itemdecl}
@@ -12691,6 +12888,8 @@ bool operator==(const directory_entry& rhs) const noexcept;
 \returns \tcode{pathobject == rhs.pathobject}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{directory_entry}!\idxcode{operator"!=}}%
+\indexlibrary{\idxcode{operator"!=}!\idxcode{directory_entry}}%
 \begin{itemdecl}
 bool operator!=(const directory_entry& rhs) const noexcept;
 \end{itemdecl}
@@ -12700,6 +12899,8 @@ bool operator!=(const directory_entry& rhs) const noexcept;
 \returns \tcode{pathobject != rhs.pathobject}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{directory_entry}!\idxcode{operator<}}%
+\indexlibrary{\idxcode{operator<}!\idxcode{directory_entry}}%
 \begin{itemdecl}
 bool operator< (const directory_entry& rhs) const noexcept;
 \end{itemdecl}
@@ -12709,6 +12910,8 @@ bool operator< (const directory_entry& rhs) const noexcept;
 \returns \tcode{pathobject < rhs.pathobject}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{directory_entry}!\idxcode{operator<=}}%
+\indexlibrary{\idxcode{operator<=}!\idxcode{directory_entry}}%
 \begin{itemdecl}
 bool operator<=(const directory_entry& rhs) const noexcept;
 \end{itemdecl}
@@ -12718,6 +12921,8 @@ bool operator<=(const directory_entry& rhs) const noexcept;
 \returns \tcode{pathobject <= rhs.pathobject}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{directory_entry}!\idxcode{operator>}}%
+\indexlibrary{\idxcode{operator>}!\idxcode{directory_entry}}%
 \begin{itemdecl}
 bool operator> (const directory_entry& rhs) const noexcept;
 \end{itemdecl}
@@ -12727,6 +12932,8 @@ bool operator> (const directory_entry& rhs) const noexcept;
 \returns \tcode{pathobject > rhs.pathobject}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{directory_entry}!\idxcode{operator>=}}%
+\indexlibrary{\idxcode{operator>=}!\idxcode{directory_entry}}%
 \begin{itemdecl}
 bool operator>=(const directory_entry& rhs) const noexcept;
 \end{itemdecl}
@@ -12738,7 +12945,7 @@ bool operator>=(const directory_entry& rhs) const noexcept;
 
 \rSec2[class.directory_iterator]{Class \tcode{directory_iterator}}
 
-\indexlibrary{\idxcode{directory_iterator}}
+\indexlibrary{\idxcode{directory_iterator}}%
 \pnum
 An object of type \tcode{directory_iterator} provides an iterator for a
 sequence of \tcode{directory_entry} elements representing the files in a
@@ -12829,6 +13036,7 @@ POSIX \tcode{readdir_r}.
 
 \rSec3[directory_iterator.members]{\tcode{directory_iterator} members}
 
+\indexlibrary{\idxcode{directory_iterator}!constructor}%
 \begin{itemdecl}
 directory_iterator() noexcept;
 \end{itemdecl}
@@ -12838,16 +13046,15 @@ directory_iterator() noexcept;
 \effects Constructs the end iterator.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{directory_iterator}!constructor}%
 \begin{itemdecl}
 explicit directory_iterator(const path& p);
 directory_iterator(const path& p, directory_options options);
 directory_iterator(const path& p, error_code& ec) noexcept;
 directory_iterator(const path& p, directory_options options, error_code& ec) noexcept;
-
 \end{itemdecl}
 
 \begin{itemdescr}
-
 \pnum
 \effects For the directory that \tcode{p} resolves to, constructs an
 iterator for the first element in a sequence of \tcode{directory_entry}
@@ -12867,6 +13074,7 @@ and does not report an error.
 \begin{note} To iterate over the current directory, use \tcode{directory_iterator(".")} rather than \tcode{directory_iterator("")}. \end{note}
 \end{itemdescr}
 
+\indexlibrary{\idxcode{directory_iterator}!constructor}%
 \begin{itemdecl}
 directory_iterator(const directory_iterator& rhs);
 directory_iterator(directory_iterator&& rhs) noexcept;
@@ -12880,6 +13088,8 @@ directory_iterator(directory_iterator&& rhs) noexcept;
 \postconditions \tcode{*this} has the original value of \tcode{rhs}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{directory_iterator}!\idxcode{operator=}}%
+\indexlibrary{\idxcode{operator=}!\idxcode{directory_iterator}}%
 \begin{itemdecl}
 directory_iterator& operator=(const directory_iterator& rhs);
 directory_iterator& operator=(directory_iterator&& rhs) noexcept;
@@ -12897,10 +13107,10 @@ directory_iterator& operator=(directory_iterator&& rhs) noexcept;
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{directory_iterator}!\idxcode{increment}}
-\indexlibrary{\idxcode{increment}!\idxcode{directory_iterator}}
-\indexlibrary{\idxcode{directory_iterator}!\idxcode{operator++}}
-\indexlibrary{\idxcode{operator++}!\idxcode{directory_iterator}}
+\indexlibrary{\idxcode{directory_iterator}!\idxcode{increment}}%
+\indexlibrary{\idxcode{increment}!\idxcode{directory_iterator}}%
+\indexlibrary{\idxcode{directory_iterator}!\idxcode{operator++}}%
+\indexlibrary{\idxcode{operator++}!\idxcode{directory_iterator}}%
 \begin{itemdecl}
 directory_iterator& operator++();
 directory_iterator& increment(error_code& ec) noexcept;
@@ -12924,6 +13134,8 @@ Input iterators~(\ref{input.iterators}).
 
 \pnum
 These functions enable range access for \tcode{directory_iterator}.
+
+\indexlibrary{\idxcode{begin}!\idxcode{directory_iterator}}%
 \begin{itemdecl}
 directory_iterator begin(directory_iterator iter) noexcept;
 \end{itemdecl}
@@ -12933,6 +13145,7 @@ directory_iterator begin(directory_iterator iter) noexcept;
 \returns \tcode{iter}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{end}!\idxcode{directory_iterator}}%
 \begin{itemdecl}
 directory_iterator end(const directory_iterator&) noexcept;
 \end{itemdecl}
@@ -12944,7 +13157,7 @@ directory_iterator end(const directory_iterator&) noexcept;
 
 \rSec2[class.rec.dir.itr]{Class \tcode{recursive_directory_iterator}}
 
-\indexlibrary{\idxcode{recursive_directory_iterator}}
+\indexlibrary{\idxcode{recursive_directory_iterator}}%
 \pnum
 An object of type \tcode{recursive_directory_iterator} provides an iterator for
 a sequence of \tcode{directory_entry} elements representing the files in a
@@ -13012,6 +13225,7 @@ then the end iterator may be unreachable. \end{note}
 
 \rSec3[rec.dir.itr.members]{\tcode{recursive_directory_iterator} members}
 
+\indexlibrary{\idxcode{recursive_directory_iterator}!constructor}%
 \begin{itemdecl}
 recursive_directory_iterator() noexcept;
 \end{itemdecl}
@@ -13024,6 +13238,7 @@ recursive_directory_iterator() noexcept;
 \end{itemdescr}
 
 
+\indexlibrary{\idxcode{recursive_directory_iterator}!constructor}%
 \begin{itemdecl}
 explicit recursive_directory_iterator(const path& p);
 recursive_directory_iterator(const path& p, directory_options options);
@@ -13061,6 +13276,7 @@ follow directory symlinks. To follow directory symlinks, specify \tcode{options}
 \tcode{directory_options::follow_directory_symlink} \end{note}
 \end{itemdescr}
 
+\indexlibrary{\idxcode{recursive_directory_iterator}!constructor}%
 \begin{itemdecl}
 recursive_directory_iterator(const recursive_directory_iterator& rhs);
 \end{itemdecl}
@@ -13078,6 +13294,7 @@ recursive_directory_iterator(const recursive_directory_iterator& rhs);
 \end{itemize}
 \end{itemdescr}
 
+\indexlibrary{\idxcode{recursive_directory_iterator}!constructor}%
 \begin{itemdecl}
 recursive_directory_iterator(recursive_directory_iterator&& rhs) noexcept;
 \end{itemdecl}
@@ -13093,6 +13310,8 @@ recursive_directory_iterator(recursive_directory_iterator&& rhs) noexcept;
   \tcode{rhs.recursion_pending()}, respectively, had before the function call.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{recursive_directory_iterator}!\idxcode{operator=}}%
+\indexlibrary{\idxcode{operator=}!\idxcode{recursive_directory_iterator}}%
 \begin{itemdecl}
 recursive_directory_iterator& operator=(const recursive_directory_iterator& rhs);
 \end{itemdecl}
@@ -13114,6 +13333,8 @@ recursive_directory_iterator& operator=(const recursive_directory_iterator& rhs)
 \returns \tcode{*this}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{recursive_directory_iterator}!\idxcode{operator=}}%
+\indexlibrary{\idxcode{operator=}!\idxcode{recursive_directory_iterator}}%
 \begin{itemdecl}
 recursive_directory_iterator& operator=(recursive_directory_iterator&& rhs) noexcept;
 \end{itemdecl}
@@ -13132,6 +13353,8 @@ and \tcode{this->recursion_pending()} return the values that \tcode{rhs.options(
 \returns \tcode{*this}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{recursive_directory_iterator}!\idxcode{options}}%
+\indexlibrary{\idxcode{options}!\idxcode{recursive_directory_iterator}}%
 \begin{itemdecl}
 directory_options options() const;
 \end{itemdecl}
@@ -13145,6 +13368,8 @@ if present, otherwise \tcode{directory_options::none}.
 \throws Nothing.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{recursive_directory_iterator}!\idxcode{depth}}%
+\indexlibrary{\idxcode{depth}!\idxcode{recursive_directory_iterator}}%
 \begin{itemdecl}
 int depth() const;
 \end{itemdecl}
@@ -13159,6 +13384,8 @@ int depth() const;
 \throws Nothing.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{recursive_directory_iterator}!\idxcode{recursion_pending}}%
+\indexlibrary{\idxcode{recursion_pending}!\idxcode{recursive_directory_iterator}}%
 \begin{itemdecl}
 bool recursion_pending() const;
 \end{itemdecl}
@@ -13173,10 +13400,10 @@ bool recursion_pending() const;
 \throws Nothing.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{recursive_directory_iterator}!\idxcode{increment}}
-\indexlibrary{\idxcode{increment}!\idxcode{recursive_directory_iterator}}
-\indexlibrary{\idxcode{recursive_directory_iterator}!\idxcode{operator++}}
-\indexlibrary{\idxcode{operator++}!\idxcode{recursive_directory_iterator}}
+\indexlibrary{\idxcode{recursive_directory_iterator}!\idxcode{increment}}%
+\indexlibrary{\idxcode{increment}!\idxcode{recursive_directory_iterator}}%
+\indexlibrary{\idxcode{recursive_directory_iterator}!\idxcode{operator++}}%
+\indexlibrary{\idxcode{operator++}!\idxcode{recursive_directory_iterator}}%
 \begin{itemdecl}
 recursive_directory_iterator& operator++();
 recursive_directory_iterator& increment(error_code& ec) noexcept;
@@ -13215,6 +13442,8 @@ treated as an empty directory and no error is reported.
 \throws As specified in Error reporting~(\ref{fs.err.report}).
 \end{itemdescr}
 
+\indexlibrary{\idxcode{recursive_directory_iterator}!\idxcode{pop}}%
+\indexlibrary{\idxcode{pop}!\idxcode{recursive_directory_iterator}}%
 \begin{itemdecl}
 void pop();
 void pop(error_code& ec);
@@ -13230,6 +13459,8 @@ void pop(error_code& ec);
 \throws As specified in Error reporting~(\ref{fs.err.report}).
 \end{itemdescr}
 
+\indexlibrary{\idxcode{recursive_directory_iterator}!\idxcode{disable_recursion_pending}}%
+\indexlibrary{\idxcode{disable_recursion_pending}!\idxcode{recursive_directory_iterator}}%
 \begin{itemdecl}
 void disable_recursion_pending();
 \end{itemdecl}
@@ -13249,6 +13480,7 @@ void disable_recursion_pending();
 These functions enable use of \tcode{recursive_directory_iterator}
 with range-based for statements.
 
+\indexlibrary{\idxcode{begin}!\idxcode{recursive_directory_iterator}}%
 \begin{itemdecl}
 recursive_directory_iterator begin(recursive_directory_iterator iter) noexcept;
 \end{itemdecl}
@@ -13258,6 +13490,7 @@ recursive_directory_iterator begin(recursive_directory_iterator iter) noexcept;
 \returns \tcode{iter}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{begin}!\idxcode{recursive_directory_iterator}}%
 \begin{itemdecl}
 recursive_directory_iterator end(const recursive_directory_iterator&) noexcept;
 \end{itemdecl}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -13489,7 +13489,7 @@ recursive_directory_iterator begin(recursive_directory_iterator iter) noexcept;
 \returns \tcode{iter}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{begin}!\idxcode{recursive_directory_iterator}}%
+\indexlibrary{\idxcode{end}!\idxcode{recursive_directory_iterator}}%
 \begin{itemdecl}
 recursive_directory_iterator end(const recursive_directory_iterator&) noexcept;
 \end{itemdecl}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -1177,8 +1177,8 @@ fmtflags flags() const;
 The format control information for both input and output.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{ios_base}!\idxcode{fmtflags}}%
-\indexlibrary{\idxcode{fmtflags}!\idxcode{ios_base}}%
+\indexlibrary{\idxcode{ios_base}!\idxcode{flags}}%
+\indexlibrary{\idxcode{flags}!\idxcode{ios_base}}%
 \begin{itemdecl}
 fmtflags flags(fmtflags fmtfl);
 \end{itemdecl}
@@ -4405,8 +4405,7 @@ a failure indication.
 explicit basic_istream(basic_streambuf<charT, traits>* sb);
 \end{itemdecl}
 
-\indexlibrary{\idxcode{init}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{init}}%
+\indexlibrary{\idxcode{init}!\idxcode{basic_ios}}%
 \begin{itemdescr}
 \pnum
 \effects


### PR DESCRIPTION
Some work remains to properly index all of the free (namespace scope) functions.

Will review other clauses later, especially those clauses with lots of additions for C++17.