### PR TITLE
[streambuf.virtuals] Simplify the logic of exposition; remove several unneeded lists

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -3711,48 +3711,32 @@ to indicate failure.
 \pnum
 The
 \term{pending sequence}
-of characters is defined as the concatenation of:
-\begin{enumeratea}
-\item
-If
-\tcode{gptr()}
-is non-null, then the
+of characters is defined as the concatenation of
+\begin{itemize}
+\item the empty sequence if \tcode{gptr()} is null, otherwise the
 \tcode{egptr() - gptr()}
 characters starting at
 \tcode{gptr()},
-otherwise the empty sequence.
+followed by
 \item
-Some sequence (possibly empty) of characters read from the input sequence.
-\end{enumeratea}
+some (possibly empty) sequence of characters read from the input sequence.
+\end{itemize}
 
 \pnum
 The
 \term{result character}
 is
-\begin{enumeratea}
-\item
-If the pending sequence is non-empty, the first character of the sequence.
-\item
-If the pending sequence
-is
-empty then the next character that would be read from the input sequence.
-\end{enumeratea}
+the first character of the pending sequence if it is non-empty,
+otherwise
+the next character that would be read from the input sequence.
 
 \pnum
 The
 \term{backup sequence}
-is defined as the concatenation of:
-\begin{enumeratea}
-\item
-If
-\tcode{eback()}
-is null then empty,
-\item
-Otherwise the
+is the empty sequence if \tcode{eback()} is null, otherwise the
 \tcode{gptr() - eback()}
 characters beginning at
 \tcode{eback()}.
-\end{enumeratea}
 
 \pnum
 \effects
@@ -3760,48 +3744,40 @@ The function sets up the
 \tcode{gptr()}
 and
 \tcode{egptr()}
-satisfying one of:
-\begin{enumeratea}
-\item
-If the pending sequence is non-empty,
+such that
+if the pending sequence is non-empty, then
 \tcode{egptr()}
 is non-null and
 \tcode{egptr() - gptr()}
 characters starting at
 \tcode{gptr()}
-are the characters in the pending sequence
-\item
-If the pending sequence is empty, either
-\tcode{gptr()}
+are the characters in the pending sequence, otherwise
+either \tcode{gptr()}
 is null or
-\tcode{gptr()}
-and
-\tcode{egptr()}
-are set to the same non-null pointer value.
-\end{enumeratea}
+\tcode{gptr() ==  egptr()}.
 
 \pnum
 If
 \tcode{eback()}
 and
 \tcode{gptr()}
-are non-null then the function is not constrained as to their contents, but the ``usual backup condition'' is that either:
-\begin{enumeratea}
+are non-null then the function is not constrained as to their contents, but the ``usual backup condition'' is that either
+\begin{itemize}
 \item
-If the backup sequence contains at least
+the backup sequence contains at least
 \tcode{gptr() - eback()}
-characters, then the
+characters, in which case the
 \tcode{gptr() - eback()}
 characters starting at
 \tcode{eback()}
 agree with the last
 \tcode{gptr() - eback()}
-characters of the backup sequence.
+characters of the backup sequence, or
 \item
-Or the \tcode{n} characters starting at
+the \tcode{n} characters starting at
 \tcode{gptr() - n}
-agree with the backup sequence (where \tcode{n} is the length of the backup sequence)
-\end{enumeratea}
+agree with the backup sequence (where \tcode{n} is the length of the backup sequence).
+\end{itemize}
 
 \pnum
 \default
@@ -3952,22 +3928,19 @@ int_type overflow(int_type c = traits::eof());
 Consumes some initial subsequence of the characters of the
 \term{pending sequence}.
 The pending sequence is defined as the concatenation of
-\begin{enumeratea}
+\begin{itemize}
 \item
-if
-\tcode{pbase()}
-is null then the empty sequence otherwise,
+the empty sequence if \tcode{pbase()} is not null, otherwise the
 \tcode{pptr() - pbase()}
 characters beginning at
-\tcode{pbase()}.
+\tcode{pbase()}, followed by
 \item
+the empty sequence
 if
 \tcode{traits::eq_int_type(c, traits::eof())}
 returns
-\tcode{true},
-then the empty sequence
-otherwise, the sequence consisting of \tcode{c}.
-\end{enumeratea}
+\tcode{true}, otherwise the sequence consisting of \tcode{c}.
+\end{itemize}
 
 \pnum
 \remarks


### PR DESCRIPTION
Some of the logic in this section is needlessly convoluted. A slight rewrite makes the exposition more compact and fluent.

Before:

![image](https://cloud.githubusercontent.com/assets/6378233/20576337/7f7159de-b1b5-11e6-9b35-956b58ad804c.png)

After:

![image](https://cloud.githubusercontent.com/assets/6378233/20576383/acdaacea-b1b5-11e6-87b3-024acd2b5b9a.png)
