### PR TITLE
[meta.trans.other] add missing cv for common_type

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16633,7 +16633,7 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
  the member \tcode{type} shall be defined or omitted as specified in Note A, below.
  If it is omitted, there shall be no member \tcode{type}.
  Each type in the parameter pack \tcode{T} shall be
- complete, \tcode{void}, or an array of unknown bound. \\ \rowsep
+ complete, \cv{}~\tcode{void}, or an array of unknown bound. \\ \rowsep
 
 \indexlibrary{\idxcode{underlying_type}}%
 \tcode{template <class T>}\br


### PR DESCRIPTION
P0435R1 says 'cv void', but the cv part was dropped.