### PR TITLE
[rand.adapt.shuf] Show exposition-only members in the order

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -3590,8 +3590,8 @@ template<class Engine, size_t k>
 
   private:
     Engine e;           // \expos
-    result_type Y;      // \expos
     result_type V[k];   // \expos
+    result_type Y;      // \expos
   };
 \end{codeblock}
 


### PR DESCRIPTION
in which initialization is described.

Fixes #1331.