### PR TITLE
[char.traits] Use \tcode around parameter name

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -49,7 +49,7 @@ Most classes specified in Clauses~\ref{string.classes}
 and~\ref{input.output} need a set of related types and functions to complete
 the definition of their semantics.  These types and functions are provided as a
 set of member \grammarterm{typedef-name}{s} and functions in the template
-parameter `traits' used by each such template.  This subclause defines the
+parameter \tcode{traits} used by each such template.  This subclause defines the
 semantics of these members.
 
 \pnum


### PR DESCRIPTION
Those quotes look really strange to me.