### PR TITLE
[utility] shorten stable names

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -20,7 +20,7 @@ These utilities are summarized in Table~\ref{tab:util.lib.summary}.
 \ref{memory}                & Memory                            & \tcode{<memory>}      \\
                             &                                   & \tcode{<cstdlib>}     \\
 \ref{smartptr}              & Smart pointers                    & \tcode{<memory>}      \\ \rowsep
-\ref{memory.resource}       & Memory resources                  & \tcode{<memory_resource>} \\ \rowsep
+\ref{mem.res}               & Memory resources                  & \tcode{<memory_resource>} \\ \rowsep
 \ref{allocator.adaptor}     & Scoped allocators                 & \tcode{<scoped_allocator>} \\ \rowsep
 \ref{function.objects}      & Function objects                  & \tcode{<functional>}  \\ \rowsep
 \ref{meta}                  & Type traits                       & \tcode{<type_traits>} \\ \rowsep
@@ -2182,7 +2182,7 @@ namespace std {
   struct nullopt_t{@\seebelow@};
   constexpr nullopt_t nullopt(@\unspec@);
 
-  // \ref{optional.bad_optional_access}, class \tcode{bad_optional_access}
+  // \ref{optional.badaccess}, class \tcode{bad_optional_access}
   class bad_optional_access;
 
   // \ref{optional.relops}, relational operators
@@ -2971,7 +2971,7 @@ this indicates that an optional object not containing a value shall be construct
 \pnum
 Type \tcode{nullopt_t} shall not have a default constructor. It shall be a literal type. Constant \tcode{nullopt} shall be initialized with an argument of literal type.
 
-\rSec2[optional.bad_optional_access]{Class \tcode{bad_optional_access}}
+\rSec2[optional.badaccess]{Class \tcode{bad_optional_access}}
 
 \begin{codeblock}
 class bad_optional_access : public logic_error {
@@ -10213,20 +10213,20 @@ the same value as \tcode{hash<T*>()(p.get())}.
 \end{itemdescr}%
 \indextext{smart pointers|)}
 
-\rSec1[memory.resource]{Memory resources}
+\rSec1[mem.res]{Memory resources}
 
-\rSec2[memory.resource.syn]{Header \tcode{<memory_resource>} synopsis}
+\rSec2[mem.res.syn]{Header \tcode{<memory_resource>} synopsis}
 
 \indexlibrary{\idxhdr{memory_resource}}%
 \begin{codeblock}
 namespace std::pmr {
-  // \ref{memory.resource.class}, class \tcode{memory_resource}
+  // \ref{mem.res.class}, class \tcode{memory_resource}
   class memory_resource;
 
   bool operator==(const memory_resource& a, const memory_resource& b) noexcept;
   bool operator!=(const memory_resource& a, const memory_resource& b) noexcept;
 
-  // \ref{memory.polymorphic.allocator.class}, class \tcode{polymorphic_allocator}
+  // \ref{mem.poly.allocator.class}, class \tcode{polymorphic_allocator}
   template <class Tp> class polymorphic_allocator;
 
   template <class T1, class T2>
@@ -10236,13 +10236,13 @@ namespace std::pmr {
     bool operator!=(const polymorphic_allocator<T1>& a,
                     const polymorphic_allocator<T2>& b) noexcept;
 
-  // \ref{memory.resource.global}, global memory resources
+  // \ref{mem.res.global}, global memory resources
   memory_resource* new_delete_resource() noexcept;
   memory_resource* null_memory_resource() noexcept;
   memory_resource* set_default_resource(memory_resource* r) noexcept;
   memory_resource* get_default_resource() noexcept;
 
-  // \ref{memory.resource.pool}, pool resource classes
+  // \ref{mem.res.pool}, pool resource classes
   struct pool_options;
   class synchronized_pool_resource;
   class unsynchronized_pool_resource;
@@ -10250,7 +10250,7 @@ namespace std::pmr {
 }
 \end{codeblock}
 
-\rSec2[memory.resource.class]{Class \tcode{memory_resource}}
+\rSec2[mem.res.class]{Class \tcode{memory_resource}}
 
 \pnum
 The \tcode{memory_resource} class is an abstract interface to an unbounded set of classes encapsulating memory resources.
@@ -10277,7 +10277,7 @@ private:
 \end{codeblock}
 
 
-\rSec3[memory.resource.public]{\tcode{memory_resource} public member functions}
+\rSec3[mem.res.public]{\tcode{memory_resource} public member functions}
 
 \indexlibrary{\idxcode{memory_resource}!destructor}%
 \begin{itemdecl}
@@ -10324,7 +10324,7 @@ Equivalent to: \tcode{return do_is_equal(other);}
 \end{itemdescr}
 
 
-\rSec3[memory.resource.private]{\tcode{memory_resource} private virtual member functions}
+\rSec3[mem.res.private]{\tcode{memory_resource} private virtual member functions}
 
 \indexlibrarymember{do_allocate}{memory_resource}%
 \begin{itemdecl}
@@ -10384,7 +10384,7 @@ will immediately return \tcode{false}
 if \tcode{dynamic_cast<const D*>(\&other) == nullptr}.\end{note}
 \end{itemdescr}
 
-\rSec3[memory.resource.eq]{\tcode{memory_resource} equality}
+\rSec3[mem.res.eq]{\tcode{memory_resource} equality}
 
 \indexlibrarymember{operator==}{memory_resource}%
 \begin{itemdecl}
@@ -10408,7 +10408,7 @@ bool operator!=(const memory_resource& a, const memory_resource& b) noexcept;
 \tcode{!(a == b)}.
 \end{itemdescr}
 
-\rSec2[memory.polymorphic.allocator.class]{Class template \tcode{polymorphic_allocator}}
+\rSec2[mem.poly.allocator.class]{Class template \tcode{polymorphic_allocator}}
 
 \pnum
 A specialization of class template \tcode{pmr::polymorphic_allocator}
@@ -10429,7 +10429,7 @@ class polymorphic_allocator {
 public:
   using value_type = Tp;
 
-  // \ref{memory.polymorphic.allocator.ctor}, constructors:
+  // \ref{mem.poly.allocator.ctor}, constructors:
   polymorphic_allocator() noexcept;
   polymorphic_allocator(memory_resource* r);
 
@@ -10441,7 +10441,7 @@ public:
   polymorphic_allocator&
     operator=(const polymorphic_allocator& rhs) = delete;
 
-  // \ref{memory.polymorphic.allocator.mem}, member functions:
+  // \ref{mem.poly.allocator.mem}, member functions:
   Tp* allocate(size_t n);
   void deallocate(Tp* p, size_t n);
 
@@ -10470,7 +10470,7 @@ public:
 \end{codeblock}
 
 
-\rSec3[memory.polymorphic.allocator.ctor]{\tcode{polymorphic_allocator} constructors}
+\rSec3[mem.poly.allocator.ctor]{\tcode{polymorphic_allocator} constructors}
 
 \indexlibrary{\idxcode{polymorphic_allocator}!constructor}%
 \begin{itemdecl}
@@ -10519,7 +10519,7 @@ Sets \tcode{memory_rsrc} to \tcode{other.resource()}.
 \end{itemdescr}
 
 
-\rSec3[memory.polymorphic.allocator.mem]{\tcode{polymorphic_allocator} member functions}
+\rSec3[mem.poly.allocator.mem]{\tcode{polymorphic_allocator} member functions}
 
 \indexlibrarymember{allocate}{polymorphic_allocator}%
 \begin{itemdecl}
@@ -10776,7 +10776,7 @@ memory_resource* resource() const;
 \tcode{memory_rsrc}.
 \end{itemdescr}
 
-\rSec3[memory.polymorphic.allocator.eq]{\tcode{polymorphic_allocator} equality}
+\rSec3[mem.poly.allocator.eq]{\tcode{polymorphic_allocator} equality}
 
 \indexlibrarymember{operator==}{polymorphic_allocator}%
 \begin{itemdecl}
@@ -10805,7 +10805,7 @@ template <class T1, class T2>
 \end{itemdescr}
 
 
-\rSec2[memory.resource.global]{Access to program-wide \tcode{memory_resource} objects}
+\rSec2[mem.res.global]{Access to program-wide \tcode{memory_resource} objects}
 
 \indexlibrary{\idxcode{new_delete_resource}}%
 \begin{itemdecl}
@@ -10885,9 +10885,9 @@ memory_resource* get_default_resource() noexcept;
 The current value of the default memory resource pointer.
 \end{itemdescr}
 
-\rSec2[memory.resource.pool]{Pool resource classes}
+\rSec2[mem.res.pool]{Pool resource classes}
 
-\rSec3[memory.resource.pool.overview]{Classes \tcode{synchronized_pool_resource} and \tcode{unsynchronized_pool_resource}}
+\rSec3[mem.res.pool.overview]{Classes \tcode{synchronized_pool_resource} and \tcode{unsynchronized_pool_resource}}
 
 \pnum
 The \tcode{synchronized_pool_resource} and
@@ -11002,7 +11002,7 @@ protected:
 };
 \end{codeblock}
 
-\rSec3[memory.resource.pool.options]{\tcode{pool_options} data members}
+\rSec3[mem.res.pool.options]{\tcode{pool_options} data members}
 
 \pnum
 The members of \tcode{pool_options}
@@ -11017,7 +11017,7 @@ size_t max_blocks_per_chunk;
 \begin{itemdescr}
 \pnum
 The maximum number of blocks that will be allocated at once
-from the upstream memory resource~(\ref{memory.resource.monotonic.buffer})
+from the upstream memory resource~(\ref{mem.res.monotonic.buffer})
 to replenish a pool.
 If the value of \tcode{max_blocks_per_chunk} is zero or
 is greater than an \impldef{largest supported value to configure the maximum number of blocks to replenish a pool}
@@ -11045,7 +11045,7 @@ The implementation may choose a pass-through threshold
 larger than specified in this field.
 \end{itemdescr}
 
-\rSec3[memory.resource.pool.ctor]{Pool resource constructors and destructors}
+\rSec3[mem.res.pool.ctor]{Pool resource constructors and destructors}
 
 \indexlibrary{\idxcode{synchronized_pool_resource}!constructor}%
 \indexlibrary{\idxcode{unsynchronized_pool_resource}!constructor}%
@@ -11093,7 +11093,7 @@ virtual ~unsynchronized_pool_resource();
 Calls \tcode{release()}.
 \end{itemdescr}
 
-\rSec3[memory.resource.pool.mem]{Pool resource members}
+\rSec3[mem.res.pool.mem]{Pool resource members}
 
 \indexlibrarymember{release}{synchronized_pool_resource}%
 \indexlibrarymember{release}{unsynchronized_pool_resource}%
@@ -11153,7 +11153,7 @@ void* do_allocate(size_t bytes, size_t alignment) override;
 A pointer to allocated storage (\ref{basic.stc.dynamic.deallocation})
 with a size of at least \tcode{bytes}.
 The size and alignment of the allocated memory shall meet the requirements
-for a class derived from \tcode{memory_resource}~(\ref{memory.resource}).
+for a class derived from \tcode{memory_resource}~(\ref{mem.res}).
 
 \pnum
 \effects
@@ -11208,7 +11208,7 @@ bool synchronized_pool_resource::do_is_equal(const memory_resource& other) const
 \tcode{this == dynamic_cast<const synchronized_pool_resource*>(\&other)}.
 \end{itemdescr}
 
-\rSec2[memory.resource.monotonic.buffer]{Class \tcode{monotonic_buffer_resource}}
+\rSec2[mem.res.monotonic.buffer]{Class \tcode{monotonic_buffer_resource}}
 
 \pnum
 A \tcode{monotonic_buffer_resource} is a special-purpose memory resource
@@ -11277,7 +11277,7 @@ protected:
 };
 \end{codeblock}
 
-\rSec3[memory.resource.monotonic.buffer.ctor]{\tcode{monotonic_buffer_resource} constructor and destructor}
+\rSec3[mem.res.monotonic.buffer.ctor]{\tcode{monotonic_buffer_resource} constructor and destructor}
 
 \indexlibrary{\idxcode{monotonic_buffer_resource}!constructor}%
 \begin{itemdecl}
@@ -11333,7 +11333,7 @@ Calls \tcode{release()}.
 \end{itemdescr}
 
 
-\rSec3[memory.resource.monotonic.buffer.mem]{\tcode{monotonic_buffer_resource} members}
+\rSec3[mem.res.monotonic.buffer.mem]{\tcode{monotonic_buffer_resource} members}
 
 \indexlibrarymember{release}{monotonic_buffer_resource}%
 \begin{itemdecl}
@@ -11375,7 +11375,7 @@ void* do_allocate(size_t bytes, size_t alignment) override;
 A pointer to allocated storage (\ref{basic.stc.dynamic.deallocation})
 with a size of at least \tcode{bytes}.
 The size and alignment of the allocated memory shall meet the requirements
-for a class derived from \tcode{memory_resource}~(\ref{memory.resource}).
+for a class derived from \tcode{memory_resource}~(\ref{mem.res}).
 
 \pnum
 \effects
@@ -12128,7 +12128,7 @@ namespace std {
   template<class R, class... ArgTypes>
     bool operator!=(nullptr_t, const function<R(ArgTypes...)>&) noexcept;
 
-  // \ref{func.searchers}, searchers:
+  // \ref{func.search}, searchers:
   template<class ForwardIterator, class BinaryPredicate = equal_to<>>
     class default_searcher;
   template<class RandomAccessIterator,
@@ -13986,7 +13986,7 @@ template<class R, class... ArgTypes>
 \end{itemdescr}%
 \indextext{function object!wrapper|)}
 
-\rSec2[func.searchers]{Searchers}
+\rSec2[func.search]{Searchers}
 
 \pnum
 This subclause provides function object types (\ref{function.objects}) for
@@ -13997,7 +13997,7 @@ the object's constructor, and the second (the sequence to be searched) is
 provided to the function call operator.
 
 \pnum
-Each specialization of a class template specified in this subclause \ref{func.searchers} shall meet the \tcode{CopyConstructible} and \tcode{CopyAssignable} requirements.
+Each specialization of a class template specified in this subclause \ref{func.search} shall meet the \tcode{CopyConstructible} and \tcode{CopyAssignable} requirements.
 Template parameters named
 \begin{itemize}
 \item \tcode{ForwardIterator},
@@ -14009,7 +14009,7 @@ Template parameters named
 \item \tcode{BinaryPredicate}
 \end{itemize}
 of templates specified in this subclause
-\ref{func.searchers} shall meet the same requirements and semantics as
+\ref{func.search} shall meet the same requirements and semantics as
 specified in \ref{algorithms.general}.
 Template parameters named \tcode{Hash} shall meet the requirements as specified in \ref{hash.requirements}.
 
@@ -14018,7 +14018,7 @@ The Boyer-Moore searcher implements the Boyer-Moore search algorithm.
 The Boyer-Moore-Horspool searcher implements the Boyer-Moore-Horspool search algorithm.
 In general, the Boyer-Moore searcher will use more memory and give better run-time performance than Boyer-Moore-Horspool
 
-\rSec3[func.searchers.default]{Class template \tcode{default_searcher}}
+\rSec3[func.search.default]{Class template \tcode{default_searcher}}
 
 \indexlibrary{\idxcode{default_searcher}}%
 \begin{codeblock}
@@ -14077,7 +14077,7 @@ otherwise \tcode{j == next(i, distance(pat_first_, pat_last_))}.
 \end{itemize}
 \end{itemdescr}
 
-\rSec4[func.searchers.default.creation]{\tcode{default_searcher} creation functions}
+\rSec4[func.search.default.creation]{\tcode{default_searcher} creation functions}
 
 \indexlibrary{\idxcode{make_default_searcher}}%
 \begin{itemdecl}
@@ -14096,7 +14096,7 @@ return default_searcher<ForwardIterator, BinaryPredicate>(pat_first, pat_last, p
 \end{codeblock}
 \end{itemdescr}
 
-\rSec3[func.searchers.boyer_moore]{Class template \tcode{boyer_moore_searcher}}
+\rSec3[func.search.bm]{Class template \tcode{boyer_moore_searcher}}
 
 \indexlibrary{\idxcode{boyer_moore_searcher}}%
 \begin{codeblock}
@@ -14185,7 +14185,7 @@ otherwise returns \tcode{make_pair(last, last)} if no such iterator is found.
 At most \tcode{(last - first) * (pat_last_ - pat_first_)} applications of the predicate.
 \end{itemdescr}
 
-\rSec4[func.searchers.boyer_moore.creation]{\tcode{boyer_moore_searcher} creation functions}
+\rSec4[func.search.bm.creation]{\tcode{boyer_moore_searcher} creation functions}
 
 \indexlibrary{\idxcode{make_boyer_moore_searcher}}%
 \begin{itemdecl}
@@ -14208,7 +14208,7 @@ return boyer_moore_searcher<RandomAccessIterator, Hash, BinaryPredicate>(
 \end{codeblock}
 \end{itemdescr}
 
-\rSec3[func.searchers.boyer_moore_horspool]{Class template \tcode{boyer_moore_horspool_searcher}}
+\rSec3[func.search.bmh]{Class template \tcode{boyer_moore_horspool_searcher}}
 
 \indexlibrary{\idxcode{boyer_moore_horspool_searcher}}%
 \begin{codeblock}
@@ -14300,7 +14300,7 @@ otherwise returns \tcode{make_pair(last, last)} if no such iterator is found.
 At most \tcode{(last - first) * (pat_last_ - pat_first_)} applications of the predicate.
 \end{itemdescr}
 
-\rSec4[func.searchers.boyer_moore_horspool.creation]{\tcode{boyer_moore_horspool_searcher} creation functions}
+\rSec4[func.search.bmh.creation]{\tcode{boyer_moore_horspool_searcher} creation functions}
 
 \indexlibrary{\idxcode{make_boyer_moore_horspool_searcher}}%
 \begin{itemdecl}


### PR DESCRIPTION
memory.resource -> mem.res
optional.bad_optional_access -> optional.badaccess
memory.polymorphic -> mem.poly
func.searchers -> func.search
... boyer_moore -> ... bm
... boyer_moore_horspool -> ... bmh

Fixes #794.