### PR TITLE
[intro.execution] Adjust example for unsequenced side effects

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -1007,7 +1007,6 @@ potentially concurrent computations.
 \begin{example}
 
 \begin{codeblock}
-void f(int, int);
 void g(int i) {
   i = 7, i++, i++;    // \tcode{i} becomes \tcode{9}
 


### PR DESCRIPTION
Provides a case where side effects to the same memory location are unsequenced. Also removes an unreferenced function declaration.