### PR TITLE
[numeric.special] Remove redundant 'inline' specifiers in example.

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -1063,9 +1063,9 @@ namespace std {
   public:
     static constexpr bool is_specialized = true;
 
-    inline static constexpr float min() noexcept { return 1.17549435E-38F; }
-    inline static constexpr float max() noexcept { return 3.40282347E+38F; }
-    inline static constexpr float lowest() noexcept { return -3.40282347E+38F; }
+    static constexpr float min() noexcept { return 1.17549435E-38F; }
+    static constexpr float max() noexcept { return 3.40282347E+38F; }
+    static constexpr float lowest() noexcept { return -3.40282347E+38F; }
 
     static constexpr int digits   = 24;
     static constexpr int digits10 =  6;
@@ -1076,8 +1076,8 @@ namespace std {
     static constexpr bool is_exact   = false;
 
     static constexpr int radix = 2;
-    inline static constexpr float epsilon() noexcept     { return 1.19209290E-07F; }
-    inline static constexpr float round_error() noexcept { return 0.5F; }
+    static constexpr float epsilon() noexcept     { return 1.19209290E-07F; }
+    static constexpr float round_error() noexcept { return 0.5F; }
 
     static constexpr int min_exponent   = -125;
     static constexpr int min_exponent10 = - 37;
@@ -1090,10 +1090,10 @@ namespace std {
     static constexpr float_denorm_style has_denorm = denorm_absent;
     static constexpr bool has_denorm_loss          = false;
 
-    inline static constexpr float infinity()      noexcept { return @\textit{value}@; }
-    inline static constexpr float quiet_NaN()     noexcept { return @\textit{value}@; }
-    inline static constexpr float signaling_NaN() noexcept { return @\textit{value}@; }
-    inline static constexpr float denorm_min()    noexcept { return min(); }
+    static constexpr float infinity()      noexcept { return @\textit{value}@; }
+    static constexpr float quiet_NaN()     noexcept { return @\textit{value}@; }
+    static constexpr float signaling_NaN() noexcept { return @\textit{value}@; }
+    static constexpr float denorm_min()    noexcept { return min(); }
 
     static constexpr bool is_iec559  = true;
     static constexpr bool is_bounded = true;


### PR DESCRIPTION
'inline' is doubly redundant here because these member functions are defined inside the class definition as well as constexpr.