### PR TITLE
[rand.util.seedseq] Replace nested ternary expressions with definition by cases.

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -4057,9 +4057,17 @@ template<class RandomAccessIterator>
    let $p = (n - t) / 2$
    and let $q = p + t$,
    where
-   \[%
-     t = (n \ge 623) \mbox{ ? } 11 \mbox{ : } (n \ge 68) \mbox{ ? } 7 \mbox{ : } (n \ge 39) \mbox{ ? } 5 \mbox{ : } (n \ge 7) \mbox{ ? } 3 \mbox{ : } (n - 1)/2;
-   \]%
+   \[
+     t = \left\{
+       \begin{array}{cc@{\ }r@{\ }l}
+         11         & , & 623 \le & n       \\
+         7          & , &  68 \le & n < 623 \\
+         5          & , &  39 \le & n < 68  \\
+         3          & , &   7 \le & n < 39  \\
+         (n - 1)/2  & , &         & n < 7
+       \end{array}
+       \right.
+   \]
  \item
    With $m$ as the larger of $s + 1$ and $n$,
    transform the elements of the range:


### PR DESCRIPTION
As suggested by @jensmaurer in #1329. Diff:

![diff](http://eel.is/tern.png)