### PR TITLE
Consistently use bold font for table headers.

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -1192,12 +1192,12 @@ The following operations perform arithmetic computations. The key, operator, and
 \begin{floattable}
 {Atomic arithmetic computations}{tab:atomic.arithmetic.computations}{lll|lll}
 \hline
-\tcode{Key}       &
-  Op          &
-  Computation     &
-\tcode{Key}       &
-  Op          &
-  Computation     \\ \hline
+\hdstyle{\tcode{\placeholder{key}}}   &
+  \hdstyle{Op}                        &
+  \hdstyle{Computation}               &
+\hdstyle{\tcode{\placeholder{key}}}   &
+  \hdstyle{Op}                        &
+  \hdstyle{Computation}  \\ \hline
 \tcode{add}       &
   \tcode{+}       &
   addition        &

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1313,7 +1313,7 @@ and the types they specify.
 {tab:simple.type.specifiers}
 {ll}
 \topline
-Specifier(s)                    &   Type                 \\ \capsep
+\hdstyle{Specifier(s)}          &   \hdstyle{Type}          \\ \capsep
 \grammarterm{type-name}         &   the type named          \\
 \grammarterm{simple-template-id}    &   the type as defined in~\ref{temp.names}   \\
 \grammarterm{template-name}     & placeholder for a type to be deduced\\

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1435,7 +1435,7 @@ signatures is called using the default argument~(\ref{dcl.fct.default}).
 \begin{concepttable}{\tcode{EqualityComparable} requirements}{equalitycomparable}
 {x{1in}x{1in}p{3in}}
 \topline
-Expression  &   Return type &   \multicolumn{1}{c|}{Requirement} \\ \capsep
+\hdstyle{Expression}  &   \hdstyle{Return type} &   \rhdr{Requirement} \\ \capsep
 \tcode{a == b}  &
 convertible to \tcode{bool} &
 \tcode{==} is an equivalence relation,
@@ -1454,7 +1454,7 @@ If \tcode{a == b} and \tcode{b == c}, then \tcode{a == c}.
 \begin{concepttable}{\tcode{LessThanComparable} requirements}{lessthancomparable}
 {x{1in}x{1in}p{3in}}
 \topline
-Expression  &   Return type &   Requirement \\ \capsep
+\hdstyle{Expression}  &   \hdstyle{Return type} &   \hdstyle{Requirement} \\ \capsep
 \tcode{a < b}   &
 convertible to \tcode{bool} &
 \tcode{<} is a strict weak ordering relation~(\ref{alg.sorting})    \\
@@ -1465,7 +1465,7 @@ convertible to \tcode{bool} &
 \begin{concepttable}{\tcode{DefaultConstructible} requirements}{defaultconstructible}
 {x{2.15in}p{3in}}
 \topline
-Expression        &     Post-condition  \\ \capsep
+\hdstyle{Expression}        &     \hdstyle{Post-condition}  \\ \capsep
 \tcode{T t;}      &     object \tcode{t} is default-initialized   \\ \rowsep
 \tcode{T u\{\};}    &     object \tcode{u} is value-initialized or aggregate-initialized \\ \rowsep
 \tcode{T()}\br\tcode{T\{\}}  &  an object of type \tcode{T} is value-initialized
@@ -1476,7 +1476,7 @@ Expression        &     Post-condition  \\ \capsep
 \begin{concepttable}{\tcode{MoveConstructible} requirements}{moveconstructible}
 {p{1in}p{4.15in}}
 \topline
-Expression          &   Post-condition  \\ \capsep
+\hdstyle{Expression}          &   \hdstyle{Post-condition}  \\ \capsep
 \tcode{T u = rv;}    &   \tcode{u} is equivalent to the value of \tcode{rv} before the construction\\ \rowsep
 \tcode{T(rv)}       &
   \tcode{T(rv)} is equivalent to the value of \tcode{rv} before the construction \\ \rowsep
@@ -1491,7 +1491,7 @@ Expression          &   Post-condition  \\ \capsep
 \begin{concepttable}{\tcode{CopyConstructible} requirements (in addition to \tcode{MoveConstructible})}{copyconstructible}
 {p{1in}p{4.15in}}
 \topline
-Expression          &   Post-condition  \\ \capsep
+\hdstyle{Expression}          &   \hdstyle{Post-condition}  \\ \capsep
 \tcode{T u = v;}     &   the value of \tcode{v} is unchanged and is equivalent to \tcode{ u}\\ \rowsep
 \tcode{T(v)}        &
   the value of \tcode{v} is unchanged and is equivalent to \tcode{T(v)} \\
@@ -1501,7 +1501,7 @@ Expression          &   Post-condition  \\ \capsep
 \begin{concepttable}{\tcode{MoveAssignable} requirements}{moveassignable}
 {p{1in}p{1in}p{1in}p{1.9in}}
 \topline
-Expression      &   Return type &   Return value    &   Post-condition  \\ \capsep
+\hdstyle{Expression} & \hdstyle{Return type} & \hdstyle{Return value} & \hdstyle{Post-condition} \\ \capsep
 \tcode{t = rv}  &   \tcode{T\&} &   \tcode{t}       &
   If \tcode{t} and \tcode{rv} do not refer to the same object,
   \tcode{t} is equivalent to the value of \tcode{rv} before the assignment\\ \rowsep
@@ -1517,7 +1517,7 @@ Expression      &   Return type &   Return value    &   Post-condition  \\ \caps
 \begin{concepttable}{\tcode{CopyAssignable} requirements (in addition to \tcode{MoveAssignable})}{copyassignable}
 {p{1in}p{1in}p{1in}p{1.9in}}
 \topline
-Expression  &   Return type &   Return value    &   Post-condition  \\ \capsep
+\hdstyle{Expression} & \hdstyle{Return type} & \hdstyle{Return value} & \hdstyle{Post-condition} \\ \capsep
 \tcode{t = v}   &   \tcode{T\&} &   \tcode{t}   &   \tcode{t} is equivalent to \tcode{v}, the value of \tcode{v} is unchanged\\
 \end{concepttable}
 
@@ -1525,7 +1525,7 @@ Expression  &   Return type &   Return value    &   Post-condition  \\ \capsep
 \begin{concepttable}{\tcode{Destructible} requirements}{destructible}
 {p{1in}p{4.15in}}
 \topline
-Expression      &   Post-condition  \\ \capsep
+\hdstyle{Expression}      &   \hdstyle{Post-condition}  \\ \capsep
 \tcode{u.\~T()} &   All resources owned by \tcode{u} are reclaimed, no exception is propagated. \\
 \end{concepttable}
 

--- a/source/tables.tex
+++ b/source/tables.tex
@@ -91,9 +91,9 @@
 {
  \begin{floattablebase}{#1}{#2}{cc|cc|cc}{htbp}
  \topline
- #3   &   #4    &
- #3   &   #4    &
- #3   &   #4    \\ \capsep
+ \hdstyle{#3}   &   \hdstyle{#4}    &
+ \hdstyle{#3}   &   \hdstyle{#4}    &
+ \hdstyle{#3}   &   \hdstyle{#4}    \\ \capsep
 }
 {
  \end{floattablebase}


### PR DESCRIPTION
For consistency with the other tables.

[diffs.pdf](http://eel.is/tableheaders.pdf)

In Table 140, I also changed the capitalization and italicization of the 'key' placeholder to match its appearance in the subsequent itemdecl.