### PR TITLE
Remove stray whitespace around scope resolution operator.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2077,7 +2077,7 @@ The result of a \tcode{typeid} expression is an lvalue of static type
 \tcode{const} \tcode{std::type_info}~(\ref{type.info}) and dynamic type \tcode{const}
 \tcode{std::type_info} or \tcode{const} \term{name} where \term{name} is an
 \impldef{derived type for \tcode{typeid}} class publicly derived from
-\tcode{std\,::\,type_info} which preserves the behavior described
+\tcode{std::type_info} which preserves the behavior described
 in~\ref{type.info}.\footnote{The recommended name for such a class is
 \tcode{extended_type_info}.}
 The lifetime of the object referred to by the lvalue extends to the end

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -4541,7 +4541,7 @@ specializations required in Tables~\ref{tab:localization.category.facets}
 and~\ref{tab:localization.required.specializations}~(\ref{locale.category}).
 Their members use their
 \tcode{ios_base\&},
-\tcode{ios_base\,::\,io\-state\&},
+\tcode{ios_base::io\-state\&},
 and
 \tcode{fill}
 arguments as described in~(\ref{locale.categories}), and the

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1483,7 +1483,7 @@ of the type of the object for which the member function is called.
 the
 \grammarterm{template-argument}
 for
-\tcode{Array<T>\,::\,op\-er\-a\-tor\,[]\,()}
+\tcode{Array<T>::op\-er\-a\-tor\,[]\,()}
 will be determined by the
 \tcode{Array}
 to which the subscripting operation is applied.


### PR DESCRIPTION
![diff](http://eel.is/scoperesws.png)