### PR TITLE
Review of library index entries

### DIFF
--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -486,7 +486,7 @@ Constructs an object of class
 
 \rSec2[underflow.error]{Class \tcode{underflow_error}}
 
-\indexlibrary{\idxcode{overflow_error}}%
+\indexlibrary{\idxcode{underflow_error}}%
 \begin{codeblock}
 namespace std {
   class underflow_error : public runtime_error {
@@ -769,6 +769,8 @@ Implementations should leave the error states provided by other
 libraries unchanged.
 
 \rSec2[system_error.syn]{Header \tcode{<system_error>} synopsis}
+\indextext{\idxhdr{system_error}}%
+\indexlibrary{\idxhdr{system_error}}%
 \indexlibrary{\idxcode{error_category}}%
 \indexlibrary{\idxcode{error_code}}%
 \indexlibrary{\idxcode{error_condition}}%
@@ -1044,8 +1046,7 @@ bool operator==(const error_category& rhs) const noexcept;
 \returns \tcode{this == \&rhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{error_category}}%
-\indexlibrary{\idxcode{error_category}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{error_category}%
 \begin{itemdecl}
 bool operator!=(const error_category& rhs) const noexcept;
 \end{itemdecl}
@@ -1387,7 +1388,7 @@ The class \tcode{error_condition} describes an object used to hold values identi
 error conditions. \begin{note} \tcode{error_condition} values are portable abstractions,
 while \tcode{error_code} values~(\ref{syserr.errcode}) are implementation specific. \end{note}
 
-\indexlibrary{\idxcode{error_code}}%
+\indexlibrary{\idxcode{error_condition}}%
 \begin{codeblock}
 namespace std {
   class error_condition {
@@ -1615,10 +1616,8 @@ bool operator==(const error_condition& lhs, const error_condition& rhs) noexcept
 \returns \tcode{lhs.category() == rhs.category() \&\& lhs.value() == rhs.value()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{error_code}}%
-\indexlibrary{\idxcode{error_code}!\idxcode{operator"!=}}%
-\indexlibrary{\idxcode{operator"!=}!\idxcode{error_condition}}%
-\indexlibrary{\idxcode{error_condition}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{error_code}%
+\indexlibrarymember{operator"!=}{error_condition}%
 \begin{itemdecl}
 bool operator!=(const error_code& lhs, const error_code& rhs) noexcept;
 bool operator!=(const error_code& lhs, const error_condition& rhs) noexcept;
@@ -1633,7 +1632,7 @@ bool operator!=(const error_condition& lhs, const error_condition& rhs) noexcept
 
 \rSec2[syserr.hash]{System error hash support}
 
-\indexlibrary{\idxcode{hash}}%
+\indexlibrary{\idxcode{hash}!\idxcode{error_code}}%
 \begin{itemdecl}
 template <> struct hash<error_code>;
 \end{itemdecl}
@@ -1672,7 +1671,7 @@ namespace std {
         const char* what_arg);
     system_error(int ev, const error_category& ecat);
     const error_code& code() const noexcept;
-    const char* what() const noexcept;
+    const char* what() const noexcept override;
   };
 }   // namespace std
 \end{codeblock}
@@ -1780,7 +1779,7 @@ as appropriate.
 
 \indexlibrarymember{what}{system_error}%
 \begin{itemdecl}
-const char* what() const noexcept;
+const char* what() const noexcept override;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1288,7 +1288,6 @@ if and only if the corresponding operations are defined on a value-initialized i
 \end{itemdescr}
 
 \indexlibrary{\idxcode{reverse_iterator}!constructor}%
-
 \begin{itemdecl}
 constexpr explicit reverse_iterator(Iterator x);
 \end{itemdecl}
@@ -1302,7 +1301,6 @@ with \tcode{x}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{reverse_iterator}!constructor}%
-
 \begin{itemdecl}
 template <class U> constexpr reverse_iterator(const reverse_iterator<U> &u);
 \end{itemdecl}
@@ -1318,7 +1316,7 @@ with
 
 \rSec4[reverse.iter.op=]{\tcode{reverse_iterator::operator=}}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator=}{reverse_iterator}%
 \begin{itemdecl}
 template <class U>
 constexpr reverse_iterator&
@@ -1350,7 +1348,7 @@ constexpr Iterator base() const;          // explicit
 
 \rSec4[reverse.iter.op.star]{\tcode{operator*}}
 
-\indexlibrary{\idxcode{operator*}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator*}{reverse_iterator}%
 \begin{itemdecl}
 constexpr reference operator*() const;
 \end{itemdecl}
@@ -1368,7 +1366,7 @@ return *--tmp;
 
 \rSec4[reverse.iter.opref]{\tcode{operator->}}
 
-\indexlibrary{\idxcode{operator->}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator->}{reverse_iterator}%
 \begin{itemdecl}
 constexpr pointer operator->() const;
 \end{itemdecl}
@@ -1380,7 +1378,7 @@ constexpr pointer operator->() const;
 
 \rSec4[reverse.iter.op++]{\tcode{operator++}}
 
-\indexlibrary{\idxcode{operator++}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator++}{reverse_iterator}%
 \begin{itemdecl}
 constexpr reverse_iterator& operator++();
 \end{itemdecl}
@@ -1413,7 +1411,7 @@ return tmp;
 
 \rSec4[reverse.iter.op\dcr]{\tcode{operator\dcr}}
 
-\indexlibrary{\idxcode{operator\dcr}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator\dcr}{reverse_iterator}%
 \begin{itemdecl}
 constexpr reverse_iterator& operator--();
 \end{itemdecl}
@@ -1446,7 +1444,7 @@ return tmp;
 
 \rSec4[reverse.iter.op+]{\tcode{operator+}}
 
-\indexlibrary{\idxcode{operator+}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator+}{reverse_iterator}%
 \begin{itemdecl}
 constexpr reverse_iterator
 operator+(typename reverse_iterator<Iterator>::difference_type n) const;
@@ -1460,7 +1458,7 @@ operator+(typename reverse_iterator<Iterator>::difference_type n) const;
 
 \rSec4[reverse.iter.op+=]{\tcode{operator+=}}
 
-\indexlibrary{\idxcode{operator+=}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator+=}{reverse_iterator}%
 \begin{itemdecl}
 constexpr reverse_iterator&
 operator+=(typename reverse_iterator<Iterator>::difference_type n);
@@ -1478,7 +1476,7 @@ As if by: \tcode{current -= n;}
 
 \rSec4[reverse.iter.op-]{\tcode{operator-}}
 
-\indexlibrary{\idxcode{operator-}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator-}{reverse_iterator}%
 \begin{itemdecl}
 constexpr reverse_iterator
 operator-(typename reverse_iterator<Iterator>::difference_type n) const;
@@ -1492,7 +1490,7 @@ operator-(typename reverse_iterator<Iterator>::difference_type n) const;
 
 \rSec4[reverse.iter.op-=]{\tcode{operator-=}}
 
-\indexlibrary{\idxcode{operator-=}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator-=}{reverse_iterator}%
 \begin{itemdecl}
 constexpr reverse_iterator&
 operator-=(typename reverse_iterator<Iterator>::difference_type n);
@@ -1510,7 +1508,7 @@ As if by: \tcode{current += n;}
 
 \rSec4[reverse.iter.opindex]{\tcode{operator[]}}
 
-\indexlibrary{\idxcode{operator[]}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator[]}{reverse_iterator}%
 \begin{itemdecl}
 constexpr @\unspec@ operator[](
     typename reverse_iterator<Iterator>::difference_type n) const;
@@ -1524,7 +1522,7 @@ constexpr @\unspec@ operator[](
 
 \rSec4[reverse.iter.op==]{\tcode{operator==}}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator==}{reverse_iterator}%
 \begin{itemdecl}
 template <class Iterator1, class Iterator2>
   constexpr bool operator==(
@@ -1540,7 +1538,7 @@ template <class Iterator1, class Iterator2>
 
 \rSec4[reverse.iter.op<]{\tcode{operator<}}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator<}{reverse_iterator}%
 \begin{itemdecl}
 template <class Iterator1, class Iterator2>
   constexpr bool operator<(
@@ -1556,7 +1554,7 @@ template <class Iterator1, class Iterator2>
 
 \rSec4[reverse.iter.op!=]{\tcode{operator!=}}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator"!=}{reverse_iterator}%
 \begin{itemdecl}
 template <class Iterator1, class Iterator2>
   constexpr bool operator!=(
@@ -1572,7 +1570,7 @@ template <class Iterator1, class Iterator2>
 
 \rSec4[reverse.iter.op>]{\tcode{operator>}}
 
-\indexlibrary{\idxcode{operator>}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator>}{reverse_iterator}%
 \begin{itemdecl}
 template <class Iterator1, class Iterator2>
   constexpr bool operator>(
@@ -1588,7 +1586,7 @@ template <class Iterator1, class Iterator2>
 
 \rSec4[reverse.iter.op>=]{\tcode{operator>=}}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator>=}{reverse_iterator}%
 \begin{itemdecl}
 template <class Iterator1, class Iterator2>
   constexpr bool operator>=(
@@ -1604,7 +1602,7 @@ template <class Iterator1, class Iterator2>
 
 \rSec4[reverse.iter.op<=]{\tcode{operator<=}}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator<=}{reverse_iterator}%
 \begin{itemdecl}
 template <class Iterator1, class Iterator2>
   constexpr bool operator<=(
@@ -1620,7 +1618,7 @@ template <class Iterator1, class Iterator2>
 
 \rSec4[reverse.iter.opdiff]{\tcode{operator-}}
 
-\indexlibrary{\idxcode{operator-}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator-}{reverse_iterator}%
 \begin{itemdecl}
 template <class Iterator1, class Iterator2>
     constexpr auto operator-(
@@ -1636,7 +1634,7 @@ template <class Iterator1, class Iterator2>
 
 \rSec4[reverse.iter.opsum]{\tcode{operator+}}
 
-\indexlibrary{\idxcode{operator+}!\idxcode{reverse_iterator}}%
+\indexlibrarymember{operator+}{reverse_iterator}%
 \begin{itemdecl}
 template <class Iterator>
   constexpr reverse_iterator<Iterator> operator+(
@@ -1652,7 +1650,7 @@ template <class Iterator>
 
 \rSec4[reverse.iter.make]{Non-member function \tcode{make_reverse_iterator()}}
 
-\indexlibrary{\idxcode{reverse_iterator}!\idxcode{make_reverse_iterator}~non-member~function}
+\indexlibrary{\idxcode{reverse_iterator}!\idxcode{make_reverse_iterator}~non-member~function}%
 \indexlibrary{\idxcode{make_reverse_iterator}}%
 \begin{itemdecl}
 template <class Iterator>
@@ -1765,7 +1763,7 @@ with \tcode{addressof(x)}.
 
 \rSec4[back.insert.iter.op=]{\tcode{back_insert_iterator::operator=}}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{back_insert_iterator}}%
+\indexlibrarymember{operator=}{back_insert_iterator}%
 \begin{itemdecl}
 back_insert_iterator& operator=(const typename Container::value_type& value);
 \end{itemdecl}
@@ -1780,7 +1778,7 @@ As if by: \tcode{container->push_back(value);}
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{back_insert_iterator}}%
+\indexlibrarymember{operator=}{back_insert_iterator}%
 \begin{itemdecl}
 back_insert_iterator& operator=(typename Container::value_type&& value);
 \end{itemdecl}
@@ -1797,7 +1795,7 @@ As if by: \tcode{container->push_back(std::move(value));}
 
 \rSec4[back.insert.iter.op*]{\tcode{back_insert_iterator::operator*}}
 
-\indexlibrary{\idxcode{operator*}!\idxcode{back_insert_iterator}}%
+\indexlibrarymember{operator*}{back_insert_iterator}%
 \begin{itemdecl}
 back_insert_iterator& operator*();
 \end{itemdecl}
@@ -1810,7 +1808,7 @@ back_insert_iterator& operator*();
 
 \rSec4[back.insert.iter.op++]{\tcode{back_insert_iterator::operator++}}
 
-\indexlibrary{\idxcode{operator++}!\idxcode{back_insert_iterator}}%
+\indexlibrarymember{operator++}{back_insert_iterator}%
 \begin{itemdecl}
 back_insert_iterator& operator++();
 back_insert_iterator  operator++(int);
@@ -1887,7 +1885,7 @@ with \tcode{addressof(x)}.
 
 \rSec4[front.insert.iter.op=]{\tcode{front_insert_iterator::operator=}}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{front_insert_iterator}}%
+\indexlibrarymember{operator=}{front_insert_iterator}%
 \begin{itemdecl}
 front_insert_iterator& operator=(const typename Container::value_type& value);
 \end{itemdecl}
@@ -1902,7 +1900,7 @@ As if by: \tcode{container->push_front(value);}
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{front_insert_iterator}}%
+\indexlibrarymember{operator=}{front_insert_iterator}%
 \begin{itemdecl}
 front_insert_iterator& operator=(typename Container::value_type&& value);
 \end{itemdecl}
@@ -1919,7 +1917,7 @@ As if by: \tcode{container->push_front(std::move(value));}
 
 \rSec4[front.insert.iter.op*]{\tcode{front_insert_iterator::operator*}}
 
-\indexlibrary{\idxcode{operator*}!\idxcode{front_insert_iterator}}%
+\indexlibrarymember{operator*}{front_insert_iterator}%
 \begin{itemdecl}
 front_insert_iterator& operator*();
 \end{itemdecl}
@@ -1932,7 +1930,7 @@ front_insert_iterator& operator*();
 
 \rSec4[front.insert.iter.op++]{\tcode{front_insert_iterator::operator++}}
 
-\indexlibrary{\idxcode{operator++}!\idxcode{front_insert_iterator}}%
+\indexlibrarymember{operator++}{front_insert_iterator}%
 \begin{itemdecl}
 front_insert_iterator& operator++();
 front_insert_iterator  operator++(int);
@@ -2012,7 +2010,7 @@ with \tcode{i}.
 
 \rSec4[insert.iter.op=]{\tcode{insert_iterator::operator=}}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{insert_iterator}}%
+\indexlibrarymember{operator=}{insert_iterator}%
 \begin{itemdecl}
 insert_iterator& operator=(const typename Container::value_type& value);
 \end{itemdecl}
@@ -2031,7 +2029,7 @@ iter = container->insert(iter, value);
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{insert_iterator}}%
+\indexlibrarymember{operator=}{insert_iterator}%
 \begin{itemdecl}
 insert_iterator& operator=(typename Container::value_type&& value);
 \end{itemdecl}
@@ -2052,7 +2050,7 @@ iter = container->insert(iter, std::move(value));
 
 \rSec4[insert.iter.op*]{\tcode{insert_iterator::operator*}}
 
-\indexlibrary{\idxcode{operator*}!\idxcode{insert_iterator}}%
+\indexlibrarymember{operator*}{insert_iterator}%
 \begin{itemdecl}
 insert_iterator& operator*();
 \end{itemdecl}
@@ -2065,7 +2063,7 @@ insert_iterator& operator*();
 
 \rSec4[insert.iter.op++]{\tcode{insert_iterator::operator++}}
 
-\indexlibrary{\idxcode{operator++}!\idxcode{insert_iterator}}%
+\indexlibrarymember{operator++}{insert_iterator}%
 \begin{itemdecl}
 insert_iterator& operator++();
 insert_iterator& operator++(int);
@@ -2441,8 +2439,7 @@ constexpr bool operator==(const move_iterator<Iterator1>& x, const move_iterator
 \returns \tcode{x.base() == y.base()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{move_iterator}}%
-\indexlibrary{\idxcode{move_iterator}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{move_iterator}%
 \begin{itemdecl}
 template <class Iterator1, class Iterator2>
 constexpr bool operator!=(const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
@@ -2775,18 +2772,15 @@ template <class T, class charT, class traits, class Distance>
 \pnum
 \returns
 \tcode{x.in_stream == y.in_stream}.%
-\indexlibrary{\idxcode{istream_iterator}!\idxcode{operator==}}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{istream_iterator}}%
-\indexlibrary{\idxcode{istream_iterator}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{istream_iterator}%
 \begin{itemdecl}
 template <class T, class charT, class traits, class Distance>
   bool operator!=(const istream_iterator<T,charT,traits,Distance> &x,
                   const istream_iterator<T,charT,traits,Distance> &y);
 \end{itemdecl}
 
-\indexlibrary{\idxcode{istream_iterator}!\idxcode{operator"!=}}%
 \begin{itemdescr}
 \pnum
 \returns
@@ -3115,7 +3109,7 @@ object's constructor argument \tcode{p}.
 
 \rSec3[istreambuf.iterator::op*]{\tcode{istreambuf_iterator::operator*}}
 
-\indexlibrary{\idxcode{operator*}!\idxcode{istreambuf_iterator}}%
+\indexlibrarymember{operator*}{istreambuf_iterator}%
 \begin{itemdecl}
 charT operator*() const
 \end{itemdecl}
@@ -3131,7 +3125,7 @@ member
 
 \rSec3[istreambuf.iterator::op++]{\tcode{istreambuf_iterator::operator++}}
 
-\indexlibrary{\idxcode{operator++}!\idxcode{istreambuf_iterator}}%
+\indexlibrarymember{operator++}{istreambuf_iterator}%
 \begin{itemdecl}
 istreambuf_iterator& operator++();
 \end{itemdecl}
@@ -3159,7 +3153,7 @@ proxy operator++(int);
 
 \rSec3[istreambuf.iterator::equal]{\tcode{istreambuf_iterator::equal}}
 
-\indexlibrary{\idxcode{equal}!\idxcode{istreambuf_iterator}}%
+\indexlibrarymember{equal}{istreambuf_iterator}%
 \begin{itemdecl}
 bool equal(const istreambuf_iterator& b) const;
 \end{itemdecl}
@@ -3176,7 +3170,7 @@ object they use.
 
 \rSec3[istreambuf.iterator::op==]{\tcode{operator==}}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{istreambuf_iterator}}%
+\indexlibrarymember{operator==}{istreambuf_iterator}%
 \begin{itemdecl}
 template <class charT, class traits>
   bool operator==(const istreambuf_iterator<charT,traits>& a,
@@ -3191,7 +3185,7 @@ template <class charT, class traits>
 
 \rSec3[istreambuf.iterator::op!=]{\tcode{operator!=}}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{istreambuf_iterator}}%
+\indexlibrarymember{operator"!=}{istreambuf_iterator}%
 \begin{itemdecl}
 template <class charT, class traits>
   bool operator!=(const istreambuf_iterator<charT,traits>& a,
@@ -3284,7 +3278,7 @@ Initializes \tcode{sbuf_} with \tcode{s}.
 
 \rSec3[ostreambuf.iter.ops]{\tcode{ostreambuf_iterator} operations}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{ostreambuf_iterator}}%
+\indexlibrarymember{operator=}{ostreambuf_iterator}%
 \begin{itemdecl}
 ostreambuf_iterator& operator=(charT c);
 \end{itemdecl}
@@ -3305,7 +3299,7 @@ otherwise has no effect.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator*}!\idxcode{ostreambuf_iterator}}%
+\indexlibrarymember{operator*}{ostreambuf_iterator}%
 \begin{itemdecl}
 ostreambuf_iterator& operator*();
 \end{itemdecl}
@@ -3316,7 +3310,7 @@ ostreambuf_iterator& operator*();
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator++}!\idxcode{ostreambuf_iterator}}%
+\indexlibrarymember{operator++}{ostreambuf_iterator}%
 \begin{itemdecl}
 ostreambuf_iterator& operator++();
 ostreambuf_iterator& operator++(int);
@@ -3328,7 +3322,7 @@ ostreambuf_iterator& operator++(int);
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{failed}!\idxcode{ostreambuf_iterator}}%
+\indexlibrarymember{failed}{ostreambuf_iterator}%
 \begin{itemdecl}
 bool failed() const noexcept;
 \end{itemdecl}
@@ -3426,7 +3420,7 @@ template <class C> constexpr auto rbegin(const C& c) -> decltype(c.rbegin());
 \pnum \returns \tcode{c.rbegin()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{rend(const C\&)}}%
+\indexlibrary{\idxcode{rend(C\&)}}%
 \begin{itemdecl}
 template <class C> constexpr auto rend(C& c) -> decltype(c.rend());
 template <class C> constexpr auto rend(const C& c) -> decltype(c.rend());
@@ -3493,6 +3487,7 @@ when any of the following headers are included:
 \tcode{<map>}, \tcode{<regex>}, \tcode{<set>}, \tcode{<string>},
 \tcode{<unordered_map>}, \tcode{<unordered_set>}, and \tcode{<vector>}.
 
+\indexlibrary{\idxcode{size(C\& c)}}%
 \begin{itemdecl}
 template <class C> constexpr auto size(const C& c) -> decltype(c.size());
 \end{itemdecl}
@@ -3500,6 +3495,7 @@ template <class C> constexpr auto size(const C& c) -> decltype(c.size());
 \pnum \returns \tcode{c.size()}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{size(T (\&array)[N])}}%
 \begin{itemdecl}
 template <class T, size_t N> constexpr size_t size(const T (&array)[N]) noexcept;
 \end{itemdecl}
@@ -3507,6 +3503,7 @@ template <class T, size_t N> constexpr size_t size(const T (&array)[N]) noexcept
 \pnum \returns \tcode{N}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{empty(C\& c)}}%
 \begin{itemdecl}
 template <class C> constexpr auto empty(const C& c) -> decltype(c.empty());
 \end{itemdecl}
@@ -3514,6 +3511,7 @@ template <class C> constexpr auto empty(const C& c) -> decltype(c.empty());
 \pnum \returns \tcode{c.empty()}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{empty(T (\&array)[N])}}%
 \begin{itemdecl}
 template <class T, size_t N> constexpr bool empty(const T (&array)[N]) noexcept;
 \end{itemdecl}
@@ -3521,6 +3519,7 @@ template <class T, size_t N> constexpr bool empty(const T (&array)[N]) noexcept;
 \pnum \returns \tcode{false}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{empty(initializer_list<E>)}}%
 \begin{itemdecl}
 template <class E> constexpr bool empty(initializer_list<E> il) noexcept;
 \end{itemdecl}
@@ -3528,6 +3527,7 @@ template <class E> constexpr bool empty(initializer_list<E> il) noexcept;
 \pnum \returns \tcode{il.size() == 0}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{data(C\& c)}}%
 \begin{itemdecl}
 template <class C> constexpr auto data(C& c) -> decltype(c.data());
 template <class C> constexpr auto data(const C& c) -> decltype(c.data());
@@ -3536,6 +3536,7 @@ template <class C> constexpr auto data(const C& c) -> decltype(c.data());
 \pnum \returns \tcode{c.data()}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{data(T (\&array)[N])}}%
 \begin{itemdecl}
 template <class T, size_t N> constexpr T* data(T (&array)[N]) noexcept;
 \end{itemdecl}
@@ -3543,6 +3544,7 @@ template <class T, size_t N> constexpr T* data(T (&array)[N]) noexcept;
 \pnum \returns \tcode{array}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{data(initializer_list<E>)}}%
 \begin{itemdecl}
 template <class E> constexpr const E* data(initializer_list<E> il) noexcept;
 \end{itemdecl}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -572,7 +572,7 @@ void imag(T val);
 
 \rSec2[complex.member.ops]{\tcode{complex} member operators}
 
-\indexlibrary{\idxcode{operator+=}!\idxcode{complex}}%
+\indexlibrarymember{operator+=}{complex}%
 \begin{itemdecl}
 complex<T>& operator+=(const T& rhs);
 \end{itemdecl}
@@ -591,7 +591,7 @@ leaving the imaginary part unchanged.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator-=}!\idxcode{complex}}%
+\indexlibrarymember{operator-=}{complex}%
 \begin{itemdecl}
 complex<T>& operator-=(const T& rhs);
 \end{itemdecl}
@@ -610,7 +610,7 @@ leaving the imaginary part unchanged.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator*=}!\idxcode{complex}}%
+\indexlibrarymember{operator*=}{complex}%
 \begin{itemdecl}
 complex<T>& operator*=(const T& rhs);
 \end{itemdecl}
@@ -628,7 +628,7 @@ and stores the result in
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator/=}!\idxcode{complex}}%
+\indexlibrarymember{operator/=}{complex}%
 \begin{itemdecl}
 complex<T>& operator/=(const T& rhs);
 \end{itemdecl}
@@ -646,7 +646,7 @@ and stores the result in
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator+=}!\idxcode{complex}}%
+\indexlibrarymember{operator+=}{complex}%
 \begin{itemdecl}
 template<class X> complex<T>& operator+=(const complex<X>& rhs);
 \end{itemdecl}
@@ -664,7 +664,7 @@ and stores the sum in
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator-=}!\idxcode{complex}}%
+\indexlibrarymember{operator-=}{complex}%
 \begin{itemdecl}
 template<class X> complex<T>& operator-=(const complex<X>& rhs);
 \end{itemdecl}
@@ -682,7 +682,7 @@ and stores the difference in
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator*=}!\idxcode{complex}}%
+\indexlibrarymember{operator*=}{complex}%
 \begin{itemdecl}
 template<class X> complex<T>& operator*=(const complex<X>& rhs);
 \end{itemdecl}
@@ -699,7 +699,7 @@ and stores the product in
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator/=}!\idxcode{complex}}%
+\indexlibrarymember{operator/=}{complex}%
 \begin{itemdecl}
 template<class X> complex<T>& operator/=(const complex<X>& rhs);
 \end{itemdecl}
@@ -719,7 +719,7 @@ and stores the quotient in
 
 \rSec2[complex.ops]{\tcode{complex} non-member operations}
 
-\indexlibrary{\idxcode{operator+}!\idxcode{complex}}%
+\indexlibrarymember{operator+}{complex}%
 \begin{itemdecl}
 template<class T> complex<T> operator+(const complex<T>& lhs);
 \end{itemdecl}
@@ -747,7 +747,7 @@ template<class T> complex<T> operator+(const T& lhs, const complex<T>& rhs);
 \tcode{complex<T>(lhs) += rhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator-}!\idxcode{complex}}%
+\indexlibrarymember{operator-}{complex}%
 \begin{itemdecl}
 template<class T> complex<T> operator-(const complex<T>& lhs);
 \end{itemdecl}
@@ -776,7 +776,7 @@ template<class T> complex<T> operator-(const T& lhs, const complex<T>& rhs);
 \tcode{complex<T>(lhs) -= rhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator*}!\idxcode{complex}}%
+\indexlibrarymember{operator*}{complex}%
 \begin{itemdecl}
 template<class T>
   complex<T> operator*(const complex<T>& lhs, const complex<T>& rhs);
@@ -804,7 +804,7 @@ template<class T> complex<T> operator/(const T& lhs, const complex<T>& rhs);
 \tcode{complex<T>(lhs) /= rhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{complex}}%
+\indexlibrarymember{operator==}{complex}%
 \begin{itemdecl}
 template<class T>
   constexpr bool operator==(const complex<T>& lhs, const complex<T>& rhs);
@@ -826,7 +826,7 @@ or 0.0, for the
 arguments.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{complex}}%
+\indexlibrarymember{operator"!=}{complex}%
 \begin{itemdecl}
 template<class T>
   constexpr bool operator!=(const complex<T>& lhs, const complex<T>& rhs);
@@ -1323,6 +1323,7 @@ the types \tcode{complex<double>}, \tcode{complex<long double>}, and
 \tcode{complex<float>} respectively, with their imaginary part denoted by the
 given literal number and the real part being zero.
 
+\indexlibrarymember{operator """" il}{complex}%
 \begin{itemdecl}
 constexpr complex<long double> operator""il(long double d);
 constexpr complex<long double> operator""il(unsigned long long d);
@@ -1334,6 +1335,7 @@ constexpr complex<long double> operator""il(unsigned long long d);
 \tcode{complex<long double>\{0.0L, static_cast<long double>(d)\}}.
 \end{itemdescr}
 
+\indexlibrarymember{operator """" i}{complex}%
 \begin{itemdecl}
 constexpr complex<double> operator""i(long double d);
 constexpr complex<double> operator""i(unsigned long long d);
@@ -1345,6 +1347,7 @@ constexpr complex<double> operator""i(unsigned long long d);
 \tcode{complex<double>\{0.0, static_cast<double>(d)\}}.
 \end{itemdescr}
 
+\indexlibrarymember{operator """" if}{complex}%
 \begin{itemdecl}
 constexpr complex<float> operator""if(long double d);
 constexpr complex<float> operator""if(unsigned long long d);
@@ -2763,6 +2766,7 @@ the generation algorithm%
 \indextext{generation algorithm!\idxcode{linear_congruential_engine}}
 is $ \mathsf{GA}(\state{x}{i}) = \state{x}{i+1} $.
 
+\indexlibrary{\idxcode{linear_congruential_engine}}%
 \begin{codeblock}
 template<class UIntType, UIntType a, UIntType c, UIntType m>
  class linear_congruential_engine
@@ -2817,7 +2821,6 @@ consists of
 the value of \state{x}{i}.
 
 \indexlibrary{\idxcode{linear_congruential_engine}!constructor}%
-
 \begin{itemdecl}
 explicit linear_congruential_engine(result_type s = default_seed);
 \end{itemdecl}
@@ -2830,7 +2833,6 @@ explicit linear_congruential_engine(result_type s = default_seed);
 \end{itemdescr}
 
 \indexlibrary{\idxcode{linear_congruential_engine}!constructor}%
-
 \begin{itemdecl}
 template<class Sseq> explicit linear_congruential_engine(Sseq& q);
 \end{itemdecl}
@@ -2927,6 +2929,7 @@ The generation algorithm%
    Let $z_4 = z_3 \xor ( z_3 \rightshift \ell )$.
 \end{enumeratea}
 
+\indexlibrary{\idxcode{mersenne_twister_engine}}%
 \begin{codeblock}
 template<class UIntType, size_t w, size_t n, size_t m, size_t r,
           UIntType a, size_t u, UIntType d, size_t s,
@@ -2996,7 +2999,6 @@ the values of
 in that order.
 
 \indexlibrary{\idxcode{mersenne_twister_engine}!constructor}%
-
 \begin{itemdecl}
 explicit mersenne_twister_engine(result_type value = default_seed);
 \end{itemdecl}
@@ -3020,7 +3022,6 @@ Sets $X_{-n}$ to $\tcode{value} \bmod 2^w$.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{mersenne_twister_engine}!constructor}%
-
 \begin{itemdecl}
 template<class Sseq> explicit mersenne_twister_engine(Sseq& q);
 \end{itemdecl}
@@ -3108,6 +3109,7 @@ as a result
 of advancing the engine's state
 as described above.
 
+\indexlibrary{\idxcode{subtract_with_carry_engine}}%
 \begin{codeblock}
 template<class UIntType, size_t w, size_t s, size_t r>
  class subtract_with_carry_engine
@@ -3307,6 +3309,7 @@ The generation algorithm%
 yields the value returned by the last invocation of \tcode{e()}
  while advancing \tcode{e}'s state as described above.
 
+\indexlibrary{\idxcode{discard_block_engine}}%
 \begin{codeblock}
 template<class Engine, size_t p, size_t r>
  class discard_block_engine
@@ -3461,6 +3464,7 @@ for (@$k$@ = @$n_0$@; @$k \neq n$@; @$k$@ += @$1$@)  {
 }
 \end{codeblock}
 
+\indexlibrary{\idxcode{independent_bits_engine}}%
 \begin{codeblock}
 template<class Engine, size_t w, class UIntType>
 class independent_bits_engine
@@ -3560,6 +3564,7 @@ The generation algorithm%
 yields the last value of \tcode{Y}
  produced while advancing \tcode{e}'s state as described above.
 
+\indexlibrary{\idxcode{shuffle_order_engine}}%
 \begin{codeblock}
 template<class Engine, size_t k>
  class shuffle_order_engine
@@ -3821,7 +3826,7 @@ is implementation-defined.
 
 
 \rSec2[rand.device]{Class \tcode{random_device}}%
-\indexlibrary{\idxcode{random_device}}
+\indexlibrary{\idxcode{random_device}}%
 
 \pnum
 A \tcode{random_device}
@@ -3834,6 +3839,7 @@ If implementation limitations%
 prevent generating non-deterministic random numbers,
 the implementation may employ a random number engine.
 
+\indexlibrary{\idxcode{random_device}}%
 \begin{codeblock}
 class random_device
 {
@@ -3882,7 +3888,7 @@ explicit random_device(const string& token = @\textit{implementation-defined}@);
  if the \tcode{random_device} could not be initialized.
 \end{itemdescr}
 
-\indexlibrarymember{random_device}{entropy}%
+\indexlibrarymember{entropy}{random_device}%
 \begin{itemdecl}
 double entropy() const noexcept;
 \end{itemdecl}
@@ -3902,7 +3908,7 @@ double entropy() const noexcept;
    $\log_2( \tcode{max()}+1)$.
 \end{itemdescr}
 
-\indexlibrarymember{random_device}{operator()}%
+\indexlibrarymember{operator()}{random_device}%
 \begin{itemdecl}
 result_type operator()();
 \end{itemdecl}
@@ -3938,6 +3944,7 @@ result_type operator()();
 
 \rSec3[rand.util.seedseq]{Class \tcode{seed_seq}}%
 
+\indexlibrary{\idxcode{seed_seq}}%
 \begin{codeblock}
 class seed_seq
 {
@@ -4021,7 +4028,7 @@ for( InputIterator s = begin; s != end; ++s)
 \end{codeblock}%
 \end{itemdescr}
 
-\indexlibrarymember{seed_seq}{generate}%
+\indexlibrarymember{generate}{seed_seq}%
 \begin{itemdecl}
 template<class RandomAccessIterator>
   void generate(RandomAccessIterator begin, RandomAccessIterator end);
@@ -4114,7 +4121,7 @@ What and when \tcode{RandomAccessIterator} operations of \tcode{begin}
 and \tcode{end} throw.
 \end{itemdescr}
 
-\indexlibrarymember{seed_seq}{size}%
+\indexlibrarymember{size}{seed_seq}%
 \begin{itemdecl}
 size_t size() const noexcept;
 \end{itemdecl}
@@ -4127,7 +4134,7 @@ size_t size() const noexcept;
 \pnum\complexity Constant time.
 \end{itemdescr}
 
-\indexlibrarymember{seed_seq}{param}%
+\indexlibrarymember{param}{seed_seq}%
 \begin{itemdecl}
 template<class OutputIterator>
   void param(OutputIterator dest) const;
@@ -4285,7 +4292,7 @@ everywhere outside its stated domain.
 
 \rSec4[rand.dist.uni.int]{Class template \tcode{uniform_int_distribution}}%
 \indexlibrary{\idxcode{uniform_int_distribution}}%
-\indextext{random number distribution!\idxcode{uniform_int_distribution}}
+\indextext{random number distribution!\idxcode{uniform_int_distribution}}%
 
 \pnum
 A \tcode{uniform_int_distribution} random number distribution
@@ -4294,12 +4301,13 @@ $ a \leq i \leq b $,
 distributed according to
 the constant discrete probability function%
 \indextext{discrete probability function!\idxcode{uniform_int_distribution}}%
-\indextext{\idxcode{uniform_int_distribution}!discrete probability function}
+\indextext{\idxcode{uniform_int_distribution}!discrete probability function}%
 \[%
  P(i\,|\,a,b) = 1 / (b - a + 1)
 \; \mbox{.}
 \]
 
+\indexlibrary{\idxcode{uniform_int_distribution}}%
 \begin{codeblock}
 template<class IntType = int>
  class uniform_int_distribution
@@ -4345,7 +4353,7 @@ explicit uniform_int_distribution(IntType a = 0, IntType b = numeric_limits<IntT
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{uniform_int_distribution}{a}%
+\indexlibrarymember{a}{uniform_int_distribution}%
 \begin{itemdecl}
 result_type a() const;
 \end{itemdecl}
@@ -4355,7 +4363,7 @@ result_type a() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrarymember{uniform_int_distribution}{b}%
+\indexlibrarymember{b}{uniform_int_distribution}%
 \begin{itemdecl}
 result_type b() const;
 \end{itemdecl}
@@ -4370,7 +4378,7 @@ result_type b() const;
 
 \rSec4[rand.dist.uni.real]{Class template \tcode{uniform_real_distribution}}%
 \indexlibrary{\idxcode{uniform_real_distribution}}%
-\indextext{random number distribution!\idxcode{uniform_real_distribution}}
+\indextext{random number distribution!\idxcode{uniform_real_distribution}}%
 
 \pnum
 A \tcode{uniform_real_distribution} random number distribution
@@ -4379,7 +4387,7 @@ $ a \leq x < b $,
 distributed according to
 the constant probability density function%
 \indextext{probability density function!\idxcode{uniform_real_distribution}}%
-\indextext{\idxcode{uniform_real_distribution}!probability density function}
+\indextext{\idxcode{uniform_real_distribution}!probability density function}%
 \[%
  p(x\,|\,a,b) = 1 / (b - a)
 \; \mbox{.}
@@ -4388,6 +4396,7 @@ the constant probability density function%
 This implies that $p(x\,|\,a,b)$ is undefined when \tcode{a == b}.
 \end{note}
 
+\indexlibrary{\idxcode{uniform_real_distribution}}%
 \begin{codeblock}
 template<class RealType = double>
  class uniform_real_distribution
@@ -4435,7 +4444,7 @@ explicit uniform_real_distribution(RealType a = 0.0, RealType b = 1.0);
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{uniform_real_distribution}{a}%
+\indexlibrarymember{a}{uniform_real_distribution}%
 \begin{itemdecl}
 result_type a() const;
 \end{itemdecl}
@@ -4445,7 +4454,7 @@ result_type a() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrarymember{uniform_real_distribution}{b}%
+\indexlibrarymember{b}{uniform_real_distribution}%
 \begin{itemdecl}
 result_type b() const;
 \end{itemdecl}
@@ -4466,14 +4475,14 @@ result_type b() const;
 
 \rSec3[rand.dist.bern]{Bernoulli distributions}%
 \indextext{Bernoulli distributions|(}%
-\indextext{random number distributions!Bernoulli|(}
+\indextext{random number distributions!Bernoulli|(}%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % bernoulli_distribution
 
 \rSec4[rand.dist.bern.bernoulli]{Class \tcode{bernoulli_distribution}}%
 \indexlibrary{\idxcode{bernoulli_distribution}}%
-\indextext{random number distribution!\idxcode{bernoulli_distribution}}
+\indextext{random number distribution!\idxcode{bernoulli_distribution}}%
 
 \pnum
 A \tcode{bernoulli_distribution} random number distribution
@@ -4481,7 +4490,7 @@ produces \tcode{bool} values $b$
 distributed according to
 the discrete probability function
 \indextext{discrete probability function!\idxcode{bernoulli_distribution}}%
-\indextext{\idxcode{bernoulli_distribution}!discrete probability function}
+\indextext{\idxcode{bernoulli_distribution}!discrete probability function}%
 \[%
  P(b\,|\,p)
       = \left\{ \begin{array}{lcl}
@@ -4491,6 +4500,7 @@ the discrete probability function
 \; \mbox{.}
 \]
 
+\indexlibrary{\idxcode{bernoulli_distribution}}%
 \begin{codeblock}
 class bernoulli_distribution
 {
@@ -4534,7 +4544,7 @@ explicit bernoulli_distribution(double p = 0.5);
  corresponds to the parameter of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{bernoulli_distribution}{p}%
+\indexlibrarymember{p}{bernoulli_distribution}%
 \begin{itemdecl}
 double p() const;
 \end{itemdecl}
@@ -4549,7 +4559,7 @@ double p() const;
 
 \rSec4[rand.dist.bern.bin]{Class template \tcode{binomial_distribution}}%
 \indexlibrary{\idxcode{binomial_distribution}}%
-\indextext{random number distribution!\idxcode{binomial_distribution}}
+\indextext{random number distribution!\idxcode{binomial_distribution}}%
 
 \pnum
 A \tcode{binomial_distribution} random number distribution
@@ -4557,13 +4567,14 @@ produces integer values $i \geq 0$
 distributed according to
 the discrete probability function%
 \indextext{discrete probability function!\idxcode{binomial_distribution}}%
-\indextext{\idxcode{binomial_distribution}!discrete probability function}
+\indextext{\idxcode{binomial_distribution}!discrete probability function}%
 \[%
  P(i\,|\,t,p)
       = \binom{t}{i} \cdot p^i \cdot (1-p)^{t-i}
 \; \mbox{.}
 \]
 
+\indexlibrary{\idxcode{binomial_distribution}}%
 \begin{codeblock}
 template<class IntType = int>
  class binomial_distribution
@@ -4609,7 +4620,7 @@ explicit binomial_distribution(IntType t = 1, double p = 0.5);
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{binomial_distribution}{t}%
+\indexlibrarymember{t}{binomial_distribution}%
 \begin{itemdecl}
 IntType t() const;
 \end{itemdecl}%
@@ -4618,7 +4629,7 @@ IntType t() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrarymember{binomial_distribution}{p}%
+\indexlibrarymember{p}{binomial_distribution}%
 \begin{itemdecl}
 double p() const;
 \end{itemdecl}
@@ -4632,8 +4643,8 @@ double p() const;
 % geometric_distribution
 
 \rSec4[rand.dist.bern.geo]{Class template \tcode{geometric_distribution}}
-\indexlibrary{\idxcode{geometric_distribution}}
-\indextext{random number distribution!\idxcode{geometric_distribution}}
+\indexlibrary{\idxcode{geometric_distribution}}%
+\indextext{random number distribution!\idxcode{geometric_distribution}}%
 
 \pnum
 A \tcode{geometric_distribution} random number distribution
@@ -4641,13 +4652,14 @@ produces integer values $i \geq 0$
 distributed according to
 the discrete probability function
 \indextext{discrete probability function!\idxcode{geometric_distribution}}%
-\indextext{\idxcode{geometric_distribution}!discrete probability function}
+\indextext{\idxcode{geometric_distribution}!discrete probability function}%
 \[%
  P(i\,|\,p)
       = p \cdot (1-p)^{i}
 \; \mbox{.}
 \]
 
+\indexlibrary{\idxcode{geometric_distribution}}%
 \begin{codeblock}
 template<class IntType = int>
  class geometric_distribution
@@ -4692,7 +4704,7 @@ explicit geometric_distribution(double p = 0.5);
  corresponds to the parameter of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{geometric_distribution}{p}%
+\indexlibrarymember{p}{geometric_distribution}%
 \begin{itemdecl}
 double p() const;
 \end{itemdecl}
@@ -4707,8 +4719,8 @@ double p() const;
 % ----------------------------------------------------------------------
 
 \rSec4[rand.dist.bern.negbin]{Class template \tcode{negative_binomial_distribution}}
-\indexlibrary{\idxcode{negative_binomial_distribution}}
-\indextext{random number distribution!\idxcode{negative_binomial_distribution}}
+\indexlibrary{\idxcode{negative_binomial_distribution}}%
+\indextext{random number distribution!\idxcode{negative_binomial_distribution}}%
 
 \pnum
 A \tcode{negative_binomial_distribution} random number distribution
@@ -4716,7 +4728,7 @@ produces random integers $i \geq 0$
 distributed according to
 the discrete probability function
 \indextext{discrete probability function!\idxcode{negative_binomial_distribution}}%
-\indextext{\idxcode{negative_binomial_distribution}!discrete probability function}
+\indextext{\idxcode{negative_binomial_distribution}!discrete probability function}%
 \[%
  P(i\,|\,k,p)
       = \binom{k+i-1}{i} \cdot p^k \cdot (1-p)^i
@@ -4726,6 +4738,7 @@ the discrete probability function
 This implies that $P(i\,|\,k,p)$ is undefined when \tcode{p == 1}.
 \end{note}
 
+\indexlibrary{\idxcode{negative_binomial_distribution}}%
 \begin{codeblock}
 template<class IntType = int>
  class negative_binomial_distribution
@@ -4772,7 +4785,7 @@ explicit negative_binomial_distribution(IntType k = 1, double p = 0.5);
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{negative_binomial_distribution}{t}%
+\indexlibrarymember{t}{negative_binomial_distribution}%
 \begin{itemdecl}
 IntType k() const;
 \end{itemdecl}
@@ -4782,7 +4795,7 @@ IntType k() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrarymember{negative_binomial_distribution}{p}%
+\indexlibrarymember{p}{negative_binomial_distribution}%
 \begin{itemdecl}
 double p() const;
 \end{itemdecl}
@@ -4792,7 +4805,7 @@ double p() const;
  with which the object was constructed.
 \end{itemdescr}%
 \indextext{random number distributions!Bernoulli|)}%
-\indextext{Bernoulli distributions|)}
+\indextext{Bernoulli distributions|)}%
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -4803,14 +4816,14 @@ double p() const;
 
 \rSec3[rand.dist.pois]{Poisson distributions}%
 \indextext{Poisson distributions|(}%
-\indextext{random number distributions!Poisson|(}
+\indextext{random number distributions!Poisson|(}%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % poisson_distribution
 
 \rSec4[rand.dist.pois.poisson]{Class template \tcode{poisson_distribution}}%
 \indexlibrary{\idxcode{poisson_distribution}}%
-\indextext{random number distribution!\idxcode{poisson_distribution}}
+\indextext{random number distribution!\idxcode{poisson_distribution}}%
 
 \pnum
 A \tcode{poisson_distribution} random number distribution
@@ -4818,7 +4831,7 @@ produces integer values $ i \geq 0 $
 distributed according to
 the discrete probability function
 \indextext{discrete probability function!\idxcode{poisson_distribution}}%
-\indextext{\idxcode{poisson_distribution}!discrete probability function}
+\indextext{\idxcode{poisson_distribution}!discrete probability function}%
 \[%
  P(i\,|\,\mu)
       = \frac{ e^{-\mu} \mu^{i} }
@@ -4831,6 +4844,7 @@ is also known as this distribution's \techterm{mean}%
 \indextext{\idxcode{poisson_distribution}!mean}%
 .
 
+\indexlibrary{\idxcode{poisson_distribution}}%
 \begin{codeblock}
 template<class IntType = int>
  class poisson_distribution
@@ -4860,8 +4874,6 @@ public:
 };
 \end{codeblock}
 
-
-
 \indexlibrary{\idxcode{poisson_distribution}!constructor}%
 \begin{itemdecl}
 explicit poisson_distribution(double mean = 1.0);
@@ -4876,7 +4888,7 @@ explicit poisson_distribution(double mean = 1.0);
  corresponds to the parameter of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{poisson_distribution}{mean}%
+\indexlibrarymember{mean}{poisson_distribution}%
 \begin{itemdecl}
 double mean() const;
 \end{itemdecl}
@@ -4891,7 +4903,7 @@ double mean() const;
 
 \rSec4[rand.dist.pois.exp]{Class template \tcode{exponential_distribution}}%
 \indexlibrary{\idxcode{exponential_distribution}}%
-\indextext{random number distribution!\idxcode{exponential_distribution}}
+\indextext{random number distribution!\idxcode{exponential_distribution}}%
 
 \pnum
 An \tcode{exponential_distribution} random number distribution
@@ -4899,13 +4911,14 @@ produces random numbers $x > 0$
 distributed according to
 the probability density function%
 \indextext{probability density function!\idxcode{exponential_distribution}}%
-\indextext{\idxcode{exponential_distribution}!probability density function}
+\indextext{\idxcode{exponential_distribution}!probability density function}%
 \[%
  p(x\,|\,\lambda)
       = \lambda e^{-\lambda x}
 \; \mbox{.}
 \]
 
+\indexlibrary{\idxcode{exponential_distribution}}%
 \begin{codeblock}
 template<class RealType = double>
  class exponential_distribution
@@ -4950,7 +4963,7 @@ explicit exponential_distribution(RealType lambda = 1.0);
  corresponds to the parameter of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{exponential_distribution}{lambda}%
+\indexlibrarymember{lambda}{exponential_distribution}%
 \begin{itemdecl}
 RealType lambda() const;
 \end{itemdecl}
@@ -4965,7 +4978,7 @@ RealType lambda() const;
 
 \rSec4[rand.dist.pois.gamma]{Class template \tcode{gamma_distribution}}%
 \indexlibrary{\idxcode{gamma_distribution}}%
-\indextext{random number distribution!\idxcode{gamma_distribution}}
+\indextext{random number distribution!\idxcode{gamma_distribution}}%
 
 \pnum
 A \tcode{gamma_distribution} random number distribution
@@ -4973,7 +4986,7 @@ produces random numbers $x > 0$
 distributed according to
 the probability density function%
 \indextext{probability density function!\idxcode{gamma_distribution}}%
-\indextext{\idxcode{gamma_distribution}!probability density function}
+\indextext{\idxcode{gamma_distribution}!probability density function}%
 \[%
  p(x\,|\,\alpha,\beta)
       = \frac{e^{-x/\beta}}{\beta^{\alpha} \cdot \Gamma(\alpha)}
@@ -4981,6 +4994,7 @@ the probability density function%
 \; \mbox{.}
 \]
 
+\indexlibrary{\idxcode{gamma_distribution}}%
 \begin{codeblock}
 template<class RealType = double>
  class gamma_distribution
@@ -5027,7 +5041,7 @@ explicit gamma_distribution(RealType alpha = 1.0, RealType beta = 1.0);
  correspond to the parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{gamma_distribution}{alpha}%
+\indexlibrarymember{alpha}{gamma_distribution}%
 \begin{itemdecl}
 RealType alpha() const;
 \end{itemdecl}
@@ -5037,7 +5051,7 @@ RealType alpha() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrarymember{gamma_distribution}{beta}%
+\indexlibrarymember{beta}{gamma_distribution}%
 \begin{itemdecl}
 RealType beta() const;
 \end{itemdecl}
@@ -5052,7 +5066,8 @@ RealType beta() const;
 % ----------------------------------------------------------------------
 
 \rSec4[rand.dist.pois.weibull]{Class template \tcode{weibull_distribution}}%
-\indexlibrary{\idxcode{weibull_distribution}}
+\indexlibrary{\idxcode{weibull_distribution}}%
+\indextext{random number distribution!\idxcode{weibull_distribution}}%
 
 \pnum
 A \tcode{weibull_distribution} random number distribution
@@ -5060,7 +5075,7 @@ produces random numbers $x \geq 0$
 distributed according to
 the probability density function%
 \indextext{probability density function!\idxcode{weibull_distribution}}%
-\indextext{\idxcode{weibull_distribution}!probability density function}
+\indextext{\idxcode{weibull_distribution}!probability density function}%
 \[%
  p(x\,|\,a,b)
       =       \frac{a}{b}
@@ -5069,6 +5084,7 @@ the probability density function%
 \; \mbox{.}
 \]
 
+\indexlibrary{\idxcode{weibull_distribution}}%
 \begin{codeblock}
 template<class RealType = double>
  class weibull_distribution
@@ -5113,7 +5129,7 @@ explicit weibull_distribution(RealType a = 1.0, RealType b = 1.0);
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{weibull_distribution}{a}%
+\indexlibrarymember{a}{weibull_distribution}%
 \begin{itemdecl}
 RealType a() const;
 \end{itemdecl}
@@ -5123,7 +5139,7 @@ RealType a() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrarymember{weibull_distribution}{b}%
+\indexlibrarymember{b}{weibull_distribution}%
 \begin{itemdecl}
 RealType b() const;
 \end{itemdecl}
@@ -5138,8 +5154,8 @@ RealType b() const;
 % ----------------------------------------------------------------------
 
 \rSec4[rand.dist.pois.extreme]{Class template \tcode{extreme_value_distribution}}
-\indexlibrary{\idxcode{extreme_value_distribution}}
-\indextext{random number distribution!\idxcode{extreme_value_distribution}}
+\indexlibrary{\idxcode{extreme_value_distribution}}%
+\indextext{random number distribution!\idxcode{extreme_value_distribution}}%
 
 \pnum
 An \tcode{extreme_value_distribution} random number distribution
@@ -5164,6 +5180,7 @@ the probability density function\footnote{The distribution corresponding to
 \; \mbox{.}
 \]
 
+\indexlibrary{\idxcode{extreme_value_distribution}}%
 \begin{codeblock}
 template<class RealType = double>
  class extreme_value_distribution
@@ -5209,7 +5226,7 @@ explicit extreme_value_distribution(RealType a = 0.0, RealType b = 1.0);
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{extreme_value_distribution}{a}%
+\indexlibrarymember{a}{extreme_value_distribution}%
 \begin{itemdecl}
 RealType a() const;
 \end{itemdecl}
@@ -5219,7 +5236,7 @@ RealType a() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrarymember{extreme_value_distribution}{b}%
+\indexlibrarymember{b}{extreme_value_distribution}%
 \begin{itemdecl}
 RealType b() const;
 \end{itemdecl}
@@ -5247,7 +5264,7 @@ RealType b() const;
 
 \rSec4[rand.dist.norm.normal]{Class template \tcode{normal_distribution}}%
 \indexlibrary{\idxcode{normal_distribution}}%
-\indextext{random number distribution!\idxcode{normal_distribution}}
+\indextext{random number distribution!\idxcode{normal_distribution}}%
 
 \pnum
 A \tcode{normal_distribution} random number distribution
@@ -5255,7 +5272,7 @@ produces random numbers $x$
 distributed according to
 the probability density function%
 \indextext{probability density function!\idxcode{normal_distribution}}%
-\indextext{\idxcode{normal_distribution}!probability density function}
+\indextext{\idxcode{normal_distribution}!probability density function}%
 \[%
  p(x\,|\,\mu,\sigma)
       = \frac{1}{\sigma \sqrt{2\pi}}
@@ -5276,6 +5293,7 @@ and \techterm{standard deviation}%
 \indextext{\idxcode{normal_distribution}!standard deviation}%
 .
 
+\indexlibrary{\idxcode{normal_distribution}}%
 \begin{codeblock}
 template<class RealType = double>
  class normal_distribution
@@ -5321,7 +5339,7 @@ explicit normal_distribution(RealType mean = 0.0, RealType stddev = 1.0);
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{normal_distribution}{mean}%
+\indexlibrarymember{mean}{normal_distribution}%
 \begin{itemdecl}
 RealType mean() const;
 \end{itemdecl}
@@ -5331,7 +5349,7 @@ RealType mean() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrarymember{normal_distribution}{stddev}%
+\indexlibrarymember{stddev}{normal_distribution}%
 \begin{itemdecl}
 RealType stddev() const;
 \end{itemdecl}
@@ -5347,7 +5365,7 @@ RealType stddev() const;
 
 \rSec4[rand.dist.norm.lognormal]{Class template \tcode{lognormal_distribution}}%
 \indexlibrary{\idxcode{lognormal_distribution}}%
-\indextext{random number distribution!\idxcode{lognormal_distribution}}
+\indextext{random number distribution!\idxcode{lognormal_distribution}}%
 
 \pnum
 A \tcode{lognormal_distribution} random number distribution
@@ -5355,7 +5373,7 @@ produces random numbers $ x > 0 $
 distributed according to
 the probability density function%
 \indextext{probability density function!\idxcode{lognormal_distribution}}%
-\indextext{\idxcode{lognormal_distribution}!probability density function}
+\indextext{\idxcode{lognormal_distribution}!probability density function}%
 \[%
  p(x\,|\,m,s)
       = \frac{1}
@@ -5368,6 +5386,7 @@ the probability density function%
 \; \mbox{.}
 \]
 
+\indexlibrary{\idxcode{lognormal_distribution}}%
 \begin{codeblock}
 template<class RealType = double>
  class lognormal_distribution
@@ -5413,7 +5432,7 @@ explicit lognormal_distribution(RealType m = 0.0, RealType s = 1.0);
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{lognormal_distribution}{m}%
+\indexlibrarymember{m}{lognormal_distribution}%
 \begin{itemdecl}
 RealType m() const;
 \end{itemdecl}
@@ -5423,7 +5442,7 @@ RealType m() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrarymember{lognormal_distribution}{s}%
+\indexlibrarymember{s}{lognormal_distribution}%
 \begin{itemdecl}
 RealType s() const;
 \end{itemdecl}
@@ -5439,7 +5458,7 @@ RealType s() const;
 
 \rSec4[rand.dist.norm.chisq]{Class template \tcode{chi_squared_distribution}}%
 \indexlibrary{\idxcode{chi_squared_distribution}}%
-\indextext{random number distribution!\idxcode{chi_squared_distribution}}
+\indextext{random number distribution!\idxcode{chi_squared_distribution}}%
 
 \pnum
 A \tcode{chi_squared_distribution} random number distribution
@@ -5447,7 +5466,7 @@ produces random numbers $x>0$
 distributed according to
 the probability density function%
 \indextext{probability density function!\idxcode{chi_squared_distribution}}%
-\indextext{\idxcode{chi_squared_distribution}!probability density function}
+\indextext{\idxcode{chi_squared_distribution}!probability density function}%
 \[%
  p(x\,|\,n)
       =  \frac{ x^{(n/2)-1} \cdot e^{-x/2}}
@@ -5455,6 +5474,7 @@ the probability density function%
 \; \mbox{.}
 \]
 
+\indexlibrary{\idxcode{chi_squared_distribution}}%
 \begin{codeblock}
 template<class RealType = double>
  class chi_squared_distribution
@@ -5499,7 +5519,7 @@ explicit chi_squared_distribution(RealType n = 1);
  corresponds to the parameter of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{chi_squared_distribution}{n}%
+\indexlibrarymember{n}{chi_squared_distribution}%
 \begin{itemdecl}
 RealType n() const;
 \end{itemdecl}
@@ -5514,7 +5534,8 @@ RealType n() const;
 % ----------------------------------------------------------------------
 
 \rSec4[rand.dist.norm.cauchy]{Class template \tcode{cauchy_distribution}}%
-\indexlibrary{\idxcode{cauchy_distribution}}
+\indexlibrary{\idxcode{cauchy_distribution}}%
+\indextext{random number distribution!\idxcode{cauchy_distribution}}%
 
 \pnum
 A \tcode{cauchy_distribution} random number distribution
@@ -5522,13 +5543,14 @@ produces random numbers $x$
 distributed according to
 the probability density function%
 \indextext{probability density function!\idxcode{cauchy_distribution}}%
-\indextext{\idxcode{cauchy_distribution}!probability density function}
+\indextext{\idxcode{cauchy_distribution}!probability density function}%
 \[%
  p(x\,|\,a,b)
       = \left( \pi b \left( 1 + \left( \frac{x-a}{b}  \right)^2 \;\right)\right)^{-1}
 \; \mbox{.}
 \]
 
+\indexlibrary{\idxcode{cauchy_distribution}}%
 \begin{codeblock}
 template<class RealType = double>
  class cauchy_distribution
@@ -5574,7 +5596,7 @@ explicit cauchy_distribution(RealType a = 0.0, RealType b = 1.0);
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{cauchy_distribution}{a}%
+\indexlibrarymember{a}{cauchy_distribution}%
 \begin{itemdecl}
 RealType a() const;
 \end{itemdecl}
@@ -5584,7 +5606,7 @@ RealType a() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrarymember{cauchy_distribution}{b}%
+\indexlibrarymember{b}{cauchy_distribution}%
 \begin{itemdecl}
 RealType b() const;
 \end{itemdecl}
@@ -5600,7 +5622,7 @@ RealType b() const;
 
 \rSec4[rand.dist.norm.f]{Class template \tcode{fisher_f_distribution}}%
 \indexlibrary{\idxcode{fisher_f_distribution}}%
-\indextext{random number distribution!\idxcode{fisher_f_distribution}}
+\indextext{random number distribution!\idxcode{fisher_f_distribution}}%
 
 \pnum
 A \tcode{fisher_f_distribution} random number distribution
@@ -5608,7 +5630,7 @@ produces random numbers $x\ge0$
 distributed according to
 the probability density function%
 \indextext{probability density function!\idxcode{fisher_f_distribution}}%
-\indextext{\idxcode{fisher_f_distribution}!probability density function}
+\indextext{\idxcode{fisher_f_distribution}!probability density function}%
 \[%
  p(x\,|\,m,n)
       = \frac{\Gamma\big((m+n)/2\big)}
@@ -5622,6 +5644,7 @@ the probability density function%
 \; \mbox{.}
 \]
 
+\indexlibrary{\idxcode{fisher_f_distribution}}%
 \begin{codeblock}
 template<class RealType = double>
  class fisher_f_distribution
@@ -5667,7 +5690,7 @@ explicit fisher_f_distribution(RealType m = 1, RealType n = 1);
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{fisher_f_distribution}{m}%
+\indexlibrarymember{m}{fisher_f_distribution}%
 \begin{itemdecl}
 RealType m() const;
 \end{itemdecl}
@@ -5677,7 +5700,7 @@ RealType m() const;
  with which the object was constructed.
 \end{itemdescr}
 
-\indexlibrarymember{fisher_f_distribution}{n}%
+\indexlibrarymember{n}{fisher_f_distribution}%
 \begin{itemdecl}
 RealType n() const;
 \end{itemdecl}
@@ -5693,7 +5716,7 @@ RealType n() const;
 
 \rSec4[rand.dist.norm.t]{Class template \tcode{student_t_distribution}}%
 \indexlibrary{\idxcode{student_t_distribution}}%
-\indextext{random number distribution!\idxcode{student_t_distribution}}
+\indextext{random number distribution!\idxcode{student_t_distribution}}%
 
 \pnum
 A \tcode{student_t_distribution} random number distribution
@@ -5701,7 +5724,7 @@ produces random numbers $x$
 distributed according to
 the probability density function%
 \indextext{probability density function!\idxcode{student_t_distribution}}%
-\indextext{\idxcode{student_t_distribution}!probability density function}
+\indextext{\idxcode{student_t_distribution}!probability density function}%
 \[%
  p(x\,|\,n)
       =  \frac{1}
@@ -5712,6 +5735,7 @@ the probability density function%
 \; \mbox{.}
 \]
 
+\indexlibrary{\idxcode{student_t_distribution}}%
 \begin{codeblock}
 template<class RealType = double>
  class student_t_distribution
@@ -5755,7 +5779,7 @@ explicit student_t_distribution(RealType n = 1);
  \tcode{n} corresponds to the parameter of the distribution.
 \end{itemdescr}
 
-\indexlibrarymember{student_t_distribution}{mean}%
+\indexlibrarymember{mean}{student_t_distribution}%
 \begin{itemdecl}
 RealType n() const;
 \end{itemdecl}
@@ -5785,7 +5809,7 @@ RealType n() const;
 
 \rSec4[rand.dist.samp.discrete]{Class template \tcode{discrete_distribution}}%
 \indexlibrary{\idxcode{discrete_distribution}}%
-\indextext{random number distribution!\idxcode{discrete_distribution}}
+\indextext{random number distribution!\idxcode{discrete_distribution}}%
 
 \pnum
 A \tcode{discrete_distribution} random number distribution
@@ -5793,7 +5817,7 @@ produces random integers $i$, $0 \leq i < n$,
 distributed according to
 the discrete probability function%
 \indextext{discrete probability function!\idxcode{discrete_distribution}}%
-\indextext{\idxcode{discrete_distribution}!discrete probability function}
+\indextext{\idxcode{discrete_distribution}!discrete probability function}%
 \[%
  P(i\,|\,p_0,\ldots,p_{n-1})
       = p_i
@@ -5813,6 +5837,7 @@ commonly known as the \techterm{weights}%
 Moreover, the following relation shall hold:
  $ 0 < S = w_0 + \cdots + w_{n-1} $.
 
+\indexlibrary{\idxcode{discrete_distribution}}%
 \begin{codeblock}
 template<class IntType = int>
  class discrete_distribution
@@ -5929,7 +5954,7 @@ template<class UnaryOperation>
  The number of invocations of \tcode{fw} shall not exceed $n$.
 \end{itemdescr}
 
-\indexlibrarymember{discrete_distribution}{probabilities}%
+\indexlibrarymember{probabilities}{discrete_distribution}%
 \begin{itemdecl}
 vector<double> probabilities() const;
 \end{itemdecl}
@@ -5948,7 +5973,7 @@ vector<double> probabilities() const;
 
 \rSec4[rand.dist.samp.pconst]{Class template \tcode{piecewise_constant_distribution}}%
 \indexlibrary{\idxcode{piecewise_constant_distribution}}%
-\indextext{random number distribution!\idxcode{piecewise_constant_distribution}}
+\indextext{random number distribution!\idxcode{piecewise_constant_distribution}}%
 
 \pnum
 A \tcode{piecewise_constant_distribution} random number distribution
@@ -5958,7 +5983,7 @@ uniformly distributed over each subinterval
 $ [ b_i, b_{i+1} ) $
 according to the probability density function
 \indextext{probability density function!\idxcode{piecewise_constant_distribution}}%
-\indextext{\idxcode{piecewise_constant_distribution}!probability density function}
+\indextext{\idxcode{piecewise_constant_distribution}!probability density function}%
 \[%
  p(x\,|\,b_0,\ldots,b_n,\;\rho_0,\ldots,\rho_{n-1})
       = \rho_i
@@ -5990,6 +6015,7 @@ commonly known as the \techterm{weights}%
 Moreover, the following relation shall hold:
  $ 0 < S = w_0 + \cdots + w_{n-1} $.
 
+\indexlibrary{\idxcode{piecewise_constant_distribution}}%
 \begin{codeblock}
 template<class RealType = double>
  class piecewise_constant_distribution
@@ -6139,7 +6165,7 @@ template<class UnaryOperation>
  The number of invocations of \tcode{fw} shall not exceed $n$.
 \end{itemdescr}
 
-\indexlibrarymember{piecewise_constant_distribution}{intervals}%
+\indexlibrarymember{intervals}{piecewise_constant_distribution}%
 \begin{itemdecl}
 vector<result_type> intervals() const;
 \end{itemdecl}
@@ -6151,7 +6177,7 @@ vector<result_type> intervals() const;
  when invoked with argument $k$ for $k = 0, \ldots, n $.
 \end{itemdescr}
 
-\indexlibrarymember{piecewise_constant_distribution}{densities}%
+\indexlibrarymember{densities}{piecewise_constant_distribution}%
 \begin{itemdecl}
 vector<result_type> densities() const;
 \end{itemdecl}
@@ -6170,7 +6196,7 @@ vector<result_type> densities() const;
 
 \rSec4[rand.dist.samp.plinear]{Class template \tcode{piecewise_linear_distribution}}%
 \indexlibrary{\idxcode{piecewise_linear_distribution}}%
-\indextext{random number distribution!\idxcode{piecewise_linear_distribution}}
+\indextext{random number distribution!\idxcode{piecewise_linear_distribution}}%
 
 \pnum
 A \tcode{piecewise_linear_distribution} random number distribution
@@ -6180,7 +6206,7 @@ distributed over each subinterval
 $ [ b_i, b_{i+1} ) $
 according to the probability density function
 \indextext{probability density function!\idxcode{piecewise_linear_distribution}}%
-\indextext{\idxcode{piecewise_linear_distribution}!probability density function}
+\indextext{\idxcode{piecewise_linear_distribution}!probability density function}%
 \[%
  p(x\,|\,b_0,\ldots,b_n,\;\rho_0,\ldots,\rho_n)
       = \rho_i     \cdot {\frac{b_{i+1} - x}{b_{i+1} - b_i}}
@@ -6213,6 +6239,7 @@ Moreover, the following relation shall hold:
 \; \mbox{.}
 \]
 
+\indexlibrary{\idxcode{piecewise_linear_distribution}}%
 \begin{codeblock}
 template<class RealType = double>
  class piecewise_linear_distribution
@@ -6360,7 +6387,7 @@ template<class UnaryOperation>
  The number of invocations of \tcode{fw} shall not exceed $n+1$.
 \end{itemdescr}
 
-\indexlibrarymember{piecewise_linear_distribution}{intervals}%
+\indexlibrarymember{intervals}{piecewise_linear_distribution}%
 \begin{itemdecl}
 vector<result_type> intervals() const;
 \end{itemdecl}
@@ -6372,7 +6399,7 @@ vector<result_type> intervals() const;
  when invoked with argument $k$ for $k = 0, \ldots, n $.
 \end{itemdescr}
 
-\indexlibrarymember{piecewise_linear_distribution}{densities}%
+\indexlibrarymember{densities}{piecewise_linear_distribution}%
 \begin{itemdecl}
 vector<result_type> densities() const;
 \end{itemdecl}
@@ -6900,7 +6927,7 @@ an implementation may return all allocated memory.
 
 \rSec3[valarray.assign]{\tcode{valarray} assignment}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{valarray}}%
+\indexlibrarymember{operator=}{valarray}%
 \begin{itemdecl}
 valarray& operator=(const valarray& v);
 \end{itemdecl}
@@ -6919,7 +6946,7 @@ as if by calling \tcode{resize(v.size())}, before performing the assignment.
 \postcondition \tcode{size() == v.size()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{valarray}}%
+\indexlibrarymember{operator=}{valarray}%
 \begin{itemdecl}
 valarray& operator=(valarray&& v) noexcept;
 \end{itemdecl}
@@ -6947,7 +6974,7 @@ valarray& operator=(initializer_list<T> il);
 \end{itemdescr}
 
 
-\indexlibrary{\idxcode{operator=}!\idxcode{valarray}}%
+\indexlibrarymember{operator=}{valarray}%
 \begin{itemdecl}
 valarray& operator=(const T&);
 \end{itemdecl}
@@ -6984,7 +7011,7 @@ the resulting behavior is undefined.
 
 \rSec3[valarray.access]{\tcode{valarray} element access}
 
-\indexlibrary{\idxcode{operator[]}!\idxcode{valarray}}%
+\indexlibrarymember{operator[]}{valarray}%
 \begin{itemdecl}
 const T&  operator[](size_t) const;
 T& operator[](size_t);
@@ -7079,7 +7106,7 @@ conjunction with various overloads of \tcode{operator=} and other assigning
 operators to allow selective replacement (slicing) of the controlled sequence.
 In each case the selected element(s) must exist.
 
-\indexlibrary{\idxcode{operator[]}!\idxcode{valarray}}%
+\indexlibrarymember{operator[]}{valarray}%
 \begin{itemdecl}
 valarray operator[](slice slicearr) const;
 \end{itemdecl}
@@ -7096,7 +7123,7 @@ const valarray<char> v0("abcdefghijklmnop", 16);
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator[]}!\idxcode{valarray}}%
+\indexlibrarymember{operator[]}{valarray}%
 \begin{itemdecl}
 slice_array<T> operator[](slice slicearr);
 \end{itemdecl}
@@ -7114,7 +7141,7 @@ v0[slice(2, 5, 3)] = v1;
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator[]}!\idxcode{valarray}}%
+\indexlibrarymember{operator[]}{valarray}%
 \begin{itemdecl}
 valarray operator[](const gslice& gslicearr) const;
 \end{itemdecl}
@@ -7135,7 +7162,7 @@ const valarray<size_t> len(lv, 2), str(dv, 2);
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator[]}!\idxcode{valarray}}%
+\indexlibrarymember{operator[]}{valarray}%
 \begin{itemdecl}
 gslice_array<T> operator[](const gslice& gslicearr);
 \end{itemdecl}
@@ -7156,7 +7183,7 @@ v0[gslice(3, len, str)] = v1;
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator[]}!\idxcode{valarray}}%
+\indexlibrarymember{operator[]}{valarray}%
 \begin{itemdecl}
 valarray operator[](const valarray<bool>& boolarr) const;
 \end{itemdecl}
@@ -7175,7 +7202,7 @@ const bool vb[] = { false, false, true, true, false, true };
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator[]}!\idxcode{valarray}}%
+\indexlibrarymember{operator[]}{valarray}%
 \begin{itemdecl}
 mask_array<T> operator[](const valarray<bool>& boolarr);
 \end{itemdecl}
@@ -7194,7 +7221,7 @@ v0[valarray<bool>(vb, 6)] = v1;
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator[]}!\idxcode{valarray}}%
+\indexlibrarymember{operator[]}{valarray}%
 \begin{itemdecl}
 valarray operator[](const valarray<size_t>& indarr) const;
 \end{itemdecl}
@@ -7213,7 +7240,7 @@ const size_t vi[] = { 7, 5, 2, 3, 8 };
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator[]}!\idxcode{valarray}}%
+\indexlibrarymember{operator[]}{valarray}%
 \begin{itemdecl}
 indirect_array<T> operator[](const valarray<size_t>& indarr);
 \end{itemdecl}
@@ -7234,10 +7261,10 @@ v0[valarray<size_t>(vi, 5)] = v1;
 
 \rSec3[valarray.unary]{\tcode{valarray} unary operators}
 
-\indexlibrary{\idxcode{operator+}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator-}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator\~{}}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator"!}!\idxcode{valarray}}%
+\indexlibrarymember{operator+}{valarray}%
+\indexlibrarymember{operator-}{valarray}%
+\indexlibrarymember{operator\~{}}{valarray}%
+\indexlibrarymember{operator"!}{valarray}%
 \begin{itemdecl}
 valarray operator+() const;
 valarray operator-() const;
@@ -7262,14 +7289,14 @@ applying the indicated operator to the corresponding element of the array.
 
 \rSec3[valarray.cassign]{\tcode{valarray} compound assignment}
 
-\indexlibrary{\idxcode{operator*=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator/=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator\%=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator+=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator-=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator\^{}=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator\&=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator"|=}!\idxcode{valarray}}%
+\indexlibrarymember{operator*=}{valarray}%
+\indexlibrarymember{operator/=}{valarray}%
+\indexlibrarymember{operator\%=}{valarray}%
+\indexlibrarymember{operator+=}{valarray}%
+\indexlibrarymember{operator-=}{valarray}%
+\indexlibrarymember{operator\^{}=}{valarray}%
+\indexlibrarymember{operator\&=}{valarray}%
+\indexlibrarymember{operator"|=}{valarray}%
 \indexlibrarymember{operator\shl=}{valarray}%
 \indexlibrarymember{operator\shr=}{valarray}%
 \begin{itemdecl}
@@ -7314,8 +7341,7 @@ hand side, the resulting behavior is undefined.
 \indexlibrarymember{operator\%=}{valarray}%
 \indexlibrarymember{operator+=}{valarray}%
 \indexlibrarymember{operator-=}{valarray}%
-\indexlibrary{\idxcode{operator\^{}=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator\^{}=}}%
+\indexlibrarymember{operator\^{}=}{valarray}%
 \indexlibrarymember{operator\&=}{valarray}%
 \indexlibrarymember{operator"|=}{valarray}%
 \indexlibrarymember{operator\shl=}{valarray}%
@@ -7519,18 +7545,16 @@ Resizing invalidates all pointers and references to elements in the array.
 
 \rSec3[valarray.binary]{\tcode{valarray} binary operators}
 
-\indexlibrary{\idxcode{operator*}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator/}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator\%}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator+}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator-}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator\^{}}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator\&}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator"|}!\idxcode{valarray}}%
+\indexlibrarymember{operator*}{valarray}%
+\indexlibrarymember{operator/}{valarray}%
+\indexlibrarymember{operator\%}{valarray}%
+\indexlibrarymember{operator+}{valarray}%
+\indexlibrarymember{operator-}{valarray}%
+\indexlibrarymember{operator\^{}}{valarray}%
+\indexlibrarymember{operator\&}{valarray}%
+\indexlibrarymember{operator"|}{valarray}%
 \indexlibrarymember{operator\shl}{valarray}%
 \indexlibrarymember{operator\shr}{valarray}%
-\indexlibrary{\idxcode{operator\&\&}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator"|"|}!\idxcode{valarray}}%
 \begin{itemdecl}
 template<class T> valarray<T> operator*
     (const valarray<T>&, const valarray<T>&);
@@ -7577,9 +7601,8 @@ If the argument arrays do not have the same length, the behavior is undefined.%
 \indexlibrarymember{operator/}{valarray}%
 \indexlibrarymember{operator\%}{valarray}%
 \indexlibrarymember{operator+}{valarray}%
-\indexlibrarymember{operator=}{valarray}%
-\indexlibrary{\idxcode{operator\^{}}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator\^{}}}%
+\indexlibrarymember{operator-}{valarray}%
+\indexlibrarymember{operator\^{}}{valarray}%
 \indexlibrarymember{operator\&}{valarray}%
 \indexlibrarymember{operator"|}{valarray}%
 \indexlibrarymember{operator\shl}{valarray}%
@@ -7624,14 +7647,14 @@ corresponding element of the array argument and the non-array argument.
 
 \rSec3[valarray.comparison]{\tcode{valarray} logical operators}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator"!=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator<}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator>}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator<=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator>=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator\&\&}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{operator"|"|}!\idxcode{valarray}}%
+\indexlibrarymember{operator==}{valarray}%
+\indexlibrarymember{operator"!=}{valarray}%
+\indexlibrarymember{operator<}{valarray}%
+\indexlibrarymember{operator>}{valarray}%
+\indexlibrarymember{operator<=}{valarray}%
+\indexlibrarymember{operator>=}{valarray}%
+\indexlibrarymember{operator\&\&}{valarray}%
+\indexlibrarymember{operator"|"|}{valarray}%
 \begin{itemdecl}
 template<class T> valarray<bool> operator==
     (const valarray<T>&, const valarray<T>&);
@@ -7672,8 +7695,7 @@ the behavior is undefined.%
 \end{itemdescr}
 
 \indexlibrarymember{operator==}{valarray}%
-\indexlibrary{\idxcode{operator"!=}!\idxcode{valarray}}%
-\indexlibrary{\idxcode{valarray}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{valarray}%
 \indexlibrarymember{operator<}{valarray}%
 \indexlibrarymember{operator<=}{valarray}%
 \indexlibrarymember{operator>}{valarray}%
@@ -7716,22 +7738,22 @@ indicated operator to the corresponding element of the array and the non-array a
 
 \rSec3[valarray.transcend]{\tcode{valarray} transcendentals}
 
-\indexlibrary{\idxcode{abs}}%
-\indexlibrary{\idxcode{acos}}%
-\indexlibrary{\idxcode{asin}}%
-\indexlibrary{\idxcode{atan}}%
-\indexlibrary{\idxcode{atan2}}%
-\indexlibrary{\idxcode{cos}}%
-\indexlibrary{\idxcode{cosh}}%
-\indexlibrary{\idxcode{exp}}%
-\indexlibrary{\idxcode{log}}%
-\indexlibrary{\idxcode{log10}}%
-\indexlibrary{\idxcode{pow}}%
-\indexlibrary{\idxcode{sin}}%
-\indexlibrary{\idxcode{sinh}}%
-\indexlibrary{\idxcode{sqrt}}%
-\indexlibrary{\idxcode{tan}}%
-\indexlibrary{\idxcode{tanh}}%
+\indexlibrary{\idxcode{abs}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{acos}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{asin}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{atan}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{atan2}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{cos}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{cosh}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{exp}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{log}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{log10}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{pow}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{sin}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{sinh}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{sqrt}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{tan}!\idxcode{valarray}}%
+\indexlibrary{\idxcode{tanh}!\idxcode{valarray}}%
 \begin{itemdecl}
 template<class T> valarray<T> abs  (const valarray<T>&);
 template<class T> valarray<T> acos (const valarray<T>&);
@@ -7837,9 +7859,9 @@ constructs a slice which selects elements 3, 5, 7, ... 17 from an array.
 \end{itemdescr}
 
 \rSec3[slice.access]{\tcode{slice} access functions}
-\indexlibrary{\idxcode{start}!\idxcode{slice}}%
-\indexlibrary{\idxcode{size}!\idxcode{slice}}%
-\indexlibrary{\idxcode{stride}!\idxcode{slice}}%
+\indexlibrarymember{start}{slice}%
+\indexlibrarymember{size}{slice}%
+\indexlibrarymember{stride}{slice}%
 \begin{itemdecl}
 size_t start() const;
 size_t size() const;
@@ -7881,7 +7903,7 @@ namespace std {
     slice_array(const slice_array&);
     ~slice_array();
     const slice_array& operator=(const slice_array&) const;
-  void operator=(const T&) const;
+    void operator=(const T&) const;
 
     slice_array() = delete;       // as implied by declaring copy constructor above
   };
@@ -7938,14 +7960,14 @@ object refers.
 
 \rSec3[slice.arr.comp.assign]{\tcode{slice_array} compound assignment}
 
-\indexlibrary{\idxcode{operator*=}!\idxcode{slice_array}}%
-\indexlibrary{\idxcode{operator/=}!\idxcode{slice_array}}%
-\indexlibrary{\idxcode{operator\%=}!\idxcode{slice_array}}%
-\indexlibrary{\idxcode{operator+=}!\idxcode{slice_array}}%
-\indexlibrary{\idxcode{operator-=}!\idxcode{slice_array}}%
-\indexlibrary{\idxcode{operator\^{}=}!\idxcode{slice_array}}%
-\indexlibrary{\idxcode{operator\&=}!\idxcode{slice_array}}%
-\indexlibrary{\idxcode{operator"|=}!\idxcode{slice_array}}%
+\indexlibrarymember{operator*=}{slice_array}%
+\indexlibrarymember{operator/=}{slice_array}%
+\indexlibrarymember{operator\%=}{slice_array}%
+\indexlibrarymember{operator+=}{slice_array}%
+\indexlibrarymember{operator-=}{slice_array}%
+\indexlibrarymember{operator\^{}=}{slice_array}%
+\indexlibrarymember{operator\&=}{slice_array}%
+\indexlibrarymember{operator"|=}{slice_array}%
 \indexlibrarymember{operator\shl=}{slice_array}%
 \indexlibrarymember{operator\shr=}{slice_array}%
 \begin{itemdecl}
@@ -7974,7 +7996,7 @@ object refers.
 
 \rSec3[slice.arr.fill]{\tcode{slice_array} fill function}
 
-\indexlibrary{\idxcode{fill}!\idxcode{slice_array}}%
+\indexlibrarymember{operator=}{slice_array}%
 \begin{itemdecl}
 void operator=(const T&) const;
 \end{itemdecl}
@@ -8125,9 +8147,9 @@ in the previous section.
 
 \rSec3[gslice.access]{\tcode{gslice} access functions}
 
-\indexlibrary{\idxcode{start}!\idxcode{gslice}}%
-\indexlibrary{\idxcode{size}!\idxcode{gslice}}%
-\indexlibrary{\idxcode{stride}!\idxcode{gslice}}%
+\indexlibrarymember{start}{gslice}%
+\indexlibrarymember{size}{gslice}%
+\indexlibrarymember{stride}{gslice}%
 \begin{itemdecl}
 size_t           start()  const;
 valarray<size_t> size() const;
@@ -8206,7 +8228,7 @@ generalized slice of the elements in
 
 \rSec3[gslice.array.assign]{\tcode{gslice_array} assignment}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{gslice_array}}%
+\indexlibrarymember{operator=}{gslice_array}%
 \begin{itemdecl}
 void operator=(const valarray<T>&) const;
 const gslice_array& operator=(const gslice_array&) const;
@@ -8224,14 +8246,14 @@ refers.
 
 \rSec3[gslice.array.comp.assign]{\tcode{gslice_array} compound assignment}
 
-\indexlibrary{\idxcode{operator*=}!\idxcode{gslice_array}}%
-\indexlibrary{\idxcode{operator/=}!\idxcode{gslice_array}}%
-\indexlibrary{\idxcode{operator\%=}!\idxcode{gslice_array}}%
-\indexlibrary{\idxcode{operator+=}!\idxcode{gslice_array}}%
-\indexlibrary{\idxcode{operator-=}!\idxcode{gslice_array}}%
-\indexlibrary{\idxcode{operator\^{}=}!\idxcode{gslice_array}}%
-\indexlibrary{\idxcode{operator\&=}!\idxcode{gslice_array}}%
-\indexlibrary{\idxcode{operator"|=}!\idxcode{gslice_array}}%
+\indexlibrarymember{operator*=}{gslice_array}%
+\indexlibrarymember{operator/=}{gslice_array}%
+\indexlibrarymember{operator\%=}{gslice_array}%
+\indexlibrarymember{operator+=}{gslice_array}%
+\indexlibrarymember{operator-=}{gslice_array}%
+\indexlibrarymember{operator\^{}=}{gslice_array}%
+\indexlibrarymember{operator\&=}{gslice_array}%
+\indexlibrarymember{operator"|=}{gslice_array}%
 \indexlibrarymember{operator\shl=}{gslice_array}%
 \indexlibrarymember{operator\shr=}{gslice_array}%
 \begin{itemdecl}
@@ -8260,7 +8282,7 @@ object refers.
 
 \rSec3[gslice.array.fill]{\tcode{gslice_array} fill function}
 
-\indexlibrary{\idxcode{fill}!\idxcode{gslice_array}}%
+\indexlibrarymember{operator=}{gslice_array}%
 \begin{itemdecl}
 void operator=(const T&) const;
 \end{itemdecl}
@@ -8335,7 +8357,7 @@ is
 
 \rSec3[mask.array.assign]{\tcode{mask_array} assignment}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{mask_array}}%
+\indexlibrarymember{operator=}{mask_array}%
 \begin{itemdecl}
 void operator=(const valarray<T>&) const;
 const mask_array& operator=(const mask_array&) const;
@@ -8351,14 +8373,14 @@ object to which it refers.
 
 \rSec3[mask.array.comp.assign]{\tcode{mask_array} compound assignment}
 
-\indexlibrary{\idxcode{operator*=}!\idxcode{mask_array}}%
-\indexlibrary{\idxcode{operator/=}!\idxcode{mask_array}}%
-\indexlibrary{\idxcode{operator\%=}!\idxcode{mask_array}}%
-\indexlibrary{\idxcode{operator+=}!\idxcode{mask_array}}%
-\indexlibrary{\idxcode{operator-=}!\idxcode{mask_array}}%
-\indexlibrary{\idxcode{operator\^{}=}!\idxcode{mask_array}}%
-\indexlibrary{\idxcode{operator\&=}!\idxcode{mask_array}}%
-\indexlibrary{\idxcode{operator"|=}!\idxcode{mask_array}}%
+\indexlibrarymember{operator*=}{mask_array}%
+\indexlibrarymember{operator/=}{mask_array}%
+\indexlibrarymember{operator\%=}{mask_array}%
+\indexlibrarymember{operator+=}{mask_array}%
+\indexlibrarymember{operator-=}{mask_array}%
+\indexlibrarymember{operator\^{}=}{mask_array}%
+\indexlibrarymember{operator\&=}{mask_array}%
+\indexlibrarymember{operator"|=}{mask_array}%
 \indexlibrarymember{operator\shl=}{mask_array}%
 \indexlibrarymember{operator\shr=}{mask_array}%
 \begin{itemdecl}
@@ -8385,7 +8407,7 @@ object to which the mask object refers.
 
 \rSec3[mask.array.fill]{\tcode{mask_array} fill function}
 
-\indexlibrary{\idxcode{fill}!\idxcode{mask_array}}%
+\indexlibrarymember{operator=}{mask_array}%
 \begin{itemdecl}
 void operator=(const T&) const;
 \end{itemdecl}
@@ -8457,7 +8479,7 @@ whose indices appear in
 
 \rSec3[indirect.array.assign]{\tcode{indirect_array} assignment}
 
-\indexlibrary{\idxcode{operator=}!\idxcode{indirect_array}}%
+\indexlibrarymember{operator=}{indirect_array}%
 \begin{itemdecl}
 void operator=(const valarray<T>&) const;
 const indirect_array& operator=(const indirect_array&) const;
@@ -8493,16 +8515,14 @@ indirection.
 
 \rSec3[indirect.array.comp.assign]{\tcode{indirect_array} compound assignment}
 
-\indexlibrary{\idxcode{operator*=}!\idxcode{indirect_array}}%
-\indexlibrary{\idxcode{operator*=}!\idxcode{indirect_array}}%
-\indexlibrary{\idxcode{operator*=}!\idxcode{indirect_array}}%
-\indexlibrary{\idxcode{operator/=}!\idxcode{indirect_array}}%
-\indexlibrary{\idxcode{operator\%=}!\idxcode{indirect_array}}%
-\indexlibrary{\idxcode{operator+=}!\idxcode{indirect_array}}%
-\indexlibrary{\idxcode{operator-=}!\idxcode{indirect_array}}%
-\indexlibrary{\idxcode{operator\^{}=}!\idxcode{indirect_array}}%
-\indexlibrary{\idxcode{operator\&=}!\idxcode{indirect_array}}%
-\indexlibrary{\idxcode{operator"|=}!\idxcode{indirect_array}}%
+\indexlibrarymember{operator*=}{indirect_array}%
+\indexlibrarymember{operator/=}{indirect_array}%
+\indexlibrarymember{operator\%=}{indirect_array}%
+\indexlibrarymember{operator+=}{indirect_array}%
+\indexlibrarymember{operator-=}{indirect_array}%
+\indexlibrarymember{operator\^{}=}{indirect_array}%
+\indexlibrarymember{operator\&=}{indirect_array}%
+\indexlibrarymember{operator"|=}{indirect_array}%
 \indexlibrarymember{operator\shl=}{indirect_array}%
 \indexlibrarymember{operator\shr=}{indirect_array}%
 \begin{itemdecl}
@@ -8539,7 +8559,7 @@ the behavior is undefined.
 
 \rSec3[indirect.array.fill]{\tcode{indirect_array} fill function}
 
-\indexlibrary{\idxcode{fill}!\idxcode{indirect_array}}%
+\indexlibrarymember{operator=}{indirect_array}%
 \begin{itemdecl}
 void operator=(const T&) const;
 \end{itemdecl}
@@ -8576,7 +8596,7 @@ are guaranteed to be valid until the member function
 array or until the lifetime of that array ends, whichever happens
 first.
 
-\indexlibrarymember{begin}{valarray}%
+\indexlibrary{\idxcode{begin}!\idxcode{valarray}}%
 \begin{itemdecl}
 template <class T> @\unspec{1}@ begin(valarray<T>& v);
 template <class T> @\unspec{2}@ begin(const valarray<T>& v);
@@ -8587,7 +8607,7 @@ template <class T> @\unspec{2}@ begin(const valarray<T>& v);
 \returns An iterator referencing the first value in the numeric array.
 \end{itemdescr}
 
-\indexlibrarymember{end}{valarray}%
+\indexlibrary{\idxcode{end}!\idxcode{valarray}}%
 \begin{itemdecl}
 template <class T> @\unspec{1}@ end(valarray<T>& v);
 template <class T> @\unspec{2}@ end(const valarray<T>& v);
@@ -8865,6 +8885,7 @@ return reduce(first, last, typename iterator_traits<InputIterator>::value_type{}
 \end{codeblock}
 \end{itemdescr}
 
+\indexlibrary{\idxcode{reduce}}%
 \begin{itemdecl}
 template<class InputIterator, class T>
   T reduce(InputIterator first, InputIterator last, T init);
@@ -8876,6 +8897,7 @@ template<class InputIterator, class T>
 Equivalent to: \tcode{return reduce(first, last, init, plus<>());}
 \end{itemdescr}
 
+\indexlibrary{\idxcode{reduce}}%
 \begin{itemdecl}
 template<class InputIterator, class T, class BinaryOperation>
   T reduce(InputIterator first, InputIterator last, T init,
@@ -8934,7 +8956,6 @@ modify elements in the range \range{first}{last}.
 \end{itemdescr}
 
 \rSec2[inner.product]{Inner product}
-\indexlibrary{\idxcode{inner_product}}%
 
 \indexlibrary{\idxcode{inner_product}}%
 \begin{itemdecl}
@@ -9055,6 +9076,7 @@ template<class InputIterator, class OutputIterator, class T>
 Equivalent to: \tcode{return exclusive_scan(first, last, result, init, plus<>());}
 \end{itemdescr}
 
+\indexlibrary{\idxcode{exclusive_scan}}%
 \begin{itemdecl}
 template<class InputIterator, class OutputIterator, class T, class BinaryOperation>
   OutputIterator exclusive_scan(InputIterator first, InputIterator last,
@@ -9110,6 +9132,7 @@ template<class InputIterator, class OutputIterator>
 Equivalent to: \tcode{return inclusive_scan(first, last, result, plus<>());}
 \end{itemdescr}
 
+\indexlibrary{\idxcode{inclusive_scan}}%
 \begin{itemdecl}
 template<class InputIterator, class OutputIterator, class BinaryOperation>
   OutputIterator inclusive_scan(InputIterator first, InputIterator last,

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -1556,8 +1556,8 @@ basic_string& operator=(initializer_list<charT> il);
 
 \rSec3[string.iterators]{\tcode{basic_string} iterator support}
 
-\indexlibrarymember{basic_string}{begin}%
-\indexlibrarymember{basic_string}{cbegin}%
+\indexlibrarymember{begin}{basic_string}%
+\indexlibrarymember{cbegin}{basic_string}%
 \begin{itemdecl}
 iterator       begin() noexcept;
 const_iterator begin() const noexcept;
@@ -1616,7 +1616,7 @@ An iterator which is semantically equivalent to
 
 \rSec3[string.capacity]{\tcode{basic_string} capacity}
 
-\indexlibrarymember{basic_string}{size}%
+\indexlibrarymember{size}{basic_string}%
 \begin{itemdecl}
 size_type size() const noexcept;
 \end{itemdecl}
@@ -1641,7 +1641,7 @@ size_type length() const noexcept;
 \tcode{size()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{max_size}%
+\indexlibrarymember{max_size}{basic_string}%
 \begin{itemdecl}
 size_type max_size() const noexcept;
 \end{itemdecl}
@@ -1655,7 +1655,7 @@ The size of the largest possible string.
 \complexity Constant time.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{resize}%
+\indexlibrarymember{resize}{basic_string}%
 \begin{itemdecl}
 void resize(size_type n, charT c);
 \end{itemdecl}
@@ -1706,7 +1706,7 @@ void resize(size_type n);
 As if by \tcode{resize(n, charT())}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{capacity}%
+\indexlibrarymember{capacity}{basic_string}%
 \begin{itemdecl}
 size_type capacity() const noexcept;
 \end{itemdecl}
@@ -1717,7 +1717,7 @@ size_type capacity() const noexcept;
 The size of the allocated storage in the string.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{reserve}%
+\indexlibrarymember{reserve}{basic_string}%
 \begin{itemdecl}
 void reserve(size_type res_arg=0);
 \end{itemdecl}
@@ -1759,7 +1759,7 @@ uses
 which may throw an appropriate exception.}
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{shrink_to_fit}%
+\indexlibrarymember{shrink_to_fit}{basic_string}%
 \begin{itemdecl}
 void shrink_to_fit();
 \end{itemdecl}
@@ -1771,7 +1771,7 @@ void shrink_to_fit();
 allow latitude for implementation-specific optimizations. \end{note}
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{clear}%
+\indexlibrarymember{clear}{basic_string}%
 \begin{itemdecl}
 void clear() noexcept;
 \end{itemdecl}
@@ -1786,7 +1786,7 @@ erase(begin(), end());
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{empty}%
+\indexlibrarymember{empty}{basic_string}%
 \begin{itemdecl}
 bool empty() const noexcept;
 \end{itemdecl}
@@ -1799,7 +1799,7 @@ bool empty() const noexcept;
 
 \rSec3[string.access]{\tcode{basic_string} element access}
 
-\indexlibrarymember{basic_string}{operator[]}%
+\indexlibrarymember{operator[]}{basic_string}%
 \begin{itemdecl}
 const_reference operator[](size_type pos) const;
 reference       operator[](size_type pos);
@@ -1822,7 +1822,7 @@ undefined behavior.
 \complexity Constant time.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{at}%
+\indexlibrarymember{at}{basic_string}%
 \begin{itemdecl}
 const_reference at(size_type pos) const;
 reference       at(size_type pos);
@@ -1840,7 +1840,7 @@ if
 \tcode{operator[](pos)}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{front}%
+\indexlibrarymember{front}{basic_string}%
 \begin{itemdecl}
 const charT& front() const;
 charT& front();
@@ -1856,7 +1856,7 @@ charT& front();
 Equivalent to \tcode{operator[](0)}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{back}%
+\indexlibrarymember{back}{basic_string}%
 \begin{itemdecl}
 const charT& back() const;
 charT& back();
@@ -1876,7 +1876,7 @@ Equivalent to \tcode{operator[](size() - 1)}.
 
 \rSec4[string::op+=]{\tcode{basic_string::operator+=}}
 
-\indexlibrarymember{basic_string}{operator+=}%
+\indexlibrarymember{operator+=}{basic_string}%
 \begin{itemdecl}
 basic_string&
   operator+=(const basic_string& str);
@@ -1920,7 +1920,7 @@ basic_string& operator+=(const charT* s);
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{operator+=}%
+\indexlibrarymember{operator+=}{basic_string}%
 \begin{itemdecl}
 basic_string& operator+=(charT c);
 \end{itemdecl}
@@ -1950,7 +1950,7 @@ basic_string& operator+=(initializer_list<charT> il);
 
 \rSec4[string::append]{\tcode{basic_string::append}}
 
-\indexlibrarymember{basic_string}{append}%
+\indexlibrarymember{append}{basic_string}%
 \begin{itemdecl}
 basic_string&
   append(const basic_string& str);
@@ -2068,7 +2068,7 @@ elements of \tcode{charT}.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{append}%
+\indexlibrarymember{append}{basic_string}%
 \begin{itemdecl}
 basic_string& append(size_type n, charT c);
 \end{itemdecl}
@@ -2128,7 +2128,7 @@ Equivalent to
 
 \rSec4[string::assign]{\tcode{basic_string::assign}}
 
-\indexlibrarymember{basic_string}{assign}%
+\indexlibrarymember{assign}{basic_string}%
 \begin{itemdecl}
 basic_string& assign(const basic_string& str);
 \end{itemdecl}
@@ -2273,7 +2273,7 @@ basic_string& assign(initializer_list<charT> il);
 \end{itemdescr}
 
 
-\indexlibrary{\idxcode{length}!\idxcode{char_traits}}%
+\indexlibrarymember{assign}{basic_string}%
 \begin{itemdecl}
 basic_string& assign(size_type n, charT c);
 \end{itemdecl}
@@ -2304,7 +2304,7 @@ template<class InputIterator>
 
 \rSec4[string::insert]{\tcode{basic_string::insert}}
 
-\indexlibrarymember{basic_string}{insert}%
+\indexlibrarymember{insert}{basic_string}%
 \begin{itemdecl}
 basic_string&
   insert(size_type pos1,
@@ -2424,7 +2424,7 @@ basic_string&
 \effects Equivalent to: \tcode{return insert(pos, s, traits::length(s));}
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{insert}%
+\indexlibrarymember{insert}{basic_string}%
 \begin{itemdecl}
 basic_string&
   insert(size_type pos, size_type n, charT c);
@@ -2519,7 +2519,7 @@ iterator insert(const_iterator p, initializer_list<charT> il);
 
 \rSec4[string::erase]{\tcode{basic_string::erase}}
 
-\indexlibrarymember{basic_string}{erase}%
+\indexlibrarymember{erase}{basic_string}%
 \begin{itemdecl}
 basic_string& erase(size_type pos = 0, size_type n = npos);
 \end{itemdecl}
@@ -2606,7 +2606,7 @@ If no such element exists,
 is returned.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{pop_back}%
+\indexlibrarymember{pop_back}{basic_string}%
 \begin{itemdecl}
 void pop_back();
 \end{itemdecl}
@@ -2626,7 +2626,7 @@ Equivalent to \tcode{erase(size() - 1, 1)}.
 
 \rSec4[string::replace]{\tcode{basic_string::replace}}
 
-\indexlibrarymember{basic_string}{replace}%
+\indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
 basic_string&
   replace(size_type pos1, size_type n1,
@@ -2666,7 +2666,7 @@ as the smaller of \tcode{n2} and \tcode{str.size() - pos2} and calls
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{replace}%
+\indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
 basic_string& replace(size_type pos1, size_type n1,
                       basic_string_view<charT, traits> sv);
@@ -2678,7 +2678,7 @@ basic_string& replace(size_type pos1, size_type n1,
 Equivalent to: \tcode{return replace(pos1, n1, sv.data(), sv.size());}
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{replace}%
+\indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
 basic_string& replace(size_type pos1, size_type n1,
                       basic_string_view<charT, traits> sv,
@@ -2752,7 +2752,7 @@ basic_string&
 \effects Equivalent to: \tcode{return replace(pos, n, s, traits::length(s));}
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{replace}%
+\indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
 basic_string&
   replace(size_type pos1, size_type n1,
@@ -2903,7 +2903,7 @@ basic_string& replace(const_iterator i1, const_iterator i2,
 
 \rSec4[string::copy]{\tcode{basic_string::copy}}
 
-\indexlibrarymember{basic_string}{copy}%
+\indexlibrarymember{copy}{basic_string}%
 \begin{itemdecl}
 size_type copy(charT* s, size_type n, size_type pos = 0) const;
 \end{itemdecl}
@@ -2939,7 +2939,7 @@ by \tcode{s}.
 
 \rSec4[string::swap]{\tcode{basic_string::swap}}
 
-\indexlibrarymember{basic_string}{swap}%
+\indexlibrarymember{swap}{basic_string}%
 \begin{itemdecl}
 void swap(basic_string& s)
   noexcept(allocator_traits<Allocator>::propagate_on_container_swap::value ||
@@ -2965,10 +2965,8 @@ contains the same sequence of characters that was in \tcode{s},
 
 \rSec4[string.accessors]{\tcode{basic_string} accessors}
 
-\indexlibrary{\idxcode{c_str}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{data}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{c_str}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{data}}%
+\indexlibrarymember{c_str}{basic_string}%
+\indexlibrarymember{data}{basic_string}%
 \begin{itemdecl}
 const charT* c_str() const noexcept;
 const charT* data() const noexcept;
@@ -3005,7 +3003,7 @@ charT* data() noexcept;
 The program shall not alter the value stored at \tcode{p + size()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{operator basic_string_view}%
+\indexlibrarymember{operator basic_string_view}{basic_string}%
 \begin{itemdecl}
 operator basic_string_view<charT, traits>() const noexcept;
 \end{itemdecl}
@@ -3032,7 +3030,7 @@ copy of the most recent replacement.
 
 \rSec4[string::find]{\tcode{basic_string::find}}
 
-\indexlibrarymember{basic_string}{find}%
+\indexlibrarymember{find}{basic_string}%
 \begin{itemdecl}
 size_type find(basic_string_view<charT, traits> sv,
                size_type pos = 0) const noexcept;
@@ -3066,7 +3064,7 @@ Uses
 \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{find}%
+\indexlibrarymember{find}{basic_string}%
 \begin{itemdecl}
 size_type find(const basic_string& str,
                size_type pos = 0) const noexcept;
@@ -3104,7 +3102,7 @@ elements of \tcode{charT}.
 \tcode{find(basic_string_view<charT, traits>(s), pos)}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{find}%
+\indexlibrarymember{find}{basic_string}%
 \begin{itemdecl}
 size_type find(charT c, size_type pos = 0) const;
 \end{itemdecl}
@@ -3117,7 +3115,7 @@ size_type find(charT c, size_type pos = 0) const;
 
 \rSec4[string::rfind]{\tcode{basic_string::rfind}}
 
-\indexlibrarymember{basic_string}{rfind}%
+\indexlibrarymember{rfind}{basic_string}%
 \begin{itemdecl}
 size_type rfind(basic_string_view<charT, traits> sv,
                 size_type pos = npos) const noexcept;
@@ -3152,7 +3150,7 @@ Uses
 \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{rfind}%
+\indexlibrarymember{rfind}{basic_string}%
 \begin{itemdecl}
 size_type rfind(const basic_string& str,
                 size_type pos = npos) const noexcept;
@@ -3190,7 +3188,7 @@ elements of \tcode{charT}.
 \tcode{rfind(basic_string_view<charT, traits>(s), pos)}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{rfind}%
+\indexlibrarymember{rfind}{basic_string}%
 \begin{itemdecl}
 size_type rfind(charT c, size_type pos = npos) const;
 \end{itemdecl}
@@ -3203,7 +3201,7 @@ size_type rfind(charT c, size_type pos = npos) const;
 
 \rSec4[string::find.first.of]{\tcode{basic_string::find_first_of}}
 
-\indexlibrarymember{basic_string}{find_first_of}%
+\indexlibrarymember{find_first_of}{basic_string}%
 \begin{itemdecl}
 size_type find_first_of(basic_string_view<charT, traits> sv,
                         size_type pos = 0) const noexcept;
@@ -3238,7 +3236,7 @@ Uses
 \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{find_first_of}%
+\indexlibrarymember{find_first_of}{basic_string}%
 \begin{itemdecl}
 size_type find_first_of(const basic_string& str,
                         size_type pos = 0) const noexcept;
@@ -3277,7 +3275,7 @@ elements of \tcode{charT}.
 \tcode{find_first_of(basic_string_view<charT, traits>(s), pos)}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{find_first_of}%
+\indexlibrarymember{find_first_of}{basic_string}%
 \begin{itemdecl}
 size_type find_first_of(charT c, size_type pos = 0) const;
 \end{itemdecl}
@@ -3290,7 +3288,7 @@ size_type find_first_of(charT c, size_type pos = 0) const;
 
 \rSec4[string::find.last.of]{\tcode{basic_string::find_last_of}}
 
-\indexlibrarymember{basic_string}{find_last_of}%
+\indexlibrarymember{find_last_of}{basic_string}%
 \begin{itemdecl}
 size_type find_last_of (basic_string_view<charT, traits> sv,
                         size_type pos = npos) const noexcept;
@@ -3325,7 +3323,7 @@ Uses
 \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{find_last_of}%
+\indexlibrarymember{find_last_of}{basic_string}%
 \begin{itemdecl}
 size_type find_last_of(const basic_string& str,
                        size_type pos = npos) const noexcept;
@@ -3363,7 +3361,7 @@ elements of \tcode{charT}.
 \tcode{find_last_of(basic_string_view<charT, traits>(s), pos)}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{find_last_of}%
+\indexlibrarymember{find_last_of}{basic_string}%
 \begin{itemdecl}
 size_type find_last_of(charT c, size_type pos = npos) const;
 \end{itemdecl}
@@ -3376,7 +3374,7 @@ size_type find_last_of(charT c, size_type pos = npos) const;
 
 \rSec4[string::find.first.not.of]{\tcode{basic_string::find_first_not_of}}
 
-\indexlibrarymember{basic_string}{find_first_not_of}%
+\indexlibrarymember{find_first_not_of}{basic_string}%
 \begin{itemdecl}
 size_type find_first_not_of(basic_string_view<charT, traits> sv,
                             size_type pos = 0) const noexcept;
@@ -3411,7 +3409,7 @@ Uses
 \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{find_first_not_of}%
+\indexlibrarymember{find_first_not_of}{basic_string}%
 \begin{itemdecl}
 size_type find_first_not_of(const basic_string& str,
                             size_type pos = 0) const noexcept;
@@ -3451,7 +3449,7 @@ elements of \tcode{charT}.
 \tcode{find_first_not_of(basic_string_view<charT, traits>(s), pos)}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{find_first_not_of}%
+\indexlibrarymember{find_first_not_of}{basic_string}%
 \begin{itemdecl}
 size_type find_first_not_of(charT c, size_type pos = 0) const;
 \end{itemdecl}
@@ -3464,7 +3462,7 @@ size_type find_first_not_of(charT c, size_type pos = 0) const;
 
 \rSec4[string::find.last.not.of]{\tcode{basic_string::find_last_not_of}}
 
-\indexlibrarymember{basic_string}{find_last_not_of}%
+\indexlibrarymember{find_last_not_of}{basic_string}%
 \begin{itemdecl}
 size_type find_last_not_of (basic_string_view<charT, traits> sv,
                             size_type pos = npos) const noexcept;
@@ -3499,7 +3497,7 @@ Uses
 \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{find_last_not_of}%
+\indexlibrarymember{find_last_not_of}{basic_string}%
 \begin{itemdecl}
 size_type find_last_not_of(const basic_string& str,
                            size_type pos = npos) const noexcept;
@@ -3539,7 +3537,7 @@ elements of \tcode{charT}.
 \tcode{find_last_not_of(basic_string_view<charT, traits>(s), pos)}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{find_last_not_of}%
+\indexlibrarymember{find_last_not_of}{basic_string}%
 \begin{itemdecl}
 size_type find_last_not_of(charT c, size_type pos = npos) const;
 \end{itemdecl}
@@ -3552,7 +3550,7 @@ size_type find_last_not_of(charT c, size_type pos = npos) const;
 
 \rSec4[string::substr]{\tcode{basic_string::substr}}
 
-\indexlibrarymember{basic_string}{substr}%
+\indexlibrarymember{substr}{basic_string}%
 \begin{itemdecl}
 basic_string substr(size_type pos = 0, size_type n = npos) const;
 \end{itemdecl}
@@ -3576,7 +3574,7 @@ Determines the effective length \tcode{rlen} of the string to copy as the smalle
 
 \rSec4[string::compare]{\tcode{basic_string::compare}}
 
-\indexlibrarymember{basic_string}{compare}%
+\indexlibrarymember{compare}{basic_string}%
 \begin{itemdecl}
 int compare(basic_string_view<charT, traits> sv) const noexcept;
 \end{itemdecl}
@@ -3639,7 +3637,7 @@ return basic_string_view<charT, traits>(this.data(), pos1, n1).compare(sv, pos2,
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{compare}%
+\indexlibrarymember{compare}{basic_string}%
 \begin{itemdecl}
 int compare(const basic_string& str) const noexcept;
 \end{itemdecl}
@@ -3718,7 +3716,7 @@ int compare(size_type pos, size_type n1,
 
 \rSec3[string::op+]{\tcode{operator+}}
 
-\indexlibrarymember{basic_string}{operator+}%
+\indexlibrarymember{operator+}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_string<charT, traits, Allocator>
@@ -3732,7 +3730,7 @@ template<class charT, class traits, class Allocator>
 \tcode{basic_string<charT, traits, Allocator>(lhs).append(rhs)}
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{operator+}%
+\indexlibrarymember{operator+}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_string<charT, traits, Allocator>
@@ -3746,7 +3744,7 @@ template<class charT, class traits, class Allocator>
 \tcode{std::move(lhs.append(rhs))}
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{operator+}%
+\indexlibrarymember{operator+}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_string<charT, traits, Allocator>
@@ -3760,7 +3758,7 @@ template<class charT, class traits, class Allocator>
 \tcode{std::move(rhs.insert(0, lhs))}
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{operator+}%
+\indexlibrarymember{operator+}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_string<charT, traits, Allocator>
@@ -3814,7 +3812,7 @@ Uses
 \tcode{traits::length()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{operator+}%
+\indexlibrarymember{operator+}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_string<charT, traits, Allocator>
@@ -3828,7 +3826,7 @@ template<class charT, class traits, class Allocator>
 \tcode{basic_string<charT, traits, Allocator>(1, lhs) + rhs}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{operator+}%
+\indexlibrarymember{operator+}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_string<charT, traits, Allocator>
@@ -3880,7 +3878,7 @@ Uses
 \tcode{traits::length()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{operator+}%
+\indexlibrarymember{operator+}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_string<charT, traits, Allocator>
@@ -3894,7 +3892,7 @@ template<class charT, class traits, class Allocator>
 \tcode{lhs + basic_string<charT, traits, Allocator>(1, rhs)}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string}{operator+}%
+\indexlibrarymember{operator+}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_string<charT, traits, Allocator>
@@ -3910,7 +3908,7 @@ template<class charT, class traits, class Allocator>
 
 \rSec3[string::operator==]{\tcode{operator==}}
 
-\indexlibrarymember{basic_string}{operator==}%
+\indexlibrarymember{operator==}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   bool operator==(const basic_string<charT, traits, Allocator>& lhs,
@@ -3953,10 +3951,9 @@ elements of \tcode{charT}.
 \tcode{lhs.compare(rhs) == 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{length}!\idxcode{char_traits}}%
 \rSec3[string::op!=]{\tcode{operator!=}}
 
-\indexlibrarymember{basic_string}{operator"!=}%
+\indexlibrarymember{operator"!=}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   bool operator!=(const basic_string<charT, traits, Allocator>& lhs,
@@ -3969,8 +3966,7 @@ template<class charT, class traits, class Allocator>
 \tcode{!(lhs == rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   bool operator!=(const charT* lhs,
@@ -3983,8 +3979,7 @@ template<class charT, class traits, class Allocator>
 \tcode{rhs != lhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{basic_string}}%
-\indexlibrary{\idxcode{basic_string}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   bool operator!=(const basic_string<charT, traits, Allocator>& lhs,
@@ -4003,7 +3998,7 @@ elements of \tcode{charT}.
 
 \rSec3[string::op<]{\tcode{operator<}}
 
-\indexlibrarymember{basic_string}{operator<}%
+\indexlibrarymember{operator<}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   bool operator< (const basic_string<charT, traits, Allocator>& lhs,
@@ -4167,7 +4162,7 @@ template<class charT, class traits, class Allocator>
 
 \rSec3[string.special]{\tcode{swap}}
 
-\indexlibrarymember{basic_string}{swap}%
+\indexlibrarymember{swap}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   void swap(basic_string<charT, traits, Allocator>& lhs,
@@ -4395,7 +4390,7 @@ for the return type.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{stof}}%
-\indexlibrary{\idxcode{stol}}%
+\indexlibrary{\idxcode{stod}}%
 \indexlibrary{\idxcode{stold}}%
 \begin{itemdecl}
 float stof(const string& str, size_t* idx = 0);
@@ -4549,7 +4544,10 @@ internal character buffer of sufficient size \tcode{buffsz}.
 
 \rSec2[basic.string.hash]{Hash support}
 
-\indexlibrary{\idxcode{hash}}%
+\indexlibrary{\idxcode{hash}!\idxcode{string}}%
+\indexlibrary{\idxcode{hash}!\idxcode{u16string}}%
+\indexlibrary{\idxcode{hash}!\idxcode{u32string}}%
+\indexlibrary{\idxcode{hash}!\idxcode{wstring}}%
 \begin{itemdecl}
 template<> struct hash<string>;
 template<> struct hash<u16string>;
@@ -4564,6 +4562,7 @@ template<> struct hash<wstring>;
 
 \rSec2[basic.string.literals]{Suffix for \tcode{basic_string} literals}
 
+\indexlibrarymember{operator """" s}{string}%
 \begin{itemdecl}
 string operator "" s(const char* str, size_t len);
 \end{itemdecl}
@@ -4574,6 +4573,7 @@ string operator "" s(const char* str, size_t len);
 \tcode{string\{str, len\}}.
 \end{itemdescr}
 
+\indexlibrarymember{operator """" s}{u16string}%
 \begin{itemdecl}
 u16string operator "" s(const char16_t* str, size_t len);
 \end{itemdecl}
@@ -4583,6 +4583,7 @@ u16string operator "" s(const char16_t* str, size_t len);
 \tcode{u16string\{str, len\}}.
 \end{itemdescr}
 
+\indexlibrarymember{operator """" s}{u32string}%
 \begin{itemdecl}
 u32string operator "" s(const char32_t* str, size_t len);
 \end{itemdecl}
@@ -4592,6 +4593,7 @@ u32string operator "" s(const char32_t* str, size_t len);
 \tcode{u32string\{str, len\}}.
 \end{itemdescr}
 
+\indexlibrarymember{operator """" s}{wstring}%
 \begin{itemdecl}
 wstring operator "" s(const wchar_t* str, size_t len);
 \end{itemdecl}
@@ -4799,6 +4801,7 @@ Constructs an empty \tcode{basic_string_view}.
 \tcode{size_ == 0} and \tcode{data_ == nullptr}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{basic_string_view}!constructor}%
 \begin{itemdecl}
 constexpr basic_string_view(const charT* str);
 \end{itemdecl}
@@ -4822,6 +4825,7 @@ in table~\ref{tab:string.view.ctr.2}.
 \bigoh{\tcode{traits::length(str)}}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{basic_string_view}!constructor}%
 \begin{itemdecl}
 constexpr basic_string_view(const charT* str, size_type len);
 \end{itemdecl}
@@ -4842,6 +4846,7 @@ Constructs a \tcode{basic_string_view}, with the postconditions in table~\ref{ta
 
 \rSec3[string.view.iterators]{Iterator support}
 
+\indexlibrarymember{const_iterator}{basic_string_view}%
 \begin{itemdecl}
 using const_iterator = @\impdefx{type of \tcode{basic_string_view::const_iterator}}@;
 \end{itemdecl}
@@ -4860,10 +4865,8 @@ For a \tcode{basic_string_view str}, any operation that invalidates a pointer in
 All requirements on container iterators (\ref{container.requirements}) apply to \tcode{basic_string_view::const_iterator} as well.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{begin}}%
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{cbegin}}%
-\indexlibrary{\idxcode{begin}!\idxcode{basic_string_view}}%
-\indexlibrary{\idxcode{cbegin}!\idxcode{basic_string_view}}%
+\indexlibrarymember{begin}{basic_string_view}%
+\indexlibrarymember{cbegin}{basic_string_view}%
 \begin{itemdecl}
 constexpr const_iterator begin() const noexcept;
 constexpr const_iterator cbegin() const noexcept;
@@ -4879,10 +4882,8 @@ An iterator such that
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{end}}%
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{cend}}%
-\indexlibrary{\idxcode{end}!\idxcode{basic_string_view}}%
-\indexlibrary{\idxcode{cend}!\idxcode{basic_string_view}}%
+\indexlibrarymember{end}{basic_string_view}%
+\indexlibrarymember{cend}{basic_string_view}%
 \begin{itemdecl}
 constexpr const_iterator end() const noexcept;
 constexpr const_iterator cend() const noexcept;
@@ -4894,10 +4895,8 @@ constexpr const_iterator cend() const noexcept;
 \tcode{begin() + size()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{rbegin}}%
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{crbegin}}%
-\indexlibrary{\idxcode{rbegin}!\idxcode{basic_string_view}}%
-\indexlibrary{\idxcode{crbegin}!\idxcode{basic_string_view}}%
+\indexlibrarymember{rbegin}{basic_string_view}%
+\indexlibrarymember{crbegin}{basic_string_view}%
 \begin{itemdecl}
 const_reverse_iterator rbegin() const noexcept;
 const_reverse_iterator crbegin() const noexcept;
@@ -4909,10 +4908,8 @@ const_reverse_iterator crbegin() const noexcept;
 \tcode{const_reverse_iterator(end())}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{rend}}%
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{crend}}%
-\indexlibrary{\idxcode{rend}!\idxcode{basic_string_view}}%
-\indexlibrary{\idxcode{crend}!\idxcode{basic_string_view}}%
+\indexlibrarymember{rend}{basic_string_view}%
+\indexlibrarymember{crend}{basic_string_view}%
 \begin{itemdecl}
 const_reverse_iterator rend() const noexcept;
 const_reverse_iterator crend() const noexcept;
@@ -4926,7 +4923,7 @@ const_reverse_iterator crend() const noexcept;
 
 \rSec3[string.view.capacity]{Capacity}
 
-\indexlibrarymember{basic_string_view}{size}%
+\indexlibrarymember{size}{basic_string_view}%
 \begin{itemdecl}
 constexpr size_type size() const noexcept;
 \end{itemdecl}
@@ -4937,7 +4934,7 @@ constexpr size_type size() const noexcept;
 \tcode{size_}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{length}%
+\indexlibrarymember{length}{basic_string_view}%
 \begin{itemdecl}
 constexpr size_type length() const noexcept;
 \end{itemdecl}
@@ -4948,7 +4945,7 @@ constexpr size_type length() const noexcept;
 \tcode{size_}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{max_size}%
+\indexlibrarymember{max_size}{basic_string_view}%
 \begin{itemdecl}
 constexpr size_type max_size() const noexcept;
 \end{itemdecl}
@@ -4959,7 +4956,7 @@ constexpr size_type max_size() const noexcept;
 The largest possible number of char-like objects that can be referred to by a \tcode{basic_string_view}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{empty}%
+\indexlibrarymember{empty}{basic_string_view}%
 \begin{itemdecl}
 constexpr bool empty() const noexcept;
 \end{itemdecl}
@@ -4972,7 +4969,7 @@ constexpr bool empty() const noexcept;
 
 \rSec3[string.view.access]{Element access}
 
-\indexlibrarymember{basic_string_view}{operator[]}%
+\indexlibrarymember{operator[]}{basic_string_view}%
 \begin{itemdecl}
 constexpr const_reference operator[](size_type pos) const;
 \end{itemdecl}
@@ -4997,7 +4994,7 @@ Unlike \tcode{basic_string::operator[]},
 \end{note}
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{at}%
+\indexlibrarymember{at}{basic_string_view}%
 \begin{itemdecl}
 constexpr const_reference at(size_type pos) const;
 \end{itemdecl}
@@ -5012,7 +5009,7 @@ constexpr const_reference at(size_type pos) const;
 \tcode{data_[pos]}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{front}%
+\indexlibrarymember{front}{basic_string_view}%
 \begin{itemdecl}
 constexpr const_reference front() const;
 \end{itemdecl}
@@ -5031,7 +5028,7 @@ constexpr const_reference front() const;
 Nothing.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{back}%
+\indexlibrarymember{back}{basic_string_view}%
 \begin{itemdecl}
 constexpr const_reference back() const;
 \end{itemdecl}
@@ -5050,7 +5047,7 @@ constexpr const_reference back() const;
 Nothing.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{data}%
+\indexlibrarymember{data}{basic_string_view}%
 \begin{itemdecl}
 constexpr const_pointer data() const noexcept;
 \end{itemdecl}
@@ -5070,7 +5067,7 @@ Therefore it is typically a mistake to pass \tcode{data()} to a routine that tak
 
 \rSec3[string.view.modifiers]{Modifiers}
 
-\indexlibrarymember{basic_string_view}{remove_prefix}%
+\indexlibrarymember{remove_prefix}{basic_string_view}%
 \begin{itemdecl}
 constexpr void remove_prefix(size_type n);
 \end{itemdecl}
@@ -5085,7 +5082,7 @@ constexpr void remove_prefix(size_type n);
 Equivalent to: \tcode{data_ += n; size_ -= n;}
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{remove_suffix}%
+\indexlibrarymember{remove_suffix}{basic_string_view}%
 \begin{itemdecl}
 constexpr void remove_suffix(size_type n);
 \end{itemdecl}
@@ -5100,7 +5097,7 @@ constexpr void remove_suffix(size_type n);
 Equivalent to: \tcode{size_ -= n;}
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{swap}%
+\indexlibrarymember{swap}{basic_string_view}%
 \begin{itemdecl}
 constexpr void swap(basic_string_view& s) noexcept;
 \end{itemdecl}
@@ -5113,7 +5110,7 @@ Exchanges the values of \tcode{*this} and \tcode{s}.
 
 \rSec3[string.view.ops]{String operations}
 
-\indexlibrarymember{basic_string_view}{copy}%
+\indexlibrarymember{copy}{basic_string_view}%
 \begin{itemdecl}
 size_type copy(charT* s, size_type n, size_type pos = 0) const;
 \end{itemdecl}
@@ -5143,7 +5140,7 @@ Equivalent to \tcode{copy_n(begin() + pos, rlen, s)}.
 \bigoh{\tcode{rlen}}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{substr}%
+\indexlibrarymember{substr}{basic_string_view}%
 \begin{itemdecl}
 constexpr basic_string_view substr(size_type pos = 0, size_type n = npos) const;
 \end{itemdecl}
@@ -5165,7 +5162,7 @@ Determines \tcode{rlen}, the effective length of the string to reference.
 \tcode{basic_string_view(data() + pos, rlen)}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{compare}%
+\indexlibrarymember{compare}{basic_string_view}%
 \begin{itemdecl}
 constexpr int compare(basic_string_view str) const noexcept;
 \end{itemdecl}
@@ -5194,6 +5191,7 @@ Otherwise, returns a value as indicated in Table~\ref{tab:string.view.compare}.
 \end{libtab2}
 \end{itemdescr}
 
+\indexlibrarymember{compare}{basic_string_view}%
 \begin{itemdecl}
 constexpr int compare(size_type pos1, size_type n1, basic_string_view str) const;
 \end{itemdecl}
@@ -5204,6 +5202,7 @@ constexpr int compare(size_type pos1, size_type n1, basic_string_view str) const
 Equivalent to: \tcode{return substr(pos1, n1).compare(str);}
 \end{itemdescr}
 
+\indexlibrarymember{compare}{basic_string_view}%
 \begin{itemdecl}
 constexpr int compare(size_type pos1, size_type n1, basic_string_view str,
                       size_type pos2, size_type n2) const;
@@ -5215,6 +5214,7 @@ constexpr int compare(size_type pos1, size_type n1, basic_string_view str,
 Equivalent to: \tcode{return substr(pos1, n1).compare(str.substr(pos2, n2));}
 \end{itemdescr}
 
+\indexlibrarymember{compare}{basic_string_view}%
 \begin{itemdecl}
 constexpr int compare(const charT* s) const;
 \end{itemdecl}
@@ -5225,6 +5225,7 @@ constexpr int compare(const charT* s) const;
 Equivalent to: \tcode{return compare(basic_string_view(s));}
 \end{itemdescr}
 
+\indexlibrarymember{compare}{basic_string_view}%
 \begin{itemdecl}
 constexpr int compare(size_type pos1, size_type n1, const charT* s) const;
 \end{itemdecl}
@@ -5235,6 +5236,7 @@ constexpr int compare(size_type pos1, size_type n1, const charT* s) const;
 Equivalent to: \tcode{return substr(pos1, n1).compare(basic_string_view(s));}
 \end{itemdescr}
 
+\indexlibrarymember{compare}{basic_string_view}%
 \begin{itemdecl}
 constexpr int compare(size_type pos1, size_type n1,
                       const charT* s, size_type n2) const;
@@ -5277,7 +5279,7 @@ constexpr @\placeholder{return-type}@ @\placeholder{F}@(charT c, size_type pos);
 \end{codeblock}
 is equivalent to \tcode{return \placeholder{F}(basic_string_view(\&c, 1), pos);}
 
-\indexlibrarymember{basic_string_view}{find}%
+\indexlibrarymember{find}{basic_string_view}%
 \begin{itemdecl}
 constexpr size_type find(basic_string_view str, size_type pos = 0) const noexcept;
 \end{itemdecl}
@@ -5308,7 +5310,7 @@ Otherwise, returns \tcode{npos}.
 Uses \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{rfind}%
+\indexlibrarymember{rfind}{basic_string_view}%
 \begin{itemdecl}
 constexpr size_type rfind(basic_string_view str, size_type pos = npos) const noexcept;
 \end{itemdecl}
@@ -5339,7 +5341,7 @@ Otherwise, returns \tcode{npos}.
 Uses \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{find_first_of}%
+\indexlibrarymember{find_first_of}{basic_string_view}%
 \begin{itemdecl}
 constexpr size_type find_first_of(basic_string_view str, size_type pos = 0) const noexcept;
 \end{itemdecl}
@@ -5370,7 +5372,7 @@ Otherwise, returns \tcode{npos}.
 Uses \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{find_last_of}%
+\indexlibrarymember{find_last_of}{basic_string_view}%
 \begin{itemdecl}
 constexpr size_type find_last_of(basic_string_view str, size_type pos = npos) const noexcept;
 \end{itemdecl}
@@ -5401,7 +5403,7 @@ Otherwise, returns \tcode{npos}.
 Uses \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{find_first_not_of}%
+\indexlibrarymember{find_first_not_of}{basic_string_view}%
 \begin{itemdecl}
 constexpr size_type find_first_not_of(basic_string_view str, size_type pos = 0) const noexcept;
 \end{itemdecl}
@@ -5431,7 +5433,7 @@ Determines \tcode{xpos}.
 Uses \tcode{traits::eq()}.
 \end{itemdescr}
 
-\indexlibrarymember{basic_string_view}{find_last_not_of}%
+\indexlibrarymember{find_last_not_of}{basic_string_view}%
 \begin{itemdecl}
 constexpr size_type find_last_not_of(basic_string_view str, size_type pos = npos) const noexcept;
 \end{itemdecl}
@@ -5517,8 +5519,7 @@ template<class charT, class traits>
 \tcode{lhs.compare(rhs) == 0}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{basic_string_view}}%
-\indexlibrary{\idxcode{basic_string_view}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{basic_string_view}%
 \begin{itemdecl}
 template<class charT, class traits>
   constexpr bool operator!=(basic_string_view<charT, traits> lhs,
@@ -5601,7 +5602,10 @@ Equivalent to: \tcode{return os << str.to_string();}
 
 \rSec2[string.view.hash]{Hash support}
 
-\indexlibrary{\idxcode{hash}!\idxcode{basic_string_view}}%
+\indexlibrary{\idxcode{hash}!\idxcode{string_view}}%
+\indexlibrary{\idxcode{hash}!\idxcode{u16string_view}}%
+\indexlibrary{\idxcode{hash}!\idxcode{u32string_view}}%
+\indexlibrary{\idxcode{hash}!\idxcode{wstring_view}}%
 \begin{itemdecl}
 template<> struct hash<string_view>;
 template<> struct hash<u16string_view>;

--- a/source/support.tex
+++ b/source/support.tex
@@ -1282,7 +1282,7 @@ duration and without calling functions passed to
 \indexlibrary{\idxcode{atexit}}%
 \end{itemdescr}
 
-\indexlibrary{\idxcode{atexit}}
+\indexlibrary{\idxcode{atexit}}%
 \begin{itemdecl}
 extern "C" int atexit(void (*f)()) noexcept;
 extern "C++" int atexit(void (*f)()) noexcept;
@@ -1341,7 +1341,7 @@ by throwing an exception that is caught in
 
 If control leaves a registered function called by \tcode{exit} because the function does
 not provide a handler for a thrown exception, \tcode{std::terminate()} shall be called~(\ref{except.terminate}).%
-\indexlibrary{\idxcode{terminate}}
+\indexlibrary{\idxcode{terminate}}%
 
 \item
 Next, all open C streams (as mediated by the function
@@ -1377,7 +1377,7 @@ are defined in
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{at_quick_exit}}
+\indexlibrary{\idxcode{at_quick_exit}}%
 \begin{itemdecl}
 extern "C" int at_quick_exit(void (*f)()) noexcept;
 extern "C++" int at_quick_exit(void (*f)()) noexcept;
@@ -1408,7 +1408,7 @@ The implementation shall support the registration of at least 32 functions.
 \returns Zero if the registration succeeds, non-zero if it fails.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{quick_exit}}
+\indexlibrary{\idxcode{quick_exit}}%
 \begin{itemdecl}
 [[noreturn]] void quick_exit(int status) noexcept;
 \end{itemdecl}
@@ -1421,13 +1421,16 @@ previously registered functions that had already been called at the time it was
 registered. Objects shall not be destroyed as a result of calling \tcode{quick_exit}.
 If control leaves a registered function called by \tcode{quick_exit} because the
 function does not provide a handler for a thrown exception, \tcode{std::terminate()} shall
-be called.%
-\indexlibrary{\idxcode{terminate}}
-\begin{note} \tcode{at_quick_exit} may call a registered function from a different thread
+be called.\indexlibrary{\idxcode{terminate}}
+\begin{note}
+\tcode{at_quick_exit} may call a registered function from a different thread
 than the one that registered it, so registered functions should not rely on the identity
-of objects with thread storage duration. \end{note}
+of objects with thread storage duration.
+\end{note}
 After calling registered functions, \tcode{quick_exit} shall call \tcode{_Exit(status)}.
-\begin{note} The standard file buffers are not flushed. \xsee ISO C~7.22.4.5. \end{note}
+\begin{note}
+The standard file buffers are not flushed. \xsee ISO C~7.22.4.5.
+\end{note}
 
 \end{itemdescr}
 
@@ -2172,7 +2175,7 @@ Constructs an object of class
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bad_alloc}!constructor}%
-\indexlibrary{\idxcode{operator=}!\idxcode{bad_alloc}}%
+\indexlibrarymember{operator=}{bad_alloc}%
 \begin{itemdecl}
 bad_alloc(const bad_alloc&) noexcept;
 bad_alloc& operator=(const bad_alloc&) noexcept;
@@ -2231,7 +2234,7 @@ bad_array_new_length() noexcept;
 \effects constructs an object of class \tcode{bad_array_new_length}.
 \end{itemdescr}
 
-\indexlibrarymember{bad_array_new_length}{what}%
+\indexlibrarymember{what}{bad_array_new_length}%
 \begin{itemdecl}
 const char* what() const noexcept override;
 \end{itemdecl}
@@ -2503,8 +2506,7 @@ Compares the current object with \tcode{rhs}.
 if the two values describe the same type.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{type_info}}%
-\indexlibrary{\idxcode{type_info}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{type_info}%
 \begin{itemdecl}
 bool operator!=(const type_info& rhs) const noexcept;
 \end{itemdecl}
@@ -2550,7 +2552,7 @@ objects which compare equal.
 \end{itemdescr}
 
 
-\indexlibrarymember{type_info}{name}%
+\indexlibrarymember{name}{type_info}%
 \begin{itemdecl}
 const char* name() const noexcept;
 \end{itemdecl}
@@ -2604,7 +2606,7 @@ Constructs an object of class
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bad_cast}!constructor}%
-\indexlibrary{\idxcode{operator=}!\idxcode{bad_cast}}%
+\indexlibrarymember{operator=}{bad_cast}%
 \begin{itemdecl}
 bad_cast(const bad_cast&) noexcept;
 bad_cast& operator=(const bad_cast&) noexcept;
@@ -2617,7 +2619,7 @@ Copies an object of class
 \tcode{bad_cast}.
 \end{itemdescr}
 
-\indexlibrarymember{bad_cast}{what}%
+\indexlibrarymember{what}{bad_cast}%
 \begin{itemdecl}
 const char* what() const noexcept override;
 \end{itemdecl}
@@ -2671,7 +2673,7 @@ Constructs an object of class
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bad_typeid}!constructor}%
-\indexlibrary{\idxcode{operator=}!\idxcode{bad_typeid}}%
+\indexlibrarymember{operator=}{bad_typeid}%
 \begin{itemdecl}
 bad_typeid(const bad_typeid&) noexcept;
 bad_typeid& operator=(const bad_typeid&) noexcept;
@@ -2684,7 +2686,7 @@ Copies an object of class
 \tcode{bad_typeid}.
 \end{itemdescr}
 
-\indexlibrarymember{bad_typeid}{what}%
+\indexlibrarymember{what}{bad_typeid}%
 \begin{itemdecl}
 const char* what() const noexcept override;
 \end{itemdecl}
@@ -2790,7 +2792,7 @@ Constructs an object of class
 \end{itemdescr}
 
 \indexlibrary{\idxcode{exception}!constructor}%
-\indexlibrary{\idxcode{operator=}!\idxcode{exception}}%
+\indexlibrarymember{operator=}{exception}%
 \begin{itemdecl}
 exception(const exception& rhs) noexcept;
 exception& operator=(const exception& rhs) noexcept;
@@ -2820,7 +2822,7 @@ Destroys an object of class
 \tcode{exception}.
 \end{itemdescr}
 
-\indexlibrarymember{exception}{what}%
+\indexlibrarymember{what}{exception}%
 \begin{itemdecl}
 virtual const char* what() const noexcept;
 \end{itemdecl}
@@ -2874,7 +2876,7 @@ Constructs an object of class
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bad_exception}!constructor}%
-\indexlibrary{\idxcode{operator=}!\idxcode{bad_exception}}%
+\indexlibrarymember{operator=}{bad_exception}%
 \begin{itemdecl}
 bad_exception(const bad_exception&) noexcept;
 bad_exception& operator=(const bad_exception&) noexcept;
@@ -2887,7 +2889,7 @@ Copies an object of class
 \tcode{bad_exception}.
 \end{itemdescr}
 
-\indexlibrarymember{bad_exception}{what}%
+\indexlibrarymember{what}{bad_exception}%
 \begin{itemdecl}
 const char* what() const noexcept override;
 \end{itemdecl}
@@ -2931,7 +2933,7 @@ terminate execution of the program without returning to the caller.
 \default
 The implementation's default \tcode{terminate_handler} calls
 \tcode{abort()}.%
-\indexlibrary{\idxcode{abort}}
+\indexlibrary{\idxcode{abort}}%
 \end{itemdescr}
 
 \rSec3[set.terminate]{\tcode{set_terminate}}
@@ -3014,7 +3016,7 @@ throwing an exception can result in a call of\\
 
 \rSec2[propagation]{Exception propagation}
 
-\indexlibrary{\idxcode{exception_ptr}}
+\indexlibrary{\idxcode{exception_ptr}}%
 \begin{itemdecl}
 using exception_ptr = @\unspec@;
 \end{itemdecl}
@@ -3055,7 +3057,7 @@ Changes in the number of \tcode{exception_ptr} objects that refer to a
 particular exception do not introduce a data race. \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{current_exception}}
+\indexlibrary{\idxcode{current_exception}}%
 \begin{itemdecl}
 exception_ptr current_exception() noexcept;
 \end{itemdecl}
@@ -3081,7 +3083,7 @@ to substitute a \tcode{bad_exception} object to avoid infinite
 recursion.\end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{rethrow_exception}}
+\indexlibrary{\idxcode{rethrow_exception}}%
 \begin{itemdecl}
 [[noreturn]] void rethrow_exception(exception_ptr p);
 \end{itemdecl}
@@ -3094,7 +3096,7 @@ recursion.\end{note}
 \throws the exception object to which \tcode{p} refers.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{make_exception_ptr}}
+\indexlibrary{\idxcode{make_exception_ptr}}%
 \begin{itemdecl}
 template<class E> exception_ptr make_exception_ptr(E e) noexcept;
 \end{itemdecl}
@@ -3147,7 +3149,7 @@ for later use.
 polymorphic class. Its presence can be tested for with \tcode{dynamic_cast}.
 \end{note}
 
-\indexlibrary{\idxcode{nested_exception}!constructor}
+\indexlibrary{\idxcode{nested_exception}!constructor}%
 \begin{itemdecl}
 nested_exception() noexcept;
 \end{itemdecl}
@@ -3269,7 +3271,7 @@ If an explicit specialization or partial specialization of
 
 \rSec2[support.initlist.cons]{Initializer list constructors}
 
-\indexlibrary{\idxcode{initializer_list}!constructor}
+\indexlibrary{\idxcode{initializer_list}!constructor}%
 \begin{itemdecl}
 constexpr initializer_list() noexcept;
 \end{itemdecl}
@@ -3321,7 +3323,7 @@ constexpr size_t size() const noexcept;
 
 \rSec2[support.initlist.range]{Initializer list range access}
 
-\indexlibrary{\idxcode{begin(initializer_list<E>)}}
+\indexlibrary{\idxcode{begin(initializer_list<E>)}}%
 \begin{itemdecl}
 template<class E> constexpr const E* begin(initializer_list<E> il) noexcept;
 \end{itemdecl}
@@ -3331,7 +3333,7 @@ template<class E> constexpr const E* begin(initializer_list<E> il) noexcept;
 \returns \tcode{il.begin()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{end(initializer_list<E>)}}
+\indexlibrary{\idxcode{end(initializer_list<E>)}}%
 \begin{itemdecl}
 template<class E> constexpr const E* end(initializer_list<E> il) noexcept;
 \end{itemdecl}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -311,6 +311,7 @@ for all \tcode{i} in the range \range{0}{N}.
 
 \rSec2[utility.exchange]{exchange}
 
+\indexlibrary{\idxcode{exchange}}%
 \begin{itemdecl}
 template <class T, class U=T> T exchange(T& obj, U&& new_val);
 \end{itemdecl}
@@ -620,7 +621,7 @@ be a \tcode{constexpr} function if and only if all required element-wise
 initializations for copy and move, respectively, would satisfy the
 requirements for a \tcode{constexpr} function.
 
-\indexlibrary{\idxcode{pair}!constructor}
+\indexlibrary{\idxcode{pair}!constructor}%
 \begin{itemdecl}
 constexpr pair();
 \end{itemdecl}
@@ -639,7 +640,7 @@ This constructor shall not participate in overload resolution unless
 with default template arguments. \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pair}!constructor}
+\indexlibrary{\idxcode{pair}!constructor}%
 \begin{itemdecl}
 @\EXPLICIT@ constexpr pair(const T1& x, const T2& y);
 \end{itemdecl}
@@ -659,7 +660,7 @@ The constructor is explicit if and only if
 \tcode{is_convertible_v<const second_type\&, second_type>} is \tcode{false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pair}!constructor}
+\indexlibrary{\idxcode{pair}!constructor}%
 \begin{itemdecl}
 template<class U, class V> @\EXPLICIT@ constexpr pair(U&& x, V&& y);
 \end{itemdecl}
@@ -681,7 +682,7 @@ The constructor is explicit if and only if
 \tcode{is_convertible_v<V\&\&, second_type>} is \tcode{false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pair}!constructor}
+\indexlibrary{\idxcode{pair}!constructor}%
 \begin{itemdecl}
 template<class U, class V> @\EXPLICIT@ constexpr pair(const pair<U, V>& p);
 \end{itemdecl}
@@ -700,7 +701,7 @@ The constructor is explicit if and only if
 \tcode{is_convertible_v<const V\&, second_type>} is \tcode{false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pair}!constructor}
+\indexlibrary{\idxcode{pair}!constructor}%
 \begin{itemdecl}
 template<class U, class V> @\EXPLICIT@ constexpr pair(pair<U, V>&& p);
 \end{itemdecl}
@@ -722,7 +723,7 @@ The constructor is explicit if and only if
 \tcode{is_convertible_v<V\&\&, second_type>} is \tcode{false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pair}!constructor}
+\indexlibrary{\idxcode{pair}!constructor}%
 \begin{itemdecl}
 template<class... Args1, class... Args2>
   pair(piecewise_construct_t,
@@ -851,7 +852,7 @@ is_nothrow_swappable_v<second_type>
 
 \rSec2[pairs.spec]{Specialized algorithms}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{pair}}%
+\indexlibrarymember{operator==}{pair}%
 \begin{itemdecl}
 template <class T1, class T2>
   constexpr bool operator==(const pair<T1, T2>& x, const pair<T1, T2>& y);
@@ -863,7 +864,7 @@ template <class T1, class T2>
 \tcode{x.first == y.first \&\& x.second == y.second}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{pair}}%
+\indexlibrarymember{operator<}{pair}%
 \begin{itemdecl}
 template <class T1, class T2>
   constexpr bool operator<(const pair<T1, T2>& x, const pair<T1, T2>& y);
@@ -875,7 +876,7 @@ template <class T1, class T2>
 \tcode{x.first < y.first || (!(y.first < x.first) \&\& x.second < y.second)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{pair}}%
+\indexlibrarymember{operator"!=}{pair}%
 \begin{itemdecl}
 template <class T1, class T2>
   constexpr bool operator!=(const pair<T1, T2>& x, const pair<T1, T2>& y);
@@ -886,7 +887,7 @@ template <class T1, class T2>
 \returns \tcode{!(x == y)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>}!\idxcode{pair}}%
+\indexlibrarymember{operator>}{pair}%
 \begin{itemdecl}
 template <class T1, class T2>
   constexpr bool operator>(const pair<T1, T2>& x, const pair<T1, T2>& y);
@@ -897,7 +898,7 @@ template <class T1, class T2>
 \returns \tcode{y < x}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{pair}}%
+\indexlibrarymember{operator>=}{pair}%
 \begin{itemdecl}
 template <class T1, class T2>
   constexpr bool operator>=(const pair<T1, T2>& x, const pair<T1, T2>& y);
@@ -908,7 +909,7 @@ template <class T1, class T2>
 \returns \tcode{!(x < y)}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{pair}}%
+\indexlibrarymember{operator<=}{pair}%
 \begin{itemdecl}
 template <class T1, class T2>
   constexpr bool operator<=(const pair<T1, T2>& x, const pair<T1, T2>& y);
@@ -993,7 +994,7 @@ tuple_element<1, pair<T1, T2>>::type
 \pnum\textit{Value:} the type T2.
 \end{itemdescr}
 
-\indexlibrarymember{pair}{get}%
+\indexlibrarymember{get}{pair}%
 \begin{itemdecl}
 template<size_t I, class T1, class T2>
   constexpr tuple_element_t<I, pair<T1, T2>>&
@@ -1016,7 +1017,7 @@ if \tcode{I == 1} returns a reference to \tcode{p.second};
 otherwise the program is ill-formed.
 \end{itemdescr}
 
-\indexlibrarymember{pair}{get}%
+\indexlibrarymember{get}{pair}%
 \begin{itemdecl}
 template <class T, class U>
   constexpr T& get(pair<T, U>& p) noexcept;
@@ -1035,7 +1036,7 @@ template <class T, class U>
 \returns A reference to \tcode{p.first}.
 \end{itemdescr}
 
-\indexlibrarymember{pair}{get}%
+\indexlibrarymember{get}{pair}%
 \begin{itemdecl}
 template <class T, class U>
   constexpr T& get(pair<U, T>& p) noexcept;
@@ -1500,7 +1501,7 @@ In the function descriptions that follow, let $i$ be in the range \range{0}{size
 in order, $T_i$ be the $i^{th}$ type in \tcode{Types}, and $U_i$ be the $i^{th}$ type in a
 template parameter pack named \tcode{UTypes}, where indexing is zero-based.
 
-\indexlibrarymember{tuple}{operator=}%
+\indexlibrarymember{operator=}{tuple}%
 \begin{itemdecl}
 tuple& operator=(const tuple& u);
 \end{itemdecl}
@@ -1517,7 +1518,7 @@ element of \tcode{*this}.
 \returns  \tcode{*this}
 \end{itemdescr}
 
-\indexlibrarymember{tuple}{operator=}%
+\indexlibrarymember{operator=}{tuple}%
 \begin{itemdecl}
 tuple& operator=(tuple&& u) noexcept(@\seebelow@);
 \end{itemdecl}
@@ -1544,7 +1545,7 @@ where $T_i$ is the $i^{th}$ type in \tcode{Types}.
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{tuple}{operator=}%
+\indexlibrarymember{operator=}{tuple}%
 \begin{itemdecl}
 template <class... UTypes>
   tuple& operator=(const tuple<UTypes...>& u);
@@ -1564,7 +1565,7 @@ of \tcode{*this}.
 \returns  \tcode{*this}
 \end{itemdescr}
 
-\indexlibrarymember{tuple}{operator=}%
+\indexlibrarymember{operator=}{tuple}%
 \begin{itemdecl}
 template <class... UTypes>
   tuple& operator=(tuple<UTypes...>&& u);
@@ -1584,7 +1585,7 @@ template <class... UTypes>
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{tuple}{operator=}%
+\indexlibrarymember{operator=}{tuple}%
 \indexlibrary{\idxcode{pair}}%
 \begin{itemdecl}
 template <class U1, class U2> tuple& operator=(const pair<U1, U2>& u);
@@ -1605,7 +1606,7 @@ and \tcode{u.second} to the second element of \tcode{*this}.
 \returns  \tcode{*this}
 \end{itemdescr}
 
-\indexlibrarymember{tuple}{operator=}%
+\indexlibrarymember{operator=}{tuple}%
 \indexlibrary{\idxcode{pair}}%
 \begin{itemdecl}
 template <class U1, class U2> tuple& operator=(pair<U1, U2>&& u);
@@ -1881,6 +1882,7 @@ type of the \tcode{I}th element of \tcode{Types},
 where indexing is zero-based.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{tuple_size}}%
 \begin{itemdecl}
 template <class T> class tuple_size<const T>;
 template <class T> class tuple_size<volatile T>;
@@ -1902,6 +1904,7 @@ the three templates are available when either of the headers \tcode{<array>} or
 \tcode{<utility>} are included.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{tuple_element}}%
 \begin{itemdecl}
 template <size_t I, class T> class tuple_element<I, const T>;
 template <size_t I, class T> class tuple_element<I, volatile T>;
@@ -1932,7 +1935,7 @@ the three templates are available when either of the headers \tcode{<array>} or
 
 \rSec3[tuple.elem]{Element access}
 
-\indexlibrarymember{tuple}{get}%
+\indexlibrarymember{get}{tuple}%
 \begin{itemdecl}
 template <size_t I, class... Types>
   constexpr tuple_element_t<I, tuple<Types...>>& get(tuple<Types...>& t) noexcept;
@@ -1973,7 +1976,7 @@ for member variables of reference type.
 \end{note}
 \end{itemdescr}
 
-\indexlibrarymember{tuple}{get}%
+\indexlibrarymember{get}{tuple}%
 \begin{itemdecl}
 template <class T, class... Types>
   constexpr T& get(tuple<Types...>& t) noexcept;
@@ -2014,7 +2017,7 @@ the \tcode{template} keyword. \end{note}
 
 \rSec3[tuple.rel]{Relational operators}
 
-\indexlibrarymember{tuple}{operator==}%
+\indexlibrarymember{operator==}{tuple}%
 \begin{itemdecl}
 template<class... TTypes, class... UTypes>
   constexpr bool operator==(const tuple<TTypes...>& t, const tuple<UTypes...>& u);
@@ -2041,7 +2044,7 @@ performed after the first equality comparison that evaluates to
 \tcode{false}.
 \end{itemdescr}
 
-\indexlibrarymember{tuple}{operator<}%
+\indexlibrarymember{operator<}{tuple}%
 \begin{itemdecl}
 template<class... TTypes, class... UTypes>
   constexpr bool operator<(const tuple<TTypes...>& t, const tuple<UTypes...>& u);
@@ -2068,7 +2071,7 @@ of \tcode{r}.  For any two zero-length tuples \tcode{e}
 and \tcode{f}, \tcode{e < f} returns \tcode{false}.
 \end{itemdescr}
 
-\indexlibrarymember{tuple}{operator"!=}%
+\indexlibrarymember{operator"!=}{tuple}%
 \begin{itemdecl}
 template<class... TTypes, class... UTypes>
   constexpr bool operator!=(const tuple<TTypes...>& t, const tuple<UTypes...>& u);
@@ -2077,7 +2080,7 @@ template<class... TTypes, class... UTypes>
 \pnum\returns \tcode{!(t == u)}.
 \end{itemdescr}
 
-\indexlibrarymember{tuple}{operator>}%
+\indexlibrarymember{operator>}{tuple}%
 \begin{itemdecl}
 template<class... TTypes, class... UTypes>
   constexpr bool operator>(const tuple<TTypes...>& t, const tuple<UTypes...>& u);
@@ -2086,7 +2089,7 @@ template<class... TTypes, class... UTypes>
 \pnum\returns \tcode{u < t}.
 \end{itemdescr}
 
-\indexlibrarymember{tuple}{operator<=}%
+\indexlibrarymember{operator<=}{tuple}%
 \begin{itemdecl}
 template<class... TTypes, class... UTypes>
   constexpr bool operator<=(const tuple<TTypes...>& t, const tuple<UTypes...>& u);
@@ -2095,7 +2098,7 @@ template<class... TTypes, class... UTypes>
 \pnum\returns \tcode{!(u < t)}
 \end{itemdescr}
 
-\indexlibrarymember{tuple}{operator>=}%
+\indexlibrarymember{operator>=}{tuple}%
 \begin{itemdecl}
 template<class... TTypes, class... UTypes>
   constexpr bool operator>=(const tuple<TTypes...>& t, const tuple<UTypes...>& u);
@@ -2115,7 +2118,7 @@ result of the comparison. \end{note}
 
 \rSec3[tuple.traits]{Tuple traits}
 
-\indexlibrary{\idxcode{uses_allocator<tuple>}}
+\indexlibrary{\idxcode{uses_allocator<tuple>}}%
 \begin{itemdecl}
 template <class... Types, class Alloc>
   struct uses_allocator<tuple<Types...>, Alloc> : true_type { };
@@ -2337,6 +2340,7 @@ No contained value is initialized.
 For every object type \tcode{T} these constructors shall be \tcode{constexpr} constructors (\ref{dcl.constexpr}).
 \end{itemdescr}
 
+\indexlibrary{\idxcode{optional}!constructor}%
 \begin{itemdecl}
 optional(const optional<T>& rhs);
 \end{itemdecl}
@@ -2360,6 +2364,7 @@ direct-non-list-initializing an object of type \tcode{T} with the expression \tc
 Any exception thrown by the selected constructor of \tcode{T}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{optional}!constructor}%
 \begin{itemdecl}
 optional(optional<T>&& rhs) noexcept(@\seebelow@);
 \end{itemdecl}
@@ -2389,6 +2394,7 @@ The expression inside \tcode{noexcept} is equivalent to
 \tcode{is_nothrow_move_constructible_v<T>}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{optional}!constructor}%
 \begin{itemdecl}
 constexpr optional(const T& v);
 \end{itemdecl}
@@ -2415,6 +2421,7 @@ Any exception thrown by the selected constructor of \tcode{T}.
 If \tcode{T}'s selected constructor is a \tcode{constexpr} constructor, this constructor shall be a \tcode{constexpr} constructor.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{optional}!constructor}%
 \begin{itemdecl}
 constexpr optional(T&& v);
 \end{itemdecl}
@@ -2441,6 +2448,7 @@ Any exception thrown by the selected constructor of \tcode{T}.
 If \tcode{T}'s selected constructor is a \tcode{constexpr} constructor, this constructor shall be a \tcode{constexpr} constructor.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{optional}!constructor}%
 \begin{itemdecl}
 template <class... Args> constexpr explicit optional(in_place_t, Args&&... args);
 \end{itemdecl}
@@ -2467,6 +2475,7 @@ Any exception thrown by the selected constructor of \tcode{T}.
 If \tcode{T}'s constructor selected for the initialization is a \tcode{constexpr} constructor, this constructor shall be a \tcode{constexpr} constructor.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{optional}!constructor}%
 \begin{itemdecl}
 template <class U, class... Args>
   constexpr explicit optional(in_place_t, initializer_list<U> il, Args&&... args);
@@ -2515,7 +2524,7 @@ If \tcode{is_trivially_destructible_v<T> == true} then this destructor shall be 
 
 \rSec3[optional.object.assign]{Assignment}
 
-\indexlibrarymember{optional}{operator=}%
+\indexlibrarymember{operator=}{optional}%
 \begin{itemdecl}
 optional<T>& operator=(nullopt_t) noexcept;
 \end{itemdecl}
@@ -2534,6 +2543,7 @@ If \tcode{*this} contains a value, calls \tcode{val->T::\~T()} to destroy the co
 \tcode{*this} does not contain a value.
 \end{itemdescr}
 
+\indexlibrarymember{operator=}{optional}%
 \begin{itemdecl}
 optional<T>& operator=(const optional<T>& rhs);
 \end{itemdecl}
@@ -2576,6 +2586,7 @@ If an exception is thrown during the call to \tcode{T}'s copy assignment,
 the state of its contained value is as defined by the exception safety guarantee of \tcode{T}'s copy assignment.
 \end{itemdescr}
 
+\indexlibrarymember{operator=}{optional}%
 \begin{itemdecl}
 optional<T>& operator=(optional<T>&& rhs) noexcept(@\seebelow@);
 \end{itemdecl}
@@ -2626,6 +2637,7 @@ If an exception is thrown during the call to \tcode{T}'s move assignment,
 the state of \tcode{*val} and \tcode{*rhs.val} is determined by the exception safety guarantee of \tcode{T}'s move assignment.
 \end{itemdescr}
 
+\indexlibrarymember{operator=}{optional}%
 \begin{itemdecl}
 template <class U> optional<T>& operator=(U&& v);
 \end{itemdecl}
@@ -2685,6 +2697,7 @@ Any exception thrown by the selected constructor of \tcode{T}.
 If an exception is thrown during the call to \tcode{T}'s constructor, \tcode{*this} does not contain a value, and the previous \tcode{*val} (if any) has been destroyed.
 \end{itemdescr}
 
+\indexlibrarymember{emplace}{optional}%
 \begin{itemdecl}
 template <class U, class... Args> void emplace(initializer_list<U> il, Args&&... args);
 \end{itemdecl}
@@ -2710,7 +2723,7 @@ This function shall not participate in overload resolution unless \tcode{is_cons
 
 \rSec3[optional.object.swap]{Swap}
 
-\indexlibrarymember{optional}{swap}%
+\indexlibrarymember{swap}{optional}%
 \begin{itemdecl}
 void swap(optional<T>& rhs) noexcept(@\seebelow@);
 \end{itemdecl}
@@ -2762,7 +2775,7 @@ the state of \tcode{*val} and \tcode{*rhs.val} is determined by the exception sa
 
 \rSec3[optional.object.observe]{Observers}
 
-\indexlibrarymember{optional}{operator->}%
+\indexlibrarymember{operator->}{optional}%
 \begin{itemdecl}
 constexpr T const* operator->() const;
 constexpr T* operator->();
@@ -2786,7 +2799,7 @@ Nothing.
 Unless \tcode{T} is a user-defined type with overloaded unary \tcode{operator\&}, these functions shall be \tcode{constexpr} functions.
 \end{itemdescr}
 
-\indexlibrarymember{optional}{operator*}%
+\indexlibrarymember{operator*}{optional}%
 \begin{itemdecl}
 constexpr T const& operator*() const &;
 constexpr T& operator*() &;
@@ -2810,6 +2823,7 @@ Nothing.
 These functions shall be \tcode{constexpr} functions.
 \end{itemdescr}
 
+\indexlibrarymember{operator*}{optional}%
 \begin{itemdecl}
 constexpr T&& operator*() &&;
 constexpr const T&& operator*() const &&;
@@ -2825,7 +2839,7 @@ constexpr const T&& operator*() const &&;
 Equivalent to: \tcode{return std::move(*val);}
 \end{itemdescr}
 
-\indexlibrarymember{optional}{operator bool}%
+\indexlibrarymember{operator bool}{optional}%
 \begin{itemdecl}
 constexpr explicit operator bool() const noexcept;
 \end{itemdecl}
@@ -2840,6 +2854,7 @@ constexpr explicit operator bool() const noexcept;
 This function shall be a \tcode{constexpr} function.
 \end{itemdescr}
 
+\indexlibrarymember{has_value}{optional}%
 \begin{itemdecl}
 constexpr bool has_value() const noexcept;
 \end{itemdecl}
@@ -2852,7 +2867,7 @@ constexpr bool has_value() const noexcept;
 \remarks This function shall be a \tcode{constexpr} function.
 \end{itemdescr}
 
-\indexlibrarymember{optional}{value}%
+\indexlibrarymember{value}{optional}%
 \begin{itemdecl}
 constexpr T const& value() const &;
 constexpr T& value() &;
@@ -2867,6 +2882,7 @@ return bool(*this) ? *val : throw bad_optional_access();
 \end{codeblock}
 \end{itemdescr}
 
+\indexlibrarymember{value}{optional}%
 \begin{itemdecl}
 constexpr T&& value() &&;
 constexpr const T&& value() const &&;
@@ -2882,7 +2898,7 @@ return bool(*this) ? std::move(*val) : throw bad_optional_access();
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{optional}{value_or}%
+\indexlibrarymember{value_or}{optional}%
 \begin{itemdecl}
 template <class U> constexpr T value_or(U&& v) const &;
 \end{itemdecl}
@@ -2901,6 +2917,7 @@ If \tcode{is_copy_constructible_v<T> \&\& is_convertible_v<U\&\&, T>} is \tcode{
 the program is ill-formed.
 \end{itemdescr}
 
+\indexlibrarymember{value_or}{optional}%
 \begin{itemdecl}
 template <class U> constexpr T value_or(U&& v) &&;
 \end{itemdecl}
@@ -2921,6 +2938,7 @@ the program is ill-formed.
 
 \rSec3[optional.object.mod]{Modifiers}
 
+\indexlibrarymember{reset}{optional}%
 \begin{itemdecl}
 void reset() noexcept;
 \end{itemdecl}
@@ -2966,7 +2984,7 @@ public:
 The class \tcode{bad_optional_access} defines the type of objects thrown as exceptions to report the situation where an attempt is made to access the value of an optional object that does not contain a value.
 
 \indexlibrary{\idxcode{bad_optional_access}!constructor}%
-\indexlibrarymember{bad_optional_access}{what}%
+\indexlibrarymember{what}{bad_optional_access}%
 \begin{itemdecl}
 bad_optional_access();
 \end{itemdecl}
@@ -2985,7 +3003,7 @@ Constructs an object of class \tcode{bad_optional_access}.
 
 \rSec2[optional.relops]{Relational operators}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{optional}}%
+\indexlibrarymember{operator==}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator==(const optional<T>& x, const optional<T>& y);
 \end{itemdecl}
@@ -3008,7 +3026,7 @@ for which \tcode{*x == *y} is a core constant expression
 shall be \tcode{constexpr} functions.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{optional}}%
+\indexlibrarymember{operator"!=}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator!=(const optional<T>& x, const optional<T>& y);
 \end{itemdecl}
@@ -3032,7 +3050,7 @@ for which \tcode{*x != *y} is a core constant expression
 shall be constexpr functions.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{optional}}%
+\indexlibrarymember{operator<}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator<(const optional<T>& x, const optional<T>& y);
 \end{itemdecl}
@@ -3056,7 +3074,7 @@ for which \tcode{*x < *y} is a core constant expression
 shall be \tcode{constexpr} functions.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>}!\idxcode{optional}}%
+\indexlibrarymember{operator>}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator>(const optional<T>& x, const optional<T>& y);
 \end{itemdecl}
@@ -3080,7 +3098,7 @@ for which \tcode{*x > *y} is a core constant expression
 shall be constexpr functions.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{optional}}%
+\indexlibrarymember{operator<=}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator<=(const optional<T>& x, const optional<T>& y);
 \end{itemdecl}
@@ -3104,7 +3122,7 @@ for which \tcode{*x <= *y} is a core constant expression
 shall be constexpr functions.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{optional}}%
+\indexlibrarymember{operator>=}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator>=(const optional<T>& x, const optional<T>& y);
 \end{itemdecl}
@@ -3130,7 +3148,7 @@ shall be constexpr functions.
 
 \rSec2[optional.nullops]{Comparison with \tcode{nullopt}}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{optional}}%
+\indexlibrarymember{operator==}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator==(const optional<T>& x, nullopt_t) noexcept;
 template <class T> constexpr bool operator==(nullopt_t, const optional<T>& x) noexcept;
@@ -3142,7 +3160,7 @@ template <class T> constexpr bool operator==(nullopt_t, const optional<T>& x) no
 \tcode{!x}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{optional}}%
+\indexlibrarymember{operator"!=}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator!=(const optional<T>& x, nullopt_t) noexcept;
 template <class T> constexpr bool operator!=(nullopt_t, const optional<T>& x) noexcept;
@@ -3154,7 +3172,7 @@ template <class T> constexpr bool operator!=(nullopt_t, const optional<T>& x) no
 \tcode{bool(x)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{optional}}%
+\indexlibrarymember{operator<}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator<(const optional<T>& x, nullopt_t) noexcept;
 \end{itemdecl}
@@ -3165,6 +3183,7 @@ template <class T> constexpr bool operator<(const optional<T>& x, nullopt_t) noe
 \tcode{false}.
 \end{itemdescr}
 
+\indexlibrarymember{operator<}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator<(nullopt_t, const optional<T>& x) noexcept;
 \end{itemdecl}
@@ -3175,7 +3194,7 @@ template <class T> constexpr bool operator<(nullopt_t, const optional<T>& x) noe
 \tcode{bool(x)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{optional}}%
+\indexlibrarymember{operator<=}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator<=(const optional<T>& x, nullopt_t) noexcept;
 \end{itemdecl}
@@ -3186,6 +3205,7 @@ template <class T> constexpr bool operator<=(const optional<T>& x, nullopt_t) no
 \tcode{!x}.
 \end{itemdescr}
 
+\indexlibrarymember{operator<=}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator<=(nullopt_t, const optional<T>& x) noexcept;
 \end{itemdecl}
@@ -3196,7 +3216,7 @@ template <class T> constexpr bool operator<=(nullopt_t, const optional<T>& x) no
 \tcode{true}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>}!\idxcode{optional}}%
+\indexlibrarymember{operator>}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator>(const optional<T>& x, nullopt_t) noexcept;
 \end{itemdecl}
@@ -3207,6 +3227,7 @@ template <class T> constexpr bool operator>(const optional<T>& x, nullopt_t) noe
 \tcode{bool(x)}.
 \end{itemdescr}
 
+\indexlibrarymember{operator>}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator>(nullopt_t, const optional<T>& x) noexcept;
 \end{itemdecl}
@@ -3217,7 +3238,7 @@ template <class T> constexpr bool operator>(nullopt_t, const optional<T>& x) noe
 \tcode{false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{optional}}%
+\indexlibrarymember{operator>=}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator>=(const optional<T>& x, nullopt_t) noexcept;
 \end{itemdecl}
@@ -3228,7 +3249,7 @@ template <class T> constexpr bool operator>=(const optional<T>& x, nullopt_t) no
 \tcode{true}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{optional}}%
+\indexlibrarymember{operator>=}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator>=(nullopt_t, const optional<T>& x) noexcept;
 \end{itemdecl}
@@ -3241,7 +3262,7 @@ template <class T> constexpr bool operator>=(nullopt_t, const optional<T>& x) no
 
 \rSec2[optional.comp_with_t]{Comparison with \tcode{T}}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{optional}}%
+\indexlibrarymember{operator==}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator==(const optional<T>& x, const T& v);
 \end{itemdecl}
@@ -3252,7 +3273,7 @@ template <class T> constexpr bool operator==(const optional<T>& x, const T& v);
 Equivalent to: \tcode{return bool(x) ? *x == v : false;}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{optional}}%
+\indexlibrarymember{operator==}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator==(const T& v, const optional<T>& x);
 \end{itemdecl}
@@ -3263,7 +3284,7 @@ template <class T> constexpr bool operator==(const T& v, const optional<T>& x);
 Equivalent to: \tcode{return bool(x) ? v == *x : false;}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{optional}}%
+\indexlibrarymember{operator"!=}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator!=(const optional<T>& x, const T& v);
 \end{itemdecl}
@@ -3274,7 +3295,7 @@ template <class T> constexpr bool operator!=(const optional<T>& x, const T& v);
 Equivalent to: \tcode{return bool(x) ? *x != v : true;}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{optional}}%
+\indexlibrarymember{operator"!=}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator!=(const T& v, const optional<T>& x);
 \end{itemdecl}
@@ -3285,7 +3306,7 @@ template <class T> constexpr bool operator!=(const T& v, const optional<T>& x);
 Equivalent to: \tcode{return bool(x) ? v != *x : true;}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{optional}}%
+\indexlibrarymember{operator<}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator<(const optional<T>& x, const T& v);
 \end{itemdecl}
@@ -3296,7 +3317,7 @@ template <class T> constexpr bool operator<(const optional<T>& x, const T& v);
 Equivalent to: \tcode{return bool(x) ? *x < v : true;}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{optional}}%
+\indexlibrarymember{operator<}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator<(const T& v, const optional<T>& x);
 \end{itemdecl}
@@ -3307,7 +3328,7 @@ template <class T> constexpr bool operator<(const T& v, const optional<T>& x);
 Equivalent to: \tcode{return bool(x) ? v < *x : false;}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{optional}}%
+\indexlibrarymember{operator<=}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator<=(const optional<T>& x, const T& v);
 \end{itemdecl}
@@ -3318,7 +3339,7 @@ template <class T> constexpr bool operator<=(const optional<T>& x, const T& v);
 Equivalent to: \tcode{return bool(x) ? *x <= v : true;}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{optional}}%
+\indexlibrarymember{operator<=}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator<=(const T& v, const optional<T>& x);
 \end{itemdecl}
@@ -3329,7 +3350,7 @@ template <class T> constexpr bool operator<=(const T& v, const optional<T>& x);
 Equivalent to: \tcode{return bool(x) ? v <= *x : false;}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>}!\idxcode{optional}}%
+\indexlibrarymember{operator>}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator>(const optional<T>& x, const T& v);
 \end{itemdecl}
@@ -3340,7 +3361,7 @@ template <class T> constexpr bool operator>(const optional<T>& x, const T& v);
 Equivalent to: \tcode{return bool(x) ? *x > v : false;}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>}!\idxcode{optional}}%
+\indexlibrarymember{operator>}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator>(const T& v, const optional<T>& x);
 \end{itemdecl}
@@ -3351,7 +3372,7 @@ template <class T> constexpr bool operator>(const T& v, const optional<T>& x);
 Equivalent to: \tcode{return bool(x) ? v > *x : true;}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{optional}}%
+\indexlibrarymember{operator>=}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator>=(const optional<T>& x, const T& v);
 \end{itemdecl}
@@ -3362,7 +3383,7 @@ template <class T> constexpr bool operator>=(const optional<T>& x, const T& v);
 Equivalent to: \tcode{return bool(x) ? *x >= v : false;}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{optional}}%
+\indexlibrarymember{operator>=}{optional}%
 \begin{itemdecl}
 template <class T> constexpr bool operator>=(const T& v, const optional<T>& x);
 \end{itemdecl}
@@ -3398,6 +3419,7 @@ template <class T> constexpr optional<decay_t<T>> make_optional(T&& v);
 \tcode{optional<decay_t<T>>(std::forward<T>(v))}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{make_optional}}%
 \begin{itemdecl}
 template <class T, class...Args>
   constexpr optional<T> make_optional(Args&&... args);
@@ -3408,6 +3430,7 @@ template <class T, class...Args>
 \effects Equivalent to: \tcode{return optional<T>(in_place, std::forward<Args>(args)...);}
 \end{itemdescr}
 
+\indexlibrary{\idxcode{make_optional}}%
 \begin{itemdecl}
 template <class T, class U, class... Args>
   constexpr optional<T> make_optional(initializer_list<U> il, Args&&... args);
@@ -3956,7 +3979,7 @@ then this destructor shall be a trivial destructor.
 
 \rSec3[variant.assign]{Assignment}
 
-\indexlibrarymember{variant}{operator=}%
+\indexlibrarymember{operator=}{variant}%
 \begin{itemdecl}
 variant& operator=(const variant& rhs);
 \end{itemdecl}
@@ -4002,7 +4025,7 @@ If an exception is thrown during the call to $T_j$'s move construction,
 the \tcode{variant} will hold no value.
 \end{itemdescr}
 
-\indexlibrarymember{variant}{operator=}%
+\indexlibrarymember{operator=}{variant}%
 \begin{itemdecl}
 variant& operator=(variant&& rhs) noexcept(@\seebelow@);
 \end{itemdecl}
@@ -4043,7 +4066,7 @@ the state of the contained value is as defined by the exception safety
 guarantee of $T_j$'s move assignment; \tcode{index()} will be $j$.
 \end{itemdescr}
 
-\indexlibrarymember{variant}{operator=}%
+\indexlibrarymember{operator=}{variant}%
 \begin{itemdecl}
 template <class T> variant& operator=(T&& t) noexcept(@\seebelow@);
 \end{itemdecl}
@@ -4105,7 +4128,7 @@ the \tcode{variant} object might not hold a value.
 
 \rSec3[variant.mod]{Modifiers}
 
-\indexlibrarymember{variant}{emplace}%
+\indexlibrarymember{emplace}{variant}%
 \begin{itemdecl}
 template <class T, class... Args> void emplace(Args&&... args);
 \end{itemdecl}
@@ -4123,7 +4146,7 @@ This function shall not participate in overload resolution unless
 exactly once in \tcode{Types...}.
 \end{itemdescr}
 
-\indexlibrarymember{variant}{emplace}%
+\indexlibrarymember{emplace}{variant}%
 \begin{itemdecl}
 template <class T, class U, class... Args> void emplace(initializer_list<U> il, Args&&... args);
 \end{itemdecl}
@@ -4141,7 +4164,7 @@ This function shall not participate in overload resolution unless
 and \tcode{T} occurs exactly once in \tcode{Types...}.
 \end{itemdescr}
 
-\indexlibrarymember{variant}{emplace}%
+\indexlibrarymember{emplace}{variant}%
 \begin{itemdecl}
 template <size_t I, class... Args> void emplace(Args&&... args);
 \end{itemdecl}
@@ -4174,7 +4197,7 @@ If an exception is thrown during the initialization of the contained value,
 the \tcode{variant} might not hold a value.
 \end{itemdescr}
 
-\indexlibrarymember{variant}{emplace}%
+\indexlibrarymember{emplace}{variant}%
 \begin{itemdecl}
 template <size_t I, class U, class... Args> void emplace(initializer_list<U> il, Args&&... args);
 \end{itemdecl}
@@ -4209,7 +4232,7 @@ the \tcode{variant} might not hold a value.
 
 \rSec3[variant.status]{Value status}
 
-\indexlibrarymember{variant}{valueless_by_exception}%
+\indexlibrarymember{valueless_by_exception}{variant}%
 \begin{itemdecl}
 constexpr bool valueless_by_exception() const noexcept;
 \end{itemdecl}
@@ -4233,7 +4256,7 @@ v.emplace<1>(S());
 \end{note}
 \end{itemdescr}
 
-\indexlibrarymember{variant}{index}%
+\indexlibrarymember{index}{variant}%
 \begin{itemdecl}
 constexpr size_t index() const noexcept;
 \end{itemdecl}
@@ -4247,7 +4270,7 @@ Otherwise, returns the zero-based index of the alternative of the contained valu
 
 \rSec3[variant.swap]{Swap}
 
-\indexlibrarymember{variant}{swap}%
+\indexlibrarymember{swap}{variant}%
 \begin{itemdecl}
 void swap(variant& rhs) noexcept(@\seebelow@);
 \end{itemdecl}
@@ -4420,7 +4443,7 @@ Otherwise, throws an exception of type \tcode{bad_variant_access}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{get_if}}%
-\indexlibrary{\idxcode{variant}!\idxcode{get_if}}
+\indexlibrary{\idxcode{variant}!\idxcode{get_if}}%
 \begin{itemdecl}
 template <size_t I, class... Types>
   constexpr add_pointer_t<variant_alternative_t<I, variant<Types...>>>
@@ -4443,7 +4466,7 @@ and \tcode{v->index() == I}. Otherwise, returns \tcode{nullptr}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{get_if}}%
-\indexlibrary{\idxcode{variant}!\idxcode{get_if}}
+\indexlibrary{\idxcode{variant}!\idxcode{get_if}}%
 \begin{itemdecl}
 template <class T, class... Types>
   constexpr add_pointer_t<T> get_if(variant<Types...>* v) noexcept;
@@ -4465,7 +4488,7 @@ index of \tcode{T} in \tcode{Types...}.
 
 \rSec2[variant.relops]{Relational operators}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{variant}}%
+\indexlibrarymember{operator==}{variant}%
 \begin{itemdecl}
 template <class... Types>
   constexpr bool operator==(const variant<Types...>& v, const variant<Types...>& w);
@@ -4484,7 +4507,7 @@ otherwise if \tcode{v.valueless_by_exception()}, \tcode{true};
 otherwise \tcode{get<$i$>(v) == get<$i$>(w)} with $i$ being \tcode{v.index()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{variant}}%
+\indexlibrarymember{operator"!=}{variant}%
 \begin{itemdecl}
 template <class... Types>
   constexpr bool operator!=(const variant<Types...>& v, const variant<Types...>& w);
@@ -4503,7 +4526,7 @@ otherwise if \tcode{v.valueless_by_exception()}, \tcode{false};
 otherwise \tcode{get<$i$>(v) != get<$i$>(w)} with $i$ being \tcode{v.index()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<}!\idxcode{variant}}%
+\indexlibrarymember{operator<}{variant}%
 \begin{itemdecl}
 template <class... Types>
   constexpr bool operator<(const variant<Types...>& v, const variant<Types...>& w);
@@ -4524,7 +4547,7 @@ otherwise if \tcode{v.index() > w.index()}, \tcode{false};
 otherwise \tcode{get<$i$>(v) < get<$i$>(w)} with $i$ being \tcode{v.index()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>}!\idxcode{variant}}%
+\indexlibrarymember{operator>}{variant}%
 \begin{itemdecl}
 template <class... Types>
   constexpr bool operator>(const variant<Types...>& v, const variant<Types...>& w);
@@ -4545,7 +4568,7 @@ otherwise if \tcode{v.index() < w.index()}, \tcode{false};
 otherwise \tcode{get<$i$>(v) > get<$i$>(w)} with $i$ being \tcode{v.index()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{variant}}%
+\indexlibrarymember{operator<=}{variant}%
 \begin{itemdecl}
 template <class... Types>
   constexpr bool operator<=(const variant<Types...>& v, const variant<Types...>& w);
@@ -4566,7 +4589,7 @@ otherwise if \tcode{v.index() > w.index()}, \tcode{false};
 otherwise \tcode{get<$i$>(v) <= get<$i$>(w)} with $i$ being \tcode{v.index()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator>=}!\idxcode{variant}}%
+\indexlibrarymember{operator>=}{variant}%
 \begin{itemdecl}
 template <class... Types>
   constexpr bool operator>=(const variant<Types...>& v, const variant<Types...>& w);
@@ -4661,6 +4684,7 @@ constexpr bool operator!=(monostate, monostate) noexcept { return false; }
 
 \rSec2[variant.specalg]{Specialized algorithms}
 
+\indexlibrary{\idxcode{swap}!\idxcode{variant}}%
 \begin{itemdecl}
 template <class... Types> void swap(variant<Types...>& v, variant<Types...>& w) noexcept(@\seebelow@);
 \end{itemdecl}
@@ -4688,6 +4712,7 @@ public:
 Objects of type \tcode{bad_variant_access} are thrown to report invalid
 accesses to the value of a \tcode{variant} object.
 
+\indexlibrary{\idxcode{bad_variant_access}!constructor}%
 \begin{itemdecl}
 bad_variant_access() noexcept;
 \end{itemdecl}
@@ -4697,6 +4722,7 @@ bad_variant_access() noexcept;
 Constructs a \tcode{bad_variant_access} object.
 \end{itemdescr}
 
+\indexlibrarymember{what}{bad_variant_access}%
 \begin{itemdecl}
 const char* what() const noexcept override;
 \end{itemdecl}
@@ -4765,6 +4791,7 @@ i.e. \tcode{5} is held strictly as an \tcode{int} and is not implicitly converti
 This indifference to interpretation but awareness of type effectively allows safe, generic containers of single values, with no scope for surprises from ambiguous conversions.
 \end{note}
 
+\indexlibrary{\idxhdr{any}}%
 \rSec2[any.synop]{Header \tcode{<any>} synopsis}
 
 \begin{codeblock}
@@ -4872,7 +4899,7 @@ Such small-object optimization shall only be applied to types \tcode{T} for whic
 
 \rSec3[any.cons]{Construction and destruction}
 
-\indexlibrary{\idxcode{any}!constructor}
+\indexlibrary{\idxcode{any}!constructor}%
 \begin{itemdecl}
 constexpr any() noexcept;
 \end{itemdecl}
@@ -4883,6 +4910,7 @@ constexpr any() noexcept;
 \tcode{has_value()} is \tcode{false}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{any}!constructor}%
 \begin{itemdecl}
 any(const any& other);
 \end{itemdecl}
@@ -4897,6 +4925,7 @@ Constructs an object of type \tcode{any} with an equivalent state as \tcode{othe
 Any exceptions arising from calling the selected constructor of the contained object.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{any}!constructor}%
 \begin{itemdecl}
 any(any&& other) noexcept;
 \end{itemdecl}
@@ -4911,6 +4940,7 @@ Constructs an object of type \tcode{any} with a state equivalent to the original
 \tcode{other} is left in a valid but otherwise unspecified state.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{any}!constructor}%
 \begin{itemdecl}
 template<class ValueType>
 any(ValueType&& value);
@@ -4938,6 +4968,7 @@ This constructor shall not participate in overload resolution if \tcode{decay_t<
 Any exception thrown by the selected constructor of \tcode{T}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{any}!constructor}%
 \begin{itemdecl}
 template <class T, class... Args>
   explicit any(in_place_type_t<T>, Args&&... args);
@@ -4958,6 +4989,7 @@ type \tcode{T} with the arguments \tcode{std::forward<Args>(args)...}.
 \throws Any exception thrown by the selected constructor of \tcode{T}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{any}!constructor}%
 \begin{itemdecl}
 template <class T, class U, class... Args>
   explicit any(in_place_type_t<T>, initializer_list<U> il, Args&&... args);
@@ -4995,7 +5027,7 @@ As if by \tcode{reset()}.
 
 \rSec3[any.assign]{Assignment}
 
-\indexlibrarymember{any}{operator=}%
+\indexlibrarymember{operator=}{any}%
 \begin{itemdecl}
 any& operator=(const any& rhs);
 \end{itemdecl}
@@ -5015,6 +5047,7 @@ No effects if an exception is thrown.
 Any exceptions arising from the copy constructor of the contained object.
 \end{itemdescr}
 
+\indexlibrarymember{operator=}{any}%
 \begin{itemdecl}
 any& operator=(any&& rhs) noexcept;
 \end{itemdecl}
@@ -5034,6 +5067,7 @@ The state of \tcode{*this} is equivalent to the original state of \tcode{rhs}
 and \tcode{rhs} is left in a valid but otherwise unspecified state.
 \end{itemdescr}
 
+\indexlibrarymember{operator=}{any}%
 \begin{itemdecl}
 template<class ValueType>
 any& operator=(ValueType&& rhs);
@@ -5068,6 +5102,7 @@ Any exception thrown by the selected constructor of \tcode{T}.
 
 \rSec3[any.modifiers]{Modifiers}
 
+\indexlibrarymember{emplace}{any}%
 \begin{itemdecl}
 template <class T, class... Args>
   void emplace(Args&&... args);
@@ -5094,6 +5129,7 @@ an object of type \tcode{T} with the arguments \tcode{std::forward<Args>(args)..
 has been destroyed.
 \end{itemdescr}
 
+\indexlibrarymember{emplace}{any}%
 \begin{itemdecl}
 template <class T, class U, class... Args>
   void emplace(initializer_list<U> il, Args&&... args);
@@ -5119,7 +5155,7 @@ The function shall not participate in overload resolution unless
 \tcode{is_constructible_v<T, initializer_list<U>\&, Args...>} is \tcode{true}.
 \end{itemdescr}
 
-\indexlibrarymember{any}{clear}%
+\indexlibrarymember{reset}{any}%
 \begin{itemdecl}
 void reset() noexcept;
 \end{itemdecl}
@@ -5134,7 +5170,7 @@ If \tcode{has_value()} is \tcode{true}, destroys the contained object.
 \tcode{has_value()} is \tcode{false}.
 \end{itemdescr}
 
-\indexlibrarymember{any}{swap}%
+\indexlibrarymember{swap}{any}%
 \begin{itemdecl}
 void swap(any& rhs) noexcept;
 \end{itemdecl}
@@ -5148,7 +5184,7 @@ Exchanges the states of \tcode{*this} and \tcode{rhs}.
 
 \rSec3[any.observers]{Observers}
 
-\indexlibrarymember{any}{empty}%
+\indexlibrarymember{has_value}{any}%
 \begin{itemdecl}
 bool has_value() const noexcept;
 \end{itemdecl}
@@ -5159,7 +5195,7 @@ bool has_value() const noexcept;
 \tcode{true} if \tcode{*this} contains an object, otherwise \tcode{false}.
 \end{itemdescr}
 
-\indexlibrarymember{any}{type}%
+\indexlibrarymember{type}{any}%
 \begin{itemdecl}
 const type_info& type() const noexcept;
 \end{itemdecl}
@@ -5178,7 +5214,7 @@ Useful for querying against types known either at compile time or only at runtim
 
 \rSec2[any.nonmembers]{Non-member functions}
 
-\indexlibrary{\idxcode{swap}!\idxcode{any}}
+\indexlibrary{\idxcode{swap}!\idxcode{any}}%
 \begin{itemdecl}
 void swap(any& x, any& y) noexcept;
 \end{itemdecl}
@@ -5213,7 +5249,7 @@ template <class T, class U, class ...Args>
 Equivalent to: \tcode{return any(in_place<T>, il, std::forward<Args>(args)...);}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{any_cast}}
+\indexlibrary{\idxcode{any_cast}}%
 \begin{itemdecl}
 template<class ValueType>
   ValueType any_cast(const any& operand);
@@ -5268,6 +5304,7 @@ any_cast<string&>(y);                       // error; cannot
 \end{example}
 \end{itemdescr}
 
+\indexlibrary{\idxcode{any_cast}}%
 \begin{itemdecl}
 template<class ValueType>
   const ValueType* any_cast(const any* operand) noexcept;
@@ -5293,10 +5330,10 @@ bool is_string(const any& operand) {
 \end{itemdescr}
 
 \rSec1[template.bitset]{Class template \tcode{bitset}}%
-\indexlibrary{\idxcode{bitset}}
+\indexlibrary{\idxcode{bitset}}%
 
 \synopsis{Header \tcode{<bitset>} synopsis}%
-\indexlibrary{\idxhdr{bitset}}
+\indexlibrary{\idxhdr{bitset}}%
 
 \begin{codeblock}
 #include <string>
@@ -5328,6 +5365,7 @@ class template
 and several related functions for representing
 and manipulating fixed-size sequences of bits.
 
+\indexlibrary{\idxcode{bitset}}%
 \begin{codeblock}
 namespace std {
   template<size_t N> class bitset {
@@ -5467,7 +5505,7 @@ Constructs an object of class
 initializing all bits to zero.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{bitset}!constructor}
+\indexlibrary{\idxcode{bitset}!constructor}%
 \begin{itemdecl}
 constexpr bitset(unsigned long long val) noexcept;
 \end{itemdecl}
@@ -5484,7 +5522,7 @@ representation~(\ref{basic.types}) of \tcode{unsigned long long}.
 If \tcode{M < N}, the remaining bit positions are initialized to zero.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{bitset}!constructor}
+\indexlibrary{\idxcode{bitset}!constructor}%
 \begin{itemdecl}
 template <class charT, class traits, class Allocator>
 explicit
@@ -5539,7 +5577,7 @@ Subsequent decreasing character positions correspond to increasing bit positions
 If \tcode{M < N}, remaining bit positions are initialized to zero.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{bitset}!constructor}
+\indexlibrary{\idxcode{bitset}!constructor}%
 \begin{itemdecl}
 template <class charT>
   explicit bitset(
@@ -5564,7 +5602,7 @@ bitset(
 
 \rSec2[bitset.members]{\tcode{bitset} members}
 
-\indexlibrary{\idxcode{operator\&=}!\idxcode{bitset}}%
+\indexlibrarymember{operator\&=}{bitset}%
 \begin{itemdecl}
 bitset<N>& operator&=(const bitset<N>& rhs) noexcept;
 \end{itemdecl}
@@ -5581,7 +5619,7 @@ for which the corresponding bit in \tcode{rhs} is clear, and leaves all other bi
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"|=}!\idxcode{bitset}}%
+\indexlibrarymember{operator"|=}{bitset}%
 \begin{itemdecl}
 bitset<N>& operator|=(const bitset<N>& rhs) noexcept;
 \end{itemdecl}
@@ -5598,7 +5636,7 @@ for which the corresponding bit in \tcode{rhs} is set, and leaves all other bits
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\^{}=}!\idxcode{bitset}}%
+\indexlibrarymember{operator\^{}=}{bitset}%
 \begin{itemdecl}
 bitset<N>& operator^=(const bitset<N>& rhs) noexcept;
 \end{itemdecl}
@@ -5741,7 +5779,7 @@ Resets the bit at position \tcode{pos} in
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\~{}}!\idxcode{bitset}}%
+\indexlibrarymember{operator\~{}}{bitset}%
 \begin{itemdecl}
 bitset<N> operator~() const noexcept;
 \end{itemdecl}
@@ -5759,7 +5797,7 @@ and initializes it with
 \tcode{x.flip()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{flip}!\idxcode{bitset}}%
+\indexlibrarymember{flip}{bitset}%
 \begin{itemdecl}
 bitset<N>& flip() noexcept;
 \end{itemdecl}
@@ -5797,7 +5835,7 @@ Toggles the bit at position \tcode{pos} in
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{to_ulong}!\idxcode{bitset}}%
+\indexlibrarymember{to_ulong}{bitset}%
 \begin{itemdecl}
 unsigned long to_ulong() const;
 \end{itemdecl}
@@ -5817,7 +5855,7 @@ cannot be represented as type
 \tcode{x}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{to_ullong}!\idxcode{bitset}}%
+\indexlibrarymember{to_ullong}{bitset}%
 \begin{itemdecl}
 unsigned long long to_ullong() const;
 \end{itemdecl}
@@ -5837,7 +5875,7 @@ cannot be represented as type
 \tcode{x}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{to_string}!\idxcode{bitset}}%
+\indexlibrarymember{to_string}{bitset}%
 \begin{itemdecl}
 template <class charT = char,
     class traits = char_traits<charT>,
@@ -5865,7 +5903,7 @@ bit value one becomes the character
 The created object.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{count}!\idxcode{bitset}}%
+\indexlibrarymember{count}{bitset}%
 \begin{itemdecl}
 size_t count() const noexcept;
 \end{itemdecl}
@@ -5877,7 +5915,7 @@ A count of the number of bits set in
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{size}!\idxcode{bitset}}%
+\indexlibrarymember{size}{bitset}%
 \begin{itemdecl}
 constexpr size_t size() const noexcept;
 \end{itemdecl}
@@ -5888,7 +5926,7 @@ constexpr size_t size() const noexcept;
 \tcode{N}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{bitset}}%
+\indexlibrarymember{operator==}{bitset}%
 \begin{itemdecl}
 bool operator==(const bitset<N>& rhs) const noexcept;
 \end{itemdecl}
@@ -5901,7 +5939,7 @@ bool operator==(const bitset<N>& rhs) const noexcept;
 equals the value of the corresponding bit in \tcode{rhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{bitset}}%
+\indexlibrarymember{operator"!=}{bitset}%
 \begin{itemdecl}
 bool operator!=(const bitset<N>& rhs) const noexcept;
 \end{itemdecl}
@@ -5913,7 +5951,7 @@ bool operator!=(const bitset<N>& rhs) const noexcept;
 \tcode{!(*this == rhs)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{test}!\idxcode{bitset}}%
+\indexlibrarymember{test}{bitset}%
 \begin{itemdecl}
 bool test(size_t pos) const;
 \end{itemdecl}
@@ -5934,7 +5972,7 @@ in
 has the value one.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{all}!\idxcode{bitset}}%
+\indexlibrarymember{all}{bitset}%
 \begin{itemdecl}
 bool all() const noexcept;
 \end{itemdecl}
@@ -5944,7 +5982,7 @@ bool all() const noexcept;
 \returns \tcode{count() == size()}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{any}!\idxcode{bitset}}%
+\indexlibrarymember{any}{bitset}%
 \begin{itemdecl}
 bool any() const noexcept;
 \end{itemdecl}
@@ -5954,7 +5992,7 @@ bool any() const noexcept;
 \returns \tcode{count() != 0}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{none}!\idxcode{bitset}}%
+\indexlibrarymember{none}{bitset}%
 \begin{itemdecl}
 bool none() const noexcept;
 \end{itemdecl}
@@ -6051,7 +6089,7 @@ template <size_t N> struct hash<bitset<N>>;
 
 \rSec2[bitset.operators]{\tcode{bitset} operators}
 
-\indexlibrary{\idxcode{operator\&}!\idxcode{bitset}}%
+\indexlibrarymember{operator\&}{bitset}%
 \begin{itemdecl}
 bitset<N> operator&(const bitset<N>& lhs, const bitset<N>& rhs) noexcept;
 \end{itemdecl}
@@ -6062,7 +6100,7 @@ bitset<N> operator&(const bitset<N>& lhs, const bitset<N>& rhs) noexcept;
 \tcode{bitset<N>(lhs) \&= rhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"|}!\idxcode{bitset}}%
+\indexlibrarymember{operator"|}{bitset}%
 \begin{itemdecl}
 bitset<N> operator|(const bitset<N>& lhs, const bitset<N>& rhs) noexcept;
 \end{itemdecl}
@@ -6073,7 +6111,7 @@ bitset<N> operator|(const bitset<N>& lhs, const bitset<N>& rhs) noexcept;
 \tcode{bitset<N>(lhs) |= rhs}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator\^{}}!\idxcode{bitset}}%
+\indexlibrarymember{operator\^{}}{bitset}%
 \begin{itemdecl}
 bitset<N> operator^(const bitset<N>& lhs, const bitset<N>& rhs) noexcept;
 \end{itemdecl}
@@ -6489,7 +6527,7 @@ namespace std {
 
 \rSec3[pointer.traits.types]{Pointer traits member types}
 
-\indexlibrarymember{pointer_traits}{element_type}%
+\indexlibrarymember{element_type}{pointer_traits}%
 \begin{itemdecl}
 using element_type = @\seebelow@;
 \end{itemdecl}
@@ -6504,7 +6542,7 @@ where \tcode{Args} is zero or more type arguments; otherwise, the specialization
 ill-formed.
 \end{itemdescr}
 
-\indexlibrarymember{pointer_traits}{difference_type}%
+\indexlibrarymember{difference_type}{pointer_traits}%
 \begin{itemdecl}
 using difference_type = @\seebelow@;
 \end{itemdecl}
@@ -6517,7 +6555,7 @@ type~(\ref{temp.deduct}); otherwise,
 \tcode{ptrdiff_t}.
 \end{itemdescr}
 
-\indexlibrarymember{pointer_traits}{rebind}%
+\indexlibrarymember{rebind}{pointer_traits}%
 \begin{itemdecl}
 template <class U> using rebind = @\seebelow@;
 \end{itemdecl}
@@ -6535,7 +6573,7 @@ where \tcode{Args} is zero or more type arguments; otherwise, the instantiation 
 
 \rSec3[pointer.traits.functions]{Pointer traits member functions}
 
-\indexlibrarymember{pointer_traits}{pointer_to}%
+\indexlibrarymember{pointer_to}{pointer_traits}%
 \begin{itemdecl}
 static pointer pointer_traits::pointer_to(@\seebelow@ r);
 static pointer pointer_traits<T*>::pointer_to(@\seebelow@ r) noexcept;
@@ -6716,8 +6754,8 @@ arguments for the same buffer.  \end{note}
 
 \rSec2[allocator.tag]{Allocator argument tag}
 
-\indexlibrary{\idxcode{allocator_arg_t}}
-\indexlibrary{\idxcode{allocator_arg}}
+\indexlibrary{\idxcode{allocator_arg_t}}%
+\indexlibrary{\idxcode{allocator_arg}}%
 \begin{itemdecl}
 namespace std {
   struct allocator_arg_t { };
@@ -6843,7 +6881,7 @@ namespace std {
 
 \rSec3[allocator.traits.types]{Allocator traits member types}
 
-\indexlibrarymember{allocator_traits}{pointer}%
+\indexlibrarymember{pointer}{allocator_traits}%
 \begin{itemdecl}
 using pointer = @\seebelow@;
 \end{itemdecl}
@@ -6855,7 +6893,7 @@ the \grammarterm{qualified-id} \tcode{Alloc::pointer} is valid and denotes a
 type~(\ref{temp.deduct}); otherwise, \tcode{value_type*}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{const_pointer}%
+\indexlibrarymember{const_pointer}{allocator_traits}%
 \begin{itemdecl}
 using const_pointer = @\seebelow@;
 \end{itemdecl}
@@ -6868,7 +6906,7 @@ type~(\ref{temp.deduct}); otherwise,
 \tcode{pointer_traits<pointer>::rebind<\brk{}const value_type>}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{void_pointer}%
+\indexlibrarymember{void_pointer}{allocator_traits}%
 \begin{itemdecl}
 using void_pointer = @\seebelow@;
 \end{itemdecl}
@@ -6881,7 +6919,7 @@ type~(\ref{temp.deduct}); otherwise,
 \tcode{pointer_traits<pointer>::rebind<\brk{}void>}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{const_void_pointer}%
+\indexlibrarymember{const_void_pointer}{allocator_traits}%
 \begin{itemdecl}
 using const_void_pointer = @\seebelow@;
 \end{itemdecl}
@@ -6894,7 +6932,7 @@ type~(\ref{temp.deduct}); otherwise,
 \tcode{pointer_traits<pointer>::\brk{}rebind<const void>}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{difference_type}%
+\indexlibrarymember{difference_type}{allocator_traits}%
 \begin{itemdecl}
 using difference_type = @\seebelow@;
 \end{itemdecl}
@@ -6907,7 +6945,7 @@ type~(\ref{temp.deduct}); otherwise,
 \tcode{pointer_traits<pointer>::dif\-ference_type}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{size_type}%
+\indexlibrarymember{size_type}{allocator_traits}%
 \begin{itemdecl}
 using size_type = @\seebelow@;
 \end{itemdecl}
@@ -6920,7 +6958,7 @@ type~(\ref{temp.deduct}); otherwise,
 \tcode{make_unsigned_t<difference_type>}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{propagate_on_container_copy_assignment}%
+\indexlibrarymember{propagate_on_container_copy_assignment}{allocator_traits}%
 \begin{itemdecl}
 using propagate_on_container_copy_assignment = @\seebelow@;
 \end{itemdecl}
@@ -6933,7 +6971,7 @@ type~(\ref{temp.deduct}); otherwise
 \tcode{false_type}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{propagate_on_container_move_assignment}%
+\indexlibrarymember{propagate_on_container_move_assignment}{allocator_traits}%
 \begin{itemdecl}
 using propagate_on_container_move_assignment = @\seebelow@;
 \end{itemdecl}
@@ -6946,7 +6984,7 @@ type~(\ref{temp.deduct}); otherwise
 \tcode{false_type}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{propagate_on_container_swap}%
+\indexlibrarymember{propagate_on_container_swap}{allocator_traits}%
 \begin{itemdecl}
 using propagate_on_container_swap = @\seebelow@;
 \end{itemdecl}
@@ -6959,7 +6997,7 @@ type~(\ref{temp.deduct}); otherwise
 \tcode{false_type}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{is_always_equal}%
+\indexlibrarymember{is_always_equal}{allocator_traits}%
 \begin{itemdecl}
 using is_always_equal = @\seebelow@;
 \end{itemdecl}
@@ -6972,7 +7010,7 @@ is valid and denotes a type~(\ref{temp.deduct});
 otherwise \tcode{is_empty<Alloc>::type}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{rebind_alloc}%
+\indexlibrarymember{rebind_alloc}{allocator_traits}%
 \begin{itemdecl}
 template <class T> using rebind_alloc = @\seebelow@;
 \end{itemdecl}
@@ -6989,7 +7027,7 @@ otherwise, the instantiation of \tcode{rebind_alloc} is ill-formed.
 
 \rSec3[allocator.traits.members]{Allocator traits static member functions}
 
-\indexlibrarymember{allocator_traits}{allocate}%
+\indexlibrarymember{allocate}{allocator_traits}%
 \begin{itemdecl}
 static pointer allocate(Alloc& a, size_type n);
 \end{itemdecl}
@@ -6999,7 +7037,7 @@ static pointer allocate(Alloc& a, size_type n);
 \returns \tcode{a.allocate(n)}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{allocate}%
+\indexlibrarymember{allocate}{allocator_traits}%
 \begin{itemdecl}
 static pointer allocate(Alloc& a, size_type n, const_void_pointer hint);
 \end{itemdecl}
@@ -7009,7 +7047,7 @@ static pointer allocate(Alloc& a, size_type n, const_void_pointer hint);
 \returns \tcode{a.allocate(n, hint)} if that expression is well-formed; otherwise, \tcode{a.allocate(n)}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{deallocate}%
+\indexlibrarymember{deallocate}{allocator_traits}%
 \begin{itemdecl}
 static void deallocate(Alloc& a, pointer p, size_type n);
 \end{itemdecl}
@@ -7022,7 +7060,7 @@ static void deallocate(Alloc& a, pointer p, size_type n);
 \throws Nothing.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{construct}%
+\indexlibrarymember{construct}{allocator_traits}%
 \begin{itemdecl}
 template <class T, class... Args>
   static void construct(Alloc& a, T* p, Args&&... args);
@@ -7035,7 +7073,7 @@ if that call is well-formed;
 otherwise, invokes \tcode{::new (static_cast<void*>(p)) T(std::forward<Args>(args)...)}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{destroy}%
+\indexlibrarymember{destroy}{allocator_traits}%
 \begin{itemdecl}
 template <class T>
   static void destroy(Alloc& a, T* p);
@@ -7047,7 +7085,7 @@ template <class T>
 \tcode{p->\~{}T()}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{max_size}%
+\indexlibrarymember{max_size}{allocator_traits}%
 \begin{itemdecl}
 static size_type max_size(const Alloc& a) noexcept;
 \end{itemdecl}
@@ -7058,7 +7096,7 @@ static size_type max_size(const Alloc& a) noexcept;
 \tcode{numeric_limits<size_type>::\brk{}max()/sizeof(value_type)}.
 \end{itemdescr}
 
-\indexlibrarymember{allocator_traits}{select_on_container_copy_construction}%
+\indexlibrarymember{select_on_container_copy_construction}{allocator_traits}%
 \begin{itemdecl}
 static Alloc select_on_container_copy_construction(const Alloc& rhs);
 \end{itemdecl}
@@ -7164,8 +7202,7 @@ template <class T, class U>
 \tcode{true}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{allocator}}%
-\indexlibrary{\idxcode{allocator}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{allocator}%
 \begin{itemdecl}
 template <class T, class U>
   bool operator!=(const allocator<T>&, const allocator<U>&) noexcept;
@@ -7675,7 +7712,7 @@ namespace std {
 }
 \end{codeblock}
 
-\indexlibrary{\idxcode{default_delete}!constructor}
+\indexlibrary{\idxcode{default_delete}!constructor}%
 \begin{itemdecl}
 template <class U> default_delete(const default_delete<U>& other) noexcept;
 \end{itemdecl}
@@ -7749,6 +7786,7 @@ unless \tcode{U(*)[]} is convertible to \tcode{T(*)[]}.
 
 \rSec3[unique.ptr.single]{\tcode{unique_ptr} for single objects}
 
+\indexlibrary{\idxcode{unique_ptr}}%
 \begin{codeblock}
 namespace std {
   template <class T, class D = default_delete<T>> class unique_ptr {
@@ -7828,7 +7866,7 @@ may be used as \tcode{unique_ptr<T, D>::pointer}. \end{example}
 
 \rSec4[unique.ptr.single.ctor]{\tcode{unique_ptr} constructors}
 
-\indexlibrary{\idxcode{unique_ptr}!constructor}
+\indexlibrary{\idxcode{unique_ptr}!constructor}%
 \begin{itemdecl}
 constexpr unique_ptr() noexcept;
 \end{itemdecl}
@@ -7852,7 +7890,7 @@ returns a reference to the stored deleter.
 for the template argument \tcode{D}, the program is ill-formed.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{unique_ptr}!constructor}
+\indexlibrary{\idxcode{unique_ptr}!constructor}%
 \begin{itemdecl}
 explicit unique_ptr(pointer p) noexcept;
 \end{itemdecl}
@@ -7877,7 +7915,7 @@ returns a reference to the stored deleter.
 for the template argument \tcode{D}, the program is ill-formed.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{unique_ptr}!constructor}
+\indexlibrary{\idxcode{unique_ptr}!constructor}%
 \begin{itemdecl}
 unique_ptr(pointer p, @\seebelow@ d1) noexcept;
 unique_ptr(pointer p, @\seebelow@ d2) noexcept;
@@ -8045,7 +8083,7 @@ to the stored deleter that was constructed from
 
 \rSec4[unique.ptr.single.dtor]{\tcode{unique_ptr} destructor}
 
-\indexlibrary{\idxcode{unique_ptr}!destructor}
+\indexlibrary{\idxcode{unique_ptr}!destructor}%
 \begin{itemdecl}
 ~unique_ptr();
 \end{itemdecl}
@@ -8256,6 +8294,7 @@ deleters of \tcode{*this} and \tcode{u}.
 
 \rSec3[unique.ptr.runtime]{\tcode{unique_ptr} for array objects with a runtime length}
 
+\indexlibrary{\idxcode{unique_ptr}}%
 \begin{codeblock}
 namespace std {
   template <class T, class D> class unique_ptr<T[], D> {
@@ -8387,7 +8426,7 @@ this replaces the overload-resolution specification of the primary template
 
 \rSec4[unique.ptr.runtime.asgn]{\tcode{unique_ptr} assignment}
 
-\indexlibrary{\idxcode{unique_ptr}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{unique_ptr}%
 \begin{itemdecl}
 template <class U, class E>
   unique_ptr& operator=(unique_ptr<U, E>&& u)noexcept;
@@ -8464,7 +8503,7 @@ unless either
 
 \rSec3[unique.ptr.create]{\tcode{unique_ptr} creation}
 
-\indexlibrary{\idxcode{make_unique}}
+\indexlibrary{\idxcode{make_unique}}%
 \begin{itemdecl}
 template <class T, class... Args> unique_ptr<T> make_unique(Args&&... args);
 \end{itemdecl}
@@ -8478,6 +8517,7 @@ template <class T, class... Args> unique_ptr<T> make_unique(Args&&... args);
 
 \end{itemdescr}
 
+\indexlibrary{\idxcode{make_unique}}%
 \begin{itemdecl}
 template <class T> unique_ptr<T> make_unique(size_t n);
 \end{itemdecl}
@@ -8491,6 +8531,7 @@ template <class T> unique_ptr<T> make_unique(size_t n);
 
 \end{itemdescr}
 
+\indexlibrary{\idxcode{make_unique}}%
 \begin{itemdecl}
 template <class T, class... Args> @\unspec@ make_unique(Args&&...) = delete;
 \end{itemdecl}
@@ -8503,7 +8544,7 @@ template <class T, class... Args> @\unspec@ make_unique(Args&&...) = delete;
 
 \rSec3[unique.ptr.special]{\tcode{unique_ptr} specialized algorithms}
 
-\indexlibrary{\idxcode{swap(unique_ptr\&, unique_ptr\&)}}
+\indexlibrary{\idxcode{swap(unique_ptr\&, unique_ptr\&)}}%
 \begin{itemdecl}
 template <class T, class D> void swap(unique_ptr<T, D>& x, unique_ptr<T, D>& y) noexcept;
 \end{itemdecl}
@@ -8528,8 +8569,7 @@ template <class T1, class D1, class T2, class D2>
 \returns \tcode{x.get() == y.get()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{unique_ptr}}%
-\indexlibrary{\idxcode{unique_ptr}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{unique_ptr}%
 \begin{itemdecl}
 template <class T1, class D1, class T2, class D2>
   bool operator!=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
@@ -8562,7 +8602,7 @@ to \tcode{\placeholder{CT}} or \tcode{unique_ptr<T2, D2>::pointer} is not implic
 convertible to \tcode{\placeholder{CT}}, the program is ill-formed.
 \end{itemdescr}
 
-\indexlibrarymember{operator<=}{shared_ptr}%
+\indexlibrarymember{operator<=}{unique_ptr}%
 \begin{itemdecl}
 template <class T1, class D1, class T2, class D2>
   bool operator<=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
@@ -8608,8 +8648,7 @@ template <class T, class D>
 \returns \tcode{!x}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{unique_ptr}}%
-\indexlibrary{\idxcode{unique_ptr}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{unique_ptr}%
 \begin{itemdecl}
 template <class T, class D>
   bool operator!=(const unique_ptr<T, D>& x, nullptr_t) noexcept;
@@ -8708,7 +8747,7 @@ An exception of type \tcode{bad_weak_ptr} is thrown by the \tcode{shared_ptr}
 constructor taking a \tcode{weak_ptr}.
 
 \indexlibrary{\idxcode{bad_weak_ptr}!constructor}%
-\indexlibrarymember{bad_weak_ptr}{what}%
+\indexlibrarymember{what}{bad_weak_ptr}%
 \begin{itemdecl}
 bad_weak_ptr() noexcept;
 \end{itemdecl}
@@ -9080,7 +9119,7 @@ than its previous value. \end{note}
 
 \rSec4[util.smartptr.shared.assign]{\tcode{shared_ptr} assignment}
 
-\indexlibrarymember{shared_ptr}{operator=}%
+\indexlibrarymember{operator=}{shared_ptr}%
 \begin{itemdecl}
 shared_ptr& operator=(const shared_ptr& r) noexcept;
 template<class Y> shared_ptr& operator=(const shared_ptr<Y>& r) noexcept;
@@ -9137,7 +9176,7 @@ template <class Y, class D> shared_ptr& operator=(unique_ptr<Y, D>&& r);
 
 \rSec4[util.smartptr.shared.mod]{\tcode{shared_ptr} modifiers}
 
-\indexlibrarymember{shared_ptr}{swap}%
+\indexlibrarymember{swap}{shared_ptr}%
 \begin{itemdecl}
 void swap(shared_ptr& r) noexcept;
 \end{itemdecl}
@@ -9185,7 +9224,7 @@ template<class Y, class D, class A> void reset(Y* p, D d, A a);
 \end{itemdescr}
 
 \rSec4[util.smartptr.shared.obs]{\tcode{shared_ptr} observers}
-\indexlibrarymember{shared_ptr}{get}%
+\indexlibrarymember{get}{shared_ptr}%
 \begin{itemdecl}
 T* get() const noexcept;
 \end{itemdecl}
@@ -9194,7 +9233,7 @@ T* get() const noexcept;
 \pnum\returns  the stored pointer.
 \end{itemdescr}
 
-\indexlibrarymember{shared_ptr}{operator*}%
+\indexlibrarymember{operator*}{shared_ptr}%
 \begin{itemdecl}
 T& operator*() const noexcept;
 \end{itemdecl}
@@ -9211,7 +9250,7 @@ return type is, except that the declaration (although not necessarily the
 definition) of the function shall be well formed.
 \end{itemdescr}
 
-\indexlibrarymember{shared_ptr}{operator->}%
+\indexlibrarymember{operator->}{shared_ptr}%
 \begin{itemdecl}
 T* operator->() const noexcept;
 \end{itemdecl}
@@ -9222,7 +9261,7 @@ T* operator->() const noexcept;
 \pnum\returns  \tcode{get()}.
 \end{itemdescr}
 
-\indexlibrarymember{shared_ptr}{use_count}%
+\indexlibrarymember{use_count}{shared_ptr}%
 \begin{itemdecl}
 long use_count() const noexcept;
 \end{itemdecl}
@@ -9233,7 +9272,7 @@ that \textit{share ownership} with \tcode{*this}, or \tcode{0} when \tcode{*this
 \textit{empty}.
 \end{itemdescr}
 
-\indexlibrarymember{shared_ptr}{unique}%
+\indexlibrarymember{unique}{shared_ptr}%
 \begin{itemdecl}
 bool unique() const noexcept;
 \end{itemdecl}
@@ -9327,7 +9366,7 @@ as the reference counts. \end{note}
 
 \rSec4[util.smartptr.shared.cmp]{\tcode{shared_ptr} comparison}
 
-\indexlibrarymember{shared_ptr}{operator==}%
+\indexlibrarymember{operator==}{shared_ptr}%
 \begin{itemdecl}
 template<class T, class U> bool operator==(const shared_ptr<T>& a, const shared_ptr<U>& b) noexcept;
 \end{itemdecl}
@@ -9336,7 +9375,7 @@ template<class T, class U> bool operator==(const shared_ptr<T>& a, const shared_
 \pnum\returns  \tcode{a.get() == b.get()}.
 \end{itemdescr}
 
-\indexlibrarymember{shared_ptr}{operator<}%
+\indexlibrarymember{operator<}{shared_ptr}%
 \begin{itemdecl}
 template<class T, class U> bool operator<(const shared_ptr<T>& a, const shared_ptr<U>& b) noexcept;
 \end{itemdecl}
@@ -9365,8 +9404,7 @@ template <class T>
 \returns \tcode{!a}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{shared_ptr}%
 \begin{itemdecl}
 template <class T>
   bool operator!=(const shared_ptr<T>& a, nullptr_t) noexcept;
@@ -9443,7 +9481,7 @@ The second function template returns \tcode{!(nullptr < a)}.
 
 \rSec4[util.smartptr.shared.spec]{\tcode{shared_ptr} specialized algorithms}
 
-\indexlibrarymember{shared_ptr}{swap}%
+\indexlibrarymember{swap}{shared_ptr}%
 \begin{itemdecl}
 template<class T> void swap(shared_ptr<T>& a, shared_ptr<T>& b) noexcept;
 \end{itemdecl}
@@ -9454,7 +9492,7 @@ template<class T> void swap(shared_ptr<T>& a, shared_ptr<T>& b) noexcept;
 
 \rSec4[util.smartptr.shared.cast]{\tcode{shared_ptr} casts}
 
-\indexlibrarymember{shared_ptr}{static_pointer_cast}%
+\indexlibrarymember{static_pointer_cast}{shared_ptr}%
 \begin{itemdecl}
 template<class T, class U> shared_ptr<T> static_pointer_cast(const shared_ptr<U>& r) noexcept;
 \end{itemdecl}
@@ -9479,7 +9517,7 @@ will eventually result in undefined behavior, attempting to delete the
 same object twice. \end{note}
 \end{itemdescr}
 
-\indexlibrarymember{shared_ptr}{dynamic_pointer_cast}%
+\indexlibrarymember{dynamic_pointer_cast}{shared_ptr}%
 \begin{itemdecl}
 template<class T, class U> shared_ptr<T> dynamic_pointer_cast(const shared_ptr<U>& r) noexcept;
 \end{itemdecl}
@@ -9505,7 +9543,7 @@ shall be well formed and shall have well defined behavior.
 undefined behavior, attempting to delete the same object twice. \end{note}
 \end{itemdescr}
 
-\indexlibrarymember{shared_ptr}{const_pointer_cast}%
+\indexlibrarymember{const_pointer_cast}{shared_ptr}%
 \begin{itemdecl}
 template<class T, class U> shared_ptr<T> const_pointer_cast(const shared_ptr<U>& r) noexcept;
 \end{itemdecl}
@@ -9529,7 +9567,7 @@ undefined behavior, attempting to delete the same object twice. \end{note}
 
 \rSec4[util.smartptr.getdeleter]{\tcode{get_deleter}}
 
-\indexlibrarymember{shared_ptr}{get_deleter}%
+\indexlibrarymember{get_deleter}{shared_ptr}%
 \begin{itemdecl}
 template<class D, class T> D* get_deleter(const shared_ptr<T>& p) noexcept;
 \end{itemdecl}
@@ -9677,7 +9715,7 @@ effect on the object its stored pointer points to.
 
 \rSec4[util.smartptr.weak.assign]{\tcode{weak_ptr} assignment}
 
-\indexlibrarymember{weak_ptr}{operator=}%
+\indexlibrarymember{operator=}{weak_ptr}%
 \begin{itemdecl}
 weak_ptr& operator=(const weak_ptr& r) noexcept;
 template<class Y> weak_ptr& operator=(const weak_ptr<Y>& r) noexcept;
@@ -9693,7 +9731,7 @@ implied guarantees) via different means, without creating a temporary.
 \pnum\returns  \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{weak_ptr}{operator=}%
+\indexlibrarymember{operator=}{weak_ptr}%
 \begin{itemdecl}
 weak_ptr& operator=(weak_ptr&& r) noexcept;
 template<class Y> weak_ptr& operator=(weak_ptr<Y>&& r) noexcept;
@@ -9706,7 +9744,7 @@ template<class Y> weak_ptr& operator=(weak_ptr<Y>&& r) noexcept;
 \end{itemdescr}
 
 \rSec4[util.smartptr.weak.mod]{\tcode{weak_ptr} modifiers}
-\indexlibrarymember{weak_ptr}{swap}%
+\indexlibrarymember{swap}{weak_ptr}%
 \begin{itemdecl}
 void swap(weak_ptr& r) noexcept;
 \end{itemdecl}
@@ -9715,7 +9753,7 @@ void swap(weak_ptr& r) noexcept;
 \pnum\effects  Exchanges the contents of \tcode{*this} and \tcode{r}.
 \end{itemdescr}
 
-\indexlibrarymember{weak_ptr}{reset}%
+\indexlibrarymember{reset}{weak_ptr}%
 \begin{itemdecl}
 void reset() noexcept;
 \end{itemdecl}
@@ -9725,7 +9763,7 @@ void reset() noexcept;
 \end{itemdescr}
 
 \rSec4[util.smartptr.weak.obs]{\tcode{weak_ptr} observers}
-\indexlibrarymember{weak_ptr}{use_count}%
+\indexlibrarymember{use_count}{weak_ptr}%
 \begin{itemdecl}
 long use_count() const noexcept;
 \end{itemdecl}
@@ -9736,7 +9774,7 @@ otherwise, the number of \tcode{shared_ptr} instances
 that \textit{share ownership} with \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{weak_ptr}{expired}%
+\indexlibrarymember{expired}{weak_ptr}%
 \begin{itemdecl}
 bool expired() const noexcept;
 \end{itemdecl}
@@ -9745,7 +9783,7 @@ bool expired() const noexcept;
 \pnum\returns  \tcode{use_count() == 0}.
 \end{itemdescr}
 
-\indexlibrarymember{weak_ptr}{lock}%
+\indexlibrarymember{lock}{weak_ptr}%
 \begin{itemdecl}
 shared_ptr<T> lock() const noexcept;
 \end{itemdecl}
@@ -9754,7 +9792,7 @@ shared_ptr<T> lock() const noexcept;
 \pnum\returns  \tcode{expired() ? shared_ptr<T>() : shared_ptr<T>(*this)}, executed atomically.
 \end{itemdescr}
 
-\indexlibrarymember{owner_before}{shared_ptr}%
+\indexlibrarymember{owner_before}{weak_ptr}%
 \begin{itemdecl}
 template<class U> bool owner_before(shared_ptr<U> const& b) const;
 template<class U> bool owner_before(weak_ptr<U> const& b) const;
@@ -9777,7 +9815,7 @@ both empty.
 
 \rSec4[util.smartptr.weak.spec]{\tcode{weak_ptr} specialized algorithms}
 
-\indexlibrarymember{weak_ptr}{swap}%
+\indexlibrarymember{swap}{weak_ptr}%
 \begin{itemdecl}
 template<class T> void swap(weak_ptr<T>& a, weak_ptr<T>& b) noexcept;
 \end{itemdecl}
@@ -9792,6 +9830,7 @@ template<class T> void swap(weak_ptr<T>& a, weak_ptr<T>& b) noexcept;
 The class template \tcode{owner_less} allows ownership-based mixed comparisons of shared
 and weak pointers.
 
+\indexlibrary{\idxcode{struct owner_less}}%
 \begin{codeblock}
 namespace std {
   template<class T = void> struct owner_less;
@@ -9823,6 +9862,7 @@ namespace std {
 }
 \end{codeblock}
 
+\indexlibrarymember{operator()}{owner_less}%
 \pnum \tcode{operator()(x, y)} shall return \tcode{x.owner_before(y)}. \begin{note}
 Note that
 
@@ -9892,7 +9932,7 @@ enable_shared_from_this(const enable_shared_from_this<T>&) noexcept;
 \pnum\effects  Value-initializes \tcode{weak_this}.
 \end{itemdescr}
 
-\indexlibrarymember{enable_shared_from_this}{operator=}%
+\indexlibrarymember{operator=}{enable_shared_from_this}%
 \begin{itemdecl}
 enable_shared_from_this<T>& operator=(const enable_shared_from_this<T>&) noexcept;
 \end{itemdecl}
@@ -9904,7 +9944,7 @@ enable_shared_from_this<T>& operator=(const enable_shared_from_this<T>&) noexcep
 \end{itemdescr}
 
 \indexlibrary{\idxcode{shared_ptr}}%
-\indexlibrarymember{enable_shared_from_this}{shared_from_this}%
+\indexlibrarymember{shared_from_this}{enable_shared_from_this}%
 \begin{itemdecl}
 shared_ptr<T>       shared_from_this();
 shared_ptr<T const> shared_from_this() const;
@@ -9917,7 +9957,7 @@ shared_ptr<T const> shared_from_this() const;
 \end{itemdescr}
 
 \indexlibrary{\idxcode{weak_ptr}}%
-\indexlibrarymember{enable_shared_from_this}{weak_from_this}%
+\indexlibrarymember{weak_from_this}{enable_shared_from_this}%
 \begin{itemdecl}
 weak_ptr<T>       weak_from_this() noexcept;
 weak_ptr<T const> weak_from_this() const noexcept;
@@ -10098,10 +10138,8 @@ template<class T>
 \tcode{memory_order_seq_cst, memory_order_seq_cst)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{atomic_compare_exchange_weak_explicit}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!atomic_compare_exchange_weak_explicit@\tcode{atomic_compare_exchange_weak_-\\explicit}}%
-\indexlibrary{\idxcode{atomic_compare_exchange_strong_explicit}!\idxcode{shared_ptr}}%
-\indexlibrary{\idxcode{shared_ptr}!atomic_compare_exchange_strong_explicit@\tcode{atomic_compare_exchange_strong_-\\explicit}}%
+\indexlibrarymember{atomic_compare_exchange_weak_explicit}{shared_ptr}%
+\indexlibrarymember{atomic_compare_exchange_strong_explicit}{shared_ptr}%
 \begin{itemdecl}
 template<class T>
   bool atomic_compare_exchange_weak_explicit(
@@ -10143,7 +10181,7 @@ pointer value and share ownership.
 
 \rSec3[util.smartptr.hash]{Smart pointer hash support}
 
-\indexlibrary{\idxcode{hash}}%
+\indexlibrary{\idxcode{hash}!\idxcode{unique_ptr}}%
 \begin{itemdecl}
 template <class T, class D> struct hash<unique_ptr<T, D>>;
 \end{itemdecl}
@@ -10160,7 +10198,7 @@ well-formed and well-defined, and shall meet the requirements of class
 template \tcode{hash}~(\ref{unord.hash}).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{hash}}%
+\indexlibrary{\idxcode{hash}!\idxcode{shared_ptr}}%
 \begin{itemdecl}
 template <class T> struct hash<shared_ptr<T>>;
 \end{itemdecl}
@@ -10251,7 +10289,7 @@ private:
 Destroys this \tcode{memory_resource}.
 \end{itemdescr}
 
-\indexlibrarymember{memory_resource}{allocate}%
+\indexlibrarymember{allocate}{memory_resource}%
 \begin{itemdecl}
 void* allocate(size_t bytes, size_t alignment = max_align);
 \end{itemdecl}
@@ -10262,7 +10300,7 @@ void* allocate(size_t bytes, size_t alignment = max_align);
 Equivalent to: \tcode{return do_allocate(bytes, alignment);}
 \end{itemdescr}
 
-\indexlibrarymember{memory_resource}{deallocate}%
+\indexlibrarymember{deallocate}{memory_resource}%
 \begin{itemdecl}
 void deallocate(void* p, size_t bytes, size_t alignment = max_align);
 \end{itemdecl}
@@ -10273,7 +10311,7 @@ void deallocate(void* p, size_t bytes, size_t alignment = max_align);
 Equivalent to: \tcode{do_deallocate(p, bytes, alignment);}
 \end{itemdescr}
 
-\indexlibrarymember{memory_resource}{is_equal}%
+\indexlibrarymember{is_equal}{memory_resource}%
 \begin{itemdecl}
 bool is_equal(const memory_resource& other) const noexcept;
 \end{itemdecl}
@@ -10287,7 +10325,7 @@ Equivalent to: \tcode{return do_is_equal(other);}
 
 \rSec3[memory.resource.private]{\tcode{memory_resource} private virtual member functions}
 
-\indexlibrarymember{memory_resource}{do_allocate}%
+\indexlibrarymember{do_allocate}{memory_resource}%
 \begin{itemdecl}
 virtual void* do_allocate(size_t bytes, size_t alignment) = 0;
 \end{itemdecl}
@@ -10308,7 +10346,7 @@ otherwise it is aligned to \tcode{max_align}.
 A derived class implementation shall throw an appropriate exception if it is unable to allocate memory with the requested size and alignment.
 \end{itemdescr}
 
-\indexlibrarymember{memory_resource}{do_deallocate}%
+\indexlibrarymember{do_deallocate}{memory_resource}%
 \begin{itemdecl}
 virtual void do_deallocate(void* p, size_t bytes, size_t alignment) = 0;
 \end{itemdecl}
@@ -10328,7 +10366,7 @@ A derived class shall implement this function to dispose of allocated storage.
 Nothing.
 \end{itemdescr}
 
-\indexlibrarymember{memory_resource}{do_is_equal}%
+\indexlibrarymember{do_is_equal}{memory_resource}%
 \begin{itemdecl}
 virtual bool do_is_equal(const memory_resource& other) const noexcept = 0;
 \end{itemdecl}
@@ -10347,7 +10385,7 @@ if \tcode{dynamic_cast<const D*>(\&other) == nullptr}.\end{note}
 
 \rSec3[memory.resource.eq]{\tcode{memory_resource} equality}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{memory_resource}}%
+\indexlibrarymember{operator==}{memory_resource}%
 \begin{itemdecl}
 bool operator==(const memory_resource& a, const memory_resource& b) noexcept;
 \end{itemdecl}
@@ -10358,7 +10396,7 @@ bool operator==(const memory_resource& a, const memory_resource& b) noexcept;
 \tcode{\&a == \&b || a.is_equal(b)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{memory_resource}}%
+\indexlibrarymember{operator"!=}{memory_resource}%
 \begin{itemdecl}
 bool operator!=(const memory_resource& a, const memory_resource& b) noexcept;
 \end{itemdecl}
@@ -10482,7 +10520,7 @@ Sets \tcode{memory_rsrc} to \tcode{other.resource()}.
 
 \rSec3[memory.polymorphic.allocator.mem]{\tcode{polymorphic_allocator} member functions}
 
-\indexlibrarymember{polymorphic_allocator}{allocate}%
+\indexlibrarymember{allocate}{polymorphic_allocator}%
 \begin{itemdecl}
 Tp* allocate(size_t n);
 \end{itemdecl}
@@ -10496,7 +10534,7 @@ return static_cast<Tp*>(memory_rsrc->allocate(n * sizeof(Tp), alignof(Tp)));
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{polymorphic_allocator}{deallocate}%
+\indexlibrarymember{deallocate}{polymorphic_allocator}%
 \begin{itemdecl}
 void deallocate(Tp* p, size_t n);
 \end{itemdecl}
@@ -10517,7 +10555,7 @@ Equivalent to \tcode{memory_rsrc->deallocate(p, n * sizeof(Tp), alignof(Tp))}.
 Nothing.
 \end{itemdescr}
 
-\indexlibrarymember{polymorphic_allocator}{construct}%
+\indexlibrarymember{construct}{polymorphic_allocator}%
 \begin{itemdecl}
 template <class T, class... Args>
   void construct(T* p, Args&&... args);
@@ -10545,7 +10583,7 @@ and constructor arguments \tcode{std::forward<Args>(args)...}.
 Nothing unless the constructor for \tcode{T} throws.
 \end{itemdescr}
 
-\indexlibrarymember{polymorphic_allocator}{construct}%
+\indexlibrarymember{construct}{polymorphic_allocator}%
 \begin{itemdecl}
 template <class T1, class T2, class... Args1, class... Args2>
   void construct(pair<T1,T2>* p, piecewise_construct_t,
@@ -10632,7 +10670,7 @@ this function constructs a \tcode{pair<T1, T2>} object
 in the storage whose address is represented by \tcode{p}.
 \end{itemdescr}
 
-\indexlibrarymember{polymorphic_allocator}{construct}%
+\indexlibrarymember{construct}{polymorphic_allocator}%
 \begin{itemdecl}
 template <class T1, class T2>
   void construct(pair<T1,T2>* p);
@@ -10647,7 +10685,7 @@ this->construct(p, piecewise_construct, tuple<>(), tuple<>());
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{polymorphic_allocator}{construct}%
+\indexlibrarymember{construct}{polymorphic_allocator}%
 \begin{itemdecl}
 template <class T1, class T2, class U, class V>
   void construct(pair<T1,T2>* p, U&& x, V&& y);
@@ -10664,7 +10702,7 @@ this->construct(p, piecewise_construct,
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{polymorphic_allocator}{construct}%
+\indexlibrarymember{construct}{polymorphic_allocator}%
 \begin{itemdecl}
 template <class T1, class T2, class U, class V>
   void construct(pair<T1,T2>* p, const pair<U, V>& pr);
@@ -10681,7 +10719,7 @@ this->construct(p, piecewise_construct,
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{polymorphic_allocator}{construct}%
+\indexlibrarymember{construct}{polymorphic_allocator}%
 \begin{itemdecl}
 template <class T1, class T2, class U, class V>
   void construct(pair<T1,T2>* p, pair<U, V>&& pr);
@@ -10698,7 +10736,7 @@ this->construct(p, piecewise_construct,
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{polymorphic_allocator}{destroy}%
+\indexlibrarymember{destroy}{polymorphic_allocator}%
 \begin{itemdecl}
 template <class T>
   void destroy(T* p);
@@ -10710,7 +10748,7 @@ template <class T>
 As if by \tcode{p->\~T()}.
 \end{itemdescr}
 
-\indexlibrarymember{polymorphic_allocator}{select_on_container_copy_construction}%
+\indexlibrarymember{select_on_container_copy_construction}{polymorphic_allocator}%
 \begin{itemdecl}
 polymorphic_allocator select_on_container_copy_construction() const;
 \end{itemdecl}
@@ -10726,7 +10764,7 @@ The memory resource is not propagated.
 \end{note}
 \end{itemdescr}
 
-\indexlibrarymember{polymorphic_allocator}{resource}%
+\indexlibrarymember{resource}{polymorphic_allocator}%
 \begin{itemdecl}
 memory_resource* resource() const;
 \end{itemdecl}
@@ -10739,7 +10777,7 @@ memory_resource* resource() const;
 
 \rSec3[memory.polymorphic.allocator.eq]{\tcode{polymorphic_allocator} equality}
 
-\indexlibrary{\idxcode{operator==}!\idxcode{polymorphic_allocator}}%
+\indexlibrarymember{operator==}{polymorphic_allocator}%
 \begin{itemdecl}
 template <class T1, class T2>
   bool operator==(const polymorphic_allocator<T1>& a,
@@ -10752,7 +10790,7 @@ template <class T1, class T2>
 \tcode{*a.resource() == *b.resource()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{polymorphic_allocator}}%
+\indexlibrarymember{operator"!=}{polymorphic_allocator}%
 \begin{itemdecl}
 template <class T1, class T2>
   bool operator!=(const polymorphic_allocator<T1>& a,
@@ -11054,10 +11092,8 @@ Calls \tcode{this->release()}.
 
 \rSec3[memory.resource.pool.mem]{Pool resource members}
 
-\indexlibrary{\idxcode{synchronized_pool_resource}!\idxcode{release}}%
-\indexlibrary{\idxcode{unsynchronized_pool_resource}!\idxcode{release}}%
-\indexlibrary{\idxcode{release}!\idxcode{synchronized_pool_resource}}%
-\indexlibrary{\idxcode{release}!\idxcode{unsynchronized_pool_resource}}%
+\indexlibrarymember{release}{synchronized_pool_resource}%
+\indexlibrarymember{release}{unsynchronized_pool_resource}%
 \begin{itemdecl}
 void release();
 \end{itemdecl}
@@ -11073,10 +11109,8 @@ even if \tcode{deallocate} has not been called
 for some of the allocated blocks.\end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{synchronized_pool_resource}!\idxcode{upstream_resource}}%
-\indexlibrary{\idxcode{unsynchronized_pool_resource}!\idxcode{upstream_resource}}%
-\indexlibrary{\idxcode{upstream_resource}!\idxcode{synchronized_pool_resource}}%
-\indexlibrary{\idxcode{upstream_resource}!\idxcode{unsynchronized_pool_resource}}%
+\indexlibrarymember{upstream_resource}{synchronized_pool_resource}%
+\indexlibrarymember{upstream_resource}{unsynchronized_pool_resource}%
 \begin{itemdecl}
 memory_resource* upstream_resource() const;
 \end{itemdecl}
@@ -11088,10 +11122,8 @@ The value of the \tcode{upstream} argument
 provided to the constructor of this object.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{synchronized_pool_resource}!\idxcode{options}}%
-\indexlibrary{\idxcode{unsynchronized_pool_resource}!\idxcode{options}}%
-\indexlibrary{\idxcode{options}!\idxcode{synchronized_pool_resource}}%
-\indexlibrary{\idxcode{options}!\idxcode{unsynchronized_pool_resource}}%
+\indexlibrarymember{options}{synchronized_pool_resource}%
+\indexlibrarymember{options}{unsynchronized_pool_resource}%
 \begin{itemdecl}
 pool_options options() const;
 \end{itemdecl}
@@ -11106,10 +11138,8 @@ values of zero will be replaced with implementation-defined defaults,
 and sizes may be rounded to unspecified granularity.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{synchronized_pool_resource}!\idxcode{do_allocate}}%
-\indexlibrary{\idxcode{unsynchronized_pool_resource}!\idxcode{do_allocate}}%
-\indexlibrary{\idxcode{do_allocate}!\idxcode{synchronized_pool_resource}}%
-\indexlibrary{\idxcode{do_allocate}!\idxcode{unsynchronized_pool_resource}}%
+\indexlibrarymember{do_allocate}{synchronized_pool_resource}%
+\indexlibrarymember{do_allocate}{unsynchronized_pool_resource}%
 \begin{itemdecl}
 void* do_allocate(size_t bytes, size_t alignment) override;
 \end{itemdecl}
@@ -11135,10 +11165,8 @@ then memory will be allocated using \tcode{upstream_resource()->allocate()}.
 Nothing unless \tcode{upstream_resource()->allocate()} throws.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{synchronized_pool_resource}!\idxcode{do_deallocate}}%
-\indexlibrary{\idxcode{unsynchronized_pool_resource}!\idxcode{do_deallocate}}%
-\indexlibrary{\idxcode{do_deallocate}!\idxcode{synchronized_pool_resource}}%
-\indexlibrary{\idxcode{do_deallocate}!\idxcode{unsynchronized_pool_resource}}%
+\indexlibrarymember{do_deallocate}{synchronized_pool_resource}%
+\indexlibrarymember{do_deallocate}{unsynchronized_pool_resource}%
 \begin{itemdecl}
 void do_deallocate(void* p, size_t bytes, size_t alignment) override;
 \end{itemdecl}
@@ -11155,7 +11183,7 @@ this operation will result in a call to \tcode{upstream_resource()->deallocate()
 Nothing.
 \end{itemdescr}
 
-\indexlibrarymember{unsynchronized_pool_resource}{do_is_equal}%
+\indexlibrarymember{do_is_equal}{unsynchronized_pool_resource}%
 \begin{itemdecl}
 bool unsynchronized_pool_resource::do_is_equal(const memory_resource& other) const noexcept override;
 \end{itemdecl}
@@ -11166,7 +11194,7 @@ bool unsynchronized_pool_resource::do_is_equal(const memory_resource& other) con
 \tcode{this == dynamic_cast<const unsynchronized_pool_resource*>(\&other)}.
 \end{itemdescr}
 
-\indexlibrarymember{synchronized_pool_resource}{do_is_equal}%
+\indexlibrarymember{do_is_equal}{synchronized_pool_resource}%
 \begin{itemdecl}
 bool synchronized_pool_resource::do_is_equal(const memory_resource& other) const noexcept override;
 \end{itemdecl}
@@ -11303,7 +11331,7 @@ Calls \tcode{this->release()}.
 
 \rSec3[memory.resource.monotonic.buffer.mem]{\tcode{monotonic_buffer_resource} members}
 
-\indexlibrary{\idxcode{monotonic_buffer_resource}!\idxcode{release}}%
+\indexlibrarymember{release}{monotonic_buffer_resource}%
 \begin{itemdecl}
 void release();
 \end{itemdecl}
@@ -11321,7 +11349,7 @@ even if some blocks that were allocated from \tcode{this}
 have not been deallocated from \tcode{this}.\end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{monotonic_buffer_resource}!\idxcode{upstream_resource}}%
+\indexlibrarymember{upstream_resource}{monotonic_buffer_resource}%
 \begin{itemdecl}
 memory_resource* upstream_resource() const;
 \end{itemdecl}
@@ -11332,7 +11360,7 @@ memory_resource* upstream_resource() const;
 The value of \tcode{upstream_rsrc}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{monotonic_buffer_resource}!\idxcode{do_allocate}}%
+\indexlibrarymember{do_allocate}{monotonic_buffer_resource}%
 \begin{itemdecl}
 void* do_allocate(size_t bytes, size_t alignment) override;
 \end{itemdecl}
@@ -11362,7 +11390,7 @@ then allocate the return block from the newly-allocated \tcode{current_buffer}.
 Nothing unless \tcode{upstream_rsrc->allocate()} throws.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{monotonic_buffer_resource}!\idxcode{do_deallocate}}%
+\indexlibrarymember{do_deallocate}{monotonic_buffer_resource}%
 \begin{itemdecl}
 void do_deallocate(void* p, size_t bytes, size_t alignment) override;
 \end{itemdecl}
@@ -11381,7 +11409,7 @@ Nothing.
 Memory used by this resource increases monotonically until its destruction.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{monotonic_buffer_resource}!\idxcode{do_is_equal}}%
+\indexlibrarymember{do_is_equal}{monotonic_buffer_resource}%
 \begin{itemdecl}
 bool do_is_equal(const memory_resource& other) const noexcept override;
 \end{itemdecl}
@@ -11429,6 +11457,7 @@ recursions. \begin{note} The \tcode{scoped_allocator_adaptor} is derived from th
 allocator type so it can be substituted for the outer allocator type in most
 expressions. \end{note}
 
+\indexlibrary{\idxcode{scoped_allocator_adaptor}}%
 \begin{codeblock}
 namespace std {
   template <class OuterAlloc, class... InnerAllocs>
@@ -11520,7 +11549,7 @@ namespace std {
 
 \rSec2[allocator.adaptor.types]{Scoped allocator adaptor member types}
 
-\indexlibrarymember{scoped_allocator_adaptor}{inner_allocator_type}%
+\indexlibrarymember{inner_allocator_type}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 using inner_allocator_type = @\seebelow@;
 \end{itemdecl}
@@ -11531,7 +11560,7 @@ using inner_allocator_type = @\seebelow@;
 zero; otherwise,\\ \tcode{scoped_allocator_adaptor<InnerAllocs...>}.
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{propagate_on_container_copy_assignment}%
+\indexlibrarymember{propagate_on_container_copy_assignment}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 using propagate_on_container_copy_assignment = @\seebelow@;
 \end{itemdecl}
@@ -11544,7 +11573,7 @@ using propagate_on_container_copy_assignment = @\seebelow@;
 \tcode{InnerAllocs...}; otherwise, \tcode{false_type}.
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{propagate_on_container_move_assignment}%
+\indexlibrarymember{propagate_on_container_move_assignment}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 using propagate_on_container_move_assignment = @\seebelow@;
 \end{itemdecl}
@@ -11557,7 +11586,7 @@ using propagate_on_container_move_assignment = @\seebelow@;
 \tcode{InnerAllocs...}; otherwise, \tcode{false_type}.
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{propagate_on_container_swap}%
+\indexlibrarymember{propagate_on_container_swap}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 using propagate_on_container_swap = @\seebelow@;
 \end{itemdecl}
@@ -11570,7 +11599,7 @@ using propagate_on_container_swap = @\seebelow@;
 \tcode{InnerAllocs...}; otherwise, \tcode{false_type}.
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{is_always_equal}%
+\indexlibrarymember{is_always_equal}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 using is_always_equal = @\seebelow@;
 \end{itemdecl}
@@ -11684,7 +11713,7 @@ is incumbent upon the definition of \tcode{outer_allocator()} to ensure that the
 recursion terminates. It will terminate for all instantiations of \\
 \tcode{scoped_allocator_adaptor}. \end{note}
 
-\indexlibrarymember{scoped_allocator_adaptor}{inner_allocator}%
+\indexlibrarymember{inner_allocator}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 inner_allocator_type& inner_allocator() noexcept;
 const inner_allocator_type& inner_allocator() const noexcept;
@@ -11696,7 +11725,7 @@ const inner_allocator_type& inner_allocator() const noexcept;
 \tcode{inner}.
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{outer_allocator}%
+\indexlibrarymember{outer_allocator}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 outer_allocator_type& outer_allocator() noexcept;
 \end{itemdecl}
@@ -11706,7 +11735,7 @@ outer_allocator_type& outer_allocator() noexcept;
 \returns \tcode{static_cast<OuterAlloc\&>(*this)}.
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{outer_allocator}%
+\indexlibrarymember{outer_allocator}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 const outer_allocator_type& outer_allocator() const noexcept;
 \end{itemdecl}
@@ -11716,7 +11745,7 @@ const outer_allocator_type& outer_allocator() const noexcept;
 \returns \tcode{static_cast<const OuterAlloc\&>(*this)}.
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{allocate}%
+\indexlibrarymember{allocate}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 pointer allocate(size_type n);
 \end{itemdecl}
@@ -11726,7 +11755,7 @@ pointer allocate(size_type n);
 \returns \tcode{allocator_traits<OuterAlloc>::allocate(outer_allocator(), n)}.
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{allocate}%
+\indexlibrarymember{allocate}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 pointer allocate(size_type n, const_void_pointer hint);
 \end{itemdecl}
@@ -11736,7 +11765,7 @@ pointer allocate(size_type n, const_void_pointer hint);
 \returns \tcode{allocator_traits<OuterAlloc>::allocate(outer_allocator(), n, hint)}.
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{deallocate}%
+\indexlibrarymember{deallocate}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 void deallocate(pointer p, size_type n) noexcept;
 \end{itemdecl}
@@ -11747,7 +11776,7 @@ void deallocate(pointer p, size_type n) noexcept;
 \tcode{allocator_traits<OuterAlloc>::deallocate(outer_allocator(), p, n);}
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{max_size}%
+\indexlibrarymember{max_size}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 size_type max_size() const;
 \end{itemdecl}
@@ -11757,7 +11786,7 @@ size_type max_size() const;
 \returns \tcode{allocator_traits<OuterAlloc>::max_size(outer_allocator())}.
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{construct}%
+\indexlibrarymember{construct}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 template <class T, class... Args>
   void construct(T* p, Args&&... args);
@@ -11790,7 +11819,7 @@ contained element. \end{note}
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{construct}%
+\indexlibrarymember{construct}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 template <class T1, class T2, class... Args1, class... Args2>
   void construct(pair<T1, T2>* p, piecewise_construct_t,
@@ -11856,7 +11885,7 @@ then calls \tcode{\textit{OUTERMOST_ALLOC_TRAITS}(*this)::construct(\textit{OUTE
 piecewise_construct, std::move(xprime), std::move(yprime))}.
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{construct}%
+\indexlibrarymember{construct}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 template <class T1, class T2>
   void construct(pair<T1, T2>* p);
@@ -11870,7 +11899,7 @@ this->construct(p, piecewise_construct, tuple<>(), tuple<>());
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{construct}%
+\indexlibrarymember{construct}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 template <class T1, class T2, class U, class V>
   void construct(pair<T1, T2>* p, U&& x, V&& y);
@@ -11886,7 +11915,7 @@ this->construct(p, piecewise_construct,
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{construct}%
+\indexlibrarymember{construct}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 template <class T1, class T2, class U, class V>
   void construct(pair<T1, T2>* p, const pair<U, V>& x);
@@ -11902,7 +11931,7 @@ this->construct(p, piecewise_construct,
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{construct}%
+\indexlibrarymember{construct}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 template <class T1, class T2, class U, class V>
   void construct(pair<T1, T2>* p, pair<U, V>&& x);
@@ -11918,7 +11947,7 @@ this->construct(p, piecewise_construct,
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{destroy}%
+\indexlibrarymember{destroy}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 template <class T>
   void destroy(T* p);
@@ -11929,7 +11958,7 @@ template <class T>
 \effects Calls \tcode{\textit{OUTERMOST_ALLOC_TRAITS}(*this)::destroy(\textit{OUTERMOST}(*this), p)}.
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{select_on_container_copy_construction}%
+\indexlibrarymember{select_on_container_copy_construction}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 scoped_allocator_adaptor select_on_container_copy_construction() const;
 \end{itemdecl}
@@ -11944,7 +11973,7 @@ corresponding allocator in \tcode{*this}.
 
 \rSec2[scoped.adaptor.operators]{Scoped allocator operators}
 
-\indexlibrarymember{scoped_allocator_adaptor}{operator==}%
+\indexlibrarymember{operator==}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 template <class OuterA1, class OuterA2, class... InnerAllocs>
   bool operator==(const scoped_allocator_adaptor<OuterA1, InnerAllocs...>& a,
@@ -11959,7 +11988,7 @@ otherwise, \tcode{a.outer_allocator() == b.outer_allocator()}
 \tcode{\&\&} \tcode{a.inner_allocator() == b.inner_allocator()}.
 \end{itemdescr}
 
-\indexlibrarymember{scoped_allocator_adaptor}{operator"!=}%
+\indexlibrarymember{operator"!=}{scoped_allocator_adaptor}%
 \begin{itemdecl}
 template <class OuterA1, class OuterA2, class... InnerAllocs>
   bool operator!=(const scoped_allocator_adaptor<OuterA1, InnerAllocs...>& a,
@@ -12307,8 +12336,6 @@ template <class F, class... Args>
 
 \indexlibrary{\idxcode{reference_wrapper}}%
 \indextext{function object!\idxcode{reference_wrapper}}%
-\indextext{unary function}%
-\indextext{binary function}%
 \begin{codeblock}
 namespace std {
   template <class T> class reference_wrapper {
@@ -12388,7 +12415,7 @@ operator T& () const noexcept;
 \pnum\returns The stored reference.
 \end{itemdescr}
 
-\indexlibrarymember{reference_wrapper}{get}%
+\indexlibrarymember{get}{reference_wrapper}%
 \begin{itemdecl}
 T& get() const noexcept;
 \end{itemdecl}
@@ -12400,7 +12427,7 @@ T& get() const noexcept;
 
 \rSec3[refwrap.invoke]{reference_wrapper invocation}
 
-\indexlibrarymember{reference_wrapper}{operator()}%
+\indexlibrarymember{operator()}{reference_wrapper}%
 \begin{itemdecl}
 template <class... ArgTypes>
   result_of_t<T&(ArgTypes&&... )>
@@ -12414,7 +12441,7 @@ template <class... ArgTypes>
 
 \rSec3[refwrap.helpers]{reference_wrapper helper functions}
 
-\indexlibrarymember{reference_wrapper}{ref}%
+\indexlibrarymember{ref}{reference_wrapper}%
 \begin{itemdecl}
 template <class T> reference_wrapper<T> ref(T& t) noexcept;
 \end{itemdecl}
@@ -12423,7 +12450,7 @@ template <class T> reference_wrapper<T> ref(T& t) noexcept;
 \pnum\returns \tcode{reference_wrapper<T>(t)}
 \end{itemdescr}
 
-\indexlibrarymember{reference_wrapper}{ref}%
+\indexlibrarymember{ref}{reference_wrapper}%
 \begin{itemdecl}
 template <class T> reference_wrapper<T> ref(reference_wrapper<T> t) noexcept;
 \end{itemdecl}
@@ -12432,7 +12459,7 @@ template <class T> reference_wrapper<T> ref(reference_wrapper<T> t) noexcept;
 \pnum\returns \tcode{ref(t.get())}
 \end{itemdescr}
 
-\indexlibrarymember{reference_wrapper}{cref}%
+\indexlibrarymember{cref}{reference_wrapper}%
 \begin{itemdecl}
 template <class T> reference_wrapper<const T> cref(const T& t) noexcept;
 \end{itemdecl}
@@ -12441,7 +12468,7 @@ template <class T> reference_wrapper<const T> cref(const T& t) noexcept;
 \pnum\returns \tcode{reference_wrapper <const T>(t)}
 \end{itemdescr}
 
-\indexlibrarymember{reference_wrapper}{cref}%
+\indexlibrarymember{cref}{reference_wrapper}%
 \begin{itemdecl}
 template <class T> reference_wrapper<const T> cref(reference_wrapper<T> t) noexcept;
 \end{itemdecl}
@@ -12463,6 +12490,7 @@ template <class T = void> struct plus {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{plus}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()}
@@ -12477,6 +12505,7 @@ template <class T = void> struct minus {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{minus}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()}
@@ -12491,6 +12520,7 @@ template <class T = void> struct multiplies {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{multiplies}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()}
@@ -12505,6 +12535,7 @@ template <class T = void> struct divides {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{divides}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()}
@@ -12519,6 +12550,7 @@ template <class T = void> struct modulus {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{modulus}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{x \% y}.
@@ -12531,6 +12563,7 @@ template <class T = void> struct negate {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{negate}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{-x}.
@@ -12546,6 +12579,7 @@ template <> struct plus<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{plus<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) + std::forward<U>(u)}.
@@ -12561,6 +12595,7 @@ template <> struct minus<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{minus<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) - std::forward<U>(u)}.
@@ -12576,6 +12611,7 @@ template <> struct multiplies<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{multiplies<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) * std::forward<U>(u)}.
@@ -12591,6 +12627,7 @@ template <> struct divides<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{divides<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) / std::forward<U>(u)}.
@@ -12606,6 +12643,7 @@ template <> struct modulus<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{modulus<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) \% std::forward<U>(u)}.
@@ -12621,6 +12659,7 @@ template <> struct negate<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{negate<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{-std::forward<T>(t)}.
@@ -12640,6 +12679,7 @@ template <class T = void> struct equal_to {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{equal_to}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{x == y}.
@@ -12652,6 +12692,7 @@ template <class T = void> struct not_equal_to {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{not_equal_to}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{x != y}.
@@ -12664,6 +12705,7 @@ template <class T = void> struct greater {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{greater}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{x > y}.
@@ -12676,6 +12718,7 @@ template <class T = void> struct less {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{less}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{x < y}.
@@ -12688,6 +12731,7 @@ template <class T = void> struct greater_equal {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{greater_equal}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{x >= y}.
@@ -12700,6 +12744,7 @@ template <class T = void> struct less_equal {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{less_equal}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{x <= y}.
@@ -12715,6 +12760,7 @@ template <> struct equal_to<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{equal_to<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) == std::forward<U>(u)}.
@@ -12730,6 +12776,7 @@ template <> struct not_equal_to<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{not_equal_to<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) != std::forward<U>(u)}.
@@ -12745,6 +12792,7 @@ template <> struct greater<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{greater<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) > std::forward<U>(u)}.
@@ -12760,6 +12808,7 @@ template <> struct less<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{less<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) < std::forward<U>(u)}.
@@ -12775,6 +12824,7 @@ template <> struct greater_equal<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{greater_equal<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) >= std::forward<U>(u)}.
@@ -12790,6 +12840,7 @@ template <> struct less_equal<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{less_equal<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) <= std::forward<U>(u)}.
@@ -12818,6 +12869,7 @@ template <class T = void> struct logical_and {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{logical_and}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{x \&\& y}.
@@ -12830,6 +12882,7 @@ template <class T = void> struct logical_or {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{logical_or}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{x || y}.
@@ -12842,6 +12895,7 @@ template <class T = void> struct logical_not {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{logical_not}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{!x}.
@@ -12857,6 +12911,7 @@ template <> struct logical_and<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{logical_and<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) \&\& std::forward<U>(u)}.
@@ -12872,6 +12927,7 @@ template <> struct logical_or<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{logical_or<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) || std::forward<U>(u)}.
@@ -12887,6 +12943,7 @@ template <> struct logical_not<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{logical_not<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{!std::forward<T>(t)}.
@@ -12907,6 +12964,7 @@ template <class T = void> struct bit_and {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{bit_and}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{x \& y}.
@@ -12919,6 +12977,7 @@ template <class T = void> struct bit_or {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{bit_or}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{x | y}.
@@ -12931,6 +12990,7 @@ template <class T = void> struct bit_xor {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{bit_xor}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{x \^{} y}.
@@ -12942,6 +13002,7 @@ template <class T = void> struct bit_not {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{bit_not}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{\~{}x}.
@@ -12957,6 +13018,7 @@ template <> struct bit_and<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{bit_and<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) \& std::forward<U>(u)}.
@@ -12972,6 +13034,7 @@ template <> struct bit_or<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{bit_or<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) | std::forward<U>(u)}.
@@ -12987,6 +13050,7 @@ template <> struct bit_xor<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{bit_xor<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{std::forward<T>(t) \^{} std::forward<U>(u)}.
@@ -13002,6 +13066,7 @@ template <> struct bit_not<void> {
 };
 \end{itemdecl}
 
+\indexlibrarymember{operator()}{bit_not<>}%
 \begin{itemdescr}
 \pnum
 \tcode{operator()} returns \tcode{\~{}std::forward<T>(t)}.
@@ -13178,7 +13243,7 @@ In the text that follows, the following names have the following meanings:
 \item \tcode{uj} is the $j^{th}$ argument associated with \tcode{Uj}.
 \end{itemize}
 
-\indexlibrary{\idxcode{bind}}
+\indexlibrary{\idxcode{bind}}%
 \begin{itemdecl}
 template<class F, class... BoundArgs>
   @\unspec@ bind(F&& f, BoundArgs&&... bound_args);
@@ -13217,7 +13282,7 @@ return type shall satisfy the requirements of \tcode{CopyConstructible}. \begin{
 that all of \tcode{FD} and \tcode{TiD} are \tcode{MoveConstructible}. \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{bind}}
+\indexlibrary{\idxcode{bind}}%
 \begin{itemdecl}
 template<class R, class F, class... BoundArgs>
   @\unspec@ bind(F&& f, BoundArgs&&... bound_args);
@@ -13344,7 +13409,7 @@ This subclause describes a polymorphic wrapper class that
 encapsulates arbitrary callable objects.
 
 \rSec3[func.wrap.badcall]{Class \tcode{bad_function_call}}%
-\indexlibrary{\idxcode{bad_function_call}}
+\indexlibrary{\idxcode{bad_function_call}}%
 
 \pnum
 An exception of type \tcode{bad_function_call} is thrown by
@@ -13364,7 +13429,7 @@ namespace std {
 \rSec4[func.wrap.badcall.const]{\tcode{bad_function_call} constructor}
 
 \indexlibrary{\idxcode{bad_function_call}!constructor}%
-\indexlibrarymember{bad_function_call}{what}%
+\indexlibrarymember{what}{bad_function_call}%
 \begin{itemdecl}
 bad_function_call() noexcept;
 \end{itemdecl}
@@ -13379,7 +13444,7 @@ bad_function_call() noexcept;
 \end{itemdescr}
 
 \rSec3[func.wrap.func]{Class template \tcode{function}}
-\indexlibrary{\idxcode{function}}
+\indexlibrary{\idxcode{function}}%
 
 \begin{codeblock}
 namespace std {
@@ -13464,7 +13529,7 @@ is \tcode{R(ArgTypes...)}.
 
 \rSec4[func.wrap.func.con]{\tcode{function} construct/copy/destroy}
 
-\indexlibrary{\idxcode{function}!constructor}
+\indexlibrary{\idxcode{function}!constructor}%
 \begin{itemdecl}
 function() noexcept;
 \end{itemdecl}
@@ -13473,7 +13538,7 @@ function() noexcept;
 \pnum\postcondition \tcode{!*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{function}!constructor}
+\indexlibrary{\idxcode{function}!constructor}%
 \begin{itemdecl}
 function(nullptr_t) noexcept;
 \end{itemdecl}
@@ -13483,7 +13548,7 @@ function(nullptr_t) noexcept;
 \postcondition \tcode{!*this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{function}!constructor}
+\indexlibrary{\idxcode{function}!constructor}%
 \begin{itemdecl}
 function(const function& f);
 \end{itemdecl}
@@ -13504,7 +13569,7 @@ dynamically allocated memory for small callable objects, for example, where
 to an object and a member function pointer. \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{function}!constructor}
+\indexlibrary{\idxcode{function}!constructor}%
 \begin{itemdecl}
 function(function&& f);
 \end{itemdecl}
@@ -13528,7 +13593,7 @@ where \tcode{f}'s target is an object holding only a pointer or reference
 to an object and a member function pointer. \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{function}!constructor}
+\indexlibrary{\idxcode{function}!constructor}%
 \begin{itemdecl}
 template<class F> function(F f);
 \end{itemdecl}
@@ -13566,7 +13631,7 @@ may throw \tcode{bad_alloc} or any exception thrown by \tcode{F}'s copy
 or move constructor.
 \end{itemdescr}
 
-\indexlibrarymember{function}{operator=}%
+\indexlibrarymember{operator=}{function}%
 \begin{itemdecl}
 function& operator=(const function& f);
 \end{itemdecl}
@@ -13579,7 +13644,7 @@ function& operator=(const function& f);
 \returns \tcode{*this}
 \end{itemdescr}
 
-\indexlibrarymember{function}{operator=}%
+\indexlibrarymember{operator=}{function}%
 \begin{itemdecl}
 function& operator=(function&& f);
 \end{itemdecl}
@@ -13593,7 +13658,7 @@ with the target of \tcode{f}.
 \returns \tcode{*this}
 \end{itemdescr}
 
-\indexlibrarymember{function}{operator=}%
+\indexlibrarymember{operator=}{function}%
 \begin{itemdecl}
 function& operator=(nullptr_t) noexcept;
 \end{itemdecl}
@@ -13606,7 +13671,7 @@ function& operator=(nullptr_t) noexcept;
 \pnum\returns \tcode{*this}
 \end{itemdescr}
 
-\indexlibrarymember{function}{operator=}%
+\indexlibrarymember{operator=}{function}%
 \begin{itemdecl}
 template<class F> function& operator=(F&& f);
 \end{itemdecl}
@@ -13622,7 +13687,7 @@ Lvalue-Callable~(\ref{func.wrap.func}) for argument types \tcode{ArgTypes...} an
 return type \tcode{R}.
 \end{itemdescr}
 
-\indexlibrarymember{function}{operator=}%
+\indexlibrarymember{operator=}{function}%
 \begin{itemdecl}
 template<class F> function& operator=(reference_wrapper<F> f) noexcept;
 \end{itemdecl}
@@ -13645,7 +13710,7 @@ template<class F> function& operator=(reference_wrapper<F> f) noexcept;
 
 \rSec4[func.wrap.func.mod]{\tcode{function} modifiers}
 
-\indexlibrarymember{function}{swap}%
+\indexlibrarymember{swap}{function}%
 \begin{itemdecl}
 void swap(function& other) noexcept;
 \end{itemdecl}
@@ -13656,7 +13721,7 @@ void swap(function& other) noexcept;
 
 \rSec4[func.wrap.func.cap]{\tcode{function} capacity}
 
-\indexlibrary{\idxcode{function}!bool conversion}%
+\indexlibrarymember{operator bool}{function}%
 \begin{itemdecl}
 explicit operator bool() const noexcept;
 \end{itemdecl}
@@ -13669,7 +13734,7 @@ explicit operator bool() const noexcept;
 \rSec4[func.wrap.func.inv]{\tcode{function} invocation}
 
 \indexlibrary{\idxcode{function}!invocation}%
-\indexlibrarymember{function}{operator()}%
+\indexlibrarymember{operator()}{function}%
 \begin{itemdecl}
 R operator()(ArgTypes... args) const;
 \end{itemdecl}
@@ -13686,7 +13751,7 @@ exception thrown by the wrapped callable object.
 
 \rSec4[func.wrap.func.targ]{function target access}
 
-\indexlibrarymember{function}{target_type}%
+\indexlibrarymember{target_type}{function}%
 \begin{itemdecl}
 const type_info& target_type() const noexcept;
 \end{itemdecl}
@@ -13696,7 +13761,7 @@ const type_info& target_type() const noexcept;
   \tcode{typeid(T)}; otherwise, \tcode{typeid(void)}.
 \end{itemdescr}
 
-\indexlibrarymember{function}{target}%
+\indexlibrarymember{target}{function}%
 \begin{itemdecl}
 template<class T>       T* target() noexcept;
 template<class T> const T* target() const noexcept;
@@ -13727,7 +13792,7 @@ template <class R, class... ArgTypes>
 \pnum\returns \tcode{!f}.
 \end{itemdescr}
 
-\indexlibrarymember{function}{operator"!=}%
+\indexlibrarymember{operator"!=}{function}%
 \begin{itemdecl}
 template <class R, class... ArgTypes>
   bool operator!=(const function<R(ArgTypes...)>& f, nullptr_t) noexcept;
@@ -13741,7 +13806,7 @@ template <class R, class... ArgTypes>
 
 \rSec4[func.wrap.func.alg]{specialized algorithms}
 
-\indexlibrarymember{function}{swap}%
+\indexlibrarymember{swap}{function}%
 \begin{itemdecl}
 template<class R, class... ArgTypes>
   void swap(function<R(ArgTypes...)>& f1, function<R(ArgTypes...)>& f2);
@@ -13825,7 +13890,7 @@ Any exception thrown by the copy constructor of \tcode{BinaryPredicate} or
 \tcode{ForwardIterator1}.
 \end{itemdescr}
 
-\indexlibrarymember{default_searcher}{operator()}%
+\indexlibrarymember{operator()}{default_searcher}%
 \begin{itemdecl}
 template<class ForwardIterator2>
   pair<ForwardIterator2, ForwardIterator2>
@@ -13916,7 +13981,7 @@ or the copy constructor or \tcode{operator()} of \tcode{BinaryPredicate} or \tco
 May throw \tcode{bad_alloc} if additional memory needed for internal data structures cannot be allocated.
 \end{itemdescr}
 
-\indexlibrarymember{boyer_moore_searcher}{operator()}%
+\indexlibrarymember{operator()}{boyer_moore_searcher}%
 \begin{itemdecl}
 template <class RandomAccessIterator2>
   pair<RandomAccessIterator2, RandomAccessIterator2>
@@ -14031,7 +14096,7 @@ or the copy constructor or \tcode{operator()} of \tcode{BinaryPredicate} or \tco
 May throw \tcode{bad_alloc} if additional memory needed for internal data structures cannot be allocated.
 \end{itemdescr}
 
-\indexlibrarymember{boyer_moore_horspool_searcher}{operator()}%
+\indexlibrarymember{operator()}{boyer_moore_horspool_searcher}%
 \begin{itemdecl}
 template <class RandomAccessIterator2>
   pair<RandomAccessIterator2, RandomAccessIterator2>
@@ -14244,6 +14309,7 @@ template type argument and, optionally, additional arguments that help
 define the modification. It shall define a publicly accessible nested type
 named \tcode{type}, which shall be a synonym for the modified type.
 
+\indexlibrary{\idxhdr{type_traits}}%
 \rSec2[meta.type.synop]{Header \tcode{<type_traits>} synopsis}
 \begin{codeblock}
 namespace std {
@@ -15885,6 +15951,7 @@ type requirements. If a template parameter is named \tcode{R1} or \tcode{R2},
 and the template argument is not a specialization of the \tcode{ratio} template,
 the program is ill-formed.
 
+\indexlibrary{\idxhdr{ratio}}%
 \rSec2[ratio.syn]{Header \tcode{<ratio>} synopsis}
 
 \begin{codeblockdigitsep}
@@ -15946,6 +16013,7 @@ namespace std {
 
 \rSec2[ratio.ratio]{Class template \tcode{ratio}}
 
+\indexlibrary{\idxcode{ratio}}%
 \begin{codeblock}
 namespace std {
   template <intmax_t N, intmax_t D = 1>
@@ -16047,19 +16115,19 @@ static_assert(ratio_multiply<ratio<1, INT_MAX>, ratio<INT_MAX, 2>>::den == 2,
 
 \rSec2[ratio.comparison]{Comparison of \tcode{ratio}{s}}
 
-\indexlibrary{\idxcode{ratio_equal}}
+\indexlibrary{\idxcode{ratio_equal}}%
 \begin{itemdecl}
 template <class R1, class R2> struct ratio_equal
   : bool_constant<R1::num == R2::num && R1::den == R2::den> { };
 \end{itemdecl}
 
-\indexlibrary{\idxcode{ratio_not_equal}}
+\indexlibrary{\idxcode{ratio_not_equal}}%
 \begin{itemdecl}
 template <class R1, class R2> struct ratio_not_equal
   : bool_constant<!ratio_equal_v<R1, R2>> { };
 \end{itemdecl}
 
-\indexlibrary{\idxcode{ratio_less}}
+\indexlibrary{\idxcode{ratio_less}}%
 \begin{itemdecl}
 template <class R1, class R2> struct ratio_less
   : bool_constant<@\seebelow@> { };
@@ -16074,19 +16142,19 @@ derived from \tcode{bool_constant<true>}; otherwise it shall be derived from
 compute this relationship to avoid overflow. If overflow occurs, the program is ill-formed.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{ratio_less_equal}}
+\indexlibrary{\idxcode{ratio_less_equal}}%
 \begin{itemdecl}
 template <class R1, class R2> struct ratio_less_equal
   : bool_constant<!ratio_less_v<R2, R1>> { };
 \end{itemdecl}
 
-\indexlibrary{\idxcode{ratio_greater}}
+\indexlibrary{\idxcode{ratio_greater}}%
 \begin{itemdecl}
 template <class R1, class R2> struct ratio_greater
   : bool_constant<ratio_less_v<R2, R1>> { };
 \end{itemdecl}
 
-\indexlibrary{\idxcode{ratio_greater_equal}}
+\indexlibrary{\idxcode{ratio_greater_equal}}%
 \begin{itemdecl}
 template <class R1, class R2> struct ratio_greater_equal
   : bool_constant<!ratio_less_v<R1, R2>> { };
@@ -16111,6 +16179,7 @@ This subclause describes the chrono library~(\ref{time.syn}) and various C
 functions~(\ref{ctime.syn}) that provide generally useful time
 utilities.
 
+\indexlibrary{\idxhdr{chrono}}%
 \rSec2[time.syn]{Header \tcode{<chrono>} synopsis}
 
 \begin{codeblock}
@@ -16508,6 +16577,7 @@ A \tcode{duration} has a representation which holds a count of ticks and a tick 
 The tick period is the amount of time which occurs from one tick to the next, in units
 of seconds. It is expressed as a rational constant using the template \tcode{ratio}.
 
+\indexlibrary{\idxcode{duration}}%
 \begin{codeblock}
 template <class Rep, class Period = ratio<1>>
 class duration {
@@ -16977,7 +17047,7 @@ template <class Rep1, class Period1, class Rep2, class Period2>
 \returns \tcode{\placeholder{CT}(lhs).count() == \placeholder{CT}(rhs).count()}.
 \end{itemdescr}
 
-\indexlibrarymember{duration}{operator"!=}%
+\indexlibrarymember{operator"!=}{duration}%
 \begin{itemdecl}
 template <class Rep1, class Period1, class Rep2, class Period2>
   constexpr bool operator!=(const duration<Rep1, Period1>& lhs, const duration<Rep2, Period2>& rhs);
@@ -17082,7 +17152,7 @@ computations are carried out in the widest representation and only converted to
 the destination representation at the final step.
 \end{itemdescr}
 
-\indexlibrarymember{duration}{floor}%
+\indexlibrarymember{floor}{duration}%
 \begin{itemdecl}
 template <class ToDuration, class Rep, class Period>
   constexpr ToDuration floor(const duration<Rep, Period>& d);
@@ -17098,7 +17168,7 @@ unless \tcode{ToDuration} is a specialization of \tcode{duration}.
 for which \tcode{t <= d}.
 \end{itemdescr}
 
-\indexlibrarymember{duration}{ceil}%
+\indexlibrarymember{ceil}{duration}%
 \begin{itemdecl}
 template <class ToDuration, class Rep, class Period>
   constexpr ToDuration ceil(const duration<Rep, Period>& d);
@@ -17114,7 +17184,7 @@ unless \tcode{ToDuration} is a specialization of \tcode{duration}.
 for which \tcode{t >= d}.
 \end{itemdescr}
 
-\indexlibrarymember{duration}{round}%
+\indexlibrarymember{round}{duration}%
 \begin{itemdecl}
 template <class ToDuration, class Rep, class Period>
   constexpr ToDuration round(const duration<Rep, Period>& d);
@@ -17162,6 +17232,7 @@ auto constexpr halfanhour=0.5h;
 \end{codeblock}
 \end{example}
 
+\indexlibrarymember{operator """" h}{duration}%
 \begin{itemdecl}
 constexpr chrono::hours                                 operator "" h(unsigned long long hours);
 constexpr chrono::duration<@\unspec,@ ratio<3600, 1>> operator "" h(long double hours);
@@ -17173,6 +17244,7 @@ constexpr chrono::duration<@\unspec,@ ratio<3600, 1>> operator "" h(long double 
 A \tcode{duration} literal representing \tcode{hours} hours.
 \end{itemdescr}
 
+\indexlibrarymember{operator """" min}{duration}%
 \begin{itemdecl}
 constexpr chrono::minutes                             operator "" min(unsigned long long minutes);
 constexpr chrono::duration<@\unspec,@ ratio<60, 1>> operator "" min(long double minutes);
@@ -17184,6 +17256,7 @@ constexpr chrono::duration<@\unspec,@ ratio<60, 1>> operator "" min(long double 
 A \tcode{duration} literal representing \tcode{minutes} minutes.
 \end{itemdescr}
 
+\indexlibrarymember{operator """" s}{duration}%
 \begin{itemdecl}
 constexpr chrono::seconds  @\itcorr@             operator "" s(unsigned long long sec);
 constexpr chrono::duration<@\unspec@> operator "" s(long double sec);
@@ -17202,6 +17275,7 @@ apply to character array literals.
 \end{note}
 \end{itemdescr}
 
+\indexlibrarymember{operator """" ms}{duration}%
 \begin{itemdecl}
 constexpr chrono::milliseconds                 operator "" ms(unsigned long long msec);
 constexpr chrono::duration<@\unspec,@ milli> operator "" ms(long double msec);
@@ -17213,6 +17287,7 @@ constexpr chrono::duration<@\unspec,@ milli> operator "" ms(long double msec);
 A \tcode{duration} literal representing \tcode{msec} milliseconds.
 \end{itemdescr}
 
+\indexlibrarymember{operator """" us}{duration}%
 \begin{itemdecl}
 constexpr chrono::microseconds                 operator "" us(unsigned long long usec);
 constexpr chrono::duration<@\unspec,@ micro> operator "" us(long double usec);
@@ -17224,6 +17299,7 @@ constexpr chrono::duration<@\unspec,@ micro> operator "" us(long double usec);
 A \tcode{duration} literal representing \tcode{usec} microseconds.
 \end{itemdescr}
 
+\indexlibrarymember{operator """" ns}{duration}%
 \begin{itemdecl}
 constexpr chrono::nanoseconds                 operator "" ns(unsigned long long nsec);
 constexpr chrono::duration<@\unspec,@ nano> operator "" ns(long double nsec);
@@ -17237,7 +17313,7 @@ A \tcode{duration} literal representing \tcode{nsec} nanoseconds.
 
 \rSec3[time.duration.alg]{\tcode{duration} algorithms}
 
-\indexlibrarymember{duration}{abs}%
+\indexlibrarymember{abs}{duration}%
 \begin{itemdecl}
 template <class Rep, class Period>
   constexpr duration<Rep, Period> abs(duration<Rep, Period> d);
@@ -17255,6 +17331,7 @@ otherwise return \tcode{-d}.
 
 \rSec2[time.point]{Class template \tcode{time_point}}
 
+\indexlibrary{\idxcode{time_point}}%
 \begin{codeblock}
 template <class Clock, class Duration = typename Clock::duration>
 class time_point {
@@ -17337,7 +17414,7 @@ is implicitly convertible to \tcode{duration}.
 
 \rSec3[time.point.observer]{\tcode{time_point} observer}
 
-\indexlibrarymember{time_point}{time_since_epoch}%
+\indexlibrarymember{time_since_epoch}{time_point}%
 \begin{itemdecl}
 constexpr duration time_since_epoch() const;
 \end{itemdecl}
@@ -17463,8 +17540,7 @@ template <class Clock, class Duration1, class Duration2>
 \returns \tcode{lhs.time_since_epoch() == rhs.time_since_epoch()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{time_point}}%
-\indexlibrary{\idxcode{time_point}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{time_point}%
 \begin{itemdecl}
 template <class Clock, class Duration1, class Duration2>
   constexpr bool operator!=(const time_point<Clock, Duration1>& lhs, const time_point<Clock, Duration2>& rhs);
@@ -17538,7 +17614,7 @@ unless \tcode{ToDuration} is a specialization of \tcode{duration}.
 \returns \tcode{time_point<Clock, ToDuration>(duration_cast<ToDuration>(t.time_since_epoch()))}.
 \end{itemdescr}
 
-\indexlibrarymember{time_point}{floor}%
+\indexlibrarymember{floor}{time_point}%
 \begin{itemdecl}
 template <class ToDuration, class Clock, class Duration>
   constexpr time_point<Clock, ToDuration>
@@ -17554,7 +17630,7 @@ unless \tcode{ToDuration} is a specialization of \tcode{duration}.
 \returns \tcode{time_point<Clock, ToDuration>(floor<ToDuration>(tp.time_since_epoch()))}.
 \end{itemdescr}
 
-\indexlibrarymember{time_point}{ceil}%
+\indexlibrarymember{ceil}{time_point}%
 \begin{itemdecl}
 template <class ToDuration, class Clock, class Duration>
   constexpr time_point<Clock, ToDuration>
@@ -17570,7 +17646,7 @@ unless \tcode{ToDuration} is a specialization of \tcode{duration}.
 \returns \tcode{time_point<Clock, ToDuration>(ceil<ToDuration>(tp.time_since_epoch()))}.
 \end{itemdescr}
 
-\indexlibrarymember{time_point}{round}%
+\indexlibrarymember{round}{time_point}%
 \begin{itemdecl}
 template <class ToDuration, class Clock, class Duration>
   constexpr time_point<Clock, ToDuration>
@@ -17595,6 +17671,7 @@ The types defined in this subclause shall satisfy the
 requirements~(\ref{time.clock.req}).
 
 \rSec3[time.clock.system]{Class \tcode{system_clock}}
+\indexlibrary{\idxcode{system_clock}}%
 
 \pnum
 Objects of class \tcode{system_clock} represent wall clock time from the system-wide
@@ -17628,7 +17705,7 @@ using system_clock::rep = @\unspec@;
 be \tcode{true}. \begin{note} This implies that \tcode{rep} is a signed type. \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{to_time_t}}%
+\indexlibrarymember{to_time_t}{system_clock}%
 \begin{itemdecl}
 static time_t to_time_t(const time_point& t) noexcept;
 \end{itemdecl}
@@ -17643,7 +17720,7 @@ required precision when converting between \tcode{time_t} values and \tcode{time
 whether values are rounded or truncated to the required precision.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{from_time_t}}%
+\indexlibrarymember{from_time_t}{system_clock}%
 \begin{itemdecl}
 static time_point from_time_t(time_t t) noexcept;
 \end{itemdecl}
@@ -17659,6 +17736,7 @@ whether values are rounded or truncated to the required precision.
 \end{itemdescr}
 
 \rSec3[time.clock.steady]{Class \tcode{steady_clock}}
+\indexlibrary{\idxcode{steady_clock}}%
 
 \pnum
 Objects of class \tcode{steady_clock} represent clocks for which values of \tcode{time_point}
@@ -17679,6 +17757,7 @@ public:
 \end{codeblock}
 
 \rSec3[time.clock.hires]{Class \tcode{high_resolution_clock}}
+\indexlibrary{\idxcode{high_resolution_clock}}%
 
 \pnum
 Objects of class \tcode{high_resolution_clock} represent clocks with the
@@ -17763,7 +17842,7 @@ races~(\ref{res.on.data.races}).
 
 \rSec1[type.index]{Class \tcode{type_index}}
 
-\indexlibrary{\idxhdr{typeinfo}}%
+\indexlibrary{\idxhdr{typeindex}}%
 \rSec2[type.index.synopsis]{Header \tcode{<typeindex>} synopsis}
 
 \begin{codeblock}
@@ -17776,6 +17855,7 @@ namespace std {
 
 \rSec2[type.index.overview]{\tcode{type_index} overview}
 
+\indexlibrary{\idxcode{type_index}}%
 \begin{codeblock}
 namespace std {
   class type_index {
@@ -17826,8 +17906,7 @@ bool operator==(const type_index& rhs) const noexcept;
 \returns \tcode{*target == *rhs.target}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{type_index}}%
-\indexlibrary{\idxcode{type_index}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{type_index}%
 \begin{itemdecl}
 bool operator!=(const type_index& rhs) const noexcept;
 \end{itemdecl}
@@ -17899,7 +17978,7 @@ const char* name() const noexcept;
 
 \rSec2[type.index.hash]{Hash support}
 
-\indexlibrary{\idxcode{hash}}%
+\indexlibrary{\idxcode{hash}!\idxcode{type_index}}%
 \begin{itemdecl}
 template <> struct hash<type_index>;
 \end{itemdecl}


### PR DESCRIPTION
* fix outright errors, indexing the wrong name
    * fix errors of omission: every itemdecl is now indexed
    * consistent ordering of indexlibrarymember{identifier}{class-name}
    * escape newlines everywhere
    * indexhdr entry for all headers