### PR TITLE
[lib] Harmonize casing for 'shall meet the requirements of ... iterator'.

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1258,7 +1258,7 @@ shall meet all the requirements of a Bidirectional Iterator~(\ref{bidirectional.
 \pnum
 Additionally,
 \tcode{Iterator}
-shall meet the requirements of a Random Access Iterator~(\ref{random.access.iterators})
+shall meet the requirements of a random access iterator~(\ref{random.access.iterators})
 if any of the members
 \tcode{operator+}~(\ref{reverse.iter.op+}),
 \tcode{operator-}~(\ref{reverse.iter.op-}),
@@ -2196,7 +2196,7 @@ otherwise as a synonym for \tcode{\placeholder{R}}.
 
 \pnum
 The template parameter \tcode{Iterator} shall meet
-the requirements for an Input Iterator~(\ref{input.iterators}).
+the requirements of an input iterator~(\ref{input.iterators}).
 Additionally, if any of the bidirectional or random access traversal
 functions are instantiated, the template parameter shall meet the
 requirements for a Bidirectional Iterator~(\ref{bidirectional.iterators})

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -4033,8 +4033,7 @@ template<class RandomAccessIterator>
 
 \begin{itemdescr}
 \pnum\requires \tcode{RandomAccessIterator}
-  shall meet the requirements of a mutable random access iterator
-  (Table~\ref{tab:iterator.random.access.requirements}) type.
+  shall meet the requirements of a mutable random access iterator~(\ref{random.access.iterators}).
   Moreover,
   \tcode{iterator_traits<RandomAccessIterator>::value_type}
   shall denote an unsigned integer type
@@ -4140,7 +4139,7 @@ template<class OutputIterator>
 \begin{itemdescr}
 \pnum\requires
   \tcode{OutputIterator} shall satisfy the requirements
-  of an output iterator (Table~\ref{tab:iterator.output.requirements}) type.
+  of an output iterator~(\ref{output.iterators}).
   Moreover,
   the expression
   \tcode{*dest = rt}
@@ -5875,7 +5874,7 @@ template<class InputIterator>
 \begin{itemdescr}
 \pnum\requires
   \tcode{InputIterator} shall satisfy the requirements
-  of an input iterator (Table~\ref{tab:iterator.input.requirements}) type.
+  of an input iterator~(\ref{input.iterators}).
   Moreover,
   \tcode{iterator_traits<InputIterator>::value_type}
   shall denote a type that is convertible to \tcode{double}.

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -18334,7 +18334,7 @@ public:
 \end{codeblock}
 
 \pnum
-\tcode{Clock} shall meet the Clock requirements~(\ref{time.clock}).
+\tcode{Clock} shall meet the Clock requirements~(\ref{time.clock.req}).
 
 \pnum
 If \tcode{Duration} is not an instance of \tcode{duration},


### PR DESCRIPTION
Also cross-reference the sections, not the tables, for
iterator requirements.

Fixes #696.