### PR TITLE
[string.view] Remove unnecessary std:: prefixes.

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -4661,8 +4661,8 @@ In the rest of this section, the type of the char-like objects held in a \tcode{
 
 \pnum
 \begin{note}
-The library provides implicit conversions from \tcode{const charT*} and \tcode{std::basic_string<charT, ...>} to \tcode{std::basic_string_view<charT, ...>} so that user code can accept just \tcode{std::basic_string_view<charT>} as a non-templated parameter wherever a sequence of characters is expected.
-User-defined types should define their own implicit conversions to \tcode{std::basic_string_view} in order to interoperate with these functions.
+The library provides implicit conversions from \tcode{const charT*} and \tcode{basic_string<charT, ...>} to \tcode{basic_string_view<charT, ...>} so that user code can accept just \tcode{basic_string_view<charT>} as a non-templated parameter wherever a sequence of characters is expected.
+User-defined types should define their own implicit conversions to \tcode{basic_string_view} in order to interoperate with these functions.
 \end{note}
 
 \pnum


### PR DESCRIPTION
Same rationale as #1085.