### PR TITLE
[expr.delete] Remove bad index entry and

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3639,11 +3639,10 @@ called as described above.
 \pnum
 \begin{note}
 An implementation provides default definitions of the global
-deallocation functions \tcode{operator delete()} for
+deallocation functions \tcode{operator delete} for
 non-arrays~(\ref{new.delete.single}) and
-\indextext{operator |see{\tcode{delete}}}%
 \indextext{\idxcode{operator delete}}%
-\tcode{operator delete[]()} for arrays~(\ref{new.delete.array}). A \Cpp
+\tcode{operator delete[]} for arrays~(\ref{new.delete.array}). A \Cpp
 program can provide alternative definitions of these
 functions~(\ref{replacement.functions}), and/or class-specific
 versions~(\ref{class.free}).


### PR DESCRIPTION
fix naming of global deallocation functions.

Fixes #1417.