### PR TITLE
[containers] Consistent semicolons in tables

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -159,7 +159,7 @@ denotes a non-const rvalue of type \tcode{X}.
  into \tcode{X} (see below).\br post: \tcode{a == X(a)}.         &
  linear                     \\ \rowsep
 
-\tcode{X u(a)}\br
+\tcode{X u(a);}\br
 \tcode{X u = a;}            &
                             &
                             &
@@ -168,8 +168,8 @@ denotes a non-const rvalue of type \tcode{X}.
  post: \tcode{u == a}       &
  linear                     \\ \rowsep
 
-\tcode{X u(rv)}\br
-\tcode{X u = rv}            &
+\tcode{X u(rv);}\br
+\tcode{X u = rv;}            &
                             &
                             &
   post: \tcode{u} shall be equal to the value that \tcode{rv} had before this construction
@@ -655,7 +655,7 @@ post: \tcode{u == t}, \tcode{u.get_allocator() == m} &
 linear													\\ \rowsep
 
 \tcode{X(rv)}\br
-\tcode{X u(rv)}
+\tcode{X u(rv);}
            &
            &
   \requires move construction of \tcode{A} shall not exit via an exception.\br
@@ -798,7 +798,7 @@ The complexities of the expressions are sequence dependent.
                         &                       &   \rhdr{pre-/post-condition}   \\ \capsep
 \endhead
 \tcode{X(n, t)}\br
-\tcode{X u(n, t)}   &
+\tcode{X u(n, t);}   &
                 &
  \requires\ \tcode{T} shall be
  \tcode{CopyInsertable} into \tcode{X}.\br
@@ -806,7 +806,7 @@ The complexities of the expressions are sequence dependent.
  Constructs a sequence container with \tcode{n} copies of \tcode{t}  \\ \rowsep
 
 \tcode{X(i, j)}\br
-\tcode{X u(i, j)}   &
+\tcode{X u(i, j);}   &
                     &
  \requires\ \tcode{T} shall be \tcode{EmplaceConstructible} into \tcode{X} from \tcode{*i}.
  For \tcode{vector}, if the iterator does
@@ -818,11 +818,11 @@ The complexities of the expressions are sequence dependent.
  \tcode{distance(i, j)}\br
  Constructs a sequence container equal to the range \tcode{[i, j)}    \\ \rowsep
 
-\tcode{X(il);}      &
+\tcode{X(il)}      &
                     &
   Equivalent to \tcode{X(il.begin(), il.end())} \\ \rowsep
 
-\tcode{a = il;}     &
+\tcode{a = il}     &
   \tcode{X\&}               &
   \requires\ \tcode{T} is
   \tcode{CopyInsertable} into \tcode{X}
@@ -832,7 +832,7 @@ The complexities of the expressions are sequence dependent.
   \returns\ \tcode{*this}.
   \\ \rowsep
 
-\tcode{a.emplace(p, args);}  &
+\tcode{a.emplace(p, args)}  &
  \tcode{iterator}            &
  \requires\ \tcode{T} is \tcode{EmplaceConstructible} into \tcode{X} from \tcode{args}. For \tcode{vector} and \tcode{deque},
  T is also
@@ -871,7 +871,7 @@ The complexities of the expressions are sequence dependent.
  pre: \tcode{i} and \tcode{j} are not iterators into \tcode{a}.\br
  Inserts copies of elements in \tcode{[i, j)} before \tcode{p}  \\ \rowsep
 
-\tcode{a.insert(p, il);}  &
+\tcode{a.insert(p, il)}  &
   \tcode{iterator}            &
   \tcode{a.insert(p, il.begin(), il.end())}.  \\ \rowsep
 
@@ -1658,12 +1658,12 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
   \effects\ Same as above, but uses \tcode{Compare()} as a comparison object.  &
   same as above                      \\ \rowsep
 
-\tcode{X(il);}            &
+\tcode{X(il)}            &
                           &
   Same as \tcode{X(il.begin(), il.end())}.  &
   Same as \tcode{X(il.begin(), il.end())}.  \\ \rowsep
 
-\tcode{X(il,c);}          &
+\tcode{X(il,c)}          &
                           &
   Same as \tcode{X(il.begin(), il.end(), c)}.  &
   Same as \tcode{X(il.begin(), il.end(), c)}.  \\ \rowsep
@@ -2271,7 +2271,7 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
  &
  compile time \\ \rowsep
 %
-\tcode{X(n, hf, eq)}\br \tcode{X a(n, hf, eq)}
+\tcode{X(n, hf, eq)}\br \tcode{X a(n, hf, eq);}
 &   \tcode{X}
 &   \effects\ Constructs an empty container with at least \tcode{n} buckets,
 using \tcode{hf} as the hash function and \tcode{eq} as the key
@@ -2279,7 +2279,7 @@ equality predicate.
 &   \bigoh{\tcode{n}}
 \\ \rowsep
 %
-\tcode{X(n, hf)}\br \tcode{X a(n, hf)}
+\tcode{X(n, hf)}\br \tcode{X a(n, hf);}
 &   \tcode{X}
 &   \requires\ \tcode{key_equal} is \tcode{DefaultConstructible}.\br
     \effects\ Constructs an empty container with at least \tcode{n} buckets,
@@ -2288,7 +2288,7 @@ equality predicate.
 &   \bigoh{\tcode{n}}
 \\ \rowsep
 %
-\tcode{X(n)}\br \tcode{X a(n)}
+\tcode{X(n)}\br \tcode{X a(n);}
 &   \tcode{X}
 &   \requires\ \tcode{hasher} and \tcode{key_equal} are \tcode{DefaultConstructible}.\br
     \effects\ Constructs an empty container with at least \tcode{n} buckets,
@@ -2297,7 +2297,7 @@ as the key equality predicate.
 &   \bigoh{\tcode{n}}
 \\ \rowsep
 %
-\tcode{X()}\br \tcode{X a}
+\tcode{X()}\br \tcode{X a;}
 &   \tcode{X}
 &   \requires\ \tcode{hasher} and \tcode{key_equal} are \tcode{DefaultConstructible}.\br
     \effects\ Constructs an empty container with an unspecified number of
@@ -2306,7 +2306,7 @@ as the key equality predicate.
 &   constant
 \\ \rowsep
 %
-\tcode{X(i, j, n, hf, eq)}\br \tcode{X a(i, j, n, hf, eq)}
+\tcode{X(i, j, n, hf, eq)}\br \tcode{X a(i, j, n, hf, eq);}
 &   \tcode{X}
 &   \requires\ \tcode{value_type} is \tcode{EmplaceConstructible} into \tcode{X} from \tcode{*i}.\br
     \effects\ Constructs an empty container with at least \tcode{n} buckets,
@@ -2316,7 +2316,7 @@ equality predicate, and inserts elements from \tcode{[i, j)} into it.
 \bigoh{N^2}
 \\ \rowsep
 %
-\tcode{X(i, j, n, hf)}\br \tcode{X a(i, j, n, hf)}
+\tcode{X(i, j, n, hf)}\br \tcode{X a(i, j, n, hf);}
 &   \tcode{X}
 &   \requires\ \tcode{key_equal} is \tcode{DefaultConstructible}.
     \tcode{value_type} is \tcode{EmplaceConstructible} into \tcode{X} from \tcode{*i}.\br
@@ -2327,7 +2327,7 @@ equality predicate, and inserts elements from \tcode{[i, j)} into it.
 \bigoh{N^2}
 \\ \rowsep
 %
-\tcode{X(i, j, n)}\br \tcode{X a(i, j, n)}
+\tcode{X(i, j, n)}\br \tcode{X a(i, j, n);}
 &   \tcode{X}
 &   \requires\ \tcode{hasher} and \tcode{key_equal} are \tcode{DefaultConstructible}.
     \tcode{value_type} is \tcode{EmplaceConstructible} into \tcode{X} from \tcode{*i}.\br
@@ -2339,7 +2339,7 @@ into it.
 \bigoh{N^2}
 \\ \rowsep
 %
-\tcode{X(i, j)}\br \tcode{X a(i, j)}
+\tcode{X(i, j)}\br \tcode{X a(i, j);}
 &   \tcode{X}
 &   \requires\ \tcode{hasher} and \tcode{key_equal} are \tcode{DefaultConstructible}.
     \tcode{value_type} is \tcode{EmplaceConstructible} into \tcode{X} from \tcode{*i}.\br
@@ -2375,7 +2375,7 @@ from \tcode{[i, j)} into it.
 &   Same as \tcode{X(il.begin(),} \tcode{il.end(), n, hf, eq)}.
 \\ \rowsep
 %
-\tcode{X(b)}\br \tcode{X a(b)}
+\tcode{X(b)}\br \tcode{X a(b);}
 &   \tcode{X}
 &   Copy constructor.  In addition to the requirements
     of Table~\ref{tab:containers.container.requirements}, copies the


### PR DESCRIPTION
The tables that list requirements contain both expressions and variable definitions. Most of the standard is consistent in using semicolons after the variable definitions, but not after expressions. This patch fixes the deviations from that.