### PR TITLE
[numeric.limits] Add missing \tcode around true

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -565,7 +565,7 @@ static constexpr bool is_signed;
 
 \begin{itemdescr}
 \pnum
-True if the type is signed.
+\tcode{true} if the type is signed.
 
 \pnum
 Meaningful for all specializations.
@@ -578,7 +578,7 @@ static constexpr bool is_integer;
 
 \begin{itemdescr}
 \pnum
-True if the type is integer.
+\tcode{true} if the type is integer.
 
 \pnum
 Meaningful for all specializations.
@@ -591,7 +591,7 @@ static constexpr bool is_exact;
 
 \begin{itemdescr}
 \pnum
-True if the type uses an exact representation.
+\tcode{true} if the type uses an exact representation.
 All integer types are exact, but not all exact types are integer.
 For example, rational and fixed-exponent representations are exact but not integer.
 
@@ -716,7 +716,7 @@ static constexpr bool has_infinity;
 
 \begin{itemdescr}
 \pnum
-True if the type has a representation for positive infinity.
+\tcode{true} if the type has a representation for positive infinity.
 
 \pnum
 Meaningful for all floating-point types.
@@ -735,7 +735,7 @@ static constexpr bool has_quiet_NaN;
 
 \begin{itemdescr}
 \pnum
-True if the type has a representation for a quiet (non-signaling) ``Not a
+\tcode{true} if the type has a representation for a quiet (non-signaling) ``Not a
 Number.''\footnote{Required by LIA-1.}
 
 \pnum
@@ -755,7 +755,7 @@ static constexpr bool has_signaling_NaN;
 
 \begin{itemdescr}
 \pnum
-True if the type has a representation for a signaling ``Not a Number.''\footnote{Required by LIA-1.}
+\tcode{true} if the type has a representation for a signaling ``Not a Number.''\footnote{Required by LIA-1.}
 
 \pnum
 Meaningful for all floating-point types.
@@ -795,7 +795,7 @@ static constexpr bool has_denorm_loss;
 
 \begin{itemdescr}
 \pnum
-True if loss of accuracy is detected as a
+\tcode{true} if loss of accuracy is detected as a
 denormalization loss, rather than as an inexact result.\footnote{See
 ISO/IEC/IEEE 60559.}
 \end{itemdescr}
@@ -873,7 +873,7 @@ static constexpr bool is_iec559;
 
 \begin{itemdescr}
 \pnum
-True if and only if the type adheres to ISO/IEC/IEEE
+\tcode{true} if and only if the type adheres to ISO/IEC/IEEE
 60559.\footnote{ISO/IEC/IEEE 60559:2011 is the same as IEEE 754-2008.}
 
 \pnum
@@ -887,7 +887,7 @@ static constexpr bool is_bounded;
 
 \begin{itemdescr}
 \pnum
-True if the set of values representable by the type is finite.\footnote{Required by LIA-1.}
+\tcode{true} if the set of values representable by the type is finite.\footnote{Required by LIA-1.}
 \begin{note} All fundamental types~(\ref{basic.fundamental}) are bounded. This member would be \tcode{false} for arbitrary
 precision types.\end{note}
 
@@ -902,7 +902,7 @@ static constexpr bool is_modulo;
 
 \begin{itemdescr}
 \pnum
-True if the type is modulo.\footnote{Required by LIA-1.}
+\tcode{true} if the type is modulo.\footnote{Required by LIA-1.}
 A type is modulo if, for any operation involving \tcode{+}, \tcode{-}, or
 \tcode{*} on values of that type whose result would fall outside the range
 \crange{min()}{max()}, the value returned differs from the true value by an


### PR DESCRIPTION
I didn't notice these in https://github.com/cplusplus/draft/pull/977 because of the capitalization.