### PR TITLE
[numarray] Add standard description elements.

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -6748,6 +6748,8 @@ is a
 one-dimensional smart array, with elements numbered sequentially from zero.
 It is a representation of the mathematical concept
 of an ordered set of values.
+For convenience, an object of type \tcode{valarray<T>} is referred
+to as an ``array'' throughout the remainder of~\ref{numarray}.
 The illusion of higher dimensionality
 may be produced by the familiar idiom of computed indices, together
 with the powerful subsetting capabilities provided
@@ -6777,11 +6779,8 @@ valarray();
 \begin{itemdescr}
 \pnum
 \effects
-Constructs an object of class
-\tcode{valarray<T>}\footnote{For convenience, such objects are referred
-to as ``arrays'' throughout the
-remainder of~\ref{numarray}.}
-which has zero length.\footnote{This default constructor is essential,
+Constructs a \tcode{valarray}
+that has zero length.\footnote{This default constructor is essential,
 since arrays of
 \tcode{valarray}
 may be useful.
@@ -6792,37 +6791,41 @@ member function.}
 
 \indexlibrary{\idxcode{valarray}!constructor}%
 \begin{itemdecl}
-explicit valarray(size_t);
+explicit valarray(size_t n);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-The array created by this constructor has a length equal to the value of the argument.
-The elements of the array are value-initialized~(\ref{dcl.init}).
+\effects
+Constructs a \tcode{valarray} that has length \tcode{n}.
+Each element of the array is value-initialized~(\ref{dcl.init}).
 \end{itemdescr}
 
 \indexlibrary{\idxcode{valarray}!constructor}%
 \begin{itemdecl}
-valarray(const T&, size_t);
+valarray(const T& v, size_t n);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-The array created by this constructor has a length equal to the second
-argument.
-The elements of the array are initialized with the value of the first argument.
+\effects
+Constructs a \tcode{valarray} that has length \tcode{n}.
+Each element of the array is initialized with \tcode{v}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{valarray}!constructor}%
 \begin{itemdecl}
-valarray(const T*, size_t);
+valarray(const T* p, size_t n);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-The array created by this constructor has a length equal to the second
-argument
-\tcode{n}.
+\requires
+\tcode{p} points to an array~(\ref{dcl.array}) of at least
+\tcode{n} elements.
+
+\effects
+Constructs a \tcode{valarray} that has length \tcode{n}.
 The values of the elements of the array are initialized with the
 first
 \tcode{n}
@@ -6830,22 +6833,19 @@ values pointed to by the first argument.\footnote{This constructor is the
 preferred method for converting a C array to a
 \tcode{valarray}
 object.}
-If the value of the second argument is greater than the number of values
-pointed to by the first argument, the behavior is undefined.%
-\indextext{undefined}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{valarray}!constructor}%
 \begin{itemdecl}
-valarray(const valarray&);
+valarray(const valarray& v);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-The array created by this constructor has the same length as the argument
-array.
+\effects
+Constructs a \tcode{valarray} that has the same length as \tcode{v}.
 The elements are initialized with the values of the corresponding
-elements of the argument array.\footnote{This copy constructor creates
+elements of \tcode{v}.\footnote{This copy constructor creates
 a distinct array rather than an alias.
 Implementations in which arrays share storage are permitted, but they
 shall implement a copy-on-reference mechanism to ensure that arrays are
@@ -6859,10 +6859,10 @@ valarray(valarray&& v) noexcept;
 
 \begin{itemdescr}
 \pnum
-The array created by this constructor has the same length as the argument
-array.
+\effects
+Constructs a \tcode{valarray} that has the same length as \tcode{v}.
 The elements are initialized with the values of the corresponding
-elements of the argument array.
+elements of \tcode{v}.
 
 \pnum
 \complexity Constant.
@@ -6875,7 +6875,7 @@ valarray(initializer_list<T> il);
 
 \begin{itemdescr}
 \pnum
-\effects Same as \tcode{valarray(il.begin(), il.size())}.
+\effects Equivalent to \tcode{valarray(il.begin(), il.size())}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{valarray}!constructor}%
@@ -6900,6 +6900,7 @@ to a
 
 \begin{itemdescr}
 \pnum
+\effects
 The destructor is applied to every element of
 \tcode{*this};
 an implementation may return all allocated memory.
@@ -6914,16 +6915,19 @@ valarray& operator=(const valarray& v);
 
 \begin{itemdescr}
 \pnum
+\effects
 Each element of the
 \tcode{*this}
-array is assigned the value of the corresponding element of the argument
-array.
-If the length of \tcode{v} is not equal to the length of \tcode{*this}
-, resizes \tcode{*this} to make the two arrays the same length,
+array is assigned the value of the corresponding element of \tcode{v}.
+If the length of \tcode{v} is not equal to the length of \tcode{*this},
+resizes \tcode{*this} to make the two arrays the same length,
 as if by calling \tcode{resize(v.size())}, before performing the assignment.
 
 \pnum
 \postconditions \tcode{size() == v.size()}.
+
+\pnum
+\returns \tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{valarray}%
@@ -6937,6 +6941,9 @@ valarray& operator=(valarray&& v) noexcept;
 The value of \tcode{v} after the assignment is not specified.
 
 \pnum
+\returns \tcode{*this}.
+
+\pnum
 \complexity Linear.
 \end{itemdescr}
 
@@ -6947,23 +6954,22 @@ valarray& operator=(initializer_list<T> il);
 
 \begin{itemdescr}
 \pnum
-\effects As if by: \tcode{*this = valarray(il);}
-
-\pnum
-\returns \tcode{*this}.
+\effects Equivalent to: \tcode{return *this = valarray(il);}
 \end{itemdescr}
 
 
 \indexlibrarymember{operator=}{valarray}%
 \begin{itemdecl}
-valarray& operator=(const T&);
+valarray& operator=(const T& v);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-The scalar assignment operator causes each element of the
-\tcode{*this}
-array to be assigned the value of the argument.
+\effects
+Assigns \tcode{v} to each element of \tcode{*this}.
+
+\pnum
+\returns \tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{valarray}%
@@ -6977,100 +6983,65 @@ valarray& operator=(const indirect_array<T>&);
 \begin{itemdescr}
 \pnum
 \requires The length of the array to which the argument refers equals \tcode{size()}.
+The value of an element in the left-hand side of a \tcode{valarray} assignment
+operator does not depend on the value of another element in that left-hand side.
 
 \pnum
 These operators allow the results of a generalized subscripting operation
 to be assigned directly to a
 \tcode{valarray}.
-
-\pnum
-If the value of an element in the left-hand side of a valarray assignment
-operator depends on the value of another element in that left-hand side,
-the behavior is undefined.
 \end{itemdescr}
 
 \rSec3[valarray.access]{\tcode{valarray} element access}
 
 \indexlibrarymember{operator[]}{valarray}%
 \begin{itemdecl}
-const T&  operator[](size_t) const;
-T& operator[](size_t);
+const T&  operator[](size_t n) const;
+T& operator[](size_t n);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-The subscript operator
-returns a reference to the corresponding element of the array.
+\requires
+\tcode{n < size()}.
 
 \pnum
-Thus, the expression
-\tcode{(a[i] = q, a[i]) == q}
-evaluates as \tcode{true} for any non-constant
-\tcode{valarray<T> a},
-any
-\tcode{T q},
-and for any
-\tcode{size_t i}
-such that the value of
-\tcode{i}
-is less than the length of
-\tcode{a}.
+\returns
+A reference to the corresponding element of the array.
+\begin{note}
+The expression \tcode{(a[i] = q, a[i]) == q}
+evaluates as \tcode{true} for any non-constant \tcode{valarray<T> a},
+any \tcode{T q}, and for any \tcode{size_t i}
+such that the value of \tcode{i} is less than the length of \tcode{a}.
+\end{note}
 
 \pnum
-The expression
-\tcode{\&a[i+j] == \&a[i] + j}
-evaluates as \tcode{true} for all
-\tcode{size_t i}
-and
-\tcode{size_t j}
-such that
-\tcode{i+j}
-is less than the length of the array
-\tcode{a}.
+\remarks
+The expression \tcode{\&a[i+j] == \&a[i] + j}
+evaluates to \tcode{true} for all \tcode{size_t i} and \tcode{size_t j}
+such that \tcode{i+j < a.size()}.
 
 \pnum
-Likewise, the expression
-\tcode{\&a[i] != \&b[j]}
-evaluates as
-\tcode{true}
-for any two arrays
-\tcode{a}
-and
-\tcode{b}
-and for any
-\tcode{size_t i}
-and
-\tcode{size_t j}
-such that
-\tcode{i}
-is less than the length of
-\tcode{a}
-and
-\tcode{j}
-is less than the length of
-\tcode{b}.
-This property indicates an absence of aliasing and may be used to
-advantage by optimizing compilers.\footnote{Compilers may take advantage
+The expression \tcode{\&a[i] != \&b[j]}
+evaluates to \tcode{true} for any two arrays
+\tcode{a} and \tcode{b} and for any
+\tcode{size_t i} and \tcode{size_t j}
+such that \tcode{i < a.size()}
+and \tcode{j < b.size()}.
+\begin{note} This property indicates an absence of aliasing and may be used to
+advantage by optimizing compilers. Compilers may take advantage
 of inlining, constant propagation, loop fusion,
 tracking of pointers obtained from
 \tcode{operator new},
-and other
-techniques to generate efficient
-\tcode{valarray}s.}
+and other techniques to generate efficient
+\tcode{valarray}s.
+\end{note}
 
 \pnum
 The reference returned by the subscript operator for an array shall
 be valid until the member function
 \tcode{resize(size_t, T)}~(\ref{valarray.members}) is called for that array or until the lifetime of
 that array ends, whichever happens first.
-
-\pnum
-If the subscript operator
-is invoked with a
-\tcode{size_t}
-argument whose value is not
-less than the length of the array, the behavior is undefined.%
-\indextext{undefined}
 \end{itemdescr}
 
 \rSec3[valarray.sub]{\tcode{valarray} subset operations}
@@ -7093,7 +7064,7 @@ valarray operator[](slice slicearr) const;
 
 \begin{itemdescr}
 \pnum
-\returns An object of class \tcode{valarray<T>} containing those
+\returns A \tcode{valarray} containing those
 elements of the controlled sequence designated by \tcode{slicearr}.
 \begin{example}
 \begin{codeblock}
@@ -7128,7 +7099,7 @@ valarray operator[](const gslice& gslicearr) const;
 
 \begin{itemdescr}
 \pnum
-\returns An object of class \tcode{valarray<T>} containing those
+\returns A \tcode{valarray} containing those
 elements of the controlled sequence designated by \tcode{gslicearr}.
 \begin{example}
 \begin{codeblock}
@@ -7170,7 +7141,7 @@ valarray operator[](const valarray<bool>& boolarr) const;
 
 \begin{itemdescr}
 \pnum
-\returns An object of class \tcode{valarray<T>} containing those
+\returns A \tcode{valarray} containing those
 elements of the controlled sequence designated by \tcode{boolarr}.
 \begin{example}
 \begin{codeblock}
@@ -7208,7 +7179,7 @@ valarray operator[](const valarray<size_t>& indarr) const;
 
 \begin{itemdescr}
 \pnum
-\returns An object of class \tcode{valarray<T>} containing those
+\returns A \tcode{valarray} containing those
 elements of the controlled sequence designated by \tcode{indarr}.
 \begin{example}
 \begin{codeblock}
@@ -7254,6 +7225,7 @@ valarray<bool> operator!() const;
 
 \begin{itemdescr}
 \pnum
+\requires
 Each of these operators may only be instantiated for a type \tcode{T}
 to which the indicated operator can be applied and for which the indicated
 operator returns a value which is of type \tcode{T} (\tcode{bool} for
@@ -7261,8 +7233,7 @@ operator returns a value which is of type \tcode{T} (\tcode{bool} for
 \tcode{T} (\tcode{bool} for \tcode{operator!}).
 
 \pnum
-Each of these operators returns an array whose length is equal to the length
-of the array.
+\returns A \tcode{valarray} whose length is \tcode{size()}.
 Each element of the returned array is initialized with the result of
 applying the indicated operator to the corresponding element of the array.
 \end{itemdescr}
@@ -7280,40 +7251,42 @@ applying the indicated operator to the corresponding element of the array.
 \indexlibrarymember{operator<<=}{valarray}%
 \indexlibrarymember{operator>>=}{valarray}%
 \begin{itemdecl}
-valarray& operator*= (const valarray&);
-valarray& operator/= (const valarray&);
-valarray& operator%= (const valarray&);
-valarray& operator+= (const valarray&);
-valarray& operator-= (const valarray&);
-valarray& operator^= (const valarray&);
-valarray& operator&= (const valarray&);
-valarray& operator|= (const valarray&);
-valarray& operator<<=(const valarray&);
-valarray& operator>>=(const valarray&);
+valarray& operator*= (const valarray& v);
+valarray& operator/= (const valarray& v);
+valarray& operator%= (const valarray& v);
+valarray& operator+= (const valarray& v);
+valarray& operator-= (const valarray& v);
+valarray& operator^= (const valarray& v);
+valarray& operator&= (const valarray& v);
+valarray& operator|= (const valarray& v);
+valarray& operator<<=(const valarray& v);
+valarray& operator>>=(const valarray& v);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
+\requires
+\tcode{size() == v.size()}.
 Each of these operators may only be instantiated for a type \tcode{T}
-to which the indicated operator can be applied.
+if the indicated operator can be applied to two operands of type \tcode{T}.
+The value of an element in the left-hand side of a valarray compound
+assignment operator does not depend on the value of another element in that left
+hand side.
+
+\pnum
+\effects
 Each of these operators
-performs the indicated operation on each of its elements and the
-corresponding element of the argument array.
+performs the indicated operation on each of the elements of \tcode{*this} and the
+corresponding element of \tcode{v}.
 
 \pnum
-The array is then returned by reference.
+\returns
+\tcode{*this}.
 
 \pnum
-If the array and the
-argument array do not have the same length, the behavior is undefined.%
-\indextext{undefined}
+\remarks
 The appearance of an array on the left-hand side of a compound assignment
-does \tcode{not} invalidate references or pointers.
-
-\pnum
-If the value of an element in the left-hand side of a valarray compound
-assignment operator depends on the value of another element in that left
-hand side, the behavior is undefined.
+does not invalidate references or pointers.
 \end{itemdescr}
 
 \indexlibrarymember{operator*=}{valarray}%
@@ -7327,34 +7300,37 @@ hand side, the behavior is undefined.
 \indexlibrarymember{operator<<=}{valarray}%
 \indexlibrarymember{operator>>=}{valarray}%
 \begin{itemdecl}
-valarray& operator*= (const T&);
-valarray& operator/= (const T&);
-valarray& operator%= (const T&);
-valarray& operator+= (const T&);
-valarray& operator-= (const T&);
-valarray& operator^= (const T&);
-valarray& operator&= (const T&);
-valarray& operator|= (const T&);
-valarray& operator<<=(const T&);
-valarray& operator>>=(const T&);
+valarray& operator*= (const T& v);
+valarray& operator/= (const T& v);
+valarray& operator%= (const T& v);
+valarray& operator+= (const T& v);
+valarray& operator-= (const T& v);
+valarray& operator^= (const T& v);
+valarray& operator&= (const T& v);
+valarray& operator|= (const T& v);
+valarray& operator<<=(const T& v);
+valarray& operator>>=(const T& v);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
+\requires
 Each of these operators may only be instantiated for a type \tcode{T}
-to which the indicated operator can be applied.
+if the indicated operator can be applied to two operands of type \tcode{T}.
 
 \pnum
+\effects
 Each of these operators applies the indicated operation to each element
-of the array and the non-array argument.
+of \tcode{*this} and \tcode{v}.
 
 \pnum
-The array is then returned by reference.
+\returns
+\tcode{*this}
 
 \pnum
+\remarks
 The appearance of an array on the left-hand side of a compound assignment
-does
-\textit{not}
+does not
 invalidate references or pointers to the elements of the array.
 \end{itemdescr}
 
@@ -7394,22 +7370,20 @@ T sum() const;
 
 \begin{itemdescr}
 \pnum
+\requires
+\tcode{size() > 0}.
 This function may only be instantiated for a type \tcode{T} to which
 \tcode{operator+=}
 can be applied.
-This function returns the sum of all the elements of the array.
 
 \pnum
-If the array has length 0, the behavior is undefined.%
-\indextext{undefined}
-If the array has length 1,
-\tcode{sum()}
-returns the value of element 0.
+\returns
+The sum of all the elements of the array.
+If the array has length 1, returns the value of element 0.
 Otherwise, the returned value is calculated by applying
 \tcode{operator+=}
 to a copy of an element of the array and
 all other elements of the array in an unspecified order.%
-\indextext{unspecified behavior}
 \end{itemdescr}
 
 \indexlibrarymember{min}{valarray}%
@@ -7419,11 +7393,13 @@ T min() const;
 
 \begin{itemdescr}
 \pnum
-This function returns the minimum value contained in
-\tcode{*this}.
-The value returned for an array of length 0 is undefined.
-For an array
-of length 1, the value of element 0 is returned.
+\requires
+\tcode{size() > 0}
+
+\pnum
+\returns
+The minimum value contained in \tcode{*this}.
+For an array of length 1, the value of element 0 is returned.
 For all other array
 lengths, the determination is made using
 \tcode{operator<}.
@@ -7436,11 +7412,13 @@ T max() const;
 
 \begin{itemdescr}
 \pnum
-This function returns the maximum value contained in
-\tcode{*this}.
-The value returned for an array of length 0 is undefined.
-For an array
-of length 1, the value of element 0 is returned.
+\requires
+\tcode{size() > 0}.
+
+\pnum
+\returns
+The maximum value contained in \tcode{*this}.
+For an array of length 1, the value of element 0 is returned.
 For all other array
 lengths, the determination is made using
 \tcode{operator<}.
@@ -7453,23 +7431,18 @@ valarray shift(int n) const;
 
 \begin{itemdescr}
 \pnum
-This function returns an object of class
-\tcode{valarray<T>}
-of length
-\tcode{size()},
-each of whose elements
-\textit{I}
-is
-\tcode{(*this)[I + n]}
-if
-\tcode{I + n}
+\returns
+A \tcode{valarray} of length \tcode{size()}, each of whose elements
+\placeholder{I} is
+\tcode{(*this)[\placeholder{I} + n]}
+if \tcode{\placeholder{I} + n}
 is non-negative and less than
-\tcode{size()},
-otherwise
-\tcode{T()}.
-Thus if element zero is taken as the leftmost element,
+\tcode{size()}, otherwise \tcode{T()}.
+\begin{note}
+If element zero is taken as the leftmost element,
 a positive value of \tcode{n} shifts the elements left \tcode{n}
 places, with zero fill.
+\end{note}
 
 \pnum
 \begin{example}
@@ -7486,11 +7459,12 @@ valarray cshift(int n) const;
 
 \begin{itemdescr}
 \pnum
-This function returns an object of class
-\tcode{valarray<T>}
-of length
-\tcode{size()}
-that is a circular shift of \tcode{*this}. If element zero is taken as the leftmost element, a non-negative value of $n$ shifts the elements circularly left $n$ places and a negative value of $n$ shifts the elements circularly right $-n$ places.
+\returns
+A \tcode{valarray} of length \tcode{size()}
+that is a circular shift of \tcode{*this}. If element zero is taken as
+the leftmost element, a non-negative value of $n$ shifts
+the elements circularly left $n$ places and a negative
+value of $n$ shifts the elements circularly right $-n$ places.
 \end{itemdescr}
 
 \indexlibrarymember{apply}{valarray}%
@@ -7501,10 +7475,11 @@ valarray apply(T func(const T&)) const;
 
 \begin{itemdescr}
 \pnum
-These functions return an array whose length is equal to the array.
+\returns
+A \tcode{valarray} whose length is \tcode{size()}.
 Each element of the returned array is assigned
 the value returned by applying the argument function to the
-corresponding element of the array.
+corresponding element of \tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{resize}{valarray}%
@@ -7514,10 +7489,8 @@ void resize(size_t sz, T c = T());
 
 \begin{itemdescr}
 \pnum
-This member function changes the length of the
-\tcode{*this}
-array to
-\tcode{sz}
+\effects
+Changes the length of the \tcode{*this} array to \tcode{sz}
 and then assigns to each element the value of the second argument.
 Resizing invalidates all pointers and references to elements in the array.
 \end{itemdescr}
@@ -7561,21 +7534,20 @@ template<class T> valarray<T> operator>>
 
 \begin{itemdescr}
 \pnum
+\requires
 Each of these operators may only be instantiated for a type \tcode{T}
 to which the indicated operator can be applied and for which the indicated
 operator returns a value which is of type \tcode{T} or which
 can be unambiguously implicitly converted to type \tcode{T}.
+The argument arrays have the same length.
 
 \pnum
-Each of these operators returns an array whose length is equal to the
+\returns
+A \tcode{valarray} whose length is equal to the
 lengths of the argument arrays.
 Each element of the returned array is
 initialized with the result of applying the indicated operator to the
 corresponding elements of the argument arrays.
-
-\pnum
-If the argument arrays do not have the same length, the behavior is undefined.%
-\indextext{undefined}
 \end{itemdescr}
 
 \indexlibrarymember{operator*}{valarray}%
@@ -7613,13 +7585,15 @@ template<class T> valarray<T> operator>>(const T&, const valarray<T>&);
 
 \begin{itemdescr}
 \pnum
+\requires
 Each of these operators may only be instantiated for a type \tcode{T}
 to which the indicated operator can be applied and for which
 the indicated operator returns a value which is of type \tcode{T}
 or which can be unambiguously implicitly converted to type \tcode{T}.
 
 \pnum
-Each of these operators returns an array whose length is equal to the
+\returns
+A \tcode{valarray} whose length is equal to the
 length of the array argument.
 Each element of the returned array is
 initialized with the result of applying the indicated operator to the
@@ -7657,22 +7631,21 @@ template<class T> valarray<bool> operator||
 
 \begin{itemdescr}
 \pnum
+\requires
 Each of these operators may only be instantiated for a type \tcode{T}
 to which the indicated operator can be applied and for which
 the indicated operator returns a value which is of type \tcode{bool}
 or which can be unambiguously implicitly converted to type \tcode{bool}.
+The two array arguments have the same length.
+\indextext{undefined}
 
 \pnum
-Each of these operators returns a \tcode{bool} array whose length
+\returns
+A \tcode{valarray<bool>} whose length
 is equal to the length of the array arguments.
 Each element of the returned
 array is initialized with the result of applying the indicated
 operator to the corresponding elements of the argument arrays.
-
-\pnum
-If the two array arguments do not have the same length,
-the behavior is undefined.%
-\indextext{undefined}
 \end{itemdescr}
 
 \indexlibrarymember{operator==}{valarray}%
@@ -7704,13 +7677,15 @@ template<class T> valarray<bool> operator||(const T&, const valarray<T>&);
 
 \begin{itemdescr}
 \pnum
+\requires
 Each of these operators may only be instantiated for a type \tcode{T}
 to which the indicated operator can be applied and for which
 the indicated operator returns a value which is of type \tcode{bool}
 or which can be unambiguously implicitly converted to type \tcode{bool}.
 
 \pnum
-Each of these operators returns a \tcode{bool} array whose
+\returns
+A \tcode{valarray<bool>} whose
 length is equal to the length of the array argument.
 Each element
 of the returned array is initialized with the result of applying the
@@ -7762,6 +7737,7 @@ template<class T> valarray<T> tanh (const valarray<T>&);
 
 \begin{itemdescr}
 \pnum
+\requires
 Each of these functions may only be instantiated for a type \tcode{T}
 to which a unique function with the indicated name can be applied (unqualified).
 This function shall return a value which is of type \tcode{T}
@@ -7777,7 +7753,7 @@ template <class T> void swap(valarray<T>& x, valarray<T>& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{x.swap(y)}.
+\effects Equivalent to \tcode{x.swap(y)}.
 \end{itemdescr}
 
 
@@ -7801,8 +7777,7 @@ namespace std {
 \end{codeblock}
 
 \pnum
-The
-\tcode{slice}
+The \tcode{slice}
 class represents a BLAS-like slice from an array.
 Such a slice is specified by a starting index, a length, and a
 stride.\footnote{BLAS stands for
@@ -8581,7 +8556,7 @@ template <class T> @\unspec{2}@ begin(const valarray<T>& v);
 
 \begin{itemdescr}
 \pnum
-\returns An iterator referencing the first value in the numeric array.
+\returns An iterator referencing the first value in the array.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{end}!\idxcode{valarray}}%
@@ -8592,7 +8567,7 @@ template <class T> @\unspec{2}@ end(const valarray<T>& v);
 
 \begin{itemdescr}
 \pnum
-\returns An iterator referencing one past the last value in the numeric array.
+\returns An iterator referencing one past the last value in the array.
 \end{itemdescr}
 
 


### PR DESCRIPTION
Partially addresses #1071.

This is a first step. I've only inserted description elements such as \effects and \returns and removed boilerplate introductory phrases where appropriate.