### PR TITLE
[extern.names] Use \tcode when referring to namespace std.

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2316,7 +2316,7 @@ is reserved to the implementation for use as a name with
 \indextext{\idxcode{extern ""C""}}%
 \tcode{extern "C"}
 linkage,
-both in namespace std and in the global namespace.
+both in namespace \tcode{std} and in the global namespace.
 
 \pnum
 Each function signature from the C standard library declared with


### PR DESCRIPTION
Like elsewhere.