### PR TITLE
[expr.cond] drop redundant subclause (CWG 2316)

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6451,24 +6451,13 @@ directly\iref{dcl.init.ref} to a glvalue.
 subject to the constraint that the reference must bind directly.
 
 \item If \tcode{E2} is a prvalue or if neither of the conversion sequences above can be
-formed and at least one of the operands has (possibly cv-qualified) class type:
-\begin{itemize}
-\item if \tcode{T1} and \tcode{T2} are the same class type
-(ignoring cv-qualification) and
-\tcode{T2} is at least as cv-qualified as \tcode{T1},
-the target type is \tcode{T2},
-
-\item otherwise, if \tcode{T2} is a base class of \tcode{T1},
-the target type is \cvqual{cv1} \tcode{T2}, where \cvqual{cv1}
-denotes the cv-qualifiers of \tcode{T1},
-
-\item otherwise, the target type is the type that \tcode{E2} would have
+formed and at least one of the operands has (possibly cv-qualified) class type, the
+target type is the type that \tcode{E2} would have
 after applying the
 lvalue-to-rvalue\iref{conv.lval},
 array-to-pointer\iref{conv.array}, and
 function-to-pointer\iref{conv.func}
 standard conversions.
-\end{itemize}
 \end{itemize}
 
 Using this process, it is determined whether an implicit conversion


### PR DESCRIPTION
proposed fix for #1373 