### PR TITLE
Adjust italics and index entries for 'underlying type'.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3848,17 +3848,21 @@ reduced modulo the number that is one greater than the largest value
 that can be represented by the resulting unsigned integer type.}
 
 \pnum
+\indextext{\idxcode{char16_t}|see{type, \tcode{char16_t}}}%
+\indextext{\idxcode{char32_t}|see{type, \tcode{char32_t}}}%
+\indextext{\idxcode{wchar_t}|see{type, \tcode{wchar_t}}}%
 \indextext{type!\idxcode{char16_t}}%
 \indextext{type!\idxcode{char32_t}}%
-\indextext{\idxcode{wchar_t}!implementation-defined}%
 \indextext{type!\idxcode{wchar_t}}%
-\indextext{type!underlying wchar_t@underlying \tcode{wchar_t}}%
+\indextext{underlying~type|see{type, underlying}}%
+\indextext{type!underlying!\idxcode{char16_t}}%
+\indextext{type!underlying!\idxcode{char32_t}}%
 Type \tcode{wchar_t} is a distinct type whose values can represent
 distinct codes for all members of the largest extended character set
 specified among the supported locales~(\ref{locale}). Type
 \tcode{wchar_t} shall have the same size, signedness, and alignment
 requirements~(\ref{basic.align}) as one of the other integral types,
-called its \defn{underlying type}. Types \tcode{char16_t} and
+called its \defnx{underlying type}{type!underlying!\idxcode{wchar_t}}. Types \tcode{char16_t} and
 \tcode{char32_t} denote distinct types with the same size, signedness,
 and alignment as \tcode{uint_least16_t} and \tcode{uint_least32_t},
 respectively, in \tcode{<cstdint>}, called the underlying types.

--- a/source/conversions.tex
+++ b/source/conversions.tex
@@ -340,6 +340,9 @@ all the values of the source type; otherwise, the source prvalue can be
 converted to a prvalue of type \tcode{unsigned int}.
 
 \pnum
+\indextext{type!underlying!\idxcode{wchar_t}}%
+\indextext{type!underlying!\idxcode{char16_t}}%
+\indextext{type!underlying!\idxcode{char32_t}}%
 A prvalue of type \tcode{char16_t}, \tcode{char32_t}, or
 \tcode{wchar_t}~(\ref{basic.fundamental}) can be converted to a prvalue
 of the first of the following types that can represent all the values of
@@ -351,6 +354,7 @@ represent all the values of its underlying type, a prvalue of type
 to a prvalue of its underlying type.
 
 \pnum
+\indextext{type!underlying!enumeration}%
 A prvalue of an unscoped enumeration type whose underlying type is not
 fixed~(\ref{dcl.enum}) can be converted to a prvalue of the first of the following
 types that can represent all the values of the enumeration (i.e., the values in the
@@ -633,6 +637,9 @@ rank of any extended integer type with the same size.
 \item The rank of \tcode{bool} shall be less than the rank of all other
 standard integer types.
 
+\indextext{type!\idxcode{wchar_t}}%
+\indextext{type!\idxcode{char16_t}}%
+\indextext{type!\idxcode{char32_t}}%
 \item The ranks of \tcode{char16_t}, \tcode{char32_t}, and
 \tcode{wchar_t} shall equal the ranks of their underlying
 types~(\ref{basic.fundamental}).

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2075,9 +2075,9 @@ declaration.
 
 \pnum
 \indextext{\idxcode{enum}!type~of}%
-\indextext{\idxcode{enum}!underlying~type}%
+\indextext{\idxcode{enum}!underlying~type|see{type, underlying}}%
 Each enumeration defines a type that is different from all other types.
-Each enumeration also has an underlying type.
+Each enumeration also has an \defnx{underlying type}{type!underlying!enumeration}.
 The underlying type can be explicitly specified using an \grammarterm{enum-base}.
 For a scoped enumeration type, the underlying type is \tcode{int} if it is not
 explicitly specified. In both of these cases, the underlying type is said to be

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -1153,7 +1153,7 @@ A UTF-8 character literal containing multiple \grammarterm{c-char}{s} is ill-for
 \pnum
 \indextext{literal!character!\tcode{char16_t}}%
 \indextext{char16_t character@\tcode{char16_t} character}%
-\indextext{\idxcode{char16_t}}%
+\indextext{type!\idxcode{char16_t}}%
 A character literal that
 begins with the letter \tcode{u}, such as \tcode{u'x'},
 \indextext{prefix!\idxcode{u}}%
@@ -1168,7 +1168,7 @@ containing multiple \grammarterm{c-char}{s} is ill-formed.
 \pnum
 \indextext{literal!character!\tcode{char32_t}}%
 \indextext{char32_t character@\tcode{char32_t} character}%
-\indextext{\idxcode{char32_t}}%
+\indextext{type!\idxcode{char32_t}}%
 A character literal that
 begins with the letter \tcode{U}, such as \tcode{U'y'},
 \indextext{prefix!\idxcode{U}}%
@@ -1181,7 +1181,7 @@ multiple \grammarterm{c-char}{s} is ill-formed.
 \indextext{literal!character!wide}%
 \indextext{wide-character}%
 \indextext{\idxhdr{stddef.h}}%
-\indextext{\idxcode{wchar_t}}%
+\indextext{type!\idxcode{wchar_t}}%
 A character literal that
 begins with the letter \tcode{L}, such as \tcode{L'z'},
 \indextext{prefix!\idxcode{L}}%
@@ -1564,6 +1564,7 @@ code unit of the UTF-8 encoding of the string.
 
 \pnum
 \indextext{literal!string!\idxcode{char16_t}}%
+\indextext{type!\idxcode{char16_t}}%
 A \grammarterm{string-literal} that begins with \tcode{u},
 \indextext{prefix!\idxcode{u}}%
 such as \tcode{u"asdf"}, is
@@ -1576,6 +1577,7 @@ surrogate pairs.
 
 \pnum
 \indextext{literal!string!\idxcode{char32_t}}%
+\indextext{type!\idxcode{char32_t}}%
 A \grammarterm{string-literal} that begins with \tcode{U},
 \indextext{prefix!\idxcode{U}}%
 such as \tcode{U"asdf"}, is
@@ -1590,7 +1592,7 @@ A \grammarterm{string-literal} that begins with \tcode{L},
 \indextext{prefix!\idxcode{L}}%
 such as \tcode{L"asdf"}, is a \defn{wide string literal}.
 \indextext{\idxhdr{stddef.h}}%
-\indextext{\idxcode{wchar_t}}%
+\indextext{type!\idxcode{wchar_t}}%
 \indextext{literal!string!wide}%
 \indextext{prefix!\idxcode{L}}%
 A wide string literal has type ``array of \placeholder{n} \tcode{const


### PR DESCRIPTION
Fixes #330.