### PR TITLE
[Editorial] Typo <memory_resorce>

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1041,7 +1041,7 @@ as shown in Table~\ref{tab:cpp.library.headers}.
 \tcode{<vector>} \\
 
 \tcode{<forward_list>} &
-\tcode{<memory_resorce>} &
+\tcode{<memory_resource>} &
 \tcode{<streambuf>} &
 \\
 


### PR DESCRIPTION
...in table 14 should be `<memory_resource>`.