### PR TITLE
[utilities], [futures.task] Use 'not defined', not 'undefined', to pr…

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -3519,7 +3519,7 @@ namespace std {
   template <class R> class shared_future<R&>;
   template <> class shared_future<void>;
 
-  template <class> class packaged_task;   // undefined
+  template <class> class packaged_task;   // not defined
   template <class R, class... ArgTypes>
     class packaged_task<R(ArgTypes...)>;
 
@@ -4793,7 +4793,7 @@ share the shared state will then be able to access the stored result.
 \indexlibrary{\idxcode{packaged_task}}%
 \begin{codeblock}
 namespace std {
-  template<class> class packaged_task; // undefined
+  template<class> class packaged_task; // not defined
 
   template<class R, class... ArgTypes>
   class packaged_task<R(ArgTypes...)> {

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1116,14 +1116,14 @@ namespace std {
     constexpr T make_from_tuple(Tuple&& t);
 
   // \ref{tuple.helper}, tuple helper classes:
-  template <class T> class tuple_size;  // undefined
+  template <class T> class tuple_size;  // not defined
   template <class T> class tuple_size<const T>;
   template <class T> class tuple_size<volatile T>;
   template <class T> class tuple_size<const volatile T>;
 
   template <class... Types> class tuple_size<tuple<Types...>>;
 
-  template <size_t I, class T> class tuple_element;    // undefined
+  template <size_t I, class T> class tuple_element;    // not defined
   template <size_t I, class T> class tuple_element<I, const T>;
   template <size_t I, class T> class tuple_element<I, volatile T>;
   template <size_t I, class T> class tuple_element<I, const volatile T>;
@@ -3478,7 +3478,7 @@ namespace std {
   template <class... Types> class variant;
 
   // \ref{variant.helper}, variant helper classes
-  template <class T> struct variant_size; // undefined
+  template <class T> struct variant_size; // not defined
   template <class T> struct variant_size<const T>;
   template <class T> struct variant_size<volatile T>;
   template <class T> struct variant_size<const volatile T>;
@@ -3488,7 +3488,7 @@ namespace std {
   template <class... Types>
     struct variant_size<variant<Types...>>;
 
-  template <size_t I, class T> struct variant_alternative; // undefined
+  template <size_t I, class T> struct variant_alternative; // not defined
   template <size_t I, class T> struct variant_alternative<I, const T>;
   template <size_t I, class T> struct variant_alternative<I, volatile T>;
   template <size_t I, class T> struct variant_alternative<I, const volatile T>;
@@ -12110,7 +12110,7 @@ namespace std {
   // \ref{func.wrap}, polymorphic function wrappers:
   class bad_function_call;
 
-  template<class> class function; // undefined
+  template<class> class function; // not defined
   template<class R, class... ArgTypes> class function<R(ArgTypes...)>;
 
   template<class R, class... ArgTypes>
@@ -13614,7 +13614,7 @@ bad_function_call() noexcept;
 
 \begin{codeblock}
 namespace std {
-  template<class> class function; // undefined
+  template<class> class function; // not defined
 
   template<class R, class... ArgTypes>
   class function<R(ArgTypes...)> {


### PR DESCRIPTION
…esent library declarations of primary templates that are not supposed to have a definition.

Fixes #528.