### PR TITLE
[ostream.iterator], [istream.iterator] Format exposition-only members

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -2669,8 +2669,8 @@ istream_iterator(istream_type& s);
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \textit{in_stream} with \tcode{addressof(s)}.
-\textit{value} may be initialized during
+Initializes \tcode{in_stream} with \tcode{addressof(s)}.
+\tcode{value} may be initialized during
 construction or the first time it is referenced.
 
 \pnum
@@ -2717,7 +2717,7 @@ const T& operator*() const;
 \begin{itemdescr}
 \pnum
 \returns
-\textit{value}.
+\tcode{value}.
 \end{itemdescr}
 
 \indexlibrarymember{operator->}{istream_iterator}%
@@ -2742,7 +2742,7 @@ istream_iterator& operator++();
 
 \pnum
 \effects
-As if by: \tcode{*in_stream \shr value;}
+As if by: \tcode{*in_stream \shr{} value;}
 
 \pnum
 \returns
@@ -2862,8 +2862,8 @@ ostream_iterator(ostream_type& s);
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \textit{out_stream} with \tcode{addressof(s)} and
-\textit{delim} with null.
+Initializes \tcode{out_stream} with \tcode{addressof(s)} and
+\tcode{delim} with null.
 \end{itemdescr}
 
 
@@ -2875,8 +2875,8 @@ ostream_iterator(ostream_type& s, const charT* delimiter);
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \textit{out_stream} with \tcode{addressof(s)} and
-\textit{delim} with \tcode{delimiter}.
+Initializes \tcode{out_stream} with \tcode{addressof(s)} and
+\tcode{delim} with \tcode{delimiter}.
 \end{itemdescr}
 
 
@@ -2914,9 +2914,9 @@ ostream_iterator& operator=(const T& value);
 \effects
 As if by:
 \begin{codeblock}
-*@\textit{out_stream}@ << value;
-if (@\textit{delim}@ != 0)
-  *@\textit{out_stream}@ << @\textit{delim}@;
+*out_stream << value;
+if (delim != 0)
+  *out_stream << delim;
 return *this;
 \end{codeblock}
 \end{itemdescr}


### PR DESCRIPTION
with \tcode, not italics.

Fixes #550.