### PR TITLE
[list.ops] Move effects to 'Effects' element.

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -4829,6 +4829,12 @@ void splice(const_iterator position, list&& x, const_iterator i);
 
 \begin{itemdescr}
 \pnum
+\requires
+\tcode{i}
+is a valid dereferenceable iterator of
+\tcode{x}.
+
+\pnum
 \effects
 Inserts an element pointed to by
 \tcode{i}
@@ -4855,12 +4861,6 @@ not into
 \tcode{x}.
 
 \pnum
-\requires
-\tcode{i}
-is a valid dereferenceable iterator of
-\tcode{x}.
-
-\pnum
 \throws Nothing.
 
 \pnum
@@ -4878,15 +4878,6 @@ void splice(const_iterator position, list&& x, const_iterator first,
 
 \begin{itemdescr}
 \pnum
-\effects
-Inserts elements in the range
-\range{first}{last}
-before
-\tcode{position}
-and removes the elements from
-\tcode{x}.
-
-\pnum
 \requires
 \tcode{[first, last)}
 is a valid range in
@@ -4895,6 +4886,15 @@ The program has undefined behavior if
 \tcode{position}
 is an iterator in the range
 \range{first}{last}.
+
+\pnum
+\effects
+Inserts elements in the range
+\range{first}{last}
+before
+\tcode{position}
+and removes the elements from
+\tcode{x}.
 Pointers and references to the moved elements of
 \tcode{x}
 now refer to those same elements but as members of


### PR DESCRIPTION
Also reorder the elements so that 'Requires' is before 'Effects'.

Fixes #796.