### PR TITLE
[any] Rename the ValueType template parameter to T.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -5338,17 +5338,17 @@ namespace std {
   template <class T, class U, class... Args>
     any make_any(initializer_list<U> il, Args&& ...args);
 
-  template<class ValueType>
-    ValueType any_cast(const any& operand);
-  template<class ValueType>
-    ValueType any_cast(any& operand);
-  template<class ValueType>
-    ValueType any_cast(any&& operand);
+  template<class T>
+    T any_cast(const any& operand);
+  template<class T>
+    T any_cast(any& operand);
+  template<class T>
+    T any_cast(any&& operand);
   
-  template<class ValueType>
-    const ValueType* any_cast(const any* operand) noexcept;
-  template<class ValueType>
-    ValueType* any_cast(any* operand) noexcept;
+  template<class T>
+    const T* any_cast(const any* operand) noexcept;
+  template<class T>
+    T* any_cast(any* operand) noexcept;
 }
 \end{codeblock}
 
@@ -5376,12 +5376,12 @@ public:
   any(const any& other);
   any(any&& other) noexcept;
 
-  template <class ValueType> any(ValueType&& value);
+  template <class T> any(T&& value);
 
-  template <class ValueType, class... Args>
-    explicit any(in_place_type_t<ValueType>, Args&&...);
-  template <class ValueType, class U, class... Args>
-    explicit any(in_place_type_t<ValueType>, initializer_list<U>, Args&&...);
+  template <class T, class... Args>
+    explicit any(in_place_type_t<T>, Args&&...);
+  template <class T, class U, class... Args>
+    explicit any(in_place_type_t<T>, initializer_list<U>, Args&&...);
 
   ~any();
 
@@ -5389,12 +5389,12 @@ public:
   any& operator=(const any& rhs);
   any& operator=(any&& rhs) noexcept;
 
-  template <class ValueType> any& operator=(ValueType&& rhs);
+  template <class T> any& operator=(T&& rhs);
 
   // \ref{any.modifiers}, modifiers
-  template <class ValueType, class... Args>
+  template <class T, class... Args>
     void emplace(Args&& ...);
-  template <class ValueType, class U, class... Args>
+  template <class T, class U, class... Args>
     void emplace(initializer_list<U>, Args&&...);
   void reset() noexcept;
   void swap(any& rhs) noexcept;
@@ -5467,92 +5467,92 @@ Constructs an object of type \tcode{any} with a state equivalent to the original
 
 \indexlibrary{\idxcode{any}!constructor}%
 \begin{itemdecl}
-template<class ValueType>
-any(ValueType&& value);
+template<class T>
+  any(T&& value);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-Let \tcode{T} be \tcode{decay_t<ValueType>}.
+Let \tcode{VT} be \tcode{decay_t<T>}.
 
 \pnum
 \requires
-\tcode{T} shall satisfy the \tcode{CopyConstructible} requirements.
+\tcode{VT} shall satisfy the \tcode{CopyConstructible} requirements.
 
 \pnum
 \effects
-Constructs an object of type \tcode{any} that contains an object of type \tcode{T} direct-initialized with \tcode{std::forward<ValueType>(value)}.
+Constructs an object of type \tcode{any} that contains an object of type \tcode{VT} direct-initialized with \tcode{std::forward<T>(value)}.
 
 \pnum
 \remarks
 This constructor shall not participate in overload resolution unless
-\tcode{T} is not the same type as \tcode{any},
-\tcode{T} is not a specialization of \tcode{in_place_type_t},
-and \tcode{is_copy_constructible_v<T>} is \tcode{true}.
+\tcode{VT} is not the same type as \tcode{any},
+\tcode{VT} is not a specialization of \tcode{in_place_type_t},
+and \tcode{is_copy_constructible_v<VT>} is \tcode{true}.
 
 \pnum
 \throws
-Any exception thrown by the selected constructor of \tcode{T}.
+Any exception thrown by the selected constructor of \tcode{VT}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{any}!constructor}%
 \begin{itemdecl}
-template <class ValueType, class... Args>
-  explicit any(in_place_type_t<ValueType>, Args&&... args);
+template <class T, class... Args>
+  explicit any(in_place_type_t<T>, Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-Let \tcode{T} be \tcode{decay_t<ValueType>}.
+Let \tcode{VT} be \tcode{decay_t<T>}.
 
 \pnum
-\requires \tcode{T} shall satisfy the \tcode{CopyConstructible} requirements.
+\requires \tcode{VT} shall satisfy the \tcode{CopyConstructible} requirements.
 
 \pnum
 \effects Initializes the contained value as if direct-non-list-initializing an object of
-type \tcode{T} with the arguments \tcode{std::forward<Args>(args)...}.
+type \tcode{VT} with the arguments \tcode{std::forward<Args>(args)...}.
 
 \pnum
-\postconditions \tcode{*this} contains a value of type \tcode{T}.
+\postconditions \tcode{*this} contains a value of type \tcode{VT}.
 
 \pnum
-\throws Any exception thrown by the selected constructor of \tcode{T}.
+\throws Any exception thrown by the selected constructor of \tcode{VT}.
 
 \pnum
 \remarks
 This constructor shall not participate in overload resolution unless
-\tcode{is_copy_constructible_v<T>} is \tcode{true} and
-\tcode{is_constructible_v<T, Args...>} is \tcode{true}.
+\tcode{is_copy_constructible_v<VT>} is \tcode{true} and
+\tcode{is_constructible_v<VT, Args...>} is \tcode{true}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{any}!constructor}%
 \begin{itemdecl}
-template <class ValueType, class U, class... Args>
-  explicit any(in_place_type_t<ValueType>, initializer_list<U> il, Args&&... args);
+template <class T, class U, class... Args>
+  explicit any(in_place_type_t<T>, initializer_list<U> il, Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-Let \tcode{T} be \tcode{decay_t<ValueType>}.
+Let \tcode{VT} be \tcode{decay_t<T>}.
 
 \pnum
-\requires \tcode{T} shall satisfy the \tcode{CopyConstructible} requirements.
+\requires \tcode{VT} shall satisfy the \tcode{CopyConstructible} requirements.
 
 \pnum
 \effects Initializes the contained value as if direct-non-list-initializing an object of
-type \tcode{T} with the arguments \tcode{il, std::forward<Args>(args)...}.
+type \tcode{VT} with the arguments \tcode{il, std::forward<Args>(args)...}.
 
 \pnum
 \postconditions \tcode{*this} contains a value.
 
 \pnum
-\throws Any exception thrown by the selected constructor of \tcode{T}.
+\throws Any exception thrown by the selected constructor of \tcode{VT}.
 
 \pnum
 \remarks
 This constructor shall not participate in overload resolution unless
-\tcode{is_copy_constructible_v<T>} is \tcode{true} and
-\tcode{is_constructible_v<T, initializer_list<U>\&, Args...>} is \tcode{true}.
+\tcode{is_copy_constructible_v<VT>} is \tcode{true} and
+\tcode{is_constructible_v<VT, initializer_list<U>\&, Args...>} is \tcode{true}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{any}!destructor}
@@ -5610,21 +5610,21 @@ and \tcode{rhs} is left in a valid but otherwise unspecified state.
 
 \indexlibrarymember{operator=}{any}%
 \begin{itemdecl}
-template<class ValueType>
-any& operator=(ValueType&& rhs);
+template<class T>
+  any& operator=(T&& rhs);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-Let \tcode{T} be \tcode{decay_t<ValueType>}.
+Let \tcode{VT} be \tcode{decay_t<T>}.
 
 \pnum
 \requires
-\tcode{T} shall satisfy the \tcode{CopyConstructible} requirements.
+\tcode{VT} shall satisfy the \tcode{CopyConstructible} requirements.
 
 \pnum
 \effects
-Constructs an object \tcode{tmp} of type \tcode{any} that contains an object of type \tcode{T} direct-initialized with \tcode{std::forward<ValueType>(rhs)}, and \tcode{tmp.swap(*this)}.
+Constructs an object \tcode{tmp} of type \tcode{any} that contains an object of type \tcode{VT} direct-initialized with \tcode{std::forward<T>(rhs)}, and \tcode{tmp.swap(*this)}.
 No effects if an exception is thrown.
 
 \pnum
@@ -5646,70 +5646,70 @@ Any exception thrown by the selected constructor of \tcode{T}.
 
 \indexlibrarymember{emplace}{any}%
 \begin{itemdecl}
-template <class ValueType, class... Args>
+template <class T, class... Args>
   void emplace(Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-Let \tcode{T} be \tcode{decay_t<ValueType>}.
+Let \tcode{VT} be \tcode{decay_t<T>}.
 
 \pnum
 \requires
-\tcode{T} shall satisfy the \tcode{CopyConstructible} requirements.
+\tcode{VT} shall satisfy the \tcode{CopyConstructible} requirements.
 
 \pnum
 \effects Calls \tcode{reset()}.
 Then initializes the contained value as if direct-non-list-initializing
-an object of type \tcode{T} with the arguments \tcode{std::forward<Args>(args)...}.
+an object of type \tcode{VT} with the arguments \tcode{std::forward<Args>(args)...}.
 
 \pnum
 \postconditions \tcode{*this} contains a value.
 
 \pnum
-\throws Any exception thrown by the selected constructor of \tcode{T}.
+\throws Any exception thrown by the selected constructor of \tcode{VT}.
 
 \pnum
-\remarks If an exception is thrown during the call to \tcode{T}'s constructor,
+\remarks If an exception is thrown during the call to \tcode{VT}'s constructor,
 \tcode{*this} does not contain a value, and any previously contained object
 has been destroyed.
 This function shall not participate in overload resolution unless
-\tcode{is_copy_constructible_v<T>} is \tcode{true} and
-\tcode{is_constructible_v<T, Args...>} is \tcode{true}.
+\tcode{is_copy_constructible_v<VT>} is \tcode{true} and
+\tcode{is_constructible_v<VT, Args...>} is \tcode{true}.
 \end{itemdescr}
 
 \indexlibrarymember{emplace}{any}%
 \begin{itemdecl}
-template <class ValueType, class U, class... Args>
+template <class T, class U, class... Args>
   void emplace(initializer_list<U> il, Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-Let \tcode{T} be \tcode{decay_t<ValueType>}.
+Let \tcode{VT} be \tcode{decay_t<T>}.
 
 \pnum
 \requires
-\tcode{T} shall satisfy the \tcode{CopyConstructible} requirements.
+\tcode{VT} shall satisfy the \tcode{CopyConstructible} requirements.
 
 \pnum
 \effects Calls \tcode{reset()}. Then initializes the contained value
-as if direct-non-list-initializing an object of type \tcode{T} with the arguments
+as if direct-non-list-initializing an object of type \tcode{VT} with the arguments
 \tcode{il, std::forward<Args> (args)...}.
 
 \pnum
 \postconditions \tcode{*this} contains a value.
 
 \pnum
-\throws Any exception thrown by the selected constructor of \tcode{T}.
+\throws Any exception thrown by the selected constructor of \tcode{VT}.
 
 \pnum
-\remarks If an exception is thrown during the call to \tcode{T}'s constructor,
+\remarks If an exception is thrown during the call to \tcode{VT}'s constructor,
 \tcode{*this} does not contain a value, and any previously contained object
 has been destroyed.
 The function shall not participate in overload resolution unless
-\tcode{is_copy_constructible_v<T>} is \tcode{true} and
-\tcode{is_constructible_v<T, initializer_list<U>\&, Args...>} is \tcode{true}.
+\tcode{is_copy_constructible_v<VT>} is \tcode{true} and
+\tcode{is_constructible_v<VT, initializer_list<U>\&, Args...>} is \tcode{true}.
 \end{itemdescr}
 
 \indexlibrarymember{reset}{any}%
@@ -5808,28 +5808,28 @@ Equivalent to: \tcode{return any(in_place_type<T>, il, std::forward<Args>(args).
 
 \indexlibrary{\idxcode{any_cast}}%
 \begin{itemdecl}
-template<class ValueType>
-  ValueType any_cast(const any& operand);
-template<class ValueType>
-  ValueType any_cast(any& operand);
-template<class ValueType>
-  ValueType any_cast(any&& operand);
+template<class T>
+  T any_cast(const any& operand);
+template<class T>
+  T any_cast(any& operand);
+template<class T>
+  T any_cast(any&& operand);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{is_reference_v<ValueType>} is \tcode{true} or \tcode{is_copy_constructible_v<ValueType>} is \tcode{true}.
+\tcode{is_reference_v<T>} is \tcode{true} or \tcode{is_copy_constructible_v<T>} is \tcode{true}.
 Otherwise the program is ill-formed.
 
 \pnum
 \returns
-For the first form, \tcode{*any_cast<add_const_t<remove_reference_t<ValueType>>>(\&operand)}.
-For the second and third forms, \tcode{*any_cast<remove_reference_t<ValueType>>(\&operand)}.
+For the first form, \tcode{*any_cast<add_const_t<remove_reference_t<T>>>(\&operand)}.
+For the second and third forms, \tcode{*any_cast<remove_reference_t<T>>(\&operand)}.
 
 \pnum
 \throws
-\tcode{bad_any_cast} if \tcode{operand.type() != typeid(remove_reference_t<ValueType>)}.
+\tcode{bad_any_cast} if \tcode{operand.type() != typeid(remove_reference_t<T>)}.
 
 \pnum
 \begin{example}
@@ -5863,16 +5863,16 @@ any_cast<string&>(y);                       // error; cannot
 
 \indexlibrary{\idxcode{any_cast}}%
 \begin{itemdecl}
-template<class ValueType>
-  const ValueType* any_cast(const any* operand) noexcept;
-template<class ValueType>
-  ValueType* any_cast(any* operand) noexcept;
+template<class T>
+  const T* any_cast(const any* operand) noexcept;
+template<class T>
+  T* any_cast(any* operand) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \returns
-If \tcode{operand != nullptr \&\& operand->type() == typeid(ValueType)},
+If \tcode{operand != nullptr \&\& operand->type() == typeid(T)},
 a pointer to the object contained by \tcode{operand};
 otherwise, \tcode{nullptr}.
 


### PR DESCRIPTION
The parameter has a confusing name: It is not actually the value type
contained in the 'any'.
Where the new T clashes with an existing use of T, rename the latter to VT,
since this is actually the value type of the 'any'.

Fixes #1202.