### PR TITLE
[temp.over.link] replace "file" with "translation unit", add space after //

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -498,7 +498,7 @@ constructor for a subobject of \tcode{D}.
 \begin{example}
 
 \begin{codeblock}
-//translation unit 1:
+// translation unit 1:
 struct X {
   X(int, int);
   X(int, int, int);
@@ -509,7 +509,7 @@ class D {
 };
 D d2;                           // \tcode{X(int, int)} called by \tcode{D()}
 
-//translation unit 2:
+// translation unit 2:
 struct X {
   X(int, int);
   X(int, int, int);

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3548,7 +3548,7 @@ namespace B {
                                     // with C language linkage has two definitions
 }
 
-int A::f() { return 98; }           //definition for the function \tcode{f} with C language linkage
+int A::f() { return 98; }           // definition for the function \tcode{f} with C language linkage
 extern "C" int h() { return 97; }   // definition for the function \tcode{h} with C language linkage
                                     // \tcode{A::h} and \tcode{::h} refer to the same function
 \end{codeblock}

--- a/source/special.tex
+++ b/source/special.tex
@@ -1365,7 +1365,7 @@ struct D : B {
 
 void f() {
   B* bp = new D;
-  delete bp;        //1: uses \tcode{D::operator delete(void*)}
+  delete bp;        // 1: uses \tcode{D::operator delete(void*)}
 }
 \end{codeblock}
 
@@ -2207,7 +2207,7 @@ A* pa = &bobj;                          // undefined, upcast to a base class typ
 B bobj;                                 // definition of \tcode{bobj}
 
 extern X xobj;
-int* p3 = &xobj.i;                      //OK, \tcode{X} is a trivial class
+int* p3 = &xobj.i;                      // OK, \tcode{X} is a trivial class
 X xobj;
 \end{codeblock}
 

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -2592,7 +2592,7 @@ function template specializations have the same type.
 
 \begin{minipage}{.45\hsize}
 \begin{codeblock}
-// file1.c
+// translation unit 1:
 template<class T>
   void f(T*);
 void g(int* p) {
@@ -2602,7 +2602,7 @@ void g(int* p) {
 \end{minipage}
 \begin{minipage}{.45\hsize}
 \begin{codeblock}
-// file2.c
+// translation unit 2:
 template<class T>
   void f(T);
 void h(int* p) {
@@ -5435,7 +5435,7 @@ template<class T> template<class X1> void A<T>::g1(T, X1) { }
 // member template specialization
 template<> template<class X1> void A<int>::g1(int, X1);
 
-//member template specialization
+// member template specialization
 template<> template<>
   void A<int>::g1(int, char);           // \tcode{X1} deduced as \tcode{char}
 template<> template<>


### PR DESCRIPTION
This removes the precedent of ".c" extension and makes the comments in this example consistent with the comments used in the example in [basic.def.odr]6.6. Also, vast majority of comments use a space after //. This commit adds the space to the few comments that don't.
