### PR TITLE
[cpp.replace] Delete obsolete footnote

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -732,7 +732,7 @@ are separated by comma preprocessing tokens,
 but comma preprocessing tokens between matching
 inner parentheses do not separate arguments.
 If there are sequences of preprocessing tokens within the list of
-arguments that would otherwise act as preprocessing directives,\footnote{Despite the name, a non-directive is a preprocessing directive.}
+arguments that would otherwise act as preprocessing directives,\footnote{A \grammarterm{conditionally-supported-directive} is a preprocessing directive regardless of whether the implementation supports it.}
 the behavior is undefined.
 
 \pnum


### PR DESCRIPTION
non-directive is not a thing anymore (renamed to conditionally-supported-directive by CWG 2001) and the new name makes it clear that it's a directive.