### PR TITLE
[basic] Remove stray whitespace after \tcode{...}

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1214,11 +1214,11 @@ of \tcode{X}~(\ref{class.member.lookup}), or
 \item if \tcode{X} is a nested class of class
 \tcode{Y}~(\ref{class.nest}), before the definition of \tcode{X} in
 \tcode{Y}, or shall be a member of a base class of \tcode{Y} (this
-lookup applies in turn to \tcode{Y} 's enclosing classes, starting with
+lookup applies in turn to \tcode{Y}'s enclosing classes, starting with
 the innermost enclosing class),\footnote{This lookup applies whether the
 definition of \tcode{X} is
 nested within \tcode{Y}'s definition or whether \tcode{X}'s definition
-appears in a namespace scope enclosing \tcode{Y} 's
+appears in a namespace scope enclosing \tcode{Y}'s
 definition~(\ref{class.nest}).}
 or
 \item if \tcode{X} is a local class~(\ref{class.local}) or is a nested
@@ -1228,7 +1228,7 @@ block enclosing the definition of class \tcode{X}, or
 class of a class that is a member of \tcode{N}, or is a local class or a
 nested class within a local class of a function that is a member of
 \tcode{N}, before the definition of class \tcode{X} in namespace
-\tcode{N} or in one of \tcode{N} 's enclosing namespaces.
+\tcode{N} or in one of \tcode{N}'s enclosing namespaces.
 \end{itemize}
 \begin{example}
 \begin{codeblock}
@@ -1304,7 +1304,7 @@ block enclosing the definition of class \tcode{X}, or
 class of a class that is a member of \tcode{N}, or is a local class or a
 nested class within a local class of a function that is a member of
 \tcode{N}, before the use of the name, in namespace \tcode{N}
-or in one of \tcode{N} 's enclosing namespaces.
+or in one of \tcode{N}'s enclosing namespaces.
 \end{itemize}
 \begin{example}
 \begin{codeblock}
@@ -3955,7 +3955,7 @@ an object type. \end{note} The type of a pointer that can designate a function
 is called a \defn{function pointer type}.
 A pointer to objects of type \tcode{T} is referred to as a ``pointer to
 \tcode{T}''. \begin{example} A pointer to an object of type \tcode{int} is
-referred to as ``pointer to \tcode{int} '' and a pointer to an object of
+referred to as ``pointer to \tcode{int}'' and a pointer to an object of
 class \tcode{X} is called a ``pointer to \tcode{X}''. \end{example}
 Except for pointers to static members, text referring to ``pointers''
 does not apply to pointers to members. Pointers to incomplete types are


### PR DESCRIPTION
(The whitespace is visible in the PDF.)