### PR TITLE
[unord.req] Split column heading into two rows

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -2181,13 +2181,13 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
   {Unordered associative container requirements (in addition to container)}
   {tab:HashRequirements}
 \\ \topline
-\lhdr{Expression} & \chdr{Return type}
-& \chdr{Assertion/note pre-/post-condition}
-& \rhdr{Complexity} \\ \capsep
+\lhdr{Expression} & \chdr{Return type}   & \chdr{Assertion/note}      & \rhdr{Complexity} \\
+                  &                      & \chdr{pre-/post-condition} & \\ \capsep
 \endfirsthead
 \continuedcaption\\
 \hline
-\lhdr{Expression} & \chdr{Return type} & \chdr{Assertion/note pre-/post-condition} & \rhdr{Complexity} \\ \capsep
+\lhdr{Expression} & \chdr{Return type}   & \chdr{Assertion/note}      & \rhdr{Complexity} \\
+                  &                      & \chdr{pre-/post-condition} & \\ \capsep
 \endhead
 %%
 \tcode{X::key_type}   &


### PR DESCRIPTION
to avoid 'Overfull hbox' warnings.

Partially addresses #693.