### PR TITLE
Replace 'run-time' by 'runtime' for consistency.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2604,7 +2604,7 @@ appears in its initializer is a constant expression.
 
 \end{itemize}
 
-\indextext{initialization!run-time}%
+\indextext{initialization!runtime}%
 If constant initialization is not performed, a variable with static
 storage duration~(\ref{basic.stc.static}) or thread storage
 duration~(\ref{basic.stc.thread}) is zero-initialized~(\ref{dcl.init}).

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -314,7 +314,7 @@ Constructors used in initializers may allocate
 resources which need to be de-allocated upon leaving the
 block.
 Allowing jump past initializers would require
-complicated run-time determination of allocation.
+complicated runtime determination of allocation.
 Furthermore, any use of the uninitialized object could be a
 disaster.
 With this simple compile-time rule, \Cpp assures that

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -1003,7 +1003,7 @@ If \tcode{e} is a \grammarterm{throw-expression}~(\ref{expr.throw}),
 initialized by the operand, if present, or is the set of all types otherwise.
 \item
 If \tcode{e} is a \tcode{dynamic_cast} expression that casts to a reference type and
-requires a run-time check~(\ref{expr.dynamic.cast}),
+requires a runtime check~(\ref{expr.dynamic.cast}),
 \placeholder{S} consists of the type \tcode{std::bad_cast}.
 \item
 If \tcode{e} is a \tcode{typeid} expression applied to a glvalue expression whose

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1993,12 +1993,12 @@ type~(\ref{class.virtual}).
 \pnum
 If \tcode{T} is ``pointer to \cvqual{cv} \tcode{void}'', then the result
 is a pointer to the most derived object pointed to by \tcode{v}.
-Otherwise, a run-time check is applied to see if the object pointed or
+Otherwise, a runtime check is applied to see if the object pointed or
 referred to by \tcode{v} can be converted to the type pointed or
 referred to by \tcode{T}.
 
 \pnum
-If \tcode{C} is the class type to which \tcode{T} points or refers, the run-time
+If \tcode{C} is the class type to which \tcode{T} points or refers, the runtime
 check logically executes as follows:
 
 \begin{itemize}
@@ -2014,7 +2014,7 @@ and \tcode{public}, the result points (refers) to the
 \tcode{C} subobject of the most derived object.
 
 \item Otherwise, the
-run-time check \term{fails}.
+runtime check \term{fails}.
 \end{itemize}
 
 \pnum
@@ -2039,7 +2039,7 @@ void g() {
   ap = dynamic_cast<A*>(bp);        // fails
   bp = dynamic_cast<B*>(ap);        // fails
   ap = dynamic_cast<A*>(&d);        // succeeds
-  bp = dynamic_cast<B*>(&d);        // ill-formed (not a run-time check)
+  bp = dynamic_cast<B*>(&d);        // ill-formed (not a runtime check)
 }
 
 class E : public D, public B { };

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1398,7 +1398,7 @@ the program prior to program startup.
 \indextext{startup!program}%
 \xref
 replacement functions~(\ref{replacement.functions}),
-run-time changes~(\ref{handler.functions}).
+runtime changes~(\ref{handler.functions}).
 
 \rSec2[utility.requirements]{Requirements on types and expressions}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -14016,7 +14016,7 @@ Template parameters named \tcode{Hash} shall meet the requirements as specified 
 \pnum
 The Boyer-Moore searcher implements the Boyer-Moore search algorithm.
 The Boyer-Moore-Horspool searcher implements the Boyer-Moore-Horspool search algorithm.
-In general, the Boyer-Moore searcher will use more memory and give better run-time performance than Boyer-Moore-Horspool
+In general, the Boyer-Moore searcher will use more memory and give better runtime performance than Boyer-Moore-Horspool
 
 \rSec3[func.searchers.default]{Class template \tcode{default_searcher}}
 


### PR DESCRIPTION
Fixes #167.