### PR TITLE
[library] Use \effects etc. when referring to them in text

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -1082,7 +1082,7 @@ of a random-access iterator~(\ref{random.access.iterators}).
 
 \pnum
 If an algorithm's
-\synopsis{Effects}
+\effects
 section says that a value pointed to by any iterator passed
 as an argument is modified, then that algorithm has an additional
 type requirement:

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -487,7 +487,7 @@ preconditions, there will be no \requires paragraph.}
 \item \throws any exceptions thrown by the function, and the conditions that would cause the exception
 \item \complexity the time and/or space complexity of the function
 \item \remarks additional semantic constraints on the function
-\item \errors the error conditions for error codes reported by the function.
+\item \errors the error conditions for error codes reported by the function
 \item \realnotes non-normative comments about the function
 \end{itemize}
 

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -476,7 +476,7 @@ Descriptions of function semantics contain the following elements (as
 appropriate):\footnote{To save space, items that do not apply to a function are omitted.
 For example, if a function does not specify any
 further
-preconditions, there will be no ``Requires'' paragraph.}
+preconditions, there will be no \requires paragraph.}
 
 \begin{itemize}
 \item \requires the preconditions for calling the function
@@ -950,7 +950,7 @@ support multiple configurations of the library.}
 Whenever a name \tcode{x} defined in the standard library is mentioned,
 the name \tcode{x} is assumed to be fully qualified as
 \tcode{::std::x},
-unless explicitly described otherwise. For example, if the Effects section
+unless explicitly described otherwise. For example, if the \effects section
 for library function \tcode{F} is described as calling library function \tcode{G},
 the function
 \tcode{::std::G}
@@ -2892,7 +2892,7 @@ described as synonyms for basic integral types, such as
 Any of the functions defined in the \Cpp standard library
 \indextext{library!C++ standard}%
 can report a failure by throwing an exception of a type described in its
-\synopsis{Throws:}
+\throws
 paragraph.
 An implementation may strengthen the
 exception specification
@@ -2901,8 +2901,8 @@ non-virtual
 function by adding a non-throwing \grammarterm{noexcept-specification}.
 
 \pnum
-A function may throw an object of a type not listed in its \synopsis{Throws}
-clause if its type is derived from a type named in the \synopsis{Throws} clause
+A function may throw an object of a type not listed in its \throws
+clause if its type is derived from a type named in the \throws clause
 and would be caught by an exception handler for the base type.
 
 \pnum

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -10450,7 +10450,7 @@ for which:
 
 \begin{itemize}
   \item
-  the function description's \emph{Returns} clause
+  the function description's \returns clause
   explicitly specifies a domain
   and those argument values fall
   outside the specified domain,


### PR DESCRIPTION
Fixes #1091.