### PR TITLE
'floating-point something', not 'floating point something'

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3836,7 +3836,7 @@ ones' complement and signed magnitude representations for integral types.
 \end{example}
 
 \pnum
-There are three \defnx{floating-point}{floating point type} types:
+There are three \defnx{floating-point}{floating-point type} types:
 \indextext{type!\idxcode{float}}%
 \tcode{float},
 \indextext{type!\idxcode{double}}%
@@ -3851,7 +3851,7 @@ least as much precision as \tcode{double}. The set of values of the type
 of the set of values of the type \tcode{long} \tcode{double}. The value
 representation of floating-point types is \impldef{value representation of
 floating-point types}.
-\indextext{floating point type!implementation-defined}%
+\indextext{floating-point type!implementation-defined}%
 \begin{note}
 This International Standard imposes no requirements on the accuracy of
 floating-point operations; see also~\ref{support.limits}. 

--- a/source/conversions.tex
+++ b/source/conversions.tex
@@ -20,8 +20,8 @@ conversion, array-to-pointer conversion, and function-to-pointer
 conversion.
 
 \item Zero or one conversion from the following set: integral
-promotions, floating-point promotion, integral conversions, floating
-point conversions, floating-integral conversions, pointer conversions,
+promotions, floating-point promotion, integral conversions, floating-point
+conversions, floating-integral conversions, pointer conversions,
 pointer to member conversions, and boolean conversions.
 
 \item Zero or one function pointer conversion.
@@ -395,7 +395,7 @@ These conversions are called \term{integral promotions}.
 \rSec1[conv.fpprom]{Floating-point promotion}
 
 \pnum
-\indextext{promotion!floating point}%
+\indextext{promotion!floating-point}%
 A prvalue of type \tcode{float} can be converted to a prvalue of type
 \tcode{double}. The value is unchanged.
 
@@ -440,7 +440,7 @@ of integral conversions.
 \rSec1[conv.double]{Floating-point conversions}
 
 \pnum
-\indextext{conversion!floating point}%
+\indextext{conversion!floating-point}%
 A prvalue of floating-point type can be converted to a prvalue of
 another floating-point type. If the source value can be exactly
 represented in the destination type, the result of the conversion is

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1675,8 +1675,8 @@ or a
 non-trivial destructor, with no corresponding parameter, is conditionally-supported with
 \impldef{passing argument of class type through ellipsis} semantics. If the argument has
 integral or enumeration type that is subject to the integral
-promotions~(\ref{conv.prom}), or a floating-point type that is subject to the floating
-point promotion~(\ref{conv.fpprom}), the value of the argument is converted to the
+promotions~(\ref{conv.prom}), or a floating-point type that is subject to the
+floating-point promotion~(\ref{conv.fpprom}), the value of the argument is converted to the
 promoted type before the call. These promotions are referred to as
 the \defnx{default argument promotions}{promotion!default argument promotion}.
 

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -1378,7 +1378,7 @@ nearest the scaled value, chosen in an \impldef{choice of larger or smaller valu
 floating literal} manner.
 \indextext{literal!\idxcode{double}}%
 The type of a floating literal is \tcode{double}
-\indextext{literal!type of floating point}%
+\indextext{literal!type of floating-point}%
 unless explicitly specified by a suffix.
 \indextext{literal!\idxcode{float}}%
 \indextext{suffix!\idxcode{F}}%

--- a/source/support.tex
+++ b/source/support.tex
@@ -734,8 +734,8 @@ static constexpr int  min_exponent;
 \pnum
 Minimum negative integer such that
 \tcode{radix}
-raised to the power of one less than that integer is a normalized floating
-point number.\footnote{Equivalent to \tcode{FLT_MIN_EXP}, \tcode{DBL_MIN_EXP},
+raised to the power of one less than that integer is a normalized floating-point
+number.\footnote{Equivalent to \tcode{FLT_MIN_EXP}, \tcode{DBL_MIN_EXP},
 \tcode{LDBL_MIN_EXP}.}
 
 \pnum


### PR DESCRIPTION
Adjust occurrences that spanned a line break in the LaTeX
source and were therefore missed in commit
cd3deb891cee5436a64ff9a8f7bb304a4fcc6c00.