### PR TITLE
Editorial: execpol.vec was renamed to unsequenced

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -18319,7 +18319,7 @@ namespace std::execution {
   // \ref{execpol.par}, parallel execution policy:
   class parallel_policy;
 
-  // \ref{execpol.vec}, parallel+unsequenced execution policy:
+  // \ref{execpol.parunseq}, parallel+unsequenced execution policy:
   class parallel_unsequenced_policy;
 
   // \ref{parallel.execpol.objects}, execution policy objects:
@@ -18386,7 +18386,7 @@ a unique type to disambiguate parallel algorithm overloading and indicate that
 a parallel algorithm's execution may be parallelized.
 \end{itemdescr}
 
-\rSec2[execpol.vec]{Parallel+Vector execution policy}
+\rSec2[execpol.parunseq]{Parallel+Unsequenced execution policy}
 
 \indexlibrary{\idxcode{execution::parallel_unsequenced_policy}}%
 \begin{itemdecl}


### PR DESCRIPTION
Update missed updates.