### PR TITLE
[lex.literal] consistent indexing of prefix and suffix

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -876,6 +876,11 @@ ISO C. }
 \indextext{literal!decimal}%
 \indextext{literal!hexadecimal}%
 \indextext{literal!base~of integer}%
+\indextext{prefix!\idxcode{0}}%
+\indextext{prefix!\idxcode{0B}}%
+\indextext{prefix!\idxcode{0X}}%
+\indextext{prefix!\idxcode{0b}}%
+\indextext{prefix!\idxcode{0x}}%
 An \term{integer literal} is a sequence of digits that has no period
 or exponent part, with optional separating single quotes that are ignored
 when determining its value. An integer literal may have a prefix that specifies
@@ -903,11 +908,12 @@ ten through fifteen.
 \pnum
 \indextext{literal!\idxcode{long}}%
 \indextext{literal!\idxcode{unsigned}}%
+\indextext{literal!integer}%
+\indextext{literal!type~of integer}%
 \indextext{suffix!\idxcode{L}}%
 \indextext{suffix!\idxcode{U}}%
 \indextext{suffix!\idxcode{l}}%
 \indextext{suffix!\idxcode{u}}%
-\indextext{literal!type~of integer}%
 The type of an integer literal is the first of the corresponding list
 in Table~\ref{tab:lex.type.integer.literal} in which its value can be
 represented.
@@ -1058,6 +1064,7 @@ respectively.
 
 \pnum
 \indextext{literal!type~of character}%
+\indextext{literal!character!ordinary}%
 A character literal that does not begin with
 \tcode{u8}, \tcode{u}, \tcode{U}, or \tcode{L}
 is an \defn{ordinary character literal}.
@@ -1076,8 +1083,10 @@ character set, is conditionally-supported, has type \tcode{int},
 and has an \impldef{value of multicharacter literal} value.
  
 \pnum
-A character literal that begins with \tcode{u8},
-such as \tcode{u8'w'},
+\indextext{literal!character!UTF-8}%
+A character literal that
+begins with \tcode{u8}, such as \tcode{u8'w'},
+\indextext{prefix!\idxcode{u8}}%
 is a character literal of type \tcode{char},
 known as a \defn{UTF-8 character literal}.
 The value of a UTF-8 character literal
@@ -1090,10 +1099,13 @@ the program is ill-formed.
 A UTF-8 character literal containing multiple \grammarterm{c-char}{s} is ill-formed.
 
 \pnum
+\indextext{literal!character!\tcode{char16_t}}%
 \indextext{char16_t character@\tcode{char16_t} character}%
 \indextext{\idxcode{char16_t}}%
-A character literal that begins with the letter \tcode{u}, such as
-\tcode{u'x'}, is a character literal of type \tcode{char16_t}. The value
+A character literal that
+begins with the letter \tcode{u}, such as \tcode{u'x'},
+\indextext{prefix!\idxcode{u}}%
+is a character literal of type \tcode{char16_t}. The value
 of a \tcode{char16_t} literal containing a single \grammarterm{c-char} is
 equal to its ISO 10646 code point value, provided that the code point is
 representable with a single 16-bit code unit. (That is, provided it is a
@@ -1102,23 +1114,26 @@ within 16 bits, the program is ill-formed. A \tcode{char16_t} literal
 containing multiple \grammarterm{c-char}{s} is ill-formed.
 
 \pnum
+\indextext{literal!character!\tcode{char32_t}}%
 \indextext{char32_t character@\tcode{char32_t} character}%
 \indextext{\idxcode{char32_t}}%
-A character
-literal that begins with the letter \tcode{U}, such as \tcode{U'y'}, is
-a character literal of type \tcode{char32_t}. The value of a
+A character literal that
+begins with the letter \tcode{U}, such as \tcode{U'y'},
+\indextext{prefix!\idxcode{U}}%
+is a character literal of type \tcode{char32_t}. The value of a
 \tcode{char32_t} literal containing a single \grammarterm{c-char} is equal
 to its ISO 10646 code point value. A \tcode{char32_t} literal containing
 multiple \grammarterm{c-char}{s} is ill-formed.
 
 \pnum
+\indextext{literal!character!wide}%
 \indextext{wide-character}%
 \indextext{\idxhdr{stddef.h}}%
 \indextext{\idxcode{wchar_t}}%
 A character literal that
 begins with the letter \tcode{L}, such as \tcode{L'z'},
 \indextext{prefix!\idxcode{L}}%
-is a wide-character literal. A wide-character literal has type
+is a \defn{wide-character literal}. A wide-character literal has type
 \tcode{wchar_t}.\footnote{They are intended for character sets where a character does
 not fit into a single byte. }
 The value of a wide-character literal containing a single
@@ -1419,7 +1434,9 @@ respectively.
 
 \pnum
 \indextext{literal!string!raw}%
-A \grammarterm{string-literal} that has an \tcode{R} in the prefix is a \defn{raw string literal}. The
+A \grammarterm{string-literal} that has an \tcode{R}
+\indextext{prefix!\idxcode{R}}%
+in the prefix is a \defn{raw string literal}. The
 \grammarterm{d-char-sequence} serves as a delimiter. The terminating
 \grammarterm{d-char-sequence} of a \grammarterm{raw-string} is the same sequence of
 characters as the initial \grammarterm{d-char-sequence}. A \grammarterm{d-char-sequence}
@@ -1472,10 +1489,14 @@ is equivalent to \tcode{"\textbackslash n)\textbackslash?\textbackslash?=\textba
 \pnum
 \indextext{string!type~of}%
 \indextext{literal!string!narrow}%
-After translation phase 6, a \grammarterm{string-literal} that does not begin with an \grammarterm{encoding-prefix} is an ordinary string literal, and is initialized with the given characters.
+After translation phase 6, a \grammarterm{string-literal} that does not begin with an \grammarterm{encoding-prefix} is an
+\defn{ordinary string literal}, and is initialized with the given characters.
 
 \pnum
-A \grammarterm{string-literal} that begins with \tcode{u8}, such as \tcode{u8"asdf"}, is a UTF-8 string literal.
+\indextext{literal!string!UTF-8}%
+A \grammarterm{string-literal} that begins with \tcode{u8},
+\indextext{prefix!\idxcode{u8}}%
+such as \tcode{u8"asdf"}, is a \defn{UTF-8 string literal}.
 
 \pnum
 Ordinary string literals and UTF-8 string literals are
@@ -1493,7 +1514,9 @@ code unit of the UTF-8 encoding of the string.
 
 \pnum
 \indextext{literal!string!\idxcode{char16_t}}%
-A \grammarterm{string-literal} that begins with \tcode{u}, such as \tcode{u"asdf"}, is
+A \grammarterm{string-literal} that begins with \tcode{u},
+\indextext{prefix!\idxcode{u}}%
+such as \tcode{u"asdf"}, is
 a \tcode{char16_t} string literal. A \tcode{char16_t} string literal has
 type ``array of \term{n} \tcode{const char16_t}'', where \term{n} is the
 size of the string as defined below; it
@@ -1503,7 +1526,9 @@ surrogate pairs.
 
 \pnum
 \indextext{literal!string!\idxcode{char32_t}}%
-A \grammarterm{string-literal} that begins with \tcode{U}, such as \tcode{U"asdf"}, is
+A \grammarterm{string-literal} that begins with \tcode{U},
+\indextext{prefix!\idxcode{U}}%
+such as \tcode{U"asdf"}, is
 a \tcode{char32_t} string literal. A \tcode{char32_t} string literal has
 type ``array of \term{n} \tcode{const char32_t}'', where \term{n} is the
 size of the string as defined below; it
@@ -1511,10 +1536,9 @@ is initialized with the given characters.
 
 \pnum
 \indextext{literal!string!wide}%
-A \grammarterm{string-literal} that begins with
-\tcode{L},
-such as \tcode{L"asdf"},
-is a wide string literal.
+A \grammarterm{string-literal} that begins with \tcode{L},
+\indextext{prefix!\idxcode{L}}%
+such as \tcode{L"asdf"}, is a \defn{wide string literal}.
 \indextext{\idxhdr{stddef.h}}%
 \indextext{\idxcode{wchar_t}}%
 \indextext{literal!string!wide}%

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -876,11 +876,6 @@ ISO C. }
 \indextext{literal!decimal}%
 \indextext{literal!hexadecimal}%
 \indextext{literal!base~of integer}%
-\indextext{prefix!\idxcode{0}}%
-\indextext{prefix!\idxcode{0B}}%
-\indextext{prefix!\idxcode{0X}}%
-\indextext{prefix!\idxcode{0b}}%
-\indextext{prefix!\idxcode{0x}}%
 An \term{integer literal} is a sequence of digits that has no period
 or exponent part, with optional separating single quotes that are ignored
 when determining its value. An integer literal may have a prefix that specifies


### PR DESCRIPTION
Provide a consistent indexing of integer, character, and string
literals - particularly regarding prefix and suffix entries that
were not completely indexed before.
