### PR TITLE
[expr.unary.noexcept] Use \grammarterm{expression}, not \tcode.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3739,7 +3739,7 @@ and is a prvalue.
 
 \pnum
 The result of the \tcode{noexcept} operator is \tcode{true}
-unless the \tcode{expression} is potentially-throwing~(\ref{except.spec}).
+unless the \grammarterm{expression} is potentially-throwing~(\ref{except.spec}).
 \indextext{expression!unary|)}
 
 \rSec1[expr.cast]{Explicit type conversion (cast notation)}%


### PR DESCRIPTION
Fixes #1311.