### PR TITLE
[cpp.preprocessor] Remove additional "implementation defined" index entries.

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1283,13 +1283,11 @@ The presumed line number (within the current source file) of the current source 
 \footnote{The presumed line number can be changed by the \tcode{\#line} directive.}
 
 \indextext{__STDC_HOSTED__@\mname{STDC_HOSTED}}%
-\indextext{__STDC_HOSTED__@\mname{STDC_HOSTED}!implementation-defined}%
 \item \mname{STDC_HOSTED}\\
 The integer literal \tcode{1} if the implementation is a hosted
 implementation or the integer literal \tcode{0} if it is not.
 
 \indextext{__STDCPP_DEFAULT_NEW_ALIGNMENT__@\mname{STDCPP_DEFAULT_NEW_ALIGNMENT}}%
-\indextext{__STDCPP_DEFAULT_NEW_ALIGNMENT__@\mname{STDCPP_DEFAULT_NEW_ALIGNMENT}!implementation-defined}%
 \item \mname{STDCPP_DEFAULT_NEW_ALIGNMENT}\\
 An integer literal of type \tcode{std\colcol{}size_t}
 whose value is the alignment guaranteed
@@ -1317,26 +1315,22 @@ The following macro names are conditionally defined by the implementation:
 
 \begin{description}
 \indextext{__STDC__@\mname{STDC}}%
-\indextext{__STDC__@\mname{STDC}!implementation-defined}%
 \item \mname{STDC}\\
 Whether \mname{STDC} is predefined and if so, what its value is,
 are \impldef{definition and meaning of \mname{STDC}}.
 
 \indextext{__STDC_MB_MIGHT_NEQ_WC__@\mname{STDC_MB_MIGHT_NEQ_WC}}%
-\indextext{__STDC_MB_MIGHT_NEQ_WC__@\mname{STDC_MB_MIGHT_NEQ_WC}!implementation-defined}%
 \item \mname{STDC_MB_MIGHT_NEQ_WC}\\
 The integer literal \tcode{1}, intended to indicate that, in the encoding for
 \tcode{wchar_t}, a member of the basic character set need not have a code value equal to
 its value when used as the lone character in an ordinary character literal.
 
 \indextext{__STDC_VERSION__@\mname{STDC_VERSION}}%
-\indextext{__STDC_VERSION__@\mname{STDC_VERSION}!implementation-defined}%
 \item \mname{STDC_VERSION}\\
 Whether \mname{STDC_VERSION} is predefined and if so, what its value is,
 are \impldef{definition and meaning of \mname{STDC_VERSION}}.
 
 \indextext{__STDC_ISO_10646__@\mname{STDC_ISO_10646}}%
-\indextext{__STDC_ISO_10646__@\mname{STDC_ISO_10646}!implementation-defined}%
 \item \mname{STDC_ISO_10646}\\
 An integer literal of the form \tcode{yyyymmL} (for example,
 \tcode{199712L}).
@@ -1347,13 +1341,11 @@ the characters that are defined by ISO/IEC 10646, along with
 all amendments and technical corrigenda as of the specified year and month.
 
 \indextext{__STDCPP_STRICT_POINTER_SAFETY__@\mname{STDCPP_STRICT_POINTER_SAFETY}}%
-\indextext{__STDCPP_STRICT_POINTER_SAFETY__@\mname{STDCPP_STRICT_POINTER_SAFETY}!implementation-defined}%
 \item \mname{STDCPP_STRICT_POINTER_SAFETY}\\
 Defined, and has the value integer literal 1, if and only if the implementation
 has strict pointer safety~(\ref{basic.stc.dynamic.safety}).
 
 \indextext{__STDCPP_THREADS__@\mname{STDCPP_THREADS}}%
-\indextext{__STDCPP_THREADS__@\mname{STDCPP_THREADS}!implementation-defined}%
 \item \mname{STDCPP_THREADS}\\
 Defined, and has the value integer literal 1, if and only if a program
 can have more than one thread of execution~(\ref{intro.multithread}).


### PR DESCRIPTION
![diffs](http://eel.is/impdef.png)

These entries don't seem to add a lot of value.