### PR TITLE
[string.io] Don't refer to sentry by name it was not given.

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -4279,7 +4279,7 @@ After the last character (if any) is extracted,
 \tcode{is.width(0)}
 is called and the
 \tcode{sentry}
-object \tcode{k} is destroyed.
+object is destroyed.
 
 \pnum
 If the function extracts no characters, it calls
@@ -4362,8 +4362,7 @@ The conditions are tested in the order shown.
 In any case,
 after the last character is extracted, the
 \tcode{sentry}
-object \tcode{k}
-is destroyed.
+object is destroyed.
 
 \pnum
 If the function extracts no characters, it calls


### PR DESCRIPTION
[[string.io]#2](http://eel.is/c++draft/string.io#2) and [#7](http://eel.is/c++draft/string.io#7) refer to "sentry object k", but the sentry object was never given that name.