### PR TITLE
OK, error, ambiguous consistency of comments in examples.

### DIFF
--- a/source/access.tex
+++ b/source/access.tex
@@ -88,8 +88,8 @@ public:
 };
 
 void f() {
-  A::BB x;          // OK, typedef name \tcode{A::BB} is public
-  A::B y;           // access error, \tcode{A::B} is private
+  A::BB x;          // OK: typedef name \tcode{A::BB} is public
+  A::B y;           // access error: \tcode{A::B} is private
 }
 \end{codeblock}
 \end{note}
@@ -187,7 +187,7 @@ protected:
 template <class U, class V = typename U::TT>
 class D : public U { };
 
-D <C<B> >* d;       // access error, C::TT is protected
+D <C<B> >* d;       // access error: C::TT is protected
 \end{codeblock}
 \end{example}
 
@@ -657,7 +657,7 @@ class X {
 };
 
 class Y {
-  int v[X::a];      // OK, \tcode{Y} is a friend of \tcode{X}
+  int v[X::a];      // OK: \tcode{Y} is a friend of \tcode{X}
 };
 
 class Z {
@@ -840,15 +840,15 @@ void f() {
   class Y;
   extern void b();
   class A {
-  friend class X;   // OK, but \tcode{X} is a local class, not \tcode{::X}
+  friend class X;   // OK: but \tcode{X} is a local class, not \tcode{::X}
   friend class Y;   // OK
-  friend class Z;   // OK, introduces local class \tcode{Z}
-  friend void a();  // error, \tcode{::a} is not considered
+  friend class Z;   // OK: introduces local class \tcode{Z}
+  friend void a();  // error: \tcode{::a} is not considered
   friend void b();  // OK
   friend void c();  // error
   };
-  X* px;            // OK, but \tcode{::X} is found
-  Z* pz;            // error, no \tcode{Z} is found
+  X* px;            // OK: but \tcode{::X} is found
+  Z* pz;            // error: no \tcode{Z} is found
 }
 \end{codeblock}
 \end{example}

--- a/source/access.tex
+++ b/source/access.tex
@@ -840,14 +840,14 @@ void f() {
   class Y;
   extern void b();
   class A {
-  friend class X;   // OK: but \tcode{X} is a local class, not \tcode{::X}
+  friend class X;   // OK, but \tcode{X} is a local class, not \tcode{::X}
   friend class Y;   // OK
   friend class Z;   // OK: introduces local class \tcode{Z}
   friend void a();  // error: \tcode{::a} is not considered
   friend void b();  // OK
   friend void c();  // error
   };
-  X* px;            // OK: but \tcode{::X} is found
+  X* px;            // OK, but \tcode{::X} is found
   Z* pz;            // error: no \tcode{Z} is found
 }
 \end{codeblock}

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3594,7 +3594,7 @@ int  arr[10];                   // now the type of \tcode{arr} is complete
 
 X x;
 void bar() {
-  xp = &x;                      // OK; type is ``pointer to \tcode{X}''
+  xp = &x;                      // OK: type is ``pointer to \tcode{X}''
   arrp = &arr;                  // ill-formed: different types
   xp++;                         // OK:  \tcode{X} is complete
   arrp++;                       // ill-formed: \tcode{UNKA} can't be completed

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1950,7 +1950,7 @@ namespace C {
   using namespace A;
   using namespace B;
   int i = C::x;     // OK: \tcode{A::x} (of type \tcode{int} )
-  int j = C::y;     // ambiguous, \tcode{A::y} or \tcode{B::y}
+  int j = C::y;     // ambiguous: \tcode{A::y} or \tcode{B::y}
 }
 \end{codeblock}
 \end{example}

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -929,7 +929,7 @@ struct Y {
 
 typedef int I;
 class D {
-  typedef I I;                      // error: even though no reordering involved
+  typedef I I;                      // error, even though no reordering involved
 };
 \end{codeblock}
 \end{example}

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -914,7 +914,7 @@ enum { i = 1 };
 class X {
   char  v[i];                       // error: \tcode{i} refers to \tcode{::i}
                                     // but when reevaluated is \tcode{X::i}
-  int  f() { return sizeof(c); }    //  OK: \tcode{X::c}
+  int  f() { return sizeof(c); }    // OK: \tcode{X::c}
   char  c;
   enum { i = 2 };
 };

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -929,7 +929,7 @@ struct Y {
 
 typedef int I;
 class D {
-  typedef I I;                      // error, even though no reordering involved
+  typedef I I;                      // error: even though no reordering involved
 };
 \end{codeblock}
 \end{example}
@@ -1753,7 +1753,7 @@ A::A() { }
 B::B() { }
 
 B::A ba;            // object of type \tcode{A}
-A::A a;             // error, \tcode{A::A} is not a type name
+A::A a;             // error: \tcode{A::A} is not a type name
 struct A::A a2;     // object of type \tcode{A}
 \end{codeblock}
 \end{example}
@@ -1949,7 +1949,7 @@ namespace B {
 namespace C {
   using namespace A;
   using namespace B;
-  int i = C::x;     // OK, \tcode{A::x} (of type \tcode{int} )
+  int i = C::x;     // OK: \tcode{A::x} (of type \tcode{int} )
   int j = C::y;     // ambiguous, \tcode{A::y} or \tcode{B::y}
 }
 \end{codeblock}
@@ -1977,7 +1977,7 @@ namespace A {
   }
   using namespace B;
 }
-void A::f1(int){ }  // ill-formed, \tcode{f1} is not a member of \tcode{A}
+void A::f1(int){ }  // ill-formed: \tcode{f1} is not a member of \tcode{A}
 \end{codeblock}
 
 \end{example} However, in such namespace member declarations, the
@@ -2000,7 +2000,7 @@ namespace C {
 
 using namespace A;
 using namespace C::D;
-void B::f1(int){ }  // OK, defines \tcode{A::B::f1(int)}
+void B::f1(int){ }  // OK: defines \tcode{A::B::f1(int)}
 \end{codeblock}
 \end{example}
 \indextext{lookup!qualified~name|)}%
@@ -3325,7 +3325,7 @@ struct D2 : B { void f(); };
 void B::mutate() {
   new (this) D2;    // reuses storage --- ends the lifetime of \tcode{*this}
   f();              // undefined behavior
-  ... = this;       // OK, \tcode{this} points to valid memory
+  ... = this;       // OK: \tcode{this} points to valid memory
 }
 
 void g() {

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -316,7 +316,7 @@ simply a single function \tcode{f()} twice. For the same reason,
 
 \begin{codeblock}
 struct S { int a; };
-struct S { int a; };            // error, double definition
+struct S { int a; };            // error: double definition
 \end{codeblock}
 
 is ill-formed because it defines \tcode{S} twice.
@@ -781,7 +781,7 @@ struct T2 { int c; double d; };
 union U { T1 t1; T2 t2; };
 int f() {
   U u = { { 1, 2 } }; // active member is \tcode{t1}
-  return u.t2.c;      // OK, as if \tcode{u.t1.a} were nominated
+  return u.t2.c;      // OK: as if \tcode{u.t1.a} were nominated
 }
 \end{codeblock}
 \end{example}
@@ -1635,7 +1635,7 @@ int f() {
 struct X { const int a; int b; };
 union Y { X x; int k; };
 void g() {
-  Y y = { { 1, 2 } }; // OK, \tcode{y.x} is active union member (\ref{class.mem})
+  Y y = { { 1, 2 } }; // OK: \tcode{y.x} is active union member (\ref{class.mem})
   int n = y.x.a;
   y.k = 4;   // OK: ends lifetime of \tcode{y.x}, \tcode{y.k} is active member of union
   y.x.b = n; // undefined behavior: \tcode{y.x.b} modified outside its lifetime,

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1578,12 +1578,12 @@ for the affected types:
 struct derived;
 struct base {
   friend struct derived;
-private: 
+private:
   base();
 };
 struct derived : base {};
 
-derived d1{};       // Error. The code was well-formed before.
+derived d1{};       // error: the code was well-formed before.
 derived d2;         // still OK
 \end{codeblock}
 

--- a/source/conversions.tex
+++ b/source/conversions.tex
@@ -154,7 +154,7 @@ auto f() {
 }
 auto g = f();
 int m = g(false); // undefined behavior due to access of \tcode{x.n} outside its lifetime
-int n = g(true);  // OK, does not access \tcode{y.n}
+int n = g(true);  // OK: does not access \tcode{y.n}
 \end{codeblock}
 \end{example}
 The result of the conversion is determined according to the
@@ -231,7 +231,7 @@ see~\ref{class.dtor}.
 \begin{example}
 \begin{codeblock}
 struct X { int n; };
-int k = X().n; // OK, \tcode{X()} prvalue is converted to xvalue
+int k = X().n; // OK: \tcode{X()} prvalue is converted to xvalue
 \end{codeblock}
 \end{example}
 

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -906,7 +906,7 @@ the program is ill-formed; no diagnostic required.
 \begin{codeblock}
 constexpr int f(bool b)
   { return b ? throw 0 : 0; }               // OK
-constexpr int f() { return f(true); }       // ill-formed, no diagnostic required
+constexpr int f() { return f(true); }       // ill-formed: no diagnostic required
 
 struct B {
   constexpr B(int x) : i(0) { }             // \tcode{x} is unused
@@ -916,7 +916,7 @@ struct B {
 int global;
 
 struct D : B {
-  constexpr D() : B(global) { }             // ill-formed, no diagnostic required
+  constexpr D() : B(global) { }             // ill-formed: no diagnostic required
                                             // lvalue-to-rvalue conversion on non-constant \tcode{global}
 };
 \end{codeblock}
@@ -1677,8 +1677,8 @@ non-discarded \tcode{return} statements, the return type is deduced as though fr
 body.
 \begin{example}
 \begin{codeblock}
-auto  f() { } // OK, return type is \tcode{void}
-auto* g() { } // error, cannot deduce \tcode{auto*} from \tcode{void()}
+auto  f() { } // OK: return type is \tcode{void}
+auto* g() { } // error: cannot deduce \tcode{auto*} from \tcode{void()}
 \end{codeblock}
 \end{example}
 
@@ -1690,14 +1690,14 @@ from that statement can be used in the rest of the function, including in other
 \tcode{return} statements.
 \begin{example}
 \begin{codeblock}
-auto n = n;            // error, \tcode{n}'s type is unknown
+auto n = n;            // error: \tcode{n}'s type is unknown
 auto f();
-void g() { &f; }       // error, \tcode{f}'s return type is unknown
+void g() { &f; }       // error: \tcode{f}'s return type is unknown
 auto sum(int i) {
   if (i == 1)
     return i;          // \tcode{sum}'s return type is \tcode{int}
   else
-    return sum(i-1)+i; // OK, \tcode{sum}'s return type has been deduced
+    return sum(i-1)+i; // OK: \tcode{sum}'s return type has been deduced
 }
 \end{codeblock}
 \end{example}
@@ -1729,19 +1729,19 @@ placeholder, not a deduced type.
 auto f();
 auto f() { return 42; } // return type is \tcode{int}
 auto f();               // OK
-int f();                // error, cannot be overloaded with \tcode{auto f()}
-decltype(auto) f();     // error, \tcode{auto} and \tcode{decltype(auto)} don't match
+int f();                // error: cannot be overloaded with \tcode{auto f()}
+decltype(auto) f();     // error: \tcode{auto} and \tcode{decltype(auto)} don't match
 
 template <typename T> auto g(T t) { return t; } // \#1
-template auto g(int);                           // OK, return type is \tcode{int}
-template char g(char);                          // error, no matching template
-template<> auto g(double);                      // OK, forward declaration with unknown return type
+template auto g(int);                           // OK: return type is \tcode{int}
+template char g(char);                          // error: no matching template
+template<> auto g(double);                      // OK: forward declaration with unknown return type
 
-template <class T> T g(T t) { return t; } // OK, not functionally equivalent to \#1
-template char g(char);                    // OK, now there is a matching template
+template <class T> T g(T t) { return t; } // OK: not functionally equivalent to \#1
+template char g(char);                    // OK: now there is a matching template
 template auto g(float);                   // still matches \#1
 
-void h() { return g(42); } // error, ambiguous
+void h() { return g(42); } // error: ambiguous
 
 template <typename T> struct A {
   friend T frf(T);
@@ -1877,9 +1877,9 @@ decltype(auto) x4d = (i);      // \tcode{decltype(x4d)} is \tcode{int\&}
 auto           x5a = f();      // \tcode{decltype(x5a)} is \tcode{int}
 decltype(auto) x5d = f();      // \tcode{decltype(x5d)} is \tcode{int\&\&}
 auto           x6a = { 1, 2 }; // \tcode{decltype(x6a)} is \tcode{std::initializer_list<int>}
-decltype(auto) x6d = { 1, 2 }; // error, \tcode{\{ 1, 2 \}} is not an expression
+decltype(auto) x6d = { 1, 2 }; // error: \tcode{\{ 1, 2 \}} is not an expression
 auto          *x7a = &i;       // \tcode{decltype(x7a)} is \tcode{int*}
-decltype(auto)*x7d = &i;       // error, declared type is not plain \tcode{decltype(auto)}
+decltype(auto)*x7d = &i;       // error: declared type is not plain \tcode{decltype(auto)}
 \end{codeblock}
 \end{example}
 
@@ -1915,9 +1915,9 @@ template<class Iter>
 container(Iter b, Iter e) -> container<typename std::iterator_traits<Iter>::value_type>;
 std::vector<double> v = { /* ... */};
 
-container c(7);                         // OK, deduces \tcode{int} for \tcode{T}
-auto d = container(v.begin(), v.end()); // OK, deduces \tcode{double} for \tcode{T}
-container e{5, 6};                      // error, \tcode{int} is not an iterator
+container c(7);                         // OK: deduces \tcode{int} for \tcode{T}
+auto d = container(v.begin(), v.end()); // OK: deduces \tcode{double} for \tcode{T}
+container e{5, 6};                      // error: \tcode{int} is not an iterator
 \end{codeblock}
 \end{example}
 
@@ -3195,7 +3195,7 @@ namespace A {
     }
     using namespace A::B::C;
     void f1() {
-      i = 5;        // OK, \tcode{C::i} visible in \tcode{B} and hides \tcode{A::i}
+      i = 5;        // OK: \tcode{C::i} visible in \tcode{B} and hides \tcode{A::i}
     }
   }
   namespace D {
@@ -3580,7 +3580,7 @@ namespace A {
 
 namespace B {
   extern "C" int f();               // \tcode{A::f} and \tcode{B::f} refer to the same function
-  extern "C" int g() { return 1; }  // ill-formed, the function \tcode{g}
+  extern "C" int g() { return 1; }  // ill-formed: the function \tcode{g}
                                     // with C language linkage has two definitions
 }
 

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3202,7 +3202,7 @@ namespace A {
     using namespace B;
     using namespace C;
     void f2() {
-      i = 5;        // ambiguous, \tcode{B::C::i} or \tcode{A::i}?
+      i = 5;        // ambiguous: \tcode{B::C::i} or \tcode{A::i}?
     }
   }
   void f3() {
@@ -3349,7 +3349,7 @@ namespace D {       // namespace extension
 }
 
 void f() {
-  d1++;             // error: ambiguous \tcode{::d1} or \tcode{D::d1}?
+  d1++;             // error: ambiguous: \tcode{::d1} or \tcode{D::d1}?
   ::d1++;           // OK
   D::d1++;          // OK
   d2++;             // OK: \tcode{D::d2}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -154,7 +154,7 @@ declaration.
 
 \begin{codeblock}
 enum { };           // ill-formed
-typedef class { };  //  ill-formed
+typedef class { };  // ill-formed
 \end{codeblock}
 \end{example}
 
@@ -906,7 +906,7 @@ the program is ill-formed; no diagnostic required.
 \begin{codeblock}
 constexpr int f(bool b)
   { return b ? throw 0 : 0; }               // OK
-constexpr int f() { return f(true); }       // ill-formed: no diagnostic required
+constexpr int f() { return f(true); }       // ill-formed, no diagnostic required
 
 struct B {
   constexpr B(int x) : i(0) { }             // \tcode{x} is unused
@@ -916,7 +916,7 @@ struct B {
 int global;
 
 struct D : B {
-  constexpr D() : B(global) { }             // ill-formed: no diagnostic required
+  constexpr D() : B(global) { }             // ill-formed, no diagnostic required
                                             // lvalue-to-rvalue conversion on non-constant \tcode{global}
 };
 \end{codeblock}
@@ -1677,7 +1677,7 @@ non-discarded \tcode{return} statements, the return type is deduced as though fr
 body.
 \begin{example}
 \begin{codeblock}
-auto  f() { } // OK: return type is \tcode{void}
+auto  f() { } // OK, return type is \tcode{void}
 auto* g() { } // error: cannot deduce \tcode{auto*} from \tcode{void()}
 \end{codeblock}
 \end{example}
@@ -1733,7 +1733,7 @@ int f();                // error: cannot be overloaded with \tcode{auto f()}
 decltype(auto) f();     // error: \tcode{auto} and \tcode{decltype(auto)} don't match
 
 template <typename T> auto g(T t) { return t; } // \#1
-template auto g(int);                           // OK: return type is \tcode{int}
+template auto g(int);                           // OK, return type is \tcode{int}
 template char g(char);                          // error: no matching template
 template<> auto g(double);                      // OK: forward declaration with unknown return type
 

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1466,7 +1466,7 @@ template<class T> auto q(T)
   -> decltype((h<T>()));        // does not force completion of \tcode{A<T>}; \tcode{A<T>::\~{}A()} is
                                 // not implicitly used within the context of this \grammarterm{decltype-specifier}
 void r() {
-  q(42);                        // Error: deduction against \tcode{q} succeeds, so overload resolution
+  q(42);                        // error: deduction against \tcode{q} succeeds, so overload resolution
                                 // selects the specialization ``\tcode{q(T) -> decltype((h<T>())) [with T=int]}''.
                                 // The return type is \tcode{A<int>}, so a temporary is introduced and its
                                 // destructor is used, so the program is ill-formed.
@@ -3851,7 +3851,7 @@ were omitted.
 struct alignas(8) S {};
 struct alignas(1) U {
   S s;
-};   // Error: \tcode{U} specifies an alignment that is less strict than
+};   // error: \tcode{U} specifies an alignment that is less strict than
      // if the \tcode{alignas(1)} were omitted.
 \end{codeblock}
 \end{example}

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -620,7 +620,7 @@ Each is unacceptable because it would either change the value of an object decla
 or allow it to be changed through a cv-unqualified pointer later, for example:
 
 \begin{codeblock}
-*ppc = &ci;         // OK: but would make \tcode{p} point to \tcode{ci} ...
+*ppc = &ci;         // OK, but would make \tcode{p} point to \tcode{ci} ...
                     // ... because of previous error
 *p = 5;             // clobber \tcode{ci}
 \end{codeblock}
@@ -2268,7 +2268,7 @@ initialization with
 
 \begin{codeblock}
 struct onlydouble {
-  onlydouble() = delete;              // OK: but redundant
+  onlydouble() = delete;              // OK, but redundant
   onlydouble(std::intmax_t) = delete;
   onlydouble(double);
 };
@@ -2734,7 +2734,7 @@ value.
 \begin{codeblock}
   int f(bool b) {
     unsigned char c;
-    unsigned char d = c; // OK: \tcode{d} has an indeterminate value
+    unsigned char d = c; // OK, \tcode{d} has an indeterminate value
     int e = d;           // undefined behavior
     return b ? d : 0;    // undefined behavior if \tcode{b} is \tcode{true}
   }

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -1949,7 +1949,7 @@ class X {
   int a;
   int mem1(int i = a);          // error: non-static member \tcode{a}
                                 // used as default argument
-  int mem2(int i = b);          // OK;  use \tcode{X::b}
+  int mem2(int i = b);          // OK:  use \tcode{X::b}
   static int b;
 };
 \end{codeblock}
@@ -3904,7 +3904,7 @@ to the underlying type of \tcode{T}, the program is ill-formed.
 enum byte : unsigned char { };
 byte b { 42 };                      // OK
 byte c = { 42 };                    // error
-byte d = byte{ 42 };                // OK; same value as \tcode{b}
+byte d = byte{ 42 };                // OK: same value as \tcode{b}
 byte e { -1 };                      // error
 
 struct A { byte b; };

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -620,7 +620,7 @@ Each is unacceptable because it would either change the value of an object decla
 or allow it to be changed through a cv-unqualified pointer later, for example:
 
 \begin{codeblock}
-*ppc = &ci;         // OK, but would make \tcode{p} point to \tcode{ci} ...
+*ppc = &ci;         // OK: but would make \tcode{p} point to \tcode{ci} ...
                     // ... because of previous error
 *p = 5;             // clobber \tcode{ci}
 \end{codeblock}
@@ -1780,12 +1780,12 @@ same value).
 \begin{example}
 
 \begin{codeblock}
-void g(int = 0, ...);           // OK, ellipsis is not a parameter so it can follow
+void g(int = 0, ...);           // OK: ellipsis is not a parameter so it can follow
                                 // a parameter with a default argument
 void f(int, int);
 void f(int, int = 7);
 void h() {
-  f(3);                         // OK, calls \tcode{f(3, 7)}
+  f(3);                         // OK: calls \tcode{f(3, 7)}
   void f(int = 1, int);         // error: does not use default
                                 // from surrounding scope
 }
@@ -1793,12 +1793,12 @@ void m() {
   void f(int, int);             // has no defaults
   f(4);                         // error: wrong number of arguments
   void f(int, int = 5);         // OK
-  f(4);                         // OK, calls \tcode{f(4, 5);}
+  f(4);                         // OK: calls \tcode{f(4, 5);}
   void f(int, int = 5);         // error: cannot redefine, even to
                                 // same value
 }
 void n() {
-  f(6);                         // OK, calls \tcode{f(6, 7)}
+  f(6);                         // OK: calls \tcode{f(6, 7)}
 }
 \end{codeblock}
 \end{example}
@@ -1929,7 +1929,7 @@ int f(int a, int b = a);            // error: parameter \tcode{a}
                                     // used as default argument
 typedef int I;
 int g(float I, int b = I(2));       // error: parameter \tcode{I} found
-int h(int a, int b = sizeof(a));    // OK, unevaluated operand
+int h(int a, int b = sizeof(a));    // OK: unevaluated operand
 \end{codeblock}
 \end{example}
 A non-static member shall not appear in a default argument unless it appears as
@@ -1969,7 +1969,7 @@ int f(int = 0);
 
 void h() {
   int j = f(1);
-  int k = f();                  // OK, means \tcode{f(0)}
+  int k = f();                  // OK: means \tcode{f(0)}
 }
 
 int (*p1)(int) = &f;
@@ -2007,7 +2007,7 @@ struct B : public A {
 void m() {
   B* pb = new B;
   A* pa = pb;
-  pa->f();          // OK, calls \tcode{pa->B::f(7)}
+  pa->f();          // OK: calls \tcode{pa->B::f(7)}
   pb->f();          // error: wrong number of arguments for \tcode{B::f()}
 }
 \end{codeblock}
@@ -2268,7 +2268,7 @@ initialization with
 
 \begin{codeblock}
 struct onlydouble {
-  onlydouble() = delete;              // OK, but redundant
+  onlydouble() = delete;              // OK: but redundant
   onlydouble(std::intmax_t) = delete;
   onlydouble(double);
 };
@@ -2285,8 +2285,8 @@ struct sometype {
   void* operator new(std::size_t) = delete;
   void* operator new[](std::size_t) = delete;
 };
-sometype* p = new sometype;     // error, deleted class \tcode{operator new}
-sometype* q = new sometype[3];  // error, deleted class \tcode{operator new[]}
+sometype* p = new sometype;     // error: deleted class \tcode{operator new}
+sometype* q = new sometype[3];  // error: deleted class \tcode{operator new[]}
 \end{codeblock}
 \end{example}
 
@@ -2304,7 +2304,7 @@ struct moveonly {
   ~moveonly() = default;
 };
 moveonly* p;
-moveonly q(*p); // error, deleted copy constructor
+moveonly q(*p); // error: deleted copy constructor
 \end{codeblock}
 \end{example}
 
@@ -2734,7 +2734,7 @@ value.
 \begin{codeblock}
   int f(bool b) {
     unsigned char c;
-    unsigned char d = c; // OK, \tcode{d} has an indeterminate value
+    unsigned char d = c; // OK: \tcode{d} has an indeterminate value
     int e = d;           // undefined behavior
     return b ? d : 0;    // undefined behavior if \tcode{b} is \tcode{true}
   }
@@ -4014,7 +4014,7 @@ void f() {
 
 struct A {
   std::initializer_list<int> i4;
-  A() : i4{ 1, 2, 3 } {}  // ill-formed, would create a dangling reference
+  A() : i4{ 1, 2, 3 } {}  // ill-formed: would create a dangling reference
 };
 \end{codeblock}
 
@@ -4063,7 +4063,7 @@ list-initializations.\end{note} \begin{example}
 int x = 999;              // x is not a constant expression
 const int y = 999;
 const int z = 99;
-char c1 = x;              // OK, though it might narrow (in this case, it does narrow)
+char c1 = x;              // OK: though it might narrow (in this case, it does narrow)
 char c2{x};               // error: might narrow
 char c3{y};               // error: narrows (assuming \tcode{char} is 8 bits)
 char c4{z};               // OK: no narrowing needed

--- a/source/derived.tex
+++ b/source/derived.tex
@@ -477,7 +477,7 @@ void f(D* pd) {
   pd->v++;          // OK: only one \tcode{v} (virtual)
   pd->s++;          // OK: only one \tcode{s} (static)
   int i = pd->e;    // OK: only one \tcode{e} (enumerator)
-  pd->a++;          // error, ambiguous: two \tcode{a}{s} in \tcode{D}
+  pd->a++;          // error: ambiguous: two \tcode{a}{s} in \tcode{D}
 }
 \end{codeblock}
 \end{example}
@@ -544,7 +544,7 @@ struct D : B, C { };
 void g() {
   D d;
   B* pb = &d;
-  A* pa = &d;       // error, ambiguous: \tcode{C}'s \tcode{A} or \tcode{B}'s \tcode{A}?
+  A* pa = &d;       // error: ambiguous: \tcode{C}'s \tcode{A} or \tcode{B}'s \tcode{A}?
   V* pv = &d;       // OK: only one \tcode{V} subobject
 }
 \end{codeblock}

--- a/source/derived.tex
+++ b/source/derived.tex
@@ -414,7 +414,7 @@ struct E: public virtual C { char x; }; // S(x,E) = \{ \{ \tcode{E::x} \}, \{ \t
 struct F: public D, public E { };       // S(x,F) = S(x,E)
 int main() {
   F f;
-  f.x = 0;                              // OK, lookup finds \tcode{E::x}
+  f.x = 0;                              // OK: lookup finds \tcode{E::x}
 }
 \end{codeblock}
 

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -1035,7 +1035,7 @@ when execution of the initial function of a thread exits via
 an exception~(\ref{thread.thread.constr}), or
 
 \item%
-for a parallel algorithm whose \tcode{ExecutionPolicy} specifies such
+for parallel algorithms whose \tcode{ExecutionPolicy} specify such
 behavior~(\ref{execpol.seq}, \ref{execpol.par}, \ref{execpol.parunseq}),
 when execution of an element access function~(\ref{algorithms.parallel.defns})
 of the parallel algorithm exits via an exception~(\ref{algorithms.parallel.exceptions}), or

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -685,7 +685,7 @@ static_assert(add(one)(zero)() == one()); // OK
 // cannot perform an lvalue-to-rvalue conversion on one of its subobjects (that represents its capture)
 // in a constant expression.
 auto two = monoid(2);
-assert(two() == 2); // OK, not a constant expression.
+assert(two() == 2); // OK: not a constant expression.
 static_assert(add(one)(one)() == two()); // ill-formed: \tcode{two()} is not a constant expression
 static_assert(add(one)(one)() == monoid(2)()); // OK
 \end{codeblock}
@@ -2573,7 +2573,7 @@ of a \tcode{const_cast} refers to the original entity.
 typedef int *A[3];               // array of 3 pointer to \tcode{int}
 typedef const int *const CA[3];  // array of 3 const pointer to \tcode{const int}
 
-CA &&r = A{}; // OK, reference binds to temporary array object after qualification conversion to type \tcode{CA}
+CA &&r = A{}; // OK: reference binds to temporary array object after qualification conversion to type \tcode{CA}
 A &&r1 = const_cast<A>(CA{});   // error: temporary array decayed to pointer
 A &&r2 = const_cast<A&&>(CA{}); // OK
 \end{codeblock}
@@ -4982,8 +4982,8 @@ the reference would be an odr-use~(\ref{basic.def.odr}, \ref{expr.prim.lambda});
 void g() {
   const int n = 0;
   [=] {
-    constexpr int i = n;   // OK, \tcode{n} is not odr-used and not captured here
-    constexpr int j = *&n; // ill-formed, \tcode{\&n} would be an odr-use of \tcode{n}
+    constexpr int i = n;   // OK: \tcode{n} is not odr-used and not captured here
+    constexpr int j = *&n; // ill-formed: \tcode{\&n} would be an odr-use of \tcode{n}
   };
 }
 \end{codeblock}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2275,8 +2275,8 @@ inverse of an ill-formed standard conversion sequence.
 struct B { };
 struct D : private B { };
 void f() {
-  static_cast<D*>((B*)0);               // Error: B is a private base of D.
-  static_cast<int B::*>((int D::*)0);   // Error: B is a private base of D.
+  static_cast<D*>((B*)0);               // error: B is a private base of D.
+  static_cast<int B::*>((int D::*)0);   // error: B is a private base of D.
 }
 \end{codeblock}
 \end{example}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5210,7 +5210,7 @@ private:
 template<int> struct X { }; 
 constexpr A a = 42; 
 X<a> x;             // OK: unique conversion to \tcode{int}
-int ary[a];         // error: ambiguous: conversion 
+int ary[a];         // error: ambiguous: conversion
 \end{codeblock}
 \end{example}%
 \indextext{expression|)}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5210,7 +5210,7 @@ private:
 template<int> struct X { }; 
 constexpr A a = 42; 
 X<a> x;             // OK: unique conversion to \tcode{int}
-int ary[a];         // error: ambiguous conversion 
+int ary[a];         // error: ambiguous: conversion 
 \end{codeblock}
 \end{example}%
 \indextext{expression|)}

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -596,8 +596,8 @@ struct X { const int n; };
 union U { X x; float f; };
 void tong() {
   U u = {{ 1 }};
-  u.f = 5.f;                          // OK, creates new subobject of \tcode{u} (\ref{class.union})
-  X *p = new (&u.x) X {2};            // OK, creates new subobject of \tcode{u}
+  u.f = 5.f;                          // OK: creates new subobject of \tcode{u} (\ref{class.union})
+  X *p = new (&u.x) X {2};            // OK: creates new subobject of \tcode{u}
   assert(p->n == 2);                  // OK
   assert(*std::launder(&u.x.n) == 2); // OK
   assert(u.x.n == 2);                 // undefined behavior, \tcode{u.x} does not name new subobject
@@ -634,8 +634,8 @@ struct AlignedUnion {
 };
 int f() {
   AlignedUnion<int, char> au;
-  int *p = new (au.data) int;     // OK, \tcode{au.data} provides storage
-  char *c = new (au.data) char(); // OK, ends lifetime of \tcode{*p}
+  int *p = new (au.data) int;     // OK: \tcode{au.data} provides storage
+  char *c = new (au.data) char(); // OK: ends lifetime of \tcode{*p}
   char *d = new (au.data + 1) char();
   return *c + *d; // OK
 }

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -2277,7 +2277,7 @@ g( {'a', 'b'} );            // OK: \tcode{g(B(int,double))} user-defined convers
 g( {1.0, 1.0} );            // error: narrowing
 
 void f(B);
-f( {'a', 'b'} );            // error: ambiguous \tcode{f(A)} or \tcode{f(B)}
+f( {'a', 'b'} );            // error: ambiguous: \tcode{f(A)} or \tcode{f(B)}
 
 struct C {
   C(std::string);

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -117,9 +117,9 @@ all, have a \grammarterm{ref-qualifier}~(\ref{dcl.fct}). \begin{example}
 class Y {
   void h() &;
   void h() const &;             // OK
-  void h() &&;                  // OK, all declarations have a ref-qualifier
+  void h() &&;                  // OK: all declarations have a ref-qualifier
   void i() &;
-  void i() const;               // ill-formed, prior declaration of \tcode{i}
+  void i() const;               // ill-formed: prior declaration of \tcode{i}
                                 // has a ref-qualifier
 };
 \end{codeblock}
@@ -297,7 +297,7 @@ void f ();                      // OK: overloaded declaration of \tcode{f}
 void prog () {
     f (1, 2);                   // OK: call \tcode{f(int, int)}
     f (1);                      // OK: call \tcode{f(int, int)}
-    f ();                       // Error: \tcode{f(int, int)} or \tcode{f()}?
+    f ();                       // error: \tcode{f(int, int)} or \tcode{f()}?
 }
 \end{codeblock}
 \end{example}
@@ -341,7 +341,7 @@ void h(D* pd) {
   pd->f(1);                     // error:
                                 // \tcode{D::f(const char*)} hides \tcode{B::f(int)}
   pd->B::f(1);                  // OK
-  pd->f("Ben");                 // OK, calls \tcode{D::f}
+  pd->f("Ben");                 // OK: calls \tcode{D::f}
 }
 \end{codeblock}
 \end{example}
@@ -1784,8 +1784,8 @@ using A::f;
 using B::f;
 
 void use() {
-  f(3);                         // OK, default argument was not used for viability
-  f();                          // Error: found default argument twice
+  f(3);                         // OK: default argument was not used for viability
+  f();                          // error: found default argument twice
 }
 \end{codeblock}
 \end{example}
@@ -2222,10 +2222,10 @@ struct A {
   A(std::initializer_list<complex<double>>);  // \#2
   A(std::initializer_list<std::string>);      // \#3
 };
-A a{ 1.0,2.0 };             // OK, uses \#1
+A a{ 1.0,2.0 };             // OK: uses \#1
 
 void g(A);
-g({ "foo", "bar" });        // OK, uses \#3
+g({ "foo", "bar" });        // OK: uses \#3
 
 typedef int IA[3];
 void h(const IA&);

--- a/source/special.tex
+++ b/source/special.tex
@@ -1885,7 +1885,7 @@ struct A {
   const int& v = 42;      // OK
 };
 A a1;                     // error: ill-formed binding of temporary to reference
-A a2(1);                  // OK, unfortunately
+A a2(1);                  // OK: unfortunately
 \end{codeblock}
 \end{example}
 
@@ -2233,7 +2233,7 @@ A* pa = &bobj;                          // undefined, upcast to a base class typ
 B bobj;                                 // definition of \tcode{bobj}
 
 extern X xobj;
-int* p3 = &xobj.i;                      // OK, \tcode{X} is a trivial class
+int* p3 = &xobj.i;                      // OK: \tcode{X} is a trivial class
 X xobj;
 \end{codeblock}
 
@@ -2515,7 +2515,7 @@ struct X {
   X(const X&);
   X(X&);            // OK
   X(X&&);
-  X(const X&&);     // OK, but possibly not sensible
+  X(const X&&);     // OK: but possibly not sensible
 };
 \end{codeblock}
 \end{example}

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -55,10 +55,10 @@ re-declares the name is ill-formed.
 
 \begin{codeblock}
 if (int x = f()) {
-  int x;            // ill-formed, redeclaration of \tcode{x}
+  int x;            // ill-formed: redeclaration of \tcode{x}
 }
 else {
-  int x;            // ill-formed, redeclaration of \tcode{x}
+  int x;            // ill-formed: redeclaration of \tcode{x}
 }
 \end{codeblock}
 \end{example}
@@ -900,7 +900,7 @@ ly:
   X a = 1;
   // ...
 lx:
-  goto ly;          // OK, jump implies destructor
+  goto ly;          // OK: jump implies destructor
                     // call for \tcode{a} followed by construction
                     // again immediately following label \tcode{ly}
 }

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -638,7 +638,7 @@ X< 1>2 > x1;                        // syntax error
 X<(1>2)> x2;                        // OK
 
 template<class T> class Y @\tcode{\{ /* ... */ \};}@
-Y<X<1>> x3;                         // OK, same as \tcode{Y<X<1> > x3;}
+Y<X<1>> x3;                         // OK: same as \tcode{Y<X<1> > x3;}
 Y<X<6>>1>> x4;                      // syntax error
 Y<X<(6>>1)>> x5;                    // OK
 \end{codeblock}
@@ -2544,12 +2544,12 @@ template<> void A<char,2>::h() { }
 int main() {
   A<char,0> a0;
   A<char,2> a2;
-  a0.f();                       // OK, uses definition of primary template's member
-  a2.g();                       // OK, uses definition of
+  a0.f();                       // OK: uses definition of primary template's member
+  a2.g();                       // OK: uses definition of
                                 // partial specialization's member
-  a2.h();                       // OK, uses definition of
+  a2.h();                       // OK: uses definition of
                                 // explicit specialization's member
-  a2.f();                       // ill-formed, no definition of \tcode{f} for \tcode{A<T,2>}
+  a2.f();                       // ill-formed: no definition of \tcode{f} for \tcode{A<T,2>}
                                 // the primary template is not used here
 }
 \end{codeblock}
@@ -2987,7 +2987,7 @@ argument substitution still applies to the \grammarterm{template-id}.
 \begin{codeblock}
 template<typename...> using void_t = void;
 template<typename T> void_t<typename T::foo> f();
-f<int>(); // error, \tcode{int} does not have a nested type \tcode{foo}
+f<int>(); // error: \tcode{int} does not have a nested type \tcode{foo}
 \end{codeblock}
 \end{example}
 
@@ -3052,10 +3052,10 @@ template<class T> class Y {
     TA* a5;                     // declare pointer to \tcode{T}'s \tcode{A}
     typename T::A* a6;          // declare pointer to \tcode{T}'s \tcode{A}
     T::A* a7;                   // \tcode{T::A} is not a type name:
-                                // multiply \tcode{T::A} by \tcode{a7}; ill-formed,
+                                // multiply \tcode{T::A} by \tcode{a7}; ill-formed:
                                 // no visible declaration of \tcode{a7}
     B* a8;                      // \tcode{B} is not a type name:
-                                // multiply \tcode{B} by \tcode{a8}; ill-formed,
+                                // multiply \tcode{B} by \tcode{a8}; ill-formed:
                                 // no visible declarations of \tcode{B} and \tcode{a8}
   }
 };
@@ -3185,7 +3185,7 @@ type of the object expression is the current instantiation~(\ref{temp.dep.expr})
 \begin{codeblock}
 template<class T> struct A {
   typedef int B;
-  B b;              // OK, no typename required
+  B b;              // OK: no typename required
 };
 \end{codeblock}
 \end{example}
@@ -3839,7 +3839,7 @@ template<class T> struct A {
 };
 
 template<class T> struct A<T>::B::C : A<T> {
-  M m; // OK, \tcode{A<T>::M}
+  M m; // OK: \tcode{A<T>::M}
 };
 \end{codeblock}
 \end{example}
@@ -5331,7 +5331,7 @@ template<> enum A<int>::E : int { eint };         // OK
 template<> enum class A<int>::S : int { sint };   // OK
 template<class T> enum A<T>::E : T { eT };
 template<class T> enum class A<T>::S : T { sT };
-template<> enum A<char>::E : char { echar };       // ill-formed, \tcode{A<char>::E} was instantiated
+template<> enum A<char>::E : char { echar };       // ill-formed: \tcode{A<char>::E} was instantiated
                                                    // when \tcode{A<char>} was instantiated
 template<> enum class A<char>::S : char { schar }; // OK
 \end{codeblock}
@@ -5771,7 +5771,7 @@ class Complex {
 };
 
 void g() {
-  f<Complex>(1);                // OK, means \tcode{f<Complex>(Complex(1))}
+  f<Complex>(1);                // OK: means \tcode{f<Complex>(Complex(1))}
 }
 \end{codeblock}
 \end{note}
@@ -5998,8 +5998,8 @@ template <class T> auto g(typename A<T>::X) -> typename T::X;
 template <class T> void g(...) { }
 
 void h() {
-  f<int>(0); // OK, substituting return type causes deduction to fail
-  g<int>(0); // error, substituting parameter type instantiates \tcode{A<int>}
+  f<int>(0); // OK: substituting return type causes deduction to fail
+  g<int>(0); // error: substituting parameter type instantiates \tcode{A<int>}
 }
 \end{codeblock}
 \end{example}
@@ -6204,13 +6204,13 @@ j({42});                    // \tcode{T} deduced to \tcode{int}, array bound not
 struct Aggr { int i; int j; };
 template<int N> void k(Aggr const(&)[N]);
 k({1,2,3});                 // error: deduction fails, no conversion from \tcode{int} to \tcode{Aggr}
-k({{1},{2},{3}});           // OK, \tcode{N} deduced to \tcode{3}
+k({{1},{2},{3}});           // OK: \tcode{N} deduced to \tcode{3}
 
 template<int M, int N> void m(int const(&)[M][N]);
 m({{1,2},{3,4}});           // \tcode{M} and \tcode{N} both deduced to \tcode{2}
 
 template<class T, int N> void n(T const(&)[N], T);
-n({{1},{2},{3}},Aggr());    // OK, \tcode{T} is \tcode{Aggr}, \tcode{N} is \tcode{3}
+n({{1},{2},{3}},Aggr());    // OK: \tcode{T} is \tcode{Aggr}, \tcode{N} is \tcode{3}
 \end{codeblock}
 \end{example}
 For a function parameter pack that occurs at the end
@@ -6236,7 +6236,7 @@ void h(int x, float& y) {
   f(x, y, z);                  // \tcode{Types} is deduced to \tcode{int}, \tcode{float}, \tcode{const int}
   g(x, y, z);                  // \tcode{T1} is deduced to \tcode{int}; \tcode{Types} is deduced to \tcode{float}, \tcode{int}
   g1(x, y, z);                 // error: \tcode{Types} is not deduced
-  g1<int, int, int>(x, y, z);  // OK, no deduction occurs
+  g1<int, int, int>(x, y, z);  // OK: no deduction occurs
 
 }
 \end{codeblock}
@@ -6474,7 +6474,7 @@ will be checked during overload resolution.
   template <class T> void f(int, T);                 // \#2
   struct A {} a;
   int main() {
-    f(1, a);       // OK, deduction fails for \#1 because there is no conversion from int to void*
+    f(1, a);       // OK: deduction fails for \#1 because there is no conversion from int to void*
   }
 \end{codeblock}
 \end{example}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -7286,7 +7286,7 @@ template<typename T, T n> struct C<A<n>> {
 };
 
 using R = long;
-using R = C<A<2>>::Q;    // OK; \tcode{T} was deduced to \tcode{long} from the
+using R = C<A<2>>::Q;    // OK: \tcode{T} was deduced to \tcode{long} from the
                          // template argument value in the type \tcode{A<2>}
 \end{codeblock}
 \end{example}
@@ -7299,7 +7299,7 @@ template<typename T, T n> struct S<int[n]> {
 };
 
 using V = decltype(sizeof 0);
-using V = S<int[42]>::Q; // OK; \tcode{T} was deduced to \tcode{std::size_t} from the type \tcode{int[42]}
+using V = S<int[42]>::Q; // OK: \tcode{T} was deduced to \tcode{std::size_t} from the type \tcode{int[42]}
 \end{codeblock}
 \end{example}
 
@@ -7490,7 +7490,7 @@ X<int(float, int)> x3;          // uses primary template
 Y<> y1;                         // use primary template; \tcode{Types} is empty
 Y<int&, float&, double&> y2;    // uses partial specialization; \tcode{T} is \tcode{int\&}, \tcode{Types} contains \tcode{float}, \tcode{double}
 Y<int, float, double> y3;       // uses primary template; \tcode{Types} contains \tcode{int}, \tcode{float}, \tcode{double}
-int fv = f(g);                  // OK; \tcode{Types} contains \tcode{int}, \tcode{float}
+int fv = f(g);                  // OK: \tcode{Types} contains \tcode{int}, \tcode{float}
 \end{codeblock}
 
 \end{example}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -9401,7 +9401,7 @@ namespace std {
     template<class U> bool owner_before(const weak_ptr<U>& b) const;
   };
 
-  // \ref{util.smartptr.shared.create}, shared_ptr creation
+  // \ref{util.smartptr.shared.create}, shared_ptr creation:
   template<class T, class... Args> shared_ptr<T> make_shared(Args&&... args);
   template<class T, class A, class... Args>
     shared_ptr<T> allocate_shared(const A& a, Args&&... args);

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -19076,7 +19076,7 @@ that a parallel algorithm's execution may not be parallelized.
 
 \pnum
 During the execution of a parallel algorithm with
-the \tcode{execution::sequenced_policy} policy,
+the \tcode{execution::sequenced_policy_policy_policy} policy,
 if the invocation of an element access function exits via an uncaught exception,
 \tcode{terminate()} shall be called.
 \end{itemdescr}
@@ -19117,7 +19117,11 @@ vectorized.
 
 \pnum
 During the execution of a parallel algorithm with
+<<<<<<< 1f1a2392349f126adec4ea6f3b3fd4cf7632e311
 the \tcode{execution::parallel_unsequenced_policy} policy,
+=======
+the \tcode{execution::parallel_policy_policy} policy,
+>>>>>>> NB US-15, US-16, US-167, US-168, US-169, US-170, CA-17 P0502R0 Throwing out of a parallel algorithm terminates—but how?
 if the invocation of an element access function exits via an uncaught exception,
 \tcode{terminate()} shall be called.
 \end{itemdescr}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -5877,7 +5877,7 @@ string cat("Meow");
 const any y(cat);                           // \tcode{const y} holds \tcode{string}
 assert(any_cast<const string&>(y) == cat);
 
-any_cast<string&>(y);                       // error; cannot
+any_cast<string&>(y);                       // error: cannot
                                             // \tcode{any_cast} away const
 \end{codeblock}
 \end{example}


### PR DESCRIPTION
Current stats:
```bash
git grep '// OK,' | wc -l
      60
git grep '// OK:' | wc -l
     246
git grep '// error,' | wc -l
      22
git grep '// error:' | wc -l
     257
git grep '// Error' | wc -l
       7
```

This PR introduces:
```
  // OK, -> // OK:
  // Error -> // error
  // error[,] -> // error:
  // ambiguous[,] -> ambiguous:
  // error[:] ambiguous[,]-> error: ambiguous:
```

If you consider this as an improvement please merge.