### PR TITLE
[cstdlib.syn, csignal.syn] Introduce exposition-only function types with C and C++ language linkage to improve the presentation of C library functions that take callbacks.

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -5390,14 +5390,12 @@ declares the functions described in this subclause.
 \indexlibrary{\idxcode{bsearch}}%
 \indexlibrary{\idxcode{qsort}}%
 \begin{itemdecl}
-extern "C" void* bsearch(const void* key, const void* base, size_t nmemb, size_t size,
-                         int (*compar)(const void*, const void*));
-extern "C++" void* bsearch(const void* key, const void* base, size_t nmemb, size_t size,
-                           int (*compar)(const void*, const void*));
-extern "C" void qsort(void* base, size_t nmemb, size_t size,
-                      int (*compar)(const void*, const void*));
-extern "C++" void qsort(void* base, size_t nmemb, size_t size,
-                        int (*compar)(const void*, const void*));
+void* bsearch(const void* key, const void* base, size_t nmemb, size_t size,
+              @\placeholder{c-compare-pred}@* compar);
+void* bsearch(const void* key, const void* base, size_t nmemb, size_t size,
+              @\placeholder{compare-pred}@* compar);
+void qsort(void* base, size_t nmemb, size_t size, @\placeholder{c-compare-pred}@* compar);
+void qsort(void* base, size_t nmemb, size_t size, @\placeholder{compare-pred}@* compar);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -581,6 +581,23 @@ Certain types defined in Clause~\ref{input.output} are used to describe implemen
 \indextext{types!implementation-defined}%
 They are based on other types, but with added constraints.
 
+\rSec4[expos.only.types]{Exposition-only types}
+
+\pnum
+Several types defined in Clauses~\ref{\firstlibchapter} through~\ref{\lastlibchapter}
+and Annex~\ref{depr} that are used as function parameter or return types are defined
+for the purpose of exposition only in order to capture their language linkage. The
+declarations of such types are followed by a comment ending in \textit{exposition only}.
+\begin{example}
+\begin{codeblock}
+namespace std {
+  extern "C" using @\placeholdernc{some-handler}@ = int(int, void*, double);  // \expos
+}
+\end{codeblock}
+The type placeholder \tcode{\placeholder{some-handler}} can now be used to specify a function
+that takes a callback parameter with C language linkage.
+\end{example}
+
 \rSec4[enumerated.types]{Enumerated types}
 
 \pnum
@@ -3039,12 +3056,18 @@ namespace std {
 #define MB_CUR_MAX @\seebelow@
 
 namespace std {
+  // Exposition-only function type aliases
+  extern "C" using @\placeholdernc{c-atexit-handler}@ = void();                        // \expos
+  extern "C++" using @\placeholdernc{atexit-handler}@ = void();                        // \expos
+  extern "C" using @\placeholdernc{c-compare-pred}@ = int(const void* , const void*);  // \expos
+  extern "C++" using @\placeholdernc{compare-pred}@ = int(const void* , const void*);  // \expos
+
   // \ref{support.start.term}, start and termination
   [[noreturn]] void abort();
-  extern "C" int atexit(void (*func)());
-  extern "C++" int atexit(void (*func)());
-  extern "C" int at_quick_exit(void (*func)());
-  extern "C++" int at_quick_exit(void (*func)());
+  int atexit(@\placeholder{c-atexit-handler}@* func);
+  int atexit(@\placeholder{atexit-handler}@* func);
+  int at_quick_exit(@\placeholder{c-atexit-handler}@* func);
+  int at_quick_exit(@\placeholder{atexit-handler}@* func);
   [[noreturn]] void exit(int status);
   [[noreturn]] void _Exit(int status);
   [[noreturn]] void quick_exit(int status);
@@ -3079,14 +3102,12 @@ namespace std {
   size_t wcstombs(char* s, const wchar_t* pwcs, size_t n);
 
   // \ref{alg.c.library}, C standard library algorithms
-  extern "C" void* bsearch(const void* key, const void* base, size_t nmemb, size_t size,
-                           int (*compar)(const void* , const void*));
-  extern "C++" void* bsearch(const void* key, const void* base, size_t nmemb, size_t size,
-                             int (*compar)(const void* , const void*));
-  extern "C" void qsort(void* base, size_t nmemb, size_t size,
-                        int (*compar)(const void* , const void*));
-  extern "C++" void qsort(void* base, size_t nmemb, size_t size,
-                          int (*compar)(const void* , const void*));
+  void* bsearch(const void* key, const void* base, size_t nmemb, size_t size,
+                @\placeholder{c-compare-pred}@*@\itcorr[-1]@ compar);
+  void* bsearch(const void* key, const void* base, size_t nmemb, size_t size,
+                @\placeholder{compare-pred}@*@\itcorr[-1]@ compar);
+  void qsort(void* base, size_t nmemb, size_t size, @\placeholder{c-compare-pred}@*@\itcorr[-1]@ compar);
+  void qsort(void* base, size_t nmemb, size_t size, @\placeholder{compare-pred}@*@\itcorr[-1]@ compar);
 
   // \ref{c.math.rand}, low-quality random number generation
   int rand();
@@ -3104,7 +3125,7 @@ namespace std {
   long long int llabs(long long int j);
 
   div_t div(int numer, int denom);
-  ldiv_t div(long int numer, long int denom);  // see \ref{library.c}
+  ldiv_t div(long int numer, long int denom);             // see \ref{library.c}
   lldiv_t div(long long int numer, long long int denom);  // see \ref{library.c}
   ldiv_t ldiv(long int numer, long int denom);
   lldiv_t lldiv(long long int numer, long long int denom);

--- a/source/support.tex
+++ b/source/support.tex
@@ -1285,8 +1285,8 @@ duration and without calling functions passed to
 
 \indexlibrary{\idxcode{atexit}}%
 \begin{itemdecl}
-extern "C" int atexit(void (*f)()) noexcept;
-extern "C++" int atexit(void (*f)()) noexcept;
+int atexit(@\placeholder{c-atexit-handler}@* f) noexcept;
+int atexit(@\placeholder{atexit-handler}@* f) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1377,8 +1377,8 @@ are defined in
 
 \indexlibrary{\idxcode{at_quick_exit}}%
 \begin{itemdecl}
-extern "C" int at_quick_exit(void (*f)()) noexcept;
-extern "C++" int at_quick_exit(void (*f)()) noexcept;
+int at_quick_exit(@\placeholder{c-atexit-handler}@* f) noexcept;
+int at_quick_exit(@\placeholder{atexit-handler}@* f) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3510,7 +3510,9 @@ define a macro named \tcode{alignas}.
 namespace std {
   using sig_atomic_t = @\seebelow@;
 
-  void (*signal(int sig, void (*func)(int)))(int);
+  extern "C" using @\placeholdernc{signal-handler}@ = void(int);  // \expos
+  @\placeholder{signal-handler}@* signal(int sig, @\placeholder{signal-handler}@* func);
+
   int raise(int sig);
 }
 


### PR DESCRIPTION
This change improves correctness, since we never meant to specify the language linkage of the function names, but only of the callback parameter type.

Fixes #1002.