### PR TITLE
[thread.lock] Extract error conditions from 'Throws' element.

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -1967,11 +1967,16 @@ void lock();
 
 \pnum
 \throws
-Any exception thrown by \tcode{pm->lock()}. \tcode{system_error} if an exception
-is required~(\ref{thread.req.exception}). \tcode{system_error} with an error
-condition of \tcode{operation_not_permitted} if \tcode{pm} is 0. \tcode{system_error}
-with an error condition of \tcode{resource_deadlock_would_occur} if on entry \tcode{owns}
+Any exception thrown by \tcode{pm->lock()}. \tcode{system_error} when an exception
+is required~(\ref{thread.req.exception}).
+
+\pnum
+\errors
+\begin{itemize}
+\item \tcode{operation_not_permitted} --- if \tcode{pm} is \tcode{nullptr}.
+\item \tcode{resource_deadlock_would_occur} --- if on entry \tcode{owns}
 is \tcode{true}.
+\end{itemize}
 \end{itemdescr}
 
 \indexlibrarymember{try_lock}{unique_lock}%
@@ -1993,12 +1998,18 @@ requirements~(\ref{thread.req.lockable.req}).
 \postconditions \tcode{owns == res}, where \tcode{res} is the value returned by
 the call to \tcode{try_lock()}.
 
-\pnum\throws
-Any exception thrown by \tcode{pm->try_lock()}. \tcode{system_error} if an exception
-is required~(\ref{thread.req.exception}). \tcode{system_error} with an error
-condition of \tcode{operation_not_permitted} if \tcode{pm} is 0. \tcode{system_error}
-with an error condition of \tcode{resource_deadlock_would_occur} if on entry \tcode{owns}
+\pnum
+\throws
+Any exception thrown by \tcode{pm->try_lock()}. \tcode{system_error} when an exception
+is required~(\ref{thread.req.exception}).
+
+\pnum
+\errors
+\begin{itemize}
+\item \tcode{operation_not_permitted} --- if \tcode{pm} is \tcode{nullptr}.
+\item \tcode{resource_deadlock_would_occur} --- if on entry \tcode{owns}
 is \tcode{true}.
+\end{itemize}
 \end{itemdescr}
 
 \indexlibrarymember{try_lock_until}{unique_lock}%
@@ -2023,11 +2034,16 @@ requirements~(\ref{thread.req.lockable.timed}).
 the call to \tcode{try_lock_until(abs_time)}.
 
 \pnum
-\throws Any exception thrown by \tcode{pm->try_lock_until()}. \tcode{system_error} if an
-exception is required~(\ref{thread.req.exception}). \tcode{system_error} with an error
-condition of \tcode{operation_not_permitted} if \tcode{pm} is 0. \tcode{system_error} with an
-error condition of \tcode{resource_deadlock_would_occur} if on entry \tcode{owns} is
+\throws Any exception thrown by \tcode{pm->try_lock_until()}. \tcode{system_error} when an
+exception is required~(\ref{thread.req.exception}). 
+
+\pnum
+\errors
+\begin{itemize}
+\item \tcode{operation_not_permitted} --- if \tcode{pm} is \tcode{nullptr}.
+\item \tcode{resource_deadlock_would_occur} --- if on entry \tcode{owns} is
 \tcode{true}.
+\end{itemize}
 \end{itemdescr}
 
 \indexlibrarymember{try_lock_for}{unique_lock}%
@@ -2050,11 +2066,16 @@ template <class Rep, class Period>
 \postconditions \tcode{owns == res}, where \tcode{res} is the value returned by the call to \tcode{try_lock_for(rel_time)}.
 
 \pnum
-\throws Any exception thrown by \tcode{pm->try_lock_for()}. \tcode{system_error} if an
-exception is required (\ref{thread.req.exception}). \tcode{system_error} with an error
-condition of \tcode{operation_not_permitted} if \tcode{pm} is 0. \tcode{system_error} with an
-error condition of \tcode{resource_deadlock_would_occur} if on entry \tcode{owns} is
+\throws Any exception thrown by \tcode{pm->try_lock_for()}. \tcode{system_error} when an
+exception is required (\ref{thread.req.exception}).
+
+\pnum
+\errors
+\begin{itemize}
+\item \tcode{operation_not_permitted} --- if \tcode{pm} is \tcode{nullptr}.
+\item \tcode{resource_deadlock_would_occur} --- if on entry \tcode{owns} is
 \tcode{true}.
+\end{itemize}
 \end{itemdescr}
 
 \indexlibrarymember{unlock}{unique_lock}%
@@ -2384,11 +2405,15 @@ void lock();
 
 \pnum
 \throws Any exception thrown by \tcode{pm->lock_shared()}.
-\tcode{system_error} if an exception is required~(\ref{thread.req.exception}).
-\tcode{system_error} with an error condition of
-\tcode{operation_not_permitted} if \tcode{pm} is \tcode{nullptr}.
-\tcode{system_error} with an error condition of
-\tcode{resource_deadlock_would_occur} if on entry \tcode{owns} is \tcode{true}.
+\tcode{system_error} when an exception is required~(\ref{thread.req.exception}).
+
+\pnum
+\errors
+\begin{itemize}
+\item \tcode{operation_not_permitted} --- if \tcode{pm} is \tcode{nullptr}.
+\item \tcode{resource_deadlock_would_occur} --- if on entry \tcode{owns} is
+\tcode{true}.
+\end{itemize}
 \end{itemdescr}
 
 \indexlibrarymember{try_lock}{shared_lock}%
@@ -2409,12 +2434,15 @@ the call to \tcode{pm->try_lock_shared()}.
 
 \pnum
 \throws Any exception thrown by \tcode{pm->try_lock_shared()}.
-\tcode{system_error} if an exception is required~(\ref{thread.req.exception}).
-\tcode{system_error} with an error condition of
-\tcode{operation_not_permitted} if \tcode{pm} is \tcode{nullptr}.
-\tcode{system_error} with an error condition of
-\tcode{resource_deadlock_would_occur} if on entry \tcode{owns} is \tcode{true}.
+\tcode{system_error} when an exception is required~(\ref{thread.req.exception}).
 
+\pnum
+\errors
+\begin{itemize}
+\item \tcode{operation_not_permitted} --- if \tcode{pm} is \tcode{nullptr}.
+\item \tcode{resource_deadlock_would_occur} --- if on entry \tcode{owns} is
+\tcode{true}.
+\end{itemize}
 \end{itemdescr}
 
 \indexlibrarymember{try_lock_until}{shared_lock}%
@@ -2438,11 +2466,15 @@ the call to \tcode{pm->try_lock_shared_until(abs_time)}.
 
 \pnum
 \throws Any exception thrown by \tcode{pm->try_lock_shared_until(abs_time)}.
-\tcode{system_error} if an exception is required~(\ref{thread.req.exception}).
-\tcode{system_error} with an error condition of
-\tcode{operation_not_permitted} if \tcode{pm} is \tcode{nullptr}.
-\tcode{system_error} with an error condition of
-\tcode{resource_deadlock_would_occur} if on entry \tcode{owns} is \tcode{true}.
+\tcode{system_error} when an exception is required~(\ref{thread.req.exception}).
+
+\pnum
+\errors
+\begin{itemize}
+\item \tcode{operation_not_permitted} --- if \tcode{pm} is \tcode{nullptr}.
+\item \tcode{resource_deadlock_would_occur} --- if on entry \tcode{owns} is
+\tcode{true}.
+\end{itemize}
 \end{itemdescr}
 
 \indexlibrarymember{try_lock_for}{shared_lock}%
@@ -2462,7 +2494,15 @@ template <class Rep, class Period>
 \postconditions \tcode{owns == res}, where \tcode{res} is the value returned by the call to \tcode{pm->try_lock_shared_for(rel_time)}.
 
 \pnum
-\throws Any exception thrown by \tcode{pm->try_lock_shared_for(rel_time)}. \tcode{system_error} if an exception is required ~(\ref{thread.req.exception}). \tcode{system_error} with an error condition of \tcode{operation_not_permitted} if \tcode{pm} is \tcode{nullptr}. \tcode{system_error} with an error condition of \tcode{resource_deadlock_would_occur} if on entry \tcode{owns} is \tcode{true}.
+\throws Any exception thrown by \tcode{pm->try_lock_shared_for(rel_time)}. \tcode{system_error} when an exception is required~(\ref{thread.req.exception}).
+
+\pnum
+\errors
+\begin{itemize}
+\item \tcode{operation_not_permitted} --- if \tcode{pm} is \tcode{nullptr}.
+\item \tcode{resource_deadlock_would_occur} --- if on entry \tcode{owns} is
+\tcode{true}.
+\end{itemize}
 \end{itemdescr}
 
 \indexlibrarymember{unlock}{shared_lock}%


### PR DESCRIPTION
Fixes #458.