### PR TITLE
[dcl.enum] Italicize 'unscoped enumeration' in its definition.

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1998,14 +1998,12 @@ the declaration shall be an explicit specialization~(\ref{temp.expl.spec}).
 \pnum
 \indextext{constant!enumeration}%
 \indextext{enumeration}%
-\indextext{enumeration!unscoped}%
-\indextext{enumeration!scoped}%
 The enumeration type declared with an \grammarterm{enum-key}
-of only \tcode{enum} is an \term{}{unscoped enumeration},
+of only \tcode{enum} is an \defnx{unscoped enumeration}{enumeration!unscoped},
 and its \grammarterm{enumerator}{s} are \term{unscoped enumerators}.
 The \grammarterm{enum-key}{s} \tcode{enum class} and
 \tcode{enum struct} are semantically equivalent; an enumeration
-type declared with one of these is a \term{scoped enumeration},
+type declared with one of these is a \defnx{scoped enumeration}{enumeration!scoped},
 and its \grammarterm{enumerator}{s} are \term{scoped enumerators}.
 The optional \grammarterm{identifier} shall not be omitted in the declaration of a scoped enumeration.
 The \grammarterm{type-specifier-seq} of an \grammarterm{enum-base}


### PR DESCRIPTION
Mainly by removing the stray curlies in \term{}{unscoped enumeration}, but I took the opportunity to also merge it with its corresponding index entry, into a \defnx. (And then the same for "scoped enumeration").
