### PR TITLE
[basic.link] consistent indexing of 'translation unit'

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -78,7 +78,7 @@ the same literal suffix identifier.
 \end{itemize}
 
 \pnum
-\indextext{translation~unit!name~and}%
+\indextext{translation unit!name and}%
 \indextext{linkage}%
 A name used in more than one translation unit can potentially
 refer to the same entity in these translation units depending on the
@@ -2234,8 +2234,8 @@ only namespace names are considered.%
 
 \pnum
 \indextext{program}%
-A \defn{program} consists of one or more \defn{translation
-units} (Clause~\ref{lex}) linked together. A translation unit consists
+A \defn{program} consists of one or more \defn{translation units}
+(Clause~\ref{lex}) linked together. A translation unit consists
 of a sequence of declarations.
 
 \begin{bnf}
@@ -2245,7 +2245,7 @@ of a sequence of declarations.
 
 \pnum
 \indextext{linkage}%
-\indextext{translation~unit}%
+\indextext{translation unit}%
 \indextext{linkage!internal}%
 \indextext{linkage!external}%
 A name is said to have \defn{linkage} when it might denote the same

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2234,7 +2234,7 @@ only namespace names are considered.%
 
 \pnum
 \indextext{program}%
-A \defn{program} consists of one or more \defn{translation units}
+A \defn{program} consists of one or more \defnx{translation units}{translation unit}
 (Clause~\ref{lex}) linked together. A translation unit consists
 of a sequence of declarations.
 


### PR DESCRIPTION
Ensure all definitions of 'translation unit' sort together
in the index, with a common spelling of the white-space.
