### PR TITLE
[mem.res.pool], [mem.res.monotonic.buffer] Do not define the otherwis…

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -11506,7 +11506,7 @@ The \tcode{synchronized_pool_resource} and
 are general-purpose memory resources having the following qualities:
 \begin{itemize}
 \item
-Each resource \term{owns} the allocated memory, and frees it on destruction --
+Each resource frees its allocated memory on destruction,
 even if \tcode{deallocate} has not been called for some of the allocated blocks.
 \item
 A pool resource consists of a collection of \defn{pools},
@@ -11847,7 +11847,7 @@ It is intended for access from one thread of control at a time.
 Specifically, calls to \tcode{allocate} and \tcode{deallocate}
 do not synchronize with one another.
 \item
-It \term{owns} the allocated memory and frees it on destruction,
+It frees the allocated memory on destruction,
 even if \tcode{deallocate} has not been called for some of the allocated blocks.
 \end{itemize}
 


### PR DESCRIPTION
…e unused term 'owns'.

Fixes #1257.