### PR TITLE
[tuple.creation] Fix formatting errors and capitalization in description of tuple_cat.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2052,31 +2052,31 @@ template <class... Tuples>
 
 \begin{itemdescr}
 \pnum
-In the following paragraphs, let $\tcode{T}_i$ be the $i^{th}$ type in \tcode{Tuples},
-$\tcode{U}_i$ be \tcode{remove_reference_t<Ti>}, and $tp_i$ be the $i^{th}$
+In the following paragraphs, let $\tcode{T}_i$ be the $i^\text{th}$ type in \tcode{Tuples},
+$\tcode{U}_i$ be \tcode{remove_reference_t<$\tcode{T}_i$>}, and $tp_i$ be the $i^\text{th}$
 parameter in the function parameter pack \tcode{tpls}, where all indexing is
 zero-based.
 
 \pnum
 \requires For all $i$, $\tcode{U}_i$ shall be the type
-$\cv_i$ \tcode{tuple<$Args_i...$>}, where $\cv_i$ is the (possibly empty) $i^{th}$
+$\cv_i$ \tcode{tuple<$Args_i...$>}, where $\cv_i$ is the (possibly empty) $i^\text{th}$
 cv-qualifier-seq and $Args_i$ is the parameter pack representing the element
-types in $\tcode{U}_i$. Let ${A_{ik}}$ be the ${k_i}^{th}$ type in $Args_i$. For all
+types in $\tcode{U}_i$. Let ${A_{ik}}$ be the ${k_i}^\text{th}$ type in $Args_i$. For all
 $A_{ik}$ the following requirements shall be satisfied: If $\tcode{T}_i$ is
 deduced as an lvalue reference type, then
 \tcode{is_constructible_v<$A_{ik}$, $cv_i$ $A_{ik}$\&> == true}, otherwise
-\tcode{is_constructible_v<$A_{ik}$, $cv_i A_{ik}$\&\&> == true}.
+\tcode{is_constructible_v<$A_{ik}$, $cv_i$ $A_{ik}$\&\&> == true}.
 
 \pnum
-\remarks The types in \tcode{\placeholder{Ctypes}} shall be equal to the ordered
+\remarks The types in \tcode{\placeholder{CTypes}} shall be equal to the ordered
 sequence of the extended types
 \tcode{$Args_0$..., $Args_1$...,} ... \tcode{$Args_{n-1}$...}, where $n$ is
-equal to \tcode{sizeof...(Tuples)}. Let \tcode{$e_i$...} be the $i^{th}$
+equal to \tcode{sizeof...(Tuples)}. Let \tcode{$e_i$...} be the $i^\text{th}$
 ordered sequence of tuple elements of the resulting \tcode{tuple} object
 corresponding to the type sequence $Args_i$.
 
 \pnum
-\returns A \tcode{tuple} object constructed by initializing the ${k_i}^{th}$
+\returns A \tcode{tuple} object constructed by initializing the ${k_i}^\text{th}$
 type element $e_{ik}$ in \tcode{$e_i$...} with\\
 \tcode{get<$k_i$>(std::forward<$\tcode{T}_i$>($tp_i$))} for each valid $k_i$ and
 each group $e_i$ in order.


### PR DESCRIPTION
![diff](http://eel.is/tuplecat.png)