### PR TITLE
Comment out ellipses when they mean "more code here" rather than an actual ellipsis token.

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -74,12 +74,12 @@ One exception is when a name introduced by one of the
 \grammarterm{decl-specifiers} are used in a subsequent declaration,
 they do not have the same meaning, as in
 \begin{codeblock}
-struct S { ... };
+struct S { /* ... */ };
 S S, T;                 // declare two instances of \tcode{struct S}
 \end{codeblock}
 which is not equivalent to
 \begin{codeblock}
-struct S { ... };
+struct S { /* ... */ };
 S S;
 S T;                    // error
 \end{codeblock}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -854,11 +854,11 @@ The behavior of the conversion function of \tcode{glambda} above is like
 that of the following conversion function:
 \begin{codeblock}
 struct Closure {
-  template<class T> auto operator()(T t) const { ... }
+  template<class T> auto operator()(T t) const { /* ... */ }
   template<class T> static auto lambda_call_operator_invoker(T a) {
     // forwards execution to \tcode{operator()(a)} and therefore has
     // the same return type deduced
-    ...
+    // ...
   }
   template<class T> using fptr_t =
      decltype(lambda_call_operator_invoker(declval<T>())) (*)(T);

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -349,8 +349,8 @@ An implementation can avoid this circularity by substituting equivalent
 types.
 One way to do this might be
 \begin{codeblock}
-template<class stateT> class fpos { ... };      // depends on nothing
-using _STATE = ... ;             // implementation private declaration of \tcode{stateT}
+template<class stateT> class fpos { /* ... */ };    // depends on nothing
+using _STATE = /* ... */ ;       // implementation private declaration of \tcode{stateT}
 
 using streampos = fpos<_STATE>;
 


### PR DESCRIPTION
Fixes #1390 