### PR TITLE
[temp.deduct.call] Don't nest paragraphs inside eachother.

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -6340,6 +6340,7 @@ argument deduction is attempted using each of the members of the set. If
 deduction succeeds for only one of the overload set members, that member is
 used as the argument value for the deduction. If deduction succeeds for more than
 one member of the overload set the parameter is treated as a non-deduced context.
+\end{itemize}
 
 \pnum
 \begin{example}
@@ -6376,7 +6377,6 @@ template <class T> T g(T);
 int i = f(1, g);    // calls \tcode{f(int, int (*)(int))}
 \end{codeblock}
 \end{example}
-\end{itemize}
 
 \pnum
 If deduction succeeds for all parameters that contain


### PR DESCRIPTION
In this section, paragraphs 7, 8 and 9 are nested /inside/ paragraph 6 (they are part of the second item of the enumeration in paragraph 6). As far as I know, this is the only instance of nested paragraphs in the document.

LaTeX seems to allows this, and so technically there is no problem, but in my HTML conversion of the draft (http://eel.is/c++draft), this curiosity is very hard to deal with, to the point where I've resorted to branching the document and moving the paragraphs outside of the enumeration.

So this is a pull request for the odd chance that you guys either want to support the HTML version, and/or agree with me that nesting paragraphs inside eachother is a very dubious construct of limited value to begin with, to be avoided in any case. :)

Cheers!
