### PR TITLE
[unord.req] Insert hint is 'p', not 'q'

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -2480,7 +2480,7 @@ and \tcode{CopyAssignable}.\br
     \tcode{CopyInsertable} into \tcode{X}.\br
     \effects\ Equivalent to a.insert(t).  Return value is an iterator pointing
 to the element with the key equivalent to that of \tcode{t}.  The
-iterator \tcode{q} is a hint pointing to where the search should
+iterator \tcode{p} is a hint pointing to where the search should
 start.  Implementations are permitted to ignore the hint.%
     \indextext{unordered associative containers!\idxcode{insert}}%
     \indextext{\idxcode{insert}!unordered associative containers}%


### PR DESCRIPTION
LWG 2540 changed the hint for insert from 'q'
(a valid and dereferenceable iterator) to 'p'
(a valid, but not necessarily dereferenceable iterator),
but neglected to adjust the description text.

Fixes #1423.