### PR TITLE
[class.bit] Add missing "bit-" to "field declaration" in index entry

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1304,7 +1304,7 @@ A \grammarterm{member-declarator} of the form
 identifier\opt  attribute-specifier-seq\opt{} \terminal{:} constant-expression
 \end{ncbnftab}
 
-\indextext{\idxcode{:}!field declaration}%
+\indextext{\idxcode{:}!bit-field declaration}%
 \indextext{declaration!bit-field}%
 specifies a bit-field;
 its length is set off from the bit-field name by a colon. The optional \grammarterm{attribute-specifier-seq} appertains to the entity being declared. The bit-field


### PR DESCRIPTION
For reference, the C standard says `bit-field declaration`.