### PR TITLE
[diagnostics] audit index entries for clause 19

### DIFF
--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -971,8 +971,8 @@ virtual ~error_category();
 \effects Destroys an object of class \tcode{error_category}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{name}!\idxcode{error_category}}
-\indexlibrary{\idxcode{error_category}!\idxcode{name}}
+\indexlibrary{\idxcode{name}!\idxcode{error_category}}%
+\indexlibrary{\idxcode{error_category}!\idxcode{name}}%
 \begin{itemdecl}
 virtual const char* name() const noexcept = 0;
 \end{itemdecl}
@@ -982,8 +982,8 @@ virtual const char* name() const noexcept = 0;
 \returns A string naming the error category.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{default_error_condition}!\idxcode{error_category}}
-\indexlibrary{\idxcode{error_category}!\idxcode{default_error_condition}}
+\indexlibrary{\idxcode{default_error_condition}!\idxcode{error_category}}%
+\indexlibrary{\idxcode{error_category}!\idxcode{default_error_condition}}%
 \begin{itemdecl}
 virtual error_condition default_error_condition(int ev) const noexcept;
 \end{itemdecl}
@@ -994,8 +994,8 @@ virtual error_condition default_error_condition(int ev) const noexcept;
 \tcode{error_condition(ev, *this)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{equivalent}!\idxcode{error_category}}
-\indexlibrary{\idxcode{error_category}!\idxcode{equivalent}}
+\indexlibrary{\idxcode{equivalent}!\idxcode{error_category}}%
+\indexlibrary{\idxcode{error_category}!\idxcode{equivalent}}%
 \begin{itemdecl}
 virtual bool equivalent(int code, const error_condition& condition) const noexcept;
 \end{itemdecl}
@@ -1005,8 +1005,8 @@ virtual bool equivalent(int code, const error_condition& condition) const noexce
 \returns \tcode{default_error_condition(code) == condition}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{equivalent}!\idxcode{error_category}}
-\indexlibrary{\idxcode{error_category}!\idxcode{equivalent}}
+\indexlibrary{\idxcode{equivalent}!\idxcode{error_category}}%
+\indexlibrary{\idxcode{error_category}!\idxcode{equivalent}}%
 \begin{itemdecl}
 virtual bool equivalent(const error_code& code, int condition) const noexcept;
 \end{itemdecl}
@@ -1016,8 +1016,8 @@ virtual bool equivalent(const error_code& code, int condition) const noexcept;
 \returns \tcode{*this == code.category() \&\& code.value() == condition}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{message}!\idxcode{error_category}}
-\indexlibrary{\idxcode{error_category}!\idxcode{message}}
+\indexlibrary{\idxcode{message}!\idxcode{error_category}}%
+\indexlibrary{\idxcode{error_category}!\idxcode{message}}%
 \begin{itemdecl}
 virtual string message(int ev) const = 0;
 \end{itemdecl}
@@ -1039,8 +1039,8 @@ constexpr error_category() noexcept;
 \effects Constructs an object of class \tcode{error_category}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{error_category}}
-\indexlibrary{\idxcode{error_category}!\idxcode{operator==}}
+\indexlibrary{\idxcode{operator==}!\idxcode{error_category}}%
+\indexlibrary{\idxcode{error_category}!\idxcode{operator==}}%
 \begin{itemdecl}
 bool operator==(const error_category& rhs) const noexcept;
 \end{itemdecl}
@@ -1050,8 +1050,8 @@ bool operator==(const error_category& rhs) const noexcept;
 \returns \tcode{this == \&rhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{error_category}}
-\indexlibrary{\idxcode{error_category}!\idxcode{operator"!=}}
+\indexlibrary{\idxcode{operator"!=}!\idxcode{error_category}}%
+\indexlibrary{\idxcode{error_category}!\idxcode{operator"!=}}%
 \begin{itemdecl}
 bool operator!=(const error_category& rhs) const noexcept;
 \end{itemdecl}
@@ -1061,8 +1061,8 @@ bool operator!=(const error_category& rhs) const noexcept;
 \returns \tcode{!(*this == rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{error_category}}
-\indexlibrary{\idxcode{error_category}!\idxcode{operator<}}
+\indexlibrary{\idxcode{operator<}!\idxcode{error_category}}%
+\indexlibrary{\idxcode{error_category}!\idxcode{operator<}}%
 \begin{itemdecl}
 bool operator<(const error_category& rhs) const noexcept;
 \end{itemdecl}
@@ -1076,8 +1076,8 @@ bool operator<(const error_category& rhs) const noexcept;
 
 \rSec3[syserr.errcat.derived]{Program defined classes derived from \tcode{error_category}}
 
-\indexlibrary{\idxcode{name}!\idxcode{error_category}}
-\indexlibrary{\idxcode{error_category}!\idxcode{name}}
+\indexlibrary{\idxcode{name}!\idxcode{error_category}}%
+\indexlibrary{\idxcode{error_category}!\idxcode{name}}%
 \begin{itemdecl}
 virtual const char* name() const noexcept = 0;
 \end{itemdecl}
@@ -1087,8 +1087,8 @@ virtual const char* name() const noexcept = 0;
 \returns A string naming the error category.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{default_error_condition}!\idxcode{error_category}}
-\indexlibrary{\idxcode{error_category}!\idxcode{default_error_condition}}
+\indexlibrary{\idxcode{default_error_condition}!\idxcode{error_category}}%
+\indexlibrary{\idxcode{error_category}!\idxcode{default_error_condition}}%
 \begin{itemdecl}
 virtual error_condition default_error_condition(int ev) const noexcept;
 \end{itemdecl}
@@ -1098,8 +1098,8 @@ virtual error_condition default_error_condition(int ev) const noexcept;
 \returns An object of type \tcode{error_condition} that corresponds to \tcode{ev}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{equivalent}!\idxcode{error_category}}
-\indexlibrary{\idxcode{error_category}!\idxcode{equivalent}}
+\indexlibrary{\idxcode{equivalent}!\idxcode{error_category}}%
+\indexlibrary{\idxcode{error_category}!\idxcode{equivalent}}%
 \begin{itemdecl}
 virtual bool equivalent(int code, const error_condition& condition) const noexcept;
 \end{itemdecl}
@@ -1109,8 +1109,8 @@ virtual bool equivalent(int code, const error_condition& condition) const noexce
 \returns \tcode{true} if, for the category of error represented by \tcode{*this}, \tcode{code} is considered equivalent to \tcode{condition}; otherwise, \tcode{false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{equivalent}!\idxcode{error_category}}
-\indexlibrary{\idxcode{error_category}!\idxcode{equivalent}}
+\indexlibrary{\idxcode{equivalent}!\idxcode{error_category}}%
+\indexlibrary{\idxcode{error_category}!\idxcode{equivalent}}%
 \begin{itemdecl}
 virtual bool equivalent(const error_code& code, int condition) const noexcept;
 \end{itemdecl}
@@ -1122,7 +1122,7 @@ virtual bool equivalent(const error_code& code, int condition) const noexcept;
 
 \rSec3[syserr.errcat.objects]{Error category objects}
 
-\indexlibrary{\idxcode{generic_category}}
+\indexlibrary{\idxcode{generic_category}}%
 \begin{itemdecl}
 const error_category& generic_category() noexcept;
 \end{itemdecl}
@@ -1136,7 +1136,7 @@ All calls to this function shall return references to the same object.
 \remarks The object's \tcode{default_error_condition} and \tcode{equivalent} virtual functions shall behave as specified for the class \tcode{error_category}. The object's \tcode{name} virtual function shall return a pointer to the string \tcode{"generic"}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{system_category}}
+\indexlibrary{\idxcode{system_category}}%
 \begin{itemdecl}
 const error_category& system_category() noexcept;
 \end{itemdecl}
@@ -1212,7 +1212,7 @@ namespace std {
 
 \rSec3[syserr.errcode.constructors]{Class \tcode{error_code} constructors}
 
-\indexlibrary{\idxcode{error_code}!constructor}
+\indexlibrary{\idxcode{error_code}!constructor}%
 \begin{itemdecl}
 error_code() noexcept;
 \end{itemdecl}
@@ -1225,7 +1225,7 @@ error_code() noexcept;
 \postconditions \tcode{val_ == 0} and \tcode{cat_ == \&system_category()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{error_code}!constructor}
+\indexlibrary{\idxcode{error_code}!constructor}%
 \begin{itemdecl}
 error_code(int val, const error_category& cat) noexcept;
 \end{itemdecl}
@@ -1238,7 +1238,7 @@ error_code(int val, const error_category& cat) noexcept;
 \postconditions \tcode{val_ == val} and \tcode{cat_ == \&cat}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{error_code}!constructor}
+\indexlibrary{\idxcode{error_code}!constructor}%
 \begin{itemdecl}
 template <class ErrorCodeEnum>
   error_code(ErrorCodeEnum e) noexcept;
@@ -1258,8 +1258,8 @@ template <class ErrorCodeEnum>
 
 \rSec3[syserr.errcode.modifiers]{Class \tcode{error_code} modifiers}
 
-\indexlibrary{\idxcode{assign}!\idxcode{error_code}}
-\indexlibrary{\idxcode{error_code}!\idxcode{assign}}
+\indexlibrary{\idxcode{assign}!\idxcode{error_code}}%
+\indexlibrary{\idxcode{error_code}!\idxcode{assign}}%
 \begin{itemdecl}
 void assign(int val, const error_category& cat) noexcept;
 \end{itemdecl}
@@ -1269,8 +1269,8 @@ void assign(int val, const error_category& cat) noexcept;
 \postconditions \tcode{val_ == val} and \tcode{cat_ == \&cat}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{error_code}}
-\indexlibrary{\idxcode{error_code}!\idxcode{operator=}}
+\indexlibrary{\idxcode{operator=}!\idxcode{error_code}}%
+\indexlibrary{\idxcode{error_code}!\idxcode{operator=}}%
 \begin{itemdecl}
 template <class ErrorCodeEnum>
     error_code& operator=(ErrorCodeEnum e) noexcept;
@@ -1288,8 +1288,8 @@ template <class ErrorCodeEnum>
 \tcode{is_error_code_enum_v<ErrorCodeEnum>} is \tcode{true}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{clear}!\idxcode{error_code}}
-\indexlibrary{\idxcode{error_code}!\idxcode{clear}}
+\indexlibrary{\idxcode{clear}!\idxcode{error_code}}%
+\indexlibrary{\idxcode{error_code}!\idxcode{clear}}%
 \begin{itemdecl}
 void clear() noexcept;
 \end{itemdecl}
@@ -1302,8 +1302,8 @@ void clear() noexcept;
 
 \rSec3[syserr.errcode.observers]{Class \tcode{error_code} observers}
 
-\indexlibrary{\idxcode{value}!\idxcode{error_code}}
-\indexlibrary{\idxcode{error_code}!\idxcode{value}}
+\indexlibrary{\idxcode{value}!\idxcode{error_code}}%
+\indexlibrary{\idxcode{error_code}!\idxcode{value}}%
 \begin{itemdecl}
 int value() const noexcept;
 \end{itemdecl}
@@ -1313,8 +1313,8 @@ int value() const noexcept;
 \returns \tcode{val_}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{category}!\idxcode{error_code}}
-\indexlibrary{\idxcode{error_code}!\idxcode{category}}
+\indexlibrary{\idxcode{category}!\idxcode{error_code}}%
+\indexlibrary{\idxcode{error_code}!\idxcode{category}}%
 \begin{itemdecl}
 const error_category& category() const noexcept;
 \end{itemdecl}
@@ -1324,8 +1324,8 @@ const error_category& category() const noexcept;
 \returns \tcode{*cat_}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{default_error_condition}!\idxcode{error_code}}
-\indexlibrary{\idxcode{error_code}!\idxcode{default_error_condition}}
+\indexlibrary{\idxcode{default_error_condition}!\idxcode{error_code}}%
+\indexlibrary{\idxcode{error_code}!\idxcode{default_error_condition}}%
 \begin{itemdecl}
 error_condition default_error_condition() const noexcept;
 \end{itemdecl}
@@ -1335,8 +1335,8 @@ error_condition default_error_condition() const noexcept;
 \returns \tcode{category().default_error_condition(value())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{message}!\idxcode{error_code}}
-\indexlibrary{\idxcode{error_code}!\idxcode{message}}
+\indexlibrary{\idxcode{message}!\idxcode{error_code}}%
+\indexlibrary{\idxcode{error_code}!\idxcode{message}}%
 \begin{itemdecl}
 string message() const;
 \end{itemdecl}
@@ -1346,8 +1346,8 @@ string message() const;
 \returns \tcode{category().message(value())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator bool}!\idxcode{error_code}}
-\indexlibrary{\idxcode{error_code}!\idxcode{operator bool}}
+\indexlibrary{\idxcode{operator bool}!\idxcode{error_code}}%
+\indexlibrary{\idxcode{error_code}!\idxcode{operator bool}}%
 \begin{itemdecl}
 explicit operator bool() const noexcept;
 \end{itemdecl}
@@ -1359,7 +1359,7 @@ explicit operator bool() const noexcept;
 
 \rSec3[syserr.errcode.nonmembers]{Class \tcode{error_code} non-member functions}
 
-\indexlibrary{\idxcode{make_error_code}}
+\indexlibrary{\idxcode{make_error_code}}%
 \begin{itemdecl}
 error_code make_error_code(errc e) noexcept;
 \end{itemdecl}
@@ -1490,8 +1490,8 @@ template <class ErrorConditionEnum>
 
 \rSec3[syserr.errcondition.modifiers]{Class \tcode{error_condition} modifiers}
 
-\indexlibrary{\idxcode{assign}!\idxcode{error_condition}}
-\indexlibrary{\idxcode{error_condition}!\idxcode{assign}}
+\indexlibrary{\idxcode{assign}!\idxcode{error_condition}}%
+\indexlibrary{\idxcode{error_condition}!\idxcode{assign}}%
 \begin{itemdecl}
 void assign(int val, const error_category& cat) noexcept;
 \end{itemdecl}
@@ -1501,8 +1501,8 @@ void assign(int val, const error_category& cat) noexcept;
 \postconditions \tcode{val_ == val} and \tcode{cat_ == \&cat}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{error_condition}}
-\indexlibrary{\idxcode{error_condition}!\idxcode{operator=}}
+\indexlibrary{\idxcode{operator=}!\idxcode{error_condition}}%
+\indexlibrary{\idxcode{error_condition}!\idxcode{operator=}}%
 \begin{itemdecl}
 template <class ErrorConditionEnum>
     error_condition& operator=(ErrorConditionEnum e) noexcept;
@@ -1520,8 +1520,8 @@ template <class ErrorConditionEnum>
 \tcode{is_error_condition_enum_v<ErrorConditionEnum>} is \tcode{true}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{clear}!\idxcode{error_condition}}
-\indexlibrary{\idxcode{error_condition}!\idxcode{clear}}
+\indexlibrary{\idxcode{clear}!\idxcode{error_condition}}%
+\indexlibrary{\idxcode{error_condition}!\idxcode{clear}}%
 \begin{itemdecl}
 void clear() noexcept;
 \end{itemdecl}
@@ -1532,8 +1532,8 @@ void clear() noexcept;
 
 \rSec3[syserr.errcondition.observers]{Class \tcode{error_condition} observers}
 
-\indexlibrary{\idxcode{value}!\idxcode{error_condition}}
-\indexlibrary{\idxcode{error_condition}!\idxcode{value}}
+\indexlibrary{\idxcode{value}!\idxcode{error_condition}}%
+\indexlibrary{\idxcode{error_condition}!\idxcode{value}}%
 \begin{itemdecl}
 int value() const noexcept;
 \end{itemdecl}
@@ -1543,8 +1543,8 @@ int value() const noexcept;
 \returns \tcode{val_}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{category}!\idxcode{error_condition}}
-\indexlibrary{\idxcode{error_condition}!\idxcode{category}}
+\indexlibrary{\idxcode{category}!\idxcode{error_condition}}%
+\indexlibrary{\idxcode{error_condition}!\idxcode{category}}%
 \begin{itemdecl}
 const error_category& category() const noexcept;
 \end{itemdecl}
@@ -1554,8 +1554,8 @@ const error_category& category() const noexcept;
 \returns \tcode{*cat_}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{message}!\idxcode{error_condition}}
-\indexlibrary{\idxcode{error_condition}!\idxcode{message}}
+\indexlibrary{\idxcode{message}!\idxcode{error_condition}}%
+\indexlibrary{\idxcode{error_condition}!\idxcode{message}}%
 \begin{itemdecl}
 string message() const;
 \end{itemdecl}
@@ -1565,8 +1565,8 @@ string message() const;
 \returns \tcode{category().message(value())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator bool}!\idxcode{error_condition}}
-\indexlibrary{\idxcode{error_condition}!\idxcode{operator bool}}
+\indexlibrary{\idxcode{operator bool}!\idxcode{error_condition}}%
+\indexlibrary{\idxcode{error_condition}!\idxcode{operator bool}}%
 \begin{itemdecl}
 explicit operator bool() const noexcept;
 \end{itemdecl}
@@ -1578,7 +1578,7 @@ explicit operator bool() const noexcept;
 
 \rSec3[syserr.errcondition.nonmembers]{Class \tcode{error_condition} non-member functions}
 
-\indexlibrary{\idxcode{make_error_condition}}
+\indexlibrary{\idxcode{make_error_condition}}%
 \begin{itemdecl}
 error_condition make_error_condition(errc e) noexcept;
 \end{itemdecl}
@@ -1714,7 +1714,7 @@ namespace std {
 
 \rSec3[syserr.syserr.members]{Class \tcode{system_error} members}
 
-\indexlibrary{\idxcode{system_error}!constructor}
+\indexlibrary{\idxcode{system_error}!constructor}%
 \begin{itemdecl}
 system_error(error_code ec, const string& what_arg);
 \end{itemdecl}
@@ -1729,7 +1729,7 @@ system_error(error_code ec, const string& what_arg);
 \tcode{string(what()).find(what_arg) != string::npos}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{system_error}!constructor}
+\indexlibrary{\idxcode{system_error}!constructor}%
 \begin{itemdecl}
 system_error(error_code ec, const char* what_arg);
 \end{itemdecl}
@@ -1744,7 +1744,7 @@ system_error(error_code ec, const char* what_arg);
 \tcode{string(what()).find(what_arg) != string::npos}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{system_error}!constructor}
+\indexlibrary{\idxcode{system_error}!constructor}%
 \begin{itemdecl}
 system_error(error_code ec);
 \end{itemdecl}
@@ -1757,7 +1757,7 @@ system_error(error_code ec);
 \postconditions \tcode{code() == ec}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{system_error}!constructor}
+\indexlibrary{\idxcode{system_error}!constructor}%
 \begin{itemdecl}
 system_error(int ev, const error_category& ecat,
   const string& what_arg);
@@ -1773,7 +1773,7 @@ system_error(int ev, const error_category& ecat,
 \tcode{string(what()).find(what_arg) != string::npos}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{system_error}!constructor}
+\indexlibrary{\idxcode{system_error}!constructor}%
 \begin{itemdecl}
 system_error(int ev, const error_category& ecat,
   const char* what_arg);
@@ -1789,7 +1789,7 @@ system_error(int ev, const error_category& ecat,
 \tcode{string(what()).find(what_arg) != string::npos}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{system_error}!constructor}
+\indexlibrary{\idxcode{system_error}!constructor}%
 \begin{itemdecl}
 system_error(int ev, const error_category& ecat);
 \end{itemdecl}
@@ -1802,8 +1802,8 @@ system_error(int ev, const error_category& ecat);
 \postconditions \tcode{code() == error_code(ev, ecat)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{code}!\idxcode{system_error}}
-\indexlibrary{\idxcode{system_error}!\idxcode{code}}
+\indexlibrary{\idxcode{code}!\idxcode{system_error}}%
+\indexlibrary{\idxcode{system_error}!\idxcode{code}}%
 \begin{itemdecl}
 const error_code& code() const noexcept;
 \end{itemdecl}
@@ -1814,8 +1814,8 @@ const error_code& code() const noexcept;
 as appropriate.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{what}!\idxcode{system_error}}
-\indexlibrary{\idxcode{system_error}!\idxcode{what}}
+\indexlibrary{\idxcode{what}!\idxcode{system_error}}%
+\indexlibrary{\idxcode{system_error}!\idxcode{what}}%
 \begin{itemdecl}
 const char* what() const noexcept;
 \end{itemdecl}


### PR DESCRIPTION
The only issues that turned up are missing '%' continuations
at the end of around half of the index entry lines.  This
patch consistently cleans that up, so that every index entry
terminates in a '%', but it is not clear that this has any
effect on the final rendering, and the patch could safely be
rejected.  The primary benefit is consistency, should we ever
want to write some follow-up tooling to analyze index entries.

Audit confirmed that every \begin{itemdecl} is indexed, and the
index entry matches the declared name(s).