### PR TITLE
[dcl.ptr] Remove unnecessary line break in comment in example code.

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -609,8 +609,7 @@ Each is unacceptable because it would either change the value of an object decla
 or allow it to be changed through a cv-unqualified pointer later, for example:
 
 \begin{codeblock}
-*ppc = &ci;         // OK, but would make \tcode{p} point to \tcode{ci} ...
-                    // ... because of previous error
+*ppc = &ci;         // OK, but would make \tcode{p} point to \tcode{ci} because of previous error
 *p = 5;             // clobber \tcode{ci}
 \end{codeblock}
 \end{example}


### PR DESCRIPTION
The comment easliy fits on one line:

![diff](http://eel.is/comment.png)