### PR TITLE
[18,19] Add and use new indexlibrarymember macro

### DIFF
--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -971,8 +971,7 @@ virtual ~error_category();
 \effects Destroys an object of class \tcode{error_category}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{name}!\idxcode{error_category}}%
-\indexlibrary{\idxcode{error_category}!\idxcode{name}}%
+\indexlibrarymember{error_category}{name}%
 \begin{itemdecl}
 virtual const char* name() const noexcept = 0;
 \end{itemdecl}
@@ -982,8 +981,7 @@ virtual const char* name() const noexcept = 0;
 \returns A string naming the error category.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{default_error_condition}!\idxcode{error_category}}%
-\indexlibrary{\idxcode{error_category}!\idxcode{default_error_condition}}%
+\indexlibrarymember{error_category}{default_error_condition}%
 \begin{itemdecl}
 virtual error_condition default_error_condition(int ev) const noexcept;
 \end{itemdecl}
@@ -994,8 +992,7 @@ virtual error_condition default_error_condition(int ev) const noexcept;
 \tcode{error_condition(ev, *this)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{equivalent}!\idxcode{error_category}}%
-\indexlibrary{\idxcode{error_category}!\idxcode{equivalent}}%
+\indexlibrarymember{error_category}{equivalent}%
 \begin{itemdecl}
 virtual bool equivalent(int code, const error_condition& condition) const noexcept;
 \end{itemdecl}
@@ -1005,8 +1002,7 @@ virtual bool equivalent(int code, const error_condition& condition) const noexce
 \returns \tcode{default_error_condition(code) == condition}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{equivalent}!\idxcode{error_category}}%
-\indexlibrary{\idxcode{error_category}!\idxcode{equivalent}}%
+\indexlibrarymember{error_category}{equivalent}%
 \begin{itemdecl}
 virtual bool equivalent(const error_code& code, int condition) const noexcept;
 \end{itemdecl}
@@ -1016,8 +1012,7 @@ virtual bool equivalent(const error_code& code, int condition) const noexcept;
 \returns \tcode{*this == code.category() \&\& code.value() == condition}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{message}!\idxcode{error_category}}%
-\indexlibrary{\idxcode{error_category}!\idxcode{message}}%
+\indexlibrarymember{error_category}{message}%
 \begin{itemdecl}
 virtual string message(int ev) const = 0;
 \end{itemdecl}
@@ -1039,8 +1034,7 @@ constexpr error_category() noexcept;
 \effects Constructs an object of class \tcode{error_category}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{error_category}}%
-\indexlibrary{\idxcode{error_category}!\idxcode{operator==}}%
+\indexlibrarymember{error_category}{operator==}%
 \begin{itemdecl}
 bool operator==(const error_category& rhs) const noexcept;
 \end{itemdecl}
@@ -1050,8 +1044,7 @@ bool operator==(const error_category& rhs) const noexcept;
 \returns \tcode{this == \&rhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{error_category}}%
-\indexlibrary{\idxcode{error_category}!\idxcode{operator"!=}}%
+\indexlibrarymember{error_category}{operator"!=}%
 \begin{itemdecl}
 bool operator!=(const error_category& rhs) const noexcept;
 \end{itemdecl}
@@ -1061,8 +1054,7 @@ bool operator!=(const error_category& rhs) const noexcept;
 \returns \tcode{!(*this == rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{error_category}}%
-\indexlibrary{\idxcode{error_category}!\idxcode{operator<}}%
+\indexlibrarymember{error_category}{operator<}%
 \begin{itemdecl}
 bool operator<(const error_category& rhs) const noexcept;
 \end{itemdecl}
@@ -1076,8 +1068,7 @@ bool operator<(const error_category& rhs) const noexcept;
 
 \rSec3[syserr.errcat.derived]{Program defined classes derived from \tcode{error_category}}
 
-\indexlibrary{\idxcode{name}!\idxcode{error_category}}%
-\indexlibrary{\idxcode{error_category}!\idxcode{name}}%
+\indexlibrarymember{error_category}{name}%
 \begin{itemdecl}
 virtual const char* name() const noexcept = 0;
 \end{itemdecl}
@@ -1087,8 +1078,7 @@ virtual const char* name() const noexcept = 0;
 \returns A string naming the error category.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{default_error_condition}!\idxcode{error_category}}%
-\indexlibrary{\idxcode{error_category}!\idxcode{default_error_condition}}%
+\indexlibrarymember{error_category}{default_error_condition}%
 \begin{itemdecl}
 virtual error_condition default_error_condition(int ev) const noexcept;
 \end{itemdecl}
@@ -1098,8 +1088,7 @@ virtual error_condition default_error_condition(int ev) const noexcept;
 \returns An object of type \tcode{error_condition} that corresponds to \tcode{ev}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{equivalent}!\idxcode{error_category}}%
-\indexlibrary{\idxcode{error_category}!\idxcode{equivalent}}%
+\indexlibrarymember{error_category}{equivalent}%
 \begin{itemdecl}
 virtual bool equivalent(int code, const error_condition& condition) const noexcept;
 \end{itemdecl}
@@ -1109,8 +1098,7 @@ virtual bool equivalent(int code, const error_condition& condition) const noexce
 \returns \tcode{true} if, for the category of error represented by \tcode{*this}, \tcode{code} is considered equivalent to \tcode{condition}; otherwise, \tcode{false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{equivalent}!\idxcode{error_category}}%
-\indexlibrary{\idxcode{error_category}!\idxcode{equivalent}}%
+\indexlibrarymember{error_category}{equivalent}%
 \begin{itemdecl}
 virtual bool equivalent(const error_code& code, int condition) const noexcept;
 \end{itemdecl}
@@ -1258,8 +1246,7 @@ template <class ErrorCodeEnum>
 
 \rSec3[syserr.errcode.modifiers]{Class \tcode{error_code} modifiers}
 
-\indexlibrary{\idxcode{assign}!\idxcode{error_code}}%
-\indexlibrary{\idxcode{error_code}!\idxcode{assign}}%
+\indexlibrarymember{error_code}{assign}%
 \begin{itemdecl}
 void assign(int val, const error_category& cat) noexcept;
 \end{itemdecl}
@@ -1269,8 +1256,7 @@ void assign(int val, const error_category& cat) noexcept;
 \postconditions \tcode{val_ == val} and \tcode{cat_ == \&cat}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{error_code}}%
-\indexlibrary{\idxcode{error_code}!\idxcode{operator=}}%
+\indexlibrarymember{error_code}{operator=}%
 \begin{itemdecl}
 template <class ErrorCodeEnum>
     error_code& operator=(ErrorCodeEnum e) noexcept;
@@ -1288,8 +1274,7 @@ template <class ErrorCodeEnum>
 \tcode{is_error_code_enum_v<ErrorCodeEnum>} is \tcode{true}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{clear}!\idxcode{error_code}}%
-\indexlibrary{\idxcode{error_code}!\idxcode{clear}}%
+\indexlibrarymember{error_code}{clear}%
 \begin{itemdecl}
 void clear() noexcept;
 \end{itemdecl}
@@ -1302,8 +1287,7 @@ void clear() noexcept;
 
 \rSec3[syserr.errcode.observers]{Class \tcode{error_code} observers}
 
-\indexlibrary{\idxcode{value}!\idxcode{error_code}}%
-\indexlibrary{\idxcode{error_code}!\idxcode{value}}%
+\indexlibrarymember{error_code}{value}%
 \begin{itemdecl}
 int value() const noexcept;
 \end{itemdecl}
@@ -1313,8 +1297,7 @@ int value() const noexcept;
 \returns \tcode{val_}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{category}!\idxcode{error_code}}%
-\indexlibrary{\idxcode{error_code}!\idxcode{category}}%
+\indexlibrarymember{error_code}{category}%
 \begin{itemdecl}
 const error_category& category() const noexcept;
 \end{itemdecl}
@@ -1324,8 +1307,7 @@ const error_category& category() const noexcept;
 \returns \tcode{*cat_}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{default_error_condition}!\idxcode{error_code}}%
-\indexlibrary{\idxcode{error_code}!\idxcode{default_error_condition}}%
+\indexlibrarymember{error_code}{default_error_condition}%
 \begin{itemdecl}
 error_condition default_error_condition() const noexcept;
 \end{itemdecl}
@@ -1335,8 +1317,7 @@ error_condition default_error_condition() const noexcept;
 \returns \tcode{category().default_error_condition(value())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{message}!\idxcode{error_code}}%
-\indexlibrary{\idxcode{error_code}!\idxcode{message}}%
+\indexlibrarymember{error_code}{message}%
 \begin{itemdecl}
 string message() const;
 \end{itemdecl}
@@ -1346,8 +1327,7 @@ string message() const;
 \returns \tcode{category().message(value())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator bool}!\idxcode{error_code}}%
-\indexlibrary{\idxcode{error_code}!\idxcode{operator bool}}%
+\indexlibrarymember{error_code}{operator bool}%
 \begin{itemdecl}
 explicit operator bool() const noexcept;
 \end{itemdecl}
@@ -1369,8 +1349,7 @@ error_code make_error_code(errc e) noexcept;
 \returns \tcode{error_code(static_cast<int>(e), generic_category())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{error_code}}%
-\indexlibrary{\idxcode{error_code}!\idxcode{operator<}}%
+\indexlibrarymember{error_code}{operator<}%
 \begin{itemdecl}
 bool operator<(const error_code& lhs, const error_code& rhs) noexcept;
 \end{itemdecl}
@@ -1384,8 +1363,7 @@ lhs.category() < rhs.category() ||
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shl}!\idxcode{error_code}}%
-\indexlibrary{\idxcode{error_code}!\idxcode{operator\shl}}%
+\indexlibrarymember{error_code}{operator\shl}%
 \begin{itemdecl}
 template <class charT, class traits>
   basic_ostream<charT, traits>&
@@ -1490,8 +1468,7 @@ template <class ErrorConditionEnum>
 
 \rSec3[syserr.errcondition.modifiers]{Class \tcode{error_condition} modifiers}
 
-\indexlibrary{\idxcode{assign}!\idxcode{error_condition}}%
-\indexlibrary{\idxcode{error_condition}!\idxcode{assign}}%
+\indexlibrarymember{error_condition}{assign}%
 \begin{itemdecl}
 void assign(int val, const error_category& cat) noexcept;
 \end{itemdecl}
@@ -1501,8 +1478,7 @@ void assign(int val, const error_category& cat) noexcept;
 \postconditions \tcode{val_ == val} and \tcode{cat_ == \&cat}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{error_condition}}%
-\indexlibrary{\idxcode{error_condition}!\idxcode{operator=}}%
+\indexlibrarymember{error_condition}{operator=}%
 \begin{itemdecl}
 template <class ErrorConditionEnum>
     error_condition& operator=(ErrorConditionEnum e) noexcept;
@@ -1520,8 +1496,7 @@ template <class ErrorConditionEnum>
 \tcode{is_error_condition_enum_v<ErrorConditionEnum>} is \tcode{true}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{clear}!\idxcode{error_condition}}%
-\indexlibrary{\idxcode{error_condition}!\idxcode{clear}}%
+\indexlibrarymember{error_condition}{clear}%
 \begin{itemdecl}
 void clear() noexcept;
 \end{itemdecl}
@@ -1532,8 +1507,7 @@ void clear() noexcept;
 
 \rSec3[syserr.errcondition.observers]{Class \tcode{error_condition} observers}
 
-\indexlibrary{\idxcode{value}!\idxcode{error_condition}}%
-\indexlibrary{\idxcode{error_condition}!\idxcode{value}}%
+\indexlibrarymember{error_condition}{value}%
 \begin{itemdecl}
 int value() const noexcept;
 \end{itemdecl}
@@ -1543,8 +1517,7 @@ int value() const noexcept;
 \returns \tcode{val_}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{category}!\idxcode{error_condition}}%
-\indexlibrary{\idxcode{error_condition}!\idxcode{category}}%
+\indexlibrarymember{error_condition}{category}%
 \begin{itemdecl}
 const error_category& category() const noexcept;
 \end{itemdecl}
@@ -1554,8 +1527,7 @@ const error_category& category() const noexcept;
 \returns \tcode{*cat_}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{message}!\idxcode{error_condition}}%
-\indexlibrary{\idxcode{error_condition}!\idxcode{message}}%
+\indexlibrarymember{error_condition}{message}%
 \begin{itemdecl}
 string message() const;
 \end{itemdecl}
@@ -1565,8 +1537,7 @@ string message() const;
 \returns \tcode{category().message(value())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator bool}!\idxcode{error_condition}}%
-\indexlibrary{\idxcode{error_condition}!\idxcode{operator bool}}%
+\indexlibrarymember{error_condition}{operator bool}%
 \begin{itemdecl}
 explicit operator bool() const noexcept;
 \end{itemdecl}
@@ -1587,8 +1558,7 @@ error_condition make_error_condition(errc e) noexcept;
 \returns \tcode{error_condition(static_cast<int>(e), generic_category())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{error_condition}}%
-\indexlibrary{\idxcode{error_condition}!\idxcode{operator<}}%
+\indexlibrarymember{error_condition}{operator<}%
 \begin{itemdecl}
 bool operator<(const error_condition& lhs, const error_condition& rhs) noexcept;
 \end{itemdecl}
@@ -1601,8 +1571,7 @@ lhs.value() < rhs.value()}.
 
 \rSec2[syserr.compare]{Comparison operators}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{error_code}}%
-\indexlibrary{\idxcode{error_code}!\idxcode{operator==}}%
+\indexlibrarymember{error_code}{operator==}%
 \begin{itemdecl}
 bool operator==(const error_code& lhs, const error_code& rhs) noexcept;
 \end{itemdecl}
@@ -1612,10 +1581,8 @@ bool operator==(const error_code& lhs, const error_code& rhs) noexcept;
 \returns \tcode{lhs.category() == rhs.category() \&\& lhs.value() == rhs.value()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{error_condition}}%
-\indexlibrary{\idxcode{error_condition}!\idxcode{operator==}}%
-\indexlibrary{\idxcode{operator==}!\idxcode{error_code}}%
-\indexlibrary{\idxcode{error_code}!\idxcode{operator==}}%
+\indexlibrarymember{error_condition}{operator==}%
+\indexlibrarymember{error_code}{operator==}%
 \begin{itemdecl}
 bool operator==(const error_code& lhs, const error_condition& rhs) noexcept;
 \end{itemdecl}
@@ -1626,10 +1593,8 @@ bool operator==(const error_code& lhs, const error_condition& rhs) noexcept;
 rhs.value())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{error_condition}}%
-\indexlibrary{\idxcode{error_condition}!\idxcode{operator==}}%
-\indexlibrary{\idxcode{operator==}!\idxcode{error_code}}%
-\indexlibrary{\idxcode{error_code}!\idxcode{operator==}}%
+\indexlibrarymember{error_condition}{operator==}%
+\indexlibrarymember{error_code}{operator==}%
 \begin{itemdecl}
 bool operator==(const error_condition& lhs, const error_code& rhs) noexcept;
 \end{itemdecl}
@@ -1639,8 +1604,7 @@ bool operator==(const error_condition& lhs, const error_code& rhs) noexcept;
 \returns \tcode{rhs.category().equivalent(rhs.value(), lhs) || lhs.category().equivalent(rhs, lhs.value())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{error_condition}}%
-\indexlibrary{\idxcode{error_condition}!\idxcode{operator==}}%
+\indexlibrarymember{error_condition}{operator==}%
 \begin{itemdecl}
 bool operator==(const error_condition& lhs, const error_condition& rhs) noexcept;
 \end{itemdecl}
@@ -1650,10 +1614,8 @@ bool operator==(const error_condition& lhs, const error_condition& rhs) noexcept
 \returns \tcode{lhs.category() == rhs.category() \&\& lhs.value() == rhs.value()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{error_code}}%
-\indexlibrary{\idxcode{error_code}!\idxcode{operator"!=}}%
-\indexlibrary{\idxcode{operator"!=}!\idxcode{error_condition}}%
-\indexlibrary{\idxcode{error_condition}!\idxcode{operator"!=}}%
+\indexlibrarymember{error_code}{operator"!=}%
+\indexlibrarymember{error_condition}{operator"!=}%
 \begin{itemdecl}
 bool operator!=(const error_code& lhs, const error_code& rhs) noexcept;
 bool operator!=(const error_code& lhs, const error_condition& rhs) noexcept;
@@ -1802,8 +1764,7 @@ system_error(int ev, const error_category& ecat);
 \postconditions \tcode{code() == error_code(ev, ecat)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{code}!\idxcode{system_error}}%
-\indexlibrary{\idxcode{system_error}!\idxcode{code}}%
+\indexlibrarymember{system_error}{code}%
 \begin{itemdecl}
 const error_code& code() const noexcept;
 \end{itemdecl}
@@ -1814,8 +1775,7 @@ const error_code& code() const noexcept;
 as appropriate.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{what}!\idxcode{system_error}}%
-\indexlibrary{\idxcode{system_error}!\idxcode{what}}%
+\indexlibrarymember{system_error}{what}%
 \begin{itemdecl}
 const char* what() const noexcept;
 \end{itemdecl}

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -105,6 +105,9 @@
 \newcommand{\indexgrammar}[1]{\indextext{#1}\indexgram{#1}}
 \newcommand{\impldef}[1]{\indeximpldef{#1}implementation-defined}
 
+% Add two names to the library index as both #1!#2 and #2!#1
+\newcommand{\indexlibrarymember}[2]{\indexlibrary{\idxcode{#1}!\idxcode{#2}}\indexlibrary{\idxcode{#2}!\idxcode{#1}}}
+
 % appearance
 \newcommand{\idxcode}[1]{#1@\tcode{#1}}
 \newcommand{\idxhdr}[1]{#1@\tcode{<#1>}}

--- a/source/support.tex
+++ b/source/support.tex
@@ -230,7 +230,7 @@ namespace std {
 
 \rSec3[numeric.limits]{Class template \tcode{numeric_limits}}
 
-\indexlibrary{\idxcode{numeric\_limits}}%
+\indexlibrary{\idxcode{numeric_limits}}%
 \begin{codeblock}
 namespace std {
   template<class T> class numeric_limits {
@@ -295,8 +295,7 @@ the specialization on the unqualified type \tcode{T}.
 
 \rSec3[numeric.limits.members]{\tcode{numeric_limits} members}
 
-\indexlibrary{\idxcode{min}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{min}}
+\indexlibrarymember{numeric_limits}{min}%
 \begin{itemdecl}
 static constexpr T min() noexcept;
 \end{itemdecl}
@@ -317,8 +316,7 @@ or
 \tcode{is_bounded == false \&\& is_signed == false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{max}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{max}}
+\indexlibrarymember{numeric_limits}{max}%
 \begin{itemdecl}
 static constexpr T max() noexcept;
 \end{itemdecl}
@@ -333,8 +331,7 @@ Meaningful for all specializations in which
 \tcode{is_bounded != false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{lowest}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{lowest}}
+\indexlibrarymember{numeric_limits}{lowest}%
 \begin{itemdecl}
 static constexpr T lowest() noexcept;
 \end{itemdecl}
@@ -350,8 +347,7 @@ the negative of the largest (most positive) finite value.}
 Meaningful for all specializations in which \tcode{is_bounded != false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{digits}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{digits}}
+\indexlibrarymember{numeric_limits}{digits}%
 \begin{itemdecl}
 static constexpr int digits;
 \end{itemdecl}
@@ -369,8 +365,7 @@ For integer types, the number of non-sign bits in the representation.
 mantissa.\footnote{Equivalent to \tcode{FLT_MANT_DIG}, \tcode{DBL_MANT_DIG},
 \tcode{LDBL_MANT_DIG}.} \end{itemdescr}
 
-\indexlibrary{\idxcode{digits10}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{digits10}}
+\indexlibrarymember{numeric_limits}{digits10}%
 \begin{itemdecl}
 static constexpr int digits10;
 \end{itemdecl}
@@ -386,8 +381,7 @@ Meaningful for all specializations in which
 \tcode{is_bounded != false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{max_digits10}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{max_digits10}}
+\indexlibrarymember{numeric_limits}{max_digits10}%
 \begin{itemdecl}
 static constexpr int max_digits10;
 \end{itemdecl}
@@ -401,8 +395,7 @@ differ are always differentiated.
 Meaningful for all floating point types.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{is_signed}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{is_signed}}
+\indexlibrarymember{numeric_limits}{is_signed}%
 \begin{itemdecl}
 static constexpr bool is_signed;
 \end{itemdecl}
@@ -415,8 +408,7 @@ True if the type is signed.
 Meaningful for all specializations.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{is_integer}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{is_integer}}
+\indexlibrarymember{numeric_limits}{is_integer}%
 \begin{itemdecl}
 static constexpr bool is_integer;
 \end{itemdecl}
@@ -429,8 +421,7 @@ True if the type is integer.
 Meaningful for all specializations.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{is_exact}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{is_exact}}
+\indexlibrarymember{numeric_limits}{is_exact}%
 \begin{itemdecl}
 static constexpr bool is_exact;
 \end{itemdecl}
@@ -445,8 +436,7 @@ For example, rational and fixed-exponent representations are exact but not integ
 Meaningful for all specializations.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{radix}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{radix}}
+\indexlibrarymember{numeric_limits}{radix}%
 \begin{itemdecl}
 static constexpr int radix;
 \end{itemdecl}
@@ -465,8 +455,7 @@ BCD).}
 Meaningful for all specializations.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{epsilon}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{epsilon}}
+\indexlibrarymember{numeric_limits}{epsilon}%
 \begin{itemdecl}
 static constexpr T epsilon() noexcept;
 \end{itemdecl}
@@ -480,8 +469,7 @@ that is representable.\footnote{Equivalent to \tcode{FLT_EPSILON}, \tcode{DBL_EP
 Meaningful for all floating point types.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{round_error}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{round_error}}
+\indexlibrarymember{numeric_limits}{round_error}%
 \begin{itemdecl}
 static constexpr T round_error() noexcept;
 \end{itemdecl}
@@ -494,8 +482,7 @@ Section 5.2.8 and
 Annex A Rationale Section A.5.2.8 - Rounding constants.}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{min_exponent}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{min_exponent}}
+\indexlibrarymember{numeric_limits}{min_exponent}%
 \begin{itemdecl}
 static constexpr int  min_exponent;
 \end{itemdecl}
@@ -512,8 +499,7 @@ point number.\footnote{Equivalent to \tcode{FLT_MIN_EXP}, \tcode{DBL_MIN_EXP},
 Meaningful for all floating point types.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{min_exponent10}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{min_exponent10}}
+\indexlibrarymember{numeric_limits}{min_exponent10}%
 \begin{itemdecl}
 static constexpr int  min_exponent10;
 \end{itemdecl}
@@ -528,8 +514,7 @@ of normalized floating point numbers.\footnote{Equivalent to
 Meaningful for all floating point types.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{max_exponent}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{max_exponent}}
+\indexlibrarymember{numeric_limits}{max_exponent}%
 \begin{itemdecl}
 static constexpr int  max_exponent;
 \end{itemdecl}
@@ -546,8 +531,7 @@ floating point number.\footnote{Equivalent to \tcode{FLT_MAX_EXP},
 Meaningful for all floating point types.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{max_exponent10}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{max_exponent10}}
+\indexlibrarymember{numeric_limits}{max_exponent10}%
 \begin{itemdecl}
 static constexpr int  max_exponent10;
 \end{itemdecl}
@@ -562,8 +546,7 @@ range of representable finite floating point numbers.\footnote{Equivalent to
 Meaningful for all floating point types.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{has_infinity}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{has_infinity}}
+\indexlibrarymember{numeric_limits}{has_infinity}%
 \begin{itemdecl}
 static constexpr bool has_infinity;
 \end{itemdecl}
@@ -582,8 +565,7 @@ for all specializations in which
 \tcode{is_iec559 != false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{has_quiet_NaN}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{has_quiet_NaN}}
+\indexlibrarymember{numeric_limits}{has_quiet_NaN}%
 \begin{itemdecl}
 static constexpr bool has_quiet_NaN;
 \end{itemdecl}
@@ -603,8 +585,7 @@ for all specializations in which
 \tcode{is_iec559 != false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{has_signaling_NaN}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{has_signaling_NaN}}
+\indexlibrarymember{numeric_limits}{has_signaling_NaN}%
 \begin{itemdecl}
 static constexpr bool has_signaling_NaN;
 \end{itemdecl}
@@ -623,8 +604,7 @@ for all specializations in which
 \tcode{is_iec559 != false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{float_denorm_style}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{float_denorm_style}}
+\indexlibrarymember{numeric_limits}{float_denorm_style}%
 \begin{itemdecl}
 static constexpr float_denorm_style has_denorm;
 \end{itemdecl}
@@ -645,8 +625,7 @@ denormalized values.
 Meaningful for all floating point types.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{has_denorm_loss}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{has_denorm_loss}}
+\indexlibrarymember{numeric_limits}{has_denorm_loss}%
 \begin{itemdecl}
 static constexpr bool has_denorm_loss;
 \end{itemdecl}
@@ -657,8 +636,7 @@ True if loss of accuracy is detected as a
 denormalization loss, rather than as an inexact result.\footnote{See IEC 559.}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{infinity}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{infinity}}
+\indexlibrarymember{numeric_limits}{infinity}%
 \begin{itemdecl}
 static constexpr T infinity() noexcept;
 \end{itemdecl}
@@ -674,8 +652,7 @@ Required in specializations for which
 \tcode{is_iec559 != false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{quiet_NaN}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{quiet_NaN}}
+\indexlibrarymember{numeric_limits}{quiet_NaN}%
 \begin{itemdecl}
 static constexpr T quiet_NaN() noexcept;
 \end{itemdecl}
@@ -691,8 +668,7 @@ Required in specializations for which
 \tcode{is_iec559 != false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{signaling_NaN}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{signaling_NaN}}
+\indexlibrarymember{numeric_limits}{signaling_NaN}%
 \begin{itemdecl}
 static constexpr T signaling_NaN() noexcept;
 \end{itemdecl}
@@ -708,8 +684,7 @@ Required in specializations for which
 \tcode{is_iec559 != false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{denorm_min}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{denorm_min}}
+\indexlibrarymember{numeric_limits}{denorm_min}%
 \begin{itemdecl}
 static constexpr T denorm_min() noexcept;
 \end{itemdecl}
@@ -727,8 +702,7 @@ In specializations for which
 returns the minimum positive normalized value.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{is_iec559}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{is_iec559}}
+\indexlibrarymember{numeric_limits}{is_iec559}%
 \begin{itemdecl}
 static constexpr bool is_iec559;
 \end{itemdecl}
@@ -743,8 +717,7 @@ IEEE 754.}
 Meaningful for all floating point types.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{is_bounded}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{is_bounded}}
+\indexlibrarymember{numeric_limits}{is_bounded}%
 \begin{itemdecl}
 static constexpr bool is_bounded;
 \end{itemdecl}
@@ -759,8 +732,7 @@ precision types.\end{note}
 Meaningful for all specializations.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{is_modulo}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{is_modulo}}
+\indexlibrarymember{numeric_limits}{is_modulo}%
 \begin{itemdecl}
 static constexpr bool is_modulo;
 \end{itemdecl}
@@ -784,8 +756,7 @@ defines signed integer overflow to wrap.
 Meaningful for all specializations.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{traps}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{traps}}
+\indexlibrarymember{numeric_limits}{traps}%
 \begin{itemdecl}
 static constexpr bool traps;
 \end{itemdecl}
@@ -800,8 +771,7 @@ an arithmetic operation using that value to trap.\footnote{Required by LIA-1.}
 Meaningful for all specializations.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{tinyness_before}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{tinyness_before}}
+\indexlibrarymember{numeric_limits}{tinyness_before}%
 \begin{itemdecl}
 static constexpr bool tinyness_before;
 \end{itemdecl}
@@ -816,8 +786,7 @@ Required by LIA-1.}
 Meaningful for all floating point types.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{round_style}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{round_style}}
+\indexlibrarymember{numeric_limits}{round_style}%
 \begin{itemdecl}
 static constexpr float_round_style round_style;
 \end{itemdecl}
@@ -1313,7 +1282,7 @@ duration and without calling functions passed to
 \indexlibrary{\idxcode{atexit}}%
 \end{itemdescr}
 
-\indexlibrary{\idxcode{atexit}}
+\indexlibrary{\idxcode{atexit}}%
 \begin{itemdecl}
 extern "C" int atexit(void (*f)()) noexcept;
 extern "C++" int atexit(void (*f)()) noexcept;
@@ -1408,7 +1377,7 @@ are defined in
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{at_quick_exit}}
+\indexlibrary{\idxcode{at_quick_exit}}%
 \begin{itemdecl}
 extern "C" int at_quick_exit(void (*f)()) noexcept;
 extern "C++" int at_quick_exit(void (*f)()) noexcept;
@@ -1439,7 +1408,7 @@ The implementation shall support the registration of at least 32 functions.
 \returns Zero if the registration succeeds, non-zero if it fails.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{quick_exit}}
+\indexlibrary{\idxcode{quick_exit}}%
 \begin{itemdecl}
 [[noreturn]] void quick_exit(int status) noexcept;
 \end{itemdecl}
@@ -1453,7 +1422,7 @@ registered. Objects shall not be destroyed as a result of calling \tcode{quick_e
 If control leaves a registered function called by \tcode{quick_exit} because the
 function does not provide a handler for a thrown exception, \tcode{std::terminate()} shall
 be called.%
-\indexlibrary{\idxcode{terminate}}
+\indexlibrary{\idxcode{terminate}}%
 \begin{note} \tcode{at_quick_exit} may call a registered function from a different thread
 than the one that registered it, so registered functions should not rely on the identity
 of objects with thread storage duration. \end{note}
@@ -2203,7 +2172,7 @@ Constructs an object of class
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bad_alloc}!constructor}%
-\indexlibrary{\idxcode{operator=}!\idxcode{bad_alloc}}%
+\indexlibrarymember{bad_alloc}{operator=}%
 \begin{itemdecl}
 bad_alloc(const bad_alloc&) noexcept;
 bad_alloc& operator=(const bad_alloc&) noexcept;
@@ -2216,8 +2185,7 @@ Copies an object of class
 \tcode{bad_alloc}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{what}!\idxcode{bad_alloc}}%
-\indexlibrary{\idxcode{bad_alloc}!\idxcode{what}}%
+\indexlibrarymember{bad_alloc}{what}%
 \begin{itemdecl}
 const char* what() const noexcept override;
 \end{itemdecl}
@@ -2263,8 +2231,7 @@ bad_array_new_length() noexcept;
 \effects constructs an object of class \tcode{bad_array_new_length}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{bad_array_new_length}!\idxcode{what}}%
-\indexlibrary{\idxcode{what}!\idxcode{bad_array_new_length}}%
+\indexlibrarymember{bad_array_new_length}{what}%
 \begin{itemdecl}
 const char* what() const noexcept override;
 \end{itemdecl}
@@ -2520,8 +2487,7 @@ The names, encoding rule, and collating sequence for types are all unspecified
 \indextext{unspecified}%
 and may differ between programs.
 
-\indexlibrary{\idxcode{operator==}!\idxcode{type_info}}%
-\indexlibrary{\idxcode{type_info}!\idxcode{operator==}}%
+\indexlibrarymember{type_info}{operator==}%
 \begin{itemdecl}
 bool operator==(const type_info& rhs) const noexcept;
 \end{itemdecl}
@@ -2537,8 +2503,7 @@ Compares the current object with \tcode{rhs}.
 if the two values describe the same type.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{type_info}}%
-\indexlibrary{\idxcode{type_info}!\idxcode{operator"!=}}%
+\indexlibrarymember{type_info}{operator"!=}%
 \begin{itemdecl}
 bool operator!=(const type_info& rhs) const noexcept;
 \end{itemdecl}
@@ -2549,8 +2514,7 @@ bool operator!=(const type_info& rhs) const noexcept;
 \tcode{!(*this == rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{before}!\idxcode{type_info}}%
-\indexlibrary{\idxcode{type_info}!\idxcode{before}}%
+\indexlibrarymember{type_info}{before}%
 \begin{itemdecl}
 bool before(const type_info& rhs) const noexcept;
 \end{itemdecl}
@@ -2568,8 +2532,7 @@ if
 precedes \tcode{rhs} in the implementation's collation order.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{hash_code}!\idxcode{type_info}}%
-\indexlibrary{\idxcode{type_info}!\idxcode{hash_code}}%
+\indexlibrarymember{type_info}{hash_code}%
 \begin{itemdecl}
 size_t hash_code() const noexcept;
 \end{itemdecl}
@@ -2586,8 +2549,7 @@ objects which compare equal.
 \end{itemdescr}
 
 
-\indexlibrary{\idxcode{type_info}!\idxcode{name}}%
-\indexlibrary{\idxcode{name}!\idxcode{type_info}}%
+\indexlibrarymember{type_info}{name}%
 \begin{itemdecl}
 const char* name() const noexcept;
 \end{itemdecl}
@@ -2641,7 +2603,7 @@ Constructs an object of class
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bad_cast}!constructor}%
-\indexlibrary{\idxcode{operator=}!\idxcode{bad_cast}}%
+\indexlibrarymember{bad_cast}{operator=}%
 \begin{itemdecl}
 bad_cast(const bad_cast&) noexcept;
 bad_cast& operator=(const bad_cast&) noexcept;
@@ -2654,8 +2616,7 @@ Copies an object of class
 \tcode{bad_cast}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{bad_cast}!\idxcode{what}}%
-\indexlibrary{\idxcode{what}!\idxcode{bad_cast}}%
+\indexlibrarymember{bad_cast}{what}%
 \begin{itemdecl}
 const char* what() const noexcept override;
 \end{itemdecl}
@@ -2709,7 +2670,7 @@ Constructs an object of class
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bad_typeid}!constructor}%
-\indexlibrary{\idxcode{operator=}!\idxcode{bad_typeid}}%
+\indexlibrarymember{bad_typeid}{operator=}%
 \begin{itemdecl}
 bad_typeid(const bad_typeid&) noexcept;
 bad_typeid& operator=(const bad_typeid&) noexcept;
@@ -2722,8 +2683,7 @@ Copies an object of class
 \tcode{bad_typeid}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{bad_typeid}!\idxcode{what}}%
-\indexlibrary{\idxcode{what}!\idxcode{bad_typeid}}%
+\indexlibrarymember{bad_typeid}{what}%
 \begin{itemdecl}
 const char* what() const noexcept override;
 \end{itemdecl}
@@ -2829,7 +2789,7 @@ Constructs an object of class
 \end{itemdescr}
 
 \indexlibrary{\idxcode{exception}!constructor}%
-\indexlibrary{\idxcode{operator=}!\idxcode{exception}}%
+\indexlibrarymember{exception}{operator=}%
 \begin{itemdecl}
 exception(const exception& rhs) noexcept;
 exception& operator=(const exception& rhs) noexcept;
@@ -2859,8 +2819,7 @@ Destroys an object of class
 \tcode{exception}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{exception}!\idxcode{what}}%
-\indexlibrary{\idxcode{what}!\idxcode{exception}}%
+\indexlibrarymember{exception}{what}%
 \begin{itemdecl}
 virtual const char* what() const noexcept;
 \end{itemdecl}
@@ -2914,7 +2873,7 @@ Constructs an object of class
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bad_exception}!constructor}%
-\indexlibrary{\idxcode{operator=}!\idxcode{bad_exception}}%
+\indexlibrarymember{bad_exception}{operator=}%
 \begin{itemdecl}
 bad_exception(const bad_exception&) noexcept;
 bad_exception& operator=(const bad_exception&) noexcept;
@@ -2927,8 +2886,7 @@ Copies an object of class
 \tcode{bad_exception}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{bad_exception}!\idxcode{what}}%
-\indexlibrary{\idxcode{what}!\idxcode{bad_exception}}%
+\indexlibrarymember{bad_exception}{what}%
 \begin{itemdecl}
 const char* what() const noexcept override;
 \end{itemdecl}
@@ -2972,7 +2930,7 @@ terminate execution of the program without returning to the caller.
 \default
 The implementation's default \tcode{terminate_handler} calls
 \tcode{abort()}.%
-\indexlibrary{\idxcode{abort}}
+\indexlibrary{\idxcode{abort}}%
 \end{itemdescr}
 
 \rSec3[set.terminate]{\tcode{set_terminate}}
@@ -3055,7 +3013,7 @@ throwing an exception can result in a call of\\
 
 \rSec2[propagation]{Exception propagation}
 
-\indexlibrary{\idxcode{exception_ptr}}
+\indexlibrary{\idxcode{exception_ptr}}%
 \begin{itemdecl}
 using exception_ptr = @\unspec@;
 \end{itemdecl}
@@ -3096,7 +3054,7 @@ Changes in the number of \tcode{exception_ptr} objects that refer to a
 particular exception do not introduce a data race. \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{current_exception}}
+\indexlibrary{\idxcode{current_exception}}%
 \begin{itemdecl}
 exception_ptr current_exception() noexcept;
 \end{itemdecl}
@@ -3122,7 +3080,7 @@ to substitute a \tcode{bad_exception} object to avoid infinite
 recursion.\end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{rethrow_exception}}
+\indexlibrary{\idxcode{rethrow_exception}}%
 \begin{itemdecl}
 [[noreturn]] void rethrow_exception(exception_ptr p);
 \end{itemdecl}
@@ -3135,7 +3093,7 @@ recursion.\end{note}
 \throws the exception object to which \tcode{p} refers.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{make_exception_ptr}}
+\indexlibrary{\idxcode{make_exception_ptr}}%
 \begin{itemdecl}
 template<class E> exception_ptr make_exception_ptr(E e) noexcept;
 \end{itemdecl}
@@ -3188,7 +3146,7 @@ for later use.
 polymorphic class. Its presence can be tested for with \tcode{dynamic_cast}.
 \end{note}
 
-\indexlibrary{\idxcode{nested_exception}!constructor}
+\indexlibrary{\idxcode{nested_exception}!constructor}%
 \begin{itemdecl}
 nested_exception() noexcept;
 \end{itemdecl}
@@ -3198,8 +3156,7 @@ nested_exception() noexcept;
 \effects The constructor calls \tcode{current_exception()} and stores the returned value.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{rethrow_nested}!\idxcode{nested_exception}}
-\indexlibrary{\idxcode{nested_exception}!\idxcode{rethrow_nested}}
+\indexlibrarymember{nested_exception}{rethrow_nested}%
 \begin{itemdecl}
 [[noreturn]] void rethrow_nested() const;
 \end{itemdecl}
@@ -3210,8 +3167,7 @@ nested_exception() noexcept;
 Otherwise, it throws the stored exception captured by \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{nested_ptr}!\idxcode{nested_exception}}
-\indexlibrary{\idxcode{nested_exception}!\idxcode{nested_ptr}}
+\indexlibrarymember{nested_exception}{nested_ptr}%
 \begin{itemdecl}
 exception_ptr nested_ptr() const noexcept;
 \end{itemdecl}
@@ -3221,8 +3177,7 @@ exception_ptr nested_ptr() const noexcept;
 \returns The stored exception captured by this \tcode{nested_exception} object.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{throw_with_nested}!\idxcode{nested_exception}}
-\indexlibrary{\idxcode{nested_exception}!\idxcode{throw_with_nested}}
+\indexlibrarymember{nested_exception}{throw_with_nested}%
 \begin{itemdecl}
 template <class T> [[noreturn]] void throw_with_nested(T&& t);
 \end{itemdecl}
@@ -3244,8 +3199,7 @@ and constructed from \tcode{std::forward<T>(t)}, otherwise
 \tcode{std::forward<T>(t)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{rethrow_if_nested}!\idxcode{nested_exception}}
-\indexlibrary{\idxcode{nested_exception}!\idxcode{rethrow_if_nested}}
+\indexlibrarymember{nested_exception}{rethrow_if_nested}%
 \begin{itemdecl}
 template <class E> void rethrow_if_nested(const E& e);
 \end{itemdecl}
@@ -3314,7 +3268,7 @@ If an explicit specialization or partial specialization of
 
 \rSec2[support.initlist.cons]{Initializer list constructors}
 
-\indexlibrary{\idxcode{initializer_list}!constructor}
+\indexlibrary{\idxcode{initializer_list}!constructor}%
 \begin{itemdecl}
 constexpr initializer_list() noexcept;
 \end{itemdecl}
@@ -3329,8 +3283,7 @@ constexpr initializer_list() noexcept;
 
 \rSec2[support.initlist.access]{Initializer list access}
 
-\indexlibrary{\idxcode{begin}!\idxcode{initializer_list}}
-\indexlibrary{\idxcode{initializer_list}!\idxcode{begin}}
+\indexlibrarymember{initializer_list}{begin}%
 \begin{itemdecl}
 constexpr const E* begin() const noexcept;
 \end{itemdecl}
@@ -3342,8 +3295,7 @@ values of \tcode{begin()} and \tcode{end()} are unspecified but they shall be
 identical.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{end}!\idxcode{initializer_list}}
-\indexlibrary{\idxcode{initializer_list}!\idxcode{end}}
+\indexlibrarymember{initializer_list}{end}%
 \begin{itemdecl}
 constexpr const E* end() const noexcept;
 \end{itemdecl}
@@ -3353,8 +3305,7 @@ constexpr const E* end() const noexcept;
 \returns \tcode{begin() + size()}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{size}!\idxcode{initializer_list}}
-\indexlibrary{\idxcode{initializer_list}!\idxcode{size}}
+\indexlibrarymember{initializer_list}{size}%
 \begin{itemdecl}
 constexpr size_t size() const noexcept;
 \end{itemdecl}
@@ -3369,7 +3320,7 @@ constexpr size_t size() const noexcept;
 
 \rSec2[support.initlist.range]{Initializer list range access}
 
-\indexlibrary{\idxcode{begin(initializer_list<E>)}}
+\indexlibrary{\idxcode{begin(initializer_list<E>)}}%
 \begin{itemdecl}
 template<class E> constexpr const E* begin(initializer_list<E> il) noexcept;
 \end{itemdecl}
@@ -3379,7 +3330,7 @@ template<class E> constexpr const E* begin(initializer_list<E> il) noexcept;
 \returns \tcode{il.begin()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{end(initializer_list<E>)}}
+\indexlibrary{\idxcode{end(initializer_list<E>)}}%
 \begin{itemdecl}
 template<class E> constexpr const E* end(initializer_list<E> il) noexcept;
 \end{itemdecl}


### PR DESCRIPTION
Add a new macro, indexlibrarymember, that takes two arguments,
a class-name and a member name, which creates two index entries
for:
   class-name, member
and
   member, class-name

This should simplify many such double-declarations in the
library clauses, and reduce errors of inconsistency.  It
will also ease fixing up existing index entries that were
(accidentally) not doubled up.

Ths new macro is applied consistently throughout clauses
18 and 19 as a proof-of-concept, and follow-up patches
will deal with successive library clauses.  This is
deliberately broken up to ease the review burden.

Finally, some minor consistency issues regarding use of
% to ensure index macros are not consuming unexpected
whitespace.