### PR TITLE
[diagnostics] review of library index

### DIFF
--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -486,7 +486,7 @@ Constructs an object of class
 
 \rSec2[underflow.error]{Class \tcode{underflow_error}}
 
-\indexlibrary{\idxcode{overflow_error}}%
+\indexlibrary{\idxcode{underflow_error}}%
 \begin{codeblock}
 namespace std {
   class underflow_error : public runtime_error {
@@ -769,6 +769,8 @@ Implementations should leave the error states provided by other
 libraries unchanged.
 
 \rSec2[system_error.syn]{Header \tcode{<system_error>} synopsis}
+\indextext{\idxhdr{system_error}}%
+\indexlibrary{\idxhdr{system_error}}%
 \indexlibrary{\idxcode{error_category}}%
 \indexlibrary{\idxcode{error_code}}%
 \indexlibrary{\idxcode{error_condition}}%
@@ -1044,8 +1046,7 @@ bool operator==(const error_category& rhs) const noexcept;
 \returns \tcode{this == \&rhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{error_category}}%
-\indexlibrary{\idxcode{error_category}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{error_category}%
 \begin{itemdecl}
 bool operator!=(const error_category& rhs) const noexcept;
 \end{itemdecl}
@@ -1387,7 +1388,7 @@ The class \tcode{error_condition} describes an object used to hold values identi
 error conditions. \begin{note} \tcode{error_condition} values are portable abstractions,
 while \tcode{error_code} values~(\ref{syserr.errcode}) are implementation specific. \end{note}
 
-\indexlibrary{\idxcode{error_code}}%
+\indexlibrary{\idxcode{error_condition}}%
 \begin{codeblock}
 namespace std {
   class error_condition {
@@ -1615,10 +1616,8 @@ bool operator==(const error_condition& lhs, const error_condition& rhs) noexcept
 \returns \tcode{lhs.category() == rhs.category() \&\& lhs.value() == rhs.value()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{error_code}}%
-\indexlibrary{\idxcode{error_code}!\idxcode{operator"!=}}%
-\indexlibrary{\idxcode{operator"!=}!\idxcode{error_condition}}%
-\indexlibrary{\idxcode{error_condition}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{error_code}%
+\indexlibrarymember{operator"!=}{error_condition}%
 \begin{itemdecl}
 bool operator!=(const error_code& lhs, const error_code& rhs) noexcept;
 bool operator!=(const error_code& lhs, const error_condition& rhs) noexcept;
@@ -1633,7 +1632,7 @@ bool operator!=(const error_condition& lhs, const error_condition& rhs) noexcept
 
 \rSec2[syserr.hash]{System error hash support}
 
-\indexlibrary{\idxcode{hash}}%
+\indexlibrary{\idxcode{hash}!\idxcode{error_code}}%
 \begin{itemdecl}
 template <> struct hash<error_code>;
 \end{itemdecl}
@@ -1672,7 +1671,7 @@ namespace std {
         const char* what_arg);
     system_error(int ev, const error_category& ecat);
     const error_code& code() const noexcept;
-    const char* what() const noexcept;
+    const char* what() const noexcept override;
   };
 }   // namespace std
 \end{codeblock}
@@ -1780,7 +1779,7 @@ as appropriate.
 
 \indexlibrarymember{what}{system_error}%
 \begin{itemdecl}
-const char* what() const noexcept;
+const char* what() const noexcept override;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
This review handles several topic related to the index of library names:

      ensure every &lt;header> has an idxdhr entry in the library index
      fix outright errors, indexing the wrong name
      properly index has functor specialization for type
      consistently apply \indexlibrarymember for operator!= overloads
      (drive by fix for 'override' on 'what' function)