### PR TITLE
[meta.logical] Fix application of LWG 2567 and add further explicit boolean conversions editorially.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16801,10 +16801,11 @@ forms the logical conjunction of its template type arguments.
 
 \pnum
 For a specialization \tcode{conjunction<B1, ..., BN>},
-if there is a template type argument \tcode{Bi} with \tcode{Bi::value == false},
+if there is a template type argument \tcode{Bi} for which \tcode{bool(Bi::value)} is \tcode{false},
 then instantiating \tcode{conjunction<B1, ..., BN>::value}
 does not require the instantiation of \tcode{Bj::value} for \tcode{j > i}.
-\begin{note} This is analogous to the short-circuiting behavior of \tcode{\&\&}.
+\begin{note} This is analogous to the short-circuiting behavior of
+the built-in operator \tcode{\&\&}.
 \end{note}
 
 \pnum
@@ -16822,7 +16823,7 @@ has a public and unambiguous base that is either
 \begin{itemize}
 \item 
 the first type \tcode{Bi} in the list \tcode{true_type, B1, ..., BN}
-for which \tcode{Bi::value == false}, or
+for which \tcode{bool(Bi::value)} is \tcode{false}, or
 \item 
 if there is no such \tcode{Bi}, the last type in the list.
 \end{itemize}
@@ -16849,10 +16850,11 @@ forms the logical disjunction of its template type arguments.
 
 \pnum
 For a specialization \tcode{disjunction<B1, ..., BN>},
-if there is a template type argument \tcode{Bi} with \tcode{Bi::value != false},
+if there is a template type argument \tcode{Bi} for which \tcode{bool(Bi::value)} is \tcode{true},
 then instantiating \tcode{disjunction<B1, ..., BN>::value}
 does not require the instantiation of \tcode{Bj::value} for \tcode{j > i}.
-\begin{note} This is analogous to the short-circuiting behavior of \tcode{||}.
+\begin{note} This is analogous to the short-circuiting behavior of
+the built-in operator \tcode{||}.
 \end{note}
 
 \pnum
@@ -16869,7 +16871,7 @@ The specialization \tcode{disjunction<B1, ..., BN>}
 has a public and unambiguous base that is either
 \begin{itemize}
 \item the first type \tcode{Bi} in the list \tcode{false_type, B1, ..., BN}
-for which \tcode{Bi::value != false}, or
+for which \tcode{bool(Bi::value)} is \tcode{true}, or
 \item if there is no such \tcode{Bi}, the last type in the list.
 \end{itemize}
 \begin{note} This means a specialization of \tcode{disjunction}


### PR DESCRIPTION
Fixes #1132.