### PR TITLE
[expr.ass] The right operand is not necessarily an expression.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4734,12 +4734,12 @@ single compound assignment operator.
 \end{bnf}
 
 \pnum
-In simple assignment (\tcode{=}), the value of the expression replaces
+In simple assignment (\tcode{=}), the value of the right operand replaces
 that of the object referred to by the left operand.
 
 \pnum
 \indextext{assignment!conversion by}%
-If the left operand is not of class type, the expression is implicitly
+If the left operand is not of class type, the right operand is implicitly
 converted (Clause~\ref{conv}) to the cv-unqualified type of the left
 operand.
 
@@ -4759,7 +4759,7 @@ initialization~(\ref{dcl.init},~\ref{class.ctor},~\ref{class.init},~\ref{class.c
 \pnum
 \indextext{reference!assignment to}%
 When the left operand of an assignment operator
-is a bit-field that cannot represent the value of the expression, the
+is a bit-field that cannot represent the value of the right operand, the
 resulting value of the bit-field is
 \impldefplain{value of bit-field that cannot represent!assigned value}.
 


### PR DESCRIPTION
Fixes #720.