### PR TITLE
[whole standard] Add a space before \begin{example}

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -642,7 +642,7 @@ value. \end{example}
 \begin{note}
 \indextext{name~hiding}%
 a name from an outer scope remains visible up
-to the point of declaration of the name that hides it.\begin{example}
+to the point of declaration of the name that hides it. \begin{example}
 
 \begin{codeblock}
 const int  i = 2;
@@ -670,7 +670,7 @@ constructor is immediately after the \grammarterm{using-declaration}~(\ref{names
 \pnum
 \indextext{declaration!enumerator point~of}%
 The point of declaration for an enumerator is immediately after its
-\grammarterm{enumerator-definition}.\begin{example}
+\grammarterm{enumerator-definition}. \begin{example}
 
 \begin{codeblock}
 const int x = 12;
@@ -1624,7 +1624,7 @@ in a \grammarterm{nested-name-specifier} is not preceded by a \grammarterm{declt
 lookup of the name preceding that \tcode{::} considers only namespaces, types, and
 templates whose specializations are types. If the
 name found does not designate a namespace or a class, enumeration, or dependent type,
-the program is ill-formed.\begin{example}
+the program is ill-formed. \begin{example}
 
 \begin{codeblock}
 class A {
@@ -2330,7 +2330,7 @@ of an entity with linkage having the same name and type, ignoring entities decla
 outside the innermost enclosing namespace scope, the block scope declaration declares
 that same entity and receives the linkage of the previous declaration. If there is more
 than one such matching entity, the program is ill-formed. Otherwise, if no matching
-entity is found, the block scope entity receives external linkage.\begin{example}
+entity is found, the block scope entity receives external linkage. \begin{example}
 
 \begin{codeblock}
 static void f();

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2217,7 +2217,7 @@ declared in the scope that immediately contains the \grammarterm{enum-specifier}
 Each scoped \grammarterm{enumerator} is declared in the scope of the
 enumeration.
 These names obey the scope rules defined for all names
-in~(\ref{basic.scope}) and~(\ref{basic.lookup}).\begin{example}
+in~(\ref{basic.scope}) and~(\ref{basic.lookup}). \begin{example}
 
 \begin{codeblock}
 enum direction { left='l', right='r' }; 

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -3938,7 +3938,7 @@ corresponding element of the initializer list, and the
 \begin{note} A constructor or conversion function selected for the copy shall be
 accessible (Clause~\ref{class.access}) in the context of the initializer list.
 \end{note}
-If a narrowing conversion is required to initialize any of the elements, the program is ill-formed.\begin{example}
+If a narrowing conversion is required to initialize any of the elements, the program is ill-formed. \begin{example}
 \begin{codeblock}
 struct X {
   X(std::initializer_list<double> v);

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -3456,7 +3456,7 @@ Decimal point characters(.) are replaced by
 A local variable is initialized as
 
 \begin{codeblock}
-fmtflags adjustfield=   (flags & (ios_base::adjustfield));
+fmtflags adjustfield = (flags & (ios_base::adjustfield));
 \end{codeblock}
  
 The location of any padding\footnote{The conversion specification


### PR DESCRIPTION
Add missing spaces before examples and normalize an odd codeblock.