### PR TITLE
[expr.call]p1 Use a more idiomatic way to specify the expression has undefined behavior

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1484,7 +1484,7 @@ conversion~(\ref{conv.func}) is suppressed on the postfix expression),
 or it shall have function pointer type. Calling a function through an
 expression whose function type has a language linkage that is different
 from the language linkage of the function type of the called function's
-definition is undefined~(\ref{dcl.link}). For a call to a non-static
+definition results in undefined behavior~(\ref{dcl.link}). For a call to a non-static
 member function,
 the postfix expression shall be an
 implicit~(\ref{class.mfct.non-static},~\ref{class.static}) or explicit


### PR DESCRIPTION
I find the phrasing to be a little weird to just say "is undefined" and think it's nominally more clear to state that the behavior of the call is what's undefined.
