### PR TITLE
[macros, styles] Make BNF vertical spacing like that of normal paragraphs

### DIFF
--- a/source/macros.tex
+++ b/source/macros.tex
@@ -399,13 +399,12 @@
  \newcommand{\bnfindentfirst}{\BnfIndent}
  \newcommand{\bnfindentinc}{\BnfInc}
  \newcommand{\bnfindentrest}{\BnfRest}
- \begin{minipage}{.9\hsize}
  \newcommand{\br}{\hfill\\}
+ \widowpenalties 1 10000
  \frenchspacing
  }
  {
  \nonfrenchspacing
- \end{minipage}
  }
 
 \newenvironment{BnfTabBase}[1]
@@ -451,17 +450,12 @@
 \newenvironment{bnf}
 {
  \begin{bnfbase}
- \list{}
-	{
-	\setlength{\leftmargin}{\bnfindentrest}
-	\setlength{\listparindent}{-\bnfindentinc}
-	\setlength{\itemindent}{\listparindent}
-	}
+ \begin{bnflist}
  \BnfNontermshape
  \item\relax
 }
 {
- \endlist
+ \end{bnflist}
  \end{bnfbase}
 }
 

--- a/source/styles.tex
+++ b/source/styles.tex
@@ -102,9 +102,12 @@
 % set style for lists (itemizations, enumerations)
 \setlength{\partopsep}{0pt}
 \newlist{indenthelper}{itemize}{1}
+\newlist{bnflist}{itemize}{1}
 \setlist[itemize]{parsep=\parskip, partopsep=0pt, itemsep=0pt, topsep=0pt}
 \setlist[enumerate]{parsep=\parskip, partopsep=0pt, itemsep=0pt, topsep=0pt}
 \setlist[indenthelper]{parsep=\parskip, partopsep=0pt, itemsep=0pt, topsep=0pt, label={}}
+\setlist[bnflist]{parsep=\parskip, partopsep=0pt, itemsep=0pt, topsep=0pt, label={},
+                  leftmargin=\bnfindentrest, listparindent=-\bnfindentinc, itemindent=\listparindent}
 
 %%--------------------------------------------------
 %%  set caption style and delimiter


### PR DESCRIPTION
Removes minpages; adds custom enumitem list.

BNF entries are now spaced like normal paragraphs. Individual paragraphs are kept on a single page by setting a high widow penalty.

It is now immaterial whether multiple nontermdefs are contained in a single bnf environment, or whether each def is in its own environment. Pages can break between elements, not within.