### PR TITLE
[thread.once] Move struct once_flag defintion into corresponding subc…

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -831,12 +831,7 @@ namespace std {
   template <class L1, class L2, class... L3> int try_lock(L1&, L2&, L3&...);
   template <class L1, class L2, class... L3> void lock(L1&, L2&, L3&...);
 
-  struct once_flag {
-    constexpr once_flag() noexcept;
-
-    once_flag(const once_flag&) = delete;
-    once_flag& operator=(const once_flag&) = delete;
-  };
+  struct once_flag;
 
   template<class Callable, class ...Args>
     void call_once(once_flag& flag, Callable&& func, Args&&... args);
@@ -2601,10 +2596,23 @@ called for any argument that had been locked by a call to \tcode{lock()} or
 
 \rSec2[thread.once]{Call once}
 
+\rSec3[thread.once.onceflag]{Struct \tcode{once_flag}}
+
+\indexlibrary{\idxcode{once_flag}}%
+\begin{codeblock}
+namespace std {
+  struct once_flag {
+    constexpr once_flag() noexcept;
+
+    once_flag(const once_flag&) = delete;
+    once_flag& operator=(const once_flag&) = delete;
+  };
+}
+\end{codeblock}
+
+\pnum
 The class \tcode{once_flag} is an opaque data structure that \tcode{call_once} uses to
 initialize data without causing a data race or deadlock.
-
-\rSec3[thread.once.onceflag]{Struct \tcode{once_flag}}
 
 \indexlibrary{\idxcode{once_flag}}%
 \begin{itemdecl}


### PR DESCRIPTION
…lause

By convention, unless the whole specification of the class is in the
header synopsis (typically a tag type) the class should be forward
declared in the synopsis.  The class definition for once_flag is moved
to 30.4.4 [thread.once].

See https://github.com/cplusplus/draft/issues/918