### PR TITLE
[language.support] review library indexing of clause 18

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -230,7 +230,7 @@ namespace std {
 
 \rSec3[numeric.limits]{Class template \tcode{numeric_limits}}
 
-\indexlibrary{\idxcode{numeric\_limits}}%
+\indexlibrary{\idxcode{numeric_limits}}%
 \begin{codeblock}
 namespace std {
   template<class T> class numeric_limits {
@@ -295,8 +295,7 @@ the specialization on the unqualified type \tcode{T}.
 
 \rSec3[numeric.limits.members]{\tcode{numeric_limits} members}
 
-\indexlibrary{\idxcode{min}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{min}}
+\indexlibrarymember{numeric_limits}{min}%
 \begin{itemdecl}
 static constexpr T min() noexcept;
 \end{itemdecl}
@@ -317,8 +316,7 @@ or
 \tcode{is_bounded == false \&\& is_signed == false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{max}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{max}}
+\indexlibrarymember{numeric_limits}{max}%
 \begin{itemdecl}
 static constexpr T max() noexcept;
 \end{itemdecl}
@@ -333,8 +331,7 @@ Meaningful for all specializations in which
 \tcode{is_bounded != false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{lowest}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{lowest}}
+\indexlibrarymember{numeric_limits}{lowest}%
 \begin{itemdecl}
 static constexpr T lowest() noexcept;
 \end{itemdecl}
@@ -350,8 +347,7 @@ the negative of the largest (most positive) finite value.}
 Meaningful for all specializations in which \tcode{is_bounded != false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{digits}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{digits}}
+\indexlibrarymember{numeric_limits}{digits}%
 \begin{itemdecl}
 static constexpr int digits;
 \end{itemdecl}
@@ -369,8 +365,7 @@ For integer types, the number of non-sign bits in the representation.
 mantissa.\footnote{Equivalent to \tcode{FLT_MANT_DIG}, \tcode{DBL_MANT_DIG},
 \tcode{LDBL_MANT_DIG}.} \end{itemdescr}
 
-\indexlibrary{\idxcode{digits10}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{digits10}}
+\indexlibrarymember{numeric_limits}{digits10}%
 \begin{itemdecl}
 static constexpr int digits10;
 \end{itemdecl}
@@ -386,8 +381,7 @@ Meaningful for all specializations in which
 \tcode{is_bounded != false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{max_digits10}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{max_digits10}}
+\indexlibrarymember{numeric_limits}{max_digits10}%
 \begin{itemdecl}
 static constexpr int max_digits10;
 \end{itemdecl}
@@ -401,8 +395,7 @@ differ are always differentiated.
 Meaningful for all floating point types.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{is_signed}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{is_signed}}
+\indexlibrarymember{numeric_limits}{is_signed}%
 \begin{itemdecl}
 static constexpr bool is_signed;
 \end{itemdecl}
@@ -415,8 +408,7 @@ True if the type is signed.
 Meaningful for all specializations.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{is_integer}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{is_integer}}
+\indexlibrarymember{numeric_limits}{is_integer}%
 \begin{itemdecl}
 static constexpr bool is_integer;
 \end{itemdecl}
@@ -429,8 +421,7 @@ True if the type is integer.
 Meaningful for all specializations.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{is_exact}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{is_exact}}
+\indexlibrarymember{numeric_limits}{is_exact}%
 \begin{itemdecl}
 static constexpr bool is_exact;
 \end{itemdecl}
@@ -445,8 +436,7 @@ For example, rational and fixed-exponent representations are exact but not integ
 Meaningful for all specializations.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{radix}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{radix}}
+\indexlibrarymember{numeric_limits}{radix}%
 \begin{itemdecl}
 static constexpr int radix;
 \end{itemdecl}
@@ -465,8 +455,7 @@ BCD).}
 Meaningful for all specializations.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{epsilon}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{epsilon}}
+\indexlibrarymember{numeric_limits}{epsilon}%
 \begin{itemdecl}
 static constexpr T epsilon() noexcept;
 \end{itemdecl}
@@ -480,8 +469,7 @@ that is representable.\footnote{Equivalent to \tcode{FLT_EPSILON}, \tcode{DBL_EP
 Meaningful for all floating point types.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{round_error}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{round_error}}
+\indexlibrarymember{numeric_limits}{round_error}%
 \begin{itemdecl}
 static constexpr T round_error() noexcept;
 \end{itemdecl}
@@ -494,8 +482,7 @@ Section 5.2.8 and
 Annex A Rationale Section A.5.2.8 - Rounding constants.}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{min_exponent}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{min_exponent}}
+\indexlibrarymember{numeric_limits}{min_exponent}%
 \begin{itemdecl}
 static constexpr int  min_exponent;
 \end{itemdecl}
@@ -512,8 +499,7 @@ point number.\footnote{Equivalent to \tcode{FLT_MIN_EXP}, \tcode{DBL_MIN_EXP},
 Meaningful for all floating point types.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{min_exponent10}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{min_exponent10}}
+\indexlibrarymember{numeric_limits}{min_exponent10}%
 \begin{itemdecl}
 static constexpr int  min_exponent10;
 \end{itemdecl}
@@ -528,8 +514,7 @@ of normalized floating point numbers.\footnote{Equivalent to
 Meaningful for all floating point types.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{max_exponent}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{max_exponent}}
+\indexlibrarymember{numeric_limits}{max_exponent}%
 \begin{itemdecl}
 static constexpr int  max_exponent;
 \end{itemdecl}
@@ -546,8 +531,7 @@ floating point number.\footnote{Equivalent to \tcode{FLT_MAX_EXP},
 Meaningful for all floating point types.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{max_exponent10}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{max_exponent10}}
+\indexlibrarymember{numeric_limits}{max_exponent10}%
 \begin{itemdecl}
 static constexpr int  max_exponent10;
 \end{itemdecl}
@@ -562,8 +546,7 @@ range of representable finite floating point numbers.\footnote{Equivalent to
 Meaningful for all floating point types.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{has_infinity}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{has_infinity}}
+\indexlibrarymember{numeric_limits}{has_infinity}%
 \begin{itemdecl}
 static constexpr bool has_infinity;
 \end{itemdecl}
@@ -582,8 +565,7 @@ for all specializations in which
 \tcode{is_iec559 != false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{has_quiet_NaN}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{has_quiet_NaN}}
+\indexlibrarymember{numeric_limits}{has_quiet_NaN}%
 \begin{itemdecl}
 static constexpr bool has_quiet_NaN;
 \end{itemdecl}
@@ -603,8 +585,7 @@ for all specializations in which
 \tcode{is_iec559 != false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{has_signaling_NaN}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{has_signaling_NaN}}
+\indexlibrarymember{numeric_limits}{has_signaling_NaN}%
 \begin{itemdecl}
 static constexpr bool has_signaling_NaN;
 \end{itemdecl}
@@ -623,8 +604,7 @@ for all specializations in which
 \tcode{is_iec559 != false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{float_denorm_style}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{float_denorm_style}}
+\indexlibrarymember{numeric_limits}{float_denorm_style}%
 \begin{itemdecl}
 static constexpr float_denorm_style has_denorm;
 \end{itemdecl}
@@ -645,8 +625,7 @@ denormalized values.
 Meaningful for all floating point types.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{has_denorm_loss}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{has_denorm_loss}}
+\indexlibrarymember{numeric_limits}{has_denorm_loss}%
 \begin{itemdecl}
 static constexpr bool has_denorm_loss;
 \end{itemdecl}
@@ -657,8 +636,7 @@ True if loss of accuracy is detected as a
 denormalization loss, rather than as an inexact result.\footnote{See IEC 559.}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{infinity}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{infinity}}
+\indexlibrarymember{numeric_limits}{infinity}%
 \begin{itemdecl}
 static constexpr T infinity() noexcept;
 \end{itemdecl}
@@ -674,8 +652,7 @@ Required in specializations for which
 \tcode{is_iec559 != false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{quiet_NaN}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{quiet_NaN}}
+\indexlibrarymember{numeric_limits}{quiet_NaN}%
 \begin{itemdecl}
 static constexpr T quiet_NaN() noexcept;
 \end{itemdecl}
@@ -691,8 +668,7 @@ Required in specializations for which
 \tcode{is_iec559 != false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{signaling_NaN}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{signaling_NaN}}
+\indexlibrarymember{numeric_limits}{signaling_NaN}%
 \begin{itemdecl}
 static constexpr T signaling_NaN() noexcept;
 \end{itemdecl}
@@ -708,8 +684,7 @@ Required in specializations for which
 \tcode{is_iec559 != false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{denorm_min}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{denorm_min}}
+\indexlibrarymember{numeric_limits}{denorm_min}%
 \begin{itemdecl}
 static constexpr T denorm_min() noexcept;
 \end{itemdecl}
@@ -727,8 +702,7 @@ In specializations for which
 returns the minimum positive normalized value.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{is_iec559}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{is_iec559}}
+\indexlibrarymember{numeric_limits}{is_iec559}%
 \begin{itemdecl}
 static constexpr bool is_iec559;
 \end{itemdecl}
@@ -743,8 +717,7 @@ IEEE 754.}
 Meaningful for all floating point types.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{is_bounded}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{is_bounded}}
+\indexlibrarymember{numeric_limits}{is_bounded}%
 \begin{itemdecl}
 static constexpr bool is_bounded;
 \end{itemdecl}
@@ -759,8 +732,7 @@ precision types.\end{note}
 Meaningful for all specializations.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{is_modulo}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{is_modulo}}
+\indexlibrarymember{numeric_limits}{is_modulo}%
 \begin{itemdecl}
 static constexpr bool is_modulo;
 \end{itemdecl}
@@ -784,8 +756,7 @@ defines signed integer overflow to wrap.
 Meaningful for all specializations.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{traps}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{traps}}
+\indexlibrarymember{numeric_limits}{traps}%
 \begin{itemdecl}
 static constexpr bool traps;
 \end{itemdecl}
@@ -800,8 +771,7 @@ an arithmetic operation using that value to trap.\footnote{Required by LIA-1.}
 Meaningful for all specializations.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{tinyness_before}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{tinyness_before}}
+\indexlibrarymember{numeric_limits}{tinyness_before}%
 \begin{itemdecl}
 static constexpr bool tinyness_before;
 \end{itemdecl}
@@ -816,8 +786,7 @@ Required by LIA-1.}
 Meaningful for all floating point types.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{round_style}!\idxcode{numeric_limits}}
-\indexlibrary{\idxcode{numeric_limits}!\idxcode{round_style}}
+\indexlibrarymember{numeric_limits}{round_style}%
 \begin{itemdecl}
 static constexpr float_round_style round_style;
 \end{itemdecl}
@@ -1313,7 +1282,7 @@ duration and without calling functions passed to
 \indexlibrary{\idxcode{atexit}}%
 \end{itemdescr}
 
-\indexlibrary{\idxcode{atexit}}
+\indexlibrary{\idxcode{atexit}}%
 \begin{itemdecl}
 extern "C" int atexit(void (*f)()) noexcept;
 extern "C++" int atexit(void (*f)()) noexcept;
@@ -1408,7 +1377,7 @@ are defined in
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{at_quick_exit}}
+\indexlibrary{\idxcode{at_quick_exit}}%
 \begin{itemdecl}
 extern "C" int at_quick_exit(void (*f)()) noexcept;
 extern "C++" int at_quick_exit(void (*f)()) noexcept;
@@ -1439,7 +1408,7 @@ The implementation shall support the registration of at least 32 functions.
 \returns Zero if the registration succeeds, non-zero if it fails.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{quick_exit}}
+\indexlibrary{\idxcode{quick_exit}}%
 \begin{itemdecl}
 [[noreturn]] void quick_exit(int status) noexcept;
 \end{itemdecl}
@@ -1453,7 +1422,7 @@ registered. Objects shall not be destroyed as a result of calling \tcode{quick_e
 If control leaves a registered function called by \tcode{quick_exit} because the
 function does not provide a handler for a thrown exception, \tcode{std::terminate()} shall
 be called.%
-\indexlibrary{\idxcode{terminate}}
+\indexlibrary{\idxcode{terminate}}%
 \begin{note} \tcode{at_quick_exit} may call a registered function from a different thread
 than the one that registered it, so registered functions should not rely on the identity
 of objects with thread storage duration. \end{note}
@@ -2203,7 +2172,7 @@ Constructs an object of class
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bad_alloc}!constructor}%
-\indexlibrary{\idxcode{operator=}!\idxcode{bad_alloc}}%
+\indexlibrarymember{bad_alloc}{operator=}%
 \begin{itemdecl}
 bad_alloc(const bad_alloc&) noexcept;
 bad_alloc& operator=(const bad_alloc&) noexcept;
@@ -2216,7 +2185,7 @@ Copies an object of class
 \tcode{bad_alloc}.
 \end{itemdescr}
 
-\indexlibrarymember{what}{bad_alloc}%
+\indexlibrarymember{bad_alloc}{what}%
 \begin{itemdecl}
 const char* what() const noexcept override;
 \end{itemdecl}
@@ -2518,7 +2487,7 @@ The names, encoding rule, and collating sequence for types are all unspecified
 \indextext{unspecified}%
 and may differ between programs.
 
-\indexlibrarymember{operator==}{type_info}%
+\indexlibrarymember{type_info}{operator==}%
 \begin{itemdecl}
 bool operator==(const type_info& rhs) const noexcept;
 \end{itemdecl}
@@ -2534,8 +2503,7 @@ Compares the current object with \tcode{rhs}.
 if the two values describe the same type.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{type_info}}%
-\indexlibrary{\idxcode{type_info}!\idxcode{operator"!=}}%
+\indexlibrarymember{type_info}{operator"!=}%
 \begin{itemdecl}
 bool operator!=(const type_info& rhs) const noexcept;
 \end{itemdecl}
@@ -2546,7 +2514,7 @@ bool operator!=(const type_info& rhs) const noexcept;
 \tcode{!(*this == rhs)}.
 \end{itemdescr}
 
-\indexlibrarymember{before}{type_info}%
+\indexlibrarymember{type_info}{before}%
 \begin{itemdecl}
 bool before(const type_info& rhs) const noexcept;
 \end{itemdecl}
@@ -2564,7 +2532,7 @@ if
 precedes \tcode{rhs} in the implementation's collation order.
 \end{itemdescr}
 
-\indexlibrarymember{hash_code}{type_info}%
+\indexlibrarymember{type_info}{hash_code}%
 \begin{itemdecl}
 size_t hash_code() const noexcept;
 \end{itemdecl}
@@ -2635,7 +2603,7 @@ Constructs an object of class
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bad_cast}!constructor}%
-\indexlibrary{\idxcode{operator=}!\idxcode{bad_cast}}%
+\indexlibrarymember{bad_cast}{operator=}%
 \begin{itemdecl}
 bad_cast(const bad_cast&) noexcept;
 bad_cast& operator=(const bad_cast&) noexcept;
@@ -2702,7 +2670,7 @@ Constructs an object of class
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bad_typeid}!constructor}%
-\indexlibrary{\idxcode{operator=}!\idxcode{bad_typeid}}%
+\indexlibrarymember{bad_typeid}{operator=}%
 \begin{itemdecl}
 bad_typeid(const bad_typeid&) noexcept;
 bad_typeid& operator=(const bad_typeid&) noexcept;
@@ -2821,7 +2789,7 @@ Constructs an object of class
 \end{itemdescr}
 
 \indexlibrary{\idxcode{exception}!constructor}%
-\indexlibrary{\idxcode{operator=}!\idxcode{exception}}%
+\indexlibrarymember{exception}{operator=}%
 \begin{itemdecl}
 exception(const exception& rhs) noexcept;
 exception& operator=(const exception& rhs) noexcept;
@@ -2905,7 +2873,7 @@ Constructs an object of class
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bad_exception}!constructor}%
-\indexlibrary{\idxcode{operator=}!\idxcode{bad_exception}}%
+\indexlibrarymember{bad_exception}{operator=}%
 \begin{itemdecl}
 bad_exception(const bad_exception&) noexcept;
 bad_exception& operator=(const bad_exception&) noexcept;
@@ -2962,7 +2930,7 @@ terminate execution of the program without returning to the caller.
 \default
 The implementation's default \tcode{terminate_handler} calls
 \tcode{abort()}.%
-\indexlibrary{\idxcode{abort}}
+\indexlibrary{\idxcode{abort}}%
 \end{itemdescr}
 
 \rSec3[set.terminate]{\tcode{set_terminate}}
@@ -3045,7 +3013,7 @@ throwing an exception can result in a call of\\
 
 \rSec2[propagation]{Exception propagation}
 
-\indexlibrary{\idxcode{exception_ptr}}
+\indexlibrary{\idxcode{exception_ptr}}%
 \begin{itemdecl}
 using exception_ptr = @\unspec@;
 \end{itemdecl}
@@ -3086,7 +3054,7 @@ Changes in the number of \tcode{exception_ptr} objects that refer to a
 particular exception do not introduce a data race. \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{current_exception}}
+\indexlibrary{\idxcode{current_exception}}%
 \begin{itemdecl}
 exception_ptr current_exception() noexcept;
 \end{itemdecl}
@@ -3112,7 +3080,7 @@ to substitute a \tcode{bad_exception} object to avoid infinite
 recursion.\end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{rethrow_exception}}
+\indexlibrary{\idxcode{rethrow_exception}}%
 \begin{itemdecl}
 [[noreturn]] void rethrow_exception(exception_ptr p);
 \end{itemdecl}
@@ -3125,7 +3093,7 @@ recursion.\end{note}
 \throws the exception object to which \tcode{p} refers.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{make_exception_ptr}}
+\indexlibrary{\idxcode{make_exception_ptr}}%
 \begin{itemdecl}
 template<class E> exception_ptr make_exception_ptr(E e) noexcept;
 \end{itemdecl}
@@ -3178,7 +3146,7 @@ for later use.
 polymorphic class. Its presence can be tested for with \tcode{dynamic_cast}.
 \end{note}
 
-\indexlibrary{\idxcode{nested_exception}!constructor}
+\indexlibrary{\idxcode{nested_exception}!constructor}%
 \begin{itemdecl}
 nested_exception() noexcept;
 \end{itemdecl}
@@ -3188,8 +3156,7 @@ nested_exception() noexcept;
 \effects The constructor calls \tcode{current_exception()} and stores the returned value.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{rethrow_nested}!\idxcode{nested_exception}}
-\indexlibrary{\idxcode{nested_exception}!\idxcode{rethrow_nested}}
+\indexlibrarymember{nested_exception}{rethrow_nested}%
 \begin{itemdecl}
 [[noreturn]] void rethrow_nested() const;
 \end{itemdecl}
@@ -3200,8 +3167,7 @@ nested_exception() noexcept;
 Otherwise, it throws the stored exception captured by \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{nested_ptr}!\idxcode{nested_exception}}
-\indexlibrary{\idxcode{nested_exception}!\idxcode{nested_ptr}}
+\indexlibrarymember{nested_exception}{nested_ptr}%
 \begin{itemdecl}
 exception_ptr nested_ptr() const noexcept;
 \end{itemdecl}
@@ -3211,8 +3177,7 @@ exception_ptr nested_ptr() const noexcept;
 \returns The stored exception captured by this \tcode{nested_exception} object.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{throw_with_nested}!\idxcode{nested_exception}}
-\indexlibrary{\idxcode{nested_exception}!\idxcode{throw_with_nested}}
+\indexlibrarymember{nested_exception}{throw_with_nested}%
 \begin{itemdecl}
 template <class T> [[noreturn]] void throw_with_nested(T&& t);
 \end{itemdecl}
@@ -3234,8 +3199,7 @@ and constructed from \tcode{std::forward<T>(t)}, otherwise
 \tcode{std::forward<T>(t)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{rethrow_if_nested}!\idxcode{nested_exception}}
-\indexlibrary{\idxcode{nested_exception}!\idxcode{rethrow_if_nested}}
+\indexlibrarymember{nested_exception}{rethrow_if_nested}%
 \begin{itemdecl}
 template <class E> void rethrow_if_nested(const E& e);
 \end{itemdecl}
@@ -3304,7 +3268,7 @@ If an explicit specialization or partial specialization of
 
 \rSec2[support.initlist.cons]{Initializer list constructors}
 
-\indexlibrary{\idxcode{initializer_list}!constructor}
+\indexlibrary{\idxcode{initializer_list}!constructor}%
 \begin{itemdecl}
 constexpr initializer_list() noexcept;
 \end{itemdecl}
@@ -3319,8 +3283,7 @@ constexpr initializer_list() noexcept;
 
 \rSec2[support.initlist.access]{Initializer list access}
 
-\indexlibrary{\idxcode{begin}!\idxcode{initializer_list}}
-\indexlibrary{\idxcode{initializer_list}!\idxcode{begin}}
+\indexlibrarymember{initializer_list}{begin}%
 \begin{itemdecl}
 constexpr const E* begin() const noexcept;
 \end{itemdecl}
@@ -3332,8 +3295,7 @@ values of \tcode{begin()} and \tcode{end()} are unspecified but they shall be
 identical.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{end}!\idxcode{initializer_list}}
-\indexlibrary{\idxcode{initializer_list}!\idxcode{end}}
+\indexlibrarymember{initializer_list}{end}%
 \begin{itemdecl}
 constexpr const E* end() const noexcept;
 \end{itemdecl}
@@ -3343,8 +3305,7 @@ constexpr const E* end() const noexcept;
 \returns \tcode{begin() + size()}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{size}!\idxcode{initializer_list}}
-\indexlibrary{\idxcode{initializer_list}!\idxcode{size}}
+\indexlibrarymember{initializer_list}{size}%
 \begin{itemdecl}
 constexpr size_t size() const noexcept;
 \end{itemdecl}
@@ -3359,7 +3320,7 @@ constexpr size_t size() const noexcept;
 
 \rSec2[support.initlist.range]{Initializer list range access}
 
-\indexlibrary{\idxcode{begin(initializer_list<E>)}}
+\indexlibrary{\idxcode{begin(initializer_list<E>)}}%
 \begin{itemdecl}
 template<class E> constexpr const E* begin(initializer_list<E> il) noexcept;
 \end{itemdecl}
@@ -3369,7 +3330,7 @@ template<class E> constexpr const E* begin(initializer_list<E> il) noexcept;
 \returns \tcode{il.begin()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{end(initializer_list<E>)}}
+\indexlibrary{\idxcode{end(initializer_list<E>)}}%
 \begin{itemdecl}
 template<class E> constexpr const E* end(initializer_list<E> il) noexcept;
 \end{itemdecl}


### PR DESCRIPTION
This change consistently applies to new indexlibrarymember
macro in places missed by the first pass - mostly for cases
where either the class or member-name has an underscore.

It consistently uses the notation of {class}{member} when
using the new macro.  This is purely a consistency concern,
as the macro will expand to the same results either way.

It consistently uses a % to eliminate potential whitespace
being introduced by an index entry macro.

It removes a duplicate entry for 'numeric_limits' causes
by the use of the \_ command.  This appears to be the
correct fix, on inspection of the index.  The alternative
would have been consistent use of \_ on every numeric_limits
entry, so trying the simpler fix first.