### PR TITLE
[numerics] review of library index

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -572,7 +572,7 @@ void imag(T val);
 
 \rSec2[complex.member.ops]{\tcode{complex} member operators}
 
-\indexlibrary{\idxcode{operator+=}!\idxcode{complex}}%
+\indexlibrarymember{operator+=}{complex}%
 \begin{itemdecl}
 complex<T>& operator+=(const T& rhs);
 \end{itemdecl}
@@ -591,7 +591,7 @@ leaving the imaginary part unchanged.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator-=}!\idxcode{complex}}%
+\indexlibrarymember{operator-=}{complex}%
 \begin{itemdecl}
 complex<T>& operator-=(const T& rhs);
 \end{itemdecl}
@@ -610,7 +610,7 @@ leaving the imaginary part unchanged.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator*=}!\idxcode{complex}}%
+\indexlibrarymember{operator*=}{complex}%
 \begin{itemdecl}
 complex<T>& operator*=(const T& rhs);
 \end{itemdecl}
@@ -628,7 +628,7 @@ and stores the result in
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator/=}!\idxcode{complex}}%
+\indexlibrarymember{operator/=}{complex}%
 \begin{itemdecl}
 complex<T>& operator/=(const T& rhs);
 \end{itemdecl}
@@ -646,7 +646,7 @@ and stores the result in
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator+=}!\idxcode{complex}}%
+\indexlibrarymember{operator+=}{complex}%
 \begin{itemdecl}
 template<class X> complex<T>& operator+=(const complex<X>& rhs);
 \end{itemdecl}
@@ -664,7 +664,7 @@ and stores the sum in
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator-=}!\idxcode{complex}}%
+\indexlibrarymember{operator-=}{complex}%
 \begin{itemdecl}
 template<class X> complex<T>& operator-=(const complex<X>& rhs);
 \end{itemdecl}
@@ -682,7 +682,7 @@ and stores the difference in
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator*=}!\idxcode{complex}}%
+\indexlibrarymember{operator*=}{complex}%
 \begin{itemdecl}
 template<class X> complex<T>& operator*=(const complex<X>& rhs);
 \end{itemdecl}
@@ -699,7 +699,7 @@ and stores the product in
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator/=}!\idxcode{complex}}%
+\indexlibrarymember{operator/=}{complex}%
 \begin{itemdecl}
 template<class X> complex<T>& operator/=(const complex<X>& rhs);
 \end{itemdecl}
@@ -719,7 +719,7 @@ and stores the quotient in
 
 \rSec2[complex.ops]{\tcode{complex} non-member operations}
 
-\indexlibrary{\idxcode{operator+}!\idxcode{complex}}%
+\indexlibrarymember{operator+}{complex}%
 \begin{itemdecl}
 template<class T> complex<T> operator+(const complex<T>& lhs);
 \end{itemdecl}
@@ -747,7 +747,7 @@ template<class T> complex<T> operator+(const T& lhs, const complex<T>& rhs);
 \tcode{complex<T>(lhs) += rhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator-}!\idxcode{complex}}%
+\indexlibrarymember{operator-}{complex}%
 \begin{itemdecl}
 template<class T> complex<T> operator-(const complex<T>& lhs);
 \end{itemdecl}
@@ -776,7 +776,7 @@ template<class T> complex<T> operator-(const T& lhs, const complex<T>& rhs);
 \tcode{complex<T>(lhs) -= rhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator*}!\idxcode{complex}}%
+\indexlibrarymember{operator*}{complex}%
 \begin{itemdecl}
 template<class T>
   complex<T> operator*(const complex<T>& lhs, const complex<T>& rhs);
@@ -804,7 +804,7 @@ template<class T> complex<T> operator/(const T& lhs, const complex<T>& rhs);
 \tcode{complex<T>(lhs) /= rhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{complex}}%
+\indexlibrarymember{operator==}{complex}%
 \begin{itemdecl}
 template<class T>
   constexpr bool operator==(const complex<T>& lhs, const complex<T>& rhs);
@@ -826,7 +826,7 @@ or 0.0, for the
 arguments.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{complex}}%
+\indexlibrarymember{operator"!=}{complex}%
 \begin{itemdecl}
 template<class T>
   constexpr bool operator!=(const complex<T>& lhs, const complex<T>& rhs);
@@ -1323,6 +1323,7 @@ the types \tcode{complex<double>}, \tcode{complex<long double>}, and
 \tcode{complex<float>} respectively, with their imaginary part denoted by the
 given literal number and the real part being zero.
 
+\indexlibrarymember{operator """" il}{complex}%
 \begin{itemdecl}
 constexpr complex<long double> operator""il(long double d);
 constexpr complex<long double> operator""il(unsigned long long d);
@@ -1334,6 +1335,7 @@ constexpr complex<long double> operator""il(unsigned long long d);
 \tcode{complex<long double>\{0.0L, static_cast<long double>(d)\}}.
 \end{itemdescr}
 
+\indexlibrarymember{operator """" i}{complex}%
 \begin{itemdecl}
 constexpr complex<double> operator""i(long double d);
 constexpr complex<double> operator""i(unsigned long long d);
@@ -1345,6 +1347,7 @@ constexpr complex<double> operator""i(unsigned long long d);
 \tcode{complex<double>\{0.0, static_cast<double>(d)\}}.
 \end{itemdescr}
 
+\indexlibrarymember{operator """" if}{complex}%
 \begin{itemdecl}
 constexpr complex<float> operator""if(long double d);
 constexpr complex<float> operator""if(unsigned long long d);
@@ -2763,6 +2766,7 @@ the generation algorithm%
 \indextext{generation algorithm!\idxcode{linear_congruential_engine}}
 is $ \mathsf{GA}(\state{x}{i}) = \state{x}{i+1} $.
 
+\indexlibrary{\idxcode{linear_congruential_engine}}%
 \begin{codeblock}
 template<class UIntType, UIntType a, UIntType c, UIntType m>
  class linear_congruential_engine
@@ -2817,7 +2821,6 @@ consists of
 the value of \state{x}{i}.
 
 \indexlibrary{\idxcode{linear_congruential_engine}!constructor}%
-
 \begin{itemdecl}
 explicit linear_congruential_engine(result_type s = default_seed);
 \end{itemdecl}
@@ -2830,7 +2833,6 @@ explicit linear_congruential_engine(result_type s = default_seed);
 \end{itemdescr}
 
 \indexlibrary{\idxcode{linear_congruential_engine}!constructor}%
-
 \begin{itemdecl}
 template<class Sseq> explicit linear_congruential_engine(Sseq& q);
 \end{itemdecl}
@@ -2927,6 +2929,7 @@ The generation algorithm%
    Let $z_4 = z_3 \xor ( z_3 \rightshift \ell )$.
 \end{enumeratea}
 
+\indexlibrary{\idxcode{mersenne_twister_engine}}%
 \begin{codeblock}
 template<class UIntType, size_t w, size_t n, size_t m, size_t r,
           UIntType a, size_t u, UIntType d, size_t s,
@@ -2996,7 +2999,6 @@ the values of
 in that order.
 
 \indexlibrary{\idxcode{mersenne_twister_engine}!constructor}%
-
 \begin{itemdecl}
 explicit mersenne_twister_engine(result_type value = default_seed);
 \end{itemdecl}
@@ -3020,7 +3022,6 @@ Sets $X_{-n}$ to $\tcode{value} \bmod 2^w$.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{mersenne_twister_engine}!constructor}%
-
 \begin{itemdecl}
 template<class Sseq> explicit mersenne_twister_engine(Sseq& q);
 \end{itemdecl}
@@ -3108,6 +3109,7 @@ as a result
 of advancing the engine's state
 as described above.
 
+\indexlibrary{\idxcode{subtract_with_carry_engine}}%
 \begin{codeblock}
 template<class UIntType, size_t w, size_t s, size_t r>
  class subtract_with_carry_engine
@@ -3307,6 +3309,7 @@ The generation algorithm%
 yields the value returned by the last invocation of \tcode{e()}
  while advancing \tcode{e}'s state as described above.
 
+\indexlibrary{\idxcode{discard_block_engine}}%
 \begin{codeblock}
 template<class Engine, size_t p, size_t r>
  class discard_block_engine
@@ -3461,6 +3464,7 @@ for (@$k$@ = @$n_0$@; @$k \neq n$@; @$k$@ += @$1$@)  {
 }
 \end{codeblock}
 
+\indexlibrary{\idxcode{independent_bits_engine}}%
 \begin{codeblock}
 template<class Engine, size_t w, class UIntType>
 class independent_bits_engine
@@ -3560,6 +3564,7 @@ The generation algorithm%
 yields the last value of \tcode{Y}
  produced while advancing \tcode{e}'s state as described above.
 
+\indexlibrary{\idxcode{shuffle_order_engine}}%
 \begin{codeblock}
 template<class Engine, size_t k>
  class shuffle_order_engine
@@ -3821,7 +3826,7 @@ is implementation-defined.
 
 
 \rSec2[rand.device]{Class \tcode{random_device}}%
-\indexlibrary{\idxcode{random_device}}
+\indexlibrary{\idxcode{random_device}}%
 
 \pnum
 A \tcode{random_device}
@@ -3834,6 +3839,7 @@ If implementation limitations%
 prevent generating non-deterministic random numbers,
 the implementation may employ a random number engine.
 
+\indexlibrary{\idxcode{random_device}}%
 \begin{codeblock}
 class random_device
 {
@@ -3882,7 +3888,7 @@ explicit random_device(const string& token = @\textit{implementation-defined}@);
  if the \tcode{random_device} could not be initialized.
 \end{itemdescr}
 
-\indexlibrarymember{random_device}{entropy}%
+\indexlibrarymember{entropy}{random_device}%
 \begin{itemdecl}
 double entropy() const noexcept;
 \end{itemdecl}
@@ -3902,7 +3908,7 @@ double entropy() const noexcept;
    $\log_2( \tcode{max()}+1)$.
 \end{itemdescr}
 
-\indexlibrarymember{random_device}{operator()}%
+\indexlibrarymember{operator()}{random_device}%
 \begin{itemdecl}
 result_type operator()();
 \end{itemdecl}
@@ -3938,6 +3944,7 @@ result_type operator()();
 
 \rSec3[rand.util.seedseq]{Class \tcode{seed_seq}}%
 
+\indexlibrary{\idxcode{seed_seq}}%
 \begin{codeblock}
 class seed_seq
 {
@@ -4021,7 +4028,7 @@ for( InputIterator s = begin; s != end; ++s)
 \end{codeblock}%
 \end{itemdescr}
 
-\indexlibrarymember{seed_seq}{generate}%
+\indexlibrarymember{generate}{seed_seq}%
 \begin{itemdecl}
 template<class RandomAccessIterator>
   void generate(RandomAccessIterator begin, RandomAccessIterator end);
@@ -4114,7 +4121,7 @@ What and when \tcode{RandomAccessIterator} operations of \tcode{begin}
 and \tcode{end} throw.
 \end{itemdescr}
 
-\indexlibrarymember{seed_seq}{size}%
+\indexlibrarymember{size}{seed_seq}%
 \begin{itemdecl}
 size_t size() const noexcept;
 \end{itemdecl}
@@ -4127,7 +4134,7 @@ size_t size() const noexcept;
 \pnum\complexity Constant time.
 \end{itemdescr}
 
-\indexlibrarymember{seed_seq}{param}%
+\indexlibrarymember{param}{seed_seq}%
 \begin{itemdecl}
 template<class OutputIterator>
   void param(OutputIterator dest) const;
@@ -4285,7 +4292,7 @@ everywhere outside its stated domain.
 
 \rSec4[rand.dist.uni.int]{Class template \tcode{uniform_int_distribution}}%
 \indexlibrary{\idxcode{uniform_int_distribution}}%
-\indextext{random number distribution!\idxcode{uniform_int_distribution}}
+\indextext{random number distribution!\idxcode{uniform_int_distribution}}%
 
 \pnum
 A \tcode{uniform_int_distribution} random number distribution
@@ -4294,12 +4301,13 @@ $ a \leq i \leq b $,
 distributed according to
 the constant discrete probability function%
 \indextext{discrete probability function!\idxcode{uniform_int_distribution}}%
-\indextext{\idxcode{uniform_int_distribution}!discrete probability function}
+\indextext{\idxcode{uniform_int_distribution}!discrete probability function}%
 \[%
  P(i\,|\,a,b) = 1 / (b - a + 1)
 \; \mbox{.}
 \]
 
+\indexlibrary{\idxcode{uniform_int_distribution}}%
 \begin{codeblock}
 template<class IntType = int>
  class uniform_int_distribution
@@ -4345,7 +4353,7 @@ explicit uniform_int_distribution(IntType a = 0, IntType b = numeric_limits<IntT
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{uniform_int_distribution}{a}%
+\indexlibrarymember{a}{uniform_int_distribution}%
 \begin{itemdecl}
 result_type a() const;
 \end{itemdecl}
@@ -4355,7 +4363,7 @@ result_type a() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrarymember{uniform_int_distribution}{b}%
+\indexlibrarymember{b}{uniform_int_distribution}%
 \begin{itemdecl}
 result_type b() const;
 \end{itemdecl}
@@ -4370,7 +4378,7 @@ result_type b() const;
 
 \rSec4[rand.dist.uni.real]{Class template \tcode{uniform_real_distribution}}%
 \indexlibrary{\idxcode{uniform_real_distribution}}%
-\indextext{random number distribution!\idxcode{uniform_real_distribution}}
+\indextext{random number distribution!\idxcode{uniform_real_distribution}}%
 
 \pnum
 A \tcode{uniform_real_distribution} random number distribution
@@ -4379,7 +4387,7 @@ $ a \leq x < b $,
 distributed according to
 the constant probability density function%
 \indextext{probability density function!\idxcode{uniform_real_distribution}}%
-\indextext{\idxcode{uniform_real_distribution}!probability density function}
+\indextext{\idxcode{uniform_real_distribution}!probability density function}%
 \[%
  p(x\,|\,a,b) = 1 / (b - a)
 \; \mbox{.}
@@ -4388,6 +4396,7 @@ the constant probability density function%
 This implies that $p(x\,|\,a,b)$ is undefined when \tcode{a == b}.
 \end{note}
 
+\indexlibrary{\idxcode{uniform_real_distribution}}%
 \begin{codeblock}
 template<class RealType = double>
  class uniform_real_distribution
@@ -4435,7 +4444,7 @@ explicit uniform_real_distribution(RealType a = 0.0, RealType b = 1.0);
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{uniform_real_distribution}{a}%
+\indexlibrarymember{a}{uniform_real_distribution}%
 \begin{itemdecl}
 result_type a() const;
 \end{itemdecl}
@@ -4445,7 +4454,7 @@ result_type a() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrarymember{uniform_real_distribution}{b}%
+\indexlibrarymember{b}{uniform_real_distribution}%
 \begin{itemdecl}
 result_type b() const;
 \end{itemdecl}
@@ -4466,14 +4475,14 @@ result_type b() const;
 
 \rSec3[rand.dist.bern]{Bernoulli distributions}%
 \indextext{Bernoulli distributions|(}%
-\indextext{random number distributions!Bernoulli|(}
+\indextext{random number distributions!Bernoulli|(}%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % bernoulli_distribution
 
 \rSec4[rand.dist.bern.bernoulli]{Class \tcode{bernoulli_distribution}}%
 \indexlibrary{\idxcode{bernoulli_distribution}}%
-\indextext{random number distribution!\idxcode{bernoulli_distribution}}
+\indextext{random number distribution!\idxcode{bernoulli_distribution}}%
 
 \pnum
 A \tcode{bernoulli_distribution} random number distribution
@@ -4481,7 +4490,7 @@ produces \tcode{bool} values $b$
 distributed according to
 the discrete probability function
 \indextext{discrete probability function!\idxcode{bernoulli_distribution}}%
-\indextext{\idxcode{bernoulli_distribution}!discrete probability function}
+\indextext{\idxcode{bernoulli_distribution}!discrete probability function}%
 \[%
  P(b\,|\,p)
       = \left\{ \begin{array}{lcl}
@@ -4491,6 +4500,7 @@ the discrete probability function
 \; \mbox{.}
 \]
 
+\indexlibrary{\idxcode{bernoulli_distribution}}%
 \begin{codeblock}
 class bernoulli_distribution
 {
@@ -4534,7 +4544,7 @@ explicit bernoulli_distribution(double p = 0.5);
  corresponds to the parameter of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{bernoulli_distribution}{p}%
+\indexlibrarymember{p}{bernoulli_distribution}%
 \begin{itemdecl}
 double p() const;
 \end{itemdecl}
@@ -4549,7 +4559,7 @@ double p() const;
 
 \rSec4[rand.dist.bern.bin]{Class template \tcode{binomial_distribution}}%
 \indexlibrary{\idxcode{binomial_distribution}}%
-\indextext{random number distribution!\idxcode{binomial_distribution}}
+\indextext{random number distribution!\idxcode{binomial_distribution}}%
 
 \pnum
 A \tcode{binomial_distribution} random number distribution
@@ -4557,13 +4567,14 @@ produces integer values $i \geq 0$
 distributed according to
 the discrete probability function%
 \indextext{discrete probability function!\idxcode{binomial_distribution}}%
-\indextext{\idxcode{binomial_distribution}!discrete probability function}
+\indextext{\idxcode{binomial_distribution}!discrete probability function}%
 \[%
  P(i\,|\,t,p)
       = \binom{t}{i} \cdot p^i \cdot (1-p)^{t-i}
 \; \mbox{.}
 \]
 
+\indexlibrary{\idxcode{binomial_distribution}}%
 \begin{codeblock}
 template<class IntType = int>
  class binomial_distribution
@@ -4609,7 +4620,7 @@ explicit binomial_distribution(IntType t = 1, double p = 0.5);
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{binomial_distribution}{t}%
+\indexlibrarymember{t}{binomial_distribution}%
 \begin{itemdecl}
 IntType t() const;
 \end{itemdecl}%
@@ -4618,7 +4629,7 @@ IntType t() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrarymember{binomial_distribution}{p}%
+\indexlibrarymember{p}{binomial_distribution}%
 \begin{itemdecl}
 double p() const;
 \end{itemdecl}
@@ -4632,8 +4643,8 @@ double p() const;
 % geometric_distribution
 
 \rSec4[rand.dist.bern.geo]{Class template \tcode{geometric_distribution}}
-\indexlibrary{\idxcode{geometric_distribution}}
-\indextext{random number distribution!\idxcode{geometric_distribution}}
+\indexlibrary{\idxcode{geometric_distribution}}%
+\indextext{random number distribution!\idxcode{geometric_distribution}}%
 
 \pnum
 A \tcode{geometric_distribution} random number distribution
@@ -4641,13 +4652,14 @@ produces integer values $i \geq 0$
 distributed according to
 the discrete probability function
 \indextext{discrete probability function!\idxcode{geometric_distribution}}%
-\indextext{\idxcode{geometric_distribution}!discrete probability function}
+\indextext{\idxcode{geometric_distribution}!discrete probability function}%
 \[%
  P(i\,|\,p)
       = p \cdot (1-p)^{i}
 \; \mbox{.}
 \]
 
+\indexlibrary{\idxcode{geometric_distribution}}%
 \begin{codeblock}
 template<class IntType = int>
  class geometric_distribution
@@ -4692,7 +4704,7 @@ explicit geometric_distribution(double p = 0.5);
  corresponds to the parameter of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{geometric_distribution}{p}%
+\indexlibrarymember{p}{geometric_distribution}%
 \begin{itemdecl}
 double p() const;
 \end{itemdecl}
@@ -4707,8 +4719,8 @@ double p() const;
 % ----------------------------------------------------------------------
 
 \rSec4[rand.dist.bern.negbin]{Class template \tcode{negative_binomial_distribution}}
-\indexlibrary{\idxcode{negative_binomial_distribution}}
-\indextext{random number distribution!\idxcode{negative_binomial_distribution}}
+\indexlibrary{\idxcode{negative_binomial_distribution}}%
+\indextext{random number distribution!\idxcode{negative_binomial_distribution}}%
 
 \pnum
 A \tcode{negative_binomial_distribution} random number distribution
@@ -4716,7 +4728,7 @@ produces random integers $i \geq 0$
 distributed according to
 the discrete probability function
 \indextext{discrete probability function!\idxcode{negative_binomial_distribution}}%
-\indextext{\idxcode{negative_binomial_distribution}!discrete probability function}
+\indextext{\idxcode{negative_binomial_distribution}!discrete probability function}%
 \[%
  P(i\,|\,k,p)
       = \binom{k+i-1}{i} \cdot p^k \cdot (1-p)^i
@@ -4726,6 +4738,7 @@ the discrete probability function
 This implies that $P(i\,|\,k,p)$ is undefined when \tcode{p == 1}.
 \end{note}
 
+\indexlibrary{\idxcode{negative_binomial_distribution}}%
 \begin{codeblock}
 template<class IntType = int>
  class negative_binomial_distribution
@@ -4772,7 +4785,7 @@ explicit negative_binomial_distribution(IntType k = 1, double p = 0.5);
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{negative_binomial_distribution}{t}%
+\indexlibrarymember{t}{negative_binomial_distribution}%
 \begin{itemdecl}
 IntType k() const;
 \end{itemdecl}
@@ -4782,7 +4795,7 @@ IntType k() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrarymember{negative_binomial_distribution}{p}%
+\indexlibrarymember{p}{negative_binomial_distribution}%
 \begin{itemdecl}
 double p() const;
 \end{itemdecl}
@@ -4792,7 +4805,7 @@ double p() const;
  with which the object was constructed.
 \end{itemdescr}%
 \indextext{random number distributions!Bernoulli|)}%
-\indextext{Bernoulli distributions|)}
+\indextext{Bernoulli distributions|)}%
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -4803,14 +4816,14 @@ double p() const;
 
 \rSec3[rand.dist.pois]{Poisson distributions}%
 \indextext{Poisson distributions|(}%
-\indextext{random number distributions!Poisson|(}
+\indextext{random number distributions!Poisson|(}%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % poisson_distribution
 
 \rSec4[rand.dist.pois.poisson]{Class template \tcode{poisson_distribution}}%
 \indexlibrary{\idxcode{poisson_distribution}}%
-\indextext{random number distribution!\idxcode{poisson_distribution}}
+\indextext{random number distribution!\idxcode{poisson_distribution}}%
 
 \pnum
 A \tcode{poisson_distribution} random number distribution
@@ -4818,7 +4831,7 @@ produces integer values $ i \geq 0 $
 distributed according to
 the discrete probability function
 \indextext{discrete probability function!\idxcode{poisson_distribution}}%
-\indextext{\idxcode{poisson_distribution}!discrete probability function}
+\indextext{\idxcode{poisson_distribution}!discrete probability function}%
 \[%
  P(i\,|\,\mu)
       = \frac{ e^{-\mu} \mu^{i} }
@@ -4831,6 +4844,7 @@ is also known as this distribution's \techterm{mean}%
 \indextext{\idxcode{poisson_distribution}!mean}%
 .
 
+\indexlibrary{\idxcode{poisson_distribution}}%
 \begin{codeblock}
 template<class IntType = int>
  class poisson_distribution
@@ -4860,8 +4874,6 @@ public:
 };
 \end{codeblock}
 
-
-
 \indexlibrary{\idxcode{poisson_distribution}!constructor}%
 \begin{itemdecl}
 explicit poisson_distribution(double mean = 1.0);
@@ -4876,7 +4888,7 @@ explicit poisson_distribution(double mean = 1.0);
  corresponds to the parameter of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{poisson_distribution}{mean}%
+\indexlibrarymember{mean}{poisson_distribution}%
 \begin{itemdecl}
 double mean() const;
 \end{itemdecl}
@@ -4891,7 +4903,7 @@ double mean() const;
 
 \rSec4[rand.dist.pois.exp]{Class template \tcode{exponential_distribution}}%
 \indexlibrary{\idxcode{exponential_distribution}}%
-\indextext{random number distribution!\idxcode{exponential_distribution}}
+\indextext{random number distribution!\idxcode{exponential_distribution}}%
 
 \pnum
 An \tcode{exponential_distribution} random number distribution
@@ -4899,13 +4911,14 @@ produces random numbers $x > 0$
 distributed according to
 the probability density function%
 \indextext{probability density function!\idxcode{exponential_distribution}}%
-\indextext{\idxcode{exponential_distribution}!probability density function}
+\indextext{\idxcode{exponential_distribution}!probability density function}%
 \[%
  p(x\,|\,\lambda)
       = \lambda e^{-\lambda x}
 \; \mbox{.}
 \]
 
+\indexlibrary{\idxcode{exponential_distribution}}%
 \begin{codeblock}
 template<class RealType = double>
  class exponential_distribution
@@ -4950,7 +4963,7 @@ explicit exponential_distribution(RealType lambda = 1.0);
  corresponds to the parameter of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{exponential_distribution}{lambda}%
+\indexlibrarymember{lambda}{exponential_distribution}%
 \begin{itemdecl}
 RealType lambda() const;
 \end{itemdecl}
@@ -4965,7 +4978,7 @@ RealType lambda() const;
 
 \rSec4[rand.dist.pois.gamma]{Class template \tcode{gamma_distribution}}%
 \indexlibrary{\idxcode{gamma_distribution}}%
-\indextext{random number distribution!\idxcode{gamma_distribution}}
+\indextext{random number distribution!\idxcode{gamma_distribution}}%
 
 \pnum
 A \tcode{gamma_distribution} random number distribution
@@ -4973,7 +4986,7 @@ produces random numbers $x > 0$
 distributed according to
 the probability density function%
 \indextext{probability density function!\idxcode{gamma_distribution}}%
-\indextext{\idxcode{gamma_distribution}!probability density function}
+\indextext{\idxcode{gamma_distribution}!probability density function}%
 \[%
  p(x\,|\,\alpha,\beta)
       = \frac{e^{-x/\beta}}{\beta^{\alpha} \cdot \Gamma(\alpha)}
@@ -4981,6 +4994,7 @@ the probability density function%
 \; \mbox{.}
 \]
 
+\indexlibrary{\idxcode{gamma_distribution}}%
 \begin{codeblock}
 template<class RealType = double>
  class gamma_distribution
@@ -5027,7 +5041,7 @@ explicit gamma_distribution(RealType alpha = 1.0, RealType beta = 1.0);
  correspond to the parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{gamma_distribution}{alpha}%
+\indexlibrarymember{alpha}{gamma_distribution}%
 \begin{itemdecl}
 RealType alpha() const;
 \end{itemdecl}
@@ -5037,7 +5051,7 @@ RealType alpha() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrarymember{gamma_distribution}{beta}%
+\indexlibrarymember{beta}{gamma_distribution}%
 \begin{itemdecl}
 RealType beta() const;
 \end{itemdecl}
@@ -5052,7 +5066,8 @@ RealType beta() const;
 % ----------------------------------------------------------------------
 
 \rSec4[rand.dist.pois.weibull]{Class template \tcode{weibull_distribution}}%
-\indexlibrary{\idxcode{weibull_distribution}}
+\indexlibrary{\idxcode{weibull_distribution}}%
+\indextext{random number distribution!\idxcode{weibull_distribution}}%
 
 \pnum
 A \tcode{weibull_distribution} random number distribution
@@ -5060,7 +5075,7 @@ produces random numbers $x \geq 0$
 distributed according to
 the probability density function%
 \indextext{probability density function!\idxcode{weibull_distribution}}%
-\indextext{\idxcode{weibull_distribution}!probability density function}
+\indextext{\idxcode{weibull_distribution}!probability density function}%
 \[%
  p(x\,|\,a,b)
       =       \frac{a}{b}
@@ -5069,6 +5084,7 @@ the probability density function%
 \; \mbox{.}
 \]
 
+\indexlibrary{\idxcode{weibull_distribution}}%
 \begin{codeblock}
 template<class RealType = double>
  class weibull_distribution
@@ -5113,7 +5129,7 @@ explicit weibull_distribution(RealType a = 1.0, RealType b = 1.0);
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{weibull_distribution}{a}%
+\indexlibrarymember{a}{weibull_distribution}%
 \begin{itemdecl}
 RealType a() const;
 \end{itemdecl}
@@ -5123,7 +5139,7 @@ RealType a() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrarymember{weibull_distribution}{b}%
+\indexlibrarymember{b}{weibull_distribution}%
 \begin{itemdecl}
 RealType b() const;
 \end{itemdecl}
@@ -5138,8 +5154,8 @@ RealType b() const;
 % ----------------------------------------------------------------------
 
 \rSec4[rand.dist.pois.extreme]{Class template \tcode{extreme_value_distribution}}
-\indexlibrary{\idxcode{extreme_value_distribution}}
-\indextext{random number distribution!\idxcode{extreme_value_distribution}}
+\indexlibrary{\idxcode{extreme_value_distribution}}%
+\indextext{random number distribution!\idxcode{extreme_value_distribution}}%
 
 \pnum
 An \tcode{extreme_value_distribution} random number distribution
@@ -5164,6 +5180,7 @@ the probability density function\footnote{The distribution corresponding to
 \; \mbox{.}
 \]
 
+\indexlibrary{\idxcode{extreme_value_distribution}}%
 \begin{codeblock}
 template<class RealType = double>
  class extreme_value_distribution
@@ -5209,7 +5226,7 @@ explicit extreme_value_distribution(RealType a = 0.0, RealType b = 1.0);
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{extreme_value_distribution}{a}%
+\indexlibrarymember{a}{extreme_value_distribution}%
 \begin{itemdecl}
 RealType a() const;
 \end{itemdecl}
@@ -5219,7 +5236,7 @@ RealType a() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrarymember{extreme_value_distribution}{b}%
+\indexlibrarymember{b}{extreme_value_distribution}%
 \begin{itemdecl}
 RealType b() const;
 \end{itemdecl}
@@ -5247,7 +5264,7 @@ RealType b() const;
 
 \rSec4[rand.dist.norm.normal]{Class template \tcode{normal_distribution}}%
 \indexlibrary{\idxcode{normal_distribution}}%
-\indextext{random number distribution!\idxcode{normal_distribution}}
+\indextext{random number distribution!\idxcode{normal_distribution}}%
 
 \pnum
 A \tcode{normal_distribution} random number distribution
@@ -5255,7 +5272,7 @@ produces random numbers $x$
 distributed according to
 the probability density function%
 \indextext{probability density function!\idxcode{normal_distribution}}%
-\indextext{\idxcode{normal_distribution}!probability density function}
+\indextext{\idxcode{normal_distribution}!probability density function}%
 \[%
  p(x\,|\,\mu,\sigma)
       = \frac{1}{\sigma \sqrt{2\pi}}
@@ -5276,6 +5293,7 @@ and \techterm{standard deviation}%
 \indextext{\idxcode{normal_distribution}!standard deviation}%
 .
 
+\indexlibrary{\idxcode{normal_distribution}}%
 \begin{codeblock}
 template<class RealType = double>
  class normal_distribution
@@ -5321,7 +5339,7 @@ explicit normal_distribution(RealType mean = 0.0, RealType stddev = 1.0);
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{normal_distribution}{mean}%
+\indexlibrarymember{mean}{normal_distribution}%
 \begin{itemdecl}
 RealType mean() const;
 \end{itemdecl}
@@ -5331,7 +5349,7 @@ RealType mean() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrarymember{normal_distribution}{stddev}%
+\indexlibrarymember{stddev}{normal_distribution}%
 \begin{itemdecl}
 RealType stddev() const;
 \end{itemdecl}
@@ -5347,7 +5365,7 @@ RealType stddev() const;
 
 \rSec4[rand.dist.norm.lognormal]{Class template \tcode{lognormal_distribution}}%
 \indexlibrary{\idxcode{lognormal_distribution}}%
-\indextext{random number distribution!\idxcode{lognormal_distribution}}
+\indextext{random number distribution!\idxcode{lognormal_distribution}}%
 
 \pnum
 A \tcode{lognormal_distribution} random number distribution
@@ -5355,7 +5373,7 @@ produces random numbers $ x > 0 $
 distributed according to
 the probability density function%
 \indextext{probability density function!\idxcode{lognormal_distribution}}%
-\indextext{\idxcode{lognormal_distribution}!probability density function}
+\indextext{\idxcode{lognormal_distribution}!probability density function}%
 \[%
  p(x\,|\,m,s)
       = \frac{1}
@@ -5368,6 +5386,7 @@ the probability density function%
 \; \mbox{.}
 \]
 
+\indexlibrary{\idxcode{lognormal_distribution}}%
 \begin{codeblock}
 template<class RealType = double>
  class lognormal_distribution
@@ -5413,7 +5432,7 @@ explicit lognormal_distribution(RealType m = 0.0, RealType s = 1.0);
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{lognormal_distribution}{m}%
+\indexlibrarymember{m}{lognormal_distribution}%
 \begin{itemdecl}
 RealType m() const;
 \end{itemdecl}
@@ -5423,7 +5442,7 @@ RealType m() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrarymember{lognormal_distribution}{s}%
+\indexlibrarymember{s}{lognormal_distribution}%
 \begin{itemdecl}
 RealType s() const;
 \end{itemdecl}
@@ -5439,7 +5458,7 @@ RealType s() const;
 
 \rSec4[rand.dist.norm.chisq]{Class template \tcode{chi_squared_distribution}}%
 \indexlibrary{\idxcode{chi_squared_distribution}}%
-\indextext{random number distribution!\idxcode{chi_squared_distribution}}
+\indextext{random number distribution!\idxcode{chi_squared_distribution}}%
 
 \pnum
 A \tcode{chi_squared_distribution} random number distribution
@@ -5447,7 +5466,7 @@ produces random numbers $x>0$
 distributed according to
 the probability density function%
 \indextext{probability density function!\idxcode{chi_squared_distribution}}%
-\indextext{\idxcode{chi_squared_distribution}!probability density function}
+\indextext{\idxcode{chi_squared_distribution}!probability density function}%
 \[%
  p(x\,|\,n)
       =  \frac{ x^{(n/2)-1} \cdot e^{-x/2}}
@@ -5455,6 +5474,7 @@ the probability density function%
 \; \mbox{.}
 \]
 
+\indexlibrary{\idxcode{chi_squared_distribution}}%
 \begin{codeblock}
 template<class RealType = double>
  class chi_squared_distribution
@@ -5499,7 +5519,7 @@ explicit chi_squared_distribution(RealType n = 1);
  corresponds to the parameter of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{chi_squared_distribution}{n}%
+\indexlibrarymember{n}{chi_squared_distribution}%
 \begin{itemdecl}
 RealType n() const;
 \end{itemdecl}
@@ -5514,7 +5534,8 @@ RealType n() const;
 % ----------------------------------------------------------------------
 
 \rSec4[rand.dist.norm.cauchy]{Class template \tcode{cauchy_distribution}}%
-\indexlibrary{\idxcode{cauchy_distribution}}
+\indexlibrary{\idxcode{cauchy_distribution}}%
+\indextext{random number distribution!\idxcode{cauchy_distribution}}%
 
 \pnum
 A \tcode{cauchy_distribution} random number distribution
@@ -5522,13 +5543,14 @@ produces random numbers $x$
 distributed according to
 the probability density function%
 \indextext{probability density function!\idxcode{cauchy_distribution}}%
-\indextext{\idxcode{cauchy_distribution}!probability density function}
+\indextext{\idxcode{cauchy_distribution}!probability density function}%
 \[%
  p(x\,|\,a,b)
       = \left( \pi b \left( 1 + \left( \frac{x-a}{b}  \right)^2 \;\right)\right)^{-1}
 \; \mbox{.}
 \]
 
+\indexlibrary{\idxcode{cauchy_distribution}}%
 \begin{codeblock}
 template<class RealType = double>
  class cauchy_distribution
@@ -5574,7 +5596,7 @@ explicit cauchy_distribution(RealType a = 0.0, RealType b = 1.0);
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{cauchy_distribution}{a}%
+\indexlibrarymember{a}{cauchy_distribution}%
 \begin{itemdecl}
 RealType a() const;
 \end{itemdecl}
@@ -5584,7 +5606,7 @@ RealType a() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrarymember{cauchy_distribution}{b}%
+\indexlibrarymember{b}{cauchy_distribution}%
 \begin{itemdecl}
 RealType b() const;
 \end{itemdecl}
@@ -5600,7 +5622,7 @@ RealType b() const;
 
 \rSec4[rand.dist.norm.f]{Class template \tcode{fisher_f_distribution}}%
 \indexlibrary{\idxcode{fisher_f_distribution}}%
-\indextext{random number distribution!\idxcode{fisher_f_distribution}}
+\indextext{random number distribution!\idxcode{fisher_f_distribution}}%
 
 \pnum
 A \tcode{fisher_f_distribution} random number distribution
@@ -5608,7 +5630,7 @@ produces random numbers $x\ge0$
 distributed according to
 the probability density function%
 \indextext{probability density function!\idxcode{fisher_f_distribution}}%
-\indextext{\idxcode{fisher_f_distribution}!probability density function}
+\indextext{\idxcode{fisher_f_distribution}!probability density function}%
 \[%
  p(x\,|\,m,n)
       = \frac{\Gamma\big((m+n)/2\big)}
@@ -5622,6 +5644,7 @@ the probability density function%
 \; \mbox{.}
 \]
 
+\indexlibrary{\idxcode{fisher_f_distribution}}%
 \begin{codeblock}
 template<class RealType = double>
  class fisher_f_distribution
@@ -5667,7 +5690,7 @@ explicit fisher_f_distribution(RealType m = 1, RealType n = 1);
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{fisher_f_distribution}{m}%
+\indexlibrarymember{m}{fisher_f_distribution}%
 \begin{itemdecl}
 RealType m() const;
 \end{itemdecl}
@@ -5677,7 +5700,7 @@ RealType m() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrarymember{fisher_f_distribution}{n}%
+\indexlibrarymember{n}{fisher_f_distribution}%
 \begin{itemdecl}
 RealType n() const;
 \end{itemdecl}
@@ -5693,7 +5716,7 @@ RealType n() const;
 
 \rSec4[rand.dist.norm.t]{Class template \tcode{student_t_distribution}}%
 \indexlibrary{\idxcode{student_t_distribution}}%
-\indextext{random number distribution!\idxcode{student_t_distribution}}
+\indextext{random number distribution!\idxcode{student_t_distribution}}%
 
 \pnum
 A \tcode{student_t_distribution} random number distribution
@@ -5701,7 +5724,7 @@ produces random numbers $x$
 distributed according to
 the probability density function%
 \indextext{probability density function!\idxcode{student_t_distribution}}%
-\indextext{\idxcode{student_t_distribution}!probability density function}
+\indextext{\idxcode{student_t_distribution}!probability density function}%
 \[%
  p(x\,|\,n)
       =  \frac{1}
@@ -5712,6 +5735,7 @@ the probability density function%
 \; \mbox{.}
 \]
 
+\indexlibrary{\idxcode{student_t_distribution}}%
 \begin{codeblock}
 template<class RealType = double>
  class student_t_distribution
@@ -5755,7 +5779,7 @@ explicit student_t_distribution(RealType n = 1);
  \tcode{n} corresponds to the parameter of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{student_t_distribution}{mean}%
+\indexlibrarymember{mean}{student_t_distribution}%
 \begin{itemdecl}
 RealType n() const;
 \end{itemdecl}
@@ -5785,7 +5809,7 @@ RealType n() const;
 
 \rSec4[rand.dist.samp.discrete]{Class template \tcode{discrete_distribution}}%
 \indexlibrary{\idxcode{discrete_distribution}}%
-\indextext{random number distribution!\idxcode{discrete_distribution}}
+\indextext{random number distribution!\idxcode{discrete_distribution}}%
 
 \pnum
 A \tcode{discrete_distribution} random number distribution
@@ -5793,7 +5817,7 @@ produces random integers $i$, $0 \leq i < n$,
 distributed according to
 the discrete probability function%
 \indextext{discrete probability function!\idxcode{discrete_distribution}}%
-\indextext{\idxcode{discrete_distribution}!discrete probability function}
+\indextext{\idxcode{discrete_distribution}!discrete probability function}%
 \[%
  P(i\,|\,p_0,\ldots,p_{n-1})
       = p_i
@@ -5813,6 +5837,7 @@ commonly known as the \techterm{weights}%
 Moreover, the following relation shall hold:
  $ 0 < S = w_0 + \cdots + w_{n-1} $.
 
+\indexlibrary{\idxcode{discrete_distribution}}%
 \begin{codeblock}
 template<class IntType = int>
  class discrete_distribution
@@ -5929,7 +5954,7 @@ template<class UnaryOperation>
  The number of invocations of \tcode{fw} shall not exceed $n$.
 \end{itemdescr}
 
-\indexlibrarymember{discrete_distribution}{probabilities}%
+\indexlibrarymember{probabilities}{discrete_distribution}%
 \begin{itemdecl}
 vector<double> probabilities() const;
 \end{itemdecl}
@@ -5948,7 +5973,7 @@ vector<double> probabilities() const;
 
 \rSec4[rand.dist.samp.pconst]{Class template \tcode{piecewise_constant_distribution}}%
 \indexlibrary{\idxcode{piecewise_constant_distribution}}%
-\indextext{random number distribution!\idxcode{piecewise_constant_distribution}}
+\indextext{random number distribution!\idxcode{piecewise_constant_distribution}}%
 
 \pnum
 A \tcode{piecewise_constant_distribution} random number distribution
@@ -5958,7 +5983,7 @@ uniformly distributed over each subinterval
 $ [ b_i, b_{i+1} ) $
 according to the probability density function
 \indextext{probability density function!\idxcode{piecewise_constant_distribution}}%
-\indextext{\idxcode{piecewise_constant_distribution}!probability density function}
+\indextext{\idxcode{piecewise_constant_distribution}!probability density function}%
 \[%
  p(x\,|\,b_0,\ldots,b_n,\;\rho_0,\ldots,\rho_{n-1})
       = \rho_i
@@ -5990,6 +6015,7 @@ commonly known as the \techterm{weights}%
 Moreover, the following relation shall hold:
  $ 0 < S = w_0 + \cdots + w_{n-1} $.
 
+\indexlibrary{\idxcode{piecewise_constant_distribution}}%
 \begin{codeblock}
 template<class RealType = double>
  class piecewise_constant_distribution
@@ -6139,7 +6165,7 @@ template<class UnaryOperation>
  The number of invocations of \tcode{fw} shall not exceed $n$.
 \end{itemdescr}
 
-\indexlibrarymember{piecewise_constant_distribution}{intervals}%
+\indexlibrarymember{intervals}{piecewise_constant_distribution}%
 \begin{itemdecl}
 vector<result_type> intervals() const;
 \end{itemdecl}
@@ -6151,7 +6177,7 @@ vector<result_type> intervals() const;
  when invoked with argument $k$ for $k = 0, \ldots, n $.
 \end{itemdescr}
 
-\indexlibrarymember{piecewise_constant_distribution}{densities}%
+\indexlibrarymember{densities}{piecewise_constant_distribution}%
 \begin{itemdecl}
 vector<result_type> densities() const;
 \end{itemdecl}
@@ -6170,7 +6196,7 @@ vector<result_type> densities() const;
 
 \rSec4[rand.dist.samp.plinear]{Class template \tcode{piecewise_linear_distribution}}%
 \indexlibrary{\idxcode{piecewise_linear_distribution}}%
-\indextext{random number distribution!\idxcode{piecewise_linear_distribution}}
+\indextext{random number distribution!\idxcode{piecewise_linear_distribution}}%
 
 \pnum
 A \tcode{piecewise_linear_distribution} random number distribution
@@ -6180,7 +6206,7 @@ distributed over each subinterval
 $ [ b_i, b_{i+1} ) $
 according to the probability density function
 \indextext{probability density function!\idxcode{piecewise_linear_distribution}}%
-\indextext{\idxcode{piecewise_linear_distribution}!probability density function}
+\indextext{\idxcode{piecewise_linear_distribution}!probability density function}%
 \[%
  p(x\,|\,b_0,\ldots,b_n,\;\rho_0,\ldots,\rho_n)
       = \rho_i     \cdot {\frac{b_{i+1} - x}{b_{i+1} - b_i}}
@@ -6213,6 +6239,7 @@ Moreover, the following relation shall hold:
 \; \mbox{.}
 \]
 
+\indexlibrary{\idxcode{piecewise_linear_distribution}}%
 \begin{codeblock}
 template<class RealType = double>
  class piecewise_linear_distribution
@@ -6360,7 +6387,7 @@ template<class UnaryOperation>
  The number of invocations of \tcode{fw} shall not exceed $n+1$.
 \end{itemdescr}
 
-\indexlibrarymember{piecewise_linear_distribution}{intervals}%
+\indexlibrarymember{intervals}{piecewise_linear_distribution}%
 \begin{itemdecl}
 vector<result_type> intervals() const;
 \end{itemdecl}
@@ -6372,7 +6399,7 @@ vector<result_type> intervals() const;
  when invoked with argument $k$ for $k = 0, \ldots, n $.
 \end{itemdescr}
 
-\indexlibrarymember{piecewise_linear_distribution}{densities}%
+\indexlibrarymember{densities}{piecewise_linear_distribution}%
 \begin{itemdecl}
 vector<result_type> densities() const;
 \end{itemdecl}
@@ -6900,7 +6927,7 @@ an implementation may return all allocated memory.
 
 \rSec3[valarray.assign]{\tcode{valarray} assignment}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{valarray}}%
+\indexlibrarymember{operator=}{valarray}%
 \begin{itemdecl}
 valarray& operator=(const valarray& v);
 \end{itemdecl}
@@ -6919,7 +6946,7 @@ as if by calling \tcode{resize(v.size())}, before performing the assignment.
 \postcondition \tcode{size() == v.size()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{valarray}}%
+\indexlibrarymember{operator=}{valarray}%
 \begin{itemdecl}
 valarray& operator=(valarray&& v) noexcept;
 \end{itemdecl}
@@ -6947,7 +6974,7 @@ valarray& operator=(initializer_list<T> il);
 \end{itemdescr}
 
 
-\indexlibrary{\idxcode{operator=}!\idxcode{valarray}}%
+\indexlibrarymember{operator=}{valarray}%
 \begin{itemdecl}
 valarray& operator=(const T&);
 \end{itemdecl}
@@ -6984,7 +7011,7 @@ the resulting behavior is undefined.
 
 \rSec3[valarray.access]{\tcode{valarray} element access}
 
-\indexlibrary{\idxcode{operator[]}!\idxcode{valarray}}%
+\indexlibrarymember{operator[]}{valarray}%
 \begin{itemdecl}
 const T&  operator[](size_t) const;
 T& operator[](size_t);
@@ -7079,7 +7106,7 @@ conjunction with various overloads of \tcode{operator=} and other assigning
 operators to allow selective replacement (slicing) of the controlled sequence.
 In each case the selected element(s) must exist.
 
-\indexlibrary{\idxcode{operator[]}!\idxcode{valarray}}%
+\indexlibrarymember{operator[]}{valarray}%
 \begin{itemdecl}
 valarray operator[](slice slicearr) const;
 \end{itemdecl}
@@ -7096,7 +7123,7 @@ const valarray<char> v0("abcdefghijklmnop", 16);
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator[]}!\idxcode{valarray}}%
+\indexlibrarymember{operator[]}{valarray}%
 \begin{itemdecl}
 slice_array<T> operator[](slice slicearr);
 \end{itemdecl}
@@ -7114,7 +7141,7 @@ v0[slice(2, 5, 3)] = v1;
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator[]}!\idxcode{valarray}}%
+\indexlibrarymember{operator[]}{valarray}%
 \begin{itemdecl}
 valarray operator[](const gslice& gslicearr) const;
 \end{itemdecl}
@@ -7135,7 +7162,7 @@ const valarray<size_t> len(lv, 2), str(dv, 2);
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator[]}!\idxcode{valarray}}%
+\indexlibrarymember{operator[]}{valarray}%
 \begin{itemdecl}
 gslice_array<T> operator[](const gslice& gslicearr);
 \end{itemdecl}
@@ -7156,7 +7183,7 @@ v0[gslice(3, len, str)] = v1;
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator[]}!\idxcode{valarray}}%
+\indexlibrarymember{operator[]}{valarray}%
 \begin{itemdecl}
 valarray operator[](const valarray<bool>& boolarr) const;
 \end{itemdecl}
@@ -7175,7 +7202,7 @@ const bool vb[] = { false, false, true, true, false, true };
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator[]}!\idxcode{valarray}}%
+\indexlibrarymember{operator[]}{valarray}%
 \begin{itemdecl}
 mask_array<T> operator[](const valarray<bool>& boolarr);
 \end{itemdecl}
@@ -7194,7 +7221,7 @@ v0[valarray<bool>(vb, 6)] = v1;
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator[]}!\idxcode{valarray}}%
+\indexlibrarymember{operator[]}{valarray}%
 \begin{itemdecl}
 valarray operator[](const valarray<size_t>& indarr) const;
 \end{itemdecl}
@@ -7213,7 +7240,7 @@ const size_t vi[] = { 7, 5, 2, 3, 8 };
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator[]}!\idxcode{valarray}}%
+\indexlibrarymember{operator[]}{valarray}%
 \begin{itemdecl}
 indirect_array<T> operator[](const valarray<size_t>& indarr);
 \end{itemdecl}
@@ -7234,10 +7261,10 @@ v0[valarray<size_t>(vi, 5)] = v1;
 
 \rSec3[valarray.unary]{\tcode{valarray} unary operators}
 
-\indexlibrary{\idxcode{operator+}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator-}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator\~{}}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator"!}!\idxcode{valarray}}%
+\indexlibrarymember{operator+}{valarray}%
+\indexlibrarymember{operator-}{valarray}%
+\indexlibrarymember{operator\~{}}{valarray}%
+\indexlibrarymember{operator"!}{valarray}%
 \begin{itemdecl}
 valarray operator+() const;
 valarray operator-() const;
@@ -7262,14 +7289,14 @@ applying the indicated operator to the corresponding element of the array.
 
 \rSec3[valarray.cassign]{\tcode{valarray} compound assignment}
 
-\indexlibrary{\idxcode{operator*=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator/=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator\%=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator+=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator-=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator\^{}=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator\&=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator"|=}!\idxcode{valarray}}%
+\indexlibrarymember{operator*=}{valarray}%
+\indexlibrarymember{operator/=}{valarray}%
+\indexlibrarymember{operator\%=}{valarray}%
+\indexlibrarymember{operator+=}{valarray}%
+\indexlibrarymember{operator-=}{valarray}%
+\indexlibrarymember{operator\^{}=}{valarray}%
+\indexlibrarymember{operator\&=}{valarray}%
+\indexlibrarymember{operator"|=}{valarray}%
 \indexlibrarymember{operator\shl=}{valarray}%
 \indexlibrarymember{operator\shr=}{valarray}%
 \begin{itemdecl}
@@ -7314,8 +7341,7 @@ hand side, the resulting behavior is undefined.
 \indexlibrarymember{operator\%=}{valarray}%
 \indexlibrarymember{operator+=}{valarray}%
 \indexlibrarymember{operator-=}{valarray}%
-\indexlibrary{\idxcode{operator\^{}=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator\^{}=}}%
+\indexlibrarymember{operator\^{}=}{valarray}%
 \indexlibrarymember{operator\&=}{valarray}%
 \indexlibrarymember{operator"|=}{valarray}%
 \indexlibrarymember{operator\shl=}{valarray}%
@@ -7519,18 +7545,16 @@ Resizing invalidates all pointers and references to elements in the array.
 
 \rSec3[valarray.binary]{\tcode{valarray} binary operators}
 
-\indexlibrary{\idxcode{operator*}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator/}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator\%}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator+}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator-}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator\^{}}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator\&}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator"|}!\idxcode{valarray}}%
+\indexlibrarymember{operator*}{valarray}%
+\indexlibrarymember{operator/}{valarray}%
+\indexlibrarymember{operator\%}{valarray}%
+\indexlibrarymember{operator+}{valarray}%
+\indexlibrarymember{operator-}{valarray}%
+\indexlibrarymember{operator\^{}}{valarray}%
+\indexlibrarymember{operator\&}{valarray}%
+\indexlibrarymember{operator"|}{valarray}%
 \indexlibrarymember{operator\shl}{valarray}%
 \indexlibrarymember{operator\shr}{valarray}%
-\indexlibrary{\idxcode{operator\&\&}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator"|"|}!\idxcode{valarray}}%
 \begin{itemdecl}
 template<class T> valarray<T> operator*
     (const valarray<T>&, const valarray<T>&);
@@ -7577,9 +7601,8 @@ If the argument arrays do not have the same length, the behavior is undefined.%
 \indexlibrarymember{operator/}{valarray}%
 \indexlibrarymember{operator\%}{valarray}%
 \indexlibrarymember{operator+}{valarray}%
-\indexlibrarymember{operator=}{valarray}%
-\indexlibrary{\idxcode{operator\^{}}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator\^{}}}%
+\indexlibrarymember{operator-}{valarray}%
+\indexlibrarymember{operator\^{}}{valarray}%
 \indexlibrarymember{operator\&}{valarray}%
 \indexlibrarymember{operator"|}{valarray}%
 \indexlibrarymember{operator\shl}{valarray}%
@@ -7624,14 +7647,14 @@ corresponding element of the array argument and the non-array argument.
 
 \rSec3[valarray.comparison]{\tcode{valarray} logical operators}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator"!=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator<}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator>}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator<=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator>=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator\&\&}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator"|"|}!\idxcode{valarray}}%
+\indexlibrarymember{operator==}{valarray}%
+\indexlibrarymember{operator"!=}{valarray}%
+\indexlibrarymember{operator<}{valarray}%
+\indexlibrarymember{operator>}{valarray}%
+\indexlibrarymember{operator<=}{valarray}%
+\indexlibrarymember{operator>=}{valarray}%
+\indexlibrarymember{operator\&\&}{valarray}%
+\indexlibrarymember{operator"|"|}{valarray}%
 \begin{itemdecl}
 template<class T> valarray<bool> operator==
     (const valarray<T>&, const valarray<T>&);
@@ -7672,8 +7695,7 @@ the behavior is undefined.%
 \end{itemdescr}
 
 \indexlibrarymember{operator==}{valarray}%
-\indexlibrary{\idxcode{operator"!=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{valarray}%
 \indexlibrarymember{operator<}{valarray}%
 \indexlibrarymember{operator<=}{valarray}%
 \indexlibrarymember{operator>}{valarray}%
@@ -7716,22 +7738,22 @@ indicated operator to the corresponding element of the array and the non-array a
 
 \rSec3[valarray.transcend]{\tcode{valarray} transcendentals}
 
-\indexlibrary{\idxcode{abs}}%
-\indexlibrary{\idxcode{acos}}%
-\indexlibrary{\idxcode{asin}}%
-\indexlibrary{\idxcode{atan}}%
-\indexlibrary{\idxcode{atan2}}%
-\indexlibrary{\idxcode{cos}}%
-\indexlibrary{\idxcode{cosh}}%
-\indexlibrary{\idxcode{exp}}%
-\indexlibrary{\idxcode{log}}%
-\indexlibrary{\idxcode{log10}}%
-\indexlibrary{\idxcode{pow}}%
-\indexlibrary{\idxcode{sin}}%
-\indexlibrary{\idxcode{sinh}}%
-\indexlibrary{\idxcode{sqrt}}%
-\indexlibrary{\idxcode{tan}}%
-\indexlibrary{\idxcode{tanh}}%
+\indexlibrary{\idxcode{abs}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{acos}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{asin}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{atan}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{atan2}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{cos}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{cosh}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{exp}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{log}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{log10}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{pow}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{sin}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{sinh}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{sqrt}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{tan}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{tanh}!\idxcode{valarray}}%
 \begin{itemdecl}
 template<class T> valarray<T> abs  (const valarray<T>&);
 template<class T> valarray<T> acos (const valarray<T>&);
@@ -7837,9 +7859,9 @@ constructs a slice which selects elements 3, 5, 7, ... 17 from an array.
 \end{itemdescr}
 
 \rSec3[slice.access]{\tcode{slice} access functions}
-\indexlibrary{\idxcode{start}!\idxcode{slice}}%
-\indexlibrary{\idxcode{size}!\idxcode{slice}}%
-\indexlibrary{\idxcode{stride}!\idxcode{slice}}%
+\indexlibrarymember{start}{slice}%
+\indexlibrarymember{size}{slice}%
+\indexlibrarymember{stride}{slice}%
 \begin{itemdecl}
 size_t start() const;
 size_t size() const;
@@ -7881,7 +7903,7 @@ namespace std {
     slice_array(const slice_array&);
     ~slice_array();
     const slice_array& operator=(const slice_array&) const;
-  void operator=(const T&) const;
+    void operator=(const T&) const;
 
     slice_array() = delete;       // as implied by declaring copy constructor above
   };
@@ -7938,14 +7960,14 @@ object refers.
 
 \rSec3[slice.arr.comp.assign]{\tcode{slice_array} compound assignment}
 
-\indexlibrary{\idxcode{operator*=}!\idxcode{slice_array}}%
-\indexlibrary{\idxcode{operator/=}!\idxcode{slice_array}}%
-\indexlibrary{\idxcode{operator\%=}!\idxcode{slice_array}}%
-\indexlibrary{\idxcode{operator+=}!\idxcode{slice_array}}%
-\indexlibrary{\idxcode{operator-=}!\idxcode{slice_array}}%
-\indexlibrary{\idxcode{operator\^{}=}!\idxcode{slice_array}}%
-\indexlibrary{\idxcode{operator\&=}!\idxcode{slice_array}}%
-\indexlibrary{\idxcode{operator"|=}!\idxcode{slice_array}}%
+\indexlibrarymember{operator*=}{slice_array}%
+\indexlibrarymember{operator/=}{slice_array}%
+\indexlibrarymember{operator\%=}{slice_array}%
+\indexlibrarymember{operator+=}{slice_array}%
+\indexlibrarymember{operator-=}{slice_array}%
+\indexlibrarymember{operator\^{}=}{slice_array}%
+\indexlibrarymember{operator\&=}{slice_array}%
+\indexlibrarymember{operator"|=}{slice_array}%
 \indexlibrarymember{operator\shl=}{slice_array}%
 \indexlibrarymember{operator\shr=}{slice_array}%
 \begin{itemdecl}
@@ -7974,7 +7996,7 @@ object refers.
 
 \rSec3[slice.arr.fill]{\tcode{slice_array} fill function}
 
-\indexlibrary{\idxcode{fill}!\idxcode{slice_array}}%
+\indexlibrarymember{operator=}{slice_array}%
 \begin{itemdecl}
 void operator=(const T&) const;
 \end{itemdecl}
@@ -8125,9 +8147,9 @@ in the previous section.
 
 \rSec3[gslice.access]{\tcode{gslice} access functions}
 
-\indexlibrary{\idxcode{start}!\idxcode{gslice}}%
-\indexlibrary{\idxcode{size}!\idxcode{gslice}}%
-\indexlibrary{\idxcode{stride}!\idxcode{gslice}}%
+\indexlibrarymember{start}{gslice}%
+\indexlibrarymember{size}{gslice}%
+\indexlibrarymember{stride}{gslice}%
 \begin{itemdecl}
 size_t           start()  const;
 valarray<size_t> size() const;
@@ -8206,7 +8228,7 @@ generalized slice of the elements in
 
 \rSec3[gslice.array.assign]{\tcode{gslice_array} assignment}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{gslice_array}}%
+\indexlibrarymember{operator=}{gslice_array}%
 \begin{itemdecl}
 void operator=(const valarray<T>&) const;
 const gslice_array& operator=(const gslice_array&) const;
@@ -8224,14 +8246,14 @@ refers.
 
 \rSec3[gslice.array.comp.assign]{\tcode{gslice_array} compound assignment}
 
-\indexlibrary{\idxcode{operator*=}!\idxcode{gslice_array}}%
-\indexlibrary{\idxcode{operator/=}!\idxcode{gslice_array}}%
-\indexlibrary{\idxcode{operator\%=}!\idxcode{gslice_array}}%
-\indexlibrary{\idxcode{operator+=}!\idxcode{gslice_array}}%
-\indexlibrary{\idxcode{operator-=}!\idxcode{gslice_array}}%
-\indexlibrary{\idxcode{operator\^{}=}!\idxcode{gslice_array}}%
-\indexlibrary{\idxcode{operator\&=}!\idxcode{gslice_array}}%
-\indexlibrary{\idxcode{operator"|=}!\idxcode{gslice_array}}%
+\indexlibrarymember{operator*=}{gslice_array}%
+\indexlibrarymember{operator/=}{gslice_array}%
+\indexlibrarymember{operator\%=}{gslice_array}%
+\indexlibrarymember{operator+=}{gslice_array}%
+\indexlibrarymember{operator-=}{gslice_array}%
+\indexlibrarymember{operator\^{}=}{gslice_array}%
+\indexlibrarymember{operator\&=}{gslice_array}%
+\indexlibrarymember{operator"|=}{gslice_array}%
 \indexlibrarymember{operator\shl=}{gslice_array}%
 \indexlibrarymember{operator\shr=}{gslice_array}%
 \begin{itemdecl}
@@ -8260,7 +8282,7 @@ object refers.
 
 \rSec3[gslice.array.fill]{\tcode{gslice_array} fill function}
 
-\indexlibrary{\idxcode{fill}!\idxcode{gslice_array}}%
+\indexlibrarymember{operator=}{gslice_array}%
 \begin{itemdecl}
 void operator=(const T&) const;
 \end{itemdecl}
@@ -8335,7 +8357,7 @@ is
 
 \rSec3[mask.array.assign]{\tcode{mask_array} assignment}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{mask_array}}%
+\indexlibrarymember{operator=}{mask_array}%
 \begin{itemdecl}
 void operator=(const valarray<T>&) const;
 const mask_array& operator=(const mask_array&) const;
@@ -8351,14 +8373,14 @@ object to which it refers.
 
 \rSec3[mask.array.comp.assign]{\tcode{mask_array} compound assignment}
 
-\indexlibrary{\idxcode{operator*=}!\idxcode{mask_array}}%
-\indexlibrary{\idxcode{operator/=}!\idxcode{mask_array}}%
-\indexlibrary{\idxcode{operator\%=}!\idxcode{mask_array}}%
-\indexlibrary{\idxcode{operator+=}!\idxcode{mask_array}}%
-\indexlibrary{\idxcode{operator-=}!\idxcode{mask_array}}%
-\indexlibrary{\idxcode{operator\^{}=}!\idxcode{mask_array}}%
-\indexlibrary{\idxcode{operator\&=}!\idxcode{mask_array}}%
-\indexlibrary{\idxcode{operator"|=}!\idxcode{mask_array}}%
+\indexlibrarymember{operator*=}{mask_array}%
+\indexlibrarymember{operator/=}{mask_array}%
+\indexlibrarymember{operator\%=}{mask_array}%
+\indexlibrarymember{operator+=}{mask_array}%
+\indexlibrarymember{operator-=}{mask_array}%
+\indexlibrarymember{operator\^{}=}{mask_array}%
+\indexlibrarymember{operator\&=}{mask_array}%
+\indexlibrarymember{operator"|=}{mask_array}%
 \indexlibrarymember{operator\shl=}{mask_array}%
 \indexlibrarymember{operator\shr=}{mask_array}%
 \begin{itemdecl}
@@ -8385,7 +8407,7 @@ object to which the mask object refers.
 
 \rSec3[mask.array.fill]{\tcode{mask_array} fill function}
 
-\indexlibrary{\idxcode{fill}!\idxcode{mask_array}}%
+\indexlibrarymember{operator=}{mask_array}%
 \begin{itemdecl}
 void operator=(const T&) const;
 \end{itemdecl}
@@ -8457,7 +8479,7 @@ whose indices appear in
 
 \rSec3[indirect.array.assign]{\tcode{indirect_array} assignment}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{indirect_array}}%
+\indexlibrarymember{operator=}{indirect_array}%
 \begin{itemdecl}
 void operator=(const valarray<T>&) const;
 const indirect_array& operator=(const indirect_array&) const;
@@ -8493,16 +8515,14 @@ indirection.
 
 \rSec3[indirect.array.comp.assign]{\tcode{indirect_array} compound assignment}
 
-\indexlibrary{\idxcode{operator*=}!\idxcode{indirect_array}}%
-\indexlibrary{\idxcode{operator*=}!\idxcode{indirect_array}}%
-\indexlibrary{\idxcode{operator*=}!\idxcode{indirect_array}}%
-\indexlibrary{\idxcode{operator/=}!\idxcode{indirect_array}}%
-\indexlibrary{\idxcode{operator\%=}!\idxcode{indirect_array}}%
-\indexlibrary{\idxcode{operator+=}!\idxcode{indirect_array}}%
-\indexlibrary{\idxcode{operator-=}!\idxcode{indirect_array}}%
-\indexlibrary{\idxcode{operator\^{}=}!\idxcode{indirect_array}}%
-\indexlibrary{\idxcode{operator\&=}!\idxcode{indirect_array}}%
-\indexlibrary{\idxcode{operator"|=}!\idxcode{indirect_array}}%
+\indexlibrarymember{operator*=}{indirect_array}%
+\indexlibrarymember{operator/=}{indirect_array}%
+\indexlibrarymember{operator\%=}{indirect_array}%
+\indexlibrarymember{operator+=}{indirect_array}%
+\indexlibrarymember{operator-=}{indirect_array}%
+\indexlibrarymember{operator\^{}=}{indirect_array}%
+\indexlibrarymember{operator\&=}{indirect_array}%
+\indexlibrarymember{operator"|=}{indirect_array}%
 \indexlibrarymember{operator\shl=}{indirect_array}%
 \indexlibrarymember{operator\shr=}{indirect_array}%
 \begin{itemdecl}
@@ -8539,7 +8559,7 @@ the behavior is undefined.
 
 \rSec3[indirect.array.fill]{\tcode{indirect_array} fill function}
 
-\indexlibrary{\idxcode{fill}!\idxcode{indirect_array}}%
+\indexlibrarymember{operator=}{indirect_array}%
 \begin{itemdecl}
 void operator=(const T&) const;
 \end{itemdecl}
@@ -8576,7 +8596,7 @@ are guaranteed to be valid until the member function
 array or until the lifetime of that array ends, whichever happens
 first.
 
-\indexlibrarymember{begin}{valarray}%
+\indexlibrary{\idxcode{begin}!\idxcode{valarray}}%
 \begin{itemdecl}
 template <class T> @\unspec{1}@ begin(valarray<T>& v);
 template <class T> @\unspec{2}@ begin(const valarray<T>& v);
@@ -8587,7 +8607,7 @@ template <class T> @\unspec{2}@ begin(const valarray<T>& v);
 \returns An iterator referencing the first value in the numeric array.
 \end{itemdescr}
 
-\indexlibrarymember{end}{valarray}%
+\indexlibrary{\idxcode{end}!\idxcode{valarray}}%
 \begin{itemdecl}
 template <class T> @\unspec{1}@ end(valarray<T>& v);
 template <class T> @\unspec{2}@ end(const valarray<T>& v);
@@ -8865,6 +8885,7 @@ return reduce(first, last, typename iterator_traits<InputIterator>::value_type{}
 \end{codeblock}
 \end{itemdescr}
 
+\indexlibrary{\idxcode{reduce}}%
 \begin{itemdecl}
 template<class InputIterator, class T>
   T reduce(InputIterator first, InputIterator last, T init);
@@ -8876,6 +8897,7 @@ template<class InputIterator, class T>
 Equivalent to: \tcode{return reduce(first, last, init, plus<>());}
 \end{itemdescr}
 
+\indexlibrary{\idxcode{reduce}}%
 \begin{itemdecl}
 template<class InputIterator, class T, class BinaryOperation>
   T reduce(InputIterator first, InputIterator last, T init,
@@ -8934,7 +8956,6 @@ modify elements in the range \range{first}{last}.
 \end{itemdescr}
 
 \rSec2[inner.product]{Inner product}
-\indexlibrary{\idxcode{inner_product}}%
 
 \indexlibrary{\idxcode{inner_product}}%
 \begin{itemdecl}
@@ -9055,6 +9076,7 @@ template<class InputIterator, class OutputIterator, class T>
 Equivalent to: \tcode{return exclusive_scan(first, last, result, init, plus<>());}
 \end{itemdescr}
 
+\indexlibrary{\idxcode{exclusive_scan}}%
 \begin{itemdecl}
 template<class InputIterator, class OutputIterator, class T, class BinaryOperation>
   OutputIterator exclusive_scan(InputIterator first, InputIterator last,
@@ -9110,6 +9132,7 @@ template<class InputIterator, class OutputIterator>
 Equivalent to: \tcode{return inclusive_scan(first, last, result, plus<>());}
 \end{itemdescr}
 
+\indexlibrary{\idxcode{inclusive_scan}}%
 \begin{itemdecl}
 template<class InputIterator, class OutputIterator, class BinaryOperation>
   OutputIterator inclusive_scan(InputIterator first, InputIterator last,


### PR DESCRIPTION
This review handles several topic related to the index of library names:

    consistently indexlibrarymember{identifier}{class-name} for all members and operators
    consistent ordering of indexlibrarymember{identifier}{class-name}
    consistent sub-indexing of special member functions for complex and valarray
    fix outright errors, indexing the wrong name
    index the user-defined literal operators
    ensure every class definition is introduced by an \indexlibrary{\idxcode{class-name}}%
    every index macro has a trailing % to avoid accidental whitespace