### PR TITLE
[thread] Index review clause 30

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -606,7 +606,7 @@ state of \tcode{x} to \tcode{*this} and sets \tcode{x} to a default constructed 
 
 \rSec3[thread.thread.member]{\tcode{thread} members}
 
-\indexlibrarymember{thread}{swap}%
+\indexlibrarymember{swap}{thread}%
 \begin{itemdecl}
 void swap(thread& x) noexcept;
 \end{itemdecl}
@@ -616,7 +616,7 @@ void swap(thread& x) noexcept;
 \effects Swaps the state of \tcode{*this} and \tcode{x}.
 \end{itemdescr}
 
-\indexlibrarymember{thread}{joinable}%
+\indexlibrarymember{joinable}{thread}%
 \begin{itemdecl}
 bool joinable() const noexcept;
 \end{itemdecl}
@@ -626,7 +626,7 @@ bool joinable() const noexcept;
 \returns \tcode{get_id() != id()}
 \end{itemdescr}
 
-\indexlibrarymember{thread}{join}%
+\indexlibrarymember{join}{thread}%
 \begin{itemdecl}
 void join();
 \end{itemdecl}
@@ -660,7 +660,7 @@ an exception is required~(\ref{thread.req.exception}).
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrarymember{thread}{detach}%
+\indexlibrarymember{detach}{thread}%
 \begin{itemdecl}
 void detach();
 \end{itemdecl}
@@ -684,7 +684,7 @@ an exception is required~(\ref{thread.req.exception}).
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrarymember{thread}{get_id}%
+\indexlibrarymember{get_id}{thread}%
 \begin{itemdecl}
 id get_id() const noexcept;
 \end{itemdecl}
@@ -698,7 +698,7 @@ otherwise \tcode{this_thread::get_id()} for the thread of execution represented 
 
 \rSec3[thread.thread.static]{\tcode{thread} static members}
 
-\indexlibrarymember{thread}{hardware_concurrency}%
+\indexlibrarymember{hardware_concurrency}{thread}%
 \begin{itemdecl}
 unsigned hardware_concurrency() noexcept;
 \end{itemdecl}
@@ -712,7 +712,7 @@ well defined an implementation should return 0.
 
 \rSec3[thread.thread.algorithm]{\tcode{thread} specialized algorithms}
 
-\indexlibrarymember{thread}{swap}%
+\indexlibrarymember{swap}{thread}%
 \begin{itemdecl}
 void swap(thread& x, thread& y) noexcept;
 \end{itemdecl}
@@ -735,7 +735,7 @@ namespace std::this_thread {
 }
 \end{codeblock}
 
-\indexlibrarymember{this_thread}{get_id}%
+\indexlibrarymember{get_id}{this_thread}%
 \begin{itemdecl}
 thread::id this_thread::get_id() noexcept;
 \end{itemdecl}
@@ -748,7 +748,7 @@ always have this id. The object returned shall not compare equal to a default co
 \tcode{thread::id}.
 \end{itemdescr}
 
-\indexlibrarymember{this_thread}{yield}%
+\indexlibrarymember{yield}{this_thread}%
 \begin{itemdecl}
 void this_thread::yield() noexcept;
 \end{itemdecl}
@@ -761,7 +761,7 @@ void this_thread::yield() noexcept;
 \sync None.
 \end{itemdescr}
 
-\indexlibrarymember{this_thread}{sleep_until}%
+\indexlibrarymember{sleep_until}{this_thread}%
 \begin{itemdecl}
 template <class Clock, class Duration>
   void sleep_until(const chrono::time_point<Clock, Duration>& abs_time);
@@ -779,7 +779,7 @@ by \tcode{abs_time}.
 \throws Timeout-related exceptions~(\ref{thread.req.timing}).
 \end{itemdescr}
 
-\indexlibrarymember{this_thread}{sleep_for}%
+\indexlibrarymember{sleep_for}{this_thread}%
 \begin{itemdecl}
 template <class Rep, class Period>
   void sleep_for(const chrono::duration<Rep, Period>& rel_time);
@@ -1947,7 +1947,7 @@ unique_lock& operator=(unique_lock&& u);
 
 \rSec4[thread.lock.unique.locking]{\tcode{unique_lock} locking}
 
-\indexlibrarymember{unique_lock}{lock}%
+\indexlibrarymember{lock}{unique_lock}%
 \begin{itemdecl}
 void lock();
 \end{itemdecl}
@@ -1968,7 +1968,7 @@ with an error condition of \tcode{resource_deadlock_would_occur} if on entry \tc
 is \tcode{true}.
 \end{itemdescr}
 
-\indexlibrarymember{unique_lock}{try_lock}%
+\indexlibrarymember{try_lock}{unique_lock}%
 \begin{itemdecl}
 bool try_lock();
 \end{itemdecl}
@@ -1995,7 +1995,7 @@ with an error condition of \tcode{resource_deadlock_would_occur} if on entry \tc
 is \tcode{true}.
 \end{itemdescr}
 
-\indexlibrarymember{unique_lock}{try_lock_until}%
+\indexlibrarymember{try_lock_until}{unique_lock}%
 \begin{itemdecl}
 template <class Clock, class Duration>
   bool try_lock_until(const chrono::time_point<Clock, Duration>& abs_time);
@@ -2024,7 +2024,7 @@ error condition of \tcode{resource_deadlock_would_occur} if on entry \tcode{owns
 \tcode{true}.
 \end{itemdescr}
 
-\indexlibrarymember{unique_lock}{try_lock_for}%
+\indexlibrarymember{try_lock_for}{unique_lock}%
 \begin{itemdecl}
 template <class Rep, class Period>
   bool try_lock_for(const chrono::duration<Rep, Period>& rel_time);
@@ -2051,7 +2051,7 @@ error condition of \tcode{resource_deadlock_would_occur} if on entry \tcode{owns
 \tcode{true}.
 \end{itemdescr}
 
-\indexlibrarymember{unique_lock}{unlock}%
+\indexlibrarymember{unlock}{unique_lock}%
 \begin{itemdecl}
 void unlock();
 \end{itemdecl}
@@ -2072,7 +2072,7 @@ an exception is required~(\ref{thread.req.exception}).
 
 \rSec4[thread.lock.unique.mod]{\tcode{unique_lock} modifiers}
 
-\indexlibrarymember{unique_lock}{swap}%
+\indexlibrarymember{swap}{unique_lock}%
 \begin{itemdecl}
 void swap(unique_lock& u) noexcept;
 \end{itemdecl}
@@ -2081,7 +2081,7 @@ void swap(unique_lock& u) noexcept;
 \pnum\effects Swaps the data members of \tcode{*this} and \tcode{u}.
 \end{itemdescr}
 
-\indexlibrarymember{unique_lock}{release}%
+\indexlibrarymember{release}{unique_lock}%
 \begin{itemdecl}
 mutex_type* release() noexcept;
 \end{itemdecl}
@@ -2092,7 +2092,7 @@ mutex_type* release() noexcept;
 \pnum\postconditions \tcode{pm == 0} and \tcode{owns == false}.
 \end{itemdescr}
 
-\indexlibrarymember{unique_lock}{swap}%
+\indexlibrarymember{swap}{unique_lock}%
 \begin{itemdecl}
 template <class Mutex>
   void swap(unique_lock<Mutex>& x, unique_lock<Mutex>& y) noexcept;
@@ -2104,7 +2104,7 @@ template <class Mutex>
 
 \rSec4[thread.lock.unique.obs]{\tcode{unique_lock} observers}
 
-\indexlibrarymember{unique_lock}{owns_lock}%
+\indexlibrarymember{owns_lock}{unique_lock}%
 \begin{itemdecl}
 bool owns_lock() const noexcept;
 \end{itemdecl}
@@ -2122,7 +2122,7 @@ explicit operator bool() const noexcept;
 \pnum\returns \tcode{owns}
 \end{itemdescr}
 
-\indexlibrarymember{unique_lock}{mutex}%
+\indexlibrarymember{mutex}{unique_lock}%
 \begin{itemdecl}
 mutex_type *mutex() const noexcept;
 \end{itemdecl}
@@ -2364,7 +2364,7 @@ shared_lock& operator=(shared_lock&& sl) noexcept;
 
 \rSec4[thread.lock.shared.locking]{\tcode{shared_lock} locking}
 
-\indexlibrarymember{shared_lock}{lock}%
+\indexlibrarymember{lock}{shared_lock}%
 \begin{itemdecl}
 void lock();
 \end{itemdecl}
@@ -2385,7 +2385,7 @@ void lock();
 \tcode{resource_deadlock_would_occur} if on entry \tcode{owns} is \tcode{true}.
 \end{itemdescr}
 
-\indexlibrarymember{shared_lock}{try_lock}%
+\indexlibrarymember{try_lock}{shared_lock}%
 \begin{itemdecl}
 bool try_lock();
 \end{itemdecl}
@@ -2411,7 +2411,7 @@ the call to \tcode{pm->try_lock_shared()}.
 
 \end{itemdescr}
 
-\indexlibrarymember{shared_lock}{try_lock_until}%
+\indexlibrarymember{try_lock_until}{shared_lock}%
 \begin{itemdecl}
 template <class Clock, class Duration>
   bool
@@ -2439,7 +2439,7 @@ the call to \tcode{pm->try_lock_shared_until(abs_time)}.
 \tcode{resource_deadlock_would_occur} if on entry \tcode{owns} is \tcode{true}.
 \end{itemdescr}
 
-\indexlibrarymember{shared_lock}{try_lock_for}%
+\indexlibrarymember{try_lock_for}{shared_lock}%
 \begin{itemdecl}
 template <class Rep, class Period>
   bool try_lock_for(const chrono::duration<Rep, Period>& rel_time);
@@ -2459,7 +2459,7 @@ template <class Rep, class Period>
 \throws Any exception thrown by \tcode{pm->try_lock_shared_for(rel_time)}. \tcode{system_error} if an exception is required ~(\ref{thread.req.exception}). \tcode{system_error} with an error condition of \tcode{operation_not_permitted} if \tcode{pm} is \tcode{nullptr}. \tcode{system_error} with an error condition of \tcode{resource_deadlock_would_occur} if on entry \tcode{owns} is \tcode{true}.
 \end{itemdescr}
 
-\indexlibrarymember{shared_lock}{unlock}%
+\indexlibrarymember{unlock}{shared_lock}%
 \begin{itemdecl}
 void unlock();
 \end{itemdecl}
@@ -2484,7 +2484,7 @@ void unlock();
 
 \rSec4[thread.lock.shared.mod]{\tcode{shared_lock} modifiers}
 
-\indexlibrarymember{shared_lock}{swap}%
+\indexlibrarymember{swap}{shared_lock}%
 \begin{itemdecl}
 void swap(shared_lock& sl) noexcept;
 \end{itemdecl}
@@ -2494,7 +2494,7 @@ void swap(shared_lock& sl) noexcept;
 \effects Swaps the data members of \tcode{*this} and \tcode{sl}.
 \end{itemdescr}
 
-\indexlibrarymember{shared_lock}{release}%
+\indexlibrarymember{release}{shared_lock}%
 \begin{itemdecl}
 mutex_type* release() noexcept;
 \end{itemdecl}
@@ -2507,7 +2507,7 @@ mutex_type* release() noexcept;
 \postconditions \tcode{pm == nullptr} and \tcode{owns == false}.
 \end{itemdescr}
 
-\indexlibrarymember{shared_lock}{swap}%
+\indexlibrarymember{swap}{shared_lock}%
 \begin{itemdecl}
 template <class Mutex>
   void swap(shared_lock<Mutex>& x, shared_lock<Mutex>& y) noexcept;
@@ -2520,7 +2520,7 @@ template <class Mutex>
 
 \rSec4[thread.lock.shared.obs]{\tcode{shared_lock} observers}
 
-\indexlibrarymember{shared_lock}{owns_lock}%
+\indexlibrarymember{owns_lock}{shared_lock}%
 \begin{itemdecl}
 bool owns_lock() const noexcept;
 \end{itemdecl}
@@ -2540,7 +2540,7 @@ explicit operator bool () const noexcept;
 \returns \tcode{owns}.
 \end{itemdescr}
 
-\indexlibrarymember{shared_lock}{mutex}%
+\indexlibrarymember{mutex}{shared_lock}%
 \begin{itemdecl}
 mutex_type* mutex() const noexcept;
 \end{itemdecl}
@@ -2870,7 +2870,7 @@ using the overloads of \tcode{wait}, \tcode{wait_for}, or \tcode{wait_until} tha
 \pnum\effects Destroys the object.
 \end{itemdescr}
 
-\indexlibrarymember{condition_variable}{notify_one}%
+\indexlibrarymember{notify_one}{condition_variable}%
 \begin{itemdecl}
 void notify_one() noexcept;
 \end{itemdecl}
@@ -2879,7 +2879,7 @@ void notify_one() noexcept;
 \pnum\effects If any threads are blocked waiting for \tcode{*this}, unblocks one of those threads.
 \end{itemdescr}
 
-\indexlibrarymember{condition_variable}{notify_all}%
+\indexlibrarymember{notify_all}{condition_variable}%
 \begin{itemdecl}
 void notify_all() noexcept;
 \end{itemdecl}
@@ -2888,7 +2888,7 @@ void notify_all() noexcept;
 \pnum\effects Unblocks all threads that are blocked waiting for \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{condition_variable}{wait}%
+\indexlibrarymember{wait}{condition_variable}%
 \begin{itemdecl}
 void wait(unique_lock<mutex>& lock);
 \end{itemdecl}
@@ -2926,7 +2926,7 @@ is locked by the calling thread.
 
 \end{itemdescr}
 
-\indexlibrarymember{condition_variable}{wait}%
+\indexlibrarymember{wait}{condition_variable}%
 \begin{itemdecl}
 template <class Predicate>
   void wait(unique_lock<mutex>& lock, Predicate pred);
@@ -2966,7 +2966,7 @@ is locked by the calling thread.
 
 \end{itemdescr}
 
-\indexlibrarymember{condition_variable}{wait_until}%
+\indexlibrarymember{wait_until}{condition_variable}%
 \begin{itemdecl}
 template <class Clock, class Duration>
   cv_status wait_until(unique_lock<mutex>& lock,
@@ -3022,7 +3022,7 @@ exceptions~(\ref{thread.req.timing}).
 
 \end{itemdescr}
 
-\indexlibrarymember{condition_variable}{wait_for}%
+\indexlibrarymember{wait_for}{condition_variable}%
 \begin{itemdecl}
 template <class Rep, class Period>
   cv_status wait_for(unique_lock<mutex>& lock,
@@ -3067,7 +3067,7 @@ exceptions~(\ref{thread.req.timing}).
 
 \end{itemdescr}
 
-\indexlibrarymember{condition_variable}{wait_until}%
+\indexlibrarymember{wait_until}{condition_variable}%
 \begin{itemdecl}
 template <class Clock, class Duration, class Predicate>
   bool wait_until(unique_lock<mutex>& lock,
@@ -3116,7 +3116,7 @@ exceptions~(\ref{thread.req.timing}) or any exception thrown by \tcode{pred}.
 
 \end{itemdescr}
 
-\indexlibrarymember{condition_variable}{wait_for}%
+\indexlibrarymember{wait_for}{condition_variable}%
 \begin{itemdecl}
 template <class Rep, class Period, class Predicate>
   bool wait_for(unique_lock<mutex>& lock,
@@ -3254,7 +3254,7 @@ using the overloads of \tcode{wait}, \tcode{wait_for}, or \tcode{wait_until} tha
 \pnum\effects Destroys the object.
 \end{itemdescr}
 
-\indexlibrarymember{condition_variable_any}{notify_one}%
+\indexlibrarymember{notify_one}{condition_variable_any}%
 \begin{itemdecl}
 void notify_one() noexcept;
 \end{itemdecl}
@@ -3263,7 +3263,7 @@ void notify_one() noexcept;
 \pnum\effects If any threads are blocked waiting for \tcode{*this}, unblocks one of those threads.
 \end{itemdescr}
 
-\indexlibrarymember{condition_variable_any}{notify_all}%
+\indexlibrarymember{notify_all}{condition_variable_any}%
 \begin{itemdecl}
 void notify_all() noexcept;
 \end{itemdecl}
@@ -3272,7 +3272,7 @@ void notify_all() noexcept;
 \pnum\effects Unblocks all threads that are blocked waiting for \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{condition_variable_any}{wait}%
+\indexlibrarymember{wait}{condition_variable_any}%
 \begin{itemdecl}
 template <class Lock>
   void wait(Lock& lock);
@@ -3305,7 +3305,7 @@ shall be called~(\ref{except.terminate}).
 
 \end{itemdescr}
 
-\indexlibrarymember{condition_variable_any}{wait}%
+\indexlibrarymember{wait}{condition_variable_any}%
 \begin{itemdecl}
 template <class Lock, class Predicate>
   void wait(Lock& lock, Predicate pred);
@@ -3320,7 +3320,7 @@ while (!pred())
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{condition_variable_any}{wait_until}%
+\indexlibrarymember{wait_until}{condition_variable_any}%
 \begin{itemdecl}
 template <class Lock, class Clock, class Duration>
   cv_status wait_until(Lock& lock, const chrono::time_point<Clock, Duration>& abs_time);
@@ -3365,7 +3365,7 @@ exceptions~(\ref{thread.req.timing}).
 
 \end{itemdescr}
 
-\indexlibrarymember{condition_variable_any}{wait_for}%
+\indexlibrarymember{wait_for}{condition_variable_any}%
 \begin{itemdecl}
 template <class Lock, class Rep, class Period>
   cv_status wait_for(Lock& lock, const chrono::duration<Rep, Period>& rel_time);
@@ -3398,7 +3398,7 @@ exceptions~(\ref{thread.req.timing}).
 
 \end{itemdescr}
 
-\indexlibrarymember{condition_variable_any}{wait_until}%
+\indexlibrarymember{wait_until}{condition_variable_any}%
 \begin{itemdecl}
 template <class Lock, class Clock, class Duration, class Predicate>
   bool wait_until(Lock& lock, const chrono::time_point<Clock, Duration>& abs_time, Predicate pred);
@@ -3423,7 +3423,7 @@ if the timeout has already expired. \end{note}
 regardless of whether the timeout was triggered. \end{note}
 \end{itemdescr}
 
-\indexlibrarymember{condition_variable_any}{wait_for}%
+\indexlibrarymember{wait_for}{condition_variable_any}%
 \begin{itemdecl}
 template <class Lock, class Rep, class Period, class Predicate>
   bool wait_for(Lock& lock, const chrono::duration<Rep, Period>& rel_time, Predicate pred);
@@ -3544,7 +3544,7 @@ behave as specified for the class \tcode{error_category}. The object's \tcode{na
 virtual function shall return a pointer to the string \tcode{"future"}.
 \end{itemdescr}
 
-\indexlibrarymember{make_error_code}{future_errc}%
+\indexlibrarymember{future_errc}{make_error_code}%
 \begin{itemdecl}
 error_code make_error_code(future_errc e) noexcept;
 \end{itemdecl}
@@ -3554,7 +3554,7 @@ error_code make_error_code(future_errc e) noexcept;
 \returns \tcode{error_code(static_cast<int>(e), future_category())}.
 \end{itemdescr}
 
-\indexlibrarymember{make_error_condition}{future_errc}%
+\indexlibrarymember{future_errc}{make_error_condition}%
 \begin{itemdecl}
 error_condition make_error_condition(future_errc e) noexcept;
 \end{itemdecl}
@@ -3578,7 +3578,7 @@ namespace std {
 }
 \end{codeblock}
 
-\indexlibrarymember{future_error}{code}%
+\indexlibrarymember{code}{future_error}%
 \begin{itemdecl}
 const error_code& code() const noexcept;
 \end{itemdecl}
@@ -3588,7 +3588,7 @@ const error_code& code() const noexcept;
 \returns The value of \tcode{ec} that was passed to the object's constructor.
 \end{itemdescr}
 
-\indexlibrarymember{future_error}{what}%
+\indexlibrarymember{what}{future_error}%
 \begin{itemdecl}
 const char* what() const noexcept;
 \end{itemdecl}
@@ -3826,7 +3826,7 @@ Abandons any shared state~(\ref{futures.state}) and then as if
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{promise}{swap}%
+\indexlibrarymember{swap}{promise}%
 \begin{itemdecl}
 void swap(promise& other) noexcept;
 \end{itemdecl}
@@ -3841,7 +3841,7 @@ prior to the call to \tcode{swap}. \tcode{other} has the shared state (if any) t
 \tcode{*this} had prior to the call to \tcode{swap}.
 \end{itemdescr}
 
-\indexlibrarymember{promise}{get_future}%
+\indexlibrarymember{get_future}{promise}%
 \begin{itemdecl}
 future<R> get_future();
 \end{itemdecl}
@@ -3867,7 +3867,7 @@ a \tcode{promise} with the same shared state as \tcode{*this}.
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrarymember{promise}{set_value}%
+\indexlibrarymember{set_value}{promise}%
 \begin{itemdecl}
 void promise::set_value(const R& r);
 void promise::set_value(R&& r);
@@ -3899,7 +3899,7 @@ already has a stored value or exception.
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrarymember{promise}{set_exception}%
+\indexlibrarymember{set_exception}{promise}%
 \begin{itemdecl}
 void set_exception(exception_ptr p);
 \end{itemdecl}
@@ -3926,7 +3926,7 @@ already has a stored value or exception.
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrarymember{promise}{set_value_at_thread_exit}%
+\indexlibrarymember{set_value_at_thread_exit}{promise}%
 \begin{itemdecl}
 void promise::set_value_at_thread_exit(const R& r);
 void promise::set_value_at_thread_exit(R&& r);
@@ -3960,7 +3960,7 @@ already has a stored value or exception.
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrarymember{promise}{set_exception_at_thread_exit}%
+\indexlibrarymember{set_exception_at_thread_exit}{promise}%
 \begin{itemdecl}
 void set_exception_at_thread_exit(exception_ptr p);
 \end{itemdecl}
@@ -3987,7 +3987,7 @@ already has a stored value or exception.
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrarymember{swap}{promise}%
+\indexlibrarymember{promise}{swap}%
 \begin{itemdecl}
 template <class R>
   void swap(promise<R>& x, promise<R>& y);
@@ -4138,7 +4138,7 @@ assignment.
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrarymember{future}{share}%
+\indexlibrarymember{share}{future}%
 \begin{itemdecl}
 shared_future<R> share();
 \end{itemdecl}
@@ -4151,7 +4151,7 @@ shared_future<R> share();
 \postcondition \tcode{valid() == false}.
 \end{itemdescr}
 
-\indexlibrarymember{future}{get}%
+\indexlibrarymember{get}{future}%
 \begin{itemdecl}
 R future::get();
 R& future<R&>::get();
@@ -4188,7 +4188,7 @@ value stored in the shared state.
 \postcondition \tcode{valid() == false}.
 \end{itemdescr}
 
-\indexlibrarymember{future}{valid}%
+\indexlibrarymember{valid}{future}%
 \begin{itemdecl}
 bool valid() const noexcept;
 \end{itemdecl}
@@ -4198,7 +4198,7 @@ bool valid() const noexcept;
 \returns \tcode{true} only if \tcode{*this} refers to a shared state.
 \end{itemdescr}
 
-\indexlibrarymember{future}{wait}%
+\indexlibrarymember{wait}{future}%
 \begin{itemdecl}
 void wait() const;
 \end{itemdecl}
@@ -4209,7 +4209,7 @@ void wait() const;
 Blocks until the shared state is ready.
 \end{itemdescr}
 
-\indexlibrarymember{future}{wait_for}%
+\indexlibrarymember{wait_for}{future}%
 \begin{itemdecl}
 template <class Rep, class Period>
   future_status wait_for(const chrono::duration<Rep, Period>& rel_time) const;
@@ -4242,7 +4242,7 @@ specified by \tcode{rel_time} has expired.
 timeout-related exceptions~(\ref{thread.req.timing}).
 \end{itemdescr}
 
-\indexlibrarymember{future}{wait_until}%
+\indexlibrarymember{wait_until}{future}%
 \begin{itemdecl}
 template <class Clock, class Duration>
   future_status wait_until(const chrono::time_point<Clock, Duration>& abs_time) const;
@@ -4450,7 +4450,7 @@ assigns the contents of \tcode{rhs} to \tcode{*this}. \begin{note} As a result,
 \postconditions \tcode{valid() == rhs.valid()}.
 \end{itemdescr}
 
-\indexlibrarymember{shared_future}{get}%
+\indexlibrarymember{get}{shared_future}%
 \begin{itemdecl}
 const R& shared_future::get() const;
 R& shared_future<R&>::get() const;
@@ -4494,7 +4494,7 @@ shared state.
 \throws the stored exception, if an exception was stored in the shared state.
 \end{itemdescr}
 
-\indexlibrarymember{shared_future}{valid}%
+\indexlibrarymember{valid}{shared_future}%
 \begin{itemdecl}
 bool valid() const noexcept;
 \end{itemdecl}
@@ -4504,7 +4504,7 @@ bool valid() const noexcept;
 \returns \tcode{true} only if \tcode{*this} refers to a shared state.
 \end{itemdescr}
 
-\indexlibrarymember{shared_future}{wait}%
+\indexlibrarymember{wait}{shared_future}%
 \begin{itemdecl}
 void wait() const;
 \end{itemdecl}
@@ -4515,7 +4515,7 @@ void wait() const;
 Blocks until the shared state is ready.
 \end{itemdescr}
 
-\indexlibrarymember{shared_future}{wait_for}%
+\indexlibrarymember{wait_for}{shared_future}%
 \begin{itemdecl}
 template <class Rep, class Period>
   future_status wait_for(const chrono::duration<Rep, Period>& rel_time) const;
@@ -4549,7 +4549,7 @@ specified by \tcode{rel_time} has expired.
 timeout-related exceptions~(\ref{thread.req.timing}).
 \end{itemdescr}
 
-\indexlibrarymember{shared_future}{wait_until}%
+\indexlibrarymember{wait_until}{shared_future}%
 \begin{itemdecl}
 template <class Clock, class Duration>
   future_status wait_until(const chrono::time_point<Clock, Duration>& abs_time) const;
@@ -4891,7 +4891,7 @@ calls \tcode{packaged_task(std::move(rhs)).swap(*this)}.
 Abandons any shared state~(\ref{futures.state}).
 \end{itemdescr}
 
-\indexlibrarymember{packaged_task}{swap}%
+\indexlibrarymember{swap}{packaged_task}%
 \begin{itemdecl}
 void swap(packaged_task& other) noexcept;
 \end{itemdecl}
@@ -4908,7 +4908,7 @@ and stored task (if any)
 as \tcode{*this} prior to the call to \tcode{swap}.
 \end{itemdescr}
 
-\indexlibrarymember{packaged_task}{valid}%
+\indexlibrarymember{valid}{packaged_task}%
 \begin{itemdecl}
 bool valid() const noexcept;
 \end{itemdecl}
@@ -4918,7 +4918,7 @@ bool valid() const noexcept;
 \returns \tcode{true} only if \tcode{*this} has a shared state.
 \end{itemdescr}
 
-\indexlibrarymember{packaged_task}{get_future}%
+\indexlibrarymember{get_future}{packaged_task}%
 \begin{itemdecl}
 future<R> get_future();
 \end{itemdecl}
@@ -4969,7 +4969,7 @@ the stored task has already been invoked.
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrarymember{packaged_task}{make_ready_at_thread_exit}%
+\indexlibrarymember{make_ready_at_thread_exit}{packaged_task}%
 \begin{itemdecl}
 void make_ready_at_thread_exit(ArgTypes... args);
 \end{itemdecl}
@@ -4998,7 +4998,7 @@ stored task has already been invoked.
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrarymember{packaged_task}{reset}%
+\indexlibrarymember{reset}{packaged_task}%
 \begin{itemdecl}
 void reset();
 \end{itemdecl}
@@ -5023,7 +5023,7 @@ has no shared state.
 
 \rSec3[futures.task.nonmembers]{\tcode{packaged_task} globals}
 
-\indexlibrarymember{packaged_task}{swap}%
+\indexlibrarymember{swap}{packaged_task}%
 \begin{itemdecl}
 template <class R, class... ArgTypes>
   void swap(packaged_task<R(ArgTypes...)>& x, packaged_task<R(ArgTypes...)>& y) noexcept;

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -321,6 +321,7 @@ execution. \begin{note} A \tcode{thread} object does not represent a thread of e
 default construction, after being moved from, or after a successful call to \tcode{detach} or
 \tcode{join}. \end{note}
 
+\indexlibrary{\idxcode{thread}}%
 \begin{codeblock}
 namespace std {
   class thread {
@@ -408,7 +409,7 @@ id() noexcept;
 \pnum\postconditions The constructed object does not represent a thread of execution.
 \end{itemdescr}
 
-\indexlibrarymember{thread::id}{operator==}%
+\indexlibrarymember{operator==}{thread::id}%
 \begin{itemdecl}
 bool operator==(thread::id x, thread::id y) noexcept;
 \end{itemdecl}
@@ -419,7 +420,7 @@ thread of execution or neither \tcode{x} nor \tcode{y} represents a thread of
 execution.
 \end{itemdescr}
 
-\indexlibrarymember{thread::id}{operator"!=}%
+\indexlibrarymember{operator"!=}{thread::id}%
 \begin{itemdecl}
 bool operator!=(thread::id x, thread::id y) noexcept;
 \end{itemdecl}
@@ -428,7 +429,7 @@ bool operator!=(thread::id x, thread::id y) noexcept;
 \pnum\returns \tcode{!(x == y)}
 \end{itemdescr}
 
-\indexlibrarymember{thread::id}{operator<}%
+\indexlibrarymember{operator<}{thread::id}%
 \begin{itemdecl}
 bool operator<(thread::id x, thread::id y) noexcept;
 \end{itemdecl}
@@ -438,7 +439,7 @@ bool operator<(thread::id x, thread::id y) noexcept;
 \returns A value such that \tcode{operator<} is a total ordering as described in~\ref{alg.sorting}.
 \end{itemdescr}
 
-\indexlibrarymember{thread::id}{operator<=}%
+\indexlibrarymember{operator<=}{thread::id}%
 \begin{itemdecl}
 bool operator<=(thread::id x, thread::id y) noexcept;
 \end{itemdecl}
@@ -448,7 +449,7 @@ bool operator<=(thread::id x, thread::id y) noexcept;
 \returns \tcode{!(y < x)}
 \end{itemdescr}
 
-\indexlibrarymember{thread::id}{operator>}%
+\indexlibrarymember{operator>}{thread::id}%
 \begin{itemdecl}
 bool operator>(thread::id x, thread::id y) noexcept;
 \end{itemdecl}
@@ -457,7 +458,7 @@ bool operator>(thread::id x, thread::id y) noexcept;
 \pnum\returns \tcode{y < x}
 \end{itemdescr}
 
-\indexlibrarymember{thread::id}{operator>=}%
+\indexlibrarymember{operator>=}{thread::id}%
 \begin{itemdecl}
 bool operator>=(thread::id x, thread::id y) noexcept;
 \end{itemdecl}
@@ -466,7 +467,7 @@ bool operator>=(thread::id x, thread::id y) noexcept;
 \pnum\returns \tcode{!(x < y)}
 \end{itemdescr}
 
-\indexlibrarymember{thread::id}{operator\shl}%
+\indexlibrarymember{operator\shl}{thread::id}%
 \begin{itemdecl}
 template<class charT, class traits>
   basic_ostream<charT, traits>&
@@ -483,6 +484,7 @@ distinct text representations.
 \pnum\returns \tcode{out}
 \end{itemdescr}
 
+\indexlibrary{\idxcode{hash}!\idxcode{thread::id}}%
 \begin{itemdecl}
 template <> struct hash<thread::id>;
 \end{itemdecl}
@@ -586,7 +588,7 @@ ensure that the destructor is never executed while the thread is still joinable.
 
 \rSec3[thread.thread.assign]{\tcode{thread} assignment}
 
-\indexlibrarymember{thread}{operator=}%
+\indexlibrarymember{operator=}{thread}%
 \begin{itemdecl}
 thread& operator=(thread&& x) noexcept;
 \end{itemdecl}
@@ -1005,6 +1007,7 @@ lock operations that obtain ownership on the same object.
 
 \rSec4[thread.mutex.class]{Class \tcode{mutex}}
 
+\indexlibrary{\idxcode{mutex}}%
 \begin{codeblock}
 namespace std {
   class mutex {
@@ -1059,6 +1062,7 @@ a thread terminates while owning a \tcode{mutex} object.
 
 \rSec4[thread.mutex.recursive]{Class \tcode{recursive_mutex}}
 
+\indexlibrary{\idxcode{recursive_mutex}}%
 \begin{codeblock}
 namespace std {
   class recursive_mutex {
@@ -1194,6 +1198,7 @@ this operation.
 
 \rSec4[thread.timedmutex.class]{Class \tcode{timed_mutex}}
 
+\indexlibrary{\idxcode{timed_mutex}}%
 \begin{codeblock}
 namespace std {
   class timed_mutex {
@@ -1244,6 +1249,7 @@ The behavior of a program is undefined if:
 
 \rSec4[thread.timedmutex.recursive]{Class \tcode{recursive_timed_mutex}}
 
+\indexlibrary{\idxcode{recursive_timed_mutex}}%
 \begin{codeblock}
 namespace std {
   class recursive_timed_mutex {
@@ -1412,6 +1418,7 @@ operation.
 
 \rSec4[thread.sharedmutex.class]{Class shared_mutex}
 
+\indexlibrary{\idxcode{shared_mutex}}%
 \begin{codeblock}
 namespace std {
   class shared_mutex {
@@ -1546,6 +1553,7 @@ with~(\ref{intro.multithread}) this operation.
 
 \rSec4[thread.sharedtimedmutex.class]{Class \tcode{shared_timed_mutex}}
 
+\indexlibrary{\idxcode{shared_timed_mutex}}%
 \begin{codeblock}
 namespace std {
   class shared_timed_mutex {
@@ -1633,6 +1641,7 @@ namespace std {
 
 \rSec3[thread.lock.guard]{Class template \tcode{lock_guard}}
 
+\indexlibrary{\idxcode{lock_guard}}%
 \begin{codeblock}
 namespace std {
   template <class... MutexTypes>
@@ -1712,6 +1721,7 @@ lock_guard(MutexTypes&... m, adopt_lock_t);
 
 \rSec3[thread.lock.unique]{Class template \tcode{unique_lock}}
 
+\indexlibrary{\idxcode{unique_lock}}%
 \begin{codeblock}
 namespace std {
   template <class Mutex>
@@ -1919,7 +1929,7 @@ unique_lock(unique_lock&& u) noexcept;
 \pnum\postconditions \tcode{pm == u_p.pm} and \tcode{owns == u_p.owns} (where \tcode{u_p} is the state of \tcode{u} just prior to this construction),  \tcode{u.pm == 0} and \tcode{u.owns == false}.
 \end{itemdescr}
 
-\indexlibrarymember{unique_lock}{operator=}%
+\indexlibrarymember{operator=}{unique_lock}%
 \begin{itemdecl}
 unique_lock& operator=(unique_lock&& u);
 \end{itemdecl}
@@ -2113,7 +2123,7 @@ bool owns_lock() const noexcept;
 \pnum\returns \tcode{owns}
 \end{itemdescr}
 
-\indexlibrarymember{unique_lock}{operator bool}%
+\indexlibrarymember{operator bool}{unique_lock}%
 \begin{itemdecl}
 explicit operator bool() const noexcept;
 \end{itemdecl}
@@ -2133,6 +2143,7 @@ mutex_type *mutex() const noexcept;
 
 \rSec3[thread.lock.shared]{Class template \tcode{shared_lock}}
 
+\indexlibrary{\idxcode{shared_lock}}%
 \begin{codeblock}
 namespace std {
 
@@ -2347,7 +2358,7 @@ shared_lock(shared_lock&& sl) noexcept;
 \tcode{sl.pm == nullptr} and \tcode{sl.owns == false}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{shared_lock}!\idxcode{operator=}}%
+\indexlibrarymember{operator=}{shared_lock}%
 \begin{itemdecl}
 shared_lock& operator=(shared_lock&& sl) noexcept;
 \end{itemdecl}
@@ -2530,9 +2541,9 @@ bool owns_lock() const noexcept;
 \returns \tcode{owns}.
 \end{itemdescr}
 
-\indexlibrarymember{shared_lock}{operator bool}%
+\indexlibrarymember{operator bool}{shared_lock}%
 \begin{itemdecl}
-explicit operator bool () const noexcept;
+explicit operator bool() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2728,9 +2739,10 @@ executed in a single unspecified total order consistent with the "happens before
 \pnum
 Condition variable construction and destruction need not be synchronized.
 
-\synopsis{Header \tcode{condition_variable} synopsis}
+\synopsis{Header \tcode{<condition_variable>} synopsis}
 \indexlibrary{\idxhdr{condition_variable}}%
 
+\indexlibrary{\idxcode{cv_status}}%
 \begin{codeblock}
 namespace std {
   class condition_variable;
@@ -2789,6 +2801,7 @@ is not released and reacquired prior to calling \tcode{notify_all_at_thread_exit
 
 \rSec2[thread.condition.condvar]{Class \tcode{condition_variable}}
 
+\indexlibrary{\idxcode{condition_variable}}%
 \begin{codeblock}
 namespace std {
   class condition_variable {
@@ -3179,6 +3192,7 @@ is used with \tcode{condition_variable_any}, the user must ensure that any
 necessary synchronization is in place with respect to the predicate associated
 with the \tcode{condition_variable_any} instance. \end{note}
 
+\indexlibrary{\idxcode{condition_variable_any}}%
 \begin{codeblock}
 namespace std {
   class condition_variable_any {
@@ -3449,6 +3463,7 @@ single-threaded programs as well. \end{note}
 
 \synopsis{Header \tcode{<future>} synopsis}
 
+\indexlibrary{\idxhdr{future}}%
 \begin{codeblock}
 namespace std {
   enum class future_errc {
@@ -3544,7 +3559,7 @@ behave as specified for the class \tcode{error_category}. The object's \tcode{na
 virtual function shall return a pointer to the string \tcode{"future"}.
 \end{itemdescr}
 
-\indexlibrarymember{future_errc}{make_error_code}%
+\indexlibrarymember{make_error_code}{future_errc}%
 \begin{itemdecl}
 error_code make_error_code(future_errc e) noexcept;
 \end{itemdecl}
@@ -3554,7 +3569,7 @@ error_code make_error_code(future_errc e) noexcept;
 \returns \tcode{error_code(static_cast<int>(e), future_category())}.
 \end{itemdescr}
 
-\indexlibrarymember{future_errc}{make_error_condition}%
+\indexlibrarymember{make_error_condition}{future_errc}%
 \begin{itemdecl}
 error_condition make_error_condition(future_errc e) noexcept;
 \end{itemdecl}
@@ -3566,6 +3581,7 @@ error_condition make_error_condition(future_errc e) noexcept;
 
 \rSec2[futures.future_error]{Class \tcode{future_error}}
 
+\indexlibrary{\idxcode{future_error}}%
 \begin{codeblock}
 namespace std {
   class future_error : public logic_error {
@@ -3712,6 +3728,7 @@ must either use read-only operations or provide additional synchronization.
 
 \rSec2[futures.promise]{Class template \tcode{promise}}
 
+\indexlibrary{\idxcode{promise}}%
 \begin{codeblock}
 namespace std {
   template <class R>
@@ -3759,7 +3776,7 @@ and \tcode{set_exception_at_thread_exit} member functions behave as though
 they acquire a single mutex associated with the promise object while updating the
 promise object.
 
-\indexlibrary{\idxcode{uses_allocator}}%
+\indexlibrary{\idxcode{uses_allocator}!\idxcode{promise}}%
 \begin{itemdecl}
 template <class R, class Alloc>
   struct uses_allocator<promise<R>, Alloc>
@@ -3811,7 +3828,7 @@ of \tcode{rhs} (if any) to the newly-constructed object.
 Abandons any shared state~(\ref{futures.state}).
 \end{itemdescr}
 
-\indexlibrarymember{promise}{operator=}%
+\indexlibrarymember{operator=}{promise}%
 \begin{itemdecl}
 promise& operator=(promise&& rhs) noexcept;
 \end{itemdecl}
@@ -3987,7 +4004,7 @@ already has a stored value or exception.
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrarymember{promise}{swap}%
+\indexlibrarymember{swap}{promise}%
 \begin{itemdecl}
 template <class R>
   void swap(promise<R>& x, promise<R>& y);
@@ -4027,6 +4044,7 @@ is undefined.
 \begin{note} Implementations are encouraged to detect this case and throw an object of type
 \tcode{future_error} with an error condition of \tcode{future_errc::no_state}. \end{note}
 
+\indexlibrary{\idxcode{future}}%
 \begin{codeblock}
 namespace std {
   template <class R>
@@ -4111,7 +4129,7 @@ destroys \tcode{*this}.
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrarymember{future}{operator=}%
+\indexlibrarymember{operator=}{future}%
 \begin{itemdecl}
 future& operator=(future&& rhs) noexcept;
 \end{itemdecl}
@@ -4303,6 +4321,7 @@ false} is undefined.
 \begin{note} Implementations are encouraged to detect this case and throw an object of type
 \tcode{future_error} with an error condition of \tcode{future_errc::no_state}. \end{note}
 
+\indexlibrary{\idxcode{shared_future}}%
 \begin{codeblock}
 namespace std {
   template <class R>
@@ -4402,7 +4421,7 @@ destroys \tcode{*this}.
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrarymember{shared_future}{operator=}%
+\indexlibrarymember{operator=}{shared_future}%
 \begin{itemdecl}
 shared_future& operator=(shared_future&& rhs) noexcept;
 \end{itemdecl}
@@ -4429,7 +4448,7 @@ the assignment.
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrarymember{shared_future}{operator=}%
+\indexlibrarymember{operator=}{shared_future}%
 \begin{itemdecl}
 shared_future& operator=(const shared_future& rhs);
 \end{itemdecl}
@@ -4763,6 +4782,7 @@ When the \tcode{packaged_task} object is invoked, its stored task is invoked and
 result (whether normal or exceptional) stored in the shared state. Any futures that
 share the shared state will then be able to access the stored result.
 
+\indexlibrary{\idxcode{packaged_task}}%
 \begin{codeblock}
 namespace std {
   template<class> class packaged_task; // undefined
@@ -4864,7 +4884,7 @@ shared state. Moves the stored task from \tcode{rhs} to \tcode{*this}.
 \postcondition \tcode{rhs} has no shared state.
 \end{itemdescr}
 
-\indexlibrarymember{packaged_task}{operator=}%
+\indexlibrarymember{operator=}{packaged_task}%
 \begin{itemdecl}
 packaged_task& operator=(packaged_task&& rhs) noexcept;
 \end{itemdecl}
@@ -4939,7 +4959,7 @@ a \tcode{packaged_task} object with the same shared state as \tcode{*this}.
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrarymember{packaged_task}{operator()}%
+\indexlibrarymember{operator()}{packaged_task}%
 \begin{itemdecl}
 void operator()(ArgTypes... args);
 \end{itemdecl}
@@ -5034,7 +5054,7 @@ template <class R, class... ArgTypes>
 \effects As if by \tcode{x.swap(y)}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{uses_allocator}}%
+\indexlibrary{\idxcode{uses_allocator}!\idxcode{packaged_task}}%
 \begin{itemdecl}
 template <class R, class Alloc>
   struct uses_allocator<packaged_task<R>, Alloc>


### PR DESCRIPTION
This review handles several topic related to the index of library names:

        apply indexlibrarymember for all member functions other than constructors/destructors
        consistent ordering of indexlibrarymember{identifier}{class-name}
        every index macro has a trailing % to avoid accidental whitespace
        ensure headers are indexed with synopsis
        ensure every itemdecl has a library index entry
        index every class definition