### PR TITLE
[cstdlib.syn] Add missing extern-C/C++ overloads for at_exit, at_quick_exit

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -3056,8 +3056,10 @@ namespace std {
 namespace std {
   // \ref{support.start.term}, start and termination
   [[noreturn]] void abort();
-  int atexit(void (*func)());
-  int at_quick_exit(void (*func)());
+  extern "C" int atexit(void (*func)());
+  extern "C++" int at_quick_exit(void (*func)());
+  extern "C" int atexit(void (*func)());
+  extern "C++" int at_quick_exit(void (*func)());
   [[noreturn]] void exit(int status);
   [[noreturn]] void _Exit(int status);
   [[noreturn]] void quick_exit(int status);


### PR DESCRIPTION
During all the discussion of overloading on language linkage with regards to the C library, we never noticed that `at_exit` and `at_quick_exit` are also overloaded.

@zygoloid, @jwakely: Is this simple change to the synopsis sufficient? Unlike for `qsort` and `bsearch`, I didn't mark these synopses entries up specially, because we actually specify these functions directly rather than by reference.