### PR TITLE
[atomics] Clean up indexing of atomics clause

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -379,6 +379,16 @@ value~(\ref{intro.multithread}).
 
 \rSec1[atomics.lockfree]{Lock-free property}
 
+\indexlibrary{\idxcode{ATOMIC_BOOL_LOCK_FREE}}%
+\indexlibrary{\idxcode{ATOMIC_CHAR_LOCK_FREE}}%
+\indexlibrary{\idxcode{ATOMIC_CHAR16_T_LOCK_FREE}}%
+\indexlibrary{\idxcode{ATOMIC_CHAR32_T_LOCK_FREE}}%
+\indexlibrary{\idxcode{ATOMIC_WCHAR_T_LOCK_FREE}}%
+\indexlibrary{\idxcode{ATOMIC_SHORT_LOCK_FREE}}%
+\indexlibrary{\idxcode{ATOMIC_INT_LOCK_FREE}}%
+\indexlibrary{\idxcode{ATOMIC_LONG_LOCK_FREE}}%
+\indexlibrary{\idxcode{ATOMIC_LLONG_LOCK_FREE}}%
+\indexlibrary{\idxcode{ATOMIC_POINTER_LOCK_FREE}}%
 \indeximpldef{values of various \tcode{ATOMIC_..._LOCK_FREE} macros}
 \begin{codeblock}
 #define ATOMIC_BOOL_LOCK_FREE @\unspec@
@@ -421,12 +431,15 @@ processes. \end{note}
 
 \rSec1[atomics.types.generic]{Atomic types}
 
+\indexlibrary{\idxcode{atomic}}%
+\indexlibrary{\idxcode{atomic<T*>}}%
+\indexlibrary{\idxcode{atomic<\placeholder{integral}>}}%
 \begin{codeblock}
 namespace std {
   template <class T> struct atomic {
+    static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic} type's operations are always lock free}@;
     bool is_lock_free() const volatile noexcept;
     bool is_lock_free() const noexcept;
-    static constexpr bool is_always_lock_free = @\impdef{}@;
     void store(T, memory_order = memory_order_seq_cst) volatile noexcept;
     void store(T, memory_order = memory_order_seq_cst) noexcept;
     T load(memory_order = memory_order_seq_cst) const volatile noexcept;
@@ -454,9 +467,9 @@ namespace std {
   };
 
   template <> struct atomic<@\placeholder{integral}@> {
+    static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic} type's operations are always lock free}@;
     bool is_lock_free() const volatile noexcept;
     bool is_lock_free() const noexcept;
-    static constexpr bool is_always_lock_free = @\impdef{}@;
     void store(@\placeholdernc{integral}@, memory_order = memory_order_seq_cst) volatile noexcept;
     void store(@\placeholdernc{integral}@, memory_order = memory_order_seq_cst) noexcept;
     @\placeholdernc{integral}@ load(memory_order = memory_order_seq_cst) const volatile noexcept;
@@ -513,9 +526,9 @@ namespace std {
   };
 
   template <class T> struct atomic<T*> {
+    static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic} type's operations are always lock free}@;
     bool is_lock_free() const volatile noexcept;
     bool is_lock_free() const noexcept;
-    static constexpr bool is_always_lock_free = @\impdef{}@;
     void store(T*, memory_order = memory_order_seq_cst) volatile noexcept;
     void store(T*, memory_order = memory_order_seq_cst) noexcept;
     T* load(memory_order = memory_order_seq_cst) const volatile noexcept;
@@ -561,6 +574,7 @@ namespace std {
 }
 \end{codeblock}
 
+\indexlibrary{\idxcode{atomic}}%
 \pnum
 There is a generic class template \tcode{atomic<T>}. The type of the template argument
 \tcode{T} shall be trivially copyable~(\ref{basic.types}). \begin{note} Type arguments that are
@@ -574,6 +588,7 @@ in~\ref{atomics.types.operations}.
 Specializations and instantiations of the \tcode{atomic} template shall have a deleted copy constructor, a deleted
 copy assignment operator, and a constexpr value constructor.
 
+\indexlibrary{\idxcode{atomic<\placeholder{integral}>}}%
 \pnum
 There shall be explicit specializations of the \tcode{atomic}
 template for the integral types
@@ -593,7 +608,7 @@ template for the integral types
 \tcode{wchar_t},
 and any other types needed by the typedefs in the header \tcode{<cstdint>}.
 For each integral type \tcode{\placeholder{integral}}, the specialization
-\tcode{atomic<integral>} provides additional atomic operations appropriate to integral types.
+\tcode{atomic<\placeholder{integral}>} provides additional atomic operations appropriate to integral types.
 There shall be a specialization \tcode{atomic<bool>} which provides the general
 atomic operations as specified in \ref{atomics.types.operations.general}.
 
@@ -603,12 +618,14 @@ shall be standard-layout structs. They shall each have a trivial default constru
 and a trivial destructor. They shall each support aggregate initialization
 syntax.
 
+\indexlibrary{\idxcode{atomic<T*>}}%
 \pnum
 There shall be pointer partial specializations of the \tcode{atomic} class template.
 These specializations shall be standard-layout structs.
 They shall each have a trivial default constructor and a trivial destructor.
 They shall each support aggregate initialization syntax.
 
+\indexlibrary{\idxcode{atomic_bool}}%
 \pnum
 There shall be named types corresponding to the integral specializations of
 \tcode{atomic}, as specified in Table~\ref{tab:atomics.integral}, and a named type
@@ -617,6 +634,20 @@ type is either a typedef to the corresponding specialization or a base class of 
 corresponding specialization. If it is a base class, it shall support the same
 member functions as the corresponding specialization.
 
+\indexlibrary{\idxcode{atomic_char}}%
+\indexlibrary{\idxcode{atomic_schar}}%
+\indexlibrary{\idxcode{atomic_uchar}}%
+\indexlibrary{\idxcode{atomic_short}}%
+\indexlibrary{\idxcode{atomic_ushort}}%
+\indexlibrary{\idxcode{atomic_int}}%
+\indexlibrary{\idxcode{atomic_uint}}%
+\indexlibrary{\idxcode{atomic_long}}%
+\indexlibrary{\idxcode{atomic_ulong}}%
+\indexlibrary{\idxcode{atomic_llong}}%
+\indexlibrary{\idxcode{atomic_ullong}}%
+\indexlibrary{\idxcode{atomic_char16_t}}%
+\indexlibrary{\idxcode{atomic_char32_t}}%
+\indexlibrary{\idxcode{atomic_wchar_t}}%
 \begin{floattablebase}
 {Named atomic types}{tab:atomics.integral}{ll}{ht}
 \hline
@@ -648,6 +679,36 @@ shall be defined if and only if
 \tcode{intptr_t}, and \tcode{uintptr_t}
 are defined, respectively.
 
+\indexlibrary{\idxcode{atomic_int8_t}}%
+\indexlibrary{\idxcode{atomic_uint8_t}}%
+\indexlibrary{\idxcode{atomic_int16_t}}%
+\indexlibrary{\idxcode{atomic_uint16_t}}%
+\indexlibrary{\idxcode{atomic_int32_t}}%
+\indexlibrary{\idxcode{atomic_uint32_t}}%
+\indexlibrary{\idxcode{atomic_int64_t}}%
+\indexlibrary{\idxcode{atomic_uint64_t}}%
+\indexlibrary{\idxcode{atomic_int_least8_t}}%
+\indexlibrary{\idxcode{atomic_uint_least8_t}}%
+\indexlibrary{\idxcode{atomic_int_least16_t}}%
+\indexlibrary{\idxcode{atomic_uint_least16_t}}%
+\indexlibrary{\idxcode{atomic_int_least32_t}}%
+\indexlibrary{\idxcode{atomic_uint_least32_t}}%
+\indexlibrary{\idxcode{atomic_int_least64_t}}%
+\indexlibrary{\idxcode{atomic_uint_least64_t}}%
+\indexlibrary{\idxcode{atomic_int_fast8_t}}%
+\indexlibrary{\idxcode{atomic_uint_fast8_t}}%
+\indexlibrary{\idxcode{atomic_int_fast16_t}}%
+\indexlibrary{\idxcode{atomic_uint_fast16_t}}%
+\indexlibrary{\idxcode{atomic_int_fast32_t}}%
+\indexlibrary{\idxcode{atomic_uint_fast32_t}}%
+\indexlibrary{\idxcode{atomic_int_fast64_t}}%
+\indexlibrary{\idxcode{atomic_uint_fast64_t}}%
+\indexlibrary{\idxcode{atomic_intptr_t}}%
+\indexlibrary{\idxcode{atomic_uintptr_t}}%
+\indexlibrary{\idxcode{atomic_size_t}}%
+\indexlibrary{\idxcode{atomic_ptrdiff_t}}%
+\indexlibrary{\idxcode{atomic_intmax_t}}%
+\indexlibrary{\idxcode{atomic_uintmax_t}}%
 \begin{floattablebase}
 {Atomic typedefs}{tab:atomics.typedefs}{ll}{ht}
 \hline
@@ -715,6 +776,7 @@ function templates identified as ``templated operations on atomic types'' in~\re
 The implementation shall provide the functions and function template specializations identified as ``arithmetic operations
 on atomic types'' in~\ref{atomics.syn}.
 
+\indexlibrary{\idxcode{atomic<\placeholder{integral}>}}%
 \pnum
 In the declarations of these functions and function template specializations,
 the name \tcode{\placeholder{integral}} refers to an
@@ -723,6 +785,7 @@ integral type and the name \tcode{\placeholder{atomic-integral}} refers to eithe
 Table~\ref{tab:atomics.integral} or inferred from Table~\ref{tab:atomics.typedefs}.
 
 \rSec2[atomics.types.operations.pointer]{Operations on atomic pointer types}
+\indexlibrary{\idxcode{atomic<T*>}}%
 
 \pnum
 The implementation shall provide the function template specializations
@@ -758,7 +821,9 @@ preserved when applying these operations to volatile objects. It does not mean t
 operations on non-volatile objects become volatile. Thus, volatile qualified operations
 on non-volatile objects may be merged under some conditions. \end{note}
 
-\indexlibrary{\idxcode{atomic type}!constructor}%
+\indexlibrary{\idxcode{atomic}!constructor}%
+\indexlibrary{\idxcode{atomic<T*>}!constructor}%
+\indexlibrary{\idxcode{atomic<\placeholder{integral}>}!constructor}%
 \begin{itemdecl}
 @\placeholdernc{A}@::@\placeholdernc{A}@() noexcept = default;
 \end{itemdecl}
@@ -772,7 +837,9 @@ These semantics ensure compatibility with C.
 \end{note}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{atomic type}!constructor}%
+\indexlibrary{\idxcode{atomic}!constructor}%
+\indexlibrary{\idxcode{atomic<T*>}!constructor}%
+\indexlibrary{\idxcode{atomic<\placeholder{integral}>}!constructor}%
 \begin{itemdecl}
 constexpr @\placeholdernc{A}@::@\placeholdernc{A}@(@\placeholdernc{C}@ desired) noexcept;
 \end{itemdecl}
@@ -789,6 +856,7 @@ variable, and then immediately accessing \tcode{A} in the receiving thread.
 This results in undefined behavior. \end{note}
 \end{itemdescr}
 
+\indexlibrary{\idxcode{ATOMIC_VAR_INIT}}%
 \begin{itemdecl}
 #define ATOMIC_VAR_INIT(value) @\seebelow@
 \end{itemdecl}
@@ -808,9 +876,11 @@ atomic<int> v = ATOMIC_VAR_INIT(5);
 \end{example}
 \end{itemdescr}
 
-\indexlibrarymember{atomic type}{is_always_lock_free}%
+\indexlibrarymember{is_always_lock_free}{atomic}%
+\indexlibrarymember{is_always_lock_free}{atomic<T*>}%
+\indexlibrarymember{is_always_lock_free}{atomic<\placeholder{integral}>}%
 \begin{itemdecl}
-static constexpr bool is_always_lock_free = @\impdef{}@;
+static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic} type's operations are always lock free}@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -824,7 +894,9 @@ the corresponding \tcode{ATOMIC_..._LOCK_FREE} macro, if defined.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{atomic_is_lock_free}}%
-\indexlibrarymember{atomic type}{is_lock_free}%
+\indexlibrarymember{is_lock_free}{atomic}%
+\indexlibrarymember{is_lock_free}{atomic<T*>}%
+\indexlibrarymember{is_lock_free}{atomic<\placeholder{integral}>}%
 \begin{itemdecl}
 bool atomic_is_lock_free(const volatile @\placeholder{A}@*@\itcorr[-1]@ object) noexcept;
 bool atomic_is_lock_free(const @\placeholder{A}@*@\itcorr[-1]@ object) noexcept;
@@ -841,6 +913,7 @@ is consistent with the value of \tcode{is_always_lock_free} for the same type.
 \end{note}
 \end{itemdescr}
 
+\indexlibrary{\idxcode{atomic_init}}%
 \begin{itemdecl}
 void atomic_init(volatile @\placeholder{A}@*@\itcorr[-1]@ object, @\placeholdernc{C}@ desired) noexcept;
 void atomic_init(@\placeholder{A}@*@\itcorr[-1]@ object, @\placeholdernc{C}@ desired) noexcept;
@@ -863,7 +936,9 @@ a data race.
 
 \indexlibrary{\idxcode{atomic_store}}%
 \indexlibrary{\idxcode{atomic_store_explicit}}%
-\indexlibrarymember{atomic type}{store}%
+\indexlibrarymember{store}{atomic}%
+\indexlibrarymember{store}{atomic<T*>}%
+\indexlibrarymember{store}{atomic<\placeholder{integral}>}%
 \begin{itemdecl}
 void atomic_store(volatile @\placeholder{A}@*@\itcorr[-1]@ object, @\placeholdernc{C}@ desired) noexcept;
 void atomic_store(@\placeholder{A}@*@\itcorr[-1]@ object, @\placeholdernc{C}@ desired) noexcept;
@@ -884,7 +959,9 @@ with the value of \tcode{desired}. Memory is affected according to the value of
 \tcode{order}.
 \end{itemdescr}
 
-\indexlibrarymember{atomic type}{operator=}%
+\indexlibrarymember{operator=}{atomic}%
+\indexlibrarymember{operator=}{atomic<T*>}%
+\indexlibrarymember{operator=}{atomic<\placeholder{integral}>}%
 \begin{itemdecl}
 @\placeholdernc{C}@ @\placeholdernc{A}@::operator=(@\placeholdernc{C}@ desired) volatile noexcept;
 @\placeholdernc{C}@ @\placeholdernc{A}@::operator=(@\placeholdernc{C}@ desired) noexcept;
@@ -900,7 +977,9 @@ with the value of \tcode{desired}. Memory is affected according to the value of
 
 \indexlibrary{\idxcode{atomic_load}}%
 \indexlibrary{\idxcode{atomic_load_explicit}}%
-\indexlibrarymember{atomic type}{load}%
+\indexlibrarymember{load}{atomic}%
+\indexlibrarymember{load}{atomic<T*>}%
+\indexlibrarymember{load}{atomic<\placeholder{integral}>}%
 \begin{itemdecl}
 @\placeholdernc{C}@ atomic_load(const volatile @\placeholder{A}@*@\itcorr[-1]@ object) noexcept;
 @\placeholdernc{C}@ atomic_load(const @\placeholder{A}@*@\itcorr[-1]@ object) noexcept;
@@ -921,8 +1000,9 @@ with the value of \tcode{desired}. Memory is affected according to the value of
 \returns Atomically returns the value pointed to by \tcode{object} or by \tcode{this}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{atomic type}!operator C@\tcode{operator \placeholder{C}}}%
-\indexlibrary{operator C@\tcode{operator \placeholder{C}}!\idxcode{atomic type}}%
+\indexlibrarymember{operator \placeholder{type}}{atomic}%
+\indexlibrarymember{operator T*}{atomic<T*>}%
+\indexlibrarymember{operator \placeholder{integral}}{atomic<\placeholder{integral}>}%
 \begin{itemdecl}
 @\placeholdernc{A}@::operator @\placeholder{C}@() const volatile noexcept;
 @\placeholdernc{A}@::operator @\placeholder{C}@() const noexcept;
@@ -939,7 +1019,9 @@ with the value of \tcode{desired}. Memory is affected according to the value of
 
 \indexlibrary{\idxcode{atomic_exchange}}%
 \indexlibrary{\idxcode{atomic_exchange_explicit}}%
-\indexlibrarymember{atomic type}{exchange}%
+\indexlibrarymember{exchange}{atomic}%
+\indexlibrarymember{exchange}{atomic<T*>}%
+\indexlibrarymember{exchange}{atomic<\placeholder{integral}>}%
 \begin{itemdecl}
 @\placeholdernc{C}@ atomic_exchange(volatile @\placeholder{A}@*@\itcorr[-1]@ object, @\placeholdernc{C}@ desired) noexcept;
 @\placeholdernc{C}@ atomic_exchange(@\placeholder{A}@*@\itcorr[-1]@ object, @\placeholdernc{C}@ desired) noexcept;
@@ -964,8 +1046,12 @@ These operations are atomic read-modify-write operations~(\ref{intro.multithread
 \indexlibrary{\idxcode{atomic_compare_exchange_strong}}%
 \indexlibrary{\idxcode{atomic_compare_exchange_weak_explicit}}%
 \indexlibrary{\idxcode{atomic_compare_exchange_strong_explicit}}%
-\indexlibrarymember{atomic type}{compare_exchange_weak}%
-\indexlibrarymember{atomic type}{compare_exchange_strong}%
+\indexlibrarymember{compare_exchange_weak}{atomic}%
+\indexlibrarymember{compare_exchange_weak}{atomic<T*>}%
+\indexlibrarymember{compare_exchange_weak}{atomic<\placeholder{integral}>}%
+\indexlibrarymember{compare_exchange_strong}{atomic}%
+\indexlibrarymember{compare_exchange_strong}{atomic<T*>}%
+\indexlibrarymember{compare_exchange_strong}{atomic<\placeholder{integral}>}%
 \begin{itemdecl}
 bool atomic_compare_exchange_weak(volatile @\placeholder{A}@*@\itcorr[-1]@ object, @\placeholder{C}@*@\itcorr[-1]@ expected, @\placeholdernc{C}@ desired) noexcept;
 bool atomic_compare_exchange_weak(@\placeholder{A}@*@\itcorr[-1]@ object, @\placeholder{C}@*@\itcorr[-1]@ expected, @\placeholdernc{C}@ desired) noexcept;
@@ -1121,9 +1207,23 @@ The following operations perform arithmetic computations. The key, operator, and
   bitwise and     &&&\\\hline
 \end{floattable}
 
-\indexlibrary{\idxcode{atomic_fetch_\placeholder{key}}}%
-\indexlibrary{\idxcode{atomic_fetch_\placeholder{key}_explicit}}%
-\indexlibrarymember{atomic type}{fetch_\placeholder{key}}%
+\indexlibrary{\idxcode{atomic_fetch_add}}%
+\indexlibrary{\idxcode{atomic_fetch_and}}%
+\indexlibrary{\idxcode{atomic_fetch_or}}%
+\indexlibrary{\idxcode{atomic_fetch_sub}}%
+\indexlibrary{\idxcode{atomic_fetch_xor}}%
+\indexlibrary{\idxcode{atomic_fetch_add_explicit}}%
+\indexlibrary{\idxcode{atomic_fetch_and_explicit}}%
+\indexlibrary{\idxcode{atomic_fetch_or_explicit}}%
+\indexlibrary{\idxcode{atomic_fetch_sub_explicit}}%
+\indexlibrary{\idxcode{atomic_fetch_xor_explicit}}%
+\indexlibrarymember{fetch_add}{atomic<T*>}%
+\indexlibrarymember{fetch_sub}{atomic<T*>}%
+\indexlibrarymember{fetch_add}{atomic<\placeholder{integral}>}%
+\indexlibrarymember{fetch_and}{atomic<\placeholder{integral}>}%
+\indexlibrarymember{fetch_or}{atomic<\placeholder{integral}>}%
+\indexlibrarymember{fetch_sub}{atomic<\placeholder{integral}>}%
+\indexlibrarymember{fetch_xor}{atomic<\placeholder{integral}>}%
 \begin{itemdecl}
 @\placeholdernc{C}@ atomic_fetch_@\placeholdernc{key}@(volatile @\placeholder{A}@*@\itcorr[-1]@ object, @\placeholdernc{M}@ operand) noexcept;
 @\placeholdernc{C}@ atomic_fetch_@\placeholdernc{key}@(@\placeholder{A}@*@\itcorr[-1]@ object, @\placeholdernc{M}@ operand) noexcept;
@@ -1151,7 +1251,13 @@ representation. There are no undefined results. For address types, the result ma
 undefined address, but the operations otherwise have no undefined behavior.
 \end{itemdescr}
 
-\indexlibrarymember{atomic type}{operator "@=}%
+\indexlibrarymember{operator+=}{atomic<T*>}%
+\indexlibrarymember{operator-=}{atomic<T*>}%
+\indexlibrarymember{operator+=}{atomic<\placeholder{integral}>}%
+\indexlibrarymember{operator-=}{atomic<\placeholder{integral}>}%
+\indexlibrarymember{operator\&=}{atomic<\placeholder{integral}>}%
+\indexlibrarymember{operator"|=}{atomic<\placeholder{integral}>}%
+\indexlibrarymember{operator\^{}=}{atomic<\placeholder{integral}>}%
 \begin{itemdecl}
 @\placeholdernc{C}@ @\placeholdernc{A}@::operator @\placeholder{op}@=(@\placeholdernc{M}@ operand) volatile noexcept;
 @\placeholdernc{C}@ @\placeholdernc{A}@::operator @\placeholder{op}@=(@\placeholdernc{M}@ operand) noexcept;
@@ -1165,7 +1271,8 @@ undefined address, but the operations otherwise have no undefined behavior.
 \returns \tcode{fetch_\placeholder{key}(operand) op operand}.
 \end{itemdescr}
 
-\indexlibrarymember{atomic type}{operator++}%
+\indexlibrarymember{operator++}{atomic<T*>}%
+\indexlibrarymember{operator++}{atomic<\placeholder{integral}>}%
 \begin{itemdecl}
 @\placeholdernc{C}@ @\placeholdernc{A}@::operator++(int) volatile noexcept;
 @\placeholdernc{C}@ @\placeholdernc{A}@::operator++(int) noexcept;
@@ -1176,7 +1283,8 @@ undefined address, but the operations otherwise have no undefined behavior.
 \returns \tcode{fetch_add(1)}.
 \end{itemdescr}
 
-\indexlibrarymember{atomic type}{operator\dcr}%
+\indexlibrarymember{operator\dcr}{atomic<T*>}%
+\indexlibrarymember{operator\dcr}{atomic<\placeholder{integral}>}%
 \begin{itemdecl}
 @\placeholdernc{C}@ @\placeholdernc{A}@::operator--(int) volatile noexcept;
 @\placeholdernc{C}@ @\placeholdernc{A}@::operator--(int) noexcept;
@@ -1187,7 +1295,8 @@ undefined address, but the operations otherwise have no undefined behavior.
 \returns \tcode{fetch_sub(1)}.
 \end{itemdescr}
 
-\indexlibrarymember{atomic type}{operator++}%
+\indexlibrarymember{operator++}{atomic<T*>}%
+\indexlibrarymember{operator++}{atomic<\placeholder{integral}>}%
 \begin{itemdecl}
 @\placeholdernc{C}@ @\placeholdernc{A}@::operator++() volatile noexcept;
 @\placeholdernc{C}@ @\placeholdernc{A}@::operator++() noexcept;
@@ -1201,7 +1310,8 @@ undefined address, but the operations otherwise have no undefined behavior.
 \returns \tcode{fetch_add(1) + 1}.
 \end{itemdescr}
 
-\indexlibrarymember{atomic type}{operator\dcr}%
+\indexlibrarymember{operator\dcr}{atomic<T*>}%
+\indexlibrarymember{operator\dcr}{atomic<\placeholder{integral}>}%
 \begin{itemdecl}
 @\placeholdernc{C}@ @\placeholdernc{A}@::operator--() volatile noexcept;
 @\placeholdernc{C}@ @\placeholdernc{A}@::operator--() noexcept;
@@ -1271,7 +1381,7 @@ Unless initialized with \tcode{ATOMIC_FLAG_INIT}, it is unspecified whether an
 
 \indexlibrary{\idxcode{atomic_flag_test_and_set}}%
 \indexlibrary{\idxcode{atomic_flag_test_and_set_explicit}}%
-\indexlibrarymember{atomic_flag}{test_and_set}%
+\indexlibrarymember{test_and_set}{atomic_flag}%
 \begin{itemdecl}
 bool atomic_flag_test_and_set(volatile atomic_flag* object) noexcept;
 bool atomic_flag_test_and_set(atomic_flag* object) noexcept;
@@ -1292,7 +1402,7 @@ bool atomic_flag::test_and_set(memory_order order = memory_order_seq_cst) noexce
 
 \indexlibrary{\idxcode{atomic_flag_clear}}%
 \indexlibrary{\idxcode{atomic_flag_clear_explicit}}%
-\indexlibrarymember{atomic_flag}{clear}%
+\indexlibrarymember{clear}{atomic_flag}%
 \begin{itemdecl}
 void atomic_flag_clear(volatile atomic_flag* object) noexcept;
 void atomic_flag_clear(atomic_flag* object) noexcept;


### PR DESCRIPTION
Reverse class/member names in indexlibrarymember macros to be
consistent with the prefered style in other clauses.

Expand in the index several functions that are documented as a
pattern-match, such as fetch_add and fetch_sub.

Use 'atomic<type>' rather than 'atomic type' for index references
to the atomic template.  This allows for a more intuitive indexing
of the conversion operator.