### PR TITLE
[pairs.spec], [tuple.creation] Avoid 'equality' of types phrasing.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1252,9 +1252,9 @@ template <class T1, class T2>
 \pnum
 \returns \tcode{pair<V1, V2>(std::forward<T1>(x), std::forward<T2>(y))},
 where \tcode{V1} and \tcode{V2} are determined as follows: Let \tcode{Ui} be
-\tcode{decay_t<Ti>} for each \tcode{Ti}. Then each \tcode{Vi} is \tcode{X\&}
-if \tcode{Ui} equals \tcode{reference_wrapper<X>}, otherwise \tcode{Vi} is
-\tcode{Ui}.
+\tcode{decay_t<Ti>} for each \tcode{Ti}. If \tcode{Ui} is a specialization
+of \tcode{reference_wrapper}, then \tcode{Vi} is \tcode{Ui::type\&},
+otherwise \tcode{Vi} is \tcode{Ui}.
 \end{itemdescr}
 
 \pnum
@@ -1982,9 +1982,9 @@ template<class... Types>
 \end{itemdecl}
 
 \begin{itemdescr} \pnum Let \tcode{$U_i$} be \tcode{decay_t<$T_i$>} for each
-$T_i$ in \tcode{Types}. Then each $V_i$ in \tcode{VTypes} is
-\tcode{X\&} if $U_i$ equals \tcode{reference_wrapper<X>}, otherwise
-$V_i$ is $U_i$.
+$T_i$ in \tcode{Types}. If $U_i$ is a specialization of
+\tcode{reference_wrapper}, then $V_i$ in \tcode{VTypes} is \tcode{$U_i$::type\&},
+otherwise $V_i$ is $U_i$.
 
 \pnum
 \returns \tcode{tuple<VTypes...>(std::forward<Types>(t)...)}.


### PR DESCRIPTION
Fixes #491.

(I agree that the formatting of the U_i indexed type-variables is dreadful in either case, but that is the subject of another issue.)