### PR TITLE
Harmonize formatting of 'main' function.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2427,11 +2427,11 @@ identity does not require a diagnostic.
 
 \rSec1[basic.start]{Start and termination}
 
-\rSec2[basic.start.main]{Main function}
+\rSec2[basic.start.main]{\tcode{main} function}
+\indextext{\idxcode{main} function|(}
 
 \pnum
 \indextext{program!start|(}%
-\indextext{\idxcode{main()}}%
 A program shall contain a global function called \tcode{main}, which is the designated
 start of the program. It is \impldef{defining \tcode{main} in freestanding environment}
 whether a program in a freestanding environment is required to define a \tcode{main}
@@ -2446,7 +2446,7 @@ An implementation shall not predefine the \tcode{main} function. This
 function shall not be overloaded.  Its type shall have \Cpp language linkage
 and it shall have a declared return type of type
 \tcode{int}, but otherwise its type is \impldef{parameters to \tcode{main}}.
-\indextext{\idxcode{main()}!implementation-defined parameters to}%
+\indextext{\idxcode{main} function!implementation-defined parameters to}%
 An implementation shall allow both
 \begin{itemize}
 \item a function of \tcode{()} returning \tcode{int} and
@@ -2456,7 +2456,7 @@ An implementation shall allow both
 \indextext{\idxcode{argc}}%
 \indextext{\idxcode{argv}}%
 as the type of \tcode{main}~(\ref{dcl.fct}).
-\indextext{\idxcode{main()}!parameters to}%
+\indextext{\idxcode{main} function!parameters to}%
 \indextext{environment!program}%
 In the latter form, for purposes of exposition, the first function
 parameter is called \tcode{argc} and the second function parameter is
@@ -2476,7 +2476,7 @@ is recommended that any further (optional) parameters be added after
 \pnum
 The function \tcode{main} shall not be used within
 a program.
-\indextext{\idxcode{main()}!implementation-defined linkage of}%
+\indextext{\idxcode{main} function!implementation-defined linkage of}%
 The linkage~(\ref{basic.link}) of \tcode{main} is
 \impldef{linkage of \tcode{main}}. A program that defines \tcode{main} as
 deleted or that declares \tcode{main} to be
@@ -2504,7 +2504,7 @@ behavior.
 
 \pnum
 \indextext{termination!program}%
-\indextext{\idxcode{main()}!return from}%
+\indextext{\idxcode{main} function!return from}%
 A return statement in \tcode{main} has the effect of leaving the main
 function (destroying any objects with automatic storage duration) and
 calling \tcode{std::exit} with the return value as the argument.
@@ -2512,6 +2512,7 @@ If control flows off the end of
 the \grammarterm{compound-statement} of \tcode{main},
 the effect is equivalent to a \tcode{return} with operand \tcode{0}
 (see also \ref{except.handle}).
+\indextext{\idxcode{main} function|)}
 
 \rSec2[basic.start.static]{Static initialization}
 
@@ -2720,7 +2721,7 @@ an exception, \tcode{std::terminate} is called~(\ref{except.terminate}).%
 \pnum
 \indextext{program!termination|(}%
 \indextext{object!destructor static}%
-\indextext{\idxcode{main()}!return from}%
+\indextext{\idxcode{main} function!return from}%
 Destructors~(\ref{class.dtor}) for initialized objects
 (that is, objects whose lifetime~(\ref{basic.life}) has begun)
 with static storage duration

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -162,10 +162,10 @@ Semantic transformation.
 \howwide
 Seldom.
 
-\ref{basic.start}
+\ref{basic.start.main}
 \change The \tcode{main} function cannot be called recursively and cannot have its address taken.
 \rationale
-The  main  function may require special actions.
+The \tcode{main} function may require special actions.
 \effect
 Deletion of semantically well-defined feature.
 \difficulty

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -631,7 +631,8 @@ Exceptions thrown in destructors of objects with static storage duration or in
 constructors of namespace-scope objects with static storage duration are not caught by a
 \grammarterm{function-try-block}
 on
-\tcode{main()}. Exceptions thrown in destructors of objects with thread storage duration or in constructors of namespace-scope objects with thread storage duration are not caught by a
+the \tcode{main} function~(\ref{basic.start.main}).
+Exceptions thrown in destructors of objects with thread storage duration or in constructors of namespace-scope objects with thread storage duration are not caught by a
 \grammarterm{function-try-block}
 on the initial function of the thread.
 

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -410,7 +410,7 @@ these objects.
 The objects are constructed and the associations are established at some
 time prior to or during the first time an object of class
 \tcode{ios_base::Init} is constructed, and in any case before the body
-of \tcode{main} begins execution.\footnote{If it is possible for them to do so, implementations are encouraged to
+of \tcode{main}~(\ref{basic.start.main}) begins execution.\footnote{If it is possible for them to do so, implementations are encouraged to
 initialize the objects earlier than required.}
 The objects are not destroyed during program execution.\footnote{Constructors and destructors for static objects can
 access these objects to read input from

--- a/source/support.tex
+++ b/source/support.tex
@@ -1502,14 +1502,13 @@ are called.\footnote{A function is called for every time it is registered.}
 See~\ref{basic.start.term} for the order of destructions and calls.
 (Automatic objects are not destroyed as a result of calling
 \tcode{exit()}.)\footnote{Objects with automatic storage duration are all destroyed in a program whose
-function
-\tcode{main()}
+\tcode{main} function~(\ref{basic.start.main})
 contains no automatic objects and executes the call to
 \tcode{exit()}.
 Control can be transferred directly to such a
-\tcode{main()}
+\tcode{main} function
 by throwing an exception that is caught in
-\tcode{main()}.}
+\tcode{main}.}
 
 If control leaves a registered function called by \tcode{exit} because the function does
 not provide a handler for a thrown exception, \tcode{std::terminate()} shall be called~(\ref{except.terminate}).%


### PR DESCRIPTION
Consistently use \tcode{main}.
Add cross-references to [basic.start.main].

Fixes #1304.