### PR TITLE
Multiple global style improvements

### DIFF
--- a/source/access.tex
+++ b/source/access.tex
@@ -678,11 +678,11 @@ class A {
 A \tcode{friend} declaration that does not declare a function
 shall have one of the following forms:
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 \terminal{friend} elaborated-type-specifier \terminal{;}\br
 \terminal{friend} simple-type-specifier \terminal{;}\br
 \terminal{friend} typename-specifier \terminal{;}
-\end{ncsimplebnf}
+\end{ncbnf}
 
 \begin{note} A \tcode{friend} declaration may be the
 \term{declaration} in a \grammarterm{template-declaration}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -93,9 +93,9 @@ A
 \grammarterm{simple-declaration} or
 \grammarterm{nodeclspec-function-declaration} of the form
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 attribute-specifier-seq\opt decl-specifier-seq\opt init-declarator-list\opt{} \terminal{;}
-\end{ncsimplebnf}
+\end{ncbnf}
 
 is divided into three parts.
 Attributes are described in~\ref{dcl.attr}.
@@ -1501,13 +1501,13 @@ specialization~(\ref{temp.expl.spec}), an explicit
 instantiation~(\ref{temp.explicit}) or it has one of the following
 forms:
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 class-key attribute-specifier-seq\opt identifier \terminal{;}\br
 \terminal{friend} class-key \terminal{::\opt} identifier \terminal{;}\br
 \terminal{friend} class-key \terminal{::\opt} simple-template-id \terminal{;}\br
 \terminal{friend} class-key nested-name-specifier identifier \terminal{;}\br
 \terminal{friend} class-key nested-name-specifier \terminal{template\opt} simple-template-id \terminal{;}
-\end{ncsimplebnf}
+\end{ncbnf}
 
 In the first case, the \grammarterm{attribute-specifier-seq}, if any, appertains
 to the class being declared; the attributes in the
@@ -2461,11 +2461,11 @@ namespace A {
 An \grammarterm{unnamed-namespace-definition} behaves as if it were
 replaced by
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 \terminal{inline}\opt{} \terminal{namespace} \uniquens{} \terminal{\{ /* empty body */ \}}\br
 \terminal{using namespace} \uniquens{} \terminal{;}\br
 \terminal{namespace} \uniquens{} \terminal{\{} namespace-body \terminal{\}}
-\end{ncsimplebnf}
+\end{ncbnf}
 
 where
 \tcode{inline} appears if and only if it appears in the

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -506,9 +506,9 @@ where
 \tcode{D}
 has the form
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 ( D1 )
-\end{ncsimplebnf}
+\end{ncbnf}
 
 the type of the contained
 \grammarterm{declarator-id}
@@ -536,9 +536,9 @@ where
 \tcode{D}
 has the form
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 \terminal{*} attribute-specifier-seq\opt cv-qualifier-seq\opt{} \terminal{D1}
-\end{ncsimplebnf}
+\end{ncbnf}
 
 and the type of the identifier in the declaration
 \tcode{T}
@@ -650,10 +650,10 @@ where
 \tcode{D}
 has either of the forms
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 \terminal{\&} attribute-specifier-seq\opt{} \terminal{D1}\br
 \terminal{\&\&} attribute-specifier-seq\opt{} \terminal{D1}
-\end{ncsimplebnf}
+\end{ncbnf}
 
 and the type of the identifier in the declaration
 \tcode{T}
@@ -845,9 +845,9 @@ where
 \tcode{D}
 has the form
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 nested-name-specifier \terminal{*} attribute-specifier-seq\opt cv-qualifier-seq\opt \tcode{D1}
-\end{ncsimplebnf}
+\end{ncbnf}
 
 and the
 \grammarterm{nested-name-specifier}
@@ -958,9 +958,9 @@ where
 \tcode{D}
 has the form
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 \terminal{D1 [} constant-expression\opt{} \terminal{]} attribute-specifier-seq\opt
-\end{ncsimplebnf}
+\end{ncbnf}
 
 and the type of the identifier in the declaration
 \tcode{T}
@@ -1260,10 +1260,10 @@ where
 \tcode{D}
 has the form
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 \terminal{D1 (} parameter-declaration-clause \terminal{)} cv-qualifier-seq\opt\br
 \hspace*{\bnfindentinc}ref-qualifier\opt exception-specification\opt attribute-specifier-seq\opt
-\end{ncsimplebnf}
+\end{ncbnf}
 
 and the type of the contained
 \grammarterm{declarator-id}
@@ -1298,10 +1298,10 @@ where
 \tcode{D}
 has the form
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 \terminal{D1 (} parameter-declaration-clause \terminal{)} cv-qualifier-seq\opt\br
 \hspace*{\bnfindentinc}ref-qualifier\opt exception-specification\opt attribute-specifier-seq\opt trailing-return-type
-\end{ncsimplebnf}
+\end{ncbnf}
 
 and the type of the contained
 \grammarterm{declarator-id}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3024,9 +3024,9 @@ If a placeholder type~(\ref{dcl.spec.auto}) appears in the
 the \nonterminal{new-expression} shall contain a
 \nonterminal{new-initializer} of the form
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 \terminal{(} assignment-expression \terminal{)}
-\end{ncsimplebnf}
+\end{ncbnf}
 
 The allocated type is deduced from the \nonterminal{new-initializer} as
 follows: Let \tcode{e} be the \grammarterm{assignment-expression} in the \nonterminal{new-initializer} and

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -970,7 +970,7 @@ The type of an integer literal is the first of the corresponding list
 in Table~\ref{tab:lex.type.integer.literal} in which its value can be
 represented.
 
-\enlargethispage{\baselineskip}%
+\enlargethispage{2\baselineskip}%
 \begin{LongTable}{Types of integer literals}{tab:lex.type.integer.literal}{l|l|l}
 \\ \topline
 \lhdr{Suffix} & \chdr{Decimal literal}  & \rhdr{Binary, octal, or hexadecimal literal}   \\  \capsep
@@ -1411,13 +1411,12 @@ values for its type, the program is ill-formed.
     s-char-sequence s-char
 \end{bnf}
 
-\begin{bnftab}
+\begin{bnf}
 \nontermdef{s-char}\br
-\>\textnormal{any member of the source character set except}\br
-\>\>\textnormal{the double-quote \terminal{"}, backslash \terminal{\textbackslash}, or new-line character}\br
-\>escape-sequence\br
-\>universal-character-name
-\end{bnftab}
+    \textnormal{any member of the source character set except} \textnormal{the double-quote \terminal{"}, backslash \terminal{\textbackslash}, or new-line character}\br
+    escape-sequence\br
+    universal-character-name
+\end{bnf}
 
 \begin{bnf}
 \nontermdef{raw-string}\br
@@ -1432,9 +1431,8 @@ values for its type, the program is ill-formed.
 
 \begin{bnftab}
 \nontermdef{r-char}\br
-\>\textnormal{any member of the source character set, except}\br
-\>\>\textnormal{a right parenthesis \terminal{)} followed by the initial \nonterminal{d-char-sequence}}\br
-\>\>\textnormal{(which may be empty) followed by a double quote \terminal{"}.}
+\>\textnormal{any member of the source character set, except} \textnormal{a right parenthesis \terminal{)} followed by}\br
+\>\>\textnormal{the initial \nonterminal{d-char-sequence} (which may be empty) followed by a double quote \terminal{"}.}
 \end{bnftab}
 
 \begin{bnf}

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -413,25 +413,23 @@
  \newcommand{\bnfindentfirst}{\BnfIndent}
  \newcommand{\bnfindentinc}{\BnfInc}
  \newcommand{\bnfindentrest}{\BnfRest}
- \begin{minipage}{.9\hsize}
  \newcommand{\br}{\hfill\\}
  \frenchspacing
  }
  {
  \nonfrenchspacing
- \end{minipage}
  }
 
 \newenvironment{BnfTabBase}[1]
 {
  \begin{bnfbase}
  #1
- \begin{indented}
+ \begin{adjustwidth}{1em}{}
  \begin{tabbing}
- \hspace*{\bnfindentfirst}\=\hspace{\bnfindentinc}\=\hspace{.6in}\=\hspace{.6in}\=\hspace{.6in}\=\hspace{.6in}\=\hspace{.6in}\=\hspace{.6in}\=\hspace{.6in}\=\hspace{.6in}\=\hspace{.6in}\=\hspace{.6in}\=\kill}
+ \hspace*{1em}\=\hspace{\bnfindentinc}\=\hspace{.6in}\=\hspace{.6in}\=\hspace{.6in}\=\hspace{.6in}\=\hspace{.6in}\=\hspace{.6in}\=\hspace{.6in}\=\hspace{.6in}\=\hspace{.6in}\=\hspace{.6in}\=\kill}
 {
  \end{tabbing}
- \end{indented}
+ \end{adjustwidth}
  \end{bnfbase}
 }
 
@@ -464,18 +462,13 @@
 
 \newenvironment{bnf}
 {
- \begin{bnfbase}
- \list{}
-	{
-	\setlength{\leftmargin}{\bnfindentrest}
-	\setlength{\listparindent}{-\bnfindentinc}
-	\setlength{\itemindent}{\listparindent}
-	}
- \BnfNontermshape
- \item\relax
+ \begin{bnfbase}%
+ \begin{adjustwidth}{2em}{0em}%
+ \BnfNontermshape%
+ \hspace*{-1.5em}%
 }
 {
- \endlist
+ \end{adjustwidth}
  \end{bnfbase}
 }
 

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -35,6 +35,20 @@
 \color{black}
 }
 
+\AtBeginDocument{
+  \setlength{\parsepi}{0pt}
+  \setlength{\parsepii}{0pt}
+  \setlength{\partopsepii}{0pt}
+  \setlength{\partopsepiii}{0pt}
+  \setlength{\itemsepi}{\parskip}
+  \setlength{\itemsepii}{\parskip} %% A bug in memoir makes this ineffective
+  \setlength{\itemsepiii}{\parskip}
+  \setlength{\topsepi}{0pt}
+  \setlength{\topsepii}{\parskip}
+  \setlength{\topsepiii}{\parskip}
+  \setlength{\itemsep}{\parskip}
+}
+
 %%--------------------------------------------------
 %% Grammar extraction.
 \def\gramSec[#1]#2{}
@@ -373,9 +387,9 @@
 
 \newenvironment{itemdescr}
 {
- \begin{indented}}
+ \begin{adjustwidth}{1em}{}} % same indent as listings
 {
- \end{indented}
+ \end{adjustwidth}
 }
 
 

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -449,17 +449,6 @@
  \end{BnfTabBase}
 }
 
-\newenvironment{simplebnf}
-{
- \begin{bnfbase}
- \BnfNontermshape
- \begin{indented}
-}
-{
- \end{indented}
- \end{bnfbase}
-}
-
 \newenvironment{bnf}
 {
  \begin{bnfbase}%
@@ -475,8 +464,6 @@
 % non-copied versions of bnf environments
 \let\ncbnftab\bnftab
 \let\endncbnftab\endbnftab
-\let\ncsimplebnf\simplebnf
-\let\endncsimplebnf\endsimplebnf
 \let\ncbnf\bnf
 \let\endncbnf\endbnf
 

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -330,7 +330,7 @@
 % italics.  Arbitrary TeX commands can be used if they're 
 % surrounded by @ signs.
 \newcommand{\CodeBlockSetup}{
- \lstset{escapechar=@}
+ \lstset{escapechar=@, aboveskip=\smallskipamount, belowskip=0pt}
  \renewcommand{\tcode}[1]{\textup{\CodeStylex{##1}}}
  \renewcommand{\techterm}[1]{\textit{\CodeStylex{##1}}}
  \renewcommand{\term}[1]{\textit{##1}}

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -648,9 +648,9 @@ contexts.
 \pnum
 In a function call~(\ref{expr.call})
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 postfix-expression \terminal{(} expression-list\opt{} \terminal{)}
-\end{ncsimplebnf}
+\end{ncbnf}
 
 if the \grammarterm{postfix-expression} denotes a set of overloaded functions and/or
 function templates, overload resolution is applied as specified in \ref{over.call.func}.
@@ -819,9 +819,9 @@ in the context of
 In addition, for each non-explicit conversion function declared in \tcode{T} of the
 form
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 \terminal{operator} conversion-type-id \terminal{(\,)} cv-qualifier ref-qualifier\opt exception-specification\opt attribute-specifier-seq\opt{} \terminal{;}
-\end{ncsimplebnf}
+\end{ncbnf}
 
 where
 \grammarterm{cv-qualifier}
@@ -3112,9 +3112,9 @@ parameters.
 It can have default arguments.
 It implements the function call syntax
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 postfix-expression \terminal{(} expression-list\opt{} \terminal{)}
-\end{ncsimplebnf}
+\end{ncbnf}
 
 where the
 \grammarterm{postfix-expression}
@@ -3147,9 +3147,9 @@ the overload resolution mechanism~(\ref{over.match.best}).
 shall be a non-static member function with exactly one parameter.
 It implements the subscripting syntax
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 postfix-expression \terminal{[} expr-or-braced-init-list \terminal{]}
-\end{ncsimplebnf}
+\end{ncbnf}
 
 Thus, a subscripting expression
 \tcode{x[y]}
@@ -3185,10 +3185,10 @@ shall be a non-static member function taking no parameters.
 It implements the class member access syntax that
 uses \tcode{->}.
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 postfix-expression \terminal{->} \terminal{template\opt} id-expression\\
 postfix-expression \terminal{->} pseudo-destructor-name
-\end{ncsimplebnf}
+\end{ncbnf}
 
 An expression
 \tcode{x->m}

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -454,9 +454,9 @@ that can be processed by the implementation.
 \pnum
 A preprocessing directive of the form
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 \terminal{\# include <}h-char-sequence\terminal{>} new-line
-\end{ncsimplebnf}
+\end{ncbnf}
 
 searches a sequence of
 \impldef{sequence of places searched for a header}
@@ -476,9 +476,9 @@ is \impldef{search locations for \tcode{<>} header}.
 \pnum
 A preprocessing directive of the form
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 \terminal{\# include "}q-char-sequence\terminal{"} new-line
-\end{ncsimplebnf}
+\end{ncbnf}
 
 causes the replacement of that
 directive by the entire contents of the
@@ -492,9 +492,9 @@ If this search is not supported,
 or if the search fails,
 the directive is reprocessed as if it read
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 \terminal{\# include <}h-char-sequence\terminal{>} new-line
-\end{ncsimplebnf}
+\end{ncbnf}
 
 with the identical contained sequence (including
 \tcode{>}
@@ -503,9 +503,9 @@ characters, if any) from the original directive.
 \pnum
 A preprocessing directive of the form
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 \terminal{\# include} pp-tokens new-line
-\end{ncsimplebnf}
+\end{ncbnf}
 
 (that does not match one of the two previous forms) is permitted.
 The preprocessing tokens after
@@ -666,10 +666,10 @@ the identifier is not subject to macro replacement.
 \pnum
 A preprocessing directive of the form
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 \terminal{\# define} identifier replacement-list new-line
 \indextext{\idxcode{\#define}}%
-\end{ncsimplebnf}
+\end{ncbnf}
 
 defines an
 \indextext{macro!object-like}%
@@ -690,11 +690,11 @@ specified below.
 \pnum
 A preprocessing directive of the form
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 \terminal{\# define} identifier lparen identifier-list\opt{} \terminal{)} replacement-list new-line\br
 \terminal{\# define} identifier lparen \terminal{...} \terminal{)} replacement-list new-line\br
 \terminal{\# define} identifier lparen identifier-list \terminal{, ...} \terminal{)} replacement-list new-line\br
-\end{ncsimplebnf}
+\end{ncbnf}
 
 \indextext{macro!function-like}%
 defines a \defn{function-like macro}
@@ -931,10 +931,10 @@ Macro definitions have no significance after translation phase 4.
 \pnum
 A preprocessing directive of the form
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 \terminal{\# undef} identifier new-line
 \indextext{\idxcode{\#undef}}%
-\end{ncsimplebnf}
+\end{ncbnf}
 
 causes the specified identifier no longer to be defined as a macro name.
 It is ignored if the specified identifier is not currently defined as
@@ -1152,9 +1152,9 @@ while processing the source file to the current token.
 \pnum
 A preprocessing directive of the form
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 \terminal{\# line} digit-sequence new-line
-\end{ncsimplebnf}
+\end{ncbnf}
 
 causes the implementation to behave as if
 the following sequence of source lines begins with a
@@ -1167,9 +1167,9 @@ the behavior is undefined.
 \pnum
 A preprocessing directive of the form
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 \terminal{\# line} digit-sequence \terminal{"} s-char-sequence\opt{} \terminal{"} new-line
-\end{ncsimplebnf}
+\end{ncbnf}
 
 sets the presumed line number similarly and changes the
 presumed name of the source file to be the contents
@@ -1178,9 +1178,9 @@ of the character string literal.
 \pnum
 A preprocessing directive of the form
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 \terminal{\# line} pp-tokens new-line
-\end{ncsimplebnf}
+\end{ncbnf}
 
 (that does not match one of the two previous forms)
 is permitted.
@@ -1200,9 +1200,9 @@ otherwise, the result is processed as appropriate.
 \pnum
 A preprocessing directive of the form
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 \terminal{\# error} pp-tokens\opt new-line
-\end{ncsimplebnf}
+\end{ncbnf}
 
 causes the implementation to produce
 a diagnostic message that includes the specified sequence of preprocessing tokens,
@@ -1215,9 +1215,9 @@ and renders the program ill-formed.
 \pnum
 A preprocessing directive of the form
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 \terminal{\# pragma} pp-tokens\opt new-line
-\end{ncsimplebnf}
+\end{ncbnf}
 
 causes the implementation to behave
 in an \impldef{\tcode{\#pragma}} manner.
@@ -1231,9 +1231,9 @@ Any pragma that is not recognized by the implementation is ignored.
 \pnum
 A preprocessing directive of the form
 
-\begin{ncsimplebnf}
+\begin{ncbnf}
 \terminal{\#} new-line
-\end{ncsimplebnf}
+\end{ncbnf}
 
 has no effect.
 

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -271,14 +271,12 @@ shall be in the lexical form of a token~(\ref{lex.token}).
 
 \pnum
 Preprocessing directives of the forms
-
 \begin{ncbnftab}
 \indextext{\idxcode{\#if}}%
-\terminal{\# if}\>\>constant-expression new-line group\opt\br
+\terminal{\# if} constant-expression new-line group\opt\br
 \indextext{\idxcode{\#elif}}%
-\terminal{\# elif}\>\>constant-expression new-line group\opt
+\terminal{\# elif} constant-expression new-line group\opt
 \end{ncbnftab}
-
 check whether the controlling constant expression evaluates to nonzero.
 
 \pnum
@@ -367,14 +365,12 @@ is subjected to integral promotion before processing continues.
 
 \pnum
 Preprocessing directives of the forms
-
 \begin{ncbnftab}
-\terminal{\# ifdef}\>\>identifier new-line group\opt\br
+\terminal{\# ifdef} identifier new-line group\opt\br
 \indextext{\idxcode{\#ifdef}}%
-\terminal{\# ifndef}\>\>identifier new-line group\opt
+\terminal{\# ifndef} identifier new-line group\opt
 \indextext{\idxcode{\#ifndef}}%
 \end{ncbnftab}
-
 check whether the identifier is or is not currently defined as a macro name.
 Their conditions are equivalent to
 \tcode{\#if}
@@ -453,11 +449,9 @@ that can be processed by the implementation.
 
 \pnum
 A preprocessing directive of the form
-
 \begin{ncbnf}
 \terminal{\# include <}h-char-sequence\terminal{>} new-line
 \end{ncbnf}
-
 searches a sequence of
 \impldef{sequence of places searched for a header}
 places
@@ -475,11 +469,9 @@ is \impldef{search locations for \tcode{<>} header}.
 
 \pnum
 A preprocessing directive of the form
-
 \begin{ncbnf}
 \terminal{\# include "}q-char-sequence\terminal{"} new-line
 \end{ncbnf}
-
 causes the replacement of that
 directive by the entire contents of the
 source file identified by the specified sequence between the
@@ -502,11 +494,9 @@ characters, if any) from the original directive.
 
 \pnum
 A preprocessing directive of the form
-
 \begin{ncbnf}
 \terminal{\# include} pp-tokens new-line
 \end{ncbnf}
-
 (that does not match one of the two previous forms) is permitted.
 The preprocessing tokens after
 \tcode{include}
@@ -665,12 +655,9 @@ the identifier is not subject to macro replacement.
 
 \pnum
 A preprocessing directive of the form
-
 \begin{ncbnf}
-\terminal{\# define} identifier replacement-list new-line
-\indextext{\idxcode{\#define}}%
+\terminal{\# define} identifier replacement-list new-line \indextext{\idxcode{\#define}}%
 \end{ncbnf}
-
 defines an
 \indextext{macro!object-like}%
 \defn{object-like macro} that
@@ -689,13 +676,11 @@ specified below.
 
 \pnum
 A preprocessing directive of the form
-
-\begin{ncbnf}
+\begin{ncbnftab}
 \terminal{\# define} identifier lparen identifier-list\opt{} \terminal{)} replacement-list new-line\br
 \terminal{\# define} identifier lparen \terminal{...} \terminal{)} replacement-list new-line\br
-\terminal{\# define} identifier lparen identifier-list \terminal{, ...} \terminal{)} replacement-list new-line\br
-\end{ncbnf}
-
+\terminal{\# define} identifier lparen identifier-list \terminal{, ...} \terminal{)} replacement-list new-line
+\end{ncbnftab}
 \indextext{macro!function-like}%
 defines a \defn{function-like macro}
 with parameters, whose use is

--- a/source/std.tex
+++ b/source/std.tex
@@ -45,7 +45,7 @@
             plainpages=false
            ]{hyperref}
 \usepackage{memhfixc}     % fix interactions between hyperref and memoir
-\usepackage[active,header=false,handles=false,copydocumentclass=false,generate=std-gram.ext,extract-cmdline={gramSec},extract-env={bnftab,simplebnf,bnf,bnfkeywordtab}]{extract} % Grammar extraction
+\usepackage[active,header=false,handles=false,copydocumentclass=false,generate=std-gram.ext,extract-cmdline={gramSec},extract-env={bnftab,bnf,bnfkeywordtab}]{extract} % Grammar extraction
 
 \renewcommand\RSsmallest{5.5pt}  % smallest font size for relsize
 

--- a/source/styles.tex
+++ b/source/styles.tex
@@ -98,7 +98,7 @@
 % set style for main text
 \setlength{\parindent}{0pt}
 \setlength{\parskip}{1ex}
-\setlength{\partopsep}{-1.5ex}
+\setlength{\partopsep}{0pt}
 
 %%--------------------------------------------------
 %%  set caption style and delimiter


### PR DESCRIPTION
* Bulleted lists spaced uniformly consistently with paragraphs.
* Bulleted lists work regardless of newlines in the source.
* All indents are now the same (1em): grammar, codeblocks, itemdecls.
* Grammar spaced uniformly consistently with paragraphs. (Removed use of minipages.)
* Removed unnecessary `simplebnf` environment. "Simple" grammar now uses less space and generally flows better with its surrounding paragraph.
* Removed excessive whitespace at the end of examples.