### PR TITLE
[conv.lval] Split off description of conversion result into dedicated paragraph.

### DIFF
--- a/source/conversions.tex
+++ b/source/conversions.tex
@@ -157,6 +157,8 @@ int m = g(false);   // undefined behavior due to access of \tcode{x.n} outside i
 int n = g(true);    // OK, does not access \tcode{y.n}
 \end{codeblock}
 \end{example}
+
+\pnum
 The result of the conversion is determined according to the
 following rules:
 


### PR DESCRIPTION
This is a long paragraph that describes two things:

- the conditions under which the conversion does not access the referenced object's value;
- the rules for determining the result of the conversion.

Doing this in two paragraphs seems clearer to me:

![diff](http://eel.is/ps.png)
