### PR TITLE
[iostreams] Refer to int values as nonzero instead of true

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -7503,7 +7503,7 @@ underlying character sequence.
 If the \tcode{basic_stringbuf} was created only in input mode, the resultant
 \tcode{basic_string} contains the character sequence in the range
 \range{eback()}{egptr()}. If the \tcode{basic_stringbuf} was created with
-\tcode{which \& ios_base::out} being true then the resultant \tcode{basic_string}
+\tcode{which \& ios_base::out} being nonzero then the resultant \tcode{basic_string}
 contains the character sequence in the range \range{pbase()}{high_mark}, where
 \tcode{high_mark} represents the position one past the highest initialized character
 in the buffer. Characters can be initialized by writing to the stream, by constructing
@@ -7527,12 +7527,12 @@ Copies the content of \tcode{s} into the \tcode{basic_stringbuf} underlying char
 sequence and initializes the input and output sequences according to \tcode{mode}.
 
 \pnum
-\postconditions If \tcode{mode \& ios_base::out} is true, \tcode{pbase()} points to the
+\postconditions If \tcode{mode \& ios_base::out} is nonzero, \tcode{pbase()} points to the
 first underlying character and \tcode{epptr()} \tcode{>= pbase() + s.size()} holds; in
-addition, if \tcode{mode \& ios_base::ate} is true,
+addition, if \tcode{mode \& ios_base::ate} is nonzero,
 \tcode{pptr() == pbase() + s.size()}
 holds, otherwise \tcode{pptr() == pbase()} is true. If \tcode{mode \& ios_base::in} is
-true, \tcode{eback()} points to the first underlying character, and both \tcode{gptr()
+nonzero, \tcode{eback()} points to the first underlying character, and both \tcode{gptr()
 == eback()} and \tcode{egptr() == eback() + s.size()} hold.
 \end{itemdescr}
 


### PR DESCRIPTION
This is consistent with rest of the file.