### PR TITLE
Use columns=fullflexible listings option.

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -517,7 +517,7 @@ Example:
 enum e { A };
 sizeof(A) == sizeof(int)        // in C
 sizeof(A) == sizeof(e)          // in \Cpp
-/* @\textit{\textrm{and \tcode{sizeof(int)} is not necessarily equal to \tcode{sizeof(e)}}}@ */
+/* and @sizeof(int)@ is not necessarily equal to @sizeof(e)@ */
 \end{codeblock}
 
 \rationale
@@ -638,8 +638,8 @@ Example:
 int x[99];
 void f() {
   struct x { int a; };
-  sizeof(x);  /* @\textit{\textrm{size of the array in C}}@ */
-  /* @\textit{\textrm{size of the struct in \Cpp}}@ */
+  sizeof(x);  /* size of the array in C */
+  /* size of the struct in @\textit{\textrm{\Cpp}}@ */
 }
 \end{codeblock}
 \rationale

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -320,7 +320,7 @@
         xleftmargin=1em,
         showstringspaces=false,
         commentstyle=\itshape\rmfamily,
-        columns=flexible,
+        columns=fullflexible,
         keepspaces=true,
         texcl=true}
 

--- a/source/special.tex
+++ b/source/special.tex
@@ -1834,7 +1834,7 @@ default member initializer is ignored.
 % ligature), so we fix it up manually.
 \begin{codeblock}
 struct A {
-  int i = /* @\textrm{\textit{some integer expression with side effects}}@ */ ;
+  int i = /* some integer expression with side effects */ ;
   A(int arg) : i(arg) { }
   // ...
 };


### PR DESCRIPTION
1. Removes the need to use `\textit{\textrm{...}}`to prevent the `columns=flexible` listings option from inserting unwanted spaces.
2. Improves spacing in a few places where that workaround was not yet used.

[diffs.pdf](http://eel.is/fullflexiblediffs.pdf)
