### PR TITLE
[intro] Replace \term with \placeholder or \defn as appropriate

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2855,7 +2855,7 @@ the functions passed to \tcode{std::atexit()} or \tcode{std::at_quick_exit()}.%
 
 \pnum
 \indextext{storage~duration|(}%
-Storage duration is the property of an object that defines the minimum
+The \defnx{storage duration}{storage~duration} is the property of an object that defines the minimum
 potential lifetime of the storage containing the object. The storage
 duration is determined by the construct used to create the object and is
 one of the following:

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -39,7 +39,7 @@ requirement appear at various places within this International Standard.
 \Cpp is a general purpose programming language based on the C
 programming language as described in ISO/IEC 9899:2011
 \doccite{Programming languages --- C} (hereinafter referred to as the
-\indexdefn{C!standard}\term{C standard}). In addition to
+\defnx{C standard}{C!standard}). In addition to
 the facilities provided by C, \Cpp provides additional data types,
 classes, templates, exceptions, namespaces, operator
 overloading, function name overloading, references, free store
@@ -548,13 +548,13 @@ in its period of destruction~(\ref{class.cdtor}).
 occupies storage in the way that objects do. \end{note}
 The properties of an
 object are determined when the object is created. An object can have a
-\term{name}~(Clause~\ref{basic}). An object has a \term{storage
-duration}~(\ref{basic.stc}) which influences its
-\term{lifetime}~(\ref{basic.life}). An object has a
-\term{type}~(\ref{basic.types}). The term \defn{object type} refers to
+name~(Clause~\ref{basic}). An object has a storage
+duration~(\ref{basic.stc}) which influences its
+lifetime~(\ref{basic.life}). An object has a
+type~(\ref{basic.types}). The term \defn{object type} refers to
 the type with which the object is created.
 Some objects are
-\term{polymorphic}~(\ref{class.virtual}); the implementation
+polymorphic~(\ref{class.virtual}); the implementation
 generates information associated with each such object that makes it
 possible to determine that object's type during program execution. For
 other objects, the interpretation of the values found therein is
@@ -950,16 +950,16 @@ may not have completed yet.
 \pnum
 \defn{Sequenced before} is an asymmetric, transitive, pair-wise relation between
 evaluations executed by a single thread~(\ref{intro.multithread}), which induces
-a partial order among those evaluations. Given any two evaluations \term{A} and
-\term{B}, if \term{A} is sequenced before \term{B}
-(or, equivalently, \term{B} is \defn{sequenced after} \term{A}),
+a partial order among those evaluations. Given any two evaluations \placeholder{A} and
+\placeholder{B}, if \placeholder{A} is sequenced before \placeholder{B}
+(or, equivalently, \placeholder{B} is \defn{sequenced after} \placeholder{A}),
 then the execution of
-\term{A} shall precede the execution of \term{B}. If \term{A} is not sequenced
-before \term{B} and \term{B} is not sequenced before \term{A}, then \term{A} and
-\term{B} are \defn{unsequenced}. \begin{note} The execution of unsequenced
-evaluations can overlap. \end{note} Evaluations \term{A} and \term{B} are
-\defn{indeterminately sequenced} when either \term{A} is sequenced before
-\term{B} or \term{B} is sequenced before \term{A}, but it is unspecified which.
+\placeholder{A} shall precede the execution of \placeholder{B}. If \placeholder{A} is not sequenced
+before \placeholder{B} and \placeholder{B} is not sequenced before \placeholder{A}, then \placeholder{A} and
+\placeholder{B} are \defn{unsequenced}. \begin{note} The execution of unsequenced
+evaluations can overlap. \end{note} Evaluations \placeholder{A} and \placeholder{B} are
+\defn{indeterminately sequenced} when either \placeholder{A} is sequenced before
+\placeholder{B} or \placeholder{B} is sequenced before \placeholder{A}, but it is unspecified which.
 \begin{note} Indeterminately sequenced evaluations cannot overlap, but either
 could be executed first. \end{note}
 An expression \placeholder{X}
@@ -1027,16 +1027,16 @@ side effect associated with any argument
 expression, or with the postfix expression designating the called
 function, is sequenced before execution of every expression or statement
 in the body of the called function.
-For each function invocation \term{F},
-for every evaluation \term{A} that occurs within \term{F} and
-every evaluation \term{B} that does not occur within \term{F} but
+For each function invocation \placeholder{F},
+for every evaluation \placeholder{A} that occurs within \placeholder{F} and
+every evaluation \placeholder{B} that does not occur within \placeholder{F} but
 is evaluated on the same thread and as part of the same signal handler (if any),
-either \term{A} is sequenced before \term{B} or
-\term{B} is sequenced before \term{A}.
+either \placeholder{A} is sequenced before \placeholder{B} or
+\placeholder{B} is sequenced before \placeholder{A}.
 \footnote{In other words, function executions do not interleave with
 each other.}
 \begin{note}
-If \term{A} and \term{B} would not otherwise be sequenced then they are
+If \placeholder{A} and \placeholder{B} would not otherwise be sequenced then they are
 indeterminately sequenced.
 \end{note}
 Several contexts in \Cpp  cause evaluation of a function call, even
@@ -1088,8 +1088,8 @@ contains a signal handler invocation.
 \rSec2[intro.races]{Data races}
 
 \pnum
-The value of an object visible to a thread \term{T} at a particular point is the
-initial value of the object, a value assigned to the object by \term{T}, or a
+The value of an object visible to a thread \placeholder{T} at a particular point is the
+initial value of the object, a value assigned to the object by \placeholder{T}, or a
 value assigned to the object by another thread, according to the rules below.
 \begin{note} In some cases, there may instead be undefined behavior. Much of this
 section is motivated by the desire to support atomic operations with explicit
@@ -1116,17 +1116,17 @@ characteristics. \begin{note} For example, a call that acquires a mutex will
 perform an acquire operation on the locations comprising the mutex.
 Correspondingly, a call that releases the same mutex will perform a release
 operation on those same locations. Informally, performing a release operation on
-\term{A} forces prior
+\placeholder{A} forces prior
 \indextext{side effects}%
 side effects on other memory locations to become visible
 to other threads that later perform a consume or an acquire operation on
-\term{A}. ``Relaxed'' atomic operations are not synchronization operations even
+\placeholder{A}. ``Relaxed'' atomic operations are not synchronization operations even
 though, like synchronization operations, they cannot contribute to data races.
 \end{note}
 
 \pnum
-All modifications to a particular atomic object \term{M} occur in some
-particular total order, called the \defn{modification order} of \term{M}.
+All modifications to a particular atomic object \placeholder{M} occur in some
+particular total order, called the \defn{modification order} of \placeholder{M}.
 \begin{note} There is a separate order for each
 atomic object. There is no requirement that these can be combined into a single
 total order for all objects. In general this will be impossible since different
@@ -1134,11 +1134,11 @@ threads may observe modifications to different objects in inconsistent orders.
 \end{note}
 
 \pnum
-A \defn{release sequence} headed by a release operation \term{A} on an atomic object
-\term{M} is a maximal contiguous sub-sequence of
+A \defn{release sequence} headed by a release operation \placeholder{A} on an atomic object
+\placeholder{M} is a maximal contiguous sub-sequence of
 \indextext{side effects}%
 side effects in the
-modification order of \term{M}, where the first operation is \tcode{A}, and
+modification order of \placeholder{M}, where the first operation is \tcode{A}, and
 every subsequent operation
 
 \begin{itemize}
@@ -1159,38 +1159,38 @@ on a given mutex occur in a single total order. Each mutex acquisition ``reads
 the value written'' by the last mutex release. \end{note}
 
 \pnum
-An evaluation \term{A} \defn{carries a dependency} to an evaluation \term{B} if
+An evaluation \placeholder{A} \defn{carries a dependency} to an evaluation \placeholder{B} if
 
 \begin{itemize}
 
 \item
-the value of \term{A} is used as an operand of \term{B}, unless:
+the value of \placeholder{A} is used as an operand of \placeholder{B}, unless:
 \begin{itemize}
 
 \item
-\term{B} is an invocation of any specialization of
+\placeholder{B} is an invocation of any specialization of
 \tcode{std::kill_dependency}~(\ref{atomics.order}), or
 
 \item
-\term{A} is the left operand of a built-in logical AND (\tcode{\&\&},
+\placeholder{A} is the left operand of a built-in logical AND (\tcode{\&\&},
 see~\ref{expr.log.and}) or logical OR (\tcode{||}, see~\ref{expr.log.or}) 
 operator, or
 
 \item
-\term{A} is the left operand of a conditional (\tcode{?:}, see~\ref{expr.cond})
+\placeholder{A} is the left operand of a conditional (\tcode{?:}, see~\ref{expr.cond})
 operator, or
 
 \item
-\term{A} is the left operand of the built-in comma (\tcode{,})
+\placeholder{A} is the left operand of the built-in comma (\tcode{,})
 operator~(\ref{expr.comma}); \end{itemize} or
 
 \item
-\term{A} writes a scalar object or bit-field \term{M}, \term{B} reads the value
-written by \term{A} from \term{M}, and \term{A} is sequenced before \term{B}, or
+\placeholder{A} writes a scalar object or bit-field \placeholder{M}, \placeholder{B} reads the value
+written by \placeholder{A} from \placeholder{M}, and \placeholder{A} is sequenced before \placeholder{B}, or
 
 \item
-for some evaluation \term{X}, \term{A} carries a dependency to \term{X}, and 
-\term{X} carries a dependency to \term{B}.
+for some evaluation \placeholder{X}, \placeholder{A} carries a dependency to \placeholder{X}, and 
+\placeholder{X} carries a dependency to \placeholder{B}.
 
 \end{itemize}
 
@@ -1198,20 +1198,20 @@ for some evaluation \term{X}, \term{A} carries a dependency to \term{X}, and
 and is similarly strictly intra-thread. \end{note}
 
 \pnum
-An evaluation \term{A} is \defn{dependency-ordered before} an evaluation
-\term{B} if
+An evaluation \placeholder{A} is \defn{dependency-ordered before} an evaluation
+\placeholder{B} if
 \begin{itemize}
 
 \item
-\term{A} performs a release operation on an atomic object \term{M}, and, in
-another thread, \term{B} performs a consume operation on \term{M} and reads a
+\placeholder{A} performs a release operation on an atomic object \placeholder{M}, and, in
+another thread, \placeholder{B} performs a consume operation on \placeholder{M} and reads a
 value written by any
 \indextext{side effects}%
-side effect in the release sequence headed by \term{A}, or
+side effect in the release sequence headed by \placeholder{A}, or
 
 \item
-for some evaluation \term{X}, \term{A} is dependency-ordered before \term{X} and
-\term{X} carries a dependency to \term{B}.
+for some evaluation \placeholder{X}, \placeholder{A} is dependency-ordered before \placeholder{X} and
+\placeholder{X} carries a dependency to \placeholder{B}.
 
 \end{itemize}
 \begin{note} The relation ``is dependency-ordered before'' is analogous to
@@ -1219,32 +1219,32 @@ for some evaluation \term{X}, \term{A} is dependency-ordered before \term{X} and
 \end{note}
 
 \pnum
-An evaluation \term{A} \defn{inter-thread happens before} an evaluation \term{B}
+An evaluation \placeholder{A} \defn{inter-thread happens before} an evaluation \placeholder{B}
 if
 
 \begin{itemize}
 
 \item
-\term{A} synchronizes with \term{B}, or
+\placeholder{A} synchronizes with \placeholder{B}, or
 
 \item
-\term{A} is dependency-ordered before \term{B}, or
+\placeholder{A} is dependency-ordered before \placeholder{B}, or
 
 \item
-for some evaluation \term{X}
+for some evaluation \placeholder{X}
 
 \begin{itemize}
 \item
-\term{A} synchronizes with \term{X} and \term{X} is sequenced before \term{B},
+\placeholder{A} synchronizes with \placeholder{X} and \placeholder{X} is sequenced before \placeholder{B},
 or
 
 \item
-\term{A} is sequenced before \term{X} and \term{X} inter-thread happens before
-\term{B}, or
+\placeholder{A} is sequenced before \placeholder{X} and \placeholder{X} inter-thread happens before
+\placeholder{B}, or
 
 \item
-\term{A} inter-thread happens before \term{X} and \term{X} inter-thread happens
-before \term{B}.
+\placeholder{A} inter-thread happens before \placeholder{X} and \placeholder{X} inter-thread happens
+before \placeholder{B}.
 \end{itemize}
 \end{itemize}
 
@@ -1265,12 +1265,12 @@ closed and (2) the ``happens before'' relation, defined below, provides for
 relationships consisting entirely of ``sequenced before''. \end{note}
 
 \pnum
-An evaluation \term{A} \defn{happens before} an evaluation \term{B}
-(or, equivalently, \term{B} \defn{happens after} \term{A}) if:
+An evaluation \placeholder{A} \defn{happens before} an evaluation \placeholder{B}
+(or, equivalently, \placeholder{B} \defn{happens after} \placeholder{A}) if:
 
 \begin{itemize}
-\item \term{A} is sequenced before \term{B}, or
-\item \term{A} inter-thread happens before \term{B}.
+\item \placeholder{A} is sequenced before \placeholder{B}, or
+\item \placeholder{A} inter-thread happens before \placeholder{B}.
 \end{itemize}
 
 The implementation shall ensure that no program execution demonstrates a cycle
@@ -1278,23 +1278,23 @@ in the ``happens before'' relation. \begin{note} This cycle would otherwise be
 possible only through the use of consume operations. \end{note}
 
 \pnum
-A \defnx{visible side effect}{side effects!visible} \term{A} on a scalar object or bit-field \term{M}
-with respect to a value computation \term{B} of \term{M} satisfies the
+A \defnx{visible side effect}{side effects!visible} \placeholder{A} on a scalar object or bit-field \placeholder{M}
+with respect to a value computation \placeholder{B} of \placeholder{M} satisfies the
 conditions:
 
 \begin{itemize}
-\item \term{A} happens before \term{B} and
+\item \placeholder{A} happens before \placeholder{B} and
 \item there is no other
 \indextext{side effects}%
-side effect \term{X} to \term{M} such that \term{A}
-happens before \term{X} and \term{X} happens before \term{B}.
+side effect \placeholder{X} to \placeholder{M} such that \placeholder{A}
+happens before \placeholder{X} and \placeholder{X} happens before \placeholder{B}.
 \end{itemize}
 
-The value of a non-atomic scalar object or bit-field \term{M}, as determined by
-evaluation \term{B}, shall be the value stored by the
+The value of a non-atomic scalar object or bit-field \placeholder{M}, as determined by
+evaluation \placeholder{B}, shall be the value stored by the
 \indextext{side effects!visible}%
 visible side effect
-\term{A}. \begin{note} If there is ambiguity about which side effect to a
+\placeholder{A}. \begin{note} If there is ambiguity about which side effect to a
 non-atomic object or bit-field is visible, then the behavior is either
 unspecified or undefined. \end{note} \begin{note} This states that operations on
 ordinary objects are not visibly reordered. This is not actually detectable
@@ -1304,51 +1304,51 @@ races in a simple interleaved (sequentially consistent) execution. \end{note}
 
 \pnum
 The value of an
-atomic object \term{M}, as determined by evaluation \term{B}, shall be the value
+atomic object \placeholder{M}, as determined by evaluation \placeholder{B}, shall be the value
 stored by some
-side effect \term{A} that modifies \term{M}, where \term{B} does not happen
-before \term{A}.
+side effect \placeholder{A} that modifies \placeholder{M}, where \placeholder{B} does not happen
+before \placeholder{A}.
 \begin{note}
 The set of such side effects is also restricted by the rest of the rules
 described here, and in particular, by the coherence requirements below.
 \end{note}
 
 \pnum
-If an operation \term{A} that modifies an atomic object \term{M} happens before
-an operation \term{B} that modifies \term{M}, then \term{A} shall be earlier
-than \term{B} in the modification order of \term{M}. \begin{note} This requirement
+If an operation \placeholder{A} that modifies an atomic object \placeholder{M} happens before
+an operation \placeholder{B} that modifies \placeholder{M}, then \placeholder{A} shall be earlier
+than \placeholder{B} in the modification order of \placeholder{M}. \begin{note} This requirement
 is known as write-write coherence. \end{note}
 
 \pnum
 If a
 \indextext{value computation}%
-value computation \term{A} of an atomic object \term{M} happens before a
-value computation \term{B} of \term{M}, and \term{A} takes its value from a side
-effect \term{X} on \term{M}, then the value computed by \term{B} shall either be
-the value stored by \term{X} or the value stored by a
+value computation \placeholder{A} of an atomic object \placeholder{M} happens before a
+value computation \placeholder{B} of \placeholder{M}, and \placeholder{A} takes its value from a side
+effect \placeholder{X} on \placeholder{M}, then the value computed by \placeholder{B} shall either be
+the value stored by \placeholder{X} or the value stored by a
 \indextext{side effects}%
-side effect \term{Y} on
-\term{M}, where \term{Y} follows \term{X} in the modification order of \term{M}.
+side effect \placeholder{Y} on
+\placeholder{M}, where \placeholder{Y} follows \placeholder{X} in the modification order of \placeholder{M}.
 \begin{note} This requirement is known as read-read coherence. \end{note}
 
 \pnum
 If a
 \indextext{value computation}%
-value computation \term{A} of an atomic object \term{M} happens before an
-operation \term{B} that modifies \term{M}, then \term{A} shall take its value from a side
-effect \term{X} on \term{M}, where \term{X} precedes \term{B} in the
-modification order of \term{M}. \begin{note} This requirement is known as
+value computation \placeholder{A} of an atomic object \placeholder{M} happens before an
+operation \placeholder{B} that modifies \placeholder{M}, then \placeholder{A} shall take its value from a side
+effect \placeholder{X} on \placeholder{M}, where \placeholder{X} precedes \placeholder{B} in the
+modification order of \placeholder{M}. \begin{note} This requirement is known as
 read-write coherence. \end{note}
 
 \pnum
 If a
 \indextext{side effects}%
-side effect \term{X} on an atomic object \term{M} happens before a value
-computation \term{B} of \term{M}, then the evaluation \term{B} shall take its
-value from \term{X} or from a
+side effect \placeholder{X} on an atomic object \placeholder{M} happens before a value
+computation \placeholder{B} of \placeholder{M}, then the evaluation \placeholder{B} shall take its
+value from \placeholder{X} or from a
 \indextext{side effects}%
-side effect \term{Y} that follows \term{X} in the
-modification order of \term{M}. \begin{note} This requirement is known as
+side effect \placeholder{Y} that follows \placeholder{X} in the
+modification order of \placeholder{M}. \begin{note} This requirement is known as
 write-read coherence. \end{note}
 
 \pnum
@@ -1367,8 +1367,7 @@ suitably chosen modification orders and the ``happens before'' relation derived
 as described above, satisfy the resulting constraints as imposed here. \end{note}
 
 \pnum
-\indextext{potentially~concurrent}%
-Two actions are \term{potentially concurrent} if
+Two actions are \defnx{potentially concurrent}{potentially~concurrent} if
 \begin{itemize}
 \item they are performed by different threads, or
 \item they are unsequenced, and at least one is performed by a signal handler.


### PR DESCRIPTION
Partially addresses #329.