### PR TITLE
Replace \nonterminal with \grammarterm or \cvqual, as appropriate.

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -609,7 +609,7 @@ exception specification of that constructor.
 
 \pnum
 A member shall not be declared with the \tcode{extern}
-\nonterminal{storage-class-specifier}. Within a class definition, a member shall not be declared with the \tcode{thread_local} \nonterminal{storage-class-specifier} unless also declared \tcode{static}.
+\grammarterm{storage-class-specifier}. Within a class definition, a member shall not be declared with the \tcode{thread_local} \grammarterm{storage-class-specifier} unless also declared \tcode{static}.
 
 \pnum
 The \grammarterm{decl-specifier-seq} may be omitted in constructor, destructor,

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -401,9 +401,9 @@ For the linkage of a name declared with an \tcode{extern} specifier,
 see~\ref{basic.link}.
 \begin{note}
 The \tcode{extern} keyword can also be used in
-\nonterminal{explicit-instantiation}s and
-\nonterminal{linkage-specification}s, but it is not a
-\nonterminal{storage-class-specifier} in such contexts.
+\grammarterm{explicit-instantiation}s and
+\grammarterm{linkage-specification}s, but it is not a
+\grammarterm{storage-class-specifier} in such contexts.
 \end{note}
 
 \pnum
@@ -1589,7 +1589,7 @@ The type of a variable declared using \tcode{auto} or \tcode{decltype(auto)} is
 deduced from its initializer. This use is allowed when declaring variables in a
 block~(\ref{stmt.block}), in
 namespace scope~(\ref{basic.scope.namespace}), and in an
-\nonterminal{init-statement} (Clause~\ref{stmt.stmt}).
+\grammarterm{init-statement} (Clause~\ref{stmt.stmt}).
 \tcode{auto} or \tcode{decltype(auto)} shall appear as one of the
 \grammarterm{decl-specifier}{s} in the
 \grammarterm{decl-specifier-seq} and the
@@ -1618,14 +1618,14 @@ auto h();                       // OK: \tcode{h}'s return type will be deduced w
 
 \pnum
 A placeholder type can also be used in declaring a variable in
-the \nonterminal{condition} of a selection statement~(\ref{stmt.select}) or an iteration
-statement~(\ref{stmt.iter}), in the \nonterminal{type-specifier-seq} in 
-the \nonterminal{new-type-id} or \nonterminal{type-id} of a
-\nonterminal{new-expression}~(\ref{expr.new}), in a
+the \grammarterm{condition} of a selection statement~(\ref{stmt.select}) or an iteration
+statement~(\ref{stmt.iter}), in the \grammarterm{type-specifier-seq} in 
+the \grammarterm{new-type-id} or \grammarterm{type-id} of a
+\grammarterm{new-expression}~(\ref{expr.new}), in a
 \grammarterm{for-range-declaration},
 in declaring a static data member with a
 \grammarterm{brace-or-equal-initializer} that appears within the
-\nonterminal{member-specification} of a class definition~(\ref{class.static.data}),
+\grammarterm{member-specification} of a class definition~(\ref{class.static.data}),
 and as a \grammarterm{decl-specifier}
 of the \grammarterm{parameter-declaration}{'s}
 \grammarterm{decl-specifier-seq}

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -956,7 +956,7 @@ is
 then the type of the identifier of
 \tcode{D}
 is an array type; if the type of the identifier of \tcode{D}
-contains the \tcode{auto} \nonterminal{type-specifier},
+contains the \tcode{auto} \grammarterm{type-specifier},
 the program is ill-formed.
 \tcode{T}
 is called the array
@@ -1005,13 +1005,13 @@ is a different type from the type
 \tcode{T}'',
 see~\ref{basic.types}.
 Any type of the form
-``\nonterminal{cv-qualifier-seq} array of
+``\grammarterm{cv-qualifier-seq} array of
 \tcode{N}
 \tcode{T}''
 is adjusted to
 ``array of
 \tcode{N}
-\nonterminal{cv-qualifier-seq}
+\grammarterm{cv-qualifier-seq}
 \tcode{T}'',
 and similarly for
 ``array of unknown bound of
@@ -1029,7 +1029,7 @@ typedef const AA CAA;           // type is ``array of 2 array of 3 \tcode{const 
 An
 ``array of
 \tcode{N}
-\nonterminal{cv-qualifier-seq}
+\grammarterm{cv-qualifier-seq}
 \tcode{T}''
 has cv-qualified type; see~\ref{basic.type.qualifier}.
 \end{note}
@@ -2858,13 +2858,13 @@ resulting value of the bit-field is
 \indextext{initialization!\idxcode{const}}%
 \begin{note}
 An expression of type
-``\nonterminal{cv1} \tcode{T}''
+``\cvqual{cv1} \tcode{T}''
 can initialize an object of type
-``\nonterminal{cv2} \tcode{T}''
+``\cvqual{cv2} \tcode{T}''
 independently of
 the cv-qualifiers
-\nonterminal{cv1}
-and \nonterminal{cv2}.
+\cvqual{cv1}
+and \cvqual{cv2}.
 
 \begin{codeblock}
 int a;
@@ -3455,15 +3455,13 @@ extern int& r2;                 // OK
 \end{example}
 
 \pnum
-Given types ``\nonterminal{cv1} \tcode{T1}'' and ``\nonterminal{cv2} \tcode{T2}'',
-``\nonterminal{cv1} \tcode{T1}'' is \nonterminal{reference-related} to
-\indextext{reference-related}%
-``\nonterminal{cv2} \tcode{T2}'' if
+Given types ``\cvqual{cv1} \tcode{T1}'' and ``\cvqual{cv2} \tcode{T2}'',
+``\cvqual{cv1} \tcode{T1}'' is \defn{reference-related} to
+``\cvqual{cv2} \tcode{T2}'' if
 \tcode{T1} is the same type as \tcode{T2}, or
 \tcode{T1} is a base class of \tcode{T2}.
-``\nonterminal{cv1} \tcode{T1}'' is \nonterminal{reference-compatible}
-\indextext{reference-compatible}%
-with ``\nonterminal{cv2} \tcode{T2}'' if
+``\cvqual{cv1} \tcode{T1}'' is \defn{reference-compatible}
+with ``\cvqual{cv2} \tcode{T2}'' if
 \begin{itemize}
 \item \tcode{T1} is reference-related to \tcode{T2}, or
 \item \tcode{T2} is ``\tcode{noexcept} function'' and \tcode{T1} is ``function'',
@@ -3497,15 +3495,15 @@ If the reference is an lvalue reference and the initializer expression
 \item
 is an lvalue (but is not a
 bit-field), and
-``\nonterminal{cv1} \tcode{T1}'' is reference-compatible with
-``\nonterminal{cv2} \tcode{T2}'', or
+``\cvqual{cv1} \tcode{T1}'' is reference-compatible with
+``\cvqual{cv2} \tcode{T2}'', or
 \item
 has a class type (i.e.,
 \tcode{T2}
 is a class type), where \tcode{T1} is not reference-related to \tcode{T2}, and can be converted
-to an lvalue of type ``\nonterminal{cv3} \tcode{T3}'', where
-``\nonterminal{cv1} \tcode{T1}'' is reference-compatible with
-``\nonterminal{cv3} \tcode{T3}''\footnote{This requires a conversion
+to an lvalue of type ``\cvqual{cv3} \tcode{T3}'', where
+``\cvqual{cv1} \tcode{T1}'' is reference-compatible with
+``\cvqual{cv3} \tcode{T3}''\footnote{This requires a conversion
 function~(\ref{class.conv.fct}) returning a reference type.}
 (this conversion is selected by enumerating the applicable conversion
 functions (\ref{over.match.ref}) and choosing the best one through overload
@@ -3605,7 +3603,7 @@ If \tcode{T1} or \tcode{T2} is a class type and
 \tcode{T1} is not reference-related to \tcode{T2},
 user-defined conversions are considered
 using the rules for copy-initialization of an object of type 
-``\nonterminal{cv1} \tcode{T1}'' by
+``\cvqual{cv1} \tcode{T1}'' by
 user-defined conversion
 (\ref{dcl.init}, \ref{over.match.copy}, \ref{over.match.conv});
 the program is ill-formed if the corresponding non-reference
@@ -3616,7 +3614,7 @@ For this direct-initialization, user-defined conversions are not considered.
 \item
 Otherwise,
 the initializer expression is implicitly converted to a prvalue
-of type ``\nonterminal{cv1} \tcode{T1}''.
+of type ``\cvqual{cv1} \tcode{T1}''.
 The temporary materialization conversion is applied and the reference is
 bound to the result.
 \end{itemize}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1424,7 +1424,7 @@ Postfix expressions group left-to-right.
 
 \pnum
 \begin{note} The \tcode{>} token following the
-\nonterminal{type-id} in a \tcode{dynamic_cast},
+\grammarterm{type-id} in a \tcode{dynamic_cast},
 \tcode{static_cast}, \tcode{reinterpret_cast}, or
 \tcode{const_cast} may be the product of replacing a
 \tcode{>{>}} token by two consecutive \tcode{>}
@@ -3023,19 +3023,19 @@ the array.
 
 \pnum
 If a placeholder type~(\ref{dcl.spec.auto}) appears in the
-\nonterminal{type-specifier-seq} of a \nonterminal{new-type-id} or
-\nonterminal{type-id} of a \nonterminal{new-expression},
-the \nonterminal{new-expression} shall contain a
-\nonterminal{new-initializer} of the form
+\grammarterm{type-specifier-seq} of a \grammarterm{new-type-id} or
+\grammarterm{type-id} of a \grammarterm{new-expression},
+the \grammarterm{new-expression} shall contain a
+\grammarterm{new-initializer} of the form
 
 \begin{ncsimplebnf}
 \terminal{(} assignment-expression \terminal{)}
 \end{ncsimplebnf}
 
-The allocated type is deduced from the \nonterminal{new-initializer} as
-follows: Let \tcode{e} be the \grammarterm{assignment-expression} in the \nonterminal{new-initializer} and
-\tcode{T} be the \nonterminal{new-type-id} or \nonterminal{type-id} of
-the \nonterminal{new-expression}, then the allocated type is the type
+The allocated type is deduced from the \grammarterm{new-initializer} as
+follows: Let \tcode{e} be the \grammarterm{assignment-expression} in the \grammarterm{new-initializer} and
+\tcode{T} be the \grammarterm{new-type-id} or \grammarterm{type-id} of
+the \grammarterm{new-expression}, then the allocated type is the type
 deduced for the variable \tcode{x} in the invented
 declaration~(\ref{dcl.spec.auto}):
 

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -1329,8 +1329,8 @@ Those non-explicit conversion functions that are not hidden within
 \tcode{S}
 and yield type ``lvalue reference to \cvqual{cv2} \tcode{T2}''
 (when initializing an lvalue reference or an rvalue reference to function) or
-``\nonterminal{cv2} \tcode{T2}''
-or ``rvalue reference to \nonterminal{cv2} \tcode{T2}'' (when initializing an
+``\cvqual{cv2} \tcode{T2}''
+or ``rvalue reference to \cvqual{cv2} \tcode{T2}'' (when initializing an
 rvalue reference or an lvalue reference to function),
 where ``\cvqual{cv1} \tcode{T}'' is reference-compatible~(\ref{dcl.init.ref})
 with ``\cvqual{cv2} \tcode{T2}'',

--- a/source/special.tex
+++ b/source/special.tex
@@ -1683,10 +1683,10 @@ is ill-formed.
 A \grammarterm{mem-initializer-list} can delegate to another
 constructor of the constructor's class using any
 \grammarterm{class-or-decltype} that denotes the constructor's class itself. If a
-\nonterminal{mem-initializer-id} designates the constructor's class,
-it shall be the only \nonterminal{mem-initializer}; the constructor
+\grammarterm{mem-initializer-id} designates the constructor's class,
+it shall be the only \grammarterm{mem-initializer}; the constructor
 is a \term{delegating constructor}, and the constructor selected by the
-\nonterminal{mem-initializer} is the \term{target constructor}.
+\grammarterm{mem-initializer} is the \term{target constructor}.
 The target constructor is selected by overload resolution.
 Once the target constructor returns, the body of the delegating constructor
 is executed. If a constructor delegates to itself directly or indirectly,
@@ -3120,7 +3120,7 @@ the function return type, the copy/move operation can be
 omitted by constructing the automatic object directly
 into the function call's return object
 
-\item in a \nonterminal{throw-expression}~(\ref{expr.throw}), when the operand
+\item in a \grammarterm{throw-expression}~(\ref{expr.throw}), when the operand
 is the name of a non-volatile automatic object
 (other than a function or catch-clause parameter)
 whose scope does not extend beyond the end of the innermost enclosing
@@ -3128,14 +3128,14 @@ whose scope does not extend beyond the end of the innermost enclosing
 operand to the exception object~(\ref{except.throw}) can be omitted by
 constructing the automatic object directly into the exception object
 
-\item when the \nonterminal{exception-declaration} of an
+\item when the \grammarterm{exception-declaration} of an
 exception handler (Clause~\ref{except}) declares an object of the same
 type (except for cv-qualification) as the exception
 object~(\ref{except.throw}), the copy operation can be omitted by treating
-the \nonterminal{exception-declaration} as an alias for the exception
+the \grammarterm{exception-declaration} as an alias for the exception
 object if the meaning of the program will be unchanged except for the execution
 of constructors and destructors for the object declared by the
-\nonterminal{exception-declaration}.
+\grammarterm{exception-declaration}.
 \begin{note} There cannot be a move from the exception object because it is
 always an lvalue.  \end{note}
 \end{itemize}

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -37,8 +37,8 @@ The rules for \grammarterm{condition}{s} apply both to
 \grammarterm{selection-statement}{s} and to the \tcode{for} and \tcode{while}
 statements~(\ref{stmt.iter}). The \grammarterm{declarator} shall not
 specify a function or an array. The \grammarterm{decl-specifier-seq} shall not
-define a class or enumeration. If the \tcode{auto} \nonterminal{type-specifier} appears in
-the \nonterminal{decl-specifier-seq},
+define a class or enumeration. If the \tcode{auto} \grammarterm{type-specifier} appears in
+the \grammarterm{decl-specifier-seq},
 the type of the identifier being declared is deduced from the initializer as described in~\ref{dcl.spec.auto}.
 
 \pnum

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -25,8 +25,8 @@ family of types.
 \end{bnf}
 
 \begin{note} The \tcode{>} token following the
-\nonterminal{template-parameter-list} of a
-\nonterminal{template-declaration}
+\grammarterm{template-parameter-list} of a
+\grammarterm{template-declaration}
 may be the product of replacing a
 \tcode{>{>}} token by two consecutive \tcode{>}
 tokens~(\ref{temp.names}).\end{note}
@@ -193,8 +193,8 @@ is:
 \end{bnf}
 
 \begin{note} The \tcode{>} token following the
-\nonterminal{template-parameter-list} of a
-\nonterminal{type-parameter}
+\grammarterm{template-parameter-list} of a
+\grammarterm{type-parameter}
 may be the product of replacing a
 \tcode{>{>}} token by two consecutive \tcode{>}
 tokens~(\ref{temp.names}).\end{note}
@@ -624,10 +624,10 @@ is taken as the ending delimiter
 rather than a greater-than operator.
 Similarly, the first non-nested \tcode{>{>}} is treated as two
 consecutive but distinct \tcode{>} tokens, the first of which is taken
-as the end of the \nonterminal{template-argument-list} and completes
-the \nonterminal{template-id}. \begin{note} The second \tcode{>}
+as the end of the \grammarterm{template-argument-list} and completes
+the \grammarterm{template-id}. \begin{note} The second \tcode{>}
 token produced by this replacement rule may terminate an enclosing
-\nonterminal{template-id} construct or it may be part of a different
+\grammarterm{template-id} construct or it may be part of a different
 construct (e.g. a cast).\end{note}
 \begin{example}
 
@@ -3037,13 +3037,13 @@ template<class T> class Y {
 \end{example}
 
 \pnum
-When a \nonterminal{qualified-id} is intended to refer to a type
+When a \grammarterm{qualified-id} is intended to refer to a type
 that is not a member of the current instantiation~(\ref{temp.dep.type})
-and its \nonterminal{nested-name-specifier}
+and its \grammarterm{nested-name-specifier}
 refers to a dependent type,
 it shall be
 prefixed by the keyword \tcode{typename}, forming a
-\nonterminal{typename-specifier}.
+\grammarterm{typename-specifier}.
 If the \grammarterm{qualified-id} in a \grammarterm{typename-specifier}
 does not denote a type
 or a class template,


### PR DESCRIPTION
Fixes #1312.