### PR TITLE
[lex.literal] Avoid references to plain 'literal'

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -947,7 +947,7 @@ digits, which include the decimal digits and the letters \tcode{a}
 through \tcode{f} and \tcode{A} through \tcode{F} with decimal values
 ten through fifteen.
 \begin{example} The number twelve can be written \tcode{12}, \tcode{014},
-\tcode{0XC}, or \tcode{0b1100}. The literals \tcode{1048576},
+\tcode{0XC}, or \tcode{0b1100}. The integer literals \tcode{1048576},
 \tcode{1'048'576}, \tcode{0X100000}, \tcode{0x10'0000}, and
 \tcode{0'004'000'000} all have the same value.
 \end{example}
@@ -1036,9 +1036,9 @@ and \tcode{ll} or \tcode{LL}  &
 \pnum
 If an integer literal cannot be represented by any type in its list and
 an extended integer type~(\ref{basic.fundamental}) can represent its value, it may have that
-extended integer type. If all of the types in the list for the literal
+extended integer type. If all of the types in the list for the integer literal
 are signed, the extended integer type shall be signed. If all of the
-types in the list for the literal are unsigned, the extended integer
+types in the list for the integer literal are unsigned, the extended integer
 type shall be unsigned. If the list contains both signed and unsigned
 types, the extended integer type may be signed or unsigned. A program is
 ill-formed if one of its translation units contains an integer literal
@@ -1153,11 +1153,11 @@ A character literal that
 begins with the letter \tcode{u}, such as \tcode{u'x'},
 \indextext{prefix!\idxcode{u}}%
 is a character literal of type \tcode{char16_t}. The value
-of a \tcode{char16_t} literal containing a single \grammarterm{c-char} is
+of a \tcode{char16_t} character literal containing a single \grammarterm{c-char} is
 equal to its ISO 10646 code point value, provided that the code point is
 representable with a single 16-bit code unit. (That is, provided it is a
 basic multi-lingual plane code point.) If the value is not representable
-within 16 bits, the program is ill-formed. A \tcode{char16_t} literal
+within 16 bits, the program is ill-formed. A \tcode{char16_t} character literal
 containing multiple \grammarterm{c-char}{s} is ill-formed.
 
 \pnum
@@ -1168,8 +1168,8 @@ A character literal that
 begins with the letter \tcode{U}, such as \tcode{U'y'},
 \indextext{prefix!\idxcode{U}}%
 is a character literal of type \tcode{char32_t}. The value of a
-\tcode{char32_t} literal containing a single \grammarterm{c-char} is equal
-to its ISO 10646 code point value. A \tcode{char32_t} literal containing
+\tcode{char32_t} character literal containing a single \grammarterm{c-char} is equal
+to its ISO 10646 code point value. A \tcode{char32_t} character literal containing
 multiple \grammarterm{c-char}{s} is ill-formed.
 
 \pnum
@@ -1251,8 +1251,8 @@ respectively.
 \indextext{literal!implementation-defined value of \idxcode{char}}%
 The value of a character literal is \impldef{value of character literal outside range of
 corresponding type} if it falls outside of the \impldef{range defined for character literals}
-range defined for \tcode{char} (for literals with no prefix) or
-\tcode{wchar_t} (for literals prefixed by \tcode{L}).
+range defined for \tcode{char} (for character literals with no prefix) or
+\tcode{wchar_t} (for character literals prefixed by \tcode{L}).
 \begin{note}
 If the value of a character literal prefixed by
 \tcode{u}, \tcode{u8}, or \tcode{U}
@@ -1350,12 +1350,12 @@ an optional type suffix.
 The integer and fraction parts both consist of
 a sequence of decimal (base ten) digits if there is no prefix, or
 hexadecimal (base sixteen) digits if the prefix is \tcode{0x} or \tcode{0X}.
-The literal is a \defnx{decimal floating literal}{literal!decimal floating} in the former case and
+The floating literal is a \defnx{decimal floating literal}{literal!decimal floating} in the former case and
 a \defnx{hexadecimal floating literal}{literal!hexadecimal floating} in the latter case.
 Optional separating single quotes in
 a \grammarterm{digit-sequence} or \grammarterm{hexadecimal-digit-sequence}
 are ignored when determining its value.
-\begin{example} The literals \tcode{1.602'176'565e-19} and \tcode{1.602176565e-19}
+\begin{example} The floating literals \tcode{1.602'176'565e-19} and \tcode{1.602176565e-19}
 have the same value. \end{example}
 Either the integer part or the fraction part (not both) can be omitted.
 Either the radix point or the letter \tcode{e} or \tcode{E} and
@@ -1369,7 +1369,7 @@ indicates the power of 10 by which the significand is to be scaled.
 In a hexadecimal floating literal, the exponent
 indicates the power of 2 by which the significand is to be scaled.
 \begin{example}
-The literals \tcode{49.625} and \tcode{0xC.68p+2} have the same value.
+The floating literals \tcode{49.625} and \tcode{0xC.68p+2} have the same value.
 \end{example}
 If the scaled value is in
 the range of representable values for its type, the result is the scaled
@@ -1605,7 +1605,7 @@ conditionally-supported with \impldef{concatenation of some types of string lite
 behavior. \begin{note} This
 concatenation is an interpretation, not a conversion.
 Because the interpretation happens in translation phase 6 (after each character from a
-literal has been translated into a value from the appropriate character set), a
+string literal has been translated into a value from the appropriate character set), a
 \grammarterm{string-literal}'s initial rawness has no effect on the interpretation or
 well-formedness of the concatenation.
 \end{note}
@@ -1672,7 +1672,7 @@ character requiring a surrogate pair, plus one for the terminating
 \tcode{u'\textbackslash 0'}. \begin{note} The size of a \tcode{char16_t}
 string literal is the number of code units, not the number of
 characters. \end{note} Within \tcode{char32_t} and \tcode{char16_t}
-literals, any \grammarterm{universal-character-name}{s} shall be within the range
+string literals, any \grammarterm{universal-character-name}{s} shall be within the range
 \tcode{0x0} to \tcode{0x10FFFF}. The size of a narrow string literal is
 the total number of escape sequences and other characters, plus at least
 one for the multibyte encoding of each \grammarterm{universal-character-name}, plus
@@ -1766,7 +1766,7 @@ and~\ref{conv.mem}.
 \end{bnf}
 
 \pnum
-If a token matches both \grammarterm{user-defined-literal} and another literal kind, it
+If a token matches both \grammarterm{user-defined-literal} and another \grammarterm{literal} kind, it
 is treated as the latter. \begin{example} \tcode{123_km}
 is a \grammarterm{user-defined-literal}, but \tcode{12LL} is an
 \grammarterm{integer-literal}. \end{example}


### PR DESCRIPTION
unless the \grammarterm is intended.

Fixes #322.