### PR TITLE
[intro.races] Remove duplicated index entry for 'data race'.

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -1415,7 +1415,6 @@ Two actions are \defn{potentially concurrent} if
 \item they are unsequenced, at least one is performed by a signal handler, and
 they are not both performed by the same signal handler invocation.
 \end{itemize}
-\indextext{data race}%
 The execution of a program contains a \defn{data race} if it contains two
 potentially concurrent conflicting actions, at least one of which is not atomic,
 and neither happens before the other,


### PR DESCRIPTION
The \defn on the next line already creates an index entry.