### PR TITLE
[headers], [depr.c.headers] Avoid brittle counts of headers.

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -54,7 +54,7 @@ The \grammarterm{noexcept-specifier} \tcode{throw()} is deprecated.
 For compatibility with the 
 \indextext{library!C standard}%
 C standard library, the \Cpp standard library provides
-the 26 \textit{C headers}, as shown in Table~\ref{tab:future.c.headers}.
+the \defnx{C headers}{headers!C library} shown in Table~\ref{tab:future.c.headers}.
 
 \begin{floattable}{C headers}{tab:future.c.headers}
 {lllll}

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -966,11 +966,9 @@ sequences delimited by \tcode{<} and \tcode{>} in header names necessarily valid
 file names~(\ref{cpp.include}).}
 
 \pnum
-The \Cpp standard library provides
-61
-\term{\Cpp library headers},
-\indextext{header!C++ library}%
-as shown in Table~\ref{tab:cpp.library.headers}.
+The \Cpp standard library provides the
+\defnx{\Cpp library headers}{header!C++ library},
+shown in Table~\ref{tab:cpp.library.headers}.
 
 \begin{floattable}{\Cpp library headers}{tab:cpp.library.headers}
 {llll}
@@ -1058,9 +1056,9 @@ as shown in Table~\ref{tab:cpp.library.headers}.
 
 
 \pnum
-The facilities of the C standard library are provided in 26
+The facilities of the C standard library are provided in the
 \indextext{library!C standard}%
-additional headers, as shown in Table~\ref{tab:cpp.c.headers}.%
+additional headers shown in Table~\ref{tab:cpp.c.headers}.%
 \footnote{It is intentional that there is no \Cpp header
 for any of these C headers:
 \indextext{\idxhdr{stdatomic.h}}%


### PR DESCRIPTION
Fixes #766.