### PR TITLE
[associative.reqmts] Add missing line break.

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -1649,7 +1649,7 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
   $N \log N$ in general ($N$ has the value \tcode{distance(i, j)});
   linear if \tcode{[i, j)} is sorted with \tcode{value_comp()} \\ \rowsep
 
-\tcode{X(i,j)} \tcode{X~u(i,j);}    &
+\tcode{X(i,j)}\br\tcode{X~u(i,j);}    &
                                     &
   \requires\ \tcode{key_compare} is \tcode{DefaultConstructible}.
   \tcode{value_type} is \tcode{EmplaceConstructible} into \tcode{X} from \tcode{*i}.\br


### PR DESCRIPTION
No visual difference in the PDF, but only because the line in question happens to wrap at the same place thanks to the narrowness of the table column. :)