### PR TITLE
[stmt.return] Change 'void' to 'cv void'

### DIFF
--- a/source/statements.tex
+++ b/source/statements.tex
@@ -810,7 +810,7 @@ no operand shall be used only in a function whose return type is
 destructor~(\ref{class.dtor}).
 \indextext{\idxcode{return}!constructor~and}%
 \indextext{\idxcode{return}!constructor~and}%
-A return statement with an operand of type \tcode{void} shall be used only
+A return statement with an operand of type \cv\ \tcode{void} shall be used only
 in a function whose return type is \cv\ \tcode{void}.
 A return statement with any other operand shall be used only
 in a function whose return type is not \cv\ \tcode{void};


### PR DESCRIPTION
Using "cv void" here is consistent with 3.9.1p9.

It's not clear to me whether the _cv_ of the expression and the _cv_ of the function are independent meta variables or whether they should match, both in 3.9.1p9 and 6.6.3p2. Can a function with any _cv_-qualified `void` return type return a `void` with a different _cv_-qualifier?

```
const volatile void fcv() {}
void f() { return fcv(); }
```

A note about formatting: basic.tex uses `\term{cv}` but statements.tex uses `\cv`. There are also instances of `\cvqual{cv}` in other files.
