### PR TITLE
Harmonize punctuation for 'ill-formed, no diagnostic required'

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -891,7 +891,7 @@ if no argument values exist such that
 an invocation of the function or constructor could be an evaluated subexpression of a core
 constant expression~(\ref{expr.const}), or,
 for a constructor, a constant initializer for some object~(\ref{basic.start.static}),
-the program is ill-formed; no diagnostic required.
+the program is ill-formed, no diagnostic required.
 \begin{example}
 \begin{codeblock}
 constexpr int f(bool b)
@@ -923,8 +923,7 @@ constructor, even though a call to such a function cannot appear in a constant
 expression. If no specialization of the template would satisfy the
 requirements for a constexpr function or constexpr constructor
 when considered as a non-template function or constructor, the template is
-ill-formed; no diagnostic
-required.
+ill-formed, no diagnostic required.
 
 \pnum
 A call to a constexpr function produces the same result as a call to an equivalent
@@ -3827,7 +3826,7 @@ in different translation units.
 struct S { int x; } s, *p = &s;
 
 // Translation unit \#2:
-struct alignas(16) S;           // error: definition of \tcode{S} lacks alignment; no diagnostic required
+struct alignas(16) S;           // error: definition of \tcode{S} lacks alignment, no diagnostic required
 extern S* p;
 \end{codeblock}
 \end{example}
@@ -3881,7 +3880,7 @@ specifies the \tcode{carries_dependency} attribute for that parameter. If a func
 parameters is declared with the \tcode{carries_dependency} attribute in its first declaration in one
 translation unit and the same function or one of its parameters is declared without the
 \tcode{carries_dependency} attribute in its first declaration in another translation unit, the
-program is ill-formed; no diagnostic required.
+program is ill-formed, no diagnostic required.
 
 \pnum
 \begin{note} The \tcode{carries_dependency} attribute does not change the meaning of the
@@ -4119,7 +4118,7 @@ shall appear at most once in each \grammarterm{attribute-list} and no
 specify the \tcode{noreturn} attribute if any declaration of that function specifies the
 \tcode{noreturn} attribute. If a function is declared with the \tcode{noreturn} attribute in one
 translation unit and the same function is declared without the \tcode{noreturn} attribute in another
-translation unit, the program is ill-formed; no diagnostic required.
+translation unit, the program is ill-formed, no diagnostic required.
 
 \pnum
 If a function \tcode{f} is called where \tcode{f} was previously declared with the \tcode{noreturn}

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -3303,7 +3303,7 @@ the \grammarterm{identifier} in a \grammarterm{literal-operator-id} is called a
 \term{literal suffix identifier}.
 Some literal suffix identifiers are reserved for future standardization;
 see~\ref{usrlit.suffix}.  A declaration whose \grammarterm{literal-operator-id} uses
-such a literal suffix identifier is ill-formed; no diagnostic required.
+such a literal suffix identifier is ill-formed, no diagnostic required.
 
 \pnum
 A declaration whose \grammarterm{declarator-id} is a

--- a/source/special.tex
+++ b/source/special.tex
@@ -1690,7 +1690,7 @@ is a \term{delegating constructor}, and the constructor selected by the
 The target constructor is selected by overload resolution.
 Once the target constructor returns, the body of the delegating constructor
 is executed. If a constructor delegates to itself directly or indirectly,
-the program is ill-formed; no diagnostic is required. \begin{example}
+the program is ill-formed, no diagnostic required. \begin{example}
 
 \begin{codeblock}
 struct C {

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1126,8 +1126,8 @@ specialization based on the template
 \grammarterm{template-parameter}
 is instantiated.
 If a specialization is not visible at the point of instantiation,
-and it would have been selected had it been visible, the program is ill-formed;
-no diagnostic is required.
+and it would have been selected had it been visible, the program is ill-formed,
+no diagnostic required.
 \begin{example}
 
 \begin{codeblock}
@@ -2719,8 +2719,8 @@ lists are functionally equivalent using the rules described above to
 compare expressions involving
 template parameters.
 If a program contains declarations of function templates that are
-functionally equivalent but not equivalent, the program is ill-formed;
-no diagnostic is required.
+functionally equivalent but not equivalent, the program is ill-formed,
+no diagnostic required.
 
 \pnum
 \begin{note}


### PR DESCRIPTION
Fixes #1450.