### PR TITLE
[alg.heap.operations] Use \bigoh instead of \mathcal{O}.

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -4666,7 +4666,7 @@ may be removed by
 or a new element added by
 \tcode{push_heap()},
 in
-$\mathcal{O}(\log(N))$
+\bigoh{\log(N)}
 time.
 \end{itemize}
 


### PR DESCRIPTION
The \mathcal 'O' looks different from the \mathscr 'O' that \bigoh uses.

As far as I can tell, this is actually the only use of \mathcal in the document.