### PR TITLE
Remove imports for unused packages: verbatim, fixme, and booktabs.

### DIFF
--- a/source/std.tex
+++ b/source/std.tex
@@ -15,11 +15,9 @@
            {listings}     % code listings
 \usepackage{longtable}    % auto-breaking tables
 \usepackage{ltcaption}    % fix captions for long tables
-\usepackage{booktabs}     % fancy tables
 \usepackage{relsize}      % provide relative font size changes
 \usepackage{textcomp}     % provide \text{l,r}angle
 \usepackage{underscore}   % remove special status of '_' in ordinary text
-\usepackage{verbatim}     % improved verbatim environment
 \usepackage{parskip}      % handle non-indented paragraphs "properly"
 \usepackage{array}        % new column definitions for tables
 \usepackage[normalem]{ulem}
@@ -29,7 +27,6 @@
 \usepackage{microtype}
 \usepackage{multicol}
 \usepackage{xspace}
-\usepackage{fixme}
 \usepackage{lmodern}
 \usepackage[T1]{fontenc}
 \usepackage[pdftex, final]{graphicx}


### PR DESCRIPTION
(No visual difference in PDF.)