### PR TITLE
[class.virtual] Adjust whitespace to fix vertical alignment in code example.

### DIFF
--- a/source/derived.tex
+++ b/source/derived.tex
@@ -755,8 +755,8 @@ struct Derived : public Base {
     void vf1();     // virtual and overrides \tcode{Base::vf1()}
     void vf2(int);  // not virtual, hides \tcode{Base::vf2()}
     char vf3();     // error: invalid difference in return type only
-    D*  vf4();      // OK: returns pointer to derived class
-    A*  vf5();      // error: returns pointer to incomplete class
+    D*   vf4();     // OK: returns pointer to derived class
+    A*   vf5();     // error: returns pointer to incomplete class
     void f();
 };
 


### PR DESCRIPTION
(Note the proper alignment in the member declarations for class Base, earlier in the same example.)