### PR TITLE
[iterators] review of library index

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1288,7 +1288,6 @@ if and only if the corresponding operations are defined on a value-initialized i
 \end{itemdescr}
 
 \indexlibrary{\idxcode{reverse_iterator}!constructor}%
-
 \begin{itemdecl}
 constexpr explicit reverse_iterator(Iterator x);
 \end{itemdecl}
@@ -1302,7 +1301,6 @@ with \tcode{x}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{reverse_iterator}!constructor}%
-
 \begin{itemdecl}
 template <class U> constexpr reverse_iterator(const reverse_iterator<U> &u);
 \end{itemdecl}
@@ -1318,7 +1316,7 @@ with
 
 \rSec4[reverse.iter.op=]{\tcode{reverse_iterator::operator=}}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator=}{reverse_iterator}%
 \begin{itemdecl}
 template <class U>
 constexpr reverse_iterator&
@@ -1350,7 +1348,7 @@ constexpr Iterator base() const;          // explicit
 
 \rSec4[reverse.iter.op.star]{\tcode{operator*}}
 
-\indexlibrary{\idxcode{operator*}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator*}{reverse_iterator}%
 \begin{itemdecl}
 constexpr reference operator*() const;
 \end{itemdecl}
@@ -1368,7 +1366,7 @@ return *--tmp;
 
 \rSec4[reverse.iter.opref]{\tcode{operator->}}
 
-\indexlibrary{\idxcode{operator->}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator->}{reverse_iterator}%
 \begin{itemdecl}
 constexpr pointer operator->() const;
 \end{itemdecl}
@@ -1380,7 +1378,7 @@ constexpr pointer operator->() const;
 
 \rSec4[reverse.iter.op++]{\tcode{operator++}}
 
-\indexlibrary{\idxcode{operator++}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator++}{reverse_iterator}%
 \begin{itemdecl}
 constexpr reverse_iterator& operator++();
 \end{itemdecl}
@@ -1413,7 +1411,7 @@ return tmp;
 
 \rSec4[reverse.iter.op\dcr]{\tcode{operator\dcr}}
 
-\indexlibrary{\idxcode{operator\dcr}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator\dcr}{reverse_iterator}%
 \begin{itemdecl}
 constexpr reverse_iterator& operator--();
 \end{itemdecl}
@@ -1446,7 +1444,7 @@ return tmp;
 
 \rSec4[reverse.iter.op+]{\tcode{operator+}}
 
-\indexlibrary{\idxcode{operator+}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator+}{reverse_iterator}%
 \begin{itemdecl}
 constexpr reverse_iterator
 operator+(typename reverse_iterator<Iterator>::difference_type n) const;
@@ -1460,7 +1458,7 @@ operator+(typename reverse_iterator<Iterator>::difference_type n) const;
 
 \rSec4[reverse.iter.op+=]{\tcode{operator+=}}
 
-\indexlibrary{\idxcode{operator+=}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator+=}{reverse_iterator}%
 \begin{itemdecl}
 constexpr reverse_iterator&
 operator+=(typename reverse_iterator<Iterator>::difference_type n);
@@ -1478,7 +1476,7 @@ As if by: \tcode{current -= n;}
 
 \rSec4[reverse.iter.op-]{\tcode{operator-}}
 
-\indexlibrary{\idxcode{operator-}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator-}{reverse_iterator}%
 \begin{itemdecl}
 constexpr reverse_iterator
 operator-(typename reverse_iterator<Iterator>::difference_type n) const;
@@ -1492,7 +1490,7 @@ operator-(typename reverse_iterator<Iterator>::difference_type n) const;
 
 \rSec4[reverse.iter.op-=]{\tcode{operator-=}}
 
-\indexlibrary{\idxcode{operator-=}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator-=}{reverse_iterator}%
 \begin{itemdecl}
 constexpr reverse_iterator&
 operator-=(typename reverse_iterator<Iterator>::difference_type n);
@@ -1510,7 +1508,7 @@ As if by: \tcode{current += n;}
 
 \rSec4[reverse.iter.opindex]{\tcode{operator[]}}
 
-\indexlibrary{\idxcode{operator[]}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator[]}{reverse_iterator}%
 \begin{itemdecl}
 constexpr @\unspec@ operator[](
     typename reverse_iterator<Iterator>::difference_type n) const;
@@ -1524,7 +1522,7 @@ constexpr @\unspec@ operator[](
 
 \rSec4[reverse.iter.op==]{\tcode{operator==}}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator==}{reverse_iterator}%
 \begin{itemdecl}
 template <class Iterator1, class Iterator2>
   constexpr bool operator==(
@@ -1540,7 +1538,7 @@ template <class Iterator1, class Iterator2>
 
 \rSec4[reverse.iter.op<]{\tcode{operator<}}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator<}{reverse_iterator}%
 \begin{itemdecl}
 template <class Iterator1, class Iterator2>
   constexpr bool operator<(
@@ -1556,7 +1554,7 @@ template <class Iterator1, class Iterator2>
 
 \rSec4[reverse.iter.op!=]{\tcode{operator!=}}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator"!=}{reverse_iterator}%
 \begin{itemdecl}
 template <class Iterator1, class Iterator2>
   constexpr bool operator!=(
@@ -1572,7 +1570,7 @@ template <class Iterator1, class Iterator2>
 
 \rSec4[reverse.iter.op>]{\tcode{operator>}}
 
-\indexlibrary{\idxcode{operator>}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator>}{reverse_iterator}%
 \begin{itemdecl}
 template <class Iterator1, class Iterator2>
   constexpr bool operator>(
@@ -1588,7 +1586,7 @@ template <class Iterator1, class Iterator2>
 
 \rSec4[reverse.iter.op>=]{\tcode{operator>=}}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator>=}{reverse_iterator}%
 \begin{itemdecl}
 template <class Iterator1, class Iterator2>
   constexpr bool operator>=(
@@ -1604,7 +1602,7 @@ template <class Iterator1, class Iterator2>
 
 \rSec4[reverse.iter.op<=]{\tcode{operator<=}}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator<=}{reverse_iterator}%
 \begin{itemdecl}
 template <class Iterator1, class Iterator2>
   constexpr bool operator<=(
@@ -1620,7 +1618,7 @@ template <class Iterator1, class Iterator2>
 
 \rSec4[reverse.iter.opdiff]{\tcode{operator-}}
 
-\indexlibrary{\idxcode{operator-}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator-}{reverse_iterator}%
 \begin{itemdecl}
 template <class Iterator1, class Iterator2>
     constexpr auto operator-(
@@ -1636,7 +1634,7 @@ template <class Iterator1, class Iterator2>
 
 \rSec4[reverse.iter.opsum]{\tcode{operator+}}
 
-\indexlibrary{\idxcode{operator+}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator+}{reverse_iterator}%
 \begin{itemdecl}
 template <class Iterator>
   constexpr reverse_iterator<Iterator> operator+(
@@ -1652,7 +1650,7 @@ template <class Iterator>
 
 \rSec4[reverse.iter.make]{Non-member function \tcode{make_reverse_iterator()}}
 
-\indexlibrary{\idxcode{reverse_iterator}!\idxcode{make_reverse_iterator}~non-member~function}
+\indexlibrary{\idxcode{reverse_iterator}!\idxcode{make_reverse_iterator}~non-member~function}%
 \indexlibrary{\idxcode{make_reverse_iterator}}%
 \begin{itemdecl}
 template <class Iterator>
@@ -1765,7 +1763,7 @@ with \tcode{addressof(x)}.
 
 \rSec4[back.insert.iter.op=]{\tcode{back_insert_iterator::operator=}}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{back_insert_iterator}}%
+\indexlibrarymember{operator=}{back_insert_iterator}%
 \begin{itemdecl}
 back_insert_iterator& operator=(const typename Container::value_type& value);
 \end{itemdecl}
@@ -1780,7 +1778,7 @@ As if by: \tcode{container->push_back(value);}
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{back_insert_iterator}}%
+\indexlibrarymember{operator=}{back_insert_iterator}%
 \begin{itemdecl}
 back_insert_iterator& operator=(typename Container::value_type&& value);
 \end{itemdecl}
@@ -1797,7 +1795,7 @@ As if by: \tcode{container->push_back(std::move(value));}
 
 \rSec4[back.insert.iter.op*]{\tcode{back_insert_iterator::operator*}}
 
-\indexlibrary{\idxcode{operator*}!\idxcode{back_insert_iterator}}%
+\indexlibrarymember{operator*}{back_insert_iterator}%
 \begin{itemdecl}
 back_insert_iterator& operator*();
 \end{itemdecl}
@@ -1810,7 +1808,7 @@ back_insert_iterator& operator*();
 
 \rSec4[back.insert.iter.op++]{\tcode{back_insert_iterator::operator++}}
 
-\indexlibrary{\idxcode{operator++}!\idxcode{back_insert_iterator}}%
+\indexlibrarymember{operator++}{back_insert_iterator}%
 \begin{itemdecl}
 back_insert_iterator& operator++();
 back_insert_iterator  operator++(int);
@@ -1887,7 +1885,7 @@ with \tcode{addressof(x)}.
 
 \rSec4[front.insert.iter.op=]{\tcode{front_insert_iterator::operator=}}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{front_insert_iterator}}%
+\indexlibrarymember{operator=}{front_insert_iterator}%
 \begin{itemdecl}
 front_insert_iterator& operator=(const typename Container::value_type& value);
 \end{itemdecl}
@@ -1902,7 +1900,7 @@ As if by: \tcode{container->push_front(value);}
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{front_insert_iterator}}%
+\indexlibrarymember{operator=}{front_insert_iterator}%
 \begin{itemdecl}
 front_insert_iterator& operator=(typename Container::value_type&& value);
 \end{itemdecl}
@@ -1919,7 +1917,7 @@ As if by: \tcode{container->push_front(std::move(value));}
 
 \rSec4[front.insert.iter.op*]{\tcode{front_insert_iterator::operator*}}
 
-\indexlibrary{\idxcode{operator*}!\idxcode{front_insert_iterator}}%
+\indexlibrarymember{operator*}{front_insert_iterator}%
 \begin{itemdecl}
 front_insert_iterator& operator*();
 \end{itemdecl}
@@ -1932,7 +1930,7 @@ front_insert_iterator& operator*();
 
 \rSec4[front.insert.iter.op++]{\tcode{front_insert_iterator::operator++}}
 
-\indexlibrary{\idxcode{operator++}!\idxcode{front_insert_iterator}}%
+\indexlibrarymember{operator++}{front_insert_iterator}%
 \begin{itemdecl}
 front_insert_iterator& operator++();
 front_insert_iterator  operator++(int);
@@ -2012,7 +2010,7 @@ with \tcode{i}.
 
 \rSec4[insert.iter.op=]{\tcode{insert_iterator::operator=}}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{insert_iterator}}%
+\indexlibrarymember{operator=}{insert_iterator}%
 \begin{itemdecl}
 insert_iterator& operator=(const typename Container::value_type& value);
 \end{itemdecl}
@@ -2031,7 +2029,7 @@ iter = container->insert(iter, value);
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{insert_iterator}}%
+\indexlibrarymember{operator=}{insert_iterator}%
 \begin{itemdecl}
 insert_iterator& operator=(typename Container::value_type&& value);
 \end{itemdecl}
@@ -2052,7 +2050,7 @@ iter = container->insert(iter, std::move(value));
 
 \rSec4[insert.iter.op*]{\tcode{insert_iterator::operator*}}
 
-\indexlibrary{\idxcode{operator*}!\idxcode{insert_iterator}}%
+\indexlibrarymember{operator*}{insert_iterator}%
 \begin{itemdecl}
 insert_iterator& operator*();
 \end{itemdecl}
@@ -2065,7 +2063,7 @@ insert_iterator& operator*();
 
 \rSec4[insert.iter.op++]{\tcode{insert_iterator::operator++}}
 
-\indexlibrary{\idxcode{operator++}!\idxcode{insert_iterator}}%
+\indexlibrarymember{operator++}{insert_iterator}%
 \begin{itemdecl}
 insert_iterator& operator++();
 insert_iterator& operator++(int);
@@ -2441,8 +2439,7 @@ constexpr bool operator==(const move_iterator<Iterator1>& x, const move_iterator
 \returns \tcode{x.base() == y.base()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{move_iterator}}%
-\indexlibrary{\idxcode{move_iterator}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{move_iterator}%
 \begin{itemdecl}
 template <class Iterator1, class Iterator2>
 constexpr bool operator!=(const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
@@ -2775,18 +2772,15 @@ template <class T, class charT, class traits, class Distance>
 \pnum
 \returns
 \tcode{x.in_stream == y.in_stream}.%
-\indexlibrary{\idxcode{istream_iterator}!\idxcode{operator==}}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{istream_iterator}}%
-\indexlibrary{\idxcode{istream_iterator}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{istream_iterator}%
 \begin{itemdecl}
 template <class T, class charT, class traits, class Distance>
   bool operator!=(const istream_iterator<T,charT,traits,Distance> &x,
                   const istream_iterator<T,charT,traits,Distance> &y);
 \end{itemdecl}
 
-\indexlibrary{\idxcode{istream_iterator}!\idxcode{operator"!=}}%
 \begin{itemdescr}
 \pnum
 \returns
@@ -3115,7 +3109,7 @@ object's constructor argument \tcode{p}.
 
 \rSec3[istreambuf.iterator::op*]{\tcode{istreambuf_iterator::operator*}}
 
-\indexlibrary{\idxcode{operator*}!\idxcode{istreambuf_iterator}}%
+\indexlibrarymember{operator*}{istreambuf_iterator}%
 \begin{itemdecl}
 charT operator*() const
 \end{itemdecl}
@@ -3131,7 +3125,7 @@ member
 
 \rSec3[istreambuf.iterator::op++]{\tcode{istreambuf_iterator::operator++}}
 
-\indexlibrary{\idxcode{operator++}!\idxcode{istreambuf_iterator}}%
+\indexlibrarymember{operator++}{istreambuf_iterator}%
 \begin{itemdecl}
 istreambuf_iterator& operator++();
 \end{itemdecl}
@@ -3159,7 +3153,7 @@ proxy operator++(int);
 
 \rSec3[istreambuf.iterator::equal]{\tcode{istreambuf_iterator::equal}}
 
-\indexlibrary{\idxcode{equal}!\idxcode{istreambuf_iterator}}%
+\indexlibrarymember{equal}{istreambuf_iterator}%
 \begin{itemdecl}
 bool equal(const istreambuf_iterator& b) const;
 \end{itemdecl}
@@ -3176,7 +3170,7 @@ object they use.
 
 \rSec3[istreambuf.iterator::op==]{\tcode{operator==}}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{istreambuf_iterator}}%
+\indexlibrarymember{operator==}{istreambuf_iterator}%
 \begin{itemdecl}
 template <class charT, class traits>
   bool operator==(const istreambuf_iterator<charT,traits>& a,
@@ -3191,7 +3185,7 @@ template <class charT, class traits>
 
 \rSec3[istreambuf.iterator::op!=]{\tcode{operator!=}}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{istreambuf_iterator}}%
+\indexlibrarymember{operator"!=}{istreambuf_iterator}%
 \begin{itemdecl}
 template <class charT, class traits>
   bool operator!=(const istreambuf_iterator<charT,traits>& a,
@@ -3284,7 +3278,7 @@ Initializes \tcode{sbuf_} with \tcode{s}.
 
 \rSec3[ostreambuf.iter.ops]{\tcode{ostreambuf_iterator} operations}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{ostreambuf_iterator}}%
+\indexlibrarymember{operator=}{ostreambuf_iterator}%
 \begin{itemdecl}
 ostreambuf_iterator& operator=(charT c);
 \end{itemdecl}
@@ -3305,7 +3299,7 @@ otherwise has no effect.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator*}!\idxcode{ostreambuf_iterator}}%
+\indexlibrarymember{operator*}{ostreambuf_iterator}%
 \begin{itemdecl}
 ostreambuf_iterator& operator*();
 \end{itemdecl}
@@ -3316,7 +3310,7 @@ ostreambuf_iterator& operator*();
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator++}!\idxcode{ostreambuf_iterator}}%
+\indexlibrarymember{operator++}{ostreambuf_iterator}%
 \begin{itemdecl}
 ostreambuf_iterator& operator++();
 ostreambuf_iterator& operator++(int);
@@ -3328,7 +3322,7 @@ ostreambuf_iterator& operator++(int);
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{failed}!\idxcode{ostreambuf_iterator}}%
+\indexlibrarymember{failed}{ostreambuf_iterator}%
 \begin{itemdecl}
 bool failed() const noexcept;
 \end{itemdecl}
@@ -3426,7 +3420,7 @@ template <class C> constexpr auto rbegin(const C& c) -> decltype(c.rbegin());
 \pnum \returns \tcode{c.rbegin()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{rend(const C\&)}}%
+\indexlibrary{\idxcode{rend(C\&)}}%
 \begin{itemdecl}
 template <class C> constexpr auto rend(C& c) -> decltype(c.rend());
 template <class C> constexpr auto rend(const C& c) -> decltype(c.rend());
@@ -3493,6 +3487,7 @@ when any of the following headers are included:
 \tcode{<map>}, \tcode{<regex>}, \tcode{<set>}, \tcode{<string>},
 \tcode{<unordered_map>}, \tcode{<unordered_set>}, and \tcode{<vector>}.
 
+\indexlibrary{\idxcode{size(C\& c)}}%
 \begin{itemdecl}
 template <class C> constexpr auto size(const C& c) -> decltype(c.size());
 \end{itemdecl}
@@ -3500,6 +3495,7 @@ template <class C> constexpr auto size(const C& c) -> decltype(c.size());
 \pnum \returns \tcode{c.size()}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{size(T (\&array)[N])}}%
 \begin{itemdecl}
 template <class T, size_t N> constexpr size_t size(const T (&array)[N]) noexcept;
 \end{itemdecl}
@@ -3507,6 +3503,7 @@ template <class T, size_t N> constexpr size_t size(const T (&array)[N]) noexcept
 \pnum \returns \tcode{N}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{empty(C\& c)}}%
 \begin{itemdecl}
 template <class C> constexpr auto empty(const C& c) -> decltype(c.empty());
 \end{itemdecl}
@@ -3514,6 +3511,7 @@ template <class C> constexpr auto empty(const C& c) -> decltype(c.empty());
 \pnum \returns \tcode{c.empty()}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{empty(T (\&array)[N])}}%
 \begin{itemdecl}
 template <class T, size_t N> constexpr bool empty(const T (&array)[N]) noexcept;
 \end{itemdecl}
@@ -3521,6 +3519,7 @@ template <class T, size_t N> constexpr bool empty(const T (&array)[N]) noexcept;
 \pnum \returns \tcode{false}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{empty(initializer_list<E>)}}%
 \begin{itemdecl}
 template <class E> constexpr bool empty(initializer_list<E> il) noexcept;
 \end{itemdecl}
@@ -3528,6 +3527,7 @@ template <class E> constexpr bool empty(initializer_list<E> il) noexcept;
 \pnum \returns \tcode{il.size() == 0}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{data(C\& c)}}%
 \begin{itemdecl}
 template <class C> constexpr auto data(C& c) -> decltype(c.data());
 template <class C> constexpr auto data(const C& c) -> decltype(c.data());
@@ -3536,6 +3536,7 @@ template <class C> constexpr auto data(const C& c) -> decltype(c.data());
 \pnum \returns \tcode{c.data()}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{data(T (\&array)[N])}}%
 \begin{itemdecl}
 template <class T, size_t N> constexpr T* data(T (&array)[N]) noexcept;
 \end{itemdecl}
@@ -3543,6 +3544,7 @@ template <class T, size_t N> constexpr T* data(T (&array)[N]) noexcept;
 \pnum \returns \tcode{array}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{data(initializer_list<E>)}}%
 \begin{itemdecl}
 template <class E> constexpr const E* data(initializer_list<E> il) noexcept;
 \end{itemdecl}


### PR DESCRIPTION
This review handles several topic related to the index of library names:

    indexed all of the container free-function overloads
    consistent apply indexlibrarymember{identifier}{class-name} for all member functions
    every index macro has a trailing % to avoid accidental whitespace
    clear out a little redundancy and unnecessary whitespace