### PR TITLE
[util.smartptr] Cleanse of italics infestation.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -9334,7 +9334,7 @@ The \tcode{shared_ptr} class template stores a pointer, usually obtained
 via \tcode{new}. \tcode{shared_ptr} implements semantics of shared ownership;
 the last remaining owner of the pointer is responsible for destroying
 the object, or otherwise releasing the resources associated with the stored pointer. A
-\tcode{shared_ptr} object is \term{empty} if it does not own a pointer.
+\tcode{shared_ptr} is said to be empty if it does not own a pointer.
 
 \begin{codeblock}
 namespace std {
@@ -9488,7 +9488,7 @@ a pointer type \tcode{T*} when either
 
 \pnum
 In the constructor definitions below,
-\term{enables \tcode{shared_from_this} with \tcode{p}},
+enables \tcode{shared_from_this} with \tcode{p},
 for a pointer \tcode{p} of type \tcode{Y*},
 means that if \tcode{Y} has an unambiguous and accessible base class
 that is a specialization of \tcode{enable_shared_from_this}~(\ref{util.smartptr.enab}),
@@ -9507,7 +9507,7 @@ constexpr shared_ptr() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects  Constructs an \textit{empty} \tcode{shared_ptr} object.
+\pnum\effects  Constructs an empty \tcode{shared_ptr} object.
 
 \pnum\postconditions  \tcode{use_count() == 0 \&\& get() == nullptr}.
 \end{itemdescr}
@@ -9529,7 +9529,7 @@ otherwise, \tcode{Y*} shall be convertible to \tcode{T*}.
 
 \pnum\effects When \tcode{T} is not an array type,
 constructs a \tcode{shared_ptr} object
-that \textit{owns} the pointer \tcode{p}.
+that owns the pointer \tcode{p}.
 Otherwise, constructs a \tcode{shared_ptr}
 that owns \tcode{p} and a deleter of an
 unspecified type that calls \tcode{delete[] p}.
@@ -9564,7 +9564,7 @@ When \tcode{T} is \tcode{U[N]}, \tcode{Y(*)[N]} shall be convertible to \tcode{T
 when \tcode{T} is \tcode{U[]}, \tcode{Y(*)[]} shall be convertible to \tcode{T*};
 otherwise, \tcode{Y*} shall be convertible to \tcode{T*}.
 
-\pnum\effects  Constructs a \tcode{shared_ptr} object that \textit{owns} the
+\pnum\effects  Constructs a \tcode{shared_ptr} object that owns the
 object \tcode{p} and the deleter \tcode{d}.
 When \tcode{T} is not an array type,
 the first and second constructors enable \tcode{shared_from_this} with \tcode{p}.
@@ -9587,7 +9587,7 @@ template<class Y> shared_ptr(const shared_ptr<Y>& r, element_type* p) noexcept;
 \begin{itemdescr}
 \pnum
 \effects Constructs a \tcode{shared_ptr} instance that
-stores \tcode{p} and \textit{shares ownership} with \tcode{r}.
+stores \tcode{p} and shares ownership with \tcode{r}.
 
 \pnum
 \postconditions \tcode{get() == p \&\& use_count() == r.use_count()}.
@@ -9598,7 +9598,7 @@ user of this constructor must ensure that \tcode{p} remains valid at
 least until the ownership group of \tcode{r} is destroyed. \end{note}
 
 \pnum
-\begin{note} This constructor allows creation of an \textit{empty}
+\begin{note} This constructor allows creation of an empty
 \tcode{shared_ptr} instance with a non-null stored pointer. \end{note}
 \end{itemdescr}
 
@@ -9613,9 +9613,9 @@ template<class Y> shared_ptr(const shared_ptr<Y>& r) noexcept;
 The second constructor shall not participate in overload resolution unless
 \tcode{Y*} is compatible with \tcode{T*}.
 
-\pnum\effects  If \tcode{r} is \textit{empty}, constructs
-an \textit{empty} \tcode{shared_ptr} object; otherwise, constructs
-a \tcode{shared_ptr} object that \textit{shares ownership} with \tcode{r}.
+\pnum\effects  If \tcode{r} is empty, constructs
+an empty \tcode{shared_ptr} object; otherwise, constructs
+a \tcode{shared_ptr} object that shares ownership with \tcode{r}.
 
 \pnum\postconditions  \tcode{get() == r.get() \&\& use_count() == r.use_count()}.
 \end{itemdescr}
@@ -9636,7 +9636,7 @@ template<class Y> shared_ptr(shared_ptr<Y>&& r) noexcept;
 
 \pnum
 \postconditions \tcode{*this} shall contain the old value of
-\tcode{r}. \tcode{r} shall be \textit{empty}. \tcode{r.get() == nullptr.}
+\tcode{r}. \tcode{r} shall be empty. \tcode{r.get() == nullptr.}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{shared_ptr}!constructor}%
@@ -9648,7 +9648,7 @@ template<class Y> explicit shared_ptr(const weak_ptr<Y>& r);
 \begin{itemdescr}
 \pnum\requires \tcode{Y*} shall be compatible with \tcode{T*}.
 
-\pnum\effects  Constructs a \tcode{shared_ptr} object that \textit{shares ownership} with
+\pnum\effects  Constructs a \tcode{shared_ptr} object that shares ownership with
 \tcode{r} and stores a copy of the pointer stored in \tcode{r}.
 If an exception is thrown, the constructor has no effect.
 
@@ -9686,14 +9686,14 @@ If an exception is thrown, the constructor has no effect.
 \begin{itemdescr}
 \pnum\effects
 \begin{itemize}
-\item If \tcode{*this} is \textit{empty} or shares ownership with another
+\item If \tcode{*this} is empty or shares ownership with another
 \tcode{shared_ptr} instance (\tcode{use_count() > 1}), there are no side effects.
 
 \item
-Otherwise, if \tcode{*this} \textit{owns} an object
+Otherwise, if \tcode{*this} owns an object
 \tcode{p} and a deleter \tcode{d}, \tcode{d(p)} is called.
 
-\item Otherwise, \tcode{*this} \textit{owns} a pointer \tcode{p},
+\item Otherwise, \tcode{*this} owns a pointer \tcode{p},
 and \tcode{delete p} is called.
 \end{itemize}
 \end{itemdescr}
@@ -9884,8 +9884,8 @@ long use_count() const noexcept;
 
 \begin{itemdescr}
 \pnum\returns  The number of \tcode{shared_ptr} objects, \tcode{*this} included,
-that \textit{share ownership} with \tcode{*this}, or \tcode{0} when \tcode{*this} is
-\textit{empty}.
+that share ownership with \tcode{*this}, or \tcode{0} when \tcode{*this} is
+empty.
 
 \pnum\sync None.
 
@@ -9948,7 +9948,7 @@ template<class T, class A, class... Args>
 \requires The expression \tcode{::new (pv) T(std::forward<Args>(args)...)},
 where \tcode{pv} has type \tcode{void*} and points to storage suitable
 to hold an object of type \tcode{T}, shall be well formed. \tcode{A} shall
-be an \textit{allocator}~(\ref{allocator.requirements}). The copy constructor
+be an allocator~(\ref{allocator.requirements}). The copy constructor
 and destructor of \tcode{A} shall not throw exceptions.
 
 \pnum
@@ -10197,7 +10197,7 @@ template<class D, class T> D* get_deleter(const shared_ptr<T>& p) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns  If \tcode{p} \textit{owns} a deleter \tcode{d} of type cv-unqualified
+\pnum\returns  If \tcode{p} owns a deleter \tcode{d} of type cv-unqualified
 \tcode{D}, returns \tcode{addressof(d)}; otherwise returns \tcode{nullptr}.
 The returned
 pointer remains valid as long as there exists a \tcode{shared_ptr} instance
@@ -10285,7 +10285,7 @@ constexpr weak_ptr() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects  Constructs an \textit{empty} \tcode{weak_ptr} object.
+\pnum\effects  Constructs an empty \tcode{weak_ptr} object.
 
 \pnum\postconditions  \tcode{use_count() == 0}.
 \end{itemdescr}
@@ -10301,9 +10301,9 @@ template<class Y> weak_ptr(const shared_ptr<Y>& r) noexcept;
 \pnum\remarks The second and third constructors shall not participate in
 overload resolution unless \tcode{Y*} is compatible with \tcode{T*}.
 
-\pnum\effects  If \tcode{r} is \textit{empty}, constructs
-an \textit{empty} \tcode{weak_ptr} object; otherwise, constructs
-a \tcode{weak_ptr} object that \textit{shares ownership}
+\pnum\effects  If \tcode{r} is empty, constructs
+an empty \tcode{weak_ptr} object; otherwise, constructs
+a \tcode{weak_ptr} object that shares ownership
 with \tcode{r} and stores a copy of the pointer stored in \tcode{r}.
 
 \pnum\postconditions  \tcode{use_count() == r.use_count()}.
@@ -10322,7 +10322,7 @@ template<class Y> weak_ptr(weak_ptr<Y>&& r) noexcept;
 \pnum\effects Move constructs a \tcode{weak_ptr} instance from \tcode{r}.
 
 \pnum\postconditions \tcode{*this} shall contain the old value of \tcode{r}.
-\tcode{r} shall be \textit{empty}. \tcode{r.use_count() == 0}.
+\tcode{r} shall be empty. \tcode{r.use_count() == 0}.
 \end{itemdescr}
 
 \rSec4[util.smartptr.weak.dest]{\tcode{weak_ptr} destructor}
@@ -10393,9 +10393,9 @@ long use_count() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns  \tcode{0} if \tcode{*this} is \textit{empty};
+\pnum\returns  \tcode{0} if \tcode{*this} is empty;
 otherwise, the number of \tcode{shared_ptr} instances
-that \textit{share ownership} with \tcode{*this}.
+that share ownership with \tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{expired}{weak_ptr}%
@@ -10505,7 +10505,7 @@ both empty.
 \indexlibrary{\idxcode{enable_shared_from_this}}%
 A class \tcode{T} can inherit from \tcode{enable_shared_from_this<T>}
 to inherit the \tcode{shared_from_this} member functions that obtain
-a \textit{shared_ptr} instance pointing to \tcode{*this}.
+a \tcode{shared_ptr} instance pointing to \tcode{*this}.
 
 \pnum
 \begin{example}


### PR DESCRIPTION
Technical terms should not be in italics everywhere they are referenced.
Common terms such as 'owns' or 'empty' that are used as technical terms
in this subsection only are not italicized or entered into the index.

Fixes #533.