### PR TITLE
[diff.expr] Remove stray paragraph break.

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -275,7 +275,6 @@ Syntactic transformation.
 Seldom.
 
 \ref{expr.cond}, \ref{expr.ass}, \ref{expr.comma}
-
 \indextext{conversion!lvalue-to-rvalue}%
 \indextext{rvalue!lvalue conversion to}%
 \indextext{lvalue}%


### PR DESCRIPTION
For consistency with all the other `\change`s.

Only visual difference is removal of the unwanted whitespace, and resulting reflow.