### PR TITLE
[stmt.stmt], [dcl.attr.deprecated] Remove hyphen in 're-declared'

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3964,7 +3964,7 @@ an enumerator, or
 a template specialization.
 
 \pnum
-A name or entity declared without the \tcode{deprecated} attribute can later be re-declared
+A name or entity declared without the \tcode{deprecated} attribute can later be redeclared
 with the attribute and vice-versa. \begin{note} Thus, an entity initially declared without the
 attribute can be marked as deprecated by a subsequent redeclaration. However, after an entity
 is marked as deprecated, later redeclarations do not un-deprecate the entity. \end{note} 

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -48,9 +48,9 @@ A name introduced by a declaration in a \grammarterm{condition} (either
 introduced by the \grammarterm{decl-specifier-seq} or the
 \grammarterm{declarator} of the condition) is in scope from its point of
 declaration until the end of the substatements controlled by the
-condition. If the name is re-declared in the outermost block of a
+condition. If the name is redeclared in the outermost block of a
 substatement controlled by the condition, the declaration that
-re-declares the name is ill-formed.
+redeclares the name is ill-formed.
 \begin{example}
 
 \begin{codeblock}


### PR DESCRIPTION
Fixes #1378.