### PR TITLE
Capitalize notes.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -669,7 +669,7 @@ constant \tcode{x}, namely 12. \end{example}
 After the point of declaration of a class member, the member name can be
 looked up in the scope of its class. \begin{note}
 \indextext{type!incomplete}%
-this is true even if the class is an incomplete class. For example,
+This is true even if the class is an incomplete class. For example,
 
 \begin{codeblock}
 struct X {
@@ -4328,7 +4328,7 @@ greater than \tcode{alignof(std::max_align_t)}. It is \impldef{support for exten
 whether any extended alignments are supported and the contexts in which they are
 supported~(\ref{dcl.align}). A type having an extended alignment
 requirement is an \grammarterm{over-aligned type}. \begin{note}
-every over-aligned type is or contains a class type
+Every over-aligned type is or contains a class type
 to which extended alignment applies (possibly through a non-static data member).
 \end{note}
 A \defn{new-extended alignment} is represented by

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -782,7 +782,7 @@ or is the declaration of a parameter or a return type (\ref{dcl.fct}); see~\ref{
 A reference shall be initialized to refer to a valid object or function.
 \begin{note}
 \indextext{reference!null}%
-in particular, a null reference cannot exist in a well-defined program,
+In particular, a null reference cannot exist in a well-defined program,
 because the only way to create such a reference would be to bind it to
 the ``object'' obtained by indirection through a null pointer,
 which causes undefined behavior.
@@ -1125,7 +1125,7 @@ void f() {
 
 \pnum
 \begin{note}
-conversions affecting expressions of array type are described in~\ref{conv.array}.
+Conversions affecting expressions of array type are described in~\ref{conv.array}.
 Objects of array types cannot be modified, see~\ref{basic.lval}.
 \end{note}
 
@@ -1348,7 +1348,7 @@ The
 determines the arguments that can be specified, and their processing, when the function is called.
 \begin{note}
 \indextext{conversion!argument}%
-the
+The
 \grammarterm{parameter-declaration-clause}
 is used to convert the arguments specified on the function call;
 see~\ref{expr.call}.

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -140,7 +140,7 @@ lvalue-to-rvalue~(\ref{conv.lval}), array-to-pointer~(\ref{conv.array}),
 or function-to-pointer~(\ref{conv.func}) standard conversions are
 applied to convert the expression to a prvalue.
 \begin{note}
-because cv-qualifiers are removed from the type of an expression of
+Because cv-qualifiers are removed from the type of an expression of
 non-class type when the expression is converted to a prvalue, an lvalue
 expression of type \tcode{const int} can, for example, be used where
 a prvalue expression of type \tcode{int} is required.
@@ -553,7 +553,7 @@ notation names the destructor~(\ref{class.dtor}).
 The form \tcode{\tilde}~\grammarterm{decltype-specifier} also denotes the destructor,
 but it shall not be used as the \grammarterm{unqualified-id} in a \grammarterm{qualified-id}.
 \begin{note}
-a \grammarterm{typedef-name} that names a class is a
+A \grammarterm{typedef-name} that names a class is a
 \grammarterm{class-name}~(\ref{class.name}).
 \end{note}
 
@@ -1625,7 +1625,7 @@ converted to the return type of the statically chosen function.
 \indextext{value!call by}%
 \indextext{reference!call by}%
 \indextext{argument!reference}%
-a function can change the values of its non-const parameters, but these
+A function can change the values of its non-const parameters, but these
 changes cannot affect the values of the arguments except where a
 parameter is of a reference type~(\ref{dcl.ref}); if the reference is to
 a const-qualified type, \tcode{const_cast} is required to be used to
@@ -1645,7 +1645,7 @@ arguments~(\ref{dcl.fct.default})) or more arguments (by using the ellipsis,
 \tcode{...}, or a function parameter pack~(\ref{dcl.fct})) than the number of
 parameters in the function definition~(\ref{dcl.fct.def}).
 \begin{note}
-this implies that, except where the ellipsis (\tcode{...}) or a function
+This implies that, except where the ellipsis (\tcode{...}) or a function
 parameter pack is used, a parameter is available for each argument.
 \end{note}
 
@@ -1897,7 +1897,7 @@ of the object expression; see~\ref{class.access.base}.
 The value of a postfix \tcode{++} expression is the value of its
 operand.
 \begin{note}
-the value obtained is a copy of the original value
+The value obtained is a copy of the original value
 \end{note}
 The operand shall be a modifiable lvalue. The type of the operand shall
 be an arithmetic type other than \cv{}~\tcode{bool},
@@ -2343,7 +2343,7 @@ contains the original member, or is a base or derived class of the class
 containing the original member, the resulting pointer to member points
 to the original member. Otherwise, the behavior is undefined.
 \begin{note}
-although class \tcode{B} need not contain the original member, the
+Although class \tcode{B} need not contain the original member, the
 dynamic type of the object with which indirection through the pointer
 to member is performed must contain the original member;
 see~\ref{expr.mptr.oper}.
@@ -3054,7 +3054,7 @@ auto x = new auto('a');         // allocated type is \tcode{char}, \tcode{x} is 
 The \grammarterm{new-type-id} in a \grammarterm{new-expression} is the longest
 possible sequence of \grammarterm{new-declarator}{s}.
 \begin{note}
-this prevents ambiguities between the declarator operators \tcode{\&}, \tcode{\&\&},
+This prevents ambiguities between the declarator operators \tcode{\&}, \tcode{\&\&},
 \tcode{*}, and \tcode{[]} and their expression counterparts.
 \end{note}
 \begin{example}
@@ -3069,7 +3069,7 @@ operator.
 \pnum
 \begin{note}
 \indextext{ambiguity!parentheses and}%
-parentheses in a \grammarterm{new-type-id} of a \grammarterm{new-expression}
+Parentheses in a \grammarterm{new-type-id} of a \grammarterm{new-expression}
 can have surprising effects.
 \begin{example}
 
@@ -3385,7 +3385,7 @@ the \grammarterm{new-expression} shall be null.
 
 \pnum
 \begin{note}
-when the allocation function returns a value other than null, it must be
+When the allocation function returns a value other than null, it must be
 a pointer to a block of storage in which space for the object has been
 reserved. The block of storage is assumed to be appropriately aligned
 and of the requested size. The address of the created object will not
@@ -3563,7 +3563,7 @@ match the type of the object allocated by \tcode{new}, not the syntax of the
 \grammarterm{new-expression}.
 \end{note}
 \begin{note}
-a pointer to a \tcode{const} type can be the operand of a
+A pointer to a \tcode{const} type can be the operand of a
 \grammarterm{delete-expression}; it is not necessary to cast away the
 constness~(\ref{expr.const.cast}) of the pointer expression before it is
 used as the operand of the \grammarterm{delete-expression}.

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -11837,7 +11837,7 @@ the forward traversal order is as follows:
 \item The \grammarterm{root-name} element, if present.
 \item The \grammarterm{root-directory} element, if present.
 \begin{note}
-the generic format is required to ensure lexicographical
+The generic format is required to ensure lexicographical
 comparison works correctly. \end{note}
 \item Each successive \grammarterm{filename} element, if present.
 \item \grammarterm{dot}, if one or more trailing non-root \grammarterm{slash}

--- a/source/special.tex
+++ b/source/special.tex
@@ -327,7 +327,7 @@ Explicit constructor calls do not yield lvalues, see~\ref{basic.lval}.
 \pnum
 \begin{note}
 \indextext{member function!constructor and}%
-some language constructs have special semantics when used during construction;
+Some language constructs have special semantics when used during construction;
 see~\ref{class.base.init} and~\ref{class.cdtor}.
 \end{note}
 
@@ -1109,7 +1109,7 @@ If a class has a base class with a virtual destructor, its  destructor
 \pnum
 \begin{note}
 \indextext{member function!destructor and}%
-some language constructs have special semantics when used during destruction;
+Some language constructs have special semantics when used during destruction;
 see~\ref{class.cdtor}.
 \end{note}
 
@@ -1571,7 +1571,7 @@ is explicitly specified (see~\ref{class.init} and~\ref{dcl.init}).
 \pnum
 \begin{note}
 \indextext{order of execution!constructor and \tcode{static} objects}%
-the order in which objects with static or thread storage duration
+The order in which objects with static or thread storage duration
 are initialized is described in~\ref{basic.start.dynamic} and~\ref{stmt.dcl}.
 \end{note}
 

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -3794,7 +3794,7 @@ template <class T1, class T2, int I> struct B {
 A \term{dependent base class} is a base class that is a dependent type and is
 not the current instantiation.
 \begin{note}
-a base class can be the current instantiation in the case of a nested class
+A base class can be the current instantiation in the case of a nested class
 naming an enclosing class as a base.
 \begin{example}
 \begin{codeblock}


### PR DESCRIPTION
For consistency. This only modifies non-mid-sentence notes.

Addresses #293.