### PR TITLE
[expr.dynamic.cast] Remove redundant specification of value category

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1971,8 +1971,7 @@ object referred to by \tcode{v}.
 \footnote{The most derived object~(\ref{intro.object}) pointed or referred to by
 \tcode{v} can contain other \tcode{B} objects as base classes, but these
 are ignored.}
-The result is an lvalue if \tcode{T} is an lvalue reference, or an
-xvalue if \tcode{T} is an rvalue reference. In both the pointer and
+In both the pointer and
 reference cases, the program is ill-formed if \cvqual{cv2} has greater
 cv-qualification than \cvqual{cv1} or if \tcode{B} is an inaccessible or
 ambiguous base class of \tcode{D}.


### PR DESCRIPTION
for a dynamic_cast to reference type.

Fixes #450.