### PR TITLE
[pairs.pair, tuple.cnstr] Replace 'The constructor initializes' with just 'Initializes', which is how we say it in many other places.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -952,8 +952,7 @@ can be initialized with \tcode{\{\}}. \end{note}
 \begin{itemdescr}
 \pnum
 \effects
-The constructor initializes \tcode{first} with \tcode{x} and \tcode{second}
-with \tcode{y}.
+Initializes \tcode{first} with \tcode{x} and \tcode{second} with \tcode{y}.
 
 \pnum
 \remarks This constructor shall not participate in overload resolution
@@ -972,9 +971,9 @@ template<class U1, class U2> @\EXPLICIT@ constexpr pair(U1&& x, U2&& y);
 \begin{itemdescr}
 \pnum
 \effects
-The constructor initializes \tcode{first} with
+Initializes \tcode{first} with
 \tcode{std::forward<U1>(x)} and \tcode{second}
-with \tcode{std::forward<\brk{}U2>(y)}.
+with \tcode{std::forward<U2>(y)}.
 
 \pnum
 \remarks
@@ -994,7 +993,7 @@ template<class U1, class U2> @\EXPLICIT@ constexpr pair(const pair<U1, U2>& p);
 \begin{itemdescr}
 \pnum
 \effects
-The constructor initializes members from the corresponding members of the argument.
+Initializes members from the corresponding members of the argument.
 
 \pnum
 \remarks This constructor shall not participate in overload resolution unless
@@ -1013,10 +1012,10 @@ template<class U1, class U2> @\EXPLICIT@ constexpr pair(pair<U1, U2>&& p);
 \begin{itemdescr}
 \pnum
 \effects
-The constructor initializes \tcode{first} with
+Initializes \tcode{first} with
 \tcode{std::forward<U1>(p.first)}
 and \tcode{second} with
-\tcode{std::\brk{}forward<U2>(p.second)}.
+\tcode{std::forward<U2>(\brk{}p.second)}.
 
 \pnum
 \remarks This constructor shall not participate in overload resolution unless
@@ -1039,7 +1038,7 @@ template<class... Args1, class... Args2>
 and \tcode{is_constructible_v<sec\-ond_type, Args2\&\&...>} is \tcode{true}.
 
 \pnum
-\effects The constructor initializes \tcode{first} with arguments of types
+\effects Initializes \tcode{first} with arguments of types
 \tcode{Args1...} obtained by forwarding the elements of \tcode{first_args}
 and initializes \tcode{second} with arguments of types \tcode{Args2...}
 obtained by forwarding the elements of \tcode{second_args}. (Here, forwarding
@@ -1599,7 +1598,7 @@ a \tcode{const T$_i$\&} can be initialized with \tcode{\{\}}. \end{note}
 
 \begin{itemdescr}
 \pnum
-\effects The constructor initializes each element with the value of the
+\effects Initializes each element with the value of the
 corresponding parameter.
 
 \pnum
@@ -1618,8 +1617,8 @@ template <class... UTypes>
 
 \begin{itemdescr}
 \pnum
-\effects The constructor initializes the elements in the tuple with the
-corresponding value in \tcode{std::for\-ward<UTypes>(u)}.
+\effects Initializes the elements in the tuple with the
+corresponding value in \tcode{std::forward<UTypes>(u)}.
 
 \pnum
 \remarks This constructor shall not participate in overload resolution unless
@@ -1665,7 +1664,7 @@ template <class... UTypes> @\EXPLICIT@ constexpr tuple(const tuple<UTypes...>& u
 
 \begin{itemdescr}
 \pnum
-\effects The constructor initializes each element of \tcode{*this}
+\effects Initializes each element of \tcode{*this}
 with the corresponding element of \tcode{u}.
 
 \pnum
@@ -1693,7 +1692,7 @@ template <class... UTypes> @\EXPLICIT@ constexpr tuple(tuple<UTypes...>&& u);
 
 \begin{itemdescr}
 \pnum
-\effects For all $i$, the constructor
+\effects For all $i$,
 initializes the $i^\text{th}$ element of \tcode{*this} with
 \tcode{std::forward<U$_i$>(get<$i$>(u))}.
 
@@ -1724,7 +1723,7 @@ template <class U1, class U2> @\EXPLICIT@ constexpr tuple(const pair<U1, U2>& u)
 
 \begin{itemdescr}
 \pnum
-\effects The constructor initializes the first element with \tcode{u.first} and the
+\effects Initializes the first element with \tcode{u.first} and the
 second element with \tcode{u.second}.
 
 \pnum
@@ -1747,7 +1746,7 @@ template <class U1, class U2> @\EXPLICIT@ constexpr tuple(pair<U1, U2>&& u);
 
 \begin{itemdescr}
 \pnum
-\effects The constructor initializes the first element with
+\effects Initializes the first element with
 \tcode{std::forward<U1>(u.first)} and the
 second element with \tcode{std::forward<U2>(u.second)}.
 


### PR DESCRIPTION
This idiosyncrasy seems to have been partially copied from `pair`, but it has eventually been abandoned. We never name the constructor in any other class or class template description.

This shortening has the pleasant effect of simplifying some previously awkward linebreaks (#693).