### PR TITLE
[lib] Remove 'std::' prefix from library names.

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -1274,11 +1274,11 @@ an execution policy object of type \tcode{execution::parallel_policy} are
 permitted to execute in either the invoking thread of execution or in a
 thread of execution implicitly
 created by the library to support parallel algorithm execution.
-If the threads of execution created by \tcode{std::thread} provide concurrent
+If the threads of execution created by \tcode{thread}~(\ref{thread.thread.class}) provide concurrent
 forward progress guarantees~(\ref{intro.progress}), then a thread of execution
 implicitly created by the library will provide parallel forward progress guarantees;
 otherwise, the provided forward progress guarantee is
-\impldef{forward progress guarantees for implicit threads of parallel algorithms (if not defined for \tcode{std::thread})}.
+\impldef{forward progress guarantees for implicit threads of parallel algorithms (if not defined for \tcode{thread})}.
 Any such
 invocations executing in the same thread of execution are indeterminately sequenced with
 respect to each other.

--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -816,7 +816,7 @@ In the following operation definitions:
 \item a \textit{C} refers to its corresponding non-atomic type.
 \item an \textit{M} refers to type of the other argument for arithmetic operations. For
 integral atomic types, \textit{M} is \textit{C}. For atomic address types, \textit{M} is
-\tcode{std::ptrdiff_t}.
+\tcode{ptrdiff_t}.
 \item the non-member functions not ending in \tcode{_explicit} have the semantics of their
 corresponding \tcode{_explicit} functions with \tcode{memory_order} arguments of
 \tcode{memory_order_seq_cst}.

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -528,8 +528,8 @@ an expression \tcode{v} of type (possibly \tcode{const}) \tcode{T},
 and an rvalue \tcode{rv} of type \tcode{T},
 the following terms are defined. If \tcode{X}
 is not allocator-aware, the terms below are defined as if \tcode{A} were
-\tcode{std::allocator<T>} --- no allocator object needs to be created
-and user specializations of \tcode{std::allocator<T>} are not instantiated:
+\tcode{allocator<T>} --- no allocator object needs to be created
+and user specializations of \tcode{allocator<T>} are not instantiated:
 
 \begin{itemize}
 \item
@@ -596,7 +596,7 @@ allocator_traits<A>::destroy(m, p)
 A container calls \tcode{allocator_traits<A>::construct(m, p, args)}
 to construct an element at \tcode{p} using \tcode{args},
 with \tcode{m == get_allocator()}.
-The default \tcode{construct} in \tcode{std::allocator} will
+The default \tcode{construct} in \tcode{allocator} will
 call \tcode{::new((void*)p) T(args)},
 but specialized allocators may choose a different definition.
 \end{note}
@@ -765,7 +765,7 @@ and \ref{tab:containers.sequence.optional},
 \tcode{A} denotes \tcode{X::allocator_type} if
 the \grammarterm{qualified-id} \tcode{X::allocator_type} is valid and denotes a
 type~(\ref{temp.deduct}) and
-\tcode{std::allocator<T>} if it doesn't,
+\tcode{allocator<T>} if it doesn't,
 \tcode{i} and \tcode{j}
 denote iterators satisfying input iterator requirements
 and refer to elements implicitly convertible to \tcode{value_type},
@@ -1222,7 +1222,7 @@ permitted to provide equivalent functionality without providing a class with
 this name.
 
 \pnum
-If a user-defined specialization of \tcode{std::pair} exists for
+If a user-defined specialization of \tcode{pair} exists for
 \tcode{pair<const Key, T>} or \tcode{pair<Key, T>}, where \tcode{Key} is the
 container's \tcode{key_type} and \tcode{T} is the container's
 \tcode{mapped_type}, the behavior of operations involving node handles is
@@ -1579,7 +1579,7 @@ and \tcode{e} in \tcode{a};
 \tcode{ke} is a value such that \tcode{a} is partitioned with respect to
 \tcode{c(r, ke)} and \tcode{!c(ke, r)}, with \tcode{c(r, ke)} implying
 \tcode{!c(ke, r)}.
-\tcode{A} denotes the storage allocator used by \tcode{X}, if any, or \tcode{std::allocator<X::value_type>} otherwise,
+\tcode{A} denotes the storage allocator used by \tcode{X}, if any, or \tcode{allocator<X::value_type>} otherwise,
 \tcode{m} denotes an allocator of a type convertible to \tcode{A},
 and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 
@@ -2112,7 +2112,7 @@ unless otherwise specified.
 \pnum
 For \tcode{unordered_set} and \tcode{unordered_multiset} the value type is
 the same as the key type.  For \tcode{unordered_map} and
-\tcode{unordered_multimap} it is \tcode{std::pair<const Key,
+\tcode{unordered_multimap} it is \tcode{pair<const Key,
 T>}.
 
 \pnum
@@ -2218,7 +2218,7 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 \tcode{X::hasher}
 &   \tcode{Hash}
 &   \tcode{Hash} shall be a unary function object type such that the expression
-    \tcode{hf(k)} has type \tcode{std::size_t}.%
+    \tcode{hf(k)} has type \tcode{size_t}.%
     \indextext{unordered associative containers!\idxcode{hasher}}%
     \indextext{\idxcode{hasher}!unordered associative containers}%
 &   compile time
@@ -6266,7 +6266,7 @@ equivalent to \tcode{return emplace_hint(position, std::forward<P>(x))}.
 \pnum
 \remarks
 These signatures shall not participate in overload resolution
-unless \tcode{std::is_constructible_v<value_type, P\&\&>} is
+unless \tcode{is_constructible_v<value_type, P\&\&>} is
 \tcode{true}.
 \end{itemdescr}
 
@@ -6722,7 +6722,7 @@ equivalent to \tcode{return emplace_hint(position, std::forward<P>(x))}.
 \pnum
 \remarks
 These signatures shall not participate in overload resolution
-unless \tcode{std::is_constructible_v<value_type, P\&\&>} is
+unless \tcode{is_constructible_v<value_type, P\&\&>} is
 \tcode{true}.
 \end{itemdescr}
 
@@ -7300,16 +7300,16 @@ namespace std {
   template <class Key,
             class T,
             class Hash = hash<Key>,
-            class Pred = std::equal_to<Key>,
-            class Alloc = std::allocator<std::pair<const Key, T>>>
+            class Pred = equal_to<Key>,
+            class Alloc = allocator<pair<const Key, T>>>
     class unordered_map;
 
   // \ref{unord.multimap}, class template unordered_multimap:
   template <class Key,
             class T,
             class Hash = hash<Key>,
-            class Pred = std::equal_to<Key>,
-            class Alloc = std::allocator<std::pair<const Key, T>>>
+            class Pred = equal_to<Key>,
+            class Alloc = allocator<pair<const Key, T>>>
     class unordered_multimap;
 
   template <class Key, class T, class Hash, class Pred, class Alloc>
@@ -7366,15 +7366,15 @@ namespace std {
   // \ref{unord.set}, class template unordered_set:
   template <class Key,
             class Hash = hash<Key>,
-            class Pred = std::equal_to<Key>,
-            class Alloc = std::allocator<Key>>
+            class Pred = equal_to<Key>,
+            class Alloc = allocator<Key>>
     class unordered_set;
 
   // \ref{unord.multiset}, class template unordered_multiset:
   template <class Key,
             class Hash = hash<Key>,
-            class Pred = std::equal_to<Key>,
-            class Alloc = std::allocator<Key>>
+            class Pred = equal_to<Key>,
+            class Alloc = allocator<Key>>
     class unordered_multiset;
 
   template <class Key, class Hash, class Pred, class Alloc>
@@ -7432,7 +7432,7 @@ The \tcode{unordered_map} class
 supports forward iterators.
 
 \pnum
-An \tcode{unordered_map} satisfies all of the requirements of a container, of an unordered associative container, and of an allocator-aware container (Table~\ref{tab:containers.allocatoraware}). It provides the operations described in the preceding requirements table for unique keys; that is, an \tcode{unordered_map} supports the \tcode{a_uniq} operations in that table, not the \tcode{a_eq} operations. For an \tcode{unordered_map<Key, T>} the \tcode{key type} is \tcode{Key}, the mapped type is \tcode{T}, and the value type is \tcode{std::pair<const Key, T>}.
+An \tcode{unordered_map} satisfies all of the requirements of a container, of an unordered associative container, and of an allocator-aware container (Table~\ref{tab:containers.allocatoraware}). It provides the operations described in the preceding requirements table for unique keys; that is, an \tcode{unordered_map} supports the \tcode{a_uniq} operations in that table, not the \tcode{a_eq} operations. For an \tcode{unordered_map<Key, T>} the \tcode{key type} is \tcode{Key}, the mapped type is \tcode{T}, and the value type is \tcode{pair<const Key, T>}.
 
 \pnum
 This section only describes operations on \tcode{unordered_map} that
@@ -7445,8 +7445,8 @@ namespace std {
   template <class Key,
             class T,
             class Hash = hash<Key>,
-            class Pred = std::equal_to<Key>,
-            class Allocator = std::allocator<std::pair<const Key, T>>>
+            class Pred = equal_to<Key>,
+            class Allocator = allocator<pair<const Key, T>>>
   class unordered_map {
   public:
     // types:
@@ -7591,8 +7591,8 @@ namespace std {
     iterator       find(const key_type& k);
     const_iterator find(const key_type& k) const;
     size_type      count(const key_type& k) const;
-    std::pair<iterator, iterator>             equal_range(const key_type& k);
-    std::pair<const_iterator, const_iterator> equal_range(const key_type& k) const;
+    pair<iterator, iterator>             equal_range(const key_type& k);
+    pair<const_iterator, const_iterator> equal_range(const key_type& k) const;
 
     // \ref{unord.map.elem} element access:
     mapped_type& operator[](const key_type& k);
@@ -7743,7 +7743,7 @@ template <class P>
 
 \pnum
 \remarks This signature shall not participate in overload resolution
-unless \tcode{std::is_constructible_v<value_type, P\&\&>} is \tcode{true}.
+unless \tcode{is_constructible_v<value_type, P\&\&>} is \tcode{true}.
 \end{itemdescr}
 
 \indexlibrarymember{unordered_map}{insert}%
@@ -7759,7 +7759,7 @@ template <class P>
 
 \pnum
 \remarks This signature shall not participate in overload resolution
-unless \tcode{std::is_constructible_v<value_type, P\&\&>} is \tcode{true}.
+unless \tcode{is_constructible_v<value_type, P\&\&>} is \tcode{true}.
 \end{itemdescr}
 
 \indexlibrarymember{try_emplace}{unordered_map}%
@@ -7940,7 +7940,7 @@ unordered associative container, and of an allocator-aware container
 preceding requirements table for equivalent keys; that is, an \tcode{unordered_multimap}
 supports the \tcode{a_eq} operations in that table, not the \tcode{a_uniq} operations.
 For an \tcode{unordered_multimap<Key, T>} the \tcode{key type} is \tcode{Key}, the
-mapped type is \tcode{T}, and the value type is \tcode{std::pair<const Key, T>}.
+mapped type is \tcode{T}, and the value type is \tcode{pair<const Key, T>}.
 
 \pnum
 This section only describes operations on \tcode{unordered_multimap}
@@ -7953,8 +7953,8 @@ namespace std {
   template <class Key,
             class T,
             class Hash = hash<Key>,
-            class Pred = std::equal_to<Key>,
-            class Allocator = std::allocator<std::pair<const Key, T>>>
+            class Pred = equal_to<Key>,
+            class Allocator = allocator<pair<const Key, T>>>
   class unordered_multimap {
   public:
     // types:
@@ -8081,8 +8081,8 @@ namespace std {
     iterator       find(const key_type& k);
     const_iterator find(const key_type& k) const;
     size_type      count(const key_type& k) const;
-    std::pair<iterator, iterator>             equal_range(const key_type& k);
-    std::pair<const_iterator, const_iterator> equal_range(const key_type& k) const;
+    pair<iterator, iterator>             equal_range(const key_type& k);
+    pair<const_iterator, const_iterator> equal_range(const key_type& k) const;
 
     // bucket interface:
     size_type bucket_count() const noexcept;
@@ -8189,7 +8189,7 @@ template <class P>
 
 \pnum
 \remarks This signature shall not participate in overload resolution
-unless \tcode{std::is_constructible_v<value_type, P\&\&>} is \tcode{true}.
+unless \tcode{is_constructible_v<value_type, P\&\&>} is \tcode{true}.
 \end{itemdescr}
 
 \indexlibrarymember{unordered_multimap}{insert}%
@@ -8205,7 +8205,7 @@ template <class P>
 
 \pnum
 \remarks This signature shall not participate in overload resolution
-unless \tcode{std::is_constructible_v<value_type, P\&\&>} is \tcode{true}.
+unless \tcode{is_constructible_v<value_type, P\&\&>} is \tcode{true}.
 \end{itemdescr}
 
 \rSec3[unord.multimap.swap]{\tcode{unordered_multimap} swap}
@@ -8251,8 +8251,8 @@ is additional semantic information.
 namespace std {
   template <class Key,
             class Hash = hash<Key>,
-            class Pred = std::equal_to<Key>,
-            class Allocator = std::allocator<Key>>
+            class Pred = equal_to<Key>,
+            class Allocator = allocator<Key>>
   class unordered_set {
   public:
     // types:
@@ -8377,8 +8377,8 @@ namespace std {
     iterator       find(const key_type& k);
     const_iterator find(const key_type& k) const;
     size_type      count(const key_type& k) const;
-    std::pair<iterator, iterator>             equal_range(const key_type& k);
-    std::pair<const_iterator, const_iterator> equal_range(const key_type& k) const;
+    pair<iterator, iterator>             equal_range(const key_type& k);
+    pair<const_iterator, const_iterator> equal_range(const key_type& k) const;
 
     // bucket interface:
     size_type bucket_count() const noexcept;
@@ -8519,8 +8519,8 @@ is additional semantic information.
 namespace std {
   template <class Key,
             class Hash = hash<Key>,
-            class Pred = std::equal_to<Key>,
-            class Allocator = std::allocator<Key>>
+            class Pred = equal_to<Key>,
+            class Allocator = allocator<Key>>
   class unordered_multiset {
   public:
     // types:
@@ -8644,8 +8644,8 @@ namespace std {
     iterator       find(const key_type& k);
     const_iterator find(const key_type& k) const;
     size_type      count(const key_type& k) const;
-    std::pair<iterator, iterator>             equal_range(const key_type& k);
-    std::pair<const_iterator, const_iterator> equal_range(const key_type& k) const;
+    pair<iterator, iterator>             equal_range(const key_type& k);
+    pair<const_iterator, const_iterator> equal_range(const key_type& k) const;
 
     // bucket interface:
     size_type bucket_count() const noexcept;

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -6531,9 +6531,9 @@ and also for the overload where the first argument is of type
 and the second is of type
 \tcode{const char*},
 \item
-\tcode{std::char_traits<char>::length(s)}
+\tcode{char_traits<char>::length(s)}
 for the overload where the first argument is of type
-\tcode{basic_ostream<\brk{}charT, traits>\&}
+\tcode{basic_ostream<charT, traits>\&}
 and the second is of type
 \tcode{const char*},
 \item
@@ -8714,7 +8714,7 @@ as required.
 It then opens a file, if possible, whose name is the
 \ntbs \tcode{s}
 (as if by calling
-\tcode{std::fopen(s, modstr)}).
+\tcode{fopen(s, modstr)}).
 \indextext{NTBS}%
 \indexlibrary{\idxcode{fopen}}%
 The \ntbs \tcode{modstr} is determined from
@@ -8753,7 +8753,7 @@ If the open operation succeeds and
 \tcode{(mode \& ios_base::ate) != 0},
 positions the file to the end
 (as if by calling
-\tcode{std::fseek(file, 0, SEEK_END)}).\footnote{The macro
+\tcode{fseek(file, 0, SEEK_END)}).\footnote{The macro
 \tcode{SEEK_END}
 is defined, and the function signatures
 \indexlibrary{\idxcode{fopen}}%
@@ -9089,9 +9089,9 @@ then update the output sequence and write any unshift sequence.
 Next, seek to the new position: if
 \tcode{width > 0},
 call
-\tcode{std::fseek(file, width * off, whence)},
+\tcode{fseek(file, width * off, whence)},
 otherwise call
-\tcode{std::fseek(file, 0, whence)}.
+\tcode{fseek(file, 0, whence)}.
 
 \pnum
 \remarks

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2121,7 +2121,7 @@ supported by an allocator, instantiation of the allocator for that type may
 fail. The allocator also may silently ignore the requested alignment.
 \begin{note} Additionally, the member function \tcode{allocate}
 for that type may fail by throwing an object of type
-\tcode{std::bad_alloc}.\end{note}
+\tcode{bad_alloc}.\end{note}
 
 \rSec4[allocator.requirements.completeness]{Allocator completeness requirements}
 

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -49,8 +49,8 @@ namespace std {
   template <class charT> charT toupper(charT c, const locale& loc);
   template <class charT> charT tolower(charT c, const locale& loc);
   template <class Codecvt, class Elem = wchar_t,
-    class Wide_alloc = std::allocator<Elem>,
-    class Byte_alloc = std::allocator<char>> class wstring_convert;
+    class Wide_alloc = allocator<Elem>,
+    class Byte_alloc = allocator<char>> class wstring_convert;
   template <class Codecvt, class Elem = wchar_t,
      class Tr = char_traits<Elem@\shr{}@ class wbuffer_convert;
 
@@ -874,7 +874,7 @@ to return a copy of the argument.
 If the argument has a name, does
 
 \begin{codeblock}
-std::setlocale(LC_ALL, loc.name().c_str());
+setlocale(LC_ALL, loc.name().c_str());
 \end{codeblock}
 
 otherwise, the effect on the C locale, if any, is \impldef{effect on C locale of calling
@@ -1055,11 +1055,11 @@ std::cout << mbstring;
 \begin{codeblock}
 namespace std {
 template<class Codecvt, class Elem = wchar_t,
-    class Wide_alloc = std::allocator<Elem>,
-    class Byte_alloc = std::allocator<char>> class wstring_convert {
+    class Wide_alloc = allocator<Elem>,
+    class Byte_alloc = allocator<char>> class wstring_convert {
   public:
-    using byte_string = std::basic_string<char, char_traits<char>, Byte_alloc>;
-    using wide_string = std::basic_string<Elem, char_traits<Elem>, Wide_alloc>;
+    using byte_string = basic_string<char, char_traits<char>, Byte_alloc>;
+    using wide_string = basic_string<Elem, char_traits<Elem>, Wide_alloc>;
     using state_type  = typename Codecvt::state_type;
     using int_type    = typename wide_string::traits_type::int_type;
 
@@ -1096,16 +1096,16 @@ template<class Codecvt, class Elem = wchar_t,
 
 \pnum
 The class template describes an object that controls conversions between wide
-string objects of class \tcode{std::basic_string<Elem, char_traits<Elem>,
-Wide_alloc>} and byte string objects of class \tcode{std::\\basic_string<char,
+string objects of class \tcode{basic_string<Elem, char_traits<Elem>,
+Wide_alloc>} and byte string objects of class \tcode{basic_string<char,
 char_traits<char>, Byte_alloc>}. The class template defines the types
 \tcode{wide_string} and \tcode{byte_string} as synonyms for these two types.
 Conversion between a sequence of \tcode{Elem} values (stored in a
 \tcode{wide_string} object) and multibyte sequences (stored in a
 \tcode{byte_string} object) is performed by an object of class
 \tcode{Codecvt}, which meets the
-requirements of the standard code-conversion facet \tcode{std::codecvt<Elem,
-char, std::mbstate_t>}.
+requirements of the standard code-conversion facet \tcode{codecvt<Elem,
+char, mbstate_t>}.
 
 \pnum
 An object of this class template stores:
@@ -1121,12 +1121,12 @@ An object of this class template stores:
 
 \indexlibrarymember{byte_string}{wstring_convert}%
 \begin{itemdecl}
-using byte_string = std::basic_string<char, char_traits<char>, Byte_alloc>;
+using byte_string = basic_string<char, char_traits<char>, Byte_alloc>;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-The type shall be a synonym for \tcode{std::basic_string<char,
+The type shall be a synonym for \tcode{basic_string<char,
 char_traits<char>, Byte_alloc>}
 \end{itemdescr}
 
@@ -1174,7 +1174,7 @@ conversion begins. Otherwise it shall be left unchanged.
 If no conversion error occurs, the member function shall return the converted wide string.
 Otherwise, if the object was constructed with a wide-error string, the
 member function shall return the wide-error string.
-Otherwise, the member function throws an object of class \tcode{std::range_error}.
+Otherwise, the member function throws an object of class \tcode{range_error}.
 \end{itemdescr}
 
 \indexlibrarymember{int_type}{wstring_convert}%
@@ -1240,17 +1240,17 @@ in \tcode{cvtcount}.
 If no conversion error occurs, the member function shall return the converted byte string.
 Otherwise, if the object was constructed with a byte-error string, the
 member function shall return the byte-error string.
-Otherwise, the member function shall throw an object of class \tcode{std::range_error}.
+Otherwise, the member function shall throw an object of class \tcode{range_error}.
 \end{itemdescr}
 
 \indexlibrarymember{wide_string}{wstring_convert}%
 \begin{itemdecl}
-using wide_string = std::basic_string<Elem, char_traits<Elem>, Wide_alloc>;
+using wide_string = basic_string<Elem, char_traits<Elem>, Wide_alloc>;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-The type shall be a synonym for \tcode{std::basic_string<Elem,
+The type shall be a synonym for \tcode{basic_string<Elem,
 char_traits<Elem>, Wide_alloc>}.
 \end{itemdescr}
 
@@ -1310,13 +1310,13 @@ without affecting any streams or locales.
 namespace std {
 template<class Codecvt,
     class Elem = wchar_t,
-    class Tr = std::char_traits<Elem>>
+    class Tr = char_traits<Elem>>
   class wbuffer_convert
-    : public std::basic_streambuf<Elem, Tr> {
+    : public basic_streambuf<Elem, Tr> {
   public:
     using state_type = typename Codecvt::state_type;
 
-    explicit wbuffer_convert(std::streambuf* bytebuf = 0,
+    explicit wbuffer_convert(streambuf* bytebuf = 0,
                              Codecvt* pcvt = new Codecvt,
                              state_type state = state_type());
 
@@ -1325,13 +1325,13 @@ template<class Codecvt,
     wbuffer_convert(const wbuffer_convert&) = delete;
     wbuffer_convert& operator=(const wbuffer_convert&) = delete;
 
-    std::streambuf* rdbuf() const;
-    std::streambuf* rdbuf(std::streambuf* bytebuf);
+    streambuf* rdbuf() const;
+    streambuf* rdbuf(streambuf* bytebuf);
 
     state_type state() const;
 
   private:
-    std::streambuf* bufptr;         // \expos
+    streambuf* bufptr;         // \expos
     Codecvt* cvtptr;                // \expos
     state_type cvtstate;            // \expos
   };
@@ -1342,10 +1342,10 @@ template<class Codecvt,
 The class template describes a stream buffer that controls the
 transmission of elements of type \tcode{Elem}, whose character traits are
 described by the class \tcode{Tr}, to and from a byte stream buffer of type
-\tcode{std::streambuf}. Conversion between a sequence of \tcode{Elem} values and
+\tcode{streambuf}. Conversion between a sequence of \tcode{Elem} values and
 multibyte sequences is performed by an object of class
 \tcode{Codecvt}, which shall meet the requirements
-of the standard code-conversion facet \tcode{std::codecvt<Elem, char, std::mbstate_t>}.
+of the standard code-conversion facet \tcode{codecvt<Elem, char, mbstate_t>}.
 
 \pnum
 An object of this class template stores:
@@ -1369,7 +1369,7 @@ state_type state() const;
 
 \indexlibrarymember{rdbuf}{wbuffer_convert}%
 \begin{itemdecl}
-std::streambuf* rdbuf() const;
+streambuf* rdbuf() const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1379,7 +1379,7 @@ std::streambuf* rdbuf() const;
 
 \indexlibrarymember{rdbuf}{wbuffer_convert}%
 \begin{itemdecl}
-std::streambuf* rdbuf(std::streambuf* bytebuf);
+streambuf* rdbuf(streambuf* bytebuf);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1402,7 +1402,7 @@ The type shall be a synonym for \tcode{Codecvt::state_type}.
 
 \indexlibrary{\idxcode{wbuffer_convert}!constructor}%
 \begin{itemdecl}
-explicit wbuffer_convert(std::streambuf* bytebuf = 0,
+explicit wbuffer_convert(streambuf* bytebuf = 0,
     Codecvt* pcvt = new Codecvt, state_type state = state_type());
 \end{itemdecl}
 

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -235,7 +235,7 @@ floating-point evaluation in constant expressions.
 The floating-point environment has thread storage
 duration~(\ref{basic.stc.thread}). The initial state for a thread's floating-point
 environment is the state of the floating-point environment of the thread that constructs
-the corresponding \tcode{std::thread} object~(\ref{thread.thread.class}) at the time it
+the corresponding \tcode{thread} object~(\ref{thread.thread.class}) at the time it
 constructed the object. \begin{note} That is, the child thread gets the floating-point
 state of the parent thread at the time of the child's creation. \end{note}
 
@@ -270,7 +270,7 @@ the range of representable values for its type, the behavior is
 undefined.
 
 \pnum
-If \tcode{z} is an lvalue expression of type \emph{cv} \tcode{std::complex<T>} then:
+If \tcode{z} is an lvalue expression of type \emph{cv} \tcode{complex<T>} then:
 
 \begin{itemize}
 \item the expression \tcode{reinterpret_cast<cv T(\&)[2]>(z)} shall be well-formed,
@@ -278,11 +278,11 @@ If \tcode{z} is an lvalue expression of type \emph{cv} \tcode{std::complex<T>} t
 \item \tcode{reinterpret_cast<cv T(\&)[2]>(z)[1]} shall designate the imaginary part of \tcode{z}.
 \end{itemize}
 
-Moreover, if \tcode{a} is an expression of type \tcode{cv std::complex<T>*} and the expression \tcode{a[i]} is well-defined for an integer expression \tcode{i}, then:
+Moreover, if \tcode{a} is an expression of type \cv{} \tcode{complex<T>*} and the expression \tcode{a[i]} is well-defined for an integer expression \tcode{i}, then:
 
 \begin{itemize}
-\item \tcode{reinterpret_cast<cv T*>(a)[2*i]} shall designate the real part of \tcode{a[i]}, and
-\item \tcode{reinterpret_cast<cv T*>(a)[2*i + 1]} shall designate the imaginary part of \tcode{a[i]}.
+\item \tcode{reinterpret_cast<\cv{} T*>(a)[2*i]} shall designate the real part of \tcode{a[i]}, and
+\item \tcode{reinterpret_cast<\cv{} T*>(a)[2*i + 1]} shall designate the imaginary part of \tcode{a[i]}.
 \end{itemize}
 
 \rSec2[complex.syn]{Header \tcode{<complex>} synopsis}
@@ -917,7 +917,7 @@ operator<<(basic_ostream<charT, traits>& o, const complex<T>& x) {
 \pnum
 \realnote In a locale in which comma is used as a decimal point character, the
 use of comma as a field separator can be ambiguous. Inserting
-\tcode{std::showpoint} into the output stream forces all outputs to
+\tcode{showpoint} into the output stream forces all outputs to
 show an explicit decimal point character; as a result, all inserted sequences of
 complex numbers can be extracted unambiguously.
 
@@ -2693,7 +2693,7 @@ throws an exception.
 Every function described in this section~\ref{rand.eng}
 that has a function parameter \tcode{q} of type \tcode{Sseq\&}
 for a template type parameter named \tcode{Sseq}
-that is different from type \tcode{std::seed_seq}
+that is different from type \tcode{seed_seq}
 throws what and when the invocation of \tcode{q.generate} throws.
 
 \pnum
@@ -3246,7 +3246,7 @@ throws an exception.
 Every function described in this section~\ref{rand.adapt}
 that has a function parameter \tcode{q} of type \tcode{Sseq\&}
 for a template type parameter named \tcode{Sseq}
-that is different from type \tcode{std::seed_seq}
+that is different from type \tcode{seed_seq}
 throws what and when the invocation of \tcode{q.generate} throws.
 
 \pnum

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -139,7 +139,7 @@ and \tcode{loc} is an object of type \tcode{X::locale_type}.
     template \tcode{basic_regex}.
   \\ \rowsep
 \tcode{X::string_type}
-  & \tcode{std::basic_string<charT>}
+  & \tcode{basic_string<charT>}
   &
   \\ \rowsep
 \tcode{X::locale_type}
@@ -153,7 +153,7 @@ and \tcode{loc} is an object of type \tcode{X::locale_type}.
    \indextext{\idxcode{char_class_type}!regular expression traits}%
  \\ \rowsep
 \tcode{X::length(p)}
-  & \tcode{std::size_t}
+  & \tcode{size_t}
   & Yields the smallest \tcode{i} such that \tcode{p[i] == 0}. Complexity is
     linear in \tcode{i} .
   \\ \rowsep
@@ -1020,7 +1020,7 @@ expression could match the specified character sequence.  \\
 \rSec1[re.badexp]{Class \tcode{regex_error}}
 \indexlibrary{\idxcode{regex_error}}%
 \begin{codeblock}
-class regex_error : public std::runtime_error {
+class regex_error : public runtime_error {
   public:
     explicit regex_error(regex_constants::error_type ecode);
     regex_constants::error_type code() const;
@@ -1060,12 +1060,12 @@ namespace std {
   struct regex_traits {
   public:
      using char_type       = charT;
-     using string_type     = std::basic_string<char_type>;
-     using locale_type     = std::locale;
+     using string_type     = basic_string<char_type>;
+     using locale_type     = locale;
      using char_class_type = @{\itshape bitmask_type}@;
 
      regex_traits();
-     static std::size_t length(const char_type* p);
+     static size_t length(const char_type* p);
      charT translate(charT c) const;
      charT translate_nocase(charT c) const;
      template <class ForwardIterator>
@@ -1109,7 +1109,7 @@ set returned by \tcode{lookup_classname}.
 
 \indexlibrarymember{length}{regex_traits}%
 \begin{itemdecl}
-static std::size_t length(const char_type* p); 
+static size_t length(const char_type* p); 
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1892,7 +1892,7 @@ by a particular marked sub-expression.
 \begin{codeblock}
 namespace std {
   template <class BidirectionalIterator>
-  class sub_match : public std::pair<BidirectionalIterator, BidirectionalIterator> {
+  class sub_match : public pair<BidirectionalIterator, BidirectionalIterator> {
   public:
      using value_type      =
              typename iterator_traits<BidirectionalIterator>::value_type;
@@ -3448,14 +3448,14 @@ If no such
 matches are found and
 \tcode{!(flags \& regex_constants::format_no_copy)}, then calls
 \begin{codeblock}
-out = std::copy(first, last, out)
+out = copy(first, last, out)
 \end{codeblock}
 If any matches are found then, for each such match:
 \begin{itemize}
 \item
 If \tcode{!(flags \& regex_constants::format_no_copy)}, calls 
 \begin{codeblock}
-out = std::copy(m.prefix().first, m.prefix().second, out)
+out = copy(m.prefix().first, m.prefix().second, out)
 \end{codeblock}
 \item
 Then calls
@@ -3472,7 +3472,7 @@ Finally, if such a match
 is found and \tcode{!(flags \& regex_constants::format_no_copy)},
 calls
 \begin{codeblock}
-out = std::copy(last_m.suffix().first, last_m.suffix().second, out)
+out = copy(last_m.suffix().first, last_m.suffix().second, out)
 \end{codeblock}
 where \tcode{last_m} is a copy of the last match
 found. If \tcode{flags \& regex_constants::format_first_only} 
@@ -3579,9 +3579,9 @@ namespace std {
   class regex_iterator {
   public:
      using regex_type        = basic_regex<charT, traits>;
-     using iterator_category = std::forward_iterator_tag;
+     using iterator_category = forward_iterator_tag;
      using value_type        = match_results<BidirectionalIterator>;
-     using difference_type   = std::ptrdiff_t;
+     using difference_type   = ptrdiff_t;
      using pointer           = const value_type*;
      using reference         = const value_type&;
 
@@ -3840,9 +3840,9 @@ namespace std {
   class regex_token_iterator {
   public:
     using regex_type        = basic_regex<charT, traits>;
-    using iterator_category = std::forward_iterator_tag;
+    using iterator_category = forward_iterator_tag;
     using value_type        = sub_match<BidirectionalIterator>;
-    using difference_type   = std::ptrdiff_t;
+    using difference_type   = ptrdiff_t;
     using pointer           = const value_type*;
     using reference         = const value_type&;
 
@@ -3854,7 +3854,7 @@ namespace std {
                           regex_constants::match_default);
     regex_token_iterator(BidirectionalIterator a, BidirectionalIterator b, 
                         const regex_type& re, 
-                        const std::vector<int>& submatches, 
+                        const vector<int>& submatches, 
                         regex_constants::match_flag_type m =
                           regex_constants::match_default);
     regex_token_iterator(BidirectionalIterator a, BidirectionalIterator b,
@@ -3862,7 +3862,7 @@ namespace std {
                         initializer_list<int> submatches,
                         regex_constants::match_flag_type m =
                           regex_constants::match_default);
-    template <std::size_t N>
+    template <size_t N>
       regex_token_iterator(BidirectionalIterator a, BidirectionalIterator b, 
                         const regex_type& re, 
                         const int (&submatches)[N], 
@@ -3875,7 +3875,7 @@ namespace std {
                            regex_constants::match_default) = delete;
     regex_token_iterator(BidirectionalIterator a, BidirectionalIterator b,
                          const regex_type&& re,
-                         const std::vector<int>& submatches,
+                         const vector<int>& submatches,
                          regex_constants::match_flag_type m =
                            regex_constants::match_default) = delete;
     regex_token_iterator(BidirectionalIterator a, BidirectionalIterator b,
@@ -3883,7 +3883,7 @@ namespace std {
                          initializer_list<int> submatches,
                          regex_constants::match_flag_type m =
                            regex_constants::match_default) = delete;
-    template <std::size_t N>
+    template <size_t N>
     regex_token_iterator(BidirectionalIterator a, BidirectionalIterator b,
                          const regex_type&& re,
                          const int (&submatches)[N],
@@ -3904,8 +3904,8 @@ namespace std {
     position_iterator position;                                 // \expos
     const value_type* result;                                   // \expos
     value_type suffix;                                          // \expos
-    std::size_t N;                                              // \expos
-    std::vector<int> subs;                                      // \expos
+    size_t N;                                                   // \expos
+    vector<int> subs;                                           // \expos
   };
 }
 \end{codeblock}
@@ -3952,7 +3952,7 @@ regex_token_iterator(BidirectionalIterator a, BidirectionalIterator b,
 
 regex_token_iterator(BidirectionalIterator a, BidirectionalIterator b, 
                     const regex_type& re, 
-                    const std::vector<int>& submatches, 
+                    const vector<int>& submatches, 
                     regex_constants::match_flag_type m =
                      regex_constants::match_default); 
 
@@ -3962,7 +3962,7 @@ regex_token_iterator(BidirectionalIterator a, BidirectionalIterator b,
                     regex_constants::match_flag_type m =
                       regex_constants::match_default);
 
-template <std::size_t N>
+template <size_t N>
   regex_token_iterator(BidirectionalIterator a, BidirectionalIterator b, 
                     const regex_type& re, 
                     const int (&submatches)[N],

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -389,7 +389,7 @@ objects that do not represent a thread of
 execution~(\ref{thread.thread.class}). Each thread of execution has an
 associated \tcode{thread::id} object that is not equal to the
 \tcode{thread::id} object of any other thread of execution and that is not
-equal to the \tcode{thread::id} object of any \tcode{std::thread} object that
+equal to the \tcode{thread::id} object of any \tcode{thread} object that
 does not represent threads of execution.
 
 \pnum
@@ -536,7 +536,7 @@ of \tcode{f} will be thrown in the constructing thread, not the new thread. \end
 invocation of
 \tcode{\textit{INVOKE}(\textit{DECAY_COPY}(}
 \tcode{std::forward<F>(f)), \textit{DECAY_COPY}(std::forward<Args>(args))...)}
-terminates with an uncaught exception, \tcode{std::terminate} shall be called.
+terminates with an uncaught exception, \tcode{terminate} shall be called.
 
 
 \pnum\sync The completion of the invocation of the constructor
@@ -579,7 +579,7 @@ value of \tcode{x.get_id()} prior to the start of construction.
 
 \begin{itemdescr}
 \pnum
-If \tcode{joinable()}, calls \tcode{std::terminate()}. Otherwise, has no effects.
+If \tcode{joinable()}, calls \tcode{terminate()}. Otherwise, has no effects.
 \begin{note} Either implicitly detaching or joining a \tcode{joinable()} thread in its
 destructor could result in difficult to debug correctness (for detach) or performance
 (for join) bugs encountered only when an exception is thrown. Thus the programmer must
@@ -596,7 +596,7 @@ thread& operator=(thread&& x) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects If \tcode{joinable()}, calls \tcode{std::terminate()}. Otherwise, assigns the
+\effects If \tcode{joinable()}, calls \tcode{terminate()}. Otherwise, assigns the
 state of \tcode{x} to \tcode{*this} and sets \tcode{x} to a default constructed state.
 
 \pnum
@@ -655,7 +655,7 @@ an exception is required~(\ref{thread.req.exception}).
 \errors
 \begin{itemize}
 \item \tcode{resource_deadlock_would_occur} --- if deadlock is detected or
-\tcode{get_id() == std::this_thread::get_id()}.
+\tcode{get_id() == this_thread::get_id()}.
 
 \item \tcode{no_such_process} --- if the thread is not valid.
 
@@ -869,9 +869,9 @@ recursive and non-recursive mutexes are supplied.
 \rSec3[thread.mutex.requirements.mutex]{Mutex types}
 
 \pnum
-The \defn{mutex types} are the standard library types \tcode{std::mutex},
-\tcode{std::recursive_mutex}, \tcode{std::timed_mutex}, \tcode{std::recursive_timed_mutex},
-\tcode{std::shared_mutex}, and \tcode{std::shared_timed_mutex}.
+The \defn{mutex types} are the standard library types \tcode{mutex},
+\tcode{recursive_mutex}, \tcode{timed_mutex}, \tcode{recursive_timed_mutex},
+\tcode{shared_mutex}, and \tcode{shared_timed_mutex}.
 They shall meet the requirements set out in this section. In this description, \tcode{m}
 denotes an object of a mutex type.
 
@@ -911,8 +911,8 @@ The expression \tcode{m.lock()} shall be well-formed and have the following sema
 
 \begin{itemdescr}
 \pnum
-\requires If \tcode{m} is of type \tcode{std::mutex}, \tcode{std::timed_mutex},
-\tcode{std::shared_mutex}, or \tcode{std::shared_timed_mutex}, the calling
+\requires If \tcode{m} is of type \tcode{mutex}, \tcode{timed_mutex},
+\tcode{shared_mutex}, or \tcode{shared_timed_mutex}, the calling
 thread does not own the mutex.
 
 \pnum
@@ -947,8 +947,8 @@ The expression \tcode{m.try_lock()} shall be well-formed and have the following 
 
 \begin{itemdescr}
 \pnum
-\requires If \tcode{m} is of type \tcode{std::mutex}, \tcode{std::timed_mutex},
-\tcode{std::shared_mutex}, or \tcode{std::shared_timed_mutex}, the calling
+\requires If \tcode{m} is of type \tcode{mutex}, \tcode{timed_mutex},
+\tcode{shared_mutex}, or \tcode{shared_timed_mutex}, the calling
 thread does not own the mutex.
 
 \pnum
@@ -1112,8 +1112,8 @@ The behavior of a program is undefined if:
 \rSec3[thread.timedmutex.requirements]{Timed mutex types}
 
 \pnum
-The \defn{timed mutex types} are the standard library types \tcode{std::timed_mutex},
-\tcode{std::recursive_timed_mutex}, and \tcode{std::shared_timed_mutex}. They shall
+The \defn{timed mutex types} are the standard library types \tcode{timed_mutex},
+\tcode{recursive_timed_mutex}, and \tcode{shared_timed_mutex}. They shall
 meet the requirements set out below.
 In this description, \tcode{m} denotes an object of a mutex type,
 \tcode{rel_time} denotes an object of an
@@ -1131,8 +1131,8 @@ following semantics:
 
 \begin{itemdescr}
 \pnum
-\requires If \tcode{m} is of type \tcode{std::timed_mutex} or
-\tcode{std::shared_timed_mutex}, the calling thread does not
+\requires If \tcode{m} is of type \tcode{timed_mutex} or
+\tcode{shared_timed_mutex}, the calling thread does not
 own the mutex.
 
 \pnum
@@ -1165,8 +1165,8 @@ following semantics:
 
 \begin{itemdescr}
 \pnum
-\requires If \tcode{m} is of type \tcode{std::timed_mutex} or
-\tcode{std::shared_timed_mutex}, the calling thread does not own the
+\requires If \tcode{m} is of type \tcode{timed_mutex} or
+\tcode{shared_timed_mutex}, the calling thread does not own the
 mutex.
 
 \pnum
@@ -1310,7 +1310,7 @@ The behavior of a program is undefined if:
 \rSec3[thread.sharedmutex.requirements]{Shared mutex types}
 
 \pnum
-The standard library types \tcode{std::shared_mutex} and \tcode{std::shared_timed_mutex}
+The standard library types \tcode{shared_mutex} and \tcode{shared_timed_mutex}
 are \defn{shared mutex types}. Shared mutex types shall meet the requirements of
 mutex types~(\ref{thread.mutex.requirements.mutex}), and additionally
 shall meet the requirements set out below. In this description,
@@ -1464,7 +1464,7 @@ The behavior of a program is undefined if:
 \rSec3[thread.sharedtimedmutex.requirements]{Shared timed mutex types}
 
 \pnum
-The standard library type \tcode{std::shared_timed_mutex} is a
+The standard library type \tcode{shared_timed_mutex} is a
 \defn{shared timed mutex type}. Shared timed mutex types shall meet the requirements of
 timed mutex types~(\ref{thread.timedmutex.requirements}),
 shared mutex types~(\ref{thread.sharedmutex.requirements}), and additionally
@@ -2935,7 +2935,7 @@ or a call to \tcode{notify_all()}, or spuriously.
 
 \pnum
 \remarks
-If the function fails to meet the postcondition, \tcode{std::terminate()}
+If the function fails to meet the postcondition, \tcode{terminate()}
 shall be called~(\ref{except.terminate}).
 \begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
 
@@ -2974,7 +2974,7 @@ while (!pred())
 
 \pnum
 \remarks
-If the function fails to meet the postcondition, \tcode{std::terminate()}
+If the function fails to meet the postcondition, \tcode{terminate()}
 shall be called~(\ref{except.terminate}).
 \begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
 
@@ -3025,7 +3025,7 @@ If the function exits via an exception, \tcode{lock.lock()} shall be called prio
 
 \pnum
 \remarks
-If the function fails to meet the postcondition, \tcode{std::terminate()}
+If the function fails to meet the postcondition, \tcode{terminate()}
 shall be called~(\ref{except.terminate}).
 \begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
 
@@ -3074,7 +3074,7 @@ otherwise \tcode{cv_status::no_timeout}.
 
 \pnum
 \remarks
-If the function fails to meet the postcondition, \tcode{std::terminate()}
+If the function fails to meet the postcondition, \tcode{terminate()}
 shall be called~(\ref{except.terminate}).
 \begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
 
@@ -3119,7 +3119,7 @@ return true;
 
 \pnum
 \remarks
-If the function fails to meet the postcondition, \tcode{std::terminate()}
+If the function fails to meet the postcondition, \tcode{terminate()}
 shall be called~(\ref{except.terminate}).
 \begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
 
@@ -3171,7 +3171,7 @@ timeout has already expired. \end{note}
 
 \pnum
 \remarks
-If the function fails to meet the postcondition, \tcode{std::terminate()}
+If the function fails to meet the postcondition, \tcode{terminate()}
 shall be called~(\ref{except.terminate}).
 \begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
 
@@ -3317,7 +3317,7 @@ a call to \tcode{notify_all()}, or spuriously.
 
 \pnum
 \remarks
-If the function fails to meet the postcondition, \tcode{std::terminate()}
+If the function fails to meet the postcondition, \tcode{terminate()}
 shall be called~(\ref{except.terminate}).
 \begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
 
@@ -3369,7 +3369,7 @@ If the function exits via an exception, \tcode{lock.lock()} shall be called prio
 
 \pnum
 \remarks
-If the function fails to meet the postcondition, \tcode{std::terminate()}
+If the function fails to meet the postcondition, \tcode{terminate()}
 shall be called~(\ref{except.terminate}).
 \begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
 
@@ -3407,7 +3407,7 @@ otherwise \tcode{cv_status::no_timeout}.
 
 \pnum
 \remarks
-If the function fails to meet the postcondition, \tcode{std::terminate()}
+If the function fails to meet the postcondition, \tcode{terminate()}
 shall be called~(\ref{except.terminate}).
 \begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
 
@@ -4726,7 +4726,7 @@ in this International Standard nor by the implementation, the behavior is undefi
 \returns An object of type
 \tcode{future<result_of_t<decay_t<F>(decay_t<Args>...)>{>}} that refers
 to the shared state created by this call to \tcode{async}.
-\begin{note} If a future obtained from \tcode{std::async} is moved outside the local scope,
+\begin{note} If a future obtained from \tcode{async} is moved outside the local scope,
 other code that uses the future must be aware that the future's destructor may
 block for the shared state to become ready. \end{note}
 
@@ -4886,7 +4886,7 @@ a copy of \tcode{f} shall behave the same as invoking \tcode{f}.
 \pnum
 \remarks
 These constructors shall not participate in overload resolution if \tcode{decay_t<F>}
-is the same type as \tcode{std::packaged_task<R(ArgTypes...)>}.
+is the same type as \tcode{packaged_task<R(ArgTypes...)>}.
 
 \pnum
 \effects Constructs a new \tcode{packaged_task} object with a shared state and
@@ -4899,9 +4899,9 @@ internal data structures.
 \begin{itemize}
 \item Any exceptions thrown by the copy or move constructor of \tcode{f}.
 \item For the first version,
-   \tcode{std::bad_alloc} if memory for the internal data structures could not be allocated.
+   \tcode{bad_alloc} if memory for the internal data structures could not be allocated.
 \item For the second version,
-   any exceptions thrown by \tcode{std::allocator_traits<Allocator>::template}
+   any exceptions thrown by \tcode{allocator_traits<Allocator>::template}
    \tcode{rebind_traits<\unspec>::allocate}.
 \end{itemize}
 \end{itemdescr}


### PR DESCRIPTION
The standard library specifies that references to its names are assumed to be prefixed by '::std::'. Therefore, we can remove any explicit 'std::' prefixes.

[iterator.range] was not touched, because it is unclear whether argument-dependent lookup was intended to be disabled here.

Fixes #431.