### PR TITLE
[stmt.stmt] Remove stray {} after \grammarterm.

### DIFF
--- a/source/statements.tex
+++ b/source/statements.tex
@@ -33,9 +33,9 @@ The optional \grammarterm{attribute-specifier-seq} appertains to the respective 
 
 \pnum
 \indextext{\idxgram{condition}{s}!rules for}%
-The rules for \grammarterm{}{condition}{s} apply both to
+The rules for \grammarterm{condition}{s} apply both to
 \grammarterm{selection-statement}{s} and to the \tcode{for} and \tcode{while}
-statements~(\ref{stmt.iter}). The \grammarterm{}{declarator} shall not
+statements~(\ref{stmt.iter}). The \grammarterm{declarator} shall not
 specify a function or an array. The \grammarterm{decl-specifier-seq} shall not
 define a class or enumeration. If the \tcode{auto} \nonterminal{type-specifier} appears in
 the \nonterminal{decl-specifier-seq},
@@ -44,9 +44,9 @@ the type of the identifier being declared is deduced from the initializer as des
 \pnum
 \indextext{statement!declaration in \tcode{if}}%
 \indextext{statement!declaration in \tcode{switch}}%
-A name introduced by a declaration in a \grammarterm{}{condition} (either
+A name introduced by a declaration in a \grammarterm{condition} (either
 introduced by the \grammarterm{decl-specifier-seq} or the
-\grammarterm{}{declarator} of the condition) is in scope from its point of
+\grammarterm{declarator} of the condition) is in scope from its point of
 declaration until the end of the substatements controlled by the
 condition. If the name is re-declared in the outermost block of a
 substatement controlled by the condition, the declaration that
@@ -64,17 +64,17 @@ else {
 \end{example}
 
 \pnum
-The value of a \grammarterm{}{condition} that is an initialized declaration
+The value of a \grammarterm{condition} that is an initialized declaration
 in a statement other than a \tcode{switch} statement is the value of the
 declared variable
 contextually converted to \tcode{bool} (Clause~\ref{conv}).
 If that
 conversion is ill-formed, the program is ill-formed. The value of a
-\grammarterm{}{condition} that is an initialized declaration in a
+\grammarterm{condition} that is an initialized declaration in a
 \tcode{switch} statement is the value of the declared variable if it has
 integral or enumeration type, or of that variable implicitly converted
 to integral or enumeration type otherwise. The value of a
-\grammarterm{}{condition} that is an expression is the value of the
+\grammarterm{condition} that is an expression is the value of the
 expression, contextually converted to \tcode{bool}
 for statements other
 than \tcode{switch};
@@ -83,7 +83,7 @@ ill-formed. The value of the condition will be referred to as simply
 ``the condition'' where the usage is unambiguous.
 
 \pnum
-If a \grammarterm{}{condition} can be syntactically resolved as either an
+If a \grammarterm{condition} can be syntactically resolved as either an
 expression or the declaration of a block-scope name, it is interpreted as a
 declaration.
 
@@ -182,7 +182,7 @@ provided.
 
 A compound statement defines a block scope~(\ref{basic.scope}).
 \begin{note}
-A declaration is a \grammarterm{}{statement}~(\ref{stmt.dcl}).
+A declaration is a \grammarterm{statement}~(\ref{stmt.dcl}).
 \end{note}
 
 \rSec1[stmt.select]{Selection statements}%
@@ -206,7 +206,7 @@ See~\ref{dcl.meaning} for the optional \grammarterm{attribute-specifier-seq} in 
 An \grammarterm{init-statement} ends with a semicolon.
 \end{note}
 In Clause~\ref{stmt.stmt}, the term \term{substatement} refers to
-the contained \grammarterm{}{statement} or \grammarterm{}{statement}{s} that appear
+the contained \grammarterm{statement} or \grammarterm{statement}{s} that appear
 in the syntax notation.
 \indextext{scope!\idxgram{selection-statement}}%
 The substatement in a \grammarterm{selection-statement} (each substatement,
@@ -492,7 +492,7 @@ substatement.
 When the condition of a \tcode{while} statement is a declaration, the scope of
 the variable that is declared extends from its point of
 declaration~(\ref{basic.scope.pdecl}) to the end of the \tcode{while}
-\grammarterm{}{statement}. A \tcode{while} statement of the form
+\grammarterm{statement}. A \tcode{while} statement of the form
 
 \begin{codeblock}
 while (T t = x) @\grammarterm{statement}@
@@ -887,7 +887,7 @@ declarations with initialization. A program that jumps\footnote{The transfer fro
 from a point where a variable with automatic storage duration is
 not in scope to a point where it is in scope is ill-formed unless the
 variable has scalar type, class type with a trivial default constructor and a trivial destructor, a cv-qualified version of one of these types, or an array of one of the preceding types and is declared without an
-\grammarterm{}{initializer}~(\ref{dcl.init}).
+\grammarterm{initializer}~(\ref{dcl.init}).
 \begin{example}
 
 \begin{codeblock}


### PR DESCRIPTION
Fixes #1320.