### PR TITLE
[tuple.creation] Simplify the introductory notation, and then use notation that matches the introduction.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1394,16 +1394,17 @@ namespace std {
   // \ref{tuple.creation}, tuple creation functions
   constexpr @\unspec@ ignore;
 
-  template <class... Types>
-    constexpr tuple<@\placeholder{VTypes}@...> make_tuple(Types&&...);
-  template <class... Types>
-    constexpr tuple<Types&&...> forward_as_tuple(Types&&...) noexcept;
+  template <class... TTypes>
+    constexpr tuple<VTypes...> make_tuple(TTypes&&...);
 
-  template<class... Types>
-    constexpr tuple<Types&...> tie(Types&...) noexcept;
+  template <class... TTypes>
+    constexpr tuple<TTypes&&...> forward_as_tuple(TTypes&&...) noexcept;
+
+  template<class... TTypes>
+    constexpr tuple<TTypes&...> tie(TTypes&...) noexcept;
 
   template <class... Tuples>
-    constexpr tuple<@\placeholder{Ctypes}@...> tuple_cat(Tuples&&...);
+    constexpr tuple<CTypes...> tuple_cat(Tuples&&...);
 
   // \ref{tuple.apply}, calling a function with a tuple of arguments
   template <class F, class Tuple>
@@ -1960,49 +1961,42 @@ where $\mathtt{T}_i$ is the $i^\text{th}$ type in \tcode{Types}.
 \rSec3[tuple.creation]{Tuple creation functions}
 
 \pnum
-In the function descriptions that follow, let $i$ be in the range \range{0}{sizeof...(TTypes)}
-in order and let $\tcode{T}_i$ be the $i^{th}$ type in a template parameter pack named \tcode{TTypes};
-let $j$ be in the range \range{0}{sizeof...(UTypes)} in order and $\tcode{U}_j$ be the $j^{th}$ type
-in a template parameter pack named \tcode{UTypes}, where indexing is zero-based.
+In the function descriptions that follow, the members of a parameter pack \tcode{\placeholder{X}Types}
+are denoted by \tcode{\placeholder{X}}$_i$ for $i$ in \range{0}{sizeof...(\placeholder{X}Types)} in
+order, where indexing is zero-based.
 
 \indexlibrary{\idxcode{make_tuple}}%
 \indexlibrary{\idxcode{tuple}!\idxcode{make_tuple}}%
 \begin{itemdecl}
-template<class... Types>
-  constexpr tuple<@\placeholder{VTypes}@...> make_tuple(Types&&... t);
+template<class... TTypes>
+  constexpr tuple<VTypes...> make_tuple(TTypes&&... t);
 \end{itemdecl}
 
-\begin{itemdescr} \pnum Let \tcode{$\tcode{U}_i$} be \tcode{decay_t<$\tcode{T}_i$>} for each
-$\tcode{T}_i$ in \tcode{Types}. If $\tcode{U}_i$ is a specialization of
-\tcode{reference_wrapper}, then $\tcode{V}_i$ in \tcode{VTypes} is \tcode{$\tcode{U}_i$::type\&},
-otherwise $\tcode{V}_i$ is $\tcode{U}_i$.
+\begin{itemdescr}
+\pnum
+The pack \tcode{VTypes} is defined as follows. Let \tcode{U}$_i$ be \tcode{decay_t<T$_i$>} for each
+\tcode{T}$_i$ in \tcode{TTypes}. If \tcode{U}$_i$ is a specialization of
+\tcode{reference_wrapper}, then \tcode{V}$_i$ in \tcode{VTypes} is \tcode{U$_i$::type\&},
+otherwise \tcode{V}$_i$ is \tcode{U}$_i$.
 
 \pnum
-\returns \tcode{tuple<VTypes...>(std::forward<Types>(t)...)}.
+\returns \tcode{tuple<VTypes...>(std::forward<TTypes>(t)...)}.
 
 \pnum
 \begin{example}
-
 \begin{codeblock}
 int i; float j;
 make_tuple(1, ref(i), cref(j))
 \end{codeblock}
-
-creates a tuple of type
-
-\begin{codeblock}
-tuple<int, int&, const float&>
-\end{codeblock}
-
+creates a tuple of type \tcode{tuple<int, int\&, const float\&>}.
 \end{example}
-
 \end{itemdescr}
 
 \indexlibrary{\idxcode{forward_as_tuple}}%
 \indexlibrary{\idxcode{tuple}!\idxcode{forward_as_tuple}}%
 \begin{itemdecl}
-template<class... Types>
-  constexpr tuple<Types&&...> forward_as_tuple(Types&&... t) noexcept;
+template<class... TTypes>
+  constexpr tuple<TTypes&&...> forward_as_tuple(TTypes&&... t) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2010,24 +2004,24 @@ template<class... Types>
 \effects Constructs a tuple of references to the arguments in \tcode{t} suitable
 for forwarding as arguments to a function. Because the result may contain references
 to temporary variables, a program shall ensure that the return value of this
-function does not outlive any of its arguments. (e.g., the program should typically
+function does not outlive any of its arguments (e.g., the program should typically
 not store the result in a named variable).
 
 \pnum
-\returns \tcode{tuple<Types\&\&...>(std::forward<Types>(t)...)}.
+\returns \tcode{tuple<TTypes\&\&...>(std::forward<TTypes>(t)...)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{tie}}%
 \indexlibrary{\idxcode{ignore}}%
 \indexlibrary{\idxcode{tuple}!\idxcode{tie}}%
 \begin{itemdecl}
-template<class... Types>
-  constexpr tuple<Types&...> tie(Types&... t) noexcept;
+template<class... TTypes>
+  constexpr tuple<TTypes&...> tie(TTypes&... t) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\returns  \tcode{tuple<Types\&...>(t...)}.  When an
+\returns \tcode{tuple<TTypes\&...>(t...)}.  When an
 argument in \tcode{t} is \tcode{ignore}, assigning
 any value to the corresponding tuple element has no effect.
 
@@ -2047,39 +2041,44 @@ tie(i, ignore, s) = make_tuple(42, 3.14, "C++");
 \indexlibrary{\idxcode{tuple_cat}}
 \begin{itemdecl}
 template <class... Tuples>
-  constexpr tuple<@\placeholder{CTypes}@...> tuple_cat(Tuples&&... tpls);
+  constexpr tuple<CTypes...> tuple_cat(Tuples&&... tpls);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-In the following paragraphs, let $\tcode{T}_i$ be the $i^{th}$ type in \tcode{Tuples},
-$\tcode{U}_i$ be \tcode{remove_reference_t<Ti>}, and $tp_i$ be the $i^{th}$
+In the following paragraphs, let $\tcode{T}_i$ be the $i^\text{th}$ type in \tcode{Tuples},
+$\tcode{U}_i$ be \tcode{remove_reference_t<T$_i$>}, and $\tcode{tp}_i$ be the $i^\text{th}$
 parameter in the function parameter pack \tcode{tpls}, where all indexing is
 zero-based.
 
 \pnum
 \requires For all $i$, $\tcode{U}_i$ shall be the type
-$\cv_i$ \tcode{tuple<$Args_i...$>}, where $\cv_i$ is the (possibly empty) $i^{th}$
-cv-qualifier-seq and $Args_i$ is the parameter pack representing the element
-types in $\tcode{U}_i$. Let ${A_{ik}}$ be the ${k_i}^{th}$ type in $Args_i$. For all
-$A_{ik}$ the following requirements shall be satisfied: If $\tcode{T}_i$ is
-deduced as an lvalue reference type, then
-\tcode{is_constructible_v<$A_{ik}$, $cv_i$ $A_{ik}$\&> == true}, otherwise
-\tcode{is_constructible_v<$A_{ik}$, $cv_i A_{ik}$\&\&> == true}.
+$\cv_i$ \tcode{tuple<$\tcode{Args}_i$...>}, where $\cv_i$ is the (possibly empty) $i^\text{th}$
+\grammarterm{cv-qualifier-seq} and $\tcode{Args}_i$ is the parameter pack representing the element
+types in $\tcode{U}_i$. Let $\tcode{A}_{ik}$ be the ${k}^\text{th}$ type in $\tcode{Args}_i$. For all
+$\tcode{A}_{ik}$ the following requirements shall be satisfied:
+\begin{itemize}
+\item If $\tcode{T}_i$ is deduced as an lvalue reference type, then
+      \tcode{is_constructible_v<$\tcode{A}_{ik}$, $cv_i\;\tcode{A}_{ik}$\&> == true}, otherwise
+\item \tcode{is_constructible_v<$\tcode{A}_{ik}$, $cv_i\;\tcode{A}_{ik}$\&\&> == true}.
+\end{itemize}
 
 \pnum
-\remarks The types in \tcode{\placeholder{Ctypes}} shall be equal to the ordered
+\remarks The types in \tcode{CTypes} shall be equal to the ordered
 sequence of the extended types
-\tcode{$Args_0$..., $Args_1$...,} ... \tcode{$Args_{n-1}$...}, where $n$ is
-equal to \tcode{sizeof...(Tuples)}. Let \tcode{$e_i$...} be the $i^{th}$
+\tcode{$\tcode{Args}_0$..., $\tcode{Args}_1$..., $\dotsc$, $\tcode{Args}_{n-1}$...},
+where $n$ is
+equal to \tcode{sizeof...(Tuples)}. Let \tcode{$\tcode{e}_i$...} be the $i^\text{th}$
 ordered sequence of tuple elements of the resulting \tcode{tuple} object
-corresponding to the type sequence $Args_i$.
+corresponding to the type sequence $\tcode{Args}_i$.
 
 \pnum
-\returns A \tcode{tuple} object constructed by initializing the ${k_i}^{th}$
-type element $e_{ik}$ in \tcode{$e_i$...} with\\
-\tcode{get<$k_i$>(std::forward<$\tcode{T}_i$>($tp_i$))} for each valid $k_i$ and
-each group $e_i$ in order.
+\returns A \tcode{tuple} object constructed by initializing the ${k_i}^\text{th}$
+type element $\tcode{e}_{ik}$ in \tcode{$\tcode{e}_i$...} with
+\begin{codeblock}
+get<@$k_i$@>(std::forward<@$\tcode{T}_i$@>(@$\tcode{tp}_i$@))
+\end{codeblock}
+for each valid $k_i$ and each group $\tcode{e}_i$ in order.
 
 \pnum
 \begin{note}


### PR DESCRIPTION
Here is a slight simplification of [tuple.creation]. I bugged me that the introduction was defining things that were only tangentially useful. I changed it to introduce the concept of indexing into a pack only once, and I used the "variable-pack" notation (e.g. `TTypes`, `VTypes`) in all the functions in this subclause.

I will work on `tuple_cat` separately.

Before:

![image](https://cloud.githubusercontent.com/assets/6378233/21210493/6cfb51f0-c273-11e6-8621-81302e713087.png)


After:

![image](https://cloud.githubusercontent.com/assets/6378233/21210500/780b451e-c273-11e6-8219-cb488a106923.png)
