### PR TITLE
[except] Replace \term and \textit

### DIFF
--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -114,10 +114,10 @@ lab:  try {
   T1 t1;
   try {
     T2 t2;
-    if (@\textit{condition}@)
+    if (@\grammarterm{condition}@)
       goto lab;
-    } catch(...) { /* @\textit{handler 2}@ */ }
-  } catch(...) { /* @\textit{handler 1}@ */ }
+    } catch(...) { @\tcode{/* handler 2 */}@ }
+  } catch(...) { @\tcode{/* handler 1 */}@ }
 \end{codeblock}
 
 Here, executing
@@ -132,11 +132,11 @@ does not declare a variable.
 Any exception thrown while destroying
 \tcode{t2}
 will result in executing
-\textit{handler 2};
+\tcode{handler 2};
 any exception thrown while destroying
 \tcode{t1}
 will result in executing
-\textit{handler 1}.
+\tcode{handler 1}.
 \end{example}
 
 \pnum
@@ -208,7 +208,7 @@ can catch it.
 throw "Help!";
 \end{codeblock}
 can be caught by a
-\term{handler}
+\grammarterm{handler}
 of
 \tcode{const}
 \tcode{char*}
@@ -260,10 +260,10 @@ keyword was most recently entered by the thread of control and not yet exited.
 Throwing an exception
 copy-initializes~(\ref{dcl.init}, \ref{class.copy}) a temporary object,
 called the
-\indextext{exception handling!exception object}\term{exception object}.
+\defnx{exception object}{exception handling!exception object}.
 An lvalue denoting the temporary is used to initialize the
 variable declared in the matching
-\term{handler}~(\ref{except.handle}).
+\grammarterm{handler}~(\ref{except.handle}).
 If the type of the exception object would
 be an incomplete type or a pointer to an incomplete
 type other than \cv{}~\tcode{void} the program is ill-formed.
@@ -444,10 +444,10 @@ if any, is called to free the storage occupied by the object.
 The
 \grammarterm{exception-declaration}
 in a
-\term{handler}
+\grammarterm{handler}
 describes the type(s) of exceptions that can cause
 that
-\term{handler}
+\grammarterm{handler}
 to be entered.
 \indextext{exception handling!handler!incomplete type in}%
 \indextext{exception handling!handler!rvalue reference in}%
@@ -482,7 +482,7 @@ is adjusted to be of type
 \pnum
 \indextext{exception handling!handler!match|(}%
 A
-\term{handler}
+\grammarterm{handler}
 is a match for
 an exception object
 of type
@@ -490,16 +490,16 @@ of type
 if
 \begin{itemize}
 \item%
-The \term{handler} is of type \cv{}~\tcode{T} or
+The \grammarterm{handler} is of type \cv{}~\tcode{T} or
 \cv{}~\tcode{T\&} and
 \tcode{E} and \tcode{T}
 are the same type (ignoring the top-level \grammarterm{cv-qualifiers}), or
 \item%
-the \term{handler} is of type \cv{}~\tcode{T} or
+the \grammarterm{handler} is of type \cv{}~\tcode{T} or
 \cv{}~\tcode{T\&} and
 \tcode{T} is an unambiguous public base class of \tcode{E}, or
 \item%
-the \term{handler} is of type \cv{}~\tcode{T} or \tcode{const T\&}
+the \grammarterm{handler} is of type \cv{}~\tcode{T} or \tcode{const T\&}
 where \tcode{T} is a pointer or pointer to member type and
 \tcode{E} is a pointer or pointer to member type
 that can be converted to \tcode{T} by one or more of
@@ -516,7 +516,7 @@ a qualification conversion~(\ref{conv.qual}), or
 \end{itemize}
 
 \item
-the \term{handler} is of type \cv{}~\tcode{T} or \tcode{const T\&} where \tcode{T} is a pointer or pointer to member type and \tcode{E} is \tcode{std::nullptr_t}.
+the \grammarterm{handler} is of type \cv{}~\tcode{T} or \tcode{const T\&} where \tcode{T} is a pointer or pointer to member type and \tcode{E} is \tcode{std::nullptr_t}.
 
 \end{itemize}
 
@@ -601,9 +601,10 @@ is entered due to a throw. A handler is no longer considered active when the
 catch clause exits.
 
 \pnum
+\indextext{currently handled exception|see{exception handline, currently handled exception}}%
 The exception with the most recently activated handler that is
 still active is called the
-\term{currently handled exception}.
+\defnx{currently handled exception}{exception handling!currently handled exception}.
 
 \pnum
 If no matching handler is found,


### PR DESCRIPTION
with \grammarterm or \defn/x as appropriate.

Also add an index entry.

Partially addresses #701.
Partially addresses #329.