### PR TITLE
Use \tcode for indexed type placeholders (also in math mode)

### DIFF
--- a/source/conversions.tex
+++ b/source/conversions.tex
@@ -280,16 +280,16 @@ if the following conditions are satisfied,
 % NB: forbid line break between 'where' and 'cv'
 % to stop superscript j from running into
 % descender of p on the previous line.
-where~$cv_i^j$ denotes the cv-qualifiers in the cv-qualification signature of $T_j$:%
+where~$\text{\cv}_i^j$ denotes the cv-qualifiers in the cv-qualification signature of $\tcode{T}_j$:%
 \footnote{These rules ensure that const-safety is preserved by the conversion.}
 
 \begin{itemize}
 \item \tcode{T1} and \tcode{T2} are similar.
 
-\item For every $i > 0$, if \tcode{const} is in $\mathit{cv}_i^1$ then \tcode{const} is in $\mathit{cv}_i^2$, and similarly for \tcode{volatile}.
+\item For every $i > 0$, if \tcode{const} is in $\text{\cv}_i^1$ then \tcode{const} is in $\text{\cv}_i^2$, and similarly for \tcode{volatile}.
 
-\item If the $\mathit{cv}_i^1$ and $\mathit{cv}_i^2$ are different,
-then \tcode{const} is in every $\mathit{cv}_k^2$ for $0 < k < i$.
+\item If the $\text{\cv}_i^1$ and $\text{\cv}_i^2$ are different,
+then \tcode{const} is in every $\text{\cv}_k^2$ for $0 < k < i$.
 \end{itemize}
 
 \begin{note}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -6554,15 +6554,15 @@ If
 \tcode{A}
 is a type
 \begin{indented}
-$\mathit{cv}_{1,0}$ ``pointer to $\ldots$'' $\mathit{cv}_{1,n-1}$ ``pointer to''
-$\mathit{cv}_{1,n}$ \tcode{T1}
+$\text{\cv}_{1,0}$ ``pointer to $\ldots$'' $\text{\cv}_{1,n-1}$ ``pointer to''
+$\text{\cv}_{1,n}$ \tcode{T1}
 \end{indented}
 and
 \tcode{P}
 is a type
 \begin{indented}
-$\mathit{cv}_{2,0}$ ``pointer to $\ldots$'' $\mathit{cv}_{2,n-1}$ ``pointer to''
-$\mathit{cv}_{2,n}$ \tcode{T2},
+$\text{\cv}_{2,0}$ ``pointer to $\ldots$'' $\text{\cv}_{2,n-1}$ ``pointer to''
+$\text{\cv}_{2,n}$ \tcode{T2},
 \end{indented}
 then the cv-unqualified
 \tcode{T1}

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -516,7 +516,7 @@ template <class F, class... Args> explicit thread(F&& f, Args&&... args);
 
 \begin{itemdescr}
 \pnum
-\requires\ \tcode{F} and each \tcode{Ti} in \tcode{Args} shall satisfy the
+\requires\ \tcode{F} and each $\tcode{T}_i$ in \tcode{Args} shall satisfy the
 \tcode{MoveConstructible} requirements.
 \tcode{\textit{INVOKE}(\textit{DECAY_COPY}(}
 \tcode{std::forward<F>(f)), \textit{DECAY_COPY}(std::forward<Args>(args))...)}~(\ref{func.require}) shall be
@@ -4695,7 +4695,7 @@ template <class F, class... Args>
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{F} and each \tcode{Ti} in \tcode{Args} shall
+\requires \tcode{F} and each $\tcode{T}_i$ in \tcode{Args} shall
 satisfy the
 \tcode{MoveConstructible} requirements, and
 \begin{codeblock}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1577,13 +1577,13 @@ is zero-based.
 \pnum
 \remarks
 This constructor shall not participate in overload resolution unless
-\tcode{is_default_construct\-ible_v<T$_i$>} is \tcode{true} for all $i$.
+\tcode{is_default_construct\-ible_v<$\tcode{T}_i$>} is \tcode{true} for all $i$.
 \begin{note} This behavior can be implemented by a constructor template
 with default template arguments. \end{note}
 The constructor is explicit if and only if \tcode{T}$_i$ is not implicitly
 default-constructible for at least one $i$.
 \begin{note} This behavior can be implemented with a trait that checks whether
-a \tcode{const T$_i$\&} can be initialized with \tcode{\{\}}. \end{note}
+a \tcode{const $\tcode{T}_i$\&} can be initialized with \tcode{\{\}}. \end{note}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{tuple}!constructor}%
@@ -1598,9 +1598,9 @@ corresponding parameter.
 
 \pnum
 \remarks This constructor shall not participate in overload resolution unless
-\tcode{sizeof...(Types) >= 1} and \tcode{is_copy_constructible_v<T$_i$>}
+\tcode{sizeof...(Types) >= 1} and \tcode{is_copy_constructible_v<$\tcode{T}_i$>}
 is \tcode{true} for all $i$. The constructor is explicit if and only if
-\tcode{is_convertible_v<const T$_i$\&, T$_i$>} is \tcode{false}
+\tcode{is_convertible_v<const $\tcode{T}_i$\&, $\tcode{T}_i$>} is \tcode{false}
 for at least one $i$.
 \end{itemdescr}
 
@@ -1617,9 +1617,9 @@ corresponding value in \tcode{std::forward<UTypes>(u)}.
 \pnum
 \remarks This constructor shall not participate in overload resolution unless
 \tcode{sizeof...(Types)} \tcode{==} \tcode{sizeof...(UTypes)} and
-\tcode{sizeof...(Types) >= 1} and \tcode{is_constructible_v<T$_i$, U$_i$\&\&>}
+\tcode{sizeof...(Types) >= 1} and \tcode{is_constructible_v<$\tcode{T}_i$, $\tcode{U}_i$\&\&>}
 is \tcode{true} for all $i$. The constructor is explicit if and only if
-\tcode{is_convertible_v<U$_i$\&\&, T$_i$>} is \tcode{false}
+\tcode{is_convertible_v<$\tcode{U}_i$\&\&, $\tcode{T}_i$>} is \tcode{false}
 for at least one $i$.
 \end{itemdescr}
 
@@ -1630,7 +1630,7 @@ tuple(const tuple& u) = default;
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{is_copy_constructible_v<T$_i$>} is \tcode{true} for all $i$.
+\requires \tcode{is_copy_constructible_v<$\tcode{T}_i$>} is \tcode{true} for all $i$.
 
 \pnum
 \effects Initializes each element of \tcode{*this} with the
@@ -1644,11 +1644,11 @@ tuple(tuple&& u) = default;
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{is_move_constructible_v<T$_i$>} is \tcode{true} for all $i$.
+\requires \tcode{is_move_constructible_v<$\tcode{T}_i$>} is \tcode{true} for all $i$.
 
 \pnum
 \effects For all $i$, initializes the $i^\text{th}$ element of \tcode{*this} with
-\tcode{std::forward<T$_i$>(get<$i$>(u))}.
+\tcode{std::forward<$\tcode{T}_i$>(get<$i$>(u))}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{tuple}!constructor}%
@@ -1667,7 +1667,7 @@ with the corresponding element of \tcode{u}.
 \item
 \tcode{sizeof...(Types)} \tcode{==} \tcode{sizeof...(UTypes)} and
 \item
-\tcode{is_constructible_v<T$_i$, const U$_i$\&>} is \tcode{true} for all $i$, and
+\tcode{is_constructible_v<$\tcode{T}_i$, const $\tcode{U}_i$\&>} is \tcode{true} for all $i$, and
 \item
 \tcode{sizeof...(Types) != 1}, or
 (when \tcode{Types...} expands to \tcode{T} and \tcode{UTypes...} expands to \tcode{U})\linebreak
@@ -1675,7 +1675,7 @@ with the corresponding element of \tcode{u}.
 is \tcode{true}.
 \end{itemize}
 The constructor is explicit if and only if
-\tcode{is_convertible_v<const U$_i$\&, T$_i$>} is \tcode{false}
+\tcode{is_convertible_v<const $\tcode{U}_i$\&, $\tcode{T}_i$>} is \tcode{false}
 for at least one $i$.
 \end{itemdescr}
 
@@ -1688,7 +1688,7 @@ template <class... UTypes> @\EXPLICIT@ constexpr tuple(tuple<UTypes...>&& u);
 \pnum
 \effects For all $i$,
 initializes the $i^\text{th}$ element of \tcode{*this} with
-\tcode{std::forward<U$_i$>(get<$i$>(u))}.
+\tcode{std::forward<$\tcode{U}_i$>(get<$i$>(u))}.
 
 \pnum
 \remarks This constructor shall not participate in overload resolution unless
@@ -1697,7 +1697,7 @@ initializes the $i^\text{th}$ element of \tcode{*this} with
 \item
 \tcode{sizeof...(Types)} \tcode{==} \tcode{sizeof...(UTypes)}, and
 \item
-\tcode{is_constructible_v<T$_i$, U$_i$\&\&>} is \tcode{true} for all $i$, and
+\tcode{is_constructible_v<$\tcode{T}_i$, $\tcode{U}_i$\&\&>} is \tcode{true} for all $i$, and
 \item
 \tcode{sizeof...(Types) != 1}, or
 (when \tcode{Types...} expands to \tcode{T} and \tcode{UTypes...} expands to \tcode{U})\linebreak
@@ -1705,7 +1705,7 @@ initializes the $i^\text{th}$ element of \tcode{*this} with
 is \tcode{true}.
 \end{itemize}
 The constructor is explicit if and only if
-\tcode{is_convertible_v<U$_i$\&\&, T$_i$>} is \tcode{false}
+\tcode{is_convertible_v<$\tcode{U}_i$\&\&, $\tcode{T}_i$>} is \tcode{false}
 for at least one $i$.
 \end{itemdescr}
 
@@ -1723,13 +1723,13 @@ second element with \tcode{u.second}.
 \pnum
 \remarks This constructor shall not participate in overload resolution unless
 \tcode{sizeof...(Types) == 2},
-\tcode{is_constructible_v<T$_0$, const U1\&>} is \tcode{true} and
-\tcode{is_constructible_v<T$_1$, const U2\&>} is \tcode{true}.
+\tcode{is_constructible_v<$\tcode{T}_0$, const U1\&>} is \tcode{true} and
+\tcode{is_constructible_v<$\tcode{T}_1$, const U2\&>} is \tcode{true}.
 
 \pnum
 The constructor is explicit if and only if
-\tcode{is_convertible_v<const U1\&, T$_0$>} is \tcode{false} or
-\tcode{is_convert\-ible_v<const U2\&, T$_1$>} is \tcode{false}.
+\tcode{is_convertible_v<const U1\&, $\tcode{T}_0$>} is \tcode{false} or
+\tcode{is_convert\-ible_v<const U2\&, $\tcode{T}_1$>} is \tcode{false}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{tuple}!constructor}%
@@ -1747,13 +1747,13 @@ second element with \tcode{std::forward<U2>(u.second)}.
 \pnum
 \remarks This constructor shall not participate in overload resolution unless
 \tcode{sizeof...(Types) == 2},
-\tcode{is_constructible_v<T$_0$, U1\&\&>} is \tcode{true} and
-\tcode{is_constructible_v<T$_1$, U2\&\&>} is \tcode{true}.
+\tcode{is_constructible_v<$\tcode{T}_0$, U1\&\&>} is \tcode{true} and
+\tcode{is_constructible_v<$\tcode{T}_1$, U2\&\&>} is \tcode{true}.
 
 \pnum
 The constructor is explicit if and only if
-\tcode{is_convertible_v<U1\&\&, T$_0$>} is \tcode{false} or
-\tcode{is_convertible_v<U2\&\&, T$_1$>} is \tcode{false}.
+\tcode{is_convertible_v<U1\&\&, $\tcode{T}_0$>} is \tcode{false} or
+\tcode{is_convertible_v<U2\&\&, $\tcode{T}_1$>} is \tcode{false}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{tuple}!constructor}%
@@ -1810,7 +1810,7 @@ element of \tcode{*this}.
 
 \pnum
 \remarks This operator shall be defined as deleted unless
-\tcode{is_copy_assignable_v<T$_i$>} is \tcode{true} for all $i$.
+\tcode{is_copy_assignable_v<$\tcode{T}_i$>} is \tcode{true} for all $i$.
 
 \pnum
 \returns \tcode{*this}.
@@ -1823,12 +1823,12 @@ tuple& operator=(tuple&& u) noexcept(@\seebelow@);
 
 \begin{itemdescr}
 \pnum
-\effects For all $i$, assigns \tcode{std::forward<T$_i$>(get<$i$>(u))} to
+\effects For all $i$, assigns \tcode{std::forward<$\tcode{T}_i$>(get<$i$>(u))} to
 \tcode{get<$i$>(*this)}.
 
 \pnum
 \remarks This operator shall be defined as deleted unless
-\tcode{is_move_assignable_v<T$_i$>} is \tcode{true} for all $i$.
+\tcode{is_move_assignable_v<$\tcode{T}_i$>} is \tcode{true} for all $i$.
 
 \pnum
 \remarks The expression inside \tcode{noexcept} is equivalent to the logical \textsc{and} of the
@@ -1856,7 +1856,7 @@ of \tcode{*this}.
 \pnum
 \remarks This operator shall not participate in overload resolution unless
 \tcode{sizeof...(Types) == sizeof...(UTypes)} and
-\tcode{is_assignable_v<T$_i$\&, const U$_i$\&>} is \tcode{true} for all $i$.
+\tcode{is_assignable_v<$\tcode{T}_i$\&, const $\tcode{U}_i$\&>} is \tcode{true} for all $i$.
 
 \pnum
 \returns \tcode{*this}.
@@ -1869,12 +1869,12 @@ template <class... UTypes> tuple& operator=(tuple<UTypes...>&& u);
 
 \begin{itemdescr}
 \pnum
-\effects For all $i$, assigns \tcode{std::forward<U$_i$>(get<$i$>(u))} to
+\effects For all $i$, assigns \tcode{std::forward<$\tcode{U}_i$>(get<$i$>(u))} to
 \tcode{get<$i$>(*this)}.
 
 \pnum
 \remarks This operator shall not participate in overload resolution unless
-\tcode{is_assignable_v<T$_i$\&, U$_i$\&\&> == true} for all $i$ and
+\tcode{is_assignable_v<$\tcode{T}_i$\&, $\tcode{U}_i$\&\&> == true} for all $i$ and
 \tcode{sizeof...(Types) == sizeof...(UTypes)}.
 
 \pnum
@@ -1895,8 +1895,8 @@ and \tcode{u.second} to the second element of \tcode{*this}.
 \pnum
 \remarks This operator shall not participate in overload resolution unless
 \tcode{sizeof...(Types) == 2} and
-\tcode{is_assignable_v<T$_0$\&, const U1\&>} is \tcode{true} for the first type \tcode{T}$_0$ in
-\tcode{Types} and \tcode{is_assignable_v<T$_1$\&, const U2\&>} is \tcode{true} for the
+\tcode{is_assignable_v<$\tcode{T}_0$\&, const U1\&>} is \tcode{true} for the first type \tcode{T}$_0$ in
+\tcode{Types} and \tcode{is_assignable_v<$\tcode{T}_1$\&, const U2\&>} is \tcode{true} for the
 second type \tcode{T}$_1$ in \tcode{Types}.
 
 \pnum
@@ -1919,8 +1919,8 @@ second element of \tcode{*this}.
 \remarks
 This operator shall not participate in overload resolution unless
 \tcode{sizeof...(Types) == 2} and
-\tcode{is_assignable_v<T$_0$\&, U1\&\&>} is \tcode{true} for the first type \tcode{T}$_0$ in
-\tcode{Types} and \tcode{is_assignable_v<T$_1$\&, U2\&\&>} is \tcode{true} for the second
+\tcode{is_assignable_v<$\tcode{T}_0$\&, U1\&\&>} is \tcode{true} for the first type \tcode{T}$_0$ in
+\tcode{Types} and \tcode{is_assignable_v<$\tcode{T}_1$\&, U2\&\&>} is \tcode{true} for the second
 type \tcode{T}$_1$ in \tcode{Types}.
 
 \pnum
@@ -1961,8 +1961,8 @@ where $\mathtt{T}_i$ is the $i^\text{th}$ type in \tcode{Types}.
 
 \pnum
 In the function descriptions that follow, let $i$ be in the range \range{0}{sizeof...(TTypes)}
-in order and let $T_i$ be the $i^{th}$ type in a template parameter pack named \tcode{TTypes};
-let $j$ be in the range \range{0}{sizeof...(UTypes)} in order and $U_j$ be the $j^{th}$ type
+in order and let $\tcode{T}_i$ be the $i^{th}$ type in a template parameter pack named \tcode{TTypes};
+let $j$ be in the range \range{0}{sizeof...(UTypes)} in order and $\tcode{U}_j$ be the $j^{th}$ type
 in a template parameter pack named \tcode{UTypes}, where indexing is zero-based.
 
 \indexlibrary{\idxcode{make_tuple}}%
@@ -1972,10 +1972,10 @@ template<class... Types>
   constexpr tuple<@\placeholder{VTypes}@...> make_tuple(Types&&... t);
 \end{itemdecl}
 
-\begin{itemdescr} \pnum Let \tcode{$U_i$} be \tcode{decay_t<$T_i$>} for each
-$T_i$ in \tcode{Types}. If $U_i$ is a specialization of
-\tcode{reference_wrapper}, then $V_i$ in \tcode{VTypes} is \tcode{$U_i$::type\&},
-otherwise $V_i$ is $U_i$.
+\begin{itemdescr} \pnum Let \tcode{$\tcode{U}_i$} be \tcode{decay_t<$\tcode{T}_i$>} for each
+$\tcode{T}_i$ in \tcode{Types}. If $\tcode{U}_i$ is a specialization of
+\tcode{reference_wrapper}, then $\tcode{V}_i$ in \tcode{VTypes} is \tcode{$\tcode{U}_i$::type\&},
+otherwise $\tcode{V}_i$ is $\tcode{U}_i$.
 
 \pnum
 \returns \tcode{tuple<VTypes...>(std::forward<Types>(t)...)}.
@@ -2052,17 +2052,17 @@ template <class... Tuples>
 
 \begin{itemdescr}
 \pnum
-In the following paragraphs, let $T_i$ be the $i^{th}$ type in \tcode{Tuples},
-$U_i$ be \tcode{remove_reference_t<Ti>}, and $tp_i$ be the $i^{th}$
+In the following paragraphs, let $\tcode{T}_i$ be the $i^{th}$ type in \tcode{Tuples},
+$\tcode{U}_i$ be \tcode{remove_reference_t<Ti>}, and $tp_i$ be the $i^{th}$
 parameter in the function parameter pack \tcode{tpls}, where all indexing is
 zero-based.
 
 \pnum
-\requires For all $i$, $U_i$ shall be the type
+\requires For all $i$, $\tcode{U}_i$ shall be the type
 $\cv_i$ \tcode{tuple<$Args_i...$>}, where $\cv_i$ is the (possibly empty) $i^{th}$
 cv-qualifier-seq and $Args_i$ is the parameter pack representing the element
-types in $U_i$. Let ${A_{ik}}$ be the ${k_i}^{th}$ type in $Args_i$. For all
-$A_{ik}$ the following requirements shall be satisfied: If $T_i$ is
+types in $\tcode{U}_i$. Let ${A_{ik}}$ be the ${k_i}^{th}$ type in $Args_i$. For all
+$A_{ik}$ the following requirements shall be satisfied: If $\tcode{T}_i$ is
 deduced as an lvalue reference type, then
 \tcode{is_constructible_v<$A_{ik}$, $cv_i$ $A_{ik}$\&> == true}, otherwise
 \tcode{is_constructible_v<$A_{ik}$, $cv_i A_{ik}$\&\&> == true}.
@@ -2078,7 +2078,7 @@ corresponding to the type sequence $Args_i$.
 \pnum
 \returns A \tcode{tuple} object constructed by initializing the ${k_i}^{th}$
 type element $e_{ik}$ in \tcode{$e_i$...} with\\
-\tcode{get<$k_i$>(std::forward<$T_i$>($tp_i$))} for each valid $k_i$ and
+\tcode{get<$k_i$>(std::forward<$\tcode{T}_i$>($tp_i$))} for each valid $k_i$ and
 each group $e_i$ in order.
 
 \pnum
@@ -2461,7 +2461,7 @@ template <class... Types>
 \begin{itemdescr}
 \pnum
 \remarks This function shall not participate in overload resolution
-unless \tcode{is_swappable_v<T$_i$>} is \tcode{true}
+unless \tcode{is_swappable_v<$\tcode{T}_i$>} is \tcode{true}
 for all $i$, where $0 \leq i < \text{\tcode{sizeof...(Types)}}$.
 The expression inside \tcode{noexcept} is equivalent to:
 
@@ -4289,7 +4289,7 @@ with \tcode{std::forward<T>(t)}.
 
 \pnum
 \postconditions
-\tcode{holds_alternative<T$_j$>(*this)} is \tcode{true}.
+\tcode{holds_alternative<$\tcode{T}_j$>(*this)} is \tcode{true}.
 
 \pnum
 \throws
@@ -4302,7 +4302,7 @@ This function shall not participate in overload resolution unless
 unless \tcode{decay_t<T>} is neither
 a specialization of \tcode{in_place_type_t}
 nor a specialization of \tcode{in_place_index_t},
-unless \tcode{is_constructible_v<T$_j$, T>} is \tcode{true},
+unless \tcode{is_constructible_v<$\tcode{T}_j$, T>} is \tcode{true},
 and unless the expression
 \tcode{\placeholdernc{FUN}(}\brk\tcode{std::forward<T>(t))} (with \tcode{\placeholdernc{FUN}}
 being the above-mentioned set of imaginary functions) is well formed.
@@ -4317,7 +4317,7 @@ for the argument. \end{note}
 
 \pnum
 The expression inside \tcode{noexcept} is equivalent to
-\tcode{is_nothrow_constructible_v<T$_j$, T>}.
+\tcode{is_nothrow_constructible_v<$\tcode{T}_j$, T>}.
 If \tcode{T}$_j$'s selected constructor is a constexpr constructor,
 this constructor shall be a constexpr constructor.
 \end{itemdescr}
@@ -4400,7 +4400,7 @@ Any exception thrown by calling the selected constructor of \tcode{T}$_I$.
 \pnum
 \remarks
 This function shall not participate in overload resolution unless \tcode{I} is
-less than \tcode{sizeof...(Types)} and \tcode{is_constructible_v<T$_I$, Args...>} is \tcode{true}.
+less than \tcode{sizeof...(Types)} and \tcode{is_constructible_v<$\tcode{T}_I$, Args...>} is \tcode{true}.
 If \tcode{T}$_I$'s selected constructor is a constexpr constructor, this
 constructor shall be a constexpr constructor.
 \end{itemdescr}
@@ -4425,7 +4425,7 @@ Initializes the contained value as if constructing an object of type
 \remarks
 This function shall not participate in overload resolution unless \tcode{I} is
 less than \tcode{sizeof...(Types)} and
-\tcode{is_constructible_v<T$_I$, initializer_list<U>\&, Args...>} is \tcode{true}.
+\tcode{is_constructible_v<$\tcode{T}_I$, initializer_list<U>\&, Args...>} is \tcode{true}.
 If \tcode{T}$_I$'s selected constructor is a constexpr constructor, this
 constructor shall be a constexpr constructor.
 \end{itemdescr}
@@ -4479,7 +4479,7 @@ destroys the currently contained value.
 
 \pnum
 \remarks
-If \tcode{is_trivially_destructible_v<T$_i$> == true} for all \tcode{T}$_i$
+If \tcode{is_trivially_destructible_v<$\tcode{T}_i$> == true} for all \tcode{T}$_i$
 then this destructor shall be a trivial destructor.
 \end{itemdescr}
 
@@ -4507,7 +4507,7 @@ copies the value contained in \tcode{rhs} to a temporary, then destroys any
 value contained in \tcode{*this}. Sets \tcode{*this} to hold the same
 alternative index as \tcode{rhs} and initializes the value contained in
 \tcode{*this} as if direct-non-list-initializing an object of type \tcode{T}$_j$
-with \tcode{std::forward<T$_j$>(TMP),} with \tcode{TMP} being the temporary and
+with \tcode{std::forward<$\tcode{T}_j$>(TMP),} with \tcode{TMP} being the temporary and
 $j$ being \tcode{rhs.index()}.
 \end{itemize}
 
@@ -4520,7 +4520,7 @@ $j$ being \tcode{rhs.index()}.
 \pnum
 \remarks
 This function shall not participate in overload resolution unless
-\tcode{is_copy_constructible_v<T$_i$> \&\& is_move_constructible_v<T$_i$> \&\& is_copy_assignable_v<T$_i$>}
+\tcode{is_copy_constructible_v<$\tcode{T}_i$> \&\& is_move_constructible_v<$\tcode{T}_i$> \&\& is_copy_assignable_v<$\tcode{T}_i$>}
 is \tcode{true} for all $i$.
 \begin{itemize}
 \item If an exception is thrown during the call to \tcode{T}$_j$'s copy assignment,
@@ -4563,10 +4563,10 @@ with \tcode{get<$j$>(std::move(rhs))} with $j$ being \tcode{rhs.index()}.
 \pnum
 \remarks
 This function shall not participate in overload resolution unless
-\tcode{is_move_constructible_v<T$_i$> \&\& is_move_assignable_v<T$_i$>} is
+\tcode{is_move_constructible_v<$\tcode{T}_i$> \&\& is_move_assignable_v<$\tcode{T}_i$>} is
 \tcode{true} for all $i$.
 The expression inside \tcode{noexcept} is equivalent to:
-\tcode{is_nothrow_move_constructible_v<T$_i$> \&\& is_nothrow_move_assignable_v<T$_i$>} for all $i$.
+\tcode{is_nothrow_move_constructible_v<$\tcode{T}_i$> \&\& is_nothrow_move_assignable_v<$\tcode{T}_i$>} for all $i$.
 \begin{itemize}
 \item If an exception is thrown during the call to \tcode{T}$_j$'s move construction
 (with $j$ being \tcode{rhs.index())}, the \tcode{variant} will hold no value.
@@ -4584,8 +4584,8 @@ template <class T> variant& operator=(T&& t) noexcept(@\seebelow@);
 \begin{itemdescr}
 \pnum
 Let \tcode{T}$_j$ be a type that is determined as follows:
-build an imaginary function \tcode{\placeholdernc{FUN}(T$_i$)} for each alternative type
-\tcode{T}$_i$. The overload \tcode{\placeholdernc{FUN}(T$_j$)} selected by overload
+build an imaginary function \tcode{\placeholdernc{FUN}($\tcode{T}_i$)} for each alternative type
+\tcode{T}$_i$. The overload \tcode{\placeholdernc{FUN}($\tcode{T}_j$)} selected by overload
 resolution for the expression \tcode{\placeholdernc{FUN}(std::forward<T>(\brk{}t))} defines
 the alternative \tcode{T}$_j$ which is the type of the contained value after
 assignment.
@@ -4601,7 +4601,7 @@ it with \tcode{std::forward<T>(t)}.
 
 \pnum
 \postconditions
-\tcode{holds_alternative<T$_j$>(*this)} is \tcode{true}, with \tcode{T}$_j$
+\tcode{holds_alternative<$\tcode{T}_j$>(*this)} is \tcode{true}, with \tcode{T}$_j$
 selected by the imaginary function overload resolution described above.
 
 \pnum
@@ -4611,7 +4611,7 @@ selected by the imaginary function overload resolution described above.
 \remarks
 This function shall not participate in overload resolution unless
 \tcode{is_same_v<decay_t<T>, variant>} is \tcode{false}, unless
-\tcode{is_assignable_v<T$_j$\&, T> \&\& is_constructible_v<T$_j$, T>} is \tcode{true},
+\tcode{is_assignable_v<$\tcode{T}_j$\&, T> \&\& is_constructible_v<$\tcode{T}_j$, T>} is \tcode{true},
 and unless the expression \tcode{\placeholdernc{FUN}(std::forward<T>(t))} (with
 \tcode{\placeholdernc{FUN}} being the above-mentioned set of imaginary functions)
 is well formed.
@@ -4706,7 +4706,7 @@ Any exception thrown during the initialization of the contained value.
 \pnum
 \remarks
 This function shall not participate in overload resolution unless
-\tcode{is_constructible_v<T$_I$, Args...>} is \tcode{true}.
+\tcode{is_constructible_v<$\tcode{T}_I$, Args...>} is \tcode{true}.
 If an exception is thrown during the initialization of the contained value,
 the \tcode{variant} might not hold a value.
 \end{itemdescr}
@@ -4739,7 +4739,7 @@ Any exception thrown during the initialization of the contained value.
 \pnum
 \remarks
 This function shall not participate in overload resolution unless
-\tcode{is_constructible_v<T$_I$, initializer_list<U>\&, Args...>} is \tcode{true}.
+\tcode{is_constructible_v<$\tcode{T}_I$, initializer_list<U>\&, Args...>} is \tcode{true}.
 If an exception is thrown during the initialization of the contained value,
 the \tcode{variant} might not hold a value.
 \end{itemdescr}
@@ -4792,7 +4792,7 @@ void swap(variant& rhs) noexcept(@\seebelow@);
 \begin{itemdescr}
 \pnum
 \requires Lvalues of type \tcode{T}$_i$ shall be swappable~(\ref{swappable.requirements}) and
-\tcode{is_move_constructible_v<T$_i$>} shall be \tcode{true} for all $i$.
+\tcode{is_move_constructible_v<$\tcode{T}_i$>} shall be \tcode{true} for all $i$.
 
 \pnum
 \effects
@@ -4824,7 +4824,7 @@ If an exception is thrown during the exchange of the values of \tcode{*this}
 and \tcode{rhs}, the states of the values of \tcode{*this} and of \tcode{rhs}
 are determined by the exception safety guarantee of \tcode{variant}'s move constructor.
 The expression inside \tcode{noexcept} is equivalent to the logical AND of
-\tcode{is_nothrow_move_constructible_v<T$_i$> \&\& is_nothrow_swappable_v<T$_i$>} for all $i$.
+\tcode{is_nothrow_move_constructible_v<$\tcode{T}_i$> \&\& is_nothrow_swappable_v<$\tcode{T}_i$>} for all $i$.
 \end{itemdescr}
 
 \rSec2[variant.helper]{\tcode{variant} helper classes}
@@ -5217,7 +5217,7 @@ template <class... Types>
 
 \pnum
 \remarks This function shall not participate in overload resolution
-unless \tcode{is_move_constructible_v<T$_i$> \&\& is_swappable_v<T$_i$>}
+unless \tcode{is_move_constructible_v<$\tcode{T}_i$> \&\& is_swappable_v<$\tcode{T}_i$>}
 is \tcode{true} for all $i$.
 The expression inside \tcode{noexcept} is equivalent to \tcode{noexcept(v.swap(w))}.
 \end{itemdescr}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1249,10 +1249,10 @@ template <class T1, class T2>
 \begin{itemdescr}
 \pnum
 \returns \tcode{pair<V1, V2>(std::forward<T1>(x), std::forward<T2>(y))},
-where \tcode{V1} and \tcode{V2} are determined as follows: Let \tcode{Ui} be
-\tcode{decay_t<Ti>} for each \tcode{Ti}. If \tcode{Ui} is a specialization
-of \tcode{reference_wrapper}, then \tcode{Vi} is \tcode{Ui::type\&},
-otherwise \tcode{Vi} is \tcode{Ui}.
+where \tcode{V1} and \tcode{V2} are determined as follows: Let $\tcode{U}_i$ be
+\tcode{decay_t<$\tcode{T}_i$>} for each $\tcode{T}_i$. If $\tcode{U}_i$ is a specialization
+of \tcode{reference_wrapper}, then $\tcode{V}_i$ is \tcode{$\tcode{U}_i$::type\&},
+otherwise $\tcode{V}_i$ is $\tcode{U}_i$.
 \end{itemdescr}
 
 \pnum
@@ -2053,7 +2053,7 @@ template <class... Tuples>
 \begin{itemdescr}
 \pnum
 In the following paragraphs, let $\tcode{T}_i$ be the $i^{th}$ type in \tcode{Tuples},
-$\tcode{U}_i$ be \tcode{remove_reference_t<Ti>}, and $tp_i$ be the $i^{th}$
+$\tcode{U}_i$ be \tcode{remove_reference_t<$\tcode{T}_i$>}, and $tp_i$ be the $i^{th}$
 parameter in the function parameter pack \tcode{tpls}, where all indexing is
 zero-based.
 
@@ -14022,10 +14022,10 @@ In the text that follows:
 \begin{itemize}
 \item \tcode{FD} is the type \tcode{decay_t<F>},
 \item \tcode{fd} is an lvalue of type \tcode{FD} constructed from \tcode{std::forward<F>(f)},
-\item \tcode{Ti} is the $i^{th}$ type in the template parameter pack \tcode{BoundArgs},
-\item \tcode{TiD} is the type \tcode{decay_t<Ti>},
+\item $\tcode{T}_i$ is the $i^{th}$ type in the template parameter pack \tcode{BoundArgs},
+\item $\tcode{TD}_i$ is the type \tcode{decay_t<$\tcode{T}_i$>},
 \item \tcode{ti} is the $i^{th}$ argument in the function parameter pack \tcode{bound_args},
-\item \tcode{tid} is an lvalue of type \tcode{TiD} constructed from \tcode{std::forward<Ti>(ti)},
+\item \tcode{tid} is an lvalue of type $\tcode{TD}_i$ constructed from \tcode{std::forward<$\tcode{T}_i$>(ti)},
 \item \tcode{Uj} is the $j^{th}$ deduced type of the \tcode{UnBoundArgs\&\&...} parameter
   of the forwarding call wrapper, and
 \item \tcode{uj} is the $j^{th}$ argument associated with \tcode{Uj}.
@@ -14040,8 +14040,8 @@ template<class F, class... BoundArgs>
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{is_constructible_v<FD, F>} shall be \tcode{true}. For each \tcode{Ti}
-in \tcode{BoundArgs}, \tcode{is_cons\-tructible_v<TiD, Ti>} shall be \tcode{true}.
+\tcode{is_constructible_v<FD, F>} shall be \tcode{true}. For each $\tcode{T}_i$
+in \tcode{BoundArgs}, \tcode{is_cons\-tructible_v<$\tcode{TD}_i$, $\tcode{T}_i$>} shall be \tcode{true}.
 \tcode{\textit{INVOKE} (fd, w1, w2, ...,
 wN)}~(\ref{func.require}) shall be a valid expression for some
 values \textit{w1, w2, ..., wN}, where
@@ -14057,7 +14057,7 @@ where the values and types of the bound
 arguments \tcode{v1, v2, ..., vN} are determined as specified below.
 The copy constructor and move constructor of the forwarding call wrapper shall throw an
 exception if and only if the corresponding constructor of \tcode{FD} or of any of the types
-\tcode{TiD} throws an exception.
+$\tcode{TD}_i$ throws an exception.
 
 \pnum
 \throws Nothing unless the construction of
@@ -14065,9 +14065,9 @@ exception if and only if the corresponding constructor of \tcode{FD} or of any o
 
 \pnum
 \remarks The return type shall satisfy the requirements of \tcode{MoveConstructible}. If all
-of \tcode{FD} and \tcode{TiD} satisfy the requirements of \tcode{CopyConstructible}, then the
+of \tcode{FD} and $\tcode{TD}_i$ satisfy the requirements of \tcode{CopyConstructible}, then the
 return type shall satisfy the requirements of \tcode{CopyConstructible}. \begin{note} This implies
-that all of \tcode{FD} and \tcode{TiD} are \tcode{MoveConstructible}. \end{note}
+that all of \tcode{FD} and $\tcode{TD}_i$ are \tcode{MoveConstructible}. \end{note}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bind}}%
@@ -14079,8 +14079,8 @@ template<class R, class F, class... BoundArgs>
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{is_constructible_v<FD, F>} shall be \tcode{true}. For each \tcode{Ti}
-in \tcode{BoundArgs}, \tcode{is_con\-structible_v<TiD, Ti>} shall be \tcode{true}.
+\tcode{is_constructible_v<FD, F>} shall be \tcode{true}. For each $\tcode{T}_i$
+in \tcode{BoundArgs}, \tcode{is_con\-structible_v<$\tcode{TD}_i$, $\tcode{T}_i$>} shall be \tcode{true}.
 \tcode{\textit{INVOKE}(fd, w1, w2, ..., wN)} shall be  a valid
 expression for some
 values \textit{w1, w2, ..., wN}, where
@@ -14098,7 +14098,7 @@ std::forward<VN>(vN), R)}, where the values and types of the bound
 arguments \tcode{v1, v2, ..., vN} are determined as specified below.
 The copy constructor and move constructor of the forwarding call wrapper shall throw an
 exception if and only if the corresponding constructor of \tcode{FD} or of any of the types
-\tcode{TiD} throws an exception.
+$\tcode{TD}_i$ throws an exception.
 
 \pnum
 \throws Nothing unless the construction of
@@ -14106,35 +14106,35 @@ exception if and only if the corresponding constructor of \tcode{FD} or of any o
 
 \pnum
 \remarks The return type shall satisfy the requirements of \tcode{MoveConstructible}. If all
-of \tcode{FD} and \tcode{TiD} satisfy the requirements of \tcode{CopyConstructible}, then the
+of \tcode{FD} and $\tcode{TD}_i$ satisfy the requirements of \tcode{CopyConstructible}, then the
 return type shall satisfy the requirements of \tcode{CopyConstructible}. \begin{note} This implies
-that all of \tcode{FD} and \tcode{TiD} are \tcode{MoveConstructible}. \end{note}
+that all of \tcode{FD} and $\tcode{TD}_i$ are \tcode{MoveConstructible}. \end{note}
 \end{itemdescr}
 
 \pnum
 \indextext{bound arguments}%
 The values of the \techterm{bound arguments} \tcode{v1, v2, ..., vN} and their
 corresponding types \tcode{V1, V2, ..., VN} depend on the
-types \tcode{TiD} derived from
+types $\tcode{TD}_i$ derived from
 the call to \tcode{bind} and the
 cv-qualifiers \cv{} of the call wrapper \tcode{g} as follows:
 
 \begin{itemize}
-\item if \tcode{TiD} is \tcode{reference_wrapper<T>}, the
-argument is \tcode{tid.get()} and its type \tcode{Vi} is \tcode{T\&};
+\item if $\tcode{TD}_i$ is \tcode{reference_wrapper<T>}, the
+argument is \tcode{tid.get()} and its type $\tcode{V}_i$ is \tcode{T\&};
 
-\item if the value of \tcode{is_bind_expression_v<TiD>}
+\item if the value of \tcode{is_bind_expression_v<$\tcode{TD}_i$>}
 is \tcode{true}, the argument is \tcode{tid(std::forward<Uj>(\brk{}uj)...)}  and its
-type \tcode{Vi} is
-\tcode{result_of_t<TiD \cv{} \& (Uj\&\&...)>\&\&};
+type $\tcode{V}_i$ is
+\tcode{result_of_t<$\tcode{TD}_i$ \cv{} \& (Uj\&\&...)>\&\&};
 
-\item if the value \tcode{j} of \tcode{is_placeholder_v<TiD>}
+\item if the value \tcode{j} of \tcode{is_placeholder_v<$\tcode{TD}_i$>}
 is not zero, the  argument is \tcode{std::forward<Uj>(uj)}
-and its type \tcode{Vi}
+and its type $\tcode{V}_i$
 is \tcode{Uj\&\&};
 
-\item otherwise, the value is \tcode{tid} and its type \tcode{Vi}
-is \tcode{TiD \cv{} \&}.
+\item otherwise, the value is \tcode{tid} and its type $\tcode{V}_i$
+is \tcode{$\tcode{TD}_i$ \cv{} \&}.
 \end{itemize}
 
 \rSec3[func.bind.place]{Placeholders}


### PR DESCRIPTION
The canonical way to format an indexed type placeholder is now $\mcode{T}_i$. This works inside an outside a \tcode area.

Fixes #1139.