### PR TITLE
[lex.ext] Add hyphen in index entry for user-defined literals

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -18,7 +18,7 @@
 \indextext{string literal|see{literal, string}}
 \indextext{boolean literal|see{literal, boolean}}
 \indextext{pointer literal|see{literal, pointer}}
-\indextext{user-defined literal|see{literal, user defined}}
+\indextext{user-defined literal|see{literal, user-defined}}
 \indextext{file, source|see{source file}}
 
 \rSec1[lex.separate]{Separate translation}
@@ -1674,7 +1674,7 @@ and~\ref{conv.mem}.
 
 \rSec2[lex.ext]{User-defined literals}
 
-\indextext{literal!user defined}%
+\indextext{literal!user-defined}%
 \begin{bnf}
 \nontermdef{user-defined-literal}\br
     user-defined-integer-literal\br


### PR DESCRIPTION
Fixes #628.