### PR TITLE
[utilities] review of library index

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -311,6 +311,7 @@ for all \tcode{i} in the range \range{0}{N}.
 
 \rSec2[utility.exchange]{exchange}
 
+\indexlibrary{\idxcode{exchange}}%
 \begin{itemdecl}
 template <class T, class U=T> T exchange(T& obj, U&& new_val);
 \end{itemdecl}
@@ -620,7 +621,7 @@ be a \tcode{constexpr} function if and only if all required element-wise
 initializations for copy and move, respectively, would satisfy the
 requirements for a \tcode{constexpr} function.
 
-\indexlibrary{\idxcode{pair}!constructor}
+\indexlibrary{\idxcode{pair}!constructor}%
 \begin{itemdecl}
 constexpr pair();
 \end{itemdecl}
@@ -639,7 +640,7 @@ This constructor shall not participate in overload resolution unless
 with default template arguments. \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pair}!constructor}
+\indexlibrary{\idxcode{pair}!constructor}%
 \begin{itemdecl}
 @\EXPLICIT@ constexpr pair(const T1& x, const T2& y);
 \end{itemdecl}
@@ -659,7 +660,7 @@ The constructor is explicit if and only if
 \tcode{is_convertible_v<const second_type\&, second_type>} is \tcode{false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pair}!constructor}
+\indexlibrary{\idxcode{pair}!constructor}%
 \begin{itemdecl}
 template<class U, class V> @\EXPLICIT@ constexpr pair(U&& x, V&& y);
 \end{itemdecl}
@@ -681,7 +682,7 @@ The constructor is explicit if and only if
 \tcode{is_convertible_v<V\&\&, second_type>} is \tcode{false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pair}!constructor}
+\indexlibrary{\idxcode{pair}!constructor}%
 \begin{itemdecl}
 template<class U, class V> @\EXPLICIT@ constexpr pair(const pair<U, V>& p);
 \end{itemdecl}
@@ -700,7 +701,7 @@ The constructor is explicit if and only if
 \tcode{is_convertible_v<const V\&, second_type>} is \tcode{false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pair}!constructor}
+\indexlibrary{\idxcode{pair}!constructor}%
 \begin{itemdecl}
 template<class U, class V> @\EXPLICIT@ constexpr pair(pair<U, V>&& p);
 \end{itemdecl}
@@ -722,7 +723,7 @@ The constructor is explicit if and only if
 \tcode{is_convertible_v<V\&\&, second_type>} is \tcode{false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pair}!constructor}
+\indexlibrary{\idxcode{pair}!constructor}%
 \begin{itemdecl}
 template<class... Args1, class... Args2>
   pair(piecewise_construct_t,
@@ -851,7 +852,7 @@ is_nothrow_swappable_v<second_type>
 
 \rSec2[pairs.spec]{Specialized algorithms}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{pair}}%
+\indexlibrarymember{operator==}{pair}%
 \begin{itemdecl}
 template <class T1, class T2>
   constexpr bool operator==(const pair<T1, T2>& x, const pair<T1, T2>& y);
@@ -863,7 +864,7 @@ template <class T1, class T2>
 \tcode{x.first == y.first \&\& x.second == y.second}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{pair}}%
+\indexlibrarymember{operator<}{pair}%
 \begin{itemdecl}
 template <class T1, class T2>
   constexpr bool operator<(const pair<T1, T2>& x, const pair<T1, T2>& y);
@@ -875,7 +876,7 @@ template <class T1, class T2>
 \tcode{x.first < y.first || (!(y.first < x.first) \&\& x.second < y.second)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{pair}}%
+\indexlibrarymember{operator"!=}{pair}%
 \begin{itemdecl}
 template <class T1, class T2>
   constexpr bool operator!=(const pair<T1, T2>& x, const pair<T1, T2>& y);
@@ -886,7 +887,7 @@ template <class T1, class T2>
 \returns \tcode{!(x == y)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>}!\idxcode{pair}}%
+\indexlibrarymember{operator>}{pair}%
 \begin{itemdecl}
 template <class T1, class T2>
   constexpr bool operator>(const pair<T1, T2>& x, const pair<T1, T2>& y);
@@ -897,7 +898,7 @@ template <class T1, class T2>
 \returns \tcode{y < x}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{pair}}%
+\indexlibrarymember{operator>=}{pair}%
 \begin{itemdecl}
 template <class T1, class T2>
   constexpr bool operator>=(const pair<T1, T2>& x, const pair<T1, T2>& y);
@@ -908,7 +909,7 @@ template <class T1, class T2>
 \returns \tcode{!(x < y)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{pair}}%
+\indexlibrarymember{operator<=}{pair}%
 \begin{itemdecl}
 template <class T1, class T2>
   constexpr bool operator<=(const pair<T1, T2>& x, const pair<T1, T2>& y);
@@ -993,7 +994,7 @@ tuple_element<1, pair<T1, T2>>::type
 \pnum\textit{Value:} the type T2.
 \end{itemdescr}
 
-\indexlibrarymember{pair}{get}%
+\indexlibrarymember{get}{pair}%
 \begin{itemdecl}
 template<size_t I, class T1, class T2>
   constexpr tuple_element_t<I, pair<T1, T2>>&
@@ -1016,7 +1017,7 @@ if \tcode{I == 1} returns a reference to \tcode{p.second};
 otherwise the program is ill-formed.
 \end{itemdescr}
 
-\indexlibrarymember{pair}{get}%
+\indexlibrarymember{get}{pair}%
 \begin{itemdecl}
 template <class T, class U>
   constexpr T& get(pair<T, U>& p) noexcept;
@@ -1035,7 +1036,7 @@ template <class T, class U>
 \returns A reference to \tcode{p.first}.
 \end{itemdescr}
 
-\indexlibrarymember{pair}{get}%
+\indexlibrarymember{get}{pair}%
 \begin{itemdecl}
 template <class T, class U>
   constexpr T& get(pair<U, T>& p) noexcept;
@@ -1500,7 +1501,7 @@ In the function descriptions that follow, let $i$ be in the range \range{0}{size
 in order, $T_i$ be the $i^{th}$ type in \tcode{Types}, and $U_i$ be the $i^{th}$ type in a
 template parameter pack named \tcode{UTypes}, where indexing is zero-based.
 
-\indexlibrarymember{tuple}{operator=}%
+\indexlibrarymember{operator=}{tuple}%
 \begin{itemdecl}
 tuple& operator=(const tuple& u);
 \end{itemdecl}
@@ -1517,7 +1518,7 @@ element of \tcode{*this}.
 \returns  \tcode{*this}
 \end{itemdescr}
 
-\indexlibrarymember{tuple}{operator=}%
+\indexlibrarymember{operator=}{tuple}%
 \begin{itemdecl}
 tuple& operator=(tuple&& u) noexcept(@\seebelow@);
 \end{itemdecl}
@@ -1544,7 +1545,7 @@ where $T_i$ is the $i^{th}$ type in \tcode{Types}.
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{tuple}{operator=}%
+\indexlibrarymember{operator=}{tuple}%
 \begin{itemdecl}
 template <class... UTypes>
   tuple& operator=(const tuple<UTypes...>& u);
@@ -1564,7 +1565,7 @@ of \tcode{*this}.
 \returns  \tcode{*this}
 \end{itemdescr}
 
-\indexlibrarymember{tuple}{operator=}%
+\indexlibrarymember{operator=}{tuple}%
 \begin{itemdecl}
 template <class... UTypes>
   tuple& operator=(tuple<UTypes...>&& u);
@@ -1584,7 +1585,7 @@ template <class... UTypes>
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{tuple}{operator=}%
+\indexlibrarymember{operator=}{tuple}%
 \indexlibrary{\idxcode{pair}}%
 \begin{itemdecl}
 template <class U1, class U2> tuple& operator=(const pair<U1, U2>& u);
@@ -1605,7 +1606,7 @@ and \tcode{u.second} to the second element of \tcode{*this}.
 \returns  \tcode{*this}
 \end{itemdescr}
 
-\indexlibrarymember{tuple}{operator=}%
+\indexlibrarymember{operator=}{tuple}%
 \indexlibrary{\idxcode{pair}}%
 \begin{itemdecl}
 template <class U1, class U2> tuple& operator=(pair<U1, U2>&& u);
@@ -1881,6 +1882,7 @@ type of the \tcode{I}th element of \tcode{Types},
 where indexing is zero-based.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{tuple_size}}%
 \begin{itemdecl}
 template <class T> class tuple_size<const T>;
 template <class T> class tuple_size<volatile T>;
@@ -1902,6 +1904,7 @@ the three templates are available when either of the headers \tcode{<array>} or
 \tcode{<utility>} are included.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{tuple_element}}%
 \begin{itemdecl}
 template <size_t I, class T> class tuple_element<I, const T>;
 template <size_t I, class T> class tuple_element<I, volatile T>;
@@ -1932,7 +1935,7 @@ the three templates are available when either of the headers \tcode{<array>} or
 
 \rSec3[tuple.elem]{Element access}
 
-\indexlibrarymember{tuple}{get}%
+\indexlibrarymember{get}{tuple}%
 \begin{itemdecl}
 template <size_t I, class... Types>
   constexpr tuple_element_t<I, tuple<Types...>>& get(tuple<Types...>& t) noexcept;
@@ -1973,7 +1976,7 @@ for member variables of reference type.
 \end{note}
 \end{itemdescr}
 
-\indexlibrarymember{tuple}{get}%
+\indexlibrarymember{get}{tuple}%
 \begin{itemdecl}
 template <class T, class... Types>
   constexpr T& get(tuple<Types...>& t) noexcept;
@@ -2014,7 +2017,7 @@ the \tcode{template} keyword. \end{note}
 
 \rSec3[tuple.rel]{Relational operators}
 
-\indexlibrarymember{tuple}{operator==}%
+\indexlibrarymember{operator==}{tuple}%
 \begin{itemdecl}
 template<class... TTypes, class... UTypes>
   constexpr bool operator==(const tuple<TTypes...>& t, const tuple<UTypes...>& u);
@@ -2041,7 +2044,7 @@ performed after the first equality comparison that evaluates to
 \tcode{false}.
 \end{itemdescr}
 
-\indexlibrarymember{tuple}{operator<}%
+\indexlibrarymember{operator<}{tuple}%
 \begin{itemdecl}
 template<class... TTypes, class... UTypes>
   constexpr bool operator<(const tuple<TTypes...>& t, const tuple<UTypes...>& u);
@@ -2068,7 +2071,7 @@ of \tcode{r}.  For any two zero-length tuples \tcode{e}
 and \tcode{f}, \tcode{e < f} returns \tcode{false}.
 \end{itemdescr}
 
-\indexlibrarymember{tuple}{operator"!=}%
+\indexlibrarymember{operator"!=}{tuple}%
 \begin{itemdecl}
 template<class... TTypes, class... UTypes>
   constexpr bool operator!=(const tuple<TTypes...>& t, const tuple<UTypes...>& u);
@@ -2077,7 +2080,7 @@ template<class... TTypes, class... UTypes>
 \pnum\returns \tcode{!(t == u)}.
 \end{itemdescr}
 
-\indexlibrarymember{tuple}{operator>}%
+\indexlibrarymember{operator>}{tuple}%
 \begin{itemdecl}
 template<class... TTypes, class... UTypes>
   constexpr bool operator>(const tuple<TTypes...>& t, const tuple<UTypes...>& u);
@@ -2086,7 +2089,7 @@ template<class... TTypes, class... UTypes>
 \pnum\returns \tcode{u < t}.
 \end{itemdescr}
 
-\indexlibrarymember{tuple}{operator<=}%
+\indexlibrarymember{operator<=}{tuple}%
 \begin{itemdecl}
 template<class... TTypes, class... UTypes>
   constexpr bool operator<=(const tuple<TTypes...>& t, const tuple<UTypes...>& u);
@@ -2095,7 +2098,7 @@ template<class... TTypes, class... UTypes>
 \pnum\returns \tcode{!(u < t)}
 \end{itemdescr}
 
-\indexlibrarymember{tuple}{operator>=}%
+\indexlibrarymember{operator>=}{tuple}%
 \begin{itemdecl}
 template<class... TTypes, class... UTypes>
   constexpr bool operator>=(const tuple<TTypes...>& t, const tuple<UTypes...>& u);
@@ -2115,7 +2118,7 @@ result of the comparison. \end{note}
 
 \rSec3[tuple.traits]{Tuple traits}
 
-\indexlibrary{\idxcode{uses_allocator<tuple>}}
+\indexlibrary{\idxcode{uses_allocator<tuple>}}%
 \begin{itemdecl}
 template <class... Types, class Alloc>
   struct uses_allocator<tuple<Types...>, Alloc> : true_type { };
@@ -2337,6 +2340,7 @@ No contained value is initialized.
 For every object type \tcode{T} these constructors shall be \tcode{constexpr} constructors (\ref{dcl.constexpr}).
 \end{itemdescr}
 
+\indexlibrary{\idxcode{optional}!constructor}%
 \begin{itemdecl}
 optional(const optional<T>& rhs);
 \end{itemdecl}
@@ -2360,6 +2364,7 @@ direct-non-list-initializing an object of type \tcode{T} with the expression \tc
 Any exception thrown by the selected constructor of \tcode{T}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{optional}!constructor}%
 \begin{itemdecl}
 optional(optional<T>&& rhs) noexcept(@\seebelow@);
 \end{itemdecl}
@@ -2389,6 +2394,7 @@ The expression inside \tcode{noexcept} is equivalent to
 \tcode{is_nothrow_move_constructible_v<T>}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{optional}!constructor}%
 \begin{itemdecl}
 constexpr optional(const T& v);
 \end{itemdecl}
@@ -2415,6 +2421,7 @@ Any exception thrown by the selected constructor of \tcode{T}.
 If \tcode{T}'s selected constructor is a \tcode{constexpr} constructor, this constructor shall be a \tcode{constexpr} constructor.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{optional}!constructor}%
 \begin{itemdecl}
 constexpr optional(T&& v);
 \end{itemdecl}
@@ -2441,6 +2448,7 @@ Any exception thrown by the selected constructor of \tcode{T}.
 If \tcode{T}'s selected constructor is a \tcode{constexpr} constructor, this constructor shall be a \tcode{constexpr} constructor.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{optional}!constructor}%
 \begin{itemdecl}
 template <class... Args> constexpr explicit optional(in_place_t, Args&&... args);
 \end{itemdecl}
@@ -2467,6 +2475,7 @@ Any exception thrown by the selected constructor of \tcode{T}.
 If \tcode{T}'s constructor selected for the initialization is a \tcode{constexpr} constructor, this constructor shall be a \tcode{constexpr} constructor.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{optional}!constructor}%
 \begin{itemdecl}
 template <class U, class... Args>
   constexpr explicit optional(in_place_t, initializer_list<U> il, Args&&... args);
@@ -2515,7 +2524,7 @@ If \tcode{is_trivially_destructible_v<T> == true} then this destructor shall be 
 
 \rSec3[optional.object.assign]{Assignment}
 
-\indexlibrarymember{optional}{operator=}%
+\indexlibrarymember{operator=}{optional}%
 \begin{itemdecl}
 optional<T>& operator=(nullopt_t) noexcept;
 \end{itemdecl}
@@ -2534,6 +2543,7 @@ If \tcode{*this} contains a value, calls \tcode{val->T::\~T()} to destroy the co
 \tcode{*this} does not contain a value.
 \end{itemdescr}
 
+\indexlibrarymember{operator=}{optional}%
 \begin{itemdecl}
 optional<T>& operator=(const optional<T>& rhs);
 \end{itemdecl}
@@ -2576,6 +2586,7 @@ If an exception is thrown during the call to \tcode{T}'s copy assignment,
 the state of its contained value is as defined by the exception safety guarantee of \tcode{T}'s copy assignment.
 \end{itemdescr}
 
+\indexlibrarymember{operator=}{optional}%
 \begin{itemdecl}
 optional<T>& operator=(optional<T>&& rhs) noexcept(@\seebelow@);
 \end{itemdecl}
@@ -2626,6 +2637,7 @@ If an exception is thrown during the call to \tcode{T}'s move assignment,
 the state of \tcode{*val} and \tcode{*rhs.val} is determined by the exception safety guarantee of \tcode{T}'s move assignment.
 \end{itemdescr}
 
+\indexlibrarymember{operator=}{optional}%
 \begin{itemdecl}
 template <class U> optional<T>& operator=(U&& v);
 \end{itemdecl}
@@ -2685,6 +2697,7 @@ Any exception thrown by the selected constructor of \tcode{T}.
 If an exception is thrown during the call to \tcode{T}'s constructor, \tcode{*this} does not contain a value, and the previous \tcode{*val} (if any) has been destroyed.
 \end{itemdescr}
 
+\indexlibrarymember{emplace}{optional}%
 \begin{itemdecl}
 template <class U, class... Args> void emplace(initializer_list<U> il, Args&&... args);
 \end{itemdecl}
@@ -2710,7 +2723,7 @@ This function shall not participate in overload resolution unless \tcode{is_cons
 
 \rSec3[optional.object.swap]{Swap}
 
-\indexlibrarymember{optional}{swap}%
+\indexlibrarymember{swap}{optional}%
 \begin{itemdecl}
 void swap(optional<T>& rhs) noexcept(@\seebelow@);
 \end{itemdecl}
@@ -2762,7 +2775,7 @@ the state of \tcode{*val} and \tcode{*rhs.val} is determined by the exception sa
 
 \rSec3[optional.object.observe]{Observers}
 
-\indexlibrarymember{optional}{operator->}%
+\indexlibrarymember{operator->}{optional}%
 \begin{itemdecl}
 constexpr T const* operator->() const;
 constexpr T* operator->();
@@ -2786,7 +2799,7 @@ Nothing.
 Unless \tcode{T} is a user-defined type with overloaded unary \tcode{operator\&}, these functions shall be \tcode{constexpr} functions.
 \end{itemdescr}
 
-\indexlibrarymember{optional}{operator*}%
+\indexlibrarymember{operator*}{optional}%
 \begin{itemdecl}
 constexpr T const& operator*() const &;
 constexpr T& operator*() &;
@@ -2810,6 +2823,7 @@ Nothing.
 These functions shall be \tcode{constexpr} functions.
 \end{itemdescr}
 
+\indexlibrarymember{operator*}{optional}%
 \begin{itemdecl}
 constexpr T&& operator*() &&;
 constexpr const T&& operator*() const &&;
@@ -2825,7 +2839,7 @@ constexpr const T&& operator*() const &&;
 Equivalent to: \tcode{return std::move(*val);}
 \end{itemdescr}
 
-\indexlibrarymember{optional}{operator bool}%
+\indexlibrarymember{operator bool}{optional}%
 \begin{itemdecl}
 constexpr explicit operator bool() const noexcept;
 \end{itemdecl}
@@ -2840,6 +2854,7 @@ constexpr explicit operator bool() const noexcept;
 This function shall be a \tcode{constexpr} function.
 \end{itemdescr}
 
+\indexlibrarymember{has_value}{optional}%
 \begin{itemdecl}
 constexpr bool has_value() const noexcept;
 \end{itemdecl}
@@ -2852,7 +2867,7 @@ constexpr bool has_value() const noexcept;
 \remarks This function shall be a \tcode{constexpr} function.
 \end{itemdescr}
 
-\indexlibrarymember{optional}{value}%
+\indexlibrarymember{value}{optional}%
 \begin{itemdecl}
 constexpr T const& value() const &;
 constexpr T& value() &;
@@ -2867,6 +2882,7 @@ return bool(*this) ? *val : throw bad_optional_access();
 \end{codeblock}
 \end{itemdescr}
 
+\indexlibrarymember{value}{optional}%
 \begin{itemdecl}
 constexpr T&& value() &&;
 constexpr const T&& value() const &&;
@@ -2882,7 +2898,7 @@ return bool(*this) ? std::move(*val) : throw bad_optional_access();
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{optional}{value_or}%
+\indexlibrarymember{value_or}{optional}%
 \begin{itemdecl}
 template <class U> constexpr T value_or(U&& v) const &;
 \end{itemdecl}
@@ -2901,6 +2917,7 @@ If \tcode{is_copy_constructible_v<T> \&\& is_convertible_v<U\&\&, T>} is \tcode{
 the program is ill-formed.
 \end{itemdescr}
 
+\indexlibrarymember{value_or}{optional}%
 \begin{itemdecl}
 template <class U> constexpr T value_or(U&& v) &&;
 \end{itemdecl}
@@ -2921,6 +2938,7 @@ the program is ill-formed.
 
 \rSec3[optional.object.mod]{Modifiers}
 
+\indexlibrarymember{reset}{optional}%
 \begin{itemdecl}
 void reset() noexcept;
 \end{itemdecl}
@@ -2966,7 +2984,7 @@ public:
 The class \tcode{bad_optional_access} defines the type of objects thrown as exceptions to report the situation where an attempt is made to access the value of an optional object that does not contain a value.
 
 \indexlibrary{\idxcode{bad_optional_access}!constructor}%
-\indexlibrarymember{bad_optional_access}{what}%
+\indexlibrarymember{what}{bad_optional_access}%
 \begin{itemdecl}
 bad_optional_access();
 \end{itemdecl}
@@ -2985,7 +3003,7 @@ Constructs an object of class \tcode{bad_optional_access}.
 
 \rSec2[optional.relops]{Relational operators}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{optional}}%
+\indexlibrarymember{operator==}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator==(const optional<T>& x, const optional<T>& y);
 \end{itemdecl}
@@ -3008,7 +3026,7 @@ for which \tcode{*x == *y} is a core constant expression
 shall be \tcode{constexpr} functions.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{optional}}%
+\indexlibrarymember{operator"!=}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator!=(const optional<T>& x, const optional<T>& y);
 \end{itemdecl}
@@ -3032,7 +3050,7 @@ for which \tcode{*x != *y} is a core constant expression
 shall be constexpr functions.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{optional}}%
+\indexlibrarymember{operator<}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator<(const optional<T>& x, const optional<T>& y);
 \end{itemdecl}
@@ -3056,7 +3074,7 @@ for which \tcode{*x < *y} is a core constant expression
 shall be \tcode{constexpr} functions.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>}!\idxcode{optional}}%
+\indexlibrarymember{operator>}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator>(const optional<T>& x, const optional<T>& y);
 \end{itemdecl}
@@ -3080,7 +3098,7 @@ for which \tcode{*x > *y} is a core constant expression
 shall be constexpr functions.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{optional}}%
+\indexlibrarymember{operator<=}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator<=(const optional<T>& x, const optional<T>& y);
 \end{itemdecl}
@@ -3104,7 +3122,7 @@ for which \tcode{*x <= *y} is a core constant expression
 shall be constexpr functions.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{optional}}%
+\indexlibrarymember{operator>=}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator>=(const optional<T>& x, const optional<T>& y);
 \end{itemdecl}
@@ -3130,7 +3148,7 @@ shall be constexpr functions.
 
 \rSec2[optional.nullops]{Comparison with \tcode{nullopt}}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{optional}}%
+\indexlibrarymember{operator==}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator==(const optional<T>& x, nullopt_t) noexcept;
 template <class T> constexpr bool operator==(nullopt_t, const optional<T>& x) noexcept;
@@ -3142,7 +3160,7 @@ template <class T> constexpr bool operator==(nullopt_t, const optional<T>& x) no
 \tcode{!x}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{optional}}%
+\indexlibrarymember{operator"!=}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator!=(const optional<T>& x, nullopt_t) noexcept;
 template <class T> constexpr bool operator!=(nullopt_t, const optional<T>& x) noexcept;
@@ -3154,7 +3172,7 @@ template <class T> constexpr bool operator!=(nullopt_t, const optional<T>& x) no
 \tcode{bool(x)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{optional}}%
+\indexlibrarymember{operator<}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator<(const optional<T>& x, nullopt_t) noexcept;
 \end{itemdecl}
@@ -3165,6 +3183,7 @@ template <class T> constexpr bool operator<(const optional<T>& x, nullopt_t) noe
 \tcode{false}.
 \end{itemdescr}
 
+\indexlibrarymember{operator<}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator<(nullopt_t, const optional<T>& x) noexcept;
 \end{itemdecl}
@@ -3175,7 +3194,7 @@ template <class T> constexpr bool operator<(nullopt_t, const optional<T>& x) noe
 \tcode{bool(x)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{optional}}%
+\indexlibrarymember{operator<=}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator<=(const optional<T>& x, nullopt_t) noexcept;
 \end{itemdecl}
@@ -3186,6 +3205,7 @@ template <class T> constexpr bool operator<=(const optional<T>& x, nullopt_t) no
 \tcode{!x}.
 \end{itemdescr}
 
+\indexlibrarymember{operator<=}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator<=(nullopt_t, const optional<T>& x) noexcept;
 \end{itemdecl}
@@ -3196,7 +3216,7 @@ template <class T> constexpr bool operator<=(nullopt_t, const optional<T>& x) no
 \tcode{true}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>}!\idxcode{optional}}%
+\indexlibrarymember{operator>}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator>(const optional<T>& x, nullopt_t) noexcept;
 \end{itemdecl}
@@ -3207,6 +3227,7 @@ template <class T> constexpr bool operator>(const optional<T>& x, nullopt_t) noe
 \tcode{bool(x)}.
 \end{itemdescr}
 
+\indexlibrarymember{operator>}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator>(nullopt_t, const optional<T>& x) noexcept;
 \end{itemdecl}
@@ -3217,7 +3238,7 @@ template <class T> constexpr bool operator>(nullopt_t, const optional<T>& x) noe
 \tcode{false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{optional}}%
+\indexlibrarymember{operator>=}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator>=(const optional<T>& x, nullopt_t) noexcept;
 \end{itemdecl}
@@ -3228,7 +3249,7 @@ template <class T> constexpr bool operator>=(const optional<T>& x, nullopt_t) no
 \tcode{true}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{optional}}%
+\indexlibrarymember{operator>=}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator>=(nullopt_t, const optional<T>& x) noexcept;
 \end{itemdecl}
@@ -3241,7 +3262,7 @@ template <class T> constexpr bool operator>=(nullopt_t, const optional<T>& x) no
 
 \rSec2[optional.comp_with_t]{Comparison with \tcode{T}}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{optional}}%
+\indexlibrarymember{operator==}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator==(const optional<T>& x, const T& v);
 \end{itemdecl}
@@ -3252,7 +3273,7 @@ template <class T> constexpr bool operator==(const optional<T>& x, const T& v);
 Equivalent to: \tcode{return bool(x) ? *x == v : false;}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{optional}}%
+\indexlibrarymember{operator==}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator==(const T& v, const optional<T>& x);
 \end{itemdecl}
@@ -3263,7 +3284,7 @@ template <class T> constexpr bool operator==(const T& v, const optional<T>& x);
 Equivalent to: \tcode{return bool(x) ? v == *x : false;}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{optional}}%
+\indexlibrarymember{operator"!=}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator!=(const optional<T>& x, const T& v);
 \end{itemdecl}
@@ -3274,7 +3295,7 @@ template <class T> constexpr bool operator!=(const optional<T>& x, const T& v);
 Equivalent to: \tcode{return bool(x) ? *x != v : true;}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{optional}}%
+\indexlibrarymember{operator"!=}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator!=(const T& v, const optional<T>& x);
 \end{itemdecl}
@@ -3285,7 +3306,7 @@ template <class T> constexpr bool operator!=(const T& v, const optional<T>& x);
 Equivalent to: \tcode{return bool(x) ? v != *x : true;}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{optional}}%
+\indexlibrarymember{operator<}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator<(const optional<T>& x, const T& v);
 \end{itemdecl}
@@ -3296,7 +3317,7 @@ template <class T> constexpr bool operator<(const optional<T>& x, const T& v);
 Equivalent to: \tcode{return bool(x) ? *x < v : true;}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{optional}}%
+\indexlibrarymember{operator<}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator<(const T& v, const optional<T>& x);
 \end{itemdecl}
@@ -3307,7 +3328,7 @@ template <class T> constexpr bool operator<(const T& v, const optional<T>& x);
 Equivalent to: \tcode{return bool(x) ? v < *x : false;}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{optional}}%
+\indexlibrarymember{operator<=}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator<=(const optional<T>& x, const T& v);
 \end{itemdecl}
@@ -3318,7 +3339,7 @@ template <class T> constexpr bool operator<=(const optional<T>& x, const T& v);
 Equivalent to: \tcode{return bool(x) ? *x <= v : true;}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{optional}}%
+\indexlibrarymember{operator<=}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator<=(const T& v, const optional<T>& x);
 \end{itemdecl}
@@ -3329,7 +3350,7 @@ template <class T> constexpr bool operator<=(const T& v, const optional<T>& x);
 Equivalent to: \tcode{return bool(x) ? v <= *x : false;}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>}!\idxcode{optional}}%
+\indexlibrarymember{operator>}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator>(const optional<T>& x, const T& v);
 \end{itemdecl}
@@ -3340,7 +3361,7 @@ template <class T> constexpr bool operator>(const optional<T>& x, const T& v);
 Equivalent to: \tcode{return bool(x) ? *x > v : false;}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>}!\idxcode{optional}}%
+\indexlibrarymember{operator>}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator>(const T& v, const optional<T>& x);
 \end{itemdecl}
@@ -3351,7 +3372,7 @@ template <class T> constexpr bool operator>(const T& v, const optional<T>& x);
 Equivalent to: \tcode{return bool(x) ? v > *x : true;}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{optional}}%
+\indexlibrarymember{operator>=}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator>=(const optional<T>& x, const T& v);
 \end{itemdecl}
@@ -3362,7 +3383,7 @@ template <class T> constexpr bool operator>=(const optional<T>& x, const T& v);
 Equivalent to: \tcode{return bool(x) ? *x >= v : false;}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{optional}}%
+\indexlibrarymember{operator>=}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator>=(const T& v, const optional<T>& x);
 \end{itemdecl}
@@ -3398,6 +3419,7 @@ template <class T> constexpr optional<decay_t<T>> make_optional(T&& v);
 \tcode{optional<decay_t<T>>(std::forward<T>(v))}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{make_optional}}%
 \begin{itemdecl}
 template <class T, class...Args>
   constexpr optional<T> make_optional(Args&&... args);
@@ -3408,6 +3430,7 @@ template <class T, class...Args>
 \effects Equivalent to: \tcode{return optional<T>(in_place, std::forward<Args>(args)...);}
 \end{itemdescr}
 
+\indexlibrary{\idxcode{make_optional}}%
 \begin{itemdecl}
 template <class T, class U, class... Args>
   constexpr optional<T> make_optional(initializer_list<U> il, Args&&... args);
@@ -3956,7 +3979,7 @@ then this destructor shall be a trivial destructor.
 
 \rSec3[variant.assign]{Assignment}
 
-\indexlibrarymember{variant}{operator=}%
+\indexlibrarymember{operator=}{variant}%
 \begin{itemdecl}
 variant& operator=(const variant& rhs);
 \end{itemdecl}
@@ -4002,7 +4025,7 @@ If an exception is thrown during the call to $T_j$'s move construction,
 the \tcode{variant} will hold no value.
 \end{itemdescr}
 
-\indexlibrarymember{variant}{operator=}%
+\indexlibrarymember{operator=}{variant}%
 \begin{itemdecl}
 variant& operator=(variant&& rhs) noexcept(@\seebelow@);
 \end{itemdecl}
@@ -4043,7 +4066,7 @@ the state of the contained value is as defined by the exception safety
 guarantee of $T_j$'s move assignment; \tcode{index()} will be $j$.
 \end{itemdescr}
 
-\indexlibrarymember{variant}{operator=}%
+\indexlibrarymember{operator=}{variant}%
 \begin{itemdecl}
 template <class T> variant& operator=(T&& t) noexcept(@\seebelow@);
 \end{itemdecl}
@@ -4105,7 +4128,7 @@ the \tcode{variant} object might not hold a value.
 
 \rSec3[variant.mod]{Modifiers}
 
-\indexlibrarymember{variant}{emplace}%
+\indexlibrarymember{emplace}{variant}%
 \begin{itemdecl}
 template <class T, class... Args> void emplace(Args&&... args);
 \end{itemdecl}
@@ -4123,7 +4146,7 @@ This function shall not participate in overload resolution unless
 exactly once in \tcode{Types...}.
 \end{itemdescr}
 
-\indexlibrarymember{variant}{emplace}%
+\indexlibrarymember{emplace}{variant}%
 \begin{itemdecl}
 template <class T, class U, class... Args> void emplace(initializer_list<U> il, Args&&... args);
 \end{itemdecl}
@@ -4141,7 +4164,7 @@ This function shall not participate in overload resolution unless
 and \tcode{T} occurs exactly once in \tcode{Types...}.
 \end{itemdescr}
 
-\indexlibrarymember{variant}{emplace}%
+\indexlibrarymember{emplace}{variant}%
 \begin{itemdecl}
 template <size_t I, class... Args> void emplace(Args&&... args);
 \end{itemdecl}
@@ -4174,7 +4197,7 @@ If an exception is thrown during the initialization of the contained value,
 the \tcode{variant} might not hold a value.
 \end{itemdescr}
 
-\indexlibrarymember{variant}{emplace}%
+\indexlibrarymember{emplace}{variant}%
 \begin{itemdecl}
 template <size_t I, class U, class... Args> void emplace(initializer_list<U> il, Args&&... args);
 \end{itemdecl}
@@ -4209,7 +4232,7 @@ the \tcode{variant} might not hold a value.
 
 \rSec3[variant.status]{Value status}
 
-\indexlibrarymember{variant}{valueless_by_exception}%
+\indexlibrarymember{valueless_by_exception}{variant}%
 \begin{itemdecl}
 constexpr bool valueless_by_exception() const noexcept;
 \end{itemdecl}
@@ -4233,7 +4256,7 @@ v.emplace<1>(S());
 \end{note}
 \end{itemdescr}
 
-\indexlibrarymember{variant}{index}%
+\indexlibrarymember{index}{variant}%
 \begin{itemdecl}
 constexpr size_t index() const noexcept;
 \end{itemdecl}
@@ -4247,7 +4270,7 @@ Otherwise, returns the zero-based index of the alternative of the contained valu
 
 \rSec3[variant.swap]{Swap}
 
-\indexlibrarymember{variant}{swap}%
+\indexlibrarymember{swap}{variant}%
 \begin{itemdecl}
 void swap(variant& rhs) noexcept(@\seebelow@);
 \end{itemdecl}
@@ -4420,7 +4443,7 @@ Otherwise, throws an exception of type \tcode{bad_variant_access}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{get_if}}%
-\indexlibrary{\idxcode{variant}!\idxcode{get_if}}
+\indexlibrary{\idxcode{variant}!\idxcode{get_if}}%
 \begin{itemdecl}
 template <size_t I, class... Types>
   constexpr add_pointer_t<variant_alternative_t<I, variant<Types...>>>
@@ -4443,7 +4466,7 @@ and \tcode{v->index() == I}. Otherwise, returns \tcode{nullptr}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{get_if}}%
-\indexlibrary{\idxcode{variant}!\idxcode{get_if}}
+\indexlibrary{\idxcode{variant}!\idxcode{get_if}}%
 \begin{itemdecl}
 template <class T, class... Types>
   constexpr add_pointer_t<T> get_if(variant<Types...>* v) noexcept;
@@ -4465,7 +4488,7 @@ index of \tcode{T} in \tcode{Types...}.
 
 \rSec2[variant.relops]{Relational operators}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{variant}}%
+\indexlibrarymember{operator==}{variant}%
 \begin{itemdecl}
 template <class... Types>
   constexpr bool operator==(const variant<Types...>& v, const variant<Types...>& w);
@@ -4484,7 +4507,7 @@ otherwise if \tcode{v.valueless_by_exception()}, \tcode{true};
 otherwise \tcode{get<$i$>(v) == get<$i$>(w)} with $i$ being \tcode{v.index()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{variant}}%
+\indexlibrarymember{operator"!=}{variant}%
 \begin{itemdecl}
 template <class... Types>
   constexpr bool operator!=(const variant<Types...>& v, const variant<Types...>& w);
@@ -4503,7 +4526,7 @@ otherwise if \tcode{v.valueless_by_exception()}, \tcode{false};
 otherwise \tcode{get<$i$>(v) != get<$i$>(w)} with $i$ being \tcode{v.index()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{variant}}%
+\indexlibrarymember{operator<}{variant}%
 \begin{itemdecl}
 template <class... Types>
   constexpr bool operator<(const variant<Types...>& v, const variant<Types...>& w);
@@ -4524,7 +4547,7 @@ otherwise if \tcode{v.index() > w.index()}, \tcode{false};
 otherwise \tcode{get<$i$>(v) < get<$i$>(w)} with $i$ being \tcode{v.index()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>}!\idxcode{variant}}%
+\indexlibrarymember{operator>}{variant}%
 \begin{itemdecl}
 template <class... Types>
   constexpr bool operator>(const variant<Types...>& v, const variant<Types...>& w);
@@ -4545,7 +4568,7 @@ otherwise if \tcode{v.index() < w.index()}, \tcode{false};
 otherwise \tcode{get<$i$>(v) > get<$i$>(w)} with $i$ being \tcode{v.index()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{variant}}%
+\indexlibrarymember{operator<=}{variant}%
 \begin{itemdecl}
 template <class... Types>
   constexpr bool operator<=(const variant<Types...>& v, const variant<Types...>& w);
@@ -4566,7 +4589,7 @@ otherwise if \tcode{v.index() > w.index()}, \tcode{false};
 otherwise \tcode{get<$i$>(v) <= get<$i$>(w)} with $i$ being \tcode{v.index()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{variant}}%
+\indexlibrarymember{operator>=}{variant}%
 \begin{itemdecl}
 template <class... Types>
   constexpr bool operator>=(const variant<Types...>& v, const variant<Types...>& w);
@@ -4661,6 +4684,7 @@ constexpr bool operator!=(monostate, monostate) noexcept { return false; }
 
 \rSec2[variant.specalg]{Specialized algorithms}
 
+\indexlibrary{\idxcode{swap}!\idxcode{variant}}%
 \begin{itemdecl}
 template <class... Types> void swap(variant<Types...>& v, variant<Types...>& w) noexcept(@\seebelow@);
 \end{itemdecl}
@@ -4688,6 +4712,7 @@ public:
 Objects of type \tcode{bad_variant_access} are thrown to report invalid
 accesses to the value of a \tcode{variant} object.
 
+\indexlibrary{\idxcode{bad_variant_access}!constructor}%
 \begin{itemdecl}
 bad_variant_access() noexcept;
 \end{itemdecl}
@@ -4697,6 +4722,7 @@ bad_variant_access() noexcept;
 Constructs a \tcode{bad_variant_access} object.
 \end{itemdescr}
 
+\indexlibrarymember{what}{bad_variant_access}%
 \begin{itemdecl}
 const char* what() const noexcept override;
 \end{itemdecl}
@@ -4765,6 +4791,7 @@ i.e. \tcode{5} is held strictly as an \tcode{int} and is not implicitly converti
 This indifference to interpretation but awareness of type effectively allows safe, generic containers of single values, with no scope for surprises from ambiguous conversions.
 \end{note}
 
+\indexlibrary{\idxhdr{any}}%
 \rSec2[any.synop]{Header \tcode{<any>} synopsis}
 
 \begin{codeblock}
@@ -4872,7 +4899,7 @@ Such small-object optimization shall only be applied to types \tcode{T} for whic
 
 \rSec3[any.cons]{Construction and destruction}
 
-\indexlibrary{\idxcode{any}!constructor}
+\indexlibrary{\idxcode{any}!constructor}%
 \begin{itemdecl}
 constexpr any() noexcept;
 \end{itemdecl}
@@ -4883,6 +4910,7 @@ constexpr any() noexcept;
 \tcode{has_value()} is \tcode{false}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{any}!constructor}%
 \begin{itemdecl}
 any(const any& other);
 \end{itemdecl}
@@ -4897,6 +4925,7 @@ Constructs an object of type \tcode{any} with an equivalent state as \tcode{othe
 Any exceptions arising from calling the selected constructor of the contained object.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{any}!constructor}%
 \begin{itemdecl}
 any(any&& other) noexcept;
 \end{itemdecl}
@@ -4911,6 +4940,7 @@ Constructs an object of type \tcode{any} with a state equivalent to the original
 \tcode{other} is left in a valid but otherwise unspecified state.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{any}!constructor}%
 \begin{itemdecl}
 template<class ValueType>
 any(ValueType&& value);
@@ -4938,6 +4968,7 @@ This constructor shall not participate in overload resolution if \tcode{decay_t<
 Any exception thrown by the selected constructor of \tcode{T}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{any}!constructor}%
 \begin{itemdecl}
 template <class T, class... Args>
   explicit any(in_place_type_t<T>, Args&&... args);
@@ -4958,6 +4989,7 @@ type \tcode{T} with the arguments \tcode{std::forward<Args>(args)...}.
 \throws Any exception thrown by the selected constructor of \tcode{T}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{any}!constructor}%
 \begin{itemdecl}
 template <class T, class U, class... Args>
   explicit any(in_place_type_t<T>, initializer_list<U> il, Args&&... args);
@@ -4995,7 +5027,7 @@ As if by \tcode{reset()}.
 
 \rSec3[any.assign]{Assignment}
 
-\indexlibrarymember{any}{operator=}%
+\indexlibrarymember{operator=}{any}%
 \begin{itemdecl}
 any& operator=(const any& rhs);
 \end{itemdecl}
@@ -5015,6 +5047,7 @@ No effects if an exception is thrown.
 Any exceptions arising from the copy constructor of the contained object.
 \end{itemdescr}
 
+\indexlibrarymember{operator=}{any}%
 \begin{itemdecl}
 any& operator=(any&& rhs) noexcept;
 \end{itemdecl}
@@ -5034,6 +5067,7 @@ The state of \tcode{*this} is equivalent to the original state of \tcode{rhs}
 and \tcode{rhs} is left in a valid but otherwise unspecified state.
 \end{itemdescr}
 
+\indexlibrarymember{operator=}{any}%
 \begin{itemdecl}
 template<class ValueType>
 any& operator=(ValueType&& rhs);
@@ -5068,6 +5102,7 @@ Any exception thrown by the selected constructor of \tcode{T}.
 
 \rSec3[any.modifiers]{Modifiers}
 
+\indexlibrarymember{emplace}{any}%
 \begin{itemdecl}
 template <class T, class... Args>
   void emplace(Args&&... args);
@@ -5094,6 +5129,7 @@ an object of type \tcode{T} with the arguments \tcode{std::forward<Args>(args)..
 has been destroyed.
 \end{itemdescr}
 
+\indexlibrarymember{emplace}{any}%
 \begin{itemdecl}
 template <class T, class U, class... Args>
   void emplace(initializer_list<U> il, Args&&... args);
@@ -5119,7 +5155,7 @@ The function shall not participate in overload resolution unless
 \tcode{is_constructible_v<T, initializer_list<U>\&, Args...>} is \tcode{true}.
 \end{itemdescr}
 
-\indexlibrarymember{any}{clear}%
+\indexlibrarymember{reset}{any}%
 \begin{itemdecl}
 void reset() noexcept;
 \end{itemdecl}
@@ -5134,7 +5170,7 @@ If \tcode{has_value()} is \tcode{true}, destroys the contained object.
 \tcode{has_value()} is \tcode{false}.
 \end{itemdescr}
 
-\indexlibrarymember{any}{swap}%
+\indexlibrarymember{swap}{any}%
 \begin{itemdecl}
 void swap(any& rhs) noexcept;
 \end{itemdecl}
@@ -5148,7 +5184,7 @@ Exchanges the states of \tcode{*this} and \tcode{rhs}.
 
 \rSec3[any.observers]{Observers}
 
-\indexlibrarymember{any}{empty}%
+\indexlibrarymember{has_value}{any}%
 \begin{itemdecl}
 bool has_value() const noexcept;
 \end{itemdecl}
@@ -5159,7 +5195,7 @@ bool has_value() const noexcept;
 \tcode{true} if \tcode{*this} contains an object, otherwise \tcode{false}.
 \end{itemdescr}
 
-\indexlibrarymember{any}{type}%
+\indexlibrarymember{type}{any}%
 \begin{itemdecl}
 const type_info& type() const noexcept;
 \end{itemdecl}
@@ -5178,7 +5214,7 @@ Useful for querying against types known either at compile time or only at runtim
 
 \rSec2[any.nonmembers]{Non-member functions}
 
-\indexlibrary{\idxcode{swap}!\idxcode{any}}
+\indexlibrary{\idxcode{swap}!\idxcode{any}}%
 \begin{itemdecl}
 void swap(any& x, any& y) noexcept;
 \end{itemdecl}
@@ -5213,7 +5249,7 @@ template <class T, class U, class ...Args>
 Equivalent to: \tcode{return any(in_place<T>, il, std::forward<Args>(args)...);}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{any_cast}}
+\indexlibrary{\idxcode{any_cast}}%
 \begin{itemdecl}
 template<class ValueType>
   ValueType any_cast(const any& operand);
@@ -5268,6 +5304,7 @@ any_cast<string&>(y);                       // error; cannot
 \end{example}
 \end{itemdescr}
 
+\indexlibrary{\idxcode{any_cast}}%
 \begin{itemdecl}
 template<class ValueType>
   const ValueType* any_cast(const any* operand) noexcept;
@@ -5293,10 +5330,10 @@ bool is_string(const any& operand) {
 \end{itemdescr}
 
 \rSec1[template.bitset]{Class template \tcode{bitset}}%
-\indexlibrary{\idxcode{bitset}}
+\indexlibrary{\idxcode{bitset}}%
 
 \synopsis{Header \tcode{<bitset>} synopsis}%
-\indexlibrary{\idxhdr{bitset}}
+\indexlibrary{\idxhdr{bitset}}%
 
 \begin{codeblock}
 #include <string>
@@ -5328,6 +5365,7 @@ class template
 and several related functions for representing
 and manipulating fixed-size sequences of bits.
 
+\indexlibrary{\idxcode{bitset}}%
 \begin{codeblock}
 namespace std {
   template<size_t N> class bitset {
@@ -5467,7 +5505,7 @@ Constructs an object of class
 initializing all bits to zero.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{bitset}!constructor}
+\indexlibrary{\idxcode{bitset}!constructor}%
 \begin{itemdecl}
 constexpr bitset(unsigned long long val) noexcept;
 \end{itemdecl}
@@ -5484,7 +5522,7 @@ representation~(\ref{basic.types}) of \tcode{unsigned long long}.
 If \tcode{M < N}, the remaining bit positions are initialized to zero.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{bitset}!constructor}
+\indexlibrary{\idxcode{bitset}!constructor}%
 \begin{itemdecl}
 template <class charT, class traits, class Allocator>
 explicit
@@ -5539,7 +5577,7 @@ Subsequent decreasing character positions correspond to increasing bit positions
 If \tcode{M < N}, remaining bit positions are initialized to zero.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{bitset}!constructor}
+\indexlibrary{\idxcode{bitset}!constructor}%
 \begin{itemdecl}
 template <class charT>
   explicit bitset(
@@ -5564,7 +5602,7 @@ bitset(
 
 \rSec2[bitset.members]{\tcode{bitset} members}
 
-\indexlibrary{\idxcode{operator\&=}!\idxcode{bitset}}%
+\indexlibrarymember{operator\&=}{bitset}%
 \begin{itemdecl}
 bitset<N>& operator&=(const bitset<N>& rhs) noexcept;
 \end{itemdecl}
@@ -5581,7 +5619,7 @@ for which the corresponding bit in \tcode{rhs} is clear, and leaves all other bi
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"|=}!\idxcode{bitset}}%
+\indexlibrarymember{operator"|=}{bitset}%
 \begin{itemdecl}
 bitset<N>& operator|=(const bitset<N>& rhs) noexcept;
 \end{itemdecl}
@@ -5598,7 +5636,7 @@ for which the corresponding bit in \tcode{rhs} is set, and leaves all other bits
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\^{}=}!\idxcode{bitset}}%
+\indexlibrarymember{operator\^{}=}{bitset}%
 \begin{itemdecl}
 bitset<N>& operator^=(const bitset<N>& rhs) noexcept;
 \end{itemdecl}
@@ -5741,7 +5779,7 @@ Resets the bit at position \tcode{pos} in
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\~{}}!\idxcode{bitset}}%
+\indexlibrarymember{operator\~{}}{bitset}%
 \begin{itemdecl}
 bitset<N> operator~() const noexcept;
 \end{itemdecl}
@@ -5759,7 +5797,7 @@ and initializes it with
 \tcode{x.flip()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{flip}!\idxcode{bitset}}%
+\indexlibrarymember{flip}{bitset}%
 \begin{itemdecl}
 bitset<N>& flip() noexcept;
 \end{itemdecl}
@@ -5797,7 +5835,7 @@ Toggles the bit at position \tcode{pos} in
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{to_ulong}!\idxcode{bitset}}%
+\indexlibrarymember{to_ulong}{bitset}%
 \begin{itemdecl}
 unsigned long to_ulong() const;
 \end{itemdecl}
@@ -5817,7 +5855,7 @@ cannot be represented as type
 \tcode{x}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{to_ullong}!\idxcode{bitset}}%
+\indexlibrarymember{to_ullong}{bitset}%
 \begin{itemdecl}
 unsigned long long to_ullong() const;
 \end{itemdecl}
@@ -5837,7 +5875,7 @@ cannot be represented as type
 \tcode{x}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{to_string}!\idxcode{bitset}}%
+\indexlibrarymember{to_string}{bitset}%
 \begin{itemdecl}
 template <class charT = char,
     class traits = char_traits<charT>,
@@ -5865,7 +5903,7 @@ bit value one becomes the character
 The created object.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{count}!\idxcode{bitset}}%
+\indexlibrarymember{count}{bitset}%
 \begin{itemdecl}
 size_t count() const noexcept;
 \end{itemdecl}
@@ -5877,7 +5915,7 @@ A count of the number of bits set in
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{size}!\idxcode{bitset}}%
+\indexlibrarymember{size}{bitset}%
 \begin{itemdecl}
 constexpr size_t size() const noexcept;
 \end{itemdecl}
@@ -5888,7 +5926,7 @@ constexpr size_t size() const noexcept;
 \tcode{N}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{bitset}}%
+\indexlibrarymember{operator==}{bitset}%
 \begin{itemdecl}
 bool operator==(const bitset<N>& rhs) const noexcept;
 \end{itemdecl}
@@ -5901,7 +5939,7 @@ bool operator==(const bitset<N>& rhs) const noexcept;
 equals the value of the corresponding bit in \tcode{rhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{bitset}}%
+\indexlibrarymember{operator"!=}{bitset}%
 \begin{itemdecl}
 bool operator!=(const bitset<N>& rhs) const noexcept;
 \end{itemdecl}
@@ -5913,7 +5951,7 @@ bool operator!=(const bitset<N>& rhs) const noexcept;
 \tcode{!(*this == rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{test}!\idxcode{bitset}}%
+\indexlibrarymember{test}{bitset}%
 \begin{itemdecl}
 bool test(size_t pos) const;
 \end{itemdecl}
@@ -5934,7 +5972,7 @@ in
 has the value one.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{all}!\idxcode{bitset}}%
+\indexlibrarymember{all}{bitset}%
 \begin{itemdecl}
 bool all() const noexcept;
 \end{itemdecl}
@@ -5944,7 +5982,7 @@ bool all() const noexcept;
 \returns \tcode{count() == size()}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{any}!\idxcode{bitset}}%
+\indexlibrarymember{any}{bitset}%
 \begin{itemdecl}
 bool any() const noexcept;
 \end{itemdecl}
@@ -5954,7 +5992,7 @@ bool any() const noexcept;
 \returns \tcode{count() != 0}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{none}!\idxcode{bitset}}%
+\indexlibrarymember{none}{bitset}%
 \begin{itemdecl}
 bool none() const noexcept;
 \end{itemdecl}
@@ -6051,7 +6089,7 @@ template <size_t N> struct hash<bitset<N>>;
 
 \rSec2[bitset.operators]{\tcode{bitset} operators}
 
-\indexlibrary{\idxcode{operator\&}!\idxcode{bitset}}%
+\indexlibrarymember{operator\&}{bitset}%
 \begin{itemdecl}
 bitset<N> operator&(const bitset<N>& lhs, const bitset<N>& rhs) noexcept;
 \end{itemdecl}
@@ -6062,7 +6100,7 @@ bitset<N> operator&(const bitset<N>& lhs, const bitset<N>& rhs) noexcept;
 \tcode{bitset<N>(lhs) \&= rhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"|}!\idxcode{bitset}}%
+\indexlibrarymember{operator"|}{bitset}%
 \begin{itemdecl}
 bitset<N> operator|(const bitset<N>& lhs, const bitset<N>& rhs) noexcept;
 \end{itemdecl}
@@ -6073,7 +6111,7 @@ bitset<N> operator|(const bitset<N>& lhs, const bitset<N>& rhs) noexcept;
 \tcode{bitset<N>(lhs) |= rhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\^{}}!\idxcode{bitset}}%
+\indexlibrarymember{operator\^{}}{bitset}%
 \begin{itemdecl}
 bitset<N> operator^(const bitset<N>& lhs, const bitset<N>& rhs) noexcept;
 \end{itemdecl}
@@ -6489,7 +6527,7 @@ namespace std {
 
 \rSec3[pointer.traits.types]{Pointer traits member types}
 
-\indexlibrarymember{pointer_traits}{element_type}%
+\indexlibrarymember{element_type}{pointer_traits}%
 \begin{itemdecl}
 using element_type = @\seebelow@;
 \end{itemdecl}
@@ -6504,7 +6542,7 @@ where \tcode{Args} is zero or more type arguments; otherwise, the specialization
 ill-formed.
 \end{itemdescr}
 
-\indexlibrarymember{pointer_traits}{difference_type}%
+\indexlibrarymember{difference_type}{pointer_traits}%
 \begin{itemdecl}
 using difference_type = @\seebelow@;
 \end{itemdecl}
@@ -6517,7 +6555,7 @@ type~(\ref{temp.deduct}); otherwise,
 \tcode{ptrdiff_t}.
 \end{itemdescr}
 
-\indexlibrarymember{pointer_traits}{rebind}%
+\indexlibrarymember{rebind}{pointer_traits}%
 \begin{itemdecl}
 template <class U> using rebind = @\seebelow@;
 \end{itemdecl}
@@ -6535,7 +6573,7 @@ where \tcode{Args} is zero or more type arguments; otherwise, the instantiation 
 
 \rSec3[pointer.traits.functions]{Pointer traits member functions}
 
-\indexlibrarymember{pointer_traits}{pointer_to}%
+\indexlibrarymember{pointer_to}{pointer_traits}%
 \begin{itemdecl}
 static pointer pointer_traits::pointer_to(@\seebelow@ r);
 static pointer pointer_traits<T*>::pointer_to(@\seebelow@ r) noexcept;
@@ -6716,8 +6754,8 @@ arguments for the same buffer.  \end{note}
 
 \rSec2[allocator.tag]{Allocator argument tag}
 
-\indexlibrary{\idxcode{allocator_arg_t}}
-\indexlibrary{\idxcode{allocator_arg}}
+\indexlibrary{\idxcode{allocator_arg_t}}%
+\indexlibrary{\idxcode{allocator_arg}}%
 \begin{itemdecl}
 namespace std {
   struct allocator_arg_t { };
@@ -6843,7 +6881,7 @@ namespace std {
 
 \rSec3[allocator.traits.types]{Allocator traits member types}
 
-\indexlibrarymember{allocator_traits}{pointer}%
+\indexlibrarymember{pointer}{allocator_traits}%
 \begin{itemdecl}
 using pointer = @\seebelow@;
 \end{itemdecl}
@@ -6855,7 +6893,7 @@ the \grammarterm{qualified-id} \tcode{Alloc::pointer} is valid and denotes a
 type~(\ref{temp.deduct}); otherwise, \tcode{value_type*}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{const_pointer}%
+\indexlibrarymember{const_pointer}{allocator_traits}%
 \begin{itemdecl}
 using const_pointer = @\seebelow@;
 \end{itemdecl}
@@ -6868,7 +6906,7 @@ type~(\ref{temp.deduct}); otherwise,
 \tcode{pointer_traits<pointer>::rebind<\brk{}const value_type>}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{void_pointer}%
+\indexlibrarymember{void_pointer}{allocator_traits}%
 \begin{itemdecl}
 using void_pointer = @\seebelow@;
 \end{itemdecl}
@@ -6881,7 +6919,7 @@ type~(\ref{temp.deduct}); otherwise,
 \tcode{pointer_traits<pointer>::rebind<\brk{}void>}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{const_void_pointer}%
+\indexlibrarymember{const_void_pointer}{allocator_traits}%
 \begin{itemdecl}
 using const_void_pointer = @\seebelow@;
 \end{itemdecl}
@@ -6894,7 +6932,7 @@ type~(\ref{temp.deduct}); otherwise,
 \tcode{pointer_traits<pointer>::\brk{}rebind<const void>}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{difference_type}%
+\indexlibrarymember{difference_type}{allocator_traits}%
 \begin{itemdecl}
 using difference_type = @\seebelow@;
 \end{itemdecl}
@@ -6907,7 +6945,7 @@ type~(\ref{temp.deduct}); otherwise,
 \tcode{pointer_traits<pointer>::dif\-ference_type}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{size_type}%
+\indexlibrarymember{size_type}{allocator_traits}%
 \begin{itemdecl}
 using size_type = @\seebelow@;
 \end{itemdecl}
@@ -6920,7 +6958,7 @@ type~(\ref{temp.deduct}); otherwise,
 \tcode{make_unsigned_t<difference_type>}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{propagate_on_container_copy_assignment}%
+\indexlibrarymember{propagate_on_container_copy_assignment}{allocator_traits}%
 \begin{itemdecl}
 using propagate_on_container_copy_assignment = @\seebelow@;
 \end{itemdecl}
@@ -6933,7 +6971,7 @@ type~(\ref{temp.deduct}); otherwise
 \tcode{false_type}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{propagate_on_container_move_assignment}%
+\indexlibrarymember{propagate_on_container_move_assignment}{allocator_traits}%
 \begin{itemdecl}
 using propagate_on_container_move_assignment = @\seebelow@;
 \end{itemdecl}
@@ -6946,7 +6984,7 @@ type~(\ref{temp.deduct}); otherwise
 \tcode{false_type}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{propagate_on_container_swap}%
+\indexlibrarymember{propagate_on_container_swap}{allocator_traits}%
 \begin{itemdecl}
 using propagate_on_container_swap = @\seebelow@;
 \end{itemdecl}
@@ -6959,7 +6997,7 @@ type~(\ref{temp.deduct}); otherwise
 \tcode{false_type}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{is_always_equal}%
+\indexlibrarymember{is_always_equal}{allocator_traits}%
 \begin{itemdecl}
 using is_always_equal = @\seebelow@;
 \end{itemdecl}
@@ -6972,7 +7010,7 @@ is valid and denotes a type~(\ref{temp.deduct});
 otherwise \tcode{is_empty<Alloc>::type}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{rebind_alloc}%
+\indexlibrarymember{rebind_alloc}{allocator_traits}%
 \begin{itemdecl}
 template <class T> using rebind_alloc = @\seebelow@;
 \end{itemdecl}
@@ -6989,7 +7027,7 @@ otherwise, the instantiation of \tcode{rebind_alloc} is ill-formed.
 
 \rSec3[allocator.traits.members]{Allocator traits static member functions}
 
-\indexlibrarymember{allocator_traits}{allocate}%
+\indexlibrarymember{allocate}{allocator_traits}%
 \begin{itemdecl}
 static pointer allocate(Alloc& a, size_type n);
 \end{itemdecl}
@@ -6999,7 +7037,7 @@ static pointer allocate(Alloc& a, size_type n);
 \returns \tcode{a.allocate(n)}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{allocate}%
+\indexlibrarymember{allocate}{allocator_traits}%
 \begin{itemdecl}
 static pointer allocate(Alloc& a, size_type n, const_void_pointer hint);
 \end{itemdecl}
@@ -7009,7 +7047,7 @@ static pointer allocate(Alloc& a, size_type n, const_void_pointer hint);
 \returns \tcode{a.allocate(n, hint)} if that expression is well-formed; otherwise, \tcode{a.allocate(n)}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{deallocate}%
+\indexlibrarymember{deallocate}{allocator_traits}%
 \begin{itemdecl}
 static void deallocate(Alloc& a, pointer p, size_type n);
 \end{itemdecl}
@@ -7022,7 +7060,7 @@ static void deallocate(Alloc& a, pointer p, size_type n);
 \throws Nothing.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{construct}%
+\indexlibrarymember{construct}{allocator_traits}%
 \begin{itemdecl}
 template <class T, class... Args>
   static void construct(Alloc& a, T* p, Args&&... args);
@@ -7035,7 +7073,7 @@ if that call is well-formed;
 otherwise, invokes \tcode{::new (static_cast<void*>(p)) T(std::forward<Args>(args)...)}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{destroy}%
+\indexlibrarymember{destroy}{allocator_traits}%
 \begin{itemdecl}
 template <class T>
   static void destroy(Alloc& a, T* p);
@@ -7047,7 +7085,7 @@ template <class T>
 \tcode{p->\~{}T()}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{max_size}%
+\indexlibrarymember{max_size}{allocator_traits}%
 \begin{itemdecl}
 static size_type max_size(const Alloc& a) noexcept;
 \end{itemdecl}
@@ -7058,7 +7096,7 @@ static size_type max_size(const Alloc& a) noexcept;
 \tcode{numeric_limits<size_type>::\brk{}max()/sizeof(value_type)}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{select_on_container_copy_construction}%
+\indexlibrarymember{select_on_container_copy_construction}{allocator_traits}%
 \begin{itemdecl}
 static Alloc select_on_container_copy_construction(const Alloc& rhs);
 \end{itemdecl}
@@ -7164,8 +7202,7 @@ template <class T, class U>
 \tcode{true}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{allocator}}%
-\indexlibrary{\idxcode{allocator}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{allocator}%
 \begin{itemdecl}
 template <class T, class U>
   bool operator!=(const allocator<T>&, const allocator<U>&) noexcept;
@@ -7675,7 +7712,7 @@ namespace std {
 }
 \end{codeblock}
 
-\indexlibrary{\idxcode{default_delete}!constructor}
+\indexlibrary{\idxcode{default_delete}!constructor}%
 \begin{itemdecl}
 template <class U> default_delete(const default_delete<U>& other) noexcept;
 \end{itemdecl}
@@ -7749,6 +7786,7 @@ unless \tcode{U(*)[]} is convertible to \tcode{T(*)[]}.
 
 \rSec3[unique.ptr.single]{\tcode{unique_ptr} for single objects}
 
+\indexlibrary{\idxcode{unique_ptr}}%
 \begin{codeblock}
 namespace std {
   template <class T, class D = default_delete<T>> class unique_ptr {
@@ -7828,7 +7866,7 @@ may be used as \tcode{unique_ptr<T, D>::pointer}. \end{example}
 
 \rSec4[unique.ptr.single.ctor]{\tcode{unique_ptr} constructors}
 
-\indexlibrary{\idxcode{unique_ptr}!constructor}
+\indexlibrary{\idxcode{unique_ptr}!constructor}%
 \begin{itemdecl}
 constexpr unique_ptr() noexcept;
 \end{itemdecl}
@@ -7852,7 +7890,7 @@ returns a reference to the stored deleter.
 for the template argument \tcode{D}, the program is ill-formed.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{unique_ptr}!constructor}
+\indexlibrary{\idxcode{unique_ptr}!constructor}%
 \begin{itemdecl}
 explicit unique_ptr(pointer p) noexcept;
 \end{itemdecl}
@@ -7877,7 +7915,7 @@ returns a reference to the stored deleter.
 for the template argument \tcode{D}, the program is ill-formed.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{unique_ptr}!constructor}
+\indexlibrary{\idxcode{unique_ptr}!constructor}%
 \begin{itemdecl}
 unique_ptr(pointer p, @\seebelow@ d1) noexcept;
 unique_ptr(pointer p, @\seebelow@ d2) noexcept;
@@ -8045,7 +8083,7 @@ to the stored deleter that was constructed from
 
 \rSec4[unique.ptr.single.dtor]{\tcode{unique_ptr} destructor}
 
-\indexlibrary{\idxcode{unique_ptr}!destructor}
+\indexlibrary{\idxcode{unique_ptr}!destructor}%
 \begin{itemdecl}
 ~unique_ptr();
 \end{itemdecl}
@@ -8256,6 +8294,7 @@ deleters of \tcode{*this} and \tcode{u}.
 
 \rSec3[unique.ptr.runtime]{\tcode{unique_ptr} for array objects with a runtime length}
 
+\indexlibrary{\idxcode{unique_ptr}}%
 \begin{codeblock}
 namespace std {
   template <class T, class D> class unique_ptr<T[], D> {
@@ -8387,7 +8426,7 @@ this replaces the overload-resolution specification of the primary template
 
 \rSec4[unique.ptr.runtime.asgn]{\tcode{unique_ptr} assignment}
 
-\indexlibrary{\idxcode{unique_ptr}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{unique_ptr}%
 \begin{itemdecl}
 template <class U, class E>
   unique_ptr& operator=(unique_ptr<U, E>&& u)noexcept;
@@ -8464,7 +8503,7 @@ unless either
 
 \rSec3[unique.ptr.create]{\tcode{unique_ptr} creation}
 
-\indexlibrary{\idxcode{make_unique}}
+\indexlibrary{\idxcode{make_unique}}%
 \begin{itemdecl}
 template <class T, class... Args> unique_ptr<T> make_unique(Args&&... args);
 \end{itemdecl}
@@ -8478,6 +8517,7 @@ template <class T, class... Args> unique_ptr<T> make_unique(Args&&... args);
 
 \end{itemdescr}
 
+\indexlibrary{\idxcode{make_unique}}%
 \begin{itemdecl}
 template <class T> unique_ptr<T> make_unique(size_t n);
 \end{itemdecl}
@@ -8491,6 +8531,7 @@ template <class T> unique_ptr<T> make_unique(size_t n);
 
 \end{itemdescr}
 
+\indexlibrary{\idxcode{make_unique}}%
 \begin{itemdecl}
 template <class T, class... Args> @\unspec@ make_unique(Args&&...) = delete;
 \end{itemdecl}
@@ -8503,7 +8544,7 @@ template <class T, class... Args> @\unspec@ make_unique(Args&&...) = delete;
 
 \rSec3[unique.ptr.special]{\tcode{unique_ptr} specialized algorithms}
 
-\indexlibrary{\idxcode{swap(unique_ptr\&, unique_ptr\&)}}
+\indexlibrary{\idxcode{swap(unique_ptr\&, unique_ptr\&)}}%
 \begin{itemdecl}
 template <class T, class D> void swap(unique_ptr<T, D>& x, unique_ptr<T, D>& y) noexcept;
 \end{itemdecl}
@@ -8528,8 +8569,7 @@ template <class T1, class D1, class T2, class D2>
 \returns \tcode{x.get() == y.get()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{unique_ptr}}%
-\indexlibrary{\idxcode{unique_ptr}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{unique_ptr}%
 \begin{itemdecl}
 template <class T1, class D1, class T2, class D2>
   bool operator!=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
@@ -8562,7 +8602,7 @@ to \tcode{\placeholder{CT}} or \tcode{unique_ptr<T2, D2>::pointer} is not implic
 convertible to \tcode{\placeholder{CT}}, the program is ill-formed.
 \end{itemdescr}
 
-\indexlibrarymember{operator<=}{shared_ptr}%
+\indexlibrarymember{operator<=}{unique_ptr}%
 \begin{itemdecl}
 template <class T1, class D1, class T2, class D2>
   bool operator<=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
@@ -8608,8 +8648,7 @@ template <class T, class D>
 \returns \tcode{!x}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{unique_ptr}}%
-\indexlibrary{\idxcode{unique_ptr}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{unique_ptr}%
 \begin{itemdecl}
 template <class T, class D>
   bool operator!=(const unique_ptr<T, D>& x, nullptr_t) noexcept;
@@ -8708,7 +8747,7 @@ An exception of type \tcode{bad_weak_ptr} is thrown by the \tcode{shared_ptr}
 constructor taking a \tcode{weak_ptr}.
 
 \indexlibrary{\idxcode{bad_weak_ptr}!constructor}%
-\indexlibrarymember{bad_weak_ptr}{what}%
+\indexlibrarymember{what}{bad_weak_ptr}%
 \begin{itemdecl}
 bad_weak_ptr() noexcept;
 \end{itemdecl}
@@ -9080,7 +9119,7 @@ than its previous value. \end{note}
 
 \rSec4[util.smartptr.shared.assign]{\tcode{shared_ptr} assignment}
 
-\indexlibrarymember{shared_ptr}{operator=}%
+\indexlibrarymember{operator=}{shared_ptr}%
 \begin{itemdecl}
 shared_ptr& operator=(const shared_ptr& r) noexcept;
 template<class Y> shared_ptr& operator=(const shared_ptr<Y>& r) noexcept;
@@ -9137,7 +9176,7 @@ template <class Y, class D> shared_ptr& operator=(unique_ptr<Y, D>&& r);
 
 \rSec4[util.smartptr.shared.mod]{\tcode{shared_ptr} modifiers}
 
-\indexlibrarymember{shared_ptr}{swap}%
+\indexlibrarymember{swap}{shared_ptr}%
 \begin{itemdecl}
 void swap(shared_ptr& r) noexcept;
 \end{itemdecl}
@@ -9185,7 +9224,7 @@ template<class Y, class D, class A> void reset(Y* p, D d, A a);
 \end{itemdescr}
 
 \rSec4[util.smartptr.shared.obs]{\tcode{shared_ptr} observers}
-\indexlibrarymember{shared_ptr}{get}%
+\indexlibrarymember{get}{shared_ptr}%
 \begin{itemdecl}
 T* get() const noexcept;
 \end{itemdecl}
@@ -9194,7 +9233,7 @@ T* get() const noexcept;
 \pnum\returns  the stored pointer.
 \end{itemdescr}
 
-\indexlibrarymember{shared_ptr}{operator*}%
+\indexlibrarymember{operator*}{shared_ptr}%
 \begin{itemdecl}
 T& operator*() const noexcept;
 \end{itemdecl}
@@ -9211,7 +9250,7 @@ return type is, except that the declaration (although not necessarily the
 definition) of the function shall be well formed.
 \end{itemdescr}
 
-\indexlibrarymember{shared_ptr}{operator->}%
+\indexlibrarymember{operator->}{shared_ptr}%
 \begin{itemdecl}
 T* operator->() const noexcept;
 \end{itemdecl}
@@ -9222,7 +9261,7 @@ T* operator->() const noexcept;
 \pnum\returns  \tcode{get()}.
 \end{itemdescr}
 
-\indexlibrarymember{shared_ptr}{use_count}%
+\indexlibrarymember{use_count}{shared_ptr}%
 \begin{itemdecl}
 long use_count() const noexcept;
 \end{itemdecl}
@@ -9233,7 +9272,7 @@ that \textit{share ownership} with \tcode{*this}, or \tcode{0} when \tcode{*this
 \textit{empty}.
 \end{itemdescr}
 
-\indexlibrarymember{shared_ptr}{unique}%
+\indexlibrarymember{unique}{shared_ptr}%
 \begin{itemdecl}
 bool unique() const noexcept;
 \end{itemdecl}
@@ -9327,7 +9366,7 @@ as the reference counts. \end{note}
 
 \rSec4[util.smartptr.shared.cmp]{\tcode{shared_ptr} comparison}
 
-\indexlibrarymember{shared_ptr}{operator==}%
+\indexlibrarymember{operator==}{shared_ptr}%
 \begin{itemdecl}
 template<class T, class U> bool operator==(const shared_ptr<T>& a, const shared_ptr<U>& b) noexcept;
 \end{itemdecl}
@@ -9336,7 +9375,7 @@ template<class T, class U> bool operator==(const shared_ptr<T>& a, const shared_
 \pnum\returns  \tcode{a.get() == b.get()}.
 \end{itemdescr}
 
-\indexlibrarymember{shared_ptr}{operator<}%
+\indexlibrarymember{operator<}{shared_ptr}%
 \begin{itemdecl}
 template<class T, class U> bool operator<(const shared_ptr<T>& a, const shared_ptr<U>& b) noexcept;
 \end{itemdecl}
@@ -9365,8 +9404,7 @@ template <class T>
 \returns \tcode{!a}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{shared_ptr}%
 \begin{itemdecl}
 template <class T>
   bool operator!=(const shared_ptr<T>& a, nullptr_t) noexcept;
@@ -9443,7 +9481,7 @@ The second function template returns \tcode{!(nullptr < a)}.
 
 \rSec4[util.smartptr.shared.spec]{\tcode{shared_ptr} specialized algorithms}
 
-\indexlibrarymember{shared_ptr}{swap}%
+\indexlibrarymember{swap}{shared_ptr}%
 \begin{itemdecl}
 template<class T> void swap(shared_ptr<T>& a, shared_ptr<T>& b) noexcept;
 \end{itemdecl}
@@ -9454,7 +9492,7 @@ template<class T> void swap(shared_ptr<T>& a, shared_ptr<T>& b) noexcept;
 
 \rSec4[util.smartptr.shared.cast]{\tcode{shared_ptr} casts}
 
-\indexlibrarymember{shared_ptr}{static_pointer_cast}%
+\indexlibrarymember{static_pointer_cast}{shared_ptr}%
 \begin{itemdecl}
 template<class T, class U> shared_ptr<T> static_pointer_cast(const shared_ptr<U>& r) noexcept;
 \end{itemdecl}
@@ -9479,7 +9517,7 @@ will eventually result in undefined behavior, attempting to delete the
 same object twice. \end{note}
 \end{itemdescr}
 
-\indexlibrarymember{shared_ptr}{dynamic_pointer_cast}%
+\indexlibrarymember{dynamic_pointer_cast}{shared_ptr}%
 \begin{itemdecl}
 template<class T, class U> shared_ptr<T> dynamic_pointer_cast(const shared_ptr<U>& r) noexcept;
 \end{itemdecl}
@@ -9505,7 +9543,7 @@ shall be well formed and shall have well defined behavior.
 undefined behavior, attempting to delete the same object twice. \end{note}
 \end{itemdescr}
 
-\indexlibrarymember{shared_ptr}{const_pointer_cast}%
+\indexlibrarymember{const_pointer_cast}{shared_ptr}%
 \begin{itemdecl}
 template<class T, class U> shared_ptr<T> const_pointer_cast(const shared_ptr<U>& r) noexcept;
 \end{itemdecl}
@@ -9529,7 +9567,7 @@ undefined behavior, attempting to delete the same object twice. \end{note}
 
 \rSec4[util.smartptr.getdeleter]{\tcode{get_deleter}}
 
-\indexlibrarymember{shared_ptr}{get_deleter}%
+\indexlibrarymember{get_deleter}{shared_ptr}%
 \begin{itemdecl}
 template<class D, class T> D* get_deleter(const shared_ptr<T>& p) noexcept;
 \end{itemdecl}
@@ -9677,7 +9715,7 @@ effect on the object its stored pointer points to.
 
 \rSec4[util.smartptr.weak.assign]{\tcode{weak_ptr} assignment}
 
-\indexlibrarymember{weak_ptr}{operator=}%
+\indexlibrarymember{operator=}{weak_ptr}%
 \begin{itemdecl}
 weak_ptr& operator=(const weak_ptr& r) noexcept;
 template<class Y> weak_ptr& operator=(const weak_ptr<Y>& r) noexcept;
@@ -9693,7 +9731,7 @@ implied guarantees) via different means, without creating a temporary.
 \pnum\returns  \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{weak_ptr}{operator=}%
+\indexlibrarymember{operator=}{weak_ptr}%
 \begin{itemdecl}
 weak_ptr& operator=(weak_ptr&& r) noexcept;
 template<class Y> weak_ptr& operator=(weak_ptr<Y>&& r) noexcept;
@@ -9706,7 +9744,7 @@ template<class Y> weak_ptr& operator=(weak_ptr<Y>&& r) noexcept;
 \end{itemdescr}
 
 \rSec4[util.smartptr.weak.mod]{\tcode{weak_ptr} modifiers}
-\indexlibrarymember{weak_ptr}{swap}%
+\indexlibrarymember{swap}{weak_ptr}%
 \begin{itemdecl}
 void swap(weak_ptr& r) noexcept;
 \end{itemdecl}
@@ -9715,7 +9753,7 @@ void swap(weak_ptr& r) noexcept;
 \pnum\effects  Exchanges the contents of \tcode{*this} and \tcode{r}.
 \end{itemdescr}
 
-\indexlibrarymember{weak_ptr}{reset}%
+\indexlibrarymember{reset}{weak_ptr}%
 \begin{itemdecl}
 void reset() noexcept;
 \end{itemdecl}
@@ -9725,7 +9763,7 @@ void reset() noexcept;
 \end{itemdescr}
 
 \rSec4[util.smartptr.weak.obs]{\tcode{weak_ptr} observers}
-\indexlibrarymember{weak_ptr}{use_count}%
+\indexlibrarymember{use_count}{weak_ptr}%
 \begin{itemdecl}
 long use_count() const noexcept;
 \end{itemdecl}
@@ -9736,7 +9774,7 @@ otherwise, the number of \tcode{shared_ptr} instances
 that \textit{share ownership} with \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{weak_ptr}{expired}%
+\indexlibrarymember{expired}{weak_ptr}%
 \begin{itemdecl}
 bool expired() const noexcept;
 \end{itemdecl}
@@ -9745,7 +9783,7 @@ bool expired() const noexcept;
 \pnum\returns  \tcode{use_count() == 0}.
 \end{itemdescr}
 
-\indexlibrarymember{weak_ptr}{lock}%
+\indexlibrarymember{lock}{weak_ptr}%
 \begin{itemdecl}
 shared_ptr<T> lock() const noexcept;
 \end{itemdecl}
@@ -9754,7 +9792,7 @@ shared_ptr<T> lock() const noexcept;
 \pnum\returns  \tcode{expired() ? shared_ptr<T>() : shared_ptr<T>(*this)}, executed atomically.
 \end{itemdescr}
 
-\indexlibrarymember{owner_before}{shared_ptr}%
+\indexlibrarymember{owner_before}{weak_ptr}%
 \begin{itemdecl}
 template<class U> bool owner_before(shared_ptr<U> const& b) const;
 template<class U> bool owner_before(weak_ptr<U> const& b) const;
@@ -9777,7 +9815,7 @@ both empty.
 
 \rSec4[util.smartptr.weak.spec]{\tcode{weak_ptr} specialized algorithms}
 
-\indexlibrarymember{weak_ptr}{swap}%
+\indexlibrarymember{swap}{weak_ptr}%
 \begin{itemdecl}
 template<class T> void swap(weak_ptr<T>& a, weak_ptr<T>& b) noexcept;
 \end{itemdecl}
@@ -9792,6 +9830,7 @@ template<class T> void swap(weak_ptr<T>& a, weak_ptr<T>& b) noexcept;
 The class template \tcode{owner_less} allows ownership-based mixed comparisons of shared
 and weak pointers.
 
+\indexlibrary{\idxcode{struct owner_less}}%
 \begin{codeblock}
 namespace std {
   template<class T = void> struct owner_less;
@@ -9823,6 +9862,7 @@ namespace std {
 }
 \end{codeblock}
 
+\indexlibrarymember{operator()}{owner_less}%
 \pnum \tcode{operator()(x, y)} shall return \tcode{x.owner_before(y)}. \begin{note}
 Note that
 
@@ -9892,7 +9932,7 @@ enable_shared_from_this(const enable_shared_from_this<T>&) noexcept;
 \pnum\effects  Value-initializes \tcode{weak_this}.
 \end{itemdescr}
 
-\indexlibrarymember{enable_shared_from_this}{operator=}%
+\indexlibrarymember{operator=}{enable_shared_from_this}%
 \begin{itemdecl}
 enable_shared_from_this<T>& operator=(const enable_shared_from_this<T>&) noexcept;
 \end{itemdecl}
@@ -9904,7 +9944,7 @@ enable_shared_from_this<T>& operator=(const enable_shared_from_this<T>&) noexcep
 \end{itemdescr}
 
 \indexlibrary{\idxcode{shared_ptr}}%
-\indexlibrarymember{enable_shared_from_this}{shared_from_this}%
+\indexlibrarymember{shared_from_this}{enable_shared_from_this}%
 \begin{itemdecl}
 shared_ptr<T>       shared_from_this();
 shared_ptr<T const> shared_from_this() const;
@@ -9917,7 +9957,7 @@ shared_ptr<T const> shared_from_this() const;
 \end{itemdescr}
 
 \indexlibrary{\idxcode{weak_ptr}}%
-\indexlibrarymember{enable_shared_from_this}{weak_from_this}%
+\indexlibrarymember{weak_from_this}{enable_shared_from_this}%
 \begin{itemdecl}
 weak_ptr<T>       weak_from_this() noexcept;
 weak_ptr<T const> weak_from_this() const noexcept;
@@ -10098,10 +10138,8 @@ template<class T>
 \tcode{memory_order_seq_cst, memory_order_seq_cst)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{atomic_compare_exchange_weak_explicit}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!atomic_compare_exchange_weak_explicit@\tcode{atomic_compare_exchange_weak_-\\explicit}}%
-\indexlibrary{\idxcode{atomic_compare_exchange_strong_explicit}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!atomic_compare_exchange_strong_explicit@\tcode{atomic_compare_exchange_strong_-\\explicit}}%
+\indexlibrarymember{atomic_compare_exchange_weak_explicit}{shared_ptr}%
+\indexlibrarymember{atomic_compare_exchange_strong_explicit}{shared_ptr}%
 \begin{itemdecl}
 template<class T>
   bool atomic_compare_exchange_weak_explicit(
@@ -10143,7 +10181,7 @@ pointer value and share ownership.
 
 \rSec3[util.smartptr.hash]{Smart pointer hash support}
 
-\indexlibrary{\idxcode{hash}}%
+\indexlibrary{\idxcode{hash}!\idxcode{unique_ptr}}%
 \begin{itemdecl}
 template <class T, class D> struct hash<unique_ptr<T, D>>;
 \end{itemdecl}
@@ -10160,7 +10198,7 @@ well-formed and well-defined, and shall meet the requirements of class
 template \tcode{hash}~(\ref{unord.hash}).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{hash}}%
+\indexlibrary{\idxcode{hash}!\idxcode{shared_ptr}}%
 \begin{itemdecl}
 template <class T> struct hash<shared_ptr<T>>;
 \end{itemdecl}
@@ -10251,7 +10289,7 @@ private:
 Destroys this \tcode{memory_resource}.
 \end{itemdescr}
 
-\indexlibrarymember{memory_resource}{allocate}%
+\indexlibrarymember{allocate}{memory_resource}%
 \begin{itemdecl}
 void* allocate(size_t bytes, size_t alignment = max_align);
 \end{itemdecl}
@@ -10262,7 +10300,7 @@ void* allocate(size_t bytes, size_t alignment = max_align);
 Equivalent to: \tcode{return do_allocate(bytes, alignment);}
 \end{itemdescr}
 
-\indexlibrarymember{memory_resource}{deallocate}%
+\indexlibrarymember{deallocate}{memory_resource}%
 \begin{itemdecl}
 void deallocate(void* p, size_t bytes, size_t alignment = max_align);
 \end{itemdecl}
@@ -10273,7 +10311,7 @@ void deallocate(void* p, size_t bytes, size_t alignment = max_align);
 Equivalent to: \tcode{do_deallocate(p, bytes, alignment);}
 \end{itemdescr}
 
-\indexlibrarymember{memory_resource}{is_equal}%
+\indexlibrarymember{is_equal}{memory_resource}%
 \begin{itemdecl}
 bool is_equal(const memory_resource& other) const noexcept;
 \end{itemdecl}
@@ -10287,7 +10325,7 @@ Equivalent to: \tcode{return do_is_equal(other);}
 
 \rSec3[memory.resource.private]{\tcode{memory_resource} private virtual member functions}
 
-\indexlibrarymember{memory_resource}{do_allocate}%
+\indexlibrarymember{do_allocate}{memory_resource}%
 \begin{itemdecl}
 virtual void* do_allocate(size_t bytes, size_t alignment) = 0;
 \end{itemdecl}
@@ -10308,7 +10346,7 @@ otherwise it is aligned to \tcode{max_align}.
 A derived class implementation shall throw an appropriate exception if it is unable to allocate memory with the requested size and alignment.
 \end{itemdescr}
 
-\indexlibrarymember{memory_resource}{do_deallocate}%
+\indexlibrarymember{do_deallocate}{memory_resource}%
 \begin{itemdecl}
 virtual void do_deallocate(void* p, size_t bytes, size_t alignment) = 0;
 \end{itemdecl}
@@ -10328,7 +10366,7 @@ A derived class shall implement this function to dispose of allocated storage.
 Nothing.
 \end{itemdescr}
 
-\indexlibrarymember{memory_resource}{do_is_equal}%
+\indexlibrarymember{do_is_equal}{memory_resource}%
 \begin{itemdecl}
 virtual bool do_is_equal(const memory_resource& other) const noexcept = 0;
 \end{itemdecl}
@@ -10347,7 +10385,7 @@ if \tcode{dynamic_cast<const D*>(\&other) == nullptr}.\end{note}
 
 \rSec3[memory.resource.eq]{\tcode{memory_resource} equality}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{memory_resource}}%
+\indexlibrarymember{operator==}{memory_resource}%
 \begin{itemdecl}
 bool operator==(const memory_resource& a, const memory_resource& b) noexcept;
 \end{itemdecl}
@@ -10358,7 +10396,7 @@ bool operator==(const memory_resource& a, const memory_resource& b) noexcept;
 \tcode{\&a == \&b || a.is_equal(b)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{memory_resource}}%
+\indexlibrarymember{operator"!=}{memory_resource}%
 \begin{itemdecl}
 bool operator!=(const memory_resource& a, const memory_resource& b) noexcept;
 \end{itemdecl}
@@ -10482,7 +10520,7 @@ Sets \tcode{memory_rsrc} to \tcode{other.resource()}.
 
 \rSec3[memory.polymorphic.allocator.mem]{\tcode{polymorphic_allocator} member functions}
 
-\indexlibrarymember{polymorphic_allocator}{allocate}%
+\indexlibrarymember{allocate}{polymorphic_allocator}%
 \begin{itemdecl}
 Tp* allocate(size_t n);
 \end{itemdecl}
@@ -10496,7 +10534,7 @@ return static_cast<Tp*>(memory_rsrc->allocate(n * sizeof(Tp), alignof(Tp)));
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{polymorphic_allocator}{deallocate}%
+\indexlibrarymember{deallocate}{polymorphic_allocator}%
 \begin{itemdecl}
 void deallocate(Tp* p, size_t n);
 \end{itemdecl}
@@ -10517,7 +10555,7 @@ Equivalent to \tcode{memory_rsrc->deallocate(p, n * sizeof(Tp), alignof(Tp))}.
 Nothing.
 \end{itemdescr}
 
-\indexlibrarymember{polymorphic_allocator}{construct}%
+\indexlibrarymember{construct}{polymorphic_allocator}%
 \begin{itemdecl}
 template <class T, class... Args>
   void construct(T* p, Args&&... args);
@@ -10545,7 +10583,7 @@ and constructor arguments \tcode{std::forward<Args>(args)...}.
 Nothing unless the constructor for \tcode{T} throws.
 \end{itemdescr}
 
-\indexlibrarymember{polymorphic_allocator}{construct}%
+\indexlibrarymember{construct}{polymorphic_allocator}%
 \begin{itemdecl}
 template <class T1, class T2, class... Args1, class... Args2>
   void construct(pair<T1,T2>* p, piecewise_construct_t,
@@ -10632,7 +10670,7 @@ this function constructs a \tcode{pair<T1, T2>} object
 in the storage whose address is represented by \tcode{p}.
 \end{itemdescr}
 
-\indexlibrarymember{polymorphic_allocator}{construct}%
+\indexlibrarymember{construct}{polymorphic_allocator}%
 \begin{itemdecl}
 template <class T1, class T2>
   void construct(pair<T1,T2>* p);
@@ -10647,7 +10685,7 @@ this->construct(p, piecewise_construct, tuple<>(), tuple<>());
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{polymorphic_allocator}{construct}%
+\indexlibrarymember{construct}{polymorphic_allocator}%
 \begin{itemdecl}
 template <class T1, class T2, class U, class V>
   void construct(pair<T1,T2>* p, U&& x, V&& y);
@@ -10664,7 +10702,7 @@ this->construct(p, piecewise_construct,
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{polymorphic_allocator}{construct}%
+\indexlibrarymember{construct}{polymorphic_allocator}%
 \begin{itemdecl}
 template <class T1, class T2, class U, class V>
   void construct(pair<T1,T2>* p, const pair<U, V>& pr);
@@ -10681,7 +10719,7 @@ this->construct(p, piecewise_construct,
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{polymorphic_allocator}{construct}%
+\indexlibrarymember{construct}{polymorphic_allocator}%
 \begin{itemdecl}
 template <class T1, class T2, class U, class V>
   void construct(pair<T1,T2>* p, pair<U, V>&& pr);
@@ -10698,7 +10736,7 @@ this->construct(p, piecewise_construct,
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{polymorphic_allocator}{destroy}%
+\indexlibrarymember{destroy}{polymorphic_allocator}%
 \begin{itemdecl}
 template <class T>
   void destroy(T* p);
@@ -10710,7 +10748,7 @@ template <class T>
 As if by \tcode{p->\~T()}.
 \end{itemdescr}
 
-\indexlibrarymember{polymorphic_allocator}{select_on_container_copy_construction}%
+\indexlibrarymember{select_on_container_copy_construction}{polymorphic_allocator}%
 \begin{itemdecl}
 polymorphic_allocator select_on_container_copy_construction() const;
 \end{itemdecl}
@@ -10726,7 +10764,7 @@ The memory resource is not propagated.
 \end{note}
 \end{itemdescr}
 
-\indexlibrarymember{polymorphic_allocator}{resource}%
+\indexlibrarymember{resource}{polymorphic_allocator}%
 \begin{itemdecl}
 memory_resource* resource() const;
 \end{itemdecl}
@@ -10739,7 +10777,7 @@ memory_resource* resource() const;
 
 \rSec3[memory.polymorphic.allocator.eq]{\tcode{polymorphic_allocator} equality}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{polymorphic_allocator}}%
+\indexlibrarymember{operator==}{polymorphic_allocator}%
 \begin{itemdecl}
 template <class T1, class T2>
   bool operator==(const polymorphic_allocator<T1>& a,
@@ -10752,7 +10790,7 @@ template <class T1, class T2>
 \tcode{*a.resource() == *b.resource()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{polymorphic_allocator}}%
+\indexlibrarymember{operator"!=}{polymorphic_allocator}%
 \begin{itemdecl}
 template <class T1, class T2>
   bool operator!=(const polymorphic_allocator<T1>& a,
@@ -11054,10 +11092,8 @@ Calls \tcode{this->release()}.
 
 \rSec3[memory.resource.pool.mem]{Pool resource members}
 
-\indexlibrary{\idxcode{synchronized_pool_resource}!\idxcode{release}}%
-\indexlibrary{\idxcode{unsynchronized_pool_resource}!\idxcode{release}}%
-\indexlibrary{\idxcode{release}!\idxcode{synchronized_pool_resource}}%
-\indexlibrary{\idxcode{release}!\idxcode{unsynchronized_pool_resource}}%
+\indexlibrarymember{release}{synchronized_pool_resource}%
+\indexlibrarymember{release}{unsynchronized_pool_resource}%
 \begin{itemdecl}
 void release();
 \end{itemdecl}
@@ -11073,10 +11109,8 @@ even if \tcode{deallocate} has not been called
 for some of the allocated blocks.\end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{synchronized_pool_resource}!\idxcode{upstream_resource}}%
-\indexlibrary{\idxcode{unsynchronized_pool_resource}!\idxcode{upstream_resource}}%
-\indexlibrary{\idxcode{upstream_resource}!\idxcode{synchronized_pool_resource}}%
-\indexlibrary{\idxcode{upstream_resource}!\idxcode{unsynchronized_pool_resource}}%
+\indexlibrarymember{upstream_resource}{synchronized_pool_resource}%
+\indexlibrarymember{upstream_resource}{unsynchronized_pool_resource}%
 \begin{itemdecl}
 memory_resource* upstream_resource() const;
 \end{itemdecl}
@@ -11088,10 +11122,8 @@ The value of the \tcode{upstream} argument
 provided to the constructor of this object.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{synchronized_pool_resource}!\idxcode{options}}%
-\indexlibrary{\idxcode{unsynchronized_pool_resource}!\idxcode{options}}%
-\indexlibrary{\idxcode{options}!\idxcode{synchronized_pool_resource}}%
-\indexlibrary{\idxcode{options}!\idxcode{unsynchronized_pool_resource}}%
+\indexlibrarymember{options}{synchronized_pool_resource}%
+\indexlibrarymember{options}{unsynchronized_pool_resource}%
 \begin{itemdecl}
 pool_options options() const;
 \end{itemdecl}
@@ -11106,10 +11138,8 @@ values of zero will be replaced with implementation-defined defaults,
 and sizes may be rounded to unspecified granularity.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{synchronized_pool_resource}!\idxcode{do_allocate}}%
-\indexlibrary{\idxcode{unsynchronized_pool_resource}!\idxcode{do_allocate}}%
-\indexlibrary{\idxcode{do_allocate}!\idxcode{synchronized_pool_resource}}%
-\indexlibrary{\idxcode{do_allocate}!\idxcode{unsynchronized_pool_resource}}%
+\indexlibrarymember{do_allocate}{synchronized_pool_resource}%
+\indexlibrarymember{do_allocate}{unsynchronized_pool_resource}%
 \begin{itemdecl}
 void* do_allocate(size_t bytes, size_t alignment) override;
 \end{itemdecl}
@@ -11135,10 +11165,8 @@ then memory will be allocated using \tcode{upstream_resource()->allocate()}.
 Nothing unless \tcode{upstream_resource()->allocate()} throws.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{synchronized_pool_resource}!\idxcode{do_deallocate}}%
-\indexlibrary{\idxcode{unsynchronized_pool_resource}!\idxcode{do_deallocate}}%
-\indexlibrary{\idxcode{do_deallocate}!\idxcode{synchronized_pool_resource}}%
-\indexlibrary{\idxcode{do_deallocate}!\idxcode{unsynchronized_pool_resource}}%
+\indexlibrarymember{do_deallocate}{synchronized_pool_resource}%
+\indexlibrarymember{do_deallocate}{unsynchronized_pool_resource}%
 \begin{itemdecl}
 void do_deallocate(void* p, size_t bytes, size_t alignment) override;
 \end{itemdecl}
@@ -11155,7 +11183,7 @@ this operation will result in a call to \tcode{upstream_resource()->deallocate()
 Nothing.
 \end{itemdescr}
 
-\indexlibrarymember{unsynchronized_pool_resource}{do_is_equal}%
+\indexlibrarymember{do_is_equal}{unsynchronized_pool_resource}%
 \begin{itemdecl}
 bool unsynchronized_pool_resource::do_is_equal(const memory_resource& other) const noexcept override;
 \end{itemdecl}
@@ -11166,7 +11194,7 @@ bool unsynchronized_pool_resource::do_is_equal(const memory_resource& other) con
 \tcode{this == dynamic_cast<const unsynchronized_pool_resource*>(\&other)}.
 \end{itemdescr}
 
-\indexlibrarymember{synchronized_pool_resource}{do_is_equal}%
+\indexlibrarymember{do_is_equal}{synchronized_pool_resource}%
 \begin{itemdecl}
 bool synchronized_pool_resource::do_is_equal(const memory_resource& other) const noexcept override;
 \end{itemdecl}
@@ -11303,7 +11331,7 @@ Calls \tcode{this->release()}.
 
 \rSec3[memory.resource.monotonic.buffer.mem]{\tcode{monotonic_buffer_resource} members}
 
-\indexlibrary{\idxcode{monotonic_buffer_resource}!\idxcode{release}}%
+\indexlibrarymember{release}{monotonic_buffer_resource}%
 \begin{itemdecl}
 void release();
 \end{itemdecl}
@@ -11321,7 +11349,7 @@ even if some blocks that were allocated from \tcode{this}
 have not been deallocated from \tcode{this}.\end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{monotonic_buffer_resource}!\idxcode{upstream_resource}}%
+\indexlibrarymember{upstream_resource}{monotonic_buffer_resource}%
 \begin{itemdecl}
 memory_resource* upstream_resource() const;
 \end{itemdecl}
@@ -11332,7 +11360,7 @@ memory_resource* upstream_resource() const;
 The value of \tcode{upstream_rsrc}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{monotonic_buffer_resource}!\idxcode{do_allocate}}%
+\indexlibrarymember{do_allocate}{monotonic_buffer_resource}%
 \begin{itemdecl}
 void* do_allocate(size_t bytes, size_t alignment) override;
 \end{itemdecl}
@@ -11362,7 +11390,7 @@ then allocate the return block from the newly-allocated \tcode{current_buffer}.
 Nothing unless \tcode{upstream_rsrc->allocate()} throws.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{monotonic_buffer_resource}!\idxcode{do_deallocate}}%
+\indexlibrarymember{do_deallocate}{monotonic_buffer_resource}%
 \begin{itemdecl}
 void do_deallocate(void* p, size_t bytes, size_t alignment) override;
 \end{itemdecl}
@@ -11381,7 +11409,7 @@ Nothing.
 Memory used by this resource increases monotonically until its destruction.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{monotonic_buffer_resource}!\idxcode{do_is_equal}}%
+\indexlibrarymember{do_is_equal}{monotonic_buffer_resource}%
 \begin{itemdecl}
 bool do_is_equal(const memory_resource& other) const noexcept override;
 \end{itemdecl}
@@ -11429,6 +11457,7 @@ recursions. \begin{note} The \tcode{scoped_allocator_adaptor} is derived from th
 allocator type so it can be substituted for the outer allocator type in most
 expressions. \end{note}
 
+\indexlibrary{\idxcode{scoped_allocator_adaptor}}%
 \begin{codeblock}
 namespace std {
   template <class OuterAlloc, class... InnerAllocs>
@@ -11520,7 +11549,7 @@ namespace std {
 
 \rSec2[allocator.adaptor.types]{Scoped allocator adaptor member types}
 
-\indexlibrarymember{scoped_allocator_adaptor}{inner_allocator_type}%
+\indexlibrarymember{inner_allocator_type}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 using inner_allocator_type = @\seebelow@;
 \end{itemdecl}
@@ -11531,7 +11560,7 @@ using inner_allocator_type = @\seebelow@;
 zero; otherwise,\\ \tcode{scoped_allocator_adaptor<InnerAllocs...>}.
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{propagate_on_container_copy_assignment}%
+\indexlibrarymember{propagate_on_container_copy_assignment}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 using propagate_on_container_copy_assignment = @\seebelow@;
 \end{itemdecl}
@@ -11544,7 +11573,7 @@ using propagate_on_container_copy_assignment = @\seebelow@;
 \tcode{InnerAllocs...}; otherwise, \tcode{false_type}.
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{propagate_on_container_move_assignment}%
+\indexlibrarymember{propagate_on_container_move_assignment}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 using propagate_on_container_move_assignment = @\seebelow@;
 \end{itemdecl}
@@ -11557,7 +11586,7 @@ using propagate_on_container_move_assignment = @\seebelow@;
 \tcode{InnerAllocs...}; otherwise, \tcode{false_type}.
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{propagate_on_container_swap}%
+\indexlibrarymember{propagate_on_container_swap}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 using propagate_on_container_swap = @\seebelow@;
 \end{itemdecl}
@@ -11570,7 +11599,7 @@ using propagate_on_container_swap = @\seebelow@;
 \tcode{InnerAllocs...}; otherwise, \tcode{false_type}.
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{is_always_equal}%
+\indexlibrarymember{is_always_equal}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 using is_always_equal = @\seebelow@;
 \end{itemdecl}
@@ -11684,7 +11713,7 @@ is incumbent upon the definition of \tcode{outer_allocator()} to ensure that the
 recursion terminates. It will terminate for all instantiations of \\
 \tcode{scoped_allocator_adaptor}. \end{note}
 
-\indexlibrarymember{scoped_allocator_adaptor}{inner_allocator}%
+\indexlibrarymember{inner_allocator}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 inner_allocator_type& inner_allocator() noexcept;
 const inner_allocator_type& inner_allocator() const noexcept;
@@ -11696,7 +11725,7 @@ const inner_allocator_type& inner_allocator() const noexcept;
 \tcode{inner}.
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{outer_allocator}%
+\indexlibrarymember{outer_allocator}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 outer_allocator_type& outer_allocator() noexcept;
 \end{itemdecl}
@@ -11706,7 +11735,7 @@ outer_allocator_type& outer_allocator() noexcept;
 \returns \tcode{static_cast<OuterAlloc\&>(*this)}.
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{outer_allocator}%
+\indexlibrarymember{outer_allocator}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 const outer_allocator_type& outer_allocator() const noexcept;
 \end{itemdecl}
@@ -11716,7 +11745,7 @@ const outer_allocator_type& outer_allocator() const noexcept;
 \returns \tcode{static_cast<const OuterAlloc\&>(*this)}.
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{allocate}%
+\indexlibrarymember{allocate}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 pointer allocate(size_type n);
 \end{itemdecl}
@@ -11726,7 +11755,7 @@ pointer allocate(size_type n);
 \returns \tcode{allocator_traits<OuterAlloc>::allocate(outer_allocator(), n)}.
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{allocate}%
+\indexlibrarymember{allocate}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 pointer allocate(size_type n, const_void_pointer hint);
 \end{itemdecl}
@@ -11736,7 +11765,7 @@ pointer allocate(size_type n, const_void_pointer hint);
 \returns \tcode{allocator_traits<OuterAlloc>::allocate(outer_allocator(), n, hint)}.
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{deallocate}%
+\indexlibrarymember{deallocate}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 void deallocate(pointer p, size_type n) noexcept;
 \end{itemdecl}
@@ -11747,7 +11776,7 @@ void deallocate(pointer p, size_type n) noexcept;
 \tcode{allocator_traits<OuterAlloc>::deallocate(outer_allocator(), p, n);}
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{max_size}%
+\indexlibrarymember{max_size}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 size_type max_size() const;
 \end{itemdecl}
@@ -11757,7 +11786,7 @@ size_type max_size() const;
 \returns \tcode{allocator_traits<OuterAlloc>::max_size(outer_allocator())}.
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{construct}%
+\indexlibrarymember{construct}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 template <class T, class... Args>
   void construct(T* p, Args&&... args);
@@ -11790,7 +11819,7 @@ contained element. \end{note}
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{construct}%
+\indexlibrarymember{construct}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 template <class T1, class T2, class... Args1, class... Args2>
   void construct(pair<T1, T2>* p, piecewise_construct_t,
@@ -11856,7 +11885,7 @@ then calls \tcode{\textit{OUTERMOST_ALLOC_TRAITS}(*this)::construct(\textit{OUTE
 piecewise_construct, std::move(xprime), std::move(yprime))}.
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{construct}%
+\indexlibrarymember{construct}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 template <class T1, class T2>
   void construct(pair<T1, T2>* p);
@@ -11870,7 +11899,7 @@ this->construct(p, piecewise_construct, tuple<>(), tuple<>());
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{construct}%
+\indexlibrarymember{construct}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 template <class T1, class T2, class U, class V>
   void construct(pair<T1, T2>* p, U&& x, V&& y);
@@ -11886,7 +11915,7 @@ this->construct(p, piecewise_construct,
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{construct}%
+\indexlibrarymember{construct}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 template <class T1, class T2, class U, class V>
   void construct(pair<T1, T2>* p, const pair<U, V>& x);
@@ -11902,7 +11931,7 @@ this->construct(p, piecewise_construct,
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{construct}%
+\indexlibrarymember{construct}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 template <class T1, class T2, class U, class V>
   void construct(pair<T1, T2>* p, pair<U, V>&& x);
@@ -11918,7 +11947,7 @@ this->construct(p, piecewise_construct,
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{destroy}%
+\indexlibrarymember{destroy}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 template <class T>
   void destroy(T* p);
@@ -11929,7 +11958,7 @@ template <class T>
 \effects Calls \tcode{\textit{OUTERMOST_ALLOC_TRAITS}(*this)::destroy(\textit{OUTERMOST}(*this), p)}.
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{select_on_container_copy_construction}%
+\indexlibrarymember{select_on_container_copy_construction}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 scoped_allocator_adaptor select_on_container_copy_construction() const;
 \end{itemdecl}
@@ -11944,7 +11973,7 @@ corresponding allocator in \tcode{*this}.
 
 \rSec2[scoped.adaptor.operators]{Scoped allocator operators}
 
-\indexlibrarymember{scoped_allocator_adaptor}{operator==}%
+\indexlibrarymember{operator==}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 template <class OuterA1, class OuterA2, class... InnerAllocs>
   bool operator==(const scoped_allocator_adaptor<OuterA1, InnerAllocs...>& a,
@@ -11959,7 +11988,7 @@ otherwise, \tcode{a.outer_allocator() == b.outer_allocator()}
 \tcode{\&\&} \tcode{a.inner_allocator() == b.inner_allocator()}.
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{operator"!=}%
+\indexlibrarymember{operator"!=}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 template <class OuterA1, class OuterA2, class... InnerAllocs>
   bool operator!=(const scoped_allocator_adaptor<OuterA1, InnerAllocs...>& a,
@@ -12307,8 +12336,6 @@ template <class F, class... Args>
 
 \indexlibrary{\idxcode{reference_wrapper}}%
 \indextext{function object!\idxcode{reference_wrapper}}%
-\indextext{unary function}%
-\indextext{binary function}%
 \begin{codeblock}
 namespace std {
   template <class T> class reference_wrapper {
@@ -12388,7 +12415,7 @@ operator T& () const noexcept;
 \pnum\returns The stored reference.
 \end{itemdescr}
 
-\indexlibrarymember{reference_wrapper}{get}%
+\indexlibrarymember{get}{reference_wrapper}%
 \begin{itemdecl}
 T& get() const noexcept;
 \end{itemdecl}
@@ -12400,7 +12427,7 @@ T& get() const noexcept;
 
 \rSec3[refwrap.invoke]{reference_wrapper invocation}
 
-\indexlibrarymember{reference_wrapper}{operator()}%
+\indexlibrarymember{operator()}{reference_wrapper}%
 \begin{itemdecl}
 template <class... ArgTypes>
   result_of_t<T&(ArgTypes&&... )>
@@ -12414,7 +12441,7 @@ template <class... ArgTypes>
 
 \rSec3[refwrap.helpers]{reference_wrapper helper functions}
 
-\indexlibrarymember{reference_wrapper}{ref}%
+\indexlibrarymember{ref}{reference_wrapper}%
 \begin{itemdecl}
 template <class T> reference_wrapper<T> ref(T& t) noexcept;
 \end{itemdecl}
@@ -12423,7 +12450,7 @@ template <class T> reference_wrapper<T> ref(T& t) noexcept;
 \pnum\returns \tcode{reference_wrapper<T>(t)}
 \end{itemdescr}
 
-\indexlibrarymember{reference_wrapper}{ref}%
+\indexlibrarymember{ref}{reference_wrapper}%
 \begin{itemdecl}
 template <class T> reference_wrapper<T> ref(reference_wrapper<T> t) noexcept;
 \end{itemdecl}
@@ -12432,7 +12459,7 @@ template <class T> reference_wrapper<T> ref(reference_wrapper<T> t) noexcept;
 \pnum\returns \tcode{ref(t.get())}
 \end{itemdescr}
 
-\indexlibrarymember{reference_wrapper}{cref}%
+\indexlibrarymember{cref}{reference_wrapper}%
 \begin{itemdecl}
 template <class T> reference_wrapper<const T> cref(const T& t) noexcept;
 \end{itemdecl}
@@ -12441,7 +12468,7 @@ template <class T> reference_wrapper<const T> cref(const T& t) noexcept;
 \pnum\returns \tcode{reference_wrapper <const T>(t)}
 \end{itemdescr}
 
-\indexlibrarymember{reference_wrapper}{cref}%
+\indexlibrarymember{cref}{reference_wrapper}%
 \begin{itemdecl}
 template <class T> reference_wrapper<const T> cref(reference_wrapper<T> t) noexcept;
 \end{itemdecl}
@@ -12463,6 +12490,7 @@ template <class T = void> struct plus {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{plus}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()}
@@ -12477,6 +12505,7 @@ template <class T = void> struct minus {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{minus}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()}
@@ -12491,6 +12520,7 @@ template <class T = void> struct multiplies {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{multiplies}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()}
@@ -12505,6 +12535,7 @@ template <class T = void> struct divides {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{divides}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()}
@@ -12519,6 +12550,7 @@ template <class T = void> struct modulus {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{modulus}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{x \% y}.
@@ -12531,6 +12563,7 @@ template <class T = void> struct negate {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{negate}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{-x}.
@@ -12546,6 +12579,7 @@ template <> struct plus<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{plus<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) + std::forward<U>(u)}.
@@ -12561,6 +12595,7 @@ template <> struct minus<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{minus<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) - std::forward<U>(u)}.
@@ -12576,6 +12611,7 @@ template <> struct multiplies<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{multiplies<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) * std::forward<U>(u)}.
@@ -12591,6 +12627,7 @@ template <> struct divides<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{divides<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) / std::forward<U>(u)}.
@@ -12606,6 +12643,7 @@ template <> struct modulus<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{modulus<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) \% std::forward<U>(u)}.
@@ -12621,6 +12659,7 @@ template <> struct negate<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{negate<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{-std::forward<T>(t)}.
@@ -12640,6 +12679,7 @@ template <class T = void> struct equal_to {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{equal_to}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{x == y}.
@@ -12652,6 +12692,7 @@ template <class T = void> struct not_equal_to {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{not_equal_to}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{x != y}.
@@ -12664,6 +12705,7 @@ template <class T = void> struct greater {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{greater}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{x > y}.
@@ -12676,6 +12718,7 @@ template <class T = void> struct less {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{less}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{x < y}.
@@ -12688,6 +12731,7 @@ template <class T = void> struct greater_equal {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{greater_equal}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{x >= y}.
@@ -12700,6 +12744,7 @@ template <class T = void> struct less_equal {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{less_equal}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{x <= y}.
@@ -12715,6 +12760,7 @@ template <> struct equal_to<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{equal_to<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) == std::forward<U>(u)}.
@@ -12730,6 +12776,7 @@ template <> struct not_equal_to<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{not_equal_to<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) != std::forward<U>(u)}.
@@ -12745,6 +12792,7 @@ template <> struct greater<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{greater<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) > std::forward<U>(u)}.
@@ -12760,6 +12808,7 @@ template <> struct less<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{less<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) < std::forward<U>(u)}.
@@ -12775,6 +12824,7 @@ template <> struct greater_equal<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{greater_equal<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) >= std::forward<U>(u)}.
@@ -12790,6 +12840,7 @@ template <> struct less_equal<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{less_equal<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) <= std::forward<U>(u)}.
@@ -12818,6 +12869,7 @@ template <class T = void> struct logical_and {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{logical_and}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{x \&\& y}.
@@ -12830,6 +12882,7 @@ template <class T = void> struct logical_or {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{logical_or}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{x || y}.
@@ -12842,6 +12895,7 @@ template <class T = void> struct logical_not {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{logical_not}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{!x}.
@@ -12857,6 +12911,7 @@ template <> struct logical_and<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{logical_and<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) \&\& std::forward<U>(u)}.
@@ -12872,6 +12927,7 @@ template <> struct logical_or<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{logical_or<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) || std::forward<U>(u)}.
@@ -12887,6 +12943,7 @@ template <> struct logical_not<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{logical_not<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{!std::forward<T>(t)}.
@@ -12907,6 +12964,7 @@ template <class T = void> struct bit_and {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{bit_and}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{x \& y}.
@@ -12919,6 +12977,7 @@ template <class T = void> struct bit_or {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{bit_or}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{x | y}.
@@ -12931,6 +12990,7 @@ template <class T = void> struct bit_xor {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{bit_xor}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{x \^{} y}.
@@ -12942,6 +13002,7 @@ template <class T = void> struct bit_not {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{bit_not}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{\~{}x}.
@@ -12957,6 +13018,7 @@ template <> struct bit_and<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{bit_and<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) \& std::forward<U>(u)}.
@@ -12972,6 +13034,7 @@ template <> struct bit_or<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{bit_or<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) | std::forward<U>(u)}.
@@ -12987,6 +13050,7 @@ template <> struct bit_xor<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{bit_xor<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) \^{} std::forward<U>(u)}.
@@ -13002,6 +13066,7 @@ template <> struct bit_not<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{bit_not<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{\~{}std::forward<T>(t)}.
@@ -13178,7 +13243,7 @@ In the text that follows, the following names have the following meanings:
 \item \tcode{uj} is the $j^{th}$ argument associated with \tcode{Uj}.
 \end{itemize}
 
-\indexlibrary{\idxcode{bind}}
+\indexlibrary{\idxcode{bind}}%
 \begin{itemdecl}
 template<class F, class... BoundArgs>
   @\unspec@ bind(F&& f, BoundArgs&&... bound_args);
@@ -13217,7 +13282,7 @@ return type shall satisfy the requirements of \tcode{CopyConstructible}. \begin{
 that all of \tcode{FD} and \tcode{TiD} are \tcode{MoveConstructible}. \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{bind}}
+\indexlibrary{\idxcode{bind}}%
 \begin{itemdecl}
 template<class R, class F, class... BoundArgs>
   @\unspec@ bind(F&& f, BoundArgs&&... bound_args);
@@ -13344,7 +13409,7 @@ This subclause describes a polymorphic wrapper class that
 encapsulates arbitrary callable objects.
 
 \rSec3[func.wrap.badcall]{Class \tcode{bad_function_call}}%
-\indexlibrary{\idxcode{bad_function_call}}
+\indexlibrary{\idxcode{bad_function_call}}%
 
 \pnum
 An exception of type \tcode{bad_function_call} is thrown by
@@ -13364,7 +13429,7 @@ namespace std {
 \rSec4[func.wrap.badcall.const]{\tcode{bad_function_call} constructor}
 
 \indexlibrary{\idxcode{bad_function_call}!constructor}%
-\indexlibrarymember{bad_function_call}{what}%
+\indexlibrarymember{what}{bad_function_call}%
 \begin{itemdecl}
 bad_function_call() noexcept;
 \end{itemdecl}
@@ -13379,7 +13444,7 @@ bad_function_call() noexcept;
 \end{itemdescr}
 
 \rSec3[func.wrap.func]{Class template \tcode{function}}
-\indexlibrary{\idxcode{function}}
+\indexlibrary{\idxcode{function}}%
 
 \begin{codeblock}
 namespace std {
@@ -13464,7 +13529,7 @@ is \tcode{R(ArgTypes...)}.
 
 \rSec4[func.wrap.func.con]{\tcode{function} construct/copy/destroy}
 
-\indexlibrary{\idxcode{function}!constructor}
+\indexlibrary{\idxcode{function}!constructor}%
 \begin{itemdecl}
 function() noexcept;
 \end{itemdecl}
@@ -13473,7 +13538,7 @@ function() noexcept;
 \pnum\postcondition \tcode{!*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{function}!constructor}
+\indexlibrary{\idxcode{function}!constructor}%
 \begin{itemdecl}
 function(nullptr_t) noexcept;
 \end{itemdecl}
@@ -13483,7 +13548,7 @@ function(nullptr_t) noexcept;
 \postcondition \tcode{!*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{function}!constructor}
+\indexlibrary{\idxcode{function}!constructor}%
 \begin{itemdecl}
 function(const function& f);
 \end{itemdecl}
@@ -13504,7 +13569,7 @@ dynamically allocated memory for small callable objects, for example, where
 to an object and a member function pointer. \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{function}!constructor}
+\indexlibrary{\idxcode{function}!constructor}%
 \begin{itemdecl}
 function(function&& f);
 \end{itemdecl}
@@ -13528,7 +13593,7 @@ where \tcode{f}'s target is an object holding only a pointer or reference
 to an object and a member function pointer. \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{function}!constructor}
+\indexlibrary{\idxcode{function}!constructor}%
 \begin{itemdecl}
 template<class F> function(F f);
 \end{itemdecl}
@@ -13566,7 +13631,7 @@ may throw \tcode{bad_alloc} or any exception thrown by \tcode{F}'s copy
 or move constructor.
 \end{itemdescr}
 
-\indexlibrarymember{function}{operator=}%
+\indexlibrarymember{operator=}{function}%
 \begin{itemdecl}
 function& operator=(const function& f);
 \end{itemdecl}
@@ -13579,7 +13644,7 @@ function& operator=(const function& f);
 \returns \tcode{*this}
 \end{itemdescr}
 
-\indexlibrarymember{function}{operator=}%
+\indexlibrarymember{operator=}{function}%
 \begin{itemdecl}
 function& operator=(function&& f);
 \end{itemdecl}
@@ -13593,7 +13658,7 @@ with the target of \tcode{f}.
 \returns \tcode{*this}
 \end{itemdescr}
 
-\indexlibrarymember{function}{operator=}%
+\indexlibrarymember{operator=}{function}%
 \begin{itemdecl}
 function& operator=(nullptr_t) noexcept;
 \end{itemdecl}
@@ -13606,7 +13671,7 @@ function& operator=(nullptr_t) noexcept;
 \pnum\returns \tcode{*this}
 \end{itemdescr}
 
-\indexlibrarymember{function}{operator=}%
+\indexlibrarymember{operator=}{function}%
 \begin{itemdecl}
 template<class F> function& operator=(F&& f);
 \end{itemdecl}
@@ -13622,7 +13687,7 @@ Lvalue-Callable~(\ref{func.wrap.func}) for argument types \tcode{ArgTypes...} an
 return type \tcode{R}.
 \end{itemdescr}
 
-\indexlibrarymember{function}{operator=}%
+\indexlibrarymember{operator=}{function}%
 \begin{itemdecl}
 template<class F> function& operator=(reference_wrapper<F> f) noexcept;
 \end{itemdecl}
@@ -13645,7 +13710,7 @@ template<class F> function& operator=(reference_wrapper<F> f) noexcept;
 
 \rSec4[func.wrap.func.mod]{\tcode{function} modifiers}
 
-\indexlibrarymember{function}{swap}%
+\indexlibrarymember{swap}{function}%
 \begin{itemdecl}
 void swap(function& other) noexcept;
 \end{itemdecl}
@@ -13656,7 +13721,7 @@ void swap(function& other) noexcept;
 
 \rSec4[func.wrap.func.cap]{\tcode{function} capacity}
 
-\indexlibrary{\idxcode{function}!bool conversion}%
+\indexlibrarymember{operator bool}{function}%
 \begin{itemdecl}
 explicit operator bool() const noexcept;
 \end{itemdecl}
@@ -13669,7 +13734,7 @@ explicit operator bool() const noexcept;
 \rSec4[func.wrap.func.inv]{\tcode{function} invocation}
 
 \indexlibrary{\idxcode{function}!invocation}%
-\indexlibrarymember{function}{operator()}%
+\indexlibrarymember{operator()}{function}%
 \begin{itemdecl}
 R operator()(ArgTypes... args) const;
 \end{itemdecl}
@@ -13686,7 +13751,7 @@ exception thrown by the wrapped callable object.
 
 \rSec4[func.wrap.func.targ]{function target access}
 
-\indexlibrarymember{function}{target_type}%
+\indexlibrarymember{target_type}{function}%
 \begin{itemdecl}
 const type_info& target_type() const noexcept;
 \end{itemdecl}
@@ -13696,7 +13761,7 @@ const type_info& target_type() const noexcept;
   \tcode{typeid(T)}; otherwise, \tcode{typeid(void)}.
 \end{itemdescr}
 
-\indexlibrarymember{function}{target}%
+\indexlibrarymember{target}{function}%
 \begin{itemdecl}
 template<class T>       T* target() noexcept;
 template<class T> const T* target() const noexcept;
@@ -13727,7 +13792,7 @@ template <class R, class... ArgTypes>
 \pnum\returns \tcode{!f}.
 \end{itemdescr}
 
-\indexlibrarymember{function}{operator"!=}%
+\indexlibrarymember{operator"!=}{function}%
 \begin{itemdecl}
 template <class R, class... ArgTypes>
   bool operator!=(const function<R(ArgTypes...)>& f, nullptr_t) noexcept;
@@ -13741,7 +13806,7 @@ template <class R, class... ArgTypes>
 
 \rSec4[func.wrap.func.alg]{specialized algorithms}
 
-\indexlibrarymember{function}{swap}%
+\indexlibrarymember{swap}{function}%
 \begin{itemdecl}
 template<class R, class... ArgTypes>
   void swap(function<R(ArgTypes...)>& f1, function<R(ArgTypes...)>& f2);
@@ -13825,7 +13890,7 @@ Any exception thrown by the copy constructor of \tcode{BinaryPredicate} or
 \tcode{ForwardIterator1}.
 \end{itemdescr}
 
-\indexlibrarymember{default_searcher}{operator()}%
+\indexlibrarymember{operator()}{default_searcher}%
 \begin{itemdecl}
 template<class ForwardIterator2>
   pair<ForwardIterator2, ForwardIterator2>
@@ -13916,7 +13981,7 @@ or the copy constructor or \tcode{operator()} of \tcode{BinaryPredicate} or \tco
 May throw \tcode{bad_alloc} if additional memory needed for internal data structures cannot be allocated.
 \end{itemdescr}
 
-\indexlibrarymember{boyer_moore_searcher}{operator()}%
+\indexlibrarymember{operator()}{boyer_moore_searcher}%
 \begin{itemdecl}
 template <class RandomAccessIterator2>
   pair<RandomAccessIterator2, RandomAccessIterator2>
@@ -14031,7 +14096,7 @@ or the copy constructor or \tcode{operator()} of \tcode{BinaryPredicate} or \tco
 May throw \tcode{bad_alloc} if additional memory needed for internal data structures cannot be allocated.
 \end{itemdescr}
 
-\indexlibrarymember{boyer_moore_horspool_searcher}{operator()}%
+\indexlibrarymember{operator()}{boyer_moore_horspool_searcher}%
 \begin{itemdecl}
 template <class RandomAccessIterator2>
   pair<RandomAccessIterator2, RandomAccessIterator2>
@@ -14244,6 +14309,7 @@ template type argument and, optionally, additional arguments that help
 define the modification. It shall define a publicly accessible nested type
 named \tcode{type}, which shall be a synonym for the modified type.
 
+\indexlibrary{\idxhdr{type_traits}}%
 \rSec2[meta.type.synop]{Header \tcode{<type_traits>} synopsis}
 \begin{codeblock}
 namespace std {
@@ -15885,6 +15951,7 @@ type requirements. If a template parameter is named \tcode{R1} or \tcode{R2},
 and the template argument is not a specialization of the \tcode{ratio} template,
 the program is ill-formed.
 
+\indexlibrary{\idxhdr{ratio}}%
 \rSec2[ratio.syn]{Header \tcode{<ratio>} synopsis}
 
 \begin{codeblockdigitsep}
@@ -15946,6 +16013,7 @@ namespace std {
 
 \rSec2[ratio.ratio]{Class template \tcode{ratio}}
 
+\indexlibrary{\idxcode{ratio}}%
 \begin{codeblock}
 namespace std {
   template <intmax_t N, intmax_t D = 1>
@@ -16047,19 +16115,19 @@ static_assert(ratio_multiply<ratio<1, INT_MAX>, ratio<INT_MAX, 2>>::den == 2,
 
 \rSec2[ratio.comparison]{Comparison of \tcode{ratio}{s}}
 
-\indexlibrary{\idxcode{ratio_equal}}
+\indexlibrary{\idxcode{ratio_equal}}%
 \begin{itemdecl}
 template <class R1, class R2> struct ratio_equal
   : bool_constant<R1::num == R2::num && R1::den == R2::den> { };
 \end{itemdecl}
 
-\indexlibrary{\idxcode{ratio_not_equal}}
+\indexlibrary{\idxcode{ratio_not_equal}}%
 \begin{itemdecl}
 template <class R1, class R2> struct ratio_not_equal
   : bool_constant<!ratio_equal_v<R1, R2>> { };
 \end{itemdecl}
 
-\indexlibrary{\idxcode{ratio_less}}
+\indexlibrary{\idxcode{ratio_less}}%
 \begin{itemdecl}
 template <class R1, class R2> struct ratio_less
   : bool_constant<@\seebelow@> { };
@@ -16074,19 +16142,19 @@ derived from \tcode{bool_constant<true>}; otherwise it shall be derived from
 compute this relationship to avoid overflow. If overflow occurs, the program is ill-formed.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{ratio_less_equal}}
+\indexlibrary{\idxcode{ratio_less_equal}}%
 \begin{itemdecl}
 template <class R1, class R2> struct ratio_less_equal
   : bool_constant<!ratio_less_v<R2, R1>> { };
 \end{itemdecl}
 
-\indexlibrary{\idxcode{ratio_greater}}
+\indexlibrary{\idxcode{ratio_greater}}%
 \begin{itemdecl}
 template <class R1, class R2> struct ratio_greater
   : bool_constant<ratio_less_v<R2, R1>> { };
 \end{itemdecl}
 
-\indexlibrary{\idxcode{ratio_greater_equal}}
+\indexlibrary{\idxcode{ratio_greater_equal}}%
 \begin{itemdecl}
 template <class R1, class R2> struct ratio_greater_equal
   : bool_constant<!ratio_less_v<R1, R2>> { };
@@ -16111,6 +16179,7 @@ This subclause describes the chrono library~(\ref{time.syn}) and various C
 functions~(\ref{ctime.syn}) that provide generally useful time
 utilities.
 
+\indexlibrary{\idxhdr{chrono}}%
 \rSec2[time.syn]{Header \tcode{<chrono>} synopsis}
 
 \begin{codeblock}
@@ -16508,6 +16577,7 @@ A \tcode{duration} has a representation which holds a count of ticks and a tick 
 The tick period is the amount of time which occurs from one tick to the next, in units
 of seconds. It is expressed as a rational constant using the template \tcode{ratio}.
 
+\indexlibrary{\idxcode{duration}}%
 \begin{codeblock}
 template <class Rep, class Period = ratio<1>>
 class duration {
@@ -16977,7 +17047,7 @@ template <class Rep1, class Period1, class Rep2, class Period2>
 \returns \tcode{\placeholder{CT}(lhs).count() == \placeholder{CT}(rhs).count()}.
 \end{itemdescr}
 
-\indexlibrarymember{duration}{operator"!=}%
+\indexlibrarymember{operator"!=}{duration}%
 \begin{itemdecl}
 template <class Rep1, class Period1, class Rep2, class Period2>
   constexpr bool operator!=(const duration<Rep1, Period1>& lhs, const duration<Rep2, Period2>& rhs);
@@ -17082,7 +17152,7 @@ computations are carried out in the widest representation and only converted to
 the destination representation at the final step.
 \end{itemdescr}
 
-\indexlibrarymember{duration}{floor}%
+\indexlibrarymember{floor}{duration}%
 \begin{itemdecl}
 template <class ToDuration, class Rep, class Period>
   constexpr ToDuration floor(const duration<Rep, Period>& d);
@@ -17098,7 +17168,7 @@ unless \tcode{ToDuration} is a specialization of \tcode{duration}.
 for which \tcode{t <= d}.
 \end{itemdescr}
 
-\indexlibrarymember{duration}{ceil}%
+\indexlibrarymember{ceil}{duration}%
 \begin{itemdecl}
 template <class ToDuration, class Rep, class Period>
   constexpr ToDuration ceil(const duration<Rep, Period>& d);
@@ -17114,7 +17184,7 @@ unless \tcode{ToDuration} is a specialization of \tcode{duration}.
 for which \tcode{t >= d}.
 \end{itemdescr}
 
-\indexlibrarymember{duration}{round}%
+\indexlibrarymember{round}{duration}%
 \begin{itemdecl}
 template <class ToDuration, class Rep, class Period>
   constexpr ToDuration round(const duration<Rep, Period>& d);
@@ -17162,6 +17232,7 @@ auto constexpr halfanhour=0.5h;
 \end{codeblock}
 \end{example}
 
+\indexlibrarymember{operator """" h}{duration}%
 \begin{itemdecl}
 constexpr chrono::hours                                 operator "" h(unsigned long long hours);
 constexpr chrono::duration<@\unspec,@ ratio<3600, 1>> operator "" h(long double hours);
@@ -17173,6 +17244,7 @@ constexpr chrono::duration<@\unspec,@ ratio<3600, 1>> operator "" h(long double 
 A \tcode{duration} literal representing \tcode{hours} hours.
 \end{itemdescr}
 
+\indexlibrarymember{operator """" min}{duration}%
 \begin{itemdecl}
 constexpr chrono::minutes                             operator "" min(unsigned long long minutes);
 constexpr chrono::duration<@\unspec,@ ratio<60, 1>> operator "" min(long double minutes);
@@ -17184,6 +17256,7 @@ constexpr chrono::duration<@\unspec,@ ratio<60, 1>> operator "" min(long double 
 A \tcode{duration} literal representing \tcode{minutes} minutes.
 \end{itemdescr}
 
+\indexlibrarymember{operator """" s}{duration}%
 \begin{itemdecl}
 constexpr chrono::seconds  @\itcorr@             operator "" s(unsigned long long sec);
 constexpr chrono::duration<@\unspec@> operator "" s(long double sec);
@@ -17202,6 +17275,7 @@ apply to character array literals.
 \end{note}
 \end{itemdescr}
 
+\indexlibrarymember{operator """" ms}{duration}%
 \begin{itemdecl}
 constexpr chrono::milliseconds                 operator "" ms(unsigned long long msec);
 constexpr chrono::duration<@\unspec,@ milli> operator "" ms(long double msec);
@@ -17213,6 +17287,7 @@ constexpr chrono::duration<@\unspec,@ milli> operator "" ms(long double msec);
 A \tcode{duration} literal representing \tcode{msec} milliseconds.
 \end{itemdescr}
 
+\indexlibrarymember{operator """" us}{duration}%
 \begin{itemdecl}
 constexpr chrono::microseconds                 operator "" us(unsigned long long usec);
 constexpr chrono::duration<@\unspec,@ micro> operator "" us(long double usec);
@@ -17224,6 +17299,7 @@ constexpr chrono::duration<@\unspec,@ micro> operator "" us(long double usec);
 A \tcode{duration} literal representing \tcode{usec} microseconds.
 \end{itemdescr}
 
+\indexlibrarymember{operator """" ns}{duration}%
 \begin{itemdecl}
 constexpr chrono::nanoseconds                 operator "" ns(unsigned long long nsec);
 constexpr chrono::duration<@\unspec,@ nano> operator "" ns(long double nsec);
@@ -17237,7 +17313,7 @@ A \tcode{duration} literal representing \tcode{nsec} nanoseconds.
 
 \rSec3[time.duration.alg]{\tcode{duration} algorithms}
 
-\indexlibrarymember{duration}{abs}%
+\indexlibrarymember{abs}{duration}%
 \begin{itemdecl}
 template <class Rep, class Period>
   constexpr duration<Rep, Period> abs(duration<Rep, Period> d);
@@ -17255,6 +17331,7 @@ otherwise return \tcode{-d}.
 
 \rSec2[time.point]{Class template \tcode{time_point}}
 
+\indexlibrary{\idxcode{time_point}}%
 \begin{codeblock}
 template <class Clock, class Duration = typename Clock::duration>
 class time_point {
@@ -17337,7 +17414,7 @@ is implicitly convertible to \tcode{duration}.
 
 \rSec3[time.point.observer]{\tcode{time_point} observer}
 
-\indexlibrarymember{time_point}{time_since_epoch}%
+\indexlibrarymember{time_since_epoch}{time_point}%
 \begin{itemdecl}
 constexpr duration time_since_epoch() const;
 \end{itemdecl}
@@ -17463,8 +17540,7 @@ template <class Clock, class Duration1, class Duration2>
 \returns \tcode{lhs.time_since_epoch() == rhs.time_since_epoch()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{time_point}}%
-\indexlibrary{\idxcode{time_point}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{time_point}%
 \begin{itemdecl}
 template <class Clock, class Duration1, class Duration2>
   constexpr bool operator!=(const time_point<Clock, Duration1>& lhs, const time_point<Clock, Duration2>& rhs);
@@ -17538,7 +17614,7 @@ unless \tcode{ToDuration} is a specialization of \tcode{duration}.
 \returns \tcode{time_point<Clock, ToDuration>(duration_cast<ToDuration>(t.time_since_epoch()))}.
 \end{itemdescr}
 
-\indexlibrarymember{time_point}{floor}%
+\indexlibrarymember{floor}{time_point}%
 \begin{itemdecl}
 template <class ToDuration, class Clock, class Duration>
   constexpr time_point<Clock, ToDuration>
@@ -17554,7 +17630,7 @@ unless \tcode{ToDuration} is a specialization of \tcode{duration}.
 \returns \tcode{time_point<Clock, ToDuration>(floor<ToDuration>(tp.time_since_epoch()))}.
 \end{itemdescr}
 
-\indexlibrarymember{time_point}{ceil}%
+\indexlibrarymember{ceil}{time_point}%
 \begin{itemdecl}
 template <class ToDuration, class Clock, class Duration>
   constexpr time_point<Clock, ToDuration>
@@ -17570,7 +17646,7 @@ unless \tcode{ToDuration} is a specialization of \tcode{duration}.
 \returns \tcode{time_point<Clock, ToDuration>(ceil<ToDuration>(tp.time_since_epoch()))}.
 \end{itemdescr}
 
-\indexlibrarymember{time_point}{round}%
+\indexlibrarymember{round}{time_point}%
 \begin{itemdecl}
 template <class ToDuration, class Clock, class Duration>
   constexpr time_point<Clock, ToDuration>
@@ -17595,6 +17671,7 @@ The types defined in this subclause shall satisfy the
 requirements~(\ref{time.clock.req}).
 
 \rSec3[time.clock.system]{Class \tcode{system_clock}}
+\indexlibrary{\idxcode{system_clock}}%
 
 \pnum
 Objects of class \tcode{system_clock} represent wall clock time from the system-wide
@@ -17628,7 +17705,7 @@ using system_clock::rep = @\unspec@;
 be \tcode{true}. \begin{note} This implies that \tcode{rep} is a signed type. \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{to_time_t}}%
+\indexlibrarymember{to_time_t}{system_clock}%
 \begin{itemdecl}
 static time_t to_time_t(const time_point& t) noexcept;
 \end{itemdecl}
@@ -17643,7 +17720,7 @@ required precision when converting between \tcode{time_t} values and \tcode{time
 whether values are rounded or truncated to the required precision.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{from_time_t}}%
+\indexlibrarymember{from_time_t}{system_clock}%
 \begin{itemdecl}
 static time_point from_time_t(time_t t) noexcept;
 \end{itemdecl}
@@ -17659,6 +17736,7 @@ whether values are rounded or truncated to the required precision.
 \end{itemdescr}
 
 \rSec3[time.clock.steady]{Class \tcode{steady_clock}}
+\indexlibrary{\idxcode{steady_clock}}%
 
 \pnum
 Objects of class \tcode{steady_clock} represent clocks for which values of \tcode{time_point}
@@ -17679,6 +17757,7 @@ public:
 \end{codeblock}
 
 \rSec3[time.clock.hires]{Class \tcode{high_resolution_clock}}
+\indexlibrary{\idxcode{high_resolution_clock}}%
 
 \pnum
 Objects of class \tcode{high_resolution_clock} represent clocks with the
@@ -17763,7 +17842,7 @@ races~(\ref{res.on.data.races}).
 
 \rSec1[type.index]{Class \tcode{type_index}}
 
-\indexlibrary{\idxhdr{typeinfo}}%
+\indexlibrary{\idxhdr{typeindex}}%
 \rSec2[type.index.synopsis]{Header \tcode{<typeindex>} synopsis}
 
 \begin{codeblock}
@@ -17776,6 +17855,7 @@ namespace std {
 
 \rSec2[type.index.overview]{\tcode{type_index} overview}
 
+\indexlibrary{\idxcode{type_index}}%
 \begin{codeblock}
 namespace std {
   class type_index {
@@ -17826,8 +17906,7 @@ bool operator==(const type_index& rhs) const noexcept;
 \returns \tcode{*target == *rhs.target}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{type_index}}%
-\indexlibrary{\idxcode{type_index}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{type_index}%
 \begin{itemdecl}
 bool operator!=(const type_index& rhs) const noexcept;
 \end{itemdecl}
@@ -17899,7 +17978,7 @@ const char* name() const noexcept;
 
 \rSec2[type.index.hash]{Hash support}
 
-\indexlibrary{\idxcode{hash}}%
+\indexlibrary{\idxcode{hash}!\idxcode{type_index}}%
 \begin{itemdecl}
 template <> struct hash<type_index>;
 \end{itemdecl}


### PR DESCRIPTION
This review handles several topic related to the index
of library names:
  fix outright errors, indexing the wrong name
  fix errors of omission: every itemdecl is now indexed
  consistent ordering of indexlibrarymember{identifier}{class-name}
  every index macro has a trailing % to avoid accidental whitespace
  all headers have an idxhdr entry