### PR TITLE
Remove tildes from index entries.

### DIFF
--- a/source/access.tex
+++ b/source/access.tex
@@ -165,7 +165,7 @@ must be deferred until the entire \grammarterm{base-specifier-list} has been see
 \end{example}
 
 \pnum
-\indextext{argument!access checking~and default}%
+\indextext{argument!access checking and default}%
 \indextext{access control!default argument}%
 The names in a default argument~(\ref{dcl.fct.default}) are
 bound at the point of declaration, and access is checked at that
@@ -192,7 +192,7 @@ D <C<B> >* d;       // access error, C::TT is protected
 \end{example}
 
 \rSec1[class.access.spec]{Access specifiers}%
-\indextext{access~specifier}
+\indextext{access specifier}
 
 \pnum
 Member declarations can be labeled by an
@@ -279,11 +279,11 @@ class C : public B {
 \end{example}
 
 \rSec1[class.access.base]{Accessibility of base classes and base class members}%
-\indextext{access control!base~class}%
-\indextext{access~specifier}%
-\indextext{base~class!\idxcode{private}}%
-\indextext{base~class!\idxcode{protected}}%
-\indextext{base~class!\idxcode{public}}
+\indextext{access control!base class}%
+\indextext{access specifier}%
+\indextext{base class!\idxcode{private}}%
+\indextext{base class!\idxcode{protected}}%
+\indextext{base class!\idxcode{public}}
 
 \pnum
 If a class is declared to be a base class (Clause~\ref{class.derived}) for another class using the
@@ -604,9 +604,9 @@ do not make the nominated friends members of the befriending class.
 \begin{example}
 the following example illustrates the differences between
 members and friends:
-\indextext{friend function!member~function~and}%
+\indextext{friend function!member function and}%
 \indextext{example!friend function}%
-\indextext{example!member~function}%
+\indextext{example!member function}%
 
 \begin{codeblock}
 class X {
@@ -628,7 +628,7 @@ void f() {
 \end{example}
 
 \pnum
-\indextext{friend!class access~and}%
+\indextext{friend!class access and}%
 Declaring a class to be a friend implies that the names of private and
 protected members from the class granting friendship can be accessed in the
 \grammarterm{base-specifier}{s} and member declarations of the befriended
@@ -715,13 +715,13 @@ R<int> Ri;          // OK: \tcode{"friend int;"} is ignored
 \end{example}
 
 \pnum
-\indextext{friend function!linkage~of}%
+\indextext{friend function!linkage of}%
 A function first declared in a friend declaration
 has the linkage of the namespace of which it is a member~(\ref{basic.link}).
 Otherwise, the function retains its previous linkage~(\ref{dcl.stc}).
 
 \pnum
-\indextext{declaration!overloaded~name~and \tcode{friend}}%
+\indextext{declaration!overloaded name and \tcode{friend}}%
 When a
 \tcode{friend}
 declaration refers to an overloaded name or operator, only the function specified
@@ -773,7 +773,7 @@ shall appear in the
 of a friend declaration.
 
 \pnum
-\indextext{friend!access~specifier~and}%
+\indextext{friend!access specifier and}%
 A name nominated by a friend declaration shall be accessible in the scope of the
 class containing the friend declaration.
 The meaning of the friend declaration is the same whether the friend declaration
@@ -786,7 +786,7 @@ portion of the class
 \grammarterm{member-specification}.
 
 \pnum
-\indextext{friend!inheritance~and}%
+\indextext{friend!inheritance and}%
 Friendship is neither inherited nor transitive.
 \begin{example}
 
@@ -817,8 +817,8 @@ class D : public B  {
 \end{example}
 
 \pnum
-\indextext{local~class!friend}%
-\indextext{friend!local~class~and}%
+\indextext{local class!friend}%
+\indextext{friend!local class and}%
 If a friend declaration appears in a local class~(\ref{class.local}) and the
 name specified is an unqualified name, a prior declaration is looked
 up without considering scopes that are outside the innermost enclosing
@@ -993,7 +993,7 @@ A nested class is a member and as such has the same access rights as any other m
 The members of an enclosing class have no special access to members of a nested
 class; the usual access rules (Clause~\ref{class.access}) shall be obeyed.
 \begin{example}
-\indextext{example!nested~class definition}%
+\indextext{example!nested class definition}%
 
 \begin{codeblock}
 class E {

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -23,7 +23,7 @@ Clauses. \end{note}
 \pnum
 \indextext{type}%
 \indextext{object}%
-\indextext{storage~class}%
+\indextext{storage class}%
 \indextext{scope}%
 \indextext{linkage}%
 \indextext{region!declarative}%
@@ -83,7 +83,7 @@ translation unit.
 \rSec1[basic.def]{Declarations and definitions}
 
 \pnum
-\indextext{declaration!definition~versus}%
+\indextext{declaration!definition versus}%
 \indextext{declaration}%
 \indextext{declaration!name}%
 A declaration (Clause~\ref{dcl.dcl}) may introduce
@@ -127,11 +127,11 @@ it declares a static data member outside a class definition
 and the variable was defined within the class with the \tcode{constexpr}
 specifier (this usage is deprecated; see \ref{depr.static_constexpr}),
 \item
-\indextext{declaration!class~name}%
+\indextext{declaration!class name}%
 it is a class name declaration~(\ref{class.name}),
 \item
 it is an
-\indextext{declaration!opaque~enum}%
+\indextext{declaration!opaque enum}%
 \grammarterm{opaque-enum-declaration}~(\ref{dcl.enum}),
 \item
 it is a
@@ -261,7 +261,7 @@ an incomplete type~(\ref{basic.types}).
 \indextext{function!definition}%
 \indextext{class!definition}%
 \indextext{enumerator!definition}%
-\indextext{one-definition~rule|(}%
+\indextext{one-definition rule|(}%
 \rSec1[basic.def.odr]{One-definition rule}
 
 \pnum
@@ -519,7 +519,7 @@ the point of instantiation~(\ref{temp.dep}). If the definitions of
 as if there were a single definition of \tcode{D}. If the definitions of
 \tcode{D} do not satisfy these requirements, then the behavior is
 undefined.%
-\indextext{one-definition~rule|)}
+\indextext{one-definition rule|)}
 
 \rSec1[basic.scope]{Scope}%
 \indextext{scope|(}
@@ -528,7 +528,7 @@ undefined.%
 \indextext{scope!declarations and|(}
 
 \pnum
-\indextext{name!scope~of}%
+\indextext{name!scope of}%
 Every name is introduced in some portion of program text called a
 \indextext{region!declarative}%
 \indextext{scope!potential}%
@@ -610,7 +610,7 @@ namespace; these restrictions apply to both regions. \end{note}
 \rSec2[basic.scope.pdecl]{Point of declaration}
 
 \pnum
-\indextext{name!point~of declaration}%
+\indextext{name!point of declaration}%
 The \defn{point of declaration} for a name is immediately after its
 complete declarator (Clause~\ref{dcl.decl}) and before its
 \grammarterm{initializer} (if any), except as noted below. \begin{example}
@@ -625,7 +625,7 @@ value. \end{example}
 
 \pnum
 \begin{note}
-\indextext{name~hiding}%
+\indextext{name hiding}%
 a name from an outer scope remains visible up
 to the point of declaration of the name that hides it. \begin{example}
 
@@ -653,7 +653,7 @@ The point of declaration of a \grammarterm{using-declarator} that does not name 
 constructor is immediately after the \grammarterm{using-declarator}~(\ref{namespace.udecl}).
 
 \pnum
-\indextext{declaration!enumerator point~of}%
+\indextext{declaration!enumerator point of}%
 The point of declaration for an enumerator is immediately after its
 \grammarterm{enumerator-definition}. \begin{example}
 
@@ -754,7 +754,7 @@ see~\ref{temp.point}.\end{note}%
 
 \pnum
 \indextext{scope!block}%
-\indextext{local~scope|see{block scope}}%
+\indextext{local scope|see{block scope}}%
 A name declared in a block~(\ref{stmt.block}) is local to that block; it has
 \defn{block scope}.
 Its potential scope begins at its point of
@@ -762,7 +762,7 @@ declaration~(\ref{basic.scope.pdecl}) and ends at the end of its block.
 A variable declared at block scope is a \defn{local variable}.
 
 \pnum
-\indextext{parameter!scope~of}%
+\indextext{parameter!scope of}%
 The potential scope of a function parameter name
 (including one appearing in a 
 \grammarterm{lambda-declarator})
@@ -779,7 +779,7 @@ function definition nor in the outermost block of any handler associated
 with a \grammarterm{function-try-block}.
 
 \pnum
-\indextext{scope!exception~declaration}%
+\indextext{scope!exception declaration}%
 The name declared in an \grammarterm{exception-declaration}
 is local to the
 \grammarterm{handler} and shall not be redeclared in the outermost block of the
@@ -798,8 +798,8 @@ see~\ref{stmt.select}.
 \rSec2[basic.scope.proto]{Function prototype scope}
 
 \pnum
-\indextext{scope!function~prototype}%
-\indextext{function~prototype}%
+\indextext{scope!function prototype}%
+\indextext{function prototype}%
 In a function declaration, or in any function declarator except the
 declarator of a function definition~(\ref{dcl.fct.def}), names of
 parameters (if supplied) have function prototype scope, which terminates
@@ -808,7 +808,7 @@ at the end of the nearest enclosing function declarator.
 \rSec2[basic.funscope]{Function scope}
 
 \pnum
-\indextext{label!scope~of}%
+\indextext{label!scope of}%
 Labels~(\ref{stmt.label}) have \defnx{function scope}{scope!function} and
 may be used anywhere in the function in which they are declared. Only
 labels have function scope.
@@ -959,8 +959,8 @@ its point of declaration and terminates at the end of the
 \grammarterm{enum-specifier}.
 
 \rSec2[basic.scope.temp]{Template parameter scope}%
-\indextext{template~parameter~scope}%
-\indextext{scope!template~parameter}%
+\indextext{template parameter scope}%
+\indextext{scope!template parameter}%
 
 \pnum
 The declarative region of the name of a template parameter of a template
@@ -1042,14 +1042,14 @@ see~\ref{temp.local}. \end{note}
 \rSec2[basic.scope.hiding]{Name hiding}
 
 \pnum
-\indextext{scope~name~hiding~and}%
-\indextext{name~hiding}%
+\indextext{scope name hiding and}%
+\indextext{name hiding}%
 \indextext{hiding|see{name hiding}}%
 A name can be hidden by an explicit declaration of that same name in a
 nested declarative region or derived class~(\ref{class.member.lookup}).
 
 \pnum
-\indextext{name~hiding}%
+\indextext{name hiding}%
 A class name~(\ref{class.name}) or enumeration name~(\ref{dcl.enum}) can
 be hidden by the name of a variable, data member, function, or enumerator declared in
 the same scope. If a class or enumeration name and a variable, data member, function,
@@ -1078,7 +1078,7 @@ If a name is in scope and is not hidden it is said to be \defn{visible}.%
 \indextext{scope|)}
 
 \rSec1[basic.lookup]{Name lookup}%
-\indextext{scope!name~lookup~and|(}%
+\indextext{scope!name lookup and|(}%
 \indextext{lookup!name|(}%
 
 \pnum
@@ -1117,7 +1117,7 @@ in~\ref{basic.scope}. \end{note}
 \rSec2[basic.lookup.unqual]{Unqualified name lookup}
 
 \pnum
-\indextext{lookup!unqualified~name}%
+\indextext{lookup!unqualified name}%
 \indextext{name!unqualified}%
 In all the cases listed in~\ref{basic.lookup.unqual}, the scopes are
 searched for a declaration in the order listed in each of the respective
@@ -1577,7 +1577,7 @@ function templates are ignored.
 \rSec2[basic.lookup.qual]{Qualified name lookup}
 
 \pnum
-\indextext{lookup!qualified~name|(}%
+\indextext{lookup!qualified name|(}%
 \indextext{name!qualified}%
 \indextext{qualification!explicit}%
 The name of a class or namespace member
@@ -1633,8 +1633,8 @@ X C::arr[number];   // ill-formed:
 \end{example}
 
 \pnum
-\indextext{operator!scope~resolution}%
-\indextext{scope~resolution~operator|see{operator, scope~resolution}}%
+\indextext{operator!scope resolution}%
+\indextext{scope resolution operator|see{operator, scope resolution}}%
 A name prefixed by the unary scope operator \tcode{::}~(\ref{expr.prim})
 is looked up in global scope, in the translation unit where it is used.
 The name shall be declared in global namespace scope or shall be a name
@@ -1687,7 +1687,7 @@ lookup proceeds after the \tcode{.} and \tcode{->} operators. \end{note}
 \rSec3[class.qual]{Class members}
 
 \pnum
-\indextext{lookup!class~member}%
+\indextext{lookup!class member}%
 If the \grammarterm{nested-name-specifier} of a \grammarterm{qualified-id}
 nominates a class, the name specified after the
 \grammarterm{nested-name-specifier} is looked up in the scope of the
@@ -1761,7 +1761,7 @@ the name of its class followed by the \tcode{::} operator.
 \rSec3[namespace.qual]{Namespace members}
 
 \pnum
-\indextext{lookup!namespace~member}%
+\indextext{lookup!namespace member}%
 If the \grammarterm{nested-name-specifier} of a \grammarterm{qualified-id}
 nominates a namespace (including the case where the
 \grammarterm{nested-name-specifier} is \tcode{::}, i.e., nominating
@@ -1992,11 +1992,11 @@ using namespace C::D;
 void B::f1(int){ }  // OK, defines \tcode{A::B::f1(int)}
 \end{codeblock}
 \end{example}
-\indextext{lookup!qualified~name|)}%
+\indextext{lookup!qualified name|)}%
 
 \rSec2[basic.lookup.elab]{Elaborated type specifiers}%
-\indextext{lookup!elaborated~type~specifier|(}%
-\indextext{type~specifier!elaborated}
+\indextext{lookup!elaborated type specifier|(}%
+\indextext{type specifier!elaborated}
 
 \pnum
 An \grammarterm{elaborated-type-specifier}~(\ref{dcl.type.elab}) may be
@@ -2071,7 +2071,7 @@ struct Base::Datum;             // error: \tcode{Datum} undefined
 struct Base::Data* pBase;       // OK: refers to nested \tcode{Data}
 \end{codeblock}
 \end{example} %
-\indextext{lookup!elaborated~type~specifier|)}%
+\indextext{lookup!elaborated type specifier|)}%
 
 \rSec2[basic.lookup.classref]{Class member access}
 
@@ -2173,14 +2173,14 @@ int main() {
 \rSec2[basic.lookup.udir]{Using-directives and namespace aliases}
 
 \pnum
-\indextext{lookup!using-directives~and}%
-\indextext{lookup!namespace~aliases~and}%
+\indextext{lookup!using-directives and}%
+\indextext{lookup!namespace aliases and}%
 In a \grammarterm{using-directive} or \grammarterm{namespace-alias-definition},
 during the lookup for a \grammarterm{namespace-name} or for a name in a
 \grammarterm{nested-name-specifier}{}
 only namespace names are considered.%
 \indextext{lookup!name|)}%
-\indextext{scope!name~lookup~and|)}
+\indextext{scope!name lookup and|)}
 
 \rSec1[basic.link]{Program and linkage}%
 \indextext{linkage|(}
@@ -2220,12 +2220,12 @@ cannot be referred to by names from other scopes.
 \end{itemize}
 
 \pnum
-\indextext{linkage!\idxcode{static}~and}%
-\indextext{\idxcode{static}!linkage~of}%
-\indextext{linkage!\idxcode{const}~and}%
-\indextext{\idxcode{const}!linkage~of}%
-\indextext{linkage!\idxcode{inline}~and}%
-\indextext{\idxcode{inline}!linkage~of}%
+\indextext{linkage!\idxcode{static} and}%
+\indextext{\idxcode{static}!linkage of}%
+\indextext{linkage!\idxcode{const} and}%
+\indextext{\idxcode{const}!linkage of}%
+\indextext{linkage!\idxcode{inline} and}%
+\indextext{\idxcode{inline}!linkage of}%
 A name having namespace scope~(\ref{basic.scope.namespace}) has internal
 linkage if it is the name of
 \begin{itemize}
@@ -2249,11 +2249,11 @@ has the same linkage as the enclosing namespace if it is the name of
 \begin{itemize}
 \item a variable; or
 \item a function; or
-\item \indextext{class!linkage~of}%
+\item \indextext{class!linkage of}%
 a named class (Clause~\ref{class}), or an unnamed class defined in a
 typedef declaration in which the class has the typedef name for linkage
 purposes~(\ref{dcl.typedef}); or
-\item \indextext{enumeration!linkage~of}%
+\item \indextext{enumeration!linkage of}%
 a named enumeration~(\ref{dcl.enum}), or an unnamed enumeration defined
 in a typedef declaration in which the enumeration has the typedef name
 for linkage purposes~(\ref{dcl.typedef}); or
@@ -2442,7 +2442,7 @@ An implementation shall not predefine the \tcode{main} function. This
 function shall not be overloaded.  Its type shall have \Cpp language linkage
 and it shall have a declared return type of type
 \tcode{int}, but otherwise its type is \impldef{parameters to \tcode{main}}.
-\indextext{\idxcode{main()}!implementation-defined parameters~to}%
+\indextext{\idxcode{main()}!implementation-defined parameters to}%
 An implementation shall allow both
 \begin{itemize}
 \item a function of \tcode{()} returning \tcode{int} and
@@ -2452,7 +2452,7 @@ An implementation shall allow both
 \indextext{\idxcode{argc}}%
 \indextext{\idxcode{argv}}%
 as the type of \tcode{main}~(\ref{dcl.fct}).
-\indextext{\idxcode{main()}!parameters~to}%
+\indextext{\idxcode{main()}!parameters to}%
 \indextext{environment!program}%
 In the latter form, for purposes of exposition, the first function
 parameter is called \tcode{argc} and the second function parameter is
@@ -2472,7 +2472,7 @@ is recommended that any further (optional) parameters be added after
 \pnum
 The function \tcode{main} shall not be used within
 a program.
-\indextext{\idxcode{main()}!implementation-defined linkage~of}%
+\indextext{\idxcode{main()}!implementation-defined linkage of}%
 The linkage~(\ref{basic.link}) of \tcode{main} is
 \impldef{linkage of \tcode{main}}. A program that defines \tcode{main} as
 deleted or that declares \tcode{main} to be
@@ -2596,9 +2596,9 @@ double d1 = fd();   // may be initialized statically or dynamically to \tcode{1.
 \rSec2[basic.start.dynamic]{Dynamic initialization of non-local variables}
 
 \pnum
-\indextext{initialization!dynamic~non-local}%
+\indextext{initialization!dynamic non-local}%
 \indextext{start!program}%
-\indextext{initialization!order~of}%
+\indextext{initialization!order of}%
 Dynamic initialization of a non-local variable with static storage duration is
 unordered if the variable is an implicitly or explicitly instantiated
 specialization, is partially-ordered if the variable
@@ -2638,7 +2638,7 @@ ordered variables concurrently with another sequence.
 \end{note}
 
 \pnum
-\indextext{evaluation!unspecified order~of}%
+\indextext{evaluation!unspecified order of}%
 It is \impldef{dynamic initialization of static variables before \tcode{main}} whether the
 dynamic initialization of a non-local non-inline variable with static storage duration
 happens before the first statement of \tcode{main}. If the initialization is deferred to
@@ -2793,7 +2793,7 @@ the functions passed to \tcode{std::atexit()} or \tcode{std::at_quick_exit()}.%
 \rSec1[basic.stc]{Storage duration}
 
 \pnum
-\indextext{storage~duration|(}%
+\indextext{storage duration|(}%
 The \defn{storage duration} is the property of an object that defines the minimum
 potential lifetime of the storage containing the object. The storage
 duration is determined by the construct used to create the object and is
@@ -2807,10 +2807,10 @@ one of the following:
 \end{itemize}
 
 \pnum
-\indextext{storage~duration!static}%
-\indextext{storage~duration!thread}%
-\indextext{storage~duration!automatic}%
-\indextext{storage~duration!dynamic}%
+\indextext{storage duration!static}%
+\indextext{storage duration!thread}%
+\indextext{storage duration!automatic}%
+\indextext{storage duration!dynamic}%
 Static, thread, and automatic storage durations are associated with objects
 introduced by declarations~(\ref{basic.def}) and implicitly created by
 the implementation~(\ref{class.temporary}). The dynamic storage duration
@@ -2837,7 +2837,7 @@ causes a system-generated runtime fault.}
 \rSec2[basic.stc.static]{Static storage duration}
 
 \pnum
-\indextext{storage~duration!static}%
+\indextext{storage duration!static}%
 All variables which do not have dynamic storage duration, do not have thread
 storage duration, and are not local
 have \defn{static storage duration}. The
@@ -2865,7 +2865,7 @@ definition gives the data member static storage duration.
 \rSec2[basic.stc.thread]{Thread storage duration}
 
 \pnum
-\indextext{storage~duration!thread}%
+\indextext{storage duration!thread}%
 All variables declared with the \tcode{thread_local} keyword have \defn{thread
 storage duration}. The storage for these entities shall last for the duration of
 the thread in which they are created. There is a distinct object or reference
@@ -2879,8 +2879,8 @@ its first odr-use~(\ref{basic.def.odr}) and, if constructed, shall be destroyed 
 \rSec2[basic.stc.auto]{Automatic storage duration}
 
 \pnum
-\indextext{storage~duration!automatic}%
-\indextext{storage~duration!local object}%
+\indextext{storage duration!automatic}%
+\indextext{storage duration!local object}%
 Block-scope variables
 not explicitly declared \tcode{static}, \tcode{thread_local}, or \tcode{extern} have
 \defn{automatic storage duration}. The storage
@@ -2899,7 +2899,7 @@ unused, except that a class object or its copy/move may be eliminated as
 specified in~\ref{class.copy}.
 
 \rSec2[basic.stc.dynamic]{Dynamic storage duration}%
-\indextext{storage~duration!dynamic|(}
+\indextext{storage duration!dynamic|(}
 
 \pnum
 Objects can be created dynamically during program
@@ -3055,7 +3055,7 @@ declared in a namespace scope other than global scope or declared static
 in global scope.
 
 \pnum
-\indextext{\idxcode{delete}!overloading~and}%
+\indextext{\idxcode{delete}!overloading and}%
 Each deallocation function shall return \tcode{void} and its first
 parameter shall be \tcode{void*}. A deallocation function may have more
 than one parameter.
@@ -3104,7 +3104,7 @@ pointer, ending the duration of the region of storage.
 
 \pnum
 \indextext{pointer!safely-derived|(}%
-\indextext{pointer!to~traceable~object}%
+\indextext{pointer!to traceable object}%
 A \defn{traceable pointer object} is
 \begin{itemize}
 \item an object of an object pointer
@@ -3190,20 +3190,20 @@ some safely-derived pointer value. \end{note} It is
 \impldef{whether an implementation has relaxed or strict pointer
 safety} whether an implementation has relaxed or strict pointer safety.%
 \indextext{pointer!safely-derived|)}%
-\indextext{storage~duration!dynamic|)}
+\indextext{storage duration!dynamic|)}
 
 \rSec2[basic.stc.inherit]{Duration of subobjects}
 
 \pnum
-\indextext{storage~duration!class member}%
+\indextext{storage duration!class member}%
 The storage duration of subobjects and reference members
 is that of their complete object~(\ref{intro.object}).
-\indextext{storage~duration|)}%
+\indextext{storage duration|)}%
 
 \rSec1[basic.life]{Object lifetime}
 
 \pnum
-\indextext{object~lifetime|(}%
+\indextext{object lifetime|(}%
 The \defn{lifetime} of an object or reference is a runtime property of the
 object or reference.
 An object is said to have \defnx{non-vacuous initialization}{initialization!non-vacuous} if it is of a class or
@@ -3455,7 +3455,7 @@ In this section, ``before'' and ``after'' refer to the ``happens before''
 relation~(\ref{intro.multithread}). \begin{note} Therefore, undefined behavior results
 if an object that is being constructed in one thread is referenced from another
 thread without adequate synchronization. \end{note}%
-\indextext{object~lifetime|)}
+\indextext{object lifetime|)}
 
 \rSec1[basic.types]{Types}%
 \indextext{type|(}
@@ -3472,8 +3472,8 @@ or functions (\ref{dcl.fct}).
 \end{note}
 
 \pnum
-\indextext{object!byte~copying~and|(}%
-\indextext{type!trivially~copyable}%
+\indextext{object!byte copying and|(}%
+\indextext{type!trivially copyable}%
 For any object (other than a base-class subobject) of trivially copyable type
 \tcode{T}, whether or not the object holds a valid value of type
 \tcode{T}, the underlying bytes~(\ref{intro.memory}) making up the
@@ -3511,7 +3511,7 @@ std::memcpy(t1p, t2p, sizeof(T));
     // the same value as the corresponding subobject in \tcode{*t2p}
 \end{codeblock}
 \end{example}%
-\indextext{object!byte~copying~and|)}
+\indextext{object!byte copying and|)}
 
 \pnum
 The \defn{object representation}
@@ -3558,7 +3558,7 @@ those two points (``array of unknown bound of \tcode{T}'' and ``array of
 unknown size, or of a type defined by a \tcode{typedef} declaration to
 be an array of unknown size, cannot be completed. \begin{example}
 
-\indextext{type!example~of incomplete}%
+\indextext{type!example of incomplete}%
 \begin{codeblock}
 class X;                        // \tcode{X} is an incomplete type
 extern X* xp;                   // \tcode{xp} is a pointer to an incomplete type
@@ -3591,7 +3591,7 @@ void bar() {
 contexts incomplete types are prohibited. \end{note}
 
 \pnum
-\indextext{object~type}%
+\indextext{object type}%
 An \defn{object type} is a (possibly cv-qualified) type that is not
 a function type, not a reference type, and not \cv{} \tcode{void}.
 
@@ -3643,7 +3643,7 @@ of non-volatile literal types.
 \end{itemize}
 
 \pnum
-\indextext{layout-compatible~type}%
+\indextext{layout-compatible type}%
 Two types \cvqual{cv1} \tcode{T1} and \cvqual{cv2} \tcode{T2} are
 \defn{layout-compatible} types
 if \tcode{T1} and \tcode{T2} are the same type,
@@ -3666,7 +3666,7 @@ character from this set is stored in a character object, the integral
 value of that character object is equal to the value of the single
 character literal form of that character. It is \impldef{signedness of \tcode{char}}
 whether a \tcode{char} object can hold negative values.
-\indextext{\idxcode{char}!implementation-defined sign~of}%
+\indextext{\idxcode{char}!implementation-defined sign of}%
 \indextext{type!\idxcode{signed char}}%
 \indextext{type!\idxcode{unsigned char}}%
 Characters can be explicitly declared \tcode{unsigned} or
@@ -3699,7 +3699,7 @@ conversion~(\ref{conv.integral}) from \placeholder{i} to \tcode{char} is
 \placeholder{j} to \tcode{unsigned char} is \placeholder{i}.
 
 \pnum
-\indextext{type!standard~signed~integer}%
+\indextext{type!standard signed integer}%
 There are five \defnx{standard signed integer types}{standard signed integer type} :
 \indextext{type!\idxcode{signed char}}%
 \indextext{type!\idxcode{short}}%
@@ -3710,14 +3710,14 @@ There are five \defnx{standard signed integer types}{standard signed integer typ
 ``\tcode{long int}'', and ``\tcode{long} \tcode{long} \tcode{int}''. In
 this list, each type provides at least as much storage as those
 preceding it in the list.
-\indextext{type!extended~signed~integer}%
-\indextext{type!signed~integer}%
+\indextext{type!extended signed integer}%
+\indextext{type!signed integer}%
 There may also be \impldef{extended signed integer types}
 \defnx{extended signed integer types}{extended signed integer type}.
 The standard and
 extended signed integer types are collectively called
 \defnx{signed integer types}{signed integer type}.
-\indextext{integral~type!implementation-defined @\tcode{sizeof}}%
+\indextext{integral type!implementation-defined @\tcode{sizeof}}%
 Plain
 \tcode{int}s have the natural size suggested by the architecture of the
 execution environment%
@@ -3731,7 +3731,7 @@ the other signed integer types are provided to meet special needs.
 \indextext{type!\idxcode{unsigned}}%
 For each of the standard signed integer types,
 there exists a corresponding (but different)
-\indextext{type!standard~unsigned~integer}%
+\indextext{type!standard unsigned integer}%
 \defn{standard unsigned integer type}:
 \indextext{type!\idxcode{unsigned char}}%
 \indextext{type!\idxcode{unsigned short}}%
@@ -3747,8 +3747,8 @@ type\footnote{See~\ref{dcl.type.simple} regarding the correspondence between typ
 the sequences of \grammarterm{type-specifier}{s} that designate them.};
 that is, each signed integer type has the same object representation as
 its corresponding unsigned integer type.
-\indextext{type!extended~unsigned~integer}%
-\indextext{type!unsigned~integer}%
+\indextext{type!extended unsigned integer}%
+\indextext{type!unsigned integer}%
 Likewise, for each of the extended signed integer types there exists a
 corresponding
 \defn{extended unsigned integer type} with the same amount of storage and alignment
@@ -3758,8 +3758,8 @@ values of a signed integer type is a subrange of the corresponding
 unsigned integer type, and the value
 representation of each corresponding signed/unsigned type shall be the
 same.
-\indextext{type!standard~integer}%
-\indextext{type!extended~integer}%
+\indextext{type!standard integer}%
+\indextext{type!extended integer}%
 The standard signed integer types and standard unsigned integer types
 are collectively called the \defnx{standard integer types}{standard integer type}, and the extended
 signed integer types and extended
@@ -3784,7 +3784,7 @@ that can be represented by the resulting unsigned integer type.}
 \indextext{type!\idxcode{char16_t}}%
 \indextext{type!\idxcode{char32_t}}%
 \indextext{type!\idxcode{wchar_t}}%
-\indextext{underlying~type|see{type, underlying}}%
+\indextext{underlying type|see{type, underlying}}%
 \indextext{type!underlying!\idxcode{char16_t}}%
 \indextext{type!underlying!\idxcode{char32_t}}%
 Type \tcode{wchar_t} is a distinct type whose values can represent
@@ -3798,7 +3798,7 @@ and alignment as \tcode{uint_least16_t} and \tcode{uint_least32_t},
 respectively, in \tcode{<cstdint>}, called the underlying types.
 
 \pnum
-\indextext{Boolean~type}%
+\indextext{Boolean type}%
 Values of type \tcode{bool} are either \tcode{true} or
 \tcode{false}.\footnote{Using a \tcode{bool} value in ways described by this International
 Standard as ``undefined'', such as by examining the value of an
@@ -3846,7 +3846,7 @@ least as much precision as \tcode{double}. The set of values of the type
 of the set of values of the type \tcode{long} \tcode{double}. The value
 representation of floating-point types is \impldef{value representation of
 floating-point types}.
-\indextext{floating~point~type!implementation-defined}%
+\indextext{floating point type!implementation-defined}%
 \begin{note}
 This International Standard imposes no requirements on the accuracy of
 floating-point operations; see also~\ref{limits}. 
@@ -3926,7 +3926,7 @@ different types at different times,~\ref{class.union};
 Each distinct enumeration constitutes a different
 \defnx{enumerated type}{type!enumerated},~\ref{dcl.enum};
 
-\item \indextext{member~pointer~to|see{pointer to member}}%
+\item \indextext{member pointer to|see{pointer to member}}%
 \defnx{pointers to non-static class members}{pointer to member},%
 \footnote{Static class members are objects or functions, and pointers to them are
 ordinary pointers to objects or functions.}
@@ -4316,7 +4316,7 @@ requirement of the type in the complete-object case.
 \pnum
 \indextext{alignment!extended}%
 \indextext{alignment!new-extended}%
-\indextext{over-aligned~type}%
+\indextext{over-aligned type}%
 \indextext{type!over-aligned}%
 An \defn{extended alignment} is represented by an alignment
 greater than \tcode{alignof(std::max_align_t)}. It is \impldef{support for extended alignments}

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2794,7 +2794,7 @@ the functions passed to \tcode{std::atexit()} or \tcode{std::at_quick_exit()}.%
 
 \pnum
 \indextext{storage~duration|(}%
-The \defnx{storage duration}{storage duration} is the property of an object that defines the minimum
+The \defn{storage duration} is the property of an object that defines the minimum
 potential lifetime of the storage containing the object. The storage
 duration is determined by the construct used to create the object and is
 one of the following:
@@ -3732,7 +3732,7 @@ the other signed integer types are provided to meet special needs.
 For each of the standard signed integer types,
 there exists a corresponding (but different)
 \indextext{type!standard~unsigned~integer}%
-\defnx{standard unsigned integer type}{standard unsigned integer type}:
+\defn{standard unsigned integer type}:
 \indextext{type!\idxcode{unsigned char}}%
 \indextext{type!\idxcode{unsigned short}}%
 \indextext{type!\idxcode{unsigned int}}%
@@ -3751,7 +3751,7 @@ its corresponding unsigned integer type.
 \indextext{type!unsigned~integer}%
 Likewise, for each of the extended signed integer types there exists a
 corresponding
-\defnx{extended unsigned integer type}{extended unsigned integer type} with the same amount of storage and alignment
+\defn{extended unsigned integer type} with the same amount of storage and alignment
 requirements. The standard and extended unsigned integer types are
 collectively called \defnx{unsigned integer types}{unsigned integer type}. The range of non-negative
 values of a signed integer type is a subrange of the corresponding
@@ -3819,7 +3819,7 @@ A synonym for integral type is
 \indextext{signed integer representation!ones' complement}%
 \indextext{signed integer representation!two's complement}%
 \indextext{signed integer representation!signed magnitude}%
-\defnx{integer type}{integer type}. The representations of integral types shall
+\defn{integer type}. The representations of integral types shall
 define values by use of a pure binary numeration system.\footnote{A positional
 representation for integers that uses the binary digits 0
 and 1, in which the values represented by successive bits are additive,
@@ -3907,8 +3907,8 @@ static members of classes) of a given type,~\ref{dcl.ptr};
 \defnx{references}{reference} to objects or functions of a given
 type,~\ref{dcl.ref}. There are two types of references:
 \begin{itemize}
-\item \defnx{lvalue reference}{lvalue reference}
-\item \defnx{rvalue reference}{rvalue reference}
+\item \defn{lvalue reference}
+\item \defn{rvalue reference}
 \end{itemize}
 
 \item
@@ -4294,7 +4294,7 @@ using the alignment specifier~(\ref{dcl.align}).
 
 \pnum
 \indextext{alignment!fundamental}%
-A \defnx{fundamental alignment}{fundamental alignment} is represented by an alignment
+A \defn{fundamental alignment} is represented by an alignment
 less than or equal to the greatest alignment supported by the implementation in
 all contexts, which is equal to
 \tcode{alignof(std::max_align_t)}~(\ref{support.types}).

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3763,8 +3763,9 @@ same.
 The standard signed integer types and standard unsigned integer types
 are collectively called the \defnx{standard integer types}{standard integer type}, and the extended
 signed integer types and extended
-unsigned integer types are collectively called the \defnx{extended
-integer types}{extended~integer~type}. The signed and unsigned integer types shall satisfy
+unsigned integer types are collectively called the
+\defnx{extended integer types}{extended integer type}.
+The signed and unsigned integer types shall satisfy
 the constraints given in the C standard, section 5.2.4.2.1.
 
 \pnum

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2794,7 +2794,7 @@ the functions passed to \tcode{std::atexit()} or \tcode{std::at_quick_exit()}.%
 
 \pnum
 \indextext{storage~duration|(}%
-The \defnx{storage duration}{storage~duration} is the property of an object that defines the minimum
+The \defnx{storage duration}{storage duration} is the property of an object that defines the minimum
 potential lifetime of the storage containing the object. The storage
 duration is determined by the construct used to create the object and is
 one of the following:
@@ -3602,7 +3602,7 @@ types, pointer to member types~(\ref{basic.compound}),
 and
 cv-qualified versions of these
 types~(\ref{basic.type.qualifier}) are collectively called
-\defnx{scalar types}{scalar~type}. Scalar types,
+\defnx{scalar types}{scalar type}. Scalar types,
 POD classes (Clause~\ref{class}), arrays of such types and
 cv-qualified versions of these
 types~(\ref{basic.type.qualifier}) are collectively called
@@ -3700,7 +3700,7 @@ conversion~(\ref{conv.integral}) from \placeholder{i} to \tcode{char} is
 
 \pnum
 \indextext{type!standard~signed~integer}%
-There are five \defnx{standard signed integer types}{standard~signed~integer~type} :
+There are five \defnx{standard signed integer types}{standard signed integer type} :
 \indextext{type!\idxcode{signed char}}%
 \indextext{type!\idxcode{short}}%
 \indextext{type!\idxcode{int}}%
@@ -3713,10 +3713,10 @@ preceding it in the list.
 \indextext{type!extended~signed~integer}%
 \indextext{type!signed~integer}%
 There may also be \impldef{extended signed integer types}
-\defnx{extended signed integer types}{extended~signed~integer~type}.
+\defnx{extended signed integer types}{extended signed integer type}.
 The standard and
 extended signed integer types are collectively called
-\defnx{signed integer types}{signed~integer~type}.
+\defnx{signed integer types}{signed integer type}.
 \indextext{integral~type!implementation-defined @\tcode{sizeof}}%
 Plain
 \tcode{int}s have the natural size suggested by the architecture of the
@@ -3732,7 +3732,7 @@ the other signed integer types are provided to meet special needs.
 For each of the standard signed integer types,
 there exists a corresponding (but different)
 \indextext{type!standard~unsigned~integer}%
-\defnx{standard unsigned integer type}{standard~unsigned~integer~type}:
+\defnx{standard unsigned integer type}{standard unsigned integer type}:
 \indextext{type!\idxcode{unsigned char}}%
 \indextext{type!\idxcode{unsigned short}}%
 \indextext{type!\idxcode{unsigned int}}%
@@ -3751,9 +3751,9 @@ its corresponding unsigned integer type.
 \indextext{type!unsigned~integer}%
 Likewise, for each of the extended signed integer types there exists a
 corresponding
-\defnx{extended unsigned integer type}{extended~unsigned~integer~type} with the same amount of storage and alignment
+\defnx{extended unsigned integer type}{extended unsigned integer type} with the same amount of storage and alignment
 requirements. The standard and extended unsigned integer types are
-collectively called \defnx{unsigned integer types}{unsigned~integer~type}. The range of non-negative
+collectively called \defnx{unsigned integer types}{unsigned integer type}. The range of non-negative
 values of a signed integer type is a subrange of the corresponding
 unsigned integer type, and the value
 representation of each corresponding signed/unsigned type shall be the
@@ -3761,7 +3761,7 @@ same.
 \indextext{type!standard~integer}%
 \indextext{type!extended~integer}%
 The standard signed integer types and standard unsigned integer types
-are collectively called the \defnx{standard integer types}{standard~integer~type}, and the extended
+are collectively called the \defnx{standard integer types}{standard integer type}, and the extended
 signed integer types and extended
 unsigned integer types are collectively called the \defnx{extended
 integer types}{extended~integer~type}. The signed and unsigned integer types shall satisfy
@@ -3812,14 +3812,14 @@ or \tcode{long bool} types or values. \end{note} Values of type
 Types \tcode{bool}, \tcode{char}, \tcode{char16_t}, \tcode{char32_t},
 \tcode{wchar_t}, and the signed and unsigned integer types are
 collectively called
-\defnx{integral}{integral~type} types.\footnote{Therefore, enumerations~(\ref{dcl.enum}) are not integral; however,
+\defnx{integral}{integral type} types.\footnote{Therefore, enumerations~(\ref{dcl.enum}) are not integral; however,
 enumerations can be promoted to integral types as specified
 in~\ref{conv.prom}.}
 A synonym for integral type is
 \indextext{signed integer representation!ones' complement}%
 \indextext{signed integer representation!two's complement}%
 \indextext{signed integer representation!signed magnitude}%
-\defnx{integer type}{integer~type}. The representations of integral types shall
+\defnx{integer type}{integer type}. The representations of integral types shall
 define values by use of a pure binary numeration system.\footnote{A positional
 representation for integers that uses the binary digits 0
 and 1, in which the values represented by successive bits are additive,
@@ -3831,7 +3831,7 @@ ones' complement and signed magnitude representations for integral types.
 \end{example}
 
 \pnum
-There are three \defnx{floating-point}{floating~point~type} types:
+There are three \defnx{floating-point}{floating point type} types:
 \indextext{type!\idxcode{float}}%
 \tcode{float},
 \indextext{type!\idxcode{double}}%
@@ -3907,8 +3907,8 @@ static members of classes) of a given type,~\ref{dcl.ptr};
 \defnx{references}{reference} to objects or functions of a given
 type,~\ref{dcl.ref}. There are two types of references:
 \begin{itemize}
-\item \defnx{lvalue reference}{lvalue~reference}
-\item \defnx{rvalue reference}{rvalue~reference}
+\item \defnx{lvalue reference}{lvalue reference}
+\item \defnx{rvalue reference}{rvalue reference}
 \end{itemize}
 
 \item
@@ -3927,7 +3927,7 @@ Each distinct enumeration constitutes a different
 \defnx{enumerated type}{type!enumerated},~\ref{dcl.enum};
 
 \item \indextext{member~pointer~to|see{pointer to member}}%
-\defnx{pointers to non-static class members}{pointer~to~member},%
+\defnx{pointers to non-static class members}{pointer to member},%
 \footnote{Static class members are objects or functions, and pointers to them are
 ordinary pointers to objects or functions.}
 which identify members of a given
@@ -4284,7 +4284,7 @@ the object,
 \rSec1[basic.align]{Alignment}
 
 \pnum
-Object types have \defnx{alignment requirements}{alignment~requirement!implementation-defined} (\ref{basic.fundamental},~\ref{basic.compound})
+Object types have \defnx{alignment requirements}{alignment requirement!implementation-defined} (\ref{basic.fundamental},~\ref{basic.compound})
 which place restrictions on the addresses at which an object of that type
 may be allocated. An \defn{alignment} is an \impldef{alignment}
 integer value representing the number of bytes between successive addresses
@@ -4294,7 +4294,7 @@ using the alignment specifier~(\ref{dcl.align}).
 
 \pnum
 \indextext{alignment!fundamental}%
-A \defnx{fundamental alignment}{fundamental~alignment} is represented by an alignment
+A \defnx{fundamental alignment}{fundamental alignment} is represented by an alignment
 less than or equal to the greatest alignment supported by the implementation in
 all contexts, which is equal to
 \tcode{alignof(std::max_align_t)}~(\ref{support.types}).

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -9,10 +9,10 @@
 \pnum
 \indextext{\idxcode{\{\}}!class declaration}%
 \indextext{\idxcode{\{\}}!class definition}%
-\indextext{type!class~and}%
-\indextext{object~class|seealso{class~object}}%
+\indextext{type!class and}%
+\indextext{object class|seealso{class object}}%
 A class is a type.
-\indextext{name~class|see{class~name}}%
+\indextext{name class|see{class name}}%
 Its name becomes a \grammarterm{class-name}~(\ref{class.name}) within its
 scope.
 
@@ -110,9 +110,9 @@ as equality comparison, can be defined by the user; see~\ref{over.oper}.
 \end{note}
 
 \pnum
-\indextext{\idxcode{struct}!\tcode{class}~versus}%
+\indextext{\idxcode{struct}!\tcode{class} versus}%
 \indextext{structure}%
-\indextext{\idxcode{union}!\tcode{class}~versus}%
+\indextext{\idxcode{union}!\tcode{class} versus}%
 A \term{union} is a class defined with the \grammarterm{class-key}
 \tcode{union};
 \indextext{access control!\idxcode{union} default member}%
@@ -122,7 +122,7 @@ Aggregates of class type are described in~\ref{dcl.init.aggr}.
 \end{note}
 
 \indextext{class!trivial}%
-\indextext{trivial~class}%
+\indextext{trivial class}%
 \indextext{class!trivially copyable}%
 \pnum
 A \defn{trivially copyable class} is a class:
@@ -144,7 +144,7 @@ at least one of which is not deleted.
 virtual functions or virtual base classes.\end{note}
 
 \indextext{class!standard-layout}%
-\indextext{standard-layout~class}%
+\indextext{standard-layout class}%
 \pnum
 A class \tcode{S} is a \grammarterm{standard-layout class} if it:
 \begin{itemize}
@@ -213,9 +213,9 @@ in \tcode{X}. \end{note}
 \end{example}
 
 \indextext{struct!standard-layout}%
-\indextext{standard-layout~struct}%
+\indextext{standard-layout struct}%
 \indextext{union!standard-layout}%
-\indextext{standard-layout~union}%
+\indextext{standard-layout union}%
 \pnum
 A \grammarterm{standard-layout struct} is a standard-layout class
 defined with the \grammarterm{class-key} \tcode{struct} or the
@@ -282,8 +282,8 @@ In such cases, the \grammarterm{nested-name-specifier} of the
 definition shall not begin with a \grammarterm{decltype-specifier}.
 
 \rSec1[class.name]{Class names}
-\indextext{definition!class~name~as type}%
-\indextext{structure~tag|see{class~name}}%
+\indextext{definition!class name as type}%
+\indextext{structure tag|see{class name}}%
 \indextext{equivalence!type}%
 
 \pnum
@@ -325,10 +325,10 @@ is ill-formed because it defines \tcode{S} twice.
 \end{example}
 
 \pnum
-\indextext{definition!scope~of class}%
-\indextext{class~name!scope~of}%
+\indextext{definition!scope of class}%
+\indextext{class name!scope of}%
 A class declaration introduces the class name into the scope where
-\indextext{name~hiding!class definition}%
+\indextext{name hiding!class definition}%
 it is declared and hides any
 class, variable, function, or other declaration of that name in an
 enclosing scope~(\ref{basic.scope}). If a class name is declared in a
@@ -355,7 +355,7 @@ void f() {
 }
 \end{codeblock}
 \end{example}
-\indextext{class~name!elaborated}%
+\indextext{class name!elaborated}%
 \indextext{declaration!forward class}%
 A \grammarterm{declaration} consisting solely of \grammarterm{class-key
 identifier;} is either a redeclaration of the name in the current scope
@@ -400,8 +400,8 @@ operator functions in~\ref{over.oper}.
 \end{note}
 
 \pnum
-\indextext{class~name!elaborated}%
-\indextext{elaborated~type~specifier|see{class name, elaborated}}%
+\indextext{class name!elaborated}%
+\indextext{elaborated type specifier|see{class name, elaborated}}%
 \begin{note}
 An \grammarterm{elaborated-type-specifier}~(\ref{dcl.type.elab}) can also
 be used as a \grammarterm{type-specifier} as part of a declaration. It
@@ -421,7 +421,7 @@ void g(int s) {
 \end{example}
 
 \pnum
-\indextext{class~name!point~of declaration}%
+\indextext{class name!point of declaration}%
 \begin{note}
 The declaration of a class name takes effect immediately after the
 \grammarterm{identifier} is seen in the class definition or
@@ -438,7 +438,7 @@ class. Such artistry with names can be confusing and is best avoided.
 \end{note}
 
 \pnum
-\indextext{class~name!\idxcode{typedef}}%
+\indextext{class name!\idxcode{typedef}}%
 A \grammarterm{typedef-name}~(\ref{dcl.typedef}) that names a class type,
 or a cv-qualified version thereof, is also a \grammarterm{class-name}. If a
 \grammarterm{typedef-name} that names a cv-qualified class type is used
@@ -448,7 +448,7 @@ ignored. A \grammarterm{typedef-name} shall not be used as the
 
 \rSec1[class.mem]{Class members}%
 \indextext{declaration!member}%
-\indextext{data~member|see{member}}
+\indextext{data member|see{member}}
 
 \begin{bnf}
 \nontermdef{member-specification}\br
@@ -572,7 +572,7 @@ are sufficiently different (Clause~\ref{over}).
 \end{note}
 
 \pnum
-\indextext{completely~defined}%
+\indextext{completely defined}%
 A class is considered a completely-defined object
 type~(\ref{basic.types}) (or complete type) at the closing \tcode{\}} of
 the \grammarterm{class-specifier}.
@@ -608,7 +608,7 @@ declaration of a data member. (For static data members,
 see~\ref{class.static.data}; for non-static data members,
 see~\ref{class.base.init} and~\ref{dcl.init.aggr}).
 A \grammarterm{brace-or-equal-initializer} for a non-static data member
-\indextext{member!default~initializer}%
+\indextext{member!default initializer}%
 specifies a \defn{default member initializer} for the member, and
 shall not directly or indirectly cause the implicit definition of a
 defaulted default constructor for the enclosing class or the
@@ -644,7 +644,7 @@ shall appear only in the declaration of a virtual member
 function~(\ref{class.virtual}).
 
 \pnum
-\indextext{class~object!member}%
+\indextext{class object!member}%
 Non-static data members shall not have
 incomplete types. In particular, a class \tcode{C} shall not contain a
 non-static member of class \tcode{C}, but it can contain a pointer or
@@ -664,7 +664,7 @@ There are no special member function types or data member types.
 \end{note}
 
 \pnum
-\indextext{example!class~definition}%
+\indextext{example!class definition}%
 \begin{example}
 A simple example of a class definition is
 
@@ -694,7 +694,7 @@ of the \tcode{tword} member of the \tcode{right} subtree of \tcode{s}.
 \end{example}
 
 \pnum
-\indextext{layout!class~object}%
+\indextext{layout!class object}%
 Non-static data members of a (non-union) class
 with the same access control (Clause~\ref{class.access})
 are allocated so that later
@@ -810,7 +810,7 @@ pointer-interconvertible~(\ref{basic.compound}, \ref{expr.static.cast}).
 
 \pnum
 \indextext{member function!inline}%
-\indextext{definition!member~function}%
+\indextext{definition!member function}%
 A member function may be defined~(\ref{dcl.fct.def}) in its class
 definition, in which case it is an \term{inline} member
 function~(\ref{dcl.fct.spec}), or it may be defined outside of its class
@@ -843,7 +843,7 @@ See~\ref{basic.def.odr} and~\ref{dcl.fct.spec}.
 \end{note}
 
 \pnum
-\indextext{operator!scope~resolution}%
+\indextext{operator!scope resolution}%
 If the definition of a member function is lexically outside its class
 definition, the member function name shall be qualified by its class
 name using the \tcode{::} operator.
@@ -883,7 +883,7 @@ the same entity, whether or not the member function is \tcode{inline}.
 Previously declared member functions may be mentioned in \tcode{friend} declarations.
 
 \pnum
-\indextext{local~class!member~function~in}%
+\indextext{local class!member function in}%
 Member functions of a local class shall be defined inline in their class
 definition, if they are defined at all.
 
@@ -958,7 +958,7 @@ an enumerator or a nested type of class \tcode{X} or of a base class of
 \grammarterm{nested-name-specifier} names the class of the member function.
 These transformations do not apply in the
 template definition context~(\ref{temp.dep.type}).
-\indextext{example!member~function}%
+\indextext{example!member function}%
 \begin{example}
 
 \begin{codeblock}
@@ -1030,11 +1030,11 @@ A non-static member function may be declared
 \indextext{member function!\idxcode{this}}
 
 \pnum
-\indextext{this pointer@\tcode{this}~pointer|see{\tcode{this}}}%
+\indextext{this pointer@\tcode{this} pointer|see{\tcode{this}}}%
 In the body of a non-static~(\ref{class.mfct}) member function, the
 keyword \tcode{this} is a prvalue expression whose value is the
 address of the object for which the function is called.
-\indextext{\idxcode{this}!type~of}%
+\indextext{\idxcode{this}!type of}%
 The type of \tcode{this} in a member function of a class \tcode{X} is
 \tcode{X*}.
 \indextext{member function!\idxcode{const}}%
@@ -1094,10 +1094,10 @@ and \tcode{s::g()} is a non-\tcode{const} member function, that is,
 \end{example}
 
 \pnum
-\indextext{\idxcode{const}!constructor~and}%
-\indextext{\idxcode{const}!destructor~and}%
-\indextext{\idxcode{volatile}!constructor~and}%
-\indextext{\idxcode{volatile}!destructor~and}%
+\indextext{\idxcode{const}!constructor and}%
+\indextext{\idxcode{const}!destructor and}%
+\indextext{\idxcode{volatile}!constructor and}%
+\indextext{\idxcode{volatile}!destructor and}%
 Constructors~(\ref{class.ctor}) and destructors~(\ref{class.dtor}) shall
 not be declared \tcode{const}, \tcode{volatile} or \tcode{const}
 \tcode{volatile}. \begin{note} However, these functions can be invoked to
@@ -1198,7 +1198,7 @@ static member function shall not be declared \tcode{const},
 \tcode{volatile}, or \tcode{const volatile}.
 
 \rSec3[class.static.data]{Static data members}
-\indextext{member~data!static}%
+\indextext{member data!static}%
 
 \pnum
 A static data member is not part of the subobjects of a class. If a
@@ -1217,7 +1217,7 @@ is not a definition and may be of an incomplete type other than
 member that is not defined inline in the class definition
 shall appear in a namespace scope enclosing the member's class
 definition.
-\indextext{operator~use!scope~resolution}%
+\indextext{operator use!scope resolution}%
 In the definition at namespace scope, the name of the static
 data member shall be qualified by its class name using the \tcode{::}
 operator. The \grammarterm{initializer} expression in the definition of a
@@ -1316,10 +1316,10 @@ be larger than the number of bits in the object
 representation~(\ref{basic.types}) of the bit-field's type; in such
 cases the extra bits are used as padding bits and do not participate in
 the value representation~(\ref{basic.types}) of the bit-field.
-\indextext{allocation!implementation~defined bit-field}%
+\indextext{allocation!implementation defined bit-field}%
 Allocation of bit-fields within a class object is
 \impldef{allocation of bit-fields within a class object}.
-\indextext{bit-field!implementation~defined alignment~of}%
+\indextext{bit-field!implementation defined alignment of}%
 Alignment of bit-fields is \impldef{alignment of bit-fields within a class object}.
 \indextext{layout!bit-field}%
 Bit-fields are packed into some addressable allocation unit.
@@ -1338,26 +1338,26 @@ members and cannot be initialized.
 An unnamed bit-field is useful for padding to conform to
 externally-imposed layouts.
 \end{note}
-\indextext{bit-field!zero~width~of}%
-\indextext{bit-field!alignment~of}%
+\indextext{bit-field!zero width of}%
+\indextext{bit-field!alignment of}%
 As a special case, an unnamed bit-field with a width of zero specifies
 alignment of the next bit-field at an allocation unit boundary. Only
 when declaring an unnamed bit-field may the value of the
 \grammarterm{constant-expression} be equal to zero.
 
 \pnum
-\indextext{bit-field!type~of}%
+\indextext{bit-field!type of}%
 A bit-field shall not be a static member. A bit-field shall have
 integral or enumeration type~(\ref{basic.fundamental}).
 \indextext{Boolean}%
 A \tcode{bool} value can successfully be stored in a bit-field of any
 nonzero size.
-\indextext{bit-field!address~of}%
+\indextext{bit-field!address of}%
 The address-of operator \tcode{\&} shall not be applied to a bit-field,
 so there are no pointers to bit-fields.
 \indextext{restriction!bit-field}%
-\indextext{restriction!address~of bit-field}%
-\indextext{restriction!pointer~to bit-field}%
+\indextext{restriction!address of bit-field}%
+\indextext{restriction!pointer to bit-field}%
 A non-const reference shall not be bound to a
 bit-field~(\ref{dcl.init.ref}).
 \begin{note}
@@ -1393,22 +1393,22 @@ void f() {
 \end{example}
 
 \rSec2[class.nest]{Nested class declarations}%
-\indextext{definition!nested~class}%
-\indextext{class~local|see{local~class}}%
-\indextext{class~nested|see{nested~class}}
+\indextext{definition!nested class}%
+\indextext{class local|see{local class}}%
+\indextext{class nested|see{nested class}}
 
 \pnum
 A class can be declared within another class. A class declared within
 another is called a \grammarterm{nested} class. The name of a nested class
 is local to its enclosing class.
-\indextext{nested~class!scope~of}%
+\indextext{nested class!scope of}%
 The nested class is in the scope of its enclosing class.
 \begin{note}
 See~\ref{expr.prim} for restrictions on the use of non-static data
 members and non-static member functions.
 \end{note}
 
-\indextext{example!nested~class}%
+\indextext{example!nested class}%
 \begin{example}
 
 \begin{codeblock}
@@ -1440,7 +1440,7 @@ inner* p = 0;                   // error: \tcode{inner} not in scope
 \pnum
 Member functions and static data members of a nested class can be
 defined in a namespace scope enclosing the definition of their class.
-\indextext{example!nested~class definition}%
+\indextext{example!nested class definition}%
 \begin{example}
 
 \begin{codeblock}
@@ -1462,7 +1462,7 @@ If class \tcode{X} is defined in a namespace scope, a nested class
 \tcode{Y} may be declared in class \tcode{X} and later defined in the
 definition of class \tcode{X} or be later defined in a namespace scope
 enclosing the definition of class \tcode{X}.
-\indextext{example!nested~class forward~declaration}%
+\indextext{example!nested class forward declaration}%
 \begin{example}
 
 \begin{codeblock}
@@ -1476,7 +1476,7 @@ class E::I2 { };                // definition of nested class
 \end{example}
 
 \pnum
-\indextext{friend~function!nested~class}%
+\indextext{friend function!nested class}%
 Like a member function, a friend function~(\ref{class.friend}) defined
 within a nested class is in the lexical scope of that class; it obeys
 the same rules for name binding as a static member function of that
@@ -1484,8 +1484,8 @@ class~(\ref{class.static}), but it has no special access rights to
 members of an enclosing class.
 
 \rSec2[class.nested.type]{Nested type names}
-\indextext{type~name!nested}%
-\indextext{type~name!nested!scope of}%
+\indextext{type name!nested}%
+\indextext{type name!nested!scope of}%
 
 \pnum
 Type names obey exactly the same scope rules as other names. In
@@ -1493,7 +1493,7 @@ particular, type names defined within a class definition cannot be used
 outside their class without qualification.
 \begin{example}
 
-\indextext{example!nested type~name}%
+\indextext{example!nested type name}%
 \begin{codeblock}
 struct X {
   typedef int I;
@@ -1704,7 +1704,7 @@ variables, but since they are union members they have the same address.
 
 \pnum
 \indextext{\idxcode{union}!global anonymous}%
-\indextext{scope!anonymous \tcode{union}~at namespace}%
+\indextext{scope!anonymous \tcode{union} at namespace}%
 Anonymous unions declared in a named namespace or in the global
 namespace shall be declared \tcode{static}. Anonymous unions declared at
 block scope shall be declared with any storage class allowed for a
@@ -1739,7 +1739,7 @@ in~(\ref{dcl.init.aggr}).
 
 \pnum
 \indextext{class!union-like}%
-\indextext{class!variant~member~of}%
+\indextext{class!variant member of}%
 A \defn{union-like class} is a union or a class that has an anonymous union as a direct
 member. A union-like class \tcode{X} has a set of \defn{variant member}{s}.
 If \tcode{X} is a union, a non-static data member of \tcode{X} that is not an anonymous
@@ -1764,14 +1764,14 @@ union U {
 \end{example}
 
 \rSec1[class.local]{Local class declarations}
-\indextext{declaration!local~class}%
-\indextext{definition!local~class}%
+\indextext{declaration!local class}%
+\indextext{definition!local class}%
 
 \pnum
 A class can be declared within a function definition; such a class is
 called a \grammarterm{local} class. The name of a local class is local to
 its enclosing scope.
-\indextext{local~class!scope~of}%
+\indextext{local class!scope of}%
 The local class is in the scope of the enclosing scope, and has the same
 access to names outside the function as does the enclosing function.
 Declarations in a local class
@@ -1779,7 +1779,7 @@ shall not odr-use~(\ref{basic.def.odr}) a variable with automatic storage
 duration from an
 enclosing scope.
 \begin{example}
-\indextext{example!local~class}%
+\indextext{example!local class}%
 \begin{codeblock}
 int x;
 void f() {
@@ -1805,20 +1805,20 @@ local* p = 0;                   // error: \tcode{local} not in scope
 \pnum
 An enclosing function has no special access to members of the local
 class; it obeys the usual access rules (Clause~\ref{class.access}).
-\indextext{member function!local~class}%
+\indextext{member function!local class}%
 Member functions of a local class shall be defined within their class
 definition, if they are defined at all.
 
 \pnum
-\indextext{nested~class!local~class}%
+\indextext{nested class!local class}%
 If class \tcode{X} is a local class a nested class \tcode{Y} may be
 declared in class \tcode{X} and later defined in the definition of class
 \tcode{X} or be later defined in the same scope as the definition of
 class \tcode{X}.
-\indextext{restriction!local~class}%
+\indextext{restriction!local class}%
 A class nested within
 a local class is a local class.
 
 \pnum
-\indextext{restriction!static member local~class}%
+\indextext{restriction!static member local class}%
 A local class shall not have static data members.

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -4,7 +4,7 @@
 \rSec1[diff.iso]{\Cpp and ISO C}
 
 \pnum
-\indextext{summary!compatibility~with ISO C}%
+\indextext{summary!compatibility with ISO C}%
 This subclause lists the differences between \Cpp and
 ISO C, by the chapters of this document.
 
@@ -277,7 +277,7 @@ Seldom.
 \ref{expr.cond}, \ref{expr.ass}, \ref{expr.comma}
 
 \indextext{conversion!lvalue-to-rvalue}%
-\indextext{rvalue!lvalue conversion~to}%
+\indextext{rvalue!lvalue conversion to}%
 \indextext{lvalue}%
 \change The result of a conditional expression, an assignment expression, or a comma expression may be an lvalue.
 \rationale
@@ -668,7 +668,7 @@ Seldom.
 
 \ref{class.bit}
 \change
-\indextext{bit-field!implementation-defined sign~of}%
+\indextext{bit-field!implementation-defined sign of}%
 Bit-fields of type plain \tcode{int} are signed.
 \rationale
 Leaving the choice of signedness to implementations could lead to
@@ -822,7 +822,7 @@ quite common.
 \rSec1[diff.cpp03]{\Cpp and ISO \CppIII}
 
 \pnum
-\indextext{summary!compatibility~with ISO \CppIII}%
+\indextext{summary!compatibility with ISO \CppIII}%
 This subclause lists the differences between \Cpp and
 ISO \CppIII (ISO/IEC 14882:2003, \doccite{Programming Languages --- \Cpp}),
 by the chapters of this document.
@@ -1331,7 +1331,7 @@ int main() {
 \rSec1[diff.cpp11]{\Cpp and ISO \CppXI}
 
 \pnum
-\indextext{summary!compatibility~with ISO \CppXI}%
+\indextext{summary!compatibility with ISO \CppXI}%
 This subclause lists the differences between \Cpp and
 ISO \CppXI (ISO/IEC 14882:2011, \doccite{Programming Languages --- \Cpp}),
 by the chapters of this document.
@@ -1470,7 +1470,7 @@ in this International Standard.
 \rSec1[diff.cpp14]{\Cpp and ISO \CppXIV}
 
 \pnum
-\indextext{summary!compatibility~with ISO \CppXIV}%
+\indextext{summary!compatibility with ISO \CppXIV}%
 This subclause lists the differences between \Cpp and
 ISO \CppXIV (ISO/IEC 14882:2014, \doccite{Programming Languages --- \Cpp}),
 by the chapters of this document.
@@ -1778,8 +1778,8 @@ and \tcode{<threads.h>}\indextext{\idxhdr{threads.h}},
 nor are the C headers themselves part of \Cpp.
 
 \pnum
-The headers \tcode{<ccomplex>}\indextext{\idxhdr{ccomplex}}~(\ref{ccomplex.syn})
-and \tcode{<ctgmath>}\indextext{\idxhdr{ctgmath}}~(\ref{ctgmath.syn}), as well
+The headers \tcode{<ccomplex>}\indextext{\idxhdr{ccomplex}} (\ref{ccomplex.syn})
+and \tcode{<ctgmath>}\indextext{\idxhdr{ctgmath}} (\ref{ctgmath.syn}), as well
 as their corresponding C headers \tcode{<complex.h>}\indextext{\idxhdr{complex.h}}
 and \tcode{<tgmath.h>}\indextext{\idxhdr{tgmath.h}}, do not contain any of the
 content from the C standard library and instead merely include other headers

--- a/source/conversions.tex
+++ b/source/conversions.tex
@@ -1,7 +1,7 @@
 %!TEX root = std.tex
 \rSec0[conv]{Standard conversions}
 
-\indextext{implicit~conversion|see{conversion, implicit}}
+\indextext{implicit conversion|see{conversion, implicit}}
 \indextext{contextually converted to bool|see{conversion, contextual}}
 \indextext{rvalue!lvalue conversion to|see{conversion, lvalue to rvalue}}%
 
@@ -395,7 +395,7 @@ These conversions are called \term{integral promotions}.
 \rSec1[conv.fpprom]{Floating-point promotion}
 
 \pnum
-\indextext{promotion!floating~point}%
+\indextext{promotion!floating point}%
 A prvalue of type \tcode{float} can be converted to a prvalue of type
 \tcode{double}. The value is unchanged.
 
@@ -440,7 +440,7 @@ of integral conversions.
 \rSec1[conv.double]{Floating-point conversions}
 
 \pnum
-\indextext{conversion!floating~point}%
+\indextext{conversion!floating point}%
 A prvalue of floating-point type can be converted to a prvalue of
 another floating-point type. If the source value can be exactly
 represented in the destination type, the result of the conversion is
@@ -456,7 +456,7 @@ the set of floating-point conversions.
 \rSec1[conv.fpint]{Floating-integral conversions}
 
 \pnum
-\indextext{conversion!floating~to~integral}%
+\indextext{conversion!floating to integral}%
 A prvalue of a floating-point type can be converted to a prvalue of an
 integer type. The conversion truncates; that is, the fractional part is
 discarded.
@@ -468,7 +468,7 @@ If the destination type is \tcode{bool}, see~\ref{conv.bool}.
 \end{note}
 
 \pnum
-\indextext{conversion!integral~to~floating}%
+\indextext{conversion!integral to floating}%
 \indextext{truncation}%
 \indextext{rounding}%
 A prvalue of an integer type or of an unscoped enumeration type can be converted to

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -216,13 +216,13 @@ the type associated with the name is a function type~(\ref{dcl.fct}) and
 an \term{object declaration} otherwise.
 
 \pnum
-\indextext{definition!declaration~as}%
+\indextext{definition!declaration as}%
 Syntactic components beyond those found in the general form of
 declaration are added to a function declaration to make a
 \grammarterm{function-definition}. An object declaration, however, is also
 a definition unless it contains the \tcode{extern} specifier and has no
 initializer~(\ref{basic.def}).
-\indextext{initialization!definition~and}%
+\indextext{initialization!definition and}%
 A
 definition causes the appropriate amount of storage to be reserved and
 any appropriate initialization~(\ref{dcl.init}) to be done.
@@ -300,10 +300,10 @@ void g(const int Pc);           // \tcode{void g(const int)}
 \end{example}
 
 \pnum
-\indextext{\idxcode{signed}!typedef@\tcode{typedef}~and}%
-\indextext{\idxcode{unsigned}!typedef@\tcode{typedef}~and}%
-\indextext{\idxcode{long}!typedef@\tcode{typedef}~and}%
-\indextext{\idxcode{short}!typedef@\tcode{typedef}~and}%
+\indextext{\idxcode{signed}!typedef@\tcode{typedef} and}%
+\indextext{\idxcode{unsigned}!typedef@\tcode{typedef} and}%
+\indextext{\idxcode{long}!typedef@\tcode{typedef} and}%
+\indextext{\idxcode{short}!typedef@\tcode{typedef} and}%
 \begin{note}
 Since \tcode{signed}, \tcode{unsigned}, \tcode{long}, and \tcode{short}
 by default imply \tcode{int}, a \grammarterm{type-name} appearing after one
@@ -317,8 +317,8 @@ void k(unsigned int Pc);        // \tcode{void k(unsigned int)}
 \end{note}
 
 \rSec2[dcl.stc]{Storage class specifiers}%
-\indextext{specifier!storage~class}%
-\indextext{declaration!storage~class}%
+\indextext{specifier!storage class}%
+\indextext{declaration!storage class}%
 \indextext{\idxcode{static}}%
 \indextext{\idxcode{thread_local}}%
 \indextext{\idxcode{extern}}%
@@ -386,7 +386,7 @@ duration~(\ref{basic.stc.static}), unless accompanied by the
 storage duration~(\ref{basic.stc.thread}). A \tcode{static} specifier can be
 used in declarations of class members;~\ref{class.static} describes its
 effect.
-\indextext{\idxcode{static}!linkage~of}%
+\indextext{\idxcode{static}!linkage of}%
 For the linkage of a name declared with a \tcode{static} specifier,
 see~\ref{basic.link}.
 
@@ -395,7 +395,7 @@ see~\ref{basic.link}.
 The \tcode{extern} specifier can be applied only to the names of variables
 and functions. The \tcode{extern} specifier cannot be used in the
 declaration of class members or function parameters.
-\indextext{\idxcode{extern}!linkage~of}%
+\indextext{\idxcode{extern}!linkage of}%
 \indextext{consistency!linkage}%
 For the linkage of a name declared with an \tcode{extern} specifier,
 see~\ref{basic.link}.
@@ -489,7 +489,7 @@ the object is \tcode{const}~(\ref{dcl.type.cv}).
 
 \rSec2[dcl.fct.spec]{Function specifiers}%
 \indextext{specifier!function}%
-\indextext{function|seealso{friend function; member~function; inline~function; virtual~function}}
+\indextext{function|seealso{friend function; member function; inline function; virtual function}}
 
 \pnum
 \grammarterm{Function-specifiers}
@@ -540,9 +540,9 @@ A name declared with the \tcode{typedef} specifier becomes a
 \grammarterm{typedef-name} is syntactically equivalent to a keyword and
 names the type associated with the identifier in the way described in
 Clause~\ref{dcl.decl}.
-\indextext{declaration!typedef@\tcode{typedef}~as type}%
+\indextext{declaration!typedef@\tcode{typedef} as type}%
 \indextext{equivalence!type}%
-\indextext{synonym!type~name~as}%
+\indextext{synonym!type name as}%
 A \grammarterm{typedef-name} is thus a synonym for another type. A
 \grammarterm{typedef-name} does not introduce a new type the way a class
 declaration~(\ref{class.name}) or enum declaration does.
@@ -661,7 +661,7 @@ class complex { @\tcode{/* ...\ */}@ };    // error: redefinition
 
 \pnum
 \begin{note}
-\indextext{class~name!\idxcode{typedef}}%
+\indextext{class name!\idxcode{typedef}}%
 A \grammarterm{typedef-name} that names a class type, or a cv-qualified
 version thereof, is also a \grammarterm{class-name}~(\ref{class.name}). If
 a \grammarterm{typedef-name} is used to identify the subject of an
@@ -686,8 +686,8 @@ struct T * p;                   // error
 \end{example}
 
 \pnum
-\indextext{class~name!\idxcode{typedef}}%
-\indextext{enum~name!\idxcode{typedef}}%
+\indextext{class name!\idxcode{typedef}}%
+\indextext{enum name!\idxcode{typedef}}%
 \indextext{class!unnamed}%
 If the typedef declaration defines an unnamed class (or enum), the first
 \grammarterm{typedef-name} declared by the declaration to be that class
@@ -977,7 +977,7 @@ or definition of a variable or function.
 
 \pnum
 \indextext{specifier!\idxcode{inline}}%
-\indextext{inline~function}%
+\indextext{inline function}%
 A function declaration~(\ref{dcl.fct},~\ref{class.mfct},
 \ref{class.friend}) with an \tcode{inline} specifier declares an
 \term{inline function}. The inline specifier indicates to
@@ -1025,7 +1025,7 @@ same type in every translation unit.
 \end{note}
 
 \rSec2[dcl.type]{Type specifiers}%
-\indextext{specifier!type|see{type~specifier}}
+\indextext{specifier!type|see{type specifier}}
 
 \pnum
 The type-specifiers are
@@ -1124,8 +1124,8 @@ and
 \rSec3[dcl.type.cv]{The \grammarterm{cv-qualifiers}}%
 \indextext{specifier!cv-qualifier}%
 \indextext{initialization!\idxcode{const}}%
-\indextext{type~specifier!\idxcode{const}}%
-\indextext{type~specifier!\idxcode{volatile}}
+\indextext{type specifier!\idxcode{const}}%
+\indextext{type specifier!\idxcode{volatile}}
 
 \pnum
 There are two \grammarterm{cv-qualifiers}, \tcode{const} and
@@ -1162,7 +1162,7 @@ subverted without casting~(\ref{expr.const.cast}).
 \end{note}
 
 \pnum
-\indextext{const~object@\tcode{const}-object!undefined change~to}%
+\indextext{const object@\tcode{const}-object!undefined change to}%
 Except that any class member declared \tcode{mutable}~(\ref{dcl.stc})
 can be modified, any attempt to modify a \tcode{const} object during its
 lifetime~(\ref{basic.life}) results in undefined behavior.
@@ -1212,7 +1212,7 @@ volatile-qualified type through the use of a glvalue with a
 non-volatile-qualified type, the behavior is undefined.
 
 \pnum
-\indextext{type~specifier!\idxcode{volatile}}%
+\indextext{type specifier!\idxcode{volatile}}%
 \indextext{\idxcode{volatile}!implementation-defined}%
 \begin{note}
 \tcode{volatile} is a hint to the implementation to avoid aggressive
@@ -1226,7 +1226,7 @@ they are in C.
 \end{note}
 
 \rSec3[dcl.type.simple]{Simple type specifiers}%
-\indextext{type~specifier!simple}
+\indextext{type specifier!simple}
 
 \pnum
 The simple type specifiers are
@@ -1268,21 +1268,21 @@ The simple type specifiers are
 \end{bnf}
 
 \pnum
-\indextext{type~specifier!\idxcode{char}}%
-\indextext{type~specifier!\idxcode{char16_t}}%
-\indextext{type~specifier!\idxcode{char32_t}}%
-\indextext{type~specifier!\idxcode{wchar_t}}%
-\indextext{type~specifier!\idxcode{bool}}%
-\indextext{type~specifier!\idxcode{short}}%
-\indextext{type~specifier!\idxcode{int}}%
-\indextext{type~specifier!\idxcode{long}}%
-\indextext{type~specifier!\idxcode{signed}}%
-\indextext{type~specifier!\idxcode{unsigned}}%
-\indextext{type~specifier!\idxcode{float}}%
-\indextext{type~specifier!\idxcode{double}}%
-\indextext{type~specifier!\idxcode{void}}%
-\indextext{type~specifier!\idxcode{auto}}%
-\indextext{type~specifier!\idxcode{decltype}}%
+\indextext{type specifier!\idxcode{char}}%
+\indextext{type specifier!\idxcode{char16_t}}%
+\indextext{type specifier!\idxcode{char32_t}}%
+\indextext{type specifier!\idxcode{wchar_t}}%
+\indextext{type specifier!\idxcode{bool}}%
+\indextext{type specifier!\idxcode{short}}%
+\indextext{type specifier!\idxcode{int}}%
+\indextext{type specifier!\idxcode{long}}%
+\indextext{type specifier!\idxcode{signed}}%
+\indextext{type specifier!\idxcode{unsigned}}%
+\indextext{type specifier!\idxcode{float}}%
+\indextext{type specifier!\idxcode{double}}%
+\indextext{type specifier!\idxcode{void}}%
+\indextext{type specifier!\idxcode{auto}}%
+\indextext{type specifier!\idxcode{decltype}}%
 \indextext{\idxgram{type-name}}%
 \indextext{\idxgram{lambda-introducer}}%
 The \grammarterm{simple-type-specifier} \tcode{auto} is a placeholder for a type to be
@@ -1366,7 +1366,7 @@ forces \tcode{char} objects to be signed; it is redundant in other contexts.
 \end{note}
 
 \pnum
-\indextext{type~specifier!\idxcode{decltype}}%
+\indextext{type specifier!\idxcode{decltype}}%
 For an expression \tcode{e}, the type denoted by \tcode{decltype(e)} is defined as follows:
 
 \begin{itemize}
@@ -1463,9 +1463,9 @@ void r() {
 \end{example}
 
 \rSec3[dcl.type.elab]{Elaborated type specifiers}%
-\indextext{type~specifier!elaborated}%
+\indextext{type specifier!elaborated}%
 \indextext{\idxcode{typename}}%
-\indextext{type~specifier!\idxcode{enum}}
+\indextext{type specifier!\idxcode{enum}}
 
 \begin{bnf}
 \nontermdef{elaborated-type-specifier}\br
@@ -1476,7 +1476,7 @@ void r() {
 \end{bnf}
 
 \pnum
-\indextext{class~name!elaborated}%
+\indextext{class name!elaborated}%
 \indextext{name!elaborated!\idxcode{enum}}%
 An \grammarterm{attribute-specifier-seq} shall not appear in an \grammarterm{elaborated-type-specifier}
 unless the latter is the sole constituent of a declaration.
@@ -1547,7 +1547,7 @@ enum E x = E::a;                // OK
 \end{example}
 
 \rSec3[dcl.spec.auto]{The \tcode{auto} specifier}%
-\indextext{type~specifier!\idxcode{auto}}
+\indextext{type specifier!\idxcode{auto}}
 
 \pnum
 The \tcode{auto} and \tcode{decltype(auto)} \grammarterm{type-specifier}{s}
@@ -1909,7 +1909,7 @@ container e{5, 6};                      // error, \tcode{int} is not an iterator
 \rSec1[dcl.enum]{Enumeration declarations}%
 \indextext{enumeration}%
 \indextext{\idxcode{\{\}}!enum declaration@\tcode{enum} declaration}%
-\indextext{\idxcode{enum}!type~of}
+\indextext{\idxcode{enum}!type of}
 
 \pnum
 An enumeration is a distinct type~(\ref{basic.compound}) with named
@@ -2014,7 +2014,7 @@ An \grammarterm{opaque-enum-declaration} declaring an unscoped enumeration shall
 not omit the \grammarterm{enum-base}.
 The identifiers in an \grammarterm{enumerator-list} are declared as
 constants, and can appear wherever constants are required.
-\indextext{enumerator!value~of}%
+\indextext{enumerator!value of}%
 An \grammarterm{enumerator-definition} with \tcode{=} gives the associated
 \grammarterm{enumerator} the value indicated by the
 \grammarterm{constant-expression}.
@@ -2059,8 +2059,8 @@ inherited nor introduced by a \grammarterm{using-declaration}), and the
 declaration.
 
 \pnum
-\indextext{\idxcode{enum}!type~of}%
-\indextext{\idxcode{enum}!underlying~type|see{type, underlying}}%
+\indextext{\idxcode{enum}!type of}%
+\indextext{\idxcode{enum}!underlying type|see{type, underlying}}%
 Each enumeration defines a type that is different from all other types.
 Each enumeration also has an \defnx{underlying type}{type!underlying!enumeration}.
 The underlying type can be explicitly specified using an \grammarterm{enum-base}.
@@ -2183,7 +2183,7 @@ if (y) { }                      // error: no \tcode{Col} to \tcode{bool} convers
 \end{example}
 
 \pnum
-\indextext{class!scope~of enumerator}%
+\indextext{class!scope of enumerator}%
 Each \grammarterm{enum-name} and each unscoped \grammarterm{enumerator} is
 declared in the scope that immediately contains the \grammarterm{enum-specifier}.
 Each scoped \grammarterm{enumerator} is declared in the scope of the
@@ -2680,7 +2680,7 @@ specifying an enumeration name in a \grammarterm{using-declaration}
 does not declare its enumerators
 in the \grammarterm{using-declaration}{'s} declarative region.
 \end{note}
-\indextext{inheritance!\idxgram{using-declaration}~and}%
+\indextext{inheritance!\idxgram{using-declaration} and}%
 If the \grammarterm{using-declarator} names a constructor,
 it declares that the class \term{inherits} the set of constructor declarations
 introduced by the \grammarterm{using-declarator} from the nominated base class.
@@ -2965,7 +2965,7 @@ void h() {
 \end{note}
 
 \pnum
-\indextext{name~hiding!using-declaration and}%
+\indextext{name hiding!using-declaration and}%
 When a \grammarterm{using-declarator} brings declarations from a base class into
 a derived class, member functions and member function templates in
 the derived class override and/or hide member functions and member
@@ -3397,7 +3397,7 @@ the vintage.
 \indextext{specification!linkage!implementation-defined}%
 Every implementation shall provide for linkage to functions written in
 the C programming language,
-\indextext{C!linkage~to}%
+\indextext{C!linkage to}%
 \tcode{"C"}, and linkage to \Cpp functions, \tcode{"C++"}.
 \begin{example}
 \begin{codeblock}
@@ -3451,7 +3451,7 @@ void f6() {
 }
 \end{codeblock}
 \end{example}
-\indextext{class!linkage~specification}%
+\indextext{class!linkage specification}%
 A C language linkage is ignored
 in determining the language linkage of
 the names of class members and the
@@ -3489,7 +3489,7 @@ namespace or declare objects with the same name to be members of the same
 namespace and the declarations give the names different language linkages, the
 program is ill-formed; no diagnostic is required if the declarations appear in
 different translation units.
-\indextext{consistency!linkage~specification}%
+\indextext{consistency!linkage specification}%
 Except for functions with \Cpp linkage, a function declaration without a
 linkage specification shall not precede the first linkage specification
 for that function. A function can be declared without a linkage
@@ -3498,7 +3498,7 @@ linkage explicitly specified in the earlier declaration is not affected
 by such a function declaration.
 
 \pnum
-\indextext{function!linkage~specification overloaded}%
+\indextext{function!linkage specification overloaded}%
 At most one function with a particular name can have C language linkage.
 Two declarations for a function with C language linkage with the same
 function name (ignoring the namespace names that qualify it) that appear
@@ -3572,7 +3572,7 @@ which the resulting lvalue refers is considered a C function.
 \end{note}
 
 \pnum
-\indextext{object!linkage~specification}%
+\indextext{object!linkage specification}%
 \indextext{linkage!implementation-defined object}%
 Linkage from \Cpp to objects defined in other languages and to objects
 defined in \Cpp from other languages is implemen\-tation-defined and

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -4,7 +4,7 @@
 
 \gramSec[gram.decl]{Declarators}
 
-\indextext{initialization!class~object|seealso{constructor}}%
+\indextext{initialization!class object|seealso{constructor}}%
 \indextext{\idxcode{*}|see{declarator, pointer}}
 \indextext{\idxcode{\&}|see{declarator, reference}}%
 \indextext{\idxcode{::*}|see{declarator, pointer to member}}%
@@ -162,7 +162,7 @@ Declarators have the syntax
 \rSec1[dcl.name]{Type names}
 
 \pnum
-\indextext{type~name}%
+\indextext{type name}%
 To specify type conversions explicitly,
 \indextext{operator!cast}%
 and as an argument of
@@ -228,7 +228,7 @@ The named type is then the same as the type of the
 hypothetical identifier.
 \begin{example}
 
-\indextext{example!type~name}%
+\indextext{example!type name}%
 \indextext{example!declarator}%
 \begin{codeblock}
 int                 // \tcode{int i}
@@ -261,8 +261,8 @@ A type can also be named (often more easily) by using a
 (\ref{dcl.typedef}).
 
 \rSec1[dcl.ambig.res]{Ambiguity resolution}%
-\indextext{ambiguity!declaration~versus cast}%
-\indextext{declaration!parentheses~in}
+\indextext{ambiguity!declaration versus cast}%
+\indextext{declaration!parentheses in}
 
 \pnum
 The ambiguity arising from the similarity between a function-style cast and
@@ -373,7 +373,7 @@ void h(int *(C[10]));           // \tcode{void h(int *(*_fp)(C _parm[10]));}
 \end{example}
 
 \rSec1[dcl.meaning]{Meaning of declarators}%
-\indextext{declarator!meaning~of|(}
+\indextext{declarator!meaning of|(}
 
 \pnum
 \indextext{declaration!type}%
@@ -514,7 +514,7 @@ in the declaration
 T D1
 \end{codeblock}
 
-\indextext{declaration!parentheses~in}%
+\indextext{declaration!parentheses in}%
 Parentheses do not alter the type of the embedded
 \grammarterm{declarator-id},
 but they can alter the binding of complex declarators.
@@ -544,7 +544,7 @@ then the type of the identifier of
 is ``\nonterminal{derived-declarator-type-list cv-qualifier-seq} pointer to
 \tcode{T}''.
 \indextext{declaration!pointer}%
-\indextext{declaration!constant~pointer}%
+\indextext{declaration!constant pointer}%
 The
 \grammarterm{cv-qualifier}{s}
 apply to the pointer and not to the object pointed to.
@@ -686,8 +686,8 @@ is ill-formed.
 
 
 \pnum
-\indextext{lvalue~reference}%
-\indextext{rvalue~reference}%
+\indextext{lvalue reference}%
+\indextext{rvalue reference}%
 A reference type that is declared using \tcode{\&} is called an
 \term{lvalue reference}, and a reference type that
 is declared using \tcode{\&\&} is called an
@@ -861,7 +861,7 @@ pointer-to-member.
 
 \pnum
 \begin{example}%
-\indextext{example!pointer~to~member}
+\indextext{example!pointer to member}
 
 \begin{codeblock}
 struct X {
@@ -981,7 +981,7 @@ expression of type \tcode{std\colcol{}size_t} and
 its value shall be greater than zero.
 The constant expression specifies the
 \indextext{array!bound}%
-\indextext{bound,~of~array}%
+\indextext{bound, of array}%
 \term{bound}
 of (number of elements in) the array.
 If the value of the constant expression is
@@ -1068,7 +1068,7 @@ when the declarator is followed by an
 when a declarator for a static data member is followed by a
 \grammarterm{brace-or-equal-initializer}~(\ref{class.mem}).
 In both cases the bound is calculated from the number
-\indextext{array~size!default}%
+\indextext{array size!default}%
 of initial elements (say,
 \tcode{N})
 supplied
@@ -1236,7 +1236,7 @@ again; this time the result is an integer.
 \begin{note}
 It follows from all this that arrays in \Cpp are stored
 row-wise (last subscript varies fastest)
-\indextext{array!storage~of}%
+\indextext{array!storage of}%
 and that the first subscript in the declaration helps determine
 the amount of storage consumed by an array
 but plays no other part in subscript calculations.
@@ -1363,7 +1363,7 @@ the
 is used to convert the arguments specified on the function call;
 see~\ref{expr.call}.
 \end{note}
-\indextext{argument~list!empty}%
+\indextext{argument list!empty}%
 If the
 \grammarterm{parameter-declaration-clause}
 is empty, the function takes no arguments.
@@ -1375,11 +1375,11 @@ Except for this special case, a parameter shall not have type \term{cv}
 \tcode{void}.
 If the
 \grammarterm{parameter-declaration-clause}
-\indextext{argument~type!unknown}%
+\indextext{argument type!unknown}%
 \indextext{\idxcode{...}|see{ellipsis}}%
-\indextext{declaration!ellipsis~in function}%
-\indextext{argument~list!variable}%
-\indextext{parameter~list!variable}%
+\indextext{declaration!ellipsis in function}%
+\indextext{argument list!variable}%
+\indextext{parameter list!variable}%
 terminates with an ellipsis or a function parameter
 pack~(\ref{temp.variadic}), the number of arguments shall be equal
 to or greater than the number of parameters that do not have a default
@@ -1391,7 +1391,7 @@ is synonymous with
 ``\tcode{...}''.
 \begin{example}
 \indextext{example!ellipsis}%
-\indextext{example!variable parameter~list}%
+\indextext{example!variable parameter list}%
 the declaration
 
 \begin{codeblock}
@@ -1432,9 +1432,9 @@ determined from its own
 and
 \grammarterm{declarator}.
 After determining the type of each parameter, any parameter
-\indextext{array!parameter~of~type}%
+\indextext{array!parameter of type}%
 of type ``array of \tcode{T}'' or
-\indextext{function!parameter~of~type}%
+\indextext{function!parameter of type}%
 of function type \tcode{T}
 is adjusted to be ``pointer to \tcode{T}''.
 After producing the list of parameter types,
@@ -1526,8 +1526,8 @@ and returning
 \end{example}
 
 \pnum
-\indextext{function~return~type|see{return~type}}%
-\indextext{return~type}%
+\indextext{function return type|see{return type}}%
+\indextext{return type}%
 Functions shall not have a return type of type array or function,
 although they may have a return type of type pointer or reference to such things.
 There shall be no arrays of functions, although there can be arrays of pointers
@@ -1705,7 +1705,7 @@ is used as a default argument.
 Default arguments will be used in calls where trailing arguments are missing.
 
 \pnum
-\indextext{argument!example~of default}%
+\indextext{argument!example of default}%
 \begin{example}
 the declaration
 
@@ -1805,9 +1805,9 @@ that declaration shall be a definition and shall be the only
 declaration of the function or function template in the translation unit.
 
 \pnum
-\indextext{argument!type~checking~of default}%
-\indextext{argument!binding~of default}%
-\indextext{argument!evaluation~of default}%
+\indextext{argument!type checking of default}%
+\indextext{argument!binding of default}%
+\indextext{argument!evaluation of default}%
 The default argument has the
 same semantic constraints as the initializer in a
 declaration of a variable of the parameter type, using the
@@ -1820,7 +1820,7 @@ arguments in function templates and in member functions of
 class templates are performed as described in~\ref{temp.inst}.
 \begin{example}
 in the following code,
-\indextext{argument!example~of default}%
+\indextext{argument!example of default}%
 \tcode{g}
 will be called with the value
 \tcode{f(2)}:
@@ -1906,13 +1906,13 @@ class A {
 \end{note}
 
 \pnum
-\indextext{argument!evaluation~of default}%
+\indextext{argument!evaluation of default}%
 A default argument is evaluated each time the function is called
 with no argument for the corresponding parameter.
-\indextext{argument!scope~of default}%
+\indextext{argument!scope of default}%
 A parameter shall not appear as a potentially-evaluated expression
 in a default argument.
-\indextext{argument~and~name~hiding!default}%
+\indextext{argument and name hiding!default}%
 Parameters of a function declared before a default argument
 are in scope and can hide namespace and class member names.
 \begin{example}
@@ -1982,7 +1982,7 @@ the redeclaration where the
 is in scope.
 
 \pnum
-\indextext{argument~and~virtual~function!default}%
+\indextext{argument and virtual function!default}%
 A virtual function call (\ref{class.virtual}) uses the default
 arguments in the declaration of the virtual function determined
 by the static type of the pointer or reference denoting the
@@ -2007,7 +2007,7 @@ void m() {
 \end{codeblock}
 \end{example}%
 \indextext{declaration!default argument|)}%
-\indextext{declarator!meaning~of|)}
+\indextext{declarator!meaning of|)}
 
 \rSec1[dcl.fct.def]{Function definitions}%
 \indextext{definition!function|(}
@@ -2078,7 +2078,7 @@ is the
 \end{example}
 
 \pnum
-\indextext{initializer!base~class}%
+\indextext{initializer!base class}%
 \indextext{initializer!member}%
 \indextext{definition!constructor}%
 A
@@ -2686,7 +2686,7 @@ is permitted in certain other initialization contexts (\ref{expr.new},
 
 \pnum
 \indextext{value!indeterminate}%
-\indextext{indeterminate~value}%
+\indextext{indeterminate value}%
 If no initializer is specified for an object, the object is default-initialized.
 When storage for an object with automatic or dynamic storage duration
 is obtained, the object has an \term{indeterminate value}, and if
@@ -2736,7 +2736,7 @@ value.
 \end{example}
 
 \pnum
-\indextext{initialization!class~member}%
+\indextext{initialization!class member}%
 An initializer for a static member is in the scope of the member's class.
 \begin{example}
 
@@ -2926,10 +2926,10 @@ or by an inherited constructor~(\ref{class.inhctor.init}).
 \rSec2[dcl.init.aggr]{Aggregates}%
 \indextext{aggregate}%
 \indextext{initialization!aggregate}%
-\indextext{aggregate~initialization}%
+\indextext{aggregate initialization}%
 \indextext{initialization!array}%
-\indextext{initialization!class~object}%
-\indextext{class~object~initialization|see{constructor}}%
+\indextext{initialization!class object}%
+\indextext{class object initialization|see{constructor}}%
 \indextext{\idxcode{\{\}}!initializer list}
 
 \pnum
@@ -3337,7 +3337,7 @@ returns.
 \end{example}
 
 \pnum
-\indextext{initialization!array~of class~objects}%
+\indextext{initialization!array of class objects}%
 \begin{note}
 An aggregate array or an aggregate class may contain elements of a
 class type with a user-provided constructor (\ref{class.ctor}).
@@ -3391,7 +3391,7 @@ narrow string literal, \tcode{char16_t} string literal, \tcode{char32_t} string
 literal, or wide string literal,
 respectively, or by an appropriately-typed string literal enclosed in
 braces~(\ref{lex.string}).
-\indextext{initialization!character~array}%
+\indextext{initialization!character array}%
 Successive
 characters of the
 value of the string literal
@@ -3464,9 +3464,9 @@ A reference cannot be changed to refer to another object after initialization.
 \begin{note}
 Assignment to a reference assigns to the object referred to by the reference (\ref{expr.ass}).
 \end{note}
-\indextext{argument~passing!reference~and}%
+\indextext{argument passing!reference and}%
 Argument passing (\ref{expr.call})
-\indextext{\idxcode{return}!reference~and}%
+\indextext{\idxcode{return}!reference and}%
 and function value return (\ref{stmt.return}) are initializations.
 
 \pnum

--- a/source/derived.tex
+++ b/source/derived.tex
@@ -1,17 +1,17 @@
 %!TEX root = std.tex
 \rSec0[class.derived]{Derived classes}%
-\indextext{derived~class|(}
+\indextext{derived class|(}
 
 \gramSec[gram.derived]{Derived classes}
 
-\indextext{virtual~base~class|see{base~class, virtual}}
-\indextext{function, virtual|see{virtual~function}}
-\indextext{dynamic binding|see{virtual~function}}
+\indextext{virtual base class|see{base class, virtual}}
+\indextext{function, virtual|see{virtual function}}
+\indextext{dynamic binding|see{virtual function}}
 
 \pnum
-\indextext{base~class}%
+\indextext{base class}%
 \indextext{inheritance}%
-\indextext{multiple~inheritance}%
+\indextext{multiple inheritance}%
 A list of base classes can be specified in a class definition using
 the notation:
 
@@ -45,7 +45,7 @@ the notation:
     class-or-decltype
 \end{bnf}
 
-\indextext{specifier~access|see{access~specifier}}%
+\indextext{specifier access|see{access specifier}}%
 %
 \begin{bnf}
 \nontermdef{access-specifier}\br
@@ -62,17 +62,17 @@ The type denoted by a \grammarterm{base-type-specifier} shall be
 a class type that is not
 an
 incompletely defined class (Clause~\ref{class}); this class is called a
-\indextext{base~class!direct}%
+\indextext{base class!direct}%
 \term{direct base class}
 for the class being defined.
-\indextext{base~class}%
+\indextext{base class}%
 \indextext{derivation|see{inheritance}}%
 During the lookup for a base class name, non-type names are
 ignored~(\ref{basic.scope.hiding}). If the name found is not a
 \grammarterm{class-name}, the program is ill-formed. A class \tcode{B} is a
 base class of a class \tcode{D} if it is a direct base class of
 \tcode{D} or a direct base class of one of \tcode{D}'s base classes.
-\indextext{base~class!indirect}%
+\indextext{base class!indirect}%
 A class is an \term{indirect} base class of another if it is a base
 class but not a direct base class. A class is said to be (directly or
 indirectly) \term{derived} from its (direct or indirect) base
@@ -81,7 +81,7 @@ classes.
 See Clause~\ref{class.access} for the meaning of
 \grammarterm{access-specifier}.
 \end{note}
-\indextext{access control!base~class member}%
+\indextext{access control!base class member}%
 Unless redeclared in the derived class, members of a base class are also
 considered to be members of the derived class.
 Members of a base class other than constructors are said to be
@@ -92,7 +92,7 @@ can also be inherited as described in~\ref{namespace.udecl}.
 Inherited members can be referred to in
 expressions in the same manner as other members of the derived class,
 unless their names are hidden or ambiguous~(\ref{class.member.lookup}).
-\indextext{operator!scope~resolution}%
+\indextext{operator!scope resolution}%
 \begin{note}
 The scope resolution operator \tcode{::}~(\ref{expr.prim}) can be used
 to refer to a direct or indirect base member explicitly. This allows
@@ -110,7 +110,7 @@ The \grammarterm{base-specifier-list} specifies the type of the
 \term{base class subobjects} contained in an
 object of the derived class type.
 \begin{example}
-\indextext{example!derived~class}%
+\indextext{example!derived class}%
 \begin{codeblock}
 struct Base {
   int a, b, c;
@@ -142,7 +142,7 @@ expansion~(\ref{temp.variadic}).
 The order in which the base class subobjects are allocated in the most
 derived object~(\ref{intro.object}) is unspecified.
 \begin{note}
-\indextext{directed~acyclic~graph|see{DAG}}%
+\indextext{directed acyclic graph|see{DAG}}%
 \indextext{lattice|see{DAG, subobject}}%
 a derived class and its base class subobjects can be represented by a
 directed acyclic graph (DAG) where an arrow means ``directly derived
@@ -178,8 +178,8 @@ address~(\ref{expr.eq}).
 \end{note}
 
 \rSec1[class.mi]{Multiple base classes}
-\indextext{multiple~inheritance}%
-\indextext{base~class}%
+\indextext{multiple inheritance}%
+\indextext{base class}%
 
 \pnum
 A class can be derived from any number of base classes.
@@ -196,8 +196,8 @@ class D : public A, public B, public C { /* ... */ };
 \end{example}
 
 \pnum
-\indextext{layout!class~object}%
-\indextext{initialization!order~of}%
+\indextext{layout!class object}%
+\indextext{initialization!order of}%
 \begin{note}
 The order of derivation is not significant except as specified by the
 semantics of initialization by constructor~(\ref{class.base.init}),
@@ -232,7 +232,7 @@ class D : public A, public L { void f(); /* ... */ };   // well-formed
 \end{example}
 
 \pnum
-\indextext{base~class!virtual}%
+\indextext{base class!virtual}%
 A base class specifier that does not contain the keyword
 \tcode{virtual}, specifies a \grammarterm{non-virtual} base class. A base
 class specifier that contains the keyword \tcode{virtual}, specifies a
@@ -281,8 +281,8 @@ type \tcode{V} is shared by every base subobject of \tcode{c} that has a
 defined above, an object of class \tcode{C} will have one subobject of
 class \tcode{V}, as shown in Figure~\ref{fig:virt}.
 
-\indextext{DAG!multiple~inheritance}%
-\indextext{DAG!virtual~base~class}%
+\indextext{DAG!multiple inheritance}%
+\indextext{DAG!virtual base class}%
 \begin{importgraphic}
 {Virtual base}
 {fig:virt}
@@ -310,9 +310,9 @@ class \tcode{AA} defined above, class \tcode{AA} has two subobjects of
 class \tcode{B}: \tcode{Z}'s \tcode{B} and the virtual \tcode{B} shared
 by \tcode{X} and \tcode{Y}, as shown in Figure~\ref{fig:virtnonvirt}.
 
-\indextext{DAG!virtual~base~class}%
-\indextext{DAG!non-virtual~base~class}%
-\indextext{DAG!multiple~inheritance}%
+\indextext{DAG!virtual base class}%
+\indextext{DAG!non-virtual base class}%
+\indextext{DAG!multiple inheritance}%
 \begin{importgraphic}
 {Virtual and non-virtual base}
 {fig:virtnonvirt}
@@ -323,7 +323,7 @@ by \tcode{X} and \tcode{Y}, as shown in Figure~\ref{fig:virtnonvirt}.
 
 \rSec1[class.member.lookup]{Member name lookup}%
 \indextext{lookup!member name}%
-\indextext{ambiguity!base~class~member}%
+\indextext{ambiguity!base class member}%
 \indextext{ambiguity!member access}
 
 \pnum
@@ -424,12 +424,12 @@ $S(x,D)$ is discarded in the first merge step.
 \end{example}
 
 \pnum
-\indextext{access control!overload~resolution~and}%
+\indextext{access control!overload resolution and}%
 If the name of an overloaded function is unambiguously found,
 overload resolution~(\ref{over.match}) also takes place before access
 control.
-\indextext{example!scope~resolution operator}%
-\indextext{example!explicit~qualification}%
+\indextext{example!scope resolution operator}%
+\indextext{example!explicit qualification}%
 \indextext{overloading!resolution!scoping ambiguity}%
 Ambiguities can often be resolved by qualifying a name with its class name.
 \begin{example}
@@ -484,7 +484,7 @@ void f(D* pd) {
 
 \pnum
 \begin{note}
-\indextext{dominance!virtual~base~class}%
+\indextext{dominance!virtual base class}%
 When virtual base classes are used, a hidden declaration can be reached
 along a path through the subobject lattice that does not pass through
 the hiding declaration. This is not an ambiguity. The identical use with
@@ -582,7 +582,7 @@ struct D: I1, I2, B2 {
 \end{codeblock}\end{example}
 
 \rSec1[class.virtual]{Virtual functions}%
-\indextext{virtual~function|(}%
+\indextext{virtual function|(}%
 \indextext{type!polymorphic}%
 \indextext{class!polymorphic}
 
@@ -734,7 +734,7 @@ final overrider of the overridden function, its result is converted to
 the type returned by the (statically chosen) overridden
 function~(\ref{expr.call}).
 \begin{example}
-\indextext{example!virtual~function}%
+\indextext{example!virtual function}%
 \begin{codeblock}
 class B { };
 class D : private B { friend class Derived; };
@@ -798,17 +798,17 @@ another class.
 \end{note}
 
 \pnum
-\indextext{definition!virtual~function}%
+\indextext{definition!virtual function}%
 A virtual function declared in a class shall be defined, or declared
 pure~(\ref{class.abstract}) in that class, or both; no diagnostic is
 required~(\ref{basic.def.odr}).
-\indextext{friend!\tcode{virtual}~and}%
+\indextext{friend!\tcode{virtual} and}%
 
 \pnum
-\indextext{multiple~inheritance!\tcode{virtual}~and}%
+\indextext{multiple inheritance!\tcode{virtual} and}%
 \begin{example}
 here are some uses of virtual functions with multiple base classes:
-\indextext{example!virtual~function}%
+\indextext{example!virtual function}%
 \begin{codeblock}
 struct A {
   virtual void f();
@@ -885,8 +885,8 @@ void foe() {
 \end{example}
 
 \pnum
-\indextext{operator!scope~resolution}%
-\indextext{virtual~function~call}%
+\indextext{operator!scope resolution}%
+\indextext{virtual function call}%
 Explicit qualification with the scope operator~(\ref{expr.prim})
 suppresses the virtual call mechanism.
 \begin{example}
@@ -910,7 +910,7 @@ A function with a deleted definition~(\ref{dcl.fct.def}) shall
 not override a function that does not have a deleted definition. Likewise,
 a function that does not have a deleted definition shall not override a
 function with a deleted definition.%
-\indextext{virtual~function|)}
+\indextext{virtual function|)}
 
 \rSec1[class.abstract]{Abstract classes}%
 \indextext{class!abstract}
@@ -932,16 +932,16 @@ abstract if it has at least one \term{pure virtual function}.
 \begin{note}
 Such a function might be inherited: see below.
 \end{note}
-\indextext{virtual~function!pure}%
+\indextext{virtual function!pure}%
 A virtual function is specified \term{pure} by using a
 \grammarterm{pure-specifier}~(\ref{class.mem}) in the function declaration
 in the class definition.
-\indextext{definition!pure virtual~function}%
+\indextext{definition!pure virtual function}%
 A pure virtual function need be defined only if called with, or as if
 with~(\ref{class.dtor}), the \grammarterm{qualified-id}
 syntax~(\ref{expr.prim}).
 \begin{example}
-\indextext{example!pure virtual~function}%
+\indextext{example!pure virtual function}%
 \begin{codeblock}
 class point { /* ... */ };
 class shape {                   // abstract class
@@ -967,7 +967,7 @@ struct C {
 \end{example}
 
 \pnum
-\indextext{class!pointer~to abstract}%
+\indextext{class!pointer to abstract}%
 An abstract class shall not be used as a parameter type, as a function
 return type, or as the type of an explicit conversion. Pointers and
 references to an abstract class can be declared.
@@ -982,7 +982,7 @@ shape& h(shape&);               // OK
 \end{example}
 
 \pnum
-\indextext{virtual~function!pure}%
+\indextext{virtual function!pure}%
 A class is abstract if it contains or inherits at least one pure virtual
 function for which the final overrider is pure virtual.
 \begin{example}
@@ -1018,11 +1018,11 @@ pure.
 \end{note}
 
 \pnum
-\indextext{class!constructor~and abstract}%
+\indextext{class!constructor and abstract}%
 Member functions can be called from a constructor (or destructor) of an
 abstract class;
-\indextext{virtual~function~call!undefined pure}%
+\indextext{virtual function call!undefined pure}%
 the effect of making a virtual call~(\ref{class.virtual}) to a pure
 virtual function directly or indirectly for the object being created (or
 destroyed) from such a constructor (or destructor) is undefined.%
-\indextext{derived~class|)}
+\indextext{derived class|)}

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -360,8 +360,8 @@ Consequently, destructors should generally catch exceptions and not let them pro
 
 \rSec1[except.ctor]{Constructors and destructors}%
 \indextext{exception handling!constructors and destructors}%
-\indextext{constructor!exception~handling|see{exception handling, constructors and destructors}}%
-\indextext{destructor!exception~handling|see{exception handling, constructors and destructors}}
+\indextext{constructor!exception handling|see{exception handling, constructors and destructors}}%
+\indextext{destructor!exception handling|see{exception handling, constructors and destructors}}
 
 \pnum
 \indextext{unwinding!stack}%
@@ -473,9 +473,9 @@ or
 
 \pnum
 A handler of type
-\indextext{array!handler~of~type}%
+\indextext{array!handler of type}%
 ``array of \tcode{T}'' or
-\indextext{function!handler~of~type}%
+\indextext{function!handler of type}%
 function type \tcode{T}
 is adjusted to be of type
 ``pointer to \tcode{T}''.

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1145,7 +1145,7 @@ void f2() {
 \end{example}
 
 \pnum
-An entity is \defnx{captured by copy}{captured!by~copy} if
+An entity is \defnx{captured by copy}{captured!by copy} if
 \begin{itemize}
 \item
 it is implicitly captured,
@@ -1192,7 +1192,7 @@ void g() {
 \end{example}
 
 \pnum
-An entity is \defnx{captured by reference}{captured!by~reference} if it is implicitly or explicitly
+An entity is \defnx{captured by reference}{captured!by reference} if it is implicitly or explicitly
 captured but not captured by copy. It is unspecified whether additional unnamed
 non-static data members are declared in the closure type for entities captured by
 reference.
@@ -1495,7 +1495,7 @@ function is non-virtual, or if the \grammarterm{id-expression} in the class
 member access expression is a \grammarterm{qualified-id}, that function is
 called. Otherwise, its final overrider~(\ref{class.virtual}) in the dynamic type
 of the object expression is called; such a call is referred to as a
-\defnx{virtual function call}{function!virtual function~call}.
+\defnx{virtual function call}{function!virtual function call}.
 \begin{note}
 The dynamic type is the type of the object referred to by the
 current value of the object expression. \ref{class.cdtor}~describes the
@@ -2530,7 +2530,7 @@ type. \begin{note} That is, for lvalues, a reference cast
 temporary is created, no copy is made, and
 constructors~(\ref{class.ctor}) or conversion
 functions~(\ref{class.conv}) are not called.\footnote{This
-is sometimes referred to as a \defnx{type pun}{type~pun}.}
+is sometimes referred to as a \defnx{type pun}{type pun}.}
 
 \rSec2[expr.const.cast]{Const cast}
 
@@ -3307,7 +3307,7 @@ padding necessary to align the allocated objects within the allocated memory.
 \indextext{new-expression@\grammarterm{new-expression}!placement}%
 The \grammarterm{new-placement} syntax is used to supply additional
 arguments to an allocation function; such an expression is called
-a \defnx{placement \grammarterm{new-expression}}{placement~new-expression@placement \grammarterm{new-expression}}{.}
+a \defnx{placement \grammarterm{new-expression}}{placement new-expression@placement \grammarterm{new-expression}}{.}
 
 \pnum
 Overload resolution is
@@ -4871,7 +4871,7 @@ during translation.\end{note}
 
 \pnum
 A \grammarterm{conditional-expression} \tcode{e} is a
-\defnx{core constant expression}{expression!core~constant}
+\defnx{core constant expression}{expression!core constant}
 unless the evaluation of \tcode{e}, following the rules of the abstract
 machine~(\ref{intro.execution}), would evaluate one of the following expressions:
 
@@ -5080,7 +5080,7 @@ constexpr int y = h(1);             // OK: initializes \tcode{y} with the value 
 \end{example}
 
 \pnum
-An \defnx{integral constant expression}{expression!integral~constant}
+An \defnx{integral constant expression}{expression!integral constant}
 is an expression of integral or
 unscoped enumeration type, implicitly converted to a prvalue, where the converted expression is a core constant expression.
 \begin{note}
@@ -5091,7 +5091,7 @@ and as alignments~(\ref{dcl.align}).
 \end{note}
 
 \pnum
-A \defnx{converted constant expression}{expression!converted~constant}
+A \defnx{converted constant expression}{expression!converted constant}
 of type \tcode{T} is an
 expression, implicitly converted to type \tcode{T}, where
 the converted expression is a constant expression and the
@@ -5152,7 +5152,7 @@ satisfies the following constraints:
   each subobject satisfies these constraints for the value.
 \end{itemize}
 An entity is a
-\defnx{permitted result of a constant expression}{constant expression!permitted result~of}
+\defnx{permitted result of a constant expression}{constant expression!permitted result of}
 if it is an
 object with static storage duration that is either not a temporary object or is
 a temporary object whose value satisfies the above constraints, or it is a

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2530,7 +2530,7 @@ type. \begin{note} That is, for lvalues, a reference cast
 temporary is created, no copy is made, and
 constructors~(\ref{class.ctor}) or conversion
 functions~(\ref{class.conv}) are not called.\footnote{This
-is sometimes referred to as a \defnx{type pun}{type pun}.}
+is sometimes referred to as a \defn{type pun}.}
 
 \rSec2[expr.const.cast]{Const cast}
 

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -85,7 +85,7 @@ If a prvalue initially has the type ``\cv{} \tcode{T}'', where
 the expression is adjusted to \tcode{T} prior to any further analysis.
 
 \pnum
-\indextext{expression!rvalue~reference}%
+\indextext{expression!rvalue reference}%
 \begin{note}
 An expression is an xvalue if it is:
 \begin{itemize}
@@ -505,16 +505,16 @@ it is a bit-field if the identifier designates a bit-field~(\ref{dcl.decomp}).
 
 \rSec3[expr.prim.id.qual]{Qualified names}
 
-\indextext{operator!scope~resolution}%
-\indextext{\idxcode{::}|see{scope~resolution~operator}}%
+\indextext{operator!scope resolution}%
+\indextext{\idxcode{::}|see{scope resolution operator}}%
 %
 \begin{bnf}
 \nontermdef{qualified-id}\br
     nested-name-specifier \terminal{template}\opt unqualified-id
 \end{bnf}
 
-\indextext{operator!scope~resolution}%
-\indextext{name~hiding}%
+\indextext{operator!scope resolution}%
+\indextext{name hiding}%
 %
 \begin{bnf}
 \nontermdef{nested-name-specifier}\br
@@ -1459,9 +1459,9 @@ A \grammarterm{braced-init-list} shall not be used with the built-in subscript o
 \rSec2[expr.call]{Function call}
 
 \pnum
-\indextext{expression!function~call}%
-\indextext{operator!function~call}%
-\indextext{\idxcode{()}|see{operator, function~call}}%
+\indextext{expression!function call}%
+\indextext{operator!function call}%
+\indextext{\idxcode{()}|see{operator, function call}}%
 A function call is a postfix expression followed by parentheses
 containing a possibly empty, comma-separated list of
 \grammarterm{initializer-clause}{s} which
@@ -1523,8 +1523,8 @@ This return type shall be an object type, a reference type or \cv{}
 \tcode{void}.
 
 \pnum
-\indextext{function~argument|see{argument}}%
-\indextext{function~parameter|see{parameter}}%
+\indextext{function argument|see{argument}}%
+\indextext{function parameter|see{parameter}}%
 \indextext{initialization!parameter}%
 When a function is called, each parameter~(\ref{dcl.fct}) shall be
 initialized~(\ref{dcl.init},~\ref{class.copy},~\ref{class.ctor}) with
@@ -1564,9 +1564,9 @@ this handler is not considered.
 \end{example}
 
 \pnum
-\indextext{evaluation!order~of argument}%
-\indextext{evaluation!unspecified order~of function~call}%
-\indextext{evaluation!unspecified order~of argument}%
+\indextext{evaluation!order of argument}%
+\indextext{evaluation!unspecified order of function call}%
+\indextext{evaluation!unspecified order of argument}%
 The \grammarterm{postfix-expression} is sequenced before
 each \grammarterm{expression} in the \grammarterm{expression-list}
 and any default argument.
@@ -1620,11 +1620,11 @@ converted to the return type of the statically chosen function.
 
 \pnum
 \begin{note}
-\indextext{type~checking!argument}%
-\indextext{function~call}%
-\indextext{argument~passing}%
-\indextext{value!call~by}%
-\indextext{reference!call~by}%
+\indextext{type checking!argument}%
+\indextext{function call}%
+\indextext{argument passing}%
+\indextext{value!call by}%
+\indextext{reference!call by}%
 \indextext{argument!reference}%
 a function can change the values of its non-const parameters, but these
 changes cannot affect the values of the arguments except where a
@@ -1639,8 +1639,8 @@ pointer parameters.
 \end{note}
 
 \pnum
-\indextext{declaration!ellipsis~in function}%
-\indextext{parameter~list!variable}%
+\indextext{declaration!ellipsis in function}%
+\indextext{parameter list!variable}%
 A function can be declared to accept fewer arguments (by declaring default
 arguments~(\ref{dcl.fct.default})) or more arguments (by using the ellipsis,
 \tcode{...}, or a function parameter pack~(\ref{dcl.fct})) than the number of
@@ -1651,7 +1651,7 @@ parameter pack is used, a parameter is available for each argument.
 \end{note}
 
 \pnum
-\indextext{ellipsis!conversion~sequence}%
+\indextext{ellipsis!conversion sequence}%
 When there is no parameter for a given argument, the argument is passed
 in such a way that the receiving function can obtain the value of the
 argument by invoking \tcode{va_arg}~(\ref{support.runtime}).
@@ -1680,7 +1680,7 @@ promoted type before the call. These promotions are referred to as
 the \defnx{default argument promotions}{promotion!default argument promotion}.
 
 \pnum
-\indextext{function~call!recursive}%
+\indextext{function call!recursive}%
 Recursive calls are permitted, except to the \tcode{main}
 function~(\ref{basic.start.main}).
 
@@ -1694,9 +1694,9 @@ otherwise.
 
 \pnum
 \indextext{expression!cast}%
-\indextext{explicit~type~conversion|see{casting}}%
-\indextext{type~conversion,~explicit|see{casting}}%
-\indextext{conversion~explicit~type|see{casting}}%
+\indextext{explicit type conversion|see{casting}}%
+\indextext{type conversion, explicit|see{casting}}%
+\indextext{conversion explicit type|see{casting}}%
 \indextext{casting}%
 A \grammarterm{simple-type-specifier}~(\ref{dcl.type.simple}) or
 \grammarterm{typename-specifier}~(\ref{temp.res}) followed
@@ -1733,8 +1733,8 @@ For an expression of the form \tcode{T()},
 \rSec2[expr.pseudo]{Pseudo destructor call}
 
 \pnum
-\indextext{expression!pseudo-destructor~call}%
-\indextext{call!pseudo~destructor}%
+\indextext{expression!pseudo-destructor call}%
+\indextext{call!pseudo destructor}%
 \indextext{pseudo-destructor-name}%
 The use of a \grammarterm{pseudo-destructor-name} after a dot \tcode{.} or
 arrow \tcode{->} operator represents the destructor for the non-class
@@ -1762,16 +1762,16 @@ shall designate the same scalar type (ignoring cv-qualification).
 \rSec2[expr.ref]{Class member access}
 
 \pnum
-\indextext{expression!class~member~access}%
+\indextext{expression!class member access}%
 \indextext{access control!class member}%
-\indextext{syntax!class~member}%
-\indextext{semantics!class~member}%
-\indextext{operator!class~member~access}%
-\indextext{\idxcode{.}|see{operator, class~member~access}}%
-\indextext{dot~operator|see{operator, class~member~access}}%
-\indextext{operator!class~member~access}%
-\indextext{\idxcode{->}|see{operator, class~member~access}}%
-\indextext{arrow~operator|see{operator, class~member~access}}%
+\indextext{syntax!class member}%
+\indextext{semantics!class member}%
+\indextext{operator!class member access}%
+\indextext{\idxcode{.}|see{operator, class member access}}%
+\indextext{dot operator|see{operator, class member access}}%
+\indextext{operator!class member access}%
+\indextext{\idxcode{->}|see{operator, class member access}}%
+\indextext{arrow operator|see{operator, class member access}}%
 A postfix expression followed by a dot \tcode{.} or an arrow \tcode{->},
 optionally followed by the keyword
 \tcode{template}~(\ref{temp.names}), and then followed by an
@@ -1894,7 +1894,7 @@ of the object expression; see~\ref{class.access.base}.
 \indextext{expression!increment}%
 \indextext{operator!increment}%
 \indextext{\idxcode{++}|see{operator, increment}}%
-\indextext{postfix~\tcode{++}}%
+\indextext{postfix \tcode{++}}%
 The value of a postfix \tcode{++} expression is the value of its
 operand.
 \begin{note}
@@ -1928,7 +1928,7 @@ and~\ref{expr.ass}.
 \indextext{expression!decrement}%
 \indextext{operator!decrement}%
 \indextext{\idxcode{\dcr}|see{operator, decrement}}%
-\indextext{postfix~\tcode{\dcr}}%
+\indextext{postfix \tcode{\dcr}}%
 The operand of postfix \tcode{\dcr} is decremented analogously to the
 postfix \tcode{++} operator.
 \begin{note}
@@ -1938,7 +1938,7 @@ For prefix increment and decrement, see~\ref{expr.pre.incr}.
 \rSec2[expr.dynamic.cast]{Dynamic cast}
 
 \pnum
-\indextext{expression!dynamic~cast}%
+\indextext{expression!dynamic cast}%
 \indextext{cast!dynamic}%
 The result of the expression \tcode{dynamic_cast<T>(v)} is the result of
 converting the expression \tcode{v} to type \tcode{T}.
@@ -2068,7 +2068,7 @@ applied to an object under construction or destruction.
 \rSec2[expr.typeid]{Type identification}
 
 \pnum
-\indextext{expression!type~identification}%
+\indextext{expression!type identification}%
 \indextext{\idxcode{typeid}}%
 The result of a \tcode{typeid} expression is an lvalue of static type
 \indextext{\idxcode{type_info}}%
@@ -2155,7 +2155,7 @@ object under construction or destruction.
 \rSec2[expr.static.cast]{Static cast}
 
 \pnum
-\indextext{expression!static~cast}%
+\indextext{expression!static cast}%
 \indextext{cast!static}%
 The result of the expression \tcode{static_cast<T>(v)} is the result of
 converting the expression \tcode{v} to type \tcode{T}.
@@ -2293,8 +2293,8 @@ floating-point type; the result is the same as that of converting from the origi
 value to the floating-point type.
 
 \pnum
-\indextext{enumeration~type!conversion~to}%
-\indextext{enumeration~type!\idxcode{static_cast}!conversion~to}%
+\indextext{enumeration type!conversion to}%
+\indextext{enumeration type!\idxcode{static_cast}!conversion to}%
 A value of integral or enumeration type can be explicitly converted to
 a complete enumeration type. The value is unchanged if the original value is
 within the range of the enumeration values~(\ref{dcl.enum}). Otherwise,
@@ -2305,8 +2305,8 @@ underlying type of the enumeration~(\ref{conv.fpint}), and subsequently to
 the enumeration type.
 
 \pnum
-\indextext{cast!base~class}%
-\indextext{cast!derived~class}%
+\indextext{cast!base class}%
+\indextext{cast!derived class}%
 A prvalue of type ``pointer to \cvqual{cv1} \tcode{B}'', where \tcode{B}
 is a class type, can be converted to a prvalue of type ``pointer to
 \cvqual{cv2} \tcode{D}'', where \tcode{D} is a class derived
@@ -2376,7 +2376,7 @@ bool b = p1 == p2;  // \tcode{b} will have the value \tcode{true}.
 \rSec2[expr.reinterpret.cast]{Reinterpret cast}
 
 \pnum
-\indextext{expression!reinterpret~cast}%
+\indextext{expression!reinterpret cast}%
 \indextext{cast!reinterpret}%
 The result of the expression \tcode{reinterpret_cast<T>(v)} is the
 result of converting the expression \tcode{v} to type \tcode{T}.
@@ -2405,10 +2405,10 @@ representation different from the original value.
 
 \pnum
 \indextext{cast!reinterpret!pointer to integer}%
-\indextext{cast!pointer~to integer}%
+\indextext{cast!pointer to integer}%
 A pointer can be explicitly converted to any integral type large enough
 to hold it.
-\indextext{conversion!implementation~defined pointer integer}%
+\indextext{conversion!implementation defined pointer integer}%
 The mapping function is implementa\-tion-defined.
 \begin{note}
 It is intended to be unsurprising to those who know the addressing
@@ -2420,13 +2420,13 @@ cannot be used to convert a value of any type to the type
 \tcode{std::nullptr_t}. \end{note}
 
 \pnum
-\indextext{cast!reinterpret!integer~to pointer}%
-\indextext{cast!integer~to pointer}%
+\indextext{cast!reinterpret!integer to pointer}%
+\indextext{cast!integer to pointer}%
 A value of integral type or enumeration type can be explicitly converted
 to a pointer. A pointer converted to an integer of sufficient size (if
 any such exists on the implementation) and back to the same pointer type
 will have its original value;
-\indextext{conversion!implementation~defined pointer integer}%
+\indextext{conversion!implementation defined pointer integer}%
 mappings between pointers and integers are otherwise
 \impldef{conversions between pointers and integers}.
 \begin{note} Except as described in \ref{basic.stc.dynamic.safety}, the result of
@@ -2438,7 +2438,7 @@ such a conversion will not be a safely-derived pointer value. \end{note}
 \indextext{cast!undefined pointer-to-function}%
 A function pointer can be explicitly converted
 to a function pointer of a different type.
-\indextext{function~call!undefined}%
+\indextext{function call!undefined}%
 \begin{note}
 The effect of calling a function through a pointer to a function
 type~(\ref{dcl.fct}) that is not the same as the type used in the
@@ -2535,7 +2535,7 @@ is sometimes referred to as a \defn{type pun}.}
 \rSec2[expr.const.cast]{Const cast}
 
 \pnum
-\indextext{expression!const~cast}%
+\indextext{expression!const cast}%
 \indextext{cast!const}%
 The result of the expression \tcode{const_cast<T>(v)} is of type
 \tcode{T}. If \tcode{T} is an lvalue reference to object type, the result is an
@@ -2676,14 +2676,14 @@ Expressions with unary operators group right-to-left.
 \indextext{\idxcode{*}|see{operator, indirection}}%
 \indextext{operator!address-of}%
 \indextext{\idxcode{\&}|see{operator, address-of}}%
-\indextext{operator!unary~minus}%
-\indextext{\idxcode{-}|see{operator, unary~minus}}%
-\indextext{operator!unary~plus}%
-\indextext{\idxcode{+}|see{operator, unary~plus}}%
+\indextext{operator!unary minus}%
+\indextext{\idxcode{-}|see{operator, unary minus}}%
+\indextext{operator!unary plus}%
+\indextext{\idxcode{+}|see{operator, unary plus}}%
 \indextext{operator!logical negation}%
-\indextext{\idxcode{"!}|see{operator, logical~negation}}%
-\indextext{operator!ones'~complement}%
-\indextext{~@\tcode{\tilde}|see{operator, ones'~complement}}%
+\indextext{\idxcode{"!}|see{operator, logical negation}}%
+\indextext{operator!ones' complement}%
+\indextext{~@\tcode{\tilde}|see{operator, ones' complement}}%
 \indextext{operator!increment}%
 \indextext{operator!decrement}%
 %
@@ -2695,7 +2695,7 @@ Expressions with unary operators group right-to-left.
 \rSec2[expr.unary.op]{Unary operators}
 
 \pnum
-\indextext{expression!unary~operator}%
+\indextext{expression!unary operator}%
 \indextext{operator!unary}%
 The unary \tcode{*} operator performs \defn{indirection}:
 \indextext{dereferencing|seealso{indirection}}%
@@ -2716,8 +2716,8 @@ lvalue must not be converted to a prvalue, see~\ref{conv.lval}.
 The result of each of the following unary operators is a prvalue.
 
 \pnum
-\indextext{name!address~of cv-qualified}%
-\indextext{expression!pointer~to~member constant}%
+\indextext{name!address of cv-qualified}%
+\indextext{expression!pointer to member constant}%
 The result of the unary \tcode{\&} operator is a pointer to its operand.
 The operand shall be an lvalue or a \grammarterm{qualified-id}.
 If the operand is a \grammarterm{qualified-id} naming a non-static or variant member \tcode{m}
@@ -2774,7 +2774,7 @@ the operator has the built-in meaning or the operator function is
 called. The operand of \tcode{\&} shall not be a bit-field.
 
 \pnum
-\indextext{overloaded~function!address~of}%
+\indextext{overloaded function!address of}%
 The address of an overloaded function (Clause~\ref{over}) can be taken
 only in a context that uniquely determines which version of the
 overloaded function is referred to (see~\ref{over.over}).
@@ -2786,14 +2786,14 @@ function''.
 \end{note}
 
 \pnum
-\indextext{operator!unary~plus}%
+\indextext{operator!unary plus}%
 The operand of the unary \tcode{+} operator shall have arithmetic, unscoped
 enumeration, or pointer type and the result is the value of the
 argument. Integral promotion is performed on integral or enumeration
 operands. The type of the result is the type of the promoted operand.
 
 \pnum
-\indextext{operator!unary~minus}%
+\indextext{operator!unary minus}%
 The operand of the unary \tcode{-} operator shall have arithmetic or unscoped
 enumeration type and the result is the negation of its operand. Integral
 promotion is performed on integral or enumeration operands. The negative
@@ -2811,7 +2811,7 @@ The type of the result is \tcode{bool}.
 
 \pnum
 \indextext{signed integer representation!ones' complement}%
-\indextext{operator!ones'~complement}%
+\indextext{operator!ones' complement}%
 The operand of \tcode{\~{}} shall have integral or unscoped enumeration type; the
 result is the ones' complement of its operand. Integral promotions are
 performed. The type of the result is the type of the promoted operand.
@@ -2836,9 +2836,9 @@ unambiguously parsed as a destructor name.
 \indextext{expression!decrement}%
 The operand of prefix \tcode{++}
 \indextext{operator!increment}%
-\indextext{prefix~\tcode{++}}%
+\indextext{prefix \tcode{++}}%
 is modified by adding \tcode{1}.
-\indextext{prefix~\tcode{\dcr}}%
+\indextext{prefix \tcode{\dcr}}%
 The operand shall be a modifiable lvalue. The type of the operand shall
 be an arithmetic type other than \cv{} \tcode{bool},
 or a pointer to a completely-defined object type.
@@ -2897,7 +2897,7 @@ and~\ref{basic.types} for the definition of \term{object representation}.
 \indextext{reference!\idxcode{sizeof}}%
 When applied to a reference or a reference type, the result is the size
 of the referenced type.
-\indextext{class~object!\idxcode{sizeof}}%
+\indextext{class object!\idxcode{sizeof}}%
 When applied to a class, the result is the number of bytes in an object
 of that class including any padding required for placing objects of that
 type in an array. The size of a most derived class shall be greater than
@@ -2954,9 +2954,9 @@ The result of \tcode{sizeof} and \tcode{sizeof...} is a constant of type
 
 \pnum
 \indextext{expression!\idxcode{new}}%
-\indextext{free~store|seealso{\tcode{new},~\tcode{delete}}}%
-\indextext{memory~management|seealso{\tcode{new},~\tcode{delete}}}%
-\indextext{storage~management|see{\tcode{new},~\tcode{delete}}}%
+\indextext{free store|seealso{\tcode{new}, \tcode{delete}}}%
+\indextext{memory management|seealso{\tcode{new}, \tcode{delete}}}%
+\indextext{storage management|see{\tcode{new}, \tcode{delete}}}%
 \indextext{\idxcode{new}}%
 The \grammarterm{new-expression} attempts to create an object of the
 \grammarterm{type-id}~(\ref{dcl.name}) or \grammarterm{new-type-id} to which
@@ -3010,11 +3010,11 @@ object created by the \grammarterm{new-expression} has a cv-qualified type.
     braced-init-list
 \end{bnf}
 
-\indextext{storage~duration!dynamic}%
+\indextext{storage duration!dynamic}%
 Entities created by a \grammarterm{new-expression} have dynamic storage
 duration~(\ref{basic.stc.dynamic}).
 \begin{note}
-\indextext{\idxcode{new}!scoping~and}%
+\indextext{\idxcode{new}!scoping and}%
 The lifetime of such an entity is not necessarily restricted to the
 scope in which it is created.
 \end{note}
@@ -3070,7 +3070,7 @@ operator.
 
 \pnum
 \begin{note}
-\indextext{ambiguity!parentheses~and}%
+\indextext{ambiguity!parentheses and}%
 parentheses in a \grammarterm{new-type-id} of a \grammarterm{new-expression}
 can have surprising effects.
 \begin{example}
@@ -3209,7 +3209,7 @@ for example, see \ref{new.delete.placement}.
 \end{note}
 
 \pnum
-\indextext{operator!scope~resolution}%
+\indextext{operator!scope resolution}%
 If the \grammarterm{new-expression} begins with a unary \tcode{::}
 operator, the allocation function's name is looked up in the global
 scope. Otherwise, if the allocated type is a class type \tcode{T} or
@@ -3287,7 +3287,7 @@ strictest fundamental
 alignment requirement~(\ref{basic.align}) of any object type whose size
 is no greater than the size of the array being created.
 \begin{note}
-\indextext{allocation!alignment~storage}%
+\indextext{allocation!alignment storage}%
 Because allocation functions are assumed to return pointers to storage
 that is appropriately aligned for objects of any type
 with fundamental alignment, this constraint
@@ -3303,7 +3303,7 @@ above, plus the size for the extended call had it not been extended, plus any
 padding necessary to align the allocated objects within the allocated memory.
 
 \pnum
-\indextext{placement~syntax!\idxcode{new}}%
+\indextext{placement syntax!\idxcode{new}}%
 \indextext{new-expression@\grammarterm{new-expression}!placement}%
 The \grammarterm{new-placement} syntax is used to supply additional
 arguments to an allocation function; such an expression is called
@@ -3395,13 +3395,13 @@ necessarily be the same as that of the block if the object is an array.
 \end{note}
 
 \pnum
-\indextext{\idxcode{new}!array~of class~objects~and}%
-\indextext{\idxcode{new}!initialization~and}%
-\indextext{\idxcode{new}!constructor~and}%
-\indextext{\idxcode{new}!default~constructor~and}%
-\indextext{default~constructor|see{constructor, default}}%
-\indextext{trivial~type}%
-\indextext{trivial~class~type}%
+\indextext{\idxcode{new}!array of class objects and}%
+\indextext{\idxcode{new}!initialization and}%
+\indextext{\idxcode{new}!constructor and}%
+\indextext{\idxcode{new}!default constructor and}%
+\indextext{default constructor|see{constructor, default}}%
+\indextext{trivial type}%
+\indextext{trivial class type}%
 A \grammarterm{new-expression} that creates an object of type \tcode{T}
 initializes that object as follows:
 
@@ -3415,8 +3415,8 @@ the initialization rules of~\ref{dcl.init} for direct-initialization.
 \end{itemize}
 
 \pnum
-\indextext{\idxcode{new}!unspecified order~of evaluation}%
-\indextext{\idxcode{new}!unspecified constructor~and}%
+\indextext{\idxcode{new}!unspecified order of evaluation}%
+\indextext{\idxcode{new}!unspecified constructor and}%
 The invocation of the allocation function is sequenced before
 the evaluations of expressions in the \grammarterm{new-initializer}. Initialization of
 the allocated object is sequenced before the
@@ -3433,7 +3433,7 @@ creates an array of objects of class type, the destructor is potentially
 invoked~(\ref{class.dtor}).
 
 \pnum
-\indextext{\idxcode{new}!exception~and}%
+\indextext{\idxcode{new}!exception and}%
 If any part of the object initialization described above\footnote{This may
 include evaluating a \grammarterm{new-initializer} and/or calling
 a constructor.}
@@ -3591,7 +3591,7 @@ deletion and the complete class has a non-trivial destructor or a
 deallocation function, the behavior is undefined.
 
 \pnum
-\indextext{\idxcode{delete}!destructor~and}%
+\indextext{\idxcode{delete}!destructor and}%
 If the value of the operand of the \grammarterm{delete-expression} is not a
 null pointer value, the \grammarterm{delete-expression} will invoke the
 destructor (if any) for the object or the elements of the array being
@@ -3639,7 +3639,7 @@ called as described above.
 An implementation provides default definitions of the global
 deallocation functions \tcode{operator delete()} for
 non-arrays~(\ref{new.delete.single}) and
-\indextext{operator~|see{\tcode{delete}}}%
+\indextext{operator |see{\tcode{delete}}}%
 \indextext{\idxcode{operator delete}}%
 \tcode{operator delete[]()} for arrays~(\ref{new.delete.array}). A \Cpp
 program can provide alternative definitions of these
@@ -3829,7 +3829,7 @@ A* foo( D* p ) {
 \end{example}
 
 \pnum
-\indextext{class!cast~to incomplete}%
+\indextext{class!cast to incomplete}%
 The operand of a cast using the cast notation can be a prvalue of type
 ``pointer to incomplete class type''. The destination type of a cast
 using the cast notation can be ``pointer to incomplete class type''. If
@@ -3849,11 +3849,11 @@ of the cast.
 
 \pnum
 \indextext{expression!pointer-to-member}%
-\indextext{pointer~to~member}%
-\indextext{operator!pointer~to~member}%
-\indextext{\idxcode{.*}|see{operator, pointer~to~member}}%
-\indextext{operator!pointer~to~member}%
-\indextext{\idxcode{->*}|see{operator, pointer~to~member}}%
+\indextext{pointer to member}%
+\indextext{operator!pointer to member}%
+\indextext{\idxcode{.*}|see{operator, pointer to member}}%
+\indextext{operator!pointer to member}%
+\indextext{\idxcode{->*}|see{operator, pointer to member}}%
 The pointer-to-member operators \tcode{->*} and \tcode{.*} group
 left-to-right.
 
@@ -3916,7 +3916,7 @@ cs.*pm = 88;                    // ill-formed: \tcode{cs} is a \tcode{const} obj
 \end{note}
 
 \pnum
-\indextext{function!pointer~to~member}%
+\indextext{function!pointer to member}%
 If the result of \tcode{.*} or \tcode{->*} is a function, then that
 result can be used only as the operand for the function call operator
 \tcode{()}.
@@ -3943,7 +3943,7 @@ If the second operand is the null
 pointer to member value~(\ref{conv.mem}), the behavior is undefined.
 
 \rSec1[expr.mul]{Multiplicative operators}%
-\indextext{expression!multiplicative~operators}%
+\indextext{expression!multiplicative operators}%
 \indextext{operator!multiplicative}
 
 \pnum
@@ -3956,7 +3956,7 @@ left-to-right.
 \indextext{\idxcode{/}|see{operator, division}}%
 \indextext{operator!remainder}%
 \indextext{\idxcode{\%}|see{operator, remainder}}%
-\indextext{remainder~operator|see{operator, remainder}}%
+\indextext{remainder operator|see{operator, remainder}}%
 %
 \begin{bnf}
 \nontermdef{multiplicative-expression}\br
@@ -3979,7 +3979,7 @@ The binary \tcode{*} operator indicates multiplication.
 The binary \tcode{/} operator yields the quotient, and the binary
 \tcode{\%} operator yields the remainder from the division of the first
 expression by the second.
-\indextext{zero!undefined division~by}%
+\indextext{zero!undefined division by}%
 If the second operand of \tcode{/} or \tcode{\%} is zero the behavior is
 undefined.
 For integral operands the \tcode{/} operator yields the algebraic quotient with
@@ -3989,7 +3989,7 @@ zero.} if the quotient \tcode{a/b} is representable in the type of the result,
 of both \tcode{a/b} and \tcode{a\%b} is undefined.
 
 \rSec1[expr.add]{Additive operators}%
-\indextext{expression!additive~operators}%
+\indextext{expression!additive operators}%
 \indextext{operator!additive}
 
 \pnum
@@ -3998,10 +3998,10 @@ usual arithmetic conversions are performed for operands of arithmetic or
 enumeration type.
 
 \indextext{operator!addition}%
-\indextext{addition~operator|see{operator, addition}}%
+\indextext{addition operator|see{operator, addition}}%
 \indextext{\idxcode{+}|see{operator, addition}}%
 \indextext{operator!subtraction}%
-\indextext{subtraction~operator|see{operator, subtraction}}%
+\indextext{subtraction operator|see{operator, subtraction}}%
 \indextext{\idxcode{-}|see{operator, subtraction}}%
 %
 \begin{bnf}
@@ -4057,8 +4057,8 @@ $\mathtt{x[}i - j\mathtt{]}$ if $0 \le i - j \le n$;
 otherwise, the behavior is undefined.
 
 \pnum
-\indextext{\idxcode{ptrdiff_t}!implementation~defined type~of}%
-\indextext{subtraction!implementation~defined pointer}%
+\indextext{\idxcode{ptrdiff_t}!implementation defined type of}%
+\indextext{subtraction!implementation defined pointer}%
 \indextext{\idxcode{ptrdiff_t}}%
 \indextext{\idxhdr{cstddef}}%
 \indextext{comparison!undefined pointer}%
@@ -4103,15 +4103,15 @@ converted to the type \tcode{std::ptrdiff_t}.
 \pnum
 \indextext{expression!left-shift-operator}%
 \indextext{expression!right-shift-operator}%
-\indextext{shift~operator|see{operator, left~shift; operator, right~shift}}%
-\indextext{right~shift~operator|see{operator, right~shift}}%
-\indextext{left~shift~operator|see{operator, left~shift}}%
+\indextext{shift operator|see{operator, left shift; operator, right shift}}%
+\indextext{right shift operator|see{operator, right shift}}%
+\indextext{left shift operator|see{operator, left shift}}%
 The shift operators \tcode{\shl} and \tcode{\shr} group left-to-right.
 
-\indextext{operator!left~shift}%
-\indextext{\idxcode{\shl}|see{operator, left~shift}}%
-\indextext{operator!right~shift}%
-\indextext{\idxcode{\shr}|see{operator, right~shift}}%
+\indextext{operator!left shift}%
+\indextext{\idxcode{\shl}|see{operator, left shift}}%
+\indextext{operator!right shift}%
+\indextext{\idxcode{\shr}|see{operator, right shift}}%
 %
 \begin{bnf}
 \nontermdef{shift-expression}\br
@@ -4123,7 +4123,7 @@ The shift operators \tcode{\shl} and \tcode{\shr} group left-to-right.
 The operands shall be of integral or unscoped enumeration type and integral
 promotions are performed. The type of the result is that of the promoted
 left operand.
-\indextext{left~shift!undefined}%
+\indextext{left shift!undefined}%
 The behavior is undefined if the right operand is negative, or greater
 than or equal to the length in bits of the promoted left operand.
 
@@ -4142,7 +4142,7 @@ The value of \tcode{E1 \shr\ E2} is \tcode{E1} right-shifted \tcode{E2}
 bit positions. If \tcode{E1} has an unsigned type or if \tcode{E1} has a
 signed type and a non-negative value, the value of the result is the
 integral part of the quotient of $\mathrm{E1}/2^\mathrm{E2}$. If \tcode{E1}
-\indextext{right~shift!implementation~defined}%
+\indextext{right shift!implementation defined}%
 has a signed type and a negative value, the resulting value is
 \impldef{result of right shift of negative value}.
 
@@ -4160,14 +4160,14 @@ The relational operators group left-to-right.
 \tcode{(a<b)\&\&(b<c)}.
 \end{example}
 
-\indextext{operator!less~than}%
-\indextext{\idxcode{<}|see{operator, less~than}}%
-\indextext{operator!greater~than}%
-\indextext{\idxcode{>}|see{operator, greater~than}}%
-\indextext{operator!less~than~or~equal~to}%
-\indextext{\idxcode{<=}|see{operator, less~than~or~equal~to}}%
-\indextext{operator!greater~than~or~equal~to}%
-\indextext{\idxcode{>=}|see{operator, greater~than~or~equal~to}}%
+\indextext{operator!less than}%
+\indextext{\idxcode{<}|see{operator, less than}}%
+\indextext{operator!greater than}%
+\indextext{\idxcode{>}|see{operator, greater than}}%
+\indextext{operator!less than or equal to}%
+\indextext{\idxcode{<=}|see{operator, less than or equal to}}%
+\indextext{operator!greater than or equal to}%
+\indextext{\idxcode{>=}|see{operator, greater than or equal to}}%
 %
 \begin{bnf}
 \nontermdef{relational-expression}\br
@@ -4232,7 +4232,7 @@ of the operators shall yield \tcode{true} if the specified relationship is true
 and \tcode{false} if it is false.
 
 \rSec1[expr.eq]{Equality operators}%
-\indextext{expression!equality~operators}%
+\indextext{expression!equality operators}%
 \indextext{operator!equality}%
 \indextext{operator!inequality}
 
@@ -4253,7 +4253,7 @@ same type after the specified conversions have been applied.
 
 \pnum
 \indextext{comparison!pointer}%
-\indextext{comparison!pointer~to function}%
+\indextext{comparison!pointer to function}%
 If at least one of the operands is a pointer,
 pointer conversions~(\ref{conv.ptr}),
 function pointer conversions~(\ref{conv.fctptr}), and
@@ -4361,7 +4361,7 @@ conversions are performed on both operands; each of the operators shall yield
 false.
 
 \rSec1[expr.bit.and]{Bitwise AND operator}%
-\indextext{expression!bitwise~AND}%
+\indextext{expression!bitwise AND}%
 \indextext{operator!bitwise}%
 \indextext{operator!bitwise AND}%
 \indextext{\idxcode{\&}|see{operator, bitwise AND}}%
@@ -4378,9 +4378,9 @@ bitwise \logop{AND} function of the operands. The operator
 applies only to integral or unscoped enumeration operands.
 
 \rSec1[expr.xor]{Bitwise exclusive OR operator}%
-\indextext{expression!bitwise~exclusive~OR}%
-\indextext{operator!bitwise~exclusive OR}%
-\indextext{\idxcode{\caret}|see{operator, bitwise~exclusive~OR}}
+\indextext{expression!bitwise exclusive OR}%
+\indextext{operator!bitwise exclusive OR}%
+\indextext{\idxcode{\caret}|see{operator, bitwise exclusive OR}}
 
 \begin{bnf}
 \nontermdef{exclusive-or-expression}\br
@@ -4394,9 +4394,9 @@ bitwise exclusive \logop{OR} function of the operands. The
 operator applies only to integral or unscoped enumeration operands.
 
 \rSec1[expr.or]{Bitwise inclusive OR operator}%
-\indextext{expression!bitwise~inclusive~OR}%
-\indextext{operator!bitwise~inclusive OR}%
-\indextext{\idxcode{"|}|see{operator, bitwise~inclusive~OR}}
+\indextext{expression!bitwise inclusive OR}%
+\indextext{operator!bitwise inclusive OR}%
+\indextext{\idxcode{"|}|see{operator, bitwise inclusive OR}}
 
 \begin{bnf}
 \nontermdef{inclusive-or-expression}\br
@@ -4410,9 +4410,9 @@ bitwise inclusive \logop{OR} function of its operands. The
 operator applies only to integral or unscoped enumeration operands.
 
 \rSec1[expr.log.and]{Logical AND operator}%
-\indextext{expression!logical~AND}%
+\indextext{expression!logical AND}%
 \indextext{operator!logical AND}%
-\indextext{\idxcode{\&\&}|see{operator, logical~AND}}%
+\indextext{\idxcode{\&\&}|see{operator, logical AND}}%
 
 \begin{bnf}
 \nontermdef{logical-and-expression}\br
@@ -4431,7 +4431,7 @@ first operand is \tcode{false}.
 
 \pnum
 The result is a \tcode{bool}.
-\indextext{operator!side~effects~and logical AND}%
+\indextext{operator!side effects and logical AND}%
 If the second expression is evaluated, every
 \indextext{value computation}%
 value computation and
@@ -4441,9 +4441,9 @@ effect associated with the first expression is sequenced before every
 value computation and side effect associated with the second expression.
 
 \rSec1[expr.log.or]{Logical OR operator}%
-\indextext{expression!logical~OR}%
+\indextext{expression!logical OR}%
 \indextext{operator!logical OR}%
-\indextext{\idxcode{"|"|}|see{operator, logical~OR}}%
+\indextext{\idxcode{"|"|}|see{operator, logical OR}}%
 
 \begin{bnf}
 \nontermdef{logical-or-expression}\br
@@ -4462,7 +4462,7 @@ if the first operand evaluates to \tcode{true}.
 
 \pnum
 The result is a \tcode{bool}.
-\indextext{operator!side~effects~and logical OR}%
+\indextext{operator!side effects and logical OR}%
 If the second expression is evaluated, every
 \indextext{value computation}%
 value computation and
@@ -4472,9 +4472,9 @@ associated with the first expression is sequenced before every value computation
 and side effect associated with the second expression.
 
 \rSec1[expr.cond]{Conditional operator}%
-\indextext{expression!conditional~operator}%
-\indextext{operator!conditional~expression}%
-\indextext{\idxcode{?:}|see{operator, conditional~expression}}%
+\indextext{expression!conditional operator}%
+\indextext{operator!conditional expression}%
+\indextext{\idxcode{?:}|see{operator, conditional expression}}%
 
 \begin{bnf}
 \nontermdef{conditional-expression}\br
@@ -4500,7 +4500,7 @@ If either the second or the third operand has type \tcode{void},
 one of the following shall hold:
 
 \begin{itemize}
-\indextext{conditional-expression!throw-expression~in}%
+\indextext{conditional-expression!throw-expression in}%
 \item The second or the third operand (but not both) is a (possibly
 parenthesized) \grammarterm{throw-expression}~(\ref{expr.throw}); the result
 is of the type and value category of the other.
@@ -4688,7 +4688,7 @@ with no operand calls
 
 \pnum
 \indextext{operator!assignment}%
-\indextext{\idxcode{=}|see{assignment~operator}}%
+\indextext{\idxcode{=}|see{assignment operator}}%
 \indextext{operator!\idxcode{+=}}%
 \indextext{operator!\idxcode{-=}}%
 \indextext{operator!\idxcode{*=}}%
@@ -4738,13 +4738,13 @@ In simple assignment (\tcode{=}), the value of the expression replaces
 that of the object referred to by the left operand.
 
 \pnum
-\indextext{assignment!conversion~by}%
+\indextext{assignment!conversion by}%
 If the left operand is not of class type, the expression is implicitly
 converted (Clause~\ref{conv}) to the cv-unqualified type of the left
 operand.
 
 \pnum
-\indextext{class~object!assignment~to}%
+\indextext{class object!assignment to}%
 \indextext{type!incomplete}%
 If the left operand is of class type, the class shall be complete.
 Assignment to objects of a class is defined by the copy/move assignment
@@ -4757,7 +4757,7 @@ initialization~(\ref{dcl.init},~\ref{class.ctor},~\ref{class.init},~\ref{class.c
 \end{note}
 
 \pnum
-\indextext{reference!assignment~to}%
+\indextext{reference!assignment to}%
 When the left operand of an assignment operator
 is a bit-field that cannot represent the value of the expression, the
 resulting value of the bit-field is
@@ -4806,9 +4806,9 @@ a = { 1 } = b;            // syntax error
 \rSec1[expr.comma]{Comma operator}%
 \indextext{expression!comma}%
 \indextext{operator!comma}%
-\indextext{comma~operator|see{operator, comma}}%
+\indextext{comma operator|see{operator, comma}}%
 \indextext{\idxcode{,}|see{operator, comma}}%
-\indextext{sequencing~operator|see{operator, comma}}%
+\indextext{sequencing operator|see{operator, comma}}%
 
 \pnum
 The comma operator groups left-to-right.
@@ -4827,7 +4827,7 @@ Every
 value computation and side effect
 associated with the left expression is sequenced before every value
 computation and side effect associated with the right expression.
-\indextext{operator!side~effects~and comma}%
+\indextext{operator!side effects and comma}%
 The type and value of the
 result are the type and value of the right operand; the result is of the same
 value category as its right operand, and is a bit-field if its

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -1409,7 +1409,7 @@ suitably chosen modification orders and the ``happens before'' relation derived
 as described above, satisfy the resulting constraints as imposed here. \end{note}
 
 \pnum
-Two actions are \defnx{potentially concurrent}{potentially concurrent} if
+Two actions are \defn{potentially concurrent} if
 \begin{itemize}
 \item they are performed by different threads, or
 \item they are unsequenced, at least one is performed by a signal handler, and

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -17,7 +17,7 @@
 \indextext{subobject|seealso{object model}}%
 \indextext{derived class!most|see{most derived class}}%
 \indextext{derived object!most|see{most derived object}}%
-\indextext{program execution!as-if rule|see{as-if~rule}}%
+\indextext{program execution!as-if rule|see{as-if rule}}%
 \indextext{observable behavior|see{behavior, observable}}%
 \indextext{precedence of operator|see{operator, precedence of}}%
 \indextext{order of evaluation in expression|see{expression, order of evaluation of}}%
@@ -735,7 +735,7 @@ parameterized nondeterministic abstract machine. This International
 Standard places no requirement on the structure of conforming
 implementations. In particular, they need not copy or emulate the
 structure of the abstract machine.
-\indextext{as-if~rule}%
+\indextext{as-if rule}%
 \indextext{behavior!observable}%
 Rather, conforming implementations are required to emulate (only) the observable
 behavior of the abstract machine as explained below.\footnote{This provision is
@@ -1049,7 +1049,7 @@ zero or more invocations of destructor functions for temporary objects takes
 place, usually in reverse order of the construction of each temporary object.}
 
 \pnum
-\indextext{evaluation!unspecified order~of}%
+\indextext{evaluation!unspecified order of}%
 Except where noted, evaluations of operands of individual operators and
 of subexpressions of individual expressions are unsequenced. \begin{note}
 In an expression that is evaluated more than once during the execution
@@ -1415,7 +1415,7 @@ Two actions are \defn{potentially concurrent} if
 \item they are unsequenced, at least one is performed by a signal handler, and
 they are not both performed by the same signal handler invocation.
 \end{itemize}
-\indextext{data~race}%
+\indextext{data race}%
 The execution of a program contains a \defn{data race} if it contains two
 potentially concurrent conflicting actions, at least one of which is not atomic,
 and neither happens before the other,

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -1409,7 +1409,7 @@ suitably chosen modification orders and the ``happens before'' relation derived
 as described above, satisfy the resulting constraints as imposed here. \end{note}
 
 \pnum
-Two actions are \defnx{potentially concurrent}{potentially~concurrent} if
+Two actions are \defnx{potentially concurrent}{potentially concurrent} if
 \begin{itemize}
 \item they are performed by different threads, or
 \item they are unsequenced, at least one is performed by a signal handler, and

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1651,7 +1651,7 @@ template <class Iterator>
 
 \rSec4[reverse.iter.make]{Non-member function \tcode{make_reverse_iterator()}}
 
-\indexlibrary{\idxcode{reverse_iterator}!\idxcode{make_reverse_iterator}~non-member~function}%
+\indexlibrary{\idxcode{reverse_iterator}!\idxcode{make_reverse_iterator} non-member function}%
 \indexlibrary{\idxcode{make_reverse_iterator}}%
 \begin{itemdecl}
 template <class Iterator>

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -401,7 +401,7 @@ Table~\ref{tab:alternative.tokens}.
 There are five kinds of tokens: identifiers, keywords, literals,\footnote{Literals include strings and character and numeric literals.
 }
 operators, and other separators.
-\indextext{white~space}%
+\indextext{white space}%
 Blanks, horizontal and vertical tabs, newlines, formfeeds, and comments
 (collectively, ``white space''), as described below, are ignored except
 as they serve to separate tokens. \begin{note} Some white space is
@@ -414,7 +414,7 @@ literals, and alternative tokens containing alphabetic characters.
 
 \pnum
 \indextext{comment|(}%
-\indextext{comment!\tcode{/*}~\tcode{*/}}%
+\indextext{comment!\tcode{/*} \tcode{*/}}%
 \indextext{comment!\tcode{//}}%
 The characters \tcode{/*} start a comment, which terminates with the
 characters \tcode{*/}. These comments do not nest.
@@ -540,7 +540,7 @@ token.%
 \end{bnf}
 
 \pnum
-\indextext{name!length~of}%
+\indextext{name!length of}%
 \indextext{name}%
 An identifier is an arbitrarily long sequence of letters and digits.
 Each \grammarterm{universal-character-name} in an identifier shall designate a
@@ -638,7 +638,7 @@ token as a regular \grammarterm{identifier}.
 \pnum
 \indextext{\idxcode{_}|see{character, underscore}}%
 \indextext{character!underscore!in identifier}%
-\indextext{reserved~identifier}%
+\indextext{reserved identifier}%
 In addition, some identifiers are reserved for use by \Cpp
 implementations and shall
 not be used otherwise; no diagnostic is required.%
@@ -926,7 +926,7 @@ ISO C. }
 \pnum
 \indextext{literal!\idxcode{unsigned}}%
 \indextext{literal!\idxcode{long}}%
-\indextext{literal!base~of integer}%
+\indextext{literal!base of integer}%
 An \defnx{integer literal}{literal!integer} is a sequence of digits that has no period
 or exponent part, with optional separating single quotes that are ignored
 when determining its value. An integer literal may have a prefix that specifies
@@ -956,7 +956,7 @@ ten through fifteen.
 \indextext{literal!\idxcode{long}}%
 \indextext{literal!\idxcode{unsigned}}%
 \indextext{literal!integer}%
-\indextext{literal!type~of integer}%
+\indextext{literal!type of integer}%
 \indextext{suffix!\idxcode{L}}%
 \indextext{suffix!\idxcode{U}}%
 \indextext{suffix!\idxcode{l}}%
@@ -1110,7 +1110,7 @@ as in
 respectively.
 
 \pnum
-\indextext{literal!type~of character}%
+\indextext{literal!type of character}%
 \indextext{literal!character!ordinary}%
 A character literal that does not begin with
 \tcode{u8}, \tcode{u}, \tcode{U}, or \tcode{L}
@@ -1199,12 +1199,12 @@ Certain non-graphic characters, the single quote \tcode{'}, the double quote \tc
 the question mark \tcode{?},\footnote{Using an escape sequence for a question mark
 is supported for compatibility with ISO \CppXIV and ISO C.}
 and the backslash
-\indextext{backslash~character}%
+\indextext{backslash character}%
 \indextext{\idxcode{\textbackslash}|see{backslash}}%
-\indextext{escape~character|see{backslash}}%
+\indextext{escape character|see{backslash}}%
 \tcode{\textbackslash}, can be represented according to
 Table~\ref{tab:escape.sequences}.
-\indextext{escape~sequence!undefined}%
+\indextext{escape sequence!undefined}%
 The double quote \tcode{"}  and the question mark \tcode{?}, can be
 represented as themselves or by the escape sequences
 \tcode{\textbackslash "} and \tcode{\textbackslash ?} respectively, but
@@ -1248,7 +1248,7 @@ character. There is no limit to the number of digits in a hexadecimal
 sequence. A sequence of octal or hexadecimal digits is terminated by the
 first character that is not an octal digit or a hexadecimal digit,
 respectively.
-\indextext{literal!implementation-defined value~of \idxcode{char}}%
+\indextext{literal!implementation-defined value of \idxcode{char}}%
 The value of a character literal is \impldef{value of character literal outside range of
 corresponding type} if it falls outside of the \impldef{range defined for character literals}
 range defined for \tcode{char} (for literals with no prefix) or
@@ -1378,7 +1378,7 @@ nearest the scaled value, chosen in an \impldef{choice of larger or smaller valu
 floating literal} manner.
 \indextext{literal!\idxcode{double}}%
 The type of a floating literal is \tcode{double}
-\indextext{literal!type~of floating~point}%
+\indextext{literal!type of floating point}%
 unless explicitly specified by a suffix.
 \indextext{literal!\idxcode{float}}%
 \indextext{suffix!\idxcode{F}}%
@@ -1452,7 +1452,7 @@ values for its type, the program is ill-formed.
 \indextext{literal!string!wide}%
 \indextext{literal!string!\idxcode{char16_t}}%
 \indextext{literal!string!\idxcode{char32_t}}%
-\indextext{character~string}%
+\indextext{character string}%
 A \grammarterm{string-literal} is a sequence of characters (as defined
 in~\ref{lex.ccon}) surrounded by double quotes, optionally prefixed by
 \tcode{R},
@@ -1532,7 +1532,7 @@ R"#(
 is equivalent to \tcode{"\textbackslash n)\textbackslash?\textbackslash?=\textbackslash"\textbackslash n"}. \end{example}
 
 \pnum
-\indextext{string!type~of}%
+\indextext{string!type of}%
 \indextext{literal!string!narrow}%
 After translation phase 6, a \grammarterm{string-literal} that does not begin with an \grammarterm{encoding-prefix} is an
 \defn{ordinary string literal}, and is initialized with the given characters.
@@ -1547,7 +1547,7 @@ such as \tcode{u8"asdf"}, is a \defn{UTF-8 string literal}.
 Ordinary string literals and UTF-8 string literals are
 also referred to as narrow
 string literals. A narrow string literal has type
-\indextext{literal!string!type~of}%
+\indextext{literal!string!type of}%
 ``array of \placeholder{n} \tcode{const char}'', where \placeholder{n} is the size of
 the string as defined below, and has static storage
 duration~(\ref{basic.stc}).
@@ -1644,9 +1644,9 @@ after concatenation (and not the single hexadecimal character
 \end{example}
 
 \pnum
-\indextext{\idxcode{0}|seealso{zero,~null}}%
+\indextext{\idxcode{0}|seealso{zero, null}}%
 \indextext{\idxcode{0}!string terminator}%
-\indextext{\idxcode{0}!null~character|see {character, null}}%
+\indextext{\idxcode{0}!null character|see {character, null}}%
 After any necessary concatenation, in translation phase
 7~(\ref{lex.phases}), \tcode{'\textbackslash 0'} is appended to every
 string literal so that programs that scan a string can find its end.
@@ -1688,7 +1688,7 @@ nonoverlapping objects) and whether successive evaluations of a
 \grammarterm{string-literal} yield the same or a different object is
 unspecified.
 \begin{note}
-\indextext{literal!string!undefined change~to}%
+\indextext{literal!string!undefined change to}%
 The effect of attempting to modify a string literal is undefined. \end{note}
 
 \rSec2[lex.bool]{Boolean literals}

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -258,7 +258,7 @@ direct-initialization of an object of some type with an rvalue of the same type
 
 \definition{NTCTS}{defns.ntcts}
 \indexdefn{NTCTS}%
-\indexdefn{string!null-terminated character~type}%
+\indexdefn{string!null-terminated character type}%
 a sequence of values that have
 \term{character type}
 that precede the terminating null character type

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2340,7 +2340,7 @@ linkage,
 \footnote{
 The function
 signatures declared in
-\indextext{Amendment~1}%
+\indextext{Amendment 1}%
 \indextext{\idxhdr{cuchar}}%
 \indexlibrary{\idxhdr{cuchar}}%
 \indextext{\idxhdr{cwchar}}%

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -66,12 +66,12 @@ Certain function declarations cannot be overloaded:
 
 \begin{itemize}
 \item
-\indextext{return~type!overloading~and}%
+\indextext{return type!overloading and}%
 Function declarations that differ only in the return type,
 the exception specification~(\ref{except.spec}), or both
 cannot be overloaded.
 \item
-\indextext{\idxcode{static}!overloading~and}%
+\indextext{\idxcode{static}!overloading and}%
 Member function declarations with the same name and the same
 parameter-type-list~(\ref{dcl.fct}) cannot be overloaded if any of them is a
 \tcode{static}
@@ -128,8 +128,8 @@ class Y {
 \end{itemize}
 
 \pnum
-\indextext{equivalent~parameter~declarations}%
-\indextext{equivalent~parameter~declarations!overloading~and}%
+\indextext{equivalent parameter declarations}%
+\indextext{equivalent parameter declarations!overloading and}%
 \begin{note}
 As specified in~\ref{dcl.fct},
 function declarations that have equivalent parameter declarations declare
@@ -138,7 +138,7 @@ be overloaded:
 
 \begin{itemize}
 \item
-\indextext{\idxcode{typedef}!overloading~and}%
+\indextext{\idxcode{typedef}!overloading and}%
 Parameter declarations that differ only in the use of equivalent typedef
 ``types'' are equivalent.
 A
@@ -157,7 +157,7 @@ void f(Int i) @\tcode{\{ /* ... */ \}}@    // error: redefinition of \tcode{f(in
 \end{codeblock}
 \end{example}
 
-\indextext{\idxcode{enum}!overloading~and}%
+\indextext{\idxcode{enum}!overloading and}%
 Enumerations, on the other hand, are distinct types and can be used to
 distinguish
 overloaded function declarations.
@@ -172,8 +172,8 @@ void f(E i)   @\tcode{\{ /* ... */ \}}@
 \end{example}
 
 \item
-\indextext{overloading!array~versus~pointer}%
-\indextext{array!overloading~and pointer~versus}%
+\indextext{overloading!array versus pointer}%
+\indextext{array!overloading and pointer versus}%
 Parameter declarations that differ only in a pointer
 \tcode{*}
 versus an array
@@ -199,8 +199,8 @@ int g(char(*)[20]);             // different from \tcode{g(char(*)[10]);}
 \end{example}
 
 \item
-\indextext{overloading!function~versus~pointer}%
-\indextext{function!overloading~and pointer~versus}%
+\indextext{overloading!function versus pointer}%
+\indextext{function!overloading and pointer versus}%
 Parameter declarations that differ only in that one is a function type
 and the other is a pointer to the same function type are equivalent.
 That is, the function type is adjusted to become a pointer to function type~(\ref{dcl.fct}).
@@ -215,8 +215,8 @@ void h(int (*x)()) { }          // ill-formed: redefinition of \tcode{h(int())}
 \end{example}
 
 \item
-\indextext{\idxcode{const}!overloading~and}%
-\indextext{\idxcode{volatile}!overloading~and}%
+\indextext{\idxcode{const}!overloading and}%
+\indextext{\idxcode{volatile}!overloading and}%
 Parameter declarations that differ only in the presence or absence of
 \tcode{const}
 and/or
@@ -282,7 +282,7 @@ and
 \tcode{volatile}
 \tcode{T}''.
 \item
-\indextext{default~initializers!overloading~and}%
+\indextext{default initializers!overloading and}%
 Two parameter declarations that differ only in their default arguments
 are equivalent.
 \begin{example}
@@ -307,7 +307,7 @@ void prog () {
 \rSec1[over.dcl]{Declaration matching}%
 \indextext{overloading!declaration matching}%
 \indextext{scope!overloading and}%
-\indextext{base~class!overloading and}
+\indextext{base class!overloading and}
 
 \pnum
 Two function declarations of the same name refer to the same function if they
@@ -327,8 +327,8 @@ struct D : B {
 };
 \end{codeblock}
 
-\indextext{name~hiding!function}%
-\indextext{name~hiding!overloading versus}%
+\indextext{name hiding!function}%
+\indextext{name hiding!overloading versus}%
 Here
 \tcode{D::f(const char*)}
 hides
@@ -1499,8 +1499,8 @@ relationships between arguments and function parameters other
 than the ranking of conversion sequences.
 
 \pnum
-\indextext{ellipsis!overload resolution~and}%
-\indextext{default~argument!overload resolution~and}%
+\indextext{ellipsis!overload resolution and}%
+\indextext{default argument!overload resolution and}%
 First, to be a viable function, a candidate function shall have
 enough parameters to agree in number with the arguments in the
 list.
@@ -1558,7 +1558,7 @@ the viability of the function (see~\ref{over.ics.ref}).
 \indextext{overloading!resolution!best viable function|(}
 
 \pnum
-\indextext{conversion!overload resolution~and}%
+\indextext{conversion!overload resolution and}%
 Define ICS\textit{i}(\tcode{F}) as follows:
 
 \begin{itemize}
@@ -2104,7 +2104,7 @@ function) is called for those cases.
 \rSec4[over.ics.ellipsis]{Ellipsis conversion sequences}
 
 \pnum
-\indextext{ellipsis!conversion~sequence}%
+\indextext{ellipsis!conversion sequence}%
 An ellipsis conversion sequence occurs when an argument in a
 function call is matched with the ellipsis parameter
 specification of the function called (see~\ref{expr.call}).
@@ -2431,7 +2431,7 @@ if
 
 \begin{itemize}
 \item
-\indextext{subsequence~rule!overloading}%
+\indextext{subsequence rule!overloading}%
 \tcode{S1}
 is a proper subsequence of
 \tcode{S2}
@@ -2742,7 +2742,7 @@ types will be different.
 
 \rSec1[over.over]{Address of overloaded function}%
 \indextext{overloading!address of overloaded function}%
-\indextext{overloaded~function!address~of}
+\indextext{overloaded function!address of}
 
 \pnum
 A use of an overloaded function name without arguments is resolved
@@ -2957,7 +2957,7 @@ and
 are formed from more than one token.
 \end{note}
 \indextext{operator!subscripting}%
-\indextext{operator!function~call}%
+\indextext{operator!function call}%
 
 \pnum
 Both the unary and binary forms of
@@ -2969,7 +2969,7 @@ Both the unary and binary forms of
 can be overloaded.
 
 \pnum
-\indextext{restriction!operator~overloading}%
+\indextext{restriction!operator overloading}%
 The following operators cannot be overloaded:
 
 \begin{codeblock}
@@ -2983,7 +2983,7 @@ and
 (Clause~\ref{cpp}).
 
 \pnum
-\indextext{call!operator~function}%
+\indextext{call!operator function}%
 Operator functions are usually not called directly; instead they are invoked
 to evaluate the operators they implement~(\ref{over.unary} -- \ref{over.inc}).
 They can be explicitly called, however, using the
@@ -3030,7 +3030,7 @@ and
 (comma), predefined for each type, can be changed for specific
 class and enumeration types by
 defining operator functions that implement these operators.
-\indextext{overloaded~operator!inheritance~of}%
+\indextext{overloaded operator!inheritance of}%
 Operator functions are inherited in the same manner as other base class
 functions.
 
@@ -3047,7 +3047,7 @@ require an operand to be an lvalue when applied to basic types;
 this is not required by operator functions.
 
 \pnum
-\indextext{argument!overloaded~operator~and default}%
+\indextext{argument!overloaded operator and default}%
 An operator function cannot have default arguments~(\ref{dcl.fct.default}),
 except where explicitly stated below.
 Operator
@@ -3070,7 +3070,7 @@ operators obeying the rules of ~\ref{over.unary} or~\ref{over.binary}.%
 A prefix unary operator shall be implemented by a
 non-static member function~(\ref{class.mfct}) with no parameters or a
 non-member function with one parameter.
-\indextext{unary~operator!interpretation~of}%
+\indextext{unary operator!interpretation of}%
 Thus, for any prefix unary operator
 \tcode{@},
 \tcode{@x}
@@ -3102,7 +3102,7 @@ operator from an enclosing scope, and vice versa.
 A binary operator shall be implemented either by a non-static member
 function~(\ref{class.mfct})
 with one parameter or by a non-member function with two parameters.
-\indextext{binary~operator!interpretation~of}%
+\indextext{binary operator!interpretation of}%
 Thus, for any binary operator
 \tcode{@},
 \tcode{x@y}
@@ -3169,7 +3169,7 @@ void f() {
 \end{note}
 
 \rSec2[over.call]{Function call}%
-\indextext{function~call~operator!overloaded}%
+\indextext{function call operator!overloaded}%
 \indextext{overloading!function call operator}
 
 \pnum
@@ -3273,8 +3273,8 @@ the overload resolution mechanism~(\ref{over.match}).
 \rSec2[over.inc]{Increment and decrement}
 \indextext{increment operator!overloaded|see{overloading, increment operator}}%
 \indextext{decrement operator!overloaded|see{overloading, decrement operator}}%
-\indextext{prefix~++ and~-{-} overloading@prefix \tcode{++}~and~\tcode{\dcr}!overloading}%
-\indextext{postfix~++~and~-{-} overloading@postfix \tcode{++}~and~\tcode{\dcr}!overloading}%
+\indextext{prefix ++ and -{-} overloading@prefix \tcode{++} and \tcode{\dcr}!overloading}%
+\indextext{postfix ++ and -{-} overloading@postfix \tcode{++} and \tcode{\dcr}!overloading}%
 
 \pnum
 The user-defined function called

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -442,7 +442,7 @@ only if it is available:
 \rSec1[cpp.include]{Source file inclusion}
 \indextext{preprocessing directives!header inclusion}
 \indextext{preprocessing directives!source-file inclusion}
-\indextext{inclusion!source~file|see{preprocessing directives, source-file inclusion}}%
+\indextext{inclusion!source file|see{preprocessing directives, source-file inclusion}}%
 \indextext{\idxcode{\#include}}%
 
 \pnum
@@ -655,7 +655,7 @@ part of the replacement list for either form of macro.
 
 \pnum
 If a
-\indextext{\#\#0~operator@\tcode{\#}~operator}
+\indextext{\#\#0 operator@\tcode{\#} operator}
 \tcode{\#}
 preprocessing token,
 followed by an identifier,
@@ -747,7 +747,7 @@ one more than the number of parameters in the macro definition (excluding the
 
 \rSec2[cpp.subst]{Argument substitution}%
 \indextext{macro!argument substitution}%
-\indextext{argument~substitution|see{macro, argument substitution}}%
+\indextext{argument substitution|see{macro, argument substitution}}%
 
 \pnum
 After the arguments for the invocation of a function-like macro have
@@ -773,7 +773,7 @@ shall be treated as if it were a parameter, and the variable arguments shall for
 the preprocessing tokens used to replace it.
 
 \rSec2[cpp.stringize]{The \tcode{\#} operator}%
-\indextext{\#\#0~operator@\tcode{\#}~operator}%
+\indextext{\#\#0 operator@\tcode{\#} operator}%
 \indextext{stringize|see{\tcode{\#}}}
 
 \pnum

--- a/source/special.tex
+++ b/source/special.tex
@@ -3,13 +3,13 @@
 
 \gramSec[gram.special]{Special member functions}
 
-\indextext{special~member~function|see{constructor, destructor, inline function,
+\indextext{special member function|see{constructor, destructor, inline function,
 user-defined conversion, virtual function}}%
 \indextext{\idxcode{X(X\&)}|see{constructor, copy}}%
 \indextext{~@\tcode{\tilde}|see{destructor}}%
 \indextext{assignment!copy|see{assignment operator, copy}}%
 \indextext{assignment!move|see{assignment operator, move}}%
-\indextext{implicitly-declared~default~constructor|see{constructor, default}}
+\indextext{implicitly-declared default constructor|see{constructor, default}}
 
 \pnum
 \indextext{constructor!default}%
@@ -56,7 +56,7 @@ Often such special member functions are called implicitly.
 \end{note}
 
 \pnum
-\indextext{access control!member~function~and}%
+\indextext{access control!member function and}%
 Special member functions obey the usual access rules (Clause~\ref{class.access}).
 \begin{example}
 declaring a constructor
@@ -132,8 +132,8 @@ For initialization of objects of class type see~\ref{class.init}.
 \end{note}
 
 \pnum
-\indextext{\idxcode{const}!constructor~and}%
-\indextext{\idxcode{volatile}!constructor~and}%
+\indextext{\idxcode{const}!constructor and}%
+\indextext{\idxcode{volatile}!constructor and}%
 A constructor can be invoked for a
 \tcode{const},
 \tcode{volatile}
@@ -150,7 +150,7 @@ They come into effect when the constructor for the
 most derived object~(\ref{intro.object}) ends.
 
 \pnum
-\indextext{constructor!inheritance~of}%
+\indextext{constructor!inheritance of}%
 \indextext{constructor!default}%
 \indextext{constructor!non-trivial}%
 A
@@ -164,7 +164,7 @@ each parameter
 that is not a function parameter pack
 has a default argument
 (including the case of a constructor with no parameters).
-\indextext{implicitly-declared~default~constructor}%
+\indextext{implicitly-declared default constructor}%
 If there is no user-declared constructor for class
 \tcode{X},
 a non-explicit constructor having no parameters is implicitly declared
@@ -283,8 +283,8 @@ is implicitly used and the constructor is not accessible (Clause~\ref{class.acce
 
 \pnum
 \begin{note}
-\indextext{order~of~execution!base~class constructor}%
-\indextext{order~of~execution!member constructor}%
+\indextext{order of execution!base class constructor}%
+\indextext{order of execution!member constructor}%
 \ref{class.base.init} describes the order in which constructors for base
 classes and non-static data members are called and
 describes how arguments can be specified for the calls to these constructors.
@@ -295,7 +295,7 @@ describes how arguments can be specified for the calls to these constructors.
 A
 \tcode{return}
 statement in the body of a constructor shall not specify a return value.
-\indextext{constructor!address~of}%
+\indextext{constructor!address of}%
 The address of a constructor shall not be taken.
 
 \pnum
@@ -326,7 +326,7 @@ Explicit constructor calls do not yield lvalues, see~\ref{basic.lval}.
 
 \pnum
 \begin{note}
-\indextext{member function!constructor~and}%
+\indextext{member function!constructor and}%
 some language constructs have special semantics when used during construction;
 see~\ref{class.base.init} and~\ref{class.cdtor}.
 \end{note}
@@ -370,11 +370,11 @@ D d = D(1);                     // value of \tcode{d.b} is unspecified
 \rSec1[class.temporary]{Temporary objects}
 
 \pnum
-\indextext{object~temporary|see{temporary}}%
+\indextext{object temporary|see{temporary}}%
 \indextext{temporary}%
-\indextext{optimization~of~temporary|see{temporary, elimination~of}}%
-\indextext{temporary!elimination~of}%
-\indextext{temporary!implementation-defined~generation~of}%
+\indextext{optimization of temporary|see{temporary, elimination of}}%
+\indextext{temporary!elimination of}%
+\indextext{temporary!implementation-defined generation of}%
 Temporary objects are created
 \begin{itemize}
 \item
@@ -450,7 +450,7 @@ void h() {
 }
 \end{codeblock}
 
-\indextext{class~object~copy|see{constructor, copy}}%
+\indextext{class object copy|see{constructor, copy}}%
 \indextext{constructor!copy}%
 \tcode{X(2)} is constructed in the space used to hold \tcode{f()}'s argument and
 \tcode{Y(3)} is constructed in the space used to hold \tcode{g()}'s argument.
@@ -488,9 +488,9 @@ This latitude is granted to allow objects of class type to be passed to or retur
 \end{note}
 
 \pnum
-\indextext{temporary!constructor~for}%
-\indextext{temporary!destructor~for}%
-\indextext{temporary!destruction~of}%
+\indextext{temporary!constructor for}%
+\indextext{temporary!destructor for}%
+\indextext{temporary!destruction of}%
 When an implementation introduces a temporary object of a class that has a
 non-trivial constructor~(\ref{class.ctor}, \ref{class.copy}), it shall ensure that
 a constructor is called for the temporary object.
@@ -511,8 +511,8 @@ are associated only with the full-expression, not with any specific
 subexpression.
 
 \pnum
-\indextext{initializer!temporary~and declarator}%
-\indextext{temporary!order~of destruction~of}%
+\indextext{initializer!temporary and declarator}%
+\indextext{temporary!order of destruction of}%
 There are three contexts in which temporaries are destroyed at a different
 point than the end of the full-expression.
 The first context is when a default constructor is called to initialize
@@ -658,7 +658,7 @@ shall be destroyed before
 \indextext{conversion!class}%
 \indextext{conversion!user-defined}%
 \indextext{constructor, conversion by|see{conversion, user-defined}}%
-\indextext{conversion~function|see{conversion, user-defined}}%
+\indextext{conversion function|see{conversion, user-defined}}%
 \indextext{conversion!implicit}%
 Type conversions of class objects can be specified by constructors and
 by conversion functions.
@@ -704,7 +704,7 @@ int c = X(a);       // OK: \tcode{a.operator X().operator int()}
 
 \pnum
 User-defined conversions are used implicitly only if they are unambiguous.
-\indextext{name~hiding!user-defined conversion~and}%
+\indextext{name hiding!user-defined conversion and}%
 A conversion function in a derived class does not hide a conversion function
 in a base class unless the two functions convert to the same type.
 Function overload resolution~(\ref{over.match.best}) selects the best
@@ -803,7 +803,7 @@ it may be called for implicit type conversions.
 
 \rSec2[class.conv.fct]{Conversion functions}%
 \indextext{function!conversion}%
-\indextext{fundamental~type~conversion|see{conversion, user-defined}}%
+\indextext{fundamental type conversion|see{conversion, user-defined}}%
 \indextext{conversion!user-defined}%
 
 \pnum
@@ -832,7 +832,7 @@ Such functions are called \defn{conversion function}{s}.
 A \grammarterm{decl-specifier} in the \grammarterm{decl-specifier-seq}
 of a conversion function (if any) shall be neither
 a \grammarterm{defining-type-specifier} nor \tcode{static}.
-\indextext{conversion!type~of}%
+\indextext{conversion!type of}%
 The type of the conversion function~(\ref{dcl.fct}) is
 ``function taking no parameter returning
 \grammarterm{conversion-type-id}''.
@@ -922,7 +922,7 @@ operator int [[noreturn]] (); // error: \tcode{noreturn} attribute applied to a 
 \end{note}
 
 \pnum
-\indextext{conversion!inheritance~of user-defined}%
+\indextext{conversion!inheritance of user-defined}%
 Conversion functions are inherited.
 
 \pnum
@@ -930,7 +930,7 @@ Conversion functions are inherited.
 Conversion functions can be virtual.
 
 \pnum
-\indextext{conversion!deduced~return~type~of user-defined}%
+\indextext{conversion!deduced return type of user-defined}%
 A conversion function template shall not have a
 deduced return type~(\ref{dcl.spec.auto}).
 \begin{example}
@@ -991,8 +991,8 @@ of a destructor declaration (if any) shall be \tcode{friend}, \tcode{inline}, or
 A destructor is used to destroy objects of its class type.
 \indextext{restriction!destructor}%
 The address of a destructor shall not be taken.
-\indextext{\idxcode{const}!destructor~and}%
-\indextext{\idxcode{volatile}!destructor~and}%
+\indextext{\idxcode{const}!destructor and}%
+\indextext{\idxcode{volatile}!destructor and}%
 A destructor can be invoked for a
 \tcode{const},
 \tcode{volatile}
@@ -1014,7 +1014,7 @@ has the same exception specification as if had been implicitly declared~(\ref{ex
 \end{note}
 
 \pnum
-\indextext{generated~destructor|see{destructor, default}}%
+\indextext{generated destructor|see{destructor, default}}%
 \indextext{destructor!default}%
 \indextext{destructor!non-trivial}%
 If a class has no user-declared
@@ -1073,9 +1073,9 @@ destructors for its base classes and its non-static data members shall have been
 implicitly defined.
 
 \pnum
-\indextext{order~of~execution!destructor}%
-\indextext{order~of~execution!base~class destructor}%
-\indextext{order~of~execution!member destructor}%
+\indextext{order of execution!destructor}%
+\indextext{order of execution!base class destructor}%
+\indextext{order of execution!member destructor}%
 After executing the body of the destructor and destroying
 any automatic objects allocated within the body, a
 destructor for class
@@ -1100,7 +1100,7 @@ A
 statement~(\ref{stmt.return}) in a destructor might not directly return to the
 caller; before transferring control to the caller, the destructors for the
 members and bases are called.
-\indextext{order~of~execution!destructor~and array}%
+\indextext{order of execution!destructor and array}%
 Destructors for elements of an array are called in reverse order of their
 construction (see~\ref{class.init}).
 
@@ -1118,14 +1118,14 @@ If a class has a base class with a virtual destructor, its  destructor
 
 \pnum
 \begin{note}
-\indextext{member function!destructor~and}%
+\indextext{member function!destructor and}%
 some language constructs have special semantics when used during destruction;
 see~\ref{class.cdtor}.
 \end{note}
 
 \pnum
 \indextext{destructor!implicit call}%
-\indextext{destructor!program termination~and}%
+\indextext{destructor!program termination and}%
 A destructor is invoked implicitly
 
 \begin{itemize}
@@ -1139,7 +1139,7 @@ A destructor is invoked implicitly
 \item for a constructed temporary object when its lifetime ends~(\ref{conv.rval}, \ref{class.temporary}).
 \end{itemize}
 
-\indextext{\idxcode{delete}!destructor~and}%
+\indextext{\idxcode{delete}!destructor and}%
 \indextext{destructor!explicit call}%
 In each case, the context of the invocation is the context of the construction of
 the object. A destructor is also invoked implicitly through use of a
@@ -1216,7 +1216,7 @@ in a member function is not an explicit destructor call~(\ref{expr.unary.op}).
 
 \pnum
 \begin{note}
-\indextext{object!destructor~and placement~of}%
+\indextext{object!destructor and placement of}%
 explicit calls of destructors are rarely needed.
 One use of such calls is for objects placed at specific
 addresses using a placement
@@ -1225,7 +1225,7 @@ Such use of explicit placement and destruction of objects can be necessary
 to cope with dedicated hardware resources and for writing memory management
 facilities.
 For example,
-\indextext{example!explicit destructor~call}%
+\indextext{example!explicit destructor call}%
 
 \begin{codeblock}
 void* operator new(std::size_t, void* p) { return p; }
@@ -1256,7 +1256,7 @@ invoke implicit destruction of the object, the behavior is undefined.
 
 \pnum
 \begin{note}
-\indextext{fundamental~type!destructor~and}%
+\indextext{fundamental type!destructor and}%
 the notation for explicit call of a destructor can be used for any scalar type
 name~(\ref{expr.pseudo}).
 Allowing this makes it possible to write code without having to know if a
@@ -1274,7 +1274,7 @@ p->I::~I();
 \indextext{free store}%
 
 \pnum
-\indextext{\idxcode{new}!type~of}
+\indextext{\idxcode{new}!type of}
 Any allocation function for a class
 \tcode{T}
 is a static member (even if not explicitly declared
@@ -1339,7 +1339,7 @@ If the result of the lookup is ambiguous or inaccessible, or if the lookup
 selects a placement deallocation function, the program is ill-formed.
 
 \pnum
-\indextext{\idxcode{delete}!type~of}%
+\indextext{\idxcode{delete}!type of}%
 Any deallocation function for a class
 \tcode{X}
 is a static member (even if not explicitly declared
@@ -1365,8 +1365,8 @@ Since member allocation and deallocation functions are
 \tcode{static}
 they cannot be virtual.
 \begin{note}
-\indextext{example!destructor~and \tcode{delete}}%
-\indextext{example!scope~of \tcode{delete}}%
+\indextext{example!destructor and \tcode{delete}}%
+\indextext{example!scope of \tcode{delete}}%
 however, when the
 \grammarterm{cast-expression}
 of a
@@ -1447,9 +1447,9 @@ has a non-throwing exception specification~(\ref{except.spec}).
 \end{note}
 
 \rSec1[class.init]{Initialization}%
-\indextext{initialization!class~object|(}%
+\indextext{initialization!class object|(}%
 \indextext{initialization!default constructor and}%
-\indextext{initialization!constructor~and}
+\indextext{initialization!constructor and}
 
 \pnum
 When no initializer is specified for an object of (possibly
@@ -1463,7 +1463,7 @@ An object of class type (or array thereof) can be explicitly initialized;
 see~\ref{class.expl.init} and~\ref{class.base.init}.
 
 \pnum
-\indextext{order~of~execution!constructor~and array}%
+\indextext{order of execution!constructor and array}%
 When an array of class objects is initialized
 (either explicitly or implicitly) and the elements are initialized by constructor,
 the constructor shall be called for each element of the array,
@@ -1475,7 +1475,7 @@ construction.
 
 \rSec2[class.expl.init]{Explicit initialization}%
 \indextext{initialization!explicit}%
-\indextext{initialization!constructor~and}%
+\indextext{initialization!constructor and}%
 
 \pnum
 An object of class type can be initialized with a parenthesized
@@ -1493,7 +1493,7 @@ using the
 form of initialization.
 Either direct-initialization semantics or copy-initialization semantics apply;
 see~\ref{dcl.init}.
-\indextext{example!constructor~and initialization}%
+\indextext{example!constructor and initialization}%
 \begin{example}
 
 \begin{codeblock}
@@ -1523,14 +1523,14 @@ complex g = { 1, 2 };           // initialize by a call of
 \end{codeblock}
 \end{example}
 \begin{note}
-\indextext{initialization!overloaded assignment~and}%
+\indextext{initialization!overloaded assignment and}%
 overloading of the assignment operator~(\ref{over.ass})
 has no effect on initialization.
 \end{note}
 
 \pnum
-\indextext{initialization!array~of class~objects}%
-\indextext{constructor!array~of class~objects~and}%
+\indextext{initialization!array of class objects}%
+\indextext{constructor!array of class objects and}%
 An object of class type can also be initialized by a
 \grammarterm{braced-init-list}. List-initialization semantics apply;
 see~\ref{dcl.init} and~\ref{dcl.init.list}. \begin{example}
@@ -1594,13 +1594,13 @@ is explicitly specified (see~\ref{class.init} and~\ref{dcl.init}).
 
 \pnum
 \begin{note}
-\indextext{order~of~execution!constructor~and \tcode{static}~objects}%
+\indextext{order of execution!constructor and \tcode{static} objects}%
 the order in which objects with static or thread storage duration
 are initialized is described in~\ref{basic.start.dynamic} and~\ref{stmt.dcl}.
 \end{note}
 
 \rSec2[class.base.init]{Initializing bases and members}%
-\indextext{initialization!base~class}%
+\indextext{initialization!base class}%
 \indextext{initialization!member}
 
 \pnum
@@ -1727,8 +1727,8 @@ struct C {
 \end{example}
 
 \pnum
-\indextext{initialization!base~class}%
-\indextext{initialization!member~object}%
+\indextext{initialization!base class}%
+\indextext{initialization!member object}%
 The
 \grammarterm{expression-list}
 or \grammarterm{braced-init-list}
@@ -1901,7 +1901,7 @@ proceeds in the following order:
 
 \begin{itemize}
 \item
-\indextext{initialization!order~of virtual~base~class}%
+\indextext{initialization!order of virtual base class}%
 First, and only for the constructor of the most derived class~(\ref{intro.object}),
 virtual base classes are initialized in the order they appear on a
 depth-first left-to-right traversal of the directed acyclic graph of
@@ -1910,14 +1910,14 @@ where ``left-to-right'' is the order of appearance of the base classes
 in the derived class
 \grammarterm{base-specifier-list}.
 \item
-\indextext{initialization!order~of base~class}%
+\indextext{initialization!order of base class}%
 Then, direct base classes are initialized in declaration order
 as they appear in the
 \grammarterm{base-specifier-list}
 (regardless of the order of the
 \grammarterm{mem-initializers}).
 \item
-\indextext{initialization!order~of member}%
+\indextext{initialization!order of member}%
 Then, non-static data members are initialized in the order
 they were declared in the class definition
 (again regardless of the order of the
@@ -1967,7 +1967,7 @@ C c(4);             // use \tcode{V()}
 \end{example}
 
 \pnum
-\indextext{initializer!scope~of member}%
+\indextext{initializer!scope of member}%
 Names in the
 \grammarterm{expression-list}
 or \grammarterm{braced-init-list}
@@ -2097,10 +2097,10 @@ public:
 \end{codeblock}
 
 \end{example}%
-\indextext{initialization!class~object|)}
+\indextext{initialization!class object|)}
 
 \rSec2[class.inhctor.init]{Initialization by inherited constructor}%
-\indextext{initialization!by~inherited~constructor}
+\indextext{initialization!by inherited constructor}
 
 \pnum
 When a constructor for type \tcode{B} is invoked
@@ -2302,8 +2302,8 @@ struct E : C, D, X {
 \end{example}
 
 \pnum
-\indextext{virtual~function~call!constructor~and}%
-\indextext{virtual~function~call!destructor~and}%
+\indextext{virtual function call!constructor and}%
+\indextext{virtual function call!destructor and}%
 \indextext{construction!virtual function call}%
 \indextext{destruction!virtual function call}%
 Member functions, including virtual functions~(\ref{class.virtual}), can be called
@@ -2439,8 +2439,8 @@ B::B(V* v, A* a) {
 \indextext{construction|)}
 
 \rSec1[class.copy]{Copying and moving class objects}%
-\indextext{copy!class~object|see{constructor, copy; assignment, copy}}%
-\indextext{move!class~object|see{constructor, move; assignment, move}}%
+\indextext{copy!class object|see{constructor, copy; assignment, copy}}%
+\indextext{move!class object|see{constructor, move; assignment, move}}%
 \indextext{operator!copy assignment|see{assignment, copy}}%
 \indextext{operator!move assignment|see{assignment, move}}
 
@@ -2774,7 +2774,7 @@ if a member \tcode{m} has rvalue reference type \tcode{T\&\&}, it is direct-init
 otherwise, the base or member is direct-initialized with the corresponding base or member of \tcode{x}.
 \end{itemize}
 
-\indextext{initialization!virtual~base~class}%
+\indextext{initialization!virtual base class}%
 Virtual base class subobjects shall be initialized only once by
 the implicitly-defined copy/move constructor (see~\ref{class.base.init}).
 
@@ -3124,7 +3124,7 @@ union \tcode{X} copies the object representation~(\ref{basic.types}) of \tcode{X
 \rSec2[class.copy.elision]{Copy/move elision}%
 
 \pnum
-\indextext{temporary!elimination~of}%
+\indextext{temporary!elimination of}%
 \indextext{elision!copy constructor|see{constructor, copy, elision}}%
 \indextext{elision!move constructor|see{constructor, move, elision}}%
 \indextext{constructor!copy!elision}%

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -32,7 +32,7 @@ Except as indicated, statements are executed in sequence.
 The optional \grammarterm{attribute-specifier-seq} appertains to the respective statement.
 
 \pnum
-\indextext{\idxgram{condition}{s}!rules~for}%
+\indextext{\idxgram{condition}{s}!rules for}%
 The rules for \grammarterm{}{condition}{s} apply both to
 \grammarterm{selection-statement}{s} and to the \tcode{for} and \tcode{while}
 statements~(\ref{stmt.iter}). The \grammarterm{}{declarator} shall not
@@ -97,7 +97,7 @@ or \tcode{constexpr}.
 
 \pnum
 \indextext{statement!labeled}%
-\indextext{\idxcode{:}!label~specifier}%
+\indextext{\idxcode{:}!label specifier}%
 A statement can be labeled.
 
 \begin{bnf}
@@ -112,11 +112,11 @@ The optional \grammarterm{attribute-specifier-seq} appertains to the label. An
 identifier label is as the target of a
 \indextext{statement!\idxcode{goto}}%
 \tcode{goto}.
-\indextext{label!scope~of}%
+\indextext{label!scope of}%
 The scope of a label is the function in which it appears. Labels shall
 not be redeclared within a function. A label can be used in a
 \tcode{goto} statement before its declaration.
-\indextext{name~space!label}%
+\indextext{name space!label}%
 Labels have their own name space and do not interfere with other
 identifiers.
 \begin{note}
@@ -390,7 +390,7 @@ Usually, the substatement that is the subject of a switch is compound
 and \tcode{case} and \tcode{default} labels appear on the top-level
 statements contained within the (compound) substatement, but this is not
 required.
-\indextext{statement!declaration~in \tcode{switch}}%
+\indextext{statement!declaration in \tcode{switch}}%
 Declarations can appear in the substatement of a
 \grammarterm{switch-statement}.
 \end{note}%
@@ -489,7 +489,7 @@ until the value of the condition~(\ref{stmt.select}) becomes
 substatement.
 
 \pnum
-\indextext{statement!declaration~in \tcode{while}}%
+\indextext{statement!declaration in \tcode{while}}%
 When the condition of a \tcode{while} statement is a declaration, the scope of
 the variable that is declared extends from its point of
 declaration~(\ref{basic.scope.pdecl}) to the end of the \tcode{while}
@@ -572,7 +572,7 @@ is equivalent to
 except that names declared in the \grammarterm{init-statement} are in
 the same declarative region as those declared in the
 \grammarterm{condition}, and except that a
-\indextext{statement!\tcode{continue}~in \tcode{for}}%
+\indextext{statement!\tcode{continue} in \tcode{for}}%
 \tcode{continue} in \grammarterm{statement} (not enclosed in another
 iteration statement) will execute \grammarterm{expression} before
 re-evaluating \grammarterm{condition}.
@@ -592,8 +592,8 @@ makes the implied \tcode{while} clause
 equivalent to \tcode{while(true)}.
 
 \pnum
-\indextext{statement!declaration~in \tcode{for}}%
-\indextext{\idxcode{for}!scope~of declaration~in}%
+\indextext{statement!declaration in \tcode{for}}%
+\indextext{\idxcode{for}!scope of declaration in}%
 If the \grammarterm{init-statement} is a declaration, the scope of the
 name(s) declared extends to the end of the \tcode{for} statement.
 \begin{example}
@@ -610,7 +610,7 @@ int j = i;          // \tcode{j = 42}
 \end{example}
 
 \rSec2[stmt.ranged]{The range-based \tcode{for} statement}%
-\indextext{statement!range~based \idxcode{for}}
+\indextext{statement!range based \idxcode{for}}
 
 \pnum
 The range-based \tcode{for} statement
@@ -707,8 +707,8 @@ Jump statements unconditionally transfer control.
 \end{bnf}
 
 \pnum
-\indextext{local~variable!destruction~of}%
-\indextext{scope!destructor~and exit~from}%
+\indextext{local variable!destruction of}%
+\indextext{scope!destructor and exit from}%
 On exit from a scope (however accomplished), objects with automatic storage
 duration~(\ref{basic.stc.auto}) that have been constructed in that scope are destroyed
 in the reverse order of their construction. \begin{note} For temporaries,
@@ -790,7 +790,7 @@ equivalent to \tcode{goto} \tcode{contin}.
 
 \rSec2[stmt.return]{The \tcode{return} statement}%
 \indextext{\idxcode{return}}%
-\indextext{function~return|see{\tcode{return}}}%
+\indextext{function return|see{\tcode{return}}}%
 
 \pnum
 A function returns to its caller by the \tcode{return} statement.
@@ -801,13 +801,13 @@ of a return statement is called its operand. A return statement with
 no operand shall be used only in a function whose return type is
 \cv{} \tcode{void}, a constructor~(\ref{class.ctor}), or a
 destructor~(\ref{class.dtor}).
-\indextext{\idxcode{return}!constructor~and}%
-\indextext{\idxcode{return}!constructor~and}%
+\indextext{\idxcode{return}!constructor and}%
+\indextext{\idxcode{return}!constructor and}%
 A return statement with an operand of type \tcode{void} shall be used only
 in a function whose return type is \cv{} \tcode{void}.
 A return statement with any other operand shall be used only
 in a function whose return type is not \cv{} \tcode{void};
-\indextext{conversion!return~type}%
+\indextext{conversion!return type}%
 the return statement initializes the
 glvalue result or prvalue result object of the (explicit or implicit) function call
 by copy-initialization~(\ref{dcl.init}) from the operand.
@@ -864,24 +864,24 @@ block; it has the form
 
 If an identifier introduced by a declaration was previously declared in
 an outer block,
-\indextext{declaration~hiding|see{name~hiding}}%
-\indextext{name~hiding}%
-\indextext{block~structure}%
+\indextext{declaration hiding|see{name hiding}}%
+\indextext{name hiding}%
+\indextext{block structure}%
 the outer declaration is hidden for the remainder of the block, after
 which it resumes its force.
 
 \pnum
-\indextext{block!initialization~in}%
+\indextext{block!initialization in}%
 \indextext{initialization!automatic}%
 Variables with automatic storage duration~(\ref{basic.stc.auto}) are
 initialized each time their \grammarterm{declaration-statement} is executed.
-\indextext{local~variable!destruction~of}%
+\indextext{local variable!destruction of}%
 Variables with automatic storage duration declared in the block are
 destroyed on exit from the block~(\ref{stmt.jump}).
 
 \pnum
-\indextext{initialization!jump~past}%
-\indextext{\idxcode{goto}!initialization~and}%
+\indextext{initialization!jump past}%
+\indextext{\idxcode{goto}!initialization and}%
 It is possible to transfer into a block, but not in a way that bypasses
 declarations with initialization. A program that jumps\footnote{The transfer from the condition of a \tcode{switch} statement to a
 \tcode{case} label is considered a jump in this respect.}
@@ -908,7 +908,7 @@ lx:
 
 \pnum
 \indextext{initialization!automatic}%
-\indextext{initialization!dynamic~block-scope}%
+\indextext{initialization!dynamic block-scope}%
 \indextext{initialization!local \tcode{static}}%
 \indextext{initialization!local \tcode{thread_local}}%
 Dynamic initialization of a block-scope variable with
@@ -931,7 +931,7 @@ int foo(int i) {
 \end{example}
 
 \pnum
-\indextext{\idxcode{static}!destruction~of local}%
+\indextext{\idxcode{static}!destruction of local}%
 The destructor for a block-scope object with static or thread storage duration will be
 executed if and only if it was constructed.
 \begin{note}
@@ -940,7 +940,7 @@ static and thread storage duration are destroyed.
 \end{note}
 
 \rSec1[stmt.ambig]{Ambiguity resolution}%
-\indextext{ambiguity!declaration~versus expression}
+\indextext{ambiguity!declaration versus expression}
 
 \pnum
 There is an ambiguity in the grammar involving

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -51,11 +51,11 @@ class template or of a class nested within a class template, or
 \end{itemize}
 
 A \grammarterm{template-declaration} is a \grammarterm{declaration}.
-\indextext{template!definition~of}%
+\indextext{template!definition of}%
 A \grammarterm{template-declaration} is also a definition
 if its \grammarterm{declaration} defines a function, a class, a variable, or a
 static data member. A declaration introduced by a template declaration of a
-\indextext{variable template!definition~of}%
+\indextext{variable template!definition of}%
 \indextext{template!variable}%
 \indextext{template!static data member}%
 variable is a \term{variable template}. A variable template at class scope is a
@@ -110,7 +110,7 @@ When such a declaration is used to declare a class template,
 no declarator is permitted.
 
 \pnum
-\indextext{template~name!linkage~of}%
+\indextext{template name!linkage of}%
 A template name has linkage~(\ref{basic.link}).
 Specializations (explicit or implicit) of
 a template that has internal linkage are
@@ -352,9 +352,9 @@ template<double& rd> class Z;   // OK
 \pnum
 A non-type
 \grammarterm{template-parameter}
-\indextext{array!template parameter~of~type}%
+\indextext{array!template parameter of type}%
 of type ``array of \tcode{T}'' or
-\indextext{function!template parameter~of~type}%
+\indextext{function!template parameter of type}%
 of function type \tcode{T}
 is adjusted to be of type ``pointer to \tcode{T}''.
 \begin{example}
@@ -471,7 +471,7 @@ template<class T = int> class X { /*... */ }; // error
 \end{codeblock}
 \end{example}
 
-\indextext{\idxcode{<}!template~and}%
+\indextext{\idxcode{<}!template and}%
 \pnum
 When parsing a
 default
@@ -600,7 +600,7 @@ to be explicitly qualified by the template arguments,
 the name must be known to refer to a template.
 
 \pnum
-\indextext{\idxcode{<}!template~and}%
+\indextext{\idxcode{<}!template and}%
 After name lookup~(\ref{basic.lookup}) finds that a name is a
 \grammarterm{template-name}
 or that an \grammarterm{operator-function-id} or a \grammarterm{literal-operator-id} refers to a set of
@@ -1457,7 +1457,7 @@ shall agree in kind with the original class template declaration~(\ref{dcl.type.
 \rSec3[temp.mem.func]{Member functions of class templates}
 
 \pnum
-\indextext{template!member~function}%
+\indextext{template!member function}%
 A member function
 of a class template
 may be defined outside of the class
@@ -1533,7 +1533,7 @@ A<int>::B  b2;                  // OK: requires \tcode{A::B} to be defined
 \rSec3[temp.static]{Static data members of class templates}
 
 \pnum
-\indextext{member!template~and \tcode{static}}%
+\indextext{member!template and \tcode{static}}%
 A definition for a static data member or static data member template may be
 provided in a namespace scope enclosing the definition of the static member's
 class template.
@@ -2003,7 +2003,7 @@ the instantiation is ill-formed.
 \rSec2[temp.friend]{Friends}
 
 \pnum
-\indextext{friend!template~and}%
+\indextext{friend!template and}%
 A friend of a class or class template can be a function template or
 class template, a specialization of a function template or class
 template, or a non-template function or class.
@@ -2436,7 +2436,7 @@ of the primary template.
 \rSec3[temp.class.order]{Partial ordering of class template specializations}
 
 \pnum
-\indextext{more~specialized!class~template}%
+\indextext{more specialized!class template}%
 For two class template partial specializations,
 the first is \term{more specialized} than the second if, given the following
 rewrite to two function templates, the first function template is more
@@ -3192,7 +3192,7 @@ template<class T> struct A {
 
 \pnum
 \indextext{checking!syntax}%
-\indextext{checking!point~of error}%
+\indextext{checking!point of error}%
 Knowing which names are type names allows the syntax of every template
 to be checked.
 The program is ill-formed, no diagnostic required, if:
@@ -3822,7 +3822,7 @@ template <class T1, class T2, int I> struct B {
 \end{example}
 
 \pnum
-\indextext{base~class!dependent}%
+\indextext{base class!dependent}%
 A \term{dependent base class} is a base class that is a dependent type and is
 not the current instantiation.
 \begin{note}
@@ -4338,7 +4338,7 @@ and from the definition context.
 \rSec3[temp.point]{Point of instantiation}
 
 \pnum
-\indextext{instantiation!point~of}%
+\indextext{instantiation!point of}%
 For a function template specialization, a member function template
 specialization, or a specialization for a member function or static data member
 of a class template,
@@ -6778,8 +6778,8 @@ at least as specialized as the argument type.
 \end{itemize}
 
 \pnum
-\indextext{more~specialized!function~template}%
-\indextext{at~least~as specialized~as|see{more~specialized}}%
+\indextext{more specialized!function template}%
+\indextext{at least as specialized as|see{more specialized}}%
 Function template \tcode{F}
 is \term{at least as specialized as}
 function template \tcode{G} if,

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2146,7 +2146,7 @@ as it cannot be deduced from the argument list. \end{note}
 
 \rSec3[tuple.helper]{Tuple helper classes}
 
-\indexlibrary{\idxcode{tuple_size}!in~general}%
+\indexlibrary{\idxcode{tuple_size}!in general}%
 \begin{itemdecl}
 template <class T> struct tuple_size;
 \end{itemdecl}


### PR DESCRIPTION
Fixes #1064 and #664.

diffpdf doesn't really work here, because a lot of index entries are shuffled around (and are now sorted correctly).