### PR TITLE
[basic.types] Remove excessive references to [basic.type.qualifier].

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3604,23 +3604,23 @@ Arithmetic types~(\ref{basic.fundamental}), enumeration types, pointer
 types, pointer to member types~(\ref{basic.compound}),
 \tcode{std::nullptr_t},
 and
-cv-qualified versions of these
-types~(\ref{basic.type.qualifier}) are collectively called
+cv-qualified~(\ref{basic.type.qualifier}) versions of these
+types are collectively called
 \defnx{scalar types}{scalar type}. Scalar types,
 POD classes (Clause~\ref{class}), arrays of such types and
 cv-qualified versions of these
-types~(\ref{basic.type.qualifier}) are collectively called
+types are collectively called
 \defnx{POD types}{type!POD}.
 Cv-unqualified scalar types, trivially copyable class types (Clause~\ref{class}), arrays of
 such types, and cv-qualified versions of these
-types~(\ref{basic.type.qualifier}) are collectively called \defn{trivially
+types are collectively called \defn{trivially
 copyable types}.
 Scalar types, trivial class types (Clause~\ref{class}),
 arrays of such types and cv-qualified versions of these
-types~(\ref{basic.type.qualifier}) are collectively called
+types are collectively called
 \defn{trivial types}. Scalar types, standard-layout class
 types (Clause~\ref{class}), arrays of such types and
-cv-qualified versions of these types~(\ref{basic.type.qualifier})
+cv-qualified versions of these types
 are collectively called \defn{standard-layout types}.
 
 \pnum


### PR DESCRIPTION
Fixes #1419.