### PR TITLE
[stmt.dcl] Clarify footnote about deadlock avoidance.

### DIFF
--- a/source/statements.tex
+++ b/source/statements.tex
@@ -917,7 +917,14 @@ the first time control passes through its declaration; such a variable is
 considered initialized upon the completion of its initialization. If the
 initialization exits by throwing an exception, the initialization is not
 complete, so it will be tried again the next time control enters the
-declaration. If control enters the declaration concurrently while the variable is being initialized, the concurrent execution shall wait for completion of the initialization.\footnote{The implementation must not introduce any deadlock around execution of the initializer.} If control re-enters the declaration recursively while
+declaration.
+If control enters the declaration concurrently while the variable is
+being initialized, the concurrent execution shall wait for completion
+of the initialization.\footnote{The implementation must not introduce
+any deadlock around execution of the initializer. Deadlocks might
+still be caused by the program logic; the implementation need only
+avoid deadlocks due to its own synchronization operations.} If control
+re-enters the declaration recursively while
 the variable is being initialized, the behavior is undefined.
 \begin{example}
 


### PR DESCRIPTION
Fixes #849.