### PR TITLE
Add back function lvalues to [dcl.init.ref]/5.2.1.2

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -3555,7 +3555,7 @@ reference-compatible with ``\cvqual{cv2} \tcode{T2}'', or
 
 \item has a class type (i.e., \tcode{T2} is a class type), where \tcode{T1}
 is not reference-related to \tcode{T2}, and can be converted to
-an rvalue of type ``\cvqual{cv3} \tcode{T3}'',
+an rvalue or function lvalue of type ``\cvqual{cv3} \tcode{T3}'',
 where ``\cvqual{cv1} \tcode{T1}'' is
 reference-compatible with ``\cvqual{cv3} \tcode{T3}'' (see~\ref{over.match.ref}),
 


### PR DESCRIPTION
I suppose this was omitted when applying [P0135R1](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0135r1.html), as it's present in the paper. 