### PR TITLE
[rand.req.adapt] Fix syntax error

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -2133,7 +2133,7 @@ A::A(result_type s);
 
 
 \begin{itemdecl}
-template<class Sseq> void A::A(Sseq& q);  
+template<class Sseq> A::A(Sseq& q);
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
The `void` return type in the constructor is clearly an error, and I think adding `A::` to the member functions is good for clarity.