### PR TITLE
[depr] Reviewed index for Anndex D

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -138,6 +138,7 @@ the namespace \tcode{std}.
 
 \pnum
 The header
+\indexlibrary{\idxhdr{strstream}}%
 \tcode{<strstream>}
 defines three types that associate stream buffers with
 character array objects and assist reading and writing such objects.
@@ -363,7 +364,7 @@ The macro
 \tcode{INT_MAX}
 is defined in
 \tcode{<climits>}~(\ref{support.limits}).
-\indexlibrary{\idxhdr{climits}}}
+\indexlibrary{\idxhdr{climits}}}%
 \end{itemize}
 
 \pnum
@@ -379,12 +380,18 @@ Otherwise, the function executes:
 \begin{codeblock}
 setg(gnext_arg, gnext_arg, pbeg_arg);
 setp(pbeg_arg,  pbeg_arg + N);
+\end{codeblock}
+\end{itemdescr}
 
+
+\indexlibrary{\idxcode{strstreambuf}!constructor}%
+\begin{itemdecl}
 strstreambuf(const char* gnext_arg, streamsize n);
 strstreambuf(const signed char* gnext_arg, streamsize n);
 strstreambuf(const unsigned char* gnext_arg, streamsize n);
-\end{codeblock}
+\end{itemdecl}
 
+\begin{itemdescr}
 \pnum
 \effects
 Behaves the same as
@@ -410,7 +417,7 @@ and
 
 \rSec3[depr.strstreambuf.members]{Member functions}
 
-\indexlibrary{\idxcode{freeze}!\idxcode{strstreambuf}}%
+\indexlibrarymember{freeze}{strstreambuf}%
 \begin{itemdecl}
 void freeze(bool freezefl = true);
 \end{itemdecl}
@@ -430,7 +437,7 @@ Otherwise, it clears \tcode{frozen} in \tcode{strmode}.
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{str}!\idxcode{strstreambuf}}%
+\indexlibrarymember{str}{strstreambuf}%
 \begin{itemdecl}
 char* str();
 \end{itemdecl}
@@ -447,7 +454,7 @@ then returns the beginning pointer for the input sequence, \tcode{gbeg}.
 The return value can be a null pointer.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pcount}!\idxcode{strstreambuf}}%
+\indexlibrarymember{pcount}{strstreambuf}%
 \begin{itemdecl}
 int pcount() const;
 \end{itemdecl}
@@ -464,7 +471,7 @@ pointer for the output sequence, \tcode{pnext} - \tcode{pbeg}.
 
 \rSec3[depr.strstreambuf.virtuals]{\tcode{strstreambuf} overridden virtual functions}
 
-\indexlibrary{\idxcode{overflow}!\idxcode{strstreambuf}}%
+\indexlibrarymember{overflow}{strstreambuf}%
 \begin{itemdecl}
 int_type overflow(int_type c = EOF) override;
 \end{itemdecl}
@@ -541,7 +548,7 @@ or if
 the function cannot extend the array (reallocate it with greater length) to make a write position available.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pbackfail}!\idxcode{strstreambuf}}%
+\indexlibrarymember{pbackfail}{strstreambuf}%
 \begin{itemdecl}
 int_type pbackfail(int_type c = EOF) override;
 \end{itemdecl}
@@ -597,7 +604,7 @@ The function can alter the number of putback
 positions available as a result of any call.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{underflow}!\idxcode{strstreambuf}}%
+\indexlibrarymember{underflow}{strstreambuf}%
 \begin{itemdecl}
 int_type underflow() override;
 \end{itemdecl}
@@ -637,7 +644,7 @@ The function can alter the number of read positions available as a
 result of any call.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{seekoff}!\idxcode{strstreambuf}}%
+\indexlibrarymember{seekoff}{strstreambuf}%
 \begin{itemdecl}
 pos_type seekoff(off_type off, seekdir way, openmode which = in | out) override;
 \end{itemdecl}
@@ -702,7 +709,7 @@ the return value is
 \tcode{pos_type(off_type(-1))}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{seekpos}!\idxcode{strstreambuf}}%
+\indexlibrarymember{seekpos}{strstreambuf}%
 \begin{itemdecl}
 pos_type seekpos(pos_type sp, ios_base::openmode which
                   = ios_base::in | ios_base::out) override;
@@ -758,7 +765,7 @@ the return value is
 \tcode{pos_type(off_type(-1))}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{setbuf}!\idxcode{strstreambuf}}%
+\indexlibrarymember{setbuf}{strstreambuf}%
 \begin{itemdecl}
 streambuf<char>* setbuf(char* s, streamsize n) override;
 \end{itemdecl}
@@ -769,7 +776,6 @@ streambuf<char>* setbuf(char* s, streamsize n) override;
 Implementation defined, except that
 \tcode{setbuf(0, 0)}
 has no effect.%
-\indexlibrary{\idxcode{setbuf}!\idxcode{streambuf}}
 \end{itemdescr}
 
 \rSec2[depr.istrstream]{Class \tcode{istrstream}}
@@ -849,7 +855,7 @@ and initializing \tcode{sb} with
 
 \rSec3[depr.istrstream.members]{Member functions}
 
-\indexlibrary{\idxcode{rdbuf}!\idxcode{istrstream}}%
+\indexlibrarymember{rdbuf}{istrstream}%
 \begin{itemdecl}
 strstreambuf* rdbuf() const;
 \end{itemdecl}
@@ -860,7 +866,7 @@ strstreambuf* rdbuf() const;
 \tcode{const_cast<strstreambuf*>(\&sb)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{str}!\idxcode{istrstream}}%
+\indexlibrarymember{str}{istrstream}%
 \begin{itemdecl}
 char* str();
 \end{itemdecl}
@@ -911,7 +917,7 @@ For the sake of exposition, the maintained data is presented here as:
 
 \indexlibrary{\idxcode{ostrstream}!constructor}%
 \begin{itemdecl}
-    ostrstream();
+ostrstream();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -966,7 +972,7 @@ is declared in
 
 \rSec3[depr.ostrstream.members]{Member functions}
 
-\indexlibrary{\idxcode{rdbuf}!\idxcode{ostrstream}}%
+\indexlibrarymember{rdbuf}{ostrstream}%
 \begin{itemdecl}
 strstreambuf* rdbuf() const;
 \end{itemdecl}
@@ -977,7 +983,7 @@ strstreambuf* rdbuf() const;
 \tcode{(strstreambuf*)\&sb}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{freeze}!\idxcode{ostrstream}}%
+\indexlibrarymember{freeze}{ostrstream}%
 \begin{itemdecl}
 void freeze(bool freezefl = true);
 \end{itemdecl}
@@ -989,7 +995,7 @@ Calls
 \tcode{rdbuf()->freeze(freezefl)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{str}!\idxcode{ostrstream}}%
+\indexlibrarymember{str}{ostrstream}%
 \begin{itemdecl}
 char* str();
 \end{itemdecl}
@@ -1000,7 +1006,7 @@ char* str();
 \tcode{rdbuf()->str()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pcount}!\idxcode{ostrstream}}%
+\indexlibrarymember{pcount}{ostrstream}%
 \begin{itemdecl}
 int pcount() const;
 \end{itemdecl}
@@ -1123,7 +1129,7 @@ Destroys an object of class
 
 \rSec3[depr.strstream.oper]{\tcode{strstream} operations}
 
-\indexlibrary{\idxcode{rdbuf}!\idxcode{strstream}}%
+\indexlibrarymember{rdbuf}{strstream}%
 \begin{itemdecl}
 strstreambuf* rdbuf() const;
 \end{itemdecl}
@@ -1134,7 +1140,7 @@ strstreambuf* rdbuf() const;
 \tcode{\&sb}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{freeze}!\idxcode{strstream}}%
+\indexlibrarymember{freeze}{strstream}%
 \begin{itemdecl}
 void freeze(bool freezefl = true);
 \end{itemdecl}
@@ -1146,7 +1152,7 @@ Calls
 \tcode{rdbuf()->freeze(freezefl)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{str}!\idxcode{strstream}}%
+\indexlibrarymember{str}{strstream}%
 \begin{itemdecl}
 char* str();
 \end{itemdecl}
@@ -1157,7 +1163,7 @@ char* str();
 \tcode{rdbuf()->str()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{pcount}!\idxcode{strstream}}%
+\indexlibrarymember{pcount}{strstream}%
 \begin{itemdecl}
 int pcount() const;
 \end{itemdecl}
@@ -1224,6 +1230,7 @@ The previous \tcode{unexpected_handler}.
 
 \rSec2[get.unexpected]{\tcode{get_unexpected}}
 
+\indexlibrary{\idxcode{get_unexpected}}%
 \begin{itemdecl}
 unexpected_handler get_unexpected() noexcept;
 \end{itemdecl}
@@ -1304,10 +1311,70 @@ for function objects that take two arguments.
 \pnum
 The following member names are defined in addition to names specified in Clause~\ref{utilities}:
 
-\indexlibrary{\idxcode{argument_type}}%
-\indexlibrary{\idxcode{first_argument_type}}%
-\indexlibrary{\idxcode{second_argument_type}}%
-\indexlibrary{\idxcode{result_type}}%
+\indexlibrarymember{result_type}{owner_less}%
+\indexlibrarymember{first_argument_type}{owner_less}%
+\indexlibrarymember{second_argument_type}{owner_less}%
+\indexlibrarymember{result_type}{owner_less}%
+\indexlibrarymember{first_argument_type}{owner_less}%
+\indexlibrarymember{second_argument_type}{owner_less}%
+\indexlibrarymember{result_type}{plus}%
+\indexlibrarymember{first_argument_type}{plus}%
+\indexlibrarymember{second_argument_type}{plus}%
+\indexlibrarymember{result_type}{minus}%
+\indexlibrarymember{first_argument_type}{minus}%
+\indexlibrarymember{second_argument_type}{minus}%
+\indexlibrarymember{result_type}{multiplies}%
+\indexlibrarymember{first_argument_type}{multiplies}%
+\indexlibrarymember{second_argument_type}{multiplies}%
+\indexlibrarymember{result_type}{divides}%
+\indexlibrarymember{first_argument_type}{divides}%
+\indexlibrarymember{second_argument_type}{divides}%
+\indexlibrarymember{result_type}{modulus}%
+\indexlibrarymember{first_argument_type}{modulus}%
+\indexlibrarymember{second_argument_type}{modulus}%
+\indexlibrarymember{result_type}{negate}%
+\indexlibrarymember{argument_type}{negate}%
+\indexlibrarymember{result_type}{equal_to}%
+\indexlibrarymember{first_argument_type}{equal_to}%
+\indexlibrarymember{second_argument_type}{equal_to}%
+\indexlibrarymember{result_type}{not_equal_to}%
+\indexlibrarymember{first_argument_type}{not_equal_to}%
+\indexlibrarymember{second_argument_type}{not_equal_to}%
+\indexlibrarymember{result_type}{greater}%
+\indexlibrarymember{first_argument_type}{greater}%
+\indexlibrarymember{second_argument_type}{greater}%
+\indexlibrarymember{result_type}{less}%
+\indexlibrarymember{first_argument_type}{less}%
+\indexlibrarymember{second_argument_type}{less}%
+\indexlibrarymember{result_type}{greater_equal}%
+\indexlibrarymember{first_argument_type}{greater_equal}%
+\indexlibrarymember{second_argument_type}{greater_equal}%
+\indexlibrarymember{result_type}{less_equal}%
+\indexlibrarymember{first_argument_type}{less_equal}%
+\indexlibrarymember{second_argument_type}{less_equal}%
+\indexlibrarymember{result_type}{logical_and}%
+\indexlibrarymember{first_argument_type}{logical_and}%
+\indexlibrarymember{second_argument_type}{logical_and}%
+\indexlibrarymember{result_type}{logical_or}%
+\indexlibrarymember{first_argument_type}{logical_or}%
+\indexlibrarymember{second_argument_type}{logical_or}%
+\indexlibrarymember{result_type}{logical_not}%
+\indexlibrarymember{argument_type}{logical_not}%
+\indexlibrarymember{result_type}{bit_and}%
+\indexlibrarymember{first_argument_type}{bit_and}%
+\indexlibrarymember{second_argument_type}{bit_and}%
+\indexlibrarymember{result_type}{bit_or}%
+\indexlibrarymember{first_argument_type}{bit_or}%
+\indexlibrarymember{second_argument_type}{bit_or}%
+\indexlibrarymember{result_type}{bit_xor}%
+\indexlibrarymember{first_argument_type}{bit_xor}%
+\indexlibrarymember{second_argument_type}{bit_xor}%
+\indexlibrarymember{result_type}{bit_not}%
+\indexlibrarymember{argument_type}{bit_not}%
+\indexlibrarymember{result_type}{function}%
+\indexlibrarymember{argument_type}{function}%
+\indexlibrarymember{first_argument_type}{function}%
+\indexlibrarymember{second_argument_type}{function}%
 \begin{codeblock}
 namespace std {
   template<class T> struct owner_less<shared_ptr<T> > {
@@ -1456,11 +1523,13 @@ namespace std {
 }
 \end{codeblock}
 
+\indexlibrary{\idxcode{reference_wrapper}!weak result type}%
 \pnum
 \tcode{reference_wrapper<T>} has a weak result type~(\ref{depr.weak.result_type}).
 If \tcode{T} is a function type,
 \tcode{result_type} shall be a synonym for the return type of \tcode{T}.
 
+\indexlibrarymember{argument_type}{reference_wrapper}%
 \pnum
 The template specialization \tcode{reference_wrapper<T>}
 shall define a nested type named \tcode{argument_type}
@@ -1475,6 +1544,8 @@ is valid and denotes a type~(\ref{temp.deduct});
 the type \tcode{T1} is \tcode{T::argument_type}.
 \end{itemize}
 
+\indexlibrarymember{first_argument_type}{reference_wrapper}%
+\indexlibrarymember{second_argument_type}{reference_wrapper}%
 \pnum
 The template instantiation \tcode{reference_wrapper<T>}
 shall define two nested types
@@ -1491,6 +1562,8 @@ the type \tcode{T1} is \tcode{T::first_argument_type} and
 the type \tcode{T2} is \tcode{T::second_argument_type}.
 \end{itemize}
 
+\indexlibrarymember{result_type}{hash}%
+\indexlibrarymember{argument_type}{hash}%
 \pnum
 For all object types \tcode{Key} for which there exists a specialization \tcode{hash<Key>},
 and for all enumeration types~(\ref{dcl.enum}) \tcode{Key},
@@ -1498,6 +1571,7 @@ the instantiation \tcode{hash<Key>} shall provide two nested types,
 \tcode{result_type} and \tcode{argument_type},
 which shall be synonyms for \tcode{size_t} and \tcode{Key}, respectively.
 
+\indexlibrary{\idxcode{bind}!weak result type}%
 \pnum
 The forwarding call wrapper \tcode{g}
 returned by a call to \tcode{bind(f, bound_args...)}~(\ref{func.bind.bind})
@@ -1508,6 +1582,7 @@ The forwarding call wrapper \tcode{g}
 returned by a call to \tcode{bind<R>(f, bound_args...)}~(\ref{func.bind.bind})
 shall have a nested type \tcode{result_type} defined as a synonym for \tcode{R}.
 
+\indexlibrarymember{result_type}{mem_fn}%
 \pnum
 The simple call wrapper
 returned from a call to \tcode{mem_fn(pm)}
@@ -1516,6 +1591,8 @@ that is a synonym for
 the return type of \tcode{pm}
 when \tcode{pm} is a pointer to member function.
 
+\indexlibrarymember{result_type}{mem_fn}%
+\indexlibrarymember{argument_type}{mem_fn}%
 \pnum
 The simple call wrapper
 returned from a call to \tcode{mem_fn(pm)}
@@ -1527,6 +1604,9 @@ with cv-qualifier \cv{}
 and taking no arguments,
 where \tcode{Ret} is \tcode{pm}{'s} return type.
 
+\indexlibrarymember{result_type}{mem_fn}%
+\indexlibrarymember{first_argument_type}{mem_fn}%
+\indexlibrarymember{second_argument_type}{mem_fn}%
 \pnum
 The simple call wrapper
 returned from a call to \tcode{mem_fn(pm)}
@@ -1541,9 +1621,12 @@ where \tcode{Ret} is \tcode{pm}{'s} return type.
 \pnum
 The following member names are defined in addition to names specified in Clause~\ref{containers}:
 
-\indexlibrary{\idxcode{first_argument_type}}%
-\indexlibrary{\idxcode{second_argument_type}}%
-\indexlibrary{\idxcode{result_type}}%
+\indexlibrarymember{result_type}{map::value_compare}%
+\indexlibrarymember{first_argument_type}{map::value_compare}%
+\indexlibrarymember{second_argument_type}{map::value_compare}%
+\indexlibrarymember{result_type}{multimap::value_compare}%
+\indexlibrarymember{first_argument_type}{multimap::value_compare}%
+\indexlibrarymember{second_argument_type}{multimap::value_compare}%
 \begin{codeblock}
 namespace std {
   template <class Key, class T, class Compare, class Allocator>
@@ -1569,6 +1652,10 @@ namespace std {
 \pnum
 The header \tcode{<functional>} has the following additional declarations:
 
+\indexlibrary{\idxcode{unary_negate}}%
+\indexlibrary{\idxcode{not1}}%
+\indexlibrary{\idxcode{binary_negate}}%
+\indexlibrary{\idxcode{not2}}%
 \begin{codeblock}
 namespace std {
   template <class Predicate> class unary_negate;
@@ -1586,6 +1673,8 @@ take a unary and a binary predicate, respectively,
 and return their logical negations~(\ref{expr.unary.op}).
 
 \indexlibrary{\idxcode{unary_negate}}%
+\indexlibrarymember{argument_type}{unary_negate}%
+\indexlibrarymember{result_type}{unary_negate}%
 \begin{codeblock}
 template <class Predicate>
 class unary_negate {
@@ -1597,7 +1686,7 @@ public:
 };
 \end{codeblock}
 
-\indexlibrary{\idxcode{unary_negate}!\idxcode{operator()}}%
+\indexlibrarymember{operator()}{unary_negate}%
 \begin{itemdecl}
 constexpr bool operator()(const typename Predicate::argument_type& x) const;
 \end{itemdecl}
@@ -1617,6 +1706,9 @@ template <class Predicate>
 \end{itemdescr}
 
 \indexlibrary{\idxcode{binary_negate}}%
+\indexlibrarymember{first_argument_type}{binary_negate}%
+\indexlibrarymember{second_argument_type}{binary_negate}%
+\indexlibrarymember{result_type}{binary_negate}%
 \begin{codeblock}
 template <class Predicate>
 class binary_negate {
@@ -1631,7 +1723,7 @@ public:
 };
 \end{codeblock}
 
-\indexlibrary{\idxcode{binary_negate}!\idxcode{operator()}}%
+\indexlibrarymember{operator()}{binary_negate}%
 \begin{itemdecl}
 constexpr bool operator()(const typename Predicate::first_argument_type& x,
                           const typename Predicate::second_argument_type& y) const;
@@ -1696,8 +1788,7 @@ namespace std {
 }
 \end{codeblock}
 
-\indexlibrary{\idxcode{allocator}!\idxcode{address}}
-\indexlibrary{\idxcode{address}!\idxcode{allocator}}
+\indexlibrarymember{address}{allocator}%
 \begin{itemdecl}
 T* address(T& x) const noexcept;
 const T* address(const T& x) const noexcept;
@@ -1710,8 +1801,7 @@ The actual address of the object referenced by \tcode{x}, even in the presence o
 overloaded operator\&.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{allocator}!\idxcode{allocate}}
-\indexlibrary{\idxcode{allocate}!\idxcode{allocator}}
+\indexlibrarymember{allocate}{allocator}%
 \begin{itemdecl}
 T* allocate(size_t n, const void* hint);
 \end{itemdecl}
@@ -1734,8 +1824,7 @@ but it is unspecified when or how often this function is called.
 \tcode{bad_alloc} if the storage cannot be obtained.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{allocator}!\idxcode{construct}}
-\indexlibrary{\idxcode{construct}!\idxcode{allocator}}
+\indexlibrarymember{construct}{allocator}%
 \begin{itemdecl}
 template <class U, class... Args>
   void construct(U* p, Args&&... args);
@@ -1747,8 +1836,7 @@ template <class U, class... Args>
 As if by: \tcode{::new((void *)p) U(std::forward<Args>(args)...);}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{allocator}!\idxcode{destroy}}
-\indexlibrary{\idxcode{destroy}!\idxcode{allocator}}
+\indexlibrarymember{destroy}{allocator}%
 \begin{itemdecl}
 template <class U>
   void destroy(U* p);
@@ -1760,8 +1848,7 @@ template <class U>
 As if by \tcode{p->\~{}U()}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{allocator}!\idxcode{max_size}}
-\indexlibrary{\idxcode{max_size}!\idxcode{allocator}}
+\indexlibrarymember{max_size}{allocator}%
 \begin{itemdecl}
 size_t max_size() const noexcept;
 \end{itemdecl}
@@ -1821,8 +1908,7 @@ explicit raw_storage_iterator(OutputIterator x);
 Initializes the iterator to point to the same value to which \tcode{x} points.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{raw_storage_iterator}!\idxcode{operator*}}
-\indexlibrary{\idxcode{operator*}!\idxcode{raw_storage_iterator}}
+\indexlibrarymember{operator*}{raw_storage_iterator}%
 \begin{itemdecl}
 raw_storage_iterator& operator*();
 \end{itemdecl}
@@ -1833,8 +1919,7 @@ raw_storage_iterator& operator*();
 \tcode{*this}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{raw_storage_iterator}!\idxcode{operator=}}
-\indexlibrary{\idxcode{operator=}!\idxcode{raw_storage_iterator}}
+\indexlibrarymember{operator=}{raw_storage_iterator}%
 \begin{itemdecl}
 raw_storage_iterator& operator=(const T& element);
 \end{itemdecl}
@@ -1853,8 +1938,7 @@ Constructs a value from \tcode{element} at the location to which the iterator po
 A reference to the iterator.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{raw_storage_iterator}!\idxcode{operator=}}
-\indexlibrary{\idxcode{operator=}!\idxcode{raw_storage_iterator}}
+\indexlibrarymember{operator=}{raw_storage_iterator}%
 \begin{itemdecl}
 raw_storage_iterator& operator=(T&& element);
 \end{itemdecl}
@@ -1874,8 +1958,7 @@ the iterator points.
 A reference to the iterator.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{raw_storage_iterator}!\idxcode{operator++}}
-\indexlibrary{\idxcode{operator++}!\idxcode{raw_storage_iterator}}
+\indexlibrarymember{operator++}{raw_storage_iterator}%
 \begin{itemdecl}
 raw_storage_iterator& operator++();
 \end{itemdecl}
@@ -1886,8 +1969,7 @@ raw_storage_iterator& operator++();
 Pre-increment:  advances the iterator and returns a reference to the updated iterator.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{raw_storage_iterator}!\idxcode{operator++}}
-\indexlibrary{\idxcode{operator++}!\idxcode{raw_storage_iterator}}
+\indexlibrarymember{operator++}{raw_storage_iterator}%
 \begin{itemdecl}
 raw_storage_iterator operator++(int);
 \end{itemdecl}
@@ -1898,8 +1980,7 @@ raw_storage_iterator operator++(int);
 Post-increment:  advances the iterator and returns the old value of the iterator.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{raw_storage_iterator}!\idxcode{base}}
-\indexlibrary{\idxcode{base}!\idxcode{raw_storage_iterator}}
+\indexlibrarymember{base}{raw_storage_iterator}%
 \begin{itemdecl}
 OutputIterator base() const;
 \end{itemdecl}


### PR DESCRIPTION
This review handles several topic related to the index of library names:
    apply indexlibrarymember for all member functions other than constructors/destructors
    consistent ordering of indexlibrarymember{identifier}{class-name}
    every index macro has a trailing % to avoid accidental whitespace
    ensure headers are indexed with synopsis
    ensure every itemdecl has a library index entry
    index all of the adaptable function typedef-names