### PR TITLE
[quoted.manip] operator>> is not a member of basic_istream.

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -7189,8 +7189,8 @@ template <class charT, class traits, class Allocator>
 and \tcode{traits}, respectively, then the expression
 \tcode{in \shr\ quoted(s, delim, escape)} behaves as if it extracts the following
 characters from \tcode{in} using
-\tcode{basic_istream::operator\shr}~(\ref{istream.extractors})
-which may throw \tcode{ios_base::failure}\brk{}~(\ref{ios::failure}):
+\tcode{operator\shr(basic_istream<charT, traits>\&, charT\&)}~(\ref{istream.extractors})
+which may throw \tcode{ios_base::failure}~(\ref{ios::failure}):
 \begin{itemize}
 \item If the first character extracted is equal to \tcode{delim}, as
 determined by \tcode{traits_type::eq}, then:


### PR DESCRIPTION
Fixes #729.