### PR TITLE
[support.types.layout], [diff.offsetof] Use \placeholder

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1916,13 +1916,13 @@ The following functions have different behavior:
 
 Subclause \ref{csetjmp.syn} describes the changes.
 
-\rSec3[diff.offsetof]{Macro \tcode{offsetof(type, member-designator)}}
+\rSec3[diff.offsetof]{Macro \tcode{offsetof(\placeholder{type}, \placeholder{member-designator})}}
 \indexlibrary{\idxcode{offsetof}}%
 
 \pnum
 The macro \tcode{offsetof}, defined in
 \tcode{<cstddef>}~(\ref{cstddef.syn})\indexlibrary{\idxhdr{cstddef}},
-accepts a restricted set of \tcode{type} arguments in this International Standard.
+accepts a restricted set of \placeholder{type} arguments in this International Standard.
 Subclause \ref{support.types.layout} describes the change.
 
 \rSec3[diff.malloc]{Memory allocation functions}

--- a/source/support.tex
+++ b/source/support.tex
@@ -256,25 +256,25 @@ but not
 \pnum
 The macro
 \indexlibrary{\idxcode{offsetof}}%
-\tcode{offsetof}(\textit{type},
-\grammarterm{member-designator})
+\tcode{offsetof}(\placeholder{type},
+\placeholder{member-designator})
 has the same semantics as the corresponding macro in
 the C standard library header \tcode{<stddef.h>}, but
-accepts a restricted set of \textit{type}
+accepts a restricted set of \placeholder{type}
 arguments in this International Standard.
-Use of the \tcode{offsetof} macro with a \textit{type}
+Use of the \tcode{offsetof} macro with a \placeholder{type}
 other than a standard-layout class (Clause~\ref{class})
 is conditionally-supported.\footnote{Note that \tcode{offsetof}
 is required to work as specified even if unary
 \tcode{operator\&}
 is overloaded for any of the types involved.}
-The expression \tcode{offsetof}(\textit{type}, \grammarterm{member-designator})
+The expression \tcode{offsetof}(\placeholder{type}, \placeholder{member-designator})
 is never type-dependent~(\ref{temp.dep.expr}) and it is
-value-dependent~(\ref{temp.dep.constexpr}) if and only if \textit{type} is
+value-dependent~(\ref{temp.dep.constexpr}) if and only if \placeholder{type} is
 dependent. The result of applying the \tcode{offsetof} macro to
 a static data member or a function member is undefined.
 No operation invoked by the \tcode{offsetof} macro shall throw an exception and
-\tcode{noexcept(offsetof(type, member-designator))} shall be \tcode{true}.
+\tcode{noexcept(offsetof(\placeholder{type}, \placeholder{member-designator}))} shall be \tcode{true}.
 
 \pnum
 The type \tcode{ptrdiff_t} is an


### PR DESCRIPTION
for meta-variables in offsetof description, not \textit and not \grammarterm.

Fixes #456.