### PR TITLE
[class.derived] Avoid \pnum inside examples.

### DIFF
--- a/source/derived.tex
+++ b/source/derived.tex
@@ -509,12 +509,9 @@ struct D : B, C { void glorp(); };
 {figname.pdf}
 \end{importgraphic}
 
-\pnum
-\begin{note}
 The names declared in \tcode{V} and the left-hand instance of \tcode{W}
 are hidden by those in \tcode{B}, but the names declared in the
 right-hand instance of \tcode{W} are not hidden at all.
-\end{note}
 \begin{codeblock}
 void D::glorp() {
   x++;              // OK: \tcode{B::x} hides \tcode{V::x}
@@ -806,7 +803,7 @@ required~(\ref{basic.def.odr}).
 \pnum
 \indextext{multiple inheritance!\tcode{virtual} and}%
 \begin{example}
-here are some uses of virtual functions with multiple base classes:
+Here are some uses of virtual functions with multiple base classes:
 \indextext{example!virtual function}%
 \begin{codeblock}
 struct A {
@@ -838,8 +835,10 @@ In class \tcode{D} above there are two occurrences of class \tcode{A}
 and hence two occurrences of the virtual member function \tcode{A::f}.
 The final overrider of \tcode{B1::A::f} is \tcode{B1::f} and the final
 overrider of \tcode{B2::A::f} is \tcode{B2::f}.
+\end{example}
 
 \pnum
+\begin{example}
 The following example shows a function that does not have a unique final
 overrider:
 \begin{codeblock}
@@ -866,8 +865,10 @@ Both \tcode{VB1::f} and \tcode{VB2::f} override \tcode{A::f} but there
 is no overrider of both of them in class \tcode{Error}. This example is
 therefore ill-formed. Class \tcode{Okay} is well formed, however,
 because \tcode{Okay::f} is a final overrider.
+\end{example}
 
 \pnum
+\begin{example}
 The following example uses the well-formed classes from above.
 \begin{codeblock}
 struct VB1a : virtual A {       // does not declare \tcode{f}


### PR DESCRIPTION
Some instances were overlooked in the previous patch.

Fixes #781.