### PR TITLE
Consistently italicize definitions' plural 's'.

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1734,7 +1734,7 @@ in~(\ref{dcl.init.aggr}).
 \indextext{class!union-like}%
 \indextext{class!variant member of}%
 A \defn{union-like class} is a union or a class that has an anonymous union as a direct
-member. A union-like class \tcode{X} has a set of \defn{variant member}{s}.
+member. A union-like class \tcode{X} has a set of \defnx{variant members}{variant member}.
 If \tcode{X} is a union, a non-static data member of \tcode{X} that is not an anonymous
 union is a variant member of \tcode{X}. In addition, a non-static data member of an
 anonymous union that is a member of \tcode{X} is also a variant member of \tcode{X}.

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -2101,7 +2101,7 @@ support equivalent keys.  In containers that support equivalent keys,
 elements with equivalent keys are adjacent to each other
 in the iteration order of the container. Thus, although the absolute order
 of elements in an unordered container is not specified, its elements are
-grouped into \defn{equivalent-key group}{s} such that all elements of each
+grouped into \defnx{equivalent-key groups}{equivalent-key group} such that all elements of each
 group have equivalent keys. Mutating operations on unordered containers shall
 preserve the relative order of elements within each equivalent-key group
 unless otherwise specified.

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4859,7 +4859,7 @@ Expressions that satisfy these requirements,
 assuming that copy elision is performed,
 are called 
 \indexdefn{expression!constant}%
-\defn{constant expression}{s}. \begin{note} Constant expressions can be evaluated
+\defnx{constant expressions}{constant expression}. \begin{note} Constant expressions can be evaluated
 during translation.\end{note}
 
 \begin{bnf}

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -902,7 +902,7 @@ used for the initialization of \tcode{b} are \tcode{5} and \tcode{1+1}.
 \end{example}
 
 \pnum
-The \defn{immediate subexpression}{s} of an expression \tcode{e} are
+The \defnx{immediate subexpressions}{immediate subexpression} of an expression \tcode{e} are
 \begin{itemize}
 \item
 the constituent expressions of \tcode{e}'s operands (Clause \ref{expr}),

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -102,8 +102,8 @@ iterators and can be used whenever a bidirectional iterator is specified.
 
 \pnum
 Iterators that further satisfy the requirements of output iterators are
-called \defn{mutable iterator}{s}. Nonmutable iterators are referred to
-as \defn{constant iterator}{s}.
+called \defnx{mutable iterators}{mutable iterator}. Nonmutable iterators are referred to
+as \defnx{constant iterators}{constant iterator}.
 
 \pnum
 In addition to the requirements in this sub-clause,

--- a/source/special.tex
+++ b/source/special.tex
@@ -825,7 +825,7 @@ specifies a conversion from
 \tcode{X}
 to the type specified by the
 \grammarterm{conversion-type-id}.
-Such functions are called \defn{conversion function}{s}.
+Such functions are called \defnx{conversion functions}{conversion function}.
 A \grammarterm{decl-specifier} in the \grammarterm{decl-specifier-seq}
 of a conversion function (if any) shall be neither
 a \grammarterm{defining-type-specifier} nor \tcode{static}.


### PR DESCRIPTION
Fixes #1295. 