### PR TITLE
[rand.util.seedseq] Consistently format T(...) as ordinary math, not code.

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -4067,10 +4067,10 @@ template<class RandomAccessIterator>
    calculate values
    \begin{eqnarray*}
      r_1 & = &
-       1664525 \cdot \tcode{T}\left(     \tcode{begin[}k\tcode{]}
-                                    \xor \tcode{begin[}k+p\tcode{]}
-                                    \xor \tcode{begin[}k-1 \tcode{]}
-                               \right)
+       1664525 \cdot T(    \tcode{begin[}k\tcode{]}
+                      \xor \tcode{begin[}k+p\tcode{]}
+                      \xor \tcode{begin[}k-1 \tcode{]}
+                      )
      \\
      r_2 & = & r_1 + \left\{
        \begin{array}{cl}
@@ -4094,10 +4094,10 @@ template<class RandomAccessIterator>
    calculate values
    \begin{eqnarray*}
      r_3 & = &
-       1566083941 \cdot \tcode{T}\left( \tcode{begin[}k  \tcode{]}
-                                      + \tcode{begin[}k+p\tcode{]}
-                                      + \tcode{begin[}k-1\tcode{]}
-                                 \right)
+       1566083941 \cdot T( \tcode{begin[}k  \tcode{]}
+                         + \tcode{begin[}k+p\tcode{]}
+                         + \tcode{begin[}k-1\tcode{]}
+                         )
      \\
      r_4 & = & r_3 - (k \bmod n)
    \end{eqnarray*}


### PR DESCRIPTION
For consistency with the start of the paragraph, where T is defined as an ordinary math function.

Using `\left(` and `\right)` instead of plain `(` and `)` here seems to have no effect other than introducing unwanted whitespace between the T and opening parenthesis.

Diff:
![diff](http://eel.is/notcode.png)