### PR TITLE
[dcl.meaning] Consistently use \placeholder{derived-declarator-type-l…

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -532,11 +532,11 @@ has the form
 and the type of the identifier in the declaration
 \tcode{T}
 \tcode{D1}
-is ``\nonterminal{derived-declarator-type-list}
+is ``\placeholder{derived-declarator-type-list}
 \tcode{T}'',
 then the type of the identifier of
 \tcode{D}
-is ``\nonterminal{derived-declarator-type-list cv-qualifier-seq} pointer to
+is ``\placeholder{derived-declarator-type-list} \grammarterm{cv-qualifier-seq} pointer to
 \tcode{T}''.
 \indextext{declaration!pointer}%
 \indextext{declaration!constant pointer}%
@@ -647,11 +647,11 @@ has either of the forms
 and the type of the identifier in the declaration
 \tcode{T}
 \tcode{D1}
-is ``\nonterminal{derived-declarator-type-list}
+is ``\placeholder{derived-declarator-type-list}
 \tcode{T}'',
 then the type of the identifier of
 \tcode{D}
-is ``\nonterminal{derived-declarator-type-list} reference to
+is ``\placeholder{derived-declarator-type-list} reference to
 \tcode{T}''.
 The optional \grammarterm{attribute-specifier-seq} appertains to the reference type.
 Cv-qualified references are ill-formed except when the cv-qualifiers
@@ -844,11 +844,11 @@ denotes a class,
 and the type of the identifier in the declaration
 \tcode{T}
 \tcode{D1}
-is ``\nonterminal{derived-declarator-type-list}
+is ``\placeholder{derived-declarator-type-list}
 \tcode{T}'',
 then the type of the identifier of
 \tcode{D}
-is ``\nonterminal{derived-declarator-type-list cv-qualifier-seq} pointer to member of class
+is ``\placeholder{derived-declarator-type-list} \grammarterm{cv-qualifier-seq} pointer to member of class
 \nonterminal{nested-name-specifier} of type
 \tcode{T}''.
 The optional \grammarterm{attribute-specifier-seq}~(\ref{dcl.attr.grammar}) appertains to the 
@@ -951,7 +951,7 @@ and the type of the identifier in the declaration
 \tcode{T}
 \tcode{D1}
 is
-``\grammarterm{derived-declarator-type-list}
+``\placeholder{derived-declarator-type-list}
 \tcode{T}'',
 then the type of the identifier of
 \tcode{D}
@@ -984,7 +984,7 @@ to
 \tcode{N-1},
 and the type of the identifier of
 \tcode{D}
-is ``\nonterminal{derived-declarator-type-list} array of
+is ``\placeholder{derived-declarator-type-list} array of
 \tcode{N}
 \tcode{T}''.
 An object of array type contains a contiguously allocated non-empty set of
@@ -994,14 +994,14 @@ subobjects of type
 Except as noted below, if
 the constant expression is omitted, the type of the identifier of
 \tcode{D}
-is ``\nonterminal{derived-declarator-type-list} array of unknown bound of
+is ``\placeholder{derived-declarator-type-list} array of unknown bound of
 \tcode{T}'',
 an incomplete object type.
-The type ``\nonterminal{derived-declarator-type-list} array of
+The type ``\placeholder{derived-declarator-type-list} array of
 \tcode{N}
 \tcode{T}''
 is a different type from the type
-``\nonterminal{derived-declarator-type-list} array of unknown bound of
+``\placeholder{derived-declarator-type-list} array of unknown bound of
 \tcode{T}'',
 see~\ref{basic.types}.
 Any type of the form
@@ -1255,14 +1255,14 @@ in the declaration
 \tcode{T}
 \tcode{D1}
 is
-``\grammarterm{derived-declarator-type-list}
+``\placeholder{derived-declarator-type-list}
 \tcode{T}'',
 the type of the
 \grammarterm{declarator-id}
 in
 \tcode{D}
 is
-``\grammarterm{derived-declarator-type-list}
+``\placeholder{derived-declarator-type-list}
 \tcode{noexcept}\opt
 function of
 (\grammarterm{parameter-declaration-clause} )
@@ -1293,14 +1293,14 @@ in the declaration
 \tcode{T}
 \tcode{D1}
 is
-``\grammarterm{derived-declarator-type-list} \tcode{T}'',
+``\placeholder{derived-declarator-type-list} \tcode{T}'',
 \tcode{T} shall be the single \grammarterm{type-specifier} \tcode{auto}.
 The type of the
 \grammarterm{declarator-id}
 in
 \tcode{D}
 is
-``\grammarterm{derived-declarator-type-list}
+``\placeholder{derived-declarator-type-list}
 \tcode{noexcept}\opt
 function of
 (\grammarterm{parameter-declaration-clause})


### PR DESCRIPTION
…ist}.

Fixes #1310.