### PR TITLE
[lib] Replace pre: and post: in requirements tables

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -1684,7 +1684,7 @@ In that table,
 \tcode{P p = i;}    &
             &
             &
- post: \tcode{p == P(i)}. \\ \rowsep
+ \postconditions \tcode{p == P(i)}. \\ \rowsep
 \tcode{P(o)}      &
  \tcode{fpos}     &
  converts from \tcode{offset} & \\ \rowsep

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -290,7 +290,7 @@ the indicated semantics.
 \tcode{*r}          &
   unspecified       &
                             &
-  pre: \tcode{r} is dereferenceable.  \\ \rowsep
+  \requires \tcode{r} is dereferenceable.  \\ \rowsep
 
 \tcode{++r}         &
   \tcode{X\&}       &
@@ -356,25 +356,25 @@ has property
 \tcode{a != b}                  &
  contextually convertible to \tcode{bool}    &
  \tcode{!(a == b)}                              &
- pre: \orange{a}{b} is in the domain of \tcode{==}. \\ \rowsep
+ \requires \orange{a}{b} is in the domain of \tcode{==}. \\ \rowsep
 
 \tcode{*a}                      &
  \tcode{reference}, convertible to \tcode{T}       &
                                 &
- pre: \tcode{a} is dereferenceable.\br
+ \requires \tcode{a} is dereferenceable.\br
  The expression\br \tcode{(void)*a, *a} is equivalent to \tcode{*a}.\br
  If \tcode{a == b} and \orange{a}{b} is in the domain of \tcode{==}
  then \tcode{*a} is equivalent to \tcode{*b}.  \\ \rowsep
 \tcode{a->m}                    &
                                 &
  \tcode{(*a).m}                                &
- pre: \tcode{a} is dereferenceable. \\ \rowsep
+ \requires \tcode{a} is dereferenceable. \\ \rowsep
 \tcode{++r}                     &
  \tcode{X\&}                    &
                                 &
- pre: \tcode{r} is dereferenceable.\br
- post: \tcode{r} is dereferenceable or \tcode{r} is past-the-end.\br
- post: any copies of the previous value of \tcode{r} are no longer
+ \requires \tcode{r} is dereferenceable.\br
+ \postconditions \tcode{r} is dereferenceable or \tcode{r} is past-the-end;\br
+ any copies of the previous value of \tcode{r} are no longer
  required either to be dereferenceable or to be in the domain of \tcode{==}.    \\ \rowsep
 
 \tcode{(void)r++}               &
@@ -432,14 +432,14 @@ are valid and have the indicated semantics.
  result is not used &
                     &
  \remarks\ After this operation \tcode{r} is not required to be dereferenceable.\br
- post: \tcode{r} is incrementable. \\ \rowsep
+ \postconditions \tcode{r} is incrementable. \\ \rowsep
 
 \tcode{++r}         &
  \tcode{X\&}        &
                     &
  \tcode{\&r == \&++r}.\br
  \remarks\ After this operation \tcode{r} is not required to be dereferenceable.\br
- post: \tcode{r} is incrementable. \\ \rowsep
+ \postconditions \tcode{r} is incrementable. \\ \rowsep
 
 \tcode{r++}         &
  convertible to \tcode{const X\&}   &
@@ -447,12 +447,12 @@ are valid and have the indicated semantics.
  \tcode{  ++r;}\br
  \tcode{  return tmp; \}}   &
  \remarks\ After this operation \tcode{r} is not required to be dereferenceable.\br
- post: \tcode{r} is incrementable. \\ \rowsep
+ \postconditions \tcode{r} is incrementable. \\ \rowsep
 
 \tcode{*r++ = o}    &
  result is not used &&
  \remarks\ After this operation \tcode{r} is not required to be dereferenceable.\br
- post: \tcode{r} is incrementable. \\
+ \postconditions \tcode{r} is incrementable. \\
 \end{libreqtab4b}
 
 \pnum
@@ -580,8 +580,8 @@ the following expressions are valid as shown in Table~\ref{tab:iterator.bidirect
 \tcode{\dcr r}      &
  \tcode{X\&}        &
                     &
- pre: there exists \tcode{s} such that \tcode{r == ++s}.\br
- post: \tcode{r} is dereferenceable.\br
+ \requires there exists \tcode{s} such that \tcode{r == ++s}.\br
+ \postconditions \tcode{r} is dereferenceable.\br
  \tcode{\dcr(++r) == r}.\br
  \tcode{\dcr r == \dcr s} implies \tcode{r == s}.\br
  \tcode{\&r == \&\dcr r}.   \\ \hline
@@ -643,7 +643,7 @@ the following expressions are valid as shown in Table~\ref{tab:iterator.random.a
 \tcode{r -= n}      &
  \tcode{X\&}        &
  \tcode{return r += -n;}    &
- pre: the absolute value of \tcode{n} is in the range of
+ \requires the absolute value of \tcode{n} is in the range of
  representable values of \tcode{difference_type}.   \\ \rowsep
 
 \tcode{a - n}       &
@@ -654,7 +654,7 @@ the following expressions are valid as shown in Table~\ref{tab:iterator.random.a
 \tcode{b - a}       &
  \tcode{difference_type}   &
  \tcode{return n}   &
- pre: there exists a value \tcode{n} of type \tcode{difference_type} such that \tcode{a + n == b}.\br
+ \requires there exists a value \tcode{n} of type \tcode{difference_type} such that \tcode{a + n == b}.\br
  \tcode{b == a + (b - a)}.  \\ \rowsep
 
 \tcode{a[n]}        &

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1679,18 +1679,18 @@ a value of type (possibly \tcode{const}) \tcode{std::nullptr_t}.
 Expression  &   Return type   &   Operational semantics \\ \capsep
 \tcode{P u(np);}\br           &
                               &
-  post: \tcode{u == nullptr}  \\
+  \postconditions \tcode{u == nullptr}  \\
 \tcode{P u = np;}             &
                               &
                               \\ \rowsep
 
 \tcode{P(np)}                 &
                               &
-  post: \tcode{P(np) == nullptr}  \\ \rowsep
+  \postconditions \tcode{P(np) == nullptr}  \\ \rowsep
 
 \tcode{t = np}                &
   \tcode{P\&}                 &
-  post: \tcode{t == nullptr}  \\ \rowsep
+  \postconditions \tcode{t == nullptr}  \\ \rowsep
 
 \tcode{a != b}                &
   contextually convertible to \tcode{bool}  &
@@ -1876,11 +1876,11 @@ type (possibly \tcode{const}) \tcode{std::nullptr_t}. \\ \rowsep
 
 \tcode{p->m}                &
   type of \tcode{T::m}      &
-  \textit{pre:} \tcode{(*p).m} is well-defined. equivalent to \tcode{(*p).m}  & \\ \rowsep
+  \requires \tcode{(*p).m} is well-defined. equivalent to \tcode{(*p).m}  & \\ \rowsep
 
 \tcode{q->m}                &
   type of \tcode{T::m}      &
-  \textit{pre:} \tcode{(*q).m} is well-defined. equivalent to \tcode{(*q).m}  & \\ \rowsep
+  \requires \tcode{(*q).m} is well-defined. equivalent to \tcode{(*q).m}  & \\ \rowsep
 
 \tcode{static_-} \tcode{cast<X::pointer>(w)}  &
   \tcode{X::pointer}                &
@@ -1905,10 +1905,10 @@ If \tcode{n == 0}, the return value is unspecified.
 
 \tcode{a.deallocate(p,n)}   &
   (not used)                &
-  \textit{pre:} \tcode{p} shall be a value returned by an earlier call
+  \requires \tcode{p} shall be a value returned by an earlier call
   to \tcode{allocate} that has not been invalidated by
   an intervening call to \tcode{deallocate}. \tcode{n} shall
-  match the value passed to \tcode{allocate} to obtain this memory.
+  match the value passed to \tcode{allocate} to obtain this memory.\br
   \throws Nothing.          &  \\ \rowsep
 
 \tcode{a.max_size()}        &
@@ -1938,33 +1938,33 @@ If \tcode{n == 0}, the return value is unspecified.
 \tcode{X u = a;}           &
                             &
   Shall not exit via an exception.\br
-  post: \tcode{u == a}     & \\ \rowsep
+  \postconditions \tcode{u == a}     & \\ \rowsep
 
 \tcode{X u(b);}             &
                             &
   Shall not exit via an exception.\br
-  post: \tcode{Y(u) == b}, \tcode{u == X(b)} &  \\ \rowsep
+  \postconditions \tcode{Y(u) == b}, \tcode{u == X(b)} &  \\ \rowsep
 
 \tcode{X u(std::move(a));}  \br
 \tcode{X u = std::move(a);} &
                             &
   Shall not exit via an exception.\br
-  post: \tcode{u} is equal to the prior value of \tcode{a}. & \\ \rowsep
+  \postconditions \tcode{u} is equal to the prior value of \tcode{a}. & \\ \rowsep
 
 \tcode{X u(std::move(b));}  &
                             &
   Shall not exit via an exception.\br
-  post: \tcode{u} is equal to the prior value of \tcode{X(b)}. & \\ \rowsep
+  \postconditions \tcode{u} is equal to the prior value of \tcode{X(b)}. & \\ \rowsep
 
 \tcode{a.construct(c, args)}&
   (not used)                &
-  Effect: Constructs an object of type \tcode{C} at
+  \effects Constructs an object of type \tcode{C} at
     \tcode{c}               &
   \tcode{::new ((void*)c) C(forward<\brk{}Args>\brk(args)...)}  \\ \rowsep
 
 \tcode{a.destroy(c)}        &
   (not used)                &
-  Effect: Destroys the object at \tcode{c}  &
+  \effects Destroys the object at \tcode{c}  &
   \tcode{c->\~{}C()}           \\  \rowsep
 
 \tcode{a.select_on_container_copy_construction()} &

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -1952,21 +1952,21 @@ according to Clause~\ref{strings} and Clause~\ref{input.output}.
 \tcode{e.seed()}%
 \indextext{\idxcode{seed}!random number engine requirement}
   & \tcode{void}
-  & post:
+  & \postconditions
     \tcode{e == E()}.
   & same as \tcode{E()}
   \\ \rowsep
 \tcode{e.seed(s)}%
 \indextext{\idxcode{seed}!random number engine requirement}
   & \tcode{void}
-  & post:
+  & \postconditions
     \tcode{e == E(s)}.
   & same as \tcode{E(s)}
   \\ \rowsep
 \tcode{e.seed(q)}%
 \indextext{\idxcode{seed}!random number engine requirement}
   & \tcode{void}
-  & post:
+  & \postconditions
     \tcode{e == E(q)}.
   & same as \tcode{E(q)}
   \\ \rowsep
@@ -2030,7 +2030,7 @@ according to Clause~\ref{strings} and Clause~\ref{input.output}.
     adjacent numbers are separated
     by one or more space characters.
 
-    post: The \tcode{os.}\textit{fmtflags} and fill character are unchanged.
+    \postconditions The \tcode{os.}\textit{fmtflags} and fill character are unchanged.
   & \bigoh{$\mbox{size of state}$}
   \\ \rowsep
 \tcode{is \shr{} v}%
@@ -2051,7 +2051,7 @@ according to Clause~\ref{strings} and Clause~\ref{input.output}.
     provided that there have been no intervening invocations
     of \tcode{x} or of \tcode{v}.
 
-    pre:
+    \requires
     \tcode{is} provides a textual representation
     that was previously written
     using an output stream
@@ -2061,7 +2061,7 @@ according to Clause~\ref{strings} and Clause~\ref{input.output}.
     \tcode{charT} and \tcode{traits}
     were respectively the same as those of \tcode{is}.
 
-    post: The \tcode{is.}\textit{fmtflags} are unchanged.
+    \postconditions The \tcode{is.}\textit{fmtflags} are unchanged.
   & \bigoh{$\mbox{size of state}$}
   \\
 \end{libreqtab4d}
@@ -2348,7 +2348,7 @@ according to Clauses~\ref{strings} and \ref{input.output}.
 \tcode{d.param(p)}
 \indextext{\idxcode{param}!random number distribution requirement}
   & \tcode{void}
-  & post: \tcode{d.param() == p}.
+  & \postconditions \tcode{d.param() == p}.
   & no worse than the complexity of \tcode{D(p)}
   \\ \rowsep
 \tcode{d(g)}
@@ -2419,7 +2419,7 @@ according to Clauses~\ref{strings} and \ref{input.output}.
   & Writes to \tcode{os} a textual representation
     for the parameters and the additional internal data of \tcode{x}.
 
-    post: The \tcode{os.}\textit{fmtflags} and fill character are unchanged.
+    \postconditions The \tcode{os.}\textit{fmtflags} and fill character are unchanged.
   &
   \\ \rowsep
 \tcode{is \shr{} d}
@@ -2433,14 +2433,14 @@ according to Clauses~\ref{strings} and \ref{input.output}.
     calls \tcode{is.setstate(ios\colcol{}failbit)}
     (which may throw \tcode{ios\colcol{}failure}~[\ref{iostate.flags}]).
 
-    pre: \tcode{is} provides a textual representation
+    \requires \tcode{is} provides a textual representation
     that was previously written
     using an \tcode{os} whose imbued locale
     and whose type's template specialization arguments
     \tcode{charT} and \tcode{traits}
     were the same as those of \tcode{is}.
 
-    post: The \tcode{is.}\textit{fmtflags} are unchanged.
+    \postconditions The \tcode{is.}\textit{fmtflags} are unchanged.
   &
   \\
 \end{libreqtab4d}

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -147,48 +147,50 @@ Operations on Traits shall not throw exceptions.
 \tcode{X::state_type}   &                       &
 (described in~\ref{char.traits.typedefs})   &   compile-time    \\ \rowsep
 \tcode{X::eq(c,d)}      &   \tcode{bool}        &
-yields: whether \tcode{c} is to be treated as equal to \tcode{d}.   &   constant    \\ \rowsep
+\returns whether \tcode{c} is to be treated as equal to \tcode{d}.   &   constant    \\ \rowsep
 \tcode{X::lt(c,d)}      &   \tcode{bool}        &
-yields: whether \tcode{c} is to be treated as less than \tcode{d}.  &   constant    \\ \rowsep
+\returns whether \tcode{c} is to be treated as less than \tcode{d}.  &   constant    \\ \rowsep
 \tcode{X::compare(p,q,n)}   &   \tcode{int}     &
-yields: \tcode{0} if for each \tcode{i} in \tcode{[0,n)}, \tcode{X::eq(p[i],q[i])}
+\returns \tcode{0} if for each \tcode{i} in \tcode{[0,n)}, \tcode{X::eq(p[i],q[i])}
 is \tcode{true}; else, a negative value if, for some \tcode{j} in \tcode{[0,n)},
 \tcode{X::lt(p[j],q[j])} is \tcode{true} and for each \tcode{i} in \tcode{[0,j)}
 \tcode{X::eq(p[i],q[i])} is \tcode{true}; else a positive value.            &   linear      \\ \rowsep
 \tcode{X::length(p)}    &   \tcode{size_t}     &
-yields: the smallest \tcode{i} such that \tcode{X::eq(p[i],charT())} is \tcode{true}.  &   linear  \\ \rowsep
+\returns the smallest \tcode{i} such that \tcode{X::eq(p[i],charT())} is \tcode{true}.  &   linear  \\ \rowsep
 \tcode{X::find(p,n,c)}  &   \tcode{const X::char_type*} &
-yields: the smallest \tcode{q} in \tcode{[p,p+n)} such that
+\returns the smallest \tcode{q} in \tcode{[p,p+n)} such that
 \tcode{X::eq(*q,c)} is \tcode{true}, zero otherwise.                        &   linear      \\ \rowsep
 \tcode{X::move(s,p,n)}  &   \tcode{X::char_type*}   &
 for each \tcode{i} in \tcode{[0,n)}, performs \tcode{X::assign(s[i],p[i])}.
-Copies correctly even where the ranges \tcode{[p,p+n)} and \tcode{[s,s+n)} overlap. yields: \tcode{s}.    &   linear  \\ \rowsep
+Copies correctly even where the ranges \tcode{[p,p+n)} and \tcode{[s,s+n)} overlap.\br \returns \tcode{s}.    &   linear  \\ \rowsep
 \tcode{X::copy(s,p,n)}  &   \tcode{X::char_type*}   &
-pre: \tcode{p} not in \tcode{[s,s+n)}. yields: \tcode{s}. for each \tcode{i} in
+\requires \tcode{p} not in \tcode{[s,s+n)}. \returns \tcode{s}.\br
+for each \tcode{i} in
 \tcode{[0,n)}, performs \tcode{X::assign(s[i],p[i])}.               &   linear      \\ \rowsep
 \tcode{X::assign(r,d)}  &   (not used)          &
 assigns \tcode{r=d}.                            &   constant        \\ \rowsep
 \tcode{X::assign\-(s,n,c)}  &   \tcode{X::char_type*}   &
 for each \tcode{i} in \tcode{[0,n)}, performs
-\tcode{X::assign(s[i],c)}. yields: \tcode{s}.                       &   linear      \\ \rowsep
+\tcode{X::assign(s[i],c)}.\br
+\returns \tcode{s}.                       &   linear      \\ \rowsep
 \tcode{X::not_eof(e)}   &   \tcode{int_type}        &
-yields: \tcode{e} if \tcode{X::eq_int_type(e,X::eof())} is \tcode{false},
+\returns \tcode{e} if \tcode{X::eq_int_type(e,X::eof())} is \tcode{false},
 otherwise a value \tcode{f} such that
 \tcode{X::eq_int_type(f,X::eof())} is \tcode{false}.                       &   constant    \\ \rowsep
 \tcode{X::to_char_type\-(e)}    &   \tcode{X::char_type}    &
-yields: if for some \tcode{c}, \tcode{X::eq_int_type(e,X::to_int_type(c))}
+\returns if for some \tcode{c}, \tcode{X::eq_int_type(e,X::to_int_type(c))}
 is \tcode{true}, \tcode{c}; else some unspecified value.                    &   constant    \\ \rowsep
 \tcode{X::to_int_type\-(c)} &   \tcode{X::int_type} &
-yields: some value \tcode{e}, constrained by the definitions of
+\returns some value \tcode{e}, constrained by the definitions of
 \tcode{to_char_type} and \tcode{eq_int_type}.                  &   constant    \\ \rowsep
 \tcode{X::eq_int_type\-(e,f)}   &   \tcode{bool}            &
-yields: for all \tcode{c} and \tcode{d}, \tcode{X::eq(c,d)} is equal to
+\returns for all \tcode{c} and \tcode{d}, \tcode{X::eq(c,d)} is equal to
 \tcode{X::eq_int_type(X::to_int_type(c), X::to_int_type(d))}; otherwise, yields \tcode{true}
 if \tcode{e} and \tcode{f} are both copies of \tcode{X::eof()}; otherwise, yields \tcode{false} if
 one of \tcode{e} and \tcode{f} is a copy of \tcode{X::eof()} and the other is not; otherwise
 the value is unspecified.                                           &   constant    \\ \rowsep
 \tcode{X::eof()}                &   \tcode{X::int_type} &
-yields: a value \tcode{e} such that \tcode{X::eq_int_type(e,X::to_int_type(c))}
+\returns a value \tcode{e} such that \tcode{X::eq_int_type(e,X::to_int_type(c))}
 is \tcode{false} for all values \tcode{c}.                                  &   constant    \\
 \end{libreqtab4d}
 


### PR DESCRIPTION
with \requires and \postcondition, respectively.

Also replace yields: with \returns and effect: with \effects.

Fixes #1281.