### PR TITLE
g/special math functions/s//mathematical special functions/

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -10074,7 +10074,7 @@ namespace std {
   int isunordered(double x, double y);
   int isunordered(long double x, long double y);
 
-  // \ref{sf.cmath}, special math functions
+  // \ref{sf.cmath}, mathematical special functions
 
   // \ref{sf.cmath.assoc_laguerre}, associated Laguerre polynomials:
   double       assoc_laguerre(unsigned n, unsigned m, double x);
@@ -10190,7 +10190,7 @@ The contents and meaning of the header \tcode{<cmath>}
 are the same as the C standard library header \tcode{<math.h>},
 with the addition of 
 a three-dimensional hypotenuse function~(\ref{c.math.hypot3}) and
-the special mathematical functions described in \ref{sf.cmath}.
+the mathematical special functions described in \ref{sf.cmath}.
 \begin{note}
 Several functions have additional overloads in this International Standard,
 but they have the same behavior as in the C standard library~(\ref{library.c}).
@@ -10287,8 +10287,8 @@ Each function is overloaded for the three floating-point types.
 \xref
 ISO C 7.12.3, 7.12.4
 
-\rSec2[sf.cmath]{Special math functions}%
-\indextext{special functions|(}%
+\rSec2[sf.cmath]{Mathematical special functions}%
+\indextext{mathematical special functions|(}%
 
 \pnum\indextext{NaN}\indextext{domain error}%
 If any argument value
@@ -11133,7 +11133,7 @@ if \tcode{n >= 128}.
 \pnum See also \ref{sf.cmath.cyl_neumann}.
 \end{itemdescr}
 
-\indextext{special functions|)}
+\indextext{mathematical special functions|)}
 
 \rSec2[ctgmath.syn]{Header \tcode{<ctgmath>} synopsis}
 


### PR DESCRIPTION
There's nothing special about the math; mathematicians have long termed these functions as "special functions".  Because C++ also uses "special functions" as a different term of art (referring to copy c'tors, d'tors, etc.), we disambiguate by prefixing "mathematical".