### PR TITLE
[util.smartptr.enab] Remove leftover postcondition after P0033R1.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -10568,8 +10568,6 @@ shared_ptr<T const> shared_from_this() const;
 
 \begin{itemdescr}
 \pnum\returns  \tcode{shared_ptr<T>(weak_this)}.
-
-\pnum\postconditions  \tcode{r.get() == this}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{weak_ptr}}%


### PR DESCRIPTION
Fixes #1299.