### PR TITLE
Fix formatting in [dcl.init.ref]/4.2

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -3459,7 +3459,7 @@ Given types ``\nonterminal{cv1} \tcode{T1}'' and ``\nonterminal{cv2} \tcode{T2}'
 with ``\nonterminal{cv2} \tcode{T2}'' if
 \begin{itemize}
 \item \tcode{T1} is reference-related to \tcode{T2}, or
-\item T2 is ``\tcode{noexcept} function'' and T1 is ``function'',
+\item \tcode{T2} is ``\tcode{noexcept} function'' and \tcode{T1} is ``function'',
 where the function types are otherwise the same,
 \end{itemize}
 and


### PR DESCRIPTION
`T1` and `T2` didn't have code formatting.