### PR TITLE
[path.generic.obs] Escape backslash in string literal in example.

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -11343,7 +11343,7 @@ the \grammarterm{directory-separator} character.
 
 \pnum
 \begin{example} On an operating system that uses backslash as
-its \grammarterm{preferred-separator}, \tcode{path("foo\textbackslash{}bar").generic_string()}
+its \grammarterm{preferred-separator}, \tcode{path("foo\textbackslash\textbackslash{}bar").generic_string()}
 returns \tcode{"foo/bar"}. \end{example}
 
 \begin{itemdecl}


### PR DESCRIPTION
![diff](http://eel.is/escape.jpg)