### PR TITLE
Replace \colcol by ::

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2956,8 +2956,8 @@ These implicit declarations introduce only the function names
 \tcode{op\-er\-a\-tor} \tcode{delete}, and \tcode{operator}
 \tcode{delete[]}. \begin{note} The implicit declarations do not introduce
 the names \tcode{std},
-\tcode{std\colcol{}size_t},
-\tcode{std\colcol{}align_val_t},
+\tcode{std::size_t},
+\tcode{std::align_val_t},
 or any other names that the library uses to
 declare these names. Thus, a \grammarterm{new-expression},
 \grammarterm{delete-expression} or function call that refers to one of
@@ -3127,13 +3127,13 @@ A pointer value is a \grammarterm{safely-derived pointer} to a dynamic object on
 has an object pointer type and it is one of the following:
 \begin{itemize}
 \item the value returned by a call to the \Cpp standard library implementation of
-\tcode{::operator new(std\colcol{}size_t)} or
-\tcode{::operator new(std\colcol{}size_t, std\colcol{}align_val_t)}%
+\tcode{::operator new(std::\brk{}size_t)} or
+\tcode{::operator new(std::size_t, std::align_val_t)}%
 ;\footnote{This section does not impose restrictions
 on indirection through pointers to memory not allocated by \tcode{::operator new}. This
 maintains the ability of many \Cpp implementations to use binary libraries and
 components written in other languages. In particular, this applies to C binaries,
-because indirection through pointers to memory allocated by \tcode{std\colcol{}malloc} is not restricted.}
+because indirection through pointers to memory allocated by \tcode{std::malloc} is not restricted.}
 
 \item the result of taking the address of an object (or one of its
   subobjects) designated by an lvalue resulting from indirection

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1231,7 +1231,7 @@ process* process::run_chain = running;
 
 The static data member \tcode{run_chain} of class
 \tcode{process} is defined in global scope; the notation
-\tcode{process\colcol{}run_chain} specifies that the member \tcode{run_chain}
+\tcode{process::run_chain} specifies that the member \tcode{run_chain}
 is a member of class \tcode{process} and in the scope of class
 \tcode{process}. In the static data member definition, the
 \grammarterm{initializer} expression refers to the static data

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -966,7 +966,7 @@ a function type or an abstract class type.
 If the
 \grammarterm{constant-expression}
 (\ref{expr.const}) is present, it shall be a converted constant
-expression of type \tcode{std\colcol{}size_t} and
+expression of type \tcode{std::size_t} and
 its value shall be greater than zero.
 The constant expression specifies the
 \indextext{array!bound}%

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3117,11 +3117,11 @@ to the associated array type.
 \pnum
 Every \grammarterm{constant-expression} in a
 \grammarterm{noptr-new-declarator} shall be a converted constant
-expression~(\ref{expr.const}) of type \tcode{std\colcol{}size_t} and
+expression~(\ref{expr.const}) of type \tcode{std::size_t} and
 shall evaluate to a strictly positive value.
 \indextext{\idxcode{new}}%
 The \grammarterm{expression} in a \grammarterm{noptr-new-declarator} is
-implicitly converted to \tcode{std\colcol{}size_t}.
+implicitly converted to \tcode{std::size_t}.
 \begin{example}
 Given the definition \tcode{int n = 42},
 \tcode{new float[n][5]} is well-formed (because \tcode{n} is the
@@ -3279,7 +3279,7 @@ When a \grammarterm{new-expression} calls an allocation function and that
 allocation has not been extended, the
 \grammarterm{new-expression} passes the amount of space requested to the
 allocation function as the first argument of type
-\tcode{std\colcol{}size_t}. That argument shall be no less than the size
+\tcode{std::size_t}. That argument shall be no less than the size
 of the object being created; it may be greater than the size of the
 object being created only if the object is an array. For arrays of
 \tcode{char} and \tcode{unsigned char}, the difference between the
@@ -3469,7 +3469,7 @@ the lookup finds a single matching deallocation function, that function
 will be called; otherwise, no deallocation function will be called. If
 the lookup finds a usual deallocation
 function
-with a parameter of type \tcode{std\colcol{}size_t}~(\ref{basic.stc.dynamic.deallocation})
+with a parameter of type \tcode{std::size_t}~(\ref{basic.stc.dynamic.deallocation})
 and that function,
 considered as a placement deallocation function, would have been
 selected as a match for the allocation function, the program is
@@ -3662,7 +3662,7 @@ the function to be called is selected as follows:
 \begin{itemize}
 \item
 If the type has new-extended alignment,
-a function with a parameter of type \tcode{std\colcol{}align_val_t} is preferred;
+a function with a parameter of type \tcode{std::align_val_t} is preferred;
 otherwise a function without such a parameter is preferred.
 If exactly one preferred function is found,
 that function is selected and the selection process terminates.
@@ -3670,15 +3670,15 @@ If more than one preferred function is found,
 all non-preferred functions are eliminated from further consideration.
 \item
 If the deallocation functions have class scope,
-the one without a parameter of type \tcode{std\colcol{}size_t} is selected.
+the one without a parameter of type \tcode{std::size_t} is selected.
 \item
 If the type is complete and if, for the second alternative (delete
 array) only, the operand is a pointer to a class type with a
 non-trivial destructor or a (possibly multi-dimensional) array thereof,
-the function with a parameter of type \tcode{std\colcol{}size_t} is selected.
+the function with a parameter of type \tcode{std::size_t} is selected.
 \item
 Otherwise, it is unspecified
-whether a deallocation function with a parameter of type \tcode{std\colcol{}size_t}
+whether a deallocation function with a parameter of type \tcode{std::size_t}
 is selected.
 \end{itemize}
 
@@ -3687,12 +3687,12 @@ When a \grammarterm{delete-expression}
 is executed, the selected deallocation function shall be called with
 the address of the block of storage to be reclaimed as its first argument.
 If a deallocation function
-with a parameter of type \tcode{std\colcol{}align_val_t}
+with a parameter of type \tcode{std::align_val_t}
 is used,
 the alignment of the type of the object to be deleted
 is passed as the corresponding argument.
 If a deallocation function
-with a parameter of type \tcode{std\colcol{}size_t}
+with a parameter of type \tcode{std::size_t}
 is used,
 the size of the block
 is passed as the corresponding argument.%
@@ -4682,7 +4682,7 @@ If no exception is presently being handled,
 evaluating a
 \grammarterm{throw-expression}
 with no operand calls
-\tcode{std\colcol{}terminate()}~(\ref{except.terminate}).
+\tcode{std::\brk{}terminate()}~(\ref{except.terminate}).
 
 \rSec1[expr.ass]{Assignment and compound assignment operators}%
 \indextext{expression!assignment and compound assignment}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -2219,7 +2219,7 @@ If
 then
 \tcode{state == rdstate()};
 otherwise
-\tcode{rdstate() == (state | ios_base\colcol{}badbit)}.
+\tcode{rdstate() == (state | ios_base::badbit)}.
 
 \pnum
 \effects
@@ -3251,7 +3251,7 @@ If the input sequence read position is not available,
 returns
 \tcode{underflow()}.
 Otherwise, returns
-\tcode{traits\colcol{}to_int_type(*gptr())}.
+\tcode{traits::to_int_type(*gptr())}.
 \end{itemdescr}
 
 \indexlibrarymember{sgetn}{basic_streambuf}%
@@ -7650,9 +7650,9 @@ controlled sequences, if possible, as indicated in Table~\ref{tab:iostreams.seek
 
 \begin{libtab2}{\tcode{seekoff} positioning}{tab:iostreams.seekoff.positioning}
 {p{2.5in}l}{Conditions}{Result}
-\tcode{(which \& ios_base\colcol{}in)}\tcode{ == ios_base::in}  &
+\tcode{(which \& ios_base::in)}\tcode{ == ios_base::in}  &
  positions the input sequence \\ \rowsep
-\tcode{(which \& ios_base\colcol{}out)}\tcode{ == ios_base::out}  &
+\tcode{(which \& ios_base::out)}\tcode{ == ios_base::out}  &
  positions the output sequence  \\ \rowsep
 \tcode{(which \& (ios_base::in |}\br
 \tcode{ios_base::out)) ==}\br
@@ -8466,7 +8466,7 @@ An instance of
 behaves as described in~\ref{filebuf} provided
 \tcode{traits::pos_type}
 is
-\tcode{fpos<traits\colcol{}state_type>}.
+\tcode{fpos<traits::\brk{}state_type>}.
 Otherwise the behavior is undefined.
 
 \pnum

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -3052,7 +3052,7 @@ is for exposition only.
 An implementation is permitted to provide equivalent functionality without
 providing a class with this name.
 Class
-\tcode{istreambuf_iterator<charT, traits>\colcol{}proxy}
+\tcode{istreambuf_iterator<charT, traits>::proxy}
 provides a temporary
 placeholder as the return value of the post-increment operator
 (\tcode{operator++}).

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -897,7 +897,7 @@ setlocale(LC_ALL, loc.name().c_str());
 otherwise, the effect on the C locale, if any, is \impldef{effect on C locale of calling
 \tcode{locale::global}}.
 No library function other than
-\tcode{locale\colcol{}global()}
+\tcode{locale::global()}
 shall affect the value returned by
 \tcode{locale()}.
 \begin{note} See~\ref{c.locales} for data race considerations when
@@ -2699,7 +2699,7 @@ and
 value
 \tcode{state}.
 The specialization
-\tcode{codecvt<char, char, mbstate_t>\colcol{}do_max_length()}
+\tcode{codecvt<char, char, mbstate_t>::do_max_length()}
 returns 1.
 \end{itemdescr}
 
@@ -5385,7 +5385,7 @@ A value that may be passed to
 \tcode{get()}
 to retrieve a message from the message catalog identified by the string
 \tcode{name} according to an \impldef{mapping from name to catalog when calling
-\tcode{mes\-sages\colcol{}do_open}} mapping.
+\tcode{mes\-sages::do_open}} mapping.
 The result can be used until it is passed to
 \tcode{close()}.
 

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -167,8 +167,6 @@
 %%--------------------------------------------------
 %% allow line break if needed for justification
 \newcommand{\brk}{\discretionary{}{}{}}
-%  especially for scope qualifier
-\newcommand{\colcol}{\brk::\brk}
 
 %%--------------------------------------------------
 %% Macros for funky text

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -1439,7 +1439,7 @@ that entity is characterized:
  \item
    otherwise
    as \techterm{integral} or equivalently as \techterm{integer-valued},
-   if \tcode{numeric_limits<T>\colcol{}is_integer} is \tcode{true};
+   if \tcode{numeric_limits<T>::is_integer} is \tcode{true};
  \item
    otherwise
    as \techterm{floating} or equivalently as \techterm{real-valued}.
@@ -2023,7 +2023,7 @@ according to Clause~\ref{strings} and Clause~\ref{input.output}.
 \indextext{\idxcode{operator<<}!random number engine requirement}
   & reference to the type of \tcode{os}
   & With \tcode{os.}\textit{fmtflags} set to
-    \tcode{ios_base\colcol{}dec|ios_base\colcol{}left}
+    \tcode{ios_base::dec|ios_base::left}
     and the fill character set to the space character,
     writes to \tcode{os}
     the textual representation
@@ -2432,8 +2432,8 @@ according to Clauses~\ref{strings} and \ref{input.output}.
     If bad input is encountered,
     ensures that \tcode{d} is unchanged by the operation
     and
-    calls \tcode{is.setstate(ios\colcol{}failbit)}
-    (which may throw \tcode{ios\colcol{}failure}~[\ref{iostate.flags}]).
+    calls \tcode{is.setstate(ios::failbit)}
+    (which may throw \tcode{ios::failure}~[\ref{iostate.flags}]).
 
     \requires \tcode{is} provides a textual representation
     that was previously written
@@ -2805,7 +2805,7 @@ If the template parameter
 the modulus $m$
 used throughout this section~\ref{rand.eng.lcong}
 \indextext{\idxcode{linear_congruential_engine}!modulus}
-is \tcode{numeric_limits<result_type>\colcol{}max()} plus $1$.
+is \tcode{numeric_limits<result_type>::max()} plus $1$.
 \begin{note}
  $m$ need not be representable
  as a value of type \tcode{result_type}.
@@ -4206,7 +4206,7 @@ template<class RealType, size_t bits, class URBG>
    to avoid any attempt
    to produce more bits of randomness
    than can be held in \tcode{RealType}.}
-   is the lesser of \tcode{numeric_limits<RealType>\colcol{}digits}
+   is the lesser of \tcode{numeric_limits<RealType>::digits}
                 and \tcode{bits},
  and
    $R$ is the value of $ \tcode{g.max()} - \tcode{g.min()} + 1 $.
@@ -4432,7 +4432,7 @@ explicit uniform_real_distribution(RealType a = 0.0, RealType b = 1.0);
 \pnum\requires
  $ \tcode{a} \leq \tcode{b} $
  and
- $ \tcode{b} - \tcode{a} \leq \tcode{numeric_limits<RealType>\colcol{}max()} $.
+ $ \tcode{b} - \tcode{a} \leq \tcode{numeric_limits<RealType>::max()} $.
 
 \pnum\effects Constructs a \tcode{uniform_real_distribution} object;
  \tcode{a} and \tcode{b}

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1282,7 +1282,7 @@ implementation or the integer literal \tcode{0} if it is not.
 
 \indextext{__STDCPP_DEFAULT_NEW_ALIGNMENT__@\mname{STDCPP_DEFAULT_NEW_ALIGNMENT}}%
 \item \mname{STDCPP_DEFAULT_NEW_ALIGNMENT}\\
-An integer literal of type \tcode{std\colcol{}size_t}
+An integer literal of type \tcode{std::size_t}
 whose value is the alignment guaranteed
 by a call to \tcode{operator new(std::size_t)}
 or \tcode{operator new[](std::size_t)}.

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -4251,7 +4251,7 @@ object is destroyed.
 If the function extracts no characters, it calls
 \tcode{is.setstate(ios::failbit)},
 which may throw
-\tcode{ios_base\colcol{}fail\-ure}~(\ref{iostate.flags}).
+\tcode{ios_base::fail\-ure}~(\ref{iostate.flags}).
 
 \pnum
 \returns
@@ -4307,7 +4307,7 @@ end-of-file occurs on the input sequence
 (in which case, the
 \tcode{getline}
 function calls
-\tcode{is.setstate(\brk{}ios_base\colcol{}eofbit)}).
+\tcode{is.setstate(\brk{}ios_base::eofbit)}).
 \item
 \tcode{traits::eq(c, delim)}
 for the next available input character
@@ -4320,7 +4320,7 @@ is extracted but not appended)~(\ref{iostate.flags})
 characters are stored
 (in which case,
 the function calls
-\tcode{is.setstate(ios_base\colcol{}fail\-bit))}~(\ref{iostate.flags})
+\tcode{is.setstate(ios_base::fail\-bit))}~(\ref{iostate.flags})
 \end{itemize}
 
 \pnum
@@ -4332,9 +4332,9 @@ object is destroyed.
 
 \pnum
 If the function extracts no characters, it calls
-\tcode{is.setstate(ios_base\colcol{}fail\-bit)}
+\tcode{is.setstate(ios_base::fail\-bit)}
 which may throw
-\tcode{ios_base\colcol{}fail\-ure}~(\ref{iostate.flags}).
+\tcode{ios_base::fail\-ure}~(\ref{iostate.flags}).
 
 \pnum
 \returns

--- a/source/support.tex
+++ b/source/support.tex
@@ -1854,9 +1854,9 @@ replacing both deallocation functions when replacing the allocation function.
 its value shall represent the address of
 a block of memory allocated by
 an earlier call to a (possibly replaced)
-\tcode{operator new(std\colcol{}size_t)}
+\tcode{operator new(std::size_t)}
 or
-\tcode{operator new(std\colcol{}size_t, std\colcol{}align_val_t)}
+\tcode{operator new(std::size_t, std::align_val_t)}
 which has not been invalidated by an intervening call to
 \tcode{operator delete}.
 
@@ -2108,9 +2108,9 @@ replacing both deallocation functions when replacing the allocation function.
 its value shall represent the address of
 a block of memory allocated by
 an earlier call to a (possibly replaced)
-\tcode{operator new[](std\colcol{}size_t)}
+\tcode{operator new[](std::size_t)}
 or
-\tcode{operator new[](std\colcol{}size_t, std\colcol{}align_val_t)}
+\tcode{operator new[](std::size_t, std::align_val_t)}
 which has not been invalidated by an intervening call to
 \tcode{operator delete[]}.
 


### PR DESCRIPTION
Explicit line-break hints are added after the :: where necessary.

Fixes #1359.