### PR TITLE
[intro.execution] Adjust example to new rules for sequencing of

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -999,11 +999,11 @@ potentially concurrent computations.
 
 \begin{codeblock}
 void f(int, int);
-void g(int i, int* v) {
-  i = v[i++];         // the behavior is undefined
+void g(int i) {
   i = 7, i++, i++;    // \tcode{i} becomes \tcode{9}
 
-  i = i++ + 1;        // the behavior is undefined
+  i = i++ + 1;        // the value of \tcode{i} is incremented
+  i = i++ + i;        // the behavior is undefined
   i = i + 1;          // the value of \tcode{i} is incremented
 }
 \end{codeblock}


### PR DESCRIPTION
expressions.

Fixes #953.