### PR TITLE
[lex.phases] Index and xref raw string literels

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -69,12 +69,12 @@ Any
 source file character not in the basic source character
 set~(\ref{lex.charset}) is replaced by the
 \indextext{universal character name}\grammarterm{universal-character-name} that
-designates that character. (An implementation may use any internal
+designates that character. An implementation may use any internal
 encoding, so long as an actual extended character encountered in the
 source file, and the same extended character expressed in the source
 file as a \grammarterm{universal-character-name} (e.g., using the \tcode{\textbackslash
 uXXXX} notation), are handled equivalently
-except where this replacement is reverted in a raw string literal.)
+except where this replacement is reverted~(\ref{lex.pptoken}) in a raw string literal.
 
 \indextext{line splicing}%
 \item Each instance of a backslash character (\textbackslash)
@@ -294,6 +294,7 @@ If the input stream has been parsed into preprocessing tokens up to a
 given character:
 
 \begin{itemize}
+\indextext{literal!string!raw}%
 \item If the next character begins a sequence of characters that could be the prefix
 and initial double quote of a raw string literal, such as \tcode{R"}, the next preprocessing
 token shall be a raw string literal. Between the initial and final
@@ -1415,6 +1416,7 @@ or \tcode{LR"(...)"},
 respectively.
 
 \pnum
+\indextext{literal!string!raw}%
 A \grammarterm{string-literal} that has an \tcode{R} in the prefix is a \defn{raw string literal}. The
 \grammarterm{d-char-sequence} serves as a delimiter. The terminating
 \grammarterm{d-char-sequence} of a \grammarterm{raw-string} is the same sequence of


### PR DESCRIPTION
Add a cross-reference on the reversion of universal characters in raw string
literals, as it is far from clear that [lex.pptoken] is the place to look
for this rule, which is not spelled out clearly in the phase1/phase2 rules.
Remove a confusing pair of parentheses as it was not clear if the intent
was to make the parenthetical a note, which we have a better way to render,
or normative.  Given the requirement that universal characters behave
consistently, this seems normative, rather than a note.

Index raw string literals, which appear to be entirely lacking from the
main index.