### PR TITLE
[diff.cpp03.input.output] Use code font for 'explicit'

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1288,7 +1288,7 @@ binary representation of the required template specializations of
 \ref{istream::sentry},
 \ref{ostream::sentry},
 \ref{iostate.flags}
-\change Specify use of explicit in existing boolean conversion functions
+\change Specify use of \tcode{explicit} in existing boolean conversion functions.
 \rationale Clarify intentions, avoid workarounds.
 \effect
 Valid \CppIII code that relies on implicit boolean conversions will fail to


### PR DESCRIPTION
Fixes #1019.