### PR TITLE
Capitalize examples where appropriate.

### DIFF
--- a/source/access.tex
+++ b/source/access.tex
@@ -600,7 +600,7 @@ A class specifies its friends, if any, by way of friend declarations.
 Such declarations give special access rights to the friends, but they
 do not make the nominated friends members of the befriending class.
 \begin{example}
-the following example illustrates the differences between
+The following example illustrates the differences between
 members and friends:
 \indextext{friend function!member function and}%
 \indextext{example!friend function}%

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -547,7 +547,7 @@ declarative region.
 
 \pnum
 \begin{example}
-in
+In
 
 \begin{codeblock}
 int j = 24;

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1242,7 +1242,7 @@ member \tcode{running} of class \tcode{process}.
 Once the static data member has been defined, it exists even if
 no objects of its class have been created.
 \begin{example}
-in the example above, \tcode{run_chain} and \tcode{running} exist even
+In the example above, \tcode{run_chain} and \tcode{running} exist even
 if no objects of class \tcode{process} are created by the program.
 \end{example}
 \end{note}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -548,7 +548,7 @@ A \grammarterm{typedef-name} is thus a synonym for another type. A
 declaration~(\ref{class.name}) or enum declaration does.
 \begin{example}
 \indextext{example!\idxcode{typedef}}%
-after
+After
 
 \begin{codeblock}
 typedef int MILES, *KLICKSP;
@@ -2628,7 +2628,7 @@ used to redefine a \grammarterm{namespace-alias} declared in that
 declarative region to refer only to the namespace to which it already
 refers.
 \begin{example}
-the following declarations are well-formed:
+The following declarations are well-formed:
 
 \begin{codeblock}
 namespace Company_with_very_long_name { @\commentellip@ }

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -465,7 +465,7 @@ the
 determines the type
 \tcode{T}.
 \begin{example}
-in the declaration
+In the declaration
 
 \begin{codeblock}
 int unsigned i;
@@ -547,7 +547,7 @@ Similarly, the optional \grammarterm{attribute-specifier-seq}~(\ref{dcl.attr.gra
 
 \pnum
 \begin{example}
-the declarations
+The declarations
 \indextext{example!\idxcode{const}}%
 \indextext{example!constant pointer}%
 \begin{codeblock}
@@ -1185,7 +1185,7 @@ is applied to this pointer,
 the result is the pointed-to $(n-1)$-dimensional array,
 which itself is immediately converted into a pointer.
 \begin{example}
-consider
+Consider
 
 \begin{codeblock}
 int x[3][5];
@@ -1381,7 +1381,7 @@ is synonymous with
 \begin{example}
 \indextext{example!ellipsis}%
 \indextext{example!variable parameter list}%
-the declaration
+The declaration
 
 \begin{codeblock}
 int printf(const char*, ...);
@@ -1502,7 +1502,7 @@ pointers to functions, references to functions, and pointers to member functions
 \pnum
 \begin{example}
 \indextext{example!function declaration}%
-the declaration
+The declaration
 
 \begin{codeblock}
 int fseek(FILE*, long, int);
@@ -1559,7 +1559,7 @@ its function declarator because that is the extent of its potential scope~(\ref{
 
 \pnum
 \begin{example}
-the declaration
+The declaration
 
 \indextext{example!declaration}%
 \begin{codeblock}
@@ -1696,7 +1696,7 @@ Default arguments will be used in calls where trailing arguments are missing.
 \pnum
 \indextext{argument!example of default}%
 \begin{example}
-the declaration
+The declaration
 
 \begin{codeblock}
 void point(int = 3, int = 4);
@@ -1806,7 +1806,7 @@ Name lookup and checking of semantic constraints for default
 arguments in function templates and in member functions of
 class templates are performed as described in~\ref{temp.inst}.
 \begin{example}
-in the following code,
+In the following code,
 \indextext{argument!example of default}%
 \tcode{g}
 will be called with the value
@@ -1911,7 +1911,7 @@ A non-static member shall not appear in a default argument unless it appears as
 the \grammarterm{id-expression} of a class member access expression (\ref{expr.ref}) or
 unless it is used to form a pointer to member (\ref{expr.unary.op}).
 \begin{example}
-the declaration of
+The declaration of
 \tcode{X::mem1()}
 in the following example is ill-formed because no object is supplied for the
 non-static member
@@ -2027,7 +2027,7 @@ A function shall be defined only in namespace or class scope.
 
 \pnum
 \begin{example}
-a simple example of a complete function definition is
+A simple example of a complete function definition is
 
 \indextext{example!function definition}%
 \begin{codeblock}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1555,7 +1555,7 @@ returns or at the end of the enclosing full-expression.
 The initialization and destruction of each parameter occurs
 within the context of the calling function.
 \begin{example}
-the access of the constructor, conversion functions or destructor is
+The access of the constructor, conversion functions or destructor is
 checked at the point of call in the calling function. If a constructor
 or destructor for a function parameter throws an exception, the search
 for a handler starts in the scope of the calling function; in
@@ -3121,7 +3121,7 @@ shall evaluate to a strictly positive value.
 The \grammarterm{expression} in a \grammarterm{noptr-new-declarator}is
 implicitly converted to \tcode{std\colcol{}size_t}.
 \begin{example}
-given the definition \tcode{int n = 42},
+Given the definition \tcode{int n = 42},
 \tcode{new float[n][5]} is well-formed (because \tcode{n} is the
 \grammarterm{expression} of a \grammarterm{noptr-new-declarator}), but
 \tcode{new float[5][n]} is ill-formed (because \tcode{n} is not a

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -164,7 +164,7 @@ implementation's output messages
 \defncontext{glvalue} type of the most derived object~(\ref{intro.object}) to which the
 glvalue refers\\
 \begin{example}
-if a pointer~(\ref{dcl.ptr}) \tcode{p} whose static type is ``pointer to
+If a pointer~(\ref{dcl.ptr}) \tcode{p} whose static type is ``pointer to
 class \tcode{B}'' is pointing to an object of class \tcode{D}, derived
 from \tcode{B} (Clause~\ref{class.derived}), the dynamic type of the
 expression \tcode{*p} is ``\tcode{D}''. References~(\ref{dcl.ref}) are

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -324,7 +324,7 @@ Each algorithm places additional requirements on the domain of
 These requirements can be inferred from the uses that algorithm
 makes of \tcode{==} and \tcode{!=}.
 \begin{example}
-the call \tcode{find(a,b,x)}
+The call \tcode{find(a,b,x)}
 is defined only if the value of \tcode{a}
 has the property \textit{p}
 defined as follows:

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -92,7 +92,7 @@ declarations with the same name and the same parameter-type-list, then
 these member function declarations can be overloaded if they differ in
 the type of their implicit object parameter.
 \begin{example}
-the following illustrates this distinction:
+The following illustrates this distinction:
 
 \begin{codeblock}
 class X {
@@ -282,7 +282,7 @@ and
 Two parameter declarations that differ only in their default arguments
 are equivalent.
 \begin{example}
-consider the following:
+Consider the following:
 
 \begin{codeblock}
 void f (int i, int j);
@@ -535,7 +535,7 @@ is the class of which the function is a member and
 is the cv-qualification on the
 member function declaration.
 \begin{example}
-for a
+For a
 \tcode{const}
 member
 function of class
@@ -1868,7 +1868,7 @@ defined in terms of constructors and is not a conversion.
 Any difference in top-level cv-qualification is
 subsumed by the initialization itself and does not constitute a conversion.
 \begin{example}
-a parameter of type
+A parameter of type
 \tcode{A}
 can be initialized from an argument of type
 \tcode{const A}.
@@ -2113,7 +2113,7 @@ that are not based on the types of the reference and the argument
 do not affect the formation of a standard conversion
 sequence, however.
 \begin{example}
-a function with an ``lvalue reference to \tcode{int}'' parameter can
+A function with an ``lvalue reference to \tcode{int}'' parameter can
 be a viable candidate even if the corresponding argument is an
 \tcode{int}
 bit-field.

--- a/source/special.tex
+++ b/source/special.tex
@@ -59,7 +59,7 @@ Often such special member functions are called implicitly.
 \indextext{access control!member function and}%
 Special member functions obey the usual access rules (Clause~\ref{class.access}).
 \begin{example}
-declaring a constructor
+Declaring a constructor
 \tcode{protected}
 ensures that only derived classes and friends can create objects using it.
 \end{example}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1480,7 +1480,7 @@ for a member function of a class template are determined by the
 \grammarterm{template-argument}{s}
 of the type of the object for which the member function is called.
 \begin{example}
-the
+The
 \grammarterm{template-argument}
 for
 \tcode{Array<T>::operator[]()}
@@ -2235,7 +2235,7 @@ template parameter list.
 Specifically, the order of the template arguments is the sequence in
 which they appear in the template parameter list.
 \begin{example}
-the template argument list for the primary template in the example
+The template argument list for the primary template in the example
 above is
 \tcode{<T1,}
 \tcode{T2,}
@@ -2568,7 +2568,7 @@ A<char>::B<int>  abci;    // uses \#1
 \pnum
 A function template defines an unbounded set of related functions.
 \begin{example}
-a family of sort functions might be declared like this:
+A family of sort functions might be declared like this:
 
 \begin{codeblock}
 template<class T> class Array { };


### PR DESCRIPTION
For consistency.