### PR TITLE
[intro] Uncapitalize index entries for 'sequenced before' and 'evaluate'.

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -1002,7 +1002,7 @@ glvalue~(\ref{basic.lval}), modifying an object, calling a library I/O
 function, or calling a function that does any of those operations are
 all
 \defn{side effects}, which are changes in the state of the execution
-environment. \defn{Evaluation} of an expression (or a
+environment. \defnx{Evaluation}{evaluation} of an expression (or a
 subexpression) in general includes both value computations (including
 determining the identity of an object for glvalue evaluation and fetching
 a value previously assigned to an object for prvalue evaluation) and
@@ -1013,7 +1013,7 @@ by the call (such as the I/O itself) or by the \tcode{volatile} access
 may not have completed yet.
 
 \pnum
-\defn{Sequenced before} is an asymmetric, transitive, pair-wise relation between
+\defnx{Sequenced before}{sequenced before} is an asymmetric, transitive, pair-wise relation between
 evaluations executed by a single thread~(\ref{intro.multithread}), which induces
 a partial order among those evaluations. Given any two evaluations \placeholder{A} and
 \placeholder{B}, if \placeholder{A} is sequenced before \placeholder{B}


### PR DESCRIPTION
Btw, while looking at capitalized index entries, I also noticed a [weird index entry](https://github.com/cplusplus/draft/blob/master/source/overloading.tex#L334) for "Ben". Is that one an inside joke or reference of some kind?
