### PR TITLE
[expr.reinterpret.cast] Fix indentation artifact by adding missing % after \indextext.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2373,7 +2373,7 @@ bool b = p1 == p2;  // \tcode{b} will have the value \tcode{true}.
 \rSec2[expr.reinterpret.cast]{Reinterpret cast}
 
 \pnum
-\indextext{expression!reinterpret~cast}
+\indextext{expression!reinterpret~cast}%
 \indextext{cast!reinterpret}%
 The result of the expression \tcode{reinterpret_cast<T>(v)} is the
 result of converting the expression \tcode{v} to type \tcode{T}.


### PR DESCRIPTION
Only visual difference is that this removes the stray indentation at the start of the paragraph.