### PR TITLE
[utilities] Do not use CamelCase for 'BaseCharacteristic'.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2173,7 +2173,7 @@ template <class T> struct tuple_size;
 \pnum
 \remarks All specializations of \tcode{tuple_size<T>} shall meet the
 \tcode{UnaryTypeTrait} requirements~(\ref{meta.rqmts}) with a
-\tcode{BaseCharacteristic} of \tcode{integral_constant<size_t, N>}
+base characteristic of \tcode{integral_constant<size_t, N>}
 for some \tcode{N}.
 \end{itemdescr}
 
@@ -2216,7 +2216,7 @@ Let \tcode{\placeholder{TS}} denote \tcode{tuple_size<T>} of the \cv-unqualified
 If the expression \tcode{\placeholder{TS}::value} is well-formed
 when treated as an unevaluated operand, then each
 of the three templates shall meet the \tcode{UnaryTypeTrait} requirements~(\ref{meta.rqmts})
-with a \tcode{BaseCharacteristic} of
+with a base characteristic of
 \begin{codeblock}
 integral_constant<size_t, @\placeholder{TS}@::value>
 \end{codeblock}
@@ -4855,7 +4855,7 @@ template <class T> struct variant_size;
 \pnum
 \remarks
 All specializations of \tcode{variant_size<T>} shall meet the
-\tcode{UnaryTypeTrait} requirements~(\ref{meta.rqmts}) with a \tcode{BaseCharacteristic} of \tcode{integral_constant<size_t, N>} for some \tcode{N}.
+\tcode{UnaryTypeTrait} requirements~(\ref{meta.rqmts}) with a base characteristic of \tcode{integral_constant<size_t, N>} for some \tcode{N}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{variant_size}}%
@@ -4870,7 +4870,7 @@ template <class T> class variant_size<const volatile T>;
 Let \tcode{VS} denote \tcode{variant_size<T>} of the cv-unqualified
 type \tcode{T}. Then each of the three templates shall meet the
 \tcode{UnaryTypeTrait} requirements~(\ref{meta.rqmts}) with a
-\tcode{BaseCharacteristic} of \tcode{integral_constant<size_t, VS::value>}.
+base characteristic of \tcode{integral_constant<size_t, VS::value>}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{variant_size}}%
@@ -13967,11 +13967,11 @@ uses \tcode{is_bind_expression} to detect subexpressions.
 \pnum
 Instantiations of the \tcode{is_bind_expression} template shall meet
 the UnaryTypeTrait requirements~(\ref{meta.rqmts}). The implementation
-shall provide a definition that has a BaseCharacteristic of
+shall provide a definition that has a base characteristic of
 \tcode{true_type} if \tcode{T} is a type returned from \tcode{bind},
-otherwise it shall have a BaseCharacteristic of \tcode{false_type}.
+otherwise it shall have a base characteristic of \tcode{false_type}.
 A program may specialize this template for a user-defined type \tcode{T}
-to have a BaseCharacteristic of \tcode{true_type} to indicate that
+to have a base characteristic of \tcode{true_type} to indicate that
 \tcode{T} should be treated as a subexpression in a \tcode{bind} call.
 
 \rSec3[func.bind.isplace]{Class template \tcode{is_placeholder}}
@@ -13991,12 +13991,12 @@ namespace std {
 \pnum
 Instantiations of the \tcode{is_placeholder} template shall meet
 the UnaryTypeTrait requirements~(\ref{meta.rqmts}). The implementation
-shall provide a definition that has the BaseCharacteristic of
+shall provide a definition that has the base characteristic of
 \tcode{integral_constant<int, J>} if \tcode{T} is the type of
 \tcode{std::placeholders::_J}, otherwise it shall have a
-BaseCharacteristic of \tcode{integral_constant<int, 0>}. A program
+base characteristic of \tcode{integral_constant<int, 0>}. A program
 may specialize this template for a user-defined type \tcode{T} to
-have a BaseCharacteristic of \tcode{integral_constant<int, \textit{N}>}
+have a base characteristic of \tcode{integral_constant<int, \textit{N}>}
 with \tcode{\textit{N} > 0} to indicate that \tcode{T} should be
 treated as a placeholder type.
 
@@ -15047,12 +15047,12 @@ argument and, optionally, additional arguments that help define the
 property being described. It shall be \tcode{DefaultConstructible},
 \tcode{CopyConstructible},
 and publicly and unambiguously derived, directly or indirectly, from
-its \defn{BaseCharacteristic}, which is
+its \defn{base characteristic}, which is
 a specialization of the template
 \tcode{integral_constant}~(\ref{meta.help}), with
 the arguments to the template \tcode{integral_constant} determined by the
 requirements for the particular property being described.
-The member names of the BaseCharacteristic shall not be hidden and shall be
+The member names of the base characteristic shall not be hidden and shall be
 unambiguously available in the UnaryTypeTrait.
 
 \pnum
@@ -15063,12 +15063,12 @@ arguments that help define the relationship being described. It shall
 be \tcode{DefaultConstructible}, \tcode{CopyConstructible},
 and publicly and unambiguously derived, directly or
 indirectly, from
-its \term{BaseCharacteristic}, which is a specialization
+its \term{base characteristic}, which is a specialization
 of the template
 \tcode{integral_constant}~(\ref{meta.help}), with
 the arguments to the template \tcode{integral_constant} determined by the
 requirements for the particular relationship being described.
-The member names of the BaseCharacteristic shall not be hidden and shall be
+The member names of the base characteristic shall not be hidden and shall be
 unambiguously available in the BinaryTypeTrait.
 
 \pnum
@@ -15492,7 +15492,7 @@ properties of a type at compile time.
 \pnum
 Each of these templates shall be a
 UnaryTypeTrait~(\ref{meta.rqmts})
-with a BaseCharacteristic of
+with a base characteristic of
 \tcode{true_type} if the corresponding condition is \tcode{true}, otherwise
 \tcode{false_type}.
 
@@ -16158,7 +16158,7 @@ properties of types at compile time.
 
 \pnum
 Each of these templates shall be a \tcode{UnaryTypeTrait}~(\ref{meta.rqmts}) with a
-\tcode{BaseCharacteristic} of \tcode{integral_constant<size_t, Value>}.
+base characteristic of \tcode{integral_constant<size_t, Value>}.
 
 \pnum
 \begin{example}
@@ -16194,7 +16194,7 @@ relationships between types at compile time.
 \pnum
 Each of these templates shall be a
 BinaryTypeTrait~(\ref{meta.rqmts})
-with a BaseCharacteristic of
+with a base characteristic of
 \tcode{true_type} if the corresponding condition is true, otherwise
 \tcode{false_type}.
 
@@ -16879,7 +16879,7 @@ template<class B> struct negation : @\seebelow@ { };
 The class template \tcode{negation}
 forms the logical negation of its template type argument.
 The type \tcode{negation<B>}
-is a UnaryTypeTrait with a BaseCharacteristic of \tcode{bool_constant<!bool(B::value)>}.
+is a UnaryTypeTrait with a base characteristic of \tcode{bool_constant<!bool(B::value)>}.
 \end{itemdescr}
 
 \rSec1[ratio]{Compile-time rational arithmetic}
@@ -19031,7 +19031,7 @@ resolution participation.
 
 \pnum
 \tcode{is_execution_policy<T>} shall be a UnaryTypeTrait with a
-BaseCharacteristic of \tcode{true_type} if \tcode{T} is the type of a standard
+base characteristic of \tcode{true_type} if \tcode{T} is the type of a standard
 or \impldef{additional execution policies supported by parallel algorithms}
 execution policy, otherwise \tcode{false_type}.
 


### PR DESCRIPTION
This is a regular English phrase used as a technical term.

Fixes #1154.