### PR TITLE
[expr] Split off definition of 'composite pointer type' into dedicated paragraph.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -268,6 +268,8 @@ $cv^1_i$ or $cv^2_i$, then
 \begin{note} Given similar types \tcode{T1} and \tcode{T2}, this
 construction ensures that
 both can be converted to \tcode{T3}. \end{note}
+
+\pnum
 \indextext{pointer!composite pointer type}%
 The \defn{composite pointer type} of
 two operands \tcode{p1} and


### PR DESCRIPTION
This splits up a long paragraph that defines two complex terms ("cv-combined type" and "composite pointer type") using itemized lists. It reads and looks so much better to me this way that I suspect the \pnum was accidentally lost at some point.

![diff](http://eel.is/parasplit2.png)