### PR TITLE
[function.objects] Use formal Returns: clause for std functors

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -12482,6 +12482,8 @@ template <class T> reference_wrapper<const T> cref(reference_wrapper<T> t) noexc
 The library provides basic function object classes for all of the arithmetic
 operators in the language~(\ref{expr.mul}, \ref{expr.add}).
 
+\rSec3[arithmetic.operations.plus]{class template \tcode{plus}}
+
 \indexlibrary{\idxcode{plus}}%
 \begin{itemdecl}
 template <class T = void> struct plus {
@@ -12490,82 +12492,12 @@ template <class T = void> struct plus {
 \end{itemdecl}
 
 \indexlibrarymember{operator()}{plus}%
-\begin{itemdescr}
-\pnum
-\tcode{operator()}
-returns
-\tcode{x + y}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{minus}}%
 \begin{itemdecl}
-template <class T = void> struct minus {
-  constexpr T operator()(const T& x, const T& y) const;
-};
+constexpr T operator()(const T& x, const T& y) const;
 \end{itemdecl}
 
-\indexlibrarymember{operator()}{minus}%
 \begin{itemdescr}
-\pnum
-\tcode{operator()}
-returns
-\tcode{x - y}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{multiplies}}%
-\begin{itemdecl}
-template <class T = void> struct multiplies {
-  constexpr T operator()(const T& x, const T& y) const;
-};
-\end{itemdecl}
-
-\indexlibrarymember{operator()}{multiplies}%
-\begin{itemdescr}
-\pnum
-\tcode{operator()}
-returns
-\tcode{x * y}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{divides}}%
-\begin{itemdecl}
-template <class T = void> struct divides {
-  constexpr T operator()(const T& x, const T& y) const;
-};
-\end{itemdecl}
-
-\indexlibrarymember{operator()}{divides}%
-\begin{itemdescr}
-\pnum
-\tcode{operator()}
-returns
-\tcode{x / y}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{modulus}}%
-\begin{itemdecl}
-template <class T = void> struct modulus {
-  constexpr T operator()(const T& x, const T& y) const;
-};
-\end{itemdecl}
-
-\indexlibrarymember{operator()}{modulus}%
-\begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{x \% y}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{negate}}%
-\begin{itemdecl}
-template <class T = void> struct negate {
-  constexpr T operator()(const T& x) const;
-};
-\end{itemdecl}
-
-\indexlibrarymember{operator()}{negate}%
-\begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{-x}.
+\pnum\returns \tcode{x + y}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{plus<>}}%
@@ -12579,9 +12511,31 @@ template <> struct plus<void> {
 \end{itemdecl}
 
 \indexlibrarymember{operator()}{plus<>}%
+\begin{itemdecl}
+template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+    -> decltype(std::forward<T>(t) + std::forward<U>(u));
+\end{itemdecl}
+
 \begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{std::forward<T>(t) + std::forward<U>(u)}.
+\pnum\returns \tcode{std::forward<T>(t) + std::forward<U>(u)}
+\end{itemdescr}
+
+\rSec3[arithmetic.operations.minus]{class template \tcode{minus}}
+
+\indexlibrary{\idxcode{minus}}%
+\begin{itemdecl}
+template <class T = void> struct minus {
+  constexpr T operator()(const T& x, const T& y) const;
+};
+\end{itemdecl}
+
+\indexlibrarymember{operator()}{minus}%
+\begin{itemdecl}
+constexpr T operator()(const T& x, const T& y) const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum\returns \tcode{x - y}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{minus<>}}%
@@ -12595,9 +12549,31 @@ template <> struct minus<void> {
 \end{itemdecl}
 
 \indexlibrarymember{operator()}{minus<>}%
+\begin{itemdecl}
+template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+    -> decltype(std::forward<T>(t) - std::forward<U>(u));
+\end{itemdecl}
+
 \begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{std::forward<T>(t) - std::forward<U>(u)}.
+\pnum\returns \tcode{std::forward<T>(t) - std::forward<U>(u)}
+\end{itemdescr}
+
+\rSec3[arithmetic.operations.multiplies]{class template \tcode{multiplies}}
+
+\indexlibrary{\idxcode{multiplies}}%
+\begin{itemdecl}
+template <class T = void> struct multiplies {
+  constexpr T operator()(const T& x, const T& y) const;
+};
+\end{itemdecl}
+
+\indexlibrarymember{operator()}{multiplies}%
+\begin{itemdecl}
+constexpr T operator()(const T& x, const T& y) const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum\returns \tcode{x * y}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{multiplies<>}}%
@@ -12611,9 +12587,31 @@ template <> struct multiplies<void> {
 \end{itemdecl}
 
 \indexlibrarymember{operator()}{multiplies<>}%
+\begin{itemdecl}
+template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+    -> decltype(std::forward<T>(t) * std::forward<U>(u));
+\end{itemdecl}
+
 \begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{std::forward<T>(t) * std::forward<U>(u)}.
+\pnum\returns \tcode{std::forward<T>(t) * std::forward<U>(u)}
+\end{itemdescr}
+
+\rSec3[arithmetic.operations.divides]{class template \tcode{divides}}
+
+\indexlibrary{\idxcode{divides}}%
+\begin{itemdecl}
+template <class T = void> struct divides {
+  constexpr T operator()(const T& x, const T& y) const;
+};
+\end{itemdecl}
+
+\indexlibrarymember{operator()}{divides}%
+\begin{itemdecl}
+constexpr T operator()(const T& x, const T& y) const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum\returns \tcode{x / y}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{divides<>}}%
@@ -12627,9 +12625,31 @@ template <> struct divides<void> {
 \end{itemdecl}
 
 \indexlibrarymember{operator()}{divides<>}%
+\begin{itemdecl}
+template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+    -> decltype(std::forward<T>(t) / std::forward<U>(u));
+\end{itemdecl}
+
 \begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{std::forward<T>(t) / std::forward<U>(u)}.
+\pnum\returns \tcode{std::forward<T>(t) / std::forward<U>(u)}
+\end{itemdescr}
+
+\rSec3[arithmetic.operations.modulus]{class template \tcode{modulus}}
+
+\indexlibrary{\idxcode{modulus}}%
+\begin{itemdecl}
+template <class T = void> struct modulus {
+  constexpr T operator()(const T& x, const T& y) const;
+};
+\end{itemdecl}
+
+\indexlibrarymember{operator()}{modulus}%
+\begin{itemdecl}
+constexpr T operator()(const T& x, const T& y) const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum\returns \tcode{x \% y}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{modulus<>}}%
@@ -12643,9 +12663,31 @@ template <> struct modulus<void> {
 \end{itemdecl}
 
 \indexlibrarymember{operator()}{modulus<>}%
+\begin{itemdecl}
+template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+    -> decltype(std::forward<T>(t) % std::forward<U>(u));
+\end{itemdecl}
+
 \begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{std::forward<T>(t) \% std::forward<U>(u)}.
+\pnum\returns \tcode{std::forward<T>(t) \% std::forward<U>(u)}
+\end{itemdescr}
+
+\rSec3[arithmetic.operations.negate]{class template \tcode{negate}}
+
+\indexlibrary{\idxcode{negate}}%
+\begin{itemdecl}
+template <class T = void> struct negate {
+  constexpr T operator()(const T& x) const;
+};
+\end{itemdecl}
+
+\indexlibrarymember{operator()}{negate}%
+\begin{itemdecl}
+constexpr T operator()(const T& x) const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum\returns \tcode{-x}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{negate<>}}%
@@ -12659,9 +12701,13 @@ template <> struct negate<void> {
 \end{itemdecl}
 
 \indexlibrarymember{operator()}{negate<>}%
+\begin{itemdecl}
+template <class T> constexpr auto operator()(T&& t) const
+    -> decltype(-std::forward<T>(t));
+\end{itemdecl}
+
 \begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{-std::forward<T>(t)}.
+\pnum\returns \tcode{-std::forward<T>(t)}
 \end{itemdescr}
 
 
@@ -12671,6 +12717,18 @@ template <> struct negate<void> {
 The library provides basic function object classes for all of the comparison
 operators in the language~(\ref{expr.rel}, \ref{expr.eq}).
 
+\pnum
+For templates \tcode{greater}, \tcode{less}, \tcode{greater_equal}, and
+\tcode{less_equal}, the specializations for any pointer type yield a total order,
+even if the built-in operators \tcode{<}, \tcode{>}, \tcode{<=}, \tcode{>=}
+do not.
+For template specializations \tcode{greater<void>}, \tcode{less<void>},
+\tcode{greater_equal<void>}, and \tcode{less_equal<void>},
+if the call operator calls a built-in operator comparing pointers,
+the call operator yields a total order.
+
+\rSec3[comparisons.equal_to]{class template \tcode{equal_to}}
+
 \indexlibrary{\idxcode{equal_to}}%
 \begin{itemdecl}
 template <class T = void> struct equal_to {
@@ -12679,74 +12737,12 @@ template <class T = void> struct equal_to {
 \end{itemdecl}
 
 \indexlibrarymember{operator()}{equal_to}%
-\begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{x == y}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{not_equal_to}}%
 \begin{itemdecl}
-template <class T = void> struct not_equal_to {
-  constexpr bool operator()(const T& x, const T& y) const;
-};
+constexpr bool operator()(const T& x, const T& y) const;
 \end{itemdecl}
 
-\indexlibrarymember{operator()}{not_equal_to}%
 \begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{x != y}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{greater}}%
-\begin{itemdecl}
-template <class T = void> struct greater {
-  constexpr bool operator()(const T& x, const T& y) const;
-};
-\end{itemdecl}
-
-\indexlibrarymember{operator()}{greater}%
-\begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{x > y}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{less}}%
-\begin{itemdecl}
-template <class T = void> struct less {
-  constexpr bool operator()(const T& x, const T& y) const;
-};
-\end{itemdecl}
-
-\indexlibrarymember{operator()}{less}%
-\begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{x < y}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{greater_equal}}%
-\begin{itemdecl}
-template <class T = void> struct greater_equal {
-  constexpr bool operator()(const T& x, const T& y) const;
-};
-\end{itemdecl}
-
-\indexlibrarymember{operator()}{greater_equal}%
-\begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{x >= y}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{less_equal}}%
-\begin{itemdecl}
-template <class T = void> struct less_equal {
-  constexpr bool operator()(const T& x, const T& y) const;
-};
-\end{itemdecl}
-
-\indexlibrarymember{operator()}{less_equal}%
-\begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{x <= y}.
+\pnum\returns \tcode{x == y}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{equal_to<>}}%
@@ -12760,9 +12756,31 @@ template <> struct equal_to<void> {
 \end{itemdecl}
 
 \indexlibrarymember{operator()}{equal_to<>}%
+\begin{itemdecl}
+template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+    -> decltype(std::forward<T>(t) == std::forward<U>(u));
+\end{itemdecl}
+
 \begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{std::forward<T>(t) == std::forward<U>(u)}.
+\pnum\returns \tcode{std::forward<T>(t) == std::forward<U>(u)}
+\end{itemdescr}
+
+\rSec3[comparisons.not_equal_to]{class template \tcode{not_equal_to}}
+
+\indexlibrary{\idxcode{not_equal_to}}%
+\begin{itemdecl}
+template <class T = void> struct not_equal_to {
+  constexpr bool operator()(const T& x, const T& y) const;
+};
+\end{itemdecl}
+
+\indexlibrarymember{operator()}{not_equal_to}%
+\begin{itemdecl}
+constexpr bool operator()(const T& x, const T& y) const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum\returns \tcode{x != y}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{not_equal_to<>}}%
@@ -12776,9 +12794,31 @@ template <> struct not_equal_to<void> {
 \end{itemdecl}
 
 \indexlibrarymember{operator()}{not_equal_to<>}%
+\begin{itemdecl}
+template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+    -> decltype(std::forward<T>(t) != std::forward<U>(u));
+\end{itemdecl}
+
 \begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{std::forward<T>(t) != std::forward<U>(u)}.
+\pnum\returns \tcode{std::forward<T>(t) != std::forward<U>(u)}
+\end{itemdescr}
+
+\rSec3[comparisons.greater]{class template \tcode{greater}}
+
+\indexlibrary{\idxcode{greater}}%
+\begin{itemdecl}
+template <class T = void> struct greater {
+  constexpr bool operator()(const T& x, const T& y) const;
+};
+\end{itemdecl}
+
+\indexlibrarymember{operator()}{greater}%
+\begin{itemdecl}
+constexpr bool operator()(const T& x, const T& y) const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum\returns \tcode{x > y}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{greater<>}}%
@@ -12792,9 +12832,31 @@ template <> struct greater<void> {
 \end{itemdecl}
 
 \indexlibrarymember{operator()}{greater<>}%
+\begin{itemdecl}
+template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+    -> decltype(std::forward<T>(t) > std::forward<U>(u));
+\end{itemdecl}
+
 \begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{std::forward<T>(t) > std::forward<U>(u)}.
+\pnum\returns \tcode{std::forward<T>(t) > std::forward<U>(u)}
+\end{itemdescr}
+
+\rSec3[comparisons.less]{class template \tcode{less}}
+
+\indexlibrary{\idxcode{less}}%
+\begin{itemdecl}
+template <class T = void> struct less {
+  constexpr bool operator()(const T& x, const T& y) const;
+};
+\end{itemdecl}
+
+\indexlibrarymember{operator()}{less}%
+\begin{itemdecl}
+constexpr bool operator()(const T& x, const T& y) const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum\returns \tcode{x < y}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{less<>}}%
@@ -12808,9 +12870,31 @@ template <> struct less<void> {
 \end{itemdecl}
 
 \indexlibrarymember{operator()}{less<>}%
+\begin{itemdecl}
+template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+    -> decltype(std::forward<T>(t) < std::forward<U>(u));
+\end{itemdecl}
+
 \begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{std::forward<T>(t) < std::forward<U>(u)}.
+\pnum\returns \tcode{std::forward<T>(t) < std::forward<U>(u)}
+\end{itemdescr}
+
+\rSec3[comparisons.greater_equal]{class template \tcode{greater_equal}}
+
+\indexlibrary{\idxcode{greater_equal}}%
+\begin{itemdecl}
+template <class T = void> struct greater_equal {
+  constexpr bool operator()(const T& x, const T& y) const;
+};
+\end{itemdecl}
+
+\indexlibrarymember{operator()}{greater_equal}%
+\begin{itemdecl}
+constexpr bool operator()(const T& x, const T& y) const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum\returns \tcode{x >= y}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{greater_equal<>}}%
@@ -12824,9 +12908,31 @@ template <> struct greater_equal<void> {
 \end{itemdecl}
 
 \indexlibrarymember{operator()}{greater_equal<>}%
+\begin{itemdecl}
+template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+    -> decltype(std::forward<T>(t) >= std::forward<U>(u));
+\end{itemdecl}
+
 \begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{std::forward<T>(t) >= std::forward<U>(u)}.
+\pnum\returns \tcode{std::forward<T>(t) >= std::forward<U>(u)}
+\end{itemdescr}
+
+\rSec3[comparisons.less_equal]{class template \tcode{less_equal}}
+
+\indexlibrary{\idxcode{less_equal}}%
+\begin{itemdecl}
+template <class T = void> struct less_equal {
+  constexpr bool operator()(const T& x, const T& y) const;
+};
+\end{itemdecl}
+
+\indexlibrarymember{operator()}{less_equal}%
+\begin{itemdecl}
+constexpr bool operator()(const T& x, const T& y) const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum\returns \tcode{x <= y}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{less_equal<>}}%
@@ -12840,26 +12946,23 @@ template <> struct less_equal<void> {
 \end{itemdecl}
 
 \indexlibrarymember{operator()}{less_equal<>}%
+\begin{itemdecl}
+template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+    -> decltype(std::forward<T>(t) <= std::forward<U>(u));
+\end{itemdecl}
+
 \begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{std::forward<T>(t) <= std::forward<U>(u)}.
+\pnum\returns \tcode{std::forward<T>(t) <= std::forward<U>(u)}
 \end{itemdescr}
 
-\pnum
-For templates \tcode{greater}, \tcode{less}, \tcode{greater_equal}, and
-\tcode{less_equal}, the specializations for any pointer type yield a total order,
-even if the built-in operators \tcode{<}, \tcode{>}, \tcode{<=}, \tcode{>=}
-do not.
-For template specializations \tcode{greater<void>}, \tcode{less<void>},
-\tcode{greater_equal<void>}, and \tcode{less_equal<void>},
-if the call operator calls a built-in operator comparing pointers,
-the call operator yields a total order.
 
 \rSec2[logical.operations]{Logical operations}
 
 \pnum
 The library provides basic function object classes for all of the logical
 operators in the language~(\ref{expr.log.and}, \ref{expr.log.or}, \ref{expr.unary.op}).
+
+\rSec3[logical.operations.and]{class template \tcode{logical_and}}
 
 \indexlibrary{\idxcode{logical_and}}%
 \begin{itemdecl}
@@ -12869,35 +12972,12 @@ template <class T = void> struct logical_and {
 \end{itemdecl}
 
 \indexlibrarymember{operator()}{logical_and}%
-\begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{x \&\& y}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{logical_or}}%
 \begin{itemdecl}
-template <class T = void> struct logical_or {
-  constexpr bool operator()(const T& x, const T& y) const;
-};
+constexpr bool operator()(const T& x, const T& y) const;
 \end{itemdecl}
 
-\indexlibrarymember{operator()}{logical_or}%
 \begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{x || y}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{logical_not}}%
-\begin{itemdecl}
-template <class T = void> struct logical_not {
-  constexpr bool operator()(const T& x) const;
-};
-\end{itemdecl}
-
-\indexlibrarymember{operator()}{logical_not}%
-\begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{!x}.
+\pnum\returns \tcode{x \&\& y}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{logical_and<>}}%
@@ -12911,9 +12991,31 @@ template <> struct logical_and<void> {
 \end{itemdecl}
 
 \indexlibrarymember{operator()}{logical_and<>}%
+\begin{itemdecl}
+template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+    -> decltype(std::forward<T>(t) && std::forward<U>(u));
+\end{itemdecl}
+
 \begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{std::forward<T>(t) \&\& std::forward<U>(u)}.
+\pnum\returns \tcode{std::forward<T>(t) \&\& std::forward<U>(u)}
+\end{itemdescr}
+
+\rSec3[logical.operations.or]{class template \tcode{logical_or}}
+
+\indexlibrary{\idxcode{logical_or}}%
+\begin{itemdecl}
+template <class T = void> struct logical_or {
+  constexpr bool operator()(const T& x, const T& y) const;
+};
+\end{itemdecl}
+
+\indexlibrarymember{operator()}{logical_or}%
+\begin{itemdecl}
+constexpr bool operator()(const T& x, const T& y) const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum\returns \tcode{x || y}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{logical_or<>}}%
@@ -12927,9 +13029,31 @@ template <> struct logical_or<void> {
 \end{itemdecl}
 
 \indexlibrarymember{operator()}{logical_or<>}%
+\begin{itemdecl}
+template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+    -> decltype(std::forward<T>(t) || std::forward<U>(u));
+\end{itemdecl}
+
 \begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{std::forward<T>(t) || std::forward<U>(u)}.
+\pnum\returns \tcode{std::forward<T>(t) || std::forward<U>(u)}
+\end{itemdescr}
+
+\rSec3[logical.operations.not]{class template \tcode{logical_not}}
+
+\indexlibrary{\idxcode{logical_not}}%
+\begin{itemdecl}
+template <class T = void> struct logical_not {
+  constexpr bool operator()(const T& x) const;
+};
+\end{itemdecl}
+
+\indexlibrarymember{operator()}{logical_not}%
+\begin{itemdecl}
+constexpr bool operator()(const T& x) const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum\returns \tcode{!x}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{logical_not<>}}%
@@ -12943,9 +13067,13 @@ template <> struct logical_not<void> {
 \end{itemdecl}
 
 \indexlibrarymember{operator()}{logical_not<>}%
+\begin{itemdecl}
+template <class T> constexpr auto operator()(T&& t) const
+    -> decltype(!std::forward<T>(t));
+\end{itemdecl}
+
 \begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{!std::forward<T>(t)}.
+\pnum\returns \tcode{!std::forward<T>(t)}
 \end{itemdescr}
 
 
@@ -12956,6 +13084,8 @@ The library provides basic function object classes for all of the bitwise
 operators in the language~(\ref{expr.bit.and}, \ref{expr.or},
 \ref{expr.xor}, \ref{expr.unary.op}).
 
+\rSec3[bitwise.operations.and]{class template \tcode{bit_and}}
+
 \indexlibrary{\idxcode{bit_and}}%
 \begin{itemdecl}
 template <class T = void> struct bit_and {
@@ -12964,47 +13094,12 @@ template <class T = void> struct bit_and {
 \end{itemdecl}
 
 \indexlibrarymember{operator()}{bit_and}%
-\begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{x \& y}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{bit_or}}%
 \begin{itemdecl}
-template <class T = void> struct bit_or {
-  constexpr T operator()(const T& x, const T& y) const;
-};
+constexpr T operator()(const T& x, const T& y) const;
 \end{itemdecl}
 
-\indexlibrarymember{operator()}{bit_or}%
 \begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{x | y}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{bit_xor}}%
-\begin{itemdecl}
-template <class T = void> struct bit_xor {
-  constexpr T operator()(const T& x, const T& y) const;
-};
-\end{itemdecl}
-
-\indexlibrarymember{operator()}{bit_xor}%
-\begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{x \^{} y}.
-\end{itemdescr}
-
-\begin{itemdecl}
-template <class T = void> struct bit_not {
-  constexpr T operator()(const T& x) const;
-};
-\end{itemdecl}
-
-\indexlibrarymember{operator()}{bit_not}%
-\begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{\~{}x}.
+\pnum\returns \tcode{x \& y}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bit_and<>}}%
@@ -13018,9 +13113,31 @@ template <> struct bit_and<void> {
 \end{itemdecl}
 
 \indexlibrarymember{operator()}{bit_and<>}%
+\begin{itemdecl}
+template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+    -> decltype(std::forward<T>(t) & std::forward<U>(u));
+\end{itemdecl}
+
 \begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{std::forward<T>(t) \& std::forward<U>(u)}.
+\pnum\returns \tcode{std::forward<T>(t) \& std::forward<U>(u)}
+\end{itemdescr}
+
+\rSec3[bitwise.operations.or]{class template \tcode{bit_or}}
+
+\indexlibrary{\idxcode{bit_or}}%
+\begin{itemdecl}
+template <class T = void> struct bit_or {
+  constexpr T operator()(const T& x, const T& y) const;
+};
+\end{itemdecl}
+
+\indexlibrarymember{operator()}{bit_or}%
+\begin{itemdecl}
+constexpr T operator()(const T& x, const T& y) const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum\returns \tcode{x | y}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bit_or<>}}%
@@ -13034,9 +13151,31 @@ template <> struct bit_or<void> {
 \end{itemdecl}
 
 \indexlibrarymember{operator()}{bit_or<>}%
+\begin{itemdecl}
+template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+    -> decltype(std::forward<T>(t) | std::forward<U>(u));
+\end{itemdecl}
+
 \begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{std::forward<T>(t) | std::forward<U>(u)}.
+\pnum\returns \tcode{std::forward<T>(t) | std::forward<U>(u)}
+\end{itemdescr}
+
+\rSec3[bitwise.operations.xor]{class template \tcode{bit_xor}}
+
+\indexlibrary{\idxcode{bit_xor}}%
+\begin{itemdecl}
+template <class T = void> struct bit_xor {
+  constexpr T operator()(const T& x, const T& y) const;
+};
+\end{itemdecl}
+
+\indexlibrarymember{operator()}{bit_xor}%
+\begin{itemdecl}
+constexpr T operator()(const T& x, const T& y) const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum\returns \tcode{x \^{} y}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bit_xor<>}}%
@@ -13050,9 +13189,30 @@ template <> struct bit_xor<void> {
 \end{itemdecl}
 
 \indexlibrarymember{operator()}{bit_xor<>}%
+\begin{itemdecl}
+template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+    -> decltype(std::forward<T>(t) ^ std::forward<U>(u));
+\end{itemdecl}
+
 \begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{std::forward<T>(t) \^{} std::forward<U>(u)}.
+\pnum\returns \tcode{std::forward<T>(t) \^{} std::forward<U>(u)}
+\end{itemdescr}
+
+\rSec3[bitwise.operations.not]{class template \tcode{bit_not}}
+
+\begin{itemdecl}
+template <class T = void> struct bit_not {
+  constexpr T operator()(const T& x) const;
+};
+\end{itemdecl}
+
+\indexlibrarymember{operator()}{bit_not}%
+\begin{itemdecl}
+constexpr T operator()(const T& x) const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum\returns \tcode{\~{}x}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bit_not<>}}%
@@ -13066,10 +13226,15 @@ template <> struct bit_not<void> {
 \end{itemdecl}
 
 \indexlibrarymember{operator()}{bit_not<>}%
+\begin{itemdecl}
+template <class T> constexpr auto operator()(T&&) const
+    -> decltype(~std::forward<T>(t));
+\end{itemdecl}
+
 \begin{itemdescr}
-\pnum
-\tcode{operator()} returns \tcode{\~{}std::forward<T>(t)}.
+\pnum\returns \tcode{\~{}std::forward<T>(t)}
 \end{itemdescr}
+
 
 \rSec2[func.not_fn]{Function template \tcode{not_fn}}
 


### PR DESCRIPTION
Revise presentation of all functors in clauses 20.14.(5-8) to use a
formal Returns: clause, consistent with the conventions laid out in
clause 17, rather than ad-hoc presentation lacking any of the
recognised markers.

This turned into a substantial re-render.  In order to break up a
wall of code with occasional normative text, I have introduced a
subsection for each class.  Under each new subsection, I collect
the primary class template and the 'diamond' specialization, which
were previously separated by the intervening classes.

I believe these changes are strictly editorial, but please let me
know soon if you would rather see a CD ballot comment before
accepting an editorial change of this scale.