### PR TITLE
Remove \shl and \shr.

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -990,9 +990,9 @@ representing non-class types would exacerbate whitespace issues.
 Change to semantics of well-defined expression. A valid \CppIII expression
 containing a right angle bracket (``\tcode{>}'') followed immediately by
 another right angle bracket may now be treated as closing two templates.
-For example, the following code is valid in \CppIII because ``\tcode{\shr}''
+For example, the following code is valid in \CppIII because ``\tcode{>>}''
 is a right-shift operator, but invalid in this International Standard because
-``\tcode{\shr}'' closes two templates.
+``\tcode{>>}'' closes two templates.
 
 \begin{codeblock}
 template <class T> struct X { };

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -1362,7 +1362,7 @@ error_code make_error_code(errc e) noexcept;
 \returns \tcode{error_code(static_cast<int>(e), generic_category())}.
 \end{itemdescr}
 
-\indexlibrarymember{operator\shl}{error_code}%
+\indexlibrarymember{operator<<}{error_code}%
 \begin{itemdecl}
 template <class charT, class traits>
   basic_ostream<charT, traits>&

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1323,8 +1323,8 @@ pack~(\ref{temp.variadic}) over a binary operator.
 
 \begin{bnf}
 \nontermdef{fold-operator} \textnormal{one of}\br
-    \terminal{+ }\quad\terminal{- }\quad\terminal{* }\quad\terminal{/ }\quad\terminal{\% }\quad\terminal{\caret }\quad\terminal{\& }\quad\terminal{| }\quad\terminal{\shl\ }\quad\terminal{\shr }\br
-    \terminal{+=}\quad\terminal{-=}\quad\terminal{*=}\quad\terminal{/=}\quad\terminal{\%=}\quad\terminal{\caret=}\quad\terminal{\&=}\quad\terminal{|=}\quad\terminal{\shl=}\quad\terminal{\shr=}\quad\terminal{=}\br
+    \terminal{+ }\quad\terminal{- }\quad\terminal{* }\quad\terminal{/ }\quad\terminal{\% }\quad\terminal{\caret }\quad\terminal{\& }\quad\terminal{| }\quad\terminal{<< }\quad\terminal{>> }\br
+    \terminal{+=}\quad\terminal{-=}\quad\terminal{*=}\quad\terminal{/=}\quad\terminal{\%=}\quad\terminal{\caret=}\quad\terminal{\&=}\quad\terminal{|=}\quad\terminal{<<=}\quad\terminal{>>=}\quad\terminal{=}\br
     \terminal{==}\quad\terminal{!=}\quad\terminal{< }\quad\terminal{> }\quad\terminal{<=}\quad\terminal{>=}\quad\terminal{\&\&}\quad\terminal{||}\quad\terminal{,  }\quad\terminal{.* }\quad\terminal{->*}
 \end{bnf}
 
@@ -4104,18 +4104,18 @@ converted to the type \tcode{std::ptrdiff_t}.
 \indextext{shift operator|see{operator, left shift; operator, right shift}}%
 \indextext{right shift operator|see{operator, right shift}}%
 \indextext{left shift operator|see{operator, left shift}}%
-The shift operators \tcode{\shl} and \tcode{\shr} group left-to-right.
+The shift operators \tcode{<<} and \tcode{>>} group left-to-right.
 
 \indextext{operator!left shift}%
-\indextext{\idxcode{\shl}|see{operator, left shift}}%
+\indextext{\idxcode{<<}|see{operator, left shift}}%
 \indextext{operator!right shift}%
-\indextext{\idxcode{\shr}|see{operator, right shift}}%
+\indextext{\idxcode{>>}|see{operator, right shift}}%
 %
 \begin{bnf}
 \nontermdef{shift-expression}\br
     additive-expression\br
-    shift-expression \terminal{\shl} additive-expression\br
-    shift-expression \terminal{\shr} additive-expression
+    shift-expression \terminal{<<} additive-expression\br
+    shift-expression \terminal{>>} additive-expression
 \end{bnf}
 
 The operands shall be of integral or unscoped enumeration type and integral
@@ -4126,7 +4126,7 @@ The behavior is undefined if the right operand is negative, or greater
 than or equal to the length in bits of the promoted left operand.
 
 \pnum
-The value of \tcode{E1 \shl\ E2} is \tcode{E1} left-shifted \tcode{E2} bit positions; vacated bits are
+The value of \tcode{E1 << E2} is \tcode{E1} left-shifted \tcode{E2} bit positions; vacated bits are
 zero-filled. If \tcode{E1} has an unsigned type, the value of the result
 is $\mathrm{E1}\times2^\mathrm{E2}$, reduced modulo
 one more than the maximum value representable in the result type. Otherwise, if
@@ -4136,7 +4136,7 @@ that value, converted to the result type, is the resulting value; otherwise, the
 behavior is undefined.
 
 \pnum
-The value of \tcode{E1 \shr\ E2} is \tcode{E1} right-shifted \tcode{E2}
+The value of \tcode{E1 >> E2} is \tcode{E1} right-shifted \tcode{E2}
 bit positions. If \tcode{E1} has an unsigned type or if \tcode{E1} has a
 signed type and a non-negative value, the value of the result is the
 integral part of the quotient of $\mathrm{E1}/2^\mathrm{E2}$. If \tcode{E1}
@@ -4692,8 +4692,8 @@ with no operand calls
 \indextext{operator!\idxcode{*=}}%
 \indextext{operator!\idxcode{/=}}%
 \indextext{operator!\idxcode{\%=}}%
-\indextext{operator!\idxcode{\shr=}}%
-\indextext{operator!\idxcode{\shl=}}%
+\indextext{operator!\idxcode{>>=}}%
+\indextext{operator!\idxcode{<<=}}%
 \indextext{operator!\idxcode{\&=}}%
 \indextext{operator!\idxcode{\caret=}}%
 \indextext{operator!\idxcode{"|=}}%
@@ -4728,7 +4728,7 @@ single compound assignment operator.
 
 \begin{bnf}
 \nontermdef{assignment-operator} \textnormal{one of}\br
-    \terminal{=  *=  /=  \%=   +=  -=  \shr=  \shl=  \&=  \caret=  |=}
+    \terminal{=  *=  /=  \%=   +=  -=  >>=  <<=  \&=  \caret=  |=}
 \end{bnf}
 
 \pnum

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -2631,9 +2631,9 @@ Calls
 \tcode{dec(ios_base\&)}
 can be called by
 the function signature
-\tcode{basic_ostream\& stream::operator\shl(ios_base\& (*)(ios_base\&))}
+\tcode{basic_ostream\& stream::operator<<(ios_base\& (*)(ios_base\&))}
 to permit expressions of the form
-\tcode{cout \shl dec}
+\tcode{cout << dec}
 to change the format flags stored in
 \tcode{cout}.}.
 \end{itemdescr}
@@ -4559,7 +4559,7 @@ If no exception has been thrown, it returns
 
 \rSec4[istream.formatted.arithmetic]{Arithmetic extractors}
 
-\indexlibrarymember{operator\shr}{basic_istream}%
+\indexlibrarymember{operator>>}{basic_istream}%
 \begin{itemdecl}
 operator>>(unsigned short& val);
 operator>>(unsigned int& val);
@@ -4610,7 +4610,7 @@ so that it does not need to depend directly on
 \tcode{istream}.
 \end{itemdescr}
 
-\indexlibrarymember{operator\shr}{basic_istream}%
+\indexlibrarymember{operator>>}{basic_istream}%
 \begin{itemdecl}
 operator>>(short& val);
 \end{itemdecl}
@@ -4636,7 +4636,7 @@ setstate(err);
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{operator\shr}{basic_istream}%
+\indexlibrarymember{operator>>}{basic_istream}%
 \begin{itemdecl}
 operator>>(int& val);
 \end{itemdecl}
@@ -4662,9 +4662,9 @@ setstate(err);
 \end{codeblock}
 \end{itemdescr}
 
-\rSec4[istream.extractors]{\tcode{basic_istream::operator\shr}}
+\rSec4[istream.extractors]{\tcode{basic_istream::operator>>}}
 
-\indexlibrarymember{operator\shr}{basic_istream}%
+\indexlibrarymember{operator>>}{basic_istream}%
 \begin{itemdecl}
 basic_istream<charT, traits>& operator>>
     (basic_istream<charT, traits>& (*pf)(basic_istream<charT, traits>&));
@@ -4684,7 +4684,7 @@ This extractor does not behave as a formatted input function
 \indexlibrary{\idxcode{ws}}}%
 \end{itemdescr}
 
-\indexlibrarymember{operator\shr}{basic_istream}%
+\indexlibrarymember{operator>>}{basic_istream}%
 \begin{itemdecl}
 basic_istream<charT, traits>& operator>>
     (basic_ios<charT, traits>& (*pf)(basic_ios<charT, traits>&));
@@ -4703,7 +4703,7 @@ This extractor does not behave as a formatted input function
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{operator\shr}{basic_istream}%
+\indexlibrarymember{operator>>}{basic_istream}%
 \begin{itemdecl}
 basic_istream<charT, traits>& operator>>
     (ios_base& (*pf)(ios_base&));
@@ -4723,7 +4723,7 @@ This extractor does not behave as a formatted input function
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{operator\shr}{basic_istream}%
+\indexlibrarymember{operator>>}{basic_istream}%
 \begin{itemdecl}
 template<class charT, class traits>
   basic_istream<charT, traits>& operator>>(basic_istream<charT, traits>& in,
@@ -4744,7 +4744,7 @@ of \tcode{in}.
 After a
 \tcode{sentry}
 object is constructed,
-\tcode{operator\shr}
+\tcode{operator>>}
 extracts characters and stores them into
 successive locations of an array whose first element is designated by
 \tcode{s}.
@@ -4777,12 +4777,12 @@ where \tcode{ct} is
 \end{itemize}
 
 \pnum
-\tcode{operator\shr}
+\tcode{operator>>}
 then stores a null byte
 (\tcode{charT()})
 in the next position, which may be the first position if no characters
 were extracted.
-\tcode{operator\shr}
+\tcode{operator>>}
 then calls
 \tcode{width(0)}.
 
@@ -4797,7 +4797,7 @@ which may throw
 \tcode{in}.
 \end{itemdescr}
 
-\indexlibrarymember{operator\shr}{basic_istream}%
+\indexlibrarymember{operator>>}{basic_istream}%
 \begin{itemdecl}
 template<class charT, class traits>
   basic_istream<charT, traits>& operator>>(basic_istream<charT, traits>& in,
@@ -4827,7 +4827,7 @@ Otherwise, the function calls
 \tcode{in}.
 \end{itemdescr}
 
-\indexlibrarymember{operator\shr}{basic_istream}%
+\indexlibrarymember{operator>>}{basic_istream}%
 \begin{itemdecl}
 basic_istream<charT, traits>& operator>>
   (basic_streambuf<charT, traits>* sb);
@@ -5583,7 +5583,7 @@ but not
 
 \rSec3[istream.rvalue]{Rvalue stream extraction}
 
-\indexlibrarymember{operator\shr}{basic_istream}%
+\indexlibrarymember{operator>>}{basic_istream}%
 \begin{itemdecl}
 template <class charT, class traits, class T>
   basic_istream<charT, traits>&
@@ -6172,7 +6172,7 @@ character sequence.
 
 \rSec4[ostream.inserters.arithmetic]{Arithmetic inserters}
 
-\indexlibrarymember{operator\shl}{basic_ostream}%
+\indexlibrarymember{operator<<}{basic_ostream}%
 \begin{itemdecl}
 operator<<(bool val);
 operator<<(short val);
@@ -6298,9 +6298,9 @@ which may throw an exception, and returns.
 \tcode{*this}.
 \end{itemdescr}
 
-\rSec4[ostream.inserters]{\tcode{basic_ostream::operator\shl}}
+\rSec4[ostream.inserters]{\tcode{basic_ostream::operator<<}}
 
-\indexlibrarymember{operator\shl}{basic_ostream}%
+\indexlibrarymember{operator<<}{basic_ostream}%
 \begin{itemdecl}
 basic_ostream<charT, traits>& operator<<
     (basic_ostream<charT, traits>& (*pf)(basic_ostream<charT, traits>&));
@@ -6320,7 +6320,7 @@ in~\ref{ostream.formatted.reqmts}).
 \tcode{endl(basic_ostream\&)}~(\ref{ostream.manip}).}
 \end{itemdescr}
 
-\indexlibrarymember{operator\shl}{basic_ostream}%
+\indexlibrarymember{operator<<}{basic_ostream}%
 \begin{itemdecl}
 basic_ostream<charT, traits>& operator<<
     (basic_ios<charT, traits>& (*pf)(basic_ios<charT, traits>&));
@@ -6341,7 +6341,7 @@ behave as a formatted output function (as described in~\ref{ostream.formatted.re
 \tcode{dec(ios_base\&)}~(\ref{basefield.manip}).}
 \end{itemdescr}
 
-\indexlibrarymember{operator\shl}{basic_ostream}%
+\indexlibrarymember{operator<<}{basic_ostream}%
 \begin{itemdecl}
 basic_ostream<charT, traits>& operator<<
     (ios_base& (*pf)(ios_base&));
@@ -6360,7 +6360,7 @@ behave as a formatted output function (as described in~\ref{ostream.formatted.re
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{operator\shl}{basic_ostream}%
+\indexlibrarymember{operator<<}{basic_ostream}%
 \begin{itemdecl}
 basic_ostream<charT, traits>& operator<<
     (basic_streambuf<charT, traits>* sb);
@@ -6412,7 +6412,7 @@ the caught exception is rethrown.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{operator\shl}{basic_ostream}%
+\indexlibrarymember{operator<<}{basic_ostream}%
 \begin{itemdecl}
 basic_ostream<charT, traits>& operator<<(nullptr_t);
 \end{itemdecl}
@@ -6431,7 +6431,7 @@ NTCTS~(\ref{defns.ntcts}).
 
 \rSec4[ostream.inserters.character]{Character inserter function templates}
 
-\indexlibrarymember{operator\shl}{basic_ostream}%
+\indexlibrarymember{operator<<}{basic_ostream}%
 \begin{itemdecl}
 template<class charT, class traits>
   basic_ostream<charT, traits>& operator<<(basic_ostream<charT, traits>& out,
@@ -6474,7 +6474,7 @@ in~\ref{ostream.formatted.reqmts}. Inserts \tcode{seq} into
 \tcode{out}.
 \end{itemdescr}
 
-\indexlibrarymember{operator\shl}{basic_ostream}%
+\indexlibrarymember{operator<<}{basic_ostream}%
 \begin{itemdecl}
 template<class charT, class traits>
   basic_ostream<charT, traits>& operator<<(basic_ostream<charT, traits>& out,
@@ -6708,7 +6708,7 @@ Calls
 
 \rSec3[ostream.rvalue]{Rvalue stream insertion}
 
-\indexlibrarymember{operator\shl}{basic_ostream}%
+\indexlibrarymember{operator<<}{basic_ostream}%
 \begin{itemdecl}
 template <class charT, class traits, class T>
   basic_ostream<charT, traits>&
@@ -6717,7 +6717,7 @@ template <class charT, class traits, class T>
 
 \begin{itemdescr}
 \pnum
-\effects As if by: \tcode{os \shl{} x;}
+\effects As if by: \tcode{os << x;}
 
 \pnum
 \returns \tcode{os}.
@@ -6743,19 +6743,19 @@ extractors and inserters that alter information maintained by class
 \pnum
 \returns An object of
 unspecified type such that if \tcode{out} is an object of type
-\tcode{basic_ostream<charT, traits>} then the expression \tcode{out \shl\
-resetiosflags(mask)} behaves as if it called \tcode{f(out,
-mask)}, or if \tcode{in} is an object of type
-\tcode{basic_istream<charT, traits>} then the expression \tcode{in \shr\
-resetiosflags(\brk{}mask)} behaves as if it called \tcode{f(in,
-mask)}, where the function \tcode{f}
-is defined as:\footnote{ The expression \tcode{cin \shr resetiosflags(ios_base::skipws)}
+\tcode{basic_ostream<charT, traits>} then the expression
+\tcode{out << resetiosflags(mask)} behaves as if it called
+\tcode{f(out, mask)}, or if \tcode{in} is an object of type
+\tcode{basic_istream<charT, traits>} then the expression
+\tcode{in >> resetiosflags(\brk{}mask)} behaves as if it called
+\tcode{f(in, mask)}, where the function \tcode{f}
+is defined as:\footnote{ The expression \tcode{cin >> resetiosflags(ios_base::skipws)}
 clears \tcode{ios_base::skipws} in the format flags stored in the
 \tcode{basic_istream<charT, traits>} object \tcode{cin} (the same as
-\tcode{cin \shr noskipws}), and the expression \tcode{cout \shl
-resetiosflags(ios_base::showbase)} clears \tcode{ios_base::showbase} in the
+\tcode{cin >> noskipws}), and the expression
+\tcode{cout << resetiosflags(ios_base::showbase)} clears \tcode{ios_base::showbase} in the
 format flags stored in the \tcode{basic_ostream<charT, traits>} object
-\tcode{cout} (the same as \tcode{cout \shl noshowbase}). }
+\tcode{cout} (the same as \tcode{cout << noshowbase}). }
 
 \begin{codeblock}
 void f(ios_base& str, ios_base::fmtflags mask) {
@@ -6764,9 +6764,9 @@ void f(ios_base& str, ios_base::fmtflags mask) {
 }
 \end{codeblock}
 
-The expression \tcode{out \shl\ resetiosflags(mask)} shall have
+The expression \tcode{out << resetiosflags(mask)} shall have
 type \tcode{basic_ostream<charT, traits>\&} and value \tcode{out}. The
-expression \tcode{in \shr\ resetiosflags(mask)} shall have type
+expression \tcode{in >> resetiosflags(mask)} shall have type
 \tcode{basic_istream<charT, traits>\&} and value \tcode{in}. \end{itemdescr}
 
 \indexlibrary{\idxcode{setiosflags}}%
@@ -6782,7 +6782,7 @@ An object of unspecified type such that if
 is an object of type
 \tcode{basic_ostream<charT, traits>}
 then the expression
-\tcode{out \shl\ setiosflags(mask)}
+\tcode{out << setiosflags(mask)}
 behaves as if it called
 \tcode{f(out, mask)},
 or if
@@ -6790,7 +6790,7 @@ or if
 is an object of type
 \tcode{basic_istream<charT, traits>}
 then the expression
-\tcode{in \shr\ setiosflags(mask)}
+\tcode{in >> setiosflags(mask)}
 behaves as if it called
 \tcode{f(in, mask)}, where the function \tcode{f} is defined as:
 \indexlibrary{\idxcode{fmtflags}!\idxcode{ios_base}}%
@@ -6803,13 +6803,13 @@ void f(ios_base& str, ios_base::fmtflags mask) {
 \end{codeblock}
 
 The expression
-\tcode{out \shl\ setiosflags(mask)}
+\tcode{out << setiosflags(mask)}
 shall have type
 \tcode{basic_ostream<charT, traits>\&}
 and value
 \tcode{out}.
 The expression
-\tcode{in \shr\ setiosflags(mask)}
+\tcode{in >> setiosflags(mask)}
 shall have type
 \tcode{basic_istream<charT, \\traits>\&}
 and value
@@ -6829,7 +6829,7 @@ An object of unspecified type such that if
 is an object of type
 \tcode{basic_ostream<charT, traits>}
 then the expression
-\tcode{out \shl\ setbase(base)}
+\tcode{out << setbase(base)}
 behaves as if it called
 \tcode{f(out, base)},
 or if
@@ -6837,7 +6837,7 @@ or if
 is an object of type
 \tcode{basic_istream<charT, traits>}
 then the expression
-\tcode{in \shr\ setbase(base)}
+\tcode{in >> setbase(base)}
 behaves as if it called
 \tcode{f(in, base)}, where the function \tcode{f} is defined as:
 
@@ -6852,13 +6852,13 @@ void f(ios_base& str, int base) {
 \end{codeblock}
 
 The expression
-\tcode{out \shl\ setbase(base)}
+\tcode{out << setbase(base)}
 shall have type
 \tcode{basic_ostream<charT, traits>\&}
 and value
 \tcode{out}.
 The expression
-\tcode{in \shr\ setbase(base)}
+\tcode{in >> setbase(base)}
 shall have type
 \tcode{basic_istream<charT, traits>\&}
 and value
@@ -6880,7 +6880,7 @@ is an object of type
 and \tcode{c} has type
 \tcode{charT}
 then the expression
-\tcode{out \shl\ setfill(c)}
+\tcode{out << setfill(c)}
 behaves as if it called
 \tcode{f(out, c)}, where the function \tcode{f} is defined as:
 
@@ -6893,7 +6893,7 @@ void f(basic_ios<charT, traits>& str, charT c) {
 \end{codeblock}
 
 The expression
-\tcode{out \shl\ setfill(c)}
+\tcode{out << setfill(c)}
 shall have type
 \tcode{basic_ostream<charT, traits>\&}
 and value
@@ -6913,7 +6913,7 @@ An object of unspecified type such that if
 is an object of type
 \tcode{basic_ostream<charT, traits>}
 then the expression
-\tcode{out \shl\ setprecision(n)}
+\tcode{out << setprecision(n)}
 behaves as if it called
 \tcode{f(out, n)},
 or if
@@ -6921,7 +6921,7 @@ or if
 is an object of type
 \tcode{basic_istream<charT, traits>}
 then the expression
-\tcode{in \shr\ setprecision(n)}
+\tcode{in >> setprecision(n)}
 behaves as if it called
 \tcode{f(in, n)}, where the function \tcode{f} is defined as:
 
@@ -6933,13 +6933,13 @@ void f(ios_base& str, int n) {
 \end{codeblock}
 
 The expression
-\tcode{out \shl\ setprecision(n)}
+\tcode{out << setprecision(n)}
 shall have type
 \tcode{basic_ostream<charT, traits>\&}
 and value
 \tcode{out}.
 The expression
-\tcode{in \shr\ setprecision(n)}
+\tcode{in >> setprecision(n)}
 shall have type
 \tcode{basic_istream<charT, traits>\&}
 and value
@@ -6959,7 +6959,7 @@ An object of unspecified type such that if
 is an instance of
 \tcode{basic_ostream<charT, traits>}
 then the expression
-\tcode{out \shl\ setw(n)}
+\tcode{out << setw(n)}
 behaves as if it called
 \tcode{f(out, n)},
 or if
@@ -6967,7 +6967,7 @@ or if
 is an object of type
 \tcode{basic_istream<charT, traits>}
 then the expression
-\tcode{in \shr\ setw(n)}
+\tcode{in >> setw(n)}
 behaves as if it called
 \tcode{f(in, n)}, where the function \tcode{f} is defined as:
 
@@ -6979,13 +6979,13 @@ void f(ios_base& str, int n) {
 \end{codeblock}
 
 The expression
-\tcode{out \shl\ setw(n)}
+\tcode{out << setw(n)}
 shall have type
 \tcode{basic_ostream<charT, traits>\&}
 and value
 \tcode{out}.
 The expression
-\tcode{in \shr\ setw(n)}
+\tcode{in >> setw(n)}
 shall have type
 \tcode{basic_istream<charT, traits>\&}
 and value
@@ -7009,13 +7009,13 @@ template <class moneyT> @\unspec@ get_money(moneyT& mon, bool intl = false);
 specialization of the \tcode{basic_string} template (Clause~\ref{strings}).
 
 \pnum
-\effects The expression \tcode{in \shr get_money(mon, intl)} described below
+\effects The expression \tcode{in >> get_money(mon, intl)} described below
 behaves as a formatted input function~(\ref{istream.formatted.reqmts}).
 
 \pnum
 \returns An object of unspecified type such that if
 \tcode{in} is an object of type \tcode{basic_istream<charT, traits>}
-then the expression \tcode{in \shr\ get_money(mon, intl)} behaves as if it called
+then the expression \tcode{in >> get_money(mon, intl)} behaves as if it called
 \tcode{f(in, mon, intl)}, where the function \tcode{f} is defined as:
 
 \begin{codeblock}
@@ -7034,7 +7034,7 @@ void f(basic_ios<charT, traits>& str, moneyT& mon, bool intl) {
 }
 \end{codeblock}
 
-The expression \tcode{in \shr\ get_money(mon, intl)} shall have type
+The expression \tcode{in >> get_money(mon, intl)} shall have type
 \tcode{basic_istream<charT, traits>\&} and value \tcode{in}.
 \end{itemdescr}
 
@@ -7051,7 +7051,8 @@ specialization of the \tcode{basic_string} template (Clause~\ref{strings}).
 \pnum
 \returns An object of unspecified type such that if
 \tcode{out} is an object of type \tcode{basic_ostream<charT, traits>}
-then the expression \tcode{out \shl\ put_money(mon, intl)} behaves as a formatted output function~(\ref{ostream.formatted.reqmts}) that calls
+then the expression \tcode{out << put_money(mon, intl)} behaves as a
+formatted output function~(\ref{ostream.formatted.reqmts}) that calls
 \tcode{f(out, mon, intl)}, where the function \tcode{f} is defined as:
 
 \begin{codeblock}
@@ -7068,7 +7069,7 @@ void f(basic_ios<charT, traits>& str, const moneyT& mon, bool intl) {
 }
 \end{codeblock}
 
-The expression \tcode{out \shl\ put_money(mon, intl)} shall have type
+The expression \tcode{out << put_money(mon, intl)} shall have type
 \tcode{basic_ostream<charT, traits>\&} and value \tcode{out}.
 
 \end{itemdescr}
@@ -7084,7 +7085,7 @@ template <class charT> @\unspec@ get_time(struct tm* tmb, const charT* fmt);
 
 \pnum
 \returns An object of unspecified type such that if \tcode{in} is an object of type
-\tcode{basic_istream<charT, traits>} then the expression \tcode{in \shr\ get_time(tmb,
+\tcode{basic_istream<charT, traits>} then the expression \tcode{in >> get_time(tmb,
 fmt)} behaves as if it called \tcode{f(in, tmb, fmt)}, where the function \tcode{f} is
 defined as:
 
@@ -7105,7 +7106,7 @@ void f(basic_ios<charT, traits>& str, struct tm* tmb, const charT* fmt) {
 }
 \end{codeblock}
 
-The expression \tcode{in \shr\ get_time(tmb, fmt)} shall have type
+The expression \tcode{in >> get_time(tmb, fmt)} shall have type
 \tcode{basic_istream<charT, traits>\&} and value \tcode{in}.
 \end{itemdescr}
 
@@ -7123,9 +7124,9 @@ array of objects of type \tcode{charT} with
 
 \pnum
 \returns An object of unspecified type such that if \tcode{out} is an object of
-type \tcode{basic_ostream<charT, traits>} then the expression \tcode{out \shl\
-put_time(tmb, fmt)} behaves as if it called \tcode{f(out, tmb, fmt)}, where the
-function \tcode{f} is defined as:
+type \tcode{basic_ostream<charT, traits>} then the expression
+\tcode{out << put_time(tmb, fmt)} behaves as if it called \tcode{f(out, tmb, fmt)},
+where the function \tcode{f} is defined as:
 
 \begin{codeblock}
 template <class charT, class traits>
@@ -7142,7 +7143,7 @@ void f(basic_ios<charT, traits>& str, const struct tm* tmb, const charT* fmt) {
 }
 \end{codeblock}
 
-The expression \tcode{out \shl\ put_time(tmb, fmt)} shall have type
+The expression \tcode{out << put_time(tmb, fmt)} shall have type
 \tcode{basic_ostream<charT, traits>\&} and value \tcode{out}.
 \end{itemdescr}
 
@@ -7166,7 +7167,7 @@ template <class charT, class traits, class Allocator>
 of \tcode{basic_ostream} with member type \tcode{char_type} the same as
 \tcode{charT} and with member type \tcode{traits_type}, which in the second
 form is the same as \tcode{traits}, then the expression
-\tcode{out \shl\ quoted(s, delim, escape)}
+\tcode{out << quoted(s, delim, escape)}
 behaves as a formatted output function~(\ref{ostream.formatted.reqmts})
 of \tcode{out}. This forms a character sequence \tcode{seq}, initially
 consisting of the following elements:
@@ -7182,7 +7183,7 @@ Then padding is determined for \tcode{seq} as described
 in~\ref{ostream.formatted.reqmts}, \tcode{seq} is inserted as if by calling
 \tcode{out.rdbuf()->sputn(seq, n)}, where \tcode{n} is the larger of
 \tcode{out.width()} and \tcode{x}, and \tcode{out.width(0)} is called.
-The expression \tcode{out \shl\ quoted(s, delim, escape)} shall have type
+The expression \tcode{out << quoted(s, delim, escape)} shall have type
 \tcode{basic_ostream<charT, traits>\&} and value \tcode{out}.
 \end{itemdescr}
 
@@ -7200,9 +7201,9 @@ template <class charT, class traits, class Allocator>
 \item If \tcode{in} is an instance of \tcode{basic_istream} with member types
 \tcode{char_type} and \tcode{traits_type} the same as \tcode{charT}
 and \tcode{traits}, respectively, then the expression
-\tcode{in \shr\ quoted(s, delim, escape)} behaves as if it extracts the following
+\tcode{in >> quoted(s, delim, escape)} behaves as if it extracts the following
 characters from \tcode{in} using
-\tcode{operator\shr(basic_istream<charT, traits>\&, charT\&)}~(\ref{istream.extractors})
+\tcode{operator>>(basic_istream<charT, traits>\&, charT\&)}~(\ref{istream.extractors})
 which may throw \tcode{ios_base::failure}~(\ref{ios::failure}):
 \begin{itemize}
 \item If the first character extracted is equal to \tcode{delim}, as
@@ -7217,18 +7218,18 @@ if an \tcode{escape} is reached, ignore it and append the next character to
 \item Discard the final \tcode{delim} character.
 \item Restore the \tcode{skipws} flag to its original value.
 \end{itemize}
-\item Otherwise, \tcode{in \shr\ s}.
+\item Otherwise, \tcode{in >> s}.
 \end{itemize}
 \item If \tcode{out} is an instance of \tcode{basic_ostream} with member types
 \tcode{char_type} and \tcode{traits_type} the same as \tcode{charT} and
 \tcode{traits}, respectively, then the expression
-\tcode{out \shl\ quoted(s, delim, escape)} behaves as specified for the
+\tcode{out << quoted(s, delim, escape)} behaves as specified for the
 \tcode{const basic_string<charT, traits, Allocator>\&} overload of the
 \tcode{quoted} function.
 \end{itemize}
-The expression \tcode{in \shr\ quoted(s, delim, escape)} shall have type
+The expression \tcode{in >> quoted(s, delim, escape)} shall have type
 \tcode{basic_istream<charT, traits>\&} and value \tcode{in}. The expression
-\tcode{out \shl\ quoted(s, delim, escape)} shall have type
+\tcode{out << quoted(s, delim, escape)} shall have type
 \tcode{basic_ostream\brk{}<charT, traits>\&} and value \tcode{out}.
 \end{itemdescr}
 
@@ -11980,7 +11981,7 @@ path operator/ (const path& lhs, const path& rhs);
 
 \rSec4[path.io]{\tcode{path} inserter and extractor}
 
-\indexlibrarymember{operator\shl}{path}%
+\indexlibrarymember{operator<<}{path}%
 \begin{itemdecl}
 template <class charT, class traits>
   basic_ostream<charT, traits>&
@@ -11996,7 +11997,7 @@ template <class charT, class traits>
 \returns \tcode{os}.
 \end{itemdescr}
 
-\indexlibrarymember{operator\shr}{path}%
+\indexlibrarymember{operator>>}{path}%
 \begin{itemdecl}
 template <class charT, class traits>
   basic_istream<charT, traits>&

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -2563,7 +2563,7 @@ The class template
 \tcode{istream_iterator}
 is an input iterator~(\ref{input.iterators}) that
 reads (using
-\tcode{operator\shr})
+\tcode{operator>>})
 successive elements from the input stream for which it was constructed.
 After it is constructed, and every time
 \tcode{++}
@@ -2742,7 +2742,7 @@ istream_iterator& operator++();
 
 \pnum
 \effects
-As if by: \tcode{*in_stream \shr{} value;}
+As if by: \tcode{*in_stream >> value;}
 
 \pnum
 \returns
@@ -2800,7 +2800,7 @@ template <class T, class charT, class traits, class Distance>
 \indexlibrary{\idxcode{ostream_iterator}}%
 \tcode{ostream_iterator}
 writes (using
-\tcode{operator\shl})
+\tcode{operator<<})
 successive elements onto the output stream from which it was constructed.
 If it was constructed with
 \tcode{charT*}

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -797,7 +797,7 @@ are converted into tokens for operators and punctuators:
 \>new \>delete \>? \>:: \>. \>.*\br
 \>+ \>- \>* \>/ \>\% \>\caret \>\& \>| \>\tilde\br
 \>! \>= \>< \>> \>+= \>-= \>*= \>/= \>\%=\br
-\>\caret= \>\&= \>|= \>\shl \>\shr \>\shr= \>\shl= \>== \>!=\br
+\>\caret= \>\&= \>|= \><< \>>> \>>>= \><<= \>== \>!=\br
 \><= \>>= \>\&\& \>|| \>++ \>-{-} \>, \>->* \>->\br
 \>and \>and_eq \>bitand \>bitor \>compl \>not \>not_eq\br
 \>or \>or_eq \>xor \>xor_eq

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -193,7 +193,7 @@ and
 \pnum
 \begin{example}
 An iostream
-\tcode{operator\shl}
+\tcode{operator<<}
 might be implemented as:\footnote{Note that in the call to
 \tcode{put}
 the stream is implicitly converted to an
@@ -1444,9 +1444,7 @@ to \tcode{pcvt}, and initializes \tcode{cvtstate} to \tcode{state}.
 Each of the standard categories includes a family of facets.
 Some of these implement formatting or parsing of a datum, for use
 by standard or users' iostream operators
-\tcode{\shl}
-and
-\tcode{\shr},
+\tcode{<<} and \tcode{>>},
 as members
 \tcode{put()}
 and
@@ -5556,9 +5554,7 @@ default is the global (presumably user-preferred) locale.
 
 \pnum
 The second is in the operators
-\tcode{\shl}
-and
-\tcode{\shr},
+\tcode{<<} and \tcode{>>},
 where a locale ``hitchhikes''
 on another object, in this case a stream, to the point where it
 is needed.

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -177,8 +177,6 @@
 \newcommand{\CppXI}{\Cpp 2011\xspace}
 \newcommand{\CppXIV}{\Cpp 2014\xspace}
 \newcommand{\opt}{{\ensuremath{_\mathit{opt}}}\xspace}
-\newcommand{\shl}{<{<}}
-\newcommand{\shr}{>{>}}
 \newcommand{\dcr}{-{-}}
 \newcommand{\bigoh}[1]{\ensuremath{\mathscr{O}(#1)}}
 

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -841,7 +841,7 @@ template<class T> constexpr bool operator!=(const T& lhs, const complex<T>& rhs)
 \tcode{rhs.real() != lhs.real() || rhs.imag() != lhs.imag()}.
 \end{itemdescr}
 
-\indexlibrarymember{operator\shr}{complex}%
+\indexlibrarymember{operator>>}{complex}%
 \begin{itemdecl}
 template<class T, class charT, class traits>
 basic_istream<charT, traits>&
@@ -885,7 +885,7 @@ Therefore, the skipping of whitespace is specified to be
 the same for each of the simpler extractions.
 \end{itemdescr}
 
-\indexlibrarymember{operator\shl}{complex}%
+\indexlibrarymember{operator<<}{complex}%
 \begin{itemdecl}
 template<class T, class charT, class traits>
 basic_ostream<charT, traits>&
@@ -1826,7 +1826,7 @@ An engine's state may be established via
  a constructor,
  a \tcode{seed} function,
  assignment,
- or a suitable \tcode{operator\shr{}}.
+ or a suitable \tcode{operator>>}.
 
 \pnum
 \tcode{E}'s specification shall define:
@@ -2013,8 +2013,8 @@ according to Clause~\ref{strings} and Clause~\ref{input.output}.
   & \tcode{!(x == y)}.
   & \bigoh{$\mbox{size of state}$}
   \\ \rowsep
-\tcode{os \shl{} x}%
-\indextext{\idxcode{operator\shl}!random number engine requirement}
+\tcode{os << x}%
+\indextext{\idxcode{operator<<}!random number engine requirement}
   & reference to the type of \tcode{os}
   & With \tcode{os.}\textit{fmtflags} set to
     \tcode{ios_base\colcol{}dec|ios_base\colcol{}left}
@@ -2029,8 +2029,8 @@ according to Clause~\ref{strings} and Clause~\ref{input.output}.
     post: The \tcode{os.}\textit{fmtflags} and fill character are unchanged.
   & \bigoh{$\mbox{size of state}$}
   \\ \rowsep
-\tcode{is \shr{} v}%
-\indextext{\idxcode{operator\shr}!random number engine requirement}
+\tcode{is >> v}%
+\indextext{\idxcode{operator>>}!random number engine requirement}
   & reference to the type of \tcode{is}
   & With \tcode{is.fmtflags}
     set to \tcode{ios_base::dec},
@@ -2041,8 +2041,8 @@ according to Clause~\ref{strings} and Clause~\ref{input.output}.
     and
     calls \tcode{is.setstate(ios::failbit)}
     (which may throw \tcode{ios::failure}~[\ref{iostate.flags}]).
-    If a textual representation written via \tcode{os \shl{} x}
-    was subsequently read via \tcode{is \shr{} v},
+    If a textual representation written via \tcode{os << x}
+    was subsequently read via \tcode{is >> v},
     then \tcode{x == v}
     provided that there have been no intervening invocations
     of \tcode{x} or of \tcode{v}.
@@ -2409,8 +2409,8 @@ according to Clauses~\ref{strings} and \ref{input.output}.
   & \tcode{!(x == y)}.
   & same as \tcode{x == y}.
   \\ \rowsep
-\tcode{os \shl{} x}
-\indextext{\idxcode{operator\shl}!random number distribution requirement}
+\tcode{os << x}
+\indextext{\idxcode{operator<<}!random number distribution requirement}
   & reference to the type of \tcode{os}
   & Writes to \tcode{os} a textual representation
     for the parameters and the additional internal data of \tcode{x}.
@@ -2418,8 +2418,8 @@ according to Clauses~\ref{strings} and \ref{input.output}.
     post: The \tcode{os.}\textit{fmtflags} and fill character are unchanged.
   &
   \\ \rowsep
-\tcode{is \shr{} d}
-\indextext{\idxcode{operator\shr}!random number distribution requirement}
+\tcode{is >> d}
+\indextext{\idxcode{operator>>}!random number distribution requirement}
   & reference to the type of \tcode{is}
   & Restores from \tcode{is}
     the parameters and additional internal data of the lvalue \tcode{d}.
@@ -2450,16 +2450,16 @@ and \tcode{CopyAssignable} (Table~\ref{tab:copyassignable}) types.
 The sequence of numbers
 produced by repeated invocations of \tcode{d(g)}
 shall be independent of any invocation of
-\tcode{os \shl{} d}
+\tcode{os << d}
 or of
 any \tcode{const} member function of \tcode{D}
 between any of the invocations \tcode{d(g)}.
 
 \pnum
-If a textual representation is written using \tcode{os \shl{} x}
+If a textual representation is written using \tcode{os << x}
 and that representation is restored
 into the same or a different object \tcode{y}
-of the same type using \tcode{is \shr{} y},
+of the same type using \tcode{is >> y},
 repeated invocations of \tcode{y(g)}
 shall produce the same sequence of numbers
 as would repeated invocations of \tcode{x(g)}.
@@ -2979,12 +2979,12 @@ The following relations shall hold:
   \tcode{t <= w},
   \tcode{l <= w},
   \tcode{w <= numeric_limits<UIntType>::digits},
-  \tcode{a <= (1u\shl{}w) - 1u},
-  \tcode{b <= (1u\shl{}w) - 1u},
-  \tcode{c <= (1u\shl{}w) - 1u},
-  \tcode{d <= (1u\shl{}w) - 1u},
+  \tcode{a <= (1u<<w) - 1u},
+  \tcode{b <= (1u<<w) - 1u},
+  \tcode{c <= (1u<<w) - 1u},
+  \tcode{d <= (1u<<w) - 1u},
 and
-  \tcode{f <= (1u\shl{}w) - 1u}.
+  \tcode{f <= (1u<<w) - 1u}.
 
 \pnum
 The textual representation%
@@ -7272,8 +7272,8 @@ applying the indicated operator to the corresponding element of the array.
 \indexlibrarymember{operator\caret=}{valarray}%
 \indexlibrarymember{operator\&=}{valarray}%
 \indexlibrarymember{operator"|=}{valarray}%
-\indexlibrarymember{operator\shl=}{valarray}%
-\indexlibrarymember{operator\shr=}{valarray}%
+\indexlibrarymember{operator<<=}{valarray}%
+\indexlibrarymember{operator>>=}{valarray}%
 \begin{itemdecl}
 valarray& operator*= (const valarray&);
 valarray& operator/= (const valarray&);
@@ -7319,8 +7319,8 @@ hand side, the behavior is undefined.
 \indexlibrarymember{operator\caret=}{valarray}%
 \indexlibrarymember{operator\&=}{valarray}%
 \indexlibrarymember{operator"|=}{valarray}%
-\indexlibrarymember{operator\shl=}{valarray}%
-\indexlibrarymember{operator\shr=}{valarray}%
+\indexlibrarymember{operator<<=}{valarray}%
+\indexlibrarymember{operator>>=}{valarray}%
 \begin{itemdecl}
 valarray& operator*= (const T&);
 valarray& operator/= (const T&);
@@ -7528,8 +7528,8 @@ Resizing invalidates all pointers and references to elements in the array.
 \indexlibrarymember{operator\caret}{valarray}%
 \indexlibrarymember{operator\&}{valarray}%
 \indexlibrarymember{operator"|}{valarray}%
-\indexlibrarymember{operator\shl}{valarray}%
-\indexlibrarymember{operator\shr}{valarray}%
+\indexlibrarymember{operator<<}{valarray}%
+\indexlibrarymember{operator>>}{valarray}%
 \begin{itemdecl}
 template<class T> valarray<T> operator*
     (const valarray<T>&, const valarray<T>&);
@@ -7580,8 +7580,8 @@ If the argument arrays do not have the same length, the behavior is undefined.%
 \indexlibrarymember{operator\caret}{valarray}%
 \indexlibrarymember{operator\&}{valarray}%
 \indexlibrarymember{operator"|}{valarray}%
-\indexlibrarymember{operator\shl}{valarray}%
-\indexlibrarymember{operator\shr}{valarray}%
+\indexlibrarymember{operator<<}{valarray}%
+\indexlibrarymember{operator>>}{valarray}%
 \begin{itemdecl}
 template<class T> valarray<T> operator* (const valarray<T>&, const T&);
 template<class T> valarray<T> operator* (const T&, const valarray<T>&);
@@ -7943,8 +7943,8 @@ object refers.
 \indexlibrarymember{operator\caret=}{slice_array}%
 \indexlibrarymember{operator\&=}{slice_array}%
 \indexlibrarymember{operator"|=}{slice_array}%
-\indexlibrarymember{operator\shl=}{slice_array}%
-\indexlibrarymember{operator\shr=}{slice_array}%
+\indexlibrarymember{operator<<=}{slice_array}%
+\indexlibrarymember{operator>>=}{slice_array}%
 \begin{itemdecl}
 void operator*= (const valarray<T>&) const;
 void operator/= (const valarray<T>&) const;
@@ -8225,8 +8225,8 @@ refers.
 \indexlibrarymember{operator\caret=}{gslice_array}%
 \indexlibrarymember{operator\&=}{gslice_array}%
 \indexlibrarymember{operator"|=}{gslice_array}%
-\indexlibrarymember{operator\shl=}{gslice_array}%
-\indexlibrarymember{operator\shr=}{gslice_array}%
+\indexlibrarymember{operator<<=}{gslice_array}%
+\indexlibrarymember{operator>>=}{gslice_array}%
 \begin{itemdecl}
 void operator*= (const valarray<T>&) const;
 void operator/= (const valarray<T>&) const;
@@ -8352,8 +8352,8 @@ object to which it refers.
 \indexlibrarymember{operator\caret=}{mask_array}%
 \indexlibrarymember{operator\&=}{mask_array}%
 \indexlibrarymember{operator"|=}{mask_array}%
-\indexlibrarymember{operator\shl=}{mask_array}%
-\indexlibrarymember{operator\shr=}{mask_array}%
+\indexlibrarymember{operator<<=}{mask_array}%
+\indexlibrarymember{operator>>=}{mask_array}%
 \begin{itemdecl}
 void operator*= (const valarray<T>&) const;
 void operator/= (const valarray<T>&) const;
@@ -8494,8 +8494,8 @@ indirection.
 \indexlibrarymember{operator\caret=}{indirect_array}%
 \indexlibrarymember{operator\&=}{indirect_array}%
 \indexlibrarymember{operator"|=}{indirect_array}%
-\indexlibrarymember{operator\shl=}{indirect_array}%
-\indexlibrarymember{operator\shr=}{indirect_array}%
+\indexlibrarymember{operator<<=}{indirect_array}%
+\indexlibrarymember{operator>>=}{indirect_array}%
 \begin{itemdecl}
 void operator*= (const valarray<T>&) const;
 void operator/= (const valarray<T>&) const;

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -2428,11 +2428,11 @@ struct A {
   void p() &&;
 };
 A& operator<<(A&&, char);
-A() << 1;                       // calls \tcode{A::operator\shl(int)}
-A() << 'c';                     // calls \tcode{operator\shl(A\&\&, char)}
+A() << 1;                       // calls \tcode{A::operator<<(int)}
+A() << 'c';                     // calls \tcode{operator<<(A\&\&, char)}
 A a;
-a << 1;                         // calls \tcode{A::operator\shl(int)}
-a << 'c';                       // calls \tcode{A::operator\shl(int)}
+a << 1;                         // calls \tcode{A::operator<<(int)}
+a << 'c';                       // calls \tcode{A::operator<<(int)}
 A().p();                        // calls \tcode{A::p()\&\&}
 a.p();                          // calls \tcode{A::p()\&}
 \end{codeblock}
@@ -2892,7 +2892,7 @@ the operator named in its
 \>new\>delete\>new[]\>delete[]\br
 \>+\>-\>*\>/\>\%\>\caret\>\&\>|\>\~\br
 \>!\>=\><\>>\>+=\>-=\>*=\>/=\>\%=\br
-\>\caret=\>\&=\>|=\>\shl\>\shr\>\shr=\>\shl=\>={=}\>!=\br
+\>\caret=\>\&=\>|=\><<\>>>\>>>=\><<=\>={=}\>!=\br
 \><=\>>=\>\&\&\>|{|}\>++\>-{-}\>,\>->*\>->\br
 \>(\,)\>[\,]
 \end{bnfkeywordtab}

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -2415,7 +2415,7 @@ template <class BiIter>
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_ostream}}%
-\indexlibrarymember{sub_match}{operator\shl}%
+\indexlibrarymember{sub_match}{operator<<}%
 \begin{itemdecl}
 template <class charT, class ST, class BiIter>
   basic_ostream<charT, ST>&

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -4233,7 +4233,7 @@ Equivalent to: \tcode{lhs.swap(rhs);}
 
 \rSec3[string.io]{Inserters and extractors}
 
-\indexlibrarymember{operator\shr}{basic_string}%
+\indexlibrarymember{operator>>}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_istream<charT, traits>&
@@ -4292,7 +4292,7 @@ which may throw
 \tcode{is}.
 \end{itemdescr}
 
-\indexlibrarymember{operator\shl}{basic_string}%
+\indexlibrarymember{operator<<}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   basic_ostream<charT, traits>&
@@ -5643,7 +5643,7 @@ template<class charT, class traits>
 
 \rSec2[string.view.io]{Inserters and extractors}
 
-\indexlibrarymember{operator\shl}{basic_string_view}%
+\indexlibrarymember{operator<<}{basic_string_view}%
 \begin{itemdecl}
 template<class charT, class traits>
   basic_ostream<charT, traits>&

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -3300,13 +3300,13 @@ until the actual
 \grammarterm{template-argument}{s}
 are known.
 For example, even though the name
-\tcode{operator\shl}
+\tcode{operator<<}
 is known within the definition of
 \tcode{printall()}
 and a declaration of it can be found in
 \tcode{<iostream>},
 the actual declaration of
-\tcode{operator\shl}
+\tcode{operator<<}
 needed to print
 \tcode{p[i]}
 cannot be known until it is known what type

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -470,7 +470,7 @@ bool operator>=(thread::id x, thread::id y) noexcept;
 \pnum\returns \tcode{!(x < y)}.
 \end{itemdescr}
 
-\indexlibrarymember{operator\shl}{thread::id}%
+\indexlibrarymember{operator<<}{thread::id}%
 \begin{itemdecl}
 template<class charT, class traits>
   basic_ostream<charT, traits>&

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -6016,7 +6016,7 @@ between an object of class
 and a value of some
 integral type, bit position \tcode{pos} corresponds to the
 \term{bit value}
-\tcode{1 \shl pos}.
+\tcode{1 << pos}.
 The integral value corresponding to two
 or more bits is the sum of their bit values.
 
@@ -6208,7 +6208,7 @@ for which the corresponding bit in \tcode{rhs} is set, and leaves all other bits
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{operator\shl=}{bitset}%
+\indexlibrarymember{operator<<=}{bitset}%
 \begin{itemdecl}
 bitset<N>& operator<<=(size_t pos) noexcept;
 \end{itemdecl}
@@ -6233,7 +6233,7 @@ value of the bit at position \tcode{I - pos}.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{operator\shr=}{bitset}%
+\indexlibrarymember{operator>>=}{bitset}%
 \begin{itemdecl}
 bitset<N>& operator>>=(size_t pos) noexcept;
 \end{itemdecl}
@@ -6561,7 +6561,7 @@ bool none() const noexcept;
 \returns \tcode{count() == 0}.
 \end{itemdescr}
 
-\indexlibrarymember{operator\shl}{bitset}%
+\indexlibrarymember{operator<<}{bitset}%
 \begin{itemdecl}
 bitset<N> operator<<(size_t pos) const noexcept;
 \end{itemdecl}
@@ -6569,10 +6569,10 @@ bitset<N> operator<<(size_t pos) const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{bitset<N>(*this) \shl= pos}.
+\tcode{bitset<N>(*this) <<= pos}.
 \end{itemdescr}
 
-\indexlibrarymember{operator\shr}{bitset}%
+\indexlibrarymember{operator>>}{bitset}%
 \begin{itemdecl}
 bitset<N> operator>>(size_t pos) const noexcept;
 \end{itemdecl}
@@ -6580,7 +6580,7 @@ bitset<N> operator>>(size_t pos) const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{bitset<N>(*this) \shr= pos}.
+\tcode{bitset<N>(*this) >>= pos}.
 \end{itemdescr}
 
 \indexlibrarymember{operator[]}{bitset}%
@@ -6680,7 +6680,7 @@ bitset<N> operator^(const bitset<N>& lhs, const bitset<N>& rhs) noexcept;
 \tcode{bitset<N>(lhs) \caret= rhs}.
 \end{itemdescr}
 
-\indexlibrarymember{operator\shr}{bitset}%
+\indexlibrarymember{operator>>}{bitset}%
 \begin{itemdecl}
 template <class charT, class traits, size_t N>
   basic_istream<charT, traits>&
@@ -6725,7 +6725,7 @@ If no characters are stored in \tcode{str}, calls
 \tcode{is}.
 \end{itemdescr}
 
-\indexlibrarymember{operator\shl}{bitset}%
+\indexlibrarymember{operator<<}{bitset}%
 \begin{itemdecl}
 template <class charT, class traits, size_t N>
   basic_ostream<charT, traits>&
@@ -6736,7 +6736,7 @@ template <class charT, class traits, size_t N>
 \pnum
 \returns
 \begin{codeblock}
-os @\shl@ x.template to_string<charT, traits, allocator<charT>>(
+os << x.template to_string<charT, traits, allocator<charT>>(
   use_facet<ctype<charT>>(os.getloc()).widen('0'),
   use_facet<ctype<charT>>(os.getloc()).widen('1'))
 \end{codeblock}
@@ -10203,7 +10203,7 @@ the deleter until all \tcode{weak_ptr} instances that share ownership with
 
 \rSec4[util.smartptr.shared.io]{\tcode{shared_ptr} I/O}
 
-\indexlibrarymember{operator\shl}{shared_ptr}%
+\indexlibrarymember{operator<<}{shared_ptr}%
 \begin{itemdecl}
 template<class E, class T, class Y>
   basic_ostream<E, T>& operator<< (basic_ostream<E, T>& os, const shared_ptr<Y>& p);


### PR DESCRIPTION
Visible differences are:

1) inserts missing whitespace:

![ws](http://eel.is/shlshr.png)

2) reorders some index entries, e.g:

![index](http://eel.is/indexdiff.png)