### PR TITLE
[containers] Replace pre: and post: in requirements tables

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -143,20 +143,20 @@ denotes a non-const rvalue of type \tcode{X}.
 \tcode{X u;}                &
                             &
                             &
- post: \tcode{u.empty()}    &
+ \postconditions \tcode{u.empty()}    &
  constant                   \\ \rowsep
 
 \tcode{X()}                 &
                             &
                             &
- post: \tcode{X().empty()}  &
+ \postconditions \tcode{X().empty()}  &
  constant                   \\ \rowsep
 
 \tcode{X(a)}                &
                             &
                             &
  \requires \tcode{T} is \tcode{CopyInsertable}
- into \tcode{X} (see below).\br post: \tcode{a == X(a)}.         &
+ into \tcode{X} (see below).\br \postconditions \tcode{a == X(a)}.         &
  linear                     \\ \rowsep
 
 \tcode{X u(a);}\br
@@ -165,14 +165,14 @@ denotes a non-const rvalue of type \tcode{X}.
                             &
  \requires \tcode{T} is \tcode{CopyInsertable}
  into \tcode{X} (see below).\br
- post: \tcode{u == a}       &
+ \postconditions \tcode{u == a}       &
  linear                     \\ \rowsep
 
 \tcode{X u(rv);}\br
 \tcode{X u = rv;}            &
                             &
                             &
-  post: \tcode{u} shall be equal to the value that \tcode{rv} had before this construction
+  \postconditions \tcode{u} shall be equal to the value that \tcode{rv} had before this construction
                             &
   (Note B)                  \\ \rowsep
 
@@ -245,7 +245,7 @@ denotes a non-const rvalue of type \tcode{X}.
 \tcode{r = a}               &
  \tcode{X\&}                &
                             &
- post: \tcode{r == a}.      &
+ \postconditions \tcode{r == a}.      &
  linear                     \\ \rowsep
 
 \tcode{a.size()}                &
@@ -488,7 +488,7 @@ Table~\ref{tab:containers.optional.operations} unless otherwise stated.
 \tcode{a < b}                   &
  convertible to \tcode{bool}    &
  \tcode{lexicographical_compare( a.begin(), a.end(), b.begin(), b.end())} &
- pre: \tcode{<} is defined for values of \tcode{T}. \tcode{<} is a total ordering relationship.    &
+ \requires \tcode{<} is defined for values of \tcode{T}. \tcode{<} is a total ordering relationship.    &
  linear                     \\ \rowsep
 
 \tcode{a > b}                   &
@@ -639,13 +639,13 @@ non-const rvalue of type \tcode{X}, and \tcode{m} is a value of type \tcode{A}.
 \tcode{X u;}							&
 													&
   \requires\ \tcode{A} is \tcode{DefaultConstructible}.\br
-  post: \tcode{u.empty()} returns \tcode{true},
+  \postconditions \tcode{u.empty()} returns \tcode{true},
   \tcode{u.get_allocator() == A()} &
   constant												\\ \rowsep
 
 \tcode{X(m)}							&
 																				&
-post: \tcode{u.empty()} returns \tcode{true}, &
+\postconditions \tcode{u.empty()} returns \tcode{true}, &
 constant												\\
 \tcode{X u(m);}					&
 																				&
@@ -656,14 +656,14 @@ constant												\\
 \tcode{X u(t, m);}				&
                           &
 \requires\ \tcode{T} is \tcode{CopyInsertable} into \tcode{X}.\br
-post: \tcode{u == t}, \tcode{u.get_allocator() == m} &
+\postconditions \tcode{u == t}, \tcode{u.get_allocator() == m} &
 linear													\\ \rowsep
 
 \tcode{X(rv)}\br
 \tcode{X u(rv);}
            &
            &
-  post: \tcode{u} shall have the same elements as \tcode{rv} had before this
+  \postconditions \tcode{u} shall have the same elements as \tcode{rv} had before this
   construction; the value of \tcode{u.get_allocator()} shall be the same as the
   value of \tcode{rv.get_allocator()} before this construction. &
   constant                            \\ \rowsep
@@ -673,7 +673,7 @@ linear													\\ \rowsep
 												&
   \requires\ \tcode{T} is
   \tcode{MoveInsertable} into \tcode{X}.\br
-  post: \tcode{u} shall have the same elements,
+  \postconditions \tcode{u} shall have the same elements,
   or copies of the elements, that \tcode{rv} had before
   this construction, \tcode{u.get_allocator() == m}												&
   constant if \tcode{m ==} \tcode{rv.get_allocator()}, otherwise linear	\\ \rowsep
@@ -683,7 +683,7 @@ linear													\\ \rowsep
   \requires\ \tcode{T} is
   \tcode{CopyInsertable} into \tcode{X}
   and \tcode{CopyAssignable}.\br
-  post: \tcode{a == t}    &
+  \postconditions \tcode{a == t}    &
   linear                  \\ \rowsep
 
 \tcode{a = rv}          &
@@ -696,7 +696,7 @@ linear													\\ \rowsep
   \tcode{MoveInsertable} into \tcode{X} and
   \tcode{MoveAssignable}. All existing elements of \tcode{a}
   are either move assigned to or destroyed.\br
-  post: \tcode{a} shall be equal to the value that \tcode{rv} had before
+  \postconditions \tcode{a} shall be equal to the value that \tcode{rv} had before
   this assignment.      &
   linear                \\ \rowsep
 
@@ -806,7 +806,7 @@ The complexities of the expressions are sequence dependent.
                 &
  \requires\ \tcode{T} shall be
  \tcode{CopyInsertable} into \tcode{X}.\br
- post: \tcode{distance(begin(), end()) == n}\br
+ \postconditions \tcode{distance(begin(), end()) == n}\br
  Constructs a sequence container with \tcode{n} copies of \tcode{t}  \\ \rowsep
 
 \tcode{X(i, j)}\br
@@ -818,7 +818,7 @@ The complexities of the expressions are sequence dependent.
  shall also be
  \tcode{MoveInsertable} into \tcode{X}.
  Each iterator in the range \range{i}{j} shall be dereferenced exactly once.\br
- post: \tcode{distance(begin(), end()) ==}
+ \postconditions \tcode{distance(begin(), end()) ==}
  \tcode{distance(i, j)}\br
  Constructs a sequence container equal to the range \tcode{[i, j)}    \\ \rowsep
 
@@ -872,7 +872,7 @@ The complexities of the expressions are sequence dependent.
  \tcode{MoveInsertable} into \tcode{X}, \tcode{MoveConstructible}, \tcode{MoveAssignable},
  and swappable~(\ref{swappable.requirements}).
  Each iterator in the range \range{i}{j} shall be dereferenced exactly once.\br
- pre: \tcode{i} and \tcode{j} are not iterators into \tcode{a}.\br
+ \requires \tcode{i} and \tcode{j} are not iterators into \tcode{a}.\br
  Inserts copies of elements in \tcode{[i, j)} before \tcode{p}  \\ \rowsep
 
 \tcode{a.insert(p, il)}  &
@@ -895,7 +895,7 @@ The complexities of the expressions are sequence dependent.
  \tcode{void}       &
  Destroys all elements in \tcode{a}. Invalidates all references, pointers, and
  iterators referring to the elements of \tcode{a} and may invalidate the past-the-end iterator.\br
- post: \tcode{a.empty()} returns \tcode{true}.\br
+ \postconditions \tcode{a.empty()} returns \tcode{true}.\br
  \complexity Linear.      \\ \rowsep
 
 \tcode{a.assign(i,j)}   &
@@ -906,7 +906,7 @@ The complexities of the expressions are sequence dependent.
  shall also be
  \tcode{MoveInsertable} into \tcode{X}.\br
  Each iterator in the range \range{i}{j} shall be dereferenced exactly once.\br
- pre: \tcode{i}, \tcode{j} are not iterators into \tcode{a}.\br
+ \requires \tcode{i}, \tcode{j} are not iterators into \tcode{a}.\br
  Replaces elements in \tcode{a} with a copy of \tcode{[i, j)}.\br
  Invalidates all references, pointers and iterators
  referring to the elements of \tcode{a}.
@@ -922,7 +922,7 @@ The complexities of the expressions are sequence dependent.
  \requires\ \tcode{T} shall be
  \tcode{CopyInsertable} into \tcode{X}
  and \tcode{CopyAssignable}.\br
- pre: \tcode{t} is not a reference into \tcode{a}.\br
+ \requires \tcode{t} is not a reference into \tcode{a}.\br
  Replaces elements in \tcode{a} with \tcode{n} copies of \tcode{t}.\br
  Invalidates all references, pointers and iterators
  referring to the elements of \tcode{a}.
@@ -1769,7 +1769,7 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
   \tcode{i, j)}          &
   \tcode{void}                   &
   \requires\ \tcode{value_type} shall be \tcode{EmplaceConstructible} into \tcode{X} from \tcode{*i}.\br
-  pre: \tcode{i}, \tcode{j} are not iterators into \tcode{a}.
+  \requires \tcode{i}, \tcode{j} are not iterators into \tcode{a}.
   inserts each element from the range \range{i}{j} if and only if there
   is no element with key equivalent to the key of that element in containers
   with unique keys; always inserts that element in containers with equivalent keys.  &
@@ -1783,12 +1783,12 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 \tcode{a_uniq.}\br
  \tcode{insert(nh)}           &
  \tcode{insert_return_type}   &
- pre: \tcode{nh} is empty or
+ \requires \tcode{nh} is empty or
  \tcode{a_uniq.get_allocator() == nh.get_allocator()}.\br
  \effects{} If \tcode{nh} is empty, has no effect. Otherwise, inserts the
  element owned by \tcode{nh} if and only if there is no element in the
  container with a key equivalent to \tcode{nh.key()}.\br
- post: If \tcode{nh} is empty, \tcode{inserted} is \tcode{false},
+ \postconditions If \tcode{nh} is empty, \tcode{inserted} is \tcode{false},
  \tcode{position} is \tcode{end()}, and \tcode{node} is empty.
  Otherwise if the insertion took place, \tcode{inserted} is \tcode{true},
  \tcode{position} points to the inserted element, and \tcode{node} is empty;
@@ -1800,19 +1800,19 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 \tcode{a_eq.}\br
  \tcode{insert(nh)}           &
  \tcode{iterator}   &
- pre: \tcode{nh} is empty or
+ \requires \tcode{nh} is empty or
  \tcode{a_eq.get_allocator() == nh.get_allocator()}.\br
  \effects{} If \tcode{nh} is empty, has no effect and returns \tcode{a_eq.end()}.
  Otherwise, inserts the element owned by \tcode{nh} and returns an iterator
  pointing to the newly inserted element. If a range containing elements with
  keys equivalent to \tcode{nh.key()} exists in \tcode{a_eq}, the element is
  inserted at the end of that range.\br
- post: \tcode{nh} is empty. &
+ \postconditions \tcode{nh} is empty. &
  logarithmic                             \\ \rowsep
 
 \tcode{a.insert(p, nh)}           &
  \tcode{iterator}   &
- pre: \tcode{nh} is empty or
+ \requires \tcode{nh} is empty or
  \tcode{a.get_allocator() == nh.get_allocator()}.\br
  \effects{} If \tcode{nh} is empty, has no effect and returns \tcode{a.end()}.
  Otherwise, inserts the element owned by \tcode{nh} if and only if there
@@ -1821,7 +1821,7 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
  with equivalent keys. Always returns the iterator pointing to the element
  with key equivalent to \tcode{nh.key()}. The element is inserted as close
  as possible to the position just prior to \tcode{p}.\br
- post: \tcode{nh} is empty if insertion succeeds, unchanged if insertion fails.  &
+ \postconditions \tcode{nh} is empty if insertion succeeds, unchanged if insertion fails.  &
  logarithmic in general, but amortized constant if the element is inserted right
  before \tcode{p}.                             \\ \rowsep
 
@@ -1840,12 +1840,12 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 
 \tcode{a.merge(a2)}              &
  \tcode{void}             &
- pre: \tcode{a.get_allocator() == a2.get_allocator()}.\br
+ \requires \tcode{a.get_allocator() == a2.get_allocator()}.\br
  Attempts to extract each element in \tcode{a2} and insert it into \tcode{a}
  using the comparison object of \tcode{a}. In containers with unique keys,
  if there is an element in \tcode{a} with key equivalent to the key of an
  element from \tcode{a2}, then that element is not extracted from \tcode{a2}.\br
- post: Pointers and references to the transferred elements of \tcode{a2}
+ \postconditions Pointers and references to the transferred elements of \tcode{a2}
  refer to those same elements but as members of \tcode{a}. Iterators referring
  to the transferred elements will continue to refer to their elements, but
  they now behave as iterators into \tcode{a}, not into \tcode{a2}.\br
@@ -1883,7 +1883,7 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 \tcode{a.clear()}       &
  \tcode{void}           &
  \tcode{a.erase(a.begin(),a.end())}\br
- post: \tcode{a.empty()} returns \tcode{true}.  &
+ \postconditions \tcode{a.empty()} returns \tcode{true}.  &
  linear in \tcode{a.size()}.  \\ \rowsep
 
 \tcode{b.find(k)}       &
@@ -2486,7 +2486,7 @@ start.  Implementations are permitted to ignore the hint.%
 \tcode{a.insert(i, j)}
 &   \tcode{void}
 &   \requires\ \tcode{value_type} shall be \tcode{EmplaceConstructible} into \tcode{X} from \tcode{*i}.\br
-    Pre: \tcode{i} and \tcode{j} are not iterators in \tcode{a}.
+    \requires \tcode{i} and \tcode{j} are not iterators in \tcode{a}.
     Equivalent to \tcode{a.insert(t)} for each element in \tcode{[i,j)}.%
     \indextext{unordered associative containers!\idxcode{insert}}%
     \indextext{\idxcode{insert}!unordered associative containers}%
@@ -2503,12 +2503,12 @@ start.  Implementations are permitted to ignore the hint.%
 \tcode{a_uniq.}\br
  \tcode{insert(nh)}           &
  \tcode{insert_return_type}   &
- Pre: \tcode{nh} is empty or
+ \requires \tcode{nh} is empty or
  \tcode{a_uniq.get_allocator() == nh.get_allocator()}.\br
  \effects{} If \tcode{nh} is empty, has no effect. Otherwise, inserts the
  element owned by \tcode{nh} if and only if there is no element in the
  container with a key equivalent to \tcode{nh.key()}.\br
- post: If \tcode{nh} is empty, \tcode{inserted} is \tcode{false},
+ \postconditions If \tcode{nh} is empty, \tcode{inserted} is \tcode{false},
  \tcode{position} is \tcode{end()}, and \tcode{node} is empty.
  Otherwise if the insertion took place, \tcode{inserted} is \tcode{true},
  \tcode{position} points to the inserted element, and \tcode{node} is empty;
@@ -2520,17 +2520,17 @@ start.  Implementations are permitted to ignore the hint.%
 \tcode{a_eq.}\br
  \tcode{insert(nh)}           &
  \tcode{iterator}   &
- Pre: \tcode{nh} is empty or
+ \requires \tcode{nh} is empty or
  \tcode{a_eq.get_allocator() == nh.get_allocator()}.\br
  \effects{} If \tcode{nh} is empty, has no effect and returns \tcode{a_eq.end()}.
  Otherwise, inserts the element owned by \tcode{nh} and returns an iterator
  pointing to the newly inserted element.\br
- Post: \tcode{nh} is empty. &
+ \postconditions \tcode{nh} is empty. &
  Average case \bigoh{1}, worst case \bigoh{\tcode{a_eq.size()}}.  \\ \rowsep
 %
 \tcode{a.insert(q, nh)}           &
  \tcode{iterator}   &
- Pre: \tcode{nh} is empty or
+ \requires \tcode{nh} is empty or
  \tcode{a.get_allocator() == nh.get_allocator()}.\br
  \effects{} If \tcode{nh} is empty, has no effect and returns \tcode{a.end()}.
  Otherwise, inserts the element owned by \tcode{nh} if and only if there
@@ -2540,7 +2540,7 @@ start.  Implementations are permitted to ignore the hint.%
  with key equivalent to \tcode{nh.key()}. The iterator \tcode{q} is a hint
  pointing to where the search should start. Implementations are permitted
  to ignore the hint.\br
- Post: \tcode{nh} is empty if insertion succeeds, unchanged if insertion fails.  &
+ \postconditions \tcode{nh} is empty if insertion succeeds, unchanged if insertion fails.  &
  Average case \bigoh{1}, worst case \bigoh{\tcode{a.size()}}.  \\ \rowsep
 %
 \tcode{a.extract(k)}              &
@@ -2558,13 +2558,13 @@ start.  Implementations are permitted to ignore the hint.%
 %
 \tcode{a.merge(a2)}              &
  \tcode{void}             &
- Pre: \tcode{a.get_allocator() == a2.get_allocator()}.\br
+ \requires \tcode{a.get_allocator() == a2.get_allocator()}.\br
  Attempts to extract each element in \tcode{a2} and insert it into \tcode{a}
  using the hash function and key equality predicate of \tcode{a}.
  In containers with unique keys, if there is an element in \tcode{a} with
  key equivalent to the key of an element from \tcode{a2}, then that
  element is not extracted from \tcode{a2}.\par
- Post: Pointers and references to the transferred elements of \tcode{a2}
+ \postconditions Pointers and references to the transferred elements of \tcode{a2}
  refer to those same elements but as members of \tcode{a}. Iterators referring
  to the transferred elements and all iterators referring to \tcode{a} will
  be invalidated, but iterators to elements remaining in \tcode{a2} will
@@ -2613,7 +2613,7 @@ the number of elements erased.
 \tcode{a.clear()}
 & \tcode{void}
 & Erases all elements in the container.
-   Post: \tcode{a.empty()} returns \tcode{true}%
+   \postconditions \tcode{a.empty()} returns \tcode{true}%
     \indextext{unordered associative containers!\idxcode{clear}}%
     \indextext{\idxcode{clear}!unordered associative containers}%
 & Linear in \tcode{a.size()}.
@@ -2668,10 +2668,10 @@ the number of elements erased.
 \tcode{b.bucket(k)}
 & \tcode{size_type}
 &
-  Pre: \tcode{b.bucket_count() > 0}.\br
+  \requires \tcode{b.bucket_count() > 0}.\br
     Returns the index of the bucket in which elements with keys equivalent
     to \tcode{k} would be found, if any such element existed.
-    Post: the return value shall be in the range \tcode{[0, b.bucket_count())}.%
+    \postconditions the return value shall be in the range \tcode{[0, b.bucket_count())}.%
     \indextext{unordered associative containers!\idxcode{bucket}}%
     \indextext{\idxcode{bucket}!unordered associative containers}%
 & Constant
@@ -2679,7 +2679,7 @@ the number of elements erased.
 %
 \tcode{b.bucket_size(n)}
 &   \tcode{size_type}
-&   Pre: \tcode{n} shall be in the range \tcode{[0, b.bucket_count())}.
+&   \requires \tcode{n} shall be in the range \tcode{[0, b.bucket_count())}.
     Returns the number of elements in the $\texttt{n}^{\textrm{ th}}$ bucket.%
     \indextext{unordered associative containers!\idxcode{bucket_size}}%
     \indextext{\idxcode{bucket_size}!unordered associative containers}%
@@ -2689,7 +2689,7 @@ the number of elements erased.
 \tcode{b.begin(n)}
 &   \tcode{local_iterator}; \br
     \tcode{const_local_iterator} for const \tcode{b}.
-&   Pre: \tcode{n} shall be in the range \tcode{[0, b.bucket_count())}.
+&   \requires \tcode{n} shall be in the range \tcode{[0, b.bucket_count())}.
     \tcode{b.begin(n)} returns an iterator referring to the
     first element in the bucket. If the bucket is empty, then
     \tcode{b.begin(n) == b.end(n)}.%
@@ -2701,7 +2701,7 @@ the number of elements erased.
 \tcode{b.end(n)}
 &   \tcode{local_iterator}; \br
     \tcode{const_local_iterator} for const \tcode{b}.
-&   Pre: \tcode{n} shall be in the range \tcode{[0, b.bucket_count())}.
+&   \requires \tcode{n} shall be in the range \tcode{[0, b.bucket_count())}.
     \tcode{b.end(n)} returns an iterator which is the past-the-end
     value for the bucket.%
     \indextext{unordered associative containers!\idxcode{end}}%
@@ -2711,7 +2711,7 @@ the number of elements erased.
 %
 \tcode{b.cbegin(n)}
 &   \tcode{const_local_iterator}
-&   Pre: \tcode{n} shall be in the range \tcode{[0, b.bucket_count())}.
+&   \requires \tcode{n} shall be in the range \tcode{[0, b.bucket_count())}.
     Note: \tcode{[b.cbegin(n), b.cend(n))} is a valid range containing
     all of the elements in the $\texttt{n}^{\textrm{ th}}$ bucket.%
     \indextext{unordered associative containers!\idxcode{cbegin}}%
@@ -2721,7 +2721,7 @@ the number of elements erased.
 %
 \tcode{b.cend(n)}
 &   \tcode{const_local_iterator}
-&   Pre: \tcode{n} shall be in the range \tcode{[0, b.bucket_count())}.%
+&   \requires \tcode{n} shall be in the range \tcode{[0, b.bucket_count())}.%
     \indextext{unordered associative containers!\idxcode{cend}}%
     \indextext{\idxcode{cend}!unordered associative containers}%
 &   Constant
@@ -2748,14 +2748,14 @@ the number of elements erased.
 %
 \tcode{a.max_load_factor(z)}
 &   \tcode{void}
-&   Pre: \tcode{z} shall be positive.
+&   \requires \tcode{z} shall be positive.
     May change the container's maximum load factor, using \tcode{z} as a hint.%
 & Constant
 \\ \rowsep
 %
 \tcode{a.rehash(n)}
 & \tcode{void}
-& Post: \tcode{a.bucket_count() >= a.size() / a.max_load_factor()} and
+& \postconditions \tcode{a.bucket_count() >= a.size() / a.max_load_factor()} and
         \tcode{a.bucket_count() >= n}.%
     \indextext{unordered associative containers!\idxcode{rehash}}%
     \indextext{\idxcode{rehash}!unordered associative containers}%


### PR DESCRIPTION
with \requires and \postcondition, respectively.

Fixes #792.

The number and location of overfull hboxes in this section is exactly the same before and after the change.