### PR TITLE
[bitset.members] Remove confusing index entries for 'set' and 'any'.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -6261,7 +6261,9 @@ If \tcode{pos < N - I}, the new value is the previous value of the bit at positi
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{set}{bitset}%
+% Do not use \indexlibrarymember.
+\indexlibrary{\idxcode{set} (member)!\idxcode{bitset}}%
+\indexlibrary{\idxcode{bitset}!\idxcode{set}}%
 \begin{itemdecl}
 bitset<N>& set() noexcept;
 \end{itemdecl}
@@ -6277,7 +6279,8 @@ Sets all bits in
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{set}{bitset}%
+\indexlibrary{\idxcode{set} (member)!\idxcode{bitset}}%
+\indexlibrary{\idxcode{bitset}!\idxcode{set}}%
 \begin{itemdecl}
 bitset<N>& set(size_t pos, bool val = true);
 \end{itemdecl}
@@ -6541,7 +6544,8 @@ bool all() const noexcept;
 \returns \tcode{count() == size()}.
 \end{itemdescr}
 
-\indexlibrarymember{any}{bitset}%
+\indexlibrary{\idxcode{any} (member)!\idxcode{bitset}}%
+\indexlibrary{\idxcode{bitset}!\idxcode{any}}%
 \begin{itemdecl}
 bool any() const noexcept;
 \end{itemdecl}


### PR DESCRIPTION
Fixes #743.