### PR TITLE
[sequence.reqmts] Remove redundant 'forward iterator' requirement

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -926,12 +926,6 @@ The complexities of the expressions are sequence dependent.
 \end{libreqtab3}
 
 \pnum
-\tcode{iterator}
-and
-\tcode{const_iterator}
-types for sequence containers shall be at least of the forward iterator category.
-
-\pnum
 The iterator returned from
 \tcode{a.insert(p, t)}
 points to the copy of


### PR DESCRIPTION
for sequence containers.

Any container is nowadays required to have forward iterators;
see the table entries for X::iterator and X::const_iterator in
[container.requirements.general].

Fixes #461.