### PR TITLE
[valarray.access] 'evaluates as' -> 'evaluates to'.

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -7010,7 +7010,7 @@ T& operator[](size_t n);
 A reference to the corresponding element of the array.
 \begin{note}
 The expression \tcode{(a[i] = q, a[i]) == q}
-evaluates as \tcode{true} for any non-constant \tcode{valarray<T> a},
+evaluates to \tcode{true} for any non-constant \tcode{valarray<T> a},
 any \tcode{T q}, and for any \tcode{size_t i}
 such that the value of \tcode{i} is less than the length of \tcode{a}.
 \end{note}


### PR DESCRIPTION
These are the only three occurrences of 'evaluates as' in the document.