### PR TITLE
[system_error.syn] [syserr.compare] Declare all nonmembers in the synopsis

### DIFF
--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -880,10 +880,19 @@ namespace std {
   
   template <> struct is_error_condition_enum<errc> : true_type {};
 
+  // \ref{syserr.errcode.nonmembers} non-member functions:
   error_code make_error_code(errc e) noexcept;
+
+  template <class charT, class traits>
+    basic_ostream<charT, traits>&
+      operator<<(basic_ostream<charT, traits>& os, const error_code& ec);
+
+  // \ref{syserr.errcondition.nonmembers} non-member functions:
   error_condition make_error_condition(errc e) noexcept;
 
   // \ref{syserr.compare}, comparison operators:
+  bool operator<(const error_code& lhs, const error_code& rhs) noexcept;
+  bool operator<(const error_condition& lhs, const error_condition& rhs) noexcept;
   bool operator==(const error_code& lhs, const error_code& rhs) noexcept;
   bool operator==(const error_code& lhs, const error_condition& rhs) noexcept;
   bool operator==(const error_condition& lhs, const error_code& rhs) noexcept;
@@ -1192,7 +1201,6 @@ namespace std {
 
   // \ref{syserr.errcode.nonmembers} non-member functions:
   error_code make_error_code(errc e) noexcept;
-  bool operator<(const error_code& lhs, const error_code& rhs) noexcept;
 
   template <class charT, class traits>
     basic_ostream<charT, traits>&
@@ -1351,20 +1359,6 @@ error_code make_error_code(errc e) noexcept;
 \returns \tcode{error_code(static_cast<int>(e), generic_category())}.
 \end{itemdescr}
 
-\indexlibrarymember{operator<}{error_code}%
-\begin{itemdecl}
-bool operator<(const error_code& lhs, const error_code& rhs) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-\begin{codeblock}
-lhs.category() < rhs.category() ||
-(lhs.category() == rhs.category() && lhs.value() < rhs.value()).
-\end{codeblock}
-\end{itemdescr}
-
 \indexlibrarymember{operator\shl}{error_code}%
 \begin{itemdecl}
 template <class charT, class traits>
@@ -1415,9 +1409,6 @@ namespace std {
     int val_;                   // \expos
     const error_category* cat_; // \expos
   };
-
-  // \ref{syserr.errcondition.nonmembers} non-member functions:
-  bool operator<(const error_condition& lhs, const error_condition& rhs) noexcept;
 } // namespace std
 \end{codeblock}
 
@@ -1560,6 +1551,22 @@ error_condition make_error_condition(errc e) noexcept;
 \returns \tcode{error_condition(static_cast<int>(e), generic_category())}.
 \end{itemdescr}
 
+\rSec2[syserr.compare]{Comparison operators}
+
+\indexlibrarymember{operator<}{error_code}%
+\begin{itemdecl}
+bool operator<(const error_code& lhs, const error_code& rhs) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\begin{codeblock}
+lhs.category() < rhs.category() ||
+(lhs.category() == rhs.category() && lhs.value() < rhs.value());
+\end{codeblock}
+\end{itemdescr}
+
 \indexlibrarymember{operator<}{error_condition}%
 \begin{itemdecl}
 bool operator<(const error_condition& lhs, const error_condition& rhs) noexcept;
@@ -1570,8 +1577,6 @@ bool operator<(const error_condition& lhs, const error_condition& rhs) noexcept;
 \returns \tcode{lhs.category() < rhs.category() || lhs.category() == rhs.category() \&\&\\
 lhs.value() < rhs.value()}.
 \end{itemdescr}
-
-\rSec2[syserr.compare]{Comparison operators}
 
 \indexlibrarymember{operator==}{error_code}%
 \begin{itemdecl}


### PR DESCRIPTION
Move definitions of less-than operators to [syserr.compare]

Fixes #880
