### PR TITLE
[filesystems] Do not repeat section title in cross-references to [fs.…

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -12630,7 +12630,7 @@ file_status status(error_code& ec) const noexcept;
 \returns \tcode{status(path())} or \tcode{status(path(), ec)}, respectively.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \indexlibrarymember{symlink_status}{directory_entry}%
@@ -12644,7 +12644,7 @@ file_status symlink_status(error_code& ec) const noexcept;
 \returns \tcode{symlink_status(path())} or \tcode{symlink_status(path(), ec)}, respectively.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \indexlibrarymember{operator==}{directory_entry}%
@@ -12832,7 +12832,7 @@ that permission to access \tcode{p} is denied, constructs the end iterator
 and does not report an error.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 
 \pnum
 \begin{note} To iterate over the current directory, use \tcode{directory_iterator(".")} rather than \tcode{directory_iterator("")}. \end{note}
@@ -12887,7 +12887,7 @@ Input iterators~(\ref{input.iterators}).
 \returns \tcode{*this}.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 
 \end{itemdescr}
 
@@ -13025,7 +13025,7 @@ and does not report an error.
 \tcode{directory_options} argument, otherwise \tcode{options() == directory_options::none}.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 
 \pnum
 \begin{note} To iterate over the current directory, use \tcode{recursive_directory_iterator(".")}
@@ -13193,7 +13193,7 @@ treated as an empty directory and no error is reported.
 \returns \tcode{*this}.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \indexlibrarymember{pop}{recursive_directory_iterator}%
@@ -13209,7 +13209,7 @@ void pop(error_code& ec);
   iterated over, and continue iteration over the parent directory.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \indexlibrarymember{disable_recursion_pending}{recursive_directory_iterator}%
@@ -13262,7 +13262,7 @@ in external storage.
 \begin{note} Because hardware failures, network failures, file system races~(\ref{fs.def.race}),
 and many other kinds of errors occur frequently in file system operations, users should be aware
 that any filesystem operation function, no matter how apparently innocuous, may encounter
-an error. See Error reporting~(\ref{fs.err.report}). \end{note}
+an error; see~\ref{fs.err.report}. \end{note}
 
 \rSec3[fs.op.absolute]{Absolute}
 
@@ -13300,7 +13300,7 @@ path absolute(const path& p, const path& base = current_path());
 \begin{note} For the returned path, \tcode{rp}, \tcode{rp.is_absolute()} is \tcode{true}. \end{note}
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \rSec3[fs.op.canonical]{Canonical}
@@ -13325,7 +13325,7 @@ without a \tcode{base} argument, \tcode{base} is \tcode{current_path()}.
 Signatures with argument \tcode{ec} return \tcode{path()} if an error occurs.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 
 \pnum
 \remarks \tcode{!exists(p)} is an error.
@@ -13379,7 +13379,7 @@ then \tcode{auto f = symlink_status(from)} and if needed \tcode{auto t = status(
 Effects are then as follows:
 \begin{itemize}
 \item
-An error is reported as specified in Error reporting~(\ref{fs.err.report}) if:
+An error is reported as specified in~\ref{fs.err.report} if:
 \begin{itemize}
 \item \tcode{!exists(f)}, or
 \item \tcode{equivalent(from, to)}, or
@@ -13398,7 +13398,7 @@ then return.
 !exists(t) && (options & copy_options::copy_symlinks) != copy_options::none
 \end{codeblock}
 then \tcode{copy_symlink(from, to)}.
-\item Otherwise report an error as specified in Error reporting~(\ref{fs.err.report}).
+\item Otherwise report an error as specified in~\ref{fs.err.report}.
 \end{itemize}
 
 \item
@@ -13439,7 +13439,7 @@ Otherwise, no effects.
 \end{itemize}
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 
 \pnum
 \remarks For the signature with argument \tcode{ec}, any
@@ -13501,7 +13501,7 @@ bool copy_file(const path& from, const path& to, error_code& ec) noexcept;
 \tcode{copy_file(from, to, copy_options::none, ec)}, respectively.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 
 \end{itemdescr}
 
@@ -13523,8 +13523,7 @@ bool copy_file(const path& from, const path& to, copy_options options,
 As follows:
 \begin{itemize}
 \item
-Report a file already exists error as specified in
-    Error reporting~(\ref{fs.err.report}) if:
+Report a file already exists error as specified in~\ref{fs.err.report} if:
 \begin{itemize}
 \item \tcode{!is_regular_file(from)}, or
 \item \tcode{exists(to)} and \tcode{!is_regular_file(to)}, or
@@ -13552,7 +13551,7 @@ Otherwise, no effects.
   \tcode{false} if an error occurs.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 
 \pnum
 \complexity At most one direct or indirect invocation of \tcode{status(to)}.
@@ -13576,7 +13575,7 @@ void copy_symlink(const path& existing_symlink, const path& new_symlink,
   \tcode{create_directory_symlink}, as appropriate.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -13601,7 +13600,7 @@ bool create_directories(const path& p, error_code& ec) noexcept;
   error occurs.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 
 \pnum
 \complexity \bigoh{n} where \textit{n} is the number of elements
@@ -13633,7 +13632,7 @@ bool create_directory(const path& p, error_code& ec) noexcept;
   The signature with argument \tcode{ec} returns \tcode{false} if an error occurs.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{create_directory}}%
@@ -13664,7 +13663,7 @@ bool create_directory(const path& p, const path& existing_p, error_code& ec) noe
   The signature with argument \tcode{ec} returns \tcode{false} if an error occurs.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -13686,7 +13685,7 @@ void create_directory_symlink(const path& to, const path& new_symlink,
   contains an unspecified representation of \tcode{to}.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 
 \pnum
 \begin{note} Some operating systems require symlink creation to
@@ -13722,7 +13721,7 @@ void create_hard_link(const path& to, const path& new_hard_link,
 \end{itemize}
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 
 \pnum
 \begin{note} Some operating systems do not support hard links at all or support
@@ -13749,7 +13748,7 @@ void create_symlink(const path& to, const path& new_symlink,
   contains an unspecified representation of \tcode{to}.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 
 \pnum
 \begin{note} Some operating systems do not support symbolic links at all or support
@@ -13774,7 +13773,7 @@ path current_path(error_code& ec);
   error occurs.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 
 \pnum
 \remarks The current working directory is the directory, associated
@@ -13805,7 +13804,7 @@ void current_path(const path& p, error_code& ec) noexcept;
 \postconditions \tcode{equivalent(p, current_path())}.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 
 \pnum
 \begin{note} The current path for many operating systems is a dangerous
@@ -13844,7 +13843,7 @@ Two paths are considered to resolve to the same file system entity if two
   and equal \tcode{st_ino} values.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~(\ref{fs.err.report}).
 \end{itemdescr}
 
 
@@ -13879,7 +13878,7 @@ if \tcode{status_known(s)}.
 \returns \tcode{exists(s)}.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -13902,7 +13901,7 @@ uintmax_t file_size(const path& p, error_code& ec) noexcept;
   if an error occurs.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -13921,7 +13920,7 @@ uintmax_t hard_link_count(const path& p, error_code& ec) noexcept;
   if an error occurs.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -13949,7 +13948,7 @@ bool is_block_file(const path& p, error_code& ec) noexcept;
 The signature with argument \tcode{ec} returns \tcode{false} if an error occurs.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -13979,7 +13978,7 @@ bool is_character_file(const path& p, error_code& ec) noexcept;
   if an error occurs.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -14008,7 +14007,7 @@ bool is_directory(const path& p, error_code& ec) noexcept;
   \tcode{ec} returns \tcode{false} if an error occurs.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -14049,7 +14048,7 @@ Otherwise:
 \end{itemize}
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -14078,7 +14077,7 @@ bool is_fifo(const path& p, error_code& ec) noexcept;
 The signature with argument \tcode{ec} returns \tcode{false} if an error occurs.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -14107,7 +14106,7 @@ bool is_other(const path& p, error_code& ec) noexcept;
   if an error occurs.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -14178,7 +14177,7 @@ bool is_socket(const path& p, error_code& ec) noexcept;
   \tcode{ec} returns \tcode{false} if an error occurs.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -14207,7 +14206,7 @@ bool is_symlink(const path& p, error_code& ec) noexcept;
   if an error occurs.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -14228,7 +14227,7 @@ file_time_type last_write_time(const path& p, error_code& ec) noexcept;
   if an error occurs.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{last_write_time}}%
@@ -14244,7 +14243,7 @@ void last_write_time(const path& p, file_time_type new_time,
   resolved to by \tcode{p} to \tcode{new_time}, as if by POSIX \tcode{futimens()}.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 
 \pnum
 \begin{note} A postcondition of \tcode{last_write_time(p) == new_time} is not specified since it might not hold for file systems
@@ -14291,7 +14290,7 @@ Neither \tcode{add_perms} nor \tcode{remove_perms} &
   implementation may use some other mechanism. \end{note}
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \rSec3[fs.op.proximate]{Proximate}
@@ -14306,7 +14305,7 @@ path proximate(const path& p, error_code& ec);
 \returns \tcode{proximate(p, current_path(), ec)}.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{proximate}}%
@@ -14328,7 +14327,7 @@ weakly_canonical(p, ec).lexically_proximate(weakly_canonical(base, ec));
   or \tcode{path()} at the first error occurrence, if any.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \rSec3[fs.op.read_symlink]{Read symlink}
@@ -14347,7 +14346,7 @@ path read_symlink(const path& p, error_code& ec);
   returns \tcode{path()} if an error occurs.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}). \begin{note} It is an error if \tcode{p} does not
+\throws As specified in~\ref{fs.err.report}. \begin{note} It is an error if \tcode{p} does not
   resolve to a symbolic link. \end{note}
 \end{itemdescr}
 
@@ -14363,7 +14362,7 @@ path relative(const path& p, error_code& ec);
 \returns \tcode{relative(p, current_path(), ec)}.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{relative}}%
@@ -14385,7 +14384,7 @@ weakly_canonical(p, ec).lexically_relative(weakly_canonical(base, ec));
   or \tcode{path()} at the first error occurrence, if any.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \rSec3[fs.op.remove]{Remove}
@@ -14412,7 +14411,7 @@ bool remove(const path& p, error_code& ec) noexcept;
   returns \tcode{false} if an error occurs.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -14440,7 +14439,7 @@ uintmax_t remove_all(const path& p, error_code& ec) noexcept;
   occurs.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -14474,7 +14473,7 @@ A symbolic link is itself renamed, rather than the file it resolves to.
 \end{note}
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -14491,7 +14490,7 @@ void resize_file(const path& p, uintmax_t new_size, error_code& ec) noexcept;
 \postconditions \tcode{file_size(p) == new_size}.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 
 \pnum
 \remarks Achieves its postconditions as if by POSIX \tcode{truncate()}.
@@ -14520,7 +14519,7 @@ space_info space(const path& p, error_code& ec) noexcept;
   \tcode{static_cast<uintmax_t>(-1)} if an error occurs.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 
 \pnum
 \remarks The value of member \tcode{space_info::available}
@@ -14672,7 +14671,7 @@ of the obtained \tcode{struct stat} to the type \tcode{perms}.
 \remarks Pathname resolution terminates if \tcode{p} names a symbolic link.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -14698,7 +14697,7 @@ path system_complete(const path& p, error_code& ec);
 \postconditions For the returned path, \tcode{rp}, \tcode{rp.is_absolute()} is \tcode{true}.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 
 \pnum
 \begin{example} For POSIX-based operating systems, \tcode{system_complete(p)}
@@ -14734,7 +14733,7 @@ path temp_directory_path(error_code& ec);
   error occurs.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 
 \pnum
 \begin{example} For POSIX-based operating systems, an implementation might
@@ -14786,7 +14785,7 @@ path weakly_canonical(const path& p, error_code& ec);
   when \tcode{canonical()} has already been called on the entirety of \tcode{p}.
 
 \pnum
-\throws As specified in Error reporting~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \rSec1[c.files]{C library files}


### PR DESCRIPTION
…err.report].

Fixes #1116.