### PR TITLE
[re.regex] Add missing 'multiline' constant.

### DIFF
--- a/source/regex.tex
+++ b/source/regex.tex
@@ -1395,6 +1395,8 @@ namespace std {
       grep = regex_constants::grep;
     static constexpr regex_constants::syntax_option_type
       egrep = regex_constants::egrep;
+    static constexpr regex_constants::syntax_option_type
+      multiline = regex_constants::multiline;
 
     // \ref{re.regex.construct}, construct/copy/destroy
     basic_regex();
@@ -1474,6 +1476,8 @@ static constexpr regex_constants::syntax_option_type
   grep = regex_constants::grep;
 static constexpr regex_constants::syntax_option_type
   egrep = regex_constants::egrep;
+static constexpr regex_constants::syntax_option_type
+  multiline = regex_constants::multiline;
 \end{codeblock}
 
 \pnum


### PR DESCRIPTION
Fixes #1129.