### PR TITLE
[re.matchflag] Remove namespace qualification when mentioning match_f…

### DIFF
--- a/source/regex.tex
+++ b/source/regex.tex
@@ -779,7 +779,7 @@ option in POSIX.
 %
 \end{libefftab}
 
-\rSec2[re.matchflag]{Bitmask type \tcode{regex_constants::match_flag_type}}
+\rSec2[re.matchflag]{Bitmask type \tcode{match_flag_type}}
 
 \indexlibrary{\idxcode{match_flag_type}}%
 \indexlibrary{\idxcode{regex_constants}!\idxcode{match_flag_type}}%
@@ -817,7 +817,7 @@ namespace std::regex_constants {
 
 \pnum
 \indexlibrary{\idxcode{match_flag_type}}%
-The type \tcode{regex_constants::match_flag_type} is an
+The type \tcode{match_flag_type} is an
 \impldef{type of \tcode{regex_constants::match_flag_type}} bitmask type~(\ref{bitmask.types}).
 The constants of that type, except for \tcode{match_default} and
 \tcode{format_default}, are bitmask elements. The \tcode{match_default} and


### PR DESCRIPTION
…lag_type.

Fixes #443.