### PR TITLE
[valarray.members] Style unary minus sign as math symbol, not as hyphen.

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -7490,7 +7490,7 @@ This function returns an object of class
 \tcode{valarray<T>}
 of length
 \tcode{size()}
-that is a circular shift of \tcode{*this}. If element zero is taken as the leftmost element, a non-negative value of \emph{n} shifts the elements circularly left \emph{n} places and a negative value of \emph{n} shifts the elements circularly right \emph{-n} places.
+that is a circular shift of \tcode{*this}. If element zero is taken as the leftmost element, a non-negative value of $n$ shifts the elements circularly left $n$ places and a negative value of $n$ shifts the elements circularly right $-n$ places.
 \end{itemdescr}
 
 \indexlibrarymember{apply}{valarray}%


### PR DESCRIPTION
By not abusing \emph for math. Diff:

![diff](http://eel.is/mathemph.png)