### PR TITLE
Change the `reference`, `pointer` etc typedefs in `string_view` to us…

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -4744,10 +4744,10 @@ public:
   // types
   using traits_type            = traits;
   using value_type             = charT;
-  using pointer                = charT*;
-  using const_pointer          = const charT*;
-  using reference              = charT&;
-  using const_reference        = const charT&;
+  using pointer                = value_type*;
+  using const_pointer          = const value_type*;
+  using reference              = value_type&;
+  using const_reference        = const value_type&;
   using const_iterator         = @\impdefx{type of \tcode{basic_string_view::const_iterator}}@; // see \ref{string.view.iterators}
   using iterator               = const_iterator;@\footnote{Because \tcode{basic_string_view} refers to a constant sequence, \tcode{iterator} and \tcode{const_iterator} are the same type.}@
   using const_reverse_iterator = reverse_iterator<const_iterator>;


### PR DESCRIPTION
…e `value_type` rather than `charT`

This is a cut down version of https://github.com/cplusplus/draft/pull/1411, to ensure that it is editorial