### PR TITLE
[language.support] review of library index

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -1282,7 +1282,7 @@ duration and without calling functions passed to
 \indexlibrary{\idxcode{atexit}}%
 \end{itemdescr}
 
-\indexlibrary{\idxcode{atexit}}
+\indexlibrary{\idxcode{atexit}}%
 \begin{itemdecl}
 extern "C" int atexit(void (*f)()) noexcept;
 extern "C++" int atexit(void (*f)()) noexcept;
@@ -1341,7 +1341,7 @@ by throwing an exception that is caught in
 
 If control leaves a registered function called by \tcode{exit} because the function does
 not provide a handler for a thrown exception, \tcode{std::terminate()} shall be called~(\ref{except.terminate}).%
-\indexlibrary{\idxcode{terminate}}
+\indexlibrary{\idxcode{terminate}}%
 
 \item
 Next, all open C streams (as mediated by the function
@@ -1377,7 +1377,7 @@ are defined in
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{at_quick_exit}}
+\indexlibrary{\idxcode{at_quick_exit}}%
 \begin{itemdecl}
 extern "C" int at_quick_exit(void (*f)()) noexcept;
 extern "C++" int at_quick_exit(void (*f)()) noexcept;
@@ -1408,7 +1408,7 @@ The implementation shall support the registration of at least 32 functions.
 \returns Zero if the registration succeeds, non-zero if it fails.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{quick_exit}}
+\indexlibrary{\idxcode{quick_exit}}%
 \begin{itemdecl}
 [[noreturn]] void quick_exit(int status) noexcept;
 \end{itemdecl}
@@ -1422,7 +1422,7 @@ registered. Objects shall not be destroyed as a result of calling \tcode{quick_e
 If control leaves a registered function called by \tcode{quick_exit} because the
 function does not provide a handler for a thrown exception, \tcode{std::terminate()} shall
 be called.%
-\indexlibrary{\idxcode{terminate}}
+\indexlibrary{\idxcode{terminate}}%
 \begin{note} \tcode{at_quick_exit} may call a registered function from a different thread
 than the one that registered it, so registered functions should not rely on the identity
 of objects with thread storage duration. \end{note}
@@ -2172,7 +2172,7 @@ Constructs an object of class
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bad_alloc}!constructor}%
-\indexlibrary{\idxcode{operator=}!\idxcode{bad_alloc}}%
+\indexlibrarymember{operator=}{bad_alloc}%
 \begin{itemdecl}
 bad_alloc(const bad_alloc&) noexcept;
 bad_alloc& operator=(const bad_alloc&) noexcept;
@@ -2231,7 +2231,7 @@ bad_array_new_length() noexcept;
 \effects constructs an object of class \tcode{bad_array_new_length}.
 \end{itemdescr}
 
-\indexlibrarymember{bad_array_new_length}{what}%
+\indexlibrarymember{what}{bad_array_new_length}%
 \begin{itemdecl}
 const char* what() const noexcept override;
 \end{itemdecl}
@@ -2503,8 +2503,7 @@ Compares the current object with \tcode{rhs}.
 if the two values describe the same type.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{type_info}}%
-\indexlibrary{\idxcode{type_info}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{type_info}%
 \begin{itemdecl}
 bool operator!=(const type_info& rhs) const noexcept;
 \end{itemdecl}
@@ -2550,7 +2549,7 @@ objects which compare equal.
 \end{itemdescr}
 
 
-\indexlibrarymember{type_info}{name}%
+\indexlibrarymember{name}{type_info}%
 \begin{itemdecl}
 const char* name() const noexcept;
 \end{itemdecl}
@@ -2604,7 +2603,7 @@ Constructs an object of class
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bad_cast}!constructor}%
-\indexlibrary{\idxcode{operator=}!\idxcode{bad_cast}}%
+\indexlibrarymember{operator=}{bad_cast}%
 \begin{itemdecl}
 bad_cast(const bad_cast&) noexcept;
 bad_cast& operator=(const bad_cast&) noexcept;
@@ -2617,7 +2616,7 @@ Copies an object of class
 \tcode{bad_cast}.
 \end{itemdescr}
 
-\indexlibrarymember{bad_cast}{what}%
+\indexlibrarymember{what}{bad_cast}%
 \begin{itemdecl}
 const char* what() const noexcept override;
 \end{itemdecl}
@@ -2671,7 +2670,7 @@ Constructs an object of class
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bad_typeid}!constructor}%
-\indexlibrary{\idxcode{operator=}!\idxcode{bad_typeid}}%
+\indexlibrarymember{operator=}{bad_typeid}%
 \begin{itemdecl}
 bad_typeid(const bad_typeid&) noexcept;
 bad_typeid& operator=(const bad_typeid&) noexcept;
@@ -2684,7 +2683,7 @@ Copies an object of class
 \tcode{bad_typeid}.
 \end{itemdescr}
 
-\indexlibrarymember{bad_typeid}{what}%
+\indexlibrarymember{what}{bad_typeid}%
 \begin{itemdecl}
 const char* what() const noexcept override;
 \end{itemdecl}
@@ -2790,7 +2789,7 @@ Constructs an object of class
 \end{itemdescr}
 
 \indexlibrary{\idxcode{exception}!constructor}%
-\indexlibrary{\idxcode{operator=}!\idxcode{exception}}%
+\indexlibrarymember{operator=}{exception}%
 \begin{itemdecl}
 exception(const exception& rhs) noexcept;
 exception& operator=(const exception& rhs) noexcept;
@@ -2820,7 +2819,7 @@ Destroys an object of class
 \tcode{exception}.
 \end{itemdescr}
 
-\indexlibrarymember{exception}{what}%
+\indexlibrarymember{what}{exception}%
 \begin{itemdecl}
 virtual const char* what() const noexcept;
 \end{itemdecl}
@@ -2874,7 +2873,7 @@ Constructs an object of class
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bad_exception}!constructor}%
-\indexlibrary{\idxcode{operator=}!\idxcode{bad_exception}}%
+\indexlibrarymember{operator=}{bad_exception}%
 \begin{itemdecl}
 bad_exception(const bad_exception&) noexcept;
 bad_exception& operator=(const bad_exception&) noexcept;
@@ -2887,7 +2886,7 @@ Copies an object of class
 \tcode{bad_exception}.
 \end{itemdescr}
 
-\indexlibrarymember{bad_exception}{what}%
+\indexlibrarymember{what}{bad_exception}%
 \begin{itemdecl}
 const char* what() const noexcept override;
 \end{itemdecl}
@@ -2931,7 +2930,7 @@ terminate execution of the program without returning to the caller.
 \default
 The implementation's default \tcode{terminate_handler} calls
 \tcode{abort()}.%
-\indexlibrary{\idxcode{abort}}
+\indexlibrary{\idxcode{abort}}%
 \end{itemdescr}
 
 \rSec3[set.terminate]{\tcode{set_terminate}}
@@ -3014,7 +3013,7 @@ throwing an exception can result in a call of\\
 
 \rSec2[propagation]{Exception propagation}
 
-\indexlibrary{\idxcode{exception_ptr}}
+\indexlibrary{\idxcode{exception_ptr}}%
 \begin{itemdecl}
 using exception_ptr = @\unspec@;
 \end{itemdecl}
@@ -3055,7 +3054,7 @@ Changes in the number of \tcode{exception_ptr} objects that refer to a
 particular exception do not introduce a data race. \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{current_exception}}
+\indexlibrary{\idxcode{current_exception}}%
 \begin{itemdecl}
 exception_ptr current_exception() noexcept;
 \end{itemdecl}
@@ -3081,7 +3080,7 @@ to substitute a \tcode{bad_exception} object to avoid infinite
 recursion.\end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{rethrow_exception}}
+\indexlibrary{\idxcode{rethrow_exception}}%
 \begin{itemdecl}
 [[noreturn]] void rethrow_exception(exception_ptr p);
 \end{itemdecl}
@@ -3094,7 +3093,7 @@ recursion.\end{note}
 \throws the exception object to which \tcode{p} refers.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{make_exception_ptr}}
+\indexlibrary{\idxcode{make_exception_ptr}}%
 \begin{itemdecl}
 template<class E> exception_ptr make_exception_ptr(E e) noexcept;
 \end{itemdecl}
@@ -3147,7 +3146,7 @@ for later use.
 polymorphic class. Its presence can be tested for with \tcode{dynamic_cast}.
 \end{note}
 
-\indexlibrary{\idxcode{nested_exception}!constructor}
+\indexlibrary{\idxcode{nested_exception}!constructor}%
 \begin{itemdecl}
 nested_exception() noexcept;
 \end{itemdecl}
@@ -3269,7 +3268,7 @@ If an explicit specialization or partial specialization of
 
 \rSec2[support.initlist.cons]{Initializer list constructors}
 
-\indexlibrary{\idxcode{initializer_list}!constructor}
+\indexlibrary{\idxcode{initializer_list}!constructor}%
 \begin{itemdecl}
 constexpr initializer_list() noexcept;
 \end{itemdecl}
@@ -3321,7 +3320,7 @@ constexpr size_t size() const noexcept;
 
 \rSec2[support.initlist.range]{Initializer list range access}
 
-\indexlibrary{\idxcode{begin(initializer_list<E>)}}
+\indexlibrary{\idxcode{begin(initializer_list<E>)}}%
 \begin{itemdecl}
 template<class E> constexpr const E* begin(initializer_list<E> il) noexcept;
 \end{itemdecl}
@@ -3331,7 +3330,7 @@ template<class E> constexpr const E* begin(initializer_list<E> il) noexcept;
 \returns \tcode{il.begin()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{end(initializer_list<E>)}}
+\indexlibrary{\idxcode{end(initializer_list<E>)}}%
 \begin{itemdecl}
 template<class E> constexpr const E* end(initializer_list<E> il) noexcept;
 \end{itemdecl}


### PR DESCRIPTION
This review handles several topic related to the index of library names:

    apply indeglibrarymember for all member functions other than constructors/destructors
    consistent ordering of indexlibrarymember{identifier}{class-name}
    every index macro has a trailing % to avoid accidental whitespace