### PR TITLE
[path.non-member] Structure multi-paragraph note using an itemization instead.

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -11943,16 +11943,16 @@ bool operator==(const path& lhs, const path& rhs) noexcept;
 \indextext{path equality}
 \pnum
 \begin{note} Path equality and path equivalence have different semantics.
-
-\pnum
-Equality is determined by the \tcode{path} non-member \tcode{operator==}, which considers the two path's lexical
-  representations only. Thus \tcode{path("foo") == "bar"} is never \tcode{true}.
-
-\pnum
-Equivalence is determined by the \tcode{equivalent()} non-member function, which determines if two paths resolve~(\ref{fs.def.pathres}) to the same file system entity.
-  Thus \tcode{equivalent("foo", "bar")} will be \tcode{true} when both paths resolve to the same file.
-
-\pnum
+\begin{itemize}
+\item Equality is determined by the \tcode{path} non-member \tcode{operator==},
+which considers the two path's lexical representations only.
+\begin{example} \tcode{path("foo") == "bar"} is never \tcode{true}. \end{example}
+\item Equivalence is determined by the \tcode{equivalent()} non-member function, which
+determines if two paths resolve~(\ref{fs.def.pathres}) to the same file system entity.
+\begin{example}
+\tcode{equivalent("foo", "bar")} will be \tcode{true} when both paths resolve to the same file.
+\end{example}
+\end{itemize}
 Programmers wishing to determine if two paths are ``the same'' must decide if
   ``the same'' means ``the same representation'' or ``resolve to the same actual
   file'', and choose the appropriate function accordingly. \end{note}


### PR DESCRIPTION
Diff:
![diff](http://eel.is/pathnote.png)

This removes the most egregious instance in the document of a note spanning multiple numbered paragraphs, and I think it actually reads and looks nicer as an itemization (and with the examples marked as examples).

Thoughts? :)