### PR TITLE
Update the reference to the C standard in intro.scope

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -37,7 +37,7 @@ requirement appear at various places within this International Standard.
 
 \pnum
 \Cpp is a general purpose programming language based on the C
-programming language as described in ISO/IEC 9899:1999
+programming language as described in ISO/IEC 9899:2011
 \doccite{Programming languages --- C} (hereinafter referred to as the
 \indexdefn{C!standard}\term{C standard}). In addition to
 the facilities provided by C, \Cpp provides additional data types,


### PR DESCRIPTION
intro.scope references the C99 edition of the C standard while intro.refs
references the C11 edition, I assume it was not updated when the change was
made.