### PR TITLE
[diff.mods.to.headers] Explain what happened to meaningless C headers

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -2152,10 +2152,30 @@ as shown in Table~\ref{tab:diff.standard.functions}.
 \rSec2[diff.mods.to.headers]{Modifications to headers}
 
 \pnum
-For compatibility with the C standard library,
-\indextext{library!C standard}%
+For compatibility with the C standard library\indextext{library!C standard},
 the \Cpp standard library provides the C headers enumerated
 in~\ref{depr.c.headers}, but their use is deprecated in \Cpp.
+
+\pnum
+There are no \Cpp headers for the C headers
+\tcode{<stdatomic.h>}\indextext{\idxhdr{stdatomic.h}},
+\tcode{<stdnoreturn.h>}\indextext{\idxhdr{stdnoreturn.h}},
+and \tcode{<threads.h>}\indextext{\idxhdr{threads.h}},
+nor are the C headers themselves part of \Cpp.
+
+\pnum
+The headers \tcode{<ccomplex>}\indextext{\idxhdr{ccomplex}}~(\ref{ccomplex.syn})
+and \tcode{<ctgmath>}\indextext{\idxhdr{ctgmath}}~(\ref{ctgmath.syn}), as well
+as their corresponding C headers \tcode{<complex.h>}\indextext{\idxhdr{complex.h}}
+and \tcode{<tgmath.h>}\indextext{\idxhdr{tgmath.h}}, do not contain any of the
+content from the C standard library and instead merely include other headers
+from the \Cpp standard library.
+
+\pnum
+The headers \tcode{<ciso646>}, \tcode{<cstdalign>}~(\ref{cstdalign.syn}),
+and \tcode{<cstdbool>}~(\ref{cstdbool.syn}) are meaningless in \Cpp. Use of
+the \Cpp headers \tcode{<ccomplex>}, \tcode{<cstdalign>}, \tcode{<cstdbool>},
+and \tcode{<ctgmath>} is deprecated~(\ref{depr.c.headers}).
 
 \rSec2[diff.mods.to.definitions]{Modifications to definitions}
 


### PR DESCRIPTION
A section called "modifications to headers" should not fail to explain what happened to all the other C headers.

Part of Issue #1006.