### PR TITLE
[iterator.requirements.general] Rephrase definition of 'writable to'

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -37,28 +37,24 @@ Iterators are a generalization of pointers that allow a \Cpp program to work wit
 To be able to construct template algorithms that work correctly and
 efficiently on different types of data structures, the library formalizes not just the interfaces but also the
 semantics and complexity assumptions of iterators.
-All input iterators
+An input iterator
 \tcode{i}
-support the expression
+supports the expression
 \tcode{*i},
 resulting in a value of some object type
 \tcode{T},
 called the
 \term{value type}
 of the iterator.
-All output iterators support the expression
-\tcode{*i = o}
-where
-\tcode{o}
-is a value of some type that is in the set of types that are
-\term{writable}
-to the particular iterator type of
-\tcode{i}.
-All iterators
+An output iterator \tcode{i} has a non-empty set of types that are
+\defn{writable} to the iterator;
+for each such type \tcode{T}, the expression \tcode{*i = o}
+is valid where \tcode{o} is a value of type \tcode{T}.
+An iterator
 \tcode{i}
 for which the expression
 \tcode{(*i).m}
-is well-defined, support the expression
+is well-defined supports the expression
 \tcode{i->m}
 with the same semantics as
 \tcode{(*i).m}.


### PR DESCRIPTION
for output iterators.

Fixes #698.