### PR TITLE
[strings] review of library index

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -1556,8 +1556,8 @@ basic_string& operator=(initializer_list<charT> il);
 
 \rSec3[string.iterators]{\tcode{basic_string} iterator support}
 
-\indexlibrarymember{basic_string}{begin}%
-\indexlibrarymember{basic_string}{cbegin}%
+\indexlibrarymember{begin}{basic_string}%
+\indexlibrarymember{cbegin}{basic_string}%
 \begin{itemdecl}
 iterator       begin() noexcept;
 const_iterator begin() const noexcept;
@@ -1616,7 +1616,7 @@ An iterator which is semantically equivalent to
 
 \rSec3[string.capacity]{\tcode{basic_string} capacity}
 
-\indexlibrarymember{basic_string}{size}%
+\indexlibrarymember{size}{basic_string}%
 \begin{itemdecl}
 size_type size() const noexcept;
 \end{itemdecl}
@@ -1641,7 +1641,7 @@ size_type length() const noexcept;
 \tcode{size()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{max_size}%
+\indexlibrarymember{max_size}{basic_string}%
 \begin{itemdecl}
 size_type max_size() const noexcept;
 \end{itemdecl}
@@ -1655,7 +1655,7 @@ The size of the largest possible string.
 \complexity Constant time.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{resize}%
+\indexlibrarymember{resize}{basic_string}%
 \begin{itemdecl}
 void resize(size_type n, charT c);
 \end{itemdecl}
@@ -1706,7 +1706,7 @@ void resize(size_type n);
 As if by \tcode{resize(n, charT())}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{capacity}%
+\indexlibrarymember{capacity}{basic_string}%
 \begin{itemdecl}
 size_type capacity() const noexcept;
 \end{itemdecl}
@@ -1717,7 +1717,7 @@ size_type capacity() const noexcept;
 The size of the allocated storage in the string.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{reserve}%
+\indexlibrarymember{reserve}{basic_string}%
 \begin{itemdecl}
 void reserve(size_type res_arg=0);
 \end{itemdecl}
@@ -1759,7 +1759,7 @@ uses
 which may throw an appropriate exception.}
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{shrink_to_fit}%
+\indexlibrarymember{shrink_to_fit}{basic_string}%
 \begin{itemdecl}
 void shrink_to_fit();
 \end{itemdecl}
@@ -1771,7 +1771,7 @@ void shrink_to_fit();
 allow latitude for implementation-specific optimizations. \end{note}
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{clear}%
+\indexlibrarymember{clear}{basic_string}%
 \begin{itemdecl}
 void clear() noexcept;
 \end{itemdecl}
@@ -1786,7 +1786,7 @@ erase(begin(), end());
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{empty}%
+\indexlibrarymember{empty}{basic_string}%
 \begin{itemdecl}
 bool empty() const noexcept;
 \end{itemdecl}
@@ -1799,7 +1799,7 @@ bool empty() const noexcept;
 
 \rSec3[string.access]{\tcode{basic_string} element access}
 
-\indexlibrarymember{basic_string}{operator[]}%
+\indexlibrarymember{operator[]}{basic_string}%
 \begin{itemdecl}
 const_reference operator[](size_type pos) const;
 reference       operator[](size_type pos);
@@ -1822,7 +1822,7 @@ undefined behavior.
 \complexity Constant time.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{at}%
+\indexlibrarymember{at}{basic_string}%
 \begin{itemdecl}
 const_reference at(size_type pos) const;
 reference       at(size_type pos);
@@ -1840,7 +1840,7 @@ if
 \tcode{operator[](pos)}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{front}%
+\indexlibrarymember{front}{basic_string}%
 \begin{itemdecl}
 const charT& front() const;
 charT& front();
@@ -1856,7 +1856,7 @@ charT& front();
 Equivalent to \tcode{operator[](0)}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{back}%
+\indexlibrarymember{back}{basic_string}%
 \begin{itemdecl}
 const charT& back() const;
 charT& back();
@@ -1876,7 +1876,7 @@ Equivalent to \tcode{operator[](size() - 1)}.
 
 \rSec4[string::op+=]{\tcode{basic_string::operator+=}}
 
-\indexlibrarymember{basic_string}{operator+=}%
+\indexlibrarymember{operator+=}{basic_string}%
 \begin{itemdecl}
 basic_string&
   operator+=(const basic_string& str);
@@ -1920,7 +1920,7 @@ basic_string& operator+=(const charT* s);
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{operator+=}%
+\indexlibrarymember{operator+=}{basic_string}%
 \begin{itemdecl}
 basic_string& operator+=(charT c);
 \end{itemdecl}
@@ -1950,7 +1950,7 @@ basic_string& operator+=(initializer_list<charT> il);
 
 \rSec4[string::append]{\tcode{basic_string::append}}
 
-\indexlibrarymember{basic_string}{append}%
+\indexlibrarymember{append}{basic_string}%
 \begin{itemdecl}
 basic_string&
   append(const basic_string& str);
@@ -2068,7 +2068,7 @@ elements of \tcode{charT}.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{append}%
+\indexlibrarymember{append}{basic_string}%
 \begin{itemdecl}
 basic_string& append(size_type n, charT c);
 \end{itemdecl}
@@ -2128,7 +2128,7 @@ Equivalent to
 
 \rSec4[string::assign]{\tcode{basic_string::assign}}
 
-\indexlibrarymember{basic_string}{assign}%
+\indexlibrarymember{assign}{basic_string}%
 \begin{itemdecl}
 basic_string& assign(const basic_string& str);
 \end{itemdecl}
@@ -2273,7 +2273,7 @@ basic_string& assign(initializer_list<charT> il);
 \end{itemdescr}
 
 
-\indexlibrary{\idxcode{length}!\idxcode{char_traits}}%
+\indexlibrarymember{assign}{basic_string}%
 \begin{itemdecl}
 basic_string& assign(size_type n, charT c);
 \end{itemdecl}
@@ -2304,7 +2304,7 @@ template<class InputIterator>
 
 \rSec4[string::insert]{\tcode{basic_string::insert}}
 
-\indexlibrarymember{basic_string}{insert}%
+\indexlibrarymember{insert}{basic_string}%
 \begin{itemdecl}
 basic_string&
   insert(size_type pos1,
@@ -2424,7 +2424,7 @@ basic_string&
 \effects Equivalent to: \tcode{return insert(pos, s, traits::length(s));}
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{insert}%
+\indexlibrarymember{insert}{basic_string}%
 \begin{itemdecl}
 basic_string&
   insert(size_type pos, size_type n, charT c);
@@ -2519,7 +2519,7 @@ iterator insert(const_iterator p, initializer_list<charT> il);
 
 \rSec4[string::erase]{\tcode{basic_string::erase}}
 
-\indexlibrarymember{basic_string}{erase}%
+\indexlibrarymember{erase}{basic_string}%
 \begin{itemdecl}
 basic_string& erase(size_type pos = 0, size_type n = npos);
 \end{itemdecl}
@@ -2606,7 +2606,7 @@ If no such element exists,
 is returned.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{pop_back}%
+\indexlibrarymember{pop_back}{basic_string}%
 \begin{itemdecl}
 void pop_back();
 \end{itemdecl}
@@ -2626,7 +2626,7 @@ Equivalent to \tcode{erase(size() - 1, 1)}.
 
 \rSec4[string::replace]{\tcode{basic_string::replace}}
 
-\indexlibrarymember{basic_string}{replace}%
+\indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
 basic_string&
   replace(size_type pos1, size_type n1,
@@ -2666,7 +2666,7 @@ as the smaller of \tcode{n2} and \tcode{str.size() - pos2} and calls
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{replace}%
+\indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
 basic_string& replace(size_type pos1, size_type n1,
                       basic_string_view<charT, traits> sv);
@@ -2678,7 +2678,7 @@ basic_string& replace(size_type pos1, size_type n1,
 Equivalent to: \tcode{return replace(pos1, n1, sv.data(), sv.size());}
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{replace}%
+\indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
 basic_string& replace(size_type pos1, size_type n1,
                       basic_string_view<charT, traits> sv,
@@ -2752,7 +2752,7 @@ basic_string&
 \effects Equivalent to: \tcode{return replace(pos, n, s, traits::length(s));}
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{replace}%
+\indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
 basic_string&
   replace(size_type pos1, size_type n1,
@@ -2903,7 +2903,7 @@ basic_string& replace(const_iterator i1, const_iterator i2,
 
 \rSec4[string::copy]{\tcode{basic_string::copy}}
 
-\indexlibrarymember{basic_string}{copy}%
+\indexlibrarymember{copy}{basic_string}%
 \begin{itemdecl}
 size_type copy(charT* s, size_type n, size_type pos = 0) const;
 \end{itemdecl}
@@ -2939,7 +2939,7 @@ by \tcode{s}.
 
 \rSec4[string::swap]{\tcode{basic_string::swap}}
 
-\indexlibrarymember{basic_string}{swap}%
+\indexlibrarymember{swap}{basic_string}%
 \begin{itemdecl}
 void swap(basic_string& s)
   noexcept(allocator_traits<Allocator>::propagate_on_container_swap::value ||
@@ -2965,10 +2965,8 @@ contains the same sequence of characters that was in \tcode{s},
 
 \rSec4[string.accessors]{\tcode{basic_string} accessors}
 
-\indexlibrary{\idxcode{c_str}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{data}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{c_str}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{data}}%
+\indexlibrarymember{c_str}{basic_string}%
+\indexlibrarymember{data}{basic_string}%
 \begin{itemdecl}
 const charT* c_str() const noexcept;
 const charT* data() const noexcept;
@@ -3005,7 +3003,7 @@ charT* data() noexcept;
 The program shall not alter the value stored at \tcode{p + size()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{operator basic_string_view}%
+\indexlibrarymember{operator basic_string_view}{basic_string}%
 \begin{itemdecl}
 operator basic_string_view<charT, traits>() const noexcept;
 \end{itemdecl}
@@ -3032,7 +3030,7 @@ copy of the most recent replacement.
 
 \rSec4[string::find]{\tcode{basic_string::find}}
 
-\indexlibrarymember{basic_string}{find}%
+\indexlibrarymember{find}{basic_string}%
 \begin{itemdecl}
 size_type find(basic_string_view<charT, traits> sv,
                size_type pos = 0) const noexcept;
@@ -3066,7 +3064,7 @@ Uses
 \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{find}%
+\indexlibrarymember{find}{basic_string}%
 \begin{itemdecl}
 size_type find(const basic_string& str,
                size_type pos = 0) const noexcept;
@@ -3104,7 +3102,7 @@ elements of \tcode{charT}.
 \tcode{find(basic_string_view<charT, traits>(s), pos)}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{find}%
+\indexlibrarymember{find}{basic_string}%
 \begin{itemdecl}
 size_type find(charT c, size_type pos = 0) const;
 \end{itemdecl}
@@ -3117,7 +3115,7 @@ size_type find(charT c, size_type pos = 0) const;
 
 \rSec4[string::rfind]{\tcode{basic_string::rfind}}
 
-\indexlibrarymember{basic_string}{rfind}%
+\indexlibrarymember{rfind}{basic_string}%
 \begin{itemdecl}
 size_type rfind(basic_string_view<charT, traits> sv,
                 size_type pos = npos) const noexcept;
@@ -3152,7 +3150,7 @@ Uses
 \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{rfind}%
+\indexlibrarymember{rfind}{basic_string}%
 \begin{itemdecl}
 size_type rfind(const basic_string& str,
                 size_type pos = npos) const noexcept;
@@ -3190,7 +3188,7 @@ elements of \tcode{charT}.
 \tcode{rfind(basic_string_view<charT, traits>(s), pos)}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{rfind}%
+\indexlibrarymember{rfind}{basic_string}%
 \begin{itemdecl}
 size_type rfind(charT c, size_type pos = npos) const;
 \end{itemdecl}
@@ -3203,7 +3201,7 @@ size_type rfind(charT c, size_type pos = npos) const;
 
 \rSec4[string::find.first.of]{\tcode{basic_string::find_first_of}}
 
-\indexlibrarymember{basic_string}{find_first_of}%
+\indexlibrarymember{find_first_of}{basic_string}%
 \begin{itemdecl}
 size_type find_first_of(basic_string_view<charT, traits> sv,
                         size_type pos = 0) const noexcept;
@@ -3238,7 +3236,7 @@ Uses
 \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{find_first_of}%
+\indexlibrarymember{find_first_of}{basic_string}%
 \begin{itemdecl}
 size_type find_first_of(const basic_string& str,
                         size_type pos = 0) const noexcept;
@@ -3277,7 +3275,7 @@ elements of \tcode{charT}.
 \tcode{find_first_of(basic_string_view<charT, traits>(s), pos)}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{find_first_of}%
+\indexlibrarymember{find_first_of}{basic_string}%
 \begin{itemdecl}
 size_type find_first_of(charT c, size_type pos = 0) const;
 \end{itemdecl}
@@ -3290,7 +3288,7 @@ size_type find_first_of(charT c, size_type pos = 0) const;
 
 \rSec4[string::find.last.of]{\tcode{basic_string::find_last_of}}
 
-\indexlibrarymember{basic_string}{find_last_of}%
+\indexlibrarymember{find_last_of}{basic_string}%
 \begin{itemdecl}
 size_type find_last_of (basic_string_view<charT, traits> sv,
                         size_type pos = npos) const noexcept;
@@ -3325,7 +3323,7 @@ Uses
 \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{find_last_of}%
+\indexlibrarymember{find_last_of}{basic_string}%
 \begin{itemdecl}
 size_type find_last_of(const basic_string& str,
                        size_type pos = npos) const noexcept;
@@ -3363,7 +3361,7 @@ elements of \tcode{charT}.
 \tcode{find_last_of(basic_string_view<charT, traits>(s), pos)}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{find_last_of}%
+\indexlibrarymember{find_last_of}{basic_string}%
 \begin{itemdecl}
 size_type find_last_of(charT c, size_type pos = npos) const;
 \end{itemdecl}
@@ -3376,7 +3374,7 @@ size_type find_last_of(charT c, size_type pos = npos) const;
 
 \rSec4[string::find.first.not.of]{\tcode{basic_string::find_first_not_of}}
 
-\indexlibrarymember{basic_string}{find_first_not_of}%
+\indexlibrarymember{find_first_not_of}{basic_string}%
 \begin{itemdecl}
 size_type find_first_not_of(basic_string_view<charT, traits> sv,
                             size_type pos = 0) const noexcept;
@@ -3411,7 +3409,7 @@ Uses
 \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{find_first_not_of}%
+\indexlibrarymember{find_first_not_of}{basic_string}%
 \begin{itemdecl}
 size_type find_first_not_of(const basic_string& str,
                             size_type pos = 0) const noexcept;
@@ -3451,7 +3449,7 @@ elements of \tcode{charT}.
 \tcode{find_first_not_of(basic_string_view<charT, traits>(s), pos)}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{find_first_not_of}%
+\indexlibrarymember{find_first_not_of}{basic_string}%
 \begin{itemdecl}
 size_type find_first_not_of(charT c, size_type pos = 0) const;
 \end{itemdecl}
@@ -3464,7 +3462,7 @@ size_type find_first_not_of(charT c, size_type pos = 0) const;
 
 \rSec4[string::find.last.not.of]{\tcode{basic_string::find_last_not_of}}
 
-\indexlibrarymember{basic_string}{find_last_not_of}%
+\indexlibrarymember{find_last_not_of}{basic_string}%
 \begin{itemdecl}
 size_type find_last_not_of (basic_string_view<charT, traits> sv,
                             size_type pos = npos) const noexcept;
@@ -3499,7 +3497,7 @@ Uses
 \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{find_last_not_of}%
+\indexlibrarymember{find_last_not_of}{basic_string}%
 \begin{itemdecl}
 size_type find_last_not_of(const basic_string& str,
                            size_type pos = npos) const noexcept;
@@ -3539,7 +3537,7 @@ elements of \tcode{charT}.
 \tcode{find_last_not_of(basic_string_view<charT, traits>(s), pos)}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{find_last_not_of}%
+\indexlibrarymember{find_last_not_of}{basic_string}%
 \begin{itemdecl}
 size_type find_last_not_of(charT c, size_type pos = npos) const;
 \end{itemdecl}
@@ -3552,7 +3550,7 @@ size_type find_last_not_of(charT c, size_type pos = npos) const;
 
 \rSec4[string::substr]{\tcode{basic_string::substr}}
 
-\indexlibrarymember{basic_string}{substr}%
+\indexlibrarymember{substr}{basic_string}%
 \begin{itemdecl}
 basic_string substr(size_type pos = 0, size_type n = npos) const;
 \end{itemdecl}
@@ -3576,7 +3574,7 @@ Determines the effective length \tcode{rlen} of the string to copy as the smalle
 
 \rSec4[string::compare]{\tcode{basic_string::compare}}
 
-\indexlibrarymember{basic_string}{compare}%
+\indexlibrarymember{compare}{basic_string}%
 \begin{itemdecl}
 int compare(basic_string_view<charT, traits> sv) const noexcept;
 \end{itemdecl}
@@ -3639,7 +3637,7 @@ return basic_string_view<charT, traits>(this.data(), pos1, n1).compare(sv, pos2,
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{compare}%
+\indexlibrarymember{compare}{basic_string}%
 \begin{itemdecl}
 int compare(const basic_string& str) const noexcept;
 \end{itemdecl}
@@ -3718,7 +3716,7 @@ int compare(size_type pos, size_type n1,
 
 \rSec3[string::op+]{\tcode{operator+}}
 
-\indexlibrarymember{basic_string}{operator+}%
+\indexlibrarymember{operator+}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_string<charT, traits, Allocator>
@@ -3732,7 +3730,7 @@ template<class charT, class traits, class Allocator>
 \tcode{basic_string<charT, traits, Allocator>(lhs).append(rhs)}
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{operator+}%
+\indexlibrarymember{operator+}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_string<charT, traits, Allocator>
@@ -3746,7 +3744,7 @@ template<class charT, class traits, class Allocator>
 \tcode{std::move(lhs.append(rhs))}
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{operator+}%
+\indexlibrarymember{operator+}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_string<charT, traits, Allocator>
@@ -3760,7 +3758,7 @@ template<class charT, class traits, class Allocator>
 \tcode{std::move(rhs.insert(0, lhs))}
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{operator+}%
+\indexlibrarymember{operator+}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_string<charT, traits, Allocator>
@@ -3814,7 +3812,7 @@ Uses
 \tcode{traits::length()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{operator+}%
+\indexlibrarymember{operator+}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_string<charT, traits, Allocator>
@@ -3828,7 +3826,7 @@ template<class charT, class traits, class Allocator>
 \tcode{basic_string<charT, traits, Allocator>(1, lhs) + rhs}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{operator+}%
+\indexlibrarymember{operator+}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_string<charT, traits, Allocator>
@@ -3880,7 +3878,7 @@ Uses
 \tcode{traits::length()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{operator+}%
+\indexlibrarymember{operator+}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_string<charT, traits, Allocator>
@@ -3894,7 +3892,7 @@ template<class charT, class traits, class Allocator>
 \tcode{lhs + basic_string<charT, traits, Allocator>(1, rhs)}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{operator+}%
+\indexlibrarymember{operator+}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_string<charT, traits, Allocator>
@@ -3910,7 +3908,7 @@ template<class charT, class traits, class Allocator>
 
 \rSec3[string::operator==]{\tcode{operator==}}
 
-\indexlibrarymember{basic_string}{operator==}%
+\indexlibrarymember{operator==}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   bool operator==(const basic_string<charT, traits, Allocator>& lhs,
@@ -3953,10 +3951,9 @@ elements of \tcode{charT}.
 \tcode{lhs.compare(rhs) == 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{length}!\idxcode{char_traits}}%
 \rSec3[string::op!=]{\tcode{operator!=}}
 
-\indexlibrarymember{basic_string}{operator"!=}%
+\indexlibrarymember{operator"!=}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   bool operator!=(const basic_string<charT, traits, Allocator>& lhs,
@@ -3969,8 +3966,7 @@ template<class charT, class traits, class Allocator>
 \tcode{!(lhs == rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   bool operator!=(const charT* lhs,
@@ -3983,8 +3979,7 @@ template<class charT, class traits, class Allocator>
 \tcode{rhs != lhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   bool operator!=(const basic_string<charT, traits, Allocator>& lhs,
@@ -4003,7 +3998,7 @@ elements of \tcode{charT}.
 
 \rSec3[string::op<]{\tcode{operator<}}
 
-\indexlibrarymember{basic_string}{operator<}%
+\indexlibrarymember{operator<}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   bool operator< (const basic_string<charT, traits, Allocator>& lhs,
@@ -4167,7 +4162,7 @@ template<class charT, class traits, class Allocator>
 
 \rSec3[string.special]{\tcode{swap}}
 
-\indexlibrarymember{basic_string}{swap}%
+\indexlibrarymember{swap}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   void swap(basic_string<charT, traits, Allocator>& lhs,
@@ -4395,7 +4390,7 @@ for the return type.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{stof}}%
-\indexlibrary{\idxcode{stol}}%
+\indexlibrary{\idxcode{stod}}%
 \indexlibrary{\idxcode{stold}}%
 \begin{itemdecl}
 float stof(const string& str, size_t* idx = 0);
@@ -4549,7 +4544,10 @@ internal character buffer of sufficient size \tcode{buffsz}.
 
 \rSec2[basic.string.hash]{Hash support}
 
-\indexlibrary{\idxcode{hash}}%
+\indexlibrary{\idxcode{hash}!\idxcode{string}}%
+\indexlibrary{\idxcode{hash}!\idxcode{u16string}}%
+\indexlibrary{\idxcode{hash}!\idxcode{u32string}}%
+\indexlibrary{\idxcode{hash}!\idxcode{wstring}}%
 \begin{itemdecl}
 template<> struct hash<string>;
 template<> struct hash<u16string>;
@@ -4564,6 +4562,7 @@ template<> struct hash<wstring>;
 
 \rSec2[basic.string.literals]{Suffix for \tcode{basic_string} literals}
 
+\indexlibrarymember{operator """" s}{string}%
 \begin{itemdecl}
 string operator "" s(const char* str, size_t len);
 \end{itemdecl}
@@ -4574,6 +4573,7 @@ string operator "" s(const char* str, size_t len);
 \tcode{string\{str, len\}}.
 \end{itemdescr}
 
+\indexlibrarymember{operator """" s}{u16string}%
 \begin{itemdecl}
 u16string operator "" s(const char16_t* str, size_t len);
 \end{itemdecl}
@@ -4583,6 +4583,7 @@ u16string operator "" s(const char16_t* str, size_t len);
 \tcode{u16string\{str, len\}}.
 \end{itemdescr}
 
+\indexlibrarymember{operator """" s}{u32string}%
 \begin{itemdecl}
 u32string operator "" s(const char32_t* str, size_t len);
 \end{itemdecl}
@@ -4592,6 +4593,7 @@ u32string operator "" s(const char32_t* str, size_t len);
 \tcode{u32string\{str, len\}}.
 \end{itemdescr}
 
+\indexlibrarymember{operator """" s}{wstring}%
 \begin{itemdecl}
 wstring operator "" s(const wchar_t* str, size_t len);
 \end{itemdecl}
@@ -4799,6 +4801,7 @@ Constructs an empty \tcode{basic_string_view}.
 \tcode{size_ == 0} and \tcode{data_ == nullptr}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{basic_string_view}!constructor}%
 \begin{itemdecl}
 constexpr basic_string_view(const charT* str);
 \end{itemdecl}
@@ -4822,6 +4825,7 @@ in table~\ref{tab:string.view.ctr.2}.
 \bigoh{\tcode{traits::length(str)}}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{basic_string_view}!constructor}%
 \begin{itemdecl}
 constexpr basic_string_view(const charT* str, size_type len);
 \end{itemdecl}
@@ -4842,6 +4846,7 @@ Constructs a \tcode{basic_string_view}, with the postconditions in table~\ref{ta
 
 \rSec3[string.view.iterators]{Iterator support}
 
+\indexlibrarymember{const_iterator}{basic_string_view}%
 \begin{itemdecl}
 using const_iterator = @\impdefx{type of \tcode{basic_string_view::const_iterator}}@;
 \end{itemdecl}
@@ -4860,10 +4865,8 @@ For a \tcode{basic_string_view str}, any operation that invalidates a pointer in
 All requirements on container iterators (\ref{container.requirements}) apply to \tcode{basic_string_view::const_iterator} as well.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{begin}}%
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{cbegin}}%
-\indexlibrary{\idxcode{begin}!\idxcode{basic_string_view}}%
-\indexlibrary{\idxcode{cbegin}!\idxcode{basic_string_view}}%
+\indexlibrarymember{begin}{basic_string_view}%
+\indexlibrarymember{cbegin}{basic_string_view}%
 \begin{itemdecl}
 constexpr const_iterator begin() const noexcept;
 constexpr const_iterator cbegin() const noexcept;
@@ -4879,10 +4882,8 @@ An iterator such that
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{end}}%
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{cend}}%
-\indexlibrary{\idxcode{end}!\idxcode{basic_string_view}}%
-\indexlibrary{\idxcode{cend}!\idxcode{basic_string_view}}%
+\indexlibrarymember{end}{basic_string_view}%
+\indexlibrarymember{cend}{basic_string_view}%
 \begin{itemdecl}
 constexpr const_iterator end() const noexcept;
 constexpr const_iterator cend() const noexcept;
@@ -4894,10 +4895,8 @@ constexpr const_iterator cend() const noexcept;
 \tcode{begin() + size()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{rbegin}}%
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{crbegin}}%
-\indexlibrary{\idxcode{rbegin}!\idxcode{basic_string_view}}%
-\indexlibrary{\idxcode{crbegin}!\idxcode{basic_string_view}}%
+\indexlibrarymember{rbegin}{basic_string_view}%
+\indexlibrarymember{crbegin}{basic_string_view}%
 \begin{itemdecl}
 const_reverse_iterator rbegin() const noexcept;
 const_reverse_iterator crbegin() const noexcept;
@@ -4909,10 +4908,8 @@ const_reverse_iterator crbegin() const noexcept;
 \tcode{const_reverse_iterator(end())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{rend}}%
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{crend}}%
-\indexlibrary{\idxcode{rend}!\idxcode{basic_string_view}}%
-\indexlibrary{\idxcode{crend}!\idxcode{basic_string_view}}%
+\indexlibrarymember{rend}{basic_string_view}%
+\indexlibrarymember{crend}{basic_string_view}%
 \begin{itemdecl}
 const_reverse_iterator rend() const noexcept;
 const_reverse_iterator crend() const noexcept;
@@ -4926,7 +4923,7 @@ const_reverse_iterator crend() const noexcept;
 
 \rSec3[string.view.capacity]{Capacity}
 
-\indexlibrarymember{basic_string_view}{size}%
+\indexlibrarymember{size}{basic_string_view}%
 \begin{itemdecl}
 constexpr size_type size() const noexcept;
 \end{itemdecl}
@@ -4937,7 +4934,7 @@ constexpr size_type size() const noexcept;
 \tcode{size_}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{length}%
+\indexlibrarymember{length}{basic_string_view}%
 \begin{itemdecl}
 constexpr size_type length() const noexcept;
 \end{itemdecl}
@@ -4948,7 +4945,7 @@ constexpr size_type length() const noexcept;
 \tcode{size_}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{max_size}%
+\indexlibrarymember{max_size}{basic_string_view}%
 \begin{itemdecl}
 constexpr size_type max_size() const noexcept;
 \end{itemdecl}
@@ -4959,7 +4956,7 @@ constexpr size_type max_size() const noexcept;
 The largest possible number of char-like objects that can be referred to by a \tcode{basic_string_view}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{empty}%
+\indexlibrarymember{empty}{basic_string_view}%
 \begin{itemdecl}
 constexpr bool empty() const noexcept;
 \end{itemdecl}
@@ -4972,7 +4969,7 @@ constexpr bool empty() const noexcept;
 
 \rSec3[string.view.access]{Element access}
 
-\indexlibrarymember{basic_string_view}{operator[]}%
+\indexlibrarymember{operator[]}{basic_string_view}%
 \begin{itemdecl}
 constexpr const_reference operator[](size_type pos) const;
 \end{itemdecl}
@@ -4997,7 +4994,7 @@ Unlike \tcode{basic_string::operator[]},
 \end{note}
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{at}%
+\indexlibrarymember{at}{basic_string_view}%
 \begin{itemdecl}
 constexpr const_reference at(size_type pos) const;
 \end{itemdecl}
@@ -5012,7 +5009,7 @@ constexpr const_reference at(size_type pos) const;
 \tcode{data_[pos]}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{front}%
+\indexlibrarymember{front}{basic_string_view}%
 \begin{itemdecl}
 constexpr const_reference front() const;
 \end{itemdecl}
@@ -5031,7 +5028,7 @@ constexpr const_reference front() const;
 Nothing.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{back}%
+\indexlibrarymember{back}{basic_string_view}%
 \begin{itemdecl}
 constexpr const_reference back() const;
 \end{itemdecl}
@@ -5050,7 +5047,7 @@ constexpr const_reference back() const;
 Nothing.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{data}%
+\indexlibrarymember{data}{basic_string_view}%
 \begin{itemdecl}
 constexpr const_pointer data() const noexcept;
 \end{itemdecl}
@@ -5070,7 +5067,7 @@ Therefore it is typically a mistake to pass \tcode{data()} to a routine that tak
 
 \rSec3[string.view.modifiers]{Modifiers}
 
-\indexlibrarymember{basic_string_view}{remove_prefix}%
+\indexlibrarymember{remove_prefix}{basic_string_view}%
 \begin{itemdecl}
 constexpr void remove_prefix(size_type n);
 \end{itemdecl}
@@ -5085,7 +5082,7 @@ constexpr void remove_prefix(size_type n);
 Equivalent to: \tcode{data_ += n; size_ -= n;}
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{remove_suffix}%
+\indexlibrarymember{remove_suffix}{basic_string_view}%
 \begin{itemdecl}
 constexpr void remove_suffix(size_type n);
 \end{itemdecl}
@@ -5100,7 +5097,7 @@ constexpr void remove_suffix(size_type n);
 Equivalent to: \tcode{size_ -= n;}
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{swap}%
+\indexlibrarymember{swap}{basic_string_view}%
 \begin{itemdecl}
 constexpr void swap(basic_string_view& s) noexcept;
 \end{itemdecl}
@@ -5113,7 +5110,7 @@ Exchanges the values of \tcode{*this} and \tcode{s}.
 
 \rSec3[string.view.ops]{String operations}
 
-\indexlibrarymember{basic_string_view}{copy}%
+\indexlibrarymember{copy}{basic_string_view}%
 \begin{itemdecl}
 size_type copy(charT* s, size_type n, size_type pos = 0) const;
 \end{itemdecl}
@@ -5143,7 +5140,7 @@ Equivalent to \tcode{copy_n(begin() + pos, rlen, s)}.
 \bigoh{\tcode{rlen}}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{substr}%
+\indexlibrarymember{substr}{basic_string_view}%
 \begin{itemdecl}
 constexpr basic_string_view substr(size_type pos = 0, size_type n = npos) const;
 \end{itemdecl}
@@ -5165,7 +5162,7 @@ Determines \tcode{rlen}, the effective length of the string to reference.
 \tcode{basic_string_view(data() + pos, rlen)}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{compare}%
+\indexlibrarymember{compare}{basic_string_view}%
 \begin{itemdecl}
 constexpr int compare(basic_string_view str) const noexcept;
 \end{itemdecl}
@@ -5194,6 +5191,7 @@ Otherwise, returns a value as indicated in Table~\ref{tab:string.view.compare}.
 \end{libtab2}
 \end{itemdescr}
 
+\indexlibrarymember{compare}{basic_string_view}%
 \begin{itemdecl}
 constexpr int compare(size_type pos1, size_type n1, basic_string_view str) const;
 \end{itemdecl}
@@ -5204,6 +5202,7 @@ constexpr int compare(size_type pos1, size_type n1, basic_string_view str) const
 Equivalent to: \tcode{return substr(pos1, n1).compare(str);}
 \end{itemdescr}
 
+\indexlibrarymember{compare}{basic_string_view}%
 \begin{itemdecl}
 constexpr int compare(size_type pos1, size_type n1, basic_string_view str,
                       size_type pos2, size_type n2) const;
@@ -5215,6 +5214,7 @@ constexpr int compare(size_type pos1, size_type n1, basic_string_view str,
 Equivalent to: \tcode{return substr(pos1, n1).compare(str.substr(pos2, n2));}
 \end{itemdescr}
 
+\indexlibrarymember{compare}{basic_string_view}%
 \begin{itemdecl}
 constexpr int compare(const charT* s) const;
 \end{itemdecl}
@@ -5225,6 +5225,7 @@ constexpr int compare(const charT* s) const;
 Equivalent to: \tcode{return compare(basic_string_view(s));}
 \end{itemdescr}
 
+\indexlibrarymember{compare}{basic_string_view}%
 \begin{itemdecl}
 constexpr int compare(size_type pos1, size_type n1, const charT* s) const;
 \end{itemdecl}
@@ -5235,6 +5236,7 @@ constexpr int compare(size_type pos1, size_type n1, const charT* s) const;
 Equivalent to: \tcode{return substr(pos1, n1).compare(basic_string_view(s));}
 \end{itemdescr}
 
+\indexlibrarymember{compare}{basic_string_view}%
 \begin{itemdecl}
 constexpr int compare(size_type pos1, size_type n1,
                       const charT* s, size_type n2) const;
@@ -5277,7 +5279,7 @@ constexpr @\placeholder{return-type}@ @\placeholder{F}@(charT c, size_type pos);
 \end{codeblock}
 is equivalent to \tcode{return \placeholder{F}(basic_string_view(\&c, 1), pos);}
 
-\indexlibrarymember{basic_string_view}{find}%
+\indexlibrarymember{find}{basic_string_view}%
 \begin{itemdecl}
 constexpr size_type find(basic_string_view str, size_type pos = 0) const noexcept;
 \end{itemdecl}
@@ -5308,7 +5310,7 @@ Otherwise, returns \tcode{npos}.
 Uses \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{rfind}%
+\indexlibrarymember{rfind}{basic_string_view}%
 \begin{itemdecl}
 constexpr size_type rfind(basic_string_view str, size_type pos = npos) const noexcept;
 \end{itemdecl}
@@ -5339,7 +5341,7 @@ Otherwise, returns \tcode{npos}.
 Uses \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{find_first_of}%
+\indexlibrarymember{find_first_of}{basic_string_view}%
 \begin{itemdecl}
 constexpr size_type find_first_of(basic_string_view str, size_type pos = 0) const noexcept;
 \end{itemdecl}
@@ -5370,7 +5372,7 @@ Otherwise, returns \tcode{npos}.
 Uses \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{find_last_of}%
+\indexlibrarymember{find_last_of}{basic_string_view}%
 \begin{itemdecl}
 constexpr size_type find_last_of(basic_string_view str, size_type pos = npos) const noexcept;
 \end{itemdecl}
@@ -5401,7 +5403,7 @@ Otherwise, returns \tcode{npos}.
 Uses \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{find_first_not_of}%
+\indexlibrarymember{find_first_not_of}{basic_string_view}%
 \begin{itemdecl}
 constexpr size_type find_first_not_of(basic_string_view str, size_type pos = 0) const noexcept;
 \end{itemdecl}
@@ -5431,7 +5433,7 @@ Determines \tcode{xpos}.
 Uses \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{find_last_not_of}%
+\indexlibrarymember{find_last_not_of}{basic_string_view}%
 \begin{itemdecl}
 constexpr size_type find_last_not_of(basic_string_view str, size_type pos = npos) const noexcept;
 \end{itemdecl}
@@ -5517,8 +5519,7 @@ template<class charT, class traits>
 \tcode{lhs.compare(rhs) == 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{basic_string_view}}%
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{basic_string_view}%
 \begin{itemdecl}
 template<class charT, class traits>
   constexpr bool operator!=(basic_string_view<charT, traits> lhs,
@@ -5601,7 +5602,10 @@ Equivalent to: \tcode{return os << str.to_string();}
 
 \rSec2[string.view.hash]{Hash support}
 
-\indexlibrary{\idxcode{hash}!\idxcode{basic_string_view}}%
+\indexlibrary{\idxcode{hash}!\idxcode{string_view}}%
+\indexlibrary{\idxcode{hash}!\idxcode{u16string_view}}%
+\indexlibrary{\idxcode{hash}!\idxcode{u32string_view}}%
+\indexlibrary{\idxcode{hash}!\idxcode{wstring_view}}%
 \begin{itemdecl}
 template<> struct hash<string_view>;
 template<> struct hash<u16string_view>;


### PR DESCRIPTION
This review handles several topic related to the index of library names:

      fix outright errors, indexing the wrong name
      indexed the user-defined literal operators
      index the hash functor specializations by type
      consistent apply \indexlibrarymember for all member functions, including previous omissions
      consistent ordering of indexlibrarymember{identifier}{class-name}