### PR TITLE
[except.spec] missing linebreak

### DIFF
--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -705,7 +705,7 @@ as a suffix of a function declarator~(\ref{dcl.fct}).
 \begin{bnf}
 \nontermdef{noexcept-specifier}\br
     \terminal{noexcept} \terminal{(} constant-expression \terminal{)}\br
-    \terminal{noexcept}
+    \terminal{noexcept}\br
     \terminal{throw} \terminal{(} \terminal{)}
 \end{bnf}
 


### PR DESCRIPTION
It seems "noexcept throw()" is ment to be split as different possibilities