### PR TITLE
[streambuf.virt.get] use half-open ranges in underflow effects

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -3726,9 +3726,8 @@ The
 of characters is defined as the concatenation of
 \begin{itemize}
 \item the empty sequence if \tcode{gptr()} is null, otherwise the
-\tcode{egptr() - gptr()}
-characters starting at
-\tcode{gptr()},
+characters in
+\range{gptr()}{egptr()},
 followed by
 \item
 some (possibly empty) sequence of characters read from the input sequence.
@@ -3746,9 +3745,8 @@ the next character that would be read from the input sequence.
 The
 \term{backup sequence}
 is the empty sequence if \tcode{eback()} is null, otherwise the
-\tcode{gptr() - eback()}
-characters beginning at
-\tcode{eback()}.
+characters in
+\range{eback()}{gptr()}.
 
 \pnum
 \effects
@@ -3760,10 +3758,9 @@ such that
 if the pending sequence is non-empty, then
 \tcode{egptr()}
 is non-null and
-\tcode{egptr() - gptr()}
-characters starting at
-\tcode{gptr()}
-are the characters in the pending sequence, otherwise
+the characters in \range{gptr()}{egptr()} are
+the characters in the pending sequence,
+otherwise
 either \tcode{gptr()}
 is null or
 \tcode{gptr() ==  egptr()}.
@@ -3778,16 +3775,13 @@ are non-null then the function is not constrained as to their contents, but the 
 \item
 the backup sequence contains at least
 \tcode{gptr() - eback()}
-characters, in which case the
-\tcode{gptr() - eback()}
-characters starting at
-\tcode{eback()}
+characters, in which case the characters in
+\range{eback()}{gptr()}
 agree with the last
 \tcode{gptr() - eback()}
 characters of the backup sequence, or
 \item
-the \tcode{n} characters starting at
-\tcode{gptr() - n}
+the characters in \range{gptr() - n}{gptr()}
 agree with the backup sequence (where \tcode{n} is the length of the backup sequence).
 \end{itemize}
 


### PR DESCRIPTION
![underflow1](https://cloud.githubusercontent.com/assets/1254480/20757291/8f345a6c-b70d-11e6-814b-ce49c261f6e1.png)
![underflow2](https://cloud.githubusercontent.com/assets/1254480/20757296/93a3f512-b70d-11e6-9d53-9e6c403b4bf5.png)

We should discuss this before merging, I'm ambivalent about it.