### PR TITLE
Hyphenate 'pointer-to-member' when it is an adjective.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3637,7 +3637,7 @@ a function type, not a reference type, and not \cv{}~\tcode{void}.
 
 \pnum
 Arithmetic types~(\ref{basic.fundamental}), enumeration types, pointer
-types, pointer to member types~(\ref{basic.compound}),
+types, pointer-to-member types~(\ref{basic.compound}),
 \tcode{std::nullptr_t},
 and
 cv-qualified~(\ref{basic.type.qualifier}) versions of these
@@ -3927,7 +3927,7 @@ to type \cv{}~\tcode{void}.
 \pnum
 A value of type \tcode{std::nullptr_t} is a null pointer
 constant~(\ref{conv.ptr}). Such values participate in the pointer and the
-pointer to member conversions~(\ref{conv.ptr}, \ref{conv.mem}).
+pointer-to-member conversions~(\ref{conv.ptr}, \ref{conv.mem}).
 \tcode{sizeof(std::nullptr_t)} shall be equal to \tcode{sizeof(void*)}.
 
 \pnum

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3976,11 +3976,13 @@ Each distinct enumeration constitutes a different
 \defnx{enumerated type}{type!enumerated},~\ref{dcl.enum};
 
 \item \indextext{member pointer to|see{pointer to member}}%
-\defnx{pointers-to-members}{pointer-to-member},%
+\defnx{pointers to non-static class members}{pointer-to-member},%
 \footnote{Static class members are objects or functions, and pointers to them are
 ordinary pointers to objects or functions.}
 which identify non-static members of a given
 type within objects of a given class,~\ref{dcl.mptr}.
+Pointers to data members and pointers to member functions are collectively
+called \defn{pointer-to-member} types.
 \end{itemize}
 
 \pnum

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3976,10 +3976,10 @@ Each distinct enumeration constitutes a different
 \defnx{enumerated type}{type!enumerated},~\ref{dcl.enum};
 
 \item \indextext{member pointer to|see{pointer to member}}%
-\defnx{pointers to non-static class members}{pointer to member},%
+\defnx{pointers-to-members}{pointer-to-member},%
 \footnote{Static class members are objects or functions, and pointers to them are
 ordinary pointers to objects or functions.}
-which identify members of a given
+which identify non-static members of a given
 type within objects of a given class,~\ref{dcl.mptr}.
 \end{itemize}
 

--- a/source/conversions.tex
+++ b/source/conversions.tex
@@ -22,7 +22,7 @@ conversion.
 \item Zero or one conversion from the following set: integral
 promotions, floating-point promotion, integral conversions, floating-point
 conversions, floating-integral conversions, pointer conversions,
-pointer to member conversions, and boolean conversions.
+pointer-to-member conversions, and boolean conversions.
 
 \item Zero or one function pointer conversion.
 
@@ -326,7 +326,7 @@ of \tcode{X} of type \cvqual{cv2} \tcode{T}'' if ``\cvqual{cv2}
 
 \pnum
 \begin{note}
-Function types (including those used in pointer to member function
+Function types (including those used in pointer-to-member-function
 types) are never cv-qualified (\ref{dcl.fct}).
 \end{note}
 \indextext{conversion!qualification|)}
@@ -527,21 +527,21 @@ conversion is a pointer to the base class subobject of the derived class
 object. The null pointer value is converted to the null pointer value of
 the destination type.
 
-\rSec1[conv.mem]{Pointer to member conversions}
+\rSec1[conv.mem]{Pointer-to-member conversions}
 
 \pnum
 \indextext{conversion!pointer to member}%
 \indextext{constant!null pointer}%
 \indextext{value!null member pointer}%
-A null pointer constant~(\ref{conv.ptr}) can be converted to a pointer
-to member type; the result is the \term{null member pointer value}
+A null pointer constant~(\ref{conv.ptr}) can be converted to a
+pointer-to-member type; the result is the \term{null member pointer value}
 of that type and is distinguishable from any pointer to member not
 created from a null pointer constant.
 Such a conversion is called a \term{null member pointer conversion}.
 Two null member pointer values of
 the same type shall compare equal. The conversion of a null pointer
 constant to a pointer to member of cv-qualified type is a single
-conversion, and not the sequence of a pointer to member conversion
+conversion, and not the sequence of a pointer-to-member conversion
 followed by a qualification conversion~(\ref{conv.qual}).
 
 \pnum
@@ -600,7 +600,7 @@ The result points to the member function.
 
 \pnum
 \indextext{conversion!boolean}%
-A prvalue of arithmetic, unscoped enumeration, pointer, or pointer to member
+A prvalue of arithmetic, unscoped enumeration, pointer, or pointer-to-member
 type can be converted to a prvalue of type \tcode{bool}. A zero value, null
 pointer value, or null member pointer value is converted to \tcode{false}; any
 other value is converted to \tcode{true}. For

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -919,7 +919,7 @@ or
 \begin{note}
 See also~\ref{expr.unary} and~\ref{expr.mptr.oper}.
 The type ``pointer to member'' is distinct from the type ``pointer'',
-that is, a pointer to member is declared only by the pointer to member
+that is, a pointer to member is declared only by the pointer-to-member
 declarator syntax, and never by the pointer declarator syntax.
 There is no ``reference-to-member'' type in \Cpp.
 \end{note}

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -496,8 +496,8 @@ the \grammarterm{handler} is of type \cv{}~\tcode{T} or
 \tcode{T} is an unambiguous public base class of \tcode{E}, or
 \item%
 the \grammarterm{handler} is of type \cv{}~\tcode{T} or \tcode{const T\&}
-where \tcode{T} is a pointer or pointer to member type and
-\tcode{E} is a pointer or pointer to member type
+where \tcode{T} is a pointer or pointer-to-member type and
+\tcode{E} is a pointer or pointer-to-member type
 that can be converted to \tcode{T} by one or more of
 \begin{itemize}
 
@@ -512,7 +512,7 @@ a qualification conversion~(\ref{conv.qual}), or
 \end{itemize}
 
 \item
-the \grammarterm{handler} is of type \cv{}~\tcode{T} or \tcode{const T\&} where \tcode{T} is a pointer or pointer to member type and \tcode{E} is \tcode{std::nullptr_t}.
+the \grammarterm{handler} is of type \cv{}~\tcode{T} or \tcode{const T\&} where \tcode{T} is a pointer or pointer-to-member type and \tcode{E} is \tcode{std::nullptr_t}.
 
 \end{itemize}
 
@@ -520,7 +520,7 @@ the \grammarterm{handler} is of type \cv{}~\tcode{T} or \tcode{const T\&} where 
 A
 \grammarterm{throw-expression}
 whose operand is an integer literal with value zero does not match a handler of
-pointer or pointer to member type.
+pointer or pointer-to-member type.
 A handler of reference to array or function type
 is never a match for any exception object~(\ref{expr.throw}).
 \end{note}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -274,7 +274,7 @@ both can be converted to \tcode{T3}. \end{note}
 The \defn{composite pointer type} of
 two operands \tcode{p1} and
 \tcode{p2} having types \tcode{T1} and \tcode{T2}, respectively, where at least one is a
-pointer or pointer to member type or
+pointer or pointer-to-member type or
 \tcode{std::nullptr_t}, is:
 
 \begin{itemize}
@@ -1721,8 +1721,8 @@ performed on the argument expression.
 An argument that has type \cv{}~\tcode{std::nullptr_t} is converted
 to type \tcode{void*}~(\ref{conv.ptr}).
 After these conversions, if the
-argument does not have arithmetic, enumeration, pointer, pointer to
-member, or class type, the program is ill-formed. Passing a potentially-evaluated
+argument does not have arithmetic, enumeration, pointer, pointer-to-member,
+or class type, the program is ill-formed. Passing a potentially-evaluated
 argument of class type (Clause~\ref{class}) having a non-trivial
 copy constructor, a non-trivial move constructor,
 or a
@@ -2387,7 +2387,7 @@ A prvalue of type ``pointer to member of \tcode{D} of type \cvqual{cv1}
 class (Clause~\ref{class.derived}) of \tcode{D},
 if \cvqual{cv2} is the same cv-qualification
 as, or greater cv-qualification than, \cvqual{cv1}.\footnote{Function types
-(including those used in pointer to member function
+(including those used in pointer-to-member-function
 types) are never cv-qualified; see~\ref{dcl.fct}.}
 If no valid standard conversion
 from ``pointer to member of \tcode{B} of type \tcode{T}''
@@ -2558,14 +2558,14 @@ conversion is unspecified, except in the following cases:
 
 \begin{itemize}
 \item converting a prvalue of type ``pointer to member function'' to a
-different pointer to member function type and back to its original type
-yields the original pointer to member value.
+different pointer-to-member-function type and back to its original type
+yields the original pointer-to-member value.
 
 \item converting a prvalue of type ``pointer to data member of \tcode{X}
 of type \tcode{T1}'' to the type ``pointer to data member of \tcode{Y}
 of type \tcode{T2}'' (where the alignment requirements of \tcode{T2} are
 no stricter than those of \tcode{T1}) and back to its original type
-yields the original pointer to member value.
+yields the original pointer-to-member value.
 \end{itemize}
 
 \pnum
@@ -2771,7 +2771,7 @@ The result of each of the following unary operators is a prvalue.
 
 \pnum
 \indextext{name!address of cv-qualified}%
-\indextext{expression!pointer to member constant}%
+\indextext{expression!pointer-to-member constant}%
 The result of the unary \tcode{\&} operator is a pointer to its operand.
 The operand shall be an lvalue or a \grammarterm{qualified-id}.
 If the operand is a \grammarterm{qualified-id} naming a non-static or variant member \tcode{m}
@@ -4312,7 +4312,7 @@ and \tcode{false} if it is false.
 \pnum
 The \tcode{==} (equal to) and the \tcode{!=} (not equal to) operators
 group left-to-right. The operands shall have arithmetic, enumeration, pointer,
-or pointer to member type, or type \tcode{std::nullptr_t}. The operators
+or pointer-to-member type, or type \tcode{std::nullptr_t}. The operators
 \tcode{==} and \tcode{!=} both yield \tcode{true} or \tcode{false}, i.e., a
 result of type \tcode{bool}. In each case below, the operands shall have the
 same type after the specified conversions have been applied.
@@ -4344,7 +4344,7 @@ Otherwise, the pointers compare unequal.
 \end{itemize}
 
 \pnum
-If at least one of the operands is a pointer to member, pointer to member
+If at least one of the operands is a pointer to member, pointer-to-member
 conversions~(\ref{conv.mem}) and qualification
 conversions~(\ref{conv.qual}) are performed on both operands to bring them to
 their composite pointer type (Clause~\ref{expr}).
@@ -4685,8 +4685,8 @@ are performed to bring them to their
 composite pointer type (Clause~\ref{expr}). The result is of the composite
 pointer type.
 
-\item One or both of the second and third operands have pointer to member type;
-pointer to member conversions~(\ref{conv.mem}) and qualification
+\item One or both of the second and third operands have pointer-to-member type;
+pointer-to-member conversions~(\ref{conv.mem}) and qualification
 conversions~(\ref{conv.qual}) are performed to bring them to their composite
 pointer type (Clause~\ref{expr}). The result is of the composite pointer type.
 

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -1710,8 +1710,8 @@ Such literals are prvalues and have type \tcode{bool}.
 The pointer literal is the keyword \tcode{nullptr}. It is a prvalue of type
 \tcode{std::nullptr_t}.
 \begin{note}
-\tcode{std::nullptr_t} is a distinct type that is neither a pointer type nor a pointer
-to member type; rather, a prvalue of this type is a null pointer constant and can be
+\tcode{std::nullptr_t} is a distinct type that is neither a pointer type nor a pointer-to-member type;
+rather, a prvalue of this type is a null pointer constant and can be
 converted to a null pointer value or null member pointer value. See~\ref{conv.ptr}
 and~\ref{conv.mem}.
 \end{note}

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -2040,7 +2040,7 @@ Integral conversions            &                               &               
 Floating-point conversions      &                               &                   &   \ref{conv.double}   \\ \cline{1-1}\cline{4-4}
 Floating-integral conversions   &                               &                   &   \ref{conv.fpint}    \\ \cline{1-1}\cline{4-4}
 Pointer conversions             &   \rb{Conversion}             &   \rb{Conversion} &   \ref{conv.ptr}      \\ \cline{1-1}\cline{4-4}
-Pointer to member conversions   &                               &                   &   \ref{conv.mem}      \\ \cline{1-1}\cline{4-4}
+Pointer-to-member conversions   &                               &                   &   \ref{conv.mem}      \\ \cline{1-1}\cline{4-4}
 Boolean conversions             &                               &                   &   \ref{conv.bool}     \\
 \end{floattable}
 
@@ -2796,7 +2796,7 @@ Non-member functions and static member functions
 match targets of function pointer type or
 reference to function type.
 Non-static member functions match targets of
-pointer to member function type.
+pointer-to-member-function type.
 If a non-static member function is selected, the reference to the overloaded
 function name is required to have the form of a pointer to member as
 described in~\ref{expr.unary.op}.
@@ -3648,7 +3648,7 @@ bool    operator!=(@\placeholder{T}@, @\placeholder{T}@);
 \end{codeblock}
 
 \pnum
-For every pointer to member type \tcode{\placeholder{T}} or type \tcode{std::nullptr_t} there
+For every pointer-to-member type \tcode{\placeholder{T}} or type \tcode{std::nullptr_t} there
 exist candidate operator functions of the form
 
 \begin{codeblock}
@@ -3715,7 +3715,7 @@ For every pair
 \cvqual{vq}),
 where
 \tcode{\placeholder{T}}
-is an enumeration or pointer to member type,
+is an enumeration or pointer-to-member type,
 there exist candidate operator functions of the form
 
 \begin{codeblock}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -6288,7 +6288,7 @@ the type referred to by the reference) can be more cv-qualified than
 the transformed \tcode{A}.
 \item
 The transformed \tcode{A}
-can be another pointer or pointer to member type that can be converted
+can be another pointer or pointer-to-member type that can be converted
 to the deduced
 \tcode{A}
 via a function pointer conversion~(\ref{conv.fctptr}) and/or
@@ -6336,8 +6336,7 @@ must be explicitly specified.
 \pnum
 When
 \tcode{P}
-is a function type, function pointer type, or pointer to member
-function type:
+is a function type, function pointer type, or pointer-to-member-function type:
 \begin{itemize}
 \item
 If the argument is an overload set containing one or more function templates,
@@ -6511,12 +6510,12 @@ If the original \tcode{A} is a function pointer type,
 \tcode{A} can be ``pointer to function''
 even if the deduced \tcode{A} is ``pointer to noexcept function''.
 \item
-If the original \tcode{A} is a pointer to member function type,
+If the original \tcode{A} is a pointer-to-member-function type,
 \tcode{A} can be ``pointer to member of type function''
 even if the deduced \tcode{A} is ``pointer to member of type noexcept function''.
 \item
 The deduced \tcode{A}
-can be another pointer or pointer to member type that
+can be another pointer or pointer-to-member type that
 can be converted to \tcode{A} via a qualification conversion.
 \end{itemize}
 
@@ -6529,7 +6528,7 @@ the type deduction fails.
 
 \pnum
 When the deduction process requires a qualification conversion for a
-pointer or pointer to member type as described above, the following
+pointer or pointer-to-member type as described above, the following
 process is used to determine the deduced template argument values:
 
 If
@@ -6830,7 +6829,7 @@ types, templates, and non-type values:
 A function type includes the types of each of the function parameters
 and the return type.
 \item
-A pointer to member type includes the type of the class object pointed to
+A pointer-to-member type includes the type of the class object pointed to
 and the type of the member pointed to.
 \item
 A type that is a specialization of a class template (e.g.,
@@ -7348,8 +7347,8 @@ void k2() {
 \pnum
 A
 \grammarterm{template-argument}
-can be deduced from a function, pointer to function, or pointer to
-member function type.
+can be deduced from a function, pointer to function, or
+pointer-to-member-function type.
 
 \begin{example}
 


### PR DESCRIPTION
Fixes #1369.