### PR TITLE
Use new macro \indexlibrarymember to simplify the library index

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -812,8 +812,7 @@ atomic<int> v = ATOMIC_VAR_INIT(5);
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{atomic type}!\idxcode{is_always_lock_free}}%
-\indexlibrary{\idxcode{is_always_lock_free}!\idxcode{atomic type}}%
+\indexlibrarymember{atomic type}{is_always_lock_free}%
 \begin{itemdecl}
 static constexpr bool is_always_lock_free = @\impdef{}@;
 \end{itemdecl}
@@ -828,8 +827,8 @@ the corresponding \tcode{ATOMIC_..._LOCK_FREE} macro, if defined.
 \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{atomic type}!\idxcode{atomic_is_lock_free}}%
-\indexlibrary{\idxcode{atomic_is_lock_free}!\idxcode{atomic type}}%
+\indexlibrary{\idxcode{atomic_is_lock_free}}%
+\indexlibrarymember{atomic type}{is_lock_free}%
 \begin{itemdecl}
 bool atomic_is_lock_free(const volatile @\placeholder{A}@*@\itcorr[-1]@ object) noexcept;
 bool atomic_is_lock_free(const @\placeholder{A}@*@\itcorr[-1]@ object) noexcept;
@@ -866,12 +865,9 @@ a data race.
 
 \end{itemdescr}
 
-\indexlibrary{\idxcode{atomic type}!\idxcode{atomic_store}}%
-\indexlibrary{\idxcode{atomic_store}!\idxcode{atomic type}}%
-\indexlibrary{\idxcode{atomic type}!\idxcode{atomic_store_explicit}}%
-\indexlibrary{\idxcode{atomic_store_explicit}!\idxcode{atomic type}}%
-\indexlibrary{\idxcode{atomic type}!\idxcode{store}}%
-\indexlibrary{\idxcode{store}!\idxcode{atomic type}}%
+\indexlibrary{\idxcode{atomic_store}}%
+\indexlibrary{\idxcode{atomic_store_explicit}}%
+\indexlibrarymember{atomic type}{store}%
 \begin{itemdecl}
 void atomic_store(volatile @\placeholder{A}@*@\itcorr[-1]@ object, @\placeholdernc{C}@ desired) noexcept;
 void atomic_store(@\placeholder{A}@*@\itcorr[-1]@ object, @\placeholdernc{C}@ desired) noexcept;
@@ -892,8 +888,7 @@ with the value of \tcode{desired}. Memory is affected according to the value of
 \tcode{order}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{atomic type}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{atomic type}}%
+\indexlibrarymember{atomic type}{operator=}%
 \begin{itemdecl}
 @\placeholdernc{C}@ @\placeholdernc{A}@::operator=(@\placeholdernc{C}@ desired) volatile noexcept;
 @\placeholdernc{C}@ @\placeholdernc{A}@::operator=(@\placeholdernc{C}@ desired) noexcept;
@@ -907,12 +902,9 @@ with the value of \tcode{desired}. Memory is affected according to the value of
 \returns \tcode{desired}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{atomic type}!\idxcode{atomic_load}}%
-\indexlibrary{\idxcode{atomic_load}!\idxcode{atomic type}}%
-\indexlibrary{\idxcode{atomic type}!\idxcode{atomic_load_explicit}}%
-\indexlibrary{\idxcode{atomic_load_explicit}!\idxcode{atomic type}}%
-\indexlibrary{\idxcode{atomic type}!\idxcode{load}}%
-\indexlibrary{\idxcode{load}!\idxcode{atomic type}}%
+\indexlibrary{\idxcode{atomic_load}}%
+\indexlibrary{\idxcode{atomic_load_explicit}}%
+\indexlibrarymember{atomic type}{load}%
 \begin{itemdecl}
 @\placeholdernc{C}@ atomic_load(const volatile @\placeholder{A}@*@\itcorr[-1]@ object) noexcept;
 @\placeholdernc{C}@ atomic_load(const @\placeholder{A}@*@\itcorr[-1]@ object) noexcept;
@@ -949,12 +941,9 @@ with the value of \tcode{desired}. Memory is affected according to the value of
 \end{itemdescr}
 
 
-\indexlibrary{\idxcode{atomic type}!\idxcode{atomic_exchange}}%
-\indexlibrary{\idxcode{atomic_exchange}!\idxcode{atomic type}}%
-\indexlibrary{\idxcode{atomic type}!\idxcode{atomic_exchange_explicit}}%
-\indexlibrary{\idxcode{atomic_exchange_explicit}!\idxcode{atomic type}}%
-\indexlibrary{\idxcode{atomic type}!\idxcode{exchange}}%
-\indexlibrary{\idxcode{exchange}!\idxcode{atomic type}}%
+\indexlibrary{\idxcode{atomic_exchange}}%
+\indexlibrary{\idxcode{atomic_exchange_explicit}}%
+\indexlibrarymember{atomic type}{exchange}%
 \begin{itemdecl}
 @\placeholdernc{C}@ atomic_exchange(volatile @\placeholder{A}@*@\itcorr[-1]@ object, @\placeholdernc{C}@ desired) noexcept;
 @\placeholdernc{C}@ atomic_exchange(@\placeholder{A}@*@\itcorr[-1]@ object, @\placeholdernc{C}@ desired) noexcept;
@@ -975,22 +964,12 @@ These operations are atomic read-modify-write operations~(\ref{intro.multithread
 \returns Atomically returns the value pointed to by \tcode{object} or by \tcode{this} immediately before the effects.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{atomic type}!\idxcode{atomic_compare_exchange_weak}}%
-\indexlibrary{\idxcode{atomic_compare_exchange_weak}!\idxcode{atomic type}}%
-\indexlibrary{\idxcode{atomic type}!\idxcode{atomic_compare_exchange_strong}}%
-\indexlibrary{\idxcode{atomic_compare_exchange_strong}!\idxcode{atomic type}}%
-\indexlibrary{\idxcode{atomic type}!atomic_compare_exchange_weak_explicit@\tcode{atomic_compare_exchange_weak_-\\explicit}}%
-\indexlibrary{\idxcode{atomic_compare_exchange_weak_explicit}!\idxcode{atomic type}}%
-\indexlibrary{\idxcode{atomic type}!atomic_compare_exchange_strong_explicit@\tcode{atomic_compare_exchange_strong_-\\explicit}}%
-\indexlibrary{\idxcode{atomic_compare_exchange_strong_explicit}!\idxcode{atomic type}}%
-\indexlibrary{\idxcode{atomic type}!\idxcode{compare_exchange_weak}}%
-\indexlibrary{\idxcode{compare_exchange_weak}!\idxcode{atomic type}}%
-\indexlibrary{\idxcode{atomic type}!\idxcode{compare_exchange_strong}}%
-\indexlibrary{\idxcode{compare_exchange_strong}!\idxcode{atomic type}}%
-\indexlibrary{\idxcode{atomic type}!\idxcode{compare_exchange_weak_explicit}}%
-\indexlibrary{\idxcode{compare_exchange_weak_explicit}!\idxcode{atomic type}}%
-\indexlibrary{\idxcode{atomic type}!\idxcode{compare_exchange_strong_explicit}}%
-\indexlibrary{\idxcode{compare_exchange_strong_explicit}!\idxcode{atomic type}}%
+\indexlibrary{\idxcode{atomic_compare_exchange_weak}}%
+\indexlibrary{\idxcode{atomic_compare_exchange_strong}}%
+\indexlibrary{\idxcode{atomic_compare_exchange_weak_explicit}}%
+\indexlibrary{\idxcode{atomic_compare_exchange_strong_explicit}}%
+\indexlibrarymember{atomic type}{compare_exchange_weak}%
+\indexlibrarymember{atomic type}{compare_exchange_strong}%
 \begin{itemdecl}
 bool atomic_compare_exchange_weak(volatile @\placeholder{A}@*@\itcorr[-1]@ object, @\placeholder{C}@*@\itcorr[-1]@ expected, @\placeholdernc{C}@ desired) noexcept;
 bool atomic_compare_exchange_weak(@\placeholder{A}@*@\itcorr[-1]@ object, @\placeholder{C}@*@\itcorr[-1]@ expected, @\placeholdernc{C}@ desired) noexcept;
@@ -1146,10 +1125,9 @@ The following operations perform arithmetic computations. The key, operator, and
   bitwise and     &&&\\\hline
 \end{floattable}
 
-\indexlibrary{\idxcode{atomic type}!\idxcode{atomic_fetch_}}%
-\indexlibrary{\idxcode{atomic_fetch_}!\idxcode{atomic type}}%
-\indexlibrary{\idxcode{atomic type}!\idxcode{fetch_}}%
-\indexlibrary{\idxcode{fetch_}!\idxcode{atomic type}}%
+\indexlibrary{\idxcode{atomic_fetch_\textit{key}}}%
+\indexlibrary{\idxcode{atomic_fetch_\textit{key}_explicit}}%
+\indexlibrarymember{atomic type}{fetch_\textit{key}}%
 \begin{itemdecl}
 @\placeholdernc{C}@ atomic_fetch_@\placeholdernc{key}@(volatile @\placeholder{A}@*@\itcorr[-1]@ object, @\placeholdernc{M}@ operand) noexcept;
 @\placeholdernc{C}@ atomic_fetch_@\placeholdernc{key}@(@\placeholder{A}@*@\itcorr[-1]@ object, @\placeholdernc{M}@ operand) noexcept;
@@ -1176,8 +1154,7 @@ representation. There are no undefined results. For address types, the result ma
 undefined address, but the operations otherwise have no undefined behavior.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{atomic type}!\idxcode{operator "@=}}%
-\indexlibrary{\idxcode{operator "@=}!\idxcode{atomic type}}%
+\indexlibrarymember{atomic type}{operator "@=}%
 \begin{itemdecl}
 @\placeholdernc{C}@ @\placeholdernc{A}@::operator @\textit{op}@=(@\placeholdernc{M}@ operand) volatile noexcept;
 @\placeholdernc{C}@ @\placeholdernc{A}@::operator @\textit{op}@=(@\placeholdernc{M}@ operand) noexcept;
@@ -1191,8 +1168,7 @@ undefined address, but the operations otherwise have no undefined behavior.
 \returns \tcode{fetch_\placeholder{key}(operand) op operand}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{atomic type}!\idxcode{operator++}}%
-\indexlibrary{\idxcode{operator++}!\idxcode{atomic type}}%
+\indexlibrarymember{atomic type}{operator++}%
 \begin{itemdecl}
 @\placeholdernc{C}@ @\placeholdernc{A}@::operator++(int) volatile noexcept;
 @\placeholdernc{C}@ @\placeholdernc{A}@::operator++(int) noexcept;
@@ -1203,8 +1179,7 @@ undefined address, but the operations otherwise have no undefined behavior.
 \returns \tcode{fetch_add(1)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{atomic type}!\idxcode{operator\dcr}}%
-\indexlibrary{\idxcode{operator\dcr}!\idxcode{atomic type}}%
+\indexlibrarymember{atomic type}{operator\dcr}%
 \begin{itemdecl}
 @\placeholdernc{C}@ @\placeholdernc{A}@::operator--(int) volatile noexcept;
 @\placeholdernc{C}@ @\placeholdernc{A}@::operator--(int) noexcept;
@@ -1215,8 +1190,7 @@ undefined address, but the operations otherwise have no undefined behavior.
 \returns \tcode{fetch_sub(1)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{atomic type}!\idxcode{operator++}}%
-\indexlibrary{\idxcode{operator++}!\idxcode{atomic type}}%
+\indexlibrarymember{atomic type}{operator++}%
 \begin{itemdecl}
 @\placeholdernc{C}@ @\placeholdernc{A}@::operator++() volatile noexcept;
 @\placeholdernc{C}@ @\placeholdernc{A}@::operator++() noexcept;
@@ -1230,8 +1204,7 @@ undefined address, but the operations otherwise have no undefined behavior.
 \returns \tcode{fetch_add(1) + 1}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{atomic type}!\idxcode{operator\dcr}}%
-\indexlibrary{\idxcode{operator\dcr}!\idxcode{atomic type}}%
+\indexlibrarymember{atomic type}{operator\dcr}%
 \begin{itemdecl}
 @\placeholdernc{C}@ @\placeholdernc{A}@::operator--() volatile noexcept;
 @\placeholdernc{C}@ @\placeholdernc{A}@::operator--() noexcept;
@@ -1300,6 +1273,7 @@ Unless initialized with \tcode{ATOMIC_FLAG_INIT}, it is unspecified whether an
 
 \indexlibrary{\idxcode{atomic_flag_test_and_set}}%
 \indexlibrary{\idxcode{atomic_flag_test_and_set_explicit}}%
+\indexlibrarymember{atomic_flag}{test_and_set}%
 \begin{itemdecl}
 bool atomic_flag_test_and_set(volatile atomic_flag* object) noexcept;
 bool atomic_flag_test_and_set(atomic_flag* object) noexcept;
@@ -1320,8 +1294,7 @@ bool atomic_flag::test_and_set(memory_order order = memory_order_seq_cst) noexce
 
 \indexlibrary{\idxcode{atomic_flag_clear}}%
 \indexlibrary{\idxcode{atomic_flag_clear_explicit}}%
-\indexlibrary{\idxcode{atomic_flag}!\idxcode{clear}}%
-\indexlibrary{\idxcode{clear}!\idxcode{atomic_flag}}%
+\indexlibrarymember{atomic_flag}{clear}%
 \begin{itemdecl}
 void atomic_flag_clear(volatile atomic_flag* object) noexcept;
 void atomic_flag_clear(atomic_flag* object) noexcept;

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -3090,14 +3090,10 @@ one of these tables and
 for operations where there is additional semantic information.
 
 \indexlibrary{\idxcode{array}}%
-\indexlibrary{\idxcode{array}!\idxcode{begin}}%
-\indexlibrary{\idxcode{begin}!\idxcode{array}}%
-\indexlibrary{\idxcode{array}!\idxcode{end}}%
-\indexlibrary{\idxcode{end}!\idxcode{array}}%
-\indexlibrary{\idxcode{array}!\idxcode{size}}%
-\indexlibrary{\idxcode{size}!\idxcode{array}}%
-\indexlibrary{\idxcode{array}!\idxcode{max_size}}%
-\indexlibrary{\idxcode{max_size}!\idxcode{array}}%
+\indexlibrarymember{array}{begin}%
+\indexlibrarymember{array}{end}%
+\indexlibrarymember{array}{size}%
+\indexlibrarymember{array}{max_size}%
 \begin{codeblock}
 namespace std {
   template <class T, size_t N>
@@ -3173,8 +3169,7 @@ respectively.
 
 \rSec3[array.special]{\tcode{array} specialized algorithms}
 
-\indexlibrary{\idxcode{array}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{array}}%
+\indexlibrarymember{array}{swap}%
 \begin{itemdecl}
 template <class T, size_t N>
   void swap(array<T, N>& x, array<T, N>& y) noexcept(noexcept(x.swap(y)));
@@ -3194,8 +3189,7 @@ As if by \tcode{x.swap(y)}.
 
 \rSec3[array.size]{\tcode{array::size}}
 
-\indexlibrary{\idxcode{array}!\idxcode{size}}%
-\indexlibrary{\idxcode{size}!\idxcode{array}}%
+\indexlibrarymember{array}{size}%
 \begin{itemdecl}
 template <class T, size_t N> constexpr size_type array<T, N>::size() const noexcept;
 \end{itemdecl}
@@ -3205,8 +3199,7 @@ template <class T, size_t N> constexpr size_type array<T, N>::size() const noexc
 \end{itemdescr}
 
 \rSec3[array.data]{\tcode{array::data}}
-\indexlibrary{\idxcode{array}!\idxcode{data}}%
-\indexlibrary{\idxcode{data}!\idxcode{array}}%
+\indexlibrarymember{array}{data}%
 \begin{itemdecl}
 constexpr T* data() noexcept;
 constexpr const T* data() const noexcept;
@@ -3220,8 +3213,7 @@ A pointer such that \range{data()}{data() + size()} is a valid range, and
 
 \rSec3[array.fill]{\tcode{array::fill}}
 
-\indexlibrary{\idxcode{array}!\idxcode{fill}}%
-\indexlibrary{\idxcode{fill}!\idxcode{array}}%
+\indexlibrarymember{array}{fill}%
 \begin{itemdecl}
 void fill(const T& u);
 \end{itemdecl}
@@ -3233,8 +3225,7 @@ void fill(const T& u);
 
 \rSec3[array.swap]{\tcode{array::swap}}
 
-\indexlibrary{\idxcode{array}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{array}}%
+\indexlibrarymember{array}{swap}%
 \begin{itemdecl}
 void swap(array& y) noexcept(is_nothrow_swappable_v<T>);
 \end{itemdecl}
@@ -3291,8 +3282,7 @@ tuple_element<I, array<T, N>>::type
 \cvalue  The type T.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{array}!\idxcode{get}}%
-\indexlibrary{\idxcode{get}!\idxcode{array}}%
+\indexlibrarymember{array}{get}%
 \begin{itemdecl}
 template <size_t I, class T, size_t N>
   constexpr T& get(array<T, N>& a) noexcept;
@@ -3570,8 +3560,7 @@ appends \tcode{sz - size()} copies of \tcode{c} to the sequence.
 \tcode{CopyInsertable} into \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{shrink_to_fit}!\idxcode{deque}}%
-\indexlibrary{\idxcode{deque}!\idxcode{shrink_to_fit}}%
+\indexlibrarymember{shrink_to_fit}{deque}%
 \begin{itemdecl}
 void shrink_to_fit();
 \end{itemdecl}
@@ -3677,8 +3666,7 @@ assignment operator, or move assignment operator of
 
 \rSec3[deque.special]{\tcode{deque} specialized algorithms}
 
-\indexlibrary{\idxcode{swap}!\idxcode{deque}}%
-\indexlibrary{\idxcode{deque}!\idxcode{swap}}%
+\indexlibrarymember{swap}{deque}%
 \begin{itemdecl}
 template <class T, class Allocator>
   void swap(deque<T, Allocator>& x, deque<T, Allocator>& y)
@@ -3928,10 +3916,8 @@ template <class InputIterator>
 
 \rSec3[forwardlist.iter]{\tcode{forward_list} iterators}
 
-\indexlibrary{\idxcode{before_begin}!\idxcode{forward_list}}%
-\indexlibrary{\idxcode{forward_list}!\idxcode{before_begin}}%
-\indexlibrary{\idxcode{cbefore_begin}!\idxcode{forward_list}}%
-\indexlibrary{\idxcode{forward_list}!\idxcode{cbefore_begin}}%
+\indexlibrarymember{before_begin}{forward_list}%
+\indexlibrarymember{cbefore_begin}{forward_list}%
 \begin{itemdecl}
 iterator before_begin() noexcept;
 const_iterator before_begin() const noexcept;
@@ -3953,8 +3939,7 @@ returned by \tcode{begin()}.
 
 \rSec3[forwardlist.access]{\tcode{forward_list} element access}
 
-\indexlibrary{\idxcode{front}!\idxcode{forward_list}}%
-\indexlibrary{\idxcode{forward_list}!\idxcode{front}}%
+\indexlibrarymember{front}{forward_list}%
 \begin{itemdecl}
 reference front();
 const_reference front() const;
@@ -3977,8 +3962,7 @@ exactly equal to \tcode{n}. Erasing \tcode{n} elements from a \tcode{forward_lis
 linear in \tcode{n} and the number of calls to the destructor of type \tcode{T} is
 exactly equal to \tcode{n}.
 
-\indexlibrary{\idxcode{emplace_front}!\idxcode{forward_list}}%
-\indexlibrary{\idxcode{forward_list}!\idxcode{emplace_front}}%
+\indexlibrarymember{emplace_front}{forward_list}%
 \begin{itemdecl}
 template <class... Args> reference emplace_front(Args&&... args);
 \end{itemdecl}
@@ -3989,8 +3973,7 @@ template <class... Args> reference emplace_front(Args&&... args);
 \tcode{value_type(std::forward<Args>(\brk{}args)...)} at the beginning of the list.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{push_front}!\idxcode{forward_list}}%
-\indexlibrary{\idxcode{forward_list}!\idxcode{push_front}}%
+\indexlibrarymember{push_front}{forward_list}%
 \begin{itemdecl}
 void push_front(const T& x);
 void push_front(T&& x);
@@ -4002,8 +3985,7 @@ void push_front(T&& x);
 \end{itemdescr}
 
 
-\indexlibrary{\idxcode{pop}!\idxcode{forward_list}}%
-\indexlibrary{\idxcode{forward_list}!\idxcode{pop}}%
+\indexlibrarymember{pop}{forward_list}%
 \begin{itemdecl}
 void pop_front();
 \end{itemdecl}
@@ -4013,8 +3995,7 @@ void pop_front();
 \effects As if by \tcode{erase_after(before_begin())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{insert_after}!\idxcode{forward_list}}%
-\indexlibrary{\idxcode{forward_list}!\idxcode{insert_after}}%
+\indexlibrarymember{insert_after}{forward_list}%
 \begin{itemdecl}
 iterator insert_after(const_iterator position, const T& x);
 iterator insert_after(const_iterator position, T&& x);
@@ -4032,8 +4013,7 @@ iterator in the range \range{begin()}{end()}.
 \returns An iterator pointing to the copy of \tcode{x}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{insert_after}!\idxcode{forward_list}}%
-\indexlibrary{\idxcode{forward_list}!\idxcode{insert_after}}%
+\indexlibrarymember{insert_after}{forward_list}%
 \begin{itemdecl}
 iterator insert_after(const_iterator position, size_type n, const T& x);
 \end{itemdecl}
@@ -4051,8 +4031,7 @@ iterator in the range \range{begin()}{end()}.
 An iterator pointing to the last inserted copy of \tcode{x} or \tcode{position} if \tcode{n == 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{insert_after}!\idxcode{forward_list}}%
-\indexlibrary{\idxcode{forward_list}!\idxcode{insert_after}}%
+\indexlibrarymember{insert_after}{forward_list}%
 \begin{itemdecl}
 template <class InputIterator>
   iterator insert_after(const_iterator position, InputIterator first, InputIterator last);
@@ -4072,8 +4051,7 @@ iterator in the range \range{begin()}{end()}.
 An iterator pointing to the last inserted element or \tcode{position} if \tcode{first == last}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{insert_after}!\idxcode{forward_list}}%
-\indexlibrary{\idxcode{forward_list}!\idxcode{insert_after}}%
+\indexlibrarymember{insert_after}{forward_list}%
 \begin{itemdecl}
 iterator insert_after(const_iterator position, initializer_list<T> il);
 \end{itemdecl}
@@ -4088,8 +4066,7 @@ An iterator pointing to the last inserted element or \tcode{position} if \tcode{
 \end{itemdescr}
 
 
-\indexlibrary{\idxcode{emplace_after}!\idxcode{forward_list}}%
-\indexlibrary{\idxcode{forward_list}!\idxcode{emplace_after}}%
+\indexlibrarymember{emplace_after}{forward_list}%
 \begin{itemdecl}
 template <class... Args>
   iterator emplace_after(const_iterator position, Args&&... args);
@@ -4108,8 +4085,7 @@ iterator in the range \range{begin()}{end()}.
 \returns An iterator pointing to the new object.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{erase_after}!\idxcode{forward_list}}%
-\indexlibrary{\idxcode{forward_list}!\idxcode{erase_after}}%
+\indexlibrarymember{erase_after}{forward_list}%
 \begin{itemdecl}
 iterator erase_after(const_iterator position);
 \end{itemdecl}
@@ -4129,8 +4105,7 @@ erased, or \tcode{end()} if no such element exists.
 \throws Nothing.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{erased}!\idxcode{forward_list}}%
-\indexlibrary{\idxcode{forward_list}!\idxcode{erased}}%
+\indexlibrarymember{erased}{forward_list}%
 \begin{itemdecl}
 iterator erase_after(const_iterator position, const_iterator last);
 \end{itemdecl}
@@ -4149,8 +4124,7 @@ iterator erase_after(const_iterator position, const_iterator last);
 \throws Nothing.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{resize}!\idxcode{forward_list}}%
-\indexlibrary{\idxcode{forward_list}!\idxcode{resize}}%
+\indexlibrarymember{resize}{forward_list}%
 \begin{itemdecl}
 void resize(size_type sz);
 \end{itemdecl}
@@ -4180,8 +4154,7 @@ copies of \tcode{c} at the end of the list.
 \end{itemdescr}
 
 
-\indexlibrary{\idxcode{clear}!\idxcode{forward_list}}%
-\indexlibrary{\idxcode{forward_list}!\idxcode{clear}}%
+\indexlibrarymember{clear}{forward_list}%
 \begin{itemdecl}
 void clear() noexcept;
 \end{itemdecl}
@@ -4196,8 +4169,7 @@ void clear() noexcept;
 
 \rSec3[forwardlist.ops]{\tcode{forward_list} operations}
 
-\indexlibrary{\idxcode{splice_after}!\idxcode{forward_list}}%
-\indexlibrary{\idxcode{forward_list}!\idxcode{splice_after}}%
+\indexlibrarymember{splice_after}{forward_list}%
 \begin{itemdecl}
 void splice_after(const_iterator position, forward_list& x);
 void splice_after(const_iterator position, forward_list&& x);
@@ -4224,8 +4196,7 @@ they now behave as iterators into \tcode{*this}, not into \tcode{x}.
 \complexity \bigoh{\tcode{distance(x.begin(), x.end())}}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{splice_after}!\idxcode{forward_list}}%
-\indexlibrary{\idxcode{forward_list}!\idxcode{splice_after}}%
+\indexlibrarymember{splice_after}{forward_list}%
 \begin{itemdecl}
 void splice_after(const_iterator position, forward_list& x, const_iterator i);
 void splice_after(const_iterator position, forward_list&& x, const_iterator i);
@@ -4253,8 +4224,7 @@ the same element, but now behave as iterators into \tcode{*this}, not into \tcod
 \complexity \bigoh{1}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{splice_after}!\idxcode{forward_list}}%
-\indexlibrary{\idxcode{forward_list}!\idxcode{splice_after}}%
+\indexlibrarymember{splice_after}{forward_list}%
 \begin{itemdecl}
 void splice_after(const_iterator position, forward_list& x,
                   const_iterator first, const_iterator last);
@@ -4281,10 +4251,8 @@ behave as iterators into \tcode{*this}, not into \tcode{x}.
 \complexity \bigoh{\tcode{distance(first, last)}}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{remove}!\idxcode{forward_list}}%
-\indexlibrary{\idxcode{forward_list}!\idxcode{remove}}%
-\indexlibrary{\idxcode{remove_if}!\idxcode{forward_list}}%
-\indexlibrary{\idxcode{forward_list}!\idxcode{remove_if}}%
+\indexlibrarymember{remove}{forward_list}%
+\indexlibrarymember{remove_if}{forward_list}%
 \begin{itemdecl}
 void remove(const T& value);
 template <class Predicate> void remove_if(Predicate pred);
@@ -4309,8 +4277,7 @@ predicate.
 predicate.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{unique}!\idxcode{forward_list}}%
-\indexlibrary{\idxcode{forward_list}!\idxcode{unique}}%
+\indexlibrarymember{unique}{forward_list}%
 \begin{itemdecl}
 void unique();
 template <class BinaryPredicate> void unique(BinaryPredicate pred);
@@ -4331,8 +4298,7 @@ Invalidates only the iterators and references to the erased elements.
 \complexity If the range \range{first}{last} is not empty, exactly \tcode{(last - first) - 1} applications of the corresponding predicate, otherwise no applications of the predicate.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{merge}!\idxcode{forward_list}}%
-\indexlibrary{\idxcode{forward_list}!\idxcode{merge}}%
+\indexlibrarymember{merge}{forward_list}%
 \begin{itemdecl}
 void merge(forward_list& x);
 void merge(forward_list&& x);
@@ -4364,8 +4330,7 @@ refer to their elements, but they now behave as iterators into \tcode{*this}, no
 end()) + distance(x.begin(), x.end()) - 1} comparisons.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sort}!\idxcode{forward_list}}%
-\indexlibrary{\idxcode{forward_list}!\idxcode{sort}}%
+\indexlibrarymember{sort}{forward_list}%
 \begin{itemdecl}
 void sort();
 template <class Compare> void sort(Compare comp);
@@ -4388,8 +4353,7 @@ Does not affect the validity of iterators and references.
 \complexity Approximately $N \log N$ comparisons, where $N$ is \tcode{distance(begin(), end())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{reverse}!\idxcode{forward_list}}%
-\indexlibrary{\idxcode{forward_list}!\idxcode{reverse}}%
+\indexlibrarymember{reverse}{forward_list}%
 \begin{itemdecl}
 void reverse() noexcept;
 \end{itemdecl}
@@ -4405,8 +4369,7 @@ Does not affect the validity of iterators and references.
 
 \rSec3[forwardlist.spec]{\tcode{forward_list} specialized algorithms}
 
-\indexlibrary{\idxcode{swap}!\idxcode{forward_list}}%
-\indexlibrary{\idxcode{forward_list}!\idxcode{swap}}%
+\indexlibrarymember{swap}{forward_list}%
 \begin{itemdecl}
 template <class T, class Allocator>
   void swap(forward_list<T, Allocator>& x, forward_list<T, Allocator>& y)
@@ -4852,8 +4815,7 @@ not into
 Constant time.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{splice}!\idxcode{list}}%
-\indexlibrary{\idxcode{list}!\idxcode{splice}}%
+\indexlibrarymember{splice}{list}%
 \begin{itemdecl}
 void splice(const_iterator position, list& x, const_iterator i);
 void splice(const_iterator position, list&& x, const_iterator i);
@@ -4900,8 +4862,7 @@ is a valid dereferenceable iterator of
 Constant time.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{splice}!\idxcode{list}}%
-\indexlibrary{\idxcode{list}!\idxcode{splice}}%
+\indexlibrarymember{splice}{list}%
 \begin{itemdecl}
 void splice(const_iterator position, list& x, const_iterator first,
             const_iterator last);
@@ -5104,8 +5065,7 @@ comparisons, where
 
 \rSec3[list.special]{\tcode{list} specialized algorithms}
 
-\indexlibrary{\idxcode{swap}!\idxcode{list}}%
-\indexlibrary{\idxcode{list}!\idxcode{swap}}%
+\indexlibrarymember{swap}{list}%
 \begin{itemdecl}
 template <class T, class Allocator>
   void swap(list<T, Allocator>& x, list<T, Allocator>& y)
@@ -5592,8 +5552,7 @@ assignment operator, or move assignment operator of
 
 \rSec3[vector.special]{\tcode{vector} specialized algorithms}
 
-\indexlibrary{\idxcode{swap}!\idxcode{vector}}%
-\indexlibrary{\idxcode{vector}!\idxcode{swap}}%
+\indexlibrarymember{swap}{vector}%
 \begin{itemdecl}
 template <class T, class Allocator>
   void swap(vector<T, Allocator>& x, vector<T, Allocator>& y)
@@ -5745,8 +5704,7 @@ when the bit is set, and \tcode{false} otherwise. The assignment operator
 sets the bit when the argument is (convertible to) \tcode{true} and
 clears it otherwise. \tcode{flip} reverses the state of the bit.
 
-\indexlibrary{\idxcode{flip}!\idxcode{vector<bool>}}%
-\indexlibrary{\idxcode{vector<bool>}!\idxcode{flip}}%
+\indexlibrarymember{flip}{vector<bool>}%
 \begin{itemdecl}
 void flip() noexcept;
 \end{itemdecl}
@@ -5756,8 +5714,7 @@ void flip() noexcept;
 \effects Replaces each element in the container with its complement.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{swap}!\idxcode{vector<bool>}}%
-\indexlibrary{\idxcode{vector<bool>}!\idxcode{swap}}%
+\indexlibrarymember{swap}{vector<bool>}%
 \begin{itemdecl}
 static void swap(reference x, reference y) noexcept;
 \end{itemdecl}
@@ -6277,8 +6234,7 @@ no such element is present.
 
 \rSec3[map.modifiers]{\tcode{map} modifiers}
 
-\indexlibrary{\idxcode{insert}!\idxcode{map}}%
-\indexlibrary{\idxcode{map}!\idxcode{insert}}%
+\indexlibrarymember{insert}{map}%
 \begin{itemdecl}
 template <class P> pair<iterator, bool> insert(P&& x);
 template <class P> iterator insert(const_iterator position, P&& x);
@@ -6298,8 +6254,7 @@ unless \tcode{std::is_constructible_v<value_type, P\&\&>} is
 \tcode{true}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{try_emplace}!\idxcode{map}}%
-\indexlibrary{\idxcode{map}!\idxcode{try_emplace}}%
+\indexlibrarymember{try_emplace}{map}%
 \begin{itemdecl}
 template <class... Args> pair<iterator, bool> try_emplace(const key_type& k, Args&&... args);
 template <class... Args> iterator try_emplace(const_iterator hint, const key_type& k, Args&&... args);
@@ -6335,8 +6290,7 @@ The same as \tcode{emplace} and \tcode{emplace_hint},
 respectively.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{try_emplace}!\idxcode{map}}%
-\indexlibrary{\idxcode{map}!\idxcode{try_emplace}}%
+\indexlibrarymember{try_emplace}{map}%
 \begin{itemdecl}
 template <class... Args> pair<iterator, bool> try_emplace(key_type&& k, Args&&... args);
 template <class... Args> iterator try_emplace(const_iterator hint, key_type&& k, Args&&... args);
@@ -6372,8 +6326,7 @@ The same as \tcode{emplace} and \tcode{emplace_hint},
 respectively.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{insert_or_assign}!\idxcode{map}}%
-\indexlibrary{\idxcode{map}!\idxcode{insert_or_assign}}%
+\indexlibrarymember{insert_or_assign}{map}%
 \begin{itemdecl}
 template <class M> pair<iterator, bool> insert_or_assign(const key_type& k, M&& obj);
 template <class M> iterator insert_or_assign(const_iterator hint, const key_type& k, M&& obj);
@@ -6408,8 +6361,7 @@ The same as \tcode{emplace} and \tcode{emplace_hint},
 respectively.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{insert_or_assign}!\idxcode{map}}%
-\indexlibrary{\idxcode{map}!\idxcode{insert_or_assign}}%
+\indexlibrarymember{insert_or_assign}{map}%
 \begin{itemdecl}
 template <class M> pair<iterator, bool> insert_or_assign(key_type&& k, M&& obj);
 template <class M> iterator insert_or_assign(const_iterator hint, key_type&& k, M&& obj);
@@ -6446,8 +6398,7 @@ respectively.
 
 \rSec3[map.special]{\tcode{map} specialized algorithms}
 
-\indexlibrary{\idxcode{swap}!\idxcode{map}}%
-\indexlibrary{\idxcode{map}!\idxcode{swap}}%
+\indexlibrarymember{swap}{map}%
 \begin{itemdecl}
 template <class Key, class T, class Compare, class Allocator>
   void swap(map<Key, T, Compare, Allocator>& x,
@@ -6739,8 +6690,7 @@ where $N$ is
 
 \rSec3[multimap.modifiers]{\tcode{multimap} modifiers}
 
-\indexlibrary{\idxcode{insert}!\idxcode{multimap}}%
-\indexlibrary{\idxcode{multimap}!\idxcode{insert}}%
+\indexlibrarymember{insert}{multimap}%
 \begin{itemdecl}
 template <class P> iterator insert(P&& x);
 template <class P> iterator insert(const_iterator position, P&& x);
@@ -6762,8 +6712,7 @@ unless \tcode{std::is_constructible_v<value_type, P\&\&>} is
 
 \rSec3[multimap.special]{\tcode{multimap} specialized algorithms}
 
-\indexlibrary{\idxcode{swap}!\idxcode{multimap}}%
-\indexlibrary{\idxcode{multimap}!\idxcode{swap}}%
+\indexlibrarymember{swap}{multimap}%
 \begin{itemdecl}
 template <class Key, class T, class Compare, class Allocator>
   void swap(multimap<Key, T, Compare, Allocator>& x,
@@ -7032,8 +6981,7 @@ where $N$ is
 
 \rSec3[set.special]{\tcode{set} specialized algorithms}
 
-\indexlibrary{\idxcode{swap}!\idxcode{set}}%
-\indexlibrary{\idxcode{set}!\idxcode{swap}}%
+\indexlibrarymember{swap}{set}%
 \begin{itemdecl}
 template <class Key, class Compare, class Allocator>
   void swap(set<Key, Compare, Allocator>& x,
@@ -7300,8 +7248,7 @@ where $N$ is
 
 \rSec3[multiset.special]{\tcode{multiset} specialized algorithms}
 
-\indexlibrary{\idxcode{swap}!\idxcode{multiset}}%
-\indexlibrary{\idxcode{multiset}!\idxcode{swap}}%
+\indexlibrarymember{swap}{multiset}%
 \begin{itemdecl}
 template <class Key, class Compare, class Allocator>
   void swap(multiset<Key, Compare, Allocator>& x,
@@ -7729,8 +7676,7 @@ for the first form, or from the range
 
 \rSec3[unord.map.elem]{\tcode{unordered_map} element access}
 
-\indexlibrary{\idxcode{unordered_map}!\idxcode{operator[]}}%
-\indexlibrary{\idxcode{operator[]}!\idxcode{unordered_map}}%
+\indexlibrarymember{unordered_map}{operator[]}%
 \indextext{\idxcode{unordered_map}!element access}%
 \begin{itemdecl}
 mapped_type& operator[](const key_type& k);
@@ -7741,8 +7687,7 @@ mapped_type& operator[](const key_type& k);
 \effects Equivalent to: \tcode{return try_emplace(k).first->second;}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{unordered_map}!\idxcode{operator[]}}%
-\indexlibrary{\idxcode{operator[]}!\idxcode{unordered_map}}%
+\indexlibrarymember{unordered_map}{operator[]}%
 \indextext{\idxcode{unordered_map}!element access}%
 \begin{itemdecl}
 mapped_type& operator[](key_type&& k);
@@ -7753,8 +7698,7 @@ mapped_type& operator[](key_type&& k);
 \effects Equivalent to: \tcode{return try_emplace(move(k)).first->second;}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{unordered_map}!\idxcode{at}}%
-\indexlibrary{\idxcode{at}!\idxcode{unordered_map}}%
+\indexlibrarymember{unordered_map}{at}%
 \indextext{\idxcode{unordered_map}!element access}%
 \begin{itemdecl}
 mapped_type& at(const key_type& k);
@@ -7771,8 +7715,7 @@ const mapped_type& at(const key_type& k) const;
 
 \rSec3[unord.map.modifiers]{\tcode{unordered_map} modifiers}
 
-\indexlibrary{\idxcode{unordered_map}!\idxcode{insert}}%
-\indexlibrary{\idxcode{insert}!\idxcode{unordered_map}}%
+\indexlibrarymember{unordered_map}{insert}%
 \begin{itemdecl}
 template <class P>
   pair<iterator, bool> insert(P&& obj);
@@ -7787,8 +7730,7 @@ template <class P>
 unless \tcode{std::is_constructible_v<value_type, P\&\&>} is \tcode{true}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{unordered_map}!\idxcode{insert}}%
-\indexlibrary{\idxcode{insert}!\idxcode{unordered_map}}%
+\indexlibrarymember{unordered_map}{insert}%
 \begin{itemdecl}
 template <class P>
   iterator insert(const_iterator hint, P&& obj);
@@ -7804,8 +7746,7 @@ template <class P>
 unless \tcode{std::is_constructible_v<value_type, P\&\&>} is \tcode{true}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{try_emplace}!\idxcode{unordered_map}}%
-\indexlibrary{\idxcode{unordered_map}!\idxcode{try_emplace}}%
+\indexlibrarymember{try_emplace}{unordered_map}%
 \begin{itemdecl}
 template <class... Args> pair<iterator, bool> try_emplace(const key_type& k, Args&&... args);
 template <class... Args> iterator try_emplace(const_iterator hint, const key_type& k, Args&&... args);
@@ -7841,8 +7782,7 @@ The same as \tcode{emplace} and \tcode{emplace_hint},
 respectively.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{try_emplace}!\idxcode{unordered_map}}%
-\indexlibrary{\idxcode{unordered_map}!\idxcode{try_emplace}}%
+\indexlibrarymember{try_emplace}{unordered_map}%
 \begin{itemdecl}
 template <class... Args> pair<iterator, bool> try_emplace(key_type&& k, Args&&... args);
 template <class... Args> iterator try_emplace(const_iterator hint, key_type&& k, Args&&... args);
@@ -7878,8 +7818,7 @@ The same as \tcode{emplace} and \tcode{emplace_hint},
 respectively.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{insert_or_assign}!\idxcode{unordered_map}}%
-\indexlibrary{\idxcode{unordered_map}!\idxcode{insert_or_assign}}%
+\indexlibrarymember{insert_or_assign}{unordered_map}%
 \begin{itemdecl}
 template <class M> pair<iterator, bool> insert_or_assign(const key_type& k, M&& obj);
 template <class M> iterator insert_or_assign(const_iterator hint, const key_type& k, M&& obj);
@@ -7914,8 +7853,7 @@ The same as \tcode{emplace} and \tcode{emplace_hint},
 respectively.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{insert_or_assign}!\idxcode{unordered_map}}%
-\indexlibrary{\idxcode{unordered_map}!\idxcode{insert_or_assign}}%
+\indexlibrarymember{insert_or_assign}{unordered_map}%
 \begin{itemdecl}
 template <class M> pair<iterator, bool> insert_or_assign(key_type&& k, M&& obj);
 template <class M> iterator insert_or_assign(const_iterator hint, key_type&& k, M&& obj);
@@ -7952,8 +7890,7 @@ respectively.
 
 \rSec3[unord.map.swap]{\tcode{unordered_map} swap}
 
-\indexlibrary{\idxcode{unordered_map}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{unordered_map}}%
+\indexlibrarymember{unordered_map}{swap}%
 \begin{itemdecl}
 template <class Key, class T, class Hash, class Pred, class Alloc>
   void swap(unordered_map<Key, T, Hash, Pred, Alloc>& x,
@@ -8224,8 +8161,7 @@ for the first form, or from the range
 
 \rSec3[unord.multimap.modifiers]{\tcode{unordered_multimap} modifiers}
 
-\indexlibrary{\idxcode{unordered_multimap}!\idxcode{insert}}%
-\indexlibrary{\idxcode{insert}!\idxcode{unordered_multimap}}%
+\indexlibrarymember{unordered_multimap}{insert}%
 \begin{itemdecl}
 template <class P>
   iterator insert(P&& obj);
@@ -8240,8 +8176,7 @@ template <class P>
 unless \tcode{std::is_constructible_v<value_type, P\&\&>} is \tcode{true}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{unordered_multimap}!\idxcode{insert}}%
-\indexlibrary{\idxcode{insert}!\idxcode{unordered_multimap}}%
+\indexlibrarymember{unordered_multimap}{insert}%
 \begin{itemdecl}
 template <class P>
   iterator insert(const_iterator hint, P&& obj);
@@ -8259,8 +8194,7 @@ unless \tcode{std::is_constructible_v<value_type, P\&\&>} is \tcode{true}.
 
 \rSec3[unord.multimap.swap]{\tcode{unordered_multimap} swap}
 
-\indexlibrary{\idxcode{unordered_multimap}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{unordered_multimap}}%
+\indexlibrarymember{unordered_multimap}{swap}%
 \begin{itemdecl}
 template <class Key, class T, class Hash, class Pred, class Alloc>
   void swap(unordered_multimap<Key, T, Hash, Pred, Alloc>& x,
@@ -8522,8 +8456,7 @@ for the first form, or from the range
 
 \rSec3[unord.set.swap]{\tcode{unordered_set} swap}
 
-\indexlibrary{\idxcode{unordered_set}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{unordered_set}}%
+\indexlibrarymember{unordered_set}{swap}%
 \begin{itemdecl}
 template <class Key, class Hash, class Pred, class Alloc>
   void swap(unordered_set<Key, Hash, Pred, Alloc>& x,
@@ -8789,8 +8722,7 @@ for the first form, or from the range
 
 \rSec3[unord.multiset.swap]{\tcode{unordered_multiset} swap}
 
-\indexlibrary{\idxcode{unordered_multiset}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{unordered_multiset}}%
+\indexlibrarymember{unordered_multiset}{swap}%
 \begin{itemdecl}
 template <class Key, class Hash, class Pred, class Alloc>
   void swap(unordered_multiset<Key, Hash, Pred, Alloc>& x,
@@ -9116,8 +9048,7 @@ template <class T, class Container>
 
 \rSec3[queue.special]{\tcode{queue} specialized algorithms}
 
-\indexlibrary{\idxcode{swap}!\idxcode{queue}}%
-\indexlibrary{\idxcode{queue}!\idxcode{swap}}%
+\indexlibrarymember{swap}{queue}%
 \begin{itemdecl}
 template <class T, class Container>
   void swap(queue<T, Container>& x, queue<T, Container>& y) noexcept(noexcept(x.swap(y)));
@@ -9372,8 +9303,7 @@ push_heap(c.begin(), c.end(), comp);
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{emplace}!\idxcode{priority_queue}}%
-\indexlibrary{\idxcode{priority_queue}!\idxcode{emplace}}%
+\indexlibrarymember{emplace}{priority_queue}%
 \begin{itemdecl}
 template <class... Args> void emplace(Args&&... args)
 \end{itemdecl}
@@ -9406,8 +9336,7 @@ c.pop_back();
 
 \rSec3[priqueue.special]{\tcode{priority_queue} specialized algorithms}
 
-\indexlibrary{\idxcode{swap}!\idxcode{priority_queue}}%
-\indexlibrary{\idxcode{priority_queue}!\idxcode{swap}}%
+\indexlibrarymember{swap}{priority_queue}%
 \begin{itemdecl}
 template <class T, class Container, class Compare>
   void swap(priority_queue<T, Container, Compare>& x,
@@ -9660,8 +9589,7 @@ template <class T, class Container>
 
 \rSec3[stack.special]{\tcode{stack} specialized algorithms}
 
-\indexlibrary{\idxcode{swap}!\idxcode{stack}}%
-\indexlibrary{\idxcode{stack}!\idxcode{swap}}%
+\indexlibrarymember{swap}{stack}%
 \begin{itemdecl}
 template <class T, class Container>
   void swap(stack<T, Container>& x, stack<T, Container>& y) noexcept(noexcept(x.swap(y)));

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -971,8 +971,7 @@ virtual ~error_category();
 \effects Destroys an object of class \tcode{error_category}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{name}!\idxcode{error_category}}%
-\indexlibrary{\idxcode{error_category}!\idxcode{name}}%
+\indexlibrarymember{name}{error_category}%
 \begin{itemdecl}
 virtual const char* name() const noexcept = 0;
 \end{itemdecl}
@@ -982,8 +981,7 @@ virtual const char* name() const noexcept = 0;
 \returns A string naming the error category.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{default_error_condition}!\idxcode{error_category}}%
-\indexlibrary{\idxcode{error_category}!\idxcode{default_error_condition}}%
+\indexlibrarymember{default_error_condition}{error_category}%
 \begin{itemdecl}
 virtual error_condition default_error_condition(int ev) const noexcept;
 \end{itemdecl}
@@ -994,8 +992,7 @@ virtual error_condition default_error_condition(int ev) const noexcept;
 \tcode{error_condition(ev, *this)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{equivalent}!\idxcode{error_category}}%
-\indexlibrary{\idxcode{error_category}!\idxcode{equivalent}}%
+\indexlibrarymember{equivalent}{error_category}%
 \begin{itemdecl}
 virtual bool equivalent(int code, const error_condition& condition) const noexcept;
 \end{itemdecl}
@@ -1005,8 +1002,7 @@ virtual bool equivalent(int code, const error_condition& condition) const noexce
 \returns \tcode{default_error_condition(code) == condition}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{equivalent}!\idxcode{error_category}}%
-\indexlibrary{\idxcode{error_category}!\idxcode{equivalent}}%
+\indexlibrarymember{equivalent}{error_category}%
 \begin{itemdecl}
 virtual bool equivalent(const error_code& code, int condition) const noexcept;
 \end{itemdecl}
@@ -1016,8 +1012,7 @@ virtual bool equivalent(const error_code& code, int condition) const noexcept;
 \returns \tcode{*this == code.category() \&\& code.value() == condition}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{message}!\idxcode{error_category}}%
-\indexlibrary{\idxcode{error_category}!\idxcode{message}}%
+\indexlibrarymember{message}{error_category}%
 \begin{itemdecl}
 virtual string message(int ev) const = 0;
 \end{itemdecl}
@@ -1039,8 +1034,7 @@ constexpr error_category() noexcept;
 \effects Constructs an object of class \tcode{error_category}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{error_category}}%
-\indexlibrary{\idxcode{error_category}!\idxcode{operator==}}%
+\indexlibrarymember{operator==}{error_category}%
 \begin{itemdecl}
 bool operator==(const error_category& rhs) const noexcept;
 \end{itemdecl}
@@ -1061,8 +1055,7 @@ bool operator!=(const error_category& rhs) const noexcept;
 \returns \tcode{!(*this == rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{error_category}}%
-\indexlibrary{\idxcode{error_category}!\idxcode{operator<}}%
+\indexlibrarymember{operator<}{error_category}%
 \begin{itemdecl}
 bool operator<(const error_category& rhs) const noexcept;
 \end{itemdecl}
@@ -1076,8 +1069,7 @@ bool operator<(const error_category& rhs) const noexcept;
 
 \rSec3[syserr.errcat.derived]{Program defined classes derived from \tcode{error_category}}
 
-\indexlibrary{\idxcode{name}!\idxcode{error_category}}%
-\indexlibrary{\idxcode{error_category}!\idxcode{name}}%
+\indexlibrarymember{name}{error_category}%
 \begin{itemdecl}
 virtual const char* name() const noexcept = 0;
 \end{itemdecl}
@@ -1087,8 +1079,7 @@ virtual const char* name() const noexcept = 0;
 \returns A string naming the error category.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{default_error_condition}!\idxcode{error_category}}%
-\indexlibrary{\idxcode{error_category}!\idxcode{default_error_condition}}%
+\indexlibrarymember{default_error_condition}{error_category}%
 \begin{itemdecl}
 virtual error_condition default_error_condition(int ev) const noexcept;
 \end{itemdecl}
@@ -1098,8 +1089,7 @@ virtual error_condition default_error_condition(int ev) const noexcept;
 \returns An object of type \tcode{error_condition} that corresponds to \tcode{ev}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{equivalent}!\idxcode{error_category}}%
-\indexlibrary{\idxcode{error_category}!\idxcode{equivalent}}%
+\indexlibrarymember{equivalent}{error_category}%
 \begin{itemdecl}
 virtual bool equivalent(int code, const error_condition& condition) const noexcept;
 \end{itemdecl}
@@ -1109,8 +1099,7 @@ virtual bool equivalent(int code, const error_condition& condition) const noexce
 \returns \tcode{true} if, for the category of error represented by \tcode{*this}, \tcode{code} is considered equivalent to \tcode{condition}; otherwise, \tcode{false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{equivalent}!\idxcode{error_category}}%
-\indexlibrary{\idxcode{error_category}!\idxcode{equivalent}}%
+\indexlibrarymember{equivalent}{error_category}%
 \begin{itemdecl}
 virtual bool equivalent(const error_code& code, int condition) const noexcept;
 \end{itemdecl}
@@ -1258,8 +1247,7 @@ template <class ErrorCodeEnum>
 
 \rSec3[syserr.errcode.modifiers]{Class \tcode{error_code} modifiers}
 
-\indexlibrary{\idxcode{assign}!\idxcode{error_code}}%
-\indexlibrary{\idxcode{error_code}!\idxcode{assign}}%
+\indexlibrarymember{assign}{error_code}%
 \begin{itemdecl}
 void assign(int val, const error_category& cat) noexcept;
 \end{itemdecl}
@@ -1269,8 +1257,7 @@ void assign(int val, const error_category& cat) noexcept;
 \postconditions \tcode{val_ == val} and \tcode{cat_ == \&cat}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{error_code}}%
-\indexlibrary{\idxcode{error_code}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{error_code}%
 \begin{itemdecl}
 template <class ErrorCodeEnum>
     error_code& operator=(ErrorCodeEnum e) noexcept;
@@ -1288,8 +1275,7 @@ template <class ErrorCodeEnum>
 \tcode{is_error_code_enum_v<ErrorCodeEnum>} is \tcode{true}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{clear}!\idxcode{error_code}}%
-\indexlibrary{\idxcode{error_code}!\idxcode{clear}}%
+\indexlibrarymember{clear}{error_code}%
 \begin{itemdecl}
 void clear() noexcept;
 \end{itemdecl}
@@ -1302,8 +1288,7 @@ void clear() noexcept;
 
 \rSec3[syserr.errcode.observers]{Class \tcode{error_code} observers}
 
-\indexlibrary{\idxcode{value}!\idxcode{error_code}}%
-\indexlibrary{\idxcode{error_code}!\idxcode{value}}%
+\indexlibrarymember{value}{error_code}%
 \begin{itemdecl}
 int value() const noexcept;
 \end{itemdecl}
@@ -1313,8 +1298,7 @@ int value() const noexcept;
 \returns \tcode{val_}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{category}!\idxcode{error_code}}%
-\indexlibrary{\idxcode{error_code}!\idxcode{category}}%
+\indexlibrarymember{category}{error_code}%
 \begin{itemdecl}
 const error_category& category() const noexcept;
 \end{itemdecl}
@@ -1324,8 +1308,7 @@ const error_category& category() const noexcept;
 \returns \tcode{*cat_}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{default_error_condition}!\idxcode{error_code}}%
-\indexlibrary{\idxcode{error_code}!\idxcode{default_error_condition}}%
+\indexlibrarymember{default_error_condition}{error_code}%
 \begin{itemdecl}
 error_condition default_error_condition() const noexcept;
 \end{itemdecl}
@@ -1335,8 +1318,7 @@ error_condition default_error_condition() const noexcept;
 \returns \tcode{category().default_error_condition(value())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{message}!\idxcode{error_code}}%
-\indexlibrary{\idxcode{error_code}!\idxcode{message}}%
+\indexlibrarymember{message}{error_code}%
 \begin{itemdecl}
 string message() const;
 \end{itemdecl}
@@ -1346,8 +1328,7 @@ string message() const;
 \returns \tcode{category().message(value())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator bool}!\idxcode{error_code}}%
-\indexlibrary{\idxcode{error_code}!\idxcode{operator bool}}%
+\indexlibrarymember{operator bool}{error_code}%
 \begin{itemdecl}
 explicit operator bool() const noexcept;
 \end{itemdecl}
@@ -1369,8 +1350,7 @@ error_code make_error_code(errc e) noexcept;
 \returns \tcode{error_code(static_cast<int>(e), generic_category())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{error_code}}%
-\indexlibrary{\idxcode{error_code}!\idxcode{operator<}}%
+\indexlibrarymember{operator<}{error_code}%
 \begin{itemdecl}
 bool operator<(const error_code& lhs, const error_code& rhs) noexcept;
 \end{itemdecl}
@@ -1384,8 +1364,7 @@ lhs.category() < rhs.category() ||
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shl}!\idxcode{error_code}}%
-\indexlibrary{\idxcode{error_code}!\idxcode{operator\shl}}%
+\indexlibrarymember{operator\shl}{error_code}%
 \begin{itemdecl}
 template <class charT, class traits>
   basic_ostream<charT, traits>&
@@ -1490,8 +1469,7 @@ template <class ErrorConditionEnum>
 
 \rSec3[syserr.errcondition.modifiers]{Class \tcode{error_condition} modifiers}
 
-\indexlibrary{\idxcode{assign}!\idxcode{error_condition}}%
-\indexlibrary{\idxcode{error_condition}!\idxcode{assign}}%
+\indexlibrarymember{assign}{error_condition}%
 \begin{itemdecl}
 void assign(int val, const error_category& cat) noexcept;
 \end{itemdecl}
@@ -1501,8 +1479,7 @@ void assign(int val, const error_category& cat) noexcept;
 \postconditions \tcode{val_ == val} and \tcode{cat_ == \&cat}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{error_condition}}%
-\indexlibrary{\idxcode{error_condition}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{error_condition}%
 \begin{itemdecl}
 template <class ErrorConditionEnum>
     error_condition& operator=(ErrorConditionEnum e) noexcept;
@@ -1520,8 +1497,7 @@ template <class ErrorConditionEnum>
 \tcode{is_error_condition_enum_v<ErrorConditionEnum>} is \tcode{true}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{clear}!\idxcode{error_condition}}%
-\indexlibrary{\idxcode{error_condition}!\idxcode{clear}}%
+\indexlibrarymember{clear}{error_condition}%
 \begin{itemdecl}
 void clear() noexcept;
 \end{itemdecl}
@@ -1532,8 +1508,7 @@ void clear() noexcept;
 
 \rSec3[syserr.errcondition.observers]{Class \tcode{error_condition} observers}
 
-\indexlibrary{\idxcode{value}!\idxcode{error_condition}}%
-\indexlibrary{\idxcode{error_condition}!\idxcode{value}}%
+\indexlibrarymember{value}{error_condition}%
 \begin{itemdecl}
 int value() const noexcept;
 \end{itemdecl}
@@ -1543,8 +1518,7 @@ int value() const noexcept;
 \returns \tcode{val_}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{category}!\idxcode{error_condition}}%
-\indexlibrary{\idxcode{error_condition}!\idxcode{category}}%
+\indexlibrarymember{category}{error_condition}%
 \begin{itemdecl}
 const error_category& category() const noexcept;
 \end{itemdecl}
@@ -1554,8 +1528,7 @@ const error_category& category() const noexcept;
 \returns \tcode{*cat_}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{message}!\idxcode{error_condition}}%
-\indexlibrary{\idxcode{error_condition}!\idxcode{message}}%
+\indexlibrarymember{message}{error_condition}%
 \begin{itemdecl}
 string message() const;
 \end{itemdecl}
@@ -1565,8 +1538,7 @@ string message() const;
 \returns \tcode{category().message(value())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator bool}!\idxcode{error_condition}}%
-\indexlibrary{\idxcode{error_condition}!\idxcode{operator bool}}%
+\indexlibrarymember{operator bool}{error_condition}%
 \begin{itemdecl}
 explicit operator bool() const noexcept;
 \end{itemdecl}
@@ -1587,8 +1559,7 @@ error_condition make_error_condition(errc e) noexcept;
 \returns \tcode{error_condition(static_cast<int>(e), generic_category())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{error_condition}}%
-\indexlibrary{\idxcode{error_condition}!\idxcode{operator<}}%
+\indexlibrarymember{operator<}{error_condition}%
 \begin{itemdecl}
 bool operator<(const error_condition& lhs, const error_condition& rhs) noexcept;
 \end{itemdecl}
@@ -1601,8 +1572,7 @@ lhs.value() < rhs.value()}.
 
 \rSec2[syserr.compare]{Comparison operators}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{error_code}}%
-\indexlibrary{\idxcode{error_code}!\idxcode{operator==}}%
+\indexlibrarymember{operator==}{error_code}%
 \begin{itemdecl}
 bool operator==(const error_code& lhs, const error_code& rhs) noexcept;
 \end{itemdecl}
@@ -1612,10 +1582,8 @@ bool operator==(const error_code& lhs, const error_code& rhs) noexcept;
 \returns \tcode{lhs.category() == rhs.category() \&\& lhs.value() == rhs.value()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{error_condition}}%
-\indexlibrary{\idxcode{error_condition}!\idxcode{operator==}}%
-\indexlibrary{\idxcode{operator==}!\idxcode{error_code}}%
-\indexlibrary{\idxcode{error_code}!\idxcode{operator==}}%
+\indexlibrarymember{operator==}{error_condition}%
+\indexlibrarymember{operator==}{error_code}%
 \begin{itemdecl}
 bool operator==(const error_code& lhs, const error_condition& rhs) noexcept;
 \end{itemdecl}
@@ -1626,10 +1594,8 @@ bool operator==(const error_code& lhs, const error_condition& rhs) noexcept;
 rhs.value())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{error_condition}}%
-\indexlibrary{\idxcode{error_condition}!\idxcode{operator==}}%
-\indexlibrary{\idxcode{operator==}!\idxcode{error_code}}%
-\indexlibrary{\idxcode{error_code}!\idxcode{operator==}}%
+\indexlibrarymember{operator==}{error_condition}%
+\indexlibrarymember{operator==}{error_code}%
 \begin{itemdecl}
 bool operator==(const error_condition& lhs, const error_code& rhs) noexcept;
 \end{itemdecl}
@@ -1639,8 +1605,7 @@ bool operator==(const error_condition& lhs, const error_code& rhs) noexcept;
 \returns \tcode{rhs.category().equivalent(rhs.value(), lhs) || lhs.category().equivalent(rhs, lhs.value())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{error_condition}}%
-\indexlibrary{\idxcode{error_condition}!\idxcode{operator==}}%
+\indexlibrarymember{operator==}{error_condition}%
 \begin{itemdecl}
 bool operator==(const error_condition& lhs, const error_condition& rhs) noexcept;
 \end{itemdecl}
@@ -1802,8 +1767,7 @@ system_error(int ev, const error_category& ecat);
 \postconditions \tcode{code() == error_code(ev, ecat)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{code}!\idxcode{system_error}}%
-\indexlibrary{\idxcode{system_error}!\idxcode{code}}%
+\indexlibrarymember{code}{system_error}%
 \begin{itemdecl}
 const error_code& code() const noexcept;
 \end{itemdecl}
@@ -1814,8 +1778,7 @@ const error_code& code() const noexcept;
 as appropriate.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{what}!\idxcode{system_error}}%
-\indexlibrary{\idxcode{system_error}!\idxcode{what}}%
+\indexlibrarymember{what}{system_error}%
 \begin{itemdecl}
 const char* what() const noexcept;
 \end{itemdecl}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -935,8 +935,7 @@ Constructs an object of class
 
 \rSec4[ios::fmtflags]{Type \tcode{ios_base::fmtflags}}
 
-\indexlibrary{\idxcode{fmtflags}!\idxcode{ios_base}}%
-\indexlibrary{\idxcode{ios_base}!\idxcode{fmtflags}}%
+\indexlibrarymember{fmtflags}{ios_base}%
 \begin{itemdecl}
 using fmtflags = @\textit{T1}@;
 \end{itemdecl}
@@ -999,8 +998,7 @@ also defines the constants indicated in Table~\ref{tab:iostreams.fmtflags.consta
 
 \rSec4[ios::iostate]{Type \tcode{ios_base::iostate}}
 
-\indexlibrary{\idxcode{ios_base}!\idxcode{iostate}}%
-\indexlibrary{\idxcode{iostate}!\idxcode{ios_base}}%
+\indexlibrarymember{ios_base}{iostate}%
 \begin{itemdecl}
 using iostate = @\textit{T2}@;
 \end{itemdecl}
@@ -1036,8 +1034,7 @@ the value zero.
 
 \rSec4[ios::openmode]{Type \tcode{ios_base::openmode}}
 
-\indexlibrary{\idxcode{openmode}!\idxcode{ios_base}}%
-\indexlibrary{\idxcode{ios_base}!\idxcode{openmode}}%
+\indexlibrarymember{openmode}{ios_base}%
 \begin{itemdecl}
 using openmode = @\textit{T3}@;
 \end{itemdecl}
@@ -1067,8 +1064,7 @@ It contains the elements indicated in Table~\ref{tab:iostreams.openmode.effects}
 
 \rSec4[ios::seekdir]{Type \tcode{ios_base::seekdir}}
 
-\indexlibrary{\idxcode{seekdir}!\idxcode{ios_base}}%
-\indexlibrary{\idxcode{ios_base}!\idxcode{seekdir}}%
+\indexlibrarymember{seekdir}{ios_base}%
 \begin{itemdecl}
 using seekdir = @\textit{T4}@;
 \end{itemdecl}
@@ -1165,8 +1161,7 @@ calls
 
 \rSec3[fmtflags.state]{\tcode{ios_base} state functions}
 
-\indexlibrary{\idxcode{flags}!\idxcode{ios_base}}%
-\indexlibrary{\idxcode{ios_base}!\idxcode{flags}}%
+\indexlibrarymember{flags}{ios_base}%
 \begin{itemdecl}
 fmtflags flags() const;
 \end{itemdecl}
@@ -1177,8 +1172,7 @@ fmtflags flags() const;
 The format control information for both input and output.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{ios_base}!\idxcode{flags}}%
-\indexlibrary{\idxcode{flags}!\idxcode{ios_base}}%
+\indexlibrarymember{ios_base}{flags}%
 \begin{itemdecl}
 fmtflags flags(fmtflags fmtfl);
 \end{itemdecl}
@@ -1194,8 +1188,7 @@ The previous value of
 \tcode{flags()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{setf}!\idxcode{ios_base}}%
-\indexlibrary{\idxcode{ios_base}!\idxcode{setf}}%
+\indexlibrarymember{setf}{ios_base}%
 \begin{itemdecl}
 fmtflags setf(fmtflags fmtfl);
 \end{itemdecl}
@@ -1212,8 +1205,7 @@ The previous value of
 \tcode{flags()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{setf}!\idxcode{ios_base}}%
-\indexlibrary{\idxcode{ios_base}!\idxcode{setf}}%
+\indexlibrarymember{setf}{ios_base}%
 \begin{itemdecl}
 fmtflags setf(fmtflags fmtfl, fmtflags mask);
 \end{itemdecl}
@@ -1234,8 +1226,7 @@ The previous value of
 \tcode{flags()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{unsetf}!\idxcode{ios_base}}%
-\indexlibrary{\idxcode{ios_base}!\idxcode{unsetf}}%
+\indexlibrarymember{unsetf}{ios_base}%
 \begin{itemdecl}
 void unsetf(fmtflags mask);
 \end{itemdecl}
@@ -1247,8 +1238,7 @@ Clears \tcode{mask} in
 \tcode{flags()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{precision}!\idxcode{ios_base}}%
-\indexlibrary{\idxcode{ios_base}!\idxcode{precision}}%
+\indexlibrarymember{precision}{ios_base}%
 \begin{itemdecl}
 streamsize precision() const;
 \end{itemdecl}
@@ -1260,8 +1250,7 @@ The precision
 to generate on certain output conversions.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{precision}!\idxcode{ios_base}}%
-\indexlibrary{\idxcode{ios_base}!\idxcode{precision}}%
+\indexlibrarymember{precision}{ios_base}%
 \begin{itemdecl}
 streamsize precision(streamsize prec);
 \end{itemdecl}
@@ -1277,8 +1266,7 @@ The previous value of
 \tcode{precision()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{width}!\idxcode{ios_base}}%
-\indexlibrary{\idxcode{ios_base}!\idxcode{width}}%
+\indexlibrarymember{width}{ios_base}%
 \begin{itemdecl}
 streamsize width() const;
 \end{itemdecl}
@@ -1290,8 +1278,7 @@ The minimum field width (number of characters) to generate on certain output
 conversions.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{width}!\idxcode{ios_base}}%
-\indexlibrary{\idxcode{ios_base}!\idxcode{width}}%
+\indexlibrarymember{width}{ios_base}%
 \begin{itemdecl}
 streamsize width(streamsize wide);
 \end{itemdecl}
@@ -1309,8 +1296,7 @@ The previous value of
 
 \rSec3[ios.base.locales]{\tcode{ios_base} functions}
 
-\indexlibrary{\idxcode{imbue}!\idxcode{ios_base}}%
-\indexlibrary{\idxcode{ios_base}!\idxcode{imbue}}%
+\indexlibrarymember{imbue}{ios_base}%
 \begin{itemdecl}
 locale imbue(const locale& loc);
 \end{itemdecl}
@@ -1339,8 +1325,7 @@ The previous value of
 \tcode{loc == getloc()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{getloc}!\idxcode{ios_base}}%
-\indexlibrary{\idxcode{ios_base}!\idxcode{getloc}}%
+\indexlibrarymember{getloc}{ios_base}%
 \begin{itemdecl}
 locale getloc() const;
 \end{itemdecl}
@@ -1357,8 +1342,7 @@ perform locale-dependent input and output operations.
 
 \rSec3[ios.members.static]{\tcode{ios_base} static members}
 
-\indexlibrary{\idxcode{sync_with_stdio}!\idxcode{ios_base}}%
-\indexlibrary{\idxcode{ios_base}!\idxcode{sync_with_stdio}}%
+\indexlibrarymember{sync_with_stdio}{ios_base}%
 \begin{itemdecl}
 bool sync_with_stdio(bool sync = true);
 \end{itemdecl}
@@ -1420,8 +1404,7 @@ buffer.
 
 \rSec3[ios.base.storage]{\tcode{ios_base} storage functions}
 
-\indexlibrary{\idxcode{xalloc}!\idxcode{ios_base}}%
-\indexlibrary{\idxcode{ios_base}!\idxcode{xalloc}}%
+\indexlibrarymember{xalloc}{ios_base}%
 \begin{itemdecl}
 static int xalloc();
 \end{itemdecl}
@@ -1438,8 +1421,7 @@ Concurrent access to this function by multiple threads shall not result in a dat
 race~(\ref{intro.multithread}).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{iword}!\idxcode{ios_base}}%
-\indexlibrary{\idxcode{ios_base}!\idxcode{iword}}%
+\indexlibrarymember{iword}{ios_base}%
 \begin{itemdecl}
 long& iword(int idx);
 \end{itemdecl}
@@ -1485,8 +1467,7 @@ On failure, a valid
 initialized to 0.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pword}!\idxcode{ios_base}}%
-\indexlibrary{\idxcode{ios_base}!\idxcode{pword}}%
+\indexlibrarymember{pword}{ios_base}%
 \begin{itemdecl}
 void*& pword(int idx);
 \end{itemdecl}
@@ -1538,8 +1519,7 @@ for the same object, the earlier return value may no longer be valid.
 
 \rSec3[ios.base.callback]{\tcode{ios_base} callbacks}
 
-\indexlibrary{\idxcode{register_callback}!\idxcode{ios_base}}%
-\indexlibrary{\idxcode{ios_base}!\idxcode{register_callback}}%
+\indexlibrarymember{register_callback}{ios_base}%
 \begin{itemdecl}
 void register_callback(event_callback fn, int index);
 \end{itemdecl}
@@ -1631,8 +1611,7 @@ namespace std {
 
 \rSec3[fpos.members]{\tcode{fpos} members}
 
-\indexlibrary{\idxcode{state}!\idxcode{fpos}}%
-\indexlibrary{\idxcode{fpos}!\idxcode{state}}%
+\indexlibrarymember{state}{fpos}%
 \begin{itemdecl}
 void state(stateT s);
 \end{itemdecl}
@@ -1643,8 +1622,7 @@ void state(stateT s);
 Assigns \tcode{s} to \tcode{st}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{state}!\idxcode{fpos}}%
-\indexlibrary{\idxcode{fpos}!\idxcode{state}}%
+\indexlibrarymember{state}{fpos}%
 \begin{itemdecl}
 stateT state() const;
 \end{itemdecl}
@@ -1869,8 +1847,7 @@ The destructor does not destroy
 \tcode{rdbuf()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{init}!\idxcode{basic_ios}}%
-\indexlibrary{\idxcode{basic_ios}!\idxcode{init}}%
+\indexlibrarymember{init}{basic_ios}%
 \begin{itemdecl}
 void init(basic_streambuf<charT, traits>* sb);
 \end{itemdecl}
@@ -1907,8 +1884,7 @@ The postconditions of this function are indicated in Table~\ref{tab:iostreams.ba
 
 \rSec3[basic.ios.members]{Member functions}
 
-\indexlibrary{\idxcode{tie}!\idxcode{basic_ios}}%
-\indexlibrary{\idxcode{basic_ios}!\idxcode{tie}}%
+\indexlibrarymember{tie}{basic_ios}%
 \begin{itemdecl}
 basic_ostream<charT, traits>* tie() const;
 \end{itemdecl}
@@ -1921,8 +1897,7 @@ An output sequence that is
 to (synchronized with) the sequence controlled by the stream buffer.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{tie}!\idxcode{basic_ios}}%
-\indexlibrary{\idxcode{basic_ios}!\idxcode{tie}}%
+\indexlibrarymember{tie}{basic_ios}%
 \begin{itemdecl}
 basic_ostream<charT, traits>* tie(basic_ostream<charT, traits>* tiestr);
 \end{itemdecl}
@@ -1944,8 +1919,7 @@ The previous value of
 \tcode{tie()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{rdbuf}!\idxcode{basic_ios}}%
-\indexlibrary{\idxcode{basic_ios}!\idxcode{rdbuf}}%
+\indexlibrarymember{rdbuf}{basic_ios}%
 \begin{itemdecl}
 basic_streambuf<charT, traits>* rdbuf() const;
 \end{itemdecl}
@@ -1958,8 +1932,7 @@ A pointer to the
 associated with the stream.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{rdbuf}!\idxcode{basic_ios}}%
-\indexlibrary{\idxcode{basic_ios}!\idxcode{rdbuf}}%
+\indexlibrarymember{rdbuf}{basic_ios}%
 \begin{itemdecl}
 basic_streambuf<charT, traits>* rdbuf(basic_streambuf<charT, traits>* sb);
 \end{itemdecl}
@@ -1980,8 +1953,7 @@ The previous value of
 \tcode{rdbuf()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{imbue}!\idxcode{basic_ios}}%
-\indexlibrary{\idxcode{basic_ios}!\idxcode{imbue}}%
+\indexlibrarymember{imbue}{basic_ios}%
 \begin{itemdecl}
 locale imbue(const locale& loc);
 \end{itemdecl}
@@ -2003,8 +1975,7 @@ The prior value of
 \tcode{ios_base::imbue()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{narrow}!\idxcode{basic_ios}}%
-\indexlibrary{\idxcode{basic_ios}!\idxcode{narrow}}%
+\indexlibrarymember{narrow}{basic_ios}%
 \begin{itemdecl}
 char narrow(char_type c, char dfault) const;
 \end{itemdecl}
@@ -2015,8 +1986,7 @@ char narrow(char_type c, char dfault) const;
 \tcode{use_facet< ctype<char_type> >(getloc()).narrow(c, dfault)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{widen}!\idxcode{basic_ios}}%
-\indexlibrary{\idxcode{basic_ios}!\idxcode{widen}}%
+\indexlibrarymember{widen}{basic_ios}%
 \begin{itemdecl}
 char_type widen(char c) const;
 \end{itemdecl}
@@ -2027,8 +1997,7 @@ char_type widen(char c) const;
 \tcode{use_facet< ctype<char_type> >(getloc()).widen(c)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{fill}!\idxcode{basic_ios}}%
-\indexlibrary{\idxcode{basic_ios}!\idxcode{fill}}%
+\indexlibrarymember{fill}{basic_ios}%
 \begin{itemdecl}
 char_type fill() const;
 \end{itemdecl}
@@ -2040,8 +2009,7 @@ The character used to pad (fill) an output conversion to the specified
 field width.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{fill}!\idxcode{basic_ios}}%
-\indexlibrary{\idxcode{basic_ios}!\idxcode{fill}}%
+\indexlibrarymember{fill}{basic_ios}%
 \begin{itemdecl}
 char_type fill(char_type fillch);
 \end{itemdecl}
@@ -2057,8 +2025,7 @@ The previous value of
 \tcode{fill()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{copyfmt}!\idxcode{basic_ios}}%
-\indexlibrary{\idxcode{basic_ios}!\idxcode{copyfmt}}%
+\indexlibrarymember{copyfmt}{basic_ios}%
 \begin{itemdecl}
 basic_ios& copyfmt(const basic_ios& rhs);
 \end{itemdecl}
@@ -2138,8 +2105,7 @@ The postconditions of this function are indicated in Table~\ref{tab:iostreams.co
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{move}!\idxcode{basic_ios}}%
-\indexlibrary{\idxcode{basic_ios}!\idxcode{move}}%
+\indexlibrarymember{move}{basic_ios}%
 \begin{itemdecl}
 void move(basic_ios& rhs);
 void move(basic_ios&& rhs);
@@ -2155,8 +2121,7 @@ same value as it returned before the function call, and
 \tcode{rhs.tie()} shall return 0.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{swap}!\idxcode{basic_ios}}%
-\indexlibrary{\idxcode{basic_ios}!\idxcode{swap}}%
+\indexlibrarymember{swap}{basic_ios}%
 \begin{itemdecl}
 void swap(basic_ios& rhs) noexcept;
 \end{itemdecl}
@@ -2169,8 +2134,7 @@ value as it returned before the function call, and \tcode{rhs.rdbuf()}
 shall return the same value as it returned before the function call.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{set_rdbuf}!\idxcode{basic_ios}}%
-\indexlibrary{\idxcode{basic_ios}!\idxcode{set_rdbuf}}%
+\indexlibrarymember{set_rdbuf}{basic_ios}%
 \begin{itemdecl}
 void set_rdbuf(basic_streambuf<charT, traits>* sb);
 \end{itemdecl}
@@ -2193,8 +2157,7 @@ pointed to by \tcode{sb} with this stream without calling
 
 \rSec3[iostate.flags]{\tcode{basic_ios} flags functions}
 
-\indexlibrary{\idxcode{operator bool}!\idxcode{basic_ios}}%
-\indexlibrary{\idxcode{basic_ios}!\idxcode{operator bool}}%
+\indexlibrarymember{operator bool}{basic_ios}%
 \begin{itemdecl}
 explicit operator bool() const;
 \end{itemdecl}
@@ -2216,8 +2179,7 @@ bool operator!() const;
 \tcode{fail()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{rdstate}!\idxcode{basic_ios}}%
-\indexlibrary{\idxcode{basic_ios}!\idxcode{rdstate}}%
+\indexlibrarymember{rdstate}{basic_ios}%
 \begin{itemdecl}
 iostate rdstate() const;
 \end{itemdecl}
@@ -2228,8 +2190,7 @@ iostate rdstate() const;
 The error state of the stream buffer.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{clear}!\idxcode{basic_ios}}%
-\indexlibrary{\idxcode{basic_ios}!\idxcode{clear}}%
+\indexlibrarymember{clear}{basic_ios}%
 \begin{itemdecl}
 void clear(iostate state = goodbit);
 \end{itemdecl}
@@ -2256,8 +2217,7 @@ constructed with
 argument values.%
 \end{itemdescr}
 
-\indexlibrary{\idxcode{setstate}!\idxcode{basic_ios}}%
-\indexlibrary{\idxcode{basic_ios}!\idxcode{setstate}}%
+\indexlibrarymember{setstate}{basic_ios}%
 \begin{itemdecl}
 void setstate(iostate state);
 \end{itemdecl}
@@ -2271,8 +2231,7 @@ Calls
 \tcode{basic_ios::failure}~(\ref{ios::failure})).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{good}!\idxcode{basic_ios}}%
-\indexlibrary{\idxcode{basic_ios}!\idxcode{good}}%
+\indexlibrarymember{good}{basic_ios}%
 \begin{itemdecl}
 bool good() const;
 \end{itemdecl}
@@ -2283,8 +2242,7 @@ bool good() const;
 \tcode{rdstate() == 0}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{eof}!\idxcode{basic_ios}}%
-\indexlibrary{\idxcode{basic_ios}!\idxcode{eof}}%
+\indexlibrarymember{eof}{basic_ios}%
 \begin{itemdecl}
 bool eof() const;
 \end{itemdecl}
@@ -2299,8 +2257,7 @@ is set in
 \tcode{rdstate()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{fail}!\idxcode{basic_ios}}%
-\indexlibrary{\idxcode{basic_ios}!\idxcode{fail}}%
+\indexlibrarymember{fail}{basic_ios}%
 \begin{itemdecl}
 bool fail() const;
 \end{itemdecl}
@@ -2321,8 +2278,7 @@ also for
 is historical practice.}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{bad}!\idxcode{basic_ios}}%
-\indexlibrary{\idxcode{basic_ios}!\idxcode{bad}}%
+\indexlibrarymember{bad}{basic_ios}%
 \begin{itemdecl}
 bool bad() const;
 \end{itemdecl}
@@ -2337,8 +2293,7 @@ is set in
 \tcode{rdstate()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{exceptions}!\idxcode{basic_ios}}%
-\indexlibrary{\idxcode{basic_ios}!\idxcode{exceptions}}%
+\indexlibrarymember{exceptions}{basic_ios}%
 \begin{itemdecl}
 iostate exceptions() const;
 \end{itemdecl}
@@ -2351,8 +2306,7 @@ A mask that determines what elements set in
 cause exceptions to be thrown.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{exceptions}!\idxcode{basic_ios}}%
-\indexlibrary{\idxcode{basic_ios}!\idxcode{exceptions}}%
+\indexlibrarymember{exceptions}{basic_ios}%
 \begin{itemdecl}
 void exceptions(iostate except);
 \end{itemdecl}
@@ -3124,8 +3078,7 @@ None.
 
 \rSec4[streambuf.locales]{Locales}
 
-\indexlibrary{\idxcode{pubimbue}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{pubimbue}}%
+\indexlibrarymember{pubimbue}{basic_streambuf}%
 \begin{itemdecl}
 locale pubimbue(const locale& loc);
 \end{itemdecl}
@@ -3146,8 +3099,7 @@ Previous value of
 \tcode{getloc()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{getloc}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{getloc}}%
+\indexlibrarymember{getloc}{basic_streambuf}%
 \begin{itemdecl}
 locale getloc() const;
 \end{itemdecl}
@@ -3172,8 +3124,7 @@ then it returns the previous value.
 
 \rSec4[streambuf.buffer]{Buffer management and positioning}
 
-\indexlibrary{\idxcode{pubsetbuf}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{pubsetbuf}}%
+\indexlibrarymember{pubsetbuf}{basic_streambuf}%
 \begin{itemdecl}
 basic_streambuf* pubsetbuf(char_type* s, streamsize n);
 \end{itemdecl}
@@ -3184,8 +3135,7 @@ basic_streambuf* pubsetbuf(char_type* s, streamsize n);
 \tcode{setbuf(s, n)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pubseekoff}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{pubseekoff}}%
+\indexlibrarymember{pubseekoff}{basic_streambuf}%
 \begin{itemdecl}
 pos_type pubseekoff(off_type off, ios_base::seekdir way,
                     ios_base::openmode which
@@ -3198,8 +3148,7 @@ pos_type pubseekoff(off_type off, ios_base::seekdir way,
 \tcode{seekoff(off, way, which)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pubseekpos}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{pubseekpos}}%
+\indexlibrarymember{pubseekpos}{basic_streambuf}%
 \begin{itemdecl}
 pos_type pubseekpos(pos_type sp,
                     ios_base::openmode which
@@ -3212,8 +3161,7 @@ pos_type pubseekpos(pos_type sp,
 \tcode{seekpos(sp, which)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pubsync}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{pubsync}}%
+\indexlibrarymember{pubsync}{basic_streambuf}%
 \begin{itemdecl}
 int pubsync();
 \end{itemdecl}
@@ -3226,8 +3174,7 @@ int pubsync();
 
 \rSec4[streambuf.pub.get]{Get area}
 
-\indexlibrary{\idxcode{in_avail}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{in_avail}}%
+\indexlibrarymember{in_avail}{basic_streambuf}%
 \begin{itemdecl}
 streamsize in_avail();
 \end{itemdecl}
@@ -3241,8 +3188,7 @@ Otherwise returns
 \tcode{showmanyc()} (\ref{streambuf.virt.get}).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{snextc}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{snextc}}%
+\indexlibrarymember{snextc}{basic_streambuf}%
 \begin{itemdecl}
 int_type snextc();
 \end{itemdecl}
@@ -3263,8 +3209,7 @@ Otherwise, returns
 \tcode{sgetc()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sbumpc}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{sbumpc}}%
+\indexlibrarymember{sbumpc}{basic_streambuf}%
 \begin{itemdecl}
 int_type sbumpc();
 \end{itemdecl}
@@ -3280,8 +3225,7 @@ Otherwise, returns
 and increments the next pointer for the input sequence.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sgetc}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{sgetc}}%
+\indexlibrarymember{sgetc}{basic_streambuf}%
 \begin{itemdecl}
 int_type sgetc();
 \end{itemdecl}
@@ -3296,8 +3240,7 @@ Otherwise, returns
 \tcode{traits\colcol{}to_int_type(*gptr())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sgetn}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{sgetn}}%
+\indexlibrarymember{sgetn}{basic_streambuf}%
 \begin{itemdecl}
 streamsize sgetn(char_type* s, streamsize n);
 \end{itemdecl}
@@ -3310,8 +3253,7 @@ streamsize sgetn(char_type* s, streamsize n);
 
 \rSec4[streambuf.pub.pback]{Putback}
 
-\indexlibrary{\idxcode{sputbackc}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{sputbackc}}%
+\indexlibrarymember{sputbackc}{basic_streambuf}%
 \begin{itemdecl}
 int_type sputbackc(char_type c);
 \end{itemdecl}
@@ -3329,8 +3271,7 @@ returns
 \tcode{traits::to_int_type(*gptr())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sungetc}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{sungetc}}%
+\indexlibrarymember{sungetc}{basic_streambuf}%
 \begin{itemdecl}
 int_type sungetc();
 \end{itemdecl}
@@ -3348,8 +3289,7 @@ returns
 
 \rSec4[streambuf.pub.put]{Put area}
 
-\indexlibrary{\idxcode{sputc}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{sputc}}%
+\indexlibrarymember{sputc}{basic_streambuf}%
 \begin{itemdecl}
 int_type sputc(char_type c);
 \end{itemdecl}
@@ -3366,8 +3306,7 @@ returns
 \tcode{traits::to_int_type(c)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sputn}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{sputn}}%
+\indexlibrarymember{sputn}{basic_streambuf}%
 \begin{itemdecl}
 streamsize sputn(const char_type* s, streamsize n);
 \end{itemdecl}
@@ -3382,8 +3321,7 @@ streamsize sputn(const char_type* s, streamsize n);
 
 \rSec4[streambuf.assign]{Assignment}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{basic_streambuf}%
 \begin{itemdecl}
 basic_streambuf& operator=(const basic_streambuf& rhs);
 \end{itemdecl}
@@ -3410,8 +3348,7 @@ to \tcode{*this}.
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{swap}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{swap}}%
+\indexlibrarymember{swap}{basic_streambuf}%
 \begin{itemdecl}
 void swap(basic_streambuf& rhs);
 \end{itemdecl}
@@ -3424,8 +3361,7 @@ and \tcode{*this}.
 
 \rSec4[streambuf.get.area]{Get area access}
 
-\indexlibrary{\idxcode{eback}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{eback}}%
+\indexlibrarymember{eback}{basic_streambuf}%
 \begin{itemdecl}
 char_type* eback() const;
 \end{itemdecl}
@@ -3436,8 +3372,7 @@ char_type* eback() const;
 The beginning pointer for the input sequence.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{gptr}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{gptr}}%
+\indexlibrarymember{gptr}{basic_streambuf}%
 \begin{itemdecl}
 char_type* gptr() const;
 \end{itemdecl}
@@ -3448,8 +3383,7 @@ char_type* gptr() const;
 The next pointer for the input sequence.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{egptr}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{egptr}}%
+\indexlibrarymember{egptr}{basic_streambuf}%
 \begin{itemdecl}
 char_type* egptr() const;
 \end{itemdecl}
@@ -3460,8 +3394,7 @@ char_type* egptr() const;
 The end pointer for the input sequence.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{gbump}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{gbump}}%
+\indexlibrarymember{gbump}{basic_streambuf}%
 \begin{itemdecl}
 void gbump(int n);
 \end{itemdecl}
@@ -3472,8 +3405,7 @@ void gbump(int n);
 Adds \tcode{n} to the next pointer for the input sequence.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{setg}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{setg}}%
+\indexlibrarymember{setg}{basic_streambuf}%
 \begin{itemdecl}
 void setg(char_type* gbeg, char_type* gnext, char_type* gend);
 \end{itemdecl}
@@ -3489,8 +3421,7 @@ and
 
 \rSec4[streambuf.put.area]{Put area access}
 
-\indexlibrary{\idxcode{pbase}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{pbase}}%
+\indexlibrarymember{pbase}{basic_streambuf}%
 \begin{itemdecl}
 char_type* pbase() const;
 \end{itemdecl}
@@ -3501,8 +3432,7 @@ char_type* pbase() const;
 The beginning pointer for the output sequence.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pptr}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{pptr}}%
+\indexlibrarymember{pptr}{basic_streambuf}%
 \begin{itemdecl}
 char_type* pptr() const;
 \end{itemdecl}
@@ -3513,8 +3443,7 @@ char_type* pptr() const;
 The next pointer for the output sequence.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{epptr}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{epptr}}%
+\indexlibrarymember{epptr}{basic_streambuf}%
 \begin{itemdecl}
 char_type* epptr() const;
 \end{itemdecl}
@@ -3525,8 +3454,7 @@ char_type* epptr() const;
 The end pointer for the output sequence.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pbump}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{pbump}}%
+\indexlibrarymember{pbump}{basic_streambuf}%
 \begin{itemdecl}
 void pbump(int n);
 \end{itemdecl}
@@ -3537,8 +3465,7 @@ void pbump(int n);
 Adds \tcode{n} to the next pointer for the output sequence.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{setp}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{setp}}%
+\indexlibrarymember{setp}{basic_streambuf}%
 \begin{itemdecl}
 void setp(char_type* pbeg, char_type* pend);
 \end{itemdecl}
@@ -3556,8 +3483,7 @@ and
 
 \rSec4[streambuf.virt.locales]{Locales}
 
-\indexlibrary{\idxcode{imbue}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{imbue}}%
+\indexlibrarymember{imbue}{basic_streambuf}%
 \begin{itemdecl}
 void imbue(const locale&);
 \end{itemdecl}
@@ -3582,8 +3508,7 @@ Does nothing.
 
 \rSec4[streambuf.virt.buffer]{Buffer management and positioning}
 
-\indexlibrary{\idxcode{setbuf}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{setbuf}}%
+\indexlibrarymember{setbuf}{basic_streambuf}%
 \begin{itemdecl}
 basic_streambuf* setbuf(char_type* s, streamsize n);
 \end{itemdecl}
@@ -3604,8 +3529,7 @@ Returns
 \tcode{this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{seekoff}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{seekoff}}%
+\indexlibrarymember{seekoff}{basic_streambuf}%
 \begin{itemdecl}
 pos_type seekoff(off_type off, ios_base::seekdir way,
                  ios_base::openmode which
@@ -3628,8 +3552,7 @@ Returns
 \tcode{pos_type(off_type(-1))}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{seekpos}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{seekpos}}%
+\indexlibrarymember{seekpos}{basic_streambuf}%
 \begin{itemdecl}
 pos_type seekpos(pos_type sp,
                  ios_base::openmode which
@@ -3652,8 +3575,7 @@ Returns
 \tcode{pos_type(off_type(-1))}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sync}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{sync}}%
+\indexlibrarymember{sync}{basic_streambuf}%
 \begin{itemdecl}
 int sync();
 \end{itemdecl}
@@ -3683,8 +3605,7 @@ Returns zero.
 
 \rSec4[streambuf.virt.get]{Get area}
 
-\indexlibrary{\idxcode{showmanyc}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{showmanyc}}%
+\indexlibrarymember{showmanyc}{basic_streambuf}%
 \begin{itemdecl}
 streamsize showmanyc();@\footnote{\textrm{The morphemes of \tcode{showmanyc}\
 are ``es-how-many-see'', not ``show-manic''.}}@
@@ -3726,8 +3647,7 @@ Uses
 \tcode{traits::eof()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{xsgetn}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{xsgetn}}%
+\indexlibrarymember{xsgetn}{basic_streambuf}%
 \begin{itemdecl}
 streamsize xsgetn(char_type* s, streamsize n);
 \end{itemdecl}
@@ -3762,8 +3682,7 @@ Uses
 \tcode{traits::eof()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{underflow}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{underflow}}%
+\indexlibrarymember{underflow}{basic_streambuf}%
 \begin{itemdecl}
 int_type underflow();
 \end{itemdecl}
@@ -3891,8 +3810,7 @@ Returns
 \tcode{traits::eof()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{uflow}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{uflow}}%
+\indexlibrarymember{uflow}{basic_streambuf}%
 \begin{itemdecl}
 int_type uflow();
 \end{itemdecl}
@@ -3928,8 +3846,7 @@ to indicate failure.
 
 \rSec4[streambuf.virt.pback]{Putback}
 
-\indexlibrary{\idxcode{pbackfail}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{pbackfail}}%
+\indexlibrarymember{pbackfail}{basic_streambuf}%
 \begin{itemdecl}
 int_type pbackfail(int_type c = traits::eof());
 \end{itemdecl}
@@ -4000,8 +3917,7 @@ Returns
 
 \rSec4[streambuf.virt.put]{Put area}
 
-\indexlibrary{\idxcode{xsputn}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{xsputn}}%
+\indexlibrarymember{xsputn}{basic_streambuf}%
 \begin{itemdecl}
 streamsize xsputn(const char_type* s, streamsize n);
 \end{itemdecl}
@@ -4026,8 +3942,7 @@ Is is unspecified whether the function calls \tcode{overflow()} when \tcode{pptr
 The number of characters written.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{overflow}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{overflow}}%
+\indexlibrarymember{overflow}{basic_streambuf}%
 \begin{itemdecl}
 int_type overflow(int_type c = traits::eof());
 \end{itemdecl}
@@ -4453,8 +4368,7 @@ Does not perform any operations of
 
 \rSec4[istream.assign]{Class \tcode{basic_istream} assign and swap}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{basic_istream}%
 \begin{itemdecl}
 basic_istream& operator=(basic_istream&& rhs);
 \end{itemdecl}
@@ -4467,8 +4381,7 @@ basic_istream& operator=(basic_istream&& rhs);
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{swap}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{swap}}%
+\indexlibrarymember{swap}{basic_istream}%
 \begin{itemdecl}
 void swap(basic_istream& rhs);
 \end{itemdecl}
@@ -4609,8 +4522,7 @@ implementation-dependent operations.}
 None.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator bool}!\idxcode{basic_istream::sentry}}%
-\indexlibrary{\idxcode{basic_istream::sentry}!\idxcode{operator bool}}%
+\indexlibrarymember{operator bool}{basic_istream::sentry}%
 \begin{itemdecl}
 explicit operator bool() const;
 \end{itemdecl}
@@ -4660,8 +4572,7 @@ If no exception has been thrown, it returns
 
 \rSec4[istream.formatted.arithmetic]{Arithmetic extractors}
 
-\indexlibrary{\idxcode{operator\shr}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{operator\shr}}%
+\indexlibrarymember{operator\shr}{basic_istream}%
 \begin{itemdecl}
 operator>>(unsigned short& val);
 operator>>(unsigned int& val);
@@ -4712,8 +4623,7 @@ so that it does not need to depend directly on
 \tcode{istream}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shr}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{operator\shr}}%
+\indexlibrarymember{operator\shr}{basic_istream}%
 \begin{itemdecl}
 operator>>(short& val);
 \end{itemdecl}
@@ -4739,8 +4649,7 @@ setstate(err);
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shr}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{operator\shr}}%
+\indexlibrarymember{operator\shr}{basic_istream}%
 \begin{itemdecl}
 operator>>(int& val);
 \end{itemdecl}
@@ -4768,8 +4677,7 @@ setstate(err);
 
 \rSec4[istream::extractors]{\tcode{basic_istream::operator\shr}}
 
-\indexlibrary{\idxcode{operator\shr}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{operator\shr}}%
+\indexlibrarymember{operator\shr}{basic_istream}%
 \begin{itemdecl}
 basic_istream<charT, traits>& operator>>
     (basic_istream<charT, traits>& (*pf)(basic_istream<charT, traits>&));
@@ -4789,8 +4697,7 @@ This extractor does not behave as a formatted input function
 \indexlibrary{\idxcode{ws}}}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shr}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{operator\shr}}%
+\indexlibrarymember{operator\shr}{basic_istream}%
 \begin{itemdecl}
 basic_istream<charT, traits>& operator>>
     (basic_ios<charT, traits>& (*pf)(basic_ios<charT, traits>&));
@@ -4809,8 +4716,7 @@ This extractor does not behave as a formatted input function
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shr}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{operator\shr}}%
+\indexlibrarymember{operator\shr}{basic_istream}%
 \begin{itemdecl}
 basic_istream<charT, traits>& operator>>
     (ios_base& (*pf)(ios_base&));
@@ -4830,8 +4736,7 @@ This extractor does not behave as a formatted input function
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shr}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{operator\shr}}%
+\indexlibrarymember{operator\shr}{basic_istream}%
 \begin{itemdecl}
 template<class charT, class traits>
   basic_istream<charT, traits>& operator>>(basic_istream<charT, traits>& in,
@@ -4905,8 +4810,7 @@ which may throw
 \tcode{in}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shr}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{operator\shr}}%
+\indexlibrarymember{operator\shr}{basic_istream}%
 \begin{itemdecl}
 template<class charT, class traits>
   basic_istream<charT, traits>& operator>>(basic_istream<charT, traits>& in,
@@ -4936,8 +4840,7 @@ Otherwise, the function calls
 \tcode{in}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shr}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{operator\shr}}%
+\indexlibrarymember{operator\shr}{basic_istream}%
 \begin{itemdecl}
 basic_istream<charT, traits>& operator>>
   (basic_streambuf<charT, traits>* sb);
@@ -5035,8 +4938,7 @@ In any event the
 object
 is destroyed before leaving the unformatted input function.
 
-\indexlibrary{\idxcode{gcount}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{gcount}}%
+\indexlibrarymember{gcount}{basic_istream}%
 \begin{itemdecl}
 streamsize gcount() const;
 \end{itemdecl}
@@ -5054,8 +4956,7 @@ The number of characters
 extracted by the last unformatted input member function called for the object.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{get}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{get}}%
+\indexlibrarymember{get}{basic_istream}%
 \begin{itemdecl}
 int_type get();
 \end{itemdecl}
@@ -5079,8 +4980,7 @@ otherwise
 \tcode{traits::eof()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{get}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{get}}%
+\indexlibrarymember{get}{basic_istream}%
 \begin{itemdecl}
 basic_istream<charT, traits>& get(char_type& c);
 \end{itemdecl}
@@ -5106,8 +5006,7 @@ Otherwise, the function calls
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{get}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{get}}%
+\indexlibrarymember{get}{basic_istream}%
 \begin{itemdecl}
 basic_istream<charT, traits>& get(char_type* s, streamsize n,
                                   char_type delim);
@@ -5154,8 +5053,7 @@ into the next successive location of the array.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{get}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{get}}%
+\indexlibrarymember{get}{basic_istream}%
 \begin{itemdecl}
 basic_istream<charT, traits>& get(char_type* s, streamsize n);
 \end{itemdecl}
@@ -5171,8 +5069,7 @@ Calls
 Value returned by the call.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{get}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{get}}%
+\indexlibrarymember{get}{basic_istream}%
 \begin{itemdecl}
 basic_istream<charT, traits>& get(basic_streambuf<char_type, traits>& sb,
                                   char_type delim);
@@ -5214,8 +5111,7 @@ which may throw
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{get}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{get}}%
+\indexlibrarymember{get}{basic_istream}%
 \begin{itemdecl}
 basic_istream<charT, traits>& get(basic_streambuf<char_type, traits>& sb);
 \end{itemdecl}
@@ -5231,8 +5127,7 @@ Calls
 Value returned by the call.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{getline}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{getline}}%
+\indexlibrarymember{getline}{basic_istream}%
 \begin{itemdecl}
 basic_istream<charT, traits>& getline(char_type* s, streamsize n,
                                       char_type delim);
@@ -5326,8 +5221,7 @@ int main() {
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{getline}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{getline}}%
+\indexlibrarymember{getline}{basic_istream}%
 \begin{itemdecl}
 basic_istream<charT, traits>& getline(char_type* s, streamsize n);
 \end{itemdecl}
@@ -5338,8 +5232,7 @@ basic_istream<charT, traits>& getline(char_type* s, streamsize n);
 \tcode{getline(s, n, widen('\textbackslash n'))}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{ignore}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{ignore}}%
+\indexlibrarymember{ignore}{basic_istream}%
 \begin{itemdecl}
 basic_istream<charT, traits>&
     ignore(streamsize n = 1, int_type delim = traits::eof());
@@ -5380,8 +5273,7 @@ The last condition will never occur if
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{peek}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{peek}}%
+\indexlibrarymember{peek}{basic_istream}%
 \begin{itemdecl}
 int_type peek();
 \end{itemdecl}
@@ -5405,8 +5297,7 @@ Otherwise, returns
 \tcode{rdbuf()->sgetc()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{read}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{read}}%
+\indexlibrarymember{read}{basic_istream}%
 \begin{itemdecl}
 basic_istream<charT, traits>& read(char_type* s, streamsize n);
 \end{itemdecl}
@@ -5445,8 +5336,7 @@ which may throw
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{readsome}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{readsome}}%
+\indexlibrarymember{readsome}{basic_istream}%
 \begin{itemdecl}
 streamsize readsome(char_type* s, streamsize n);
 \end{itemdecl}
@@ -5489,8 +5379,7 @@ extracts
 The number of characters extracted.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{putback}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{putback}}%
+\indexlibrarymember{putback}{basic_istream}%
 \begin{itemdecl}
 basic_istream<charT, traits>& putback(char_type c);
 \end{itemdecl}
@@ -5533,8 +5422,7 @@ is 0.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{unget}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{unget}}%
+\indexlibrarymember{unget}{basic_istream}%
 \begin{itemdecl}
 basic_istream<charT, traits>& unget();
 \end{itemdecl}
@@ -5577,8 +5465,7 @@ is 0.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sync}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{sync}}%
+\indexlibrarymember{sync}{basic_istream}%
 \begin{itemdecl}
 int sync();
 \end{itemdecl}
@@ -5606,8 +5493,7 @@ and returns
 Otherwise, returns zero.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{tellg}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{tellg}}%
+\indexlibrarymember{tellg}{basic_istream}%
 \begin{itemdecl}
 pos_type tellg();
 \end{itemdecl}
@@ -5631,8 +5517,7 @@ Otherwise, returns
 \tcode{rdbuf()->pubseekoff(0, cur, in)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{seekg}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{seekg}}%
+\indexlibrarymember{seekg}{basic_istream}%
 \begin{itemdecl}
 basic_istream<charT, traits>& seekg(pos_type pos);
 \end{itemdecl}
@@ -5660,8 +5545,7 @@ In case of failure, the function calls
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{seekg}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{seekg}}%
+\indexlibrarymember{seekg}{basic_istream}%
 \begin{itemdecl}
 basic_istream<charT, traits>& seekg(off_type off, ios_base::seekdir dir);
 \end{itemdecl}
@@ -5814,8 +5698,7 @@ Does not perform any operations on
 
 \rSec4[iostream.assign]{\tcode{basic_iostream} assign and swap}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{basic_iostream}}%
-\indexlibrary{\idxcode{basic_iostream}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{basic_iostream}%
 \begin{itemdecl}
 basic_iostream& operator=(basic_iostream&& rhs);
 \end{itemdecl}
@@ -5825,8 +5708,7 @@ basic_iostream& operator=(basic_iostream&& rhs);
 \effects As if by \tcode{swap(rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{swap}!\idxcode{basic_iostream}}%
-\indexlibrary{\idxcode{basic_iostream}!\idxcode{swap}}%
+\indexlibrarymember{swap}{basic_iostream}%
 \begin{itemdecl}
 void swap(basic_iostream& rhs);
 \end{itemdecl}
@@ -5838,8 +5720,7 @@ void swap(basic_iostream& rhs);
 
 \rSec3[istream.rvalue]{Rvalue stream extraction}
 
-\indexlibrary{\idxcode{operator\shr}!\idxcode{basic_istream}}%
-\indexlibrary{\idxcode{basic_istream}!\idxcode{operator\shr}}%
+\indexlibrarymember{operator\shr}{basic_istream}%
 \begin{itemdecl}
 template <class charT, class traits, class T>
   basic_istream<charT, traits>&
@@ -6019,8 +5900,7 @@ it does not throw anything and treat as an error.
 explicit basic_ostream(basic_streambuf<charT, traits>* sb);
 \end{itemdecl}
 
-\indexlibrary{\idxcode{init}!\idxcode{basic_ostream}}%
-\indexlibrary{\idxcode{basic_ostream}!\idxcode{init}}%
+\indexlibrarymember{init}{basic_ostream}%
 \begin{itemdescr}
 \pnum
 \effects
@@ -6064,8 +5944,7 @@ base class.
 
 \rSec3[ostream.assign]{Class \tcode{basic_ostream} assign and swap}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{basic_ostream}}%
-\indexlibrary{\idxcode{basic_ostream}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{basic_ostream}%
 \begin{itemdecl}
 basic_ostream& operator=(basic_ostream&& rhs);
 \end{itemdecl}
@@ -6078,8 +5957,7 @@ basic_ostream& operator=(basic_ostream&& rhs);
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{swap}!\idxcode{basic_ostream}}%
-\indexlibrary{\idxcode{basic_ostream}!\idxcode{swap}}%
+\indexlibrarymember{swap}{basic_ostream}%
 \begin{itemdecl}
 void swap(basic_ostream& rhs);
 \end{itemdecl}
@@ -6169,8 +6047,7 @@ calls
 \end{itemdescr}
 
 \indexlibrary{\idxcode{flush}}%
-\indexlibrary{\idxcode{operator bool}!\idxcode{basic_ostream::sentry}}%
-\indexlibrary{\idxcode{basic_ostream::sentry}!\idxcode{operator bool}}%
+\indexlibrarymember{operator bool}{basic_ostream::sentry}%
 \begin{itemdecl}
 explicit operator bool() const;
 \end{itemdecl}
@@ -6188,8 +6065,7 @@ Returns
 Each seek member function begins execution by constructing an object of class \tcode{sentry}.
 It returns by destroying the \tcode{sentry} object.
 
-\indexlibrary{\idxcode{tellp}!\idxcode{basic_ostream}}%
-\indexlibrary{\idxcode{basic_ostream}!\idxcode{tellp}}%
+\indexlibrarymember{tellp}{basic_ostream}%
 \begin{itemdecl}
 pos_type tellp();
 \end{itemdecl}
@@ -6227,8 +6103,7 @@ In case of failure, the function calls
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{seekp}!\idxcode{basic_ostream}}%
-\indexlibrary{\idxcode{basic_ostream}!\idxcode{seekp}}%
+\indexlibrarymember{seekp}{basic_ostream}%
 \begin{itemdecl}
 basic_ostream<charT, traits>& seekp(off_type off, ios_base::seekdir dir);
 \end{itemdecl}
@@ -6304,8 +6179,7 @@ character sequence.
 
 \rSec4[ostream.inserters.arithmetic]{Arithmetic inserters}
 
-\indexlibrary{\idxcode{operator\shl}!\idxcode{basic_ostream}}%
-\indexlibrary{\idxcode{basic_ostream}!\idxcode{operator\shl}}%
+\indexlibrarymember{operator\shl}{basic_ostream}%
 \begin{itemdecl}
 operator<<(bool val);
 operator<<(short val);
@@ -6433,8 +6307,7 @@ which may throw an exception, and returns.
 
 \rSec4[ostream.inserters]{\tcode{basic_ostream::operator\shl}}
 
-\indexlibrary{\idxcode{operator\shl}!\idxcode{basic_ostream}}%
-\indexlibrary{\idxcode{basic_ostream}!\idxcode{operator\shl}}%
+\indexlibrarymember{operator\shl}{basic_ostream}%
 \begin{itemdecl}
 basic_ostream<charT, traits>& operator<<
     (basic_ostream<charT, traits>& (*pf)(basic_ostream<charT, traits>&));
@@ -6454,8 +6327,7 @@ in~\ref{ostream.formatted.reqmts}).
 \tcode{endl(basic_ostream\&)}~(\ref{ostream.manip}).}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shl}!\idxcode{basic_ostream}}%
-\indexlibrary{\idxcode{basic_ostream}!\idxcode{operator\shl}}%
+\indexlibrarymember{operator\shl}{basic_ostream}%
 \begin{itemdecl}
 basic_ostream<charT, traits>& operator<<
     (basic_ios<charT, traits>& (*pf)(basic_ios<charT, traits>&));
@@ -6476,8 +6348,7 @@ behave as a formatted output function (as described in~\ref{ostream.formatted.re
 \tcode{dec(ios_base\&)}~(\ref{basefield.manip}).}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shl}!\idxcode{basic_ostream}}%
-\indexlibrary{\idxcode{basic_ostream}!\idxcode{operator\shl}}%
+\indexlibrarymember{operator\shl}{basic_ostream}%
 \begin{itemdecl}
 basic_ostream<charT, traits>& operator<<
     (ios_base& (*pf)(ios_base&));
@@ -6496,8 +6367,7 @@ behave as a formatted output function (as described in~\ref{ostream.formatted.re
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shl}!\idxcode{basic_ostream}}%
-\indexlibrary{\idxcode{basic_ostream}!\idxcode{operator\shl}}%
+\indexlibrarymember{operator\shl}{basic_ostream}%
 \begin{itemdecl}
 basic_ostream<charT, traits>& operator<<
     (basic_streambuf<charT, traits>* sb);
@@ -6551,8 +6421,7 @@ the caught exception is rethrown.
 
 \rSec4[ostream.inserters.character]{Character inserter function templates}
 
-\indexlibrary{\idxcode{operator\shl}!\idxcode{basic_ostream}}%
-\indexlibrary{\idxcode{basic_ostream}!\idxcode{operator\shl}}%
+\indexlibrarymember{operator\shl}{basic_ostream}%
 \begin{itemdecl}
 template<class charT, class traits>
   basic_ostream<charT, traits>& operator<<(basic_ostream<charT, traits>& out,
@@ -6595,8 +6464,7 @@ in~\ref{ostream.formatted.reqmts}. Inserts \tcode{seq} into
 \tcode{out}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shl}!\idxcode{basic_ostream}}%
-\indexlibrary{\idxcode{basic_ostream}!\idxcode{operator\shl}}%
+\indexlibrarymember{operator\shl}{basic_ostream}%
 \begin{itemdecl}
 template<class charT, class traits>
   basic_ostream<charT, traits>& operator<<(basic_ostream<charT, traits>& out,
@@ -6686,8 +6554,7 @@ In any case, the unformatted output function ends by destroying the
 sentry object, then, if no exception was thrown, returning the value
 specified for the unformatted output function.
 
-\indexlibrary{\idxcode{put}!\idxcode{basic_ostream}}%
-\indexlibrary{\idxcode{basic_ostream}!\idxcode{put}}%
+\indexlibrarymember{put}{basic_ostream}%
 \begin{itemdecl}
 basic_ostream<charT, traits>& put(char_type c);
 \end{itemdecl}
@@ -6714,8 +6581,7 @@ Otherwise, calls
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{write}!\idxcode{basic_ostream}}%
-\indexlibrary{\idxcode{basic_ostream}!\idxcode{write}}%
+\indexlibrarymember{write}{basic_ostream}%
 \begin{itemdecl}
 basic_ostream& write(const char_type* s, streamsize n);
 \end{itemdecl}
@@ -6748,8 +6614,7 @@ which may throw
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{flush}!\idxcode{basic_ostream}}%
-\indexlibrary{\idxcode{basic_ostream}!\idxcode{flush}}%
+\indexlibrarymember{flush}{basic_ostream}%
 \begin{itemdecl}
 basic_ostream& flush();
 \end{itemdecl}
@@ -6833,8 +6698,7 @@ Calls
 
 \rSec3[ostream.rvalue]{Rvalue stream insertion}
 
-\indexlibrary{\idxcode{operator\shl}!\idxcode{basic_ostream}}%
-\indexlibrary{\idxcode{basic_ostream}!\idxcode{operator\shl}}%
+\indexlibrarymember{operator\shl}{basic_ostream}%
 \begin{itemdecl}
 template <class charT, class traits, class T>
   basic_ostream<charT, traits>&
@@ -7576,8 +7440,7 @@ refer to the state of \tcode{rhs} just after this construction.
 
 \rSec3[stringbuf.assign]{Assign and swap}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{basic_stringbuf}}%
-\indexlibrary{\idxcode{basic_stringbuf}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{basic_stringbuf}%
 \begin{itemdecl}
 basic_stringbuf& operator=(basic_stringbuf&& rhs);
 \end{itemdecl}
@@ -7591,8 +7454,7 @@ have had if it had been move constructed from \tcode{rhs} (see~\ref{stringbuf.co
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{swap}!\idxcode{basic_stringbuf}}%
-\indexlibrary{\idxcode{basic_stringbuf}!\idxcode{swap}}%
+\indexlibrarymember{swap}{basic_stringbuf}%
 \begin{itemdecl}
 void swap(basic_stringbuf& rhs);
 \end{itemdecl}
@@ -7603,8 +7465,7 @@ void swap(basic_stringbuf& rhs);
 and \tcode{rhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{swap}!\idxcode{basic_stringbuf}}%
-\indexlibrary{\idxcode{basic_stringbuf}!\idxcode{swap}}%
+\indexlibrarymember{swap}{basic_stringbuf}%
 \begin{itemdecl}
 template <class charT, class traits, class Allocator>
   void swap(basic_stringbuf<charT, traits, Allocator>& x,
@@ -7618,8 +7479,7 @@ template <class charT, class traits, class Allocator>
 
 \rSec3[stringbuf.members]{Member functions}
 
-\indexlibrary{\idxcode{str}!\idxcode{basic_stringbuf}}%
-\indexlibrary{\idxcode{basic_stringbuf}!\idxcode{str}}%
+\indexlibrarymember{str}{basic_stringbuf}%
 \begin{itemdecl}
 basic_string<charT, traits, Allocator> str() const;
 \end{itemdecl}
@@ -7647,8 +7507,7 @@ by the new \tcode{basic_string}). Otherwise the \tcode{basic_stringbuf} has been
 in neither input nor output mode and a zero length \tcode{basic_string} is returned. 
 \end{itemdescr}
 
-\indexlibrary{\idxcode{str}!\idxcode{basic_stringbuf}}%
-\indexlibrary{\idxcode{basic_stringbuf}!\idxcode{str}}%
+\indexlibrarymember{str}{basic_stringbuf}%
 \begin{itemdecl}
 void str(const basic_string<charT, traits, Allocator>& s);
 \end{itemdecl}
@@ -7671,8 +7530,7 @@ true, \tcode{eback()} points to the first underlying character, and both \tcode{
 
 \rSec3[stringbuf.virtuals]{Overridden virtual functions}
 
-\indexlibrary{\idxcode{underflow}!\idxcode{basic_stringbuf}}%
-\indexlibrary{\idxcode{basic_stringbuf}!\idxcode{underflow}}%
+\indexlibrarymember{underflow}{basic_stringbuf}%
 \begin{itemdecl}
 int_type underflow() override;
 \end{itemdecl}
@@ -7689,8 +7547,7 @@ Any character in the underlying buffer which has been initialized is considered
 to be part of the input sequence. 
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pbackfail}!\idxcode{basic_stringbuf}}%
-\indexlibrary{\idxcode{basic_stringbuf}!\idxcode{pbackfail}}%
+\indexlibrarymember{pbackfail}{basic_stringbuf}%
 \begin{itemdecl}
 int_type pbackfail(int_type c = traits::eof()) override;
 \end{itemdecl}
@@ -7762,8 +7619,7 @@ unspecified which way is chosen.
 \indextext{unspecified}%
 \end{itemdescr}
 
-\indexlibrary{\idxcode{overflow}!\idxcode{basic_stringbuf}}%
-\indexlibrary{\idxcode{basic_stringbuf}!\idxcode{overflow}}%
+\indexlibrarymember{overflow}{basic_stringbuf}%
 \begin{itemdecl}
 int_type overflow(int_type c = traits::eof()) override;
 \end{itemdecl}
@@ -7825,8 +7681,7 @@ the function alters the read end pointer
 to point just past the new write position.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{seekoff}!\idxcode{basic_stringbuf}}%
-\indexlibrary{\idxcode{basic_stringbuf}!\idxcode{seekoff}}%
+\indexlibrarymember{seekoff}{basic_stringbuf}%
 \begin{itemdecl}
 pos_type seekoff(off_type off, ios_base::seekdir way,
                  ios_base::openmode which
@@ -7900,8 +7755,7 @@ the return value is
 \tcode{pos_type(off_type(-1))}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{seekpos}!\idxcode{basic_stringbuf}}%
-\indexlibrary{\idxcode{basic_stringbuf}!\idxcode{seekpos}}%
+\indexlibrarymember{seekpos}{basic_stringbuf}%
 \begin{itemdecl}
 pos_type seekpos(pos_type sp,
                  ios_base::openmode which
@@ -7921,8 +7775,7 @@ to indicate success, or
 to indicate failure.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{setbuf}!\idxcode{basic_streambuf}}%
-\indexlibrary{\idxcode{basic_streambuf}!\idxcode{setbuf}}%
+\indexlibrarymember{setbuf}{basic_streambuf}%
 \begin{itemdecl}
 basic_streambuf<charT, traits>* setbuf(charT* s, streamsize n);
 \end{itemdecl}
@@ -8053,8 +7906,7 @@ install the contained \tcode{basic_stringbuf}.
 
 \rSec3[istringstream.assign]{Assign and swap}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{basic_istringstream}}%
-\indexlibrary{\idxcode{basic_istringstream}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{basic_istringstream}%
 \begin{itemdecl}
 basic_istringstream& operator=(basic_istringstream&& rhs);
 \end{itemdecl}
@@ -8068,8 +7920,7 @@ members of \tcode{rhs}.
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{swap}!\idxcode{basic_istringstream}}%
-\indexlibrary{\idxcode{basic_istringstream}!\idxcode{swap}}%
+\indexlibrarymember{swap}{basic_istringstream}%
 \begin{itemdecl}
 void swap(basic_istringstream& rhs);
 \end{itemdecl}
@@ -8083,8 +7934,7 @@ void swap(basic_istringstream& rhs);
 \end{itemdescr}
 
 
-\indexlibrary{\idxcode{swap}!\idxcode{basic_istringstream}}%
-\indexlibrary{\idxcode{basic_istringstream}!\idxcode{swap}}%
+\indexlibrarymember{swap}{basic_istringstream}%
 \begin{itemdecl}
 template <class charT, class traits, class Allocator>
   void swap(basic_istringstream<charT, traits, Allocator>& x,
@@ -8098,8 +7948,7 @@ template <class charT, class traits, class Allocator>
 
 \rSec3[istringstream.members]{Member functions}
 
-\indexlibrary{\idxcode{rdbuf}!\idxcode{basic_istringstream}}%
-\indexlibrary{\idxcode{basic_istringstream}!\idxcode{rdbuf}}%
+\indexlibrarymember{rdbuf}{basic_istringstream}%
 \begin{itemdecl}
 basic_stringbuf<charT, traits, Allocator>* rdbuf() const;
 \end{itemdecl}
@@ -8110,8 +7959,7 @@ basic_stringbuf<charT, traits, Allocator>* rdbuf() const;
 \tcode{const_cast<basic_stringbuf<charT, traits, Allocator>*>(\&sb)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{str}!\idxcode{basic_istringstream}}%
-\indexlibrary{\idxcode{basic_istringstream}!\idxcode{str}}%
+\indexlibrarymember{str}{basic_istringstream}%
 \begin{itemdecl}
 basic_string<charT, traits, Allocator> str() const;
 \end{itemdecl}
@@ -8122,8 +7970,7 @@ basic_string<charT, traits, Allocator> str() const;
 \tcode{rdbuf()->str()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{str}!\idxcode{basic_istringstream}}%
-\indexlibrary{\idxcode{basic_istringstream}!\idxcode{str}}%
+\indexlibrarymember{str}{basic_istringstream}%
 \begin{itemdecl}
 void str(const basic_string<charT, traits, Allocator>& s);
 \end{itemdecl}
@@ -8248,8 +8095,7 @@ install the contained \tcode{basic_stringbuf}.
 
 \rSec3[ostringstream.assign]{Assign and swap}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{basic_ostringstream}}%
-\indexlibrary{\idxcode{basic_ostringstream}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{basic_ostringstream}%
 \begin{itemdecl}
 basic_ostringstream& operator=(basic_ostringstream&& rhs);
 \end{itemdecl}
@@ -8263,8 +8109,7 @@ members of \tcode{rhs}.
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{swap}!\idxcode{basic_ostringstream}}%
-\indexlibrary{\idxcode{basic_ostringstream}!\idxcode{swap}}%
+\indexlibrarymember{swap}{basic_ostringstream}%
 \begin{itemdecl}
 void swap(basic_ostringstream& rhs);
 \end{itemdecl}
@@ -8278,8 +8123,7 @@ void swap(basic_ostringstream& rhs);
 \end{itemdescr}
 
 
-\indexlibrary{\idxcode{swap}!\idxcode{basic_ostringstream}}%
-\indexlibrary{\idxcode{basic_ostringstream}!\idxcode{swap}}%
+\indexlibrarymember{swap}{basic_ostringstream}%
 \begin{itemdecl}
 template <class charT, class traits, class Allocator>
   void swap(basic_ostringstream<charT, traits, Allocator>& x,
@@ -8293,8 +8137,7 @@ template <class charT, class traits, class Allocator>
 
 \rSec3[ostringstream.members]{Member functions}
 
-\indexlibrary{\idxcode{rdbuf}!\idxcode{basic_ostringstream}}%
-\indexlibrary{\idxcode{basic_ostringstream}!\idxcode{rdbuf}}%
+\indexlibrarymember{rdbuf}{basic_ostringstream}%
 \begin{itemdecl}
 basic_stringbuf<charT, traits, Allocator>* rdbuf() const;
 \end{itemdecl}
@@ -8305,8 +8148,7 @@ basic_stringbuf<charT, traits, Allocator>* rdbuf() const;
 \tcode{const_cast<basic_stringbuf<charT, traits, Allocator>*>(\&sb)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{str}!\idxcode{basic_ostringstream}}%
-\indexlibrary{\idxcode{basic_ostringstream}!\idxcode{str}}%
+\indexlibrarymember{str}{basic_ostringstream}%
 \begin{itemdecl}
 basic_string<charT, traits, Allocator> str() const;
 \end{itemdecl}
@@ -8317,8 +8159,7 @@ basic_string<charT, traits, Allocator> str() const;
 \tcode{rdbuf()->str()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{str}!\idxcode{basic_ostringstream}}%
-\indexlibrary{\idxcode{basic_ostringstream}!\idxcode{str}}%
+\indexlibrarymember{str}{basic_ostringstream}%
 \begin{itemdecl}
 void str(const basic_string<charT, traits, Allocator>& s);
 \end{itemdecl}
@@ -8448,8 +8289,7 @@ install the contained \tcode{basic_stringbuf}.
 
 \rSec3[stringstream.assign]{Assign and swap}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{basic_stringstream}}%
-\indexlibrary{\idxcode{basic_stringstream}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{basic_stringstream}%
 \begin{itemdecl}
 basic_stringstream& operator=(basic_stringstream&& rhs);
 \end{itemdecl}
@@ -8463,8 +8303,7 @@ members of \tcode{rhs}.
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{swap}!\idxcode{basic_stringstream}}%
-\indexlibrary{\idxcode{basic_stringstream}!\idxcode{swap}}%
+\indexlibrarymember{swap}{basic_stringstream}%
 \begin{itemdecl}
 void swap(basic_stringstream& rhs);
 \end{itemdecl}
@@ -8478,8 +8317,7 @@ void swap(basic_stringstream& rhs);
 \end{itemdescr}
 
 
-\indexlibrary{\idxcode{swap}!\idxcode{basic_stringstream}}%
-\indexlibrary{\idxcode{basic_stringstream}!\idxcode{swap}}%
+\indexlibrarymember{swap}{basic_stringstream}%
 \begin{itemdecl}
 template <class charT, class traits, class Allocator>
   void swap(basic_stringstream<charT, traits, Allocator>& x,
@@ -8493,8 +8331,7 @@ template <class charT, class traits, class Allocator>
 
 \rSec3[stringstream.members]{Member functions}
 
-\indexlibrary{\idxcode{rdbuf}!\idxcode{basic_stringstream}}%
-\indexlibrary{\idxcode{basic_stringstream}!\idxcode{rdbuf}}%
+\indexlibrarymember{rdbuf}{basic_stringstream}%
 \begin{itemdecl}
 basic_stringbuf<charT, traits, Allocator>* rdbuf() const;
 \end{itemdecl}
@@ -8505,8 +8342,7 @@ basic_stringbuf<charT, traits, Allocator>* rdbuf() const;
 \tcode{const_cast<basic_stringbuf<charT, traits, Allocator>*>(\&sb)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{str}!\idxcode{basic_stringstream}}%
-\indexlibrary{\idxcode{basic_stringstream}!\idxcode{str}}%
+\indexlibrarymember{str}{basic_stringstream}%
 \begin{itemdecl}
 basic_string<charT, traits, Allocator> str() const;
 \end{itemdecl}
@@ -8517,8 +8353,7 @@ basic_string<charT, traits, Allocator> str() const;
 \tcode{rdbuf()->str()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{str}!\idxcode{basic_stringstream}}%
-\indexlibrary{\idxcode{basic_stringstream}!\idxcode{str}}%
+\indexlibrarymember{str}{basic_stringstream}%
 \begin{itemdecl}
 void str(const basic_string<charT, traits, Allocator>& str);
 \end{itemdecl}
@@ -8770,8 +8605,7 @@ If an exception occurs during the destruction of the object, including the call 
 
 \rSec3[filebuf.assign]{Assign and swap}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{basic_filebuf}}%
-\indexlibrary{\idxcode{basic_filebuf}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{basic_filebuf}%
 \begin{itemdecl}
 basic_filebuf& operator=(basic_filebuf&& rhs);
 \end{itemdecl}
@@ -8786,8 +8620,7 @@ had been move constructed from \tcode{rhs} (see~\ref{filebuf.cons}).
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{swap}!\idxcode{basic_filebuf}}%
-\indexlibrary{\idxcode{basic_filebuf}!\idxcode{swap}}%
+\indexlibrarymember{swap}{basic_filebuf}%
 \begin{itemdecl}
 void swap(basic_filebuf& rhs);
 \end{itemdecl}
@@ -8798,8 +8631,7 @@ void swap(basic_filebuf& rhs);
 and \tcode{rhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{swap}!\idxcode{basic_filebuf}}%
-\indexlibrary{\idxcode{basic_filebuf}!\idxcode{swap}}%
+\indexlibrarymember{swap}{basic_filebuf}%
 \begin{itemdecl}
 template <class charT, class traits>
   void swap(basic_filebuf<charT, traits>& x,
@@ -8813,8 +8645,7 @@ template <class charT, class traits>
 
 \rSec3[filebuf.members]{Member functions}
 
-\indexlibrary{\idxcode{is_open}!\idxcode{basic_filebuf}}%
-\indexlibrary{\idxcode{basic_filebuf}!\idxcode{is_open}}%
+\indexlibrarymember{is_open}{basic_filebuf}%
 \begin{itemdecl}
 bool is_open() const;
 \end{itemdecl}
@@ -8829,8 +8660,7 @@ succeeded (returned a non-null value) and there has been no intervening
 call to close.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{open}!\idxcode{basic_filebuf}}%
-\indexlibrary{\idxcode{basic_filebuf}!\idxcode{open}}%
+\indexlibrarymember{open}{basic_filebuf}%
 \begin{itemdecl}
 basic_filebuf<charT, traits>* open(const char* s,
                                    ios_base::openmode mode);
@@ -8911,8 +8741,7 @@ and returns a null pointer to indicate failure.
 if successful, a null pointer otherwise.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{open}!\idxcode{basic_filebuf}}%
-\indexlibrary{\idxcode{basic_filebuf}!\idxcode{open}}%
+\indexlibrarymember{open}{basic_filebuf}%
 \begin{itemdecl}
 basic_filebuf<charT, traits>* open(const string& s,
                                    ios_base::openmode mode);
@@ -8923,8 +8752,7 @@ basic_filebuf<charT, traits>* open(const string& s,
 \tcode{open(s.c_str(), mode);}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{close}!\idxcode{basic_filebuf}}%
-\indexlibrary{\idxcode{basic_filebuf}!\idxcode{close}}%
+\indexlibrarymember{close}{basic_filebuf}%
 \begin{itemdecl}
 basic_filebuf<charT, traits>* close();
 \end{itemdecl}
@@ -8975,8 +8803,7 @@ on success, a null pointer otherwise.
 
 \rSec3[filebuf.virtuals]{Overridden virtual functions}
 
-\indexlibrary{\idxcode{showmanyc}!\idxcode{basic_filebuf}}%
-\indexlibrary{\idxcode{basic_filebuf}!\idxcode{showmanyc}}%
+\indexlibrarymember{showmanyc}{basic_filebuf}%
 \begin{itemdecl}
 streamsize showmanyc() override;
 \end{itemdecl}
@@ -8996,8 +8823,7 @@ signature if it can determine that more characters can be read from the input
 sequence.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{underflow}!\idxcode{basic_filebuf}}%
-\indexlibrary{\idxcode{basic_filebuf}!\idxcode{underflow}}%
+\indexlibrarymember{underflow}{basic_filebuf}%
 \begin{itemdecl}
 int_type underflow() override;
 \end{itemdecl}
@@ -9040,8 +8866,7 @@ retry with a larger
 \tcode{intern_buf}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{uflow}!\idxcode{basic_filebuf}}%
-\indexlibrary{\idxcode{basic_filebuf}!\idxcode{uflow}}%
+\indexlibrarymember{uflow}{basic_filebuf}%
 \begin{itemdecl}
 int_type uflow() override;
 \end{itemdecl}
@@ -9056,8 +8881,7 @@ with the same method as used by
 \tcode{underflow}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pbackfail}!\idxcode{basic_filebuf}}%
-\indexlibrary{\idxcode{basic_filebuf}!\idxcode{pbackfail}}%
+\indexlibrarymember{pbackfail}{basic_filebuf}%
 \begin{itemdecl}
 int_type pbackfail(int_type c = traits::eof()) override;
 \end{itemdecl}
@@ -9133,8 +8957,7 @@ unspecified which way is chosen.
 The function can alter the number of putback positions available as a result of any call.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{overflow}!\idxcode{basic_filebuf}}%
-\indexlibrary{\idxcode{basic_filebuf}!\idxcode{overflow}}%
+\indexlibrarymember{overflow}{basic_filebuf}%
 \begin{itemdecl}
 int_type overflow(int_type c = traits::eof()) override;
 \end{itemdecl}
@@ -9181,8 +9004,7 @@ If
 the function always fails.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{setbuf}!\idxcode{basic_filebuf}}%
-\indexlibrary{\idxcode{basic_filebuf}!\idxcode{setbuf}}%
+\indexlibrarymember{setbuf}{basic_filebuf}%
 \begin{itemdecl}
 basic_streambuf* setbuf(char_type* s, streamsize n) override;
 \end{itemdecl}
@@ -9204,8 +9026,7 @@ always return null
 and output to the file should appear as soon as possible.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{seekoff}!\idxcode{basic_filebuf}}%
-\indexlibrary{\idxcode{basic_filebuf}!\idxcode{seekoff}}%
+\indexlibrarymember{seekoff}{basic_filebuf}%
 \begin{itemdecl}
 pos_type seekoff(off_type off, ios_base::seekdir way,
                  ios_base::openmode which
@@ -9272,8 +9093,7 @@ returns
 \tcode{pos_type(off_type(-1))}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{seekpos}!\idxcode{basic_filebuf}}%
-\indexlibrary{\idxcode{basic_filebuf}!\idxcode{seekpos}}%
+\indexlibrarymember{seekpos}{basic_filebuf}%
 \begin{itemdecl}
 pos_type seekpos(pos_type sp,
                  ios_base::openmode which
@@ -9322,8 +9142,7 @@ Otherwise returns
 \tcode{pos_type(off_type(-1))}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sync}!\idxcode{basic_filebuf}}%
-\indexlibrary{\idxcode{basic_filebuf}!\idxcode{sync}}%
+\indexlibrarymember{sync}{basic_filebuf}%
 \begin{itemdecl}
 int sync() override;
 \end{itemdecl}
@@ -9339,8 +9158,7 @@ If a get area exists, the effect is \impldef{effect of calling
 \tcode{basic_filebuf::sync} when a get area exists}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{imbue}!\idxcode{basic_filebuf}}%
-\indexlibrary{\idxcode{basic_filebuf}!\idxcode{imbue}}%
+\indexlibrarymember{imbue}{basic_filebuf}%
 \begin{itemdecl}
 void imbue(const locale& loc) override;
 \end{itemdecl}
@@ -9497,8 +9315,7 @@ the contained \tcode{basic_filebuf}.
 
 \rSec3[ifstream.assign]{Assign and swap}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{basic_ifstream}}%
-\indexlibrary{\idxcode{basic_ifstream}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{basic_ifstream}%
 \begin{itemdecl}
 basic_ifstream& operator=(basic_ifstream&& rhs);
 \end{itemdecl}
@@ -9512,8 +9329,7 @@ members of \tcode{rhs}.
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{swap}!\idxcode{basic_ifstream}}%
-\indexlibrary{\idxcode{basic_ifstream}!\idxcode{swap}}%
+\indexlibrarymember{swap}{basic_ifstream}%
 \begin{itemdecl}
 void swap(basic_ifstream& rhs);
 \end{itemdecl}
@@ -9526,8 +9342,7 @@ and \tcode{rhs} by calling
 \tcode{sb.swap(rhs.sb)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{swap}!\idxcode{basic_ifstream}}%
-\indexlibrary{\idxcode{basic_ifstream}!\idxcode{swap}}%
+\indexlibrarymember{swap}{basic_ifstream}%
 \begin{itemdecl}
 template <class charT, class traits>
   void swap(basic_ifstream<charT, traits>& x,
@@ -9541,8 +9356,7 @@ template <class charT, class traits>
 
 \rSec3[ifstream.members]{Member functions}
 
-\indexlibrary{\idxcode{rdbuf}!\idxcode{basic_ifstream}}%
-\indexlibrary{\idxcode{basic_ifstream}!\idxcode{rdbuf}}%
+\indexlibrarymember{rdbuf}{basic_ifstream}%
 \begin{itemdecl}
 basic_filebuf<charT, traits>* rdbuf() const;
 \end{itemdecl}
@@ -9553,8 +9367,7 @@ basic_filebuf<charT, traits>* rdbuf() const;
 \tcode{const_cast<basic_filebuf<charT, traits>*>(\&sb)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{is_open}!\idxcode{basic_ifstream}}%
-\indexlibrary{\idxcode{basic_ifstream}!\idxcode{is_open}}%
+\indexlibrarymember{is_open}{basic_ifstream}%
 \begin{itemdecl}
 bool is_open() const;
 \end{itemdecl}
@@ -9565,8 +9378,7 @@ bool is_open() const;
 \tcode{rdbuf()->is_open()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{open}!\idxcode{basic_ifstream}}%
-\indexlibrary{\idxcode{basic_ifstream}!\idxcode{open}}%
+\indexlibrarymember{open}{basic_ifstream}%
 \begin{itemdecl}
 void open(const char* s, ios_base::openmode mode = ios_base::in);
 \end{itemdecl}
@@ -9584,8 +9396,7 @@ otherwise calls
 \tcode{ios_base::failure}) (\ref{iostate.flags}).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{open}!\idxcode{basic_ifstream}}%
-\indexlibrary{\idxcode{basic_ifstream}!\idxcode{open}}%
+\indexlibrarymember{open}{basic_ifstream}%
 \begin{itemdecl}
 void open(const string& s, ios_base::openmode mode = ios_base::in);
 \end{itemdecl}
@@ -9595,8 +9406,7 @@ void open(const string& s, ios_base::openmode mode = ios_base::in);
 \effects Calls \tcode{open(s.c_str(), mode)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{close}!\idxcode{basic_ifstream}}%
-\indexlibrary{\idxcode{basic_ifstream}!\idxcode{close}}%
+\indexlibrarymember{close}{basic_ifstream}%
 \begin{itemdecl}
 void close();
 \end{itemdecl}
@@ -9742,8 +9552,7 @@ the contained \tcode{basic_filebuf}.
 
 \rSec3[ofstream.assign]{Assign and swap}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{basic_ofstream}}%
-\indexlibrary{\idxcode{basic_ofstream}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{basic_ofstream}%
 \begin{itemdecl}
 basic_ofstream& operator=(basic_ofstream&& rhs);
 \end{itemdecl}
@@ -9757,8 +9566,7 @@ members of \tcode{rhs}.
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{swap}!\idxcode{basic_ofstream}}%
-\indexlibrary{\idxcode{basic_ofstream}!\idxcode{swap}}%
+\indexlibrarymember{swap}{basic_ofstream}%
 \begin{itemdecl}
 void swap(basic_ofstream& rhs);
 \end{itemdecl}
@@ -9771,8 +9579,7 @@ and \tcode{rhs} by calling
 \tcode{sb.swap(rhs.sb)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{swap}!\idxcode{basic_ofstream}}%
-\indexlibrary{\idxcode{basic_ofstream}!\idxcode{swap}}%
+\indexlibrarymember{swap}{basic_ofstream}%
 \begin{itemdecl}
 template <class charT, class traits>
   void swap(basic_ofstream<charT, traits>& x,
@@ -9786,8 +9593,7 @@ template <class charT, class traits>
 
 \rSec3[ofstream.members]{Member functions}
 
-\indexlibrary{\idxcode{rdbuf}!\idxcode{basic_ofstream}}%
-\indexlibrary{\idxcode{basic_ofstream}!\idxcode{rdbuf}}%
+\indexlibrarymember{rdbuf}{basic_ofstream}%
 \begin{itemdecl}
 basic_filebuf<charT, traits>* rdbuf() const;
 \end{itemdecl}
@@ -9798,8 +9604,7 @@ basic_filebuf<charT, traits>* rdbuf() const;
 \tcode{const_cast<basic_filebuf<charT, traits>*>(\&sb)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{is_open}!\idxcode{basic_ofstream}}%
-\indexlibrary{\idxcode{basic_ofstream}!\idxcode{is_open}}%
+\indexlibrarymember{is_open}{basic_ofstream}%
 \begin{itemdecl}
 bool is_open() const;
 \end{itemdecl}
@@ -9810,8 +9615,7 @@ bool is_open() const;
 \tcode{rdbuf()->is_open()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{open}!\idxcode{basic_ofstream}}%
-\indexlibrary{\idxcode{basic_ofstream}!\idxcode{open}}%
+\indexlibrarymember{open}{basic_ofstream}%
 \begin{itemdecl}
 void open(const char* s, ios_base::openmode mode = ios_base::out);
 \end{itemdecl}
@@ -9829,8 +9633,7 @@ otherwise calls
 \tcode{ios_base::failure}) (\ref{iostate.flags}).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{close}!\idxcode{basic_ofstream}}%
-\indexlibrary{\idxcode{basic_ofstream}!\idxcode{close}}%
+\indexlibrarymember{close}{basic_ofstream}%
 \begin{itemdecl}
 void close();
 \end{itemdecl}
@@ -9846,8 +9649,7 @@ and, if that function fails (returns a null pointer), calls
 \tcode{ios_base::failure})~(\ref{iostate.flags}).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{open}!\idxcode{basic_ofstream}}%
-\indexlibrary{\idxcode{basic_ofstream}!\idxcode{open}}%
+\indexlibrarymember{open}{basic_ofstream}%
 \begin{itemdecl}
 void open(const string& s, ios_base::openmode mode = ios_base::out);
 \end{itemdecl}
@@ -9995,8 +9797,7 @@ the contained \tcode{basic_filebuf}.
 
 \rSec3[fstream.assign]{Assign and swap}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{basic_fstream}}%
-\indexlibrary{\idxcode{basic_fstream}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{basic_fstream}%
 \begin{itemdecl}
 basic_fstream& operator=(basic_fstream&& rhs);
 \end{itemdecl}
@@ -10010,8 +9811,7 @@ members of \tcode{rhs}.
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{swap}!\idxcode{basic_fstream}}%
-\indexlibrary{\idxcode{basic_fstream}!\idxcode{swap}}%
+\indexlibrarymember{swap}{basic_fstream}%
 \begin{itemdecl}
 void swap(basic_fstream& rhs);
 \end{itemdecl}
@@ -10024,8 +9824,7 @@ and \tcode{rhs} by calling
 \tcode{sb.swap(rhs.sb)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{swap}!\idxcode{basic_fstream}}%
-\indexlibrary{\idxcode{basic_fstream}!\idxcode{swap}}%
+\indexlibrarymember{swap}{basic_fstream}%
 \begin{itemdecl}
 template <class charT, class traits>
   void swap(basic_fstream<charT, traits>& x,
@@ -10039,8 +9838,7 @@ template <class charT, class traits>
 
 \rSec3[fstream.members]{Member functions}
 
-\indexlibrary{\idxcode{rdbuf}!\idxcode{basic_fstream}}%
-\indexlibrary{\idxcode{basic_fstream}!\idxcode{rdbuf}}%
+\indexlibrarymember{rdbuf}{basic_fstream}%
 \begin{itemdecl}
 basic_filebuf<charT, traits>* rdbuf() const;
 \end{itemdecl}
@@ -10051,8 +9849,7 @@ basic_filebuf<charT, traits>* rdbuf() const;
 \tcode{const_cast<basic_filebuf<charT, traits>*>(\&sb)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{is_open}!\idxcode{basic_fstream}}%
-\indexlibrary{\idxcode{basic_fstream}!\idxcode{is_open}}%
+\indexlibrarymember{is_open}{basic_fstream}%
 \begin{itemdecl}
 bool is_open() const;
 \end{itemdecl}
@@ -10063,8 +9860,7 @@ bool is_open() const;
 \tcode{rdbuf()->is_open()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{open}!\idxcode{basic_fstream}}%
-\indexlibrary{\idxcode{basic_fstream}!\idxcode{open}}%
+\indexlibrarymember{open}{basic_fstream}%
 \begin{itemdecl}
 void open(
   const char* s,
@@ -10083,8 +9879,7 @@ otherwise calls
 \tcode{ios_base::failure})~(\ref{iostate.flags}).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{open}!\idxcode{basic_fstream}}%
-\indexlibrary{\idxcode{basic_fstream}!\idxcode{open}}%
+\indexlibrarymember{open}{basic_fstream}%
 \begin{itemdecl}
 void open(
   const string& s,
@@ -11162,8 +10957,7 @@ converted to their Unicode representation.
 
 \rSec4[path.assign]{\tcode{path} assignments}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{path}}%
-\indexlibrary{\idxcode{path}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{path}%
 \begin{itemdecl}
 path& operator=(const path& p);
 \end{itemdecl}
@@ -11178,8 +10972,7 @@ original value of \tcode{p.pathname}.
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{path}}%
-\indexlibrary{\idxcode{path}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{path}%
 \begin{itemdecl}
 path& operator=(path&& p) noexcept;
 \end{itemdecl}
@@ -11196,10 +10989,8 @@ valid but unspecified state.
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{path}}%
-\indexlibrary{\idxcode{path}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{assign}!\idxcode{path}}%
-\indexlibrary{\idxcode{path}!\idxcode{assign}}%
+\indexlibrarymember{operator=}{path}%
+\indexlibrarymember{assign}{path}%
 \begin{itemdecl}
 path& operator=(string_type&& source);
 path& assign(string_type&& source);
@@ -11214,10 +11005,8 @@ path& assign(string_type&& source);
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{path}}%
-\indexlibrary{\idxcode{path}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{assign}!\idxcode{path}}%
-\indexlibrary{\idxcode{path}!\idxcode{assign}}%
+\indexlibrarymember{operator=}{path}%
+\indexlibrarymember{assign}{path}%
 \begin{itemdecl}
 template <class Source>
   path& operator=(const Source& source);
@@ -11243,8 +11032,7 @@ converting format and encoding if required (\ref{path.cvt}).
 The append operations use \tcode{operator/=} to denote their semantic effect of appending
 \grammarterm{preferred-separator} when needed.
 
-\indexlibrary{\idxcode{operator/=}!\idxcode{path}}%
-\indexlibrary{\idxcode{path}!\idxcode{operator/=}}%
+\indexlibrarymember{operator/=}{path}%
 \begin{itemdecl}
 path& operator/=(const path& p);
 \end{itemdecl}
@@ -11266,8 +11054,7 @@ Then appends \tcode{p.native()} to \tcode{pathname}.
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{append}}%
-\indexlibrary{\idxcode{append}!\idxcode{path}}%
+\indexlibrarymember{path}{append}%
 \begin{itemdecl}
 template <class Source>
   path& operator/=(const Source& source);
@@ -11297,10 +11084,8 @@ Then appends the effective range of \tcode{source} (\ref{path.req})
 
 \rSec4[path.concat]{\tcode{path} concatenation}
 
-\indexlibrary{\idxcode{operator+=}!\idxcode{path}}%
-\indexlibrary{\idxcode{path}!\idxcode{operator+=}}%
-\indexlibrary{\idxcode{concat}!\idxcode{path}}%
-\indexlibrary{\idxcode{path}!\idxcode{concat}}%
+\indexlibrarymember{operator+=}{path}%
+\indexlibrarymember{concat}{path}%
 \begin{itemdecl}
 path& operator+=(const path& x);
 path& operator+=(const string_type& x);
@@ -11340,8 +11125,7 @@ If the value type of \tcode{\textit{effective-argument}} would not be \tcode{pat
 
 \rSec4[path.modifiers]{\tcode{path} modifiers}
 
-\indexlibrary{\idxcode{path}!\idxcode{clear}}%
-\indexlibrary{\idxcode{clear}!\idxcode{path}}%
+\indexlibrarymember{path}{clear}%
 \begin{itemdecl}
 void clear() noexcept;
 \end{itemdecl}
@@ -11351,8 +11135,7 @@ void clear() noexcept;
 \postcondition \tcode{empty() == true}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{make_preferred}}%
-\indexlibrary{\idxcode{make_preferred}!\idxcode{path}}%
+\indexlibrarymember{path}{make_preferred}%
 \begin{itemdecl}
 path& make_preferred();
 \end{itemdecl}
@@ -11388,8 +11171,7 @@ output is:
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{remove_filename}}%
-\indexlibrary{\idxcode{remove_filename}!\idxcode{path}}%
+\indexlibrarymember{path}{remove_filename}%
 \begin{itemdecl}
 path& remove_filename();
 \end{itemdecl}
@@ -11410,8 +11192,7 @@ std::cout << path("/").remove_filename();     // outputs \tcode{""}
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{replace_filename}}%
-\indexlibrary{\idxcode{replace_filename}!\idxcode{path}}%
+\indexlibrarymember{path}{replace_filename}%
 \begin{itemdecl}
 path& replace_filename(const path& replacement);
 \end{itemdecl}
@@ -11436,8 +11217,7 @@ std::cout << path("/").replace_filename("bar");     // outputs \tcode{"bar"}
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{replace_extension}}%
-\indexlibrary{\idxcode{replace_extension}!\idxcode{path}}%
+\indexlibrarymember{path}{replace_extension}%
 \begin{itemdecl}
 path& replace_extension(const path& replacement = path());
 \end{itemdecl}
@@ -11458,8 +11238,7 @@ path& replace_extension(const path& replacement = path());
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{path}}%
+\indexlibrarymember{path}{swap}%
 \begin{itemdecl}
 void swap(path& rhs) noexcept;
 \end{itemdecl}
@@ -11478,8 +11257,7 @@ void swap(path& rhs) noexcept;
 \pnum
 The string returned by all native format observers is in the native pathname format~(\ref{fs.def.native}).
 
-\indexlibrary{\idxcode{path}!\idxcode{native}}%
-\indexlibrary{\idxcode{native}!\idxcode{path}}%
+\indexlibrarymember{path}{native}%
 \begin{itemdecl}
 const string_type& native() const noexcept;
 \end{itemdecl}
@@ -11489,8 +11267,7 @@ const string_type& native() const noexcept;
 \returns \tcode{pathname}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{c_str}}%
-\indexlibrary{\idxcode{c_str}!\idxcode{path}}%
+\indexlibrarymember{path}{c_str}%
 \begin{itemdecl}
 const value_type* c_str() const noexcept;
 \end{itemdecl}
@@ -11658,8 +11435,7 @@ int compare(const value_type* s) const
 
 \rSec4[path.decompose]{\tcode{path} decomposition}
 
-\indexlibrary{\idxcode{path}!\idxcode{root_name}}%
-\indexlibrary{\idxcode{root_name}!\idxcode{path}}%
+\indexlibrarymember{path}{root_name}%
 \begin{itemdecl}
 path root_name() const;
 \end{itemdecl}
@@ -11669,8 +11445,7 @@ path root_name() const;
 \returns \grammarterm{root-name}, if \tcode{pathname} includes \grammarterm{root-name}, otherwise \tcode{path()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{root_directory}}%
-\indexlibrary{\idxcode{root_directory}!\idxcode{path}}%
+\indexlibrarymember{path}{root_directory}%
 \begin{itemdecl}
 path root_directory() const;
 \end{itemdecl}
@@ -11680,8 +11455,7 @@ path root_directory() const;
 \returns \grammarterm{root-directory}, if \tcode{pathname} includes \grammarterm{root-directory}, otherwise \tcode{path()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{root_path}}%
-\indexlibrary{\idxcode{root_path}!\idxcode{path}}%
+\indexlibrarymember{path}{root_path}%
 \begin{itemdecl}
 path root_path() const;
 \end{itemdecl}
@@ -11691,8 +11465,7 @@ path root_path() const;
 \returns \tcode{root_name() / root_directory()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{relative_path}}%
-\indexlibrary{\idxcode{relative_path}!\idxcode{path}}%
+\indexlibrarymember{path}{relative_path}%
 \begin{itemdecl}
 path relative_path() const;
 \end{itemdecl}
@@ -11703,8 +11476,7 @@ path relative_path() const;
 with the first \grammarterm{filename} after \grammarterm{root-path}. Otherwise, \tcode{path()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{parent_path}}%
-\indexlibrary{\idxcode{parent_path}!\idxcode{path}}%
+\indexlibrarymember{path}{parent_path}%
 \begin{itemdecl}
 path parent_path() const;
 \end{itemdecl}
@@ -11717,8 +11489,7 @@ where \tcode{\textit{pp}} is constructed as if by
   \range{begin()}{--end()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{filename}}%
-\indexlibrary{\idxcode{filename}!\idxcode{path}}%
+\indexlibrarymember{path}{filename}%
 \begin{itemdecl}
 path filename() const;
 \end{itemdecl}
@@ -11738,8 +11509,7 @@ std::cout << path("..").filename();           // outputs ".."
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{stem}}%
-\indexlibrary{\idxcode{stem}!\idxcode{path}}%
+\indexlibrarymember{path}{stem}%
 \begin{itemdecl}
 path stem() const;
 \end{itemdecl}
@@ -11766,8 +11536,7 @@ for (; !p.extension().empty(); p = p.stem())
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{extension}}%
-\indexlibrary{\idxcode{extension}!\idxcode{path}}%
+\indexlibrarymember{path}{extension}%
 \begin{itemdecl}
 path extension() const;
 \end{itemdecl}
@@ -11800,8 +11569,7 @@ std::cout << path("/foo/bar.txt").extension(); // outputs ".txt"
 
 \rSec4[path.query]{\tcode{path} query}
 
-\indexlibrary{\idxcode{path}!\idxcode{empty}}%
-\indexlibrary{\idxcode{empty}!\idxcode{path}}%
+\indexlibrarymember{path}{empty}%
 \begin{itemdecl}
 bool empty() const noexcept;
 \end{itemdecl}
@@ -11811,8 +11579,7 @@ bool empty() const noexcept;
 \returns \tcode{pathname.empty()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{has_root_path}}%
-\indexlibrary{\idxcode{has_root_path}!\idxcode{path}}%
+\indexlibrarymember{path}{has_root_path}%
 \begin{itemdecl}
 bool has_root_path() const;
 \end{itemdecl}
@@ -11822,8 +11589,7 @@ bool has_root_path() const;
 \returns \tcode{!root_path().empty()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{has_root_name}}%
-\indexlibrary{\idxcode{has_root_name}!\idxcode{path}}%
+\indexlibrarymember{path}{has_root_name}%
 \begin{itemdecl}
 bool has_root_name() const;
 \end{itemdecl}
@@ -11833,8 +11599,7 @@ bool has_root_name() const;
 \returns \tcode{!root_name().empty()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{has_root_directory}}%
-\indexlibrary{\idxcode{has_root_directory}!\idxcode{path}}%
+\indexlibrarymember{path}{has_root_directory}%
 \begin{itemdecl}
 bool has_root_directory() const;
 \end{itemdecl}
@@ -11844,8 +11609,7 @@ bool has_root_directory() const;
 \returns \tcode{!root_directory().empty()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{has_relative_path}}%
-\indexlibrary{\idxcode{has_relative_path}!\idxcode{path}}%
+\indexlibrarymember{path}{has_relative_path}%
 \begin{itemdecl}
 bool has_relative_path() const;
 \end{itemdecl}
@@ -11855,8 +11619,7 @@ bool has_relative_path() const;
 \returns \tcode{!relative_path().empty()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{has_parent_path}}%
-\indexlibrary{\idxcode{has_parent_path}!\idxcode{path}}%
+\indexlibrarymember{path}{has_parent_path}%
 \begin{itemdecl}
 bool has_parent_path() const;
 \end{itemdecl}
@@ -11866,8 +11629,7 @@ bool has_parent_path() const;
 \returns \tcode{!parent_path().empty()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{has_filename}}%
-\indexlibrary{\idxcode{has_filename}!\idxcode{path}}%
+\indexlibrarymember{path}{has_filename}%
 \begin{itemdecl}
 bool has_filename() const;
 \end{itemdecl}
@@ -11877,8 +11639,7 @@ bool has_filename() const;
 \returns \tcode{!filename().empty()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{has_stem}}%
-\indexlibrary{\idxcode{has_stem}!\idxcode{path}}%
+\indexlibrarymember{path}{has_stem}%
 \begin{itemdecl}
 bool has_stem() const;
 \end{itemdecl}
@@ -11888,8 +11649,7 @@ bool has_stem() const;
 \returns \tcode{!stem().empty()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{has_extension}}%
-\indexlibrary{\idxcode{has_extension}!\idxcode{path}}%
+\indexlibrarymember{path}{has_extension}%
 \begin{itemdecl}
 bool has_extension() const;
 \end{itemdecl}
@@ -11899,8 +11659,7 @@ bool has_extension() const;
 \returns \tcode{!extension().empty()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{is_absolute}}%
-\indexlibrary{\idxcode{is_absolute}!\idxcode{path}}%
+\indexlibrarymember{path}{is_absolute}%
 \begin{itemdecl}
 bool is_absolute() const;
 \end{itemdecl}
@@ -11916,8 +11675,7 @@ bool is_absolute() const;
 operating systems. \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{is_relative}}%
-\indexlibrary{\idxcode{is_relative}!\idxcode{path}}%
+\indexlibrarymember{path}{is_relative}%
 \begin{itemdecl}
 bool is_relative() const;
 \end{itemdecl}
@@ -11929,8 +11687,7 @@ bool is_relative() const;
 
 \rSec4[path.gen]{\tcode{path} generation}
 
-\indexlibrary{\idxcode{path}!\idxcode{lexically_normal}}%
-\indexlibrary{\idxcode{lexically_normal}!\idxcode{path}}%
+\indexlibrarymember{path}{lexically_normal}%
 \begin{itemdecl}
 path lexically_normal() const;
 \end{itemdecl}
@@ -11955,8 +11712,7 @@ but that does not affect \tcode{path} equality.
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{lexically_relative}}%
-\indexlibrary{\idxcode{lexically_relative}!\idxcode{path}}%
+\indexlibrarymember{path}{lexically_relative}%
 \begin{itemdecl}
 path lexically_relative(const path& base) const;
 \end{itemdecl}
@@ -12016,8 +11772,7 @@ but that does not affect \tcode{path} equality.
   \tcode{*this}, \tcode{base}, or both. \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{lexically_proximate}}%
-\indexlibrary{\idxcode{lexically_proximate}!\idxcode{path}}%
+\indexlibrarymember{path}{lexically_proximate}%
 \begin{itemdecl}
 path lexically_proximate(const path& base) const;
 \end{itemdecl}
@@ -12075,8 +11830,7 @@ characters are present.
 \pnum
 The backward traversal order is the reverse of forward traversal.
 
-\indexlibrary{\idxcode{begin}!\idxcode{path}}%
-\indexlibrary{\idxcode{path}!\idxcode{begin}}%
+\indexlibrarymember{begin}{path}%
 \begin{itemdecl}
 iterator begin() const;
 \end{itemdecl}
@@ -12087,8 +11841,7 @@ iterator begin() const;
 list above. If no elements are present, the end iterator.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{end}!\idxcode{path}}%
-\indexlibrary{\idxcode{path}!\idxcode{end}}%
+\indexlibrarymember{end}{path}%
 \begin{itemdecl}
 iterator end() const;
 \end{itemdecl}
@@ -12121,8 +11874,7 @@ size_t hash_value (const path& p) noexcept;
   for two paths, \tcode{p1 == p2} then \tcode{hash_value(p1) == hash_value(p2)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{path}}%
-\indexlibrary{\idxcode{path}!\idxcode{operator<}}%
+\indexlibrarymember{operator<}{path}%
 \begin{itemdecl}
 bool operator< (const path& lhs, const path& rhs) noexcept;
 \end{itemdecl}
@@ -12132,8 +11884,7 @@ bool operator< (const path& lhs, const path& rhs) noexcept;
 \returns \tcode{lhs.compare(rhs) < 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{path}}%
-\indexlibrary{\idxcode{path}!\idxcode{operator<=}}%
+\indexlibrarymember{operator<=}{path}%
 \begin{itemdecl}
 bool operator<=(const path& lhs, const path& rhs) noexcept;
 \end{itemdecl}
@@ -12143,8 +11894,7 @@ bool operator<=(const path& lhs, const path& rhs) noexcept;
 \returns \tcode{!(rhs < lhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>}!\idxcode{path}}%
-\indexlibrary{\idxcode{path}!\idxcode{operator>}}%
+\indexlibrarymember{operator>}{path}%
 \begin{itemdecl}
 bool operator> (const path& lhs, const path& rhs) noexcept;
 \end{itemdecl}
@@ -12154,8 +11904,7 @@ bool operator> (const path& lhs, const path& rhs) noexcept;
 \returns \tcode{rhs < lhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{path}}%
-\indexlibrary{\idxcode{path}!\idxcode{operator>=}}%
+\indexlibrarymember{operator>=}{path}%
 \begin{itemdecl}
 bool operator>=(const path& lhs, const path& rhs) noexcept;
 \end{itemdecl}
@@ -12165,8 +11914,7 @@ bool operator>=(const path& lhs, const path& rhs) noexcept;
 \returns \tcode{!(lhs < rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{path}}%
-\indexlibrary{\idxcode{path}!\idxcode{operator==}}%
+\indexlibrarymember{operator==}{path}%
 \begin{itemdecl}
 bool operator==(const path& lhs, const path& rhs) noexcept;
 \end{itemdecl}
@@ -12204,8 +11952,7 @@ bool operator!=(const path& lhs, const path& rhs) noexcept;
 \returns \tcode{!(lhs == rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator/}!\idxcode{path}}%
-\indexlibrary{\idxcode{path}!\idxcode{operator/}}%
+\indexlibrarymember{operator/}{path}%
 \begin{itemdecl}
 path operator/ (const path& lhs, const path& rhs);
 \end{itemdecl}
@@ -12217,8 +11964,7 @@ path operator/ (const path& lhs, const path& rhs);
 
 \rSec4[path.io]{\tcode{path} inserter and extractor}
 
-\indexlibrary{\idxcode{operator\shl}!\idxcode{path}}%
-\indexlibrary{\idxcode{path}!\idxcode{operator\shl}}%
+\indexlibrarymember{operator\shl}{path}%
 \begin{itemdecl}
 template <class charT, class traits>
   basic_ostream<charT, traits>&
@@ -12234,8 +11980,7 @@ template <class charT, class traits>
 \returns \tcode{os}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shr}!\idxcode{path}}%
-\indexlibrary{\idxcode{path}!\idxcode{operator\shr}}%
+\indexlibrarymember{operator\shr}{path}%
 \begin{itemdecl}
 template <class charT, class traits>
   basic_istream<charT, traits>&
@@ -12418,8 +12163,7 @@ Table~\ref{tab:filesystem_error.3}.
 \end{floattable}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{filesystem_error}!\idxcode{path1}}%
-\indexlibrary{\idxcode{path1}!\idxcode{filesystem_error}}%
+\indexlibrarymember{filesystem_error}{path1}%
 \begin{itemdecl}
 const path& path1() const noexcept;
 \end{itemdecl}
@@ -12430,8 +12174,7 @@ const path& path1() const noexcept;
   constructor, or, if none, an empty path.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{filesystem_error}!\idxcode{path2}}%
-\indexlibrary{\idxcode{path2}!\idxcode{filesystem_error}}%
+\indexlibrarymember{filesystem_error}{path2}%
 \begin{itemdecl}
 const path& path2() const noexcept;
 \end{itemdecl}
@@ -12442,8 +12185,7 @@ const path& path2() const noexcept;
   constructor, or, if none, an empty path.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{filesystem_error}!\idxcode{what}}%
-\indexlibrary{\idxcode{what}!\idxcode{filesystem_error}}%
+\indexlibrarymember{filesystem_error}{what}%
 \begin{itemdecl}
 const char* what() const noexcept;
 \end{itemdecl}
@@ -12702,8 +12444,7 @@ explicit file_status(file_type ft, perms prms = perms::unknown) noexcept;
 
 \rSec3[file_status.obs]{\tcode{file_status} observers}
 
-\indexlibrary{\idxcode{file_status}!\idxcode{type}}%
-\indexlibrary{\idxcode{type}!\idxcode{file_status}}%
+\indexlibrarymember{file_status}{type}%
 \begin{itemdecl}
 file_type type() const noexcept;
 \end{itemdecl}
@@ -12714,8 +12455,7 @@ file_type type() const noexcept;
   \tcode{operator=}, or \tcode{type(file_type)} function.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{file_status}!\idxcode{permissions}}%
-\indexlibrary{\idxcode{permissions}!\idxcode{file_status}}%
+\indexlibrarymember{file_status}{permissions}%
 \begin{itemdecl}
 \begin{itemdecl}
 perms permissions() const noexcept;
@@ -12729,8 +12469,7 @@ perms permissions() const noexcept;
 
 \rSec3[file_status.mods]{\tcode{file_status} modifiers}
 
-\indexlibrary{\idxcode{file_status}!\idxcode{type}}%
-\indexlibrary{\idxcode{type}!\idxcode{file_status}}%
+\indexlibrarymember{file_status}{type}%
 \begin{itemdecl}
 void type(file_type ft) noexcept;
 \end{itemdecl}
@@ -12740,8 +12479,7 @@ void type(file_type ft) noexcept;
 \postconditions \tcode{type() == ft}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{file_status}!\idxcode{permissions}}%
-\indexlibrary{\idxcode{permissions}!\idxcode{file_status}}%
+\indexlibrarymember{file_status}{permissions}%
 \begin{itemdecl}
 void permissions(perms prms) noexcept;
 \end{itemdecl}
@@ -12812,8 +12550,7 @@ explicit directory_entry(const path& p);
 
 \rSec3[directory_entry.mods]{\tcode{directory_entry} modifiers}
 
-\indexlibrary{\idxcode{directory_entry}!\idxcode{assign}}%
-\indexlibrary{\idxcode{assign}!\idxcode{directory_entry}}%
+\indexlibrarymember{directory_entry}{assign}%
 \begin{itemdecl}
 void assign(const path& p);
 \end{itemdecl}
@@ -12823,8 +12560,7 @@ void assign(const path& p);
 \postcondition \tcode{path() == p}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{directory_entry}!\idxcode{replace_filename}}%
-\indexlibrary{\idxcode{replace_filename}!\idxcode{directory_entry}}%
+\indexlibrarymember{directory_entry}{replace_filename}%
 \begin{itemdecl}
 void replace_filename(const path& p);
 \end{itemdecl}
@@ -12838,8 +12574,7 @@ void replace_filename(const path& p);
 
 \rSec3[directory_entry.obs]{\tcode{directory_entry} observers}
 
-\indexlibrary{\idxcode{directory_entry}!\idxcode{path}}%
-\indexlibrary{\idxcode{path}!\idxcode{directory_entry}}%
+\indexlibrarymember{directory_entry}{path}%
 \begin{itemdecl}
 const path& path() const noexcept;
 operator const path&() const noexcept;
@@ -12850,8 +12585,7 @@ operator const path&() const noexcept;
 \returns \tcode{pathobject}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{directory_entry}!\idxcode{status}}%
-\indexlibrary{\idxcode{status}!\idxcode{directory_entry}}%
+\indexlibrarymember{directory_entry}{status}%
 \begin{itemdecl}
 file_status status() const;
 file_status status(error_code& ec) const noexcept;
@@ -12865,8 +12599,7 @@ file_status status(error_code& ec) const noexcept;
 \throws As specified in Error reporting~(\ref{fs.err.report}).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{directory_entry}!\idxcode{symlink_status}}%
-\indexlibrary{\idxcode{symlink_status}!\idxcode{directory_entry}}%
+\indexlibrarymember{directory_entry}{symlink_status}%
 \begin{itemdecl}
 file_status  symlink_status() const;
 file_status  symlink_status(error_code& ec) const noexcept;
@@ -12880,8 +12613,7 @@ file_status  symlink_status(error_code& ec) const noexcept;
 \throws As specified in Error reporting~(\ref{fs.err.report}).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{directory_entry}!\idxcode{operator==}}%
-\indexlibrary{\idxcode{operator==}!\idxcode{directory_entry}}%
+\indexlibrarymember{directory_entry}{operator==}%
 \begin{itemdecl}
 bool operator==(const directory_entry& rhs) const noexcept;
 \end{itemdecl}
@@ -12891,8 +12623,7 @@ bool operator==(const directory_entry& rhs) const noexcept;
 \returns \tcode{pathobject == rhs.pathobject}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{directory_entry}!\idxcode{operator"!=}}%
-\indexlibrary{\idxcode{operator"!=}!\idxcode{directory_entry}}%
+\indexlibrarymember{directory_entry}{operator"!=}%
 \begin{itemdecl}
 bool operator!=(const directory_entry& rhs) const noexcept;
 \end{itemdecl}
@@ -12902,8 +12633,7 @@ bool operator!=(const directory_entry& rhs) const noexcept;
 \returns \tcode{pathobject != rhs.pathobject}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{directory_entry}!\idxcode{operator<}}%
-\indexlibrary{\idxcode{operator<}!\idxcode{directory_entry}}%
+\indexlibrarymember{directory_entry}{operator<}%
 \begin{itemdecl}
 bool operator< (const directory_entry& rhs) const noexcept;
 \end{itemdecl}
@@ -12913,8 +12643,7 @@ bool operator< (const directory_entry& rhs) const noexcept;
 \returns \tcode{pathobject < rhs.pathobject}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{directory_entry}!\idxcode{operator<=}}%
-\indexlibrary{\idxcode{operator<=}!\idxcode{directory_entry}}%
+\indexlibrarymember{directory_entry}{operator<=}%
 \begin{itemdecl}
 bool operator<=(const directory_entry& rhs) const noexcept;
 \end{itemdecl}
@@ -12924,8 +12653,7 @@ bool operator<=(const directory_entry& rhs) const noexcept;
 \returns \tcode{pathobject <= rhs.pathobject}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{directory_entry}!\idxcode{operator>}}%
-\indexlibrary{\idxcode{operator>}!\idxcode{directory_entry}}%
+\indexlibrarymember{directory_entry}{operator>}%
 \begin{itemdecl}
 bool operator> (const directory_entry& rhs) const noexcept;
 \end{itemdecl}
@@ -12935,8 +12663,7 @@ bool operator> (const directory_entry& rhs) const noexcept;
 \returns \tcode{pathobject > rhs.pathobject}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{directory_entry}!\idxcode{operator>=}}%
-\indexlibrary{\idxcode{operator>=}!\idxcode{directory_entry}}%
+\indexlibrarymember{directory_entry}{operator>=}%
 \begin{itemdecl}
 bool operator>=(const directory_entry& rhs) const noexcept;
 \end{itemdecl}
@@ -13091,8 +12818,7 @@ directory_iterator(directory_iterator&& rhs) noexcept;
 \postconditions \tcode{*this} has the original value of \tcode{rhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{directory_iterator}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{directory_iterator}}%
+\indexlibrarymember{directory_iterator}{operator=}%
 \begin{itemdecl}
 directory_iterator& operator=(const directory_iterator& rhs);
 directory_iterator& operator=(directory_iterator&& rhs) noexcept;
@@ -13110,10 +12836,8 @@ directory_iterator& operator=(directory_iterator&& rhs) noexcept;
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{directory_iterator}!\idxcode{increment}}%
-\indexlibrary{\idxcode{increment}!\idxcode{directory_iterator}}%
-\indexlibrary{\idxcode{directory_iterator}!\idxcode{operator++}}%
-\indexlibrary{\idxcode{operator++}!\idxcode{directory_iterator}}%
+\indexlibrarymember{directory_iterator}{increment}%
+\indexlibrarymember{directory_iterator}{operator++}%
 \begin{itemdecl}
 directory_iterator& operator++();
 directory_iterator& increment(error_code& ec) noexcept;
@@ -13313,8 +13037,7 @@ recursive_directory_iterator(recursive_directory_iterator&& rhs) noexcept;
   \tcode{rhs.recursion_pending()}, respectively, had before the function call.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{recursive_directory_iterator}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{recursive_directory_iterator}}%
+\indexlibrarymember{recursive_directory_iterator}{operator=}%
 \begin{itemdecl}
 recursive_directory_iterator& operator=(const recursive_directory_iterator& rhs);
 \end{itemdecl}
@@ -13336,8 +13059,7 @@ recursive_directory_iterator& operator=(const recursive_directory_iterator& rhs)
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{recursive_directory_iterator}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{recursive_directory_iterator}}%
+\indexlibrarymember{recursive_directory_iterator}{operator=}%
 \begin{itemdecl}
 recursive_directory_iterator& operator=(recursive_directory_iterator&& rhs) noexcept;
 \end{itemdecl}
@@ -13356,8 +13078,7 @@ and \tcode{this->recursion_pending()} return the values that \tcode{rhs.options(
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{recursive_directory_iterator}!\idxcode{options}}%
-\indexlibrary{\idxcode{options}!\idxcode{recursive_directory_iterator}}%
+\indexlibrarymember{recursive_directory_iterator}{options}%
 \begin{itemdecl}
 directory_options options() const;
 \end{itemdecl}
@@ -13371,8 +13092,7 @@ if present, otherwise \tcode{directory_options::none}.
 \throws Nothing.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{recursive_directory_iterator}!\idxcode{depth}}%
-\indexlibrary{\idxcode{depth}!\idxcode{recursive_directory_iterator}}%
+\indexlibrarymember{recursive_directory_iterator}{depth}%
 \begin{itemdecl}
 int depth() const;
 \end{itemdecl}
@@ -13387,8 +13107,7 @@ int depth() const;
 \throws Nothing.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{recursive_directory_iterator}!\idxcode{recursion_pending}}%
-\indexlibrary{\idxcode{recursion_pending}!\idxcode{recursive_directory_iterator}}%
+\indexlibrarymember{recursive_directory_iterator}{recursion_pending}%
 \begin{itemdecl}
 bool recursion_pending() const;
 \end{itemdecl}
@@ -13403,10 +13122,8 @@ bool recursion_pending() const;
 \throws Nothing.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{recursive_directory_iterator}!\idxcode{increment}}%
-\indexlibrary{\idxcode{increment}!\idxcode{recursive_directory_iterator}}%
-\indexlibrary{\idxcode{recursive_directory_iterator}!\idxcode{operator++}}%
-\indexlibrary{\idxcode{operator++}!\idxcode{recursive_directory_iterator}}%
+\indexlibrarymember{recursive_directory_iterator}{increment}%
+\indexlibrarymember{recursive_directory_iterator}{operator++}%
 \begin{itemdecl}
 recursive_directory_iterator& operator++();
 recursive_directory_iterator& increment(error_code& ec) noexcept;
@@ -13445,8 +13162,7 @@ treated as an empty directory and no error is reported.
 \throws As specified in Error reporting~(\ref{fs.err.report}).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{recursive_directory_iterator}!\idxcode{pop}}%
-\indexlibrary{\idxcode{pop}!\idxcode{recursive_directory_iterator}}%
+\indexlibrarymember{recursive_directory_iterator}{pop}%
 \begin{itemdecl}
 void pop();
 void pop(error_code& ec);
@@ -13462,8 +13178,7 @@ void pop(error_code& ec);
 \throws As specified in Error reporting~(\ref{fs.err.report}).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{recursive_directory_iterator}!\idxcode{disable_recursion_pending}}%
-\indexlibrary{\idxcode{disable_recursion_pending}!\idxcode{recursive_directory_iterator}}%
+\indexlibrarymember{recursive_directory_iterator}{disable_recursion_pending}%
 \begin{itemdecl}
 void disable_recursion_pending();
 \end{itemdecl}

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1337,8 +1337,7 @@ Assigns \tcode{u.base()} to current.
 
 \rSec4[reverse.iter.conv]{Conversion}
 
-\indexlibrary{\idxcode{base}!\idxcode{reverse_iterator}}%
-\indexlibrary{\idxcode{reverse_iterator}!\idxcode{base}}%
+\indexlibrarymember{base}{reverse_iterator}%
 \begin{itemdecl}
 constexpr Iterator base() const;          // explicit
 \end{itemdecl}
@@ -1396,8 +1395,7 @@ As if by: \tcode{\dcr current;}
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator++}!\idxcode{reverse_iterator}}%
-\indexlibrary{\idxcode{reverse_iterator}!\idxcode{operator++}}%
+\indexlibrarymember{operator++}{reverse_iterator}%
 \begin{itemdecl}
 constexpr reverse_iterator operator++(int);
 \end{itemdecl}
@@ -1430,8 +1428,7 @@ As if by \tcode{++current}.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\dcr}!\idxcode{reverse_iterator}}%
-\indexlibrary{\idxcode{reverse_iterator}!\idxcode{operator\dcr}}%
+\indexlibrarymember{operator\dcr}{reverse_iterator}%
 \begin{itemdecl}
 constexpr reverse_iterator operator--(int);
 \end{itemdecl}
@@ -2252,8 +2249,7 @@ template <class U> constexpr move_iterator(const move_iterator<U>& u);
 
 \rSec4[move.iter.op=]{\tcode{move_iterator::operator=}}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{move_iterator}}%
-\indexlibrary{\idxcode{move_iterator}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{move_iterator}%
 \begin{itemdecl}
 template <class U> constexpr move_iterator& operator=(const move_iterator<U>& u);
 \end{itemdecl}
@@ -2270,8 +2266,7 @@ template <class U> constexpr move_iterator& operator=(const move_iterator<U>& u)
 
 \rSec4[move.iter.op.conv]{\tcode{move_iterator} conversion}
 
-\indexlibrary{\idxcode{base}!\idxcode{move_iterator}}%
-\indexlibrary{\idxcode{move_iterator}!\idxcode{base}}%
+\indexlibrarymember{base}{move_iterator}%
 \begin{itemdecl}
 constexpr Iterator base() const;
 \end{itemdecl}
@@ -2283,8 +2278,7 @@ constexpr Iterator base() const;
 
 \rSec4[move.iter.op.star]{\tcode{move_iterator::operator*}}
 
-\indexlibrary{\idxcode{operator*}!\idxcode{move_iterator}}%
-\indexlibrary{\idxcode{move_iterator}!\idxcode{operator*}}%
+\indexlibrarymember{operator*}{move_iterator}%
 \begin{itemdecl}
 constexpr reference operator*() const;
 \end{itemdecl}
@@ -2296,8 +2290,7 @@ constexpr reference operator*() const;
 
 \rSec4[move.iter.op.ref]{\tcode{move_iterator::operator->}}
 
-\indexlibrary{\idxcode{operator->}!\idxcode{move_iterator}}%
-\indexlibrary{\idxcode{move_iterator}!\idxcode{operator->}}%
+\indexlibrarymember{operator->}{move_iterator}%
 \begin{itemdecl}
 constexpr pointer operator->() const;
 \end{itemdecl}
@@ -2309,8 +2302,7 @@ constexpr pointer operator->() const;
 
 \rSec4[move.iter.op.incr]{\tcode{move_iterator::operator++}}
 
-\indexlibrary{\idxcode{operator++}!\idxcode{move_iterator}}%
-\indexlibrary{\idxcode{move_iterator}!\idxcode{operator++}}%
+\indexlibrarymember{operator++}{move_iterator}%
 \begin{itemdecl}
 constexpr move_iterator& operator++();
 \end{itemdecl}
@@ -2323,8 +2315,7 @@ constexpr move_iterator& operator++();
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator++}!\idxcode{move_iterator}}%
-\indexlibrary{\idxcode{move_iterator}!\idxcode{operator++}}%
+\indexlibrarymember{operator++}{move_iterator}%
 \begin{itemdecl}
 constexpr move_iterator operator++(int);
 \end{itemdecl}
@@ -2342,8 +2333,7 @@ return tmp;
 
 \rSec4[move.iter.op.decr]{\tcode{move_iterator::operator-{-}}}
 
-\indexlibrary{\idxcode{operator\dcr}!\idxcode{move_iterator}}%
-\indexlibrary{\idxcode{move_iterator}!\idxcode{operator\dcr}}%
+\indexlibrarymember{operator\dcr}{move_iterator}%
 \begin{itemdecl}
 constexpr move_iterator& operator--();
 \end{itemdecl}
@@ -2356,8 +2346,7 @@ constexpr move_iterator& operator--();
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\dcr}!\idxcode{move_iterator}}%
-\indexlibrary{\idxcode{move_iterator}!\idxcode{operator\dcr}}%
+\indexlibrarymember{operator\dcr}{move_iterator}%
 \begin{itemdecl}
 constexpr move_iterator operator--(int);
 \end{itemdecl}
@@ -2375,8 +2364,7 @@ return tmp;
 
 \rSec4[move.iter.op.+]{\tcode{move_iterator::operator+}}
 
-\indexlibrary{\idxcode{operator+}!\idxcode{move_iterator}}%
-\indexlibrary{\idxcode{move_iterator}!\idxcode{operator+}}%
+\indexlibrarymember{operator+}{move_iterator}%
 \begin{itemdecl}
 constexpr move_iterator operator+(difference_type n) const;
 \end{itemdecl}
@@ -2388,8 +2376,7 @@ constexpr move_iterator operator+(difference_type n) const;
 
 \rSec4[move.iter.op.+=]{\tcode{move_iterator::operator+=}}
 
-\indexlibrary{\idxcode{operator+=}!\idxcode{move_iterator}}%
-\indexlibrary{\idxcode{move_iterator}!\idxcode{operator+=}}%
+\indexlibrarymember{operator+=}{move_iterator}%
 \begin{itemdecl}
 constexpr move_iterator& operator+=(difference_type n);
 \end{itemdecl}
@@ -2404,8 +2391,7 @@ constexpr move_iterator& operator+=(difference_type n);
 
 \rSec4[move.iter.op.-]{\tcode{move_iterator::operator-}}
 
-\indexlibrary{\idxcode{operator-}!\idxcode{move_iterator}}%
-\indexlibrary{\idxcode{move_iterator}!\idxcode{operator-}}%
+\indexlibrarymember{operator-}{move_iterator}%
 \begin{itemdecl}
 constexpr move_iterator operator-(difference_type n) const;
 \end{itemdecl}
@@ -2417,8 +2403,7 @@ constexpr move_iterator operator-(difference_type n) const;
 
 \rSec4[move.iter.op.-=]{\tcode{move_iterator::operator-=}}
 
-\indexlibrary{\idxcode{operator-=}!\idxcode{move_iterator}}%
-\indexlibrary{\idxcode{move_iterator}!\idxcode{operator-=}}%
+\indexlibrarymember{operator-=}{move_iterator}%
 \begin{itemdecl}
 constexpr move_iterator& operator-=(difference_type n);
 \end{itemdecl}
@@ -2433,8 +2418,7 @@ constexpr move_iterator& operator-=(difference_type n);
 
 \rSec4[move.iter.op.index]{\tcode{move_iterator::operator[]}}
 
-\indexlibrary{\idxcode{operator[]}!\idxcode{move_iterator}}%
-\indexlibrary{\idxcode{move_iterator}!\idxcode{operator[]}}%
+\indexlibrarymember{operator[]}{move_iterator}%
 \begin{itemdecl}
 constexpr @\unspec@ operator[](difference_type n) const;
 \end{itemdecl}
@@ -2446,8 +2430,7 @@ constexpr @\unspec@ operator[](difference_type n) const;
 
 \rSec4[move.iter.op.comp]{\tcode{move_iterator} comparisons}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{move_iterator}}%
-\indexlibrary{\idxcode{move_iterator}!\idxcode{operator==}}%
+\indexlibrarymember{operator==}{move_iterator}%
 \begin{itemdecl}
 template <class Iterator1, class Iterator2>
 constexpr bool operator==(const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
@@ -2470,8 +2453,7 @@ constexpr bool operator!=(const move_iterator<Iterator1>& x, const move_iterator
 \returns \tcode{!(x == y)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{move_iterator}}%
-\indexlibrary{\idxcode{move_iterator}!\idxcode{operator<}}%
+\indexlibrarymember{operator<}{move_iterator}%
 \begin{itemdecl}
 template <class Iterator1, class Iterator2>
 constexpr bool operator<(const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
@@ -2482,8 +2464,7 @@ constexpr bool operator<(const move_iterator<Iterator1>& x, const move_iterator<
 \returns \tcode{x.base() < y.base()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{move_iterator}}%
-\indexlibrary{\idxcode{move_iterator}!\idxcode{operator<=}}%
+\indexlibrarymember{operator<=}{move_iterator}%
 \begin{itemdecl}
 template <class Iterator1, class Iterator2>
 constexpr bool operator<=(const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
@@ -2494,8 +2475,7 @@ constexpr bool operator<=(const move_iterator<Iterator1>& x, const move_iterator
 \returns \tcode{!(y < x)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>}!\idxcode{move_iterator}}%
-\indexlibrary{\idxcode{move_iterator}!\idxcode{operator>}}%
+\indexlibrarymember{operator>}{move_iterator}%
 \begin{itemdecl}
 template <class Iterator1, class Iterator2>
 constexpr bool operator>(const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
@@ -2506,8 +2486,7 @@ constexpr bool operator>(const move_iterator<Iterator1>& x, const move_iterator<
 \returns \tcode{y < x}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{move_iterator}}%
-\indexlibrary{\idxcode{move_iterator}!\idxcode{operator>=}}%
+\indexlibrarymember{operator>=}{move_iterator}%
 \begin{itemdecl}
 template <class Iterator1, class Iterator2>
 constexpr bool operator>=(const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
@@ -2520,8 +2499,7 @@ constexpr bool operator>=(const move_iterator<Iterator1>& x, const move_iterator
 
 \rSec4[move.iter.nonmember]{\tcode{move_iterator} non-member functions}
 
-\indexlibrary{\idxcode{operator-}!\idxcode{move_iterator}}%
-\indexlibrary{\idxcode{move_iterator}!\idxcode{operator-}}%
+\indexlibrarymember{operator-}{move_iterator}%
 \begin{itemdecl}
 template <class Iterator1, class Iterator2>
     constexpr auto operator-(
@@ -2534,8 +2512,7 @@ template <class Iterator1, class Iterator2>
 \returns \tcode{x.base() - y.base()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator+}!\idxcode{move_iterator}}%
-\indexlibrary{\idxcode{move_iterator}!\idxcode{operator+}}%
+\indexlibrarymember{operator+}{move_iterator}%
 \begin{itemdecl}
 template <class Iterator>
   constexpr move_iterator<Iterator> operator+(
@@ -2728,8 +2705,7 @@ The iterator is destroyed. If \tcode{T} is a literal type, then this destructor 
 
 \rSec3[istream.iterator.ops]{\tcode{istream_iterator} operations}
 
-\indexlibrary{\idxcode{operator*}!\idxcode{istream_iterator}}%
-\indexlibrary{\idxcode{istream_iterator}!\idxcode{operator*}}%
+\indexlibrarymember{operator*}{istream_iterator}%
 \begin{itemdecl}
 const T& operator*() const;
 \end{itemdecl}
@@ -2740,8 +2716,7 @@ const T& operator*() const;
 \textit{value}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator->}!\idxcode{istream_iterator}}%
-\indexlibrary{\idxcode{istream_iterator}!\idxcode{operator->}}%
+\indexlibrarymember{operator->}{istream_iterator}%
 \begin{itemdecl}
 const T* operator->() const;
 \end{itemdecl}
@@ -2752,8 +2727,7 @@ const T* operator->() const;
 \tcode{addressof(operator*())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator++}!\idxcode{istream_iterator}}%
-\indexlibrary{\idxcode{istream_iterator}!\idxcode{operator++}}%
+\indexlibrarymember{operator++}{istream_iterator}%
 \begin{itemdecl}
 istream_iterator& operator++();
 \end{itemdecl}
@@ -2771,8 +2745,7 @@ As if by: \tcode{*in_stream \shr value;}
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator++}!\idxcode{istream_iterator}}%
-\indexlibrary{\idxcode{istream_iterator}!\idxcode{operator++}}%
+\indexlibrarymember{operator++}{istream_iterator}%
 \begin{itemdecl}
 istream_iterator operator++(int);
 \end{itemdecl}
@@ -2791,8 +2764,7 @@ return (tmp);
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{istream_iterator}}%
-\indexlibrary{\idxcode{istream_iterator}!\idxcode{operator==}}%
+\indexlibrarymember{operator==}{istream_iterator}%
 \begin{itemdecl}
 template <class T, class charT, class traits, class Distance>
   bool operator==(const istream_iterator<T,charT,traits,Distance> &x,
@@ -2931,8 +2903,7 @@ The iterator is destroyed.
 
 \rSec3[ostream.iterator.ops]{\tcode{ostream_iterator} operations}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{ostream_iterator}}%
-\indexlibrary{\idxcode{ostream_iterator}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{ostream_iterator}%
 \begin{itemdecl}
 ostream_iterator& operator=(const T& value);
 \end{itemdecl}
@@ -2949,8 +2920,7 @@ return *this;
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator*}!\idxcode{ostream_iterator}}%
-\indexlibrary{\idxcode{ostream_iterator}!\idxcode{operator*}}%
+\indexlibrarymember{operator*}{ostream_iterator}%
 \begin{itemdecl}
 ostream_iterator& operator*();
 \end{itemdecl}
@@ -2961,8 +2931,7 @@ ostream_iterator& operator*();
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator++}!\idxcode{ostream_iterator}}%
-\indexlibrary{\idxcode{ostream_iterator}!\idxcode{operator++}}%
+\indexlibrarymember{operator++}{ostream_iterator}%
 \begin{itemdecl}
 ostream_iterator& operator++();
 ostream_iterator& operator++(int);
@@ -3177,8 +3146,7 @@ As if by \tcode{sbuf_->sbumpc()}.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator++}!\idxcode{istreambuf_iterator}}%
-\indexlibrary{\idxcode{istreambuf_iterator}!\idxcode{operator++}}%
+\indexlibrarymember{operator++}{istreambuf_iterator}%
 \begin{itemdecl}
 proxy operator++(int);
 \end{itemdecl}

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -282,8 +282,7 @@ implementations are not required to avoid data races on it~(\ref{res.on.data.rac
 
 \rSec4[locale.category]{Type \tcode{locale::category}}
 
-\indexlibrary{\idxcode{locale}!\idxcode{category}}%
-\indexlibrary{\idxcode{category}!\idxcode{locale}}%
+\indexlibrarymember{locale}{category}%
 \begin{itemdecl}
 using category = int;
 \end{itemdecl}
@@ -453,8 +452,7 @@ represents the set of all possible specializations on a bool parameter.
 
 \rSec4[locale.facet]{Class \tcode{locale::facet}}
 
-\indexlibrary{\idxcode{locale}!\idxcode{facet}}%
-\indexlibrary{\idxcode{facet}!\idxcode{locale}}%
+\indexlibrarymember{locale}{facet}%
 \begin{codeblock}
 namespace std {
   class locale::facet {
@@ -532,8 +530,7 @@ semantics itself by reference to other facets.
 
 \rSec4[locale.id]{Class \tcode{locale::id}}
 
-\indexlibrary{\idxcode{locale}!\idxcode{id}}%
-\indexlibrary{\idxcode{id}!\idxcode{locale}}%
+\indexlibrarymember{locale}{id}%
 \begin{codeblock}
 namespace std {
   class locale::id {
@@ -709,8 +706,7 @@ The resulting locale has a name if and only if the first two arguments
 have names.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{locale}}%
-\indexlibrary{\idxcode{locale}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{locale}%
 \begin{itemdecl}
 const locale& operator=(const locale& other) noexcept;
 \end{itemdecl}
@@ -737,8 +733,7 @@ A non-virtual destructor that throws no exceptions.
 
 \rSec3[locale.members]{\tcode{locale} members}
 
-\indexlibrary{\idxcode{locale}!\idxcode{combine}}%
-\indexlibrary{\idxcode{combine}!\idxcode{locale}}%
+\indexlibrarymember{locale}{combine}%
 \begin{itemdecl}
 template <class Facet> locale combine(const locale& other) const;
 \end{itemdecl}
@@ -770,8 +765,7 @@ is false.
 The resulting locale has no name.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{locale}!\idxcode{name}}%
-\indexlibrary{\idxcode{name}!\idxcode{locale}}%
+\indexlibrarymember{locale}{name}%
 \begin{itemdecl}
 basic_string<char> name() const;
 \end{itemdecl}
@@ -794,8 +788,7 @@ Details of the contents of the resulting string are otherwise implementation-def
 
 \rSec3[locale.operators]{\tcode{locale} operators}
 
-\indexlibrary{\idxcode{locale}!\idxcode{operator==}}%
-\indexlibrary{\idxcode{operator==}!\idxcode{locale}}%
+\indexlibrarymember{locale}{operator==}%
 \begin{itemdecl}
 bool operator==(const locale& other) const;
 \end{itemdecl}
@@ -810,8 +803,7 @@ other, or each has a name and the names are identical;
 otherwise.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{locale}!\idxcode{operator"!=}}%
-\indexlibrary{\idxcode{operator"!=}!\idxcode{locale}}%
+\indexlibrarymember{locale}{operator"!=}%
 \begin{itemdecl}
 bool operator!=(const locale& other) const;
 \end{itemdecl}
@@ -823,8 +815,7 @@ The result of the expression:
 \tcode{!(*this == other)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{locale}!\idxcode{operator()}}%
-\indexlibrary{\idxcode{operator()}!\idxcode{locale}}%
+\indexlibrarymember{locale}{operator()}%
 \begin{itemdecl}
 template <class charT, class traits, class Allocator>
   bool operator()(const basic_string<charT,traits,Allocator>& s1,
@@ -870,8 +861,7 @@ std::sort(v.begin(), v.end(), loc);
 
 \rSec3[locale.statics]{\tcode{locale} static members}
 
-\indexlibrary{\idxcode{locale}!\idxcode{global}}%
-\indexlibrary{\idxcode{global}!\idxcode{locale}}%
+\indexlibrarymember{locale}{global}%
 \begin{itemdecl}
 static locale global(const locale& loc);
 \end{itemdecl}
@@ -906,8 +896,7 @@ The previous value of
 \tcode{locale()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{locale}!\idxcode{classic}}%
-\indexlibrary{\idxcode{classic}!\idxcode{locale}}%
+\indexlibrarymember{locale}{classic}%
 \begin{itemdecl}
 static const locale& classic();
 \end{itemdecl}
@@ -929,8 +918,7 @@ with time.
 
 \rSec2[locale.global.templates]{\tcode{locale} globals}
 
-\indexlibrary{\idxcode{locale}!\idxcode{use_facet}}%
-\indexlibrary{\idxcode{use_facet}!\idxcode{locale}}%
+\indexlibrarymember{locale}{use_facet}%
 \begin{itemdecl}
 template <class Facet> const Facet& use_facet(const locale& loc);
 \end{itemdecl}
@@ -961,8 +949,7 @@ The reference returned remains valid at least as long as any copy of
 \tcode{loc} exists.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{locale}!\idxcode{has_facet}}%
-\indexlibrary{\idxcode{has_facet}!\idxcode{locale}}%
+\indexlibrarymember{locale}{has_facet}%
 \begin{itemdecl}
 template <class Facet> bool has_facet(const locale& loc) noexcept;
 \end{itemdecl}
@@ -1136,8 +1123,7 @@ An object of this class template stores:
 \item \tcode{cvtcount} --- a conversion count
 \end{itemize}
 
-\indexlibrary{\idxcode{byte_string}!\idxcode{wstring_convert}}%
-\indexlibrary{\idxcode{wstring_convert}!\idxcode{byte_string}}%
+\indexlibrarymember{byte_string}{wstring_convert}%
 \begin{itemdecl}
 using byte_string = std::basic_string<char, char_traits<char>, Byte_alloc>;
 \end{itemdecl}
@@ -1148,8 +1134,7 @@ The type shall be a synonym for \tcode{std::basic_string<char,
 char_traits<char>, Byte_alloc>}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{converted}!\idxcode{wstring_convert}}%
-\indexlibrary{\idxcode{wstring_convert}!\idxcode{converted}}%
+\indexlibrarymember{converted}{wstring_convert}%
 \begin{itemdecl}
 size_t converted() const noexcept;
 \end{itemdecl}
@@ -1159,8 +1144,7 @@ size_t converted() const noexcept;
 \returns \tcode{cvtcount}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{from_bytes}!\idxcode{wstring_convert}}%
-\indexlibrary{\idxcode{wstring_convert}!\idxcode{from_bytes}}%
+\indexlibrarymember{from_bytes}{wstring_convert}%
 \begin{itemdecl}
 wide_string from_bytes(char byte);
 wide_string from_bytes(const char* ptr);
@@ -1197,8 +1181,7 @@ member function shall return the wide-error string.
 Otherwise, the member function throws an object of class \tcode{std::range_error}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{int_type}!\idxcode{wstring_convert}}%
-\indexlibrary{\idxcode{wstring_convert}!\idxcode{int_type}}%
+\indexlibrarymember{int_type}{wstring_convert}%
 \begin{itemdecl}
 using int_type = typename wide_string::traits_type::int_type;
 \end{itemdecl}
@@ -1207,8 +1190,7 @@ using int_type = typename wide_string::traits_type::int_type;
 The type shall be a synonym for \tcode{wide_string::traits_type::int_type}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{state}!\idxcode{wstring_convert}}%
-\indexlibrary{\idxcode{wstring_convert}!\idxcode{state}}%
+\indexlibrarymember{state}{wstring_convert}%
 \begin{itemdecl}
 state_type state() const;
 \end{itemdecl}
@@ -1218,8 +1200,7 @@ state_type state() const;
 returns \tcode{cvtstate}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{state_type}!\idxcode{wstring_convert}}%
-\indexlibrary{\idxcode{wstring_convert}!\idxcode{state_type}}%
+\indexlibrarymember{state_type}{wstring_convert}%
 \begin{itemdecl}
 using state_type = typename Codecvt::state_type;
 \end{itemdecl}
@@ -1229,8 +1210,7 @@ using state_type = typename Codecvt::state_type;
 The type shall be a synonym for \tcode{Codecvt::state_type}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{to_bytes}!\idxcode{wstring_convert}}%
-\indexlibrary{\idxcode{wstring_convert}!\idxcode{to_bytes}}%
+\indexlibrarymember{to_bytes}{wstring_convert}%
 \begin{itemdecl}
 byte_string to_bytes(Elem wchar);
 byte_string to_bytes(const Elem* wptr);
@@ -1267,8 +1247,7 @@ member function shall return the byte-error string.
 Otherwise, the member function shall throw an object of class \tcode{std::range_error}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{wide_string}!\idxcode{wstring_convert}}%
-\indexlibrary{\idxcode{wstring_convert}!\idxcode{wide_string}}%
+\indexlibrarymember{wide_string}{wstring_convert}%
 \begin{itemdecl}
 using wide_string = std::basic_string<Elem, char_traits<Elem>, Wide_alloc>;
 \end{itemdecl}
@@ -1382,8 +1361,7 @@ An object of this class template stores:
 \item \tcode{cvtstate} --- a conversion state object
 \end{itemize}
 
-\indexlibrary{\idxcode{state}!\idxcode{wbuffer_convert}}%
-\indexlibrary{\idxcode{wbuffer_convert}!\idxcode{state}}%
+\indexlibrarymember{state}{wbuffer_convert}%
 \begin{itemdecl}
 state_type state() const;
 \end{itemdecl}
@@ -1393,8 +1371,7 @@ state_type state() const;
 \returns \tcode{cvtstate}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{rdbuf}!\idxcode{wbuffer_convert}}%
-\indexlibrary{\idxcode{wbuffer_convert}!\idxcode{rdbuf}}%
+\indexlibrarymember{rdbuf}{wbuffer_convert}%
 \begin{itemdecl}
 std::streambuf* rdbuf() const;
 \end{itemdecl}
@@ -1404,8 +1381,7 @@ std::streambuf* rdbuf() const;
 \returns \tcode{bufptr}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{rdbuf}!\idxcode{wbuffer_convert}}%
-\indexlibrary{\idxcode{wbuffer_convert}!\idxcode{rdbuf}}%
+\indexlibrarymember{rdbuf}{wbuffer_convert}%
 \begin{itemdecl}
 std::streambuf* rdbuf(std::streambuf* bytebuf);
 \end{itemdecl}
@@ -1418,8 +1394,7 @@ std::streambuf* rdbuf(std::streambuf* bytebuf);
 \returns The previous value of \tcode{bufptr}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{state_type}!\idxcode{wbuffer_convert}}%
-\indexlibrary{\idxcode{wbuffer_convert}!\idxcode{state_type}}%
+\indexlibrarymember{state_type}{wbuffer_convert}%
 \begin{itemdecl}
 using state_type = typename Codecvt::state_type;
 \end{itemdecl}
@@ -1613,8 +1588,7 @@ to the implementation's native character set.
 
 \rSec4[locale.ctype.members]{\tcode{ctype} members}
 
-\indexlibrary{\idxcode{ctype}!\idxcode{is}}%
-\indexlibrary{\idxcode{is}!\idxcode{ctype}}%
+\indexlibrarymember{ctype}{is}%
 \begin{itemdecl}
 bool         is(mask m, charT c) const;
 const charT* is(const charT* low, const charT* high,
@@ -1629,8 +1603,7 @@ or
 \tcode{do_is(low,high,vec)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{ctype}!\idxcode{scan_is}}%
-\indexlibrary{\idxcode{scan_is}!\idxcode{ctype}}%
+\indexlibrarymember{ctype}{scan_is}%
 \begin{itemdecl}
 const charT* scan_is(mask m,
                      const charT* low, const charT* high) const;
@@ -1642,8 +1615,7 @@ const charT* scan_is(mask m,
 \tcode{do_scan_is(m,low,high)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{ctype}!\idxcode{scan_not}}%
-\indexlibrary{\idxcode{scan_not}!\idxcode{ctype}}%
+\indexlibrarymember{ctype}{scan_not}%
 \begin{itemdecl}
 const charT* scan_not(mask m,
                       const charT* low, const charT* high) const;
@@ -1655,8 +1627,7 @@ const charT* scan_not(mask m,
 \tcode{do_scan_not(m,low,high)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{ctype}!\idxcode{toupper}}%
-\indexlibrary{\idxcode{toupper}!\idxcode{ctype}}%
+\indexlibrarymember{ctype}{toupper}%
 \begin{itemdecl}
 charT        toupper(charT) const;
 const charT* toupper(charT* low, const charT* high) const;
@@ -1670,8 +1641,7 @@ or
 \tcode{do_toupper(low,high)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{ctype}!\idxcode{tolower}}%
-\indexlibrary{\idxcode{tolower}!\idxcode{ctype}}%
+\indexlibrarymember{ctype}{tolower}%
 \begin{itemdecl}
 charT        tolower(charT c) const;
 const charT* tolower(charT* low, const charT* high) const;
@@ -1685,8 +1655,7 @@ or
 \tcode{do_tolower(low,high)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{ctype}!\idxcode{widen}}%
-\indexlibrary{\idxcode{widen}!\idxcode{ctype}}%
+\indexlibrarymember{ctype}{widen}%
 \begin{itemdecl}
 charT       widen(char c) const;
 const char* widen(const char* low, const char* high, charT* to) const;
@@ -1700,8 +1669,7 @@ or
 \tcode{do_widen(low,high,to)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{ctype}!\idxcode{narrow}}%
-\indexlibrary{\idxcode{narrow}!\idxcode{ctype}}%
+\indexlibrarymember{ctype}{narrow}%
 \begin{itemdecl}
 char         narrow(charT c, char dfault) const;
 const charT* narrow(const charT* low, const charT* high, char dfault,
@@ -1718,8 +1686,7 @@ or
 
 \rSec4[locale.ctype.virtuals]{\tcode{ctype} virtual functions}
 
-\indexlibrary{\idxcode{ctype}!\idxcode{do_is}}%
-\indexlibrary{\idxcode{do_is}!\idxcode{ctype}}%
+\indexlibrarymember{ctype}{do_is}%
 \begin{itemdecl}
 bool         do_is(mask m, charT c) const;
 const charT* do_is(const charT* low, const charT* high,
@@ -1753,8 +1720,7 @@ if the character has the characteristics specified.
 The second form returns \tcode{high}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{ctype_base}!\idxcode{do_scan_is}}%
-\indexlibrary{\idxcode{do_scan_is}!\idxcode{ctype_base}}%
+\indexlibrarymember{ctype_base}{do_scan_is}%
 \begin{itemdecl}
 const charT* do_scan_is(mask m,
                        const charT* low, const charT* high) const;
@@ -1777,8 +1743,7 @@ would return
 otherwise, returns \tcode{high}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{ctype}!\idxcode{do_scan_not}}%
-\indexlibrary{\idxcode{do_scan_not}!\idxcode{ctype}}%
+\indexlibrarymember{ctype}{do_scan_not}%
 \begin{itemdecl}
 const charT* do_scan_not(mask m,
                         const charT* low, const charT* high) const;
@@ -1801,8 +1766,7 @@ would return
 otherwise, returns \tcode{high}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{ctype}!\idxcode{do_toupper}}%
-\indexlibrary{\idxcode{do_toupper}!\idxcode{ctype}}%
+\indexlibrarymember{ctype}{do_toupper}%
 \begin{itemdecl}
 charT        do_toupper(charT c) const;
 const charT* do_toupper(charT* low, const charT* high) const;
@@ -1826,8 +1790,7 @@ is known to exist, or its argument if not.
 The second form returns \tcode{high}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{ctype}!\idxcode{do_tolower}}%
-\indexlibrary{\idxcode{do_tolower}!\idxcode{ctype}}%
+\indexlibrarymember{ctype}{do_tolower}%
 \begin{itemdecl}
 charT        do_tolower(charT c) const;
 const charT* do_tolower(charT* low, const charT* high) const;
@@ -1851,8 +1814,7 @@ is known to exist, or its argument if not.
 The second form returns \tcode{high}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{ctype}!\idxcode{do_widen}}%
-\indexlibrary{\idxcode{do_widen}!\idxcode{ctype}}%
+\indexlibrarymember{ctype}{do_widen}%
 \begin{itemdecl}
 charT        do_widen(char c) const;
 const char*  do_widen(const char* low, const char* high,
@@ -1900,8 +1862,7 @@ The first form returns the transformed value.
 The second form returns \tcode{high}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{ctype}!\idxcode{do_narrow}}%
-\indexlibrary{\idxcode{do_narrow}!\idxcode{ctype}}%
+\indexlibrarymember{ctype}{do_narrow}%
 \begin{itemdecl}
 char         do_narrow(charT c, char dfault) const;
 const charT* do_narrow(const charT* low, const charT* high,
@@ -2100,8 +2061,7 @@ elements.
 Passes its \tcode{refs} argument to its base class constructor.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{ctype<char>}!\idxcode{is}}%
-\indexlibrary{\idxcode{is}!\idxcode{ctype<char>}}%
+\indexlibrarymember{ctype<char>}{is}%
 \begin{itemdecl}
 bool        is(mask m, char c) const;
 const char* is(const char* low, const char* high,
@@ -2128,8 +2088,7 @@ The first form returns
 the second form returns \tcode{high}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{ctype<char>}!\idxcode{scan_is}}%
-\indexlibrary{\idxcode{scan_is}!\idxcode{ctype<char>}}%
+\indexlibrarymember{ctype<char>}{scan_is}%
 \begin{itemdecl}
 const char* scan_is(mask m,
                     const char* low, const char* high) const;
@@ -2150,8 +2109,7 @@ is
 \tcode{true}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{ctype<char>}!\idxcode{scan_not}}%
-\indexlibrary{\idxcode{scan_not}!\idxcode{ctype<char>}}%
+\indexlibrarymember{ctype<char>}{scan_not}%
 \begin{itemdecl}
 const char* scan_not(mask m,
                      const char* low, const char* high) const;
@@ -2172,8 +2130,7 @@ is
 \tcode{false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{ctype<char>}!\idxcode{toupper}}%
-\indexlibrary{\idxcode{toupper}!\idxcode{ctype<char>}}%
+\indexlibrarymember{ctype<char>}{toupper}%
 \begin{itemdecl}
 char        toupper(char c) const;
 const char* toupper(char* low, const char* high) const;
@@ -2188,8 +2145,7 @@ or
 respectively.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{ctype<char>}!\idxcode{tolower}}%
-\indexlibrary{\idxcode{tolower}!\idxcode{ctype<char>}}%
+\indexlibrarymember{ctype<char>}{tolower}%
 \begin{itemdecl}
 char        tolower(char c) const;
 const char* tolower(char* low, const char* high) const;
@@ -2204,8 +2160,7 @@ or
 respectively.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{ctype<char>}!\idxcode{widen}}%
-\indexlibrary{\idxcode{widen}!\idxcode{ctype<char>}}%
+\indexlibrarymember{ctype<char>}{widen}%
 \begin{itemdecl}
 char  widen(char c) const;
 const char* widen(const char* low, const char* high,
@@ -2222,8 +2177,7 @@ or
 respectively.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{ctype<char>}!\idxcode{narrow}}%
-\indexlibrary{\idxcode{narrow}!\idxcode{ctype<char>}}%
+\indexlibrarymember{ctype<char>}{narrow}%
 \begin{itemdecl}
 char        narrow(char c, char dfault) const;
 const char* narrow(const char* low, const char* high,
@@ -2241,8 +2195,7 @@ or
 respectively.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{ctype<char>}!\idxcode{table}}%
-\indexlibrary{\idxcode{table}!\idxcode{ctype<char>}}%
+\indexlibrarymember{ctype<char>}{table}%
 \begin{itemdecl}
 const mask* table() const noexcept;
 \end{itemdecl}
@@ -2256,8 +2209,7 @@ The first constructor argument, if it was non-zero, otherwise
 
 \rSec4[facet.ctype.char.statics]{\tcode{ctype<char>} static members}
 
-\indexlibrary{\idxcode{ctype<char>}!\idxcode{classic_table}}%
-\indexlibrary{\idxcode{classic_table}!\idxcode{ctype<char>}}%
+\indexlibrarymember{ctype<char>}{classic_table}%
 \begin{itemdecl}
 static const mask* classic_table() noexcept;
 \end{itemdecl}
@@ -2272,14 +2224,10 @@ which represents the classifications of characters in the "C" locale.
 
 \rSec4[facet.ctype.char.virtuals]{\tcode{ctype<char>} virtual functions}
 
-\indexlibrary{\idxcode{ctype<char>}!\idxcode{do_toupper}}%
-\indexlibrary{\idxcode{do_toupper}!\idxcode{ctype<char>}}%
-\indexlibrary{\idxcode{ctype<char>}!\idxcode{do_tolower}}%
-\indexlibrary{\idxcode{do_tolower}!\idxcode{ctype<char>}}%
-\indexlibrary{\idxcode{ctype<char>}!\idxcode{do_widen}}%
-\indexlibrary{\idxcode{do_widen}!\idxcode{ctype<char>}}%
-\indexlibrary{\idxcode{ctype<char>}!\idxcode{do_narrow}}%
-\indexlibrary{\idxcode{do_narrow}!\idxcode{ctype<char>}}%
+\indexlibrarymember{ctype<char>}{do_toupper}%
+\indexlibrarymember{ctype<char>}{do_tolower}%
+\indexlibrarymember{ctype<char>}{do_widen}%
+\indexlibrarymember{ctype<char>}{do_narrow}%
 \begin{codeblock}
 char        do_toupper(char) const;
 const char* do_toupper(char* low, const char* high) const;
@@ -2397,8 +2345,7 @@ members.
 
 \rSec4[locale.codecvt.members]{\tcode{codecvt} members}
 
-\indexlibrary{\idxcode{codecvt}!\idxcode{out}}%
-\indexlibrary{\idxcode{out}!\idxcode{codecvt}}%
+\indexlibrarymember{codecvt}{out}%
 \begin{itemdecl}
 result out(stateT& state,
   const internT* from, const internT* from_end, const internT*& from_next,
@@ -2411,8 +2358,7 @@ result out(stateT& state,
 \tcode{do_out(state, from, from_end, from_next, to, to_end, to_next)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{codecvt}!\idxcode{unshift}}%
-\indexlibrary{\idxcode{unshift}!\idxcode{codecvt}}%
+\indexlibrarymember{codecvt}{unshift}%
 \begin{itemdecl}
 result unshift(stateT& state,
         externT* to, externT* to_end, externT*& to_next) const;
@@ -2424,8 +2370,7 @@ result unshift(stateT& state,
 \tcode{do_unshift(state, to, to_end, to_next)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{codecvt}!\idxcode{in}}%
-\indexlibrary{\idxcode{in}!\idxcode{codecvt}}%
+\indexlibrarymember{codecvt}{in}%
 \begin{itemdecl}
 result in(stateT& state,
   const externT* from, const externT* from_end, const externT*& from_next,
@@ -2438,8 +2383,7 @@ result in(stateT& state,
 \tcode{do_in(state, from, from_end, from_next, to, to_end, to_next)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{codecvt}!\idxcode{encoding}}%
-\indexlibrary{\idxcode{encoding}!\idxcode{codecvt}}%
+\indexlibrarymember{codecvt}{encoding}%
 \begin{itemdecl}
 int encoding() const noexcept;
 \end{itemdecl}
@@ -2450,8 +2394,7 @@ int encoding() const noexcept;
 \tcode{do_encoding()}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{codecvt}!\idxcode{always_noconv}}%
-\indexlibrary{\idxcode{always_noconv}!\idxcode{codecvt}}%
+\indexlibrarymember{codecvt}{always_noconv}%
 \begin{itemdecl}
 bool always_noconv() const noexcept;
 \end{itemdecl}
@@ -2462,8 +2405,7 @@ bool always_noconv() const noexcept;
 \tcode{do_always_noconv()}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{codecvt}!\idxcode{length}}%
-\indexlibrary{\idxcode{length}!\idxcode{codecvt}}%
+\indexlibrarymember{codecvt}{length}%
 \begin{itemdecl}
 int length(stateT& state, const externT* from, const externT* from_end,
            size_t max) const;
@@ -2475,8 +2417,7 @@ int length(stateT& state, const externT* from, const externT* from_end,
 \tcode{do_length(state, from, from_end, max)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{codecvt}!\idxcode{max_length}}%
-\indexlibrary{\idxcode{max_length}!\idxcode{codecvt}}%
+\indexlibrarymember{codecvt}{max_length}%
 \begin{itemdecl}
 int max_length() const noexcept;
 \end{itemdecl}
@@ -2489,10 +2430,8 @@ int max_length() const noexcept;
 
 \rSec4[locale.codecvt.virtuals]{\tcode{codecvt} virtual functions}
 
-\indexlibrary{\idxcode{codecvt}!\idxcode{do_out}}%
-\indexlibrary{\idxcode{do_out}!\idxcode{codecvt}}%
-\indexlibrary{\idxcode{codecvt}!\idxcode{do_in}}%
-\indexlibrary{\idxcode{do_in}!\idxcode{codecvt}}%
+\indexlibrarymember{codecvt}{do_out}%
+\indexlibrarymember{codecvt}{do_in}%
 \begin{itemdecl}
 result do_out(stateT& state,
   const internT* from, const internT* from_end, const internT*& from_next,
@@ -2617,8 +2556,7 @@ available destination elements, or that additional source elements are
 needed before another destination element can be produced.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{codecvt}!\idxcode{do_unshift}}%
-\indexlibrary{\idxcode{do_unshift}!\idxcode{codecvt}}%
+\indexlibrarymember{codecvt}{do_unshift}%
 \begin{itemdecl}
 result do_unshift(stateT& state,
   externT* to, externT* to_end, externT*& to_next) const;
@@ -2661,8 +2599,7 @@ to terminate a sequence given the value of \tcode{state}\\
 \end{floattable}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{codecvt}!\idxcode{do_encoding}}%
-\indexlibrary{\idxcode{do_encoding}!\idxcode{codecvt}}%
+\indexlibrarymember{codecvt}{do_encoding}%
 \begin{itemdecl}
 int do_encoding() const noexcept;
 \end{itemdecl}
@@ -2679,8 +2616,7 @@ may be consumed when producing a single \tcode{internT} character, and additiona
 yield the final \tcode{internT} character.}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{codecvt}!\idxcode{do_always_noconv}}%
-\indexlibrary{\idxcode{do_always_noconv}!\idxcode{codecvt}}%
+\indexlibrarymember{codecvt}{do_always_noconv}%
 \begin{itemdecl}
 bool do_always_noconv() const noexcept;
 \end{itemdecl}
@@ -2701,8 +2637,7 @@ returns
 \tcode{true}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{codecvt}!\idxcode{do_length}}%
-\indexlibrary{\idxcode{do_length}!\idxcode{codecvt}}%
+\indexlibrarymember{codecvt}{do_length}%
 \begin{itemdecl}
 int do_length(stateT& state, const externT* from, const externT* from_end,
               size_t max) const;
@@ -2744,8 +2679,7 @@ and
 \tcode{(from_end-from)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{codecvt}!\idxcode{do_max_length}}%
-\indexlibrary{\idxcode{do_max_length}!\idxcode{codecvt}}%
+\indexlibrarymember{codecvt}{do_max_length}%
 \begin{itemdecl}
 int do_max_length() const noexcept;
 \end{itemdecl}
@@ -2904,8 +2838,7 @@ is used to parse numeric values from an input sequence such as an istream.
 
 \rSec4[facet.num.get.members]{\tcode{num_get} members}
 
-\indexlibrary{\idxcode{num_get}!\idxcode{get}}%
-\indexlibrary{\idxcode{get}!\idxcode{num_get}}%
+\indexlibrarymember{num_get}{get}%
 \begin{itemdecl}
 iter_type get(iter_type in, iter_type end, ios_base& str,
   ios_base::iostate& err, bool& val) const;
@@ -2939,8 +2872,7 @@ iter_type get(iter_type in, iter_type end, ios_base& str,
 
 \rSec4[facet.num.get.virtuals]{\tcode{num_get} virtual functions}
 
-\indexlibrary{\idxcode{num_get}!\idxcode{do_get}}%
-\indexlibrary{\idxcode{do_get}!\idxcode{num_get}}%
+\indexlibrarymember{num_get}{do_get}%
 \begin{itemdecl}
 iter_type do_get(iter_type in, iter_type end, ios_base& str,
   ios_base::iostate& err, long& val) const;
@@ -3156,8 +3088,7 @@ then
 is performed.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{do_get}!\idxcode{num_get}}%
-\indexlibrary{\idxcode{num_get}!\idxcode{do_get}}%
+\indexlibrarymember{do_get}{num_get}%
 \begin{itemdecl}
 iter_type do_get(iter_type in, iter_type end, ios_base& str,
                  ios_base::iostate& err, bool& val) const;
@@ -3306,8 +3237,7 @@ is used to format numeric values to a character sequence such as an ostream.
 
 \rSec4[facet.num.put.members]{\tcode{num_put} members}
 
-\indexlibrary{\idxcode{num_put}!\idxcode{put}}%
-\indexlibrary{\idxcode{put}!\idxcode{num_put}}%
+\indexlibrarymember{num_put}{put}%
 \begin{itemdecl}
 iter_type put(iter_type out, ios_base& str, char_type fill,
   bool val) const;
@@ -3335,8 +3265,7 @@ iter_type put(iter_type out, ios_base& str, char_type fill,
 
 \rSec4[facet.num.put.virtuals]{\tcode{num_put} virtual functions}
 
-\indexlibrary{\idxcode{num_put}!\idxcode{do_put}}%
-\indexlibrary{\idxcode{do_put}!\idxcode{num_put}}%
+\indexlibrarymember{num_put}{do_put}%
 \begin{itemdecl}
 iter_type do_put(iter_type out, ios_base& str, char_type fill,
   long val) const;
@@ -3575,8 +3504,7 @@ at the end of stage 3 are output via
 \end{description}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{do_put}!\idxcode{num_put}}%
-\indexlibrary{\idxcode{num_put}!\idxcode{do_put}}%
+\indexlibrarymember{do_put}{num_put}%
 \begin{itemdecl}
 iter_type do_put(iter_type out, ios_base& str, char_type fill,
                  bool val) const;
@@ -3700,8 +3628,7 @@ is applied.
 
 \rSec4[facet.numpunct.members]{\tcode{numpunct} members}
 
-\indexlibrary{\idxcode{numpunct}!\idxcode{decimal_point}}%
-\indexlibrary{\idxcode{decimal_point}!\idxcode{numpunct}}%
+\indexlibrarymember{numpunct}{decimal_point}%
 \begin{itemdecl}
 char_type decimal_point() const;
 \end{itemdecl}
@@ -3712,8 +3639,7 @@ char_type decimal_point() const;
 \tcode{do_decimal_point()}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{numpunct}!\idxcode{thousands_sep}}%
-\indexlibrary{\idxcode{thousands_sep}!\idxcode{numpunct}}%
+\indexlibrarymember{numpunct}{thousands_sep}%
 \begin{itemdecl}
 char_type thousands_sep() const;
 \end{itemdecl}
@@ -3724,8 +3650,7 @@ char_type thousands_sep() const;
 \tcode{do_thousands_sep()}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{numpunct}!\idxcode{grouping}}%
-\indexlibrary{\idxcode{grouping}!\idxcode{numpunct}}%
+\indexlibrarymember{numpunct}{grouping}%
 \begin{itemdecl}
 string grouping()  const;
 \end{itemdecl}
@@ -3736,10 +3661,8 @@ string grouping()  const;
 \tcode{do_grouping()}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{numpunct}!\idxcode{truename}}%
-\indexlibrary{\idxcode{truename}!\idxcode{numpunct}}%
-\indexlibrary{\idxcode{numpunct}!\idxcode{falsename}}%
-\indexlibrary{\idxcode{falsename}!\idxcode{numpunct}}%
+\indexlibrarymember{numpunct}{truename}%
+\indexlibrarymember{numpunct}{falsename}%
 \begin{itemdecl}
 string_type truename()  const;
 string_type falsename() const;
@@ -3756,8 +3679,7 @@ respectively.
 
 \rSec4[facet.numpunct.virtuals]{\tcode{numpunct} virtual functions}
 
-\indexlibrary{\idxcode{numpunct}!\idxcode{do_decimal_point}}%
-\indexlibrary{\idxcode{do_decimal_point}!\idxcode{numpunct}}%
+\indexlibrarymember{numpunct}{do_decimal_point}%
 \begin{itemdecl}
 char_type do_decimal_point() const;
 \end{itemdecl}
@@ -3769,8 +3691,7 @@ A character for use as the decimal radix separator.
 The required specializations return \tcode{'.'} or \tcode{L'.'}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{numpunct}!\idxcode{do_thousands_sep}}%
-\indexlibrary{\idxcode{do_thousands_sep}!\idxcode{numpunct}}%
+\indexlibrarymember{numpunct}{do_thousands_sep}%
 \begin{itemdecl}
 char_type do_thousands_sep() const;
 \end{itemdecl}
@@ -3782,8 +3703,7 @@ A character for use as the digit group separator.
 The required specializations return \tcode{','} or \tcode{L','}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{numpunct}!\idxcode{do_grouping}}%
-\indexlibrary{\idxcode{do_grouping}!\idxcode{numpunct}}%
+\indexlibrarymember{numpunct}{do_grouping}%
 \begin{itemdecl}
 string do_grouping() const;
 \end{itemdecl}
@@ -3813,10 +3733,8 @@ The required specializations return the empty string, indicating
 no grouping.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{numpunct}!\idxcode{do_truename}}%
-\indexlibrary{\idxcode{do_truename}!\idxcode{numpunct}}%
-\indexlibrary{\idxcode{numpunct}!\idxcode{do_falsename}}%
-\indexlibrary{\idxcode{do_falsename}!\idxcode{numpunct}}%
+\indexlibrarymember{numpunct}{do_truename}%
+\indexlibrarymember{numpunct}{do_falsename}%
 \begin{itemdecl}
 string_type do_truename()  const;
 string_type do_falsename() const;
@@ -3911,8 +3829,7 @@ in the range
 
 \rSec4[locale.collate.members]{\tcode{collate} members}
 
-\indexlibrary{\idxcode{collate}!\idxcode{compare}}%
-\indexlibrary{\idxcode{compare}!\idxcode{collate}}%
+\indexlibrarymember{collate}{compare}%
 \begin{itemdecl}
 int compare(const charT* low1, const charT* high1,
             const charT* low2, const charT* high2) const;
@@ -3924,8 +3841,7 @@ int compare(const charT* low1, const charT* high1,
 \tcode{do_compare(low1, high1, low2, high2)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{collate}!\idxcode{transform}}%
-\indexlibrary{\idxcode{transform}!\idxcode{collate}}%
+\indexlibrarymember{collate}{transform}%
 \begin{itemdecl}
 string_type transform(const charT* low, const charT* high) const;
 \end{itemdecl}
@@ -3936,8 +3852,7 @@ string_type transform(const charT* low, const charT* high) const;
 \tcode{do_transform(low, high)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{collate}!\idxcode{hash}}%
-\indexlibrary{\idxcode{hash}!\idxcode{collate}}%
+\indexlibrarymember{collate}{hash}%
 \begin{itemdecl}
 long hash(const charT* low, const charT* high) const;
 \end{itemdecl}
@@ -3950,8 +3865,7 @@ long hash(const charT* low, const charT* high) const;
 
 \rSec4[locale.collate.virtuals]{\tcode{collate} virtual functions}
 
-\indexlibrary{\idxcode{collate}!\idxcode{do_compare}}%
-\indexlibrary{\idxcode{do_compare}!\idxcode{collate}}%
+\indexlibrarymember{collate}{do_compare}%
 \begin{itemdecl}
 int do_compare(const charT* low1, const charT* high1,
                const charT* low2, const charT* high2) const;
@@ -3972,8 +3886,7 @@ implement
 a lexicographical comparison~(\ref{alg.lex.comparison}).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{collate}!\idxcode{do_transform}}%
-\indexlibrary{\idxcode{do_transform}!\idxcode{collate}}%
+\indexlibrarymember{collate}{do_transform}%
 \begin{itemdecl}
 string_type do_transform(const charT* low, const charT* high) const;
 \end{itemdecl}
@@ -3991,8 +3904,7 @@ on the same two strings.\footnote{This function is useful when one string is
 being compared to many other strings.}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{collate}!\idxcode{do_hash}}%
-\indexlibrary{\idxcode{do_hash}!\idxcode{collate}}%
+\indexlibrarymember{collate}{do_hash}%
 \begin{itemdecl}
 long do_hash(const charT* low, const charT* high) const;
 \end{itemdecl}
@@ -4141,8 +4053,7 @@ in \tcode{err}.
 
 \rSec4[locale.time.get.members]{\tcode{time_get} members}
 
-\indexlibrary{\idxcode{time_get}!\idxcode{date_order}}%
-\indexlibrary{\idxcode{date_order}!\idxcode{time_get}}%
+\indexlibrarymember{time_get}{date_order}%
 \begin{itemdecl}
 dateorder date_order() const;
 \end{itemdecl}
@@ -4153,8 +4064,7 @@ dateorder date_order() const;
 \tcode{do_date_order()}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{time_get}!\idxcode{get_time}}%
-\indexlibrary{\idxcode{get_time}!\idxcode{time_get}}%
+\indexlibrarymember{time_get}{get_time}%
 \begin{itemdecl}
 iter_type get_time(iter_type s, iter_type end, ios_base& str,
                    ios_base::iostate& err, tm* t) const;
@@ -4166,8 +4076,7 @@ iter_type get_time(iter_type s, iter_type end, ios_base& str,
 \tcode{do_get_time(s, end, str, err, t)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{time_get}!\idxcode{get_date}}%
-\indexlibrary{\idxcode{get_date}!\idxcode{time_get}}%
+\indexlibrarymember{time_get}{get_date}%
 \begin{itemdecl}
 iter_type get_date(iter_type s, iter_type end, ios_base& str,
                    ios_base::iostate& err, tm* t) const;
@@ -4179,10 +4088,8 @@ iter_type get_date(iter_type s, iter_type end, ios_base& str,
 \tcode{do_get_date(s, end, str, err, t)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{time_get}!\idxcode{get_weekday}}%
-\indexlibrary{\idxcode{get_weekday}!\idxcode{time_get}}%
-\indexlibrary{\idxcode{time_get}!\idxcode{get_monthname}}%
-\indexlibrary{\idxcode{get_monthname}!\idxcode{time_get}}%
+\indexlibrarymember{time_get}{get_weekday}%
+\indexlibrarymember{time_get}{get_monthname}%
 \begin{itemdecl}
 iter_type get_weekday(iter_type s, iter_type end, ios_base& str,
                       ios_base::iostate& err, tm* t) const;
@@ -4198,8 +4105,7 @@ or
 \tcode{do_get_monthname(s, end, str, err, t)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{time_get}!\idxcode{get_year}}%
-\indexlibrary{\idxcode{get_year}!\idxcode{time_get}}%
+\indexlibrarymember{time_get}{get_year}%
 \begin{itemdecl}
 iter_type get_year(iter_type s, iter_type end, ios_base& str,
                    ios_base::iostate& err, tm* t) const;
@@ -4211,8 +4117,7 @@ iter_type get_year(iter_type s, iter_type end, ios_base& str,
 \tcode{do_get_year(s, end, str, err, t)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{get}!\idxcode{time_get}}%
-\indexlibrary{\idxcode{time_get}!\idxcode{get}}%
+\indexlibrarymember{get}{time_get}%
 \begin{itemdecl}
 iter_type get(iter_type s, iter_type end, ios_base& f,
     ios_base::iostate& err, tm* t, char format, char modifier = 0) const;
@@ -4223,8 +4128,7 @@ iter_type get(iter_type s, iter_type end, ios_base& f,
 \returns \tcode{do_get(s, end, f, err, t, format, modifier)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{get}!\idxcode{time_get}}%
-\indexlibrary{\idxcode{time_get}!\idxcode{get}}%
+\indexlibrarymember{get}{time_get}%
 \begin{itemdecl}
 iter_type get(iter_type s, iter_type end, ios_base& f,
     ios_base::iostate& err, tm* t, const char_type* fmt, const char_type* fmtend) const;
@@ -4291,8 +4195,7 @@ multi-character sequences are considered while doing so. \end{note}
 
 \rSec4[locale.time.get.virtuals]{\tcode{time_get} virtual functions}
 
-\indexlibrary{\idxcode{time_get}!\idxcode{do_date_order}}%
-\indexlibrary{\idxcode{do_date_order}!\idxcode{time_get}}%
+\indexlibrarymember{time_get}{do_date_order}%
 \begin{itemdecl}
 dateorder do_date_order() const;
 \end{itemdecl}
@@ -4313,8 +4216,7 @@ if the date format specified by
 contains other variable components (e.g., Julian day, week number, week day).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{time_get}!\idxcode{do_get_time}}%
-\indexlibrary{\idxcode{do_get_time}!\idxcode{time_get}}%
+\indexlibrarymember{time_get}{do_get_time}%
 \begin{itemdecl}
 iter_type do_get_time(iter_type s, iter_type end, ios_base& str,
                       ios_base::iostate& err, tm* t) const;
@@ -4338,8 +4240,7 @@ An iterator pointing immediately beyond the last character recognized
 as possibly part of a valid time.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{time_get}!\idxcode{do_get_date}}%
-\indexlibrary{\idxcode{do_get_date}!\idxcode{time_get}}%
+\indexlibrarymember{time_get}{do_get_date}%
 \begin{itemdecl}
 iter_type do_get_date(iter_type s, iter_type end, ios_base& str,
                       ios_base::iostate& err, tm* t) const;
@@ -4376,10 +4277,8 @@ An iterator pointing immediately beyond the last character recognized
 as possibly part of a valid date.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{time_get}!\idxcode{do_get_weekday}}%
-\indexlibrary{\idxcode{do_get_weekday}!\idxcode{time_get}}%
-\indexlibrary{\idxcode{time_get}!\idxcode{do_get_monthname}}%
-\indexlibrary{\idxcode{do_get_monthname}!\idxcode{time_get}}%
+\indexlibrarymember{time_get}{do_get_weekday}%
+\indexlibrarymember{time_get}{do_get_monthname}%
 \begin{itemdecl}
 iter_type do_get_weekday(iter_type s, iter_type end, ios_base& str,
                          ios_base::iostate& err, tm* t) const;
@@ -4405,8 +4304,7 @@ An iterator pointing immediately beyond the last character recognized
 as part of a valid name.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{time_get}!\idxcode{do_get_year}}%
-\indexlibrary{\idxcode{do_get_year}!\idxcode{time_get}}%
+\indexlibrarymember{time_get}{do_get_year}%
 \begin{itemdecl}
 iter_type do_get_year(iter_type s, iter_type end, ios_base& str,
                       ios_base::iostate& err, tm* t) const;
@@ -4431,8 +4329,7 @@ An iterator pointing immediately beyond the last character recognized
 as part of a valid year identifier.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{do_get}!\idxcode{time_get}}%
-\indexlibrary{\idxcode{time_get}!\idxcode{do_get}}%
+\indexlibrarymember{do_get}{time_get}%
 \begin{itemdecl}
 iter_type do_get(iter_type s, iter_type end, ios_base& f,
     ios_base::iostate& err, tm* t, char format, char modifier) const;
@@ -4531,8 +4428,7 @@ namespace std {
 
 \rSec4[locale.time.put.members]{\tcode{time_put} members}
 
-\indexlibrary{\idxcode{time_put}!\idxcode{put}}%
-\indexlibrary{\idxcode{put}!\idxcode{time_put}}%
+\indexlibrarymember{time_put}{put}%
 \begin{itemdecl}
 iter_type put(iter_type s, ios_base& str, char_type fill, const tm* t,
               const charT* pattern, const charT* pat_end) const;
@@ -4599,8 +4495,7 @@ An iterator pointing immediately after the last character produced.
 
 \rSec4[locale.time.put.virtuals]{\tcode{time_put} virtual functions}
 
-\indexlibrary{\idxcode{time_put}!\idxcode{do_put}}%
-\indexlibrary{\idxcode{do_put}!\idxcode{time_put}}%
+\indexlibrarymember{time_put}{do_put}%
 \begin{itemdecl}
 iter_type do_put(iter_type s, ios_base&, char_type fill, const tm* t,
                  char format, char modifier) const;
@@ -4717,8 +4612,7 @@ namespace std {
 
 \rSec4[locale.money.get.members]{\tcode{money_get} members}
 
-\indexlibrary{\idxcode{money_get}!\idxcode{get}}%
-\indexlibrary{\idxcode{get}!\idxcode{money_get}}%
+\indexlibrarymember{money_get}{get}%
 \begin{itemdecl}
 iter_type get(iter_type s, iter_type end, bool intl,
               ios_base& f, ios_base::iostate& err,
@@ -4735,8 +4629,7 @@ iter_type get(s, iter_type end, bool intl, ios_base&f,
 
 \rSec4[locale.money.get.virtuals]{\tcode{money_get} virtual functions}
 
-\indexlibrary{\idxcode{money_get}!\idxcode{do_get}}%
-\indexlibrary{\idxcode{do_get}!\idxcode{money_get}}%
+\indexlibrarymember{money_get}{do_get}%
 \begin{itemdecl}
 iter_type do_get(iter_type s, iter_type end, bool intl,
                  ios_base& str, ios_base::iostate& err,
@@ -4947,8 +4840,7 @@ namespace std {
 
 \rSec4[locale.money.put.members]{\tcode{money_put} members}
 
-\indexlibrary{\idxcode{money_put}!\idxcode{put}}%
-\indexlibrary{\idxcode{put}!\idxcode{money_put}}%
+\indexlibrarymember{money_put}{put}%
 \begin{itemdecl}
 iter_type put(iter_type s, bool intl, ios_base& f, char_type fill,
               long double quant) const;
@@ -4964,8 +4856,7 @@ iter_type put(iter_type s, bool intl, ios_base& f, char_type fill,
 
 \rSec4[locale.money.put.virtuals]{\tcode{money_put} virtual functions}
 
-\indexlibrary{\idxcode{money_put}!\idxcode{do_put}}%
-\indexlibrary{\idxcode{do_put}!\idxcode{money_put}}%
+\indexlibrarymember{money_put}{do_put}%
 \begin{itemdecl}
 iter_type do_put(iter_type s, bool intl, ios_base& str,
                  char_type fill, long double units) const;
@@ -5259,24 +5150,15 @@ defined identically as the member
 
 \rSec4[locale.moneypunct.members]{\tcode{moneypunct} members}
 
-\indexlibrary{\idxcode{moneypunct}!\idxcode{decimal_point}}%
-\indexlibrary{\idxcode{decimal_point}!\idxcode{moneypunct}}%
-\indexlibrary{\idxcode{moneypunct}!\idxcode{thousands_sep}}%
-\indexlibrary{\idxcode{thousands_sep}!\idxcode{moneypunct}}%
-\indexlibrary{\idxcode{moneypunct}!\idxcode{grouping}}%
-\indexlibrary{\idxcode{grouping}!\idxcode{moneypunct}}%
-\indexlibrary{\idxcode{moneypunct}!\idxcode{curr_symbol}}%
-\indexlibrary{\idxcode{curr_symbol}!\idxcode{moneypunct}}%
-\indexlibrary{\idxcode{moneypunct}!\idxcode{positive_sign}}%
-\indexlibrary{\idxcode{positive_sign}!\idxcode{moneypunct}}%
-\indexlibrary{\idxcode{moneypunct}!\idxcode{negative_sign}}%
-\indexlibrary{\idxcode{negative_sign}!\idxcode{moneypunct}}%
-\indexlibrary{\idxcode{moneypunct}!\idxcode{frac_digits}}%
-\indexlibrary{\idxcode{frac_digits}!\idxcode{moneypunct}}%
-\indexlibrary{\idxcode{moneypunct}!\idxcode{positive_sign}}%
-\indexlibrary{\idxcode{positive_sign}!\idxcode{moneypunct}}%
-\indexlibrary{\idxcode{moneypunct}!\idxcode{negative_sign}}%
-\indexlibrary{\idxcode{negative_sign}!\idxcode{moneypunct}}%
+\indexlibrarymember{moneypunct}{decimal_point}%
+\indexlibrarymember{moneypunct}{thousands_sep}%
+\indexlibrarymember{moneypunct}{grouping}%
+\indexlibrarymember{moneypunct}{curr_symbol}%
+\indexlibrarymember{moneypunct}{positive_sign}%
+\indexlibrarymember{moneypunct}{negative_sign}%
+\indexlibrarymember{moneypunct}{frac_digits}%
+\indexlibrarymember{moneypunct}{positive_sign}%
+\indexlibrarymember{moneypunct}{negative_sign}%
 \begin{codeblock}
 charT        decimal_point() const;
 charT        thousands_sep() const;
@@ -5297,8 +5179,7 @@ virtual member function
 
 \rSec4[locale.moneypunct.virtuals]{\tcode{moneypunct} virtual functions}
 
-\indexlibrary{\idxcode{moneypunct}!\idxcode{do_decimal_point}}%
-\indexlibrary{\idxcode{do_decimal_point}!\idxcode{moneypunct}}%
+\indexlibrarymember{moneypunct}{do_decimal_point}%
 \begin{itemdecl}
 charT do_decimal_point() const;
 \end{itemdecl}
@@ -5312,8 +5193,7 @@ is greater than zero.\footnote{In common U.S. locales this is
 \tcode{'.'}.}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{moneypunct}!\idxcode{do_thousands_sep}}%
-\indexlibrary{\idxcode{do_thousands_sep}!\idxcode{moneypunct}}%
+\indexlibrarymember{moneypunct}{do_thousands_sep}%
 \begin{itemdecl}
 charT do_thousands_sep() const;
 \end{itemdecl}
@@ -5327,8 +5207,7 @@ specifies a digit grouping pattern.\footnote{In common U.S. locales this is
 \tcode{','}.}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{moneypunct}!\idxcode{do_grouping}}%
-\indexlibrary{\idxcode{do_grouping}!\idxcode{moneypunct}}%
+\indexlibrarymember{moneypunct}{do_grouping}%
 \begin{itemdecl}
 string do_grouping() const;
 \end{itemdecl}
@@ -5343,8 +5222,7 @@ the value is \tcode{"\textbackslash003"}
 \tcode{"3"}.}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{moneypunct}!\idxcode{do_curr_symbol}}%
-\indexlibrary{\idxcode{do_curr_symbol}!\idxcode{moneypunct}}%
+\indexlibrarymember{moneypunct}{do_curr_symbol}%
 \begin{itemdecl}
 string_type do_curr_symbol() const;
 \end{itemdecl}
@@ -5358,10 +5236,8 @@ specializations (second template parameter
 this is typically four characters long, usually three letters and a space.}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{moneypunct}!\idxcode{do_positive_sign}}%
-\indexlibrary{\idxcode{do_positive_sign}!\idxcode{moneypunct}}%
-\indexlibrary{\idxcode{moneypunct}!\idxcode{do_negative_sign}}%
-\indexlibrary{\idxcode{do_negative_sign}!\idxcode{moneypunct}}%
+\indexlibrarymember{moneypunct}{do_positive_sign}%
+\indexlibrarymember{moneypunct}{do_negative_sign}%
 \begin{itemdecl}
 string_type do_positive_sign() const;
 string_type do_negative_sign() const;
@@ -5377,8 +5253,7 @@ positive monetary value;\footnote{This is usually the empty string.}
 returns the string to use to indicate a negative value.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{moneypunct}!\idxcode{do_frac_digits}}%
-\indexlibrary{\idxcode{do_frac_digits}!\idxcode{moneypunct}}%
+\indexlibrarymember{moneypunct}{do_frac_digits}%
 \begin{itemdecl}
 int do_frac_digits() const;
 \end{itemdecl}
@@ -5390,10 +5265,8 @@ The number of digits after the decimal radix separator, if any.\footnote{In
 common U.S. locales, this is 2.}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{moneypunct}!\idxcode{do_pos_format}}%
-\indexlibrary{\idxcode{do_pos_format}!\idxcode{moneypunct}}%
-\indexlibrary{\idxcode{moneypunct}!\idxcode{do_neg_format}}%
-\indexlibrary{\idxcode{do_neg_format}!\idxcode{moneypunct}}%
+\indexlibrarymember{moneypunct}{do_pos_format}%
+\indexlibrarymember{moneypunct}{do_neg_format}%
 \begin{itemdecl}
 pattern do_pos_format() const;
 pattern do_neg_format() const;
@@ -5491,8 +5364,7 @@ can be obtained only by calling member
 
 \rSec4[locale.messages.members]{\tcode{messages} members}
 
-\indexlibrary{\idxcode{messages}!\idxcode{open}}%
-\indexlibrary{\idxcode{open}!\idxcode{messages}}%
+\indexlibrarymember{messages}{open}%
 \begin{itemdecl}
 catalog open(const basic_string<char>& name, const locale& loc) const;
 \end{itemdecl}
@@ -5503,8 +5375,7 @@ catalog open(const basic_string<char>& name, const locale& loc) const;
 \tcode{do_open(name, loc)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{messages}!\idxcode{get}}%
-\indexlibrary{\idxcode{get}!\idxcode{messages}}%
+\indexlibrarymember{messages}{get}%
 \begin{itemdecl}
 string_type get(catalog cat, int set, int msgid,
                 const string_type& dfault) const;
@@ -5516,8 +5387,7 @@ string_type get(catalog cat, int set, int msgid,
 \tcode{do_get(cat, set, msgid, dfault)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{messages}!\idxcode{close}}%
-\indexlibrary{\idxcode{close}!\idxcode{messages}}%
+\indexlibrarymember{messages}{close}%
 \begin{itemdecl}
 void  close(catalog cat) const;
 \end{itemdecl}
@@ -5531,8 +5401,7 @@ Calls
 
 \rSec4[locale.messages.virtuals]{\tcode{messages} virtual functions}
 
-\indexlibrary{\idxcode{messages}!\idxcode{do_open}}%
-\indexlibrary{\idxcode{do_open}!\idxcode{messages}}%
+\indexlibrarymember{messages}{do_open}%
 \begin{itemdecl}
 catalog do_open(const basic_string<char>& name,
                 const locale& loc) const;
@@ -5559,8 +5428,7 @@ is used for character set code conversion when retrieving
 messages, if needed.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{messages}!\idxcode{do_get}}%
-\indexlibrary{\idxcode{do_get}!\idxcode{messages}}%
+\indexlibrarymember{messages}{do_get}%
 \begin{itemdecl}
 string_type do_get(catalog cat, int set, int msgid,
               const string_type& dfault) const;
@@ -5580,8 +5448,7 @@ to an \impldef{mapping to message when calling \tcode{messages::do_get}} mapping
 such message can be found, returns \tcode{dfault}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{message}!\idxcode{do_close}}%
-\indexlibrary{\idxcode{do_close}!\idxcode{message}}%
+\indexlibrarymember{message}{do_close}%
 \begin{itemdecl}
 void do_close(catalog cat) const;
 \end{itemdecl}

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -110,6 +110,9 @@
 \newcommand{\idxhdr}[1]{#1@\tcode{<#1>}}
 \newcommand{\idxgram}[1]{#1@\textit{#1}}
 
+% class member library index
+\newcommand{\indexlibrarymember}[2]{\indexlibrary{\idxcode{#1}!\idxcode{#2}}\indexlibrary{\idxcode{#2}!\idxcode{#1}}}
+
 %%--------------------------------------------------
 % General code style
 \newcommand{\CodeStyle}{\ttfamily}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -534,8 +534,7 @@ Constructs an object of class
 \tcode{real() == re \&\& imag() == im}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{real}!\idxcode{complex}}%
-\indexlibrary{\idxcode{complex}!\idxcode{real}}%
+\indexlibrarymember{real}{complex}%
 \begin{itemdecl}
 constexpr T real() const;
 \end{itemdecl}
@@ -544,8 +543,7 @@ constexpr T real() const;
 \returns The value of the real component.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{real}!\idxcode{complex}}%
-\indexlibrary{\idxcode{complex}!\idxcode{real}}%
+\indexlibrarymember{real}{complex}%
 \begin{itemdecl}
 void real(T val);
 \end{itemdecl}
@@ -554,8 +552,7 @@ void real(T val);
 \effects Assigns \tcode{val} to the real component.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{imag}!\idxcode{complex}}%
-\indexlibrary{\idxcode{complex}!\idxcode{imag}}%
+\indexlibrarymember{imag}{complex}%
 \begin{itemdecl}
 constexpr T imag() const;
 \end{itemdecl}
@@ -564,8 +561,7 @@ constexpr T imag() const;
 \returns The value of the imaginary component.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{imag}!\idxcode{complex}}%
-\indexlibrary{\idxcode{complex}!\idxcode{imag}}%
+\indexlibrarymember{imag}{complex}%
 \begin{itemdecl}
 void imag(T val);
 \end{itemdecl}
@@ -766,8 +762,7 @@ unary operator.
 \tcode{complex<T>(-lhs.real(),-lhs.imag())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator-}!\idxcode{complex}}%
-\indexlibrary{\idxcode{complex}!\idxcode{operator-}}%
+\indexlibrarymember{operator-}{complex}%
 \begin{itemdecl}
 template<class T>
   complex<T> operator-(const complex<T>& lhs, const complex<T>& rhs);
@@ -795,8 +790,7 @@ template<class T> complex<T> operator*(const T& lhs, const complex<T>& rhs);
 \tcode{complex<T>(lhs) *= rhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator/}!\idxcode{complex}}%
-\indexlibrary{\idxcode{complex}!\idxcode{operator/}}%
+\indexlibrarymember{operator/}{complex}%
 \begin{itemdecl}
 template<class T>
   complex<T> operator/(const complex<T>& lhs, const complex<T>& rhs);
@@ -846,8 +840,7 @@ template<class T> constexpr bool operator!=(const T& lhs, const complex<T>& rhs)
 \tcode{rhs.real() != lhs.real() || rhs.imag() != lhs.imag()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shr}!\idxcode{complex}}%
-\indexlibrary{\idxcode{complex}!\idxcode{operator\shr}}%
+\indexlibrarymember{operator\shr}{complex}%
 \begin{itemdecl}
 template<class T, class charT, class traits>
 basic_istream<charT, traits>&
@@ -890,8 +883,7 @@ Therefore, the skipping of whitespace is specified to be
 the same for each of the simpler extractions.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shl}!\idxcode{complex}}%
-\indexlibrary{\idxcode{complex}!\idxcode{operator\shl}}%
+\indexlibrarymember{operator\shl}{complex}%
 \begin{itemdecl}
 template<class T, class charT, class traits>
 basic_ostream<charT, traits>&
@@ -3890,8 +3882,7 @@ explicit random_device(const string& token = @\textit{implementation-defined}@);
  if the \tcode{random_device} could not be initialized.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{random_device}!\idxcode{entropy}}%
-\indexlibrary{\idxcode{entropy}!\idxcode{random_device}}%
+\indexlibrarymember{random_device}{entropy}%
 \begin{itemdecl}
 double entropy() const noexcept;
 \end{itemdecl}
@@ -3911,8 +3902,7 @@ double entropy() const noexcept;
    $\log_2( \tcode{max()}+1)$.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{random_device}!\idxcode{operator()}}%
-\indexlibrary{\idxcode{operator()}!\idxcode{random_device}}%
+\indexlibrarymember{random_device}{operator()}%
 \begin{itemdecl}
 result_type operator()();
 \end{itemdecl}
@@ -4031,8 +4021,7 @@ for( InputIterator s = begin; s != end; ++s)
 \end{codeblock}%
 \end{itemdescr}
 
-\indexlibrary{\idxcode{seed_seq}!\idxcode{generate}}%
-\indexlibrary{\idxcode{generate}!\idxcode{seed_seq}}%
+\indexlibrarymember{seed_seq}{generate}%
 \begin{itemdecl}
 template<class RandomAccessIterator>
   void generate(RandomAccessIterator begin, RandomAccessIterator end);
@@ -4125,8 +4114,7 @@ What and when \tcode{RandomAccessIterator} operations of \tcode{begin}
 and \tcode{end} throw.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{seed_seq}!\idxcode{size}}%
-\indexlibrary{\idxcode{size}!\idxcode{seed_seq}}%
+\indexlibrarymember{seed_seq}{size}%
 \begin{itemdecl}
 size_t size() const noexcept;
 \end{itemdecl}
@@ -4139,8 +4127,7 @@ size_t size() const noexcept;
 \pnum\complexity Constant time.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{seed_seq}!\idxcode{param}}%
-\indexlibrary{\idxcode{param}!\idxcode{seed_seq}}%
+\indexlibrarymember{seed_seq}{param}%
 \begin{itemdecl}
 template<class OutputIterator>
   void param(OutputIterator dest) const;
@@ -4358,8 +4345,7 @@ explicit uniform_int_distribution(IntType a = 0, IntType b = numeric_limits<IntT
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{uniform_int_distribution}!\idxcode{a}}%
-\indexlibrary{\idxcode{a}!\idxcode{uniform_int_distribution}}%
+\indexlibrarymember{uniform_int_distribution}{a}%
 \begin{itemdecl}
 result_type a() const;
 \end{itemdecl}
@@ -4369,8 +4355,7 @@ result_type a() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{uniform_int_distribution}!\idxcode{b}}%
-\indexlibrary{\idxcode{b}!\idxcode{uniform_int_distribution}}%
+\indexlibrarymember{uniform_int_distribution}{b}%
 \begin{itemdecl}
 result_type b() const;
 \end{itemdecl}
@@ -4450,8 +4435,7 @@ explicit uniform_real_distribution(RealType a = 0.0, RealType b = 1.0);
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{uniform_real_distribution}!\idxcode{a}}%
-\indexlibrary{\idxcode{a}!\idxcode{uniform_real_distribution}}%
+\indexlibrarymember{uniform_real_distribution}{a}%
 \begin{itemdecl}
 result_type a() const;
 \end{itemdecl}
@@ -4461,8 +4445,7 @@ result_type a() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{uniform_real_distribution}!\idxcode{b}}%
-\indexlibrary{\idxcode{b}!\idxcode{uniform_real_distribution}}%
+\indexlibrarymember{uniform_real_distribution}{b}%
 \begin{itemdecl}
 result_type b() const;
 \end{itemdecl}
@@ -4551,8 +4534,7 @@ explicit bernoulli_distribution(double p = 0.5);
  corresponds to the parameter of the distribution.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{bernoulli_distribution}!\idxcode{p}}%
-\indexlibrary{\idxcode{p}!\idxcode{bernoulli_distribution}}%
+\indexlibrarymember{bernoulli_distribution}{p}%
 \begin{itemdecl}
 double p() const;
 \end{itemdecl}
@@ -4627,8 +4609,7 @@ explicit binomial_distribution(IntType t = 1, double p = 0.5);
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{binomial_distribution}!\idxcode{t}}%
-\indexlibrary{\idxcode{t}!\idxcode{binomial_distribution}}%
+\indexlibrarymember{binomial_distribution}{t}%
 \begin{itemdecl}
 IntType t() const;
 \end{itemdecl}%
@@ -4637,8 +4618,7 @@ IntType t() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{binomial_distribution}!\idxcode{p}}%
-\indexlibrary{\idxcode{p}!\idxcode{binomial_distribution}}%
+\indexlibrarymember{binomial_distribution}{p}%
 \begin{itemdecl}
 double p() const;
 \end{itemdecl}
@@ -4712,8 +4692,7 @@ explicit geometric_distribution(double p = 0.5);
  corresponds to the parameter of the distribution.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{geometric_distribution}!\idxcode{p}}%
-\indexlibrary{\idxcode{p}!\idxcode{geometric_distribution}}%
+\indexlibrarymember{geometric_distribution}{p}%
 \begin{itemdecl}
 double p() const;
 \end{itemdecl}
@@ -4793,8 +4772,7 @@ explicit negative_binomial_distribution(IntType k = 1, double p = 0.5);
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{negative_binomial_distribution}!\idxcode{t}}%
-\indexlibrary{\idxcode{t}!\idxcode{negative_binomial_distribution}}%
+\indexlibrarymember{negative_binomial_distribution}{t}%
 \begin{itemdecl}
 IntType k() const;
 \end{itemdecl}
@@ -4804,8 +4782,7 @@ IntType k() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{negative_binomial_distribution}!\idxcode{p}}%
-\indexlibrary{\idxcode{p}!\idxcode{negative_binomial_distribution}}%
+\indexlibrarymember{negative_binomial_distribution}{p}%
 \begin{itemdecl}
 double p() const;
 \end{itemdecl}
@@ -4899,8 +4876,7 @@ explicit poisson_distribution(double mean = 1.0);
  corresponds to the parameter of the distribution.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{poisson_distribution}!\idxcode{mean}}%
-\indexlibrary{\idxcode{mean}!\idxcode{poisson_distribution}}%
+\indexlibrarymember{poisson_distribution}{mean}%
 \begin{itemdecl}
 double mean() const;
 \end{itemdecl}
@@ -4974,8 +4950,7 @@ explicit exponential_distribution(RealType lambda = 1.0);
  corresponds to the parameter of the distribution.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{exponential_distribution}!\idxcode{lambda}}%
-\indexlibrary{\idxcode{lambda}!\idxcode{exponential_distribution}}%
+\indexlibrarymember{exponential_distribution}{lambda}%
 \begin{itemdecl}
 RealType lambda() const;
 \end{itemdecl}
@@ -5052,8 +5027,7 @@ explicit gamma_distribution(RealType alpha = 1.0, RealType beta = 1.0);
  correspond to the parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{gamma_distribution}!\idxcode{alpha}}%
-\indexlibrary{\idxcode{alpha}!\idxcode{gamma_distribution}}%
+\indexlibrarymember{gamma_distribution}{alpha}%
 \begin{itemdecl}
 RealType alpha() const;
 \end{itemdecl}
@@ -5063,8 +5037,7 @@ RealType alpha() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{gamma_distribution}!\idxcode{beta}}%
-\indexlibrary{\idxcode{beta}!\idxcode{gamma_distribution}}%
+\indexlibrarymember{gamma_distribution}{beta}%
 \begin{itemdecl}
 RealType beta() const;
 \end{itemdecl}
@@ -5140,8 +5113,7 @@ explicit weibull_distribution(RealType a = 1.0, RealType b = 1.0);
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{weibull_distribution}!\idxcode{a}}%
-\indexlibrary{\idxcode{a}!\idxcode{weibull_distribution}}%
+\indexlibrarymember{weibull_distribution}{a}%
 \begin{itemdecl}
 RealType a() const;
 \end{itemdecl}
@@ -5151,8 +5123,7 @@ RealType a() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{weibull_distribution}!\idxcode{b}}%
-\indexlibrary{\idxcode{b}!\idxcode{weibull_distribution}}%
+\indexlibrarymember{weibull_distribution}{b}%
 \begin{itemdecl}
 RealType b() const;
 \end{itemdecl}
@@ -5238,8 +5209,7 @@ explicit extreme_value_distribution(RealType a = 0.0, RealType b = 1.0);
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{extreme_value_distribution}!\idxcode{a}}%
-\indexlibrary{\idxcode{a}!\idxcode{extreme_value_distribution}}%
+\indexlibrarymember{extreme_value_distribution}{a}%
 \begin{itemdecl}
 RealType a() const;
 \end{itemdecl}
@@ -5249,8 +5219,7 @@ RealType a() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{extreme_value_distribution}!\idxcode{b}}%
-\indexlibrary{\idxcode{b}!\idxcode{extreme_value_distribution}}%
+\indexlibrarymember{extreme_value_distribution}{b}%
 \begin{itemdecl}
 RealType b() const;
 \end{itemdecl}
@@ -5352,8 +5321,7 @@ explicit normal_distribution(RealType mean = 0.0, RealType stddev = 1.0);
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{normal_distribution}!\idxcode{mean}}%
-\indexlibrary{\idxcode{mean}!\idxcode{normal_distribution}}%
+\indexlibrarymember{normal_distribution}{mean}%
 \begin{itemdecl}
 RealType mean() const;
 \end{itemdecl}
@@ -5363,8 +5331,7 @@ RealType mean() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{normal_distribution}!\idxcode{stddev}}%
-\indexlibrary{\idxcode{stddev}!\idxcode{normal_distribution}}%
+\indexlibrarymember{normal_distribution}{stddev}%
 \begin{itemdecl}
 RealType stddev() const;
 \end{itemdecl}
@@ -5446,8 +5413,7 @@ explicit lognormal_distribution(RealType m = 0.0, RealType s = 1.0);
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{lognormal_distribution}!\idxcode{m}}%
-\indexlibrary{\idxcode{m}!\idxcode{lognormal_distribution}}%
+\indexlibrarymember{lognormal_distribution}{m}%
 \begin{itemdecl}
 RealType m() const;
 \end{itemdecl}
@@ -5457,8 +5423,7 @@ RealType m() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{lognormal_distribution}!\idxcode{s}}%
-\indexlibrary{\idxcode{s}!\idxcode{lognormal_distribution}}%
+\indexlibrarymember{lognormal_distribution}{s}%
 \begin{itemdecl}
 RealType s() const;
 \end{itemdecl}
@@ -5534,8 +5499,7 @@ explicit chi_squared_distribution(RealType n = 1);
  corresponds to the parameter of the distribution.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{chi_squared_distribution}!\idxcode{n}}%
-\indexlibrary{\idxcode{n}!\idxcode{chi_squared_distribution}}%
+\indexlibrarymember{chi_squared_distribution}{n}%
 \begin{itemdecl}
 RealType n() const;
 \end{itemdecl}
@@ -5610,8 +5574,7 @@ explicit cauchy_distribution(RealType a = 0.0, RealType b = 1.0);
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{cauchy_distribution}!\idxcode{a}}%
-\indexlibrary{\idxcode{a}!\idxcode{cauchy_distribution}}%
+\indexlibrarymember{cauchy_distribution}{a}%
 \begin{itemdecl}
 RealType a() const;
 \end{itemdecl}
@@ -5621,8 +5584,7 @@ RealType a() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{cauchy_distribution}!\idxcode{b}}%
-\indexlibrary{\idxcode{b}!\idxcode{cauchy_distribution}}%
+\indexlibrarymember{cauchy_distribution}{b}%
 \begin{itemdecl}
 RealType b() const;
 \end{itemdecl}
@@ -5705,8 +5667,7 @@ explicit fisher_f_distribution(RealType m = 1, RealType n = 1);
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{fisher_f_distribution}!\idxcode{m}}%
-\indexlibrary{\idxcode{m}!\idxcode{fisher_f_distribution}}%
+\indexlibrarymember{fisher_f_distribution}{m}%
 \begin{itemdecl}
 RealType m() const;
 \end{itemdecl}
@@ -5716,8 +5677,7 @@ RealType m() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{fisher_f_distribution}!\idxcode{n}}%
-\indexlibrary{\idxcode{n}!\idxcode{fisher_f_distribution}}%
+\indexlibrarymember{fisher_f_distribution}{n}%
 \begin{itemdecl}
 RealType n() const;
 \end{itemdecl}
@@ -5795,8 +5755,7 @@ explicit student_t_distribution(RealType n = 1);
  \tcode{n} corresponds to the parameter of the distribution.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{student_t_distribution}!\idxcode{mean}}%
-\indexlibrary{\idxcode{mean}!\idxcode{student_t_distribution}}%
+\indexlibrarymember{student_t_distribution}{mean}%
 \begin{itemdecl}
 RealType n() const;
 \end{itemdecl}
@@ -5970,8 +5929,7 @@ template<class UnaryOperation>
  The number of invocations of \tcode{fw} shall not exceed $n$.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{discrete_distribution}!\idxcode{probabilities}}%
-\indexlibrary{\idxcode{probabilities}!\idxcode{discrete_distribution}}%
+\indexlibrarymember{discrete_distribution}{probabilities}%
 \begin{itemdecl}
 vector<double> probabilities() const;
 \end{itemdecl}
@@ -6181,8 +6139,7 @@ template<class UnaryOperation>
  The number of invocations of \tcode{fw} shall not exceed $n$.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{piecewise_constant_distribution}!\idxcode{intervals}}%
-\indexlibrary{\idxcode{intervals}!\idxcode{piecewise_constant_distribution}}%
+\indexlibrarymember{piecewise_constant_distribution}{intervals}%
 \begin{itemdecl}
 vector<result_type> intervals() const;
 \end{itemdecl}
@@ -6194,8 +6151,7 @@ vector<result_type> intervals() const;
  when invoked with argument $k$ for $k = 0, \ldots, n $.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{piecewise_constant_distribution}!\idxcode{densities}}%
-\indexlibrary{\idxcode{densities}!\idxcode{piecewise_constant_distribution}}%
+\indexlibrarymember{piecewise_constant_distribution}{densities}%
 \begin{itemdecl}
 vector<result_type> densities() const;
 \end{itemdecl}
@@ -6404,8 +6360,7 @@ template<class UnaryOperation>
  The number of invocations of \tcode{fw} shall not exceed $n+1$.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{piecewise_linear_distribution}!\idxcode{intervals}}%
-\indexlibrary{\idxcode{intervals}!\idxcode{piecewise_linear_distribution}}%
+\indexlibrarymember{piecewise_linear_distribution}{intervals}%
 \begin{itemdecl}
 vector<result_type> intervals() const;
 \end{itemdecl}
@@ -6417,8 +6372,7 @@ vector<result_type> intervals() const;
  when invoked with argument $k$ for $k = 0, \ldots, n $.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{piecewise_linear_distribution}!\idxcode{densities}}%
-\indexlibrary{\idxcode{densities}!\idxcode{piecewise_linear_distribution}}%
+\indexlibrarymember{piecewise_linear_distribution}{densities}%
 \begin{itemdecl}
 vector<result_type> densities() const;
 \end{itemdecl}
@@ -6979,8 +6933,7 @@ The value of \tcode{v} after the assignment is not specified.
 \complexity Linear.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{valarray}%
 \begin{itemdecl}
 valarray& operator=(initializer_list<T> il);
 \end{itemdecl}
@@ -7006,8 +6959,7 @@ The scalar assignment operator causes each element of the
 array to be assigned the value of the argument.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{valarray}%
 \begin{itemdecl}
 valarray& operator=(const slice_array<T>&);
 valarray& operator=(const gslice_array<T>&);
@@ -7318,10 +7270,8 @@ applying the indicated operator to the corresponding element of the array.
 \indexlibrary{\idxcode{operator\^{}=}!\idxcode{valarray}}%
 \indexlibrary{\idxcode{operator\&=}!\idxcode{valarray}}%
 \indexlibrary{\idxcode{operator"|=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator\shl=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator\shl=}}%
-\indexlibrary{\idxcode{operator\shr=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator\shr=}}%
+\indexlibrarymember{operator\shl=}{valarray}%
+\indexlibrarymember{operator\shr=}{valarray}%
 \begin{itemdecl}
 valarray& operator*= (const valarray&);
 valarray& operator/= (const valarray&);
@@ -7359,26 +7309,17 @@ assignment operator depends on the value of another element in that left
 hand side, the resulting behavior is undefined.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator*=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator*=}}%
-\indexlibrary{\idxcode{operator/=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator/=}}%
-\indexlibrary{\idxcode{operator\%=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator\%=}}%
-\indexlibrary{\idxcode{operator+=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator+=}}%
-\indexlibrary{\idxcode{operator-=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator-=}}%
+\indexlibrarymember{operator*=}{valarray}%
+\indexlibrarymember{operator/=}{valarray}%
+\indexlibrarymember{operator\%=}{valarray}%
+\indexlibrarymember{operator+=}{valarray}%
+\indexlibrarymember{operator-=}{valarray}%
 \indexlibrary{\idxcode{operator\^{}=}!\idxcode{valarray}}%
 \indexlibrary{\idxcode{valarray}!\idxcode{operator\^{}=}}%
-\indexlibrary{\idxcode{operator\&=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator\&=}}%
-\indexlibrary{\idxcode{operator"|=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator"|=}}%
-\indexlibrary{\idxcode{operator\shl=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator\shl=}}%
-\indexlibrary{\idxcode{operator\shr=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator\shr=}}%
+\indexlibrarymember{operator\&=}{valarray}%
+\indexlibrarymember{operator"|=}{valarray}%
+\indexlibrarymember{operator\shl=}{valarray}%
+\indexlibrarymember{operator\shr=}{valarray}%
 \begin{itemdecl}
 valarray& operator*= (const T&);
 valarray& operator/= (const T&);
@@ -7413,8 +7354,7 @@ invalidate references or pointers to the elements of the array.
 
 \rSec3[valarray.members]{\tcode{valarray} member functions}
 
-\indexlibrary{\idxcode{swap}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{swap}}%
+\indexlibrarymember{swap}{valarray}%
 \begin{itemdecl}
 void swap(valarray& v) noexcept;
 \end{itemdecl}
@@ -7428,8 +7368,7 @@ void swap(valarray& v) noexcept;
 \complexity Constant.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{size}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{size}}%
+\indexlibrarymember{size}{valarray}%
 \begin{itemdecl}
 size_t size() const;
 \end{itemdecl}
@@ -7442,8 +7381,7 @@ size_t size() const;
 \complexity Constant time.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sum}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{sum}}%
+\indexlibrarymember{sum}{valarray}%
 \begin{itemdecl}
 T sum() const;
 \end{itemdecl}
@@ -7467,8 +7405,7 @@ all other elements of the array in an unspecified order.%
 \indextext{unspecified behavior}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{min}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{min}}%
+\indexlibrarymember{min}{valarray}%
 \begin{itemdecl}
 T min() const;
 \end{itemdecl}
@@ -7485,8 +7422,7 @@ lengths, the determination is made using
 \tcode{operator<}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{max}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{max}}%
+\indexlibrarymember{max}{valarray}%
 \begin{itemdecl}
 T max() const;
 \end{itemdecl}
@@ -7503,8 +7439,7 @@ lengths, the determination is made using
 \tcode{operator<}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{shift}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{shift}}%
+\indexlibrarymember{shift}{valarray}%
 \begin{itemdecl}
 valarray shift(int n) const;
 \end{itemdecl}
@@ -7537,8 +7472,7 @@ of the first element of the argument; etc.
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{cshift}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{cshift}}%
+\indexlibrarymember{cshift}{valarray}%
 \begin{itemdecl}
 valarray cshift(int n) const;
 \end{itemdecl}
@@ -7552,8 +7486,7 @@ of length
 that is a circular shift of \tcode{*this}. If element zero is taken as the leftmost element, a non-negative value of \emph{n} shifts the elements circularly left \emph{n} places and a negative value of \emph{n} shifts the elements circularly right \emph{-n} places.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{apply}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{apply}}%
+\indexlibrarymember{apply}{valarray}%
 \begin{itemdecl}
 valarray apply(T func(T)) const;
 valarray apply(T func(const T&)) const;
@@ -7567,8 +7500,7 @@ the value returned by applying the argument function to the
 corresponding element of the array.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{resize}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{resize}}%
+\indexlibrarymember{resize}{valarray}%
 \begin{itemdecl}
 void resize(size_t sz, T c = T());
 \end{itemdecl}
@@ -7595,10 +7527,8 @@ Resizing invalidates all pointers and references to elements in the array.
 \indexlibrary{\idxcode{operator\^{}}!\idxcode{valarray}}%
 \indexlibrary{\idxcode{operator\&}!\idxcode{valarray}}%
 \indexlibrary{\idxcode{operator"|}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator\shl}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator\shl}}%
-\indexlibrary{\idxcode{operator\shr}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator\shr}}%
+\indexlibrarymember{operator\shl}{valarray}%
+\indexlibrarymember{operator\shr}{valarray}%
 \indexlibrary{\idxcode{operator\&\&}!\idxcode{valarray}}%
 \indexlibrary{\idxcode{operator"|"|}!\idxcode{valarray}}%
 \begin{itemdecl}
@@ -7643,26 +7573,17 @@ If the argument arrays do not have the same length, the behavior is undefined.%
 \indextext{undefined}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator*}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator*}}%
-\indexlibrary{\idxcode{operator/}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator/}}%
-\indexlibrary{\idxcode{operator\%}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator\%}}%
-\indexlibrary{\idxcode{operator+}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator+}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator=}}%
+\indexlibrarymember{operator*}{valarray}%
+\indexlibrarymember{operator/}{valarray}%
+\indexlibrarymember{operator\%}{valarray}%
+\indexlibrarymember{operator+}{valarray}%
+\indexlibrarymember{operator=}{valarray}%
 \indexlibrary{\idxcode{operator\^{}}!\idxcode{valarray}}%
 \indexlibrary{\idxcode{valarray}!\idxcode{operator\^{}}}%
-\indexlibrary{\idxcode{operator\&}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator\&}}%
-\indexlibrary{\idxcode{operator"|}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator"|}}%
-\indexlibrary{\idxcode{operator\shl}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator\shl}}%
-\indexlibrary{\idxcode{operator\shr}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator\shr}}%
+\indexlibrarymember{operator\&}{valarray}%
+\indexlibrarymember{operator"|}{valarray}%
+\indexlibrarymember{operator\shl}{valarray}%
+\indexlibrarymember{operator\shr}{valarray}%
 \begin{itemdecl}
 template<class T> valarray<T> operator* (const valarray<T>&, const T&);
 template<class T> valarray<T> operator* (const T&, const valarray<T>&);
@@ -7750,22 +7671,15 @@ the behavior is undefined.%
 \indextext{undefined}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator==}}%
+\indexlibrarymember{operator==}{valarray}%
 \indexlibrary{\idxcode{operator"!=}!\idxcode{valarray}}%
 \indexlibrary{\idxcode{valarray}!\idxcode{operator"!=}}%
-\indexlibrary{\idxcode{operator<}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator<}}%
-\indexlibrary{\idxcode{operator<=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator<=}}%
-\indexlibrary{\idxcode{operator>}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator>}}%
-\indexlibrary{\idxcode{operator>=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator>=}}%
-\indexlibrary{\idxcode{operator\&\&}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator\&\&}}%
-\indexlibrary{\idxcode{operator"|"|}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator"|"|}}%
+\indexlibrarymember{operator<}{valarray}%
+\indexlibrarymember{operator<=}{valarray}%
+\indexlibrarymember{operator>}{valarray}%
+\indexlibrarymember{operator>=}{valarray}%
+\indexlibrarymember{operator\&\&}{valarray}%
+\indexlibrarymember{operator"|"|}{valarray}%
 \begin{itemdecl}
 template<class T> valarray<bool> operator==(const valarray<T>&, const T&);
 template<class T> valarray<bool> operator==(const T&, const valarray<T>&);
@@ -7853,8 +7767,7 @@ or which can be unambiguously implicitly converted to type \tcode{T}.
 
 \rSec3[valarray.special]{\tcode{valarray} specialized algorithms}
 
-\indexlibrary{\idxcode{swap}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{swap}}%
+\indexlibrarymember{swap}{valarray}%
 \begin{itemdecl}
 template <class T> void swap(valarray<T>& x, valarray<T>& y) noexcept;
 \end{itemdecl}
@@ -8033,10 +7946,8 @@ object refers.
 \indexlibrary{\idxcode{operator\^{}=}!\idxcode{slice_array}}%
 \indexlibrary{\idxcode{operator\&=}!\idxcode{slice_array}}%
 \indexlibrary{\idxcode{operator"|=}!\idxcode{slice_array}}%
-\indexlibrary{\idxcode{operator\shl=}!\idxcode{slice_array}}%
-\indexlibrary{\idxcode{slice_array}!\idxcode{operator\shl=}}%
-\indexlibrary{\idxcode{operator\shr=}!\idxcode{slice_array}}%
-\indexlibrary{\idxcode{slice_array}!\idxcode{operator\shr=}}%
+\indexlibrarymember{operator\shl=}{slice_array}%
+\indexlibrarymember{operator\shr=}{slice_array}%
 \begin{itemdecl}
 void operator*= (const valarray<T>&) const;
 void operator/= (const valarray<T>&) const;
@@ -8321,10 +8232,8 @@ refers.
 \indexlibrary{\idxcode{operator\^{}=}!\idxcode{gslice_array}}%
 \indexlibrary{\idxcode{operator\&=}!\idxcode{gslice_array}}%
 \indexlibrary{\idxcode{operator"|=}!\idxcode{gslice_array}}%
-\indexlibrary{\idxcode{operator\shl=}!\idxcode{gslice_array}}%
-\indexlibrary{\idxcode{gslice_array}!\idxcode{operator\shl=}}%
-\indexlibrary{\idxcode{operator\shr=}!\idxcode{gslice_array}}%
-\indexlibrary{\idxcode{gslice_array}!\idxcode{operator\shr=}}%
+\indexlibrarymember{operator\shl=}{gslice_array}%
+\indexlibrarymember{operator\shr=}{gslice_array}%
 \begin{itemdecl}
 void operator*= (const valarray<T>&) const;
 void operator/= (const valarray<T>&) const;
@@ -8402,8 +8311,7 @@ namespace std {
 \pnum
 This template is a helper template used by the mask subscript operator:
 
-\indexlibrary{\idxcode{operator[]}!\idxcode{mask_array}}%
-\indexlibrary{\idxcode{mask_array}!\idxcode{operator[]}}%
+\indexlibrarymember{operator[]}{mask_array}%
 \begin{itemdecl}
 mask_array<T> valarray<T>::operator[](const valarray<bool>&).
 \end{itemdecl}
@@ -8451,10 +8359,8 @@ object to which it refers.
 \indexlibrary{\idxcode{operator\^{}=}!\idxcode{mask_array}}%
 \indexlibrary{\idxcode{operator\&=}!\idxcode{mask_array}}%
 \indexlibrary{\idxcode{operator"|=}!\idxcode{mask_array}}%
-\indexlibrary{\idxcode{operator\shl=}!\idxcode{mask_array}}%
-\indexlibrary{\idxcode{mask_array}!\idxcode{operator\shl=}}%
-\indexlibrary{\idxcode{operator\shr=}!\idxcode{mask_array}}%
-\indexlibrary{\idxcode{mask_array}!\idxcode{operator\shr=}}%
+\indexlibrarymember{operator\shl=}{mask_array}%
+\indexlibrarymember{operator\shr=}{mask_array}%
 \begin{itemdecl}
 void operator*= (const valarray<T>&) const;
 void operator/= (const valarray<T>&) const;
@@ -8530,8 +8436,7 @@ namespace std {
 \pnum
 This template is a helper template used by the indirect subscript operator
 
-\indexlibrary{\idxcode{operator[]}!\idxcode{indirect_array}}%
-\indexlibrary{\idxcode{indirect_array}!\idxcode{operator[]}}%
+\indexlibrarymember{operator[]}{indirect_array}%
 \begin{itemdecl}
 indirect_array<T> valarray<T>::operator[](const valarray<size_t>&).
 \end{itemdecl}
@@ -8598,10 +8503,8 @@ indirection.
 \indexlibrary{\idxcode{operator\^{}=}!\idxcode{indirect_array}}%
 \indexlibrary{\idxcode{operator\&=}!\idxcode{indirect_array}}%
 \indexlibrary{\idxcode{operator"|=}!\idxcode{indirect_array}}%
-\indexlibrary{\idxcode{operator\shl=}!\idxcode{indirect_array}}%
-\indexlibrary{\idxcode{indirect_array}!\idxcode{operator\shl=}}%
-\indexlibrary{\idxcode{operator\shr=}!\idxcode{indirect_array}}%
-\indexlibrary{\idxcode{indirect_array}!\idxcode{operator\shr=}}%
+\indexlibrarymember{operator\shl=}{indirect_array}%
+\indexlibrarymember{operator\shr=}{indirect_array}%
 \begin{itemdecl}
 void operator*= (const valarray<T>&) const;
 void operator/= (const valarray<T>&) const;
@@ -8673,8 +8576,7 @@ are guaranteed to be valid until the member function
 array or until the lifetime of that array ends, whichever happens
 first.
 
-\indexlibrary{\idxcode{begin}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{begin}}%
+\indexlibrarymember{begin}{valarray}%
 \begin{itemdecl}
 template <class T> @\unspec{1}@ begin(valarray<T>& v);
 template <class T> @\unspec{2}@ begin(const valarray<T>& v);
@@ -8685,8 +8587,7 @@ template <class T> @\unspec{2}@ begin(const valarray<T>& v);
 \returns An iterator referencing the first value in the numeric array.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{end}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{end}}%
+\indexlibrarymember{end}{valarray}%
 \begin{itemdecl}
 template <class T> @\unspec{1}@ end(valarray<T>& v);
 template <class T> @\unspec{2}@ end(const valarray<T>& v);

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -1086,8 +1086,7 @@ The specializations \tcode{regex_traits<char>} and
 \tcode{regex_traits<wchar_t>} shall be valid and shall satisfy the
 requirements for a regular expression traits class~(\ref{re.req}).
 
-\indexlibrary{\idxcode{regex_traits}!\idxcode{char_class_type}}%
-\indexlibrary{\idxcode{char_class_type}!\idxcode{regex_traits}}%
+\indexlibrarymember{regex_traits}{char_class_type}%
 \begin{itemdecl}
 using char_class_type = @\textit{bitmask_type}@; 
 \end{itemdecl}
@@ -1099,8 +1098,7 @@ classification and is capable of holding an implementation specific
 set returned by \tcode{lookup_classname}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{length}!\idxcode{regex_traits}}%
-\indexlibrary{\idxcode{regex_traits}!\idxcode{length}}%
+\indexlibrarymember{length}{regex_traits}%
 \begin{itemdecl}
 static std::size_t length(const char_type* p); 
 \end{itemdecl}
@@ -1109,8 +1107,7 @@ static std::size_t length(const char_type* p);
 \pnum\returns \tcode{char_traits<charT>::length(p)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{regex_traits}!\idxcode{translate}}%
-\indexlibrary{\idxcode{translate}!\idxcode{regex_traits}}%
+\indexlibrarymember{regex_traits}{translate}%
 \begin{itemdecl}
 charT translate(charT c) const; 
 \end{itemdecl}
@@ -1119,8 +1116,7 @@ charT translate(charT c) const;
 \pnum\returns \tcode{(c)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{regex_traits}!\idxcode{translate_nocase}}%
-\indexlibrary{\idxcode{translate_nocase}!\idxcode{regex_traits}}%
+\indexlibrarymember{regex_traits}{translate_nocase}%
 \begin{itemdecl}
 charT translate_nocase(charT c) const; 
 \end{itemdecl}
@@ -1129,8 +1125,7 @@ charT translate_nocase(charT c) const;
 \pnum\returns  \tcode{use_facet<ctype<charT> >(getloc()).tolower(c)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{regex_traits}!\idxcode{transform}}%
-\indexlibrary{\idxcode{transform}!\idxcode{regex_traits}}%
+\indexlibrarymember{regex_traits}{transform}%
 \begin{itemdecl}
 template <class ForwardIterator>
   string_type transform(ForwardIterator first, ForwardIterator last) const; 
@@ -1146,8 +1141,7 @@ return use_facet<collate<charT> >(
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{regex_traits}!\idxcode{transform_primary}}%
-\indexlibrary{\idxcode{transform_primary}!\idxcode{regex_traits}}%
+\indexlibrarymember{regex_traits}{transform_primary}%
 \begin{itemdecl}
 template <class ForwardIterator>
   string_type transform_primary(ForwardIterator first, ForwardIterator last) const; 
@@ -1162,8 +1156,7 @@ can be converted into a primary sort key then returns that key,
 otherwise returns an empty string.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{regex_traits}!\idxcode{lookup_collatename}}%
-\indexlibrary{\idxcode{lookup_collatename}!\idxcode{regex_traits}}%
+\indexlibrarymember{regex_traits}{lookup_collatename}%
 \begin{itemdecl}
 template <class ForwardIterator>
   string_type lookup_collatename(ForwardIterator first, ForwardIterator last) const; 
@@ -1177,8 +1170,7 @@ Returns an empty string if the character sequence is not a
 valid collating element.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{regex_traits}!\idxcode{lookup_classname}}%
-\indexlibrary{\idxcode{lookup_classname}!\idxcode{regex_traits}}%
+\indexlibrarymember{regex_traits}{lookup_classname}%
 \begin{itemdecl}
 template <class ForwardIterator>
   char_class_type lookup_classname(
@@ -1206,8 +1198,7 @@ For \tcode{regex_traits<wchar_t>}, at least the wide character names
 in Table~\ref{tab:re.traits.classnames} shall be recognized.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{regex_traits}!\idxcode{isctype}}%
-\indexlibrary{\idxcode{isctype}!\idxcode{regex_traits}}%
+\indexlibrarymember{regex_traits}{isctype}%
 \begin{itemdecl}
 bool isctype(charT c, char_class_type f) const; 
 \end{itemdecl}
@@ -1268,8 +1259,7 @@ t.isctype(' ', f); // returns \tcode{false}
 
 \end{itemdescr}
 
-\indexlibrary{\idxcode{value}!\idxcode{regex_traits}}%
-\indexlibrary{\idxcode{regex_traits}!\idxcode{value}}%
+\indexlibrarymember{value}{regex_traits}%
 \begin{itemdecl}
 int value(charT ch, int radix) const;
 \end{itemdecl}
@@ -1637,8 +1627,7 @@ basic_regex(initializer_list<charT> il,
 
 \rSec2[re.regex.assign]{\tcode{basic_regex} assign}
 
-\indexlibrary{\idxcode{basic_regex}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{basic_regex}}%
+\indexlibrarymember{basic_regex}{operator=}%
 \begin{itemdecl}
 basic_regex& operator=(const basic_regex& e); 
 \end{itemdecl}
@@ -1652,8 +1641,7 @@ basic_regex& operator=(const basic_regex& e);
 \tcode{e.flags()} and \tcode{e.mark_count()}, respectively.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_regex}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{basic_regex}}%
+\indexlibrarymember{basic_regex}{operator=}%
 \begin{itemdecl}
 basic_regex& operator=(basic_regex&& e) noexcept;
 \end{itemdecl}
@@ -1668,8 +1656,7 @@ basic_regex& operator=(basic_regex&& e) noexcept;
 \tcode{e} is in a valid state with unspecified value.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_regex}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{basic_regex}}%
+\indexlibrarymember{basic_regex}{operator=}%
 \begin{itemdecl}
 basic_regex& operator=(const charT* ptr); 
 \end{itemdecl}
@@ -1682,8 +1669,7 @@ basic_regex& operator=(const charT* ptr);
 \effects Returns \tcode{assign(ptr)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_regex}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{basic_regex}}%
+\indexlibrarymember{basic_regex}{operator=}%
 \begin{itemdecl}
 basic_regex& operator=(initializer_list<charT> il);
 \end{itemdecl}
@@ -1693,8 +1679,7 @@ basic_regex& operator=(initializer_list<charT> il);
 \effects Returns \tcode{assign(il.begin(), il.end())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_regex}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{basic_regex}}%
+\indexlibrarymember{basic_regex}{operator=}%
 \begin{itemdecl}
 template <class ST, class SA>
   basic_regex& operator=(const basic_string<charT, ST, SA>& p); 
@@ -1705,8 +1690,7 @@ template <class ST, class SA>
 \effects Returns \tcode{assign(p)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_regex}!\idxcode{assign}}%
-\indexlibrary{\idxcode{assign}!\idxcode{basic_regex}}%
+\indexlibrarymember{basic_regex}{assign}%
 \begin{itemdecl}
 basic_regex& assign(const basic_regex& that); 
 \end{itemdecl}
@@ -1719,8 +1703,7 @@ basic_regex& assign(const basic_regex& that);
 \returns  \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_regex}!\idxcode{assign}}%
-\indexlibrary{\idxcode{assign}!\idxcode{basic_regex}}%
+\indexlibrarymember{basic_regex}{assign}%
 \begin{itemdecl}
 basic_regex& assign(basic_regex&& that) noexcept;
 \end{itemdecl}
@@ -1733,8 +1716,7 @@ basic_regex& assign(basic_regex&& that) noexcept;
 \returns  \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_regex}!\idxcode{assign}}%
-\indexlibrary{\idxcode{assign}!\idxcode{basic_regex}}%
+\indexlibrarymember{basic_regex}{assign}%
 \begin{itemdecl}
 basic_regex& assign(const charT* ptr, flag_type f = regex_constants::ECMAScript); 
 \end{itemdecl}
@@ -1744,8 +1726,7 @@ basic_regex& assign(const charT* ptr, flag_type f = regex_constants::ECMAScript)
 \returns  \tcode{assign(string_type(ptr), f)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_regex}!\idxcode{assign}}%
-\indexlibrary{\idxcode{assign}!\idxcode{basic_regex}}%
+\indexlibrarymember{basic_regex}{assign}%
 \begin{itemdecl}
 basic_regex& assign(const charT* ptr, size_t len,
   flag_type f = regex_constants::ECMAScript);
@@ -1756,8 +1737,7 @@ basic_regex& assign(const charT* ptr, size_t len,
 \returns \tcode{assign(string_type(ptr, len), f)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_regex}!\idxcode{assign}}%
-\indexlibrary{\idxcode{assign}!\idxcode{basic_regex}}%
+\indexlibrarymember{basic_regex}{assign}%
 \begin{itemdecl}
 template <class string_traits, class A>
   basic_regex& assign(const basic_string<charT, string_traits, A>& s,
@@ -1783,8 +1763,7 @@ If no exception is thrown,
 returns the number of marked sub-expressions within the expression.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_regex}!\idxcode{assign}}%
-\indexlibrary{\idxcode{assign}!\idxcode{basic_regex}}%
+\indexlibrarymember{basic_regex}{assign}%
 \begin{itemdecl}
 template <class InputIterator>
   basic_regex& assign(InputIterator first, InputIterator last,
@@ -1800,8 +1779,7 @@ Iterator~(\ref{input.iterators}).
 \returns  \tcode{assign(string_type(first, last), f)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{assign}!\idxcode{basic_regex}}%
-\indexlibrary{\idxcode{basic_regex}!\idxcode{assign}}%
+\indexlibrarymember{assign}{basic_regex}%
 \begin{itemdecl}
 basic_regex& assign(initializer_list<charT> il,
                     flag_type f = regex_constants::ECMAScript);
@@ -1818,8 +1796,7 @@ basic_regex& assign(initializer_list<charT> il,
 
 \rSec2[re.regex.operations]{\tcode{basic_regex} constant operations}
 
-\indexlibrary{\idxcode{mark_count}!\idxcode{basic_regex}}%
-\indexlibrary{\idxcode{basic_regex}!\idxcode{mark_count}}%
+\indexlibrarymember{mark_count}{basic_regex}%
 \begin{itemdecl}
 unsigned mark_count() const; 
 \end{itemdecl}
@@ -1830,8 +1807,7 @@ unsigned mark_count() const;
 regular expression.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{flag_type}!\idxcode{basic_regex}}%
-\indexlibrary{\idxcode{basic_regex}!\idxcode{flag_type}}%
+\indexlibrarymember{flag_type}{basic_regex}%
 \begin{itemdecl}
 flag_type flags() const; 
 \end{itemdecl}
@@ -1846,8 +1822,7 @@ to \tcode{assign}.
 \rSec2[re.regex.locale]{\tcode{basic_regex} locale}%
 \indexlibrary{\idxcode{locale}}
 
-\indexlibrary{\idxcode{imbue}!\idxcode{basic_regex}}%
-\indexlibrary{\idxcode{basic_regex}!\idxcode{imbue}}%
+\indexlibrarymember{imbue}{basic_regex}%
 \begin{itemdecl}
 locale_type imbue(locale_type loc);
 \end{itemdecl}
@@ -1860,8 +1835,7 @@ to \tcode{imbue} the \tcode{basic_regex} object does not match any
 character sequence.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{getloc}!\idxcode{basic_regex}}%
-\indexlibrary{\idxcode{basic_regex}!\idxcode{getloc}}%
+\indexlibrarymember{getloc}{basic_regex}%
 \begin{itemdecl}
 locale_type getloc() const; 
 \end{itemdecl}
@@ -1873,11 +1847,9 @@ parameter \tcode{traits} stored within the object.
 \end{itemdescr}
 
 \rSec2[re.regex.swap]{\tcode{basic_regex} swap}
-\indexlibrary{\idxcode{basic_regex}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{basic_regex}}%
+\indexlibrarymember{basic_regex}{swap}%
 
-\indexlibrary{\idxcode{swap}!\idxcode{basic_regex}}%
-\indexlibrary{\idxcode{basic_regex}!\idxcode{swap}}%
+\indexlibrarymember{swap}{basic_regex}%
 \begin{itemdecl}
 void swap(basic_regex& e); 
 \end{itemdecl}
@@ -1895,8 +1867,7 @@ was in \tcode{*this}.
 \rSec2[re.regex.nonmemb]{\tcode{basic_regex} non-member functions}
 
 \rSec3[re.regex.nmswap]{\tcode{basic_regex} non-member swap}
-\indexlibrary{\idxcode{basic_regex}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{basic_regex}}%
+\indexlibrarymember{basic_regex}{swap}%
 \begin{itemdecl}
 template <class charT, class traits>
   void swap(basic_regex<charT, traits>& lhs, basic_regex<charT, traits>& rhs); 
@@ -1953,8 +1924,7 @@ constexpr sub_match();
 \tcode{matched}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{length}}%
-\indexlibrary{\idxcode{length}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{length}%
 \begin{itemdecl}
 difference_type length() const;
 \end{itemdecl}
@@ -1963,8 +1933,7 @@ difference_type length() const;
 \pnum\returns  \tcode{(matched ? distance(first, second) : 0)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator basic_string}!\idxcode{sub_match}}%
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator basic_string}}%
+\indexlibrarymember{operator basic_string}{sub_match}%
 \begin{itemdecl}
 operator string_type() const;
 \end{itemdecl}
@@ -1973,8 +1942,7 @@ operator string_type() const;
 \pnum\returns \tcode{matched ? string_type(first, second) : string_type()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{str}}%
-\indexlibrary{\idxcode{str}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{str}%
 \begin{itemdecl}
 string_type str() const;
 \end{itemdecl}
@@ -1983,8 +1951,7 @@ string_type str() const;
 \pnum\returns  \tcode{matched ? string_type(first, second) : string_type()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{compare}}%
-\indexlibrary{\idxcode{compare}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{compare}%
 \begin{itemdecl}
 int compare(const sub_match& s) const;
 \end{itemdecl}
@@ -1993,8 +1960,7 @@ int compare(const sub_match& s) const;
 \pnum\returns  \tcode{str().compare(s.str())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{compare}}%
-\indexlibrary{\idxcode{compare}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{compare}%
 \begin{itemdecl}
 int compare(const string_type& s) const;
 \end{itemdecl}
@@ -2003,8 +1969,7 @@ int compare(const string_type& s) const;
 \pnum\returns  \tcode{str().compare(s)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{compare}}%
-\indexlibrary{\idxcode{compare}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{compare}%
 \begin{itemdecl}
 int compare(const value_type* s) const;
 \end{itemdecl}
@@ -2015,8 +1980,7 @@ int compare(const value_type* s) const;
 
 \rSec2[re.submatch.op]{\tcode{sub_match} non-member operators}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator==}}%
-\indexlibrary{\idxcode{operator==}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator==}%
 \begin{itemdecl}
 template <class BiIter>
   bool operator==(const sub_match<BiIter>& lhs, const sub_match<BiIter>& rhs); 
@@ -2026,8 +1990,7 @@ template <class BiIter>
 \pnum\returns  \tcode{lhs.compare(rhs) == 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator"!=}}%
-\indexlibrary{\idxcode{operator"!=}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator"!=}%
 \begin{itemdecl}
 template <class BiIter>
   bool operator!=(const sub_match<BiIter>& lhs, const sub_match<BiIter>& rhs); 
@@ -2037,8 +2000,7 @@ template <class BiIter>
 \pnum\returns \tcode{lhs.compare(rhs) != 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator<}}%
-\indexlibrary{\idxcode{operator<}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator<}%
 \begin{itemdecl}
 template <class BiIter>
   bool operator<(const sub_match<BiIter>& lhs, const sub_match<BiIter>& rhs); 
@@ -2048,8 +2010,7 @@ template <class BiIter>
 \pnum\returns  \tcode{lhs.compare(rhs) < 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator<=}}%
-\indexlibrary{\idxcode{operator<=}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator<=}%
 \begin{itemdecl}
 template <class BiIter>
   bool operator<=(const sub_match<BiIter>& lhs, const sub_match<BiIter>& rhs); 
@@ -2059,8 +2020,7 @@ template <class BiIter>
 \pnum\returns  \tcode{lhs.compare(rhs) <= 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator>=}}%
-\indexlibrary{\idxcode{operator>=}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator>=}%
 \begin{itemdecl}
 template <class BiIter>
   bool operator>=(const sub_match<BiIter>& lhs, const sub_match<BiIter>& rhs); 
@@ -2070,8 +2030,7 @@ template <class BiIter>
 \pnum\returns  \tcode{lhs.compare(rhs) >= 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator>}}%
-\indexlibrary{\idxcode{operator>}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator>}%
 \begin{itemdecl}
 template <class BiIter>
   bool operator>(const sub_match<BiIter>& lhs, const sub_match<BiIter>& rhs); 
@@ -2081,8 +2040,7 @@ template <class BiIter>
 \pnum\returns  \tcode{lhs.compare(rhs) > 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator==}}%
-\indexlibrary{\idxcode{operator==}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator==}%
 \begin{itemdecl}
 template <class BiIter, class ST, class SA>
   bool operator==(
@@ -2095,8 +2053,7 @@ template <class BiIter, class ST, class SA>
 \pnum\returns  \tcode{rhs.compare(typename sub_match<BiIter>::string_type(lhs.data(), lhs.size())) == 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator"!=}}%
-\indexlibrary{\idxcode{operator"!=}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator"!=}%
 \begin{itemdecl}
 template <class BiIter, class ST, class SA>
   bool operator!=(
@@ -2109,8 +2066,7 @@ template <class BiIter, class ST, class SA>
 \pnum\returns  \tcode{!(lhs == rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator<}}%
-\indexlibrary{\idxcode{operator<}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator<}%
 \begin{itemdecl}
 template <class BiIter, class ST, class SA>
   bool operator<(
@@ -2123,8 +2079,7 @@ template <class BiIter, class ST, class SA>
 \pnum\returns  \tcode{rhs.compare(typename sub_match<BiIter>::string_type(lhs.data(), lhs.size())) > 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator>}}%
-\indexlibrary{\idxcode{operator>}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator>}%
 \begin{itemdecl}
 template <class BiIter, class ST, class SA>
   bool operator>(
@@ -2137,8 +2092,7 @@ template <class BiIter, class ST, class SA>
 \pnum\returns  \tcode{rhs < lhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator>=}}%
-\indexlibrary{\idxcode{operator>=}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator>=}%
 \begin{itemdecl}
 template <class BiIter, class ST, class SA>
   bool operator>=(
@@ -2151,8 +2105,7 @@ template <class BiIter, class ST, class SA>
 \pnum\returns  \tcode{!(lhs < rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator<=}}%
-\indexlibrary{\idxcode{operator<=}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator<=}%
 \begin{itemdecl}
 template <class BiIter, class ST, class SA>
   bool operator<=(
@@ -2165,8 +2118,7 @@ template <class BiIter, class ST, class SA>
 \pnum\returns  \tcode{!(rhs < lhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{sub_match}}%
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator==}}%
+\indexlibrarymember{operator==}{sub_match}%
 \begin{itemdecl}
 template <class BiIter, class ST, class SA>
   bool operator==(const sub_match<BiIter>& lhs,
@@ -2204,8 +2156,7 @@ template <class BiIter, class ST, class SA>
 \pnum\returns  \tcode{lhs.compare(typename sub_match<BiIter>::string_type(rhs.data(), rhs.size())) < 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>}!\idxcode{sub_match}}%
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator>}}%
+\indexlibrarymember{operator>}{sub_match}%
 \begin{itemdecl}
 template <class BiIter, class ST, class SA>
   bool operator>(const sub_match<BiIter>& lhs,
@@ -2217,8 +2168,7 @@ template <class BiIter, class ST, class SA>
 \pnum\returns  \tcode{rhs < lhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{sub_match}}%
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator>=}}%
+\indexlibrarymember{operator>=}{sub_match}%
 \begin{itemdecl}
 template <class BiIter, class ST, class SA>
   bool operator>=(const sub_match<BiIter>& lhs,
@@ -2230,8 +2180,7 @@ template <class BiIter, class ST, class SA>
 \pnum\returns  \tcode{!(lhs < rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{sub_match}}%
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator<=}}%
+\indexlibrarymember{operator<=}{sub_match}%
 \begin{itemdecl}
 template <class BiIter, class ST, class SA>
   bool operator<=(const sub_match<BiIter>& lhs,
@@ -2243,8 +2192,7 @@ template <class BiIter, class ST, class SA>
 \pnum\returns  \tcode{!(rhs < lhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator==}}%
-\indexlibrary{\idxcode{operator==}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator==}%
 \begin{itemdecl}
 template <class BiIter> 
   bool operator==(typename iterator_traits<BiIter>::value_type const* lhs, 
@@ -2255,8 +2203,7 @@ template <class BiIter>
 \pnum\returns  \tcode{rhs.compare(lhs) == 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator"!=}}%
-\indexlibrary{\idxcode{operator"!=}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator"!=}%
 \begin{itemdecl}
 template <class BiIter> 
   bool operator!=(typename iterator_traits<BiIter>::value_type const* lhs, 
@@ -2267,8 +2214,7 @@ template <class BiIter>
 \pnum\returns  \tcode{!(lhs == rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator<}}%
-\indexlibrary{\idxcode{operator<}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator<}%
 \begin{itemdecl}
 template <class BiIter> 
   bool operator<(typename iterator_traits<BiIter>::value_type const* lhs, 
@@ -2279,8 +2225,7 @@ template <class BiIter>
 \pnum\returns  \tcode{rhs.compare(lhs) > 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator>}}%
-\indexlibrary{\idxcode{operator>}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator>}%
 \begin{itemdecl}
 template <class BiIter> 
   bool operator>(typename iterator_traits<BiIter>::value_type const* lhs, 
@@ -2291,8 +2236,7 @@ template <class BiIter>
 \pnum\returns  \tcode{rhs < lhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator>=}}%
-\indexlibrary{\idxcode{operator>=}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator>=}%
 \begin{itemdecl}
 template <class BiIter> 
   bool operator>=(typename iterator_traits<BiIter>::value_type const* lhs, 
@@ -2303,8 +2247,7 @@ template <class BiIter>
 \pnum\returns  \tcode{!(lhs < rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator<=}}%
-\indexlibrary{\idxcode{operator<=}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator<=}%
 \begin{itemdecl}
 template <class BiIter> 
   bool operator<=(typename iterator_traits<BiIter>::value_type const* lhs, 
@@ -2315,8 +2258,7 @@ template <class BiIter>
 \pnum\returns  \tcode{!(rhs < lhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator==}}%
-\indexlibrary{\idxcode{operator==}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator==}%
 \begin{itemdecl}
 template <class BiIter> 
   bool operator==(const sub_match<BiIter>& lhs, 
@@ -2327,8 +2269,7 @@ template <class BiIter>
 \pnum\returns  \tcode{lhs.compare(rhs) == 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator"!=}}%
-\indexlibrary{\idxcode{operator"!=}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator"!=}%
 \begin{itemdecl}
 template <class BiIter> 
   bool operator!=(const sub_match<BiIter>& lhs, 
@@ -2339,8 +2280,7 @@ template <class BiIter>
 \pnum\returns  \tcode{!(lhs == rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator<}}%
-\indexlibrary{\idxcode{operator<}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator<}%
 \begin{itemdecl}
 template <class BiIter> 
   bool operator<(const sub_match<BiIter>& lhs, 
@@ -2351,8 +2291,7 @@ template <class BiIter>
 \pnum\returns  \tcode{lhs.compare(rhs) < 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator>}}%
-\indexlibrary{\idxcode{operator>}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator>}%
 \begin{itemdecl}
 template <class BiIter> 
   bool operator>(const sub_match<BiIter>& lhs, 
@@ -2363,8 +2302,7 @@ template <class BiIter>
 \pnum\returns  \tcode{rhs < lhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator>=}}%
-\indexlibrary{\idxcode{operator>=}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator>=}%
 \begin{itemdecl}
 template <class BiIter> 
   bool operator>=(const sub_match<BiIter>& lhs, 
@@ -2375,8 +2313,7 @@ template <class BiIter>
 \pnum\returns  \tcode{!(lhs < rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator<=}}%
-\indexlibrary{\idxcode{operator<=}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator<=}%
 \begin{itemdecl}
 template <class BiIter> 
   bool operator<=(const sub_match<BiIter>& lhs, 
@@ -2388,8 +2325,7 @@ template <class BiIter>
 \returns  \tcode{!(rhs < lhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator==}}%
-\indexlibrary{\idxcode{operator==}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator==}%
 \begin{itemdecl}
 template <class BiIter> 
   bool operator==(typename iterator_traits<BiIter>::value_type const& lhs, 
@@ -2401,8 +2337,7 @@ template <class BiIter>
 \returns \tcode{rhs.compare(typename sub_match<BiIter>::string_type(1, lhs)) == 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator"!=}}%
-\indexlibrary{\idxcode{operator"!=}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator"!=}%
 \begin{itemdecl}
 template <class BiIter> 
   bool operator!=(typename iterator_traits<BiIter>::value_type const& lhs, 
@@ -2414,8 +2349,7 @@ template <class BiIter>
 \returns \tcode{!(lhs == rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator<}}%
-\indexlibrary{\idxcode{operator<}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator<}%
 \begin{itemdecl}
 template <class BiIter> 
   bool operator<(typename iterator_traits<BiIter>::value_type const& lhs, 
@@ -2427,8 +2361,7 @@ template <class BiIter>
 \returns \tcode{rhs.compare(typename sub_match<BiIter>::string_type(1, lhs)) > 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator>}}%
-\indexlibrary{\idxcode{operator>}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator>}%
 \begin{itemdecl}
 template <class BiIter> 
   bool operator>(typename iterator_traits<BiIter>::value_type const& lhs, 
@@ -2440,8 +2373,7 @@ template <class BiIter>
 \returns \tcode{rhs < lhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator>=}}%
-\indexlibrary{\idxcode{operator>=}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator>=}%
 \begin{itemdecl}
 template <class BiIter> 
   bool operator>=(typename iterator_traits<BiIter>::value_type const& lhs, 
@@ -2453,8 +2385,7 @@ template <class BiIter>
 \returns \tcode{!(lhs < rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator<=}}%
-\indexlibrary{\idxcode{operator<=}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator<=}%
 \begin{itemdecl}
 template <class BiIter> 
   bool operator<=(typename iterator_traits<BiIter>::value_type const& lhs, 
@@ -2466,8 +2397,7 @@ template <class BiIter>
 \returns \tcode{!(rhs < lhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator==}}%
-\indexlibrary{\idxcode{operator==}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator==}%
 \begin{itemdecl}
 template <class BiIter> 
   bool operator==(const sub_match<BiIter>& lhs, 
@@ -2479,8 +2409,7 @@ template <class BiIter>
 \returns \tcode{lhs.compare(typename sub_match<BiIter>::string_type(1, rhs)) == 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator"!=}}%
-\indexlibrary{\idxcode{operator"!=}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator"!=}%
 \begin{itemdecl}
 template <class BiIter> 
   bool operator!=(const sub_match<BiIter>& lhs, 
@@ -2492,8 +2421,7 @@ template <class BiIter>
 \returns \tcode{!(lhs == rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator<}}%
-\indexlibrary{\idxcode{operator<}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator<}%
 \begin{itemdecl}
 template <class BiIter> 
   bool operator<(const sub_match<BiIter>& lhs, 
@@ -2505,8 +2433,7 @@ template <class BiIter>
 \returns \tcode{lhs.compare(typename sub_match<BiIter>::string_type(1, rhs)) < 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator>}}%
-\indexlibrary{\idxcode{operator>}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator>}%
 \begin{itemdecl}
 template <class BiIter> 
   bool operator>(const sub_match<BiIter>& lhs, 
@@ -2518,8 +2445,7 @@ template <class BiIter>
 \returns \tcode{rhs < lhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator>=}}%
-\indexlibrary{\idxcode{operator>=}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator>=}%
 \begin{itemdecl}
 template <class BiIter> 
   bool operator>=(const sub_match<BiIter>& lhs, 
@@ -2531,8 +2457,7 @@ template <class BiIter>
 \returns \tcode{!(lhs < rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator<=}}%
-\indexlibrary{\idxcode{operator<=}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator<=}%
 \begin{itemdecl}
 template <class BiIter> 
   bool operator<=(const sub_match<BiIter>& lhs, 
@@ -2545,8 +2470,7 @@ template <class BiIter>
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_ostream}}%
-\indexlibrary{\idxcode{sub_match}!\idxcode{operator\shl}}%
-\indexlibrary{\idxcode{operator\shl}!\idxcode{sub_match}}%
+\indexlibrarymember{sub_match}{operator\shl}%
 \begin{itemdecl}
 template <class charT, class ST, class BiIter>
   basic_ostream<charT, ST>&
@@ -2725,8 +2649,7 @@ the stored \tcode{Allocator} value is move constructed from \tcode{m.get_allocat
 \throws Nothing.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{match_results}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{match_results}}%
+\indexlibrarymember{match_results}{operator=}%
 \begin{itemdecl}
 match_results& operator=(const match_results& m); 
 \end{itemdecl}
@@ -2737,8 +2660,7 @@ match_results& operator=(const match_results& m);
 function are indicated in Table~\ref{tab:re:results:assign}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{match_results}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{match_results}}%
+\indexlibrarymember{match_results}{operator=}%
 \begin{itemdecl}
 match_results& operator=(match_results&& m);
 \end{itemdecl}
@@ -2764,8 +2686,7 @@ are indicated in Table~\ref{tab:re:results:assign}.
 
 \rSec2[re.results.state]{\tcode{match_results} state}
 
-\indexlibrary{\idxcode{match_results}!\idxcode{state}}%
-\indexlibrary{\idxcode{state}!\idxcode{match_results}}%
+\indexlibrarymember{match_results}{state}%
 \begin{itemdecl}
 bool ready() const;
 \end{itemdecl}
@@ -2778,8 +2699,7 @@ bool ready() const;
 
 \rSec2[re.results.size]{\tcode{match_results} size}
 
-\indexlibrary{\idxcode{match_results}!\idxcode{size}}%
-\indexlibrary{\idxcode{size}!\idxcode{match_results}}%
+\indexlibrarymember{match_results}{size}%
 \begin{itemdecl}
 size_type size() const; 
 \end{itemdecl}
@@ -2795,8 +2715,7 @@ effects of those algorithms on their \tcode{match_results} arguments.
 \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{match_results}!\idxcode{max_size}}%
-\indexlibrary{\idxcode{max_size}!\idxcode{match_results}}%
+\indexlibrarymember{match_results}{max_size}%
 \begin{itemdecl}
 size_type max_size() const;
 \end{itemdecl}
@@ -2806,8 +2725,7 @@ size_type max_size() const;
 stored in \tcode{*this}.
 \end{itemdescr} 
 
-\indexlibrary{\idxcode{match_results}!\idxcode{empty}}%
-\indexlibrary{\idxcode{empty}!\idxcode{match_results}}%
+\indexlibrarymember{match_results}{empty}%
 \begin{itemdecl}
 bool empty() const;
 \end{itemdecl}
@@ -2818,8 +2736,7 @@ bool empty() const;
 
 \rSec2[re.results.acc]{\tcode{match_results} element access}
 
-\indexlibrary{\idxcode{length}!\idxcode{match_results}}%
-\indexlibrary{\idxcode{match_results}!\idxcode{length}}%
+\indexlibrarymember{length}{match_results}%
 \begin{itemdecl}
 difference_type length(size_type sub = 0) const;
 \end{itemdecl}
@@ -2832,8 +2749,7 @@ difference_type length(size_type sub = 0) const;
 \returns  \tcode{(*this)[sub].length()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{position}!\idxcode{match_results}}%
-\indexlibrary{\idxcode{match_results}!\idxcode{position}}%
+\indexlibrarymember{position}{match_results}%
 \begin{itemdecl}
 difference_type position(size_type sub = 0) const;
 \end{itemdecl}
@@ -2847,8 +2763,7 @@ difference_type position(size_type sub = 0) const;
 to \tcode{(*this)[sub].first}.
 \end{itemdescr} 
 
-\indexlibrary{\idxcode{match_results}!\idxcode{str}}%
-\indexlibrary{\idxcode{str}!\idxcode{match_results}}%
+\indexlibrarymember{match_results}{str}%
 \begin{itemdecl}
 string_type str(size_type sub = 0) const;
 \end{itemdecl}
@@ -2861,8 +2776,7 @@ string_type str(size_type sub = 0) const;
 \returns  \tcode{string_type((*this)[sub])}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{match_results}!\idxcode{operator[]}}%
-\indexlibrary{\idxcode{operator[]}!\idxcode{match_results}}%
+\indexlibrarymember{match_results}{operator[]}%
 \begin{itemdecl}
 const_reference operator[](size_type n) const;
 \end{itemdecl}
@@ -2880,8 +2794,7 @@ character sequence that matched the whole regular expression. If
 unmatched sub-expression.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{match_results}!\idxcode{prefix}}%
-\indexlibrary{\idxcode{prefix}!\idxcode{match_results}}%
+\indexlibrarymember{match_results}{prefix}%
 \begin{itemdecl}
 const_reference prefix() const;
 \end{itemdecl}
@@ -2896,8 +2809,7 @@ character sequence from the start of the string being
 matched/searched to the start of the match found.  
 \end{itemdescr}
 
-\indexlibrary{\idxcode{match_results}!\idxcode{suffix}}%
-\indexlibrary{\idxcode{suffix}!\idxcode{match_results}}%
+\indexlibrarymember{match_results}{suffix}%
 \begin{itemdecl}
 const_reference suffix() const;
 \end{itemdecl}
@@ -2912,8 +2824,7 @@ character sequence from the end of the match found to the end of the
 string being matched/searched.  
 \end{itemdescr}
 
-\indexlibrary{\idxcode{match_results}!\idxcode{begin}}%
-\indexlibrary{\idxcode{begin}!\idxcode{match_results}}%
+\indexlibrarymember{match_results}{begin}%
 \begin{itemdecl}
 const_iterator begin() const;
 const_iterator cbegin() const;
@@ -2924,8 +2835,7 @@ const_iterator cbegin() const;
 sub-expressions stored in \tcode{*this}.
 \end{itemdescr}  
 
-\indexlibrary{\idxcode{match_results}!\idxcode{end}}%
-\indexlibrary{\idxcode{end}!\idxcode{match_results}}%
+\indexlibrarymember{match_results}{end}%
 \begin{itemdecl}
 const_iterator end() const;
 const_iterator cend() const;
@@ -2938,8 +2848,7 @@ sub-expressions stored in \tcode{*this}.
 
 \rSec2[re.results.form]{\tcode{match_results} formatting}
 
-\indexlibrary{\idxcode{match_results}!\idxcode{format}}%
-\indexlibrary{\idxcode{format}!\idxcode{match_results}}%
+\indexlibrarymember{match_results}{format}%
 \begin{itemdecl}
 template <class OutputIter>
   OutputIter format(OutputIter out,
@@ -2965,8 +2874,7 @@ specifiers and escape sequences are recognized.
 \returns\ \tcode{out}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{match_results}!\idxcode{format}}%
-\indexlibrary{\idxcode{format}!\idxcode{match_results}}%
+\indexlibrarymember{match_results}{format}%
 \begin{itemdecl}
 template <class OutputIter, class ST, class SA>
   OutputIter format(OutputIter out,
@@ -2983,8 +2891,7 @@ return format(out, fmt.data(), fmt.data() + fmt.size(), flags);
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{match_results}!\idxcode{format}}%
-\indexlibrary{\idxcode{format}!\idxcode{match_results}}%
+\indexlibrarymember{match_results}{format}%
 \begin{itemdecl}
 template <class ST, class SA>
   basic_string<char_type, ST, SA>
@@ -3009,8 +2916,7 @@ format(back_inserter(result), fmt, flags);
 \returns\ \tcode{result}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{match_results}!\idxcode{format}}%
-\indexlibrary{\idxcode{format}!\idxcode{match_results}}%
+\indexlibrarymember{match_results}{format}%
 \begin{itemdecl}
 string_type
   format(const char_type* fmt,
@@ -3036,8 +2942,7 @@ format(back_inserter(result),
 
 \rSec2[re.results.all]{\tcode{match_results} allocator}%
 
-\indexlibrary{\idxcode{get_allocator}!\idxcode{match_results}}%
-\indexlibrary{\idxcode{match_results}!\idxcode{get_allocator}}%
+\indexlibrarymember{get_allocator}{match_results}%
 \begin{itemdecl}
 allocator_type get_allocator() const;
 \end{itemdecl}
@@ -3050,8 +2955,7 @@ allocator has been replaced, a copy of the most recent replacement.
 
 \rSec2[re.results.swap]{\tcode{match_results} swap}
 
-\indexlibrary{\idxcode{match_results}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{match_results}}%
+\indexlibrarymember{match_results}{swap}%
 \begin{itemdecl}
 void swap(match_results& that); 
 \end{itemdecl}
@@ -3066,8 +2970,7 @@ sequence of matched sub-expressions that were in \tcode{*this}.
 \pnum\complexity Constant time. 
 \end{itemdescr}
 
-\indexlibrary{\idxcode{match_results}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{match_results}}%
+\indexlibrarymember{match_results}{swap}%
 \begin{itemdecl}
 template <class BidirectionalIterator, class Allocator>
   void swap(match_results<BidirectionalIterator, Allocator>& m1,
@@ -3078,8 +2981,7 @@ template <class BidirectionalIterator, class Allocator>
 
 \rSec2[re.results.nonmember]{\tcode{match_results} non-member functions}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{match_results}}%
-\indexlibrary{\idxcode{match_results}!\idxcode{operator==}}%
+\indexlibrarymember{operator==}{match_results}%
 \begin{itemdecl}
 template <class BidirectionalIterator, class Allocator>
 bool operator==(const match_results<BidirectionalIterator, Allocator>& m1,
@@ -3740,8 +3642,7 @@ iterator.
 
 \rSec3[re.regiter.comp]{\tcode{regex_iterator} comparisons}
 
-\indexlibrary{\idxcode{regex_iterator}!\idxcode{operator==}}%
-\indexlibrary{\idxcode{operator==}!\idxcode{regex_iterator}}%
+\indexlibrarymember{regex_iterator}{operator==}%
 \begin{itemdecl}
 bool operator==(const regex_iterator& right) const;
 \end{itemdecl}
@@ -3760,8 +3661,7 @@ iterators or if the following conditions all hold:
 otherwise \tcode{false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{regex_iterator}!\idxcode{operator"!=}}%
-\indexlibrary{\idxcode{operator"!=}!\idxcode{regex_iterator}}%
+\indexlibrarymember{regex_iterator}{operator"!=}%
 \begin{itemdecl}
 bool operator!=(const regex_iterator& right) const;
 \end{itemdecl}
@@ -3772,8 +3672,7 @@ bool operator!=(const regex_iterator& right) const;
 
 \rSec3[re.regiter.deref]{\tcode{regex_iterator} indirection}
 
-\indexlibrary{\idxcode{regex_iterator}!\idxcode{operator*}}%
-\indexlibrary{\idxcode{operator*}!\idxcode{regex_iterator}}%
+\indexlibrarymember{regex_iterator}{operator*}%
 \begin{itemdecl}
 const value_type& operator*() const;
 \end{itemdecl}
@@ -3782,8 +3681,7 @@ const value_type& operator*() const;
 \pnum\returns  \tcode{match}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator->}!\idxcode{regex_iterator}}%
-\indexlibrary{\idxcode{regex_iterator}!\idxcode{operator->}}%
+\indexlibrarymember{operator->}{regex_iterator}%
 \begin{itemdecl}
 const value_type* operator->() const;
 \end{itemdecl}
@@ -3794,8 +3692,7 @@ const value_type* operator->() const;
 
 \rSec3[re.regiter.incr]{\tcode{regex_iterator} increment}
 
-\indexlibrary{\idxcode{regex_iterator}!\idxcode{operator++}}%
-\indexlibrary{\idxcode{operator++}!\idxcode{regex_iterator}}%
+\indexlibrarymember{regex_iterator}{operator++}%
 \indexlibrary{\idxcode{regex_iterator}!increment}%
 \begin{itemdecl}
 regex_iterator& operator++(); 
@@ -3851,8 +3748,7 @@ specialization of \tcode{regex_search} will not be
 called. \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{regex_iterator}!\idxcode{operator++}}%
-\indexlibrary{\idxcode{operator++}!\idxcode{regex_iterator}}%
+\indexlibrarymember{regex_iterator}{operator++}%
 \begin{itemdecl}
 regex_iterator operator++(int); 
 \end{itemdecl}
@@ -3919,8 +3815,7 @@ is not defined. For any other iterator value a \tcode{const
 sub_match<BidirectionalIterator>*} is returned.
 
 \pnum
-\indexlibrary{\idxcode{regex_token_iterator}!\idxcode{operator==}}%
-\indexlibrary{\idxcode{operator==}!\idxcode{regex_token_iterator}}%
+\indexlibrarymember{regex_token_iterator}{operator==}%
 It is impossible to store things
 into \tcode{regex_token_iterator}s. Two end-of-sequence iterators are always
 equal. An end-of-sequence iterator is not equal to a
@@ -4090,8 +3985,7 @@ sets \tcode{*this} to an end-of-sequence iterator.
 
 \rSec3[re.tokiter.comp]{\tcode{regex_token_iterator} comparisons}
 
-\indexlibrary{\idxcode{regex_token_iterator}!\idxcode{operator==}}%
-\indexlibrary{\idxcode{operator==}!\idxcode{regex_token_iterator}}%
+\indexlibrarymember{regex_token_iterator}{operator==}%
 \begin{itemdecl}
 bool operator==(const regex_token_iterator& right) const;
 \end{itemdecl}
@@ -4105,8 +3999,7 @@ iterator or a suffix iterator. Otherwise returns \tcode{true} if \tcode{position
 \tcode{N == right.N}, and \tcode{subs == right.subs}. Otherwise returns \tcode{false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{regex_token_iterator}!\idxcode{operator"!=}}%
-\indexlibrary{\idxcode{operator"!=}!\idxcode{regex_token_iterator}}%
+\indexlibrarymember{regex_token_iterator}{operator"!=}%
 \begin{itemdecl}
 bool operator!=(const regex_token_iterator& right) const;
 \end{itemdecl}
@@ -4117,8 +4010,7 @@ bool operator!=(const regex_token_iterator& right) const;
 
 \rSec3[re.tokiter.deref]{\tcode{regex_token_iterator} indirection}
 
-\indexlibrary{\idxcode{regex_token_iterator}!\idxcode{operator*}}%
-\indexlibrary{\idxcode{operator*}!\idxcode{regex_token_iterator}}%
+\indexlibrarymember{regex_token_iterator}{operator*}%
 \begin{itemdecl}
 const value_type& operator*() const;
 \end{itemdecl}
@@ -4128,8 +4020,7 @@ const value_type& operator*() const;
 \end{itemdescr}
 
 
-\indexlibrary{\idxcode{operator->}!\idxcode{regex_token_iterator}}%
-\indexlibrary{\idxcode{regex_token_iterator}!\idxcode{operator->}}%
+\indexlibrarymember{operator->}{regex_token_iterator}%
 \begin{itemdecl}
 const value_type* operator->() const;
 \end{itemdecl}
@@ -4141,8 +4032,7 @@ const value_type* operator->() const;
 
 \rSec3[re.tokiter.incr]{\tcode{regex_token_iterator} increment}
 
-\indexlibrary{\idxcode{regex_token_iterator}!\idxcode{operator++}}%
-\indexlibrary{\idxcode{operator++}!\idxcode{regex_token_iterator}}%
+\indexlibrarymember{regex_token_iterator}{operator++}%
 \begin{itemdecl}
 regex_token_iterator& operator++(); 
 \end{itemdecl}
@@ -4178,8 +4068,7 @@ Otherwise, sets \tcode{*this} to an end-of-sequence iterator.
 \returns  \tcode{*this}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{regex_token_iterator}!\idxcode{operator++}}%
-\indexlibrary{\idxcode{operator++}!\idxcode{regex_token_iterator}}%
+\indexlibrarymember{regex_token_iterator}{operator++}%
 \begin{itemdecl}
 regex_token_iterator& operator++(int); 
 \end{itemdecl}

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -206,8 +206,7 @@ as a basis for explicit specializations.
 
 \rSec2[char.traits.typedefs]{traits typedefs}
 
-\indexlibrary{\idxcode{char_type}!\idxcode{char_traits}}%
-\indexlibrary{\idxcode{char_traits}!\idxcode{char_type}}%
+\indexlibrarymember{char_type}{char_traits}%
 \begin{itemdecl}
 using char_type = CHAR_T;
 \end{itemdecl}
@@ -220,8 +219,7 @@ is used to refer to the character container type
 in the implementation of the library classes defined in~\ref{string.classes} and Clause~\ref{input.output}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{int_type}!\idxcode{char_traits}}%
-\indexlibrary{\idxcode{char_traits}!\idxcode{int_type}}%
+\indexlibrarymember{int_type}{char_traits}%
 \begin{itemdecl}
 using int_type = INT_T;
 \end{itemdecl}
@@ -249,10 +247,8 @@ can be held in
 then some iostreams operations may give surprising results.}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{off_type}!\idxcode{char_traits}}%
-\indexlibrary{\idxcode{char_traits}!\idxcode{off_type}}%
-\indexlibrary{\idxcode{pos_type}!\idxcode{char_traits}}%
-\indexlibrary{\idxcode{char_traits}!\idxcode{pos_type}}%
+\indexlibrarymember{off_type}{char_traits}%
+\indexlibrarymember{pos_type}{char_traits}%
 \begin{itemdecl}
 using off_type = @\impdef@;
 using pos_type = @\impdef@;
@@ -268,8 +264,7 @@ and
 are described in~\ref{iostreams.limits.pos} and \ref{iostream.forward}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{state_type}!\idxcode{char_traits}}%
-\indexlibrary{\idxcode{char_traits}!\idxcode{state_type}}%
+\indexlibrarymember{state_type}{char_traits}%
 \begin{itemdecl}
 using state_type = STATE_T;
 \end{itemdecl}
@@ -1454,8 +1449,7 @@ element is pointed at by the original value of \tcode{str.data()}. \\
 \end{itemdescr}
 
 
-\indexlibrary{\idxcode{operator=}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{basic_string}%
 \begin{itemdecl}
 basic_string& operator=(const basic_string& str);
 \end{itemdecl}
@@ -1491,8 +1485,7 @@ element is pointed at by \tcode{str.data()}                                     
 \end{libefftabvalue}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{basic_string}%
 \begin{itemdecl}
 basic_string& operator=(basic_string&& str)
   noexcept(allocator_traits<Allocator>::propagate_on_container_move_assignment::value ||
@@ -1510,8 +1503,7 @@ except that iterators, pointers and references may be invalidated.
 \tcode{*this}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{basic_string}%
 \begin{itemdecl}
 basic_string& operator=(basic_string_view<charT, traits> sv);
 \end{itemdecl}
@@ -1521,8 +1513,7 @@ basic_string& operator=(basic_string_view<charT, traits> sv);
 \effects Equivalent to: \tcode{return assign(sv);}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{basic_string}%
 \begin{itemdecl}
 basic_string& operator=(const charT* s);
 \end{itemdecl}
@@ -1539,8 +1530,7 @@ Uses
 \tcode{traits::length()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{basic_string}%
 \begin{itemdecl}
 basic_string& operator=(charT c);
 \end{itemdecl}
@@ -1551,8 +1541,7 @@ basic_string& operator=(charT c);
 \tcode{*this = basic_string(1, c)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{basic_string}%
 \begin{itemdecl}
 basic_string& operator=(initializer_list<charT> il);
 \end{itemdecl}
@@ -1567,10 +1556,8 @@ basic_string& operator=(initializer_list<charT> il);
 
 \rSec3[string.iterators]{\tcode{basic_string} iterator support}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{begin}}%
-\indexlibrary{\idxcode{begin}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{cbegin}}%
-\indexlibrary{\idxcode{cbegin}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{begin}%
+\indexlibrarymember{basic_string}{cbegin}%
 \begin{itemdecl}
 iterator       begin() noexcept;
 const_iterator begin() const noexcept;
@@ -1583,10 +1570,8 @@ const_iterator cbegin() const noexcept;
 An iterator referring to the first character in the string.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{end}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{end}}%
-\indexlibrary{\idxcode{cend}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{cend}}%
+\indexlibrarymember{end}{basic_string}%
+\indexlibrarymember{cend}{basic_string}%
 \begin{itemdecl}
 iterator       end() noexcept;
 const_iterator end() const noexcept;
@@ -1599,10 +1584,8 @@ const_iterator cend() const noexcept;
 An iterator which is the past-the-end value.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{rbegin}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{rbegin}}%
-\indexlibrary{\idxcode{crbegin}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{crbegin}}%
+\indexlibrarymember{rbegin}{basic_string}%
+\indexlibrarymember{crbegin}{basic_string}%
 \begin{itemdecl}
 reverse_iterator       rbegin() noexcept;
 const_reverse_iterator rbegin() const noexcept;
@@ -1616,10 +1599,8 @@ An iterator which is semantically equivalent to
 \tcode{reverse_iterator(end())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{rend}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{rend}}%
-\indexlibrary{\idxcode{crend}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{crend}}%
+\indexlibrarymember{rend}{basic_string}%
+\indexlibrarymember{crend}{basic_string}%
 \begin{itemdecl}
 reverse_iterator       rend() noexcept;
 const_reverse_iterator rend() const noexcept;
@@ -1635,8 +1616,7 @@ An iterator which is semantically equivalent to
 
 \rSec3[string.capacity]{\tcode{basic_string} capacity}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{size}}%
-\indexlibrary{\idxcode{size}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{size}%
 \begin{itemdecl}
 size_type size() const noexcept;
 \end{itemdecl}
@@ -1650,8 +1630,7 @@ A count of the number of char-like objects currently in the string.
 \complexity Constant time.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{length}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{length}}%
+\indexlibrarymember{length}{basic_string}%
 \begin{itemdecl}
 size_type length() const noexcept;
 \end{itemdecl}
@@ -1662,8 +1641,7 @@ size_type length() const noexcept;
 \tcode{size()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{max_size}}%
-\indexlibrary{\idxcode{max_size}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{max_size}%
 \begin{itemdecl}
 size_type max_size() const noexcept;
 \end{itemdecl}
@@ -1677,8 +1655,7 @@ The size of the largest possible string.
 \complexity Constant time.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{resize}}%
-\indexlibrary{\idxcode{resize}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{resize}%
 \begin{itemdecl}
 void resize(size_type n, charT c);
 \end{itemdecl}
@@ -1718,8 +1695,7 @@ and whose remaining elements are all initialized to \tcode{c}.
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{resize}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{resize}}%
+\indexlibrarymember{resize}{basic_string}%
 \begin{itemdecl}
 void resize(size_type n);
 \end{itemdecl}
@@ -1730,8 +1706,7 @@ void resize(size_type n);
 As if by \tcode{resize(n, charT())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{capacity}}%
-\indexlibrary{\idxcode{capacity}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{capacity}%
 \begin{itemdecl}
 size_type capacity() const noexcept;
 \end{itemdecl}
@@ -1742,8 +1717,7 @@ size_type capacity() const noexcept;
 The size of the allocated storage in the string.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{reserve}}%
-\indexlibrary{\idxcode{reserve}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{reserve}%
 \begin{itemdecl}
 void reserve(size_type res_arg=0);
 \end{itemdecl}
@@ -1785,8 +1759,7 @@ uses
 which may throw an appropriate exception.}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{shrink_to_fit}}%
-\indexlibrary{\idxcode{shrink_to_fit}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{shrink_to_fit}%
 \begin{itemdecl}
 void shrink_to_fit();
 \end{itemdecl}
@@ -1798,8 +1771,7 @@ void shrink_to_fit();
 allow latitude for implementation-specific optimizations. \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{clear}}%
-\indexlibrary{\idxcode{clear}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{clear}%
 \begin{itemdecl}
 void clear() noexcept;
 \end{itemdecl}
@@ -1814,8 +1786,7 @@ erase(begin(), end());
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{empty}}%
-\indexlibrary{\idxcode{empty}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{empty}%
 \begin{itemdecl}
 bool empty() const noexcept;
 \end{itemdecl}
@@ -1828,8 +1799,7 @@ bool empty() const noexcept;
 
 \rSec3[string.access]{\tcode{basic_string} element access}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator[]}}%
-\indexlibrary{\idxcode{operator[]}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{operator[]}%
 \begin{itemdecl}
 const_reference operator[](size_type pos) const;
 reference       operator[](size_type pos);
@@ -1852,8 +1822,7 @@ undefined behavior.
 \complexity Constant time.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{at}}%
-\indexlibrary{\idxcode{at}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{at}%
 \begin{itemdecl}
 const_reference at(size_type pos) const;
 reference       at(size_type pos);
@@ -1871,8 +1840,7 @@ if
 \tcode{operator[](pos)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{front}}%
-\indexlibrary{\idxcode{front}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{front}%
 \begin{itemdecl}
 const charT& front() const;
 charT& front();
@@ -1888,8 +1856,7 @@ charT& front();
 Equivalent to \tcode{operator[](0)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{back}}%
-\indexlibrary{\idxcode{back}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{back}%
 \begin{itemdecl}
 const charT& back() const;
 charT& back();
@@ -1909,8 +1876,7 @@ Equivalent to \tcode{operator[](size() - 1)}.
 
 \rSec4[string::op+=]{\tcode{basic_string::operator+=}}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator+=}}%
-\indexlibrary{\idxcode{operator+=}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{operator+=}%
 \begin{itemdecl}
 basic_string&
   operator+=(const basic_string& str);
@@ -1925,8 +1891,7 @@ basic_string&
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator+=}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator+=}}%
+\indexlibrarymember{operator+=}{basic_string}%
 \begin{itemdecl}
 basic_string& operator+=(basic_string_view<charT, traits> sv);
 \end{itemdecl}
@@ -1941,8 +1906,7 @@ Calls \tcode{append(sv)}.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator+=}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator+=}}%
+\indexlibrarymember{operator+=}{basic_string}%
 \begin{itemdecl}
 basic_string& operator+=(const charT* s);
 \end{itemdecl}
@@ -1956,8 +1920,7 @@ basic_string& operator+=(const charT* s);
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator+=}}%
-\indexlibrary{\idxcode{operator+=}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{operator+=}%
 \begin{itemdecl}
 basic_string& operator+=(charT c);
 \end{itemdecl}
@@ -1971,8 +1934,7 @@ basic_string& operator+=(charT c);
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator+=}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator+=}}%
+\indexlibrarymember{operator+=}{basic_string}%
 \begin{itemdecl}
 basic_string& operator+=(initializer_list<charT> il);
 \end{itemdecl}
@@ -1988,8 +1950,7 @@ basic_string& operator+=(initializer_list<charT> il);
 
 \rSec4[string::append]{\tcode{basic_string::append}}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{append}}%
-\indexlibrary{\idxcode{append}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{append}%
 \begin{itemdecl}
 basic_string&
   append(const basic_string& str);
@@ -2004,8 +1965,7 @@ basic_string&
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{append}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{append}}%
+\indexlibrarymember{append}{basic_string}%
 \begin{itemdecl}
 basic_string&
   append(const basic_string& str, size_type pos, size_type n = npos);
@@ -2029,8 +1989,7 @@ of the string to append as the smaller of \tcode{n} and
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{append}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{append}}%
+\indexlibrarymember{append}{basic_string}%
 \begin{itemdecl}
 basic_string& append(basic_string_view<charT, traits> sv);
 \end{itemdecl}
@@ -2041,8 +2000,7 @@ basic_string& append(basic_string_view<charT, traits> sv);
 Equivalent to: \tcode{return append(sv.data(), sv.size());}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{append}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{append}}%
+\indexlibrarymember{append}{basic_string}%
 \begin{itemdecl}
 basic_string& append(basic_string_view<charT, traits> sv,
                      size_type pos, size_type n = npos);
@@ -2066,8 +2024,7 @@ and calls \tcode{append(sv.data() + pos, rlen)}.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{append}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{append}}%
+\indexlibrarymember{append}{basic_string}%
 \begin{itemdecl}
 basic_string&
   append(const charT* s, size_type n);
@@ -2093,8 +2050,7 @@ of \tcode{s}.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{append}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{append}}%
+\indexlibrarymember{append}{basic_string}%
 \begin{itemdecl}
 basic_string& append(const charT* s);
 \end{itemdecl}
@@ -2112,8 +2068,7 @@ elements of \tcode{charT}.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{append}}%
-\indexlibrary{\idxcode{append}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{append}%
 \begin{itemdecl}
 basic_string& append(size_type n, charT c);
 \end{itemdecl}
@@ -2127,8 +2082,7 @@ basic_string& append(size_type n, charT c);
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{append}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{append}}%
+\indexlibrarymember{append}{basic_string}%
 \begin{itemdecl}
 template<class InputIterator>
   basic_string& append(InputIterator first, InputIterator last);
@@ -2146,8 +2100,7 @@ template<class InputIterator>
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{append}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{append}}%
+\indexlibrarymember{append}{basic_string}%
 \begin{itemdecl}
 basic_string& append(initializer_list<charT> il);
 \end{itemdecl}
@@ -2161,8 +2114,7 @@ basic_string& append(initializer_list<charT> il);
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{push_back}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{push_back}}%
+\indexlibrarymember{push_back}{basic_string}%
 \begin{itemdecl}
 void push_back(charT c);
 \end{itemdecl}
@@ -2176,8 +2128,7 @@ Equivalent to
 
 \rSec4[string::assign]{\tcode{basic_string::assign}}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{assign}}%
-\indexlibrary{\idxcode{assign}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{assign}%
 \begin{itemdecl}
 basic_string& assign(const basic_string& str);
 \end{itemdecl}
@@ -2191,8 +2142,7 @@ basic_string& assign(const basic_string& str);
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{assign}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{assign}}%
+\indexlibrarymember{assign}{basic_string}%
 \begin{itemdecl}
 basic_string& assign(basic_string&& str)
   noexcept(allocator_traits<Allocator>::propagate_on_container_move_assignment::value ||
@@ -2209,8 +2159,7 @@ basic_string& assign(basic_string&& str)
 \end{itemdescr}
 
 
-\indexlibrary{\idxcode{assign}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{assign}}%
+\indexlibrarymember{assign}{basic_string}%
 \begin{itemdecl}
 basic_string&
   assign(const basic_string& str, size_type pos,
@@ -2236,8 +2185,7 @@ of the string to assign as the smaller of \tcode{n} and
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{assign}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{assign}}%
+\indexlibrarymember{assign}{basic_string}%
 \begin{itemdecl}
 basic_string& assign(basic_string_view<charT, traits> sv);
 \end{itemdecl}
@@ -2248,8 +2196,7 @@ basic_string& assign(basic_string_view<charT, traits> sv);
 Equivalent to: \tcode{return assign(sv.data(), sv.size());}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{assign}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{assign}}%
+\indexlibrarymember{assign}{basic_string}%
 \begin{itemdecl}
 basic_string& assign(basic_string_view<charT, traits> sv, size_type pos,
                      size_type n = npos);
@@ -2273,8 +2220,7 @@ and calls \tcode{assign(sv.data() + pos, rlen)}.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{assign}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{assign}}%
+\indexlibrarymember{assign}{basic_string}%
 \begin{itemdecl}
 basic_string& assign(const charT* s, size_type n);
 \end{itemdecl}
@@ -2295,8 +2241,7 @@ of length \tcode{n} whose elements are a copy of those pointed to by \tcode{s}.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{assign}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{assign}}%
+\indexlibrarymember{assign}{basic_string}%
 \begin{itemdecl}
 basic_string& assign(const charT* s);
 \end{itemdecl}
@@ -2314,8 +2259,7 @@ elements of \tcode{charT}.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{assign}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{assign}}%
+\indexlibrarymember{assign}{basic_string}%
 \begin{itemdecl}
 basic_string& assign(initializer_list<charT> il);
 \end{itemdecl}
@@ -2343,8 +2287,7 @@ basic_string& assign(size_type n, charT c);
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{assign}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{assign}}%
+\indexlibrarymember{assign}{basic_string}%
 \begin{itemdecl}
 template<class InputIterator>
   basic_string& assign(InputIterator first, InputIterator last);
@@ -2361,8 +2304,7 @@ template<class InputIterator>
 
 \rSec4[string::insert]{\tcode{basic_string::insert}}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{insert}}%
-\indexlibrary{\idxcode{insert}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{insert}%
 \begin{itemdecl}
 basic_string&
   insert(size_type pos1,
@@ -2374,8 +2316,7 @@ basic_string&
 \effects Equivalent to: \tcode{return insert(pos, str.data(), str.size());}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{insert}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{insert}}%
+\indexlibrarymember{insert}{basic_string}%
 \begin{itemdecl}
 basic_string&
   insert(size_type pos1,
@@ -2403,8 +2344,7 @@ of \tcode{n} and
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{insert}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{insert}}%
+\indexlibrarymember{insert}{basic_string}%
 \begin{itemdecl}
 basic_string& insert(size_type pos1, basic_string_view<charT, traits> sv);
 \end{itemdecl}
@@ -2415,8 +2355,7 @@ basic_string& insert(size_type pos1, basic_string_view<charT, traits> sv);
 Equivalent to: \tcode{return insert(pos1, sv.data(), sv.size());}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{insert}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{insert}}%
+\indexlibrarymember{insert}{basic_string}%
 \begin{itemdecl}
 basic_string& insert(size_type pos1, basic_string_view<charT, traits> sv,
                      size_type pos2, size_type n = npos);
@@ -2442,8 +2381,7 @@ and calls \tcode{insert(pos1, sv.data() + pos2, rlen)}.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{insert}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{insert}}%
+\indexlibrarymember{insert}{basic_string}%
 \begin{itemdecl}
 basic_string&
   insert(size_type pos, const charT* s, size_type n);
@@ -2471,8 +2409,7 @@ string controlled by \tcode{*this}.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{insert}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{insert}}%
+\indexlibrarymember{insert}{basic_string}%
 \begin{itemdecl}
 basic_string&
   insert(size_type pos, const charT* s);
@@ -2487,8 +2424,7 @@ basic_string&
 \effects Equivalent to: \tcode{return insert(pos, s, traits::length(s));}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{insert}}%
-\indexlibrary{\idxcode{insert}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{insert}%
 \begin{itemdecl}
 basic_string&
   insert(size_type pos, size_type n, charT c);
@@ -2503,8 +2439,7 @@ basic_string&
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{insert}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{insert}}%
+\indexlibrarymember{insert}{basic_string}%
 \begin{itemdecl}
 iterator insert(const_iterator p, charT c);
 \end{itemdecl}
@@ -2524,8 +2459,7 @@ Inserts a copy of \tcode{c} before the character referred to by \tcode{p}.
 An iterator which refers to the copy of the inserted character.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{insert}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{insert}}%
+\indexlibrarymember{insert}{basic_string}%
 \begin{itemdecl}
 iterator insert(const_iterator p, size_type n, charT c);
 \end{itemdecl}
@@ -2545,8 +2479,7 @@ Inserts \tcode{n} copies of \tcode{c} before the character referred to by \tcode
 \tcode{p} if \tcode{n == 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{insert}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{insert}}%
+\indexlibrarymember{insert}{basic_string}%
 \begin{itemdecl}
 template<class InputIterator>
   iterator insert(const_iterator p, InputIterator first, InputIterator last);
@@ -2570,8 +2503,7 @@ Equivalent to
 \tcode{p} if \tcode{first == last}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{insert}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{insert}}%
+\indexlibrarymember{insert}{basic_string}%
 \begin{itemdecl}
 iterator insert(const_iterator p, initializer_list<charT> il);
 \end{itemdecl}
@@ -2587,8 +2519,7 @@ iterator insert(const_iterator p, initializer_list<charT> il);
 
 \rSec4[string::erase]{\tcode{basic_string::erase}}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{erase}}%
-\indexlibrary{\idxcode{erase}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{erase}%
 \begin{itemdecl}
 basic_string& erase(size_type pos = 0, size_type n = npos);
 \end{itemdecl}
@@ -2623,8 +2554,7 @@ beginning at position
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{erase}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{erase}}%
+\indexlibrarymember{erase}{basic_string}%
 \begin{itemdecl}
 iterator erase(const_iterator p);
 \end{itemdecl}
@@ -2646,8 +2576,7 @@ If no such element exists,
 is returned.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{erase}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{erase}}%
+\indexlibrarymember{erase}{basic_string}%
 \begin{itemdecl}
 iterator erase(const_iterator first, const_iterator last);
 \end{itemdecl}
@@ -2677,8 +2606,7 @@ If no such element exists,
 is returned.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{pop_back}}%
-\indexlibrary{\idxcode{pop_back}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{pop_back}%
 \begin{itemdecl}
 void pop_back();
 \end{itemdecl}
@@ -2698,8 +2626,7 @@ Equivalent to \tcode{erase(size() - 1, 1)}.
 
 \rSec4[string::replace]{\tcode{basic_string::replace}}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{replace}}%
-\indexlibrary{\idxcode{replace}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{replace}%
 \begin{itemdecl}
 basic_string&
   replace(size_type pos1, size_type n1,
@@ -2711,8 +2638,7 @@ basic_string&
 \effects Equivalent to: \tcode{return replace(pos1, n1, str.data(), str.size());}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{replace}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{replace}}%
+\indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
 basic_string&
   replace(size_type pos1, size_type n1,
@@ -2740,8 +2666,7 @@ as the smaller of \tcode{n2} and \tcode{str.size() - pos2} and calls
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{replace}}%
-\indexlibrary{\idxcode{replace}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{replace}%
 \begin{itemdecl}
 basic_string& replace(size_type pos1, size_type n1,
                       basic_string_view<charT, traits> sv);
@@ -2753,8 +2678,7 @@ basic_string& replace(size_type pos1, size_type n1,
 Equivalent to: \tcode{return replace(pos1, n1, sv.data(), sv.size());}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{replace}}%
-\indexlibrary{\idxcode{replace}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{replace}%
 \begin{itemdecl}
 basic_string& replace(size_type pos1, size_type n1,
                       basic_string_view<charT, traits> sv,
@@ -2781,8 +2705,7 @@ and calls \tcode{replace(pos1, n1, sv.data() + pos2, rlen)}.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{replace}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{replace}}%
+\indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
 basic_string&
   replace(size_type pos1, size_type n1, const charT* s, size_type n2);
@@ -2814,8 +2737,7 @@ original string controlled by \tcode{*this} beginning at position
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{replace}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{replace}}%
+\indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
 basic_string&
   replace(size_type pos, size_type n, const charT* s);
@@ -2830,8 +2752,7 @@ basic_string&
 \effects Equivalent to: \tcode{return replace(pos, n, s, traits::length(s));}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{replace}}%
-\indexlibrary{\idxcode{replace}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{replace}%
 \begin{itemdecl}
 basic_string&
   replace(size_type pos1, size_type n1,
@@ -2847,8 +2768,7 @@ basic_string&
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{replace}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{replace}}%
+\indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
 basic_string& replace(const_iterator i1, const_iterator i2, const basic_string& str);
 \end{itemdecl}
@@ -2867,8 +2787,7 @@ Calls \tcode{replace(i1 - begin(), i2 - i1, str)}.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{replace}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{replace}}%
+\indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
 basic_string& replace(const_iterator i1, const_iterator i2,
                       basic_string_view<charT, traits> sv);
@@ -2888,8 +2807,7 @@ Calls \tcode{replace(i1 - begin(), i2 - i1, sv)}.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{replace}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{replace}}%
+\indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
 basic_string&
   replace(const_iterator i1, const_iterator i2, const charT* s, size_type n);
@@ -2908,8 +2826,7 @@ basic_string&
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{replace}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{replace}}%
+\indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
 basic_string& replace(const_iterator i1, const_iterator i2, const charT* s);
 \end{itemdecl}
@@ -2928,8 +2845,7 @@ elements of \tcode{charT}.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{replace}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{replace}}%
+\indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
 basic_string& replace(const_iterator i1, const_iterator i2, size_type n,
                       charT c);
@@ -2947,8 +2863,7 @@ basic_string& replace(const_iterator i1, const_iterator i2, size_type n,
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{replace}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{replace}}%
+\indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
 template<class InputIterator>
   basic_string& replace(const_iterator i1, const_iterator i2,
@@ -2967,8 +2882,7 @@ template<class InputIterator>
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{replace}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{replace}}%
+\indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
 basic_string& replace(const_iterator i1, const_iterator i2,
                       initializer_list<charT> il);
@@ -2989,8 +2903,7 @@ basic_string& replace(const_iterator i1, const_iterator i2,
 
 \rSec4[string::copy]{\tcode{basic_string::copy}}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{copy}}%
-\indexlibrary{\idxcode{copy}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{copy}%
 \begin{itemdecl}
 size_type copy(charT* s, size_type n, size_type pos = 0) const;
 \end{itemdecl}
@@ -3026,8 +2939,7 @@ by \tcode{s}.
 
 \rSec4[string::swap]{\tcode{basic_string::swap}}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{swap}%
 \begin{itemdecl}
 void swap(basic_string& s)
   noexcept(allocator_traits<Allocator>::propagate_on_container_swap::value ||
@@ -3075,8 +2987,7 @@ const charT* data() const noexcept;
 The program shall not alter any of the values stored in the character array.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{data}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{data}}%
+\indexlibrarymember{data}{basic_string}%
 \begin{itemdecl}
 charT* data() noexcept;
 \end{itemdecl}
@@ -3094,8 +3005,7 @@ charT* data() noexcept;
 The program shall not alter the value stored at \tcode{p + size()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator basic_string_view}}%
-\indexlibrary{\idxcode{operator basic_string_view}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{operator basic_string_view}%
 \begin{itemdecl}
 operator basic_string_view<charT, traits>() const noexcept;
 \end{itemdecl}
@@ -3106,8 +3016,7 @@ operator basic_string_view<charT, traits>() const noexcept;
 \tcode{return basic_string_view<charT, traits>(data(), size());}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{get_allocator}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{get_allocator}}%
+\indexlibrarymember{get_allocator}{basic_string}%
 \begin{itemdecl}
 allocator_type get_allocator() const noexcept;
 \end{itemdecl}
@@ -3123,8 +3032,7 @@ copy of the most recent replacement.
 
 \rSec4[string::find]{\tcode{basic_string::find}}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{find}}%
-\indexlibrary{\idxcode{find}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{find}%
 \begin{itemdecl}
 size_type find(basic_string_view<charT, traits> sv,
                size_type pos = 0) const noexcept;
@@ -3158,8 +3066,7 @@ Uses
 \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{find}}%
-\indexlibrary{\idxcode{find}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{find}%
 \begin{itemdecl}
 size_type find(const basic_string& str,
                size_type pos = 0) const noexcept;
@@ -3171,8 +3078,7 @@ size_type find(const basic_string& str,
 Equivalent to: \tcode{return find(basic_string_view<charT, traits>(str), pos);}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{find}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{find}}%
+\indexlibrarymember{find}{basic_string}%
 \begin{itemdecl}
 size_type find(const charT* s, size_type pos, size_type n) const;
 \end{itemdecl}
@@ -3183,8 +3089,7 @@ size_type find(const charT* s, size_type pos, size_type n) const;
 \tcode{find(basic_string_view<charT, traits>(s, n), pos)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{find}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{find}}%
+\indexlibrarymember{find}{basic_string}%
 \begin{itemdecl}
 size_type find(const charT* s, size_type pos = 0) const;
 \end{itemdecl}
@@ -3199,8 +3104,7 @@ elements of \tcode{charT}.
 \tcode{find(basic_string_view<charT, traits>(s), pos)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{find}}%
-\indexlibrary{\idxcode{find}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{find}%
 \begin{itemdecl}
 size_type find(charT c, size_type pos = 0) const;
 \end{itemdecl}
@@ -3213,8 +3117,7 @@ size_type find(charT c, size_type pos = 0) const;
 
 \rSec4[string::rfind]{\tcode{basic_string::rfind}}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{rfind}}%
-\indexlibrary{\idxcode{rfind}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{rfind}%
 \begin{itemdecl}
 size_type rfind(basic_string_view<charT, traits> sv,
                 size_type pos = npos) const noexcept;
@@ -3249,8 +3152,7 @@ Uses
 \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{rfind}}%
-\indexlibrary{\idxcode{rfind}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{rfind}%
 \begin{itemdecl}
 size_type rfind(const basic_string& str,
                 size_type pos = npos) const noexcept;
@@ -3262,8 +3164,7 @@ size_type rfind(const basic_string& str,
 Equivalent to: \tcode{return rfind(basic_string_view<charT, traits>(str), pos);}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{rfind}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{rfind}}%
+\indexlibrarymember{rfind}{basic_string}%
 \begin{itemdecl}
 size_type rfind(const charT* s, size_type pos, size_type n) const;
 \end{itemdecl}
@@ -3274,8 +3175,7 @@ size_type rfind(const charT* s, size_type pos, size_type n) const;
 \tcode{rfind(basic_string_view<charT, traits>(s, n), pos)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{rfind}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{rfind}}%
+\indexlibrarymember{rfind}{basic_string}%
 \begin{itemdecl}
 size_type rfind(const charT* s, size_type pos = npos) const;
 \end{itemdecl}
@@ -3290,8 +3190,7 @@ elements of \tcode{charT}.
 \tcode{rfind(basic_string_view<charT, traits>(s), pos)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{rfind}}%
-\indexlibrary{\idxcode{rfind}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{rfind}%
 \begin{itemdecl}
 size_type rfind(charT c, size_type pos = npos) const;
 \end{itemdecl}
@@ -3304,8 +3203,7 @@ size_type rfind(charT c, size_type pos = npos) const;
 
 \rSec4[string::find.first.of]{\tcode{basic_string::find_first_of}}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{find_first_of}}%
-\indexlibrary{\idxcode{find_first_of}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{find_first_of}%
 \begin{itemdecl}
 size_type find_first_of(basic_string_view<charT, traits> sv,
                         size_type pos = 0) const noexcept;
@@ -3340,8 +3238,7 @@ Uses
 \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{find_first_of}}%
-\indexlibrary{\idxcode{find_first_of}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{find_first_of}%
 \begin{itemdecl}
 size_type find_first_of(const basic_string& str,
                         size_type pos = 0) const noexcept;
@@ -3353,8 +3250,7 @@ size_type find_first_of(const basic_string& str,
 Equivalent to: \tcode{return find_first_of(basic_string_view<charT, traits>(str), pos);}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{find_first_of}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{find_first_of}}%
+\indexlibrarymember{find_first_of}{basic_string}%
 \begin{itemdecl}
 size_type
   find_first_of(const charT* s, size_type pos, size_type n) const;
@@ -3366,8 +3262,7 @@ size_type
 \tcode{find_first_of(basic_string_view<charT, traits>(s, n), pos)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{find_first_of}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{find_first_of}}%
+\indexlibrarymember{find_first_of}{basic_string}%
 \begin{itemdecl}
 size_type find_first_of(const charT* s, size_type pos = 0) const;
 \end{itemdecl}
@@ -3382,8 +3277,7 @@ elements of \tcode{charT}.
 \tcode{find_first_of(basic_string_view<charT, traits>(s), pos)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{find_first_of}}%
-\indexlibrary{\idxcode{find_first_of}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{find_first_of}%
 \begin{itemdecl}
 size_type find_first_of(charT c, size_type pos = 0) const;
 \end{itemdecl}
@@ -3396,8 +3290,7 @@ size_type find_first_of(charT c, size_type pos = 0) const;
 
 \rSec4[string::find.last.of]{\tcode{basic_string::find_last_of}}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{find_last_of}}%
-\indexlibrary{\idxcode{find_last_of}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{find_last_of}%
 \begin{itemdecl}
 size_type find_last_of (basic_string_view<charT, traits> sv,
                         size_type pos = npos) const noexcept;
@@ -3432,8 +3325,7 @@ Uses
 \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{find_last_of}}%
-\indexlibrary{\idxcode{find_last_of}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{find_last_of}%
 \begin{itemdecl}
 size_type find_last_of(const basic_string& str,
                        size_type pos = npos) const noexcept;
@@ -3445,8 +3337,7 @@ size_type find_last_of(const basic_string& str,
 Equivalent to: \tcode{return find_last_of(basic_string_view<charT, traits>(str), pos);}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{find_last_of}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{find_last_of}}%
+\indexlibrarymember{find_last_of}{basic_string}%
 \begin{itemdecl}
 size_type find_last_of(const charT* s, size_type pos, size_type n) const;
 \end{itemdecl}
@@ -3457,8 +3348,7 @@ size_type find_last_of(const charT* s, size_type pos, size_type n) const;
 \tcode{find_last_of(basic_string_view<charT, traits>(s, n), pos)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{find_last_of}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{find_last_of}}%
+\indexlibrarymember{find_last_of}{basic_string}%
 \begin{itemdecl}
 size_type find_last_of(const charT* s, size_type pos = npos) const;
 \end{itemdecl}
@@ -3473,8 +3363,7 @@ elements of \tcode{charT}.
 \tcode{find_last_of(basic_string_view<charT, traits>(s), pos)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{find_last_of}}%
-\indexlibrary{\idxcode{find_last_of}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{find_last_of}%
 \begin{itemdecl}
 size_type find_last_of(charT c, size_type pos = npos) const;
 \end{itemdecl}
@@ -3487,8 +3376,7 @@ size_type find_last_of(charT c, size_type pos = npos) const;
 
 \rSec4[string::find.first.not.of]{\tcode{basic_string::find_first_not_of}}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{find_first_not_of}}%
-\indexlibrary{\idxcode{find_first_not_of}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{find_first_not_of}%
 \begin{itemdecl}
 size_type find_first_not_of(basic_string_view<charT, traits> sv,
                             size_type pos = 0) const noexcept;
@@ -3523,8 +3411,7 @@ Uses
 \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{find_first_not_of}}%
-\indexlibrary{\idxcode{find_first_not_of}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{find_first_not_of}%
 \begin{itemdecl}
 size_type find_first_not_of(const basic_string& str,
                             size_type pos = 0) const noexcept;
@@ -3537,8 +3424,7 @@ Equivalent to:
 \tcode{return find_first_not_of(basic_string_view<charT, traits>(str), pos);}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{find_first_not_of}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{find_first_not_of}}%
+\indexlibrarymember{find_first_not_of}{basic_string}%
 \begin{itemdecl}
 size_type
   find_first_not_of(const charT* s, size_type pos, size_type n) const;
@@ -3550,8 +3436,7 @@ size_type
 \tcode{find_first_not_of(basic_string_view<charT, traits>(s, n), pos)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{find_first_not_of}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{find_first_not_of}}%
+\indexlibrarymember{find_first_not_of}{basic_string}%
 \begin{itemdecl}
 size_type find_first_not_of(const charT* s, size_type pos = 0) const;
 \end{itemdecl}
@@ -3566,8 +3451,7 @@ elements of \tcode{charT}.
 \tcode{find_first_not_of(basic_string_view<charT, traits>(s), pos)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{find_first_not_of}}%
-\indexlibrary{\idxcode{find_first_not_of}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{find_first_not_of}%
 \begin{itemdecl}
 size_type find_first_not_of(charT c, size_type pos = 0) const;
 \end{itemdecl}
@@ -3580,8 +3464,7 @@ size_type find_first_not_of(charT c, size_type pos = 0) const;
 
 \rSec4[string::find.last.not.of]{\tcode{basic_string::find_last_not_of}}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{find_last_not_of}}%
-\indexlibrary{\idxcode{find_last_not_of}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{find_last_not_of}%
 \begin{itemdecl}
 size_type find_last_not_of (basic_string_view<charT, traits> sv,
                             size_type pos = npos) const noexcept;
@@ -3616,8 +3499,7 @@ Uses
 \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{find_last_not_of}}%
-\indexlibrary{\idxcode{find_last_not_of}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{find_last_not_of}%
 \begin{itemdecl}
 size_type find_last_not_of(const basic_string& str,
                            size_type pos = npos) const noexcept;
@@ -3630,8 +3512,7 @@ Equivalent to:
 \tcode{return find_last_not_of(basic_string_view<charT, traits>(str), pos);}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{find_last_not_of}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{find_last_not_of}}%
+\indexlibrarymember{find_last_not_of}{basic_string}%
 \begin{itemdecl}
 size_type find_last_not_of(const charT* s, size_type pos,
                            size_type n) const;
@@ -3643,8 +3524,7 @@ size_type find_last_not_of(const charT* s, size_type pos,
 \tcode{find_last_not_of(basic_string_view<charT, traits>(s, n), pos)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{find_last_not_of}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{find_last_not_of}}%
+\indexlibrarymember{find_last_not_of}{basic_string}%
 \begin{itemdecl}
 size_type find_last_not_of(const charT* s, size_type pos = npos) const;
 \end{itemdecl}
@@ -3659,8 +3539,7 @@ elements of \tcode{charT}.
 \tcode{find_last_not_of(basic_string_view<charT, traits>(s), pos)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{find_last_not_of}}%
-\indexlibrary{\idxcode{find_last_not_of}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{find_last_not_of}%
 \begin{itemdecl}
 size_type find_last_not_of(charT c, size_type pos = npos) const;
 \end{itemdecl}
@@ -3673,8 +3552,7 @@ size_type find_last_not_of(charT c, size_type pos = npos) const;
 
 \rSec4[string::substr]{\tcode{basic_string::substr}}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{substr}}%
-\indexlibrary{\idxcode{substr}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{substr}%
 \begin{itemdecl}
 basic_string substr(size_type pos = 0, size_type n = npos) const;
 \end{itemdecl}
@@ -3698,8 +3576,7 @@ Determines the effective length \tcode{rlen} of the string to copy as the smalle
 
 \rSec4[string::compare]{\tcode{basic_string::compare}}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{compare}}%
-\indexlibrary{\idxcode{compare}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{compare}%
 \begin{itemdecl}
 int compare(basic_string_view<charT, traits> sv) const noexcept;
 \end{itemdecl}
@@ -3731,8 +3608,7 @@ Otherwise, returns a value as indicated in Table~\ref{tab:strings.compare}.
 \end{floattable}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{compare}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{compare}}%
+\indexlibrarymember{compare}{basic_string}%
 \begin{itemdecl}
 int compare(size_type pos1, size_type n1,
             basic_string_view<charT, traits> sv) const;
@@ -3747,8 +3623,7 @@ return basic_string_view<charT, traits>(this.data(), pos1, n1).compare(sv);
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{compare}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{compare}}%
+\indexlibrarymember{compare}{basic_string}%
 \begin{itemdecl}
 int compare(size_type pos1, size_type n1,
             basic_string_view<charT, traits> sv,
@@ -3764,8 +3639,7 @@ return basic_string_view<charT, traits>(this.data(), pos1, n1).compare(sv, pos2,
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{compare}}%
-\indexlibrary{\idxcode{compare}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{compare}%
 \begin{itemdecl}
 int compare(const basic_string& str) const noexcept;
 \end{itemdecl}
@@ -3777,8 +3651,7 @@ Equivalent to:
 \tcode{return compare(basic_string_view<charT, traits>(str));}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{compare}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{compare}}%
+\indexlibrarymember{compare}{basic_string}%
 \begin{itemdecl}
 int compare(size_type pos1, size_type n1,
             const basic_string& str) const;
@@ -3791,8 +3664,7 @@ Equivalent to:
 \tcode{return compare(pos1, n1, basic_string_view<charT, traits>(str));}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{compare}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{compare}}%
+\indexlibrarymember{compare}{basic_string}%
 \begin{itemdecl}
 int compare(size_type pos1, size_type n1,
             const basic_string& str,
@@ -3807,8 +3679,7 @@ return compare(pos1, n1, basic_string_view<charT, traits>(str), pos2, n2);
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{compare}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{compare}}%
+\indexlibrarymember{compare}{basic_string}%
 \begin{itemdecl}
 int compare(const charT* s) const;
 \end{itemdecl}
@@ -3819,8 +3690,7 @@ int compare(const charT* s) const;
 \tcode{compare(basic_string(s))}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{compare}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{compare}}%
+\indexlibrarymember{compare}{basic_string}%
 \begin{itemdecl}
 int compare(size_type pos, size_type n1,
             const charT* s) const;
@@ -3831,8 +3701,7 @@ int compare(size_type pos, size_type n1,
 \returns \tcode{basic_string(*this, pos, n1).compare(basic_string(s))}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{compare}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{compare}}%
+\indexlibrarymember{compare}{basic_string}%
 \begin{itemdecl}
 int compare(size_type pos, size_type n1,
             const charT* s, size_type n2) const;
@@ -3849,8 +3718,7 @@ int compare(size_type pos, size_type n1,
 
 \rSec3[string::op+]{\tcode{operator+}}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator+}}%
-\indexlibrary{\idxcode{operator+}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{operator+}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_string<charT, traits, Allocator>
@@ -3864,8 +3732,7 @@ template<class charT, class traits, class Allocator>
 \tcode{basic_string<charT, traits, Allocator>(lhs).append(rhs)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator+}}%
-\indexlibrary{\idxcode{operator+}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{operator+}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_string<charT, traits, Allocator>
@@ -3879,8 +3746,7 @@ template<class charT, class traits, class Allocator>
 \tcode{std::move(lhs.append(rhs))}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator+}}%
-\indexlibrary{\idxcode{operator+}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{operator+}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_string<charT, traits, Allocator>
@@ -3894,8 +3760,7 @@ template<class charT, class traits, class Allocator>
 \tcode{std::move(rhs.insert(0, lhs))}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator+}}%
-\indexlibrary{\idxcode{operator+}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{operator+}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_string<charT, traits, Allocator>
@@ -3911,8 +3776,7 @@ template<class charT, class traits, class Allocator>
 \tcode{std::move(rhs.insert(0, lhs))} \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator+}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator+}}%
+\indexlibrarymember{operator+}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_string<charT, traits, Allocator>
@@ -3931,8 +3795,7 @@ Uses
 \tcode{traits::length()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator+}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator+}}%
+\indexlibrarymember{operator+}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_string<charT, traits, Allocator>
@@ -3951,8 +3814,7 @@ Uses
 \tcode{traits::length()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator+}}%
-\indexlibrary{\idxcode{operator+}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{operator+}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_string<charT, traits, Allocator>
@@ -3966,8 +3828,7 @@ template<class charT, class traits, class Allocator>
 \tcode{basic_string<charT, traits, Allocator>(1, lhs) + rhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator+}}%
-\indexlibrary{\idxcode{operator+}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{operator+}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_string<charT, traits, Allocator>
@@ -3981,8 +3842,7 @@ template<class charT, class traits, class Allocator>
 \tcode{std::move(rhs.insert(0, 1, lhs))}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator+}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator+}}%
+\indexlibrarymember{operator+}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_string<charT, traits, Allocator>
@@ -4001,8 +3861,7 @@ Uses
 \tcode{traits::length()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator+}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator+}}%
+\indexlibrarymember{operator+}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_string<charT, traits, Allocator>
@@ -4021,8 +3880,7 @@ Uses
 \tcode{traits::length()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator+}}%
-\indexlibrary{\idxcode{operator+}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{operator+}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_string<charT, traits, Allocator>
@@ -4036,8 +3894,7 @@ template<class charT, class traits, class Allocator>
 \tcode{lhs + basic_string<charT, traits, Allocator>(1, rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator+}}%
-\indexlibrary{\idxcode{operator+}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{operator+}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_string<charT, traits, Allocator>
@@ -4053,8 +3910,7 @@ template<class charT, class traits, class Allocator>
 
 \rSec3[string::operator==]{\tcode{operator==}}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator==}}%
-\indexlibrary{\idxcode{operator==}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{operator==}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   bool operator==(const basic_string<charT, traits, Allocator>& lhs,
@@ -4067,8 +3923,7 @@ template<class charT, class traits, class Allocator>
 \tcode{lhs.compare(rhs) == 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator==}}%
+\indexlibrarymember{operator==}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   bool operator==(const charT* lhs,
@@ -4081,8 +3936,7 @@ template<class charT, class traits, class Allocator>
 \tcode{rhs == lhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator==}}%
+\indexlibrarymember{operator==}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   bool operator==(const basic_string<charT, traits, Allocator>& lhs,
@@ -4102,8 +3956,7 @@ elements of \tcode{charT}.
 \indexlibrary{\idxcode{length}!\idxcode{char_traits}}%
 \rSec3[string::op!=]{\tcode{operator!=}}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator"!=}}%
-\indexlibrary{\idxcode{operator"!=}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{operator"!=}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   bool operator!=(const basic_string<charT, traits, Allocator>& lhs,
@@ -4150,8 +4003,7 @@ elements of \tcode{charT}.
 
 \rSec3[string::op<]{\tcode{operator<}}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator<}}%
-\indexlibrary{\idxcode{operator<}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{operator<}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   bool operator< (const basic_string<charT, traits, Allocator>& lhs,
@@ -4164,8 +4016,7 @@ template<class charT, class traits, class Allocator>
 \tcode{lhs.compare(rhs) < 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator<}}%
+\indexlibrarymember{operator<}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   bool operator< (const charT* lhs,
@@ -4178,8 +4029,7 @@ template<class charT, class traits, class Allocator>
 \tcode{rhs.compare(lhs) > 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator<}}%
+\indexlibrarymember{operator<}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   bool operator< (const basic_string<charT, traits, Allocator>& lhs,
@@ -4194,8 +4044,7 @@ template<class charT, class traits, class Allocator>
 
 \rSec3[string::op>]{\tcode{operator>}}
 
-\indexlibrary{\idxcode{operator>}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator>}}%
+\indexlibrarymember{operator>}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   bool operator> (const basic_string<charT, traits, Allocator>& lhs,
@@ -4208,8 +4057,7 @@ template<class charT, class traits, class Allocator>
 \tcode{lhs.compare(rhs) > 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator>}}%
+\indexlibrarymember{operator>}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   bool operator> (const charT* lhs,
@@ -4222,8 +4070,7 @@ template<class charT, class traits, class Allocator>
 \tcode{rhs.compare(lhs) < 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator>}}%
+\indexlibrarymember{operator>}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   bool operator> (const basic_string<charT, traits, Allocator>& lhs,
@@ -4238,8 +4085,7 @@ template<class charT, class traits, class Allocator>
 
 \rSec3[string::op<=]{\tcode{operator<=}}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator<=}}%
+\indexlibrarymember{operator<=}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   bool operator<=(const basic_string<charT, traits, Allocator>& lhs,
@@ -4252,8 +4098,7 @@ template<class charT, class traits, class Allocator>
 \tcode{lhs.compare(rhs) <= 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator<=}}%
+\indexlibrarymember{operator<=}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   bool operator<=(const charT* lhs,
@@ -4266,8 +4111,7 @@ template<class charT, class traits, class Allocator>
 \tcode{rhs.compare(lhs) >= 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator<=}}%
+\indexlibrarymember{operator<=}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   bool operator<=(const basic_string<charT, traits, Allocator>& lhs,
@@ -4282,8 +4126,7 @@ template<class charT, class traits, class Allocator>
 
 \rSec3[string::op>=]{\tcode{operator>=}}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator>=}}%
+\indexlibrarymember{operator>=}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   bool operator>=(const basic_string<charT, traits, Allocator>& lhs,
@@ -4296,8 +4139,7 @@ template<class charT, class traits, class Allocator>
 \tcode{lhs.compare(rhs) >= 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator>=}}%
+\indexlibrarymember{operator>=}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   bool operator>=(const charT* lhs,
@@ -4310,8 +4152,7 @@ template<class charT, class traits, class Allocator>
 \tcode{rhs.compare(lhs) <= 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator>=}}%
+\indexlibrarymember{operator>=}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   bool operator>=(const basic_string<charT, traits, Allocator>& lhs,
@@ -4326,8 +4167,7 @@ template<class charT, class traits, class Allocator>
 
 \rSec3[string.special]{\tcode{swap}}
 
-\indexlibrary{\idxcode{basic_string}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{basic_string}}%
+\indexlibrarymember{basic_string}{swap}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   void swap(basic_string<charT, traits, Allocator>& lhs,
@@ -4343,8 +4183,7 @@ Equivalent to: \tcode{lhs.swap(rhs);}
 
 \rSec3[string.io]{Inserters and extractors}
 
-\indexlibrary{\idxcode{operator\shr}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator\shr}}%
+\indexlibrarymember{operator\shr}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_istream<charT, traits>&
@@ -4403,8 +4242,7 @@ which may throw
 \tcode{is}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shl}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator\shl}}%
+\indexlibrarymember{operator\shl}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_ostream<charT, traits>&
@@ -4430,8 +4268,7 @@ then calls \tcode{os.\brk{}width(0)}.
 \tcode{os}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{getline}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{getline}}%
+\indexlibrarymember{getline}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_istream<charT, traits>&
@@ -4501,8 +4338,7 @@ which may throw
 \tcode{is}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{getline}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{getline}}%
+\indexlibrarymember{getline}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_istream<charT, traits>&
@@ -5090,8 +4926,7 @@ const_reverse_iterator crend() const noexcept;
 
 \rSec3[string.view.capacity]{Capacity}
 
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{size}}%
-\indexlibrary{\idxcode{size}!\idxcode{basic_string_view}}%
+\indexlibrarymember{basic_string_view}{size}%
 \begin{itemdecl}
 constexpr size_type size() const noexcept;
 \end{itemdecl}
@@ -5102,8 +4937,7 @@ constexpr size_type size() const noexcept;
 \tcode{size_}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{length}}%
-\indexlibrary{\idxcode{length}!\idxcode{basic_string_view}}%
+\indexlibrarymember{basic_string_view}{length}%
 \begin{itemdecl}
 constexpr size_type length() const noexcept;
 \end{itemdecl}
@@ -5114,8 +4948,7 @@ constexpr size_type length() const noexcept;
 \tcode{size_}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{max_size}}%
-\indexlibrary{\idxcode{max_size}!\idxcode{basic_string_view}}%
+\indexlibrarymember{basic_string_view}{max_size}%
 \begin{itemdecl}
 constexpr size_type max_size() const noexcept;
 \end{itemdecl}
@@ -5126,8 +4959,7 @@ constexpr size_type max_size() const noexcept;
 The largest possible number of char-like objects that can be referred to by a \tcode{basic_string_view}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{empty}}%
-\indexlibrary{\idxcode{empty}!\idxcode{basic_string_view}}%
+\indexlibrarymember{basic_string_view}{empty}%
 \begin{itemdecl}
 constexpr bool empty() const noexcept;
 \end{itemdecl}
@@ -5140,8 +4972,7 @@ constexpr bool empty() const noexcept;
 
 \rSec3[string.view.access]{Element access}
 
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{operator[]}}%
-\indexlibrary{\idxcode{operator[]}!\idxcode{basic_string_view}}%
+\indexlibrarymember{basic_string_view}{operator[]}%
 \begin{itemdecl}
 constexpr const_reference operator[](size_type pos) const;
 \end{itemdecl}
@@ -5166,8 +4997,7 @@ Unlike \tcode{basic_string::operator[]},
 \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{at}}%
-\indexlibrary{\idxcode{at}!\idxcode{basic_string_view}}%
+\indexlibrarymember{basic_string_view}{at}%
 \begin{itemdecl}
 constexpr const_reference at(size_type pos) const;
 \end{itemdecl}
@@ -5182,8 +5012,7 @@ constexpr const_reference at(size_type pos) const;
 \tcode{data_[pos]}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{front}}%
-\indexlibrary{\idxcode{front}!\idxcode{basic_string_view}}%
+\indexlibrarymember{basic_string_view}{front}%
 \begin{itemdecl}
 constexpr const_reference front() const;
 \end{itemdecl}
@@ -5202,8 +5031,7 @@ constexpr const_reference front() const;
 Nothing.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{back}}%
-\indexlibrary{\idxcode{back}!\idxcode{basic_string_view}}%
+\indexlibrarymember{basic_string_view}{back}%
 \begin{itemdecl}
 constexpr const_reference back() const;
 \end{itemdecl}
@@ -5222,8 +5050,7 @@ constexpr const_reference back() const;
 Nothing.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{data}}%
-\indexlibrary{\idxcode{data}!\idxcode{basic_string_view}}%
+\indexlibrarymember{basic_string_view}{data}%
 \begin{itemdecl}
 constexpr const_pointer data() const noexcept;
 \end{itemdecl}
@@ -5243,8 +5070,7 @@ Therefore it is typically a mistake to pass \tcode{data()} to a routine that tak
 
 \rSec3[string.view.modifiers]{Modifiers}
 
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{remove_prefix}}%
-\indexlibrary{\idxcode{remove_prefix}!\idxcode{basic_string_view}}%
+\indexlibrarymember{basic_string_view}{remove_prefix}%
 \begin{itemdecl}
 constexpr void remove_prefix(size_type n);
 \end{itemdecl}
@@ -5259,8 +5085,7 @@ constexpr void remove_prefix(size_type n);
 Equivalent to: \tcode{data_ += n; size_ -= n;}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{remove_suffix}}%
-\indexlibrary{\idxcode{remove_suffix}!\idxcode{basic_string_view}}%
+\indexlibrarymember{basic_string_view}{remove_suffix}%
 \begin{itemdecl}
 constexpr void remove_suffix(size_type n);
 \end{itemdecl}
@@ -5275,8 +5100,7 @@ constexpr void remove_suffix(size_type n);
 Equivalent to: \tcode{size_ -= n;}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{basic_string_view}}%
+\indexlibrarymember{basic_string_view}{swap}%
 \begin{itemdecl}
 constexpr void swap(basic_string_view& s) noexcept;
 \end{itemdecl}
@@ -5289,8 +5113,7 @@ Exchanges the values of \tcode{*this} and \tcode{s}.
 
 \rSec3[string.view.ops]{String operations}
 
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{copy}}%
-\indexlibrary{\idxcode{copy}!\idxcode{basic_string_view}}%
+\indexlibrarymember{basic_string_view}{copy}%
 \begin{itemdecl}
 size_type copy(charT* s, size_type n, size_type pos = 0) const;
 \end{itemdecl}
@@ -5320,8 +5143,7 @@ Equivalent to \tcode{copy_n(begin() + pos, rlen, s)}.
 \bigoh{\tcode{rlen}}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{substr}}%
-\indexlibrary{\idxcode{substr}!\idxcode{basic_string_view}}%
+\indexlibrarymember{basic_string_view}{substr}%
 \begin{itemdecl}
 constexpr basic_string_view substr(size_type pos = 0, size_type n = npos) const;
 \end{itemdecl}
@@ -5343,8 +5165,7 @@ Determines \tcode{rlen}, the effective length of the string to reference.
 \tcode{basic_string_view(data() + pos, rlen)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{compare}}%
-\indexlibrary{\idxcode{compare}!\idxcode{basic_string_view}}%
+\indexlibrarymember{basic_string_view}{compare}%
 \begin{itemdecl}
 constexpr int compare(basic_string_view str) const noexcept;
 \end{itemdecl}
@@ -5456,8 +5277,7 @@ constexpr @\placeholder{return-type}@ @\placeholder{F}@(charT c, size_type pos);
 \end{codeblock}
 is equivalent to \tcode{return \placeholder{F}(basic_string_view(\&c, 1), pos);}
 
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{find}}%
-\indexlibrary{\idxcode{find}!\idxcode{basic_string_view}}%
+\indexlibrarymember{basic_string_view}{find}%
 \begin{itemdecl}
 constexpr size_type find(basic_string_view str, size_type pos = 0) const noexcept;
 \end{itemdecl}
@@ -5488,8 +5308,7 @@ Otherwise, returns \tcode{npos}.
 Uses \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{rfind}}%
-\indexlibrary{\idxcode{rfind}!\idxcode{basic_string_view}}%
+\indexlibrarymember{basic_string_view}{rfind}%
 \begin{itemdecl}
 constexpr size_type rfind(basic_string_view str, size_type pos = npos) const noexcept;
 \end{itemdecl}
@@ -5520,8 +5339,7 @@ Otherwise, returns \tcode{npos}.
 Uses \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{find_first_of}}%
-\indexlibrary{\idxcode{find_first_of}!\idxcode{basic_string_view}}%
+\indexlibrarymember{basic_string_view}{find_first_of}%
 \begin{itemdecl}
 constexpr size_type find_first_of(basic_string_view str, size_type pos = 0) const noexcept;
 \end{itemdecl}
@@ -5552,8 +5370,7 @@ Otherwise, returns \tcode{npos}.
 Uses \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{find_last_of}}%
-\indexlibrary{\idxcode{find_last_of}!\idxcode{basic_string_view}}%
+\indexlibrarymember{basic_string_view}{find_last_of}%
 \begin{itemdecl}
 constexpr size_type find_last_of(basic_string_view str, size_type pos = npos) const noexcept;
 \end{itemdecl}
@@ -5584,8 +5401,7 @@ Otherwise, returns \tcode{npos}.
 Uses \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{find_first_not_of}}%
-\indexlibrary{\idxcode{find_first_not_of}!\idxcode{basic_string_view}}%
+\indexlibrarymember{basic_string_view}{find_first_not_of}%
 \begin{itemdecl}
 constexpr size_type find_first_not_of(basic_string_view str, size_type pos = 0) const noexcept;
 \end{itemdecl}
@@ -5615,8 +5431,7 @@ Determines \tcode{xpos}.
 Uses \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{find_last_not_of}}%
-\indexlibrary{\idxcode{find_last_not_of}!\idxcode{basic_string_view}}%
+\indexlibrarymember{basic_string_view}{find_last_not_of}%
 \begin{itemdecl}
 constexpr size_type find_last_not_of(basic_string_view str, size_type pos = npos) const noexcept;
 \end{itemdecl}
@@ -5689,8 +5504,7 @@ template<class charT, class traits>
 \end{codeblock}
 \end{example}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{basic_string_view}}%
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{operator==}}%
+\indexlibrarymember{operator==}{basic_string_view}%
 \begin{itemdecl}
 template<class charT, class traits>
   constexpr bool operator==(basic_string_view<charT, traits> lhs,
@@ -5717,8 +5531,7 @@ template<class charT, class traits>
 \tcode{lhs.compare(rhs) != 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{basic_string_view}}%
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{operator<}}%
+\indexlibrarymember{operator<}{basic_string_view}%
 \begin{itemdecl}
 template<class charT, class traits>
   constexpr bool operator< (basic_string_view<charT, traits> lhs,
@@ -5731,8 +5544,7 @@ template<class charT, class traits>
 \tcode{lhs.compare(rhs) < 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>}!\idxcode{basic_string_view}}%
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{operator>}}%
+\indexlibrarymember{operator>}{basic_string_view}%
 \begin{itemdecl}
 template<class charT, class traits>
   constexpr bool operator> (basic_string_view<charT, traits> lhs,
@@ -5745,8 +5557,7 @@ template<class charT, class traits>
 \tcode{lhs.compare(rhs) > 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{basic_string_view}}%
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{operator<=}}%
+\indexlibrarymember{operator<=}{basic_string_view}%
 \begin{itemdecl}
 template<class charT, class traits>
   constexpr bool operator<=(basic_string_view<charT, traits> lhs,
@@ -5759,8 +5570,7 @@ template<class charT, class traits>
 \tcode{lhs.compare(rhs) <= 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{basic_string_view}}%
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{operator>=}}%
+\indexlibrarymember{operator>=}{basic_string_view}%
 \begin{itemdecl}
 template<class charT, class traits>
   constexpr bool operator>=(basic_string_view<charT, traits> lhs,
@@ -5775,8 +5585,7 @@ template<class charT, class traits>
 
 \rSec2[string.view.io]{Inserters and extractors}
 
-\indexlibrary{\idxcode{operator\shl}!\idxcode{basic_string_view}}%
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{operator\shl}}%
+\indexlibrarymember{operator\shl}{basic_string_view}%
 \begin{itemdecl}
 template<class charT, class traits>
   basic_ostream<charT, traits>&

--- a/source/support.tex
+++ b/source/support.tex
@@ -2216,8 +2216,7 @@ Copies an object of class
 \tcode{bad_alloc}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{what}!\idxcode{bad_alloc}}%
-\indexlibrary{\idxcode{bad_alloc}!\idxcode{what}}%
+\indexlibrarymember{what}{bad_alloc}%
 \begin{itemdecl}
 const char* what() const noexcept override;
 \end{itemdecl}
@@ -2263,8 +2262,7 @@ bad_array_new_length() noexcept;
 \effects constructs an object of class \tcode{bad_array_new_length}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{bad_array_new_length}!\idxcode{what}}%
-\indexlibrary{\idxcode{what}!\idxcode{bad_array_new_length}}%
+\indexlibrarymember{bad_array_new_length}{what}%
 \begin{itemdecl}
 const char* what() const noexcept override;
 \end{itemdecl}
@@ -2520,8 +2518,7 @@ The names, encoding rule, and collating sequence for types are all unspecified
 \indextext{unspecified}%
 and may differ between programs.
 
-\indexlibrary{\idxcode{operator==}!\idxcode{type_info}}%
-\indexlibrary{\idxcode{type_info}!\idxcode{operator==}}%
+\indexlibrarymember{operator==}{type_info}%
 \begin{itemdecl}
 bool operator==(const type_info& rhs) const noexcept;
 \end{itemdecl}
@@ -2549,8 +2546,7 @@ bool operator!=(const type_info& rhs) const noexcept;
 \tcode{!(*this == rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{before}!\idxcode{type_info}}%
-\indexlibrary{\idxcode{type_info}!\idxcode{before}}%
+\indexlibrarymember{before}{type_info}%
 \begin{itemdecl}
 bool before(const type_info& rhs) const noexcept;
 \end{itemdecl}
@@ -2568,8 +2564,7 @@ if
 precedes \tcode{rhs} in the implementation's collation order.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{hash_code}!\idxcode{type_info}}%
-\indexlibrary{\idxcode{type_info}!\idxcode{hash_code}}%
+\indexlibrarymember{hash_code}{type_info}%
 \begin{itemdecl}
 size_t hash_code() const noexcept;
 \end{itemdecl}
@@ -2586,8 +2581,7 @@ objects which compare equal.
 \end{itemdescr}
 
 
-\indexlibrary{\idxcode{type_info}!\idxcode{name}}%
-\indexlibrary{\idxcode{name}!\idxcode{type_info}}%
+\indexlibrarymember{type_info}{name}%
 \begin{itemdecl}
 const char* name() const noexcept;
 \end{itemdecl}
@@ -2654,8 +2648,7 @@ Copies an object of class
 \tcode{bad_cast}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{bad_cast}!\idxcode{what}}%
-\indexlibrary{\idxcode{what}!\idxcode{bad_cast}}%
+\indexlibrarymember{bad_cast}{what}%
 \begin{itemdecl}
 const char* what() const noexcept override;
 \end{itemdecl}
@@ -2722,8 +2715,7 @@ Copies an object of class
 \tcode{bad_typeid}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{bad_typeid}!\idxcode{what}}%
-\indexlibrary{\idxcode{what}!\idxcode{bad_typeid}}%
+\indexlibrarymember{bad_typeid}{what}%
 \begin{itemdecl}
 const char* what() const noexcept override;
 \end{itemdecl}
@@ -2859,8 +2851,7 @@ Destroys an object of class
 \tcode{exception}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{exception}!\idxcode{what}}%
-\indexlibrary{\idxcode{what}!\idxcode{exception}}%
+\indexlibrarymember{exception}{what}%
 \begin{itemdecl}
 virtual const char* what() const noexcept;
 \end{itemdecl}
@@ -2927,8 +2918,7 @@ Copies an object of class
 \tcode{bad_exception}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{bad_exception}!\idxcode{what}}%
-\indexlibrary{\idxcode{what}!\idxcode{bad_exception}}%
+\indexlibrarymember{bad_exception}{what}%
 \begin{itemdecl}
 const char* what() const noexcept override;
 \end{itemdecl}

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -408,8 +408,7 @@ id() noexcept;
 \pnum\postconditions The constructed object does not represent a thread of execution.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{thread::id}!\idxcode{operator==}}%
-\indexlibrary{\idxcode{operator==}!\idxcode{thread::id}}%
+\indexlibrarymember{thread::id}{operator==}%
 \begin{itemdecl}
 bool operator==(thread::id x, thread::id y) noexcept;
 \end{itemdecl}
@@ -420,8 +419,7 @@ thread of execution or neither \tcode{x} nor \tcode{y} represents a thread of
 execution.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{thread::id}!\idxcode{operator"!=}}%
-\indexlibrary{\idxcode{operator"!=}!\idxcode{thread::id}}%
+\indexlibrarymember{thread::id}{operator"!=}%
 \begin{itemdecl}
 bool operator!=(thread::id x, thread::id y) noexcept;
 \end{itemdecl}
@@ -430,8 +428,7 @@ bool operator!=(thread::id x, thread::id y) noexcept;
 \pnum\returns \tcode{!(x == y)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{thread::id}!\idxcode{operator<}}%
-\indexlibrary{\idxcode{operator<}!\idxcode{thread::id}}%
+\indexlibrarymember{thread::id}{operator<}%
 \begin{itemdecl}
 bool operator<(thread::id x, thread::id y) noexcept;
 \end{itemdecl}
@@ -441,8 +438,7 @@ bool operator<(thread::id x, thread::id y) noexcept;
 \returns A value such that \tcode{operator<} is a total ordering as described in~\ref{alg.sorting}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{thread::id}!\idxcode{operator<=}}%
-\indexlibrary{\idxcode{operator<=}!\idxcode{thread::id}}%
+\indexlibrarymember{thread::id}{operator<=}%
 \begin{itemdecl}
 bool operator<=(thread::id x, thread::id y) noexcept;
 \end{itemdecl}
@@ -452,8 +448,7 @@ bool operator<=(thread::id x, thread::id y) noexcept;
 \returns \tcode{!(y < x)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{thread::id}!\idxcode{operator>}}%
-\indexlibrary{\idxcode{operator>}!\idxcode{thread::id}}%
+\indexlibrarymember{thread::id}{operator>}%
 \begin{itemdecl}
 bool operator>(thread::id x, thread::id y) noexcept;
 \end{itemdecl}
@@ -462,8 +457,7 @@ bool operator>(thread::id x, thread::id y) noexcept;
 \pnum\returns \tcode{y < x}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{thread::id}!\idxcode{operator>=}}%
-\indexlibrary{\idxcode{operator>=}!\idxcode{thread::id}}%
+\indexlibrarymember{thread::id}{operator>=}%
 \begin{itemdecl}
 bool operator>=(thread::id x, thread::id y) noexcept;
 \end{itemdecl}
@@ -472,8 +466,7 @@ bool operator>=(thread::id x, thread::id y) noexcept;
 \pnum\returns \tcode{!(x < y)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{thread::id}!\idxcode{operator\shl}}%
-\indexlibrary{\idxcode{operator\shl}!\idxcode{thread::id}}%
+\indexlibrarymember{thread::id}{operator\shl}%
 \begin{itemdecl}
 template<class charT, class traits>
   basic_ostream<charT, traits>&
@@ -593,8 +586,7 @@ ensure that the destructor is never executed while the thread is still joinable.
 
 \rSec3[thread.thread.assign]{\tcode{thread} assignment}
 
-\indexlibrary{\idxcode{thread}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{thread}}%
+\indexlibrarymember{thread}{operator=}%
 \begin{itemdecl}
 thread& operator=(thread&& x) noexcept;
 \end{itemdecl}
@@ -614,8 +606,7 @@ state of \tcode{x} to \tcode{*this} and sets \tcode{x} to a default constructed 
 
 \rSec3[thread.thread.member]{\tcode{thread} members}
 
-\indexlibrary{\idxcode{thread}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{thread}}%
+\indexlibrarymember{thread}{swap}%
 \begin{itemdecl}
 void swap(thread& x) noexcept;
 \end{itemdecl}
@@ -625,8 +616,7 @@ void swap(thread& x) noexcept;
 \effects Swaps the state of \tcode{*this} and \tcode{x}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{thread}!\idxcode{joinable}}%
-\indexlibrary{\idxcode{joinable}!\idxcode{thread}}%
+\indexlibrarymember{thread}{joinable}%
 \begin{itemdecl}
 bool joinable() const noexcept;
 \end{itemdecl}
@@ -636,8 +626,7 @@ bool joinable() const noexcept;
 \returns \tcode{get_id() != id()}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{thread}!\idxcode{join}}%
-\indexlibrary{\idxcode{join}!\idxcode{thread}}%
+\indexlibrarymember{thread}{join}%
 \begin{itemdecl}
 void join();
 \end{itemdecl}
@@ -671,8 +660,7 @@ an exception is required~(\ref{thread.req.exception}).
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{thread}!\idxcode{detach}}%
-\indexlibrary{\idxcode{detach}!\idxcode{thread}}%
+\indexlibrarymember{thread}{detach}%
 \begin{itemdecl}
 void detach();
 \end{itemdecl}
@@ -696,8 +684,7 @@ an exception is required~(\ref{thread.req.exception}).
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{thread}!\idxcode{get_id}}%
-\indexlibrary{\idxcode{get_id}!\idxcode{thread}}%
+\indexlibrarymember{thread}{get_id}%
 \begin{itemdecl}
 id get_id() const noexcept;
 \end{itemdecl}
@@ -711,8 +698,7 @@ otherwise \tcode{this_thread::get_id()} for the thread of execution represented 
 
 \rSec3[thread.thread.static]{\tcode{thread} static members}
 
-\indexlibrary{\idxcode{thread}!\idxcode{hardware_concurrency}}%
-\indexlibrary{\idxcode{hardware_concurrency}!\idxcode{thread}}%
+\indexlibrarymember{thread}{hardware_concurrency}%
 \begin{itemdecl}
 unsigned hardware_concurrency() noexcept;
 \end{itemdecl}
@@ -726,8 +712,7 @@ well defined an implementation should return 0.
 
 \rSec3[thread.thread.algorithm]{\tcode{thread} specialized algorithms}
 
-\indexlibrary{\idxcode{thread}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{thread}}%
+\indexlibrarymember{thread}{swap}%
 \begin{itemdecl}
 void swap(thread& x, thread& y) noexcept;
 \end{itemdecl}
@@ -750,8 +735,7 @@ namespace std::this_thread {
 }
 \end{codeblock}
 
-\indexlibrary{\idxcode{this_thread}!\idxcode{get_id}}%
-\indexlibrary{\idxcode{get_id}!\idxcode{this_thread}}%
+\indexlibrarymember{this_thread}{get_id}%
 \begin{itemdecl}
 thread::id this_thread::get_id() noexcept;
 \end{itemdecl}
@@ -764,8 +748,7 @@ always have this id. The object returned shall not compare equal to a default co
 \tcode{thread::id}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{this_thread}!\idxcode{yield}}%
-\indexlibrary{\idxcode{yield}!\idxcode{this_thread}}%
+\indexlibrarymember{this_thread}{yield}%
 \begin{itemdecl}
 void this_thread::yield() noexcept;
 \end{itemdecl}
@@ -778,8 +761,7 @@ void this_thread::yield() noexcept;
 \sync None.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{this_thread}!\idxcode{sleep_until}}%
-\indexlibrary{\idxcode{sleep_until}!\idxcode{this_thread}}%
+\indexlibrarymember{this_thread}{sleep_until}%
 \begin{itemdecl}
 template <class Clock, class Duration>
   void sleep_until(const chrono::time_point<Clock, Duration>& abs_time);
@@ -797,8 +779,7 @@ by \tcode{abs_time}.
 \throws Timeout-related exceptions~(\ref{thread.req.timing}).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{this_thread}!\idxcode{sleep_for}}%
-\indexlibrary{\idxcode{sleep_for}!\idxcode{this_thread}}%
+\indexlibrarymember{this_thread}{sleep_for}%
 \begin{itemdecl}
 template <class Rep, class Period>
   void sleep_for(const chrono::duration<Rep, Period>& rel_time);
@@ -1938,8 +1919,7 @@ unique_lock(unique_lock&& u) noexcept;
 \pnum\postconditions \tcode{pm == u_p.pm} and \tcode{owns == u_p.owns} (where \tcode{u_p} is the state of \tcode{u} just prior to this construction),  \tcode{u.pm == 0} and \tcode{u.owns == false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{unique_lock}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{unique_lock}}%
+\indexlibrarymember{unique_lock}{operator=}%
 \begin{itemdecl}
 unique_lock& operator=(unique_lock&& u);
 \end{itemdecl}
@@ -1967,8 +1947,7 @@ unique_lock& operator=(unique_lock&& u);
 
 \rSec4[thread.lock.unique.locking]{\tcode{unique_lock} locking}
 
-\indexlibrary{\idxcode{unique_lock}!\idxcode{lock}}%
-\indexlibrary{\idxcode{lock}!\idxcode{unique_lock}}%
+\indexlibrarymember{unique_lock}{lock}%
 \begin{itemdecl}
 void lock();
 \end{itemdecl}
@@ -1989,8 +1968,7 @@ with an error condition of \tcode{resource_deadlock_would_occur} if on entry \tc
 is \tcode{true}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{unique_lock}!\idxcode{try_lock}}%
-\indexlibrary{\idxcode{try_lock}!\idxcode{unique_lock}}%
+\indexlibrarymember{unique_lock}{try_lock}%
 \begin{itemdecl}
 bool try_lock();
 \end{itemdecl}
@@ -2017,8 +1995,7 @@ with an error condition of \tcode{resource_deadlock_would_occur} if on entry \tc
 is \tcode{true}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{unique_lock}!\idxcode{try_lock_until}}%
-\indexlibrary{\idxcode{try_lock_until}!\idxcode{unique_lock}}%
+\indexlibrarymember{unique_lock}{try_lock_until}%
 \begin{itemdecl}
 template <class Clock, class Duration>
   bool try_lock_until(const chrono::time_point<Clock, Duration>& abs_time);
@@ -2047,8 +2024,7 @@ error condition of \tcode{resource_deadlock_would_occur} if on entry \tcode{owns
 \tcode{true}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{unique_lock}!\idxcode{try_lock_for}}%
-\indexlibrary{\idxcode{try_lock_for}!\idxcode{unique_lock}}%
+\indexlibrarymember{unique_lock}{try_lock_for}%
 \begin{itemdecl}
 template <class Rep, class Period>
   bool try_lock_for(const chrono::duration<Rep, Period>& rel_time);
@@ -2075,8 +2051,7 @@ error condition of \tcode{resource_deadlock_would_occur} if on entry \tcode{owns
 \tcode{true}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{unique_lock}!\idxcode{unlock}}%
-\indexlibrary{\idxcode{unlock}!\idxcode{unique_lock}}%
+\indexlibrarymember{unique_lock}{unlock}%
 \begin{itemdecl}
 void unlock();
 \end{itemdecl}
@@ -2097,8 +2072,7 @@ an exception is required~(\ref{thread.req.exception}).
 
 \rSec4[thread.lock.unique.mod]{\tcode{unique_lock} modifiers}
 
-\indexlibrary{\idxcode{unique_lock}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{unique_lock}}%
+\indexlibrarymember{unique_lock}{swap}%
 \begin{itemdecl}
 void swap(unique_lock& u) noexcept;
 \end{itemdecl}
@@ -2107,8 +2081,7 @@ void swap(unique_lock& u) noexcept;
 \pnum\effects Swaps the data members of \tcode{*this} and \tcode{u}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{unique_lock}!\idxcode{release}}%
-\indexlibrary{\idxcode{release}!\idxcode{unique_lock}}%
+\indexlibrarymember{unique_lock}{release}%
 \begin{itemdecl}
 mutex_type* release() noexcept;
 \end{itemdecl}
@@ -2119,8 +2092,7 @@ mutex_type* release() noexcept;
 \pnum\postconditions \tcode{pm == 0} and \tcode{owns == false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{unique_lock}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{unique_lock}}%
+\indexlibrarymember{unique_lock}{swap}%
 \begin{itemdecl}
 template <class Mutex>
   void swap(unique_lock<Mutex>& x, unique_lock<Mutex>& y) noexcept;
@@ -2132,8 +2104,7 @@ template <class Mutex>
 
 \rSec4[thread.lock.unique.obs]{\tcode{unique_lock} observers}
 
-\indexlibrary{\idxcode{unique_lock}!\idxcode{owns_lock}}%
-\indexlibrary{\idxcode{owns_lock}!\idxcode{unique_lock}}%
+\indexlibrarymember{unique_lock}{owns_lock}%
 \begin{itemdecl}
 bool owns_lock() const noexcept;
 \end{itemdecl}
@@ -2142,8 +2113,7 @@ bool owns_lock() const noexcept;
 \pnum\returns \tcode{owns}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{unique_lock}!\idxcode{operator bool}}%
-\indexlibrary{\idxcode{operator bool}!\idxcode{unique_lock}}%
+\indexlibrarymember{unique_lock}{operator bool}%
 \begin{itemdecl}
 explicit operator bool() const noexcept;
 \end{itemdecl}
@@ -2152,8 +2122,7 @@ explicit operator bool() const noexcept;
 \pnum\returns \tcode{owns}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{unique_lock}!\idxcode{mutex}}%
-\indexlibrary{\idxcode{mutex}!\idxcode{unique_lock}}%
+\indexlibrarymember{unique_lock}{mutex}%
 \begin{itemdecl}
 mutex_type *mutex() const noexcept;
 \end{itemdecl}
@@ -2395,8 +2364,7 @@ shared_lock& operator=(shared_lock&& sl) noexcept;
 
 \rSec4[thread.lock.shared.locking]{\tcode{shared_lock} locking}
 
-\indexlibrary{\idxcode{shared_lock}!\idxcode{lock}}%
-\indexlibrary{\idxcode{lock}!\idxcode{shared_lock}}%
+\indexlibrarymember{shared_lock}{lock}%
 \begin{itemdecl}
 void lock();
 \end{itemdecl}
@@ -2417,8 +2385,7 @@ void lock();
 \tcode{resource_deadlock_would_occur} if on entry \tcode{owns} is \tcode{true}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{shared_lock}!\idxcode{try_lock}}%
-\indexlibrary{\idxcode{try_lock}!\idxcode{shared_lock}}%
+\indexlibrarymember{shared_lock}{try_lock}%
 \begin{itemdecl}
 bool try_lock();
 \end{itemdecl}
@@ -2444,8 +2411,7 @@ the call to \tcode{pm->try_lock_shared()}.
 
 \end{itemdescr}
 
-\indexlibrary{\idxcode{shared_lock}!\idxcode{try_lock_until}}%
-\indexlibrary{\idxcode{try_lock_until}!\idxcode{shared_lock}}%
+\indexlibrarymember{shared_lock}{try_lock_until}%
 \begin{itemdecl}
 template <class Clock, class Duration>
   bool
@@ -2473,8 +2439,7 @@ the call to \tcode{pm->try_lock_shared_until(abs_time)}.
 \tcode{resource_deadlock_would_occur} if on entry \tcode{owns} is \tcode{true}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{shared_lock}!\idxcode{try_lock_for}}%
-\indexlibrary{\idxcode{try_lock_for}!\idxcode{shared_lock}}%
+\indexlibrarymember{shared_lock}{try_lock_for}%
 \begin{itemdecl}
 template <class Rep, class Period>
   bool try_lock_for(const chrono::duration<Rep, Period>& rel_time);
@@ -2494,8 +2459,7 @@ template <class Rep, class Period>
 \throws Any exception thrown by \tcode{pm->try_lock_shared_for(rel_time)}. \tcode{system_error} if an exception is required ~(\ref{thread.req.exception}). \tcode{system_error} with an error condition of \tcode{operation_not_permitted} if \tcode{pm} is \tcode{nullptr}. \tcode{system_error} with an error condition of \tcode{resource_deadlock_would_occur} if on entry \tcode{owns} is \tcode{true}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{shared_lock}!\idxcode{unlock}}%
-\indexlibrary{\idxcode{unlock}!\idxcode{shared_lock}}%
+\indexlibrarymember{shared_lock}{unlock}%
 \begin{itemdecl}
 void unlock();
 \end{itemdecl}
@@ -2520,8 +2484,7 @@ void unlock();
 
 \rSec4[thread.lock.shared.mod]{\tcode{shared_lock} modifiers}
 
-\indexlibrary{\idxcode{shared_lock}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{shared_lock}}%
+\indexlibrarymember{shared_lock}{swap}%
 \begin{itemdecl}
 void swap(shared_lock& sl) noexcept;
 \end{itemdecl}
@@ -2531,8 +2494,7 @@ void swap(shared_lock& sl) noexcept;
 \effects Swaps the data members of \tcode{*this} and \tcode{sl}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{shared_lock}!\idxcode{release}}%
-\indexlibrary{\idxcode{release}!\idxcode{shared_lock}}%
+\indexlibrarymember{shared_lock}{release}%
 \begin{itemdecl}
 mutex_type* release() noexcept;
 \end{itemdecl}
@@ -2545,8 +2507,7 @@ mutex_type* release() noexcept;
 \postconditions \tcode{pm == nullptr} and \tcode{owns == false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{shared_lock}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{shared_lock}}%
+\indexlibrarymember{shared_lock}{swap}%
 \begin{itemdecl}
 template <class Mutex>
   void swap(shared_lock<Mutex>& x, shared_lock<Mutex>& y) noexcept;
@@ -2559,8 +2520,7 @@ template <class Mutex>
 
 \rSec4[thread.lock.shared.obs]{\tcode{shared_lock} observers}
 
-\indexlibrary{\idxcode{shared_lock}!\idxcode{owns_lock}}%
-\indexlibrary{\idxcode{owns_lock}!\idxcode{shared_lock}}%
+\indexlibrarymember{shared_lock}{owns_lock}%
 \begin{itemdecl}
 bool owns_lock() const noexcept;
 \end{itemdecl}
@@ -2570,8 +2530,7 @@ bool owns_lock() const noexcept;
 \returns \tcode{owns}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{shared_lock}!\idxcode{operator bool}}%
-\indexlibrary{\idxcode{operator bool}!\idxcode{shared_lock}}%
+\indexlibrarymember{shared_lock}{operator bool}%
 \begin{itemdecl}
 explicit operator bool () const noexcept;
 \end{itemdecl}
@@ -2581,8 +2540,7 @@ explicit operator bool () const noexcept;
 \returns \tcode{owns}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{shared_lock}!\idxcode{mutex}}%
-\indexlibrary{\idxcode{mutex}!\idxcode{shared_lock}}%
+\indexlibrarymember{shared_lock}{mutex}%
 \begin{itemdecl}
 mutex_type* mutex() const noexcept;
 \end{itemdecl}
@@ -2912,8 +2870,7 @@ using the overloads of \tcode{wait}, \tcode{wait_for}, or \tcode{wait_until} tha
 \pnum\effects Destroys the object.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{condition_variable}!\idxcode{notify_one}}%
-\indexlibrary{\idxcode{notify_one}!\idxcode{condition_variable}}%
+\indexlibrarymember{condition_variable}{notify_one}%
 \begin{itemdecl}
 void notify_one() noexcept;
 \end{itemdecl}
@@ -2922,8 +2879,7 @@ void notify_one() noexcept;
 \pnum\effects If any threads are blocked waiting for \tcode{*this}, unblocks one of those threads.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{condition_variable}!\idxcode{notify_all}}%
-\indexlibrary{\idxcode{notify_all}!\idxcode{condition_variable}}%
+\indexlibrarymember{condition_variable}{notify_all}%
 \begin{itemdecl}
 void notify_all() noexcept;
 \end{itemdecl}
@@ -2932,8 +2888,7 @@ void notify_all() noexcept;
 \pnum\effects Unblocks all threads that are blocked waiting for \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{condition_variable}!\idxcode{wait}}%
-\indexlibrary{\idxcode{wait}!\idxcode{condition_variable}}%
+\indexlibrarymember{condition_variable}{wait}%
 \begin{itemdecl}
 void wait(unique_lock<mutex>& lock);
 \end{itemdecl}
@@ -2971,8 +2926,7 @@ is locked by the calling thread.
 
 \end{itemdescr}
 
-\indexlibrary{\idxcode{condition_variable}!\idxcode{wait}}%
-\indexlibrary{\idxcode{wait}!\idxcode{condition_variable}}%
+\indexlibrarymember{condition_variable}{wait}%
 \begin{itemdecl}
 template <class Predicate>
   void wait(unique_lock<mutex>& lock, Predicate pred);
@@ -3012,8 +2966,7 @@ is locked by the calling thread.
 
 \end{itemdescr}
 
-\indexlibrary{\idxcode{condition_variable}!\idxcode{wait_until}}%
-\indexlibrary{\idxcode{wait_until}!\idxcode{condition_variable}}%
+\indexlibrarymember{condition_variable}{wait_until}%
 \begin{itemdecl}
 template <class Clock, class Duration>
   cv_status wait_until(unique_lock<mutex>& lock,
@@ -3069,8 +3022,7 @@ exceptions~(\ref{thread.req.timing}).
 
 \end{itemdescr}
 
-\indexlibrary{\idxcode{condition_variable}!\idxcode{wait_for}}%
-\indexlibrary{\idxcode{wait_for}!\idxcode{condition_variable}}%
+\indexlibrarymember{condition_variable}{wait_for}%
 \begin{itemdecl}
 template <class Rep, class Period>
   cv_status wait_for(unique_lock<mutex>& lock,
@@ -3115,8 +3067,7 @@ exceptions~(\ref{thread.req.timing}).
 
 \end{itemdescr}
 
-\indexlibrary{\idxcode{condition_variable}!\idxcode{wait_until}}%
-\indexlibrary{\idxcode{wait_until}!\idxcode{condition_variable}}%
+\indexlibrarymember{condition_variable}{wait_until}%
 \begin{itemdecl}
 template <class Clock, class Duration, class Predicate>
   bool wait_until(unique_lock<mutex>& lock,
@@ -3165,8 +3116,7 @@ exceptions~(\ref{thread.req.timing}) or any exception thrown by \tcode{pred}.
 
 \end{itemdescr}
 
-\indexlibrary{\idxcode{condition_variable}!\idxcode{wait_for}}%
-\indexlibrary{\idxcode{wait_for}!\idxcode{condition_variable}}%
+\indexlibrarymember{condition_variable}{wait_for}%
 \begin{itemdecl}
 template <class Rep, class Period, class Predicate>
   bool wait_for(unique_lock<mutex>& lock,
@@ -3304,8 +3254,7 @@ using the overloads of \tcode{wait}, \tcode{wait_for}, or \tcode{wait_until} tha
 \pnum\effects Destroys the object.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{condition_variable_any}!\idxcode{notify_one}}%
-\indexlibrary{\idxcode{notify_one}!\idxcode{condition_variable_any}}%
+\indexlibrarymember{condition_variable_any}{notify_one}%
 \begin{itemdecl}
 void notify_one() noexcept;
 \end{itemdecl}
@@ -3314,8 +3263,7 @@ void notify_one() noexcept;
 \pnum\effects If any threads are blocked waiting for \tcode{*this}, unblocks one of those threads.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{condition_variable_any}!\idxcode{notify_all}}%
-\indexlibrary{\idxcode{notify_all}!\idxcode{condition_variable_any}}%
+\indexlibrarymember{condition_variable_any}{notify_all}%
 \begin{itemdecl}
 void notify_all() noexcept;
 \end{itemdecl}
@@ -3324,8 +3272,7 @@ void notify_all() noexcept;
 \pnum\effects Unblocks all threads that are blocked waiting for \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{condition_variable_any}!\idxcode{wait}}%
-\indexlibrary{\idxcode{wait}!\idxcode{condition_variable_any}}%
+\indexlibrarymember{condition_variable_any}{wait}%
 \begin{itemdecl}
 template <class Lock>
   void wait(Lock& lock);
@@ -3358,8 +3305,7 @@ shall be called~(\ref{except.terminate}).
 
 \end{itemdescr}
 
-\indexlibrary{\idxcode{condition_variable_any}!\idxcode{wait}}%
-\indexlibrary{\idxcode{wait}!\idxcode{condition_variable_any}}%
+\indexlibrarymember{condition_variable_any}{wait}%
 \begin{itemdecl}
 template <class Lock, class Predicate>
   void wait(Lock& lock, Predicate pred);
@@ -3374,8 +3320,7 @@ while (!pred())
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{condition_variable_any}!\idxcode{wait_until}}%
-\indexlibrary{\idxcode{wait_until}!\idxcode{condition_variable_any}}%
+\indexlibrarymember{condition_variable_any}{wait_until}%
 \begin{itemdecl}
 template <class Lock, class Clock, class Duration>
   cv_status wait_until(Lock& lock, const chrono::time_point<Clock, Duration>& abs_time);
@@ -3420,8 +3365,7 @@ exceptions~(\ref{thread.req.timing}).
 
 \end{itemdescr}
 
-\indexlibrary{\idxcode{condition_variable_any}!\idxcode{wait_for}}%
-\indexlibrary{\idxcode{wait_for}!\idxcode{condition_variable_any}}%
+\indexlibrarymember{condition_variable_any}{wait_for}%
 \begin{itemdecl}
 template <class Lock, class Rep, class Period>
   cv_status wait_for(Lock& lock, const chrono::duration<Rep, Period>& rel_time);
@@ -3454,8 +3398,7 @@ exceptions~(\ref{thread.req.timing}).
 
 \end{itemdescr}
 
-\indexlibrary{\idxcode{condition_variable_any}!\idxcode{wait_until}}%
-\indexlibrary{\idxcode{wait_until}!\idxcode{condition_variable_any}}%
+\indexlibrarymember{condition_variable_any}{wait_until}%
 \begin{itemdecl}
 template <class Lock, class Clock, class Duration, class Predicate>
   bool wait_until(Lock& lock, const chrono::time_point<Clock, Duration>& abs_time, Predicate pred);
@@ -3480,8 +3423,7 @@ if the timeout has already expired. \end{note}
 regardless of whether the timeout was triggered. \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{condition_variable_any}!\idxcode{wait_for}}%
-\indexlibrary{\idxcode{wait_for}!\idxcode{condition_variable_any}}%
+\indexlibrarymember{condition_variable_any}{wait_for}%
 \begin{itemdecl}
 template <class Lock, class Rep, class Period, class Predicate>
   bool wait_for(Lock& lock, const chrono::duration<Rep, Period>& rel_time, Predicate pred);
@@ -3602,8 +3544,7 @@ behave as specified for the class \tcode{error_category}. The object's \tcode{na
 virtual function shall return a pointer to the string \tcode{"future"}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{make_error_code}!\idxcode{future_errc}}%
-\indexlibrary{\idxcode{future_errc}!\idxcode{make_error_code}}%
+\indexlibrarymember{make_error_code}{future_errc}%
 \begin{itemdecl}
 error_code make_error_code(future_errc e) noexcept;
 \end{itemdecl}
@@ -3613,8 +3554,7 @@ error_code make_error_code(future_errc e) noexcept;
 \returns \tcode{error_code(static_cast<int>(e), future_category())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{make_error_condition}!\idxcode{future_errc}}%
-\indexlibrary{\idxcode{future_errc}!\idxcode{make_error_condition}}%
+\indexlibrarymember{make_error_condition}{future_errc}%
 \begin{itemdecl}
 error_condition make_error_condition(future_errc e) noexcept;
 \end{itemdecl}
@@ -3638,8 +3578,7 @@ namespace std {
 }
 \end{codeblock}
 
-\indexlibrary{\idxcode{future_error}!\idxcode{code}}%
-\indexlibrary{\idxcode{code}!\idxcode{future_error}}%
+\indexlibrarymember{future_error}{code}%
 \begin{itemdecl}
 const error_code& code() const noexcept;
 \end{itemdecl}
@@ -3649,8 +3588,7 @@ const error_code& code() const noexcept;
 \returns The value of \tcode{ec} that was passed to the object's constructor.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{future_error}!\idxcode{what}}%
-\indexlibrary{\idxcode{what}!\idxcode{future_error}}%
+\indexlibrarymember{future_error}{what}%
 \begin{itemdecl}
 const char* what() const noexcept;
 \end{itemdecl}
@@ -3873,8 +3811,7 @@ of \tcode{rhs} (if any) to the newly-constructed object.
 Abandons any shared state~(\ref{futures.state}).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{promise}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{promise}}%
+\indexlibrarymember{promise}{operator=}%
 \begin{itemdecl}
 promise& operator=(promise&& rhs) noexcept;
 \end{itemdecl}
@@ -3889,8 +3826,7 @@ Abandons any shared state~(\ref{futures.state}) and then as if
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{promise}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{promise}}%
+\indexlibrarymember{promise}{swap}%
 \begin{itemdecl}
 void swap(promise& other) noexcept;
 \end{itemdecl}
@@ -3905,8 +3841,7 @@ prior to the call to \tcode{swap}. \tcode{other} has the shared state (if any) t
 \tcode{*this} had prior to the call to \tcode{swap}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{promise}!\idxcode{get_future}}%
-\indexlibrary{\idxcode{get_future}!\idxcode{promise}}%
+\indexlibrarymember{promise}{get_future}%
 \begin{itemdecl}
 future<R> get_future();
 \end{itemdecl}
@@ -3932,8 +3867,7 @@ a \tcode{promise} with the same shared state as \tcode{*this}.
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{promise}!\idxcode{set_value}}%
-\indexlibrary{\idxcode{set_value}!\idxcode{promise}}%
+\indexlibrarymember{promise}{set_value}%
 \begin{itemdecl}
 void promise::set_value(const R& r);
 void promise::set_value(R&& r);
@@ -3965,8 +3899,7 @@ already has a stored value or exception.
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{promise}!\idxcode{set_exception}}%
-\indexlibrary{\idxcode{set_exception}!\idxcode{promise}}%
+\indexlibrarymember{promise}{set_exception}%
 \begin{itemdecl}
 void set_exception(exception_ptr p);
 \end{itemdecl}
@@ -3993,8 +3926,7 @@ already has a stored value or exception.
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{promise}!\idxcode{set_value_at_thread_exit}}%
-\indexlibrary{\idxcode{set_value_at_thread_exit}!\idxcode{promise}}%
+\indexlibrarymember{promise}{set_value_at_thread_exit}%
 \begin{itemdecl}
 void promise::set_value_at_thread_exit(const R& r);
 void promise::set_value_at_thread_exit(R&& r);
@@ -4028,8 +3960,7 @@ already has a stored value or exception.
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{promise}!\idxcode{set_exception_at_thread_exit}}%
-\indexlibrary{\idxcode{set_exception_at_thread_exit}!\idxcode{promise}}%
+\indexlibrarymember{promise}{set_exception_at_thread_exit}%
 \begin{itemdecl}
 void set_exception_at_thread_exit(exception_ptr p);
 \end{itemdecl}
@@ -4056,8 +3987,7 @@ already has a stored value or exception.
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{swap}!\idxcode{promise}}%
-\indexlibrary{\idxcode{promise}!\idxcode{swap}}%
+\indexlibrarymember{swap}{promise}%
 \begin{itemdecl}
 template <class R>
   void swap(promise<R>& x, promise<R>& y);
@@ -4181,8 +4111,7 @@ destroys \tcode{*this}.
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{future}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{future}}%
+\indexlibrarymember{future}{operator=}%
 \begin{itemdecl}
 future& operator=(future&& rhs) noexcept;
 \end{itemdecl}
@@ -4209,8 +4138,7 @@ assignment.
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{future}!\idxcode{share}}%
-\indexlibrary{\idxcode{share}!\idxcode{future}}%
+\indexlibrarymember{future}{share}%
 \begin{itemdecl}
 shared_future<R> share();
 \end{itemdecl}
@@ -4223,8 +4151,7 @@ shared_future<R> share();
 \postcondition \tcode{valid() == false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{future}!\idxcode{get}}%
-\indexlibrary{\idxcode{get}!\idxcode{future}}%
+\indexlibrarymember{future}{get}%
 \begin{itemdecl}
 R future::get();
 R& future<R&>::get();
@@ -4261,8 +4188,7 @@ value stored in the shared state.
 \postcondition \tcode{valid() == false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{future}!\idxcode{valid}}%
-\indexlibrary{\idxcode{valid}!\idxcode{future}}%
+\indexlibrarymember{future}{valid}%
 \begin{itemdecl}
 bool valid() const noexcept;
 \end{itemdecl}
@@ -4272,8 +4198,7 @@ bool valid() const noexcept;
 \returns \tcode{true} only if \tcode{*this} refers to a shared state.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{future}!\idxcode{wait}}%
-\indexlibrary{\idxcode{wait}!\idxcode{future}}%
+\indexlibrarymember{future}{wait}%
 \begin{itemdecl}
 void wait() const;
 \end{itemdecl}
@@ -4284,8 +4209,7 @@ void wait() const;
 Blocks until the shared state is ready.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{future}!\idxcode{wait_for}}%
-\indexlibrary{\idxcode{wait_for}!\idxcode{future}}%
+\indexlibrarymember{future}{wait_for}%
 \begin{itemdecl}
 template <class Rep, class Period>
   future_status wait_for(const chrono::duration<Rep, Period>& rel_time) const;
@@ -4318,8 +4242,7 @@ specified by \tcode{rel_time} has expired.
 timeout-related exceptions~(\ref{thread.req.timing}).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{future}!\idxcode{wait_until}}%
-\indexlibrary{\idxcode{wait_until}!\idxcode{future}}%
+\indexlibrarymember{future}{wait_until}%
 \begin{itemdecl}
 template <class Clock, class Duration>
   future_status wait_until(const chrono::time_point<Clock, Duration>& abs_time) const;
@@ -4479,8 +4402,7 @@ destroys \tcode{*this}.
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{shared_future}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{shared_future}}%
+\indexlibrarymember{shared_future}{operator=}%
 \begin{itemdecl}
 shared_future& operator=(shared_future&& rhs) noexcept;
 \end{itemdecl}
@@ -4507,8 +4429,7 @@ the assignment.
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{shared_future}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{shared_future}}%
+\indexlibrarymember{shared_future}{operator=}%
 \begin{itemdecl}
 shared_future& operator=(const shared_future& rhs);
 \end{itemdecl}
@@ -4529,8 +4450,7 @@ assigns the contents of \tcode{rhs} to \tcode{*this}. \begin{note} As a result,
 \postconditions \tcode{valid() == rhs.valid()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{shared_future}!\idxcode{get}}%
-\indexlibrary{\idxcode{get}!\idxcode{shared_future}}%
+\indexlibrarymember{shared_future}{get}%
 \begin{itemdecl}
 const R& shared_future::get() const;
 R& shared_future<R&>::get() const;
@@ -4574,8 +4494,7 @@ shared state.
 \throws the stored exception, if an exception was stored in the shared state.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{shared_future}!\idxcode{valid}}%
-\indexlibrary{\idxcode{valid}!\idxcode{shared_future}}%
+\indexlibrarymember{shared_future}{valid}%
 \begin{itemdecl}
 bool valid() const noexcept;
 \end{itemdecl}
@@ -4585,8 +4504,7 @@ bool valid() const noexcept;
 \returns \tcode{true} only if \tcode{*this} refers to a shared state.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{shared_future}!\idxcode{wait}}%
-\indexlibrary{\idxcode{wait}!\idxcode{shared_future}}%
+\indexlibrarymember{shared_future}{wait}%
 \begin{itemdecl}
 void wait() const;
 \end{itemdecl}
@@ -4597,8 +4515,7 @@ void wait() const;
 Blocks until the shared state is ready.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{shared_future}!\idxcode{wait_for}}%
-\indexlibrary{\idxcode{wait_for}!\idxcode{shared_future}}%
+\indexlibrarymember{shared_future}{wait_for}%
 \begin{itemdecl}
 template <class Rep, class Period>
   future_status wait_for(const chrono::duration<Rep, Period>& rel_time) const;
@@ -4632,8 +4549,7 @@ specified by \tcode{rel_time} has expired.
 timeout-related exceptions~(\ref{thread.req.timing}).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{shared_future}!\idxcode{wait_until}}%
-\indexlibrary{\idxcode{wait_until}!\idxcode{shared_future}}%
+\indexlibrarymember{shared_future}{wait_until}%
 \begin{itemdecl}
 template <class Clock, class Duration>
   future_status wait_until(const chrono::time_point<Clock, Duration>& abs_time) const;
@@ -4948,8 +4864,7 @@ shared state. Moves the stored task from \tcode{rhs} to \tcode{*this}.
 \postcondition \tcode{rhs} has no shared state.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{packaged_task}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{packaged_task}}%
+\indexlibrarymember{packaged_task}{operator=}%
 \begin{itemdecl}
 packaged_task& operator=(packaged_task&& rhs) noexcept;
 \end{itemdecl}
@@ -4976,8 +4891,7 @@ calls \tcode{packaged_task(std::move(rhs)).swap(*this)}.
 Abandons any shared state~(\ref{futures.state}).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{packaged_task}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{packaged_task}}%
+\indexlibrarymember{packaged_task}{swap}%
 \begin{itemdecl}
 void swap(packaged_task& other) noexcept;
 \end{itemdecl}
@@ -4994,8 +4908,7 @@ and stored task (if any)
 as \tcode{*this} prior to the call to \tcode{swap}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{packaged_task}!\idxcode{valid}}%
-\indexlibrary{\idxcode{valid}!\idxcode{packaged_task}}%
+\indexlibrarymember{packaged_task}{valid}%
 \begin{itemdecl}
 bool valid() const noexcept;
 \end{itemdecl}
@@ -5005,8 +4918,7 @@ bool valid() const noexcept;
 \returns \tcode{true} only if \tcode{*this} has a shared state.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{packaged_task}!\idxcode{get_future}}%
-\indexlibrary{\idxcode{get_future}!\idxcode{packaged_task}}%
+\indexlibrarymember{packaged_task}{get_future}%
 \begin{itemdecl}
 future<R> get_future();
 \end{itemdecl}
@@ -5027,8 +4939,7 @@ a \tcode{packaged_task} object with the same shared state as \tcode{*this}.
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{packaged_task}!\idxcode{operator()}}%
-\indexlibrary{\idxcode{operator()}!\idxcode{packaged_task}}%
+\indexlibrarymember{packaged_task}{operator()}%
 \begin{itemdecl}
 void operator()(ArgTypes... args);
 \end{itemdecl}
@@ -5058,8 +4969,7 @@ the stored task has already been invoked.
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{packaged_task}!\idxcode{make_ready_at_thread_exit}}%
-\indexlibrary{\idxcode{make_ready_at_thread_exit}!\idxcode{packaged_task}}%
+\indexlibrarymember{packaged_task}{make_ready_at_thread_exit}%
 \begin{itemdecl}
 void make_ready_at_thread_exit(ArgTypes... args);
 \end{itemdecl}
@@ -5088,8 +4998,7 @@ stored task has already been invoked.
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{packaged_task}!\idxcode{reset}}%
-\indexlibrary{\idxcode{reset}!\idxcode{packaged_task}}%
+\indexlibrarymember{packaged_task}{reset}%
 \begin{itemdecl}
 void reset();
 \end{itemdecl}
@@ -5114,8 +5023,7 @@ has no shared state.
 
 \rSec3[futures.task.nonmembers]{\tcode{packaged_task} globals}
 
-\indexlibrary{\idxcode{packaged_task}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{packaged_task}}%
+\indexlibrarymember{packaged_task}{swap}%
 \begin{itemdecl}
 template <class R, class... ArgTypes>
   void swap(packaged_task<R(ArgTypes...)>& x, packaged_task<R(ArgTypes...)>& y) noexcept;

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -998,8 +998,7 @@ tuple_element<1, pair<T1, T2>>::type
 \pnum\textit{Value:} the type T2.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pair}!\idxcode{get}}%
-\indexlibrary{\idxcode{get}!\idxcode{pair}}%
+\indexlibrarymember{pair}{get}%
 \begin{itemdecl}
 template<size_t I, class T1, class T2>
   constexpr tuple_element_t<I, pair<T1, T2>>&
@@ -1022,8 +1021,7 @@ if \tcode{I == 1} returns a reference to \tcode{p.second};
 otherwise the program is ill-formed.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pair}!\idxcode{get}}%
-\indexlibrary{\idxcode{get}!\idxcode{pair}}%
+\indexlibrarymember{pair}{get}%
 \begin{itemdecl}
 template <class T, class U>
   constexpr T& get(pair<T, U>& p) noexcept;
@@ -1042,8 +1040,7 @@ template <class T, class U>
 \returns A reference to \tcode{p.first}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pair}!\idxcode{get}}%
-\indexlibrary{\idxcode{get}!\idxcode{pair}}%
+\indexlibrarymember{pair}{get}%
 \begin{itemdecl}
 template <class T, class U>
   constexpr T& get(pair<U, T>& p) noexcept;
@@ -1508,8 +1505,7 @@ In the function descriptions that follow, let $i$ be in the range \range{0}{size
 in order, $T_i$ be the $i^{th}$ type in \tcode{Types}, and $U_i$ be the $i^{th}$ type in a
 template parameter pack named \tcode{UTypes}, where indexing is zero-based.
 
-\indexlibrary{\idxcode{tuple}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{tuple}}%
+\indexlibrarymember{tuple}{operator=}%
 \begin{itemdecl}
 tuple& operator=(const tuple& u);
 \end{itemdecl}
@@ -1526,8 +1522,7 @@ element of \tcode{*this}.
 \returns  \tcode{*this}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{tuple}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{tuple}}%
+\indexlibrarymember{tuple}{operator=}%
 \begin{itemdecl}
 tuple& operator=(tuple&& u) noexcept(@\seebelow@);
 \end{itemdecl}
@@ -1554,8 +1549,7 @@ where $T_i$ is the $i^{th}$ type in \tcode{Types}.
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{tuple}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{tuple}}%
+\indexlibrarymember{tuple}{operator=}%
 \begin{itemdecl}
 template <class... UTypes>
   tuple& operator=(const tuple<UTypes...>& u);
@@ -1575,8 +1569,7 @@ of \tcode{*this}.
 \returns  \tcode{*this}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{tuple}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{tuple}}%
+\indexlibrarymember{tuple}{operator=}%
 \begin{itemdecl}
 template <class... UTypes>
   tuple& operator=(tuple<UTypes...>&& u);
@@ -1596,8 +1589,7 @@ template <class... UTypes>
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{tuple}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{tuple}}%
+\indexlibrarymember{tuple}{operator=}%
 \indexlibrary{\idxcode{pair}}%
 \begin{itemdecl}
 template <class U1, class U2> tuple& operator=(const pair<U1, U2>& u);
@@ -1618,8 +1610,7 @@ and \tcode{u.second} to the second element of \tcode{*this}.
 \returns  \tcode{*this}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{tuple}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{tuple}}%
+\indexlibrarymember{tuple}{operator=}%
 \indexlibrary{\idxcode{pair}}%
 \begin{itemdecl}
 template <class U1, class U2> tuple& operator=(pair<U1, U2>&& u);
@@ -1947,8 +1938,7 @@ the three templates are available when either of the headers \tcode{<array>} or
 
 \rSec3[tuple.elem]{Element access}
 
-\indexlibrary{\idxcode{tuple}!\idxcode{get}}%
-\indexlibrary{\idxcode{get}!\idxcode{tuple}}%
+\indexlibrarymember{tuple}{get}%
 \begin{itemdecl}
 template <size_t I, class... Types>
   constexpr tuple_element_t<I, tuple<Types...>>& get(tuple<Types...>& t) noexcept;
@@ -1989,8 +1979,7 @@ for member variables of reference type.
 \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{tuple}!\idxcode{get}}%
-\indexlibrary{\idxcode{get}!\idxcode{tuple}}%
+\indexlibrarymember{tuple}{get}%
 \begin{itemdecl}
 template <class T, class... Types>
   constexpr T& get(tuple<Types...>& t) noexcept;
@@ -2031,8 +2020,7 @@ the \tcode{template} keyword. \end{note}
 
 \rSec3[tuple.rel]{Relational operators}
 
-\indexlibrary{\idxcode{tuple}!\idxcode{operator==}}%
-\indexlibrary{\idxcode{operator==}!\idxcode{tuple}}%
+\indexlibrarymember{tuple}{operator==}%
 \begin{itemdecl}
 template<class... TTypes, class... UTypes>
   constexpr bool operator==(const tuple<TTypes...>& t, const tuple<UTypes...>& u);
@@ -2059,8 +2047,7 @@ performed after the first equality comparison that evaluates to
 \tcode{false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{tuple}!\idxcode{operator<}}%
-\indexlibrary{\idxcode{operator<}!\idxcode{tuple}}%
+\indexlibrarymember{tuple}{operator<}%
 \begin{itemdecl}
 template<class... TTypes, class... UTypes>
   constexpr bool operator<(const tuple<TTypes...>& t, const tuple<UTypes...>& u);
@@ -2087,8 +2074,7 @@ of \tcode{r}.  For any two zero-length tuples \tcode{e}
 and \tcode{f}, \tcode{e < f} returns \tcode{false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{tuple}!\idxcode{operator"!=}}%
-\indexlibrary{\idxcode{operator"!=}!\idxcode{tuple}}%
+\indexlibrarymember{tuple}{operator"!=}%
 \begin{itemdecl}
 template<class... TTypes, class... UTypes>
   constexpr bool operator!=(const tuple<TTypes...>& t, const tuple<UTypes...>& u);
@@ -2097,8 +2083,7 @@ template<class... TTypes, class... UTypes>
 \pnum\returns \tcode{!(t == u)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{tuple}!\idxcode{operator>}}%
-\indexlibrary{\idxcode{operator>}!\idxcode{tuple}}%
+\indexlibrarymember{tuple}{operator>}%
 \begin{itemdecl}
 template<class... TTypes, class... UTypes>
   constexpr bool operator>(const tuple<TTypes...>& t, const tuple<UTypes...>& u);
@@ -2107,8 +2092,7 @@ template<class... TTypes, class... UTypes>
 \pnum\returns \tcode{u < t}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{tuple}!\idxcode{operator<=}}%
-\indexlibrary{\idxcode{operator<=}!\idxcode{tuple}}%
+\indexlibrarymember{tuple}{operator<=}%
 \begin{itemdecl}
 template<class... TTypes, class... UTypes>
   constexpr bool operator<=(const tuple<TTypes...>& t, const tuple<UTypes...>& u);
@@ -2117,8 +2101,7 @@ template<class... TTypes, class... UTypes>
 \pnum\returns \tcode{!(u < t)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{tuple}!\idxcode{operator>=}}%
-\indexlibrary{\idxcode{operator>=}!\idxcode{tuple}}%
+\indexlibrarymember{tuple}{operator>=}%
 \begin{itemdecl}
 template<class... TTypes, class... UTypes>
   constexpr bool operator>=(const tuple<TTypes...>& t, const tuple<UTypes...>& u);
@@ -2538,8 +2521,7 @@ If \tcode{is_trivially_destructible_v<T> == true} then this destructor shall be 
 
 \rSec3[optional.object.assign]{Assignment}
 
-\indexlibrary{\idxcode{optional}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{optional}}%
+\indexlibrarymember{optional}{operator=}%
 \begin{itemdecl}
 optional<T>& operator=(nullopt_t) noexcept;
 \end{itemdecl}
@@ -2682,8 +2664,7 @@ The function shall not participate in overload resolution unless
 The reason for providing such generic assignment and then constraining it so that effectively \tcode{T} == \tcode{U} is to guarantee that assignment of the form \tcode{o = \{\}} is unambiguous.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{emplace}!\idxcode{optional}}%
-\indexlibrary{\idxcode{optional}!\idxcode{emplace}}%
+\indexlibrarymember{emplace}{optional}%
 \begin{itemdecl}
 template <class... Args> void emplace(Args&&... args);
 \end{itemdecl}
@@ -2735,8 +2716,7 @@ This function shall not participate in overload resolution unless \tcode{is_cons
 
 \rSec3[optional.object.swap]{Swap}
 
-\indexlibrary{\idxcode{optional}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{optional}}%
+\indexlibrarymember{optional}{swap}%
 \begin{itemdecl}
 void swap(optional<T>& rhs) noexcept(@\seebelow@);
 \end{itemdecl}
@@ -2788,8 +2768,7 @@ the state of \tcode{*val} and \tcode{*rhs.val} is determined by the exception sa
 
 \rSec3[optional.object.observe]{Observers}
 
-\indexlibrary{\idxcode{optional}!\idxcode{operator->}}%
-\indexlibrary{\idxcode{operator->}!\idxcode{optional}}%
+\indexlibrarymember{optional}{operator->}%
 \begin{itemdecl}
 constexpr T const* operator->() const;
 constexpr T* operator->();
@@ -2813,8 +2792,7 @@ Nothing.
 Unless \tcode{T} is a user-defined type with overloaded unary \tcode{operator\&}, these functions shall be \tcode{constexpr} functions.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{optional}!\idxcode{operator*}}%
-\indexlibrary{\idxcode{operator*}!\idxcode{optional}}%
+\indexlibrarymember{optional}{operator*}%
 \begin{itemdecl}
 constexpr T const& operator*() const &;
 constexpr T& operator*() &;
@@ -2853,8 +2831,7 @@ constexpr const T&& operator*() const &&;
 Equivalent to: \tcode{return std::move(*val);}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{optional}!\idxcode{operator bool}}%
-\indexlibrary{\idxcode{operator bool}!\idxcode{optional}}%
+\indexlibrarymember{optional}{operator bool}%
 \begin{itemdecl}
 constexpr explicit operator bool() const noexcept;
 \end{itemdecl}
@@ -2881,8 +2858,7 @@ constexpr bool has_value() const noexcept;
 \remarks This function shall be a \tcode{constexpr} function.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{optional}!\idxcode{value}}%
-\indexlibrary{\idxcode{value}!\idxcode{optional}}%
+\indexlibrarymember{optional}{value}%
 \begin{itemdecl}
 constexpr T const& value() const &;
 constexpr T& value() &;
@@ -2912,8 +2888,7 @@ return bool(*this) ? std::move(*val) : throw bad_optional_access();
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{optional}!\idxcode{value_or}}%
-\indexlibrary{\idxcode{value_or}!\idxcode{optional}}%
+\indexlibrarymember{optional}{value_or}%
 \begin{itemdecl}
 template <class U> constexpr T value_or(U&& v) const &;
 \end{itemdecl}
@@ -2997,8 +2972,7 @@ public:
 The class \tcode{bad_optional_access} defines the type of objects thrown as exceptions to report the situation where an attempt is made to access the value of an optional object that does not contain a value.
 
 \indexlibrary{\idxcode{bad_optional_access}!constructor}%
-\indexlibrary{\idxcode{bad_optional_access}!\idxcode{what}}%
-\indexlibrary{\idxcode{what}!\idxcode{bad_optional_access}}%
+\indexlibrarymember{bad_optional_access}{what}%
 \begin{itemdecl}
 bad_optional_access();
 \end{itemdecl}
@@ -3988,8 +3962,7 @@ then this destructor shall be a trivial destructor.
 
 \rSec3[variant.assign]{Assignment}
 
-\indexlibrary{\idxcode{variant}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{variant}}%
+\indexlibrarymember{variant}{operator=}%
 \begin{itemdecl}
 variant& operator=(const variant& rhs);
 \end{itemdecl}
@@ -4035,8 +4008,7 @@ If an exception is thrown during the call to $T_j$'s move construction,
 the \tcode{variant} will hold no value.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{variant}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{variant}}%
+\indexlibrarymember{variant}{operator=}%
 \begin{itemdecl}
 variant& operator=(variant&& rhs) noexcept(@\seebelow@);
 \end{itemdecl}
@@ -4077,8 +4049,7 @@ the state of the contained value is as defined by the exception safety
 guarantee of $T_j$'s move assignment; \tcode{index()} will be $j$.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{variant}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{variant}}%
+\indexlibrarymember{variant}{operator=}%
 \begin{itemdecl}
 template <class T> variant& operator=(T&& t) noexcept(@\seebelow@);
 \end{itemdecl}
@@ -4140,8 +4111,7 @@ the \tcode{variant} object might not hold a value.
 
 \rSec3[variant.mod]{Modifiers}
 
-\indexlibrary{\idxcode{variant}!\idxcode{emplace}}%
-\indexlibrary{\idxcode{emplace}!\idxcode{variant}}%
+\indexlibrarymember{variant}{emplace}%
 \begin{itemdecl}
 template <class T, class... Args> void emplace(Args&&... args);
 \end{itemdecl}
@@ -4159,8 +4129,7 @@ This function shall not participate in overload resolution unless
 exactly once in \tcode{Types...}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{variant}!\idxcode{emplace}}%
-\indexlibrary{\idxcode{emplace}!\idxcode{variant}}%
+\indexlibrarymember{variant}{emplace}%
 \begin{itemdecl}
 template <class T, class U, class... Args> void emplace(initializer_list<U> il, Args&&... args);
 \end{itemdecl}
@@ -4178,8 +4147,7 @@ This function shall not participate in overload resolution unless
 and \tcode{T} occurs exactly once in \tcode{Types...}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{variant}!\idxcode{emplace}}%
-\indexlibrary{\idxcode{emplace}!\idxcode{variant}}%
+\indexlibrarymember{variant}{emplace}%
 \begin{itemdecl}
 template <size_t I, class... Args> void emplace(Args&&... args);
 \end{itemdecl}
@@ -4212,8 +4180,7 @@ If an exception is thrown during the initialization of the contained value,
 the \tcode{variant} might not hold a value.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{variant}!\idxcode{emplace}}%
-\indexlibrary{\idxcode{emplace}!\idxcode{variant}}%
+\indexlibrarymember{variant}{emplace}%
 \begin{itemdecl}
 template <size_t I, class U, class... Args> void emplace(initializer_list<U> il, Args&&... args);
 \end{itemdecl}
@@ -4248,8 +4215,7 @@ the \tcode{variant} might not hold a value.
 
 \rSec3[variant.status]{Value status}
 
-\indexlibrary{\idxcode{variant}!\idxcode{valueless_by_exception}}%
-\indexlibrary{\idxcode{valueless_by_exception}!\idxcode{variant}}%
+\indexlibrarymember{variant}{valueless_by_exception}%
 \begin{itemdecl}
 constexpr bool valueless_by_exception() const noexcept;
 \end{itemdecl}
@@ -4273,8 +4239,7 @@ v.emplace<1>(S());
 \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{variant}!\idxcode{index}}%
-\indexlibrary{\idxcode{index}!\idxcode{variant}}%
+\indexlibrarymember{variant}{index}%
 \begin{itemdecl}
 constexpr size_t index() const noexcept;
 \end{itemdecl}
@@ -4288,8 +4253,7 @@ Otherwise, returns the zero-based index of the alternative of the contained valu
 
 \rSec3[variant.swap]{Swap}
 
-\indexlibrary{\idxcode{variant}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{variant}}%
+\indexlibrarymember{variant}{swap}%
 \begin{itemdecl}
 void swap(variant& rhs) noexcept(@\seebelow@);
 \end{itemdecl}
@@ -4417,8 +4381,7 @@ Otherwise, the program is ill-formed.
 \tcode{true} if \tcode{index()} is equal to the zero-based index of \tcode{T} in \tcode{Types...}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{get}!\idxcode{variant}}%
-\indexlibrary{\idxcode{variant}!\idxcode{get}}%
+\indexlibrarymember{get}{variant}%
 \begin{itemdecl}
 template <size_t I, class... Types>
   constexpr variant_alternative_t<I, variant<Types...>>& get(variant<Types...>& v);
@@ -4442,8 +4405,7 @@ If \tcode{v.index()} is \tcode{I}, returns a reference to the object stored in
 the \tcode{variant}. Otherwise, throws an exception of type \tcode{bad_variant_access}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{get}!\idxcode{variant}}%
-\indexlibrary{\idxcode{variant}!\idxcode{get}}%
+\indexlibrarymember{get}{variant}%
 \begin{itemdecl}
 template <class T, class... Types> constexpr T& get(variant<Types...>& v);
 template <class T, class... Types> constexpr T&& get(variant<Types...>&& v);
@@ -5664,8 +5626,7 @@ for which the corresponding bit in \tcode{rhs} is set, and leaves all other bits
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shl=}!\idxcode{bitset}}%
-\indexlibrary{\idxcode{bitset}!\idxcode{operator\shl=}}%
+\indexlibrarymember{operator\shl=}{bitset}%
 \begin{itemdecl}
 bitset<N>& operator<<=(size_t pos) noexcept;
 \end{itemdecl}
@@ -5690,8 +5651,7 @@ value of the bit at position \tcode{I - pos}.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shr=}!\idxcode{bitset}}%
-\indexlibrary{\idxcode{bitset}!\idxcode{operator\shr=}}%
+\indexlibrarymember{operator\shr=}{bitset}%
 \begin{itemdecl}
 bitset<N>& operator>>=(size_t pos) noexcept;
 \end{itemdecl}
@@ -6020,8 +5980,7 @@ bool none() const noexcept;
 \returns \tcode{count() == 0}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shl}!\idxcode{bitset}}%
-\indexlibrary{\idxcode{bitset}!\idxcode{operator\shl}}%
+\indexlibrarymember{operator\shl}{bitset}%
 \begin{itemdecl}
 bitset<N> operator<<(size_t pos) const noexcept;
 \end{itemdecl}
@@ -6032,8 +5991,7 @@ bitset<N> operator<<(size_t pos) const noexcept;
 \tcode{bitset<N>(*this) \shl= pos}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shr}!\idxcode{bitset}}%
-\indexlibrary{\idxcode{bitset}!\idxcode{operator\shr}}%
+\indexlibrarymember{operator\shr}{bitset}%
 \begin{itemdecl}
 bitset<N> operator>>(size_t pos) const noexcept;
 \end{itemdecl}
@@ -6144,8 +6102,7 @@ bitset<N> operator^(const bitset<N>& lhs, const bitset<N>& rhs) noexcept;
 \tcode{bitset<N>(lhs) \^{}= rhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shr}!\idxcode{bitset}}%
-\indexlibrary{\idxcode{bitset}!\idxcode{operator\shr}}%
+\indexlibrarymember{operator\shr}{bitset}%
 \begin{itemdecl}
 template <class charT, class traits, size_t N>
   basic_istream<charT, traits>&
@@ -6190,8 +6147,7 @@ If no characters are stored in \tcode{str}, calls
 \tcode{is}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\shl}!\idxcode{bitset}}%
-\indexlibrary{\idxcode{bitset}!\idxcode{operator\shl}}%
+\indexlibrarymember{operator\shl}{bitset}%
 \begin{itemdecl}
 template <class charT, class traits, size_t N>
   basic_ostream<charT, traits>&
@@ -6551,8 +6507,7 @@ namespace std {
 
 \rSec3[pointer.traits.types]{Pointer traits member types}
 
-\indexlibrary{\idxcode{pointer_traits}!\idxcode{element_type}}%
-\indexlibrary{\idxcode{element_type}!\idxcode{pointer_traits}}%
+\indexlibrarymember{pointer_traits}{element_type}%
 \begin{itemdecl}
 using element_type = @\seebelow@;
 \end{itemdecl}
@@ -6567,8 +6522,7 @@ where \tcode{Args} is zero or more type arguments; otherwise, the specialization
 ill-formed.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pointer_traits}!\idxcode{difference_type}}%
-\indexlibrary{\idxcode{difference_type}!\idxcode{pointer_traits}}%
+\indexlibrarymember{pointer_traits}{difference_type}%
 \begin{itemdecl}
 using difference_type = @\seebelow@;
 \end{itemdecl}
@@ -6581,8 +6535,7 @@ type~(\ref{temp.deduct}); otherwise,
 \tcode{ptrdiff_t}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pointer_traits}!\idxcode{rebind}}%
-\indexlibrary{\idxcode{rebind}!\idxcode{pointer_traits}}%
+\indexlibrarymember{pointer_traits}{rebind}%
 \begin{itemdecl}
 template <class U> using rebind = @\seebelow@;
 \end{itemdecl}
@@ -6600,8 +6553,7 @@ where \tcode{Args} is zero or more type arguments; otherwise, the instantiation 
 
 \rSec3[pointer.traits.functions]{Pointer traits member functions}
 
-\indexlibrary{\idxcode{pointer_traits}!\idxcode{pointer_to}}%
-\indexlibrary{\idxcode{pointer_to}!\idxcode{pointer_traits}}%
+\indexlibrarymember{pointer_traits}{pointer_to}%
 \begin{itemdecl}
 static pointer pointer_traits::pointer_to(@\seebelow@ r);
 static pointer pointer_traits<T*>::pointer_to(@\seebelow@ r) noexcept;
@@ -6909,8 +6861,7 @@ namespace std {
 
 \rSec3[allocator.traits.types]{Allocator traits member types}
 
-\indexlibrary{\idxcode{allocator_traits}!\idxcode{pointer}}%
-\indexlibrary{\idxcode{pointer}!\idxcode{allocator_traits}}%
+\indexlibrarymember{allocator_traits}{pointer}%
 \begin{itemdecl}
 using pointer = @\seebelow@;
 \end{itemdecl}
@@ -6922,8 +6873,7 @@ the \grammarterm{qualified-id} \tcode{Alloc::pointer} is valid and denotes a
 type~(\ref{temp.deduct}); otherwise, \tcode{value_type*}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{allocator_traits}!\idxcode{const_pointer}}%
-\indexlibrary{\idxcode{const_pointer}!\idxcode{allocator_traits}}%
+\indexlibrarymember{allocator_traits}{const_pointer}%
 \begin{itemdecl}
 using const_pointer = @\seebelow@;
 \end{itemdecl}
@@ -6936,8 +6886,7 @@ type~(\ref{temp.deduct}); otherwise,
 \tcode{pointer_traits<pointer>::rebind<\brk{}const value_type>}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{allocator_traits}!\idxcode{void_pointer}}%
-\indexlibrary{\idxcode{void_pointer}!\idxcode{allocator_traits}}%
+\indexlibrarymember{allocator_traits}{void_pointer}%
 \begin{itemdecl}
 using void_pointer = @\seebelow@;
 \end{itemdecl}
@@ -6950,8 +6899,7 @@ type~(\ref{temp.deduct}); otherwise,
 \tcode{pointer_traits<pointer>::rebind<\brk{}void>}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{allocator_traits}!\idxcode{const_void_pointer}}%
-\indexlibrary{\idxcode{const_void_pointer}!\idxcode{allocator_traits}}%
+\indexlibrarymember{allocator_traits}{const_void_pointer}%
 \begin{itemdecl}
 using const_void_pointer = @\seebelow@;
 \end{itemdecl}
@@ -6964,8 +6912,7 @@ type~(\ref{temp.deduct}); otherwise,
 \tcode{pointer_traits<pointer>::\brk{}rebind<const void>}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{allocator_traits}!\idxcode{difference_type}}%
-\indexlibrary{\idxcode{difference_type}!\idxcode{allocator_traits}}%
+\indexlibrarymember{allocator_traits}{difference_type}%
 \begin{itemdecl}
 using difference_type = @\seebelow@;
 \end{itemdecl}
@@ -6978,8 +6925,7 @@ type~(\ref{temp.deduct}); otherwise,
 \tcode{pointer_traits<pointer>::dif\-ference_type}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{allocator_traits}!\idxcode{size_type}}%
-\indexlibrary{\idxcode{size_type}!\idxcode{allocator_traits}}%
+\indexlibrarymember{allocator_traits}{size_type}%
 \begin{itemdecl}
 using size_type = @\seebelow@;
 \end{itemdecl}
@@ -6992,8 +6938,7 @@ type~(\ref{temp.deduct}); otherwise,
 \tcode{make_unsigned_t<difference_type>}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{allocator_traits}!\idxcode{propagate_on_container_copy_assignment}}%
-\indexlibrary{\idxcode{propagate_on_container_copy_assignment}!\idxcode{allocator_traits}}%
+\indexlibrarymember{allocator_traits}{propagate_on_container_copy_assignment}%
 \begin{itemdecl}
 using propagate_on_container_copy_assignment = @\seebelow@;
 \end{itemdecl}
@@ -7006,8 +6951,7 @@ type~(\ref{temp.deduct}); otherwise
 \tcode{false_type}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{allocator_traits}!\idxcode{propagate_on_container_move_assignment}}%
-\indexlibrary{\idxcode{propagate_on_container_move_assignment}!\idxcode{allocator_traits}}%
+\indexlibrarymember{allocator_traits}{propagate_on_container_move_assignment}%
 \begin{itemdecl}
 using propagate_on_container_move_assignment = @\seebelow@;
 \end{itemdecl}
@@ -7020,8 +6964,7 @@ type~(\ref{temp.deduct}); otherwise
 \tcode{false_type}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{allocator_traits}!\idxcode{propagate_on_container_swap}}%
-\indexlibrary{\idxcode{propagate_on_container_swap}!\idxcode{allocator_traits}}%
+\indexlibrarymember{allocator_traits}{propagate_on_container_swap}%
 \begin{itemdecl}
 using propagate_on_container_swap = @\seebelow@;
 \end{itemdecl}
@@ -7034,8 +6977,7 @@ type~(\ref{temp.deduct}); otherwise
 \tcode{false_type}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{allocator_traits}!\idxcode{is_always_equal}}%
-\indexlibrary{\idxcode{is_always_equal}!\idxcode{allocator_traits}}%
+\indexlibrarymember{allocator_traits}{is_always_equal}%
 \begin{itemdecl}
 using is_always_equal = @\seebelow@;
 \end{itemdecl}
@@ -7048,8 +6990,7 @@ is valid and denotes a type~(\ref{temp.deduct});
 otherwise \tcode{is_empty<Alloc>::type}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{allocator_traits}!\idxcode{rebind_alloc}}%
-\indexlibrary{\idxcode{rebind_alloc}!\idxcode{allocator_traits}}%
+\indexlibrarymember{allocator_traits}{rebind_alloc}%
 \begin{itemdecl}
 template <class T> using rebind_alloc = @\seebelow@;
 \end{itemdecl}
@@ -7066,8 +7007,7 @@ otherwise, the instantiation of \tcode{rebind_alloc} is ill-formed.
 
 \rSec3[allocator.traits.members]{Allocator traits static member functions}
 
-\indexlibrary{\idxcode{allocator_traits}!\idxcode{allocate}}%
-\indexlibrary{\idxcode{allocate}!\idxcode{allocator_traits}}%
+\indexlibrarymember{allocator_traits}{allocate}%
 \begin{itemdecl}
 static pointer allocate(Alloc& a, size_type n);
 \end{itemdecl}
@@ -7077,8 +7017,7 @@ static pointer allocate(Alloc& a, size_type n);
 \returns \tcode{a.allocate(n)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{allocator_traits}!\idxcode{allocate}}%
-\indexlibrary{\idxcode{allocate}!\idxcode{allocator_traits}}%
+\indexlibrarymember{allocator_traits}{allocate}%
 \begin{itemdecl}
 static pointer allocate(Alloc& a, size_type n, const_void_pointer hint);
 \end{itemdecl}
@@ -7088,8 +7027,7 @@ static pointer allocate(Alloc& a, size_type n, const_void_pointer hint);
 \returns \tcode{a.allocate(n, hint)} if that expression is well-formed; otherwise, \tcode{a.allocate(n)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{allocator_traits}!\idxcode{deallocate}}%
-\indexlibrary{\idxcode{deallocate}!\idxcode{allocator_traits}}%
+\indexlibrarymember{allocator_traits}{deallocate}%
 \begin{itemdecl}
 static void deallocate(Alloc& a, pointer p, size_type n);
 \end{itemdecl}
@@ -7102,8 +7040,7 @@ static void deallocate(Alloc& a, pointer p, size_type n);
 \throws Nothing.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{allocator_traits}!\idxcode{construct}}%
-\indexlibrary{\idxcode{construct}!\idxcode{allocator_traits}}%
+\indexlibrarymember{allocator_traits}{construct}%
 \begin{itemdecl}
 template <class T, class... Args>
   static void construct(Alloc& a, T* p, Args&&... args);
@@ -7116,8 +7053,7 @@ if that call is well-formed;
 otherwise, invokes \tcode{::new (static_cast<void*>(p)) T(std::forward<Args>(args)...)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{allocator_traits}!\idxcode{destroy}}%
-\indexlibrary{\idxcode{destroy}!\idxcode{allocator_traits}}%
+\indexlibrarymember{allocator_traits}{destroy}%
 \begin{itemdecl}
 template <class T>
   static void destroy(Alloc& a, T* p);
@@ -7129,8 +7065,7 @@ template <class T>
 \tcode{p->\~{}T()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{allocator_traits}!\idxcode{max_size}}%
-\indexlibrary{\idxcode{max_size}!\idxcode{allocator_traits}}%
+\indexlibrarymember{allocator_traits}{max_size}%
 \begin{itemdecl}
 static size_type max_size(const Alloc& a) noexcept;
 \end{itemdecl}
@@ -7141,8 +7076,7 @@ static size_type max_size(const Alloc& a) noexcept;
 \tcode{numeric_limits<size_type>::\brk{}max()/sizeof(value_type)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{allocator_traits}!\idxcode{select_on_container_copy_construction}}%
-\indexlibrary{\idxcode{select_on_container_copy_construction}!\idxcode{allocator_traits}}%
+\indexlibrarymember{allocator_traits}{select_on_container_copy_construction}%
 \begin{itemdecl}
 static Alloc select_on_container_copy_construction(const Alloc& rhs);
 \end{itemdecl}
@@ -7238,8 +7172,7 @@ when this function is called.
 
 \rSec3[allocator.globals]{\tcode{allocator} globals}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{allocator}}%
-\indexlibrary{\idxcode{allocator}!\idxcode{operator==}}%
+\indexlibrarymember{operator==}{allocator}%
 \begin{itemdecl}
 template <class T, class U>
   bool operator==(const allocator<T>&, const allocator<U>&) noexcept;
@@ -8620,8 +8553,7 @@ unless \tcode{is_swappable_v<D>} is \tcode{true}.
 \effects Calls \tcode{x.swap(y)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{unique_ptr}}%
-\indexlibrary{\idxcode{unique_ptr}!\idxcode{operator==}}%
+\indexlibrarymember{operator==}{unique_ptr}%
 \begin{itemdecl}
 template <class T1, class D1, class T2, class D2>
   bool operator==(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
@@ -8644,8 +8576,7 @@ template <class T1, class D1, class T2, class D2>
 \returns \tcode{x.get() != y.get()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{unique_ptr}}%
-\indexlibrary{\idxcode{unique_ptr}!\idxcode{operator<}}%
+\indexlibrarymember{operator<}{unique_ptr}%
 \begin{itemdecl}
 template <class T1, class D1, class T2, class D2>
   bool operator<(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
@@ -8667,8 +8598,7 @@ to \tcode{\placeholder{CT}} or \tcode{unique_ptr<T2, D2>::pointer} is not implic
 convertible to \tcode{\placeholder{CT}}, the program is ill-formed.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{operator<=}}%
+\indexlibrarymember{operator<=}{shared_ptr}%
 \begin{itemdecl}
 template <class T1, class D1, class T2, class D2>
   bool operator<=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
@@ -8679,8 +8609,7 @@ template <class T1, class D1, class T2, class D2>
 \returns \tcode{!(y < x)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>}!\idxcode{unique_ptr}}%
-\indexlibrary{\idxcode{unique_ptr}!\idxcode{operator>}}%
+\indexlibrarymember{operator>}{unique_ptr}%
 \begin{itemdecl}
 template <class T1, class D1, class T2, class D2>
   bool operator>(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
@@ -8691,8 +8620,7 @@ template <class T1, class D1, class T2, class D2>
 \returns \tcode{y < x}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{unique_ptr}}%
-\indexlibrary{\idxcode{unique_ptr}!\idxcode{operator>=}}%
+\indexlibrarymember{operator>=}{unique_ptr}%
 \begin{itemdecl}
 template <class T1, class D1, class T2, class D2>
   bool operator>=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
@@ -8703,8 +8631,7 @@ template <class T1, class D1, class T2, class D2>
 \returns \tcode{!(x < y)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{unique_ptr}}%
-\indexlibrary{\idxcode{unique_ptr}!\idxcode{operator==}}%
+\indexlibrarymember{operator==}{unique_ptr}%
 \begin{itemdecl}
 template <class T, class D>
   bool operator==(const unique_ptr<T, D>& x, nullptr_t) noexcept;
@@ -8731,8 +8658,7 @@ template <class T, class D>
 \returns \tcode{(bool)x}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{unique_ptr}}%
-\indexlibrary{\idxcode{unique_ptr}!\idxcode{operator<}}%
+\indexlibrarymember{operator<}{unique_ptr}%
 \begin{itemdecl}
 template <class T, class D>
   bool operator<(const unique_ptr<T, D>& x, nullptr_t);
@@ -8754,8 +8680,7 @@ The second function template returns
 \tcode{less<unique_ptr<T, D>::pointer>()(nullptr, x.get())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>}!\idxcode{unique_ptr}}%
-\indexlibrary{\idxcode{unique_ptr}!\idxcode{operator>}}%
+\indexlibrarymember{operator>}{unique_ptr}%
 \begin{itemdecl}
 template <class T, class D>
   bool operator>(const unique_ptr<T, D>& x, nullptr_t);
@@ -8770,8 +8695,7 @@ The first function template returns \tcode{nullptr < x}.
 The second function template returns \tcode{x < nullptr}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{unique_ptr}}%
-\indexlibrary{\idxcode{unique_ptr}!\idxcode{operator<=}}%
+\indexlibrarymember{operator<=}{unique_ptr}%
 \begin{itemdecl}
 template <class T, class D>
   bool operator<=(const unique_ptr<T, D>& x, nullptr_t);
@@ -8786,8 +8710,7 @@ The first function template returns \tcode{!(nullptr < x)}.
 The second function template returns \tcode{!(x < nullptr)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{unique_ptr}}%
-\indexlibrary{\idxcode{unique_ptr}!\idxcode{operator>=}}%
+\indexlibrarymember{operator>=}{unique_ptr}%
 \begin{itemdecl}
 template <class T, class D>
   bool operator>=(const unique_ptr<T, D>& x, nullptr_t);
@@ -8821,8 +8744,7 @@ An exception of type \tcode{bad_weak_ptr} is thrown by the \tcode{shared_ptr}
 constructor taking a \tcode{weak_ptr}.
 
 \indexlibrary{\idxcode{bad_weak_ptr}!constructor}%
-\indexlibrary{\idxcode{bad_weak_ptr}!\idxcode{what}}%
-\indexlibrary{\idxcode{what}!\idxcode{bad_weak_ptr}}%
+\indexlibrarymember{bad_weak_ptr}{what}%
 \begin{itemdecl}
 bad_weak_ptr() noexcept;
 \end{itemdecl}
@@ -9194,8 +9116,7 @@ than its previous value. \end{note}
 
 \rSec4[util.smartptr.shared.assign]{\tcode{shared_ptr} assignment}
 
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{shared_ptr}}%
+\indexlibrarymember{shared_ptr}{operator=}%
 \begin{itemdecl}
 shared_ptr& operator=(const shared_ptr& r) noexcept;
 template<class Y> shared_ptr& operator=(const shared_ptr<Y>& r) noexcept;
@@ -9221,8 +9142,7 @@ q = p;
 both assignments may be no-ops. \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{shared_ptr}%
 \begin{itemdecl}
 shared_ptr& operator=(shared_ptr&& r) noexcept;
 template<class Y> shared_ptr& operator=(shared_ptr<Y>&& r) noexcept;
@@ -9236,8 +9156,7 @@ template<class Y> shared_ptr& operator=(shared_ptr<Y>&& r) noexcept;
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{shared_ptr}%
 \begin{itemdecl}
 template <class Y, class D> shared_ptr& operator=(unique_ptr<Y, D>&& r);
 \end{itemdecl}
@@ -9254,8 +9173,7 @@ template <class Y, class D> shared_ptr& operator=(unique_ptr<Y, D>&& r);
 
 \rSec4[util.smartptr.shared.mod]{\tcode{shared_ptr} modifiers}
 
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{shared_ptr}}%
+\indexlibrarymember{shared_ptr}{swap}%
 \begin{itemdecl}
 void swap(shared_ptr& r) noexcept;
 \end{itemdecl}
@@ -9265,8 +9183,7 @@ void swap(shared_ptr& r) noexcept;
 \pnum\effects  Exchanges the contents of \tcode{*this} and \tcode{r}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{reset}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{reset}}%
+\indexlibrarymember{reset}{shared_ptr}%
 \begin{itemdecl}
 void reset() noexcept;
 \end{itemdecl}
@@ -9275,8 +9192,7 @@ void reset() noexcept;
 \pnum\effects  Equivalent to \tcode{shared_ptr().swap(*this)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{reset}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{reset}}%
+\indexlibrarymember{reset}{shared_ptr}%
 \begin{itemdecl}
 template<class Y> void reset(Y* p);
 \end{itemdecl}
@@ -9285,8 +9201,7 @@ template<class Y> void reset(Y* p);
 \pnum\effects  Equivalent to \tcode{shared_ptr(p).swap(*this)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{reset}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{reset}}%
+\indexlibrarymember{reset}{shared_ptr}%
 \begin{itemdecl}
 template<class Y, class D> void reset(Y* p, D d);
 \end{itemdecl}
@@ -9295,8 +9210,7 @@ template<class Y, class D> void reset(Y* p, D d);
 \pnum\effects  Equivalent to \tcode{shared_ptr(p, d).swap(*this)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{reset}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{reset}}%
+\indexlibrarymember{reset}{shared_ptr}%
 \begin{itemdecl}
 template<class Y, class D, class A> void reset(Y* p, D d, A a);
 \end{itemdecl}
@@ -9307,8 +9221,7 @@ template<class Y, class D, class A> void reset(Y* p, D d, A a);
 \end{itemdescr}
 
 \rSec4[util.smartptr.shared.obs]{\tcode{shared_ptr} observers}
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{get}}%
-\indexlibrary{\idxcode{get}!\idxcode{shared_ptr}}%
+\indexlibrarymember{shared_ptr}{get}%
 \begin{itemdecl}
 T* get() const noexcept;
 \end{itemdecl}
@@ -9317,8 +9230,7 @@ T* get() const noexcept;
 \pnum\returns  the stored pointer.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{operator*}}%
-\indexlibrary{\idxcode{operator*}!\idxcode{shared_ptr}}%
+\indexlibrarymember{shared_ptr}{operator*}%
 \begin{itemdecl}
 T& operator*() const noexcept;
 \end{itemdecl}
@@ -9335,8 +9247,7 @@ return type is, except that the declaration (although not necessarily the
 definition) of the function shall be well formed.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{operator->}}%
-\indexlibrary{\idxcode{operator->}!\idxcode{shared_ptr}}%
+\indexlibrarymember{shared_ptr}{operator->}%
 \begin{itemdecl}
 T* operator->() const noexcept;
 \end{itemdecl}
@@ -9347,8 +9258,7 @@ T* operator->() const noexcept;
 \pnum\returns  \tcode{get()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{use_count}}%
-\indexlibrary{\idxcode{use_count}!\idxcode{shared_ptr}}%
+\indexlibrarymember{shared_ptr}{use_count}%
 \begin{itemdecl}
 long use_count() const noexcept;
 \end{itemdecl}
@@ -9359,8 +9269,7 @@ that \textit{share ownership} with \tcode{*this}, or \tcode{0} when \tcode{*this
 \textit{empty}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{unique}}%
-\indexlibrary{\idxcode{unique}!\idxcode{shared_ptr}}%
+\indexlibrarymember{shared_ptr}{unique}%
 \begin{itemdecl}
 bool unique() const noexcept;
 \end{itemdecl}
@@ -9373,8 +9282,7 @@ using \tcode{unique()} to implement copy on write, do not rely on a
 specific value when \tcode{get() == nullptr}. \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator bool}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{operator bool}}%
+\indexlibrarymember{operator bool}{shared_ptr}%
 \begin{itemdecl}
 explicit operator bool() const noexcept;
 \end{itemdecl}
@@ -9383,8 +9291,7 @@ explicit operator bool() const noexcept;
 \pnum\returns \tcode{get() != 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{owner_before}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{owner_before}}%
+\indexlibrarymember{owner_before}{shared_ptr}%
 \begin{itemdecl}
 template<class U> bool owner_before(shared_ptr<U> const& b) const;
 template<class U> bool owner_before(weak_ptr<U> const& b) const;
@@ -9456,8 +9363,7 @@ as the reference counts. \end{note}
 
 \rSec4[util.smartptr.shared.cmp]{\tcode{shared_ptr} comparison}
 
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{operator==}}%
-\indexlibrary{\idxcode{operator==}!\idxcode{shared_ptr}}%
+\indexlibrarymember{shared_ptr}{operator==}%
 \begin{itemdecl}
 template<class T, class U> bool operator==(const shared_ptr<T>& a, const shared_ptr<U>& b) noexcept;
 \end{itemdecl}
@@ -9466,8 +9372,7 @@ template<class T, class U> bool operator==(const shared_ptr<T>& a, const shared_
 \pnum\returns  \tcode{a.get() == b.get()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{operator<}}%
-\indexlibrary{\idxcode{operator<}!\idxcode{shared_ptr}}%
+\indexlibrarymember{shared_ptr}{operator<}%
 \begin{itemdecl}
 template<class T, class U> bool operator<(const shared_ptr<T>& a, const shared_ptr<U>& b) noexcept;
 \end{itemdecl}
@@ -9483,8 +9388,7 @@ used as keys in associative containers.
 
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{operator==}}%
+\indexlibrarymember{operator==}{shared_ptr}%
 \begin{itemdecl}
 template <class T>
   bool operator==(const shared_ptr<T>& a, nullptr_t) noexcept;
@@ -9511,8 +9415,7 @@ template <class T>
 \returns \tcode{(bool)a}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{operator<}}%
+\indexlibrarymember{operator<}{shared_ptr}%
 \begin{itemdecl}
 template <class T>
   bool operator<(const shared_ptr<T>& a, nullptr_t) noexcept;
@@ -9529,8 +9432,7 @@ The second function template returns
 \tcode{less<T*>()(nullptr, a.get())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{operator>}}%
+\indexlibrarymember{operator>}{shared_ptr}%
 \begin{itemdecl}
 template <class T>
   bool operator>(const shared_ptr<T>& a, nullptr_t) noexcept;
@@ -9545,8 +9447,7 @@ The first function template returns \tcode{nullptr < a}.
 The second function template returns \tcode{a < nullptr}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{operator<=}}%
+\indexlibrarymember{operator<=}{shared_ptr}%
 \begin{itemdecl}
 template <class T>
   bool operator<=(const shared_ptr<T>& a, nullptr_t) noexcept;
@@ -9561,8 +9462,7 @@ The first function template returns \tcode{!(nullptr < a)}.
 The second function template returns \tcode{!(a < nullptr)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{operator>=}}%
+\indexlibrarymember{operator>=}{shared_ptr}%
 \begin{itemdecl}
 template <class T>
   bool operator>=(const shared_ptr<T>& a, nullptr_t) noexcept;
@@ -9579,8 +9479,7 @@ The second function template returns \tcode{!(nullptr < a)}.
 
 \rSec4[util.smartptr.shared.spec]{\tcode{shared_ptr} specialized algorithms}
 
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{shared_ptr}}%
+\indexlibrarymember{shared_ptr}{swap}%
 \begin{itemdecl}
 template<class T> void swap(shared_ptr<T>& a, shared_ptr<T>& b) noexcept;
 \end{itemdecl}
@@ -9591,8 +9490,7 @@ template<class T> void swap(shared_ptr<T>& a, shared_ptr<T>& b) noexcept;
 
 \rSec4[util.smartptr.shared.cast]{\tcode{shared_ptr} casts}
 
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{static_pointer_cast}}%
-\indexlibrary{\idxcode{static_pointer_cast}!\idxcode{shared_ptr}}%
+\indexlibrarymember{shared_ptr}{static_pointer_cast}%
 \begin{itemdecl}
 template<class T, class U> shared_ptr<T> static_pointer_cast(const shared_ptr<U>& r) noexcept;
 \end{itemdecl}
@@ -9617,8 +9515,7 @@ will eventually result in undefined behavior, attempting to delete the
 same object twice. \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{dynamic_pointer_cast}}%
-\indexlibrary{\idxcode{dynamic_pointer_cast}!\idxcode{shared_ptr}}%
+\indexlibrarymember{shared_ptr}{dynamic_pointer_cast}%
 \begin{itemdecl}
 template<class T, class U> shared_ptr<T> dynamic_pointer_cast(const shared_ptr<U>& r) noexcept;
 \end{itemdecl}
@@ -9644,8 +9541,7 @@ shall be well formed and shall have well defined behavior.
 undefined behavior, attempting to delete the same object twice. \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{const_pointer_cast}}%
-\indexlibrary{\idxcode{const_pointer_cast}!\idxcode{shared_ptr}}%
+\indexlibrarymember{shared_ptr}{const_pointer_cast}%
 \begin{itemdecl}
 template<class T, class U> shared_ptr<T> const_pointer_cast(const shared_ptr<U>& r) noexcept;
 \end{itemdecl}
@@ -9669,8 +9565,7 @@ undefined behavior, attempting to delete the same object twice. \end{note}
 
 \rSec4[util.smartptr.getdeleter]{get_deleter}
 
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{get_deleter}}%
-\indexlibrary{\idxcode{get_deleter}!\idxcode{shared_ptr}}%
+\indexlibrarymember{shared_ptr}{get_deleter}%
 \begin{itemdecl}
 template<class D, class T> D* get_deleter(const shared_ptr<T>& p) noexcept;
 \end{itemdecl}
@@ -9688,8 +9583,7 @@ the deleter until all \tcode{weak_ptr} instances that share ownership with
 
 \rSec4[util.smartptr.shared.io]{\tcode{shared_ptr} I/O}
 
-\indexlibrary{\idxcode{operator\shl}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{operator\shl}}%
+\indexlibrarymember{operator\shl}{shared_ptr}%
 \begin{itemdecl}
 template<class E, class T, class Y>
   basic_ostream<E, T>& operator<< (basic_ostream<E, T>& os, shared_ptr<Y> const& p);
@@ -9819,8 +9713,7 @@ effect on the object its stored pointer points to.
 
 \rSec4[util.smartptr.weak.assign]{\tcode{weak_ptr} assignment}
 
-\indexlibrary{\idxcode{weak_ptr}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{weak_ptr}}%
+\indexlibrarymember{weak_ptr}{operator=}%
 \begin{itemdecl}
 weak_ptr& operator=(const weak_ptr& r) noexcept;
 template<class Y> weak_ptr& operator=(const weak_ptr<Y>& r) noexcept;
@@ -9836,8 +9729,7 @@ implied guarantees) via different means, without creating a temporary.
 \pnum\returns  \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{weak_ptr}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{weak_ptr}}%
+\indexlibrarymember{weak_ptr}{operator=}%
 \begin{itemdecl}
 weak_ptr& operator=(weak_ptr&& r) noexcept;
 template<class Y> weak_ptr& operator=(weak_ptr<Y>&& r) noexcept;
@@ -9850,8 +9742,7 @@ template<class Y> weak_ptr& operator=(weak_ptr<Y>&& r) noexcept;
 \end{itemdescr}
 
 \rSec4[util.smartptr.weak.mod]{\tcode{weak_ptr} modifiers}
-\indexlibrary{\idxcode{weak_ptr}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{weak_ptr}}%
+\indexlibrarymember{weak_ptr}{swap}%
 \begin{itemdecl}
 void swap(weak_ptr& r) noexcept;
 \end{itemdecl}
@@ -9860,8 +9751,7 @@ void swap(weak_ptr& r) noexcept;
 \pnum\effects  Exchanges the contents of \tcode{*this} and \tcode{r}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{weak_ptr}!\idxcode{reset}}%
-\indexlibrary{\idxcode{reset}!\idxcode{weak_ptr}}%
+\indexlibrarymember{weak_ptr}{reset}%
 \begin{itemdecl}
 void reset() noexcept;
 \end{itemdecl}
@@ -9871,8 +9761,7 @@ void reset() noexcept;
 \end{itemdescr}
 
 \rSec4[util.smartptr.weak.obs]{\tcode{weak_ptr} observers}
-\indexlibrary{\idxcode{weak_ptr}!\idxcode{use_count}}%
-\indexlibrary{\idxcode{use_count}!\idxcode{weak_ptr}}%
+\indexlibrarymember{weak_ptr}{use_count}%
 \begin{itemdecl}
 long use_count() const noexcept;
 \end{itemdecl}
@@ -9883,8 +9772,7 @@ otherwise, the number of \tcode{shared_ptr} instances
 that \textit{share ownership} with \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{weak_ptr}!\idxcode{expired}}%
-\indexlibrary{\idxcode{expired}!\idxcode{weak_ptr}}%
+\indexlibrarymember{weak_ptr}{expired}%
 \begin{itemdecl}
 bool expired() const noexcept;
 \end{itemdecl}
@@ -9893,8 +9781,7 @@ bool expired() const noexcept;
 \pnum\returns  \tcode{use_count() == 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{weak_ptr}!\idxcode{lock}}%
-\indexlibrary{\idxcode{lock}!\idxcode{weak_ptr}}%
+\indexlibrarymember{weak_ptr}{lock}%
 \begin{itemdecl}
 shared_ptr<T> lock() const noexcept;
 \end{itemdecl}
@@ -9903,8 +9790,7 @@ shared_ptr<T> lock() const noexcept;
 \pnum\returns  \tcode{expired() ? shared_ptr<T>() : shared_ptr<T>(*this)}, executed atomically.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{owner_before}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{owner_before}}%
+\indexlibrarymember{owner_before}{shared_ptr}%
 \begin{itemdecl}
 template<class U> bool owner_before(shared_ptr<U> const& b) const;
 template<class U> bool owner_before(weak_ptr<U> const& b) const;
@@ -9927,8 +9813,7 @@ both empty.
 
 \rSec4[util.smartptr.weak.spec]{\tcode{weak_ptr} specialized algorithms}
 
-\indexlibrary{\idxcode{weak_ptr}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{weak_ptr}}%
+\indexlibrarymember{weak_ptr}{swap}%
 \begin{itemdecl}
 template<class T> void swap(weak_ptr<T>& a, weak_ptr<T>& b) noexcept;
 \end{itemdecl}
@@ -10043,8 +9928,7 @@ enable_shared_from_this(const enable_shared_from_this<T>&) noexcept;
 \pnum\effects  Value-initializes \tcode{weak_this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{enable_shared_from_this}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{enable_shared_from_this}}%
+\indexlibrarymember{enable_shared_from_this}{operator=}%
 \begin{itemdecl}
 enable_shared_from_this<T>& operator=(const enable_shared_from_this<T>&) noexcept;
 \end{itemdecl}
@@ -10056,8 +9940,7 @@ enable_shared_from_this<T>& operator=(const enable_shared_from_this<T>&) noexcep
 \end{itemdescr}
 
 \indexlibrary{\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{enable_shared_from_this}!\idxcode{shared_from_this}}%
-\indexlibrary{\idxcode{shared_from_this}!\idxcode{enable_shared_from_this}}%
+\indexlibrarymember{enable_shared_from_this}{shared_from_this}%
 \begin{itemdecl}
 shared_ptr<T>       shared_from_this();
 shared_ptr<T const> shared_from_this() const;
@@ -10070,8 +9953,7 @@ shared_ptr<T const> shared_from_this() const;
 \end{itemdescr}
 
 \indexlibrary{\idxcode{weak_ptr}}%
-\indexlibrary{\idxcode{enable_shared_from_this}!\idxcode{weak_from_this}}%
-\indexlibrary{\idxcode{weak_from_this}!\idxcode{enable_shared_from_this}}%
+\indexlibrarymember{enable_shared_from_this}{weak_from_this}%
 \begin{itemdecl}
 weak_ptr<T>       weak_from_this() noexcept;
 weak_ptr<T const> weak_from_this() const noexcept;
@@ -10091,8 +9973,7 @@ this section and the instance is passed as their first argument.
 \pnum
 The meaning of the arguments of type \tcode{memory_order} is explained in~\ref{atomics.order}.
 
-\indexlibrary{\idxcode{atomic_is_lock_free}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{atomic_is_lock_free}}%
+\indexlibrarymember{atomic_is_lock_free}{shared_ptr}%
 \begin{itemdecl}
 template<class T>
   bool atomic_is_lock_free(const shared_ptr<T>* p);
@@ -10109,8 +9990,7 @@ template<class T>
 \throws Nothing.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{atomic_load}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{atomic_load}}%
+\indexlibrarymember{atomic_load}{shared_ptr}%
 \begin{itemdecl}
 template<class T>
   shared_ptr<T> atomic_load(const shared_ptr<T>* p);
@@ -10127,8 +10007,7 @@ template<class T>
 \throws Nothing.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{atomic_load_explicit}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{atomic_load_explicit}}%
+\indexlibrarymember{atomic_load_explicit}{shared_ptr}%
 \begin{itemdecl}
 template<class T>
   shared_ptr<T> atomic_load_explicit(const shared_ptr<T>* p, memory_order mo);
@@ -10148,8 +10027,7 @@ template<class T>
 \throws Nothing.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{atomic_store}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{atomic_store}}%
+\indexlibrarymember{atomic_store}{shared_ptr}%
 \begin{itemdecl}
 template<class T>
   void atomic_store(shared_ptr<T>* p, shared_ptr<T> r);
@@ -10166,8 +10044,7 @@ template<class T>
 \throws Nothing.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{atomic_store_explicit}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{atomic_store_explicit}}%
+\indexlibrarymember{atomic_store_explicit}{shared_ptr}%
 \begin{itemdecl}
 template<class T>
   void atomic_store_explicit(shared_ptr<T>* p, shared_ptr<T> r, memory_order mo);
@@ -10187,8 +10064,7 @@ template<class T>
 \throws Nothing.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{atomic_exchange}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{atomic_exchange}}%
+\indexlibrarymember{atomic_exchange}{shared_ptr}%
 \begin{itemdecl}
 template<class T>
   shared_ptr<T> atomic_exchange(shared_ptr<T>* p, shared_ptr<T> r);
@@ -10205,8 +10081,7 @@ template<class T>
 \throws Nothing.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{atomic_exchange_explicit}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{atomic_exchange_explicit}}%
+\indexlibrarymember{atomic_exchange_explicit}{shared_ptr}%
 \begin{itemdecl}
 template<class T>
   shared_ptr<T> atomic_exchange_explicit(shared_ptr<T>* p, shared_ptr<T> r,
@@ -10227,8 +10102,7 @@ template<class T>
 \throws Nothing.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{atomic_compare_exchange_weak}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{atomic_compare_exchange_weak}}%
+\indexlibrarymember{atomic_compare_exchange_weak}{shared_ptr}%
 \begin{itemdecl}
 template<class T>
   bool atomic_compare_exchange_weak(
@@ -10247,8 +10121,7 @@ memory_order_seq_cst, memory_order_seq_cst)}.
 \throws Nothing.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{atomic_compare_exchange_strong}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{atomic_compare_exchange_strong}}%
+\indexlibrarymember{atomic_compare_exchange_strong}{shared_ptr}%
 \begin{itemdecl}
 template<class T>
   bool atomic_compare_exchange_strong(
@@ -10414,8 +10287,7 @@ private:
 Destroys this \tcode{memory_resource}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{memory_resource}!\idxcode{allocate}}%
-\indexlibrary{\idxcode{allocate}!\idxcode{memory_resource}}%
+\indexlibrarymember{memory_resource}{allocate}%
 \begin{itemdecl}
 void* allocate(size_t bytes, size_t alignment = max_align);
 \end{itemdecl}
@@ -10426,8 +10298,7 @@ void* allocate(size_t bytes, size_t alignment = max_align);
 Equivalent to: \tcode{return do_allocate(bytes, alignment);}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{memory_resource}!\idxcode{deallocate}}%
-\indexlibrary{\idxcode{deallocate}!\idxcode{memory_resource}}%
+\indexlibrarymember{memory_resource}{deallocate}%
 \begin{itemdecl}
 void deallocate(void* p, size_t bytes, size_t alignment = max_align);
 \end{itemdecl}
@@ -10438,8 +10309,7 @@ void deallocate(void* p, size_t bytes, size_t alignment = max_align);
 Equivalent to: \tcode{do_deallocate(p, bytes, alignment);}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{memory_resource}!\idxcode{is_equal}}%
-\indexlibrary{\idxcode{is_equal}!\idxcode{memory_resource}}%
+\indexlibrarymember{memory_resource}{is_equal}%
 \begin{itemdecl}
 bool is_equal(const memory_resource& other) const noexcept;
 \end{itemdecl}
@@ -10453,8 +10323,7 @@ Equivalent to: \tcode{return do_is_equal(other);}
 
 \rSec3[memory.resource.private]{\tcode{memory_resource} private virtual member functions}
 
-\indexlibrary{\idxcode{memory_resource}!\idxcode{do_allocate}}%
-\indexlibrary{\idxcode{do_allocate}!\idxcode{memory_resource}}%
+\indexlibrarymember{memory_resource}{do_allocate}%
 \begin{itemdecl}
 virtual void* do_allocate(size_t bytes, size_t alignment) = 0;
 \end{itemdecl}
@@ -10475,8 +10344,7 @@ otherwise it is aligned to \tcode{max_align}.
 A derived class implementation shall throw an appropriate exception if it is unable to allocate memory with the requested size and alignment.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{memory_resource}!\idxcode{do_deallocate}}%
-\indexlibrary{\idxcode{do_deallocate}!\idxcode{memory_resource}}%
+\indexlibrarymember{memory_resource}{do_deallocate}%
 \begin{itemdecl}
 virtual void do_deallocate(void* p, size_t bytes, size_t alignment) = 0;
 \end{itemdecl}
@@ -10496,8 +10364,7 @@ A derived class shall implement this function to dispose of allocated storage.
 Nothing.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{memory_resource}!\idxcode{do_is_equal}}%
-\indexlibrary{\idxcode{do_is_equal}!\idxcode{memory_resource}}%
+\indexlibrarymember{memory_resource}{do_is_equal}%
 \begin{itemdecl}
 virtual bool do_is_equal(const memory_resource& other) const noexcept = 0;
 \end{itemdecl}
@@ -10651,8 +10518,7 @@ Sets \tcode{memory_rsrc} to \tcode{other.resource()}.
 
 \rSec3[memory.polymorphic.allocator.mem]{\tcode{polymorphic_allocator} member functions}
 
-\indexlibrary{\idxcode{polymorphic_allocator}!\idxcode{allocate}}%
-\indexlibrary{\idxcode{allocate}!\idxcode{polymorphic_allocator}}%
+\indexlibrarymember{polymorphic_allocator}{allocate}%
 \begin{itemdecl}
 Tp* allocate(size_t n);
 \end{itemdecl}
@@ -10666,8 +10532,7 @@ return static_cast<Tp*>(memory_rsrc->allocate(n * sizeof(Tp), alignof(Tp)));
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{polymorphic_allocator}!\idxcode{deallocate}}%
-\indexlibrary{\idxcode{deallocate}!\idxcode{polymorphic_allocator}}%
+\indexlibrarymember{polymorphic_allocator}{deallocate}%
 \begin{itemdecl}
 void deallocate(Tp* p, size_t n);
 \end{itemdecl}
@@ -10688,8 +10553,7 @@ Equivalent to \tcode{memory_rsrc->deallocate(p, n * sizeof(Tp), alignof(Tp))}.
 Nothing.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{polymorphic_allocator}!\idxcode{construct}}%
-\indexlibrary{\idxcode{construct}!\idxcode{polymorphic_allocator}}%
+\indexlibrarymember{polymorphic_allocator}{construct}%
 \begin{itemdecl}
 template <class T, class... Args>
   void construct(T* p, Args&&... args);
@@ -10717,8 +10581,7 @@ and constructor arguments \tcode{std::forward<Args>(args)...}.
 Nothing unless the constructor for \tcode{T} throws.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{polymorphic_allocator}!\idxcode{construct}}%
-\indexlibrary{\idxcode{construct}!\idxcode{polymorphic_allocator}}%
+\indexlibrarymember{polymorphic_allocator}{construct}%
 \begin{itemdecl}
 template <class T1, class T2, class... Args1, class... Args2>
   void construct(pair<T1,T2>* p, piecewise_construct_t,
@@ -10805,8 +10668,7 @@ this function constructs a \tcode{pair<T1, T2>} object
 in the storage whose address is represented by \tcode{p}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{polymorphic_allocator}!\idxcode{construct}}%
-\indexlibrary{\idxcode{construct}!\idxcode{polymorphic_allocator}}%
+\indexlibrarymember{polymorphic_allocator}{construct}%
 \begin{itemdecl}
 template <class T1, class T2>
   void construct(pair<T1,T2>* p);
@@ -10821,8 +10683,7 @@ this->construct(p, piecewise_construct, tuple<>(), tuple<>());
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{polymorphic_allocator}!\idxcode{construct}}%
-\indexlibrary{\idxcode{construct}!\idxcode{polymorphic_allocator}}%
+\indexlibrarymember{polymorphic_allocator}{construct}%
 \begin{itemdecl}
 template <class T1, class T2, class U, class V>
   void construct(pair<T1,T2>* p, U&& x, V&& y);
@@ -10839,8 +10700,7 @@ this->construct(p, piecewise_construct,
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{polymorphic_allocator}!\idxcode{construct}}%
-\indexlibrary{\idxcode{construct}!\idxcode{polymorphic_allocator}}%
+\indexlibrarymember{polymorphic_allocator}{construct}%
 \begin{itemdecl}
 template <class T1, class T2, class U, class V>
   void construct(pair<T1,T2>* p, const pair<U, V>& pr);
@@ -10857,8 +10717,7 @@ this->construct(p, piecewise_construct,
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{polymorphic_allocator}!\idxcode{construct}}%
-\indexlibrary{\idxcode{construct}!\idxcode{polymorphic_allocator}}%
+\indexlibrarymember{polymorphic_allocator}{construct}%
 \begin{itemdecl}
 template <class T1, class T2, class U, class V>
   void construct(pair<T1,T2>* p, pair<U, V>&& pr);
@@ -10875,8 +10734,7 @@ this->construct(p, piecewise_construct,
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{polymorphic_allocator}!\idxcode{destroy}}%
-\indexlibrary{\idxcode{destroy}!\idxcode{polymorphic_allocator}}%
+\indexlibrarymember{polymorphic_allocator}{destroy}%
 \begin{itemdecl}
 template <class T>
   void destroy(T* p);
@@ -10888,8 +10746,7 @@ template <class T>
 As if by \tcode{p->\~T()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{polymorphic_allocator}!\idxcode{select_on_container_copy_construction}}%
-\indexlibrary{\idxcode{select_on_container_copy_construction}!\idxcode{polymorphic_allocator}}%
+\indexlibrarymember{polymorphic_allocator}{select_on_container_copy_construction}%
 \begin{itemdecl}
 polymorphic_allocator select_on_container_copy_construction() const;
 \end{itemdecl}
@@ -10905,8 +10762,7 @@ The memory resource is not propagated.
 \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{polymorphic_allocator}!\idxcode{resource}}%
-\indexlibrary{\idxcode{resource}!\idxcode{polymorphic_allocator}}%
+\indexlibrarymember{polymorphic_allocator}{resource}%
 \begin{itemdecl}
 memory_resource* resource() const;
 \end{itemdecl}
@@ -11335,8 +11191,7 @@ this operation will result in a call to \tcode{upstream_resource()->deallocate()
 Nothing.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{unsynchronized_pool_resource}!\idxcode{do_is_equal}}%
-\indexlibrary{\idxcode{do_is_equal}!\idxcode{unsynchronized_pool_resource}}%
+\indexlibrarymember{unsynchronized_pool_resource}{do_is_equal}%
 \begin{itemdecl}
 bool unsynchronized_pool_resource::do_is_equal(const memory_resource& other) const noexcept override;
 \end{itemdecl}
@@ -11347,8 +11202,7 @@ bool unsynchronized_pool_resource::do_is_equal(const memory_resource& other) con
 \tcode{this == dynamic_cast<const unsynchronized_pool_resource*>(\&other)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{synchronized_pool_resource}!\idxcode{do_is_equal}}%
-\indexlibrary{\idxcode{do_is_equal}!\idxcode{synchronized_pool_resource}}%
+\indexlibrarymember{synchronized_pool_resource}{do_is_equal}%
 \begin{itemdecl}
 bool synchronized_pool_resource::do_is_equal(const memory_resource& other) const noexcept override;
 \end{itemdecl}
@@ -11702,8 +11556,7 @@ namespace std {
 
 \rSec2[allocator.adaptor.types]{Scoped allocator adaptor member types}
 
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{inner_allocator_type}}%
-\indexlibrary{\idxcode{inner_allocator_type}!\idxcode{scoped_allocator_adaptor}}%
+\indexlibrarymember{scoped_allocator_adaptor}{inner_allocator_type}%
 \begin{itemdecl}
 using inner_allocator_type = @\seebelow@;
 \end{itemdecl}
@@ -11714,8 +11567,7 @@ using inner_allocator_type = @\seebelow@;
 zero; otherwise,\\ \tcode{scoped_allocator_adaptor<InnerAllocs...>}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{propagate_on_container_copy_assignment}}%
-\indexlibrary{\idxcode{propagate_on_container_copy_assignment}!\idxcode{scoped_allocator_adaptor}}%
+\indexlibrarymember{scoped_allocator_adaptor}{propagate_on_container_copy_assignment}%
 \begin{itemdecl}
 using propagate_on_container_copy_assignment = @\seebelow@;
 \end{itemdecl}
@@ -11728,8 +11580,7 @@ using propagate_on_container_copy_assignment = @\seebelow@;
 \tcode{InnerAllocs...}; otherwise, \tcode{false_type}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{propagate_on_container_move_assignment}}%
-\indexlibrary{\idxcode{propagate_on_container_move_assignment}!\idxcode{scoped_allocator_adaptor}}%
+\indexlibrarymember{scoped_allocator_adaptor}{propagate_on_container_move_assignment}%
 \begin{itemdecl}
 using propagate_on_container_move_assignment = @\seebelow@;
 \end{itemdecl}
@@ -11742,8 +11593,7 @@ using propagate_on_container_move_assignment = @\seebelow@;
 \tcode{InnerAllocs...}; otherwise, \tcode{false_type}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{propagate_on_container_swap}}%
-\indexlibrary{\idxcode{propagate_on_container_swap}!\idxcode{scoped_allocator_adaptor}}%
+\indexlibrarymember{scoped_allocator_adaptor}{propagate_on_container_swap}%
 \begin{itemdecl}
 using propagate_on_container_swap = @\seebelow@;
 \end{itemdecl}
@@ -11756,8 +11606,7 @@ using propagate_on_container_swap = @\seebelow@;
 \tcode{InnerAllocs...}; otherwise, \tcode{false_type}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{is_always_equal}}%
-\indexlibrary{\idxcode{is_always_equal}!\idxcode{scoped_allocator_adaptor}}%
+\indexlibrarymember{scoped_allocator_adaptor}{is_always_equal}%
 \begin{itemdecl}
 using is_always_equal = @\seebelow@;
 \end{itemdecl}
@@ -11871,8 +11720,7 @@ is incumbent upon the definition of \tcode{outer_allocator()} to ensure that the
 recursion terminates. It will terminate for all instantiations of \\
 \tcode{scoped_allocator_adaptor}. \end{note}
 
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{inner_allocator}}%
-\indexlibrary{\idxcode{inner_allocator}!\idxcode{scoped_allocator_adaptor}}%
+\indexlibrarymember{scoped_allocator_adaptor}{inner_allocator}%
 \begin{itemdecl}
 inner_allocator_type& inner_allocator() noexcept;
 const inner_allocator_type& inner_allocator() const noexcept;
@@ -11884,8 +11732,7 @@ const inner_allocator_type& inner_allocator() const noexcept;
 \tcode{inner}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{outer_allocator}}%
-\indexlibrary{\idxcode{outer_allocator}!\idxcode{scoped_allocator_adaptor}}%
+\indexlibrarymember{scoped_allocator_adaptor}{outer_allocator}%
 \begin{itemdecl}
 outer_allocator_type& outer_allocator() noexcept;
 \end{itemdecl}
@@ -11895,8 +11742,7 @@ outer_allocator_type& outer_allocator() noexcept;
 \returns \tcode{static_cast<OuterAlloc\&>(*this)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{outer_allocator}}%
-\indexlibrary{\idxcode{outer_allocator}!\idxcode{scoped_allocator_adaptor}}%
+\indexlibrarymember{scoped_allocator_adaptor}{outer_allocator}%
 \begin{itemdecl}
 const outer_allocator_type& outer_allocator() const noexcept;
 \end{itemdecl}
@@ -11906,8 +11752,7 @@ const outer_allocator_type& outer_allocator() const noexcept;
 \returns \tcode{static_cast<const OuterAlloc\&>(*this)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{allocate}}%
-\indexlibrary{\idxcode{allocate}!\idxcode{scoped_allocator_adaptor}}%
+\indexlibrarymember{scoped_allocator_adaptor}{allocate}%
 \begin{itemdecl}
 pointer allocate(size_type n);
 \end{itemdecl}
@@ -11917,8 +11762,7 @@ pointer allocate(size_type n);
 \returns \tcode{allocator_traits<OuterAlloc>::allocate(outer_allocator(), n)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{allocate}}%
-\indexlibrary{\idxcode{allocate}!\idxcode{scoped_allocator_adaptor}}%
+\indexlibrarymember{scoped_allocator_adaptor}{allocate}%
 \begin{itemdecl}
 pointer allocate(size_type n, const_void_pointer hint);
 \end{itemdecl}
@@ -11928,8 +11772,7 @@ pointer allocate(size_type n, const_void_pointer hint);
 \returns \tcode{allocator_traits<OuterAlloc>::allocate(outer_allocator(), n, hint)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{deallocate}}%
-\indexlibrary{\idxcode{deallocate}!\idxcode{scoped_allocator_adaptor}}%
+\indexlibrarymember{scoped_allocator_adaptor}{deallocate}%
 \begin{itemdecl}
 void deallocate(pointer p, size_type n) noexcept;
 \end{itemdecl}
@@ -11940,8 +11783,7 @@ void deallocate(pointer p, size_type n) noexcept;
 \tcode{allocator_traits<OuterAlloc>::deallocate(outer_allocator(), p, n);}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{max_size}}%
-\indexlibrary{\idxcode{max_size}!\idxcode{scoped_allocator_adaptor}}%
+\indexlibrarymember{scoped_allocator_adaptor}{max_size}%
 \begin{itemdecl}
 size_type max_size() const;
 \end{itemdecl}
@@ -11951,8 +11793,7 @@ size_type max_size() const;
 \returns \tcode{allocator_traits<OuterAlloc>::max_size(outer_allocator())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{construct}}%
-\indexlibrary{\idxcode{construct}!\idxcode{scoped_allocator_adaptor}}%
+\indexlibrarymember{scoped_allocator_adaptor}{construct}%
 \begin{itemdecl}
 template <class T, class... Args>
   void construct(T* p, Args&&... args);
@@ -11985,8 +11826,7 @@ contained element. \end{note}
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{construct}}%
-\indexlibrary{\idxcode{construct}!\idxcode{scoped_allocator_adaptor}}%
+\indexlibrarymember{scoped_allocator_adaptor}{construct}%
 \begin{itemdecl}
 template <class T1, class T2, class... Args1, class... Args2>
   void construct(pair<T1, T2>* p, piecewise_construct_t,
@@ -12052,8 +11892,7 @@ then calls \tcode{\textit{OUTERMOST_ALLOC_TRAITS}(*this)::construct(\textit{OUTE
 piecewise_construct, std::move(xprime), std::move(yprime))}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{construct}}%
-\indexlibrary{\idxcode{construct}!\idxcode{scoped_allocator_adaptor}}%
+\indexlibrarymember{scoped_allocator_adaptor}{construct}%
 \begin{itemdecl}
 template <class T1, class T2>
   void construct(pair<T1, T2>* p);
@@ -12067,8 +11906,7 @@ this->construct(p, piecewise_construct, tuple<>(), tuple<>());
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{construct}}%
-\indexlibrary{\idxcode{construct}!\idxcode{scoped_allocator_adaptor}}%
+\indexlibrarymember{scoped_allocator_adaptor}{construct}%
 \begin{itemdecl}
 template <class T1, class T2, class U, class V>
   void construct(pair<T1, T2>* p, U&& x, V&& y);
@@ -12084,8 +11922,7 @@ this->construct(p, piecewise_construct,
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{construct}}%
-\indexlibrary{\idxcode{construct}!\idxcode{scoped_allocator_adaptor}}%
+\indexlibrarymember{scoped_allocator_adaptor}{construct}%
 \begin{itemdecl}
 template <class T1, class T2, class U, class V>
   void construct(pair<T1, T2>* p, const pair<U, V>& x);
@@ -12101,8 +11938,7 @@ this->construct(p, piecewise_construct,
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{construct}}%
-\indexlibrary{\idxcode{construct}!\idxcode{scoped_allocator_adaptor}}%
+\indexlibrarymember{scoped_allocator_adaptor}{construct}%
 \begin{itemdecl}
 template <class T1, class T2, class U, class V>
   void construct(pair<T1, T2>* p, pair<U, V>&& x);
@@ -12118,8 +11954,7 @@ this->construct(p, piecewise_construct,
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{destroy}}%
-\indexlibrary{\idxcode{destroy}!\idxcode{scoped_allocator_adaptor}}%
+\indexlibrarymember{scoped_allocator_adaptor}{destroy}%
 \begin{itemdecl}
 template <class T>
   void destroy(T* p);
@@ -12130,8 +11965,7 @@ template <class T>
 \effects Calls \tcode{\textit{OUTERMOST_ALLOC_TRAITS}(*this)::destroy(\textit{OUTERMOST}(*this), p)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{select_on_container_copy_construction}}%
-\indexlibrary{\idxcode{select_on_container_copy_construction}!\idxcode{scoped_allocator_adaptor}}%
+\indexlibrarymember{scoped_allocator_adaptor}{select_on_container_copy_construction}%
 \begin{itemdecl}
 scoped_allocator_adaptor select_on_container_copy_construction() const;
 \end{itemdecl}
@@ -12146,8 +11980,7 @@ corresponding allocator in \tcode{*this}.
 
 \rSec2[scoped.adaptor.operators]{Scoped allocator operators}
 
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{operator==}}%
-\indexlibrary{\idxcode{operator==}!\idxcode{scoped_allocator_adaptor}}%
+\indexlibrarymember{scoped_allocator_adaptor}{operator==}%
 \begin{itemdecl}
 template <class OuterA1, class OuterA2, class... InnerAllocs>
   bool operator==(const scoped_allocator_adaptor<OuterA1, InnerAllocs...>& a,
@@ -12162,8 +11995,7 @@ otherwise, \tcode{a.outer_allocator() == b.outer_allocator()}
 \tcode{\&\&} \tcode{a.inner_allocator() == b.inner_allocator()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{scoped_allocator_adaptor}!\idxcode{operator"!=}}%
-\indexlibrary{\idxcode{operator"!=}!\idxcode{scoped_allocator_adaptor}}%
+\indexlibrarymember{scoped_allocator_adaptor}{operator"!=}%
 \begin{itemdecl}
 template <class OuterA1, class OuterA2, class... InnerAllocs>
   bool operator!=(const scoped_allocator_adaptor<OuterA1, InnerAllocs...>& a,
@@ -12594,8 +12426,7 @@ operator T& () const noexcept;
 \pnum\returns The stored reference.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{reference_wrapper}!\idxcode{get}}%
-\indexlibrary{\idxcode{get}!\idxcode{reference_wrapper}}%
+\indexlibrarymember{reference_wrapper}{get}%
 \begin{itemdecl}
 T& get() const noexcept;
 \end{itemdecl}
@@ -12607,8 +12438,7 @@ T& get() const noexcept;
 
 \rSec3[refwrap.invoke]{reference_wrapper invocation}
 
-\indexlibrary{\idxcode{reference_wrapper}!\idxcode{operator()}}%
-\indexlibrary{\idxcode{operator()}!\idxcode{reference_wrapper}}%
+\indexlibrarymember{reference_wrapper}{operator()}%
 \begin{itemdecl}
 template <class... ArgTypes>
   result_of_t<T&(ArgTypes&&... )>
@@ -12622,8 +12452,7 @@ template <class... ArgTypes>
 
 \rSec3[refwrap.helpers]{reference_wrapper helper functions}
 
-\indexlibrary{\idxcode{reference_wrapper}!\idxcode{ref}}%
-\indexlibrary{\idxcode{ref}!\idxcode{reference_wrapper}}%
+\indexlibrarymember{reference_wrapper}{ref}%
 \begin{itemdecl}
 template <class T> reference_wrapper<T> ref(T& t) noexcept;
 \end{itemdecl}
@@ -12632,8 +12461,7 @@ template <class T> reference_wrapper<T> ref(T& t) noexcept;
 \pnum\returns \tcode{reference_wrapper<T>(t)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{reference_wrapper}!\idxcode{ref}}%
-\indexlibrary{\idxcode{ref}!\idxcode{reference_wrapper}}%
+\indexlibrarymember{reference_wrapper}{ref}%
 \begin{itemdecl}
 template <class T> reference_wrapper<T> ref(reference_wrapper<T> t) noexcept;
 \end{itemdecl}
@@ -12642,8 +12470,7 @@ template <class T> reference_wrapper<T> ref(reference_wrapper<T> t) noexcept;
 \pnum\returns \tcode{ref(t.get())}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{reference_wrapper}!\idxcode{cref}}%
-\indexlibrary{\idxcode{cref}!\idxcode{reference_wrapper}}%
+\indexlibrarymember{reference_wrapper}{cref}%
 \begin{itemdecl}
 template <class T> reference_wrapper<const T> cref(const T& t) noexcept;
 \end{itemdecl}
@@ -12652,8 +12479,7 @@ template <class T> reference_wrapper<const T> cref(const T& t) noexcept;
 \pnum\returns \tcode{reference_wrapper <const T>(t)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{reference_wrapper}!\idxcode{cref}}%
-\indexlibrary{\idxcode{cref}!\idxcode{reference_wrapper}}%
+\indexlibrarymember{reference_wrapper}{cref}%
 \begin{itemdecl}
 template <class T> reference_wrapper<const T> cref(reference_wrapper<T> t) noexcept;
 \end{itemdecl}
@@ -13576,8 +13402,7 @@ namespace std {
 \rSec4[func.wrap.badcall.const]{\tcode{bad_function_call} constructor}
 
 \indexlibrary{\idxcode{bad_function_call}!constructor}%
-\indexlibrary{\idxcode{bad_function_call}!\idxcode{what}}%
-\indexlibrary{\idxcode{what}!\idxcode{bad_function_call}}%
+\indexlibrarymember{bad_function_call}{what}%
 \begin{itemdecl}
 bad_function_call() noexcept;
 \end{itemdecl}
@@ -13779,8 +13604,7 @@ may throw \tcode{bad_alloc} or any exception thrown by \tcode{F}'s copy
 or move constructor.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{function}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{function}}%
+\indexlibrarymember{function}{operator=}%
 \begin{itemdecl}
 function& operator=(const function& f);
 \end{itemdecl}
@@ -13793,8 +13617,7 @@ function& operator=(const function& f);
 \returns \tcode{*this}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{function}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{function}}%
+\indexlibrarymember{function}{operator=}%
 \begin{itemdecl}
 function& operator=(function&& f);
 \end{itemdecl}
@@ -13808,8 +13631,7 @@ with the target of \tcode{f}.
 \returns \tcode{*this}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{function}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{function}}%
+\indexlibrarymember{function}{operator=}%
 \begin{itemdecl}
 function& operator=(nullptr_t) noexcept;
 \end{itemdecl}
@@ -13822,8 +13644,7 @@ function& operator=(nullptr_t) noexcept;
 \pnum\returns \tcode{*this}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{function}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{function}}%
+\indexlibrarymember{function}{operator=}%
 \begin{itemdecl}
 template<class F> function& operator=(F&& f);
 \end{itemdecl}
@@ -13839,8 +13660,7 @@ Lvalue-Callable~(\ref{func.wrap.func}) for argument types \tcode{ArgTypes...} an
 return type \tcode{R}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{function}!\idxcode{operator=}}%
-\indexlibrary{\idxcode{operator=}!\idxcode{function}}%
+\indexlibrarymember{function}{operator=}%
 \begin{itemdecl}
 template<class F> function& operator=(reference_wrapper<F> f) noexcept;
 \end{itemdecl}
@@ -13863,8 +13683,7 @@ template<class F> function& operator=(reference_wrapper<F> f) noexcept;
 
 \rSec4[func.wrap.func.mod]{\tcode{function} modifiers}
 
-\indexlibrary{\idxcode{function}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{function}}%
+\indexlibrarymember{function}{swap}%
 \begin{itemdecl}
 void swap(function& other) noexcept;
 \end{itemdecl}
@@ -13888,8 +13707,7 @@ explicit operator bool() const noexcept;
 \rSec4[func.wrap.func.inv]{\tcode{function} invocation}
 
 \indexlibrary{\idxcode{function}!invocation}%
-\indexlibrary{\idxcode{function}!\idxcode{operator()}}%
-\indexlibrary{\idxcode{operator()}!\idxcode{function}}%
+\indexlibrarymember{function}{operator()}%
 \begin{itemdecl}
 R operator()(ArgTypes... args) const;
 \end{itemdecl}
@@ -13906,8 +13724,7 @@ exception thrown by the wrapped callable object.
 
 \rSec4[func.wrap.func.targ]{function target access}
 
-\indexlibrary{\idxcode{function}!\idxcode{target_type}}%
-\indexlibrary{\idxcode{target_type}!\idxcode{function}}%
+\indexlibrarymember{function}{target_type}%
 \begin{itemdecl}
 const type_info& target_type() const noexcept;
 \end{itemdecl}
@@ -13917,8 +13734,7 @@ const type_info& target_type() const noexcept;
   \tcode{typeid(T)}; otherwise, \tcode{typeid(void)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{function}!\idxcode{target}}%
-\indexlibrary{\idxcode{target}!\idxcode{function}}%
+\indexlibrarymember{function}{target}%
 \begin{itemdecl}
 template<class T>       T* target() noexcept;
 template<class T> const T* target() const noexcept;
@@ -13937,8 +13753,7 @@ a pointer to the stored function target; otherwise a null pointer.
 
 \rSec4[func.wrap.func.nullptr]{null pointer comparison operators}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{function}}%
-\indexlibrary{\idxcode{function}!\idxcode{operator==}}%
+\indexlibrarymember{operator==}{function}%
 \begin{itemdecl}
 template <class R, class... ArgTypes>
   bool operator==(const function<R(ArgTypes...)>& f, nullptr_t) noexcept;
@@ -13965,8 +13780,7 @@ template <class R, class... ArgTypes>
 
 \rSec4[func.wrap.func.alg]{specialized algorithms}
 
-\indexlibrary{\idxcode{function}!\idxcode{swap}}%
-\indexlibrary{\idxcode{swap}!\idxcode{function}}%
+\indexlibrarymember{function}{swap}%
 \begin{itemdecl}
 template<class R, class... ArgTypes>
   void swap(function<R(ArgTypes...)>& f1, function<R(ArgTypes...)>& f2);
@@ -14050,8 +13864,7 @@ Any exception thrown by the copy constructor of \tcode{BinaryPredicate} or
 \tcode{ForwardIterator1}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{default_searcher}!\idxcode{operator()}}%
-\indexlibrary{\idxcode{operator()}!\idxcode{default_searcher}}%
+\indexlibrarymember{default_searcher}{operator()}%
 \begin{itemdecl}
 template<class ForwardIterator2>
   pair<ForwardIterator2, ForwardIterator2>
@@ -14142,8 +13955,7 @@ or the copy constructor or \tcode{operator()} of \tcode{BinaryPredicate} or \tco
 May throw \tcode{bad_alloc} if additional memory needed for internal data structures cannot be allocated.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{boyer_moore_searcher}!\idxcode{operator()}}%
-\indexlibrary{\idxcode{operator()}!\idxcode{boyer_moore_searcher}}%
+\indexlibrarymember{boyer_moore_searcher}{operator()}%
 \begin{itemdecl}
 template <class RandomAccessIterator2>
   pair<RandomAccessIterator2, RandomAccessIterator2>
@@ -14258,8 +14070,7 @@ or the copy constructor or \tcode{operator()} of \tcode{BinaryPredicate} or \tco
 May throw \tcode{bad_alloc} if additional memory needed for internal data structures cannot be allocated.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{boyer_moore_horspool_searcher}!\idxcode{operator()}}%
-\indexlibrary{\idxcode{operator()}!\idxcode{boyer_moore_horspool_searcher}}%
+\indexlibrarymember{boyer_moore_horspool_searcher}{operator()}%
 \begin{itemdecl}
 template <class RandomAccessIterator2>
   pair<RandomAccessIterator2, RandomAccessIterator2>
@@ -16649,8 +16460,7 @@ requires some other implementation to return these special values. In that case,
 the author of that class type should specialize \tcode{duration_values} to
 return the indicated values.
 
-\indexlibrary{\idxcode{zero}!\idxcode{duration_values}}%
-\indexlibrary{\idxcode{duration_values}!\idxcode{zero}}%
+\indexlibrarymember{zero}{duration_values}%
 \begin{itemdecl}
 static constexpr Rep zero();
 \end{itemdecl}
@@ -16665,8 +16475,7 @@ uninitialized value. \end{note}
 \remark The value returned shall be the additive identity.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{min}!\idxcode{duration_values}}%
-\indexlibrary{\idxcode{duration_values}!\idxcode{min}}%
+\indexlibrarymember{min}{duration_values}%
 \begin{itemdecl}
 static constexpr Rep min();
 \end{itemdecl}
@@ -16679,8 +16488,7 @@ static constexpr Rep min();
 \remark The value returned shall compare less than or equal to \tcode{zero()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{max}!\idxcode{duration_values}}%
-\indexlibrary{\idxcode{duration_values}!\idxcode{max}}%
+\indexlibrarymember{max}{duration_values}%
 \begin{itemdecl}
 static constexpr Rep max();
 \end{itemdecl}
@@ -16880,8 +16688,7 @@ duration<int, milli> ms2 = us;      // error
 
 \rSec3[time.duration.observer]{\tcode{duration} observer}
 
-\indexlibrary{\idxcode{count}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{count}}%
+\indexlibrarymember{count}{duration}%
 \begin{itemdecl}
 constexpr rep count() const;
 \end{itemdecl}
@@ -16893,8 +16700,7 @@ constexpr rep count() const;
 
 \rSec3[time.duration.arithmetic]{\tcode{duration} arithmetic}
 
-\indexlibrary{\idxcode{operator+}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{operator+}}%
+\indexlibrarymember{operator+}{duration}%
 \begin{itemdecl}
 constexpr duration operator+() const;
 \end{itemdecl}
@@ -16904,8 +16710,7 @@ constexpr duration operator+() const;
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator-}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{operator-}}%
+\indexlibrarymember{operator-}{duration}%
 \begin{itemdecl}
 constexpr duration operator-() const;
 \end{itemdecl}
@@ -16915,8 +16720,7 @@ constexpr duration operator-() const;
 \returns \tcode{duration(-rep_)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator++}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{operator++}}%
+\indexlibrarymember{operator++}{duration}%
 \begin{itemdecl}
 duration& operator++();
 \end{itemdecl}
@@ -16929,8 +16733,7 @@ duration& operator++();
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator++}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{operator++}}%
+\indexlibrarymember{operator++}{duration}%
 \begin{itemdecl}
 duration operator++(int);
 \end{itemdecl}
@@ -16940,8 +16743,7 @@ duration operator++(int);
 \returns \tcode{duration(rep_++)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\dcr}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{operator\dcr}}%
+\indexlibrarymember{operator\dcr}{duration}%
 \begin{itemdecl}
 duration& operator--();
 \end{itemdecl}
@@ -16954,8 +16756,7 @@ duration& operator--();
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\dcr}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{operator\dcr}}%
+\indexlibrarymember{operator\dcr}{duration}%
 \begin{itemdecl}
 duration operator--(int);
 \end{itemdecl}
@@ -16965,8 +16766,7 @@ duration operator--(int);
 \returns \tcode{duration(rep_-{}-)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator+=}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{operator+=}}%
+\indexlibrarymember{operator+=}{duration}%
 \begin{itemdecl}
 duration& operator+=(const duration& d);
 \end{itemdecl}
@@ -16979,8 +16779,7 @@ duration& operator+=(const duration& d);
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator-=}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{operator-=}}%
+\indexlibrarymember{operator-=}{duration}%
 \begin{itemdecl}
 duration& operator-=(const duration& d);
 \end{itemdecl}
@@ -16993,8 +16792,7 @@ duration& operator-=(const duration& d);
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator*=}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{operator*=}}%
+\indexlibrarymember{operator*=}{duration}%
 \begin{itemdecl}
 duration& operator*=(const rep& rhs);
 \end{itemdecl}
@@ -17007,8 +16805,7 @@ duration& operator*=(const rep& rhs);
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator/=}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{operator/=}}%
+\indexlibrarymember{operator/=}{duration}%
 \begin{itemdecl}
 duration& operator/=(const rep& rhs);
 \end{itemdecl}
@@ -17021,8 +16818,7 @@ duration& operator/=(const rep& rhs);
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\%=}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{operator\%=}}%
+\indexlibrarymember{operator\%=}{duration}%
 \begin{itemdecl}
 duration& operator%=(const rep& rhs);
 \end{itemdecl}
@@ -17035,8 +16831,7 @@ duration& operator%=(const rep& rhs);
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\%=}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{operator\%=}}%
+\indexlibrarymember{operator\%=}{duration}%
 \begin{itemdecl}
 duration& operator%=(const duration& rhs);
 \end{itemdecl}
@@ -17052,8 +16847,7 @@ duration& operator%=(const duration& rhs);
 
 \rSec3[time.duration.special]{\tcode{duration} special values}
 
-\indexlibrary{\idxcode{zero}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{zero}}%
+\indexlibrarymember{zero}{duration}%
 \begin{itemdecl}
 static constexpr duration zero();
 \end{itemdecl}
@@ -17063,8 +16857,7 @@ static constexpr duration zero();
 \returns \tcode{duration(duration_values<rep>::zero())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{min}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{min}}%
+\indexlibrarymember{min}{duration}%
 \begin{itemdecl}
 static constexpr duration min();
 \end{itemdecl}
@@ -17074,8 +16867,7 @@ static constexpr duration min();
 \returns \tcode{duration(duration_values<rep>::min())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{max}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{max}}%
+\indexlibrarymember{max}{duration}%
 \begin{itemdecl}
 static constexpr duration max();
 \end{itemdecl}
@@ -17115,8 +16907,7 @@ template <class Rep1, class Period1, class Rep2, class Period2>
 \returns CD(CD(lhs).count() - CD(rhs).count()).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator*}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{operator*}}%
+\indexlibrarymember{operator*}{duration}%
 \begin{itemdecl}
 template <class Rep1, class Period, class Rep2>
   constexpr duration<common_type_t<Rep1, Rep2>, Period>
@@ -17132,8 +16923,7 @@ resolution unless \tcode{Rep2} is implicitly convertible to \tcode{CR(Rep1, Rep2
 \returns CD(CD(d).count() * s).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator*}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{operator*}}%
+\indexlibrarymember{operator*}{duration}%
 \begin{itemdecl}
 template <class Rep1, class Rep2, class Period>
   constexpr duration<common_type_t<Rep1, Rep2>, Period>
@@ -17149,8 +16939,7 @@ resolution unless \tcode{Rep1} is implicitly convertible to \tcode{CR(Rep1, Rep2
 \returns \tcode{d * s}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator/}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{operator/}}%
+\indexlibrarymember{operator/}{duration}%
 \begin{itemdecl}
 template <class Rep1, class Period, class Rep2>
   constexpr duration<common_type_t<Rep1, Rep2>, Period>
@@ -17167,8 +16956,7 @@ and \tcode{Rep2} is not a specialization of \tcode{duration}.
 \returns CD(CD(d).count() / s).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator/}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{operator/}}%
+\indexlibrarymember{operator/}{duration}%
 \begin{itemdecl}
 template <class Rep1, class Period1, class Rep2, class Period2>
   constexpr common_type_t<Rep1, Rep2>
@@ -17180,8 +16968,7 @@ template <class Rep1, class Period1, class Rep2, class Period2>
 \returns \tcode{CD(lhs).count() / CD(rhs).count()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\%}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{operator\%}}%
+\indexlibrarymember{operator\%}{duration}%
 \begin{itemdecl}
 template <class Rep1, class Period, class Rep2>
   constexpr duration<common_type_t<Rep1, Rep2>, Period>
@@ -17198,8 +16985,7 @@ resolution unless \tcode{Rep2} is implicitly convertible to \tcode{CR(Rep1, Rep2
 \returns CD(CD(d).count() \% s).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\%}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{operator\%}}%
+\indexlibrarymember{operator\%}{duration}%
 \begin{itemdecl}
 template <class Rep1, class Period1, class Rep2, class Period2>
   constexpr common_type_t<duration<Rep1, Period1>, duration<Rep2, Period2>>
@@ -17219,8 +17005,7 @@ In the function descriptions that follow, \tcode{\placeholder{CT}} represents
 \tcode{common_type_t<A, B>}, where \tcode{A} and \tcode{B} are the types of
 the two arguments to the function.
 
-\indexlibrary{\idxcode{operator==}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{operator==}}%
+\indexlibrarymember{operator==}{duration}%
 \begin{itemdecl}
 template <class Rep1, class Period1, class Rep2, class Period2>
   constexpr bool operator==(const duration<Rep1, Period1>& lhs, const duration<Rep2, Period2>& rhs);
@@ -17243,8 +17028,7 @@ template <class Rep1, class Period1, class Rep2, class Period2>
 \returns \tcode{!(lhs == rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{operator<}}%
+\indexlibrarymember{operator<}{duration}%
 \begin{itemdecl}
 template <class Rep1, class Period1, class Rep2, class Period2>
   constexpr bool operator<(const duration<Rep1, Period1>& lhs, const duration<Rep2, Period2>& rhs);
@@ -17255,8 +17039,7 @@ template <class Rep1, class Period1, class Rep2, class Period2>
 \returns \tcode{\placeholder{CT}(lhs).count() < \placeholder{CT}(rhs).count()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{operator<=}}%
+\indexlibrarymember{operator<=}{duration}%
 \begin{itemdecl}
 template <class Rep1, class Period1, class Rep2, class Period2>
   constexpr bool operator<=(const duration<Rep1, Period1>& lhs, const duration<Rep2, Period2>& rhs);
@@ -17267,8 +17050,7 @@ template <class Rep1, class Period1, class Rep2, class Period2>
 \returns \tcode{!(rhs < lhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{operator>}}%
+\indexlibrarymember{operator>}{duration}%
 \begin{itemdecl}
 template <class Rep1, class Period1, class Rep2, class Period2>
   constexpr bool operator>(const duration<Rep1, Period1>& lhs, const duration<Rep2, Period2>& rhs);
@@ -17279,8 +17061,7 @@ template <class Rep1, class Period1, class Rep2, class Period2>
 \returns \tcode{rhs < lhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{operator>=}}%
+\indexlibrarymember{operator>=}{duration}%
 \begin{itemdecl}
 template <class Rep1, class Period1, class Rep2, class Period2>
   constexpr bool operator>=(const duration<Rep1, Period1>& lhs, const duration<Rep2, Period2>& rhs);
@@ -17341,8 +17122,7 @@ computations are carried out in the widest representation and only converted to
 the destination representation at the final step.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{duration}!\idxcode{floor}}%
-\indexlibrary{\idxcode{floor}!\idxcode{duration}}%
+\indexlibrarymember{duration}{floor}%
 \begin{itemdecl}
 template <class ToDuration, class Rep, class Period>
   constexpr ToDuration floor(const duration<Rep, Period>& d);
@@ -17358,8 +17138,7 @@ unless \tcode{ToDuration} is a specialization of \tcode{duration}.
 for which \tcode{t <= d}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{duration}!\idxcode{ceil}}%
-\indexlibrary{\idxcode{ceil}!\idxcode{duration}}%
+\indexlibrarymember{duration}{ceil}%
 \begin{itemdecl}
 template <class ToDuration, class Rep, class Period>
   constexpr ToDuration ceil(const duration<Rep, Period>& d);
@@ -17375,8 +17154,7 @@ unless \tcode{ToDuration} is a specialization of \tcode{duration}.
 for which \tcode{t >= d}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{duration}!\idxcode{round}}%
-\indexlibrary{\idxcode{round}!\idxcode{duration}}%
+\indexlibrarymember{duration}{round}%
 \begin{itemdecl}
 template <class ToDuration, class Rep, class Period>
   constexpr ToDuration round(const duration<Rep, Period>& d);
@@ -17499,8 +17277,7 @@ A \tcode{duration} literal representing \tcode{nsec} nanoseconds.
 
 \rSec3[time.duration.alg]{\tcode{duration} algorithms}
 
-\indexlibrary{\idxcode{duration}!\idxcode{abs}}%
-\indexlibrary{\idxcode{abs}!\idxcode{duration}}%
+\indexlibrarymember{duration}{abs}%
 \begin{itemdecl}
 template <class Rep, class Period>
   constexpr duration<Rep, Period> abs(duration<Rep, Period> d);
@@ -17600,8 +17377,7 @@ is implicitly convertible to \tcode{duration}.
 
 \rSec3[time.point.observer]{\tcode{time_point} observer}
 
-\indexlibrary{\idxcode{time_point}!\idxcode{time_since_epoch}}%
-\indexlibrary{\idxcode{time_since_epoch}!\idxcode{time_point}}%
+\indexlibrarymember{time_point}{time_since_epoch}%
 \begin{itemdecl}
 constexpr duration time_since_epoch() const;
 \end{itemdecl}
@@ -17613,8 +17389,7 @@ constexpr duration time_since_epoch() const;
 
 \rSec3[time.point.arithmetic]{\tcode{time_point} arithmetic}
 
-\indexlibrary{\idxcode{operator+=}!\idxcode{time_point}}%
-\indexlibrary{\idxcode{time_point}!\idxcode{operator+=}}%
+\indexlibrarymember{operator+=}{time_point}%
 \begin{itemdecl}
 time_point& operator+=(const duration& d);
 \end{itemdecl}
@@ -17627,8 +17402,7 @@ time_point& operator+=(const duration& d);
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator-=}!\idxcode{time_point}}%
-\indexlibrary{\idxcode{time_point}!\idxcode{operator-=}}%
+\indexlibrarymember{operator-=}{time_point}%
 \begin{itemdecl}
 time_point& operator-=(const duration& d);
 \end{itemdecl}
@@ -17643,8 +17417,7 @@ time_point& operator-=(const duration& d);
 
 \rSec3[time.point.special]{\tcode{time_point} special values}
 
-\indexlibrary{\idxcode{min}!\idxcode{time_point}}%
-\indexlibrary{\idxcode{time_point}!\idxcode{min}}%
+\indexlibrarymember{min}{time_point}%
 \begin{itemdecl}
 static constexpr time_point min();
 \end{itemdecl}
@@ -17654,8 +17427,7 @@ static constexpr time_point min();
 \returns \tcode{time_point(duration::min())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{max}!\idxcode{time_point}}%
-\indexlibrary{\idxcode{time_point}!\idxcode{max}}%
+\indexlibrarymember{max}{time_point}%
 \begin{itemdecl}
 static constexpr time_point max();
 \end{itemdecl}
@@ -17667,10 +17439,8 @@ static constexpr time_point max();
 
 \rSec3[time.point.nonmember]{\tcode{time_point} non-member arithmetic}
 
-\indexlibrary{\idxcode{operator+}!\idxcode{time_point}}%
-\indexlibrary{\idxcode{time_point}!\idxcode{operator+}}%
-\indexlibrary{\idxcode{operator+}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{operator+}}%
+\indexlibrarymember{operator+}{time_point}%
+\indexlibrarymember{operator+}{duration}%
 \begin{itemdecl}
 template <class Clock, class Duration1, class Rep2, class Period2>
   constexpr time_point<Clock, common_type_t<Duration1, duration<Rep2, Period2>>>
@@ -17682,10 +17452,8 @@ template <class Clock, class Duration1, class Rep2, class Period2>
 \returns \tcode{\placeholder{CT}(lhs.time_since_epoch() + rhs)}, where \tcode{\placeholder{CT}} is the type of the return value.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator+}!\idxcode{time_point}}%
-\indexlibrary{\idxcode{time_point}!\idxcode{operator+}}%
-\indexlibrary{\idxcode{operator+}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{operator+}}%
+\indexlibrarymember{operator+}{time_point}%
+\indexlibrarymember{operator+}{duration}%
 \begin{itemdecl}
 template <class Rep1, class Period1, class Clock, class Duration2>
   constexpr time_point<Clock, common_type_t<duration<Rep1, Period1>, Duration2>>
@@ -17697,10 +17465,8 @@ template <class Rep1, class Period1, class Clock, class Duration2>
 \returns \tcode{rhs + lhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator-}!\idxcode{time_point}}%
-\indexlibrary{\idxcode{time_point}!\idxcode{operator-}}%
-\indexlibrary{\idxcode{operator-}!\idxcode{duration}}%
-\indexlibrary{\idxcode{duration}!\idxcode{operator-}}%
+\indexlibrarymember{operator-}{time_point}%
+\indexlibrarymember{operator-}{duration}%
 \begin{itemdecl}
 template <class Clock, class Duration1, class Rep2, class Period2>
   constexpr time_point<Clock, common_type_t<Duration1, duration<Rep2, Period2>>>
@@ -17712,8 +17478,7 @@ template <class Clock, class Duration1, class Rep2, class Period2>
 \returns \tcode{lhs + (-rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator-}!\idxcode{time_point}}%
-\indexlibrary{\idxcode{time_point}!\idxcode{operator-}}%
+\indexlibrarymember{operator-}{time_point}%
 \begin{itemdecl}
 template <class Clock, class Duration1, class Duration2>
   constexpr common_type_t<Duration1, Duration2>
@@ -17727,8 +17492,7 @@ template <class Clock, class Duration1, class Duration2>
 
 \rSec3[time.point.comparisons]{\tcode{time_point} comparisons}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{time_point}}%
-\indexlibrary{\idxcode{time_point}!\idxcode{operator==}}%
+\indexlibrarymember{operator==}{time_point}%
 \begin{itemdecl}
 template <class Clock, class Duration1, class Duration2>
   constexpr bool operator==(const time_point<Clock, Duration1>& lhs, const time_point<Clock, Duration2>& rhs);
@@ -17751,8 +17515,7 @@ template <class Clock, class Duration1, class Duration2>
 \returns \tcode{!(lhs == rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{time_point}}%
-\indexlibrary{\idxcode{time_point}!\idxcode{operator<}}%
+\indexlibrarymember{operator<}{time_point}%
 \begin{itemdecl}
 template <class Clock, class Duration1, class Duration2>
   constexpr bool operator<(const time_point<Clock, Duration1>& lhs, const time_point<Clock, Duration2>& rhs);
@@ -17763,8 +17526,7 @@ template <class Clock, class Duration1, class Duration2>
 \returns \tcode{lhs.time_since_epoch() < rhs.time_since_epoch()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{time_point}}%
-\indexlibrary{\idxcode{time_point}!\idxcode{operator<=}}%
+\indexlibrarymember{operator<=}{time_point}%
 \begin{itemdecl}
 template <class Clock, class Duration1, class Duration2>
   constexpr bool operator<=(const time_point<Clock, Duration1>& lhs, const time_point<Clock, Duration2>& rhs);
@@ -17775,8 +17537,7 @@ template <class Clock, class Duration1, class Duration2>
 \returns \tcode{!(rhs < lhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>}!\idxcode{time_point}}%
-\indexlibrary{\idxcode{time_point}!\idxcode{operator>}}%
+\indexlibrarymember{operator>}{time_point}%
 \begin{itemdecl}
 template <class Clock, class Duration1, class Duration2>
   constexpr bool operator>(const time_point<Clock, Duration1>& lhs, const time_point<Clock, Duration2>& rhs);
@@ -17787,8 +17548,7 @@ template <class Clock, class Duration1, class Duration2>
 \returns \tcode{rhs < lhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{time_point}}%
-\indexlibrary{\idxcode{time_point}!\idxcode{operator>=}}%
+\indexlibrarymember{operator>=}{time_point}%
 \begin{itemdecl}
 template <class Clock, class Duration1, class Duration2>
   constexpr bool operator>=(const time_point<Clock, Duration1>& lhs, const time_point<Clock, Duration2>& rhs);
@@ -17818,8 +17578,7 @@ unless \tcode{ToDuration} is a specialization of \tcode{duration}.
 \returns \tcode{time_point<Clock, ToDuration>(duration_cast<ToDuration>(t.time_since_epoch()))}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{time_point}!\idxcode{floor}}%
-\indexlibrary{\idxcode{floor}!\idxcode{time_point}}%
+\indexlibrarymember{time_point}{floor}%
 \begin{itemdecl}
 template <class ToDuration, class Clock, class Duration>
   constexpr time_point<Clock, ToDuration>
@@ -17835,8 +17594,7 @@ unless \tcode{ToDuration} is a specialization of \tcode{duration}.
 \returns \tcode{time_point<Clock, ToDuration>(floor<ToDuration>(tp.time_since_epoch()))}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{time_point}!\idxcode{ceil}}%
-\indexlibrary{\idxcode{ceil}!\idxcode{time_point}}%
+\indexlibrarymember{time_point}{ceil}%
 \begin{itemdecl}
 template <class ToDuration, class Clock, class Duration>
   constexpr time_point<Clock, ToDuration>
@@ -17852,8 +17610,7 @@ unless \tcode{ToDuration} is a specialization of \tcode{duration}.
 \returns \tcode{time_point<Clock, ToDuration>(ceil<ToDuration>(tp.time_since_epoch()))}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{time_point}!\idxcode{round}}%
-\indexlibrary{\idxcode{round}!\idxcode{time_point}}%
+\indexlibrarymember{time_point}{round}%
 \begin{itemdecl}
 template <class ToDuration, class Clock, class Duration>
   constexpr time_point<Clock, ToDuration>
@@ -17900,8 +17657,7 @@ public:
 };
 \end{codeblock}
 
-\indexlibrary{\idxcode{rep}!\idxcode{system_clock}}%
-\indexlibrary{\idxcode{system_clock}!\idxcode{rep}}%
+\indexlibrarymember{rep}{system_clock}%
 \begin{itemdecl}
 using system_clock::rep = @\unspec@;
 \end{itemdecl}
@@ -18100,8 +17856,7 @@ type_index(const type_info& rhs) noexcept;
 \effects Constructs a \tcode{type_index} object, the equivalent of \tcode{target = \&rhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{type_index}}%
-\indexlibrary{\idxcode{type_index}!\idxcode{operator==}}%
+\indexlibrarymember{operator==}{type_index}%
 \begin{itemdecl}
 bool operator==(const type_index& rhs) const noexcept;
 \end{itemdecl}
@@ -18122,8 +17877,7 @@ bool operator!=(const type_index& rhs) const noexcept;
 \returns \tcode{*target != *rhs.target}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{type_index}}%
-\indexlibrary{\idxcode{type_index}!\idxcode{operator<}}%
+\indexlibrarymember{operator<}{type_index}%
 \begin{itemdecl}
 bool operator<(const type_index& rhs) const noexcept;
 \end{itemdecl}
@@ -18133,8 +17887,7 @@ bool operator<(const type_index& rhs) const noexcept;
 \returns \tcode{target->before(*rhs.target)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{type_index}}%
-\indexlibrary{\idxcode{type_index}!\idxcode{operator<=}}%
+\indexlibrarymember{operator<=}{type_index}%
 \begin{itemdecl}
 bool operator<=(const type_index& rhs) const noexcept;
 \end{itemdecl}
@@ -18144,8 +17897,7 @@ bool operator<=(const type_index& rhs) const noexcept;
 \returns \tcode{!rhs.target->before(*target)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>}!\idxcode{type_index}}%
-\indexlibrary{\idxcode{type_index}!\idxcode{operator>}}%
+\indexlibrarymember{operator>}{type_index}%
 \begin{itemdecl}
 bool operator>(const type_index& rhs) const noexcept;
 \end{itemdecl}
@@ -18155,8 +17907,7 @@ bool operator>(const type_index& rhs) const noexcept;
 \returns \tcode{rhs.target->before(*target)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{type_index}}%
-\indexlibrary{\idxcode{type_index}!\idxcode{operator>=}}%
+\indexlibrarymember{operator>=}{type_index}%
 \begin{itemdecl}
 bool operator>=(const type_index& rhs) const noexcept;
 \end{itemdecl}
@@ -18166,8 +17917,7 @@ bool operator>=(const type_index& rhs) const noexcept;
 \returns \tcode{!target->before(*rhs.target)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{hash_code}!\idxcode{type_index}}%
-\indexlibrary{\idxcode{type_index}!\idxcode{hash_code}}%
+\indexlibrarymember{hash_code}{type_index}%
 \begin{itemdecl}
 size_t hash_code() const noexcept;
 \end{itemdecl}
@@ -18177,8 +17927,7 @@ size_t hash_code() const noexcept;
 \returns \tcode{target->hash_code()}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{name}!\idxcode{type_index}}%
-\indexlibrary{\idxcode{type_index}!\idxcode{name}}%
+\indexlibrarymember{name}{type_index}%
 \begin{itemdecl}
 const char* name() const noexcept;
 \end{itemdecl}


### PR DESCRIPTION
The new command `\indexlibrarymember{C}{mem}` creates an entry `C!mem` and another entry `mem!C` in the index of library names. This makes it easier to always create both entries consistently.

Thanks to @AlisdairM for the idea and the prototype.