### PR TITLE
[rand.req.eng] Omit superfluous dollar-math wrapping inside \bigoh.

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -1912,21 +1912,21 @@ according to Clause~\ref{strings} and Clause~\ref{input.output}.
     with the same initial state
     as all other default-constructed engines
     of type \tcode{E}.
-  & \bigoh{$\mbox{size of state}$}
+  & \bigoh{\mbox{size of state}}
   \\ \rowsep
 \tcode{E(x)}
 \indextext{copy constructor!random number engine requirement}
   &
   & Creates an engine
     that compares equal to \tcode{x}.
-  & \bigoh{$\mbox{size of state}$}
+  & \bigoh{\mbox{size of state}}
   \\ \rowsep
 \tcode{E(s)}%
 \indextext{constructor!random number engine requirement}
   &
   & Creates an engine
       with initial state determined by \tcode{s}.
-  & \bigoh{$\mbox{size of state}$}
+  & \bigoh{\mbox{size of state}}
   \\ \rowsep
 \tcode{E(q)}%
 \indextext{constructor!random number engine requirement}\footnote{  This constructor
@@ -2005,13 +2005,13 @@ according to Clause~\ref{strings} and Clause~\ref{input.output}.
     returns \tcode{true}
       if $ S_x = S_y $;
     else returns \tcode{false}.
-  & \bigoh{$\mbox{size of state}$}
+  & \bigoh{\mbox{size of state}}
   \\ \rowsep
 \tcode{x != y}%
 \indextext{\idxcode{operator"!=}!random number engine requirement}
   & \tcode{bool}
   & \tcode{!(x == y)}.
-  & \bigoh{$\mbox{size of state}$}
+  & \bigoh{\mbox{size of state}}
   \\ \rowsep
 \tcode{os \shl{} x}%
 \indextext{\idxcode{operator\shl}!random number engine requirement}
@@ -2027,7 +2027,7 @@ according to Clause~\ref{strings} and Clause~\ref{input.output}.
     by one or more space characters.
 
     post: The \tcode{os.}\textit{fmtflags} and fill character are unchanged.
-  & \bigoh{$\mbox{size of state}$}
+  & \bigoh{\mbox{size of state}}
   \\ \rowsep
 \tcode{is \shr{} v}%
 \indextext{\idxcode{operator\shr}!random number engine requirement}
@@ -2058,7 +2058,7 @@ according to Clause~\ref{strings} and Clause~\ref{input.output}.
     were respectively the same as those of \tcode{is}.
 
     post: The \tcode{is.}\textit{fmtflags} are unchanged.
-  & \bigoh{$\mbox{size of state}$}
+  & \bigoh{\mbox{size of state}}
   \\
 \end{libreqtab4d}
 


### PR DESCRIPTION
Compare: [line 2070](https://github.com/cplusplus/draft/blob/master/source/numerics.tex#L2070)