### PR TITLE
[vector.bool] Excise use of undefined term 'conversion operator'

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1289,7 +1289,7 @@ binary representation of the required template specializations of
 \ref{istream::sentry},
 \ref{ostream::sentry},
 \ref{iostate.flags}
-\change Specify use of explicit in existing boolean conversion operators
+\change Specify use of explicit in existing boolean conversion functions
 \rationale Clarify intentions, avoid workarounds.
 \effect
 Valid \CppIII code that relies on implicit boolean conversions will fail to

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -5701,7 +5701,7 @@ recommended instead.
 \pnum
 \tcode{reference}
 is a class that simulates the behavior of references of a single bit in
-\tcode{vector<bool>}. The conversion operator returns \tcode{true}
+\tcode{vector<bool>}. The conversion function returns \tcode{true}
 when the bit is set, and \tcode{false} otherwise. The assignment operator
 sets the bit when the argument is (convertible to) \tcode{true} and
 clears it otherwise. \tcode{flip} reverses the state of the bit.

--- a/source/special.tex
+++ b/source/special.tex
@@ -799,7 +799,6 @@ it may be called for implicit type conversions.
 \indextext{function!conversion}%
 \indextext{fundamental~type~conversion|see{conversion, user-defined}}%
 \indextext{conversion!user-defined}%
-\indextext{conversion operator|see{conversion, user defined}}
 
 \pnum
 A member function of a class \tcode{X} having no parameters with a name of the form


### PR DESCRIPTION
Fixes #444.