### PR TITLE
[thread.lock.shared] Apply conventional indent to shared_lock class d…

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -2135,58 +2135,56 @@ mutex_type *mutex() const noexcept;
 
 \begin{codeblock}
 namespace std {
+  template <class Mutex>
+  class shared_lock {
+  public:
+    using mutex_type = Mutex;
 
-template <class Mutex>
-class shared_lock {
-public:
-  using mutex_type = Mutex;
-
-  // Shared locking
-  shared_lock() noexcept;
-  explicit shared_lock(mutex_type& m);  // blocking
-  shared_lock(mutex_type& m, defer_lock_t) noexcept;
-  shared_lock(mutex_type& m, try_to_lock_t);
-  shared_lock(mutex_type& m, adopt_lock_t);
-  template <class Clock, class Duration>
-    shared_lock(mutex_type& m,
-                const chrono::time_point<Clock, Duration>& abs_time);
-  template <class Rep, class Period>
-    shared_lock(mutex_type& m,
+    // Shared locking
+    shared_lock() noexcept;
+    explicit shared_lock(mutex_type& m);  // blocking
+    shared_lock(mutex_type& m, defer_lock_t) noexcept;
+    shared_lock(mutex_type& m, try_to_lock_t);
+    shared_lock(mutex_type& m, adopt_lock_t);
+    template <class Clock, class Duration>
+      shared_lock(mutex_type& m,
+                  const chrono::time_point<Clock, Duration>& abs_time);
+    template <class Rep, class Period>
+      shared_lock(mutex_type& m,
                 const chrono::duration<Rep, Period>& rel_time);
-  ~shared_lock();
+    ~shared_lock();
 
-  shared_lock(shared_lock const&) = delete;
-  shared_lock& operator=(shared_lock const&) = delete;
+    shared_lock(shared_lock const&) = delete;
+    shared_lock& operator=(shared_lock const&) = delete;
 
-  shared_lock(shared_lock&& u) noexcept;
-  shared_lock& operator=(shared_lock&& u) noexcept;
+    shared_lock(shared_lock&& u) noexcept;
+    shared_lock& operator=(shared_lock&& u) noexcept;
 
-  void lock();  // blocking
-  bool try_lock();
-  template <class Rep, class Period>
-    bool try_lock_for(const chrono::duration<Rep, Period>& rel_time);
-  template <class Clock, class Duration>
-    bool try_lock_until(const chrono::time_point<Clock, Duration>& abs_time);
-  void unlock();
+    void lock();  // blocking
+    bool try_lock();
+    template <class Rep, class Period>
+      bool try_lock_for(const chrono::duration<Rep, Period>& rel_time);
+    template <class Clock, class Duration>
+      bool try_lock_until(const chrono::time_point<Clock, Duration>& abs_time);
+    void unlock();
 
-  // Setters
-  void swap(shared_lock& u) noexcept;
-  mutex_type* release() noexcept;
+    // Setters
+    void swap(shared_lock& u) noexcept;
+    mutex_type* release() noexcept;
 
-  // Getters
-  bool owns_lock() const noexcept;
-  explicit operator bool () const noexcept;
-  mutex_type* mutex() const noexcept;
+    // Getters
+    bool owns_lock() const noexcept;
+    explicit operator bool () const noexcept;
+    mutex_type* mutex() const noexcept;
 
-private:
-  mutex_type* pm; // \expos
-  bool owns;      // \expos
-};
+  private:
+    mutex_type* pm; // \expos
+    bool owns;      // \expos
+  };
 
-template <class Mutex>
-  void swap(shared_lock<Mutex>& x, shared_lock<Mutex>& y) noexcept;
-
-}  // std
+  template <class Mutex>
+    void swap(shared_lock<Mutex>& x, shared_lock<Mutex>& y) noexcept;
+}
 \end{codeblock}
 
 \pnum


### PR DESCRIPTION
…efinition

The convention appears to be no blank lines between the opening
of the enclosing namespace, and the class defintion; a two-space
indent for everything inside the namespace; and no comment on
closing brace of the namespace.