### PR TITLE
[function.objects] removes uses of term functor

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -12797,7 +12797,7 @@ namespace std {
   // \ref{unord.hash}, hash function primary template
   template <class T> struct hash;
 
-  // \ref{func.default.traits}, default functor traits
+  // \ref{func.default.traits}, default function object traits
   template <class T = void>
   struct default_order;
 
@@ -14996,7 +14996,7 @@ is an object of type \tcode{hash<Key>} and \tcode{k} is an object of type
 user-defined specialization that depends on at least one user-defined type.
 \end{itemize}
 
-\rSec2[func.default.traits]{Default functor traits}
+\rSec2[func.default.traits]{Default function object traits}
 
 \indexlibrary{\idxcode{default_order}}%
 \begin{codeblock}


### PR DESCRIPTION
Fixes issue #1403 by removing all mentions of the term "functor". While
there is a convention to use "functor" to mean "function object" it
seems to be fading away. Also, the word "functor" has very different
meaning in Category Theory and (as a consequence of that) in many
Functional Programming languages. As a result of that use of the word
"functor" in the Standard could be confusing to the reader.