### PR TITLE
[container.node] Move sub-clause to after [sequence.reqmts]

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -31,254 +31,6 @@ Table~\ref{tab:containers.lib.summary}.
                              &                                  & \tcode{<stack>}         \\ \rowsep
 \end{libsumtab}
 
-\rSec2[container.node]{Node handles}
-
-\rSec3[container.node.overview]{\tcode{node_handle} overview}
-
-\pnum
-A \term{node handle} is an object that accepts ownership of a single element
-from an associative container~(\ref{associative.reqmts}) or an unordered
-associative container~(\ref{unord.req}). It may be used to transfer that
-ownership to another container with compatible nodes.  Containers with
-compatible nodes have the same node handle type. Elements may be transferred in
-either direction between container types in the same row of
-Table~\ref{tab:containers.node.compat}.
-
-\begin{floattable}{Container types with compatible nodes}{tab:containers.node.compat}
-{ll}
-\topline
-\tcode{map<K, T, C1, A>}               & \tcode{map<K, T, C2, A>}                    \\
-\rowsep
-\tcode{map<K, T, C1, A>}               & \tcode{multimap<K, T, C2, A>}               \\
-\rowsep
-\tcode{set<K, C1, A>}                  & \tcode{set<K, C2, A>}                       \\
-\rowsep
-\tcode{set<K, C1, A>}                  & \tcode{multiset<K, C2, A>}                  \\
-\rowsep
-\tcode{unordered_map<K, T, H1, E1, A>} & \tcode{unordered_map<K, T, H2, E2, A>}      \\
-\rowsep
-\tcode{unordered_map<K, T, H1, E1, A>} & \tcode{unordered_multimap<K, T, H2, E2, A>} \\
-\rowsep
-\tcode{unordered_set<K, H1, E1, A>}    & \tcode{unordered_set<K, H2, E2, A>}         \\
-\rowsep
-\tcode{unordered_set<K, H1, E1, A>}    & \tcode{unordered_multiset<K, H2, E2, A>}    \\
-\end{floattable}
-
-\pnum
-If a node handle is not empty, then it contains an allocator that is equal to
-the allocator of the container when the element was extracted. If a node handle
-is empty, it contains no allocator.
-
-\pnum
-Class \tcode{\textit{node_handle}} is for exposition only. An implementation is
-permitted to provide equivalent functionality without providing a class with
-this name.
-
-\pnum
-If a user-defined specialization of \tcode{std::pair} exists for
-\tcode{pair<const Key, T>} or \tcode{pair<Key, T>}, where \tcode{Key} is the
-container's \tcode{key_type} and \tcode{T} is the container's
-\tcode{mapped_type}, the behavior of operations involving node handles is
-undefined.
-
-\begin{codeblock}
-template<@\unspecnc@>
-class @\textit{node_handle}@ {
-public:
-  // These type declarations are described in Tables \ref{tab:containers.associative.requirements} and \ref{tab:HashRequirements}
-  using value_type     = @\seebelownc{}@; // Not present for map containers
-  using key_type       = @\seebelownc{}@; // Not present for set containers
-  using mapped_type    = @\seebelownc{}@; // Not present for set containers
-  using allocator_type = @\seebelownc{}@;
-
-private:
-  using container_node_type = @\unspecnc@;
-  using ator_traits         = allocator_traits<allocator_type>;
-  typename ator_traits::rebind_traits<container_node_type>::pointer ptr_;
-  optional<allocator_type> alloc_;
-
-public:
-  constexpr @\textit{node_handle}@() noexcept : ptr_(), alloc_() {}
-  ~@\textit{node_handle}@();
-  @\textit{node_handle}@(@\textit{node_handle}@&&) noexcept;
-  @\textit{node_handle}@& operator=(@\textit{node_handle}@&&);
-  value_type& value() const;    // Not present for map containers
-  key_type& key() const;        // Not present for set containers
-  mapped_type& mapped() const;  // Not present for set containers
-  allocator_type get_allocator() const;
-  explicit operator bool() const noexcept;
-  bool empty() const noexcept;
-  void swap(@\textit{node_handle}@&)
-    noexcept(ator_traits::propagate_on_container_swap::value ||
-             ator_traits::is_always_equal::value);
-  friend void swap(@\textit{node_handle}@& x, @\textit{node_handle}@& y) noexcept(noexcept(x.swap(y)))
-    { x.swap(y); }
-};
-\end{codeblock}
-
-\rSec3[container.node.cons]{\tcode{\textit{node_handle}} constructors, copy, and assignment}
-
-\begin{itemdecl}
-@\textit{node_handle}@(@\textit{node_handle}@&& nh) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects Constructs a \tcode{\textit{node_handle}} object initializing
-\tcode{ptr_} with \tcode{nh.ptr_}.  Move constructs \tcode{alloc_} with
-\tcode{nh.alloc_}.  Assigns \tcode{nullptr} to \tcode{nh.ptr_} and assigns
-\tcode{nullopt} to \tcode{nh.alloc_}.
-\end{itemdescr}
-
-\begin{itemdecl}
-@\textit{node_handle}@& operator=(@\textit{node_handle}@&& nh);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\requires Either \tcode{!alloc_}, or
-\tcode{ator_traits::propagate_on_container_move_assignment}
-is \tcode{true}, or \tcode{alloc_ ==  nh.alloc_}.
-
-\pnum
-\effects If \tcode{ptr_ != nullptr}, destroys the \tcode{value_type}
-subobject in the \tcode{container_node_type} object pointed to by \tcode{ptr_}
-by calling \tcode{ator_traits::destroy}, then deallocates \tcode{ptr_} by
-calling \tcode{ator_traits::rebind_traits<container_node_type>::deallocate}.
-Assigns \tcode{nh.ptr_} to \tcode{ptr_}.
-If \tcode{!alloc\textunderscore} or \tcode{ator_traits::propagate_on_container_move_assignment}
-is \tcode{true}, move assigns \tcode{nh.alloc_} to \tcode{alloc_}. Assigns
-\tcode{nullptr} to \tcode{nh.ptr_} and assigns \tcode{nullopt} to
-\tcode{nh.alloc_}.
-
-\pnum \returns \tcode{*this}.
-
-\pnum \throws Nothing.
-\end{itemdescr}
-
-\rSec3[container.node.dtor]{\tcode{\textit{node_handle}} destructor}
-
-\begin{itemdecl}
-~@\textit{node_handle}@();
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects If \tcode{ptr_ != nullptr}, destroys the \tcode{value_type} subobject
-in the \tcode{container_node_type} object pointed to by \tcode{ptr_} by calling
-\tcode{ator_traits::destroy}, then deallocates \tcode{ptr_} by calling
-\tcode{ator_traits::rebind_traits<container_node_type>::deallocate}.
-\end{itemdescr}
-
-\rSec3[container.node.observers]{\tcode{\textit{node_handle}} observers}
-
-\begin{itemdecl}
-value_type& value() const;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\requires \tcode{empty() == false}.
-
-\pnum
-\returns A reference to the \tcode{value_type} subobject in the
-\tcode{container_node_type} object pointed to by \tcode{ptr_}.
-
-\pnum
-\throws Nothing.
-\end{itemdescr}
-
-\begin{itemdecl}
-key_type& key() const;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\requires \tcode{empty() == false}.
-
-\pnum
-\returns A non-const reference to the \tcode{key_type} member of the
-\tcode{value_type} subobject in the \tcode{container_node_type} object
-pointed to by \tcode{ptr_}.
-
-\pnum
-\throws  Nothing.
-
-\pnum
-\remarks Modifying the key through the returned reference is permitted.
-\end{itemdescr}
-
-\begin{itemdecl}
-mapped_type& mapped() const;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\requires \tcode{empty() == false}.
-
-\pnum
-\returns A reference to the \tcode{mapped_type} member of the
-\tcode{value_type} subobject in the \tcode{container_node_type} object
-pointed to by \tcode{ptr_}.
-
-\pnum
-\throws  Nothing.
-\end{itemdescr}
-
-
-\begin{itemdecl}
-allocator_type get_allocator() const;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\requires \tcode{empty() == false}.
-
-\pnum
-\returns \tcode{*alloc_}.
-
-\pnum
-\throws Nothing.
-\end{itemdescr}
-
-\begin{itemdecl}
-explicit operator bool() const noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{ptr_ != nullptr}.
-\end{itemdescr}
-
-\begin{itemdecl}
-bool empty() const noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{ptr_ == nullptr}.
-\end{itemdescr}
-
-\rSec3[container.node.modifiers]{\tcode{\textit{node_handle}} modifiers}
-
-\begin{itemdecl}
-void swap(@\textit{node_handle}@& nh)
-  noexcept(ator_traits::propagate_on_container_swap::value ||
-           ator_traits::is_always_equal::value);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\requires \tcode{!alloc_}, or \tcode{!nh.alloc_}, or
-\tcode{ator_traits::propagate_on_container_swap} is \tcode{true},
-or \tcode{alloc_ == nh.alloc_}.
-
-\pnum
-\effects Calls \tcode{swap(ptr_, nh.ptr_)}. If \tcode{!alloc_}, or
-\tcode{!nh.alloc_}, or \tcode{ator_traits::propagate_on_container_swap}
-is \tcode{true} calls \tcode{swap(alloc_, nh.alloc_)}.
-\end{itemdescr}
-
 
 \rSec1[container.requirements]{Container requirements}%
 \indextext{requirements!container}
@@ -1426,6 +1178,256 @@ throws
 \tcode{out_of_range}
 if
 \tcode{n >= a.size()}.
+
+
+\rSec2[container.node]{Node handles}
+
+\rSec3[container.node.overview]{\tcode{node_handle} overview}
+
+\pnum
+A \term{node handle} is an object that accepts ownership of a single element
+from an associative container~(\ref{associative.reqmts}) or an unordered
+associative container~(\ref{unord.req}). It may be used to transfer that
+ownership to another container with compatible nodes.  Containers with
+compatible nodes have the same node handle type. Elements may be transferred in
+either direction between container types in the same row of
+Table~\ref{tab:containers.node.compat}.
+
+\begin{floattable}{Container types with compatible nodes}{tab:containers.node.compat}
+{ll}
+\topline
+\tcode{map<K, T, C1, A>}               & \tcode{map<K, T, C2, A>}                    \\
+\rowsep
+\tcode{map<K, T, C1, A>}               & \tcode{multimap<K, T, C2, A>}               \\
+\rowsep
+\tcode{set<K, C1, A>}                  & \tcode{set<K, C2, A>}                       \\
+\rowsep
+\tcode{set<K, C1, A>}                  & \tcode{multiset<K, C2, A>}                  \\
+\rowsep
+\tcode{unordered_map<K, T, H1, E1, A>} & \tcode{unordered_map<K, T, H2, E2, A>}      \\
+\rowsep
+\tcode{unordered_map<K, T, H1, E1, A>} & \tcode{unordered_multimap<K, T, H2, E2, A>} \\
+\rowsep
+\tcode{unordered_set<K, H1, E1, A>}    & \tcode{unordered_set<K, H2, E2, A>}         \\
+\rowsep
+\tcode{unordered_set<K, H1, E1, A>}    & \tcode{unordered_multiset<K, H2, E2, A>}    \\
+\end{floattable}
+
+\pnum
+If a node handle is not empty, then it contains an allocator that is equal to
+the allocator of the container when the element was extracted. If a node handle
+is empty, it contains no allocator.
+
+\pnum
+Class \tcode{\textit{node_handle}} is for exposition only. An implementation is
+permitted to provide equivalent functionality without providing a class with
+this name.
+
+\pnum
+If a user-defined specialization of \tcode{std::pair} exists for
+\tcode{pair<const Key, T>} or \tcode{pair<Key, T>}, where \tcode{Key} is the
+container's \tcode{key_type} and \tcode{T} is the container's
+\tcode{mapped_type}, the behavior of operations involving node handles is
+undefined.
+
+\begin{codeblock}
+template<@\unspecnc@>
+class @\textit{node_handle}@ {
+public:
+  // These type declarations are described in Tables \ref{tab:containers.associative.requirements} and \ref{tab:HashRequirements}
+  using value_type     = @\seebelownc{}@; // Not present for map containers
+  using key_type       = @\seebelownc{}@; // Not present for set containers
+  using mapped_type    = @\seebelownc{}@; // Not present for set containers
+  using allocator_type = @\seebelownc{}@;
+
+private:
+  using container_node_type = @\unspecnc@;
+  using ator_traits         = allocator_traits<allocator_type>;
+  typename ator_traits::rebind_traits<container_node_type>::pointer ptr_;
+  optional<allocator_type> alloc_;
+
+public:
+  constexpr @\textit{node_handle}@() noexcept : ptr_(), alloc_() {}
+  ~@\textit{node_handle}@();
+  @\textit{node_handle}@(@\textit{node_handle}@&&) noexcept;
+  @\textit{node_handle}@& operator=(@\textit{node_handle}@&&);
+  value_type& value() const;    // Not present for map containers
+  key_type& key() const;        // Not present for set containers
+  mapped_type& mapped() const;  // Not present for set containers
+  allocator_type get_allocator() const;
+  explicit operator bool() const noexcept;
+  bool empty() const noexcept;
+  void swap(@\textit{node_handle}@&)
+    noexcept(ator_traits::propagate_on_container_swap::value ||
+             ator_traits::is_always_equal::value);
+  friend void swap(@\textit{node_handle}@& x, @\textit{node_handle}@& y) noexcept(noexcept(x.swap(y)))
+    { x.swap(y); }
+};
+\end{codeblock}
+
+\rSec3[container.node.cons]{\tcode{\textit{node_handle}} constructors, copy, and assignment}
+
+\begin{itemdecl}
+@\textit{node_handle}@(@\textit{node_handle}@&& nh) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Constructs a \tcode{\textit{node_handle}} object initializing
+\tcode{ptr_} with \tcode{nh.ptr_}.  Move constructs \tcode{alloc_} with
+\tcode{nh.alloc_}.  Assigns \tcode{nullptr} to \tcode{nh.ptr_} and assigns
+\tcode{nullopt} to \tcode{nh.alloc_}.
+\end{itemdescr}
+
+\begin{itemdecl}
+@\textit{node_handle}@& operator=(@\textit{node_handle}@&& nh);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\requires Either \tcode{!alloc_}, or
+\tcode{ator_traits::propagate_on_container_move_assignment}
+is \tcode{true}, or \tcode{alloc_ ==  nh.alloc_}.
+
+\pnum
+\effects If \tcode{ptr_ != nullptr}, destroys the \tcode{value_type}
+subobject in the \tcode{container_node_type} object pointed to by \tcode{ptr_}
+by calling \tcode{ator_traits::destroy}, then deallocates \tcode{ptr_} by
+calling \tcode{ator_traits::rebind_traits<container_node_type>::deallocate}.
+Assigns \tcode{nh.ptr_} to \tcode{ptr_}.
+If \tcode{!alloc\textunderscore} or \tcode{ator_traits::propagate_on_container_move_assignment}
+is \tcode{true}, move assigns \tcode{nh.alloc_} to \tcode{alloc_}. Assigns
+\tcode{nullptr} to \tcode{nh.ptr_} and assigns \tcode{nullopt} to
+\tcode{nh.alloc_}.
+
+\pnum \returns \tcode{*this}.
+
+\pnum \throws Nothing.
+\end{itemdescr}
+
+\rSec3[container.node.dtor]{\tcode{\textit{node_handle}} destructor}
+
+\begin{itemdecl}
+~@\textit{node_handle}@();
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects If \tcode{ptr_ != nullptr}, destroys the \tcode{value_type} subobject
+in the \tcode{container_node_type} object pointed to by \tcode{ptr_} by calling
+\tcode{ator_traits::destroy}, then deallocates \tcode{ptr_} by calling
+\tcode{ator_traits::rebind_traits<container_node_type>::deallocate}.
+\end{itemdescr}
+
+\rSec3[container.node.observers]{\tcode{\textit{node_handle}} observers}
+
+\begin{itemdecl}
+value_type& value() const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\requires \tcode{empty() == false}.
+
+\pnum
+\returns A reference to the \tcode{value_type} subobject in the
+\tcode{container_node_type} object pointed to by \tcode{ptr_}.
+
+\pnum
+\throws Nothing.
+\end{itemdescr}
+
+\begin{itemdecl}
+key_type& key() const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\requires \tcode{empty() == false}.
+
+\pnum
+\returns A non-const reference to the \tcode{key_type} member of the
+\tcode{value_type} subobject in the \tcode{container_node_type} object
+pointed to by \tcode{ptr_}.
+
+\pnum
+\throws  Nothing.
+
+\pnum
+\remarks Modifying the key through the returned reference is permitted.
+\end{itemdescr}
+
+\begin{itemdecl}
+mapped_type& mapped() const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\requires \tcode{empty() == false}.
+
+\pnum
+\returns A reference to the \tcode{mapped_type} member of the
+\tcode{value_type} subobject in the \tcode{container_node_type} object
+pointed to by \tcode{ptr_}.
+
+\pnum
+\throws  Nothing.
+\end{itemdescr}
+
+
+\begin{itemdecl}
+allocator_type get_allocator() const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\requires \tcode{empty() == false}.
+
+\pnum
+\returns \tcode{*alloc_}.
+
+\pnum
+\throws Nothing.
+\end{itemdescr}
+
+\begin{itemdecl}
+explicit operator bool() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns \tcode{ptr_ != nullptr}.
+\end{itemdescr}
+
+\begin{itemdecl}
+bool empty() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns \tcode{ptr_ == nullptr}.
+\end{itemdescr}
+
+\rSec3[container.node.modifiers]{\tcode{\textit{node_handle}} modifiers}
+
+\begin{itemdecl}
+void swap(@\textit{node_handle}@& nh)
+  noexcept(ator_traits::propagate_on_container_swap::value ||
+           ator_traits::is_always_equal::value);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\requires \tcode{!alloc_}, or \tcode{!nh.alloc_}, or
+\tcode{ator_traits::propagate_on_container_swap} is \tcode{true},
+or \tcode{alloc_ == nh.alloc_}.
+
+\pnum
+\effects Calls \tcode{swap(ptr_, nh.ptr_)}. If \tcode{!alloc_}, or
+\tcode{!nh.alloc_}, or \tcode{ator_traits::propagate_on_container_swap}
+is \tcode{true} calls \tcode{swap(alloc_, nh.alloc_)}.
+\end{itemdescr}
+
 
 \rSec2[associative.reqmts]{Associative containers}
 


### PR DESCRIPTION
Resolves #842 