### PR TITLE
[over.match] 'underlying type' for a reference is undefined

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -1323,8 +1323,8 @@ to a glvalue or class prvalue that is the result of applying a conversion
 function to an initializer expression.
 Overload resolution is used to select the
 conversion function to be invoked.
-Assuming that ``\textit{cv1} \tcode{T}'' is the
-underlying type of the reference being initialized, and
+Assuming that ``reference to \textit{cv1} \tcode{T}'' is the
+type of the reference being initialized, and
 ``\textit{cv} \tcode{S}'' is the type
 of the initializer expression, with
 \tcode{S}
@@ -2071,9 +2071,9 @@ of the parameter type, a derived-to-base Conversion.
 \pnum
 When a parameter of reference type is not bound directly to an argument
 expression, the conversion sequence is the one required to convert the argument
-expression to the underlying type of the reference according to~\ref{over.best.ics}.
+expression to the referenced type according to~\ref{over.best.ics}.
 Conceptually, this conversion sequence corresponds to copy-initializing a
-temporary of the underlying type with the argument expression.
+temporary of the referenced type with the argument expression.
 Any difference
 in top-level cv-qualification is subsumed by the initialization itself and
 does not constitute a conversion.
@@ -2130,7 +2130,7 @@ required to convert the element to the parameter type.
 \pnum
 Otherwise, if the parameter type is a character array%
 \footnote{Since there are no parameters of array type,
-this will only occur as the underlying type of a reference parameter.}
+this will only occur as the referenced type of a reference parameter.}
 and the initializer list has a single element that is an appropriately-typed
 string literal~(\ref{dcl.init.string}), the implicit conversion
 sequence is the identity conversion.


### PR DESCRIPTION
Fixes #391.