### PR TITLE
[class.union] Clarify in the note that a default member

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1550,7 +1550,8 @@ base classes. A union shall not be used as a base class.
 \indextext{restriction!\idxcode{union}}%
 If a union contains a non-static data member of
 reference type the program is ill-formed.
-\begin{note} If any non-static data member of a union has a non-trivial
+\begin{note} Absent default member initializers~(\ref{class.mem}),
+if any non-static data member of a union has a non-trivial
 default constructor~(\ref{class.ctor}),
 copy constructor~(\ref{class.copy}),
 move constructor~(\ref{class.copy}),


### PR DESCRIPTION
initializer may prevent a defaulted special member function
from being implicitly deleted.

Fixes #1073.