### PR TITLE
consistent whitespace in \tcode types

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3481,11 +3481,11 @@ or functions (\ref{dcl.fct}).
 For any object (other than a base-class subobject) of trivially copyable type
 \tcode{T}, whether or not the object holds a valid value of type
 \tcode{T}, the underlying bytes~(\ref{intro.memory}) making up the
-object can be copied into an array of \tcode{char} or \tcode{unsigned}
-\tcode{char}.\footnote{By using, for example, the library
+object can be copied into an array of \tcode{char} or
+\tcode{unsigned char}.\footnote{By using, for example, the library
 functions~(\ref{headers}) \tcode{std::memcpy} or \tcode{std::memmove}.}
-If the content of the array of \tcode{char} or \tcode{unsigned}
-\tcode{char} is copied back into the object, the object shall
+If the content of the array of \tcode{char} or \tcode{unsigned char}
+is copied back into the object, the object shall
 subsequently hold its original value. \begin{example}
 \begin{codeblock}
 #define N sizeof(T)
@@ -3521,7 +3521,7 @@ std::memcpy(t1p, t2p, sizeof(T));
 The \defn{object representation}
 \indextext{representation!object}%
 of an object of type \tcode{T} is the
-sequence of \placeholder{N} \tcode{unsigned} \tcode{char} objects taken up
+sequence of \placeholder{N} \tcode{unsigned char} objects taken up
 by the object of type \tcode{T}, where \placeholder{N} equals
 \tcode{sizeof(T)}. The
 \indextext{representation!value}%
@@ -3711,7 +3711,7 @@ There are five \defnx{standard signed integer types}{standard signed integer typ
 \indextext{type!\idxcode{long}}%
 \indextext{type!\idxcode{long long}}%
 ``\tcode{signed char}'', ``\tcode{short int}'', ``\tcode{int}'',
-``\tcode{long int}'', and ``\tcode{long} \tcode{long} \tcode{int}''. In
+``\tcode{long int}'', and ``\tcode{long long int}''. In
 this list, each type provides at least as much storage as those
 preceding it in the list.
 \indextext{type!extended signed integer}%
@@ -3744,7 +3744,7 @@ there exists a corresponding (but different)
 \indextext{type!\idxcode{unsigned long long}}%
 ``\tcode{unsigned char}'', ``\tcode{unsigned short int}'',
 ``\tcode{unsigned int}'', ``\tcode{unsigned long int}'', and
-``\tcode{unsigned} \tcode{long} \tcode{long} \tcode{int}'', each of
+``\tcode{unsigned long long int}'', each of
 which occupies the same amount of storage and has the same alignment
 requirements~(\ref{basic.align}) as the corresponding signed integer
 type\footnote{See~\ref{dcl.type.simple} regarding the correspondence between types and
@@ -3848,7 +3848,7 @@ precision as \tcode{float}, and the type \tcode{long double} provides at
 least as much precision as \tcode{double}. The set of values of the type
 \tcode{float} is a subset of the set of values of the type
 \tcode{double}; the set of values of the type \tcode{double} is a subset
-of the set of values of the type \tcode{long} \tcode{double}. The value
+of the set of values of the type \tcode{long double}. The value
 representation of floating-point types is \impldef{value representation of
 floating-point types}.
 \indextext{floating point type!implementation-defined}%
@@ -4283,7 +4283,7 @@ subaggregate or contained union),
 \item a type that is a (possibly cv-qualified) base class type of the dynamic type of
 the object,
 
-\item a \tcode{char} or \tcode{unsigned} \tcode{char} type.
+\item a \tcode{char} or \tcode{unsigned char} type.
 \end{itemize}
 
 \rSec1[basic.align]{Alignment}

--- a/source/conversions.tex
+++ b/source/conversions.tex
@@ -346,8 +346,8 @@ converted to a prvalue of type \tcode{unsigned int}.
 A prvalue of type \tcode{char16_t}, \tcode{char32_t}, or
 \tcode{wchar_t}~(\ref{basic.fundamental}) can be converted to a prvalue
 of the first of the following types that can represent all the values of
-its underlying type: \tcode{int}, \tcode{unsigned int}, \tcode{long}
-\tcode{int}, \tcode{unsigned long} \tcode{int}, \tcode{long long int},
+its underlying type: \tcode{int}, \tcode{unsigned int}, \tcode{long int},
+\tcode{unsigned long int}, \tcode{long long int},
 or \tcode{unsigned long long int}. If none of the types in that list can
 represent all the values of its underlying type, a prvalue of type
 \tcode{char16_t}, \tcode{char32_t}, or \tcode{wchar_t} can be converted
@@ -359,12 +359,12 @@ A prvalue of an unscoped enumeration type whose underlying type is not
 fixed~(\ref{dcl.enum}) can be converted to a prvalue of the first of the following
 types that can represent all the values of the enumeration (i.e., the values in the
 range $b_\text{min}$ to $b_\text{max}$ as described in~\ref{dcl.enum}): \tcode{int},
-\tcode{unsigned int}, \tcode{long} \tcode{int}, \tcode{unsigned long} \tcode{int},
+\tcode{unsigned int}, \tcode{long int}, \tcode{unsigned long int},
 \tcode{long long int}, or \tcode{unsigned long long int}. If none of the types in that
 list can represent all the values of the enumeration, a prvalue of an unscoped
 enumeration type can be converted to a prvalue of the extended integer type with lowest
-integer conversion rank~(\ref{conv.rank}) greater than the rank of \tcode{long}
-\tcode{long} in which all the values of the enumeration can be represented. If there are
+integer conversion rank~(\ref{conv.rank}) greater than the rank of \tcode{long long}
+in which all the values of the enumeration can be represented. If there are
 two such extended types, the signed one is chosen.
 
 \pnum
@@ -619,11 +619,11 @@ the same representation.
 \item The rank of a signed integer type shall be greater than the rank
 of any signed integer type with a smaller size.
 
-\item The rank of \tcode{long} \tcode{long} \tcode{int} shall be greater
-than the rank of \tcode{long} \tcode{int}, which shall be greater than
+\item The rank of \tcode{long long int} shall be greater
+than the rank of \tcode{long int}, which shall be greater than
 the rank of \tcode{int}, which shall be greater than the rank of
-\tcode{short} \tcode{int}, which shall be greater than the rank of
-\tcode{signed} \tcode{char}.
+\tcode{short int}, which shall be greater than the rank of
+\tcode{signed char}.
 
 \item The rank of any unsigned integer type shall equal the rank of the
 corresponding signed integer type.
@@ -631,8 +631,8 @@ corresponding signed integer type.
 \item The rank of any standard integer type shall be greater than the
 rank of any extended integer type with the same size.
 
-\item The rank of \tcode{char} shall equal the rank of \tcode{signed}
-\tcode{char} and \tcode{unsigned} \tcode{char}.
+\item The rank of \tcode{char} shall equal the rank of \tcode{signed char}
+and \tcode{unsigned char}.
 
 \item The rank of \tcode{bool} shall be less than the rank of all other
 standard integer types.

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -165,8 +165,8 @@ which are defined as follows:
 are performed; if the other operand does not have the same type, the expression is
 ill-formed.
 
-\item If either operand is of type \tcode{long} \tcode{double}, the
-other shall be converted to \tcode{long} \tcode{double}.
+\item If either operand is of type \tcode{long double}, the
+other shall be converted to \tcode{long double}.
 
 \item Otherwise, if either operand is \tcode{double}, the other shall be
 converted to \tcode{double}.

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -1521,7 +1521,7 @@ the effect of instantiating a template:
     is undefined unless the corresponding template argument
     is cv-unqualified and
     is one of
-    \tcode{float}, \tcode{double}, or \tcode{long} \tcode{double}.
+    \tcode{float}, \tcode{double}, or \tcode{long double}.
   \item
     that has a template type parameter
     named \tcode{IntType}
@@ -1531,23 +1531,23 @@ the effect of instantiating a template:
       \tcode{short},
       \tcode{int},
       \tcode{long},
-      \tcode{long} \tcode{long},
-      \tcode{unsigned} \tcode{short},
-      \tcode{unsigned} \tcode{int},
-      \tcode{unsigned} \tcode{long},
+      \tcode{long long},
+      \tcode{unsigned short},
+      \tcode{unsigned int},
+      \tcode{unsigned long},
       or
-      \tcode{unsigned} \tcode{long} \tcode{long}.
+      \tcode{unsigned long long}.
   \item
     that has a template type parameter
     named \tcode{UIntType}
     is undefined unless the corresponding template argument
     is cv-unqualified and
     is one of
-      \tcode{unsigned} \tcode{short},
-      \tcode{unsigned} \tcode{int},
-      \tcode{unsigned} \tcode{long},
+      \tcode{unsigned short},
+      \tcode{unsigned int},
+      \tcode{unsigned long},
       or
-      \tcode{unsigned} \tcode{long} \tcode{long}.
+      \tcode{unsigned long long}.
 \end{enumeratea}
 
 \pnum

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -382,8 +382,7 @@ character encoding rules.
 The two-argument member \tcode{assign} shall be defined identically to the
 built-in operator \tcode{=}. The two-argument members \tcode{eq}
 and \tcode{lt} shall be defined identically to the built-in operators
-\tcode{==} and \tcode{<} for type \tcode{unsigned}
-\tcode{char}.
+\tcode{==} and \tcode{<} for type \tcode{unsigned char}.
 
 \pnum
 The member


### PR DESCRIPTION
Where a type contains embedded whitespace, such as 'long long',
the tex files have been inconsistent in rendering this as
'\tcode{long long}' or '\tode{long} \tcode{long}', even within
a list of such types.

This patch consistently reduces the numbwr of \tcode macros
by combining whitespaced keywords into a single \txode element.
There may be some minimal kerning adjustments through the use of
non-proportional whitespace, but I don't immediately see any
tezt reflowing.  The end result is source for the standard that
is easier to grep.