### PR TITLE
[{ex,in}clusive.scan]: Rephase 'for each *j' in terms of indexes

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -9155,11 +9155,12 @@ ranges \range{first}{last} or \range{result}{result + (last - first)}.
 
 \pnum
 \effects
-Assigns through each iterator \tcode{i} in \range{result}{result + (last - first)} the value of
+For each integer \tcode{K} in \range{0}{last - first}
+assigns through \tcode{result + K} the value of:
 \begin{codeblock}
-@\placeholder{GENERALIZED_NONCOMMUTATIVE_SUM}@(binary_op, init, *j, ...)
+@\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}@(
+    binary_op, init, *(first + 0), *(first + 1), ..., *(first + K - 1))
 \end{codeblock}
-for every \tcode{j} in \range{first}{first + (i - result)}.
 
 \pnum
 \returns
@@ -9248,15 +9249,15 @@ elements in the ranges \range{first}{last} or
 
 \pnum
 \effects
-Assigns through each iterator \tcode{i} in \range{result}{result + (last - first)} the value of
+For each integer \tcode{K} in \range{0}{last - first}
+assigns through \tcode{result + K} the value of
 \begin{itemize}
 \item
-\tcode{\textit{GENERALIZED_NONCOMMUTATIVE_SUM}(binary_op, init, *j, ...)}
-for every \tcode{j} in \range{first}{first + (i - result + 1)}
-if \tcode{init} is provided, or
+  \tcode{\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}(\\\phantom{\tcode{\ \ \ \ }}binary_op,
+  init, *(first + 0), *(first + 1), ..., *(first + K))}\\if \tcode{init} is provided, or
 \item
-\tcode{\textit{GENERALIZED_NONCOMMUTATIVE_SUM}(binary_op, *j, ...)}
-for every \tcode{j} in \range{first}{first + (i - result + 1)} otherwise.
+  \tcode{\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}(\\\phantom{\tcode{\ \ \ \ }}binary_op,
+  *(first + 0), *(first + 1), ..., *(first + K))}\\otherwise.
 \end{itemize}
 
 \pnum
@@ -9310,9 +9311,13 @@ subranges, or modify elements in the ranges
 
 \pnum
 \effects
-Assigns through each iterator \tcode{i} in \range{result}{result + (last - first)} the value of
-\tcode{\textit{GENERALIZED_NONCOMMUTATIVE_SUM}(binary_op, init, unary_op(*j), ...)}
-for every \tcode{j} in \range{first}{first + (i - result)}.
+For each integer \tcode{K} in \range{0}{last - first}
+assigns through \tcode{result + K} the value of:
+\begin{codeblock}
+@\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}@(
+    binary_op, init,
+    unary_op(*(first + 0)), unary_op(*(first + 1)), ..., unary_op(*(first + K - 1)))
+\end{codeblock}
 
 \pnum
 \returns
@@ -9383,15 +9388,15 @@ subranges, or modify elements in the ranges \range{first}{last} or
 
 \pnum
 \effects
-Assigns through each iterator \tcode{i} in \range{result}{result + (last - first)} the value of
+For each integer \tcode{K} in \range{0}{last - first}
+assigns through \tcode{result + K} the value of
 \begin{itemize}
 \item
-\tcode{\textit{GENERALIZED_NONCOMMUTATIVE_SUM}(binary_op, init, unary_op(*j), ...)}
-for every \tcode{j} in \range{first}{first + (i - result + 1)}
-if \tcode{init} is provided, or
+  \tcode{\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}(\\\phantom{\tcode{\ \ \ \ }}binary_op, init,\\\phantom{\tcode{\ \ \ \ }}unary_op(*(first + 0)), unary_op(*(first + 1)), ..., unary_op(*(first + K)))}\\
+  if \tcode{init} is provided, or
 \item
-\tcode{\textit{GENERALIZED_NONCOMMUTATIVE_SUM}(binary_op, unary_op(*j), ...)}
-for every \tcode{j} in \range{first}{first + (i - result + 1)} otherwise.
+  \tcode{\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}(\\\phantom{\tcode{\ \ \ \ }}binary_op,\\\phantom{\tcode{\ \ \ \ }}unary_op(*(first + 0)), unary_op(*(first + 1)), ..., unary_op(*(first + K)))}\\
+  otherwise.
 \end{itemize}
 
 \pnum


### PR DESCRIPTION
Addresses #693 for this part, but is also clearer.

**Exclusive:**

![image](https://cloud.githubusercontent.com/assets/6378233/21080105/a9e8273c-bf9e-11e6-9d1f-0846d80a449a.png)

Note that the range is *empty* when `K` is zero.

**Inclusive:**

![image](https://cloud.githubusercontent.com/assets/6378233/21080116/d1ff33dc-bf9e-11e6-8e26-b2080d361792.png)
