### PR TITLE
[thread.thread.id] Consistently use an lvalue reference for operator<<'s first parameter.

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -470,7 +470,7 @@ bool operator>=(thread::id x, thread::id y) noexcept;
 \begin{itemdecl}
 template<class charT, class traits>
   basic_ostream<charT, traits>&
-    operator<< (basic_ostream<charT, traits>&& out, thread::id id);
+    operator<< (basic_ostream<charT, traits>& out, thread::id id);
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
(Note how the parameter type /is/ specified correctly in the synopsis at the start of the section.)