### PR TITLE
[styles] Give lists uniform vertical spacing.

### DIFF
--- a/source/macros.tex
+++ b/source/macros.tex
@@ -353,7 +353,7 @@
 %%--------------------------------------------------
 %% Indented text
 \newenvironment{indented}
-{\list{}{}\item\relax}
+{\list{}{\setlength{\parsep}{\parskip}}\item\relax}
 {\endlist}
 
 %%--------------------------------------------------
@@ -455,6 +455,7 @@
 	\setlength{\leftmargin}{\bnfindentrest}
 	\setlength{\listparindent}{-\bnfindentinc}
 	\setlength{\itemindent}{\listparindent}
+        \setlength{\parsep}{1ex}
 	}
  \BnfNontermshape
  \item\relax

--- a/source/styles.tex
+++ b/source/styles.tex
@@ -98,7 +98,21 @@
 % set style for main text
 \setlength{\parindent}{0pt}
 \setlength{\parskip}{1ex}
-\setlength{\partopsep}{-1.5ex}
+\setlength{\partopsep}{0pt}
+
+\AtBeginDocument{
+  \setlength{\parsepi}{0pt}
+  \setlength{\parsepii}{0pt}
+  \setlength{\partopsepii}{0pt}
+  \setlength{\partopsepiii}{0pt}
+  \setlength{\itemsepi}{\parskip}
+  \setlength{\itemsepii}{\parskip} %% A bug in memoir makes this ineffective
+  \setlength{\itemsepiii}{\parskip}
+  \setlength{\topsepi}{0pt}
+  \setlength{\topsepii}{\parskip}
+  \setlength{\topsepiii}{\parskip}
+  \setlength{\itemsep}{\parskip}
+}
 
 %%--------------------------------------------------
 %%  set caption style and delimiter


### PR DESCRIPTION
This change makes it so that the vertical space surrounding lists is independent of whether there is a paragraph break before the list (by setting partopsep to zero).

Moreover, all nested lists now use the same vertical spacing, which in turn is the same as the paragraph spacing.

There is a bug in memoir that may cause second-level lists (lists within a top-level list) to be rendered too tightly (because the itemsepii length is ignored). This can be fixed locally, though.