### PR TITLE
[cstdint, cinttypes.syn] Reorganize <cstdint> presentation

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -1872,42 +1872,41 @@ namespace std {
   using uintptr_t      = @\textit{unsigned integer type}@; // optional
 }
 
-#define INT@\placeholdernc{N}@_MIN         @\seebelow@
-#define INT@\placeholdernc{N}@_MAX         @\seebelow@
-#define UINT@\placeholdernc{N}@_MAX        @\seebelow@
+#define INT[8, 16, 32, 64]_MIN @\seebelow@         // optional
+#define INT[8, 16, 32, 64]_MAX @\seebelow@         // optional
+#define UINT[8, 16, 32, 64]_MAX @\seebelow@        // optional
 
-#define INT_FAST@\placeholdernc{N}@_MIN    @\seebelow@
-#define INT_FAST@\placeholdernc{N}@_MAX    @\seebelow@
-#define UINT_FAST@\placeholdernc{N}@_MAX   @\seebelow@
+#define INT_LEAST[8, 16, 32, 64]_MIN @\seebelow@
+#define INT_LEAST[8, 16, 32, 64]_MAX @\seebelow@
+#define UINT_LEAST[8, 16, 32, 64]_MAX @\seebelow@
 
-#define INT_LEAST@\placeholdernc{N}@_MIN   @\seebelow@
-#define INT_LEAST@\placeholdernc{N}@_MAX   @\seebelow@
-#define UINT_LEAST@\placeholdernc{N}@_MAX  @\seebelow@
+#define INT_FAST[8, 16, 32, 64]_MIN @\seebelow@
+#define INT_FAST[8, 16, 32, 64]_MAX @\seebelow@
+#define UINT_FAST[8, 16, 32, 64]_MAX @\seebelow@
 
-#define INTMAX_MIN       @\seebelow@
-#define INTMAX_MAX       @\seebelow@
-#define UINTMAX_MAX      @\seebelow@
+#define INTPTR_MIN @\seebelow@                     // optional
+#define INTPTR_MAX @\seebelow@                     // optional
+#define UINTPTR_MAX @\seebelow@                    // optional
 
-#define INTPTR_MIN       @\seebelow@              // optional
-#define INTPTR_MAX       @\seebelow@              // optional
-#define UINTPTR_MAX      @\seebelow@              // optional
+#define INTMAX_MIN @\seebelow@
+#define INTMAX_MAX @\seebelow@
+#define UINTMAX_MAX @\seebelow@
 
-#define PTRDIFF_MIN      @\seebelow@
-#define PTRDIFF_MAX      @\seebelow@
-#define SIZE_MAX         @\seebelow@
+#define PTRDIFF_MIN @\seebelow@
+#define PTRDIFF_MAX @\seebelow@
+#define SIG_ATOMIC_MIN @\seebelow@
+#define SIG_ATOMIC_MAX @\seebelow@
+#define SIZE_MAX @\seebelow@
 
-#define SIG_ATOMIC_MIN   @\seebelow@
-#define SIG_ATOMIC_MAX   @\seebelow@
+#define WCHAR_MIN @\seebelow@
+#define WCHAR_MAX @\seebelow@
+#define WINT_MIN @\seebelow@
+#define WINT_MAX @\seebelow@
 
-#define WCHAR_MIN        @\seebelow@
-#define WCHAR_MAX        @\seebelow@
+#define INT[8, 16, 32, 64]_C(value) @\seebelow@    // optional
+#define UINT[8, 16, 32, 64]_C(value) @\seebelow@   // optional
 
-#define WINT_MIN         @\seebelow@
-#define WINT_MAX         @\seebelow@
-
-#define INT@\placeholdernc{N}@_C(value)    @\seebelow@
-#define UINT@\placeholdernc{N}@_C(value)   @\seebelow@
-#define INTMAX_C(value)  @\seebelow@
+#define INTMAX_C(value) @\seebelow@
 #define UINTMAX_C(value) @\seebelow@
 \end{codeblock}
 


### PR DESCRIPTION
- Demote heading "18.4.1 Header `<cstdint>` synopsis" to `\synopsis`.
- Show MIN/MAX macros in synopsis.
- Remove stray namespace comment.
- Add See Also for the relevant C clause.
- Add cross reference from `<cinttypes>` synopsis.
