### PR TITLE
Replace \textit{cv} with \cv{} or \cvqual{...} as appopriate.

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -687,7 +687,7 @@ A reference can be thought of as a name of an object.
 \end{note}
 \indextext{\idxcode{void\&}}%
 A declarator that specifies the type
-``reference to \textit{cv} \tcode{void}''
+``reference to \cv{} \tcode{void}''
 is ill-formed.
 
 
@@ -934,7 +934,7 @@ A pointer to member shall not point to a static member
 of a class (\ref{class.static}),
 a member with reference type,
 or
-``\textit{cv}
+``\cv{}
 \tcode{void}''.
 
 \begin{note}
@@ -3472,9 +3472,9 @@ with ``\nonterminal{cv2} \tcode{T2}'' if
 where the function types are otherwise the same,
 \end{itemize}
 and
-\textit{cv1}
+\cvqual{cv1}
 is the same cv-qualification as, or greater cv-qualification than,
-\textit{cv2}.
+\cvqual{cv2}.
 In all cases where the reference-related or reference-compatible relationship
 of two types is used to establish the validity of a reference binding, and
 \tcode{T1}
@@ -3541,7 +3541,7 @@ int& ir = B();                  // \tcode{ir} refers to the result of \tcode{B::
 \item
 Otherwise, the reference shall be an lvalue reference to a non-volatile
 const type (i.e.,
-\textit{cv1}
+\cvqual{cv1}
 shall be
 \tcode{const}), or the reference shall be an rvalue reference.
 \begin{example}
@@ -3622,9 +3622,9 @@ is reference-related to
 \tcode{T2}:
 \begin{itemize}
 \item
-\textit{cv1}
+\cvqual{cv1}
 shall be the same cv-qualification as, or greater cv-qualification than,
-\textit{cv2}; and
+\cvqual{cv2}; and
 \item
 if the reference is an rvalue reference,
 the initializer expression shall not be an lvalue.

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -477,16 +477,16 @@ of type
 if
 \begin{itemize}
 \item%
-The \term{handler} is of type \textit{cv} \tcode{T} or
-\textit{cv} \tcode{T\&} and
+The \term{handler} is of type \cv{} \tcode{T} or
+\cv{} \tcode{T\&} and
 \tcode{E} and \tcode{T}
 are the same type (ignoring the top-level \grammarterm{cv-qualifiers}), or
 \item%
-the \term{handler} is of type \textit{cv} \tcode{T} or
-\textit{cv} \tcode{T\&} and
+the \term{handler} is of type \cv{} \tcode{T} or
+\cv{} \tcode{T\&} and
 \tcode{T} is an unambiguous public base class of \tcode{E}, or
 \item%
-the \term{handler} is of type \textit{cv} \tcode{T} or \tcode{const T\&}
+the \term{handler} is of type \cv{} \tcode{T} or \tcode{const T\&}
 where \tcode{T} is a pointer or pointer to member type and
 \tcode{E} is a pointer or pointer to member type
 that can be converted to \tcode{T} by one or more of
@@ -503,7 +503,7 @@ a qualification conversion~(\ref{conv.qual}), or
 \end{itemize}
 
 \item
-the \term{handler} is of type \textit{cv} \tcode{T} or \tcode{const T\&} where \tcode{T} is a pointer or pointer to member type and \tcode{E} is \tcode{std::nullptr_t}.
+the \term{handler} is of type \cv{} \tcode{T} or \tcode{const T\&} where \tcode{T} is a pointer or pointer to member type and \tcode{E} is \tcode{std::nullptr_t}.
 
 \end{itemize}
 

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -525,17 +525,17 @@ For non-static member functions, the type of the implicit object
 parameter is
 
 \begin{itemize}
-\item ``lvalue reference to \textit{cv} \tcode{X}'' for functions declared
+\item ``lvalue reference to \cv{} \tcode{X}'' for functions declared
 without a \grammarterm{ref-qualifier} or with the
 \tcode{\&} \grammarterm{ref-qualifier}
-\item ``rvalue reference to \textit{cv} \tcode{X}'' for functions declared with the
+\item ``rvalue reference to \cv{} \tcode{X}'' for functions declared with the
 \tcode{\&\&} \grammarterm{ref-qualifier}
 \end{itemize}
 
 where
 \tcode{X}
 is the class of which the function is a member and
-\textit{cv}
+\cv{}
 is the cv-qualification on the
 member function declaration.
 \begin{example}
@@ -712,7 +712,7 @@ the
 that is the left operand of the
 \tcode{.}
 operator
-has type ``\textit{cv}
+has type ``\cv{}
 \tcode{T}''
 where
 \tcode{T}
@@ -801,7 +801,7 @@ If the
 \grammarterm{primary-expression}
 \tcode{E}
 in the function call syntax evaluates
-to a class object of type ``\textit{cv}
+to a class object of type ``\cv{}
 \tcode{T}'',
 then the set of candidate
 functions includes at least the function call operators of
@@ -826,7 +826,7 @@ form
 where
 \grammarterm{cv-qualifier}
 is the same cv-qualification as, or a greater cv-qualification than,
-\textit{cv},
+\cv{},
 and where
 \grammarterm{conversion-type-id}
 denotes the type ``pointer to function
@@ -1205,7 +1205,7 @@ to select the user-defined conversion to be invoked.
 cv-qualified class type is determined in terms of a corresponding non-reference
 copy-initialization. \end{note}
 Assuming that
-``\textit{cv1} \tcode{T}'' is the type of the object being initialized, with
+``\cvqual{cv1} \tcode{T}'' is the type of the object being initialized, with
 \tcode{T}
 a class type,
 the candidate functions are selected as follows:
@@ -1217,7 +1217,7 @@ The converting constructors~(\ref{class.conv.ctor}) of
 are candidate functions.
 \item
 When the type of the initializer expression is a class type
-``\textit{cv} \tcode{S}'',
+``\cv{} \tcode{S}'',
 the non-explicit conversion functions of
 \tcode{S}
 and its base classes are considered.
@@ -1227,7 +1227,7 @@ where the parameter is of type
 ``reference to possibly \cv-qualified \tcode{T}''
 and the constructor is
 called with a single argument in the context of
-direct-initialization of an object of type ``\textit{cv2} \tcode{T}'', explicit
+direct-initialization of an object of type ``\cvqual{cv2} \tcode{T}'', explicit
 conversion functions are also considered.
 Those that are not hidden within
 \tcode{S}
@@ -1266,8 +1266,8 @@ expression of class type to the type of the object
 being initialized.
 Overload resolution is used to select the
 conversion function to be invoked.
-Assuming that ``\textit{cv1} \tcode{T}'' is the
-type of the object being initialized, and ``\textit{cv} \tcode{S}'' is the type
+Assuming that ``\cvqual{cv1} \tcode{T}'' is the
+type of the object being initialized, and ``\cv{} \tcode{S}'' is the type
 of the initializer expression, with
 \tcode{S}
 a class type,
@@ -1295,11 +1295,11 @@ Conversion functions that return a cv-qualified type
 are considered to yield the cv-unqualified version of that type
 for this process of selecting candidate functions.
 Conversion functions that return ``reference to
-\textit{cv2}
+\cvqual{cv2}
 \tcode{X}''
 return
 lvalues or xvalues, depending on the type of reference, of type
-``\textit{cv2}
+``\cvqual{cv2}
 \tcode{X}''
 and are therefore considered to yield
 \tcode{X}
@@ -1323,9 +1323,9 @@ to a glvalue or class prvalue that is the result of applying a conversion
 function to an initializer expression.
 Overload resolution is used to select the
 conversion function to be invoked.
-Assuming that ``reference to \textit{cv1} \tcode{T}'' is the
+Assuming that ``reference to \cvqual{cv1} \tcode{T}'' is the
 type of the reference being initialized, and
-``\textit{cv} \tcode{S}'' is the type
+``\cv{} \tcode{S}'' is the type
 of the initializer expression, with
 \tcode{S}
 a class type,
@@ -1337,13 +1337,13 @@ The conversion functions of
 and its base classes are considered.
 Those non-explicit conversion functions that are not hidden within
 \tcode{S}
-and yield type ``lvalue reference to \textit{cv2} \tcode{T2}''
+and yield type ``lvalue reference to \cvqual{cv2} \tcode{T2}''
 (when initializing an lvalue reference or an rvalue reference to function) or
 ``\nonterminal{cv2} \tcode{T2}''
 or ``rvalue reference to \nonterminal{cv2} \tcode{T2}'' (when initializing an
 rvalue reference or an lvalue reference to function),
-where ``\textit{cv1} \tcode{T}'' is reference-compatible~(\ref{dcl.init.ref})
-with ``\textit{cv2} \tcode{T2}'',
+where ``\cvqual{cv1} \tcode{T}'' is reference-compatible~(\ref{dcl.init.ref})
+with ``\cvqual{cv2} \tcode{T2}'',
 are candidate functions. For direct-initialization, those explicit
 conversion functions that are not hidden within \tcode{S} and yield
 type ``lvalue reference to \cvqual{cv2} \tcode{T2}'' or ``\cvqual{cv2}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -13442,7 +13442,7 @@ in \tcode{BoundArgs}, \tcode{is_cons\-tructible_v<TiD, Ti>} shall be \tcode{true
 wN)}~(\ref{func.require}) shall be a valid expression for some
 values \textit{w1, w2, ..., wN}, where
 \tcode{N == sizeof...(bound_args)}.
-The \textit{cv}-qualifiers \textit{cv} of the call wrapper \tcode{g},
+The cv-qualifiers \cv{} of the call wrapper \tcode{g},
 as specified below, shall be neither \tcode{volatile} nor \tcode{const volatile}.
 
 \pnum\returns
@@ -13481,7 +13481,7 @@ in \tcode{BoundArgs}, \tcode{is_con\-structible_v<TiD, Ti>} shall be \tcode{true
 expression for some
 values \textit{w1, w2, ..., wN}, where
 \tcode{N == sizeof...(bound_args)}.
-The \textit{cv}-qualifiers \textit{cv} of the call wrapper \tcode{g},
+The cv-qualifiers \cv{} of the call wrapper \tcode{g},
 as specified below, shall be neither \tcode{volatile} nor \tcode{const volatile}.
 
 \pnum
@@ -13513,7 +13513,7 @@ The values of the \techterm{bound arguments} \tcode{v1, v2, ..., vN} and their
 corresponding types \tcode{V1, V2, ..., VN} depend on the
 types \tcode{TiD} derived from
 the call to \tcode{bind} and the
-\textit{cv}-qualifiers \textit{cv} of the call wrapper \tcode{g} as follows:
+cv-qualifiers \cv{} of the call wrapper \tcode{g} as follows:
 
 \begin{itemize}
 \item if \tcode{TiD} is \tcode{reference_wrapper<T>}, the
@@ -13522,7 +13522,7 @@ argument is \tcode{tid.get()} and its type \tcode{Vi} is \tcode{T\&};
 \item if the value of \tcode{is_bind_expression_v<TiD>}
 is \tcode{true}, the argument is \tcode{tid(std::forward<Uj>(\brk{}uj)...)}  and its
 type \tcode{Vi} is
-\tcode{result_of_t<TiD \textit{cv} \& (Uj\&\&...)>\&\&};
+\tcode{result_of_t<TiD \cv{} \& (Uj\&\&...)>\&\&};
 
 \item if the value \tcode{j} of \tcode{is_placeholder_v<TiD>}
 is not zero, the  argument is \tcode{std::forward<Uj>(uj)}
@@ -13530,7 +13530,7 @@ and its type \tcode{Vi}
 is \tcode{Uj\&\&};
 
 \item otherwise, the value is \tcode{tid} and its type \tcode{Vi}
-is \tcode{TiD \textit{cv} \&}.
+is \tcode{TiD \cv{} \&}.
 \end{itemize}
 
 \rSec3[func.bind.place]{Placeholders}
@@ -14918,7 +14918,7 @@ section~\ref{basic.types} of the \Cpp standard.
 
 \pnum
 For any given type \tcode{T}, the result of applying one of these templates to
-\tcode{T} and to \textit{cv-qualified} \tcode{T} shall yield the same result.
+\tcode{T} and to \cv{} \tcode{T} shall yield the same result.
 
 \pnum
 \begin{note}
@@ -15004,7 +15004,7 @@ categories, corresponding to the descriptions given in section~\ref{basic.types}
 
 \pnum
 For any given type \tcode{T}, the result of applying one of these templates to
-\tcode{T}, and to \textit{cv-qualified} \tcode{T} shall yield the same result.
+\tcode{T} and to \cv{} \tcode{T} shall yield the same result.
 
 \begin{libreqtab3b}{Composite type category predicates}{tab:type-traits.composite}
 \\ \topline


### PR DESCRIPTION
diffpdf shows no differences other than the two cv-qualified -> \cv{} replacements.