### PR TITLE
[enum.copy_options] Rephrase restriction on copy_options values.

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -12416,9 +12416,7 @@ The \tcode{enum class} type \tcode{copy_options}
 is a bitmask type~(\ref{bitmask.types}) that specifies bitmask constants used to control the semantics of
 copy operations. The constants are specified in option groups with the meanings listed in Table~\ref{tab:fs.enum.copy_options}.
 Constant \tcode{none} is shown in each option group for purposes of exposition;
-implementations shall provide only a single definition. Calling a
-library function with more than a single constant for an option
-group results in undefined behavior.
+implementations shall provide only a single definition.
 
 \begin{floattable}
 {Enum class \tcode{copy_options}}{tab:fs.enum.copy_options}
@@ -13839,8 +13837,8 @@ void copy(const path& from, const path& to, copy_options options,
 
 \begin{itemdescr}
 \pnum
-\requires At most one constant from each option group (\ref{fs.enum.copy.opts})
-  is present in \tcode{options}.
+\requires At most one element from each option group (\ref{fs.enum.copy.opts})
+  is set in \tcode{options}.
 
 \pnum
 \effects
@@ -14000,8 +13998,8 @@ bool copy_file(const path& from, const path& to, copy_options options,
 
 \begin{itemdescr}
 \pnum
-\requires At most one constant from each \tcode{copy_options}
-  option group (\ref{fs.enum.copy.opts}) is present
+\requires At most one element from each
+  option group (\ref{fs.enum.copy.opts}) is set
   in \tcode{options}.
 
 \pnum


### PR DESCRIPTION
Fixes #1422.