### PR TITLE
[whole standard] Put commas outside quotes

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3821,7 +3821,7 @@ respectively, in \tcode{<cstdint>}, called the underlying types.
 \indextext{Boolean~type}%
 Values of type \tcode{bool} are either \tcode{true} or
 \tcode{false}.\footnote{Using a \tcode{bool} value in ways described by this International
-Standard as ``undefined,'' such as by examining the value of an
+Standard as ``undefined'', such as by examining the value of an
 uninitialized automatic object, might cause it to behave as if it is
 neither \tcode{true} nor \tcode{false}.}
 \begin{note} There are no \tcode{signed}, \tcode{unsigned}, \tcode{short},

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -591,7 +591,7 @@ This style of type definition is seen as poor coding style.
 
 \ref{dcl.fct.def}
 \change In \Cpp, the syntax for function definition excludes the ``old-style'' C function.
-In C, ``old-style'' syntax is allowed, but deprecated as ``obsolescent.''
+In C, ``old-style'' syntax is allowed, but deprecated as ``obsolescent''.
 \rationale
 Prototypes are essential to type safety.
 \effect

--- a/source/derived.tex
+++ b/source/derived.tex
@@ -146,8 +146,8 @@ derived object~(\ref{intro.object}) is unspecified.
 \indextext{lattice|see{DAG, subobject}}%
 a derived class and its base class subobjects can be represented by a
 directed acyclic graph (DAG) where an arrow means ``directly derived
-from.'' A DAG of subobjects is often referred to as a ``subobject
-lattice.''
+from''. A DAG of subobjects is often referred to as a ``subobject
+lattice''.
 
 \begin{importgraphic}
 {Directed acyclic graph}

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -310,7 +310,7 @@ The set of
 consists of all syntactic and semantic rules in this International
 Standard except for those rules containing an explicit notation that
 ``no diagnostic is required'' or which are described as resulting in
-``undefined behavior.''
+``undefined behavior''.
 
 \pnum
 \indextext{conformance requirements!method of description}%
@@ -438,7 +438,7 @@ In the syntax notation used in this International Standard, syntactic
 categories are indicated by \grammarterm{italic} type, and literal words
 and characters in \tcode{constant} \tcode{width} type. Alternatives are
 listed on separate lines except in a few cases where a long set of
-alternatives is marked by the phrase ``one of.'' If the text of an alternative is too long to fit on a line, the text is continued on subsequent lines indented from the first one.
+alternatives is marked by the phrase ``one of''. If the text of an alternative is too long to fit on a line, the text is continued on subsequent lines indented from the first one.
 An optional terminal or non-terminal symbol is indicated by the subscript
 ``\opt'', so
 

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -3634,7 +3634,7 @@ or
 might fail by throwing an exception prematurely.
 The intention is not only that the calls will not return
 \tcode{eof()}
-but that they will return ``immediately.''}
+but that they will return ``immediately''.}
 
 \pnum
 \default
@@ -5129,7 +5129,7 @@ end-of-file occurs on the input sequence
 for the next available input
 character \tcode{c}
 (in which case the input character is extracted but not stored);\footnote{Since
-the final input character is ``extracted,''
+the final input character is ``extracted'',
 it is counted in the
 \tcode{gcount()},
 even though it is not stored.}

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -419,9 +419,9 @@ define these constraints.
 
 \pnum
 Interface convention requirements are stated as generally as possible. Instead
-of stating ``class X has to define a member function \tcode{operator++()},'' the
+of stating ``class X has to define a member function \tcode{operator++()}'', the
 interface requires ``for any object \tcode{x} of class \tcode{X}, \tcode{++x} is
-defined.'' That is, whether the operator is a member is unspecified.
+defined''. That is, whether the operator is a member is unspecified.
 
 \pnum
 Requirements are stated in terms of well-defined expressions that define valid terms of

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -1556,7 +1556,7 @@ phrases of the form ``\tcode{x} is an iterator of a specific kind''
 shall be interpreted as equivalent to the more formal requirement that
 ``\tcode{x} is a value
 of a type satisfying the requirements
-of the specified iterator type.''
+of the specified iterator type''.
 
 \pnum
 Throughout this subclause \ref{rand},

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -19,7 +19,7 @@ is either the first character in the source file
 or that follows white space containing at least one new-line character.
 The last token in the sequence is the first new-line character
 that follows the first token in the sequence.\footnote{Thus,
-preprocessing directives are commonly called ``lines.''
+preprocessing directives are commonly called ``lines''.
 These ``lines'' have no other syntactic significance,
 as all white space is equivalent except in certain situations
 during preprocessing (see the
@@ -942,7 +942,7 @@ a macro name.
 
 \pnum
 \begin{example}
-The simplest use of this facility is to define a ``manifest constant,''
+The simplest use of this facility is to define a ``manifest constant'',
 as in
 \begin{codeblock}
 #define TABSIZE 100

--- a/source/support.tex
+++ b/source/support.tex
@@ -736,7 +736,7 @@ static constexpr bool has_quiet_NaN;
 \begin{itemdescr}
 \pnum
 \tcode{true} if the type has a representation for a quiet (non-signaling) ``Not a
-Number.''\footnote{Required by LIA-1.}
+Number''.\footnote{Required by LIA-1.}
 
 \pnum
 Meaningful for all floating-point types.
@@ -755,7 +755,7 @@ static constexpr bool has_signaling_NaN;
 
 \begin{itemdescr}
 \pnum
-\tcode{true} if the type has a representation for a signaling ``Not a Number.''\footnote{Required by LIA-1.}
+\tcode{true} if the type has a representation for a signaling ``Not a Number''.\footnote{Required by LIA-1.}
 
 \pnum
 Meaningful for all floating-point types.
@@ -823,7 +823,7 @@ static constexpr T quiet_NaN() noexcept;
 
 \begin{itemdescr}
 \pnum
-Representation of a quiet ``Not a Number,'' if available.\footnote{Required by LIA-1.}
+Representation of a quiet ``Not a Number'', if available.\footnote{Required by LIA-1.}
 
 \pnum
 Meaningful for all specializations for which
@@ -839,7 +839,7 @@ static constexpr T signaling_NaN() noexcept;
 
 \begin{itemdescr}
 \pnum
-Representation of a signaling ``Not a Number,'' if available.\footnote{Required by LIA-1.}
+Representation of a signaling ``Not a Number'', if available.\footnote{Required by LIA-1.}
 
 \pnum
 Meaningful for all specializations for which


### PR DESCRIPTION
Grep shows that putting commas and periods outside quotes is much more common.