### PR TITLE
Add constexpr to optional::value_or(U&&) &&

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2908,7 +2908,7 @@ the program is ill-formed.
 \end{itemdescr}
 
 \begin{itemdecl}
-template <class U> T value_or(U&& v) &&;
+template <class U> constexpr T value_or(U&& v) &&;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
This constexpr specifier is present in the `<optional>` synopsis, but omitted from the detailed specification in [optional.object.observe]. (I understand I'm stretching the definition of "editorial" here. Please let me know if the editors feel this change is substantive, and I'll file a defect report with LWG.)