### PR TITLE
[class.derived] Don't bother splitting last remark in note off into separate paragraph.

### DIFF
--- a/source/derived.tex
+++ b/source/derived.tex
@@ -144,19 +144,16 @@ derived object~(\ref{intro.object}) is unspecified.
 \begin{note}
 \indextext{directed acyclic graph|see{DAG}}%
 \indextext{lattice|see{DAG, subobject}}%
-a derived class and its base class subobjects can be represented by a
+A derived class and its base class subobjects can be represented by a
 directed acyclic graph (DAG) where an arrow means ``directly derived
-from''. A DAG of subobjects is often referred to as a ``subobject
-lattice''.
+from''. An arrow need not have a physical representation in memory.
+A DAG of subobjects is often referred to as a ``subobject lattice''.
 
 \begin{importgraphic}
 {Directed acyclic graph}
 {fig:dag}
 {figdag.pdf}
 \end{importgraphic}
-
-\pnum
-The arrows need not have a physical representation in memory.
 \end{note}
 
 \pnum


### PR DESCRIPTION
While I think this change is definitely merited on its own, its real significance is that it gets rid of the very last (as far as I can tell) multi-paragraph note in the document, thereby fixing half of #781.