### PR TITLE
[futures.overview], [futures.async] Use 'bitmask type' terminology.

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -3540,7 +3540,7 @@ namespace std {
 
 \pnum
 The \tcode{enum} type \tcode{launch} is a bitmask type~(\ref{bitmask.types}) with
-\tcode{launch::async} and \tcode{launch::deferred} denoting individual bits.
+elements \tcode{launch::async} and \tcode{launch::deferred}.
 \begin{note} Implementations can provide bitmasks to specify restrictions on task
 interaction by functions launched by \tcode{async()} applicable to a
 corresponding subset of available launch policies. Implementations can extend
@@ -4649,8 +4649,8 @@ the corresponding policies):
 
 \begin{itemize}
 \item
-If \tcode{policy \& launch::async} is non-zero --- calls
-\tcode{\textit{INVOKE}(\textit{DECAY_COPY}(std::forward<F>(f)),}\\ 
+If \tcode{launch::async} is set in \tcode{policy}, calls
+\tcode{\textit{INVOKE}(\textit{DECAY_COPY}(std::forward<F>(f)),}
 \tcode{\textit{DECAY_COPY}(std::forward<Args>(args))...)}
 (\ref{func.require}, \ref{thread.thread.constr})
 as if in a new thread of execution represented by a \tcode{thread} object
@@ -4668,8 +4668,8 @@ and affects the behavior of any asynchronous return objects that
 reference that state.
 
 \item
-If \tcode{policy \& launch::deferred} is non-zero ---
-Stores \tcode{\textit{DECAY_COPY}(std::forward<F>(f))} and\\
+If \tcode{launch::deferred} is set in \tcode{policy},
+stores \tcode{\textit{DECAY_COPY}(std::forward<F>(f))} and
 \tcode{\textit{DECAY_COPY}(std::forward<Args>(args))...}
 in the shared state. These copies of \tcode{f} and \tcode{args} constitute
 a \defn{deferred function}. Invocation of the deferred function evaluates


### PR DESCRIPTION
Fixes #826.