### PR TITLE
[dcl.ambig.res] Describe example ambiguous case more clearly.

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -350,7 +350,7 @@ rather than a
 \begin{codeblock}
 class C { };
 void f(int(C)) { }              // \tcode{void f(int(*fp)(C c)) \{ \}}
-                                // not: \tcode{void f(int C)};
+                                // not: \tcode{void f(int C) \{ \}}
 
 int g(C);
 


### PR DESCRIPTION
First I thought "hey that semicolon should be styled like the one on line 368", but then I noticed that it shouldn't be a semicolon at all.