### PR TITLE
NB GB-29 (C++17 CD): [intro.defs] move block and unblock definitions

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -143,6 +143,12 @@ comma-separated list bounded by the parentheses~(\ref{cpp.replace})
 \grammarterm{id-expression} in the comma-separated
 list bounded by the angle brackets~(\ref{temp.arg})
 
+\indexdefn{block}%
+\definition{block}{defns.block}
+a thread of execution that blocks is waiting for some condition (other than
+for the implementation to execute its execution steps) to be satisfied before
+it can continue execution past the blocking operation
+
 \indexdefn{behavior!conditionally-supported}%
 \definition{conditionally-supported}{defns.cond.supp}
 program construct that an implementation is not required to support\\
@@ -257,6 +263,10 @@ analysis of the program without considering execution semantics\\
 static type of an expression depends only on the form of the program in
 which the expression appears, and does not change while the program is
 executing. \end{note}
+
+\indexdefn{unblock}%
+\definition{unblock}{defns.unblock}
+satisfy a condition that one or more blocked threads of execution are waiting for
 
 \indexdefn{behavior!undefined}%
 \definition{undefined behavior}{defns.undefined}

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -136,12 +136,6 @@ a stream (described in Clause~\ref{input.output}) that can seek to any integral 
 the length of the stream\\
 \begin{note} Every arbitrary-positional stream is also a repositional stream. \end{note}
 
-\definition{block}{defns.block}
-\indexdefn{block}%
-a thread of execution that blocks is waiting for some condition (other than
-for the implementation to execute its execution steps) to be satisfied before
-it can continue execution past the blocking operation
-
 \definition{character}{defns.character}
 \indexdefn{character}%
 \defncontext{Clauses~\ref{strings}, \ref{localization}, \ref{input.output}, and~\ref{re}}
@@ -352,10 +346,6 @@ Traits classes defined in Clauses~\ref{strings}, \ref{localization} and~\ref{inp
 \term{character traits}, which provide the character handling support needed by the string and
 iostream classes.
 \end{note}
-
-\definition{unblock}{defns.unblock}
-\indexdefn{unblock}%
-satisfy a condition that one or more blocked threads of execution are waiting for
 
 \definition{valid but unspecified state}{defns.valid}
 \indexdefn{valid but unspecified state}%


### PR DESCRIPTION
Move the definitions of block and unblock to the clause 1
definitions subclause, rather than the library definitions
subclause, as the memory model relies on these terms.