### PR TITLE
[istreambuf.iterator] Join subsections for operations descriptions.

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -3028,7 +3028,7 @@ namespace std {
 }
 \end{codeblock}
 
-\rSec3[istreambuf.iterator::proxy]{Class template \tcode{istreambuf_iterator::proxy}}
+\rSec3[istreambuf.iterator.proxy]{Class template \tcode{istreambuf_iterator::proxy}}
 
 \indexlibrary{\idxcode{proxy}!\idxcode{istreambuf_iterator}}%
 \begin{codeblock}
@@ -3114,7 +3114,7 @@ istreambuf_iterator(const proxy& p) noexcept;
 Initializes \tcode{sbuf_} with \tcode{p.sbuf_}.
 \end{itemdescr}
 
-\rSec3[istreambuf.iterator::op*]{\tcode{istreambuf_iterator::operator*}}
+\rSec3[istreambuf.iterator.ops]{\tcode{istreambuf_iterator} operations}
 
 \indexlibrarymember{operator*}{istreambuf_iterator}%
 \begin{itemdecl}
@@ -3129,8 +3129,6 @@ The character obtained via the
 member
 \tcode{sbuf_->sgetc()}.
 \end{itemdescr}
-
-\rSec3[istreambuf.iterator::op++]{\tcode{istreambuf_iterator::operator++}}
 
 \indexlibrarymember{operator++}{istreambuf_iterator}%
 \begin{itemdecl}
@@ -3158,8 +3156,6 @@ proxy operator++(int);
 \tcode{proxy(sbuf_->sbumpc(), sbuf_)}.
 \end{itemdescr}
 
-\rSec3[istreambuf.iterator::equal]{\tcode{istreambuf_iterator::equal}}
-
 \indexlibrarymember{equal}{istreambuf_iterator}%
 \begin{itemdecl}
 bool equal(const istreambuf_iterator& b) const;
@@ -3175,8 +3171,6 @@ or neither is at end-of-stream, regardless of what
 object they use.
 \end{itemdescr}
 
-\rSec3[istreambuf.iterator::op==]{\tcode{operator==}}
-
 \indexlibrarymember{operator==}{istreambuf_iterator}%
 \begin{itemdecl}
 template <class charT, class traits>
@@ -3189,8 +3183,6 @@ template <class charT, class traits>
 \returns
 \tcode{a.equal(b)}.
 \end{itemdescr}
-
-\rSec3[istreambuf.iterator::op!=]{\tcode{operator!=}}
 
 \indexlibrarymember{operator"!=}{istreambuf_iterator}%
 \begin{itemdecl}

--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -97,7 +97,7 @@
 \movedxref{string::op<=}{string.op<=}
 \movedxref{string::op>}{string.op>}
 \movedxref{string::op>=}{string.op>=}
-\movedxref{string::op!=}{string.op!=}
+% \movedxref{string::op!=}{string.op!=}
 \movedxref{string::op+}{string.op+}
 \movedxref{string::op+=}{string.op+=}
 \movedxref{string::operator==}{string.operator==}
@@ -105,3 +105,11 @@
 \movedxref{string::rfind}{string.rfind}
 \movedxref{string::substr}{string.substr}
 \movedxref{string::swap}{string.swap}
+
+% Merged sections.
+\movedxref{istreambuf.iterator::proxy}{istreambuf.iterator.proxy}
+\movedxref{istreambuf.iterator::op*}{istreambuf.iterator.ops}
+\movedxref{istreambuf.iterator::op++}{istreambuf.iterator.ops}
+\movedxref{istreambuf.iterator::equal}{istreambuf.iterator.ops}
+\movedxref{istreambuf.iterator::op==}{istreambuf.iterator.ops}
+% \movedxref{istreambuf.iterator::op!=}{istreambuf.iterator.ops}


### PR DESCRIPTION
There was one subsection for every operator, yet everything
fits on half a page.

Fixes #1429.