### PR TITLE
[17-30] Create index entries for all namespaces

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -10166,6 +10166,8 @@ subclause are assumed to be qualified with \tcode{::std::filesystem::}.
 
 \rSec2[fs.filesystem.syn]{Header \tcode{<filesystem>} synopsis}
 \indexlibrary{\idxhdr{filesystem}}%
+\indexlibrary{\idxcode{filesystem}}%
+\indexlibrary{\idxcode{std}!\idxcode{filesystem}}%
 
 \begin{codeblock}
 namespace std::filesystem {

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -930,6 +930,7 @@ for the entities and macros described in the synopses
 of the \Cpp standard library headers~(\ref{headers}).
 
 \pnum
+\indexlibrary{\idxcode{std}}%
 All library entities except
 \tcode{operator new}
 and
@@ -2151,6 +2152,7 @@ installation of handler functions during execution~(\ref{handler.functions}).
 \rSec4[namespace.std]{Namespace \tcode{std}}
 
 \pnum
+\indexlibrary{\idxcode{std}}%
 The behavior of a \Cpp program is undefined if it adds declarations or definitions to namespace
 \tcode{std}
 or to a namespace within namespace
@@ -2189,6 +2191,7 @@ A translation unit shall not declare namespace \tcode{std} to be an inline names
 \rSec4[namespace.posix]{Namespace \tcode{posix}}
 
 \pnum
+\indexlibrary{\idxcode{posix}}%
 The behavior of a \Cpp program is undefined if it adds declarations or definitions to namespace
 \tcode{posix}
 or to a namespace within namespace
@@ -2199,6 +2202,7 @@ ISO/IEC 9945 and other POSIX standards.
 \rSec4[namespace.future]{Namespaces for future standardization}
 
 \pnum
+\indexlibrary{\idxcode{std\placeholder{digits}}}%
 Top level namespaces with a name starting with \tcode{std} and
 followed by a non-empty sequence of digits
 are reserved for future standardization.

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -381,6 +381,9 @@ namespace std {
   }
 }
 \end{codeblock}
+\indexlibrary{\idxcode{std}!\idxcode{literals}}%
+\indexlibrarymember{std}{complex_literals}%
+\indexlibrarymember{std::literals}{complex_literals}%
 
 \rSec2[complex]{Class template \tcode{complex}}
 
@@ -1314,6 +1317,9 @@ ensure, for a call with at least one argument of type \tcode{complex<T>}:
 
 \rSec2[complex.literals]{Suffixes for complex number literals}
 
+\indexlibrary{\idxcode{std}!\idxcode{literals}}%
+\indexlibrarymember{std}{complex_literals}%
+\indexlibrarymember{std::literals}{complex_literals}%
 \indexlibrary{complex!literals}%
 \indexlibrary{literals!complex}%
 \pnum

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -257,6 +257,8 @@ the header \tcode{<regex>}, and is described in Clause~\ref{re.traits}.
 \indexlibrary{\idxcode{basic_regex}}%
 \indexlibrary{\idxcode{regex}}%
 \indexlibrary{\idxcode{wregex}}%
+\indexlibrary{\idxcode{regex_constants}}%
+\indexlibrary{\idxcode{std}!\idxcode{regex_constants}}%
 \begin{codeblock}
 #include <initializer_list>
 
@@ -654,6 +656,7 @@ namespace std {
 
 \pnum
 \indexlibrary{\idxcode{regex_constants}}%
+\indexlibrary{\idxcode{std}!\idxcode{regex_constants}}%
 The namespace \tcode{std::regex_constants} holds
 symbolic constants used by the regular expression library.  This
 namespace provides three types, \tcode{syntax_option_type}, 

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -818,6 +818,9 @@ namespace std {
   }
 }
 \end{codeblock}
+\indexlibrary{\idxcode{std}!\idxcode{literals}}%
+\indexlibrarymember{std}{string_literals}%
+\indexlibrarymember{std::literals}{string_literals}%
 
 \rSec2[basic.string]{Class template \tcode{basic_string}}
 
@@ -4566,6 +4569,9 @@ template<> struct hash<wstring>;
 \end{itemdescr}
 
 \rSec2[basic.string.literals]{Suffix for \tcode{basic_string} literals}
+\indexlibrary{\idxcode{std}!\idxcode{literals}}%
+\indexlibrarymember{std}{string_literals}%
+\indexlibrarymember{std::literals}{string_literals}%
 
 \indexlibrarymember{operator """" s}{string}%
 \begin{itemdecl}

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -290,6 +290,8 @@ template <class T> decay_t<T> decay_copy(T&& v)
 
 \synopsis{Header \tcode{<thread>} synopsis}
 \indexlibrary{\idxhdr{thread}}%
+\indexlibrary{\idxcode{this_thread}}%
+\indexlibrary{\idxcode{std}!\idxcode{this_thread}}%
 
 \begin{codeblock}
 namespace std {
@@ -726,6 +728,8 @@ void swap(thread& x, thread& y) noexcept;
 \end{itemdescr}
 
 \rSec2[thread.thread.this]{Namespace \tcode{this_thread}}
+\indexlibrary{\idxcode{this_thread}}%
+\indexlibrary{\idxcode{std}!\idxcode{this_thread}}%
 
 \begin{codeblock}
 namespace std::this_thread {

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -39,6 +39,7 @@ throughout the rest of the library.
 
 \indexlibrary{\idxhdr{utility}}%
 \indexlibrary{\idxcode{rel_ops}}%
+\indexlibrary{\idxcode{std}!\idxcode{rel_ops}}%
 \synopsis{Header \tcode{<utility>} synopsis}
 
 \pnum
@@ -10229,6 +10230,8 @@ the same value as \tcode{hash<T*>()(p.get())}.
 \rSec2[mem.res.syn]{Header \tcode{<memory_resource>} synopsis}
 
 \indexlibrary{\idxhdr{memory_resource}}%
+\indexlibrary{\idxcode{pmr}}%
+\indexlibrary{\idxcode{std}!\idxcode{pmr}}%
 \begin{codeblock}
 namespace std::pmr {
   // \ref{mem.res.class}, class \tcode{memory_resource}
@@ -12038,6 +12041,8 @@ work with arbitrary function objects.
 \synopsis{Header \tcode{<functional>} synopsis}
 
 \indexlibrary{\idxhdr{functional}}%
+\indexlibrary{\idxcode{placeholders}}%
+\indexlibrary{\idxcode{std}!\idxcode{placeholders}}%
 \begin{codeblock}
 namespace std {
   // \ref{func.invoke}, invoke:
@@ -13536,6 +13541,7 @@ is \tcode{TiD \textit{cv} \&}.
 \rSec3[func.bind.place]{Placeholders}
 
 \indexlibrary{\idxcode{placeholders}}%
+\indexlibrary{\idxcode{std}!\idxcode{placeholders}}%
 \indexlibrary{1@\tcode{_1}}%
 \begin{codeblock}
 namespace std::placeholders {
@@ -16480,6 +16486,8 @@ utilities.
 \indexlibrary{\idxhdr{chrono}}%
 \rSec2[time.syn]{Header \tcode{<chrono>} synopsis}
 
+\indexlibrary{\idxcode{chrono}}%
+\indexlibrary{\idxcode{std}!\idxcode{chrono}}%
 \begin{codeblock}
 namespace std {
   namespace chrono {
@@ -16659,6 +16667,9 @@ namespace std {
   }
 }
 \end{codeblock}
+\indexlibrary{\idxcode{std}!\idxcode{literals}}%
+\indexlibrarymember{std}{chrono_literals}%
+\indexlibrarymember{std::literals}{chrono_literals}%
 
 \rSec2[time.clock.req]{Clock requirements}
 
@@ -17510,6 +17521,9 @@ for which \tcode{t \% 2 == 0}.
 \end{itemdescr}
 
 \rSec3[time.duration.literals]{Suffixes for duration literals}
+\indexlibrary{\idxcode{std}!\idxcode{literals}}%
+\indexlibrarymember{std}{chrono_literals}%
+\indexlibrarymember{std::literals}{chrono_literals}%
 
 \pnum
 This section describes literal suffixes for constructing duration literals. The
@@ -18348,6 +18362,8 @@ namespace std {
   template<class T> constexpr bool is_execution_policy_v = is_execution_policy<T>::value;
 }
 
+\indexlibrary{\idxcode{execution}}%
+\indexlibrary{\idxcode{std}!\idxcode{execution}}%
 namespace std::execution {
   // \ref{execpol.seq}, sequenced execution policy:
   class sequenced_policy;


### PR DESCRIPTION
Index each library namespace, and the reserved posix namespace.
Note that many entries for literals namespaces are added after
the header syonpsis, as typically they are the last entries in
that synposis, and the index will find them much more easily
here.  Indexing inside the synopsis is avoided, as it leads to
duplicate index entries.