### PR TITLE
[numeric.limits.members] replace IEC 559 by ISO/IEC/IEEE 60559

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -633,7 +633,8 @@ static constexpr bool has_denorm_loss;
 \begin{itemdescr}
 \pnum
 True if loss of accuracy is detected as a
-denormalization loss, rather than as an inexact result.\footnote{See IEC 559.}
+denormalization loss, rather than as an inexact result.\footnote{See
+ISO/IEC/IEEE 60559.}
 \end{itemdescr}
 
 \indexlibrarymember{infinity}{numeric_limits}%
@@ -709,9 +710,8 @@ static constexpr bool is_iec559;
 
 \begin{itemdescr}
 \pnum
-True if and only if the type adheres to IEC 559 standard.\footnote{International
-Electrotechnical Commission standard 559 is the same as
-IEEE 754.}
+True if and only if the type adheres to ISO/IEC/IEEE
+60559.\footnote{ISO/IEC/IEEE 60559:2011 is the same as IEEE 754-2008.}
 
 \pnum
 Meaningful for all floating point types.
@@ -779,7 +779,8 @@ static constexpr bool tinyness_before;
 \begin{itemdescr}
 \pnum
 \tcode{true}
-if tinyness is detected before rounding.\footnote{Refer to IEC 559.
+if tinyness is detected before rounding.\footnote{Refer to
+ISO/IEC/IEEE 60559.
 Required by LIA-1.}
 
 \pnum


### PR DESCRIPTION
Fixes #343.

We should probably add a bullet to 1.2 "normative references", too, but that didn't exist before, so would be a more substantive change.