### PR TITLE
[sf.math] Promote parenthesized parts of function names

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -10233,17 +10233,17 @@ namespace std {
   float        betaf(float x, float y);
   long double  betal(long double x, long double y);
 
-  // \ref{sf.cmath.comp_ellint_1}, (complete) elliptic integral of the first kind
+  // \ref{sf.cmath.comp_ellint_1}, complete elliptic integral of the first kind
   double       comp_ellint_1(double k);
   float        comp_ellint_1f(float k);
   long double  comp_ellint_1l(long double k);
 
-  // \ref{sf.cmath.comp_ellint_2}, (complete) elliptic integral of the second kind
+  // \ref{sf.cmath.comp_ellint_2}, complete elliptic integral of the second kind
   double       comp_ellint_2(double k);
   float        comp_ellint_2f(float k);
   long double  comp_ellint_2l(long double k);
 
-  // \ref{sf.cmath.comp_ellint_3}, (complete) elliptic integral of the third kind
+  // \ref{sf.cmath.comp_ellint_3}, complete elliptic integral of the third kind
   double       comp_ellint_3(double k, double nu);
   float        comp_ellint_3f(float k, float nu);
   long double  comp_ellint_3l(long double k, long double nu);
@@ -10253,7 +10253,7 @@ namespace std {
   float        cyl_bessel_if(float nu, float x);
   long double  cyl_bessel_il(long double nu, long double x);
 
-  // \ref{sf.cmath.cyl_bessel_j}, cylindrical Bessel functions (of the first kind)
+  // \ref{sf.cmath.cyl_bessel_j}, cylindrical Bessel functions of the first kind
   double       cyl_bessel_j(double nu, double x);
   float        cyl_bessel_jf(float nu, float x);
   long double  cyl_bessel_jl(long double nu, long double x);
@@ -10264,22 +10264,22 @@ namespace std {
   long double  cyl_bessel_kl(long double nu, long double x);
 
   // \ref{sf.cmath.cyl_neumann}, cylindrical Neumann functions;
-  // cylindrical Bessel functions (of the second kind):
+  // cylindrical Bessel functions of the second kind
   double       cyl_neumann(double nu, double x);
   float        cyl_neumannf(float nu, float x);
   long double  cyl_neumannl(long double nu, long double x);
 
-  // \ref{sf.cmath.ellint_1}, (incomplete) elliptic integral of the first kind
+  // \ref{sf.cmath.ellint_1}, incomplete elliptic integral of the first kind
   double       ellint_1(double k, double phi);
   float        ellint_1f(float k, float phi);
   long double  ellint_1l(long double k, long double phi);
 
-  // \ref{sf.cmath.ellint_2}, (incomplete) elliptic integral of the second kind
+  // \ref{sf.cmath.ellint_2}, incomplete elliptic integral of the second kind
   double       ellint_2(double k, double phi);
   float        ellint_2f(float k, float phi);
   long double  ellint_2l(long double k, long double phi);
 
-  // \ref{sf.cmath.ellint_3}, (incomplete) elliptic integral of the third kind
+  // \ref{sf.cmath.ellint_3}, incomplete elliptic integral of the third kind
   double       ellint_3(double k, double nu, double phi);
   float        ellint_3f(float k, float nu, float phi);
   long double  ellint_3l(long double k, long double nu, long double phi);
@@ -10309,7 +10309,7 @@ namespace std {
   float        riemann_zetaf(float x);
   long double  riemann_zetal(long double x);
 
-  // \ref{sf.cmath.sph_bessel}, spherical Bessel functions (of the first kind)
+  // \ref{sf.cmath.sph_bessel}, spherical Bessel functions of the first kind
   double       sph_bessel(unsigned n, double x);
   float        sph_besself(unsigned n, float x);
   long double  sph_bessell(unsigned n, long double x);
@@ -10320,7 +10320,7 @@ namespace std {
   long double  sph_legendrel(unsigned l, unsigned m, long double theta);
 
   // \ref{sf.cmath.sph_neumann}, spherical Neumann functions;
-  // spherical Bessel functions (of the second kind):
+  // spherical Bessel functions of the second kind:
   double       sph_neumann(unsigned n, double x);
   float        sph_neumannf(unsigned n, float x);
   long double  sph_neumannl(unsigned n, long double x);
@@ -10594,7 +10594,7 @@ $x$ is \tcode{x} and
 $y$ is \tcode{y}.
 \end{itemdescr}
 
-\rSec3[sf.cmath.comp_ellint_1]{(Complete) elliptic integral of the first kind}%
+\rSec3[sf.cmath.comp_ellint_1]{Complete elliptic integral of the first kind}%
 \indexlibrary{\idxcode{comp_ellint_1}}%
 \indexlibrary{\idxcode{comp_ellint_1f}}%
 \indexlibrary{\idxcode{comp_ellint_1l}}%
@@ -10625,7 +10625,7 @@ $k$ is \tcode{k}.
 \pnum See also \ref{sf.cmath.ellint_1}.
 \end{itemdescr}
 
-\rSec3[sf.cmath.comp_ellint_2]{(Complete) elliptic integral of the second kind}%
+\rSec3[sf.cmath.comp_ellint_2]{Complete elliptic integral of the second kind}%
 \indexlibrary{\idxcode{comp_ellint_2}}%
 \indexlibrary{\idxcode{comp_ellint_2f}}%
 \indexlibrary{\idxcode{comp_ellint_2l}}%
@@ -10657,7 +10657,7 @@ $k$ is \tcode{k}.
 \pnum See also \ref{sf.cmath.ellint_2}.
 \end{itemdescr}
 
-\rSec3[sf.cmath.comp_ellint_3]{(Complete) elliptic integral of the third kind}%
+\rSec3[sf.cmath.comp_ellint_3]{Complete elliptic integral of the third kind}%
 \indexlibrary{\idxcode{comp_ellint_3}}%
 \indexlibrary{\idxcode{comp_ellint_3f}}%
 \indexlibrary{\idxcode{comp_ellint_3l}}%
@@ -10730,7 +10730,7 @@ if \tcode{nu >= 128}.
 \pnum See also \ref{sf.cmath.cyl_bessel_j}.
 \end{itemdescr}
 
-\rSec3[sf.cmath.cyl_bessel_j]{Cylindrical Bessel functions (of the first kind)}%
+\rSec3[sf.cmath.cyl_bessel_j]{Cylindrical Bessel functions of the first kind}%
 \indexlibrary{\idxcode{cyl_bessel_j}}%
 \indexlibrary{\idxcode{cyl_bessel_jf}}%
 \indexlibrary{\idxcode{cyl_bessel_jl}}%
@@ -10874,7 +10874,7 @@ if \tcode{nu >= 128}.
 \pnum See also \ref{sf.cmath.cyl_bessel_j}.
 \end{itemdescr}
 
-\rSec3[sf.cmath.ellint_1]{(Incomplete) elliptic integral of the first kind}%
+\rSec3[sf.cmath.ellint_1]{Incomplete elliptic integral of the first kind}%
 \indexlibrary{\idxcode{ellint_1}}%
 \indexlibrary{\idxcode{ellint_1f}}%
 \indexlibrary{\idxcode{ellint_1l}}%
@@ -10906,7 +10906,7 @@ $k$ is \tcode{k} and
 $phi$ is \tcode{phi}.
 \end{itemdescr}
 
-\rSec3[sf.cmath.ellint_2]{(Incomplete) elliptic integral of the second kind}%
+\rSec3[sf.cmath.ellint_2]{Incomplete elliptic integral of the second kind}%
 \indexlibrary{\idxcode{ellint_2}}%
 \indexlibrary{\idxcode{ellint_2f}}%
 \indexlibrary{\idxcode{ellint_2l}}%
@@ -10937,7 +10937,7 @@ $k$ is \tcode{k} and
 $phi$ is \tcode{phi}.
 \end{itemdescr}
 
-\rSec3[sf.cmath.ellint_3]{(Incomplete) elliptic integral of the third kind}%
+\rSec3[sf.cmath.ellint_3]{Incomplete elliptic integral of the third kind}%
 \indexlibrary{\idxcode{ellint_3}}%
 \indexlibrary{\idxcode{ellint_3f}}%
 \indexlibrary{\idxcode{ellint_3l}}%
@@ -11156,7 +11156,7 @@ where
 $x$ is \tcode{x}.
 \end{itemdescr}
 
-\rSec3[sf.cmath.sph_bessel]{Spherical Bessel functions (of the first kind)}%
+\rSec3[sf.cmath.sph_bessel]{Spherical Bessel functions of the first kind}%
 \indexlibrary{\idxcode{sph_bessel}}%
 \indexlibrary{\idxcode{sph_besself}}%
 \indexlibrary{\idxcode{sph_bessell}}%


### PR DESCRIPTION
to un-parenthesized.

Fixes #1250.