### PR TITLE
[re.submatch.op] Remove excessive parentheses in "Returns:" element.

### DIFF
--- a/source/regex.tex
+++ b/source/regex.tex
@@ -2486,7 +2486,7 @@ template <class charT, class ST, class BiIter>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{(os <{}< m.str())}.
+\pnum\returns \tcode{os << m.str()}.
 \end{itemdescr}
 
 \rSec1[re.results]{Class template \tcode{match_results}}


### PR DESCRIPTION
(... and remove an invisible but unnecessary pair of curlies.)