### PR TITLE
[meta.unary.cat] Use core term non-union class type

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -14785,7 +14785,7 @@ but not pointers to non-static members.                        \\ \rowsep
 \tcode{T} is a union type~(\ref{basic.compound})                        &   \\ \rowsep
 \tcode{template <class T>}\br
  \tcode{struct is_class;}           &
-\tcode{T} is a class type but not a union type~(\ref{basic.compound}) & \\ \rowsep
+\tcode{T} is a non-union class type~(\ref{basic.compound}) & \\ \rowsep
 \tcode{template <class T>}\br
  \tcode{struct is_function;}        &
 \tcode{T} is a function type~(\ref{basic.compound})                     &   \\


### PR DESCRIPTION
There is another use of "but not a union type" in this section, which will be captured in an LWG issue resolution (http://cplusplus.github.io/LWG/lwg-active.html#2358) in Chicago.