### PR TITLE
[dcl.fct] Make bnf indentation in source match presentation.

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -1320,7 +1320,7 @@ A type of either form is a \term{function type}.\footnote{As indicated by syntax
 \indextext{declaration!function}%
 \begin{bnf}
 \nontermdef{parameter-declaration-clause}\br
-parameter-declaration-list\opt{} \terminal{...}\opt\br
+    parameter-declaration-list\opt{} \terminal{...}\opt\br
     parameter-declaration-list \terminal{, ...}
 \end{bnf}
 


### PR DESCRIPTION
No visual difference in the PDF, but it makes the source look nicer and more consistent.

(Incidentally, it makes life a tiny bit easier for cxxdraft-htmlgen.)