### PR TITLE
Fix typos in [mem.poly.allocator.mem]/9.1 and /9.5

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -65,7 +65,7 @@ namespace std {
     T exchange(T& obj, U&& new_val);
 
   // \ref{forward}, forward/move
-  template <class T> 
+  template <class T>
     constexpr T&& forward(remove_reference_t<T>& t) noexcept;
   template <class T>
     constexpr T&& forward(remove_reference_t<T>&& t) noexcept;
@@ -2260,7 +2260,7 @@ template <size_t I, class... Types>
   constexpr const tuple_element_t<I, tuple<Types...>>&
     get(const tuple<Types...>& t) noexcept;   // Note B
 template <size_t I, class... Types>
-  constexpr const tuple_element_t<I, tuple<Types...>>&& get(const tuple<Types...>&& t) noexcept; 
+  constexpr const tuple_element_t<I, tuple<Types...>>&& get(const tuple<Types...>&& t) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5341,7 +5341,7 @@ namespace std {
     T any_cast(any& operand);
   template<class T>
     T any_cast(any&& operand);
-  
+
   template<class T>
     const T* any_cast(const any* operand) noexcept;
   template<class T>
@@ -10246,7 +10246,7 @@ namespace std {
     template<class Y> weak_ptr& operator=(const weak_ptr<Y>& r) noexcept;
     template<class Y> weak_ptr& operator=(const shared_ptr<Y>& r) noexcept;
     weak_ptr& operator=(weak_ptr&& r) noexcept;
-    template<class Y> weak_ptr& operator=(weak_ptr<Y>&& r) noexcept;    
+    template<class Y> weak_ptr& operator=(weak_ptr<Y>&& r) noexcept;
 
     // \ref{util.smartptr.weak.mod}, modifiers
     void swap(weak_ptr& r) noexcept;
@@ -11226,7 +11226,7 @@ and \tcode{p->second} using the elements of \tcode{y}.
 If \tcode{uses_allocator_v<T1,memory_resource*>} is \tcode{false}
 \\
 and
-\tcode{is_constructible_v<T,Args1...>} is \tcode{true},
+\tcode{is_constructible_v<T1,Args1...>} is \tcode{true},
 \\
 then \tcode{xprime} is \tcode{x}.
 \item
@@ -11253,7 +11253,7 @@ according to the appropriate rule from the following list:
 If \tcode{uses_allocator_v<T2,memory_resource*>} is \tcode{false}
 \\
 and
-\tcode{is_constructible_v<T,Args2...>} is \tcode{true},
+\tcode{is_constructible_v<T2,Args2...>} is \tcode{true},
 \\
 then \tcode{yprime} is \tcode{y}.
 \item
@@ -12800,7 +12800,7 @@ namespace std {
   struct default_order;
 
   template <class T = void>
-  using default_order_t = typename default_order<T>::type; 
+  using default_order_t = typename default_order<T>::type;
 
   // \ref{func.bind}, function object binders
   template <class T> constexpr bool is_bind_expression_v
@@ -12884,7 +12884,7 @@ and \tcode{t1} does not satisfy the previous two items;
 \item \tcode{t1.*f} when \tcode{N == 1} and \tcode{f} is a pointer to
 data member of a class \tcode{T}
 and \tcode{is_base_of_v<T, decay_t<decltype(t1)>>} is \tcode{true};
-    
+
 \item \tcode{t1.get().*f} when \tcode{N == 1} and \tcode{f} is a pointer to
 data member of a class \tcode{T}
 and \tcode{decay_t<decltype(t1)>} is a specialization of \tcode{reference_wrapper};
@@ -15202,7 +15202,7 @@ namespace std {
   template <class, class R = void> struct is_callable; // not defined
   template <class Fn, class... ArgTypes, class R>
     struct is_callable<Fn(ArgTypes...), R>;
-     
+
   template <class, class R = void> struct is_nothrow_callable; // not defined
   template <class Fn, class... ArgTypes, class R>
     struct is_nothrow_callable<Fn(ArgTypes...), R>;
@@ -15270,7 +15270,7 @@ namespace std {
   // \ref{meta.trans.other}, other transformations
   template <size_t Len,
             size_t Align = @\textit{default-alignment}@> // see \ref{meta.trans.other}
-    struct aligned_storage;      
+    struct aligned_storage;
   template <size_t Len, class... Types> struct aligned_union;
   template <class T> struct decay;
   template <bool, class T = void> struct enable_if;
@@ -15296,7 +15296,7 @@ namespace std {
   template <class T>
     using underlying_type_t = typename underlying_type<T>::type;
   template <class T>
-    using result_of_t       = typename result_of<T>::type;  
+    using result_of_t       = typename result_of<T>::type;
   template <class...>
     using void_t            = void;
 
@@ -16821,10 +16821,10 @@ is unambiguously available in the type.
 The specialization \tcode{conjunction<B1, ..., BN>}
 has a public and unambiguous base that is either
 \begin{itemize}
-\item 
+\item
 the first type \tcode{Bi} in the list \tcode{true_type, B1, ..., BN}
 for which \tcode{bool(Bi::value)} is \tcode{false}, or
-\item 
+\item
 if there is no such \tcode{Bi}, the last type in the list.
 \end{itemize}
 \begin{note} This means a specialization of \tcode{conjunction}


### PR DESCRIPTION
(Obviously a typo since there is no "T" in scope.)

Also trim trailing whitespace in utilities.tex.