### PR TITLE
[limits] Use normal font in "try block"

### DIFF
--- a/source/limits.tex
+++ b/source/limits.tex
@@ -126,9 +126,7 @@ Template arguments in a template declaration [1\,024].
 Recursively nested template instantiations, including substitution
 during template argument deduction~(\ref{temp.deduct}) [1\,024].
 \item%
-Handlers per
-\tcode{try}
-block [256].
+Handlers per try block [256].
 \item%
 Number of placeholders~(\ref{func.bind.place}) [10].
 


### PR DESCRIPTION
This is the only place where "try block" uses code font for the first word.