### PR TITLE
Remove space between period/comma and footnote reference.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1975,8 +1975,8 @@ subobject of the \tcode{D} object pointed to by \tcode{v}. Similarly, if
 \tcode{T} is ``reference to \cvqual{cv1} \tcode{B}'' and \tcode{v} has
 type \cvqual{cv2} \tcode{D} such that \tcode{B} is a base class of
 \tcode{D}, the result is the unique \tcode{B} subobject of the \tcode{D}
-object referred to by \tcode{v}.
-\footnote{The most derived object~(\ref{intro.object}) pointed or referred to by
+object referred to by \tcode{v}.\footnote{The most derived
+object~(\ref{intro.object}) pointed or referred to by
 \tcode{v} can contain other \tcode{B} objects as base classes, but these
 are ignored.}
 In both the pointer and

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -1096,9 +1096,8 @@ for every evaluation \placeholder{A} that occurs within \placeholder{F} and
 every evaluation \placeholder{B} that does not occur within \placeholder{F} but
 is evaluated on the same thread and as part of the same signal handler (if any),
 either \placeholder{A} is sequenced before \placeholder{B} or
-\placeholder{B} is sequenced before \placeholder{A}.
-\footnote{In other words, function executions do not interleave with
-each other.}
+\placeholder{B} is sequenced before \placeholder{A}.\footnote{In other words,
+function executions do not interleave with each other.}
 \begin{note}
 If \placeholder{A} and \placeholder{B} would not otherwise be sequenced then they are
 indeterminately sequenced.

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2299,8 +2299,7 @@ global function signature declared with
 external linkage in a header is reserved to the
 implementation to designate that function signature with
 \indextext{linkage!external}%
-external linkage.
-\footnote{The list of such reserved function
+external linkage.\footnote{The list of such reserved function
 signatures with external linkage includes
 \indexlibrary{\idxcode{setjmp}}%
 \tcode{setjmp(jmp_buf)},
@@ -2338,10 +2337,7 @@ a function signature with both
 and
 \indextext{\idxcode{extern ""C++""}}%
 \tcode{extern "C++"}
-linkage,
-\footnote{
-The function
-signatures declared in
+linkage,\footnote{The function signatures declared in
 \indextext{Amendment 1}%
 \indextext{\idxhdr{cuchar}}%
 \indexlibrary{\idxhdr{cuchar}}%

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -3869,8 +3869,8 @@ explicit random_device(const string& token = @\textit{implementation-defined}@);
  nondeterministic uniform random bit generator object.
  The semantics and default value of the \tcode{token}
  parameter are
- \impldef{semantics and default value of \tcode{token} parameter to \tcode{random_device} constructor}.
- \footnote{The parameter is intended
+ \impldef{semantics and default value of \tcode{token} parameter to \tcode{random_device} constructor}.%
+\footnote{The parameter is intended
    to allow an implementation to differentiate
    between different sources of randomness.
  }

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1248,8 +1248,7 @@ The following macro names shall be defined by the implementation:
 
 \indextext{__CPLUSPLUS@\xname{cplusplus}}%
 \item \xname{cplusplus}\\
-The integer literal \tcode{\cppver}.
-\footnote{It is intended that future
+The integer literal \tcode{\cppver}.\footnote{It is intended that future
 versions of this International Standard will
 replace the value of this macro with a greater value.
 Non-conforming compilers should use a value with at most


### PR DESCRIPTION
![diff](http://eel.is/footnotespace.png)