### PR TITLE
[optional.nullopt] Add missing 'the'.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2969,7 +2969,7 @@ In particular, \tcode{optional<T>} has a constructor with \tcode{nullopt_t} as a
 this indicates that an optional object not containing a value shall be constructed.
 
 \pnum
-Type \tcode{nullopt_t} shall not have a default constructor. It shall be a literal type. Constant \tcode{nullopt} shall be initialized with an argument of literal type.
+Type \tcode{nullopt_t} shall not have a default constructor. It shall be a literal type. The constant \tcode{nullopt} shall be initialized with an argument of literal type.
 
 \rSec2[optional.bad_optional_access]{Class \tcode{bad_optional_access}}
 


### PR DESCRIPTION
(Pure coincidence that I spotted two of these today. Unfortunately I have no way to search for these systematically.)