### PR TITLE
[impldef] Collate index correctly

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -2123,7 +2123,8 @@ static const char __func__[] = "@\grammarterm{function-name}@";
 \end{codeblock}
 
 had been provided, where \grammarterm{function-name} is an \impldef{string resulting
-from \tcode{__func__}} string. It is unspecified whether such a variable has an address
+from \mname{func}} string.
+It is unspecified whether such a variable has an address
 distinct from that of any other object in the program.\footnote{Implementations are
 permitted to provide additional predefined variables with names that are reserved to the
 implementation~(\ref{lex.name}). If a predefined variable is not
@@ -2859,7 +2860,7 @@ If the conversion cannot
 be done, the initialization is ill-formed.
 When initializing a bit-field with a value that it cannot represent, the
 resulting value of the bit-field is
-\impldef{value of bit-field that cannot represent!initializer}.
+\impldefplain{value of bit-field that cannot represent!initializer}.
 \indextext{initialization!\idxcode{const}}%
 \begin{note}
 An expression of type

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1915,7 +1915,7 @@ The result is a prvalue. The type of the result is the cv-unqualified
 version of the type of the operand.
 If the operand is a bit-field that cannot represent the incremented value, the
 resulting value of the bit-field is
-\impldef{value of bit-field that cannot represent!incremented value}.
+\impldefplain{value of bit-field that cannot represent!incremented value}.
 See also~\ref{expr.add}
 and~\ref{expr.ass}.
 
@@ -2871,7 +2871,7 @@ types, or to a glvalue that designates a bit-field.
 \tcode{sizeof(char)}, \tcode{sizeof(signed char)} and
 \tcode{sizeof(unsigned char)} are \tcode{1}. The result of
 \tcode{sizeof} applied to any other fundamental
-type~(\ref{basic.fundamental}) is \impldef{sizeof applied@\tcode{sizeof} applied to
+type~(\ref{basic.fundamental}) is \impldef{\tcode{sizeof} applied to
 fundamental types
 other than \tcode{char}, \tcode{signed char}, and \tcode{unsigned char}}.
 \begin{note}
@@ -4750,7 +4750,7 @@ initialization~(\ref{dcl.init},~\ref{class.ctor},~\ref{class.init},~\ref{class.c
 When the left operand of an assignment operator
 is a bit-field that cannot represent the value of the expression, the
 resulting value of the bit-field is
-\impldef{value of bit-field that cannot represent!assigned value}.
+\impldefplain{value of bit-field that cannot represent!assigned value}.
 
 \pnum
 The behavior of an expression of the form \tcode{E1} \term{op}\tcode{=}

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2969,7 +2969,7 @@ Certain functions in the \Cpp standard library report errors via a
 \tcode{std::error_code}~(\ref{syserr.errcode.overview}) object. That object's
 \tcode{category()} member shall return \tcode{std::system_category()} for
 errors originating from the operating system, or a reference to an
-\impldef{error_category@\tcode{error_category} for errors originating outside the
+\impldef{\tcode{error_category} for errors originating outside the
 operating system} \tcode{error_category} object for errors originating elsewhere.
 The implementation shall define the possible values of \tcode{value()} for each of these
 error categories. \begin{example} For operating systems that are based on POSIX,

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -99,11 +99,46 @@
 \newcommand{\indextext}[1]{\index[generalindex]{#1}}
 \newcommand{\indexlibrary}[1]{\index[libraryindex]{#1}}
 \newcommand{\indexgram}[1]{\index[grammarindex]{#1}}
-\newcommand{\indeximpldef}[1]{\index[impldefindex]{#1}}
 
+% Collation helper: When building an index key, replace all macro definitions
+% in the key argument with a no-op for purposes of collation. 
+\newcommand{\nocode}[1]{#1}
+\newcommand{\idxmname}[1]{\_\_#1\_\_}
+\newcommand{\idxCpp}{C++}
+
+% \indeximpldef synthesizes a collation key from the argument; that is, an
+% invocation \indeximpldef{arg} emits an index entry `key@arg`, where `key`
+% is derived from `arg` by replacing the folowing list of commands with their
+% bare content. This allows, say, collating plain text and code.
+\newcommand{\indeximpldef}[1]{%
+\let\otcode\tcode%
+\let\tcode\nocode%
+\let\ogrammarterm\grammarterm%
+\let\grammarterm\nocode%
+\let\omname\mname%
+\let\mname\idxmname%
+\let\oCpp\Cpp%
+\let\Cpp\idxCpp
+\let\oBreakableUnderscore\BreakableUnderscore%  See the "underscore" package.
+\let\BreakableUnderscore\textunderscore%
+\edef\x{#1}%
+\let\tcode\otcode%
+\let\grammarterm\ogrammarterm%
+\let\mname\omname%
+\let\Cpp\oCpp%
+\let\BreakableUnderscore\oBreakableUnderscore%
+\index[impldefindex]{\x@#1}%
+}
+
+% These three commands use the "cooked" \indeximpldef command to emit index
+% entries; thus they only work for simple index entries that do not contain
+% special indexing instructions.
 \newcommand{\indexdefn}[1]{\indextext{#1}}
 \newcommand{\indexgrammar}[1]{\indextext{#1}\indexgram{#1}}
 \newcommand{\impldef}[1]{\indeximpldef{#1}implementation-defined}
+% \impldefplain passes the argument directly to the index, allowing you to
+% use special indexing instructions (!, @, |).
+\newcommand{\impldefplain}[1]{\index[impldefindex]{#1}implementation-defined}
 
 % appearance
 \newcommand{\idxcode}[1]{#1@\tcode{#1}}

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1209,7 +1209,7 @@ A preprocessing directive of the form
 \end{ncsimplebnf}
 
 causes the implementation to behave
-in an \impldef{\#pragma@\tcode{\#pragma}} manner.
+in an \impldef{\tcode{\#pragma}} manner.
 The behavior might cause translation to fail or cause the translator or
 the resulting program to behave in a non-conforming manner.
 Any pragma that is not recognized by the implementation is ignored.

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -6683,7 +6683,7 @@ pointer_safety get_pointer_safety() noexcept;
 \returns \tcode{pointer_safety::strict} if the implementation has strict pointer
 safety~(\ref{basic.stc.dynamic.safety}). It is implementation defined%
 \indeximpldef{whether \tcode{get_pointer_safety} returns
-\tcode{pointer_safety::\brk{}relaxed} or
+\tcode{pointer_safety::relaxed} or
 \tcode{pointer_safety::preferred} if the implementation has relaxed pointer safety}
 whether
 \tcode{get_pointer_safety} returns \tcode{pointer_safety::relaxed} or


### PR DESCRIPTION
This involves modifying the `\indeximpldef` macro to strip out the bare arguments from a selection of commands that we use inside index entries, and using the bare text to create the collation key. Complex index commands need to use the new `\impldefplain` commands.