### PR TITLE
Consistently use 'this International Standard'.

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -1203,7 +1203,7 @@ operations on containers and other sequences in parallel.
 
 \rSec2[algorithms.parallel.defns]{Terms and definitions}
 \pnum
-A \defn{parallel algorithm} is a function template listed in this standard with
+A \defn{parallel algorithm} is a function template listed in this International Standard with
 a template parameter named \tcode{ExecutionPolicy}.
 
 \pnum

--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -1369,7 +1369,7 @@ The \tcode{atomic_flag} type provides the classic test-and-set functionality. It
 Operations on an object of type \tcode{atomic_flag} shall be lock-free. \begin{note} Hence
 the operations should also be address-free. No other type requires lock-free operations,
 so the \tcode{atomic_flag} type is the minimum hardware-implemented type needed to
-conform to this International standard. The remaining types can be emulated with
+conform to this International Standard. The remaining types can be emulated with
 \tcode{atomic_flag}, though with less than ideal properties. \end{note}
 
 \pnum

--- a/source/future.tex
+++ b/source/future.tex
@@ -9,7 +9,7 @@ existing implementations.
 These are deprecated features, where
 \term{deprecated}
 is defined as:
-Normative for the current edition of the Standard,
+Normative for the current edition of this International Standard,
 but having been identified as a candidate for removal from future revisions.
 An implementation may declare library names and entities described in this section with the
 \tcode{deprecated} attribute~(\ref{dcl.attr.deprecated}).
@@ -1236,7 +1236,7 @@ then \tcode{result_type} shall be a synonym for \tcode{T::result_type};
 \pnum
 To enable old function adaptors to manipulate function objects
 that take one or two arguments,
-many of the function objects in this standard
+many of the function objects in this International Standard
 correspondingly provide \grammarterm{typedef-name}{s}
 \tcode{argument_type} and \tcode{result_type}
 for function objects that take one argument and

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -328,7 +328,7 @@ that program.
 \item
 \indextext{message!diagnostic}%
 If a program contains a violation of any diagnosable rule or an occurrence
-of a construct described in this Standard as ``conditionally-supported'' when
+of a construct described in this International Standard as ``conditionally-supported'' when
 the implementation does not support that construct, a conforming implementation
 shall issue at least one diagnostic message.
 \item
@@ -1135,7 +1135,7 @@ one specific thread, and can be accessed by a different thread only indirectly
 through a pointer or reference~(\ref{basic.compound}).} Under a hosted
 implementation, a \Cpp program can have more than one thread running
 concurrently. The execution of each thread proceeds as defined by the remainder
-of this standard. The execution of the entire program consists of an execution
+of this International Standard. The execution of the entire program consists of an execution
 of all of its threads. \begin{note} Usually the execution can be viewed as an
 interleaving of all its threads. However, some kinds of atomic operations, for
 example, allow executions inconsistent with a simple interleaving, as described
@@ -1451,7 +1451,7 @@ in \placeholder{B}.
 \pnum
 \begin{note} Compiler transformations that introduce assignments to a potentially
 shared memory location that would not be modified by the abstract machine are
-generally precluded by this standard, since such an assignment might overwrite
+generally precluded by this International Standard, since such an assignment might overwrite
 another assignment by a different thread in cases in which an abstract machine
 execution would not have encountered a data race. This includes implementations
 of data member assignment that overwrite adjacent members in separate memory
@@ -1462,7 +1462,7 @@ rules. \end{note}
 \pnum
 \begin{note} Transformations that introduce a speculative read of a potentially
 shared memory location may not preserve the semantics of the \Cpp program as
-defined in this standard, since they potentially introduce a data race. However,
+defined in this International Standard, since they potentially introduce a data race. However,
 they are typically valid in the context of an optimizing compiler that targets a
 specific machine with well-defined semantics for data races. They would be
 invalid for a hypothetical machine that is not tolerant of races or provides

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2165,7 +2165,7 @@ and the specialization meets the standard library requirements
 for the original template and is not explicitly prohibited.\footnote{Any
 library code that instantiates other library templates
 must be prepared to work adequately with any user-supplied specialization
-that meets the minimum requirements of the Standard.}
+that meets the minimum requirements of this International Standard.}
 
 \pnum
 The behavior of a \Cpp program is undefined if it declares
@@ -2206,7 +2206,7 @@ are reserved for future standardization.
 The behavior of a \Cpp program is undefined if
 it adds declarations or definitions to such a namespace.
 \begin{example} The top level namespace \tcode{std2} is reserved
-for use by future revisions of this standard. \end{example}
+for use by future revisions of this International Standard. \end{example}
 
 \rSec3[reserved.names]{Reserved names}%
 \indextext{name!reserved}
@@ -2530,7 +2530,7 @@ any of the \tcode{set_*} functions shall synchronize with subsequent calls to th
 In certain cases (replacement functions, handler functions, operations on types used to
 instantiate standard library template components), the \Cpp standard library depends on
 components supplied by a \Cpp program.
-If these components do not meet their requirements, the Standard places no requirements
+If these components do not meet their requirements, this International Standard places no requirements
 on the implementation.
 
 \pnum
@@ -2738,7 +2738,7 @@ It is unspecified whether any member functions in the \Cpp standard library are 
 For a non-virtual member function described in the \Cpp standard library,
 an implementation may declare a different set of member function signatures,
 provided that any call to the member function that would select
-an overload from the set of declarations described in this standard
+an overload from the set of declarations described in this International Standard
 behaves as if that overload were selected.
 \begin{note}
 For instance, an implementation may add parameters with default values,
@@ -2750,7 +2750,7 @@ or add additional signatures for a member function name.
 \rSec3[constexpr.functions]{Constexpr functions and constructors}
 
 \pnum
-This standard explicitly requires that certain standard library functions are
+This International Standard explicitly requires that certain standard library functions are
 \tcode{constexpr}~(\ref{dcl.constexpr}). An implementation shall not declare
 any standard library function signature as \tcode{constexpr} except for those where
 it is explicitly required.
@@ -2781,7 +2781,7 @@ original order).
 \rSec3[reentrancy]{Reentrancy}
 
 \pnum
-Except where explicitly specified in this standard, it is \impldef{which functions in
+Except where explicitly specified in this International Standard, it is \impldef{which functions in
 the \Cpp standard library may be recursively reentered} which functions in the \Cpp standard
 library may be recursively reentered.
 

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -6424,7 +6424,7 @@ may introduce data races~(\ref{res.on.data.races}).
 \begin{note}
 \indexlibrary{\idxcode{rand}!discouraged}%
 The other random
-number generation facilities in this standard~(\ref{rand}) are often preferable
+number generation facilities in this International Standard~(\ref{rand}) are often preferable
 to \tcode{rand}, because \tcode{rand}'s underlying algorithm is unspecified.
 Use of \tcode{rand} therefore continues to be non-portable, with unpredictable
 and oft-questionable quality and performance.

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1250,7 +1250,7 @@ The following macro names shall be defined by the implementation:
 \item \xname{cplusplus}\\
 The integer literal \tcode{\cppver}.
 \footnote{It is intended that future
-versions of this standard will
+versions of this International Standard will
 replace the value of this macro with a greater value.
 Non-conforming compilers should use a value with at most
 five decimal digits.}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -3228,7 +3228,7 @@ Otherwise, no diagnostic shall be issued for a template
 for which a valid specialization can be generated.
 \begin{note}
 If a template is instantiated, errors will be diagnosed according
-to the other rules in this Standard.
+to the other rules in this International Standard.
 Exactly when these errors are diagnosed is a quality of implementation issue.
 \end{note}
 \begin{example}


### PR DESCRIPTION
For consistency with all other occurrences.

A related question is whether all occurrences of "this Standard" should really say "this International Standard". (IMHO saying the latter over and over sounds pointless and pompous, but if it's to satisfy some legal requirement, perhaps we ought to do it consistently.)