### PR TITLE
remove \exor command

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4375,7 +4375,7 @@ applies only to integral or unscoped enumeration operands.
 \rSec1[expr.xor]{Bitwise exclusive OR operator}%
 \indextext{expression!bitwise~exclusive~OR}%
 \indextext{operator!bitwise~exclusive OR}%
-\indextext{\idxcode{\exor}|see{operator, bitwise~exclusive~OR}}
+\indextext{\idxcode{\caret}|see{operator, bitwise~exclusive~OR}}
 
 \begin{bnf}
 \nontermdef{exclusive-or-expression}\br

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -182,7 +182,6 @@
 \newcommand{\shl}{<{<}}
 \newcommand{\shr}{>{>}}
 \newcommand{\dcr}{-{-}}
-\newcommand{\exor}{\^{}}
 \newcommand{\bigoh}[1]{\ensuremath{\mathscr{O}(#1)}}
 
 % Make all tildes a little larger to avoid visual similarity with hyphens.


### PR DESCRIPTION
This command is only used once, and it has the same effect as `\caret`, except that `\exor` produces the wrong character.