### PR TITLE
[unord] Use 'key equality predicate' consistently.

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -7666,7 +7666,7 @@ explicit unordered_map(size_type n,
 \begin{itemdescr}
 \pnum
 \effects Constructs an empty \tcode{unordered_map} using the
-specified hash function, key equality function, and allocator, and
+specified hash function, key equality predicate, and allocator, and
 using at least \tcode{n} buckets.  For the default constructor,
 the number of buckets is \impldef{default number of buckets in
 \tcode{unordered_map}}.
@@ -7694,7 +7694,7 @@ unordered_map(initializer_list<value_type> il,
 \begin{itemdescr}
 \pnum
 \effects Constructs an empty \tcode{unordered_map} using the
-specified hash function, key equality function, and allocator, and
+specified hash function, key equality predicate, and allocator, and
 using at least \tcode{n} buckets. If \tcode{n} is not
 provided, the number of buckets is \impldef{default number of buckets in
 \tcode{unordered_map}}. Then
@@ -8159,7 +8159,7 @@ explicit unordered_multimap(size_type n,
 \begin{itemdescr}
 \pnum
 \effects Constructs an empty \tcode{unordered_multimap} using the
-specified hash function, key equality function, and allocator, and
+specified hash function, key equality predicate, and allocator, and
 using at least \tcode{n} buckets.  For the default constructor,
 the number of buckets is \impldef{default number of buckets in
 \tcode{unordered_multimap}}.
@@ -8187,7 +8187,7 @@ unordered_multimap(initializer_list<value_type> il,
 \begin{itemdescr}
 \pnum
 \effects Constructs an empty \tcode{unordered_multimap} using the
-specified hash function, key equality function, and allocator, and
+specified hash function, key equality predicate, and allocator, and
 using at least \tcode{n} buckets. If \tcode{n} is not
 provided, the number of buckets is \impldef{default number of buckets in
 \tcode{unordered_multimap}}. Then
@@ -8454,7 +8454,7 @@ explicit unordered_set(size_type n,
 \begin{itemdescr}
 \pnum
 \effects Constructs an empty \tcode{unordered_set} using the
-specified hash function, key equality function, and allocator, and
+specified hash function, key equality predicate, and allocator, and
 using at least \tcode{n} buckets.  For the default constructor,
 the number of buckets is \impldef{default number of buckets in
 \tcode{unordered_set}}.
@@ -8482,7 +8482,7 @@ unordered_set(initializer_list<value_type> il,
 \begin{itemdescr}
 \pnum
 \effects Constructs an empty \tcode{unordered_set} using the
-specified hash function, key equality function, and allocator, and
+specified hash function, key equality predicate, and allocator, and
 using at least \tcode{n} buckets. If \tcode{n} is not
 provided, the number of buckets is \impldef{default number of buckets in
 \tcode{unordered_set}}. Then
@@ -8721,7 +8721,7 @@ explicit unordered_multiset(size_type n,
 \begin{itemdescr}
 \pnum
 \effects Constructs an empty \tcode{unordered_multiset} using the
-specified hash function, key equality function, and allocator, and
+specified hash function, key equality predicate, and allocator, and
 using at least \tcode{n} buckets.  For the default constructor,
 the number of buckets is \impldef{default number of buckets in
 \tcode{unordered_multiset}}.
@@ -8749,7 +8749,7 @@ unordered_multiset(initializer_list<value_type> il,
 \begin{itemdescr}
 \pnum\effects
 Constructs an empty \tcode{unordered_multiset} using the
-specified hash function, key equality function, and allocator, and
+specified hash function, key equality predicate, and allocator, and
 using at least \tcode{n} buckets. If \tcode{n} is not
 provided, the number of buckets is \impldef{default number of buckets in
 \tcode{unordered_multiset}}. Then


### PR DESCRIPTION
Replaces occasional uses of 'key equality function'.

Fixes #630.