### PR TITLE
[expr.mptr.oper] Use defined term 'null member pointer value'.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3942,7 +3942,7 @@ whose second operand is a pointer to a data member is an lvalue if the first
 operand is an lvalue and an xvalue otherwise. The result of a \tcode{.*} expression whose
 second operand is a pointer to a member function is a prvalue.
 If the second operand is the null
-pointer to member value~(\ref{conv.mem}), the behavior is undefined.
+member pointer value~(\ref{conv.mem}), the behavior is undefined.
 
 \rSec1[expr.mul]{Multiplicative operators}%
 \indextext{expression!multiplicative operators}%


### PR DESCRIPTION
See the definition at [conversions.tex#L536](https://github.com/cplusplus/draft/blob/master/source/conversions.tex#L536)