### PR TITLE
Remove redundant `this->` in library specification

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -4323,7 +4323,7 @@ refer to their elements, but they now behave as iterators into \tcode{*this}, no
 
 \pnum
 \remarks Stable~(\ref{algorithm.stable}). The behavior is undefined if
-\tcode{this->get_allocator() != x.get_allocator()}.
+\tcode{get_allocator() != x.get_allocator()}.
 
 \pnum
 \complexity At most \tcode{distance(begin(),
@@ -5002,7 +5002,7 @@ refer to their elements, but they now behave as iterators into \tcode{*this}, no
 \remarks Stable~(\ref{algorithm.stable}). If \tcode{(\&x != this)} the range \tcode{[x.begin(), x.end())}
 is empty after the merge.
 No elements are copied by this operation. The behavior is undefined if
-\tcode{this->get_allocator() != x.get_allocator()}.
+\tcode{get_allocator() != x.get_allocator()}.
 
 \pnum
 \complexity

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -8613,7 +8613,7 @@ basic_filebuf& operator=(basic_filebuf&& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Calls \tcode{this->close()} then move assigns from \tcode{rhs}. After the
+\effects Calls \tcode{close()} then move assigns from \tcode{rhs}. After the
 move assignment \tcode{*this} has the observable state it would have had if it
 had been move constructed from \tcode{rhs} (see~\ref{filebuf.cons}).
 
@@ -13015,9 +13015,9 @@ recursive_directory_iterator(const recursive_directory_iterator& rhs);
 \pnum
 \postconditions
 \begin{itemize}
-\item \tcode{this->options() == rhs.options()}
-\item \tcode{this->depth() == rhs.depth()}
-\item \tcode{this->recursion_pending() == rhs.recursion_pending()}
+\item \tcode{options() == rhs.options()}
+\item \tcode{depth() == rhs.depth()}
+\item \tcode{recursion_pending() == rhs.recursion_pending()}
 \end{itemize}
 \end{itemdescr}
 
@@ -13031,8 +13031,8 @@ recursive_directory_iterator(recursive_directory_iterator&& rhs) noexcept;
 \effects Constructs an object of class \tcode{recursive_directory_iterator}.
 
 \pnum
-\postconditions \tcode{this->options()}, \tcode{this->depth()},
-  and \tcode{this->recursion_pending()} return the values that
+\postconditions \tcode{options()}, \tcode{depth()},
+  and \tcode{recursion_pending()} return the values that
   \tcode{rhs.options()}, \tcode{rhs.depth()}, and
   \tcode{rhs.recursion_pending()}, respectively, had before the function call.
 \end{itemdescr}
@@ -13050,9 +13050,9 @@ recursive_directory_iterator& operator=(const recursive_directory_iterator& rhs)
 \pnum
 \postconditions
 \begin{itemize}
-\item \tcode{this->options() == rhs.options()}
-\item \tcode{this->depth() == rhs.depth()}
-\item \tcode{this->recursion_pending() == rhs.recursion_pending()}
+\item \tcode{options() == rhs.options()}
+\item \tcode{depth() == rhs.depth()}
+\item \tcode{recursion_pending() == rhs.recursion_pending()}
 \end{itemize}
 
 \pnum
@@ -13070,8 +13070,8 @@ recursive_directory_iterator& operator=(recursive_directory_iterator&& rhs) noex
 object, the member has no effect.
 
 \pnum
-\postconditions \tcode{this->options()}, \tcode{this->depth()},
-and \tcode{this->recursion_pending()} return the values that \tcode{rhs.options()},
+\postconditions \tcode{options()}, \tcode{depth()},
+and \tcode{recursion_pending()} return the values that \tcode{rhs.options()},
 \tcode{rhs.depth()}, and \tcode{rhs.recursion_pending()}, respectively, had before the function call.
 
 \pnum

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -3617,7 +3617,7 @@ int compare(size_type pos1, size_type n1,
 \effects
 Equivalent to:
 \begin{codeblock}
-return basic_string_view<charT, traits>(this.data(), pos1, n1).compare(sv);
+return basic_string_view<charT, traits>(data(), pos1, n1).compare(sv);
 \end{codeblock}
 \end{itemdescr}
 
@@ -3633,7 +3633,7 @@ int compare(size_type pos1, size_type n1,
 \effects
 Equivalent to:
 \begin{codeblock}
-return basic_string_view<charT, traits>(this.data(), pos1, n1).compare(sv, pos2, n2);
+return basic_string_view<charT, traits>(data(), pos1, n1).compare(sv, pos2, n2);
 \end{codeblock}
 \end{itemdescr}
 

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -652,7 +652,7 @@ an exception is required~(\ref{thread.req.exception}).
 \errors
 \begin{itemize}
 \item \tcode{resource_deadlock_would_occur} --- if deadlock is detected or
-\tcode{this->get_id() == std::this_thread::get_id()}.
+\tcode{get_id() == std::this_thread::get_id()}.
 
 \item \tcode{no_such_process} --- if the thread is not valid.
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -3995,7 +3995,7 @@ if \tcode{*this} holds a value but \tcode{rhs} does not, destroys the value
 contained in \tcode{*this} and sets \tcode{*this} to not hold a value.  Otherwise,
 \item
 if \tcode{index() == rhs.index()}, assigns the value contained in \tcode{rhs}
-to the value contained in *this. Otherwise,
+to the value contained in \tcode{*this}. Otherwise,
 \item
 copies the value contained in \tcode{rhs} to a temporary, then destroys any
 value contained in \tcode{*this}. Sets \tcode{*this} to hold the same
@@ -5113,7 +5113,7 @@ template <class T, class... Args>
 \requires \tcode{is_constructible_v<T, Args...>} is \tcode{true}.
 
 \pnum
-\effects Calls \tcode{this.reset()}.
+\effects Calls \tcode{reset()}.
 Then initializes the contained value as if direct-non-list-initializing
 an object of type \tcode{T} with the arguments \tcode{std::forward<Args>(args)...}.
 
@@ -5137,7 +5137,7 @@ template <class T, class U, class... Args>
 
 \begin{itemdescr}
 \pnum
-\effects Calls \tcode{this->reset()}. Then initializes the contained value
+\effects Calls \tcode{reset()}. Then initializes the contained value
 as if direct-non-list-initializing an object of type \tcode{T} with the arguments
 \tcode{il, std::forward<Args> (args)...}.
 
@@ -10564,7 +10564,7 @@ template <class T, class... Args>
 \pnum
 \requires
 Uses-allocator construction of \tcode{T}
-with allocator \tcode{this->resource()} (see~\ref{allocator.uses.construction})
+with allocator \tcode{resource()} (see~\ref{allocator.uses.construction})
 and constructor arguments \tcode{std::forward<Args>(args)...} is well-formed.
 \begin{note}
 Uses-allocator construction is always well formed
@@ -10574,7 +10574,7 @@ for types that do not use allocators.\end{note}
 \effects
 Construct a \tcode{T} object in the storage
 whose address is represented by \tcode{p}
-by uses-allocator construction with allocator \tcode{this->resource()}
+by uses-allocator construction with allocator \tcode{resource()}
 and constructor arguments \tcode{std::forward<Args>(args)...}.
 
 \pnum
@@ -10605,7 +10605,7 @@ The following description can be summarized as
 constructing a \tcode{pair<T1, T2>} object
 in the storage whose address is represented by \tcode{p},
 as if by separate uses-allocator construction
-with allocator \tcode{this->resource()}~(\ref{allocator.uses.construction})
+with allocator \tcode{resource()}~(\ref{allocator.uses.construction})
 of \tcode{p->first} using the elements of \tcode{x}
 and \tcode{p->second} using the elements of \tcode{y}.
 \end{note}
@@ -10623,14 +10623,14 @@ Otherwise, if \tcode{uses_allocator_v<T1,memory_resource*>} is \tcode{true}
 and
 \tcode{is_constructible_v<T1,allocator_arg_t,memory_resource*,Args1...>} is \tcode{true},
 \\
-then \tcode{xprime} is \tcode{tuple_cat(make_tuple(allocator_arg, this->resource()), std::move(x))}.
+then \tcode{xprime} is \tcode{tuple_cat(make_tuple(allocator_arg, resource()), std::move(x))}.
 \item
 Otherwise, if \tcode{uses_allocator_v<T1,memory_resource*>} is \tcode{true}
 \\
 and
 \tcode{is_constructible_v<T1,Args1...,memory_resource*>} is \tcode{true},
 \\
-then \tcode{xprime} is \tcode{tuple_cat(std::move(x), make_tuple(this->resource()))}.
+then \tcode{xprime} is \tcode{tuple_cat(std::move(x), make_tuple(resource()))}.
 \item
 Otherwise the program is ill formed.
 \end{itemize}
@@ -10650,7 +10650,7 @@ Otherwise, if \tcode{uses_allocator_v<T2,memory_resource*>} is \tcode{true}
 and
 \tcode{is_constructible_v<T2,allocator_arg_t,memory_resource*,Args2...>} is \tcode{true},
 \\
-then \tcode{yprime} is \tcode{tuple_cat(make_tuple(allocator_arg, this->resource()), std::move(y))}.
+then \tcode{yprime} is \tcode{tuple_cat(make_tuple(allocator_arg, resource()), std::move(y))}.
 \item
 Otherwise, if \tcode{uses_allocator_v<T2,memory_resource*>} is \tcode{true}
 \\
@@ -10658,7 +10658,7 @@ and
 \tcode{is_constructible_v<T2,Args2...,memory_resource*>} is \tcode{true},
 \\
 then
-\tcode{yprime} is \tcode{tuple_cat(std::move(y), make_tuple(this->resource()))}.
+\tcode{yprime} is \tcode{tuple_cat(std::move(y), make_tuple(resource()))}.
 \item
 Otherwise the program is ill formed.
 \end{itemize}
@@ -10680,7 +10680,7 @@ template <class T1, class T2>
 \effects
 Equivalent to:
 \begin{codeblock}
-this->construct(p, piecewise_construct, tuple<>(), tuple<>());
+construct(p, piecewise_construct, tuple<>(), tuple<>());
 \end{codeblock}
 \end{itemdescr}
 
@@ -10695,9 +10695,9 @@ template <class T1, class T2, class U, class V>
 \effects
 Equivalent to:
 \begin{codeblock}
-this->construct(p, piecewise_construct,
-                forward_as_tuple(std::forward<U>(x)),
-                forward_as_tuple(std::forward<V>(y)));
+construct(p, piecewise_construct,
+          forward_as_tuple(std::forward<U>(x)),
+          forward_as_tuple(std::forward<V>(y)));
 \end{codeblock}
 \end{itemdescr}
 
@@ -10712,9 +10712,9 @@ template <class T1, class T2, class U, class V>
 \effects
 Equivalent to:
 \begin{codeblock}
-this->construct(p, piecewise_construct,
-                forward_as_tuple(pr.first),
-                forward_as_tuple(pr.second));
+construct(p, piecewise_construct,
+          forward_as_tuple(pr.first),
+          forward_as_tuple(pr.second));
 \end{codeblock}
 \end{itemdescr}
 
@@ -10729,9 +10729,9 @@ template <class T1, class T2, class U, class V>
 \effects
 Equivalent to:
 \begin{codeblock}
-this->construct(p, piecewise_construct,
-                forward_as_tuple(std::forward<U>(pr.first)),
-                forward_as_tuple(std::forward<V>(pr.second)));
+construct(p, piecewise_construct,
+          forward_as_tuple(std::forward<U>(pr.first)),
+          forward_as_tuple(std::forward<V>(pr.second)));
 \end{codeblock}
 \end{itemdescr}
 
@@ -11086,7 +11086,7 @@ virtual ~unsynchronized_pool_resource();
 \begin{itemdescr}
 \pnum
 \effects
-Calls \tcode{this->release()}.
+Calls \tcode{release()}.
 \end{itemdescr}
 
 \rSec3[memory.resource.pool.mem]{Pool resource members}
@@ -11324,7 +11324,7 @@ by an implementation-defined growth factor (which need not be integral).
 \begin{itemdescr}
 \pnum
 \effects
-Calls \tcode{this->release()}.
+Calls \tcode{release()}.
 \end{itemdescr}
 
 
@@ -11894,7 +11894,7 @@ template <class T1, class T2>
 \pnum
 \effects Equivalent to:
 \begin{codeblock}
-this->construct(p, piecewise_construct, tuple<>(), tuple<>());
+construct(p, piecewise_construct, tuple<>(), tuple<>());
 \end{codeblock}
 \end{itemdescr}
 
@@ -11908,9 +11908,9 @@ template <class T1, class T2, class U, class V>
 \pnum
 \effects Equivalent to:
 \begin{codeblock}
-this->construct(p, piecewise_construct,
-                forward_as_tuple(std::forward<U>(x)),
-                forward_as_tuple(std::forward<V>(y)));
+construct(p, piecewise_construct,
+          forward_as_tuple(std::forward<U>(x)),
+          forward_as_tuple(std::forward<V>(y)));
 \end{codeblock}
 \end{itemdescr}
 
@@ -11924,9 +11924,9 @@ template <class T1, class T2, class U, class V>
 \pnum
 \effects Equivalent to:
 \begin{codeblock}
-this->construct(p, piecewise_construct,
-                forward_as_tuple(x.first),
-                forward_as_tuple(x.second));
+construct(p, piecewise_construct,
+          forward_as_tuple(x.first),
+          forward_as_tuple(x.second));
 \end{codeblock}
 \end{itemdescr}
 
@@ -11940,9 +11940,9 @@ template <class T1, class T2, class U, class V>
 \pnum
 \effects Equivalent to:
 \begin{codeblock}
-this->construct(p, piecewise_construct,
-                forward_as_tuple(std::forward<U>(x.first)),
-                forward_as_tuple(std::forward<V>(x.second)));
+construct(p, piecewise_construct,
+          forward_as_tuple(std::forward<U>(x.first)),
+          forward_as_tuple(std::forward<V>(x.second)));
 \end{codeblock}
 \end{itemdescr}
 


### PR DESCRIPTION
in [string::compare] and [any.modifiers].

Also fix a missing `\tcode` in [variant.assign] discovered on the way.