### PR TITLE
[utility] Harmonize spelling of template parameters for std::pair<T1,…

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -144,22 +144,22 @@ namespace std {
   template<size_t I, class T1, class T2>
     constexpr const tuple_element_t<I, pair<T1, T2>>&&
       get(const pair<T1, T2>&&) noexcept;
-  template <class T, class U>
-    constexpr T& get(pair<T, U>& p) noexcept;
-  template <class T, class U>
-    constexpr const T& get(const pair<T, U>& p) noexcept;
-  template <class T, class U>
-    constexpr T&& get(pair<T, U>&& p) noexcept;
-  template <class T, class U>
-    constexpr const T&& get(const pair<T, U>&& p) noexcept;
-  template <class T, class U>
-    constexpr T& get(pair<U, T>& p) noexcept;
-  template <class T, class U>
-    constexpr const T& get(const pair<U, T>& p) noexcept;
-  template <class T, class U>
-    constexpr T&& get(pair<U, T>&& p) noexcept;
-  template <class T, class U>
-    constexpr const T&& get(const pair<U, T>&& p) noexcept;
+  template <class T1, class T2>
+    constexpr T1& get(pair<T1, T2>& p) noexcept;
+  template <class T1, class T2>
+    constexpr const T1& get(const pair<T1, T2>& p) noexcept;
+  template <class T1, class T2>
+    constexpr T1&& get(pair<T1, T2>&& p) noexcept;
+  template <class T1, class T2>
+    constexpr const T1&& get(const pair<T1, T2>&& p) noexcept;
+  template <class T2, class T1>
+    constexpr T2& get(pair<T1, T2>& p) noexcept;
+  template <class T2, class T1>
+    constexpr const T2& get(const pair<T1, T2>& p) noexcept;
+  template <class T2, class T1>
+    constexpr T2&& get(pair<T1, T2>&& p) noexcept;
+  template <class T2, class T1>
+    constexpr const T2&& get(const pair<T1, T2>&& p) noexcept;
 
   // \ref{pair.piecewise}, pair piecewise construction
   struct piecewise_construct_t { explicit piecewise_construct_t() = default; };
@@ -1333,18 +1333,18 @@ otherwise the program is ill-formed.
 
 \indexlibrarymember{get}{pair}%
 \begin{itemdecl}
-template <class T, class U>
-  constexpr T& get(pair<T, U>& p) noexcept;
-template <class T, class U>
-  constexpr const T& get(const pair<T, U>& p) noexcept;
-template <class T, class U>
-  constexpr T&& get(pair<T, U>&& p) noexcept;
-template <class T, class U>
-  constexpr const T&& get(const pair<T, U>&& p) noexcept;
+template <class T1, class T2>
+  constexpr T1& get(pair<T1, T2>& p) noexcept;
+template <class T1, class T2>
+  constexpr const T1& get(const pair<T1, T2>& p) noexcept;
+template <class T1, class T2>
+  constexpr T1&& get(pair<T1, T2>&& p) noexcept;
+template <class T1, class T2>
+  constexpr const T1&& get(const pair<T1, T2>&& p) noexcept;
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\requires \tcode{T} and \tcode{U} are distinct types. Otherwise, the program is ill-formed.
+\requires \tcode{T1} and \tcode{T2} are distinct types. Otherwise, the program is ill-formed.
 
 \pnum
 \returns A reference to \tcode{p.first}.
@@ -1352,19 +1352,19 @@ template <class T, class U>
 
 \indexlibrarymember{get}{pair}%
 \begin{itemdecl}
-template <class T, class U>
-  constexpr T& get(pair<U, T>& p) noexcept;
-template <class T, class U>
-  constexpr const T& get(const pair<U, T>& p) noexcept;
-template <class T, class U>
-  constexpr T&& get(pair<U, T>&& p) noexcept;
-template <class T, class U>
-  constexpr const T&& get(const pair<U, T>&& p) noexcept;
+template <class T2, class T1>
+  constexpr T2& get(pair<T1, T2>& p) noexcept;
+template <class T2, class T1>
+  constexpr const T2& get(const pair<T1, T2>& p) noexcept;
+template <class T2, class T1>
+  constexpr T2&& get(pair<T1, T2>&& p) noexcept;
+template <class T2, class T1>
+  constexpr const T2&& get(const pair<T1, T2>&& p) noexcept;
 \end{itemdecl}
 \begin{itemdescr}
 
 \pnum
-\requires \tcode{T} and \tcode{U} are distinct types. Otherwise, the program is ill-formed.
+\requires \tcode{T1} and \tcode{T2} are distinct types. Otherwise, the program is ill-formed.
 
 \pnum
 \returns A reference to \tcode{p.second}.


### PR DESCRIPTION
…T2>.

Fixes #125.