### PR TITLE
[intro.progress] Add missing impldef index entry for concurrent forward progress guarantees provided by threads of execution.

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -1524,7 +1524,7 @@ this will happen in an unspecified but finite amount of time.
 \end{note}
 
 \pnum
-It is implementation-defined whether the implementation-created thread of execution
+It is \impldef{concurrent forward progress guarantees provided by threads of execution} whether the implementation-created thread of execution
 that executes \tcode{main}~(\ref{basic.start.main}) and the threads of execution
 created by \tcode{std::thread}~(\ref{thread.thread.class}) provide concurrent forward
 progress guarantees.


### PR DESCRIPTION
Just an index entry, no visual change in the section itself.