### PR TITLE
[basic.def.odr] Avoid counting bullets in normative text.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -481,7 +481,7 @@ and
 \item in each definition of \tcode{D}, a default argument used by an
 (implicit or explicit) function call is treated as if its token sequence
 were present in the definition of \tcode{D}; that is, the default
-argument is subject to the three requirements described above (and, if
+argument is subject to the requirements described in this paragraph (and, if
 the default argument has sub-expressions with default arguments, this
 requirement applies recursively).\footnote{\ref{dcl.fct.default} 
 describes how default argument names are looked up.}


### PR DESCRIPTION
Fixes #944.