### PR TITLE
[path.type.cvt] remove redundant word

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -10980,15 +10980,15 @@ strings to identify paths. Changing this behavior would be surprising and error
 prone.
 \end{note}
 \item \tcode{wchar_t}: The encoding is the native wide encoding~(\ref{fs.def.native.encode}).
-The method of conversion method is unspecified.
+The method of conversion is unspecified.
 \begin{note}
 For Windows-based operating systems \tcode{path::value_type} is \tcode{wchar_t}
 so no conversion from \tcode{wchar_t} value type arguments or to \tcode{wchar_t}
 value type return values is performed.
 \end{note}
-\item \tcode{char16_t}: The encoding is UTF-16. The method of conversion method
+\item \tcode{char16_t}: The encoding is UTF-16. The method of conversion
 is unspecified.
-\item \tcode{char32_t}: The encoding is UTF-32. The method of conversion method
+\item \tcode{char32_t}: The encoding is UTF-32. The method of conversion
 is unspecified.
 \end{itemize}
 


### PR DESCRIPTION
Remove the second "method" in "The method of conversion method is unspecified."