### PR TITLE
[time.duration.nonmember] Add missing \tcode

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -17215,7 +17215,7 @@ template <class Rep1, class Period1, class Rep2, class Period2>
 
 \begin{itemdescr}
 \pnum
-\returns CD(CD(lhs).count() - CD(rhs).count()).
+\returns \tcode{CD(CD(lhs).count() - CD(rhs).count())}.
 \end{itemdescr}
 
 \indexlibrarymember{operator*}{duration}%
@@ -17231,7 +17231,7 @@ template <class Rep1, class Period, class Rep2>
 resolution unless \tcode{Rep2} is implicitly convertible to \tcode{CR(Rep1, Rep2)}.
 
 \pnum
-\returns CD(CD(d).count() * s).
+\returns \tcode{CD(CD(d).count() * s)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator*}{duration}%
@@ -17264,7 +17264,7 @@ resolution unless \tcode{Rep2} is implicitly convertible to \tcode{CR(Rep1, Rep2
 and \tcode{Rep2} is not a specialization of \tcode{duration}.
 
 \pnum
-\returns CD(CD(d).count() / s).
+\returns \tcode{CD(CD(d).count() / s)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator/}{duration}%
@@ -17293,7 +17293,7 @@ resolution unless \tcode{Rep2} is implicitly convertible to \tcode{CR(Rep1, Rep2
 \tcode{Rep2} is not a specialization of \tcode{duration}.
 
 \pnum
-\returns CD(CD(d).count() \% s).
+\returns \tcode{CD(CD(d).count() \% s)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator\%}{duration}%
@@ -17305,7 +17305,7 @@ template <class Rep1, class Period1, class Rep2, class Period2>
 
 \begin{itemdescr}
 \pnum
-\returns CD(CD(lhs).count() \% CD(rhs).count()).
+\returns \tcode{CD(CD(lhs).count() \% CD(rhs).count())}.
 \end{itemdescr}
 
 


### PR DESCRIPTION
Addresses parts of issue #916.