### PR TITLE
[any] Use 'contained value' consistently.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -4169,7 +4169,7 @@ Any instance of \tcode{variant} at any given time either holds a value
 of one of its alternative types, or it holds no value.
 When an instance of \tcode{variant} holds a value of alternative type \tcode{T},
 it means that a value of type \tcode{T}, referred to as the \tcode{variant}
-object's contained value, is allocated within the storage of the
+object's \defnx{contained value}{contained value!\idxcode{variant}}, is allocated within the storage of the
 \tcode{variant} object.
 Implementations are not permitted to use additional storage, such as dynamic
 memory, to allocate the contained value.
@@ -5410,14 +5410,14 @@ public:
 \pnum
 An object of class \tcode{any} stores an instance of any type that satisfies the constructor requirements or it has no value,
 and this is referred to as the \defn{state} of the class \tcode{any} object.
-The stored instance is called the \defn{contained object}.
-Two states are equivalent if either they both have no value, or both have a value and the contained objects are equivalent.
+The stored instance is called the \defnx{contained value}{contained value!\idxcode{any}},
+Two states are equivalent if either they both have no value, or both have a value and the contained values are equivalent.
 
 \pnum
-The non-member \tcode{any_cast} functions provide type-safe access to the contained object.
+The non-member \tcode{any_cast} functions provide type-safe access to the contained value.
 
 \pnum
-Implementations should avoid the use of dynamically allocated memory for a small contained object.
+Implementations should avoid the use of dynamically allocated memory for a small contained value.
 \begin{example}
 where the object constructed is holding only an \tcode{int}.
 \end{example}
@@ -5449,7 +5449,7 @@ Constructs an object of type \tcode{any} with an equivalent state as \tcode{othe
 
 \pnum
 \throws
-Any exceptions arising from calling the selected constructor of the contained object.
+Any exceptions arising from calling the selected constructor for the contained value.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{any}!constructor}%
@@ -5587,7 +5587,7 @@ No effects if an exception is thrown.
 
 \pnum
 \throws
-Any exceptions arising from the copy constructor of the contained object.
+Any exceptions arising from the copy constructor for the contained value.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{any}%
@@ -5673,7 +5673,7 @@ an object of type \tcode{VT} with the arguments \tcode{std::forward<Args>(args).
 
 \pnum
 \remarks If an exception is thrown during the call to \tcode{VT}'s constructor,
-\tcode{*this} does not contain a value, and any previously contained object
+\tcode{*this} does not contain a value, and any previously contained value
 has been destroyed.
 This function shall not participate in overload resolution unless
 \tcode{is_copy_constructible_v<VT>} is \tcode{true} and
@@ -5707,7 +5707,7 @@ as if direct-non-list-initializing an object of type \tcode{VT} with the argumen
 
 \pnum
 \remarks If an exception is thrown during the call to \tcode{VT}'s constructor,
-\tcode{*this} does not contain a value, and any previously contained object
+\tcode{*this} does not contain a value, and any previously contained value
 has been destroyed.
 The function shall not participate in overload resolution unless
 \tcode{is_copy_constructible_v<VT>} is \tcode{true} and
@@ -5722,7 +5722,7 @@ void reset() noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-If \tcode{has_value()} is \tcode{true}, destroys the contained object.
+If \tcode{has_value()} is \tcode{true}, destroys the contained value.
 
 \pnum
 \postconditions
@@ -5762,7 +5762,7 @@ const type_info& type() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{typeid(T)} if \tcode{*this} has a contained object of type \tcode{T},
+\tcode{typeid(T)} if \tcode{*this} has a contained value of type \tcode{T},
 otherwise \tcode{typeid(void)}.
 
 \pnum


### PR DESCRIPTION
This harmonizes the use of 'constained value' across
optional, variant, and any, with appropriate index
entries.

Fixes #1401.