### PR TITLE
[dcl.attr.deprecated, depr.ostream.members] Fix trailing whitespace in \tcode.

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3990,7 +3990,7 @@ Redeclarations using different forms of the attribute (with or without the
 \grammarterm{attribute-argument-clause}{s}) are allowed.
 
 \pnum
-\begin{note} Implementations may use the \tcode{deprecated }attribute to produce a diagnostic
+\begin{note} Implementations may use the \tcode{deprecated} attribute to produce a diagnostic
 message in case the program refers to a name or entity other than to declare it, after a
 declaration that specifies the attribute. The diagnostic message may include the text provided
 within the \grammarterm{attribute-argument-clause} of any \tcode{deprecated} attribute applied

--- a/source/future.tex
+++ b/source/future.tex
@@ -976,7 +976,7 @@ strstreambuf* rdbuf() const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{(strstreambuf*)\&sb }.
+\tcode{(strstreambuf*)\&sb}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{freeze}!\idxcode{ostrstream}}%


### PR DESCRIPTION
(Of the two changes, only the change in [depr.ostream.members] has a visible effect.)