### PR TITLE
[class.gslice.overview] Replace $$...$$ with \[...\].

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -8023,10 +8023,8 @@ It is useful for building multidimensional array classes using
 the
 \tcode{valarray}
 template, which is one-dimensional.
-The set of one-dimensional index values specified by a
-\tcode{gslice}
-are $$k = s + \sum_ji_jd_j$$
-% \$k = s + sum from j \{ i sub j d sub j \}\$
+The set of one-dimensional index values specified by a \tcode{gslice} are
+\[ k = s + \sum_j i_j d_j \]
 where the multidimensional indices $i_j$ range in value from
 0 to $l_{ij} - 1$.
 
@@ -8041,9 +8039,7 @@ length = {2, 4, 3}
 stride = {19, 4, 1}
 \end{codeblock}
 yields the sequence of one-dimensional indices
-
-$$k = 3 + (0,1) \times 19 + (0,1,2,3) \times 4 + (0,1,2) \times 1$$
-
+\[ k = 3 + (0, 1) \times 19 + (0, 1, 2, 3) \times 4 + (0, 1, 2) \times 1 \]
 which are ordered as shown in the following table:
 
 \begin{tabbing}


### PR DESCRIPTION
The use of double dollars for math is an old TeX practice that is discouraged in LaTeX.

This patch removes the only two uses of double dollar math in the document.

No visual difference (because `\[...\]` is equivalent here).

(Incidentally, this helps my HTML version of the standard, because cxxdraft-htmlgen uses HaTeX, a Haskell LaTeX parsing library that does not support archaic double dollar math.)
 

