### PR TITLE
[string.require] Add note that traits::char_type is the same as

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -1153,6 +1153,10 @@ as \tcode{charT}. Every object of type
 \tcode{Allocator} to allocate and free storage for the contained \tcode{charT}
 objects as needed. The \tcode{Allocator} object used shall be
 obtained as described in \ref{container.requirements.general}.
+\begin{note} In every specialization
+\tcode{basic_string<charT, traits, Allocator>}, the type
+\tcode{traits::char_type} shall be the same type as
+\tcode{charT}; see \ref{char.traits}. \end{note}
 
 \pnum
 References, pointers, and iterators referring to the elements of a


### PR DESCRIPTION
charT for basic_string specializations.

Fixes #198.