### PR TITLE
[sequence.reqmts] Use placeholders for 'member functions of the form'.

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -998,13 +998,13 @@ shall not participate in overload resolution.
 
 \begin{codeblock}
 template <class InputIterator>          // such as insert()
-  rt fx1(const_iterator p, InputIterator first, InputIterator last);
+  @\placeholder{return-type}@ @\placeholder{F}@(const_iterator p, InputIterator first, InputIterator last);
 
 template <class InputIterator>          // such as append(), assign()
-  rt fx2(InputIterator first, InputIterator last);
+  @\placeholder{return-type}@ @\placeholder{F}@(InputIterator first, InputIterator last);
 
 template <class InputIterator>          // such as replace()
-  rt fx3(const_iterator i1, const_iterator i2, InputIterator first, InputIterator last);
+  @\placeholder{return-type}@ @\placeholder{F}@(const_iterator i1, const_iterator i2, InputIterator first, InputIterator last);
 \end{codeblock}
 
 are called with a type \tcode{InputIterator} that does not qualify as an input


### PR DESCRIPTION
Fixes #254.