### PR TITLE
[allocator] Format OUTERMOST in code font

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -12313,15 +12313,15 @@ from \tcode{other}.
 \pnum
 In the \tcode{construct} member functions,
 \tcode{\textit{OUTERMOST}(x)} is \tcode{x} if \tcode{x} does not have an
-\tcode{outer_allocator()} member function and \\
+\tcode{outer_allocator()} member function and
 \tcode{\textit{OUTERMOST}(x.outer_allocator())}
 otherwise;
 \tcode{\textit{OUTERMOST_ALLOC_TRAITS}(x)} is \\
 \tcode{allocator_traits<decltype(\textit{OUTERMOST}(x))>}.
-\begin{note} \tcode{\textit{OUTERMOST}(x)} and \\
+\begin{note} \tcode{\textit{OUTERMOST}(x)} and
 \tcode{\textit{OUTERMOST_ALLOC_TRAITS}(x)} are recursive operations. It
 is incumbent upon the definition of \tcode{outer_allocator()} to ensure that the
-recursion terminates. It will terminate for all instantiations of \\
+recursion terminates. It will terminate for all instantiations of
 \tcode{scoped_allocator_adaptor}. \end{note}
 
 \indexlibrarymember{inner_allocator}{scoped_allocator_adaptor}%

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -12312,14 +12312,14 @@ from \tcode{other}.
 
 \pnum
 In the \tcode{construct} member functions,
-\textit{OUTERMOST(x)} is \tcode{x} if \tcode{x} does not have an
+\tcode{\textit{OUTERMOST}(x)} is \tcode{x} if \tcode{x} does not have an
 \tcode{outer_allocator()} member function and \\
-\textit{OUTERMOST(x.outer_allocator())}
+\tcode{\textit{OUTERMOST}(x.outer_allocator())}
 otherwise;
-\textit{OUTERMOST_ALLOC_TRAITS(x)} is \\
+\tcode{\textit{OUTERMOST_ALLOC_TRAITS}(x)} is \\
 \tcode{allocator_traits<decltype(\textit{OUTERMOST}(x))>}.
-\begin{note} \textit{OUTERMOST}(x) and \\
-\textit{OUTERMOST_ALLOC_TRAITS}(x) are recursive operations. It
+\begin{note} \tcode{\textit{OUTERMOST}(x)} and \\
+\tcode{\textit{OUTERMOST_ALLOC_TRAITS}(x)} are recursive operations. It
 is incumbent upon the definition of \tcode{outer_allocator()} to ensure that the
 recursion terminates. It will terminate for all instantiations of \\
 \tcode{scoped_allocator_adaptor}. \end{note}
@@ -12410,18 +12410,18 @@ template <class T, class... Args>
 \begin{itemize}
 \item If \tcode{uses_allocator_v<T, inner_allocator_type>} is \tcode{false} and\\
 \tcode{is_constructible_v<T, Args...>} is \tcode{true}, calls\\
-\textit{OUTERMOST_ALLOC_TRAITS}(\tcode{*this})\tcode{::construct(\\
+\tcode{\textit{OUTERMOST_ALLOC_TRAITS}(*this)::construct(\\
 \textit{OUTERMOST}(*this), p, std::forward<Args>(args)...)}.
 
 \item Otherwise, if \tcode{uses_allocator_v<T, inner_allocator_type>} is \tcode{true} and
 \tcode{is_construc\-tible_v<T, allocator_arg_t, inner_allocator_type\&, Args...>} is \tcode{true}, calls
-\textit{OUTERMOST_ALLOC_TRAITS}(\tcode{*this})\tcode{::construct(\textit{OUTERMOST}(*this),
+\tcode{\textit{OUTERMOST_ALLOC_TRAITS}(*this)::construct(\textit{OUTERMOST}(*this),
 p, allocator_arg,\\inner_allocator(), std::forward<Args>(args)...)}.
 
 \item Otherwise, if \tcode{uses_allocator_v<T, inner_allocator_type>} is \tcode{true} and
 \tcode{is_construct\-ible_v<T, Args..., inner_allocator_type\&>} is \tcode{true}, calls
-\textit{OUTERMOST_ALLOC_TRAITS}(*this)::
-\tcode{construct(\textit{OUTERMOST}(*this), p, std::forward<Args>(args)...,\\inner_allocator())}.
+\tcode{\textit{OUTERMOST_ALLOC_TRAITS}(*this)::
+construct(\textit{OUTERMOST}(*this), p, std::forward<Args>(args)...,\\inner_allocator())}.
 
 \item Otherwise, the program is ill-formed. \begin{note} An error will result if
 \tcode{uses_allocator} evaluates to \tcode{true} but the specific constructor does not take an


### PR DESCRIPTION
Other similar terms like *`INVOKE`*, *`DECAY_COPY`*, and *`GENERALIZED_SUM`* are always in code font and italics.

![diff-1](https://cloud.githubusercontent.com/assets/148275/21035408/c3a49ca8-bdb6-11e6-90b6-cda7e2e87150.png)
![diff-2](https://cloud.githubusercontent.com/assets/148275/21035411/c667f250-bdb6-11e6-89ee-01bc15a52276.png)

