### PR TITLE
[sf.cmath] Fix 'where' associations of Greek variable names.

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -10684,7 +10684,7 @@ of their respective arguments
 \]
 where
 $k$ is \tcode{k} and
-$nu$ is \tcode{nu}.
+$\nu$ is \tcode{nu}.
 
 \pnum See also \ref{sf.cmath.ellint_3}.
 \end{itemdescr}
@@ -10719,7 +10719,7 @@ of their respective arguments
 	   \quad \mbox{for $x \ge 0$}
 \]
 where
-$nu$ is \tcode{nu} and
+$\nu$ is \tcode{nu} and
 $x$ is \tcode{x}.
 
 \pnum\remarks
@@ -10758,7 +10758,7 @@ of their respective arguments
 	   \quad \mbox{for $x \ge 0$}
 \]
 where
-$nu$ is \tcode{nu} and
+$\nu$ is \tcode{nu} and
 $x$ is \tcode{x}.
 
 \pnum\remarks
@@ -10812,7 +10812,7 @@ of their respective arguments
   \right.
 \]
 where
-$nu$ is \tcode{nu} and
+$\nu$ is \tcode{nu} and
 $x$ is \tcode{x}.
 
 \pnum\remarks
@@ -10863,7 +10863,7 @@ of their respective arguments
   \right.
 \]
 where
-$nu$ is \tcode{nu} and
+$\nu$ is \tcode{nu} and
 $x$ is \tcode{x}.
 
 \pnum\remarks
@@ -10903,7 +10903,7 @@ of their respective arguments
 \]
 where
 $k$ is \tcode{k} and
-$phi$ is \tcode{phi}.
+$\phi$ is \tcode{phi}.
 \end{itemdescr}
 
 \rSec3[sf.cmath.ellint_2]{Incomplete elliptic integral of the second kind}%
@@ -10934,7 +10934,7 @@ of their respective arguments
 \]
 where
 $k$ is \tcode{k} and
-$phi$ is \tcode{phi}.
+$\phi$ is \tcode{phi}.
 \end{itemdescr}
 
 \rSec3[sf.cmath.ellint_3]{Incomplete elliptic integral of the third kind}%
@@ -10965,9 +10965,9 @@ of their respective arguments
 	   \quad \mbox{for $|k| \le 1$}
 \]
 where
-$nu$ is \tcode{nu},
+$\nu$ is \tcode{nu},
 $k$ is \tcode{k}, and
-$phi$ is \tcode{phi}.
+$\phi$ is \tcode{phi}.
 \end{itemdescr}
 
 \rSec3[sf.cmath.expint]{Exponential integral}%
@@ -11232,7 +11232,7 @@ where
 and
 $l$ is \tcode{l},
 $m$ is \tcode{m}, and
-$theta$ is \tcode{theta}.
+$\theta$ is \tcode{theta}.
 
 \pnum\remarks
 The effect of calling each of these functions


### PR DESCRIPTION
Fixes #1291.