### PR TITLE
Do not italicize colons when defining grammar non-terminals or

### DIFF
--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -353,7 +353,7 @@ int main() {
 \end{codeblock}
 \end{example}
 \begin{note}
-Consequently, destructors should generally catch exceptions and not let them propagate.
+Consequently, a destructor should generally catch exceptions and not let them propagate.
 \end{note}
 
 

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -198,7 +198,7 @@
 \newcommand{\leftshift}[1]{\ensuremath{\, \mathsf{lshift}_#1 \,}}
 
 %% Notes and examples
-\newcommand{\noteintro}[1]{[\,\textit{#1:}\space}
+\newcommand{\noteintro}[1]{[\,\textit{#1}:\space}
 \newcommand{\noteoutro}[1]{\textit{\,---\,end #1}\,]}
 \newenvironment{note}[1][Note]{\noteintro{#1}}{\noteoutro{note}\xspace}
 \newenvironment{example}[1][Example]{\noteintro{#1}}{\noteoutro{example}\xspace}
@@ -393,9 +393,9 @@
 
 \newenvironment{bnfbase}
  {
- \newcommand{\nontermdef}[1]{\nonterminal{##1}\indexgrammar{\idxgram{##1}}:}
+ \newcommand{\nontermdef}[1]{\nonterminal{##1\itcorr}\indexgrammar{\idxgram{##1}}\textnormal{:}}
  \newcommand{\terminal}[1]{{\BnfTermshape ##1}\xspace}
- \newcommand{\descr}[1]{\normalfont{##1}}
+ \newcommand{\descr}[1]{\textnormal{##1}}
  \newcommand{\bnfindentfirst}{\BnfIndent}
  \newcommand{\bnfindentinc}{\BnfInc}
  \newcommand{\bnfindentrest}{\BnfRest}


### PR DESCRIPTION
following the "[ Note" and "[ Example" introducers.

Fixes #1351.

In "Appearance" mode, diffpdf shows everything (including spacing differences caused by the upright colon). In "characters" mode, there are just six pages of differences where a word was hyphenated the other way.

Sample change:

![page](https://cloud.githubusercontent.com/assets/23412755/21868978/9a2cb838-d855-11e6-819e-54cc27e5fc0a.png)

An additional "Overfull hbox" appeared in exceptions.tex, which took a reformulation of a note to fix. (Hyphenation hints were ineffective, for unknown reasons.)