### PR TITLE
[input.output] Add numbered headings for synopses.

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -115,7 +115,7 @@ library call \textit{b} such that this does not result in a data race, then
 
 \rSec1[iostream.forward]{Forward declarations}
 
-\synopsis{Header \tcode{<iosfwd>} synopsis}
+\rSec2[iosfwd.syn]{Header \tcode{<iosfwd>} synopsis}
 \indextext{\idxhdr{iosfwd}}%
 \indexlibrary{\idxhdr{iosfwd}}%
 
@@ -256,6 +256,8 @@ that including
 and other headers does not violate the rules about
 multiple occurrences of default arguments.}
 
+\rSec2[iostream.forward.overview]{Overview}
+
 \pnum
 \begin{note}
 The
@@ -360,9 +362,7 @@ template<> struct char_traits<char> {
 
 \rSec1[iostream.objects]{Standard iostream objects}
 
-\rSec2[iostream.objects.overview]{Overview}
-
-\synopsis{Header \tcode{<iostream>} synopsis}
+\rSec2[iostream.syn]{Header \tcode{<iostream>} synopsis}
 \indextext{\idxhdr{iostream}}%
 \indexlibrary{\idxhdr{iostream}}%
 
@@ -384,6 +384,8 @@ namespace std {
   extern wostream wclog;
 }
 \end{codeblock}
+
+\rSec2[iostream.objects.overview]{Overview}
 
 \pnum
 In this Clause, the type name \tcode{FILE} refers to
@@ -621,9 +623,7 @@ declared in
 
 \rSec1[iostreams.base]{Iostreams base classes}
 
-\rSec2[iostreams.base.overview]{Overview}
-
-\synopsis{Header \tcode{<ios>} synopsis}
+\rSec2[ios.syn]{Header \tcode{<ios>} synopsis}
 \indextext{\idxhdr{ios}}%
 \indexlibrary{\idxhdr{ios}}%
 \indexlibrary{\idxcode{io_errc}}%
@@ -2776,9 +2776,7 @@ The object's \tcode{default_error_condition} and \tcode{equivalent} virtual func
 
 \rSec1[stream.buffers]{Stream buffers}
 
-\rSec2[stream.buffers.overview]{Overview}
-
-\synopsis{Header \tcode{<streambuf>} synopsis}
+\rSec2[streambuf.syn]{Header \tcode{<streambuf>} synopsis}
 \indextext{\idxhdr{streambuf}}%
 \indexlibrary{\idxhdr{streambuf}}%
 
@@ -4040,11 +4038,9 @@ Returns
 
 \rSec1[iostream.format]{Formatting and manipulators}
 
-\rSec2[iostream.format.overview]{Overview}
-
 \indextext{\idxhdr{istream}}%
 \indexlibrary{\idxhdr{istream}}%
-\synopsis{Header \tcode{<istream>} synopsis}
+\rSec2[istream.syn]{Header \tcode{<istream>} synopsis}
 
 \begin{codeblock}
 namespace std {
@@ -4072,7 +4068,7 @@ namespace std {
 \indexlibrary{\idxcode{wistream}}%
 \indexlibrary{\idxcode{basic_istream<wchar_t>}}%
 
-\synopsis{Header \tcode{<ostream>} synopsis}
+\rSec2[ostream.syn]{Header \tcode{<ostream>} synopsis}
 \indextext{\idxhdr{ostream}}%
 \indexlibrary{\idxhdr{ostream}}%
 
@@ -4101,7 +4097,7 @@ namespace std {
 \indexlibrary{\idxcode{wostream}}%
 \indexlibrary{\idxcode{basic_ostream<wchar_t>}}%
 
-\synopsis{Header \tcode{<iomanip>} synopsis}
+\rSec2[iomanip.syn]{Header \tcode{<iomanip>} synopsis}
 \indextext{\idxhdr{iomanip}}%
 \indexlibrary{\idxhdr{iomanip}}%
 
@@ -7238,19 +7234,7 @@ The expression \tcode{in \shr\ quoted(s, delim, escape)} shall have type
 
 \rSec1[string.streams]{String-based streams}
 
-\rSec2[string.streams.overview]{Overview}
-
-\pnum
-The header
-\tcode{<sstream>}
-defines four
-class templates
-and eight types that associate stream buffers with objects of class
-\tcode{basic_string},
-\indexlibrary{\idxcode{basic_string}}%
-as described in~\ref{string.classes}.
-
-\synopsis{Header \tcode{<sstream>} synopsis}
+\rSec2[sstream.syn]{Header \tcode{<sstream>} synopsis}
 \indextext{\idxhdr{sstream}}%
 \indexlibrary{\idxhdr{sstream}}%
 
@@ -7299,6 +7283,16 @@ namespace std {
   using wstringstream = basic_stringstream<wchar_t>;
 }
 \end{codeblock}
+
+\pnum
+The header
+\tcode{<sstream>}
+defines four
+class templates
+and eight types that associate stream buffers with objects of class
+\tcode{basic_string},
+\indexlibrary{\idxcode{basic_string}}%
+as described in~\ref{string.classes}.
 
 \rSec2[stringbuf]{Class template \tcode{basic_stringbuf}}
 \indexlibrary{\idxcode{basic_stringbuf}}%
@@ -8389,16 +8383,7 @@ Calls
 
 \rSec1[file.streams]{File-based streams}
 
-\rSec2[fstreams]{Overview}
-
-\pnum
-The header
-\tcode{<fstream>}
-defines four class templates and eight types
-that associate stream buffers with files and assist
-reading and writing files.
-
-\synopsis{Header \tcode{<fstream>} synopsis}
+\rSec2[fstream.syn]{Header \tcode{<fstream>} synopsis}
 \indextext{\idxhdr{fstream}}%
 \indexlibrary{\idxhdr{fstream}}%
 \indexlibrary{\idxcode{filebuf}}%
@@ -8440,6 +8425,13 @@ namespace std {
   using wfstream = basic_fstream<wchar_t>;
 }
 \end{codeblock}
+
+\pnum
+The header
+\tcode{<fstream>}
+defines four class templates and eight types
+that associate stream buffers with files and assist
+reading and writing files.
 
 \pnum
 \begin{note} The class template \tcode{basic_filebuf} treats a file as a source or


### PR DESCRIPTION
Remove now-empty 'Overview' sections.

Partially addresses #566.