### PR TITLE
[istream], [ostream] Remove paragraph numbers in cross-references.

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -4851,8 +4851,7 @@ basic_istream<charT, traits>& operator>>
 \begin{itemdescr}
 \pnum
 \effects
-Behaves as an unformatted input function (as described
-in~\ref{istream.unformatted}, paragraph 1).
+Behaves as an unformatted input function (\ref{istream.unformatted}).
 If \tcode{sb} is null, calls
 \tcode{setstate(fail\-bit)},
 which may throw
@@ -4950,7 +4949,7 @@ streamsize gcount() const;
 \effects
 None.
 This member function does not behave as an unformatted
-input function (as described in~\ref{istream.unformatted}, paragraph 1).
+input function (as described above).
 
 \pnum
 \returns
@@ -4967,7 +4966,7 @@ int_type get();
 \pnum
 \effects
 Behaves as an unformatted input function
-(as described in~\ref{istream.unformatted}, paragraph 1).
+(as described above).
 After constructing a sentry object, extracts
 a character \tcode{c}, if one is available.
 Otherwise, the function calls
@@ -4991,7 +4990,7 @@ basic_istream<charT, traits>& get(char_type& c);
 \pnum
 \effects
 Behaves as an unformatted input function
-(as described in~\ref{istream.unformatted}, paragraph 1).
+(as described above).
 After constructing a sentry object, extracts
 a character, if one is available, and assigns it to \tcode{c}.\footnote{Note
 that this function is not overloaded on types
@@ -5018,7 +5017,7 @@ basic_istream<charT, traits>& get(char_type* s, streamsize n,
 \pnum
 \effects
 Behaves as an unformatted input function
-(as described in~\ref{istream.unformatted}, paragraph 1).
+(as described above).
 After constructing a sentry object, extracts
 characters and stores them
 into successive locations of an array whose first element is designated by
@@ -5081,7 +5080,7 @@ basic_istream<charT, traits>& get(basic_streambuf<char_type, traits>& sb,
 \pnum
 \effects
 Behaves as an unformatted input function
-(as described in~\ref{istream.unformatted}, paragraph 1).
+(as described above).
 After constructing a sentry object, extracts
 characters and inserts them
 in the output sequence controlled by
@@ -5139,7 +5138,7 @@ basic_istream<charT, traits>& getline(char_type* s, streamsize n,
 \pnum
 \effects
 Behaves as an unformatted input function
-(as described in~\ref{istream.unformatted}, paragraph 1).
+(as described above).
 After constructing a sentry object, extracts
 characters and stores them
 into successive locations of an array whose first element is designated by
@@ -5244,7 +5243,7 @@ basic_istream<charT, traits>&
 \pnum
 \effects
 Behaves as an unformatted input function
-(as described in~\ref{istream.unformatted}, paragraph 1).
+(as described above).
 After constructing a sentry object, extracts
 characters and discards them.
 Characters are extracted until any of the following occurs:
@@ -5284,7 +5283,7 @@ int_type peek();
 \pnum
 \effects
 Behaves as an unformatted input function
-(as described in~\ref{istream.unformatted}, paragraph 1).
+(as described above).
 After constructing a sentry object, reads but does not extract
 the current input character.
 
@@ -5307,7 +5306,7 @@ basic_istream<charT, traits>& read(char_type* s, streamsize n);
 \begin{itemdescr}
 \pnum
 \effects
-Behaves as an unformatted input function (as described in~\ref{istream.unformatted}, paragraph 1).
+Behaves as an unformatted input function (as described above).
 After constructing
 a sentry object, if
 \tcode{!good()}
@@ -5346,7 +5345,7 @@ streamsize readsome(char_type* s, streamsize n);
 \begin{itemdescr}
 \pnum
 \effects
-Behaves as an unformatted input function (as described in~\ref{istream.unformatted}, paragraph 1).
+Behaves as an unformatted input function (as described above).
 After constructing
 a sentry object, if
 \tcode{!good()}
@@ -5389,8 +5388,7 @@ basic_istream<charT, traits>& putback(char_type c);
 \begin{itemdescr}
 \pnum
 \effects
-Behaves as an unformatted input function (as described in~\ref{istream.unformatted}, paragraph
-1), except that the function first clears \tcode{eofbit}.
+Behaves as an unformatted input function (as described above), except that the function first clears \tcode{eofbit}.
 After constructing
 a sentry object, if
 \tcode{!good()}
@@ -5432,8 +5430,7 @@ basic_istream<charT, traits>& unget();
 \begin{itemdescr}
 \pnum
 \effects
-Behaves as an unformatted input function (as described in~\ref{istream.unformatted}, paragraph
-1), except that the function first clears \tcode{eofbit}.
+Behaves as an unformatted input function (as described above), except that the function first clears \tcode{eofbit}.
 After constructing
 a sentry object, if
 \tcode{!good()}
@@ -5475,7 +5472,7 @@ int sync();
 \begin{itemdescr}
 \pnum
 \effects
-Behaves as an unformatted input function (as described in~\ref{istream.unformatted}, paragraph 1), except that it does not
+Behaves as an unformatted input function (as described above), except that it does not
 count the number of characters extracted and does not affect the
 value returned by subsequent calls to
 \tcode{gcount()}.
@@ -5503,7 +5500,7 @@ pos_type tellg();
 \begin{itemdescr}
 \pnum
 \effects
-Behaves as an unformatted input function (as described in~\ref{istream.unformatted}, paragraph 1), except that it does not count
+Behaves as an unformatted input function (as described above), except that it does not count
 the number of characters extracted and does not affect the value
 returned by subsequent calls to
 \tcode{gcount()}.
@@ -5527,7 +5524,7 @@ basic_istream<charT, traits>& seekg(pos_type pos);
 \begin{itemdescr}
 \pnum
 \effects
-Behaves as an unformatted input function (as described in~\ref{istream.unformatted}, paragraph 1), except that
+Behaves as an unformatted input function (as described above), except that
 the function first clears \tcode{eofbit},
 it does not count
 the number of characters extracted, and it does not affect the value
@@ -5555,8 +5552,7 @@ basic_istream<charT, traits>& seekg(off_type off, ios_base::seekdir dir);
 \begin{itemdescr}
 \pnum
 \effects
-Behaves as an unformatted input function (as described in~\ref{istream.unformatted}, paragraph
-1), except that the function first clears \tcode{eofbit},
+Behaves as an unformatted input function (as described above), except that the function first clears \tcode{eofbit},
 does not count the number of characters extracted, and
 does not affect the value returned by subsequent calls to \tcode{gcount()}.
 After constructing a sentry object, if
@@ -5582,8 +5578,7 @@ template <class charT, class traits>
 \begin{itemdescr}
 \pnum
 \effects
-Behaves as an unformatted input function (as described in~\ref{istream.unformatted},
-paragraph 1), except that it does not count the number of characters extracted and
+Behaves as an unformatted input function (\ref{istream.unformatted}), except that it does not count the number of characters extracted and
 does not affect the value returned by subsequent calls to is.gcount(). After
 constructing a sentry object extracts characters as long as the next available
 character \tcode{c} is whitespace or until there are no more characters in the sequence.
@@ -6382,7 +6377,7 @@ basic_ostream<charT, traits>& operator<<
 \begin{itemdescr}
 \pnum
 \effects
-Behaves as an unformatted output function (as described in~\ref{ostream.unformatted}, paragraph 1).
+Behaves as an unformatted output function (\ref{ostream.unformatted}).
 After the sentry object is
 constructed, if
 \tcode{sb} is null calls
@@ -6568,7 +6563,7 @@ basic_ostream<charT, traits>& put(char_type c);
 \begin{itemdescr}
 \pnum
 \effects
-Behaves as an unformatted output function (as described in~\ref{ostream.unformatted}, paragraph 1).
+Behaves as an unformatted output function (as described above).
 After constructing a sentry
 object, inserts
 the character \tcode{c}, if possible.\footnote{Note that this function is not overloaded on types
@@ -6595,7 +6590,7 @@ basic_ostream& write(const char_type* s, streamsize n);
 \begin{itemdescr}
 \pnum
 \effects
-Behaves as an unformatted output function (as described in~\ref{ostream.unformatted}, paragraph 1).  After constructing a sentry
+Behaves as an unformatted output function (as described above).  After constructing a sentry
 object, obtains
 characters to insert from
 successive locations of an array whose first element is designated by
@@ -6627,7 +6622,7 @@ basic_ostream& flush();
 
 \begin{itemdescr}
 \pnum
-\effects Behaves as an unformatted output function (as described in~\ref{ostream.unformatted}, paragraph 1).
+\effects Behaves as an unformatted output function (as described above).
 If
 \tcode{rdbuf()}
 is not a null pointer,
@@ -7746,7 +7741,7 @@ Table~\ref{tab:iostreams.newoff.values}.
 If
 \tcode{(newoff + off) < 0},
 or if \tcode{newoff + off} refers to an uninitialized
-character (as defined in~\ref{stringbuf.members} paragraph 1),
+character (\ref{stringbuf.members}),
 the positioning operation fails.
 Otherwise, the function assigns
 \tcode{xbeg + newoff + off}


### PR DESCRIPTION
Also replace cross-references referring to their own section with 'above'.

Fixes #702.