### PR TITLE
[lib] Adjust whitespace to attach & to the type, not the declarator-id.

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -286,7 +286,7 @@ namespace std {
 
   template <class ForwardIterator, class Searcher>
     ForwardIterator search(ForwardIterator first, ForwardIterator last,
-                           const Searcher &searcher);
+                           const Searcher& searcher);
 
   // \ref{alg.modifying.operations}, modifying sequence operations
   // \ref{alg.copy}, copy

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -7012,7 +7012,7 @@ void f(basic_ios<charT, traits>& str, moneyT& mon, bool intl) {
   using MoneyGet = money_get<charT, Iter>;
 
   ios_base::iostate err = ios_base::goodbit;
-  const MoneyGet &mg = use_facet<MoneyGet>(str.getloc());
+  const MoneyGet& mg = use_facet<MoneyGet>(str.getloc());
 
   mg.get(Iter(str.rdbuf()), Iter(), intl, str, err, mon);
 


### PR DESCRIPTION
Fixes #166.