### PR TITLE
[dcl.init.aggr] Add example for array of unknown bound

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3539,7 +3539,7 @@ with that of ISO/IEC 9899 Programming Language C.}
 \indextext{type!incompletely-defined object}%
 A class that has been declared but not defined, an enumeration type in certain
 contexts~(\ref{dcl.enum}), or an array of unknown
-size or of incomplete element type, is an
+bound or of incomplete element type, is an
 \defnx{incompletely-defined object type}{object type!incompletely-defined}.%
 \footnote{The size and layout of an instance of an incompletely-defined
 object type is unknown.}
@@ -3560,8 +3560,8 @@ might be an array of unknown bound and therefore be incomplete at one
 point in a translation unit and complete later on; the array types at
 those two points (``array of unknown bound of \tcode{T}'' and ``array of
 \tcode{N} \tcode{T}'') are different types. The type of a pointer to array of
-unknown size, or of a type defined by a \tcode{typedef} declaration to
-be an array of unknown size, cannot be completed. \begin{example}
+unknown bound, or of a type defined by a \tcode{typedef} declaration to
+be an array of unknown bound, cannot be completed. \begin{example}
 
 \indextext{type!example of incomplete}%
 \begin{codeblock}

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -2992,7 +2992,7 @@ An aggregate that is a class can also be initialized with a single
 expression not enclosed in braces, as described in~\ref{dcl.init}.
 
 \pnum
-An array of unknown size initialized with a
+An array of unknown bound initialized with a
 brace-enclosed
 \grammarterm{initializer-list}
 containing

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -3002,7 +3002,7 @@ where
 \tcode{n}
 shall be greater than zero, is defined as having
 \tcode{n}
-elements (\ref{dcl.array}).
+elements~(\ref{dcl.array}).
 \begin{example}
 
 \begin{codeblock}
@@ -3020,6 +3020,20 @@ shall not be used as the \grammarterm{initializer-clause}
 for an array of unknown bound.\footnote{The syntax provides for empty
 \grammarterm{initializer-list}{s},
 but nonetheless \Cpp does not have zero length arrays.}
+\begin{note}
+A default member initializer does not determine the bound for a member
+array of unknown bound.  Since the default member initializer is
+ignored if a suitable \grammarterm{mem-initializer} is present
+(\ref{class.base.init}), the default member initializer is not
+considered to initialize the array of unknown bound.
+\begin{example}
+\begin{codeblock}
+struct S {
+  int y[] = { 0 };          // error: non-static data member of incomplete type
+};
+\end{codeblock}
+\end{example}
+\end{note}
 
 \pnum
 \begin{note}


### PR DESCRIPTION
as non-static data member.
    
Addresses core issue 1985.
    
Fixes #396.

Consistently refer to 'array of unknown bound' not 'array of unknown size'; see [dcl.array].
