### PR TITLE
[facet.num.get.virtuals] Clarify 'fails to convert' for empty sequence

### DIFF
--- a/source/locales.tex
+++ b/source/locales.tex
@@ -3051,7 +3051,7 @@ The sequence of \tcode{char}{s} accumulated in stage 2 (the field) is converted 
 The numeric value to be stored can be one of:
 
 \begin{itemize}
-\item zero, if the conversion function fails to convert the entire field.
+\item zero, if the conversion function does not convert the entire field.
 
 \item the most positive (or negative) representable value,
 if the field to be converted to a signed integer type represents a value
@@ -3065,7 +3065,7 @@ that cannot be represented in \tcode{val}.
 \end{itemize}
 
 The resultant numeric value is stored in \tcode{val}.
-If the conversion function fails to convert the entire field, or
+If the conversion function does not convert the entire field, or
 if the field represents a value outside the range of representable values,
 \tcode{ios_base::failbit} is assigned to \tcode{err}.
 


### PR DESCRIPTION
Fixes #378.