### PR TITLE
[associative.reqmts] Fully qualify 'mapped_type'

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -1581,7 +1581,7 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
                         &
   compile time \\ \rowsep
 
-\tcode{mapped_type} (\tcode{map} and \tcode{multimap} only) &
+\tcode{X::mapped_type} (\tcode{map} and \tcode{multimap} only) &
   \tcode{T}             &
                         &
   compile time          \\ \rowsep


### PR DESCRIPTION
In the table most types are defined as `X::key_type`, `X::value_type` etc., apart from `mapped_type`, which I assume is a typo.