### PR TITLE
[clause 21] Index cstd header synopses

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -5627,6 +5627,7 @@ The template specializations shall meet the requirements of class template hash 
 
 \rSec2[cctype.syn]{Header \tcode{<cctype>} synopsis}
 
+\indexlibrary{\idxhdr{cctype}}%
 \indexlibrary{\idxcode{isalnum}}%
 \indexlibrary{\idxcode{isalpha}}%
 \indexlibrary{\idxcode{isblank}}%
@@ -5669,6 +5670,7 @@ are the same as the C standard library header \tcode{<ctype.h>}.
 
 \rSec2[cwctype.syn]{Header \tcode{<cwctype>} synopsis}
 
+\indexlibrary{\idxhdr{cwctype}}%
 \indexlibrary{\idxcode{wint_t}}%
 \indexlibrary{\idxcode{wctrans_t}}%
 \indexlibrary{\idxcode{wctype_t}}%
@@ -5729,6 +5731,7 @@ are the same as the C standard library header \tcode{<wctype.h>}.
 
 \rSec2[cstring.syn]{Header \tcode{<cstring>} synopsis}
 
+\indexlibrary{\idxhdr{cstring}}%
 \indexlibrary{\idxcode{memchr}}%
 \indexlibrary{\idxcode{memcmp}}%
 \indexlibrary{\idxcode{memcpy}}%
@@ -5809,6 +5812,7 @@ but they have the same behavior as in the C standard library~(\ref{library.c}).
 
 \rSec2[cwchar.syn]{Header \tcode{<cwchar>} synopsis}
 
+\indexlibrary{\idxhdr{cwchar}}%
 \indexlibrary{\idxcode{NULL}}%
 \indexlibrary{\idxcode{WCHAR_MAX}}%
 \indexlibrary{\idxcode{WCHAR_MIN}}%
@@ -5976,6 +5980,7 @@ but they have the same behavior as in the C standard library~(\ref{library.c}).
 
 \rSec2[cuchar.syn]{Header \tcode{<cuchar>} synopsis}
 
+\indexlibrary{\idxhdr{cuchar}}%
 \indexlibrary{\idxcode{mbstate_t}}%
 \indexlibrary{\idxcode{size_t}}%
 \indexlibrary{\idxcode{mbrtoc16}}%


### PR DESCRIPTION
Adds entries to the library index for every cstd... header
in the strings clause, pointing to their synopsis.