### PR TITLE
[unique.ptr.single.modifiers] Use 'if and only if' when calling deleter.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -8821,7 +8821,7 @@ void reset(pointer p = pointer()) noexcept;
 well-defined behavior, and shall not throw exceptions.
 
 \pnum
-\effects Assigns \tcode{p} to the stored pointer, and then if the old value of the
+\effects Assigns \tcode{p} to the stored pointer, and then if and only if the old value of the
 stored pointer, \tcode{old_p}, was not equal to \tcode{nullptr}, calls
 \tcode{get_deleter()(old_p)}. \begin{note} The order of these operations is significant
 because the call to \tcode{get_deleter()} may destroy \tcode{*this}. \end{note}


### PR DESCRIPTION
Fixes #248.