### PR TITLE
[dcl.type.simple] Add decltype(auto) to the table giving meaning to

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1370,6 +1370,7 @@ double                          &   ``double''              \\
 long double                     &   ``long double''         \\
 void                            &   ``void''                \\
 auto                            & placeholder for a type to be deduced\\
+decltype(auto)                  & placeholder for a type to be deduced\\
 decltype(\grammarterm{expression}) &   the type as defined below\\
 \end{simpletypetable}
 


### PR DESCRIPTION
simple-type-specifiers.

Fixes #436.