### PR TITLE
[dcl.decl] Turn very large footnote into ordinary note.

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -55,51 +55,45 @@ initializers are discussed in~\ref{dcl.init} and~\ref{class.init}.
 \pnum
 Each
 \grammarterm{init-declarator}
-in a declaration is analyzed separately as if it was in a declaration by
-itself.\footnote{A declaration with several declarators is usually equivalent
-to the corresponding sequence of declarations each with a single declarator.
-That is
-
-\tcode{T  D1, D2, ... Dn;}
-
-\noindent is usually equivalent to
-
-\tcode{T  D1; T D2; ... T Dn;}
-
-\noindent where
-\tcode{T}
-is a
-\grammarterm{decl-specifier-seq}
-and each
-\tcode{Di}
-is an
-\grammarterm{init-declarator}.
-An exception occurs when a name introduced by one of the
-\grammarterm{declarator}{s}
-hides a type name used by the
-\grammarterm{decl-specifiers},
-so that when the same
-\grammarterm{decl-specifiers}
-are used in a subsequent declaration, they do not have the same meaning,
-as in
-
-\tcode{struct S { ... };}\\
-\indent\tcode{S S, T; \textrm{// declare two instances of \tcode{struct S}}}
-
-\noindent which is not equivalent to
-
-\tcode{struct S { ... };}\\
-\indent\tcode{S S;}\\
-\indent\tcode{S T; \textrm{// error}}
-
-\noindent Another exception occurs when \tcode{T} is \tcode{auto}~(\ref{dcl.spec.auto}),
+in a declaration is analyzed separately as if it was in a declaration by itself.
+\begin{note}
+A declaration with several declarators is usually equivalent to the corresponding
+sequence of declarations each with a single declarator. That is
+\begin{codeblock}
+T D1, D2, ... Dn;
+\end{codeblock}
+is usually equivalent to
+\begin{codeblock}
+T D1; T D2; ... T Dn;
+\end{codeblock}
+where \tcode{T} is a \grammarterm{decl-specifier-seq}
+and each \tcode{Di} is an \grammarterm{init-declarator}.
+One exception is when a name introduced by one of the
+\grammarterm{declarator}{s} hides a type name used by the
+\grammarterm{decl-specifiers}, so that when the same
+\grammarterm{decl-specifiers} are used in a subsequent declaration,
+they do not have the same meaning, as in
+\begin{codeblock}
+struct S { ... };
+S S, T;              // declare two instances of \tcode{struct S}
+\end{codeblock}
+which is not equivalent to
+\begin{codeblock}
+struct S { ... };
+S S;
+S T;                 // error
+\end{codeblock}
+Another exception is when \tcode{T} is \tcode{auto}~(\ref{dcl.spec.auto}),
 for example:
-
-\tcode{auto i = 1, j = 2.0; \textrm{// error: deduced types for \tcode{i} and \tcode{j} do not match}}\\
-\noindent as opposed to\\
-\indent\tcode{auto i = 1;    \textrm{// OK: \tcode{i} deduced to have type \tcode{int}}}\\
-\indent\tcode{auto j = 2.0;  \textrm{// OK: \tcode{j} deduced to have type \tcode{double}}}
-}
+\begin{codeblock}
+auto i = 1, j = 2.0; // error: deduced types for \tcode{i} and \tcode{j} do not match
+\end{codeblock}
+as opposed to
+\begin{codeblock}
+auto i = 1;          // OK: \tcode{i} deduced to have type \tcode{int}
+auto j = 2.0;        // OK: \tcode{j} deduced to have type \tcode{double}
+\end{codeblock}
+\end{note}
 
 \pnum
 Declarators have the syntax


### PR DESCRIPTION
This footnote
- is very large
- has very dense vertical layout in the pdf (as a result of being a footnote)
- uses unusual commands for its code formatting (\indent for indentation, \textrm for comments) 
- forgets to escape curly brackets in its tcode fragments, so they're missing in the pdf
- uses unusual commands for its prose formatting (\noindent)
- has unusual code formatting in the pdf (non-italic comments)

Some or all of these issues might be addressable individually, but the easiest way to fix them all in one fell swoop is to just turn this weird creature into a normal note that needs no special treatment or commands. :)

![diff](http://eel.is/fn.png)

(I tried diffpdf's other comparison modes, but they produced even less useful coloring.)