### PR TITLE
[dcl.attr.depend] Fix spacing in /**/ comments in example.

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3888,7 +3888,7 @@ program, but may result in generation of more efficient code. \end{note}
 \pnum
 \begin{example}
 \begin{codeblock}
-/* Translation unit A. */
+/* @\textrm{\textit{Translation unit A.}}@ */
 
 struct foo { int* a; int* b; };
 std::atomic<struct foo *> foo_head[10];
@@ -3902,7 +3902,7 @@ int g(int* x, int* y [[carries_dependency]]) {
   return kill_dependency(foo_array[*x][*y]);
 }
 
-/* Translation unit B. */
+/* @\textrm{\textit{Translation unit B.}}@ */
 
 [[carries_dependency]] struct foo* f(int i);
 int g(int* x, int* y [[carries_dependency]]);


### PR DESCRIPTION
![diff](http://eel.is/commentspacing.png)

(See [special.tex#1837](https://github.com/cplusplus/draft/blob/master/source/special.tex#L1837) for an example where the same trick is used for the same reason.)