### PR TITLE
Fix remaining uses of \Cpp macro

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1501,7 +1501,7 @@ in this International Standard.
 
 \begin{codeblock}
 #define F(a) b ## a
-int b0p = F(0p+0);  // ill-formed; equivalent to ``\tcode{int b0p = b0p + 0;}\!'' in C++ 2014
+int b0p = F(0p+0);  // ill-formed; equivalent to ``\tcode{int b0p = b0p + 0;}\!'' in \CppXIV
 \end{codeblock}
 
 \rSec2[diff.cpp14.expr]{Clause \ref{expr}: expressions}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -5305,7 +5305,7 @@ even though it does not have a nested \tcode{allocator_type}.
 \rSec1[any]{Storage for any type}
 
 \pnum
-This section describes components that C++ programs may use to perform operations on objects of a discriminated type.
+This section describes components that \Cpp programs may use to perform operations on objects of a discriminated type.
 
 \pnum
 \begin{note}


### PR DESCRIPTION
I believe this patch catches the last two places in the current
draft that should be using a variant of the \Cpp macros to
better render the 'C++' string.