### PR TITLE
[class.virtual] Add index entry for covariant return types.

### DIFF
--- a/source/derived.tex
+++ b/source/derived.tex
@@ -703,7 +703,7 @@ see~\ref{class.dtor} and~\ref{class.free}.
 
 \pnum
 The return type of an overriding function shall be either identical to
-the return type of the overridden function or \term{covariant} with
+the return type of the overridden function or \defnx{covariant}{return type!covariant} with
 the classes of the functions. If a function \tcode{D::f} overrides a
 function \tcode{B::f}, the return types of the functions are covariant
 if they satisfy the following criteria:


### PR DESCRIPTION
Currently there is no index entry for covariant return types. Diff:

![diff](http://eel.is/covar.png)