### PR TITLE
Use body font, not \tcode, for '#1' code line references in running t…

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -986,7 +986,7 @@ namespace N {
 \end{codeblock}
 
 The declarative regions of \tcode{T}, \tcode{U} and \tcode{V} are the
-\grammarterm{template-declaration}{s} on lines \tcode{\#1}, \tcode{\#2} and \tcode{\#3},
+\grammarterm{template-declaration}{s} on lines \#1, \#2, and \#3,
 respectively. But the names \tcode{A}, \tcode{f}, \tcode{g} and \tcode{C} all belong to
 the same declarative region --- namely, the \grammarterm{namespace-body} of \tcode{N}.
 (\tcode{g} is still considered to belong to this declarative region in spite of its
@@ -2297,10 +2297,10 @@ void g() {
 
 There are three objects named \tcode{i} in this program. The object with
 internal linkage introduced by the declaration in global scope (line
-\tcode{\#1} ), the object with automatic storage duration and no linkage
-introduced by the declaration on line \tcode{\#2}, and the object with
+\#1), the object with automatic storage duration and no linkage
+introduced by the declaration on line \#2, and the object with
 static storage duration and external linkage introduced by the
-declaration on line \tcode{\#3}. \end{example}
+declaration on line \#3. \end{example}
 
 \pnum
 When a block scope declaration of an entity with linkage is not found to

--- a/source/conversions.tex
+++ b/source/conversions.tex
@@ -294,9 +294,9 @@ then \tcode{const} is in every $\mathit{cv}_k^2$ for $0 < k < i$.
 
 \begin{note}
 If a program could assign a pointer of type \tcode{T**} to a pointer of
-type \tcode{const} \tcode{T**} (that is, if line \tcode{\#1} below were
+type \tcode{const} \tcode{T**} (that is, if line \#1 below were
 allowed), a program could inadvertently modify a \tcode{const} object
-(as it is done on line \tcode{\#2}). For example,
+(as it is done on line \#2). For example,
 
 \begin{codeblock}
 int main() {

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -2458,24 +2458,18 @@ template <auto** pp0> void g(Y<pp0>);                   // D
 
 According to the ordering rules for function templates,
 the function template
-\tcode{B}
+\placeholder{B}
 is more specialized than the function template
-\tcode{A}
+\placeholder{A}
 and
 the function template
-\tcode{D}
+\placeholder{D}
 is more specialized than the function template
-\tcode{C}.
-Therefore,
-the partial specialization
-\tcode{\#2}
-is more specialized than the partial specialization
-\tcode{\#1}
-and
-the partial specialization
-\tcode{\#4}
-is more specialized than the partial specialization
-\tcode{\#3}.
+\placeholder{C}.
+Therefore, the partial specialization \#2
+is more specialized than the partial specialization \#1
+and the partial specialization \#4
+is more specialized than the partial specialization \#3.
 \end{example}
 
 \rSec3[temp.class.spec.mfunc]{Members of class template specializations}


### PR DESCRIPTION
…ext.

Fixes #1375.