### PR TITLE
Harmonize spacing for template headers.

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -1890,7 +1890,7 @@ template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
                   ForwardIterator2 first2, ForwardIterator2 last2);
 
 template<class InputIterator, class ForwardIterator,
-          class BinaryPredicate>
+         class BinaryPredicate>
   constexpr InputIterator
     find_first_of(InputIterator first1, InputIterator last1,
                   ForwardIterator first2, ForwardIterator last2,

--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -33,7 +33,7 @@ and operations, as summarized below.
 namespace std {
   // \ref{atomics.order}, order and consistency
   enum class memory_order : @\unspec@;
-  template <class T>
+  template<class T>
     T kill_dependency(T y) noexcept;
 
   // \ref{atomics.lockfree}, lock-free property
@@ -127,54 +127,54 @@ namespace std {
                                                  typename atomic<T>::value_type,
                                                  memory_order, memory_order) noexcept;
 
-  template <class T>
+  template<class T>
     T atomic_fetch_add(volatile atomic<T>*, typename atomic<T>::difference_type) noexcept;
-  template <class T>
+  template<class T>
     T atomic_fetch_add(atomic<T>*, typename atomic<T>::difference_type) noexcept;
-  template <class T>
+  template<class T>
     T atomic_fetch_add_explicit(volatile atomic<T>*, typename atomic<T>::difference_type,
                                 memory_order) noexcept;
-  template <class T>
+  template<class T>
     T atomic_fetch_add_explicit(atomic<T>*, typename atomic<T>::difference_type,
                                 memory_order) noexcept;
-  template <class T>
+  template<class T>
     T atomic_fetch_sub(volatile atomic<T>*, typename atomic<T>::difference_type) noexcept;
-  template <class T>
+  template<class T>
     T atomic_fetch_sub(atomic<T>*, typename atomic<T>::difference_type) noexcept;
-  template <class T>
+  template<class T>
     T atomic_fetch_sub_explicit(volatile atomic<T>*, typename atomic<T>::difference_type,
                                 memory_order) noexcept;
-  template <class T>
+  template<class T>
     T atomic_fetch_sub_explicit(atomic<T>*, typename atomic<T>::difference_type,
                                 memory_order) noexcept;
-  template <class T>
+  template<class T>
     T atomic_fetch_and(volatile atomic<T>*, typename atomic<T>::value_type) noexcept;
-  template <class T>
+  template<class T>
     T atomic_fetch_and(atomic<T>*, typename atomic<T>::value_type) noexcept;
-  template <class T>
+  template<class T>
     T atomic_fetch_and_explicit(volatile atomic<T>*, typename atomic<T>::value_type,
                                 memory_order) noexcept;
-  template <class T>
+  template<class T>
     T atomic_fetch_and_explicit(atomic<T>*, typename atomic<T>::value_type,
                                 memory_order) noexcept;
-  template <class T>
+  template<class T>
     T atomic_fetch_or(volatile atomic<T>*, typename atomic<T>::value_type) noexcept;
-  template <class T>
+  template<class T>
     T atomic_fetch_or(atomic<T>*, typename atomic<T>::value_type) noexcept;
-  template <class T>
+  template<class T>
     T atomic_fetch_or_explicit(volatile atomic<T>*, typename atomic<T>::value_type,
                                memory_order) noexcept;
-  template <class T>
+  template<class T>
     T atomic_fetch_or_explicit(atomic<T>*, typename atomic<T>::value_type,
                                memory_order) noexcept;
-  template <class T>
+  template<class T>
     T atomic_fetch_xor(volatile atomic<T>*, typename atomic<T>::value_type) noexcept;
-  template <class T>
+  template<class T>
     T atomic_fetch_xor(atomic<T>*, typename atomic<T>::value_type) noexcept;
-  template <class T>
+  template<class T>
     T atomic_fetch_xor_explicit(volatile atomic<T>*, typename atomic<T>::value_type,
                                 memory_order) noexcept;
-  template <class T>
+  template<class T>
     T atomic_fetch_xor_explicit(atomic<T>*, typename atomic<T>::value_type,
                                 memory_order) noexcept;
 
@@ -493,7 +493,7 @@ amount of time.
 
 \indexlibrary{\idxcode{kill_dependency}}%
 \begin{itemdecl}
-template <class T>
+template<class T>
   T kill_dependency(T y) noexcept;
 \end{itemdecl}
 
@@ -565,7 +565,7 @@ processes. \end{note}
 \indexlibrarymember{value_type}{atomic}%
 \begin{codeblock}
 namespace std {
-  template <class T> struct atomic {
+  template<class T> struct atomic {
     using value_type = T;
     static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic} type's operations are always lock free}@;
     bool is_lock_free() const volatile noexcept;
@@ -963,7 +963,7 @@ For the specialization \tcode{atomic<bool>}, see \ref{atomics.types.generic}.
 
 \begin{codeblock}
 namespace std {
-  template <> struct atomic<@\placeholder{integral}@> {
+  template<> struct atomic<@\placeholder{integral}@> {
     using value_type = @\placeholder{integral}@;
     using difference_type = value_type;
     static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic} type's operations are always lock free}@;
@@ -1278,7 +1278,7 @@ calling thread's floating-point environment.
 
 \begin{codeblock}
 namespace std {
-  template <class T> struct atomic<T*> {
+  template<class T> struct atomic<T*> {
     using value_type = T*;
     using difference_type = ptrdiff_t;
     static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic} type's operations are always lock free}@;

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -994,7 +994,7 @@ For every sequence container defined in this Clause and in \ref{strings}:
 \begin{itemize}
 \item If the constructor
 \begin{codeblock}
-template <class InputIterator>
+template<class InputIterator>
   X(InputIterator first, InputIterator last,
     const allocator_type& alloc = allocator_type());
 \end{codeblock}
@@ -1004,14 +1004,14 @@ shall not participate in overload resolution.
 
 \item If the member functions of the forms:
 \begin{codeblock}
-template <class InputIterator>
+template<class InputIterator>
   @\placeholdernc{return-type}@ @\placeholdernc{F}@(const_iterator p,
                 InputIterator first, InputIterator last);       // such as \tcode{insert}
 
-template <class InputIterator>
+template<class InputIterator>
   @\placeholdernc{return-type}@ @\placeholdernc{F}@(InputIterator first, InputIterator last);       // such as \tcode{append}, \tcode{assign}
 
-template <class InputIterator>
+template<class InputIterator>
   @\placeholdernc{return-type}@ @\placeholdernc{F}@(const_iterator i1, const_iterator i2,
                 InputIterator first, InputIterator last);       // such as \tcode{replace}
 \end{codeblock}
@@ -1457,7 +1457,7 @@ have a member function \tcode{insert} that returns a nested type \tcode{insert_r
 That return type is a specialization of the type specified in this subclause.
 
 \begin{codeblock}
-template <class Iterator, class NodeType>
+template<class Iterator, class NodeType>
 struct @\placeholder{INSERT_RETURN_TYPE}@
 {
   Iterator position;
@@ -2932,36 +2932,36 @@ requirements for sequence containers.
 
 namespace std {
   // \ref{array}, class template \tcode{array}
-  template <class T, size_t N> struct array;
+  template<class T, size_t N> struct array;
 
-  template <class T, size_t N>
+  template<class T, size_t N>
     bool operator==(const array<T, N>& x, const array<T, N>& y);
-  template <class T, size_t N>
+  template<class T, size_t N>
     bool operator!=(const array<T, N>& x, const array<T, N>& y);
-  template <class T, size_t N>
+  template<class T, size_t N>
     bool operator< (const array<T, N>& x, const array<T, N>& y);
-  template <class T, size_t N>
+  template<class T, size_t N>
     bool operator> (const array<T, N>& x, const array<T, N>& y);
-  template <class T, size_t N>
+  template<class T, size_t N>
     bool operator<=(const array<T, N>& x, const array<T, N>& y);
-  template <class T, size_t N>
+  template<class T, size_t N>
     bool operator>=(const array<T, N>& x, const array<T, N>& y);
-  template <class T, size_t N>
+  template<class T, size_t N>
     void swap(array<T, N>& x, array<T, N>& y) noexcept(noexcept(x.swap(y)));
 
-  template <class T> class tuple_size;
-  template <size_t I, class T> class tuple_element;
-  template <class T, size_t N>
+  template<class T> class tuple_size;
+  template<size_t I, class T> class tuple_element;
+  template<class T, size_t N>
     struct tuple_size<array<T, N>>;
-  template <size_t I, class T, size_t N>
+  template<size_t I, class T, size_t N>
     struct tuple_element<I, array<T, N>>;
-  template <size_t I, class T, size_t N>
+  template<size_t I, class T, size_t N>
     constexpr T& get(array<T, N>&) noexcept;
-  template <size_t I, class T, size_t N>
+  template<size_t I, class T, size_t N>
     constexpr T&& get(array<T, N>&&) noexcept;
-  template <size_t I, class T, size_t N>
+  template<size_t I, class T, size_t N>
     constexpr const T& get(const array<T, N>&) noexcept;
-  template <size_t I, class T, size_t N>
+  template<size_t I, class T, size_t N>
     constexpr const T&& get(const array<T, N>&&) noexcept;
 }
 \end{codeblock}
@@ -2975,27 +2975,27 @@ namespace std {
 
 namespace std {
   // \ref{deque}, class template \tcode{deque}
-  template <class T, class Allocator = allocator<T>> class deque;
+  template<class T, class Allocator = allocator<T>> class deque;
 
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     bool operator==(const deque<T, Allocator>& x, const deque<T, Allocator>& y);
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     bool operator< (const deque<T, Allocator>& x, const deque<T, Allocator>& y);
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     bool operator!=(const deque<T, Allocator>& x, const deque<T, Allocator>& y);
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     bool operator> (const deque<T, Allocator>& x, const deque<T, Allocator>& y);
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     bool operator>=(const deque<T, Allocator>& x, const deque<T, Allocator>& y);
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     bool operator<=(const deque<T, Allocator>& x, const deque<T, Allocator>& y);
 
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     void swap(deque<T, Allocator>& x, deque<T, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 
   namespace pmr {
-    template <class T>
+    template<class T>
       using deque = std::deque<T, polymorphic_allocator<T>>;
   }
 }
@@ -3010,27 +3010,27 @@ namespace std {
 
 namespace std {
   // \ref{forwardlist}, class template \tcode{forward_list}
-  template <class T, class Allocator = allocator<T>> class forward_list;
+  template<class T, class Allocator = allocator<T>> class forward_list;
 
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     bool operator==(const forward_list<T, Allocator>& x, const forward_list<T, Allocator>& y);
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     bool operator< (const forward_list<T, Allocator>& x, const forward_list<T, Allocator>& y);
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     bool operator!=(const forward_list<T, Allocator>& x, const forward_list<T, Allocator>& y);
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     bool operator> (const forward_list<T, Allocator>& x, const forward_list<T, Allocator>& y);
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     bool operator>=(const forward_list<T, Allocator>& x, const forward_list<T, Allocator>& y);
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     bool operator<=(const forward_list<T, Allocator>& x, const forward_list<T, Allocator>& y);
 
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     void swap(forward_list<T, Allocator>& x, forward_list<T, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 
   namespace pmr {
-    template <class T>
+    template<class T>
       using forward_list = std::forward_list<T, polymorphic_allocator<T>>;
   }
 }
@@ -3045,27 +3045,27 @@ namespace std {
 
 namespace std {
   // \ref{list}, class template \tcode{list}
-  template <class T, class Allocator = allocator<T>> class list;
+  template<class T, class Allocator = allocator<T>> class list;
 
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     bool operator==(const list<T, Allocator>& x, const list<T, Allocator>& y);
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     bool operator< (const list<T, Allocator>& x, const list<T, Allocator>& y);
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     bool operator!=(const list<T, Allocator>& x, const list<T, Allocator>& y);
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     bool operator> (const list<T, Allocator>& x, const list<T, Allocator>& y);
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     bool operator>=(const list<T, Allocator>& x, const list<T, Allocator>& y);
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     bool operator<=(const list<T, Allocator>& x, const list<T, Allocator>& y);
 
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     void swap(list<T, Allocator>& x, list<T, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 
   namespace pmr {
-    template <class T>
+    template<class T>
       using list = std::list<T, polymorphic_allocator<T>>;
   }
 }
@@ -3080,34 +3080,34 @@ namespace std {
 
 namespace std {
   // \ref{vector}, class template \tcode{vector}
-  template <class T, class Allocator = allocator<T>> class vector;
+  template<class T, class Allocator = allocator<T>> class vector;
 
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     bool operator==(const vector<T, Allocator>& x, const vector<T, Allocator>& y);
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     bool operator< (const vector<T, Allocator>& x, const vector<T, Allocator>& y);
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     bool operator!=(const vector<T, Allocator>& x, const vector<T, Allocator>& y);
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     bool operator> (const vector<T, Allocator>& x, const vector<T, Allocator>& y);
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     bool operator>=(const vector<T, Allocator>& x, const vector<T, Allocator>& y);
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     bool operator<=(const vector<T, Allocator>& x, const vector<T, Allocator>& y);
 
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     void swap(vector<T, Allocator>& x, vector<T, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 
   // \ref{vector.bool}, class \tcode{vector<bool>}
-  template <class Allocator> class vector<bool, Allocator>;
+  template<class Allocator> class vector<bool, Allocator>;
 
   // hash support
-  template <class T> struct hash;
-  template <class Allocator> struct hash<vector<bool, Allocator>>;
+  template<class T> struct hash;
+  template<class Allocator> struct hash<vector<bool, Allocator>>;
 
   namespace pmr {
-    template <class T>
+    template<class T>
       using vector = std::vector<T, polymorphic_allocator<T>>;
   }
 }
@@ -3152,7 +3152,7 @@ for operations where there is additional semantic information.
 \indexlibrarymember{array}{max_size}%
 \begin{codeblock}
 namespace std {
-  template <class T, size_t N>
+  template<class T, size_t N>
   struct array {
     // types
     using value_type             = T;
@@ -3289,7 +3289,7 @@ become associated with the other container.
 
 \indexlibrarymember{array}{swap}%
 \begin{itemdecl}
-template <class T, size_t N>
+template<class T, size_t N>
   void swap(array<T, N>& x, array<T, N>& y) noexcept(noexcept(x.swap(y)));
 \end{itemdecl}
 
@@ -3327,7 +3327,7 @@ non-throwing exception specification.
 \indextext{\idxcode{array}!tuple interface to}%
 \indexlibrary{\idxcode{tuple_size}}%
 \begin{itemdecl}
-template <class T, size_t N>
+template<class T, size_t N>
   struct tuple_size<array<T, N>> : integral_constant<size_t, N> { };
 \end{itemdecl}
 
@@ -3346,13 +3346,13 @@ tuple_element<I, array<T, N>>::type
 
 \indexlibrarymember{array}{get}%
 \begin{itemdecl}
-template <size_t I, class T, size_t N>
+template<size_t I, class T, size_t N>
   constexpr T& get(array<T, N>& a) noexcept;
-template <size_t I, class T, size_t N>
+template<size_t I, class T, size_t N>
   constexpr T&& get(array<T, N>&& a) noexcept;
-template <size_t I, class T, size_t N>
+template<size_t I, class T, size_t N>
   constexpr const T& get(const array<T, N>& a) noexcept;
-template <size_t I, class T, size_t N>
+template<size_t I, class T, size_t N>
   constexpr const T&& get(const array<T, N>&& a) noexcept;
 \end{itemdecl}
 
@@ -3392,7 +3392,7 @@ or for operations where there is additional semantic information.
 
 \begin{codeblock}
 namespace std {
-  template <class T, class Allocator = allocator<T>>
+  template<class T, class Allocator = allocator<T>>
   class deque {
   public:
     // types
@@ -3414,7 +3414,7 @@ namespace std {
     explicit deque(const Allocator&);
     explicit deque(size_type n, const Allocator& = Allocator());
     deque(size_type n, const T& value, const Allocator& = Allocator());
-    template <class InputIterator>
+    template<class InputIterator>
       deque(InputIterator first, InputIterator last, const Allocator& = Allocator());
     deque(const deque& x);
     deque(deque&&);
@@ -3427,7 +3427,7 @@ namespace std {
     deque& operator=(deque&& x)
       noexcept(allocator_traits<Allocator>::is_always_equal::value);
     deque& operator=(initializer_list<T>);
-    template <class InputIterator>
+    template<class InputIterator>
       void assign(InputIterator first, InputIterator last);
     void assign(size_type n, const T& t);
     void assign(initializer_list<T>);
@@ -3467,9 +3467,9 @@ namespace std {
     const_reference back() const;
 
     // \ref{deque.modifiers}, modifiers
-    template <class... Args> reference emplace_front(Args&&... args);
-    template <class... Args> reference emplace_back(Args&&... args);
-    template <class... Args> iterator emplace(const_iterator position, Args&&... args);
+    template<class... Args> reference emplace_front(Args&&... args);
+    template<class... Args> reference emplace_back(Args&&... args);
+    template<class... Args> iterator emplace(const_iterator position, Args&&... args);
 
     void push_front(const T& x);
     void push_front(T&& x);
@@ -3479,7 +3479,7 @@ namespace std {
     iterator insert(const_iterator position, const T& x);
     iterator insert(const_iterator position, T&& x);
     iterator insert(const_iterator position, size_type n, const T& x);
-    template <class InputIterator>
+    template<class InputIterator>
       iterator insert(const_iterator position, InputIterator first, InputIterator last);
     iterator insert(const_iterator position, initializer_list<T>);
 
@@ -3499,7 +3499,7 @@ namespace std {
       -> deque<typename iterator_traits<InputIterator>::value_type, Allocator>;
 
   // \ref{deque.special}, specialized algorithms
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     void swap(deque<T, Allocator>& x, deque<T, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 }
@@ -3564,7 +3564,7 @@ Linear in \tcode{n}.
 
 \indexlibrary{\idxcode{deque}!constructor}%
 \begin{itemdecl}
-template <class InputIterator>
+template<class InputIterator>
   deque(InputIterator first, InputIterator last, const Allocator& = Allocator());
 \end{itemdecl}
 
@@ -3649,14 +3649,14 @@ referring to the elements in the sequence as well as the past-the-end iterator.
 iterator insert(const_iterator position, const T& x);
 iterator insert(const_iterator position, T&& x);
 iterator insert(const_iterator position, size_type n, const T& x);
-template <class InputIterator>
+template<class InputIterator>
   iterator insert(const_iterator position,
                   InputIterator first, InputIterator last);
 iterator insert(const_iterator position, initializer_list<T>);
 
-template <class... Args> reference emplace_front(Args&&... args);
-template <class... Args> reference emplace_back(Args&&... args);
-template <class... Args> iterator emplace(const_iterator position, Args&&... args);
+template<class... Args> reference emplace_front(Args&&... args);
+template<class... Args> reference emplace_back(Args&&... args);
+template<class... Args> iterator emplace(const_iterator position, Args&&... args);
 void push_front(const T& x);
 void push_front(T&& x);
 void push_back(const T& x);
@@ -3729,7 +3729,7 @@ Nothing unless an exception is thrown by the assignment operator of
 
 \indexlibrarymember{swap}{deque}%
 \begin{itemdecl}
-template <class T, class Allocator>
+template<class T, class Allocator>
   void swap(deque<T, Allocator>& x, deque<T, Allocator>& y)
     noexcept(noexcept(x.swap(y)));
 \end{itemdecl}
@@ -3773,7 +3773,7 @@ preceding element. For this reason, ranges that are modified, such as those supp
 
 \begin{codeblock}
 namespace std {
-  template <class T, class Allocator = allocator<T>>
+  template<class T, class Allocator = allocator<T>>
   class forward_list {
   public:
     // types
@@ -3793,7 +3793,7 @@ namespace std {
     explicit forward_list(const Allocator&);
     explicit forward_list(size_type n, const Allocator& = Allocator());
     forward_list(size_type n, const T& value, const Allocator& = Allocator());
-    template <class InputIterator>
+    template<class InputIterator>
       forward_list(InputIterator first, InputIterator last, const Allocator& = Allocator());
     forward_list(const forward_list& x);
     forward_list(forward_list&& x);
@@ -3805,7 +3805,7 @@ namespace std {
     forward_list& operator=(forward_list&& x)
       noexcept(allocator_traits<Allocator>::is_always_equal::value);
     forward_list& operator=(initializer_list<T>);
-    template <class InputIterator>
+    template<class InputIterator>
       void assign(InputIterator first, InputIterator last);
     void assign(size_type n, const T& t);
     void assign(initializer_list<T>);
@@ -3832,17 +3832,17 @@ namespace std {
     const_reference front() const;
 
     // \ref{forwardlist.modifiers}, modifiers
-    template <class... Args> reference emplace_front(Args&&... args);
+    template<class... Args> reference emplace_front(Args&&... args);
     void push_front(const T& x);
     void push_front(T&& x);
     void pop_front();
 
-    template <class... Args> iterator emplace_after(const_iterator position, Args&&... args);
+    template<class... Args> iterator emplace_after(const_iterator position, Args&&... args);
     iterator insert_after(const_iterator position, const T& x);
     iterator insert_after(const_iterator position, T&& x);
 
     iterator insert_after(const_iterator position, size_type n, const T& x);
-    template <class InputIterator>
+    template<class InputIterator>
       iterator insert_after(const_iterator position, InputIterator first, InputIterator last);
     iterator insert_after(const_iterator position, initializer_list<T> il);
 
@@ -3866,18 +3866,18 @@ namespace std {
                       const_iterator first, const_iterator last);
 
     void remove(const T& value);
-    template <class Predicate> void remove_if(Predicate pred);
+    template<class Predicate> void remove_if(Predicate pred);
 
     void unique();
-    template <class BinaryPredicate> void unique(BinaryPredicate binary_pred);
+    template<class BinaryPredicate> void unique(BinaryPredicate binary_pred);
 
     void merge(forward_list& x);
     void merge(forward_list&& x);
-    template <class Compare> void merge(forward_list& x, Compare comp);
-    template <class Compare> void merge(forward_list&& x, Compare comp);
+    template<class Compare> void merge(forward_list& x, Compare comp);
+    template<class Compare> void merge(forward_list&& x, Compare comp);
 
     void sort();
-    template <class Compare> void sort(Compare comp);
+    template<class Compare> void sort(Compare comp);
 
     void reverse() noexcept;
   };
@@ -3888,7 +3888,7 @@ namespace std {
       -> forward_list<typename iterator_traits<InputIterator>::value_type, Allocator>;
 
   // \ref{forwardlist.spec}, specialized algorithms
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     void swap(forward_list<T, Allocator>& x, forward_list<T, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 }
@@ -3951,7 +3951,7 @@ forward_list(size_type n, const T& value, const Allocator& = Allocator());
 
 \indexlibrary{\idxcode{forward_list}!constructor}%
 \begin{itemdecl}
-template <class InputIterator>
+template<class InputIterator>
   forward_list(InputIterator first, InputIterator last, const Allocator& = Allocator());
 \end{itemdecl}
 
@@ -4013,7 +4013,7 @@ exactly equal to \tcode{n}.
 
 \indexlibrarymember{emplace_front}{forward_list}%
 \begin{itemdecl}
-template <class... Args> reference emplace_front(Args&&... args);
+template<class... Args> reference emplace_front(Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4082,7 +4082,7 @@ An iterator pointing to the last inserted copy of \tcode{x} or \tcode{position} 
 
 \indexlibrarymember{insert_after}{forward_list}%
 \begin{itemdecl}
-template <class InputIterator>
+template<class InputIterator>
   iterator insert_after(const_iterator position, InputIterator first, InputIterator last);
 \end{itemdecl}
 
@@ -4117,7 +4117,7 @@ An iterator pointing to the last inserted element or \tcode{position} if \tcode{
 
 \indexlibrarymember{emplace_after}{forward_list}%
 \begin{itemdecl}
-template <class... Args>
+template<class... Args>
   iterator emplace_after(const_iterator position, Args&&... args);
 \end{itemdecl}
 
@@ -4312,7 +4312,7 @@ behave as iterators into \tcode{*this}, not into \tcode{x}.
 \indexlibrarymember{remove_if}{forward_list}%
 \begin{itemdecl}
 void remove(const T& value);
-template <class Predicate> void remove_if(Predicate pred);
+template<class Predicate> void remove_if(Predicate pred);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4337,7 +4337,7 @@ predicate.
 \indexlibrarymember{unique}{forward_list}%
 \begin{itemdecl}
 void unique();
-template <class BinaryPredicate> void unique(BinaryPredicate pred);
+template<class BinaryPredicate> void unique(BinaryPredicate pred);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4359,8 +4359,8 @@ Invalidates only the iterators and references to the erased elements.
 \begin{itemdecl}
 void merge(forward_list& x);
 void merge(forward_list&& x);
-template <class Compare> void merge(forward_list& x, Compare comp);
-template <class Compare> void merge(forward_list&& x, Compare comp);
+template<class Compare> void merge(forward_list& x, Compare comp);
+template<class Compare> void merge(forward_list&& x, Compare comp);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4391,7 +4391,7 @@ end()) + distance(x.begin(), x.end()) - 1} comparisons.
 \indexlibrarymember{sort}{forward_list}%
 \begin{itemdecl}
 void sort();
-template <class Compare> void sort(Compare comp);
+template<class Compare> void sort(Compare comp);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4425,7 +4425,7 @@ Does not affect the validity of iterators and references.
 
 \indexlibrarymember{swap}{forward_list}%
 \begin{itemdecl}
-template <class T, class Allocator>
+template<class T, class Allocator>
   void swap(forward_list<T, Allocator>& x, forward_list<T, Allocator>& y)
     noexcept(noexcept(x.swap(y)));
 \end{itemdecl}
@@ -4472,7 +4472,7 @@ or for operations where there is additional semantic information.
 
 \begin{codeblock}
 namespace std {
-  template <class T, class Allocator = allocator<T>>
+  template<class T, class Allocator = allocator<T>>
   class list {
   public:
     // types
@@ -4494,7 +4494,7 @@ namespace std {
     explicit list(const Allocator&);
     explicit list(size_type n, const Allocator& = Allocator());
     list(size_type n, const T& value, const Allocator& = Allocator());
-    template <class InputIterator>
+    template<class InputIterator>
       list(InputIterator first, InputIterator last, const Allocator& = Allocator());
     list(const list& x);
     list(list&& x);
@@ -4506,7 +4506,7 @@ namespace std {
     list& operator=(list&& x)
       noexcept(allocator_traits<Allocator>::is_always_equal::value);
     list& operator=(initializer_list<T>);
-    template <class InputIterator>
+    template<class InputIterator>
       void assign(InputIterator first, InputIterator last);
     void assign(size_type n, const T& t);
     void assign(initializer_list<T>);
@@ -4541,8 +4541,8 @@ namespace std {
     const_reference back() const;
 
     // \ref{list.modifiers}, modifiers
-    template <class... Args> reference emplace_front(Args&&... args);
-    template <class... Args> reference emplace_back(Args&&... args);
+    template<class... Args> reference emplace_front(Args&&... args);
+    template<class... Args> reference emplace_back(Args&&... args);
     void push_front(const T& x);
     void push_front(T&& x);
     void pop_front();
@@ -4550,11 +4550,11 @@ namespace std {
     void push_back(T&& x);
     void pop_back();
 
-    template <class... Args> iterator emplace(const_iterator position, Args&&... args);
+    template<class... Args> iterator emplace(const_iterator position, Args&&... args);
     iterator insert(const_iterator position, const T& x);
     iterator insert(const_iterator position, T&& x);
     iterator insert(const_iterator position, size_type n, const T& x);
-    template <class InputIterator>
+    template<class InputIterator>
       iterator insert(const_iterator position, InputIterator first, InputIterator last);
     iterator insert(const_iterator position, initializer_list<T> il);
 
@@ -4572,19 +4572,19 @@ namespace std {
     void splice(const_iterator position, list&& x, const_iterator first, const_iterator last);
 
     void remove(const T& value);
-    template <class Predicate> void remove_if(Predicate pred);
+    template<class Predicate> void remove_if(Predicate pred);
 
     void unique();
-    template <class BinaryPredicate>
+    template<class BinaryPredicate>
       void unique(BinaryPredicate binary_pred);
 
     void merge(list& x);
     void merge(list&& x);
-    template <class Compare> void merge(list& x, Compare comp);
-    template <class Compare> void merge(list&& x, Compare comp);
+    template<class Compare> void merge(list& x, Compare comp);
+    template<class Compare> void merge(list&& x, Compare comp);
 
     void sort();
-    template <class Compare> void sort(Compare comp);
+    template<class Compare> void sort(Compare comp);
 
     void reverse() noexcept;
   };
@@ -4595,7 +4595,7 @@ namespace std {
       -> list<typename iterator_traits<InputIterator>::value_type, Allocator>;
 
   // \ref{list.special}, specialized algorithms
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     void swap(list<T, Allocator>& x, list<T, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 }
@@ -4671,7 +4671,7 @@ Linear in
 
 \indexlibrary{\idxcode{list}!constructor}%
 \begin{itemdecl}
-template <class InputIterator>
+template<class InputIterator>
   list(InputIterator first, InputIterator last, const Allocator& = Allocator());
 \end{itemdecl}
 
@@ -4748,14 +4748,14 @@ else
 iterator insert(const_iterator position, const T& x);
 iterator insert(const_iterator position, T&& x);
 iterator insert(const_iterator position, size_type n, const T& x);
-template <class InputIterator>
+template<class InputIterator>
   iterator insert(const_iterator position, InputIterator first,
                   InputIterator last);
 iterator insert(const_iterator position, initializer_list<T>);
 
-template <class... Args> reference emplace_front(Args&&... args);
-template <class... Args> reference emplace_back(Args&&... args);
-template <class... Args> iterator emplace(const_iterator position, Args&&... args);
+template<class... Args> reference emplace_front(Args&&... args);
+template<class... Args> reference emplace_back(Args&&... args);
+template<class... Args> iterator emplace(const_iterator position, Args&&... args);
 void push_front(const T& x);
 void push_front(T&& x);
 void push_back(const T& x);
@@ -4960,7 +4960,7 @@ otherwise, linear time.
 \indexlibrary{\idxcode{remove}!\idxcode{list}}%
 \begin{itemdecl}
 void remove(const T& value);
-template <class Predicate> void remove_if(Predicate pred);
+template<class Predicate> void remove_if(Predicate pred);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4990,7 +4990,7 @@ applications of the corresponding predicate.
 \indexlibrary{\idxcode{unique}!\idxcode{list}}%
 \begin{itemdecl}
 void unique();
-template <class BinaryPredicate> void unique(BinaryPredicate binary_pred);
+template<class BinaryPredicate> void unique(BinaryPredicate binary_pred);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5024,8 +5024,8 @@ otherwise no applications of the predicate.
 \begin{itemdecl}
 void merge(list& x);
 void merge(list&& x);
-template <class Compare> void merge(list& x, Compare comp);
-template <class Compare> void merge(list&& x, Compare comp);
+template<class Compare> void merge(list& x, Compare comp);
+template<class Compare> void merge(list&& x, Compare comp);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5083,7 +5083,7 @@ Linear time.
 \indexlibrary{\idxcode{sort}!\idxcode{list}}%
 \begin{itemdecl}
 void sort();
-template <class Compare> void sort(Compare comp);
+template<class Compare> void sort(Compare comp);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5109,7 +5109,7 @@ comparisons, where
 
 \indexlibrarymember{swap}{list}%
 \begin{itemdecl}
-template <class T, class Allocator>
+template<class T, class Allocator>
   void swap(list<T, Allocator>& x, list<T, Allocator>& y)
     noexcept(noexcept(x.swap(y)));
 \end{itemdecl}
@@ -5150,7 +5150,7 @@ additional semantic information.
 
 \begin{codeblock}
 namespace std {
-  template <class T, class Allocator = allocator<T>>
+  template<class T, class Allocator = allocator<T>>
   class vector {
   public:
     // types
@@ -5172,7 +5172,7 @@ namespace std {
     explicit vector(const Allocator&) noexcept;
     explicit vector(size_type n, const Allocator& = Allocator());
     vector(size_type n, const T& value, const Allocator& = Allocator());
-    template <class InputIterator>
+    template<class InputIterator>
       vector(InputIterator first, InputIterator last, const Allocator& = Allocator());
     vector(const vector& x);
     vector(vector&&) noexcept;
@@ -5185,7 +5185,7 @@ namespace std {
       noexcept(allocator_traits<Allocator>::propagate_on_container_move_assignment::value ||
                allocator_traits<Allocator>::is_always_equal::value);
     vector& operator=(initializer_list<T>);
-    template <class InputIterator>
+    template<class InputIterator>
       void assign(InputIterator first, InputIterator last);
     void assign(size_type n, const T& u);
     void assign(initializer_list<T>);
@@ -5231,16 +5231,16 @@ namespace std {
     const T* data() const noexcept;
 
     // \ref{vector.modifiers}, modifiers
-    template <class... Args> reference emplace_back(Args&&... args);
+    template<class... Args> reference emplace_back(Args&&... args);
     void push_back(const T& x);
     void push_back(T&& x);
     void pop_back();
 
-    template <class... Args> iterator emplace(const_iterator position, Args&&... args);
+    template<class... Args> iterator emplace(const_iterator position, Args&&... args);
     iterator insert(const_iterator position, const T& x);
     iterator insert(const_iterator position, T&& x);
     iterator insert(const_iterator position, size_type n, const T& x);
-    template <class InputIterator>
+    template<class InputIterator>
       iterator insert(const_iterator position, InputIterator first, InputIterator last);
     iterator insert(const_iterator position, initializer_list<T> il);
     iterator erase(const_iterator position);
@@ -5257,7 +5257,7 @@ namespace std {
       -> vector<typename iterator_traits<InputIterator>::value_type, Allocator>;
 
   // \ref{vector.special}, specialized algorithms
-  template <class T, class Allocator>
+  template<class T, class Allocator>
     void swap(vector<T, Allocator>& x, vector<T, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 }
@@ -5326,7 +5326,7 @@ copies of \tcode{value}, using the specified allocator.
 
 \indexlibrary{\idxcode{vector}!constructor}
 \begin{itemdecl}
-template <class InputIterator>
+template<class InputIterator>
   vector(InputIterator first, InputIterator last,
          const Allocator& = Allocator());
 \end{itemdecl}
@@ -5536,12 +5536,12 @@ Constant time.
 iterator insert(const_iterator position, const T& x);
 iterator insert(const_iterator position, T&& x);
 iterator insert(const_iterator position, size_type n, const T& x);
-template <class InputIterator>
+template<class InputIterator>
   iterator insert(const_iterator position, InputIterator first, InputIterator last);
 iterator insert(const_iterator position, initializer_list<T>);
 
-template <class... Args> reference emplace_back(Args&&... args);
-template <class... Args> iterator emplace(const_iterator position, Args&&... args);
+template<class... Args> reference emplace_back(Args&&... args);
+template<class... Args> iterator emplace(const_iterator position, Args&&... args);
 void push_back(const T& x);
 void push_back(T&& x);
 \end{itemdecl}
@@ -5600,7 +5600,7 @@ assignment operator or move assignment operator of
 
 \indexlibrarymember{swap}{vector}%
 \begin{itemdecl}
-template <class T, class Allocator>
+template<class T, class Allocator>
   void swap(vector<T, Allocator>& x, vector<T, Allocator>& y)
     noexcept(noexcept(x.swap(y)));
 \end{itemdecl}
@@ -5621,7 +5621,7 @@ elements is provided:
 
 \begin{codeblock}
 namespace std {
-  template <class Allocator>
+  template<class Allocator>
   class vector<bool, Allocator> {
   public:
     // types
@@ -5654,7 +5654,7 @@ namespace std {
     explicit vector(const Allocator&);
     explicit vector(size_type n, const Allocator& = Allocator());
     vector(size_type n, const bool& value, const Allocator& = Allocator());
-    template <class InputIterator>
+    template<class InputIterator>
       vector(InputIterator first, InputIterator last, const Allocator& = Allocator());
     vector(const vector& x);
     vector(vector&& x);
@@ -5665,7 +5665,7 @@ namespace std {
     vector& operator=(const vector& x);
     vector& operator=(vector&& x);
     vector& operator=(initializer_list<bool>);
-    template <class InputIterator>
+    template<class InputIterator>
       void assign(InputIterator first, InputIterator last);
     void assign(size_type n, const bool& t);
     void assign(initializer_list<bool>);
@@ -5706,13 +5706,13 @@ namespace std {
     const_reference back() const;
 
     // modifiers
-    template <class... Args> reference emplace_back(Args&&... args);
+    template<class... Args> reference emplace_back(Args&&... args);
     void push_back(const bool& x);
     void pop_back();
-    template <class... Args> iterator emplace(const_iterator position, Args&&... args);
+    template<class... Args> iterator emplace(const_iterator position, Args&&... args);
     iterator insert(const_iterator position, const bool& x);
     iterator insert(const_iterator position, size_type n, const bool& x);
-    template <class InputIterator>
+    template<class InputIterator>
       iterator insert(const_iterator position, InputIterator first, InputIterator last);
     iterator insert(const_iterator position, initializer_list<bool> il);
 
@@ -5775,7 +5775,7 @@ y = b;
 \end{itemdescr}
 
 \begin{itemdecl}
-template <class Allocator> struct hash<vector<bool, Allocator>>;
+template<class Allocator> struct hash<vector<bool, Allocator>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5816,69 +5816,69 @@ template<class InputIterator>
 
 namespace std {
   // \ref{map}, class template \tcode{map}
-  template <class Key, class T, class Compare = less<Key>,
-            class Allocator = allocator<pair<const Key, T>>>
+  template<class Key, class T, class Compare = less<Key>,
+           class Allocator = allocator<pair<const Key, T>>>
     class map;
 
-  template <class Key, class T, class Compare, class Allocator>
+  template<class Key, class T, class Compare, class Allocator>
     bool operator==(const map<Key, T, Compare, Allocator>& x,
                     const map<Key, T, Compare, Allocator>& y);
-  template <class Key, class T, class Compare, class Allocator>
+  template<class Key, class T, class Compare, class Allocator>
     bool operator< (const map<Key, T, Compare, Allocator>& x,
                     const map<Key, T, Compare, Allocator>& y);
-  template <class Key, class T, class Compare, class Allocator>
+  template<class Key, class T, class Compare, class Allocator>
     bool operator!=(const map<Key, T, Compare, Allocator>& x,
                     const map<Key, T, Compare, Allocator>& y);
-  template <class Key, class T, class Compare, class Allocator>
+  template<class Key, class T, class Compare, class Allocator>
     bool operator> (const map<Key, T, Compare, Allocator>& x,
                     const map<Key, T, Compare, Allocator>& y);
-  template <class Key, class T, class Compare, class Allocator>
+  template<class Key, class T, class Compare, class Allocator>
     bool operator>=(const map<Key, T, Compare, Allocator>& x,
                     const map<Key, T, Compare, Allocator>& y);
-  template <class Key, class T, class Compare, class Allocator>
+  template<class Key, class T, class Compare, class Allocator>
     bool operator<=(const map<Key, T, Compare, Allocator>& x,
                     const map<Key, T, Compare, Allocator>& y);
 
-  template <class Key, class T, class Compare, class Allocator>
+  template<class Key, class T, class Compare, class Allocator>
     void swap(map<Key, T, Compare, Allocator>& x,
               map<Key, T, Compare, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 
   // \ref{multimap}, class template \tcode{multimap}
-  template <class Key, class T, class Compare = less<Key>,
-            class Allocator = allocator<pair<const Key, T>>>
+  template<class Key, class T, class Compare = less<Key>,
+           class Allocator = allocator<pair<const Key, T>>>
     class multimap;
 
-  template <class Key, class T, class Compare, class Allocator>
+  template<class Key, class T, class Compare, class Allocator>
     bool operator==(const multimap<Key, T, Compare, Allocator>& x,
                     const multimap<Key, T, Compare, Allocator>& y);
-  template <class Key, class T, class Compare, class Allocator>
+  template<class Key, class T, class Compare, class Allocator>
     bool operator< (const multimap<Key, T, Compare, Allocator>& x,
                     const multimap<Key, T, Compare, Allocator>& y);
-  template <class Key, class T, class Compare, class Allocator>
+  template<class Key, class T, class Compare, class Allocator>
     bool operator!=(const multimap<Key, T, Compare, Allocator>& x,
                     const multimap<Key, T, Compare, Allocator>& y);
-  template <class Key, class T, class Compare, class Allocator>
+  template<class Key, class T, class Compare, class Allocator>
     bool operator> (const multimap<Key, T, Compare, Allocator>& x,
                     const multimap<Key, T, Compare, Allocator>& y);
-  template <class Key, class T, class Compare, class Allocator>
+  template<class Key, class T, class Compare, class Allocator>
     bool operator>=(const multimap<Key, T, Compare, Allocator>& x,
                     const multimap<Key, T, Compare, Allocator>& y);
-  template <class Key, class T, class Compare, class Allocator>
+  template<class Key, class T, class Compare, class Allocator>
     bool operator<=(const multimap<Key, T, Compare, Allocator>& x,
                     const multimap<Key, T, Compare, Allocator>& y);
 
-  template <class Key, class T, class Compare, class Allocator>
+  template<class Key, class T, class Compare, class Allocator>
     void swap(multimap<Key, T, Compare, Allocator>& x,
               multimap<Key, T, Compare, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 
   namespace pmr {
-    template <class Key, class T, class Compare = less<Key>>
+    template<class Key, class T, class Compare = less<Key>>
       using map = std::map<Key, T, Compare,
                            polymorphic_allocator<pair<const Key, T>>>;
 
-    template <class Key, class T, class Compare = less<Key>>
+    template<class Key, class T, class Compare = less<Key>>
       using multimap = std::multimap<Key, T, Compare,
                                      polymorphic_allocator<pair<const Key, T>>>;
   }
@@ -5894,66 +5894,66 @@ namespace std {
 
 namespace std {
   // \ref{set}, class template \tcode{set}
-  template <class Key, class Compare = less<Key>, class Allocator = allocator<Key>>
+  template<class Key, class Compare = less<Key>, class Allocator = allocator<Key>>
     class set;
 
-  template <class Key, class Compare, class Allocator>
+  template<class Key, class Compare, class Allocator>
     bool operator==(const set<Key, Compare, Allocator>& x,
                     const set<Key, Compare, Allocator>& y);
-  template <class Key, class Compare, class Allocator>
+  template<class Key, class Compare, class Allocator>
     bool operator< (const set<Key, Compare, Allocator>& x,
                     const set<Key, Compare, Allocator>& y);
-  template <class Key, class Compare, class Allocator>
+  template<class Key, class Compare, class Allocator>
     bool operator!=(const set<Key, Compare, Allocator>& x,
                     const set<Key, Compare, Allocator>& y);
-  template <class Key, class Compare, class Allocator>
+  template<class Key, class Compare, class Allocator>
     bool operator> (const set<Key, Compare, Allocator>& x,
                     const set<Key, Compare, Allocator>& y);
-  template <class Key, class Compare, class Allocator>
+  template<class Key, class Compare, class Allocator>
     bool operator>=(const set<Key, Compare, Allocator>& x,
                     const set<Key, Compare, Allocator>& y);
-  template <class Key, class Compare, class Allocator>
+  template<class Key, class Compare, class Allocator>
     bool operator<=(const set<Key, Compare, Allocator>& x,
                     const set<Key, Compare, Allocator>& y);
 
-  template <class Key, class Compare, class Allocator>
+  template<class Key, class Compare, class Allocator>
     void swap(set<Key, Compare, Allocator>& x,
               set<Key, Compare, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 
   // \ref{multiset}, class template \tcode{multiset}
-  template <class Key, class Compare = less<Key>, class Allocator = allocator<Key>>
+  template<class Key, class Compare = less<Key>, class Allocator = allocator<Key>>
     class multiset;
 
-  template <class Key, class Compare, class Allocator>
+  template<class Key, class Compare, class Allocator>
     bool operator==(const multiset<Key, Compare, Allocator>& x,
                     const multiset<Key, Compare, Allocator>& y);
-  template <class Key, class Compare, class Allocator>
+  template<class Key, class Compare, class Allocator>
     bool operator< (const multiset<Key, Compare, Allocator>& x,
                     const multiset<Key, Compare, Allocator>& y);
-  template <class Key, class Compare, class Allocator>
+  template<class Key, class Compare, class Allocator>
     bool operator!=(const multiset<Key, Compare, Allocator>& x,
                     const multiset<Key, Compare, Allocator>& y);
-  template <class Key, class Compare, class Allocator>
+  template<class Key, class Compare, class Allocator>
     bool operator> (const multiset<Key, Compare, Allocator>& x,
                     const multiset<Key, Compare, Allocator>& y);
-  template <class Key, class Compare, class Allocator>
+  template<class Key, class Compare, class Allocator>
     bool operator>=(const multiset<Key, Compare, Allocator>& x,
                     const multiset<Key, Compare, Allocator>& y);
-  template <class Key, class Compare, class Allocator>
+  template<class Key, class Compare, class Allocator>
     bool operator<=(const multiset<Key, Compare, Allocator>& x,
                     const multiset<Key, Compare, Allocator>& y);
 
-  template <class Key, class Compare, class Allocator>
+  template<class Key, class Compare, class Allocator>
     void swap(multiset<Key, Compare, Allocator>& x,
               multiset<Key, Compare, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 
   namespace pmr {
-    template <class Key, class Compare = less<Key>>
+    template<class Key, class Compare = less<Key>>
       using set = std::set<Key, Compare, polymorphic_allocator<Key>>;
 
-    template <class Key, class Compare = less<Key>>
+    template<class Key, class Compare = less<Key>>
       using multiset = std::multiset<Key, Compare, polymorphic_allocator<Key>>;
   }
 }
@@ -6004,8 +6004,8 @@ or for operations where there is additional semantic information.
 
 \begin{codeblock}
 namespace std {
-  template <class Key, class T, class Compare = less<Key>,
-            class Allocator = allocator<pair<const Key, T>>>
+  template<class Key, class T, class Compare = less<Key>,
+           class Allocator = allocator<pair<const Key, T>>>
   class map {
   public:
     // types
@@ -6041,7 +6041,7 @@ namespace std {
     // \ref{map.cons}, construct/copy/destroy
     map() : map(Compare()) { }
     explicit map(const Compare& comp, const Allocator& = Allocator());
-    template <class InputIterator>
+    template<class InputIterator>
       map(InputIterator first, InputIterator last,
           const Compare& comp = Compare(), const Allocator& = Allocator());
     map(const map& x);
@@ -6052,7 +6052,7 @@ namespace std {
     map(initializer_list<value_type>,
       const Compare& = Compare(),
       const Allocator& = Allocator());
-    template <class InputIterator>
+    template<class InputIterator>
       map(InputIterator first, InputIterator last, const Allocator& a)
         : map(first, last, Compare(), a) { }
     map(initializer_list<value_type> il, const Allocator& a)
@@ -6093,16 +6093,16 @@ namespace std {
     const T& at(const key_type& x) const;
 
     // \ref{map.modifiers}, modifiers
-    template <class... Args> pair<iterator, bool> emplace(Args&&... args);
-    template <class... Args> iterator emplace_hint(const_iterator position, Args&&... args);
+    template<class... Args> pair<iterator, bool> emplace(Args&&... args);
+    template<class... Args> iterator emplace_hint(const_iterator position, Args&&... args);
     pair<iterator, bool> insert(const value_type& x);
     pair<iterator, bool> insert(value_type&& x);
-    template <class P> pair<iterator, bool> insert(P&& x);
+    template<class P> pair<iterator, bool> insert(P&& x);
     iterator insert(const_iterator position, const value_type& x);
     iterator insert(const_iterator position, value_type&& x);
-    template <class P>
+    template<class P>
       iterator insert(const_iterator position, P&&);
-    template <class InputIterator>
+    template<class InputIterator>
       void insert(InputIterator first, InputIterator last);
     void insert(initializer_list<value_type>);
 
@@ -6111,21 +6111,21 @@ namespace std {
     insert_return_type insert(node_type&& nh);
     iterator           insert(const_iterator hint, node_type&& nh);
 
-    template <class... Args>
+    template<class... Args>
       pair<iterator, bool> try_emplace(const key_type& k, Args&&... args);
-    template <class... Args>
+    template<class... Args>
       pair<iterator, bool> try_emplace(key_type&& k, Args&&... args);
-    template <class... Args>
+    template<class... Args>
       iterator try_emplace(const_iterator hint, const key_type& k, Args&&... args);
-    template <class... Args>
+    template<class... Args>
       iterator try_emplace(const_iterator hint, key_type&& k, Args&&... args);
-    template <class M>
+    template<class M>
       pair<iterator, bool> insert_or_assign(const key_type& k, M&& obj);
-    template <class M>
+    template<class M>
       pair<iterator, bool> insert_or_assign(key_type&& k, M&& obj);
-    template <class M>
+    template<class M>
       iterator insert_or_assign(const_iterator hint, const key_type& k, M&& obj);
-    template <class M>
+    template<class M>
       iterator insert_or_assign(const_iterator hint, key_type&& k, M&& obj);
 
     iterator  erase(iterator position);
@@ -6153,27 +6153,27 @@ namespace std {
     // map operations
     iterator       find(const key_type& x);
     const_iterator find(const key_type& x) const;
-    template <class K> iterator       find(const K& x);
-    template <class K> const_iterator find(const K& x) const;
+    template<class K> iterator       find(const K& x);
+    template<class K> const_iterator find(const K& x) const;
 
     size_type      count(const key_type& x) const;
-    template <class K> size_type count(const K& x) const;
+    template<class K> size_type count(const K& x) const;
 
     iterator       lower_bound(const key_type& x);
     const_iterator lower_bound(const key_type& x) const;
-    template <class K> iterator       lower_bound(const K& x);
-    template <class K> const_iterator lower_bound(const K& x) const;
+    template<class K> iterator       lower_bound(const K& x);
+    template<class K> const_iterator lower_bound(const K& x) const;
 
     iterator       upper_bound(const key_type& x);
     const_iterator upper_bound(const key_type& x) const;
-    template <class K> iterator       upper_bound(const K& x);
-    template <class K> const_iterator upper_bound(const K& x) const;
+    template<class K> iterator       upper_bound(const K& x);
+    template<class K> const_iterator upper_bound(const K& x) const;
 
     pair<iterator, iterator>               equal_range(const key_type& x);
     pair<const_iterator, const_iterator>   equal_range(const key_type& x) const;
-    template <class K>
+    template<class K>
       pair<iterator, iterator>             equal_range(const K& x);
-    template <class K>
+    template<class K>
       pair<const_iterator, const_iterator> equal_range(const K& x) const;
   };
 
@@ -6187,7 +6187,7 @@ namespace std {
     map(initializer_list<pair<const Key, T>>, Compare = Compare(), Allocator = Allocator())
       -> map<Key, T, Compare, Allocator>;
 
-  template <class InputIterator, class Allocator>
+  template<class InputIterator, class Allocator>
     map(InputIterator, InputIterator, Allocator)
       -> map<iter_key_t<InputIterator>, iter_val_t<InputIterator>,
              less<iter_key_t<InputIterator>>, Allocator>;
@@ -6196,7 +6196,7 @@ namespace std {
     map(initializer_list<pair<const Key, T>>, Allocator) -> map<Key, T, less<Key>, Allocator>;
 
   // \ref{map.special}, specialized algorithms
-  template <class Key, class T, class Compare, class Allocator>
+  template<class Key, class T, class Compare, class Allocator>
     void swap(map<Key, T, Compare, Allocator>& x,
               map<Key, T, Compare, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
@@ -6227,7 +6227,7 @@ Constant.
 
 \indexlibrary{\idxcode{map}!constructor}%
 \begin{itemdecl}
-template <class InputIterator>
+template<class InputIterator>
   map(InputIterator first, InputIterator last,
       const Compare& comp = Compare(), const Allocator& = Allocator());
 \end{itemdecl}
@@ -6298,9 +6298,9 @@ no such element is present.
 
 \indexlibrarymember{insert}{map}%
 \begin{itemdecl}
-template <class P>
+template<class P>
   pair<iterator, bool> insert(P&& x);
-template <class P>
+template<class P>
   iterator insert(const_iterator position, P&& x);
 \end{itemdecl}
 
@@ -6320,9 +6320,9 @@ unless \tcode{is_constructible_v<value_type, P\&\&>} is
 
 \indexlibrarymember{try_emplace}{map}%
 \begin{itemdecl}
-template <class... Args>
+template<class... Args>
   pair<iterator, bool> try_emplace(const key_type& k, Args&&... args);
-template <class... Args>
+template<class... Args>
   iterator try_emplace(const_iterator hint, const key_type& k, Args&&... args);
 \end{itemdecl}
 
@@ -6358,9 +6358,9 @@ respectively.
 
 \indexlibrarymember{try_emplace}{map}%
 \begin{itemdecl}
-template <class... Args>
+template<class... Args>
   pair<iterator, bool> try_emplace(key_type&& k, Args&&... args);
-template <class... Args>
+template<class... Args>
   iterator try_emplace(const_iterator hint, key_type&& k, Args&&... args);
 \end{itemdecl}
 
@@ -6396,9 +6396,9 @@ respectively.
 
 \indexlibrarymember{insert_or_assign}{map}%
 \begin{itemdecl}
-template <class M>
+template<class M>
   pair<iterator, bool> insert_or_assign(const key_type& k, M&& obj);
-template <class M>
+template<class M>
   iterator insert_or_assign(const_iterator hint, const key_type& k, M&& obj);
 \end{itemdecl}
 
@@ -6433,9 +6433,9 @@ respectively.
 
 \indexlibrarymember{insert_or_assign}{map}%
 \begin{itemdecl}
-template <class M>
+template<class M>
   pair<iterator, bool> insert_or_assign(key_type&& k, M&& obj);
-template <class M>
+template<class M>
   iterator insert_or_assign(const_iterator hint, key_type&& k, M&& obj);
 \end{itemdecl}
 
@@ -6472,7 +6472,7 @@ respectively.
 
 \indexlibrarymember{swap}{map}%
 \begin{itemdecl}
-template <class Key, class T, class Compare, class Allocator>
+template<class Key, class T, class Compare, class Allocator>
   void swap(map<Key, T, Compare, Allocator>& x,
             map<Key, T, Compare, Allocator>& y)
     noexcept(noexcept(x.swap(y)));
@@ -6536,8 +6536,8 @@ or for operations where there is additional semantic information.
 
 \begin{codeblock}
 namespace std {
-  template <class Key, class T, class Compare = less<Key>,
-            class Allocator = allocator<pair<const Key, T>>>
+  template<class Key, class T, class Compare = less<Key>,
+           class Allocator = allocator<pair<const Key, T>>>
   class multimap {
   public:
     // types
@@ -6572,7 +6572,7 @@ namespace std {
     // \ref{multimap.cons}, construct/copy/destroy
     multimap() : multimap(Compare()) { }
     explicit multimap(const Compare& comp, const Allocator& = Allocator());
-    template <class InputIterator>
+    template<class InputIterator>
       multimap(InputIterator first, InputIterator last,
                const Compare& comp = Compare(),
                const Allocator& = Allocator());
@@ -6584,7 +6584,7 @@ namespace std {
     multimap(initializer_list<value_type>,
       const Compare& = Compare(),
       const Allocator& = Allocator());
-    template <class InputIterator>
+    template<class InputIterator>
       multimap(InputIterator first, InputIterator last, const Allocator& a)
         : multimap(first, last, Compare(), a) { }
     multimap(initializer_list<value_type> il, const Allocator& a)
@@ -6619,15 +6619,15 @@ namespace std {
     size_type max_size() const noexcept;
 
     // \ref{multimap.modifiers}, modifiers
-    template <class... Args> iterator emplace(Args&&... args);
-    template <class... Args> iterator emplace_hint(const_iterator position, Args&&... args);
+    template<class... Args> iterator emplace(Args&&... args);
+    template<class... Args> iterator emplace_hint(const_iterator position, Args&&... args);
     iterator insert(const value_type& x);
     iterator insert(value_type&& x);
-    template <class P> iterator insert(P&& x);
+    template<class P> iterator insert(P&& x);
     iterator insert(const_iterator position, const value_type& x);
     iterator insert(const_iterator position, value_type&& x);
-    template <class P> iterator insert(const_iterator position, P&& x);
-    template <class InputIterator>
+    template<class P> iterator insert(const_iterator position, P&& x);
+    template<class InputIterator>
       void insert(InputIterator first, InputIterator last);
     void insert(initializer_list<value_type>);
 
@@ -6661,27 +6661,27 @@ namespace std {
     // map operations
     iterator       find(const key_type& x);
     const_iterator find(const key_type& x) const;
-    template <class K> iterator       find(const K& x);
-    template <class K> const_iterator find(const K& x) const;
+    template<class K> iterator       find(const K& x);
+    template<class K> const_iterator find(const K& x) const;
 
     size_type      count(const key_type& x) const;
-    template <class K> size_type count(const K& x) const;
+    template<class K> size_type count(const K& x) const;
 
     iterator       lower_bound(const key_type& x);
     const_iterator lower_bound(const key_type& x) const;
-    template <class K> iterator       lower_bound(const K& x);
-    template <class K> const_iterator lower_bound(const K& x) const;
+    template<class K> iterator       lower_bound(const K& x);
+    template<class K> const_iterator lower_bound(const K& x) const;
 
     iterator       upper_bound(const key_type& x);
     const_iterator upper_bound(const key_type& x) const;
-    template <class K> iterator       upper_bound(const K& x);
-    template <class K> const_iterator upper_bound(const K& x) const;
+    template<class K> iterator       upper_bound(const K& x);
+    template<class K> const_iterator upper_bound(const K& x) const;
 
     pair<iterator, iterator>               equal_range(const key_type& x);
     pair<const_iterator, const_iterator>   equal_range(const key_type& x) const;
-    template <class K>
+    template<class K>
       pair<iterator, iterator>             equal_range(const K& x);
-    template <class K>
+    template<class K>
       pair<const_iterator, const_iterator> equal_range(const K& x) const;
   };
 
@@ -6705,7 +6705,7 @@ namespace std {
       -> multimap<Key, T, less<Key>, Allocator>;
 
   // \ref{multimap.special}, specialized algorithms
-  template <class Key, class T, class Compare, class Allocator>
+  template<class Key, class T, class Compare, class Allocator>
     void swap(multimap<Key, T, Compare, Allocator>& x,
               multimap<Key, T, Compare, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
@@ -6735,7 +6735,7 @@ Constant.
 
 \indexlibrary{\idxcode{multimap}!constructor}%
 \begin{itemdecl}
-template <class InputIterator>
+template<class InputIterator>
   multimap(InputIterator first, InputIterator last,
            const Compare& comp = Compare(),
            const Allocator& = Allocator());
@@ -6764,8 +6764,8 @@ where $N$ is
 
 \indexlibrarymember{insert}{multimap}%
 \begin{itemdecl}
-template <class P> iterator insert(P&& x);
-template <class P> iterator insert(const_iterator position, P&& x);
+template<class P> iterator insert(P&& x);
+template<class P> iterator insert(const_iterator position, P&& x);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6786,7 +6786,7 @@ unless \tcode{is_constructible_v<value_type, P\&\&>} is
 
 \indexlibrarymember{swap}{multimap}%
 \begin{itemdecl}
-template <class Key, class T, class Compare, class Allocator>
+template<class Key, class T, class Compare, class Allocator>
   void swap(multimap<Key, T, Compare, Allocator>& x,
             multimap<Key, T, Compare, Allocator>& y)
     noexcept(noexcept(x.swap(y)));
@@ -6844,8 +6844,8 @@ and for operations where there is additional semantic information.
 
 \begin{codeblock}
 namespace std {
-  template <class Key, class Compare = less<Key>,
-            class Allocator = allocator<Key>>
+  template<class Key, class Compare = less<Key>,
+           class Allocator = allocator<Key>>
   class set {
   public:
     // types
@@ -6870,7 +6870,7 @@ namespace std {
     // \ref{set.cons}, construct/copy/destroy
     set() : set(Compare()) { }
     explicit set(const Compare& comp, const Allocator& = Allocator());
-    template <class InputIterator>
+    template<class InputIterator>
       set(InputIterator first, InputIterator last,
           const Compare& comp = Compare(), const Allocator& = Allocator());
     set(const set& x);
@@ -6880,7 +6880,7 @@ namespace std {
     set(set&&, const Allocator&);
     set(initializer_list<value_type>, const Compare& = Compare(),
         const Allocator& = Allocator());
-    template <class InputIterator>
+    template<class InputIterator>
       set(InputIterator first, InputIterator last, const Allocator& a)
         : set(first, last, Compare(), a) { }
     set(initializer_list<value_type> il, const Allocator& a)
@@ -6915,13 +6915,13 @@ namespace std {
     size_type max_size() const noexcept;
 
     // modifiers
-    template <class... Args> pair<iterator, bool> emplace(Args&&... args);
-    template <class... Args> iterator emplace_hint(const_iterator position, Args&&... args);
+    template<class... Args> pair<iterator, bool> emplace(Args&&... args);
+    template<class... Args> iterator emplace_hint(const_iterator position, Args&&... args);
     pair<iterator,bool> insert(const value_type& x);
     pair<iterator,bool> insert(value_type&& x);
     iterator insert(const_iterator position, const value_type& x);
     iterator insert(const_iterator position, value_type&& x);
-    template <class InputIterator>
+    template<class InputIterator>
       void insert(InputIterator first, InputIterator last);
     void insert(initializer_list<value_type>);
 
@@ -6955,27 +6955,27 @@ namespace std {
     // set operations
     iterator       find(const key_type& x);
     const_iterator find(const key_type& x) const;
-    template <class K> iterator       find(const K& x);
-    template <class K> const_iterator find(const K& x) const;
+    template<class K> iterator       find(const K& x);
+    template<class K> const_iterator find(const K& x) const;
 
     size_type      count(const key_type& x) const;
-    template <class K> size_type count(const K& x) const;
+    template<class K> size_type count(const K& x) const;
 
     iterator       lower_bound(const key_type& x);
     const_iterator lower_bound(const key_type& x) const;
-    template <class K> iterator       lower_bound(const K& x);
-    template <class K> const_iterator lower_bound(const K& x) const;
+    template<class K> iterator       lower_bound(const K& x);
+    template<class K> const_iterator lower_bound(const K& x) const;
 
     iterator       upper_bound(const key_type& x);
     const_iterator upper_bound(const key_type& x) const;
-    template <class K> iterator       upper_bound(const K& x);
-    template <class K> const_iterator upper_bound(const K& x) const;
+    template<class K> iterator       upper_bound(const K& x);
+    template<class K> const_iterator upper_bound(const K& x) const;
 
     pair<iterator, iterator>               equal_range(const key_type& x);
     pair<const_iterator, const_iterator>   equal_range(const key_type& x) const;
-    template <class K>
+    template<class K>
       pair<iterator, iterator>             equal_range(const K& x);
-    template <class K>
+    template<class K>
       pair<const_iterator, const_iterator> equal_range(const K& x) const;
   };
 
@@ -6999,7 +6999,7 @@ namespace std {
     set(initializer_list<Key>, Allocator) -> set<Key, less<Key>, Allocator>;
 
   // \ref{set.special}, specialized algorithms
-  template <class Key, class Compare, class Allocator>
+  template<class Key, class Compare, class Allocator>
     void swap(set<Key, Compare, Allocator>& x,
               set<Key, Compare, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
@@ -7027,7 +7027,7 @@ Constant.
 
 \indexlibrary{\idxcode{set}!constructor}%
 \begin{itemdecl}
-template <class InputIterator>
+template<class InputIterator>
   set(InputIterator first, InputIterator last,
       const Compare& comp = Compare(), const Allocator& = Allocator());
 \end{itemdecl}
@@ -7055,7 +7055,7 @@ where $N$ is
 
 \indexlibrarymember{swap}{set}%
 \begin{itemdecl}
-template <class Key, class Compare, class Allocator>
+template<class Key, class Compare, class Allocator>
   void swap(set<Key, Compare, Allocator>& x,
             set<Key, Compare, Allocator>& y)
     noexcept(noexcept(x.swap(y)));
@@ -7112,8 +7112,8 @@ and for operations where there is additional semantic information.
 
 \begin{codeblock}
 namespace std {
-  template <class Key, class Compare = less<Key>,
-            class Allocator = allocator<Key>>
+  template<class Key, class Compare = less<Key>,
+           class Allocator = allocator<Key>>
   class multiset {
   public:
     // types
@@ -7137,7 +7137,7 @@ namespace std {
     // \ref{multiset.cons}, construct/copy/destroy
     multiset() : multiset(Compare()) { }
     explicit multiset(const Compare& comp, const Allocator& = Allocator());
-    template <class InputIterator>
+    template<class InputIterator>
       multiset(InputIterator first, InputIterator last,
                const Compare& comp = Compare(), const Allocator& = Allocator());
     multiset(const multiset& x);
@@ -7147,7 +7147,7 @@ namespace std {
     multiset(multiset&&, const Allocator&);
     multiset(initializer_list<value_type>, const Compare& = Compare(),
              const Allocator& = Allocator());
-    template <class InputIterator>
+    template<class InputIterator>
       multiset(InputIterator first, InputIterator last, const Allocator& a)
         : multiset(first, last, Compare(), a) { }
     multiset(initializer_list<value_type> il, const Allocator& a)
@@ -7182,13 +7182,13 @@ namespace std {
     size_type max_size() const noexcept;
 
     // modifiers
-    template <class... Args> iterator emplace(Args&&... args);
-    template <class... Args> iterator emplace_hint(const_iterator position, Args&&... args);
+    template<class... Args> iterator emplace(Args&&... args);
+    template<class... Args> iterator emplace_hint(const_iterator position, Args&&... args);
     iterator insert(const value_type& x);
     iterator insert(value_type&& x);
     iterator insert(const_iterator position, const value_type& x);
     iterator insert(const_iterator position, value_type&& x);
-    template <class InputIterator>
+    template<class InputIterator>
       void insert(InputIterator first, InputIterator last);
     void insert(initializer_list<value_type>);
 
@@ -7222,27 +7222,27 @@ namespace std {
     // set operations
     iterator       find(const key_type& x);
     const_iterator find(const key_type& x) const;
-    template <class K> iterator       find(const K& x);
-    template <class K> const_iterator find(const K& x) const;
+    template<class K> iterator       find(const K& x);
+    template<class K> const_iterator find(const K& x) const;
 
     size_type      count(const key_type& x) const;
-    template <class K> size_type count(const K& x) const;
+    template<class K> size_type count(const K& x) const;
 
     iterator       lower_bound(const key_type& x);
     const_iterator lower_bound(const key_type& x) const;
-    template <class K> iterator       lower_bound(const K& x);
-    template <class K> const_iterator lower_bound(const K& x) const;
+    template<class K> iterator       lower_bound(const K& x);
+    template<class K> const_iterator lower_bound(const K& x) const;
 
     iterator       upper_bound(const key_type& x);
     const_iterator upper_bound(const key_type& x) const;
-    template <class K> iterator       upper_bound(const K& x);
-    template <class K> const_iterator upper_bound(const K& x) const;
+    template<class K> iterator       upper_bound(const K& x);
+    template<class K> const_iterator upper_bound(const K& x) const;
 
     pair<iterator, iterator>               equal_range(const key_type& x);
     pair<const_iterator, const_iterator>   equal_range(const key_type& x) const;
-    template <class K>
+    template<class K>
       pair<iterator, iterator>             equal_range(const K& x);
-    template <class K>
+    template<class K>
       pair<const_iterator, const_iterator> equal_range(const K& x) const;
   };
 
@@ -7266,7 +7266,7 @@ namespace std {
     multiset(initializer_list<Key>, Allocator) -> multiset<Key, less<Key>, Allocator>;
 
   // \ref{multiset.special}, specialized algorithms
-  template <class Key, class Compare, class Allocator>
+  template<class Key, class Compare, class Allocator>
     void swap(multiset<Key, Compare, Allocator>& x,
               multiset<Key, Compare, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
@@ -7294,7 +7294,7 @@ Constant.
 
 \indexlibrary{\idxcode{multiset}!constructor}%
 \begin{itemdecl}
-template <class InputIterator>
+template<class InputIterator>
   multiset(InputIterator first, InputIterator last,
            const Compare& comp = Compare(), const Allocator& = Allocator());
 \end{itemdecl}
@@ -7322,7 +7322,7 @@ where $N$ is
 
 \indexlibrarymember{swap}{multiset}%
 \begin{itemdecl}
-template <class Key, class Compare, class Allocator>
+template<class Key, class Compare, class Allocator>
   void swap(multiset<Key, Compare, Allocator>& x,
             multiset<Key, Compare, Allocator>& y)
     noexcept(noexcept(x.swap(y)));
@@ -7357,57 +7357,57 @@ defined in \ref{associative.general} may appear in deduction guides for unordere
 
 namespace std {
   // \ref{unord.map}, class template \tcode{unordered_map}
-  template <class Key,
-            class T,
-            class Hash = hash<Key>,
-            class Pred = equal_to<Key>,
-            class Alloc = allocator<pair<const Key, T>>>
+  template<class Key,
+           class T,
+           class Hash = hash<Key>,
+           class Pred = equal_to<Key>,
+           class Alloc = allocator<pair<const Key, T>>>
     class unordered_map;
 
   // \ref{unord.multimap}, class template \tcode{unordered_multimap}
-  template <class Key,
-            class T,
-            class Hash = hash<Key>,
-            class Pred = equal_to<Key>,
-            class Alloc = allocator<pair<const Key, T>>>
+  template<class Key,
+           class T,
+           class Hash = hash<Key>,
+           class Pred = equal_to<Key>,
+           class Alloc = allocator<pair<const Key, T>>>
     class unordered_multimap;
 
-  template <class Key, class T, class Hash, class Pred, class Alloc>
+  template<class Key, class T, class Hash, class Pred, class Alloc>
     bool operator==(const unordered_map<Key, T, Hash, Pred, Alloc>& a,
                     const unordered_map<Key, T, Hash, Pred, Alloc>& b);
-  template <class Key, class T, class Hash, class Pred, class Alloc>
+  template<class Key, class T, class Hash, class Pred, class Alloc>
     bool operator!=(const unordered_map<Key, T, Hash, Pred, Alloc>& a,
                     const unordered_map<Key, T, Hash, Pred, Alloc>& b);
 
-  template <class Key, class T, class Hash, class Pred, class Alloc>
+  template<class Key, class T, class Hash, class Pred, class Alloc>
     bool operator==(const unordered_multimap<Key, T, Hash, Pred, Alloc>& a,
                     const unordered_multimap<Key, T, Hash, Pred, Alloc>& b);
-  template <class Key, class T, class Hash, class Pred, class Alloc>
+  template<class Key, class T, class Hash, class Pred, class Alloc>
     bool operator!=(const unordered_multimap<Key, T, Hash, Pred, Alloc>& a,
                     const unordered_multimap<Key, T, Hash, Pred, Alloc>& b);
 
-  template <class Key, class T, class Hash, class Pred, class Alloc>
+  template<class Key, class T, class Hash, class Pred, class Alloc>
     void swap(unordered_map<Key, T, Hash, Pred, Alloc>& x,
               unordered_map<Key, T, Hash, Pred, Alloc>& y)
       noexcept(noexcept(x.swap(y)));
 
-  template <class Key, class T, class Hash, class Pred, class Alloc>
+  template<class Key, class T, class Hash, class Pred, class Alloc>
     void swap(unordered_multimap<Key, T, Hash, Pred, Alloc>& x,
               unordered_multimap<Key, T, Hash, Pred, Alloc>& y)
       noexcept(noexcept(x.swap(y)));
 
   namespace pmr {
-    template <class Key,
-              class T,
-              class Hash = hash<Key>,
-              class Pred = equal_to<Key>>
+    template<class Key,
+             class T,
+             class Hash = hash<Key>,
+             class Pred = equal_to<Key>>
       using unordered_map =
         std::unordered_map<Key, T, Hash, Pred,
                            polymorphic_allocator<pair<const Key, T>>>;
-    template <class Key,
-              class T,
-              class Hash = hash<Key>,
-              class Pred = equal_to<Key>>
+    template<class Key,
+             class T,
+             class Hash = hash<Key>,
+             class Pred = equal_to<Key>>
       using unordered_multimap =
         std::unordered_multimap<Key, T, Hash, Pred,
                                 polymorphic_allocator<pair<const Key, T>>>;
@@ -7425,53 +7425,53 @@ namespace std {
 
 namespace std {
   // \ref{unord.set}, class template \tcode{unordered_set}
-  template <class Key,
-            class Hash = hash<Key>,
-            class Pred = equal_to<Key>,
-            class Alloc = allocator<Key>>
+  template<class Key,
+           class Hash = hash<Key>,
+           class Pred = equal_to<Key>,
+           class Alloc = allocator<Key>>
     class unordered_set;
 
   // \ref{unord.multiset}, class template \tcode{unordered_multiset}
-  template <class Key,
-            class Hash = hash<Key>,
-            class Pred = equal_to<Key>,
-            class Alloc = allocator<Key>>
+  template<class Key,
+           class Hash = hash<Key>,
+           class Pred = equal_to<Key>,
+           class Alloc = allocator<Key>>
     class unordered_multiset;
 
-  template <class Key, class Hash, class Pred, class Alloc>
+  template<class Key, class Hash, class Pred, class Alloc>
     bool operator==(const unordered_set<Key, Hash, Pred, Alloc>& a,
                     const unordered_set<Key, Hash, Pred, Alloc>& b);
-  template <class Key, class Hash, class Pred, class Alloc>
+  template<class Key, class Hash, class Pred, class Alloc>
     bool operator!=(const unordered_set<Key, Hash, Pred, Alloc>& a,
                     const unordered_set<Key, Hash, Pred, Alloc>& b);
 
-  template <class Key, class Hash, class Pred, class Alloc>
+  template<class Key, class Hash, class Pred, class Alloc>
     bool operator==(const unordered_multiset<Key, Hash, Pred, Alloc>& a,
                     const unordered_multiset<Key, Hash, Pred, Alloc>& b);
-  template <class Key, class Hash, class Pred, class Alloc>
+  template<class Key, class Hash, class Pred, class Alloc>
     bool operator!=(const unordered_multiset<Key, Hash, Pred, Alloc>& a,
                     const unordered_multiset<Key, Hash, Pred, Alloc>& b);
 
-  template <class Key, class Hash, class Pred, class Alloc>
+  template<class Key, class Hash, class Pred, class Alloc>
     void swap(unordered_set<Key, Hash, Pred, Alloc>& x,
               unordered_set<Key, Hash, Pred, Alloc>& y)
       noexcept(noexcept(x.swap(y)));
 
-  template <class Key, class Hash, class Pred, class Alloc>
+  template<class Key, class Hash, class Pred, class Alloc>
     void swap(unordered_multiset<Key, Hash, Pred, Alloc>& x,
               unordered_multiset<Key, Hash, Pred, Alloc>& y)
       noexcept(noexcept(x.swap(y)));
 
   namespace pmr {
-    template <class Key,
-              class Hash = hash<Key>,
-              class Pred = equal_to<Key>>
+    template<class Key,
+             class Hash = hash<Key>,
+             class Pred = equal_to<Key>>
       using unordered_set = std::unordered_set<Key, Hash, Pred,
                                                polymorphic_allocator<Key>>;
 
-    template <class Key,
-              class Hash = hash<Key>,
-              class Pred = equal_to<Key>>
+    template<class Key,
+             class Hash = hash<Key>,
+             class Pred = equal_to<Key>>
       using unordered_multiset = std::unordered_multiset<Key, Hash, Pred,
                                                          polymorphic_allocator<Key>>;
   }
@@ -7504,11 +7504,11 @@ is additional semantic information.
 \indexlibrary{\idxcode{unordered_map}}%
 \begin{codeblock}
 namespace std {
-  template <class Key,
-            class T,
-            class Hash = hash<Key>,
-            class Pred = equal_to<Key>,
-            class Allocator = allocator<pair<const Key, T>>>
+  template<class Key,
+           class T,
+           class Hash = hash<Key>,
+           class Pred = equal_to<Key>,
+           class Allocator = allocator<pair<const Key, T>>>
   class unordered_map {
   public:
     // types
@@ -7538,7 +7538,7 @@ namespace std {
                            const hasher& hf = hasher(),
                            const key_equal& eql = key_equal(),
                            const allocator_type& a = allocator_type());
-    template <class InputIterator>
+    template<class InputIterator>
       unordered_map(InputIterator f, InputIterator l,
                     size_type n = @\seebelow@,
                     const hasher& hf = hasher(),
@@ -7558,10 +7558,10 @@ namespace std {
       : unordered_map(n, hasher(), key_equal(), a) { }
     unordered_map(size_type n, const hasher& hf, const allocator_type& a)
       : unordered_map(n, hf, key_equal(), a) { }
-    template <class InputIterator>
+    template<class InputIterator>
       unordered_map(InputIterator f, InputIterator l, size_type n, const allocator_type& a)
         : unordered_map(f, l, n, hasher(), key_equal(), a) { }
-    template <class InputIterator>
+    template<class InputIterator>
       unordered_map(InputIterator f, InputIterator l, size_type n, const hasher& hf,
                     const allocator_type& a)
         : unordered_map(f, l, n, hf, key_equal(), a) { }
@@ -7593,15 +7593,15 @@ namespace std {
     size_type max_size() const noexcept;
 
     // \ref{unord.map.modifiers}, modifiers
-    template <class... Args> pair<iterator, bool> emplace(Args&&... args);
-    template <class... Args> iterator emplace_hint(const_iterator position, Args&&... args);
+    template<class... Args> pair<iterator, bool> emplace(Args&&... args);
+    template<class... Args> iterator emplace_hint(const_iterator position, Args&&... args);
     pair<iterator, bool> insert(const value_type& obj);
     pair<iterator, bool> insert(value_type&& obj);
-    template <class P> pair<iterator, bool> insert(P&& obj);
+    template<class P> pair<iterator, bool> insert(P&& obj);
     iterator       insert(const_iterator hint, const value_type& obj);
     iterator       insert(const_iterator hint, value_type&& obj);
-    template <class P> iterator insert(const_iterator hint, P&& obj);
-    template <class InputIterator> void insert(InputIterator first, InputIterator last);
+    template<class P> iterator insert(const_iterator hint, P&& obj);
+    template<class InputIterator> void insert(InputIterator first, InputIterator last);
     void insert(initializer_list<value_type>);
 
     node_type extract(const_iterator position);
@@ -7609,21 +7609,21 @@ namespace std {
     insert_return_type insert(node_type&& nh);
     iterator           insert(const_iterator hint, node_type&& nh);
 
-    template <class... Args>
+    template<class... Args>
       pair<iterator, bool> try_emplace(const key_type& k, Args&&... args);
-    template <class... Args>
+    template<class... Args>
       pair<iterator, bool> try_emplace(key_type&& k, Args&&... args);
-    template <class... Args>
+    template<class... Args>
       iterator try_emplace(const_iterator hint, const key_type& k, Args&&... args);
-    template <class... Args>
+    template<class... Args>
       iterator try_emplace(const_iterator hint, key_type&& k, Args&&... args);
-    template <class M>
+    template<class M>
       pair<iterator, bool> insert_or_assign(const key_type& k, M&& obj);
-    template <class M>
+    template<class M>
       pair<iterator, bool> insert_or_assign(key_type&& k, M&& obj);
-    template <class M>
+    template<class M>
       iterator insert_or_assign(const_iterator hint, const key_type& k, M&& obj);
-    template <class M>
+    template<class M>
       iterator insert_or_assign(const_iterator hint, key_type&& k, M&& obj);
 
     iterator  erase(iterator position);
@@ -7715,12 +7715,12 @@ namespace std {
       -> unordered_map<iter_key_t<InputIterator>, iter_val_t<InputIterator>, Hash,
                        equal_to<iter_key_t<InputIterator>>, Allocator>;
 
-  template<class Key, class T, typename Allocator>
+  template<class Key, class T, class Allocator>
     unordered_map(initializer_list<pair<const Key, T>>, typename @\seebelow@::size_type,
                   Allocator)
       -> unordered_map<Key, T, hash<Key>, equal_to<Key>, Allocator>;
 
-  template<class Key, class T, typename Allocator>
+  template<class Key, class T, class Allocator>
     unordered_map(initializer_list<pair<const Key, T>>, Allocator)
       -> unordered_map<Key, T, hash<Key>, equal_to<Key>, Allocator>;
 
@@ -7730,7 +7730,7 @@ namespace std {
       -> unordered_map<Key, T, Hash, equal_to<Key>, Allocator>;
 
   // \ref{unord.map.swap}, swap
-  template <class Key, class T, class Hash, class Pred, class Alloc>
+  template<class Key, class T, class Hash, class Pred, class Alloc>
     void swap(unordered_map<Key, T, Hash, Pred, Alloc>& x,
               unordered_map<Key, T, Hash, Pred, Alloc>& y)
       noexcept(noexcept(x.swap(y)));
@@ -7767,7 +7767,7 @@ the number of buckets is \impldef{default number of buckets in
 
 \indexlibrary{\idxcode{unordered_map}!constructor}%
 \begin{itemdecl}
-template <class InputIterator>
+template<class InputIterator>
   unordered_map(InputIterator f, InputIterator l,
                 size_type n = @\seebelow@,
                 const hasher& hf = hasher(),
@@ -7839,7 +7839,7 @@ const mapped_type& at(const key_type& k) const;
 
 \indexlibrarymember{unordered_map}{insert}%
 \begin{itemdecl}
-template <class P>
+template<class P>
   pair<iterator, bool> insert(P&& obj);
 \end{itemdecl}
 
@@ -7854,7 +7854,7 @@ unless \tcode{is_constructible_v<value_type, P\&\&>} is \tcode{true}.
 
 \indexlibrarymember{unordered_map}{insert}%
 \begin{itemdecl}
-template <class P>
+template<class P>
   iterator insert(const_iterator hint, P&& obj);
 \end{itemdecl}
 
@@ -7870,9 +7870,9 @@ unless \tcode{is_constructible_v<value_type, P\&\&>} is \tcode{true}.
 
 \indexlibrarymember{try_emplace}{unordered_map}%
 \begin{itemdecl}
-template <class... Args>
+template<class... Args>
   pair<iterator, bool> try_emplace(const key_type& k, Args&&... args);
-template <class... Args>
+template<class... Args>
   iterator try_emplace(const_iterator hint, const key_type& k, Args&&... args);
 \end{itemdecl}
 
@@ -7908,9 +7908,9 @@ respectively.
 
 \indexlibrarymember{try_emplace}{unordered_map}%
 \begin{itemdecl}
-template <class... Args>
+template<class... Args>
   pair<iterator, bool> try_emplace(key_type&& k, Args&&... args);
-template <class... Args>
+template<class... Args>
   iterator try_emplace(const_iterator hint, key_type&& k, Args&&... args);
 \end{itemdecl}
 
@@ -7946,9 +7946,9 @@ respectively.
 
 \indexlibrarymember{insert_or_assign}{unordered_map}%
 \begin{itemdecl}
-template <class M>
+template<class M>
   pair<iterator, bool> insert_or_assign(const key_type& k, M&& obj);
-template <class M>
+template<class M>
   iterator insert_or_assign(const_iterator hint, const key_type& k, M&& obj);
 \end{itemdecl}
 
@@ -7983,9 +7983,9 @@ respectively.
 
 \indexlibrarymember{insert_or_assign}{unordered_map}%
 \begin{itemdecl}
-template <class M>
+template<class M>
   pair<iterator, bool> insert_or_assign(key_type&& k, M&& obj);
-template <class M>
+template<class M>
   iterator insert_or_assign(const_iterator hint, key_type&& k, M&& obj);
 \end{itemdecl}
 
@@ -8022,7 +8022,7 @@ respectively.
 
 \indexlibrarymember{unordered_map}{swap}%
 \begin{itemdecl}
-template <class Key, class T, class Hash, class Pred, class Alloc>
+template<class Key, class T, class Hash, class Pred, class Alloc>
   void swap(unordered_map<Key, T, Hash, Pred, Alloc>& x,
             unordered_map<Key, T, Hash, Pred, Alloc>& y)
     noexcept(noexcept(x.swap(y)));
@@ -8064,11 +8064,11 @@ there is additional semantic information.
 \indexlibrary{\idxcode{unordered_multimap}}%
 \begin{codeblock}
 namespace std {
-  template <class Key,
-            class T,
-            class Hash = hash<Key>,
-            class Pred = equal_to<Key>,
-            class Allocator = allocator<pair<const Key, T>>>
+  template<class Key,
+           class T,
+           class Hash = hash<Key>,
+           class Pred = equal_to<Key>,
+           class Allocator = allocator<pair<const Key, T>>>
   class unordered_multimap {
   public:
     // types
@@ -8097,7 +8097,7 @@ namespace std {
                                 const hasher& hf = hasher(),
                                 const key_equal& eql = key_equal(),
                                 const allocator_type& a = allocator_type());
-    template <class InputIterator>
+    template<class InputIterator>
       unordered_multimap(InputIterator f, InputIterator l,
                          size_type n = @\seebelow@,
                          const hasher& hf = hasher(),
@@ -8117,10 +8117,10 @@ namespace std {
       : unordered_multimap(n, hasher(), key_equal(), a) { }
     unordered_multimap(size_type n, const hasher& hf, const allocator_type& a)
       : unordered_multimap(n, hf, key_equal(), a) { }
-    template <class InputIterator>
+    template<class InputIterator>
       unordered_multimap(InputIterator f, InputIterator l, size_type n, const allocator_type& a)
         : unordered_multimap(f, l, n, hasher(), key_equal(), a) { }
-    template <class InputIterator>
+    template<class InputIterator>
       unordered_multimap(InputIterator f, InputIterator l, size_type n, const hasher& hf,
                          const allocator_type& a)
         : unordered_multimap(f, l, n, hf, key_equal(), a) { }
@@ -8152,15 +8152,15 @@ namespace std {
     size_type max_size() const noexcept;
 
     // \ref{unord.multimap.modifiers}, modifiers
-    template <class... Args> iterator emplace(Args&&... args);
-    template <class... Args> iterator emplace_hint(const_iterator position, Args&&... args);
+    template<class... Args> iterator emplace(Args&&... args);
+    template<class... Args> iterator emplace_hint(const_iterator position, Args&&... args);
     iterator insert(const value_type& obj);
     iterator insert(value_type&& obj);
-    template <class P> iterator insert(P&& obj);
+    template<class P> iterator insert(P&& obj);
     iterator insert(const_iterator hint, const value_type& obj);
     iterator insert(const_iterator hint, value_type&& obj);
-    template <class P> iterator insert(const_iterator hint, P&& obj);
-    template <class InputIterator> void insert(InputIterator first, InputIterator last);
+    template<class P> iterator insert(const_iterator hint, P&& obj);
+    template<class InputIterator> void insert(InputIterator first, InputIterator last);
     void insert(initializer_list<value_type>);
 
     node_type extract(const_iterator position);
@@ -8253,12 +8253,12 @@ namespace std {
       -> unordered_multimap<iter_key_t<InputIterator>, iter_val_t<InputIterator>, Hash,
                             equal_to<iter_key_t<InputIterator>>, Allocator>;
 
-  template<class Key, class T, typename Allocator>
+  template<class Key, class T, class Allocator>
     unordered_multimap(initializer_list<pair<const Key, T>>, typename @\seebelow@::size_type,
                        Allocator)
       -> unordered_multimap<Key, T, hash<Key>, equal_to<Key>, Allocator>;
 
-  template<class Key, class T, typename Allocator>
+  template<class Key, class T, class Allocator>
     unordered_multimap(initializer_list<pair<const Key, T>>, Allocator)
       -> unordered_multimap<Key, T, hash<Key>, equal_to<Key>, Allocator>;
 
@@ -8268,7 +8268,7 @@ namespace std {
       -> unordered_multimap<Key, T, Hash, equal_to<Key>, Allocator>;
 
   // \ref{unord.multimap.swap}, swap
-  template <class Key, class T, class Hash, class Pred, class Alloc>
+  template<class Key, class T, class Hash, class Pred, class Alloc>
     void swap(unordered_multimap<Key, T, Hash, Pred, Alloc>& x,
               unordered_multimap<Key, T, Hash, Pred, Alloc>& y)
       noexcept(noexcept(x.swap(y)));
@@ -8305,7 +8305,7 @@ the number of buckets is \impldef{default number of buckets in
 
 \indexlibrary{\idxcode{unordered_multimap}!constructor}%
 \begin{itemdecl}
-template <class InputIterator>
+template<class InputIterator>
   unordered_multimap(InputIterator f, InputIterator l,
                      size_type n = @\seebelow@,
                      const hasher& hf = hasher(),
@@ -8338,7 +8338,7 @@ for the first form, or from the range
 
 \indexlibrarymember{unordered_multimap}{insert}%
 \begin{itemdecl}
-template <class P>
+template<class P>
   iterator insert(P&& obj);
 \end{itemdecl}
 
@@ -8353,7 +8353,7 @@ unless \tcode{is_constructible_v<value_type, P\&\&>} is \tcode{true}.
 
 \indexlibrarymember{unordered_multimap}{insert}%
 \begin{itemdecl}
-template <class P>
+template<class P>
   iterator insert(const_iterator hint, P&& obj);
 \end{itemdecl}
 
@@ -8371,7 +8371,7 @@ unless \tcode{is_constructible_v<value_type, P\&\&>} is \tcode{true}.
 
 \indexlibrarymember{unordered_multimap}{swap}%
 \begin{itemdecl}
-template <class Key, class T, class Hash, class Pred, class Alloc>
+template<class Key, class T, class Hash, class Pred, class Alloc>
   void swap(unordered_multimap<Key, T, Hash, Pred, Alloc>& x,
             unordered_multimap<Key, T, Hash, Pred, Alloc>& y)
     noexcept(noexcept(x.swap(y)));
@@ -8408,10 +8408,10 @@ is additional semantic information.
 \indexlibrary{\idxcode{unordered_set}}%
 \begin{codeblock}
 namespace std {
-  template <class Key,
-            class Hash = hash<Key>,
-            class Pred = equal_to<Key>,
-            class Allocator = allocator<Key>>
+  template<class Key,
+           class Hash = hash<Key>,
+           class Pred = equal_to<Key>,
+           class Allocator = allocator<Key>>
   class unordered_set {
   public:
     // types
@@ -8440,7 +8440,7 @@ namespace std {
                            const hasher& hf = hasher(),
                            const key_equal& eql = key_equal(),
                            const allocator_type& a = allocator_type());
-    template <class InputIterator>
+    template<class InputIterator>
       unordered_set(InputIterator f, InputIterator l,
                     size_type n = @\seebelow@,
                     const hasher& hf = hasher(),
@@ -8460,10 +8460,10 @@ namespace std {
       : unordered_set(n, hasher(), key_equal(), a) { }
     unordered_set(size_type n, const hasher& hf, const allocator_type& a)
       : unordered_set(n, hf, key_equal(), a) { }
-    template <class InputIterator>
+    template<class InputIterator>
       unordered_set(InputIterator f, InputIterator l, size_type n, const allocator_type& a)
         : unordered_set(f, l, n, hasher(), key_equal(), a) { }
-    template <class InputIterator>
+    template<class InputIterator>
       unordered_set(InputIterator f, InputIterator l, size_type n, const hasher& hf,
                     const allocator_type& a)
       : unordered_set(f, l, n, hf, key_equal(), a) { }
@@ -8495,13 +8495,13 @@ namespace std {
     size_type max_size() const noexcept;
 
     // modifiers
-    template <class... Args> pair<iterator, bool> emplace(Args&&... args);
-    template <class... Args> iterator emplace_hint(const_iterator position, Args&&... args);
+    template<class... Args> pair<iterator, bool> emplace(Args&&... args);
+    template<class... Args> iterator emplace_hint(const_iterator position, Args&&... args);
     pair<iterator, bool> insert(const value_type& obj);
     pair<iterator, bool> insert(value_type&& obj);
     iterator insert(const_iterator hint, const value_type& obj);
     iterator insert(const_iterator hint, value_type&& obj);
-    template <class InputIterator> void insert(InputIterator first, InputIterator last);
+    template<class InputIterator> void insert(InputIterator first, InputIterator last);
     void insert(initializer_list<value_type>);
 
     node_type extract(const_iterator position);
@@ -8597,7 +8597,7 @@ namespace std {
       -> unordered_set<T, Hash, equal_to<T>, Allocator>;
 
   // \ref{unord.set.swap}, swap
-  template <class Key, class Hash, class Pred, class Alloc>
+  template<class Key, class Hash, class Pred, class Alloc>
     void swap(unordered_set<Key, Hash, Pred, Alloc>& x,
               unordered_set<Key, Hash, Pred, Alloc>& y)
       noexcept(noexcept(x.swap(y)));
@@ -8635,7 +8635,7 @@ the number of buckets is \impldef{default number of buckets in
 
 \indexlibrary{\idxcode{unordered_set}!constructor}%
 \begin{itemdecl}
-template <class InputIterator>
+template<class InputIterator>
   unordered_set(InputIterator f, InputIterator l,
                 size_type n = @\seebelow@,
                 const hasher& hf = hasher(),
@@ -8668,7 +8668,7 @@ for the first form, or from the range
 
 \indexlibrarymember{unordered_set}{swap}%
 \begin{itemdecl}
-template <class Key, class Hash, class Pred, class Alloc>
+template<class Key, class Hash, class Pred, class Alloc>
   void swap(unordered_set<Key, Hash, Pred, Alloc>& x,
             unordered_set<Key, Hash, Pred, Alloc>& y)
     noexcept(noexcept(x.swap(y)));
@@ -8711,10 +8711,10 @@ is additional semantic information.
 \indexlibrary{\idxcode{unordered_multiset}}%
 \begin{codeblock}
 namespace std {
-  template <class Key,
-            class Hash = hash<Key>,
-            class Pred = equal_to<Key>,
-            class Allocator = allocator<Key>>
+  template<class Key,
+           class Hash = hash<Key>,
+           class Pred = equal_to<Key>,
+           class Allocator = allocator<Key>>
   class unordered_multiset {
   public:
     // types
@@ -8742,7 +8742,7 @@ namespace std {
                                 const hasher& hf = hasher(),
                                 const key_equal& eql = key_equal(),
                                 const allocator_type& a = allocator_type());
-    template <class InputIterator>
+    template<class InputIterator>
       unordered_multiset(InputIterator f, InputIterator l,
                          size_type n = @\seebelow@,
                          const hasher& hf = hasher(),
@@ -8762,10 +8762,10 @@ namespace std {
       : unordered_multiset(n, hasher(), key_equal(), a) { }
     unordered_multiset(size_type n, const hasher& hf, const allocator_type& a)
       : unordered_multiset(n, hf, key_equal(), a) { }
-    template <class InputIterator>
+    template<class InputIterator>
       unordered_multiset(InputIterator f, InputIterator l, size_type n, const allocator_type& a)
         : unordered_multiset(f, l, n, hasher(), key_equal(), a) { }
-    template <class InputIterator>
+    template<class InputIterator>
       unordered_multiset(InputIterator f, InputIterator l, size_type n, const hasher& hf,
                          const allocator_type& a)
       : unordered_multiset(f, l, n, hf, key_equal(), a) { }
@@ -8797,13 +8797,13 @@ namespace std {
     size_type max_size() const noexcept;
 
     // modifiers
-    template <class... Args> iterator emplace(Args&&... args);
-    template <class... Args> iterator emplace_hint(const_iterator position, Args&&... args);
+    template<class... Args> iterator emplace(Args&&... args);
+    template<class... Args> iterator emplace_hint(const_iterator position, Args&&... args);
     iterator insert(const value_type& obj);
     iterator insert(value_type&& obj);
     iterator insert(const_iterator hint, const value_type& obj);
     iterator insert(const_iterator hint, value_type&& obj);
-    template <class InputIterator> void insert(InputIterator first, InputIterator last);
+    template<class InputIterator> void insert(InputIterator first, InputIterator last);
     void insert(initializer_list<value_type>);
 
     node_type extract(const_iterator position);
@@ -8899,7 +8899,7 @@ namespace std {
       -> unordered_multiset<T, Hash, equal_to<T>, Allocator>;
 
   // \ref{unord.multiset.swap}, swap
-  template <class Key, class Hash, class Pred, class Alloc>
+  template<class Key, class Hash, class Pred, class Alloc>
     void swap(unordered_multiset<Key, Hash, Pred, Alloc>& x,
               unordered_multiset<Key, Hash, Pred, Alloc>& y)
       noexcept(noexcept(x.swap(y)));
@@ -8937,7 +8937,7 @@ the number of buckets is \impldef{default number of buckets in
 
 \indexlibrary{\idxcode{unordered_multiset}!constructor}%
 \begin{itemdecl}
-template <class InputIterator>
+template<class InputIterator>
   unordered_multiset(InputIterator f, InputIterator l,
                      size_type n = @\seebelow@,
                      const hasher& hf = hasher(),
@@ -8969,7 +8969,7 @@ for the first form, or from the range
 
 \indexlibrarymember{unordered_multiset}{swap}%
 \begin{itemdecl}
-template <class Key, class Hash, class Pred, class Alloc>
+template<class Key, class Hash, class Pred, class Alloc>
   void swap(unordered_multiset<Key, Hash, Pred, Alloc>& x,
             unordered_multiset<Key, Hash, Pred, Alloc>& y)
     noexcept(noexcept(x.swap(y)));
@@ -9018,27 +9018,27 @@ A deduction guide for a container adaptor shall not participate in overload reso
 #include <initializer_list>
 
 namespace std {
-  template <class T, class Container = deque<T>> class queue;
-  template <class T, class Container = vector<T>,
-            class Compare = less<typename Container::value_type>>
+  template<class T, class Container = deque<T>> class queue;
+  template<class T, class Container = vector<T>,
+           class Compare = less<typename Container::value_type>>
     class priority_queue;
 
-  template <class T, class Container>
+  template<class T, class Container>
     bool operator==(const queue<T, Container>& x, const queue<T, Container>& y);
-  template <class T, class Container>
+  template<class T, class Container>
     bool operator< (const queue<T, Container>& x, const queue<T, Container>& y);
-  template <class T, class Container>
+  template<class T, class Container>
     bool operator!=(const queue<T, Container>& x, const queue<T, Container>& y);
-  template <class T, class Container>
+  template<class T, class Container>
     bool operator> (const queue<T, Container>& x, const queue<T, Container>& y);
-  template <class T, class Container>
+  template<class T, class Container>
     bool operator>=(const queue<T, Container>& x, const queue<T, Container>& y);
-  template <class T, class Container>
+  template<class T, class Container>
     bool operator<=(const queue<T, Container>& x, const queue<T, Container>& y);
 
-  template <class T, class Container>
+  template<class T, class Container>
     void swap(queue<T, Container>& x, queue<T, Container>& y) noexcept(noexcept(x.swap(y)));
-  template <class T, class Container, class Compare>
+  template<class T, class Container, class Compare>
     void swap(priority_queue<T, Container, Compare>& x,
               priority_queue<T, Container, Compare>& y) noexcept(noexcept(x.swap(y)));
 }
@@ -9051,22 +9051,22 @@ namespace std {
 #include <initializer_list>
 
 namespace std {
-  template <class T, class Container = deque<T>> class stack;
+  template<class T, class Container = deque<T>> class stack;
 
-  template <class T, class Container>
+  template<class T, class Container>
     bool operator==(const stack<T, Container>& x, const stack<T, Container>& y);
-  template <class T, class Container>
+  template<class T, class Container>
     bool operator< (const stack<T, Container>& x, const stack<T, Container>& y);
-  template <class T, class Container>
+  template<class T, class Container>
     bool operator!=(const stack<T, Container>& x, const stack<T, Container>& y);
-  template <class T, class Container>
+  template<class T, class Container>
     bool operator> (const stack<T, Container>& x, const stack<T, Container>& y);
-  template <class T, class Container>
+  template<class T, class Container>
     bool operator>=(const stack<T, Container>& x, const stack<T, Container>& y);
-  template <class T, class Container>
+  template<class T, class Container>
     bool operator<=(const stack<T, Container>& x, const stack<T, Container>& y);
 
-  template <class T, class Container>
+  template<class T, class Container>
     void swap(stack<T, Container>& x, stack<T, Container>& y) noexcept(noexcept(x.swap(y)));
 }
 \end{codeblock}
@@ -9093,7 +9093,7 @@ can be used.
 
 \begin{codeblock}
 namespace std {
-  template <class T, class Container = deque<T>>
+  template<class T, class Container = deque<T>>
   class queue {
   public:
     using value_type      = typename Container::value_type;
@@ -9108,11 +9108,11 @@ namespace std {
   public:
     explicit queue(const Container&);
     explicit queue(Container&& = Container());
-    template <class Alloc> explicit queue(const Alloc&);
-    template <class Alloc> queue(const Container&, const Alloc&);
-    template <class Alloc> queue(Container&&, const Alloc&);
-    template <class Alloc> queue(const queue&, const Alloc&);
-    template <class Alloc> queue(queue&&, const Alloc&);
+    template<class Alloc> explicit queue(const Alloc&);
+    template<class Alloc> queue(const Container&, const Alloc&);
+    template<class Alloc> queue(Container&&, const Alloc&);
+    template<class Alloc> queue(const queue&, const Alloc&);
+    template<class Alloc> queue(queue&&, const Alloc&);
 
     [[nodiscard]] bool empty() const    { return c.empty(); }
     size_type         size()  const     { return c.size(); }
@@ -9122,7 +9122,7 @@ namespace std {
     const_reference   back() const      { return c.back(); }
     void push(const value_type& x)      { c.push_back(x); }
     void push(value_type&& x)           { c.push_back(std::move(x)); }
-    template <class... Args>
+    template<class... Args>
       decltype(auto) emplace(Args&&... args)
         { return c.emplace_back(std::forward<Args>(args)...); }
     void pop()                          { c.pop_front(); }
@@ -9136,10 +9136,10 @@ namespace std {
   template<class Container, class Allocator>
     queue(Container, Allocator) -> queue<typename Container::value_type, Container>;
 
-  template <class T, class Container>
+  template<class T, class Container>
     void swap(queue<T, Container>& x, queue<T, Container>& y) noexcept(noexcept(x.swap(y)));
 
-  template <class T, class Container, class Alloc>
+  template<class T, class Container, class Alloc>
     struct uses_allocator<queue<T, Container>, Alloc>
       : uses_allocator<Container, Alloc>::type { };
 }
@@ -9172,7 +9172,7 @@ If \tcode{uses_allocator_v<container_type, Alloc>} is \tcode{false}
 the constructors in this subclause shall not participate in overload resolution.
 
 \begin{itemdecl}
-template <class Alloc> explicit queue(const Alloc& a);
+template<class Alloc> explicit queue(const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9181,7 +9181,7 @@ template <class Alloc> explicit queue(const Alloc& a);
 \end{itemdescr}
 
 \begin{itemdecl}
-template <class Alloc> queue(const container_type& cont, const Alloc& a);
+template<class Alloc> queue(const container_type& cont, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9191,7 +9191,7 @@ as the second argument.
 \end{itemdescr}
 
 \begin{itemdecl}
-template <class Alloc> queue(container_type&& cont, const Alloc& a);
+template<class Alloc> queue(container_type&& cont, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9201,7 +9201,7 @@ as the second argument.
 \end{itemdescr}
 
 \begin{itemdecl}
-template <class Alloc> queue(const queue& q, const Alloc& a);
+template<class Alloc> queue(const queue& q, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9211,7 +9211,7 @@ second argument.
 \end{itemdescr}
 
 \begin{itemdecl}
-template <class Alloc> queue(queue&& q, const Alloc& a);
+template<class Alloc> queue(queue&& q, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9224,7 +9224,7 @@ as the second argument.
 
 \indexlibrary{\idxcode{operator==}!\idxcode{queue}}%
 \begin{itemdecl}
-template <class T, class Container>
+template<class T, class Container>
   bool operator==(const queue<T, Container>& x, const queue<T, Container>& y);
 \end{itemdecl}
 
@@ -9236,7 +9236,7 @@ template <class T, class Container>
 
 \indexlibrary{\idxcode{operator"!=}!\idxcode{queue}}%
 \begin{itemdecl}
-template <class T, class Container>
+template<class T, class Container>
   bool operator!=(const queue<T, Container>& x,  const queue<T, Container>& y);
 \end{itemdecl}
 
@@ -9248,7 +9248,7 @@ template <class T, class Container>
 
 \indexlibrary{\idxcode{operator<}!\idxcode{queue}}%
 \begin{itemdecl}
-template <class T, class Container>
+template<class T, class Container>
   bool operator< (const queue<T, Container>& x, const queue<T, Container>& y);
 \end{itemdecl}
 
@@ -9260,7 +9260,7 @@ template <class T, class Container>
 
 \indexlibrary{\idxcode{operator<=}!\idxcode{queue}}%
 \begin{itemdecl}
-template <class T, class Container>
+template<class T, class Container>
   bool operator<=(const queue<T, Container>& x, const queue<T, Container>& y);
 \end{itemdecl}
 
@@ -9272,7 +9272,7 @@ template <class T, class Container>
 
 \indexlibrary{\idxcode{operator>}!\idxcode{queue}}%
 \begin{itemdecl}
-template <class T, class Container>
+template<class T, class Container>
   bool operator> (const queue<T, Container>& x, const queue<T, Container>& y);
 \end{itemdecl}
 
@@ -9284,7 +9284,7 @@ template <class T, class Container>
 
 \indexlibrary{\idxcode{operator>=}!\idxcode{queue}}%
 \begin{itemdecl}
-template <class T, class Container>
+template<class T, class Container>
     bool operator>=(const queue<T, Container>& x,
                     const queue<T, Container>& y);
 \end{itemdecl}
@@ -9299,7 +9299,7 @@ template <class T, class Container>
 
 \indexlibrarymember{swap}{queue}%
 \begin{itemdecl}
-template <class T, class Container>
+template<class T, class Container>
   void swap(queue<T, Container>& x, queue<T, Container>& y) noexcept(noexcept(x.swap(y)));
 \end{itemdecl}
 
@@ -9337,8 +9337,8 @@ object defines a strict weak ordering\iref{alg.sorting}.
 
 \begin{codeblock}
 namespace std {
-  template <class T, class Container = vector<T>,
-    class Compare = less<typename Container::value_type>>
+  template<class T, class Container = vector<T>,
+           class Compare = less<typename Container::value_type>>
   class priority_queue {
   public:
     using value_type      = typename Container::value_type;
@@ -9355,25 +9355,25 @@ namespace std {
   public:
     priority_queue(const Compare& x, const Container&);
     explicit priority_queue(const Compare& x = Compare(), Container&& = Container());
-    template <class InputIterator>
+    template<class InputIterator>
       priority_queue(InputIterator first, InputIterator last, const Compare& x,
                      const Container&);
-    template <class InputIterator>
+    template<class InputIterator>
       priority_queue(InputIterator first, InputIterator last,
                      const Compare& x = Compare(), Container&& = Container());
-    template <class Alloc> explicit priority_queue(const Alloc&);
-    template <class Alloc> priority_queue(const Compare&, const Alloc&);
-    template <class Alloc> priority_queue(const Compare&, const Container&, const Alloc&);
-    template <class Alloc> priority_queue(const Compare&, Container&&, const Alloc&);
-    template <class Alloc> priority_queue(const priority_queue&, const Alloc&);
-    template <class Alloc> priority_queue(priority_queue&&, const Alloc&);
+    template<class Alloc> explicit priority_queue(const Alloc&);
+    template<class Alloc> priority_queue(const Compare&, const Alloc&);
+    template<class Alloc> priority_queue(const Compare&, const Container&, const Alloc&);
+    template<class Alloc> priority_queue(const Compare&, Container&&, const Alloc&);
+    template<class Alloc> priority_queue(const priority_queue&, const Alloc&);
+    template<class Alloc> priority_queue(priority_queue&&, const Alloc&);
 
     [[nodiscard]] bool empty() const { return c.empty(); }
     size_type size()  const          { return c.size(); }
     const_reference   top() const    { return c.front(); }
     void push(const value_type& x);
     void push(value_type&& x);
-    template <class... Args> void emplace(Args&&... args);
+    template<class... Args> void emplace(Args&&... args);
     void pop();
     void swap(priority_queue& q) noexcept(is_nothrow_swappable_v<Container> &&
                                           is_nothrow_swappable_v<Compare>)
@@ -9396,11 +9396,11 @@ namespace std {
 
   // no equality is provided
 
-  template <class T, class Container, class Compare>
+  template<class T, class Container, class Compare>
     void swap(priority_queue<T, Container, Compare>& x,
               priority_queue<T, Container, Compare>& y) noexcept(noexcept(x.swap(y)));
 
-  template <class T, class Container, class Compare, class Alloc>
+  template<class T, class Container, class Compare, class Alloc>
     struct uses_allocator<priority_queue<T, Container, Compare>, Alloc>
       : uses_allocator<Container, Alloc>::type { };
 }
@@ -9432,9 +9432,9 @@ calls
 
 \indexlibrary{\idxcode{priority_queue}!constructor}%
 \begin{itemdecl}
-template <class InputIterator>
+template<class InputIterator>
   priority_queue(InputIterator first, InputIterator last, const Compare& x, const Container& y);
-template <class InputIterator>
+template<class InputIterator>
   priority_queue(InputIterator first, InputIterator last, const Compare& x = Compare(),
                  Container&& y = Container());
 \end{itemdecl}
@@ -9465,7 +9465,7 @@ the constructors in this subclause shall not participate in overload resolution.
 
 \indexlibrary{\idxcode{priority_queue}!constructor}%
 \begin{itemdecl}
-template <class Alloc> explicit priority_queue(const Alloc& a);
+template<class Alloc> explicit priority_queue(const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9475,7 +9475,7 @@ template <class Alloc> explicit priority_queue(const Alloc& a);
 
 \indexlibrary{\idxcode{priority_queue}!constructor}%
 \begin{itemdecl}
-template <class Alloc> priority_queue(const Compare& compare, const Alloc& a);
+template<class Alloc> priority_queue(const Compare& compare, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9485,7 +9485,7 @@ template <class Alloc> priority_queue(const Compare& compare, const Alloc& a);
 
 \indexlibrary{\idxcode{priority_queue}!constructor}%
 \begin{itemdecl}
-template <class Alloc>
+template<class Alloc>
   priority_queue(const Compare& compare, const Container& cont, const Alloc& a);
 \end{itemdecl}
 
@@ -9498,7 +9498,7 @@ calls \tcode{make_heap(c.begin(), c.end(), comp)}.
 
 \indexlibrary{\idxcode{priority_queue}!constructor}%
 \begin{itemdecl}
-template <class Alloc>
+template<class Alloc>
   priority_queue(const Compare& compare, Container&& cont, const Alloc& a);
 \end{itemdecl}
 
@@ -9511,7 +9511,7 @@ calls \tcode{make_heap(c.begin(), c.end(), comp)}.
 
 \indexlibrary{\idxcode{priority_queue}!constructor}%
 \begin{itemdecl}
-template <class Alloc> priority_queue(const priority_queue& q, const Alloc& a);
+template<class Alloc> priority_queue(const priority_queue& q, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9522,7 +9522,7 @@ the second argument, and initializes \tcode{comp} with \tcode{q.comp}.
 
 \indexlibrary{\idxcode{priority_queue}!constructor}%
 \begin{itemdecl}
-template <class Alloc> priority_queue(priority_queue&& q, const Alloc& a);
+template<class Alloc> priority_queue(priority_queue&& q, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9565,7 +9565,7 @@ push_heap(c.begin(), c.end(), comp);
 
 \indexlibrarymember{emplace}{priority_queue}%
 \begin{itemdecl}
-template <class... Args> void emplace(Args&&... args)
+template<class... Args> void emplace(Args&&... args)
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9598,7 +9598,7 @@ c.pop_back();
 
 \indexlibrarymember{swap}{priority_queue}%
 \begin{itemdecl}
-template <class T, class Container, class Compare>
+template<class T, class Container, class Compare>
   void swap(priority_queue<T, Container, Compare>& x,
             priority_queue<T, Container, Compare>& y) noexcept(noexcept(x.swap(y)));
 \end{itemdecl}
@@ -9636,7 +9636,7 @@ can be used.
 
 \begin{codeblock}
 namespace std {
-  template <class T, class Container = deque<T>>
+  template<class T, class Container = deque<T>>
   class stack {
   public:
     using value_type      = typename Container::value_type;
@@ -9651,11 +9651,11 @@ namespace std {
   public:
     explicit stack(const Container&);
     explicit stack(Container&& = Container());
-    template <class Alloc> explicit stack(const Alloc&);
-    template <class Alloc> stack(const Container&, const Alloc&);
-    template <class Alloc> stack(Container&&, const Alloc&);
-    template <class Alloc> stack(const stack&, const Alloc&);
-    template <class Alloc> stack(stack&&, const Alloc&);
+    template<class Alloc> explicit stack(const Alloc&);
+    template<class Alloc> stack(const Container&, const Alloc&);
+    template<class Alloc> stack(Container&&, const Alloc&);
+    template<class Alloc> stack(const stack&, const Alloc&);
+    template<class Alloc> stack(stack&&, const Alloc&);
 
     [[nodiscard]] bool empty() const    { return c.empty(); }
     size_type size()  const             { return c.size(); }
@@ -9663,7 +9663,7 @@ namespace std {
     const_reference   top() const       { return c.back(); }
     void push(const value_type& x)      { c.push_back(x); }
     void push(value_type&& x)           { c.push_back(std::move(x)); }
-    template <class... Args>
+    template<class... Args>
       decltype(auto) emplace(Args&&... args)
         { return c.emplace_back(std::forward<Args>(args)...); }
     void pop()                          { c.pop_back(); }
@@ -9677,7 +9677,7 @@ namespace std {
   template<class Container, class Allocator>
     stack(Container, Allocator) -> stack<typename Container::value_type, Container>;
 
-  template <class T, class Container, class Alloc>
+  template<class T, class Container, class Alloc>
     struct uses_allocator<stack<T, Container>, Alloc>
       : uses_allocator<Container, Alloc>::type { };
 }
@@ -9713,7 +9713,7 @@ the constructors in this subclause shall not participate in overload resolution.
 
 \indexlibrary{\idxcode{stack}!constructor}%
 \begin{itemdecl}
-template <class Alloc> explicit stack(const Alloc& a);
+template<class Alloc> explicit stack(const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9723,7 +9723,7 @@ template <class Alloc> explicit stack(const Alloc& a);
 
 \indexlibrary{\idxcode{stack}!constructor}%
 \begin{itemdecl}
-template <class Alloc> stack(const container_type& cont, const Alloc& a);
+template<class Alloc> stack(const container_type& cont, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9734,7 +9734,7 @@ second argument.
 
 \indexlibrary{\idxcode{stack}!constructor}%
 \begin{itemdecl}
-template <class Alloc> stack(container_type&& cont, const Alloc& a);
+template<class Alloc> stack(container_type&& cont, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9745,7 +9745,7 @@ as the second argument.
 
 \indexlibrary{\idxcode{stack}!constructor}%
 \begin{itemdecl}
-template <class Alloc> stack(const stack& s, const Alloc& a);
+template<class Alloc> stack(const stack& s, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9756,7 +9756,7 @@ as the second argument.
 
 \indexlibrary{\idxcode{stack}!constructor}%
 \begin{itemdecl}
-template <class Alloc> stack(stack&& s, const Alloc& a);
+template<class Alloc> stack(stack&& s, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9769,7 +9769,7 @@ as the second argument.
 
 \indexlibrary{\idxcode{operator==}!\idxcode{stack}}%
 \begin{itemdecl}
-template <class T, class Container>
+template<class T, class Container>
   bool operator==(const stack<T, Container>& x, const stack<T, Container>& y);
 \end{itemdecl}
 
@@ -9781,7 +9781,7 @@ template <class T, class Container>
 
 \indexlibrary{\idxcode{operator"!=}!\idxcode{stack}}%
 \begin{itemdecl}
-template <class T, class Container>
+template<class T, class Container>
   bool operator!=(const stack<T, Container>& x, const stack<T, Container>& y);
 \end{itemdecl}
 
@@ -9793,7 +9793,7 @@ template <class T, class Container>
 
 \indexlibrary{\idxcode{operator<}!\idxcode{stack}}%
 \begin{itemdecl}
-template <class T, class Container>
+template<class T, class Container>
   bool operator< (const stack<T, Container>& x, const stack<T, Container>& y);
 \end{itemdecl}
 
@@ -9805,7 +9805,7 @@ template <class T, class Container>
 
 \indexlibrary{\idxcode{operator<=}!\idxcode{stack}}%
 \begin{itemdecl}
-template <class T, class Container>
+template<class T, class Container>
   bool operator<=(const stack<T, Container>& x, const stack<T, Container>& y);
 \end{itemdecl}
 
@@ -9817,7 +9817,7 @@ template <class T, class Container>
 
 \indexlibrary{\idxcode{operator>}!\idxcode{stack}}%
 \begin{itemdecl}
-template <class T, class Container>
+template<class T, class Container>
   bool operator> (const stack<T, Container>& x, const stack<T, Container>& y);
 \end{itemdecl}
 
@@ -9829,7 +9829,7 @@ template <class T, class Container>
 
 \indexlibrary{\idxcode{operator>=}!\idxcode{stack}}%
 \begin{itemdecl}
-template <class T, class Container>
+template<class T, class Container>
     bool operator>=(const stack<T, Container>& x, const stack<T, Container>& y);
 \end{itemdecl}
 
@@ -9843,7 +9843,7 @@ template <class T, class Container>
 
 \indexlibrarymember{swap}{stack}%
 \begin{itemdecl}
-template <class T, class Container>
+template<class T, class Container>
   void swap(stack<T, Container>& x, stack<T, Container>& y) noexcept(noexcept(x.swap(y)));
 \end{itemdecl}
 

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -787,10 +787,10 @@ namespace std {
   class error_condition;
   class system_error;
 
-  template <class T>
+  template<class T>
     struct is_error_code_enum : public false_type {};
 
-  template <class T>
+  template<class T>
     struct is_error_condition_enum : public false_type {};
 
   enum class errc {
@@ -874,12 +874,12 @@ namespace std {
     wrong_protocol_type,                // \tcode{EPROTOTYPE}
   };
 
-  template <> struct is_error_condition_enum<errc> : true_type {};
+  template<> struct is_error_condition_enum<errc> : true_type {};
 
   // \ref{syserr.errcode.nonmembers}, non-member functions
   error_code make_error_code(errc e) noexcept;
 
-  template <class charT, class traits>
+  template<class charT, class traits>
     basic_ostream<charT, traits>&
       operator<<(basic_ostream<charT, traits>& os, const error_code& ec);
 
@@ -899,14 +899,14 @@ namespace std {
   bool operator!=(const error_condition& lhs, const error_condition& rhs) noexcept;
 
   // \ref{syserr.hash}, hash support
-  template <class T> struct hash;
-  template <> struct hash<error_code>;
-  template <> struct hash<error_condition>;
+  template<class T> struct hash;
+  template<> struct hash<error_code>;
+  template<> struct hash<error_condition>;
 
   // \ref{syserr}, system error support
-  template <class T>
+  template<class T>
     inline constexpr bool is_error_code_enum_v = is_error_code_enum<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_error_condition_enum_v = is_error_condition_enum<T>::value;
 }
 \end{codeblock}
@@ -1173,12 +1173,12 @@ namespace std {
     // \ref{syserr.errcode.constructors}, constructors
     error_code() noexcept;
     error_code(int val, const error_category& cat) noexcept;
-    template <class ErrorCodeEnum>
+    template<class ErrorCodeEnum>
       error_code(ErrorCodeEnum e) noexcept;
 
     // \ref{syserr.errcode.modifiers}, modifiers
     void assign(int val, const error_category& cat) noexcept;
-    template <class ErrorCodeEnum>
+    template<class ErrorCodeEnum>
       error_code& operator=(ErrorCodeEnum e) noexcept;
     void clear() noexcept;
 
@@ -1197,7 +1197,7 @@ namespace std {
   // \ref{syserr.errcode.nonmembers}, non-member functions
   error_code make_error_code(errc e) noexcept;
 
-  template <class charT, class traits>
+  template<class charT, class traits>
     basic_ostream<charT, traits>&
       operator<<(basic_ostream<charT, traits>& os, const error_code& ec);
 }
@@ -1233,7 +1233,7 @@ error_code(int val, const error_category& cat) noexcept;
 
 \indexlibrary{\idxcode{error_code}!constructor}%
 \begin{itemdecl}
-template <class ErrorCodeEnum>
+template<class ErrorCodeEnum>
   error_code(ErrorCodeEnum e) noexcept;
 \end{itemdecl}
 
@@ -1263,7 +1263,7 @@ void assign(int val, const error_category& cat) noexcept;
 
 \indexlibrarymember{operator=}{error_code}%
 \begin{itemdecl}
-template <class ErrorCodeEnum>
+template<class ErrorCodeEnum>
   error_code& operator=(ErrorCodeEnum e) noexcept;
 \end{itemdecl}
 
@@ -1356,7 +1356,7 @@ error_code make_error_code(errc e) noexcept;
 
 \indexlibrarymember{operator<<}{error_code}%
 \begin{itemdecl}
-template <class charT, class traits>
+template<class charT, class traits>
   basic_ostream<charT, traits>& operator<<(basic_ostream<charT, traits>& os, const error_code& ec);
 \end{itemdecl}
 
@@ -1384,12 +1384,12 @@ namespace std {
     // \ref{syserr.errcondition.constructors}, constructors
     error_condition() noexcept;
     error_condition(int val, const error_category& cat) noexcept;
-    template <class ErrorConditionEnum>
+    template<class ErrorConditionEnum>
       error_condition(ErrorConditionEnum e) noexcept;
 
     // \ref{syserr.errcondition.modifiers}, modifiers
     void assign(int val, const error_category& cat) noexcept;
-    template <class ErrorConditionEnum>
+    template<class ErrorConditionEnum>
       error_condition& operator=(ErrorConditionEnum e) noexcept;
     void clear() noexcept;
 
@@ -1436,7 +1436,7 @@ error_condition(int val, const error_category& cat) noexcept;
 
 \indexlibrary{\idxcode{error_condition}!constructor}%
 \begin{itemdecl}
-template <class ErrorConditionEnum>
+template<class ErrorConditionEnum>
   error_condition(ErrorConditionEnum e) noexcept;
 \end{itemdecl}
 
@@ -1467,7 +1467,7 @@ void assign(int val, const error_category& cat) noexcept;
 
 \indexlibrarymember{operator=}{error_condition}%
 \begin{itemdecl}
-template <class ErrorConditionEnum>
+template<class ErrorConditionEnum>
   error_condition& operator=(ErrorConditionEnum e) noexcept;
 \end{itemdecl}
 
@@ -1649,8 +1649,8 @@ bool operator!=(const error_condition& lhs, const error_condition& rhs) noexcept
 
 \indexlibrary{\idxcode{hash}!\idxcode{error_code}}%
 \begin{itemdecl}
-template <> struct hash<error_code>;
-template <> struct hash<error_condition>;
+template<> struct hash<error_code>;
+template<> struct hash<error_condition>;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/future.tex
+++ b/source/future.tex
@@ -233,7 +233,7 @@ the library provides the following:
 
 \indexlibrary{\idxcode{operator"!=}}%
 \begin{itemdecl}
-template <class T> bool operator!=(const T& x, const T& y);
+template<class T> bool operator!=(const T& x, const T& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -248,7 +248,7 @@ Type \tcode{T} is \tcode{EqualityComparable} (Table~\ref{tab:equalitycomparable}
 
 \indexlibrary{\idxcode{operator>}}%
 \begin{itemdecl}
-template <class T> bool operator>(const T& x, const T& y);
+template<class T> bool operator>(const T& x, const T& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -263,7 +263,7 @@ Type \tcode{T} is \tcode{LessThanComparable} (Table~\ref{tab:lessthancomparable}
 
 \indexlibrary{\idxcode{operator<=}}%
 \begin{itemdecl}
-template <class T> bool operator<=(const T& x, const T& y);
+template<class T> bool operator<=(const T& x, const T& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -278,7 +278,7 @@ Type \tcode{T} is \tcode{LessThanComparable} (Table~\ref{tab:lessthancomparable}
 
 \indexlibrary{\idxcode{operator>=}}%
 \begin{itemdecl}
-template <class T> bool operator>=(const T& x, const T& y);
+template<class T> bool operator>=(const T& x, const T& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1466,7 +1466,7 @@ namespace std {
     using second_argument_type = weak_ptr<T>;
   };
 
-  template <class T> class reference_wrapper {
+  template<class T> class reference_wrapper {
   public:
     using result_type          = @\seebelow@; // not always defined
     using argument_type        = @\seebelow@; // not always defined
@@ -1474,113 +1474,113 @@ namespace std {
     using second_argument_type = @\seebelow@; // not always defined
   };
 
-  template <class T> struct plus {
+  template<class T> struct plus {
     using first_argument_type  = T;
     using second_argument_type = T;
     using result_type          = T;
   };
 
-  template <class T> struct minus {
+  template<class T> struct minus {
     using first_argument_type  = T;
     using second_argument_type = T;
     using result_type          = T;
   };
 
-  template <class T> struct multiplies {
+  template<class T> struct multiplies {
     using first_argument_type  = T;
     using second_argument_type = T;
     using result_type          = T;
   };
 
-  template <class T> struct divides {
+  template<class T> struct divides {
     using first_argument_type  = T;
     using second_argument_type = T;
     using result_type          = T;
   };
 
-  template <class T> struct modulus {
+  template<class T> struct modulus {
     using first_argument_type  = T;
     using second_argument_type = T;
     using result_type          = T;
   };
 
-  template <class T> struct negate {
+  template<class T> struct negate {
     using argument_type = T;
     using result_type   = T;
   };
 
-  template <class T> struct equal_to {
+  template<class T> struct equal_to {
     using first_argument_type  = T;
     using second_argument_type = T;
     using result_type          = bool;
   };
 
-  template <class T> struct not_equal_to {
+  template<class T> struct not_equal_to {
     using first_argument_type  = T;
     using second_argument_type = T;
     using result_type          = bool;
   };
 
-  template <class T> struct greater {
+  template<class T> struct greater {
     using first_argument_type  = T;
     using second_argument_type = T;
     using result_type          = bool;
   };
 
-  template <class T> struct less {
+  template<class T> struct less {
     using first_argument_type  = T;
     using second_argument_type = T;
     using result_type          = bool;
   };
 
-  template <class T> struct greater_equal {
+  template<class T> struct greater_equal {
     using first_argument_type  = T;
     using second_argument_type = T;
     using result_type          = bool;
   };
 
-  template <class T> struct less_equal {
+  template<class T> struct less_equal {
     using first_argument_type  = T;
     using second_argument_type = T;
     using result_type          = bool;
   };
 
-  template <class T> struct logical_and {
+  template<class T> struct logical_and {
     using first_argument_type  = T;
     using second_argument_type = T;
     using result_type          = bool;
   };
 
-  template <class T> struct logical_or {
+  template<class T> struct logical_or {
     using first_argument_type  = T;
     using second_argument_type = T;
     using result_type          = bool;
   };
 
-  template <class T> struct logical_not {
+  template<class T> struct logical_not {
     using argument_type = T;
     using result_type   = bool;
   };
 
-  template <class T> struct bit_and {
+  template<class T> struct bit_and {
     using first_argument_type  = T;
     using second_argument_type = T;
     using result_type          = T;
   };
 
-  template <class T> struct bit_or {
+  template<class T> struct bit_or {
     using first_argument_type  = T;
     using second_argument_type = T;
     using result_type          = T;
   };
 
-  template <class T> struct bit_xor {
+  template<class T> struct bit_xor {
     using first_argument_type  = T;
     using second_argument_type = T;
     using result_type          = T;
   };
 
-  template <class T> struct bit_not {
+  template<class T> struct bit_not {
     using argument_type = T;
     using result_type   = T;
   };
@@ -1701,7 +1701,7 @@ The following member names are defined in addition to names specified in \ref{co
 \indexlibrarymember{second_argument_type}{multimap::value_compare}%
 \begin{codeblock}
 namespace std {
-  template <class Key, class T, class Compare, class Allocator>
+  template<class Key, class T, class Compare, class Allocator>
   class map<Key, T, Compare, Allocator>::value_compare {
   public:
     using result_type          = bool;
@@ -1709,7 +1709,7 @@ namespace std {
     using second_argument_type = value_type;
   };
 
-  template <class Key, class T, class Compare, class Allocator>
+  template<class Key, class T, class Compare, class Allocator>
   class multimap<Key, T, Compare, Allocator>::value_compare {
   public:
     using result_type          = bool;
@@ -1732,11 +1732,11 @@ The header
 \indexlibrary{\idxcode{not2}}%
 \begin{codeblock}
 namespace std {
-  template <class Predicate> class unary_negate;
-  template <class Predicate>
+  template<class Predicate> class unary_negate;
+  template<class Predicate>
     constexpr unary_negate<Predicate> not1(const Predicate&);
-  template <class Predicate> class binary_negate;
-  template <class Predicate>
+  template<class Predicate> class binary_negate;
+  template<class Predicate>
     constexpr binary_negate<Predicate> not2(const Predicate&);
 }
 \end{codeblock}
@@ -1750,7 +1750,7 @@ and return their logical negations\iref{expr.unary.op}.
 \indexlibrarymember{argument_type}{unary_negate}%
 \indexlibrarymember{result_type}{unary_negate}%
 \begin{codeblock}
-template <class Predicate>
+template<class Predicate>
 class unary_negate {
 public:
   constexpr explicit unary_negate(const Predicate& pred);
@@ -1771,7 +1771,7 @@ constexpr bool operator()(const typename Predicate::argument_type& x) const;
 
 \indexlibrary{\idxcode{not1}}%
 \begin{itemdecl}
-template <class Predicate>
+template<class Predicate>
    constexpr unary_negate<Predicate> not1(const Predicate& pred);
 \end{itemdecl}
 
@@ -1784,7 +1784,7 @@ template <class Predicate>
 \indexlibrarymember{second_argument_type}{binary_negate}%
 \indexlibrarymember{result_type}{binary_negate}%
 \begin{codeblock}
-template <class Predicate>
+template<class Predicate>
 class binary_negate {
 public:
   constexpr explicit binary_negate(const Predicate& pred);
@@ -1809,7 +1809,7 @@ constexpr bool operator()(const typename Predicate::first_argument_type& x,
 
 \indexlibrary{\idxcode{not2}}%
 \begin{itemdecl}
-template <class Predicate>
+template<class Predicate>
   constexpr binary_negate<Predicate> not2(const Predicate& pred);
 \end{itemdecl}
 
@@ -1827,17 +1827,17 @@ addition to those specified in \ref{default.allocator}:
 \begin{codeblock}
 namespace std {
   // specialization for \tcode{void}
-  template <> class allocator<void> {
+  template<> class allocator<void> {
   public:
     using value_type    = void;
     using pointer       = void*;
     using const_pointer = const void*;
     // reference-to-\tcode{void} members are impossible.
 
-    template <class U> struct rebind { using other = allocator<U>; };
+    template<class U> struct rebind { using other = allocator<U>; };
   };
 
-  template <class T> class allocator {
+  template<class T> class allocator {
    public:
     using size_type       = size_t;
     using difference_type = ptrdiff_t;
@@ -1845,7 +1845,7 @@ namespace std {
     using const_pointer   = const T*;
     using reference       = T&;
     using const_reference = const T&;
-    template <class U> struct rebind { using other = allocator<U>; };
+    template<class U> struct rebind { using other = allocator<U>; };
 
     T* address(T& x) const noexcept;
     const T* address(const T& x) const noexcept;
@@ -1854,7 +1854,7 @@ namespace std {
 
     template<class U, class... Args>
       void construct(U* p, Args&&... args);
-    template <class U>
+    template<class U>
       void destroy(U* p);
 
     size_t max_size() const noexcept;
@@ -1898,7 +1898,7 @@ but it is unspecified when or how often this function is called.
 
 \indexlibrarymember{construct}{allocator}%
 \begin{itemdecl}
-template <class U, class... Args>
+template<class U, class... Args>
   void construct(U* p, Args&&... args);
 \end{itemdecl}
 
@@ -1910,7 +1910,7 @@ As if by: \tcode{::new((void *)p) U(std::forward<Args>(args)...);}
 
 \indexlibrarymember{destroy}{allocator}%
 \begin{itemdecl}
-template <class U>
+template<class U>
   void destroy(U* p);
 \end{itemdecl}
 
@@ -1942,7 +1942,7 @@ The header
 \indexlibrary{\idxcode{raw_storage_iterator}}%
 \begin{codeblock}
 namespace std {
-  template <class OutputIterator, class T>
+  template<class OutputIterator, class T>
   class raw_storage_iterator {
   public:
     using iterator_category = output_iterator_tag;
@@ -2075,16 +2075,16 @@ The header
 
 \begin{codeblock}
 namespace std {
-  template <class T>
+  template<class T>
     pair<T*, ptrdiff_t> get_temporary_buffer(ptrdiff_t n) noexcept;
-  template <class T>
+  template<class T>
     void return_temporary_buffer(T* p);
 }
 \end{codeblock}
 
 \indexlibrary{\idxcode{get_temporary_buffer}}%
 \begin{itemdecl}
-template <class T>
+template<class T>
   pair<T*, ptrdiff_t> get_temporary_buffer(ptrdiff_t n) noexcept;
 \end{itemdecl}
 
@@ -2118,7 +2118,7 @@ otherwise returns a pair \tcode{P} such that
 
 \indexlibrary{\idxcode{return_temporary_buffer}}%
 \begin{itemdecl}
-template <class T> void return_temporary_buffer(T* p);
+template<class T> void return_temporary_buffer(T* p);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2147,15 +2147,15 @@ The header
 \indexlibrary{\idxcode{is_literal_type}}%
 \begin{codeblock}
 namespace std {
-  template <class T> struct is_literal_type;
-  template <class T> constexpr bool is_literal_type_v = is_literal_type<T>::value;
+  template<class T> struct is_literal_type;
+  template<class T> constexpr bool is_literal_type_v = is_literal_type<T>::value;
 
-  template <class> struct result_of;    // not defined
-  template <class Fn, class... ArgTypes> struct result_of<Fn(ArgTypes...)>;
-  template <class T> using result_of_t = typename result_of<T>::type;
+  template<class> struct result_of;    // not defined
+  template<class Fn, class... ArgTypes> struct result_of<Fn(ArgTypes...)>;
+  template<class T> using result_of_t = typename result_of<T>::type;
 
-  template <class T> struct is_pod;
-  template <class T> inline constexpr bool is_pod_v = is_pod<T>::value;
+  template<class T> struct is_pod;
+  template<class T> inline constexpr bool is_pod_v = is_pod<T>::value;
 }
 \end{codeblock}
 
@@ -2165,7 +2165,7 @@ any of the templates defined in this subclause is undefined,
 unless explicitly permitted by the specification of the corresponding template.
 
 \begin{itemdecl}
-template <class T> struct is_literal_type;
+template<class T> struct is_literal_type;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2181,7 +2181,7 @@ if \tcode{T} is a literal type\iref{basic.types}, and
 \end{itemdescr}
 
 \begin{itemdecl}
-template <class Fn, class... ArgTypes> struct result_of<Fn(ArgTypes...)>;
+template<class Fn, class... ArgTypes> struct result_of<Fn(ArgTypes...)>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2198,7 +2198,7 @@ If \tcode{type} is defined, it names the same type as \tcode{invoke_result_t<Fn,
 \end{itemdescr}
 
 \begin{itemdecl}
-template <class T> struct is_pod;
+template<class T> struct is_pod;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2236,7 +2236,7 @@ The header
 \begin{codeblock}
 namespace std {
   template<class Category, class T, class Distance = ptrdiff_t,
-    class Pointer = T*, class Reference = T&>
+           class Pointer = T*, class Reference = T&>
   struct iterator {
     using iterator_category = Category;
     using value_type        = T;
@@ -2559,21 +2559,21 @@ namespace std {
     little_endian = 1
   };
 
-  template <class Elem, unsigned long Maxcode = 0x10ffff, codecvt_mode Mode = (codecvt_mode)0>
+  template<class Elem, unsigned long Maxcode = 0x10ffff, codecvt_mode Mode = (codecvt_mode)0>
     class codecvt_utf8 : public codecvt<Elem, char, mbstate_t> {
     public:
       explicit codecvt_utf8(size_t refs = 0);
       ~codecvt_utf8();
     };
 
-  template <class Elem, unsigned long Maxcode = 0x10ffff, codecvt_mode Mode = (codecvt_mode)0>
+  template<class Elem, unsigned long Maxcode = 0x10ffff, codecvt_mode Mode = (codecvt_mode)0>
     class codecvt_utf16 : public codecvt<Elem, char, mbstate_t> {
     public:
       explicit codecvt_utf16(size_t refs = 0);
       ~codecvt_utf16();
     };
 
-  template <class Elem, unsigned long Maxcode = 0x10ffff, codecvt_mode Mode = (codecvt_mode)0>
+  template<class Elem, unsigned long Maxcode = 0x10ffff, codecvt_mode Mode = (codecvt_mode)0>
     class codecvt_utf8_utf16 : public codecvt<Elem, char, mbstate_t> {
     public:
       explicit codecvt_utf8_utf16(size_t refs = 0);
@@ -2657,13 +2657,13 @@ The header \tcode{<locale>} has the following additions:
 
 \begin{codeblock}
 namespace std {
-  template <class Codecvt, class Elem = wchar_t,
-            class Wide_alloc = allocator<Elem>,
-            class Byte_alloc = allocator<char>>
+  template<class Codecvt, class Elem = wchar_t,
+           class Wide_alloc = allocator<Elem>,
+           class Byte_alloc = allocator<char>>
     class wstring_convert;
 
-  template <class Codecvt, class Elem = wchar_t,
-            class Tr = char_traits<Elem>>
+  template<class Codecvt, class Elem = wchar_t,
+           class Tr = char_traits<Elem>>
     class wbuffer_convert;
 }
 \end{codeblock}
@@ -2688,9 +2688,9 @@ std::cout << mbstring;
 \indexlibrary{\idxcode{wstring_convert}}%
 \begin{codeblock}
 namespace std {
-  template <class Codecvt, class Elem = wchar_t,
-            class Wide_alloc = allocator<Elem>,
-            class Byte_alloc = allocator<char>>
+  template<class Codecvt, class Elem = wchar_t,
+           class Wide_alloc = allocator<Elem>,
+           class Byte_alloc = allocator<char>>
     class wstring_convert {
     public:
       using byte_string = basic_string<char, char_traits<char>, Byte_alloc>;
@@ -2941,7 +2941,7 @@ without affecting any streams or locales.
 \indexlibrary{\idxcode{wbuffer_convert}}%
 \begin{codeblock}
 namespace std {
-  template <class Codecvt, class Elem = wchar_t, class Tr = char_traits<Elem>>
+  template<class Codecvt, class Elem = wchar_t, class Tr = char_traits<Elem>>
     class wbuffer_convert : public basic_streambuf<Elem, Tr> {
     public:
       using state_type = typename Codecvt::state_type;

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -172,49 +172,49 @@ namespace std {
 
   template<class T> class allocator;
 
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
     class basic_ios;
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
     class basic_streambuf;
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
     class basic_istream;
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
     class basic_ostream;
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
     class basic_iostream;
 
-  template <class charT, class traits = char_traits<charT>,
-            class Allocator = allocator<charT>>
+  template<class charT, class traits = char_traits<charT>,
+           class Allocator = allocator<charT>>
     class basic_stringbuf;
-  template <class charT, class traits = char_traits<charT>,
-            class Allocator = allocator<charT>>
+  template<class charT, class traits = char_traits<charT>,
+           class Allocator = allocator<charT>>
     class basic_istringstream;
-  template <class charT, class traits = char_traits<charT>,
-            class Allocator = allocator<charT>>
+  template<class charT, class traits = char_traits<charT>,
+           class Allocator = allocator<charT>>
     class basic_ostringstream;
-  template <class charT, class traits = char_traits<charT>,
-            class Allocator = allocator<charT>>
+  template<class charT, class traits = char_traits<charT>,
+           class Allocator = allocator<charT>>
     class basic_stringstream;
 
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
     class basic_filebuf;
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
     class basic_ifstream;
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
     class basic_ofstream;
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
     class basic_fstream;
 
-  template <class charT, class traits = char_traits<charT>,
-            class Allocator = allocator<charT>>
+  template<class charT, class traits = char_traits<charT>,
+           class Allocator = allocator<charT>>
     class basic_syncbuf;
-  template <class charT, class traits = char_traits<charT>,
-            class Allocator = allocator<charT>>
+  template<class charT, class traits = char_traits<charT>,
+           class Allocator = allocator<charT>>
     class basic_osyncstream;
 
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
     class istreambuf_iterator;
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
     class ostreambuf_iterator;
 
   using ios  = basic_ios<char>;
@@ -256,7 +256,7 @@ namespace std {
   using wsyncbuf = basic_syncbuf<wchar_t>;
   using wosyncstream = basic_osyncstream<wchar_t>;
 
-  template <class state> class fpos;
+  template<class state> class fpos;
   using streampos  = fpos<char_traits<char>::state_type>;
   using wstreampos = fpos<char_traits<wchar_t>::state_type>;
 }
@@ -641,10 +641,10 @@ declared in
 namespace std {
   using streamoff  = @\impdef@;
   using streamsize = @\impdef@;
-  template <class stateT> class fpos;
+  template<class stateT> class fpos;
 
   class ios_base;
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
     class basic_ios;
 
   // \ref{std.ios.manip}, manipulators
@@ -690,7 +690,7 @@ namespace std {
     stream = 1
   };
 
-  template <> struct is_error_code_enum<io_errc> : public true_type { };
+  template<> struct is_error_code_enum<io_errc> : public true_type { };
   error_code make_error_code(io_errc e) noexcept;
   error_condition make_error_condition(io_errc e) noexcept;
   const error_category& iostream_category() noexcept;
@@ -1619,7 +1619,7 @@ has well-defined results.
 \indexlibrary{\idxcode{fpos}}%
 \begin{codeblock}
 namespace std {
-  template <class stateT> class fpos {
+  template<class stateT> class fpos {
   public:
     // \ref{fpos.members}, members
     stateT state() const;
@@ -1764,7 +1764,7 @@ then the behavior of that function is undefined.
 \indexlibrary{\idxcode{basic_ios}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
   class basic_ios : public ios_base {
   public:
     using char_type   = charT;
@@ -2795,7 +2795,7 @@ The object's \tcode{default_error_condition} and \tcode{equivalent} virtual func
 \indexlibrary{\idxcode{basic_streambuf<wchar_t>}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
     class basic_streambuf;
   using streambuf  = basic_streambuf<char>;
   using wstreambuf = basic_streambuf<wchar_t>;
@@ -2914,7 +2914,7 @@ and is the next element to read
 \indexlibrary{\idxcode{basic_streambuf}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
   class basic_streambuf {
   public:
     using char_type   = charT;
@@ -4046,22 +4046,22 @@ Returns
 
 \begin{codeblock}
 namespace std {
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
     class basic_istream;
 
   using istream  = basic_istream<char>;
   using wistream = basic_istream<wchar_t>;
 
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
     class basic_iostream;
 
   using iostream  = basic_iostream<char>;
   using wiostream = basic_iostream<wchar_t>;
 
-  template <class charT, class traits>
+  template<class charT, class traits>
     basic_istream<charT, traits>& ws(basic_istream<charT, traits>& is);
 
-  template <class charT, class traits, class T>
+  template<class charT, class traits, class T>
     basic_istream<charT, traits>& operator>>(basic_istream<charT, traits>&& is, T&& x);
 }
 \end{codeblock}
@@ -4076,20 +4076,20 @@ namespace std {
 
 \begin{codeblock}
 namespace std {
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
     class basic_ostream;
 
   using ostream  = basic_ostream<char>;
   using wostream = basic_ostream<wchar_t>;
 
-  template <class charT, class traits>
+  template<class charT, class traits>
     basic_ostream<charT, traits>& endl(basic_ostream<charT, traits>& os);
-  template <class charT, class traits>
+  template<class charT, class traits>
     basic_ostream<charT, traits>& ends(basic_ostream<charT, traits>& os);
-  template <class charT, class traits>
+  template<class charT, class traits>
     basic_ostream<charT, traits>& flush(basic_ostream<charT, traits>& os);
 
-  template <class charT, class traits, class T>
+  template<class charT, class traits, class T>
     basic_ostream<charT, traits>& operator<<(basic_ostream<charT, traits>&& os, const T& x);
 }
 \end{codeblock}
@@ -4111,23 +4111,23 @@ namespace std {
   template<class charT> @\textit{T4}@ setfill(charT c);
   @\textit{T5}@ setprecision(int n);
   @\textit{T6}@ setw(int n);
-  template <class moneyT> @\textit{T7}@ get_money(moneyT& mon, bool intl = false);
-  template <class moneyT> @\textit{T8}@ put_money(const moneyT& mon, bool intl = false);
-  template <class charT> @\textit{T9}@ get_time(struct tm* tmb, const charT* fmt);
-  template <class charT> @\textit{T10}@ put_time(const struct tm* tmb, const charT* fmt);
+  template<class moneyT> @\textit{T7}@ get_money(moneyT& mon, bool intl = false);
+  template<class moneyT> @\textit{T8}@ put_money(const moneyT& mon, bool intl = false);
+  template<class charT> @\textit{T9}@ get_time(struct tm* tmb, const charT* fmt);
+  template<class charT> @\textit{T10}@ put_time(const struct tm* tmb, const charT* fmt);
 
-  template <class charT>
+  template<class charT>
     @\textit{T11}@ quoted(const charT* s, charT delim = charT('"'), charT escape = charT('\\'));
 
-  template <class charT, class traits, class Allocator>
+  template<class charT, class traits, class Allocator>
     @\textit{T12}@ quoted(const basic_string<charT, traits, Allocator>& s,
     @\itcorr@           charT delim = charT('"'), charT escape = charT('\\'));
 
-  template <class charT, class traits, class Allocator>
+  template<class charT, class traits, class Allocator>
     @\textit{T13}@ quoted(basic_string<charT, traits, Allocator>& s,
     @\itcorr@           charT delim = charT('"'), charT escape = charT('\\'));
 
-  template <class charT, class traits>
+  template<class charT, class traits>
     @\textit{T14}@ quoted(basic_string_view<charT, traits> s,
     @\itcorr@           charT delim = charT('"'), charT escape = charT('\\'));
 }
@@ -4146,7 +4146,7 @@ and a function signature that control input from a stream buffer along with a fu
 \indexlibrary{\idxcode{basic_istream}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
   class basic_istream : virtual public basic_ios<charT, traits> {
   public:
     // types (inherited from \tcode{basic_ios}\iref{ios})
@@ -4377,7 +4377,7 @@ Exchanges the values returned by \tcode{gcount()} and
 \indexlibrary{\idxcode{sentry}!\idxcode{basic_istream}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
   class basic_istream<charT, traits>::sentry {
     using traits_type = traits;
     bool ok_; // \expos
@@ -5528,7 +5528,7 @@ In case of failure, the function calls \tcode{setstate(\brk{}failbit)} (which ma
 
 \indexlibrary{\idxcode{ws}}%
 \begin{itemdecl}
-template <class charT, class traits>
+template<class charT, class traits>
   basic_istream<charT, traits>& ws(basic_istream<charT, traits>& is);
 \end{itemdecl}
 
@@ -5557,7 +5557,7 @@ but not
 
 \indexlibrarymember{operator>>}{basic_istream}%
 \begin{itemdecl}
-template <class charT, class traits, class T>
+template<class charT, class traits, class T>
   basic_istream<charT, traits>& operator>>(basic_istream<charT, traits>&& is, T&& x);
 \end{itemdecl}
 
@@ -5579,7 +5579,7 @@ unless the expression \tcode{is >> std::forward<T>(x)} is well-formed.
 \indexlibrary{\idxcode{basic_iostream}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
   class basic_iostream
     : public basic_istream<charT, traits>,
       public basic_ostream<charT, traits> {
@@ -5706,7 +5706,7 @@ stream buffer along with a function template that inserts into stream rvalues.
 \indexlibrary{\idxcode{basic_ostream}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
   class basic_ostream : virtual public basic_ios<charT, traits> {
   public:
     // types (inherited from \tcode{basic_ios}\iref{ios})
@@ -5922,7 +5922,7 @@ void swap(basic_ostream& rhs);
 \indexlibrary{\idxcode{sentry}!\idxcode{basic_ostream}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
   class basic_ostream<charT, traits>::sentry {
     bool ok_; // \expos
   public:
@@ -6599,7 +6599,7 @@ Otherwise, if the sentry object returns \tcode{false}, does nothing.
 
 \indexlibrary{\idxcode{endl}}%
 \begin{itemdecl}
-template <class charT, class traits>
+template<class charT, class traits>
   basic_ostream<charT, traits>& endl(basic_ostream<charT, traits>& os);
 \end{itemdecl}
 
@@ -6618,7 +6618,7 @@ then
 
 \indexlibrary{\idxcode{ends}}%
 \begin{itemdecl}
-template <class charT, class traits>
+template<class charT, class traits>
   basic_ostream<charT, traits>& ends(basic_ostream<charT, traits>& os);
 \end{itemdecl}
 
@@ -6636,7 +6636,7 @@ calls
 
 \indexlibrary{\idxcode{flush}}%
 \begin{itemdecl}
-template <class charT, class traits>
+template<class charT, class traits>
   basic_ostream<charT, traits>& flush(basic_ostream<charT, traits>& os);
 \end{itemdecl}
 
@@ -6655,7 +6655,7 @@ Calls
 
 \indexlibrarymember{operator<<}{basic_ostream}%
 \begin{itemdecl}
-template <class charT, class traits, class T>
+template<class charT, class traits, class T>
   basic_ostream<charT, traits>& operator<<(basic_ostream<charT, traits>&& os, const T& x);
 \end{itemdecl}
 
@@ -6944,7 +6944,7 @@ parsing and formatting of sequences and values for money and time.
 
 \indexlibrary{\idxcode{get_money}}%
 \begin{itemdecl}
-template <class moneyT> @\unspec@ get_money(moneyT& mon, bool intl = false);
+template<class moneyT> @\unspec@ get_money(moneyT& mon, bool intl = false);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6963,7 +6963,7 @@ then the expression \tcode{in >> get_money(mon, intl)} behaves as if it called
 \tcode{f(in, mon, intl)}, where the function \tcode{f} is defined as:
 
 \begin{codeblock}
-template <class charT, class traits, class moneyT>
+template<class charT, class traits, class moneyT>
 void f(basic_ios<charT, traits>& str, moneyT& mon, bool intl) {
   using Iter     = istreambuf_iterator<charT, traits>;
   using MoneyGet = money_get<charT, Iter>;
@@ -6984,7 +6984,7 @@ The expression \tcode{in >> get_money(mon, intl)} shall have type
 
 \indexlibrary{\idxcode{put_money}}%
 \begin{itemdecl}
-template <class moneyT> @\unspec@ put_money(const moneyT& mon, bool intl = false);
+template<class moneyT> @\unspec@ put_money(const moneyT& mon, bool intl = false);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7000,7 +7000,7 @@ formatted output function\iref{ostream.formatted.reqmts} that calls
 \tcode{f(out, mon, intl)}, where the function \tcode{f} is defined as:
 
 \begin{codeblock}
-template <class charT, class traits, class moneyT>
+template<class charT, class traits, class moneyT>
 void f(basic_ios<charT, traits>& str, const moneyT& mon, bool intl) {
   using Iter     = ostreambuf_iterator<charT, traits>;
   using MoneyPut = money_put<charT, Iter>;
@@ -7020,7 +7020,7 @@ The expression \tcode{out << put_money(mon, intl)} shall have type
 
 \indexlibrary{\idxcode{get_time}}%
 \begin{itemdecl}
-template <class charT> @\unspec@ get_time(struct tm* tmb, const charT* fmt);
+template<class charT> @\unspec@ get_time(struct tm* tmb, const charT* fmt);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7035,7 +7035,7 @@ fmt)} behaves as if it called \tcode{f(in, tmb, fmt)}, where the function \tcode
 defined as:
 
 \begin{codeblock}
-template <class charT, class traits>
+template<class charT, class traits>
 void f(basic_ios<charT, traits>& str, struct tm* tmb, const charT* fmt) {
   using Iter    = istreambuf_iterator<charT, traits>;
   using TimeGet = time_get<charT, Iter>;
@@ -7057,7 +7057,7 @@ The expression \tcode{in >> get_time(tmb, fmt)} shall have type
 
 \indexlibrary{\idxcode{put_time}}%
 \begin{itemdecl}
-template <class charT> @\unspec@ put_time(const struct tm* tmb, const charT* fmt);
+template<class charT> @\unspec@ put_time(const struct tm* tmb, const charT* fmt);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7074,7 +7074,7 @@ type \tcode{basic_ostream<charT, traits>} then the expression
 where the function \tcode{f} is defined as:
 
 \begin{codeblock}
-template <class charT, class traits>
+template<class charT, class traits>
 void f(basic_ios<charT, traits>& str, const struct tm* tmb, const charT* fmt) {
   using Iter    = ostreambuf_iterator<charT, traits>;
   using TimePut = time_put<charT, Iter>;
@@ -7099,12 +7099,12 @@ The expression \tcode{out << put_time(tmb, fmt)} shall have type
 
 \indexlibrary{\idxcode{quoted}}%
 \begin{itemdecl}
-template <class charT>
+template<class charT>
   @\unspec@ quoted(const charT* s, charT delim = charT('"'), charT escape = charT('\\'));
-template <class charT, class traits, class Allocator>
+template<class charT, class traits, class Allocator>
   @\unspec@ quoted(const basic_string<charT, traits, Allocator>& s,
   @\itcorr@                   charT delim = charT('"'), charT escape = charT('\\'));
-template <class charT, class traits>
+template<class charT, class traits>
   @\unspec@ quoted(basic_string_view<charT, traits> s,
   @\itcorr@                   charT delim = charT('"'), charT escape = charT('\\'));
 \end{itemdecl}
@@ -7137,7 +7137,7 @@ The expression \tcode{out << quoted(s, delim, escape)} shall have type
 
 \indexlibrary{\idxcode{quoted}}%
 \begin{itemdecl}
-template <class charT, class traits, class Allocator>
+template<class charT, class traits, class Allocator>
   @\unspec@ quoted(basic_string<charT, traits, Allocator>& s,
   @\itcorr@                   charT delim = charT('"'), charT escape = charT('\\'));
 \end{itemdecl}
@@ -7204,28 +7204,28 @@ The expression \tcode{in >> quoted(s, delim, escape)} shall have type
 \indexlibrary{\idxcode{basic_stringstream<wchar_t>}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class traits = char_traits<charT>,
-            class Allocator = allocator<charT>>
+  template<class charT, class traits = char_traits<charT>,
+           class Allocator = allocator<charT>>
     class basic_stringbuf;
 
   using stringbuf  = basic_stringbuf<char>;
   using wstringbuf = basic_stringbuf<wchar_t>;
 
-  template <class charT, class traits = char_traits<charT>,
-            class Allocator = allocator<charT>>
+  template<class charT, class traits = char_traits<charT>,
+           class Allocator = allocator<charT>>
     class basic_istringstream;
 
   using istringstream  = basic_istringstream<char>;
   using wistringstream = basic_istringstream<wchar_t>;
 
-  template <class charT, class traits = char_traits<charT>,
-            class Allocator = allocator<charT>>
+  template<class charT, class traits = char_traits<charT>,
+           class Allocator = allocator<charT>>
     class basic_ostringstream;
   using ostringstream  = basic_ostringstream<char>;
   using wostringstream = basic_ostringstream<wchar_t>;
 
-  template <class charT, class traits = char_traits<charT>,
-            class Allocator = allocator<charT>>
+  template<class charT, class traits = char_traits<charT>,
+           class Allocator = allocator<charT>>
     class basic_stringstream;
   using stringstream  = basic_stringstream<char>;
   using wstringstream = basic_stringstream<wchar_t>;
@@ -7246,8 +7246,8 @@ as described in~\ref{string.classes}.
 \indexlibrary{\idxcode{basic_stringbuf}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class traits = char_traits<charT>,
-            class Allocator = allocator<charT>>
+  template<class charT, class traits = char_traits<charT>,
+           class Allocator = allocator<charT>>
   class basic_stringbuf : public basic_streambuf<charT, traits> {
   public:
     using char_type      = charT;
@@ -7293,7 +7293,7 @@ namespace std {
     ios_base::openmode mode;  // \expos
   };
 
-  template <class charT, class traits, class Allocator>
+  template<class charT, class traits, class Allocator>
     void swap(basic_stringbuf<charT, traits, Allocator>& x,
               basic_stringbuf<charT, traits, Allocator>& y);
 }
@@ -7431,7 +7431,7 @@ and \tcode{rhs}.
 
 \indexlibrarymember{swap}{basic_stringbuf}%
 \begin{itemdecl}
-template <class charT, class traits, class Allocator>
+template<class charT, class traits, class Allocator>
   void swap(basic_stringbuf<charT, traits, Allocator>& x,
             basic_stringbuf<charT, traits, Allocator>& y);
 \end{itemdecl}
@@ -7766,8 +7766,8 @@ has no effect.
 \indexlibrary{\idxcode{basic_istringstream}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class traits = char_traits<charT>,
-            class Allocator = allocator<charT>>
+  template<class charT, class traits = char_traits<charT>,
+           class Allocator = allocator<charT>>
   class basic_istringstream : public basic_istream<charT, traits> {
   public:
     using char_type      = charT;
@@ -7800,7 +7800,7 @@ namespace std {
     basic_stringbuf<charT, traits, Allocator> sb; // \expos
   };
 
-  template <class charT, class traits, class Allocator>
+  template<class charT, class traits, class Allocator>
     void swap(basic_istringstream<charT, traits, Allocator>& x,
               basic_istringstream<charT, traits, Allocator>& y);
 }
@@ -7902,7 +7902,7 @@ void swap(basic_istringstream& rhs);
 
 \indexlibrarymember{swap}{basic_istringstream}%
 \begin{itemdecl}
-template <class charT, class traits, class Allocator>
+template<class charT, class traits, class Allocator>
   void swap(basic_istringstream<charT, traits, Allocator>& x,
             basic_istringstream<charT, traits, Allocator>& y);
 \end{itemdecl}
@@ -7953,8 +7953,8 @@ Calls
 \indexlibrary{\idxcode{basic_ostringstream}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class traits = char_traits<charT>,
-            class Allocator = allocator<charT>>
+  template<class charT, class traits = char_traits<charT>,
+           class Allocator = allocator<charT>>
   class basic_ostringstream : public basic_ostream<charT, traits> {
   public:
     using char_type      = charT;
@@ -7987,7 +7987,7 @@ namespace std {
     basic_stringbuf<charT, traits, Allocator> sb; // \expos
   };
 
-  template <class charT, class traits, class Allocator>
+  template<class charT, class traits, class Allocator>
     void swap(basic_ostringstream<charT, traits, Allocator>& x,
               basic_ostringstream<charT, traits, Allocator>& y);
 }
@@ -8090,7 +8090,7 @@ void swap(basic_ostringstream& rhs);
 
 \indexlibrarymember{swap}{basic_ostringstream}%
 \begin{itemdecl}
-template <class charT, class traits, class Allocator>
+template<class charT, class traits, class Allocator>
   void swap(basic_ostringstream<charT, traits, Allocator>& x,
             basic_ostringstream<charT, traits, Allocator>& y);
 \end{itemdecl}
@@ -8141,8 +8141,8 @@ Calls
 \indexlibrary{\idxcode{basic_stringstream}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class traits = char_traits<charT>,
-            class Allocator = allocator<charT>>
+  template<class charT, class traits = char_traits<charT>,
+           class Allocator = allocator<charT>>
   class basic_stringstream : public basic_iostream<charT, traits> {
   public:
     using char_type      = charT;
@@ -8175,7 +8175,7 @@ namespace std {
     basic_stringbuf<charT, traits> sb;  // \expos
   };
 
-  template <class charT, class traits, class Allocator>
+  template<class charT, class traits, class Allocator>
     void swap(basic_stringstream<charT, traits, Allocator>& x,
               basic_stringstream<charT, traits, Allocator>& y);
 }
@@ -8283,7 +8283,7 @@ void swap(basic_stringstream& rhs);
 
 \indexlibrarymember{swap}{basic_stringstream}%
 \begin{itemdecl}
-template <class charT, class traits, class Allocator>
+template<class charT, class traits, class Allocator>
   void swap(basic_stringstream<charT, traits, Allocator>& x,
             basic_stringstream<charT, traits, Allocator>& y);
 \end{itemdecl}
@@ -8351,22 +8351,22 @@ Calls
 \indexlibrary{\idxcode{basic_fstream<wchar_t>}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
     class basic_filebuf;
   using filebuf  = basic_filebuf<char>;
   using wfilebuf = basic_filebuf<wchar_t>;
 
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
     class basic_ifstream;
   using ifstream  = basic_ifstream<char>;
   using wifstream = basic_ifstream<wchar_t>;
 
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
     class basic_ofstream;
   using ofstream  = basic_ofstream<char>;
   using wofstream = basic_ofstream<wchar_t>;
 
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
     class basic_fstream;
   using fstream  = basic_fstream<char>;
   using wfstream = basic_fstream<wchar_t>;
@@ -8399,7 +8399,7 @@ These functions enable class \tcode{path} support for systems with a wide native
 \indexlibrary{\idxcode{basic_filebuf}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
   class basic_filebuf : public basic_streambuf<charT, traits> {
   public:
     using char_type   = charT;
@@ -8450,7 +8450,7 @@ namespace std {
     void     imbue(const locale& loc) override;
   };
 
-  template <class charT, class traits>
+  template<class charT, class traits>
     void swap(basic_filebuf<charT, traits>& x,
               basic_filebuf<charT, traits>& y);
 }
@@ -8608,7 +8608,7 @@ and \tcode{rhs}.
 
 \indexlibrarymember{swap}{basic_filebuf}%
 \begin{itemdecl}
-template <class charT, class traits>
+template<class charT, class traits>
   void swap(basic_filebuf<charT, traits>& x,
             basic_filebuf<charT, traits>& y);
 \end{itemdecl}
@@ -9168,7 +9168,7 @@ the original contents of the file.
 \indexlibrary{\idxcode{basic_ifstream}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
   class basic_ifstream : public basic_istream<charT, traits> {
   public:
     using char_type   = charT;
@@ -9209,7 +9209,7 @@ namespace std {
     basic_filebuf<charT, traits> sb; // \expos
   };
 
-  template <class charT, class traits>
+  template<class charT, class traits>
     void swap(basic_ifstream<charT, traits>& x,
               basic_ifstream<charT, traits>& y);
 }
@@ -9329,7 +9329,7 @@ and \tcode{rhs} by calling
 
 \indexlibrarymember{swap}{basic_ifstream}%
 \begin{itemdecl}
-template <class charT, class traits>
+template<class charT, class traits>
   void swap(basic_ifstream<charT, traits>& x,
             basic_ifstream<charT, traits>& y);
 \end{itemdecl}
@@ -9417,7 +9417,7 @@ calls
 \indexlibrary{\idxcode{basic_ofstream}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
   class basic_ofstream : public basic_ostream<charT, traits> {
   public:
     using char_type   = charT;
@@ -9458,7 +9458,7 @@ namespace std {
     basic_filebuf<charT, traits> sb; // \expos
   };
 
-  template <class charT, class traits>
+  template<class charT, class traits>
     void swap(basic_ofstream<charT, traits>& x,
               basic_ofstream<charT, traits>& y);
 }
@@ -9577,7 +9577,7 @@ and \tcode{rhs} by calling
 
 \indexlibrarymember{swap}{basic_ofstream}%
 \begin{itemdecl}
-template <class charT, class traits>
+template<class charT, class traits>
   void swap(basic_ofstream<charT, traits>& x,
             basic_ofstream<charT, traits>& y);
 \end{itemdecl}
@@ -9663,7 +9663,7 @@ void open(const filesystem::path& s, ios_base::openmode mode = ios_base::out);
 \indexlibrary{\idxcode{basic_fstream}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
   class basic_fstream : public basic_iostream<charT, traits> {
   public:
     using char_type   = charT;
@@ -9715,7 +9715,7 @@ namespace std {
     basic_filebuf<charT, traits> sb; // \expos
   };
 
-  template <class charT, class traits>
+  template<class charT, class traits>
     void swap(basic_fstream<charT, traits>& x,
               basic_fstream<charT, traits>& y);
 }
@@ -9842,7 +9842,7 @@ and \tcode{rhs} by calling
 
 \indexlibrarymember{swap}{basic_fstream}%
 \begin{itemdecl}
-template <class charT, class traits>
+template<class charT, class traits>
   void swap(basic_fstream<charT, traits>& x,
             basic_fstream<charT, traits>& y);
 \end{itemdecl}
@@ -9942,13 +9942,13 @@ calls
 \indexlibrary{\idxcode{wosyncstream}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class traits, class Allocator>
+  template<class charT, class traits, class Allocator>
     class basic_syncbuf;
 
   using syncbuf = basic_syncbuf<char>;
   using wsyncbuf = basic_syncbuf<wchar_t>;
 
-  template <class charT, class traits, class Allocator>
+  template<class charT, class traits, class Allocator>
     class basic_osyncstream;
 
   using osyncstream = basic_osyncstream<char>;
@@ -9967,7 +9967,7 @@ to synchronize execution agents writing to the same stream.
 \indexlibrary{\idxcode{basic_syncbuf}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class traits, class Allocator>
+  template<class charT, class traits, class Allocator>
   class basic_syncbuf : public basic_streambuf<charT, traits> {
   public:
     using char_type      = charT;
@@ -10006,7 +10006,7 @@ namespace std {
   };
 
   // \ref{syncstream.syncbuf.special}, specialized algorithms
-  template <class charT, class traits, class Allocator>
+  template<class charT, class traits, class Allocator>
     void swap(basic_syncbuf<charT, traits, Allocator>&,
               basic_syncbuf<charT, traits, Allocator>&);
 }
@@ -10270,7 +10270,7 @@ returns \tcode{-1}; otherwise \tcode{0}.
 
 \indexlibrarymember{swap}{basic_syncbuf}%
 \begin{itemdecl}
-template <class charT, class traits, class Allocator>
+template<class charT, class traits, class Allocator>
   void swap(basic_syncbuf<charT, traits, Allocator>& a,
             basic_syncbuf<charT, traits, Allocator>& b) noexcept;
 \end{itemdecl}
@@ -10288,7 +10288,7 @@ Equivalent to \tcode{a.swap(b)}.
 \indexlibrary{\idxcode{basic_osyncstream}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class traits, class Allocator>
+  template<class charT, class traits, class Allocator>
   class basic_osyncstream : public basic_ostream<charT, traits> {
   public:
     using char_type   = charT;
@@ -10700,17 +10700,17 @@ namespace std::filesystem {
   path operator/ (const path& lhs, const path& rhs);
 
   // \ref{fs.path.io}, \tcode{path} inserter and extractor
-  template <class charT, class traits>
+  template<class charT, class traits>
     basic_ostream<charT, traits>&
       operator<<(basic_ostream<charT, traits>& os, const path& p);
-  template <class charT, class traits>
+  template<class charT, class traits>
     basic_istream<charT, traits>&
       operator>>(basic_istream<charT, traits>& is, path& p);
 
   // \ref{fs.path.factory}, \tcode{path} factory functions
-  template <class Source>
+  template<class Source>
     path u8path(const Source& source);
-  template <class InputIterator>
+  template<class InputIterator>
     path u8path(InputIterator first, InputIterator last);
 
   // \ref{fs.class.filesystem_error}, filesystem errors
@@ -11036,13 +11036,13 @@ namespace std::filesystem {
     path(const path& p);
     path(path&& p) noexcept;
     path(string_type&& source, format fmt = auto_format);
-    template <class Source>
+    template<class Source>
       path(const Source& source, format fmt = auto_format);
-    template <class InputIterator>
+    template<class InputIterator>
       path(InputIterator first, InputIterator last, format fmt = auto_format);
-    template <class Source>
+    template<class Source>
       path(const Source& source, const locale& loc, format fmt = auto_format);
-    template <class InputIterator>
+    template<class InputIterator>
       path(InputIterator first, InputIterator last, const locale& loc, format fmt = auto_format);
     ~path();
 
@@ -11051,20 +11051,20 @@ namespace std::filesystem {
     path& operator=(path&& p) noexcept;
     path& operator=(string_type&& source);
     path& assign(string_type&& source);
-    template <class Source>
+    template<class Source>
       path& operator=(const Source& source);
-    template <class Source>
+    template<class Source>
       path& assign(const Source& source);
-    template <class InputIterator>
+    template<class InputIterator>
       path& assign(InputIterator first, InputIterator last);
 
     // \ref{fs.path.append}, appends
     path& operator/=(const path& p);
-    template <class Source>
+    template<class Source>
       path& operator/=(const Source& source);
-    template <class Source>
+    template<class Source>
       path& append(const Source& source);
-    template <class InputIterator>
+    template<class InputIterator>
       path& append(InputIterator first, InputIterator last);
 
     // \ref{fs.path.concat}, concatenation
@@ -11073,13 +11073,13 @@ namespace std::filesystem {
     path& operator+=(basic_string_view<value_type> x);
     path& operator+=(const value_type* x);
     path& operator+=(value_type x);
-    template <class Source>
+    template<class Source>
       path& operator+=(const Source& x);
-    template <class EcharT>
+    template<class EcharT>
       path& operator+=(EcharT x);
-    template <class Source>
+    template<class Source>
       path& concat(const Source& x);
-    template <class InputIterator>
+    template<class InputIterator>
       path& concat(InputIterator first, InputIterator last);
 
     // \ref{fs.path.modifiers}, modifiers
@@ -11095,8 +11095,8 @@ namespace std::filesystem {
     const value_type*  c_str() const noexcept;
     operator string_type() const;
 
-    template <class EcharT, class traits = char_traits<EcharT>,
-              class Allocator = allocator<EcharT>>
+    template<class EcharT, class traits = char_traits<EcharT>,
+             class Allocator = allocator<EcharT>>
       basic_string<EcharT, traits, Allocator>
         string(const Allocator& a = Allocator()) const;
     std::string    string() const;
@@ -11106,8 +11106,8 @@ namespace std::filesystem {
     std::u32string u32string() const;
 
     // \ref{fs.path.generic.obs}, generic format observers
-    template <class EcharT, class traits = char_traits<EcharT>,
-              class Allocator = allocator<EcharT>>
+    template<class EcharT, class traits = char_traits<EcharT>,
+             class Allocator = allocator<EcharT>>
       basic_string<EcharT, traits, Allocator>
         generic_string(const Allocator& a = Allocator()) const;
     std::string    generic_string() const;
@@ -11544,9 +11544,9 @@ converting format if required\iref{fs.path.fmt.cvt}.
 
 \indexlibrary{\idxcode{path}!constructor}%
 \begin{itemdecl}
-template <class Source>
+template<class Source>
   path(const Source& source, format fmt = auto_format);
-template <class InputIterator>
+template<class InputIterator>
   path(InputIterator first, InputIterator last, format fmt = auto_format);
 \end{itemdecl}
 
@@ -11561,9 +11561,9 @@ for which the pathname in that format is \tcode{s}.
 
 \indexlibrary{\idxcode{path}!constructor}%
 \begin{itemdecl}
-template <class Source>
+template<class Source>
   path(const Source& source, const locale& loc, format fmt = auto_format);
-template <class InputIterator>
+template<class InputIterator>
   path(InputIterator first, InputIterator last, const locale& loc, format fmt = auto_format);
 \end{itemdecl}
 
@@ -11680,11 +11680,11 @@ to the original value of \tcode{source}.
 \indexlibrarymember{operator=}{path}%
 \indexlibrarymember{assign}{path}%
 \begin{itemdecl}
-template <class Source>
+template<class Source>
   path& operator=(const Source& source);
-template <class Source>
+template<class Source>
   path& assign(const Source& source);
-template <class InputIterator>
+template<class InputIterator>
   path& assign(InputIterator first, InputIterator last);
 \end{itemdecl}
 
@@ -11760,9 +11760,9 @@ path("c:foo") / "c:bar"; // yields \tcode{"c:foo/bar"}
 \indexlibrarymember{operator/=}{path}%
 \indexlibrarymember{append}{path}%
 \begin{itemdecl}
-template <class Source>
+template<class Source>
   path& operator/=(const Source& source);
-template <class Source>
+template<class Source>
   path& append(const Source& source);
 \end{itemdecl}
 
@@ -11774,7 +11774,7 @@ template <class Source>
 \indexlibrarymember{operator/=}{path}%
 \indexlibrarymember{append}{path}%
 \begin{itemdecl}
-template <class InputIterator>
+template<class InputIterator>
   path& append(InputIterator first, InputIterator last);
 \end{itemdecl}
 
@@ -11793,11 +11793,11 @@ path& operator+=(const string_type& x);
 path& operator+=(basic_string_view<value_type> x);
 path& operator+=(const value_type* x);
 path& operator+=(value_type x);
-template <class Source>
+template<class Source>
   path& operator+=(const Source& x);
-template <class EcharT>
+template<class EcharT>
   path& operator+=(EcharT x);
-template <class Source>
+template<class Source>
   path& concat(const Source& x);
 \end{itemdecl}
 
@@ -11815,7 +11815,7 @@ and may not be portable between operating systems.
 
 \indexlibrarymember{concat}{path}%
 \begin{itemdecl}
-template <class InputIterator>
+template<class InputIterator>
   path& concat(InputIterator first, InputIterator last);
 \end{itemdecl}
 
@@ -12002,8 +12002,8 @@ operator string_type() const;
 
 \indexlibrarymember{string}{path}%
 \begin{itemdecl}
-template <class EcharT, class traits = char_traits<EcharT>,
-          class Allocator = allocator<EcharT>>
+template<class EcharT, class traits = char_traits<EcharT>,
+         class Allocator = allocator<EcharT>>
   basic_string<EcharT, traits, Allocator>
     string(const Allocator& a = Allocator()) const;
 \end{itemdecl}
@@ -12060,8 +12060,8 @@ returns \tcode{"foo/bar"}. \end{example}
 
 \indexlibrarymember{generic_string}{path}%
 \begin{itemdecl}
-template <class EcharT, class traits = char_traits<EcharT>,
-          class Allocator = allocator<EcharT>>
+template<class EcharT, class traits = char_traits<EcharT>,
+         class Allocator = allocator<EcharT>>
   basic_string<EcharT, traits, Allocator>
     generic_string(const Allocator& a = Allocator()) const;
 \end{itemdecl}
@@ -12695,7 +12695,7 @@ path operator/ (const path& lhs, const path& rhs);
 
 \indexlibrarymember{operator<<}{path}%
 \begin{itemdecl}
-template <class charT, class traits>
+template<class charT, class traits>
   basic_ostream<charT, traits>&
     operator<<(basic_ostream<charT, traits>& os, const path& p);
 \end{itemdecl}
@@ -12711,7 +12711,7 @@ template <class charT, class traits>
 
 \indexlibrarymember{operator>>}{path}%
 \begin{itemdecl}
-template <class charT, class traits>
+template<class charT, class traits>
   basic_istream<charT, traits>&
     operator>>(basic_istream<charT, traits>& is, path& p);
 \end{itemdecl}
@@ -12734,9 +12734,9 @@ p = tmp;
 
 \indexlibrary{\idxcode{u8path}}%
 \begin{itemdecl}
-template <class Source>
+template<class Source>
   path u8path(const Source& source);
-template <class InputIterator>
+template<class InputIterator>
   path u8path(InputIterator first, InputIterator last);
 \end{itemdecl}
 

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -700,162 +700,162 @@ namespace std {
   struct random_access_iterator_tag: public bidirectional_iterator_tag { };
 
   // \ref{iterator.operations}, iterator operations
-  template <class InputIterator, class Distance>
+  template<class InputIterator, class Distance>
     constexpr void
       advance(InputIterator& i, Distance n);
-  template <class InputIterator>
+  template<class InputIterator>
     constexpr typename iterator_traits<InputIterator>::difference_type
       distance(InputIterator first, InputIterator last);
-  template <class InputIterator>
+  template<class InputIterator>
     constexpr InputIterator
       next(InputIterator x,
            typename iterator_traits<InputIterator>::difference_type n = 1);
-  template <class BidirectionalIterator>
+  template<class BidirectionalIterator>
     constexpr BidirectionalIterator
       prev(BidirectionalIterator x,
            typename iterator_traits<BidirectionalIterator>::difference_type n = 1);
 
   // \ref{predef.iterators}, predefined iterators
-  template <class Iterator> class reverse_iterator;
+  template<class Iterator> class reverse_iterator;
 
-  template <class Iterator1, class Iterator2>
+  template<class Iterator1, class Iterator2>
     constexpr bool operator==(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
-  template <class Iterator1, class Iterator2>
+  template<class Iterator1, class Iterator2>
     constexpr bool operator<(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
-  template <class Iterator1, class Iterator2>
+  template<class Iterator1, class Iterator2>
     constexpr bool operator!=(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
-  template <class Iterator1, class Iterator2>
+  template<class Iterator1, class Iterator2>
     constexpr bool operator>(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
-  template <class Iterator1, class Iterator2>
+  template<class Iterator1, class Iterator2>
     constexpr bool operator>=(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
-  template <class Iterator1, class Iterator2>
+  template<class Iterator1, class Iterator2>
     constexpr bool operator<=(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
 
-  template <class Iterator1, class Iterator2>
+  template<class Iterator1, class Iterator2>
     constexpr auto operator-(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y) -> decltype(y.base() - x.base());
-  template <class Iterator>
+  template<class Iterator>
     constexpr reverse_iterator<Iterator>
       operator+(
     typename reverse_iterator<Iterator>::difference_type n,
     const reverse_iterator<Iterator>& x);
 
-  template <class Iterator>
+  template<class Iterator>
     constexpr reverse_iterator<Iterator> make_reverse_iterator(Iterator i);
 
-  template <class Container> class back_insert_iterator;
-  template <class Container>
+  template<class Container> class back_insert_iterator;
+  template<class Container>
     back_insert_iterator<Container> back_inserter(Container& x);
 
-  template <class Container> class front_insert_iterator;
-  template <class Container>
+  template<class Container> class front_insert_iterator;
+  template<class Container>
     front_insert_iterator<Container> front_inserter(Container& x);
 
-  template <class Container> class insert_iterator;
-  template <class Container>
+  template<class Container> class insert_iterator;
+  template<class Container>
     insert_iterator<Container> inserter(Container& x, typename Container::iterator i);
 
-  template <class Iterator> class move_iterator;
-  template <class Iterator1, class Iterator2>
+  template<class Iterator> class move_iterator;
+  template<class Iterator1, class Iterator2>
     constexpr bool operator==(
       const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
-  template <class Iterator1, class Iterator2>
+  template<class Iterator1, class Iterator2>
     constexpr bool operator!=(
       const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
-  template <class Iterator1, class Iterator2>
+  template<class Iterator1, class Iterator2>
     constexpr bool operator<(
       const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
-  template <class Iterator1, class Iterator2>
+  template<class Iterator1, class Iterator2>
     constexpr bool operator<=(
       const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
-  template <class Iterator1, class Iterator2>
+  template<class Iterator1, class Iterator2>
     constexpr bool operator>(
       const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
-  template <class Iterator1, class Iterator2>
+  template<class Iterator1, class Iterator2>
     constexpr bool operator>=(
       const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
 
-  template <class Iterator1, class Iterator2>
+  template<class Iterator1, class Iterator2>
     constexpr auto operator-(
     const move_iterator<Iterator1>& x,
     const move_iterator<Iterator2>& y) -> decltype(x.base() - y.base());
-  template <class Iterator>
+  template<class Iterator>
     constexpr move_iterator<Iterator> operator+(
       typename move_iterator<Iterator>::difference_type n, const move_iterator<Iterator>& x);
-  template <class Iterator>
+  template<class Iterator>
     constexpr move_iterator<Iterator> make_move_iterator(Iterator i);
 
   // \ref{stream.iterators}, stream iterators
-  template <class T, class charT = char, class traits = char_traits<charT>,
-      class Distance = ptrdiff_t>
+  template<class T, class charT = char, class traits = char_traits<charT>,
+           class Distance = ptrdiff_t>
   class istream_iterator;
-  template <class T, class charT, class traits, class Distance>
+  template<class T, class charT, class traits, class Distance>
     bool operator==(const istream_iterator<T,charT,traits,Distance>& x,
             const istream_iterator<T,charT,traits,Distance>& y);
-  template <class T, class charT, class traits, class Distance>
+  template<class T, class charT, class traits, class Distance>
     bool operator!=(const istream_iterator<T,charT,traits,Distance>& x,
             const istream_iterator<T,charT,traits,Distance>& y);
 
-  template <class T, class charT = char, class traits = char_traits<charT>>
+  template<class T, class charT = char, class traits = char_traits<charT>>
       class ostream_iterator;
 
   template<class charT, class traits = char_traits<charT>>
     class istreambuf_iterator;
-  template <class charT, class traits>
+  template<class charT, class traits>
     bool operator==(const istreambuf_iterator<charT,traits>& a,
             const istreambuf_iterator<charT,traits>& b);
-  template <class charT, class traits>
+  template<class charT, class traits>
     bool operator!=(const istreambuf_iterator<charT,traits>& a,
             const istreambuf_iterator<charT,traits>& b);
 
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
     class ostreambuf_iterator;
 
   // \ref{iterator.range}, range access
-  template <class C> constexpr auto begin(C& c) -> decltype(c.begin());
-  template <class C> constexpr auto begin(const C& c) -> decltype(c.begin());
-  template <class C> constexpr auto end(C& c) -> decltype(c.end());
-  template <class C> constexpr auto end(const C& c) -> decltype(c.end());
-  template <class T, size_t N> constexpr T* begin(T (&array)[N]) noexcept;
-  template <class T, size_t N> constexpr T* end(T (&array)[N]) noexcept;
-  template <class C> constexpr auto cbegin(const C& c) noexcept(noexcept(std::begin(c)))
+  template<class C> constexpr auto begin(C& c) -> decltype(c.begin());
+  template<class C> constexpr auto begin(const C& c) -> decltype(c.begin());
+  template<class C> constexpr auto end(C& c) -> decltype(c.end());
+  template<class C> constexpr auto end(const C& c) -> decltype(c.end());
+  template<class T, size_t N> constexpr T* begin(T (&array)[N]) noexcept;
+  template<class T, size_t N> constexpr T* end(T (&array)[N]) noexcept;
+  template<class C> constexpr auto cbegin(const C& c) noexcept(noexcept(std::begin(c)))
     -> decltype(std::begin(c));
-  template <class C> constexpr auto cend(const C& c) noexcept(noexcept(std::end(c)))
+  template<class C> constexpr auto cend(const C& c) noexcept(noexcept(std::end(c)))
     -> decltype(std::end(c));
-  template <class C> constexpr auto rbegin(C& c) -> decltype(c.rbegin());
-  template <class C> constexpr auto rbegin(const C& c) -> decltype(c.rbegin());
-  template <class C> constexpr auto rend(C& c) -> decltype(c.rend());
-  template <class C> constexpr auto rend(const C& c) -> decltype(c.rend());
-  template <class T, size_t N> constexpr reverse_iterator<T*> rbegin(T (&array)[N]);
-  template <class T, size_t N> constexpr reverse_iterator<T*> rend(T (&array)[N]);
-  template <class E> constexpr reverse_iterator<const E*> rbegin(initializer_list<E> il);
-  template <class E> constexpr reverse_iterator<const E*> rend(initializer_list<E> il);
-  template <class C> constexpr auto crbegin(const C& c) -> decltype(std::rbegin(c));
-  template <class C> constexpr auto crend(const C& c) -> decltype(std::rend(c));
+  template<class C> constexpr auto rbegin(C& c) -> decltype(c.rbegin());
+  template<class C> constexpr auto rbegin(const C& c) -> decltype(c.rbegin());
+  template<class C> constexpr auto rend(C& c) -> decltype(c.rend());
+  template<class C> constexpr auto rend(const C& c) -> decltype(c.rend());
+  template<class T, size_t N> constexpr reverse_iterator<T*> rbegin(T (&array)[N]);
+  template<class T, size_t N> constexpr reverse_iterator<T*> rend(T (&array)[N]);
+  template<class E> constexpr reverse_iterator<const E*> rbegin(initializer_list<E> il);
+  template<class E> constexpr reverse_iterator<const E*> rend(initializer_list<E> il);
+  template<class C> constexpr auto crbegin(const C& c) -> decltype(std::rbegin(c));
+  template<class C> constexpr auto crend(const C& c) -> decltype(std::rend(c));
 
   // \ref{iterator.container}, container access
-  template <class C> constexpr auto size(const C& c) -> decltype(c.size());
-  template <class T, size_t N> constexpr size_t size(const T (&array)[N]) noexcept;
-  template <class C> [[nodiscard]] constexpr auto empty(const C& c) -> decltype(c.empty());
-  template <class T, size_t N> [[nodiscard]] constexpr bool empty(const T (&array)[N]) noexcept;
-  template <class E> [[nodiscard]] constexpr bool empty(initializer_list<E> il) noexcept;
-  template <class C> constexpr auto data(C& c) -> decltype(c.data());
-  template <class C> constexpr auto data(const C& c) -> decltype(c.data());
-  template <class T, size_t N> constexpr T* data(T (&array)[N]) noexcept;
-  template <class E> constexpr const E* data(initializer_list<E> il) noexcept;
+  template<class C> constexpr auto size(const C& c) -> decltype(c.size());
+  template<class T, size_t N> constexpr size_t size(const T (&array)[N]) noexcept;
+  template<class C> [[nodiscard]] constexpr auto empty(const C& c) -> decltype(c.empty());
+  template<class T, size_t N> [[nodiscard]] constexpr bool empty(const T (&array)[N]) noexcept;
+  template<class E> [[nodiscard]] constexpr bool empty(initializer_list<E> il) noexcept;
+  template<class C> constexpr auto data(C& c) -> decltype(c.data());
+  template<class C> constexpr auto data(const C& c) -> decltype(c.data());
+  template<class T, size_t N> constexpr T* data(T (&array)[N]) noexcept;
+  template<class E> constexpr const E* data(initializer_list<E> il) noexcept;
 }
 \end{codeblock}
 
@@ -947,7 +947,7 @@ To implement a generic
 function, a \Cpp{} program can do the following:
 
 \begin{codeblock}
-template <class BidirectionalIterator>
+template<class BidirectionalIterator>
 void reverse(BidirectionalIterator first, BidirectionalIterator last) {
   typename iterator_traits<BidirectionalIterator>::difference_type n =
     distance(first, last);
@@ -1036,20 +1036,20 @@ is well-defined for bidirectional iterators, but can be implemented more
 efficiently for random access iterators, then the implementation is as follows:
 
 \begin{codeblock}
-template <class BidirectionalIterator>
+template<class BidirectionalIterator>
 inline void
 evolve(BidirectionalIterator first, BidirectionalIterator last) {
   evolve(first, last,
     typename iterator_traits<BidirectionalIterator>::iterator_category());
 }
 
-template <class BidirectionalIterator>
+template<class BidirectionalIterator>
 void evolve(BidirectionalIterator first, BidirectionalIterator last,
   bidirectional_iterator_tag) {
   // more generic, but less efficient algorithm
 }
 
-template <class RandomAccessIterator>
+template<class RandomAccessIterator>
 void evolve(RandomAccessIterator first, RandomAccessIterator last,
   random_access_iterator_tag) {
   // more efficient, but less generic algorithm
@@ -1083,7 +1083,7 @@ implementations.
 
 \indexlibrary{\idxcode{advance}}%
 \begin{itemdecl}
-template <class InputIterator, class Distance>
+template<class InputIterator, class Distance>
   constexpr void advance(InputIterator& i, Distance n);
 \end{itemdecl}
 
@@ -1105,7 +1105,7 @@ by
 
 \indexlibrary{\idxcode{distance}}%
 \begin{itemdecl}
-template <class InputIterator>
+template<class InputIterator>
   constexpr typename iterator_traits<InputIterator>::difference_type
     distance(InputIterator first, InputIterator last);
 \end{itemdecl}
@@ -1132,7 +1132,7 @@ shall be reachable from
 
 \indexlibrary{\idxcode{next}}%
 \begin{itemdecl}
-template <class InputIterator>
+template<class InputIterator>
   constexpr InputIterator next(InputIterator x,
     typename iterator_traits<InputIterator>::difference_type n = 1);
 \end{itemdecl}
@@ -1144,7 +1144,7 @@ template <class InputIterator>
 
 \indexlibrary{\idxcode{prev}}%
 \begin{itemdecl}
-template <class BidirectionalIterator>
+template<class BidirectionalIterator>
   constexpr BidirectionalIterator prev(BidirectionalIterator x,
     typename iterator_traits<BidirectionalIterator>::difference_type n = 1);
 \end{itemdecl}
@@ -1170,7 +1170,7 @@ is established by the identity:
 \indexlibrary{\idxcode{reverse_iterator}}%
 \begin{codeblock}
 namespace std {
-  template <class Iterator>
+  template<class Iterator>
   class reverse_iterator {
   public:
     using iterator_type     = Iterator;
@@ -1182,8 +1182,8 @@ namespace std {
 
     constexpr reverse_iterator();
     constexpr explicit reverse_iterator(Iterator x);
-    template <class U> constexpr reverse_iterator(const reverse_iterator<U>& u);
-    template <class U> constexpr reverse_iterator& operator=(const reverse_iterator<U>& u);
+    template<class U> constexpr reverse_iterator(const reverse_iterator<U>& u);
+    template<class U> constexpr reverse_iterator& operator=(const reverse_iterator<U>& u);
 
     constexpr Iterator base() const;      // explicit
     constexpr reference operator*() const;
@@ -1204,40 +1204,40 @@ namespace std {
     Iterator current;
   };
 
-  template <class Iterator1, class Iterator2>
+  template<class Iterator1, class Iterator2>
     constexpr bool operator==(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
-  template <class Iterator1, class Iterator2>
+  template<class Iterator1, class Iterator2>
     constexpr bool operator<(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
-  template <class Iterator1, class Iterator2>
+  template<class Iterator1, class Iterator2>
     constexpr bool operator!=(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
-  template <class Iterator1, class Iterator2>
+  template<class Iterator1, class Iterator2>
     constexpr bool operator>(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
-  template <class Iterator1, class Iterator2>
+  template<class Iterator1, class Iterator2>
     constexpr bool operator>=(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
-  template <class Iterator1, class Iterator2>
+  template<class Iterator1, class Iterator2>
     constexpr bool operator<=(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
-  template <class Iterator1, class Iterator2>
+  template<class Iterator1, class Iterator2>
     constexpr auto operator-(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y) -> decltype(y.base() - x.base());
-  template <class Iterator>
+  template<class Iterator>
     constexpr reverse_iterator<Iterator> operator+(
       typename reverse_iterator<Iterator>::difference_type n,
       const reverse_iterator<Iterator>& x);
 
-  template <class Iterator>
+  template<class Iterator>
     constexpr reverse_iterator<Iterator> make_reverse_iterator(Iterator i);
 }
 \end{codeblock}
@@ -1303,7 +1303,7 @@ with \tcode{x}.
 
 \indexlibrary{\idxcode{reverse_iterator}!constructor}%
 \begin{itemdecl}
-template <class U> constexpr reverse_iterator(const reverse_iterator<U>& u);
+template<class U> constexpr reverse_iterator(const reverse_iterator<U>& u);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1319,7 +1319,7 @@ with
 
 \indexlibrarymember{operator=}{reverse_iterator}%
 \begin{itemdecl}
-template <class U>
+template<class U>
 constexpr reverse_iterator&
   operator=(const reverse_iterator<U>& u);
 \end{itemdecl}
@@ -1520,7 +1520,7 @@ constexpr @\unspec@ operator[](difference_type n) const;
 
 \indexlibrarymember{operator==}{reverse_iterator}%
 \begin{itemdecl}
-template <class Iterator1, class Iterator2>
+template<class Iterator1, class Iterator2>
   constexpr bool operator==(
     const reverse_iterator<Iterator1>& x,
     const reverse_iterator<Iterator2>& y);
@@ -1536,7 +1536,7 @@ template <class Iterator1, class Iterator2>
 
 \indexlibrarymember{operator<}{reverse_iterator}%
 \begin{itemdecl}
-template <class Iterator1, class Iterator2>
+template<class Iterator1, class Iterator2>
   constexpr bool operator<(
     const reverse_iterator<Iterator1>& x,
     const reverse_iterator<Iterator2>& y);
@@ -1552,7 +1552,7 @@ template <class Iterator1, class Iterator2>
 
 \indexlibrarymember{operator"!=}{reverse_iterator}%
 \begin{itemdecl}
-template <class Iterator1, class Iterator2>
+template<class Iterator1, class Iterator2>
   constexpr bool operator!=(
     const reverse_iterator<Iterator1>& x,
     const reverse_iterator<Iterator2>& y);
@@ -1568,7 +1568,7 @@ template <class Iterator1, class Iterator2>
 
 \indexlibrarymember{operator>}{reverse_iterator}%
 \begin{itemdecl}
-template <class Iterator1, class Iterator2>
+template<class Iterator1, class Iterator2>
   constexpr bool operator>(
     const reverse_iterator<Iterator1>& x,
     const reverse_iterator<Iterator2>& y);
@@ -1584,7 +1584,7 @@ template <class Iterator1, class Iterator2>
 
 \indexlibrarymember{operator>=}{reverse_iterator}%
 \begin{itemdecl}
-template <class Iterator1, class Iterator2>
+template<class Iterator1, class Iterator2>
   constexpr bool operator>=(
     const reverse_iterator<Iterator1>& x,
     const reverse_iterator<Iterator2>& y);
@@ -1600,7 +1600,7 @@ template <class Iterator1, class Iterator2>
 
 \indexlibrarymember{operator<=}{reverse_iterator}%
 \begin{itemdecl}
-template <class Iterator1, class Iterator2>
+template<class Iterator1, class Iterator2>
   constexpr bool operator<=(
     const reverse_iterator<Iterator1>& x,
     const reverse_iterator<Iterator2>& y);
@@ -1616,7 +1616,7 @@ template <class Iterator1, class Iterator2>
 
 \indexlibrarymember{operator-}{reverse_iterator}%
 \begin{itemdecl}
-template <class Iterator1, class Iterator2>
+template<class Iterator1, class Iterator2>
     constexpr auto operator-(
     const reverse_iterator<Iterator1>& x,
     const reverse_iterator<Iterator2>& y) -> decltype(y.base() - x.base());
@@ -1632,7 +1632,7 @@ template <class Iterator1, class Iterator2>
 
 \indexlibrarymember{operator+}{reverse_iterator}%
 \begin{itemdecl}
-template <class Iterator>
+template<class Iterator>
   constexpr reverse_iterator<Iterator> operator+(
     typename reverse_iterator<Iterator>::difference_type n,
     const reverse_iterator<Iterator>& x);
@@ -1649,7 +1649,7 @@ template <class Iterator>
 \indexlibrary{\idxcode{reverse_iterator}!\idxcode{make_reverse_iterator} non-member function}%
 \indexlibrary{\idxcode{make_reverse_iterator}}%
 \begin{itemdecl}
-template <class Iterator>
+template<class Iterator>
   constexpr reverse_iterator<Iterator> make_reverse_iterator(Iterator i);
 \end{itemdecl}
 
@@ -1713,7 +1713,7 @@ functions making the insert iterators out of a container.
 \indexlibrary{\idxcode{back_insert_iterator}}%
 \begin{codeblock}
 namespace std {
-  template <class Container>
+  template<class Container>
   class back_insert_iterator {
   protected:
     Container* container;
@@ -1735,7 +1735,7 @@ namespace std {
     back_insert_iterator  operator++(int);
   };
 
-  template <class Container>
+  template<class Container>
     back_insert_iterator<Container> back_inserter(Container& x);
 }
 \end{codeblock}
@@ -1820,7 +1820,7 @@ back_insert_iterator  operator++(int);
 
 \indexlibrary{\idxcode{back_inserter}}%
 \begin{itemdecl}
-template <class Container>
+template<class Container>
   back_insert_iterator<Container> back_inserter(Container& x);
 \end{itemdecl}
 
@@ -1835,7 +1835,7 @@ template <class Container>
 \indexlibrary{\idxcode{front_insert_iterator}}%
 \begin{codeblock}
 namespace std {
-  template <class Container>
+  template<class Container>
   class front_insert_iterator {
   protected:
     Container* container;
@@ -1857,7 +1857,7 @@ namespace std {
     front_insert_iterator  operator++(int);
   };
 
-  template <class Container>
+  template<class Container>
     front_insert_iterator<Container> front_inserter(Container& x);
 }
 \end{codeblock}
@@ -1942,7 +1942,7 @@ front_insert_iterator  operator++(int);
 
 \indexlibrary{\idxcode{front_inserter}}%
 \begin{itemdecl}
-template <class Container>
+template<class Container>
   front_insert_iterator<Container> front_inserter(Container& x);
 \end{itemdecl}
 
@@ -1957,7 +1957,7 @@ template <class Container>
 \indexlibrary{\idxcode{insert_iterator}}%
 \begin{codeblock}
 namespace std {
-  template <class Container>
+  template<class Container>
   class insert_iterator {
   protected:
     Container* container;
@@ -1980,7 +1980,7 @@ namespace std {
     insert_iterator& operator++(int);
   };
 
-  template <class Container>
+  template<class Container>
     insert_iterator<Container> inserter(Container& x, typename Container::iterator i);
 }
 \end{codeblock}
@@ -2075,7 +2075,7 @@ insert_iterator& operator++(int);
 
 \indexlibrary{\idxcode{inserter}}%
 \begin{itemdecl}
-template <class Container>
+template<class Container>
   insert_iterator<Container> inserter(Container& x, typename Container::iterator i);
 \end{itemdecl}
 
@@ -2113,7 +2113,7 @@ vector<string> v2(make_move_iterator(s.begin()),
 \indexlibrary{\idxcode{move_iterator}}%
 \begin{codeblock}
 namespace std {
-  template <class Iterator>
+  template<class Iterator>
   class move_iterator {
   public:
     using iterator_type     = Iterator;
@@ -2125,8 +2125,8 @@ namespace std {
 
     constexpr move_iterator();
     constexpr explicit move_iterator(Iterator i);
-    template <class U> constexpr move_iterator(const move_iterator<U>& u);
-    template <class U> constexpr move_iterator& operator=(const move_iterator<U>& u);
+    template<class U> constexpr move_iterator(const move_iterator<U>& u);
+    template<class U> constexpr move_iterator& operator=(const move_iterator<U>& u);
 
     constexpr iterator_type base() const;
     constexpr reference operator*() const;
@@ -2147,33 +2147,33 @@ namespace std {
     Iterator current;   // \expos
   };
 
-  template <class Iterator1, class Iterator2>
+  template<class Iterator1, class Iterator2>
     constexpr bool operator==(
       const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
-  template <class Iterator1, class Iterator2>
+  template<class Iterator1, class Iterator2>
     constexpr bool operator!=(
       const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
-  template <class Iterator1, class Iterator2>
+  template<class Iterator1, class Iterator2>
     constexpr bool operator<(
       const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
-  template <class Iterator1, class Iterator2>
+  template<class Iterator1, class Iterator2>
     constexpr bool operator<=(
       const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
-  template <class Iterator1, class Iterator2>
+  template<class Iterator1, class Iterator2>
     constexpr bool operator>(
       const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
-  template <class Iterator1, class Iterator2>
+  template<class Iterator1, class Iterator2>
     constexpr bool operator>=(
       const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
 
-  template <class Iterator1, class Iterator2>
+  template<class Iterator1, class Iterator2>
     constexpr auto operator-(
       const move_iterator<Iterator1>& x,
       const move_iterator<Iterator2>& y) -> decltype(x.base() - y.base());
-  template <class Iterator>
+  template<class Iterator>
     constexpr move_iterator<Iterator> operator+(
       typename move_iterator<Iterator>::difference_type n, const move_iterator<Iterator>& x);
-  template <class Iterator>
+  template<class Iterator>
     constexpr move_iterator<Iterator> make_move_iterator(Iterator i);
 }
 \end{codeblock}
@@ -2228,7 +2228,7 @@ constexpr explicit move_iterator(Iterator i);
 
 \indexlibrary{\idxcode{move_iterator}!constructor}%
 \begin{itemdecl}
-template <class U> constexpr move_iterator(const move_iterator<U>& u);
+template<class U> constexpr move_iterator(const move_iterator<U>& u);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2245,7 +2245,7 @@ template <class U> constexpr move_iterator(const move_iterator<U>& u);
 
 \indexlibrarymember{operator=}{move_iterator}%
 \begin{itemdecl}
-template <class U> constexpr move_iterator& operator=(const move_iterator<U>& u);
+template<class U> constexpr move_iterator& operator=(const move_iterator<U>& u);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2426,7 +2426,7 @@ constexpr @\unspec@ operator[](difference_type n) const;
 
 \indexlibrarymember{operator==}{move_iterator}%
 \begin{itemdecl}
-template <class Iterator1, class Iterator2>
+template<class Iterator1, class Iterator2>
 constexpr bool operator==(const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
 \end{itemdecl}
 
@@ -2437,7 +2437,7 @@ constexpr bool operator==(const move_iterator<Iterator1>& x, const move_iterator
 
 \indexlibrarymember{operator"!=}{move_iterator}%
 \begin{itemdecl}
-template <class Iterator1, class Iterator2>
+template<class Iterator1, class Iterator2>
 constexpr bool operator!=(const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
 \end{itemdecl}
 
@@ -2448,7 +2448,7 @@ constexpr bool operator!=(const move_iterator<Iterator1>& x, const move_iterator
 
 \indexlibrarymember{operator<}{move_iterator}%
 \begin{itemdecl}
-template <class Iterator1, class Iterator2>
+template<class Iterator1, class Iterator2>
 constexpr bool operator<(const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
 \end{itemdecl}
 
@@ -2459,7 +2459,7 @@ constexpr bool operator<(const move_iterator<Iterator1>& x, const move_iterator<
 
 \indexlibrarymember{operator<=}{move_iterator}%
 \begin{itemdecl}
-template <class Iterator1, class Iterator2>
+template<class Iterator1, class Iterator2>
 constexpr bool operator<=(const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
 \end{itemdecl}
 
@@ -2470,7 +2470,7 @@ constexpr bool operator<=(const move_iterator<Iterator1>& x, const move_iterator
 
 \indexlibrarymember{operator>}{move_iterator}%
 \begin{itemdecl}
-template <class Iterator1, class Iterator2>
+template<class Iterator1, class Iterator2>
 constexpr bool operator>(const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
 \end{itemdecl}
 
@@ -2481,7 +2481,7 @@ constexpr bool operator>(const move_iterator<Iterator1>& x, const move_iterator<
 
 \indexlibrarymember{operator>=}{move_iterator}%
 \begin{itemdecl}
-template <class Iterator1, class Iterator2>
+template<class Iterator1, class Iterator2>
 constexpr bool operator>=(const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
 \end{itemdecl}
 
@@ -2494,7 +2494,7 @@ constexpr bool operator>=(const move_iterator<Iterator1>& x, const move_iterator
 
 \indexlibrarymember{operator-}{move_iterator}%
 \begin{itemdecl}
-template <class Iterator1, class Iterator2>
+template<class Iterator1, class Iterator2>
     constexpr auto operator-(
     const move_iterator<Iterator1>& x,
     const move_iterator<Iterator2>& y) -> decltype(x.base() - y.base());
@@ -2507,7 +2507,7 @@ template <class Iterator1, class Iterator2>
 
 \indexlibrarymember{operator+}{move_iterator}%
 \begin{itemdecl}
-template <class Iterator>
+template<class Iterator>
   constexpr move_iterator<Iterator> operator+(
     typename move_iterator<Iterator>::difference_type n, const move_iterator<Iterator>& x);
 \end{itemdecl}
@@ -2519,7 +2519,7 @@ template <class Iterator>
 
 \indexlibrary{\idxcode{make_move_iterator}}%
 \begin{itemdecl}
-template <class Iterator>
+template<class Iterator>
 constexpr move_iterator<Iterator> make_move_iterator(Iterator i);
 \end{itemdecl}
 
@@ -2601,8 +2601,8 @@ Two non-end-of-stream iterators are equal when they are constructed from the sam
 
 \begin{codeblock}
 namespace std {
-  template <class T, class charT = char, class traits = char_traits<charT>,
-      class Distance = ptrdiff_t>
+  template<class T, class charT = char, class traits = char_traits<charT>,
+           class Distance = ptrdiff_t>
   class istream_iterator {
   public:
     using iterator_category = input_iterator_tag;
@@ -2629,10 +2629,10 @@ namespace std {
     T value;                                // \expos
   };
 
-  template <class T, class charT, class traits, class Distance>
+  template<class T, class charT, class traits, class Distance>
     bool operator==(const istream_iterator<T,charT,traits,Distance>& x,
             const istream_iterator<T,charT,traits,Distance>& y);
-  template <class T, class charT, class traits, class Distance>
+  template<class T, class charT, class traits, class Distance>
     bool operator!=(const istream_iterator<T,charT,traits,Distance>& x,
             const istream_iterator<T,charT,traits,Distance>& y);
 }
@@ -2767,7 +2767,7 @@ return (tmp);
 
 \indexlibrarymember{operator==}{istream_iterator}%
 \begin{itemdecl}
-template <class T, class charT, class traits, class Distance>
+template<class T, class charT, class traits, class Distance>
   bool operator==(const istream_iterator<T,charT,traits,Distance>& x,
                   const istream_iterator<T,charT,traits,Distance>& y);
 \end{itemdecl}
@@ -2780,7 +2780,7 @@ template <class T, class charT, class traits, class Distance>
 
 \indexlibrarymember{operator"!=}{istream_iterator}%
 \begin{itemdecl}
-template <class T, class charT, class traits, class Distance>
+template<class T, class charT, class traits, class Distance>
   bool operator!=(const istream_iterator<T,charT,traits,Distance>& x,
                   const istream_iterator<T,charT,traits,Distance>& y);
 \end{itemdecl}
@@ -2820,7 +2820,7 @@ is defined as:
 
 \begin{codeblock}
 namespace std {
-  template <class T, class charT = char, class traits = char_traits<charT>>
+  template<class T, class charT = char, class traits = char_traits<charT>>
   class ostream_iterator {
   public:
     using iterator_category = output_iterator_tag;
@@ -3015,10 +3015,10 @@ namespace std {
     streambuf_type* sbuf_;                // \expos
   };
 
-  template <class charT, class traits>
+  template<class charT, class traits>
     bool operator==(const istreambuf_iterator<charT,traits>& a,
             const istreambuf_iterator<charT,traits>& b);
-  template <class charT, class traits>
+  template<class charT, class traits>
     bool operator!=(const istreambuf_iterator<charT,traits>& a,
             const istreambuf_iterator<charT,traits>& b);
 }
@@ -3029,7 +3029,7 @@ namespace std {
 \indexlibrary{\idxcode{proxy}!\idxcode{istreambuf_iterator}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
   class istreambuf_iterator<charT, traits>::proxy { // \expos
     charT keep_;
     basic_streambuf<charT,traits>* sbuf_;
@@ -3169,7 +3169,7 @@ object they use.
 
 \indexlibrarymember{operator==}{istreambuf_iterator}%
 \begin{itemdecl}
-template <class charT, class traits>
+template<class charT, class traits>
   bool operator==(const istreambuf_iterator<charT,traits>& a,
                   const istreambuf_iterator<charT,traits>& b);
 \end{itemdecl}
@@ -3182,7 +3182,7 @@ template <class charT, class traits>
 
 \indexlibrarymember{operator"!=}{istreambuf_iterator}%
 \begin{itemdecl}
-template <class charT, class traits>
+template<class charT, class traits>
   bool operator!=(const istreambuf_iterator<charT,traits>& a,
                   const istreambuf_iterator<charT,traits>& b);
 \end{itemdecl}
@@ -3198,7 +3198,7 @@ template <class charT, class traits>
 \indexlibrary{\idxcode{ostreambuf_iterator}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class traits = char_traits<charT>>
+  template<class charT, class traits = char_traits<charT>>
   class ostreambuf_iterator {
   public:
     using iterator_category = output_iterator_tag;
@@ -3348,8 +3348,8 @@ headers are included: \tcode{<array>}, \tcode{<deque>}, \tcode{<forward_list>},
 
 \indexlibrary{\idxcode{begin(C\&)}}%
 \begin{itemdecl}
-template <class C> constexpr auto begin(C& c) -> decltype(c.begin());
-template <class C> constexpr auto begin(const C& c) -> decltype(c.begin());
+template<class C> constexpr auto begin(C& c) -> decltype(c.begin());
+template<class C> constexpr auto begin(const C& c) -> decltype(c.begin());
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3359,8 +3359,8 @@ template <class C> constexpr auto begin(const C& c) -> decltype(c.begin());
 
 \indexlibrary{\idxcode{end(C\&)}}%
 \begin{itemdecl}
-template <class C> constexpr auto end(C& c) -> decltype(c.end());
-template <class C> constexpr auto end(const C& c) -> decltype(c.end());
+template<class C> constexpr auto end(C& c) -> decltype(c.end());
+template<class C> constexpr auto end(const C& c) -> decltype(c.end());
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3370,7 +3370,7 @@ template <class C> constexpr auto end(const C& c) -> decltype(c.end());
 
 \indexlibrary{\idxcode{begin(T (\&)[N])}}%
 \begin{itemdecl}
-template <class T, size_t N> constexpr T* begin(T (&array)[N]) noexcept;
+template<class T, size_t N> constexpr T* begin(T (&array)[N]) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3380,7 +3380,7 @@ template <class T, size_t N> constexpr T* begin(T (&array)[N]) noexcept;
 
 \indexlibrary{\idxcode{end(T (\&)[N])}}%
 \begin{itemdecl}
-template <class T, size_t N> constexpr T* end(T (&array)[N]) noexcept;
+template<class T, size_t N> constexpr T* end(T (&array)[N]) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3390,7 +3390,7 @@ template <class T, size_t N> constexpr T* end(T (&array)[N]) noexcept;
 
 \indexlibrary{\idxcode{cbegin(const C\&)}}%
 \begin{itemdecl}
-template <class C> constexpr auto cbegin(const C& c) noexcept(noexcept(std::begin(c)))
+template<class C> constexpr auto cbegin(const C& c) noexcept(noexcept(std::begin(c)))
   -> decltype(std::begin(c));
 \end{itemdecl}
 \begin{itemdescr}
@@ -3399,7 +3399,7 @@ template <class C> constexpr auto cbegin(const C& c) noexcept(noexcept(std::begi
 
 \indexlibrary{\idxcode{cend(const C\&)}}%
 \begin{itemdecl}
-template <class C> constexpr auto cend(const C& c) noexcept(noexcept(std::end(c)))
+template<class C> constexpr auto cend(const C& c) noexcept(noexcept(std::end(c)))
   -> decltype(std::end(c));
 \end{itemdecl}
 \begin{itemdescr}
@@ -3408,8 +3408,8 @@ template <class C> constexpr auto cend(const C& c) noexcept(noexcept(std::end(c)
 
 \indexlibrary{\idxcode{rbegin(C\&)}}%
 \begin{itemdecl}
-template <class C> constexpr auto rbegin(C& c) -> decltype(c.rbegin());
-template <class C> constexpr auto rbegin(const C& c) -> decltype(c.rbegin());
+template<class C> constexpr auto rbegin(C& c) -> decltype(c.rbegin());
+template<class C> constexpr auto rbegin(const C& c) -> decltype(c.rbegin());
 \end{itemdecl}
 \begin{itemdescr}
 \pnum \returns \tcode{c.rbegin()}.
@@ -3417,8 +3417,8 @@ template <class C> constexpr auto rbegin(const C& c) -> decltype(c.rbegin());
 
 \indexlibrary{\idxcode{rend(C\&)}}%
 \begin{itemdecl}
-template <class C> constexpr auto rend(C& c) -> decltype(c.rend());
-template <class C> constexpr auto rend(const C& c) -> decltype(c.rend());
+template<class C> constexpr auto rend(C& c) -> decltype(c.rend());
+template<class C> constexpr auto rend(const C& c) -> decltype(c.rend());
 \end{itemdecl}
 \begin{itemdescr}
 \pnum \returns \tcode{c.rend()}.
@@ -3426,7 +3426,7 @@ template <class C> constexpr auto rend(const C& c) -> decltype(c.rend());
 
 \indexlibrary{\idxcode{rbegin(T (\&array)[N])}}%
 \begin{itemdecl}
-template <class T, size_t N> constexpr reverse_iterator<T*> rbegin(T (&array)[N]);
+template<class T, size_t N> constexpr reverse_iterator<T*> rbegin(T (&array)[N]);
 \end{itemdecl}
 \begin{itemdescr}
 \pnum \returns \tcode{reverse_iterator<T*>(array + N)}.
@@ -3434,7 +3434,7 @@ template <class T, size_t N> constexpr reverse_iterator<T*> rbegin(T (&array)[N]
 
 \indexlibrary{\idxcode{rend(T (\&array)[N])}}%
 \begin{itemdecl}
-template <class T, size_t N> constexpr reverse_iterator<T*> rend(T (&array)[N]);
+template<class T, size_t N> constexpr reverse_iterator<T*> rend(T (&array)[N]);
 \end{itemdecl}
 \begin{itemdescr}
 \pnum \returns \tcode{reverse_iterator<T*>(array)}.
@@ -3442,7 +3442,7 @@ template <class T, size_t N> constexpr reverse_iterator<T*> rend(T (&array)[N]);
 
 \indexlibrary{\idxcode{rbegin(initializer_list<E>)}}%
 \begin{itemdecl}
-template <class E> constexpr reverse_iterator<const E*> rbegin(initializer_list<E> il);
+template<class E> constexpr reverse_iterator<const E*> rbegin(initializer_list<E> il);
 \end{itemdecl}
 \begin{itemdescr}
 \pnum \returns \tcode{reverse_iterator<const E*>(il.end())}.
@@ -3450,7 +3450,7 @@ template <class E> constexpr reverse_iterator<const E*> rbegin(initializer_list<
 
 \indexlibrary{\idxcode{rend(initializer_list<E>)}}%
 \begin{itemdecl}
-template <class E> constexpr reverse_iterator<const E*> rend(initializer_list<E> il);
+template<class E> constexpr reverse_iterator<const E*> rend(initializer_list<E> il);
 \end{itemdecl}
 \begin{itemdescr}
 \pnum \returns \tcode{reverse_iterator<const E*>(il.begin())}.
@@ -3458,7 +3458,7 @@ template <class E> constexpr reverse_iterator<const E*> rend(initializer_list<E>
 
 \indexlibrary{\idxcode{crbegin(const C\& c)}}%
 \begin{itemdecl}
-template <class C> constexpr auto crbegin(const C& c) -> decltype(std::rbegin(c));
+template<class C> constexpr auto crbegin(const C& c) -> decltype(std::rbegin(c));
 \end{itemdecl}
 \begin{itemdescr}
 \pnum \returns \tcode{std::rbegin(c)}.
@@ -3466,7 +3466,7 @@ template <class C> constexpr auto crbegin(const C& c) -> decltype(std::rbegin(c)
 
 \indexlibrary{\idxcode{crend(const C\& c)}}%
 \begin{itemdecl}
-template <class C> constexpr auto crend(const C& c) -> decltype(std::rend(c));
+template<class C> constexpr auto crend(const C& c) -> decltype(std::rend(c));
 \end{itemdecl}
 \begin{itemdescr}
 \pnum \returns \tcode{std::rend(c)}.
@@ -3484,7 +3484,7 @@ when any of the following headers are included:
 
 \indexlibrary{\idxcode{size(C\& c)}}%
 \begin{itemdecl}
-template <class C> constexpr auto size(const C& c) -> decltype(c.size());
+template<class C> constexpr auto size(const C& c) -> decltype(c.size());
 \end{itemdecl}
 \begin{itemdescr}
 \pnum \returns \tcode{c.size()}.
@@ -3492,7 +3492,7 @@ template <class C> constexpr auto size(const C& c) -> decltype(c.size());
 
 \indexlibrary{\idxcode{size(T (\&array)[N])}}%
 \begin{itemdecl}
-template <class T, size_t N> constexpr size_t size(const T (&array)[N]) noexcept;
+template<class T, size_t N> constexpr size_t size(const T (&array)[N]) noexcept;
 \end{itemdecl}
 \begin{itemdescr}
 \pnum \returns \tcode{N}.
@@ -3500,7 +3500,7 @@ template <class T, size_t N> constexpr size_t size(const T (&array)[N]) noexcept
 
 \indexlibrary{\idxcode{empty(C\& c)}}%
 \begin{itemdecl}
-template <class C> [[nodiscard]] constexpr auto empty(const C& c) -> decltype(c.empty());
+template<class C> [[nodiscard]] constexpr auto empty(const C& c) -> decltype(c.empty());
 \end{itemdecl}
 \begin{itemdescr}
 \pnum \returns \tcode{c.empty()}.
@@ -3508,7 +3508,7 @@ template <class C> [[nodiscard]] constexpr auto empty(const C& c) -> decltype(c.
 
 \indexlibrary{\idxcode{empty(T (\&array)[N])}}%
 \begin{itemdecl}
-template <class T, size_t N> [[nodiscard]] constexpr bool empty(const T (&array)[N]) noexcept;
+template<class T, size_t N> [[nodiscard]] constexpr bool empty(const T (&array)[N]) noexcept;
 \end{itemdecl}
 \begin{itemdescr}
 \pnum \returns \tcode{false}.
@@ -3516,7 +3516,7 @@ template <class T, size_t N> [[nodiscard]] constexpr bool empty(const T (&array)
 
 \indexlibrary{\idxcode{empty(initializer_list<E>)}}%
 \begin{itemdecl}
-template <class E> [[nodiscard]] constexpr bool empty(initializer_list<E> il) noexcept;
+template<class E> [[nodiscard]] constexpr bool empty(initializer_list<E> il) noexcept;
 \end{itemdecl}
 \begin{itemdescr}
 \pnum \returns \tcode{il.size() == 0}.
@@ -3524,8 +3524,8 @@ template <class E> [[nodiscard]] constexpr bool empty(initializer_list<E> il) no
 
 \indexlibrary{\idxcode{data(C\& c)}}%
 \begin{itemdecl}
-template <class C> constexpr auto data(C& c) -> decltype(c.data());
-template <class C> constexpr auto data(const C& c) -> decltype(c.data());
+template<class C> constexpr auto data(C& c) -> decltype(c.data());
+template<class C> constexpr auto data(const C& c) -> decltype(c.data());
 \end{itemdecl}
 \begin{itemdescr}
 \pnum \returns \tcode{c.data()}.
@@ -3533,7 +3533,7 @@ template <class C> constexpr auto data(const C& c) -> decltype(c.data());
 
 \indexlibrary{\idxcode{data(T (\&array)[N])}}%
 \begin{itemdecl}
-template <class T, size_t N> constexpr T* data(T (&array)[N]) noexcept;
+template<class T, size_t N> constexpr T* data(T (&array)[N]) noexcept;
 \end{itemdecl}
 \begin{itemdescr}
 \pnum \returns \tcode{array}.
@@ -3541,7 +3541,7 @@ template <class T, size_t N> constexpr T* data(T (&array)[N]) noexcept;
 
 \indexlibrary{\idxcode{data(initializer_list<E>)}}%
 \begin{itemdecl}
-template <class E> constexpr const E* data(initializer_list<E> il) noexcept;
+template<class E> constexpr const E* data(initializer_list<E> il) noexcept;
 \end{itemdecl}
 \begin{itemdescr}
 \pnum \returns \tcode{il.begin()}.

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1662,7 +1662,7 @@ is performed in an appropriate context under the various conditions as follows:
 #include <utility>
 
 // Requires: \tcode{std::forward<T>(t)} shall be swappable with \tcode{std::forward<U>(u)}.
-template <class T, class U>
+template<class T, class U>
 void value_swap(T&& t, U&& u) {
   using std::swap;
   swap(std::forward<T>(t), std::forward<U>(u)); // OK: uses ``swappable with'' conditions
@@ -1670,7 +1670,7 @@ void value_swap(T&& t, U&& u) {
 }
 
 // Requires: lvalues of \tcode{T} shall be swappable.
-template <class T>
+template<class T>
 void lv_swap(T& t1, T& t2) {
   using std::swap;
   swap(t1, t2);                                 // OK: uses swappable conditions for lvalues of type \tcode{T}
@@ -2169,20 +2169,20 @@ interface that satisfies the requirements of
 Table~\ref{tab:utilities.allocator.requirements}:
 
 \begin{codeblock}
-template <class Tp>
+template<class Tp>
 struct SimpleAllocator {
   typedef Tp value_type;
   SimpleAllocator(@\textit{ctor args}@);
 
-  template <class T> SimpleAllocator(const SimpleAllocator<T>& other);
+  template<class T> SimpleAllocator(const SimpleAllocator<T>& other);
 
   [[nodiscard]] Tp* allocate(std::size_t n);
   void deallocate(Tp* p, std::size_t n);
 };
 
-template <class T, class U>
+template<class T, class U>
 bool operator==(const SimpleAllocator<T>&, const SimpleAllocator<U>&);
-template <class T, class U>
+template<class T, class U>
 bool operator!=(const SimpleAllocator<T>&, const SimpleAllocator<U>&);
 \end{codeblock}
 \end{example}

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -29,74 +29,74 @@ from the ISO C library, as summarized in Table~\ref{tab:localization.lib.summary
 namespace std {
   // \ref{locale}, locale
   class locale;
-  template <class Facet> const Facet& use_facet(const locale&);
-  template <class Facet> bool         has_facet(const locale&) noexcept;
+  template<class Facet> const Facet& use_facet(const locale&);
+  template<class Facet> bool         has_facet(const locale&) noexcept;
 
   // \ref{locale.convenience}, convenience interfaces
-  template <class charT> bool isspace (charT c, const locale& loc);
-  template <class charT> bool isprint (charT c, const locale& loc);
-  template <class charT> bool iscntrl (charT c, const locale& loc);
-  template <class charT> bool isupper (charT c, const locale& loc);
-  template <class charT> bool islower (charT c, const locale& loc);
-  template <class charT> bool isalpha (charT c, const locale& loc);
-  template <class charT> bool isdigit (charT c, const locale& loc);
-  template <class charT> bool ispunct (charT c, const locale& loc);
-  template <class charT> bool isxdigit(charT c, const locale& loc);
-  template <class charT> bool isalnum (charT c, const locale& loc);
-  template <class charT> bool isgraph (charT c, const locale& loc);
-  template <class charT> bool isblank (charT c, const locale& loc);
-  template <class charT> charT toupper(charT c, const locale& loc);
-  template <class charT> charT tolower(charT c, const locale& loc);
+  template<class charT> bool isspace (charT c, const locale& loc);
+  template<class charT> bool isprint (charT c, const locale& loc);
+  template<class charT> bool iscntrl (charT c, const locale& loc);
+  template<class charT> bool isupper (charT c, const locale& loc);
+  template<class charT> bool islower (charT c, const locale& loc);
+  template<class charT> bool isalpha (charT c, const locale& loc);
+  template<class charT> bool isdigit (charT c, const locale& loc);
+  template<class charT> bool ispunct (charT c, const locale& loc);
+  template<class charT> bool isxdigit(charT c, const locale& loc);
+  template<class charT> bool isalnum (charT c, const locale& loc);
+  template<class charT> bool isgraph (charT c, const locale& loc);
+  template<class charT> bool isblank (charT c, const locale& loc);
+  template<class charT> charT toupper(charT c, const locale& loc);
+  template<class charT> charT tolower(charT c, const locale& loc);
 
   // \ref{category.ctype}, ctype
   class ctype_base;
-  template <class charT> class ctype;
-  template <>            class ctype<char>;     // specialization
-  template <class charT> class ctype_byname;
+  template<class charT> class ctype;
+  template<>            class ctype<char>;     // specialization
+  template<class charT> class ctype_byname;
   class codecvt_base;
-  template <class internT, class externT, class stateT> class codecvt;
-  template <class internT, class externT, class stateT> class codecvt_byname;
+  template<class internT, class externT, class stateT> class codecvt;
+  template<class internT, class externT, class stateT> class codecvt_byname;
 
   // \ref{category.numeric}, numeric
-  template <class charT, class InputIterator = istreambuf_iterator<charT>>
+  template<class charT, class InputIterator = istreambuf_iterator<charT>>
     class num_get;
-  template <class charT, class OutputIterator = ostreambuf_iterator<charT>>
+  template<class charT, class OutputIterator = ostreambuf_iterator<charT>>
     class num_put;
-  template <class charT>
+  template<class charT>
     class numpunct;
-  template <class charT>
+  template<class charT>
     class numpunct_byname;
 
   // \ref{category.collate}, collation
-  template <class charT> class collate;
-  template <class charT> class collate_byname;
+  template<class charT> class collate;
+  template<class charT> class collate_byname;
 
   // \ref{category.time}, date and time
   class time_base;
-  template <class charT, class InputIterator = istreambuf_iterator<charT>>
+  template<class charT, class InputIterator = istreambuf_iterator<charT>>
     class time_get;
-  template <class charT, class InputIterator = istreambuf_iterator<charT>>
+  template<class charT, class InputIterator = istreambuf_iterator<charT>>
     class time_get_byname;
-  template <class charT, class OutputIterator = ostreambuf_iterator<charT>>
+  template<class charT, class OutputIterator = ostreambuf_iterator<charT>>
     class time_put;
-  template <class charT, class OutputIterator = ostreambuf_iterator<charT>>
+  template<class charT, class OutputIterator = ostreambuf_iterator<charT>>
     class time_put_byname;
 
   // \ref{category.monetary}, money
   class money_base;
-  template <class charT, class InputIterator = istreambuf_iterator<charT>>
+  template<class charT, class InputIterator = istreambuf_iterator<charT>>
     class money_get;
-  template <class charT, class OutputIterator = ostreambuf_iterator<charT>>
+  template<class charT, class OutputIterator = ostreambuf_iterator<charT>>
     class money_put;
-  template <class charT, bool Intl = false>
+  template<class charT, bool Intl = false>
     class moneypunct;
-  template <class charT, bool Intl = false>
+  template<class charT, bool Intl = false>
     class moneypunct_byname;
 
   // \ref{category.messages}, message retrieval
   class messages_base;
-  template <class charT> class messages;
-  template <class charT> class messages_byname;
+  template<class charT> class messages;
+  template<class charT> class messages_byname;
 }
 \end{codeblock}
 
@@ -137,11 +137,11 @@ namespace std {
     explicit locale(const string& std_name);
     locale(const locale& other, const char* std_name, category);
     locale(const locale& other, const string& std_name, category);
-    template <class Facet> locale(const locale& other, Facet* f);
+    template<class Facet> locale(const locale& other, Facet* f);
     locale(const locale& other, const locale& one, category);
     ~locale();                  // not virtual
     const locale& operator=(const locale& other) noexcept;
-    template <class Facet> locale combine(const locale& other) const;
+    template<class Facet> locale combine(const locale& other) const;
 
     // locale operations
     basic_string<char> name() const;
@@ -149,7 +149,7 @@ namespace std {
     bool operator==(const locale& other) const;
     bool operator!=(const locale& other) const;
 
-    template <class charT, class traits, class Allocator>
+    template<class charT, class traits, class Allocator>
       bool operator()(const basic_string<charT, traits, Allocator>& s1,
                       const basic_string<charT, traits, Allocator>& s2) const;
 
@@ -187,14 +187,14 @@ the stream is implicitly converted to an
 \tcode{ostreambuf_iterator<charT, traits>}.}
 
 \begin{codeblock}
-template <class charT, class traits>
+template<class charT, class traits>
 basic_ostream<charT, traits>&
 operator<< (basic_ostream<charT, traits>& s, Date d) {
   typename basic_ostream<charT, traits>::sentry cerberos(s);
   if (cerberos) {
     ios_base::iostate err = ios_base::iostate::goodbit;
     tm tmbuf; d.extract(tmbuf);
-    use_facet<time_put<charT, ostreambuf_iterator<charT, traits>> >(
+    use_facet<time_put<charT, ostreambuf_iterator<charT, traits>>>(
       s.getloc()).put(s, s, s.fill(), err, &tmbuf, 'x');
     s.setstate(err);            // might throw
   }
@@ -681,7 +681,7 @@ locale(const locale& other, const string& std_name, category cat);
 
 \indexlibrary{\idxcode{locale}!constructor}%
 \begin{itemdecl}
-template <class Facet> locale(const locale& other, Facet* f);
+template<class Facet> locale(const locale& other, Facet* f);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -747,7 +747,7 @@ A non-virtual destructor that throws no exceptions.
 
 \indexlibrarymember{locale}{combine}%
 \begin{itemdecl}
-template <class Facet> locale combine(const locale& other) const;
+template<class Facet> locale combine(const locale& other) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -819,7 +819,7 @@ bool operator!=(const locale& other) const;
 
 \indexlibrarymember{locale}{operator()}%
 \begin{itemdecl}
-template <class charT, class traits, class Allocator>
+template<class charT, class traits, class Allocator>
   bool operator()(const basic_string<charT, traits, Allocator>& s1,
                   const basic_string<charT, traits, Allocator>& s2) const;
 \end{itemdecl}
@@ -920,7 +920,7 @@ with time.
 
 \indexlibrarymember{locale}{use_facet}%
 \begin{itemdecl}
-template <class Facet> const Facet& use_facet(const locale& loc);
+template<class Facet> const Facet& use_facet(const locale& loc);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -951,7 +951,7 @@ The reference returned remains valid at least as long as any copy of
 
 \indexlibrarymember{locale}{has_facet}%
 \begin{itemdecl}
-template <class Facet> bool has_facet(const locale& loc) noexcept;
+template<class Facet> bool has_facet(const locale& loc) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -977,18 +977,18 @@ template <class Facet> bool has_facet(const locale& loc) noexcept;
 \indexlibrary{\idxcode{isgraph}}%
 \indexlibrary{\idxcode{isblank}}%
 \begin{itemdecl}
-template <class charT> bool isspace (charT c, const locale& loc);
-template <class charT> bool isprint (charT c, const locale& loc);
-template <class charT> bool iscntrl (charT c, const locale& loc);
-template <class charT> bool isupper (charT c, const locale& loc);
-template <class charT> bool islower (charT c, const locale& loc);
-template <class charT> bool isalpha (charT c, const locale& loc);
-template <class charT> bool isdigit (charT c, const locale& loc);
-template <class charT> bool ispunct (charT c, const locale& loc);
-template <class charT> bool isxdigit(charT c, const locale& loc);
-template <class charT> bool isalnum (charT c, const locale& loc);
-template <class charT> bool isgraph (charT c, const locale& loc);
-template <class charT> bool isblank (charT c, const locale& loc);
+template<class charT> bool isspace (charT c, const locale& loc);
+template<class charT> bool isprint (charT c, const locale& loc);
+template<class charT> bool iscntrl (charT c, const locale& loc);
+template<class charT> bool isupper (charT c, const locale& loc);
+template<class charT> bool islower (charT c, const locale& loc);
+template<class charT> bool isalpha (charT c, const locale& loc);
+template<class charT> bool isdigit (charT c, const locale& loc);
+template<class charT> bool ispunct (charT c, const locale& loc);
+template<class charT> bool isxdigit(charT c, const locale& loc);
+template<class charT> bool isalnum (charT c, const locale& loc);
+template<class charT> bool isgraph (charT c, const locale& loc);
+template<class charT> bool isblank (charT c, const locale& loc);
 \end{itemdecl}
 
 \pnum
@@ -1014,7 +1014,7 @@ facet and use it directly, or use the vector form of
 
 \indexlibrary{\idxcode{toupper}}%
 \begin{itemdecl}
-template <class charT> charT toupper(charT c, const locale& loc);
+template<class charT> charT toupper(charT c, const locale& loc);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1025,7 +1025,7 @@ template <class charT> charT toupper(charT c, const locale& loc);
 
 \indexlibrary{\idxcode{tolower}}%
 \begin{itemdecl}
-template <class charT> charT tolower(charT c, const locale& loc);
+template<class charT> charT tolower(charT c, const locale& loc);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1119,7 +1119,7 @@ is a bitmask type\iref{bitmask.types}.
 \indexlibrary{\idxcode{ctype}}%
 \begin{codeblock}
 namespace std {
-  template <class charT>
+  template<class charT>
     class ctype : public locale::facet, public ctype_base {
     public:
       using char_type = charT;
@@ -1512,7 +1512,7 @@ The second form returns \tcode{high}.
 \indexlibrary{\idxcode{ctype_byname}}%
 \begin{codeblock}
 namespace std {
-  template <class charT>
+  template<class charT>
     class ctype_byname : public ctype<charT> {
     public:
       using mask = typename ctype<charT>::mask;
@@ -1530,7 +1530,7 @@ namespace std {
 \indexlibrary{\idxcode{ctype<char>}}%
 \begin{codeblock}
 namespace std {
-  template <>
+  template<>
     class ctype<char> : public locale::facet, public ctype_base {
     public:
       using char_type = char;
@@ -1828,7 +1828,7 @@ namespace std {
     enum result { ok, partial, error, noconv };
   };
 
-  template <class internT, class externT, class stateT>
+  template<class internT, class externT, class stateT>
     class codecvt : public locale::facet, public codecvt_base {
     public:
       using intern_type = internT;
@@ -2282,7 +2282,7 @@ returns 1.
 \indexlibrary{\idxcode{codecvt_byname}}%
 \begin{codeblock}
 namespace std {
-  template <class internT, class externT, class stateT>
+  template<class internT, class externT, class stateT>
     class codecvt_byname : public codecvt<internT, externT, stateT> {
     public:
       explicit codecvt_byname(const char*, size_t refs = 0);
@@ -2348,7 +2348,7 @@ member functions for formatting and parsing numeric values~(\ref{istream.formatt
 \indexlibrary{\idxcode{num_get}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class InputIterator = istreambuf_iterator<charT>>
+  template<class charT, class InputIterator = istreambuf_iterator<charT>>
     class num_get : public locale::facet {
     public:
       using char_type = charT;
@@ -2762,7 +2762,7 @@ For empty targets \tcode{("")}, any input sequence yields
 \indexlibrary{\idxcode{num_put}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class OutputIterator = ostreambuf_iterator<charT>>
+  template<class charT, class OutputIterator = ostreambuf_iterator<charT>>
     class num_put : public locale::facet {
     public:
       using char_type = charT;
@@ -3095,7 +3095,7 @@ and returns
 \indexlibrary{\idxcode{numpunct}}%
 \begin{codeblock}
 namespace std {
-  template <class charT>
+  template<class charT>
     class numpunct : public locale::facet {
     public:
       using char_type   = charT;
@@ -3310,7 +3310,7 @@ In the base class implementation these names are
 \indexlibrary{\idxcode{numpunct_byname}}%
 \begin{codeblock}
 namespace std {
-  template <class charT>
+  template<class charT>
     class numpunct_byname : public numpunct<charT> {
     // this class is specialized for \tcode{char} and \tcode{wchar_t}.
     public:
@@ -3333,7 +3333,7 @@ namespace std {
 \indexlibrary{\idxcode{collate}}%
 \begin{codeblock}
 namespace std {
-  template <class charT>
+  template<class charT>
     class collate : public locale::facet {
     public:
       using char_type   = charT;
@@ -3481,7 +3481,7 @@ not compare equal should be very small, approaching
 \indexlibrary{\idxcode{collate_byname}}%
 \begin{codeblock}
 namespace std {
-  template <class charT>
+  template<class charT>
     class collate_byname : public collate<charT> {
     public:
       using string_type = basic_string<charT>;
@@ -3529,7 +3529,7 @@ namespace std {
     enum dateorder { no_order, dmy, mdy, ymd, ydm };
   };
 
-  template <class charT, class InputIterator = istreambuf_iterator<charT>>
+  template<class charT, class InputIterator = istreambuf_iterator<charT>>
     class time_get : public locale::facet, public time_base {
     public:
       using char_type = charT;
@@ -3936,7 +3936,7 @@ recognized as possibly part of a valid input sequence for the given
 \indexlibrary{\idxcode{time_get_byname}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class InputIterator = istreambuf_iterator<charT>>
+  template<class charT, class InputIterator = istreambuf_iterator<charT>>
     class time_get_byname : public time_get<charT, InputIterator> {
     public:
       using dateorder = time_base::dateorder;
@@ -3956,7 +3956,7 @@ namespace std {
 \indexlibrary{\idxcode{time_put}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class OutputIterator = ostreambuf_iterator<charT>>
+  template<class charT, class OutputIterator = ostreambuf_iterator<charT>>
     class time_put : public locale::facet {
     public:
       using char_type = charT;
@@ -4089,7 +4089,7 @@ default for this argument.
 \indexlibrary{\idxcode{time_put_byname}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class OutputIterator = ostreambuf_iterator<charT>>
+  template<class charT, class OutputIterator = ostreambuf_iterator<charT>>
     class time_put_byname : public time_put<charT, OutputIterator> {
     public:
       using char_type = charT;
@@ -4135,7 +4135,7 @@ facets, to determine formatting details.
 \indexlibrary{\idxcode{money_get}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class InputIterator = istreambuf_iterator<charT>>
+  template<class charT, class InputIterator = istreambuf_iterator<charT>>
     class money_get : public locale::facet {
     public:
       using char_type   = charT;
@@ -4361,7 +4361,7 @@ as part of a valid monetary quantity.
 \indexlibrary{\idxcode{money_put}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class OutputIterator = ostreambuf_iterator<charT>>
+  template<class charT, class OutputIterator = ostreambuf_iterator<charT>>
     class money_put : public locale::facet {
     public:
       using char_type   = charT;
@@ -4515,7 +4515,7 @@ namespace std {
     struct pattern { char field[4]; };
   };
 
-  template <class charT, bool International = false>
+  template<class charT, bool International = false>
     class moneypunct : public locale::facet, public money_base {
     public:
       using char_type   = charT;
@@ -4845,7 +4845,7 @@ for example, \tcode{"USD "}.}
 \indexlibrary{\idxcode{moneypunct_byname}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, bool Intl = false>
+  template<class charT, bool Intl = false>
   class moneypunct_byname : public moneypunct<charT, Intl> {
     public:
       using pattern     = money_base::pattern;
@@ -4877,7 +4877,7 @@ namespace std {
     using catalog = @\textit{unspecified signed integer type}@;
   };
 
-  template <class charT>
+  template<class charT>
     class messages : public locale::facet, public messages_base {
     public:
       using char_type   = charT;
@@ -5021,7 +5021,7 @@ The limit on such resources, if any, is \impldef{resource limits on a message ca
 \indexlibrary{\idxcode{messages_byname}}%
 \begin{codeblock}
 namespace std {
-  template <class charT>
+  template<class charT>
     class messages_byname : public messages<charT> {
     public:
       using catalog     = messages_base::catalog;

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -2707,7 +2707,7 @@ defined in this subclause\iref{rand.eng} and in subclause~\ref{rand.adapt}:
 \item
 if the constructor
 \begin{codeblock}
-template <class Sseq> explicit X(Sseq& q);
+template<class Sseq> explicit X(Sseq& q);
 \end{codeblock}
 is called with a type \tcode{Sseq} that does not qualify as a seed sequence, then this
 constructor shall not participate in overload resolution;
@@ -2715,7 +2715,7 @@ constructor shall not participate in overload resolution;
 \item
 if the member function
 \begin{codeblock}
-template <class Sseq> void seed(Sseq& q);
+template<class Sseq> void seed(Sseq& q);
 \end{codeblock}
 is called with a type \tcode{Sseq} that does not qualify as a seed sequence, then this
 function shall not participate in overload resolution.
@@ -6533,10 +6533,10 @@ namespace std {
   template<class T> valarray<T> tan  (const valarray<T>&);
   template<class T> valarray<T> tanh (const valarray<T>&);
 
-  template <class T> @\unspec{1}@ begin(valarray<T>& v);
-  template <class T> @\unspec{2}@ begin(const valarray<T>& v);
-  template <class T> @\unspec{1}@ end(valarray<T>& v);
-  template <class T> @\unspec{2}@ end(const valarray<T>& v);
+  template<class T> @\unspec{1}@ begin(valarray<T>& v);
+  template<class T> @\unspec{2}@ begin(const valarray<T>& v);
+  template<class T> @\unspec{1}@ end(valarray<T>& v);
+  template<class T> @\unspec{2}@ end(const valarray<T>& v);
 }
 \end{codeblock}
 
@@ -7697,7 +7697,7 @@ or which can be unambiguously implicitly converted to type \tcode{T}.
 
 \indexlibrarymember{swap}{valarray}%
 \begin{itemdecl}
-template <class T> void swap(valarray<T>& x, valarray<T>& y) noexcept;
+template<class T> void swap(valarray<T>& x, valarray<T>& y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7790,7 +7790,7 @@ by a \tcode{slice} object.
 \indexlibrarymember{value_type}{slice_array}%
 \begin{codeblock}
 namespace std {
-  template <class T> class slice_array {
+  template<class T> class slice_array {
   public:
     using value_type = T;
 
@@ -8076,7 +8076,7 @@ are linear in the number of strides.
 \indexlibrarymember{value_type}{gslice_array}%
 \begin{codeblock}
 namespace std {
-  template <class T> class gslice_array {
+  template<class T> class gslice_array {
   public:
     using value_type = T;
 
@@ -8208,7 +8208,7 @@ object refers.
 \indexlibrarymember{value_type}{mask_array}%
 \begin{codeblock}
 namespace std {
-  template <class T> class mask_array {
+  template<class T> class mask_array {
   public:
     using value_type = T;
 
@@ -8334,7 +8334,7 @@ object refers.
 \indexlibrarymember{value_type}{indirect_array}%
 \begin{codeblock}
 namespace std {
-  template <class T> class indirect_array {
+  template<class T> class indirect_array {
   public:
     using value_type = T;
 
@@ -8503,8 +8503,8 @@ first.
 
 \indexlibrary{\idxcode{begin}!\idxcode{valarray}}%
 \begin{itemdecl}
-template <class T> @\unspec{1}@ begin(valarray<T>& v);
-template <class T> @\unspec{2}@ begin(const valarray<T>& v);
+template<class T> @\unspec{1}@ begin(valarray<T>& v);
+template<class T> @\unspec{2}@ begin(const valarray<T>& v);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8514,8 +8514,8 @@ template <class T> @\unspec{2}@ begin(const valarray<T>& v);
 
 \indexlibrary{\idxcode{end}!\idxcode{valarray}}%
 \begin{itemdecl}
-template <class T> @\unspec{1}@ end(valarray<T>& v);
-template <class T> @\unspec{2}@ end(const valarray<T>& v);
+template<class T> @\unspec{1}@ end(valarray<T>& v);
+template<class T> @\unspec{2}@ end(const valarray<T>& v);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8532,9 +8532,9 @@ template <class T> @\unspec{2}@ end(const valarray<T>& v);
 \begin{codeblock}
 namespace std {
   // \ref{accumulate}, accumulate
-  template <class InputIterator, class T>
+  template<class InputIterator, class T>
     T accumulate(InputIterator first, InputIterator last, T init);
-  template <class InputIterator, class T, class BinaryOperation>
+  template<class InputIterator, class T, class BinaryOperation>
     T accumulate(InputIterator first, InputIterator last, T init, BinaryOperation binary_op);
 
   // \ref{reduce}, reduce
@@ -8557,11 +8557,11 @@ namespace std {
              ForwardIterator first, ForwardIterator last, T init, BinaryOperation binary_op);
 
   // \ref{inner.product}, inner product
-  template <class InputIterator1, class InputIterator2, class T>
+  template<class InputIterator1, class InputIterator2, class T>
     T inner_product(InputIterator1 first1, InputIterator1 last1,
                     InputIterator2 first2, T init);
-  template <class InputIterator1, class InputIterator2, class T,
-            class BinaryOperation1, class BinaryOperation2>
+  template<class InputIterator1, class InputIterator2, class T,
+           class BinaryOperation1, class BinaryOperation2>
     T inner_product(InputIterator1 first1, InputIterator1 last1,
                     InputIterator2 first2, T init,
                     BinaryOperation1 binary_op1,
@@ -8608,11 +8608,11 @@ namespace std {
                        BinaryOperation binary_op, UnaryOperation unary_op);
 
   // \ref{partial.sum}, partial sum
-  template <class InputIterator, class OutputIterator>
+  template<class InputIterator, class OutputIterator>
     OutputIterator partial_sum(InputIterator first,
                                InputIterator last,
                                OutputIterator result);
-  template <class InputIterator, class OutputIterator, class BinaryOperation>
+  template<class InputIterator, class OutputIterator, class BinaryOperation>
     OutputIterator partial_sum(InputIterator first,
                                InputIterator last,
                                OutputIterator result,
@@ -8719,22 +8719,22 @@ namespace std {
                                               T init);
 
   // \ref{adjacent.difference}, adjacent difference
-  template <class InputIterator, class OutputIterator>
+  template<class InputIterator, class OutputIterator>
     OutputIterator adjacent_difference(InputIterator first,
                                        InputIterator last,
                                        OutputIterator result);
-  template <class InputIterator, class OutputIterator, class BinaryOperation>
+  template<class InputIterator, class OutputIterator, class BinaryOperation>
     OutputIterator adjacent_difference(InputIterator first,
                                        InputIterator last,
                                        OutputIterator result,
                                        BinaryOperation binary_op);
-  template <class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
+  template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
     ForwardIterator2 adjacent_difference(ExecutionPolicy&& exec, // see \ref{algorithms.parallel.overloads}
                                          ForwardIterator1 first,
                                          ForwardIterator1 last,
                                          ForwardIterator2 result);
-  template <class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2,
-            class BinaryOperation>
+  template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2,
+           class BinaryOperation>
     ForwardIterator2 adjacent_difference(ExecutionPolicy&& exec, // see \ref{algorithms.parallel.overloads}
                                          ForwardIterator1 first,
                                          ForwardIterator1 last,
@@ -8742,15 +8742,15 @@ namespace std {
                                          BinaryOperation binary_op);
 
   // \ref{numeric.iota}, iota
-  template <class ForwardIterator, class T>
+  template<class ForwardIterator, class T>
     void iota(ForwardIterator first, ForwardIterator last, T value);
 
   // \ref{numeric.ops.gcd}, greatest common divisor
-  template <class M, class N>
+  template<class M, class N>
     constexpr common_type_t<M,N> gcd(M m, N n);
 
   // \ref{numeric.ops.lcm}, least common multiple
-  template <class M, class N>
+  template<class M, class N>
     constexpr common_type_t<M,N> lcm(M m, N n);
 }
 \end{codeblock}
@@ -8779,9 +8779,9 @@ throughout this subclause is intentional.
 
 \indexlibrary{\idxcode{accumulate}}%
 \begin{itemdecl}
-template <class InputIterator, class T>
+template<class InputIterator, class T>
   T accumulate(InputIterator first, InputIterator last, T init);
-template <class InputIterator, class T, class BinaryOperation>
+template<class InputIterator, class T, class BinaryOperation>
   T accumulate(InputIterator first, InputIterator last, T init,
                BinaryOperation binary_op);
 \end{itemdecl}
@@ -8925,11 +8925,11 @@ a nondeterministic result for non-associative or non-commutative
 
 \indexlibrary{\idxcode{inner_product}}%
 \begin{itemdecl}
-template <class InputIterator1, class InputIterator2, class T>
+template<class InputIterator1, class InputIterator2, class T>
   T inner_product(InputIterator1 first1, InputIterator1 last1,
                   InputIterator2 first2, T init);
-template <class InputIterator1, class InputIterator2, class T,
-          class BinaryOperation1, class BinaryOperation2>
+template<class InputIterator1, class InputIterator2, class T,
+         class BinaryOperation1, class BinaryOperation2>
   T inner_product(InputIterator1 first1, InputIterator1 last1,
                   InputIterator2 first2, T init,
                   BinaryOperation1 binary_op1,
@@ -8973,12 +8973,12 @@ in order.
 \rSec2[transform.reduce]{Transform reduce}
 \indexlibrary{\idxcode{transform_reduce}}%
 \begin{itemdecl}
-template <class InputIterator1, class InputIterator2, class T>
+template<class InputIterator1, class InputIterator2, class T>
   T transform_reduce(InputIterator1 first1, InputIterator1 last1,
                      InputIterator2 first2,
                      T init);
-template <class ExecutionPolicy,
-          class ForwardIterator1, class ForwardIterator2, class T>
+template<class ExecutionPolicy,
+         class ForwardIterator1, class ForwardIterator2, class T>
   T transform_reduce(ExecutionPolicy&& exec,
                      ForwardIterator1 first1, ForwardIterator1 last1,
                      ForwardIterator2 first2,
@@ -8995,16 +8995,16 @@ return transform_reduce(first1, last1, first2, init, plus<>(), multiplies<>());
 
 \indexlibrary{\idxcode{transform_reduce}}%
 \begin{itemdecl}
-template <class InputIterator1, class InputIterator2, class T,
-          class BinaryOperation1, class BinaryOperation2>
+template<class InputIterator1, class InputIterator2, class T,
+         class BinaryOperation1, class BinaryOperation2>
   T transform_reduce(InputIterator1 first1, InputIterator1 last1,
                      InputIterator2 first2,
                      T init,
                      BinaryOperation1 binary_op1,
                      BinaryOperation2 binary_op2);
-template <class ExecutionPolicy,
-          class ForwardIterator1, class ForwardIterator2, class T,
-          class BinaryOperation1, class BinaryOperation2>
+template<class ExecutionPolicy,
+         class ForwardIterator1, class ForwardIterator2, class T,
+         class BinaryOperation1, class BinaryOperation2>
   T transform_reduce(ExecutionPolicy&& exec,
                      ForwardIterator1 first1, ForwardIterator1 last1,
                      ForwardIterator2 first2,
@@ -9096,11 +9096,11 @@ for every iterator \tcode{i} in \range{first}{last}.
 
 \indexlibrary{\idxcode{partial_sum}}%
 \begin{itemdecl}
-template <class InputIterator, class OutputIterator>
+template<class InputIterator, class OutputIterator>
   OutputIterator partial_sum(
     InputIterator first, InputIterator last,
     OutputIterator result);
-template <class InputIterator, class OutputIterator, class BinaryOperation>
+template<class InputIterator, class OutputIterator, class BinaryOperation>
   OutputIterator partial_sum(
     InputIterator first, InputIterator last,
     OutputIterator result, BinaryOperation binary_op);
@@ -9507,20 +9507,20 @@ may be nondeterministic. \tcode{transform_inclusive_scan} does not apply
 
 \indexlibrary{\idxcode{adjacent_difference}}%
 \begin{itemdecl}
-template <class InputIterator, class OutputIterator>
+template<class InputIterator, class OutputIterator>
   OutputIterator
     adjacent_difference(InputIterator first, InputIterator last, OutputIterator result);
-template <class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
   ForwardIterator2
     adjacent_difference(ExecutionPolicy&& exec,
                         ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result);
 
-template <class InputIterator, class OutputIterator, class BinaryOperation>
+template<class InputIterator, class OutputIterator, class BinaryOperation>
   OutputIterator
     adjacent_difference(InputIterator first, InputIterator last,
                         OutputIterator result, BinaryOperation binary_op);
-template <class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2,
-          class BinaryOperation>
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2,
+         class BinaryOperation>
   ForwardIterator2
     adjacent_difference(ExecutionPolicy&& exec,
                         ForwardIterator1 first, ForwardIterator1 last,
@@ -9599,7 +9599,7 @@ to \tcode{first}.  For the overloads with an \tcode{ExecutionPolicy}, the ranges
 
 \indexlibrary{\idxcode{iota}}%
 \begin{itemdecl}
-template <class ForwardIterator, class T>
+template<class ForwardIterator, class T>
   void iota(ForwardIterator first, ForwardIterator last, T value);
 \end{itemdecl}
 
@@ -9622,7 +9622,7 @@ if by \tcode{++value}.
 
 \indexlibrary{\idxcode{gcd}}%
 \begin{itemdecl}
-template <class M, class N>
+template<class M, class N>
   constexpr common_type_t<M,N> gcd(M m, N n);
 \end{itemdecl}
 
@@ -9653,7 +9653,7 @@ Nothing.
 
 \indexlibrary{\idxcode{lcm}}%
 \begin{itemdecl}
-template <class M, class N>
+template<class M, class N>
   constexpr common_type_t<M,N> lcm(M m, N n);
 \end{itemdecl}
 

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -273,20 +273,20 @@ namespace std {
   class regex_error;
 
   // \ref{re.traits}, class template \tcode{regex_traits}
-  template <class charT> struct regex_traits;
+  template<class charT> struct regex_traits;
 
   // \ref{re.regex}, class template \tcode{basic_regex}
-  template <class charT, class traits = regex_traits<charT>> class basic_regex;
+  template<class charT, class traits = regex_traits<charT>> class basic_regex;
 
   using regex  = basic_regex<char>;
   using wregex = basic_regex<wchar_t>;
 
   // \ref{re.regex.swap}, \tcode{basic_regex} swap
-  template <class charT, class traits>
+  template<class charT, class traits>
     void swap(basic_regex<charT, traits>& e1, basic_regex<charT, traits>& e2);
 
   // \ref{re.submatch}, class template \tcode{sub_match}
-  template <class BidirectionalIterator>
+  template<class BidirectionalIterator>
     class sub_match;
 
   using csub_match  = sub_match<const char*>;
@@ -295,152 +295,152 @@ namespace std {
   using wssub_match = sub_match<wstring::const_iterator>;
 
   // \ref{re.submatch.op}, \tcode{sub_match} non-member operators
-  template <class BiIter>
+  template<class BiIter>
     bool operator==(const sub_match<BiIter>& lhs, const sub_match<BiIter>& rhs);
-  template <class BiIter>
+  template<class BiIter>
     bool operator!=(const sub_match<BiIter>& lhs, const sub_match<BiIter>& rhs);
-  template <class BiIter>
+  template<class BiIter>
     bool operator<(const sub_match<BiIter>& lhs, const sub_match<BiIter>& rhs);
-  template <class BiIter>
+  template<class BiIter>
     bool operator<=(const sub_match<BiIter>& lhs, const sub_match<BiIter>& rhs);
-  template <class BiIter>
+  template<class BiIter>
     bool operator>=(const sub_match<BiIter>& lhs, const sub_match<BiIter>& rhs);
-  template <class BiIter>
+  template<class BiIter>
     bool operator>(const sub_match<BiIter>& lhs, const sub_match<BiIter>& rhs);
 
-  template <class BiIter, class ST, class SA>
+  template<class BiIter, class ST, class SA>
     bool operator==(
       const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& lhs,
       const sub_match<BiIter>& rhs);
-  template <class BiIter, class ST, class SA>
+  template<class BiIter, class ST, class SA>
     bool operator!=(
       const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& lhs,
       const sub_match<BiIter>& rhs);
-  template <class BiIter, class ST, class SA>
+  template<class BiIter, class ST, class SA>
     bool operator<(
       const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& lhs,
       const sub_match<BiIter>& rhs);
-  template <class BiIter, class ST, class SA>
+  template<class BiIter, class ST, class SA>
     bool operator>(
       const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& lhs,
       const sub_match<BiIter>& rhs);
-  template <class BiIter, class ST, class SA>
+  template<class BiIter, class ST, class SA>
     bool operator>=(
       const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& lhs,
       const sub_match<BiIter>& rhs);
-  template <class BiIter, class ST, class SA>
+  template<class BiIter, class ST, class SA>
     bool operator<=(
       const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& lhs,
       const sub_match<BiIter>& rhs);
 
-  template <class BiIter, class ST, class SA>
+  template<class BiIter, class ST, class SA>
     bool operator==(
       const sub_match<BiIter>& lhs,
       const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& rhs);
-  template <class BiIter, class ST, class SA>
+  template<class BiIter, class ST, class SA>
     bool operator!=(
       const sub_match<BiIter>& lhs,
       const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& rhs);
-  template <class BiIter, class ST, class SA>
+  template<class BiIter, class ST, class SA>
     bool operator<(
       const sub_match<BiIter>& lhs,
       const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& rhs);
-  template <class BiIter, class ST, class SA>
+  template<class BiIter, class ST, class SA>
     bool operator>(
       const sub_match<BiIter>& lhs,
       const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& rhs);
-  template <class BiIter, class ST, class SA>
+  template<class BiIter, class ST, class SA>
     bool operator>=(
       const sub_match<BiIter>& lhs,
       const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& rhs);
-  template <class BiIter, class ST, class SA>
+  template<class BiIter, class ST, class SA>
     bool operator<=(
       const sub_match<BiIter>& lhs,
       const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& rhs);
 
-  template <class BiIter>
+  template<class BiIter>
     bool operator==(const typename iterator_traits<BiIter>::value_type* lhs,
                     const sub_match<BiIter>& rhs);
-  template <class BiIter>
+  template<class BiIter>
     bool operator!=(const typename iterator_traits<BiIter>::value_type* lhs,
                     const sub_match<BiIter>& rhs);
-  template <class BiIter>
+  template<class BiIter>
     bool operator<(const typename iterator_traits<BiIter>::value_type* lhs,
                    const sub_match<BiIter>& rhs);
-  template <class BiIter>
+  template<class BiIter>
     bool operator>(const typename iterator_traits<BiIter>::value_type* lhs,
                    const sub_match<BiIter>& rhs);
-  template <class BiIter>
+  template<class BiIter>
     bool operator>=(const typename iterator_traits<BiIter>::value_type* lhs,
                     const sub_match<BiIter>& rhs);
-  template <class BiIter>
+  template<class BiIter>
     bool operator<=(const typename iterator_traits<BiIter>::value_type* lhs,
                     const sub_match<BiIter>& rhs);
 
-  template <class BiIter>
+  template<class BiIter>
     bool operator==(const sub_match<BiIter>& lhs,
                     const typename iterator_traits<BiIter>::value_type* rhs);
-  template <class BiIter>
+  template<class BiIter>
     bool operator!=(const sub_match<BiIter>& lhs,
                     const typename iterator_traits<BiIter>::value_type* rhs);
-  template <class BiIter>
+  template<class BiIter>
     bool operator<(const sub_match<BiIter>& lhs,
                    const typename iterator_traits<BiIter>::value_type* rhs);
-  template <class BiIter>
+  template<class BiIter>
     bool operator>(const sub_match<BiIter>& lhs,
                    const typename iterator_traits<BiIter>::value_type* rhs);
-  template <class BiIter>
+  template<class BiIter>
     bool operator>=(const sub_match<BiIter>& lhs,
                     const typename iterator_traits<BiIter>::value_type* rhs);
-  template <class BiIter>
+  template<class BiIter>
     bool operator<=(const sub_match<BiIter>& lhs,
                     const typename iterator_traits<BiIter>::value_type* rhs);
 
-  template <class BiIter>
+  template<class BiIter>
     bool operator==(const typename iterator_traits<BiIter>::value_type& lhs,
                     const sub_match<BiIter>& rhs);
-  template <class BiIter>
+  template<class BiIter>
     bool operator!=(const typename iterator_traits<BiIter>::value_type& lhs,
                     const sub_match<BiIter>& rhs);
-  template <class BiIter>
+  template<class BiIter>
     bool operator<(const typename iterator_traits<BiIter>::value_type& lhs,
                    const sub_match<BiIter>& rhs);
-  template <class BiIter>
+  template<class BiIter>
     bool operator>(const typename iterator_traits<BiIter>::value_type& lhs,
                    const sub_match<BiIter>& rhs);
-  template <class BiIter>
+  template<class BiIter>
     bool operator>=(const typename iterator_traits<BiIter>::value_type& lhs,
                     const sub_match<BiIter>& rhs);
-  template <class BiIter>
+  template<class BiIter>
     bool operator<=(const typename iterator_traits<BiIter>::value_type& lhs,
                     const sub_match<BiIter>& rhs);
 
-  template <class BiIter>
+  template<class BiIter>
     bool operator==(const sub_match<BiIter>& lhs,
                     const typename iterator_traits<BiIter>::value_type& rhs);
-  template <class BiIter>
+  template<class BiIter>
     bool operator!=(const sub_match<BiIter>& lhs,
                     const typename iterator_traits<BiIter>::value_type& rhs);
-  template <class BiIter>
+  template<class BiIter>
     bool operator<(const sub_match<BiIter>& lhs,
                    const typename iterator_traits<BiIter>::value_type& rhs);
-  template <class BiIter>
+  template<class BiIter>
     bool operator>(const sub_match<BiIter>& lhs,
                    const typename iterator_traits<BiIter>::value_type& rhs);
-  template <class BiIter>
+  template<class BiIter>
     bool operator>=(const sub_match<BiIter>& lhs,
                     const typename iterator_traits<BiIter>::value_type& rhs);
-  template <class BiIter>
+  template<class BiIter>
     bool operator<=(const sub_match<BiIter>& lhs,
                     const typename iterator_traits<BiIter>::value_type& rhs);
 
-  template <class charT, class ST, class BiIter>
+  template<class charT, class ST, class BiIter>
     basic_ostream<charT, ST>&
       operator<<(basic_ostream<charT, ST>& os, const sub_match<BiIter>& m);
 
   // \ref{re.results}, class template \tcode{match_results}
-  template <class BidirectionalIterator,
-            class Allocator = allocator<sub_match<BidirectionalIterator>>>
+  template<class BidirectionalIterator,
+           class Allocator = allocator<sub_match<BidirectionalIterator>>>
     class match_results;
 
   using cmatch  = match_results<const char*>;
@@ -449,83 +449,83 @@ namespace std {
   using wsmatch = match_results<wstring::const_iterator>;
 
   // \tcode{match_results} comparisons
-  template <class BidirectionalIterator, class Allocator>
+  template<class BidirectionalIterator, class Allocator>
     bool operator==(const match_results<BidirectionalIterator, Allocator>& m1,
                     const match_results<BidirectionalIterator, Allocator>& m2);
-  template <class BidirectionalIterator, class Allocator>
+  template<class BidirectionalIterator, class Allocator>
     bool operator!=(const match_results<BidirectionalIterator, Allocator>& m1,
                     const match_results<BidirectionalIterator, Allocator>& m2);
 
   // \ref{re.results.swap}, \tcode{match_results} swap
-  template <class BidirectionalIterator, class Allocator>
+  template<class BidirectionalIterator, class Allocator>
     void swap(match_results<BidirectionalIterator, Allocator>& m1,
               match_results<BidirectionalIterator, Allocator>& m2);
 
   // \ref{re.alg.match}, function template \tcode{regex_match}
-  template <class BidirectionalIterator, class Allocator, class charT, class traits>
+  template<class BidirectionalIterator, class Allocator, class charT, class traits>
     bool regex_match(BidirectionalIterator first, BidirectionalIterator last,
                      match_results<BidirectionalIterator, Allocator>& m,
                      const basic_regex<charT, traits>& e,
                      regex_constants::match_flag_type flags = regex_constants::match_default);
-  template <class BidirectionalIterator, class charT, class traits>
+  template<class BidirectionalIterator, class charT, class traits>
     bool regex_match(BidirectionalIterator first, BidirectionalIterator last,
                      const basic_regex<charT, traits>& e,
                      regex_constants::match_flag_type flags = regex_constants::match_default);
-  template <class charT, class Allocator, class traits>
+  template<class charT, class Allocator, class traits>
     bool regex_match(const charT* str, match_results<const charT*, Allocator>& m,
                      const basic_regex<charT, traits>& e,
                      regex_constants::match_flag_type flags = regex_constants::match_default);
-  template <class ST, class SA, class Allocator, class charT, class traits>
+  template<class ST, class SA, class Allocator, class charT, class traits>
     bool regex_match(const basic_string<charT, ST, SA>& s,
                      match_results<typename basic_string<charT, ST, SA>::const_iterator,
                                    Allocator>& m,
                      const basic_regex<charT, traits>& e,
                      regex_constants::match_flag_type flags = regex_constants::match_default);
-  template <class ST, class SA, class Allocator, class charT, class traits>
+  template<class ST, class SA, class Allocator, class charT, class traits>
     bool regex_match(const basic_string<charT, ST, SA>&&,
                      match_results<typename basic_string<charT, ST, SA>::const_iterator,
                                    Allocator>&,
                      const basic_regex<charT, traits>&,
                      regex_constants::match_flag_type = regex_constants::match_default) = delete;
-  template <class charT, class traits>
+  template<class charT, class traits>
     bool regex_match(const charT* str,
                      const basic_regex<charT, traits>& e,
                      regex_constants::match_flag_type flags = regex_constants::match_default);
-  template <class ST, class SA, class charT, class traits>
+  template<class ST, class SA, class charT, class traits>
     bool regex_match(const basic_string<charT, ST, SA>& s,
                      const basic_regex<charT, traits>& e,
                      regex_constants::match_flag_type flags = regex_constants::match_default);
 
   // \ref{re.alg.search}, function template \tcode{regex_search}
-  template <class BidirectionalIterator, class Allocator, class charT, class traits>
+  template<class BidirectionalIterator, class Allocator, class charT, class traits>
     bool regex_search(BidirectionalIterator first, BidirectionalIterator last,
                       match_results<BidirectionalIterator, Allocator>& m,
                       const basic_regex<charT, traits>& e,
                       regex_constants::match_flag_type flags = regex_constants::match_default);
-  template <class BidirectionalIterator, class charT, class traits>
+  template<class BidirectionalIterator, class charT, class traits>
     bool regex_search(BidirectionalIterator first, BidirectionalIterator last,
                       const basic_regex<charT, traits>& e,
                       regex_constants::match_flag_type flags = regex_constants::match_default);
-  template <class charT, class Allocator, class traits>
+  template<class charT, class Allocator, class traits>
     bool regex_search(const charT* str,
                       match_results<const charT*, Allocator>& m,
                       const basic_regex<charT, traits>& e,
                       regex_constants::match_flag_type flags = regex_constants::match_default);
-  template <class charT, class traits>
+  template<class charT, class traits>
     bool regex_search(const charT* str,
                       const basic_regex<charT, traits>& e,
                       regex_constants::match_flag_type flags = regex_constants::match_default);
-  template <class ST, class SA, class charT, class traits>
+  template<class ST, class SA, class charT, class traits>
     bool regex_search(const basic_string<charT, ST, SA>& s,
                       const basic_regex<charT, traits>& e,
                       regex_constants::match_flag_type flags = regex_constants::match_default);
-  template <class ST, class SA, class Allocator, class charT, class traits>
+  template<class ST, class SA, class Allocator, class charT, class traits>
     bool regex_search(const basic_string<charT, ST, SA>& s,
                       match_results<typename basic_string<charT, ST, SA>::const_iterator,
                                     Allocator>& m,
                       const basic_regex<charT, traits>& e,
                       regex_constants::match_flag_type flags = regex_constants::match_default);
-  template <class ST, class SA, class Allocator, class charT, class traits>
+  template<class ST, class SA, class Allocator, class charT, class traits>
     bool regex_search(const basic_string<charT, ST, SA>&&,
                       match_results<typename basic_string<charT, ST, SA>::const_iterator,
                                     Allocator>&,
@@ -534,7 +534,7 @@ namespace std {
                         = regex_constants::match_default) = delete;
 
   // \ref{re.alg.replace}, function template \tcode{regex_replace}
-  template <class OutputIterator, class BidirectionalIterator,
+  template<class OutputIterator, class BidirectionalIterator,
             class traits, class charT, class ST, class SA>
     OutputIterator
       regex_replace(OutputIterator out,
@@ -542,32 +542,32 @@ namespace std {
                     const basic_regex<charT, traits>& e,
                     const basic_string<charT, ST, SA>& fmt,
                     regex_constants::match_flag_type flags = regex_constants::match_default);
-  template <class OutputIterator, class BidirectionalIterator, class traits, class charT>
+  template<class OutputIterator, class BidirectionalIterator, class traits, class charT>
     OutputIterator
       regex_replace(OutputIterator out,
                     BidirectionalIterator first, BidirectionalIterator last,
                     const basic_regex<charT, traits>& e,
                     const charT* fmt,
                     regex_constants::match_flag_type flags = regex_constants::match_default);
-  template <class traits, class charT, class ST, class SA, class FST, class FSA>
+  template<class traits, class charT, class ST, class SA, class FST, class FSA>
     basic_string<charT, ST, SA>
       regex_replace(const basic_string<charT, ST, SA>& s,
                     const basic_regex<charT, traits>& e,
                     const basic_string<charT, FST, FSA>& fmt,
                     regex_constants::match_flag_type flags = regex_constants::match_default);
-  template <class traits, class charT, class ST, class SA>
+  template<class traits, class charT, class ST, class SA>
     basic_string<charT, ST, SA>
       regex_replace(const basic_string<charT, ST, SA>& s,
                     const basic_regex<charT, traits>& e,
                     const charT* fmt,
                     regex_constants::match_flag_type flags = regex_constants::match_default);
-  template <class traits, class charT, class ST, class SA>
+  template<class traits, class charT, class ST, class SA>
     basic_string<charT>
       regex_replace(const charT* s,
                     const basic_regex<charT, traits>& e,
                     const basic_string<charT, ST, SA>& fmt,
                     regex_constants::match_flag_type flags = regex_constants::match_default);
-  template <class traits, class charT>
+  template<class traits, class charT>
     basic_string<charT>
       regex_replace(const charT* s,
                     const basic_regex<charT, traits>& e,
@@ -575,7 +575,7 @@ namespace std {
                     regex_constants::match_flag_type flags = regex_constants::match_default);
 
   // \ref{re.regiter}, class template \tcode{regex_iterator}
-  template <class BidirectionalIterator,
+  template<class BidirectionalIterator,
             class charT = typename iterator_traits<BidirectionalIterator>::value_type,
             class traits = regex_traits<charT>>
     class regex_iterator;
@@ -586,7 +586,7 @@ namespace std {
   using wsregex_iterator = regex_iterator<wstring::const_iterator>;
 
   // \ref{re.tokiter}, class template \tcode{regex_token_iterator}
-  template <class BidirectionalIterator,
+  template<class BidirectionalIterator,
             class charT = typename iterator_traits<BidirectionalIterator>::value_type,
             class traits = regex_traits<charT>>
     class regex_token_iterator;
@@ -597,7 +597,7 @@ namespace std {
   using wsregex_token_iterator = regex_token_iterator<wstring::const_iterator>;
 
   namespace pmr {
-    template <class BidirectionalIterator>
+    template<class BidirectionalIterator>
       using match_results =
         std::match_results<BidirectionalIterator,
                            polymorphic_allocator<sub_match<BidirectionalIterator>>>;
@@ -1016,7 +1016,7 @@ regex_constants::error_type code() const;
 \indexlibrary{\idxcode{regex_traits}}%
 \begin{codeblock}
 namespace std {
-  template <class charT>
+  template<class charT>
     struct regex_traits {
       using char_type       = charT;
       using string_type     = basic_string<char_type>;
@@ -1027,15 +1027,15 @@ namespace std {
       static size_t length(const char_type* p);
       charT translate(charT c) const;
       charT translate_nocase(charT c) const;
-      template <class ForwardIterator>
+      template<class ForwardIterator>
         string_type transform(ForwardIterator first, ForwardIterator last) const;
-      template <class ForwardIterator>
+      template<class ForwardIterator>
         string_type transform_primary(
           ForwardIterator first, ForwardIterator last) const;
-      template <class ForwardIterator>
+      template<class ForwardIterator>
         string_type lookup_collatename(
           ForwardIterator first, ForwardIterator last) const;
-      template <class ForwardIterator>
+      template<class ForwardIterator>
         char_class_type lookup_classname(
           ForwardIterator first, ForwardIterator last, bool icase = false) const;
       bool isctype(charT c, char_class_type f) const;
@@ -1095,7 +1095,7 @@ charT translate_nocase(charT c) const;
 
 \indexlibrarymember{regex_traits}{transform}%
 \begin{itemdecl}
-template <class ForwardIterator>
+template<class ForwardIterator>
   string_type transform(ForwardIterator first, ForwardIterator last) const;
 \end{itemdecl}
 
@@ -1111,7 +1111,7 @@ return use_facet<collate<charT>>(
 
 \indexlibrarymember{regex_traits}{transform_primary}%
 \begin{itemdecl}
-template <class ForwardIterator>
+template<class ForwardIterator>
   string_type transform_primary(ForwardIterator first, ForwardIterator last) const;
 \end{itemdecl}
 
@@ -1130,7 +1130,7 @@ otherwise returns an empty string.
 
 \indexlibrarymember{regex_traits}{lookup_collatename}%
 \begin{itemdecl}
-template <class ForwardIterator>
+template<class ForwardIterator>
   string_type lookup_collatename(ForwardIterator first, ForwardIterator last) const;
 \end{itemdecl}
 
@@ -1144,7 +1144,7 @@ valid collating element.
 
 \indexlibrarymember{regex_traits}{lookup_classname}%
 \begin{itemdecl}
-template <class ForwardIterator>
+template<class ForwardIterator>
   char_class_type lookup_classname(
     ForwardIterator first, ForwardIterator last, bool icase = false) const;
 \end{itemdecl}
@@ -1326,7 +1326,7 @@ exceptions of type \tcode{regex_error}.
 \indexlibrary{\idxcode{basic_regex}}%
 \begin{codeblock}
 namespace std {
-  template <class charT, class traits = regex_traits<charT>>
+  template<class charT, class traits = regex_traits<charT>>
     class basic_regex {
     public:
       // types
@@ -1366,10 +1366,10 @@ namespace std {
       basic_regex(const charT* p, size_t len, flag_type f = regex_constants::ECMAScript);
       basic_regex(const basic_regex&);
       basic_regex(basic_regex&&) noexcept;
-      template <class ST, class SA>
+      template<class ST, class SA>
         explicit basic_regex(const basic_string<charT, ST, SA>& p,
                              flag_type f = regex_constants::ECMAScript);
-      template <class ForwardIterator>
+      template<class ForwardIterator>
         basic_regex(ForwardIterator first, ForwardIterator last,
                     flag_type f = regex_constants::ECMAScript);
       basic_regex(initializer_list<charT>, flag_type = regex_constants::ECMAScript);
@@ -1380,7 +1380,7 @@ namespace std {
       basic_regex& operator=(basic_regex&&) noexcept;
       basic_regex& operator=(const charT* ptr);
       basic_regex& operator=(initializer_list<charT> il);
-      template <class ST, class SA>
+      template<class ST, class SA>
         basic_regex& operator=(const basic_string<charT, ST, SA>& p);
 
       // \ref{re.regex.assign}, assign
@@ -1388,10 +1388,10 @@ namespace std {
       basic_regex& assign(basic_regex&& that) noexcept;
       basic_regex& assign(const charT* ptr, flag_type f = regex_constants::ECMAScript);
       basic_regex& assign(const charT* p, size_t len, flag_type f);
-      template <class string_traits, class A>
+      template<class string_traits, class A>
         basic_regex& assign(const basic_string<charT, string_traits, A>& s,
                             flag_type f = regex_constants::ECMAScript);
-      template <class InputIterator>
+      template<class InputIterator>
         basic_regex& assign(InputIterator first, InputIterator last,
                             flag_type f = regex_constants::ECMAScript);
       basic_regex& assign(initializer_list<charT>,
@@ -1532,7 +1532,7 @@ basic_regex(basic_regex&& e) noexcept;
 
 \indexlibrary{\idxcode{basic_regex}!constructor}%
 \begin{itemdecl}
-template <class ST, class SA>
+template<class ST, class SA>
   explicit basic_regex(const basic_string<charT, ST, SA>& s,
                        flag_type f = regex_constants::ECMAScript);
 \end{itemdecl}
@@ -1555,7 +1555,7 @@ within the expression.
 
 \indexlibrary{\idxcode{basic_regex}!constructor}%
 \begin{itemdecl}
-template <class ForwardIterator>
+template<class ForwardIterator>
   basic_regex(ForwardIterator first, ForwardIterator last,
               flag_type f = regex_constants::ECMAScript);
 \end{itemdecl}
@@ -1643,7 +1643,7 @@ basic_regex& operator=(initializer_list<charT> il);
 
 \indexlibrarymember{basic_regex}{operator=}%
 \begin{itemdecl}
-template <class ST, class SA>
+template<class ST, class SA>
   basic_regex& operator=(const basic_string<charT, ST, SA>& p);
 \end{itemdecl}
 
@@ -1700,7 +1700,7 @@ basic_regex& assign(const charT* ptr, size_t len, flag_type f = regex_constants:
 
 \indexlibrarymember{basic_regex}{assign}%
 \begin{itemdecl}
-template <class string_traits, class A>
+template<class string_traits, class A>
   basic_regex& assign(const basic_string<charT, string_traits, A>& s,
                       flag_type f = regex_constants::ECMAScript);
 \end{itemdecl}
@@ -1726,7 +1726,7 @@ returns the number of marked sub-expressions within the expression.
 
 \indexlibrarymember{basic_regex}{assign}%
 \begin{itemdecl}
-template <class InputIterator>
+template<class InputIterator>
   basic_regex& assign(InputIterator first, InputIterator last,
                       flag_type f = regex_constants::ECMAScript);
 \end{itemdecl}
@@ -1830,7 +1830,7 @@ was in \tcode{*this}.
 \rSec3[re.regex.nmswap]{\tcode{basic_regex} non-member swap}
 \indexlibrarymember{basic_regex}{swap}%
 \begin{itemdecl}
-template <class charT, class traits>
+template<class charT, class traits>
   void swap(basic_regex<charT, traits>& lhs, basic_regex<charT, traits>& rhs);
 \end{itemdecl}
 
@@ -1846,7 +1846,7 @@ by a particular marked sub-expression.
 
 \begin{codeblock}
 namespace std {
-  template <class BidirectionalIterator>
+  template<class BidirectionalIterator>
     class sub_match : public pair<BidirectionalIterator, BidirectionalIterator> {
     public:
       using value_type      =
@@ -1943,7 +1943,7 @@ int compare(const value_type* s) const;
 
 \indexlibrarymember{sub_match}{operator==}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator==(const sub_match<BiIter>& lhs, const sub_match<BiIter>& rhs);
 \end{itemdecl}
 
@@ -1953,7 +1953,7 @@ template <class BiIter>
 
 \indexlibrarymember{sub_match}{operator"!=}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator!=(const sub_match<BiIter>& lhs, const sub_match<BiIter>& rhs);
 \end{itemdecl}
 
@@ -1963,7 +1963,7 @@ template <class BiIter>
 
 \indexlibrarymember{sub_match}{operator<}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator<(const sub_match<BiIter>& lhs, const sub_match<BiIter>& rhs);
 \end{itemdecl}
 
@@ -1973,7 +1973,7 @@ template <class BiIter>
 
 \indexlibrarymember{sub_match}{operator<=}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator<=(const sub_match<BiIter>& lhs, const sub_match<BiIter>& rhs);
 \end{itemdecl}
 
@@ -1983,7 +1983,7 @@ template <class BiIter>
 
 \indexlibrarymember{sub_match}{operator>=}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator>=(const sub_match<BiIter>& lhs, const sub_match<BiIter>& rhs);
 \end{itemdecl}
 
@@ -1993,7 +1993,7 @@ template <class BiIter>
 
 \indexlibrarymember{sub_match}{operator>}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator>(const sub_match<BiIter>& lhs, const sub_match<BiIter>& rhs);
 \end{itemdecl}
 
@@ -2003,7 +2003,7 @@ template <class BiIter>
 
 \indexlibrarymember{sub_match}{operator==}%
 \begin{itemdecl}
-template <class BiIter, class ST, class SA>
+template<class BiIter, class ST, class SA>
   bool operator==(
     const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& lhs,
     const sub_match<BiIter>& rhs);
@@ -2019,7 +2019,7 @@ rhs.compare(typename sub_match<BiIter>::string_type(lhs.data(), lhs.size())) == 
 
 \indexlibrarymember{sub_match}{operator"!=}%
 \begin{itemdecl}
-template <class BiIter, class ST, class SA>
+template<class BiIter, class ST, class SA>
   bool operator!=(
       const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& lhs,
       const sub_match<BiIter>& rhs);
@@ -2031,7 +2031,7 @@ template <class BiIter, class ST, class SA>
 
 \indexlibrarymember{sub_match}{operator<}%
 \begin{itemdecl}
-template <class BiIter, class ST, class SA>
+template<class BiIter, class ST, class SA>
   bool operator<(
       const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& lhs,
       const sub_match<BiIter>& rhs);
@@ -2047,7 +2047,7 @@ rhs.compare(typename sub_match<BiIter>::string_type(lhs.data(), lhs.size())) > 0
 
 \indexlibrarymember{sub_match}{operator>}%
 \begin{itemdecl}
-template <class BiIter, class ST, class SA>
+template<class BiIter, class ST, class SA>
   bool operator>(
       const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& lhs,
       const sub_match<BiIter>& rhs);
@@ -2059,7 +2059,7 @@ template <class BiIter, class ST, class SA>
 
 \indexlibrarymember{sub_match}{operator>=}%
 \begin{itemdecl}
-template <class BiIter, class ST, class SA>
+template<class BiIter, class ST, class SA>
   bool operator>=(
       const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& lhs,
       const sub_match<BiIter>& rhs);
@@ -2071,7 +2071,7 @@ template <class BiIter, class ST, class SA>
 
 \indexlibrarymember{sub_match}{operator<=}%
 \begin{itemdecl}
-template <class BiIter, class ST, class SA>
+template<class BiIter, class ST, class SA>
   bool operator<=(
       const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& lhs,
       const sub_match<BiIter>& rhs);
@@ -2083,7 +2083,7 @@ template <class BiIter, class ST, class SA>
 
 \indexlibrarymember{operator==}{sub_match}%
 \begin{itemdecl}
-template <class BiIter, class ST, class SA>
+template<class BiIter, class ST, class SA>
   bool operator==(
       const sub_match<BiIter>& lhs,
       const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& rhs);
@@ -2100,7 +2100,7 @@ lhs.compare(typename sub_match<BiIter>::string_type(rhs.data(), rhs.size())) == 
 \indexlibrary{\idxcode{operator"!=}!\idxcode{sub_match}}%
 \indexlibrary{\idxcode{sub_match}!\idxcode{operator"!=}}%
 \begin{itemdecl}
-template <class BiIter, class ST, class SA>
+template<class BiIter, class ST, class SA>
   bool operator!=(
       const sub_match<BiIter>& lhs,
       const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& rhs);
@@ -2113,7 +2113,7 @@ template <class BiIter, class ST, class SA>
 \indexlibrary{\idxcode{operator>}!\idxcode{sub_match}}%
 \indexlibrary{\idxcode{sub_match}!\idxcode{operator<}}%
 \begin{itemdecl}
-template <class BiIter, class ST, class SA>
+template<class BiIter, class ST, class SA>
   bool operator<(
       const sub_match<BiIter>& lhs,
       const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& rhs);
@@ -2129,7 +2129,7 @@ lhs.compare(typename sub_match<BiIter>::string_type(rhs.data(), rhs.size())) < 0
 
 \indexlibrarymember{operator>}{sub_match}%
 \begin{itemdecl}
-template <class BiIter, class ST, class SA>
+template<class BiIter, class ST, class SA>
   bool operator>(
       const sub_match<BiIter>& lhs,
       const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& rhs);
@@ -2141,7 +2141,7 @@ template <class BiIter, class ST, class SA>
 
 \indexlibrarymember{operator>=}{sub_match}%
 \begin{itemdecl}
-template <class BiIter, class ST, class SA>
+template<class BiIter, class ST, class SA>
   bool operator>=(
       const sub_match<BiIter>& lhs,
       const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& rhs);
@@ -2153,7 +2153,7 @@ template <class BiIter, class ST, class SA>
 
 \indexlibrarymember{operator<=}{sub_match}%
 \begin{itemdecl}
-template <class BiIter, class ST, class SA>
+template<class BiIter, class ST, class SA>
   bool operator<=(
       const sub_match<BiIter>& lhs,
       const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& rhs);
@@ -2165,7 +2165,7 @@ template <class BiIter, class ST, class SA>
 
 \indexlibrarymember{sub_match}{operator==}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator==(const typename iterator_traits<BiIter>::value_type* lhs,
                   const sub_match<BiIter>& rhs);
 \end{itemdecl}
@@ -2176,7 +2176,7 @@ template <class BiIter>
 
 \indexlibrarymember{sub_match}{operator"!=}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator!=(const typename iterator_traits<BiIter>::value_type* lhs,
                   const sub_match<BiIter>& rhs);
 \end{itemdecl}
@@ -2187,7 +2187,7 @@ template <class BiIter>
 
 \indexlibrarymember{sub_match}{operator<}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator<(const typename iterator_traits<BiIter>::value_type* lhs,
                  const sub_match<BiIter>& rhs);
 \end{itemdecl}
@@ -2198,7 +2198,7 @@ template <class BiIter>
 
 \indexlibrarymember{sub_match}{operator>}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator>(const typename iterator_traits<BiIter>::value_type* lhs,
                  const sub_match<BiIter>& rhs);
 \end{itemdecl}
@@ -2209,7 +2209,7 @@ template <class BiIter>
 
 \indexlibrarymember{sub_match}{operator>=}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator>=(const typename iterator_traits<BiIter>::value_type* lhs,
                   const sub_match<BiIter>& rhs);
 \end{itemdecl}
@@ -2220,7 +2220,7 @@ template <class BiIter>
 
 \indexlibrarymember{sub_match}{operator<=}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator<=(const typename iterator_traits<BiIter>::value_type* lhs,
                   const sub_match<BiIter>& rhs);
 \end{itemdecl}
@@ -2231,7 +2231,7 @@ template <class BiIter>
 
 \indexlibrarymember{sub_match}{operator==}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator==(const sub_match<BiIter>& lhs,
                   const typename iterator_traits<BiIter>::value_type* rhs);
 \end{itemdecl}
@@ -2242,7 +2242,7 @@ template <class BiIter>
 
 \indexlibrarymember{sub_match}{operator"!=}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator!=(const sub_match<BiIter>& lhs,
                   const typename iterator_traits<BiIter>::value_type* rhs);
 \end{itemdecl}
@@ -2253,7 +2253,7 @@ template <class BiIter>
 
 \indexlibrarymember{sub_match}{operator<}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator<(const sub_match<BiIter>& lhs,
                  const typename iterator_traits<BiIter>::value_type* rhs);
 \end{itemdecl}
@@ -2264,7 +2264,7 @@ template <class BiIter>
 
 \indexlibrarymember{sub_match}{operator>}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator>(const sub_match<BiIter>& lhs,
                  const typename iterator_traits<BiIter>::value_type* rhs);
 \end{itemdecl}
@@ -2275,7 +2275,7 @@ template <class BiIter>
 
 \indexlibrarymember{sub_match}{operator>=}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator>=(const sub_match<BiIter>& lhs,
                   const typename iterator_traits<BiIter>::value_type* rhs);
 \end{itemdecl}
@@ -2286,7 +2286,7 @@ template <class BiIter>
 
 \indexlibrarymember{sub_match}{operator<=}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator<=(const sub_match<BiIter>& lhs,
                   const typename iterator_traits<BiIter>::value_type* rhs);
 \end{itemdecl}
@@ -2298,7 +2298,7 @@ template <class BiIter>
 
 \indexlibrarymember{sub_match}{operator==}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator==(const typename iterator_traits<BiIter>::value_type& lhs,
                   const sub_match<BiIter>& rhs);
 \end{itemdecl}
@@ -2310,7 +2310,7 @@ template <class BiIter>
 
 \indexlibrarymember{sub_match}{operator"!=}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator!=(const typename iterator_traits<BiIter>::value_type& lhs,
                   const sub_match<BiIter>& rhs);
 \end{itemdecl}
@@ -2322,7 +2322,7 @@ template <class BiIter>
 
 \indexlibrarymember{sub_match}{operator<}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator<(const typename iterator_traits<BiIter>::value_type& lhs,
                  const sub_match<BiIter>& rhs);
 \end{itemdecl}
@@ -2334,7 +2334,7 @@ template <class BiIter>
 
 \indexlibrarymember{sub_match}{operator>}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator>(const typename iterator_traits<BiIter>::value_type& lhs,
                  const sub_match<BiIter>& rhs);
 \end{itemdecl}
@@ -2346,7 +2346,7 @@ template <class BiIter>
 
 \indexlibrarymember{sub_match}{operator>=}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator>=(const typename iterator_traits<BiIter>::value_type& lhs,
                   const sub_match<BiIter>& rhs);
 \end{itemdecl}
@@ -2358,7 +2358,7 @@ template <class BiIter>
 
 \indexlibrarymember{sub_match}{operator<=}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator<=(const typename iterator_traits<BiIter>::value_type& lhs,
                   const sub_match<BiIter>& rhs);
 \end{itemdecl}
@@ -2370,7 +2370,7 @@ template <class BiIter>
 
 \indexlibrarymember{sub_match}{operator==}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator==(const sub_match<BiIter>& lhs,
                   const typename iterator_traits<BiIter>::value_type& rhs);
 \end{itemdecl}
@@ -2382,7 +2382,7 @@ template <class BiIter>
 
 \indexlibrarymember{sub_match}{operator"!=}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator!=(const sub_match<BiIter>& lhs,
                   const typename iterator_traits<BiIter>::value_type& rhs);
 \end{itemdecl}
@@ -2394,7 +2394,7 @@ template <class BiIter>
 
 \indexlibrarymember{sub_match}{operator<}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator<(const sub_match<BiIter>& lhs,
                  const typename iterator_traits<BiIter>::value_type& rhs);
 \end{itemdecl}
@@ -2406,7 +2406,7 @@ template <class BiIter>
 
 \indexlibrarymember{sub_match}{operator>}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator>(const sub_match<BiIter>& lhs,
                  const typename iterator_traits<BiIter>::value_type& rhs);
 \end{itemdecl}
@@ -2418,7 +2418,7 @@ template <class BiIter>
 
 \indexlibrarymember{sub_match}{operator>=}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator>=(const sub_match<BiIter>& lhs,
                   const typename iterator_traits<BiIter>::value_type& rhs);
 \end{itemdecl}
@@ -2430,7 +2430,7 @@ template <class BiIter>
 
 \indexlibrarymember{sub_match}{operator<=}%
 \begin{itemdecl}
-template <class BiIter>
+template<class BiIter>
   bool operator<=(const sub_match<BiIter>& lhs,
                   const typename iterator_traits<BiIter>::value_type& rhs);
 \end{itemdecl}
@@ -2443,7 +2443,7 @@ template <class BiIter>
 \indexlibrary{\idxcode{basic_ostream}}%
 \indexlibrarymember{sub_match}{operator<<}%
 \begin{itemdecl}
-template <class charT, class ST, class BiIter>
+template<class charT, class ST, class BiIter>
   basic_ostream<charT, ST>&
     operator<<(basic_ostream<charT, ST>& os, const sub_match<BiIter>& m);
 \end{itemdecl}
@@ -2497,8 +2497,8 @@ match need not be distinct.\end{note}
 
 \begin{codeblock}
 namespace std {
-  template <class BidirectionalIterator,
-            class Allocator = allocator<sub_match<BidirectionalIterator>>>
+  template<class BidirectionalIterator,
+           class Allocator = allocator<sub_match<BidirectionalIterator>>>
     class match_results {
     public:
       using value_type      = sub_match<BidirectionalIterator>;
@@ -2544,17 +2544,17 @@ namespace std {
       const_iterator cend() const;
 
       // \ref{re.results.form}, format
-      template <class OutputIter>
+      template<class OutputIter>
         OutputIter
           format(OutputIter out,
                  const char_type* fmt_first, const char_type* fmt_last,
                  regex_constants::match_flag_type flags = regex_constants::format_default) const;
-      template <class OutputIter, class ST, class SA>
+      template<class OutputIter, class ST, class SA>
         OutputIter
           format(OutputIter out,
                  const basic_string<char_type, ST, SA>& fmt,
                  regex_constants::match_flag_type flags = regex_constants::format_default) const;
-      template <class ST, class SA>
+      template<class ST, class SA>
         basic_string<char_type, ST, SA>
           format(const basic_string<char_type, ST, SA>& fmt,
                  regex_constants::match_flag_type flags = regex_constants::format_default) const;
@@ -2820,7 +2820,7 @@ sub-expressions stored in \tcode{*this}.
 
 \indexlibrarymember{match_results}{format}%
 \begin{itemdecl}
-template <class OutputIter>
+template<class OutputIter>
   OutputIter format(
       OutputIter out,
       const char_type* fmt_first, const char_type* fmt_last,
@@ -2846,7 +2846,7 @@ specifiers and escape sequences are recognized.
 
 \indexlibrarymember{match_results}{format}%
 \begin{itemdecl}
-template <class OutputIter, class ST, class SA>
+template<class OutputIter, class ST, class SA>
   OutputIter format(
       OutputIter out,
       const basic_string<char_type, ST, SA>& fmt,
@@ -2863,7 +2863,7 @@ return format(out, fmt.data(), fmt.data() + fmt.size(), flags);
 
 \indexlibrarymember{match_results}{format}%
 \begin{itemdecl}
-template <class ST, class SA>
+template<class ST, class SA>
   basic_string<char_type, ST, SA> format(
       const basic_string<char_type, ST, SA>& fmt,
       regex_constants::match_flag_type flags = regex_constants::format_default) const;
@@ -2940,7 +2940,7 @@ sequence of matched sub-expressions that were in \tcode{*this}.
 
 \indexlibrarymember{match_results}{swap}%
 \begin{itemdecl}
-template <class BidirectionalIterator, class Allocator>
+template<class BidirectionalIterator, class Allocator>
   void swap(match_results<BidirectionalIterator, Allocator>& m1,
             match_results<BidirectionalIterator, Allocator>& m2);
 \end{itemdecl}
@@ -2951,7 +2951,7 @@ template <class BidirectionalIterator, class Allocator>
 
 \indexlibrarymember{operator==}{match_results}%
 \begin{itemdecl}
-template <class BidirectionalIterator, class Allocator>
+template<class BidirectionalIterator, class Allocator>
 bool operator==(const match_results<BidirectionalIterator, Allocator>& m1,
                 const match_results<BidirectionalIterator, Allocator>& m2);
 \end{itemdecl}
@@ -2986,7 +2986,7 @@ other is not. If both match results are ready, returns \tcode{true} only if:
 \indexlibrary{\idxcode{operator"!=}!\idxcode{match_results}}%
 \indexlibrary{\idxcode{match_results}!\idxcode{operator"!=}}%
 \begin{itemdecl}
-template <class BidirectionalIterator, class Allocator>
+template<class BidirectionalIterator, class Allocator>
 bool operator!=(const match_results<BidirectionalIterator, Allocator>& m1,
                 const match_results<BidirectionalIterator, Allocator>& m2);
 \end{itemdecl}
@@ -3008,7 +3008,7 @@ or \tcode{regex_constants::error_stack}.
 \rSec2[re.alg.match]{\tcode{regex_match}}
 \indexlibrary{\idxcode{regex_match}}%
 \begin{itemdecl}
-template <class BidirectionalIterator, class Allocator, class charT, class traits>
+template<class BidirectionalIterator, class Allocator, class charT, class traits>
   bool regex_match(BidirectionalIterator first, BidirectionalIterator last,
                    match_results<BidirectionalIterator, Allocator>& m,
                    const basic_regex<charT, traits>& e,
@@ -3118,7 +3118,7 @@ the match, \tcode{false} otherwise.
 
 \indexlibrary{\idxcode{regex_match}}%
 \begin{itemdecl}
-template <class BidirectionalIterator, class charT, class traits>
+template<class BidirectionalIterator, class charT, class traits>
   bool regex_match(BidirectionalIterator first, BidirectionalIterator last,
                    const basic_regex<charT, traits>& e,
                    regex_constants::match_flag_type flags = regex_constants::match_default);
@@ -3134,7 +3134,7 @@ returning the result of
 
 \indexlibrary{\idxcode{regex_match}}%
 \begin{itemdecl}
-template <class charT, class Allocator, class traits>
+template<class charT, class Allocator, class traits>
   bool regex_match(const charT* str,
                    match_results<const charT*, Allocator>& m,
                    const basic_regex<charT, traits>& e,
@@ -3148,7 +3148,7 @@ template <class charT, class Allocator, class traits>
 
 \indexlibrary{\idxcode{regex_match}}%
 \begin{itemdecl}
-template <class ST, class SA, class Allocator, class charT, class traits>
+template<class ST, class SA, class Allocator, class charT, class traits>
   bool regex_match(const basic_string<charT, ST, SA>& s,
                    match_results<typename basic_string<charT, ST, SA>::const_iterator,
                                  Allocator>& m,
@@ -3163,7 +3163,7 @@ template <class ST, class SA, class Allocator, class charT, class traits>
 
 \indexlibrary{\idxcode{regex_match}}%
 \begin{itemdecl}
-template <class charT, class traits>
+template<class charT, class traits>
   bool regex_match(const charT* str,
                    const basic_regex<charT, traits>& e,
                    regex_constants::match_flag_type flags = regex_constants::match_default);
@@ -3176,7 +3176,7 @@ template <class charT, class traits>
 
 \indexlibrary{\idxcode{regex_match}}%
 \begin{itemdecl}
-template <class ST, class SA, class charT, class traits>
+template<class ST, class SA, class charT, class traits>
   bool regex_match(const basic_string<charT, ST, SA>& s,
                    const basic_regex<charT, traits>& e,
                    regex_constants::match_flag_type flags = regex_constants::match_default);
@@ -3191,7 +3191,7 @@ template <class ST, class SA, class charT, class traits>
 
 \indexlibrary{\idxcode{regex_search}}%
 \begin{itemdecl}
-template <class BidirectionalIterator, class Allocator, class charT, class traits>
+template<class BidirectionalIterator, class Allocator, class charT, class traits>
   bool regex_search(BidirectionalIterator first, BidirectionalIterator last,
                     match_results<BidirectionalIterator, Allocator>& m,
                     const basic_regex<charT, traits>& e,
@@ -3286,7 +3286,7 @@ participated in the match, \tcode{false} otherwise.
 
 \indexlibrary{\idxcode{regex_search}}%
 \begin{itemdecl}
-template <class charT, class Allocator, class traits>
+template<class charT, class Allocator, class traits>
   bool regex_search(const charT* str, match_results<const charT*, Allocator>& m,
                     const basic_regex<charT, traits>& e,
                     regex_constants::match_flag_type flags = regex_constants::match_default);
@@ -3299,7 +3299,7 @@ template <class charT, class Allocator, class traits>
 
 \indexlibrary{\idxcode{regex_search}}%
 \begin{itemdecl}
-template <class ST, class SA, class Allocator, class charT, class traits>
+template<class ST, class SA, class Allocator, class charT, class traits>
   bool regex_search(const basic_string<charT, ST, SA>& s,
                     match_results<typename basic_string<charT, ST, SA>::const_iterator,
                                   Allocator>& m,
@@ -3314,7 +3314,7 @@ template <class ST, class SA, class Allocator, class charT, class traits>
 
 \indexlibrary{\idxcode{regex_search}}%
 \begin{itemdecl}
-template <class BidirectionalIterator, class charT, class traits>
+template<class BidirectionalIterator, class charT, class traits>
   bool regex_search(BidirectionalIterator first, BidirectionalIterator last,
                     const basic_regex<charT, traits>& e,
                     regex_constants::match_flag_type flags = regex_constants::match_default);
@@ -3329,7 +3329,7 @@ of type \tcode{match_results<Bidirectional\-Iterator>} and returning
 
 \indexlibrary{\idxcode{regex_search}}%
 \begin{itemdecl}
-template <class charT, class traits>
+template<class charT, class traits>
   bool regex_search(const charT* str,
                     const basic_regex<charT, traits>& e,
                     regex_constants::match_flag_type flags = regex_constants::match_default);
@@ -3342,7 +3342,7 @@ template <class charT, class traits>
 
 \indexlibrary{\idxcode{regex_search}}%
 \begin{itemdecl}
-template <class ST, class SA, class charT, class traits>
+template<class ST, class SA, class charT, class traits>
   bool regex_search(const basic_string<charT, ST, SA>& s,
                     const basic_regex<charT, traits>& e,
                     regex_constants::match_flag_type flags = regex_constants::match_default);
@@ -3356,7 +3356,7 @@ template <class ST, class SA, class charT, class traits>
 
 \indexlibrary{\idxcode{regex_replace}}%
 \begin{itemdecl}
-template <class OutputIterator, class BidirectionalIterator,
+template<class OutputIterator, class BidirectionalIterator,
           class traits, class charT, class ST, class SA>
   OutputIterator
     regex_replace(OutputIterator out,
@@ -3364,7 +3364,7 @@ template <class OutputIterator, class BidirectionalIterator,
                   const basic_regex<charT, traits>& e,
                   const basic_string<charT, ST, SA>& fmt,
                   regex_constants::match_flag_type flags = regex_constants::match_default);
-template <class OutputIterator, class BidirectionalIterator, class traits, class charT>
+template<class OutputIterator, class BidirectionalIterator, class traits, class charT>
   OutputIterator
     regex_replace(OutputIterator out,
                   BidirectionalIterator first, BidirectionalIterator last,
@@ -3425,13 +3425,13 @@ is nonzero, then only the first match found is replaced.
 
 \indexlibrary{\idxcode{regex_replace}}%
 \begin{itemdecl}
-template <class traits, class charT, class ST, class SA, class FST, class FSA>
+template<class traits, class charT, class ST, class SA, class FST, class FSA>
   basic_string<charT, ST, SA>
     regex_replace(const basic_string<charT, ST, SA>& s,
                   const basic_regex<charT, traits>& e,
                   const basic_string<charT, FST, FSA>& fmt,
                   regex_constants::match_flag_type flags = regex_constants::match_default);
-template <class traits, class charT, class ST, class SA>
+template<class traits, class charT, class ST, class SA>
   basic_string<charT, ST, SA>
     regex_replace(const basic_string<charT, ST, SA>& s,
                   const basic_regex<charT, traits>& e,
@@ -3452,13 +3452,13 @@ regex_replace(back_inserter(result), s.begin(), s.end(), e, fmt, flags);
 
 \indexlibrary{\idxcode{regex_replace}}%
 \begin{itemdecl}
-template <class traits, class charT, class ST, class SA>
+template<class traits, class charT, class ST, class SA>
   basic_string<charT>
     regex_replace(const charT* s,
                   const basic_regex<charT, traits>& e,
                   const basic_string<charT, ST, SA>& fmt,
                   regex_constants::match_flag_type flags = regex_constants::match_default);
-template <class traits, class charT>
+template<class traits, class charT>
   basic_string<charT>
     regex_replace(const charT* s,
                   const basic_regex<charT, traits>& e,
@@ -3509,7 +3509,7 @@ the same arguments.
 
 \begin{codeblock}
 namespace std {
-  template <class BidirectionalIterator,
+  template<class BidirectionalIterator,
             class charT = typename iterator_traits<BidirectionalIterator>::value_type,
             class traits = regex_traits<charT>>
     class regex_iterator {
@@ -3770,7 +3770,7 @@ equal when they are constructed from the same arguments.
 
 \begin{codeblock}
 namespace std {
-  template <class BidirectionalIterator,
+  template<class BidirectionalIterator,
             class charT = typename iterator_traits<BidirectionalIterator>::value_type,
             class traits = regex_traits<charT>>
     class regex_token_iterator {
@@ -3798,7 +3798,7 @@ namespace std {
                            initializer_list<int> submatches,
                            regex_constants::match_flag_type m =
                              regex_constants::match_default);
-      template <size_t N>
+      template<size_t N>
         regex_token_iterator(BidirectionalIterator a, BidirectionalIterator b,
                              const regex_type& re,
                              const int (&submatches)[N],
@@ -3819,7 +3819,7 @@ namespace std {
                            initializer_list<int> submatches,
                            regex_constants::match_flag_type m =
                              regex_constants::match_default) = delete;
-      template <size_t N>
+      template<size_t N>
       regex_token_iterator(BidirectionalIterator a, BidirectionalIterator b,
                            const regex_type&& re,
                            const int (&submatches)[N],
@@ -3895,7 +3895,7 @@ regex_token_iterator(BidirectionalIterator a, BidirectionalIterator b,
                      initializer_list<int> submatches,
                      regex_constants::match_flag_type m = regex_constants::match_default);
 
-template <size_t N>
+template<size_t N>
   regex_token_iterator(BidirectionalIterator a, BidirectionalIterator b,
                        const regex_type& re,
                        const int (&submatches)[N],

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -791,7 +791,7 @@ namespace std {
   wstring to_wstring(long double val);
 
   namespace pmr {
-    template <class charT, class traits = char_traits<charT>>
+    template<class charT, class traits = char_traits<charT>>
       using basic_string = std::basic_string<charT, traits, polymorphic_allocator<charT>>;
 
     using string    = basic_string<char>;

--- a/source/support.tex
+++ b/source/support.tex
@@ -61,13 +61,13 @@ namespace std {
   enum class byte : unsigned char {};
 
   // \ref{support.types.byteops}, \tcode{byte} type operations
-  template <class IntType>
+  template<class IntType>
     constexpr byte& operator<<=(byte& b, IntType shift) noexcept;
-  template <class IntType>
+  template<class IntType>
     constexpr byte operator<<(byte b, IntType shift) noexcept;
-  template <class IntType>
+  template<class IntType>
     constexpr byte& operator>>=(byte& b, IntType shift) noexcept;
-  template <class IntType>
+  template<class IntType>
     constexpr byte operator>>(byte b, IntType shift) noexcept;
   constexpr byte& operator|=(byte& l, byte r) noexcept;
   constexpr byte operator|(byte l, byte r) noexcept;
@@ -76,7 +76,7 @@ namespace std {
   constexpr byte& operator^=(byte& l, byte r) noexcept;
   constexpr byte operator^(byte l, byte r) noexcept;
   constexpr byte operator~(byte b) noexcept;
-  template <class IntType>
+  template<class IntType>
     constexpr IntType to_integer(byte b) noexcept;
 }
 
@@ -341,7 +341,7 @@ requirement is supported in every context\iref{basic.align}.
 
 \indexlibrarymember{operator<<=}{byte}%
 \begin{itemdecl}
-template <class IntType>
+template<class IntType>
   constexpr byte& operator<<=(byte& b, IntType shift) noexcept;
 \end{itemdecl}
 
@@ -355,7 +355,7 @@ template <class IntType>
 
 \indexlibrarymember{operator<<}{byte}%
 \begin{itemdecl}
-template <class IntType>
+template<class IntType>
   constexpr byte operator<<(byte b, IntType shift) noexcept;
 \end{itemdecl}
 
@@ -372,7 +372,7 @@ return static_cast<byte>(static_cast<unsigned char>(
 
 \indexlibrarymember{operator>>=}{byte}%
 \begin{itemdecl}
-template <class IntType>
+template<class IntType>
   constexpr byte& operator>>=(byte& b, IntType shift) noexcept;
 \end{itemdecl}
 
@@ -386,7 +386,7 @@ template <class IntType>
 
 \indexlibrarymember{operator>>}{byte}%
 \begin{itemdecl}
-template <class IntType>
+template<class IntType>
   constexpr byte operator>>(byte b, IntType shift) noexcept;
 \end{itemdecl}
 
@@ -482,7 +482,7 @@ return static_cast<byte>(static_cast<unsigned char>(
 
 \indexlibrarymember{to_integer}{byte}%
 \begin{itemdecl}
-template <class IntType>
+template<class IntType>
   constexpr IntType to_integer(byte b) noexcept;
 \end{itemdecl}
 
@@ -1830,7 +1830,7 @@ namespace std {
   new_handler set_new_handler(new_handler new_p) noexcept;
 
   // \ref{ptr.launder}, pointer optimization barrier
-  template <class T> [[nodiscard]] constexpr T* launder(T* p) noexcept;
+  template<class T> [[nodiscard]] constexpr T* launder(T* p) noexcept;
 
   // \ref{hardware.interference}, hardware interference size
   inline constexpr size_t hardware_destructive_interference_size = @\impdef{}@;
@@ -2691,7 +2691,7 @@ new_handler get_new_handler() noexcept;
 
 \indexlibrary{\idxcode{launder}}%
 \begin{itemdecl}
-template <class T> [[nodiscard]] constexpr T* launder(T* p) noexcept;
+template<class T> [[nodiscard]] constexpr T* launder(T* p) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3094,8 +3094,8 @@ namespace std {
   [[noreturn]] void rethrow_exception(exception_ptr p);
   template<class E> exception_ptr make_exception_ptr(E e) noexcept;
 
-  template <class T> [[noreturn]] void throw_with_nested(T&& t);
-  template <class E> void rethrow_if_nested(const E& e);
+  template<class T> [[noreturn]] void throw_with_nested(T&& t);
+  template<class E> void rethrow_if_nested(const E& e);
 }
 \end{codeblock}
 
@@ -3489,7 +3489,7 @@ namespace std {
   };
 
   template<class T> [[noreturn]] void throw_with_nested(T&& t);
-  template <class E> void rethrow_if_nested(const E& e);
+  template<class E> void rethrow_if_nested(const E& e);
 }
 \end{codeblock}
 
@@ -3536,7 +3536,7 @@ exception_ptr nested_ptr() const noexcept;
 
 \indexlibrarymember{throw_with_nested}{nested_exception}%
 \begin{itemdecl}
-template <class T> [[noreturn]] void throw_with_nested(T&& t);
+template<class T> [[noreturn]] void throw_with_nested(T&& t);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3558,7 +3558,7 @@ and constructed from \tcode{std::forward<T>(t)}, otherwise
 
 \indexlibrarymember{rethrow_if_nested}{nested_exception}%
 \begin{itemdecl}
-template <class E> void rethrow_if_nested(const E& e);
+template<class E> void rethrow_if_nested(const E& e);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -279,7 +279,7 @@ such uses mean call the function \tcode{decay_copy(x)} and use the
 result, where \tcode{decay_copy} is defined as follows:
 
 \begin{codeblock}
-template <class T> decay_t<T> decay_copy(T&& v)
+template<class T> decay_t<T> decay_copy(T&& v)
   { return std::forward<T>(v); }
 \end{codeblock}
 
@@ -303,9 +303,9 @@ namespace std {
     thread::id get_id() noexcept;
 
     void yield() noexcept;
-    template <class Clock, class Duration>
+    template<class Clock, class Duration>
       void sleep_until(const chrono::time_point<Clock, Duration>& abs_time);
-    template <class Rep, class Period>
+    template<class Rep, class Period>
       void sleep_for(const chrono::duration<Rep, Period>& rel_time);
   }
 }
@@ -336,7 +336,7 @@ namespace std {
 
     // construct/copy/destroy
     thread() noexcept;
-    template <class F, class... Args> explicit thread(F&& f, Args&&... args);
+    template<class F, class... Args> explicit thread(F&& f, Args&&... args);
     ~thread();
     thread(const thread&) = delete;
     thread(thread&&) noexcept;
@@ -380,8 +380,8 @@ namespace std {
       operator<<(basic_ostream<charT, traits>& out, thread::id id);
 
   // hash support
-  template <class T> struct hash;
-  template <> struct hash<thread::id>;
+  template<class T> struct hash;
+  template<> struct hash<thread::id>;
 }
 \end{codeblock}
 
@@ -490,7 +490,7 @@ distinct text representations.
 
 \indexlibrary{\idxcode{hash}!\idxcode{thread::id}}%
 \begin{itemdecl}
-template <> struct hash<thread::id>;
+template<> struct hash<thread::id>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -512,7 +512,7 @@ thread() noexcept;
 
 \indexlibrary{\idxcode{thread}!constructor}%
 \begin{itemdecl}
-template <class F, class... Args> explicit thread(F&& f, Args&&... args);
+template<class F, class... Args> explicit thread(F&& f, Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -745,9 +745,9 @@ namespace std::this_thread {
   thread::id get_id() noexcept;
 
   void yield() noexcept;
-  template <class Clock, class Duration>
+  template<class Clock, class Duration>
     void sleep_until(const chrono::time_point<Clock, Duration>& abs_time);
-  template <class Rep, class Period>
+  template<class Rep, class Period>
     void sleep_for(const chrono::duration<Rep, Period>& rel_time);
 }
 \end{codeblock}
@@ -780,7 +780,7 @@ void this_thread::yield() noexcept;
 
 \indexlibrarymember{sleep_until}{this_thread}%
 \begin{itemdecl}
-template <class Clock, class Duration>
+template<class Clock, class Duration>
   void sleep_until(const chrono::time_point<Clock, Duration>& abs_time);
 \end{itemdecl}
 
@@ -798,7 +798,7 @@ by \tcode{abs_time}.
 
 \indexlibrarymember{sleep_for}{this_thread}%
 \begin{itemdecl}
-template <class Rep, class Period>
+template<class Rep, class Period>
   void sleep_for(const chrono::duration<Rep, Period>& rel_time);
 \end{itemdecl}
 
@@ -839,15 +839,15 @@ namespace std {
   inline constexpr try_to_lock_t try_to_lock { };
   inline constexpr adopt_lock_t  adopt_lock { };
 
-  template <class Mutex> class lock_guard;
-  template <class... MutexTypes> class scoped_lock;
-  template <class Mutex> class unique_lock;
+  template<class Mutex> class lock_guard;
+  template<class... MutexTypes> class scoped_lock;
+  template<class Mutex> class unique_lock;
 
-  template <class Mutex>
+  template<class Mutex>
     void swap(unique_lock<Mutex>& x, unique_lock<Mutex>& y) noexcept;
 
-  template <class L1, class L2, class... L3> int try_lock(L1&, L2&, L3&...);
-  template <class L1, class L2, class... L3> void lock(L1&, L2&, L3&...);
+  template<class L1, class L2, class... L3> int try_lock(L1&, L2&, L3&...);
+  template<class L1, class L2, class... L3> void lock(L1&, L2&, L3&...);
 
   struct once_flag;
 
@@ -863,8 +863,8 @@ namespace std {
 namespace std {
   class shared_mutex;
   class shared_timed_mutex;
-  template <class Mutex> class shared_lock;
-  template <class Mutex>
+  template<class Mutex> class shared_lock;
+  template<class Mutex>
     void swap(shared_lock<Mutex>& x, shared_lock<Mutex>& y) noexcept;
 }
 \end{codeblock}
@@ -1222,9 +1222,9 @@ namespace std {
 
     void lock();    // blocking
     bool try_lock();
-    template <class Rep, class Period>
+    template<class Rep, class Period>
       bool try_lock_for(const chrono::duration<Rep, Period>& rel_time);
-    template <class Clock, class Duration>
+    template<class Clock, class Duration>
       bool try_lock_until(const chrono::time_point<Clock, Duration>& abs_time);
     void unlock();
 
@@ -1273,9 +1273,9 @@ namespace std {
 
     void lock();    // blocking
     bool try_lock() noexcept;
-    template <class Rep, class Period>
+    template<class Rep, class Period>
       bool try_lock_for(const chrono::duration<Rep, Period>& rel_time);
-    template <class Clock, class Duration>
+    template<class Clock, class Duration>
       bool try_lock_until(const chrono::time_point<Clock, Duration>& abs_time);
     void unlock();
 
@@ -1578,18 +1578,18 @@ namespace std {
     // exclusive ownership
     void lock();                // blocking
     bool try_lock();
-    template <class Rep, class Period>
+    template<class Rep, class Period>
       bool try_lock_for(const chrono::duration<Rep, Period>& rel_time);
-    template <class Clock, class Duration>
+    template<class Clock, class Duration>
       bool try_lock_until(const chrono::time_point<Clock, Duration>& abs_time);
     void unlock();
 
     // shared ownership
     void lock_shared();         // blocking
     bool try_lock_shared();
-    template <class Rep, class Period>
+    template<class Rep, class Period>
       bool try_lock_shared_for(const chrono::duration<Rep, Period>& rel_time);
-    template <class Clock, class Duration>
+    template<class Clock, class Duration>
       bool try_lock_shared_until(const chrono::time_point<Clock, Duration>& abs_time);
     void unlock_shared();
   };
@@ -1653,7 +1653,7 @@ namespace std {
 \indexlibrary{\idxcode{lock_guard}}%
 \begin{codeblock}
 namespace std {
-  template <class Mutex>
+  template<class Mutex>
   class lock_guard {
   public:
     using mutex_type = Mutex;
@@ -1729,7 +1729,7 @@ lock_guard(mutex_type& m, adopt_lock_t);
 \indexlibrary{\idxcode{scoped_lock}}%
 \begin{codeblock}
 namespace std {
-  template <class... MutexTypes>
+  template<class... MutexTypes>
   class scoped_lock {
   public:
     using mutex_type = Mutex;   // If \tcode{MutexTypes...} consists of the single type \tcode{Mutex}
@@ -1809,7 +1809,7 @@ explicit scoped_lock(adopt_lock_t, MutexTypes&... m);
 \indexlibrary{\idxcode{unique_lock}}%
 \begin{codeblock}
 namespace std {
-  template <class Mutex>
+  template<class Mutex>
   class unique_lock {
   public:
     using mutex_type = Mutex;
@@ -1820,9 +1820,9 @@ namespace std {
     unique_lock(mutex_type& m, defer_lock_t) noexcept;
     unique_lock(mutex_type& m, try_to_lock_t);
     unique_lock(mutex_type& m, adopt_lock_t);
-    template <class Clock, class Duration>
+    template<class Clock, class Duration>
       unique_lock(mutex_type& m, const chrono::time_point<Clock, Duration>& abs_time);
-    template <class Rep, class Period>
+    template<class Rep, class Period>
       unique_lock(mutex_type& m, const chrono::duration<Rep, Period>& rel_time);
     ~unique_lock();
 
@@ -1836,9 +1836,9 @@ namespace std {
     void lock();
     bool try_lock();
 
-    template <class Rep, class Period>
+    template<class Rep, class Period>
       bool try_lock_for(const chrono::duration<Rep, Period>& rel_time);
-    template <class Clock, class Duration>
+    template<class Clock, class Duration>
       bool try_lock_until(const chrono::time_point<Clock, Duration>& abs_time);
 
     void unlock();
@@ -1857,7 +1857,7 @@ namespace std {
     bool owns;                  // \expos
   };
 
-  template <class Mutex>
+  template<class Mutex>
     void swap(unique_lock<Mutex>& x, unique_lock<Mutex>& y) noexcept;
 }
 \end{codeblock}
@@ -1967,7 +1967,7 @@ unique_lock(mutex_type& m, adopt_lock_t);
 
 \indexlibrary{\idxcode{unique_lock}!constructor}%
 \begin{itemdecl}
-template <class Clock, class Duration>
+template<class Clock, class Duration>
   unique_lock(mutex_type& m, const chrono::time_point<Clock, Duration>& abs_time);
 \end{itemdecl}
 
@@ -1988,7 +1988,7 @@ the value returned by the call to \tcode{m.try_lock_until(abs_time)}.
 
 \indexlibrary{\idxcode{unique_lock}!constructor}%
 \begin{itemdecl}
-template <class Rep, class Period>
+template<class Rep, class Period>
   unique_lock(mutex_type& m, const chrono::duration<Rep, Period>& rel_time);
 \end{itemdecl}
 
@@ -2103,7 +2103,7 @@ is \tcode{true}.
 
 \indexlibrarymember{try_lock_until}{unique_lock}%
 \begin{itemdecl}
-template <class Clock, class Duration>
+template<class Clock, class Duration>
   bool try_lock_until(const chrono::time_point<Clock, Duration>& abs_time);
 \end{itemdecl}
 
@@ -2137,7 +2137,7 @@ exception is required\iref{thread.req.exception}.
 
 \indexlibrarymember{try_lock_for}{unique_lock}%
 \begin{itemdecl}
-template <class Rep, class Period>
+template<class Rep, class Period>
   bool try_lock_for(const chrono::duration<Rep, Period>& rel_time);
 \end{itemdecl}
 
@@ -2210,7 +2210,7 @@ mutex_type* release() noexcept;
 
 \indexlibrarymember{swap}{unique_lock}%
 \begin{itemdecl}
-template <class Mutex>
+template<class Mutex>
   void swap(unique_lock<Mutex>& x, unique_lock<Mutex>& y) noexcept;
 \end{itemdecl}
 
@@ -2252,7 +2252,7 @@ mutex_type *mutex() const noexcept;
 \indexlibrary{\idxcode{shared_lock}}%
 \begin{codeblock}
 namespace std {
-  template <class Mutex>
+  template<class Mutex>
   class shared_lock {
   public:
     using mutex_type = Mutex;
@@ -2263,9 +2263,9 @@ namespace std {
     shared_lock(mutex_type& m, defer_lock_t) noexcept;
     shared_lock(mutex_type& m, try_to_lock_t);
     shared_lock(mutex_type& m, adopt_lock_t);
-    template <class Clock, class Duration>
+    template<class Clock, class Duration>
       shared_lock(mutex_type& m, const chrono::time_point<Clock, Duration>& abs_time);
-    template <class Rep, class Period>
+    template<class Rep, class Period>
       shared_lock(mutex_type& m, const chrono::duration<Rep, Period>& rel_time);
     ~shared_lock();
 
@@ -2278,9 +2278,9 @@ namespace std {
     // \ref{thread.lock.shared.locking}, locking
     void lock();                                // blocking
     bool try_lock();
-    template <class Rep, class Period>
+    template<class Rep, class Period>
       bool try_lock_for(const chrono::duration<Rep, Period>& rel_time);
-    template <class Clock, class Duration>
+    template<class Clock, class Duration>
       bool try_lock_until(const chrono::time_point<Clock, Duration>& abs_time);
     void unlock();
 
@@ -2298,7 +2298,7 @@ namespace std {
     bool owns;                                  // \expos
   };
 
-  template <class Mutex>
+  template<class Mutex>
     void swap(shared_lock<Mutex>& x, shared_lock<Mutex>& y) noexcept;
 }
 \end{codeblock}
@@ -2399,7 +2399,7 @@ shared_lock(mutex_type& m, adopt_lock_t);
 
 \indexlibrary{\idxcode{shared_lock}!constructor}%
 \begin{itemdecl}
-template <class Clock, class Duration>
+template<class Clock, class Duration>
   shared_lock(mutex_type& m,
               const chrono::time_point<Clock, Duration>& abs_time);
 \end{itemdecl}
@@ -2420,7 +2420,7 @@ is the value returned by the call to \tcode{m.try_lock_shared_until(abs_time)}.
 
 \indexlibrary{\idxcode{shared_lock}!constructor}%
 \begin{itemdecl}
-template <class Rep, class Period>
+template<class Rep, class Period>
   shared_lock(mutex_type& m,
               const chrono::duration<Rep, Period>& rel_time);
 \end{itemdecl}
@@ -2534,7 +2534,7 @@ the call to \tcode{pm->try_lock_shared()}.
 
 \indexlibrarymember{try_lock_until}{shared_lock}%
 \begin{itemdecl}
-template <class Clock, class Duration>
+template<class Clock, class Duration>
   bool try_lock_until(const chrono::time_point<Clock, Duration>& abs_time);
 \end{itemdecl}
 
@@ -2565,7 +2565,7 @@ the call to \tcode{pm->try_lock_shared_until(abs_time)}.
 
 \indexlibrarymember{try_lock_for}{shared_lock}%
 \begin{itemdecl}
-template <class Rep, class Period>
+template<class Rep, class Period>
   bool try_lock_for(const chrono::duration<Rep, Period>& rel_time);
 \end{itemdecl}
 
@@ -2641,7 +2641,7 @@ mutex_type* release() noexcept;
 
 \indexlibrarymember{swap}{shared_lock}%
 \begin{itemdecl}
-template <class Mutex>
+template<class Mutex>
   void swap(shared_lock<Mutex>& x, shared_lock<Mutex>& y) noexcept;
 \end{itemdecl}
 
@@ -2686,7 +2686,7 @@ mutex_type* mutex() const noexcept;
 
 \indexlibrary{\idxcode{try_lock}}%
 \begin{itemdecl}
-template <class L1, class L2, class... L3> int try_lock(L1&, L2&, L3&...);
+template<class L1, class L2, class... L3> int try_lock(L1&, L2&, L3&...);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2710,7 +2710,7 @@ returned \tcode{false}.
 
 \indexlibrary{\idxcode{lock}}%
 \begin{itemdecl}
-template <class L1, class L2, class... L3> void lock(L1&, L2&, L3&...);
+template<class L1, class L2, class... L3> void lock(L1&, L2&, L3&...);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2954,19 +2954,19 @@ namespace std {
     void notify_one() noexcept;
     void notify_all() noexcept;
     void wait(unique_lock<mutex>& lock);
-    template <class Predicate>
+    template<class Predicate>
       void wait(unique_lock<mutex>& lock, Predicate pred);
-    template <class Clock, class Duration>
+    template<class Clock, class Duration>
       cv_status wait_until(unique_lock<mutex>& lock,
                            const chrono::time_point<Clock, Duration>& abs_time);
-    template <class Clock, class Duration, class Predicate>
+    template<class Clock, class Duration, class Predicate>
       bool wait_until(unique_lock<mutex>& lock,
                       const chrono::time_point<Clock, Duration>& abs_time,
                       Predicate pred);
-    template <class Rep, class Period>
+    template<class Rep, class Period>
       cv_status wait_for(unique_lock<mutex>& lock,
                          const chrono::duration<Rep, Period>& rel_time);
-    template <class Rep, class Period, class Predicate>
+    template<class Rep, class Period, class Predicate>
       bool wait_for(unique_lock<mutex>& lock,
                     const chrono::duration<Rep, Period>& rel_time,
                     Predicate pred);
@@ -3078,7 +3078,7 @@ is locked by the calling thread.
 
 \indexlibrarymember{wait}{condition_variable}%
 \begin{itemdecl}
-template <class Predicate>
+template<class Predicate>
   void wait(unique_lock<mutex>& lock, Predicate pred);
 \end{itemdecl}
 
@@ -3118,7 +3118,7 @@ is locked by the calling thread.
 
 \indexlibrarymember{wait_until}{condition_variable}%
 \begin{itemdecl}
-template <class Clock, class Duration>
+template<class Clock, class Duration>
   cv_status wait_until(unique_lock<mutex>& lock,
                        const chrono::time_point<Clock, Duration>& abs_time);
 \end{itemdecl}
@@ -3174,7 +3174,7 @@ exceptions\iref{thread.req.timing}.
 
 \indexlibrarymember{wait_for}{condition_variable}%
 \begin{itemdecl}
-template <class Rep, class Period>
+template<class Rep, class Period>
   cv_status wait_for(unique_lock<mutex>& lock,
                      const chrono::duration<Rep, Period>& rel_time);
 \end{itemdecl}
@@ -3219,7 +3219,7 @@ exceptions\iref{thread.req.timing}.
 
 \indexlibrarymember{wait_until}{condition_variable}%
 \begin{itemdecl}
-template <class Clock, class Duration, class Predicate>
+template<class Clock, class Duration, class Predicate>
   bool wait_until(unique_lock<mutex>& lock,
                   const chrono::time_point<Clock, Duration>& abs_time,
                   Predicate pred);
@@ -3268,7 +3268,7 @@ exceptions\iref{thread.req.timing} or any exception thrown by \tcode{pred}.
 
 \indexlibrarymember{wait_for}{condition_variable}%
 \begin{itemdecl}
-template <class Rep, class Period, class Predicate>
+template<class Rep, class Period, class Predicate>
   bool wait_for(unique_lock<mutex>& lock,
                 const chrono::duration<Rep, Period>& rel_time,
                 Predicate pred);
@@ -3342,19 +3342,19 @@ namespace std {
 
     void notify_one() noexcept;
     void notify_all() noexcept;
-    template <class Lock>
+    template<class Lock>
       void wait(Lock& lock);
-    template <class Lock, class Predicate>
+    template<class Lock, class Predicate>
       void wait(Lock& lock, Predicate pred);
 
-    template <class Lock, class Clock, class Duration>
+    template<class Lock, class Clock, class Duration>
       cv_status wait_until(Lock& lock, const chrono::time_point<Clock, Duration>& abs_time);
-    template <class Lock, class Clock, class Duration, class Predicate>
+    template<class Lock, class Clock, class Duration, class Predicate>
       bool wait_until(Lock& lock, const chrono::time_point<Clock, Duration>& abs_time,
                       Predicate pred);
-    template <class Lock, class Rep, class Period>
+    template<class Lock, class Rep, class Period>
       cv_status wait_for(Lock& lock, const chrono::duration<Rep, Period>& rel_time);
-    template <class Lock, class Rep, class Period, class Predicate>
+    template<class Lock, class Rep, class Period, class Predicate>
       bool wait_for(Lock& lock, const chrono::duration<Rep, Period>& rel_time, Predicate pred);
   };
 }
@@ -3424,7 +3424,7 @@ void notify_all() noexcept;
 
 \indexlibrarymember{wait}{condition_variable_any}%
 \begin{itemdecl}
-template <class Lock>
+template<class Lock>
   void wait(Lock& lock);
 \end{itemdecl}
 
@@ -3452,7 +3452,7 @@ shall be called\iref{except.terminate}.
 
 \indexlibrarymember{wait}{condition_variable_any}%
 \begin{itemdecl}
-template <class Lock, class Predicate>
+template<class Lock, class Predicate>
   void wait(Lock& lock, Predicate pred);
 \end{itemdecl}
 
@@ -3467,7 +3467,7 @@ while (!pred())
 
 \indexlibrarymember{wait_until}{condition_variable_any}%
 \begin{itemdecl}
-template <class Lock, class Clock, class Duration>
+template<class Lock, class Clock, class Duration>
   cv_status wait_until(Lock& lock, const chrono::time_point<Clock, Duration>& abs_time);
 \end{itemdecl}
 
@@ -3512,7 +3512,7 @@ exceptions\iref{thread.req.timing}.
 
 \indexlibrarymember{wait_for}{condition_variable_any}%
 \begin{itemdecl}
-template <class Lock, class Rep, class Period>
+template<class Lock, class Rep, class Period>
   cv_status wait_for(Lock& lock, const chrono::duration<Rep, Period>& rel_time);
 \end{itemdecl}
 
@@ -3545,7 +3545,7 @@ exceptions\iref{thread.req.timing}.
 
 \indexlibrarymember{wait_until}{condition_variable_any}%
 \begin{itemdecl}
-template <class Lock, class Clock, class Duration, class Predicate>
+template<class Lock, class Clock, class Duration, class Predicate>
   bool wait_until(Lock& lock, const chrono::time_point<Clock, Duration>& abs_time, Predicate pred);
 \end{itemdecl}
 
@@ -3570,7 +3570,7 @@ regardless of whether the timeout was triggered. \end{note}
 
 \indexlibrarymember{wait_for}{condition_variable_any}%
 \begin{itemdecl}
-template <class Lock, class Rep, class Period, class Predicate>
+template<class Lock, class Rep, class Period, class Predicate>
   bool wait_for(Lock& lock, const chrono::duration<Rep, Period>& rel_time, Predicate pred);
 \end{itemdecl}
 
@@ -3617,7 +3617,7 @@ namespace std {
     deferred
   };
 
-  template <> struct is_error_code_enum<future_errc> : public true_type { };
+  template<> struct is_error_code_enum<future_errc> : public true_type { };
   error_code make_error_code(future_errc e) noexcept;
   error_condition make_error_condition(future_errc e) noexcept;
 
@@ -3625,35 +3625,35 @@ namespace std {
 
   class future_error;
 
-  template <class R> class promise;
-  template <class R> class promise<R&>;
-  template <> class promise<void>;
+  template<class R> class promise;
+  template<class R> class promise<R&>;
+  template<> class promise<void>;
 
-  template <class R>
+  template<class R>
     void swap(promise<R>& x, promise<R>& y) noexcept;
 
-  template <class R, class Alloc>
+  template<class R, class Alloc>
     struct uses_allocator<promise<R>, Alloc>;
 
-  template <class R> class future;
-  template <class R> class future<R&>;
-  template <> class future<void>;
+  template<class R> class future;
+  template<class R> class future<R&>;
+  template<> class future<void>;
 
-  template <class R> class shared_future;
-  template <class R> class shared_future<R&>;
-  template <> class shared_future<void>;
+  template<class R> class shared_future;
+  template<class R> class shared_future<R&>;
+  template<> class shared_future<void>;
 
-  template <class> class packaged_task;   // not defined
-  template <class R, class... ArgTypes>
+  template<class> class packaged_task;   // not defined
+  template<class R, class... ArgTypes>
     class packaged_task<R(ArgTypes...)>;
 
-  template <class R, class... ArgTypes>
+  template<class R, class... ArgTypes>
     void swap(packaged_task<R(ArgTypes...)>&, packaged_task<R(ArgTypes...)>&) noexcept;
 
-  template <class F, class... Args>
+  template<class F, class... Args>
     [[nodiscard]] future<invoke_result_t<decay_t<F>, decay_t<Args>...>>
       async(F&& f, Args&&... args);
-  template <class F, class... Args>
+  template<class F, class... Args>
     [[nodiscard]] future<invoke_result_t<decay_t<F>, decay_t<Args>...>>
       async(launch policy, F&& f, Args&&... args);
 }
@@ -3874,11 +3874,11 @@ must either use read-only operations or provide additional synchronization.
 \indexlibrary{\idxcode{promise}}%
 \begin{codeblock}
 namespace std {
-  template <class R>
+  template<class R>
   class promise {
   public:
     promise();
-    template <class Allocator>
+    template<class Allocator>
       promise(allocator_arg_t, const Allocator& a);
     promise(promise&& rhs) noexcept;
     promise(const promise& rhs) = delete;
@@ -3901,10 +3901,10 @@ namespace std {
     void set_exception_at_thread_exit(exception_ptr p);
   };
 
-  template <class R>
+  template<class R>
     void swap(promise<R>& x, promise<R>& y) noexcept;
 
-  template <class R, class Alloc>
+  template<class R, class Alloc>
     struct uses_allocator<promise<R>, Alloc>;
 }
 \end{codeblock}
@@ -3923,7 +3923,7 @@ promise object.
 
 \indexlibrary{\idxcode{uses_allocator}!\idxcode{promise}}%
 \begin{itemdecl}
-template <class R, class Alloc>
+template<class R, class Alloc>
   struct uses_allocator<promise<R>, Alloc>
     : true_type { };
 \end{itemdecl}
@@ -3937,7 +3937,7 @@ template <class R, class Alloc>
 \indexlibrary{\idxcode{promise}!constructor}%
 \begin{itemdecl}
 promise();
-template <class Allocator>
+template<class Allocator>
   promise(allocator_arg_t, const Allocator& a);
 \end{itemdecl}
 
@@ -4151,7 +4151,7 @@ already has a stored value or exception.
 
 \indexlibrarymember{swap}{promise}%
 \begin{itemdecl}
-template <class R>
+template<class R>
   void swap(promise<R>& x, promise<R>& y) noexcept;
 \end{itemdecl}
 
@@ -4194,7 +4194,7 @@ is undefined.
 \indexlibrary{\idxcode{future}}%
 \begin{codeblock}
 namespace std {
-  template <class R>
+  template<class R>
   class future {
   public:
     future() noexcept;
@@ -4212,9 +4212,9 @@ namespace std {
     bool valid() const noexcept;
 
     void wait() const;
-    template <class Rep, class Period>
+    template<class Rep, class Period>
       future_status wait_for(const chrono::duration<Rep, Period>& rel_time) const;
-    template <class Clock, class Duration>
+    template<class Clock, class Duration>
       future_status wait_until(const chrono::time_point<Clock, Duration>& abs_time) const;
   };
 }
@@ -4382,7 +4382,7 @@ Blocks until the shared state is ready.
 
 \indexlibrarymember{wait_for}{future}%
 \begin{itemdecl}
-template <class Rep, class Period>
+template<class Rep, class Period>
   future_status wait_for(const chrono::duration<Rep, Period>& rel_time) const;
 \end{itemdecl}
 
@@ -4415,7 +4415,7 @@ timeout-related exceptions\iref{thread.req.timing}.
 
 \indexlibrarymember{wait_until}{future}%
 \begin{itemdecl}
-template <class Clock, class Duration>
+template<class Clock, class Duration>
   future_status wait_until(const chrono::time_point<Clock, Duration>& abs_time) const;
 \end{itemdecl}
 
@@ -4479,7 +4479,7 @@ object for which \tcode{valid()} is \tcode{false}. \end{note}
 \indexlibrary{\idxcode{shared_future}}%
 \begin{codeblock}
 namespace std {
-  template <class R>
+  template<class R>
   class shared_future {
   public:
     shared_future() noexcept;
@@ -4497,9 +4497,9 @@ namespace std {
     bool valid() const noexcept;
 
     void wait() const;
-    template <class Rep, class Period>
+    template<class Rep, class Period>
       future_status wait_for(const chrono::duration<Rep, Period>& rel_time) const;
-    template <class Clock, class Duration>
+    template<class Clock, class Duration>
       future_status wait_until(const chrono::time_point<Clock, Duration>& abs_time) const;
   };
 }
@@ -4695,7 +4695,7 @@ Blocks until the shared state is ready.
 
 \indexlibrarymember{wait_for}{shared_future}%
 \begin{itemdecl}
-template <class Rep, class Period>
+template<class Rep, class Period>
   future_status wait_for(const chrono::duration<Rep, Period>& rel_time) const;
 \end{itemdecl}
 
@@ -4729,7 +4729,7 @@ timeout-related exceptions\iref{thread.req.timing}.
 
 \indexlibrarymember{wait_until}{shared_future}%
 \begin{itemdecl}
-template <class Clock, class Duration>
+template<class Clock, class Duration>
   future_status wait_until(const chrono::time_point<Clock, Duration>& abs_time) const;
 \end{itemdecl}
 
@@ -4770,10 +4770,10 @@ it shares a shared state.
 
 \indexlibrary{\idxcode{async}}%
 \begin{itemdecl}
-template <class F, class... Args>
+template<class F, class... Args>
   [[nodiscard]] future<invoke_result_t<decay_t<F>, decay_t<Args>...>>
     async(F&& f, Args&&... args);
-template <class F, class... Args>
+template<class F, class... Args>
   [[nodiscard]] future<invoke_result_t<decay_t<F>, decay_t<Args>...>>
     async(launch policy, F&& f, Args&&... args);
 \end{itemdecl}
@@ -4957,7 +4957,7 @@ namespace std {
   public:
     // construction and destruction
     packaged_task() noexcept;
-    template <class F>
+    template<class F>
       explicit packaged_task(F&& f);
     ~packaged_task();
 
@@ -4982,7 +4982,7 @@ namespace std {
     void reset();
   };
 
-  template <class R, class... ArgTypes>
+  template<class R, class... ArgTypes>
     void swap(packaged_task<R(ArgTypes...)>& x, packaged_task<R(ArgTypes...)>& y) noexcept;
 }
 \end{codeblock}
@@ -5001,7 +5001,7 @@ packaged_task() noexcept;
 
 \indexlibrary{\idxcode{packaged_task}!constructor}%
 \begin{itemdecl}
-template <class F>
+template<class F>
   packaged_task(F&& f);
 \end{itemdecl}
 
@@ -5204,7 +5204,7 @@ has no shared state.
 
 \indexlibrarymember{swap}{packaged_task}%
 \begin{itemdecl}
-template <class R, class... ArgTypes>
+template<class R, class... ArgTypes>
   void swap(packaged_task<R(ArgTypes...)>& x, packaged_task<R(ArgTypes...)>& y) noexcept;
 \end{itemdecl}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -47,35 +47,35 @@ throughout the rest of the library.
 
 namespace std {
   // \ref{utility.swap}, swap
-  template <class T>
+  template<class T>
     void swap(T& a, T& b) noexcept(@\seebelow@);
-  template <class T, size_t N>
+  template<class T, size_t N>
     void swap(T (&a)[N], T (&b)[N]) noexcept(is_nothrow_swappable_v<T>);
 
   // \ref{utility.exchange}, exchange
-  template <class T, class U = T>
+  template<class T, class U = T>
     constexpr T exchange(T& obj, U&& new_val);
 
   // \ref{forward}, forward/move
-  template <class T>
+  template<class T>
     constexpr T&& forward(remove_reference_t<T>& t) noexcept;
-  template <class T>
+  template<class T>
     constexpr T&& forward(remove_reference_t<T>&& t) noexcept;
-  template <class T>
+  template<class T>
     constexpr remove_reference_t<T>&& move(T&&) noexcept;
-  template <class T>
+  template<class T>
     constexpr conditional_t<
         !is_nothrow_move_constructible_v<T> && is_copy_constructible_v<T>, const T&, T&&>
       move_if_noexcept(T& x) noexcept;
 
   // \ref{utility.as_const}, \tcode{as_const}
-  template <class T>
+  template<class T>
     constexpr add_const_t<T>& as_const(T& t) noexcept;
-  template <class T>
+  template<class T>
     void as_const(const T&&) = delete;
 
   // \ref{declval}, declval
-  template <class T>
+  template<class T>
     add_rvalue_reference_t<T> declval() noexcept;  // as unevaluated operand
 @%
 \indexlibrary{\idxcode{index_sequence}}%
@@ -97,35 +97,35 @@ namespace std {
     using index_sequence_for = make_index_sequence<sizeof...(T)>;
 
   // \ref{pairs}, class template \tcode{pair}
-  template <class T1, class T2>
+  template<class T1, class T2>
     struct pair;
 
   // \ref{pairs.spec}, pair specialized algorithms
-  template <class T1, class T2>
+  template<class T1, class T2>
     constexpr bool operator==(const pair<T1, T2>&, const pair<T1, T2>&);
-  template <class T1, class T2>
+  template<class T1, class T2>
     constexpr bool operator< (const pair<T1, T2>&, const pair<T1, T2>&);
-  template <class T1, class T2>
+  template<class T1, class T2>
     constexpr bool operator!=(const pair<T1, T2>&, const pair<T1, T2>&);
-  template <class T1, class T2>
+  template<class T1, class T2>
     constexpr bool operator> (const pair<T1, T2>&, const pair<T1, T2>&);
-  template <class T1, class T2>
+  template<class T1, class T2>
     constexpr bool operator>=(const pair<T1, T2>&, const pair<T1, T2>&);
-  template <class T1, class T2>
+  template<class T1, class T2>
     constexpr bool operator<=(const pair<T1, T2>&, const pair<T1, T2>&);
 
-  template <class T1, class T2>
+  template<class T1, class T2>
     void swap(pair<T1, T2>& x, pair<T1, T2>& y) noexcept(noexcept(x.swap(y)));
 
-  template <class T1, class T2>
+  template<class T1, class T2>
     constexpr @\seebelow@ make_pair(T1&&, T2&&);
 
   // \ref{pair.astuple}, tuple-like access to pair
-  template <class T> class tuple_size;
-  template <size_t I, class T> class tuple_element;
+  template<class T> class tuple_size;
+  template<size_t I, class T> class tuple_element;
 
-  template <class T1, class T2> struct tuple_size<pair<T1, T2>>;
-  template <size_t I, class T1, class T2> struct tuple_element<I, pair<T1, T2>>;
+  template<class T1, class T2> struct tuple_size<pair<T1, T2>>;
+  template<size_t I, class T1, class T2> struct tuple_element<I, pair<T1, T2>>;
 
   template<size_t I, class T1, class T2>
     constexpr tuple_element_t<I, pair<T1, T2>>& get(pair<T1, T2>&) noexcept;
@@ -135,21 +135,21 @@ namespace std {
     constexpr const tuple_element_t<I, pair<T1, T2>>& get(const pair<T1, T2>&) noexcept;
   template<size_t I, class T1, class T2>
     constexpr const tuple_element_t<I, pair<T1, T2>>&& get(const pair<T1, T2>&&) noexcept;
-  template <class T1, class T2>
+  template<class T1, class T2>
     constexpr T1& get(pair<T1, T2>& p) noexcept;
-  template <class T1, class T2>
+  template<class T1, class T2>
     constexpr const T1& get(const pair<T1, T2>& p) noexcept;
-  template <class T1, class T2>
+  template<class T1, class T2>
     constexpr T1&& get(pair<T1, T2>&& p) noexcept;
-  template <class T1, class T2>
+  template<class T1, class T2>
     constexpr const T1&& get(const pair<T1, T2>&& p) noexcept;
-  template <class T2, class T1>
+  template<class T2, class T1>
     constexpr T2& get(pair<T1, T2>& p) noexcept;
-  template <class T2, class T1>
+  template<class T2, class T1>
     constexpr const T2& get(const pair<T1, T2>& p) noexcept;
-  template <class T2, class T1>
+  template<class T2, class T1>
     constexpr T2&& get(pair<T1, T2>&& p) noexcept;
-  template <class T2, class T1>
+  template<class T2, class T1>
     constexpr const T2&& get(const pair<T1, T2>&& p) noexcept;
 
   // \ref{pair.piecewise}, pair piecewise construction
@@ -157,23 +157,23 @@ namespace std {
     explicit piecewise_construct_t() = default;
   };
   inline constexpr piecewise_construct_t piecewise_construct{};
-  template <class... Types> class tuple;        // defined in \tcode{<tuple>}\iref{tuple.syn}
+  template<class... Types> class tuple;        // defined in \tcode{<tuple>}\iref{tuple.syn}
 
   // in-place construction
   struct in_place_t {
     explicit in_place_t() = default;
   };
   inline constexpr in_place_t in_place{};
-  template <class T>
+  template<class T>
     struct in_place_type_t {
       explicit in_place_type_t() = default;
     };
-  template <class T> inline constexpr in_place_type_t<T> in_place_type{};
-  template <size_t I>
+  template<class T> inline constexpr in_place_type_t<T> in_place_type{};
+  template<size_t I>
     struct in_place_index_t {
       explicit in_place_index_t() = default;
     };
-  template <size_t I> inline constexpr in_place_index_t<I> in_place_index{};
+  template<size_t I> inline constexpr in_place_index_t<I> in_place_index{};
 }
 \end{codeblock}
 
@@ -194,7 +194,7 @@ and \tcode{hex}.
 
 \indexlibrary{\idxcode{swap}}%
 \begin{itemdecl}
-template <class T>
+template<class T>
   void swap(T& a, T& b) noexcept(@\seebelow@);
 \end{itemdecl}
 
@@ -225,7 +225,7 @@ Exchanges values stored in two locations.
 
 \indexlibrary{\idxcode{swap}}%
 \begin{itemdecl}
-template <class T, size_t N>
+template<class T, size_t N>
   void swap(T (&a)[N], T (&b)[N]) noexcept(is_nothrow_swappable_v<T>);
 \end{itemdecl}
 
@@ -248,7 +248,7 @@ for all \tcode{i} in the range \range{0}{N}.
 
 \indexlibrary{\idxcode{exchange}}%
 \begin{itemdecl}
-template <class T, class U = T>
+template<class T, class U = T>
   constexpr T exchange(T& obj, U&& new_val);
 \end{itemdecl}
 
@@ -278,8 +278,8 @@ All functions specified in this subclause are signal-safe\iref{support.signal}.
 \indexlibrary{\idxcode{forward}}%
 \indextext{\idxcode{forward}}%
 \begin{itemdecl}
-template <class T> constexpr T&& forward(remove_reference_t<T>& t) noexcept;
-template <class T> constexpr T&& forward(remove_reference_t<T>&& t) noexcept;
+template<class T> constexpr T&& forward(remove_reference_t<T>& t) noexcept;
+template<class T> constexpr T&& forward(remove_reference_t<T>&& t) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -292,7 +292,7 @@ template <class T> constexpr T&& forward(remove_reference_t<T>&& t) noexcept;
 \pnum
 \begin{example}
 \begin{codeblock}
-template <class T, class A1, class A2>
+template<class T, class A1, class A2>
 shared_ptr<T> factory(A1&& a1, A2&& a2) {
   return shared_ptr<T>(new T(std::forward<A1>(a1), std::forward<A2>(a2)));
 }
@@ -321,7 +321,7 @@ both cases, \tcode{A2} is deduced as \tcode{double}, so
 \indexlibrary{\idxcode{move}!function}%
 \indextext{\idxcode{move}}%
 \begin{itemdecl}
-template <class T> constexpr remove_reference_t<T>&& move(T&& t) noexcept;
+template<class T> constexpr remove_reference_t<T>&& move(T&& t) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -332,7 +332,7 @@ template <class T> constexpr remove_reference_t<T>&& move(T&& t) noexcept;
 \pnum
 \begin{example}
 \begin{codeblock}
-template <class T, class A1>
+template<class T, class A1>
 shared_ptr<T> factory(A1&& a1) {
   return shared_ptr<T>(new T(std::forward<A1>(a1)));
 }
@@ -363,7 +363,7 @@ which moves the value from \tcode{a}.
 
 \indexlibrary{\idxcode{move_if_noexcept}}%
 \begin{itemdecl}
-template <class T> constexpr conditional_t<
+template<class T> constexpr conditional_t<
     !is_nothrow_move_constructible_v<T> && is_copy_constructible_v<T>, const T&, T&&>
   move_if_noexcept(T& x) noexcept;
 \end{itemdecl}
@@ -377,7 +377,7 @@ template <class T> constexpr conditional_t<
 
 \indexlibrary{\idxcode{as_const}}%
 \begin{itemdecl}
-template <class T> constexpr add_const_t<T>& as_const(T& t) noexcept;
+template<class T> constexpr add_const_t<T>& as_const(T& t) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -393,7 +393,7 @@ expressions which occur as unevaluated operands\iref{expr.prop}.
 
 \indexlibrary{\idxcode{declval}}%
 \begin{itemdecl}
-template <class T> add_rvalue_reference_t<T> declval() noexcept;    // as unevaluated operand
+template<class T> add_rvalue_reference_t<T> declval() noexcept;    // as unevaluated operand
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -407,7 +407,7 @@ template <class T> add_rvalue_reference_t<T> declval() noexcept;    // as uneval
 \pnum
 \begin{example}
 \begin{codeblock}
-template <class To, class From> decltype(static_cast<To>(declval<From>())) convert(From&&);
+template<class To, class From> decltype(static_cast<To>(declval<From>())) convert(From&&);
 \end{codeblock}
 declares a function template \tcode{convert} which only participates in overloading if the
 type \tcode{From} can be explicitly converted to type \tcode{To}. For another example see class
@@ -482,7 +482,7 @@ and~\ref{tuple.elem}).%
 \indexlibrary{\idxcode{pair}}%
 \begin{codeblock}
 namespace std {
-  template <class T1, class T2>
+  template<class T1, class T2>
     struct pair {
       using first_type  = T1;
       using second_type = T2;
@@ -497,7 +497,7 @@ namespace std {
       template<class U1, class U2> @\EXPLICIT@ constexpr pair(U1&& x, U2&& y);
       template<class U1, class U2> @\EXPLICIT@ constexpr pair(const pair<U1, U2>& p);
       template<class U1, class U2> @\EXPLICIT@ constexpr pair(pair<U1, U2>&& p);
-      template <class... Args1, class... Args2>
+      template<class... Args1, class... Args2>
         pair(piecewise_construct_t, tuple<Args1...> first_args, tuple<Args2...> second_args);
 
       pair& operator=(const pair& p);
@@ -764,7 +764,7 @@ is_nothrow_swappable_v<first_type> && is_nothrow_swappable_v<second_type>
 
 \indexlibrarymember{operator==}{pair}%
 \begin{itemdecl}
-template <class T1, class T2>
+template<class T1, class T2>
   constexpr bool operator==(const pair<T1, T2>& x, const pair<T1, T2>& y);
 \end{itemdecl}
 
@@ -776,7 +776,7 @@ template <class T1, class T2>
 
 \indexlibrarymember{operator<}{pair}%
 \begin{itemdecl}
-template <class T1, class T2>
+template<class T1, class T2>
   constexpr bool operator<(const pair<T1, T2>& x, const pair<T1, T2>& y);
 \end{itemdecl}
 
@@ -788,7 +788,7 @@ template <class T1, class T2>
 
 \indexlibrarymember{operator"!=}{pair}%
 \begin{itemdecl}
-template <class T1, class T2>
+template<class T1, class T2>
   constexpr bool operator!=(const pair<T1, T2>& x, const pair<T1, T2>& y);
 \end{itemdecl}
 
@@ -799,7 +799,7 @@ template <class T1, class T2>
 
 \indexlibrarymember{operator>}{pair}%
 \begin{itemdecl}
-template <class T1, class T2>
+template<class T1, class T2>
   constexpr bool operator>(const pair<T1, T2>& x, const pair<T1, T2>& y);
 \end{itemdecl}
 
@@ -810,7 +810,7 @@ template <class T1, class T2>
 
 \indexlibrarymember{operator>=}{pair}%
 \begin{itemdecl}
-template <class T1, class T2>
+template<class T1, class T2>
   constexpr bool operator>=(const pair<T1, T2>& x, const pair<T1, T2>& y);
 \end{itemdecl}
 
@@ -821,7 +821,7 @@ template <class T1, class T2>
 
 \indexlibrarymember{operator<=}{pair}%
 \begin{itemdecl}
-template <class T1, class T2>
+template<class T1, class T2>
   constexpr bool operator<=(const pair<T1, T2>& x, const pair<T1, T2>& y);
 \end{itemdecl}
 
@@ -850,7 +850,7 @@ This function shall not participate in overload resolution unless
 
 \indexlibrary{\idxcode{make_pair}}%
 \begin{itemdecl}
-template <class T1, class T2>
+template<class T1, class T2>
   constexpr pair<V1, V2> make_pair(T1&& x, T2&& y);
 \end{itemdecl}
 
@@ -879,7 +879,7 @@ a \Cpp{} program may contain:
 
 \indexlibrary{\idxcode{tuple_size}}%
 \begin{itemdecl}
-template <class T1, class T2>
+template<class T1, class T2>
   struct tuple_size<pair<T1, T2>> : integral_constant<size_t, 2> { };
 \end{itemdecl}
 
@@ -916,13 +916,13 @@ otherwise the program is ill-formed.
 
 \indexlibrarymember{get}{pair}%
 \begin{itemdecl}
-template <class T1, class T2>
+template<class T1, class T2>
   constexpr T1& get(pair<T1, T2>& p) noexcept;
-template <class T1, class T2>
+template<class T1, class T2>
   constexpr const T1& get(const pair<T1, T2>& p) noexcept;
-template <class T1, class T2>
+template<class T1, class T2>
   constexpr T1&& get(pair<T1, T2>&& p) noexcept;
-template <class T1, class T2>
+template<class T1, class T2>
   constexpr const T1&& get(const pair<T1, T2>&& p) noexcept;
 \end{itemdecl}
 \begin{itemdescr}
@@ -935,13 +935,13 @@ template <class T1, class T2>
 
 \indexlibrarymember{get}{pair}%
 \begin{itemdecl}
-template <class T2, class T1>
+template<class T2, class T1>
   constexpr T2& get(pair<T1, T2>& p) noexcept;
-template <class T2, class T1>
+template<class T2, class T1>
   constexpr const T2& get(const pair<T1, T2>& p) noexcept;
-template <class T2, class T1>
+template<class T2, class T1>
   constexpr T2&& get(pair<T1, T2>&& p) noexcept;
-template <class T2, class T1>
+template<class T2, class T1>
   constexpr const T2&& get(const pair<T1, T2>&& p) noexcept;
 \end{itemdecl}
 \begin{itemdescr}
@@ -991,66 +991,66 @@ See~\ref{pairs}.
 \begin{codeblock}
 namespace std {
   // \ref{tuple.tuple}, class template \tcode{tuple}
-  template <class... Types>
+  template<class... Types>
     class tuple;
 
   // \ref{tuple.creation}, tuple creation functions
   inline constexpr @\unspec@ ignore;
 
-  template <class... TTypes>
+  template<class... TTypes>
     constexpr tuple<VTypes...> make_tuple(TTypes&&...);
 
-  template <class... TTypes>
+  template<class... TTypes>
     constexpr tuple<TTypes&&...> forward_as_tuple(TTypes&&...) noexcept;
 
   template<class... TTypes>
     constexpr tuple<TTypes&...> tie(TTypes&...) noexcept;
 
-  template <class... Tuples>
+  template<class... Tuples>
     constexpr tuple<CTypes...> tuple_cat(Tuples&&...);
 
   // \ref{tuple.apply}, calling a function with a tuple of arguments
-  template <class F, class Tuple>
+  template<class F, class Tuple>
     constexpr decltype(auto) apply(F&& f, Tuple&& t);
 
-  template <class T, class Tuple>
+  template<class T, class Tuple>
     constexpr T make_from_tuple(Tuple&& t);
 
   // \ref{tuple.helper}, tuple helper classes
-  template <class T> class tuple_size;                  // not defined
-  template <class T> class tuple_size<const T>;
-  template <class T> class tuple_size<volatile T>;
-  template <class T> class tuple_size<const volatile T>;
+  template<class T> class tuple_size;                  // not defined
+  template<class T> class tuple_size<const T>;
+  template<class T> class tuple_size<volatile T>;
+  template<class T> class tuple_size<const volatile T>;
 
-  template <class... Types> class tuple_size<tuple<Types...>>;
+  template<class... Types> class tuple_size<tuple<Types...>>;
 
-  template <size_t I, class T> class tuple_element;     // not defined
-  template <size_t I, class T> class tuple_element<I, const T>;
-  template <size_t I, class T> class tuple_element<I, volatile T>;
-  template <size_t I, class T> class tuple_element<I, const volatile T>;
+  template<size_t I, class T> class tuple_element;     // not defined
+  template<size_t I, class T> class tuple_element<I, const T>;
+  template<size_t I, class T> class tuple_element<I, volatile T>;
+  template<size_t I, class T> class tuple_element<I, const volatile T>;
 
-  template <size_t I, class... Types>
+  template<size_t I, class... Types>
     class tuple_element<I, tuple<Types...>>;
 
-  template <size_t I, class T>
+  template<size_t I, class T>
     using tuple_element_t = typename tuple_element<I, T>::type;
 
   // \ref{tuple.elem}, element access
-  template <size_t I, class... Types>
+  template<size_t I, class... Types>
     constexpr tuple_element_t<I, tuple<Types...>>& get(tuple<Types...>&) noexcept;
-  template <size_t I, class... Types>
+  template<size_t I, class... Types>
     constexpr tuple_element_t<I, tuple<Types...>>&& get(tuple<Types...>&&) noexcept;
-  template <size_t I, class... Types>
+  template<size_t I, class... Types>
     constexpr const tuple_element_t<I, tuple<Types...>>& get(const tuple<Types...>&) noexcept;
-  template <size_t I, class... Types>
+  template<size_t I, class... Types>
     constexpr const tuple_element_t<I, tuple<Types...>>&& get(const tuple<Types...>&&) noexcept;
-  template <class T, class... Types>
+  template<class T, class... Types>
     constexpr T& get(tuple<Types...>& t) noexcept;
-  template <class T, class... Types>
+  template<class T, class... Types>
     constexpr T&& get(tuple<Types...>&& t) noexcept;
-  template <class T, class... Types>
+  template<class T, class... Types>
     constexpr const T& get(const tuple<Types...>& t) noexcept;
-  template <class T, class... Types>
+  template<class T, class... Types>
     constexpr const T&& get(const tuple<Types...>&& t) noexcept;
 
   // \ref{tuple.rel}, relational operators
@@ -1068,15 +1068,15 @@ namespace std {
     constexpr bool operator>=(const tuple<TTypes...>&, const tuple<UTypes...>&);
 
   // \ref{tuple.traits}, allocator-related traits
-  template <class... Types, class Alloc>
+  template<class... Types, class Alloc>
     struct uses_allocator<tuple<Types...>, Alloc>;
 
   // \ref{tuple.special}, specialized algorithms
-  template <class... Types>
+  template<class... Types>
     void swap(tuple<Types...>& x, tuple<Types...>& y) noexcept(@\seebelow@);
 
   // \ref{tuple.helper}, tuple helper classes
-  template <class T>
+  template<class T>
     inline constexpr size_t tuple_size_v = tuple_size<T>::value;
 }
 \end{codeblock}
@@ -1086,60 +1086,60 @@ namespace std {
 
 \begin{codeblock}
 namespace std {
-  template <class... Types>
+  template<class... Types>
     class tuple {
     public:
       // \ref{tuple.cnstr}, \tcode{tuple} construction
       @\EXPLICIT@ constexpr tuple();
       @\EXPLICIT@ constexpr tuple(const Types&...);         // only if \tcode{sizeof...(Types) >= 1}
-      template <class... UTypes>
+      template<class... UTypes>
         @\EXPLICIT@ constexpr tuple(UTypes&&...);           // only if \tcode{sizeof...(Types) >= 1}
 
       tuple(const tuple&) = default;
       tuple(tuple&&) = default;
 
-      template <class... UTypes>
+      template<class... UTypes>
         @\EXPLICIT@ constexpr tuple(const tuple<UTypes...>&);
-      template <class... UTypes>
+      template<class... UTypes>
         @\EXPLICIT@ constexpr tuple(tuple<UTypes...>&&);
 
-      template <class U1, class U2>
+      template<class U1, class U2>
         @\EXPLICIT@ constexpr tuple(const pair<U1, U2>&);   // only if \tcode{sizeof...(Types) == 2}
-      template <class U1, class U2>
+      template<class U1, class U2>
         @\EXPLICIT@ constexpr tuple(pair<U1, U2>&&);        // only if \tcode{sizeof...(Types) == 2}
 
       // allocator-extended constructors
-      template <class Alloc>
+      template<class Alloc>
         tuple(allocator_arg_t, const Alloc& a);
-      template <class Alloc>
+      template<class Alloc>
         @\EXPLICIT@ tuple(allocator_arg_t, const Alloc& a, const Types&...);
-      template <class Alloc, class... UTypes>
+      template<class Alloc, class... UTypes>
         @\EXPLICIT@ tuple(allocator_arg_t, const Alloc& a, UTypes&&...);
-      template <class Alloc>
+      template<class Alloc>
         tuple(allocator_arg_t, const Alloc& a, const tuple&);
-      template <class Alloc>
+      template<class Alloc>
         tuple(allocator_arg_t, const Alloc& a, tuple&&);
-      template <class Alloc, class... UTypes>
+      template<class Alloc, class... UTypes>
         @\EXPLICIT@ tuple(allocator_arg_t, const Alloc& a, const tuple<UTypes...>&);
-      template <class Alloc, class... UTypes>
+      template<class Alloc, class... UTypes>
         @\EXPLICIT@ tuple(allocator_arg_t, const Alloc& a, tuple<UTypes...>&&);
-      template <class Alloc, class U1, class U2>
+      template<class Alloc, class U1, class U2>
         @\EXPLICIT@ tuple(allocator_arg_t, const Alloc& a, const pair<U1, U2>&);
-      template <class Alloc, class U1, class U2>
+      template<class Alloc, class U1, class U2>
         @\EXPLICIT@ tuple(allocator_arg_t, const Alloc& a, pair<U1, U2>&&);
 
       // \ref{tuple.assign}, \tcode{tuple} assignment
       tuple& operator=(const tuple&);
       tuple& operator=(tuple&&) noexcept(@\seebelow@);
 
-      template <class... UTypes>
+      template<class... UTypes>
         tuple& operator=(const tuple<UTypes...>&);
-      template <class... UTypes>
+      template<class... UTypes>
         tuple& operator=(tuple<UTypes...>&&);
 
-      template <class U1, class U2>
+      template<class U1, class U2>
         tuple& operator=(const pair<U1, U2>&);              // only if \tcode{sizeof...(Types) == 2}
-      template <class U1, class U2>
+      template<class U1, class U2>
         tuple& operator=(pair<U1, U2>&&);                   // only if \tcode{sizeof...(Types) == 2}
 
       // \ref{tuple.swap}, \tcode{tuple} swap
@@ -1226,7 +1226,7 @@ for at least one $i$.
 
 \indexlibrary{\idxcode{tuple}!constructor}%
 \begin{itemdecl}
-template <class... UTypes> @\EXPLICIT@ constexpr tuple(UTypes&&... u);
+template<class... UTypes> @\EXPLICIT@ constexpr tuple(UTypes&&... u);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1273,7 +1273,7 @@ tuple(tuple&& u) = default;
 
 \indexlibrary{\idxcode{tuple}!constructor}%
 \begin{itemdecl}
-template <class... UTypes> @\EXPLICIT@ constexpr tuple(const tuple<UTypes...>& u);
+template<class... UTypes> @\EXPLICIT@ constexpr tuple(const tuple<UTypes...>& u);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1301,7 +1301,7 @@ for at least one $i$.
 
 \indexlibrary{\idxcode{tuple}!constructor}%
 \begin{itemdecl}
-template <class... UTypes> @\EXPLICIT@ constexpr tuple(tuple<UTypes...>&& u);
+template<class... UTypes> @\EXPLICIT@ constexpr tuple(tuple<UTypes...>&& u);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1333,7 +1333,7 @@ for at least one $i$.
 \indexlibrary{\idxcode{tuple}!constructor}%
 \indexlibrary{\idxcode{pair}}%
 \begin{itemdecl}
-template <class U1, class U2> @\EXPLICIT@ constexpr tuple(const pair<U1, U2>& u);
+template<class U1, class U2> @\EXPLICIT@ constexpr tuple(const pair<U1, U2>& u);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1356,7 +1356,7 @@ The constructor is explicit if and only if
 \indexlibrary{\idxcode{tuple}!constructor}%
 \indexlibrary{\idxcode{pair}}%
 \begin{itemdecl}
-template <class U1, class U2> @\EXPLICIT@ constexpr tuple(pair<U1, U2>&& u);
+template<class U1, class U2> @\EXPLICIT@ constexpr tuple(pair<U1, U2>&& u);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1379,23 +1379,23 @@ The constructor is explicit if and only if
 
 \indexlibrary{\idxcode{tuple}!constructor}%
 \begin{itemdecl}
-template <class Alloc>
+template<class Alloc>
   tuple(allocator_arg_t, const Alloc& a);
-template <class Alloc>
+template<class Alloc>
   @\EXPLICIT@ tuple(allocator_arg_t, const Alloc& a, const Types&...);
-template <class Alloc, class... UTypes>
+template<class Alloc, class... UTypes>
   @\EXPLICIT@ tuple(allocator_arg_t, const Alloc& a, UTypes&&...);
-template <class Alloc>
+template<class Alloc>
   tuple(allocator_arg_t, const Alloc& a, const tuple&);
-template <class Alloc>
+template<class Alloc>
   tuple(allocator_arg_t, const Alloc& a, tuple&&);
-template <class Alloc, class... UTypes>
+template<class Alloc, class... UTypes>
   @\EXPLICIT@ tuple(allocator_arg_t, const Alloc& a, const tuple<UTypes...>&);
-template <class Alloc, class... UTypes>
+template<class Alloc, class... UTypes>
   @\EXPLICIT@ tuple(allocator_arg_t, const Alloc& a, tuple<UTypes...>&&);
-template <class Alloc, class U1, class U2>
+template<class Alloc, class U1, class U2>
   @\EXPLICIT@ tuple(allocator_arg_t, const Alloc& a, const pair<U1, U2>&);
-template <class Alloc, class U1, class U2>
+template<class Alloc, class U1, class U2>
   @\EXPLICIT@ tuple(allocator_arg_t, const Alloc& a, pair<U1, U2>&&);
 \end{itemdecl}
 
@@ -1466,7 +1466,7 @@ where $\mathtt{T}_i$ is the $i^\text{th}$ type in \tcode{Types}.
 
 \indexlibrarymember{operator=}{tuple}%
 \begin{itemdecl}
-template <class... UTypes> tuple& operator=(const tuple<UTypes...>& u);
+template<class... UTypes> tuple& operator=(const tuple<UTypes...>& u);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1485,7 +1485,7 @@ of \tcode{*this}.
 
 \indexlibrarymember{operator=}{tuple}%
 \begin{itemdecl}
-template <class... UTypes> tuple& operator=(tuple<UTypes...>&& u);
+template<class... UTypes> tuple& operator=(tuple<UTypes...>&& u);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1505,7 +1505,7 @@ template <class... UTypes> tuple& operator=(tuple<UTypes...>&& u);
 \indexlibrarymember{operator=}{tuple}%
 \indexlibrary{\idxcode{pair}}%
 \begin{itemdecl}
-template <class U1, class U2> tuple& operator=(const pair<U1, U2>& u);
+template<class U1, class U2> tuple& operator=(const pair<U1, U2>& u);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1527,7 +1527,7 @@ second type $\tcode{T}_1$ in \tcode{Types}.
 \indexlibrarymember{operator=}{tuple}%
 \indexlibrary{\idxcode{pair}}%
 \begin{itemdecl}
-template <class U1, class U2> tuple& operator=(pair<U1, U2>&& u);
+template<class U1, class U2> tuple& operator=(pair<U1, U2>&& u);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1660,7 +1660,7 @@ tie(i, ignore, s) = make_tuple(42, 3.14, "C++");
 
 \indexlibrary{\idxcode{tuple_cat}}
 \begin{itemdecl}
-template <class... Tuples>
+template<class... Tuples>
   constexpr tuple<CTypes...> tuple_cat(Tuples&&... tpls);
 \end{itemdecl}
 
@@ -1712,7 +1712,7 @@ pack \tcode{Tuples} that support the \tcode{tuple}-like protocol, such as
 
 \indexlibrary{\idxcode{apply}}%
 \begin{itemdecl}
-template <class F, class Tuple>
+template<class F, class Tuple>
   constexpr decltype(auto) apply(F&& f, Tuple&& t);
 \end{itemdecl}
 
@@ -1721,7 +1721,7 @@ template <class F, class Tuple>
 \effects
 Given the exposition-only function:
 \begin{codeblock}
-template <class F, class Tuple, size_t... I>
+template<class F, class Tuple, size_t... I>
 constexpr decltype(auto)
     apply_impl(F&& f, Tuple&& t, index_sequence<I...>) {                // exposition only
   return @\placeholdernc{INVOKE}@(std::forward<F>(f), std::get<I>(std::forward<Tuple>(t))...);  // see \ref{func.require}
@@ -1736,7 +1736,7 @@ return apply_impl(std::forward<F>(f), std::forward<Tuple>(t),
 
 \indexlibrary{\idxcode{make_from_tuple}}%
 \begin{itemdecl}
-template <class T, class Tuple>
+template<class T, class Tuple>
   constexpr T make_from_tuple(Tuple&& t);
 \end{itemdecl}
 
@@ -1745,7 +1745,7 @@ template <class T, class Tuple>
 \effects
 Given the exposition-only function:
 \begin{codeblock}
-template <class T, class Tuple, size_t... I>
+template<class T, class Tuple, size_t... I>
 constexpr T make_from_tuple_impl(Tuple&& t, index_sequence<I...>) {     // exposition only
   return T(get<I>(std::forward<Tuple>(t))...);
 }
@@ -1765,7 +1765,7 @@ as it cannot be deduced from the argument list. \end{note}
 
 \indexlibrary{\idxcode{tuple_size}!in general}%
 \begin{itemdecl}
-template <class T> struct tuple_size;
+template<class T> struct tuple_size;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1778,13 +1778,13 @@ for some \tcode{N}.
 
 \indexlibrary{\idxcode{tuple_size}}%
 \begin{itemdecl}
-template <class... Types>
+template<class... Types>
   class tuple_size<tuple<Types...>> : public integral_constant<size_t, sizeof...(Types)> { };
 \end{itemdecl}
 
 \indexlibrary{\idxcode{tuple_element}}%
 \begin{itemdecl}
-template <size_t I, class... Types>
+template<size_t I, class... Types>
   class tuple_element<I, tuple<Types...>> {
   public:
     using type = TI;
@@ -1804,9 +1804,9 @@ where indexing is zero-based.
 
 \indexlibrary{\idxcode{tuple_size}}%
 \begin{itemdecl}
-template <class T> class tuple_size<const T>;
-template <class T> class tuple_size<volatile T>;
-template <class T> class tuple_size<const volatile T>;
+template<class T> class tuple_size<const T>;
+template<class T> class tuple_size<volatile T>;
+template<class T> class tuple_size<const volatile T>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1841,9 +1841,9 @@ the three templates are available when either of the headers \tcode{<array>} or
 
 \indexlibrary{\idxcode{tuple_element}}%
 \begin{itemdecl}
-template <size_t I, class T> class tuple_element<I, const T>;
-template <size_t I, class T> class tuple_element<I, volatile T>;
-template <size_t I, class T> class tuple_element<I, const volatile T>;
+template<size_t I, class T> class tuple_element<I, const T>;
+template<size_t I, class T> class tuple_element<I, volatile T>;
+template<size_t I, class T> class tuple_element<I, const volatile T>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1872,16 +1872,16 @@ the three templates are available when either of the headers \tcode{<array>} or
 
 \indexlibrarymember{get}{tuple}%
 \begin{itemdecl}
-template <size_t I, class... Types>
+template<size_t I, class... Types>
   constexpr tuple_element_t<I, tuple<Types...>>&
     get(tuple<Types...>& t) noexcept;
-template <size_t I, class... Types>
+template<size_t I, class... Types>
   constexpr tuple_element_t<I, tuple<Types...>>&&
     get(tuple<Types...>&& t) noexcept;        // Note A
-template <size_t I, class... Types>
+template<size_t I, class... Types>
   constexpr const tuple_element_t<I, tuple<Types...>>&
     get(const tuple<Types...>& t) noexcept;   // Note B
-template <size_t I, class... Types>
+template<size_t I, class... Types>
   constexpr const tuple_element_t<I, tuple<Types...>>&& get(const tuple<Types...>&& t) noexcept;
 \end{itemdecl}
 
@@ -1916,13 +1916,13 @@ for member variables of reference type.
 
 \indexlibrarymember{get}{tuple}%
 \begin{itemdecl}
-template <class T, class... Types>
+template<class T, class... Types>
   constexpr T& get(tuple<Types...>& t) noexcept;
-template <class T, class... Types>
+template<class T, class... Types>
   constexpr T&& get(tuple<Types...>&& t) noexcept;
-template <class T, class... Types>
+template<class T, class... Types>
   constexpr const T& get(const tuple<Types...>& t) noexcept;
-template <class T, class... Types>
+template<class T, class... Types>
   constexpr const T&& get(const tuple<Types...>&& t) noexcept;
 \end{itemdecl}
 
@@ -2058,7 +2058,7 @@ result of the comparison. \end{note}
 
 \indexlibrary{\idxcode{uses_allocator<tuple>}}%
 \begin{itemdecl}
-template <class... Types, class Alloc>
+template<class... Types, class Alloc>
   struct uses_allocator<tuple<Types...>, Alloc> : true_type { };
 \end{itemdecl}
 
@@ -2076,7 +2076,7 @@ a nested \tcode{allocator_type}. \end{note}
 
 \indexlibrary{\idxcode{swap}}%
 \begin{itemdecl}
-template <class... Types>
+template<class... Types>
   void swap(tuple<Types...>& x, tuple<Types...>& y) noexcept(@\seebelow@);
 \end{itemdecl}
 
@@ -2115,7 +2115,7 @@ object is tracked by the optional object.
 \begin{codeblock}
 namespace std {
   // \ref{optional.optional}, class template \tcode{optional}
-  template <class T>
+  template<class T>
     class optional;
 
   // \ref{optional.nullopt}, no-value state indicator
@@ -2126,61 +2126,61 @@ namespace std {
   class bad_optional_access;
 
   // \ref{optional.relops}, relational operators
-  template <class T, class U>
+  template<class T, class U>
   constexpr bool operator==(const optional<T>&, const optional<U>&);
-  template <class T, class U>
+  template<class T, class U>
   constexpr bool operator!=(const optional<T>&, const optional<U>&);
-  template <class T, class U>
+  template<class T, class U>
   constexpr bool operator<(const optional<T>&, const optional<U>&);
-  template <class T, class U>
+  template<class T, class U>
   constexpr bool operator>(const optional<T>&, const optional<U>&);
-  template <class T, class U>
+  template<class T, class U>
   constexpr bool operator<=(const optional<T>&, const optional<U>&);
-  template <class T, class U>
+  template<class T, class U>
   constexpr bool operator>=(const optional<T>&, const optional<U>&);
 
   // \ref{optional.nullops}, comparison with \tcode{nullopt}
-  template <class T> constexpr bool operator==(const optional<T>&, nullopt_t) noexcept;
-  template <class T> constexpr bool operator==(nullopt_t, const optional<T>&) noexcept;
-  template <class T> constexpr bool operator!=(const optional<T>&, nullopt_t) noexcept;
-  template <class T> constexpr bool operator!=(nullopt_t, const optional<T>&) noexcept;
-  template <class T> constexpr bool operator<(const optional<T>&, nullopt_t) noexcept;
-  template <class T> constexpr bool operator<(nullopt_t, const optional<T>&) noexcept;
-  template <class T> constexpr bool operator<=(const optional<T>&, nullopt_t) noexcept;
-  template <class T> constexpr bool operator<=(nullopt_t, const optional<T>&) noexcept;
-  template <class T> constexpr bool operator>(const optional<T>&, nullopt_t) noexcept;
-  template <class T> constexpr bool operator>(nullopt_t, const optional<T>&) noexcept;
-  template <class T> constexpr bool operator>=(const optional<T>&, nullopt_t) noexcept;
-  template <class T> constexpr bool operator>=(nullopt_t, const optional<T>&) noexcept;
+  template<class T> constexpr bool operator==(const optional<T>&, nullopt_t) noexcept;
+  template<class T> constexpr bool operator==(nullopt_t, const optional<T>&) noexcept;
+  template<class T> constexpr bool operator!=(const optional<T>&, nullopt_t) noexcept;
+  template<class T> constexpr bool operator!=(nullopt_t, const optional<T>&) noexcept;
+  template<class T> constexpr bool operator<(const optional<T>&, nullopt_t) noexcept;
+  template<class T> constexpr bool operator<(nullopt_t, const optional<T>&) noexcept;
+  template<class T> constexpr bool operator<=(const optional<T>&, nullopt_t) noexcept;
+  template<class T> constexpr bool operator<=(nullopt_t, const optional<T>&) noexcept;
+  template<class T> constexpr bool operator>(const optional<T>&, nullopt_t) noexcept;
+  template<class T> constexpr bool operator>(nullopt_t, const optional<T>&) noexcept;
+  template<class T> constexpr bool operator>=(const optional<T>&, nullopt_t) noexcept;
+  template<class T> constexpr bool operator>=(nullopt_t, const optional<T>&) noexcept;
 
   // \ref{optional.comp_with_t}, comparison with \tcode{T}
-  template <class T, class U> constexpr bool operator==(const optional<T>&, const U&);
-  template <class T, class U> constexpr bool operator==(const T&, const optional<U>&);
-  template <class T, class U> constexpr bool operator!=(const optional<T>&, const U&);
-  template <class T, class U> constexpr bool operator!=(const T&, const optional<U>&);
-  template <class T, class U> constexpr bool operator<(const optional<T>&, const U&);
-  template <class T, class U> constexpr bool operator<(const T&, const optional<U>&);
-  template <class T, class U> constexpr bool operator<=(const optional<T>&, const U&);
-  template <class T, class U> constexpr bool operator<=(const T&, const optional<U>&);
-  template <class T, class U> constexpr bool operator>(const optional<T>&, const U&);
-  template <class T, class U> constexpr bool operator>(const T&, const optional<U>&);
-  template <class T, class U> constexpr bool operator>=(const optional<T>&, const U&);
-  template <class T, class U> constexpr bool operator>=(const T&, const optional<U>&);
+  template<class T, class U> constexpr bool operator==(const optional<T>&, const U&);
+  template<class T, class U> constexpr bool operator==(const T&, const optional<U>&);
+  template<class T, class U> constexpr bool operator!=(const optional<T>&, const U&);
+  template<class T, class U> constexpr bool operator!=(const T&, const optional<U>&);
+  template<class T, class U> constexpr bool operator<(const optional<T>&, const U&);
+  template<class T, class U> constexpr bool operator<(const T&, const optional<U>&);
+  template<class T, class U> constexpr bool operator<=(const optional<T>&, const U&);
+  template<class T, class U> constexpr bool operator<=(const T&, const optional<U>&);
+  template<class T, class U> constexpr bool operator>(const optional<T>&, const U&);
+  template<class T, class U> constexpr bool operator>(const T&, const optional<U>&);
+  template<class T, class U> constexpr bool operator>=(const optional<T>&, const U&);
+  template<class T, class U> constexpr bool operator>=(const T&, const optional<U>&);
 
   // \ref{optional.specalg}, specialized algorithms
-  template <class T>
+  template<class T>
     void swap(optional<T>&, optional<T>&) noexcept(@\seebelow@);
 
-  template <class T>
+  template<class T>
     constexpr optional<@\seebelow@> make_optional(T&&);
-  template <class T, class... Args>
+  template<class T, class... Args>
     constexpr optional<T> make_optional(Args&&... args);
-  template <class T, class U, class... Args>
+  template<class T, class U, class... Args>
     constexpr optional<T> make_optional(initializer_list<U> il, Args&&... args);
 
   // \ref{optional.hash}, hash support
-  template <class T> struct hash;
-  template <class T> struct hash<optional<T>>;
+  template<class T> struct hash;
+  template<class T> struct hash<optional<T>>;
 }
 \end{codeblock}
 
@@ -2194,7 +2194,7 @@ a reference type, or for possibly cv-qualified types \tcode{in_place_t} or
 \indexlibrary{\idxcode{optional}}%
 \indexlibrarymember{value_type}{optional}%
 \begin{codeblock}
-template <class T>
+template<class T>
   class optional {
   public:
     using value_type = T;
@@ -2204,15 +2204,15 @@ template <class T>
     constexpr optional(nullopt_t) noexcept;
     constexpr optional(const optional&);
     constexpr optional(optional&&) noexcept(@\seebelow@);
-    template <class... Args>
+    template<class... Args>
       constexpr explicit optional(in_place_t, Args&&...);
-    template <class U, class... Args>
+    template<class U, class... Args>
       constexpr explicit optional(in_place_t, initializer_list<U>, Args&&...);
-    template <class U = T>
+    template<class U = T>
       @\EXPLICIT@ constexpr optional(U&&);
-    template <class U>
+    template<class U>
       @\EXPLICIT@ optional(const optional<U>&);
-    template <class U>
+    template<class U>
       @\EXPLICIT@ optional(optional<U>&&);
 
     // \ref{optional.dtor}, destructor
@@ -2222,11 +2222,11 @@ template <class T>
     optional& operator=(nullopt_t) noexcept;
     optional& operator=(const optional&);
     optional& operator=(optional&&) noexcept(@\seebelow@);
-    template <class U = T> optional& operator=(U&&);
-    template <class U> optional& operator=(const optional<U>&);
-    template <class U> optional& operator=(optional<U>&&);
-    template <class... Args> T& emplace(Args&&...);
-    template <class U, class... Args> T& emplace(initializer_list<U>, Args&&...);
+    template<class U = T> optional& operator=(U&&);
+    template<class U> optional& operator=(const optional<U>&);
+    template<class U> optional& operator=(optional<U>&&);
+    template<class... Args> T& emplace(Args&&...);
+    template<class U, class... Args> T& emplace(initializer_list<U>, Args&&...);
 
     // \ref{optional.swap}, swap
     void swap(optional&) noexcept(@\seebelow@);
@@ -2244,8 +2244,8 @@ template <class T>
     constexpr T& value() &;
     constexpr T&& value() &&;
     constexpr const T&& value() const&&;
-    template <class U> constexpr T value_or(U&&) const&;
-    template <class U> constexpr T value_or(U&&) &&;
+    template<class U> constexpr T value_or(U&&) const&;
+    template<class U> constexpr T value_or(U&&) &&;
 
     // \ref{optional.mod}, modifiers
     void reset() noexcept;
@@ -2352,7 +2352,7 @@ this constructor shall be a \tcode{constexpr} constructor.
 
 \indexlibrary{\idxcode{optional}!constructor}%
 \begin{itemdecl}
-template <class... Args> constexpr explicit optional(in_place_t, Args&&... args);
+template<class... Args> constexpr explicit optional(in_place_t, Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2377,7 +2377,7 @@ unless \tcode{is_constructible_v<T, Args...>} is \tcode{true}.
 
 \indexlibrary{\idxcode{optional}!constructor}%
 \begin{itemdecl}
-template <class U, class... Args>
+template<class U, class... Args>
   constexpr explicit optional(in_place_t, initializer_list<U> il, Args&&... args);
 \end{itemdecl}
 
@@ -2409,7 +2409,7 @@ of which at most one participates in overload resolution.
 
 \indexlibrary{\idxcode{optional}!constructor}%
 \begin{itemdecl}
-template <class U = T> @\EXPLICIT@ constexpr optional(U&& v);
+template<class U = T> @\EXPLICIT@ constexpr optional(U&& v);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2440,7 +2440,7 @@ The constructor is explicit if and only if
 
 \indexlibrary{\idxcode{optional}!constructor}%
 \begin{itemdecl}
-template <class U> @\EXPLICIT@ optional(const optional<U>& rhs);
+template<class U> @\EXPLICIT@ optional(const optional<U>& rhs);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2478,7 +2478,7 @@ The constructor is explicit if and only if
 
 \indexlibrary{\idxcode{optional}!constructor}%
 \begin{itemdecl}
-template <class U> @\EXPLICIT@ optional(optional<U>&& rhs);
+template<class U> @\EXPLICIT@ optional(optional<U>&& rhs);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2650,7 +2650,7 @@ This operator shall not participate in overload resolution unless
 
 \indexlibrarymember{operator=}{optional}%
 \begin{itemdecl}
-template <class U = T> optional<T>& operator=(U&& v);
+template<class U = T> optional<T>& operator=(U&& v);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2678,7 +2678,7 @@ This function shall not participate in overload resolution unless
 
 \indexlibrarymember{operator=}{optional}%
 \begin{itemdecl}
-template <class U> optional<T>& operator=(const optional<U>& rhs);
+template<class U> optional<T>& operator=(const optional<U>& rhs);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2739,7 +2739,7 @@ This function shall not participate in overload resolution unless
 
 \indexlibrarymember{operator=}{optional}%
 \begin{itemdecl}
-template <class U> optional<T>& operator=(optional<U>&& rhs);
+template<class U> optional<T>& operator=(optional<U>&& rhs);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2801,7 +2801,7 @@ This function shall not participate in overload resolution unless
 
 \indexlibrarymember{emplace}{optional}%
 \begin{itemdecl}
-template <class... Args> T& emplace(Args&&... args);
+template<class... Args> T& emplace(Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2832,7 +2832,7 @@ If an exception is thrown during the call to \tcode{T}'s constructor, \tcode{*th
 
 \indexlibrarymember{emplace}{optional}%
 \begin{itemdecl}
-template <class U, class... Args> T& emplace(initializer_list<U> il, Args&&... args);
+template<class U, class... Args> T& emplace(initializer_list<U> il, Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3037,7 +3037,7 @@ return bool(*this) ? std::move(*val) : throw bad_optional_access();
 
 \indexlibrarymember{value_or}{optional}%
 \begin{itemdecl}
-template <class U> constexpr T value_or(U&& v) const&;
+template<class U> constexpr T value_or(U&& v) const&;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3056,7 +3056,7 @@ the program is ill-formed.
 
 \indexlibrarymember{value_or}{optional}%
 \begin{itemdecl}
-template <class U> constexpr T value_or(U&& v) &&;
+template<class U> constexpr T value_or(U&& v) &&;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3142,7 +3142,7 @@ Constructs an object of class \tcode{bad_optional_access}.
 
 \indexlibrarymember{operator==}{optional}%
 \begin{itemdecl}
-template <class T, class U> constexpr bool operator==(const optional<T>& x, const optional<U>& y);
+template<class T, class U> constexpr bool operator==(const optional<T>& x, const optional<U>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3165,7 +3165,7 @@ shall be constexpr functions.
 
 \indexlibrarymember{operator"!=}{optional}%
 \begin{itemdecl}
-template <class T, class U> constexpr bool operator!=(const optional<T>& x, const optional<U>& y);
+template<class T, class U> constexpr bool operator!=(const optional<T>& x, const optional<U>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3189,7 +3189,7 @@ shall be constexpr functions.
 
 \indexlibrarymember{operator<}{optional}%
 \begin{itemdecl}
-template <class T, class U> constexpr bool operator<(const optional<T>& x, const optional<U>& y);
+template<class T, class U> constexpr bool operator<(const optional<T>& x, const optional<U>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3213,7 +3213,7 @@ shall be constexpr functions.
 
 \indexlibrarymember{operator>}{optional}%
 \begin{itemdecl}
-template <class T, class U> constexpr bool operator>(const optional<T>& x, const optional<U>& y);
+template<class T, class U> constexpr bool operator>(const optional<T>& x, const optional<U>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3237,7 +3237,7 @@ shall be constexpr functions.
 
 \indexlibrarymember{operator<=}{optional}%
 \begin{itemdecl}
-template <class T, class U> constexpr bool operator<=(const optional<T>& x, const optional<U>& y);
+template<class T, class U> constexpr bool operator<=(const optional<T>& x, const optional<U>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3261,7 +3261,7 @@ shall be constexpr functions.
 
 \indexlibrarymember{operator>=}{optional}%
 \begin{itemdecl}
-template <class T, class U> constexpr bool operator>=(const optional<T>& x, const optional<U>& y);
+template<class T, class U> constexpr bool operator>=(const optional<T>& x, const optional<U>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3287,8 +3287,8 @@ shall be constexpr functions.
 
 \indexlibrarymember{operator==}{optional}%
 \begin{itemdecl}
-template <class T> constexpr bool operator==(const optional<T>& x, nullopt_t) noexcept;
-template <class T> constexpr bool operator==(nullopt_t, const optional<T>& x) noexcept;
+template<class T> constexpr bool operator==(const optional<T>& x, nullopt_t) noexcept;
+template<class T> constexpr bool operator==(nullopt_t, const optional<T>& x) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3299,8 +3299,8 @@ template <class T> constexpr bool operator==(nullopt_t, const optional<T>& x) no
 
 \indexlibrarymember{operator"!=}{optional}%
 \begin{itemdecl}
-template <class T> constexpr bool operator!=(const optional<T>& x, nullopt_t) noexcept;
-template <class T> constexpr bool operator!=(nullopt_t, const optional<T>& x) noexcept;
+template<class T> constexpr bool operator!=(const optional<T>& x, nullopt_t) noexcept;
+template<class T> constexpr bool operator!=(nullopt_t, const optional<T>& x) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3311,7 +3311,7 @@ template <class T> constexpr bool operator!=(nullopt_t, const optional<T>& x) no
 
 \indexlibrarymember{operator<}{optional}%
 \begin{itemdecl}
-template <class T> constexpr bool operator<(const optional<T>& x, nullopt_t) noexcept;
+template<class T> constexpr bool operator<(const optional<T>& x, nullopt_t) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3322,7 +3322,7 @@ template <class T> constexpr bool operator<(const optional<T>& x, nullopt_t) noe
 
 \indexlibrarymember{operator<}{optional}%
 \begin{itemdecl}
-template <class T> constexpr bool operator<(nullopt_t, const optional<T>& x) noexcept;
+template<class T> constexpr bool operator<(nullopt_t, const optional<T>& x) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3333,7 +3333,7 @@ template <class T> constexpr bool operator<(nullopt_t, const optional<T>& x) noe
 
 \indexlibrarymember{operator<=}{optional}%
 \begin{itemdecl}
-template <class T> constexpr bool operator<=(const optional<T>& x, nullopt_t) noexcept;
+template<class T> constexpr bool operator<=(const optional<T>& x, nullopt_t) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3344,7 +3344,7 @@ template <class T> constexpr bool operator<=(const optional<T>& x, nullopt_t) no
 
 \indexlibrarymember{operator<=}{optional}%
 \begin{itemdecl}
-template <class T> constexpr bool operator<=(nullopt_t, const optional<T>& x) noexcept;
+template<class T> constexpr bool operator<=(nullopt_t, const optional<T>& x) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3355,7 +3355,7 @@ template <class T> constexpr bool operator<=(nullopt_t, const optional<T>& x) no
 
 \indexlibrarymember{operator>}{optional}%
 \begin{itemdecl}
-template <class T> constexpr bool operator>(const optional<T>& x, nullopt_t) noexcept;
+template<class T> constexpr bool operator>(const optional<T>& x, nullopt_t) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3366,7 +3366,7 @@ template <class T> constexpr bool operator>(const optional<T>& x, nullopt_t) noe
 
 \indexlibrarymember{operator>}{optional}%
 \begin{itemdecl}
-template <class T> constexpr bool operator>(nullopt_t, const optional<T>& x) noexcept;
+template<class T> constexpr bool operator>(nullopt_t, const optional<T>& x) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3377,7 +3377,7 @@ template <class T> constexpr bool operator>(nullopt_t, const optional<T>& x) noe
 
 \indexlibrarymember{operator>=}{optional}%
 \begin{itemdecl}
-template <class T> constexpr bool operator>=(const optional<T>& x, nullopt_t) noexcept;
+template<class T> constexpr bool operator>=(const optional<T>& x, nullopt_t) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3388,7 +3388,7 @@ template <class T> constexpr bool operator>=(const optional<T>& x, nullopt_t) no
 
 \indexlibrarymember{operator>=}{optional}%
 \begin{itemdecl}
-template <class T> constexpr bool operator>=(nullopt_t, const optional<T>& x) noexcept;
+template<class T> constexpr bool operator>=(nullopt_t, const optional<T>& x) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3401,7 +3401,7 @@ template <class T> constexpr bool operator>=(nullopt_t, const optional<T>& x) no
 
 \indexlibrarymember{operator==}{optional}%
 \begin{itemdecl}
-template <class T, class U> constexpr bool operator==(const optional<T>& x, const U& v);
+template<class T, class U> constexpr bool operator==(const optional<T>& x, const U& v);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3420,7 +3420,7 @@ Equivalent to: \tcode{return bool(x) ?\ *x == v :\ false;}
 
 \indexlibrarymember{operator==}{optional}%
 \begin{itemdecl}
-template <class T, class U> constexpr bool operator==(const T& v, const optional<U>& x);
+template<class T, class U> constexpr bool operator==(const T& v, const optional<U>& x);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3436,7 +3436,7 @@ Equivalent to: \tcode{return bool(x) ?\ v == *x :\ false;}
 
 \indexlibrarymember{operator"!=}{optional}%
 \begin{itemdecl}
-template <class T, class U> constexpr bool operator!=(const optional<T>& x, const U& v);
+template<class T, class U> constexpr bool operator!=(const optional<T>& x, const U& v);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3452,7 +3452,7 @@ Equivalent to: \tcode{return bool(x) ?\ *x != v :\ true;}
 
 \indexlibrarymember{operator"!=}{optional}%
 \begin{itemdecl}
-template <class T, class U> constexpr bool operator!=(const T& v, const optional<U>& x);
+template<class T, class U> constexpr bool operator!=(const T& v, const optional<U>& x);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3468,7 +3468,7 @@ Equivalent to: \tcode{return bool(x) ?\ v != *x :\ true;}
 
 \indexlibrarymember{operator<}{optional}%
 \begin{itemdecl}
-template <class T, class U> constexpr bool operator<(const optional<T>& x, const U& v);
+template<class T, class U> constexpr bool operator<(const optional<T>& x, const U& v);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3484,7 +3484,7 @@ Equivalent to: \tcode{return bool(x) ?\ *x < v :\ true;}
 
 \indexlibrarymember{operator<}{optional}%
 \begin{itemdecl}
-template <class T, class U> constexpr bool operator<(const T& v, const optional<U>& x);
+template<class T, class U> constexpr bool operator<(const T& v, const optional<U>& x);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3500,7 +3500,7 @@ Equivalent to: \tcode{return bool(x) ?\ v < *x :\ false;}
 
 \indexlibrarymember{operator<=}{optional}%
 \begin{itemdecl}
-template <class T, class U> constexpr bool operator<=(const optional<T>& x, const U& v);
+template<class T, class U> constexpr bool operator<=(const optional<T>& x, const U& v);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3516,7 +3516,7 @@ Equivalent to: \tcode{return bool(x) ?\ *x <= v :\ true;}
 
 \indexlibrarymember{operator<=}{optional}%
 \begin{itemdecl}
-template <class T, class U> constexpr bool operator<=(const T& v, const optional<U>& x);
+template<class T, class U> constexpr bool operator<=(const T& v, const optional<U>& x);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3532,7 +3532,7 @@ Equivalent to: \tcode{return bool(x) ?\ v <= *x :\ false;}
 
 \indexlibrarymember{operator>}{optional}%
 \begin{itemdecl}
-template <class T, class U> constexpr bool operator>(const optional<T>& x, const U& v);
+template<class T, class U> constexpr bool operator>(const optional<T>& x, const U& v);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3548,7 +3548,7 @@ Equivalent to: \tcode{return bool(x) ?\ *x > v :\ false;}
 
 \indexlibrarymember{operator>}{optional}%
 \begin{itemdecl}
-template <class T, class U> constexpr bool operator>(const T& v, const optional<U>& x);
+template<class T, class U> constexpr bool operator>(const T& v, const optional<U>& x);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3564,7 +3564,7 @@ Equivalent to: \tcode{return bool(x) ?\ v > *x :\ true;}
 
 \indexlibrarymember{operator>=}{optional}%
 \begin{itemdecl}
-template <class T, class U> constexpr bool operator>=(const optional<T>& x, const U& v);
+template<class T, class U> constexpr bool operator>=(const optional<T>& x, const U& v);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3580,7 +3580,7 @@ Equivalent to: \tcode{return bool(x) ?\ *x >= v :\ false;}
 
 \indexlibrarymember{operator>=}{optional}%
 \begin{itemdecl}
-template <class T, class U> constexpr bool operator>=(const T& v, const optional<U>& x);
+template<class T, class U> constexpr bool operator>=(const T& v, const optional<U>& x);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3599,7 +3599,7 @@ Equivalent to: \tcode{return bool(x) ?\ v >= *x :\ true;}
 
 \indexlibrary{\idxcode{swap}!\idxcode{optional}}%
 \begin{itemdecl}
-template <class T> void swap(optional<T>& x, optional<T>& y) noexcept(noexcept(x.swap(y)));
+template<class T> void swap(optional<T>& x, optional<T>& y) noexcept(noexcept(x.swap(y)));
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3615,7 +3615,7 @@ unless \tcode{is_move_constructible_v<T>} is \tcode{true} and
 
 \indexlibrary{\idxcode{make_optional}}%
 \begin{itemdecl}
-template <class T> constexpr optional<decay_t<T>> make_optional(T&& v);
+template<class T> constexpr optional<decay_t<T>> make_optional(T&& v);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3626,7 +3626,7 @@ template <class T> constexpr optional<decay_t<T>> make_optional(T&& v);
 
 \indexlibrary{\idxcode{make_optional}}%
 \begin{itemdecl}
-template <class T, class...Args>
+template<class T, class...Args>
   constexpr optional<T> make_optional(Args&&... args);
 \end{itemdecl}
 
@@ -3637,7 +3637,7 @@ template <class T, class...Args>
 
 \indexlibrary{\idxcode{make_optional}}%
 \begin{itemdecl}
-template <class T, class U, class... Args>
+template<class T, class U, class... Args>
   constexpr optional<T> make_optional(initializer_list<U> il, Args&&... args);
 \end{itemdecl}
 
@@ -3650,7 +3650,7 @@ template <class T, class U, class... Args>
 
 \indexlibrary{\idxcode{hash}!\idxcode{optional}}%
 \begin{itemdecl}
-template <class T> struct hash<optional<T>>;
+template<class T> struct hash<optional<T>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3681,84 +3681,84 @@ These template arguments are called alternatives.
 \begin{codeblock}
 namespace std {
   // \ref{variant.variant}, class template \tcode{variant}
-  template <class... Types>
+  template<class... Types>
     class variant;
 
   // \ref{variant.helper}, variant helper classes
-  template <class T> struct variant_size;                   // not defined
-  template <class T> struct variant_size<const T>;
-  template <class T> struct variant_size<volatile T>;
-  template <class T> struct variant_size<const volatile T>;
-  template <class T>
+  template<class T> struct variant_size;                   // not defined
+  template<class T> struct variant_size<const T>;
+  template<class T> struct variant_size<volatile T>;
+  template<class T> struct variant_size<const volatile T>;
+  template<class T>
     inline constexpr size_t variant_size_v = variant_size<T>::value;
 
-  template <class... Types>
+  template<class... Types>
     struct variant_size<variant<Types...>>;
 
-  template <size_t I, class T> struct variant_alternative;  // not defined
-  template <size_t I, class T> struct variant_alternative<I, const T>;
-  template <size_t I, class T> struct variant_alternative<I, volatile T>;
-  template <size_t I, class T> struct variant_alternative<I, const volatile T>;
-  template <size_t I, class T>
+  template<size_t I, class T> struct variant_alternative;  // not defined
+  template<size_t I, class T> struct variant_alternative<I, const T>;
+  template<size_t I, class T> struct variant_alternative<I, volatile T>;
+  template<size_t I, class T> struct variant_alternative<I, const volatile T>;
+  template<size_t I, class T>
     using variant_alternative_t = typename variant_alternative<I, T>::type;
 
-  template <size_t I, class... Types>
+  template<size_t I, class... Types>
     struct variant_alternative<I, variant<Types...>>;
 
   inline constexpr size_t variant_npos = -1;
 
   // \ref{variant.get}, value access
-  template <class T, class... Types>
+  template<class T, class... Types>
     constexpr bool holds_alternative(const variant<Types...>&) noexcept;
 
-  template <size_t I, class... Types>
+  template<size_t I, class... Types>
     constexpr variant_alternative_t<I, variant<Types...>>& get(variant<Types...>&);
-  template <size_t I, class... Types>
+  template<size_t I, class... Types>
     constexpr variant_alternative_t<I, variant<Types...>>&& get(variant<Types...>&&);
-  template <size_t I, class... Types>
+  template<size_t I, class... Types>
     constexpr const variant_alternative_t<I, variant<Types...>>& get(const variant<Types...>&);
-  template <size_t I, class... Types>
+  template<size_t I, class... Types>
     constexpr const variant_alternative_t<I, variant<Types...>>&& get(const variant<Types...>&&);
 
-  template <class T, class... Types>
+  template<class T, class... Types>
     constexpr T& get(variant<Types...>&);
-  template <class T, class... Types>
+  template<class T, class... Types>
     constexpr T&& get(variant<Types...>&&);
-  template <class T, class... Types>
+  template<class T, class... Types>
     constexpr const T& get(const variant<Types...>&);
-  template <class T, class... Types>
+  template<class T, class... Types>
     constexpr const T&& get(const variant<Types...>&&);
 
-  template <size_t I, class... Types>
+  template<size_t I, class... Types>
     constexpr add_pointer_t<variant_alternative_t<I, variant<Types...>>>
       get_if(variant<Types...>*) noexcept;
-  template <size_t I, class... Types>
+  template<size_t I, class... Types>
     constexpr add_pointer_t<const variant_alternative_t<I, variant<Types...>>>
       get_if(const variant<Types...>*) noexcept;
 
-  template <class T, class... Types>
+  template<class T, class... Types>
     constexpr add_pointer_t<T>
       get_if(variant<Types...>*) noexcept;
-  template <class T, class... Types>
+  template<class T, class... Types>
     constexpr add_pointer_t<const T>
       get_if(const variant<Types...>*) noexcept;
 
   // \ref{variant.relops}, relational operators
-  template <class... Types>
+  template<class... Types>
     constexpr bool operator==(const variant<Types...>&, const variant<Types...>&);
-  template <class... Types>
+  template<class... Types>
     constexpr bool operator!=(const variant<Types...>&, const variant<Types...>&);
-  template <class... Types>
+  template<class... Types>
     constexpr bool operator<(const variant<Types...>&, const variant<Types...>&);
-  template <class... Types>
+  template<class... Types>
     constexpr bool operator>(const variant<Types...>&, const variant<Types...>&);
-  template <class... Types>
+  template<class... Types>
     constexpr bool operator<=(const variant<Types...>&, const variant<Types...>&);
-  template <class... Types>
+  template<class... Types>
     constexpr bool operator>=(const variant<Types...>&, const variant<Types...>&);
 
   // \ref{variant.visit}, visitation
-  template <class Visitor, class... Variants>
+  template<class Visitor, class... Variants>
     constexpr @\seebelow@ visit(Visitor&&, Variants&&...);
 
   // \ref{variant.monostate}, class \tcode{monostate}
@@ -3773,16 +3773,16 @@ namespace std {
   constexpr bool operator!=(monostate, monostate) noexcept;
 
   // \ref{variant.specalg}, specialized algorithms
-  template <class... Types>
+  template<class... Types>
     void swap(variant<Types...>&, variant<Types...>&) noexcept(@\seebelow@);
 
   // \ref{variant.bad.access}, class \tcode{bad_variant_access}
   class bad_variant_access;
 
   // \ref{variant.hash}, hash support
-  template <class T> struct hash;
-  template <class... Types> struct hash<variant<Types...>>;
-  template <> struct hash<monostate>;
+  template<class T> struct hash;
+  template<class... Types> struct hash<variant<Types...>>;
+  template<> struct hash<monostate>;
 }
 \end{codeblock}
 
@@ -3791,7 +3791,7 @@ namespace std {
 
 \begin{codeblock}
 namespace std {
-  template <class... Types>
+  template<class... Types>
     class variant {
     public:
       // \ref{variant.ctor}, constructors
@@ -3799,17 +3799,17 @@ namespace std {
       variant(const variant&);
       variant(variant&&) noexcept(@\seebelow@);
 
-      template <class T>
+      template<class T>
         constexpr variant(T&&) noexcept(@\seebelow@);
 
-      template <class T, class... Args>
+      template<class T, class... Args>
         constexpr explicit variant(in_place_type_t<T>, Args&&...);
-      template <class T, class U, class... Args>
+      template<class T, class U, class... Args>
         constexpr explicit variant(in_place_type_t<T>, initializer_list<U>, Args&&...);
 
-      template <size_t I, class... Args>
+      template<size_t I, class... Args>
         constexpr explicit variant(in_place_index_t<I>, Args&&...);
-      template <size_t I, class U, class... Args>
+      template<size_t I, class U, class... Args>
         constexpr explicit variant(in_place_index_t<I>, initializer_list<U>, Args&&...);
 
       // \ref{variant.dtor}, destructor
@@ -3819,16 +3819,16 @@ namespace std {
       variant& operator=(const variant&);
       variant& operator=(variant&&) noexcept(@\seebelow@);
 
-      template <class T> variant& operator=(T&&) noexcept(@\seebelow@);
+      template<class T> variant& operator=(T&&) noexcept(@\seebelow@);
 
       // \ref{variant.mod}, modifiers
-      template <class T, class... Args>
+      template<class T, class... Args>
         T& emplace(Args&&...);
-      template <class T, class U, class... Args>
+      template<class T, class U, class... Args>
         T& emplace(initializer_list<U>, Args&&...);
-      template <size_t I, class... Args>
+      template<size_t I, class... Args>
         variant_alternative_t<I, variant<Types...>>& emplace(Args&&...);
-      template <size_t I, class U, class... Args>
+      template<size_t I, class U, class... Args>
         variant_alternative_t<I, variant<Types...>>& emplace(initializer_list<U>, Args&&...);
 
       // \ref{variant.status}, value status
@@ -3949,7 +3949,7 @@ This function shall not participate in overload resolution unless
 
 \indexlibrary{\idxcode{variant}!constructor}%
 \begin{itemdecl}
-template <class T> constexpr variant(T&& t) noexcept(@\seebelow@);
+template<class T> constexpr variant(T&& t) noexcept(@\seebelow@);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4015,7 +4015,7 @@ this constructor shall be a constexpr constructor.
 
 \indexlibrary{\idxcode{variant}!constructor}%
 \begin{itemdecl}
-template <class T, class... Args> constexpr explicit variant(in_place_type_t<T>, Args&&... args);
+template<class T, class... Args> constexpr explicit variant(in_place_type_t<T>, Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4044,7 +4044,7 @@ constructor shall be a constexpr constructor.
 
 \indexlibrary{\idxcode{variant}!constructor}%
 \begin{itemdecl}
-template <class T, class U, class... Args>
+template<class T, class U, class... Args>
   constexpr explicit variant(in_place_type_t<T>, initializer_list<U> il, Args&&... args);
 \end{itemdecl}
 
@@ -4074,7 +4074,7 @@ constructor shall be a constexpr constructor.
 
 \indexlibrary{\idxcode{variant}!constructor}%
 \begin{itemdecl}
-template <size_t I, class... Args> constexpr explicit variant(in_place_index_t<I>, Args&&... args);
+template<size_t I, class... Args> constexpr explicit variant(in_place_index_t<I>, Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4107,7 +4107,7 @@ constructor shall be a constexpr constructor.
 
 \indexlibrary{\idxcode{variant}!constructor}%
 \begin{itemdecl}
-template <size_t I, class U, class... Args>
+template<size_t I, class U, class... Args>
   constexpr explicit variant(in_place_index_t<I>, initializer_list<U> il, Args&&... args);
 \end{itemdecl}
 
@@ -4244,7 +4244,7 @@ guarantee of $\tcode{T}_j$'s move assignment; \tcode{index()} will be $j$.
 
 \indexlibrarymember{operator=}{variant}%
 \begin{itemdecl}
-template <class T> variant& operator=(T&& t) noexcept(@\seebelow@);
+template<class T> variant& operator=(T&& t) noexcept(@\seebelow@);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4323,7 +4323,7 @@ the \tcode{variant} object might not hold a value.
 
 \indexlibrarymember{emplace}{variant}%
 \begin{itemdecl}
-template <class T, class... Args> T& emplace(Args&&... args);
+template<class T, class... Args> T& emplace(Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4343,7 +4343,7 @@ exactly once in \tcode{Types...}.
 
 \indexlibrarymember{emplace}{variant}%
 \begin{itemdecl}
-template <class T, class U, class... Args> T& emplace(initializer_list<U> il, Args&&... args);
+template<class T, class U, class... Args> T& emplace(initializer_list<U> il, Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4363,7 +4363,7 @@ and \tcode{T} occurs exactly once in \tcode{Types...}.
 
 \indexlibrarymember{emplace}{variant}%
 \begin{itemdecl}
-template <size_t I, class... Args>
+template<size_t I, class... Args>
   variant_alternative_t<I, variant<Types...>>& emplace(Args&&... args);
 \end{itemdecl}
 
@@ -4402,7 +4402,7 @@ the \tcode{variant} might not hold a value.
 
 \indexlibrarymember{emplace}{variant}%
 \begin{itemdecl}
-template <size_t I, class U, class... Args>
+template<size_t I, class U, class... Args>
   variant_alternative_t<I, variant<Types...>>& emplace(initializer_list<U> il, Args&&... args);
 \end{itemdecl}
 
@@ -4526,7 +4526,7 @@ The expression inside \tcode{noexcept} is equivalent to the logical AND of
 
 \indexlibrary{\idxcode{variant_size}}%
 \begin{itemdecl}
-template <class T> struct variant_size;
+template<class T> struct variant_size;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4539,9 +4539,9 @@ with a base characteristic of \tcode{integral_constant<size_t, N>} for some \tco
 
 \indexlibrary{\idxcode{variant_size}}%
 \begin{itemdecl}
-template <class T> class variant_size<const T>;
-template <class T> class variant_size<volatile T>;
-template <class T> class variant_size<const volatile T>;
+template<class T> class variant_size<const T>;
+template<class T> class variant_size<volatile T>;
+template<class T> class variant_size<const volatile T>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4554,16 +4554,16 @@ base characteristic of \tcode{integral_constant<size_t, VS::value>}.
 
 \indexlibrary{\idxcode{variant_size}}%
 \begin{itemdecl}
-template <class... Types>
+template<class... Types>
   struct variant_size<variant<Types...>> : integral_constant<size_t, sizeof...(Types)> { };
 \end{itemdecl}
 % No itemdescr needed for variant_size<variant<Types...>>
 
 \indexlibrary{\idxcode{variant_alternative}}%
 \begin{itemdecl}
-template <size_t I, class T> class variant_alternative<I, const T>;
-template <size_t I, class T> class variant_alternative<I, volatile T>;
-template <size_t I, class T> class variant_alternative<I, const volatile T>;
+template<size_t I, class T> class variant_alternative<I, const T>;
+template<size_t I, class T> class variant_alternative<I, volatile T>;
+template<size_t I, class T> class variant_alternative<I, const volatile T>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4598,7 +4598,7 @@ The program is ill-formed if \tcode{I} is out of bounds.
 \indexlibrary{\idxcode{holds_alternative}}
 \indexlibrary{\idxcode{variant}!\idxcode{holds_alternative}}
 \begin{itemdecl}
-template <class T, class... Types>
+template<class T, class... Types>
   constexpr bool holds_alternative(const variant<Types...>& v) noexcept;
 \end{itemdecl}
 
@@ -4615,13 +4615,13 @@ Otherwise, the program is ill-formed.
 
 \indexlibrarymember{get}{variant}%
 \begin{itemdecl}
-template <size_t I, class... Types>
+template<size_t I, class... Types>
   constexpr variant_alternative_t<I, variant<Types...>>& get(variant<Types...>& v);
-template <size_t I, class... Types>
+template<size_t I, class... Types>
   constexpr variant_alternative_t<I, variant<Types...>>&& get(variant<Types...>&& v);
-template <size_t I, class... Types>
+template<size_t I, class... Types>
   constexpr const variant_alternative_t<I, variant<Types...>>& get(const variant<Types...>& v);
-template <size_t I, class... Types>
+template<size_t I, class... Types>
   constexpr const variant_alternative_t<I, variant<Types...>>&& get(const variant<Types...>&& v);
 \end{itemdecl}
 
@@ -4639,10 +4639,10 @@ the \tcode{variant}. Otherwise, throws an exception of type \tcode{bad_variant_a
 
 \indexlibrarymember{get}{variant}%
 \begin{itemdecl}
-template <class T, class... Types> constexpr T& get(variant<Types...>& v);
-template <class T, class... Types> constexpr T&& get(variant<Types...>&& v);
-template <class T, class... Types> constexpr const T& get(const variant<Types...>& v);
-template <class T, class... Types> constexpr const T&& get(const variant<Types...>&& v);
+template<class T, class... Types> constexpr T& get(variant<Types...>& v);
+template<class T, class... Types> constexpr T&& get(variant<Types...>&& v);
+template<class T, class... Types> constexpr const T& get(const variant<Types...>& v);
+template<class T, class... Types> constexpr const T&& get(const variant<Types...>&& v);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4660,10 +4660,10 @@ Otherwise, throws an exception of type \tcode{bad_variant_access}.
 \indexlibrary{\idxcode{get_if}}%
 \indexlibrary{\idxcode{variant}!\idxcode{get_if}}%
 \begin{itemdecl}
-template <size_t I, class... Types>
+template<size_t I, class... Types>
   constexpr add_pointer_t<variant_alternative_t<I, variant<Types...>>>
     get_if(variant<Types...>* v) noexcept;
-template <size_t I, class... Types>
+template<size_t I, class... Types>
   constexpr add_pointer_t<const variant_alternative_t<I, variant<Types...>>>
     get_if(const variant<Types...>* v) noexcept;
 \end{itemdecl}
@@ -4683,10 +4683,10 @@ and \tcode{v->index() == I}. Otherwise, returns \tcode{nullptr}.
 \indexlibrary{\idxcode{get_if}}%
 \indexlibrary{\idxcode{variant}!\idxcode{get_if}}%
 \begin{itemdecl}
-template <class T, class... Types>
+template<class T, class... Types>
   constexpr add_pointer_t<T>
     get_if(variant<Types...>* v) noexcept;
-template <class T, class... Types>
+template<class T, class... Types>
   constexpr add_pointer_t<const T>
     get_if(const variant<Types...>* v) noexcept;
 \end{itemdecl}
@@ -4707,7 +4707,7 @@ index of \tcode{T} in \tcode{Types...}.
 
 \indexlibrarymember{operator==}{variant}%
 \begin{itemdecl}
-template <class... Types>
+template<class... Types>
   constexpr bool operator==(const variant<Types...>& v, const variant<Types...>& w);
 \end{itemdecl}
 
@@ -4726,7 +4726,7 @@ otherwise \tcode{get<$i$>(v) == get<$i$>(w)} with $i$ being \tcode{v.index()}.
 
 \indexlibrarymember{operator"!=}{variant}%
 \begin{itemdecl}
-template <class... Types>
+template<class... Types>
   constexpr bool operator!=(const variant<Types...>& v, const variant<Types...>& w);
 \end{itemdecl}
 
@@ -4745,7 +4745,7 @@ otherwise \tcode{get<$i$>(v) != get<$i$>(w)} with $i$ being \tcode{v.index()}.
 
 \indexlibrarymember{operator<}{variant}%
 \begin{itemdecl}
-template <class... Types>
+template<class... Types>
   constexpr bool operator<(const variant<Types...>& v, const variant<Types...>& w);
 \end{itemdecl}
 
@@ -4766,7 +4766,7 @@ otherwise \tcode{get<$i$>(v) < get<$i$>(w)} with $i$ being \tcode{v.index()}.
 
 \indexlibrarymember{operator>}{variant}%
 \begin{itemdecl}
-template <class... Types>
+template<class... Types>
   constexpr bool operator>(const variant<Types...>& v, const variant<Types...>& w);
 \end{itemdecl}
 
@@ -4787,7 +4787,7 @@ otherwise \tcode{get<$i$>(v) > get<$i$>(w)} with $i$ being \tcode{v.index()}.
 
 \indexlibrarymember{operator<=}{variant}%
 \begin{itemdecl}
-template <class... Types>
+template<class... Types>
   constexpr bool operator<=(const variant<Types...>& v, const variant<Types...>& w);
 \end{itemdecl}
 
@@ -4808,7 +4808,7 @@ otherwise \tcode{get<$i$>(v) <= get<$i$>(w)} with $i$ being \tcode{v.index()}.
 
 \indexlibrarymember{operator>=}{variant}%
 \begin{itemdecl}
-template <class... Types>
+template<class... Types>
   constexpr bool operator>=(const variant<Types...>& v, const variant<Types...>& w);
 \end{itemdecl}
 
@@ -4832,7 +4832,7 @@ otherwise \tcode{get<$i$>(v) >= get<$i$>(w)} with $i$ being \tcode{v.index()}.
 \indexlibrary{\idxcode{visit}}%
 \indexlibrary{\idxcode{variant}!\idxcode{visit}}%
 \begin{itemdecl}
-template <class Visitor, class... Variants>
+template<class Visitor, class... Variants>
   constexpr @\seebelow@ visit(Visitor&& vis, Variants&&... vars);
 \end{itemdecl}
 
@@ -4906,7 +4906,7 @@ constexpr bool operator!=(monostate, monostate) noexcept { return false; }
 
 \indexlibrary{\idxcode{swap}!\idxcode{variant}}%
 \begin{itemdecl}
-template <class... Types>
+template<class... Types>
   void swap(variant<Types...>& v, variant<Types...>& w) noexcept(@\seebelow@);
 \end{itemdecl}
 
@@ -4960,7 +4960,7 @@ const char* what() const noexcept override;
 
 \indexlibrary{\idxcode{hash}!\idxcode{variant}}%
 \begin{itemdecl}
-template <class... Types> struct hash<variant<Types...>>;
+template<class... Types> struct hash<variant<Types...>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4972,7 +4972,7 @@ The member functions are not guaranteed to be \tcode{noexcept}.
 
 \indexlibrary{\idxcode{hash}!\idxcode{monostate}}%
 \begin{itemdecl}
-template <> struct hash<monostate>;
+template<> struct hash<monostate>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5008,9 +5008,9 @@ namespace std {
   // \ref{any.nonmembers}, non-member functions
   void swap(any& x, any& y) noexcept;
 
-  template <class T, class... Args>
+  template<class T, class... Args>
     any make_any(Args&& ...args);
-  template <class T, class U, class... Args>
+  template<class T, class U, class... Args>
     any make_any(initializer_list<U> il, Args&& ...args);
 
   template<class T>
@@ -5066,11 +5066,11 @@ public:
   any(const any& other);
   any(any&& other) noexcept;
 
-  template <class T> any(T&& value);
+  template<class T> any(T&& value);
 
-  template <class T, class... Args>
+  template<class T, class... Args>
     explicit any(in_place_type_t<T>, Args&&...);
-  template <class T, class U, class... Args>
+  template<class T, class U, class... Args>
     explicit any(in_place_type_t<T>, initializer_list<U>, Args&&...);
 
   ~any();
@@ -5079,12 +5079,12 @@ public:
   any& operator=(const any& rhs);
   any& operator=(any&& rhs) noexcept;
 
-  template <class T> any& operator=(T&& rhs);
+  template<class T> any& operator=(T&& rhs);
 
   // \ref{any.modifiers}, modifiers
-  template <class T, class... Args>
+  template<class T, class... Args>
     decay_t<T>& emplace(Args&& ...);
-  template <class T, class U, class... Args>
+  template<class T, class U, class... Args>
     decay_t<T>& emplace(initializer_list<U>, Args&&...);
   void reset() noexcept;
   void swap(any& rhs) noexcept;
@@ -5193,7 +5193,7 @@ Any exception thrown by the selected constructor of \tcode{VT}.
 
 \indexlibrary{\idxcode{any}!constructor}%
 \begin{itemdecl}
-template <class T, class... Args>
+template<class T, class... Args>
   explicit any(in_place_type_t<T>, Args&&... args);
 \end{itemdecl}
 
@@ -5223,7 +5223,7 @@ This constructor shall not participate in overload resolution unless
 
 \indexlibrary{\idxcode{any}!constructor}%
 \begin{itemdecl}
-template <class T, class U, class... Args>
+template<class T, class U, class... Args>
   explicit any(in_place_type_t<T>, initializer_list<U> il, Args&&... args);
 \end{itemdecl}
 
@@ -5342,7 +5342,7 @@ Any exception thrown by the selected constructor of \tcode{VT}.
 
 \indexlibrarymember{emplace}{any}%
 \begin{itemdecl}
-template <class T, class... Args>
+template<class T, class... Args>
   decay_t<T>& emplace(Args&&... args);
 \end{itemdecl}
 
@@ -5380,7 +5380,7 @@ This function shall not participate in overload resolution unless
 
 \indexlibrarymember{emplace}{any}%
 \begin{itemdecl}
-template <class T, class U, class... Args>
+template<class T, class U, class... Args>
   decay_t<T>& emplace(initializer_list<U> il, Args&&... args);
 \end{itemdecl}
 
@@ -5488,7 +5488,7 @@ As if by \tcode{x.swap(y)}.
 
 \indexlibrary{\idxcode{make_any}}%
 \begin{itemdecl}
-template <class T, class... Args>
+template<class T, class... Args>
   any make_any(Args&& ...args);
 \end{itemdecl}
 
@@ -5500,7 +5500,7 @@ Equivalent to: \tcode{return any(in_place_type<T>, std::forward<Args>(args)...);
 
 \indexlibrary{\idxcode{make_any}}%
 \begin{itemdecl}
-template <class T, class U, class... Args>
+template<class T, class U, class... Args>
   any make_any(initializer_list<U> il, Args&& ...args);
 \end{itemdecl}
 
@@ -5607,19 +5607,19 @@ bool is_string(const any& operand) {
 #include <iosfwd>   // for \tcode{istream}\iref{istream.syn}, \tcode{ostream}\iref{ostream.syn}, see \ref{iosfwd.syn}
 
 namespace std {
-  template <size_t N> class bitset;
+  template<size_t N> class bitset;
 
   // \ref{bitset.operators}, bitset operators
-  template <size_t N>
+  template<size_t N>
     bitset<N> operator&(const bitset<N>&, const bitset<N>&) noexcept;
-  template <size_t N>
+  template<size_t N>
     bitset<N> operator|(const bitset<N>&, const bitset<N>&) noexcept;
-  template <size_t N>
+  template<size_t N>
     bitset<N> operator^(const bitset<N>&, const bitset<N>&) noexcept;
-  template <class charT, class traits, size_t N>
+  template<class charT, class traits, size_t N>
     basic_istream<charT, traits>&
       operator>>(basic_istream<charT, traits>& is, bitset<N>& x);
-  template <class charT, class traits, size_t N>
+  template<class charT, class traits, size_t N>
     basic_ostream<charT, traits>&
       operator<<(basic_ostream<charT, traits>& os, const bitset<N>& x);
 }
@@ -5664,7 +5664,7 @@ namespace std {
           = basic_string<charT, traits, Allocator>::npos,
         charT zero = charT('0'),
         charT one = charT('1'));
-    template <class charT>
+    template<class charT>
       explicit bitset(
         const charT* str,
         typename basic_string<charT>::size_type n = basic_string<charT>::npos,
@@ -5691,7 +5691,7 @@ namespace std {
 
     unsigned long to_ulong() const;
     unsigned long long to_ullong() const;
-    template <class charT = char,
+    template<class charT = char,
               class traits = char_traits<charT>,
               class Allocator = allocator<charT>>
       basic_string<charT, traits, Allocator>
@@ -5710,8 +5710,8 @@ namespace std {
   };
 
   // \ref{bitset.hash}, hash support
-  template <class T> struct hash;
-  template <size_t N> struct hash<bitset<N>>;
+  template<class T> struct hash;
+  template<size_t N> struct hash<bitset<N>>;
 }
 \end{codeblock}
 
@@ -5797,7 +5797,7 @@ If \tcode{M < N}, the remaining bit positions are initialized to zero.
 
 \indexlibrary{\idxcode{bitset}!constructor}%
 \begin{itemdecl}
-template <class charT, class traits, class Allocator>
+template<class charT, class traits, class Allocator>
   explicit bitset(
     const basic_string<charT, traits, Allocator>& str,
     typename basic_string<charT, traits, Allocator>::size_type pos = 0,
@@ -5853,7 +5853,7 @@ If \tcode{M < N}, remaining bit positions are initialized to zero.
 
 \indexlibrary{\idxcode{bitset}!constructor}%
 \begin{itemdecl}
-template <class charT>
+template<class charT>
   explicit bitset(
     const charT* str,
     typename basic_string<charT>::size_type n = basic_string<charT>::npos,
@@ -6153,7 +6153,7 @@ cannot be represented as type
 
 \indexlibrarymember{to_string}{bitset}%
 \begin{itemdecl}
-template <class charT = char,
+template<class charT = char,
           class traits = char_traits<charT>,
           class Allocator = allocator<charT>>
   basic_string<charT, traits, Allocator>
@@ -6355,7 +6355,7 @@ underlying bitset.
 
 \indexlibrary{\idxcode{hash_code}}%
 \begin{itemdecl}
-template <size_t N> struct hash<bitset<N>>;
+template<size_t N> struct hash<bitset<N>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6400,7 +6400,7 @@ bitset<N> operator^(const bitset<N>& lhs, const bitset<N>& rhs) noexcept;
 
 \indexlibrarymember{operator>>}{bitset}%
 \begin{itemdecl}
-template <class charT, class traits, size_t N>
+template<class charT, class traits, size_t N>
   basic_istream<charT, traits>&
     operator>>(basic_istream<charT, traits>& is, bitset<N>& x);
 \end{itemdecl}
@@ -6445,7 +6445,7 @@ If no characters are stored in \tcode{str}, calls
 
 \indexlibrarymember{operator<<}{bitset}%
 \begin{itemdecl}
-template <class charT, class traits, size_t N>
+template<class charT, class traits, size_t N>
   basic_ostream<charT, traits>&
     operator<<(basic_ostream<charT, traits>& os, const bitset<N>& x);
 \end{itemdecl}
@@ -6487,19 +6487,19 @@ templates that operate on objects of these types\iref{smartptr}.
 \begin{codeblock}
 namespace std {
   // \ref{pointer.traits}, pointer traits
-  template <class Ptr> struct pointer_traits;
-  template <class T> struct pointer_traits<T*>;
+  template<class Ptr> struct pointer_traits;
+  template<class T> struct pointer_traits<T*>;
 
   // \ref{pointer.conversion}, pointer conversion
-  template <class Ptr>
+  template<class Ptr>
     auto to_address(const Ptr& p) noexcept;
-  template <class T>
+  template<class T>
     constexpr T* to_address(T* p) noexcept;
 
   // \ref{util.dynamic.safety}, pointer safety
   enum class pointer_safety { relaxed, preferred, strict };
   void declare_reachable(void* p);
-  template <class T>
+  template<class T>
     T* undeclare_reachable(T* p);
   void declare_no_pointers(char* p, size_t n);
   void undeclare_no_pointers(char* p, size_t n);
@@ -6513,146 +6513,146 @@ namespace std {
   inline constexpr allocator_arg_t allocator_arg{};
 
   // \ref{allocator.uses}, \tcode{uses_allocator}
-  template <class T, class Alloc> struct uses_allocator;
+  template<class T, class Alloc> struct uses_allocator;
 
   // \ref{allocator.traits}, allocator traits
-  template <class Alloc> struct allocator_traits;
+  template<class Alloc> struct allocator_traits;
 
   // \ref{default.allocator}, the default allocator
-  template <class T> class allocator;
-  template <class T, class U>
+  template<class T> class allocator;
+  template<class T, class U>
     bool operator==(const allocator<T>&, const allocator<U>&) noexcept;
-  template <class T, class U>
+  template<class T, class U>
     bool operator!=(const allocator<T>&, const allocator<U>&) noexcept;
 
   // \ref{specialized.algorithms}, specialized algorithms
-  template <class T>
+  template<class T>
     constexpr T* addressof(T& r) noexcept;
-  template <class T>
+  template<class T>
     const T* addressof(const T&&) = delete;
-  template <class ForwardIterator>
+  template<class ForwardIterator>
     void uninitialized_default_construct(ForwardIterator first, ForwardIterator last);
-  template <class ExecutionPolicy, class ForwardIterator>
+  template<class ExecutionPolicy, class ForwardIterator>
     void uninitialized_default_construct(ExecutionPolicy&& exec, // see \ref{algorithms.parallel.overloads}
                                          ForwardIterator first, ForwardIterator last);
-  template <class ForwardIterator, class Size>
+  template<class ForwardIterator, class Size>
     ForwardIterator uninitialized_default_construct_n(ForwardIterator first, Size n);
-  template <class ExecutionPolicy, class ForwardIterator, class Size>
+  template<class ExecutionPolicy, class ForwardIterator, class Size>
     ForwardIterator uninitialized_default_construct_n(ExecutionPolicy&& exec, // see \ref{algorithms.parallel.overloads}
                                                       ForwardIterator first, Size n);
-  template <class ForwardIterator>
+  template<class ForwardIterator>
     void uninitialized_value_construct(ForwardIterator first, ForwardIterator last);
-  template <class ExecutionPolicy, class ForwardIterator>
+  template<class ExecutionPolicy, class ForwardIterator>
     void uninitialized_value_construct(ExecutionPolicy&& exec, // see \ref{algorithms.parallel.overloads}
                                        ForwardIterator first, ForwardIterator last);
-  template <class ForwardIterator, class Size>
+  template<class ForwardIterator, class Size>
     ForwardIterator uninitialized_value_construct_n(ForwardIterator first, Size n);
-  template <class ExecutionPolicy, class ForwardIterator, class Size>
+  template<class ExecutionPolicy, class ForwardIterator, class Size>
     ForwardIterator uninitialized_value_construct_n(ExecutionPolicy&& exec, // see \ref{algorithms.parallel.overloads}
                                                     ForwardIterator first, Size n);
-  template <class InputIterator, class ForwardIterator>
+  template<class InputIterator, class ForwardIterator>
     ForwardIterator uninitialized_copy(InputIterator first, InputIterator last,
                                        ForwardIterator result);
-  template <class ExecutionPolicy, class InputIterator, class ForwardIterator>
+  template<class ExecutionPolicy, class InputIterator, class ForwardIterator>
     ForwardIterator uninitialized_copy(ExecutionPolicy&& exec, // see \ref{algorithms.parallel.overloads}
                                        InputIterator first, InputIterator last,
                                        ForwardIterator result);
-  template <class InputIterator, class Size, class ForwardIterator>
+  template<class InputIterator, class Size, class ForwardIterator>
     ForwardIterator uninitialized_copy_n(InputIterator first, Size n,
                                          ForwardIterator result);
-  template <class ExecutionPolicy, class InputIterator, class Size, class ForwardIterator>
+  template<class ExecutionPolicy, class InputIterator, class Size, class ForwardIterator>
     ForwardIterator uninitialized_copy_n(ExecutionPolicy&& exec, // see \ref{algorithms.parallel.overloads}
                                          InputIterator first, Size n,
                                          ForwardIterator result);
-  template <class InputIterator, class ForwardIterator>
+  template<class InputIterator, class ForwardIterator>
     ForwardIterator uninitialized_move(InputIterator first, InputIterator last,
                                        ForwardIterator result);
-  template <class ExecutionPolicy, class InputIterator, class ForwardIterator>
+  template<class ExecutionPolicy, class InputIterator, class ForwardIterator>
     ForwardIterator uninitialized_move(ExecutionPolicy&& exec, // see \ref{algorithms.parallel.overloads}
                                        InputIterator first, InputIterator last,
                                        ForwardIterator result);
-  template <class InputIterator, class Size, class ForwardIterator>
+  template<class InputIterator, class Size, class ForwardIterator>
     pair<InputIterator, ForwardIterator> uninitialized_move_n(InputIterator first, Size n,
                                                               ForwardIterator result);
-  template <class ExecutionPolicy, class InputIterator, class Size, class ForwardIterator>
+  template<class ExecutionPolicy, class InputIterator, class Size, class ForwardIterator>
     pair<InputIterator, ForwardIterator> uninitialized_move_n(ExecutionPolicy&& exec, // see \ref{algorithms.parallel.overloads}
                                                               InputIterator first, Size n,
                                                               ForwardIterator result);
-  template <class ForwardIterator, class T>
+  template<class ForwardIterator, class T>
     void uninitialized_fill(ForwardIterator first, ForwardIterator last, const T& x);
-  template <class ExecutionPolicy, class ForwardIterator, class T>
+  template<class ExecutionPolicy, class ForwardIterator, class T>
     void uninitialized_fill(ExecutionPolicy&& exec, // see \ref{algorithms.parallel.overloads}
                             ForwardIterator first, ForwardIterator last, const T& x);
-  template <class ForwardIterator, class Size, class T>
+  template<class ForwardIterator, class Size, class T>
     ForwardIterator uninitialized_fill_n(ForwardIterator first, Size n, const T& x);
-  template <class ExecutionPolicy, class ForwardIterator, class Size, class T>
+  template<class ExecutionPolicy, class ForwardIterator, class Size, class T>
     ForwardIterator uninitialized_fill_n(ExecutionPolicy&& exec, // see \ref{algorithms.parallel.overloads}
                                          ForwardIterator first, Size n, const T& x);
-  template <class T>
+  template<class T>
     void destroy_at(T* location);
-  template <class ForwardIterator>
+  template<class ForwardIterator>
     void destroy(ForwardIterator first, ForwardIterator last);
-  template <class ExecutionPolicy, class ForwardIterator>
+  template<class ExecutionPolicy, class ForwardIterator>
     void destroy(ExecutionPolicy&& exec, // see \ref{algorithms.parallel.overloads}
                  ForwardIterator first, ForwardIterator last);
-  template <class ForwardIterator, class Size>
+  template<class ForwardIterator, class Size>
     ForwardIterator destroy_n(ForwardIterator first, Size n);
-  template <class ExecutionPolicy, class ForwardIterator, class Size>
+  template<class ExecutionPolicy, class ForwardIterator, class Size>
     ForwardIterator destroy_n(ExecutionPolicy&& exec, // see \ref{algorithms.parallel.overloads}
                               ForwardIterator first, Size n);
 
   // \ref{unique.ptr}, class template \tcode{unique_ptr}
-  template <class T> struct default_delete;
-  template <class T> struct default_delete<T[]>;
-  template <class T, class D = default_delete<T>> class unique_ptr;
-  template <class T, class D> class unique_ptr<T[], D>;
+  template<class T> struct default_delete;
+  template<class T> struct default_delete<T[]>;
+  template<class T, class D = default_delete<T>> class unique_ptr;
+  template<class T, class D> class unique_ptr<T[], D>;
 
-  template <class T, class... Args> unique_ptr<T>
+  template<class T, class... Args> unique_ptr<T>
     make_unique(Args&&... args);                                                // \tcode{T} is not array
-  template <class T> unique_ptr<T>
+  template<class T> unique_ptr<T>
     make_unique(size_t n);                                                      // \tcode{T} is \tcode{U[]}
-  template <class T, class... Args>
+  template<class T, class... Args>
     @\unspecnc@ make_unique(Args&&...) = delete;                                // \tcode{T} is \tcode{U[N]}
 
-  template <class T, class D>
+  template<class T, class D>
     void swap(unique_ptr<T, D>& x, unique_ptr<T, D>& y) noexcept;
 
-  template <class T1, class D1, class T2, class D2>
+  template<class T1, class D1, class T2, class D2>
     bool operator==(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
-  template <class T1, class D1, class T2, class D2>
+  template<class T1, class D1, class T2, class D2>
     bool operator!=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
-  template <class T1, class D1, class T2, class D2>
+  template<class T1, class D1, class T2, class D2>
     bool operator<(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
-  template <class T1, class D1, class T2, class D2>
+  template<class T1, class D1, class T2, class D2>
     bool operator<=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
-  template <class T1, class D1, class T2, class D2>
+  template<class T1, class D1, class T2, class D2>
     bool operator>(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
-  template <class T1, class D1, class T2, class D2>
+  template<class T1, class D1, class T2, class D2>
     bool operator>=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
 
-  template <class T, class D>
+  template<class T, class D>
     bool operator==(const unique_ptr<T, D>& x, nullptr_t) noexcept;
-  template <class T, class D>
+  template<class T, class D>
     bool operator==(nullptr_t, const unique_ptr<T, D>& y) noexcept;
-  template <class T, class D>
+  template<class T, class D>
     bool operator!=(const unique_ptr<T, D>& x, nullptr_t) noexcept;
-  template <class T, class D>
+  template<class T, class D>
     bool operator!=(nullptr_t, const unique_ptr<T, D>& y) noexcept;
-  template <class T, class D>
+  template<class T, class D>
     bool operator<(const unique_ptr<T, D>& x, nullptr_t);
-  template <class T, class D>
+  template<class T, class D>
     bool operator<(nullptr_t, const unique_ptr<T, D>& y);
-  template <class T, class D>
+  template<class T, class D>
     bool operator<=(const unique_ptr<T, D>& x, nullptr_t);
-  template <class T, class D>
+  template<class T, class D>
     bool operator<=(nullptr_t, const unique_ptr<T, D>& y);
-  template <class T, class D>
+  template<class T, class D>
     bool operator>(const unique_ptr<T, D>& x, nullptr_t);
-  template <class T, class D>
+  template<class T, class D>
     bool operator>(nullptr_t, const unique_ptr<T, D>& y);
-  template <class T, class D>
+  template<class T, class D>
     bool operator>=(const unique_ptr<T, D>& x, nullptr_t);
-  template <class T, class D>
+  template<class T, class D>
     bool operator>=(nullptr_t, const unique_ptr<T, D>& y);
 
   template<class E, class T, class Y, class D>
@@ -6705,29 +6705,29 @@ namespace std {
   template<class T, class U>
     bool operator>=(const shared_ptr<T>& a, const shared_ptr<U>& b) noexcept;
 
-  template <class T>
+  template<class T>
     bool operator==(const shared_ptr<T>& x, nullptr_t) noexcept;
-  template <class T>
+  template<class T>
     bool operator==(nullptr_t, const shared_ptr<T>& y) noexcept;
-  template <class T>
+  template<class T>
     bool operator!=(const shared_ptr<T>& x, nullptr_t) noexcept;
-  template <class T>
+  template<class T>
     bool operator!=(nullptr_t, const shared_ptr<T>& y) noexcept;
-  template <class T>
+  template<class T>
     bool operator<(const shared_ptr<T>& x, nullptr_t) noexcept;
-  template <class T>
+  template<class T>
     bool operator<(nullptr_t, const shared_ptr<T>& y) noexcept;
-  template <class T>
+  template<class T>
     bool operator<=(const shared_ptr<T>& x, nullptr_t) noexcept;
-  template <class T>
+  template<class T>
     bool operator<=(nullptr_t, const shared_ptr<T>& y) noexcept;
-  template <class T>
+  template<class T>
     bool operator>(const shared_ptr<T>& x, nullptr_t) noexcept;
-  template <class T>
+  template<class T>
     bool operator>(nullptr_t, const shared_ptr<T>& y) noexcept;
-  template <class T>
+  template<class T>
     bool operator>=(const shared_ptr<T>& x, nullptr_t) noexcept;
-  template <class T>
+  template<class T>
     bool operator>=(nullptr_t, const shared_ptr<T>& y) noexcept;
 
   // \ref{util.smartptr.shared.spec}, \tcode{shared_ptr} specialized algorithms
@@ -6765,16 +6765,16 @@ namespace std {
   template<class T> class enable_shared_from_this;
 
   // \ref{util.smartptr.hash}, hash support
-  template <class T> struct hash;
-  template <class T, class D> struct hash<unique_ptr<T, D>>;
-  template <class T> struct hash<shared_ptr<T>>;
+  template<class T> struct hash;
+  template<class T, class D> struct hash<unique_ptr<T, D>>;
+  template<class T> struct hash<shared_ptr<T>>;
 
   // \ref{util.smartptr.atomic}, atomic smart pointers
-  template <class T> struct atomic<shared_ptr<T>>;
-  template <class T> struct atomic<weak_ptr<T>>;
+  template<class T> struct atomic<shared_ptr<T>>;
+  template<class T> struct atomic<weak_ptr<T>>;
 
   // \ref{allocator.uses.trait}, \tcode{uses_allocator}
-  template <class T, class Alloc>
+  template<class T, class Alloc>
     inline constexpr bool uses_allocator_v = uses_allocator<T, Alloc>::value;
 }
 \end{codeblock}
@@ -6788,22 +6788,22 @@ attributes of pointer-like types.
 \indexlibrary{\idxcode{pointer_traits}}%
 \begin{codeblock}
 namespace std {
-  template <class Ptr> struct pointer_traits {
+  template<class Ptr> struct pointer_traits {
     using pointer         = Ptr;
     using element_type    = @\seebelow@;
     using difference_type = @\seebelow@;
 
-    template <class U> using rebind = @\seebelow@;
+    template<class U> using rebind = @\seebelow@;
 
     static pointer pointer_to(@\seebelow@ r);
   };
 
-  template <class T> struct pointer_traits<T*> {
+  template<class T> struct pointer_traits<T*> {
     using pointer         = T*;
     using element_type    = T;
     using difference_type = ptrdiff_t;
 
-    template <class U> using rebind = U*;
+    template<class U> using rebind = U*;
 
     static pointer pointer_to(@\seebelow@ r) noexcept;
   };
@@ -6842,7 +6842,7 @@ type\iref{temp.deduct}; otherwise,
 
 \indexlibrarymember{rebind}{pointer_traits}%
 \begin{itemdecl}
-template <class U> using rebind = @\seebelow@;
+template<class U> using rebind = @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6907,7 +6907,7 @@ the non-member function
 
 \indexlibrary{\idxcode{to_address}}%
 \begin{itemdecl}
-template <class Ptr> auto to_address(const Ptr& p) noexcept;
+template<class Ptr> auto to_address(const Ptr& p) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6920,7 +6920,7 @@ otherwise \tcode{to_address(p.operator->())}.
 
 \indexlibrary{\idxcode{to_address}}%
 \begin{itemdecl}
-template <class T> constexpr T* to_address(T* p) noexcept;
+template<class T> constexpr T* to_address(T* p) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6960,7 +6960,7 @@ additional memory that may be required to track objects declared reachable.
 
 \indexlibrary{\idxcode{undeclare_reachable}}%
 \begin{itemdecl}
-template <class T> T* undeclare_reachable(T* p);
+template<class T> T* undeclare_reachable(T* p);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7115,7 +7115,7 @@ argument, immediately followed by an argument of a type that satisfies the
 
 \indexlibrary{\idxcode{uses_allocator}}%
 \begin{itemdecl}
-template <class T, class Alloc> struct uses_allocator;
+template<class T, class Alloc> struct uses_allocator;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7179,7 +7179,7 @@ a derived class from an allocator. \end{note}
 \indexlibrary{\idxcode{allocator_traits}}%
 \begin{codeblock}
 namespace std {
-  template <class Alloc> struct allocator_traits {
+  template<class Alloc> struct allocator_traits {
     using allocator_type     = Alloc;
 
     using value_type         = typename Alloc::value_type;
@@ -7197,18 +7197,18 @@ namespace std {
     using propagate_on_container_swap            = @\seebelow@;
     using is_always_equal                        = @\seebelow@;
 
-    template <class T> using rebind_alloc = @\seebelow@;
-    template <class T> using rebind_traits = allocator_traits<rebind_alloc<T>>;
+    template<class T> using rebind_alloc = @\seebelow@;
+    template<class T> using rebind_traits = allocator_traits<rebind_alloc<T>>;
 
     [[nodiscard]] static pointer allocate(Alloc& a, size_type n);
     [[nodiscard]] static pointer allocate(Alloc& a, size_type n, const_void_pointer hint);
 
     static void deallocate(Alloc& a, pointer p, size_type n);
 
-    template <class T, class... Args>
+    template<class T, class... Args>
       static void construct(Alloc& a, T* p, Args&&... args);
 
-    template <class T>
+    template<class T>
       static void destroy(Alloc& a, T* p);
 
     static size_type max_size(const Alloc& a) noexcept;
@@ -7351,7 +7351,7 @@ otherwise \tcode{is_empty<Alloc>::type}.
 
 \indexlibrarymember{rebind_alloc}{allocator_traits}%
 \begin{itemdecl}
-template <class T> using rebind_alloc = @\seebelow@;
+template<class T> using rebind_alloc = @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7401,7 +7401,7 @@ static void deallocate(Alloc& a, pointer p, size_type n);
 
 \indexlibrarymember{construct}{allocator_traits}%
 \begin{itemdecl}
-template <class T, class... Args>
+template<class T, class... Args>
   static void construct(Alloc& a, T* p, Args&&... args);
 \end{itemdecl}
 
@@ -7414,7 +7414,7 @@ otherwise, invokes \tcode{::new (static_cast<void*>(p)) T(std::forward<Args>(arg
 
 \indexlibrarymember{destroy}{allocator_traits}%
 \begin{itemdecl}
-template <class T>
+template<class T>
   static void destroy(Alloc& a, T* p);
 \end{itemdecl}
 
@@ -7458,7 +7458,7 @@ allocator completeness requirements\iref{allocator.requirements.completeness}.
 \indexlibrarymember{is_always_equal}{allocator}%
 \begin{codeblock}
 namespace std {
-  template <class T> class allocator {
+  template<class T> class allocator {
    public:
     using value_type      = T;
     using propagate_on_container_move_assignment = true_type;
@@ -7466,7 +7466,7 @@ namespace std {
 
     allocator() noexcept;
     allocator(const allocator&) noexcept;
-    template <class U> allocator(const allocator<U>&) noexcept;
+    template<class U> allocator(const allocator<U>&) noexcept;
     ~allocator();
 
     [[nodiscard]] T* allocate(size_t n);
@@ -7534,7 +7534,7 @@ when this function is called.
 
 \indexlibrarymember{operator==}{allocator}%
 \begin{itemdecl}
-template <class T, class U>
+template<class T, class U>
   bool operator==(const allocator<T>&, const allocator<U>&) noexcept;
 \end{itemdecl}
 
@@ -7546,7 +7546,7 @@ template <class T, class U>
 
 \indexlibrarymember{operator"!=}{allocator}%
 \begin{itemdecl}
-template <class T, class U>
+template<class T, class U>
   bool operator!=(const allocator<T>&, const allocator<U>&) noexcept;
 \end{itemdecl}
 
@@ -7580,7 +7580,7 @@ if an exception is thrown in the following algorithms there are no effects.
 
 \indexlibrary{\idxcode{addressof}}%
 \begin{itemdecl}
-template <class T> constexpr T* addressof(T& r) noexcept;
+template<class T> constexpr T* addressof(T& r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7598,7 +7598,7 @@ if \tcode{E} is an lvalue constant subexpression.
 
 \indexlibrary{\idxcode{uninitialized_default_construct}}%
 \begin{itemdecl}
-template <class ForwardIterator>
+template<class ForwardIterator>
   void uninitialized_default_construct(ForwardIterator first, ForwardIterator last);
 \end{itemdecl}
 
@@ -7615,7 +7615,7 @@ for (; first != last; ++first)
 
 \indexlibrary{\idxcode{uninitialized_default_construct_n}}%
 \begin{itemdecl}
-template <class ForwardIterator, class Size>
+template<class ForwardIterator, class Size>
   ForwardIterator uninitialized_default_construct_n(ForwardIterator first, Size n);
 \end{itemdecl}
 
@@ -7635,7 +7635,7 @@ return first;
 
 \indexlibrary{\idxcode{uninitialized_value_construct}}%
 \begin{itemdecl}
-template <class ForwardIterator>
+template<class ForwardIterator>
   void uninitialized_value_construct(ForwardIterator first, ForwardIterator last);
 \end{itemdecl}
 
@@ -7652,7 +7652,7 @@ for (; first != last; ++first)
 
 \indexlibrary{\idxcode{uninitialized_value_construct_n}}%
 \begin{itemdecl}
-template <class ForwardIterator, class Size>
+template<class ForwardIterator, class Size>
   ForwardIterator uninitialized_value_construct_n(ForwardIterator first, Size n);
 \end{itemdecl}
 
@@ -7672,7 +7672,7 @@ return first;
 
 \indexlibrary{\idxcode{uninitialized_copy}}%
 \begin{itemdecl}
-template <class InputIterator, class ForwardIterator>
+template<class InputIterator, class ForwardIterator>
   ForwardIterator uninitialized_copy(InputIterator first, InputIterator last,
                                      ForwardIterator result);
 \end{itemdecl}
@@ -7694,7 +7694,7 @@ for (; first != last; ++result, (void) ++first)
 
 \indexlibrary{\idxcode{uninitialized_copy_n}}%
 \begin{itemdecl}
-template <class InputIterator, class Size, class ForwardIterator>
+template<class InputIterator, class Size, class ForwardIterator>
   ForwardIterator uninitialized_copy_n(InputIterator first, Size n, ForwardIterator result);
 \end{itemdecl}
 
@@ -7717,7 +7717,7 @@ for ( ; n > 0; ++result, (void) ++first, --n) {
 
 \indexlibrary{\idxcode{uninitialized_move}}%
 \begin{itemdecl}
-template <class InputIterator, class ForwardIterator>
+template<class InputIterator, class ForwardIterator>
   ForwardIterator uninitialized_move(InputIterator first, InputIterator last,
                                      ForwardIterator result);
 \end{itemdecl}
@@ -7741,7 +7741,7 @@ are left in a valid but unspecified state.
 
 \indexlibrary{\idxcode{uninitialized_move_n}}%
 \begin{itemdecl}
-template <class InputIterator, class Size, class ForwardIterator>
+template<class InputIterator, class Size, class ForwardIterator>
   pair<InputIterator, ForwardIterator>
     uninitialized_move_n(InputIterator first, Size n, ForwardIterator result);
 \end{itemdecl}
@@ -7767,7 +7767,7 @@ are left in a valid but unspecified state.
 
 \indexlibrary{\idxcode{uninitialized_fill}}%
 \begin{itemdecl}
-template <class ForwardIterator, class T>
+template<class ForwardIterator, class T>
   void uninitialized_fill(ForwardIterator first, ForwardIterator last, const T& x);
 \end{itemdecl}
 
@@ -7784,7 +7784,7 @@ for (; first != last; ++first)
 
 \indexlibrary{\idxcode{uninitialized_fill_n}}%
 \begin{itemdecl}
-template <class ForwardIterator, class Size, class T>
+template<class ForwardIterator, class Size, class T>
   ForwardIterator uninitialized_fill_n(ForwardIterator first, Size n, const T& x);
 \end{itemdecl}
 
@@ -7804,7 +7804,7 @@ return first;
 
 \indexlibrary{\idxcode{destroy_at}}%
 \begin{itemdecl}
-template <class T>
+template<class T>
   void destroy_at(T* location);
 \end{itemdecl}
 
@@ -7819,7 +7819,7 @@ location->~T();
 
 \indexlibrary{\idxcode{destroy}}%
 \begin{itemdecl}
-template <class ForwardIterator>
+template<class ForwardIterator>
   void destroy(ForwardIterator first, ForwardIterator last);
 \end{itemdecl}
 
@@ -7835,7 +7835,7 @@ for (; first!=last; ++first)
 
 \indexlibrary{\idxcode{destroy_n}}%
 \begin{itemdecl}
-template <class ForwardIterator, class Size>
+template<class ForwardIterator, class Size>
   ForwardIterator destroy_n(ForwardIterator first, Size n);
 \end{itemdecl}
 
@@ -7989,9 +7989,9 @@ an incomplete type.
 
 \begin{codeblock}
 namespace std {
-  template <class T> struct default_delete {
+  template<class T> struct default_delete {
     constexpr default_delete() noexcept = default;
-    template <class U> default_delete(const default_delete<U>&) noexcept;
+    template<class U> default_delete(const default_delete<U>&) noexcept;
     void operator()(T*) const;
   };
 }
@@ -7999,7 +7999,7 @@ namespace std {
 
 \indexlibrary{\idxcode{default_delete}!constructor}%
 \begin{itemdecl}
-template <class U> default_delete(const default_delete<U>& other) noexcept;
+template<class U> default_delete(const default_delete<U>& other) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8029,17 +8029,17 @@ void operator()(T* ptr) const;
 
 \begin{codeblock}
 namespace std {
-  template <class T> struct default_delete<T[]> {
+  template<class T> struct default_delete<T[]> {
     constexpr default_delete() noexcept = default;
-    template <class U> default_delete(const default_delete<U[]>&) noexcept;
-    template <class U> void operator()(U* ptr) const;
+    template<class U> default_delete(const default_delete<U[]>&) noexcept;
+    template<class U> void operator()(U* ptr) const;
   };
 }
 \end{codeblock}
 
 \indexlibrary{\idxcode{default_delete}!constructor}
 \begin{itemdecl}
-template <class U> default_delete(const default_delete<U[]>& other) noexcept;
+template<class U> default_delete(const default_delete<U[]>& other) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8055,7 +8055,7 @@ convertible to \tcode{T(*)[]}.
 
 \indexlibrarymember{operator()}{default_delete}%
 \begin{itemdecl}
-template <class U> void operator()(U* ptr) const;
+template<class U> void operator()(U* ptr) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8074,7 +8074,7 @@ unless \tcode{U(*)[]} is convertible to \tcode{T(*)[]}.
 \indexlibrary{\idxcode{unique_ptr}}%
 \begin{codeblock}
 namespace std {
-  template <class T, class D = default_delete<T>> class unique_ptr {
+  template<class T, class D = default_delete<T>> class unique_ptr {
   public:
     using pointer      = @\seebelow@;
     using element_type = T;
@@ -8087,7 +8087,7 @@ namespace std {
     unique_ptr(pointer p, @\seebelow@ d2) noexcept;
     unique_ptr(unique_ptr&& u) noexcept;
     constexpr unique_ptr(nullptr_t) noexcept;
-    template <class U, class E>
+    template<class U, class E>
       unique_ptr(unique_ptr<U, E>&& u) noexcept;
 
     // \ref{unique.ptr.single.dtor}, destructor
@@ -8095,7 +8095,7 @@ namespace std {
 
     // \ref{unique.ptr.single.asgn}, assignment
     unique_ptr& operator=(unique_ptr&& u) noexcept;
-    template <class U, class E>
+    template<class U, class E>
       unique_ptr& operator=(unique_ptr<U, E>&& u) noexcept;
     unique_ptr& operator=(nullptr_t) noexcept;
 
@@ -8314,7 +8314,7 @@ the same lvalue deleter.
 
 \indexlibrary{\idxcode{unique_ptr}!constructor}%
 \begin{itemdecl}
-template <class U, class E> unique_ptr(unique_ptr<U, E>&& u) noexcept;
+template<class U, class E> unique_ptr(unique_ptr<U, E>&& u) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8398,7 +8398,7 @@ Transfers ownership from \tcode{u} to \tcode{*this} as if by calling
 
 \indexlibrarymember{operator=}{unique_ptr}%
 \begin{itemdecl}
-template <class U, class E> unique_ptr& operator=(unique_ptr<U, E>&& u) noexcept;
+template<class U, class E> unique_ptr& operator=(unique_ptr<U, E>&& u) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8568,7 +8568,7 @@ deleters of \tcode{*this} and \tcode{u}.
 \indexlibrary{\idxcode{unique_ptr}}%
 \begin{codeblock}
 namespace std {
-  template <class T, class D> class unique_ptr<T[], D> {
+  template<class T, class D> class unique_ptr<T[], D> {
   public:
     using pointer      = @\seebelow@;
     using element_type = T;
@@ -8576,11 +8576,11 @@ namespace std {
 
     // \ref{unique.ptr.runtime.ctor}, constructors
     constexpr unique_ptr() noexcept;
-    template <class U> explicit unique_ptr(U p) noexcept;
-    template <class U> unique_ptr(U p, @\seebelow@ d) noexcept;
-    template <class U> unique_ptr(U p, @\seebelow@ d) noexcept;
+    template<class U> explicit unique_ptr(U p) noexcept;
+    template<class U> unique_ptr(U p, @\seebelow@ d) noexcept;
+    template<class U> unique_ptr(U p, @\seebelow@ d) noexcept;
     unique_ptr(unique_ptr&& u) noexcept;
-    template <class U, class E>
+    template<class U, class E>
       unique_ptr(unique_ptr<U, E>&& u) noexcept;
     constexpr unique_ptr(nullptr_t) noexcept;
 
@@ -8589,7 +8589,7 @@ namespace std {
 
     // assignment
     unique_ptr& operator=(unique_ptr&& u) noexcept;
-    template <class U, class E>
+    template<class U, class E>
       unique_ptr& operator=(unique_ptr<U, E>&& u) noexcept;
     unique_ptr& operator=(nullptr_t) noexcept;
 
@@ -8602,7 +8602,7 @@ namespace std {
 
     // \ref{unique.ptr.runtime.modifiers}, modifiers
     pointer release() noexcept;
-    template <class U> void reset(U p) noexcept;
+    template<class U> void reset(U p) noexcept;
     void reset(nullptr_t = nullptr) noexcept;
     void swap(unique_ptr& u) noexcept;
 
@@ -8646,7 +8646,7 @@ The template argument \tcode{T} shall be a complete type.
 
 \indexlibrary{\idxcode{unique_ptr}!constructor}%
 \begin{itemdecl}
-template <class U> explicit unique_ptr(U p) noexcept;
+template<class U> explicit unique_ptr(U p) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8667,8 +8667,8 @@ shall not participate in overload resolution unless
 
 \indexlibrary{\idxcode{unique_ptr}!constructor}%
 \begin{itemdecl}
-template <class U> unique_ptr(U p, @\seebelow@ d) noexcept;
-template <class U> unique_ptr(U p, @\seebelow@ d) noexcept;
+template<class U> unique_ptr(U p, @\seebelow@ d) noexcept;
+template<class U> unique_ptr(U p, @\seebelow@ d) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8690,7 +8690,7 @@ shall not participate in overload resolution unless either
 
 \indexlibrary{\idxcode{unique_ptr}!constructor}%
 \begin{itemdecl}
-template <class U, class E> unique_ptr(unique_ptr<U, E>&& u) noexcept;
+template<class U, class E> unique_ptr(unique_ptr<U, E>&& u) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8718,7 +8718,7 @@ This replaces the overload-resolution specification of the primary template
 
 \indexlibrarymember{operator=}{unique_ptr}%
 \begin{itemdecl}
-template <class U, class E> unique_ptr& operator=(unique_ptr<U, E>&& u)noexcept;
+template<class U, class E> unique_ptr& operator=(unique_ptr<U, E>&& u)noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8772,7 +8772,7 @@ void reset(nullptr_t p = nullptr) noexcept;
 
 \indexlibrarymember{reset}{unique_ptr}%
 \begin{itemdecl}
-template <class U> void reset(U p) noexcept;
+template<class U> void reset(U p) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8794,7 +8794,7 @@ unless either
 
 \indexlibrary{\idxcode{make_unique}}%
 \begin{itemdecl}
-template <class T, class... Args> unique_ptr<T> make_unique(Args&&... args);
+template<class T, class... Args> unique_ptr<T> make_unique(Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8808,7 +8808,7 @@ template <class T, class... Args> unique_ptr<T> make_unique(Args&&... args);
 
 \indexlibrary{\idxcode{make_unique}}%
 \begin{itemdecl}
-template <class T> unique_ptr<T> make_unique(size_t n);
+template<class T> unique_ptr<T> make_unique(size_t n);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8822,7 +8822,7 @@ template <class T> unique_ptr<T> make_unique(size_t n);
 
 \indexlibrary{\idxcode{make_unique}}%
 \begin{itemdecl}
-template <class T, class... Args> @\unspec@ make_unique(Args&&...) = delete;
+template<class T, class... Args> @\unspec@ make_unique(Args&&...) = delete;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8835,7 +8835,7 @@ template <class T, class... Args> @\unspec@ make_unique(Args&&...) = delete;
 
 \indexlibrary{\idxcode{swap(unique_ptr\&, unique_ptr\&)}}%
 \begin{itemdecl}
-template <class T, class D> void swap(unique_ptr<T, D>& x, unique_ptr<T, D>& y) noexcept;
+template<class T, class D> void swap(unique_ptr<T, D>& x, unique_ptr<T, D>& y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8849,7 +8849,7 @@ unless \tcode{is_swappable_v<D>} is \tcode{true}.
 
 \indexlibrarymember{operator==}{unique_ptr}%
 \begin{itemdecl}
-template <class T1, class D1, class T2, class D2>
+template<class T1, class D1, class T2, class D2>
   bool operator==(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
 \end{itemdecl}
 
@@ -8860,7 +8860,7 @@ template <class T1, class D1, class T2, class D2>
 
 \indexlibrarymember{operator"!=}{unique_ptr}%
 \begin{itemdecl}
-template <class T1, class D1, class T2, class D2>
+template<class T1, class D1, class T2, class D2>
   bool operator!=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
 \end{itemdecl}
 
@@ -8871,7 +8871,7 @@ template <class T1, class D1, class T2, class D2>
 
 \indexlibrarymember{operator<}{unique_ptr}%
 \begin{itemdecl}
-template <class T1, class D1, class T2, class D2>
+template<class T1, class D1, class T2, class D2>
   bool operator<(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
 \end{itemdecl}
 
@@ -8897,7 +8897,7 @@ convertible to \tcode{\placeholder{CT}}, the program is ill-formed.
 
 \indexlibrarymember{operator<=}{unique_ptr}%
 \begin{itemdecl}
-template <class T1, class D1, class T2, class D2>
+template<class T1, class D1, class T2, class D2>
   bool operator<=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
 \end{itemdecl}
 
@@ -8908,7 +8908,7 @@ template <class T1, class D1, class T2, class D2>
 
 \indexlibrarymember{operator>}{unique_ptr}%
 \begin{itemdecl}
-template <class T1, class D1, class T2, class D2>
+template<class T1, class D1, class T2, class D2>
   bool operator>(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
 \end{itemdecl}
 
@@ -8919,7 +8919,7 @@ template <class T1, class D1, class T2, class D2>
 
 \indexlibrarymember{operator>=}{unique_ptr}%
 \begin{itemdecl}
-template <class T1, class D1, class T2, class D2>
+template<class T1, class D1, class T2, class D2>
   bool operator>=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
 \end{itemdecl}
 
@@ -8930,9 +8930,9 @@ template <class T1, class D1, class T2, class D2>
 
 \indexlibrarymember{operator==}{unique_ptr}%
 \begin{itemdecl}
-template <class T, class D>
+template<class T, class D>
   bool operator==(const unique_ptr<T, D>& x, nullptr_t) noexcept;
-template <class T, class D>
+template<class T, class D>
   bool operator==(nullptr_t, const unique_ptr<T, D>& x) noexcept;
 \end{itemdecl}
 
@@ -8943,9 +8943,9 @@ template <class T, class D>
 
 \indexlibrarymember{operator"!=}{unique_ptr}%
 \begin{itemdecl}
-template <class T, class D>
+template<class T, class D>
   bool operator!=(const unique_ptr<T, D>& x, nullptr_t) noexcept;
-template <class T, class D>
+template<class T, class D>
   bool operator!=(nullptr_t, const unique_ptr<T, D>& x) noexcept;
 \end{itemdecl}
 
@@ -8956,9 +8956,9 @@ template <class T, class D>
 
 \indexlibrarymember{operator<}{unique_ptr}%
 \begin{itemdecl}
-template <class T, class D>
+template<class T, class D>
   bool operator<(const unique_ptr<T, D>& x, nullptr_t);
-template <class T, class D>
+template<class T, class D>
   bool operator<(nullptr_t, const unique_ptr<T, D>& x);
 \end{itemdecl}
 
@@ -8982,9 +8982,9 @@ less<unique_ptr<T, D>::pointer>()(nullptr, x.get())
 
 \indexlibrarymember{operator>}{unique_ptr}%
 \begin{itemdecl}
-template <class T, class D>
+template<class T, class D>
   bool operator>(const unique_ptr<T, D>& x, nullptr_t);
-template <class T, class D>
+template<class T, class D>
   bool operator>(nullptr_t, const unique_ptr<T, D>& x);
 \end{itemdecl}
 
@@ -8997,9 +8997,9 @@ The second function template returns \tcode{x < nullptr}.
 
 \indexlibrarymember{operator<=}{unique_ptr}%
 \begin{itemdecl}
-template <class T, class D>
+template<class T, class D>
   bool operator<=(const unique_ptr<T, D>& x, nullptr_t);
-template <class T, class D>
+template<class T, class D>
   bool operator<=(nullptr_t, const unique_ptr<T, D>& x);
 \end{itemdecl}
 
@@ -9012,9 +9012,9 @@ The second function template returns \tcode{!(x < nullptr)}.
 
 \indexlibrarymember{operator>=}{unique_ptr}%
 \begin{itemdecl}
-template <class T, class D>
+template<class T, class D>
   bool operator>=(const unique_ptr<T, D>& x, nullptr_t);
-template <class T, class D>
+template<class T, class D>
   bool operator>=(nullptr_t, const unique_ptr<T, D>& x);
 \end{itemdecl}
 
@@ -9085,7 +9085,7 @@ the object, or otherwise releasing the resources associated with the stored poin
 
 \begin{codeblock}
 namespace std {
-  template <class T> class shared_ptr {
+  template<class T> class shared_ptr {
   public:
     using element_type = remove_extent_t<T>;
     using weak_type    = weak_ptr<T>;
@@ -9093,27 +9093,27 @@ namespace std {
     // \ref{util.smartptr.shared.const}, constructors
     constexpr shared_ptr() noexcept;
     constexpr shared_ptr(nullptr_t) noexcept : shared_ptr() { }
-    template <class Y>
+    template<class Y>
       explicit shared_ptr(Y* p);
-    template <class Y, class D>
+    template<class Y, class D>
       shared_ptr(Y* p, D d);
-    template <class Y, class D, class A>
+    template<class Y, class D, class A>
       shared_ptr(Y* p, D d, A a);
-    template <class D>
+    template<class D>
       shared_ptr(nullptr_t p, D d);
-    template <class D, class A>
+    template<class D, class A>
       shared_ptr(nullptr_t p, D d, A a);
-    template <class Y>
+    template<class Y>
       shared_ptr(const shared_ptr<Y>& r, element_type* p) noexcept;
     shared_ptr(const shared_ptr& r) noexcept;
-    template <class Y>
+    template<class Y>
       shared_ptr(const shared_ptr<Y>& r) noexcept;
     shared_ptr(shared_ptr&& r) noexcept;
-    template <class Y>
+    template<class Y>
       shared_ptr(shared_ptr<Y>&& r) noexcept;
-    template <class Y>
+    template<class Y>
       explicit shared_ptr(const weak_ptr<Y>& r);
-    template <class Y, class D>
+    template<class Y, class D>
       shared_ptr(unique_ptr<Y, D>&& r);
 
     // \ref{util.smartptr.shared.dest}, destructor
@@ -9121,22 +9121,22 @@ namespace std {
 
     // \ref{util.smartptr.shared.assign}, assignment
     shared_ptr& operator=(const shared_ptr& r) noexcept;
-    template <class Y>
+    template<class Y>
       shared_ptr& operator=(const shared_ptr<Y>& r) noexcept;
     shared_ptr& operator=(shared_ptr&& r) noexcept;
-    template <class Y>
+    template<class Y>
       shared_ptr& operator=(shared_ptr<Y>&& r) noexcept;
-    template <class Y, class D>
+    template<class Y, class D>
       shared_ptr& operator=(unique_ptr<Y, D>&& r);
 
     // \ref{util.smartptr.shared.mod}, modifiers
     void swap(shared_ptr& r) noexcept;
     void reset() noexcept;
-    template <class Y>
+    template<class Y>
       void reset(Y* p);
-    template <class Y, class D>
+    template<class Y, class D>
       void reset(Y* p, D d);
-    template <class Y, class D, class A>
+    template<class Y, class D, class A>
       void reset(Y* p, D d, A a);
 
     // \ref{util.smartptr.shared.obs}, observers
@@ -9146,15 +9146,15 @@ namespace std {
     element_type& operator[](ptrdiff_t i) const;
     long use_count() const noexcept;
     explicit operator bool() const noexcept;
-    template <class U>
+    template<class U>
       bool owner_before(const shared_ptr<U>& b) const noexcept;
-    template <class U>
+    template<class U>
       bool owner_before(const weak_ptr<U>& b) const noexcept;
   };
 
-  template <class T>
+  template<class T>
     shared_ptr(weak_ptr<T>) -> shared_ptr<T>;
-  template <class T, class D>
+  template<class T, class D>
     shared_ptr(unique_ptr<T, D>) -> shared_ptr<T>;
 }
 \end{codeblock}
@@ -9220,7 +9220,7 @@ constexpr shared_ptr() noexcept;
 
 \indexlibrary{\idxcode{shared_ptr}!constructor}%
 \begin{itemdecl}
-template <class Y> explicit shared_ptr(Y* p);
+template<class Y> explicit shared_ptr(Y* p);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9259,10 +9259,10 @@ the expression \tcode{delete p} is well-formed and
 
 \indexlibrary{\idxcode{shared_ptr}!constructor}%
 \begin{itemdecl}
-template <class Y, class D> shared_ptr(Y* p, D d);
-template <class Y, class D, class A> shared_ptr(Y* p, D d, A a);
-template <class D> shared_ptr(nullptr_t p, D d);
-template <class D, class A> shared_ptr(nullptr_t p, D d, A a);
+template<class Y, class D> shared_ptr(Y* p, D d);
+template<class Y, class D, class A> shared_ptr(Y* p, D d, A a);
+template<class D> shared_ptr(nullptr_t p, D d);
+template<class D, class A> shared_ptr(nullptr_t p, D d, A a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9302,7 +9302,7 @@ the expression \tcode{d(p)} is well-formed, and
 
 \indexlibrary{\idxcode{shared_ptr}!constructor}%
 \begin{itemdecl}
-template <class Y> shared_ptr(const shared_ptr<Y>& r, element_type* p) noexcept;
+template<class Y> shared_ptr(const shared_ptr<Y>& r, element_type* p) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9326,7 +9326,7 @@ least until the ownership group of \tcode{r} is destroyed. \end{note}
 \indexlibrary{\idxcode{shared_ptr}!constructor}%
 \begin{itemdecl}
 shared_ptr(const shared_ptr& r) noexcept;
-template <class Y> shared_ptr(const shared_ptr<Y>& r) noexcept;
+template<class Y> shared_ptr(const shared_ptr<Y>& r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9344,7 +9344,7 @@ a \tcode{shared_ptr} object that shares ownership with \tcode{r}.
 \indexlibrary{\idxcode{shared_ptr}!constructor}%
 \begin{itemdecl}
 shared_ptr(shared_ptr&& r) noexcept;
-template <class Y> shared_ptr(shared_ptr<Y>&& r) noexcept;
+template<class Y> shared_ptr(shared_ptr<Y>&& r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9363,7 +9363,7 @@ template <class Y> shared_ptr(shared_ptr<Y>&& r) noexcept;
 \indexlibrary{\idxcode{shared_ptr}!constructor}%
 \indexlibrary{\idxcode{weak_ptr}}%
 \begin{itemdecl}
-template <class Y> explicit shared_ptr(const weak_ptr<Y>& r);
+template<class Y> explicit shared_ptr(const weak_ptr<Y>& r);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9382,7 +9382,7 @@ If an exception is thrown, the constructor has no effect.
 \indexlibrary{\idxcode{shared_ptr}!constructor}%
 \indexlibrary{\idxcode{unique_ptr}}%
 \begin{itemdecl}
-template <class Y, class D> shared_ptr(unique_ptr<Y, D>&& r);
+template<class Y, class D> shared_ptr(unique_ptr<Y, D>&& r);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9434,7 +9434,7 @@ than its previous value. \end{note}
 \indexlibrarymember{operator=}{shared_ptr}%
 \begin{itemdecl}
 shared_ptr& operator=(const shared_ptr& r) noexcept;
-template <class Y> shared_ptr& operator=(const shared_ptr<Y>& r) noexcept;
+template<class Y> shared_ptr& operator=(const shared_ptr<Y>& r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9460,7 +9460,7 @@ both assignments may be no-ops. \end{note}
 \indexlibrarymember{operator=}{shared_ptr}%
 \begin{itemdecl}
 shared_ptr& operator=(shared_ptr&& r) noexcept;
-template <class Y> shared_ptr& operator=(shared_ptr<Y>&& r) noexcept;
+template<class Y> shared_ptr& operator=(shared_ptr<Y>&& r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9473,7 +9473,7 @@ template <class Y> shared_ptr& operator=(shared_ptr<Y>&& r) noexcept;
 
 \indexlibrarymember{operator=}{shared_ptr}%
 \begin{itemdecl}
-template <class Y, class D> shared_ptr& operator=(unique_ptr<Y, D>&& r);
+template<class Y, class D> shared_ptr& operator=(unique_ptr<Y, D>&& r);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9507,7 +9507,7 @@ void reset() noexcept;
 
 \indexlibrarymember{reset}{shared_ptr}%
 \begin{itemdecl}
-template <class Y> void reset(Y* p);
+template<class Y> void reset(Y* p);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9516,7 +9516,7 @@ template <class Y> void reset(Y* p);
 
 \indexlibrarymember{reset}{shared_ptr}%
 \begin{itemdecl}
-template <class Y, class D> void reset(Y* p, D d);
+template<class Y, class D> void reset(Y* p, D d);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9525,7 +9525,7 @@ template <class Y, class D> void reset(Y* p, D d);
 
 \indexlibrarymember{reset}{shared_ptr}%
 \begin{itemdecl}
-template <class Y, class D, class A> void reset(Y* p, D d, A a);
+template<class Y, class D, class A> void reset(Y* p, D d, A a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9633,8 +9633,8 @@ explicit operator bool() const noexcept;
 
 \indexlibrarymember{owner_before}{shared_ptr}%
 \begin{itemdecl}
-template <class U> bool owner_before(const shared_ptr<U>& b) const noexcept;
-template <class U> bool owner_before(const weak_ptr<U>& b) const noexcept;
+template<class U> bool owner_before(const shared_ptr<U>& b) const noexcept;
+template<class U> bool owner_before(const weak_ptr<U>& b) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9662,9 +9662,9 @@ unless specified otherwise, are described below.
 \indexlibrary{\idxcode{make_shared}}%
 \indexlibrary{\idxcode{allocate_shared}}%
 \begin{itemdecl}
-template <class T, ...>
+template<class T, ...>
   shared_ptr<T> make_shared(@\placeholdernc{args}@);
-template <class T, class A, ...>
+template<class T, class A, ...>
   shared_ptr<T> allocate_shared(const A& a, @\placeholdernc{args}@);
 \end{itemdecl}
 
@@ -9769,9 +9769,9 @@ allow for internal bookkeeping structures such as reference counts.
 \indexlibrary{\idxcode{make_shared}}%
 \indexlibrary{\idxcode{allocate_shared}}%
 \begin{itemdecl}
-template <class T, class... Args>
+template<class T, class... Args>
   shared_ptr<T> make_shared(Args&&... args);                    // \tcode{T} is not array
-template <class T, class A, class... Args>
+template<class T, class A, class... Args>
   shared_ptr<T> allocate_shared(const A& a, Args&&... args);    // \tcode{T} is not array
 \end{itemdecl}
 
@@ -9800,9 +9800,9 @@ shared_ptr<vector<int>> q = make_shared<vector<int>>(16, 1);
 \indexlibrary{\idxcode{make_shared}}%
 \indexlibrary{\idxcode{allocate_shared}}%
 \begin{itemdecl}
-template <class T> shared_ptr<T>
+template<class T> shared_ptr<T>
   make_shared(size_t N);                                        // \tcode{T} is \tcode{U[]}
-template <class T, class A>
+template<class T, class A>
   shared_ptr<T> allocate_shared(const A& a, size_t N);          // \tcode{T} is \tcode{U[]}
 \end{itemdecl}
 
@@ -9830,9 +9830,9 @@ shared_ptr<double[][2][2]> q = make_shared<double[][2][2]>(6);
 \indexlibrary{\idxcode{make_shared}}%
 \indexlibrary{\idxcode{allocate_shared}}%
 \begin{itemdecl}
-template <class T>
+template<class T>
   shared_ptr<T> make_shared();                                  // \tcode{T} is \tcode{U[N]}
-template <class T, class A>
+template<class T, class A>
   shared_ptr<T> allocate_shared(const A& a);                    // \tcode{T} is \tcode{U[N]}
 \end{itemdecl}
 
@@ -9927,7 +9927,7 @@ shared_ptr<vector<int>[4]> r = make_shared<vector<int>[4]>({1, 2});
 
 \indexlibrarymember{operator==}{shared_ptr}%
 \begin{itemdecl}
-template <class T, class U>
+template<class T, class U>
   bool operator==(const shared_ptr<T>& a, const shared_ptr<U>& b) noexcept;
 \end{itemdecl}
 
@@ -9938,7 +9938,7 @@ template <class T, class U>
 
 \indexlibrarymember{operator<}{shared_ptr}%
 \begin{itemdecl}
-template <class T, class U>
+template<class T, class U>
   bool operator<(const shared_ptr<T>& a, const shared_ptr<U>& b) noexcept;
 \end{itemdecl}
 
@@ -9955,9 +9955,9 @@ used as keys in associative containers.
 
 \indexlibrarymember{operator==}{shared_ptr}%
 \begin{itemdecl}
-template <class T>
+template<class T>
   bool operator==(const shared_ptr<T>& a, nullptr_t) noexcept;
-template <class T>
+template<class T>
   bool operator==(nullptr_t, const shared_ptr<T>& a) noexcept;
 \end{itemdecl}
 
@@ -9968,9 +9968,9 @@ template <class T>
 
 \indexlibrarymember{operator"!=}{shared_ptr}%
 \begin{itemdecl}
-template <class T>
+template<class T>
   bool operator!=(const shared_ptr<T>& a, nullptr_t) noexcept;
-template <class T>
+template<class T>
   bool operator!=(nullptr_t, const shared_ptr<T>& a) noexcept;
 \end{itemdecl}
 
@@ -9981,9 +9981,9 @@ template <class T>
 
 \indexlibrarymember{operator<}{shared_ptr}%
 \begin{itemdecl}
-template <class T>
+template<class T>
   bool operator<(const shared_ptr<T>& a, nullptr_t) noexcept;
-template <class T>
+template<class T>
   bool operator<(nullptr_t, const shared_ptr<T>& a) noexcept;
 \end{itemdecl}
 
@@ -10002,9 +10002,9 @@ less<typename shared_ptr<T>::element_type*>()(nullptr, a.get())
 
 \indexlibrarymember{operator>}{shared_ptr}%
 \begin{itemdecl}
-template <class T>
+template<class T>
   bool operator>(const shared_ptr<T>& a, nullptr_t) noexcept;
-template <class T>
+template<class T>
   bool operator>(nullptr_t, const shared_ptr<T>& a) noexcept;
 \end{itemdecl}
 
@@ -10017,9 +10017,9 @@ The second function template returns \tcode{a < nullptr}.
 
 \indexlibrarymember{operator<=}{shared_ptr}%
 \begin{itemdecl}
-template <class T>
+template<class T>
   bool operator<=(const shared_ptr<T>& a, nullptr_t) noexcept;
-template <class T>
+template<class T>
   bool operator<=(nullptr_t, const shared_ptr<T>& a) noexcept;
 \end{itemdecl}
 
@@ -10032,9 +10032,9 @@ The second function template returns \tcode{!(a < nullptr)}.
 
 \indexlibrarymember{operator>=}{shared_ptr}%
 \begin{itemdecl}
-template <class T>
+template<class T>
   bool operator>=(const shared_ptr<T>& a, nullptr_t) noexcept;
-template <class T>
+template<class T>
   bool operator>=(nullptr_t, const shared_ptr<T>& a) noexcept;
 \end{itemdecl}
 
@@ -10049,7 +10049,7 @@ The second function template returns \tcode{!(nullptr < a)}.
 
 \indexlibrarymember{swap}{shared_ptr}%
 \begin{itemdecl}
-template <class T>
+template<class T>
   void swap(shared_ptr<T>& a, shared_ptr<T>& b) noexcept;
 \end{itemdecl}
 
@@ -10061,7 +10061,7 @@ template <class T>
 
 \indexlibrarymember{static_pointer_cast}{shared_ptr}%
 \begin{itemdecl}
-template <class T, class U>
+template<class T, class U>
   shared_ptr<T> static_pointer_cast(const shared_ptr<U>& r) noexcept;
 \end{itemdecl}
 
@@ -10087,7 +10087,7 @@ same object twice.
 
 \indexlibrarymember{dynamic_pointer_cast}{shared_ptr}%
 \begin{itemdecl}
-template <class T, class U>
+template<class T, class U>
   shared_ptr<T> dynamic_pointer_cast(const shared_ptr<U>& r) noexcept;
 \end{itemdecl}
 
@@ -10116,7 +10116,7 @@ undefined behavior, attempting to delete the same object twice.
 
 \indexlibrarymember{const_pointer_cast}{shared_ptr}%
 \begin{itemdecl}
-template <class T, class U>
+template<class T, class U>
   shared_ptr<T> const_pointer_cast(const shared_ptr<U>& r) noexcept;
 \end{itemdecl}
 
@@ -10141,7 +10141,7 @@ undefined behavior, attempting to delete the same object twice.
 
 \indexlibrarymember{reinterpret_pointer_cast}{shared_ptr}%
 \begin{itemdecl}
-template <class T, class U>
+template<class T, class U>
   shared_ptr<T> reinterpret_pointer_cast(const shared_ptr<U>& r) noexcept;
 \end{itemdecl}
 
@@ -10167,7 +10167,7 @@ undefined behavior, attempting to delete the same object twice.
 
 \indexlibrarymember{get_deleter}{shared_ptr}%
 \begin{itemdecl}
-template <class D, class T>
+template<class D, class T>
   D* get_deleter(const shared_ptr<T>& p) noexcept;
 \end{itemdecl}
 
@@ -10186,7 +10186,7 @@ the deleter until all \tcode{weak_ptr} instances that share ownership with
 
 \indexlibrarymember{operator<<}{shared_ptr}%
 \begin{itemdecl}
-template <class E, class T, class Y>
+template<class E, class T, class Y>
   basic_ostream<E, T>& operator<<(basic_ostream<E, T>& os, const shared_ptr<Y>& p);
 \end{itemdecl}
 
@@ -10582,7 +10582,7 @@ weak_ptr<T const> weak_from_this() const noexcept;
 
 \indexlibrary{\idxcode{hash}!\idxcode{unique_ptr}}%
 \begin{itemdecl}
-template <class T, class D> struct hash<unique_ptr<T, D>>;
+template<class T, class D> struct hash<unique_ptr<T, D>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10598,7 +10598,7 @@ The member functions are not guaranteed to be \tcode{noexcept}.
 
 \indexlibrary{\idxcode{hash}!\idxcode{shared_ptr}}%
 \begin{itemdecl}
-template <class T> struct hash<shared_ptr<T>>;
+template<class T> struct hash<shared_ptr<T>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10642,7 +10642,7 @@ resulting from this is performed.
 \indexlibrary{\idxcode{atomic<shared_ptr<T>>}}%
 \begin{codeblock}
 namespace std {
-  template <class T> struct atomic<shared_ptr<T>> {
+  template<class T> struct atomic<shared_ptr<T>> {
     using value_type = shared_ptr<T>;
     static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic} type's operations are always lock free}@;
 
@@ -10882,7 +10882,7 @@ shall be replaced by the value \tcode{memory_order::relaxed}.
 \indexlibrary{\idxcode{atomic<weak_ptr<T>>}}%
 \begin{codeblock}
 namespace std {
-  template <class T> struct atomic<weak_ptr<T>> {
+  template<class T> struct atomic<weak_ptr<T>> {
     using value_type = weak_ptr<T>;
     static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic} type's operations are always lock free}@;
 
@@ -11132,12 +11132,12 @@ namespace std::pmr {
   bool operator!=(const memory_resource& a, const memory_resource& b) noexcept;
 
   // \ref{mem.poly.allocator.class}, class template \tcode{polymorphic_allocator}
-  template <class Tp> class polymorphic_allocator;
+  template<class Tp> class polymorphic_allocator;
 
-  template <class T1, class T2>
+  template<class T1, class T2>
     bool operator==(const polymorphic_allocator<T1>& a,
                     const polymorphic_allocator<T2>& b) noexcept;
-  template <class T1, class T2>
+  template<class T1, class T2>
     bool operator!=(const polymorphic_allocator<T1>& a,
                     const polymorphic_allocator<T2>& b) noexcept;
 
@@ -11331,7 +11331,7 @@ even though they use the same static allocator type.
 \indexlibrarymember{value_type}{polymorphic_allocator}%
 \begin{codeblock}
 namespace std::pmr {
-  template <class Tp>
+  template<class Tp>
     class polymorphic_allocator {
       memory_resource* memory_rsrc;     // \expos
 
@@ -11344,7 +11344,7 @@ namespace std::pmr {
 
       polymorphic_allocator(const polymorphic_allocator& other) = default;
 
-      template <class U>
+      template<class U>
         polymorphic_allocator(const polymorphic_allocator<U>& other) noexcept;
 
       polymorphic_allocator& operator=(const polymorphic_allocator& rhs) = delete;
@@ -11353,22 +11353,22 @@ namespace std::pmr {
       [[nodiscard]] Tp* allocate(size_t n);
       void deallocate(Tp* p, size_t n);
 
-      template <class T, class... Args>
+      template<class T, class... Args>
         void construct(T* p, Args&&... args);
 
-      template <class T1, class T2, class... Args1, class... Args2>
+      template<class T1, class T2, class... Args1, class... Args2>
         void construct(pair<T1, T2>* p, piecewise_construct_t,
                        tuple<Args1...> x, tuple<Args2...> y);
-      template <class T1, class T2>
+      template<class T1, class T2>
         void construct(pair<T1, T2>* p);
-      template <class T1, class T2, class U, class V>
+      template<class T1, class T2, class U, class V>
         void construct(pair<T1, T2>* p, U&& x, V&& y);
-      template <class T1, class T2, class U, class V>
+      template<class T1, class T2, class U, class V>
         void construct(pair<T1, T2>* p, const pair<U, V>& pr);
-      template <class T1, class T2, class U, class V>
+      template<class T1, class T2, class U, class V>
         void construct(pair<T1, T2>* p, pair<U, V>&& pr);
 
-      template <class T>
+      template<class T>
         void destroy(T* p);
 
       polymorphic_allocator select_on_container_copy_construction() const;
@@ -11417,7 +11417,7 @@ This constructor provides an implicit conversion from \tcode{memory_resource*}.
 
 \indexlibrary{\idxcode{polymorphic_allocator}!constructor}%
 \begin{itemdecl}
-template <class U>
+template<class U>
   polymorphic_allocator(const polymorphic_allocator<U>& other) noexcept;
 \end{itemdecl}
 
@@ -11467,7 +11467,7 @@ Nothing.
 
 \indexlibrarymember{construct}{polymorphic_allocator}%
 \begin{itemdecl}
-template <class T, class... Args>
+template<class T, class... Args>
   void construct(T* p, Args&&... args);
 \end{itemdecl}
 
@@ -11495,7 +11495,7 @@ Nothing unless the constructor for \tcode{T} throws.
 
 \indexlibrarymember{construct}{polymorphic_allocator}%
 \begin{itemdecl}
-template <class T1, class T2, class... Args1, class... Args2>
+template<class T1, class T2, class... Args1, class... Args2>
   void construct(pair<T1, T2>* p, piecewise_construct_t, tuple<Args1...> x, tuple<Args2...> y);
 \end{itemdecl}
 
@@ -11581,7 +11581,7 @@ in the storage whose address is represented by \tcode{p}.
 
 \indexlibrarymember{construct}{polymorphic_allocator}%
 \begin{itemdecl}
-template <class T1, class T2>
+template<class T1, class T2>
   void construct(pair<T1, T2>* p);
 \end{itemdecl}
 
@@ -11596,7 +11596,7 @@ construct(p, piecewise_construct, tuple<>(), tuple<>());
 
 \indexlibrarymember{construct}{polymorphic_allocator}%
 \begin{itemdecl}
-template <class T1, class T2, class U, class V>
+template<class T1, class T2, class U, class V>
   void construct(pair<T1, T2>* p, U&& x, V&& y);
 \end{itemdecl}
 
@@ -11613,7 +11613,7 @@ construct(p, piecewise_construct,
 
 \indexlibrarymember{construct}{polymorphic_allocator}%
 \begin{itemdecl}
-template <class T1, class T2, class U, class V>
+template<class T1, class T2, class U, class V>
   void construct(pair<T1, T2>* p, const pair<U, V>& pr);
 \end{itemdecl}
 
@@ -11630,7 +11630,7 @@ construct(p, piecewise_construct,
 
 \indexlibrarymember{construct}{polymorphic_allocator}%
 \begin{itemdecl}
-template <class T1, class T2, class U, class V>
+template<class T1, class T2, class U, class V>
   void construct(pair<T1, T2>* p, pair<U, V>&& pr);
 \end{itemdecl}
 
@@ -11647,7 +11647,7 @@ construct(p, piecewise_construct,
 
 \indexlibrarymember{destroy}{polymorphic_allocator}%
 \begin{itemdecl}
-template <class T>
+template<class T>
   void destroy(T* p);
 \end{itemdecl}
 
@@ -11688,7 +11688,7 @@ memory_resource* resource() const;
 
 \indexlibrarymember{operator==}{polymorphic_allocator}%
 \begin{itemdecl}
-template <class T1, class T2>
+template<class T1, class T2>
   bool operator==(const polymorphic_allocator<T1>& a,
                   const polymorphic_allocator<T2>& b) noexcept;
 \end{itemdecl}
@@ -11701,7 +11701,7 @@ template <class T1, class T2>
 
 \indexlibrarymember{operator"!=}{polymorphic_allocator}%
 \begin{itemdecl}
-template <class T1, class T2>
+template<class T1, class T2>
   bool operator!=(const polymorphic_allocator<T1>& a,
                   const polymorphic_allocator<T2>& b) noexcept;
 \end{itemdecl}
@@ -12337,13 +12337,13 @@ bool do_is_equal(const memory_resource& other) const noexcept override;
 \begin{codeblock}
 namespace std {
   // scoped allocator adaptor
-  template <class OuterAlloc, class... InnerAlloc>
+  template<class OuterAlloc, class... InnerAlloc>
     class scoped_allocator_adaptor;
 
-  template <class OuterA1, class OuterA2, class... InnerAllocs>
+  template<class OuterA1, class OuterA2, class... InnerAllocs>
     bool operator==(const scoped_allocator_adaptor<OuterA1, InnerAllocs...>& a,
                     const scoped_allocator_adaptor<OuterA2, InnerAllocs...>& b) noexcept;
-  template <class OuterA1, class OuterA2, class... InnerAllocs>
+  template<class OuterA1, class OuterA2, class... InnerAllocs>
     bool operator!=(const scoped_allocator_adaptor<OuterA1, InnerAllocs...>& a,
                     const scoped_allocator_adaptor<OuterA2, InnerAllocs...>& b) noexcept;
 }
@@ -12379,7 +12379,7 @@ expressions. \end{note}
 \indexlibrarymember{const_void_pointer}{scoped_allocator}%
 \begin{codeblock}
 namespace std {
-  template <class OuterAlloc, class... InnerAllocs>
+  template<class OuterAlloc, class... InnerAllocs>
     class scoped_allocator_adaptor : public OuterAlloc {
   private:
     using OuterTraits = allocator_traits<OuterAlloc>;   // \expos
@@ -12402,24 +12402,24 @@ namespace std {
     using propagate_on_container_swap            = @\seebelow@;
     using is_always_equal                        = @\seebelow@;
 
-    template <class Tp>
+    template<class Tp>
       struct rebind {
         using other = scoped_allocator_adaptor<
           OuterTraits::template rebind_alloc<Tp>, InnerAllocs...>;
       };
 
     scoped_allocator_adaptor();
-    template <class OuterA2>
+    template<class OuterA2>
       scoped_allocator_adaptor(OuterA2&& outerAlloc,
                                const InnerAllocs&... innerAllocs) noexcept;
 
     scoped_allocator_adaptor(const scoped_allocator_adaptor& other) noexcept;
     scoped_allocator_adaptor(scoped_allocator_adaptor&& other) noexcept;
 
-    template <class OuterA2>
+    template<class OuterA2>
       scoped_allocator_adaptor(
         const scoped_allocator_adaptor<OuterA2, InnerAllocs...>& other) noexcept;
-    template <class OuterA2>
+    template<class OuterA2>
       scoped_allocator_adaptor(
         scoped_allocator_adaptor<OuterA2, InnerAllocs...>&& other) noexcept;
 
@@ -12438,21 +12438,21 @@ namespace std {
     void deallocate(pointer p, size_type n);
     size_type max_size() const;
 
-    template <class T, class... Args>
+    template<class T, class... Args>
       void construct(T* p, Args&&... args);
-    template <class T1, class T2, class... Args1, class... Args2>
+    template<class T1, class T2, class... Args1, class... Args2>
       void construct(pair<T1, T2>* p, piecewise_construct_t,
                      tuple<Args1...> x, tuple<Args2...> y);
-    template <class T1, class T2>
+    template<class T1, class T2>
       void construct(pair<T1, T2>* p);
-    template <class T1, class T2, class U, class V>
+    template<class T1, class T2, class U, class V>
       void construct(pair<T1, T2>* p, U&& x, V&& y);
-    template <class T1, class T2, class U, class V>
+    template<class T1, class T2, class U, class V>
       void construct(pair<T1, T2>* p, const pair<U, V>& x);
-    template <class T1, class T2, class U, class V>
+    template<class T1, class T2, class U, class V>
       void construct(pair<T1, T2>* p, pair<U, V>&& x);
 
-    template <class T>
+    template<class T>
       void destroy(T* p);
 
     scoped_allocator_adaptor select_on_container_copy_construction() const;
@@ -12462,10 +12462,10 @@ namespace std {
     scoped_allocator_adaptor(OuterAlloc, InnerAllocs...)
       -> scoped_allocator_adaptor<OuterAlloc, InnerAllocs...>;
 
-  template <class OuterA1, class OuterA2, class... InnerAllocs>
+  template<class OuterA1, class OuterA2, class... InnerAllocs>
     bool operator==(const scoped_allocator_adaptor<OuterA1, InnerAllocs...>& a,
                     const scoped_allocator_adaptor<OuterA2, InnerAllocs...>& b) noexcept;
-  template <class OuterA1, class OuterA2, class... InnerAllocs>
+  template<class OuterA1, class OuterA2, class... InnerAllocs>
     bool operator!=(const scoped_allocator_adaptor<OuterA1, InnerAllocs...>& a,
                     const scoped_allocator_adaptor<OuterA2, InnerAllocs...>& b) noexcept;
 }
@@ -12551,7 +12551,7 @@ object.
 
 \indexlibrary{\idxcode{scoped_allocator_adaptor}!constructor}%
 \begin{itemdecl}
-template <class OuterA2>
+template<class OuterA2>
   scoped_allocator_adaptor(OuterA2&& outerAlloc, const InnerAllocs&... innerAllocs) noexcept;
 \end{itemdecl}
 
@@ -12591,7 +12591,7 @@ from \tcode{other}.
 
 \indexlibrary{\idxcode{scoped_allocator_adaptor}!constructor}%
 \begin{itemdecl}
-template <class OuterA2>
+template<class OuterA2>
   scoped_allocator_adaptor(
     const scoped_allocator_adaptor<OuterA2, InnerAllocs...>& other) noexcept;
 \end{itemdecl}
@@ -12608,7 +12608,7 @@ from \tcode{other}.
 
 \indexlibrary{\idxcode{scoped_allocator_adaptor}!constructor}%
 \begin{itemdecl}
-template <class OuterA2>
+template<class OuterA2>
   scoped_allocator_adaptor(scoped_allocator_adaptor<OuterA2, InnerAllocs...>&& other) noexcept;
 \end{itemdecl}
 
@@ -12713,7 +12713,7 @@ size_type max_size() const;
 
 \indexlibrarymember{construct}{scoped_allocator_adaptor}%
 \begin{itemdecl}
-template <class T, class... Args>
+template<class T, class... Args>
   void construct(T* p, Args&&... args);
 \end{itemdecl}
 
@@ -12754,7 +12754,7 @@ contained element.
 
 \indexlibrarymember{construct}{scoped_allocator_adaptor}%
 \begin{itemdecl}
-template <class T1, class T2, class... Args1, class... Args2>
+template<class T1, class T2, class... Args1, class... Args2>
   void construct(pair<T1, T2>* p, piecewise_construct_t, tuple<Args1...> x, tuple<Args2...> y);
 \end{itemdecl}
 
@@ -12827,7 +12827,7 @@ then calls:
 
 \indexlibrarymember{construct}{scoped_allocator_adaptor}%
 \begin{itemdecl}
-template <class T1, class T2>
+template<class T1, class T2>
   void construct(pair<T1, T2>* p);
 \end{itemdecl}
 
@@ -12841,7 +12841,7 @@ construct(p, piecewise_construct, tuple<>(), tuple<>());
 
 \indexlibrarymember{construct}{scoped_allocator_adaptor}%
 \begin{itemdecl}
-template <class T1, class T2, class U, class V>
+template<class T1, class T2, class U, class V>
   void construct(pair<T1, T2>* p, U&& x, V&& y);
 \end{itemdecl}
 
@@ -12857,7 +12857,7 @@ construct(p, piecewise_construct,
 
 \indexlibrarymember{construct}{scoped_allocator_adaptor}%
 \begin{itemdecl}
-template <class T1, class T2, class U, class V>
+template<class T1, class T2, class U, class V>
   void construct(pair<T1, T2>* p, const pair<U, V>& x);
 \end{itemdecl}
 
@@ -12873,7 +12873,7 @@ construct(p, piecewise_construct,
 
 \indexlibrarymember{construct}{scoped_allocator_adaptor}%
 \begin{itemdecl}
-template <class T1, class T2, class U, class V>
+template<class T1, class T2, class U, class V>
   void construct(pair<T1, T2>* p, pair<U, V>&& x);
 \end{itemdecl}
 
@@ -12889,7 +12889,7 @@ construct(p, piecewise_construct,
 
 \indexlibrarymember{destroy}{scoped_allocator_adaptor}%
 \begin{itemdecl}
-template <class T>
+template<class T>
   void destroy(T* p);
 \end{itemdecl}
 
@@ -12915,7 +12915,7 @@ corresponding allocator in \tcode{*this}.
 
 \indexlibrarymember{operator==}{scoped_allocator_adaptor}%
 \begin{itemdecl}
-template <class OuterA1, class OuterA2, class... InnerAllocs>
+template<class OuterA1, class OuterA2, class... InnerAllocs>
   bool operator==(const scoped_allocator_adaptor<OuterA1, InnerAllocs...>& a,
                   const scoped_allocator_adaptor<OuterA2, InnerAllocs...>& b) noexcept;
 \end{itemdecl}
@@ -12934,7 +12934,7 @@ a.outer_allocator() == b.outer_allocator() && a.inner_allocator() == b.inner_all
 
 \indexlibrarymember{operator"!=}{scoped_allocator_adaptor}%
 \begin{itemdecl}
-template <class OuterA1, class OuterA2, class... InnerAllocs>
+template<class OuterA1, class OuterA2, class... InnerAllocs>
   bool operator!=(const scoped_allocator_adaptor<OuterA1, InnerAllocs...>& a,
                   const scoped_allocator_adaptor<OuterA2, InnerAllocs...>& b) noexcept;
 \end{itemdecl}
@@ -12965,69 +12965,69 @@ work with arbitrary function objects.
 \begin{codeblock}
 namespace std {
   // \ref{func.invoke}, invoke
-  template <class F, class... Args>
+  template<class F, class... Args>
     invoke_result_t<F, Args...> invoke(F&& f, Args&&... args)
       noexcept(is_nothrow_invocable_v<F, Args...>);
 
   // \ref{refwrap}, \tcode{reference_wrapper}
-  template <class T> class reference_wrapper;
+  template<class T> class reference_wrapper;
 
-  template <class T> reference_wrapper<T> ref(T&) noexcept;
-  template <class T> reference_wrapper<const T> cref(const T&) noexcept;
-  template <class T> void ref(const T&&) = delete;
-  template <class T> void cref(const T&&) = delete;
+  template<class T> reference_wrapper<T> ref(T&) noexcept;
+  template<class T> reference_wrapper<const T> cref(const T&) noexcept;
+  template<class T> void ref(const T&&) = delete;
+  template<class T> void cref(const T&&) = delete;
 
-  template <class T> reference_wrapper<T> ref(reference_wrapper<T>) noexcept;
-  template <class T> reference_wrapper<const T> cref(reference_wrapper<T>) noexcept;
+  template<class T> reference_wrapper<T> ref(reference_wrapper<T>) noexcept;
+  template<class T> reference_wrapper<const T> cref(reference_wrapper<T>) noexcept;
 
   // \ref{arithmetic.operations}, arithmetic operations
-  template <class T = void> struct plus;
-  template <class T = void> struct minus;
-  template <class T = void> struct multiplies;
-  template <class T = void> struct divides;
-  template <class T = void> struct modulus;
-  template <class T = void> struct negate;
-  template <> struct plus<void>;
-  template <> struct minus<void>;
-  template <> struct multiplies<void>;
-  template <> struct divides<void>;
-  template <> struct modulus<void>;
-  template <> struct negate<void>;
+  template<class T = void> struct plus;
+  template<class T = void> struct minus;
+  template<class T = void> struct multiplies;
+  template<class T = void> struct divides;
+  template<class T = void> struct modulus;
+  template<class T = void> struct negate;
+  template<> struct plus<void>;
+  template<> struct minus<void>;
+  template<> struct multiplies<void>;
+  template<> struct divides<void>;
+  template<> struct modulus<void>;
+  template<> struct negate<void>;
 
   // \ref{comparisons}, comparisons
-  template <class T = void> struct equal_to;
-  template <class T = void> struct not_equal_to;
-  template <class T = void> struct greater;
-  template <class T = void> struct less;
-  template <class T = void> struct greater_equal;
-  template <class T = void> struct less_equal;
-  template <> struct equal_to<void>;
-  template <> struct not_equal_to<void>;
-  template <> struct greater<void>;
-  template <> struct less<void>;
-  template <> struct greater_equal<void>;
-  template <> struct less_equal<void>;
+  template<class T = void> struct equal_to;
+  template<class T = void> struct not_equal_to;
+  template<class T = void> struct greater;
+  template<class T = void> struct less;
+  template<class T = void> struct greater_equal;
+  template<class T = void> struct less_equal;
+  template<> struct equal_to<void>;
+  template<> struct not_equal_to<void>;
+  template<> struct greater<void>;
+  template<> struct less<void>;
+  template<> struct greater_equal<void>;
+  template<> struct less_equal<void>;
 
   // \ref{logical.operations}, logical operations
-  template <class T = void> struct logical_and;
-  template <class T = void> struct logical_or;
-  template <class T = void> struct logical_not;
-  template <> struct logical_and<void>;
-  template <> struct logical_or<void>;
-  template <> struct logical_not<void>;
+  template<class T = void> struct logical_and;
+  template<class T = void> struct logical_or;
+  template<class T = void> struct logical_not;
+  template<> struct logical_and<void>;
+  template<> struct logical_or<void>;
+  template<> struct logical_not<void>;
 
   // \ref{bitwise.operations}, bitwise operations
-  template <class T = void> struct bit_and;
-  template <class T = void> struct bit_or;
-  template <class T = void> struct bit_xor;
-  template <class T = void> struct bit_not;
-  template <> struct bit_and<void>;
-  template <> struct bit_or<void>;
-  template <> struct bit_xor<void>;
-  template <> struct bit_not<void>;
+  template<class T = void> struct bit_and;
+  template<class T = void> struct bit_or;
+  template<class T = void> struct bit_xor;
+  template<class T = void> struct bit_not;
+  template<> struct bit_and<void>;
+  template<> struct bit_or<void>;
+  template<> struct bit_xor<void>;
+  template<> struct bit_not<void>;
 
   // \ref{func.not_fn}, function template \tcode{not_fn}
-  template <class F> @\unspec@ not_fn(F&& f);
+  template<class F> @\unspec@ not_fn(F&& f);
 
   // \ref{func.bind}, bind
   template<class T> struct is_bind_expression;
@@ -13085,13 +13085,13 @@ namespace std {
     class boyer_moore_horspool_searcher;
 
   // \ref{unord.hash}, hash function primary template
-  template <class T>
+  template<class T>
     struct hash;
 
   // \ref{func.bind}, function object binders
-  template <class T>
+  template<class T>
     inline constexpr bool is_bind_expression_v = is_bind_expression<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr int is_placeholder_v = is_placeholder<T>::value;
 }
 \end{codeblock}
@@ -13214,7 +13214,7 @@ template<class... UnBoundArgs>
 \indexlibrary{\idxcode{invoke}}%
 \indexlibrary{invoke@\tcode{\placeholder{INVOKE}}}%
 \begin{itemdecl}
-template <class F, class... Args>
+template<class F, class... Args>
   invoke_result_t<F, Args...> invoke(F&& f, Args&&... args)
     noexcept(is_nothrow_invocable_v<F, Args...>);
 \end{itemdecl}
@@ -13231,13 +13231,13 @@ template <class F, class... Args>
 \indextext{function object!\idxcode{reference_wrapper}}%
 \begin{codeblock}
 namespace std {
-  template <class T> class reference_wrapper {
+  template<class T> class reference_wrapper {
   public:
     // types
     using type = T;
 
     // construct/copy/destroy
-    template <class U>
+    template<class U>
       reference_wrapper(U&&) noexcept(@\seebelow@);
     reference_wrapper(const reference_wrapper& x) noexcept;
 
@@ -13249,10 +13249,10 @@ namespace std {
     T& get() const noexcept;
 
     // invocation
-    template <class... ArgTypes>
+    template<class... ArgTypes>
       invoke_result_t<T&, ArgTypes...> operator()(ArgTypes&&...) const;
   };
-  template <class T>
+  template<class T>
     reference_wrapper(T&) -> reference_wrapper<T>;
 }
 \end{codeblock}
@@ -13338,7 +13338,7 @@ T& get() const noexcept;
 
 \indexlibrarymember{operator()}{reference_wrapper}%
 \begin{itemdecl}
-template <class... ArgTypes>
+template<class... ArgTypes>
   invoke_result_t<T&, ArgTypes...>
     operator()(ArgTypes&&... args) const;
 \end{itemdecl}
@@ -13352,7 +13352,7 @@ template <class... ArgTypes>
 
 \indexlibrarymember{ref}{reference_wrapper}%
 \begin{itemdecl}
-template <class T> reference_wrapper<T> ref(T& t) noexcept;
+template<class T> reference_wrapper<T> ref(T& t) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -13361,7 +13361,7 @@ template <class T> reference_wrapper<T> ref(T& t) noexcept;
 
 \indexlibrarymember{ref}{reference_wrapper}%
 \begin{itemdecl}
-template <class T> reference_wrapper<T> ref(reference_wrapper<T> t) noexcept;
+template<class T> reference_wrapper<T> ref(reference_wrapper<T> t) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -13370,7 +13370,7 @@ template <class T> reference_wrapper<T> ref(reference_wrapper<T> t) noexcept;
 
 \indexlibrarymember{cref}{reference_wrapper}%
 \begin{itemdecl}
-template <class T> reference_wrapper<const T> cref(const T& t) noexcept;
+template<class T> reference_wrapper<const T> cref(const T& t) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -13379,7 +13379,7 @@ template <class T> reference_wrapper<const T> cref(const T& t) noexcept;
 
 \indexlibrarymember{cref}{reference_wrapper}%
 \begin{itemdecl}
-template <class T> reference_wrapper<const T> cref(reference_wrapper<T> t) noexcept;
+template<class T> reference_wrapper<const T> cref(reference_wrapper<T> t) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -13396,7 +13396,7 @@ operators in the language~(\ref{expr.mul}, \ref{expr.add}).
 
 \indexlibrary{\idxcode{plus}}%
 \begin{itemdecl}
-template <class T = void> struct plus {
+template<class T = void> struct plus {
   constexpr T operator()(const T& x, const T& y) const;
 };
 \end{itemdecl}
@@ -13412,8 +13412,8 @@ constexpr T operator()(const T& x, const T& y) const;
 
 \indexlibrary{\idxcode{plus<>}}%
 \begin{itemdecl}
-template <> struct plus<void> {
-  template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<> struct plus<void> {
+  template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) + std::forward<U>(u));
 
   using is_transparent = @\unspec@;
@@ -13422,7 +13422,7 @@ template <> struct plus<void> {
 
 \indexlibrarymember{operator()}{plus<>}%
 \begin{itemdecl}
-template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) + std::forward<U>(u));
 \end{itemdecl}
 
@@ -13434,7 +13434,7 @@ template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \indexlibrary{\idxcode{minus}}%
 \begin{itemdecl}
-template <class T = void> struct minus {
+template<class T = void> struct minus {
   constexpr T operator()(const T& x, const T& y) const;
 };
 \end{itemdecl}
@@ -13450,8 +13450,8 @@ constexpr T operator()(const T& x, const T& y) const;
 
 \indexlibrary{\idxcode{minus<>}}%
 \begin{itemdecl}
-template <> struct minus<void> {
-  template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<> struct minus<void> {
+  template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) - std::forward<U>(u));
 
   using is_transparent = @\unspec@;
@@ -13460,7 +13460,7 @@ template <> struct minus<void> {
 
 \indexlibrarymember{operator()}{minus<>}%
 \begin{itemdecl}
-template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) - std::forward<U>(u));
 \end{itemdecl}
 
@@ -13472,7 +13472,7 @@ template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \indexlibrary{\idxcode{multiplies}}%
 \begin{itemdecl}
-template <class T = void> struct multiplies {
+template<class T = void> struct multiplies {
   constexpr T operator()(const T& x, const T& y) const;
 };
 \end{itemdecl}
@@ -13488,8 +13488,8 @@ constexpr T operator()(const T& x, const T& y) const;
 
 \indexlibrary{\idxcode{multiplies<>}}%
 \begin{itemdecl}
-template <> struct multiplies<void> {
-  template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<> struct multiplies<void> {
+  template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) * std::forward<U>(u));
 
   using is_transparent = @\unspec@;
@@ -13498,7 +13498,7 @@ template <> struct multiplies<void> {
 
 \indexlibrarymember{operator()}{multiplies<>}%
 \begin{itemdecl}
-template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) * std::forward<U>(u));
 \end{itemdecl}
 
@@ -13510,7 +13510,7 @@ template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \indexlibrary{\idxcode{divides}}%
 \begin{itemdecl}
-template <class T = void> struct divides {
+template<class T = void> struct divides {
   constexpr T operator()(const T& x, const T& y) const;
 };
 \end{itemdecl}
@@ -13526,8 +13526,8 @@ constexpr T operator()(const T& x, const T& y) const;
 
 \indexlibrary{\idxcode{divides<>}}%
 \begin{itemdecl}
-template <> struct divides<void> {
-  template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<> struct divides<void> {
+  template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) / std::forward<U>(u));
 
   using is_transparent = @\unspec@;
@@ -13536,7 +13536,7 @@ template <> struct divides<void> {
 
 \indexlibrarymember{operator()}{divides<>}%
 \begin{itemdecl}
-template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) / std::forward<U>(u));
 \end{itemdecl}
 
@@ -13548,7 +13548,7 @@ template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \indexlibrary{\idxcode{modulus}}%
 \begin{itemdecl}
-template <class T = void> struct modulus {
+template<class T = void> struct modulus {
   constexpr T operator()(const T& x, const T& y) const;
 };
 \end{itemdecl}
@@ -13564,8 +13564,8 @@ constexpr T operator()(const T& x, const T& y) const;
 
 \indexlibrary{\idxcode{modulus<>}}%
 \begin{itemdecl}
-template <> struct modulus<void> {
-  template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<> struct modulus<void> {
+  template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) % std::forward<U>(u));
 
   using is_transparent = @\unspec@;
@@ -13574,7 +13574,7 @@ template <> struct modulus<void> {
 
 \indexlibrarymember{operator()}{modulus<>}%
 \begin{itemdecl}
-template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) % std::forward<U>(u));
 \end{itemdecl}
 
@@ -13586,7 +13586,7 @@ template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \indexlibrary{\idxcode{negate}}%
 \begin{itemdecl}
-template <class T = void> struct negate {
+template<class T = void> struct negate {
   constexpr T operator()(const T& x) const;
 };
 \end{itemdecl}
@@ -13602,8 +13602,8 @@ constexpr T operator()(const T& x) const;
 
 \indexlibrary{\idxcode{negate<>}}%
 \begin{itemdecl}
-template <> struct negate<void> {
-  template <class T> constexpr auto operator()(T&& t) const
+template<> struct negate<void> {
+  template<class T> constexpr auto operator()(T&& t) const
     -> decltype(-std::forward<T>(t));
 
   using is_transparent = @\unspec@;
@@ -13612,7 +13612,7 @@ template <> struct negate<void> {
 
 \indexlibrarymember{operator()}{negate<>}%
 \begin{itemdecl}
-template <class T> constexpr auto operator()(T&& t) const
+template<class T> constexpr auto operator()(T&& t) const
     -> decltype(-std::forward<T>(t));
 \end{itemdecl}
 
@@ -13648,7 +13648,7 @@ is also consistent with the partial order imposed by those built-in operators.
 
 \indexlibrary{\idxcode{equal_to}}%
 \begin{itemdecl}
-template <class T = void> struct equal_to {
+template<class T = void> struct equal_to {
   constexpr bool operator()(const T& x, const T& y) const;
 };
 \end{itemdecl}
@@ -13664,8 +13664,8 @@ constexpr bool operator()(const T& x, const T& y) const;
 
 \indexlibrary{\idxcode{equal_to<>}}%
 \begin{itemdecl}
-template <> struct equal_to<void> {
-  template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<> struct equal_to<void> {
+  template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) == std::forward<U>(u));
 
   using is_transparent = @\unspec@;
@@ -13674,7 +13674,7 @@ template <> struct equal_to<void> {
 
 \indexlibrarymember{operator()}{equal_to<>}%
 \begin{itemdecl}
-template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) == std::forward<U>(u));
 \end{itemdecl}
 
@@ -13686,7 +13686,7 @@ template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \indexlibrary{\idxcode{not_equal_to}}%
 \begin{itemdecl}
-template <class T = void> struct not_equal_to {
+template<class T = void> struct not_equal_to {
   constexpr bool operator()(const T& x, const T& y) const;
 };
 \end{itemdecl}
@@ -13702,8 +13702,8 @@ constexpr bool operator()(const T& x, const T& y) const;
 
 \indexlibrary{\idxcode{not_equal_to<>}}%
 \begin{itemdecl}
-template <> struct not_equal_to<void> {
-  template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<> struct not_equal_to<void> {
+  template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) != std::forward<U>(u));
 
   using is_transparent = @\unspec@;
@@ -13712,7 +13712,7 @@ template <> struct not_equal_to<void> {
 
 \indexlibrarymember{operator()}{not_equal_to<>}%
 \begin{itemdecl}
-template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) != std::forward<U>(u));
 \end{itemdecl}
 
@@ -13724,7 +13724,7 @@ template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \indexlibrary{\idxcode{greater}}%
 \begin{itemdecl}
-template <class T = void> struct greater {
+template<class T = void> struct greater {
   constexpr bool operator()(const T& x, const T& y) const;
 };
 \end{itemdecl}
@@ -13740,8 +13740,8 @@ constexpr bool operator()(const T& x, const T& y) const;
 
 \indexlibrary{\idxcode{greater<>}}%
 \begin{itemdecl}
-template <> struct greater<void> {
-  template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<> struct greater<void> {
+  template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) > std::forward<U>(u));
 
   using is_transparent = @\unspec@;
@@ -13750,7 +13750,7 @@ template <> struct greater<void> {
 
 \indexlibrarymember{operator()}{greater<>}%
 \begin{itemdecl}
-template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) > std::forward<U>(u));
 \end{itemdecl}
 
@@ -13762,7 +13762,7 @@ template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \indexlibrary{\idxcode{less}}%
 \begin{itemdecl}
-template <class T = void> struct less {
+template<class T = void> struct less {
   constexpr bool operator()(const T& x, const T& y) const;
 };
 \end{itemdecl}
@@ -13778,8 +13778,8 @@ constexpr bool operator()(const T& x, const T& y) const;
 
 \indexlibrary{\idxcode{less<>}}%
 \begin{itemdecl}
-template <> struct less<void> {
-  template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<> struct less<void> {
+  template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) < std::forward<U>(u));
 
   using is_transparent = @\unspec@;
@@ -13788,7 +13788,7 @@ template <> struct less<void> {
 
 \indexlibrarymember{operator()}{less<>}%
 \begin{itemdecl}
-template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) < std::forward<U>(u));
 \end{itemdecl}
 
@@ -13800,7 +13800,7 @@ template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \indexlibrary{\idxcode{greater_equal}}%
 \begin{itemdecl}
-template <class T = void> struct greater_equal {
+template<class T = void> struct greater_equal {
   constexpr bool operator()(const T& x, const T& y) const;
 };
 \end{itemdecl}
@@ -13816,8 +13816,8 @@ constexpr bool operator()(const T& x, const T& y) const;
 
 \indexlibrary{\idxcode{greater_equal<>}}%
 \begin{itemdecl}
-template <> struct greater_equal<void> {
-  template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<> struct greater_equal<void> {
+  template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) >= std::forward<U>(u));
 
   using is_transparent = @\unspec@;
@@ -13826,7 +13826,7 @@ template <> struct greater_equal<void> {
 
 \indexlibrarymember{operator()}{greater_equal<>}%
 \begin{itemdecl}
-template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) >= std::forward<U>(u));
 \end{itemdecl}
 
@@ -13838,7 +13838,7 @@ template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \indexlibrary{\idxcode{less_equal}}%
 \begin{itemdecl}
-template <class T = void> struct less_equal {
+template<class T = void> struct less_equal {
   constexpr bool operator()(const T& x, const T& y) const;
 };
 \end{itemdecl}
@@ -13854,8 +13854,8 @@ constexpr bool operator()(const T& x, const T& y) const;
 
 \indexlibrary{\idxcode{less_equal<>}}%
 \begin{itemdecl}
-template <> struct less_equal<void> {
-  template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<> struct less_equal<void> {
+  template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) <= std::forward<U>(u));
 
   using is_transparent = @\unspec@;
@@ -13864,7 +13864,7 @@ template <> struct less_equal<void> {
 
 \indexlibrarymember{operator()}{less_equal<>}%
 \begin{itemdecl}
-template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) <= std::forward<U>(u));
 \end{itemdecl}
 
@@ -13883,7 +13883,7 @@ operators in the language~(\ref{expr.log.and}, \ref{expr.log.or}, \ref{expr.unar
 
 \indexlibrary{\idxcode{logical_and}}%
 \begin{itemdecl}
-template <class T = void> struct logical_and {
+template<class T = void> struct logical_and {
   constexpr bool operator()(const T& x, const T& y) const;
 };
 \end{itemdecl}
@@ -13899,8 +13899,8 @@ constexpr bool operator()(const T& x, const T& y) const;
 
 \indexlibrary{\idxcode{logical_and<>}}%
 \begin{itemdecl}
-template <> struct logical_and<void> {
-  template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<> struct logical_and<void> {
+  template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) && std::forward<U>(u));
 
   using is_transparent = @\unspec@;
@@ -13909,7 +13909,7 @@ template <> struct logical_and<void> {
 
 \indexlibrarymember{operator()}{logical_and<>}%
 \begin{itemdecl}
-template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) && std::forward<U>(u));
 \end{itemdecl}
 
@@ -13921,7 +13921,7 @@ template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \indexlibrary{\idxcode{logical_or}}%
 \begin{itemdecl}
-template <class T = void> struct logical_or {
+template<class T = void> struct logical_or {
   constexpr bool operator()(const T& x, const T& y) const;
 };
 \end{itemdecl}
@@ -13937,8 +13937,8 @@ constexpr bool operator()(const T& x, const T& y) const;
 
 \indexlibrary{\idxcode{logical_or<>}}%
 \begin{itemdecl}
-template <> struct logical_or<void> {
-  template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<> struct logical_or<void> {
+  template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) || std::forward<U>(u));
 
   using is_transparent = @\unspec@;
@@ -13947,7 +13947,7 @@ template <> struct logical_or<void> {
 
 \indexlibrarymember{operator()}{logical_or<>}%
 \begin{itemdecl}
-template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) || std::forward<U>(u));
 \end{itemdecl}
 
@@ -13959,7 +13959,7 @@ template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \indexlibrary{\idxcode{logical_not}}%
 \begin{itemdecl}
-template <class T = void> struct logical_not {
+template<class T = void> struct logical_not {
   constexpr bool operator()(const T& x) const;
 };
 \end{itemdecl}
@@ -13975,8 +13975,8 @@ constexpr bool operator()(const T& x) const;
 
 \indexlibrary{\idxcode{logical_not<>}}%
 \begin{itemdecl}
-template <> struct logical_not<void> {
-  template <class T> constexpr auto operator()(T&& t) const
+template<> struct logical_not<void> {
+  template<class T> constexpr auto operator()(T&& t) const
     -> decltype(!std::forward<T>(t));
 
   using is_transparent = @\unspec@;
@@ -13985,7 +13985,7 @@ template <> struct logical_not<void> {
 
 \indexlibrarymember{operator()}{logical_not<>}%
 \begin{itemdecl}
-template <class T> constexpr auto operator()(T&& t) const
+template<class T> constexpr auto operator()(T&& t) const
     -> decltype(!std::forward<T>(t));
 \end{itemdecl}
 
@@ -14005,7 +14005,7 @@ operators in the language~(\ref{expr.bit.and}, \ref{expr.or},
 
 \indexlibrary{\idxcode{bit_and}}%
 \begin{itemdecl}
-template <class T = void> struct bit_and {
+template<class T = void> struct bit_and {
   constexpr T operator()(const T& x, const T& y) const;
 };
 \end{itemdecl}
@@ -14021,8 +14021,8 @@ constexpr T operator()(const T& x, const T& y) const;
 
 \indexlibrary{\idxcode{bit_and<>}}%
 \begin{itemdecl}
-template <> struct bit_and<void> {
-  template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<> struct bit_and<void> {
+  template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) & std::forward<U>(u));
 
   using is_transparent = @\unspec@;
@@ -14031,7 +14031,7 @@ template <> struct bit_and<void> {
 
 \indexlibrarymember{operator()}{bit_and<>}%
 \begin{itemdecl}
-template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) & std::forward<U>(u));
 \end{itemdecl}
 
@@ -14043,7 +14043,7 @@ template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \indexlibrary{\idxcode{bit_or}}%
 \begin{itemdecl}
-template <class T = void> struct bit_or {
+template<class T = void> struct bit_or {
   constexpr T operator()(const T& x, const T& y) const;
 };
 \end{itemdecl}
@@ -14059,8 +14059,8 @@ constexpr T operator()(const T& x, const T& y) const;
 
 \indexlibrary{\idxcode{bit_or<>}}%
 \begin{itemdecl}
-template <> struct bit_or<void> {
-  template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<> struct bit_or<void> {
+  template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) | std::forward<U>(u));
 
   using is_transparent = @\unspec@;
@@ -14069,7 +14069,7 @@ template <> struct bit_or<void> {
 
 \indexlibrarymember{operator()}{bit_or<>}%
 \begin{itemdecl}
-template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) | std::forward<U>(u));
 \end{itemdecl}
 
@@ -14081,7 +14081,7 @@ template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \indexlibrary{\idxcode{bit_xor}}%
 \begin{itemdecl}
-template <class T = void> struct bit_xor {
+template<class T = void> struct bit_xor {
   constexpr T operator()(const T& x, const T& y) const;
 };
 \end{itemdecl}
@@ -14097,8 +14097,8 @@ constexpr T operator()(const T& x, const T& y) const;
 
 \indexlibrary{\idxcode{bit_xor<>}}%
 \begin{itemdecl}
-template <> struct bit_xor<void> {
-  template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<> struct bit_xor<void> {
+  template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) ^ std::forward<U>(u));
 
   using is_transparent = @\unspec@;
@@ -14107,7 +14107,7 @@ template <> struct bit_xor<void> {
 
 \indexlibrarymember{operator()}{bit_xor<>}%
 \begin{itemdecl}
-template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
+template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) ^ std::forward<U>(u));
 \end{itemdecl}
 
@@ -14118,7 +14118,7 @@ template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
 \rSec3[bitwise.operations.not]{Class template \tcode{bit_not}}
 
 \begin{itemdecl}
-template <class T = void> struct bit_not {
+template<class T = void> struct bit_not {
   constexpr T operator()(const T& x) const;
 };
 \end{itemdecl}
@@ -14134,8 +14134,8 @@ constexpr T operator()(const T& x) const;
 
 \indexlibrary{\idxcode{bit_not<>}}%
 \begin{itemdecl}
-template <> struct bit_not<void> {
-  template <class T> constexpr auto operator()(T&& t) const
+template<> struct bit_not<void> {
+  template<class T> constexpr auto operator()(T&& t) const
     -> decltype(~std::forward<T>(t));
 
   using is_transparent = @\unspec@;
@@ -14144,7 +14144,7 @@ template <> struct bit_not<void> {
 
 \indexlibrarymember{operator()}{bit_not<>}%
 \begin{itemdecl}
-template <class T> constexpr auto operator()(T&&) const
+template<class T> constexpr auto operator()(T&&) const
     -> decltype(~std::forward<T>(t));
 \end{itemdecl}
 
@@ -14157,7 +14157,7 @@ template <class T> constexpr auto operator()(T&&) const
 
 \indexlibrary{\idxcode{not_fn}}%
 \begin{itemdecl}
-template <class F> @\unspec@ not_fn(F&& f);
+template<class F> @\unspec@ not_fn(F&& f);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -14579,20 +14579,20 @@ namespace std {
   template<class F> function(F) -> function<@\seebelow@>;
 
   // \ref{func.wrap.func.nullptr}, Null pointer comparisons
-  template <class R, class... ArgTypes>
+  template<class R, class... ArgTypes>
     bool operator==(const function<R(ArgTypes...)>&, nullptr_t) noexcept;
 
-  template <class R, class... ArgTypes>
+  template<class R, class... ArgTypes>
     bool operator==(nullptr_t, const function<R(ArgTypes...)>&) noexcept;
 
-  template <class R, class... ArgTypes>
+  template<class R, class... ArgTypes>
     bool operator!=(const function<R(ArgTypes...)>&, nullptr_t) noexcept;
 
-  template <class R, class... ArgTypes>
+  template<class R, class... ArgTypes>
     bool operator!=(nullptr_t, const function<R(ArgTypes...)>&) noexcept;
 
   // \ref{func.wrap.func.alg}, specialized algorithms
-  template <class R, class... ArgTypes>
+  template<class R, class... ArgTypes>
     void swap(function<R(ArgTypes...)>&, function<R(ArgTypes...)>&) noexcept;
 }
 \end{codeblock}
@@ -14898,9 +14898,9 @@ a pointer to the stored function target; otherwise a null pointer.
 
 \indexlibrarymember{operator==}{function}%
 \begin{itemdecl}
-template <class R, class... ArgTypes>
+template<class R, class... ArgTypes>
   bool operator==(const function<R(ArgTypes...)>& f, nullptr_t) noexcept;
-template <class R, class... ArgTypes>
+template<class R, class... ArgTypes>
   bool operator==(nullptr_t, const function<R(ArgTypes...)>& f) noexcept;
 \end{itemdecl}
 
@@ -14910,9 +14910,9 @@ template <class R, class... ArgTypes>
 
 \indexlibrarymember{operator"!=}{function}%
 \begin{itemdecl}
-template <class R, class... ArgTypes>
+template<class R, class... ArgTypes>
   bool operator!=(const function<R(ArgTypes...)>& f, nullptr_t) noexcept;
-template <class R, class... ArgTypes>
+template<class R, class... ArgTypes>
   bool operator!=(nullptr_t, const function<R(ArgTypes...)>& f) noexcept;
 \end{itemdecl}
 
@@ -14969,13 +14969,13 @@ In general, the Boyer-Moore searcher will use more memory and give better runtim
 
 \indexlibrary{\idxcode{default_searcher}}%
 \begin{codeblock}
-template <class ForwardIterator1, class BinaryPredicate = equal_to<>>
+template<class ForwardIterator1, class BinaryPredicate = equal_to<>>
   class default_searcher {
   public:
     default_searcher(ForwardIterator1 pat_first, ForwardIterator1 pat_last,
                      BinaryPredicate pred = BinaryPredicate());
 
-    template <class ForwardIterator2>
+    template<class ForwardIterator2>
       pair<ForwardIterator2, ForwardIterator2>
         operator()(ForwardIterator2 first, ForwardIterator2 last) const;
 
@@ -15028,9 +15028,9 @@ otherwise \tcode{j == next(i, distance(pat_first_, pat_last_))}.
 
 \indexlibrary{\idxcode{boyer_moore_searcher}}%
 \begin{codeblock}
-template <class RandomAccessIterator1,
-          class Hash = hash<typename iterator_traits<RandomAccessIterator1>::value_type>,
-          class BinaryPredicate = equal_to<>>
+template<class RandomAccessIterator1,
+         class Hash = hash<typename iterator_traits<RandomAccessIterator1>::value_type>,
+         class BinaryPredicate = equal_to<>>
   class boyer_moore_searcher {
   public:
     boyer_moore_searcher(RandomAccessIterator1 pat_first,
@@ -15038,7 +15038,7 @@ template <class RandomAccessIterator1,
                          Hash hf = Hash(),
                          BinaryPredicate pred = BinaryPredicate());
 
-    template <class RandomAccessIterator2>
+    template<class RandomAccessIterator2>
       pair<RandomAccessIterator2, RandomAccessIterator2>
         operator()(RandomAccessIterator2 first, RandomAccessIterator2 last) const;
 
@@ -15084,7 +15084,7 @@ May throw \tcode{bad_alloc} if additional memory needed for internal data struct
 
 \indexlibrarymember{operator()}{boyer_moore_searcher}%
 \begin{itemdecl}
-template <class RandomAccessIterator2>
+template<class RandomAccessIterator2>
   pair<RandomAccessIterator2, RandomAccessIterator2>
     operator()(RandomAccessIterator2 first, RandomAccessIterator2 last) const;
 \end{itemdecl}
@@ -15121,9 +15121,9 @@ At most \tcode{(last - first) * (pat_last_ - pat_first_)} applications of the pr
 
 \indexlibrary{\idxcode{boyer_moore_horspool_searcher}}%
 \begin{codeblock}
-template <class RandomAccessIterator1,
-          class Hash = hash<typename iterator_traits<RandomAccessIterator1>::value_type>,
-          class BinaryPredicate = equal_to<>>
+template<class RandomAccessIterator1,
+         class Hash = hash<typename iterator_traits<RandomAccessIterator1>::value_type>,
+         class BinaryPredicate = equal_to<>>
   class boyer_moore_horspool_searcher {
   public:
     boyer_moore_horspool_searcher(RandomAccessIterator1 pat_first,
@@ -15131,7 +15131,7 @@ template <class RandomAccessIterator1,
                                   Hash hf = Hash(),
                                   BinaryPredicate pred = BinaryPredicate());
 
-    template <class RandomAccessIterator2>
+    template<class RandomAccessIterator2>
       pair<RandomAccessIterator2, RandomAccessIterator2>
         operator()(RandomAccessIterator2 first, RandomAccessIterator2 last) const;
 
@@ -15177,7 +15177,7 @@ May throw \tcode{bad_alloc} if additional memory needed for internal data struct
 
 \indexlibrarymember{operator()}{boyer_moore_horspool_searcher}%
 \begin{itemdecl}
-template <class RandomAccessIterator2>
+template<class RandomAccessIterator2>
   pair<RandomAccessIterator2, RandomAccessIterator2>
     operator()(RandomAccessIterator2 first, RandomAccessIterator2 last) const;
 \end{itemdecl}
@@ -15335,202 +15335,202 @@ named \tcode{type}, which shall be a synonym for the modified type.
 \begin{codeblock}
 namespace std {
   // \ref{meta.help}, helper class
-  template <class T, T v> struct integral_constant;
+  template<class T, T v> struct integral_constant;
 
-  template <bool B>
+  template<bool B>
     using bool_constant = integral_constant<bool, B>;
   using true_type  = bool_constant<true>;
   using false_type = bool_constant<false>;
 
   // \ref{meta.unary.cat}, primary type categories
-  template <class T> struct is_void;
-  template <class T> struct is_null_pointer;
-  template <class T> struct is_integral;
-  template <class T> struct is_floating_point;
-  template <class T> struct is_array;
-  template <class T> struct is_pointer;
-  template <class T> struct is_lvalue_reference;
-  template <class T> struct is_rvalue_reference;
-  template <class T> struct is_member_object_pointer;
-  template <class T> struct is_member_function_pointer;
-  template <class T> struct is_enum;
-  template <class T> struct is_union;
-  template <class T> struct is_class;
-  template <class T> struct is_function;
+  template<class T> struct is_void;
+  template<class T> struct is_null_pointer;
+  template<class T> struct is_integral;
+  template<class T> struct is_floating_point;
+  template<class T> struct is_array;
+  template<class T> struct is_pointer;
+  template<class T> struct is_lvalue_reference;
+  template<class T> struct is_rvalue_reference;
+  template<class T> struct is_member_object_pointer;
+  template<class T> struct is_member_function_pointer;
+  template<class T> struct is_enum;
+  template<class T> struct is_union;
+  template<class T> struct is_class;
+  template<class T> struct is_function;
 
   // \ref{meta.unary.comp}, composite type categories
-  template <class T> struct is_reference;
-  template <class T> struct is_arithmetic;
-  template <class T> struct is_fundamental;
-  template <class T> struct is_object;
-  template <class T> struct is_scalar;
-  template <class T> struct is_compound;
-  template <class T> struct is_member_pointer;
+  template<class T> struct is_reference;
+  template<class T> struct is_arithmetic;
+  template<class T> struct is_fundamental;
+  template<class T> struct is_object;
+  template<class T> struct is_scalar;
+  template<class T> struct is_compound;
+  template<class T> struct is_member_pointer;
 
   // \ref{meta.unary.prop}, type properties
-  template <class T> struct is_const;
-  template <class T> struct is_volatile;
-  template <class T> struct is_trivial;
-  template <class T> struct is_trivially_copyable;
-  template <class T> struct is_standard_layout;
-  template <class T> struct is_empty;
-  template <class T> struct is_polymorphic;
-  template <class T> struct is_abstract;
-  template <class T> struct is_final;
-  template <class T> struct is_aggregate;
+  template<class T> struct is_const;
+  template<class T> struct is_volatile;
+  template<class T> struct is_trivial;
+  template<class T> struct is_trivially_copyable;
+  template<class T> struct is_standard_layout;
+  template<class T> struct is_empty;
+  template<class T> struct is_polymorphic;
+  template<class T> struct is_abstract;
+  template<class T> struct is_final;
+  template<class T> struct is_aggregate;
 
-  template <class T> struct is_signed;
-  template <class T> struct is_unsigned;
+  template<class T> struct is_signed;
+  template<class T> struct is_unsigned;
 
-  template <class T, class... Args> struct is_constructible;
-  template <class T> struct is_default_constructible;
-  template <class T> struct is_copy_constructible;
-  template <class T> struct is_move_constructible;
+  template<class T, class... Args> struct is_constructible;
+  template<class T> struct is_default_constructible;
+  template<class T> struct is_copy_constructible;
+  template<class T> struct is_move_constructible;
 
-  template <class T, class U> struct is_assignable;
-  template <class T> struct is_copy_assignable;
-  template <class T> struct is_move_assignable;
+  template<class T, class U> struct is_assignable;
+  template<class T> struct is_copy_assignable;
+  template<class T> struct is_move_assignable;
 
-  template <class T, class U> struct is_swappable_with;
-  template <class T> struct is_swappable;
+  template<class T, class U> struct is_swappable_with;
+  template<class T> struct is_swappable;
 
-  template <class T> struct is_destructible;
+  template<class T> struct is_destructible;
 
-  template <class T, class... Args> struct is_trivially_constructible;
-  template <class T> struct is_trivially_default_constructible;
-  template <class T> struct is_trivially_copy_constructible;
-  template <class T> struct is_trivially_move_constructible;
+  template<class T, class... Args> struct is_trivially_constructible;
+  template<class T> struct is_trivially_default_constructible;
+  template<class T> struct is_trivially_copy_constructible;
+  template<class T> struct is_trivially_move_constructible;
 
-  template <class T, class U> struct is_trivially_assignable;
-  template <class T> struct is_trivially_copy_assignable;
-  template <class T> struct is_trivially_move_assignable;
-  template <class T> struct is_trivially_destructible;
+  template<class T, class U> struct is_trivially_assignable;
+  template<class T> struct is_trivially_copy_assignable;
+  template<class T> struct is_trivially_move_assignable;
+  template<class T> struct is_trivially_destructible;
 
-  template <class T, class... Args> struct is_nothrow_constructible;
-  template <class T> struct is_nothrow_default_constructible;
-  template <class T> struct is_nothrow_copy_constructible;
-  template <class T> struct is_nothrow_move_constructible;
+  template<class T, class... Args> struct is_nothrow_constructible;
+  template<class T> struct is_nothrow_default_constructible;
+  template<class T> struct is_nothrow_copy_constructible;
+  template<class T> struct is_nothrow_move_constructible;
 
-  template <class T, class U> struct is_nothrow_assignable;
-  template <class T> struct is_nothrow_copy_assignable;
-  template <class T> struct is_nothrow_move_assignable;
+  template<class T, class U> struct is_nothrow_assignable;
+  template<class T> struct is_nothrow_copy_assignable;
+  template<class T> struct is_nothrow_move_assignable;
 
-  template <class T, class U> struct is_nothrow_swappable_with;
-  template <class T> struct is_nothrow_swappable;
+  template<class T, class U> struct is_nothrow_swappable_with;
+  template<class T> struct is_nothrow_swappable;
 
-  template <class T> struct is_nothrow_destructible;
+  template<class T> struct is_nothrow_destructible;
 
-  template <class T> struct has_virtual_destructor;
+  template<class T> struct has_virtual_destructor;
 
-  template <class T> struct has_unique_object_representations;
+  template<class T> struct has_unique_object_representations;
 
   // \ref{meta.unary.prop.query}, type property queries
-  template <class T> struct alignment_of;
-  template <class T> struct rank;
-  template <class T, unsigned I = 0> struct extent;
+  template<class T> struct alignment_of;
+  template<class T> struct rank;
+  template<class T, unsigned I = 0> struct extent;
 
   // \ref{meta.rel}, type relations
-  template <class T, class U> struct is_same;
-  template <class Base, class Derived> struct is_base_of;
-  template <class From, class To> struct is_convertible;
+  template<class T, class U> struct is_same;
+  template<class Base, class Derived> struct is_base_of;
+  template<class From, class To> struct is_convertible;
 
-  template <class Fn, class... ArgTypes> struct is_invocable;
-  template <class R, class Fn, class... ArgTypes> struct is_invocable_r;
+  template<class Fn, class... ArgTypes> struct is_invocable;
+  template<class R, class Fn, class... ArgTypes> struct is_invocable_r;
 
-  template <class Fn, class... ArgTypes> struct is_nothrow_invocable;
-  template <class R, class Fn, class... ArgTypes> struct is_nothrow_invocable_r;
+  template<class Fn, class... ArgTypes> struct is_nothrow_invocable;
+  template<class R, class Fn, class... ArgTypes> struct is_nothrow_invocable_r;
 
   // \ref{meta.trans.cv}, const-volatile modifications
-  template <class T> struct remove_const;
-  template <class T> struct remove_volatile;
-  template <class T> struct remove_cv;
-  template <class T> struct add_const;
-  template <class T> struct add_volatile;
-  template <class T> struct add_cv;
+  template<class T> struct remove_const;
+  template<class T> struct remove_volatile;
+  template<class T> struct remove_cv;
+  template<class T> struct add_const;
+  template<class T> struct add_volatile;
+  template<class T> struct add_cv;
 
-  template <class T>
+  template<class T>
     using remove_const_t    = typename remove_const<T>::type;
-  template <class T>
+  template<class T>
     using remove_volatile_t = typename remove_volatile<T>::type;
-  template <class T>
+  template<class T>
     using remove_cv_t       = typename remove_cv<T>::type;
-  template <class T>
+  template<class T>
     using add_const_t       = typename add_const<T>::type;
-  template <class T>
+  template<class T>
     using add_volatile_t    = typename add_volatile<T>::type;
-  template <class T>
+  template<class T>
     using add_cv_t          = typename add_cv<T>::type;
 
   // \ref{meta.trans.ref}, reference modifications
-  template <class T> struct remove_reference;
-  template <class T> struct add_lvalue_reference;
-  template <class T> struct add_rvalue_reference;
+  template<class T> struct remove_reference;
+  template<class T> struct add_lvalue_reference;
+  template<class T> struct add_rvalue_reference;
 
-  template <class T>
+  template<class T>
     using remove_reference_t     = typename remove_reference<T>::type;
-  template <class T>
+  template<class T>
     using add_lvalue_reference_t = typename add_lvalue_reference<T>::type;
-  template <class T>
+  template<class T>
     using add_rvalue_reference_t = typename add_rvalue_reference<T>::type;
 
   // \ref{meta.trans.sign}, sign modifications
-  template <class T> struct make_signed;
-  template <class T> struct make_unsigned;
+  template<class T> struct make_signed;
+  template<class T> struct make_unsigned;
 
-  template <class T>
+  template<class T>
     using make_signed_t   = typename make_signed<T>::type;
-  template <class T>
+  template<class T>
     using make_unsigned_t = typename make_unsigned<T>::type;
 
   // \ref{meta.trans.arr}, array modifications
-  template <class T> struct remove_extent;
-  template <class T> struct remove_all_extents;
+  template<class T> struct remove_extent;
+  template<class T> struct remove_all_extents;
 
-  template <class T>
+  template<class T>
     using remove_extent_t      = typename remove_extent<T>::type;
-  template <class T>
+  template<class T>
     using remove_all_extents_t = typename remove_all_extents<T>::type;
 
   // \ref{meta.trans.ptr}, pointer modifications
-  template <class T> struct remove_pointer;
-  template <class T> struct add_pointer;
+  template<class T> struct remove_pointer;
+  template<class T> struct add_pointer;
 
-  template <class T>
+  template<class T>
     using remove_pointer_t = typename remove_pointer<T>::type;
-  template <class T>
+  template<class T>
     using add_pointer_t    = typename add_pointer<T>::type;
 
   // \ref{meta.trans.other}, other transformations
-  template <size_t Len, size_t Align = @\textit{default-alignment}@> // see \ref{meta.trans.other}
+  template<size_t Len, size_t Align = @\textit{default-alignment}@> // see \ref{meta.trans.other}
     struct aligned_storage;
-  template <size_t Len, class... Types> struct aligned_union;
-  template <class T> struct remove_cvref;
-  template <class T> struct decay;
-  template <bool, class T = void> struct enable_if;
-  template <bool, class T, class F> struct conditional;
-  template <class... T> struct common_type;
-  template <class T> struct underlying_type;
-  template <class Fn, class... ArgTypes> struct invoke_result;
+  template<size_t Len, class... Types> struct aligned_union;
+  template<class T> struct remove_cvref;
+  template<class T> struct decay;
+  template<bool, class T = void> struct enable_if;
+  template<bool, class T, class F> struct conditional;
+  template<class... T> struct common_type;
+  template<class T> struct underlying_type;
+  template<class Fn, class... ArgTypes> struct invoke_result;
 
-  template <size_t Len, size_t Align = @\textit{default-alignment}@> // see \ref{meta.trans.other}
+  template<size_t Len, size_t Align = @\textit{default-alignment}@> // see \ref{meta.trans.other}
     using aligned_storage_t = typename aligned_storage<Len, Align>::type;
-  template <size_t Len, class... Types>
+  template<size_t Len, class... Types>
     using aligned_union_t   = typename aligned_union<Len, Types...>::type;
-  template <class T>
+  template<class T>
     using remove_cvref_t    = typename remove_cvref<T>::type;
-  template <class T>
+  template<class T>
     using decay_t           = typename decay<T>::type;
-  template <bool b, class T = void>
+  template<bool b, class T = void>
     using enable_if_t       = typename enable_if<b, T>::type;
-  template <bool b, class T, class F>
+  template<bool b, class T, class F>
     using conditional_t     = typename conditional<b, T, F>::type;
-  template <class... T>
+  template<class... T>
     using common_type_t     = typename common_type<T...>::type;
-  template <class T>
+  template<class T>
     using underlying_type_t = typename underlying_type<T>::type;
-  template <class Fn, class... ArgTypes>
+  template<class Fn, class... ArgTypes>
     using invoke_result_t   = typename invoke_result<Fn, ArgTypes...>::type;
-  template <class...>
+  template<class...>
     using void_t            = void;
 
   // \ref{meta.logical}, logical operator traits
@@ -15546,170 +15546,170 @@ namespace std {
   };
 
   // \ref{meta.unary.cat}, primary type categories
-  template <class T>
+  template<class T>
     inline constexpr bool is_void_v = is_void<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_null_pointer_v = is_null_pointer<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_integral_v = is_integral<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_floating_point_v = is_floating_point<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_array_v = is_array<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_pointer_v = is_pointer<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_lvalue_reference_v = is_lvalue_reference<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_rvalue_reference_v = is_rvalue_reference<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_member_object_pointer_v = is_member_object_pointer<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_member_function_pointer_v = is_member_function_pointer<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_enum_v = is_enum<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_union_v = is_union<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_class_v = is_class<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_function_v = is_function<T>::value;
 
   // \ref{meta.unary.comp}, composite type categories
-  template <class T>
+  template<class T>
     inline constexpr bool is_reference_v = is_reference<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_arithmetic_v = is_arithmetic<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_fundamental_v = is_fundamental<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_object_v = is_object<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_scalar_v = is_scalar<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_compound_v = is_compound<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_member_pointer_v = is_member_pointer<T>::value;
 
   // \ref{meta.unary.prop}, type properties
-  template <class T>
+  template<class T>
     inline constexpr bool is_const_v = is_const<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_volatile_v = is_volatile<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_trivial_v = is_trivial<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_trivially_copyable_v = is_trivially_copyable<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_standard_layout_v = is_standard_layout<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_empty_v = is_empty<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_polymorphic_v = is_polymorphic<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_abstract_v = is_abstract<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_final_v = is_final<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_aggregate_v = is_aggregate<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_signed_v = is_signed<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_unsigned_v = is_unsigned<T>::value;
-  template <class T, class... Args>
+  template<class T, class... Args>
     inline constexpr bool is_constructible_v = is_constructible<T, Args...>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_default_constructible_v = is_default_constructible<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_copy_constructible_v = is_copy_constructible<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_move_constructible_v = is_move_constructible<T>::value;
-  template <class T, class U>
+  template<class T, class U>
     inline constexpr bool is_assignable_v = is_assignable<T, U>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_copy_assignable_v = is_copy_assignable<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_move_assignable_v = is_move_assignable<T>::value;
-  template <class T, class U>
+  template<class T, class U>
     inline constexpr bool is_swappable_with_v = is_swappable_with<T, U>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_swappable_v = is_swappable<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_destructible_v = is_destructible<T>::value;
-  template <class T, class... Args>
+  template<class T, class... Args>
     inline constexpr bool is_trivially_constructible_v
       = is_trivially_constructible<T, Args...>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_trivially_default_constructible_v
       = is_trivially_default_constructible<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_trivially_copy_constructible_v
       = is_trivially_copy_constructible<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_trivially_move_constructible_v
       = is_trivially_move_constructible<T>::value;
-  template <class T, class U>
+  template<class T, class U>
     inline constexpr bool is_trivially_assignable_v = is_trivially_assignable<T, U>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_trivially_copy_assignable_v
       = is_trivially_copy_assignable<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_trivially_move_assignable_v
       = is_trivially_move_assignable<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_trivially_destructible_v = is_trivially_destructible<T>::value;
-  template <class T, class... Args>
+  template<class T, class... Args>
     inline constexpr bool is_nothrow_constructible_v
       = is_nothrow_constructible<T, Args...>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_nothrow_default_constructible_v
       = is_nothrow_default_constructible<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_nothrow_copy_constructible_v
     = is_nothrow_copy_constructible<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_nothrow_move_constructible_v
       = is_nothrow_move_constructible<T>::value;
-  template <class T, class U>
+  template<class T, class U>
     inline constexpr bool is_nothrow_assignable_v = is_nothrow_assignable<T, U>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_nothrow_copy_assignable_v = is_nothrow_copy_assignable<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_nothrow_move_assignable_v = is_nothrow_move_assignable<T>::value;
-  template <class T, class U>
+  template<class T, class U>
     inline constexpr bool is_nothrow_swappable_with_v = is_nothrow_swappable_with<T, U>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_nothrow_swappable_v = is_nothrow_swappable<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool is_nothrow_destructible_v = is_nothrow_destructible<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool has_virtual_destructor_v = has_virtual_destructor<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr bool has_unique_object_representations_v
       = has_unique_object_representations<T>::value;
 
   // \ref{meta.unary.prop.query}, type property queries
-  template <class T>
+  template<class T>
     inline constexpr size_t alignment_of_v = alignment_of<T>::value;
-  template <class T>
+  template<class T>
     inline constexpr size_t rank_v = rank<T>::value;
-  template <class T, unsigned I = 0>
+  template<class T, unsigned I = 0>
     inline constexpr size_t extent_v = extent<T, I>::value;
 
   // \ref{meta.rel}, type relations
-  template <class T, class U>
+  template<class T, class U>
     inline constexpr bool is_same_v = is_same<T, U>::value;
-  template <class Base, class Derived>
+  template<class Base, class Derived>
     inline constexpr bool is_base_of_v = is_base_of<Base, Derived>::value;
-  template <class From, class To>
+  template<class From, class To>
     inline constexpr bool is_convertible_v = is_convertible<From, To>::value;
-  template <class Fn, class... ArgTypes>
+  template<class Fn, class... ArgTypes>
     inline constexpr bool is_invocable_v = is_invocable<Fn, ArgTypes...>::value;
-  template <class R, class Fn, class... ArgTypes>
+  template<class R, class Fn, class... ArgTypes>
     inline constexpr bool is_invocable_r_v = is_invocable_r<R, Fn, ArgTypes...>::value;
-  template <class Fn, class... ArgTypes>
+  template<class Fn, class... ArgTypes>
     inline constexpr bool is_nothrow_invocable_v = is_nothrow_invocable<Fn, ArgTypes...>::value;
-  template <class R, class Fn, class... ArgTypes>
+  template<class R, class Fn, class... ArgTypes>
     inline constexpr bool is_nothrow_invocable_r_v
       = is_nothrow_invocable_r<R, Fn, ArgTypes...>::value;
 
@@ -15736,7 +15736,7 @@ to instantiate a template in this subclause.
 \indexlibrarymember{value_type}{integral_constant}%
 \begin{codeblock}
 namespace std {
-  template <class T, T v> struct integral_constant {
+  template<class T, T v> struct integral_constant {
     static constexpr T value = v;
 
     using value_type = T;
@@ -15798,63 +15798,63 @@ has a \tcode{value} member that evaluates to \tcode{true}.
 \lhdr{Template} &   \chdr{Condition}    &   \rhdr{Comments} \\ \capsep
 \endhead
 \indexlibrary{\idxcode{is_void}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_void;}                &
 \tcode{T} is \tcode{void}       &   \\ \rowsep
 \indexlibrary{\idxcode{is_null_pointer}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_null_pointer;}                &
 \tcode{T} is \tcode{nullptr_t}\iref{basic.fundamental}       &   \\ \rowsep
 \indexlibrary{\idxcode{is_integral}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_integral;}        &
 \tcode{T} is an integral type\iref{basic.fundamental}                 &   \\ \rowsep
 \indexlibrary{\idxcode{is_floating_point}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_floating_point;}  &
 \tcode{T} is a floating-point type\iref{basic.fundamental}            &   \\ \rowsep
 \indexlibrary{\idxcode{is_array}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_array;}           &
 \tcode{T} is an array type\iref{basic.compound} of known or unknown extent    &
 Class template \tcode{array}\iref{array}
 is not an array type.                   \\ \rowsep
 \indexlibrary{\idxcode{is_pointer}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_pointer;}         &
 \tcode{T} is a pointer type\iref{basic.compound}                      &
 Includes pointers to functions
 but not pointers to non-static members.                        \\ \rowsep
 \indexlibrary{\idxcode{is_lvalue_reference}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_lvalue_reference;}    &
  \tcode{T} is an lvalue reference type\iref{dcl.ref}   &   \\ \rowsep
 \indexlibrary{\idxcode{is_rvalue_reference}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_rvalue_reference;}    &
  \tcode{T} is an rvalue reference type\iref{dcl.ref}   &   \\ \rowsep
 \indexlibrary{\idxcode{is_member_object_pointer}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_member_object_pointer;}&
  \tcode{T} is a pointer to data member                              &   \\ \rowsep
 \indexlibrary{\idxcode{is_member_function_pointer}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_member_function_pointer;}&
 \tcode{T} is a pointer to member function                           &   \\ \rowsep
 \indexlibrary{\idxcode{is_enum}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_enum;}            &
 \tcode{T} is an enumeration type\iref{basic.compound}                 &   \\ \rowsep
 \indexlibrary{\idxcode{is_union}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_union;}           &
 \tcode{T} is a union type\iref{basic.compound}                        &   \\ \rowsep
 \indexlibrary{\idxcode{is_class}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_class;}           &
 \tcode{T} is a non-union class type\iref{basic.compound} & \\ \rowsep
 \indexlibrary{\idxcode{is_function}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_function;}        &
 \tcode{T} is a function type\iref{basic.compound}                     &   \\
 \end{libreqtab3e}
@@ -15878,31 +15878,31 @@ For any given type \tcode{T}, the result of applying one of these templates to
 \lhdr{Template} &   \chdr{Condition}    &   \rhdr{Comments} \\ \capsep
 \endhead
 \indexlibrary{\idxcode{is_reference}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_reference;}   &
  \tcode{T} is an lvalue reference or an rvalue reference &  \\ \rowsep
 \indexlibrary{\idxcode{is_arithmetic}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_arithmetic;}          &
  \tcode{T} is an arithmetic type\iref{basic.fundamental}              &   \\ \rowsep
 \indexlibrary{\idxcode{is_fundamental}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_fundamental;}         &
  \tcode{T} is a fundamental type\iref{basic.fundamental}              &   \\ \rowsep
 \indexlibrary{\idxcode{is_object}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_object;}              &
  \tcode{T} is an object type\iref{basic.types}                            &   \\ \rowsep
 \indexlibrary{\idxcode{is_scalar}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_scalar;}              &
  \tcode{T} is a scalar type\iref{basic.types}                         &   \\ \rowsep
 \indexlibrary{\idxcode{is_compound}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_compound;}            &
  \tcode{T} is a compound type\iref{basic.compound}                        &   \\ \rowsep
 \indexlibrary{\idxcode{is_member_pointer}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_member_pointer;}      &
  \tcode{T} is a pointer-to-member type\iref{basic.compound}               &   \\
 \end{libreqtab3b}
@@ -15942,39 +15942,39 @@ notwithstanding the restrictions of~\ref{declval}.
 \endhead
 
 \indexlibrary{\idxcode{is_const}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_const;}               &
  \tcode{T} is const-qualified\iref{basic.type.qualifier}                  &   \\ \rowsep
 
 \indexlibrary{\idxcode{is_volatile}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_volatile;}            &
  \tcode{T} is volatile-qualified\iref{basic.type.qualifier}                   &   \\ \rowsep
 
 
 \indexlibrary{\idxcode{is_trivial}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_trivial;}                 &
  \tcode{T} is a trivial type\iref{basic.types}     &
  \tcode{remove_all_extents_t<T>} shall be a complete
  type or \cv{}~\tcode{void}.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_trivially_copyable}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_trivially_copyable;}      &
  \tcode{T} is a trivially copyable type\iref{basic.types} &
  \tcode{remove_all_extents_t<T>} shall be a complete type or
  \cv{}~\tcode{void}.                               \\ \rowsep
 
 \indexlibrary{\idxcode{is_standard_layout}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_standard_layout;}                 &
  \tcode{T} is a standard-layout type\iref{basic.types}   &
  \tcode{remove_all_extents_t<T>} shall be a complete
  type or \cv{}~\tcode{void}.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_empty}!class}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_empty;}               &
  \tcode{T} is a class type, but not a union type, with no non-static data
  members other than bit-fields of length 0, no virtual member functions,
@@ -15983,19 +15983,19 @@ notwithstanding the restrictions of~\ref{declval}.
  If \tcode{T} is a non-union class type, \tcode{T} shall be a complete type.                               \\ \rowsep
 
 \indexlibrary{\idxcode{is_polymorphic}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_polymorphic;}         &
  \tcode{T} is a polymorphic class\iref{class.virtual}                             &
  If \tcode{T} is a non-union class type, \tcode{T} shall be a complete type.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_abstract}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_abstract;}            &
  \tcode{T} is an abstract class\iref{class.abstract}                              &
  If \tcode{T} is a non-union class type, \tcode{T} shall be a complete type.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_final}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_final;}               &
  \tcode{T} is a class type marked with the \grammarterm{class-virt-specifier}
  \tcode{final}\iref{class}. \begin{note} A union is a class type that
@@ -16003,27 +16003,27 @@ notwithstanding the restrictions of~\ref{declval}.
  If \tcode{T} is a class type, \tcode{T} shall be a complete type.                          \\ \rowsep
 
 \indexlibrary{\idxcode{is_aggregate}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
   \tcode{struct is_aggregate;}           &
  \tcode{T} is an aggregate type\iref{dcl.init.aggr} &
  \tcode{remove_all_extents_t<T>} shall be a complete type or \cv~\tcode{void}.              \\ \rowsep
 
 \indexlibrary{\idxcode{is_signed}!class}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
   \tcode{struct is_signed;}              &
   If \tcode{is_arithmetic_v<T>} is \tcode{true}, the same result as
   \tcode{T(-1) < T(0)};
   otherwise, \tcode{false}   &   \\  \rowsep
 
 \indexlibrary{\idxcode{is_unsigned}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
   \tcode{struct is_unsigned;}            &
   If \tcode{is_arithmetic_v<T>} is \tcode{true}, the same result as
   \tcode{T(0) < T(-1)};
   otherwise, \tcode{false}   &   \\  \rowsep
 
 \indexlibrary{\idxcode{is_constructible}}%
-\tcode{template <class T, class... Args>}\br
+\tcode{template<class T, class... Args>}\br
  \tcode{struct is_constructible;}   &
  For a function type \tcode{T} or
  for a \cv{}~\tcode{void} type \tcode{T},
@@ -16034,14 +16034,14 @@ notwithstanding the restrictions of~\ref{declval}.
  or arrays of unknown bound.  \\ \rowsep
 
 \indexlibrary{\idxcode{is_default_constructible}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
   \tcode{struct is_default_constructible;} &
   \tcode{is_constructible_v<T>} is \tcode{true}. &
   \tcode{T} shall be a complete type, \cv{}~\tcode{void},
   or an array of unknown bound. \\ \rowsep
 
 \indexlibrary{\idxcode{is_copy_constructible}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
   \tcode{struct is_copy_constructible;} &
   For a referenceable type \tcode{T}\iref{defns.referenceable}, the same result as
   \tcode{is_constructible_v<T, const T\&>}, otherwise \tcode{false}. &
@@ -16049,7 +16049,7 @@ notwithstanding the restrictions of~\ref{declval}.
   or an array of unknown bound. \\ \rowsep
 
 \indexlibrary{\idxcode{is_move_constructible}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
   \tcode{struct is_move_constructible;} &
   For a referenceable type \tcode{T}, the same result as
   \tcode{is_constructible_v<T, T\&\&>}, otherwise \tcode{false}. &
@@ -16057,7 +16057,7 @@ notwithstanding the restrictions of~\ref{declval}.
   or an array of unknown bound. \\ \rowsep
 
 \indexlibrary{\idxcode{is_assignable}}%
-\tcode{template <class T, class U>}\br
+\tcode{template<class T, class U>}\br
   \tcode{struct is_assignable;} &
   The expression \tcode{declval<T>() =} \tcode{declval<U>()} is well-formed
   when treated as an unevaluated
@@ -16072,7 +16072,7 @@ notwithstanding the restrictions of~\ref{declval}.
   or arrays of unknown bound. \\ \rowsep
 
 \indexlibrary{\idxcode{is_copy_assignable}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
   \tcode{struct is_copy_assignable;} &
   For a referenceable type \tcode{T}, the same result as
   \tcode{is_assignable_v<T\&, const T\&>}, otherwise \tcode{false}. &
@@ -16080,7 +16080,7 @@ notwithstanding the restrictions of~\ref{declval}.
   or an array of unknown bound. \\ \rowsep
 
 \indexlibrary{\idxcode{is_move_assignable}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
   \tcode{struct is_move_assignable;} &
   For a referenceable type \tcode{T}, the same result as
   \tcode{is_assignable_v<T\&, T\&\&>}, otherwise \tcode{false}. &
@@ -16088,7 +16088,7 @@ notwithstanding the restrictions of~\ref{declval}.
   or an array of unknown bound. \\ \rowsep
 
 \indexlibrary{\idxcode{is_swappable_with}}%
-\tcode{template <class T, class U>}\br
+\tcode{template<class T, class U>}\br
   \tcode{struct is_swappable_with;} &
   The expressions \tcode{swap(declval<T>(), declval<U>())} and
   \tcode{swap(declval<U>(), declval<T>())} are each well-formed
@@ -16112,7 +16112,7 @@ notwithstanding the restrictions of~\ref{declval}.
   arrays of unknown bound.  \\ \rowsep
 
 \indexlibrary{\idxcode{is_swappable}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
   \tcode{struct is_swappable;} &
   For a referenceable type \tcode{T},
   the same result as \tcode{is_swappable_with_v<T\&, T\&>},
@@ -16122,7 +16122,7 @@ notwithstanding the restrictions of~\ref{declval}.
   an array of unknown bound. \\ \rowsep
 
 \indexlibrary{\idxcode{is_destructible}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
   \tcode{struct is_destructible;} &
   Either \tcode{T} is a reference type,
   or \tcode{T} is a complete object type
@@ -16136,7 +16136,7 @@ notwithstanding the restrictions of~\ref{declval}.
   or an array of unknown bound. \\ \rowsep
 
 \indexlibrary{\idxcode{is_trivially_constructible}}%
-\tcode{template <class T, class... Args>}\br
+\tcode{template<class T, class... Args>}\br
   \tcode{struct}\br
   \tcode{is_trivially_constructible;} &
   \tcode{is_constructible_v<T,}\br
@@ -16147,7 +16147,7 @@ notwithstanding the restrictions of~\ref{declval}.
   \cv{}~\tcode{void}, or arrays of unknown bound. \\ \rowsep
 
 \indexlibrary{\idxcode{is_trivially_default_constructible}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_trivially_default_constructible;} &
  \tcode{is_trivially_constructible_v<T>} is \tcode{true}. &
  \tcode{T} shall be a complete type,
@@ -16155,7 +16155,7 @@ notwithstanding the restrictions of~\ref{declval}.
  bound.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_trivially_copy_constructible}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_trivially_copy_constructible;}      &
   For a referenceable type \tcode{T}, the same result as
  \tcode{is_trivially_constructible_v<T, const T\&>}, otherwise \tcode{false}. &
@@ -16164,7 +16164,7 @@ notwithstanding the restrictions of~\ref{declval}.
  bound.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_trivially_move_constructible}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_trivially_move_constructible;}      &
   For a referenceable type \tcode{T}, the same result as
  \tcode{is_trivially_constructible_v<T, T\&\&>}, otherwise \tcode{false}. &
@@ -16173,7 +16173,7 @@ notwithstanding the restrictions of~\ref{declval}.
  bound.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_trivially_assignable}}%
-\tcode{template <class T, class U>}\br
+\tcode{template<class T, class U>}\br
   \tcode{struct is_trivially_assignable;} &
   \tcode{is_assignable_v<T, U>} is \tcode{true} and the assignment, as defined by
   \tcode{is_assignable}, is known to call no operation that is not trivial
@@ -16182,7 +16182,7 @@ notwithstanding the restrictions of~\ref{declval}.
   or arrays of unknown bound. \\ \rowsep
 
 \indexlibrary{\idxcode{is_trivially_copy_assignable}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_trivially_copy_assignable;} &
   For a referenceable type \tcode{T}, the same result as
  \tcode{is_trivially_assignable_v<T\&, const T\&>}, otherwise \tcode{false}. &
@@ -16191,7 +16191,7 @@ notwithstanding the restrictions of~\ref{declval}.
  bound.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_trivially_move_assignable}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_trivially_move_assignable;} &
   For a referenceable type \tcode{T}, the same result as
  \tcode{is_trivially_assignable_v<T\&, T\&\&>}, otherwise \tcode{false}. &
@@ -16199,7 +16199,7 @@ notwithstanding the restrictions of~\ref{declval}.
  \cv{}~\tcode{void}, or an array of unknown bound.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_trivially_destructible}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_trivially_destructible;} &
  \tcode{is_destructible_v<T>} is \tcode{true} and
  \tcode{remove_all_extents_t<T>} is either a non-class type or
@@ -16209,7 +16209,7 @@ notwithstanding the restrictions of~\ref{declval}.
  bound.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_nothrow_constructible}}%
-\tcode{template <class T, class... Args>}\br
+\tcode{template<class T, class... Args>}\br
  \tcode{struct is_nothrow_constructible;}   &
  \tcode{is_constructible_v<T,} \tcode{ Args...>} is \tcode{true}
  and the
@@ -16221,7 +16221,7 @@ notwithstanding the restrictions of~\ref{declval}.
  or arrays of unknown bound.  \\ \rowsep
 
 \indexlibrary{\idxcode{is_nothrow_default_constructible}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_nothrow_default_constructible;} &
  \tcode{is_nothrow_constructible_v<T>} is \tcode{true}.  &
  \tcode{T} shall be a complete type,
@@ -16229,7 +16229,7 @@ notwithstanding the restrictions of~\ref{declval}.
  bound.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_nothrow_copy_constructible}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_nothrow_copy_constructible;}      &
   For a referenceable type \tcode{T}, the same result as
  \tcode{is_nothrow_constructible_v<T, const T\&>}, otherwise \tcode{false}. &
@@ -16238,7 +16238,7 @@ notwithstanding the restrictions of~\ref{declval}.
  bound.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_nothrow_move_constructible}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_nothrow_move_constructible;}      &
   For a referenceable type \tcode{T}, the same result as
  \tcode{is_nothrow_constructible_v<T, T\&\&>}, otherwise \tcode{false}. &
@@ -16246,7 +16246,7 @@ notwithstanding the restrictions of~\ref{declval}.
  \cv{}~\tcode{void}, or an array of unknown bound.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_nothrow_assignable}}%
-\tcode{template <class T, class U>}\br
+\tcode{template<class T, class U>}\br
   \tcode{struct is_nothrow_assignable;} &
   \tcode{is_assignable_v<T, U>} is \tcode{true} and the assignment is known not to
   throw any exceptions\iref{expr.unary.noexcept}. &
@@ -16254,7 +16254,7 @@ notwithstanding the restrictions of~\ref{declval}.
   or arrays of unknown bound. \\ \rowsep
 
 \indexlibrary{\idxcode{is_nothrow_copy_assignable}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct is_nothrow_copy_assignable;} &
   For a referenceable type \tcode{T}, the same result as
  \tcode{is_nothrow_assignable_v<T\&, const T\&>}, otherwise \tcode{false}. &
@@ -16263,7 +16263,7 @@ notwithstanding the restrictions of~\ref{declval}.
  bound.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_nothrow_move_assignable}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
   \tcode{struct is_nothrow_move_assignable;} &
   For a referenceable type \tcode{T}, the same result as
   \tcode{is_nothrow_assignable_v<T\&, T\&\&>}, otherwise \tcode{false}. &
@@ -16272,7 +16272,7 @@ notwithstanding the restrictions of~\ref{declval}.
  bound.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_nothrow_swappable_with}}%
-\tcode{template <class T, class U>}\br
+\tcode{template<class T, class U>}\br
   \tcode{struct is_nothrow_swappable_with;} &
   \tcode{is_swappable_with_v<T, U>} is \tcode{true} and
   each \tcode{swap} expression of the definition of
@@ -16283,7 +16283,7 @@ notwithstanding the restrictions of~\ref{declval}.
   arrays of unknown bound. \\ \rowsep
 
 \indexlibrary{\idxcode{is_nothrow_swappable}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
   \tcode{struct is_nothrow_swappable;} &
   For a referenceable type \tcode{T},
   the same result as \tcode{is_nothrow_swappable_with_v<T\&, T\&>},
@@ -16293,7 +16293,7 @@ notwithstanding the restrictions of~\ref{declval}.
   an array of unknown bound. \\ \rowsep
 
 \indexlibrary{\idxcode{is_nothrow_destructible}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
   \tcode{struct is_nothrow_destructible;} &
   \tcode{is_destructible_v<T>} is \tcode{true} and the indicated destructor is known
   not to throw any exceptions\iref{expr.unary.noexcept}. &
@@ -16302,13 +16302,13 @@ notwithstanding the restrictions of~\ref{declval}.
   bound.                \\ \rowsep
 
 \indexlibrary{\idxcode{has_virtual_destructor}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct has_virtual_destructor;} &
  \tcode{T} has a virtual destructor\iref{class.dtor} &
  If \tcode{T} is a non-union class type, \tcode{T} shall be a complete type.                \\ \rowsep
 
 \indexlibrary{\idxcode{has_unique_object_representations}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
   \tcode{struct has_unique_object_representations;} &
   For an array type \tcode{T}, the same result as
   \tcode{has_unique_object_representations_v<remove_all_extents_t<T>>},
@@ -16409,20 +16409,20 @@ properties of types at compile time.
 \endhead
 
 \indexlibrary{\idxcode{alignment_of}}%
-\tcode{template <class T>\br
+\tcode{template<class T>\br
  struct alignment_of;}      &
  \tcode{alignof(T)}.\br
  \requires{}
  \tcode{alignof(T)} shall be a valid expression\iref{expr.alignof}  \\  \rowsep
 
 \indexlibrary{\idxcode{rank}}%
-\tcode{template <class T>\br
+\tcode{template<class T>\br
  struct rank;}      &
  If \tcode{T} names an array type, an integer value representing
  the number of dimensions of \tcode{T}; otherwise, 0. \\    \rowsep
 
 \indexlibrary{\idxcode{extent}}%
-\tcode{template <class T,\br
+\tcode{template<class T,\br
  unsigned I = 0>\br
  struct extent;}        &
  If \tcode{T} is not an array type, or if it has rank less
@@ -16482,12 +16482,12 @@ with a base characteristic of
 \topline
 \lhdr{Template} &   \chdr{Condition}    &   \rhdr{Comments} \\ \capsep
 \endhead
-\tcode{template <class T, class U>}\br
+\tcode{template<class T, class U>}\br
  \tcode{struct is_same;}                    &
  \tcode{T} and \tcode{U} name the same type with the same cv-qualifications                            &   \\ \rowsep
 
 \indexlibrary{\idxcode{is_base_of}}%
-\tcode{template <class Base, class Derived>}\br
+\tcode{template<class Base, class Derived>}\br
  \tcode{struct is_base_of;}                 &
  \tcode{Base} is a base class of \tcode{Derived}\iref{class.derived}
  without regard to cv-qualifiers
@@ -16503,7 +16503,7 @@ not possibly cv-qualified versions of the same type,
  are, nonetheless, base classes. \end{note} \\ \rowsep
 
 \indexlibrary{\idxcode{is_convertible}}%
-\tcode{template <class From, class To>}\br
+\tcode{template<class From, class To>}\br
  \tcode{struct is_convertible;}             &
  \seebelow                                  &
  \tcode{From} and \tcode{To} shall be complete
@@ -16511,7 +16511,7 @@ not possibly cv-qualified versions of the same type,
  bound, or \cv{}~\tcode{void} types.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_invocable}}%
-\tcode{template <class Fn, class... ArgTypes>}\br
+\tcode{template<class Fn, class... ArgTypes>}\br
  \tcode{struct is_invocable;}                      &
  The expression \tcode{\placeholdernc{INVOKE}(declval<Fn>(), declval<ArgTypes>()...)}
  is well-formed when treated as an unevaluated operand                &
@@ -16520,7 +16520,7 @@ not possibly cv-qualified versions of the same type,
  arrays of unknown bound.                                             \\ \rowsep
 
 \indexlibrary{\idxcode{is_invocable_r}}%
-\tcode{template <class R, class Fn, class... ArgTypes>}\br
+\tcode{template<class R, class Fn, class... ArgTypes>}\br
  \tcode{struct is_invocable_r;}                      &
  The expression \tcode{\placeholdernc{INVOKE}<R>(declval<Fn>(), declval<ArgTypes>()...)}
  is well-formed when treated as an unevaluated operand                &
@@ -16529,7 +16529,7 @@ not possibly cv-qualified versions of the same type,
  arrays of unknown bound.                                             \\ \rowsep
 
 \indexlibrary{\idxcode{is_nothrow_invocable}}%
-\tcode{template <class Fn, class... ArgTypes>}\br
+\tcode{template<class Fn, class... ArgTypes>}\br
  \tcode{struct is_nothrow_invocable;}              &
  \tcode{is_invocable_v<}\br\tcode{Fn, ArgTypes...>} is \tcode{true} and
  the expression \tcode{\placeholdernc{INVOKE}(declval<Fn>(), declval<ArgTypes>()...)}
@@ -16539,7 +16539,7 @@ not possibly cv-qualified versions of the same type,
  arrays of unknown bound.                                             \\ \rowsep
 
 \indexlibrary{\idxcode{is_nothrow_invocable_r}}%
-\tcode{template <class R, class Fn, class... ArgTypes>}\br
+\tcode{template<class R, class Fn, class... ArgTypes>}\br
  \tcode{struct is_nothrow_invocable_r;}              &
  \tcode{is_invocable_r_v<}\br\tcode{R, Fn, ArgTypes...>} is \tcode{true} and
  the expression \tcode{\placeholdernc{INVOKE}<R>(declval<Fn>(), declval<ArgTypes>()...)}
@@ -16620,7 +16620,7 @@ Each of the templates in this subclause shall be a
 \endhead
 
 \indexlibrary{\idxcode{remove_const}}%
-\tcode{template <class T>\br
+\tcode{template<class T>\br
  struct remove_const;}                  &
  The member typedef \tcode{type} names
  the same type as \tcode{T}
@@ -16630,7 +16630,7 @@ Each of the templates in this subclause shall be a
  \tcode{const int*}. \end{example}                          \\  \rowsep
 
 \indexlibrary{\idxcode{remove_volatile}}%
-\tcode{template <class T>\br
+\tcode{template<class T>\br
  struct remove_volatile;}               &
  The member typedef \tcode{type} names
  the same type as \tcode{T}
@@ -16641,7 +16641,7 @@ Each of the templates in this subclause shall be a
  \end{example}                                              \\  \rowsep
 
 \indexlibrary{\idxcode{remove_cv}}%
-\tcode{template <class T>\br
+\tcode{template<class T>\br
  struct remove_cv;}                 &
  The member typedef \tcode{type} shall be the same as \tcode{T}
  except that any top-level cv-qualifier has been removed.
@@ -16650,7 +16650,7 @@ Each of the templates in this subclause shall be a
  evaluates to \tcode{const volatile int*}. \end{example}  \\  \rowsep
 
 \indexlibrary{\idxcode{add_const}}%
-\tcode{template <class T>\br
+\tcode{template<class T>\br
  struct add_const;}                 &
  If \tcode{T} is a reference, function, or top-level const-qualified
  type, then \tcode{type} names
@@ -16658,7 +16658,7 @@ Each of the templates in this subclause shall be a
  \tcode{T const}.                                                           \\  \rowsep
 
 \indexlibrary{\idxcode{add_volatile}}%
-\tcode{template <class T>\br
+\tcode{template<class T>\br
  struct add_volatile;}                  &
  If \tcode{T} is a reference, function, or top-level volatile-qualified
  type, then \tcode{type} names
@@ -16666,7 +16666,7 @@ Each of the templates in this subclause shall be a
  \tcode{T volatile}.                                                            \\  \rowsep
 
 \indexlibrary{\idxcode{add_cv}}%
-\tcode{template <class T>\br
+\tcode{template<class T>\br
  struct add_cv;}                    &
  The member typedef \tcode{type} names
  the same type as
@@ -16685,14 +16685,14 @@ Each of the templates in this subclause shall be a
 \endhead
 
 \indexlibrary{\idxcode{remove_reference}}%
-\tcode{template <class T>\br
+\tcode{template<class T>\br
  struct remove_reference;}                  &
  If \tcode{T} has type ``reference to \tcode{T1}'' then the
  member typedef \tcode{type} names \tcode{T1};
  otherwise, \tcode{type} names \tcode{T}.\\ \rowsep
 
 \indexlibrary{\idxcode{add_lvalue_reference}}%
-\tcode{template <class T>\br
+\tcode{template<class T>\br
  struct add_lvalue_reference;}                     &
  If \tcode{T} names a referenceable type\iref{defns.referenceable} then
  the member typedef \tcode{type} names \tcode{T\&};
@@ -16702,7 +16702,7 @@ Each of the templates in this subclause shall be a
  \end{note}\\ \rowsep
 
 \indexlibrary{\idxcode{add_rvalue_reference}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct add_rvalue_reference;}    &
  If \tcode{T} names a referenceable type then
  the member typedef \tcode{type} names \tcode{T\&\&};
@@ -16724,7 +16724,7 @@ Each of the templates in this subclause shall be a
 \endhead
 
 \indexlibrary{\idxcode{make_signed}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct make_signed;} &
  If \tcode{T} names a (possibly cv-qualified) signed integer
  type\iref{basic.fundamental} then the member typedef
@@ -16741,7 +16741,7 @@ Each of the templates in this subclause shall be a
  but not a \tcode{bool} type.\\ \rowsep
 
 \indexlibrary{\idxcode{make_unsigned}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct make_unsigned;} &
  If \tcode{T} names a (possibly cv-qualified) unsigned integer
  type\iref{basic.fundamental} then the member typedef
@@ -16769,7 +16769,7 @@ Each of the templates in this subclause shall be a
 \endhead
 
 \indexlibrary{\idxcode{remove_extent}}%
-\tcode{template <class T>\br
+\tcode{template<class T>\br
  struct remove_extent;}                 &
  If \tcode{T} names a type ``array of \tcode{U}'',
  the member typedef \tcode{type} shall
@@ -16779,7 +16779,7 @@ Each of the templates in this subclause shall be a
  \tcode{const U}. \end{note}                                 \\  \rowsep
 
 \indexlibrary{\idxcode{remove_all_extents}}%
-\tcode{template <class T>\br
+\tcode{template<class T>\br
  struct remove_all_extents;}                &
  If \tcode{T} is ``multi-dimensional array of \tcode{U}'', the resulting member
  typedef \tcode{type} is \tcode{U}, otherwise \tcode{T}.                                       \\
@@ -16818,14 +16818,14 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
 \endhead
 
 \indexlibrary{\idxcode{remove_pointer}}%
-\tcode{template <class T>\br
+\tcode{template<class T>\br
  struct remove_pointer;}                    &
  If \tcode{T} has type ``(possibly cv-qualified) pointer
  to \tcode{T1}'' then the member typedef \tcode{type}
  names \tcode{T1}; otherwise, it names \tcode{T}.\\ \rowsep
 
 \indexlibrary{\idxcode{add_pointer}}%
-\tcode{template <class T>\br
+\tcode{template<class T>\br
  struct add_pointer;}                       &
  If \tcode{T} names a referenceable type\iref{defns.referenceable} or a
  \cv{}~\tcode{void} type then
@@ -16846,7 +16846,7 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
 \endhead
 
 \indexlibrary{\idxcode{aligned_storage}}%
-\tcode{template <size_t Len,\br
+\tcode{template<size_t Len,\br
  size_t Align\br
  = \textit{default-alignment}>\br
  struct aligned_storage;}
@@ -16861,7 +16861,7 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
  \tcode{alignof(T)} for some type \tcode{T} or to \textit{default-alignment}.\\ \rowsep
 
 \indexlibrary{\idxcode{aligned_union}}%
-\tcode{template <size_t Len,\br
+\tcode{template<size_t Len,\br
   class... Types>\br
   struct aligned_union;}
   &
@@ -16875,14 +16875,14 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
   \\ \rowsep
 
 \indexlibrary{\idxcode{remove_cvref}}%
-\tcode{template <class T>\br struct remove_cvref;}
+\tcode{template<class T>\br struct remove_cvref;}
  &
  The member typedef \tcode{type} names the same type as
  \tcode{remove_cv_t<remove_reference_t<T>>}.
  \\ \rowsep
 
 \indexlibrary{\idxcode{decay}}%
-\tcode{template <class T>\br struct decay;}
+\tcode{template<class T>\br struct decay;}
  &
  Let \tcode{U} be \tcode{remove_reference_t<T>}. If \tcode{is_array_v<U>} is
  \tcode{true}, the member typedef \tcode{type} shall equal
@@ -16897,20 +16897,20 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
  \\ \rowsep
 
 \indexlibrary{\idxcode{enable_if}}%
-\tcode{template <bool B, class T = void>} \tcode{struct enable_if;}
+\tcode{template<bool B, class T = void>} \tcode{struct enable_if;}
  &
  If \tcode{B} is \tcode{true}, the member typedef \tcode{type}
  shall equal \tcode{T}; otherwise, there shall be no member
  \tcode{type}. \\ \rowsep
 
-\tcode{template <bool B, class T,}
+\tcode{template<bool B, class T,}
  \tcode{class F>}\br
  \tcode{struct conditional;}
  &
  If \tcode{B} is \tcode{true},  the member typedef \tcode{type} shall equal \tcode{T}.
  If \tcode{B} is \tcode{false}, the member typedef \tcode{type} shall equal \tcode{F}. \\ \rowsep
 
- \tcode{template <class... T>} \tcode{struct common_type;}
+ \tcode{template<class... T>} \tcode{struct common_type;}
  &
  Unless this trait is specialized (as specified in Note B, below),
  the member \tcode{type} shall be defined or omitted as specified in Note A, below.
@@ -16919,14 +16919,14 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
  complete, \cv{}~\tcode{void}, or an array of unknown bound. \\ \rowsep
 
 \indexlibrary{\idxcode{underlying_type}}%
-\tcode{template <class T>}\br
+\tcode{template<class T>}\br
  \tcode{struct underlying_type;}
  &
  The member typedef \tcode{type} names the underlying type
  of \tcode{T}.\br
  \requires{} \tcode{T} shall be a complete enumeration type\iref{dcl.enum} \\ \rowsep
 
-\tcode{template <class Fn,}\br
+\tcode{template<class Fn,}\br
  \tcode{class... ArgTypes>}\br
  \tcode{struct invoke_result;}
  &
@@ -16955,7 +16955,7 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
 \begin{note} A typical implementation would define \tcode{aligned_storage} as:
 
 \begin{codeblock}
-template <size_t Len, size_t Alignment>
+template<size_t Len, size_t Alignment>
 struct aligned_storage {
   typedef struct {
     alignas(Alignment) unsigned char __data[Len];
@@ -17236,33 +17236,33 @@ the program is ill-formed.
 \begin{codeblockdigitsep}
 namespace std {
   // \ref{ratio.ratio}, class template \tcode{ratio}
-  template <intmax_t N, intmax_t D = 1> class ratio;
+  template<intmax_t N, intmax_t D = 1> class ratio;
 
   // \ref{ratio.arithmetic}, ratio arithmetic
-  template <class R1, class R2> using ratio_add = @\seebelow@;
-  template <class R1, class R2> using ratio_subtract = @\seebelow@;
-  template <class R1, class R2> using ratio_multiply = @\seebelow@;
-  template <class R1, class R2> using ratio_divide = @\seebelow@;
+  template<class R1, class R2> using ratio_add = @\seebelow@;
+  template<class R1, class R2> using ratio_subtract = @\seebelow@;
+  template<class R1, class R2> using ratio_multiply = @\seebelow@;
+  template<class R1, class R2> using ratio_divide = @\seebelow@;
 
   // \ref{ratio.comparison}, ratio comparison
-  template <class R1, class R2> struct ratio_equal;
-  template <class R1, class R2> struct ratio_not_equal;
-  template <class R1, class R2> struct ratio_less;
-  template <class R1, class R2> struct ratio_less_equal;
-  template <class R1, class R2> struct ratio_greater;
-  template <class R1, class R2> struct ratio_greater_equal;
+  template<class R1, class R2> struct ratio_equal;
+  template<class R1, class R2> struct ratio_not_equal;
+  template<class R1, class R2> struct ratio_less;
+  template<class R1, class R2> struct ratio_less_equal;
+  template<class R1, class R2> struct ratio_greater;
+  template<class R1, class R2> struct ratio_greater_equal;
 
-  template <class R1, class R2>
+  template<class R1, class R2>
     inline constexpr bool ratio_equal_v = ratio_equal<R1, R2>::value;
-  template <class R1, class R2>
+  template<class R1, class R2>
     inline constexpr bool ratio_not_equal_v = ratio_not_equal<R1, R2>::value;
-  template <class R1, class R2>
+  template<class R1, class R2>
     inline constexpr bool ratio_less_v = ratio_less<R1, R2>::value;
-  template <class R1, class R2>
+  template<class R1, class R2>
     inline constexpr bool ratio_less_equal_v = ratio_less_equal<R1, R2>::value;
-  template <class R1, class R2>
+  template<class R1, class R2>
     inline constexpr bool ratio_greater_v = ratio_greater<R1, R2>::value;
-  template <class R1, class R2>
+  template<class R1, class R2>
     inline constexpr bool ratio_greater_equal_v = ratio_greater_equal<R1, R2>::value;
 
   // \ref{ratio.si}, convenience SI typedefs
@@ -17294,7 +17294,7 @@ namespace std {
 \indexlibrary{\idxcode{ratio}}%
 \begin{codeblock}
 namespace std {
-  template <intmax_t N, intmax_t D = 1> class ratio {
+  template<intmax_t N, intmax_t D = 1> class ratio {
   public:
     static constexpr intmax_t num;
     static constexpr intmax_t den;
@@ -17395,19 +17395,19 @@ static_assert(ratio_multiply<ratio<1, INT_MAX>, ratio<INT_MAX, 2>>::den == 2,
 
 \indexlibrary{\idxcode{ratio_equal}}%
 \begin{itemdecl}
-template <class R1, class R2>
+template<class R1, class R2>
   struct ratio_equal : bool_constant<R1::num == R2::num && R1::den == R2::den> { };
 \end{itemdecl}
 
 \indexlibrary{\idxcode{ratio_not_equal}}%
 \begin{itemdecl}
-template <class R1, class R2>
+template<class R1, class R2>
   struct ratio_not_equal : bool_constant<!ratio_equal_v<R1, R2>> { };
 \end{itemdecl}
 
 \indexlibrary{\idxcode{ratio_less}}%
 \begin{itemdecl}
-template <class R1, class R2>
+template<class R1, class R2>
   struct ratio_less : bool_constant<@\seebelow@> { };
 \end{itemdecl}
 
@@ -17422,19 +17422,19 @@ compute this relationship to avoid overflow. If overflow occurs, the program is 
 
 \indexlibrary{\idxcode{ratio_less_equal}}%
 \begin{itemdecl}
-template <class R1, class R2>
+template<class R1, class R2>
   struct ratio_less_equal : bool_constant<!ratio_less_v<R2, R1>> { };
 \end{itemdecl}
 
 \indexlibrary{\idxcode{ratio_greater}}%
 \begin{itemdecl}
-template <class R1, class R2>
+template<class R1, class R2>
   struct ratio_greater : bool_constant<ratio_less_v<R2, R1>> { };
 \end{itemdecl}
 
 \indexlibrary{\idxcode{ratio_greater_equal}}%
 \begin{itemdecl}
-template <class R1, class R2>
+template<class R1, class R2>
   struct ratio_greater_equal : bool_constant<!ratio_less_v<R1, R2>> { };
 \end{itemdecl}
 
@@ -17464,82 +17464,82 @@ utilities.
 namespace std {
   namespace chrono {
     // \ref{time.duration}, class template \tcode{duration}
-    template <class Rep, class Period = ratio<1>> class duration;
+    template<class Rep, class Period = ratio<1>> class duration;
 
     // \ref{time.point}, class template \tcode{time_point}
-    template <class Clock, class Duration = typename Clock::duration> class time_point;
+    template<class Clock, class Duration = typename Clock::duration> class time_point;
   }
 
   // \ref{time.traits.specializations}, \tcode{common_type} specializations
-  template <class Rep1, class Period1, class Rep2, class Period2>
+  template<class Rep1, class Period1, class Rep2, class Period2>
     struct common_type<chrono::duration<Rep1, Period1>,
                        chrono::duration<Rep2, Period2>>;
 
-  template <class Clock, class Duration1, class Duration2>
+  template<class Clock, class Duration1, class Duration2>
     struct common_type<chrono::time_point<Clock, Duration1>,
                        chrono::time_point<Clock, Duration2>>;
 
   namespace chrono {
     // \ref{time.traits}, customization traits
-    template <class Rep> struct treat_as_floating_point;
-    template <class Rep> struct duration_values;
-    template <class Rep>
+    template<class Rep> struct treat_as_floating_point;
+    template<class Rep> struct duration_values;
+    template<class Rep>
       inline constexpr bool treat_as_floating_point_v = treat_as_floating_point<Rep>::value;
 
     // \ref{time.duration.nonmember}, \tcode{duration} arithmetic
-    template <class Rep1, class Period1, class Rep2, class Period2>
+    template<class Rep1, class Period1, class Rep2, class Period2>
       constexpr common_type_t<duration<Rep1, Period1>, duration<Rep2, Period2>>
         operator+(const duration<Rep1, Period1>& lhs, const duration<Rep2, Period2>& rhs);
-    template <class Rep1, class Period1, class Rep2, class Period2>
+    template<class Rep1, class Period1, class Rep2, class Period2>
       constexpr common_type_t<duration<Rep1, Period1>, duration<Rep2, Period2>>
         operator-(const duration<Rep1, Period1>& lhs, const duration<Rep2, Period2>& rhs);
-    template <class Rep1, class Period, class Rep2>
+    template<class Rep1, class Period, class Rep2>
       constexpr duration<common_type_t<Rep1, Rep2>, Period>
         operator*(const duration<Rep1, Period>& d, const Rep2& s);
-    template <class Rep1, class Rep2, class Period>
+    template<class Rep1, class Rep2, class Period>
       constexpr duration<common_type_t<Rep1, Rep2>, Period>
         operator*(const Rep1& s, const duration<Rep2, Period>& d);
-    template <class Rep1, class Period, class Rep2>
+    template<class Rep1, class Period, class Rep2>
       constexpr duration<common_type_t<Rep1, Rep2>, Period>
         operator/(const duration<Rep1, Period>& d, const Rep2& s);
-    template <class Rep1, class Period1, class Rep2, class Period2>
+    template<class Rep1, class Period1, class Rep2, class Period2>
       constexpr common_type_t<Rep1, Rep2>
         operator/(const duration<Rep1, Period1>& lhs, const duration<Rep2, Period2>& rhs);
-    template <class Rep1, class Period, class Rep2>
+    template<class Rep1, class Period, class Rep2>
       constexpr duration<common_type_t<Rep1, Rep2>, Period>
         operator%(const duration<Rep1, Period>& d, const Rep2& s);
-    template <class Rep1, class Period1, class Rep2, class Period2>
+    template<class Rep1, class Period1, class Rep2, class Period2>
       constexpr common_type_t<duration<Rep1, Period1>, duration<Rep2, Period2>>
         operator%(const duration<Rep1, Period1>& lhs, const duration<Rep2, Period2>& rhs);
 
     // \ref{time.duration.comparisons}, \tcode{duration} comparisons
-    template <class Rep1, class Period1, class Rep2, class Period2>
+    template<class Rep1, class Period1, class Rep2, class Period2>
       constexpr bool operator==(const duration<Rep1, Period1>& lhs,
                                 const duration<Rep2, Period2>& rhs);
-    template <class Rep1, class Period1, class Rep2, class Period2>
+    template<class Rep1, class Period1, class Rep2, class Period2>
       constexpr bool operator!=(const duration<Rep1, Period1>& lhs,
                                 const duration<Rep2, Period2>& rhs);
-    template <class Rep1, class Period1, class Rep2, class Period2>
+    template<class Rep1, class Period1, class Rep2, class Period2>
       constexpr bool operator< (const duration<Rep1, Period1>& lhs,
                                 const duration<Rep2, Period2>& rhs);
-    template <class Rep1, class Period1, class Rep2, class Period2>
+    template<class Rep1, class Period1, class Rep2, class Period2>
       constexpr bool operator<=(const duration<Rep1, Period1>& lhs,
                                 const duration<Rep2, Period2>& rhs);
-    template <class Rep1, class Period1, class Rep2, class Period2>
+    template<class Rep1, class Period1, class Rep2, class Period2>
       constexpr bool operator> (const duration<Rep1, Period1>& lhs,
                                 const duration<Rep2, Period2>& rhs);
-    template <class Rep1, class Period1, class Rep2, class Period2>
+    template<class Rep1, class Period1, class Rep2, class Period2>
       constexpr bool operator>=(const duration<Rep1, Period1>& lhs,
                                 const duration<Rep2, Period2>& rhs);
 
     // \ref{time.duration.cast}, \tcode{duration_cast}
-    template <class ToDuration, class Rep, class Period>
+    template<class ToDuration, class Rep, class Period>
       constexpr ToDuration duration_cast(const duration<Rep, Period>& d);
-    template <class ToDuration, class Rep, class Period>
+    template<class ToDuration, class Rep, class Period>
       constexpr ToDuration floor(const duration<Rep, Period>& d);
-    template <class ToDuration, class Rep, class Period>
+    template<class ToDuration, class Rep, class Period>
       constexpr ToDuration ceil(const duration<Rep, Period>& d);
-    template <class ToDuration, class Rep, class Period>
+    template<class ToDuration, class Rep, class Period>
       constexpr ToDuration round(const duration<Rep, Period>& d);
 
     // convenience typedefs
@@ -17551,53 +17551,53 @@ namespace std {
     using hours        = duration<@\term{signed integer type of at least 23 bits}@, ratio<3600>>;
 
     // \ref{time.point.nonmember}, \tcode{time_point} arithmetic
-    template <class Clock, class Duration1, class Rep2, class Period2>
+    template<class Clock, class Duration1, class Rep2, class Period2>
       constexpr time_point<Clock, common_type_t<Duration1, duration<Rep2, Period2>>>
         operator+(const time_point<Clock, Duration1>& lhs, const duration<Rep2, Period2>& rhs);
-    template <class Rep1, class Period1, class Clock, class Duration2>
+    template<class Rep1, class Period1, class Clock, class Duration2>
       constexpr time_point<Clock, common_type_t<duration<Rep1, Period1>, Duration2>>
         operator+(const duration<Rep1, Period1>& lhs, const time_point<Clock, Duration2>& rhs);
-    template <class Clock, class Duration1, class Rep2, class Period2>
+    template<class Clock, class Duration1, class Rep2, class Period2>
       constexpr time_point<Clock, common_type_t<Duration1, duration<Rep2, Period2>>>
         operator-(const time_point<Clock, Duration1>& lhs, const duration<Rep2, Period2>& rhs);
-    template <class Clock, class Duration1, class Duration2>
+    template<class Clock, class Duration1, class Duration2>
       constexpr common_type_t<Duration1, Duration2>
         operator-(const time_point<Clock, Duration1>& lhs,
                   const time_point<Clock, Duration2>& rhs);
 
     // \ref{time.point.comparisons}, \tcode{time_point} comparisons
-    template <class Clock, class Duration1, class Duration2>
+    template<class Clock, class Duration1, class Duration2>
        constexpr bool operator==(const time_point<Clock, Duration1>& lhs,
                                  const time_point<Clock, Duration2>& rhs);
-    template <class Clock, class Duration1, class Duration2>
+    template<class Clock, class Duration1, class Duration2>
        constexpr bool operator!=(const time_point<Clock, Duration1>& lhs,
                                  const time_point<Clock, Duration2>& rhs);
-    template <class Clock, class Duration1, class Duration2>
+    template<class Clock, class Duration1, class Duration2>
        constexpr bool operator< (const time_point<Clock, Duration1>& lhs,
                                  const time_point<Clock, Duration2>& rhs);
-    template <class Clock, class Duration1, class Duration2>
+    template<class Clock, class Duration1, class Duration2>
        constexpr bool operator<=(const time_point<Clock, Duration1>& lhs,
                                  const time_point<Clock, Duration2>& rhs);
-    template <class Clock, class Duration1, class Duration2>
+    template<class Clock, class Duration1, class Duration2>
        constexpr bool operator> (const time_point<Clock, Duration1>& lhs,
                                  const time_point<Clock, Duration2>& rhs);
-    template <class Clock, class Duration1, class Duration2>
+    template<class Clock, class Duration1, class Duration2>
        constexpr bool operator>=(const time_point<Clock, Duration1>& lhs,
                                  const time_point<Clock, Duration2>& rhs);
 
     // \ref{time.point.cast}, \tcode{time_point_cast}
-    template <class ToDuration, class Clock, class Duration>
+    template<class ToDuration, class Clock, class Duration>
       constexpr time_point<Clock, ToDuration>
         time_point_cast(const time_point<Clock, Duration>& t);
-    template <class ToDuration, class Clock, class Duration>
+    template<class ToDuration, class Clock, class Duration>
       constexpr time_point<Clock, ToDuration> floor(const time_point<Clock, Duration>& tp);
-    template <class ToDuration, class Clock, class Duration>
+    template<class ToDuration, class Clock, class Duration>
       constexpr time_point<Clock, ToDuration> ceil(const time_point<Clock, Duration>& tp);
-    template <class ToDuration, class Clock, class Duration>
+    template<class ToDuration, class Clock, class Duration>
       constexpr time_point<Clock, ToDuration> round(const time_point<Clock, Duration>& tp);
 
     // \ref{time.duration.alg}, specialized algorithms
-    template <class Rep, class Period>
+    template<class Rep, class Period>
       constexpr duration<Rep, Period> abs(duration<Rep, Period> d);
 
     // \ref{time.clock}, clocks
@@ -17721,7 +17721,7 @@ requirements, recursively.
 
 \indexlibrary{\idxcode{treat_as_floating_point}}%
 \begin{itemdecl}
-template <class Rep> struct treat_as_floating_point : is_floating_point<Rep> { };
+template<class Rep> struct treat_as_floating_point : is_floating_point<Rep> { };
 \end{itemdecl}
 
 \pnum
@@ -17742,7 +17742,7 @@ if it behaved like an integral type for the purpose of these conversions.
 
 \indexlibrary{\idxcode{duration_values}}%
 \begin{itemdecl}
-template <class Rep>
+template<class Rep>
   struct duration_values {
   public:
     static constexpr Rep zero();
@@ -17804,7 +17804,7 @@ static constexpr Rep max();
 
 \indexlibrary{\idxcode{common_type}}%
 \begin{itemdecl}
-template <class Rep1, class Period1, class Rep2, class Period2>
+template<class Rep1, class Period1, class Rep2, class Period2>
 struct common_type<chrono::duration<Rep1, Period1>, chrono::duration<Rep2, Period2>> {
   using type = chrono::duration<common_type_t<Rep1, Rep2>, @\seebelow@>;
 };
@@ -17828,7 +17828,7 @@ floating-point durations may have round-off errors. \end{note}
 
 \indexlibrary{\idxcode{common_type}}%
 \begin{itemdecl}
-template <class Clock, class Duration1, class Duration2>
+template<class Clock, class Duration1, class Duration2>
   struct common_type<chrono::time_point<Clock, Duration1>, chrono::time_point<Clock, Duration2>> {
     using type = chrono::time_point<Clock, common_type_t<Duration1, Duration2>>;
 };
@@ -17849,7 +17849,7 @@ of seconds. It is expressed as a rational constant using the template \tcode{rat
 \indexlibrary{\idxcode{duration}}%
 \begin{codeblock}
 namespace std::chrono {
-  template <class Rep, class Period = ratio<1>>
+  template<class Rep, class Period = ratio<1>>
     class duration {
     public:
       using rep    = Rep;
@@ -17861,9 +17861,9 @@ namespace std::chrono {
     public:
       // \ref{time.duration.cons}, construct/copy/destroy
       constexpr duration() = default;
-      template <class Rep2>
+      template<class Rep2>
         constexpr explicit duration(const Rep2& r);
-      template <class Rep2, class Period2>
+      template<class Rep2, class Period2>
         constexpr duration(const duration<Rep2, Period2>& d);
       ~duration() = default;
       duration(const duration&) = default;
@@ -17929,7 +17929,7 @@ duration<double, ratio<1, 30>>  d2; // holds a count with a tick period of $\fra
 
 \indexlibrary{\idxcode{duration}!constructor}%
 \begin{itemdecl}
-template <class Rep2>
+template<class Rep2>
   constexpr explicit duration(const Rep2& r);
 \end{itemdecl}
 
@@ -17958,7 +17958,7 @@ duration<int, milli> d(3.5);        // error
 
 \indexlibrary{\idxcode{duration}!constructor}%
 \begin{itemdecl}
-template <class Rep2, class Period2>
+template<class Rep2, class Period2>
   constexpr duration(const duration<Rep2, Period2>& d);
 \end{itemdecl}
 
@@ -18184,7 +18184,7 @@ of the function. \tcode{CR(A, B)} represents \tcode{common_type_t<A, B>}.
 
 \indexlibrary{\idxcode{common_type}}%
 \begin{itemdecl}
-template <class Rep1, class Period1, class Rep2, class Period2>
+template<class Rep1, class Period1, class Rep2, class Period2>
   constexpr common_type_t<duration<Rep1, Period1>, duration<Rep2, Period2>>
     operator+(const duration<Rep1, Period1>& lhs, const duration<Rep2, Period2>& rhs);
 \end{itemdecl}
@@ -18196,7 +18196,7 @@ template <class Rep1, class Period1, class Rep2, class Period2>
 
 \indexlibrary{\idxcode{common_type}}%
 \begin{itemdecl}
-template <class Rep1, class Period1, class Rep2, class Period2>
+template<class Rep1, class Period1, class Rep2, class Period2>
   constexpr common_type_t<duration<Rep1, Period1>, duration<Rep2, Period2>>
   operator-(const duration<Rep1, Period1>& lhs, const duration<Rep2, Period2>& rhs);
 \end{itemdecl}
@@ -18208,7 +18208,7 @@ template <class Rep1, class Period1, class Rep2, class Period2>
 
 \indexlibrarymember{operator*}{duration}%
 \begin{itemdecl}
-template <class Rep1, class Period, class Rep2>
+template<class Rep1, class Period, class Rep2>
   constexpr duration<common_type_t<Rep1, Rep2>, Period>
     operator*(const duration<Rep1, Period>& d, const Rep2& s);
 \end{itemdecl}
@@ -18224,7 +18224,7 @@ resolution unless \tcode{Rep2} is implicitly convertible to \tcode{CR(Rep1, Rep2
 
 \indexlibrarymember{operator*}{duration}%
 \begin{itemdecl}
-template <class Rep1, class Rep2, class Period>
+template<class Rep1, class Rep2, class Period>
   constexpr duration<common_type_t<Rep1, Rep2>, Period>
     operator*(const Rep1& s, const duration<Rep2, Period>& d);
 \end{itemdecl}
@@ -18240,7 +18240,7 @@ resolution unless \tcode{Rep1} is implicitly convertible to \tcode{CR(Rep1, Rep2
 
 \indexlibrarymember{operator/}{duration}%
 \begin{itemdecl}
-template <class Rep1, class Period, class Rep2>
+template<class Rep1, class Period, class Rep2>
   constexpr duration<common_type_t<Rep1, Rep2>, Period>
     operator/(const duration<Rep1, Period>& d, const Rep2& s);
 \end{itemdecl}
@@ -18257,7 +18257,7 @@ and \tcode{Rep2} is not a specialization of \tcode{duration}.
 
 \indexlibrarymember{operator/}{duration}%
 \begin{itemdecl}
-template <class Rep1, class Period1, class Rep2, class Period2>
+template<class Rep1, class Period1, class Rep2, class Period2>
   constexpr common_type_t<Rep1, Rep2>
     operator/(const duration<Rep1, Period1>& lhs, const duration<Rep2, Period2>& rhs);
 \end{itemdecl}
@@ -18269,7 +18269,7 @@ template <class Rep1, class Period1, class Rep2, class Period2>
 
 \indexlibrarymember{operator\%}{duration}%
 \begin{itemdecl}
-template <class Rep1, class Period, class Rep2>
+template<class Rep1, class Period, class Rep2>
   constexpr duration<common_type_t<Rep1, Rep2>, Period>
     operator%(const duration<Rep1, Period>& d, const Rep2& s);
 \end{itemdecl}
@@ -18286,7 +18286,7 @@ resolution unless \tcode{Rep2} is implicitly convertible to \tcode{CR(Rep1, Rep2
 
 \indexlibrarymember{operator\%}{duration}%
 \begin{itemdecl}
-template <class Rep1, class Period1, class Rep2, class Period2>
+template<class Rep1, class Period1, class Rep2, class Period2>
   constexpr common_type_t<duration<Rep1, Period1>, duration<Rep2, Period2>>
     operator%(const duration<Rep1, Period1>& lhs, const duration<Rep2, Period2>& rhs);
 \end{itemdecl}
@@ -18306,7 +18306,7 @@ the two arguments to the function.
 
 \indexlibrarymember{operator==}{duration}%
 \begin{itemdecl}
-template <class Rep1, class Period1, class Rep2, class Period2>
+template<class Rep1, class Period1, class Rep2, class Period2>
   constexpr bool operator==(const duration<Rep1, Period1>& lhs,
                             const duration<Rep2, Period2>& rhs);
 \end{itemdecl}
@@ -18318,7 +18318,7 @@ template <class Rep1, class Period1, class Rep2, class Period2>
 
 \indexlibrarymember{operator"!=}{duration}%
 \begin{itemdecl}
-template <class Rep1, class Period1, class Rep2, class Period2>
+template<class Rep1, class Period1, class Rep2, class Period2>
   constexpr bool operator!=(const duration<Rep1, Period1>& lhs,
                             const duration<Rep2, Period2>& rhs);
 \end{itemdecl}
@@ -18330,7 +18330,7 @@ template <class Rep1, class Period1, class Rep2, class Period2>
 
 \indexlibrarymember{operator<}{duration}%
 \begin{itemdecl}
-template <class Rep1, class Period1, class Rep2, class Period2>
+template<class Rep1, class Period1, class Rep2, class Period2>
   constexpr bool operator<(const duration<Rep1, Period1>& lhs,
                            const duration<Rep2, Period2>& rhs);
 \end{itemdecl}
@@ -18342,7 +18342,7 @@ template <class Rep1, class Period1, class Rep2, class Period2>
 
 \indexlibrarymember{operator<=}{duration}%
 \begin{itemdecl}
-template <class Rep1, class Period1, class Rep2, class Period2>
+template<class Rep1, class Period1, class Rep2, class Period2>
   constexpr bool operator<=(const duration<Rep1, Period1>& lhs,
                             const duration<Rep2, Period2>& rhs);
 \end{itemdecl}
@@ -18354,7 +18354,7 @@ template <class Rep1, class Period1, class Rep2, class Period2>
 
 \indexlibrarymember{operator>}{duration}%
 \begin{itemdecl}
-template <class Rep1, class Period1, class Rep2, class Period2>
+template<class Rep1, class Period1, class Rep2, class Period2>
   constexpr bool operator>(const duration<Rep1, Period1>& lhs,
                            const duration<Rep2, Period2>& rhs);
 \end{itemdecl}
@@ -18366,7 +18366,7 @@ template <class Rep1, class Period1, class Rep2, class Period2>
 
 \indexlibrarymember{operator>=}{duration}%
 \begin{itemdecl}
-template <class Rep1, class Period1, class Rep2, class Period2>
+template<class Rep1, class Period1, class Rep2, class Period2>
   constexpr bool operator>=(const duration<Rep1, Period1>& lhs,
                             const duration<Rep2, Period2>& rhs);
 \end{itemdecl}
@@ -18381,7 +18381,7 @@ template <class Rep1, class Period1, class Rep2, class Period2>
 \indexlibrary{\idxcode{duration}!\idxcode{duration_cast}}%
 \indexlibrary{\idxcode{duration_cast}}%
 \begin{itemdecl}
-template <class ToDuration, class Rep, class Period>
+template<class ToDuration, class Rep, class Period>
   constexpr ToDuration duration_cast(const duration<Rep, Period>& d);
 \end{itemdecl}
 
@@ -18431,7 +18431,7 @@ the destination representation at the final step.
 
 \indexlibrarymember{floor}{duration}%
 \begin{itemdecl}
-template <class ToDuration, class Rep, class Period>
+template<class ToDuration, class Rep, class Period>
   constexpr ToDuration floor(const duration<Rep, Period>& d);
 \end{itemdecl}
 
@@ -18447,7 +18447,7 @@ for which \tcode{t <= d}.
 
 \indexlibrarymember{ceil}{duration}%
 \begin{itemdecl}
-template <class ToDuration, class Rep, class Period>
+template<class ToDuration, class Rep, class Period>
   constexpr ToDuration ceil(const duration<Rep, Period>& d);
 \end{itemdecl}
 
@@ -18463,7 +18463,7 @@ for which \tcode{t >= d}.
 
 \indexlibrarymember{round}{duration}%
 \begin{itemdecl}
-template <class ToDuration, class Rep, class Period>
+template<class ToDuration, class Rep, class Period>
   constexpr ToDuration round(const duration<Rep, Period>& d);
 \end{itemdecl}
 
@@ -18592,7 +18592,7 @@ A \tcode{duration} literal representing \tcode{nsec} nanoseconds.
 
 \indexlibrarymember{abs}{duration}%
 \begin{itemdecl}
-template <class Rep, class Period>
+template<class Rep, class Period>
   constexpr duration<Rep, Period> abs(duration<Rep, Period> d);
 \end{itemdecl}
 
@@ -18611,7 +18611,7 @@ otherwise return \tcode{-d}.
 \indexlibrary{\idxcode{time_point}}%
 \begin{codeblock}
 namespace std::chrono {
-  template <class Clock, class Duration = typename Clock::duration>
+  template<class Clock, class Duration = typename Clock::duration>
     class time_point {
     public:
       using clock    = Clock;
@@ -18626,7 +18626,7 @@ namespace std::chrono {
       // \ref{time.point.cons}, construct
       constexpr time_point();                                   // has value epoch
       constexpr explicit time_point(const duration& d);         // same as \tcode{time_point() + d}
-      template <class Duration2>
+      template<class Duration2>
         constexpr time_point(const time_point<clock, Duration2>& t);
 
       // \ref{time.point.observer}, observer
@@ -18678,7 +18678,7 @@ constexpr explicit time_point(const duration& d);
 
 \indexlibrary{\idxcode{time_point}!constructor}%
 \begin{itemdecl}
-template <class Duration2>
+template<class Duration2>
   constexpr time_point(const time_point<clock, Duration2>& t);
 \end{itemdecl}
 
@@ -18759,7 +18759,7 @@ static constexpr time_point max();
 \indexlibrarymember{operator+}{time_point}%
 \indexlibrarymember{operator+}{duration}%
 \begin{itemdecl}
-template <class Clock, class Duration1, class Rep2, class Period2>
+template<class Clock, class Duration1, class Rep2, class Period2>
   constexpr time_point<Clock, common_type_t<Duration1, duration<Rep2, Period2>>>
     operator+(const time_point<Clock, Duration1>& lhs, const duration<Rep2, Period2>& rhs);
 \end{itemdecl}
@@ -18772,7 +18772,7 @@ template <class Clock, class Duration1, class Rep2, class Period2>
 \indexlibrarymember{operator+}{time_point}%
 \indexlibrarymember{operator+}{duration}%
 \begin{itemdecl}
-template <class Rep1, class Period1, class Clock, class Duration2>
+template<class Rep1, class Period1, class Clock, class Duration2>
   constexpr time_point<Clock, common_type_t<duration<Rep1, Period1>, Duration2>>
     operator+(const duration<Rep1, Period1>& lhs, const time_point<Clock, Duration2>& rhs);
 \end{itemdecl}
@@ -18785,7 +18785,7 @@ template <class Rep1, class Period1, class Clock, class Duration2>
 \indexlibrarymember{operator-}{time_point}%
 \indexlibrarymember{operator-}{duration}%
 \begin{itemdecl}
-template <class Clock, class Duration1, class Rep2, class Period2>
+template<class Clock, class Duration1, class Rep2, class Period2>
   constexpr time_point<Clock, common_type_t<Duration1, duration<Rep2, Period2>>>
     operator-(const time_point<Clock, Duration1>& lhs, const duration<Rep2, Period2>& rhs);
 \end{itemdecl}
@@ -18798,7 +18798,7 @@ where \tcode{\placeholder{CT}} is the type of the return value.
 
 \indexlibrarymember{operator-}{time_point}%
 \begin{itemdecl}
-template <class Clock, class Duration1, class Duration2>
+template<class Clock, class Duration1, class Duration2>
   constexpr common_type_t<Duration1, Duration2>
     operator-(const time_point<Clock, Duration1>& lhs, const time_point<Clock, Duration2>& rhs);
 \end{itemdecl}
@@ -18812,7 +18812,7 @@ template <class Clock, class Duration1, class Duration2>
 
 \indexlibrarymember{operator==}{time_point}%
 \begin{itemdecl}
-template <class Clock, class Duration1, class Duration2>
+template<class Clock, class Duration1, class Duration2>
   constexpr bool operator==(const time_point<Clock, Duration1>& lhs,
                             const time_point<Clock, Duration2>& rhs);
 \end{itemdecl}
@@ -18824,7 +18824,7 @@ template <class Clock, class Duration1, class Duration2>
 
 \indexlibrarymember{operator"!=}{time_point}%
 \begin{itemdecl}
-template <class Clock, class Duration1, class Duration2>
+template<class Clock, class Duration1, class Duration2>
   constexpr bool operator!=(const time_point<Clock, Duration1>& lhs,
                             const time_point<Clock, Duration2>& rhs);
 \end{itemdecl}
@@ -18836,7 +18836,7 @@ template <class Clock, class Duration1, class Duration2>
 
 \indexlibrarymember{operator<}{time_point}%
 \begin{itemdecl}
-template <class Clock, class Duration1, class Duration2>
+template<class Clock, class Duration1, class Duration2>
   constexpr bool operator<(const time_point<Clock, Duration1>& lhs,
                            const time_point<Clock, Duration2>& rhs);
 \end{itemdecl}
@@ -18848,7 +18848,7 @@ template <class Clock, class Duration1, class Duration2>
 
 \indexlibrarymember{operator<=}{time_point}%
 \begin{itemdecl}
-template <class Clock, class Duration1, class Duration2>
+template<class Clock, class Duration1, class Duration2>
   constexpr bool operator<=(const time_point<Clock, Duration1>& lhs,
                             const time_point<Clock, Duration2>& rhs);
 \end{itemdecl}
@@ -18860,7 +18860,7 @@ template <class Clock, class Duration1, class Duration2>
 
 \indexlibrarymember{operator>}{time_point}%
 \begin{itemdecl}
-template <class Clock, class Duration1, class Duration2>
+template<class Clock, class Duration1, class Duration2>
   constexpr bool operator>(const time_point<Clock, Duration1>& lhs,
                            const time_point<Clock, Duration2>& rhs);
 \end{itemdecl}
@@ -18872,7 +18872,7 @@ template <class Clock, class Duration1, class Duration2>
 
 \indexlibrarymember{operator>=}{time_point}%
 \begin{itemdecl}
-template <class Clock, class Duration1, class Duration2>
+template<class Clock, class Duration1, class Duration2>
   constexpr bool operator>=(const time_point<Clock, Duration1>& lhs,
                             const time_point<Clock, Duration2>& rhs);
 \end{itemdecl}
@@ -18887,7 +18887,7 @@ template <class Clock, class Duration1, class Duration2>
 \indexlibrary{\idxcode{time_point}!\idxcode{time_point_cast}}%
 \indexlibrary{\idxcode{time_point_cast}}%
 \begin{itemdecl}
-template <class ToDuration, class Clock, class Duration>
+template<class ToDuration, class Clock, class Duration>
   constexpr time_point<Clock, ToDuration> time_point_cast(const time_point<Clock, Duration>& t);
 \end{itemdecl}
 
@@ -18905,7 +18905,7 @@ time_point<Clock, ToDuration>(duration_cast<ToDuration>(t.time_since_epoch()))
 
 \indexlibrarymember{floor}{time_point}%
 \begin{itemdecl}
-template <class ToDuration, class Clock, class Duration>
+template<class ToDuration, class Clock, class Duration>
   constexpr time_point<Clock, ToDuration> floor(const time_point<Clock, Duration>& tp);
 \end{itemdecl}
 
@@ -18920,7 +18920,7 @@ unless \tcode{ToDuration} is a specialization of \tcode{duration}.
 
 \indexlibrarymember{ceil}{time_point}%
 \begin{itemdecl}
-template <class ToDuration, class Clock, class Duration>
+template<class ToDuration, class Clock, class Duration>
   constexpr time_point<Clock, ToDuration> ceil(const time_point<Clock, Duration>& tp);
 \end{itemdecl}
 
@@ -18935,7 +18935,7 @@ unless \tcode{ToDuration} is a specialization of \tcode{duration}.
 
 \indexlibrarymember{round}{time_point}%
 \begin{itemdecl}
-template <class ToDuration, class Clock, class Duration>
+template<class ToDuration, class Clock, class Duration>
   constexpr time_point<Clock, ToDuration> round(const time_point<Clock, Duration>& tp);
 \end{itemdecl}
 
@@ -19141,7 +19141,7 @@ races\iref{res.on.data.races}.
 \begin{codeblock}
 namespace std {
   class type_index;
-  template <class T> struct hash;
+  template<class T> struct hash;
   template<> struct hash<type_index>;
 }
 \end{codeblock}
@@ -19274,7 +19274,7 @@ const char* name() const noexcept;
 
 \indexlibrary{\idxcode{hash}!\idxcode{type_index}}%
 \begin{itemdecl}
-template <> struct hash<type_index>;
+template<> struct hash<type_index>;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Use `template<class T>`.
Also remove space between two closing template brackets in [lib].
Leave [temp] unchanged, intentionally showing a variety of styles.

Fixes #53.