### PR TITLE
[temp.deduct.call] Add example involving cv-qualifiers and references.

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -6239,7 +6239,16 @@ If
 is a reference type, the type
 referred to by
 \tcode{P}
-is used for type deduction.
+is used for type deduction. \begin{example}
+\begin{codeblock}
+template<class T> int f(const T&);
+int n1 = f(5);                  // calls \tcode{f<int>(const int\&)}
+const int i = 0;
+int n2 = f(i);                  // calls \tcode{f<int>(const int\&)}
+template <class T> int g(volatile T&);
+int n3 = g(i);                  // calls \tcode{g<const int>(const volatile int\&)}
+\end{codeblock}
+\end{example}%
 A \defn{forwarding reference}
 is an rvalue reference to a cv-unqualified template parameter.
 If \tcode{P} is a forwarding reference and the argument is an


### PR DESCRIPTION
Fixes #517.