### PR TITLE
[cpp.predefined] Make description for __cplusplus non-redundant and consistent with rest.

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1237,11 +1237,8 @@ The following macro names shall be defined by the implementation:
 
 \indextext{__CPLUSPLUS@\xname{cplusplus}}%
 \item \xname{cplusplus}\\
-The name \xname{cplusplus} is defined
-to the value
-\tcode{\cppver}
-when
-compiling a \Cpp translation unit.\footnote{It is intended that future
+The integer literal \tcode{\cppver}.
+\footnote{It is intended that future
 versions of this standard will
 replace the value of this macro with a greater value.
 Non-conforming compilers should use a value with at most


### PR DESCRIPTION
On the point of redundancy: please correct me if I'm wrong, but my understanding is that /all/ the requirements in the C++ standard only apply to implementations compiling C++ translation units, in which case spelling it out in this instance seems unnecessary. :)