### PR TITLE
[numeric] Order elements correctly

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -725,12 +725,12 @@ template<class T> complex<T> operator+(const complex<T>& lhs);
 
 \begin{itemdescr}
 \pnum
-\remarks
-unary operator.
-
-\pnum
 \returns
 \tcode{complex<T>(lhs)}.
+
+\pnum
+\remarks
+unary operator.
 \end{itemdescr}
 
 \begin{codeblock}
@@ -753,12 +753,12 @@ template<class T> complex<T> operator-(const complex<T>& lhs);
 
 \begin{itemdescr}
 \pnum
-\remarks
-unary operator.
-
-\pnum
 \returns
 \tcode{complex<T>(-lhs.real(),-lhs.imag())}.
+
+\pnum
+\remarks
+unary operator.
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{complex}%
@@ -848,6 +848,11 @@ operator>>(basic_istream<charT, traits>& is, complex<T>& x);
 
 \begin{itemdescr}
 \pnum
+\requires
+The input values shall be convertible to
+\tcode{T}.
+
+\pnum
 \effects
 Extracts a complex number \tcode{x} of the form:
 \tcode{u},
@@ -861,10 +866,6 @@ is the real part and
 is the imaginary part~(\ref{istream.formatted}).
 
 \pnum
-\requires
-The input values shall be convertible to
-\tcode{T}.
-
 If bad input is encountered, calls
 \tcode{is.setstate(ios_base::failbit)}
 (which may throw
@@ -1156,14 +1157,14 @@ template<class T> complex<T> log(const complex<T>& x);
 
 \begin{itemdescr}
 \pnum
-\remarks
-The branch cuts are along the negative real axis.
-
-\pnum
 \returns
 The complex natural (base-$e$) logarithm of \tcode{x}. For all \tcode{x},
 \tcode{imag(log(x))} lies in the interval \crange{$-\pi$}{$\pi$}, and
 when \tcode{x} is a negative real number, \tcode{imag(log(x))} is $\pi$.
+
+\pnum
+\remarks
+The branch cuts are along the negative real axis.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{log10}!\idxcode{complex}}%
@@ -1173,13 +1174,13 @@ template<class T> complex<T> log10(const complex<T>& x);
 
 \begin{itemdescr}
 \pnum
-\remarks
-The branch cuts are along the negative real axis.
-
-\pnum
 \returns
 The complex common (base-$10$) logarithm of \tcode{x}, defined as
 \tcode{log(x) / log(10)}.
+
+\pnum
+\remarks
+The branch cuts are along the negative real axis.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{pow}!\idxcode{complex}}%
@@ -1191,10 +1192,6 @@ template<class T> complex<T> pow(const T& x, const complex<T>& y);
 
 \begin{itemdescr}
 \pnum
-\remarks
-The branch cuts are along the negative real axis.
-
-\pnum
 \returns
 The complex power of base \tcode{x} raised to the \tcode{y}$^\text{th}$ power,
 defined as
@@ -1202,6 +1199,10 @@ defined as
 The value returned for
 \tcode{pow(0, 0)}
 is \impldef{value of \tcode{pow(0,0)}}.
+
+\pnum
+\remarks
+The branch cuts are along the negative real axis.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{sin}!\idxcode{complex}}%
@@ -1233,15 +1234,15 @@ template<class T> complex<T> sqrt(const complex<T>& x);
 
 \begin{itemdescr}
 \pnum
-\remarks
-The branch cuts are along the negative real axis.
-
-\pnum
 \returns
 The complex square root of \tcode{x}, in the range of the right
 half-plane.
 If the argument is a negative real number, the
 value returned lies on the positive imaginary axis.
+
+\pnum
+\remarks
+The branch cuts are along the negative real axis.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{tan}!\idxcode{complex}}%
@@ -8839,6 +8840,15 @@ template <class InputIterator, class T, class BinaryOperation>
 
 \begin{itemdescr}
 \pnum
+\requires
+\tcode{T} shall meet the requirements of \tcode{CopyConstructible} (Table~\ref{tab:copyconstructible})
+and \tcode{CopyAssignable} (Table~\ref{tab:copyassignable}) types.
+In the range
+\crange{first}{last},
+\tcode{binary_op}
+shall neither modify elements nor invalidate iterators or subranges.\footnote{The use of fully closed ranges is intentional.}
+
+\pnum
 \effects
 Computes its result by initializing the accumulator
 \tcode{acc}
@@ -8855,15 +8865,6 @@ in order.\footnote{\tcode{accumulate}
 is similar to the APL reduction operator and Common Lisp reduce function, but
 it avoids the difficulty of defining the result of reduction on an empty
 sequence by always requiring an initial value.}
-
-\pnum
-\requires
-\tcode{T} shall meet the requirements of \tcode{CopyConstructible} (Table~\ref{tab:copyconstructible})
-and \tcode{CopyAssignable} (Table~\ref{tab:copyassignable}) types.
-In the range
-\crange{first}{last},
-\tcode{binary_op}
-shall neither modify elements nor invalidate iterators or subranges.\footnote{The use of fully closed ranges is intentional.}
 \end{itemdescr}
 
 \rSec2[reduce]{Reduce}
@@ -8945,13 +8946,13 @@ template<class ExecutionPolicy, class InputIterator, class T, class BinaryOperat
 
 \begin{itemdescr}
 \pnum
-\returns
-\tcode{\textit{GENERALIZED_SUM}(binary_op, init, *i, ...)} for every \tcode{i} in \range{first}{last}.
-
-\pnum
 \requires
 \tcode{binary_op} shall neither invalidate iterators or subranges, nor modify
 elements in the range \range{first}{last}.
+
+\pnum
+\returns
+\tcode{\textit{GENERALIZED_SUM}(binary_op, init, *i, ...)} for every \tcode{i} in \range{first}{last}.
 
 \pnum
 \complexity
@@ -8981,13 +8982,13 @@ template<class ExecutionPolicy, class InputIterator,
 
 \begin{itemdescr}
 \pnum
-\returns
-\tcode{\textit{GENERALIZED_SUM}(binary_op, init, unary_op(*i), ...)} for every \tcode{i} in \range{first}{last}.
-
-\pnum
 \requires
 Neither \tcode{unary_op} nor \tcode{binary_op} shall invalidate subranges, or
 modify elements in the range \range{first}{last}.
+
+\pnum
+\returns
+\tcode{\textit{GENERALIZED_SUM}(binary_op, init, unary_op(*i), ...)} for every \tcode{i} in \range{first}{last}.
 
 \pnum
 \complexity
@@ -9028,6 +9029,19 @@ template <class ExecutionPolicy, class InputIterator1, class InputIterator2, cla
 
 \begin{itemdescr}
 \pnum
+\requires
+\tcode{T} shall meet the requirements of \tcode{CopyConstructible} (Table~\ref{tab:copyconstructible})
+and \tcode{CopyAssignable} (Table~\ref{tab:copyassignable}) types.
+In the ranges
+\crange{first1}{last1}
+and
+\crange{first2}{first2 + (last1 - first1)}
+\tcode{binary_op1}
+and
+\tcode{binary_op2}
+shall neither modify elements nor invalidate iterators or subranges.\footnote{The use of fully closed ranges is intentional.}
+
+\pnum
 \effects
 Computes its result by initializing the accumulator
 \tcode{acc}
@@ -9045,19 +9059,6 @@ and iterator
 in the range
 \range{first2}{first2 + (last1 - first1)}
 in order.
-
-\pnum
-\requires
-\tcode{T} shall meet the requirements of \tcode{CopyConstructible} (Table~\ref{tab:copyconstructible})
-and \tcode{CopyAssignable} (Table~\ref{tab:copyassignable}) types.
-In the ranges
-\crange{first1}{last1}
-and
-\crange{first2}{first2 + (last1 - first1)}
-\tcode{binary_op1}
-and
-\tcode{binary_op2}
-shall neither modify elements nor invalidate iterators or subranges.\footnote{The use of fully closed ranges is intentional.}
 \end{itemdescr}
 
 \rSec2[partial.sum]{Partial sum}
@@ -9076,6 +9077,20 @@ template <class InputIterator, class OutputIterator, class BinaryOperation>
 
 \begin{itemdescr}
 \pnum
+\requires
+\tcode{InputIterator}'s value type shall be constructible from the type of \tcode{*first}.
+The result of the expression \tcode{acc + *i} or \tcode{binary_op(acc, *i)} shall be
+implicitly convertible to \tcode{InputIterator}'s value type. \tcode{acc}
+shall be writable~(\ref{iterator.requirements.general}) to the \tcode{result} output iterator.
+In the ranges
+\crange{first}{last}
+and
+\mbox{\crange{result}{result + (last - first)}}
+\tcode{binary_op}
+shall neither modify elements nor invalidate iterators or subranges.\footnote{The use of fully closed ranges is intentional.
+}
+
+\pnum
 \effects For a non-empty range,
 the function creates an accumulator \tcode{acc} whose type is \tcode{InputIterator}'s
 value type, initializes it with \tcode{*first},
@@ -9093,20 +9108,6 @@ Exactly
 \tcode{(last - first) - 1}
 applications of
 the binary operation.
-
-\pnum
-\requires
-\tcode{InputIterator}'s value type shall be constructible from the type of \tcode{*first}.
-The result of the expression \tcode{acc + *i} or \tcode{binary_op(acc, *i)} shall be
-implicitly convertible to \tcode{InputIterator}'s value type. \tcode{acc}
-shall be writable~(\ref{iterator.requirements.general}) to the \tcode{result} output iterator.
-In the ranges
-\crange{first}{last}
-and
-\mbox{\crange{result}{result + (last - first)}}
-\tcode{binary_op}
-shall neither modify elements nor invalidate iterators or subranges.\footnote{The use of fully closed ranges is intentional.
-}
 
 \pnum
 \remarks
@@ -9166,6 +9167,12 @@ template<class ExecutionPolicy, class InputIterator, class OutputIterator, class
 
 \begin{itemdescr}
 \pnum
+\requires
+\tcode{binary_op} shall neither invalidate iterators or subranges, nor modify
+elements in the
+ranges \range{first}{last} or \range{result}{result + (last - first)}.
+
+\pnum
 \effects
 Assigns through each iterator \tcode{i} in \range{result}{result + (last - first)} the value of
 \tcode{\textit{GENERALIZED_NONCOMMUTATIVE_SUM}(binary_op, init, *j, ...)}
@@ -9176,14 +9183,12 @@ for every \tcode{j} in \range{first}{first + (i - result)}.
 The end of the resulting range beginning at \tcode{result}.
 
 \pnum
-\requires
-\tcode{binary_op} shall neither invalidate iterators or subranges, nor modify
-elements in the
-ranges \range{first}{last} or \range{result}{result + (last - first)}.
-
-\pnum
 \complexity
 \bigoh{\tcode{last - first}} applications of \tcode{binary_op}.
+
+\pnum
+\remarks
+\tcode{result} may be equal to \tcode{first}.
 
 \pnum
 \realnotes
@@ -9191,10 +9196,6 @@ The difference between \tcode{exclusive_scan} and \tcode{inclusive_scan} is
 that \tcode{exclusive_scan} excludes the \tcode{i}th input element from the
 \tcode{i}th sum. If \tcode{binary_op} is not mathematically associative, the
 behavior of \tcode{exclusive_scan} may be non-deterministic.
-
-\pnum
-\remarks
-\tcode{result} may be equal to \tcode{first}.
 \end{itemdescr}
 
 \rSec2[inclusive.scan]{Inclusive scan}
@@ -9256,6 +9257,12 @@ template<class ExecutionPolicy, class InputIterator, class OutputIterator, class
 
 \begin{itemdescr}
 \pnum
+\requires
+\tcode{binary_op} shall not invalidate iterators or subranges, nor modify
+elements in the ranges \range{first}{last} or
+\range{result}{result + (last - first)}.
+
+\pnum
 \effects
 Assigns through each iterator \tcode{i} in \range{result}{result + (last - first)} the value of
 \begin{itemize}
@@ -9271,12 +9278,6 @@ for every \tcode{j} in \range{first}{first + (i - result + 1)} otherwise.
 \pnum
 \returns
 The end of the resulting range beginning at \tcode{result}.
-
-\pnum
-\requires
-\tcode{binary_op} shall not invalidate iterators or subranges, nor modify
-elements in the ranges \range{first}{last} or \range{result}{result + (last -
-first)}.
 
 \pnum
 \complexity
@@ -9317,6 +9318,13 @@ template<class ExecutionPolicy, class InputIterator, class OutputIterator,
 
 \begin{itemdescr}
 \pnum
+\requires
+Neither \tcode{unary_op} nor \tcode{binary_op} shall invalidate iterators or
+subranges, or modify elements in the ranges
+\range{first}{last} or
+\range{result}{result + (last - first)}.
+
+\pnum
 \effects
 Assigns through each iterator \tcode{i} in \range{result}{result + (last - first)} the value of
 \tcode{\textit{GENERALIZED_NONCOMMUTATIVE_SUM}(binary_op, init, unary_op(*j), ...)}
@@ -9325,13 +9333,6 @@ for every \tcode{j} in \range{first}{first + (i - result)}.
 \pnum
 \returns
 The end of the resulting range beginning at \tcode{result}.
-
-\pnum
-\requires
-Neither \tcode{unary_op} nor \tcode{binary_op} shall invalidate iterators or
-subranges, or modify elements in the ranges
-\range{first}{last} or
-\range{result}{result + (last - first)}.
 
 \pnum
 \complexity
@@ -9391,6 +9392,12 @@ template<class ExecutionPolicy, class InputIterator, class OutputIterator,
 
 \begin{itemdescr}
 \pnum
+\requires
+Neither \tcode{unary_op} nor \tcode{binary_op} shall invalidate iterators or
+subranges, or modify elements in the ranges \range{first}{last} or
+\range{result}{result + (last - first)}.
+
+\pnum
 \effects
 Assigns through each iterator \tcode{i} in \range{result}{result + (last - first)} the value of
 \begin{itemize}
@@ -9406,12 +9413,6 @@ for every \tcode{j} in \range{first}{first + (i - result + 1)} otherwise.
 \pnum
 \returns
 The end of the resulting range beginning at \tcode{result}.
-
-\pnum
-\requires
-Neither \tcode{unary_op} nor \tcode{binary_op} shall invalidate iterators or
-subranges, or modify elements in the ranges \range{first}{last} or
-\range{result}{result + (last - first)}.
 
 \pnum
 \complexity
@@ -9461,15 +9462,6 @@ template <class ExecutionPolicy, class InputIterator, class OutputIterator, clas
 
 \begin{itemdescr}
 \pnum
-\effects For a non-empty range,
-the function creates an accumulator \tcode{acc} whose type is \tcode{InputIterator}'s
-value type, initializes it with \tcode{*first},
-and assigns the result to \tcode{*result}. For every iterator \tcode{i} in \range{first + 1}{last}
-in order, creates an object \tcode{val} whose type is \tcode{InputIterator}'s value type, initializes it
-with \tcode{*i}, computes \tcode{val - acc} or \tcode{binary_op(val, acc)}, assigns the result
-to \tcode{*(result + (i - first))}, and move assigns from \tcode{val} to \tcode{acc}.
-
-\pnum
 \requires
 \tcode{InputIterator}'s value type shall be \tcode{MoveAssignable} (Table~\ref{tab:moveassignable})
 and shall be constructible from the type of \tcode{*first}. \tcode{acc} shall be
@@ -9484,10 +9476,13 @@ shall neither modify elements nor invalidate iterators or
 subranges.\footnote{The use of fully closed ranges is intentional.}
 
 \pnum
-\remarks
-\tcode{result}
-may be equal to
-\tcode{first}.
+\effects For a non-empty range,
+the function creates an accumulator \tcode{acc} whose type is \tcode{InputIterator}'s
+value type, initializes it with \tcode{*first},
+and assigns the result to \tcode{*result}. For every iterator \tcode{i} in \range{first + 1}{last}
+in order, creates an object \tcode{val} whose type is \tcode{InputIterator}'s value type, initializes it
+with \tcode{*i}, computes \tcode{val - acc} or \tcode{binary_op(val, acc)}, assigns the result
+to \tcode{*(result + (i - first))}, and move assigns from \tcode{val} to \tcode{acc}.
 
 \pnum
 \returns
@@ -9499,6 +9494,12 @@ Exactly
 \tcode{(last - first) - 1}
 applications of
 the binary operation.
+
+\pnum
+\remarks
+\tcode{result}
+may be equal to
+\tcode{first}.
 \end{itemdescr}
 
 \rSec2[numeric.iota]{Iota}


### PR DESCRIPTION
This is the analog to ballot comment JP-21, ordering the
Requires/Effects/Returns clauses correctly through clause
26.  A couple of re-orderings are deliberately skipped,
due to a dependency in the wording, introducing terms in
the out-of-order elements.