### PR TITLE
For some X, choose a consistent spelling between non-X vs. nonX.

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -1521,7 +1521,7 @@ starting from
 and proceeding to
 \tcode{last - 1}.
 \begin{note} If the type of \tcode{first} satisfies the
-requirements of a mutable iterator, \tcode{f} may apply nonconstant
+requirements of a mutable iterator, \tcode{f} may apply non-constant
 functions through the dereferenced iterator.\end{note}
 
 \pnum
@@ -1559,7 +1559,7 @@ Applies \tcode{f} to the result of dereferencing every iterator in the range
 \range{first}{last}.
 \begin{note}
 If the type of \tcode{first} satisfies the requirements of a mutable iterator,
-\tcode{f} may apply nonconstant functions through the dereferenced iterator.
+\tcode{f} may apply non-constant functions through the dereferenced iterator.
 \end{note}
 
 \pnum
@@ -1598,7 +1598,7 @@ Applies \tcode{f} to the result of dereferencing every iterator in the range
 \range{first}{first + n} in order.
 \begin{note}
 If the type of \tcode{first} satisfies the requirements of a mutable iterator,
-\tcode{f} may apply nonconstant functions through the dereferenced iterator.
+\tcode{f} may apply non-constant functions through the dereferenced iterator.
 \end{note}
 
 \pnum
@@ -1632,7 +1632,7 @@ Applies \tcode{f} to the result of dereferencing every iterator in the range
 \range{first}{first + n}.
 \begin{note}
 If the type of \tcode{first} satisfies the requirements of a mutable iterator,
-\tcode{f} may apply nonconstant functions through the dereferenced iterator.
+\tcode{f} may apply non-constant functions through the dereferenced iterator.
 \end{note}
 
 \pnum

--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -5217,7 +5217,7 @@ otherwise \tcode{v}.
 
 \pnum
 \begin{note}
-If NaN is avoided, \tcode{T} can be a floating point type.
+If NaN is avoided, \tcode{T} can be a floating-point type.
 \end{note}
 
 \pnum

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -474,7 +474,7 @@ and
 (implicit or explicit) function call is treated as if its token sequence
 were present in the definition of \tcode{D}; that is, the default
 argument is subject to the requirements described in this paragraph (and, if
-the default argument has sub-expressions with default arguments, this
+the default argument has subexpressions with default arguments, this
 requirement applies recursively).\footnote{\ref{dcl.fct.default} 
 describes how default argument names are looked up.}
 

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3671,7 +3671,7 @@ layout-compatible standard-layout class types~(\ref{class.mem}).
 \pnum
 \indextext{type!fundamental}%
 \indextext{type!integral}%
-\indextext{type!floating point}%
+\indextext{type!floating-point}%
 \indextext{type!implementation-defined @\tcode{sizeof}}%
 \indextext{type!Boolean}%
 \indextext{type!\idxcode{char}}%
@@ -3847,7 +3847,7 @@ ones' complement and signed magnitude representations for integral types.
 \end{example}
 
 \pnum
-There are three \defnx{floating point}{floating~point~type} types:
+There are three \defnx{floating-point}{floating~point~type} types:
 \indextext{type!\idxcode{float}}%
 \tcode{float},
 \indextext{type!\idxcode{double}}%

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1695,7 +1695,7 @@ void f() {
 }
 \end{codeblock}
 
-Here \tcode{a} and \tcode{p} are used like ordinary (nonmember)
+Here \tcode{a} and \tcode{p} are used like ordinary (non-member)
 variables, but since they are union members they have the same address.
 \end{example}
 

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -985,7 +985,7 @@ International Standard.
 \change Remove whitespace requirement for nested closing template right angle
 brackets.
 \rationale Considered a persistent but minor annoyance. Template aliases
-representing nonclass types would exacerbate whitespace issues.
+representing non-class types would exacerbate whitespace issues.
 \effect
 Change to semantics of well-defined expression. A valid \CppIII expression
 containing a right angle bracket (``\tcode{>}'') followed immediately by

--- a/source/conversions.tex
+++ b/source/conversions.tex
@@ -20,7 +20,7 @@ conversion, array-to-pointer conversion, and function-to-pointer
 conversion.
 
 \item Zero or one conversion from the following set: integral
-promotions, floating point promotion, integral conversions, floating
+promotions, floating-point promotion, integral conversions, floating
 point conversions, floating-integral conversions, pointer conversions,
 pointer to member conversions, and boolean conversions.
 
@@ -392,7 +392,7 @@ one.
 \pnum
 These conversions are called \term{integral promotions}.
 
-\rSec1[conv.fpprom]{Floating point promotion}
+\rSec1[conv.fpprom]{Floating-point promotion}
 
 \pnum
 \indextext{promotion!floating~point}%
@@ -400,7 +400,7 @@ A prvalue of type \tcode{float} can be converted to a prvalue of type
 \tcode{double}. The value is unchanged.
 
 \pnum
-This conversion is called \term{floating point promotion}.
+This conversion is called \term{floating-point promotion}.
 
 \rSec1[conv.integral]{Integral conversions}
 
@@ -437,12 +437,12 @@ zero and the value \tcode{true} is converted to one.
 The conversions allowed as integral promotions are excluded from the set
 of integral conversions.
 
-\rSec1[conv.double]{Floating point conversions}
+\rSec1[conv.double]{Floating-point conversions}
 
 \pnum
 \indextext{conversion!floating~point}%
-A prvalue of floating point type can be converted to a prvalue of
-another floating point type. If the source value can be exactly
+A prvalue of floating-point type can be converted to a prvalue of
+another floating-point type. If the source value can be exactly
 represented in the destination type, the result of the conversion is
 that exact representation. If the source value is between two adjacent
 destination values, the result of the conversion is an
@@ -450,14 +450,14 @@ destination values, the result of the conversion is an
 Otherwise, the behavior is undefined.
 
 \pnum
-The conversions allowed as floating point promotions are excluded from
-the set of floating point conversions.
+The conversions allowed as floating-point promotions are excluded from
+the set of floating-point conversions.
 
 \rSec1[conv.fpint]{Floating-integral conversions}
 
 \pnum
 \indextext{conversion!floating~to~integral}%
-A prvalue of a floating point type can be converted to a prvalue of an
+A prvalue of a floating-point type can be converted to a prvalue of an
 integer type. The conversion truncates; that is, the fractional part is
 discarded.
 \indextext{value!undefined unrepresentable integral}%
@@ -472,7 +472,7 @@ If the destination type is \tcode{bool}, see~\ref{conv.bool}.
 \indextext{truncation}%
 \indextext{rounding}%
 A prvalue of an integer type or of an unscoped enumeration type can be converted to
-a prvalue of a floating point type. The result is exact if possible. If the value being
+a prvalue of a floating-point type. The result is exact if possible. If the value being
 converted is in the range of values that can be represented but the value cannot be
 represented exactly, it is an \impldef{value of result of inexact integer to
 floating-point conversion} choice of either the next lower or higher representable

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3836,7 +3836,7 @@ An \grammarterm{alignment-specifier} of the form
 effect as \tcode{alignas(\brk{}alignof(} \grammarterm{type-id}~\tcode{))}~(\ref{expr.alignof}).
 
 \pnum
-The alignment requirement of an entity is the strictest non-zero alignment
+The alignment requirement of an entity is the strictest nonzero alignment
 specified by its \grammarterm{alignment-specifier}{s}, if any;
 otherwise, the \grammarterm{alignment-specifier}{s} have no effect.
 

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -864,7 +864,7 @@ shall satisfy the requirements for a \grammarterm{function-body} of a
 \tcode{constexpr} function;
 
 \item
-every non-variant non-static data member and base class sub-object
+every non-variant non-static data member and base class subobject
 shall be initialized~(\ref{class.base.init});
 
 \item
@@ -877,7 +877,7 @@ members having variant members, exactly one of them shall be initialized;
 
 \item
 for a non-delegating constructor, every constructor selected to initialize non-static
-data members and base class sub-objects shall be a \tcode{constexpr} constructor;
+data members and base class subobjects shall be a \tcode{constexpr} constructor;
 
 \item
 for a delegating constructor, the target constructor shall be a \tcode{constexpr}

--- a/source/derived.tex
+++ b/source/derived.tex
@@ -1006,7 +1006,7 @@ public:
   void draw();                  // a definition is required somewhere
 };
 \end{codeblock}
-would make class \tcode{circle} nonabstract and a definition of
+would make class \tcode{circle} non-abstract and a definition of
 \tcode{circle::draw()} must be provided.
 \end{example}
 

--- a/source/derived.tex
+++ b/source/derived.tex
@@ -790,7 +790,7 @@ type)~(\ref{expr.call}).
 \pnum
 \begin{note}
 The \tcode{virtual} specifier implies membership, so a virtual function
-cannot be a nonmember~(\ref{dcl.fct.spec}) function. Nor can a virtual
+cannot be a non-member~(\ref{dcl.fct.spec}) function. Nor can a virtual
 function be a static member, since a virtual function call relies on a
 specific object for determining which function to invoke. A virtual
 function declared in one class can be declared a \tcode{friend} in

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4940,7 +4940,7 @@ it is applied to
 
   \item
   a non-volatile glvalue that refers to a non-volatile object
-  defined with \tcode{constexpr}, or that refers to a non-mutable sub-object
+  defined with \tcode{constexpr}, or that refers to a non-mutable subobject
   of such an object, or
 
   \item

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3563,7 +3563,7 @@ In the second alternative (\term{delete array}), the value of the
 operand of \tcode{delete}
 may be a null pointer value or a pointer value
 that resulted from
-a previous array \grammarterm{new-expression}.\footnote{For non-zero-length
+a previous array \grammarterm{new-expression}.\footnote{For nonzero-length
 arrays, this is the same as a pointer to the first
 element of the array created by that \grammarterm{new-expression}.
 Zero-length arrays do not have a first element.}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1642,7 +1642,7 @@ cast away the constness in order to modify the argument's value. Where a
 parameter is of \tcode{const} reference type a temporary object is
 introduced if
 needed~(\ref{dcl.type},~\ref{lex.literal},~\ref{lex.string},~\ref{dcl.array},~\ref{class.temporary}).
-In addition, it is possible to modify the values of nonconstant objects through
+In addition, it is possible to modify the values of non-constant objects through
 pointer parameters.
 \end{note}
 

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -63,7 +63,7 @@ its type, the behavior is undefined.
 \begin{note}
 \indextext{overflow}%
 Treatment of division by zero, forming a remainder using a zero divisor,
-and all floating point exceptions vary among machines, and is sometimes
+and all floating-point exceptions vary among machines, and is sometimes
 adjustable by a library function.
 \end{note}
 
@@ -1682,7 +1682,7 @@ or a
 non-trivial destructor, with no corresponding parameter, is conditionally-supported with
 \impldef{passing argument of class type through ellipsis} semantics. If the argument has
 integral or enumeration type that is subject to the integral
-promotions~(\ref{conv.prom}), or a floating point type that is subject to the floating
+promotions~(\ref{conv.prom}), or a floating-point type that is subject to the floating
 point promotion~(\ref{conv.fpprom}), the value of the argument is converted to the
 promoted type before the call. These promotions are referred to as
 the \defnx{default argument promotions}{promotion!default argument promotion}.

--- a/source/future.tex
+++ b/source/future.tex
@@ -429,7 +429,7 @@ void freeze(bool freezefl = true);
 \begin{itemdescr}
 \pnum
 \effects
-If \tcode{strmode} \& \tcode{dynamic} is non-zero, alters the
+If \tcode{strmode} \& \tcode{dynamic} is nonzero, alters the
 freeze status of the dynamic array object as follows:
 \begin{itemize}
 \item

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -491,7 +491,7 @@ in~\ref{basic.types}. \end{note}
 
 \pnum
 A \defn{memory location} is either an object of scalar type or a maximal
-sequence of adjacent bit-fields all having non-zero width. \begin{note} Various
+sequence of adjacent bit-fields all having nonzero width. \begin{note} Various
 features of the language, such as references and virtual functions, might
 involve additional memory locations that are not accessible to programs but are
 managed by the implementation. \end{note} Two or more threads of
@@ -505,7 +505,7 @@ without interference. The same applies to two bit-fields, if one is declared
 inside a nested struct declaration and the other is not, or if the two are
 separated by a zero-length bit-field declaration, or if they are separated by a
 non-bit-field declaration. It is not safe to concurrently update two bit-fields
-in the same struct if all fields between them are also bit-fields of non-zero
+in the same struct if all fields between them are also bit-fields of nonzero
 width. \end{note}
 
 \pnum
@@ -687,7 +687,7 @@ an object of a most derived class type or of a non-class type is called a
 \pnum
 \indextext{most derived object!bit-field}%
 Unless it is a bit-field~(\ref{class.bit}), a most derived object shall have a
-non-zero size and shall occupy one or more bytes of storage. Base class
+nonzero size and shall occupy one or more bytes of storage. Base class
 subobjects may have zero size. An object of trivially copyable or
 standard-layout type~(\ref{basic.types}) shall occupy contiguous bytes of
 storage.

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -1003,7 +1003,7 @@ function, or calling a function that does any of those operations are
 all
 \defn{side effects}, which are changes in the state of the execution
 environment. \defn{Evaluation} of an expression (or a
-sub-expression) in general includes both value computations (including
+subexpression) in general includes both value computations (including
 determining the identity of an object for glvalue evaluation and fetching
 a value previously assigned to an object for prvalue evaluation) and
 initiation of side effects. When a call to a library I/O function

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -2053,7 +2053,7 @@ the corresponding member objects of \tcode{rhs} as follows:
 
 \item the contents of arrays pointed at by \tcode{pword} and \tcode{iword} are copied,
 not the pointers themselves;\footnote{ This suggests an infinite amount of copying, but the implementation can keep
-track of the maximum element of the arrays that is non-zero.}
+track of the maximum element of the arrays that is nonzero.}
 and
 
 \item if any newly stored pointer values in \tcode{*this} point at objects stored outside
@@ -3971,7 +3971,7 @@ Let
 be the number of characters in the pending sequence not consumed.
 If
 \tcode{r}
-is non-zero then
+is nonzero then
 \tcode{pbase()}
 and
 \tcode{pptr()}
@@ -4884,7 +4884,7 @@ the sentry object returns \tcode{false}, when converted to a value of type
 \tcode{bool},
 the function returns without attempting to obtain any input.
 In either case the number of extracted characters is set to 0;
-unformatted input functions taking a character array of non-zero size as
+unformatted input functions taking a character array of nonzero size as
 an argument shall also store a null character (using
 \tcode{charT()})
 in the first location of the array.
@@ -7788,7 +7788,7 @@ basic_streambuf<charT, traits>* setbuf(charT* s, streamsize n);
 \begin{itemdescr}
 \pnum
 \effects
-\impldef{effect of calling \tcode{basic_streambuf::setbuf} with non-zero arguments},
+\impldef{effect of calling \tcode{basic_streambuf::setbuf} with nonzero arguments},
 except that
 \tcode{setbuf(0, 0)}
 has no effect.
@@ -9025,7 +9025,7 @@ If
 is called on a stream before any I/O has occurred on that stream, the
 stream becomes unbuffered.
 Otherwise the results are \impldef{effect of calling \tcode{basic_filebuf::setbuf} with
-non-zero arguments}.
+nonzero arguments}.
 ``Unbuffered'' means that
 \tcode{pbase()}
 and

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -2548,7 +2548,7 @@ partial_sum(istream_iterator<double, char>(cin),
   ostream_iterator<double, char>(cout, "@\textbackslash@n"));
 \end{codeblock}
 
-reads a file containing floating point numbers from
+reads a file containing floating-point numbers from
 \tcode{cin},
 and prints the partial sums onto
 \tcode{cout}.

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -1199,7 +1199,7 @@ of a wide-character literal containing multiple \grammarterm{c-char}{s} is
 \impldef{value of wide-character literal containing multiple characters}.
 
 \pnum
-Certain nongraphic characters, the single quote \tcode{'}, the double quote \tcode{"},
+Certain non-graphic characters, the single quote \tcode{'}, the double quote \tcode{"},
 the question mark \tcode{?},\footnote{Using an escape sequence for a question mark
 is supported for compatibility with ISO \CppXIV and ISO C.}
 and the backslash

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -2199,7 +2199,7 @@ const mask* table() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-The first constructor argument, if it was non-zero, otherwise
+The first constructor argument, if it was nonzero, otherwise
 \tcode{classic_table()}.
 \end{itemdescr}
 

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -13,7 +13,7 @@ complex number types, random number generation,
 numeric (%
 \textit{n}-at-a-time)
 arrays, generalized numeric algorithms,
-and mathematical functions for floating point types,
+and mathematical functions for floating-point types,
 as summarized in Table~\ref{tab:numerics.lib.summary}.
 
 \begin{libsumtab}{Numerics library summary}{tab:numerics.lib.summary}
@@ -25,7 +25,7 @@ as summarized in Table~\ref{tab:numerics.lib.summary}.
 \ref{numarray}  & Numeric arrays     & \tcode{<valarray>}  \\ \rowsep
 \ref{numeric.ops} & Generalized numeric operations  & \tcode{<numeric>} \\ \rowsep
 \ref{c.math}  & Mathematical functions for & \tcode{<cmath>}   \\
-              & floating point types       & \tcode{<ctgmath>} \\
+              & floating-point types       & \tcode{<ctgmath>} \\
               &                            & \tcode{<cstdlib>} \\
 \end{libsumtab}
 
@@ -1288,7 +1288,7 @@ imag                  real
 \end{codeblock}
 
 \pnum
-\indextext{overloads!floating point}%
+\indextext{overloads!floating-point}%
 The additional overloads shall be sufficient to ensure:
 
 \begin{enumerate}
@@ -9590,7 +9590,7 @@ Nothing.
 \end{itemdescr}
 
 
-\rSec1[c.math]{Mathematical functions for floating point types}
+\rSec1[c.math]{Mathematical functions for floating-point types}
 
 \rSec2[cmath.syn]{Header \tcode{<cmath>} synopsis}
 

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -6455,7 +6455,7 @@ may introduce data races~(\ref{res.on.data.races}).
 The other random
 number generation facilities in this standard~(\ref{rand}) are often preferable
 to \tcode{rand}, because \tcode{rand}'s underlying algorithm is unspecified.
-Use of \tcode{rand} therefore continues to be nonportable, with unpredictable
+Use of \tcode{rand} therefore continues to be non-portable, with unpredictable
 and oft-questionable quality and performance.
 \end{note}
 \end{itemdescr}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -10469,7 +10469,7 @@ for which:
 
   \item
   the corresponding mathematical function value
-  has a non-zero imaginary component,
+  has a nonzero imaginary component,
   or
 
   \item

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -3834,12 +3834,12 @@ is \impldef{type of \tcode{default_random_engine}}.
 \pnum
 A \tcode{random_device}
 uniform random bit generator
-produces non-deterministic random numbers.
+produces nondeterministic random numbers.
 
 \pnum
 If implementation limitations%
 \indextext{\idxcode{random_device}!implementation leeway}
-prevent generating non-deterministic random numbers,
+prevent generating nondeterministic random numbers,
 the implementation may employ a random number engine.
 
 \indexlibrary{\idxcode{random_device}}%
@@ -3877,7 +3877,7 @@ explicit random_device(const string& token = @\textit{implementation-defined}@);
 
 \begin{itemdescr}
 \pnum\effects Constructs a \tcode{random_device}
- non-deterministic uniform random bit generator object.
+ nondeterministic uniform random bit generator object.
  The semantics and default value of the \tcode{token}
  parameter are
  \impldef{semantics and default value of \tcode{token} parameter to \tcode{random_device} constructor}.
@@ -3918,7 +3918,7 @@ result_type operator()();
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns A non-deterministic random value,
+\pnum\returns A nondeterministic random value,
  uniformly distributed
  between \tcode{min()} and \tcode{max()},
  inclusive.
@@ -8964,7 +8964,7 @@ elements in the range \range{first}{last}.
 \realnotes
 The difference between \tcode{reduce} and \tcode{accumulate} is that
 \tcode{reduce} applies \tcode{binary_op} in an unspecified order, which yields
-a non-deterministic result for non-associative or non-commutative
+a nondeterministic result for non-associative or non-commutative
 \tcode{binary_op} such as floating-point addition.
 \end{itemdescr}
 
@@ -9197,7 +9197,7 @@ The end of the resulting range beginning at \tcode{result}.
 The difference between \tcode{exclusive_scan} and \tcode{inclusive_scan} is
 that \tcode{exclusive_scan} excludes the \tcode{i}th input element from the
 \tcode{i}th sum. If \tcode{binary_op} is not mathematically associative, the
-behavior of \tcode{exclusive_scan} may be non-deterministic.
+behavior of \tcode{exclusive_scan} may be nondeterministic.
 \end{itemdescr}
 
 \rSec2[inclusive.scan]{Inclusive scan}
@@ -9294,7 +9294,7 @@ The end of the resulting range beginning at \tcode{result}.
 The difference between \tcode{exclusive_scan} and \tcode{inclusive_scan} is
 that \tcode{inclusive_scan} includes the \tcode{i}th input element in the
 \tcode{i}th sum.  If \tcode{binary_op} is not mathematically associative, the
-behavior of \tcode{inclusive_scan} may be non-deterministic.
+behavior of \tcode{inclusive_scan} may be nondeterministic.
 \end{itemdescr}
 
 \rSec2[transform.exclusive.scan]{Transform exclusive scan}
@@ -9351,7 +9351,7 @@ The difference between \tcode{transform_exclusive_scan} and
 \tcode{transform_inclusive_scan} is that \tcode{transform_exclusive_scan}
 excludes the ith input element from the ith sum. If \tcode{binary_op} is not
 mathematically associative, the behavior of \tcode{transform_exclusive_scan}
-may be non-deterministic. \tcode{transform_exclusive_scan} does not apply
+may be nondeterministic. \tcode{transform_exclusive_scan} does not apply
 \tcode{unary_op} to \tcode{init}.
 \end{itemdescr}
 
@@ -9431,7 +9431,7 @@ The difference between \tcode{transform_exclusive_scan} and
 \tcode{transform_inclusive_scan} is that \tcode{transform_inclusive_scan}
 includes the ith input element in the ith sum. If \tcode{binary_op} is not
 mathematically associative, the behavior of \tcode{transform_inclusive_scan}
-may be non-deterministic. \tcode{transform_inclusive_scan} does not apply
+may be nondeterministic. \tcode{transform_inclusive_scan} does not apply
 \tcode{unary_op} to \tcode{init}.
 \end{itemdescr}
 

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -2053,9 +2053,9 @@ Function-to-pointer conversion  &                               &   \rb{Exact Ma
 Qualification conversions       &                               &                   &   \ref{conv.qual}     \\ \cline{1-1}\cline{4-4}
 Function pointer conversion     & \rb{Qualification Adjustment} &                   &   \ref{conv.fctptr}   \\ \hline
 Integral promotions             &                               &                   &   \ref{conv.prom}     \\ \cline{1-1}\cline{4-4}
-Floating point promotion        &   \rb{Promotion}              &   \rb{Promotion}  &   \ref{conv.fpprom}   \\ \hline
+Floating-point promotion        &   \rb{Promotion}              &   \rb{Promotion}  &   \ref{conv.fpprom}   \\ \hline
 Integral conversions            &                               &                   &   \ref{conv.integral} \\ \cline{1-1}\cline{4-4}
-Floating point conversions      &                               &                   &   \ref{conv.double}   \\ \cline{1-1}\cline{4-4}
+Floating-point conversions      &                               &                   &   \ref{conv.double}   \\ \cline{1-1}\cline{4-4}
 Floating-integral conversions   &                               &                   &   \ref{conv.fpint}    \\ \cline{1-1}\cline{4-4}
 Pointer conversions             &   \rb{Conversion}             &   \rb{Conversion} &   \ref{conv.ptr}      \\ \cline{1-1}\cline{4-4}
 Pointer to member conversions   &                               &                   &   \ref{conv.mem}      \\ \cline{1-1}\cline{4-4}

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -440,7 +440,7 @@ invocation of a user-defined conversion for
 copy-initialization~(\ref{dcl.init}) of a class object~(\ref{over.match.copy});
 \item
 invocation of a conversion function for initialization of an object of a
-nonclass type from an expression of class type~(\ref{over.match.conv}); and
+non-class type from an expression of class type~(\ref{over.match.conv}); and
 \item
 invocation of a conversion function for conversion to a glvalue
 or class prvalue
@@ -1260,7 +1260,7 @@ object parameter of the conversion functions.
 
 \pnum
 Under the conditions specified in~\ref{dcl.init}, as
-part of an initialization of an object of nonclass type,
+part of an initialization of an object of non-class type,
 a conversion function can be invoked to convert an initializer
 expression of class type to the type of the object
 being initialized.

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -3476,7 +3476,7 @@ out = copy(last_m.suffix().first, last_m.suffix().second, out)
 \end{codeblock}
 where \tcode{last_m} is a copy of the last match
 found. If \tcode{flags \& regex_constants::format_first_only}
-is non-zero, then only the first match found is replaced.
+is nonzero, then only the first match found is replaced.
 
 \pnum\returns \tcode{out}.
 \end{itemdescr}

--- a/source/special.tex
+++ b/source/special.tex
@@ -1893,7 +1893,7 @@ A a2(1);                  // OK, unfortunately
 In a non-delegating constructor, the destructor for each potentially constructed
 subobject of class type is potentially invoked~(\ref{class.dtor}).
 \begin{note} This provision ensures that destructors can be called for fully-constructed
-sub-objects in case an exception is thrown~(\ref{except.ctor}). \end{note}
+subobjects in case an exception is thrown~(\ref{except.ctor}). \end{note}
 
 \pnum
 In a non-delegating constructor, initialization

--- a/source/special.tex
+++ b/source/special.tex
@@ -2542,7 +2542,7 @@ cv-qualified)
 \begin{codeblock}
 struct X {
   X();              // default constructor
-  X(X&);            // copy constructor with a nonconst parameter
+  X(X&);            // copy constructor with a non-const parameter
 };
 const X cx;
 X x = cx;           // error: \tcode{X::X(X\&)} cannot copy \tcode{cx} into \tcode{x}

--- a/source/std.tex
+++ b/source/std.tex
@@ -71,7 +71,7 @@
 
 %%--------------------------------------------------
 %% add special hyphenation rules
-\hyphenation{tem-plate ex-am-ple in-put-it-er-a-tor name-space name-spaces}
+\hyphenation{tem-plate ex-am-ple in-put-it-er-a-tor name-space name-spaces non-zero}
 
 %%--------------------------------------------------
 %% turn off all ligatures inside \texttt

--- a/source/support.tex
+++ b/source/support.tex
@@ -331,7 +331,7 @@ arithmetic types.
 \pnum
 Specializations shall be provided for each
 arithmetic type,
-both floating point and integer, including
+both floating-point and integer, including
 \tcode{bool}.
 The member
 \tcode{is_specialized}
@@ -524,7 +524,7 @@ digits that can be represented without change.
 \pnum
 For integer types, the number of non-sign bits in the representation.
 
-\pnum For floating point types, the number of \tcode{radix} digits in the
+\pnum For floating-point types, the number of \tcode{radix} digits in the
 mantissa.\footnote{Equivalent to \tcode{FLT_MANT_DIG}, \tcode{DBL_MANT_DIG},
 \tcode{LDBL_MANT_DIG}.} \end{itemdescr}
 
@@ -555,7 +555,7 @@ Number of base 10 digits required to ensure that values which
 differ are always differentiated.
 
 \pnum
-Meaningful for all floating point types.
+Meaningful for all floating-point types.
 \end{itemdescr}
 
 \indexlibrarymember{is_signed}{numeric_limits}%
@@ -629,7 +629,7 @@ Machine epsilon:  the difference between 1 and the least value greater than 1
 that is representable.\footnote{Equivalent to \tcode{FLT_EPSILON}, \tcode{DBL_EPSILON}, \tcode{LDBL_EPSILON}.}
 
 \pnum
-Meaningful for all floating point types.
+Meaningful for all floating-point types.
 \end{itemdescr}
 
 \indexlibrarymember{round_error}{numeric_limits}%
@@ -659,7 +659,7 @@ point number.\footnote{Equivalent to \tcode{FLT_MIN_EXP}, \tcode{DBL_MIN_EXP},
 \tcode{LDBL_MIN_EXP}.}
 
 \pnum
-Meaningful for all floating point types.
+Meaningful for all floating-point types.
 \end{itemdescr}
 
 \indexlibrarymember{min_exponent10}{numeric_limits}%
@@ -670,11 +670,11 @@ static constexpr int  min_exponent10;
 \begin{itemdescr}
 \pnum
 Minimum negative integer such that 10 raised to that power is in the range
-of normalized floating point numbers.\footnote{Equivalent to
+of normalized floating-point numbers.\footnote{Equivalent to
 \tcode{FLT_MIN_10_EXP}, \tcode{DBL_MIN_10_EXP}, \tcode{LDBL_MIN_10_EXP}.}
 
 \pnum
-Meaningful for all floating point types.
+Meaningful for all floating-point types.
 \end{itemdescr}
 
 \indexlibrarymember{max_exponent}{numeric_limits}%
@@ -687,11 +687,11 @@ static constexpr int  max_exponent;
 Maximum positive integer such that
 \tcode{radix}
 raised to the power one less than that integer is a representable finite
-floating point number.\footnote{Equivalent to \tcode{FLT_MAX_EXP},
+floating-point number.\footnote{Equivalent to \tcode{FLT_MAX_EXP},
 \tcode{DBL_MAX_EXP}, \tcode{LDBL_MAX_EXP}.}
 
 \pnum
-Meaningful for all floating point types.
+Meaningful for all floating-point types.
 \end{itemdescr}
 
 \indexlibrarymember{max_exponent10}{numeric_limits}%
@@ -702,11 +702,11 @@ static constexpr int  max_exponent10;
 \begin{itemdescr}
 \pnum
 Maximum positive integer such that 10 raised to that power is in the
-range of representable finite floating point numbers.\footnote{Equivalent to
+range of representable finite floating-point numbers.\footnote{Equivalent to
 \tcode{FLT_MAX_10_EXP}, \tcode{DBL_MAX_10_EXP}, \tcode{LDBL_MAX_10_EXP}.}
 
 \pnum
-Meaningful for all floating point types.
+Meaningful for all floating-point types.
 \end{itemdescr}
 
 \indexlibrarymember{has_infinity}{numeric_limits}%
@@ -719,7 +719,7 @@ static constexpr bool has_infinity;
 True if the type has a representation for positive infinity.
 
 \pnum
-Meaningful for all floating point types.
+Meaningful for all floating-point types.
 
 \pnum
 Shall be
@@ -739,7 +739,7 @@ True if the type has a representation for a quiet (non-signaling) ``Not a
 Number.''\footnote{Required by LIA-1.}
 
 \pnum
-Meaningful for all floating point types.
+Meaningful for all floating-point types.
 
 \pnum
 Shall be
@@ -758,7 +758,7 @@ static constexpr bool has_signaling_NaN;
 True if the type has a representation for a signaling ``Not a Number.''\footnote{Required by LIA-1.}
 
 \pnum
-Meaningful for all floating point types.
+Meaningful for all floating-point types.
 
 \pnum
 Shall be
@@ -785,7 +785,7 @@ if it is indeterminate at compile time whether the type allows
 denormalized values.
 
 \pnum
-Meaningful for all floating point types.
+Meaningful for all floating-point types.
 \end{itemdescr}
 
 \indexlibrarymember{has_denorm_loss}{numeric_limits}%
@@ -858,7 +858,7 @@ static constexpr T denorm_min() noexcept;
 Minimum positive denormalized value.\footnote{Required by LIA-1.}
 
 \pnum
-Meaningful for all floating point types.
+Meaningful for all floating-point types.
 
 \pnum
 In specializations for which
@@ -877,7 +877,7 @@ True if and only if the type adheres to ISO/IEC/IEEE
 60559.\footnote{ISO/IEC/IEEE 60559:2011 is the same as IEEE 754-2008.}
 
 \pnum
-Meaningful for all floating point types.
+Meaningful for all floating-point types.
 \end{itemdescr}
 
 \indexlibrarymember{is_bounded}{numeric_limits}%
@@ -947,7 +947,7 @@ ISO/IEC/IEEE 60559.
 Required by LIA-1.}
 
 \pnum
-Meaningful for all floating point types.
+Meaningful for all floating-point types.
 \end{itemdescr}
 
 \indexlibrarymember{round_style}{numeric_limits}%
@@ -961,7 +961,7 @@ The rounding style for the type.\footnote{Equivalent to \tcode{FLT_ROUNDS}.
 Required by LIA-1.}
 
 \pnum
-Meaningful for all floating point types.
+Meaningful for all floating-point types.
 Specializations for integer types shall return
 \tcode{round_toward_zero}.
 \end{itemdescr}
@@ -982,7 +982,7 @@ namespace std {
 \end{codeblock}
 
 \pnum
-The rounding mode for floating point arithmetic is characterized by the
+The rounding mode for floating-point arithmetic is characterized by the
 values:
 
 \begin{itemize}

--- a/source/support.tex
+++ b/source/support.tex
@@ -1473,7 +1473,7 @@ The implementation shall support the registration of at least 32 functions.
 The
 \tcode{atexit()}
 function returns zero if the registration succeeds,
-non-zero if it fails.
+nonzero if it fails.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{exit}}%
@@ -1566,7 +1566,7 @@ and applications may need to call both registration functions with the same argu
 The implementation shall support the registration of at least 32 functions.
 
 \pnum
-\returns Zero if the registration succeeds, non-zero if it fails.
+\returns Zero if the registration succeeds, nonzero if it fails.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{quick_exit}}%

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -2833,8 +2833,8 @@ parameter list. Given \cv{} as the cv-qualifiers of \placeholder{M}
 template has rvalue reference type. Otherwise, the new parameter is
 of type ``lvalue reference to \cv{} \placeholder{A}''.
 \begin{note} This allows a non-static
-member to be ordered with respect to a nonmember function and for the results
-to be equivalent to the ordering of two equivalent nonmembers. \end{note}
+member to be ordered with respect to a non-member function and for the results
+to be equivalent to the ordering of two equivalent non-members. \end{note}
 \begin{example}
 \begin{codeblock}
 struct A { };

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -339,7 +339,7 @@ template<const X& x, int i> void f() {
 \pnum
 A non-type
 \grammarterm{template-parameter}
-shall not be declared to have floating point, class, or void type.
+shall not be declared to have floating-point, class, or void type.
 \begin{example}
 
 \begin{codeblock}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -7390,7 +7390,7 @@ of type
 \tcode{bool}
 may be deduced from an array bound, the resulting value will always be
 \tcode{true}
-because the array bound will be non-zero.}
+because the array bound will be nonzero.}
 \begin{example}
 
 \begin{codeblock}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -15551,7 +15551,7 @@ has a \tcode{value} member that evaluates to \tcode{true}.
 \indexlibrary{\idxcode{is_floating_point}}%
 \tcode{template <class T>}\br
  \tcode{struct is_floating_point;}  &
-\tcode{T} is a floating point type~(\ref{basic.fundamental})            &   \\ \rowsep
+\tcode{T} is a floating-point type~(\ref{basic.fundamental})            &   \\ \rowsep
 \indexlibrary{\idxcode{is_array}}%
 \tcode{template <class T>}\br
  \tcode{struct is_array;}           &
@@ -18186,8 +18186,8 @@ denote duration values of the corresponding types \tcode{hours}, \tcode{minutes}
 respectively if they are applied to integral literals.
 
 \pnum
-If any of these suffixes are applied to a floating point literal the result is a
-\tcode{chrono::duration} literal with an unspecified floating point representation.
+If any of these suffixes are applied to a floating-point literal the result is a
+\tcode{chrono::duration} literal with an unspecified floating-point representation.
 
 \pnum
 If any of these suffixes are applied to an integer literal and the resulting

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -742,7 +742,7 @@ from_chars_result from_chars(const char* first, const char* last,
 \pnum
 \effects The pattern is the expected form of the subject sequence
 in the \tcode{"C"} locale
-for the given non-zero base,
+for the given nonzero base,
 as described for \tcode{strtol},
 except that no \tcode{"0x"} or \tcode{"0X"} prefix shall appear
 if the value of \tcode{base} is 16,

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2362,7 +2362,7 @@ Otherwise, the program is ill-formed.
 
 \pnum
 \begin{note} The reason \tcode{get} is a
-nonmember function is that if this functionality had been
+non-member function is that if this functionality had been
 provided as a member function, code where the type
 depended on a template parameter would have required using
 the \tcode{template} keyword. \end{note}


### PR DESCRIPTION
Fixes #440.