### PR TITLE
NB US-91 (C++17 CD): [algorithm][numeric] Specify all parallel algorithms

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -50,12 +50,12 @@ namespace std {
   template<class InputIterator, class Function>
     Function for_each(InputIterator first, InputIterator last, Function f);
   template<class ExecutionPolicy, class InputIterator, class Function>
-    void for_each(ExecutionPolicy&& exec,
+    void for_each(ExecutionPolicy&& exec, // see \ref{algorithms.parallel.overloads}
                   InputIterator first, InputIterator last, Function f);
   template<class InputIterator, class Size, class Function>
     InputIterator for_each_n(InputIterator first, Size n, Function f);
   template<class ExecutionPolicy, class InputIterator, class Size, class Function>
-    InputIterator for_each_n(ExecutionPolicy&& exec,
+    InputIterator for_each_n(ExecutionPolicy&& exec, // see \ref{algorithms.parallel.overloads}
                              InputIterator first, Size n, Function f);
 
   template<class InputIterator, class T>
@@ -1438,6 +1438,9 @@ Parallel algorithms shall not participate in overload resolution unless
 \begin{itemdecl}
 template <class InputIterator, class Predicate>
   bool all_of(InputIterator first, InputIterator last, Predicate pred);
+template <class ExecutionPolicy, class InputIterator, class Predicate>
+  bool all_of(ExecutionPolicy&& exec, InputIterator first, InputIterator last,
+              Predicate pred);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1456,6 +1459,9 @@ template <class InputIterator, class Predicate>
 \begin{itemdecl}
 template <class InputIterator, class Predicate>
   bool any_of(InputIterator first, InputIterator last, Predicate pred);
+template <class ExecutionPolicy, class InputIterator, class Predicate>
+  bool any_of(ExecutionPolicy&& exec, InputIterator first, InputIterator last,
+              Predicate pred);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1474,6 +1480,9 @@ if there is no iterator \tcode{i} in the range
 \begin{itemdecl}
 template <class InputIterator, class Predicate>
   bool none_of(InputIterator first, InputIterator last, Predicate pred);
+template <class ExecutionPolicy, class InputIterator, class Predicate>
+  bool none_of(ExecutionPolicy&& exec, InputIterator first, InputIterator last,
+               Predicate pred);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1643,12 +1652,22 @@ If \tcode{f} returns a result, the result is ignored.
 template<class InputIterator, class T>
   InputIterator find(InputIterator first, InputIterator last,
                      const T& value);
+template<class ExecutionPolicy, class InputIterator, class T>
+  InputIterator find(ExecutionPolicy&& exec, InputIterator first, InputIterator last,
+                     const T& value);
 
 template<class InputIterator, class Predicate>
   InputIterator find_if(InputIterator first, InputIterator last,
                         Predicate pred);
+template<class ExecutionPolicy, class InputIterator, class Predicate>
+  InputIterator find_if(ExecutionPolicy&& exec, InputIterator first, InputIterator last,
+                        Predicate pred);
+
 template<class InputIterator, class Predicate>
   InputIterator find_if_not(InputIterator first, InputIterator last,
+                            Predicate pred);
+template<class ExecutionPolicy, class InputIterator, class Predicate>
+  InputIterator find_if_not(ExecutionPolicy&& exec, InputIterator first, InputIterator last,
                             Predicate pred);
 \end{itemdecl}
 
@@ -1679,11 +1698,23 @@ template<class ForwardIterator1, class ForwardIterator2>
   ForwardIterator1
     find_end(ForwardIterator1 first1, ForwardIterator1 last1,
              ForwardIterator2 first2, ForwardIterator2 last2);
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
+  ForwardIterator1
+    find_end(ExecutionPolicy&& exec,
+             ForwardIterator1 first1, ForwardIterator1 last1,
+             ForwardIterator2 first2, ForwardIterator2 last2);
 
 template<class ForwardIterator1, class ForwardIterator2,
          class BinaryPredicate>
   ForwardIterator1
     find_end(ForwardIterator1 first1, ForwardIterator1 last1,
+             ForwardIterator2 first2, ForwardIterator2 last2,
+             BinaryPredicate pred);
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2,
+         class BinaryPredicate>
+  ForwardIterator1
+    find_end(ExecutionPolicy&& exec,
+             ForwardIterator1 first1, ForwardIterator1 last1,
              ForwardIterator2 first2, ForwardIterator2 last2,
              BinaryPredicate pred);
 \end{itemdecl}
@@ -1722,11 +1753,23 @@ template<class InputIterator, class ForwardIterator>
   InputIterator
     find_first_of(InputIterator first1, InputIterator last1,
                   ForwardIterator first2, ForwardIterator last2);
+template<class ExecutionPolicy, class InputIterator, class ForwardIterator>
+  InputIterator
+    find_first_of(ExecutionPolicy&& exec,
+                  InputIterator first1, InputIterator last1,
+                  ForwardIterator first2, ForwardIterator last2);
 
 template<class InputIterator, class ForwardIterator,
           class BinaryPredicate>
   InputIterator
     find_first_of(InputIterator first1, InputIterator last1,
+                  ForwardIterator first2, ForwardIterator last2,
+                  BinaryPredicate pred);
+template<class ExecutionPolicy, class InputIterator, class ForwardIterator,
+         class BinaryPredicate>
+  InputIterator
+    find_first_of(ExecutionPolicy&& exec,
+                  InputIterator first1, InputIterator last1,
                   ForwardIterator first2, ForwardIterator last2,
                   BinaryPredicate pred);
 \end{itemdecl}
@@ -1764,10 +1807,17 @@ applications of the corresponding predicate.
 \begin{itemdecl}
 template<class ForwardIterator>
   ForwardIterator adjacent_find(ForwardIterator first, ForwardIterator last);
+template<class ExecutionPolicy, class ForwardIterator>
+  ForwardIterator adjacent_find(ExecutionPolicy&& exec,
+                                ForwardIterator first, ForwardIterator last);
 
 template<class ForwardIterator, class BinaryPredicate>
   ForwardIterator adjacent_find(ForwardIterator first, ForwardIterator last,
-                              BinaryPredicate pred);
+                                BinaryPredicate pred);
+template<class ExecutionPolicy, class ForwardIterator, class BinaryPredicate>
+  ForwardIterator adjacent_find(ExecutionPolicy&& exec,
+                                ForwardIterator first, ForwardIterator last,
+                                BinaryPredicate pred);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1803,12 +1853,18 @@ return value.
 \indexlibrary{\idxcode{count_if}}%
 \begin{itemdecl}
 template<class InputIterator, class T>
-    typename iterator_traits<InputIterator>::difference_type
-       count(InputIterator first, InputIterator last, const T& value);
+  typename iterator_traits<InputIterator>::difference_type
+     count(InputIterator first, InputIterator last, const T& value);
+template<class ExecutionPolicy, class InputIterator, class T>
+  typename iterator_traits<InputIterator>::difference_type
+    count(ExecutionPolicy&& exec, InputIterator first, InputIterator last, const T& value);
 
 template<class InputIterator, class Predicate>
-    typename iterator_traits<InputIterator>::difference_type
-      count_if(InputIterator first, InputIterator last, Predicate pred);
+  typename iterator_traits<InputIterator>::difference_type
+    count_if(InputIterator first, InputIterator last, Predicate pred);
+template<class ExecutionPolicy, class InputIterator, class Predicate>
+  typename iterator_traits<InputIterator>::difference_type
+    count_if(ExecutionPolicy&& exec, InputIterator first, InputIterator last, Predicate pred);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1836,22 +1892,45 @@ template<class InputIterator1, class InputIterator2>
   pair<InputIterator1, InputIterator2>
       mismatch(InputIterator1 first1, InputIterator1 last1,
                InputIterator2 first2);
+template<class ExecutionPolicy, class InputIterator1, class InputIterator2>
+  pair<InputIterator1, InputIterator2>
+    mismatch(ExecutionPolicy&& exec,
+             InputIterator1 first1, InputIterator1 last1,
+             InputIterator2 first2);
 
 template<class InputIterator1, class InputIterator2,
-          class BinaryPredicate>
+         class BinaryPredicate>
   pair<InputIterator1, InputIterator2>
       mismatch(InputIterator1 first1, InputIterator1 last1,
                InputIterator2 first2, BinaryPredicate pred);
+template<class ExecutionPolicy, class InputIterator1, class InputIterator2,
+         class BinaryPredicate>
+  pair<InputIterator1, InputIterator2>
+    mismatch(ExecutionPolicy&& exec,
+             InputIterator1 first1, InputIterator1 last1,
+             InputIterator2 first2, BinaryPredicate pred);
 
 template<class InputIterator1, class InputIterator2>
   pair<InputIterator1, InputIterator2>
     mismatch(InputIterator1 first1, InputIterator1 last1,
              InputIterator2 first2, InputIterator2 last2);
+template<class ExecutionPolicy, class InputIterator1, class InputIterator2>
+  pair<InputIterator1, InputIterator2>
+    mismatch(ExecutionPolicy&& exec,
+             InputIterator1 first1, InputIterator1 last1,
+             InputIterator2 first2, InputIterator2 last2);
 
-template <class InputIterator1, class InputIterator2,
-           class BinaryPredicate>
+template<class InputIterator1, class InputIterator2,
+         class BinaryPredicate>
   pair<InputIterator1, InputIterator2>
     mismatch(InputIterator1 first1, InputIterator1 last1,
+             InputIterator2 first2, InputIterator2 last2,
+             BinaryPredicate pred);
+template<class ExecutionPolicy, class InputIterator1, class InputIterator2,
+         class BinaryPredicate>
+  pair<InputIterator1, InputIterator2>
+    mismatch(ExecutionPolicy&& exec,
+             InputIterator1 first1, InputIterator1 last1,
              InputIterator2 first2, InputIterator2 last2,
              BinaryPredicate pred);
 \end{itemdecl}
@@ -1903,19 +1982,38 @@ applications of the corresponding predicate.
 template<class InputIterator1, class InputIterator2>
   bool equal(InputIterator1 first1, InputIterator1 last1,
              InputIterator2 first2);
+template<class ExecutionPolicy, class InputIterator1, class InputIterator2>
+  bool equal(ExecutionPolicy&& exec,
+             InputIterator1 first1, InputIterator1 last1,
+             InputIterator2 first2);
 
 template<class InputIterator1, class InputIterator2,
           class BinaryPredicate>
   bool equal(InputIterator1 first1, InputIterator1 last1,
              InputIterator2 first2, BinaryPredicate pred);
+template<class ExecutionPolicy, class InputIterator1, class InputIterator2,
+         class BinaryPredicate>
+  bool equal(ExecutionPolicy&& exec,
+             InputIterator1 first1, InputIterator1 last1,
+             InputIterator2 first2, BinaryPredicate pred);
 
 template<class InputIterator1, class InputIterator2>
   bool equal(InputIterator1 first1, InputIterator1 last1,
+             InputIterator2 first2, InputIterator2 last2);
+template<class ExecutionPolicy, class InputIterator1, class InputIterator2>
+  bool equal(ExecutionPolicy&& exec,
+             InputIterator1 first1, InputIterator1 last1,
              InputIterator2 first2, InputIterator2 last2);
 
 template<class InputIterator1, class InputIterator2,
            class BinaryPredicate>
   bool equal(InputIterator1 first1, InputIterator1 last1,
+             InputIterator2 first2, InputIterator2 last2,
+             BinaryPredicate pred);
+template<class ExecutionPolicy, class InputIterator1, class InputIterator2,
+         class BinaryPredicate>
+  bool equal(ExecutionPolicy&& exec,
+             InputIterator1 first1, InputIterator1 last1,
              InputIterator2 first2, InputIterator2 last2,
              BinaryPredicate pred);
 \end{itemdecl}
@@ -2011,11 +2109,23 @@ template<class ForwardIterator1, class ForwardIterator2>
   ForwardIterator1
     search(ForwardIterator1 first1, ForwardIterator1 last1,
            ForwardIterator2 first2, ForwardIterator2 last2);
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
+  ForwardIterator1
+    search(ExecutionPolicy&& exec,
+           ForwardIterator1 first1, ForwardIterator1 last1,
+           ForwardIterator2 first2, ForwardIterator2 last2);
 
 template<class ForwardIterator1, class ForwardIterator2,
          class BinaryPredicate>
   ForwardIterator1
     search(ForwardIterator1 first1, ForwardIterator1 last1,
+           ForwardIterator2 first2, ForwardIterator2 last2,
+           BinaryPredicate pred);
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2,
+         class BinaryPredicate>
+  ForwardIterator1
+    search(ExecutionPolicy&& exec,
+           ForwardIterator1 first1, ForwardIterator1 last1,
            ForwardIterator2 first2, ForwardIterator2 last2,
            BinaryPredicate pred);
 \end{itemdecl}
@@ -2053,13 +2163,26 @@ applications of the corresponding predicate.
 template<class ForwardIterator, class Size, class T>
   ForwardIterator
     search_n(ForwardIterator first, ForwardIterator last, Size count,
-           const T& value);
+             const T& value);
 
 template<class ForwardIterator, class Size, class T,
          class BinaryPredicate>
   ForwardIterator
     search_n(ForwardIterator first, ForwardIterator last, Size count,
-           const T& value, BinaryPredicate pred);
+             const T& value, BinaryPredicate pred);
+
+template<class ExecutionPolicy, class ForwardIterator, class Size, class T>
+  ForwardIterator
+    search_n(ExecutionPolicy&& exec,
+             ForwardIterator first, ForwardIterator last,
+             Size count, const T& value);
+template<class ExecutionPolicy, class ForwardIterator, class Size, class T,
+         class BinaryPredicate>
+  ForwardIterator
+    search_n(ExecutionPolicy&& exec,
+             ForwardIterator first, ForwardIterator last,
+             Size count, const T& value,
+             BinaryPredicate pred);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2167,6 +2290,10 @@ performs \tcode{*(result + n) = *(first + n)}.
 template<class InputIterator, class Size, class OutputIterator>
   OutputIterator copy_n(InputIterator first, Size n,
                         OutputIterator result);
+template<class ExecutionPolicy, class InputIterator, class Size, class OutputIterator>
+  OutputIterator copy_n(ExecutionPolicy&& exec,
+                        InputIterator first, Size n,
+                        OutputIterator result);
 \end{itemdecl}
 
 
@@ -2182,10 +2309,14 @@ $i < n$, performs \tcode{*(result + i) = *(first + i)}.
 \complexity Exactly \tcode{n} assignments.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{copy_n}}%
+\indexlibrary{\idxcode{copy_if}}%
 \begin{itemdecl}
 template<class InputIterator, class OutputIterator, class Predicate>
   OutputIterator copy_if(InputIterator first, InputIterator last,
+                         OutputIterator result, Predicate pred);
+template<class ExecutionPolicy, class InputIterator, class OutputIterator, class Predicate>
+  OutputIterator copy_if(ExecutionPolicy&& exec,
+                         InputIterator first, InputIterator last,
                          OutputIterator result, Predicate pred);
 \end{itemdecl}
 
@@ -2255,7 +2386,7 @@ assignments.
 
 \rSec2[alg.move]{Move}
 
-\indexlibrary{move\tcode{move}}%
+\indexlibrary{\idxcode{move}!algorithm}%
 \begin{itemdecl}
 template<class InputIterator, class OutputIterator>
   OutputIterator move(InputIterator first, InputIterator last,
@@ -2291,7 +2422,7 @@ Exactly
 move assignments.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{move}}%
+\indexlibrary{\idxcode{move}!algorithm}%
 \begin{itemdecl}
 template<class ExecutionPolicy, class InputIterator, class OutputIterator>
   OutputIterator move(ExecutionPolicy&& policy, InputIterator first, InputIterator last,
@@ -2369,6 +2500,11 @@ template<class ForwardIterator1, class ForwardIterator2>
   ForwardIterator2
     swap_ranges(ForwardIterator1 first1, ForwardIterator1 last1,
                 ForwardIterator2 first2);
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
+  ForwardIterator2
+    swap_ranges(ExecutionPolicy&& exec,
+                ForwardIterator1 first1, ForwardIterator1 last1,
+                ForwardIterator2 first2);
 \end{itemdecl}
 
 
@@ -2427,11 +2563,24 @@ template<class InputIterator, class OutputIterator,
   OutputIterator
     transform(InputIterator first, InputIterator last,
               OutputIterator result, UnaryOperation op);
+template<class ExecutionPolicy, class InputIterator, class OutputIterator,
+         class UnaryOperation>
+  OutputIterator
+    transform(ExecutionPolicy&& exec,
+              InputIterator first, InputIterator last,
+              OutputIterator result, UnaryOperation op);
 
 template<class InputIterator1, class InputIterator2,
          class OutputIterator, class BinaryOperation>
   OutputIterator
     transform(InputIterator1 first1, InputIterator1 last1,
+              InputIterator2 first2, OutputIterator result,
+              BinaryOperation binary_op);
+template<class ExecutionPolicy, class InputIterator1, class InputIterator2,
+         class OutputIterator, class BinaryOperation>
+  OutputIterator
+    transform(ExecutionPolicy&& exec,
+              InputIterator1 first1, InputIterator1 last1,
               InputIterator2 first2, OutputIterator result,
               BinaryOperation binary_op);
 \end{itemdecl}
@@ -2487,9 +2636,17 @@ in case of binary transform.
 template<class ForwardIterator, class T>
   void replace(ForwardIterator first, ForwardIterator last,
                const T& old_value, const T& new_value);
+template<class ExecutionPolicy, class ForwardIterator, class T>
+  void replace(ExecutionPolicy&& exec,
+               ForwardIterator first, ForwardIterator last,
+               const T& old_value, const T& new_value);
 
 template<class ForwardIterator, class Predicate, class T>
   void replace_if(ForwardIterator first, ForwardIterator last,
+                  Predicate pred, const T& new_value);
+template<class ExecutionPolicy, class ForwardIterator, class Predicate, class T>
+  void replace_if(ExecutionPolicy&& exec,
+                  ForwardIterator first, ForwardIterator last,
                   Predicate pred, const T& new_value);
 \end{itemdecl}
 
@@ -2524,10 +2681,23 @@ template<class InputIterator, class OutputIterator, class T>
     replace_copy(InputIterator first, InputIterator last,
                  OutputIterator result,
                  const T& old_value, const T& new_value);
+template<class ExecutionPolicy, class InputIterator, class OutputIterator, class T>
+  OutputIterator
+    replace_copy(ExecutionPolicy&& exec,
+                 InputIterator first, InputIterator last,
+                 OutputIterator result,
+                 const T& old_value, const T& new_value);
 
 template<class InputIterator, class OutputIterator, class Predicate, class T>
   OutputIterator
     replace_copy_if(InputIterator first, InputIterator last,
+                    OutputIterator result,
+                    Predicate pred, const T& new_value);
+template<class ExecutionPolicy, class InputIterator, class OutputIterator,
+         class Predicate, class T>
+  OutputIterator
+    replace_copy_if(ExecutionPolicy&& exec,
+                    InputIterator first, InputIterator last,
                     OutputIterator result,
                     Predicate pred, const T& new_value);
 \end{itemdecl}
@@ -2584,9 +2754,16 @@ applications of the corresponding predicate.
 \begin{itemdecl}
 template<class ForwardIterator, class T>
   void fill(ForwardIterator first, ForwardIterator last, const T& value);
+template<class ExecutionPolicy, class ForwardIterator, class T>
+  void fill(ExecutionPolicy&& exec,
+            ForwardIterator first, ForwardIterator last, const T& value);
 
 template<class OutputIterator, class Size, class T>
   OutputIterator fill_n(OutputIterator first, Size n, const T& value);
+template<class ExecutionPolicy, class OutputIterator, class Size, class T>
+  OutputIterator fill_n(ExecutionPolicy&& exec,
+                        OutputIterator first, Size n, const T& value);
+
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2600,10 +2777,10 @@ shall be convertible to an integral type~(\ref{conv.integral}, \ref{class.conv})
 
 \pnum
 \effects
-The first algorithm assigns \tcode{value} through all the iterators in the range
-\range{first}{last}. The second algorithm assigns \tcode{value}
+The \tcode{fill} algorithms assign \tcode{value} through all the iterators in the range
+\range{first}{last}. The \tcode{fill_n} algorithms assign \tcode{value}
 through all the iterators in the range \range{first}{first + n}
-if \tcode{n} is positive, otherwise it does nothing.
+if \tcode{n} is positive, otherwise they do nothing.
 
 \pnum
 \returns \tcode{fill_n} returns \tcode{first + n} for non-negative values of \tcode{n}
@@ -2624,20 +2801,27 @@ Exactly
 template<class ForwardIterator, class Generator>
   void generate(ForwardIterator first, ForwardIterator last,
                 Generator gen);
+template<class ExecutionPolicy, class ForwardIterator, class Generator>
+  void generate(ExecutionPolicy&& exec,
+                ForwardIterator first, ForwardIterator last,
+                Generator gen);
 
 template<class OutputIterator, class Size, class Generator>
   OutputIterator generate_n(OutputIterator first, Size n, Generator gen);
+template<class ExecutionPolicy, class OutputIterator, class Size, class Generator>
+  OutputIterator generate_n(ExecutionPolicy&& exec,
+                            OutputIterator first, Size n, Generator gen);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \effects
-The first algorithm invokes the function object \tcode{gen} and assigns the return
+The \tcode{generate} algorithms invoke the function object \tcode{gen} and assign the return
 value of \tcode{gen} through all the iterators in the range
-\range{first}{last}. The second algorithm invokes the function object
-\tcode{gen} and assigns the return value of \tcode{gen} through all the iterators in
+\range{first}{last}. The \tcode{generate_n} algorithms invoke the function object
+\tcode{gen} and assign the return value of \tcode{gen} through all the iterators in
 the range \range{first}{first + n} if \tcode{n} is positive,
-otherwise it does nothing.
+otherwise they do nothing.
 
 \pnum
 \requires
@@ -2665,9 +2849,17 @@ invocations of \tcode{gen} and assignments, respectively.
 template<class ForwardIterator, class T>
   ForwardIterator remove(ForwardIterator first, ForwardIterator last,
                          const T& value);
+template<class ExecutionPolicy, class ForwardIterator, class T>
+  ForwardIterator remove(ExecutionPolicy&& exec,
+                         ForwardIterator first, ForwardIterator last,
+                         const T& value);
 
 template<class ForwardIterator, class Predicate>
   ForwardIterator remove_if(ForwardIterator first, ForwardIterator last,
+                            Predicate pred);
+template<class ExecutionPolicy, class ForwardIterator, class Predicate>
+  ForwardIterator remove_if(ExecutionPolicy&& exec,
+                            ForwardIterator first, ForwardIterator last,
                             Predicate pred);
 \end{itemdecl}
 
@@ -2714,10 +2906,20 @@ template<class InputIterator, class OutputIterator, class T>
   OutputIterator
     remove_copy(InputIterator first, InputIterator last,
                 OutputIterator result, const T& value);
+template<class ExecutionPolicy, class InputIterator, class OutputIterator, class T>
+  OutputIterator
+    remove_copy(ExecutionPolicy&& exec,
+                InputIterator first, InputIterator last,
+                OutputIterator result, const T& value);
 
 template<class InputIterator, class OutputIterator, class Predicate>
   OutputIterator
     remove_copy_if(InputIterator first, InputIterator last,
+                   OutputIterator result, Predicate pred);
+template<class ExecutionPolicy, class InputIterator, class OutputIterator, class Predicate>
+  OutputIterator
+    remove_copy_if(ExecutionPolicy&& exec,
+                   InputIterator first, InputIterator last,
                    OutputIterator result, Predicate pred);
 \end{itemdecl}
 
@@ -2759,9 +2961,16 @@ applications of the corresponding predicate.
 \begin{itemdecl}
 template<class ForwardIterator>
   ForwardIterator unique(ForwardIterator first, ForwardIterator last);
+template<class ExecutionPolicy, class ForwardIterator>
+  ForwardIterator unique(ExecutionPolicy&& exec,
+                         ForwardIterator first, ForwardIterator last);
 
 template<class ForwardIterator, class BinaryPredicate>
   ForwardIterator unique(ForwardIterator first, ForwardIterator last,
+                         BinaryPredicate pred);
+template<class ExecutionPolicy, class ForwardIterator, class BinaryPredicate>
+  ForwardIterator unique(ExecutionPolicy&& exec,
+                         ForwardIterator first, ForwardIterator last,
                          BinaryPredicate pred);
 \end{itemdecl}
 
@@ -2801,11 +3010,22 @@ template<class InputIterator, class OutputIterator>
   OutputIterator
     unique_copy(InputIterator first, InputIterator last,
                 OutputIterator result);
+template<class ExecutionPolicy, class InputIterator, class OutputIterator>
+  OutputIterator
+    unique_copy(ExecutionPolicy&& exec,
+                InputIterator first, InputIterator last,
+                OutputIterator result);
 
 template<class InputIterator, class OutputIterator,
          class BinaryPredicate>
   OutputIterator
     unique_copy(InputIterator first, InputIterator last,
+                OutputIterator result, BinaryPredicate pred);
+template<class ExecutionPolicy, class InputIterator, class OutputIterator,
+         class BinaryPredicate>
+  OutputIterator
+    unique_copy(ExecutionPolicy&& exec,
+                InputIterator first, InputIterator last,
                 OutputIterator result, BinaryPredicate pred);
 \end{itemdecl}
 
@@ -2860,6 +3080,9 @@ applications of the corresponding predicate.
 \begin{itemdecl}
 template<class BidirectionalIterator>
   void reverse(BidirectionalIterator first, BidirectionalIterator last);
+template<class ExecutionPolicy, class BidirectionalIterator>
+  void reverse(ExecutionPolicy&& exec,
+               BidirectionalIterator first, BidirectionalIterator last);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2888,8 +3111,13 @@ swaps.
 \begin{itemdecl}
 template<class BidirectionalIterator, class OutputIterator>
   OutputIterator
-    reverse_copy(BidirectionalIterator first,
-                 BidirectionalIterator last, OutputIterator result);
+    reverse_copy(BidirectionalIterator first, BidirectionalIterator last,
+                 OutputIterator result);
+template<class ExecutionPolicy, class BidirectionalIterator, class OutputIterator>
+  OutputIterator
+    reverse_copy(ExecutionPolicy&& exec,
+                 BidirectionalIterator first, BidirectionalIterator last,
+                 OutputIterator result);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2929,8 +3157,12 @@ assignments.
 \indexlibrary{\idxcode{rotate}}%
 \begin{itemdecl}
 template<class ForwardIterator>
-  ForwardIterator rotate(ForwardIterator first, ForwardIterator middle,
-              ForwardIterator last);
+  ForwardIterator
+    rotate(ForwardIterator first, ForwardIterator middle, ForwardIterator last);
+template<class ExecutionPolicy, class ForwardIterator>
+  ForwardIterator
+    rotate(ExecutionPolicy&& exec,
+           ForwardIterator first, ForwardIterator middle, ForwardIterator last);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2976,8 +3208,13 @@ swaps.
 \begin{itemdecl}
 template<class ForwardIterator, class OutputIterator>
   OutputIterator
-    rotate_copy(ForwardIterator first, ForwardIterator middle,
-                ForwardIterator last, OutputIterator result);
+    rotate_copy(ForwardIterator first, ForwardIterator middle, ForwardIterator last,
+                OutputIterator result);
+template<class ExecutionPolicy, class ForwardIterator, class OutputIterator>
+  OutputIterator
+    rotate_copy(ExecutionPolicy&& exec,
+                ForwardIterator first, ForwardIterator middle, ForwardIterator last,
+                OutputIterator result);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3125,6 +3362,9 @@ randomness.
 \begin{itemdecl}
 template <class InputIterator, class Predicate>
   bool is_partitioned(InputIterator first, InputIterator last, Predicate pred);
+template <class ExecutionPolicy, class InputIterator, class Predicate>
+  bool is_partitioned(ExecutionPolicy&& exec,
+                      InputIterator first, InputIterator last, Predicate pred);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3144,8 +3384,11 @@ template <class InputIterator, class Predicate>
 \begin{itemdecl}
 template<class ForwardIterator, class Predicate>
   ForwardIterator
-    partition(ForwardIterator first,
-              ForwardIterator last, Predicate pred);
+    partition(ForwardIterator first, ForwardIterator last, Predicate pred);
+template<class ExecutionPolicy, class ForwardIterator, class Predicate>
+  ForwardIterator
+    partition(ExecutionPolicy&& exec,
+              ForwardIterator first, ForwardIterator last, Predicate pred);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3172,8 +3415,13 @@ are done. Exactly \tcode{last - first} applications of the predicate are done.
 \begin{itemdecl}
 template<class BidirectionalIterator, class Predicate>
   BidirectionalIterator
-    stable_partition(BidirectionalIterator first,
-                     BidirectionalIterator last, Predicate pred);
+    stable_partition(BidirectionalIterator first, BidirectionalIterator last,
+                     Predicate pred);
+template<class ExecutionPolicy, class BidirectionalIterator, class Predicate>
+  BidirectionalIterator
+    stable_partition(ExecutionPolicy&& exec,
+                     BidirectionalIterator first, BidirectionalIterator last,
+                     Predicate pred);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3222,9 +3470,16 @@ applications of the predicate.
 template <class InputIterator, class OutputIterator1,
           class OutputIterator2, class Predicate>
   pair<OutputIterator1, OutputIterator2>
-  partition_copy(InputIterator first, InputIterator last,
-                 OutputIterator1 out_true, OutputIterator2 out_false,
-                 Predicate pred);
+    partition_copy(InputIterator first, InputIterator last,
+                   OutputIterator1 out_true, OutputIterator2 out_false,
+                   Predicate pred);
+template <class ExecutionPolicy, class InputIterator, class OutputIterator1,
+          class OutputIterator2, class Predicate>
+  pair<OutputIterator1, OutputIterator2>
+    partition_copy(ExecutionPolicy&& exec,
+                   InputIterator first, InputIterator last,
+                   OutputIterator1 out_true, OutputIterator2 out_false,
+                   Predicate pred);
 \end{itemdecl}
 
 
@@ -3397,9 +3652,16 @@ are considered equivalent if and only if
 \begin{itemdecl}
 template<class RandomAccessIterator>
   void sort(RandomAccessIterator first, RandomAccessIterator last);
+template<class ExecutionPolicy, class RandomAccessIterator>
+  void sort(ExecutionPolicy&& exec,
+            RandomAccessIterator first, RandomAccessIterator last);
 
 template<class RandomAccessIterator, class Compare>
   void sort(RandomAccessIterator first, RandomAccessIterator last,
+            Compare comp);
+template<class ExecutionPolicy, class RandomAccessIterator, class Compare>
+  void sort(ExecutionPolicy&& exec,
+            RandomAccessIterator first, RandomAccessIterator last,
             Compare comp);
 \end{itemdecl}
 
@@ -3428,9 +3690,16 @@ of \tcode{*first} shall satisfy the requirements of
 \begin{itemdecl}
 template<class RandomAccessIterator>
   void stable_sort(RandomAccessIterator first, RandomAccessIterator last);
+template<class ExecutionPolicy, class RandomAccessIterator>
+  void stable_sort(ExecutionPolicy&& exec,
+                   RandomAccessIterator first, RandomAccessIterator last);
 
 template<class RandomAccessIterator, class Compare>
   void stable_sort(RandomAccessIterator first, RandomAccessIterator last,
+                   Compare comp);
+template<class ExecutionPolicy, class RandomAccessIterator, class Compare>
+  void stable_sort(ExecutionPolicy&& exec,
+                   RandomAccessIterator first, RandomAccessIterator last,
                    Compare comp);
 \end{itemdecl}
 
@@ -3466,12 +3735,24 @@ template<class RandomAccessIterator>
   void partial_sort(RandomAccessIterator first,
                     RandomAccessIterator middle,
                     RandomAccessIterator last);
+template<class ExecutionPolicy, class RandomAccessIterator>
+  void partial_sort(ExecutionPolicy&& exec,
+                    RandomAccessIterator first,
+                    RandomAccessIterator middle,
+                    RandomAccessIterator last);
 
 template<class RandomAccessIterator, class Compare>
   void partial_sort(RandomAccessIterator first,
                     RandomAccessIterator middle,
                     RandomAccessIterator last,
                     Compare comp);
+template<class ExecutionPolicy, class RandomAccessIterator, class Compare>
+  void partial_sort(ExecutionPolicy&& exec,
+                    RandomAccessIterator first,
+                    RandomAccessIterator middle,
+                    RandomAccessIterator last,
+                    Compare comp);
+
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3513,11 +3794,25 @@ template<class InputIterator, class RandomAccessIterator>
     partial_sort_copy(InputIterator first, InputIterator last,
                       RandomAccessIterator result_first,
                       RandomAccessIterator result_last);
+template<class ExecutionPolicy, class InputIterator, class RandomAccessIterator>
+  RandomAccessIterator
+    partial_sort_copy(ExecutionPolicy&& exec,
+                      InputIterator first, InputIterator last,
+                      RandomAccessIterator result_first,
+                      RandomAccessIterator result_last);
 
 template<class InputIterator, class RandomAccessIterator,
          class Compare>
   RandomAccessIterator
     partial_sort_copy(InputIterator first, InputIterator last,
+                      RandomAccessIterator result_first,
+                      RandomAccessIterator result_last,
+                      Compare comp);
+template<class ExecutionPolicy, class InputIterator, class RandomAccessIterator,
+         class Compare>
+  RandomAccessIterator
+    partial_sort_copy(ExecutionPolicy&& exec,
+                      InputIterator first, InputIterator last,
                       RandomAccessIterator result_first,
                       RandomAccessIterator result_last,
                       Compare comp);
@@ -3561,7 +3856,6 @@ template<class ForwardIterator>
   bool is_sorted(ForwardIterator first, ForwardIterator last);
 \end{itemdecl}
 
-
 \begin{itemdescr}
 \pnum
 \returns \tcode{is_sorted_until(first, last) == last}
@@ -3569,24 +3863,59 @@ template<class ForwardIterator>
 
 \indexlibrary{\idxcode{is_sorted}}%
 \begin{itemdecl}
-template<class ForwardIterator, class Compare>
-  bool is_sorted(ForwardIterator first, ForwardIterator last,
-    Compare comp);
+template<class ExecutionPolicy, class ForwardIterator>
+  bool is_sorted(ExecutionPolicy&& exec,
+                 ForwardIterator first, ForwardIterator last);
 \end{itemdecl}
 
+\begin{itemdescr}
+\pnum
+\returns \tcode{is_sorted_until(std::forward<ExecutionPolicy>(exec), first, last) == last}
+\end{itemdescr}
+
+
+\indexlibrary{\idxcode{is_sorted}}%
+\begin{itemdecl}
+template<class ForwardIterator, class Compare>
+  bool is_sorted(ForwardIterator first, ForwardIterator last,
+                 Compare comp);
+\end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \returns \tcode{is_sorted_until(first, last, comp) == last}
 \end{itemdescr}
 
+
+\indexlibrary{\idxcode{is_sorted}}%
+\begin{itemdecl}
+template<class ExecutionPolicy, class ForwardIterator, class Compare>
+  bool is_sorted(ExecutionPolicy&& exec,
+                 ForwardIterator first, ForwardIterator last,
+                 Compare comp);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns \tcode{is_sorted_until(std::forward<ExecutionPolicy>(exec), first, last, comp) == last}
+\end{itemdescr}
+
+
 \indexlibrary{\idxcode{is_sorted_until}}%
 \begin{itemdecl}
 template<class ForwardIterator>
   ForwardIterator is_sorted_until(ForwardIterator first, ForwardIterator last);
+template<class ExecutionPolicy, class ForwardIterator>
+  ForwardIterator is_sorted_until(ExecutionPolicy&& exec,
+                                  ForwardIterator first, ForwardIterator last);
+
 template<class ForwardIterator, class Compare>
   ForwardIterator is_sorted_until(ForwardIterator first, ForwardIterator last,
-    Compare comp);
+                                  Compare comp);
+template<class ExecutionPolicy, class ForwardIterator, class Compare>
+  ForwardIterator is_sorted_until(ExecutionPolicy&& exec,
+                                  ForwardIterator first, ForwardIterator last,
+                                  Compare comp);
 \end{itemdecl}
 
 
@@ -3608,10 +3937,18 @@ range \range{first}{i} is sorted.
 template<class RandomAccessIterator>
   void nth_element(RandomAccessIterator first, RandomAccessIterator nth,
                    RandomAccessIterator last);
+template<class ExecutionPolicy, class RandomAccessIterator>
+  void nth_element(ExecutionPolicy&& exec,
+                   RandomAccessIterator first, RandomAccessIterator nth,
+                   RandomAccessIterator last);
 
 template<class RandomAccessIterator, class Compare>
   void nth_element(RandomAccessIterator first, RandomAccessIterator nth,
                    RandomAccessIterator last,  Compare comp);
+template<class ExecutionPolicy, class RandomAccessIterator, class Compare>
+  void nth_element(ExecutionPolicy&& exec,
+                   RandomAccessIterator first, RandomAccessIterator nth,
+                   RandomAccessIterator last, Compare comp);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3891,11 +4228,25 @@ template<class InputIterator1, class InputIterator2,
     merge(InputIterator1 first1, InputIterator1 last1,
           InputIterator2 first2, InputIterator2 last2,
           OutputIterator result);
+template<class ExecutionPolicy, class InputIterator1, class InputIterator2,
+         class OutputIterator>
+  OutputIterator
+    merge(ExecutionPolicy&& exec,
+          InputIterator1 first1, InputIterator1 last1,
+          InputIterator2 first2, InputIterator2 last2,
+          OutputIterator result);
 
 template<class InputIterator1, class InputIterator2,
          class OutputIterator, class Compare>
   OutputIterator
     merge(InputIterator1 first1, InputIterator1 last1,
+          InputIterator2 first2, InputIterator2 last2,
+          OutputIterator result, Compare comp);
+template<class ExecutionPolicy, class InputIterator1, class InputIterator2,
+         class OutputIterator, class Compare>
+  OutputIterator
+    merge(ExecutionPolicy&& exec,
+          InputIterator1 first1, InputIterator1 last1,
           InputIterator2 first2, InputIterator2 last2,
           OutputIterator result, Compare comp);
 \end{itemdecl}
@@ -3932,9 +4283,19 @@ template<class BidirectionalIterator>
   void inplace_merge(BidirectionalIterator first,
                      BidirectionalIterator middle,
                      BidirectionalIterator last);
+template<class ExecutionPolicy, class BidirectionalIterator>
+  void inplace_merge(ExecutionPolicy&& exec,
+                     BidirectionalIterator first,
+                     BidirectionalIterator middle,
+                     BidirectionalIterator last);
 
 template<class BidirectionalIterator, class Compare>
   void inplace_merge(BidirectionalIterator first,
+                     BidirectionalIterator middle,
+                     BidirectionalIterator last, Compare comp);
+template<class ExecutionPolicy, class BidirectionalIterator, class Compare>
+  void inplace_merge(ExecutionPolicy&& exec,
+                     BidirectionalIterator first,
                      BidirectionalIterator middle,
                      BidirectionalIterator last, Compare comp);
 \end{itemdecl}
@@ -4006,9 +4367,18 @@ to contain the minimum, and so on.
 template<class InputIterator1, class InputIterator2>
   bool includes(InputIterator1 first1, InputIterator1 last1,
                 InputIterator2 first2, InputIterator2 last2);
+template<class ExecutionPolicy, class InputIterator1, class InputIterator2>
+  bool includes(ExecutionPolicy&& exec,
+                InputIterator1 first1, InputIterator1 last1,
+                InputIterator2 first2, InputIterator2 last2);
 
 template<class InputIterator1, class InputIterator2, class Compare>
   bool includes(InputIterator1 first1, InputIterator1 last1,
+                InputIterator2 first2, InputIterator2 last2,
+                Compare comp);
+template<class ExecutionPolicy, class InputIterator1, class InputIterator2, class Compare>
+  bool includes(ExecutionPolicy&& exec,
+                InputIterator1 first1, InputIterator1 last1,
                 InputIterator2 first2, InputIterator2 last2,
                 Compare comp);
 \end{itemdecl}
@@ -4043,11 +4413,25 @@ template<class InputIterator1, class InputIterator2,
     set_union(InputIterator1 first1, InputIterator1 last1,
               InputIterator2 first2, InputIterator2 last2,
               OutputIterator result);
+template<class ExecutionPolicy, class InputIterator1, class InputIterator2,
+         class OutputIterator>
+  OutputIterator
+    set_union(ExecutionPolicy&& exec,
+              InputIterator1 first1, InputIterator1 last1,
+              InputIterator2 first2, InputIterator2 last2,
+              OutputIterator result);
 
 template<class InputIterator1, class InputIterator2,
          class OutputIterator, class Compare>
   OutputIterator
     set_union(InputIterator1 first1, InputIterator1 last1,
+              InputIterator2 first2, InputIterator2 last2,
+              OutputIterator result, Compare comp);
+template<class ExecutionPolicy, class InputIterator1, class InputIterator2,
+         class OutputIterator, class Compare>
+  OutputIterator
+    set_union(ExecutionPolicy&& exec,
+              InputIterator1 first1, InputIterator1 last1,
               InputIterator2 first2, InputIterator2 last2,
               OutputIterator result, Compare comp);
 \end{itemdecl}
@@ -4090,11 +4474,25 @@ template<class InputIterator1, class InputIterator2,
     set_intersection(InputIterator1 first1, InputIterator1 last1,
                      InputIterator2 first2, InputIterator2 last2,
                      OutputIterator result);
+template<class ExecutionPolicy, class InputIterator1, class InputIterator2,
+         class OutputIterator>
+  OutputIterator
+    set_intersection(ExecutionPolicy&& exec,
+                     InputIterator1 first1, InputIterator1 last1,
+                     InputIterator2 first2, InputIterator2 last2,
+                     OutputIterator result);
 
 template<class InputIterator1, class InputIterator2,
          class OutputIterator, class Compare>
   OutputIterator
     set_intersection(InputIterator1 first1, InputIterator1 last1,
+                     InputIterator2 first2, InputIterator2 last2,
+                     OutputIterator result, Compare comp);
+template<class ExecutionPolicy, class InputIterator1, class InputIterator2,
+         class OutputIterator, class Compare>
+  OutputIterator
+    set_intersection(ExecutionPolicy&& exec,
+                     InputIterator1 first1, InputIterator1 last1,
                      InputIterator2 first2, InputIterator2 last2,
                      OutputIterator result, Compare comp);
 \end{itemdecl}
@@ -4136,11 +4534,25 @@ template<class InputIterator1, class InputIterator2,
     set_difference(InputIterator1 first1, InputIterator1 last1,
                    InputIterator2 first2, InputIterator2 last2,
                    OutputIterator result);
+template<class ExecutionPolicy, class InputIterator1, class InputIterator2,
+           class OutputIterator>
+  OutputIterator
+    set_difference(ExecutionPolicy&& exec,
+                   InputIterator1 first1, InputIterator1 last1,
+                   InputIterator2 first2, InputIterator2 last2,
+                   OutputIterator result);
 
 template<class InputIterator1, class InputIterator2,
          class OutputIterator, class Compare>
   OutputIterator
     set_difference(InputIterator1 first1, InputIterator1 last1,
+                   InputIterator2 first2, InputIterator2 last2,
+                   OutputIterator result, Compare comp);
+template<class ExecutionPolicy, class InputIterator1, class InputIterator2,
+         class OutputIterator, class Compare>
+  OutputIterator
+    set_difference(ExecutionPolicy&& exec,
+                   InputIterator1 first1, InputIterator1 last1,
                    InputIterator2 first2, InputIterator2 last2,
                    OutputIterator result, Compare comp);
 \end{itemdecl}
@@ -4195,11 +4607,25 @@ template<class InputIterator1, class InputIterator2,
     set_symmetric_difference(InputIterator1 first1, InputIterator1 last1,
                              InputIterator2 first2, InputIterator2 last2,
                              OutputIterator result);
+template<class ExecutionPolicy, class InputIterator1, class InputIterator2,
+         class OutputIterator>
+  OutputIterator
+    set_symmetric_difference(ExecutionPolicy&& exec,
+                             InputIterator1 first1, InputIterator1 last1,
+                             InputIterator2 first2, InputIterator2 last2,
+                             OutputIterator result);
 
 template<class InputIterator1, class InputIterator2,
          class OutputIterator, class Compare>
   OutputIterator
     set_symmetric_difference(InputIterator1 first1, InputIterator1 last1,
+                             InputIterator2 first2, InputIterator2 last2,
+                             OutputIterator result, Compare comp);
+template<class ExecutionPolicy, class InputIterator1, class InputIterator2,
+         class OutputIterator, class Compare>
+  OutputIterator
+    set_symmetric_difference(ExecutionPolicy&& exec,
+                             InputIterator1 first1, InputIterator1 last1,
                              InputIterator2 first2, InputIterator2 last2,
                              OutputIterator result, Compare comp);
 \end{itemdecl}
@@ -4428,11 +4854,24 @@ template<class RandomAccessIterator>
   bool is_heap(RandomAccessIterator first, RandomAccessIterator last);
 \end{itemdecl}
 
-
 \begin{itemdescr}
 \pnum
 \returns \tcode{is_heap_until(first, last) == last}
 \end{itemdescr}
+
+
+\indexlibrary{\idxcode{is_heap}}%
+\begin{itemdecl}
+template<class ExecutionPolicy, class RandomAccessIterator>
+  bool is_heap(ExecutionPolicy&& exec,
+               RandomAccessIterator first, RandomAccessIterator last);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns \tcode{is_heap_until(std::forward<ExecutionPolicy>(exec), first, last) == last}
+\end{itemdescr}
+
 
 \indexlibrary{\idxcode{is_heap}}%
 \begin{itemdecl}
@@ -4440,19 +4879,40 @@ template<class RandomAccessIterator, class Compare>
   bool is_heap(RandomAccessIterator first, RandomAccessIterator last, Compare comp);
 \end{itemdecl}
 
-
 \begin{itemdescr}
 \pnum
 \returns \tcode{is_heap_until(first, last, comp) == last}
 \end{itemdescr}
 
+
+\indexlibrary{\idxcode{is_heap}}%
+\begin{itemdecl}
+template<class ExecutionPolicy, class RandomAccessIterator, class Compare>
+  bool is_heap(ExecutionPolicy&& exec,
+               RandomAccessIterator first, RandomAccessIterator last, Compare comp);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns \tcode{is_heap_until(std::forward<ExecutionPolicy>(exec), first, last, comp) == last}
+\end{itemdescr}
+
+
 \indexlibrary{\idxcode{is_heap_until}}%
 \begin{itemdecl}
 template<class RandomAccessIterator>
   RandomAccessIterator is_heap_until(RandomAccessIterator first, RandomAccessIterator last);
+template<class ExecutionPolicy, class RandomAccessIterator>
+  RandomAccessIterator is_heap_until(ExecutionPolicy&& exec,
+                                     RandomAccessIterator first, RandomAccessIterator last);
+
 template<class RandomAccessIterator, class Compare>
   RandomAccessIterator is_heap_until(RandomAccessIterator first, RandomAccessIterator last,
-    Compare comp);
+                                     Compare comp);
+template<class ExecutionPolicy, class RandomAccessIterator, class Compare>
+  RandomAccessIterator is_heap_until(ExecutionPolicy&& exec,
+                                     RandomAccessIterator first, RandomAccessIterator last,
+                                     Compare comp);
 \end{itemdecl}
 
 
@@ -4630,9 +5090,17 @@ equivalent to the largest.
 template<class ForwardIterator>
   constexpr ForwardIterator min_element(ForwardIterator first, ForwardIterator last);
 
+template<class ExecutionPolicy, class ForwardIterator>
+  ForwardIterator min_element(ExecutionPolicy&& exec,
+                              ForwardIterator first, ForwardIterator last);
+
 template<class ForwardIterator, class Compare>
   constexpr ForwardIterator min_element(ForwardIterator first, ForwardIterator last,
                                         Compare comp);
+template<class ExecutionPolicy, class ForwardIterator, class Compare>
+  ForwardIterator min_element(ExecutionPolicy&& exec,
+                              ForwardIterator first, ForwardIterator last,
+                              Compare comp);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4666,9 +5134,17 @@ applications of the corresponding comparisons.
 \begin{itemdecl}
 template<class ForwardIterator>
   constexpr ForwardIterator max_element(ForwardIterator first, ForwardIterator last);
+template<class ExecutionPolicy, class ForwardIterator>
+  ForwardIterator max_element(ExecutionPolicy&& exec,
+                              ForwardIterator first, ForwardIterator last);
+
 template<class ForwardIterator, class Compare>
   constexpr ForwardIterator max_element(ForwardIterator first, ForwardIterator last,
                                         Compare comp);
+template<class ExecutionPolicy, class ForwardIterator, class Compare>
+  ForwardIterator max_element(ExecutionPolicy&& exec,
+                              ForwardIterator first, ForwardIterator last,
+                              Compare comp);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4703,9 +5179,18 @@ applications of the corresponding comparisons.
 template<class ForwardIterator>
   constexpr pair<ForwardIterator, ForwardIterator>
     minmax_element(ForwardIterator first, ForwardIterator last);
+template<class ExecutionPolicy, class ForwardIterator>
+  pair<ForwardIterator, ForwardIterator>
+    minmax_element(ExecutionPolicy&& exec,
+                   ForwardIterator first, ForwardIterator last);
+
 template<class ForwardIterator, class Compare>
   constexpr pair<ForwardIterator, ForwardIterator>
     minmax_element(ForwardIterator first, ForwardIterator last, Compare comp);
+template<class ExecutionPolicy, class ForwardIterator, class Compare>
+  pair<ForwardIterator, ForwardIterator>
+    minmax_element(ExecutionPolicy&& exec,
+                   ForwardIterator first, ForwardIterator last, Compare comp);
 \end{itemdecl}
 
 
@@ -4766,10 +5251,21 @@ template<class InputIterator1, class InputIterator2>
   bool
     lexicographical_compare(InputIterator1 first1, InputIterator1 last1,
                             InputIterator2 first2, InputIterator2 last2);
+template<class ExecutionPolicy, class InputIterator1, class InputIterator2>
+  bool
+    lexicographical_compare(ExecutionPolicy&& exec,
+                            InputIterator1 first1, InputIterator1 last1,
+                            InputIterator2 first2, InputIterator2 last2);
 
 template<class InputIterator1, class InputIterator2, class Compare>
   bool
     lexicographical_compare(InputIterator1 first1, InputIterator1 last1,
+                            InputIterator2 first2, InputIterator2 last2,
+                            Compare comp);
+template<class ExecutionPolicy, class InputIterator1, class InputIterator2, class Compare>
+  bool
+    lexicographical_compare(ExecutionPolicy&& exec,
+                            InputIterator1 first1, InputIterator1 last1,
                             InputIterator2 first2, InputIterator2 last2,
                             Compare comp);
 \end{itemdecl}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -8877,12 +8877,30 @@ template<class InputIterator>
 
 \begin{itemdescr}
 \pnum
-\effects
-Equivalent to:
+\effects Equivalent to:
 \begin{codeblock}
-return reduce(first, last, typename iterator_traits<InputIterator>::value_type{});
+return reduce(first, last,
+              typename iterator_traits<InputIterator>::value_type{});
 \end{codeblock}
 \end{itemdescr}
+
+\indexlibrary{\idxcode{reduce}}%
+\begin{itemdecl}
+template<class ExecutionPolicy, class InputIterator>
+  typename iterator_traits<InputIterator>::value_type
+    reduce(ExecutionPolicy&& exec,
+           InputIterator first, InputIterator last);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Equivalent to:
+\begin{codeblock}
+return reduce(std::forward<ExecutionPolicy>(exec), first, last,
+              typename iterator_traits<InputIterator>::value_type{});
+\end{codeblock}
+\end{itemdescr}
+
 
 \indexlibrary{\idxcode{reduce}}%
 \begin{itemdecl}
@@ -8892,14 +8910,36 @@ template<class InputIterator, class T>
 
 \begin{itemdescr}
 \pnum
-\effects
-Equivalent to: \tcode{return reduce(first, last, init, plus<>());}
+\effects Equivalent to:
+\begin{codeblock}
+return reduce(first, last, init, plus<>());
+\end{codeblock}
 \end{itemdescr}
+
+\indexlibrary{\idxcode{reduce}}%
+\begin{itemdecl}
+template<class ExecutionPolicy, class InputIterator, class T>
+  T reduce(ExecutionPolicy&& exec,
+           InputIterator first, InputIterator last, T init);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Equivalent to:
+\begin{codeblock}
+return reduce(std::forward<ExecutionPolicy>(exec), first, last, init, plus<>());
+\end{codeblock}
+\end{itemdescr}
+
 
 \indexlibrary{\idxcode{reduce}}%
 \begin{itemdecl}
 template<class InputIterator, class T, class BinaryOperation>
   T reduce(InputIterator first, InputIterator last, T init,
+           BinaryOperation binary_op);
+template<class ExecutionPolicy, class InputIterator, class T, class BinaryOperation>
+  T reduce(ExecutionPolicy&& exec,
+           InputIterator first, InputIterator last, T init,
            BinaryOperation binary_op);
 \end{itemdecl}
 
@@ -8932,6 +8972,11 @@ a non-deterministic result for non-associative or non-commutative
 template<class InputIterator, class UnaryFunction, class T, class BinaryOperation>
   T transform_reduce(InputIterator first, InputIterator last,
                      UnaryOperation unary_op, T init, BinaryOperation binary_op);
+template<class ExecutionPolicy, class InputIterator,
+         class UnaryFunction, class T, class BinaryOperation>
+  T transform_reduce(ExecutionPolicy&& exec,
+                     InputIterator first, InputIterator last,
+                     UnaryOperation unary_op, T init, BinaryOperation binary_op);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8961,9 +9006,21 @@ modify elements in the range \range{first}{last}.
 template <class InputIterator1, class InputIterator2, class T>
   T inner_product(InputIterator1 first1, InputIterator1 last1,
                   InputIterator2 first2, T init);
+template <class ExecutionPolicy, class InputIterator1, class InputIterator2, class T>
+  T inner_product(ExecutionPolicy&& exec,
+                  InputIterator1 first1, InputIterator1 last1,
+                  InputIterator2 first2, T init);
+
 template <class InputIterator1, class InputIterator2, class T,
           class BinaryOperation1, class BinaryOperation2>
   T inner_product(InputIterator1 first1, InputIterator1 last1,
+                  InputIterator2 first2, T init,
+                  BinaryOperation1 binary_op1,
+                  BinaryOperation2 binary_op2);
+template <class ExecutionPolicy, class InputIterator1, class InputIterator2, class T,
+          class BinaryOperation1, class BinaryOperation2>
+  T inner_product(ExecutionPolicy&& exec,
+                  InputIterator1 first1, InputIterator1 last1,
                   InputIterator2 first2, T init,
                   BinaryOperation1 binary_op1,
                   BinaryOperation2 binary_op2);
@@ -9070,14 +9127,39 @@ template<class InputIterator, class OutputIterator, class T>
 
 \begin{itemdescr}
 \pnum
-\effects
-Equivalent to: \tcode{return exclusive_scan(first, last, result, init, plus<>());}
+\effects Equivalent to:
+\begin{codeblock}
+return exclusive_scan(first, last, result, init, plus<>());
+\end{codeblock}
 \end{itemdescr}
+
+\indexlibrary{\idxcode{exclusive_scan}}%
+\begin{itemdecl}
+template<class ExecutionPolicy, class InputIterator, class OutputIterator, class T>
+  OutputIterator exclusive_scan(ExecutionPolicy&& exec,
+                                InputIterator first, InputIterator last,
+                                OutputIterator result,
+                                T init);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Equivalent to:
+\begin{codeblock}
+return exclusive_scan(std::forward<ExecutionPolicy>(exec), first, last, result, init, plus<>());
+\end{codeblock}
+\end{itemdescr}
+
 
 \indexlibrary{\idxcode{exclusive_scan}}%
 \begin{itemdecl}
 template<class InputIterator, class OutputIterator, class T, class BinaryOperation>
   OutputIterator exclusive_scan(InputIterator first, InputIterator last,
+                                OutputIterator result,
+                                T init, BinaryOperation binary_op);
+template<class ExecutionPolicy, class InputIterator, class OutputIterator, class T, class BinaryOperation>
+  OutputIterator exclusive_scan(ExecutionPolicy&& exec,
+                                InputIterator first, InputIterator last,
                                 OutputIterator result,
                                 T init, BinaryOperation binary_op);
 \end{itemdecl}
@@ -9126,9 +9208,28 @@ template<class InputIterator, class OutputIterator>
 
 \begin{itemdescr}
 \pnum
-\effects
-Equivalent to: \tcode{return inclusive_scan(first, last, result, plus<>());}
+\effects Equivalent to:
+\begin{codeblock}
+return inclusive_scan(first, last, result, plus<>());
+\end{codeblock}
 \end{itemdescr}
+
+\indexlibrary{\idxcode{inclusive_scan}}%
+\begin{itemdecl}
+template<class ExecutionPolicy, class InputIterator, class OutputIterator>
+  OutputIterator inclusive_scan(ExecutionPolicy&& exec,
+                                InputIterator first, InputIterator last,
+                                OutputIterator result);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Equivalent to:
+\begin{codeblock}
+return inclusive_scan(std::forward<ExecutionPolicy>(exec), first, last, result, plus<>());
+\end{codeblock}
+\end{itemdescr}
+
 
 \indexlibrary{\idxcode{inclusive_scan}}%
 \begin{itemdecl}
@@ -9136,8 +9237,19 @@ template<class InputIterator, class OutputIterator, class BinaryOperation>
   OutputIterator inclusive_scan(InputIterator first, InputIterator last,
                                 OutputIterator result,
                                 BinaryOperation binary_op);
+template<class ExecutionPolicy, class InputIterator, class OutputIterator, class BinaryOperation>
+  OutputIterator inclusive_scan(ExecutionPolicy&& exec,
+                                InputIterator first, InputIterator last,
+                                OutputIterator result,
+                                BinaryOperation binary_op);
+
 template<class InputIterator, class OutputIterator, class BinaryOperation, class T>
   OutputIterator inclusive_scan(InputIterator first, InputIterator last,
+                                OutputIterator result,
+                                BinaryOperation binary_op, T init);
+template<class ExecutionPolicy, class InputIterator, class OutputIterator, class BinaryOperation, class T>
+  OutputIterator inclusive_scan(ExecutionPolicy&& exec,
+                                InputIterator first, InputIterator last,
                                 OutputIterator result,
                                 BinaryOperation binary_op, T init);
 \end{itemdecl}
@@ -9193,6 +9305,14 @@ template<class InputIterator, class OutputIterator,
                                           OutputIterator result,
                                           UnaryOperation unary_op,
                                           T init, BinaryOperation binary_op);
+template<class ExecutionPolicy, class InputIterator, class OutputIterator,
+         class UnaryOperation,
+         class T, class BinaryOperation>
+  OutputIterator transform_exclusive_scan(ExecutionPolicy&& exec,
+                                          InputIterator first, InputIterator last,
+                                          OutputIterator result,
+                                          UnaryOperation unary_op,
+                                          T init, BinaryOperation binary_op);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9243,10 +9363,27 @@ template<class InputIterator, class OutputIterator,
                                           OutputIterator result,
                                           UnaryOperation unary_op,
                                           BinaryOperation binary_op);
+template<class ExecutionPolicy, class InputIterator, class OutputIterator,
+         class UnaryOperation,
+         class BinaryOperation>
+  OutputIterator transform_inclusive_scan(ExecutionPolicy&& exec,
+                                          InputIterator first, InputIterator last,
+                                          OutputIterator result,
+                                          UnaryOperation unary_op,
+                                          BinaryOperation binary_op);
+
 template<class InputIterator, class OutputIterator,
          class UnaryOperation,
          class BinaryOperation, class T>
   OutputIterator transform_inclusive_scan(InputIterator first, InputIterator last,
+                                          OutputIterator result,
+                                          UnaryOperation unary_op,
+                                          BinaryOperation binary_op, T init);
+template<class ExecutionPolicy, class InputIterator, class OutputIterator,
+         class UnaryOperation,
+         class BinaryOperation, class T>
+  OutputIterator transform_inclusive_scan(ExecutionPolicy&& exec,
+                                          InputIterator first, InputIterator last,
                                           OutputIterator result,
                                           UnaryOperation unary_op,
                                           BinaryOperation binary_op, T init);
@@ -9300,14 +9437,26 @@ may be non-deterministic. \tcode{transform_inclusive_scan} does not apply
 \indexlibrary{\idxcode{adjacent_difference}}%
 \begin{itemdecl}
 template <class InputIterator, class OutputIterator>
-  OutputIterator adjacent_difference(
-    InputIterator first, InputIterator last,
-    OutputIterator result);
+  OutputIterator
+    adjacent_difference(InputIterator first, InputIterator last,
+                        OutputIterator result);
+template <class ExecutionPolicy, class InputIterator, class OutputIterator>
+  OutputIterator
+    adjacent_difference(ExecutionPolicy&& exec,
+                        InputIterator first, InputIterator last,
+                        OutputIterator result);
+
 template <class InputIterator, class OutputIterator, class BinaryOperation>
-  OutputIterator adjacent_difference(
-    InputIterator first, InputIterator last,
-    OutputIterator result,
-    BinaryOperation binary_op);
+  OutputIterator
+    adjacent_difference(InputIterator first, InputIterator last,
+                        OutputIterator result,
+                        BinaryOperation binary_op);
+template <class ExecutionPolicy, class InputIterator, class OutputIterator, class BinaryOperation>
+  OutputIterator
+    adjacent_difference(ExecutionPolicy&& exec,
+                        InputIterator first, InputIterator last,
+                        OutputIterator result,
+                        BinaryOperation binary_op);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -380,7 +380,7 @@ both cases, \tcode{A2} is deduced as \tcode{double}, so
 \end{example}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{move}}%
+\indexlibrary{\idxcode{move}!function}%
 \begin{itemdecl}
 template <class T> constexpr remove_reference_t<T>&& move(T&& t) noexcept;
 \end{itemdecl}


### PR DESCRIPTION
Add a copy of the parallel algorithm signature below each corresponding
non-parallel signature in the specification for each algorithm in the
<algorithm> and <numeric> headers.  This is _mostly_ an exercise in
copy/paste - however a small subset of algorithms have wording that
either refers to the signatures obliquely, requiring a minor wording
tweak, or uses the 'Effects: as if ...' formulation, which requires a
separate specification for the parallel form to perfectly forward the
execution policy.

This change corresponds to (known to be pending) national body comments
requesting more clarity in the specification of each algorithm that has
a parallel overload.

A further tweak disambiguates the indexing of the various 'move'
functions.
