### PR TITLE
[basic, class.this, algorithms] Remove parentheses after "see".

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -1265,7 +1265,7 @@ The invocations of element access functions in parallel algorithms invoked with
 an execution policy object of type \tcode{execution::sequenced_policy} all occur
 in the calling thread of execution.
 \begin{note}
-The invocations are not interleaved; see~(\ref{intro.execution}).
+The invocations are not interleaved; see~\ref{intro.execution}.
 \end{note}
 
 \pnum

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1087,7 +1087,7 @@ a base class of the same name; see~\ref{class.member.lookup}.
 During the lookup of a name qualified by a namespace name, declarations
 that would otherwise be made visible by a \grammarterm{using-directive} can
 be hidden by declarations with the same name in the namespace containing
-the \grammarterm{using-directive}; see~(\ref{namespace.qual}).
+the \grammarterm{using-directive}; see~\ref{namespace.qual}.
 
 \pnum
 \indextext{visibility}%

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1100,7 +1100,7 @@ Constructors~(\ref{class.ctor}) and destructors~(\ref{class.dtor}) shall
 not be declared \tcode{const}, \tcode{volatile} or \tcode{const}
 \tcode{volatile}. \begin{note} However, these functions can be invoked to
 create and destroy objects with cv-qualified types,
-see~(\ref{class.ctor}) and~(\ref{class.dtor}).
+see~\ref{class.ctor} and~\ref{class.dtor}.
 \end{note}
 
 \rSec2[class.static]{Static members}%


### PR DESCRIPTION
Nowhere else does the document use parentheses when "see" is written explicitly.