### PR TITLE
[intseq.general] Remove example not quite mirroring a standard function.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -820,27 +820,9 @@ closest to the value of the string matching the pattern.
 The library provides a class template that can represent an integer sequence.
 When used as an argument to a function template the parameter pack defining the
 sequence can be deduced and used in a pack expansion.
-
-\pnum
-\begin{example}
-
-\begin{codeblock}
-template<class F, class Tuple, std::size_t... I>
-  decltype(auto) apply_impl(F&& f, Tuple&& t, index_sequence<I...>) {
-    return std::forward<F>(f)(std::get<I>(std::forward<Tuple>(t))...);
-  }
-
-template<class F, class Tuple>
-  decltype(auto) apply(F&& f, Tuple&& t) {
-    using Indices = make_index_sequence<std::tuple_size_v<std::decay_t<Tuple>>>;
-    return apply_impl(std::forward<F>(f), std::forward<Tuple>(t), Indices());
-  }
-\end{codeblock}
-
-\end{example}
 \begin{note}
 The \tcode{index_sequence} alias template is provided for the common case of
-an integer sequence of type \tcode{size_t}.
+an integer sequence of type \tcode{size_t}; see also \ref{tuple.apply}.
 \end{note}
 
 \rSec2[intseq.intseq]{Class template \tcode{integer_sequence}}


### PR DESCRIPTION
Fixes #1176.