### PR TITLE
[class.copy] Rephrase rule preferring a move constructor

### DIFF
--- a/source/special.tex
+++ b/source/special.tex
@@ -3203,17 +3203,23 @@ move construction from the local automatic object to \tcode{t2} that is elided.
 \end{example}
 
 \pnum
-When the criteria for elision of a copy/move operation are met,
-but not for an \nonterminal{exception-declaration},
-and the object
-to be copied is designated by an lvalue,
-or when the \grammarterm{expression} in a \tcode{return} statement
+In the following copy-initialization contexts, a move operation might be used instead of a copy operation:
+\begin{itemize}
+\item If the \grammarterm{expression} in a \tcode{return} statement~(\ref{stmt.return})
 is a (possibly parenthesized) \grammarterm{id-expression}
 that names an object with automatic storage duration declared in the body
 or \grammarterm{parameter-declaration-clause} of the innermost enclosing
-function or \grammarterm{lambda-expression},
+function or \grammarterm{lambda-expression}, or
+
+\item if the operand of a \grammarterm{throw-expression}~(\ref{expr.throw})
+is the name of a non-volatile automatic object
+(other than a function or catch-clause parameter)
+whose scope does not extend beyond the end of the innermost enclosing
+\grammarterm{try-block} (if there is one),
+\end{itemize}
 overload resolution to select the constructor
-for the copy is first performed as if the object were designated by an rvalue.
+for the copy is first performed as if the object were designated by an
+rvalue.
 If the first overload resolution fails or was not performed,
 or if the type of the first parameter of the selected
 constructor is not an rvalue reference to the object's type (possibly cv-qualified),
@@ -3224,6 +3230,8 @@ of whether copy elision will occur. It determines the constructor to be called i
 elision is not performed, and the selected constructor must be accessible even if
 the call is elided.
 \end{note}
+
+\pnum
 \begin{example}
 \begin{codeblock}
 class Thing {


### PR DESCRIPTION
in a throw-expression or a return statement.

Fixes #712.