### PR TITLE
[meta] Add index entries for each type trait

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -13995,7 +13995,7 @@ bool is_directory(const path& p, error_code& ec) noexcept;
 
 \rSec3[fs.op.is_empty]{Is empty}
 
-\indexlibrary{\idxcode{is_empty}}%
+\indexlibrary{\idxcode{is_empty}!function}%
 \begin{itemdecl}
 bool is_empty(const path& p);
 bool is_empty(const path& p, error_code& ec) noexcept;

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -14698,6 +14698,10 @@ namespace std {
 }
 \end{codeblock}
 
+\indexlibrary{\idxcode{integral_constant}}%
+\indexlibrary{\idxcode{bool_constant}}%
+\indexlibrary{\idxcode{true_type}}%
+\indexlibrary{\idxcode{false_type}}%
 \pnum
 The class template \tcode{integral_constant},
 alias template \tcode{bool_constant}, and
@@ -14743,49 +14747,63 @@ has a \tcode{value} member that evaluates to \tcode{true}.
 \topline
 \lhdr{Template} &   \chdr{Condition}    &   \rhdr{Comments} \\ \capsep
 \endhead
+\indexlibrary{\idxcode{is_void}}%
 \tcode{template <class T>}\br
  \tcode{struct is_void;}                &
 \tcode{T} is \tcode{void}       &   \\ \rowsep
+\indexlibrary{\idxcode{is_null_pointer}}%
 \tcode{template <class T>}\br
  \tcode{struct is_null_pointer;}                &
 \tcode{T} is \tcode{nullptr_t}~(\ref{basic.fundamental})       &   \\ \rowsep
+\indexlibrary{\idxcode{is_integral}}%
 \tcode{template <class T>}\br
  \tcode{struct is_integral;}        &
 \tcode{T} is an integral type~(\ref{basic.fundamental})                 &   \\ \rowsep
+\indexlibrary{\idxcode{is_floating_point}}%
 \tcode{template <class T>}\br
  \tcode{struct is_floating_point;}  &
 \tcode{T} is a floating point type~(\ref{basic.fundamental})            &   \\ \rowsep
+\indexlibrary{\idxcode{is_array}}%
 \tcode{template <class T>}\br
  \tcode{struct is_array;}           &
 \tcode{T} is an array type~(\ref{basic.compound}) of known or unknown extent    &
 Class template \tcode{array}~(\ref{array})
 is not an array type.                   \\ \rowsep
+\indexlibrary{\idxcode{is_pointer}}%
 \tcode{template <class T>}\br
  \tcode{struct is_pointer;}         &
 \tcode{T} is a pointer type~(\ref{basic.compound})                      &
 Includes pointers to functions
 but not pointers to non-static members.                        \\ \rowsep
+\indexlibrary{\idxcode{is_lvalue_reference}}%
 \tcode{template <class T>}\br
  \tcode{struct is_lvalue_reference;}    &
  \tcode{T} is an lvalue reference type~(\ref{dcl.ref})   &   \\ \rowsep
+\indexlibrary{\idxcode{is_rvalue_reference}}%
 \tcode{template <class T>}\br
  \tcode{struct is_rvalue_reference;}    &
  \tcode{T} is an rvalue reference type~(\ref{dcl.ref})   &   \\ \rowsep
+\indexlibrary{\idxcode{is_member_object_pointer}}%
 \tcode{template <class T>}\br
  \tcode{struct is_member_object_pointer;}&
  \tcode{T} is a pointer to non-static data member                              &   \\ \rowsep
+\indexlibrary{\idxcode{is_member_function_pointer}}%
 \tcode{template <class T>}\br
  \tcode{struct is_member_function_pointer;}&
 \tcode{T} is a pointer to non-static member function                           &   \\ \rowsep
+\indexlibrary{\idxcode{is_enum}}%
 \tcode{template <class T>}\br
  \tcode{struct is_enum;}            &
 \tcode{T} is an enumeration type~(\ref{basic.compound})                 &   \\ \rowsep
+\indexlibrary{\idxcode{is_union}}%
 \tcode{template <class T>}\br
  \tcode{struct is_union;}           &
 \tcode{T} is a union type~(\ref{basic.compound})                        &   \\ \rowsep
+\indexlibrary{\idxcode{is_class}}%
 \tcode{template <class T>}\br
  \tcode{struct is_class;}           &
 \tcode{T} is a non-union class type~(\ref{basic.compound}) & \\ \rowsep
+\indexlibrary{\idxcode{is_function}}%
 \tcode{template <class T>}\br
  \tcode{struct is_function;}        &
 \tcode{T} is a function type~(\ref{basic.compound})                     &   \\
@@ -14809,24 +14827,31 @@ For any given type \tcode{T}, the result of applying one of these templates to
 \topline
 \lhdr{Template} &   \chdr{Condition}    &   \rhdr{Comments} \\ \capsep
 \endhead
+\indexlibrary{\idxcode{is_reference}}%
 \tcode{template <class T>}\br
  \tcode{struct is_reference;}   &
  \tcode{T} is an lvalue reference or an rvalue reference &  \\ \rowsep
+\indexlibrary{\idxcode{is_arithmetic}}%
 \tcode{template <class T>}\br
  \tcode{struct is_arithmetic;}          &
  \tcode{T} is an arithmetic type~(\ref{basic.fundamental})              &   \\ \rowsep
+\indexlibrary{\idxcode{is_fundamental}}%
 \tcode{template <class T>}\br
  \tcode{struct is_fundamental;}         &
  \tcode{T} is a fundamental type~(\ref{basic.fundamental})              &   \\ \rowsep
+\indexlibrary{\idxcode{is_object}}%
 \tcode{template <class T>}\br
  \tcode{struct is_object;}              &
  \tcode{T} is an object type~(\ref{basic.types})                            &   \\ \rowsep
+\indexlibrary{\idxcode{is_scalar}}%
 \tcode{template <class T>}\br
  \tcode{struct is_scalar;}              &
  \tcode{T} is a scalar type~(\ref{basic.types})                         &   \\ \rowsep
+\indexlibrary{\idxcode{is_compound}}%
 \tcode{template <class T>}\br
  \tcode{struct is_compound;}            &
  \tcode{T} is a compound type~(\ref{basic.compound})                        &   \\ \rowsep
+\indexlibrary{\idxcode{is_member_pointer}}%
 \tcode{template <class T>}\br
  \tcode{struct is_member_pointer;}      &
  \tcode{T} is a pointer to non-static data member
@@ -14867,39 +14892,46 @@ notwithstanding the restrictions of~\ref{declval}.
 \lhdr{Template} &   \chdr{Condition}    &   \rhdr{Preconditions}    \\ \capsep
 \endhead
 
+\indexlibrary{\idxcode{is_const}}%
 \tcode{template <class T>}\br
  \tcode{struct is_const;}               &
  \tcode{T} is const-qualified~(\ref{basic.type.qualifier})                  &   \\ \rowsep
 
+\indexlibrary{\idxcode{is_volatile}}%
 \tcode{template <class T>}\br
  \tcode{struct is_volatile;}            &
  \tcode{T} is volatile-qualified~(\ref{basic.type.qualifier})                   &   \\ \rowsep
 
 
+\indexlibrary{\idxcode{is_trivial}}%
 \tcode{template <class T>}\br
  \tcode{struct is_trivial;}                 &
  \tcode{T} is a trivial type~(\ref{basic.types})     &
  \tcode{remove_all_extents_t<T>} shall be a complete
  type or (possibly cv-qualified) \tcode{void}.                \\ \rowsep
 
+\indexlibrary{\idxcode{is_trivially_copyable}}%
 \tcode{template <class T>}\br
  \tcode{struct is_trivially_copyable;}      &
  \tcode{T} is a trivially copyable type~(\ref{basic.types}) &
  \tcode{remove_all_extents_t<T>} shall be a complete type or
  (possibly cv-qualified) \tcode{void}.                               \\ \rowsep
 
+\indexlibrary{\idxcode{is_standard_layout}}%
 \tcode{template <class T>}\br
  \tcode{struct is_standard_layout;}                 &
  \tcode{T} is a standard-layout type~(\ref{basic.types})   &
  \tcode{remove_all_extents_t<T>} shall be a complete
  type or (possibly cv-qualified) \tcode{void}.                \\ \rowsep
 
+\indexlibrary{\idxcode{is_pod}}%
 \tcode{template <class T>}\br
  \tcode{struct is_pod;}                 &
  \tcode{T} is a POD type~(\ref{basic.types})                                &
  \tcode{remove_all_extents_t<T>} shall be a complete
  type or (possibly cv-qualified) \tcode{void}.                \\ \rowsep
 
+\indexlibrary{\idxcode{is_empty}!class}%
 \tcode{template <class T>}\br
  \tcode{struct is_empty;}               &
  \tcode{T} is a class type, but not a union type, with no non-static data
@@ -14908,16 +14940,19 @@ notwithstanding the restrictions of~\ref{declval}.
  which \tcode{is_empty_v<B>} is false. &
  If \tcode{T} is a non-union class type, \tcode{T} shall be a complete type.                               \\ \rowsep
 
+\indexlibrary{\idxcode{is_polymorphic}}%
 \tcode{template <class T>}\br
  \tcode{struct is_polymorphic;}         &
  \tcode{T} is a polymorphic class~(\ref{class.virtual})                             &
  If \tcode{T} is a non-union class type, \tcode{T} shall be a complete type.                \\ \rowsep
 
+\indexlibrary{\idxcode{is_abstract}}%
 \tcode{template <class T>}\br
  \tcode{struct is_abstract;}            &
  \tcode{T} is an abstract class~(\ref{class.abstract})                              &
  If \tcode{T} is a non-union class type, \tcode{T} shall be a complete type.                \\ \rowsep
 
+\indexlibrary{\idxcode{is_final}}%
 \tcode{template <class T>}\br
  \tcode{struct is_final;}               &
  \tcode{T} is a class type marked with the \grammarterm{class-virt-specifier}
@@ -14925,18 +14960,21 @@ notwithstanding the restrictions of~\ref{declval}.
  can be marked with \tcode{final}. \end{note}                                        &
  If \tcode{T} is a class type, \tcode{T} shall be a complete type.                          \\ \rowsep
 
+\indexlibrary{\idxcode{is_signed}!class}%
 \tcode{template <class T>}\br
   \tcode{struct is_signed;}              &
   If \tcode{is_arithmetic_v<T>} is \tcode{true}, the same result as
   \tcode{bool_constant<T(-1) < T(0)>::value};
   otherwise, \tcode{false}   &   \\  \rowsep
 
+\indexlibrary{\idxcode{is_unsigned}}%
 \tcode{template <class T>}\br
   \tcode{struct is_unsigned;}            &
   If \tcode{is_arithmetic_v<T>} is \tcode{true}, the same result as
   \tcode{bool_constant<T(0) < T(-1)>::value};
   otherwise, \tcode{false}   &   \\  \rowsep
 
+\indexlibrary{\idxcode{is_constructible}}%
 \tcode{template <class T, class... Args>}\br
  \tcode{struct is_constructible;}   &
  For a function type \tcode{T},
@@ -14946,12 +14984,14 @@ notwithstanding the restrictions of~\ref{declval}.
  shall be complete types, (possibly cv-qualified) \tcode{void},
  or arrays of unknown bound.  \\ \rowsep
 
+\indexlibrary{\idxcode{is_default_constructible}}%
 \tcode{template <class T>}\br
   \tcode{struct is_default_constructible;} &
   \tcode{is_constructible_v<T>} is \tcode{true}. &
   \tcode{T} shall be a complete type, (possibly cv-qualified) \tcode{void},
   or an array of unknown bound. \\ \rowsep
 
+\indexlibrary{\idxcode{is_copy_constructible}}%
 \tcode{template <class T>}\br
   \tcode{struct is_copy_constructible;} &
   For a referenceable type \tcode{T}, the same result as
@@ -14959,6 +14999,7 @@ notwithstanding the restrictions of~\ref{declval}.
   \tcode{T} shall be a complete type, (possibly cv-qualified) \tcode{void},
   or an array of unknown bound. \\ \rowsep
 
+\indexlibrary{\idxcode{is_move_constructible}}%
 \tcode{template <class T>}\br
   \tcode{struct is_move_constructible;} &
   For a referenceable type \tcode{T}, the same result as
@@ -14966,6 +15007,7 @@ notwithstanding the restrictions of~\ref{declval}.
   \tcode{T} shall be a complete type, (possibly cv-qualified) \tcode{void},
   or an array of unknown bound. \\ \rowsep
 
+\indexlibrary{\idxcode{is_assignable}}%
 \tcode{template <class T, class U>}\br
   \tcode{struct is_assignable;} &
   The expression \tcode{declval<T>() =} \tcode{declval<U>()} is well-formed
@@ -14980,6 +15022,7 @@ notwithstanding the restrictions of~\ref{declval}.
   \tcode{T} and \tcode{U} shall be complete types, (possibly cv-qualified) \tcode{void},
   or arrays of unknown bound. \\ \rowsep
 
+\indexlibrary{\idxcode{is_copy_assignable}}%
 \tcode{template <class T>}\br
   \tcode{struct is_copy_assignable;} &
   For a referenceable type \tcode{T}, the same result as
@@ -14987,6 +15030,7 @@ notwithstanding the restrictions of~\ref{declval}.
   \tcode{T} shall be a complete type, (possibly cv-qualified) \tcode{void},
   or an array of unknown bound. \\ \rowsep
 
+\indexlibrary{\idxcode{is_move_assignable}}%
 \tcode{template <class T>}\br
   \tcode{struct is_move_assignable;} &
   For a referenceable type \tcode{T}, the same result as
@@ -14994,6 +15038,7 @@ notwithstanding the restrictions of~\ref{declval}.
   \tcode{T} shall be a complete type, (possibly cv-qualified) \tcode{void},
   or an array of unknown bound. \\ \rowsep
 
+\indexlibrary{\idxcode{is_swappable_with}}%
 \tcode{template <class T, class U>}\br
   \tcode{struct is_swappable_with;} &
   The expressions \tcode{swap(declval<T>(), declval<U>())} and
@@ -15017,6 +15062,7 @@ notwithstanding the restrictions of~\ref{declval}.
   (possibly cv-qualified) \tcode{void}, or
   arrays of unknown bound.  \\ \rowsep
 
+\indexlibrary{\idxcode{is_swappable}}%
 \tcode{template <class T>}\br
   \tcode{struct is_swappable;} &
   For a referenceable type \tcode{T},
@@ -15026,6 +15072,7 @@ notwithstanding the restrictions of~\ref{declval}.
   (possibly cv-qualified) \tcode{void}, or
   an array of unknown bound. \\ \rowsep
 
+\indexlibrary{\idxcode{is_destructible}}%
 \tcode{template <class T>}\br
   \tcode{struct is_destructible;} &
   For reference types, \tcode{is_destructible<T>::value} is \tcode{true}. \br
@@ -15039,6 +15086,7 @@ notwithstanding the restrictions of~\ref{declval}.
   \tcode{T} shall be a complete type, (possibly cv-qualified) \tcode{void},
   or an array of unknown bound. \\ \rowsep
 
+\indexlibrary{\idxcode{is_trivially_constructible}}%
 \tcode{template <class T, class... Args>}\br
   \tcode{struct}\br
   \tcode{is_trivially_constructible;} &
@@ -15049,6 +15097,7 @@ notwithstanding the restrictions of~\ref{declval}.
   \tcode{T} and all types in the parameter pack \tcode{Args} shall be complete types,
   (possibly cv-qualified) \tcode{void}, or arrays of unknown bound. \\ \rowsep
 
+\indexlibrary{\idxcode{is_trivially_default_constructible}}%
 \tcode{template <class T>}\br
  \tcode{struct is_trivially_default_constructible;} &
  \tcode{is_trivially_constructible_v<T>} is \tcode{true}. &
@@ -15056,6 +15105,7 @@ notwithstanding the restrictions of~\ref{declval}.
  (possibly cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
+\indexlibrary{\idxcode{is_trivially_copy_constructible}}%
 \tcode{template <class T>}\br
  \tcode{struct is_trivially_copy_constructible;}      &
   For a referenceable type \tcode{T}, the same result as
@@ -15064,6 +15114,7 @@ notwithstanding the restrictions of~\ref{declval}.
  (possibly cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
+\indexlibrary{\idxcode{is_trivially_move_constructible}}%
 \tcode{template <class T>}\br
  \tcode{struct is_trivially_move_constructible;}      &
   For a referenceable type \tcode{T}, the same result as
@@ -15072,6 +15123,7 @@ notwithstanding the restrictions of~\ref{declval}.
  (possibly cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
+\indexlibrary{\idxcode{is_trivially_assignable}}%
 \tcode{template <class T, class U>}\br
   \tcode{struct is_trivially_assignable;} &
   \tcode{is_assignable_v<T, U>} is \tcode{true} and the assignment, as defined by
@@ -15080,6 +15132,7 @@ notwithstanding the restrictions of~\ref{declval}.
   \tcode{T} and \tcode{U} shall be complete types, (possibly cv-qualified) \tcode{void},
   or arrays of unknown bound. \\ \rowsep
 
+\indexlibrary{\idxcode{is_trivially_copy_assignable}}%
 \tcode{template <class T>}\br
  \tcode{struct is_trivially_copy_assignable;} &
   For a referenceable type \tcode{T}, the same result as
@@ -15088,6 +15141,7 @@ notwithstanding the restrictions of~\ref{declval}.
  (possibly cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
+\indexlibrary{\idxcode{is_trivially_move_assignable}}%
 \tcode{template <class T>}\br
  \tcode{struct is_trivially_move_assignable;} &
   For a referenceable type \tcode{T}, the same result as
@@ -15095,6 +15149,7 @@ notwithstanding the restrictions of~\ref{declval}.
  \tcode{T} shall be a complete type,
  (possibly cv-qualified) \tcode{void}, or an array of unknown bound.                \\ \rowsep
 
+\indexlibrary{\idxcode{is_trivially_destructible}}%
 \tcode{template <class T>}\br
  \tcode{struct is_trivially_destructible;} &
  \tcode{is_destructible_v<T>} is \tcode{true} and the indicated destructor is known
@@ -15103,6 +15158,7 @@ notwithstanding the restrictions of~\ref{declval}.
  (possibly cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
+\indexlibrary{\idxcode{is_nothrow_constructible}}%
 \tcode{template <class T, class... Args>}\br
  \tcode{struct is_nothrow_constructible;}   &
  \tcode{is_constructible_v<T,} \tcode{ Args...>} is \tcode{true}
@@ -15114,6 +15170,7 @@ notwithstanding the restrictions of~\ref{declval}.
  shall be complete types, (possibly cv-qualified) \tcode{void},
  or arrays of unknown bound.  \\ \rowsep
 
+\indexlibrary{\idxcode{is_nothrow_default_constructible}}%
 \tcode{template <class T>}\br
  \tcode{struct is_nothrow_default_constructible;} &
  \tcode{is_nothrow_constructible_v<T>} is \tcode{true}.  &
@@ -15121,6 +15178,7 @@ notwithstanding the restrictions of~\ref{declval}.
  (possibly cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
+\indexlibrary{\idxcode{is_nothrow_copy_constructible}}%
 \tcode{template <class T>}\br
  \tcode{struct is_nothrow_copy_constructible;}      &
   For a referenceable type \tcode{T}, the same result as
@@ -15129,6 +15187,7 @@ notwithstanding the restrictions of~\ref{declval}.
  (possibly cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
+\indexlibrary{\idxcode{is_nothrow_move_constructible}}%
 \tcode{template <class T>}\br
  \tcode{struct is_nothrow_move_constructible;}      &
   For a referenceable type \tcode{T}, the same result as
@@ -15136,6 +15195,7 @@ notwithstanding the restrictions of~\ref{declval}.
  \tcode{T} shall be a complete type,
  (possibly cv-qualified) \tcode{void}, or an array of unknown bound.                \\ \rowsep
 
+\indexlibrary{\idxcode{is_nothrow_assignable}}%
 \tcode{template <class T, class U>}\br
   \tcode{struct is_nothrow_assignable;} &
   \tcode{is_assignable_v<T, U>} is \tcode{true} and the assignment is known not to
@@ -15143,6 +15203,7 @@ notwithstanding the restrictions of~\ref{declval}.
   \tcode{T} and \tcode{U} shall be complete types, (possibly cv-qualified) \tcode{void},
   or arrays of unknown bound. \\ \rowsep
 
+\indexlibrary{\idxcode{is_nothrow_copy_assignable}}%
 \tcode{template <class T>}\br
  \tcode{struct is_nothrow_copy_assignable;} &
   For a referenceable type \tcode{T}, the same result as
@@ -15151,6 +15212,7 @@ notwithstanding the restrictions of~\ref{declval}.
  (possibly cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
+\indexlibrary{\idxcode{is_nothrow_move_assignable}}%
 \tcode{template <class T>}\br
   \tcode{struct is_nothrow_move_assignable;} &
   For a referenceable type \tcode{T}, the same result as
@@ -15159,6 +15221,7 @@ notwithstanding the restrictions of~\ref{declval}.
  (possibly cv-qualified) \tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
+\indexlibrary{\idxcode{is_nothrow_swappable_with}}%
 \tcode{template <class T, class U>}\br
   \tcode{struct is_nothrow_swappable_with;} &
   \tcode{is_swappable_with_v<T, U>} is \tcode{true} and
@@ -15169,6 +15232,7 @@ notwithstanding the restrictions of~\ref{declval}.
   (possibly cv-qualified) \tcode{void}, or
   arrays of unknown bound. \\ \rowsep
 
+\indexlibrary{\idxcode{is_nothrow_swappable}}%
 \tcode{template <class T>}\br
   \tcode{struct is_nothrow_swappable;} &
   For a referenceable type \tcode{T},
@@ -15178,6 +15242,7 @@ notwithstanding the restrictions of~\ref{declval}.
   (possibly cv-qualified) \tcode{void}, or
   an array of unknown bound. \\ \rowsep
 
+\indexlibrary{\idxcode{is_nothrow_destructible}}%
 \tcode{template <class T>}\br
   \tcode{struct is_nothrow_destructible;} &
   \tcode{is_destructible_v<T>} is \tcode{true} and the indicated destructor is known
@@ -15186,11 +15251,13 @@ notwithstanding the restrictions of~\ref{declval}.
   (possibly cv-qualified) \tcode{void}, or an array of unknown
   bound.                \\ \rowsep
 
+\indexlibrary{\idxcode{has_virtual_destructor}}%
 \tcode{template <class T>}\br
  \tcode{struct has_virtual_destructor;} &
  \tcode{T} has a virtual destructor~(\ref{class.dtor}) &
  If \tcode{T} is a non-union class type, \tcode{T} shall be a complete type.                \\ \rowsep
 
+\indexlibrary{\idxcode{has_unique_object_representations}}%
 \tcode{template <class T>}\br
   \tcode{struct has_unique_object_representations;} &
   For an array type \tcode{T}, the same result as
@@ -15238,6 +15305,7 @@ static_assert( is_final_v<U2>, "Error!");
 \end{codeblock}
 \end{example}
 
+\indexlibrary{\idxcode{is_constructible}}%
 \pnum
 The predicate condition for a template specialization
 \tcode{is_constructible<T, Args...>} shall be satisfied if and only if the
@@ -15256,6 +15324,7 @@ template specializations and function template specializations, the generation
 of implicitly-defined functions, and so on. Such side effects are not in the
 ``immediate context'' and can result in the program being ill-formed. \end{note}
 
+\indexlibrary{\idxcode{has_unique_object_representations}}%
 \pnum
 The predicate condition for a template specialization
 \tcode{has_unique_object_representations<T>::value}
@@ -15289,17 +15358,20 @@ properties of types at compile time.
 \lhdr{Template} &   \rhdr{Value}    \\ \capsep
 \endhead
 
+\indexlibrary{\idxcode{alignment_of}}%
 \tcode{template <class T>\br
  struct alignment_of;}      &
  \tcode{alignof(T)}.\br
  \precondition{}
  \tcode{alignof(T)} shall be a valid expression~(\ref{expr.alignof})  \\  \rowsep
 
+\indexlibrary{\idxcode{rank}}%
 \tcode{template <class T>\br
  struct rank;}      &
  If \tcode{T} names an array type, an integer value representing
  the number of dimensions of \tcode{T}; otherwise, 0. \\    \rowsep
 
+\indexlibrary{\idxcode{extent}}%
 \tcode{template <class T,\br
  unsigned I = 0>\br
  struct extent;}        &
@@ -15364,6 +15436,7 @@ with a BaseCharacteristic of
  \tcode{struct is_same;}                    &
  \tcode{T} and \tcode{U} name the same type with the same cv-qualifications                            &   \\ \rowsep
 
+\indexlibrary{\idxcode{is_base_of}}%
 \tcode{template <class Base, class Derived>}\br
  \tcode{struct is_base_of;}                 &
  \tcode{Base} is a base class of \tcode{Derived} (Clause~\ref{class.derived})
@@ -15379,6 +15452,7 @@ with a BaseCharacteristic of
  \begin{note} Base classes that are private, protected, or ambiguous
  are, nonetheless, base classes. \end{note} \\ \rowsep
 
+\indexlibrary{\idxcode{is_convertible}}%
 \tcode{template <class From, class To>}\br
  \tcode{struct is_convertible;}             &
  \seebelow                                  &
@@ -15386,6 +15460,7 @@ with a BaseCharacteristic of
  types, arrays of unknown
  bound, or (possibly cv-qualified) \tcode{void} types.                \\ \rowsep
 
+\indexlibrary{\idxcode{is_callable}}%
 \tcode{template <class Fn, class... ArgTypes, class R>}\br
  \tcode{struct is_callable<}\br
  \tcode{Fn(ArgTypes...), R>;}                      &
@@ -15395,6 +15470,7 @@ with a BaseCharacteristic of
  shall be complete types, (possibly cv-qualified) \tcode{void}, or
  arrays of unknown bound.                                             \\ \rowsep
 
+\indexlibrary{\idxcode{is_nothrow_callable}}%
 \tcode{template <class Fn, class... ArgTypes, class R>}\br
  \tcode{struct is_nothrow_callable<}\br
  \tcode{Fn(ArgTypes...), R>;}              &
@@ -15433,6 +15509,7 @@ is_base_of_v<int, int>     // false
 \end{codeblock}
 \end{example}
 
+\indexlibrary{\idxcode{is_convertible}}%
 \pnum
 The predicate condition for a template specialization \tcode{is_convertible<From, To>}
 shall be satisfied if and only if the return expression in the following code would be
@@ -15474,6 +15551,8 @@ Each of the templates in this subclause shall be a
 \topline
 \lhdr{Template} &   \rhdr{Comments} \\ \capsep
 \endhead
+
+\indexlibrary{\idxcode{remove_const}}%
 \tcode{template <class T>\br
  struct remove_const;}                  &
  The member typedef \tcode{type} shall name
@@ -15482,6 +15561,8 @@ Each of the templates in this subclause shall be a
  \begin{example} \tcode{remove_const_t<const volatile int>} evaluates
  to \tcode{volatile int}, whereas \tcode{remove_const_t<const int*>} evaluates to
  \tcode{const int*}. \end{example}                          \\  \rowsep
+
+\indexlibrary{\idxcode{remove_volatile}}%
 \tcode{template <class T>\br
  struct remove_volatile;}               &
  The member typedef \tcode{type} shall name
@@ -15491,6 +15572,8 @@ Each of the templates in this subclause shall be a
  evaluates to \tcode{const int},
  whereas \tcode{remove_volatile_t<volatile int*>} evaluates to \tcode{volatile int*}.
  \end{example}                                              \\  \rowsep
+
+\indexlibrary{\idxcode{remove_cv}}%
 \tcode{template <class T>\br
  struct remove_cv;}                 &
  The member typedef \tcode{type} shall be the same as \tcode{T}
@@ -15498,18 +15581,24 @@ Each of the templates in this subclause shall be a
  \begin{example} \tcode{remove_cv_t<const volatile int>}
  evaluates to \tcode{int}, whereas \tcode{remove_cv_t<const volatile int*>}
  evaluates to \tcode{const volatile int*}. \end{example}  \\  \rowsep
+
+\indexlibrary{\idxcode{add_const}}%
 \tcode{template <class T>\br
  struct add_const;}                 &
  If \tcode{T} is a reference, function, or top-level const-qualified
  type, then \tcode{type} shall name
  the same type as \tcode{T}, otherwise
  \tcode{T const}.                                                           \\  \rowsep
+
+\indexlibrary{\idxcode{add_volatile}}%
 \tcode{template <class T>\br
  struct add_volatile;}                  &
  If \tcode{T} is a reference, function, or top-level volatile-qualified
  type, then \tcode{type} shall name
  the same type as \tcode{T}, otherwise
  \tcode{T volatile}.                                                            \\  \rowsep
+
+\indexlibrary{\idxcode{add_cv}}%
 \tcode{template <class T>\br
  struct add_cv;}                    &
  The member typedef \tcode{type} shall name
@@ -15528,12 +15617,14 @@ Each of the templates in this subclause shall be a
 \lhdr{Template} &   \rhdr{Comments} \\ \capsep
 \endhead
 
+\indexlibrary{\idxcode{remove_reference}}%
 \tcode{template <class T>\br
  struct remove_reference;}                  &
  If \tcode{T} has type ``reference to \tcode{T1}'' then the
  member typedef \tcode{type} shall name \tcode{T1};
  otherwise, \tcode{type} shall name \tcode{T}.\\ \rowsep
 
+\indexlibrary{\idxcode{add_lvalue_reference}}%
 \tcode{template <class T>\br
  struct add_lvalue_reference;}                     &
  If \tcode{T} names a referenceable type then
@@ -15543,6 +15634,7 @@ Each of the templates in this subclause shall be a
  This rule reflects the semantics of reference collapsing~(\ref{dcl.ref}).
  \end{note}\\ \rowsep
 
+\indexlibrary{\idxcode{add_rvalue_reference}}%
 \tcode{template <class T>}\br
  \tcode{struct add_rvalue_reference;}    &
  If \tcode{T} names a referenceable type then
@@ -15563,6 +15655,8 @@ Each of the templates in this subclause shall be a
 \topline
 \lhdr{Template} &   \rhdr{Comments} \\ \capsep
 \endhead
+
+\indexlibrary{\idxcode{make_signed}}%
 \tcode{template <class T>}\br
  \tcode{struct make_signed;} &
  If \tcode{T} names a (possibly cv-qualified) signed integer
@@ -15578,6 +15672,8 @@ Each of the templates in this subclause shall be a
  \requires{} \tcode{T} shall be a (possibly cv-qualified)
  integral type or enumeration
  but not a \tcode{bool} type.\\ \rowsep
+
+\indexlibrary{\idxcode{make_unsigned}}%
 \tcode{template <class T>}\br
  \tcode{struct make_unsigned;} &
  If \tcode{T} names a (possibly cv-qualified) unsigned integer
@@ -15605,6 +15701,8 @@ Each of the templates in this subclause shall be a
 \topline
 \lhdr{Template} &   \rhdr{Comments} \\ \capsep
 \endhead
+
+\indexlibrary{\idxcode{remove_extent}}%
 \tcode{template <class T>\br
  struct remove_extent;}                 &
  If \tcode{T} names a type ``array of \tcode{U}'',
@@ -15613,6 +15711,8 @@ Each of the templates in this subclause shall be a
  \begin{note} For multidimensional arrays, only the first array dimension is
  removed. For a type ``array of \tcode{const U}'', the resulting type is
  \tcode{const U}. \end{note}                                 \\  \rowsep
+
+\indexlibrary{\idxcode{remove_all_extents}}%
 \tcode{template <class T>\br
  struct remove_all_extents;}                &
  If \tcode{T} is ``multi-dimensional array of \tcode{U}'', the resulting member
@@ -15650,11 +15750,15 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
 \topline
 \lhdr{Template} &   \rhdr{Comments} \\ \capsep
 \endhead
+
+\indexlibrary{\idxcode{remove_pointer}}%
 \tcode{template <class T>\br
  struct remove_pointer;}                    &
  If \tcode{T} has type ``(possibly cv-qualified) pointer
  to \tcode{T1}'' then the member typedef \tcode{type}
  shall name \tcode{T1}; otherwise, it shall name \tcode{T}.\\ \rowsep
+
+\indexlibrary{\idxcode{add_pointer}}%
 \tcode{template <class T>\br
  struct add_pointer;}                       &
  If \tcode{T} names a referenceable type or a
@@ -15676,6 +15780,7 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
 \lhdr{Template}   &   \rhdr{Comments} \\ \capsep
 \endhead
 
+\indexlibrary{\idxcode{aligned_storage}}%
 \tcode{template <size_t Len,\br
  size_t Align\br
  = \textit{default-alignment}>\br
@@ -15690,6 +15795,7 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
  \requires{} \tcode{Len} shall not be zero. \tcode{Align} shall be equal to
  \tcode{alignof(T)} for some type \tcode{T} or to \textit{default-alignment}.\\ \rowsep
 
+\indexlibrary{\idxcode{aligned_union}}%
 \tcode{template <size_t Len,\br
   class... Types>\br
   struct aligned_union;}
@@ -15702,6 +15808,7 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
  \requires{} At least one type is provided.
   \\ \rowsep
 
+\indexlibrary{\idxcode{decay}}%
 \tcode{template <class T>\br struct decay;}
  &
  Let \tcode{U} be \tcode{remove_reference_t<T>}. If \tcode{is_array_v<U>} is
@@ -15716,6 +15823,7 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
  argument passing. \end{note}
  \\ \rowsep
 
+\indexlibrary{\idxcode{enable_if}}%
 \tcode{template <bool B, class T = void>} \tcode{struct enable_if;}
  &
  If \tcode{B} is \tcode{true}, the member typedef \tcode{type}
@@ -15739,6 +15847,7 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
  needed when only explicit conversions are desired among the template arguments.
  \end{note} \\ \rowsep
 
+\indexlibrary{\idxcode{underlying_type}}%
 \tcode{template <class T>}\br
  \tcode{struct underlying_type;}
  &
@@ -15771,6 +15880,7 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
  unknown bound.\\
 \end{libreqtab2a}
 
+\indexlibrary{\idxcode{aligned_storage}}%
 \pnum
 \begin{note} A typical implementation would define \tcode{aligned_storage} as:
 
@@ -15788,6 +15898,7 @@ struct aligned_storage {
 It is \impldef{support for extended alignment} whether any extended alignment is
 supported~(\ref{basic.align}).
 
+\indexlibrary{\idxcode{common_type}}%
 \pnum
 For the \tcode{common_type} trait applied to a parameter pack \tcode{T} of types,
 the member \tcode{type} shall be either defined or not present as follows:


### PR DESCRIPTION
Create an index entry for each row in the type traits tables,
indexing the corresping trait.  Where a trait is defined outside
the table, add a second index reference to the latter.  This
causes an annoying duplication, as the current software sees the
index entry inside the table as in some way NOT the same as the
entry outside the table.

Disambiguate the is_empty function from the filesystem library,
and the is_empty trait.  The issue for is_signed being a trait
and a member of numberic_limits resolves itself.

This is intended to resolve https://github.com/cplusplus/draft/issues/905