### PR TITLE
Preserve whitespace after \shr and \shl where appropriate.

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -2633,7 +2633,7 @@ can be called by
 the function signature
 \tcode{basic_ostream\& stream::operator\shl(ios_base\& (*)(ios_base\&))}
 to permit expressions of the form
-\tcode{cout \shl dec}
+\tcode{cout \shl{} dec}
 to change the format flags stored in
 \tcode{cout}.}.
 \end{itemdescr}
@@ -6749,13 +6749,13 @@ mask)}, or if \tcode{in} is an object of type
 \tcode{basic_istream<charT, traits>} then the expression \tcode{in \shr\
 resetiosflags(\brk{}mask)} behaves as if it called \tcode{f(in,
 mask)}, where the function \tcode{f}
-is defined as:\footnote{ The expression \tcode{cin \shr resetiosflags(ios_base::skipws)}
+is defined as:\footnote{ The expression \tcode{cin \shr{} resetiosflags(ios_base::skipws)}
 clears \tcode{ios_base::skipws} in the format flags stored in the
 \tcode{basic_istream<charT, traits>} object \tcode{cin} (the same as
-\tcode{cin \shr noskipws}), and the expression \tcode{cout \shl
+\tcode{cin \shr{} noskipws}), and the expression \tcode{cout \shl{}
 resetiosflags(ios_base::showbase)} clears \tcode{ios_base::showbase} in the
 format flags stored in the \tcode{basic_ostream<charT, traits>} object
-\tcode{cout} (the same as \tcode{cout \shl noshowbase}). }
+\tcode{cout} (the same as \tcode{cout \shl{} noshowbase}). }
 
 \begin{codeblock}
 void f(ios_base& str, ios_base::fmtflags mask) {
@@ -7009,7 +7009,7 @@ template <class moneyT> @\unspec@ get_money(moneyT& mon, bool intl = false);
 specialization of the \tcode{basic_string} template (Clause~\ref{strings}).
 
 \pnum
-\effects The expression \tcode{in \shr get_money(mon, intl)} described below
+\effects The expression \tcode{in \shr{} get_money(mon, intl)} described below
 behaves as a formatted input function~(\ref{istream.formatted.reqmts}).
 
 \pnum

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -6016,7 +6016,7 @@ between an object of class
 and a value of some
 integral type, bit position \tcode{pos} corresponds to the
 \term{bit value}
-\tcode{1 \shl pos}.
+\tcode{1 \shl{} pos}.
 The integral value corresponding to two
 or more bits is the sum of their bit values.
 


### PR DESCRIPTION
Diffs:
![diff](http://eel.is/shlshr.png)