### PR TITLE
In math, do not needlessly wrap \tcode inside \text.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1824,11 +1824,11 @@ namespace AB {
 
 void h()
 {
-  AB::g();          // \tcode{g} is declared directly in \tcode{AB}, therefore \tcode{S} is $\{ \text{\tcode{AB::g()}} \}$ and \tcode{AB::g()} is chosen
+  AB::g();          // \tcode{g} is declared directly in \tcode{AB}, therefore \tcode{S} is $\{ \tcode{AB::g()} \}$ and \tcode{AB::g()} is chosen
 
   AB::f(1);         // \tcode{f} is not declared directly in \tcode{AB} so the rules are applied recursively to \tcode{A} and \tcode{B};
                     // namespace \tcode{Y} is not searched and \tcode{Y::f(float)} is not considered;
-                    // \tcode{S} is $\{ \text{\tcode{A::f(int)}}, \text{\tcode{B::f(char)}} \}$ and overload resolution chooses \tcode{A::f(int)}
+                    // \tcode{S} is $\{ \tcode{A::f(int)}, \tcode{B::f(char)} \}$ and overload resolution chooses \tcode{A::f(int)}
 
   AB::f('c');       // as above but resolution chooses \tcode{B::f(char)}
 
@@ -1836,10 +1836,10 @@ void h()
                     // are applied recursively to \tcode{Y} and \tcode{Z}, \tcode{S} is $\{ \}$ so the program is ill-formed
 
   AB::i++;          // \tcode{i} is not declared directly in \tcode{AB} so the rules are applied recursively to \tcode{A} and \tcode{B},
-                    // \tcode{S} is $\{ \text{\tcode{A::i}}, \text{\tcode{B::i}} \}$ so the use is ambiguous and the program is ill-formed
+                    // \tcode{S} is $\{ \tcode{A::i}, \tcode{B::i} \}$ so the use is ambiguous and the program is ill-formed
 
   AB::h(16.8);      // \tcode{h} is not declared directly in \tcode{AB} and not declared directly in \tcode{A} or \tcode{B} so the rules
-                    // are applied recursively to \tcode{Y} and \tcode{Z}, \tcode{S} is $\{ \text{\tcode{Y::h(int)}}, \text{\tcode{Z::h(double)}} \}$ and
+                    // are applied recursively to \tcode{Y} and \tcode{Z}, \tcode{S} is $\{ \tcode{Y::h(int)}, \tcode{Z::h(double)} \}$ and
                     // overload resolution chooses \tcode{Z::h(double)}
 }
 \end{codeblock}
@@ -1870,7 +1870,7 @@ namespace BC {
 
 void f()
 {
-  BC::a++;          // OK: \tcode{S} is $\{ \text{\tcode{A::a}}, \text{\tcode{A::a}} \}$
+  BC::a++;          // OK: \tcode{S} is $\{ \tcode{A::a}, \tcode{A::a} \}$
 }
 
 namespace D {
@@ -1884,7 +1884,7 @@ namespace BD {
 
 void g()
 {
-  BD::a++;          // OK: \tcode{S} is $\{ \text{\tcode{A::a}}, \text{\tcode{A::a}} \}$
+  BD::a++;          // OK: \tcode{S} is $\{ \tcode{A::a}, \tcode{A::a} \}$
 }
 \end{codeblock}
 \end{example}
@@ -1911,10 +1911,10 @@ namespace B {
 
 void f()
 {
-  A::a++;           // OK: \tcode{a} declared directly in \tcode{A}, \tcode{S} is $\{ \text{\tcode{A::a}} \}$
-  B::a++;           // OK: both \tcode{A} and \tcode{B} searched (once), \tcode{S} is $\{ \text{\tcode{A::a}} \}$
-  A::b++;           // OK: both \tcode{A} and \tcode{B} searched (once), \tcode{S} is $\{ \text{\tcode{B::b}} \}$
-  B::b++;           // OK: \tcode{b} declared directly in \tcode{B}, \tcode{S} is $\{ \text{\tcode{B::b}} \}$
+  A::a++;           // OK: \tcode{a} declared directly in \tcode{A}, \tcode{S} is $\{ \tcode{A::a} \}$
+  B::a++;           // OK: both \tcode{A} and \tcode{B} searched (once), \tcode{S} is $\{ \tcode{A::a} \}$
+  A::b++;           // OK: both \tcode{A} and \tcode{B} searched (once), \tcode{S} is $\{ \tcode{B::b} \}$
+  B::b++;           // OK: \tcode{b} declared directly in \tcode{B}, \tcode{S} is $\{ \tcode{B::b} \}$
 }
 \end{codeblock}
 \end{example}

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -824,11 +824,11 @@ is the same cv-qualification as, or a greater cv-qualification than,
 and where
 \grammarterm{conversion-type-id}
 denotes the type ``pointer to function
-of ($\text{\tcode{P}}_1, \dotsc, \text{\tcode{P}}_n$) returning \tcode{R}'',
+of ($\tcode{P}_1, \dotsc, \tcode{P}_n$) returning \tcode{R}'',
 or the type ``reference to pointer to function
-of ($\text{\tcode{P}}_1, \dotsc, \text{\tcode{P}}_n$) returning \tcode{R}'',
+of ($\tcode{P}_1, \dotsc, \tcode{P}_n$) returning \tcode{R}'',
 or the type
-``reference to function of ($\text{\tcode{P}}_1, \dotsc, \text{\tcode{P}}_n$)
+``reference to function of ($\tcode{P}_1, \dotsc, \tcode{P}_n$)
 returning \tcode{R}'', a \term{surrogate call function} with the unique name
 \grammarterm{call-function}
 and having the form

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2462,7 +2462,7 @@ template <class... Types>
 \pnum
 \remarks This function shall not participate in overload resolution
 unless \tcode{is_swappable_v<$\tcode{T}_i$>} is \tcode{true}
-for all $i$, where $0 \leq i < \text{\tcode{sizeof...(Types)}}$.
+for all $i$, where $0 \leq i < \tcode{sizeof...(Types)}$.
 The expression inside \tcode{noexcept} is equivalent to:
 
 \begin{codeblock}


### PR DESCRIPTION
The rest of the document already uses \tcode directly inside math, which works fine.

No visual difference.

(Incidentally, this helps my HTML version of the standard, which relies on MathJax, which sadly does not support \texttt inside \text inside math.)