### PR TITLE
[support] clean up index for clause 18

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -2104,7 +2104,7 @@ void* operator new[](std::size_t size, void* ptr) noexcept;
 Intentionally performs no other action.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{new}!\idxcode{operator}}%
+\indexlibrary{\idxcode{delete}!\idxcode{operator}}%
 \begin{itemdecl}
 void operator delete(void* ptr, void*) noexcept;
 \end{itemdecl}
@@ -2127,7 +2127,7 @@ non-array placement operator new
 terminates by throwing an exception~(\ref{expr.new}).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{new}!\idxcode{operator}}%
+\indexlibrary{\idxcode{delete}!\idxcode{operator}}%
 \begin{itemdecl}
 void operator delete[](void* ptr, void*) noexcept;
 \end{itemdecl}
@@ -2341,6 +2341,7 @@ The initial \tcode{new_handler} is a null pointer.
 
 \rSec3[get.new.handler]{\tcode{get_new_handler}}
 
+\indexlibrary{\idxcode{get_new_handler}}%
 \begin{itemdecl}
 new_handler get_new_handler() noexcept;
 \end{itemdecl}
@@ -2353,6 +2354,7 @@ new_handler get_new_handler() noexcept;
 
 \rSec2[ptr.launder]{Pointer optimization barrier}
 
+\indexlibrary{\idxcode{launder}}%
 \begin{itemdecl}
 template <class T> constexpr T* launder(T* p) noexcept;
 \end{itemdecl}
@@ -2519,6 +2521,7 @@ The names, encoding rule, and collating sequence for types are all unspecified
 and may differ between programs.
 
 \indexlibrary{\idxcode{operator==}!\idxcode{type_info}}%
+\indexlibrary{\idxcode{type_info}!\idxcode{operator==}}%
 \begin{itemdecl}
 bool operator==(const type_info& rhs) const noexcept;
 \end{itemdecl}
@@ -2535,6 +2538,7 @@ if the two values describe the same type.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator"!=}!\idxcode{type_info}}%
+\indexlibrary{\idxcode{type_info}!\idxcode{operator"!=}}%
 \begin{itemdecl}
 bool operator!=(const type_info& rhs) const noexcept;
 \end{itemdecl}
@@ -2546,6 +2550,7 @@ bool operator!=(const type_info& rhs) const noexcept;
 \end{itemdescr}
 
 \indexlibrary{\idxcode{before}!\idxcode{type_info}}%
+\indexlibrary{\idxcode{type_info}!\idxcode{before}}%
 \begin{itemdecl}
 bool before(const type_info& rhs) const noexcept;
 \end{itemdecl}
@@ -2564,6 +2569,7 @@ precedes \tcode{rhs} in the implementation's collation order.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{hash_code}!\idxcode{type_info}}%
+\indexlibrary{\idxcode{type_info}!\idxcode{hash_code}}%
 \begin{itemdecl}
 size_t hash_code() const noexcept;
 \end{itemdecl}
@@ -2993,6 +2999,7 @@ The previous \tcode{terminate_handler}.
 
 \rSec3[get.terminate]{\tcode{get_terminate}}
 
+\indexlibrary{\idxcode{get_terminate}}%
 \begin{itemdecl}
 terminate_handler get_terminate() noexcept;
 \end{itemdecl}


### PR DESCRIPTION
Fix a couple of mis-indexed operators, and add index entries
for a few missing functions, most notably the new launder
function.