### PR TITLE
[input.output] Review library index for clause 27

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -95,8 +95,9 @@ are other types is
 \pnum
 In the classes of Clause~\ref{input.output}, a template parameter with name
 \tcode{charT} represents a member of the set of types containing \tcode{char}, \tcode{wchar_t},
-and any other implementation-defined character types that satisfy the requirements for
-a character on which any of the iostream components can be instantiated.
+and any other \impldef{set of character types that iostreams templates can be instantiated for}
+character types that satisfy the requirements for a character on which any of
+the iostream components can be instantiated.
 
 \rSec2[iostreams.threadsafety]{Thread safety}
 
@@ -999,7 +1000,7 @@ also defines the constants indicated in Table~\ref{tab:iostreams.fmtflags.consta
 
 \rSec4[ios::iostate]{Type \tcode{ios_base::iostate}}
 
-\indexlibrarymember{ios_base}{iostate}%
+\indexlibrarymember{iostate}{ios_base}%
 \begin{itemdecl}
 using iostate = @\textit{T2}@;
 \end{itemdecl}
@@ -1173,7 +1174,7 @@ fmtflags flags() const;
 The format control information for both input and output.
 \end{itemdescr}
 
-\indexlibrarymember{ios_base}{flags}%
+\indexlibrarymember{flags}{ios_base}%
 \begin{itemdecl}
 fmtflags flags(fmtflags fmtfl);
 \end{itemdecl}
@@ -2168,8 +2169,7 @@ explicit operator bool() const;
 \returns \tcode{!fail()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!}!\idxcode{basic_ios}}%
-\indexlibrary{\idxcode{basic_ios}!\idxcode{operator"!}}%
+\indexlibrarymember{operator"!}{basic_ios}%
 \begin{itemdecl}
 bool operator!() const;
 \end{itemdecl}
@@ -4321,7 +4321,7 @@ a failure indication.
 explicit basic_istream(basic_streambuf<charT, traits>* sb);
 \end{itemdecl}
 
-\indexlibrary{\idxcode{init}!\idxcode{basic_ios}}%
+\indexlibrarymember{init}{basic_ios}%
 \begin{itemdescr}
 \pnum
 \effects
@@ -4396,6 +4396,7 @@ Exchanges the values returned by \tcode{gcount()} and
 
 \rSec4[istream::sentry]{Class \tcode{basic_istream::sentry}}
 
+\indexlibrary{\idxcode{basic_istream::sentry}}%
 \indexlibrary{\idxcode{sentry}!\idxcode{basic_istream}}%
 \begin{codeblock}
 namespace std {
@@ -4695,7 +4696,7 @@ This extractor does not behave as a formatted input function
 \returns
 \tcode{pf(*this)}.\footnote{See, for example, the function signature
 \tcode{ws(basic_istream\&)}~(\ref{istream.manip}).%
-\indexlibrary{\idxcode{ws}}}
+\indexlibrary{\idxcode{ws}}}%
 \end{itemdescr}
 
 \indexlibrarymember{operator\shr}{basic_istream}%
@@ -5600,6 +5601,24 @@ but not
 \tcode{is}.
 \end{itemdescr}
 
+\rSec3[istream.rvalue]{Rvalue stream extraction}
+
+\indexlibrarymember{operator\shr}{basic_istream}%
+\begin{itemdecl}
+template <class charT, class traits, class T>
+  basic_istream<charT, traits>&
+  operator>>(basic_istream<charT, traits>&& is, T&& x);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Equivalent to:
+\begin{codeblock}
+is >> std::forward<T>(x);
+return is;
+\end{codeblock}
+\end{itemdescr}
+
 \rSec3[iostreamclass]{Class template \tcode{basic_iostream}}
 
 \indexlibrary{\idxcode{basic_iostream}}%
@@ -5663,7 +5682,6 @@ and
 \tcode{rdbuf() == sb}
 and
 \tcode{gcount() == 0}.
-\indexlibrary{\idxcode{basic_iostream}!destructor}%
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_iostream}!constructor}%
@@ -5719,24 +5737,6 @@ void swap(basic_iostream& rhs);
 \effects Calls \tcode{basic_istream<charT, traits>::swap(rhs)}.
 \end{itemdescr}
 
-\rSec3[istream.rvalue]{Rvalue stream extraction}
-
-\indexlibrarymember{operator\shr}{basic_istream}%
-\begin{itemdecl}
-template <class charT, class traits, class T>
-  basic_istream<charT, traits>&
-  operator>>(basic_istream<charT, traits>&& is, T&& x);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects Equivalent to:
-\begin{codeblock}
-is >> std::forward<T>(x);
-return is;
-\end{codeblock}
-\end{itemdescr}
-
 
 \rSec2[output.streams]{Output streams}
 
@@ -5748,6 +5748,8 @@ and several function signatures that control output to a
 stream buffer along with a function template that inserts into stream rvalues.
 
 \rSec3[ostream]{Class template \tcode{basic_ostream}}
+
+\indexlibrary{\idxcode{basic_ostream}}%
 \begin{codeblock}
 namespace std {
   template <class charT, class traits = char_traits<charT> >
@@ -5894,7 +5896,7 @@ the output function
 rethrows the exception without completing its actions, otherwise
 it does not throw anything and treat as an error.
 
-\rSec3[ostream.cons]{\tcode{basic_ostream} constructors}
+\rSec4[ostream.cons]{\tcode{basic_ostream} constructors}
 
 \indexlibrary{\idxcode{basic_ostream}!constructor}%
 \begin{itemdecl}
@@ -5914,6 +5916,19 @@ assigning initial values to the base class by calling
 \postcondition
 \tcode{rdbuf() == sb}.
 
+\indexlibrary{\idxcode{basic_ostream}!constructor}%
+\begin{itemdecl}
+basic_ostream(basic_ostream&& rhs);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Move constructs from the rvalue \tcode{rhs}.
+This is accomplished by default constructing the base class and calling
+\tcode{basic_ios<charT, traits>::move(rhs)} to initialize the
+base class.
+\end{itemdescr}
+
 \indexlibrary{\idxcode{basic_ostream}!destructor}%
 \begin{itemdecl}
 virtual ~basic_ostream();
@@ -5930,20 +5945,7 @@ Does not perform any operations on
 \tcode{rdbuf()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{basic_ostream}!constructor}%
-\begin{itemdecl}
-basic_ostream(basic_ostream&& rhs);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects Move constructs from the rvalue \tcode{rhs}.
-This is accomplished by default constructing the base class and calling
-\tcode{basic_ios<charT, traits>::move(rhs)} to initialize the
-base class.
-\end{itemdescr}
-
-\rSec3[ostream.assign]{Class \tcode{basic_ostream} assign and swap}
+\rSec4[ostream.assign]{Class \tcode{basic_ostream} assign and swap}
 
 \indexlibrarymember{operator=}{basic_ostream}%
 \begin{itemdecl}
@@ -5968,8 +5970,9 @@ void swap(basic_ostream& rhs);
 \effects Calls \tcode{basic_ios<charT, traits>::swap(rhs)}.
 \end{itemdescr}
 
-\rSec3[ostream::sentry]{Class \tcode{basic_ostream::sentry}}
+\rSec4[ostream::sentry]{Class \tcode{basic_ostream::sentry}}
 
+\indexlibrary{\idxcode{basic_ostream::sentry}}%
 \indexlibrary{\idxcode{sentry}!\idxcode{basic_ostream}}%
 \begin{codeblock}
 namespace std {
@@ -6047,7 +6050,6 @@ calls
 \tcode{os.rdstate()} without propagating an exception.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{flush}}%
 \indexlibrarymember{operator bool}{basic_ostream::sentry}%
 \begin{itemdecl}
 explicit operator bool() const;
@@ -6060,7 +6062,7 @@ Returns
 \tcode{ok_}.
 \end{itemdescr}
 
-\rSec3[ostream.seeks]{\tcode{basic_ostream} seek members}
+\rSec4[ostream.seeks]{\tcode{basic_ostream} seek members}
 
 \pnum
 Each seek member function begins execution by constructing an object of class \tcode{sentry}.
@@ -6083,6 +6085,7 @@ Otherwise, returns
 \tcode{rdbuf()->\brk{}pub\-seek\-off(\brk0, cur, out)}.
 \end{itemdescr}
 
+\indexlibrarymember{seekp}{basic_ostream}%
 \begin{itemdecl}
 basic_ostream<charT, traits>& seekp(pos_type pos);
 \end{itemdecl}
@@ -7248,6 +7251,10 @@ as described in~\ref{string.classes}.
 \indexlibrary{\idxcode{basic_ostringstream<char>}}%
 \indexlibrary{\idxcode{wostringstream}}%
 \indexlibrary{\idxcode{basic_ostringstream<wchar_t>}}%
+\indexlibrary{\idxcode{stringstream}}%
+\indexlibrary{\idxcode{basic_stringstream<char>}}%
+\indexlibrary{\idxcode{wstringstream}}%
+\indexlibrary{\idxcode{basic_stringstream<wchar_t>}}%
 \begin{codeblock}
 namespace std {
   template <class charT, class traits = char_traits<charT>,
@@ -8391,6 +8398,10 @@ reading and writing files.
 \indexlibrary{\idxcode{basic_ofstream<char>}}%
 \indexlibrary{\idxcode{wofstream}}%
 \indexlibrary{\idxcode{basic_ofstream<wchar_t>}}%
+\indexlibrary{\idxcode{fstream}}%
+\indexlibrary{\idxcode{basic_fstream<char>}}%
+\indexlibrary{\idxcode{wfstream}}%
+\indexlibrary{\idxcode{basic_fstream<wchar_t>}}%
 \begin{codeblock}
 namespace std {
   template <class charT, class traits = char_traits<charT> >
@@ -9892,8 +9903,7 @@ void open(
 \effects Calls \tcode{open(s.c_str(), mode)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{close}!\idxcode{basic_fstream}}%
-\indexlibrary{\idxcode{basic_fstream}!\idxcode{open}}%
+\indexlibrarymember{close}{basic_fstream}%
 \begin{itemdecl}
 void close();
 \end{itemdecl}
@@ -10161,6 +10171,7 @@ Unless otherwise specified, references to entities described in this
 sub-clause are assumed to be qualified with \tcode{::std::filesystem::}.
 
 \rSec2[fs.filesystem.syn]{Header \tcode{<filesystem>} synopsis}
+\indexlibrary{\idxhdr{filesystem}}%
 
 \begin{codeblock}
 namespace std::filesystem {
@@ -10596,10 +10607,12 @@ namespace std::filesystem {
 }
 \end{codeblock}
 
+\indexlibrarymember{value_type}{path}%
 \pnum
 \tcode{value_type} is a \tcode{typedef} for the
 operating system dependent encoded character type used to represent pathnames.
 
+\indexlibrarymember{preferred_separator}{path}%
 \pnum
 The value of \tcode{preferred_separator}
 is the operating system dependent \grammarterm{preferred-separator} character~(\ref{path.generic}).
@@ -11055,7 +11068,8 @@ Then appends \tcode{p.native()} to \tcode{pathname}.
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{path}{append}%
+\indexlibrarymember{operator/=}{path}%
+\indexlibrarymember{append}{path}%
 \begin{itemdecl}
 template <class Source>
   path& operator/=(const Source& source);
@@ -11126,7 +11140,7 @@ If the value type of \tcode{\textit{effective-argument}} would not be \tcode{pat
 
 \rSec4[path.modifiers]{\tcode{path} modifiers}
 
-\indexlibrarymember{path}{clear}%
+\indexlibrarymember{clear}{path}%
 \begin{itemdecl}
 void clear() noexcept;
 \end{itemdecl}
@@ -11136,7 +11150,7 @@ void clear() noexcept;
 \postcondition \tcode{empty() == true}.
 \end{itemdescr}
 
-\indexlibrarymember{path}{make_preferred}%
+\indexlibrarymember{make_preferred}{path}%
 \begin{itemdecl}
 path& make_preferred();
 \end{itemdecl}
@@ -11172,7 +11186,7 @@ output is:
 \end{example}
 \end{itemdescr}
 
-\indexlibrarymember{path}{remove_filename}%
+\indexlibrarymember{remove_filename}{path}%
 \begin{itemdecl}
 path& remove_filename();
 \end{itemdecl}
@@ -11193,7 +11207,7 @@ std::cout << path("/").remove_filename();     // outputs \tcode{""}
 \end{example}
 \end{itemdescr}
 
-\indexlibrarymember{path}{replace_filename}%
+\indexlibrarymember{replace_filename}{path}%
 \begin{itemdecl}
 path& replace_filename(const path& replacement);
 \end{itemdecl}
@@ -11218,7 +11232,7 @@ std::cout << path("/").replace_filename("bar");     // outputs \tcode{"bar"}
 \end{example}
 \end{itemdescr}
 
-\indexlibrarymember{path}{replace_extension}%
+\indexlibrarymember{replace_extension}{path}%
 \begin{itemdecl}
 path& replace_extension(const path& replacement = path());
 \end{itemdecl}
@@ -11239,7 +11253,7 @@ path& replace_extension(const path& replacement = path());
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{path}{swap}%
+\indexlibrarymember{swap}{path}%
 \begin{itemdecl}
 void swap(path& rhs) noexcept;
 \end{itemdecl}
@@ -11258,7 +11272,7 @@ void swap(path& rhs) noexcept;
 \pnum
 The string returned by all native format observers is in the native pathname format~(\ref{fs.def.native}).
 
-\indexlibrarymember{path}{native}%
+\indexlibrarymember{native}{path}%
 \begin{itemdecl}
 const string_type& native() const noexcept;
 \end{itemdecl}
@@ -11268,7 +11282,7 @@ const string_type& native() const noexcept;
 \returns \tcode{pathname}.
 \end{itemdescr}
 
-\indexlibrarymember{path}{c_str}%
+\indexlibrarymember{c_str}{path}%
 \begin{itemdecl}
 const value_type* c_str() const noexcept;
 \end{itemdecl}
@@ -11278,7 +11292,7 @@ const value_type* c_str() const noexcept;
 \returns \tcode{pathname.c_str()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{operator string_type}}%
+\indexlibrarymember{operator string_type}{path}%
 \begin{itemdecl}
 operator string_type() const;
 \end{itemdecl}
@@ -11293,6 +11307,7 @@ operator string_type() const;
   standard library file stream constructors and open functions. \end{note}
 \end{itemdescr}
 
+\indexlibrarymember{string}{path}%
 \begin{itemdecl}
 template <class EcharT, class traits = char_traits<EcharT>,
           class Allocator = allocator<EcharT>>
@@ -11310,11 +11325,11 @@ be performed by \tcode{a}. Conversion, if any, is specified by
 \ref{path.cvt}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{string}}%
-\indexlibrary{\idxcode{path}!\idxcode{wstring}}%
-\indexlibrary{\idxcode{path}!\idxcode{u8string}}%
-\indexlibrary{\idxcode{path}!\idxcode{u16string}}%
-\indexlibrary{\idxcode{path}!\idxcode{u32string}}%
+\indexlibrarymember{string}{path}%
+\indexlibrarymember{wstring}{path}%
+\indexlibrarymember{u8string}{path}%
+\indexlibrarymember{u16string}{path}%
+\indexlibrarymember{u32string}{path}%
 \begin{itemdecl}
 std::string string() const;
 std::wstring wstring() const;
@@ -11347,6 +11362,7 @@ the \grammarterm{directory-separator} character.
 its \grammarterm{preferred-separator}, \tcode{path("foo\textbackslash\textbackslash{}bar").generic_string()}
 returns \tcode{"foo/bar"}. \end{example}
 
+\indexlibrarymember{generic_string}{path}%
 \begin{itemdecl}
 template <class EcharT, class traits = char_traits<EcharT>,
           class Allocator = allocator<EcharT>>
@@ -11365,11 +11381,11 @@ be performed by \tcode{a}. Conversion, if any, is specified by
 \ref{path.cvt}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{path}!\idxcode{generic_string}}%
-\indexlibrary{\idxcode{path}!\idxcode{generic_wstring}}%
-\indexlibrary{\idxcode{path}!\idxcode{generic_u8string}}%
-\indexlibrary{\idxcode{path}!\idxcode{generic_u16string}}%
-\indexlibrary{\idxcode{path}!\idxcode{generic_u32string}}%
+\indexlibrarymember{generic_string}{path}%
+\indexlibrarymember{generic_wstring}{path}%
+\indexlibrarymember{generic_u8string}{path}%
+\indexlibrarymember{generic_u16string}{path}%
+\indexlibrarymember{generic_u32string}{path}%
 \begin{itemdecl}
 std::string generic_string() const;
 std::wstring generic_wstring() const;
@@ -11391,6 +11407,7 @@ UTF-8.
 
 \rSec4[path.compare]{\tcode{path} compare}
 
+\indexlibrarymember{compare}{path}%
 \begin{itemdecl}
 int compare(const path& p) const noexcept;
 \end{itemdecl}
@@ -11415,6 +11432,7 @@ int compare(const path& p) const noexcept;
 range \range{begin()}{end()} for \tcode{*this} and \tcode{p}.
 \end{itemdescr}
 
+\indexlibrarymember{compare}{path}%
 \begin{itemdecl}
 int compare(const string_type& s) const
 int compare(basic_string_view<value_type> s) const;
@@ -11425,6 +11443,7 @@ int compare(basic_string_view<value_type> s) const;
 \returns \tcode{compare(path(s))}.
 \end{itemdescr}
 
+\indexlibrarymember{compare}{path}%
 \begin{itemdecl}
 int compare(const value_type* s) const
 \end{itemdecl}
@@ -11436,7 +11455,7 @@ int compare(const value_type* s) const
 
 \rSec4[path.decompose]{\tcode{path} decomposition}
 
-\indexlibrarymember{path}{root_name}%
+\indexlibrarymember{root_name}{path}%
 \begin{itemdecl}
 path root_name() const;
 \end{itemdecl}
@@ -11446,7 +11465,7 @@ path root_name() const;
 \returns \grammarterm{root-name}, if \tcode{pathname} includes \grammarterm{root-name}, otherwise \tcode{path()}.
 \end{itemdescr}
 
-\indexlibrarymember{path}{root_directory}%
+\indexlibrarymember{root_directory}{path}%
 \begin{itemdecl}
 path root_directory() const;
 \end{itemdecl}
@@ -11456,7 +11475,7 @@ path root_directory() const;
 \returns \grammarterm{root-directory}, if \tcode{pathname} includes \grammarterm{root-directory}, otherwise \tcode{path()}.
 \end{itemdescr}
 
-\indexlibrarymember{path}{root_path}%
+\indexlibrarymember{root_path}{path}%
 \begin{itemdecl}
 path root_path() const;
 \end{itemdecl}
@@ -11466,7 +11485,7 @@ path root_path() const;
 \returns \tcode{root_name() / root_directory()}.
 \end{itemdescr}
 
-\indexlibrarymember{path}{relative_path}%
+\indexlibrarymember{relative_path}{path}%
 \begin{itemdecl}
 path relative_path() const;
 \end{itemdecl}
@@ -11477,7 +11496,7 @@ path relative_path() const;
 with the first \grammarterm{filename} after \grammarterm{root-path}. Otherwise, \tcode{path()}.
 \end{itemdescr}
 
-\indexlibrarymember{path}{parent_path}%
+\indexlibrarymember{parent_path}{path}%
 \begin{itemdecl}
 path parent_path() const;
 \end{itemdecl}
@@ -11490,7 +11509,7 @@ where \tcode{\textit{pp}} is constructed as if by
   \range{begin()}{--end()}.
 \end{itemdescr}
 
-\indexlibrarymember{path}{filename}%
+\indexlibrarymember{filename}{path}%
 \begin{itemdecl}
 path filename() const;
 \end{itemdecl}
@@ -11510,7 +11529,7 @@ std::cout << path("..").filename();           // outputs ".."
 \end{example}
 \end{itemdescr}
 
-\indexlibrarymember{path}{stem}%
+\indexlibrarymember{stem}{path}%
 \begin{itemdecl}
 path stem() const;
 \end{itemdecl}
@@ -11537,7 +11556,7 @@ for (; !p.extension().empty(); p = p.stem())
 \end{example}
 \end{itemdescr}
 
-\indexlibrarymember{path}{extension}%
+\indexlibrarymember{extension}{path}%
 \begin{itemdecl}
 path extension() const;
 \end{itemdecl}
@@ -11570,7 +11589,7 @@ std::cout << path("/foo/bar.txt").extension(); // outputs ".txt"
 
 \rSec4[path.query]{\tcode{path} query}
 
-\indexlibrarymember{path}{empty}%
+\indexlibrarymember{empty}{path}%
 \begin{itemdecl}
 bool empty() const noexcept;
 \end{itemdecl}
@@ -11580,7 +11599,7 @@ bool empty() const noexcept;
 \returns \tcode{pathname.empty()}.
 \end{itemdescr}
 
-\indexlibrarymember{path}{has_root_path}%
+\indexlibrarymember{has_root_path}{path}%
 \begin{itemdecl}
 bool has_root_path() const;
 \end{itemdecl}
@@ -11590,7 +11609,7 @@ bool has_root_path() const;
 \returns \tcode{!root_path().empty()}.
 \end{itemdescr}
 
-\indexlibrarymember{path}{has_root_name}%
+\indexlibrarymember{has_root_name}{path}%
 \begin{itemdecl}
 bool has_root_name() const;
 \end{itemdecl}
@@ -11600,7 +11619,7 @@ bool has_root_name() const;
 \returns \tcode{!root_name().empty()}.
 \end{itemdescr}
 
-\indexlibrarymember{path}{has_root_directory}%
+\indexlibrarymember{has_root_directory}{path}%
 \begin{itemdecl}
 bool has_root_directory() const;
 \end{itemdecl}
@@ -11610,7 +11629,7 @@ bool has_root_directory() const;
 \returns \tcode{!root_directory().empty()}.
 \end{itemdescr}
 
-\indexlibrarymember{path}{has_relative_path}%
+\indexlibrarymember{has_relative_path}{path}%
 \begin{itemdecl}
 bool has_relative_path() const;
 \end{itemdecl}
@@ -11620,7 +11639,7 @@ bool has_relative_path() const;
 \returns \tcode{!relative_path().empty()}.
 \end{itemdescr}
 
-\indexlibrarymember{path}{has_parent_path}%
+\indexlibrarymember{has_parent_path}{path}%
 \begin{itemdecl}
 bool has_parent_path() const;
 \end{itemdecl}
@@ -11630,7 +11649,7 @@ bool has_parent_path() const;
 \returns \tcode{!parent_path().empty()}.
 \end{itemdescr}
 
-\indexlibrarymember{path}{has_filename}%
+\indexlibrarymember{has_filename}{path}%
 \begin{itemdecl}
 bool has_filename() const;
 \end{itemdecl}
@@ -11640,7 +11659,7 @@ bool has_filename() const;
 \returns \tcode{!filename().empty()}.
 \end{itemdescr}
 
-\indexlibrarymember{path}{has_stem}%
+\indexlibrarymember{has_stem}{path}%
 \begin{itemdecl}
 bool has_stem() const;
 \end{itemdecl}
@@ -11650,7 +11669,7 @@ bool has_stem() const;
 \returns \tcode{!stem().empty()}.
 \end{itemdescr}
 
-\indexlibrarymember{path}{has_extension}%
+\indexlibrarymember{has_extension}{path}%
 \begin{itemdecl}
 bool has_extension() const;
 \end{itemdecl}
@@ -11660,7 +11679,7 @@ bool has_extension() const;
 \returns \tcode{!extension().empty()}.
 \end{itemdescr}
 
-\indexlibrarymember{path}{is_absolute}%
+\indexlibrarymember{is_absolute}{path}%
 \begin{itemdecl}
 bool is_absolute() const;
 \end{itemdecl}
@@ -11676,7 +11695,7 @@ bool is_absolute() const;
 operating systems. \end{example}
 \end{itemdescr}
 
-\indexlibrarymember{path}{is_relative}%
+\indexlibrarymember{is_relative}{path}%
 \begin{itemdecl}
 bool is_relative() const;
 \end{itemdecl}
@@ -11688,7 +11707,7 @@ bool is_relative() const;
 
 \rSec4[path.gen]{\tcode{path} generation}
 
-\indexlibrarymember{path}{lexically_normal}%
+\indexlibrarymember{lexically_normal}{path}%
 \begin{itemdecl}
 path lexically_normal() const;
 \end{itemdecl}
@@ -11713,7 +11732,7 @@ but that does not affect \tcode{path} equality.
 \end{example}
 \end{itemdescr}
 
-\indexlibrarymember{path}{lexically_relative}%
+\indexlibrarymember{lexically_relative}{path}%
 \begin{itemdecl}
 path lexically_relative(const path& base) const;
 \end{itemdecl}
@@ -11773,7 +11792,7 @@ but that does not affect \tcode{path} equality.
   \tcode{*this}, \tcode{base}, or both. \end{note}
 \end{itemdescr}
 
-\indexlibrarymember{path}{lexically_proximate}%
+\indexlibrarymember{lexically_proximate}{path}%
 \begin{itemdecl}
 path lexically_proximate(const path& base) const;
 \end{itemdecl}
@@ -11942,8 +11961,7 @@ Programmers wishing to determine if two paths are ``the same'' must decide if
   file'', and choose the appropriate function accordingly. \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator"!=}!\idxcode{path}}%
-\indexlibrary{\idxcode{path}!\idxcode{operator"!=}}%
+\indexlibrarymember{operator"!=}{path}%
 \begin{itemdecl}
 bool operator!=(const path& lhs, const path& rhs) noexcept;
 \end{itemdecl}
@@ -12004,6 +12022,7 @@ p = tmp;
 
 \rSec4[path.factory]{\tcode{path} factory functions}
 
+\indexlibrary{\idxcode{u8path}}%
 \begin{itemdecl}
 template <class Source>
   path u8path(const Source& source);
@@ -12083,7 +12102,7 @@ namespace std::filesystem {
 
     const path& path1() const noexcept;
     const path& path2() const noexcept;
-    const char* what() const noexcept;
+    const char* what() const noexcept override;
   };
 }
 \end{codeblock}
@@ -12164,7 +12183,7 @@ Table~\ref{tab:filesystem_error.3}.
 \end{floattable}
 \end{itemdescr}
 
-\indexlibrarymember{filesystem_error}{path1}%
+\indexlibrarymember{path1}{filesystem_error}%
 \begin{itemdecl}
 const path& path1() const noexcept;
 \end{itemdecl}
@@ -12175,7 +12194,7 @@ const path& path1() const noexcept;
   constructor, or, if none, an empty path.
 \end{itemdescr}
 
-\indexlibrarymember{filesystem_error}{path2}%
+\indexlibrarymember{path2}{filesystem_error}%
 \begin{itemdecl}
 const path& path2() const noexcept;
 \end{itemdecl}
@@ -12186,9 +12205,9 @@ const path& path2() const noexcept;
   constructor, or, if none, an empty path.
 \end{itemdescr}
 
-\indexlibrarymember{filesystem_error}{what}%
+\indexlibrarymember{what}{filesystem_error}%
 \begin{itemdecl}
-const char* what() const noexcept;
+const char* what() const noexcept override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -12445,7 +12464,7 @@ explicit file_status(file_type ft, perms prms = perms::unknown) noexcept;
 
 \rSec3[file_status.obs]{\tcode{file_status} observers}
 
-\indexlibrarymember{file_status}{type}%
+\indexlibrarymember{type}{file_status}%
 \begin{itemdecl}
 file_type type() const noexcept;
 \end{itemdecl}
@@ -12456,7 +12475,7 @@ file_type type() const noexcept;
   \tcode{operator=}, or \tcode{type(file_type)} function.
 \end{itemdescr}
 
-\indexlibrarymember{file_status}{permissions}%
+\indexlibrarymember{permissions}{file_status}%
 \begin{itemdecl}
 perms permissions() const noexcept;
 \end{itemdecl}
@@ -12469,7 +12488,7 @@ perms permissions() const noexcept;
 
 \rSec3[file_status.mods]{\tcode{file_status} modifiers}
 
-\indexlibrarymember{file_status}{type}%
+\indexlibrarymember{type}{file_status}%
 \begin{itemdecl}
 void type(file_type ft) noexcept;
 \end{itemdecl}
@@ -12479,7 +12498,7 @@ void type(file_type ft) noexcept;
 \postconditions \tcode{type() == ft}.
 \end{itemdescr}
 
-\indexlibrarymember{file_status}{permissions}%
+\indexlibrarymember{permissions}{file_status}%
 \begin{itemdecl}
 void permissions(perms prms) noexcept;
 \end{itemdecl}
@@ -12491,6 +12510,7 @@ void permissions(perms prms) noexcept;
 
 \rSec2[class.directory_entry]{Class \tcode{directory_entry}}
 
+\indexlibrary{\idxcode{directory_entry}}%
 \begin{codeblock}
 namespace std::filesystem {
   class directory_entry {
@@ -12550,7 +12570,7 @@ explicit directory_entry(const path& p);
 
 \rSec3[directory_entry.mods]{\tcode{directory_entry} modifiers}
 
-\indexlibrarymember{directory_entry}{assign}%
+\indexlibrarymember{assign}{directory_entry}%
 \begin{itemdecl}
 void assign(const path& p);
 \end{itemdecl}
@@ -12560,7 +12580,7 @@ void assign(const path& p);
 \postcondition \tcode{path() == p}.
 \end{itemdescr}
 
-\indexlibrarymember{directory_entry}{replace_filename}%
+\indexlibrarymember{replace_filename}{directory_entry}%
 \begin{itemdecl}
 void replace_filename(const path& p);
 \end{itemdecl}
@@ -12574,7 +12594,8 @@ void replace_filename(const path& p);
 
 \rSec3[directory_entry.obs]{\tcode{directory_entry} observers}
 
-\indexlibrarymember{directory_entry}{path}%
+\indexlibrarymember{path}{directory_entry}%
+\indexlibrarymember{operator const path\&}{directory_entry}%
 \begin{itemdecl}
 const path& path() const noexcept;
 operator const path&() const noexcept;
@@ -12585,7 +12606,7 @@ operator const path&() const noexcept;
 \returns \tcode{pathobject}.
 \end{itemdescr}
 
-\indexlibrarymember{directory_entry}{status}%
+\indexlibrarymember{status}{directory_entry}%
 \begin{itemdecl}
 file_status status() const;
 file_status status(error_code& ec) const noexcept;
@@ -12599,10 +12620,10 @@ file_status status(error_code& ec) const noexcept;
 \throws As specified in Error reporting~(\ref{fs.err.report}).
 \end{itemdescr}
 
-\indexlibrarymember{directory_entry}{symlink_status}%
+\indexlibrarymember{symlink_status}{directory_entry}%
 \begin{itemdecl}
-file_status  symlink_status() const;
-file_status  symlink_status(error_code& ec) const noexcept;
+file_status symlink_status() const;
+file_status symlink_status(error_code& ec) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -12613,7 +12634,7 @@ file_status  symlink_status(error_code& ec) const noexcept;
 \throws As specified in Error reporting~(\ref{fs.err.report}).
 \end{itemdescr}
 
-\indexlibrarymember{directory_entry}{operator==}%
+\indexlibrarymember{operator==}{directory_entry}%
 \begin{itemdecl}
 bool operator==(const directory_entry& rhs) const noexcept;
 \end{itemdecl}
@@ -12623,7 +12644,7 @@ bool operator==(const directory_entry& rhs) const noexcept;
 \returns \tcode{pathobject == rhs.pathobject}.
 \end{itemdescr}
 
-\indexlibrarymember{directory_entry}{operator"!=}%
+\indexlibrarymember{operator"!=}{directory_entry}%
 \begin{itemdecl}
 bool operator!=(const directory_entry& rhs) const noexcept;
 \end{itemdecl}
@@ -12633,7 +12654,7 @@ bool operator!=(const directory_entry& rhs) const noexcept;
 \returns \tcode{pathobject != rhs.pathobject}.
 \end{itemdescr}
 
-\indexlibrarymember{directory_entry}{operator<}%
+\indexlibrarymember{operator<}{directory_entry}%
 \begin{itemdecl}
 bool operator< (const directory_entry& rhs) const noexcept;
 \end{itemdecl}
@@ -12643,7 +12664,7 @@ bool operator< (const directory_entry& rhs) const noexcept;
 \returns \tcode{pathobject < rhs.pathobject}.
 \end{itemdescr}
 
-\indexlibrarymember{directory_entry}{operator<=}%
+\indexlibrarymember{operator<=}{directory_entry}%
 \begin{itemdecl}
 bool operator<=(const directory_entry& rhs) const noexcept;
 \end{itemdecl}
@@ -12653,7 +12674,7 @@ bool operator<=(const directory_entry& rhs) const noexcept;
 \returns \tcode{pathobject <= rhs.pathobject}.
 \end{itemdescr}
 
-\indexlibrarymember{directory_entry}{operator>}%
+\indexlibrarymember{operator>}{directory_entry}%
 \begin{itemdecl}
 bool operator> (const directory_entry& rhs) const noexcept;
 \end{itemdecl}
@@ -12663,7 +12684,7 @@ bool operator> (const directory_entry& rhs) const noexcept;
 \returns \tcode{pathobject > rhs.pathobject}.
 \end{itemdescr}
 
-\indexlibrarymember{directory_entry}{operator>=}%
+\indexlibrarymember{operator>=}{directory_entry}%
 \begin{itemdecl}
 bool operator>=(const directory_entry& rhs) const noexcept;
 \end{itemdecl}
@@ -12818,7 +12839,7 @@ directory_iterator(directory_iterator&& rhs) noexcept;
 \postconditions \tcode{*this} has the original value of \tcode{rhs}.
 \end{itemdescr}
 
-\indexlibrarymember{directory_iterator}{operator=}%
+\indexlibrarymember{operator=}{directory_iterator}%
 \begin{itemdecl}
 directory_iterator& operator=(const directory_iterator& rhs);
 directory_iterator& operator=(directory_iterator&& rhs) noexcept;
@@ -12836,8 +12857,8 @@ directory_iterator& operator=(directory_iterator&& rhs) noexcept;
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{directory_iterator}{increment}%
-\indexlibrarymember{directory_iterator}{operator++}%
+\indexlibrarymember{increment}{directory_iterator}%
+\indexlibrarymember{operator++}{directory_iterator}%
 \begin{itemdecl}
 directory_iterator& operator++();
 directory_iterator& increment(error_code& ec) noexcept;
@@ -13037,7 +13058,7 @@ recursive_directory_iterator(recursive_directory_iterator&& rhs) noexcept;
   \tcode{rhs.recursion_pending()}, respectively, had before the function call.
 \end{itemdescr}
 
-\indexlibrarymember{recursive_directory_iterator}{operator=}%
+\indexlibrarymember{operator=}{recursive_directory_iterator}%
 \begin{itemdecl}
 recursive_directory_iterator& operator=(const recursive_directory_iterator& rhs);
 \end{itemdecl}
@@ -13059,7 +13080,7 @@ recursive_directory_iterator& operator=(const recursive_directory_iterator& rhs)
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{recursive_directory_iterator}{operator=}%
+\indexlibrarymember{operator=}{recursive_directory_iterator}%
 \begin{itemdecl}
 recursive_directory_iterator& operator=(recursive_directory_iterator&& rhs) noexcept;
 \end{itemdecl}
@@ -13078,7 +13099,7 @@ and \tcode{this->recursion_pending()} return the values that \tcode{rhs.options(
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{recursive_directory_iterator}{options}%
+\indexlibrarymember{options}{recursive_directory_iterator}%
 \begin{itemdecl}
 directory_options options() const;
 \end{itemdecl}
@@ -13092,7 +13113,7 @@ if present, otherwise \tcode{directory_options::none}.
 \throws Nothing.
 \end{itemdescr}
 
-\indexlibrarymember{recursive_directory_iterator}{depth}%
+\indexlibrarymember{depth}{recursive_directory_iterator}%
 \begin{itemdecl}
 int depth() const;
 \end{itemdecl}
@@ -13107,7 +13128,7 @@ int depth() const;
 \throws Nothing.
 \end{itemdescr}
 
-\indexlibrarymember{recursive_directory_iterator}{recursion_pending}%
+\indexlibrarymember{recursion_pending}{recursive_directory_iterator}%
 \begin{itemdecl}
 bool recursion_pending() const;
 \end{itemdecl}
@@ -13122,8 +13143,8 @@ bool recursion_pending() const;
 \throws Nothing.
 \end{itemdescr}
 
-\indexlibrarymember{recursive_directory_iterator}{increment}%
-\indexlibrarymember{recursive_directory_iterator}{operator++}%
+\indexlibrarymember{increment}{recursive_directory_iterator}%
+\indexlibrarymember{operator++}{recursive_directory_iterator}%
 \begin{itemdecl}
 recursive_directory_iterator& operator++();
 recursive_directory_iterator& increment(error_code& ec) noexcept;
@@ -13162,7 +13183,7 @@ treated as an empty directory and no error is reported.
 \throws As specified in Error reporting~(\ref{fs.err.report}).
 \end{itemdescr}
 
-\indexlibrarymember{recursive_directory_iterator}{pop}%
+\indexlibrarymember{pop}{recursive_directory_iterator}%
 \begin{itemdecl}
 void pop();
 void pop(error_code& ec);
@@ -13178,7 +13199,7 @@ void pop(error_code& ec);
 \throws As specified in Error reporting~(\ref{fs.err.report}).
 \end{itemdescr}
 
-\indexlibrarymember{recursive_directory_iterator}{disable_recursion_pending}%
+\indexlibrarymember{disable_recursion_pending}{recursive_directory_iterator}%
 \begin{itemdecl}
 void disable_recursion_pending();
 \end{itemdecl}
@@ -13232,7 +13253,7 @@ an error. See Error reporting~(\ref{fs.err.report}). \end{note}
 
 \rSec3[fs.op.absolute]{Absolute}
 
-\indexlibrary{\idxcode{absolute}}
+\indexlibrary{\idxcode{absolute}}%
 \begin{itemdecl}
 path absolute(const path& p, const path& base = current_path());
 \end{itemdecl}
@@ -13271,7 +13292,7 @@ path absolute(const path& p, const path& base = current_path());
 
 \rSec3[fs.op.canonical]{Canonical}
 
-\indexlibrary{\idxcode{canonical}}
+\indexlibrary{\idxcode{canonical}}%
 \begin{itemdecl}
 path canonical(const path& p, const path& base = current_path());
 path canonical(const path& p, error_code& ec);
@@ -13299,7 +13320,7 @@ Signatures with argument \tcode{ec} return \tcode{path()} if an error occurs.
 
 \rSec3[fs.op.copy]{Copy}
 
-\indexlibrary{\idxcode{copy}!\idxcode{path}}
+\indexlibrary{\idxcode{copy}!\idxcode{path}}%
 \begin{itemdecl}
 void copy(const path& from, const path& to);
 void copy(const path& from, const path& to, error_code& ec) noexcept;
@@ -13311,7 +13332,7 @@ void copy(const path& from, const path& to, error_code& ec) noexcept;
 or \tcode{copy(from, to, copy_options::none, ec)}, respectively.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{copy}!\idxcode{path}}
+\indexlibrary{\idxcode{copy}!\idxcode{path}}%
 \begin{itemdecl}
 void copy(const path& from, const path& to, copy_options options);
 void copy(const path& from, const path& to, copy_options options,
@@ -13448,6 +13469,8 @@ Alternatively, calling \tcode{copy("/dir1", "/dir3", copy_options::recursive)} w
 
 
 \rSec3[fs.op.copy_file]{Copy file}
+
+\indexlibrary{\idxcode{copy_file}}%
 \begin{itemdecl}
 bool copy_file(const path& from, const path& to);
 bool copy_file(const path& from, const path& to, error_code& ec) noexcept;
@@ -13463,7 +13486,7 @@ bool copy_file(const path& from, const path& to, error_code& ec) noexcept;
 
 \end{itemdescr}
 
-\indexlibrary{\idxcode{copy_file}}
+\indexlibrary{\idxcode{copy_file}}%
 \begin{itemdecl}
 bool copy_file(const path& from, const path& to, copy_options options);
 bool copy_file(const path& from, const path& to, copy_options options,
@@ -13516,7 +13539,7 @@ Otherwise, no effects.
 
 \rSec3[fs.op.copy_symlink]{Copy symlink}
 
-\indexlibrary{\idxcode{copy_symlink}}
+\indexlibrary{\idxcode{copy_symlink}}%
 \begin{itemdecl}
 void copy_symlink(const path& existing_symlink, const path& new_symlink);
 void copy_symlink(const path& existing_symlink, const path& new_symlink,
@@ -13538,7 +13561,7 @@ void copy_symlink(const path& existing_symlink, const path& new_symlink,
 
 \rSec3[fs.op.create_directories]{Create directories}
 
-\indexlibrary{\idxcode{create_directories}}
+\indexlibrary{\idxcode{create_directories}}%
 \begin{itemdecl}
 bool create_directories(const path& p);
 bool create_directories(const path& p, error_code& ec) noexcept;
@@ -13567,7 +13590,7 @@ bool create_directories(const path& p, error_code& ec) noexcept;
 
 \rSec3[fs.op.create_directory]{Create directory}
 
-\indexlibrary{\idxcode{create_directory}}
+\indexlibrary{\idxcode{create_directory}}%
 \begin{itemdecl}
 bool create_directory(const path& p);
 bool create_directory(const path& p, error_code& ec) noexcept;
@@ -13592,7 +13615,7 @@ bool create_directory(const path& p, error_code& ec) noexcept;
 \throws As specified in Error reporting~(\ref{fs.err.report}).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{create_directory}}
+\indexlibrary{\idxcode{create_directory}}%
 \begin{itemdecl}
 bool create_directory(const path& p, const path& existing_p);
 bool create_directory(const path& p, const path& existing_p, error_code& ec) noexcept;
@@ -13626,7 +13649,7 @@ bool create_directory(const path& p, const path& existing_p, error_code& ec) noe
 
 \rSec3[fs.op.create_dir_symlk]{Create directory symlink}
 
-\indexlibrary{\idxcode{create_directory_symlink}}
+\indexlibrary{\idxcode{create_directory_symlink}}%
 \begin{itemdecl}
 void create_directory_symlink(const path& to, const path& new_symlink);
 void create_directory_symlink(const path& to, const path& new_symlink,
@@ -13658,7 +13681,7 @@ void create_directory_symlink(const path& to, const path& new_symlink,
 
 \rSec3[fs.op.create_hard_lk]{Create hard link}
 
-\indexlibrary{\idxcode{create_hard_link}}
+\indexlibrary{\idxcode{create_hard_link}}%
 \begin{itemdecl}
 void create_hard_link(const path& to, const path& new_hard_link);
 void create_hard_link(const path& to, const path& new_hard_link,
@@ -13689,7 +13712,7 @@ void create_hard_link(const path& to, const path& new_hard_link,
 
 \rSec3[fs.op.create_symlink]{Create symlink}
 
-\indexlibrary{\idxcode{create_symlink}}
+\indexlibrary{\idxcode{create_symlink}}%
 \begin{itemdecl}
 void create_symlink(const path& to, const path& new_symlink);
 void create_symlink(const path& to, const path& new_symlink,
@@ -13716,7 +13739,7 @@ void create_symlink(const path& to, const path& new_symlink,
 
 \rSec3[fs.op.current_path]{Current path}
 
-\indexlibrary{\idxcode{current_path}}
+\indexlibrary{\idxcode{current_path}}%
 \begin{itemdecl}
 path current_path();
 path current_path(error_code& ec);
@@ -13747,7 +13770,7 @@ The current path as returned by many operating systems is a dangerous
   library functions, or by another thread. \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{current_path}}
+\indexlibrary{\idxcode{current_path}}%
 \begin{itemdecl}
 void current_path(const path& p);
 void current_path(const path& p, error_code& ec) noexcept;
@@ -13771,7 +13794,7 @@ void current_path(const path& p, error_code& ec) noexcept;
 
 \rSec3[fs.op.exists]{Exists}
 
-\indexlibrary{\idxcode{exists}}
+\indexlibrary{\idxcode{exists}}%
 \begin{itemdecl}
 bool exists(file_status s) noexcept;
 \end{itemdecl}
@@ -13781,7 +13804,7 @@ bool exists(file_status s) noexcept;
 \returns \tcode{status_known(s) \&\& s.type() != file_type::not_found}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{exists}}
+\indexlibrary{\idxcode{exists}}%
 \begin{itemdecl}
 bool exists(const path& p);
 bool exists(const path& p, error_code& ec) noexcept;
@@ -13806,7 +13829,7 @@ if \tcode{status_known(s)}.
 
 \rSec3[fs.op.equivalent]{Equivalent}
 
-\indexlibrary{\idxcode{equivalent}}
+\indexlibrary{\idxcode{equivalent}}%
 \begin{itemdecl}
 bool equivalent(const path& p1, const path& p2);
 bool equivalent(const path& p1, const path& p2, error_code& ec) noexcept;
@@ -13840,7 +13863,7 @@ Two paths are considered to resolve to the same file system entity if two
 
 \rSec3[fs.op.file_size]{File size}
 
-\indexlibrary{\idxcode{file_size}}
+\indexlibrary{\idxcode{file_size}}%
 \begin{itemdecl}
 uintmax_t file_size(const path& p);
 uintmax_t file_size(const path& p, error_code& ec) noexcept;
@@ -13863,7 +13886,7 @@ uintmax_t file_size(const path& p, error_code& ec) noexcept;
 
 \rSec3[fs.op.hard_lk_ct]{Hard link count}
 
-\indexlibrary{\idxcode{hard_link_count}}
+\indexlibrary{\idxcode{hard_link_count}}%
 \begin{itemdecl}
 uintmax_t hard_link_count(const path& p);
 uintmax_t hard_link_count(const path& p, error_code& ec) noexcept;
@@ -13882,7 +13905,7 @@ uintmax_t hard_link_count(const path& p, error_code& ec) noexcept;
 
 \rSec3[fs.op.is_block_file]{Is block file}
 
-\indexlibrary{\idxcode{is_block_file}}
+\indexlibrary{\idxcode{is_block_file}}%
 \begin{itemdecl}
 bool is_block_file(file_status s) noexcept;
 \end{itemdecl}
@@ -13892,6 +13915,7 @@ bool is_block_file(file_status s) noexcept;
 \returns \tcode{s.type() == file_type::block}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{is_block_file}}%
 \begin{itemdecl}
 bool is_block_file(const path& p);
 bool is_block_file(const path& p, error_code& ec) noexcept;
@@ -13909,7 +13933,7 @@ The signature with argument \tcode{ec} returns \tcode{false} if an error occurs.
 
 \rSec3[fs.op.is_char_file]{Is character file}
 
-\indexlibrary{\idxcode{is_character_file}}
+\indexlibrary{\idxcode{is_character_file}}%
 \begin{itemdecl}
 bool is_character_file(file_status s) noexcept;
 \end{itemdecl}
@@ -13919,6 +13943,7 @@ bool is_character_file(file_status s) noexcept;
 \returns \tcode{s.type() == file_type::character}.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{is_character_file}}%
 \begin{itemdecl}
 bool is_character_file(const path& p);
 bool is_character_file(const path& p, error_code& ec) noexcept;
@@ -13938,7 +13963,7 @@ bool is_character_file(const path& p, error_code& ec) noexcept;
 
 \rSec3[fs.op.is_directory]{Is directory}
 
-\indexlibrary{\idxcode{is_directory}}
+\indexlibrary{\idxcode{is_directory}}%
 \begin{itemdecl}
 bool is_directory(file_status s) noexcept;
 \end{itemdecl}
@@ -13948,7 +13973,7 @@ bool is_directory(file_status s) noexcept;
 \returns \tcode{s.type() == file_type::directory}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{is_directory}}
+\indexlibrary{\idxcode{is_directory}}%
 \begin{itemdecl}
 bool is_directory(const path& p);
 bool is_directory(const path& p, error_code& ec) noexcept;
@@ -13967,7 +13992,7 @@ bool is_directory(const path& p, error_code& ec) noexcept;
 
 \rSec3[fs.op.is_empty]{Is empty}
 
-\indexlibrary{\idxcode{is_empty}}
+\indexlibrary{\idxcode{is_empty}}%
 \begin{itemdecl}
 bool is_empty(const path& p);
 bool is_empty(const path& p, error_code& ec) noexcept;
@@ -13996,7 +14021,7 @@ The signature with argument \tcode{ec} returns \tcode{false} if
 
 \rSec3[fs.op.is_fifo]{Is fifo}
 
-\indexlibrary{\idxcode{is_fifo}}
+\indexlibrary{\idxcode{is_fifo}}%
 \begin{itemdecl}
 bool is_fifo(file_status s) noexcept;
 \end{itemdecl}
@@ -14007,6 +14032,7 @@ bool is_fifo(file_status s) noexcept;
 \end{itemdescr}
 
 
+\indexlibrary{\idxcode{is_fifo}}%
 \begin{itemdecl}
 bool is_fifo(const path& p);
 bool is_fifo(const path& p, error_code& ec) noexcept;
@@ -14024,7 +14050,7 @@ The signature with argument \tcode{ec} returns \tcode{false} if an error occurs.
 
 \rSec3[fs.op.is_other]{Is other}
 
-\indexlibrary{\idxcode{is_other}}
+\indexlibrary{\idxcode{is_other}}%
 \begin{itemdecl}
 bool is_other(file_status s) noexcept;
 \end{itemdecl}
@@ -14034,7 +14060,7 @@ bool is_other(file_status s) noexcept;
 \returns \tcode{exists(s) \&\& !is_regular_file(s) \&\& !is_directory(s) \&\& !is_symlink(s)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{is_other}}
+\indexlibrary{\idxcode{is_other}}%
 \begin{itemdecl}
 bool is_other(const path& p);
 bool is_other(const path& p, error_code& ec) noexcept;
@@ -14053,7 +14079,7 @@ bool is_other(const path& p, error_code& ec) noexcept;
 
 \rSec3[fs.op.is_regular_file]{Is regular file}
 
-\indexlibrary{\idxcode{is_regular_file}}
+\indexlibrary{\idxcode{is_regular_file}}%
 \begin{itemdecl}
 bool is_regular_file(file_status s) noexcept;
 \end{itemdecl}
@@ -14063,7 +14089,7 @@ bool is_regular_file(file_status s) noexcept;
 \returns \tcode{s.type() == file_type::regular}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{is_regular_file}}
+\indexlibrary{\idxcode{is_regular_file}}%
 \begin{itemdecl}
 bool is_regular_file(const path& p);
 \end{itemdecl}
@@ -14076,7 +14102,7 @@ bool is_regular_file(const path& p);
 \throws \tcode{filesystem_error} if \tcode{status(p)} would throw \tcode{filesystem_error.}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{is_regular_file}}
+\indexlibrary{\idxcode{is_regular_file}}%
 \begin{itemdecl}
 bool is_regular_file(const path& p, error_code& ec) noexcept;
 \end{itemdecl}
@@ -14095,7 +14121,7 @@ Returns \tcode{false} if an error occurs.
 
 \rSec3[fs.op.is_socket]{Is socket}
 
-\indexlibrary{\idxcode{is_socket}}
+\indexlibrary{\idxcode{is_socket}}%
 \begin{itemdecl}
 bool is_socket(file_status s) noexcept;
 \end{itemdecl}
@@ -14105,7 +14131,7 @@ bool is_socket(file_status s) noexcept;
 \returns \tcode{s.type() == file_type::socket}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{is_socket}}
+\indexlibrary{\idxcode{is_socket}}%
 \begin{itemdecl}
 bool is_socket(const path& p);
 bool is_socket(const path& p, error_code& ec) noexcept;
@@ -14124,7 +14150,7 @@ bool is_socket(const path& p, error_code& ec) noexcept;
 
 \rSec3[fs.op.is_symlink]{Is symlink}
 
-\indexlibrary{\idxcode{is_symlink}}
+\indexlibrary{\idxcode{is_symlink}}%
 \begin{itemdecl}
 bool is_symlink(file_status s) noexcept;
 \end{itemdecl}
@@ -14134,7 +14160,7 @@ bool is_symlink(file_status s) noexcept;
 \returns \tcode{s.type() == file_type::symlink}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{is_symlink}}
+\indexlibrary{\idxcode{is_symlink}}%
 \begin{itemdecl}
 bool is_symlink(const path& p);
 bool is_symlink(const path& p, error_code& ec) noexcept;
@@ -14153,7 +14179,7 @@ bool is_symlink(const path& p, error_code& ec) noexcept;
 
 \rSec3[fs.op.last_write_time]{Last write time}
 
-\indexlibrary{\idxcode{last_write_time}}
+\indexlibrary{\idxcode{last_write_time}}%
 \begin{itemdecl}
 file_time_type last_write_time(const path& p);
 file_time_type last_write_time(const path& p, error_code& ec) noexcept;
@@ -14171,7 +14197,7 @@ file_time_type last_write_time(const path& p, error_code& ec) noexcept;
 \throws As specified in Error reporting~(\ref{fs.err.report}).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{last_write_time}}
+\indexlibrary{\idxcode{last_write_time}}%
 \begin{itemdecl}
 void last_write_time(const path& p, file_time_type new_time);
 void last_write_time(const path& p, file_time_type new_time,
@@ -14193,7 +14219,7 @@ void last_write_time(const path& p, file_time_type new_time,
 
 \rSec3[fs.op.permissions]{Permissions}
 
-\indexlibrary{\idxcode{permissions}}
+\indexlibrary{\idxcode{permissions}}%
 \begin{itemdecl}
 void permissions(const path& p, perms prms);
 void permissions(const path& p, perms prms, error_code& ec);
@@ -14236,7 +14262,7 @@ Neither \tcode{add_perms} nor \tcode{remove_perms} &
 
 \rSec3[fs.op.proximate]{Proximate}
 
-\indexlibrary{\idxcode{proximate}}
+\indexlibrary{\idxcode{proximate}}%
 \begin{itemdecl}
 path proximate(const path& p, error_code& ec);
 \end{itemdecl}
@@ -14249,7 +14275,7 @@ path proximate(const path& p, error_code& ec);
 \throws As specified in Error reporting~(\ref{fs.err.report}).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{proximate}}
+\indexlibrary{\idxcode{proximate}}%
 \begin{itemdecl}
 path proximate(const path& p, const path& base = current_path());
 path proximate(const path& p, const path& base, error_code& ec);
@@ -14273,7 +14299,7 @@ weakly_canonical(p, ec).lexically_proximate(weakly_canonical(base, ec));
 
 \rSec3[fs.op.read_symlink]{Read symlink}
 
-\indexlibrary{\idxcode{read_symlink}}
+\indexlibrary{\idxcode{read_symlink}}%
 \begin{itemdecl}
 path read_symlink(const path& p);
 path read_symlink(const path& p, error_code& ec);
@@ -14293,7 +14319,7 @@ path read_symlink(const path& p, error_code& ec);
 
 \rSec3[fs.op.relative]{Relative}
 
-\indexlibrary{\idxcode{relative}}
+\indexlibrary{\idxcode{relative}}%
 \begin{itemdecl}
 path relative(const path& p, error_code& ec);
 \end{itemdecl}
@@ -14306,7 +14332,7 @@ path relative(const path& p, error_code& ec);
 \throws As specified in Error reporting~(\ref{fs.err.report}).
 \end{itemdescr}
 
-\indexlibrary{\idxcode{relative}}
+\indexlibrary{\idxcode{relative}}%
 \begin{itemdecl}
 path relative(const path& p, const path& base = current_path());
 path relative(const path& p, const path& base, error_code& ec);
@@ -14330,7 +14356,7 @@ weakly_canonical(p, ec).lexically_relative(weakly_canonical(base, ec));
 
 \rSec3[fs.op.remove]{Remove}
 
-\indexlibrary{\idxcode{remove}!\idxcode{path}}
+\indexlibrary{\idxcode{remove}!\idxcode{path}}%
 \begin{itemdecl}
 bool remove(const path& p);
 bool remove(const path& p, error_code& ec) noexcept;
@@ -14358,7 +14384,7 @@ bool remove(const path& p, error_code& ec) noexcept;
 
 \rSec3[fs.op.remove_all]{Remove all}
 
-\indexlibrary{\idxcode{remove_all}}
+\indexlibrary{\idxcode{remove_all}}%
 \begin{itemdecl}
 uintmax_t remove_all(const path& p);
 uintmax_t remove_all(const path& p, error_code& ec) noexcept;
@@ -14386,7 +14412,7 @@ uintmax_t remove_all(const path& p, error_code& ec) noexcept;
 
 \rSec3[fs.op.rename]{Rename}
 
-\indexlibrary{\idxcode{rename}}
+\indexlibrary{\idxcode{rename}}%
 \begin{itemdecl}
 void rename(const path& old_p, const path& new_p);
 void rename(const path& old_p, const path& new_p, error_code& ec) noexcept;
@@ -14420,7 +14446,7 @@ A symbolic link is itself renamed, rather than the file it resolves to.
 
 \rSec3[fs.op.resize_file]{Resize file}
 
-\indexlibrary{\idxcode{resize_file}}
+\indexlibrary{\idxcode{resize_file}}%
 \begin{itemdecl}
 void resize_file(const path& p, uintmax_t new_size);
 void resize_file(const path& p, uintmax_t new_size, error_code& ec) noexcept;
@@ -14440,7 +14466,7 @@ void resize_file(const path& p, uintmax_t new_size, error_code& ec) noexcept;
 
 \rSec3[fs.op.space]{Space}
 
-\indexlibrary{\idxcode{space}}
+\indexlibrary{\idxcode{space}}%
 \begin{itemdecl}
 space_info space(const path& p);
 space_info space(const path& p, error_code& ec) noexcept;
@@ -14471,7 +14497,7 @@ space_info space(const path& p, error_code& ec) noexcept;
 
 \rSec3[fs.op.status]{Status}
 
-\indexlibrary{\idxcode{status}}
+\indexlibrary{\idxcode{status}}%
 \begin{itemdecl}
 file_status status(const path& p);
 \end{itemdecl}
@@ -14497,7 +14523,7 @@ return result;
   cause an exception to be thrown.\end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{status}}
+\indexlibrary{\idxcode{status}}%
 \begin{itemdecl}
 file_status status(const path& p, error_code& ec) noexcept;
 \end{itemdecl}
@@ -14570,7 +14596,7 @@ Otherwise,
 
 \rSec3[fs.op.status_known]{Status known}
 
-\indexlibrary{\idxcode{status_known}}
+\indexlibrary{\idxcode{status_known}}%
 \begin{itemdecl}
 bool status_known(file_status s) noexcept;
 \end{itemdecl}
@@ -14583,7 +14609,7 @@ bool status_known(file_status s) noexcept;
 
 \rSec3[fs.op.symlink_status]{Symlink status}
 
-\indexlibrary{\idxcode{symlink_status}}
+\indexlibrary{\idxcode{symlink_status}}%
 \begin{itemdecl}
 file_status symlink_status(const path& p);
 file_status symlink_status(const path& p, error_code& ec) noexcept;
@@ -14618,7 +14644,7 @@ of the obtained \tcode{struct stat} to the type \tcode{perms}.
 
 \rSec3[fs.op.system_complete]{System complete}
 
-\indexlibrary{\idxcode{system_complete}}
+\indexlibrary{\idxcode{system_complete}}%
 \begin{itemdecl}
 path system_complete(const path& p);
 path system_complete(const path& p, error_code& ec);
@@ -14660,7 +14686,7 @@ For Windows-based operating systems, \tcode{system_complete(p)} has the
 
 \rSec3[fs.op.temp_dir_path]{Temporary directory path}
 
-\indexlibrary{\idxcode{temp_directory_path}}
+\indexlibrary{\idxcode{temp_directory_path}}%
 \begin{itemdecl}
 path temp_directory_path();
 path temp_directory_path(error_code& ec);
@@ -14690,7 +14716,7 @@ For Windows-based operating systems, an implementation might return the path
 
 \rSec3[fs.op.weakly_canonical]{Weakly Canonical}
 
-\indexlibrary{\idxcode{weakly}}
+\indexlibrary{\idxcode{weakly_canonical}}%
 \begin{itemdecl}
 path weakly_canonical(const path& p);
 path weakly_canonical(const path& p, error_code& ec);


### PR DESCRIPTION
This review handles several topic related to the index of library names:

  apply indexlibrarymember for all member functions other than constructors/destructors
  consistent ordering of indexlibrarymember{identifier}{class-name}
  every index macro has a trailing % to avoid accidental whitespace
  ensure headers are indexed with synopsis
  ensure every itemdecl has a library index entry
  fix some mislabeled index entries
  minor reordering of paragraphs so istream/ostream have consistent layout
  add a missing entry to index of implementation defined behavior