### PR TITLE
[diff] Miscellaneous fixes.

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -30,7 +30,7 @@ of related programs takes more work.
 Common.
 
 \ref{lex.ccon}
-\change Type of character literal is changed from \tcode{int} to \tcode{char}
+\change Type of character literal is changed from \tcode{int} to \tcode{char}.
 \rationale
 This is needed for improved overloaded function argument type
 matching.
@@ -60,7 +60,7 @@ Simple.
 Programs which depend upon \tcode{sizeof('x')} are probably rare.
 
 Subclause \ref{lex.string}:
-\change String literals made const\\
+\change String literals made const.\\
 The type of a string literal is changed
 from ``array of \tcode{char}''
 to ``array of \tcode{const char}''.
@@ -97,7 +97,7 @@ as pointers to potentially modifiable memory are probably rare.
 \rSec2[diff.basic]{Clause \ref{basic}: basic concepts}
 
 \ref{basic.def}
-\change \Cpp does not have ``tentative definitions'' as in C
+\change \Cpp does not have ``tentative definitions'' as in C.\\
 E.g., at file scope,
 
 \begin{codeblock}
@@ -126,7 +126,6 @@ fundamental types and user-defined types.
 Deletion of semantically well-defined feature.
 \difficulty
 Semantic transformation.
-\rationale
 In \Cpp, the initializer for one of a set of
 mutually-referential file-local static objects must invoke a function
 call to achieve the initialization.
@@ -134,7 +133,7 @@ call to achieve the initialization.
 Seldom.
 
 \ref{basic.scope}
-\change A \tcode{struct} is a scope in \Cpp, not in C
+\change A \tcode{struct} is a scope in \Cpp, not in C.
 \rationale
 Class scope is crucial to \Cpp, and a struct is a class.
 \effect
@@ -149,7 +148,7 @@ The latter is probably rare.
 
 \ref{basic.link} [also \ref{dcl.type}] 
 \change A name of file scope that is explicitly declared \tcode{const}, and not explicitly
-declared \tcode{extern}, has internal linkage, while in C it would have external linkage
+declared \tcode{extern}, has internal linkage, while in C it would have external linkage.
 \rationale
 Because \tcode{const} objects may be used as values during translation in
 \Cpp, this feature urges programmers to provide an explicit initializer
@@ -159,24 +158,24 @@ in more than one translation unit.
 \effect
 Change to semantics of well-defined feature.
 \difficulty
-Semantic transformation
+Semantic transformation.
 \howwide
-Seldom
+Seldom.
 
 \ref{basic.start}
-\change Main cannot be called recursively and cannot have its address taken
+\change The \tcode{main} function cannot be called recursively and cannot have its address taken.
 \rationale
 The  main  function may require special actions.
 \effect
-Deletion of semantically well-defined feature
+Deletion of semantically well-defined feature.
 \difficulty
 Trivial: create an intermediary function such as
 \tcode{mymain(argc, argv)}.
 \howwide
-Seldom
+Seldom.
 
 \ref{basic.types}
-\change C allows ``compatible types'' in several places, \Cpp does not
+\change C allows ``compatible types'' in several places, \Cpp does not.\\
 For example,
 otherwise-identical \tcode{struct} types with different tag names
 are ``compatible'' in C but are distinctly different types
@@ -199,7 +198,7 @@ Common.
 \rSec2[diff.conv]{Clause \ref{conv}: standard conversions}
 
 \ref{conv.ptr}
-\change Converting \tcode{void*} to a pointer-to-object type requires casting
+\change Converting \tcode{void*} to a pointer-to-object type requires casting.
 
 \begin{codeblock}
 char a[10];
@@ -236,7 +235,7 @@ if the cast is not used.
 \rSec2[diff.expr]{Clause \ref{expr}: expressions}
 
 \ref{expr.call}
-\change Implicit declaration of functions is not allowed
+\change Implicit declaration of functions is not allowed.
 \rationale
 The type-safe nature of \Cpp.
 \effect
@@ -258,18 +257,18 @@ a \tcode{bool} lvalue (for instance, via the C typedef in \tcode{<stdbool.h>})
 is ill-formed in this International Standard.
 
 \ref{expr.sizeof}, \ref{expr.cast}
-\change Types must be defined in declarations, not in expressions\\
+\change Types must be defined in declarations, not in expressions.\\
 In C, a sizeof expression or cast expression may define a new type.
 For example,
 \begin{codeblock}
 p = (void*)(struct x {int i;} *)0;
 \end{codeblock}
-defines a new type, struct \tcode{x} .
+defines a new type, struct \tcode{x}.
 \rationale
 This prohibition helps to clarify the location of
 definitions in the source code.
 \effect
-Deletion of a semantically well-defined feature.
+Deletion of semantically well-defined feature.
 \difficulty
 Syntactic transformation.
 \howwide
@@ -280,7 +279,7 @@ Seldom.
 \indextext{conversion!lvalue-to-rvalue}%
 \indextext{rvalue!lvalue conversion~to}%
 \indextext{lvalue}%
-\change The result of a conditional expression, an assignment expression, or a comma expression may be an lvalue
+\change The result of a conditional expression, an assignment expression, or a comma expression may be an lvalue.
 \rationale
 \Cpp is an object-oriented language, placing relatively
 more emphasis on lvalues.  For example, functions may
@@ -308,7 +307,7 @@ Rare.
 \rSec2[diff.stat]{Clause \ref{stmt.stmt}: statements}
 
 \ref{stmt.switch}, \ref{stmt.goto}
-\change It is now invalid to jump past a declaration with explicit or implicit initializer (except across entire block not entered)
+\change It is now invalid to jump past a declaration with explicit or implicit initializer (except across entire block not entered).
 \rationale
 Constructors used in initializers may allocate
 resources which need to be de-allocated upon leaving the
@@ -329,7 +328,7 @@ Seldom.
 
 \ref{stmt.return}
 \change It is now invalid to return (explicitly or implicitly) from a function which is
-declared to return a value without actually returning a value
+declared to return a value without actually returning a value.
 \rationale
 The caller and callee may assume fairly elaborate
 return-value mechanisms for the return of class objects.
@@ -354,7 +353,7 @@ this case.
 \rSec2[diff.dcl]{Clause \ref{dcl.dcl}: declarations}
 
 \ref{dcl.stc}
-\change In \Cpp, the \tcode{static} or \tcode{extern} specifiers can only be applied to names of objects or functions
+\change In \Cpp, the \tcode{static} or \tcode{extern} specifiers can only be applied to names of objects or functions.\\
 Using these specifiers with type declarations is illegal in \Cpp.
 In C, these specifiers are ignored when used on type declarations.
 
@@ -395,7 +394,7 @@ Common.
 \change A \Cpp typedef name must be different from any class type name declared
 in the same scope (except if the typedef is a synonym of the class name with the
 same name). In C, a typedef name and a struct tag name declared in the same scope
-can have the same name (because they have different name spaces)
+can have the same name (because they have different name spaces).
 
 Example:
 \begin{codeblock}
@@ -424,7 +423,7 @@ One of the 2 types has to be renamed.
 Seldom.
 
 \ref{dcl.type} [see also \ref{basic.link}]
-\change const objects must be initialized in \Cpp but can be left uninitialized in C
+\change \tcode{const} objects must be initialized in \Cpp but can be left uninitialized in C.
 \rationale
 A const object cannot be assigned to so it must be initialized
 to hold a useful value.
@@ -436,7 +435,7 @@ Semantic transformation.
 Seldom.
 
 \ref{dcl.type}
-\change Banning implicit int
+\change Banning implicit \tcode{int}.
 
 In \Cpp a
 \grammarterm{decl-specifier-seq}
@@ -478,7 +477,7 @@ The keyword \tcode{auto} cannot be used as a storage class specifier.
 
 \begin{codeblock}
 void f() {
-  auto int x;     // valid C, invalid C++
+  auto int x;     // valid C, invalid \Cpp
 }
 \end{codeblock}
 
@@ -491,7 +490,7 @@ of a variable from its initializer results in undesired interpretations of
 
 \ref{dcl.enum}
 \change \Cpp objects of enumeration type can only be assigned values of the same enumeration type.
-In C, objects of enumeration type can be assigned values of any integral type
+In C, objects of enumeration type can be assigned values of any integral type.
 
 Example:
 \begin{codeblock}
@@ -606,7 +605,7 @@ Common in old programs, but already known to be obsolescent.
 \change In \Cpp, when initializing an array of character with a string, the number of
 characters in the string (including the terminating \tcode{'\textbackslash 0'}) must not exceed the
 number of elements in the array. In C, an array can be initialized with a string even if
-the array is not large enough to contain the string-terminating \tcode{'\textbackslash 0'}
+the array is not large enough to contain the string-terminating \tcode{'\textbackslash 0'}.
 
 Example:
 
@@ -632,7 +631,7 @@ This style of array initialization is seen as poor coding style.
 \change In \Cpp, a class declaration introduces the class name into the scope where it is
 declared and hides any object, function or other declaration of that name in an enclosing
 scope. In C, an inner scope declaration of a struct tag name never hides the name of an
-object or function in an outer scope
+object or function in an outer scope.
 
 Example:
 
@@ -706,7 +705,7 @@ be very complicated and \Cpp programmers would be unable to predict
 reliably the meanings of nontrivial examples involving nested or
 local functions.
 \effect
-Change of semantics of well-defined feature.
+Change to semantics of well-defined feature.
 \difficulty
 Semantic transformation.
 To make the struct type name visible in the scope of the enclosing
@@ -730,7 +729,7 @@ which is documented in \ref{basic.scope}.
 Seldom.
 
 \ref{class.nested.type}
-\change In \Cpp, a typedef name may not be redeclared in a class definition after being used in that definition
+\change In \Cpp, a typedef name may not be redeclared in a class definition after being used in that definition.
 
 Example:
 
@@ -756,7 +755,7 @@ Seldom.
 \rSec2[diff.special]{Clause \ref{special}: special member functions}
 
 \ref{class.copy}
-\change Copying volatile objects
+\change Copying volatile objects.
 
 The implicitly-declared copy constructor and
 implicitly-declared copy assignment operator
@@ -766,7 +765,7 @@ For example, the following is valid in ISO C:
 \begin{codeblock}
 struct X { int i; };
 volatile struct X x1 = {0};
-struct X x2(x1);                // invalid \Cpp
+struct X x2 = x1;               // invalid \Cpp
 struct X x3;
 x3 = x1;                        // also invalid \Cpp
 \end{codeblock}
@@ -831,7 +830,7 @@ by the chapters of this document.
 \rSec2[diff.cpp03.lex]{Clause \ref{lex}: lexical conventions}
 
 \ref{lex.pptoken}
-\change New kinds of string literals
+\change New kinds of string literals.
 \rationale Required for new features.
 \effect
 Valid \CppIII code may fail to compile or produce different results in
@@ -846,7 +845,7 @@ const char* s = u8"def";        // Previously \tcode{"abcdef"}, now \tcode{"def"
 \end{codeblock}
 
 \ref{lex.pptoken}
-\change User-defined literal string support
+\change User-defined literal string support.
 \rationale Required for new features.
 \effect
 Valid \CppIII code may fail to compile or produce different results in
@@ -859,10 +858,10 @@ this International Standard, as the following example illustrates.
 
 Previously, \#1 would have consisted of two separate preprocessing tokens and
 the macro \tcode{_x} would have been expanded. In this International Standard,
-\#1 consists of a single preprocessing tokens, so the macro is not expanded.
+\#1 consists of a single preprocessing token, so the macro is not expanded.
 
 \ref{lex.key}
-\change New keywords
+\change New keywords.
 \rationale Required for new features.
 \effect
 Added to Table~\ref{tab:keywords}, the following identifiers are new keywords:
@@ -881,7 +880,7 @@ Valid \CppIII code using these identifiers is invalid in this International
 Standard.
 
 \ref{lex.icon}
-\change Type of integer literals
+\change Type of integer literals.
 \rationale C99 compatibility.
 \effect
 Certain integer literals larger than can be represented by \tcode{long} could
@@ -890,9 +889,9 @@ change from an unsigned integer type to \tcode{signed long long}.
 \rSec2[diff.cpp03.conv]{Clause~\ref{conv}: standard conversions}
 
 \ref{conv.ptr}
-\change Only literals are integer null pointer constants
+\change Only literals are integer null pointer constants.
 \rationale Removing surprising interactions with templates and constant
-expressions
+expressions.
 \effect Valid \CppIII code may fail to compile or produce different results in
 this International Standard, as the following example illustrates:
 
@@ -907,7 +906,7 @@ template<int N> void g() {
 \rSec2[diff.cpp03.expr]{Clause \ref{expr}: expressions}
 
 \ref{expr.mul}
-\change Specify rounding for results of integer \tcode{/} and \tcode{\%}
+\change Specify rounding for results of integer \tcode{/} and \tcode{\%}.
 \rationale Increase portability, C99 compatibility.
 \effect
 Valid \CppIII code that uses integer division rounds the result toward 0 or
@@ -915,7 +914,7 @@ toward negative infinity, whereas this International Standard always rounds
 the result toward 0.
 
 \ref{expr.log.and}
-\change \tcode{\&\&} is valid in a \grammarterm{type-name}
+\change \tcode{\&\&} is valid in a \grammarterm{type-name}.
 \rationale Required for new features.
 \effect 
 Valid \CppIII code may fail to compile or produce different results in
@@ -930,7 +929,7 @@ bool b2 = &S::operator int && false;  // previously \tcode{false}, now ill-forme
 \rSec2[diff.cpp03.dcl.dcl]{Clause \ref{dcl.dcl}: declarations}
 
 \ref{dcl.spec}
-\change Remove \tcode{auto} as a storage class specifier
+\change Remove \tcode{auto} as a storage class specifier.
 \rationale New feature.
 \effect
 Valid \CppIII code that uses the keyword \tcode{auto} as a storage class
@@ -941,7 +940,7 @@ from its initializer expression.
 \rSec2[diff.cpp03.dcl.decl]{Clause \ref{dcl.decl}: declarators}
 
 \ref{dcl.init.list}
-\change Narrowing restrictions in aggregate initializers
+\change Narrowing restrictions in aggregate initializers.
 \rationale Catches bugs.
 \effect
 Valid \CppIII code may fail to compile in this International Standard. For
@@ -979,7 +978,7 @@ and not \tcode{noexcept(true)}.
 \rSec2[diff.cpp03.temp]{Clause \ref{temp}: templates}
 
 \ref{temp.param}
-\change Remove \tcode{export}
+\change Remove \tcode{export}.
 \rationale No implementation consensus.
 \effect
 A valid \CppIII declaration containing \tcode{export} is ill-formed in this
@@ -987,7 +986,7 @@ International Standard.
 
 \ref{temp.arg}
 \change Remove whitespace requirement for nested closing template right angle
-brackets
+brackets.
 \rationale Considered a persistent but minor annoyance. Template aliases
 representing nonclass types would exacerbate whitespace issues.
 \effect
@@ -1005,7 +1004,7 @@ X< Y< 1 >> 2 > > x;
 \end{codeblock}
 
 \ref{temp.dep.candidate}
-\change Allow dependent calls of functions with internal linkage
+\change Allow dependent calls of functions with internal linkage.
 \rationale Overly constrained, simplify overload resolution rules.
 \effect
 A valid \CppIII program could get a different result than this
@@ -1014,17 +1013,17 @@ International Standard.
 \rSec2[diff.cpp03.library]{Clause \ref{library}: library introduction}
 
 \ref{library} -- \ref{\lastlibchapter}
-\change New reserved identifiers
+\change New reserved identifiers.
 \rationale Required by new features.
 \effect
 Valid \CppIII code that uses any identifiers added to the \Cpp standard
 library by this International Standard may fail to compile or produce different
-results in This International Standard. A comprehensive list of identifiers used
+results in this International Standard. A comprehensive list of identifiers used
 by the \Cpp standard library can be found in the Index of Library Names in this
 International Standard.
 
 \ref{headers}
-\change New headers
+\change New headers.
 \rationale New functionality.
 \effect
 The following \Cpp headers are new:
@@ -1069,7 +1068,7 @@ invalid in this International Standard.
 \tcode{<algorithm>} may have to instead include \tcode{<utility>}.
 
 \ref{namespace.posix}
-\change New reserved namespace
+\change New reserved namespace.
 \rationale New functionality.
 \effect
 The global namespace \tcode{posix} is now reserved for standardization. Valid
@@ -1077,7 +1076,7 @@ The global namespace \tcode{posix} is now reserved for standardization. Valid
 this International Standard.
 
 \ref{res.on.macro.definitions}
-\change Additional restrictions on macro names
+\change Additional restrictions on macro names.
 \rationale Avoid hard to diagnose or non-portable constructs.
 \effect
 Names of attribute identifiers may not be used as macro names. Valid \Cpp
@@ -1089,7 +1088,7 @@ International Standard.
 language support library}
 
 \ref{new.delete.single}
-\change Linking \tcode{new} and \tcode{delete} operators
+\change Linking \tcode{new} and \tcode{delete} operators.
 \rationale The two throwing single-object signatures of \tcode{operator new} and
 \tcode{operator delete} are now specified to form the base functionality for
 the other operators. This clarifies that replacing just these two signatures
@@ -1125,7 +1124,7 @@ int main() {
 
 \ref{new.delete.single}
 \change \tcode{operator new} may throw exceptions other than
-\tcode{std::bad_alloc}
+\tcode{std::bad_alloc}.
 \rationale Consistent application of \tcode{noexcept}.
 \effect
 Valid \CppIII code that assumes that global \tcode{operator new} only
@@ -1135,7 +1134,7 @@ Standard.
 \rSec2[diff.cpp03.diagnostics]{Clause \ref{diagnostics}: diagnostics library}
 
 \ref{errno}
-\change Thread-local error numbers
+\change Thread-local error numbers.
 \rationale Support for new thread facilities.
 \effect Valid but implementation-specific \CppIII code that relies on
 \tcode{errno} being the same across threads may change behavior in this
@@ -1144,7 +1143,7 @@ International Standard.
 \rSec2[diff.cpp03.utilities]{Clause \ref{utilities}: general utilities library}
 
 \ref{util.dynamic.safety}
-\change Minimal support for garbage-collected regions
+\change Minimal support for garbage-collected regions.
 \rationale Required by new feature.
 \effect
 Valid \CppIII code, compiled without traceable pointer support,
@@ -1154,7 +1153,7 @@ have different runtime behavior.
 \ref{refwrap}, \ref{arithmetic.operations}, \ref{comparisons},
 \ref{logical.operations}, \ref{bitwise.operations}, \ref{depr.negators}
 \change Standard function object types no longer derived from
-\tcode{std::unary_function} or \tcode{std::binary_function}
+\tcode{std::unary_function} or \tcode{std::binary_function}.
 \rationale Superseded by new feature; \tcode{unary_function} and
 \tcode{binary_function} are no longer defined.
 \effect
@@ -1166,14 +1165,14 @@ in this International Standard.
 
 \ref{string.classes}
 \change \tcode{basic_string} requirements no longer allow reference-counted
-strings
+strings.
 \rationale Invalidation is subtly different with reference-counted strings.
 This change regularizes behavior for this International Standard.
 \effect
 Valid \CppIII code may execute differently in this International Standard.
 
 \ref{string.require}
-\change Loosen \tcode{basic_string} invalidation rules
+\change Loosen \tcode{basic_string} invalidation rules.
 \rationale Allow small-string optimization.
 \effect
 Valid \CppIII code may execute differently in this International Standard.
@@ -1183,7 +1182,7 @@ no longer invalidate iterators.
 \rSec2[diff.cpp03.containers]{Clause \ref{containers}: containers library}
 
 \ref{container.requirements}
-\change Complexity of \tcode{size()} member functions now constant
+\change Complexity of \tcode{size()} member functions now constant.
 \rationale Lack of specification of complexity of \tcode{size()} resulted in
 divergent implementations with inconsistent performance characteristics.
 \effect
@@ -1193,7 +1192,7 @@ containers such as \tcode{std::list} to the stricter requirements may require
 incompatible changes.
 
 \ref{container.requirements}
-\change Requirements change: relaxation
+\change Requirements change: relaxation.
 \rationale Clarification.
 \effect
 Valid \CppIII code that attempts to meet the specified container requirements
@@ -1207,14 +1206,14 @@ of \tcode{size() == 0};
 \end{itemize}
 
 \ref{container.requirements}
-\change Requirements change: default constructible
+\change Requirements change: default constructible.
 \rationale Clarification of container requirements.
 \effect
 Valid \CppIII code that attempts to explicitly instantiate a container using
 a user-defined type with no default constructor may fail to compile.
 
 \ref{sequence.reqmts}, \ref{associative.reqmts}
-\change Signature changes: from \tcode{void} return types
+\change Signature changes: from \tcode{void} return types.
 \rationale Old signature threw away useful information that may be expensive
 to recalculate.
 \effect
@@ -1232,7 +1231,7 @@ of these functions) will fail to compile with this International Standard.
 
 \ref{sequence.reqmts}, \ref{associative.reqmts}
 \change Signature changes: from \tcode{iterator} to \tcode{const_iterator}
-parameters
+parameters.
 \rationale Overspecification.
 \effect
 The signatures of the following member functions changed from taking an
@@ -1252,7 +1251,7 @@ Valid \CppIII code that uses these functions may fail to compile with this
 International Standard.
 
 \ref{sequence.reqmts}, \ref{associative.reqmts}
-\change Signature changes: \tcode{resize}
+\change Signature changes: \tcode{resize}.
 \rationale Performance, compatibility with move semantics.
 \effect
 For \tcode{vector}, \tcode{deque}, and \tcode{list}
@@ -1264,7 +1263,7 @@ Standard.
 \rSec2[diff.cpp03.algorithms]{Clause \ref{algorithms}: algorithms library}
 
 \ref{algorithms.general}
-\change Result state of inputs after application of some algorithms
+\change Result state of inputs after application of some algorithms.
 \rationale Required by new feature.
 \effect
 A valid \CppIII program may detect that an object with a valid but
@@ -1276,7 +1275,7 @@ different set of values than previously.
 \rSec2[diff.cpp03.numerics]{Clause \ref{numerics}: numerics library}
 
 \ref{complex.numbers}
-\change Specified representation of complex numbers
+\change Specified representation of complex numbers.
 \rationale Compatibility with C99.
 \effect
 Valid \CppIII code that uses implementation-specific knowledge about the
@@ -1304,7 +1303,7 @@ following conditions:
 \end{itemize}
 
 \ref{ios::failure}
-\change Change base class of \tcode{std::ios_base::failure}
+\change Change base class of \tcode{std::ios_base::failure}.
 \rationale More detailed error messages.
 \effect
 \tcode{std::ios_base::failure} is no longer derived directly from
@@ -1315,7 +1314,7 @@ that assumes that \tcode{std::ios_base::failure} is derived directly from
 
 \ref{ios.base}
 \change Flag types in \tcode{std::ios_base} are now bitmasks with values
-defined as constexpr static members
+defined as constexpr static members.
 \rationale Required for new features.
 \effect
 Valid \CppIII code that relies on \tcode{std::ios_base} flag types being
@@ -1361,7 +1360,7 @@ int x[2] = { M(1'2,3'4, 5) };
 \rSec2[diff.cpp11.basic]{Clause \ref{basic}: basic concepts}
 
 \ref{basic.stc.dynamic.deallocation}
-\change New usual (non-placement) deallocator 
+\change New usual (non-placement) deallocator.
 \rationale Required for sized deallocation.
 \effect Valid \CppXI code could declare a global placement allocation function and
 deallocation function as follows:
@@ -1495,7 +1494,7 @@ the basic source character set.
 
 \ref{lex.ppnumber}
 \change \grammarterm{pp-number} can contain \tcode{p} \grammarterm{sign} and
-\tcode{P} \grammarterm{sign}
+\tcode{P} \grammarterm{sign}.
 \rationale Necessary to enable hexadecimal floating literals.
 \effect
 Valid \CppXIV code may fail to compile or produce different results in


### PR DESCRIPTION
Consistently end the 'Changes' phrase with a period.
Add missing newlines.
Remove spurious 'Rationale' item.
Fix typos.

Fixes #214.