### PR TITLE
[dcl.align] Avoid 'shall' for a requirement on the implementation

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3804,9 +3804,9 @@ declaration, the program is ill-formed.
 \end{itemize}
 
 \pnum
-When the \grammarterm{alignment-specifier}{} is of the form
-\tcode{alignas(} \grammarterm{type-id} \tcode{)}, it shall have the same
-effect as \tcode{alignas(\brk{}alignof(}\grammarterm{type-id}\tcode{))}~(\ref{expr.alignof}).
+An \grammarterm{alignment-specifier} of the form
+\tcode{alignas(} \grammarterm{type-id} \tcode{)} has the same
+effect as \tcode{alignas(\brk{}alignof(} \grammarterm{type-id}~\tcode{))}~(\ref{expr.alignof}).
 
 \pnum
 The alignment requirement of an entity is the strictest non-zero alignment


### PR DESCRIPTION
Fixes #493.