### PR TITLE
LWG2754 The in_place constructors and emplace functions added by P0032R3 don't require CopyConstructible

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -5048,10 +5048,10 @@ public:
 
   template <class ValueType> any(ValueType&& value);
 
-  template <class T, class... Args>
-    explicit any(in_place_type_t<T>, Args&&...);
-  template <class T, class U, class... Args>
-    explicit any(in_place_type_t<T>, initializer_list<U>, Args&&...);
+  template <class ValueType, class... Args>
+    explicit any(in_place_type_t<ValueType>, Args&&...);
+  template <class ValueType, class U, class... Args>
+    explicit any(in_place_type_t<ValueType>, initializer_list<U>, Args&&...);
 
   ~any();
 
@@ -5062,9 +5062,9 @@ public:
   template <class ValueType> any& operator=(ValueType&& rhs);
 
   // \ref{any.modifiers}, modifiers
-  template <class T, class... Args>
+  template <class ValueType, class... Args>
     void emplace(Args&& ...);
-  template <class T, class U, class... Args>
+  template <class ValueType, class U, class... Args>
     void emplace(initializer_list<U>, Args&&...);
   void reset() noexcept;
   void swap(any& rhs) noexcept;
@@ -5151,7 +5151,6 @@ Let \tcode{T} be equal to \tcode{decay_t<ValueType>}.
 \pnum
 \requires
 \tcode{T} shall satisfy the \tcode{CopyConstructible} requirements.
-If \tcode{is_copy_constructible_v<T>} is \tcode{false}, the program is ill-formed.
 
 \pnum
 \effects
@@ -5159,9 +5158,10 @@ Constructs an object of type \tcode{any} that contains an object of type \tcode{
 
 \pnum
 \remarks
-This constructor shall not participate in overload resolution
-if \tcode{decay_t<ValueType>} is the same type as \tcode{any} or
-if \tcode{ValueType} is a specialization of \tcode{in_place_type_t}.
+This constructor shall not participate in overload resolution unless
+\tcode{T} is not the same type as \tcode{any},
+\tcode{T} is not a specialization of \tcode{in_place_type_t},
+and \tcode{is_copy_constructible_v<T>} is \tcode{true}.
 
 \pnum
 \throws
@@ -5170,11 +5170,17 @@ Any exception thrown by the selected constructor of \tcode{T}.
 
 \indexlibrary{\idxcode{any}!constructor}%
 \begin{itemdecl}
-template <class T, class... Args>
-  explicit any(in_place_type_t<T>, Args&&... args);
+template <class ValueType, class... Args>
+  explicit any(in_place_type_t<ValueType>, Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+Let \tcode{T} be equal to \tcode{decay_t<ValueType>}.
+
+\pnum
+\requires \tcode{T} shall satisfy the \tcode{CopyConstructible} requirements.
+
 \pnum
 \effects Initializes the contained value as if direct-non-list-initializing an object of
 type \tcode{T} with the arguments \tcode{std::forward<Args>(args)...}.
@@ -5186,17 +5192,25 @@ type \tcode{T} with the arguments \tcode{std::forward<Args>(args)...}.
 \throws Any exception thrown by the selected constructor of \tcode{T}.
 
 \pnum
-\remarks This constructor shall not participate in overload resolution
-unless tcode{is_constructible_v<T, Args...>} is \tcode{true}.
+\remarks
+This constructor shall not participate in overload resolution unless
+\tcode{is_copy_constructible_v<T>} is \tcode{true}
+and \tcode{is_constructible_v<T, Args...>} is \tcode{true}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{any}!constructor}%
 \begin{itemdecl}
-template <class T, class U, class... Args>
-  explicit any(in_place_type_t<T>, initializer_list<U> il, Args&&... args);
+template <class ValueType, class U, class... Args>
+  explicit any(in_place_type_t<ValueType>, initializer_list<U> il, Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+Let \tcode{T} be equal to \tcode{decay_t<ValueType>}.
+
+\pnum
+\requires \tcode{T} shall satisfy the \tcode{CopyConstructible} requirements.
+
 \pnum
 \effects Initializes the contained value as if direct-non-list-initializing an object of
 type \tcode{T} with the arguments \tcode{il, std::forward<Args>(args)...}.
@@ -5208,8 +5222,10 @@ type \tcode{T} with the arguments \tcode{il, std::forward<Args>(args)...}.
 \throws Any exception thrown by the selected constructor of \tcode{T}.
 
 \pnum
-\remarks This constructor shall not participate in overload resolution
-unless \tcode{is_constructible_v<T, initializer_list<U>\&, Args...>} is \tcode{true}.
+\remarks
+This constructor shall not participate in overload resolution unless
+\tcode{is_copy_constructible_v<T>} is \tcode{true}
+and \tcode{is_constructible_v<T, initializer_list<U>\&, Args...>} is \tcode{true}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{any}!destructor}
@@ -5278,7 +5294,6 @@ Let \tcode{T} be equal to \tcode{decay_t<ValueType>}.
 \pnum
 \requires
 \tcode{T} shall satisfy the \tcode{CopyConstructible} requirements.
-If \tcode{is_copy_constructible_v<T>} is \tcode{false}, the program is ill-formed.
 
 \pnum
 \effects
@@ -5291,7 +5306,9 @@ No effects if an exception is thrown.
 
 \pnum
 \remarks
-This operator shall not participate in overload resolution if \tcode{decay_t<ValueType>} is the same type as \tcode{any}.
+This operator shall not participate in overload resolution unless
+\tcode{T} is not the same type as \tcode{any}
+and \tcode{is_copy_constructible_v<T>} is \tcode{true}.
 
 \pnum
 \throws
@@ -5302,13 +5319,17 @@ Any exception thrown by the selected constructor of \tcode{T}.
 
 \indexlibrarymember{emplace}{any}%
 \begin{itemdecl}
-template <class T, class... Args>
+template <class ValueType, class... Args>
   void emplace(Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{is_constructible_v<T, Args...>} is \tcode{true}.
+Let \tcode{T} be equal to \tcode{decay_t<ValueType>}.
+
+\pnum
+\requires
+\tcode{T} shall satisfy the \tcode{CopyConstructible} requirements.
 
 \pnum
 \effects Calls \tcode{reset()}.
@@ -5325,15 +5346,25 @@ an object of type \tcode{T} with the arguments \tcode{std::forward<Args>(args)..
 \remarks If an exception is thrown during the call to \tcode{T}'s constructor,
 \tcode{*this} does not contain a value, and any previously contained object
 has been destroyed.
+This function shall not participate in overload resolution unless
+\tcode{is_copy_constructible_v<T>} is \tcode{true}
+and \tcode{is_constructible_v<T, Args...>} is \tcode{true}.
 \end{itemdescr}
 
 \indexlibrarymember{emplace}{any}%
 \begin{itemdecl}
-template <class T, class U, class... Args>
+template <class ValueType, class U, class... Args>
   void emplace(initializer_list<U> il, Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+Let \tcode{T} be equal to \tcode{decay_t<ValueType>}.
+
+\pnum
+\requires
+\tcode{T} shall satisfy the \tcode{CopyConstructible} requirements.
+
 \pnum
 \effects Calls \tcode{reset()}. Then initializes the contained value
 as if direct-non-list-initializing an object of type \tcode{T} with the arguments
@@ -5350,7 +5381,8 @@ as if direct-non-list-initializing an object of type \tcode{T} with the argument
 \tcode{*this} does not contain a value, and any previously contained object
 has been destroyed.
 The function shall not participate in overload resolution unless
-\tcode{is_constructible_v<T, initializer_list<U>\&, Args...>} is \tcode{true}.
+\tcode{is_copy_constructible_v<T>} is \tcode{true}
+and \tcode{is_constructible_v<T, initializer_list<U>\&, Args...>} is \tcode{true}.
 \end{itemdescr}
 
 \indexlibrarymember{reset}{any}%


### PR DESCRIPTION
Also includes the changes to [ans.cons] p9 from P0504R0 (LWG Motion 19)
which modify the same paragraph.