### PR TITLE
[library] Add full stops to \returns etc.

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -3193,7 +3193,7 @@ template <class T, size_t N> constexpr size_type array<T, N>::size() const noexc
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{N}
+\pnum\returns \tcode{N}.
 \end{itemdescr}
 
 \rSec3[array.data]{\tcode{array::data}}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -2031,7 +2031,7 @@ char_type fill(char_type fillch);
 \begin{itemdescr}
 \pnum
 \postconditions
-\tcode{traits::eq(fillch, fill())}
+\tcode{traits::eq(fillch, fill())}.
 
 \pnum
 \returns
@@ -4317,7 +4317,7 @@ assigning initial values to the base class by calling
 
 \pnum
 \postconditions
-\tcode{gcount() == 0}
+\tcode{gcount() == 0}.
 \end{itemdescr}
 
 
@@ -6720,7 +6720,7 @@ template <class charT, class traits, class T>
 \effects As if by: \tcode{os \shl{} x;}
 
 \pnum
-\returns \tcode{os}
+\returns \tcode{os}.
 
 \pnum
 \remarks This function shall not participate in overload resolution

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -1039,7 +1039,7 @@ regex_error(regex_constants::error_type ecode);
 \begin{itemdescr}
 \pnum\effects  Constructs an object of class \tcode{regex_error}.
 
-\pnum\postconditions  \tcode{ecode == code()}
+\pnum\postconditions  \tcode{ecode == code()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{error_type}}%

--- a/source/support.tex
+++ b/source/support.tex
@@ -2199,7 +2199,7 @@ respectively.
 \rSec3[new.delete.placement]{Non-allocating forms}
 
 \pnum
-These functions are reserved, a \Cpp program may not define functions that displace
+These functions are reserved; a \Cpp program may not define functions that displace
 the versions in the \Cpp standard library~(\ref{constraints}).
 The provisions of~(\ref{basic.stc.dynamic}) do not apply to these reserved
 placement forms of \tcode{operator new} and \tcode{operator delete}.
@@ -2449,7 +2449,7 @@ or a class derived from
 \indexlibrary{\idxcode{bad_alloc}}%
 \tcode{bad_alloc};
 \item
-terminate execution of the program without returning to the caller;
+terminate execution of the program without returning to the caller.
 \indexlibrary{\idxcode{abort}}%
 \indexlibrary{\idxcode{exit}}%
 \end{itemize}

--- a/source/support.tex
+++ b/source/support.tex
@@ -2715,7 +2715,7 @@ program, it shall return the same value for any two \tcode{type_info}
 objects which compare equal.
 
 \pnum
-\remarks an implementation should return different values for two
+\remarks An implementation should return different values for two
 \tcode{type_info} objects which do not compare equal.
 \end{itemdescr}
 
@@ -3256,7 +3256,7 @@ recursion.\end{note}
 \requires \tcode{p} shall not be a null pointer.
 
 \pnum
-\throws the exception object to which \tcode{p} refers.
+\throws The exception object to which \tcode{p} refers.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{make_exception_ptr}}%
@@ -3357,7 +3357,7 @@ Let \tcode{U} be \tcode{remove_reference_t<T>}.
 
 \pnum
 \throws
-if \tcode{is_class_v<U> \&\& !is_final_v<U> \&\& !is_base_of_v<nested_exception, U>}
+If \tcode{is_class_v<U> \&\& !is_final_v<U> \&\& !is_base_of_v<nested_exception, U>}
 is \tcode{true},
 an exception of unspecified type that is publicly derived from both
 \tcode{U} and \tcode{nested_exception}
@@ -3441,10 +3441,10 @@ constexpr initializer_list() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects constructs an empty \tcode{initializer_list} object.
+\effects Constructs an empty \tcode{initializer_list} object.
 
 \pnum
-\postconditions \tcode{size() == 0}
+\postconditions \tcode{size() == 0}.
 \end{itemdescr}
 
 \rSec2[support.initlist.access]{Initializer list access}
@@ -3468,7 +3468,7 @@ constexpr const E* end() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{begin() + size()}
+\returns \tcode{begin() + size()}.
 \end{itemdescr}
 
 \indexlibrarymember{size}{initializer_list}%

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -449,7 +449,7 @@ bool operator<=(thread::id x, thread::id y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!(y < x)}
+\returns \tcode{!(y < x)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>}{thread::id}%
@@ -458,7 +458,7 @@ bool operator>(thread::id x, thread::id y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{y < x}
+\pnum\returns \tcode{y < x}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>=}{thread::id}%
@@ -467,7 +467,7 @@ bool operator>=(thread::id x, thread::id y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{!(x < y)}
+\pnum\returns \tcode{!(x < y)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator\shl}{thread::id}%
@@ -484,7 +484,7 @@ if \tcode{x == y} the \tcode{thread::id} objects shall have the same text
 representation and if \tcode{x != y} the \tcode{thread::id} objects shall have
 distinct text representations.
 
-\pnum\returns \tcode{out}
+\pnum\returns \tcode{out}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{hash}!\idxcode{thread::id}}%
@@ -506,7 +506,7 @@ thread() noexcept;
 \begin{itemdescr}
 \pnum\effects Constructs a \tcode{thread} object that does not represent a thread of execution.
 
-\pnum\postconditions \tcode{get_id() == id()}
+\pnum\postconditions \tcode{get_id() == id()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{thread}!constructor}%
@@ -605,7 +605,7 @@ state of \tcode{x} to \tcode{*this} and sets \tcode{x} to a default constructed 
 \tcode{x.get_id()} prior to the assignment.
 
 \pnum
-\returns \tcode{*this}
+\returns \tcode{*this}.
 \end{itemdescr}
 
 \rSec3[thread.thread.member]{\tcode{thread} members}
@@ -627,7 +627,7 @@ bool joinable() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{get_id() != id()}
+\returns \tcode{get_id() != id()}.
 \end{itemdescr}
 
 \indexlibrarymember{join}{thread}%
@@ -925,7 +925,7 @@ thread does not own the mutex.
 \postconditions The calling thread owns the mutex.
 
 \pnum
-\returntype \tcode{void}
+\returntype \tcode{void}.
 
 \pnum
 \sync Prior \tcode{unlock()} operations on the same object shall
@@ -966,7 +966,7 @@ An implementation should ensure that \tcode{try_lock()} does not consistently re
 in the absence of contending mutex acquisitions.
 
 \pnum
-\returntype \tcode{bool}
+\returntype \tcode{bool}.
 
 \pnum
 \returns \tcode{true} if ownership of the mutex was obtained for the calling
@@ -994,7 +994,7 @@ The expression \tcode{m.unlock()} shall be well-formed and have the following se
 \effects Releases the calling thread's ownership of the mutex.
 
 \pnum
-\returntype \tcode{void}
+\returntype \tcode{void}.
 
 \pnum
 \sync This operation synchronizes with~(\ref{intro.multithread}) subsequent
@@ -1150,7 +1150,7 @@ lock is available, but implementations are expected to make a strong effort to d
 \end{note}
 
 \pnum
-\returntype \tcode{bool}
+\returntype \tcode{bool}.
 
 \pnum
 \returns \tcode{true} if ownership was obtained, otherwise \tcode{false}.
@@ -1182,7 +1182,7 @@ return before the absolute timeout~(\ref{thread.req.timing}) specified by
 be obtained if the lock is available, but implementations are expected to make a
 strong effort to do so. \end{note}
 
-\pnum\returntype \tcode{bool}
+\pnum\returntype \tcode{bool}.
 
 \pnum
 \returns \tcode{true} if ownership was obtained, otherwise \tcode{false}.
@@ -1966,7 +1966,7 @@ void lock();
 \effects As if by \tcode{pm->lock()}.
 
 \pnum
-\postconditions \tcode{owns == true}
+\postconditions \tcode{owns == true}.
 
 \pnum
 \throws
@@ -2089,7 +2089,7 @@ void unlock();
 \begin{itemdescr}
 \pnum\effects As if by \tcode{pm->unlock()}.
 
-\pnum\postconditions \tcode{owns == false}
+\pnum\postconditions \tcode{owns == false}.
 
 \pnum\throws \tcode{system_error} when
 an exception is required~(\ref{thread.req.exception}).
@@ -2140,7 +2140,7 @@ bool owns_lock() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{owns}
+\pnum\returns \tcode{owns}.
 \end{itemdescr}
 
 \indexlibrarymember{operator bool}{unique_lock}%
@@ -2149,7 +2149,7 @@ explicit operator bool() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{owns}
+\pnum\returns \tcode{owns}.
 \end{itemdescr}
 
 \indexlibrarymember{mutex}{unique_lock}%
@@ -2158,7 +2158,7 @@ mutex_type *mutex() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{pm}
+\pnum\returns \tcode{pm}.
 \end{itemdescr}
 
 \rSec3[thread.lock.shared]{Class template \tcode{shared_lock}}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1281,7 +1281,7 @@ template <class T1, class T2>
 tuple_element<0, pair<T1, T2>>::type
 \end{itemdecl}
 \begin{itemdescr}
-\pnum\textit{Value:} the type \tcode{T1}.
+\pnum\textit{Value:} The type \tcode{T1}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{tuple_element}}%
@@ -1289,7 +1289,7 @@ tuple_element<0, pair<T1, T2>>::type
 tuple_element<1, pair<T1, T2>>::type
 \end{itemdecl}
 \begin{itemdescr}
-\pnum\textit{Value:} the type T2.
+\pnum\textit{Value:} The type T2.
 \end{itemdescr}
 
 \indexlibrarymember{get}{pair}%
@@ -7344,7 +7344,7 @@ template <class T, class Alloc> struct uses_allocator;
 
 \begin{itemdescr}
 \pnum
-\remarks automatically detects whether \tcode{T} has a nested \tcode{allocator_type} that
+\remarks Automatically detects whether \tcode{T} has a nested \tcode{allocator_type} that
 is convertible from \tcode{Alloc}. Meets the BinaryTypeTrait
 requirements~(\ref{meta.rqmts}). The implementation shall provide a definition that is
 derived from \tcode{true_type} if the \grammarterm{qualified-id} \tcode{T::allocator_type}
@@ -9635,7 +9635,7 @@ template<class Y> shared_ptr(shared_ptr<Y>&& r) noexcept;
 
 \pnum
 \postconditions \tcode{*this} shall contain the old value of
-\tcode{r}. \tcode{r} shall be empty. \tcode{r.get() == nullptr.}
+\tcode{r}. \tcode{r} shall be empty. \tcode{r.get() == nullptr}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{shared_ptr}!constructor}%

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -18990,7 +18990,7 @@ the element access functions.
 \begin{example}
 \begin{codeblock}
 using namespace std;
-vector<int> v = ...
+vector<int> v = @\commentellip@;
 
 // standard sequential sort
 sort(v.begin(), v.end());


### PR DESCRIPTION
My understanding is that we want to always end \returns and other elements in a full stop. The wiki (https://github.com/cplusplus/draft/wiki/Specification-Style-Guidelines) seems to agree with this, although it doesn't talk about all elements and there is one conflicting "*Returns:* `T{0}`" example.

I haven't gone through the whole draft so there are likely a lot more remaining. These are just ones I've noticed so far.