### PR TITLE
Remove \xspace

### DIFF
--- a/source/access.tex
+++ b/source/access.tex
@@ -200,7 +200,7 @@ Member declarations can be labeled by an
 (\ref{class.derived}):
 
 \begin{ncbnftab}
-access-specifier \terminal{:} member-specification\opt
+access-specifier \terminal{:} member-specification\opt{}
 \end{ncbnftab}
 
 An

--- a/source/access.tex
+++ b/source/access.tex
@@ -200,7 +200,7 @@ Member declarations can be labeled by an
 (\ref{class.derived}):
 
 \begin{ncbnftab}
-access-specifier \terminal{:} member-specification\opt{}
+access-specifier \terminal{:} \opt{member-specification}
 \end{ncbnftab}
 
 An

--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -4407,10 +4407,10 @@ sorted with respect to \tcode{oper\-ator<} or \tcode{comp}.
 The resulting range shall not overlap with either of the original ranges.
 
 \pnum
-\effects\ Copies all the elements of the two ranges \range{first1}{last1} and
+\effects Copies all the elements of the two ranges \range{first1}{last1} and
 \range{first2}{last2} into the range \range{result}{result_last}, where \tcode{result_last}
 is \tcode{result + (last1 - first1) + (last2 - first2)}, such that the resulting range satisfies
-\tcode{is_sorted(result, result_last)} or \tcode{is_sorted(result, result_last, comp)}, respectively.
+\tcode{is_sorted(result, result_last)} or \tcode{is_sorted(\brk{}result, result_last, comp)}, respectively.
 
 \pnum
 \returns

--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -4,7 +4,7 @@
 \rSec1[algorithms.general]{General}
 
 \pnum
-This Clause describes components that \Cpp programs may use to perform
+This Clause describes components that \Cpp{} programs may use to perform
 algorithmic operations on containers\iref{containers} and other sequences.
 
 \pnum
@@ -1226,7 +1226,7 @@ return distance(a, b);
 \rSec1[algorithms.parallel]{Parallel algorithms}
 
 \pnum
-This section describes components that \Cpp programs may use to perform
+This section describes components that \Cpp{} programs may use to perform
 operations on containers and other sequences in parallel.
 
 \rSec2[algorithms.parallel.defns]{Terms and definitions}

--- a/source/back.tex
+++ b/source/back.tex
@@ -35,7 +35,7 @@ corresponding section number and page number, in alphabetical order by label.\\}
 \input{xrefdelta}
 \renewcommand{\glossaryname}{Cross references from ISO \CppXVII}
 \renewcommand{\preglossaryhook}{All section labels from
-ISO \CppXVII (ISO/IEC 14882:2017, \doccite{Programming Languages --- \Cpp})
+ISO \CppXVII{} (ISO/IEC 14882:2017, \doccite{Programming Languages --- \Cpp{}})
 are present in this document, with the exceptions described below.\\}
 \renewcommand{\leftmark}{\glossaryname}
 {

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -687,7 +687,7 @@ The point of declaration of a class first declared in an
 \item for a declaration of the form
 
 \begin{ncbnf}
-class-key attribute-specifier-seq\opt{} identifier \terminal{;}
+class-key \opt{attribute-specifier-seq} identifier \terminal{;}
 \end{ncbnf}
 
 the \grammarterm{identifier} is declared to be a
@@ -1664,7 +1664,7 @@ up as types in the scope designated by the
 \grammarterm{qualified-id} of the form:
 
 \begin{ncbnf}
-nested-name-specifier\opt{} class-name \terminal{::} \terminal{\tilde} class-name
+\opt{nested-name-specifier} class-name \terminal{::} \terminal{\tilde} class-name
 \end{ncbnf}
 
 the second \grammarterm{class-name} is looked up in the same scope as the
@@ -2024,7 +2024,7 @@ If the \grammarterm{elaborated-type-specifier} has no
 following form:
 
 \begin{ncbnf}
-class-key attribute-specifier-seq\opt{} identifier \terminal{;}
+class-key \opt{attribute-specifier-seq} identifier \terminal{;}
 \end{ncbnf}
 
 the \grammarterm{identifier} is looked up according
@@ -2039,7 +2039,7 @@ declared \grammarterm{type-name}, or if the
 form:
 
 \begin{ncbnf}
-class-key attribute-specifier-seq\opt{} identifier \terminal{;}
+class-key \opt{attribute-specifier-seq} identifier \terminal{;}
 \end{ncbnf}
 
 the \grammarterm{elaborated-type-specifier} is a declaration that
@@ -2205,7 +2205,7 @@ of a sequence of declarations.
 
 \begin{bnf}
 \nontermdef{translation-unit}\br
-    declaration-seq\opt{}
+    \opt{declaration-seq}
 \end{bnf}
 
 \pnum

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -687,7 +687,7 @@ The point of declaration of a class first declared in an
 \item for a declaration of the form
 
 \begin{ncbnf}
-class-key attribute-specifier-seq\opt identifier \terminal{;}
+class-key attribute-specifier-seq\opt{} identifier \terminal{;}
 \end{ncbnf}
 
 the \grammarterm{identifier} is declared to be a
@@ -1664,7 +1664,7 @@ up as types in the scope designated by the
 \grammarterm{qualified-id} of the form:
 
 \begin{ncbnf}
-nested-name-specifier\opt class-name \terminal{::} \terminal{\tilde} class-name
+nested-name-specifier\opt{} class-name \terminal{::} \terminal{\tilde} class-name
 \end{ncbnf}
 
 the second \grammarterm{class-name} is looked up in the same scope as the
@@ -2024,7 +2024,7 @@ If the \grammarterm{elaborated-type-specifier} has no
 following form:
 
 \begin{ncbnf}
-class-key attribute-specifier-seq\opt identifier \terminal{;}
+class-key attribute-specifier-seq\opt{} identifier \terminal{;}
 \end{ncbnf}
 
 the \grammarterm{identifier} is looked up according
@@ -2039,7 +2039,7 @@ declared \grammarterm{type-name}, or if the
 form:
 
 \begin{ncbnf}
-class-key attribute-specifier-seq\opt identifier \terminal{;}
+class-key attribute-specifier-seq\opt{} identifier \terminal{;}
 \end{ncbnf}
 
 the \grammarterm{elaborated-type-specifier} is a declaration that
@@ -2205,7 +2205,7 @@ of a sequence of declarations.
 
 \begin{bnf}
 \nontermdef{translation-unit}\br
-    declaration-seq\opt
+    declaration-seq\opt{}
 \end{bnf}
 
 \pnum

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2479,7 +2479,7 @@ program is run. If
 \tcode{argv[0]} through \tcode{argv[argc-1]} as pointers to the initial
 characters of null-terminated multibyte strings (\ntmbs{}s)\iref{multibyte.strings}
 and \tcode{argv[0]} shall be the pointer to
-the initial character of a \ntmbs that represents the name used to
+the initial character of a \ntmbs{} that represents the name used to
 invoke the program or \tcode{""}. The value of \tcode{argc} shall be
 non-negative. The value of \tcode{argv[argc]} shall be 0. \begin{note} It
 is recommended that any further (optional) parameters be added after

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4,11 +4,11 @@
 \gramSec[gram.basic]{Basic concepts}
 
 \pnum
-\begin{note} This Clause presents the basic concepts of the \Cpp language.
+\begin{note} This Clause presents the basic concepts of the \Cpp{} language.
 It explains the difference between an object and a
 name and how they relate to the value categories for expressions.
 It introduces the concepts of a
-declaration and a definition and presents \Cpp's
+declaration and a definition and presents \Cpp{}'s
 notion of type, scope, linkage, and
 storage duration. The mechanisms for starting and
 terminating a program are discussed. Finally, this Clause presents the
@@ -206,7 +206,7 @@ using N::d;                     // declares \tcode{d}
 \pnum
 \begin{note}
 \indextext{implementation-generated}%
-In some circumstances, \Cpp implementations implicitly define the
+In some circumstances, \Cpp{} implementations implicitly define the
 default constructor\iref{class.ctor},
 copy constructor\iref{class.copy},
 move constructor\iref{class.copy},
@@ -2429,7 +2429,7 @@ a major array bound\iref{dcl.array}. A violation of this rule on type
 identity does not require a diagnostic.
 
 \pnum
-\begin{note} Linkage to non-\Cpp declarations can be achieved using a
+\begin{note} Linkage to non-\Cpp{} declarations can be achieved using a
 \grammarterm{linkage-specification}\iref{dcl.link}. \end{note}%
 \indextext{linkage|)}
 
@@ -2455,7 +2455,7 @@ duration. \end{note}
 
 \pnum
 An implementation shall not predefine the \tcode{main} function. This
-function shall not be overloaded.  Its type shall have \Cpp language linkage
+function shall not be overloaded.  Its type shall have \Cpp{} language linkage
 and it shall have a declared return type of type
 \tcode{int}, but otherwise its type is \impldef{parameters to \tcode{main}}.
 \indextext{\idxcode{main} function!implementation-defined parameters to}%
@@ -2952,7 +2952,7 @@ execution\iref{intro.execution}, using
 \indextext{\idxcode{new}}%
 \grammarterm{new-expression}{s}\iref{expr.new}, and destroyed using
 \indextext{\idxcode{delete}}%
-\grammarterm{delete-expression}{s}\iref{expr.delete}. A \Cpp implementation
+\grammarterm{delete-expression}{s}\iref{expr.delete}. A \Cpp{} implementation
 provides access to, and management of, dynamic storage via the global
 \defn{allocation functions} \tcode{operator new} and \tcode{operator
 new[]} and the global \defn{deallocation functions} \tcode{operator
@@ -2965,7 +2965,7 @@ do not perform allocation or deallocation.
 \pnum
 The library provides default definitions for the global allocation and
 deallocation functions. Some global allocation and deallocation
-functions are replaceable\iref{new.delete}. A \Cpp program shall
+functions are replaceable\iref{new.delete}. A \Cpp{} program shall
 provide at most one definition of a replaceable allocation or
 deallocation function. Any such function definition replaces the default
 version provided in the library\iref{replacement.functions}. The
@@ -3011,7 +3011,7 @@ deallocation functions may also be declared and defined for any
 class\iref{class.free}.
 
 \pnum
-Any allocation and/or deallocation functions defined in a \Cpp program,
+Any allocation and/or deallocation functions defined in a \Cpp{} program,
 including the default versions in the library, shall conform to the
 semantics specified in~\ref{basic.stc.dynamic.allocation}
 and~\ref{basic.stc.dynamic.deallocation}.
@@ -3059,7 +3059,7 @@ The effect of indirecting through a pointer
 returned as a request for zero size is undefined.\footnote{The intent is
 to have \tcode{operator new()} implementable by
 calling \tcode{std::malloc()} or \tcode{std::calloc()}, so the rules are
-substantially the same. \Cpp differs from C in requiring a zero request
+substantially the same. \Cpp{} differs from C in requiring a zero request
 to return a non-null pointer.}
 
 \pnum
@@ -3082,7 +3082,7 @@ that would match a handler\iref{except.handle} of type
 A global allocation function is only called as the result of a new
 expression\iref{expr.new}, or called directly using the function call
 syntax\iref{expr.call}, or called indirectly through calls to the
-functions in the \Cpp standard library. \begin{note} In particular, a
+functions in the \Cpp{} standard library. \begin{note} In particular, a
 global allocation function is not called to allocate storage for objects
 with static storage duration\iref{basic.stc.static}, for objects or references
 with thread storage duration\iref{basic.stc.thread}, for objects of
@@ -3165,12 +3165,12 @@ match those of some object pointer type.
 A pointer value is a \defn{safely-derived pointer} to a dynamic object only if it
 has an object pointer type and it is one of the following:
 \begin{itemize}
-\item the value returned by a call to the \Cpp standard library implementation of
+\item the value returned by a call to the \Cpp{} standard library implementation of
 \tcode{::operator new(std::\brk{}size_t)} or
 \tcode{::operator new(std::size_t, std::align_val_t)}%
 ;\footnote{This section does not impose restrictions
 on indirection through pointers to memory not allocated by \tcode{::operator new}. This
-maintains the ability of many \Cpp implementations to use binary libraries and
+maintains the ability of many \Cpp{} implementations to use binary libraries and
 components written in other languages. In particular, this applies to C binaries,
 because indirection through pointers to memory allocated by \tcode{std::malloc} is not restricted.}
 
@@ -3578,7 +3578,7 @@ For trivially copyable types, the value representation is
 a set of bits in the object representation that determines a
 \defn{value}, which is one discrete element of an
 \impldef{values of a trivially copyable type} set of values.\footnote{The
-intent is that the memory model of \Cpp is compatible
+intent is that the memory model of \Cpp{} is compatible
 with that of ISO/IEC 9899 Programming Language C.}
 
 \pnum

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -29,18 +29,18 @@ make \grammarterm{class-name}{s}. An object of a class consists of a
 
 \begin{bnf}
 \nontermdef{class-specifier}\br
-    class-head \terminal{\{} member-specification\opt{} \terminal{\}}
+    class-head \terminal{\{} \opt{member-specification} \terminal{\}}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{class-head}\br
-    class-key attribute-specifier-seq\opt{} class-head-name class-virt-specifier\opt{} base-clause\opt{}\br
-    class-key attribute-specifier-seq\opt{} base-clause\opt{}
+    class-key \opt{attribute-specifier-seq} class-head-name \opt{class-virt-specifier} \opt{base-clause}\br
+    class-key \opt{attribute-specifier-seq} \opt{base-clause}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{class-head-name}\br
-    nested-name-specifier\opt{} class-name
+    \opt{nested-name-specifier} class-name
 \end{bnf}
 
 \begin{bnf}
@@ -441,13 +441,13 @@ ignored. A \grammarterm{typedef-name} shall not be used as the
 
 \begin{bnf}
 \nontermdef{member-specification}\br
-    member-declaration member-specification\opt{}\br
-    access-specifier \terminal{:} member-specification\opt{}
+    member-declaration \opt{member-specification}\br
+    access-specifier \terminal{:} \opt{member-specification}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{member-declaration}\br
-    attribute-specifier-seq\opt{} decl-specifier-seq\opt{} member-declarator-list\opt{} \terminal{;}\br
+    \opt{attribute-specifier-seq} \opt{decl-specifier-seq} \opt{member-declarator-list} \terminal{;}\br
     function-definition\br
     using-declaration\br
     static_assert-declaration\br
@@ -465,10 +465,10 @@ ignored. A \grammarterm{typedef-name} shall not be used as the
 
 \begin{bnf}
 \nontermdef{member-declarator}\br
-    declarator virt-specifier-seq\opt{} pure-specifier\opt{}\br
+    declarator \opt{virt-specifier-seq} \opt{pure-specifier}\br
     declarator requires-clause\br
-    declarator brace-or-equal-initializer\opt{}\br
-    identifier\opt{} attribute-specifier-seq\opt{} \terminal{:} constant-expression brace-or-equal-initializer\opt{}
+    declarator \opt{brace-or-equal-initializer}\br
+    \opt{identifier} \opt{attribute-specifier-seq} \terminal{:} constant-expression \opt{brace-or-equal-initializer}
 \end{bnf}
 
 \begin{bnf}
@@ -1314,7 +1314,7 @@ A static data member shall not be
 A \grammarterm{member-declarator} of the form
 
 \begin{ncbnftab}
-identifier\opt{} attribute-specifier-seq\opt{} \terminal{:} constant-expression brace-or-equal-initializer\opt{}
+\opt{identifier} \opt{attribute-specifier-seq} \terminal{:} constant-expression \opt{brace-or-equal-initializer}
 \end{ncbnftab}
 
 \indextext{\idxcode{:}!bit-field declaration}%

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -34,13 +34,13 @@ make \grammarterm{class-name}{s}. An object of a class consists of a
 
 \begin{bnf}
 \nontermdef{class-head}\br
-    class-key attribute-specifier-seq\opt class-head-name class-virt-specifier\opt base-clause\opt\br
-    class-key attribute-specifier-seq\opt base-clause\opt
+    class-key attribute-specifier-seq\opt{} class-head-name class-virt-specifier\opt{} base-clause\opt{}\br
+    class-key attribute-specifier-seq\opt{} base-clause\opt{}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{class-head-name}\br
-    nested-name-specifier\opt class-name
+    nested-name-specifier\opt{} class-name
 \end{bnf}
 
 \begin{bnf}
@@ -441,13 +441,13 @@ ignored. A \grammarterm{typedef-name} shall not be used as the
 
 \begin{bnf}
 \nontermdef{member-specification}\br
-    member-declaration member-specification\opt\br
-    access-specifier \terminal{:} member-specification\opt
+    member-declaration member-specification\opt{}\br
+    access-specifier \terminal{:} member-specification\opt{}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{member-declaration}\br
-    attribute-specifier-seq\opt decl-specifier-seq\opt member-declarator-list\opt{} \terminal{;}\br
+    attribute-specifier-seq\opt{} decl-specifier-seq\opt{} member-declarator-list\opt{} \terminal{;}\br
     function-definition\br
     using-declaration\br
     static_assert-declaration\br
@@ -465,9 +465,9 @@ ignored. A \grammarterm{typedef-name} shall not be used as the
 
 \begin{bnf}
 \nontermdef{member-declarator}\br
-    declarator virt-specifier-seq\opt pure-specifier\opt\br
+    declarator virt-specifier-seq\opt{} pure-specifier\opt{}\br
     declarator requires-clause\br
-    declarator brace-or-equal-initializer\opt\br
+    declarator brace-or-equal-initializer\opt{}\br
     identifier\opt{} attribute-specifier-seq\opt{} \terminal{:} constant-expression brace-or-equal-initializer\opt{}
 \end{bnf}
 

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1,26 +1,26 @@
 %!TEX root = std.tex
 \infannex{diff}{Compatibility}
 
-\rSec1[diff.iso]{\Cpp and ISO C}
+\rSec1[diff.iso]{\Cpp{} and ISO C}
 
 \pnum
 \indextext{summary!compatibility with ISO C}%
-This subclause lists the differences between \Cpp and
+This subclause lists the differences between \Cpp{} and
 ISO C, by the chapters of this document.
 
 \rSec2[diff.lex]{\ref{lex}: lexical conventions}
 
 \ref{lex.key}
 \change New Keywords\\
-New keywords are added to \Cpp;
+New keywords are added to \Cpp{};
 see \ref{lex.key}.
 \rationale
 These keywords were added in order to implement the new
-semantics of \Cpp.
+semantics of \Cpp{}.
 \effect
 Change to semantics of well-defined feature.
 Any ISO C programs that used any of these keywords as identifiers
-are not valid \Cpp programs.
+are not valid \Cpp{} programs.
 \difficulty
 Syntactic transformation.
 Converting one specific program is easy.
@@ -53,7 +53,7 @@ ISO C programs which depend on
 sizeof('x') == sizeof(int)
 \end{codeblock}
 
-will not work the same as \Cpp programs.
+will not work the same as \Cpp{} programs.
 \difficulty
 Simple.
 \howwide
@@ -82,7 +82,7 @@ Change to semantics of well-defined feature.
 Syntactic transformation. The fix is to add a cast:
 
 \begin{codeblock}
-char* p = "abc";                // valid in C, invalid in \Cpp
+char* p = "abc";                // valid in C, invalid in \Cpp{}
 void f(char*) {
   char* p = (char*)"abc";       // OK: cast added
   f(p);
@@ -97,7 +97,7 @@ as pointers to potentially modifiable memory are probably rare.
 \rSec2[diff.basic]{\ref{basic}: basic concepts}
 
 \ref{basic.def}
-\change \Cpp does not have ``tentative definitions'' as in C.\\
+\change \Cpp{} does not have ``tentative definitions'' as in C.\\
 E.g., at file scope,
 
 \begin{codeblock}
@@ -105,7 +105,7 @@ int i;
 int i;
 \end{codeblock}
 
-is valid in C, invalid in \Cpp.
+is valid in C, invalid in \Cpp{}.
 This makes it impossible to define
 mutually referential file-local static objects, if initializers are
 restricted to the syntactic forms of C\@.
@@ -126,16 +126,16 @@ fundamental types and user-defined types.
 Deletion of semantically well-defined feature.
 \difficulty
 Semantic transformation.
-In \Cpp, the initializer for one of a set of
+In \Cpp{}, the initializer for one of a set of
 mutually-referential file-local static objects must invoke a function
 call to achieve the initialization.
 \howwide
 Seldom.
 
 \ref{basic.scope}
-\change A \tcode{struct} is a scope in \Cpp, not in C.
+\change A \tcode{struct} is a scope in \Cpp{}, not in C.
 \rationale
-Class scope is crucial to \Cpp, and a struct is a class.
+Class scope is crucial to \Cpp{}, and a struct is a class.
 \effect
 Change to semantics of well-defined feature.
 \difficulty
@@ -151,7 +151,7 @@ The latter is probably rare.
 declared \tcode{extern}, has internal linkage, while in C it would have external linkage.
 \rationale
 Because \tcode{const} objects may be used as values during translation in
-\Cpp, this feature urges programmers to provide an explicit initializer
+\Cpp{}, this feature urges programmers to provide an explicit initializer
 for each \tcode{const} object.
 This feature allows the user to put \tcode{const} objects in source files that are included
 in more than one translation unit.
@@ -175,13 +175,13 @@ Trivial: create an intermediary function such as
 Seldom.
 
 \ref{basic.types}
-\change C allows ``compatible types'' in several places, \Cpp does not.\\
+\change C allows ``compatible types'' in several places, \Cpp{} does not.\\
 For example,
 otherwise-identical \tcode{struct} types with different tag names
 are ``compatible'' in C but are distinctly different types
-in \Cpp.
+in \Cpp{}.
 \rationale
-Stricter type checking is essential for \Cpp.
+Stricter type checking is essential for \Cpp{}.
 \effect
 Deletion of semantically well-defined feature.
 \difficulty
@@ -210,14 +210,14 @@ void foo() {
 
 ISO C will accept this usage of pointer to void being assigned
 to a pointer to object type.
-\Cpp will not.
+\Cpp{} will not.
 \rationale
-\Cpp tries harder than C to enforce compile-time type safety.
+\Cpp{} tries harder than C to enforce compile-time type safety.
 \effect
 Deletion of semantically well-defined feature.
 \difficulty
 Could be automated.
-Violations will be diagnosed by the \Cpp translator.
+Violations will be diagnosed by the \Cpp{} translator.
 The
 fix is to add a  cast.
 For example:
@@ -237,7 +237,7 @@ if the cast is not used.
 \ref{expr.call}
 \change Implicit declaration of functions is not allowed.
 \rationale
-The type-safe nature of \Cpp.
+The type-safe nature of \Cpp{}.
 \effect
 Deletion of semantically well-defined feature.
 Note: the original feature was labeled as ``obsolescent'' in ISO C.
@@ -280,7 +280,7 @@ Seldom.
 \indextext{lvalue}%
 \change The result of a conditional expression, an assignment expression, or a comma expression may be an lvalue.
 \rationale
-\Cpp is an object-oriented language, placing relatively
+\Cpp{} is an object-oriented language, placing relatively
 more emphasis on lvalues.  For example, functions may
 return lvalues.
 \effect
@@ -295,7 +295,7 @@ sizeof(0, arr)
 
 yields
 \tcode{100}
-in \Cpp and
+in \Cpp{} and
 \tcode{sizeof(char*)}
 in C.
 \difficulty
@@ -315,7 +315,7 @@ Allowing jump past initializers would require
 complicated runtime determination of allocation.
 Furthermore, any use of the uninitialized object could be a
 disaster.
-With this simple compile-time rule, \Cpp assures that
+With this simple compile-time rule, \Cpp{} assures that
 if an initialized variable is in scope, then it has assuredly been
 initialized.
 \effect
@@ -352,14 +352,14 @@ this case.
 \rSec2[diff.dcl]{\ref{dcl.dcl}: declarations}
 
 \ref{dcl.stc}
-\change In \Cpp, the \tcode{static} or \tcode{extern} specifiers can only be applied to names of objects or functions.\\
-Using these specifiers with type declarations is illegal in \Cpp.
+\change In \Cpp{}, the \tcode{static} or \tcode{extern} specifiers can only be applied to names of objects or functions.\\
+Using these specifiers with type declarations is illegal in \Cpp{}.
 In C, these specifiers are ignored when used on type declarations.
 
 Example:
 
 \begin{codeblock}
-static struct S {               // valid C, invalid in \Cpp
+static struct S {               // valid C, invalid in \Cpp{}
   int i;
 };
 \end{codeblock}
@@ -367,7 +367,7 @@ static struct S {               // valid C, invalid in \Cpp
 \rationale
 Storage class specifiers don't have any meaning when associated
 with a type.
-In \Cpp, class members can be declared with the \tcode{static} storage
+In \Cpp{}, class members can be declared with the \tcode{static} storage
 class specifier.
 Allowing storage class specifiers on type
 declarations could render the code confusing for users.
@@ -379,9 +379,9 @@ Syntactic transformation.
 Seldom.
 
 \ref{dcl.stc}
-\change In \Cpp, \tcode{register} is not a storage class specifier.
+\change In \Cpp{}, \tcode{register} is not a storage class specifier.
 \rationale
-The storage class specifier had no effect in \Cpp.
+The storage class specifier had no effect in \Cpp{}.
 \effect
 Deletion of semantically well-defined feature.
 \difficulty
@@ -390,20 +390,20 @@ Syntactic transformation.
 Common.
 
 \ref{dcl.typedef}
-\change A \Cpp typedef name must be different from any class type name declared
+\change A \Cpp{} typedef name must be different from any class type name declared
 in the same scope (except if the typedef is a synonym of the class name with the
 same name). In C, a typedef name and a struct tag name declared in the same scope
 can have the same name (because they have different name spaces).
 
 Example:
 \begin{codeblock}
-typedef struct name1 { @\commentellip@ } name1;         // valid C and \Cpp
+typedef struct name1 { @\commentellip@ } name1;         // valid C and \Cpp{}
 struct name { @\commentellip@ };
-typedef int name;               // valid C, invalid \Cpp
+typedef int name;               // valid C, invalid \Cpp{}
 \end{codeblock}
 
 \rationale
-For ease of use, \Cpp doesn't require that a type name be prefixed
+For ease of use, \Cpp{} doesn't require that a type name be prefixed
 with the keywords \tcode{class}, \tcode{struct} or \tcode{union} when used in object
 declarations or type casts.
 
@@ -422,7 +422,7 @@ One of the 2 types has to be renamed.
 Seldom.
 
 \ref{dcl.type} [see also \ref{basic.link}]
-\change \tcode{const} objects must be initialized in \Cpp but can be left uninitialized in C.
+\change \tcode{const} objects must be initialized in \Cpp{} but can be left uninitialized in C.
 \rationale
 A const object cannot be assigned to so it must be initialized
 to hold a useful value.
@@ -436,7 +436,7 @@ Seldom.
 \ref{dcl.type}
 \change Banning implicit \tcode{int}.
 
-In \Cpp a
+In \Cpp{} a
 \grammarterm{decl-specifier-seq}
 must contain a
 \grammarterm{type-specifier}{}, unless
@@ -445,7 +445,7 @@ conversion function.
 In the following example, the
 left-hand column presents valid C;
 the right-hand column presents
-equivalent \Cpp :
+equivalent \Cpp{} :
 
 \begin{codeblock}
 void f(const parm);            void f(const int parm);
@@ -455,7 +455,7 @@ main()                         int main()
 \end{codeblock}
 
 \rationale
-In \Cpp, implicit int creates several opportunities for
+In \Cpp{}, implicit int creates several opportunities for
 ambiguity between expressions involving function-like
 casts and declarations.
 Explicit declaration is increasingly considered
@@ -476,7 +476,7 @@ The keyword \tcode{auto} cannot be used as a storage class specifier.
 
 \begin{codeblock}
 void f() {
-  auto int x;     // valid C, invalid \Cpp
+  auto int x;     // valid C, invalid \Cpp{}
 }
 \end{codeblock}
 
@@ -488,17 +488,17 @@ of a variable from its initializer results in undesired interpretations of
 \howwide Rare.
 
 \ref{dcl.enum}
-\change \Cpp objects of enumeration type can only be assigned values of the same enumeration type.
+\change \Cpp{} objects of enumeration type can only be assigned values of the same enumeration type.
 In C, objects of enumeration type can be assigned values of any integral type.
 
 Example:
 \begin{codeblock}
 enum color { red, blue, green };
-enum color c = 1;               // valid C, invalid \Cpp
+enum color c = 1;               // valid C, invalid \Cpp{}
 \end{codeblock}
 
 \rationale
-The type-safe nature of \Cpp.
+The type-safe nature of \Cpp{}.
 \effect
 Deletion of semantically well-defined feature.
 \difficulty
@@ -509,19 +509,19 @@ corrected by applying an explicit cast.)
 Common.
 
 \ref{dcl.enum}
-\change In \Cpp, the type of an enumerator is its enumeration. In C, the type of an enumerator is \tcode{int}.
+\change In \Cpp{}, the type of an enumerator is its enumeration. In C, the type of an enumerator is \tcode{int}.
 
 Example:
 
 \begin{codeblock}
 enum e { A };
 sizeof(A) == sizeof(int)        // in C
-sizeof(A) == sizeof(e)          // in \Cpp
+sizeof(A) == sizeof(e)          // in \Cpp{}
 /* and @sizeof(int)@ is not necessarily equal to @sizeof(e)@ */
 \end{codeblock}
 
 \rationale
-In \Cpp, an enumeration is a distinct type.
+In \Cpp{}, an enumeration is a distinct type.
 \effect
 Change to semantics of well-defined feature.
 \difficulty
@@ -536,13 +536,13 @@ common C coding practice.
 \rSec2[diff.decl]{\ref{dcl.decl}: declarators}
 
 \ref{dcl.fct}
-\change In \Cpp, a function declared with an empty parameter list takes no arguments.
+\change In \Cpp{}, a function declared with an empty parameter list takes no arguments.
 In C, an empty parameter list means that the number and type of the function arguments are unknown.
 
 Example:
 
 \begin{codeblock}
-int f();            // means   \tcode{int f(void)} in \Cpp
+int f();            // means   \tcode{int f(void)} in \Cpp{}
                     // \tcode{int f(} unknown \tcode{)} in C
 \end{codeblock}
 
@@ -563,21 +563,21 @@ if the type of corresponding arguments differed.
 Common.
 
 \ref{dcl.fct} [see \ref{expr.sizeof}]
-\change In \Cpp, types may not be defined in return or parameter types.
+\change In \Cpp{}, types may not be defined in return or parameter types.
 In C, these type definitions are allowed.
 
 Example:
 
 \begin{codeblock}
-void f( struct S { int a; } arg ) {}    // valid C, invalid \Cpp
-enum E { A, B, C } f() {}               // valid C, invalid \Cpp
+void f( struct S { int a; } arg ) {}    // valid C, invalid \Cpp{}
+enum E { A, B, C } f() {}               // valid C, invalid \Cpp{}
 \end{codeblock}
 
 \rationale
-When comparing types in different translation units, \Cpp relies
+When comparing types in different translation units, \Cpp{} relies
 on name equivalence when C relies on structural equivalence.
 Regarding parameter types: since the type defined in a parameter list
-would be in the scope of the function, the only legal calls in \Cpp
+would be in the scope of the function, the only legal calls in \Cpp{}
 would be from within the function itself.
 \effect
 Deletion of semantically well-defined feature.
@@ -589,7 +589,7 @@ Seldom.
 This style of type definition is seen as poor coding style.
 
 \ref{dcl.fct.def}
-\change In \Cpp, the syntax for function definition excludes the ``old-style'' C function.
+\change In \Cpp{}, the syntax for function definition excludes the ``old-style'' C function.
 In C, ``old-style'' syntax is allowed, but deprecated as ``obsolescent''.
 \rationale
 Prototypes are essential to type safety.
@@ -602,9 +602,9 @@ Common in old programs, but already known to be obsolescent.
 
 \ref{dcl.init.aggr}
 \change
-In \Cpp, designated initialization support is restricted
+In \Cpp{}, designated initialization support is restricted
 compared to the corresponding functionality in C.
-In \Cpp,
+In \Cpp{},
 designators for non-static data members
 must be specified in declaration order,
 designators for array elements and nested designators
@@ -618,19 +618,19 @@ Example:
 \begin{codeblock}
 struct A { int x, y; };
 struct B { struct A a; };
-struct A a = {.y = 1, .x = 2};  // valid C, invalid \Cpp
-int arr[3] = {[1] = 5};         // valid C, invalid \Cpp
-struct B b = {.a.x = 0};        // valid C, invalid \Cpp
-struct A c = {.x = 1, 2};       // valid C, invalid \Cpp
+struct A a = {.y = 1, .x = 2};  // valid C, invalid \Cpp{}
+int arr[3] = {[1] = 5};         // valid C, invalid \Cpp{}
+struct B b = {.a.x = 0};        // valid C, invalid \Cpp{}
+struct A c = {.x = 1, 2};       // valid C, invalid \Cpp{}
 \end{codeblock}
 \rationale
-In \Cpp, members are destroyed in reverse construction order
+In \Cpp{}, members are destroyed in reverse construction order
 and the elements of an initializer list are evaluated in lexical order,
 so field initializers must be specified in order.
 Array designators conflict with \grammarterm{lambda-expression} syntax.
 Nested designators are seldom used.
 \effect
-Deletion of feature that is incompatible with \Cpp.
+Deletion of feature that is incompatible with \Cpp{}.
 \difficulty
 Syntactic transformation.
 \howwide
@@ -638,7 +638,7 @@ Out-of-order initializers are common.
 The other features are seldom used.
 
 \ref{dcl.init.string}
-\change In \Cpp, when initializing an array of character with a string, the number of
+\change In \Cpp{}, when initializing an array of character with a string, the number of
 characters in the string (including the terminating \tcode{'\textbackslash 0'}) must not exceed the
 number of elements in the array. In C, an array can be initialized with a string even if
 the array is not large enough to contain the string-terminating \tcode{'\textbackslash 0'}.
@@ -646,7 +646,7 @@ the array is not large enough to contain the string-terminating \tcode{'\textbac
 Example:
 
 \begin{codeblock}
-char array[4] = "abcd";         // valid C, invalid \Cpp
+char array[4] = "abcd";         // valid C, invalid \Cpp{}
 \end{codeblock}
 \rationale
 When these non-terminated arrays are manipulated by standard
@@ -664,7 +664,7 @@ This style of array initialization is seen as poor coding style.
 \rSec2[diff.class]{\ref{class}: classes}
 
 \ref{class.name} [see also \ref{dcl.typedef}]
-\change In \Cpp, a class declaration introduces the class name into the scope where it is
+\change In \Cpp{}, a class declaration introduces the class name into the scope where it is
 declared and hides any object, function or other declaration of that name in an enclosing
 scope. In C, an inner scope declaration of a struct tag name never hides the name of an
 object or function in an outer scope.
@@ -676,17 +676,17 @@ int x[99];
 void f() {
   struct x { int a; };
   sizeof(x);  /* size of the array in C */
-  /* size of the struct in @\textit{\textrm{\Cpp}}@ */
+  /* size of the struct in @\textit{\textrm{\Cpp{}}}@ */
 }
 \end{codeblock}
 \rationale
-This is one of the few incompatibilities between C and \Cpp that
-can be attributed to the new \Cpp name space definition where a
+This is one of the few incompatibilities between C and \Cpp{} that
+can be attributed to the new \Cpp{} name space definition where a
 name can be declared as a type and as a non-type in a single scope
 causing the non-type name to hide the type name and requiring that
 the keywords \tcode{class}, \tcode{struct}, \tcode{union} or \tcode{enum} be used to refer to the type name.
 This new name space definition provides important notational
-conveniences to \Cpp programmers and helps making the use of the
+conveniences to \Cpp{} programmers and helps making the use of the
 user-defined types as similar as possible to the use of fundamental
 types.
 The advantages of the new name space definition were judged to
@@ -696,7 +696,7 @@ Change to semantics of well-defined feature.
 \difficulty
 Semantic transformation.
 If the hidden name that needs to be accessed is at global scope,
-the \tcode{::} \Cpp operator can be used.
+the \tcode{::} \Cpp{} operator can be used.
 If the hidden name is at block scope, either the type or the struct
 tag has to be renamed.
 \howwide
@@ -712,14 +712,14 @@ inconsistent definitions of template specializations. For consistency,
 the implementation freedom was eliminated for non-dependent types,
 too.
 \effect
-The choice is implementation-defined in C, but not so in \Cpp.
+The choice is implementation-defined in C, but not so in \Cpp{}.
 \difficulty
 Syntactic transformation.
 \howwide
 Seldom.
 
 \ref{class.nest}
-\change In \Cpp, the name of a nested class is local to its enclosing class. In C
+\change In \Cpp{}, the name of a nested class is local to its enclosing class. In C
 the name of the nested class belongs to the same scope as the name of the outermost enclosing class.
 
 Example:
@@ -728,16 +728,16 @@ Example:
 struct X {
   struct Y { @\commentellip@ } y;
 };
-struct Y yy;                    // valid C, invalid \Cpp
+struct Y yy;                    // valid C, invalid \Cpp{}
 \end{codeblock}
 \rationale
-\Cpp classes have member functions which require that classes
+\Cpp{} classes have member functions which require that classes
 establish scopes.
 The C rule would leave classes as an incomplete scope mechanism
-which would prevent \Cpp programmers from maintaining locality
+which would prevent \Cpp{} programmers from maintaining locality
 within a class.
-A coherent set of scope rules for \Cpp based on the C rule would
-be very complicated and \Cpp programmers would be unable to predict
+A coherent set of scope rules for \Cpp{} based on the C rule would
+be very complicated and \Cpp{} programmers would be unable to predict
 reliably the meanings of nontrivial examples involving nested or
 local functions.
 \effect
@@ -765,7 +765,7 @@ which is documented in \ref{basic.scope}.
 Seldom.
 
 \ref{class.nested.type}
-\change In \Cpp, a typedef name may not be redeclared in a class definition after being used in that definition.
+\change In \Cpp{}, a typedef name may not be redeclared in a class definition after being used in that definition.
 
 Example:
 
@@ -773,12 +773,12 @@ Example:
 typedef int I;
 struct S {
   I i;
-  int I;                  // valid C, invalid \Cpp
+  int I;                  // valid C, invalid \Cpp{}
 };
 \end{codeblock}
 \rationale
 When classes become complicated, allowing such a redefinition
-after the type has been used can create confusion for \Cpp
+after the type has been used can create confusion for \Cpp{}
 programmers as to what the meaning of \tcode{I} really is.
 \effect
 Deletion of semantically well-defined feature.
@@ -801,9 +801,9 @@ For example, the following is valid in ISO C:
 \begin{codeblock}
 struct X { int i; };
 volatile struct X x1 = {0};
-struct X x2 = x1;               // invalid \Cpp
+struct X x2 = x1;               // invalid \Cpp{}
 struct X x3;
-x3 = x1;                        // also invalid \Cpp
+x3 = x1;                        // also invalid \Cpp{}
 \end{codeblock}
 
 \rationale
@@ -842,7 +842,7 @@ Seldom.
 \change Whether \mname{STDC} is defined and if so, what its value is, are
 \impldef{definition and meaning of \mname{STDC}}.
 \rationale
-\Cpp is not identical to ISO C\@.
+\Cpp{} is not identical to ISO C\@.
 Mandating that \mname{STDC}
 be defined would require that translators make an incorrect claim.
 Each implementation must choose the behavior that will be most
@@ -855,12 +855,12 @@ Semantic transformation.
 Programs and headers that reference \mname{STDC} are
 quite common.
 
-\rSec1[diff.cpp03]{\Cpp and ISO \CppIII}
+\rSec1[diff.cpp03]{\Cpp{} and ISO \CppIII{}}
 
 \pnum
-\indextext{summary!compatibility with ISO \CppIII}%
-This subclause lists the differences between \Cpp and
-ISO \CppIII (ISO/IEC 14882:2003, \doccite{Programming Languages --- \Cpp}),
+\indextext{summary!compatibility with ISO \CppIII{}}%
+This subclause lists the differences between \Cpp{} and
+ISO \CppIII{} (ISO/IEC 14882:2003, \doccite{Programming Languages --- \Cpp{}}),
 by the chapters of this document.
 
 \rSec2[diff.cpp03.lex]{\ref{lex}: lexical conventions}
@@ -869,7 +869,7 @@ by the chapters of this document.
 \change New kinds of string literals.
 \rationale Required for new features.
 \effect
-Valid \CppIII code may fail to compile or produce different results in
+Valid \CppIII{} code may fail to compile or produce different results in
 this International Standard. Specifically, macros named \tcode{R}, \tcode{u8},
 \tcode{u8R}, \tcode{u}, \tcode{uR}, \tcode{U}, \tcode{UR}, or \tcode{LR} will
 not be expanded when adjacent to a string literal but will be interpreted as
@@ -884,7 +884,7 @@ const char* s = u8"def";        // Previously \tcode{"abcdef"}, now \tcode{"def"
 \change User-defined literal string support.
 \rationale Required for new features.
 \effect
-Valid \CppIII code may fail to compile or produce different results in
+Valid \CppIII{} code may fail to compile or produce different results in
 this International Standard, as the following example illustrates.
 
 \begin{codeblock}
@@ -912,7 +912,7 @@ Added to Table~\ref{tab:keywords}, the following identifiers are new keywords:
 \tcode{static_assert},
 and
 \tcode{thread_local}.
-Valid \CppIII code using these identifiers is invalid in this International
+Valid \CppIII{} code using these identifiers is invalid in this International
 Standard.
 
 \ref{lex.icon}
@@ -928,7 +928,7 @@ change from an unsigned integer type to \tcode{signed long long}.
 \change Only literals are integer null pointer constants.
 \rationale Removing surprising interactions with templates and constant
 expressions.
-\effect Valid \CppIII code may fail to compile or produce different results in
+\effect Valid \CppIII{} code may fail to compile or produce different results in
 this International Standard, as the following example illustrates:
 
 \begin{codeblock}
@@ -945,7 +945,7 @@ template<int N> void g() {
 \change Specify rounding for results of integer \tcode{/} and \tcode{\%}.
 \rationale Increase portability, C99 compatibility.
 \effect
-Valid \CppIII code that uses integer division rounds the result toward 0 or
+Valid \CppIII{} code that uses integer division rounds the result toward 0 or
 toward negative infinity, whereas this International Standard always rounds
 the result toward 0.
 
@@ -953,7 +953,7 @@ the result toward 0.
 \change \tcode{\&\&} is valid in a \grammarterm{type-name}.
 \rationale Required for new features.
 \effect
-Valid \CppIII code may fail to compile or produce different results in
+Valid \CppIII{} code may fail to compile or produce different results in
 this International Standard, as the following example illustrates:
 
 \begin{codeblock}
@@ -968,7 +968,7 @@ bool b2 = &S::operator int && false;  // previously \tcode{false}, now ill-forme
 \change Remove \tcode{auto} as a storage class specifier.
 \rationale New feature.
 \effect
-Valid \CppIII code that uses the keyword \tcode{auto} as a storage class
+Valid \CppIII{} code that uses the keyword \tcode{auto} as a storage class
 specifier may be invalid in this International Standard. In this International
 Standard, \tcode{auto} indicates that the type of a variable is to be deduced
 from its initializer expression.
@@ -979,8 +979,8 @@ from its initializer expression.
 \change Narrowing restrictions in aggregate initializers.
 \rationale Catches bugs.
 \effect
-Valid \CppIII code may fail to compile in this International Standard. For
-example, the following code is valid in \CppIII but invalid in this
+Valid \CppIII{} code may fail to compile in this International Standard. For
+example, the following code is valid in \CppIII{} but invalid in this
 International Standard because \tcode{double} to \tcode{int} is a narrowing
 conversion:
 
@@ -995,7 +995,7 @@ int x[] = { 2.0 };
 when the implicit definition would have been ill-formed.
 \rationale Improves template argument deduction failure.
 \effect
-A valid \CppIII program that uses one of these special member functions in a
+A valid \CppIII{} program that uses one of these special member functions in a
 context where the definition is not required (e.g., in an expression that is
 not potentially evaluated) becomes ill-formed.
 
@@ -1003,7 +1003,7 @@ not potentially evaluated) becomes ill-formed.
 \change User-declared destructors have an implicit exception specification.
 \rationale Clarification of destructor requirements.
 \effect
-Valid \CppIII code may execute differently in this International Standard. In
+Valid \CppIII{} code may execute differently in this International Standard. In
 particular, destructors that throw exceptions will call \tcode{std::terminate}
 (without calling \tcode{std::unexpected}) if their exception specification is
 non-throwing.
@@ -1014,7 +1014,7 @@ non-throwing.
 \change Remove \tcode{export}.
 \rationale No implementation consensus.
 \effect
-A valid \CppIII declaration containing \tcode{export} is ill-formed in this
+A valid \CppIII{} declaration containing \tcode{export} is ill-formed in this
 International Standard.
 
 \ref{temp.arg}
@@ -1023,10 +1023,10 @@ brackets.
 \rationale Considered a persistent but minor annoyance. Template aliases
 representing non-class types would exacerbate whitespace issues.
 \effect
-Change to semantics of well-defined expression. A valid \CppIII expression
+Change to semantics of well-defined expression. A valid \CppIII{} expression
 containing a right angle bracket (``\tcode{>}'') followed immediately by
 another right angle bracket may now be treated as closing two templates.
-For example, the following code is valid in \CppIII because ``\tcode{>>}''
+For example, the following code is valid in \CppIII{} because ``\tcode{>>}''
 is a right-shift operator, but invalid in this International Standard because
 ``\tcode{>>}'' closes two templates.
 
@@ -1040,7 +1040,7 @@ X< Y< 1 >> 2 > > x;
 \change Allow dependent calls of functions with internal linkage.
 \rationale Overly constrained, simplify overload resolution rules.
 \effect
-A valid \CppIII program could get a different result than this
+A valid \CppIII{} program could get a different result than this
 International Standard.
 
 \rSec2[diff.cpp03.library]{\ref{library}: library introduction}
@@ -1049,17 +1049,17 @@ International Standard.
 \change New reserved identifiers.
 \rationale Required by new features.
 \effect
-Valid \CppIII code that uses any identifiers added to the \Cpp standard
+Valid \CppIII{} code that uses any identifiers added to the \Cpp{} standard
 library by this International Standard may fail to compile or produce different
 results in this International Standard. A comprehensive list of identifiers used
-by the \Cpp standard library can be found in the Index of Library Names in this
+by the \Cpp{} standard library can be found in the Index of Library Names in this
 International Standard.
 
 \ref{headers}
 \change New headers.
 \rationale New functionality.
 \effect
-The following \Cpp headers are new:
+The following \Cpp{} headers are new:
 \tcode{<array>},
 \tcode{<atomic>},
 \tcode{<chrono>},
@@ -1091,13 +1091,13 @@ In addition the following C compatibility headers are new:
 \tcode{<ctgmath>},
 and
 \tcode{<cuchar>}.
-Valid \CppIII code that \tcode{\#include}{s} headers with these names may be
+Valid \CppIII{} code that \tcode{\#include}{s} headers with these names may be
 invalid in this International Standard.
 
 \ref{swappable.requirements}
 \effect Function \tcode{swap} moved to a different header
 \rationale Remove dependency on \tcode{<algorithm>} for \tcode{swap}.
-\effect Valid \CppIII code that has been compiled expecting swap to be in
+\effect Valid \CppIII{} code that has been compiled expecting swap to be in
 \tcode{<algorithm>} may have to instead include \tcode{<utility>}.
 
 \ref{namespace.posix}
@@ -1105,14 +1105,14 @@ invalid in this International Standard.
 \rationale New functionality.
 \effect
 The global namespace \tcode{posix} is now reserved for standardization. Valid
-\CppIII code that uses a top-level namespace \tcode{posix} may be invalid in
+\CppIII{} code that uses a top-level namespace \tcode{posix} may be invalid in
 this International Standard.
 
 \ref{res.on.macro.definitions}
 \change Additional restrictions on macro names.
 \rationale Avoid hard to diagnose or non-portable constructs.
 \effect
-Names of attribute identifiers may not be used as macro names. Valid \Cpp
+Names of attribute identifiers may not be used as macro names. Valid \Cpp{}
 2003 code that defines \tcode{override}, \tcode{final},
 \tcode{carries_dependency}, or \tcode{noreturn} as macros is invalid in this
 International Standard.
@@ -1127,7 +1127,7 @@ language support library}
 the other operators. This clarifies that replacing just these two signatures
 changes others, even if they are not explicitly changed.
 \effect
-Valid \CppIII code that replaces global \tcode{new} or \tcode{delete}
+Valid \CppIII{} code that replaces global \tcode{new} or \tcode{delete}
 operators may execute differently in this International Standard. For
 example, the following program should write \tcode{"custom deallocation"} twice,
 once for the single-object delete and once for the array delete.
@@ -1159,7 +1159,7 @@ int main() {
 \tcode{std::bad_alloc}.
 \rationale Consistent application of \tcode{noexcept}.
 \effect
-Valid \CppIII code that assumes that global \tcode{operator new} only
+Valid \CppIII{} code that assumes that global \tcode{operator new} only
 throws \tcode{std::bad_alloc} may execute differently in this International
 Standard.
 
@@ -1168,7 +1168,7 @@ Standard.
 \ref{errno}
 \change Thread-local error numbers.
 \rationale Support for new thread facilities.
-\effect Valid but implementation-specific \CppIII code that relies on
+\effect Valid but implementation-specific \CppIII{} code that relies on
 \tcode{errno} being the same across threads may change behavior in this
 International Standard.
 
@@ -1178,8 +1178,8 @@ International Standard.
 \change Minimal support for garbage-collected regions.
 \rationale Required by new feature.
 \effect
-Valid \CppIII code, compiled without traceable pointer support,
-that interacts with newer \Cpp code using regions declared reachable may
+Valid \CppIII{} code, compiled without traceable pointer support,
+that interacts with newer \Cpp{} code using regions declared reachable may
 have different runtime behavior.
 
 \ref{refwrap}, \ref{arithmetic.operations}, \ref{comparisons},
@@ -1189,7 +1189,7 @@ have different runtime behavior.
 \rationale Superseded by new feature; \tcode{unary_function} and
 \tcode{binary_function} are no longer defined.
 \effect
-Valid \CppIII code that depends on function object types being derived from
+Valid \CppIII{} code that depends on function object types being derived from
 \tcode{unary_function} or \tcode{binary_function} may fail to compile
 in this International Standard.
 
@@ -1201,13 +1201,13 @@ strings.
 \rationale Invalidation is subtly different with reference-counted strings.
 This change regularizes behavior for this International Standard.
 \effect
-Valid \CppIII code may execute differently in this International Standard.
+Valid \CppIII{} code may execute differently in this International Standard.
 
 \ref{string.require}
 \change Loosen \tcode{basic_string} invalidation rules.
 \rationale Allow small-string optimization.
 \effect
-Valid \CppIII code may execute differently in this International Standard.
+Valid \CppIII{} code may execute differently in this International Standard.
 Some \tcode{const} member functions, such as \tcode{data} and \tcode{c_str},
 no longer invalidate iterators.
 
@@ -1218,7 +1218,7 @@ no longer invalidate iterators.
 \rationale Lack of specification of complexity of \tcode{size()} resulted in
 divergent implementations with inconsistent performance characteristics.
 \effect
-Some container implementations that conform to \CppIII may not conform to the
+Some container implementations that conform to \CppIII{} may not conform to the
 specified \tcode{size()} requirements in this International Standard. Adjusting
 containers such as \tcode{std::list} to the stricter requirements may require
 incompatible changes.
@@ -1227,7 +1227,7 @@ incompatible changes.
 \change Requirements change: relaxation.
 \rationale Clarification.
 \effect
-Valid \CppIII code that attempts to meet the specified container requirements
+Valid \CppIII{} code that attempts to meet the specified container requirements
 may now be over-specified. Code that attempted to be portable across containers
 may need to be adjusted as follows:
 \begin{itemize}
@@ -1241,7 +1241,7 @@ of \tcode{size() == 0};
 \change Requirements change: default constructible.
 \rationale Clarification of container requirements.
 \effect
-Valid \CppIII code that attempts to explicitly instantiate a container using
+Valid \CppIII{} code that attempts to explicitly instantiate a container using
 a user-defined type with no default constructor may fail to compile.
 
 \ref{sequence.reqmts}, \ref{associative.reqmts}
@@ -1257,7 +1257,7 @@ The following member functions have changed:
 \item \tcode{insert(pos, beg, end)} for \tcode{vector}, \tcode{deque}, \tcode{list}, \tcode{forward_list}
 \end{itemize}
 
-Valid \CppIII code that relies on these functions returning \tcode{void}
+Valid \CppIII{} code that relies on these functions returning \tcode{void}
 (e.g., code that creates a pointer to member function that points to one
 of these functions) will fail to compile with this International Standard.
 
@@ -1279,7 +1279,7 @@ The signatures of the following member functions changed from taking an
 \item all forms of \tcode{list::merge}
 \end{itemize}
 
-Valid \CppIII code that uses these functions may fail to compile with this
+Valid \CppIII{} code that uses these functions may fail to compile with this
 International Standard.
 
 \ref{sequence.reqmts}, \ref{associative.reqmts}
@@ -1289,7 +1289,7 @@ International Standard.
 For \tcode{vector}, \tcode{deque}, and \tcode{list}
 the fill value passed to \tcode{resize} is now passed by reference instead of
 by value, and an additional overload of \tcode{resize} has been added. Valid
-\CppIII code that uses this function may fail to compile with this International
+\CppIII{} code that uses this function may fail to compile with this International
 Standard.
 
 \rSec2[diff.cpp03.algorithms]{\ref{algorithms}: algorithms library}
@@ -1298,7 +1298,7 @@ Standard.
 \change Result state of inputs after application of some algorithms.
 \rationale Required by new feature.
 \effect
-A valid \CppIII program may detect that an object with a valid but
+A valid \CppIII{} program may detect that an object with a valid but
 unspecified state has a different valid but unspecified state with this
 International Standard. For example, \tcode{std::remove} and
 \tcode{std::remove_if} may leave the tail of the input sequence with a
@@ -1310,7 +1310,7 @@ different set of values than previously.
 \change Specified representation of complex numbers.
 \rationale Compatibility with C99.
 \effect
-Valid \CppIII code that uses implementation-specific knowledge about the
+Valid \CppIII{} code that uses implementation-specific knowledge about the
 binary representation of the required template specializations of
 \tcode{std::complex} may not be compatible with this International Standard.
 
@@ -1322,7 +1322,7 @@ binary representation of the required template specializations of
 \change Specify use of \tcode{explicit} in existing boolean conversion functions.
 \rationale Clarify intentions, avoid workarounds.
 \effect
-Valid \CppIII code that relies on implicit boolean conversions will fail to
+Valid \CppIII{} code that relies on implicit boolean conversions will fail to
 compile with this International Standard. Such conversions occur in the
 following conditions:
 
@@ -1340,7 +1340,7 @@ following conditions:
 \effect
 \tcode{std::ios_base::failure} is no longer derived directly from
 \tcode{std::exception}, but is now derived from \tcode{std::system_error},
-which in turn is derived from \tcode{std::runtime_error}. Valid \CppIII code
+which in turn is derived from \tcode{std::runtime_error}. Valid \CppIII{} code
 that assumes that \tcode{std::ios_base::failure} is derived directly from
 \tcode{std::exception} may execute differently in this International Standard.
 
@@ -1349,7 +1349,7 @@ that assumes that \tcode{std::ios_base::failure} is derived directly from
 defined as constexpr static members.
 \rationale Required for new features.
 \effect
-Valid \CppIII code that relies on \tcode{std::ios_base} flag types being
+Valid \CppIII{} code that relies on \tcode{std::ios_base} flag types being
 represented as \tcode{std::bitset} or as an integer type may fail to compile
 with this International Standard. For example:
 
@@ -1362,12 +1362,12 @@ int main() {
 }
 \end{codeblock}
 
-\rSec1[diff.cpp11]{\Cpp and ISO \CppXI}
+\rSec1[diff.cpp11]{\Cpp{} and ISO \CppXI{}}
 
 \pnum
-\indextext{summary!compatibility with ISO \CppXI}%
-This subclause lists the differences between \Cpp and
-ISO \CppXI (ISO/IEC 14882:2011, \doccite{Programming Languages --- \Cpp}),
+\indextext{summary!compatibility with ISO \CppXI{}}%
+This subclause lists the differences between \Cpp{} and
+ISO \CppXI{} (ISO/IEC 14882:2011, \doccite{Programming Languages --- \Cpp{}}),
 by the chapters of this document.
 
 \rSec2[diff.cpp11.lex]{\ref{lex}: lexical conventions}
@@ -1375,16 +1375,16 @@ by the chapters of this document.
 \ref{lex.ppnumber}
 \change \grammarterm{pp-number} can contain one or more single quotes.
 \rationale Necessary to enable single quotes as digit separators.
-\effect Valid \CppXI code may fail to compile or may change meaning in this
-International Standard. For example, the following code is valid both in \CppXI and in
+\effect Valid \CppXI{} code may fail to compile or may change meaning in this
+International Standard. For example, the following code is valid both in \CppXI{} and in
 this International Standard, but the macro invocation produces different outcomes
-because the single quotes delimit a character literal in \CppXI, whereas they are digit
+because the single quotes delimit a character literal in \CppXI{}, whereas they are digit
 separators in this International Standard:
 
 \begin{codeblock}
 #define M(x, ...) __VA_ARGS__
 int x[2] = { M(1'2,3'4, 5) };
-// \tcode{int x[2] = \{ 5 \};\ \ \ \ \ } --- \CppXI
+// \tcode{int x[2] = \{ 5 \};\ \ \ \ \ } --- \CppXI{}
 // \tcode{int x[2] = \{ 3'4, 5 \};} --- this International Standard
 \end{codeblock}
 
@@ -1393,7 +1393,7 @@ int x[2] = { M(1'2,3'4, 5) };
 \ref{basic.stc.dynamic.deallocation}
 \change New usual (non-placement) deallocator.
 \rationale Required for sized deallocation.
-\effect Valid \CppXI code could declare a global placement allocation function and
+\effect Valid \CppXI{} code could declare a global placement allocation function and
 deallocation function as follows:
 
 \begin{codeblock}
@@ -1416,7 +1416,7 @@ operand keeps the type and value category of the other operand.
 array-to-pointer\iref{conv.array}, and function-to-pointer\iref{conv.func}
 standard conversions), especially the creation of the temporary due to
 lvalue-to-rvalue conversion, were considered gratuitous and surprising.
-\effect Valid \CppXI code that relies on the conversions may behave differently
+\effect Valid \CppXI{} code that relies on the conversions may behave differently
 in this International Standard:
 
 \begin{codeblock}
@@ -1431,14 +1431,14 @@ int f(bool cond) {
 }
 \end{codeblock}
 
-In \CppXI, \tcode{f(true)} returns \tcode{1}. In this International Standard,
+In \CppXI{}, \tcode{f(true)} returns \tcode{1}. In this International Standard,
 it returns \tcode{2}.
 
 \begin{codeblock}
 sizeof(true ? "" : throw 0)
 \end{codeblock}
 
-In \CppXI, the expression yields \tcode{sizeof(const char*)}. In this
+In \CppXI{}, the expression yields \tcode{sizeof(const char*)}. In this
 International Standard, it yields \tcode{sizeof(const char[1])}.
 
 \rSec2[diff.cpp11.dcl.dcl]{\ref{dcl.dcl}: declarations}
@@ -1449,8 +1449,8 @@ International Standard, it yields \tcode{sizeof(const char[1])}.
 \rationale Necessary to allow \tcode{constexpr} member functions to mutate
 the object.
 \effect
-Valid \CppXI code may fail to compile in this International Standard.
-For example, the following code is valid in \CppXI
+Valid \CppXI{} code may fail to compile in this International Standard.
+For example, the following code is valid in \CppXI{}
 but invalid in this International Standard because it declares the same member
 function twice with different return types:
 
@@ -1468,9 +1468,9 @@ struct S {
 \rationale Necessary to allow default member initializers to be used
 by aggregate initialization.
 \effect
-Valid \CppXI code may fail to compile or may change meaning in this International Standard.
+Valid \CppXI{} code may fail to compile or may change meaning in this International Standard.
 \begin{codeblock}
-struct S { // Aggregate in \CppXIV onwards.
+struct S { // Aggregate in \CppXIV{} onwards.
   int m = 1;
 };
 struct X {
@@ -1478,7 +1478,7 @@ struct X {
   operator S();
 };
 X a{};
-S b{a};  // uses copy constructor in \CppXI,
+S b{a};  // uses copy constructor in \CppXI{},
          // performs aggregate initialization in this International Standard
 \end{codeblock}
 
@@ -1488,8 +1488,8 @@ S b{a};  // uses copy constructor in \CppXI,
 \change New header.
 \rationale New functionality.
 \effect
-The \Cpp header \tcode{<shared_mutex>} is new.
-Valid \CppXI code that \tcode{\#include}{s} a header with that name may be
+The \Cpp{} header \tcode{<shared_mutex>} is new.
+Valid \CppXI{} code that \tcode{\#include}{s} a header with that name may be
 invalid in this International Standard.
 
 \rSec2[diff.cpp11.input.output]{\ref{input.output}: input/output library}
@@ -1498,15 +1498,15 @@ invalid in this International Standard.
 \change \tcode{gets} is not defined.
 \rationale Use of \tcode{gets} is considered dangerous.
 \effect
-Valid \CppXI code that uses the \tcode{gets} function may fail to compile
+Valid \CppXI{} code that uses the \tcode{gets} function may fail to compile
 in this International Standard.
 
-\rSec1[diff.cpp14]{\Cpp and ISO \CppXIV}
+\rSec1[diff.cpp14]{\Cpp{} and ISO \CppXIV{}}
 
 \pnum
-\indextext{summary!compatibility with ISO \CppXIV}%
-This subclause lists the differences between \Cpp and
-ISO \CppXIV (ISO/IEC 14882:2014, \doccite{Programming Languages --- \Cpp}),
+\indextext{summary!compatibility with ISO \CppXIV{}}%
+This subclause lists the differences between \Cpp{} and
+ISO \CppXIV{} (ISO/IEC 14882:2014, \doccite{Programming Languages --- \Cpp{}}),
 by the chapters of this document.
 
 \rSec2[diff.cpp14.lex]{\ref{lex}: lexical conventions}
@@ -1516,9 +1516,9 @@ by the chapters of this document.
 \change Removal of trigraph support as a required feature.
 \rationale Prevents accidental uses of trigraphs in non-raw string literals and comments.
 \effect
-Valid \CppXIV code that uses trigraphs may not be valid or may have different
+Valid \CppXIV{} code that uses trigraphs may not be valid or may have different
 semantics in this International Standard. Implementations may choose to
-translate trigraphs as specified in \CppXIV if they appear outside of a raw
+translate trigraphs as specified in \CppXIV{} if they appear outside of a raw
 string literal, as part of the \impldef{mapping from physical source file characters
 to basic source character set} mapping from physical source file characters to
 the basic source character set.
@@ -1528,14 +1528,14 @@ the basic source character set.
 \tcode{P} \grammarterm{sign}.
 \rationale Necessary to enable hexadecimal floating literals.
 \effect
-Valid \CppXIV code may fail to compile or produce different results in
+Valid \CppXIV{} code may fail to compile or produce different results in
 this International Standard. Specifically, character sequences like \tcode{0p+0}
-and \tcode{0e1_p+0} are three separate tokens each in \CppXIV, but one single token
+and \tcode{0e1_p+0} are three separate tokens each in \CppXIV{}, but one single token
 in this International Standard.
 
 \begin{codeblock}
 #define F(a) b ## a
-int b0p = F(0p+0);  // ill-formed; equivalent to ``\tcode{int b0p = b0p + 0;}\!'' in \CppXIV
+int b0p = F(0p+0);  // ill-formed; equivalent to ``\tcode{int b0p = b0p + 0;}\!'' in \CppXIV{}
 \end{codeblock}
 
 \rSec2[diff.cpp14.expr]{\ref{expr}: expressions}
@@ -1544,7 +1544,7 @@ int b0p = F(0p+0);  // ill-formed; equivalent to ``\tcode{int b0p = b0p + 0;}\!'
 \change
 Remove increment operator with \tcode{bool} operand.
 \rationale Obsolete feature with occasionally surprising semantics.
-\effect A valid \CppXIV expression utilizing the increment operator on
+\effect A valid \CppXIV{} expression utilizing the increment operator on
 a \tcode{bool} lvalue is ill-formed in this International Standard.
 Note that this might occur when the lvalue has a type given by a template
 parameter.
@@ -1552,7 +1552,7 @@ parameter.
 \ref{expr.new}, \ref{expr.delete}
 \change Dynamic allocation mechanism for over-aligned types.
 \rationale Simplify use of over-aligned types.
-\effect In \CppXIV code that uses a \grammarterm{new-expression}
+\effect In \CppXIV{} code that uses a \grammarterm{new-expression}
 to allocate an object with an over-aligned class type,
 where that class has no allocation functions of its own,
 \tcode{::operator new(std::size_t)}
@@ -1568,7 +1568,7 @@ is used instead.
 \change Removal of \tcode{register} \grammarterm{storage-class-specifier}.
 \rationale Enable repurposing of deprecated keyword in future revisions of this International Standard.
 \effect
-A valid \CppXIV declaration utilizing the \tcode{register}
+A valid \CppXIV{} declaration utilizing the \tcode{register}
 \grammarterm{storage-class-specifier} is ill-formed in this International Standard.
 The specifier can simply be removed to retain the original meaning.
 
@@ -1576,7 +1576,7 @@ The specifier can simply be removed to retain the original meaning.
 \change \tcode{auto} deduction from \grammarterm{braced-init-list}.
 \rationale More intuitive deduction behavior.
 \effect
-Valid \CppXIV code may fail to compile or may change meaning
+Valid \CppXIV{} code may fail to compile or may change meaning
 in this International Standard. For example:
 \begin{codeblock}
 auto x1{1};    // was \tcode{std::initializer_list<int>}, now \tcode{int}
@@ -1589,7 +1589,7 @@ auto x2{1, 2}; // was \tcode{std::initializer_list<int>}, now ill-formed
 \change Make exception specifications be part of the type system.
 \rationale Improve type-safety.
 \effect
-Valid \CppXIV code may fail to compile or change meaning in this
+Valid \CppXIV{} code may fail to compile or change meaning in this
 International Standard:
 
 \begin{codeblock}
@@ -1604,7 +1604,7 @@ int x = f(g1, g2);    // ill-formed; previously well-formed
 to apply to user-defined types with base classes.
 \rationale To increase convenience of aggregate initialization.
 \effect
-Valid \CppXIV code may fail to compile or produce different results in this
+Valid \CppXIV{} code may fail to compile or produce different results in this
 International Standard; initialization from an empty initializer list will
 perform aggregate initialization instead of invoking a default constructor
 for the affected types:
@@ -1629,7 +1629,7 @@ Inheriting a constructor no longer injects a constructor into the derived class.
 \rationale
 Better interaction with other language features.
 \effect
-Valid \CppXIV code that uses inheriting constructors may not be valid
+Valid \CppXIV{} code that uses inheriting constructors may not be valid
 or may have different semantics. A \grammarterm{using-declaration}
 that names a constructor now makes the corresponding base class constructors
 visible to initializations of the derived class
@@ -1656,7 +1656,7 @@ B b(42L); // now calls \tcode{B(int)}, used to call \tcode{B<long>(long)},
 non-type template arguments with placeholder types,
 allows partial specializations to decompose
 from the type deduced for the non-type template argument.
-\effect Valid \CppXIV code may fail to compile
+\effect Valid \CppXIV{} code may fail to compile
 or produce different results in this International Standard:
 \begin{codeblock}
 template <int N> struct A;
@@ -1677,7 +1677,7 @@ They interacted badly with the type system,
 which became a more significant issue in this International Standard
 where (non-dynamic) exception specifications are part of the function type.
 \effect
-A valid \CppXIV function declaration,
+A valid \CppXIV{} function declaration,
 member function declaration,
 function pointer declaration,
 or function reference declaration,
@@ -1698,7 +1698,7 @@ that might otherwise be incompatible with existing programs.
 The global namespaces \tcode{std}
 followed by an arbitrary sequence of digits
 is reserved for future standardization.
-Valid \CppXIV code that uses such a top-level namespace,
+Valid \CppXIV{} code that uses such a top-level namespace,
 e.g., \tcode{std2}, may be invalid in this International Standard.
 
 \rSec2[diff.cpp14.utilities]{\ref{utilities}: general utilities library}
@@ -1707,7 +1707,7 @@ e.g., \tcode{std2}, may be invalid in this International Standard.
 \change Constructors taking allocators removed.
 \rationale No implementation consensus.
 \effect
-Valid \CppXIV code may fail to compile or may change meaning in this
+Valid \CppXIV{} code may fail to compile or may change meaning in this
 International Standard. Specifically, constructing a \tcode{std::function} with
 an allocator is ill-formed and uses-allocator construction will not pass an
 allocator to \tcode{std::function} constructors in this International Standard.
@@ -1717,7 +1717,7 @@ allocator to \tcode{std::function} constructors in this International Standard.
 \rationale Adding array support to \tcode{shared_ptr},
 via the syntax \tcode{shared_ptr<T[]>} and \tcode{shared_ptr<T[N]>}.
 \effect
-Valid \CppXIV code may fail to compile or may change meaning in this
+Valid \CppXIV{} code may fail to compile or may change meaning in this
 International Standard.
 For example:
 
@@ -1754,7 +1754,7 @@ int x = f(s.data()); // ill-formed; previously well-formed
 \change Requirements change:
 \rationale Increase portability, clarification of associative container requirements.
 \effect
-Valid \CppXIV code that attempts to use associative containers
+Valid \CppXIV{} code that attempts to use associative containers
 having a comparison object with non-const function call operator
 may fail to compile in this International Standard:
 
@@ -1792,22 +1792,22 @@ and the function templates (and their return types)
 \tcode{bind2nd}
 are not defined.
 \rationale Superseded by new features.
-\effect Valid \CppXIV code that uses these class templates
+\effect Valid \CppXIV{} code that uses these class templates
 and function templates may fail to compile in this International Standard.
 
 \change
 Remove old iostreams members [depr.ios.members].
 \rationale Redundant feature for compatibility with pre-standard code
 has served its time.
-\effect A valid \CppXIV program using these identifiers
+\effect A valid \CppXIV{} program using these identifiers
 may be ill-formed in this International Standard.
 
-\rSec1[diff.cpp17]{\Cpp and ISO \CppXVII}
+\rSec1[diff.cpp17]{\Cpp{} and ISO \CppXVII{}}
 
 \pnum
-\indextext{summary!compatibility with ISO \CppXVII}%
-This subclause lists the differences between \Cpp and
-ISO \CppXVII (ISO/IEC 14882:2017, \doccite{Programming Languages --- \Cpp}),
+\indextext{summary!compatibility with ISO \CppXVII{}}%
+This subclause lists the differences between \Cpp{} and
+ISO \CppXVII{} (ISO/IEC 14882:2017, \doccite{Programming Languages --- \Cpp{}}),
 by the chapters of this document.
 
 \rSec2[diff.cpp17.lex]{\ref{lex}: lexical conventions}
@@ -1820,7 +1820,7 @@ to introduce constraints through a \grammarterm{requires-clause} or
 a \grammarterm{requires-expression}. The \tcode{concept} keyword is
 added to enable the definition of concepts\iref{temp.concept}.
 \effect
-Valid ISO \CppXVII code using \tcode{concept} or \tcode{requires}
+Valid ISO \CppXVII{} code using \tcode{concept} or \tcode{requires}
 as an identifier is not valid in this International Standard.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -1830,35 +1830,35 @@ as an identifier is not valid in this International Standard.
 \pnum
 This subclause summarizes the explicit changes in headers,
 definitions, declarations, or behavior between the C standard library
-in the C standard and the parts of the \Cpp standard library that were
+in the C standard and the parts of the \Cpp{} standard library that were
 included from the C standard library.
 
 \rSec2[diff.mods.to.headers]{Modifications to headers}
 
 \pnum
 For compatibility with the C standard library\indextext{library!C standard},
-the \Cpp standard library provides the C headers enumerated
-in~\ref{depr.c.headers}, but their use is deprecated in \Cpp.
+the \Cpp{} standard library provides the C headers enumerated
+in~\ref{depr.c.headers}, but their use is deprecated in \Cpp{}.
 
 \pnum
-There are no \Cpp headers for the C headers
+There are no \Cpp{} headers for the C headers
 \tcode{<stdatomic.h>}\indextext{\idxhdr{stdatomic.h}},
 \tcode{<stdnoreturn.h>}\indextext{\idxhdr{stdnoreturn.h}},
 and \tcode{<threads.h>}\indextext{\idxhdr{threads.h}},
-nor are the C headers themselves part of \Cpp.
+nor are the C headers themselves part of \Cpp{}.
 
 \pnum
-The \Cpp headers \tcode{<ccomplex>}\indextext{\idxhdr{ccomplex}}\iref{depr.ccomplex.syn}
+The \Cpp{} headers \tcode{<ccomplex>}\indextext{\idxhdr{ccomplex}}\iref{depr.ccomplex.syn}
 and \tcode{<ctgmath>}\indextext{\idxhdr{ctgmath}}\iref{depr.ctgmath.syn}, as well
 as their corresponding C headers \tcode{<complex.h>}\indextext{\idxhdr{complex.h}}
 and \tcode{<tgmath.h>}\indextext{\idxhdr{tgmath.h}}, do not contain any of the
 content from the C standard library and instead merely include other headers
-from the \Cpp standard library.
+from the \Cpp{} standard library.
 
 \pnum
 The headers \tcode{<ciso646>}, \tcode{<cstdalign>}\iref{depr.cstdalign.syn},
-and \tcode{<cstdbool>}\iref{depr.cstdbool.syn} are meaningless in \Cpp. Use of
-the \Cpp headers \tcode{<ccomplex>}, \tcode{<cstdalign>}, \tcode{<cstdbool>},
+and \tcode{<cstdbool>}\iref{depr.cstdbool.syn} are meaningless in \Cpp{}. Use of
+the \Cpp{} headers \tcode{<ccomplex>}, \tcode{<cstdalign>}, \tcode{<cstdbool>},
 and \tcode{<ctgmath>} is deprecated\iref{depr.c.headers}.
 
 \rSec2[diff.mods.to.definitions]{Modifications to definitions}
@@ -1946,7 +1946,7 @@ defined in any of
 \tcode{<cstring>}\iref{cstring.syn}\indexlibrary{\idxhdr{cstring}},
 \tcode{<ctime>}\iref{ctime.syn}\indexlibrary{\idxhdr{ctime}},
 or \tcode{<cwchar>}\iref{cwchar.syn}\indexlibrary{\idxhdr{cwchar}},
-is an \impldef{definition of \tcode{NULL}} \Cpp null pointer constant in
+is an \impldef{definition of \tcode{NULL}} \Cpp{} null pointer constant in
 this International Standard\iref{support.types}.
 
 \rSec2[diff.mods.to.declarations]{Modifications to declarations}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -4,7 +4,7 @@
 \rSec1[containers.general]{General}
 
 \pnum
-This Clause describes components that \Cpp programs may use to
+This Clause describes components that \Cpp{} programs may use to
 organize collections of information.
 
 \pnum

--- a/source/conversions.tex
+++ b/source/conversions.tex
@@ -129,7 +129,7 @@ program that necessitates this conversion is ill-formed. If \tcode{T}
 is a non-class type, the type of the prvalue is
 the cv-unqualified version of \tcode{T}. Otherwise, the type of the
 prvalue is \tcode{T}.%
-\footnote{In \Cpp class and array prvalues can have cv-qualified types.
+\footnote{In \Cpp{} class and array prvalues can have cv-qualified types.
 This differs from ISO C, in which non-lvalues never have
 cv-qualified types.}
 

--- a/source/cover-reg.tex
+++ b/source/cover-reg.tex
@@ -22,9 +22,9 @@ Secretariat: ANSI
 
 \vfill
 
-\textbf{\LARGE Programming Languages --- \Cpp}
+\textbf{\LARGE Programming Languages --- \Cpp{}}
 
-Langages de programmation --- \Cpp
+Langages de programmation --- \Cpp{}
 
 \vfill
 

--- a/source/cover-wd.tex
+++ b/source/cover-wd.tex
@@ -22,7 +22,7 @@
 \vspace{2.5cm}
 \begin{center}
 \textbf{\Huge
-Working Draft, Standard for Programming Language \Cpp}
+Working Draft, Standard for Programming Language \Cpp{}}
 \end{center}
 \vfill
 \textbf{Note: this is an early draft. It's known to be incomplet and

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -45,19 +45,19 @@ the form
 
 \begin{bnf}
 \nontermdef{nodeclspec-function-declaration}\br
-    attribute-specifier-seq\opt{} declarator \terminal{;}
+    \opt{attribute-specifier-seq} declarator \terminal{;}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{alias-declaration}\br
-    \terminal{using} identifier attribute-specifier-seq\opt{} \terminal{=} defining-type-id \terminal{;}
+    \terminal{using} identifier \opt{attribute-specifier-seq} \terminal{=} defining-type-id \terminal{;}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{simple-declaration}\br
-    decl-specifier-seq init-declarator-list\opt{} \terminal{;}\br
+    decl-specifier-seq \opt{init-declarator-list} \terminal{;}\br
     attribute-specifier-seq decl-specifier-seq init-declarator-list \terminal{;}\br
-    attribute-specifier-seq\opt{} decl-specifier-seq ref-qualifier\opt{} \terminal{[} identifier-list \terminal{]} initializer \terminal{;}
+    \opt{attribute-specifier-seq} decl-specifier-seq \opt{ref-qualifier} \terminal{[} identifier-list \terminal{]} initializer \terminal{;}
 \end{bnf}
 
 \begin{bnf}
@@ -93,7 +93,7 @@ A
 \grammarterm{nodeclspec-function-declaration} of the form
 
 \begin{ncsimplebnf}
-attribute-specifier-seq\opt{} decl-specifier-seq\opt{} init-declarator-list\opt{} \terminal{;}
+\opt{attribute-specifier-seq} \opt{decl-specifier-seq} \opt{init-declarator-list} \terminal{;}
 \end{ncsimplebnf}
 
 is divided into three parts.
@@ -259,7 +259,7 @@ The specifiers that can be used in a declaration are
 
 \begin{bnf}
 \nontermdef{decl-specifier-seq}\br
-    decl-specifier attribute-specifier-seq\opt{}\br
+    decl-specifier \opt{attribute-specifier-seq}\br
     decl-specifier decl-specifier-seq
 \end{bnf}
 
@@ -1035,7 +1035,7 @@ The type-specifiers are
 
 \begin{bnf}
 \nontermdef{type-specifier-seq}\br
-    type-specifier attribute-specifier-seq\opt{}\br
+    type-specifier \opt{attribute-specifier-seq}\br
     type-specifier type-specifier-seq
 \end{bnf}
 
@@ -1048,7 +1048,7 @@ The type-specifiers are
 
 \begin{bnf}
 \nontermdef{defining-type-specifier-seq}\br
-  defining-type-specifier attribute-specifier-seq\opt{}\br
+  defining-type-specifier \opt{attribute-specifier-seq}\br
   defining-type-specifier defining-type-specifier-seq
 \end{bnf}
 
@@ -1225,9 +1225,9 @@ The simple type specifiers are
 
 \begin{bnf}
 \nontermdef{simple-type-specifier}\br
-    nested-name-specifier\opt{} type-name\br
+    \opt{nested-name-specifier} type-name\br
     nested-name-specifier \terminal{template} simple-template-id\br
-    nested-name-specifier\opt{} template-name\br
+    \opt{nested-name-specifier} template-name\br
     \terminal{char}\br
     \terminal{char16_t}\br
     \terminal{char32_t}\br
@@ -1459,10 +1459,10 @@ void r() {
 
 \begin{bnf}
 \nontermdef{elaborated-type-specifier}\br
-    class-key attribute-specifier-seq\opt{} nested-name-specifier\opt{} identifier\br
+    class-key \opt{attribute-specifier-seq} \opt{nested-name-specifier} identifier\br
     class-key simple-template-id\br
-    class-key nested-name-specifier \terminal{template}\opt{} simple-template-id\br
-    \terminal{enum} nested-name-specifier\opt{} identifier
+    class-key nested-name-specifier \opt{\terminal{template}} simple-template-id\br
+    \terminal{enum} \opt{nested-name-specifier} identifier
 \end{bnf}
 
 \pnum
@@ -1477,11 +1477,11 @@ instantiation\iref{temp.explicit} or it has one of the following
 forms:
 
 \begin{ncsimplebnf}
-class-key attribute-specifier-seq\opt{} identifier \terminal{;}\br
-\terminal{friend} class-key \terminal{::\opt{}} identifier \terminal{;}\br
-\terminal{friend} class-key \terminal{::\opt{}} simple-template-id \terminal{;}\br
+class-key \opt{attribute-specifier-seq} identifier \terminal{;}\br
+\terminal{friend} class-key \terminal{\opt{::}} identifier \terminal{;}\br
+\terminal{friend} class-key \terminal{\opt{::}} simple-template-id \terminal{;}\br
 \terminal{friend} class-key nested-name-specifier identifier \terminal{;}\br
-\terminal{friend} class-key nested-name-specifier \terminal{template\opt{}} simple-template-id \terminal{;}
+\terminal{friend} class-key nested-name-specifier \terminal{\opt{template}} simple-template-id \terminal{;}
 \end{ncsimplebnf}
 
 In the first case, the \grammarterm{attribute-specifier-seq}, if any, appertains
@@ -1906,23 +1906,23 @@ constants. Its name becomes an \grammarterm{enum-name} within its scope.
 
 \begin{bnf}
 \nontermdef{enum-specifier}\br
-    enum-head \terminal{\{} enumerator-list\opt{} \terminal{\}}\br
+    enum-head \terminal{\{} \opt{enumerator-list} \terminal{\}}\br
     enum-head \terminal{\{} enumerator-list \terminal{, \}}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{enum-head}\br
-    enum-key attribute-specifier-seq\opt{} enum-head-name\opt{} enum-base\opt{}
+    enum-key \opt{attribute-specifier-seq} \opt{enum-head-name} \opt{enum-base}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{enum-head-name}\br
-    nested-name-specifier\opt{} identifier
+    \opt{nested-name-specifier} identifier
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{opaque-enum-declaration}\br
-    enum-key attribute-specifier-seq\opt{} nested-name-specifier\opt{} identifier enum-base\opt{} \terminal{;}
+    enum-key \opt{attribute-specifier-seq} \opt{nested-name-specifier} identifier \opt{enum-base} \terminal{;}
 \end{bnf}
 
 \begin{bnf}
@@ -1951,7 +1951,7 @@ constants. Its name becomes an \grammarterm{enum-name} within its scope.
 
 \begin{bnf}
 \nontermdef{enumerator}\br
-    identifier attribute-specifier-seq\opt{}
+    identifier \opt{attribute-specifier-seq}
 \end{bnf}
 
 The optional \grammarterm{attribute-specifier-seq} in the \grammarterm{enum-head} and
@@ -1959,7 +1959,7 @@ the \grammarterm{opaque-enum-declaration} appertains to the enumeration; the att
 in that \grammarterm{attribute-specifier-seq} are thereafter considered attributes of the
 enumeration whenever it is named.
 A \tcode{:} following
-``\tcode{enum} \grammarterm{nested-name-specifier}\opt{} \grammarterm{identifier}''
+``\tcode{enum} \opt{\grammarterm{nested-name-specifier}} \grammarterm{identifier}''
 within the \grammarterm{decl-specifier-seq} of a \grammarterm{member-declaration}
 is parsed as part of an \grammarterm{enum-base}.
 \begin{note} This resolves a potential ambiguity between the declaration of an enumeration
@@ -2260,12 +2260,12 @@ see~\ref{basic.scope.namespace}.
 
 \begin{bnf}
 \nontermdef{named-namespace-definition}\br
-        \terminal{inline\opt{}} \terminal{namespace} attribute-specifier-seq\opt{} identifier \terminal{\{} namespace-body \terminal{\}}
+        \terminal{\opt{inline}} \terminal{namespace} \opt{attribute-specifier-seq} identifier \terminal{\{} namespace-body \terminal{\}}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{unnamed-namespace-definition}\br
-        \terminal{inline\opt{}} \terminal{namespace} attribute-specifier-seq\opt{} \terminal{\{} namespace-body \terminal{\}}
+        \terminal{\opt{inline}} \terminal{namespace} \opt{attribute-specifier-seq} \terminal{\{} namespace-body \terminal{\}}
 \end{bnf}
 
 \begin{bnf}
@@ -2281,7 +2281,7 @@ see~\ref{basic.scope.namespace}.
 
 \begin{bnf}
 \nontermdef{namespace-body}\br
-        declaration-seq\opt{}
+        \opt{declaration-seq}
 \end{bnf}
 
 \pnum
@@ -2418,7 +2418,7 @@ An \grammarterm{unnamed-namespace-definition} behaves as if it were
 replaced by
 
 \begin{ncsimplebnf}
-\terminal{inline}\opt{} \terminal{namespace} \terminal{\uniquens} \terminal{\{ /* empty body */ \}}\br
+\opt{\terminal{inline}} \terminal{namespace} \terminal{\uniquens} \terminal{\{ /* empty body */ \}}\br
 \terminal{using namespace} \terminal{\uniquens} \terminal{;}\br
 \terminal{namespace} \terminal{\uniquens} \terminal{\{} namespace-body \terminal{\}}
 \end{ncsimplebnf}
@@ -2463,7 +2463,7 @@ whose \grammarterm{declarator-id} is an \grammarterm{unqualified-id}\iref{dcl.me
 whose \grammarterm{class-head-name}\iref{class} or
 \grammarterm{enum-head-name}\iref{dcl.enum} is an \grammarterm{identifier}, or
 whose \grammarterm{elaborated-type-specifier} is of the form \grammarterm{class-key}
-\grammarterm{attribute-specifier-seq}\opt{} \grammarterm{identifier}\iref{dcl.type.elab}, or
+\opt{\grammarterm{attribute-specifier-seq}} \grammarterm{identifier}\iref{dcl.type.elab}, or
 that is an \grammarterm{opaque-enum-declaration},
 declares (or redeclares) its \grammarterm{unqualified-id} or
 \grammarterm{identifier} as a member of \tcode{N}.
@@ -2592,7 +2592,7 @@ namespace according to the following grammar:
 
 \begin{bnf}
 \nontermdef{qualified-namespace-specifier}\br
-    nested-name-specifier\opt{} namespace-name
+    \opt{nested-name-specifier} namespace-name
 \end{bnf}
 
 \pnum
@@ -2632,13 +2632,13 @@ namespace CWVLN = CWVLN;
 
 \begin{bnf}
 \nontermdef{using-declarator-list}\br
-    using-declarator \terminal{...}\opt{}\br
-    using-declarator-list \terminal{,} using-declarator \terminal{...}\opt{}
+    using-declarator \opt{\terminal{...}}\br
+    using-declarator-list \terminal{,} using-declarator \opt{\terminal{...}}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{using-declarator}\br
-    \terminal{typename\opt{}} nested-name-specifier unqualified-id
+    \terminal{\opt{typename}} nested-name-specifier unqualified-id
 \end{bnf}
 
 \pnum
@@ -3112,7 +3112,7 @@ specifies a dependent name\iref{temp.dep}, the name introduced by the
 
 \begin{bnf}
 \nontermdef{using-directive}\br
-    attribute-specifier-seq\opt{} \terminal{using  namespace} nested-name-specifier\opt{} namespace-name \terminal{;}
+    \opt{attribute-specifier-seq} \terminal{using  namespace} \opt{nested-name-specifier} namespace-name \terminal{;}
 \end{bnf}
 
 \pnum
@@ -3367,7 +3367,7 @@ be achieved using a \grammarterm{linkage-specification}:
 %
 \begin{bnf}
 \nontermdef{linkage-specification}\br
-    \terminal{extern} string-literal \terminal{\{} declaration-seq\opt{} \terminal{\}}\br
+    \terminal{extern} string-literal \terminal{\{} \opt{declaration-seq} \terminal{\}}\br
     \terminal{extern} string-literal declaration
 \end{bnf}
 
@@ -3587,19 +3587,19 @@ such as types, variables, names, blocks, or translation units.
 
 \begin{bnf}
 \nontermdef{attribute-specifier-seq}\br
-  attribute-specifier-seq\opt{} attribute-specifier
+  \opt{attribute-specifier-seq} attribute-specifier
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{attribute-specifier}\br
-  \terminal{[} \terminal{[} attribute-using-prefix\opt{} attribute-list \terminal{]} \terminal{]}\br
+  \terminal{[} \terminal{[} \opt{attribute-using-prefix} attribute-list \terminal{]} \terminal{]}\br
   alignment-specifier
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{alignment-specifier}\br
-  \terminal{alignas (} type-id \terminal{...}\opt{} \terminal{)}\br
-  \terminal{alignas (} constant-expression \terminal{...}\opt{} \terminal{)}
+  \terminal{alignas (} type-id \opt{\terminal{...}} \terminal{)}\br
+  \terminal{alignas (} constant-expression \opt{\terminal{...}} \terminal{)}
 \end{bnf}
 
 \begin{bnf}
@@ -3609,15 +3609,15 @@ such as types, variables, names, blocks, or translation units.
 
 \begin{bnf}
 \nontermdef{attribute-list}\br
-  attribute\opt{}\br
-  attribute-list \terminal{,} attribute\opt{}\br
+  \opt{attribute}\br
+  attribute-list \terminal{,} \opt{attribute}\br
   attribute \terminal{...}\br
   attribute-list \terminal{,} attribute \terminal{...}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{attribute}\br
-    attribute-token attribute-argument-clause\opt{}
+    attribute-token \opt{attribute-argument-clause}
 \end{bnf}
 
 \begin{bnf}
@@ -3638,7 +3638,7 @@ such as types, variables, names, blocks, or translation units.
 
 \begin{bnf}
 \nontermdef{attribute-argument-clause}\br
-    \terminal{(} balanced-token-seq\opt{} \terminal{)}
+    \terminal{(} \opt{balanced-token-seq} \terminal{)}
 \end{bnf}
 
 \begin{bnf}
@@ -3649,9 +3649,9 @@ such as types, variables, names, blocks, or translation units.
 
 \begin{bnf}
 \nontermdef{balanced-token}\br
-    \terminal{(} balanced-token-seq\opt{} \terminal{)}\br
-    \terminal{[} balanced-token-seq\opt{} \terminal{]}\br
-    \terminal{\{} balanced-token-seq\opt{} \terminal{\}}\br
+    \terminal{(} \opt{balanced-token-seq} \terminal{)}\br
+    \terminal{[} \opt{balanced-token-seq} \terminal{]}\br
+    \terminal{\{} \opt{balanced-token-seq} \terminal{\}}\br
     \textnormal{any \grammarterm{token} other than a parenthesis, a bracket, or a brace}
 \end{bnf}
 

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1282,7 +1282,7 @@ is a placeholder for
 a type to be deduced\iref{dcl.spec.auto}.
 \indextext{deduction!class template arguments}%
 A \grammarterm{type-specifier} of the form
-\tcode{typename}\opt{} \grammarterm{nested-name-specifier}\opt{} \grammarterm{template-name}
+\opt{\tcode{typename}} \opt{\grammarterm{nested-name-specifier}} \grammarterm{template-name}
 is a placeholder for
 a deduced class type\iref{dcl.type.class.deduct}.
 The \grammarterm{template-name} shall name a class template

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1213,7 +1213,7 @@ be changed by means undetectable by an implementation.
 Furthermore, for some implementations, \tcode{volatile} might indicate that
 special hardware instructions are required to access the object.
 See~\ref{intro.execution} for detailed semantics. In general, the
-semantics of \tcode{volatile} are intended to be the same in \Cpp as
+semantics of \tcode{volatile} are intended to be the same in \Cpp{} as
 they are in C.
 \end{note}
 
@@ -3354,12 +3354,12 @@ particular form of representing names of objects and functions with
 external linkage, or with a particular calling convention, etc.
 \end{note}
 The default language linkage of all function types, function names, and
-variable names is \Cpp language linkage. Two function types with
+variable names is \Cpp{} language linkage. Two function types with
 different language linkages are distinct types even if they are
 otherwise identical.
 
 \pnum
-Linkage\iref{basic.link} between \Cpp and  non-\Cpp code fragments can
+Linkage\iref{basic.link} between \Cpp{} and  non-\Cpp{} code fragments can
 be achieved using a \grammarterm{linkage-specification}:
 
 \indextext{\idxgram{linkage-specification}}%
@@ -3392,10 +3392,10 @@ the vintage.
 Every implementation shall provide for linkage to functions written in
 the C programming language,
 \indextext{C!linkage to}%
-\tcode{"C"}, and linkage to \Cpp functions, \tcode{"C++"}.
+\tcode{"C"}, and linkage to \Cpp{} functions, \tcode{"C++"}.
 \begin{example}
 \begin{codeblock}
-complex sqrt(complex);          // \Cpp linkage by default
+complex sqrt(complex);          // \Cpp{} linkage by default
 extern "C" {
   double sqrt(double);          // C linkage
 }
@@ -3418,13 +3418,13 @@ extern "C"                      // the name \tcode{f1} and its function type hav
   void f1(void(*pf)(int));      // \tcode{pf} is a pointer to a C function
 
 extern "C" typedef void FUNC();
-FUNC f2;                        // the name \tcode{f2} has \Cpp language linkage and the
+FUNC f2;                        // the name \tcode{f2} has \Cpp{} language linkage and the
                                 // function's type has C language linkage
 
 extern "C" FUNC f3;             // the name of function \tcode{f3} and the function's type have C language linkage
 
-void (*pf2)(FUNC*);             // the name of the variable \tcode{pf2} has \Cpp linkage and the type
-                                // of \tcode{pf2} is ``pointer to \Cpp function that takes one parameter of type
+void (*pf2)(FUNC*);             // the name of the variable \tcode{pf2} has \Cpp{} linkage and the type
+                                // of \tcode{pf2} is ``pointer to \Cpp{} function that takes one parameter of type
                                 // pointer to C function''
 extern "C" {
   static void f4();             // the name of the function \tcode{f4} has internal linkage (not C language linkage)
@@ -3456,20 +3456,20 @@ extern "C" typedef void FUNC_c();
 
 class C {
   void mf1(FUNC_c*);            // the name of the function \tcode{mf1} and the member function's type have
-                                // \Cpp language linkage; the parameter has type ``pointer to C function''
+                                // \Cpp{} language linkage; the parameter has type ``pointer to C function''
 
   FUNC_c mf2;                   // the name of the function \tcode{mf2} and the member function's type have
-                                // \Cpp language linkage
+                                // \Cpp{} language linkage
 
-  static FUNC_c* q;             // the name of the data member \tcode{q} has \Cpp language linkage and
+  static FUNC_c* q;             // the name of the data member \tcode{q} has \Cpp{} language linkage and
                                 // the data member's type is ``pointer to C function''
 };
 
 extern "C" {
   class X {
     void mf();                  // the name of the function \tcode{mf} and the member function's type have
-                                // \Cpp language linkage
-    void mf2(void(*)());        // the name of the function \tcode{mf2} has \Cpp language linkage;
+                                // \Cpp{} language linkage
+    void mf2(void(*)());        // the name of the function \tcode{mf2} has \Cpp{} language linkage;
                                 // the parameter has type ``pointer to C function''
   };
 }
@@ -3484,7 +3484,7 @@ namespace and the declarations give the names different language linkages, the
 program is ill-formed; no diagnostic is required if the declarations appear in
 different translation units.
 \indextext{consistency!linkage specification}%
-Except for functions with \Cpp linkage, a function declaration without a
+Except for functions with \Cpp{} linkage, a function declaration without a
 linkage specification shall not precede the first linkage specification
 for that function. A function can be declared without a linkage
 specification after an explicit linkage specification has been seen; the
@@ -3568,8 +3568,8 @@ which the resulting lvalue refers is considered a C function.
 \pnum
 \indextext{object!linkage specification}%
 \indextext{linkage!implementation-defined object}%
-Linkage from \Cpp to objects defined in other languages and to objects
-defined in \Cpp from other languages is \impldef{linkage of objects between \Cpp and other languages} and
+Linkage from \Cpp{} to objects defined in other languages and to objects
+defined in \Cpp{} from other languages is \impldef{linkage of objects between \Cpp{} and other languages} and
 language-dependent. Only where the object layout strategies of two
 language implementations are similar enough can such linkage be
 achieved.%

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -45,7 +45,7 @@ the form
 
 \begin{bnf}
 \nontermdef{nodeclspec-function-declaration}\br
-    attribute-specifier-seq\opt declarator \terminal{;}
+    attribute-specifier-seq\opt{} declarator \terminal{;}
 \end{bnf}
 
 \begin{bnf}
@@ -57,7 +57,7 @@ the form
 \nontermdef{simple-declaration}\br
     decl-specifier-seq init-declarator-list\opt{} \terminal{;}\br
     attribute-specifier-seq decl-specifier-seq init-declarator-list \terminal{;}\br
-    attribute-specifier-seq\opt decl-specifier-seq ref-qualifier\opt{} \terminal{[} identifier-list \terminal{]} initializer \terminal{;}
+    attribute-specifier-seq\opt{} decl-specifier-seq ref-qualifier\opt{} \terminal{[} identifier-list \terminal{]} initializer \terminal{;}
 \end{bnf}
 
 \begin{bnf}
@@ -93,7 +93,7 @@ A
 \grammarterm{nodeclspec-function-declaration} of the form
 
 \begin{ncsimplebnf}
-attribute-specifier-seq\opt decl-specifier-seq\opt init-declarator-list\opt{} \terminal{;}
+attribute-specifier-seq\opt{} decl-specifier-seq\opt{} init-declarator-list\opt{} \terminal{;}
 \end{ncsimplebnf}
 
 is divided into three parts.
@@ -259,7 +259,7 @@ The specifiers that can be used in a declaration are
 
 \begin{bnf}
 \nontermdef{decl-specifier-seq}\br
-    decl-specifier attribute-specifier-seq\opt\br
+    decl-specifier attribute-specifier-seq\opt{}\br
     decl-specifier decl-specifier-seq
 \end{bnf}
 
@@ -1035,7 +1035,7 @@ The type-specifiers are
 
 \begin{bnf}
 \nontermdef{type-specifier-seq}\br
-    type-specifier attribute-specifier-seq\opt\br
+    type-specifier attribute-specifier-seq\opt{}\br
     type-specifier type-specifier-seq
 \end{bnf}
 
@@ -1048,7 +1048,7 @@ The type-specifiers are
 
 \begin{bnf}
 \nontermdef{defining-type-specifier-seq}\br
-  defining-type-specifier attribute-specifier-seq\opt\br
+  defining-type-specifier attribute-specifier-seq\opt{}\br
   defining-type-specifier defining-type-specifier-seq
 \end{bnf}
 
@@ -1225,9 +1225,9 @@ The simple type specifiers are
 
 \begin{bnf}
 \nontermdef{simple-type-specifier}\br
-    nested-name-specifier\opt type-name\br
+    nested-name-specifier\opt{} type-name\br
     nested-name-specifier \terminal{template} simple-template-id\br
-    nested-name-specifier\opt template-name\br
+    nested-name-specifier\opt{} template-name\br
     \terminal{char}\br
     \terminal{char16_t}\br
     \terminal{char32_t}\br
@@ -1459,10 +1459,10 @@ void r() {
 
 \begin{bnf}
 \nontermdef{elaborated-type-specifier}\br
-    class-key attribute-specifier-seq\opt nested-name-specifier\opt identifier\br
+    class-key attribute-specifier-seq\opt{} nested-name-specifier\opt{} identifier\br
     class-key simple-template-id\br
-    class-key nested-name-specifier \terminal{template}\opt simple-template-id\br
-    \terminal{enum} nested-name-specifier\opt identifier
+    class-key nested-name-specifier \terminal{template}\opt{} simple-template-id\br
+    \terminal{enum} nested-name-specifier\opt{} identifier
 \end{bnf}
 
 \pnum
@@ -1477,11 +1477,11 @@ instantiation\iref{temp.explicit} or it has one of the following
 forms:
 
 \begin{ncsimplebnf}
-class-key attribute-specifier-seq\opt identifier \terminal{;}\br
-\terminal{friend} class-key \terminal{::\opt} identifier \terminal{;}\br
-\terminal{friend} class-key \terminal{::\opt} simple-template-id \terminal{;}\br
+class-key attribute-specifier-seq\opt{} identifier \terminal{;}\br
+\terminal{friend} class-key \terminal{::\opt{}} identifier \terminal{;}\br
+\terminal{friend} class-key \terminal{::\opt{}} simple-template-id \terminal{;}\br
 \terminal{friend} class-key nested-name-specifier identifier \terminal{;}\br
-\terminal{friend} class-key nested-name-specifier \terminal{template\opt} simple-template-id \terminal{;}
+\terminal{friend} class-key nested-name-specifier \terminal{template\opt{}} simple-template-id \terminal{;}
 \end{ncsimplebnf}
 
 In the first case, the \grammarterm{attribute-specifier-seq}, if any, appertains
@@ -1912,17 +1912,17 @@ constants. Its name becomes an \grammarterm{enum-name} within its scope.
 
 \begin{bnf}
 \nontermdef{enum-head}\br
-    enum-key attribute-specifier-seq\opt enum-head-name\opt enum-base\opt
+    enum-key attribute-specifier-seq\opt{} enum-head-name\opt{} enum-base\opt{}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{enum-head-name}\br
-    nested-name-specifier\opt identifier
+    nested-name-specifier\opt{} identifier
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{opaque-enum-declaration}\br
-    enum-key attribute-specifier-seq\opt nested-name-specifier\opt identifier enum-base\opt{} \terminal{;}
+    enum-key attribute-specifier-seq\opt{} nested-name-specifier\opt{} identifier enum-base\opt{} \terminal{;}
 \end{bnf}
 
 \begin{bnf}
@@ -1951,7 +1951,7 @@ constants. Its name becomes an \grammarterm{enum-name} within its scope.
 
 \begin{bnf}
 \nontermdef{enumerator}\br
-    identifier attribute-specifier-seq\opt
+    identifier attribute-specifier-seq\opt{}
 \end{bnf}
 
 The optional \grammarterm{attribute-specifier-seq} in the \grammarterm{enum-head} and
@@ -2260,12 +2260,12 @@ see~\ref{basic.scope.namespace}.
 
 \begin{bnf}
 \nontermdef{named-namespace-definition}\br
-        \terminal{inline\opt} \terminal{namespace} attribute-specifier-seq\opt identifier \terminal{\{} namespace-body \terminal{\}}
+        \terminal{inline\opt{}} \terminal{namespace} attribute-specifier-seq\opt{} identifier \terminal{\{} namespace-body \terminal{\}}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{unnamed-namespace-definition}\br
-        \terminal{inline\opt} \terminal{namespace} attribute-specifier-seq\opt{} \terminal{\{} namespace-body \terminal{\}}
+        \terminal{inline\opt{}} \terminal{namespace} attribute-specifier-seq\opt{} \terminal{\{} namespace-body \terminal{\}}
 \end{bnf}
 
 \begin{bnf}
@@ -2281,7 +2281,7 @@ see~\ref{basic.scope.namespace}.
 
 \begin{bnf}
 \nontermdef{namespace-body}\br
-        declaration-seq\opt
+        declaration-seq\opt{}
 \end{bnf}
 
 \pnum
@@ -2592,7 +2592,7 @@ namespace according to the following grammar:
 
 \begin{bnf}
 \nontermdef{qualified-namespace-specifier}\br
-    nested-name-specifier\opt namespace-name
+    nested-name-specifier\opt{} namespace-name
 \end{bnf}
 
 \pnum
@@ -2632,13 +2632,13 @@ namespace CWVLN = CWVLN;
 
 \begin{bnf}
 \nontermdef{using-declarator-list}\br
-    using-declarator \terminal{...}\opt\br
-    using-declarator-list \terminal{,} using-declarator \terminal{...}\opt
+    using-declarator \terminal{...}\opt{}\br
+    using-declarator-list \terminal{,} using-declarator \terminal{...}\opt{}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{using-declarator}\br
-    \terminal{typename\opt} nested-name-specifier unqualified-id
+    \terminal{typename\opt{}} nested-name-specifier unqualified-id
 \end{bnf}
 
 \pnum
@@ -3112,7 +3112,7 @@ specifies a dependent name\iref{temp.dep}, the name introduced by the
 
 \begin{bnf}
 \nontermdef{using-directive}\br
-    attribute-specifier-seq\opt{} \terminal{using  namespace} nested-name-specifier\opt namespace-name \terminal{;}
+    attribute-specifier-seq\opt{} \terminal{using  namespace} nested-name-specifier\opt{} namespace-name \terminal{;}
 \end{bnf}
 
 \pnum
@@ -3587,7 +3587,7 @@ such as types, variables, names, blocks, or translation units.
 
 \begin{bnf}
 \nontermdef{attribute-specifier-seq}\br
-  attribute-specifier-seq\opt attribute-specifier
+  attribute-specifier-seq\opt{} attribute-specifier
 \end{bnf}
 
 \begin{bnf}
@@ -3609,15 +3609,15 @@ such as types, variables, names, blocks, or translation units.
 
 \begin{bnf}
 \nontermdef{attribute-list}\br
-  attribute\opt\br
-  attribute-list \terminal{,} attribute\opt\br
+  attribute\opt{}\br
+  attribute-list \terminal{,} attribute\opt{}\br
   attribute \terminal{...}\br
   attribute-list \terminal{,} attribute \terminal{...}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{attribute}\br
-    attribute-token attribute-argument-clause\opt
+    attribute-token attribute-argument-clause\opt{}
 \end{bnf}
 
 \begin{bnf}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3328,7 +3328,7 @@ An \tcode{asm} declaration has the form
 
 \begin{bnf}
 \nontermdef{asm-definition}\br
-    attribute-specifier-seq\opt{} \terminal{asm (} string-literal \terminal{) ;}
+    \opt{attribute-specifier-seq} \terminal{asm (} string-literal \terminal{) ;}
 \end{bnf}
 
 The \tcode{asm} declaration is conditionally-supported; its meaning is

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -943,7 +943,7 @@ See also~\ref{expr.unary} and~\ref{expr.mptr.oper}.
 The type ``pointer to member'' is distinct from the type ``pointer'',
 that is, a pointer to member is declared only by the pointer to member
 declarator syntax, and never by the pointer declarator syntax.
-There is no ``reference-to-member'' type in \Cpp.
+There is no ``reference-to-member'' type in \Cpp{}.
 \end{note}
 
 \rSec2[dcl.array]{Arrays}%
@@ -3168,7 +3168,7 @@ An empty initializer list
 shall not be used as the \grammarterm{initializer-clause}
 for an array of unknown bound.\footnote{The syntax provides for empty
 \grammarterm{initializer-list}{s},
-but nonetheless \Cpp does not have zero length arrays.}
+but nonetheless \Cpp{} does not have zero length arrays.}
 \begin{note}
 A default member initializer does not determine the bound for a member
 array of unknown bound.  Since the default member initializer is

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -27,7 +27,7 @@ each of which can have an initializer.
 
 \begin{bnf}
 \nontermdef{init-declarator}\br
-    declarator initializer\opt\br
+    declarator initializer\opt{}\br
     declarator requires-clause
 \end{bnf}
 
@@ -139,16 +139,16 @@ Declarators have the syntax
 
 \begin{bnf}
 \nontermdef{noptr-declarator}\br
-    declarator-id attribute-specifier-seq\opt\br
+    declarator-id attribute-specifier-seq\opt{}\br
     noptr-declarator parameters-and-qualifiers\br
-    noptr-declarator \terminal{[} constant-expression\opt{} \terminal{]} attribute-specifier-seq\opt\br
+    noptr-declarator \terminal{[} constant-expression\opt{} \terminal{]} attribute-specifier-seq\opt{}\br
     \terminal{(} ptr-declarator \terminal{)}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{parameters-and-qualifiers}\br
-    \terminal{(} parameter-declaration-clause \terminal{)} cv-qualifier-seq\opt\br
-\hspace*{\bnfindentinc}ref-qualifier\opt noexcept-specifier\opt attribute-specifier-seq\opt
+    \terminal{(} parameter-declaration-clause \terminal{)} cv-qualifier-seq\opt{}\br
+\hspace*{\bnfindentinc}ref-qualifier\opt{} noexcept-specifier\opt{} attribute-specifier-seq\opt{}
 \end{bnf}
 
 \begin{bnf}
@@ -158,15 +158,15 @@ Declarators have the syntax
 
 \begin{bnf}
 \nontermdef{ptr-operator}\br
-    \terminal{*} attribute-specifier-seq\opt cv-qualifier-seq\opt\br
-    \terminal{\&} attribute-specifier-seq\opt\br
-    \terminal{\&\&} attribute-specifier-seq\opt\br
-    nested-name-specifier \terminal{*} attribute-specifier-seq\opt cv-qualifier-seq\opt
+    \terminal{*} attribute-specifier-seq\opt{} cv-qualifier-seq\opt{}\br
+    \terminal{\&} attribute-specifier-seq\opt{}\br
+    \terminal{\&\&} attribute-specifier-seq\opt{}\br
+    nested-name-specifier \terminal{*} attribute-specifier-seq\opt{} cv-qualifier-seq\opt{}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{cv-qualifier-seq}\br
-    cv-qualifier cv-qualifier-seq\opt
+    cv-qualifier cv-qualifier-seq\opt{}
 \end{bnf}
 
 \begin{bnf}
@@ -183,7 +183,7 @@ Declarators have the syntax
 
 \begin{bnf}
 \nontermdef{declarator-id}\br
-    \terminal{...}\opt id-expression
+    \terminal{...}\opt{} id-expression
 \end{bnf}
 
 \rSec1[dcl.name]{Type names}
@@ -206,31 +206,31 @@ of that type that omits the name of the entity.
 
 \begin{bnf}
 \nontermdef{type-id}\br
-    type-specifier-seq abstract-declarator\opt
+    type-specifier-seq abstract-declarator\opt{}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{defining-type-id}\br
-    defining-type-specifier-seq abstract-declarator\opt
+    defining-type-specifier-seq abstract-declarator\opt{}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{abstract-declarator}\br
     ptr-abstract-declarator\br
-    noptr-abstract-declarator\opt parameters-and-qualifiers trailing-return-type\br
+    noptr-abstract-declarator\opt{} parameters-and-qualifiers trailing-return-type\br
     abstract-pack-declarator
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{ptr-abstract-declarator}\br
     noptr-abstract-declarator\br
-    ptr-operator ptr-abstract-declarator\opt
+    ptr-operator ptr-abstract-declarator\opt{}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{noptr-abstract-declarator}\br
-    noptr-abstract-declarator\opt parameters-and-qualifiers\br
-    noptr-abstract-declarator\opt{} \terminal{[} constant-expression\opt{} \terminal{]} attribute-specifier-seq\opt\br
+    noptr-abstract-declarator\opt{} parameters-and-qualifiers\br
+    noptr-abstract-declarator\opt{} \terminal{[} constant-expression\opt{} \terminal{]} attribute-specifier-seq\opt{}\br
     \terminal{(} ptr-abstract-declarator \terminal{)}
 \end{bnf}
 
@@ -243,7 +243,7 @@ of that type that omits the name of the entity.
 \begin{bnf}
 \nontermdef{noptr-abstract-pack-declarator}\br
     noptr-abstract-pack-declarator parameters-and-qualifiers\br
-    noptr-abstract-pack-declarator \terminal{[} constant-expression\opt{} \terminal{]} attribute-specifier-seq\opt\br
+    noptr-abstract-pack-declarator \terminal{[} constant-expression\opt{} \terminal{]} attribute-specifier-seq\opt{}\br
     \terminal{...}
 \end{bnf}
 
@@ -544,7 +544,7 @@ where
 has the form
 
 \begin{ncsimplebnf}
-\terminal{*} attribute-specifier-seq\opt cv-qualifier-seq\opt{} \terminal{D1}
+\terminal{*} attribute-specifier-seq\opt{} cv-qualifier-seq\opt{} \terminal{D1}
 \end{ncsimplebnf}
 
 and the type of the identifier in the declaration
@@ -849,7 +849,7 @@ where
 has the form
 
 \begin{ncsimplebnf}
-nested-name-specifier \terminal{*} attribute-specifier-seq\opt cv-qualifier-seq\opt{} \terminal{D1}
+nested-name-specifier \terminal{*} attribute-specifier-seq\opt{} cv-qualifier-seq\opt{} \terminal{D1}
 \end{ncsimplebnf}
 
 and the
@@ -958,7 +958,7 @@ where
 has the form
 
 \begin{ncsimplebnf}
-\terminal{D1 [} constant-expression\opt{} \terminal{]} attribute-specifier-seq\opt
+\terminal{D1 [} constant-expression\opt{} \terminal{]} attribute-specifier-seq\opt{}
 \end{ncsimplebnf}
 
 and the type of the identifier in the declaration
@@ -1229,8 +1229,8 @@ where
 \tcode{D}
 has the form
 \begin{ncsimplebnf}
-\terminal{D1 (} parameter-declaration-clause \terminal{)} cv-qualifier-seq\opt\br
-\hspace*{\bnfindentinc}ref-qualifier\opt noexcept-specifier\opt attribute-specifier-seq\opt
+\terminal{D1 (} parameter-declaration-clause \terminal{)} cv-qualifier-seq\opt{}\br
+\hspace*{\bnfindentinc}ref-qualifier\opt{} noexcept-specifier\opt{} attribute-specifier-seq\opt{}
 \end{ncsimplebnf}
 and the type of the contained
 \grammarterm{declarator-id}
@@ -1246,7 +1246,7 @@ in
 \tcode{D}
 is
 ``\placeholder{derived-declarator-type-list}
-\tcode{noexcept}\opt
+\tcode{noexcept}\opt{}
 function of
 (\grammarterm{parameter-declaration-clause})
 \grammarterm{cv-qualifier-seq}\opt{} \grammarterm{ref-qualifier}\opt{}
@@ -1266,8 +1266,8 @@ where
 has the form
 
 \begin{ncsimplebnf}
-\terminal{D1 (} parameter-declaration-clause \terminal{)} cv-qualifier-seq\opt\br
-\hspace*{\bnfindentinc}ref-qualifier\opt noexcept-specifier\opt attribute-specifier-seq\opt trailing-return-type
+\terminal{D1 (} parameter-declaration-clause \terminal{)} cv-qualifier-seq\opt{}\br
+\hspace*{\bnfindentinc}ref-qualifier\opt{} noexcept-specifier\opt{} attribute-specifier-seq\opt{} trailing-return-type
 \end{ncsimplebnf}
 
 and the type of the contained
@@ -1284,10 +1284,10 @@ in
 \tcode{D}
 is
 ``\placeholder{derived-declarator-type-list}
-\tcode{noexcept}\opt
+\tcode{noexcept}\opt{}
 function of
 (\grammarterm{parameter-declaration-clause})
-\grammarterm{cv-qualifier-seq}\opt \grammarterm{ref-qualifier}\opt
+\grammarterm{cv-qualifier-seq}\opt{} \grammarterm{ref-qualifier}\opt{}
 returning \tcode{U}'',
 where \tcode{U} is the type specified by
 the \grammarterm{trailing-return-type}, and
@@ -1303,7 +1303,7 @@ A type of either form is a \term{function type}.\footnote{As indicated by syntax
 \indextext{declaration!function}%
 \begin{bnf}
 \nontermdef{parameter-declaration-clause}\br
-    parameter-declaration-list\opt{} \terminal{...}\opt\br
+    parameter-declaration-list\opt{} \terminal{...}\opt{}\br
     parameter-declaration-list \terminal{, ...}
 \end{bnf}
 
@@ -1315,10 +1315,10 @@ A type of either form is a \term{function type}.\footnote{As indicated by syntax
 
 \begin{bnf}
 \nontermdef{parameter-declaration}\br
-    attribute-specifier-seq\opt decl-specifier-seq declarator\br
-    attribute-specifier-seq\opt decl-specifier-seq declarator \terminal{=} initializer-clause\br
-    attribute-specifier-seq\opt decl-specifier-seq abstract-declarator\opt\br
-    attribute-specifier-seq\opt decl-specifier-seq abstract-declarator\opt{} \terminal{=} initializer-clause
+    attribute-specifier-seq\opt{} decl-specifier-seq declarator\br
+    attribute-specifier-seq\opt{} decl-specifier-seq declarator \terminal{=} initializer-clause\br
+    attribute-specifier-seq\opt{} decl-specifier-seq abstract-declarator\opt{}\br
+    attribute-specifier-seq\opt{} decl-specifier-seq abstract-declarator\opt{} \terminal{=} initializer-clause
 \end{bnf}
 
 The optional \grammarterm{attribute-specifier-seq} in a \grammarterm{parameter-declaration}
@@ -1984,13 +1984,13 @@ Function definitions have the form
 %
 \begin{bnf}
 \nontermdef{function-definition}\br
-    attribute-specifier-seq\opt decl-specifier-seq\opt declarator virt-specifier-seq\opt function-body\br
-    attribute-specifier-seq\opt decl-specifier-seq\opt declarator requires-clause function-body
+    attribute-specifier-seq\opt{} decl-specifier-seq\opt{} declarator virt-specifier-seq\opt{} function-body\br
+    attribute-specifier-seq\opt{} decl-specifier-seq\opt{} declarator requires-clause function-body
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{function-body}\br
-    ctor-initializer\opt compound-statement\br
+    ctor-initializer\opt{} compound-statement\br
     function-try-block\br
     \terminal{= default ;}\br
     \terminal{= delete ;}
@@ -2409,15 +2409,15 @@ the initialization of return values\iref{stmt.return}.
 
 \begin{bnf}
 \nontermdef{braced-init-list}\br
-    \terminal{\{} initializer-list \terminal{,\opt} \terminal{\}}\br
-    \terminal{\{} designated-initializer-list \terminal{,\opt} \terminal{\}}\br
+    \terminal{\{} initializer-list \terminal{,\opt{}} \terminal{\}}\br
+    \terminal{\{} designated-initializer-list \terminal{,\opt{}} \terminal{\}}\br
     \terminal{\{} \terminal{\}}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{initializer-list}\br
-    initializer-clause \terminal{...}\opt\br
-    initializer-list \terminal{,} initializer-clause \terminal{...}\opt
+    initializer-clause \terminal{...}\opt{}\br
+    initializer-list \terminal{,} initializer-clause \terminal{...}\opt{}
 \end{bnf}
 
 \begin{bnf}

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -27,7 +27,7 @@ each of which can have an initializer.
 
 \begin{bnf}
 \nontermdef{init-declarator}\br
-    declarator initializer\opt{}\br
+    declarator \opt{initializer}\br
     declarator requires-clause
 \end{bnf}
 
@@ -139,16 +139,16 @@ Declarators have the syntax
 
 \begin{bnf}
 \nontermdef{noptr-declarator}\br
-    declarator-id attribute-specifier-seq\opt{}\br
+    declarator-id \opt{attribute-specifier-seq}\br
     noptr-declarator parameters-and-qualifiers\br
-    noptr-declarator \terminal{[} constant-expression\opt{} \terminal{]} attribute-specifier-seq\opt{}\br
+    noptr-declarator \terminal{[} \opt{constant-expression} \terminal{]} \opt{attribute-specifier-seq}\br
     \terminal{(} ptr-declarator \terminal{)}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{parameters-and-qualifiers}\br
-    \terminal{(} parameter-declaration-clause \terminal{)} cv-qualifier-seq\opt{}\br
-\hspace*{\bnfindentinc}ref-qualifier\opt{} noexcept-specifier\opt{} attribute-specifier-seq\opt{}
+    \terminal{(} parameter-declaration-clause \terminal{)} \opt{cv-qualifier-seq}\br
+\hspace*{\bnfindentinc}\opt{ref-qualifier} \opt{noexcept-specifier} \opt{attribute-specifier-seq}
 \end{bnf}
 
 \begin{bnf}
@@ -158,15 +158,15 @@ Declarators have the syntax
 
 \begin{bnf}
 \nontermdef{ptr-operator}\br
-    \terminal{*} attribute-specifier-seq\opt{} cv-qualifier-seq\opt{}\br
-    \terminal{\&} attribute-specifier-seq\opt{}\br
-    \terminal{\&\&} attribute-specifier-seq\opt{}\br
-    nested-name-specifier \terminal{*} attribute-specifier-seq\opt{} cv-qualifier-seq\opt{}
+    \terminal{*} \opt{attribute-specifier-seq} \opt{cv-qualifier-seq}\br
+    \terminal{\&} \opt{attribute-specifier-seq}\br
+    \terminal{\&\&} \opt{attribute-specifier-seq}\br
+    nested-name-specifier \terminal{*} \opt{attribute-specifier-seq} \opt{cv-qualifier-seq}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{cv-qualifier-seq}\br
-    cv-qualifier cv-qualifier-seq\opt{}
+    cv-qualifier \opt{cv-qualifier-seq}
 \end{bnf}
 
 \begin{bnf}
@@ -183,7 +183,7 @@ Declarators have the syntax
 
 \begin{bnf}
 \nontermdef{declarator-id}\br
-    \terminal{...}\opt{} id-expression
+    \opt{\terminal{...}} id-expression
 \end{bnf}
 
 \rSec1[dcl.name]{Type names}
@@ -206,31 +206,31 @@ of that type that omits the name of the entity.
 
 \begin{bnf}
 \nontermdef{type-id}\br
-    type-specifier-seq abstract-declarator\opt{}
+    type-specifier-seq \opt{abstract-declarator}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{defining-type-id}\br
-    defining-type-specifier-seq abstract-declarator\opt{}
+    defining-type-specifier-seq \opt{abstract-declarator}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{abstract-declarator}\br
     ptr-abstract-declarator\br
-    noptr-abstract-declarator\opt{} parameters-and-qualifiers trailing-return-type\br
+    \opt{noptr-abstract-declarator} parameters-and-qualifiers trailing-return-type\br
     abstract-pack-declarator
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{ptr-abstract-declarator}\br
     noptr-abstract-declarator\br
-    ptr-operator ptr-abstract-declarator\opt{}
+    ptr-operator \opt{ptr-abstract-declarator}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{noptr-abstract-declarator}\br
-    noptr-abstract-declarator\opt{} parameters-and-qualifiers\br
-    noptr-abstract-declarator\opt{} \terminal{[} constant-expression\opt{} \terminal{]} attribute-specifier-seq\opt{}\br
+    \opt{noptr-abstract-declarator} parameters-and-qualifiers\br
+    \opt{noptr-abstract-declarator} \terminal{[} \opt{constant-expression} \terminal{]} \opt{attribute-specifier-seq}\br
     \terminal{(} ptr-abstract-declarator \terminal{)}
 \end{bnf}
 
@@ -243,7 +243,7 @@ of that type that omits the name of the entity.
 \begin{bnf}
 \nontermdef{noptr-abstract-pack-declarator}\br
     noptr-abstract-pack-declarator parameters-and-qualifiers\br
-    noptr-abstract-pack-declarator \terminal{[} constant-expression\opt{} \terminal{]} attribute-specifier-seq\opt{}\br
+    noptr-abstract-pack-declarator \terminal{[} \opt{constant-expression} \terminal{]} \opt{attribute-specifier-seq}\br
     \terminal{...}
 \end{bnf}
 
@@ -458,7 +458,7 @@ T D
 
 where
 \tcode{T}
-is of the form \grammarterm{attribute-specifier-seq}\opt{}
+is of the form \opt{\grammarterm{attribute-specifier-seq}}
 \grammarterm{decl-specifier-seq}
 and
 \tcode{D}
@@ -499,7 +499,7 @@ determine the type
 
 \pnum
 In a declaration
-\grammarterm{attribute-specifier-seq}\opt{}
+\opt{\grammarterm{attribute-specifier-seq}}
 \tcode{T}
 \tcode{D}
 where
@@ -544,7 +544,7 @@ where
 has the form
 
 \begin{ncsimplebnf}
-\terminal{*} attribute-specifier-seq\opt{} cv-qualifier-seq\opt{} \terminal{D1}
+\terminal{*} \opt{attribute-specifier-seq} \opt{cv-qualifier-seq} \terminal{D1}
 \end{ncsimplebnf}
 
 and the type of the identifier in the declaration
@@ -657,8 +657,8 @@ where
 has either of the forms
 
 \begin{ncsimplebnf}
-\terminal{\&} attribute-specifier-seq\opt{} \terminal{D1}\br
-\terminal{\&\&} attribute-specifier-seq\opt{} \terminal{D1}
+\terminal{\&} \opt{attribute-specifier-seq} \terminal{D1}\br
+\terminal{\&\&} \opt{attribute-specifier-seq} \terminal{D1}
 \end{ncsimplebnf}
 
 and the type of the identifier in the declaration
@@ -849,7 +849,7 @@ where
 has the form
 
 \begin{ncsimplebnf}
-nested-name-specifier \terminal{*} attribute-specifier-seq\opt{} cv-qualifier-seq\opt{} \terminal{D1}
+nested-name-specifier \terminal{*} \opt{attribute-specifier-seq} \opt{cv-qualifier-seq} \terminal{D1}
 \end{ncsimplebnf}
 
 and the
@@ -958,7 +958,7 @@ where
 has the form
 
 \begin{ncsimplebnf}
-\terminal{D1 [} constant-expression\opt{} \terminal{]} attribute-specifier-seq\opt{}
+\terminal{D1 [} \opt{constant-expression} \terminal{]} \opt{attribute-specifier-seq}
 \end{ncsimplebnf}
 
 and the type of the identifier in the declaration
@@ -1229,8 +1229,8 @@ where
 \tcode{D}
 has the form
 \begin{ncsimplebnf}
-\terminal{D1 (} parameter-declaration-clause \terminal{)} cv-qualifier-seq\opt{}\br
-\hspace*{\bnfindentinc}ref-qualifier\opt{} noexcept-specifier\opt{} attribute-specifier-seq\opt{}
+\terminal{D1 (} parameter-declaration-clause \terminal{)} \opt{cv-qualifier-seq}\br
+\hspace*{\bnfindentinc}\opt{ref-qualifier} \opt{noexcept-specifier} \opt{attribute-specifier-seq}
 \end{ncsimplebnf}
 and the type of the contained
 \grammarterm{declarator-id}
@@ -1246,10 +1246,10 @@ in
 \tcode{D}
 is
 ``\placeholder{derived-declarator-type-list}
-\tcode{noexcept}\opt{}
+\opt{\tcode{noexcept}}
 function of
 (\grammarterm{parameter-declaration-clause})
-\grammarterm{cv-qualifier-seq}\opt{} \grammarterm{ref-qualifier}\opt{}
+\opt{\grammarterm{cv-qualifier-seq}} \opt{\grammarterm{ref-qualifier}}
 returning \tcode{T}'',
 where the optional \tcode{noexcept} is present
 if and only if
@@ -1266,8 +1266,8 @@ where
 has the form
 
 \begin{ncsimplebnf}
-\terminal{D1 (} parameter-declaration-clause \terminal{)} cv-qualifier-seq\opt{}\br
-\hspace*{\bnfindentinc}ref-qualifier\opt{} noexcept-specifier\opt{} attribute-specifier-seq\opt{} trailing-return-type
+\terminal{D1 (} parameter-declaration-clause \terminal{)} \opt{cv-qualifier-seq}\br
+\hspace*{\bnfindentinc}\opt{ref-qualifier} \opt{noexcept-specifier} \opt{attribute-specifier-seq} trailing-return-type
 \end{ncsimplebnf}
 
 and the type of the contained
@@ -1284,10 +1284,10 @@ in
 \tcode{D}
 is
 ``\placeholder{derived-declarator-type-list}
-\tcode{noexcept}\opt{}
+\opt{\tcode{noexcept}}
 function of
 (\grammarterm{parameter-declaration-clause})
-\grammarterm{cv-qualifier-seq}\opt{} \grammarterm{ref-qualifier}\opt{}
+\opt{\grammarterm{cv-qualifier-seq}} \opt{\grammarterm{ref-qualifier}}
 returning \tcode{U}'',
 where \tcode{U} is the type specified by
 the \grammarterm{trailing-return-type}, and
@@ -1303,7 +1303,7 @@ A type of either form is a \term{function type}.\footnote{As indicated by syntax
 \indextext{declaration!function}%
 \begin{bnf}
 \nontermdef{parameter-declaration-clause}\br
-    parameter-declaration-list\opt{} \terminal{...}\opt{}\br
+    \opt{parameter-declaration-list} \opt{\terminal{...}}\br
     parameter-declaration-list \terminal{, ...}
 \end{bnf}
 
@@ -1315,10 +1315,10 @@ A type of either form is a \term{function type}.\footnote{As indicated by syntax
 
 \begin{bnf}
 \nontermdef{parameter-declaration}\br
-    attribute-specifier-seq\opt{} decl-specifier-seq declarator\br
-    attribute-specifier-seq\opt{} decl-specifier-seq declarator \terminal{=} initializer-clause\br
-    attribute-specifier-seq\opt{} decl-specifier-seq abstract-declarator\opt{}\br
-    attribute-specifier-seq\opt{} decl-specifier-seq abstract-declarator\opt{} \terminal{=} initializer-clause
+    \opt{attribute-specifier-seq} decl-specifier-seq declarator\br
+    \opt{attribute-specifier-seq} decl-specifier-seq declarator \terminal{=} initializer-clause\br
+    \opt{attribute-specifier-seq} decl-specifier-seq \opt{abstract-declarator}\br
+    \opt{attribute-specifier-seq} decl-specifier-seq \opt{abstract-declarator} \terminal{=} initializer-clause
 \end{bnf}
 
 The optional \grammarterm{attribute-specifier-seq} in a \grammarterm{parameter-declaration}
@@ -1984,13 +1984,13 @@ Function definitions have the form
 %
 \begin{bnf}
 \nontermdef{function-definition}\br
-    attribute-specifier-seq\opt{} decl-specifier-seq\opt{} declarator virt-specifier-seq\opt{} function-body\br
-    attribute-specifier-seq\opt{} decl-specifier-seq\opt{} declarator requires-clause function-body
+    \opt{attribute-specifier-seq} \opt{decl-specifier-seq} declarator \opt{virt-specifier-seq} function-body\br
+    \opt{attribute-specifier-seq} \opt{decl-specifier-seq} declarator requires-clause function-body
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{function-body}\br
-    ctor-initializer\opt{} compound-statement\br
+    \opt{ctor-initializer} compound-statement\br
     function-try-block\br
     \terminal{= default ;}\br
     \terminal{= delete ;}
@@ -2296,7 +2296,7 @@ Otherwise, \tcode{e}
 is defined as-if by
 
 \begin{ncbnf}
-attribute-specifier-seq\opt{} decl-specifier-seq ref-qualifier\opt{} \terminal{e} initializer \terminal{;}
+\opt{attribute-specifier-seq} decl-specifier-seq \opt{ref-qualifier} \terminal{e} initializer \terminal{;}
 \end{ncbnf}
 
 where
@@ -2409,15 +2409,15 @@ the initialization of return values\iref{stmt.return}.
 
 \begin{bnf}
 \nontermdef{braced-init-list}\br
-    \terminal{\{} initializer-list \terminal{,\opt{}} \terminal{\}}\br
-    \terminal{\{} designated-initializer-list \terminal{,\opt{}} \terminal{\}}\br
+    \terminal{\{} initializer-list \opt{\terminal{,}} \terminal{\}}\br
+    \terminal{\{} designated-initializer-list \opt{\terminal{,}} \terminal{\}}\br
     \terminal{\{} \terminal{\}}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{initializer-list}\br
-    initializer-clause \terminal{...}\opt{}\br
-    initializer-list \terminal{,} initializer-clause \terminal{...}\opt{}
+    initializer-clause \opt{\terminal{...}}\br
+    initializer-list \terminal{,} initializer-clause \opt{\terminal{...}}
 \end{bnf}
 
 \begin{bnf}

--- a/source/derived.tex
+++ b/source/derived.tex
@@ -23,20 +23,20 @@ the notation:
 
 \begin{bnf}
 \nontermdef{base-specifier-list}\br
-    base-specifier \terminal{...}\opt{}\br
-    base-specifier-list \terminal{,} base-specifier \terminal{...}\opt{}
+    base-specifier \opt{\terminal{...}}\br
+    base-specifier-list \terminal{,} base-specifier \opt{\terminal{...}}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{base-specifier}\br
-    attribute-specifier-seq\opt{} class-or-decltype\br
-    attribute-specifier-seq\opt{} \terminal{virtual} access-specifier\opt{} class-or-decltype\br
-    attribute-specifier-seq\opt{} access-specifier \terminal{virtual}\opt{} class-or-decltype
+    \opt{attribute-specifier-seq} class-or-decltype\br
+    \opt{attribute-specifier-seq} \terminal{virtual} \opt{access-specifier} class-or-decltype\br
+    \opt{attribute-specifier-seq} access-specifier \opt{\terminal{virtual}} class-or-decltype
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{class-or-decltype}\br
-    nested-name-specifier\opt{} class-name\br
+    \opt{nested-name-specifier} class-name\br
     nested-name-specifier \terminal{template} simple-template-id\br
     decltype-specifier
 \end{bnf}

--- a/source/derived.tex
+++ b/source/derived.tex
@@ -23,20 +23,20 @@ the notation:
 
 \begin{bnf}
 \nontermdef{base-specifier-list}\br
-    base-specifier \terminal{...}\opt\br
-    base-specifier-list \terminal{,} base-specifier \terminal{...}\opt
+    base-specifier \terminal{...}\opt{}\br
+    base-specifier-list \terminal{,} base-specifier \terminal{...}\opt{}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{base-specifier}\br
-    attribute-specifier-seq\opt class-or-decltype\br
-    attribute-specifier-seq\opt{} \terminal{virtual} access-specifier\opt class-or-decltype\br
-    attribute-specifier-seq\opt access-specifier \terminal{virtual}\opt class-or-decltype
+    attribute-specifier-seq\opt{} class-or-decltype\br
+    attribute-specifier-seq\opt{} \terminal{virtual} access-specifier\opt{} class-or-decltype\br
+    attribute-specifier-seq\opt{} access-specifier \terminal{virtual}\opt{} class-or-decltype
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{class-or-decltype}\br
-    nested-name-specifier\opt class-name\br
+    nested-name-specifier\opt{} class-name\br
     nested-name-specifier \terminal{template} simple-template-id\br
     decltype-specifier
 \end{bnf}

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -1791,8 +1791,8 @@ const char* what() const noexcept override;
 
 \begin{itemdescr}
 \pnum
-\returns An \ntbs incorporating the arguments supplied in the constructor.
+\returns An \ntbs{} incorporating the arguments supplied in the constructor.
 
-\begin{note} The returned \ntbs might be the contents of \tcode{what_arg + ": " +
+\begin{note} The returned \ntbs{} might be the contents of \tcode{what_arg + ": " +
 code.message()}.\end{note}
 \end{itemdescr}

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -4,7 +4,7 @@
 \rSec1[diagnostics.general]{General}
 
 \pnum
-This Clause describes components that \Cpp programs may use to detect and
+This Clause describes components that \Cpp{} programs may use to detect and
 report error conditions.
 
 \pnum
@@ -24,8 +24,8 @@ as summarized in Table~\ref{tab:diagnostics.lib.summary}.
 \rSec1[std.exceptions]{Exception classes}
 
 \pnum
-The \Cpp standard library provides classes to be used to report certain errors\iref{res.on.exception.handling} in
-\Cpp programs.
+The \Cpp{} standard library provides classes to be used to report certain errors\iref{res.on.exception.handling} in
+\Cpp{} programs.
 In the error model reflected in these classes, errors are divided into two
 broad categories:
 \term{logic}
@@ -45,7 +45,7 @@ The header
 \tcode{<stdexcept>}
 \indextext{\idxhdr{stdexcept}}%
 \indexlibrary{\idxhdr{stdexcept}}%
-defines several types of predefined exceptions for reporting errors in a \Cpp program.
+defines several types of predefined exceptions for reporting errors in a \Cpp{} program.
 These exceptions are related by inheritance.
 
 \rSec2[stdexcept.syn]{Header \tcode{<stdexcept>} synopsis}
@@ -540,7 +540,7 @@ Constructs an object of class
 \pnum
 The header
 \tcode{<cassert>}
-provides a macro for documenting \Cpp program assertions and a mechanism
+provides a macro for documenting \Cpp{} program assertions and a mechanism
 for disabling the assertion checks.
 
 \rSec2[cassert.syn]{Header \tcode{<cassert>} synopsis}
@@ -764,7 +764,7 @@ The meaning of the macros in this header is defined by the POSIX standard.
 
 \pnum
 This subclause describes components that the standard library and
-\Cpp programs may use to report error conditions originating from
+\Cpp{} programs may use to report error conditions originating from
 the operating system or other low-level application program interfaces.
 
 \pnum

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -26,12 +26,12 @@ or in functions called from the handler's try block.
 %
 \begin{bnf}
 \nontermdef{function-try-block}\br
-    \terminal{try} ctor-initializer\opt compound-statement handler-seq
+    \terminal{try} ctor-initializer\opt{} compound-statement handler-seq
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{handler-seq}\br
-    handler handler-seq\opt
+    handler handler-seq\opt{}
 \end{bnf}
 
 \indextext{\idxcode{catch}}%
@@ -43,8 +43,8 @@ or in functions called from the handler's try block.
 
 \begin{bnf}
 \nontermdef{exception-declaration}\br
-    attribute-specifier-seq\opt type-specifier-seq declarator\br
-    attribute-specifier-seq\opt type-specifier-seq abstract-declarator\opt\br
+    attribute-specifier-seq\opt{} type-specifier-seq declarator\br
+    attribute-specifier-seq\opt{} type-specifier-seq abstract-declarator\opt{}\br
     \terminal{...}
 \end{bnf}
 

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -26,12 +26,12 @@ or in functions called from the handler's try block.
 %
 \begin{bnf}
 \nontermdef{function-try-block}\br
-    \terminal{try} ctor-initializer\opt{} compound-statement handler-seq
+    \terminal{try} \opt{ctor-initializer} compound-statement handler-seq
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{handler-seq}\br
-    handler handler-seq\opt{}
+    handler \opt{handler-seq}
 \end{bnf}
 
 \indextext{\idxcode{catch}}%
@@ -43,8 +43,8 @@ or in functions called from the handler's try block.
 
 \begin{bnf}
 \nontermdef{exception-declaration}\br
-    attribute-specifier-seq\opt{} type-specifier-seq declarator\br
-    attribute-specifier-seq\opt{} type-specifier-seq abstract-declarator\opt{}\br
+    \opt{attribute-specifier-seq} type-specifier-seq declarator\br
+    \opt{attribute-specifier-seq} type-specifier-seq \opt{abstract-declarator}\br
     \terminal{...}
 \end{bnf}
 

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -865,7 +865,7 @@ static_assert(add(one)(one)() == monoid(2)()); // OK
 The closure type for a non-generic \grammarterm{lambda-expression} with no
 \grammarterm{lambda-capture}
 has a conversion function to pointer to
-function with \Cpp language linkage\iref{dcl.link} having
+function with \Cpp{} language linkage\iref{dcl.link} having
 the same parameter and return types as the closure type's function call operator.
 The conversion is to ``pointer to \tcode{noexcept} function''
 if the function call operator
@@ -1074,7 +1074,7 @@ be of the form
 ``\tcode{this}'',
 or ``\tcode{* this}''.
 \begin{note} The form \tcode{[\&,this]} is redundant but accepted
-for compatibility with ISO \CppXIV. \end{note}
+for compatibility with ISO \CppXIV{}. \end{note}
 Ignoring appearances in
 \grammarterm{initializer}{s} of \grammarterm{init-capture}{s}, an identifier or
 \tcode{this} shall not appear more than once in a
@@ -3672,7 +3672,7 @@ and the deallocation function's name is
 An implementation shall provide default definitions for the global
 allocation
 functions~(\ref{basic.stc.dynamic}, \ref{new.delete.single}, \ref{new.delete.array}).
-A \Cpp program can provide alternative definitions of
+A \Cpp{} program can provide alternative definitions of
 these functions\iref{replacement.functions} and/or class-specific
 versions\iref{class.free}.
 The set of allocation and deallocation functions that may be called
@@ -4112,7 +4112,7 @@ An implementation provides default definitions of the global
 deallocation functions \tcode{operator delete} for
 non-arrays\iref{new.delete.single} and
 \indextext{\idxcode{operator delete}}%
-\tcode{operator delete[]} for arrays\iref{new.delete.array}. A \Cpp
+\tcode{operator delete[]} for arrays\iref{new.delete.array}. A \Cpp{}
 program can provide alternative definitions of these
 functions\iref{replacement.functions}, and/or class-specific
 versions\iref{class.free}.

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -569,7 +569,7 @@ it is a bit-field if the identifier designates a bit-field\iref{dcl.struct.bind}
 %
 \begin{bnf}
 \nontermdef{qualified-id}\br
-    nested-name-specifier \terminal{template}\opt unqualified-id
+    nested-name-specifier \terminal{template}\opt{} unqualified-id
 \end{bnf}
 
 \indextext{operator!scope resolution}%
@@ -582,7 +582,7 @@ it is a bit-field if the identifier designates a bit-field\iref{dcl.struct.bind}
     namespace-name \terminal{::}\br
     decltype-specifier \terminal{::}\br
     nested-name-specifier identifier \terminal{::}\br
-    nested-name-specifier \terminal{template}\opt simple-template-id \terminal{::}
+    nested-name-specifier \terminal{template}\opt{} simple-template-id \terminal{::}
 \end{bnf}
 
 \pnum
@@ -661,8 +661,8 @@ by the \grammarterm{nested-name-specifier}.
 
 \begin{bnf}
 \nontermdef{lambda-declarator}\br
-    \terminal{(} parameter-declaration-clause \terminal{)} decl-specifier-seq\opt\br
-    \hspace*{\bnfindentinc}noexcept-specifier\opt attribute-specifier-seq\opt trailing-return-type\opt
+    \terminal{(} parameter-declaration-clause \terminal{)} decl-specifier-seq\opt{}\br
+    \hspace*{\bnfindentinc}noexcept-specifier\opt{} attribute-specifier-seq\opt{} trailing-return-type\opt{}
 \end{bnf}
 
 \pnum
@@ -1032,8 +1032,8 @@ named in a \tcode{friend} declaration\iref{class.friend}.
 
 \begin{bnf}
 \nontermdef{capture-list}\br
-    capture \terminal{...\opt}\br
-    capture-list \terminal{,} capture \terminal{...\opt}
+    capture \terminal{...\opt{}}\br
+    capture-list \terminal{,} capture \terminal{...\opt{}}
 \end{bnf}
 
 \begin{bnf}
@@ -1864,8 +1864,8 @@ Postfix expressions group left-to-right.
     typename-specifier \terminal{(} expression-list\opt{} \terminal{)}\br
     simple-type-specifier braced-init-list\br
     typename-specifier braced-init-list\br
-    postfix-expression \terminal{. template}\opt id-expression\br
-    postfix-expression \terminal{-> template}\opt id-expression\br
+    postfix-expression \terminal{. template}\opt{} id-expression\br
+    postfix-expression \terminal{-> template}\opt{} id-expression\br
     postfix-expression \terminal{.} pseudo-destructor-name\br
     postfix-expression \terminal{->} pseudo-destructor-name\br
     postfix-expression \terminal{++}\br
@@ -1887,7 +1887,7 @@ Postfix expressions group left-to-right.
 
 \begin{bnf}
 \nontermdef{pseudo-destructor-name}\br
-    nested-name-specifier\opt type-name \terminal{::\,\tilde} type-name\br
+    nested-name-specifier\opt{} type-name \terminal{::\,\tilde} type-name\br
     nested-name-specifier \terminal{template} simple-template-id \terminal{::\,\tilde} type-name\br
     \terminal{\tilde} type-name\br
     \terminal{\tilde} decltype-specifier
@@ -2224,7 +2224,7 @@ the two \grammarterm{type-name}{s} in a \grammarterm{pseudo-destructor-name} of
 the form
 
 \begin{ncbnf}
-nested-name-specifier\opt type-name \terminal{::\,\tilde} type-name
+nested-name-specifier\opt{} type-name \terminal{::\,\tilde} type-name
 \end{ncbnf}
 
 shall designate the same scalar type (ignoring cv-qualification).
@@ -3451,8 +3451,8 @@ object created by the \grammarterm{new-expression} has a cv-qualified type.
 
 \begin{bnf}
 \nontermdef{new-expression}\br
-    \terminal{::}\opt{} \terminal{new} new-placement\opt new-type-id new-initializer\opt \br
-    \terminal{::}\opt{} \terminal{new} new-placement\opt{} \terminal{(} type-id \terminal{)} new-initializer\opt
+    \terminal{::}\opt{} \terminal{new} new-placement\opt{} new-type-id new-initializer\opt{} \br
+    \terminal{::}\opt{} \terminal{new} new-placement\opt{} \terminal{(} type-id \terminal{)} new-initializer\opt{}
 \end{bnf}
 
 \indextext{\idxcode{new}!storage allocation}%
@@ -3464,19 +3464,19 @@ object created by the \grammarterm{new-expression} has a cv-qualified type.
 
 \begin{bnf}
 \nontermdef{new-type-id}\br
-    type-specifier-seq new-declarator\opt
+    type-specifier-seq new-declarator\opt{}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{new-declarator}\br
-    ptr-operator new-declarator\opt \br
+    ptr-operator new-declarator\opt{} \br
     noptr-new-declarator
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{noptr-new-declarator}\br
-    \terminal{[} expression \terminal{]} attribute-specifier-seq\opt\br
-    noptr-new-declarator \terminal{[} constant-expression \terminal{]} attribute-specifier-seq\opt
+    \terminal{[} expression \terminal{]} attribute-specifier-seq\opt{}\br
+    noptr-new-declarator \terminal{[} constant-expression \terminal{]} attribute-specifier-seq\opt{}
 \end{bnf}
 
 \begin{bnf}
@@ -5126,7 +5126,7 @@ that type and the other is a null pointer constant. The result is of type
 %
 \begin{bnf}
 \nontermdef{throw-expression}\br
-    \terminal{throw}  assignment-expression\opt
+    \terminal{throw}  assignment-expression\opt{}
 \end{bnf}
 
 \pnum

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -569,7 +569,7 @@ it is a bit-field if the identifier designates a bit-field\iref{dcl.struct.bind}
 %
 \begin{bnf}
 \nontermdef{qualified-id}\br
-    nested-name-specifier \terminal{template}\opt{} unqualified-id
+    nested-name-specifier \opt{\terminal{template}} unqualified-id
 \end{bnf}
 
 \indextext{operator!scope resolution}%
@@ -582,7 +582,7 @@ it is a bit-field if the identifier designates a bit-field\iref{dcl.struct.bind}
     namespace-name \terminal{::}\br
     decltype-specifier \terminal{::}\br
     nested-name-specifier identifier \terminal{::}\br
-    nested-name-specifier \terminal{template}\opt{} simple-template-id \terminal{::}
+    nested-name-specifier \opt{\terminal{template}} simple-template-id \terminal{::}
 \end{bnf}
 
 \pnum
@@ -650,19 +650,19 @@ by the \grammarterm{nested-name-specifier}.
 
 \begin{bnf}
 \nontermdef{lambda-expression}\br
-    lambda-introducer lambda-declarator\opt{} compound-statement\br
-    lambda-introducer \tcode{<} template-parameter-list \tcode{>} lambda-declarator\opt{} compound-statement
+    lambda-introducer \opt{lambda-declarator} compound-statement\br
+    lambda-introducer \tcode{<} template-parameter-list \tcode{>} \opt{lambda-declarator} compound-statement
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{lambda-introducer}\br
-    \terminal{[} lambda-capture\opt{} \terminal{]}
+    \terminal{[} \opt{lambda-capture} \terminal{]}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{lambda-declarator}\br
-    \terminal{(} parameter-declaration-clause \terminal{)} decl-specifier-seq\opt{}\br
-    \hspace*{\bnfindentinc}noexcept-specifier\opt{} attribute-specifier-seq\opt{} trailing-return-type\opt{}
+    \terminal{(} parameter-declaration-clause \terminal{)} \opt{decl-specifier-seq}\br
+    \hspace*{\bnfindentinc}\opt{noexcept-specifier} \opt{attribute-specifier-seq} \opt{trailing-return-type}
 \end{bnf}
 
 \pnum
@@ -1032,8 +1032,8 @@ named in a \tcode{friend} declaration\iref{class.friend}.
 
 \begin{bnf}
 \nontermdef{capture-list}\br
-    capture \terminal{...\opt{}}\br
-    capture-list \terminal{,} capture \terminal{...\opt{}}
+    capture \opt{\terminal{...}}\br
+    capture-list \terminal{,} capture \opt{\terminal{...}}
 \end{bnf}
 
 \begin{bnf}
@@ -1520,12 +1520,12 @@ or by checking properties of types and expressions.
 
 \begin{bnf}
 \nontermdef{requires-expression}\br
-    \terminal{requires} requirement-parameter-list\opt{} requirement-body
+    \terminal{requires} \opt{requirement-parameter-list} requirement-body
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{requirement-parameter-list}\br
-    \terminal{(} parameter-declaration-clause\opt{} \terminal{)}
+    \terminal{(} \opt{parameter-declaration-clause} \terminal{)}
 \end{bnf}
 
 \begin{bnf}
@@ -1696,13 +1696,13 @@ does not require that type to be complete\iref{basic.types}.
 
 \begin{bnf}
 \nontermdef{compound-requirement}\br
-    \terminal{\{} expression \terminal{\}} \terminal{noexcept}\opt{} return-type-requirement\opt{} \terminal{;}
+    \terminal{\{} expression \terminal{\}} \opt{\terminal{noexcept}} \opt{return-type-requirement} \terminal{;}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{return-type-requirement}\br
     trailing-return-type\br
-    \terminal{->} cv-qualifier-seq\opt{} constrained-parameter cv-qualifier-seq\opt{} abstract-declarator\opt{}
+    \terminal{->} \opt{cv-qualifier-seq} constrained-parameter \opt{cv-qualifier-seq} \opt{abstract-declarator}
 \end{bnf}
 
 \pnum
@@ -1859,13 +1859,13 @@ Postfix expressions group left-to-right.
 \nontermdef{postfix-expression}\br
     primary-expression\br
     postfix-expression \terminal{[} expr-or-braced-init-list \terminal{]}\br
-    postfix-expression \terminal{(} expression-list\opt{} \terminal{)}\br
-    simple-type-specifier \terminal{(} expression-list\opt{} \terminal{)}\br
-    typename-specifier \terminal{(} expression-list\opt{} \terminal{)}\br
+    postfix-expression \terminal{(} \opt{expression-list} \terminal{)}\br
+    simple-type-specifier \terminal{(} \opt{expression-list} \terminal{)}\br
+    typename-specifier \terminal{(} \opt{expression-list} \terminal{)}\br
     simple-type-specifier braced-init-list\br
     typename-specifier braced-init-list\br
-    postfix-expression \terminal{. template}\opt{} id-expression\br
-    postfix-expression \terminal{-> template}\opt{} id-expression\br
+    postfix-expression \opt{\terminal{. template}} id-expression\br
+    postfix-expression \opt{\terminal{-> template}} id-expression\br
     postfix-expression \terminal{.} pseudo-destructor-name\br
     postfix-expression \terminal{->} pseudo-destructor-name\br
     postfix-expression \terminal{++}\br
@@ -1887,7 +1887,7 @@ Postfix expressions group left-to-right.
 
 \begin{bnf}
 \nontermdef{pseudo-destructor-name}\br
-    nested-name-specifier\opt{} type-name \terminal{::\,\tilde} type-name\br
+    \opt{nested-name-specifier} type-name \terminal{::\,\tilde} type-name\br
     nested-name-specifier \terminal{template} simple-template-id \terminal{::\,\tilde} type-name\br
     \terminal{\tilde} type-name\br
     \terminal{\tilde} decltype-specifier
@@ -2224,7 +2224,7 @@ the two \grammarterm{type-name}{s} in a \grammarterm{pseudo-destructor-name} of
 the form
 
 \begin{ncbnf}
-nested-name-specifier\opt{} type-name \terminal{::\,\tilde} type-name
+\opt{nested-name-specifier} type-name \terminal{::\,\tilde} type-name
 \end{ncbnf}
 
 shall designate the same scalar type (ignoring cv-qualification).
@@ -2337,7 +2337,7 @@ member function. The type of \tcode{E1.E2} is the same type as that of
 
 \item Otherwise, if \tcode{E1.E2} refers to a non-static member
 function and the type of \tcode{E2} is ``function of
-parameter-type-list \cvqual{cv} \grammarterm{ref-qualifier}\opt{} returning \tcode{T}'', then
+parameter-type-list \cvqual{cv} \opt{\grammarterm{ref-qualifier}} returning \tcode{T}'', then
 \tcode{E1.E2} is a prvalue. The expression designates a
 non-static member function. The expression can be used only as the
 left-hand operand of a member function call\iref{class.mfct}.
@@ -3451,8 +3451,8 @@ object created by the \grammarterm{new-expression} has a cv-qualified type.
 
 \begin{bnf}
 \nontermdef{new-expression}\br
-    \terminal{::}\opt{} \terminal{new} new-placement\opt{} new-type-id new-initializer\opt{} \br
-    \terminal{::}\opt{} \terminal{new} new-placement\opt{} \terminal{(} type-id \terminal{)} new-initializer\opt{}
+    \opt{\terminal{::}} \terminal{new} \opt{new-placement} new-type-id \opt{new-initializer} \br
+    \opt{\terminal{::}} \terminal{new} \opt{new-placement} \terminal{(} type-id \terminal{)} \opt{new-initializer}
 \end{bnf}
 
 \indextext{\idxcode{new}!storage allocation}%
@@ -3464,24 +3464,24 @@ object created by the \grammarterm{new-expression} has a cv-qualified type.
 
 \begin{bnf}
 \nontermdef{new-type-id}\br
-    type-specifier-seq new-declarator\opt{}
+    type-specifier-seq \opt{new-declarator}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{new-declarator}\br
-    ptr-operator new-declarator\opt{} \br
+    ptr-operator \opt{new-declarator} \br
     noptr-new-declarator
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{noptr-new-declarator}\br
-    \terminal{[} expression \terminal{]} attribute-specifier-seq\opt{}\br
-    noptr-new-declarator \terminal{[} constant-expression \terminal{]} attribute-specifier-seq\opt{}
+    \terminal{[} expression \terminal{]} \opt{attribute-specifier-seq}\br
+    noptr-new-declarator \terminal{[} constant-expression \terminal{]} \opt{attribute-specifier-seq}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{new-initializer}\br
-    \terminal{(} expression-list\opt{} \terminal{)}\br
+    \terminal{(} \opt{expression-list} \terminal{)}\br
     braced-init-list
 \end{bnf}
 
@@ -3989,8 +3989,8 @@ object\iref{intro.object} or array created by a
 
 \begin{bnf}
 \nontermdef{delete-expression}\br
-    \terminal{::}\opt{} \terminal{delete} cast-expression\br
-    \terminal{::}\opt{} \terminal{delete [ ]} cast-expression
+    \opt{\terminal{::}} \terminal{delete} cast-expression\br
+    \opt{\terminal{::}} \terminal{delete [ ]} cast-expression
 \end{bnf}
 
 The first alternative is for non-array objects, and the second is for arrays. Whenever
@@ -5126,7 +5126,7 @@ that type and the other is a null pointer constant. The result is of type
 %
 \begin{bnf}
 \nontermdef{throw-expression}\br
-    \terminal{throw}  assignment-expression\opt{}
+    \terminal{throw}  \opt{assignment-expression}
 \end{bnf}
 
 \pnum

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1665,7 +1665,7 @@ template<typename T> concept C =
 
 \begin{bnf}
 \nontermdef{type-requirement}\br
-    \terminal{typename} nested-name-specifier\opt type-name \terminal{;}
+    \terminal{typename} \opt{nested-name-specifier} type-name \terminal{;}
 \end{bnf}
 
 \pnum

--- a/source/future.tex
+++ b/source/future.tex
@@ -911,7 +911,7 @@ initializing the base class with
 \tcode{istream(\&sb)}
 and initializing \tcode{sb} with
 \tcode{strstreambuf(s,0)}.
-\tcode{s} shall designate the first element of an \ntbs.%
+\tcode{s} shall designate the first element of an \ntbs{}.%
 \indextext{NTBS}
 \end{itemdescr}
 
@@ -1038,7 +1038,7 @@ The constructor is
 If
 \tcode{(mode \& app) != 0},
 then \tcode{s} shall designate the first element of an array of \tcode{n} elements that
-contains an \ntbs whose first element is designated by \tcode{s}.
+contains an \ntbs{} whose first element is designated by \tcode{s}.
 \indextext{NTBS}%
 The constructor is
 \tcode{strstreambuf(s, n, s + std::strlen(s))}.\footnote{The function signature
@@ -1187,7 +1187,7 @@ If
 \tcode{(mode \& app) != 0},
 then \tcode{s} shall
 designate the first element of an array of \tcode{n} elements that contains
-an \ntbs whose first element is designated by \tcode{s}.
+an \ntbs{} whose first element is designated by \tcode{s}.
 The constructor is
 \tcode{strstreambuf(s,n,s + std::strlen(s))}.
 \indexlibrary{\idxcode{strstream}!destructor}%

--- a/source/future.tex
+++ b/source/future.tex
@@ -2,7 +2,7 @@
 \normannex{depr}{Compatibility features}
 
 \pnum
-This Clause describes features of the \Cpp Standard that are specified for compatibility with
+This Clause describes features of the \Cpp{} Standard that are specified for compatibility with
 existing implementations.
 
 \pnum
@@ -23,10 +23,10 @@ This usage is deprecated.
 \begin{example}
 \begin{codeblock}
 struct A {
-  static constexpr int n = 5;  // definition (declaration in \CppXIV)
+  static constexpr int n = 5;  // definition (declaration in \CppXIV{})
 };
 
-constexpr int A::n;  // redundant declaration (definition in \CppXIV)
+constexpr int A::n;  // redundant declaration (definition in \CppXIV{})
 \end{codeblock}
 \end{example}
 
@@ -48,11 +48,11 @@ could become deleted\iref{dcl.fct.def}.
 \pnum
 The \grammarterm{noexcept-specifier} \tcode{throw()} is deprecated.
 
-\rSec1[depr.cpp.headers]{\Cpp standard library headers}
+\rSec1[depr.cpp.headers]{\Cpp{} standard library headers}
 
 \pnum
-For compatibility with prior \Cpp International Standards,
-the \Cpp standard library provides headers
+For compatibility with prior \Cpp{} International Standards,
+the \Cpp{} standard library provides headers
 \tcode{<ccomplex>}\iref{depr.ccomplex.syn},
 \tcode{<cstdalign>}\iref{depr.cstdalign.syn},
 \tcode{<cstdbool>}\iref{depr.cstdbool.syn},
@@ -129,7 +129,7 @@ overloads.\end{note}
 \pnum
 For compatibility with the
 \indextext{library!C standard}%
-C standard library, the \Cpp standard library provides
+C standard library, the \Cpp{} standard library provides
 the \defnx{C headers}{headers!C library} shown in Table~\ref{tab:future.c.headers}.
 
 \begin{floattable}{C headers}{tab:future.c.headers}
@@ -2149,7 +2149,7 @@ only to callers of that class.\end{note}
 
 \pnum
 \begin{example}
-If a \Cpp program wants to define a bidirectional iterator for some data
+If a \Cpp{} program wants to define a bidirectional iterator for some data
 structure containing \tcode{double} and such that it works on a large memory
 model of the implementation, it can do so with:
 

--- a/source/grammar.tex
+++ b/source/grammar.tex
@@ -3,10 +3,10 @@
 \pnum
 \indextext{grammar}%
 \indextext{summary!syntax}%
-This summary of \Cpp grammar is intended to be an aid to comprehension.
+This summary of \Cpp{} grammar is intended to be an aid to comprehension.
 It is not an exact statement of the language.
 In particular, the grammar described here accepts
-a superset of valid \Cpp constructs.
+a superset of valid \Cpp{} constructs.
 Disambiguation rules~(\ref{stmt.ambig}, \ref{dcl.spec}, \ref{class.member.lookup})
 must be applied to distinguish expressions from declarations.
 Further, access control, ambiguity, and type rules must be used

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -477,7 +477,7 @@ An optional terminal or non-terminal symbol is indicated by the subscript
 ``\opt{}'', so
 
 \begin{ncbnf}
-\terminal{\{} expression\opt{} \terminal{\}}
+\terminal{\{} \opt{expression} \terminal{\}}
 \end{ncbnf}
 
 indicates an optional expression enclosed in braces.%

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -5,17 +5,17 @@
 \pnum
 \indextext{scope|(}%
 This document specifies requirements for implementations
-of the \Cpp programming language. The first such requirement is that
+of the \Cpp{} programming language. The first such requirement is that
 they implement the language, so this document also
-defines \Cpp. Other requirements and relaxations of the first
+defines \Cpp{}. Other requirements and relaxations of the first
 requirement appear at various places within this document.
 
 \pnum
-\Cpp is a general purpose programming language based on the C
+\Cpp{} is a general purpose programming language based on the C
 programming language as described in ISO/IEC 9899:2011
 \doccite{Programming languages --- C} (hereinafter referred to as the
 \defnx{C standard}{C!standard}). In addition to
-the facilities provided by C, \Cpp provides additional data types,
+the facilities provided by C, \Cpp{} provides additional data types,
 classes, templates, exceptions, namespaces, operator
 overloading, function name overloading, references, free store
 management operators, and additional library facilities.%
@@ -58,7 +58,7 @@ is hereinafter called the
 \defnx{C standard library}{C!standard library}.%
 \footnote{With the qualifications noted in \ref{\firstlibchapter}
 through \ref{\lastlibchapter} and in \ref{diff.library}, the C standard
-library is a subset of the \Cpp standard library.}
+library is a subset of the \Cpp{} standard library.}
 
 \pnum
 The operating system interface described in ISO/IEC 9945:2003 is
@@ -306,7 +306,7 @@ possible behaviors is usually delineated by this International Standard.
 
 \indexdefn{program!well-formed}%
 \definition{well-formed program}{defns.well.formed}
-\Cpp  program constructed according to the syntax rules, diagnosable
+\Cpp{}  program constructed according to the syntax rules, diagnosable
 semantic rules, and the one-definition rule\iref{basic.def.odr}%
 \indextext{definitions|)}
 
@@ -348,7 +348,7 @@ Standard except for those rules containing an explicit notation that
 
 \pnum
 \indextext{conformance requirements!method of description}%
-Although this International Standard states only requirements on \Cpp
+Although this International Standard states only requirements on \Cpp{}
 implementations, those requirements are often easier to understand if
 they are phrased as requirements on programs, parts of programs, or
 execution of programs. Such requirements have the following meaning:
@@ -394,7 +394,7 @@ consistent with the descriptions in the library Clauses.
 
 \pnum
 The names defined in the library have namespace
-scope\iref{basic.namespace}. A \Cpp  translation
+scope\iref{basic.namespace}. A \Cpp{}  translation
 unit\iref{lex.phases} obtains access to these names by including the
 appropriate standard library header\iref{cpp.include}.
 
@@ -402,7 +402,7 @@ appropriate standard library header\iref{cpp.include}.
 The templates, classes, functions, and objects in the library have
 external linkage\iref{basic.link}. The implementation provides
 definitions for standard library entities, as necessary, while combining
-translation units to form a complete \Cpp  program\iref{lex.phases}.%
+translation units to form a complete \Cpp{}  program\iref{lex.phases}.%
 \indextext{conformance requirements!library|)}
 
 \pnum
@@ -435,14 +435,14 @@ see~\ref{intro.execution}.}%
 \pnum
 \indextext{standard!structure of|(}%
 \indextext{standard!structure of}%
-\ref{lex} through \ref{cpp} describe the \Cpp  programming
+\ref{lex} through \ref{cpp} describe the \Cpp{}  programming
 language. That description includes detailed syntactic specifications in
 a form described in~\ref{syntax}. For convenience, \ref{gram}
 repeats all such syntactic specifications.
 
 \pnum
 \ref{\firstlibchapter} through \ref{\lastlibchapter} and \ref{depr}
-(the \defn{library clauses}) describe the \Cpp standard library.
+(the \defn{library clauses}) describe the \Cpp{} standard library.
 That description includes detailed descriptions of the
 entities and macros
 that constitute the library, in a form described in \ref{library}.
@@ -452,9 +452,9 @@ that constitute the library, in a form described in \ref{library}.
 implementations.
 
 \pnum
-\ref{diff} summarizes the evolution of \Cpp  since its first
+\ref{diff} summarizes the evolution of \Cpp{}  since its first
 published description, and explains in detail the differences between
-\Cpp  and C\@. Certain features of \Cpp  exist solely for compatibility
+\Cpp{}  and C\@. Certain features of \Cpp{}  exist solely for compatibility
 purposes; \ref{depr} describes those features.
 
 \pnum
@@ -500,11 +500,11 @@ identifiers separated by commas).
 \end{itemize}%
 \indextext{notation!syntax|)}
 
-\rSec1[intro.memory]{The \Cpp memory model}
+\rSec1[intro.memory]{The \Cpp{} memory model}
 
 \pnum
 \indextext{memory model|(}%
-The fundamental storage unit in the \Cpp memory model is the
+The fundamental storage unit in the \Cpp{} memory model is the
 \defn{byte}.
 A byte is at least large enough to contain any member of the basic
 \indextext{character set!basic execution}%
@@ -516,7 +516,7 @@ bits,\footnote{The number of bits in a byte is reported by the macro
 the number of which is \impldef{bits in a byte}. The least
 significant bit is called the \defn{low-order bit}; the most
 significant bit is called the \defn{high-order bit}. The memory
-available to a \Cpp program consists of one or more sequences of
+available to a \Cpp{} program consists of one or more sequences of
 contiguous bytes. Every byte has a unique address.
 
 \pnum
@@ -564,11 +564,11 @@ bit-fields \tcode{b} and \tcode{c} cannot be concurrently modified, but
 \tcode{b} and \tcode{a}, for example, can be. \end{example}%
 \indextext{memory model|)}
 
-\rSec1[intro.object]{The \Cpp object model}
+\rSec1[intro.object]{The \Cpp{} object model}
 
 \pnum
 \indextext{object model|(}%
-The constructs in a \Cpp program create, destroy, refer to, access, and
+The constructs in a \Cpp{} program create, destroy, refer to, access, and
 manipulate objects.
 An \defn{object} is created
 by a definition\iref{basic.def},
@@ -754,7 +754,7 @@ const bool b = &test1 != &test2;      // always \tcode{true}
 
 \pnum
 \begin{note}
-\Cpp  provides a variety of fundamental types and several ways of composing
+\Cpp{}  provides a variety of fundamental types and several ways of composing
 new types from existing types\iref{basic.types}.
 \end{note}%
 \indextext{object model|)}
@@ -1126,7 +1126,7 @@ function executions do not interleave with each other.}
 If \placeholder{A} and \placeholder{B} would not otherwise be sequenced then they are
 indeterminately sequenced.
 \end{note}
-Several contexts in \Cpp  cause evaluation of a function call, even
+Several contexts in \Cpp{}  cause evaluation of a function call, even
 though no corresponding function call syntax appears in the translation
 unit.
 \begin{example}
@@ -1166,7 +1166,7 @@ potentially access every object and function in a program.\footnote{An object
 with automatic or thread storage duration\iref{basic.stc} is associated with
 one specific thread, and can be accessed by a different thread only indirectly
 through a pointer or reference\iref{basic.compound}.} Under a hosted
-implementation, a \Cpp program can have more than one thread running
+implementation, a \Cpp{} program can have more than one thread running
 concurrently. The execution of each thread proceeds as defined by the remainder
 of this International Standard. The execution of the entire program consists of an execution
 of all of its threads. \begin{note} Usually the execution can be viewed as an
@@ -1444,7 +1444,7 @@ write-read coherence. \end{note}
 \begin{note} The four preceding coherence requirements effectively disallow
 compiler reordering of atomic operations to a single object, even if both
 operations are relaxed loads. This effectively makes the cache coherence
-guarantee provided by most hardware available to \Cpp atomic operations.
+guarantee provided by most hardware available to \Cpp{} atomic operations.
 \end{note}
 
 \pnum
@@ -1508,7 +1508,7 @@ rules. \end{note}
 
 \pnum
 \begin{note} Transformations that introduce a speculative read of a potentially
-shared memory location may not preserve the semantics of the \Cpp program as
+shared memory location may not preserve the semantics of the \Cpp{} program as
 defined in this International Standard, since they potentially introduce a data race. However,
 they are typically valid in the context of an optimizing compiler that targets a
 specific machine with well-defined semantics for data races. They would be
@@ -1721,9 +1721,9 @@ other threads in a finite period of time.%
 \rSec1[intro.ack]{Acknowledgments}
 
 \pnum
-The \Cpp  programming language as described in this document
+The \Cpp{}  programming language as described in this document
 is based on the language as described in Chapter R (Reference
-Manual) of Stroustrup: \doccite{The \Cpp  Programming Language} (second
+Manual) of Stroustrup: \doccite{The \Cpp{}  Programming Language} (second
 edition, Addison-Wesley Publishing Company, ISBN 0-201-53992-6,
 copyright \copyright 1991 AT\&T). That, in turn, is based on the C
 programming language as described in Appendix A of Kernighan and
@@ -1733,7 +1733,7 @@ Ritchie: \doccite{The C Programming Language} (Prentice-Hall, 1978, ISBN
 \pnum
 Portions of the library Clauses of this document are based
 on work by P.J. Plauger, which was published as \doccite{The Draft
-Standard \Cpp  Library} (Prentice-Hall, ISBN 0-13-117003-1, copyright
+Standard \Cpp{}  Library} (Prentice-Hall, ISBN 0-13-117003-1, copyright
 \copyright 1995 P.J. Plauger).
 
 \pnum

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -474,7 +474,7 @@ and characters in \tcode{constant} \tcode{width} type. Alternatives are
 listed on separate lines except in a few cases where a long set of
 alternatives is marked by the phrase ``one of''. If the text of an alternative is too long to fit on a line, the text is continued on subsequent lines indented from the first one.
 An optional terminal or non-terminal symbol is indicated by the subscript
-``\opt'', so
+``\opt{}'', so
 
 \begin{ncbnf}
 \terminal{\{} expression\opt{} \terminal{\}}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -4,7 +4,7 @@
 \rSec1[input.output.general]{General}
 
 \pnum
-This Clause describes components that \Cpp programs may use to perform
+This Clause describes components that \Cpp{} programs may use to perform
 input/output operations.
 
 \pnum
@@ -1347,7 +1347,7 @@ locale getloc() const;
 \begin{itemdescr}
 \pnum
 \returns
-If no locale has been imbued, a copy of the global \Cpp locale,
+If no locale has been imbued, a copy of the global \Cpp{} locale,
 \tcode{locale()},
 in effect at the time of construction.
 Otherwise, returns the imbued locale, to be used to
@@ -2721,7 +2721,7 @@ ios_base& hexfloat(ios_base& str);
 \pnum
 \begin{note} The more obvious use of
 \tcode{ios_base::hex} to specify hexadecimal floating-point format would
-change the meaning of existing well-defined programs. \CppIII
+change the meaning of existing well-defined programs. \CppIII{}
 gives no meaning to the combination of \tcode{fixed} and
 \tcode{scientific}.\end{note}
 
@@ -10835,7 +10835,7 @@ For Windows-based operating systems, the
 native narrow encoding is determined by calling a Windows API function.
 \end{note}
 \begin{note}
-This results in behavior identical to other C and \Cpp
+This results in behavior identical to other C and \Cpp{}
 standard library functions that perform file operations using narrow character
 strings to identify paths. Changing this behavior would be surprising and error
 prone.

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -10109,8 +10109,8 @@ entry for the file under discussion.
 A sequence of elements that identify
 the location of a file within a filesystem.
 The elements are the
-\grammarterm{root-name}\opt{},
-\grammarterm{root-directory}\opt{},
+\opt{\grammarterm{root-name}},
+\opt{\grammarterm{root-directory}},
 and an optional sequence of filenames.
 The maximum number of elements in the sequence is operating system dependent.
 
@@ -10647,7 +10647,7 @@ any operating system dependent \grammarterm{root-name}{s}}}
 
 \begin{ncbnf}
 \nontermdef{pathname}\br
-    root-name\opt{} root-directory\opt{} relative-path
+    \opt{root-name} \opt{root-directory} relative-path
 \end{ncbnf}
 
 \begin{ncbnf}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -8649,12 +8649,12 @@ initializes the
 \tcode{filebuf}
 as required.
 It then opens a file, if possible, whose name is the
-\ntbs \tcode{s}
+\ntbs{} \tcode{s}
 (as if by calling
 \tcode{fopen(s, modstr)}).
 \indextext{NTBS}%
 \indexlibrary{\idxcode{fopen}}%
-The \ntbs \tcode{modstr} is determined from
+The \ntbs{} \tcode{modstr} is determined from
 \tcode{mode \& \~{}ios_base::ate}
 as indicated in Table~\ref{tab:iostreams.file.open.modes}.
 If \tcode{mode} is not some combination of flags shown in the table then

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -10675,8 +10675,8 @@ any operating system dependent \grammarterm{root-name}{s}}}
 
 \begin{ncbnf}
 \nontermdef{directory-separator}\br
-    preferred-separator directory-separator\opt\br
-    fallback-separator directory-separator\opt
+    preferred-separator \opt{directory-separator}\br
+    fallback-separator \opt{directory-separator}
 \end{ncbnf}
 
 \begin{ncbnf}

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -4,7 +4,7 @@
 \rSec1[iterators.general]{General}
 
 \pnum
-This Clause describes components that \Cpp programs may use to perform
+This Clause describes components that \Cpp{} programs may use to perform
 iterations over containers\iref{containers},
 streams\iref{iostream.format},
 and stream buffers\iref{stream.buffers}.
@@ -32,7 +32,7 @@ as summarized in Table~\ref{tab:iterators.lib.summary}.
 
 \pnum
 \indextext{requirements!iterator}%
-Iterators are a generalization of pointers that allow a \Cpp program to work with different data structures
+Iterators are a generalization of pointers that allow a \Cpp{} program to work with different data structures
 (containers) in a uniform manner.
 To be able to construct template algorithms that work correctly and
 efficiently on different types of data structures, the library formalizes not just the interfaces but also the
@@ -67,7 +67,7 @@ of the iterator.
 
 \pnum
 Since iterators are an abstraction of pointers, their semantics is
-a generalization of most of the semantics of pointers in \Cpp.
+a generalization of most of the semantics of pointers in \Cpp{}.
 This ensures that every
 function template
 that takes iterators
@@ -952,7 +952,7 @@ namespace std {
 \begin{example}
 To implement a generic
 \tcode{reverse}
-function, a \Cpp program can do the following:
+function, a \Cpp{} program can do the following:
 
 \begin{codeblock}
 template <class BidirectionalIterator>

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -302,7 +302,7 @@ parenthesis is identified. The raw string literal is defined as the shortest seq
 of characters that matches the raw-string pattern
 
 \begin{ncbnf}
-encoding-prefix\opt{} \terminal{R} raw-string
+\opt{encoding-prefix} \terminal{R} raw-string
 \end{ncbnf}
 
 \item Otherwise, if the next three characters are \tcode{<::} and the subsequent character
@@ -838,29 +838,29 @@ ISO C. }
 \indextext{literal!integer}%
 \begin{bnf}
 \nontermdef{integer-literal}\br
-    binary-literal integer-suffix\opt{}\br
-    octal-literal integer-suffix\opt{}\br
-    decimal-literal integer-suffix\opt{}\br
-    hexadecimal-literal integer-suffix\opt{}
+    binary-literal \opt{integer-suffix}\br
+    octal-literal \opt{integer-suffix}\br
+    decimal-literal \opt{integer-suffix}\br
+    hexadecimal-literal \opt{integer-suffix}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{binary-literal}\br
     \terminal{0b} binary-digit\br
     \terminal{0B} binary-digit\br
-    binary-literal \terminal{'}\opt{} binary-digit
+    binary-literal \opt{\terminal{'}} binary-digit
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{octal-literal}\br
     \terminal{0}\br
-    octal-literal \terminal{'}\opt{} octal-digit
+    octal-literal \opt{\terminal{'}} octal-digit
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{decimal-literal}\br
     nonzero-digit\br
-    decimal-literal \terminal{'}\opt{} digit
+    decimal-literal \opt{\terminal{'}} digit
 \end{bnf}
 
 \begin{bnf}
@@ -892,7 +892,7 @@ ISO C. }
 \begin{bnf}
 \nontermdef{hexadecimal-digit-sequence}\br
     hexadecimal-digit\br
-    hexadecimal-digit-sequence \terminal{'}\opt{} hexadecimal-digit
+    hexadecimal-digit-sequence \opt{\terminal{'}} hexadecimal-digit
 \end{bnf}
 
 \begin{bnf}
@@ -904,10 +904,10 @@ ISO C. }
 
 \begin{bnf}
 \nontermdef{integer-suffix}\br
-    unsigned-suffix long-suffix\opt{} \br
-    unsigned-suffix long-long-suffix\opt{} \br
-    long-suffix unsigned-suffix\opt{} \br
-    long-long-suffix unsigned-suffix\opt{}
+    unsigned-suffix \opt{long-suffix} \br
+    unsigned-suffix \opt{long-long-suffix} \br
+    long-suffix \opt{unsigned-suffix} \br
+    long-long-suffix \opt{unsigned-suffix}
 \end{bnf}
 
 \begin{bnf}
@@ -1051,7 +1051,7 @@ that cannot be represented by any of the allowed types.
 \indextext{literal!character}%
 \begin{bnf}
 \nontermdef{character-literal}\br
-    encoding-prefix\opt{} \terminal{'} c-char-sequence \terminal{'}
+    \opt{encoding-prefix} \terminal{'} c-char-sequence \terminal{'}
 \end{bnf}
 
 \begin{bnf}
@@ -1285,38 +1285,38 @@ so long as the same results are obtained. \end{note}
 
 \begin{bnf}
 \nontermdef{decimal-floating-literal}\br
-    fractional-constant exponent-part\opt{} floating-suffix\opt{}\br
-    digit-sequence exponent-part floating-suffix\opt{}
+    fractional-constant \opt{exponent-part} \opt{floating-suffix}\br
+    digit-sequence exponent-part \opt{floating-suffix}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{hexadecimal-floating-literal}\br
-    hexadecimal-prefix hexadecimal-fractional-constant binary-exponent-part floating-suffix\opt{}\br
-    hexadecimal-prefix hexadecimal-digit-sequence binary-exponent-part floating-suffix\opt{}
+    hexadecimal-prefix hexadecimal-fractional-constant binary-exponent-part \opt{floating-suffix}\br
+    hexadecimal-prefix hexadecimal-digit-sequence binary-exponent-part \opt{floating-suffix}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{fractional-constant}\br
-    digit-sequence\opt{} \terminal{.} digit-sequence\br
+    \opt{digit-sequence} \terminal{.} digit-sequence\br
     digit-sequence \terminal{.}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{hexadecimal-fractional-constant}\br
-    hexadecimal-digit-sequence\opt{} \terminal{.} hexadecimal-digit-sequence\br
+    \opt{hexadecimal-digit-sequence} \terminal{.} hexadecimal-digit-sequence\br
     hexadecimal-digit-sequence \terminal{.}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{exponent-part}\br
-    \terminal{e} sign\opt{} digit-sequence\br
-    \terminal{E} sign\opt{} digit-sequence
+    \terminal{e} \opt{sign} digit-sequence\br
+    \terminal{E} \opt{sign} digit-sequence
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{binary-exponent-part}\br
-    \terminal{p} sign\opt{} digit-sequence\br
-    \terminal{P} sign\opt{} digit-sequence
+    \terminal{p} \opt{sign} digit-sequence\br
+    \terminal{P} \opt{sign} digit-sequence
 \end{bnf}
 
 \begin{bnf}
@@ -1327,7 +1327,7 @@ so long as the same results are obtained. \end{note}
 \begin{bnf}
 \nontermdef{digit-sequence}\br
     digit\br
-    digit-sequence \terminal{'}\opt{} digit
+    digit-sequence \opt{\terminal{'}} digit
 \end{bnf}
 
 \begin{bnf}
@@ -1398,8 +1398,8 @@ values for its type, the program is ill-formed.
 \indextext{literal!string}%
 \begin{bnf}
 \nontermdef{string-literal}\br
-    encoding-prefix\opt{} \terminal{"} s-char-sequence\opt{} \terminal{"}\br
-    encoding-prefix\opt{} \terminal{R} raw-string
+    \opt{encoding-prefix} \terminal{"} \opt{s-char-sequence} \terminal{"}\br
+    \opt{encoding-prefix} \terminal{R} raw-string
 \end{bnf}
 
 \begin{bnf}
@@ -1418,7 +1418,7 @@ values for its type, the program is ill-formed.
 
 \begin{bnf}
 \nontermdef{raw-string}\br
-    \terminal{"} d-char-sequence\opt{} \terminal{(} r-char-sequence\opt{} \terminal{)} d-char-sequence\opt{} \terminal{"}
+    \terminal{"} \opt{d-char-sequence} \terminal{(} \opt{r-char-sequence} \terminal{)} \opt{d-char-sequence} \terminal{"}
 \end{bnf}
 
 \begin{bnf}
@@ -1739,7 +1739,7 @@ and~\ref{conv.mem}.
 
 \begin{bnf}
 \nontermdef{user-defined-floating-literal}\br
-    fractional-constant exponent-part\opt{} ud-suffix\br
+    fractional-constant \opt{exponent-part} ud-suffix\br
     digit-sequence exponent-part ud-suffix\br
     hexadecimal-prefix hexadecimal-fractional-constant binary-exponent-part ud-suffix\br
     hexadecimal-prefix hexadecimal-digit-sequence binary-exponent-part ud-suffix

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -35,7 +35,7 @@ and source files included\iref{cpp.include} via the preprocessing
 directive \tcode{\#include}, less any source lines skipped by any of the
 conditional inclusion\iref{cpp.cond} preprocessing directives, is
 called a \defn{translation unit}.
-\begin{note} A \Cpp program need not all be translated at the same time.
+\begin{note} A \Cpp{} program need not all be translated at the same time.
 \end{note}
 
 \pnum
@@ -555,9 +555,9 @@ characters, an encoding of the \grammarterm{universal-character-name} may be use
 forming valid external identifiers. For example, some otherwise unused
 character or sequence of characters may be used to encode the
 \tcode{\textbackslash u} in a \grammarterm{universal-character-name}. Extended
-characters may produce a long external identifier, but \Cpp does not
+characters may produce a long external identifier, but \Cpp{} does not
 place a translation limit on significant characters for external
-identifiers. In \Cpp, upper- and lower-case letters are considered
+identifiers. In \Cpp{}, upper- and lower-case letters are considered
 different for all identifiers, including external identifiers. }
 
 \begin{floattable}{Ranges of characters allowed}{tab:charname.allowed}
@@ -639,7 +639,7 @@ token as a regular \grammarterm{identifier}.
 \indextext{\idxcode{_}|see{character, underscore}}%
 \indextext{character!underscore!in identifier}%
 \indextext{reserved identifier}%
-In addition, some identifiers are reserved for use by \Cpp
+In addition, some identifiers are reserved for use by \Cpp{}
 implementations and shall
 not be used otherwise; no diagnostic is required.
 \begin{itemize}
@@ -788,7 +788,7 @@ otherwise:
 \pnum
 \indextext{operator|(}%
 \indextext{punctuator|(}%
-The lexical representation of \Cpp programs includes a number of
+The lexical representation of \Cpp{} programs includes a number of
 preprocessing tokens which are used in the syntax of the preprocessor or
 are converted into tokens for operators and punctuators:
 
@@ -1199,7 +1199,7 @@ of a wide-character literal containing multiple \grammarterm{c-char}{s} is
 \pnum
 Certain non-graphic characters, the single quote \tcode{'}, the double quote \tcode{"},
 the question mark \tcode{?},\footnote{Using an escape sequence for a question mark
-is supported for compatibility with ISO \CppXIV and ISO C.}
+is supported for compatibility with ISO \CppXIV{} and ISO C.}
 and the backslash
 \indextext{backslash character}%
 \indextext{\idxcode{\textbackslash}|see{backslash character}}%

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -838,29 +838,29 @@ ISO C. }
 \indextext{literal!integer}%
 \begin{bnf}
 \nontermdef{integer-literal}\br
-    binary-literal integer-suffix\opt\br
-    octal-literal integer-suffix\opt\br
-    decimal-literal integer-suffix\opt\br
-    hexadecimal-literal integer-suffix\opt
+    binary-literal integer-suffix\opt{}\br
+    octal-literal integer-suffix\opt{}\br
+    decimal-literal integer-suffix\opt{}\br
+    hexadecimal-literal integer-suffix\opt{}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{binary-literal}\br
     \terminal{0b} binary-digit\br
     \terminal{0B} binary-digit\br
-    binary-literal \terminal{'}\opt binary-digit
+    binary-literal \terminal{'}\opt{} binary-digit
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{octal-literal}\br
     \terminal{0}\br
-    octal-literal \terminal{'}\opt octal-digit
+    octal-literal \terminal{'}\opt{} octal-digit
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{decimal-literal}\br
     nonzero-digit\br
-    decimal-literal \terminal{'}\opt digit
+    decimal-literal \terminal{'}\opt{} digit
 \end{bnf}
 
 \begin{bnf}
@@ -892,7 +892,7 @@ ISO C. }
 \begin{bnf}
 \nontermdef{hexadecimal-digit-sequence}\br
     hexadecimal-digit\br
-    hexadecimal-digit-sequence \terminal{'}\opt hexadecimal-digit
+    hexadecimal-digit-sequence \terminal{'}\opt{} hexadecimal-digit
 \end{bnf}
 
 \begin{bnf}
@@ -904,10 +904,10 @@ ISO C. }
 
 \begin{bnf}
 \nontermdef{integer-suffix}\br
-    unsigned-suffix long-suffix\opt \br
-    unsigned-suffix long-long-suffix\opt \br
-    long-suffix unsigned-suffix\opt \br
-    long-long-suffix unsigned-suffix\opt
+    unsigned-suffix long-suffix\opt{} \br
+    unsigned-suffix long-long-suffix\opt{} \br
+    long-suffix unsigned-suffix\opt{} \br
+    long-long-suffix unsigned-suffix\opt{}
 \end{bnf}
 
 \begin{bnf}
@@ -1285,14 +1285,14 @@ so long as the same results are obtained. \end{note}
 
 \begin{bnf}
 \nontermdef{decimal-floating-literal}\br
-    fractional-constant exponent-part\opt floating-suffix\opt\br
-    digit-sequence exponent-part floating-suffix\opt
+    fractional-constant exponent-part\opt{} floating-suffix\opt{}\br
+    digit-sequence exponent-part floating-suffix\opt{}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{hexadecimal-floating-literal}\br
-    hexadecimal-prefix hexadecimal-fractional-constant binary-exponent-part floating-suffix\opt\br
-    hexadecimal-prefix hexadecimal-digit-sequence binary-exponent-part floating-suffix\opt
+    hexadecimal-prefix hexadecimal-fractional-constant binary-exponent-part floating-suffix\opt{}\br
+    hexadecimal-prefix hexadecimal-digit-sequence binary-exponent-part floating-suffix\opt{}
 \end{bnf}
 
 \begin{bnf}
@@ -1309,14 +1309,14 @@ so long as the same results are obtained. \end{note}
 
 \begin{bnf}
 \nontermdef{exponent-part}\br
-    \terminal{e} sign\opt digit-sequence\br
-    \terminal{E} sign\opt digit-sequence
+    \terminal{e} sign\opt{} digit-sequence\br
+    \terminal{E} sign\opt{} digit-sequence
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{binary-exponent-part}\br
-    \terminal{p} sign\opt digit-sequence\br
-    \terminal{P} sign\opt digit-sequence
+    \terminal{p} sign\opt{} digit-sequence\br
+    \terminal{P} sign\opt{} digit-sequence
 \end{bnf}
 
 \begin{bnf}
@@ -1327,7 +1327,7 @@ so long as the same results are obtained. \end{note}
 \begin{bnf}
 \nontermdef{digit-sequence}\br
     digit\br
-    digit-sequence \terminal{'}\opt digit
+    digit-sequence \terminal{'}\opt{} digit
 \end{bnf}
 
 \begin{bnf}
@@ -1739,7 +1739,7 @@ and~\ref{conv.mem}.
 
 \begin{bnf}
 \nontermdef{user-defined-floating-literal}\br
-    fractional-constant exponent-part\opt ud-suffix\br
+    fractional-constant exponent-part\opt{} ud-suffix\br
     digit-sequence exponent-part ud-suffix\br
     hexadecimal-prefix hexadecimal-fractional-constant binary-exponent-part ud-suffix\br
     hexadecimal-prefix hexadecimal-digit-sequence binary-exponent-part ud-suffix

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -5,9 +5,9 @@
 
 \pnum
 This Clause describes the contents of the
-\term{\Cpp standard library},
+\term{\Cpp{} standard library},
 \indextext{library!C++ standard}%
-how a well-formed \Cpp program makes use of the library, and
+how a well-formed \Cpp{} program makes use of the library, and
 how a conforming implementation may provide the entities in the library.
 
 \pnum
@@ -16,7 +16,7 @@ description\iref{description}, and organization\iref{organization} of the
 library. \ref{requirements}, \ref{\firstlibchapter}
 through \ref{\lastlibchapter}, and \ref{depr} specify the contents of the
 library, as well as library requirements and constraints on both well-formed
-\Cpp programs and conforming implementations.
+\Cpp{} programs and conforming implementations.
 
 \pnum
 Detailed specifications for each of the components in the library are in
@@ -41,19 +41,19 @@ Table~\ref{tab:library.categories}.
 
 \pnum
 The language support library\iref{language.support} provides components that are
-required by certain parts of the \Cpp language, such as memory allocation~(\ref{expr.new},
+required by certain parts of the \Cpp{} language, such as memory allocation~(\ref{expr.new},
 \ref{expr.delete}) and exception processing\iref{except}.
 
 \pnum
 The diagnostics library\iref{diagnostics} provides a consistent framework for
-reporting errors in a \Cpp program, including predefined exception classes.
+reporting errors in a \Cpp{} program, including predefined exception classes.
 
 \pnum
 The general utilities library\iref{utilities} includes components used
 by other library elements, such as a predefined storage allocator for dynamic
 storage management\iref{basic.stc.dynamic}, and components used
 as infrastructure
-in \Cpp programs,
+in \Cpp{} programs,
 such as tuples, function wrappers, and time facilities.
 
 \pnum
@@ -74,7 +74,7 @@ support for text processing.
 
 \pnum
 The containers\iref{containers}, iterators\iref{iterators},
-and algorithms\iref{algorithms} libraries provide a \Cpp program with access
+and algorithms\iref{algorithms} libraries provide a \Cpp{} program with access
 to a subset of the most widely used algorithms and data structures.
 
 \pnum
@@ -91,7 +91,7 @@ The random number component provides facilities for generating pseudo-random num
 \pnum
 The input/output library\iref{input.output} provides the
 \tcode{iostream}
-components that are the primary mechanism for \Cpp program input and output.
+components that are the primary mechanism for \Cpp{} program input and output.
 They can be used with other elements of the library, particularly
 strings, locales, and iterators.
 
@@ -109,7 +109,7 @@ and manage threads, including mutual exclusion and interthread communication.
 \rSec1[library.c]{The C standard library}
 
 \pnum
-The \Cpp standard library also makes available the facilities of the C standard library,
+The \Cpp{} standard library also makes available the facilities of the C standard library,
 \indextext{library!C standard}%
 suitably adjusted to ensure static type safety.
 
@@ -223,9 +223,9 @@ that is not list-initialization\iref{dcl.init.list}
 \indexdefn{function!handler}%
 a
 \term{non-reserved function}
-whose definition may be provided by a \Cpp program\\
+whose definition may be provided by a \Cpp{} program\\
 \begin{note}
-A \Cpp program may designate a handler function at various points in its execution by
+A \Cpp{} program may designate a handler function at various points in its execution by
 supplying a pointer to the function when calling any of the library functions that install
 handler functions\iref{language.support}.
 \end{note}
@@ -293,7 +293,7 @@ including reference types. \end{note}
 \indexdefn{function!replacement}%
 a
 \term{non-reserved function}
-whose definition is provided by a \Cpp program\\
+whose definition is provided by a \Cpp{} program\\
 \begin{note}
 Only one definition for such a function is in effect for the duration of the program's
 execution, as the result of creating the program\iref{lex.phases} and resolving the
@@ -315,17 +315,17 @@ semantics
 applicable to both the behavior provided by the implementation and
 the behavior of any such function definition in the program\\
 \begin{note}
-If such a function defined in a \Cpp program fails to meet the required
+If such a function defined in a \Cpp{} program fails to meet the required
 behavior when it executes, the behavior is undefined.%
 \indextext{undefined}
 \end{note}
 
 \definition{reserved function}{defns.reserved.function}
 \indexdefn{function!reserved}%
-a function, specified as part of the \Cpp standard library, that must be defined by the
+a function, specified as part of the \Cpp{} standard library, that must be defined by the
 implementation\\
 \begin{note}
-If a \Cpp program provides a definition for any reserved function, the results are undefined.%
+If a \Cpp{} program provides a definition for any reserved function, the results are undefined.%
 \indextext{undefined}
 \end{note}
 
@@ -353,7 +353,7 @@ and \tcode{x.front()} can be called only if \tcode{x.empty()} returns
 \rSec1[description]{Method of description (Informative)}
 
 \pnum
-This subclause describes the conventions used to specify the \Cpp standard
+This subclause describes the conventions used to specify the \Cpp{} standard
 library. \ref{structure} describes the structure of the normative
 \ref{\firstlibchapter} through \ref{\lastlibchapter} and
 \ref{depr}. \ref{conventions} describes other editorial conventions.
@@ -402,7 +402,7 @@ The contents of the summary and the detailed specifications include:
 
 \pnum
 \indextext{requirements}%
-Requirements describe constraints that shall be met by a \Cpp program that extends the standard library.
+Requirements describe constraints that shall be met by a \Cpp{} program that extends the standard library.
 Such extensions are generally one of the following:
 
 \begin{itemize}
@@ -435,7 +435,7 @@ Template argument requirements are sometimes referenced by name.
 See~\ref{type.descriptions}.
 
 \pnum
-In some cases the semantic requirements are presented as \Cpp code.
+In some cases the semantic requirements are presented as \Cpp{} code.
 Such code is intended as a
 specification of equivalence of a construct to another construct, not
 necessarily as the way the construct
@@ -512,7 +512,7 @@ The \defnx{default behavior}{behavior!default}
 describes a function definition provided by the implementation.
 The \defnx{required behavior}{behavior!required}
 describes the semantics of a function definition provided by
-either the implementation or a \Cpp program.
+either the implementation or a \Cpp{} program.
 Where no distinction is explicitly made in the description, the
 behavior described is the required behavior.
 
@@ -542,7 +542,7 @@ of this International Standard and the ISO C standard.
 
 \pnum
 This subclause describes several editorial conventions used to describe the contents
-of the \Cpp standard library.
+of the \Cpp{} standard library.
 These conventions are for describing
 implementation-defined types\iref{type.descriptions},
 and member functions\iref{functions.within.classes}.
@@ -563,7 +563,7 @@ Examples from~\ref{iterator.requirements} include:
 \tcode{ForwardIterator}.}
 These names are used in library Clauses
 to describe the types that
-may be supplied as arguments by a \Cpp program when instantiating template components from
+may be supplied as arguments by a \Cpp{} program when instantiating template components from
 the library.
 
 \pnum
@@ -883,7 +883,7 @@ An implementation may use any technique that provides equivalent observable beha
 \rSec1[requirements]{Library-wide requirements}
 
 \pnum
-This subclause specifies requirements that apply to the entire \Cpp standard library.
+This subclause specifies requirements that apply to the entire \Cpp{} standard library.
 \ref{\firstlibchapter} through \ref{\lastlibchapter} and \ref{depr}
 specify the requirements of individual entities within the library.
 
@@ -893,27 +893,27 @@ programs having only a single thread of execution.
 
 \pnum
 Within this subclause, \ref{organization} describes the library's contents and
-organization, \ref{using} describes how well-formed \Cpp programs gain access to library
+organization, \ref{using} describes how well-formed \Cpp{} programs gain access to library
 entities,
 \ref{utility.requirements} describes constraints on types and functions used with
-the \Cpp standard library,
-\ref{constraints} describes constraints on well-formed \Cpp programs, and
+the \Cpp{} standard library,
+\ref{constraints} describes constraints on well-formed \Cpp{} programs, and
 \ref{conforming} describes constraints on conforming implementations.
 
 \rSec2[organization]{Library contents and organization}
 
 \pnum
-\ref{contents} describes the entities and macros defined in the \Cpp standard library.
+\ref{contents} describes the entities and macros defined in the \Cpp{} standard library.
 \ref{headers} lists the standard library headers and some constraints on those headers.
-\ref{compliance} lists requirements for a freestanding implementation of the \Cpp
+\ref{compliance} lists requirements for a freestanding implementation of the \Cpp{}
 standard library.
 
 \rSec3[contents]{Library contents}
 
 \pnum
-The \Cpp standard library provides definitions
+The \Cpp{} standard library provides definitions
 for the entities and macros described in the synopses
-of the \Cpp standard library headers\iref{headers}.
+of the \Cpp{} standard library headers\iref{headers}.
 
 \pnum
 All library entities except
@@ -924,7 +924,7 @@ are defined within the namespace
 \tcode{std}
 or namespaces nested within namespace
 \tcode{std}.\footnote{The C standard library headers\iref{depr.c.headers} also define
-names within the global namespace, while the \Cpp headers for C library
+names within the global namespace, while the \Cpp{} headers for C library
 facilities\iref{headers} may also define names within the global namespace.}%
 \indextext{namespace}
 It is unspecified whether names declared in a specific namespace are declared
@@ -945,17 +945,17 @@ is meant.
 \rSec3[headers]{Headers}
 
 \pnum
-Each element of the \Cpp standard library is declared or defined (as appropriate) in a
+Each element of the \Cpp{} standard library is declared or defined (as appropriate) in a
 \term{header}.\footnote{A header is not necessarily a source file, nor are the
 sequences delimited by \tcode{<} and \tcode{>} in header names necessarily valid source
 file names\iref{cpp.include}.}
 
 \pnum
-The \Cpp standard library provides the
-\defnx{\Cpp library headers}{header!C++ library},
+The \Cpp{} standard library provides the
+\defnx{\Cpp{} library headers}{header!C++ library},
 shown in Table~\ref{tab:cpp.library.headers}.
 
-\begin{floattable}{\Cpp library headers}{tab:cpp.library.headers}
+\begin{floattable}{\Cpp{} library headers}{tab:cpp.library.headers}
 {llll}
 \topline
 \tcode{<algorithm>} &
@@ -1044,7 +1044,7 @@ shown in Table~\ref{tab:cpp.library.headers}.
 The facilities of the C standard library are provided in the
 \indextext{library!C standard}%
 additional headers shown in Table~\ref{tab:cpp.c.headers}.%
-\footnote{It is intentional that there is no \Cpp header
+\footnote{It is intentional that there is no \Cpp{} header
 for any of these C headers:
 \indextext{\idxhdr{stdatomic.h}}%
 \indextext{\idxhdr{stdnoreturn.h}}%
@@ -1053,7 +1053,7 @@ for any of these C headers:
 \tcode{<stdnoreturn.h>},
 \tcode{<threads.h>}.}
 
-\begin{floattable}{\Cpp headers for C library facilities}{tab:cpp.c.headers}
+\begin{floattable}{\Cpp{} headers for C library facilities}{tab:cpp.c.headers}
 {lllll}
 \topline
 
@@ -1097,7 +1097,7 @@ Except as noted in \ref{library} through \ref{\lastlibchapter}
 and \ref{depr}, the contents of each header \tcode{c\placeholder{name}} is
 the same as that of the corresponding header \tcode{\placeholder{name}.h} as
 specified in the C standard library\iref{intro.refs}.
-In the \Cpp standard library, however, the
+In the \Cpp{} standard library, however, the
 declarations (except for names which are defined as macros in C) are within
 namespace scope\iref{basic.scope.namespace} of the namespace \tcode{std}.
 It is unspecified whether these names (including any overloads added in
@@ -1107,7 +1107,7 @@ and are then injected into namespace \tcode{std} by explicit
 \grammarterm{using-declaration}{s}\iref{namespace.udecl}.
 
 \pnum
-Names which are defined as macros in C shall be defined as macros in the \Cpp
+Names which are defined as macros in C shall be defined as macros in the \Cpp{}
 standard library, even if C grants license for implementation as functions.
 \begin{note} The names defined as macros in C include the following:
 \tcode{assert}, \tcode{offsetof}, \tcode{setjmp}, \tcode{va_arg},
@@ -1115,22 +1115,22 @@ standard library, even if C grants license for implementation as functions.
 
 \pnum
 Names that are defined as functions in C shall be defined as functions in the
-\Cpp standard library.\footnote{This disallows the practice, allowed in C, of
+\Cpp{} standard library.\footnote{This disallows the practice, allowed in C, of
 providing a masking macro in addition to the function prototype. The only way to
-achieve equivalent inline behavior in \Cpp is to provide a definition as an
+achieve equivalent inline behavior in \Cpp{} is to provide a definition as an
 extern inline function.}
 
 \pnum
-Identifiers that are keywords or operators in \Cpp shall not be defined as
-macros in \Cpp standard library headers.\footnote{In particular, including the
+Identifiers that are keywords or operators in \Cpp{} shall not be defined as
+macros in \Cpp{} standard library headers.\footnote{In particular, including the
 standard header \tcode{<iso646.h>} or \tcode{<ciso646>} has no effect.}
 
 \pnum
 \ref{depr.c.headers}, C standard library headers, describes the effects of using
-the \tcode{\placeholder{name}.h} (C header) form in a \Cpp program.\footnote{ The
+the \tcode{\placeholder{name}.h} (C header) form in a \Cpp{} program.\footnote{ The
 \tcode{".h"} headers dump all their names into the global namespace, whereas the
 newer forms keep their names in namespace \tcode{std}. Therefore, the newer
-forms are the preferred forms for all uses except for \Cpp programs which are
+forms are the preferred forms for all uses except for \Cpp{} programs which are
 intended to be strictly compatible with C. }
 
 \pnum
@@ -1143,9 +1143,9 @@ most of them provide the same service
 as the C library function with the unsuffixed name,
 but generally take an additional argument
 whose value is the size of the result array.
-If any \Cpp header is included,
+If any \Cpp{} header is included,
 it is \impldef{whether functions from Annex K of the C standard library
-are declared when \Cpp headers are included}
+are declared when \Cpp{} headers are included}
 whether any of these names
 is declared in the global namespace.
 (None of them is declared in namespace \tcode{std}.)
@@ -1267,7 +1267,7 @@ A freestanding implementation\indextext{implementation!freestanding} has an
 \impldef{headers for freestanding implementation} set of headers. This set shall
 include at least the headers shown in Table~\ref{tab:cpp.headers.freestanding}.
 
-\begin{libsumtab}{\Cpp headers for freestanding implementations}{tab:cpp.headers.freestanding}
+\begin{libsumtab}{\Cpp{} headers for freestanding implementations}{tab:cpp.headers.freestanding}
                          &                           & \tcode{<ciso646>}          \\ \rowsep
 \ref{support.types}      & Types                     & \tcode{<cstddef>}          \\ \rowsep
 \ref{support.limits}     & Implementation properties & \tcode{<cfloat>} \tcode{<limits>} \tcode{<climits>} \\ \rowsep
@@ -1307,15 +1307,15 @@ The other headers listed in this table shall meet the same requirements as for a
 \rSec3[using.overview]{Overview}
 
 \pnum
-This section describes how a \Cpp program gains access to the facilities of the
-\Cpp standard library. \ref{using.headers} describes effects during translation
+This section describes how a \Cpp{} program gains access to the facilities of the
+\Cpp{} standard library. \ref{using.headers} describes effects during translation
 phase 4, while~\ref{using.linkage} describes effects during phase
 8\iref{lex.phases}.
 
 \rSec3[using.headers]{Headers}
 
 \pnum
-The entities in the \Cpp standard library are defined in headers,
+The entities in the \Cpp{} standard library are defined in headers,
 whose contents are made available to a translation unit when it contains the appropriate
 \indextext{unit!translation}%
 \tcode{\#include}
@@ -1351,7 +1351,7 @@ declared in that header. No diagnostic is required.
 \rSec3[using.linkage]{Linkage}
 
 \pnum
-Entities in the \Cpp standard library have external linkage\iref{basic.link}.
+Entities in the \Cpp{} standard library have external linkage\iref{basic.link}.
 Unless otherwise specified, objects and functions have the default
 \tcode{extern "C++"}
 linkage\iref{dcl.link}.
@@ -1377,7 +1377,7 @@ Standard.}
 
 \pnum
 Objects and functions
-defined in the library and required by a \Cpp program are included in
+defined in the library and required by a \Cpp{} program are included in
 the program prior to program startup.
 
 \indextext{startup!program}%
@@ -1391,7 +1391,7 @@ runtime changes\iref{handler.functions}.
 \pnum
 \ref{utility.arg.requirements}
 describes requirements on types and expressions used to instantiate templates
-defined in the \Cpp standard library.
+defined in the \Cpp{} standard library.
 \ref{swappable.requirements} describes the requirements on swappable types and
 swappable expressions.
 \ref{nullablepointer.requirements} describes the requirements on pointer-like
@@ -1403,11 +1403,11 @@ allocators.
 \rSec3[utility.arg.requirements]{Template argument requirements}
 
 \pnum
-The template definitions in the \Cpp standard library
+The template definitions in the \Cpp{} standard library
 refer to various named requirements whose details are set out in
 Tables~\ref{tab:equalitycomparable}--\ref{tab:destructible}.
 In these tables, \tcode{T} is an object or reference type to be
-supplied by a \Cpp program instantiating a template;
+supplied by a \Cpp{} program instantiating a template;
 \tcode{a},
 \tcode{b}, and
 \tcode{c} are values of type (possibly \tcode{const}) \tcode{T};
@@ -2134,8 +2134,8 @@ whether or not \tcode{T} is a complete type:
 \rSec3[constraints.overview]{Overview}
 
 \pnum
-This section describes restrictions on \Cpp programs that use the facilities of
-the \Cpp standard library. The following subclauses specify constraints on the
+This section describes restrictions on \Cpp{} programs that use the facilities of
+the \Cpp{} standard library. The following subclauses specify constraints on the
 program's use of namespaces\iref{namespace.std}, its use of various reserved
 names\iref{reserved.names}, its use of headers\iref{alt.headers}, its use of
 standard library classes as base classes\iref{derived.classes}, its
@@ -2147,7 +2147,7 @@ installation of handler functions during execution\iref{handler.functions}.
 \rSec4[namespace.std]{Namespace \tcode{std}}
 
 \pnum
-The behavior of a \Cpp program is undefined if it adds declarations or definitions to namespace
+The behavior of a \Cpp{} program is undefined if it adds declarations or definitions to namespace
 \tcode{std}
 or to a namespace within namespace
 \tcode{std}
@@ -2163,13 +2163,13 @@ must be prepared to work adequately with any user-supplied specialization
 that meets the minimum requirements of this International Standard.}
 
 \pnum
-The behavior of a \Cpp program is undefined
+The behavior of a \Cpp{} program is undefined
 if it declares an explicit or partial specialization
 of any standard library variable template,
 except where explicitly permitted by the specification of that variable template.
 
 \pnum
-The behavior of a \Cpp program is undefined if it declares
+The behavior of a \Cpp{} program is undefined if it declares
 \begin{itemize}
 \item an explicit specialization of any member function of a standard
 library class template, or
@@ -2193,7 +2193,7 @@ A translation unit shall not declare namespace \tcode{std} to be an inline names
 \rSec4[namespace.posix]{Namespace \tcode{posix}}
 
 \pnum
-The behavior of a \Cpp program is undefined if it adds declarations or definitions to namespace
+The behavior of a \Cpp{} program is undefined if it adds declarations or definitions to namespace
 \tcode{posix}
 or to a namespace within namespace
 \tcode{posix}
@@ -2206,7 +2206,7 @@ ISO/IEC 9945 and other POSIX standards.
 Top level namespaces with a name starting with \tcode{std} and
 followed by a non-empty sequence of digits
 are reserved for future standardization.
-The behavior of a \Cpp program is undefined if
+The behavior of a \Cpp{} program is undefined if
 it adds declarations or definitions to such a namespace.
 \begin{example} The top level namespace \tcode{std2} is reserved
 for use by future revisions of this International Standard. \end{example}
@@ -2215,7 +2215,7 @@ for use by future revisions of this International Standard. \end{example}
 \indextext{name!reserved}
 
 \pnum
-The \Cpp standard library reserves the following kinds of names:
+The \Cpp{} standard library reserves the following kinds of names:
 \begin{itemize}
 \item macros
 \item global names
@@ -2398,7 +2398,7 @@ Literal suffix identifiers\iref{over.literal} that do not start with an undersco
 
 \pnum
 If a file with a name
-equivalent to the derived file name for one of the \Cpp standard library headers
+equivalent to the derived file name for one of the \Cpp{} standard library headers
 is not provided as part of the implementation, and a file with that name
 is placed in any of the standard places for a source file to be included\iref{cpp.include},
 the behavior is undefined.%
@@ -2410,7 +2410,7 @@ the behavior is undefined.%
 \pnum
 Virtual member function signatures defined
 \indextext{function!virtual member}%
-for a base class in the \Cpp standard
+for a base class in the \Cpp{} standard
 \indextext{class!base}%
 \indextext{library!C++ standard}%
 library may be overridden in a derived class defined in the program\iref{class.virtual}.
@@ -2421,14 +2421,14 @@ library may be overridden in a derived class defined in the program\iref{class.v
 \indextext{definition!alternate}%
 \ref{\firstlibchapter} through \ref{\lastlibchapter} and \ref{depr}
 describe the behavior of numerous functions defined by
-the \Cpp standard library.
+the \Cpp{} standard library.
 Under some circumstances,
 \indextext{library!C++ standard}%
 however, certain of these function descriptions also apply to replacement functions defined
 in the program\iref{definitions}.
 
 \pnum
-A \Cpp program may provide the definition for any of the following
+A \Cpp{} program may provide the definition for any of the following
 dynamic memory allocation function signatures declared in header
 \tcode{<new>}~(\ref{basic.stc.dynamic}, \ref{support.dynamic}):
 
@@ -2481,7 +2481,7 @@ No diagnostic is required.
 \rSec3[handler.functions]{Handler functions}
 
 \pnum
-The \Cpp standard library provides a default version of the following handler
+The \Cpp{} standard library provides a default version of the following handler
 function\iref{language.support}:
 
 \begin{itemize}
@@ -2491,7 +2491,7 @@ function\iref{language.support}:
 \end{itemize}
 
 \pnum
-A \Cpp program may install different handler functions during execution, by
+A \Cpp{} program may install different handler functions during execution, by
 supplying a pointer to a function defined in the program or the library
 as an argument to (respectively):
 \begin{itemize}
@@ -2502,7 +2502,7 @@ See also subclauses~\ref{alloc.errors}, Storage allocation errors, and~\ref{supp
 Exception handling.
 
 \pnum
-A \Cpp program can get a pointer to the current handler function by calling the following
+A \Cpp{} program can get a pointer to the current handler function by calling the following
 functions:
 
 \begin{itemize}
@@ -2523,8 +2523,8 @@ any of the \tcode{set_*} functions shall synchronize with subsequent calls to th
 
 \pnum
 In certain cases (replacement functions, handler functions, operations on types used to
-instantiate standard library template components), the \Cpp standard library depends on
-components supplied by a \Cpp program.
+instantiate standard library template components), the \Cpp{} standard library depends on
+components supplied by a \Cpp{} program.
 If these components do not meet their requirements, this International Standard places no requirements
 on the implementation.
 
@@ -2569,7 +2569,7 @@ allowed for that component.
 \indextext{argument}%
 Each of the following applies to all arguments
 \indextext{argument}%
-to functions defined in the \Cpp standard library,%
+to functions defined in the \Cpp{} standard library,%
 \indextext{library!C++ standard}
 unless explicitly stated otherwise.
 
@@ -2637,7 +2637,7 @@ paragraph specifies throwing an exception when the precondition is violated.
 \rSec3[conforming.overview]{Overview}
 
 \pnum
-This section describes the constraints upon, and latitude of, implementations of the \Cpp standard library.
+This section describes the constraints upon, and latitude of, implementations of the \Cpp{} standard library.
 
 \pnum
 An implementation's use of headers is discussed in~\ref{res.on.headers}, its use
@@ -2650,9 +2650,9 @@ exceptions in~\ref{res.on.exception.handling}.
 \rSec3[res.on.headers]{Headers}
 
 \pnum
-A \Cpp header may include other \Cpp headers.
-A \Cpp header shall provide the declarations and definitions that appear in its
-synopsis. A \Cpp header shown in its synopsis as including other \Cpp headers
+A \Cpp{} header may include other \Cpp{} headers.
+A \Cpp{} header shall provide the declarations and definitions that appear in its
+synopsis. A \Cpp{} header shown in its synopsis as including other \Cpp{} headers
 shall provide the declarations and definitions that appear in the synopses of
 those other headers.
 
@@ -2663,7 +2663,7 @@ included after any other header that also defines it\iref{basic.def.odr}.
 
 \pnum
 The C standard library headers\iref{depr.c.headers}
-shall include only their corresponding \Cpp standard library header,
+shall include only their corresponding \Cpp{} standard library header,
 as described in~\ref{headers}.
 
 \rSec3[res.on.macro.definitions]{Restrictions on macro definitions}
@@ -2689,17 +2689,17 @@ explicitly stated otherwise.
 \pnum
 It is unspecified whether any
 non-member
-functions in the \Cpp standard library are defined as
+functions in the \Cpp{} standard library are defined as
 \tcode{inline}\iref{dcl.inline}.
 
 \pnum
 A call to a non-member function signature
 described in \ref{\firstlibchapter} through \ref{\lastlibchapter} and
 \ref{depr} shall behave as if the implementation declared no additional
-non-member function signatures.\footnote{A valid \Cpp program always
+non-member function signatures.\footnote{A valid \Cpp{} program always
 calls the expected library non-member function. An implementation may
 also define additional non-member functions that would otherwise not
-be called by a valid \Cpp program.}
+be called by a valid \Cpp{} program.}
 
 \pnum
 An implementation shall not declare a non-member function signature
@@ -2729,11 +2729,11 @@ return *this;
 \rSec3[member.functions]{Member functions}
 
 \pnum
-It is unspecified whether any member functions in the \Cpp standard library are defined as
+It is unspecified whether any member functions in the \Cpp{} standard library are defined as
 \tcode{inline}\iref{dcl.inline}.
 
 \pnum
-For a non-virtual member function described in the \Cpp standard library,
+For a non-virtual member function described in the \Cpp{} standard library,
 an implementation may declare a different set of member function signatures,
 provided that any call to the member function that would select
 an overload from the set of declarations described in this International Standard
@@ -2780,7 +2780,7 @@ original order).
 
 \pnum
 Except where explicitly specified in this International Standard, it is \impldef{which functions in
-the \Cpp standard library may be recursively reentered} which functions in the \Cpp standard
+the \Cpp{} standard library may be recursively reentered} which functions in the \Cpp{} standard
 library may be recursively reentered.
 
 \rSec3[res.on.data.races]{Data race avoidance}
@@ -2792,13 +2792,13 @@ Every standard library function shall meet each requirement unless otherwise spe
 Implementations may prevent data races in cases other than those specified below.
 
 \pnum
-A \Cpp standard library function shall not directly or indirectly access
+A \Cpp{} standard library function shall not directly or indirectly access
 objects\iref{intro.multithread} accessible by threads other than the current thread
 unless the objects are accessed directly or indirectly via the function's arguments,
 including \tcode{this}.
 
 \pnum
-A \Cpp standard library function shall not directly or indirectly modify
+A \Cpp{} standard library function shall not directly or indirectly modify
 objects\iref{intro.multithread} accessible by threads other than the current thread
 unless the objects are accessed directly or indirectly via the function's non-const
 arguments, including \tcode{this}.
@@ -2809,7 +2809,7 @@ internal purposes without synchronization because it could cause a data race eve
 programs that do not explicitly share objects between threads. \end{note}
 
 \pnum
-A \Cpp standard library function shall not access objects indirectly accessible via its
+A \Cpp{} standard library function shall not access objects indirectly accessible via its
 arguments or via elements of its container arguments except by invoking functions
 required by its specification on those container elements.
 
@@ -2824,7 +2824,7 @@ Implementations may share their own internal objects between threads if the obje
 not visible to users and are protected against data races.
 
 \pnum
-Unless otherwise specified, \Cpp standard library functions shall perform all operations
+Unless otherwise specified, \Cpp{} standard library functions shall perform all operations
 solely within the current thread if those operations have effects that are
 visible\iref{intro.multithread} to users.
 
@@ -2840,7 +2840,7 @@ side effects. \end{note}
 It is unspecified whether any function signature or class described in
 \ref{\firstlibchapter} through \ref{\lastlibchapter} and \ref{depr} is a
 \tcode{friend}
-of another class in the \Cpp standard library.
+of another class in the \Cpp{} standard library.
 \indextext{specifier!\idxcode{friend}}
 
 \rSec3[derivation]{Derived classes}
@@ -2848,13 +2848,13 @@ of another class in the \Cpp standard library.
 \pnum
 \indextext{class!derived}%
 \indextext{class!base}%
-An implementation may derive any class in the \Cpp standard library from a class with a
+An implementation may derive any class in the \Cpp{} standard library from a class with a
 name reserved to the implementation.
 
 \pnum
-Certain classes defined in the \Cpp standard library are required to be derived from
+Certain classes defined in the \Cpp{} standard library are required to be derived from
 other classes
-in the \Cpp standard library.
+in the \Cpp{} standard library.
 \indextext{library!C++ standard}%
 An implementation may derive such a class directly from the required base or indirectly
 through a hierarchy of base classes with names reserved to the implementation.
@@ -2880,7 +2880,7 @@ described as synonyms for basic integral types, such as
 \end{itemize}
 
 \pnum
-All types specified in the \Cpp standard library shall be non-\tcode{final} types
+All types specified in the \Cpp{} standard library shall be non-\tcode{final} types
 unless otherwise specified.
 
 \rSec3[res.on.exception.handling]{Restrictions on exception handling}%
@@ -2888,7 +2888,7 @@ unless otherwise specified.
 \indextext{exception handling!handler}
 
 \pnum
-Any of the functions defined in the \Cpp standard library
+Any of the functions defined in the \Cpp{} standard library
 \indextext{library!C++ standard}%
 can report a failure by throwing an exception of a type described in its
 \throws
@@ -2914,14 +2914,14 @@ and
 \tcode{bsearch()}\iref{alg.c.library} meet this condition.}
 
 \pnum
-Destructor operations defined in the \Cpp standard library
+Destructor operations defined in the \Cpp{} standard library
 shall not throw exceptions.
-Every destructor in the \Cpp standard library shall behave as if it had a
+Every destructor in the \Cpp{} standard library shall behave as if it had a
 non-throwing exception specification.
 
 \pnum
 Functions defined in the
-\Cpp standard library
+\Cpp{} standard library
 \indextext{specifications!C++}%
 that do not have a
 \throws
@@ -2962,7 +2962,7 @@ pointer location. \end{note}
 \rSec3[value.error.codes]{Value of error codes}
 
 \pnum
-Certain functions in the \Cpp standard library report errors via a
+Certain functions in the \Cpp{} standard library report errors via a
 \tcode{std::error_code}\iref{syserr.errcode.overview} object. That object's
 \tcode{category()} member shall return \tcode{std::system_category()} for
 errors originating from the operating system, or a reference to an
@@ -2980,7 +2980,7 @@ may provide enums for the associated values. \end{example}
 \rSec3[lib.types.movedfrom]{Moved-from state of library types}
 
 \pnum
-Objects of types defined in the \Cpp standard library may be moved
+Objects of types defined in the \Cpp{} standard library may be moved
 from\iref{class.copy}. Move operations may be explicitly specified or
 implicitly generated. Unless otherwise specified, such moved-from objects shall
 be placed in a valid but unspecified state.

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -490,18 +490,18 @@ preconditions, there will be no \requires paragraph.}
 \end{itemize}
 
 \pnum
-Whenever the \effects element specifies that the semantics of some function
+Whenever the \Fundescx{Effects} element specifies that the semantics of some function
 \tcode{F} are \techterm{Equivalent to} some code sequence, then the various elements are
-interpreted as follows. If \tcode{F}'s semantics specifies a \requires element, then
+interpreted as follows. If \tcode{F}'s semantics specifies a \Fundescx{Requires} element, then
 that requirement is logically imposed prior to the \techterm{equivalent-to} semantics.
-Next, the semantics of the code sequence are determined by the \requires, \effects,
-\sync, \postconditions, \returns, \throws, \complexity, \remarks, and \errors
+Next, the semantics of the code sequence are determined by the \Fundescx{Requires}, \Fundescx{Effects},
+\Fundescx{Synchronization}, \Fundescx{Postconditions}, \Fundescx{Returns}, \Fundescx{Throws}, \Fundescx{Complexity}, \Fundescx{Remarks}, and \Fundescx{Error conditions}
 specified for the function invocations contained in the code sequence. The value
-returned from \tcode{F} is specified by \tcode{F}'s \returns element, or if \tcode{F}
-has no \returns element, a non-\tcode{void} return from \tcode{F} is specified by the
+returned from \tcode{F} is specified by \tcode{F}'s \Fundescx{Returns} element, or if \tcode{F}
+has no \Fundescx{Returns} element, a non-\tcode{void} return from \tcode{F} is specified by the
 \tcode{return} statements in the code sequence.
-If \tcode{F}'s semantics contains a \throws,
-\postconditions, or \complexity element, then that supersedes any occurrences of that
+If \tcode{F}'s semantics contains a \Fundescx{Throws},
+\Fundescx{Postconditions}, or \Fundescx{Complexity} element, then that supersedes any occurrences of that
 element in the code sequence.
 
 \pnum
@@ -534,7 +534,7 @@ constants\iref{syserr}.
 \rSec3[structure.see.also]{C library}
 
 \pnum
-Paragraphs labeled ``\xref'' contain cross-references to the relevant portions
+Paragraphs labeled ``\textsc{See also}'' contain cross-references to the relevant portions
 of this International Standard and the ISO C standard.
 
 \rSec2[conventions]{Other conventions}

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -774,7 +774,7 @@ A character sequence can be designated by a pointer value
 A
 \indextext{NTBS}%
 \defnx{null-terminated byte string}{string!null-terminated byte},
-or \ntbs,
+or \ntbs{},
 is a character sequence whose highest-addressed element
 with defined content has the value zero
 (the
@@ -792,17 +792,17 @@ a length value, maintained separately from the character sequence.}
 
 \pnum
 The
-\term{length} of an \ntbs
+\term{length} of an \ntbs{}
 is the number of elements that
 precede the terminating null character.
 \indextext{NTBS}%
 An
-\term{empty} \ntbs
+\term{empty} \ntbs{}
 has a length of zero.
 
 \pnum
 The
-\term{value} of an \ntbs
+\term{value} of an \ntbs{}
 is the sequence of values of the
 elements up to and including the terminating null character.
 \indextext{NTBS}%
@@ -811,10 +811,10 @@ elements up to and including the terminating null character.
 A
 \indextext{NTBS}%
 \defnx{static}{NTBS!static} \ntbs
-is an \ntbs with
+is an \ntbs{} with
 static storage duration.\footnote{A string literal, such as
 \tcode{"abc"},
-is a static \ntbs.}
+is a static \ntbs{}.}
 
 \rSec5[multibyte.strings]{Multibyte strings}
 
@@ -822,17 +822,18 @@ is a static \ntbs.}
 \indextext{NTBS}%
 \indextext{NTMBS}%
 A \defnx{null-terminated multibyte string}{string!null-terminated multibyte},
-or \ntmbs, is an \ntbs that constitutes a
+or \ntmbs{},
+is an \ntbs{} that constitutes a
 sequence of valid multibyte characters, beginning and ending in the initial
-shift state.\footnote{An \ntbs that contains characters only from the
-basic execution character set is also an \ntmbs.
+shift state.\footnote{An \ntbs{} that contains characters only from the
+basic execution character set is also an \ntmbs{}.
 Each multibyte character then
 consists of a single byte.}
 
 \pnum
 A
 \defnx{static}{NTMBS!static} \ntmbs
-is an \ntmbs with static storage duration.
+is an \ntmbs{} with static storage duration.
 \indextext{NTMBS}%
 
 \rSec3[functions.within.classes]{Functions within classes}

--- a/source/limits.tex
+++ b/source/limits.tex
@@ -2,7 +2,7 @@
 \infannex{implimits}{Implementation quantities}
 
 \pnum
-Because computers are finite, \Cpp  implementations are inevitably
+Because computers are finite, \Cpp{}  implementations are inevitably
 limited in the size of the programs they can successfully process.
 Every implementation shall
 document those limitations where known.

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -4,7 +4,7 @@
 \rSec1[localization.general]{General}
 
 \pnum
-This Clause describes components that \Cpp programs may use to
+This Clause describes components that \Cpp{} programs may use to
 encapsulate (and therefore be more portable when confronting)
 cultural differences.
 The locale facility includes internationalization
@@ -219,7 +219,7 @@ is not present in a
 locale,
 it throws the standard exception
 \tcode{bad_cast}.
-A \Cpp program can check if a locale implements a particular
+A \Cpp{} program can check if a locale implements a particular
 facet with the
 function template
 \tcode{has_facet<Facet>()}.
@@ -248,7 +248,7 @@ functions such as
 and
 \tcode{isspace()},
 so that given a locale
-object \tcode{loc} a \Cpp program can call
+object \tcode{loc} a \Cpp{} program can call
 \tcode{isspace(c, loc)}.
 (This eases upgrading existing extractors\iref{istream.formatted}.)
 \end{itemize}
@@ -5041,9 +5041,9 @@ namespace std {
 \rSec2[facets.examples]{Program-defined facets}
 
 \pnum
-A \Cpp program may define facets to be added to a locale and used identically as
+A \Cpp{} program may define facets to be added to a locale and used identically as
 the built-in facets.
-To create a new facet interface, \Cpp programs simply derive from
+To create a new facet interface, \Cpp{} programs simply derive from
 \tcode{locale::facet}
 a class containing a static member:
 \tcode{static locale::id id}.
@@ -5169,7 +5169,7 @@ std::istream& operator>>(std::istream& s, Date& d) {
 A locale object may be extended with a new facet simply by constructing
 it with an instance of a class derived from
 \tcode{locale::facet}.
-The only member a \Cpp program must define is the static member
+The only member a \Cpp{} program must define is the static member
 \tcode{id},
 which identifies your class interface as a new facet.
 

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -189,10 +189,10 @@
 %%--------------------------------------------------
 %% Macros for funky text
 \newcommand{\Cpp}{\texorpdfstring{C\kern-0.05em\protect\raisebox{.35ex}{\textsmaller[2]{+\kern-0.05em+}}}{C++}}
-\newcommand{\CppIII}{\Cpp{} 2003}
-\newcommand{\CppXI}{\Cpp{} 2011}
-\newcommand{\CppXIV}{\Cpp{} 2014}
-\newcommand{\CppXVII}{\Cpp{} 2017}
+\newcommand{\CppIII}{\Cpp~2003}
+\newcommand{\CppXI}{\Cpp~2011}
+\newcommand{\CppXIV}{\Cpp~2014}
+\newcommand{\CppXVII}{\Cpp~2017}
 \newcommand{\opt}[1]{#1{\ensuremath{_\mathit{opt}}}}
 \newcommand{\dcr}{-{-}}
 \newcommand{\bigoh}[1]{\ensuremath{\mathscr{O}(#1)}}

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -193,7 +193,7 @@
 \newcommand{\CppXI}{\Cpp{} 2011}
 \newcommand{\CppXIV}{\Cpp{} 2014}
 \newcommand{\CppXVII}{\Cpp{} 2017}
-\newcommand{\opt}{{\ensuremath{_\mathit{opt}}}\xspace}
+\newcommand{\opt}{{\ensuremath{_\mathit{opt}}}}
 \newcommand{\dcr}{-{-}}
 \newcommand{\bigoh}[1]{\ensuremath{\mathscr{O}(#1)}}
 

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -135,7 +135,7 @@
 \let\omname\mname%
 \let\mname\idxmname%
 \let\oCpp\Cpp%
-\let\Cpp\idxCpp
+\let\Cpp\idxCpp%
 \let\oBreakableUnderscore\BreakableUnderscore%  See the "underscore" package.
 \let\BreakableUnderscore\textunderscore%
 \edef\x{#1}%
@@ -173,11 +173,11 @@
 
 % Code and definitions embedded in text.
 \newcommand{\tcode}[1]{\CodeStylex{#1}}
-\newcommand{\techterm}[1]{\textit{#1}\xspace}
-\newcommand{\defnx}[2]{\indexdefn{#2}\textit{#1}\xspace}
+\newcommand{\techterm}[1]{\textit{#1}}
+\newcommand{\defnx}[2]{\indexdefn{#2}\textit{#1}}
 \newcommand{\defn}[1]{\defnx{#1}{#1}}
-\newcommand{\term}[1]{\textit{#1}\xspace}
-\newcommand{\grammarterm}[1]{\textit{#1}\xspace}
+\newcommand{\term}[1]{\textit{#1}}
+\newcommand{\grammarterm}[1]{\textit{#1}}
 \newcommand{\grammartermnc}[1]{\textit{#1}\nocorr}
 \newcommand{\placeholder}[1]{\textit{#1}}
 \newcommand{\placeholdernc}[1]{\textit{#1\nocorr}}
@@ -188,11 +188,11 @@
 
 %%--------------------------------------------------
 %% Macros for funky text
-\newcommand{\Cpp}{\texorpdfstring{C\kern-0.05em\protect\raisebox{.35ex}{\textsmaller[2]{+\kern-0.05em+}}}{C++}\xspace}
-\newcommand{\CppIII}{\Cpp 2003\xspace}
-\newcommand{\CppXI}{\Cpp 2011\xspace}
-\newcommand{\CppXIV}{\Cpp 2014\xspace}
-\newcommand{\CppXVII}{\Cpp 2017\xspace}
+\newcommand{\Cpp}{\texorpdfstring{C\kern-0.05em\protect\raisebox{.35ex}{\textsmaller[2]{+\kern-0.05em+}}}{C++}}
+\newcommand{\CppIII}{\Cpp{} 2003}
+\newcommand{\CppXI}{\Cpp{} 2011}
+\newcommand{\CppXIV}{\Cpp{} 2014}
+\newcommand{\CppXVII}{\Cpp{} 2017}
 \newcommand{\opt}{{\ensuremath{_\mathit{opt}}}\xspace}
 \newcommand{\dcr}{-{-}}
 \newcommand{\bigoh}[1]{\ensuremath{\mathscr{O}(#1)}}
@@ -217,12 +217,12 @@
 %% Notes and examples
 \newcommand{\noteintro}[1]{[\,\textit{#1:}\space}
 \newcommand{\noteoutro}[1]{\textit{\,---\,end #1}\,]}
-\newenvironment{note}[1][Note]{\noteintro{#1}}{\noteoutro{note}\xspace}
-\newenvironment{example}[1][Example]{\noteintro{#1}}{\noteoutro{example}\xspace}
+\newenvironment{note}[1][Note]{\noteintro{#1}}{\noteoutro{note}\space}
+\newenvironment{example}[1][Example]{\noteintro{#1}}{\noteoutro{example}\space}
 
 %% Library function descriptions
-\newcommand{\Fundescx}[1]{\textit{#1}\xspace}
-\newcommand{\Fundesc}[1]{\Fundescx{#1:}}
+\newcommand{\Fundescx}[1]{\textit{#1}}
+\newcommand{\Fundesc}[1]{\Fundescx{#1:}\xspace}
 \newcommand{\required}{\Fundesc{Required behavior}}
 \newcommand{\requires}{\Fundesc{Requires}}
 \newcommand{\effects}{\Fundesc{Effects}}
@@ -301,14 +301,14 @@
 \newcommand{\commentellip}{\tcode{/* ...\ */}}
 
 %% Ranges
-\newcommand{\Range}[4]{\tcode{#1#3,\penalty2000{} #4#2}\xspace}
+\newcommand{\Range}[4]{\tcode{#1#3,\penalty2000{} #4#2}}
 \newcommand{\crange}[2]{\Range{[}{]}{#1}{#2}}
 \newcommand{\brange}[2]{\Range{(}{]}{#1}{#2}}
 \newcommand{\orange}[2]{\Range{(}{)}{#1}{#2}}
 \newcommand{\range}[2]{\Range{[}{)}{#1}{#2}}
 
 %% Change descriptions
-\newcommand{\diffdef}[1]{\hfill\break\textbf{#1:}\xspace}
+\newcommand{\diffdef}[1]{\hfill\break\textbf{#1:}\space}
 \newcommand{\change}{\diffdef{Change}}
 \newcommand{\rationale}{\diffdef{Rationale}}
 \newcommand{\effect}{\diffdef{Effect on original feature}}
@@ -317,13 +317,13 @@
 
 %% Miscellaneous
 \newcommand{\uniquens}{\placeholdernc{unique}}
-\newcommand{\stage}[1]{\item{\textbf{Stage #1:}}\xspace}
-\newcommand{\doccite}[1]{\textit{#1}\xspace}
+\newcommand{\stage}[1]{\item{\textbf{Stage #1:}}}
+\newcommand{\doccite}[1]{\textit{#1}}
 \newcommand{\cvqual}[1]{\textit{#1}}
 \newcommand{\cv}{\cvqual{cv}}
-\renewcommand{\emph}[1]{\textit{#1}\xspace}
-\newcommand{\numconst}[1]{\textsl{#1}\xspace}
-\newcommand{\logop}[1]{{\footnotesize #1}\xspace}
+\renewcommand{\emph}[1]{\textit{#1}}
+\newcommand{\numconst}[1]{\textsl{#1}}
+\newcommand{\logop}[1]{{\footnotesize #1}}
 
 %%--------------------------------------------------
 %% Environments for code listings.
@@ -411,7 +411,7 @@
 \newenvironment{bnfbase}
  {
  \newcommand{\nontermdef}[1]{{\BnfNontermshape##1\itcorr}\indexgrammar{\idxgram{##1}}\textnormal{:}}
- \newcommand{\terminal}[1]{{\BnfTermshape ##1}\xspace}
+ \newcommand{\terminal}[1]{{\BnfTermshape ##1}}
  \newcommand{\descr}[1]{\textnormal{##1}}
  \newcommand{\bnfindentfirst}{\BnfIndent}
  \newcommand{\bnfindentinc}{\BnfInc}

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -251,12 +251,13 @@
 \newcommand{\iref}[1]{\nolinebreak[3] (\ref{#1})}
 
 %% NTBS, etc.
-\newcommand{\NTS}[1]{\textsc{#1}\xspace}
+\newcommand{\NTS}[1]{\textsc{#1}}
 \newcommand{\ntbs}{\NTS{ntbs}}
 \newcommand{\ntmbs}{\NTS{ntmbs}}
-\newcommand{\ntwcs}{\NTS{ntwcs}}
-\newcommand{\ntcxvis}{\NTS{ntc16s}}
-\newcommand{\ntcxxxiis}{\NTS{ntc32s}}
+% The following are currently unused:
+% \newcommand{\ntwcs}{\NTS{ntwcs}}
+% \newcommand{\ntcxvis}{\NTS{ntc16s}}
+% \newcommand{\ntcxxxiis}{\NTS{ntc32s}}
 
 %% Code annotations
 \newcommand{\EXPO}[1]{\textit{#1}}

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -222,7 +222,7 @@
 
 %% Library function descriptions
 \newcommand{\Fundescx}[1]{\textit{#1}}
-\newcommand{\Fundesc}[1]{\Fundescx{#1:}\xspace}
+\newcommand{\Fundesc}[1]{\Fundescx{#1:}\space}
 \newcommand{\required}{\Fundesc{Required behavior}}
 \newcommand{\requires}{\Fundesc{Requires}}
 \newcommand{\effects}{\Fundesc{Effects}}
@@ -245,7 +245,7 @@
 \newcommand{\templalias}{\Fundesc{Alias template}}
 
 %% Cross reference
-\newcommand{\xref}{\textsc{See also:}\xspace}
+\newcommand{\xref}{\textsc{See also:}\space}
 
 %% Inline parenthesized reference
 \newcommand{\iref}[1]{\nolinebreak[3] (\ref{#1})}

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -193,7 +193,7 @@
 \newcommand{\CppXI}{\Cpp{} 2011}
 \newcommand{\CppXIV}{\Cpp{} 2014}
 \newcommand{\CppXVII}{\Cpp{} 2017}
-\newcommand{\opt}{{\ensuremath{_\mathit{opt}}}}
+\newcommand{\opt}[1]{#1{\ensuremath{_\mathit{opt}}}}
 \newcommand{\dcr}{-{-}}
 \newcommand{\bigoh}[1]{\ensuremath{\mathscr{O}(#1)}}
 

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -1457,7 +1457,7 @@ Further:
 
 \begin{enumeratea}
  \item
-   the operator \rightshift\xspace
+   the operator \rightshift{}
    denotes a bitwise right shift
    with zero-valued bits appearing in the high bits of the result,
  and

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -4,7 +4,7 @@
 \rSec1[numerics.general]{General}
 
 \pnum
-This Clause describes components that \Cpp programs may use to perform
+This Clause describes components that \Cpp{} programs may use to perform
 seminumerical operations.
 
 \pnum
@@ -59,7 +59,7 @@ The
 and
 \tcode{valarray}
 components are parameterized by the type of information they contain and manipulate.
-A \Cpp program shall instantiate these components only with a type
+A \Cpp{} program shall instantiate these components only with a type
 \tcode{T}
 that satisfies the
 following requirements:\footnote{In other words, value types.
@@ -7776,7 +7776,7 @@ class represents a BLAS-like slice from an array.
 Such a slice is specified by a starting index, a length, and a
 stride.\footnote{BLAS stands for
 \textit{Basic Linear Algebra Subprograms.}
-\Cpp programs may instantiate this class.
+\Cpp{} programs may instantiate this class.
 See, for example,
 Dongarra, Du Croz, Duff, and Hammerling:
 \textit{A set of Level 3 Basic Linear Algebra Subprograms};

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -647,7 +647,7 @@ contexts.
 In a function call\iref{expr.call}
 
 \begin{ncsimplebnf}
-postfix-expression \terminal{(} expression-list\opt{} \terminal{)}
+postfix-expression \terminal{(} \opt{expression-list} \terminal{)}
 \end{ncsimplebnf}
 
 if the \grammarterm{postfix-expression} denotes a set of overloaded functions and/or
@@ -816,7 +816,7 @@ In addition, for each non-explicit conversion function declared in \tcode{T} of 
 form
 
 \begin{ncsimplebnf}
-\terminal{operator} conversion-type-id \terminal{(\,)} cv-qualifier ref-qualifier\opt{} noexcept-specifier\opt{} attribute-specifier-seq\opt{} \terminal{;}
+\terminal{operator} conversion-type-id \terminal{(\,)} cv-qualifier \opt{ref-qualifier} \opt{noexcept-specifier} \opt{attribute-specifier-seq} \terminal{;}
 \end{ncsimplebnf}
 
 where
@@ -3248,7 +3248,7 @@ It can have default arguments.
 It implements the function call syntax
 
 \begin{ncsimplebnf}
-postfix-expression \terminal{(} expression-list\opt{} \terminal{)}
+postfix-expression \terminal{(} \opt{expression-list} \terminal{)}
 \end{ncsimplebnf}
 
 where the
@@ -3321,7 +3321,7 @@ It implements the class member access syntax that
 uses \tcode{->}.
 
 \begin{ncsimplebnf}
-postfix-expression \terminal{->} \terminal{template\opt{}} id-expression\\
+postfix-expression \terminal{->} \terminal{\opt{template}} id-expression\\
 postfix-expression \terminal{->} pseudo-destructor-name
 \end{ncsimplebnf}
 

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -816,7 +816,7 @@ In addition, for each non-explicit conversion function declared in \tcode{T} of 
 form
 
 \begin{ncsimplebnf}
-\terminal{operator} conversion-type-id \terminal{(\,)} cv-qualifier ref-qualifier\opt noexcept-specifier\opt attribute-specifier-seq\opt{} \terminal{;}
+\terminal{operator} conversion-type-id \terminal{(\,)} cv-qualifier ref-qualifier\opt{} noexcept-specifier\opt{} attribute-specifier-seq\opt{} \terminal{;}
 \end{ncsimplebnf}
 
 where
@@ -3321,7 +3321,7 @@ It implements the class member access syntax that
 uses \tcode{->}.
 
 \begin{ncsimplebnf}
-postfix-expression \terminal{->} \terminal{template\opt} id-expression\\
+postfix-expression \terminal{->} \terminal{template\opt{}} id-expression\\
 postfix-expression \terminal{->} pseudo-destructor-name
 \end{ncsimplebnf}
 

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -30,7 +30,7 @@ within what would otherwise be an invocation of a function-like macro.
 
 \begin{bnf}
 \nontermdef{preprocessing-file}\br
-    group\opt
+    group\opt{}
 \end{bnf}
 
 \begin{bnf}
@@ -56,21 +56,21 @@ within what would otherwise be an invocation of a function-like macro.
 \>\terminal{\# define}\>\>identifier lparen identifier-list \terminal{, ... )} replacement-list new-line\br
 \>\terminal{\# undef}\>\>identifier new-line\br
 \>\terminal{\# line}\>\>pp-tokens new-line\br
-\>\terminal{\# error}\>\>pp-tokens\opt new-line\br
-\>\terminal{\# pragma}\>\>pp-tokens\opt new-line\br
+\>\terminal{\# error}\>\>pp-tokens\opt{} new-line\br
+\>\terminal{\# pragma}\>\>pp-tokens\opt{} new-line\br
 \>\terminal{\# }new-line
 \end{bnftab}
 
 \begin{bnf}
 \nontermdef{if-section}\br
-    if-group elif-groups\opt else-group\opt endif-line
+    if-group elif-groups\opt{} else-group\opt{} endif-line
 \end{bnf}
 
 \begin{bnftab}
 \nontermdef{if-group}\br
-\>\terminal{\# if}\>\>constant-expression new-line group\opt\br
-\>\terminal{\# ifdef}\>\>identifier new-line group\opt\br
-\>\terminal{\# ifndef}\>\>identifier new-line group\opt
+\>\terminal{\# if}\>\>constant-expression new-line group\opt{}\br
+\>\terminal{\# ifdef}\>\>identifier new-line group\opt{}\br
+\>\terminal{\# ifndef}\>\>identifier new-line group\opt{}
 \end{bnftab}
 
 \begin{bnf}
@@ -81,12 +81,12 @@ within what would otherwise be an invocation of a function-like macro.
 
 \begin{bnftab}
 \nontermdef{elif-group}\br
-\>\terminal{\# elif}\>\>constant-expression new-line group\opt
+\>\terminal{\# elif}\>\>constant-expression new-line group\opt{}
 \end{bnftab}
 
 \begin{bnftab}
 \nontermdef{else-group}\br
-\>\terminal{\# else}\>\>new-line group\opt
+\>\terminal{\# else}\>\>new-line group\opt{}
 \end{bnftab}
 
 \begin{bnftab}
@@ -96,7 +96,7 @@ within what would otherwise be an invocation of a function-like macro.
 
 \begin{bnf}
 \nontermdef{text-line}\br
-    pp-tokens\opt new-line
+    pp-tokens\opt{} new-line
 \end{bnf}
 
 \begin{bnf}
@@ -117,7 +117,7 @@ within what would otherwise be an invocation of a function-like macro.
 
 \begin{bnf}
 \nontermdef{replacement-list}\br
-    pp-tokens\opt
+    pp-tokens\opt{}
 \end{bnf}
 
 \begin{bnf}
@@ -274,9 +274,9 @@ Preprocessing directives of the forms
 
 \begin{ncbnftab}
 \indextext{\idxcode{\#if}}%
-\terminal{\# if}\>\>constant-expression new-line group\opt\br
+\terminal{\# if}\>\>constant-expression new-line group\opt{}\br
 \indextext{\idxcode{\#elif}}%
-\terminal{\# elif}\>\>constant-expression new-line group\opt
+\terminal{\# elif}\>\>constant-expression new-line group\opt{}
 \end{ncbnftab}
 
 check whether the controlling constant expression evaluates to nonzero.
@@ -369,9 +369,9 @@ is subjected to integral promotion before processing continues.
 Preprocessing directives of the forms
 
 \begin{ncbnftab}
-\terminal{\# ifdef}\>\>identifier new-line group\opt\br
+\terminal{\# ifdef}\>\>identifier new-line group\opt{}\br
 \indextext{\idxcode{\#ifdef}}%
-\terminal{\# ifndef}\>\>identifier new-line group\opt
+\terminal{\# ifndef}\>\>identifier new-line group\opt{}
 \indextext{\idxcode{\#ifndef}}%
 \end{ncbnftab}
 
@@ -1246,7 +1246,7 @@ otherwise, the result is processed as appropriate.
 A preprocessing directive of the form
 
 \begin{ncsimplebnf}
-\terminal{\# error} pp-tokens\opt new-line
+\terminal{\# error} pp-tokens\opt{} new-line
 \end{ncsimplebnf}
 
 causes the implementation to produce
@@ -1261,7 +1261,7 @@ and renders the program ill-formed.
 A preprocessing directive of the form
 
 \begin{ncsimplebnf}
-\terminal{\# pragma} pp-tokens\opt new-line
+\terminal{\# pragma} pp-tokens\opt{} new-line
 \end{ncsimplebnf}
 
 causes the implementation to behave

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -30,7 +30,7 @@ within what would otherwise be an invocation of a function-like macro.
 
 \begin{bnf}
 \nontermdef{preprocessing-file}\br
-    group\opt{}
+    \opt{group}
 \end{bnf}
 
 \begin{bnf}
@@ -51,26 +51,26 @@ within what would otherwise be an invocation of a function-like macro.
 \nontermdef{control-line}\br
 \>\terminal{\# include}\>\>pp-tokens new-line\br
 \>\terminal{\# define}\>\>identifier replacement-list new-line\br
-\>\terminal{\# define}\>\>identifier lparen identifier-list\opt{} \terminal{)} replacement-list new-line\br
+\>\terminal{\# define}\>\>identifier lparen \opt{identifier-list} \terminal{)} replacement-list new-line\br
 \>\terminal{\# define}\>\>identifier lparen \terminal{... )} replacement-list new-line\br
 \>\terminal{\# define}\>\>identifier lparen identifier-list \terminal{, ... )} replacement-list new-line\br
 \>\terminal{\# undef}\>\>identifier new-line\br
 \>\terminal{\# line}\>\>pp-tokens new-line\br
-\>\terminal{\# error}\>\>pp-tokens\opt{} new-line\br
-\>\terminal{\# pragma}\>\>pp-tokens\opt{} new-line\br
+\>\terminal{\# error}\>\>\opt{pp-tokens} new-line\br
+\>\terminal{\# pragma}\>\>\opt{pp-tokens} new-line\br
 \>\terminal{\# }new-line
 \end{bnftab}
 
 \begin{bnf}
 \nontermdef{if-section}\br
-    if-group elif-groups\opt{} else-group\opt{} endif-line
+    if-group \opt{elif-groups} \opt{else-group} endif-line
 \end{bnf}
 
 \begin{bnftab}
 \nontermdef{if-group}\br
-\>\terminal{\# if}\>\>constant-expression new-line group\opt{}\br
-\>\terminal{\# ifdef}\>\>identifier new-line group\opt{}\br
-\>\terminal{\# ifndef}\>\>identifier new-line group\opt{}
+\>\terminal{\# if}\>\>constant-expression new-line \opt{group}\br
+\>\terminal{\# ifdef}\>\>identifier new-line \opt{group}\br
+\>\terminal{\# ifndef}\>\>identifier new-line \opt{group}
 \end{bnftab}
 
 \begin{bnf}
@@ -81,12 +81,12 @@ within what would otherwise be an invocation of a function-like macro.
 
 \begin{bnftab}
 \nontermdef{elif-group}\br
-\>\terminal{\# elif}\>\>constant-expression new-line group\opt{}
+\>\terminal{\# elif}\>\>constant-expression new-line \opt{group}
 \end{bnftab}
 
 \begin{bnftab}
 \nontermdef{else-group}\br
-\>\terminal{\# else}\>\>new-line group\opt{}
+\>\terminal{\# else}\>\>new-line \opt{group}
 \end{bnftab}
 
 \begin{bnftab}
@@ -96,7 +96,7 @@ within what would otherwise be an invocation of a function-like macro.
 
 \begin{bnf}
 \nontermdef{text-line}\br
-    pp-tokens\opt{} new-line
+    \opt{pp-tokens} new-line
 \end{bnf}
 
 \begin{bnf}
@@ -117,7 +117,7 @@ within what would otherwise be an invocation of a function-like macro.
 
 \begin{bnf}
 \nontermdef{replacement-list}\br
-    pp-tokens\opt{}
+    \opt{pp-tokens}
 \end{bnf}
 
 \begin{bnf}
@@ -274,9 +274,9 @@ Preprocessing directives of the forms
 
 \begin{ncbnftab}
 \indextext{\idxcode{\#if}}%
-\terminal{\# if}\>\>constant-expression new-line group\opt{}\br
+\terminal{\# if}\>\>constant-expression new-line \opt{group}\br
 \indextext{\idxcode{\#elif}}%
-\terminal{\# elif}\>\>constant-expression new-line group\opt{}
+\terminal{\# elif}\>\>constant-expression new-line \opt{group}
 \end{ncbnftab}
 
 check whether the controlling constant expression evaluates to nonzero.
@@ -369,9 +369,9 @@ is subjected to integral promotion before processing continues.
 Preprocessing directives of the forms
 
 \begin{ncbnftab}
-\terminal{\# ifdef}\>\>identifier new-line group\opt{}\br
+\terminal{\# ifdef}\>\>identifier new-line \opt{group}\br
 \indextext{\idxcode{\#ifdef}}%
-\terminal{\# ifndef}\>\>identifier new-line group\opt{}
+\terminal{\# ifndef}\>\>identifier new-line \opt{group}
 \indextext{\idxcode{\#ifndef}}%
 \end{ncbnftab}
 
@@ -688,7 +688,7 @@ specified below.
 \pnum
 A preprocessing directive of the form
 \begin{ncsimplebnf}
-\terminal{\# define} identifier lparen identifier-list\opt{} \terminal{)} replacement-list new-line\br
+\terminal{\# define} identifier lparen \opt{identifier-list} \terminal{)} replacement-list new-line\br
 \terminal{\# define} identifier lparen \terminal{...} \terminal{)} replacement-list new-line\br
 \terminal{\# define} identifier lparen identifier-list \terminal{, ...} \terminal{)} replacement-list new-line
 \end{ncsimplebnf}
@@ -1213,7 +1213,7 @@ the behavior is undefined.
 A preprocessing directive of the form
 
 \begin{ncsimplebnf}
-\terminal{\# line} digit-sequence \terminal{"} s-char-sequence\opt{} \terminal{"} new-line
+\terminal{\# line} digit-sequence \terminal{"} \opt{s-char-sequence} \terminal{"} new-line
 \end{ncsimplebnf}
 
 sets the presumed line number similarly and changes the
@@ -1246,7 +1246,7 @@ otherwise, the result is processed as appropriate.
 A preprocessing directive of the form
 
 \begin{ncsimplebnf}
-\terminal{\# error} pp-tokens\opt{} new-line
+\terminal{\# error} \opt{pp-tokens} new-line
 \end{ncsimplebnf}
 
 causes the implementation to produce
@@ -1261,7 +1261,7 @@ and renders the program ill-formed.
 A preprocessing directive of the form
 
 \begin{ncsimplebnf}
-\terminal{\# pragma} pp-tokens\opt{} new-line
+\terminal{\# pragma} \opt{pp-tokens} new-line
 \end{ncsimplebnf}
 
 causes the implementation to behave

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -6,7 +6,7 @@
 
 
 \pnum
-This Clause describes components that \Cpp programs may use to
+This Clause describes components that \Cpp{} programs may use to
 perform operations involving regular expression matching and
 searching.
 
@@ -4039,7 +4039,7 @@ Objects of type specialization of \tcode{basic_regex} store within themselves a
 default-constructed instance of their \tcode{traits} template parameter, henceforth
 referred to as \tcode{traits_inst}. This \tcode{traits_inst} object is used to support localization
 of the regular expression; \tcode{basic_regex} member functions shall not call
-any locale dependent C or \Cpp API, including the formatted string input functions.
+any locale dependent C or \Cpp{} API, including the formatted string input functions.
 Instead they shall call the appropriate traits member function to achieve the required effect.
 
 \pnum

--- a/source/special.tex
+++ b/source/special.tex
@@ -77,7 +77,7 @@ In a declaration of a constructor, the \grammarterm{declarator} is a
 function declarator\iref{dcl.fct} of the form
 
 \begin{ncbnf}
-ptr-declarator \terminal{(} parameter-declaration-clause \terminal{)} noexcept-specifier\opt{} attribute-specifier-seq\opt{}
+ptr-declarator \terminal{(} parameter-declaration-clause \terminal{)} \opt{noexcept-specifier} \opt{attribute-specifier-seq}
 \end{ncbnf}
 
 where the \grammarterm{ptr-declarator} consists solely of an
@@ -880,12 +880,12 @@ A member function of a class \tcode{X} having no parameters with a name of the f
 
 \begin{bnf}
 \nontermdef{conversion-type-id}\br
-    type-specifier-seq conversion-declarator\opt{}
+    type-specifier-seq \opt{conversion-declarator}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{conversion-declarator}\br
-    ptr-operator conversion-declarator\opt{}
+    ptr-operator \opt{conversion-declarator}
 \end{bnf}
 
 specifies a conversion from
@@ -1009,7 +1009,7 @@ In a declaration of a destructor, the \grammarterm{declarator} is a
 function declarator\iref{dcl.fct} of the form
 
 \begin{ncbnf}
-ptr-declarator \terminal{(} parameter-declaration-clause \terminal{)} noexcept-specifier\opt{} attribute-specifier-seq\opt{}
+ptr-declarator \terminal{(} parameter-declaration-clause \terminal{)} \opt{noexcept-specifier} \opt{attribute-specifier-seq}
 \end{ncbnf}
 
 where the \grammarterm{ptr-declarator} consists solely of an
@@ -1659,13 +1659,13 @@ which has the form
 
 \begin{bnf}
 \nontermdef{mem-initializer-list}\br
-    mem-initializer \terminal{...}\opt{}\br
-    mem-initializer-list \terminal{,} mem-initializer \terminal{...}\opt{}
+    mem-initializer \opt{\terminal{...}}\br
+    mem-initializer-list \terminal{,} mem-initializer \opt{\terminal{...}}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{mem-initializer}\br
-    mem-initializer-id \terminal{(} expression-list\opt{} \terminal{)}\br
+    mem-initializer-id \terminal{(} \opt{expression-list} \terminal{)}\br
     mem-initializer-id braced-init-list
 \end{bnf}
 

--- a/source/special.tex
+++ b/source/special.tex
@@ -77,7 +77,7 @@ In a declaration of a constructor, the \grammarterm{declarator} is a
 function declarator\iref{dcl.fct} of the form
 
 \begin{ncbnf}
-ptr-declarator \terminal{(} parameter-declaration-clause \terminal{)} noexcept-specifier\opt attribute-specifier-seq\opt
+ptr-declarator \terminal{(} parameter-declaration-clause \terminal{)} noexcept-specifier\opt{} attribute-specifier-seq\opt{}
 \end{ncbnf}
 
 where the \grammarterm{ptr-declarator} consists solely of an
@@ -880,12 +880,12 @@ A member function of a class \tcode{X} having no parameters with a name of the f
 
 \begin{bnf}
 \nontermdef{conversion-type-id}\br
-    type-specifier-seq conversion-declarator\opt
+    type-specifier-seq conversion-declarator\opt{}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{conversion-declarator}\br
-    ptr-operator conversion-declarator\opt
+    ptr-operator conversion-declarator\opt{}
 \end{bnf}
 
 specifies a conversion from
@@ -1009,7 +1009,7 @@ In a declaration of a destructor, the \grammarterm{declarator} is a
 function declarator\iref{dcl.fct} of the form
 
 \begin{ncbnf}
-ptr-declarator \terminal{(} parameter-declaration-clause \terminal{)} noexcept-specifier\opt attribute-specifier-seq\opt
+ptr-declarator \terminal{(} parameter-declaration-clause \terminal{)} noexcept-specifier\opt{} attribute-specifier-seq\opt{}
 \end{ncbnf}
 
 where the \grammarterm{ptr-declarator} consists solely of an
@@ -1659,8 +1659,8 @@ which has the form
 
 \begin{bnf}
 \nontermdef{mem-initializer-list}\br
-    mem-initializer \terminal{...}\opt\br
-    mem-initializer-list \terminal{,} mem-initializer \terminal{...}\opt
+    mem-initializer \terminal{...}\opt{}\br
+    mem-initializer-list \terminal{,} mem-initializer \terminal{...}\opt{}
 \end{bnf}
 
 \begin{bnf}

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -12,13 +12,13 @@ Except as indicated, statements are executed in sequence.
 \begin{bnf}
 \nontermdef{statement}\br
     labeled-statement\br
-    attribute-specifier-seq\opt expression-statement\br
-    attribute-specifier-seq\opt compound-statement\br
-    attribute-specifier-seq\opt selection-statement\br
-    attribute-specifier-seq\opt iteration-statement\br
-    attribute-specifier-seq\opt jump-statement\br
+    attribute-specifier-seq\opt{} expression-statement\br
+    attribute-specifier-seq\opt{} compound-statement\br
+    attribute-specifier-seq\opt{} selection-statement\br
+    attribute-specifier-seq\opt{} iteration-statement\br
+    attribute-specifier-seq\opt{} jump-statement\br
     declaration-statement\br
-    attribute-specifier-seq\opt try-block
+    attribute-specifier-seq\opt{} try-block
 
 \nontermdef{init-statement}\br
     expression-statement\br
@@ -26,7 +26,7 @@ Except as indicated, statements are executed in sequence.
 
 \nontermdef{condition}\br
     expression\br
-    attribute-specifier-seq\opt decl-specifier-seq declarator brace-or-equal-initializer
+    attribute-specifier-seq\opt{} decl-specifier-seq declarator brace-or-equal-initializer
 \end{bnf}
 
 The optional \grammarterm{attribute-specifier-seq} appertains to the respective statement.
@@ -102,7 +102,7 @@ A statement can be labeled.
 
 \begin{bnf}
 \nontermdef{labeled-statement}\br
-    attribute-specifier-seq\opt identifier \terminal{:} statement\br
+    attribute-specifier-seq\opt{} identifier \terminal{:} statement\br
     attribute-specifier-seq\opt{} \terminal{case} constant-expression \terminal{:} statement\br
     attribute-specifier-seq\opt{} \terminal{default :} statement
 \end{bnf}
@@ -196,9 +196,9 @@ Selection statements choose one of several flows of control.
 %
 \begin{bnf}
 \nontermdef{selection-statement}\br
-    \terminal{if constexpr\opt (} init-statement\opt condition \terminal{)} statement\br
-    \terminal{if constexpr\opt (} init-statement\opt condition \terminal{)} statement \terminal{else} statement\br
-    \terminal{switch (} init-statement\opt condition \terminal{)} statement
+    \terminal{if constexpr\opt{} (} init-statement\opt{} condition \terminal{)} statement\br
+    \terminal{if constexpr\opt{} (} init-statement\opt{} condition \terminal{)} statement \terminal{else} statement\br
+    \terminal{switch (} init-statement\opt{} condition \terminal{)} statement
 \end{bnf}
 
 See~\ref{dcl.meaning} for the optional \grammarterm{attribute-specifier-seq} in a condition.
@@ -295,7 +295,7 @@ int f() {
 An \tcode{if} statement of the form
 
 \begin{ncbnf}
-\terminal{if constexpr\opt (} init-statement condition \terminal{)} statement
+\terminal{if constexpr\opt{} (} init-statement condition \terminal{)} statement
 \end{ncbnf}
 
 is equivalent to
@@ -303,14 +303,14 @@ is equivalent to
 \begin{ncbnftab}
 \terminal{\{}\br
 \>init-statement\br
-\>\terminal{if constexpr\opt (} condition \terminal{)} statement\br
+\>\terminal{if constexpr\opt{} (} condition \terminal{)} statement\br
 \terminal{\}}
 \end{ncbnftab}
 
 and an \tcode{if} statement of the form
 
 \begin{ncbnf}
-\terminal{if constexpr\opt (} init-statement condition \terminal{)} statement \terminal{else} statement
+\terminal{if constexpr\opt{} (} init-statement condition \terminal{)} statement \terminal{else} statement
 \end{ncbnf}
 
 is equivalent to
@@ -318,7 +318,7 @@ is equivalent to
 \begin{ncbnftab}
 \terminal{\{}\br
 \>init-statement\br
-\>\terminal{if constexpr\opt (} condition \terminal{)} statement \terminal{else} statement\br
+\>\terminal{if constexpr\opt{} (} condition \terminal{)} statement \terminal{else} statement\br
 \terminal{\}}
 \end{ncbnftab}
 
@@ -436,8 +436,8 @@ Iteration statements specify looping.
 
 \begin{bnf}
 \nontermdef{for-range-declaration}\br
-    attribute-specifier-seq\opt decl-specifier-seq declarator\br
-    attribute-specifier-seq\opt decl-specifier-seq ref-qualifier\opt{} \terminal{[} identifier-list \terminal{]}
+    attribute-specifier-seq\opt{} decl-specifier-seq declarator\br
+    attribute-specifier-seq\opt{} decl-specifier-seq ref-qualifier\opt{} \terminal{[} identifier-list \terminal{]}
 \end{bnf}
 
 \begin{bnf}

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -12,13 +12,13 @@ Except as indicated, statements are executed in sequence.
 \begin{bnf}
 \nontermdef{statement}\br
     labeled-statement\br
-    attribute-specifier-seq\opt{} expression-statement\br
-    attribute-specifier-seq\opt{} compound-statement\br
-    attribute-specifier-seq\opt{} selection-statement\br
-    attribute-specifier-seq\opt{} iteration-statement\br
-    attribute-specifier-seq\opt{} jump-statement\br
+    \opt{attribute-specifier-seq} expression-statement\br
+    \opt{attribute-specifier-seq} compound-statement\br
+    \opt{attribute-specifier-seq} selection-statement\br
+    \opt{attribute-specifier-seq} iteration-statement\br
+    \opt{attribute-specifier-seq} jump-statement\br
     declaration-statement\br
-    attribute-specifier-seq\opt{} try-block
+    \opt{attribute-specifier-seq} try-block
 
 \nontermdef{init-statement}\br
     expression-statement\br
@@ -26,7 +26,7 @@ Except as indicated, statements are executed in sequence.
 
 \nontermdef{condition}\br
     expression\br
-    attribute-specifier-seq\opt{} decl-specifier-seq declarator brace-or-equal-initializer
+    \opt{attribute-specifier-seq} decl-specifier-seq declarator brace-or-equal-initializer
 \end{bnf}
 
 The optional \grammarterm{attribute-specifier-seq} appertains to the respective statement.
@@ -102,9 +102,9 @@ A statement can be labeled.
 
 \begin{bnf}
 \nontermdef{labeled-statement}\br
-    attribute-specifier-seq\opt{} identifier \terminal{:} statement\br
-    attribute-specifier-seq\opt{} \terminal{case} constant-expression \terminal{:} statement\br
-    attribute-specifier-seq\opt{} \terminal{default :} statement
+    \opt{attribute-specifier-seq} identifier \terminal{:} statement\br
+    \opt{attribute-specifier-seq} \terminal{case} constant-expression \terminal{:} statement\br
+    \opt{attribute-specifier-seq} \terminal{default :} statement
 \end{bnf}
 
 The optional \grammarterm{attribute-specifier-seq} appertains to the label. An
@@ -139,7 +139,7 @@ Expression statements have the form
 
 \begin{bnf}
 \nontermdef{expression-statement}\br
-    expression\opt{} \terminal{;}
+    \opt{expression} \terminal{;}
 \end{bnf}
 
 The expression is
@@ -171,7 +171,7 @@ provided.
 
 \begin{bnf}
 \nontermdef{compound-statement}\br
-    \terminal{\{} statement-seq\opt{} \terminal{\}}
+    \terminal{\{} \opt{statement-seq} \terminal{\}}
 \end{bnf}
 
 \begin{bnf}
@@ -196,9 +196,9 @@ Selection statements choose one of several flows of control.
 %
 \begin{bnf}
 \nontermdef{selection-statement}\br
-    \terminal{if constexpr\opt{} (} init-statement\opt{} condition \terminal{)} statement\br
-    \terminal{if constexpr\opt{} (} init-statement\opt{} condition \terminal{)} statement \terminal{else} statement\br
-    \terminal{switch (} init-statement\opt{} condition \terminal{)} statement
+    \terminal{if \opt{constexpr} (} \opt{init-statement} condition \terminal{)} statement\br
+    \terminal{if \opt{constexpr} (} \opt{init-statement} condition \terminal{)} statement \terminal{else} statement\br
+    \terminal{switch (} \opt{init-statement} condition \terminal{)} statement
 \end{bnf}
 
 See~\ref{dcl.meaning} for the optional \grammarterm{attribute-specifier-seq} in a condition.
@@ -295,7 +295,7 @@ int f() {
 An \tcode{if} statement of the form
 
 \begin{ncbnf}
-\terminal{if constexpr\opt{} (} init-statement condition \terminal{)} statement
+\terminal{if \opt{constexpr} (} init-statement condition \terminal{)} statement
 \end{ncbnf}
 
 is equivalent to
@@ -303,14 +303,14 @@ is equivalent to
 \begin{ncbnftab}
 \terminal{\{}\br
 \>init-statement\br
-\>\terminal{if constexpr\opt{} (} condition \terminal{)} statement\br
+\>\terminal{if \opt{constexpr} (} condition \terminal{)} statement\br
 \terminal{\}}
 \end{ncbnftab}
 
 and an \tcode{if} statement of the form
 
 \begin{ncbnf}
-\terminal{if constexpr\opt{} (} init-statement condition \terminal{)} statement \terminal{else} statement
+\terminal{if \opt{constexpr} (} init-statement condition \terminal{)} statement \terminal{else} statement
 \end{ncbnf}
 
 is equivalent to
@@ -318,7 +318,7 @@ is equivalent to
 \begin{ncbnftab}
 \terminal{\{}\br
 \>init-statement\br
-\>\terminal{if constexpr\opt{} (} condition \terminal{)} statement \terminal{else} statement\br
+\>\terminal{if \opt{constexpr} (} condition \terminal{)} statement \terminal{else} statement\br
 \terminal{\}}
 \end{ncbnftab}
 
@@ -430,14 +430,14 @@ Iteration statements specify looping.
 \nontermdef{iteration-statement}\br
     \terminal{while (} condition \terminal{)} statement\br
     \terminal{do} statement \terminal{while (} expression \terminal{) ;}\br
-    \terminal{for (} init-statement condition\opt{} \terminal{;} expression\opt{} \terminal{)} statement\br
+    \terminal{for (} init-statement \opt{condition} \terminal{;} \opt{expression} \terminal{)} statement\br
     \terminal{for (} for-range-declaration \terminal{:} for-range-initializer \terminal{)} statement
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{for-range-declaration}\br
-    attribute-specifier-seq\opt{} decl-specifier-seq declarator\br
-    attribute-specifier-seq\opt{} decl-specifier-seq ref-qualifier\opt{} \terminal{[} identifier-list \terminal{]}
+    \opt{attribute-specifier-seq} decl-specifier-seq declarator\br
+    \opt{attribute-specifier-seq} decl-specifier-seq \opt{ref-qualifier} \terminal{[} identifier-list \terminal{]}
 \end{bnf}
 
 \begin{bnf}
@@ -568,7 +568,7 @@ place after each execution of the statement.
 The \tcode{for} statement
 
 \begin{ncbnf}
-\terminal{for (} init-statement condition\opt{} \terminal{;} expression\opt{} \terminal{)} statement
+\terminal{for (} init-statement \opt{condition} \terminal{;} \opt{expression} \terminal{)} statement
 \end{ncbnf}
 
 is equivalent to
@@ -716,7 +716,7 @@ Jump statements unconditionally transfer control.
 \nontermdef{jump-statement}\br
     \terminal{break ;}\br
     \terminal{continue ;}\br
-    \terminal{return} expr-or-braced-init-list\opt{} \terminal{;}\br
+    \terminal{return} \opt{expr-or-braced-init-list} \terminal{;}\br
     \terminal{goto} identifier \terminal{;}
 \end{bnf}
 

--- a/source/std.tex
+++ b/source/std.tex
@@ -27,7 +27,6 @@
 \usepackage{mathrsfs}     % mathscr font
 \usepackage[final]{microtype}
 \usepackage{multicol}
-\usepackage{xspace}
 \usepackage{lmodern}
 \usepackage[T1]{fontenc}
 \usepackage[pdftex, final]{graphicx}

--- a/source/support.tex
+++ b/source/support.tex
@@ -2557,7 +2557,7 @@ const char* what() const noexcept override;
 \begin{itemdescr}
 \pnum
 \returns
-An \impldef{return value of \tcode{bad_alloc::what}} \ntbs.
+An \impldef{return value of \tcode{bad_alloc::what}} \ntbs{}.
 
 \pnum
 \remarks
@@ -2603,7 +2603,7 @@ const char* what() const noexcept override;
 \begin{itemdescr}
 \pnum
 \returns
-An \impldef{return value of \tcode{bad_array_new_length::what}} \ntbs.
+An \impldef{return value of \tcode{bad_array_new_length::what}} \ntbs{}.
 
 \pnum
 \remarks
@@ -2919,7 +2919,7 @@ const char* name() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-An \impldef{return value of \tcode{type_info::name()}} \ntbs.
+An \impldef{return value of \tcode{type_info::name()}} \ntbs{}.
 
 \pnum
 \remarks
@@ -2986,7 +2986,7 @@ const char* what() const noexcept override;
 \begin{itemdescr}
 \pnum
 \returns
-An \impldef{return value of \tcode{bad_cast::what}} \ntbs.
+An \impldef{return value of \tcode{bad_cast::what}} \ntbs{}.
 
 \pnum
 \remarks
@@ -3053,7 +3053,7 @@ const char* what() const noexcept override;
 \begin{itemdescr}
 \pnum
 \returns
-An \impldef{return value of \tcode{bad_typeid::what}} \ntbs.
+An \impldef{return value of \tcode{bad_typeid::what}} \ntbs{}.
 
 \pnum
 \remarks
@@ -3180,7 +3180,7 @@ virtual const char* what() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-An \impldef{return value of \tcode{exception::what}} \ntbs.
+An \impldef{return value of \tcode{exception::what}} \ntbs{}.
 
 \pnum
 \remarks
@@ -3249,7 +3249,7 @@ const char* what() const noexcept override;
 \begin{itemdescr}
 \pnum
 \returns
-An \impldef{return value of \tcode{bad_exception::what}} \ntbs.
+An \impldef{return value of \tcode{bad_exception::what}} \ntbs{}.
 
 \pnum
 \remarks

--- a/source/support.tex
+++ b/source/support.tex
@@ -6,7 +6,7 @@
 \pnum
 This Clause describes the function signatures that are called
 implicitly, and the types of objects generated implicitly, during the execution
-of some \Cpp programs.
+of some \Cpp{} programs.
 It also describes the headers that declare these function
 signatures and define any related types.
 
@@ -14,7 +14,7 @@ signatures and define any related types.
 The following subclauses describe
 common type definitions used throughout the library,
 characteristics of the predefined types,
-functions supporting start and termination of a \Cpp program,
+functions supporting start and termination of a \Cpp{} program,
 support for dynamic memory management,
 support for dynamic type identification,
 support for exception processing, support for initializer lists,
@@ -628,7 +628,7 @@ if the type does allow subnormal values
 The
 \indexlibrary{\idxcode{numeric_limits}}%
 \tcode{numeric_limits}
-class template provides a \Cpp program with information about various properties of
+class template provides a \Cpp{} program with information about various properties of
 the implementation's representation of the
 arithmetic types.
 
@@ -1879,9 +1879,9 @@ is not a valid alignment value,
 the behavior is undefined.
 
 \newcommand{\replaceabledesc}[1]{%
-A \Cpp program may define functions with #1 of these function signatures,
+A \Cpp{} program may define functions with #1 of these function signatures,
 and thereby displace the default versions defined by the
-\Cpp standard library.%
+\Cpp{} standard library.%
 }
 
 \rSec3[new.delete.single]{Single-object forms}
@@ -1962,7 +1962,7 @@ void* operator new(std::size_t size, std::align_val_t alignment, const std::noth
 \effects
 Same as above, except that these are called by a placement version of a
 \grammarterm{new-expression}
-when a \Cpp program prefers a null pointer result as an error indication,
+when a \Cpp{} program prefers a null pointer result as an error indication,
 instead of a
 \tcode{bad_alloc}
 exception.
@@ -2224,7 +2224,7 @@ void* operator new[](std::size_t size, std::align_val_t alignment, const std::no
 \effects
 Same as above, except that these are called by a placement version of a
 \grammarterm{new-expression}
-when a \Cpp program prefers a null pointer result as an error indication,
+when a \Cpp{} program prefers a null pointer result as an error indication,
 instead of a
 \tcode{bad_alloc}
 exception.
@@ -2392,8 +2392,8 @@ respectively.
 \rSec3[new.delete.placement]{Non-allocating forms}
 
 \pnum
-These functions are reserved; a \Cpp program may not define functions that displace
-the versions in the \Cpp standard library\iref{constraints}.
+These functions are reserved; a \Cpp{} program may not define functions that displace
+the versions in the \Cpp{} standard library\iref{constraints}.
 The provisions of~\ref{basic.stc.dynamic} do not apply to these reserved
 placement forms of \tcode{operator new} and \tcode{operator delete}.
 
@@ -3067,7 +3067,7 @@ suitable for conversion and display as a
 \pnum
 The header
 \tcode{<exception>}
-defines several types and functions related to the handling of exceptions in a \Cpp program.
+defines several types and functions related to the handling of exceptions in a \Cpp{} program.
 
 \rSec2[exception.syn]{Header \tcode{<exception>} synopsis}
 \indextext{\idxhdr{exception}}%
@@ -3118,7 +3118,7 @@ The class
 \tcode{exception}
 defines the base
 class for the types of objects thrown as exceptions by
-\Cpp standard library components, and certain
+\Cpp{} standard library components, and certain
 expressions, to report errors detected during program execution.
 
 \pnum

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -244,10 +244,10 @@ is:
 
 \begin{bnf}
 \nontermdef{type-parameter}\br
-  type-parameter-key \terminal{...}\opt{} identifier\opt{}\br
-  type-parameter-key identifier\opt{} \terminal{=} type-id\br
-  \terminal{template <} template-parameter-list \terminal{>} type-parameter-key \terminal{...}\opt{} identifier\opt{}\br
-  \terminal{template <} template-parameter-list \terminal{>} type-parameter-key identifier\opt{} \terminal{=} id-expression
+  type-parameter-key \opt{\terminal{...}} \opt{identifier}\br
+  type-parameter-key \opt{identifier} \terminal{=} type-id\br
+  \terminal{template <} template-parameter-list \terminal{>} type-parameter-key \opt{\terminal{...}} \opt{identifier}\br
+  \terminal{template <} template-parameter-list \terminal{>} type-parameter-key \opt{identifier} \terminal{=} id-expression
 \end{bnf}
 
 \begin{bnf}
@@ -768,14 +768,14 @@ A template specialization\iref{temp.spec} can be referred to by a
 
 \begin{bnf}
 \nontermdef{simple-template-id}\br
-  template-name \terminal{<} template-argument-list\opt{} \terminal{>}
+  template-name \terminal{<} \opt{template-argument-list} \terminal{>}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{template-id}\br
   simple-template-id\br
-  operator-function-id \terminal{<} template-argument-list\opt{} \terminal{>}\br
-  literal-operator-id \terminal{<} template-argument-list\opt{} \terminal{>}
+  operator-function-id \terminal{<} \opt{template-argument-list} \terminal{>}\br
+  literal-operator-id \terminal{<} \opt{template-argument-list} \terminal{>}
 \end{bnf}
 
 \begin{bnf}
@@ -785,8 +785,8 @@ A template specialization\iref{temp.spec} can be referred to by a
 
 \begin{bnf}
 \nontermdef{template-argument-list}\br
-  template-argument \terminal{...}\opt{}\br
-  template-argument-list \terminal{,} template-argument \terminal{...}\opt{}
+  template-argument \opt{\terminal{...}}\br
+  template-argument-list \terminal{,} template-argument \opt{\terminal{...}}
 \end{bnf}
 
 \begin{bnf}
@@ -3987,7 +3987,7 @@ the program is ill-formed.
 \begin{bnf}
 \nontermdef{typename-specifier}\br
   \terminal{typename} nested-name-specifier identifier\br
-  \terminal{typename} nested-name-specifier \terminal{template\opt{}} simple-template-id
+  \terminal{typename} nested-name-specifier \terminal{\opt{template}} simple-template-id
 \end{bnf}
 
 \pnum
@@ -4514,7 +4514,7 @@ as described in this subclause.
 In an expression of the form:
 
 \begin{ncbnftab}
-postfix-expression \terminal{(} expression-list\opt{} \terminal{)}
+postfix-expression \terminal{(} \opt{expression-list} \terminal{)}
 \end{ncbnftab}
 
 where the
@@ -5012,9 +5012,9 @@ or
 is dependent, even if any subexpression is type-dependent:
 
 \begin{ncbnftab}
-simple-type-specifier \terminal{(} expression-list\opt{} \terminal{)}\br
-\terminal{::\opt{} new} new-placement\opt{} new-type-id new-initializer\opt{}\br
-\terminal{::\opt{} new} new-placement\opt{} \terminal{(} type-id \terminal{)} new-initializer\opt{}\br
+simple-type-specifier \terminal{(} \opt{expression-list} \terminal{)}\br
+\terminal{\opt{::} new} \opt{new-placement} new-type-id \opt{new-initializer}\br
+\terminal{\opt{::} new} \opt{new-placement} \terminal{(} type-id \terminal{)} \opt{new-initializer}\br
 \terminal{dynamic_cast <} type-id \terminal{> (} expression \terminal{)}\br
 \terminal{static_cast <} type-id \terminal{> (} expression \terminal{)}\br
 \terminal{const_cast <} type-id \terminal{> (} expression \terminal{)}\br
@@ -5036,9 +5036,9 @@ postfix-expression \terminal{->} pseudo-destructor-name\br
 \terminal{alignof (} type-id \terminal{)}\br
 \terminal{typeid (} expression \terminal{)}\br
 \terminal{typeid (} type-id \terminal{)}\br
-\terminal{::\opt{} delete} cast-expression\br
-\terminal{::\opt{} delete [ ]} cast-expression\br
-\terminal{throw} assignment-expression\opt{}\br
+\terminal{\opt{::} delete} cast-expression\br
+\terminal{\opt{::} delete [ ]} cast-expression\br
+\terminal{throw} \opt{assignment-expression}\br
 \terminal{noexcept} \terminal{(} expression \terminal{)}
 \end{ncbnftab}
 
@@ -5143,7 +5143,7 @@ or
 is value-dependent:
 
 \begin{ncbnftab}
-simple-type-specifier \terminal{(} expression-list\opt{} \terminal{)}\br
+simple-type-specifier \terminal{(} \opt{expression-list} \terminal{)}\br
 \terminal{static_cast <} type-id \terminal{> (} expression \terminal{)}\br
 \terminal{const_cast <} type-id \terminal{> (} expression \terminal{)}\br
 \terminal{reinterpret_cast <} type-id \terminal{> (} expression \terminal{)}\br
@@ -5886,7 +5886,7 @@ The syntax for explicit instantiation is:
 
 \begin{bnf}
 \nontermdef{explicit-instantiation}\br
-  \terminal{extern\opt{}} \terminal{template} declaration
+  \terminal{\opt{extern}} \terminal{template} declaration
 \end{bnf}
 
 There are two forms of explicit instantiation: an explicit instantiation
@@ -8665,7 +8665,7 @@ any deduction guides declared for the class template are considered.
 
 \begin{bnf}
 \nontermdef{deduction-guide}\br
-    \terminal{explicit}\opt{} template-name \terminal{(} parameter-declaration-clause \terminal{) ->} simple-template-id \terminal{;}
+    \opt{\terminal{explicit}} template-name \terminal{(} parameter-declaration-clause \terminal{) ->} simple-template-id \terminal{;}
 \end{bnf}
 
 \pnum

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -244,9 +244,9 @@ is:
 
 \begin{bnf}
 \nontermdef{type-parameter}\br
-  type-parameter-key \terminal{...}\opt identifier\opt\br
+  type-parameter-key \terminal{...}\opt{} identifier\opt{}\br
   type-parameter-key identifier\opt{} \terminal{=} type-id\br
-  \terminal{template <} template-parameter-list \terminal{>} type-parameter-key \terminal{...}\opt identifier\opt\br
+  \terminal{template <} template-parameter-list \terminal{>} type-parameter-key \terminal{...}\opt{} identifier\opt{}\br
   \terminal{template <} template-parameter-list \terminal{>} type-parameter-key identifier\opt{} \terminal{=} id-expression
 \end{bnf}
 
@@ -785,8 +785,8 @@ A template specialization\iref{temp.spec} can be referred to by a
 
 \begin{bnf}
 \nontermdef{template-argument-list}\br
-  template-argument \terminal{...}\opt\br
-  template-argument-list \terminal{,} template-argument \terminal{...}\opt
+  template-argument \terminal{...}\opt{}\br
+  template-argument-list \terminal{,} template-argument \terminal{...}\opt{}
 \end{bnf}
 
 \begin{bnf}
@@ -3987,7 +3987,7 @@ the program is ill-formed.
 \begin{bnf}
 \nontermdef{typename-specifier}\br
   \terminal{typename} nested-name-specifier identifier\br
-  \terminal{typename} nested-name-specifier \terminal{template\opt} simple-template-id
+  \terminal{typename} nested-name-specifier \terminal{template\opt{}} simple-template-id
 \end{bnf}
 
 \pnum
@@ -5013,8 +5013,8 @@ is dependent, even if any subexpression is type-dependent:
 
 \begin{ncbnftab}
 simple-type-specifier \terminal{(} expression-list\opt{} \terminal{)}\br
-\terminal{::\opt new} new-placement\opt new-type-id new-initializer\opt\br
-\terminal{::\opt new} new-placement\opt{} \terminal{(} type-id \terminal{)} new-initializer\opt\br
+\terminal{::\opt{} new} new-placement\opt{} new-type-id new-initializer\opt{}\br
+\terminal{::\opt{} new} new-placement\opt{} \terminal{(} type-id \terminal{)} new-initializer\opt{}\br
 \terminal{dynamic_cast <} type-id \terminal{> (} expression \terminal{)}\br
 \terminal{static_cast <} type-id \terminal{> (} expression \terminal{)}\br
 \terminal{const_cast <} type-id \terminal{> (} expression \terminal{)}\br
@@ -5036,9 +5036,9 @@ postfix-expression \terminal{->} pseudo-destructor-name\br
 \terminal{alignof (} type-id \terminal{)}\br
 \terminal{typeid (} expression \terminal{)}\br
 \terminal{typeid (} type-id \terminal{)}\br
-\terminal{::\opt delete} cast-expression\br
-\terminal{::\opt delete [ ]} cast-expression\br
-\terminal{throw} assignment-expression\opt\br
+\terminal{::\opt{} delete} cast-expression\br
+\terminal{::\opt{} delete [ ]} cast-expression\br
+\terminal{throw} assignment-expression\opt{}\br
 \terminal{noexcept} \terminal{(} expression \terminal{)}
 \end{ncbnftab}
 
@@ -5886,7 +5886,7 @@ The syntax for explicit instantiation is:
 
 \begin{bnf}
 \nontermdef{explicit-instantiation}\br
-  \terminal{extern\opt} \terminal{template} declaration
+  \terminal{extern\opt{}} \terminal{template} declaration
 \end{bnf}
 
 There are two forms of explicit instantiation: an explicit instantiation

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1552,7 +1552,7 @@ on functions and function templates.
 There are two binary logical operations on constraints: conjunction
 and disjunction.
 \begin{note}
-These logical operations have no corresponding \Cpp syntax.
+These logical operations have no corresponding \Cpp{} syntax.
 For the purpose of exposition, conjunction is spelled
 using the symbol $\land$ and disjunction is spelled using the
 symbol $\lor$.

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -21,7 +21,7 @@ an alias for a family of types, or a concept.
 
 \begin{bnf}
 \nontermdef{template-head}\br
-  \terminal{template} \terminal{<} template-parameter-list \terminal{>} requires-clause\opt
+  \terminal{template} \terminal{<} template-parameter-list \terminal{>} \opt{requires-clause}
 \end{bnf}
 
 \begin{bnf}
@@ -258,19 +258,19 @@ is:
 
 \begin{bnf}
 \nontermdef{constrained-parameter}\br
-  qualified-concept-name \terminal{...} identifier\opt\br
-  qualified-concept-name identifier\opt{} default-template-argument\opt
+  qualified-concept-name \terminal{...} \opt{identifier}\br
+  qualified-concept-name \opt{identifier} \opt{default-template-argument}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{qualified-concept-name}\br
-  nested-name-specifier\opt{} concept-name\br
-  nested-name-specifier\opt{} partial-concept-id
+  \opt{nested-name-specifier} concept-name\br
+  \opt{nested-name-specifier} partial-concept-id
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{partial-concept-id}\br
-  concept-name \terminal{<} template-argument-list\opt{} \terminal{>}
+  concept-name \terminal{<} \opt{template-argument-list} \terminal{>}
 \end{bnf}
 
 \begin{bnf}

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -3785,7 +3785,7 @@ const char* what() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns An \ntbs incorporating \tcode{code().message()}.
+\returns An \ntbs{} incorporating \tcode{code().message()}.
 \end{itemdescr}
 
 \rSec2[futures.state]{Shared state}

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -3615,7 +3615,7 @@ return wait_until(lock, chrono::steady_clock::now() + rel_time, std::move(pred))
 \rSec2[futures.overview]{Overview}
 
 \pnum
-\ref{futures} describes components that a \Cpp program can use to retrieve in one thread the
+\ref{futures} describes components that a \Cpp{} program can use to retrieve in one thread the
 result (value or exception) from a function that has run in the same thread or another thread.
 \begin{note} These components are not restricted to multi-threaded programs but can be useful in
 single-threaded programs as well. \end{note}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -4,8 +4,8 @@
 \rSec1[utilities.general]{General}
 
 \pnum
-This Clause describes utilities that are generally useful in \Cpp programs; some
-of these utilities are used by other elements of the \Cpp standard library.
+This Clause describes utilities that are generally useful in \Cpp{} programs; some
+of these utilities are used by other elements of the \Cpp{} standard library.
 These utilities are summarized in Table~\ref{tab:util.lib.summary}.
 
 \begin{libsumtab}{General utilities library summary}{tab:util.lib.summary}
@@ -948,7 +948,7 @@ In place of:
 \begin{codeblock}
   return pair<int, double>(5, 3.1415926);   // explicit types
 \end{codeblock}
-a \Cpp program may contain:
+a \Cpp{} program may contain:
 \begin{codeblock}
   return make_pair(5, 3.1415926);           // types are deduced
 \end{codeblock}
@@ -5043,7 +5043,7 @@ The specialization is enabled\iref{unord.hash}.
 \rSec1[any]{Storage for any type}
 
 \pnum
-This section describes components that \Cpp programs may use to perform operations on objects of a discriminated type.
+This section describes components that \Cpp{} programs may use to perform operations on objects of a discriminated type.
 
 \pnum
 \begin{note}
@@ -12871,7 +12871,7 @@ namespace std {
 
 \pnum
 \begin{example}
-If a \Cpp program wants to have a by-element addition of two vectors \tcode{a}
+If a \Cpp{} program wants to have a by-element addition of two vectors \tcode{a}
 and \tcode{b} containing \tcode{double} and put the result into \tcode{a},
 it can do:
 
@@ -15032,13 +15032,13 @@ user-defined specialization that depends on at least one user-defined type.
 \rSec1[meta]{Metaprogramming and type traits}
 
 \pnum
-This subclause describes components used by \Cpp programs, particularly in
+This subclause describes components used by \Cpp{} programs, particularly in
 templates, to support the widest possible range of types, optimise
 template code usage, detect type related user errors, and perform
 type inference and transformation at compile time. It includes type
 classification traits, type property inspection traits, and type
 transformations. The type classification traits describe a complete taxonomy
-of all possible \Cpp types, and state where in that taxonomy a given
+of all possible \Cpp{} types, and state where in that taxonomy a given
 type belongs. The type property inspection traits allow important
 characteristics of types or of combinations of types to be inspected. The
 type transformations allow certain properties of types to be manipulated.
@@ -15522,7 +15522,7 @@ with a base characteristic of
 
 \pnum
 The primary type categories correspond to the descriptions given in
-section~\ref{basic.types} of the \Cpp standard.
+section~\ref{basic.types} of the \Cpp{} standard.
 
 \pnum
 For any given type \tcode{T}, the result of applying one of these templates to
@@ -16606,7 +16606,7 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
  struct aligned_storage;}
  &
  The value of \textit{default-alignment} shall be the most
- stringent alignment requirement for any \Cpp object type whose size
+ stringent alignment requirement for any \Cpp{} object type whose size
  is no greater than \tcode{Len}\iref{basic.types}.
  The member typedef \tcode{type} shall be a POD type
  suitable for use as uninitialized storage for any object whose size

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -3213,7 +3213,7 @@ Constructs an object of class \tcode{bad_optional_access}.
 \postconditions
 \tcode{what()} returns an
 \impldef{return value of \tcode{bad_optional_access::what}}
-\ntbs.
+\ntbs{}.
 \end{itemdescr}
 
 \rSec2[optional.relops]{Relational operators}
@@ -5012,7 +5012,7 @@ const char* what() const noexcept override;
 
 \begin{itemdescr}
 \pnum
-\returns An \impldef{return value of \tcode{bad_variant_access::what}} \ntbs.
+\returns An \impldef{return value of \tcode{bad_variant_access::what}} \ntbs{}.
 \end{itemdescr}
 
 \rSec2[variant.hash]{Hash support}
@@ -9097,7 +9097,7 @@ bad_weak_ptr() noexcept;
 
 \begin{itemdescr}
 \pnum\postconditions  \tcode{what()} returns an
-\impldef{return value of \tcode{bad_weak_ptr::what}} \ntbs.
+\impldef{return value of \tcode{bad_weak_ptr::what}} \ntbs{}.
 
 \end{itemdescr}
 
@@ -14287,7 +14287,7 @@ bad_function_call() noexcept;
 
 \begin{itemdescr}
 \pnum\postconditions  \tcode{what()} returns an
-\impldef{return value of \tcode{bad_function_call::what}} \ntbs.
+\impldef{return value of \tcode{bad_function_call::what}} \ntbs{}.
 \end{itemdescr}
 
 \rSec3[func.wrap.func]{Class template \tcode{function}}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -14498,7 +14498,7 @@ template<class F> function(F) -> function<@\seebelow@>;
 \remarks This deduction guide participates in overload resolution only if
 \tcode{\&F::operator()} is well-formed when treated as an unevaluated operand.
 In that case, if \tcode{decltype(\&F::operator())} is of the form
-\tcode{R(G::*)(A...)}~\cv{}~\tcode{\&\opt{}~noexcept\opt}
+\tcode{R(G::*)(A...)}~\cv{}~\tcode{\opt{\&}~\opt{noexcept}}
 for a class type \tcode{G}, then the deduced type is \tcode{function<R(A...)>}.
 
 \pnum


### PR DESCRIPTION
Fixes #1433.

This removes lots of kerning ugliness when (e.g.) a \grammarterm is followed by a punctuator. It's also a surprise to notice all the places where we actually had superfluous whitespace in the document.