### PR TITLE
[variant] Use \tcode for type designators, not math mode.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -4220,7 +4220,7 @@ no template arguments is ill-formed.
 
 \pnum
 In the descriptions that follow, let $i$ be in the range \range{0}{sizeof...(Types)},
-and $T_i$ be the $i^{th}$ type in \tcode{Types...}.
+and \tcode{T}$_i$ be the $i^{th}$ type in \tcode{Types...}.
 
 \indexlibrary{\idxcode{variant}!constructor}%
 \begin{itemdecl}
@@ -4230,7 +4230,7 @@ constexpr variant() noexcept(@\seebelow@);
 \begin{itemdescr}
 \pnum
 \effects
-Constructs a \tcode{variant} holding a value-initialized value of type $T_0$.
+Constructs a \tcode{variant} holding a value-initialized value of type \tcode{T}$_0$.
 
 \pnum
 \postconditions
@@ -4238,17 +4238,17 @@ Constructs a \tcode{variant} holding a value-initialized value of type $T_0$.
 
 \pnum
 \throws
-Any exception thrown by the value-initialization of $T_0$.
+Any exception thrown by the value-initialization of \tcode{T}$_0$.
 
 \pnum
 \remarks
 This function shall be \tcode{constexpr} if and only if the
-value-initialization of the alternative type $T_0$ would satisfy the
+value-initialization of the alternative type \tcode{T}$_0$ would satisfy the
 requirements for a \tcode{constexpr} function.
 The expression inside \tcode{noexcept} is equivalent to
-\tcode{is_nothrow_default_constructible_v<$T_0$>}.
+\tcode{is_nothrow_default_constructible_v<\tcode{T}$_0$>}.
 This function shall not participate in overload resolution unless
-\tcode{is_default_constructible_v<$T_0$>} is \tcode{true}.
+\tcode{is_default_constructible_v<\tcode{T}$_0$>} is \tcode{true}.
 \begin{note} See also class \tcode{monostate}. \end{note}
 \end{itemdescr}
 
@@ -4267,12 +4267,12 @@ Otherwise, initializes the \tcode{variant} to not hold a value.
 
 \pnum
 \throws
-Any exception thrown by direct-initializing any $T_i$ for all $i$.
+Any exception thrown by direct-initializing any \tcode{T}$_i$ for all $i$.
 
 \pnum
 \remarks
 This function shall not participate in overload resolution unless
-\tcode{is_copy_constructible_v<$T_i$>} is \tcode{true} for all $i$.
+\tcode{is_copy_constructible_v<\tcode{T}$_i$>} is \tcode{true} for all $i$.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{variant}!constructor}%
@@ -4290,14 +4290,14 @@ Otherwise, initializes the \tcode{variant} to not hold a value.
 
 \pnum
 \throws
-Any exception thrown by move-constructing any $T_i$ for all $i$.
+Any exception thrown by move-constructing any \tcode{T}$_i$ for all $i$.
 
 \pnum
 \remarks
 The expression inside \tcode{noexcept} is equivalent to the logical AND of
-\tcode{is_nothrow_move_constructible_v<$T_i$>} for all $i$.
+\tcode{is_nothrow_move_constructible_v<\tcode{T}$_i$>} for all $i$.
 This function shall not participate in overload resolution unless
-\tcode{is_move_constructible_v<$T_i$>} is \tcode{true} for all $i$.
+\tcode{is_move_constructible_v<\tcode{T}$_i$>} is \tcode{true} for all $i$.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{variant}!constructor}%
@@ -4307,25 +4307,25 @@ template <class T> constexpr variant(T&& t) noexcept(@\seebelow@);
 
 \begin{itemdescr}
 \pnum
-Let $T_j$ be a type that is determined as follows:
-build an imaginary function \tcode{\textit{FUN}($T_i$)} for each alternative type $T_i$. The overload \tcode{\textit{FUN}($T_j$)} selected by overload
+Let \tcode{T}$_j$ be a type that is determined as follows:
+build an imaginary function \tcode{\textit{FUN}(\tcode{T}$_i$)} for each alternative type \tcode{T}$_i$. The overload \tcode{\textit{FUN}(\tcode{T}$_j$)} selected by overload
 resolution for the expression \tcode{\textit{FUN}(std::forward<T>(\brk{}t))} defines
-the alternative $T_j$ which is the type of the contained value after
+the alternative \tcode{T}$_j$ which is the type of the contained value after
 construction.
 
 \pnum
 \effects
-Initializes \tcode{*this} to hold the alternative type $T_j$ and
+Initializes \tcode{*this} to hold the alternative type \tcode{T}$_j$ and
 direct-initializes the contained value as if direct-non-list-initializing it
 with \tcode{std::forward<T>(t)}.
 
 \pnum
 \postconditions
-\tcode{holds_alternative<$T_j$>(*this)} is \tcode{true}.
+\tcode{holds_alternative<T$_j$>(*this)} is \tcode{true}.
 
 \pnum
 \throws
-Any exception thrown by the initialization of the selected alternative $T_j$.
+Any exception thrown by the initialization of the selected alternative \tcode{T}$_j$.
 
 \pnum
 \remarks
@@ -4334,7 +4334,7 @@ This function shall not participate in overload resolution unless
 unless \tcode{decay_t<T>} is neither
 a specialization of \tcode{in_place_type_t}
 nor a specialization of \tcode{in_place_index_t},
-unless \tcode{is_constructible_v<$T_j$, T>} is \tcode{true},
+unless \tcode{is_constructible_v<T$_j$, T>} is \tcode{true},
 and unless the expression
 \tcode{\textit{FUN}(}\brk\tcode{std::forward<T>(t))} (with \tcode{\textit{FUN}}
 being the above-mentioned set of imaginary functions) is well formed.
@@ -4349,8 +4349,8 @@ for the argument. \end{note}
 
 \pnum
 The expression inside \tcode{noexcept} is equivalent to
-\tcode{is_nothrow_constructible_v<$T_j$, T>}.
-If $T_j$'s selected constructor is a constexpr constructor,
+\tcode{is_nothrow_constructible_v<T$_j$, T>}.
+If \tcode{T}$_j$'s selected constructor is a constexpr constructor,
 this constructor shall be a constexpr constructor.
 \end{itemdescr}
 
@@ -4418,7 +4418,7 @@ template <size_t I, class... Args> constexpr explicit variant(in_place_index_t<I
 \begin{itemdescr}
 \pnum
 \effects
-Initializes the contained value as if constructing an object of type $T_I$
+Initializes the contained value as if constructing an object of type \tcode{T}$_I$
 with the arguments \tcode{std::forward<Args>(args)...}.
 
 \pnum
@@ -4427,13 +4427,13 @@ with the arguments \tcode{std::forward<Args>(args)...}.
 
 \pnum
 \throws
-Any exception thrown by calling the selected constructor of $T_I$.
+Any exception thrown by calling the selected constructor of \tcode{T}$_I$.
 
 \pnum
 \remarks
 This function shall not participate in overload resolution unless \tcode{I} is
-less than \tcode{sizeof...(Types)} and \tcode{is_constructible_v<$T_I$, Args...>} is \tcode{true}.
-If $T_I$'s selected constructor is a \tcode{constexpr} constructor, this
+less than \tcode{sizeof...(Types)} and \tcode{is_constructible_v<T$_I$, Args...>} is \tcode{true}.
+If \tcode{T}$_I$'s selected constructor is a \tcode{constexpr} constructor, this
 constructor shall be a constexpr constructor.
 \end{itemdescr}
 
@@ -4447,7 +4447,7 @@ template <size_t I, class U, class... Args>
 \pnum
 \effects
 Initializes the contained value as if constructing an object of type
-$T_I$ with the arguments \tcode{il, std::forward<Args>(args)...}.
+\tcode{T}$_I$ with the arguments \tcode{il, std::forward<Args>(args)...}.
 
 \pnum
 \postconditions
@@ -4457,8 +4457,8 @@ $T_I$ with the arguments \tcode{il, std::forward<Args>(args)...}.
 \remarks
 This function shall not participate in overload resolution unless \tcode{I} is
 less than \tcode{sizeof...(Types)} and
-\tcode{is_constructible_v<$T_I$, initializer_list<U>\&, Args...>} is \tcode{true}.
-If $T_I$'s selected constructor is a \tcode{constexpr} constructor, this
+\tcode{is_constructible_v<T$_I$, initializer_list<U>\&, Args...>} is \tcode{true}.
+If \tcode{T}$_I$'s selected constructor is a \tcode{constexpr} constructor, this
 constructor shall be a constexpr constructor.
 \end{itemdescr}
 
@@ -4511,7 +4511,7 @@ destroys the currently contained value.
 
 \pnum
 \remarks
-If \tcode{is_trivially_destructible_v<$T_i$> == true} for all $T_i$
+If \tcode{is_trivially_destructible_v<T$_i$> == true} for all \tcode{T}$_i$
 then this destructor shall be a trivial destructor.
 \end{itemdescr}
 
@@ -4538,8 +4538,8 @@ to the value contained in \tcode{*this}. Otherwise,
 copies the value contained in \tcode{rhs} to a temporary, then destroys any
 value contained in \tcode{*this}. Sets \tcode{*this} to hold the same
 alternative index as \tcode{rhs} and initializes the value contained in
-\tcode{*this} as if direct-non-list-initializing an object of type $T_j$
-with \tcode{std::forward<$T_j$>(TMP),} with \tcode{TMP} being the temporary and
+\tcode{*this} as if direct-non-list-initializing an object of type \tcode{T}$_j$
+with \tcode{std::forward<T$_j$>(TMP),} with \tcode{TMP} being the temporary and
 $j$ being \tcode{rhs.index()}.
 \end{itemize}
 
@@ -4552,15 +4552,15 @@ $j$ being \tcode{rhs.index()}.
 \pnum
 \remarks
 This function shall not participate in overload resolution unless
-\tcode{is_copy_constructible_v<$T_i$> \&\& is_move_constructible_v<$T_i$> \&\& is_copy_assignable_v<$T_i$>}
+\tcode{is_copy_constructible_v<T$_i$> \&\& is_move_constructible_v<T$_i$> \&\& is_copy_assignable_v<T$_i$>}
 is \tcode{true} for all $i$.
 \begin{itemize}
-\item If an exception is thrown during the call to $T_j$'s copy assignment,
+\item If an exception is thrown during the call to \tcode{T}$_j$'s copy assignment,
 the state of the contained value is as defined by the exception safety
-guarantee of $T_j$'s copy assignment; \tcode{index()} will be $j$.
-\item If an exception is thrown during the call to $T_j$'s copy construction
+guarantee of \tcode{T}$_j$'s copy assignment; \tcode{index()} will be $j$.
+\item If an exception is thrown during the call to \tcode{T}$_j$'s copy construction
 (with $j$ being \tcode{rhs.index()}), \tcode{*this} will remain unchanged.
-\item If an exception is thrown during the call to $T_j$'s move construction,
+\item If an exception is thrown during the call to \tcode{T}$_j$'s move construction,
 the \tcode{variant} will hold no value.
 \end{itemize}
 \end{itemdescr}
@@ -4585,7 +4585,7 @@ the value contained in \tcode{*this}, with $j$ being \tcode{index()}. Otherwise,
 \item
 destroys any value contained in \tcode{*this}. Sets \tcode{*this} to hold the
 same alternative index as \tcode{rhs} and initializes the value contained in
-\tcode{*this} as if direct-non-list-initializing an object of type $T_j$
+\tcode{*this} as if direct-non-list-initializing an object of type \tcode{T}$_j$
 with \tcode{get<$j$>(std::move(rhs))} with $j$ being \tcode{rhs.index()}.
 \end{itemize}
 
@@ -4595,16 +4595,16 @@ with \tcode{get<$j$>(std::move(rhs))} with $j$ being \tcode{rhs.index()}.
 \pnum
 \remarks
 This function shall not participate in overload resolution unless
-\tcode{is_move_constructible_v<$T_i$> \&\& is_move_assignable_v<$T_i$>} is
+\tcode{is_move_constructible_v<T$_i$> \&\& is_move_assignable_v<T$_i$>} is
 \tcode{true} for all $i$.
 The expression inside \tcode{noexcept} is equivalent to:
-\tcode{is_nothrow_move_constructible_v<$T_i$> \&\& is_nothrow_move_assignable_v<$T_i$>} for all $i$.
+\tcode{is_nothrow_move_constructible_v<T$_i$> \&\& is_nothrow_move_assignable_v<T$_i$>} for all $i$.
 \begin{itemize}
-\item If an exception is thrown during the call to $T_j$'s move construction
+\item If an exception is thrown during the call to \tcode{T}$_j$'s move construction
 (with $j$ being \tcode{rhs.index())}, the \tcode{variant} will hold no value.
-\item If an exception is thrown during the call to $T_j$'s move assignment,
+\item If an exception is thrown during the call to \tcode{T}$_j$'s move assignment,
 the state of the contained value is as defined by the exception safety
-guarantee of $T_j$'s move assignment; \tcode{index()} will be $j$.
+guarantee of \tcode{T}$_j$'s move assignment; \tcode{index()} will be $j$.
 \end{itemize}
 \end{itemdescr}
 
@@ -4615,25 +4615,25 @@ template <class T> variant& operator=(T&& t) noexcept(@\seebelow@);
 
 \begin{itemdescr}
 \pnum
-Let $T_j$ be a type that is determined as follows:
-build an imaginary function \tcode{\textit{FUN}($T_i$)} for each alternative type
-$T_i$. The overload \tcode{\textit{FUN}($T_j$)} selected by overload
+Let \tcode{T}$_j$ be a type that is determined as follows:
+build an imaginary function \tcode{\textit{FUN}(T$_i$)} for each alternative type
+\tcode{T}$_i$. The overload \tcode{\textit{FUN}(T$_j$)} selected by overload
 resolution for the expression \tcode{\textit{FUN}(std::forward<T>(\brk{}t))} defines
-the alternative $T_j$ which is the type of the contained value after
+the alternative \tcode{T}$_j$ which is the type of the contained value after
 assignment.
 
 \pnum
 \effects
-If \tcode{*this} holds a $T_j$, assigns \tcode{std::forward<T>(t)} to
+If \tcode{*this} holds a \tcode{T}$_j$, assigns \tcode{std::forward<T>(t)} to
 the value contained in \tcode{*this}. Otherwise, destroys any value contained
-in \tcode{*this}, sets \tcode{*this} to hold the alternative type $T_j$
+in \tcode{*this}, sets \tcode{*this} to hold the alternative type \tcode{T}$_j$
 as selected by the imaginary function overload resolution described above,
 and direct-initializes the contained value as if direct-non-list-initializing
 it with \tcode{std::forward<T>(t)}.
 
 \pnum
 \postconditions
-\tcode{holds_alternative<$T_j$>(*this)} is \tcode{true}, with $T_j$
+\tcode{holds_alternative<T$_j$>(*this)} is \tcode{true}, with \tcode{T}$_j$
 selected by the imaginary function overload resolution described above.
 
 \pnum
@@ -4643,7 +4643,7 @@ selected by the imaginary function overload resolution described above.
 \remarks
 This function shall not participate in overload resolution unless
 \tcode{is_same_v<decay_t<T>, variant>} is \tcode{false}, unless
-\tcode{is_assignable_v<$T_j$\&, T> \&\& is_constructible_v<$T_j$, T>} is \tcode{true},
+\tcode{is_assignable_v<T$_j$\&, T> \&\& is_constructible_v<T$_j$, T>} is \tcode{true},
 and unless the expression \tcode{\textit{FUN}(std::forward<T>(t))} (with
 \tcode{\textit{FUN}} being the above-mentioned set of imaginary functions)
 is well formed.
@@ -4659,7 +4659,7 @@ for the argument. \end{note}
 
 \pnum
 The expression inside \tcode{noexcept} is equivalent to:
-\tcode{is_nothrow_assignable_v<$T_j$\&, T> \&\& is_nothrow_constructible_v<$T_j$, T>}.
+\tcode{is_nothrow_assignable_v<T$_j$\&, T> \&\& is_nothrow_constructible_v<T$_j$, T>}.
 \begin{itemize}
 \item If an exception is thrown during the assignment of \tcode{std::forward<T>(t)}
 to the value contained in \tcode{*this}, the state of the contained value and
@@ -4722,7 +4722,7 @@ template <size_t I, class... Args> void emplace(Args&&... args);
 \effects
 Destroys the currently contained value if \tcode{valueless_by_exception()}
 is \tcode{false}. Then direct-initializes the contained value as if
-constructing a value of type $T_I$ with the arguments
+constructing a value of type \tcode{T}$_I$ with the arguments
 \tcode{std::forward<Ar\-gs>(args)...}.
 
 \pnum
@@ -4736,7 +4736,7 @@ Any exception thrown during the initialization of the contained value.
 \pnum
 \remarks
 This function shall not participate in overload resolution unless
-\tcode{is_constructible_v<$T_I$, Args...>} is \tcode{true}.
+\tcode{is_constructible_v<T$_I$, Args...>} is \tcode{true}.
 If an exception is thrown during the initialization of the contained value,
 the \tcode{variant} might not hold a value.
 \end{itemdescr}
@@ -4755,7 +4755,7 @@ template <size_t I, class U, class... Args> void emplace(initializer_list<U> il,
 \effects
 Destroys the currently contained value if \tcode{valueless_by_exception()}
 is \tcode{false}. Then direct-initializes the contained value as if
-constructing a value of type $T_I$ with the arguments
+constructing a value of type \tcode{T}$_I$ with the arguments
 \tcode{il, std::forward<Args>(args)...}.
 
 \pnum
@@ -4769,7 +4769,7 @@ Any exception thrown during the initialization of the contained value.
 \pnum
 \remarks
 This function shall not participate in overload resolution unless
-\tcode{is_constructible_v<$T_I$, initializer_list<U>\&, Args...>} is \tcode{true}.
+\tcode{is_constructible_v<T$_I$, initializer_list<U>\&, Args...>} is \tcode{true}.
 If an exception is thrown during the initialization of the contained value,
 the \tcode{variant} might not hold a value.
 \end{itemdescr}
@@ -4821,8 +4821,8 @@ void swap(variant& rhs) noexcept(@\seebelow@);
 
 \begin{itemdescr}
 \pnum
-\requires Lvalues of type \tcode{$T_i$} shall be swappable~(\ref{swappable.requirements}) and
-\tcode{is_move_constructible_v<$T_i$>} shall be \tcode{true} for all $i$.
+\requires Lvalues of type \tcode{T}$_i$ shall be swappable~(\ref{swappable.requirements}) and
+\tcode{is_move_constructible_v<T$_i$>} shall be \tcode{true} for all $i$.
 
 \pnum
 \effects
@@ -4841,7 +4841,7 @@ If \tcode{index() == rhs.index()},
 any exception thrown by \tcode{swap(get<$i$>(*this), get<$i$>(rhs))}
 with $i$ being \tcode{index()}.
 Otherwise, any exception thrown by the move constructor
-of \tcode{$T_i$} or \tcode{$T_j$}
+of \tcode{T}$_i$ or \tcode{T}$_j$
 with $i$ being \tcode{index()} and $j$ being \tcode{rhs.index()}.
 
 \pnum
@@ -4849,12 +4849,12 @@ with $i$ being \tcode{index()} and $j$ being \tcode{rhs.index()}.
 If an exception is thrown during the call to function \tcode{swap(get<$i$>(*this), get<$i$>(rhs))},
 the states of the contained values of \tcode{*this} and of \tcode{rhs} are
 determined by the exception safety guarantee of \tcode{swap} for lvalues of
-$T_i$ with $i$ being \tcode{index()}.
+\tcode{T}$_i$ with $i$ being \tcode{index()}.
 If an exception is thrown during the exchange of the values of \tcode{*this}
 and \tcode{rhs}, the states of the values of \tcode{*this} and of \tcode{rhs}
 are determined by the exception safety guarantee of \tcode{variant}'s move constructor.
 The expression inside \tcode{noexcept} is equivalent to the logical AND of
-\tcode{is_nothrow_move_constructible_v<$T_i$> \&\& is_nothrow_swappable_v<$T_i$>} for all $i$.
+\tcode{is_nothrow_move_constructible_v<T$_i$> \&\& is_nothrow_swappable_v<T$_i$>} for all $i$.
 \end{itemdescr}
 
 \rSec2[variant.helper]{\tcode{variant} helper classes}
@@ -4924,7 +4924,7 @@ variant_alternative<I, variant<Types...>>::type
 \requires \tcode{I < sizeof...(Types)}.
 
 \pnum
-\textit{Value:} The type $T_I$.
+\textit{Value:} The type \tcode{T}$_I$.
 \end{itemdescr}
 
 \rSec2[variant.get]{Value access}
@@ -5244,7 +5244,7 @@ template <class... Types> void swap(variant<Types...>& v, variant<Types...>& w) 
 
 \pnum
 \remarks This function shall not participate in overload resolution
-unless \tcode{is_move_constructible_v<$T_i$> \&\& is_swappable_v<$T_i$>}
+unless \tcode{is_move_constructible_v<T$_i$> \&\& is_swappable_v<T$_i$>}
 is \tcode{true} for all $i$.
 The expression inside \tcode{noexcept} is equivalent to \tcode{noexcept(v.swap(w))}.
 \end{itemdescr}


### PR DESCRIPTION
Fixes #1115.