### PR TITLE
[macros, basic, streambuf] Retire enumeraten environment in favour of…

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -894,7 +894,7 @@ A name with global namespace scope is said to be a
 \indextext{scope!class}%
 The following rules describe the scope of names declared in classes.
 
-\begin{enumeraten}
+\begin{enumerate}
 \item The potential scope of a name declared in a class consists not
 only of the declarative region following the name's point of
 declaration, but also of all function bodies, default arguments,
@@ -944,7 +944,7 @@ class D {
 };
 \end{codeblock}
 \end{example}
-\end{enumeraten}
+\end{enumerate}
 
 \pnum
 The name of a class member shall only be used as follows:

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -3984,7 +3984,7 @@ argument character sequence.
 \requires
 Every overriding definition of this virtual function
 shall obey the following constraints:
-\begin{enumeraten}
+\begin{enumerate}
 \item
 The effect of consuming a character on the associated output sequence is
 specified\footnote{That is, for each class derived from an instance of
@@ -4026,7 +4026,7 @@ if it is unable to establish
 and
 \tcode{pptr()}
 according to the above rules.
-\end{enumeraten}
+\end{enumerate}
 
 \pnum
 \returns

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -518,16 +518,6 @@
  \end{enumerate}
 }
 
-% enumerate with arabic numbers
-\newenvironment{enumeraten}
-{
- \renewcommand{\labelenumi}{\arabic{enumi})}
- \begin{enumerate}
-}
-{
- \end{enumerate}
-}
-
 %%--------------------------------------------------
 %% Definitions section
 % usage: \definition{name}{xref}


### PR DESCRIPTION
Only visual difference between enumeraten (which is only used twice) and enumerate is that the former shows item numbers as "1)" while the latter shows them as "1."

Also see #1102 