### PR TITLE
Do not use code font for constexpr constructor and constexpr function

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2540,7 +2540,7 @@ Within each of these phases of initiation, initialization occurs as follows.
 \indextext{initialization!\idxcode{static object}}%
 \indextext{initialization!constant}%
 A \defn{constant initializer} for an object \tcode{o} is an expression that is a
-constant expression, except that it may also invoke \tcode{constexpr} constructors
+constant expression, except that it may also invoke constexpr constructors
 for \tcode{o} and its subobjects even if those objects are of non-literal class
 types. \begin{note} Such a class may have a non-trivial destructor. \end{note}
 \defnx{Constant initialization}{constant initialization} is performed:
@@ -3652,7 +3652,7 @@ has all of the following properties:
 \item it has a trivial destructor,
 \item it is either a closure type~(\ref{expr.prim.lambda}),
 an aggregate type~(\ref{dcl.init.aggr}), or
-has at least one \tcode{constexpr} constructor or constructor template
+has at least one constexpr constructor or constructor template
 (possibly inherited~(\ref{namespace.udecl}) from a base class)
 that is not a copy or move constructor,
 \item if it is a union, at least one of its non-static data members is

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -771,7 +771,7 @@ a constructor declaration declares that constructor to be a
 \pnum
 \indextext{specifier!\idxcode{constexpr}!function}
 \indextext{constexpr function}
-The definition of a \tcode{constexpr} function shall satisfy the following
+The definition of a constexpr function shall satisfy the following
 requirements:
 
 \begin{itemize}
@@ -838,7 +838,7 @@ constexpr int g(int x, int n) { // OK
 
 \pnum
 \indextext{specifier!\idxcode{constexpr}!constructor}%
-The definition of a \tcode{constexpr} constructor shall satisfy the
+The definition of a constexpr constructor shall satisfy the
 following requirements:
 \begin{itemize}
 \item
@@ -861,7 +861,7 @@ In addition, either its \grammarterm{function-body} shall be
 \item
 either its \grammarterm{function-body} shall be \tcode{= default}, or the \grammarterm{compound-statement} of its \grammarterm{function-body}
 shall satisfy the requirements for a \grammarterm{function-body} of a
-\tcode{constexpr} function;
+constexpr function;
 
 \item
 every non-variant non-static data member and base class subobject
@@ -877,7 +877,7 @@ members having variant members, exactly one of them shall be initialized;
 
 \item
 for a non-delegating constructor, every constructor selected to initialize non-static
-data members and base class subobjects shall be a \tcode{constexpr} constructor;
+data members and base class subobjects shall be a constexpr constructor;
 
 \item
 for a delegating constructor, the target constructor shall be a \tcode{constexpr}
@@ -895,7 +895,7 @@ private:
 \end{example}
 
 \pnum
-For a \tcode{constexpr} function or \tcode{constexpr} constructor
+For a constexpr function or constexpr constructor
 that is neither defaulted nor a template,
 if no argument values exist such that
 an invocation of the function or constructor could be an evaluated subexpression of a core
@@ -924,22 +924,22 @@ struct D : B {
 \end{example}
 
 \pnum
-If the instantiated template specialization of a \tcode{constexpr} function
+If the instantiated template specialization of a constexpr function
 template
 or member function of a class template
 would fail to satisfy the requirements for a \tcode{constexpr}
-function or \tcode{constexpr} constructor,
-that specialization is still a \tcode{constexpr} function or \tcode{constexpr}
+function or constexpr constructor,
+that specialization is still a constexpr function or \tcode{constexpr}
 constructor, even though a call to such a function cannot appear in a constant
 expression. If no specialization of the template would satisfy the
-requirements for a \tcode{constexpr} function or \tcode{constexpr} constructor
+requirements for a constexpr function or constexpr constructor
 when considered as a non-template function or constructor, the template is
 ill-formed; no diagnostic
 required.
 
 \pnum
-A call to a \tcode{constexpr} function produces the same result as a call to an equivalent
-non-\tcode{constexpr} function in all respects except that
+A call to a constexpr function produces the same result as a call to an equivalent
+non-constexpr function in all respects except that
 \begin{itemize}
 \item
 a call to a \tcode{constexpr}
@@ -950,7 +950,7 @@ copy elision is mandatory in a constant expression~(\ref{class.copy}).
 
 \pnum
 The \tcode{constexpr} specifier has no
-effect on the type of a \tcode{constexpr} function or a \tcode{constexpr} constructor.  \begin{example}
+effect on the type of a constexpr function or a constexpr constructor.  \begin{example}
 \begin{codeblock}
 constexpr int bar(int x, int y) // OK 
     { return x + y + x*y; } 

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4883,26 +4883,26 @@ machine~(\ref{intro.execution}), would evaluate one of the following expressions
 \begin{itemize}
 \item
 \tcode{this}~(\ref{expr.prim.this}), except in a \tcode{constexpr}
-function or a \tcode{constexpr} constructor that is being evaluated as part
+function or a constexpr constructor that is being evaluated as part
 of \tcode{e};
 
 \item
 an invocation of a function other than
-a \tcode{constexpr} constructor for a literal class,
-a \tcode{constexpr} function,
+a constexpr constructor for a literal class,
+a constexpr function,
 or an implicit invocation of a trivial destructor~(\ref{class.dtor})
 \begin{note} Overload resolution~(\ref{over.match})
 is applied as usual \end{note};
 
 \item
-an invocation of an undefined \tcode{constexpr} function or an
-undefined \tcode{constexpr} constructor;
+an invocation of an undefined constexpr function or an
+undefined constexpr constructor;
 
 \item
-an invocation of an instantiated \tcode{constexpr} function or
-\tcode{constexpr} constructor that fails to satisfy the requirements
-for a \tcode{constexpr} function or
-\tcode{constexpr} constructor~(\ref{dcl.constexpr});
+an invocation of an instantiated constexpr function or
+constexpr constructor that fails to satisfy the requirements
+for a constexpr function or
+constexpr constructor~(\ref{dcl.constexpr});
 
 \item
 an expression that would exceed the implementation-defined

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -2653,7 +2653,7 @@ namespace std {
 \effects
 Constructs the end-of-stream iterator.
 If \tcode{is_trivially_default_constructible_v<T>} is \tcode{true},
-then this constructor is a \tcode{constexpr} constructor.
+then this constructor is a constexpr constructor.
 
 \pnum
 \postconditions \tcode{in_stream == 0}.

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2746,7 +2746,7 @@ with two or more member functions with equivalent behavior,
 or add additional signatures for a member function name.
 \end{note}
 
-\rSec3[constexpr.functions]{\tcode{constexpr} functions and constructors}
+\rSec3[constexpr.functions]{Constexpr functions and constructors}
 
 \pnum
 This standard explicitly requires that certain standard library functions are

--- a/source/limits.tex
+++ b/source/limits.tex
@@ -117,7 +117,7 @@ Scope qualifications of one identifier [256].
 \item%
 Nested external specifications [1\,024].
 \item%
-Recursive \tcode{constexpr} function invocations [512].
+Recursive constexpr function invocations [512].
 \item%
 Full-expressions evaluated within a core constant expression [1\,048\,576].
 \item%

--- a/source/special.tex
+++ b/source/special.tex
@@ -253,7 +253,7 @@ constructor for that class with no
 If that user-written default constructor would be ill-formed,
 the program is ill-formed.
 If that user-written default constructor would satisfy the requirements
-of a \tcode{constexpr} constructor~(\ref{dcl.constexpr}), the implicitly-defined
+of a constexpr constructor~(\ref{dcl.constexpr}), the implicitly-defined
 default constructor is \tcode{constexpr}.
 Before the defaulted default constructor for a class is
 implicitly defined,
@@ -2735,7 +2735,7 @@ The copy/move constructor is implicitly defined even if the implementation elide
 its odr-use (\ref{basic.def.odr}, \ref{class.temporary}).
 \end{note}
 If the implicitly-defined constructor would satisfy the requirements of a
-\tcode{constexpr} constructor~(\ref{dcl.constexpr}), the implicitly-defined
+constexpr constructor~(\ref{dcl.constexpr}), the implicitly-defined
 constructor is \tcode{constexpr}.
 
 \pnum
@@ -3051,12 +3051,12 @@ The implicitly-defined copy/move assignment operator is \tcode{constexpr} if
 
 \item
 the assignment operator selected to copy/move each direct base class subobject
-is a \tcode{constexpr} function, and
+is a constexpr function, and
 
 \item
 for each non-static data member of \tcode{X} that is of class type (or array
 thereof), the assignment operator selected to copy/move that member is a
-\tcode{constexpr} function.
+constexpr function.
 \end{itemize}
 
 \pnum

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -3237,7 +3237,7 @@ instantiation uses
   \item the value of a \tcode{const} object of integral or unscoped enumeration type or
   \item the value of a \tcode{constexpr} object or
   \item the value of a reference or
-  \item the definition of a \tcode{constexpr} function,
+  \item the definition of a constexpr function,
   \end{itemize}
 and that entity was not defined when the template was defined, or
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -931,9 +931,9 @@ throws an exception.
 
 \pnum
 The defaulted move and copy constructor, respectively, of pair shall
-be a \tcode{constexpr} function if and only if all required element-wise
+be a constexpr function if and only if all required element-wise
 initializations for copy and move, respectively, would satisfy the
-requirements for a \tcode{constexpr} function.
+requirements for a constexpr function.
 
 \indexlibrary{\idxcode{pair}!constructor}%
 \begin{itemdecl}
@@ -1572,11 +1572,11 @@ one of the types in \tcode{Types} throws an exception.
 
 \pnum
 The defaulted move and copy constructor, respectively, of
-\tcode{tuple} shall be a \tcode{constexpr} function if and only if all
+\tcode{tuple} shall be a constexpr function if and only if all
 required element-wise initializations for copy and move, respectively,
-would satisfy the requirements for a \tcode{constexpr} function. The
+would satisfy the requirements for a constexpr function. The
 defaulted move and copy constructor of \tcode{tuple<>} shall be
-\tcode{constexpr} functions.
+constexpr functions.
 
 \pnum
 In the constructor descriptions that follow, let $i$ be in the range
@@ -2680,7 +2680,7 @@ constexpr optional(nullopt_t) noexcept;
 \pnum
 \remarks
 No contained value is initialized.
-For every object type \tcode{T} these constructors shall be \tcode{constexpr} constructors (\ref{dcl.constexpr}).
+For every object type \tcode{T} these constructors shall be constexpr constructors (\ref{dcl.constexpr}).
 \end{itemdescr}
 
 \indexlibrary{\idxcode{optional}!constructor}%
@@ -2755,7 +2755,7 @@ Any exception thrown by the selected constructor of \tcode{T}.
 
 \pnum
 \remarks
-If \tcode{T}'s constructor selected for the initialization is a \tcode{constexpr} constructor, this constructor shall be a \tcode{constexpr} constructor.
+If \tcode{T}'s constructor selected for the initialization is a constexpr constructor, this constructor shall be a \tcode{constexpr} constructor.
 This constructor shall not participate in overload resolution
 unless \tcode{is_constructible_v<T, Args...>} is \tcode{true}.
 \end{itemdescr}
@@ -2782,7 +2782,7 @@ Any exception thrown by the selected constructor of \tcode{T}.
 \pnum
 \remarks
 This constructor shall not participate in overload resolution unless \tcode{is_constructible_v<T, initializer_list<U>\&, Args\&\&...>} is \tcode{true}.
-If \tcode{T}'s constructor selected for the initialization is a \tcode{constexpr} constructor, this constructor shall be a \tcode{constexpr} constructor.
+If \tcode{T}'s constructor selected for the initialization is a constexpr constructor, this constructor shall be a \tcode{constexpr} constructor.
 \end{itemdescr}
 
 \pnum
@@ -2814,8 +2814,8 @@ Any exception thrown by the selected constructor of \tcode{T}.
 
 \pnum
 \remarks
-If \tcode{T}'s selected constructor is a \tcode{constexpr} constructor,
-this constructor shall be a \tcode{constexpr} constructor.
+If \tcode{T}'s selected constructor is a constexpr constructor,
+this constructor shall be a constexpr constructor.
 This constructor shall not participate in overload resolution unless
 \tcode{is_constructible_v<T, U\&\&>} is \tcode{true},
 \tcode{is_same_v<U, in_place_t>} is \tcode{false}, and
@@ -3310,7 +3310,7 @@ Nothing.
 
 \pnum
 \remarks
-These functions shall be \tcode{constexpr} functions.
+These functions shall be constexpr functions.
 \end{itemdescr}
 
 \indexlibrarymember{operator*}{optional}%
@@ -3334,7 +3334,7 @@ Nothing.
 
 \pnum
 \remarks
-These functions shall be \tcode{constexpr} functions.
+These functions shall be constexpr functions.
 \end{itemdescr}
 
 \indexlibrarymember{operator*}{optional}%
@@ -3365,7 +3365,7 @@ constexpr explicit operator bool() const noexcept;
 
 \pnum
 \remarks
-This function shall be a \tcode{constexpr} function.
+This function shall be a constexpr function.
 \end{itemdescr}
 
 \indexlibrarymember{has_value}{optional}%
@@ -3378,7 +3378,7 @@ constexpr bool has_value() const noexcept;
 \returns \tcode{true} if and only if \tcode{*this} contains a value.
 
 \pnum
-\remarks This function shall be a \tcode{constexpr} function.
+\remarks This function shall be a constexpr function.
 \end{itemdescr}
 
 \indexlibrarymember{value}{optional}%
@@ -3537,7 +3537,7 @@ If \tcode{bool(x) != bool(y)}, \tcode{false}; otherwise if \tcode{bool(x) == fal
 \remarks
 Specializations of this function template
 for which \tcode{*x == *y} is a core constant expression
-shall be \tcode{constexpr} functions.
+shall be constexpr functions.
 \end{itemdescr}
 
 \indexlibrarymember{operator"!=}{optional}%
@@ -3585,7 +3585,7 @@ otherwise \tcode{*x < *y}.
 \remarks
 Specializations of this function template
 for which \tcode{*x < *y} is a core constant expression
-shall be \tcode{constexpr} functions.
+shall be constexpr functions.
 \end{itemdescr}
 
 \indexlibrarymember{operator>}{optional}%
@@ -4231,7 +4231,7 @@ Any exception thrown by the value-initialization of \tcode{T}$_0$.
 \remarks
 This function shall be \tcode{constexpr} if and only if the
 value-initialization of the alternative type \tcode{T}$_0$ would satisfy the
-requirements for a \tcode{constexpr} function.
+requirements for a constexpr function.
 The expression inside \tcode{noexcept} is equivalent to
 \tcode{is_nothrow_default_constructible_v<\tcode{T}$_0$>}.
 This function shall not participate in overload resolution unless
@@ -4420,7 +4420,7 @@ Any exception thrown by calling the selected constructor of \tcode{T}$_I$.
 \remarks
 This function shall not participate in overload resolution unless \tcode{I} is
 less than \tcode{sizeof...(Types)} and \tcode{is_constructible_v<T$_I$, Args...>} is \tcode{true}.
-If \tcode{T}$_I$'s selected constructor is a \tcode{constexpr} constructor, this
+If \tcode{T}$_I$'s selected constructor is a constexpr constructor, this
 constructor shall be a constexpr constructor.
 \end{itemdescr}
 
@@ -4445,7 +4445,7 @@ Initializes the contained value as if constructing an object of type
 This function shall not participate in overload resolution unless \tcode{I} is
 less than \tcode{sizeof...(Types)} and
 \tcode{is_constructible_v<T$_I$, initializer_list<U>\&, Args...>} is \tcode{true}.
-If \tcode{T}$_I$'s selected constructor is a \tcode{constexpr} constructor, this
+If \tcode{T}$_I$'s selected constructor is a constexpr constructor, this
 constructor shall be a constexpr constructor.
 \end{itemdescr}
 
@@ -17594,9 +17594,9 @@ those thrown by the indicated operations on their representations.
 
 \pnum
 \remarks The defaulted copy constructor of duration shall be a
-\tcode{constexpr} function if and only if the required initialization
+constexpr function if and only if the required initialization
 of the member \tcode{rep_} for copy and move, respectively, would
-satisfy the requirements for a \tcode{constexpr} function.
+satisfy the requirements for a constexpr function.
 \end{itemdescr}
 
 \begin{example}


### PR DESCRIPTION
Fixes #825.