### PR TITLE
For 'immediate context', refer to [temp.deduct].

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16312,11 +16312,11 @@ To test() {
 \end{codeblock}
 
 \begin{note} This requirement gives well defined results for reference types, void
-types, array types, and function types.\end{note} Access checking is performed as
-if in a context unrelated to \tcode{To} and \tcode{From}. Only the validity of
-the immediate context of the expression of the \grammarterm{return-statement}
-(including conversions to the return type) is considered. \begin{note} The
-evaluation of the conversion can result in side effects such as the
+types, array types, and function types.\end{note} Access checking is performed
+in a context unrelated to \tcode{To} and \tcode{From}. Only the validity of
+the immediate context of the \grammarterm{expression} of the \tcode{return} statement
+(including conversions to the returned object or reference) is considered. \begin{note} The
+initialization can result in side effects such as the
 instantiation of class template specializations and function template
 specializations, the generation of implicitly-defined functions, and so on. Such
 side effects are not in the ``immediate context'' and can result in the program


### PR DESCRIPTION
Drop the duplicated notes explaining ill-formed specializations
in other than the immediate context.

Fixes #445.
Fixes #272.