### PR TITLE
[lib] Use 'comparison function', not 'comparison operator'.

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -2047,7 +2047,7 @@ four unordered associative containers: \tcode{unordered_set},
 \tcode{unordered_multimap}.
 
 \pnum
-\indextext{unordered associative containers!lack of comparison operators}%
+\indextext{unordered associative containers!lack of comparison functions}%
 \indextext{unordered associative containers!requirements}%
 \indextext{requirements!container!not required for unordered associated containers}%
 Unordered associative containers conform to the requirements for
@@ -2793,7 +2793,7 @@ proportional to $N$ (but worst-case complexity remains \bigoh{N^2}, e.g., for
 a pathologically bad hash function). The behavior of a program that uses
 \tcode{operator==} or \tcode{operator!=} on unordered containers is undefined
 unless the \tcode{Hash} and \tcode{Pred} function objects respectively have
-the same behavior for both containers and the equality comparison operator
+the same behavior for both containers and the equality comparison function
 for \tcode{Key} is a refinement\footnote{Equality comparison is a refinement
 of partitioning if no two objects that
 compare equal fall into different partitions.}

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -895,7 +895,7 @@ namespace std {
   // \ref{syserr.errcondition.nonmembers}, non-member functions
   error_condition make_error_condition(errc e) noexcept;
 
-  // \ref{syserr.compare}, comparison operators
+  // \ref{syserr.compare}, comparison functions
   bool operator<(const error_code& lhs, const error_code& rhs) noexcept;
   bool operator<(const error_condition& lhs, const error_condition& rhs) noexcept;
   bool operator==(const error_code& lhs, const error_code& rhs) noexcept;
@@ -1556,7 +1556,7 @@ error_condition make_error_condition(errc e) noexcept;
 \returns \tcode{error_condition(static_cast<int>(e), generic_category())}.
 \end{itemdescr}
 
-\rSec2[syserr.compare]{Comparison operators}
+\rSec2[syserr.compare]{Comparison functions}
 
 \indexlibrarymember{operator<}{error_code}%
 \begin{itemdecl}

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2044,7 +2044,7 @@ The \tcode{X::pointer}, \tcode{X::const_pointer}, \tcode{X::void_pointer}, and
 \tcode{X::const_void_pointer} types shall satisfy the requirements of
 \tcode{NullablePointer}~(\ref{nullablepointer.requirements}).
 No constructor,
-comparison operator, copy operation, move operation, or swap operation on
+comparison function, copy operation, move operation, or swap operation on
 these pointer types shall exit via an exception. \tcode{X::pointer} and \tcode{X::const_pointer} shall also
 satisfy the requirements for a random access
 iterator~(\ref{iterator.requirements}).

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2432,11 +2432,11 @@ template<class... TTypes, class... UTypes>
 \pnum\returns \tcode{!(t < u)}.
 \end{itemdescr}
 
-\pnum \begin{note} The above definitions for comparison operators
+\pnum \begin{note} The above definitions for comparison functions
 do not require \tcode{t$_{\mathrm{tail}}$}
 (or \tcode{u$_{\mathrm{tail}}$}) to be constructed. It may not
 even be possible, as \tcode{t} and \tcode{u} are not required to be copy
-constructible. Also, all comparison operators are short circuited;
+constructible. Also, all comparison functions are short circuited;
 they do not perform element accesses beyond what is required to determine the
 result of the comparison. \end{note}
 
@@ -10005,7 +10005,7 @@ where \tcode{V} is the composite pointer type (Clause~\ref{expr})
 of \tcode{shared_ptr<T>::element_type*} and \tcode{shared_ptr<U>::element_type*}.
 
 \pnum \begin{note}
-Defining a comparison operator allows \tcode{shared_ptr} objects to be
+Defining a comparison function allows \tcode{shared_ptr} objects to be
 used as keys in associative containers.
 \end{note}
 
@@ -14565,7 +14565,7 @@ template<class T> const T* target() const noexcept;
 a pointer to the stored function target; otherwise a null pointer.
 \end{itemdescr}
 
-\rSec4[func.wrap.func.nullptr]{null pointer comparison operators}
+\rSec4[func.wrap.func.nullptr]{null pointer comparison functions}
 
 \indexlibrarymember{operator==}{function}%
 \begin{itemdecl}


### PR DESCRIPTION
When talking about an operator function, use the term defined in
[defns.comparison].

Fixes #612.