### PR TITLE
[basic] Replace \term with \defnx as appropriate

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5,15 +5,15 @@
 
 \pnum
 \begin{note} This Clause presents the basic concepts of the \Cpp language.
-It explains the difference between an \term{object} and a
-\term{name} and how they relate to the value categories for expressions.
+It explains the difference between an object and a
+name and how they relate to the value categories for expressions.
 It introduces the concepts of a
-\term{declaration} and a \term{definition} and presents \Cpp's
-notion of \term{type}, \term{scope}, \term{linkage}, and
-\term{storage} \term{duration}. The mechanisms for starting and
+declaration and a definition and presents \Cpp's
+notion of type, scope, linkage, and
+storage duration. The mechanisms for starting and
 terminating a program are discussed. Finally, this Clause presents the
-\term{fundamental} types of the language and lists the ways of constructing
-\term{compound} types from these.\end{note}
+fundamental types of the language and lists the ways of constructing
+compound types from these.\end{note}
 
 \pnum
 \begin{note} This Clause does not cover concepts that affect only a single
@@ -21,15 +21,12 @@ part of the language. Such concepts are discussed in the relevant
 Clauses. \end{note}
 
 \pnum
-\indextext{name}%
-\indextext{declaration}%
 \indextext{type}%
 \indextext{object}%
 \indextext{storage~class}%
 \indextext{scope}%
 \indextext{linkage}%
 \indextext{region!declarative}%
-\indextext{entity}%
 An \defn{entity} is a value, object, reference, function, enumerator, type,
 class member, bit-field, template, template specialization, namespace, or
 parameter pack.
@@ -44,7 +41,7 @@ A \defn{name} is a use of an \grammarterm{identifier}~(\ref{lex.name}),
 
 \pnum
 Every name that denotes an entity is introduced by a
-\term{declaration}. Every name that denotes a label is introduced
+\defn{declaration}. Every name that denotes a label is introduced
 either by a \tcode{goto} statement~(\ref{stmt.goto}) or a
 \grammarterm{labeled-statement}~(\ref{stmt.label}).
 
@@ -59,11 +56,10 @@ Some names denote types or templates. In general,
 whenever a name is encountered it is necessary to determine whether that name denotes
 one of these entities before continuing to parse the program that contains it. The
 process that determines this is called
-\indextext{lookup!name}%
-\term{name lookup}~(\ref{basic.lookup}).
+\defnx{name lookup}{lookup!name}~(\ref{basic.lookup}).
 
 \pnum
-Two names are \term{the same} if
+Two names are \defnx{the same}{name!same} if
 
 \begin{itemize}
 \item they are \grammarterm{identifier}{s} composed of the same character sequence, or
@@ -411,7 +407,7 @@ to an object of type \tcode{T}~(\ref{conv.lval}), or
 type \tcode{T} (Clause~\ref{conv}, \ref{expr.type.conv},
 \ref{expr.dynamic.cast}, \ref{expr.static.cast}, \ref{expr.cast}), or
 \item an expression that is not a null pointer constant, and has type
-other than \term{cv} \tcode{void*}, is converted to the type pointer to \tcode{T}
+other than \cv{} \tcode{void*}, is converted to the type pointer to \tcode{T}
 or reference to \tcode{T} using a standard conversion
 (Clause~\ref{conv}), a \tcode{dynamic_cast}~(\ref{expr.dynamic.cast}) or
 a \tcode{static_cast}~(\ref{expr.static.cast}), or
@@ -824,9 +820,8 @@ at the end of the nearest enclosing function declarator.
 \rSec2[basic.funscope]{Function scope}
 
 \pnum
-\indextext{scope!function}%
 \indextext{label!scope~of}%
-Labels~(\ref{stmt.label}) have \term{function scope} and
+Labels~(\ref{stmt.label}) have \defnx{function scope}{scope!function} and
 may be used anywhere in the function in which they are declared. Only
 labels have function scope.
 
@@ -1551,9 +1546,9 @@ those of its type \grammarterm{template-argument}{s} and its template
 \grammarterm{template-argument}{s}.
 
 \pnum
-Let \term{X} be the lookup set produced by unqualified
-lookup~(\ref{basic.lookup.unqual}) and let \term{Y} be the lookup set produced
-by argument dependent lookup (defined as follows). If \term{X} contains
+Let \placeholder{X} be the lookup set produced by unqualified
+lookup~(\ref{basic.lookup.unqual}) and let \placeholder{Y} be the lookup set produced
+by argument dependent lookup (defined as follows). If \placeholder{X} contains
 \begin{itemize}
 \item a declaration of a class member, or
 
@@ -1563,10 +1558,10 @@ by argument dependent lookup (defined as follows). If \term{X} contains
 \item a declaration that is neither a function nor a function template
 
 \end{itemize}
-then \term{Y} is empty. Otherwise \term{Y} is the set of declarations
+then \placeholder{Y} is empty. Otherwise \placeholder{Y} is the set of declarations
 found in the namespaces associated with the argument types as described
 below. The set of declarations found by the lookup of the name is the
-union of \term{X} and \term{Y}. \begin{note} The namespaces and classes
+union of \placeholder{X} and \placeholder{Y}. \begin{note} The namespaces and classes
 associated with the argument types can include namespaces and classes
 already considered by the ordinary unqualified lookup. \end{note}
 \begin{example}
@@ -3267,10 +3262,9 @@ is that of their complete object~(\ref{intro.object}).
 
 \pnum
 \indextext{object~lifetime|(}%
-\indextext{initialization!non-vacuous}%
 The \defn{lifetime} of an object or reference is a runtime property of the
 object or reference.
-An object is said to have \term{non-vacuous initialization} if it is of a class or
+An object is said to have \defnx{non-vacuous initialization}{initialization!non-vacuous} if it is of a class or
 aggregate type and it or one of its subobjects is initialized by a constructor
 other than a trivial default constructor. \begin{note} initialization by a
 trivial copy/move constructor is non-vacuous initialization. \end{note}
@@ -3359,9 +3353,9 @@ to a virtual base class, or
 
 \item the pointer is used as the operand of a
 \tcode{static_cast}~(\ref{expr.static.cast}), except when the conversion
-is to pointer to \term{cv} \tcode{void}, or to pointer to \term{cv}
-\tcode{void} and subsequently to pointer to either \term{cv}
-\tcode{char} or \term{cv} \tcode{unsigned char}, or
+is to pointer to \cv{} \tcode{void}, or to pointer to \cv{}
+\tcode{void} and subsequently to pointer to either \cv{}
+\tcode{char} or \cv{} \tcode{unsigned char}, or
 
 \item the pointer is used as the operand of a
 \tcode{dynamic_cast}~(\ref{expr.dynamic.cast}). \begin{example}
@@ -3595,8 +3589,8 @@ std::memcpy(t1p, t2p, sizeof(T));
 The \defn{object representation}
 \indextext{representation!object}%
 of an object of type \tcode{T} is the
-sequence of \term{N} \tcode{unsigned} \tcode{char} objects taken up
-by the object of type \tcode{T}, where \term{N} equals
+sequence of \placeholder{N} \tcode{unsigned} \tcode{char} objects taken up
+by the object of type \tcode{T}, where \placeholder{N} equals
 \tcode{sizeof(T)}. The
 \indextext{representation!value}%
 \defn{value representation}
@@ -3609,16 +3603,16 @@ intent is that the memory model of \Cpp is compatible
 with that of ISO/IEC 9899 Programming Language C.}
 
 \pnum
-\indextext{type!incomplete}%
 \indextext{type!incompletely-defined object}%
-\indextext{object type!incompletely-defined}%
 A class that has been declared but not defined, an enumeration type in certain
 contexts~(\ref{dcl.enum}), or an array of unknown
-size or of incomplete element type, is an \defn{incompletely-defined object
-type}.\footnote{The size and layout of an instance of an incompletely-defined
+size or of incomplete element type, is an
+\defnx{incompletely-defined object type}{object type!incompletely-defined}.%
+\footnote{The size and layout of an instance of an incompletely-defined
 object type is unknown.}
-Incompletely-defined object types and \cv\ \tcode{void} are \term{incomplete
-types}~(\ref{basic.fundamental}). Objects shall not be defined to have an
+Incompletely-defined object types and \cv\ \tcode{void} are
+\defnx{incomplete types}{type!incomplete}~(\ref{basic.fundamental}).
+Objects shall not be defined to have an
 incomplete type.
 
 \pnum
@@ -3680,13 +3674,11 @@ types, pointer to member types~(\ref{basic.compound}),
 and
 cv-qualified versions of these
 types~(\ref{basic.type.qualifier}) are collectively called
-\indextext{scalar~type}%
-\term{scalar types}. Scalar types,
+\defnx{scalar types}{scalar~type}. Scalar types,
 POD classes (Clause~\ref{class}), arrays of such types and
 cv-qualified versions of these
 types~(\ref{basic.type.qualifier}) are collectively called
-\indextext{type!POD}%
-\term{POD types}.
+\defnx{POD types}{type!POD}.
 Cv-unqualified scalar types, trivially copyable class types (Clause~\ref{class}), arrays of
 such types, and non-volatile const-qualified versions of these
 types~(\ref{basic.type.qualifier}) are collectively called \defn{trivially
@@ -3741,7 +3733,6 @@ layout-compatible standard-layout class types~(\ref{class.mem}).
 \indextext{type!Boolean}%
 \indextext{type!\idxcode{char}}%
 \indextext{type!character}%
-\indextext{type!narrow character}%
 Objects declared as characters (\tcode{char}) shall be large enough to
 store any member of the implementation's basic character set. If a
 character from this set is stored in a character object, the integral
@@ -3755,7 +3746,8 @@ Characters can be explicitly declared \tcode{unsigned} or
 \tcode{signed}.
 \indextext{character!\idxcode{signed}}%
 Plain \tcode{char}, \tcode{signed char}, and \tcode{unsigned char} are
-three distinct types, collectively called \term{narrow character types}.
+three distinct types, collectively called
+\defnx{narrow character types}{type!narrow character}.
 A \tcode{char}, a \tcode{signed char}, and an
 \tcode{unsigned char} occupy the same amount of storage and have the
 same alignment requirements~(\ref{basic.align}); that is, they have the
@@ -3781,8 +3773,7 @@ conversion~(\ref{conv.integral}) from \placeholder{i} to \tcode{char} is
 
 \pnum
 \indextext{type!standard~signed~integer}%
-\indextext{standard~signed~integer~type}%
-There are five \term{standard signed integer types} :
+There are five \defnx{standard signed integer types}{standard~signed~integer~type} :
 \indextext{type!\idxcode{signed char}}%
 \indextext{type!\idxcode{short}}%
 \indextext{type!\idxcode{int}}%
@@ -3793,12 +3784,12 @@ There are five \term{standard signed integer types} :
 this list, each type provides at least as much storage as those
 preceding it in the list.
 \indextext{type!extended~signed~integer}%
-\indextext{extended~signed~integer~type}%
 \indextext{type!signed~integer}%
-\indextext{signed~integer~type}%
-There may also be \impldef{extended signed integer types} \term{extended signed
-integer types}. The standard and
-extended signed integer types are collectively called \term{signed integer types}.
+There may also be \impldef{extended signed integer types}
+\defnx{extended signed integer types}{extended~signed~integer~type}.
+The standard and
+extended signed integer types are collectively called
+\defnx{signed integer types}{signed~integer~type}.
 \indextext{integral~type!implementation-defined @\tcode{sizeof}}%
 Plain
 \tcode{int}s have the natural size suggested by the architecture of the
@@ -3814,8 +3805,7 @@ the other signed integer types are provided to meet special needs.
 For each of the standard signed integer types,
 there exists a corresponding (but different)
 \indextext{type!standard~unsigned~integer}%
-\indextext{standard~unsigned~integer~type}%
-\term{standard unsigned integer type}:
+\defnx{standard unsigned integer type}{standard~unsigned~integer~type}:
 \indextext{type!\idxcode{unsigned char}}%
 \indextext{type!\idxcode{unsigned short}}%
 \indextext{type!\idxcode{unsigned int}}%
@@ -3831,26 +3821,23 @@ the sequences of \grammarterm{type-specifier}{s} that designate them.};
 that is, each signed integer type has the same object representation as
 its corresponding unsigned integer type.
 \indextext{type!extended~unsigned~integer}%
-\indextext{extended~unsigned~integer~type}%
 \indextext{type!unsigned~integer}%
-\indextext{unsigned~integer~type}%
 Likewise, for each of the extended signed integer types there exists a
-corresponding \term{extended unsigned integer type} with the same amount of storage and alignment
+corresponding
+\defnx{extended unsigned integer type}{extended~unsigned~integer~type} with the same amount of storage and alignment
 requirements. The standard and extended unsigned integer types are
-collectively called \term{unsigned integer types}. The range of non-negative
-values of a \term{signed integer} type is a subrange of the corresponding
-\term{unsigned integer} type, and the value
+collectively called \defnx{unsigned integer types}{unsigned~integer~type}. The range of non-negative
+values of a signed integer type is a subrange of the corresponding
+unsigned integer type, and the value
 representation of each corresponding signed/unsigned type shall be the
 same.
 \indextext{type!standard~integer}%
-\indextext{standard~integer~type}%
 \indextext{type!extended~integer}%
-\indextext{extended~integer~type}%
 The standard signed integer types and standard unsigned integer types
-are collectively called the \term{standard integer types}, and the extended
+are collectively called the \defnx{standard integer types}{standard~integer~type}, and the extended
 signed integer types and extended
-unsigned integer types are collectively called the \term{extended
-integer types}. The signed and unsigned integer types shall satisfy
+unsigned integer types are collectively called the \defnx{extended
+integer types}{extended~integer~type}. The signed and unsigned integer types shall satisfy
 the constraints given in the C standard, section 5.2.4.2.1.
 
 \pnum
@@ -3894,16 +3881,14 @@ or \tcode{long bool} types or values. \end{note} Values of type
 Types \tcode{bool}, \tcode{char}, \tcode{char16_t}, \tcode{char32_t},
 \tcode{wchar_t}, and the signed and unsigned integer types are
 collectively called
-\indextext{integral~type}%
-\term{integral} types.\footnote{Therefore, enumerations~(\ref{dcl.enum}) are not integral; however,
+\defnx{integral}{integral~type} types.\footnote{Therefore, enumerations~(\ref{dcl.enum}) are not integral; however,
 enumerations can be promoted to integral types as specified
 in~\ref{conv.prom}.}
 A synonym for integral type is
-\indextext{integer~type}%
 \indextext{signed integer representation!ones' complement}%
 \indextext{signed integer representation!two's complement}%
 \indextext{signed integer representation!signed magnitude}%
-\term{integer type}. The representations of integral types shall
+\defnx{integer type}{integer~type}. The representations of integral types shall
 define values by use of a pure binary numeration system.\footnote{A positional
 representation for integers that uses the binary digits 0
 and 1, in which the values represented by successive bits are additive,
@@ -3915,8 +3900,7 @@ ones' complement and signed magnitude representations for integral types.
 \end{example}
 
 \pnum
-\indextext{floating~point~type}%
-There are three \term{floating point} types:
+There are three \defnx{floating point}{floating~point~type} types:
 \indextext{type!\idxcode{float}}%
 \tcode{float},
 \indextext{type!\idxcode{double}}%
@@ -3932,13 +3916,12 @@ of the set of values of the type \tcode{long} \tcode{double}. The value
 representation of floating-point types is \impldef{value representation of
 floating-point types}.
 \indextext{floating~point~type!implementation-defined}%
-\indextext{type!arithmetic}%
 \begin{note}
 This International Standard imposes no requirements on the accuracy of
 floating-point operations; see also~\ref{limits}. 
 \end{note}
-\term{Integral} and \term{floating} types are collectively
-called \term{arithmetic} types.
+Integral and floating types are collectively
+called \defnx{arithmetic}{type!arithmetic} types.
 \indextext{\idxcode{numeric_limits}!specializations for arithmetic types}%
 Specializations of the standard library template
 \tcode{std::numeric_limits}~(\ref{support.limits}) shall specify the
@@ -3980,52 +3963,44 @@ same value representation, they are nevertheless different types.
 Compound types can be constructed in the following ways:
 
 \begin{itemize}
-\item \indextext{type!array}%
-\term{arrays} of objects of a given type,~\ref{dcl.array};
+\item \defnx{arrays}{type!array} of objects of a given type,~\ref{dcl.array};
 
-\item \indextext{type!function}%
-\term{functions}, which have parameters of given types and return
+\item \defnx{functions}{type!function}, which have parameters of given types and return
 \tcode{void} or references or objects of a given type,~\ref{dcl.fct};
 
-\item \indextext{type!pointer}%
-\term{pointers} to \cv\ \tcode{void} or objects or functions (including
+\item \defnx{pointers}{type!pointer} to \cv\ \tcode{void} or objects or functions (including
 static members of classes) of a given type,~\ref{dcl.ptr};
 
 \item %
-\indextext{reference}%
 \indextext{reference!lvalue}%
 \indextext{reference!rvalue}%
-\indextext{lvalue~reference}%
-\indextext{rvalue~reference}%
-\term{references} to objects or functions of a given
+\defnx{references}{reference} to objects or functions of a given
 type,~\ref{dcl.ref}. There are two types of references:
 \begin{itemize}
-\item \term{lvalue reference}
-\item \term{rvalue reference}
+\item \defnx{lvalue reference}{lvalue~reference}
+\item \defnx{rvalue reference}{rvalue~reference}
 \end{itemize}
 
-\item \indextext{class}%
-\term{classes} containing a sequence of objects of various types
+\item
+\defnx{classes}{class} containing a sequence of objects of various types
 (Clause~\ref{class}), a set of types, enumerations and functions for
 manipulating these objects~(\ref{class.mfct}), and a set of restrictions
 on the access to these entities (Clause~\ref{class.access});
 
-\item \indextext{\idxcode{union}}%
-\term{unions}, which are classes capable of containing objects of
+\item
+\defnx{unions}{\idxcode{union}}, which are classes capable of containing objects of
 different types at different times,~\ref{class.union};
 
-\item \indextext{\idxcode{enum}}%
-\term{enumerations}, which comprise a set of named constant values.
+\item
+\defnx{enumerations}{\idxcode{enum}}, which comprise a set of named constant values.
 Each distinct enumeration constitutes a different
-\indextext{type!enumerated}%
-\term{enumerated type},~\ref{dcl.enum};
+\defnx{enumerated type}{type!enumerated},~\ref{dcl.enum};
 
 \item \indextext{member~pointer~to|see{pointer to member}}%
-\indextext{pointer~to~member}%
-\term{pointers to non-static}
+\defnx{pointers to non-static class members}{pointer~to~member},%
 \footnote{Static class members are objects or functions, and pointers to them are
 ordinary pointers to objects or functions.}
-\term{class members}, which identify members of a given
+which identify members of a given
 type within objects of a given class,~\ref{dcl.mptr}.
 \end{itemize}
 
@@ -4144,12 +4119,12 @@ requirements as \cv\ \tcode{char*}.
 \indextext{\idxcode{const}}%
 \indextext{\idxcode{volatile}}%
 A type mentioned in~\ref{basic.fundamental} and~\ref{basic.compound} is
-a \term{cv-unqualified type}. Each type which is a
+a \defnx{cv-unqualified type}{type!cv-unqualified}. Each type which is a
 cv-unqualified complete or incomplete object type or is
 \tcode{void}~(\ref{basic.types}) has three corresponding cv-qualified
-versions of its type: a \term{const-qualified} version, a
-\term{volatile-qualified} version, and a
-\term{const-volatile-qualified} version. The term
+versions of its type: a \defn{const-qualified} version, a
+\defn{volatile-qualified} version, and a
+\defn{const-volatile-qualified} version. The term
 \term{object type}~(\ref{intro.object}) includes the cv-qualifiers
 specified in the \grammarterm{decl-specifier-seq}~(\ref{dcl.spec}), 
 \grammarterm{declarator} (Clause~\ref{dcl.decl}),
@@ -4157,14 +4132,14 @@ specified in the \grammarterm{decl-specifier-seq}~(\ref{dcl.spec}),
 \grammarterm{new-type-id}~(\ref{expr.new}) when the object is created.
 
 \begin{itemize}
-\item A \term{const object} is an object of type \tcode{const T} or a
+\item A \defnx{const object}{object!const} is an object of type \tcode{const T} or a
   non-mutable subobject of such an object.
 
-\item A \term{volatile object} is an object of type
+\item A \defnx{volatile object}{object!volatile} is an object of type
   \tcode{volatile T}, a subobject of such an object, or a mutable
   subobject of a const volatile object.
 
-\item A \term{const volatile object} is an object of type
+\item A \defnx{const volatile object}{object!const volatile} is an object of type
   \tcode{const volatile T}, a non-mutable subobject of such an object,
   a const subobject of a volatile object, or a non-mutable volatile
   subobject of a const object.
@@ -4207,13 +4182,12 @@ constitute this ordering.
 \end{floattable}
 
 \pnum
-In this International Standard, the notation \term{cv} (or
-\term{cv1}, \term{cv2}, etc.), used in the description of types,
+In this International Standard, the notation \cv{} (or
+\cvqual{cv1}, \cvqual{cv2}, etc.), used in the description of types,
 represents an arbitrary set of cv-qualifiers, i.e., one of
 \{\tcode{const}\}, \{\tcode{volatile}\}, \{\tcode{const},
 \tcode{volatile}\}, or the empty set.
-\indextext{cv-qualifier!top-level}
-For a type \cv\ \tcode{T}, the \term{top-level cv-qualifiers}
+For a type \cv\ \tcode{T}, the \defnx{top-level cv-qualifiers}{cv-qualifier!top-level}
 of that type are those denoted by \cv.
 \begin{example}
 The type corresponding to the \grammarterm{type-id}
@@ -4231,7 +4205,7 @@ has the top-level cv-qualifier \tcode{volatile}.
 \pnum
 Cv-qualifiers applied to an array
 type attach to the underlying element type, so the notation
-``\term{cv} \tcode{T}'', where \tcode{T} is an array type, refers to
+``\cv{} \tcode{T}'', where \tcode{T} is an array type, refers to
 an array whose elements are so-qualified. An array type whose elements
 are cv-qualified is also considered to have the same cv-qualifications
 as its elements.%
@@ -4384,19 +4358,17 @@ the object,
 \rSec1[basic.align]{Alignment}
 
 \pnum
-\indextext{alignment~requirement!implementation-defined}%
-Object types have \term{alignment requirements} (\ref{basic.fundamental},~\ref{basic.compound})
+Object types have \defnx{alignment requirements}{alignment~requirement!implementation-defined} (\ref{basic.fundamental},~\ref{basic.compound})
 which place restrictions on the addresses at which an object of that type
-may be allocated. An \term{alignment} is an \impldef{alignment}
+may be allocated. An \defn{alignment} is an \impldef{alignment}
 integer value representing the number of bytes between successive addresses
 at which a given object can be allocated. An object type imposes an alignment
 requirement on every object of that type; stricter alignment can be requested
 using the alignment specifier~(\ref{dcl.align}).
 
 \pnum
-\indextext{fundamental~alignment}%
 \indextext{alignment!fundamental}%
-A \term{fundamental alignment} is represented by an alignment
+A \defnx{fundamental alignment}{fundamental~alignment} is represented by an alignment
 less than or equal to the greatest alignment supported by the implementation in
 all contexts, which is equal to
 \tcode{alignof(std::max_align_t)}~(\ref{support.types}).
@@ -4440,8 +4412,8 @@ set of values, which may be empty.
 Every alignment value shall be a non-negative integral power of two.
 
 \pnum
-Alignments have an order from \term{weaker} to
-\term{stronger} or \term{stricter} alignments. Stricter
+Alignments have an order from \defnx{weaker}{alignment!weaker} to
+\defnx{stronger}{alignment!stronger} or \defnx{stricter}{alignment!stricter} alignments. Stricter
 alignments have larger alignment values. An address that satisfies an alignment
 requirement also satisfies any weaker valid alignment requirement.
 


### PR DESCRIPTION
Partially addresses #329.

Also removes \term from the introductory note in 3p1 and uses \defnx instead of separate \term and \indextext where applicable.

diffpdf shows only whitespace differences in the main body, plus one slightly moved footnote. The index has a few more entries now, e.g. for "object, const".