### PR TITLE
[re.traits] Remove excessive newlines from codeblocks.

### DIFF
--- a/source/regex.tex
+++ b/source/regex.tex
@@ -1226,7 +1226,6 @@ if (ct.is(m, c)) {
 } else if (c == ct.widen('_')) {
   charT w[1] = { ct.widen('w') };
   char_class_type x = lookup_classname(w, w+1);
-  
   return (f&x) == x;
 } else {
   return false;
@@ -1234,7 +1233,6 @@ if (ct.is(m, c)) {
 \end{codeblock}
 \begin{example}
 \begin{codeblock}
-
 regex_traits<char> t;
 string d("d");
 string u("upper");
@@ -1246,7 +1244,6 @@ ctype_base::mask m = convert<char>(f); // \tcode{m == ctype_base::digit|ctype_ba
 \end{example}
 \begin{example}
 \begin{codeblock}
-
 regex_traits<char> t;
 string w("w");
 regex_traits<char>::char_class_type f;


### PR DESCRIPTION
These two newlines are visible in the pdf as awkward whitespace.

I also tried a larger patch which removed trailing newlines and spliced adjacent codeblocks as well, but that seemed to have no visible effect.