### PR TITLE
[temp.deduct] Avoid talking about 'side effect' and 'evaluation'

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1696,7 +1696,7 @@ body contains a \tcode{return} statement with a non-type-dependent operand.
 \begin{note} Therefore, any use of a specialization of the function template will
 cause an implicit instantiation. Any errors that arise from this instantiation
 are not in the immediate context of the function type and can result in the
-program being ill-formed. \end{note}
+program being ill-formed~(\ref{temp.deduct}). \end{note}
 \begin{example}
 \begin{codeblock}
 template <class T> auto f(T t) { return t; }    // return type deduced at instantiation time

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -5963,10 +5963,10 @@ diagnostic is required, the program is still ill-formed. Access checking is done
 as part of the substitution
 process. \end{note} Only invalid types and expressions in the immediate
 context of the function type and its template parameter types can result in a deduction
-failure. \begin{note} The evaluation of the substituted types and expressions can result
-in side effects such as the instantiation of class template specializations and/or
+failure. \begin{note} The substitution into types and expressions can result
+in effects such as the instantiation of class template specializations and/or
 function template specializations, the generation of implicitly-defined functions,
-etc. Such side effects are not in the ``immediate context'' and can result in the
+etc. Such effects are not in the ``immediate context'' and can result in the
 program being ill-formed.\end{note}
 
 \begin{example}


### PR DESCRIPTION
when discussing template instantiations.