### PR TITLE
Define 'object type' only once.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -391,7 +391,7 @@ type \tcode{T} must be complete if:
 \item an object of type \tcode{T} is defined~(\ref{basic.def}), or
 \item a non-static class data member of type \tcode{T} is
 declared~(\ref{class.mem}), or
-\item \tcode{T} is used as the object type or array element type in a
+\item \tcode{T} is used as the allocated type or array element type in a
 \grammarterm{new-expression}~(\ref{expr.new}), or
 \item an lvalue-to-rvalue conversion is applied to
 a glvalue referring
@@ -3596,7 +3596,6 @@ void bar() {
 contexts incomplete types are prohibited. \end{note}
 
 \pnum
-\indextext{object type}%
 An \defn{object type} is a (possibly cv-qualified) type that is not
 a function type, not a reference type, and not \cv{}~\tcode{void}.
 
@@ -4060,8 +4059,8 @@ cv-unqualified complete or incomplete object type or is
 \tcode{void}~(\ref{basic.types}) has three corresponding cv-qualified
 versions of its type: a \defn{const-qualified} version, a
 \defn{volatile-qualified} version, and a
-\defn{const-volatile-qualified} version. The term
-\term{object type}~(\ref{intro.object}) includes the cv-qualifiers
+\defn{const-volatile-qualified} version. The
+type of an object~(\ref{intro.object}) includes the \grammarterm{cv-qualifier}{s}
 specified in the \grammarterm{decl-specifier-seq}~(\ref{dcl.spec}), 
 \grammarterm{declarator} (Clause~\ref{dcl.decl}),
 \grammarterm{type-id}~(\ref{dcl.name}), or 

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -554,8 +554,7 @@ object are determined when the object is created. An object can have a
 name~(Clause~\ref{basic}). An object has a storage
 duration~(\ref{basic.stc}) which influences its
 lifetime~(\ref{basic.life}). An object has a
-type~(\ref{basic.types}). The term \defn{object type} refers to
-the type with which the object is created.
+type~(\ref{basic.types}).
 Some objects are
 polymorphic~(\ref{class.virtual}); the implementation
 generates information associated with each such object that makes it


### PR DESCRIPTION
There were only a few references to the definition in
1.8 [intro.object], so drop that definition and refer
to 'an object's type' instead.

Fixes #511.