### PR TITLE
[container.requirements.general] Remove redundant Requires

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -658,7 +658,6 @@ linear													\\ \rowsep
 \tcode{X u(rv)}
            &
            &
-  \requires move construction of \tcode{A} shall not exit via an exception.\br
   post: \tcode{u} shall have the same elements as \tcode{rv} had before this
   construction; the value of \tcode{u.get_allocator()} shall be the same as the
   value of \tcode{rv.get_allocator()} before this construction. &


### PR DESCRIPTION
The allocator requirements already require move construction to not throw, so there's no need to repeat it here.