### PR TITLE
disambiguate an odr usage requirement in [basic.def.odr]

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -449,7 +449,7 @@ a non-volatile \tcode{const} object with internal or no linkage if the object
 \begin{itemize}
 \item has the same literal type in all definitions of \tcode{D},
 \item is initialized with a constant expression~(\ref{expr.const}),
-\item is not odr-used, and
+\item is not odr-used in any definition of \tcode{D}, and
 \item has the same value in all definitions of \tcode{D},
 \end{itemize}
 or


### PR DESCRIPTION
[basic.def.odr] (6.2.1.3)
Coming from: http://stackoverflow.com/questions/41133290 where T.C. asserted that this should be "not odr-used within the definition of D." Otherwise another entity odr-using the constant could break existing definitions non-odr-use. Alternatively this could read "is not odr-used in anl definitions of D" but that language seems more ambiguous.

The example code:
```c++
static constexpr int CONSTANT = 2;
inline int f() {
  return CONSTANT;
}
```

If this appears in a header, it could be broken later (by a strict reading of the currently language) if anyone, anywhere odr-uses `CONSTANT`