### PR TITLE
s/(possibly cv-qualified)/\\cv{}~/ and allied changes.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -400,7 +400,7 @@ to an object of type \tcode{T}~(\ref{conv.lval}), or
 type \tcode{T} (Clause~\ref{conv}, \ref{expr.type.conv},
 \ref{expr.dynamic.cast}, \ref{expr.static.cast}, \ref{expr.cast}), or
 \item an expression that is not a null pointer constant, and has type
-other than \cv{} \tcode{void*}, is converted to the type pointer to \tcode{T}
+other than \cv{}~\tcode{void*}, is converted to the type pointer to \tcode{T}
 or reference to \tcode{T} using a standard conversion
 (Clause~\ref{conv}), a \tcode{dynamic_cast}~(\ref{expr.dynamic.cast}) or
 a \tcode{static_cast}~(\ref{expr.static.cast}), or
@@ -2101,8 +2101,7 @@ If the \grammarterm{unqualified-id} is \tcode{\~}\grammarterm{type-name}, the
 \grammarterm{postfix-expression}. If the type \tcode{T} of the object
 expression is of a class type \tcode{C}, the \grammarterm{type-name} is
 also looked up in the scope of class \tcode{C}. At least one of the
-lookups shall find a name that refers to (possibly cv-qualified)
-\tcode{T}. \begin{example}
+lookups shall find a name that refers to \cv{}~\tcode{T}. \begin{example}
 
 \begin{codeblock}
 struct A { };
@@ -3290,9 +3289,9 @@ program has undefined behavior if:
 \item
   the pointer is used as the operand of a
   \tcode{static_cast}~(\ref{expr.static.cast}), except when the conversion
-  is to pointer to \cv{} \tcode{void}, or to pointer to \cv{}
-  \tcode{void} and subsequently to pointer to either \cv{}
-  \tcode{char} or \cv{} \tcode{unsigned char}, or
+  is to pointer to \cv{}~\tcode{void}, or to pointer to \cv{}~\tcode{void}
+  and subsequently to pointer to either \cv{}~\tcode{char}
+  or \cv{}~\tcode{unsigned char}, or
 \item
   the pointer is used as the operand of a
   \tcode{dynamic_cast}~(\ref{expr.dynamic.cast}).
@@ -3538,7 +3537,7 @@ size or of incomplete element type, is an
 \defnx{incompletely-defined object type}{object type!incompletely-defined}.%
 \footnote{The size and layout of an instance of an incompletely-defined
 object type is unknown.}
-Incompletely-defined object types and \cv{} \tcode{void} are
+Incompletely-defined object types and \cv{}~\tcode{void} are
 \defnx{incomplete types}{type!incomplete}~(\ref{basic.fundamental}).
 Objects shall not be defined to have an
 incomplete type.
@@ -3593,7 +3592,7 @@ contexts incomplete types are prohibited. \end{note}
 \pnum
 \indextext{object type}%
 An \defn{object type} is a (possibly cv-qualified) type that is not
-a function type, not a reference type, and not \cv{} \tcode{void}.
+a function type, not a reference type, and not \cv{}~\tcode{void}.
 
 \pnum
 Arithmetic types~(\ref{basic.fundamental}), enumeration types, pointer
@@ -3862,19 +3861,19 @@ implementation.
 
 \pnum
 \indextext{type!\idxcode{void}}%
-A type \cv{} \tcode{void}
+A type \cv{}~\tcode{void}
 is an incomplete type that cannot be completed; such a type has
 an empty set of values. It is used as the return
 type for functions that do not return a value. Any expression can be
-explicitly converted to type \cv{} \tcode{void}~(\ref{expr.cast}).
-An expression of type \cv{} \tcode{void} shall
+explicitly converted to type \cv{}~\tcode{void}~(\ref{expr.cast}).
+An expression of type \cv{}~\tcode{void} shall
 be used only as an expression statement~(\ref{stmt.expr}), as an operand
 of a comma expression~(\ref{expr.comma}), as a second or third operand
 of \tcode{?:}~(\ref{expr.cond}), as the operand of
 \tcode{typeid}, \tcode{noexcept}, or \tcode{decltype}, as
 the expression in a return statement~(\ref{stmt.return}) for a function
-with the return type \cv{} \tcode{void}, or as the operand of an explicit conversion
-to type \cv{} \tcode{void}.
+with the return type \cv{}~\tcode{void}, or as the operand of an explicit conversion
+to type \cv{}~\tcode{void}.
 
 \pnum
 A value of type \tcode{std::nullptr_t} is a null pointer
@@ -3899,7 +3898,7 @@ Compound types can be constructed in the following ways:
 \item \defnx{functions}{type!function}, which have parameters of given types and return
 \tcode{void} or references or objects of a given type,~\ref{dcl.fct};
 
-\item \defnx{pointers}{type!pointer} to \cv{} \tcode{void} or objects or functions (including
+\item \defnx{pointers}{type!pointer} to \cv{}~\tcode{void} or objects or functions (including
 static members of classes) of a given type,~\ref{dcl.ptr};
 
 \item %
@@ -3944,7 +3943,7 @@ the type \tcode{std::size_t}~(\ref{support.types}) is ill-formed.
 
 \pnum
 \indextext{terminology!pointer}%
-The type of a pointer to \cv{} \tcode{void} or a pointer to an object type is
+The type of a pointer to \cv{}~\tcode{void} or a pointer to an object type is
 called an \defn{object pointer type}. \begin{note} A pointer to \tcode{void}
 does not have a pointer-to-object type, however, because \tcode{void} is not
 an object type. \end{note} The type of a pointer that can designate a function
@@ -4039,9 +4038,9 @@ A pointer to \cv-qualified~(\ref{basic.type.qualifier}) or \cv-unqualified
 \tcode{void}
 can be used to point to objects of
 unknown type. Such a pointer shall be able to hold any object pointer.
-An object of type \cv{}
-\tcode{void*} shall have the same representation and alignment
-requirements as \cv{} \tcode{char*}.
+An object of type \cv{}~\tcode{void*}
+shall have the same representation and alignment
+requirements as \cv{}~\tcode{char*}.
 
 \rSec2[basic.type.qualifier]{CV-qualifiers}
 
@@ -4115,7 +4114,7 @@ In this International Standard, the notation \cv{} (or
 represents an arbitrary set of cv-qualifiers, i.e., one of
 \{\tcode{const}\}, \{\tcode{volatile}\}, \{\tcode{const},
 \tcode{volatile}\}, or the empty set.
-For a type \cv{} \tcode{T}, the \defnx{top-level cv-qualifiers}{cv-qualifier!top-level}
+For a type \cv{}~\tcode{T}, the \defnx{top-level cv-qualifiers}{cv-qualifier!top-level}
 of that type are those denoted by \cv.
 \begin{example}
 The type corresponding to the \grammarterm{type-id}
@@ -4133,7 +4132,7 @@ has the top-level cv-qualifier \tcode{volatile}.
 \pnum
 Cv-qualifiers applied to an array
 type attach to the underlying element type, so the notation
-``\cv{} \tcode{T}'', where \tcode{T} is an array type, refers to
+``\cv{}~\tcode{T}'', where \tcode{T} is an array type, refers to
 an array whose elements are so-qualified. An array type whose elements
 are cv-qualified is also considered to have the same cv-qualifications
 as its elements.%
@@ -4201,7 +4200,7 @@ The \defn{result object} of a prvalue
 is the object initialized by the prvalue;
 a prvalue
 that is used to compute the value of an operand of an operator or
-that has type (possibly cv-qualified) \tcode{void}
+that has type \cv{}~\tcode{void}
 has no result object.
 \begin{note}
 Except when the prvalue is the operand of a \grammarterm{decltype-specifier},
@@ -4237,7 +4236,7 @@ and rvalues in other significant contexts.
 \pnum
 Unless otherwise indicated~(\ref{expr.call}),
 a prvalue shall always have complete type or the \tcode{void} type.
-A glvalue shall not have type \cv{} \tcode{void}.
+A glvalue shall not have type \cv{}~\tcode{void}.
 \begin{note}
 A glvalue may have complete or incomplete non-\tcode{void} type.
 Class and array prvalues can have cv-qualified types; other prvalues

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1213,7 +1213,7 @@ the objects of the class.
 The declaration of a non-inline
 static data member in its class definition
 is not a definition and may be of an incomplete type other than
-\cv{} \tcode{void}. The definition for a static data
+\cv{}~\tcode{void}. The definition for a static data
 member that is not defined inline in the class definition
 shall appear in a namespace scope enclosing the member's class
 definition.

--- a/source/conversions.tex
+++ b/source/conversions.tex
@@ -162,7 +162,7 @@ following rules:
 
 \begin{itemize}
 
-\item If \tcode{T} is (possibly cv-qualified) \tcode{std::nullptr_t}, the result is a
+\item If \tcode{T} is \cv{}~\tcode{std::nullptr_t}, the result is a
 null pointer constant~(\ref{conv.ptr}).
 \begin{note}
 Since no value is fetched from memory,

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1798,7 +1798,7 @@ and \tcode{e} is the corresponding template argument.
 In the case of a \tcode{return} statement with no operand
 or with an operand of type \tcode{void},
 \tcode{T} shall be either
-\tcode{decltype(auto)} or \cv{} \tcode{auto}.
+\tcode{decltype(auto)} or \cv{}~\tcode{auto}.
 
 \pnum
 If the deduction is for a \tcode{return} statement

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -676,7 +676,7 @@ A reference can be thought of as a name of an object.
 \end{note}
 \indextext{\idxcode{void\&}}%
 A declarator that specifies the type
-``reference to \cv{} \tcode{void}''
+``reference to \cv{}~\tcode{void}''
 is ill-formed.
 
 
@@ -794,9 +794,9 @@ to a bit-field.
 \indextext{reference collapsing}%
 If a \grammarterm{typedef-name}~(\ref{dcl.typedef}, \ref{temp.param})
 or a \grammarterm{decltype-specifier}~(\ref{dcl.type.simple}) denotes a type \tcode{TR} that
-is a reference to a type \tcode{T}, an attempt to create the type ``lvalue reference to \cv{} 
-\tcode{TR}'' creates the type ``lvalue reference to \tcode{T}'', while an attempt to create
-the type ``rvalue reference to \cv{} \tcode{TR}'' creates the type \tcode{TR}.
+is a reference to a type \tcode{T}, an attempt to create the type ``lvalue reference to \cv{}~\tcode{TR}''
+creates the type ``lvalue reference to \tcode{T}'', while an attempt to create
+the type ``rvalue reference to \cv{}~\tcode{TR}'' creates the type \tcode{TR}.
 \begin{note} This rule is known as reference collapsing. \end{note}
 \begin{example}
 
@@ -922,8 +922,7 @@ A pointer to member shall not point to a static member
 of a class (\ref{class.static}),
 a member with reference type,
 or
-``\cv{}
-\tcode{void}''.
+``\cv{}~\tcode{void}''.
 
 \begin{note}
 See also~\ref{expr.unary} and~\ref{expr.mptr.oper}.
@@ -962,8 +961,7 @@ the program is ill-formed.
 \tcode{T}
 is called the array
 \term{element type};
-this type shall not be a reference type, the (possibly cv-qualified) type
-\tcode{void},
+this type shall not be a reference type, \cv{}~\tcode{void},
 a function type or an abstract class type.
 \indextext{declaration!array}%
 If the
@@ -2309,7 +2307,7 @@ Let \cv{} denote the
 variable with a unique name \tcode{e} is introduced. If the
 \grammarterm{assignment-expression} in the \grammarterm{initializer}
 has array type \tcode{A} and no \grammarterm{ref-qualifier} is present, \tcode{e}
-has type \cv{} \tcode{A} and each element is copy-initialized or direct-initialized
+has type \cv{}~\tcode{A} and each element is copy-initialized or direct-initialized
 from the corresponding element of the \grammarterm{assignment-expression} as specified
 by the form of the \grammarterm{initializer}.
 Otherwise, \tcode{e}
@@ -2381,8 +2379,8 @@ Designating the non-static data members of \tcode{E} as
 (in declaration order),
 each \tcode{v}$_i$ is the
 name of an lvalue that refers to the member \tcode{m}$_i$ of \tcode{e} and
-whose type is \cv{} \tcode{T}$_i$, where \tcode{T}$_i$ is the declared type of
-that member; the referenced type is \cv{} \tcode{T}$_i$. The lvalue is a
+whose type is \cv{}~\tcode{T}$_i$, where \tcode{T}$_i$ is the declared type of
+that member; the referenced type is \cv{}~\tcode{T}$_i$. The lvalue is a
 bit-field if that member is a bit-field.
 \begin{example}
 \begin{codeblock}

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -266,8 +266,7 @@ variable declared in the matching
 \term{handler}~(\ref{except.handle}).
 If the type of the exception object would
 be an incomplete type or a pointer to an incomplete
-type other than (possibly cv-qualified)
-\tcode{void} the program is ill-formed.
+type other than \cv{}~\tcode{void} the program is ill-formed.
 
 \pnum
 \indextext{exception handling!memory}%
@@ -491,16 +490,16 @@ of type
 if
 \begin{itemize}
 \item%
-The \term{handler} is of type \cv{} \tcode{T} or
-\cv{} \tcode{T\&} and
+The \term{handler} is of type \cv{}~\tcode{T} or
+\cv{}~\tcode{T\&} and
 \tcode{E} and \tcode{T}
 are the same type (ignoring the top-level \grammarterm{cv-qualifiers}), or
 \item%
-the \term{handler} is of type \cv{} \tcode{T} or
-\cv{} \tcode{T\&} and
+the \term{handler} is of type \cv{}~\tcode{T} or
+\cv{}~\tcode{T\&} and
 \tcode{T} is an unambiguous public base class of \tcode{E}, or
 \item%
-the \term{handler} is of type \cv{} \tcode{T} or \tcode{const T\&}
+the \term{handler} is of type \cv{}~\tcode{T} or \tcode{const T\&}
 where \tcode{T} is a pointer or pointer to member type and
 \tcode{E} is a pointer or pointer to member type
 that can be converted to \tcode{T} by one or more of
@@ -517,7 +516,7 @@ a qualification conversion~(\ref{conv.qual}), or
 \end{itemize}
 
 \item
-the \term{handler} is of type \cv{} \tcode{T} or \tcode{const T\&} where \tcode{T} is a pointer or pointer to member type and \tcode{E} is \tcode{std::nullptr_t}.
+the \term{handler} is of type \cv{}~\tcode{T} or \tcode{const T\&} where \tcode{T} is a pointer or pointer to member type and \tcode{E} is \tcode{std::nullptr_t}.
 
 \end{itemize}
 
@@ -657,7 +656,7 @@ of that function (see \ref{stmt.return}).
 
 \pnum
 The variable declared by the \grammarterm{exception-declaration}, of type
-\cv{} \tcode{T} or \cv{} \tcode{T\&}, is initialized from the exception object,
+\cv{}~\tcode{T} or \cv{}~\tcode{T\&}, is initialized from the exception object,
 of type \tcode{E}, as follows:
 
 \begin{itemize}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -80,7 +80,7 @@ the behavior is undefined (see~\ref{basic.life}).
 \end{note}
 
 \pnum
-If a prvalue initially has the type ``\cv{} \tcode{T}'', where
+If a prvalue initially has the type ``\cv{}~\tcode{T}'', where
 \tcode{T} is a cv-unqualified non-class, non-array type, the type of
 the expression is adjusted to \tcode{T} prior to any further analysis.
 
@@ -1519,8 +1519,7 @@ type of the function call expression is the return type of the
 statically chosen function (i.e., ignoring the \tcode{virtual} keyword),
 even if the type of the function actually called is different.
 \indextext{type!incomplete}%
-This return type shall be an object type, a reference type or \cv{}
-\tcode{void}.
+This return type shall be an object type, a reference type or \cv{}~\tcode{void}.
 
 \pnum
 \indextext{function argument|see{argument}}%
@@ -1663,7 +1662,7 @@ The
 lvalue-to-rvalue~(\ref{conv.lval}), array-to-pointer~(\ref{conv.array}),
 and function-to-pointer~(\ref{conv.func}) standard conversions are
 performed on the argument expression.
-An argument that has (possibly cv-qualified) type \tcode{std::nullptr_t} is converted
+An argument that has type \cv{}~\tcode{std::nullptr_t} is converted
 to type \tcode{void*}~(\ref{conv.ptr}).
 After these conversions, if the
 argument does not have arithmetic, enumeration, pointer, pointer to
@@ -1719,7 +1718,7 @@ the type conversion expression is equivalent (in
 definedness, and if defined in meaning) to the corresponding cast
 expression~(\ref{expr.cast}).
 \indextext{type!incomplete}%
-If the type is (possibly cv-qualified) \tcode{void}
+If the type is \cv{}~\tcode{void}
 and the initializer is \tcode{()},
 the expression is a prvalue of the specified type
 that performs no initialization.
@@ -1901,7 +1900,7 @@ operand.
 the value obtained is a copy of the original value
 \end{note}
 The operand shall be a modifiable lvalue. The type of the operand shall
-be an arithmetic type other than \cv{} \tcode{bool},
+be an arithmetic type other than \cv{}~\tcode{bool},
 or a pointer to a complete object type. The value
 of the operand object is modified by adding \tcode{1} to it.
 The
@@ -2238,8 +2237,8 @@ listed below. No other conversion shall be performed explicitly using a
 \tcode{static_cast}.
 
 \pnum
-Any expression can be explicitly converted to type \cv{}
-\tcode{void}, in which case it becomes a discarded-value
+Any expression can be explicitly converted to type \cv{}~\tcode{void},
+in which case it becomes a discarded-value
 expression (Clause~\ref{expr}).
 \begin{note}
 However, if the value is in a temporary
@@ -2283,7 +2282,7 @@ for specific cases:
 
 \pnum
 A value of a scoped enumeration type~(\ref{dcl.enum}) can be explicitly converted to an
-integral type. When that type is \cv{} \tcode{bool}, the resulting value is
+integral type. When that type is \cv{}~\tcode{bool}, the resulting value is
 \tcode{false} if the original value is zero and \tcode{true} for all other
 values. For the remaining integral types, the value is unchanged if the
 original value can be represented by the
@@ -2460,8 +2459,7 @@ types may have different \cv-qualifiers, subject to
 the overall
 restriction that a \tcode{reinterpret_cast} cannot cast away constness.}
 When a prvalue \tcode{v} of object pointer type is converted to
-the object pointer type ``pointer to \cv{} \tcode{T}'', the result is \tcode{static_cast<\cv{} T*>(static_cast<\cv{}
-void*>(v))}.
+the object pointer type ``pointer to \cv{}~\tcode{T}'', the result is \tcode{static_cast<\cv{} T*>(static_cast<\cv{}~void*>(v))}.
 \begin{note}
 Converting a prvalue of type ``pointer to \tcode{T1}'' to
 the type ``pointer to \tcode{T2}'' (where \tcode{T1} and \tcode{T2} are
@@ -2726,7 +2724,7 @@ of class \tcode{C} of type \tcode{T}'' and is a prvalue designating \tcode{C::m}
 Otherwise, if the type of the expression is \tcode{T}, the result has type ``pointer to
 \tcode{T}'' and is a prvalue that is the address of the designated object~(\ref{intro.memory})
 or a pointer to the designated function. \begin{note} In particular, the address of an
-object of type ``\cv{} \tcode{T}'' is ``pointer to \cv{} \tcode{T}'', with the same
+object of type ``\cv{}~\tcode{T}'' is ``pointer to \cv{}~\tcode{T}'', with the same
 cv-qualification. \end{note}
 For purposes of pointer arithmetic~(\ref{expr.add}) and
 comparison~(\ref{expr.rel}, \ref{expr.eq}),
@@ -2840,7 +2838,7 @@ The operand of prefix \tcode{++}
 is modified by adding \tcode{1}.
 \indextext{prefix \tcode{\dcr}}%
 The operand shall be a modifiable lvalue. The type of the operand shall
-be an arithmetic type other than \cv{} \tcode{bool},
+be an arithmetic type other than \cv{}~\tcode{bool},
 or a pointer to a completely-defined object type.
 The result is the updated operand; it is an lvalue, and it is a
 bit-field if the operand is a bit-field.
@@ -4085,7 +4083,7 @@ the behavior is undefined.
 
 \pnum
 For addition or subtraction, if the expressions \tcode{P} or \tcode{Q} have
-type ``pointer to \cv{} \tcode{T}'', where \tcode{T} and the array element type
+type ``pointer to \cv{}~\tcode{T}'', where \tcode{T} and the array element type
 are not similar~(\ref{conv.qual}), the behavior is undefined.
 \begin{note} In particular, a pointer to a base class cannot be used for
 pointer arithmetic when the array contains objects of a derived class type.
@@ -4997,7 +4995,7 @@ static_assert(bind(monad(2))(monad)() == monad(2)());
 \end{note}
 
 \item
-a conversion from type \cv{} \tcode{void *} to a pointer-to-object type;
+a conversion from type \cv{}~\tcode{void*} to a pointer-to-object type;
 
 \item
 a dynamic cast~(\ref{expr.dynamic.cast});

--- a/source/future.tex
+++ b/source/future.tex
@@ -1473,7 +1473,7 @@ only if the type \tcode{T} is any of the following:
 \begin{itemize}
 \item a function type or a pointer to function type taking one argument of type \tcode{T1}
 % FIXME: Should this be R T0::f() ?
-\item a pointer to member function \tcode{R T0::f} \cv{} (where \cv{} represents the member function's cv-qualifiers); the type \tcode{T1} is \cv{} \tcode{T0*}
+\item a pointer to member function \tcode{R T0::f} \cv{} (where \cv{} represents the member function's cv-qualifiers); the type \tcode{T1} is \cv{}~\tcode{T0*}
 \item a class type where the \grammarterm{qualified-id} \tcode{T::argument_type}
 is valid and denotes a type~(\ref{temp.deduct});
 the type \tcode{T1} is \tcode{T::argument_type}.
@@ -1489,7 +1489,7 @@ as synonyms for \tcode{T1} and \tcode{T2}, respectively,
 only if the type \tcode{T} is any of the following:
 \begin{itemize}
 \item a function type or a pointer to function type taking two arguments of types \tcode{T1} and \tcode{T2}
-\item a pointer to member function \tcode{R T0::f(T2)} \cv{} (where \cv{} represents the member function's cv-qualifiers); the type \tcode{T1} is \cv{} \tcode{T0*}
+\item a pointer to member function \tcode{R T0::f(T2)} \cv{} (where \cv{} represents the member function's cv-qualifiers); the type \tcode{T1} is \cv{}~\tcode{T0*}
 \item a class type where the \grammarterm{qualified-id}{s}
 \tcode{T::first_argument_type} and \tcode{T::second_argument_type}
 are both valid and both denote types~(\ref{temp.deduct});
@@ -1531,7 +1531,7 @@ The simple call wrapper
 returned from a call to \tcode{mem_fn(pm)}
 shall define two nested types
 named \tcode{argument_type} and \tcode{result_type}
-as synonyms for \cv{} \tcode{T*} and \tcode{Ret}, respectively,
+as synonyms for \cv{}~\tcode{T*} and \tcode{Ret}, respectively,
 when \tcode{pm} is a pointer to member function
 with cv-qualifier \cv{}
 and taking no arguments,
@@ -1545,7 +1545,7 @@ The simple call wrapper
 returned from a call to \tcode{mem_fn(pm)}
 shall define three nested types
 named \tcode{first_argument_type}, \tcode{second_argument_type}, and \tcode{result_type}
-as synonyms for \cv{} \tcode{T*}, \tcode{T1}, and \tcode{Ret}, respectively,
+as synonyms for \cv{}~\tcode{T*}, \tcode{T1}, and \tcode{Ret}, respectively,
 when \tcode{pm} is a pointer to member function
 with cv-qualifier \cv{}
 and taking one argument of type \tcode{T1},
@@ -2020,8 +2020,7 @@ namespace std {
 
 \pnum
 \requires
-\tcode{remove_all_extents_t<T>} shall be a complete type or (possibly
-cv-qualified) \tcode{void}.
+\tcode{remove_all_extents_t<T>} shall be a complete type or \cv{}~\tcode{void}.
 
 \pnum
 \effects

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -280,7 +280,7 @@ If \tcode{z} is an lvalue expression of type \cv{} \tcode{complex<T>} then:
 \item \tcode{reinterpret_cast<\cv{} T(\&)[2]>(z)[1]} shall designate the imaginary part of \tcode{z}.
 \end{itemize}
 
-Moreover, if \tcode{a} is an expression of type \cv{} \tcode{complex<T>*} and the expression \tcode{a[i]} is well-defined for an integer expression \tcode{i}, then:
+Moreover, if \tcode{a} is an expression of type \cv{}~\tcode{complex<T>*} and the expression \tcode{a[i]} is well-defined for an integer expression \tcode{i}, then:
 
 \begin{itemize}
 \item \tcode{reinterpret_cast<\cv{} T*>(a)[2*i]} shall designate the real part of \tcode{a[i]}, and
@@ -9528,7 +9528,7 @@ that \tcode{gcd(m, m) = |m|} is representable as a value of type \tcode{M}. \end
 \pnum
 \remarks
 If either \tcode{M} or \tcode{N} is not an integer type, or
-if either is (possibly cv-qualified) \tcode{bool}, the program is ill-formed.
+if either is \cv{}~\tcode{bool}, the program is ill-formed.
 
 \pnum
 \returns
@@ -9559,7 +9559,7 @@ shall be representable as a value of type \tcode{common_type_t<M,N>}.
 \pnum
 \remarks
 If either \tcode{M} or \tcode{N} is not an integer type, or
-if either is (possibly cv-qualified) \tcode{bool} the program is ill-formed.
+if either is \cv{}~\tcode{bool} the program is ill-formed.
 
 \pnum
 \returns

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -525,10 +525,10 @@ For non-static member functions, the type of the implicit object
 parameter is
 
 \begin{itemize}
-\item ``lvalue reference to \cv{} \tcode{X}'' for functions declared
+\item ``lvalue reference to \cv{}~\tcode{X}'' for functions declared
 without a \grammarterm{ref-qualifier} or with the
 \tcode{\&} \grammarterm{ref-qualifier}
-\item ``rvalue reference to \cv{} \tcode{X}'' for functions declared with the
+\item ``rvalue reference to \cv{}~\tcode{X}'' for functions declared with the
 \tcode{\&\&} \grammarterm{ref-qualifier}
 \end{itemize}
 
@@ -712,8 +712,7 @@ the
 that is the left operand of the
 \tcode{.}
 operator
-has type ``\cv{}
-\tcode{T}''
+has type ``\cv{}~\tcode{T}''
 where
 \tcode{T}
 denotes a class\footnote{Note that cv-qualifiers on the type of objects are
@@ -801,8 +800,7 @@ If the
 \grammarterm{primary-expression}
 \tcode{E}
 in the function call syntax evaluates
-to a class object of type ``\cv{}
-\tcode{T}'',
+to a class object of type ``\cv{}~\tcode{T}'',
 then the set of candidate
 functions includes at least the function call operators of
 \tcode{T}.
@@ -1011,15 +1009,13 @@ that all member functions are ignored.
 However, if no operand has a class type, only those non-member
 functions in the lookup set that have a first parameter of type
 \tcode{T1}
-or ``reference to (possibly cv-qualified)
-\tcode{T1}'',
+or ``reference to \cv{}~\tcode{T1}'',
 when
 \tcode{T1}
 is an enumeration type,
 or (if there is a right operand) a second parameter of type
 \tcode{T2}
-or ``reference to (possibly cv-qualified)
-\tcode{T2}'',
+or ``reference to \cv{}~\tcode{T2}'',
 when
 \tcode{T2}
 is an enumeration type,
@@ -1217,7 +1213,7 @@ The converting constructors~(\ref{class.conv.ctor}) of
 are candidate functions.
 \item
 When the type of the initializer expression is a class type
-``\cv{} \tcode{S}'',
+``\cv{}~\tcode{S}'',
 the non-explicit conversion functions of
 \tcode{S}
 and its base classes are considered.
@@ -1267,7 +1263,7 @@ being initialized.
 Overload resolution is used to select the
 conversion function to be invoked.
 Assuming that ``\cvqual{cv1} \tcode{T}'' is the
-type of the object being initialized, and ``\cv{} \tcode{S}'' is the type
+type of the object being initialized, and ``\cv{}~\tcode{S}'' is the type
 of the initializer expression, with
 \tcode{S}
 a class type,
@@ -1325,7 +1321,7 @@ Overload resolution is used to select the
 conversion function to be invoked.
 Assuming that ``reference to \cvqual{cv1} \tcode{T}'' is the
 type of the reference being initialized, and
-``\cv{} \tcode{S}'' is the type
+``\cv{}~\tcode{S}'' is the type
 of the initializer expression, with
 \tcode{S}
 a class type,
@@ -1852,7 +1848,7 @@ step of a class copy-initialization,
 when the initializer list has exactly one element that
 is itself an initializer list, and
 the target is the first parameter of a constructor of class \tcode{X}, and
-the conversion is to \tcode{X} or reference to (possibly cv-qualified) \tcode{X},
+the conversion is to \tcode{X} or reference to \cv{}~\tcode{X},
 \end{itemize}
 user-defined conversion sequences are not considered.
 \begin{note}
@@ -2190,7 +2186,7 @@ expression and special rules apply for converting it to a parameter type.
 
 \pnum
 If the parameter type is an aggregate class \tcode{X} and the initializer list has a
-single element of type \cv{} \tcode{U}, where \tcode{U} is \tcode{X}
+single element of type \cv{}~\tcode{U}, where \tcode{U} is \tcode{X}
 or a class derived from \tcode{X}, the implicit conversion sequence is the one
 required to convert the element to the parameter type.
 
@@ -2248,7 +2244,7 @@ argument initializer list:
 \begin{itemize}
 \item
 If \tcode{C} is not an initializer-list constructor
-and the initializer list has a single element of type \cv{} \tcode{U},
+and the initializer list has a single element of type \cv{}~\tcode{U},
 where \tcode{U} is \tcode{X} or a class derived from \tcode{X},
 the implicit conversion sequence has Exact Match rank if \tcode{U} is \tcode{X},
 or Conversion rank if \tcode{U} is derived from \tcode{X}.

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -799,14 +799,14 @@ A function returns to its caller by the \tcode{return} statement.
 The \grammarterm{expr-or-braced-init-list}
 of a return statement is called its operand. A return statement with
 no operand shall be used only in a function whose return type is
-\cv{} \tcode{void}, a constructor~(\ref{class.ctor}), or a
+\cv{}~\tcode{void}, a constructor~(\ref{class.ctor}), or a
 destructor~(\ref{class.dtor}).
 \indextext{\idxcode{return}!constructor and}%
 \indextext{\idxcode{return}!constructor and}%
 A return statement with an operand of type \tcode{void} shall be used only
-in a function whose return type is \cv{} \tcode{void}.
+in a function whose return type is \cv{}~\tcode{void}.
 A return statement with any other operand shall be used only
-in a function whose return type is not \cv{} \tcode{void};
+in a function whose return type is not \cv{}~\tcode{void};
 \indextext{conversion!return type}%
 the return statement initializes the
 glvalue result or prvalue result object of the (explicit or implicit) function call
@@ -828,7 +828,7 @@ std::pair<std::string,int> f(const char* p, int x) {
 Flowing off the end of
 a constructor,
 a destructor, or
-a function with a \cv{} \tcode{void} return type is
+a function with a \cv{}~\tcode{void} return type is
 equivalent to a \tcode{return} with no operand.
 Otherwise, flowing off the end of a function
 other than \tcode{main}~(\ref{basic.start.main})

--- a/source/support.tex
+++ b/source/support.tex
@@ -2525,7 +2525,7 @@ if it is within the storage occupied by
 an object that is pointer-interconvertible with \placeholder{Y}, or
 the immediately-enclosing array object if \placeholder{Y} is an array element.
 The program is ill-formed if \tcode{T} is a function type
-or (possibly cv-qualified) \tcode{void}.
+or \cv{}~\tcode{void}.
 
 \pnum
 \realnotes

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -2827,11 +2827,11 @@ member of some class \placeholder{A}, \placeholder{M} is considered to have
 a new first parameter inserted in its function
 parameter list. Given \cv{} as the cv-qualifiers of \placeholder{M}
 (if any), the new parameter is of type ``rvalue reference to
-\cv{} \placeholder{A}'' if the optional \grammarterm{ref-qualifier} of
+\cv{}~\placeholder{A}'' if the optional \grammarterm{ref-qualifier} of
 \placeholder{M} is \tcode{\&\&} or if \placeholder{M} has no
 \grammarterm{ref-qualifier} and the first parameter of the other
 template has rvalue reference type. Otherwise, the new parameter is
-of type ``lvalue reference to \cv{} \placeholder{A}''.
+of type ``lvalue reference to \cv{}~\placeholder{A}''.
 \begin{note} This allows a non-static
 member to be ordered with respect to a non-member function and for the results
 to be equivalent to the ordering of two equivalent non-members. \end{note}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -7140,7 +7140,7 @@ static pointer pointer_traits<T*>::pointer_to(@\seebelow@ r) noexcept;
 
 \begin{itemdescr}
 \pnum
-\remarks If \tcode{element_type} is (possibly cv-qualified) \tcode{void}, the type of
+\remarks If \tcode{element_type} is \cv{}~\tcode{void}, the type of
 \tcode{r} is unspecified; otherwise, it is \tcode{element_type\&}.
 
 \pnum
@@ -9477,7 +9477,7 @@ a pointer type \tcode{Y*} is said to be
 \defnx{compatible with}{compatible with!\idxcode{shared_ptr}}
 a pointer type \tcode{T*} when either
 \tcode{Y*} is convertible to \tcode{T*} or
-\tcode{Y} is \tcode{U[N]} and \tcode{T} is \cv{} \tcode{U[]}.
+\tcode{Y} is \tcode{U[N]} and \tcode{T} is \cv{}~\tcode{U[]}.
 
 \rSec4[util.smartptr.shared.const]{\tcode{shared_ptr} constructors}
 
@@ -9828,7 +9828,7 @@ T& operator*() const noexcept;
 
 \pnum\returns  \tcode{*get()}.
 
-\pnum\remarks When \tcode{T} is an array type or (possibly cv-qualified) \tcode{void},
+\pnum\remarks When \tcode{T} is an array type or \cv{}~\tcode{void},
 it is unspecified whether this
 member function is declared. If it is declared, it is unspecified what its
 return type is, except that the declaration (although not necessarily the
@@ -12901,7 +12901,7 @@ and \tcode{t1} does not satisfy the previous two items;
 \indexlibrary{invoke@\tcode{\textit{INVOKE}}}%
 Define \tcode{\textit{INVOKE}(f, t1, t2, ..., tN, R)} as
 \tcode{static_cast<void>(\textit{INVOKE}(f, t1, t2, ..., tN))}
-if \tcode{R} is \cv{} \tcode{void}, otherwise
+if \tcode{R} is \cv{}~\tcode{void}, otherwise
 \tcode{\textit{INVOKE}(f, t1, t2, ..., tN)} implicitly converted
 to \tcode{R}.
 
@@ -15521,7 +15521,7 @@ section~\ref{basic.types} of the \Cpp standard.
 
 \pnum
 For any given type \tcode{T}, the result of applying one of these templates to
-\tcode{T} and to \cv{} \tcode{T} shall yield the same result.
+\tcode{T} and to \cv{}~\tcode{T} shall yield the same result.
 
 \pnum
 \begin{note}
@@ -15607,7 +15607,7 @@ categories, corresponding to the descriptions given in section~\ref{basic.types}
 
 \pnum
 For any given type \tcode{T}, the result of applying one of these templates to
-\tcode{T} and to \cv{} \tcode{T} shall yield the same result.
+\tcode{T} and to \cv{}~\tcode{T} shall yield the same result.
 
 \begin{libreqtab3b}{Composite type category predicates}{tab:type-traits.composite}
 \\ \topline
@@ -15698,28 +15698,28 @@ notwithstanding the restrictions of~\ref{declval}.
  \tcode{struct is_trivial;}                 &
  \tcode{T} is a trivial type~(\ref{basic.types})     &
  \tcode{remove_all_extents_t<T>} shall be a complete
- type or (possibly cv-qualified) \tcode{void}.                \\ \rowsep
+ type or \cv{}~\tcode{void}.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_trivially_copyable}}%
 \tcode{template <class T>}\br
  \tcode{struct is_trivially_copyable;}      &
  \tcode{T} is a trivially copyable type~(\ref{basic.types}) &
  \tcode{remove_all_extents_t<T>} shall be a complete type or
- (possibly cv-qualified) \tcode{void}.                               \\ \rowsep
+ \cv{}~\tcode{void}.                               \\ \rowsep
 
 \indexlibrary{\idxcode{is_standard_layout}}%
 \tcode{template <class T>}\br
  \tcode{struct is_standard_layout;}                 &
  \tcode{T} is a standard-layout type~(\ref{basic.types})   &
  \tcode{remove_all_extents_t<T>} shall be a complete
- type or (possibly cv-qualified) \tcode{void}.                \\ \rowsep
+ type or \cv{}~\tcode{void}.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_pod}}%
 \tcode{template <class T>}\br
  \tcode{struct is_pod;}                 &
  \tcode{T} is a POD type~(\ref{basic.types})                                &
  \tcode{remove_all_extents_t<T>} shall be a complete
- type or (possibly cv-qualified) \tcode{void}.                \\ \rowsep
+ type or \cv{}~\tcode{void}.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_empty}!class}%
 \tcode{template <class T>}\br
@@ -15768,18 +15768,18 @@ notwithstanding the restrictions of~\ref{declval}.
 \tcode{template <class T, class... Args>}\br
  \tcode{struct is_constructible;}   &
  For a function type \tcode{T} or
- for a (possibly cv-qualified) \tcode{void} type \tcode{T},
+ for a \cv{}~\tcode{void} type \tcode{T},
  \tcode{is_constructible_v<T, Args...>} is \tcode{false},
  otherwise \seebelow                &
  \tcode{T} and all types in the parameter pack \tcode{Args}
- shall be complete types, (possibly cv-qualified) \tcode{void},
+ shall be complete types, \cv{}~\tcode{void},
  or arrays of unknown bound.  \\ \rowsep
 
 \indexlibrary{\idxcode{is_default_constructible}}%
 \tcode{template <class T>}\br
   \tcode{struct is_default_constructible;} &
   \tcode{is_constructible_v<T>} is \tcode{true}. &
-  \tcode{T} shall be a complete type, (possibly cv-qualified) \tcode{void},
+  \tcode{T} shall be a complete type, \cv{}~\tcode{void},
   or an array of unknown bound. \\ \rowsep
 
 \indexlibrary{\idxcode{is_copy_constructible}}%
@@ -15787,7 +15787,7 @@ notwithstanding the restrictions of~\ref{declval}.
   \tcode{struct is_copy_constructible;} &
   For a referenceable type \tcode{T} (\ref{defns.referenceable}), the same result as
   \tcode{is_constructible_v<T, const T\&>}, otherwise \tcode{false}. &
-  \tcode{T} shall be a complete type, (possibly cv-qualified) \tcode{void},
+  \tcode{T} shall be a complete type, \cv{}~\tcode{void},
   or an array of unknown bound. \\ \rowsep
 
 \indexlibrary{\idxcode{is_move_constructible}}%
@@ -15795,7 +15795,7 @@ notwithstanding the restrictions of~\ref{declval}.
   \tcode{struct is_move_constructible;} &
   For a referenceable type \tcode{T}, the same result as
   \tcode{is_constructible_v<T, T\&\&>}, otherwise \tcode{false}. &
-  \tcode{T} shall be a complete type, (possibly cv-qualified) \tcode{void},
+  \tcode{T} shall be a complete type, \cv{}~\tcode{void},
   or an array of unknown bound. \\ \rowsep
 
 \indexlibrary{\idxcode{is_assignable}}%
@@ -15810,7 +15810,7 @@ notwithstanding the restrictions of~\ref{declval}.
   specializations and function template specializations, the generation of
   implicitly-defined functions, and so on. Such side effects are not in the ``immediate
   context'' and can result in the program being ill-formed. \end{note} &
-  \tcode{T} and \tcode{U} shall be complete types, (possibly cv-qualified) \tcode{void},
+  \tcode{T} and \tcode{U} shall be complete types, \cv{}~\tcode{void},
   or arrays of unknown bound. \\ \rowsep
 
 \indexlibrary{\idxcode{is_copy_assignable}}%
@@ -15818,7 +15818,7 @@ notwithstanding the restrictions of~\ref{declval}.
   \tcode{struct is_copy_assignable;} &
   For a referenceable type \tcode{T}, the same result as
   \tcode{is_assignable_v<T\&, const T\&>}, otherwise \tcode{false}. &
-  \tcode{T} shall be a complete type, (possibly cv-qualified) \tcode{void},
+  \tcode{T} shall be a complete type, \cv{}~\tcode{void},
   or an array of unknown bound. \\ \rowsep
 
 \indexlibrary{\idxcode{is_move_assignable}}%
@@ -15826,7 +15826,7 @@ notwithstanding the restrictions of~\ref{declval}.
   \tcode{struct is_move_assignable;} &
   For a referenceable type \tcode{T}, the same result as
   \tcode{is_assignable_v<T\&, T\&\&>}, otherwise \tcode{false}. &
-  \tcode{T} shall be a complete type, (possibly cv-qualified) \tcode{void},
+  \tcode{T} shall be a complete type, \cv{}~\tcode{void},
   or an array of unknown bound. \\ \rowsep
 
 \indexlibrary{\idxcode{is_swappable_with}}%
@@ -15850,7 +15850,7 @@ notwithstanding the restrictions of~\ref{declval}.
   can result in the program being ill-formed.
   \end{note} &
   \tcode{T} and \tcode{U} shall be complete types,
-  (possibly cv-qualified) \tcode{void}, or
+  \cv{}~\tcode{void}, or
   arrays of unknown bound.  \\ \rowsep
 
 \indexlibrary{\idxcode{is_swappable}}%
@@ -15860,7 +15860,7 @@ notwithstanding the restrictions of~\ref{declval}.
   the same result as \tcode{is_swappable_with_v<T\&, T\&>},
   otherwise \tcode{false}. &
   \tcode{T} shall be a complete type,
-  (possibly cv-qualified) \tcode{void}, or
+  \cv{}~\tcode{void}, or
   an array of unknown bound. \\ \rowsep
 
 \indexlibrary{\idxcode{is_destructible}}%
@@ -15874,7 +15874,7 @@ notwithstanding the restrictions of~\ref{declval}.
   when treated as an unevaluated operand (Clause \ref{expr}),
   where \tcode{U} is
   \tcode{remove_all_extents<T>}. &
-  \tcode{T} shall be a complete type, (possibly cv-qualified) \tcode{void},
+  \tcode{T} shall be a complete type, \cv{}~\tcode{void},
   or an array of unknown bound. \\ \rowsep
 
 \indexlibrary{\idxcode{is_trivially_constructible}}%
@@ -15886,14 +15886,14 @@ notwithstanding the restrictions of~\ref{declval}.
   definition for \tcode{is_constructible}, as defined below, is known to call
   no operation that is not trivial (~\ref{basic.types},~\ref{special}). &
   \tcode{T} and all types in the parameter pack \tcode{Args} shall be complete types,
-  (possibly cv-qualified) \tcode{void}, or arrays of unknown bound. \\ \rowsep
+  \cv{}~\tcode{void}, or arrays of unknown bound. \\ \rowsep
 
 \indexlibrary{\idxcode{is_trivially_default_constructible}}%
 \tcode{template <class T>}\br
  \tcode{struct is_trivially_default_constructible;} &
  \tcode{is_trivially_constructible_v<T>} is \tcode{true}. &
  \tcode{T} shall be a complete type,
- (possibly cv-qualified) \tcode{void}, or an array of unknown
+ \cv{}~\tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_trivially_copy_constructible}}%
@@ -15902,7 +15902,7 @@ notwithstanding the restrictions of~\ref{declval}.
   For a referenceable type \tcode{T}, the same result as
  \tcode{is_trivially_constructible_v<T, const T\&>}, otherwise \tcode{false}. &
   \tcode{T} shall be a complete type,
- (possibly cv-qualified) \tcode{void}, or an array of unknown
+ \cv{}~\tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_trivially_move_constructible}}%
@@ -15911,7 +15911,7 @@ notwithstanding the restrictions of~\ref{declval}.
   For a referenceable type \tcode{T}, the same result as
  \tcode{is_trivially_constructible_v<T, T\&\&>}, otherwise \tcode{false}. &
   \tcode{T} shall be a complete type,
- (possibly cv-qualified) \tcode{void}, or an array of unknown
+ \cv{}~\tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_trivially_assignable}}%
@@ -15920,7 +15920,7 @@ notwithstanding the restrictions of~\ref{declval}.
   \tcode{is_assignable_v<T, U>} is \tcode{true} and the assignment, as defined by
   \tcode{is_assignable}, is known to call no operation that is not trivial
   (\ref{basic.types},~\ref{special}). &
-  \tcode{T} and \tcode{U} shall be complete types, (possibly cv-qualified) \tcode{void},
+  \tcode{T} and \tcode{U} shall be complete types, \cv{}~\tcode{void},
   or arrays of unknown bound. \\ \rowsep
 
 \indexlibrary{\idxcode{is_trivially_copy_assignable}}%
@@ -15929,7 +15929,7 @@ notwithstanding the restrictions of~\ref{declval}.
   For a referenceable type \tcode{T}, the same result as
  \tcode{is_trivially_assignable_v<T\&, const T\&>}, otherwise \tcode{false}. &
  \tcode{T} shall be a complete type,
- (possibly cv-qualified) \tcode{void}, or an array of unknown
+ \cv{}~\tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_trivially_move_assignable}}%
@@ -15938,7 +15938,7 @@ notwithstanding the restrictions of~\ref{declval}.
   For a referenceable type \tcode{T}, the same result as
  \tcode{is_trivially_assignable_v<T\&, T\&\&>}, otherwise \tcode{false}. &
  \tcode{T} shall be a complete type,
- (possibly cv-qualified) \tcode{void}, or an array of unknown bound.                \\ \rowsep
+ \cv{}~\tcode{void}, or an array of unknown bound.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_trivially_destructible}}%
 \tcode{template <class T>}\br
@@ -15946,7 +15946,7 @@ notwithstanding the restrictions of~\ref{declval}.
  \tcode{is_destructible_v<T>} is \tcode{true} and the indicated destructor is known
  to be trivial. &
  \tcode{T} shall be a complete type,
- (possibly cv-qualified) \tcode{void}, or an array of unknown
+ \cv{}~\tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_nothrow_constructible}}%
@@ -15958,7 +15958,7 @@ notwithstanding the restrictions of~\ref{declval}.
  throw any exceptions~(\ref{expr.unary.noexcept}).
  &
  \tcode{T} and all types in the parameter pack \tcode{Args}
- shall be complete types, (possibly cv-qualified) \tcode{void},
+ shall be complete types, \cv{}~\tcode{void},
  or arrays of unknown bound.  \\ \rowsep
 
 \indexlibrary{\idxcode{is_nothrow_default_constructible}}%
@@ -15966,7 +15966,7 @@ notwithstanding the restrictions of~\ref{declval}.
  \tcode{struct is_nothrow_default_constructible;} &
  \tcode{is_nothrow_constructible_v<T>} is \tcode{true}.  &
  \tcode{T} shall be a complete type,
- (possibly cv-qualified) \tcode{void}, or an array of unknown
+ \cv{}~\tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_nothrow_copy_constructible}}%
@@ -15975,7 +15975,7 @@ notwithstanding the restrictions of~\ref{declval}.
   For a referenceable type \tcode{T}, the same result as
  \tcode{is_nothrow_constructible_v<T, const T\&>}, otherwise \tcode{false}. &
  \tcode{T} shall be a complete type,
- (possibly cv-qualified) \tcode{void}, or an array of unknown
+ \cv{}~\tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_nothrow_move_constructible}}%
@@ -15984,14 +15984,14 @@ notwithstanding the restrictions of~\ref{declval}.
   For a referenceable type \tcode{T}, the same result as
  \tcode{is_nothrow_constructible_v<T, T\&\&>}, otherwise \tcode{false}. &
  \tcode{T} shall be a complete type,
- (possibly cv-qualified) \tcode{void}, or an array of unknown bound.                \\ \rowsep
+ \cv{}~\tcode{void}, or an array of unknown bound.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_nothrow_assignable}}%
 \tcode{template <class T, class U>}\br
   \tcode{struct is_nothrow_assignable;} &
   \tcode{is_assignable_v<T, U>} is \tcode{true} and the assignment is known not to
   throw any exceptions~(\ref{expr.unary.noexcept}). &
-  \tcode{T} and \tcode{U} shall be complete types, (possibly cv-qualified) \tcode{void},
+  \tcode{T} and \tcode{U} shall be complete types, \cv{}~\tcode{void},
   or arrays of unknown bound. \\ \rowsep
 
 \indexlibrary{\idxcode{is_nothrow_copy_assignable}}%
@@ -16000,7 +16000,7 @@ notwithstanding the restrictions of~\ref{declval}.
   For a referenceable type \tcode{T}, the same result as
  \tcode{is_nothrow_assignable_v<T\&, const T\&>}, otherwise \tcode{false}. &
  \tcode{T} shall be a complete type,
- (possibly cv-qualified) \tcode{void}, or an array of unknown
+ \cv{}~\tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_nothrow_move_assignable}}%
@@ -16009,7 +16009,7 @@ notwithstanding the restrictions of~\ref{declval}.
   For a referenceable type \tcode{T}, the same result as
   \tcode{is_nothrow_assignable_v<T\&, T\&\&>}, otherwise \tcode{false}. &
  \tcode{T} shall be a complete type,
- (possibly cv-qualified) \tcode{void}, or an array of unknown
+ \cv{}~\tcode{void}, or an array of unknown
  bound.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_nothrow_swappable_with}}%
@@ -16020,7 +16020,7 @@ notwithstanding the restrictions of~\ref{declval}.
   \tcode{is_swappable_with<T, U>} is known not to throw
   any exceptions~(\ref{expr.unary.noexcept}). &
   \tcode{T} and \tcode{U} shall be complete types,
-  (possibly cv-qualified) \tcode{void}, or
+  \cv{}~\tcode{void}, or
   arrays of unknown bound. \\ \rowsep
 
 \indexlibrary{\idxcode{is_nothrow_swappable}}%
@@ -16030,7 +16030,7 @@ notwithstanding the restrictions of~\ref{declval}.
   the same result as \tcode{is_nothrow_swappable_with_v<T\&, T\&>},
   otherwise \tcode{false}. &
   \tcode{T} shall be a complete type,
-  (possibly cv-qualified) \tcode{void}, or
+  \cv{}~\tcode{void}, or
   an array of unknown bound. \\ \rowsep
 
 \indexlibrary{\idxcode{is_nothrow_destructible}}%
@@ -16039,7 +16039,7 @@ notwithstanding the restrictions of~\ref{declval}.
   \tcode{is_destructible_v<T>} is \tcode{true} and the indicated destructor is known
   not to throw any exceptions~(\ref{expr.unary.noexcept}). &
   \tcode{T} shall be a complete type,
-  (possibly cv-qualified) \tcode{void}, or an array of unknown
+  \cv{}~\tcode{void}, or an array of unknown
   bound.                \\ \rowsep
 
 \indexlibrary{\idxcode{has_virtual_destructor}}%
@@ -16054,7 +16054,7 @@ notwithstanding the restrictions of~\ref{declval}.
   For an array type \tcode{T}, the same result as
   \tcode{has_unique_object_representations_v<remove_all_extents_t<T>>},
   otherwise \seebelow. &
-  \tcode{T} shall be a complete type, (possibly cv-qualified) \tcode{void}, or
+  \tcode{T} shall be a complete type, \cv{}~\tcode{void}, or
   an array of unknown bound. \\ \rowsep
 
 \end{libreqtab3b}
@@ -16249,7 +16249,7 @@ not possibly cv-qualified versions of the same type,
  \seebelow                                  &
  \tcode{From} and \tcode{To} shall be complete
  types, arrays of unknown
- bound, or (possibly cv-qualified) \tcode{void} types.                \\ \rowsep
+ bound, or \cv{}~\tcode{void} types.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_callable}}%
 \tcode{template <class Fn, class... ArgTypes, class R>}\br
@@ -16258,7 +16258,7 @@ not possibly cv-qualified versions of the same type,
  The expression \tcode{\textit{INVOKE}(declval<Fn>(), declval<ArgTypes>()..., R)}
  is well formed when treated as an unevaluated operand                &
  \tcode{Fn}, \tcode{R}, and all types in the parameter pack \tcode{ArgTypes}
- shall be complete types, (possibly cv-qualified) \tcode{void}, or
+ shall be complete types, \cv{}~\tcode{void}, or
  arrays of unknown bound.                                             \\ \rowsep
 
 \indexlibrary{\idxcode{is_nothrow_callable}}%
@@ -16269,7 +16269,7 @@ not possibly cv-qualified versions of the same type,
  the expression \tcode{\textit{INVOKE}(declval<Fn>(), declval<ArgTypes>()..., R)}
  is known not to throw any exceptions                                 &
  \tcode{Fn}, \tcode{R}, and all types in the parameter pack \tcode{ArgTypes}
- shall be complete types, (possibly cv-qualified) \tcode{void}, or
+ shall be complete types, \cv{}~\tcode{void}, or
  arrays of unknown bound.                                             \\
 \end{libreqtab3f}
 
@@ -16553,7 +16553,7 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
 \tcode{template <class T>\br
  struct add_pointer;}                       &
  If \tcode{T} names a referenceable type (\ref{defns.referenceable}) or a
- (possibly cv-qualified) \tcode{void} type then
+ \cv{}~\tcode{void} type then
  the member typedef \tcode{type} shall name the same type as
  \tcode{remove_reference_t<T>*};
  otherwise, \tcode{type} shall name \tcode{T}.             \\
@@ -16665,7 +16665,7 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
  context'' and can result in the program being ill-formed.
  \end{note} \br
  \requires{} \tcode{Fn} and all types in the parameter pack \tcode{ArgTypes} shall
- be complete types, (possibly cv-qualified) \tcode{void}, or arrays of
+ be complete types, \cv{}~\tcode{void}, or arrays of
  unknown bound.\\
 \end{libreqtab2a}
 


### PR DESCRIPTION
As previously discussed with the Project Editor, changed (mainly in <type_traits> tables but also in other places) occurrences of "(possibly cv-qualified)" followed by a type (usually void, but also occasionally bool, etc.) by the \cv{} macro.  To avoid a line break after \cv{}, replaced the space by a tilde (i.e., by a non-breaking space).