### PR TITLE
[dcl.ref] Introduce the phrase 'reference collapsing' in a note.

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -807,7 +807,9 @@ If a \grammarterm{typedef-name}~(\ref{dcl.typedef}, \ref{temp.param})
 or a \grammarterm{decltype-specifier}~(\ref{dcl.type.simple}) denotes a type \tcode{TR} that
 is a reference to a type \tcode{T}, an attempt to create the type ``lvalue reference to \cv{} 
 \tcode{TR}'' creates the type ``lvalue reference to \tcode{T}'', while an attempt to create
-the type ``rvalue reference to \cv{} \tcode{TR}'' creates the type \tcode{TR}. \begin{example}
+the type ``rvalue reference to \cv{} \tcode{TR}'' creates the type \tcode{TR}.
+\begin{note} This rule is known as reference collapsing. \end{note}
+\begin{example}
 
 \begin{codeblock}
 int i;


### PR DESCRIPTION
Fixes #546.