### PR TITLE
[alg.min.max] Make lfloor/rfloor delimiters stretchable.

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -5190,7 +5190,7 @@ in \range{first}{last} such that no iterator in the range refers to a larger ele
 \pnum
 \complexity
 At most
-$\max(\lfloor{\frac{3}{2}} (N-1)\rfloor, 0)$
+$\max(\bigl\lfloor{\frac{3}{2}} (N-1)\bigr\rfloor, 0)$
 applications of the corresponding predicate, where $N$ is \tcode{last - first}.
 \end{itemdescr}
 


### PR DESCRIPTION
Effect:
![diff](http://eel.is/floor.png)
Unfortunately, while this stretches the \lfloor/\rfloor nicely, it also seems to introduce some extra space before the comma. Anybody know a trick to avoid that?