### PR TITLE
[expr.const] Avoid 'value' of a glvalue in definition of

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5129,7 +5129,7 @@ the conversion sequence contains only the conversions above.
 \pnum
 \indextext{expression!constant}%
 A \term{constant expression} is either
-a glvalue core constant expression whose value refers to
+a glvalue core constant expression that refers to
 an entity that is a permitted result of a constant expression (as defined below), or
 a prvalue core constant expression whose value
 satisfies the following constraints:


### PR DESCRIPTION
constant expressions.

Fixes #594.