### PR TITLE
[dcl.type.simple] consistent indexing of type specifiers

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1133,8 +1133,8 @@ and
 \rSec3[dcl.type.cv]{The \grammarterm{cv-qualifiers}}%
 \indextext{specifier!cv-qualifier}%
 \indextext{initialization!\idxcode{const}}%
-\indextext{type specifier!\idxcode{const}}%
-\indextext{type specifier!\idxcode{volatile}}
+\indextext{type~specifier!\idxcode{const}}%
+\indextext{type~specifier!\idxcode{volatile}}
 
 \pnum
 There are two \grammarterm{cv-qualifiers}, \tcode{const} and
@@ -1239,7 +1239,7 @@ they are in C.
 \end{note}
 
 \rSec3[dcl.type.simple]{Simple type specifiers}%
-\indextext{type specifier!simple}
+\indextext{type~specifier!simple}
 
 \pnum
 The simple type specifiers are
@@ -1284,8 +1284,8 @@ The simple type specifiers are
 \indextext{type~specifier!\idxcode{char}}%
 \indextext{type~specifier!\idxcode{char16_t}}%
 \indextext{type~specifier!\idxcode{char32_t}}%
-\indextext{type-specifier!\idxcode{wchar_t}}%
-\indextext{type-specifier!\idxcode{bool}}%
+\indextext{type~specifier!\idxcode{wchar_t}}%
+\indextext{type~specifier!\idxcode{bool}}%
 \indextext{type~specifier!\idxcode{short}}%
 \indextext{type~specifier!\idxcode{int}}%
 \indextext{type~specifier!\idxcode{long}}%
@@ -1476,7 +1476,7 @@ void r() {
 \end{example}
 
 \rSec3[dcl.type.elab]{Elaborated type specifiers}%
-\indextext{type specifier!elaborated}%
+\indextext{type~specifier!elaborated}%
 \indextext{\idxcode{typename}}%
 \indextext{type~specifier!\idxcode{enum}}
 
@@ -1560,7 +1560,7 @@ enum E x = E::a;                // OK
 \end{example}
 
 \rSec3[dcl.spec.auto]{The \tcode{auto} specifier}%
-\indextext{type specifier!\idxcode{auto}}
+\indextext{type~specifier!\idxcode{auto}}
 
 \pnum
 The \tcode{auto} and \tcode{decltype(auto)} \grammarterm{type-specifier}{s}


### PR DESCRIPTION
The main index for type specifiers was split in two, due to
alternate spellings as 'type specifier' and 'type~specifier'.
Consistently use the latter, as it was the dominant form.