### PR TITLE
[whole standard] fix typos (#647)

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3138,7 +3138,7 @@ negative value afterwards.} is less than zero;
 
 \item
 its value is such that the size of the allocated object would exceed the
-\impldef{maximum size of an allocated object} limit (annex~\ref{implimits}); or
+\impldef{maximum size of an allocated object} limit (Annex~\ref{implimits}); or
 
 \item
 the \grammarterm{new-initializer} is a \grammarterm{braced-init-list} and the

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1416,7 +1416,7 @@ allocators.
 \pnum
 The template definitions in the \Cpp standard library
 refer to various named requirements whose details are set out in
-tables~\ref{tab:equalitycomparable}--\ref{tab:destructible}.
+Tables~\ref{tab:equalitycomparable}--\ref{tab:destructible}.
 In these tables, \tcode{T} is an object or reference type to be
 supplied by a \Cpp program instantiating a template;
 \tcode{a},

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -693,7 +693,7 @@ namespace std::regex_constants {
 \indexlibrary{\idxcode{syntax_option_type}!\idxcode{egrep}}%
 The type \tcode{syntax_option_type} is an \impldef{type of \tcode{syntax_option_type}} bitmask
 type~(\ref{bitmask.types}). Setting its elements has the effects listed in
-table~\ref{tab:re:syntaxoption}.  A valid value of type
+Table~\ref{tab:re:syntaxoption}.  A valid value of type
 \tcode{syntax_option_type} shall have at most one of the grammar elements
 \tcode{ECMAScript}, \tcode{basic}, \tcode{extended}, \tcode{awk}, \tcode{grep}, \tcode{egrep}, set.
 If no grammar element is set, the default grammar is \tcode{ECMAScript}.

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -4813,7 +4813,7 @@ constexpr basic_string_view(const charT* str);
 \pnum
 \effects
 Constructs a \tcode{basic_string_view}, with the postconditions
-in table~\ref{tab:string.view.ctr.2}.
+in Table~\ref{tab:string.view.ctr.2}.
 \begin{libefftabvaluenarrow}{\tcode{basic_string_view(const charT*)} effects}{tab:string.view.ctr.2}
 \tcode{data_} & \tcode{str} \\
 \tcode{size_} & \tcode{traits::length(str)} \\
@@ -4836,7 +4836,7 @@ constexpr basic_string_view(const charT* str, size_type len);
 
 \pnum
 \effects
-Constructs a \tcode{basic_string_view}, with the postconditions in table~\ref{tab:string.view.ctr.3}.
+Constructs a \tcode{basic_string_view}, with the postconditions in Table~\ref{tab:string.view.ctr.3}.
 \begin{libefftabvaluenarrow}{\tcode{basic_string_view(const charT*, size_type)} effects}{tab:string.view.ctr.3}
 \tcode{data_} & \tcode{str} \\
 \tcode{size_} & \tcode{len} \\
@@ -5468,7 +5468,7 @@ Uses \tcode{traits::eq()}.
 \pnum
 Let \tcode{S} be \tcode{basic_string_view<charT, traits>}, and \tcode{sv} be an instance of \tcode{S}.
 Implementations shall provide sufficient additional overloads marked \tcode{constexpr} and \tcode{noexcept}
-so that an object \tcode{t} with an implicit conversion to \tcode{S} can be compared according to table~\ref{tab:string.view.comparison.overloads}.
+so that an object \tcode{t} with an implicit conversion to \tcode{S} can be compared according to Table~\ref{tab:string.view.comparison.overloads}.
 \begin{libtab2}{Additional \tcode{basic_string_view} comparison overloads}{tab:string.view.comparison.overloads}{cc}{Expression}{Equivalent to}
 \tcode{t == sv} & \tcode{S(t) == sv} \\
 \tcode{sv == t} & \tcode{sv == S(t)} \\


### PR DESCRIPTION
- [re.synopt, string.view.cons, string.view.comparison] table~/ref -> Table~/ref
- [expr.new] annex~/ref -> Annex~/ref
- [utility.arg.requirements] tables~/ref -> Tables~/ref
