### PR TITLE
[intro.multithread] add 'std' to standard library names

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -787,9 +787,9 @@ operation).
 \indextext{behavior!on receipt of signal}%
 \indextext{signal}%
 \pnum
-If a signal handler is executed as a result of a call to the \tcode{raise}
+If a signal handler is executed as a result of a call to the \tcode{std::raise}
 function, then the execution of the handler is sequenced after the invocation
-of the \tcode{raise} function and before its return.
+of the \tcode{std::raise} function and before its return.
 \begin{note} When a signal is received for another reason, the execution of the
 signal handler is usually unsequenced with respect to the rest of the program.
 \end{note}
@@ -1071,10 +1071,9 @@ threads in a program under a freestanding implementation} whether a program can
 have more than one thread of execution.
 
 \pnum
-A signal handler that is executed as a result of a call to the \tcode{raise}
-function belongs to the same thread of execution as the call to the
-\tcode{raise} function. Otherwise it is unspecified which thread of execution
-contains a signal handler invocation.
+For a signal handler that is not executed as a result of a call to the
+\tcode{std::raise} function, it is unspecified which thread of execution
+contains the signal handler invocation.
 
 \rSec2[intro.races]{Data races}
 
@@ -1387,13 +1386,13 @@ transformations continue to be allowed, since any program that behaves
 differently as a result must perform an undefined operation. \end{note}
 
 \pnum
-Two accesses to the same object of type \tcode{volatile sig_atomic_t} do not
+Two accesses to the same object of type \tcode{volatile std::sig_atomic_t} do not
 result in a data race if both occur in the same thread, even if one or more
 occurs in a signal handler. For each signal handler invocation, evaluations
 performed by the thread invoking a signal handler can be divided into two
 groups \placeholder{A} and \placeholder{B}, such that no evaluations in
 \placeholder{B} happen before evaluations in \placeholder{A}, and the
-evaluations of such \tcode{volatile sig_atomic_t} objects take values as though
+evaluations of such \tcode{volatile std::sig_atomic_t} objects take values as though
 all evaluations in \placeholder{A} happened before the execution of the signal
 handler and the execution of the signal handler happened before all evaluations
 in \placeholder{B}.


### PR DESCRIPTION
remove redundant description of same-thread signal handler execution
Fixes #285.

(If something is sequenced before something else, it's also on the same thread. No need to say that again.)