### PR TITLE
[dcl.init] Fix a typo in definition of const-default-constructible

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -2573,7 +2573,7 @@ or, if \tcode{M} is of class type \tcode{X} (or array thereof),
 if \tcode{T} is a union with at least one non-static data member,
 exactly one variant member has a default member initializer,
 \item
-if \tcode{T} is a not a union,
+if \tcode{T} is not a union,
 for each anonymous union member with at least one non-static data member (if any),
 exactly one non-static data member has a default member initializer, and
 \item


### PR DESCRIPTION
The typo was from [p0490r0](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0490r0.html).