### PR TITLE
[multibyte.strings] Move punctuation out of \term.

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -829,13 +829,10 @@ is a static \ntbs.}
 \rSec5[multibyte.strings]{Multibyte strings}
 
 \pnum
-A
 \indextext{NTBS}%
 \indextext{NTMBS}%
-\term{null-terminated multibyte string,}
-or \ntmbs,
-\indextext{string!null-terminated multibyte}%
-is an \ntbs that constitutes a
+A \defnx{null-terminated multibyte string}{string!null-terminated multibyte},
+or \ntmbs, is an \ntbs that constitutes a
 sequence of valid multibyte characters, beginning and ending in the initial
 shift state.\footnote{An \ntbs that contains characters only from the
 basic execution character set is also an \ntmbs.


### PR DESCRIPTION
I took the opportunity to also merge it with its corresponding \indextext, into a \defnx.

Only visual difference is that the comma is unitalicized.