### PR TITLE
[function.objects] Introduce a new subsection for the <functional> sy…

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -12641,10 +12641,9 @@ interface is specified to accept a function object. This not only makes
 algorithmic templates work with pointers to functions, but also enables them to
 work with arbitrary function objects.
 
-\pnum
-\synopsis{Header \tcode{<functional>} synopsis}
+\rSec2[functional.syn]{Header \tcode{<functional>} synopsis}
+\indexlibrary{\idxhdr{functional}}
 
-\indexlibrary{\idxhdr{functional}}%
 \begin{codeblock}
 namespace std {
   // \ref{func.invoke}, invoke
@@ -14930,7 +14929,8 @@ return boyer_moore_horspool_searcher<RandomAccessIterator, Hash, BinaryPredicate
 \indexlibrary{\idxcode{hash}}%
 \indextext{\idxcode{hash}!instantiation restrictions}%
 The unordered associative containers defined in \ref{unord} use
-specializations of the class template \tcode{hash} as the default hash function.
+specializations of the class template \tcode{hash} (\ref{functional.syn})
+as the default hash function.
 
 \pnum
 Each specialization of \tcode{hash} is either enabled or disabled,


### PR DESCRIPTION
…nopsis.

Also add a cross-reference from [unord.hash] to the synopsis, which
is the only place where the primary template is declared.

Fixes #192.