### PR TITLE
[limits] Use 'subnormal number' as defined by IEEE 754-2008 = ISO 60559.

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -468,8 +468,9 @@ static constexpr T min() noexcept;
 Minimum finite value.\footnote{Equivalent to \tcode{CHAR_MIN}, \tcode{SHRT_MIN},
 \tcode{FLT_MIN}, \tcode{DBL_MIN}, etc.}
 
+\indextext{number!subnormal}%
 \pnum
-For floating types with denormalization, returns the minimum positive
+For floating types with subnormal numbers, returns the minimum positive
 normalized value.
 
 \pnum
@@ -772,17 +773,18 @@ for all specializations in which
 static constexpr float_denorm_style has_denorm;
 \end{itemdecl}
 
+\indextext{number!subnormal}%
 \begin{itemdescr}
 \pnum
 \tcode{denorm_present}
-if the type allows denormalized values
+if the type allows subnormal values
 (variable number of exponent bits)\footnote{Required by LIA-1.},
 \tcode{denorm_absent}
-if the type does not allow denormalized values,
+if the type does not allow subnormal values,
 and
 \tcode{denorm_indeterminate}
 if it is indeterminate at compile time whether the type allows
-denormalized values.
+subnormal values.
 
 \pnum
 Meaningful for all floating-point types.
@@ -854,8 +856,9 @@ static constexpr T denorm_min() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
+\indextext{number!subnormal}%
 \pnum
-Minimum positive denormalized value.\footnote{Required by LIA-1.}
+Minimum positive subnormal value.\footnote{Required by LIA-1.}
 
 \pnum
 Meaningful for all floating-point types.
@@ -1021,23 +1024,27 @@ namespace std {
 }
 \end{codeblock}
 
+\indextext{denormalized value|see{number, subnormal}}%
+\indextext{value!denormalized|see{number, subnormal}}%
+\indextext{subnormal number|see{number, subnormal}}%
+\indextext{number!subnormal}%
 \pnum
-The presence or absence of denormalization (variable number of exponent bits)
+The presence or absence of subnormal numbers (variable number of exponent bits)
 is characterized by the values:
 
 \begin{itemize}
 \item
 \indexlibrary{\idxcode{denorm_indeterminate}}%
 \tcode{denorm_indeterminate}
-if it cannot be determined whether or not the type allows denormalized values
+if it cannot be determined whether or not the type allows subnormal values
 \item
 \indexlibrary{\idxcode{denorm_absent}}%
 \tcode{denorm_absent}
-if the type does not allow denormalized values
+if the type does not allow subnormal values
 \item
 \indexlibrary{\idxcode{denorm_present}}%
 \tcode{denorm_present}
-if the type does allow denormalized values
+if the type does allow subnormal values
 \end{itemize}
 
 \rSec3[numeric.special]{\tcode{numeric_limits} specializations}


### PR DESCRIPTION
Also add index entries for 'denormalized value' and 'value,
denormalized', pointing to 'number, subnormal'.

Fixes #1017.