### PR TITLE
[istream.extractors] rename stable name from istream::extractors

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -4239,7 +4239,7 @@ namespace std {
     void swap(basic_istream& rhs);
   };
 
-  // \ref{istream::extractors}, character extraction templates:
+  // \ref{istream.extractors}, character extraction templates:
   template<class charT, class traits>
     basic_istream<charT, traits>& operator>>(basic_istream<charT, traits>&,
                                              charT&);
@@ -4677,7 +4677,7 @@ setstate(err);
 \end{codeblock}
 \end{itemdescr}
 
-\rSec4[istream::extractors]{\tcode{basic_istream::operator\shr}}
+\rSec4[istream.extractors]{\tcode{basic_istream::operator\shr}}
 
 \indexlibrarymember{operator\shr}{basic_istream}%
 \begin{itemdecl}
@@ -7194,7 +7194,7 @@ template <class charT, class traits, class Allocator>
 and \tcode{traits}, respectively, then the expression
 \tcode{in \shr\ quoted(s, delim, escape)} behaves as if it extracts the following
 characters from \tcode{in} using
-\tcode{basic_istream::operator\shr}~(\ref{istream::extractors})
+\tcode{basic_istream::operator\shr}~(\ref{istream.extractors})
 which may throw \tcode{ios_base::failure}\brk{}~(\ref{ios::failure}):
 \begin{itemize}
 \item If the first character extracted is equal to \tcode{delim}, as


### PR DESCRIPTION
Fixes #271.