### PR TITLE
Use \term and \defnx more correctly and consistently

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -234,10 +234,10 @@ given atomic access to a particular atomic object be indivisible with respect
 to all other atomic accesses to that object. \end{note}
 
 \pnum
-An atomic operation \term{A} that performs a release operation on an atomic
-object \term{M} synchronizes with an atomic operation \term{B} that performs
-an acquire operation on \term{M} and takes its value from any side effect in the
-release sequence headed by \term{A}.
+An atomic operation \placeholder{A} that performs a release operation on an atomic
+object \placeholder{M} synchronizes with an atomic operation \placeholder{B} that performs
+an acquire operation on \placeholder{M} and takes its value from any side effect in the
+release sequence headed by \placeholder{A}.
 
 \pnum
 There shall be a single total order \textit{S} on all \tcode{memory_order_seq_cst}

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3773,7 +3773,7 @@ conversion~(\ref{conv.integral}) from \placeholder{i} to \tcode{char} is
 
 \pnum
 \indextext{type!standard~signed~integer}%
-There are five \defnx{standard signed integer types}{standard~signed~integer~type} :
+There are five \defnx{standard signed integer types}{standard~signed~integer~type}:
 \indextext{type!\idxcode{signed char}}%
 \indextext{type!\idxcode{short}}%
 \indextext{type!\idxcode{int}}%

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -144,9 +144,8 @@ at least one of which is not deleted.
 virtual functions or virtual base classes.\end{note}
 
 \indextext{class!standard-layout}%
-\indextext{standard-layout~class}%
 \pnum
-A class \tcode{S} is a \grammarterm{standard-layout class} if it:
+A class \tcode{S} is a \defnx{standard-layout class}{standard-layout~class} if it:
 \begin{itemize}
 \item has no non-static data members of type non-standard-layout class
 (or array of such types) or reference,
@@ -211,14 +210,12 @@ in \tcode{X}. \end{note}
 \end{example}
 
 \indextext{struct!standard-layout}%
-\indextext{standard-layout~struct}%
 \indextext{union!standard-layout}%
-\indextext{standard-layout~union}%
 \pnum
-A \grammarterm{standard-layout struct} is a standard-layout class
+A \defnx{standard-layout struct}{standard-layout~struct} is a standard-layout class
 defined with the \grammarterm{class-key} \tcode{struct} or the
 \grammarterm{class-key} \tcode{class}.
-A \grammarterm{standard-layout union} is a standard-layout class
+A \defnx{standard-layout union}{standard-layout~union} is a standard-layout class
 defined with the
 \grammarterm{class-key} \tcode{union}.
 
@@ -228,14 +225,13 @@ code written in other programming languages. Their layout is specified
 in~\ref{class.mem}.\end{note}
 
 \pnum
-\indextext{POD struct}\indextext{POD class}\indextext{POD union}%
-A \term{POD struct}\footnote{The acronym POD stands for ``plain old data''.}
+A \defn{POD struct}\footnote{The acronym POD stands for ``plain old data''.}
 is a non-union class that is both a trivial class and a
 standard-layout class, and has no non-static data members of type non-POD struct,
 non-POD union (or array of such types). Similarly, a
-\term{POD union} is a union that is both a trivial class and a standard-layout
+\defn{POD union} is a union that is both a trivial class and a standard-layout
 class, and has no non-static data members of type non-POD struct, non-POD
-union (or array of such types). A \term{POD class} is a
+union (or array of such types). A \defn{POD class} is a
 class that is either a POD struct or a POD union.
 
 \begin{example}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -2059,7 +2059,7 @@ requirements~(\ref{hash.requirements}) and acts as a hash function for
 argument values of type \tcode{Key}, and by a binary predicate \tcode{Pred}
 that induces an equivalence relation on values of type \tcode{Key}.
 Additionally, \tcode{unordered_map} and \tcode{unordered_multimap} associate
-an arbitrary \textit{mapped type} \tcode{T} with the \tcode{Key}.
+an arbitrary \term{mapped type} \tcode{T} with the \tcode{Key}.
 
 \pnum
 \indextext{unordered associative containers!hash function}%
@@ -2089,9 +2089,9 @@ shall always return the same value.
 \pnum
 \indextext{unordered associative containers!unique keys}%
 \indextext{unordered associative containers!equivalent keys}%
-An unordered associative container supports \textit{unique keys} if it
+An unordered associative container supports \term{unique keys} if it
 may contain at most one element for each key.  Otherwise, it supports
-\textit{equivalent keys}.  \tcode{unordered_set} and \tcode{unordered_map}
+\term{equivalent keys}.  \tcode{unordered_set} and \tcode{unordered_map}
 support unique keys. \tcode{unordered_multiset} and \tcode{unordered_multimap}
 support equivalent keys.  In containers that support equivalent keys,
 elements with equivalent keys are adjacent to each other
@@ -2123,7 +2123,7 @@ by always using \tcode{const_iterator} in their function parameter lists.
 \indextext{buckets}%
 \indextext{hash code}%
 The elements of an unordered associative container are organized into
-\textit{buckets}.  Keys with the same hash code appear in the same
+\term{buckets}.  Keys with the same hash code appear in the same
 bucket.  The number of buckets is automatically increased as elements
 are added to an unordered associative container, so that the average
 number of elements per bucket is kept below a bound.  Rehashing

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2013,14 +2013,12 @@ the declaration shall be an explicit specialization~(\ref{temp.expl.spec}).
 \pnum
 \indextext{constant!enumeration}%
 \indextext{enumeration}%
-\indextext{enumeration!unscoped}%
-\indextext{enumeration!scoped}%
 The enumeration type declared with an \grammarterm{enum-key}
-of only \tcode{enum} is an \term{}{unscoped enumeration},
+of only \tcode{enum} is an \defnx{unscoped enumeration}{enumeration!unscoped},
 and its \grammarterm{enumerator}{s} are \term{unscoped enumerators}.
 The \grammarterm{enum-key}{s} \tcode{enum class} and
 \tcode{enum struct} are semantically equivalent; an enumeration
-type declared with one of these is a \term{scoped enumeration},
+type declared with one of these is a \defnx{scoped enumeration}{enumeration!scoped},
 and its \grammarterm{enumerator}{s} are \term{scoped enumerators}.
 The optional \grammarterm{identifier} shall not be omitted in the declaration of a scoped enumeration.
 The \grammarterm{type-specifier-seq} of an \grammarterm{enum-base}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -153,11 +153,10 @@ temporary materialization conversion~(\ref{conv.rval}) is
 applied to convert the expression to an xvalue.
 
 \pnum
-\indextext{conversion!usual arithmetic}%
 Many binary operators that expect operands of arithmetic or enumeration
 type cause conversions and yield result types in a similar way. The
 purpose is to yield a common type, which is also the type of the result.
-This pattern is called the \term{usual arithmetic conversions},
+This pattern is called the \defnx{usual arithmetic conversions}{conversion!usual arithmetic},
 which are defined as follows:
 
 \begin{itemize}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -1372,7 +1372,7 @@ operate independently of the standard C streams.
 
 \pnum
 When a standard iostream object \tcode{str} is
-\textit{synchronized}
+\term{synchronized}
 with a standard stdio stream \tcode{f}, the effect of inserting a character \tcode{c} by
 \begin{codeblock}
 fputc(f, c);
@@ -1895,7 +1895,7 @@ basic_ostream<charT, traits>* tie() const;
 \pnum
 \returns
 An output sequence that is
-\textit{tied}
+\term{tied}
 to (synchronized with) the sequence controlled by the stream buffer.
 \end{itemdescr}
 

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -1498,7 +1498,7 @@ Ordinary string literals and UTF-8 string literals are
 also referred to as narrow
 string literals. A narrow string literal has type
 \indextext{literal!string!type~of}%
-``array of \term{n} \tcode{const char}'', where \term{n} is the size of
+``array of \placeholder{n} \tcode{const char}'', where \placeholder{n} is the size of
 the string as defined below, and has static storage
 duration~(\ref{basic.stc}).
 
@@ -1513,7 +1513,7 @@ A \grammarterm{string-literal} that begins with \tcode{u},
 \indextext{prefix!\idxcode{u}}%
 such as \tcode{u"asdf"}, is
 a \tcode{char16_t} string literal. A \tcode{char16_t} string literal has
-type ``array of \term{n} \tcode{const char16_t}'', where \term{n} is the
+type ``array of \placeholder{n} \tcode{const char16_t}'', where \placeholder{n} is the
 size of the string as defined below; it
 is initialized with the given characters. A single \grammarterm{c-char} may
 produce more than one \tcode{char16_t} character in the form of
@@ -1525,7 +1525,7 @@ A \grammarterm{string-literal} that begins with \tcode{U},
 \indextext{prefix!\idxcode{U}}%
 such as \tcode{U"asdf"}, is
 a \tcode{char32_t} string literal. A \tcode{char32_t} string literal has
-type ``array of \term{n} \tcode{const char32_t}'', where \term{n} is the
+type ``array of \placeholder{n} \tcode{const char32_t}'', where \placeholder{n} is the
 size of the string as defined below; it
 is initialized with the given characters.
 
@@ -1538,8 +1538,8 @@ such as \tcode{L"asdf"}, is a \defn{wide string literal}.
 \indextext{\idxcode{wchar_t}}%
 \indextext{literal!string!wide}%
 \indextext{prefix!\idxcode{L}}%
-A wide string literal has type ``array of \term{n} \tcode{const
-wchar_t}'', where \term{n} is the size of the string as defined below; it
+A wide string literal has type ``array of \placeholder{n} \tcode{const
+wchar_t}'', where \placeholder{n} is the size of the string as defined below; it
 is initialized with the given characters.
 
 \pnum
@@ -1726,93 +1726,93 @@ characters that could match that non-terminal.
 \pnum
 A \grammarterm{user-defined-literal} is treated as a call to a literal operator or
 literal operator template~(\ref{over.literal}). To determine the form of this call for a
-given \grammarterm{user-defined-literal} \term{L} with \grammarterm{ud-suffix} \term{X},
-the \grammarterm{literal-operator-id} whose literal suffix identifier is \term{X} is
-looked up in the context of \term{L} using the rules for unqualified name
-lookup~(\ref{basic.lookup.unqual}). Let \term{S} be the set of declarations found by
-this lookup. \term{S} shall not be empty.
+given \grammarterm{user-defined-literal} \placeholder{L} with \grammarterm{ud-suffix} \placeholder{X},
+the \grammarterm{literal-operator-id} whose literal suffix identifier is \placeholder{X} is
+looked up in the context of \placeholder{L} using the rules for unqualified name
+lookup~(\ref{basic.lookup.unqual}). Let \placeholder{S} be the set of declarations found by
+this lookup. \placeholder{S} shall not be empty.
 
 \pnum
-If \term{L} is a \grammarterm{user-defined-integer-literal}, let \term{n} be the literal
-without its \grammarterm{ud-suffix}. If \term{S} contains a literal operator with
-parameter type \tcode{unsigned long long}, the literal \term{L} is treated as a call of
+If \placeholder{L} is a \grammarterm{user-defined-integer-literal}, let \placeholder{n} be the literal
+without its \grammarterm{ud-suffix}. If \placeholder{S} contains a literal operator with
+parameter type \tcode{unsigned long long}, the literal \placeholder{L} is treated as a call of
 the form
 
 \begin{codeblock}
-operator "" @\term{X}@(@\term{n}@ULL)
+operator "" @\placeholder{X}@(@\placeholder{n}@ULL)
 \end{codeblock}
 
-Otherwise, \term{S} shall contain a raw literal operator or a literal operator
-template~(\ref{over.literal}) but not both. If \term{S} contains a raw literal operator,
-the literal \term{L} is treated as a call of the form
+Otherwise, \placeholder{S} shall contain a raw literal operator or a literal operator
+template~(\ref{over.literal}) but not both. If \placeholder{S} contains a raw literal operator,
+the literal \placeholder{L} is treated as a call of the form
 
 \begin{codeblock}
-operator "" @\term{X}@(@"\term{n}{"}@)
+operator "" @\placeholder{X}@(@"\placeholder{n}{"}@)
 \end{codeblock}
 
-Otherwise (\term{S} contains a literal operator template), \term{L} is treated as a call
+Otherwise (\placeholder{S} contains a literal operator template), \placeholder{L} is treated as a call
 of the form
 
 
 \begin{codeblock}
-operator "" @\term{X}@<'@$c_1$@', '@$c_2$@', ... '@$c_k$@'>()
+operator "" @\placeholder{X}@<'@$c_1$@', '@$c_2$@', ... '@$c_k$@'>()
 \end{codeblock}
 
-where \term{n} is the source character sequence $c_1c_2...c_k$. \begin{note} The sequence
+where \placeholder{n} is the source character sequence $c_1c_2...c_k$. \begin{note} The sequence
 $c_1c_2...c_k$ can only contain characters from the basic source character set.
 \end{note}
 
 \pnum
-If \term{L} is a \grammarterm{user-defined-floating-literal}, let \term{f} be the
-literal without its \grammarterm{ud-suffix}. If \term{S} contains a literal operator
-with parameter type \tcode{long double}, the literal \term{L} is treated as a call of
+If \placeholder{L} is a \grammarterm{user-defined-floating-literal}, let \placeholder{f} be the
+literal without its \grammarterm{ud-suffix}. If \placeholder{S} contains a literal operator
+with parameter type \tcode{long double}, the literal \placeholder{L} is treated as a call of
 the form
 
 \begin{codeblock}
-operator "" @\term{X}@(@\term{f}@L)
+operator "" @\placeholder{X}@(@\placeholder{f}@L)
 \end{codeblock}
 
-Otherwise, \term{S} shall contain a raw literal operator or a literal operator
-template~(\ref{over.literal}) but not both. If \term{S} contains a raw literal operator,
-the \term{literal} \term{L} is treated as a call of the form
+Otherwise, \placeholder{S} shall contain a raw literal operator or a literal operator
+template~(\ref{over.literal}) but not both. If \placeholder{S} contains a raw literal operator,
+the \placeholder{literal} \placeholder{L} is treated as a call of the form
 
 \begin{codeblock}
-operator "" @\term{X}@(@"\term{f}{"}@)
+operator "" @\placeholder{X}@(@"\placeholder{f}{"}@)
 \end{codeblock}
 
-Otherwise (\term{S} contains a literal operator template), \term{L} is treated as a call
+Otherwise (\placeholder{S} contains a literal operator template), \placeholder{L} is treated as a call
 of the form
 
 \begin{codeblock}
-operator "" @\term{X}@<'@$c_1$@', '@$c_2$@', ... '@$c_k$@'>()
+operator "" @\placeholder{X}@<'@$c_1$@', '@$c_2$@', ... '@$c_k$@'>()
 \end{codeblock}
 
-where \term{f} is the source character sequence $c_1c_2...c_k$. \begin{note} The sequence
+where \placeholder{f} is the source character sequence $c_1c_2...c_k$. \begin{note} The sequence
 $c_1c_2...c_k$ can only contain characters from the basic source character set.
 \end{note}
 
 \pnum
-If \term{L} is a \grammarterm{user-defined-string-literal}, let \term{str} be the
-literal without its \grammarterm{ud-suffix} and let \term{len} be
+If \placeholder{L} is a \grammarterm{user-defined-string-literal}, let \placeholder{str} be the
+literal without its \grammarterm{ud-suffix} and let \placeholder{len} be
 the number of
-code units in \term{str} (i.e., its length excluding the terminating
+code units in \placeholder{str} (i.e., its length excluding the terminating
 null character).
- The literal \term{L} is treated as a call of the form
+ The literal \placeholder{L} is treated as a call of the form
 
 \begin{codeblock}
-operator "" @\term{X}@(@\term{str}{}@, @\term{len}{}@)
+operator "" @\placeholder{X}@(@\placeholder{str}{}@, @\placeholder{len}{}@)
 \end{codeblock}
 
 \pnum
-If \term{L} is a \grammarterm{user-defined-character-literal}, let \term{ch} be the
+If \placeholder{L} is a \grammarterm{user-defined-character-literal}, let \placeholder{ch} be the
 literal without its \grammarterm{ud-suffix}.
-\term{S} shall contain a literal operator~(\ref{over.literal}) whose only parameter has
-the type of \term{ch} and the
-literal \term{L} is treated as a call
+\placeholder{S} shall contain a literal operator~(\ref{over.literal}) whose only parameter has
+the type of \placeholder{ch} and the
+literal \placeholder{L} is treated as a call
 of the form
 
 \begin{codeblock}
-operator "" @\term{X}@(@\term{ch}{}@)
+operator "" @\placeholder{X}@(@\placeholder{ch}{}@)
 \end{codeblock}
 
 \pnum

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -870,26 +870,21 @@ ISO C. }
 \pnum
 \indextext{literal!\idxcode{unsigned}}%
 \indextext{literal!\idxcode{long}}%
-\indextext{literal!integer}%
-\indextext{literal!binary}%
-\indextext{literal!octal}%
-\indextext{literal!decimal}%
-\indextext{literal!hexadecimal}%
 \indextext{literal!base~of integer}%
-An \term{integer literal} is a sequence of digits that has no period
+An \defnx{integer literal}{literal!integer} is a sequence of digits that has no period
 or exponent part, with optional separating single quotes that are ignored
 when determining its value. An integer literal may have a prefix that specifies
 its base and a suffix that specifies its type. The lexically first digit
 of the sequence of digits is the most significant.
-A \term{binary} integer literal (base two) begins with
+A \defnx{binary}{literal!binary} integer literal (base two) begins with
 \tcode{0b} or \tcode{0B} and consists of a sequence of binary digits.
-An \term{octal} integer
+An \defnx{octal}{literal!octal} integer
 literal (base eight) begins with the digit \tcode{0} and consists of a
 sequence of octal digits.\footnote{The digits \tcode{8} and \tcode{9} are not octal digits. }
-A \term{decimal}
+A \defnx{decimal}{literal!decimal}
 integer literal (base ten) begins with a digit other than \tcode{0} and
 consists of a sequence of decimal digits.
-A \term{hexadecimal} integer literal (base sixteen) begins with
+A \defnx{hexadecimal}{literal!hexadecimal} integer literal (base sixteen) begins with
 \tcode{0x} or \tcode{0X} and consists of a sequence of hexadecimal
 digits, which include the decimal digits and the letters \tcode{a}
 through \tcode{f} and \tcode{A} through \tcode{F} with decimal values
@@ -1298,10 +1293,8 @@ an optional type suffix.
 The integer and fraction parts both consist of
 a sequence of decimal (base ten) digits if there is no prefix, or
 hexadecimal (base sixteen) digits if the prefix is \tcode{0x} or \tcode{0X}.
-\indextext{literal!decimal floating}%
-The literal is a \term{decimal floating literal} in the former case and
-\indextext{literal!hexadecimal floating}%
-a \term{hexadecimal floating literal} in the latter case.
+The literal is a \defnx{decimal floating literal}{literal!decimal floating} in the former case and
+a \defnx{hexadecimal floating literal}{literal!hexadecimal floating} in the latter case.
 Optional separating single quotes in
 a \grammarterm{digit-sequence} or \grammarterm{hexadecimal-digit-sequence}
 are ignored when determining its value.

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -604,20 +604,20 @@ an enumeration.\footnote{Such as an integer type, with constant integer
 values~(\ref{basic.fundamental}).}
 
 \pnum
-The enumerated type \term{enumerated} can be written:
+The enumerated type \placeholder{enumerated} can be written:
 
 \begin{codeblock}
-enum @\term{enumerated}@ { @\term{V0}@, @\term{V1}@, @\term{V2}@, @\term{V3}@, ..... };
+enum @\placeholder{enumerated}@ { @\placeholder{V0}@, @\placeholder{V1}@, @\placeholder{V2}@, @\placeholder{V3}@, ..... };
 
-static const @\term{enumerated C0}@ (@\term{V0}@);
-static const @\term{enumerated C1}@ (@\term{V1}@);
-static const @\term{enumerated C2}@ (@\term{V2}@);
-static const @\term{enumerated C3}@ (@\term{V3}@);
+static const @\placeholder{enumerated C0}@ (@\placeholder{V0}@);
+static const @\placeholder{enumerated C1}@ (@\placeholder{V1}@);
+static const @\placeholder{enumerated C2}@ (@\placeholder{V2}@);
+static const @\placeholder{enumerated C3}@ (@\placeholder{V3}@);
   .....
 \end{codeblock}
 
 \pnum
-Here, the names \term{C0}, \term{C1}, etc. represent
+Here, the names \placeholder{C0}, \placeholder{C1}, etc. represent
 \term{enumerated elements}
 for this particular enumerated type.
 \indextext{type!enumerated}%
@@ -637,56 +637,56 @@ or as a
 \indextext{type!enumerated}%
 
 \pnum
-The bitmask type \term{bitmask} can be written:
+The bitmask type \placeholder{bitmask} can be written:
 
 \begin{codeblock}
 // For exposition only.
 // \tcode{int_type} is an integral type capable of
 // representing all values of the bitmask type.
-enum @\term{bitmask}@ : int_type {
-  @\term{V0}@ = 1 << 0, @\term{V1}@ = 1 << 1, @\term{V2}@ = 1 << 2, @\term{V3}@ = 1 << 3, .....
+enum @\placeholder{bitmask}@ : int_type {
+  @\placeholder{V0}@ = 1 << 0, @\placeholder{V1}@ = 1 << 1, @\placeholder{V2}@ = 1 << 2, @\placeholder{V3}@ = 1 << 3, .....
 };
 
-constexpr @\term{bitmask C0}@(@\term{V0}{}@);
-constexpr @\term{bitmask C1}@(@\term{V1}{}@);
-constexpr @\term{bitmask C2}@(@\term{V2}{}@);
-constexpr @\term{bitmask C3}@(@\term{V3}{}@);
+constexpr @\placeholder{bitmask C0}@(@\placeholder{V0}{}@);
+constexpr @\placeholder{bitmask C1}@(@\placeholder{V1}{}@);
+constexpr @\placeholder{bitmask C2}@(@\placeholder{V2}{}@);
+constexpr @\placeholder{bitmask C3}@(@\placeholder{V3}{}@);
   .....
 
-constexpr @\term{bitmask}{}@ operator&(@\term{bitmask}{}@ X, @\term{bitmask}{}@ Y) {
-  return static_cast<@\term{bitmask}{}@>(
+constexpr @\placeholder{bitmask}{}@ operator&(@\placeholder{bitmask}{}@ X, @\placeholder{bitmask}{}@ Y) {
+  return static_cast<@\placeholder{bitmask}{}@>(
     static_cast<int_type>(X) & static_cast<int_type>(Y));
 }
-constexpr @\term{bitmask}{}@ operator|(@\term{bitmask}{}@ X, @\term{bitmask}{}@ Y) {
-  return static_cast<@\term{bitmask}{}@>(
+constexpr @\placeholder{bitmask}{}@ operator|(@\placeholder{bitmask}{}@ X, @\placeholder{bitmask}{}@ Y) {
+  return static_cast<@\placeholder{bitmask}{}@>(
     static_cast<int_type>(X) | static_cast<int_type>(Y));
 }
-constexpr @\term{bitmask}{}@ operator^(@\term{bitmask}{}@ X, @\term{bitmask}{}@ Y){
-  return static_cast<@\term{bitmask}{}@>(
+constexpr @\placeholder{bitmask}{}@ operator^(@\placeholder{bitmask}{}@ X, @\placeholder{bitmask}{}@ Y){
+  return static_cast<@\placeholder{bitmask}{}@>(
     static_cast<int_type>(X) ^ static_cast<int_type>(Y));
 }
-constexpr @\term{bitmask}{}@ operator~(@\term{bitmask}{}@ X){
-  return static_cast<@\term{bitmask}{}@>(~static_cast<int_type>(X));
+constexpr @\placeholder{bitmask}{}@ operator~(@\placeholder{bitmask}{}@ X){
+  return static_cast<@\placeholder{bitmask}{}@>(~static_cast<int_type>(X));
 }
-@\term{bitmask}{}@& operator&=(@\term{bitmask}{}@& X, @\term{bitmask}{}@ Y){
+@\placeholder{bitmask}{}@& operator&=(@\placeholder{bitmask}{}@& X, @\placeholder{bitmask}{}@ Y){
   X = X & Y; return X;
 }
-@\term{bitmask}{}@& operator|=(@\term{bitmask}{}@& X, @\term{bitmask}{}@ Y) {
+@\placeholder{bitmask}{}@& operator|=(@\placeholder{bitmask}{}@& X, @\placeholder{bitmask}{}@ Y) {
   X = X | Y; return X;
 }
-@\term{bitmask}{}@& operator^=(@\term{bitmask}{}@& X, @\term{bitmask}{}@ Y) {
+@\placeholder{bitmask}{}@& operator^=(@\placeholder{bitmask}{}@& X, @\placeholder{bitmask}{}@ Y) {
   X = X ^ Y; return X;
 }
 \end{codeblock}
 
 \pnum
-Here, the names \term{C0}, \term{C1}, etc. represent
+Here, the names \placeholder{C0}, \placeholder{C1}, etc. represent
 \term{bitmask elements}
 for this particular bitmask type.
 \indextext{type!bitmask}%
-All such elements have distinct, nonzero values such that, for any pair \term{Ci}
-and \term{Cj} where \term{i} != \term{j}, \term{Ci} \& \term{Ci} is nonzero and
-\term{Ci} \& \term{Cj} is zero.
+All such elements have distinct, nonzero values such that, for any pair \placeholder{Ci}
+and \placeholder{Cj} where \placeholder{i} != \placeholder{j}, \placeholder{Ci} \& \placeholder{Ci} is nonzero and
+\placeholder{Ci} \& \placeholder{Cj} is zero.
 \indextext{bitmask!empty}%
 Additionally, the value 0 is used to represent an \term{empty bitmask}, in which no
 bitmask elements are set.

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -5,8 +5,7 @@
 
 \pnum
 This Clause describes the contents of the
-\term{\Cpp standard library},
-\indextext{library!C++ standard}%
+\defnx{\Cpp standard library}{library!C++ standard},
 how a well-formed \Cpp program makes use of the library, and
 how a conforming implementation may provide the entities in the library.
 
@@ -597,8 +596,7 @@ that takes a callback parameter with C language linkage.
 
 \pnum
 Several types defined in Clause~\ref{input.output} are
-\term{enumerated types}.
-\indextext{type!enumerated}%
+\defnx{enumerated types}{type!enumerated}.
 Each enumerated type may be implemented as an enumeration or as a synonym for
 an enumeration.\footnote{Such as an integer type, with constant integer
 values~(\ref{basic.fundamental}).}
@@ -687,8 +685,7 @@ for this particular bitmask type.
 All such elements have distinct, nonzero values such that, for any pair \placeholder{Ci}
 and \placeholder{Cj} where \placeholder{i} != \placeholder{j}, \placeholder{Ci} \& \placeholder{Ci} is nonzero and
 \placeholder{Ci} \& \placeholder{Cj} is zero.
-\indextext{bitmask!empty}%
-Additionally, the value 0 is used to represent an \term{empty bitmask}, in which no
+Additionally, the value 0 is used to represent an \defnx{empty bitmask}{bitmask!empty}, in which no
 bitmask elements are set.
 
 \pnum
@@ -729,10 +726,7 @@ is any of the 26 lowercase or 26
 \indextext{uppercase}%
 uppercase letters in the basic execution character set.
 \item
-The
-\term{decimal-point character}
-is the
-\indextext{character!decimal-point}%
+The \defnx{decimal-point character}{character!decimal-point} is the
 (single-byte) character used by functions that convert between a (single-byte)
 character sequence and a value of one of the floating-point types.
 It is used
@@ -780,9 +774,8 @@ A character sequence can be designated by a pointer value
 
 \pnum
 A
-\indextext{string!null-terminated byte}%
 \indextext{NTBS}%
-\term{null-terminated byte string},
+\defnx{null-terminated byte string}{string!null-terminated byte},
 or \ntbs,
 is a character sequence whose highest-addressed element
 with defined content has the value zero
@@ -819,8 +812,7 @@ elements up to and including the terminating null character.
 \pnum
 A
 \indextext{NTBS}%
-\indextext{NTBS!static}%
-\term{static} \ntbs
+\defnx{static}{NTBS!static} \ntbs
 is an \ntbs with
 static storage duration.\footnote{A string literal, such as
 \tcode{"abc"},
@@ -832,9 +824,8 @@ is a static \ntbs.}
 A
 \indextext{NTBS}%
 \indextext{NTMBS}%
-\term{null-terminated multibyte string,}
+\defnx{null-terminated multibyte string}{string!null-terminated multibyte},
 or \ntmbs,
-\indextext{string!null-terminated multibyte}%
 is an \ntbs that constitutes a
 sequence of valid multibyte characters, beginning and ending in the initial
 shift state.\footnote{An \ntbs that contains characters only from the
@@ -843,10 +834,8 @@ Each multibyte character then
 consists of a single byte.}
 
 \pnum
-A
-\term{static} \ntmbs
+A \defnx{static}{NTMBS!static} \ntmbs
 is an \ntmbs with static storage duration.
-\indextext{NTMBS!static}%
 \indextext{NTMBS}%
 
 \rSec3[functions.within.classes]{Functions within classes}
@@ -967,8 +956,7 @@ file names~(\ref{cpp.include}).}
 \pnum
 The \Cpp standard library provides
 61
-\term{\Cpp library headers},
-\indextext{header!C++ library}%
+\defnx{\Cpp library headers}{header!C++ library},
 as shown in Table~\ref{tab:cpp.library.headers}.
 
 \begin{floattable}{\Cpp library headers}{tab:cpp.library.headers}
@@ -1272,11 +1260,10 @@ These names are also subject to the restrictions of~\ref{macro.names}.
 
 \pnum
 Two kinds of implementations are defined:
-\term{hosted}
+\defnx{hosted}{implementation!hosted}
 and
 \term{freestanding}~(\ref{intro.compliance}).
 For a hosted implementation, this International Standard
-\indextext{implementation!hosted}%
 describes the set of available headers.
 
 \pnum

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -3603,146 +3603,146 @@ is a pointer to object type,
 there exist candidate operator functions of the form
 
 \begin{codeblock}
-std::ptrdiff_t   operator-(@\term{T}@, @\term{T}@);
+std::ptrdiff_t   operator-(@\placeholder{T}@, @\placeholder{T}@);
 \end{codeblock}
 
 \pnum
-For every \term{T}, where \term{T} is an enumeration type or a pointer type,
+For every \placeholder{T}, where \placeholder{T} is an enumeration type or a pointer type,
 there exist candidate operator functions of the form
 
 \begin{codeblock}
-bool    operator<(@\term{T}@, @\term{T}@);
-bool    operator>(@\term{T}@, @\term{T}@);
-bool    operator<=(@\term{T}@, @\term{T}@);
-bool    operator>=(@\term{T}@, @\term{T}@);
-bool    operator==(@\term{T}@, @\term{T}@);
-bool    operator!=(@\term{T}@, @\term{T}@);
+bool    operator<(@\placeholder{T}@, @\placeholder{T}@);
+bool    operator>(@\placeholder{T}@, @\placeholder{T}@);
+bool    operator<=(@\placeholder{T}@, @\placeholder{T}@);
+bool    operator>=(@\placeholder{T}@, @\placeholder{T}@);
+bool    operator==(@\placeholder{T}@, @\placeholder{T}@);
+bool    operator!=(@\placeholder{T}@, @\placeholder{T}@);
 \end{codeblock}
 
 \pnum
-For every pointer to member type \term{T} or type \tcode{std::nullptr_t} there
+For every pointer to member type \placeholder{T} or type \tcode{std::nullptr_t} there
 exist candidate operator functions of the form
 
 \begin{codeblock}
-bool    operator==(@\term{T}@, @\term{T}@);
-bool    operator!=(@\term{T}@, @\term{T}@);
+bool    operator==(@\placeholder{T}@, @\placeholder{T}@);
+bool    operator!=(@\placeholder{T}@, @\placeholder{T}@);
 \end{codeblock}
 
 \pnum
 For every pair of promoted integral types
-\term{L}
+\placeholder{L}
 and
-\term{R},
+\placeholder{R},
 there exist candidate operator functions of the form
 
 \begin{codeblock}
-@\term{LR}@      operator%(@\term{L}@, @\term{R}@);
-@\term{LR}@      operator&(@\term{L}@, @\term{R}@);
-@\term{LR}@      operator^(@\term{L}@, @\term{R}@);
-@\term{LR}@      operator|(@\term{L}@, @\term{R}@);
-@\term{L}@       operator<<(@\term{L}@, @\term{R}@);
-@\term{L}@       operator>>(@\term{L}@, @\term{R}@);
+@\placeholder{LR}@      operator%(@\placeholder{L}@, @\placeholder{R}@);
+@\placeholder{LR}@      operator&(@\placeholder{L}@, @\placeholder{R}@);
+@\placeholder{LR}@      operator^(@\placeholder{L}@, @\placeholder{R}@);
+@\placeholder{LR}@      operator|(@\placeholder{L}@, @\placeholder{R}@);
+@\placeholder{L}@       operator<<(@\placeholder{L}@, @\placeholder{R}@);
+@\placeholder{L}@       operator>>(@\placeholder{L}@, @\placeholder{R}@);
 \end{codeblock}
 
 where
-\term{LR}
+\placeholder{LR}
 is the result of the usual arithmetic conversions between types
-\term{L}
+\placeholder{L}
 and
-\term{R}.
+\placeholder{R}.
 
 \pnum
 For every triple
-(\term{L},
-\term{VQ},
-\term{R}),
+(\placeholder{L},
+\placeholder{VQ},
+\placeholder{R}),
 where
-\term{L}
+\placeholder{L}
 is an arithmetic type,
-\term{VQ}
+\placeholder{VQ}
 is either
 \tcode{volatile}
 or empty,
 and
-\term{R}
+\placeholder{R}
 is a promoted arithmetic type,
 there exist candidate operator functions of the form
 
 \begin{codeblock}
-@\term{VQ L}@&   operator=(@\term{VQ L}@&, @\term{R}@);
-@\term{VQ L}@&   operator*=(@\term{VQ L}@&, @\term{R}@);
-@\term{VQ L}@&   operator/=(@\term{VQ L}@&, @\term{R}@);
-@\term{VQ L}@&   operator+=(@\term{VQ L}@&, @\term{R}@);
-@\term{VQ L}@&   operator-=(@\term{VQ L}@&, @\term{R}@);
+@\placeholder{VQ L}@&   operator=(@\placeholder{VQ L}@&, @\placeholder{R}@);
+@\placeholder{VQ L}@&   operator*=(@\placeholder{VQ L}@&, @\placeholder{R}@);
+@\placeholder{VQ L}@&   operator/=(@\placeholder{VQ L}@&, @\placeholder{R}@);
+@\placeholder{VQ L}@&   operator+=(@\placeholder{VQ L}@&, @\placeholder{R}@);
+@\placeholder{VQ L}@&   operator-=(@\placeholder{VQ L}@&, @\placeholder{R}@);
 \end{codeblock}
 
 \pnum
-For every pair (\term{T}, \term{VQ}), where \term{T} is any type and \term{VQ} is either
+For every pair (\placeholder{T}, \placeholder{VQ}), where \placeholder{T} is any type and \placeholder{VQ} is either
 \tcode{volatile} or empty, there exist candidate operator functions of the form
 
 \begin{codeblock}
-@\term{T}@*@\term{VQ}@&   operator=(@\term{T}@*@\term{VQ}@&, @\term{T}@*);
+@\placeholder{T}@*@\placeholder{VQ}@&   operator=(@\placeholder{T}@*@\placeholder{VQ}@&, @\placeholder{T}@*);
 \end{codeblock}
 
 \pnum
 For every pair
-(\term{T},
-\term{VQ}),
+(\placeholder{T},
+\placeholder{VQ}),
 where
-\term{T}
+\placeholder{T}
 is an enumeration or pointer to member type and
-\term{VQ}
+\placeholder{VQ}
 is either
 \tcode{volatile}
 or empty,
 there exist candidate operator functions of the form
 
 \begin{codeblock}
-@\term{VQ} \term{T}@&   operator=(@\term{VQ} \term{T}@&, @\term{T}@);
+@\placeholder{VQ} \placeholder{T}@&   operator=(@\placeholder{VQ} \placeholder{T}@&, @\placeholder{T}@);
 \end{codeblock}
 
 \pnum
 For every pair
-(\term{T},
-\term{VQ}),
+(\placeholder{T},
+\placeholder{VQ}),
 where
-\term{T}
+\placeholder{T}
 is a cv-qualified or cv-unqualified object type and
-\term{VQ}
+\placeholder{VQ}
 is either
 \tcode{volatile}
 or empty,
 there exist candidate operator functions of the form
 
 \begin{codeblock}
-@\term{T}@*@\term{VQ}@&   operator+=(@\term{T}@*@\term{VQ}@&, std::ptrdiff_t);
-@\term{T}@*@\term{VQ}@&   operator-=(@\term{T}@*@\term{VQ}@&, std::ptrdiff_t);
+@\placeholder{T}@*@\placeholder{VQ}@&   operator+=(@\placeholder{T}@*@\placeholder{VQ}@&, std::ptrdiff_t);
+@\placeholder{T}@*@\placeholder{VQ}@&   operator-=(@\placeholder{T}@*@\placeholder{VQ}@&, std::ptrdiff_t);
 \end{codeblock}
 
 \pnum
 For every triple
-(\term{L},
-\term{VQ},
-\term{R}),
+(\placeholder{L},
+\placeholder{VQ},
+\placeholder{R}),
 where
-\term{L}
+\placeholder{L}
 is an integral type,
-\term{VQ}
+\placeholder{VQ}
 is either
 \tcode{volatile}
 or empty,
 and
-\term{R}
+\placeholder{R}
 is a promoted integral type,
 there exist candidate operator functions of the form
 
 \begin{codeblock}
-@\term{VQ L}@&   operator%=(@\term{VQ L}@&, @\term{R}@);
-@\term{VQ L}@&   operator<<=(@\term{VQ L}@&, @\term{R}@);
-@\term{VQ L}@&   operator>>=(@\term{VQ L}@&, @\term{R}@);
-@\term{VQ L}@&   operator&=(@\term{VQ L}@&, @\term{R}@);
-@\term{VQ L}@&   operator^=(@\term{VQ L}@&, @\term{R}@);
-@\term{VQ L}@&   operator|=(@\term{VQ L}@&, @\term{R}@);
+@\placeholder{VQ L}@&   operator%=(@\placeholder{VQ L}@&, @\placeholder{R}@);
+@\placeholder{VQ L}@&   operator<<=(@\placeholder{VQ L}@&, @\placeholder{R}@);
+@\placeholder{VQ L}@&   operator>>=(@\placeholder{VQ L}@&, @\placeholder{R}@);
+@\placeholder{VQ L}@&   operator&=(@\placeholder{VQ L}@&, @\placeholder{R}@);
+@\placeholder{VQ L}@&   operator^=(@\placeholder{VQ L}@&, @\placeholder{R}@);
+@\placeholder{VQ L}@&   operator|=(@\placeholder{VQ L}@&, @\placeholder{R}@);
 \end{codeblock}
 
 \pnum
@@ -3756,21 +3756,21 @@ bool    operator||(bool, bool);
 
 \pnum
 For every pair of promoted arithmetic types
-\term{L}
+\placeholder{L}
 and
-\term{R},
+\placeholder{R},
 there exist candidate operator functions of the form
 
 \begin{codeblock}
-@\term{LR}@      operator?:(bool, @\term{L}@, @\term{R}@);
+@\placeholder{LR}@      operator?:(bool, @\placeholder{L}@, @\placeholder{R}@);
 \end{codeblock}
 
 where
-\term{LR}
+\placeholder{LR}
 is the result of the usual arithmetic conversions between types
-\term{L}
+\placeholder{L}
 and
-\term{R}.
+\placeholder{R}.
 \begin{note}
 As with all these descriptions of candidate functions, this declaration serves
 only to describe the built-in operator for purposes of overload resolution.
@@ -3781,13 +3781,13 @@ cannot be overloaded.
 
 \pnum
 For every type
-\term{T},
+\placeholder{T},
 where
-\term{T}
+\placeholder{T}
 is a pointer, pointer-to-member, or scoped enumeration type, there exist candidate operator
 functions of the form
 
 \begin{codeblock}
-@\term{T}@       operator?:(bool, @\term{T}@, @\term{T}@);
+@\placeholder{T}@       operator?:(bool, @\placeholder{T}@, @\placeholder{T}@);
 \end{codeblock}%
 \indextext{overloading|)}

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -3605,7 +3605,7 @@ namespace std {
 \pnum
 \indextext{\idxcode{regex_iterator}!end-of-sequence}%
 An object of type \tcode{regex_iterator} that is not an end-of-sequence iterator
-holds a \textit{zero-length match} if \tcode{match[0].matched == true} and
+holds a \term{zero-length match} if \tcode{match[0].matched == true} and
 \tcode{match[0].first == match[0].second}. \begin{note} For
 example, this can occur when the part of the regular expression that
 matched consists only of an assertion (such as \verb|'^'|, \verb|'$'|, 
@@ -3900,7 +3900,7 @@ namespace std {
 \end{codeblock}
 
 \pnum
-A \textit{suffix iterator} is a \tcode{regex_token_iterator} object
+A \term{suffix iterator} is a \tcode{regex_token_iterator} object
 that points to a final sequence of characters at
 the end of the target sequence. In a suffix iterator the
 member \tcode{result} holds a pointer to the data
@@ -3916,7 +3916,7 @@ found, and \tcode{suffix\brk.second} is the same as the end of the target
 sequence \end{note}
 
 \pnum
-The \textit{current match} is \tcode{(*position).prefix()} if \tcode{subs[N] == -1}, or
+The \term{current match} is \tcode{(*position).prefix()} if \tcode{subs[N] == -1}, or
 \tcode{(*position)[subs[N]]} for any other value of \tcode{subs[N]}.
 
 \rSec3[re.tokiter.cnstr]{\tcode{regex_token_iterator} constructors}

--- a/source/special.tex
+++ b/source/special.tex
@@ -733,8 +733,7 @@ specifies a conversion from
 the types of its parameters (if any)
 to the type of its class.
 Such a constructor is called a
-\indexdefn{constructor!converting}%
-\term{converting constructor}.
+\defnx{converting constructor}{constructor!converting}.
 \begin{example}
 
 \indextext{Jessie}%

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -56,10 +56,8 @@ A \grammarterm{template-declaration} is also a definition
 if its \grammarterm{declaration} defines a function, a class, a variable, or a
 static data member. A declaration introduced by a template declaration of a
 \indextext{variable template!definition~of}%
-\indextext{template!variable}%
-\indextext{template!static data member}%
-variable is a \term{variable template}. A variable template at class scope is a
-\term{static data member template}.
+variable is a \defnx{variable template}{template!variable}. A variable template at class scope is a
+\defnx{static data member template}{template!static data member}.
 
 \begin{example}
 \begin{codeblock}
@@ -2169,16 +2167,14 @@ declaration.
 \rSec2[temp.class.spec]{Class template partial specializations}
 
 \pnum
-\indextext{specialization!class template partial}%
-\indextext{template!primary}%
 A
-\term{primary}
+\defnx{primary}{template!primary}
 class template declaration is one in which the class template name is an
 identifier.
 A template declaration in which the class template name is a
 \grammarterm{simple-template-id}
 is a
-\term{partial specialization}
+\defnx{partial specialization}{specialization!class template partial}
 of the class template named in the
 \grammarterm{simple-template-id}.
 A partial specialization of a class template provides an alternative definition
@@ -2403,9 +2399,8 @@ of the primary template.
 \rSec3[temp.class.order]{Partial ordering of class template specializations}
 
 \pnum
-\indextext{more~specialized!class~template}%
 For two class template partial specializations,
-the first is \term{more specialized} than the second if, given the following
+the first is \defnx{more specialized}{more~specialized!class~template} than the second if, given the following
 rewrite to two function templates, the first function template is more
 specialized than the second according to the ordering rules for function
 templates~(\ref{temp.func.order}):
@@ -2742,12 +2737,11 @@ template <int I> void f(A<I>, A<I+1+2+3+4>);
 
 \pnum
 \indextext{overloading!resolution!template}%
-\indextext{ordering!function template partial}%
 If a function template is overloaded,
 the use of a function template specialization might be ambiguous because
 template argument deduction~(\ref{temp.deduct}) may associate the function
 template specialization with more than one function template declaration.
-\term{Partial ordering}
+\defnx{Partial ordering}{ordering!function template partial}
 of overloaded function template declarations is used in the following contexts
 to select the function template to which a function template specialization
 refers:
@@ -3581,8 +3575,7 @@ is an
 the
 \grammarterm{unqualified-id}
 denotes a
-\indextext{name!dependent}%
-\term{dependent name}
+\defnx{dependent name}{name!dependent}
 if
 
 \begin{itemize}
@@ -3784,8 +3777,7 @@ template <class T1, class T2, int I> struct B {
 \end{example}
 
 \pnum
-\indextext{base class!dependent}%
-A \term{dependent base class} is a base class that is a dependent type and is
+A \defnx{dependent base class}{base class!dependent} is a base class that is a dependent type and is
 not the current instantiation.
 \begin{note}
 a base class can be the current instantiation in the case of a nested class
@@ -3808,9 +3800,8 @@ template<class T> struct A<T>::B::C : A<T> {
 \end{note}
 
 \pnum
-\indextext{instantiation!member of the current}%
 A name is a
-\term{member of the current instantiation}
+\defnx{member of the current instantiation}{instantiation!member of the current}
 if it is
 
 \begin{itemize}
@@ -3863,8 +3854,9 @@ template <class T> int A<T>::f() {
 \end{codeblock}
 \end{example}
 
-\indextext{instantiation!dependent member of the current}%
-A name is a \term{dependent member of the current instantiation} if it is a
+A name is a
+\defnx{dependent member of the current instantiation}{instantiation!dependent member of the current}
+if it is a
 member of the current instantiation that, when looked up, refers to at least
 one member of a class that is the current instantiation.
 
@@ -6707,7 +6699,6 @@ at least as specialized as the argument type.
 \end{itemize}
 
 \pnum
-\indextext{more~specialized!function~template}%
 \indextext{at~least~as specialized~as|see{more~specialized}}%
 Function template \tcode{F}
 is \term{at least as specialized as}
@@ -6717,7 +6708,7 @@ the type from \tcode{F}
 is at least as specialized as
 the type from \tcode{G}.
 \tcode{F}
-is \term{more specialized than}
+is \defnx{more specialized than}{more~specialized!function~template}
 \tcode{G} if
 \tcode{F}
 is at least as specialized as

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -12004,7 +12004,7 @@ template <class OuterA1, class OuterA2, class... InnerAllocs>
 \rSec1[function.objects]{Function objects}
 
 \pnum
-A \indexdefn{function object!type}\term{function object type} is an object
+A \defnx{function object type}{function object!type} is an object
 type~(\ref{basic.types}) that can be the type of the
 \grammarterm{postfix-expression} in a function call
 (\ref{expr.call},~\ref{over.match.call}).\footnote{Such a type is a function
@@ -12224,30 +12224,24 @@ transform(a.begin(), a.end(), a.begin(), negate<double>());
 The following definitions apply to this Clause:
 
 \pnum
-\indexdefn{call signature}%
-A \term{call signature} is the name of a return type followed by a
+A \defn{call signature} is the name of a return type followed by a
 parenthesized comma-separated list of zero or more argument types.
 
 \pnum
-\indexdefn{callable type}%
-A \term{callable type} is a function object type~(\ref{function.objects}) or a pointer to member.
+A \defn{callable type} is a function object type~(\ref{function.objects}) or a pointer to member.
 
 \pnum
-\indexdefn{callable object}%
-A \term{callable object} is an object of a callable type.
+A \defn{callable object} is an object of a callable type.
 
 \pnum
-\indexdefn{call wrapper!type}%
-A \term{call wrapper type} is a type that holds a callable object
+A \defnx{call wrapper type}{call wrapper!type} is a type that holds a callable object
 and supports a call operation that forwards to that object.
 
 \pnum
-\indexdefn{call wrapper}%
-A \term{call wrapper} is an object of a call wrapper type.
+A \defn{call wrapper} is an object of a call wrapper type.
 
 \pnum
-\indexdefn{target object}%
-A \term{target object} is the callable object held by a call wrapper.
+A \defn{target object} is the callable object held by a call wrapper.
 
 \rSec2[func.require]{Requirements}
 
@@ -12295,16 +12289,14 @@ to \tcode{R}.
 \indextext{call wrapper}%
 \indextext{call wrapper!simple}%
 \indextext{call wrapper!forwarding}%
-\indextext{simple call wrapper}%
-\indextext{forwarding call wrapper}%
 Every call wrapper~(\ref{func.def}) shall be
 \tcode{MoveConstructible}.
-A \term{forwarding call wrapper} is a
+A \defn{forwarding call wrapper} is a
 call wrapper that can be called with an arbitrary argument list
 and delivers the arguments to the wrapped callable object as references.
 This forwarding step shall ensure that rvalue arguments are delivered as rvalue references
 and lvalue arguments are delivered as lvalue references.
-A \term{simple call wrapper} is a forwarding call wrapper that is
+A \defn{simple call wrapper} is a forwarding call wrapper that is
 \tcode{CopyConstructible} and \tcode{CopyAssignable} and
 whose copy constructor, move constructor, and assignment operator
 do not throw exceptions.


### PR DESCRIPTION
No visual difference in the PDF.