### PR TITLE
[depr, exception.syn] Consistently move deprecated decls to Annex D

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -1176,6 +1176,22 @@ int pcount() const;
 
 \rSec1[exception.unexpected]{Violating \grammarterm{exception-specification}{s}}
 
+\pnum
+The header
+\indexlibrary{\idxhdr{exception}}%
+\tcode{<exception>} has the following additions:
+
+\indexlibrary{\idxcode{iterator}}%
+\begin{codeblock}
+namespace std {
+  using unexpected_handler = void (*)();
+  unexpected_handler get_unexpected() noexcept;
+  unexpected_handler set_unexpected(unexpected_handler f) noexcept;
+  [[noreturn]] void unexpected();
+}
+\end{codeblock}
+
+
 \rSec2[unexpected.handler]{Type \tcode{unexpected_handler}}
 
 \indexlibrary{\idxcode{unexpected_handler}}%
@@ -1267,6 +1283,18 @@ this context. \end{note}
 
 \rSec1[depr.uncaught]{\tcode{uncaught_exception}}
 
+\pnum
+The header
+\indexlibrary{\idxhdr{exception}}%
+\tcode{<exception>} has the following addition:
+
+\indexlibrary{\idxcode{iterator}}%
+\begin{codeblock}
+namespace std {
+  bool uncaught_exception() noexcept;
+}
+\end{codeblock}
+
 \indexlibrary{\idxcode{uncaught_exception}}%
 \begin{itemdecl}
 bool uncaught_exception() noexcept;
@@ -1309,7 +1337,7 @@ for function objects that take one argument and
 for function objects that take two arguments.
 
 \pnum
-The following member names are defined in addition to names specified in Clause~\ref{utilities}:
+The following member names are defined in addition to names specified in Clause~\ref{function.objects}:
 
 \indexlibrarymember{result_type}{owner_less}%
 \indexlibrarymember{first_argument_type}{owner_less}%
@@ -1650,7 +1678,9 @@ namespace std {
 \rSec2[depr.negators]{Negators}
 
 \pnum
-The header \tcode{<functional>} has the following additional declarations:
+The header
+\indexlibrary{\idxhdr{functional}}%
+\tcode{<functional>} has the following additions:
 
 \indexlibrary{\idxcode{unary_negate}}%
 \indexlibrary{\idxcode{not1}}%
@@ -1863,7 +1893,9 @@ might succeed.
 \rSec1[depr.storage.iterator]{Raw storage iterator}
 
 \pnum
-The header \tcode{<memory>} has the following addition:
+The header
+\indexlibrary{\idxhdr{memory}}%
+\tcode{<memory>} has the following addition:
 
 \indexlibrary{\idxcode{raw_storage_iterator}}%
 \begin{codeblock}
@@ -1995,7 +2027,9 @@ An iterator of type \tcode{OutputIterator} that points to the same value as
 \rSec1[depr.temporary.buffer]{Temporary buffers}
 
 \pnum
-The header \tcode{<memory>} has the following additions:
+The header
+\indexlibrary{\idxhdr{memory}}%
+\tcode{<memory>} has the following additions:
 
 \begin{codeblock}
 namespace std {
@@ -2064,7 +2098,9 @@ Nothing.
 \rSec1[depr.meta.types]{Deprecated Type Traits}
 
 \pnum
-The header \tcode{<type_traits>} has the following addition:
+The header
+\indexlibrary{\idxhdr{type_traits}}%
+\tcode{<type_traits>} has the following addition:
 
 \indexlibrary{\idxcode{is_literal_type}}%
 \begin{codeblock}
@@ -2091,7 +2127,9 @@ cv-qualified) \tcode{void}.
 \rSec2[depr.iterator.basic]{Basic iterator}
 
 \pnum
-The header \tcode{<iterator>} has the following addition:
+The header
+\indexlibrary{\idxhdr{iterator}}%
+\tcode{<iterator>} has the following addition:
 
 \indexlibrary{\idxcode{iterator}}%
 \begin{codeblock}

--- a/source/support.tex
+++ b/source/support.tex
@@ -2720,19 +2720,12 @@ namespace std {
   class bad_exception;
   class nested_exception;
 
-  using unexpected_handler = void (*)();
-  unexpected_handler get_unexpected() noexcept;
-  unexpected_handler set_unexpected(unexpected_handler f) noexcept;
-  [[noreturn]] void unexpected();
-
   using terminate_handler = void (*)();
   terminate_handler get_terminate() noexcept;
   terminate_handler set_terminate(terminate_handler f) noexcept;
   [[noreturn]] void terminate() noexcept;
 
   int uncaught_exceptions() noexcept;
-  // \ref{depr.uncaught}, uncaught_exception (deprecated)
-  bool uncaught_exception() noexcept;
 
   using exception_ptr = @\unspec@;
 


### PR DESCRIPTION
This change moves the deprecated declarations in the <exception>
header to Annex D, in a manner consistent with the library pattern
of fully specifying deprecated components and names in the deprecation
annex.

Then apply consistent wording across the library parts of the annex
describing how non-deprecated headers introduce the deprecated extensions.

Finally, ensure that the deprecated extensions to standard headers are
indexed as part of that standard header.