### PR TITLE
[diff.cpp11.lex] fix example for digit separators

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1354,9 +1354,9 @@ separators in this International Standard:
 
 \begin{codeblock}
 #define M(x, ...) __VA_ARGS__
-int x[2] = { M(1'2,3'4) };
-// \tcode{int x[2] = \{\};\ \ \ \ \ } --- \CppXI
-// \tcode{int x[2] = \{ 3'4 \};} --- this International Standard
+int x[2] = { M(1'2,3'4, 5) };
+// \tcode{int x[2] = \{ 5 \};\ \ \ \ \ } --- \CppXI
+// \tcode{int x[2] = \{ 3'4, 5 \};} --- this International Standard
 \end{codeblock}
 
 \rSec2[diff.cpp11.basic]{Clause \ref{basic}: basic concepts}


### PR DESCRIPTION
Fixes #306.