### PR TITLE
[temp.deduct.call] Avoid line wrap in long comment.

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -6402,7 +6402,7 @@ will be checked during overload resolution.
   template <class T> void f(int, T);                 // \#2
   struct A {} a;
   int main() {
-    f(1, a);                                         // OK, deduction fails for \#1 because there is no conversion from int to void*
+    f(1, a);       // OK, deduction fails for \#1 because there is no conversion from int to void*
   }
 \end{codeblock}
 \end{example}


### PR DESCRIPTION
Avoiding the line wrap results in reflow that affects 13 pages. The first two pages of diffs: ![diffs](http://eel.is/longlinediffs.jpg)
