### PR TITLE
[basic, stmt, dcl.dcl] Move surrounding punctuation out of \grammarterm arguments.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -878,7 +878,7 @@ namespace N {
 A namespace member can also be referred to after the \tcode{::} scope
 resolution operator~(\ref{expr.prim}) applied to the name of its
 namespace or the name of a namespace which nominates the member's
-namespace in a \grammarterm{using-directive;} see~\ref{namespace.qual}.
+namespace in a \grammarterm{using-directive}; see~\ref{namespace.qual}.
 
 \pnum
 \indextext{scope!global namespace}%
@@ -1087,7 +1087,7 @@ a base class of the same name; see~\ref{class.member.lookup}.
 During the lookup of a name qualified by a namespace name, declarations
 that would otherwise be made visible by a \grammarterm{using-directive} can
 be hidden by declarations with the same name in the namespace containing
-the \grammarterm{using-directive;} see~(\ref{namespace.qual}).
+the \grammarterm{using-directive}; see~(\ref{namespace.qual}).
 
 \pnum
 \indextext{visibility}%

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -3012,7 +3012,7 @@ since no size was specified and there are three initializers.
 \end{example}
 An empty initializer list
 \tcode{\{\}}
-shall not be used as the \grammarterm{initializer-clause }
+shall not be used as the \grammarterm{initializer-clause}
 for an array of unknown bound.\footnote{The syntax provides for empty
 \grammarterm{initializer-list}{s},
 but nonetheless \Cpp does not have zero length arrays.}

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -214,7 +214,7 @@ The substatement in a \grammarterm{selection-statement} (each substatement,
 in the \tcode{else} form of the \tcode{if} statement) implicitly defines
 a block scope~(\ref{basic.scope}). If the substatement in a
 selection-statement is a single statement and not a
-\grammarterm{compound-statement,} it is as if it was rewritten to be a
+\grammarterm{compound-statement}, it is as if it was rewritten to be a
 compound-statement containing the original substatement.
 \begin{example}
 
@@ -459,7 +459,7 @@ through the loop.
 
 \indextext{scope!\idxgram{iteration-statement}}%
 If the substatement in an iteration-statement is a single statement and
-not a \grammarterm{compound-statement,} it is as if it was rewritten to be
+not a \grammarterm{compound-statement}, it is as if it was rewritten to be
 a compound-statement containing the original statement.
 \begin{example}
 


### PR DESCRIPTION
Btw, you may notice the inconsistency in whether parentheses are used after "see". That happens in a couple other places in the document as well, and I'll submit a separate patch for that.