### PR TITLE
Fix lots of see/seealso references, especially regarding operators.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1665,7 +1665,8 @@ X C::arr[number];   // ill-formed:
 \end{example}
 
 \pnum
-\indextext{scope~resolution~operator}%
+\indextext{operator!scope~resolution}%
+\indextext{scope~resolution~operator|see{operator, scope~resolution}}%
 A name prefixed by the unary scope operator \tcode{::}~(\ref{expr.prim})
 is looked up in global scope, in the translation unit where it is used.
 The name shall be declared in global namespace scope or shall be a name

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -10,7 +10,7 @@
 \indextext{\idxcode{\{\}}!class declaration}%
 \indextext{\idxcode{\{\}}!class definition}%
 \indextext{type!class~and}%
-\indextext{object~class|see{also~class~object}}%
+\indextext{object~class|seealso{class~object}}%
 A class is a type.
 \indextext{name~class|see{class~name}}%
 Its name becomes a \grammarterm{class-name}~(\ref{class.name}) within its

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -2331,7 +2331,7 @@ sometype::sometype() = delete;      // ill-formed; not first declaration
 
 \rSec1[dcl.decomp]{Decomposition declarations}%
 \indextext{decomposition declaration}%
-\indextext{declaration!decomposition|see {decomposition declaration}}%
+\indextext{declaration!decomposition|see{decomposition declaration}}%
 
 \pnum
 A decomposition declaration introduces the \grammarterm{identifier}{s} of the

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6,8 +6,8 @@
 \indextext{\idxcode{operator new}|seealso{\tcode{new}}}%
 \indextext{\idxcode{operator delete}|seealso{\tcode{delete}}}%
 \indextext{usual arithmetic conversions|see{conversion, usual arithmetic}}%
-\indextext{\idxcode{==}|see{equality~operator}}%
-\indextext{\idxcode{"!=}|see{inequality~operator}}
+\indextext{\idxcode{==}|see{operator, equality}}%
+\indextext{\idxcode{"!=}|see{operator, inequality}}
 \indextext{\idxcode{static_cast}|see{cast, static}}%
 \indextext{\idxcode{dynamic_cast}|see{cast, dynamic}}%
 \indextext{\idxcode{const_cast}|see{cast, const}}%
@@ -3390,7 +3390,7 @@ necessarily be the same as that of the block if the object is an array.
 \indextext{\idxcode{new}!initialization~and}%
 \indextext{\idxcode{new}!constructor~and}%
 \indextext{\idxcode{new}!default~constructor~and}%
-\indextext{constructor, default|see{default~constructor}}%
+\indextext{default~constructor|see{constructor, default}}%
 \indextext{trivial~type}%
 \indextext{trivial~class~type}%
 A \grammarterm{new-expression} that creates an object of type \tcode{T}
@@ -3843,9 +3843,9 @@ of the cast.
 \indextext{expression!pointer-to-member}%
 \indextext{pointer~to~member}%
 \indextext{operator!pointer~to~member}%
-\indextext{\idxcode{.*}|see{pointer~to~member~operator}}%
+\indextext{\idxcode{.*}|see{operator, pointer~to~member}}%
 \indextext{operator!pointer~to~member}%
-\indextext{\idxcode{->*}|see{pointer~to~member~operator}}%
+\indextext{\idxcode{->*}|see{operator, pointer~to~member}}%
 The pointer-to-member operators \tcode{->*} and \tcode{.*} group
 left-to-right.
 
@@ -3943,12 +3943,12 @@ The multiplicative operators \tcode{*}, \tcode{/}, and \tcode{\%} group
 left-to-right.
 
 \indextext{operator!multiplication}%
-\indextext{\idxcode{*}|see{multiplication~operator}}%
+\indextext{\idxcode{*}|see{operator, multiplication}}%
 \indextext{operator!division}%
-\indextext{\idxcode{/}|see{division~operator}}%
+\indextext{\idxcode{/}|see{operator, division}}%
 \indextext{operator!remainder}%
-\indextext{\idxcode{\%}|see{remainder~operator}}%
-\indextext{remainder~operator|see{remainder~operator}}%
+\indextext{\idxcode{\%}|see{operator, remainder}}%
+\indextext{remainder~operator|see{operator, remainder}}%
 %
 \begin{bnf}
 \nontermdef{multiplicative-expression}\br
@@ -3989,10 +3989,12 @@ The additive operators \tcode{+} and \tcode{-} group left-to-right. The
 usual arithmetic conversions are performed for operands of arithmetic or
 enumeration type.
 
-\indextext{addition~operator}%
-\indextext{\idxcode{+}|see{addition~operator}}%
-\indextext{subtraction~operator}%
-\indextext{\idxcode{-}|see{subtraction~operator}}%
+\indextext{operator!addition}%
+\indextext{addition~operator|see{operator, addition}}%
+\indextext{\idxcode{+}|see{operator, addition}}%
+\indextext{operator!subtraction}%
+\indextext{subtraction~operator|see{operator, subtraction}}%
+\indextext{\idxcode{-}|see{operator, subtraction}}%
 %
 \begin{bnf}
 \nontermdef{additive-expression}\br
@@ -4093,15 +4095,15 @@ converted to the type \tcode{std::ptrdiff_t}.
 \pnum
 \indextext{expression!left-shift-operator}%
 \indextext{expression!right-shift-operator}%
-\indextext{shift~operator|see{left~shift~operator,~right~shift~operator}}%
-\indextext{operator~right~shift|see{right~shift~operator}}%
-\indextext{operator~left~shift|see{left~shift~operator}}%
+\indextext{shift~operator|see{operator, left~shift; operator, right~shift}}%
+\indextext{right~shift~operator|see{operator, right~shift}}%
+\indextext{left~shift~operator|see{operator, left~shift}}%
 The shift operators \tcode{\shl} and \tcode{\shr} group left-to-right.
 
-\indextext{left~shift~operator}%
-\indextext{\idxcode{\shl}|see{left~shift~operator}}%
-\indextext{right~shift~operator}%
-\indextext{\idxcode{\shr}|see{right~shift~operator}}%
+\indextext{operator!left~shift}%
+\indextext{\idxcode{\shl}|see{operator, left~shift}}%
+\indextext{operator!right~shift}%
+\indextext{\idxcode{\shr}|see{operator, right~shift}}%
 %
 \begin{bnf}
 \nontermdef{shift-expression}\br
@@ -4151,13 +4153,13 @@ The relational operators group left-to-right.
 \end{example}
 
 \indextext{operator!less~than}%
-\indextext{\idxcode{<}|see{less~than~operator}}%
+\indextext{\idxcode{<}|see{operator, less~than}}%
 \indextext{operator!greater~than}%
-\indextext{\idxcode{>}|see{greater~than~operator}}%
+\indextext{\idxcode{>}|see{operator, greater~than}}%
 \indextext{operator!less~than~or~equal~to}%
-\indextext{\idxcode{<=}|see{less~than~or~equal~to~operator}}%
+\indextext{\idxcode{<=}|see{operator, less~than~or~equal~to}}%
 \indextext{operator!greater~than~or~equal~to}%
-\indextext{\idxcode{>=}|see{greater~than~or~equal~operator}}%
+\indextext{\idxcode{>=}|see{operator, greater~than~or~equal~to}}%
 %
 \begin{bnf}
 \nontermdef{relational-expression}\br
@@ -4352,7 +4354,7 @@ false.
 \indextext{expression!bitwise~AND}%
 \indextext{operator!bitwise}%
 \indextext{operator!bitwise AND}%
-\indextext{\idxcode{\&}|see{bitwise~AND~operator}}%
+\indextext{\idxcode{\&}|see{operator, bitwise AND}}%
 
 \begin{bnf}
 \nontermdef{and-expression}\br
@@ -4368,7 +4370,7 @@ applies only to integral or unscoped enumeration operands.
 \rSec1[expr.xor]{Bitwise exclusive OR operator}%
 \indextext{expression!bitwise~exclusive~OR}%
 \indextext{operator!bitwise~exclusive OR}%
-\indextext{\idxcode{\exor}|see{bitwise~exclusive~OR~operator}}
+\indextext{\idxcode{\exor}|see{operator, bitwise~exclusive~OR}}
 
 \begin{bnf}
 \nontermdef{exclusive-or-expression}\br
@@ -4384,7 +4386,7 @@ operator applies only to integral or unscoped enumeration operands.
 \rSec1[expr.or]{Bitwise inclusive OR operator}%
 \indextext{expression!bitwise~inclusive~OR}%
 \indextext{operator!bitwise~inclusive OR}%
-\indextext{\idxcode{"|}|see{bitwise~inclusive~OR~operator}}
+\indextext{\idxcode{"|}|see{operator, bitwise~inclusive~OR}}
 
 \begin{bnf}
 \nontermdef{inclusive-or-expression}\br
@@ -4400,7 +4402,7 @@ operator applies only to integral or unscoped enumeration operands.
 \rSec1[expr.log.and]{Logical AND operator}%
 \indextext{expression!logical~AND}%
 \indextext{operator!logical AND}%
-\indextext{\idxcode{\&\&}|see{logical~AND~operator}}%
+\indextext{\idxcode{\&\&}|see{operator, logical~AND}}%
 
 \begin{bnf}
 \nontermdef{logical-and-expression}\br
@@ -4431,7 +4433,7 @@ value computation and side effect associated with the second expression.
 \rSec1[expr.log.or]{Logical OR operator}%
 \indextext{expression!logical~OR}%
 \indextext{operator!logical OR}%
-\indextext{\idxcode{"|"|}|see{logical~OR~operator}}%
+\indextext{\idxcode{"|"|}|see{operator, logical~OR}}%
 
 \begin{bnf}
 \nontermdef{logical-or-expression}\br
@@ -4462,7 +4464,7 @@ and side effect associated with the second expression.
 \rSec1[expr.cond]{Conditional operator}%
 \indextext{expression!conditional~operator}%
 \indextext{operator!conditional~expression}%
-\indextext{\idxcode{?:}|see{conditional~expression~operator}}%
+\indextext{\idxcode{?:}|see{operator, conditional~expression}}%
 
 \begin{bnf}
 \nontermdef{conditional-expression}\br
@@ -4797,8 +4799,9 @@ a = { 1 } = b;            // syntax error
 \rSec1[expr.comma]{Comma operator}%
 \indextext{expression!comma}%
 \indextext{operator!comma}%
-\indextext{\idxcode{,}|see{comma~operator}}%
-\indextext{sequencing~operator|see{comma~operator}}%
+\indextext{comma~operator|see{operator, comma}}%
+\indextext{\idxcode{,}|see{operator, comma}}%
+\indextext{sequencing~operator|see{operator, comma}}%
 
 \pnum
 The comma operator groups left-to-right.

--- a/source/special.tex
+++ b/source/special.tex
@@ -5,7 +5,7 @@
 
 \indextext{special~member~function|see{constructor, destructor, inline function,
 user-defined conversion, virtual function}}%
-\indextext{\idxcode{X(X\&)}|see{copy~constructor}}%
+\indextext{\idxcode{X(X\&)}|see{constructor, copy}}%
 \indextext{~@\tcode{\tilde}|see{destructor}}%
 \indextext{assignment!copy|see{assignment operator, copy}}%
 \indextext{assignment!move|see{assignment operator, move}}%
@@ -360,7 +360,7 @@ void no_opt(C* cptr) {
 \pnum
 \indextext{object~temporary|see{temporary}}%
 \indextext{temporary}%
-\indextext{optimization~of~temporary|see{elimination~of~temporary}}%
+\indextext{optimization~of~temporary|see{temporary, elimination~of}}%
 \indextext{temporary!elimination~of}%
 \indextext{temporary!implementation-defined~generation~of}%
 Temporary objects are created
@@ -438,7 +438,7 @@ void h() {
 }
 \end{codeblock}
 
-\indextext{class~object~copy|see{copy~constructor}}%
+\indextext{class~object~copy|see{constructor, copy}}%
 \indextext{constructor!copy}%
 \tcode{X(2)} is constructed in the space used to hold \tcode{f()}'s argument and
 \tcode{Y(3)} is constructed in the space used to hold \tcode{g()}'s argument.


### PR DESCRIPTION
To fix dead "links" and make the operator index entries more consistent.
