### PR TITLE
Don't parenthesize \refs after 'in'/'of'/'notwithstanding'.

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1727,7 +1727,7 @@ associated with any particular object.
 \end{example}
 \begin{note}
 Initialization of unions with no user-declared constructors is described
-in~(\ref{dcl.init.aggr}).
+in~\ref{dcl.init.aggr}.
 \end{note}
 
 \pnum

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -515,7 +515,7 @@ The algorithm \tcode{lexicographical_compare()} is defined in Clause~\ref{algori
 \end{note}
 
 \pnum
-All of the containers defined in this Clause and in~(\ref{basic.string}) except \tcode{array}
+All of the containers defined in this Clause and in~\ref{basic.string} except \tcode{array}
 meet the additional requirements of an allocator-aware container, as described in
 Table~\ref{tab:containers.allocatoraware}.
 
@@ -717,7 +717,7 @@ consider the following functions to be \tcode{const}: \tcode{begin}, \tcode{end}
 associative or unordered associative containers, \tcode{operator[]}.
 
 \pnum
-Notwithstanding~(\ref{res.on.data.races}), implementations are required to avoid data
+Notwithstanding~\ref{res.on.data.races}, implementations are required to avoid data
 races when the contents of the contained object in different elements in the same
 container, excepting \tcode{vector<bool>}, are modified concurrently.
 
@@ -5934,13 +5934,13 @@ satisfies all of the requirements of a container, of a reversible container~(\re
 an associative container~(\ref{associative.reqmts}), and of an allocator-aware container (Table~\ref{tab:containers.allocatoraware}).
 A
 \tcode{map}
-also provides most operations described in~(\ref{associative.reqmts})
+also provides most operations described in~\ref{associative.reqmts}
 for unique keys.
 This means that a
 \tcode{map}
 supports the
 \tcode{a_uniq}
-operations in~(\ref{associative.reqmts})
+operations in~\ref{associative.reqmts}
 but not the
 \tcode{a_eq}
 operations.
@@ -6467,13 +6467,13 @@ container~(\ref{associative.reqmts}), and of an allocator-aware container
 (Table~\ref{tab:containers.allocatoraware}).
 A
 \tcode{multimap}
-also provides most operations described in~(\ref{associative.reqmts})
+also provides most operations described in~\ref{associative.reqmts}
 for equal keys.
 This means that a
 \tcode{multimap}
 supports the
 \tcode{a_eq}
-operations in~(\ref{associative.reqmts})
+operations in~\ref{associative.reqmts}
 but not the
 \tcode{a_uniq}
 operations.
@@ -6777,13 +6777,13 @@ container~(\ref{associative.reqmts}), and of an allocator-aware container
 (Table~\ref{tab:containers.allocatoraware}).
 A
 \tcode{set}
-also provides most operations described in~(\ref{associative.reqmts})
+also provides most operations described in~\ref{associative.reqmts}
 for unique keys.
 This means that a
 \tcode{set}
 supports the
 \tcode{a_uniq}
-operations in~(\ref{associative.reqmts})
+operations in~\ref{associative.reqmts}
 but not the
 \tcode{a_eq}
 operations.
@@ -7045,13 +7045,13 @@ reversible container~(\ref{container.requirements}), of an associative
 container~(\ref{associative.reqmts}), and of an allocator-aware container
 (Table~\ref{tab:containers.allocatoraware}).
 \tcode{multiset}
-also provides most operations described in~(\ref{associative.reqmts})
+also provides most operations described in~\ref{associative.reqmts}
 for duplicate keys.
 This means that a
 \tcode{multiset}
 supports the
 \tcode{a_eq}
-operations in~(\ref{associative.reqmts})
+operations in~\ref{associative.reqmts}
 but not the
 \tcode{a_uniq}
 operations.

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2187,7 +2187,7 @@ declared in the scope that immediately contains the \grammarterm{enum-specifier}
 Each scoped \grammarterm{enumerator} is declared in the scope of the
 enumeration.
 These names obey the scope rules defined for all names
-in~(\ref{basic.scope}) and~(\ref{basic.lookup}). \begin{example}
+in~\ref{basic.scope} and~\ref{basic.lookup}. \begin{example}
 \begin{codeblock}
 enum direction { left='l', right='r' }; 
 

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -13827,7 +13827,7 @@ Two paths are considered to resolve to the same file system entity if two
   and equal \tcode{st_ino} values.
 
 \pnum
-\throws As specified in~(\ref{fs.err.report}).
+\throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -3937,7 +3937,7 @@ Their members use their
 \tcode{ios_base::iostate\&},
 and
 \tcode{fill}
-arguments as described in~(\ref{locale.categories}), and the
+arguments as described in~\ref{locale.categories}, and the
 \tcode{ctype<>}
 facet, to determine formatting details.
 
@@ -4545,7 +4545,7 @@ Their members use their
 \tcode{ios_base::io\-state\&},
 and
 \tcode{fill}
-arguments as described in~(\ref{locale.categories}), and the
+arguments as described in~\ref{locale.categories}, and the
 \tcode{moneypunct<>}
 and
 \tcode{ctype<>}

--- a/source/support.tex
+++ b/source/support.tex
@@ -1678,7 +1678,7 @@ void  operator delete[](void* ptr, void*) noexcept;
 \rSec2[new.delete]{Storage allocation and deallocation}
 
 \pnum
-Except where otherwise specified, the provisions of~(\ref{basic.stc.dynamic})
+Except where otherwise specified, the provisions of~\ref{basic.stc.dynamic}
 apply to the library versions of \tcode{operator new} and \tcode{op\-er\-a\-tor
 delete}.
 If the value of an alignment argument
@@ -2202,7 +2202,7 @@ respectively.
 \pnum
 These functions are reserved; a \Cpp program may not define functions that displace
 the versions in the \Cpp standard library~(\ref{constraints}).
-The provisions of~(\ref{basic.stc.dynamic}) do not apply to these reserved
+The provisions of~\ref{basic.stc.dynamic} do not apply to these reserved
 placement forms of \tcode{operator new} and \tcode{operator delete}.
 
 \indexlibrary{\idxcode{new}!\idxcode{operator}}%

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -131,7 +131,7 @@ instantiation~(\ref{temp.decls}) and must also obey the one-definition rule.
 \pnum
 A class template shall not have the same name as any other
 template, class, function, variable, enumeration, enumerator, namespace, or
-type in the same scope~(\ref{basic.scope}), except as specified in~(\ref{temp.class.spec}).
+type in the same scope~(\ref{basic.scope}), except as specified in~\ref{temp.class.spec}.
 Except that a function template can be overloaded either by non-template
 functions~(\ref{dcl.fct}) with the same name or by other function templates
 with the same name~(\ref{temp.over}),


### PR DESCRIPTION
For consistency with the rest of the document.