### PR TITLE
[class.copy] Introduce three subsections.

### DIFF
--- a/source/special.tex
+++ b/source/special.tex
@@ -2424,8 +2424,6 @@ B::B(V* v, A* a) {
 \rSec1[class.copy]{Copying and moving class objects}%
 \indextext{copy!class~object|see{constructor, copy; assignment, copy}}%
 \indextext{move!class~object|see{constructor, move; assignment, move}}%
-\indextext{constructor!copy}%
-\indextext{constructor!move}%
 \indextext{operator!copy assignment|see{assignment, copy}}%
 \indextext{operator!move assignment|see{assignment, move}}
 
@@ -2436,6 +2434,22 @@ and by assignment~(\ref{expr.ass}).
 Conceptually, these two operations are implemented by a
 copy/move constructor~(\ref{class.ctor})
 and copy/move assignment operator~(\ref{over.ass}).
+
+\pnum
+\indextext{constructor!copy!inaccessible}%
+\indextext{constructor!move!inaccessible}%
+\indextext{assignment operator!copy!inaccessible}%
+\indextext{assignment operator!move!inaccessible}%
+A program is ill-formed if the copy/move constructor or the copy/move assignment
+operator for an object is implicitly odr-used and the special member function
+is not accessible (Clause~\ref{class.access}).
+\begin{note}
+Copying/moving one object into another using the copy/move constructor or
+the copy/move assignment operator does not change the layout or size of either
+object.
+\end{note}
+
+\rSec2[class.copy.ctor]{Copy/move constructors}%
 
 \pnum
 \indextext{constructor!copy|(}%
@@ -2754,6 +2768,9 @@ The implicitly-defined copy/move constructor for a union
 \tcode{X} copies the object representation~(\ref{basic.types}) of \tcode{X}.%
 \indextext{constructor!move|)}%
 \indextext{constructor!copy|)}
+
+
+\rSec2[class.copy.assign]{Copy/move assignment operator}%
 
 \pnum
 \indextext{assignment operator!copy|(}%
@@ -3092,19 +3109,7 @@ union \tcode{X} copies the object representation~(\ref{basic.types}) of \tcode{X
 \indextext{assignment operator!move|)}%
 \indextext{assignment operator!copy|)}
 
-\pnum
-\indextext{constructor!copy!inaccessible}%
-\indextext{constructor!move!inaccessible}%
-\indextext{assignment operator!copy!inaccessible}%
-\indextext{assignment operator!move!inaccessible}%
-A program is ill-formed if the copy/move constructor or the copy/move assignment
-operator for an object is implicitly odr-used and the special member function
-is not accessible (Clause~\ref{class.access}).
-\begin{note}
-Copying/moving one object into another using the copy/move constructor or
-the copy/move assignment operator does not change the layout or size of either
-object.
-\end{note}
+\rSec2[class.copy.elision]{Copy/move elision}%
 
 \pnum
 \indextext{temporary!elimination~of}%
@@ -3176,6 +3181,7 @@ if the same expression
 is evaluated in another context.
 \end{note}
 
+\pnum
 \begin{example}
 
 \begin{codeblock}


### PR DESCRIPTION
Fixes #490.

This should probably be reviewed by Richard. Note that I moved the "accessible" paragraph to the top, although I think that's redundant nowadays that we always perform overload resolution for copy/move, and access checking is on of the last steps there. Also, the "accessible" paragraph should say in which context the access is checked (existing defect).