### PR TITLE
[index] consistent indexing of name hiding

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2965,7 +2965,7 @@ void h() {
 \end{note}
 
 \pnum
-\indextext{name hiding!using-declaration and}%
+\indextext{name~hiding!using-declaration and}%
 When a \grammarterm{using-declaration} brings declarations from a base class into
 a derived class, member functions and member function templates in
 the derived class override and/or hide member functions and member

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -327,8 +327,8 @@ struct D : B {
 };
 \end{codeblock}
 
-\indextext{name hiding!function}%
-\indextext{name hiding!overloading versus}%
+\indextext{name~hiding!function}%
+\indextext{name~hiding!overloading versus}%
 Here
 \tcode{D::f(const char*)}
 hides


### PR DESCRIPTION
Ensure all index references to name hiding use the same whitespace character.