### PR TITLE
[class, class.derived, special] Write space in 'access control' consistently in index keys.

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1707,7 +1707,7 @@ namespace shall be declared \tcode{static}. Anonymous unions declared at
 block scope shall be declared with any storage class allowed for a
 block-scope variable, or with no storage class. A storage class is not
 allowed in a declaration of an anonymous union in a class scope.
-\indextext{access~control!anonymous \tcode{union}}%
+\indextext{access control!anonymous \tcode{union}}%
 \indextext{restriction!anonymous \tcode{union}}%
 An anonymous union shall not have \tcode{private} or \tcode{protected}
 members (Clause~\ref{class.access}). An anonymous union shall not have

--- a/source/derived.tex
+++ b/source/derived.tex
@@ -424,7 +424,7 @@ $S(x,D)$ is discarded in the first merge step.
 \end{example}
 
 \pnum
-\indextext{access~control!overload~resolution~and}%
+\indextext{access control!overload~resolution~and}%
 If the name of an overloaded function is unambiguously found,
 overload resolution~(\ref{over.match}) also takes place before access
 control.

--- a/source/special.tex
+++ b/source/special.tex
@@ -56,7 +56,7 @@ Often such special member functions are called implicitly.
 \end{note}
 
 \pnum
-\indextext{access~control!member~function~and}%
+\indextext{access control!member~function~and}%
 Special member functions obey the usual access rules (Clause~\ref{class.access}).
 \begin{example}
 declaring a constructor


### PR DESCRIPTION
Other places already use a space instead of a tilde, and this distinction currently results in two separate index key nodes.