### PR TITLE
[strings] Remove remarks that repeat what was stated a few lines before.

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -1380,12 +1380,6 @@ is pointed at by \tcode{s}                                                      
 \tcode{size()}      &   \tcode{traits::length(s)}                                       \\
 \tcode{capacity()}  &   a value at least as large as \tcode{size()}                     \\
 \end{libefftabvalue}
-
-\pnum
-\remarks
-Uses
-\tcode{traits::length()}.
-\indexlibrary{\idxcode{length}!\idxcode{char_traits}}%
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_string}!constructor}%
@@ -3119,11 +3113,6 @@ for all elements \tcode{I} of the data referenced by \tcode{sv}.
 \tcode{xpos} if the function can determine such a value for \tcode{xpos}.
 Otherwise, returns
 \tcode{npos}.
-
-\pnum
-\remarks
-Uses
-\tcode{traits::eq()}.
 \end{itemdescr}
 
 \indexlibrarymember{find}{basic_string}%
@@ -3202,11 +3191,6 @@ for all elements \tcode{I} of the data referenced by \tcode{sv}.
 \tcode{xpos} if the function can determine such a value for \tcode{xpos}.
 Otherwise, returns
 \tcode{npos}.
-
-\pnum
-\remarks
-Uses
-\tcode{traits::eq()}.
 \end{itemdescr}
 
 \indexlibrarymember{rfind}{basic_string}%
@@ -3286,11 +3270,6 @@ for some element \tcode{I} of the data referenced by \tcode{sv}.
 \tcode{xpos} if the function can determine such a value for \tcode{xpos}.
 Otherwise, returns
 \tcode{npos}.
-
-\pnum
-\remarks
-Uses
-\tcode{traits::eq()}.
 \end{itemdescr}
 
 \indexlibrarymember{find_first_of}{basic_string}%
@@ -3369,11 +3348,6 @@ for some element \tcode{I} of the data referenced by \tcode{sv}.
 \tcode{xpos} if the function can determine such a value for \tcode{xpos}.
 Otherwise, returns
 \tcode{npos}.
-
-\pnum
-\remarks
-Uses
-\tcode{traits::eq()}.
 \end{itemdescr}
 
 \indexlibrarymember{find_last_of}{basic_string}%
@@ -3453,11 +3427,6 @@ for no element \tcode{I} of the data referenced by \tcode{sv}.
 \tcode{xpos} if the function can determine such a value for \tcode{xpos}.
 Otherwise, returns
 \tcode{npos}.
-
-\pnum
-\remarks
-Uses
-\tcode{traits::eq()}.
 \end{itemdescr}
 
 \indexlibrarymember{find_first_not_of}{basic_string}%
@@ -3540,11 +3509,6 @@ for no element \tcode{I} of the data referenced by \tcode{sv}.
 \tcode{xpos} if the function can determine such a value for \tcode{xpos}.
 Otherwise, returns
 \tcode{npos}.
-
-\pnum
-\remarks
-Uses
-\tcode{traits::eq()}.
 \end{itemdescr}
 
 \indexlibrarymember{find_last_not_of}{basic_string}%
@@ -5361,10 +5325,6 @@ Determines \tcode{xpos}.
 \returns
 \tcode{xpos} if the function can determine such a value for \tcode{xpos}.
 Otherwise, returns \tcode{npos}.
-
-\pnum
-\remarks
-Uses \tcode{traits::eq()}.
 \end{itemdescr}
 
 \indexlibrarymember{rfind}{basic_string_view}%
@@ -5392,10 +5352,6 @@ Determines \tcode{xpos}.
 \returns
 \tcode{xpos} if the function can determine such a value for \tcode{xpos}.
 Otherwise, returns \tcode{npos}.
-
-\pnum
-\remarks
-Uses \tcode{traits::eq()}.
 \end{itemdescr}
 
 \indexlibrarymember{find_first_of}{basic_string_view}%
@@ -5423,10 +5379,6 @@ Determines \tcode{xpos}.
 \returns
 \tcode{xpos} if the function can determine such a value for \tcode{xpos}.
 Otherwise, returns \tcode{npos}.
-
-\pnum
-\remarks
-Uses \tcode{traits::eq()}.
 \end{itemdescr}
 
 \indexlibrarymember{find_last_of}{basic_string_view}%
@@ -5454,10 +5406,6 @@ Determines \tcode{xpos}.
 \returns
 \tcode{xpos} if the function can determine such a value for \tcode{xpos}.
 Otherwise, returns \tcode{npos}.
-
-\pnum
-\remarks
-Uses \tcode{traits::eq()}.
 \end{itemdescr}
 
 \indexlibrarymember{find_first_not_of}{basic_string_view}%
@@ -5484,10 +5432,6 @@ Determines \tcode{xpos}.
 \pnum
 \returns
 \tcode{xpos} if the function can determine such a value for \tcode{xpos}. Otherwise, returns \tcode{npos}.
-
-\pnum
-\remarks
-Uses \tcode{traits::eq()}.
 \end{itemdescr}
 
 \indexlibrarymember{find_last_not_of}{basic_string_view}%
@@ -5515,10 +5459,6 @@ Determines \tcode{xpos}.
 \returns
 \tcode{xpos} if the function can determine such a value for \tcode{xpos}.
 Otherwise, returns \tcode{npos}.
-
-\pnum
-\remarks
-Uses \tcode{traits::eq()}.
 \end{itemdescr}
 
 \rSec2[string.view.comparison]{Non-member comparison functions}


### PR DESCRIPTION
This removes remarks that literally repeat what was just stated, but leaves intact instances where the same remarks do _not_ repeat what was just stated, e.g. http://eel.is/c++draft/string.cons#28.

Representative diff:
![diff](http://eel.is/remark2.png)