### PR TITLE
[associative.reqmts] Harmonize capitalization.

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -1664,13 +1664,13 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 
 \tcode{X(il)}            &
                           &
-  Same as \tcode{X(il.begin(), il.end())}.  &
-  Same as \tcode{X(il.begin(), il.end())}.  \\ \rowsep
+  same as \tcode{X(il.begin(), il.end())}  &
+  same as \tcode{X(il.begin(), il.end())}  \\ \rowsep
 
 \tcode{X(il,c)}          &
                           &
-  Same as \tcode{X(il.begin(), il.end(), c)}.  &
-  Same as \tcode{X(il.begin(), il.end(), c)}.  \\ \rowsep
+  same as \tcode{X(il.begin(), il.end(), c)}  &
+  same as \tcode{X(il.begin(), il.end(), c)}  \\ \rowsep
 
 \tcode{a = il}     &
   \tcode{X\&}               &
@@ -1777,7 +1777,7 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 
 \tcode{a.insert(il)}           &
   \tcode{void}                  &
-  Equivalent to \tcode{a.insert(il.begin(), il.end())}. &
+  equivalent to \tcode{a.insert(il.begin(), il.end())} &
                                           \\ \rowsep
 
 \tcode{a_uniq.}\br
@@ -1827,14 +1827,14 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 
 \tcode{a.extract(k)}              &
  \tcode{node_type}             &
- Removes the first element in the container with key equivalent to \tcode{k}.
+ removes the first element in the container with key equivalent to \tcode{k}.
  Returns a \tcode{node_type} owning the element if found, otherwise an empty
  \tcode{node_type}. &
  $\log (\tcode{a.size()})$       \\ \rowsep
 
 \tcode{a.extract(q)}              &
  \tcode{node_type}             &
- Removes the element pointed to by \tcode{q}.
+ removes the element pointed to by \tcode{q}.
  Returns a \tcode{node_type} owning that element. &
  amortized constant       \\ \rowsep
 


### PR DESCRIPTION
Older entries seem to start with a lowercase letter and only
have a full stop if a second sentence follows.  For newer
entries (initializer lists, node_handle functions), apply
that style, too.

Fixes #328.