### PR TITLE
[optional.object.ctor] remove redundant <T>

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2342,7 +2342,7 @@ For every object type \tcode{T} these constructors shall be \tcode{constexpr} co
 
 \indexlibrary{\idxcode{optional}!constructor}%
 \begin{itemdecl}
-optional(const optional<T>& rhs);
+optional(const optional& rhs);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2366,7 +2366,7 @@ Any exception thrown by the selected constructor of \tcode{T}.
 
 \indexlibrary{\idxcode{optional}!constructor}%
 \begin{itemdecl}
-optional(optional<T>&& rhs) noexcept(@\seebelow@);
+optional(optional&& rhs) noexcept(@\seebelow@);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2545,7 +2545,7 @@ If \tcode{*this} contains a value, calls \tcode{val->T::\~T()} to destroy the co
 
 \indexlibrarymember{operator=}{optional}%
 \begin{itemdecl}
-optional<T>& operator=(const optional<T>& rhs);
+optional<T>& operator=(const optional& rhs);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2588,7 +2588,7 @@ the state of its contained value is as defined by the exception safety guarantee
 
 \indexlibrarymember{operator=}{optional}%
 \begin{itemdecl}
-optional<T>& operator=(optional<T>&& rhs) noexcept(@\seebelow@);
+optional<T>& operator=(optional&& rhs) noexcept(@\seebelow@);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2725,7 +2725,7 @@ This function shall not participate in overload resolution unless \tcode{is_cons
 
 \indexlibrarymember{swap}{optional}%
 \begin{itemdecl}
-void swap(optional<T>& rhs) noexcept(@\seebelow@);
+void swap(optional& rhs) noexcept(@\seebelow@);
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Remove redundant <T> when passing an optional<T> parameter to a construtor or other member function.  The class definition is already correct, so this is just making the function specifications consistent with their original declarations.