### PR TITLE
Remove \synopsis macro.

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2550,9 +2550,9 @@ paragraph
 \item
 for types used as template arguments when instantiating a template component,
 if the operations on the type do not implement the semantics of the applicable
-\synopsis{Requirements}
+\emph{Requirements}
 subclause~(\ref{allocator.requirements}, \ref{container.requirements}, \ref{iterator.requirements},
-\ref{numeric.requirements}).
+\ref{algorithms.requirements}, \ref{numeric.requirements}).
 Operations on such types can report a failure by throwing an exception
 unless otherwise specified.
 \item

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -90,8 +90,6 @@
 \addtocounter{scratch}{\value{SectionDepthBase}}
 \Sec{\arabic{scratch}}[#2]{#3}}
 
-\newcommand{\synopsis}[1]{\textbf{#1}}
-
 %%--------------------------------------------------
 % Indexing
 


### PR DESCRIPTION
[res.on.functions] Do not use \synopsis for emphasis.

Fixes #566.