### PR TITLE
[support.types] Properly describe <cstddef> header

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -63,6 +63,16 @@ namespace std {
 #define offsetof(P, D) @\seebelow@
 \end{codeblock}
 
+\pnum
+The contents and meaning of the header \tcode{<cstddef>} are the same as
+the C standard library header \tcode{<stddef.h>},
+except that it does not declare the type \tcode{wchar_t},
+and except as noted in
+\ref{support.types.nullptr} and
+\ref{support.types.layout}.
+
+\xref ISO C 7.19
+
 \rSec2[cstdlib.syn]{Header \tcode{<cstdlib>} synopsis}
 
 \indextext{\idxhdr{cstdlib}}%


### PR DESCRIPTION
After the synopsis for <cstddef>, add a sentence (cloned from cstdlib.syn)
that the contents are the same as <stddef.h> except for wchar_t,
[support.types.nullptr], and [support.types.layout].

Fixes #1404.