### PR TITLE
[diff.cpp14.special] Clarify example comment

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1606,9 +1606,9 @@ struct B : A {
   using A::A;
   B(int);
 };
-B b(42L); // now calls \tcode{B(int)}, used to call \tcode{B<long>(long)},
-          // which called \tcode{A(int)} due to substitution failure
-          // in \tcode{A<long>(long)}.
+B b(42L); // due to substitution failure in \tcode{A<long>(long)}, now
+          // calls \tcode{B(int)}, used to call \tcode{B<long>(long)},
+          // which called \tcode{A(int)}.
 \end{codeblock}
 
 \rSec2[diff.cpp14.temp]{Clause \ref{temp}: templates}


### PR DESCRIPTION
The comment describing the reason for the new behavior was subject to
misinterpretation; a reader may have thought that the substition
failure was the cause of A(int) being called, which is not the case.
This patch reorders the clauses of the sentence so that they follow
a logical cause-and-effect order.
