### PR TITLE
[associative.reqmts, unord.req] insert_return_type only for unique keys

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -1615,7 +1615,7 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
  see~\ref{container.node} &
  compile time \\ \rowsep
 
-\tcode{X::insert_return_type} &
+\tcode{X::insert_return_type} (\tcode{map} and \tcode{set} only) &
  a class type used to describe the results of inserting a
  \tcode{node_type} that includes at least the following non-static
  public data members:\br
@@ -2258,7 +2258,7 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
  see~\ref{container.node} &
  compile time \\ \rowsep
 %
-\tcode{X::insert_return_type} &
+\tcode{X::insert_return_type} (\tcode{unordered_map} and \tcode{unordered_set} only) &
  a class type used to describe the results of inserting a
  \tcode{node_type} that includes at least the following non-static
  public data members:\br


### PR DESCRIPTION
The requirements for associative and unordered associative containers require `insert_return_type` for all containers, but it's only defined for containers with unique keys.

I'm not sure about the wording, I followed the example of other entries in the table which say things like (map and multimap only), although it might be better to say it's only for containers that support unique keys.

I think this is an editorial change, because it just changes the requirements to match what's specified elsewhere.