### PR TITLE
[cpp.pragma.op] Add missing \pnums and remove unwanted paragraph breaks.

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1386,6 +1386,7 @@ underscore.
 \indextext{macro!pragma operator}%
 \indextext{operator!pragma|see{macro, pragma operator}}
 
+\pnum
 A unary operator expression of the form:
 
 \begin{ncbnf}
@@ -1401,27 +1402,22 @@ to produce preprocessing tokens that are executed as if they were the
 \grammarterm{pp-tokens} in a pragma directive. The original four preprocessing
 tokens in the unary operator expression are removed.
 
+\pnum
 \begin{example}
-
 \begin{codeblock}
 #pragma listing on "..\listing.dir"
 \end{codeblock}
-
 can also be expressed as:
-
 \begin{codeblock}
 _Pragma ( "listing on \"..\\listing.dir\"" )
 \end{codeblock}
-
 The latter form is processed in the same way whether it appears literally
 as shown, or results from macro replacement, as in:
-
 \begin{codeblock}
 #define LISTING(x) PRAGMA(listing on #x)
 #define PRAGMA(x) _Pragma(#x)
 
 LISTING( ..\listing.dir )
 \end{codeblock}
-
 \end{example}%
 \indextext{preprocessing directives|)}


### PR DESCRIPTION
[[cpp.pragma.op]](http://eel.is/c++draft/cpp#pragma.op) currently lacks numbered paragraphs altogether.