### PR TITLE
[iostream.forward.overview] Promote introductory sentences

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -259,7 +259,6 @@ multiple occurrences of default arguments.}
 \rSec2[iostream.forward.overview]{Overview}
 
 \pnum
-\begin{note}
 The
 class template specialization
 \tcode{basic_ios<charT, traits>}
@@ -341,6 +340,7 @@ and
 respectively.
 
 \pnum
+\begin{note}
 This synopsis suggests a circularity between
 \tcode{streampos}
 and


### PR DESCRIPTION
to normative text.

Fixes #494.