### PR TITLE
Fix index entries for 'nested/local class'.

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1387,12 +1387,11 @@ void f() {
 
 \rSec2[class.nest]{Nested class declarations}%
 \indextext{definition!nested class}%
-\indextext{class local|see{local class}}%
-\indextext{class nested|see{nested class}}
+\indextext{class!nested|see{nested class}}
 
 \pnum
 A class can be declared within another class. A class declared within
-another is called a \grammarterm{nested} class. The name of a nested class
+another is called a \defnx{nested}{nested class} class. The name of a nested class
 is local to its enclosing class.
 \indextext{nested class!scope of}%
 The nested class is in the scope of its enclosing class.
@@ -1757,10 +1756,11 @@ union U {
 \rSec1[class.local]{Local class declarations}
 \indextext{declaration!local class}%
 \indextext{definition!local class}%
+\indextext{class!local|see{local class}}%
 
 \pnum
 A class can be declared within a function definition; such a class is
-called a \grammarterm{local} class. The name of a local class is local to
+called a \defnx{local}{local class} class. The name of a local class is local to
 its enclosing scope.
 \indextext{local class!scope of}%
 The local class is in the scope of the enclosing scope, and has the same


### PR DESCRIPTION
- Changes the peculiar redirection entries "class nested" and "class local" to the more conventional "class, nested" and "class, local".
- Adds main index entries for "local class" and "nested class" (fixing some abuse of \grammarterm in the process)

[diffs.pdf](http://eel.is/classindex.pdf)