### PR TITLE
[temp.deduct.type] Don't style prose as monotype.

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -7047,7 +7047,7 @@ T*
 T&
 T&&
 T[@\grammarterm{integer-constant}@]
-@\grammarterm{template-name}@<T>  (where @\grammarterm{template-name}@ refers to a class template)
+@\grammarterm{template-name}@<T>  @\textrm{(where \tcode{\grammarterm{template-name}} refers to a class template)}@
 @\term{type}@(T)
 T()
 T(T)
@@ -7062,7 +7062,7 @@ T (@\term{type}@::*)(T)
 T (T::*)()
 T (T::*)(T)
 @\term{type}@[i]
-@\grammarterm{template-name}@<i>  (where @\grammarterm{template-name}@ refers to a class template)
+@\grammarterm{template-name}@<i>  @\textrm{(where \tcode{\grammarterm{template-name}} refers to a class template)}@
 TT<T>
 TT<i>
 TT<>


### PR DESCRIPTION
![diff](http://eel.is/mono2.png)