### PR TITLE
Cleanup "partial specializations" language in [atomics.syn]

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -154,7 +154,7 @@ namespace std {
   @\placeholdernc{integral}@ atomic_fetch_xor_explicit(volatile @\placeholder{atomic-integral}@*@\itcorr[-1]@, @\placeholdernc{integral}@, memory_order) noexcept;
   @\placeholdernc{integral}@ atomic_fetch_xor_explicit(@\placeholder{atomic-integral}@*@\itcorr[-1]@, @\placeholdernc{integral}@, memory_order) noexcept;
 
-  // \ref{atomics.types.operations.pointer}, partial specializations for pointers
+  // \ref{atomics.types.operations.pointer}, non-member overloads for atomic<T*>
   template <class T>
     T* atomic_fetch_add(volatile atomic<T*>*, ptrdiff_t) noexcept;
   template <class T>
@@ -797,8 +797,8 @@ Table~\ref{tab:atomics.integral} or inferred from Table~\ref{tab:atomics.typedef
 \indexlibrary{\idxcode{atomic<T*>}}%
 
 \pnum
-The implementation shall provide the function template specializations
-identified as ``partial specializations for pointers'' in~\ref{atomics.syn}.
+The implementation shall provide the function templates identified as
+``non-member overloads for atomic<T*>'' in~\ref{atomics.syn}.
 
 \rSec2[atomics.types.operations.req]{Requirements for operations on atomic types}
 


### PR DESCRIPTION
They aren't partial specializations -- there are no partial specializations of function templates.