### PR TITLE
[algorithms] Move non-modifying algorithms away

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -3337,171 +3337,6 @@ randomness.
 
 \end{itemdescr}
 
-\rSec2[alg.partitions]{Partitions}
-
-\indexlibrary{\idxcode{is_partitioned}}%
-\begin{itemdecl}
-template <class InputIterator, class Predicate>
-  bool is_partitioned(InputIterator first, InputIterator last, Predicate pred);
-template <class ExecutionPolicy, class InputIterator, class Predicate>
-  bool is_partitioned(ExecutionPolicy&& exec,
-                      InputIterator first, InputIterator last, Predicate pred);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\requires \tcode{InputIterator}'s value type shall be convertible to \tcode{Predicate}'s argument type.
-
-\pnum
-\returns \tcode{true} if
-\range{first}{last} is empty or if
-\range{first}{last} is partitioned by \tcode{pred}, i.e. if all elements that satisfy \tcode{pred} appear before those that do not.
-
-\pnum
-\complexity Linear. At most \tcode{last - first} applications of \tcode{pred}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{partition}}%
-\begin{itemdecl}
-template<class ForwardIterator, class Predicate>
-  ForwardIterator
-    partition(ForwardIterator first, ForwardIterator last, Predicate pred);
-template<class ExecutionPolicy, class ForwardIterator, class Predicate>
-  ForwardIterator
-    partition(ExecutionPolicy&& exec,
-              ForwardIterator first, ForwardIterator last, Predicate pred);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\requires
-\tcode{ForwardIterator} shall satisfy the requirements of
-\tcode{ValueSwappable}~(\ref{swappable.requirements}).
-
-\pnum
-\effects Places all the elements in the range \range{first}{last} that satisfy \tcode{pred} before all the elements that do not satisfy it.
-
-\pnum
-\returns An iterator \tcode{i} such that for every iterator \tcode{j} in the range
-\range{first}{i} \tcode{pred(*j) != false}, and for every iterator \tcode{k} in the
-range \range{i}{last}, \tcode{pred(*k) == false}.
-
-\pnum
-\complexity If \tcode{ForwardIterator} meets the requirements for a \tcode{BidirectionalIterator}, at most
-\tcode{(last - first) / 2} swaps are done; otherwise at most \tcode{last - first} swaps
-are done. Exactly \tcode{last - first} applications of the predicate are done.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{stable_partition}}%
-\begin{itemdecl}
-template<class BidirectionalIterator, class Predicate>
-  BidirectionalIterator
-    stable_partition(BidirectionalIterator first, BidirectionalIterator last,
-                     Predicate pred);
-template<class ExecutionPolicy, class BidirectionalIterator, class Predicate>
-  BidirectionalIterator
-    stable_partition(ExecutionPolicy&& exec,
-                     BidirectionalIterator first, BidirectionalIterator last,
-                     Predicate pred);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\requires
-\tcode{BidirectionalIterator} shall satisfy the requirements of
-\tcode{ValueSwappable}~(\ref{swappable.requirements}). The type
-of \tcode{*first} shall satisfy the requirements of
-\tcode{MoveConstructible} (Table~\ref{tab:moveconstructible}) and of
-\tcode{MoveAssignable} (Table~\ref{tab:moveassignable}).
-
-\pnum
-\effects
-Places all the elements in the range
-\range{first}{last}
-that satisfy \tcode{pred} before all the
-elements that do not satisfy it.
-
-\pnum
-\returns
-An iterator
-\tcode{i}
-such that for every iterator
-\tcode{j}
-in the range
-\range{first}{i},
-\tcode{pred(*j) != false},
-and for every iterator
-\tcode{k}
-in the range
-\range{i}{last},
-\tcode{pred(*k) == false}.
-The relative order of the elements in both groups is preserved.
-
-\pnum
-\complexity
-At most $N \log(N)$ swaps, where $N = \tcode{last - first}$,
-but only \bigoh{N} swaps if there is enough extra memory.
-Exactly
-\tcode{last - first}
-applications of the predicate.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{partition_copy}}%
-\begin{itemdecl}
-template <class InputIterator, class OutputIterator1,
-          class OutputIterator2, class Predicate>
-  pair<OutputIterator1, OutputIterator2>
-    partition_copy(InputIterator first, InputIterator last,
-                   OutputIterator1 out_true, OutputIterator2 out_false,
-                   Predicate pred);
-template <class ExecutionPolicy, class InputIterator, class OutputIterator1,
-          class OutputIterator2, class Predicate>
-  pair<OutputIterator1, OutputIterator2>
-    partition_copy(ExecutionPolicy&& exec,
-                   InputIterator first, InputIterator last,
-                   OutputIterator1 out_true, OutputIterator2 out_false,
-                   Predicate pred);
-\end{itemdecl}
-
-
-\begin{itemdescr}
-\pnum
-\requires \tcode{InputIterator}'s value type shall be \tcode{CopyAssignable}, and shall be
-writable~(\ref{iterator.requirements.general}) to the \tcode{out_true} and \tcode{out_false} \tcode{OutputIterator}s, and shall be
-convertible to \tcode{Predicate}'s argument type. The input range shall not overlap with
-either of the output ranges.
-
-\pnum
-\effects For each iterator \tcode{i} in \range{first}{last}, copies \tcode{*i} to the output range beginning with \tcode{out_true} if \tcode{pred(*i)} is \tcode{true}, or to the output range beginning with \tcode{out_false} otherwise.
-
-\pnum
-\returns A pair \tcode{p} such that \tcode{p.first} is the end of the output range beginning at \tcode{out_true} and \tcode{p.second} is the end of the output range beginning at \tcode{out_false}.
-
-\pnum
-\complexity Exactly \tcode{last - first} applications of \tcode{pred}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{partition_point}}%
-\begin{itemdecl}
-template<class ForwardIterator, class Predicate>
-  ForwardIterator partition_point(ForwardIterator first,
-                                  ForwardIterator last,
-                                  Predicate pred);
-\end{itemdecl}
-
-
-\begin{itemdescr}
-\pnum
-\requires \tcode{ForwardIterator}'s value type shall be convertible to \tcode{Predicate}'s argument type. \range{first}{last} shall be partitioned by \tcode{pred}, i.e. all elements that satisfy \tcode{pred} shall appear before those that do not.
-
-\pnum
-\returns An iterator \tcode{mid} such that \tcode{all_of(first, mid, pred)} and \tcode{none_of(mid, last, pred)} are both \tcode{true}.
-
-\pnum
-\complexity \bigoh{\log(\tcode{last - first})} applications of \tcode{pred}.
-\end{itemdescr}
-
-
 \rSec1[alg.sorting]{Sorting and related operations}
 
 \pnum
@@ -4197,6 +4032,170 @@ or
 At most
 $\log_2(\tcode{last - first}) + \bigoh{1}$
 comparisons.
+\end{itemdescr}
+
+\rSec2[alg.partitions]{Partitions}
+
+\indexlibrary{\idxcode{is_partitioned}}%
+\begin{itemdecl}
+template <class InputIterator, class Predicate>
+  bool is_partitioned(InputIterator first, InputIterator last, Predicate pred);
+template <class ExecutionPolicy, class InputIterator, class Predicate>
+  bool is_partitioned(ExecutionPolicy&& exec,
+                      InputIterator first, InputIterator last, Predicate pred);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\requires \tcode{InputIterator}'s value type shall be convertible to \tcode{Predicate}'s argument type.
+
+\pnum
+\returns \tcode{true} if
+\range{first}{last} is empty or if
+\range{first}{last} is partitioned by \tcode{pred}, i.e. if all elements that satisfy \tcode{pred} appear before those that do not.
+
+\pnum
+\complexity Linear. At most \tcode{last - first} applications of \tcode{pred}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{partition}}%
+\begin{itemdecl}
+template<class ForwardIterator, class Predicate>
+  ForwardIterator
+    partition(ForwardIterator first, ForwardIterator last, Predicate pred);
+template<class ExecutionPolicy, class ForwardIterator, class Predicate>
+  ForwardIterator
+    partition(ExecutionPolicy&& exec,
+              ForwardIterator first, ForwardIterator last, Predicate pred);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\requires
+\tcode{ForwardIterator} shall satisfy the requirements of
+\tcode{ValueSwappable}~(\ref{swappable.requirements}).
+
+\pnum
+\effects Places all the elements in the range \range{first}{last} that satisfy \tcode{pred} before all the elements that do not satisfy it.
+
+\pnum
+\returns An iterator \tcode{i} such that for every iterator \tcode{j} in the range
+\range{first}{i} \tcode{pred(*j) != false}, and for every iterator \tcode{k} in the
+range \range{i}{last}, \tcode{pred(*k) == false}.
+
+\pnum
+\complexity If \tcode{ForwardIterator} meets the requirements for a \tcode{BidirectionalIterator}, at most
+\tcode{(last - first) / 2} swaps are done; otherwise at most \tcode{last - first} swaps
+are done. Exactly \tcode{last - first} applications of the predicate are done.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{stable_partition}}%
+\begin{itemdecl}
+template<class BidirectionalIterator, class Predicate>
+  BidirectionalIterator
+    stable_partition(BidirectionalIterator first, BidirectionalIterator last,
+                     Predicate pred);
+template<class ExecutionPolicy, class BidirectionalIterator, class Predicate>
+  BidirectionalIterator
+    stable_partition(ExecutionPolicy&& exec,
+                     BidirectionalIterator first, BidirectionalIterator last,
+                     Predicate pred);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\requires
+\tcode{BidirectionalIterator} shall satisfy the requirements of
+\tcode{ValueSwappable}~(\ref{swappable.requirements}). The type
+of \tcode{*first} shall satisfy the requirements of
+\tcode{MoveConstructible} (Table~\ref{tab:moveconstructible}) and of
+\tcode{MoveAssignable} (Table~\ref{tab:moveassignable}).
+
+\pnum
+\effects
+Places all the elements in the range
+\range{first}{last}
+that satisfy \tcode{pred} before all the
+elements that do not satisfy it.
+
+\pnum
+\returns
+An iterator
+\tcode{i}
+such that for every iterator
+\tcode{j}
+in the range
+\range{first}{i},
+\tcode{pred(*j) != false},
+and for every iterator
+\tcode{k}
+in the range
+\range{i}{last},
+\tcode{pred(*k) == false}.
+The relative order of the elements in both groups is preserved.
+
+\pnum
+\complexity
+At most $N \log(N)$ swaps, where $N = \tcode{last - first}$,
+but only \bigoh{N} swaps if there is enough extra memory.
+Exactly
+\tcode{last - first}
+applications of the predicate.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{partition_copy}}%
+\begin{itemdecl}
+template <class InputIterator, class OutputIterator1,
+          class OutputIterator2, class Predicate>
+  pair<OutputIterator1, OutputIterator2>
+    partition_copy(InputIterator first, InputIterator last,
+                   OutputIterator1 out_true, OutputIterator2 out_false,
+                   Predicate pred);
+template <class ExecutionPolicy, class InputIterator, class OutputIterator1,
+          class OutputIterator2, class Predicate>
+  pair<OutputIterator1, OutputIterator2>
+    partition_copy(ExecutionPolicy&& exec,
+                   InputIterator first, InputIterator last,
+                   OutputIterator1 out_true, OutputIterator2 out_false,
+                   Predicate pred);
+\end{itemdecl}
+
+
+\begin{itemdescr}
+\pnum
+\requires \tcode{InputIterator}'s value type shall be \tcode{CopyAssignable}, and shall be
+writable~(\ref{iterator.requirements.general}) to the \tcode{out_true} and \tcode{out_false} \tcode{OutputIterator}s, and shall be
+convertible to \tcode{Predicate}'s argument type. The input range shall not overlap with
+either of the output ranges.
+
+\pnum
+\effects For each iterator \tcode{i} in \range{first}{last}, copies \tcode{*i} to the output range beginning with \tcode{out_true} if \tcode{pred(*i)} is \tcode{true}, or to the output range beginning with \tcode{out_false} otherwise.
+
+\pnum
+\returns A pair \tcode{p} such that \tcode{p.first} is the end of the output range beginning at \tcode{out_true} and \tcode{p.second} is the end of the output range beginning at \tcode{out_false}.
+
+\pnum
+\complexity Exactly \tcode{last - first} applications of \tcode{pred}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{partition_point}}%
+\begin{itemdecl}
+template<class ForwardIterator, class Predicate>
+  ForwardIterator partition_point(ForwardIterator first,
+                                  ForwardIterator last,
+                                  Predicate pred);
+\end{itemdecl}
+
+
+\begin{itemdescr}
+\pnum
+\requires \tcode{ForwardIterator}'s value type shall be convertible to \tcode{Predicate}'s argument type. \range{first}{last} shall be partitioned by \tcode{pred}, i.e. all elements that satisfy \tcode{pred} shall appear before those that do not.
+
+\pnum
+\returns An iterator \tcode{mid} such that \tcode{all_of(first, mid, pred)} and \tcode{none_of(mid, last, pred)} are both \tcode{true}.
+
+\pnum
+\complexity \bigoh{\log(\tcode{last - first})} applications of \tcode{pred}.
 \end{itemdescr}
 
 \rSec2[alg.merge]{Merge}


### PR DESCRIPTION
from [alg.modifying.operations].

For is_partitioned, create a new subsection [alg.is_partitioned]
under [alg.nonmodifying].
For partition_point, create a new subsection [partition.point]
under [alg.binary.search].

Fixes #289.