### PR TITLE
[hardware.interference] prefer itemdecl to codeblock

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -2417,9 +2417,9 @@ const int c = std::launder(p)->n; // OK
 \rSec2[hardware.interference]{Hardware interference size}
 
 \indexlibrary{\idxcode{hardware_destructive_interference_size}}%
-\begin{codeblock}
+\begin{itemdecl}
 constexpr size_t hardware_destructive_interference_size = @\impdef{}@;
-\end{codeblock}
+\end{itemdecl}
 
 \pnum
 This number is the minimum recommended offset
@@ -2439,9 +2439,9 @@ struct keep_apart {
 \end{example}
 
 \indexlibrary{\idxcode{hardware_constructive_interference_size}}%
-\begin{codeblock}
+\begin{itemdecl}
 constexpr size_t hardware_constructive_interference_size = @\impdef{}@;
-\end{codeblock}
+\end{itemdecl}
 
 \pnum
 This number is the maximum recommended size of contiguous memory


### PR DESCRIPTION
The new hardware interference constants are introduced
above the definition of their semantics with a codeblock,
rather than an itemdecl, macro.  Prefer the latter for
consistently introducing names that are about to be defined,
as this will simply auditing the text in the future, e.g.,
when trying to reivew that every itemdecl has a corresponding
library index entry.