### PR TITLE
[dcl.init.ref] Replace 'type qualifier' with 'cv-qualifier' in example.

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -3650,9 +3650,9 @@ void enigmatic() {
 const double& rcd2 = 2;         // \tcode{rcd2} refers to temporary with value \tcode{2.0}
 double&& rrd = 2;               // \tcode{rrd} refers to temporary with value \tcode{2.0}
 const volatile int cvi = 1;
-const int& r2 = cvi;            // error: type qualifiers dropped
+const int& r2 = cvi;            // error: cv-qualifier dropped
 struct A { operator volatile int&(); } a;
-const int& r3 = a;              // error: type qualifiers dropped
+const int& r3 = a;              // error: cv-qualifier dropped
                                 // from result of conversion function
 double d2 = 1.0;
 double&& rrd2 = d2;             // error: initializer is lvalue of related type


### PR DESCRIPTION
Fixes #1219.