### PR TITLE
[stmt.iter] Remove superfluous and incorrect note

### DIFF
--- a/source/statements.tex
+++ b/source/statements.tex
@@ -479,12 +479,6 @@ while (--x >= 0) {
 Thus after the \tcode{while} statement, \tcode{i} is no longer in scope.
 \end{example}
 
-\pnum
-\begin{note}
-The requirements on \grammarterm{}{condition}{s} in iteration statements are
-described in~\ref{stmt.select}.
-\end{note}
-
 \rSec2[stmt.while]{The \tcode{while} statement}%
 \indextext{statement!\idxcode{while}}
 


### PR DESCRIPTION
The original note has become obsolete with f40f23d2c9b8de9eeeb781c4e7b90d056750535f.