### PR TITLE
Special math functions editorial issues found by Matwey V. Kornilov f…

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -10081,7 +10081,7 @@ namespace std {
   float        assoc_laguerref(unsigned n, unsigned m, float x);
   long double  assoc_laguerrel(unsigned n, unsigned m, long double x);
 
-  // \ref{sf.cmath.assoc_legendre}, associated Legendre polynomials:
+  // \ref{sf.cmath.assoc_legendre}, associated Legendre functions:
   double       assoc_legendre(unsigned l, unsigned m, double x);
   float        assoc_legendref(unsigned l, unsigned m, float x);
   long double  assoc_legendrel(unsigned l, unsigned m, long double x);
@@ -10106,7 +10106,7 @@ namespace std {
   float        comp_ellint_3f(float k, float nu);
   long double  comp_ellint_3l(long double k, long double nu);
 
-  // \ref{sf.cmath.cyl_bessel}, regular modified cylindrical Bessel functions:
+  // \ref{sf.cmath.cyl_bessel_i}, regular modified cylindrical Bessel functions:
   double       cyl_bessel_i(double nu, double x);
   float        cyl_bessel_if(float nu, float x);
   long double  cyl_bessel_il(long double nu, long double x);
@@ -10374,7 +10374,7 @@ is \impldef{effect of calling associated Laguerre polynomials with \tcode{n >= 1
 if \tcode{n >= 128} or if \tcode{m >= 128}.
 \end{itemdescr}
 
-\rSec3[sf.cmath.assoc_legendre]{Associated Legendre polynomials}%
+\rSec3[sf.cmath.assoc_legendre]{Associated Legendre functions}%
 \indexlibrary{\idxcode{assoc_legendre}}%
 \indexlibrary{\idxcode{assoc_legendref}}%
 \indexlibrary{\idxcode{assoc_legendrel}}%
@@ -10541,7 +10541,7 @@ $nu$ is \tcode{nu}.
 \pnum See also \ref{sf.cmath.ellint_3}.
 \end{itemdescr}
 
-\rSec3[sf.cmath.cyl_bessel]{Regular modified cylindrical Bessel functions}%
+\rSec3[sf.cmath.cyl_bessel_i]{Regular modified cylindrical Bessel functions}%
 \indexlibrary{\idxcode{cyl_bessel_i}}%
 \indexlibrary{\idxcode{cyl_bessel_if}}%
 \indexlibrary{\idxcode{cyl_bessel_il}}%
@@ -10672,7 +10672,7 @@ The effect of calling each of these functions
 is \impldef{effect of calling irregular modified cylindrical Bessel functions with \tcode{nu >= 128}}
 if \tcode{nu >= 128}.
 
-\pnum See also \ref{sf.cmath.cyl_bessel}.
+\pnum See also \ref{sf.cmath.cyl_bessel_i}, \ref{sf.cmath.cyl_bessel_j}, \ref{sf.cmath.cyl_neumann}.
 \end{itemdescr}
 
 \rSec3[sf.cmath.cyl_neumann]{Cylindrical Neumann functions}%


### PR DESCRIPTION
…rom Sternberg Astronomical Institute, Lomonosov Moscow State University, Russia:
- Clause "Associated Legendre polynomials" is wrongly entitled. "Associated Legendre functions" would be more appropriate here. Though "Associated Legendre polynomials" term is sometimes used it is formally wrong term. A polynomial (by definition) is a particular kind of function which can be represented using only finite number of additions, multiplications and exponentiations to a non-negative power, i.e. in canonical form of `SUM(AiX^i)`. Obviously, some of P^m_l are not polynomials. For instance, for m=l=1, `P11(x) == sqrt(1 − x*x)` is not representable as `SUM(AiX^i)`. See for reference: Abramowitz and Stegun, Chapter 8 "Legendre Functions".
- "[sf.cmath.cyl_bessel]" is a bad name for the tag. "[sf.cmath.cyl_bessel]" sounds like "Bessel functions" and when people say "Bessel functions" they usually mean Jν from [sf.cmath.cyl_bessel_j]. Replaced "[sf.cmath.cyl_bessel]" with "[sf.cmath.cyl_bessel_i]".
- "[sf.cmath.cyl_bessel_k]" misses references to "[sf.cmath.cyl_bessel_j]" and "[sf.cmath.cyl_neumann]" in the "See also" section. In [sf.cmath.cyl_bessel_j] Jv(x) is defined, in [sf.cmath.cyl_neumann] Nν(x) is defined - both of them are used in the "Returns:" section of the [sf.cmath.cyl_bessel_k].
