### PR TITLE
Fix cross-reference for 'inline'.

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -806,7 +806,7 @@ pointer-interconvertible~(\ref{basic.compound}, \ref{expr.static.cast}).
 \indextext{definition!member function}%
 A member function may be defined~(\ref{dcl.fct.def}) in its class
 definition, in which case it is an \term{inline} member
-function~(\ref{dcl.fct.spec}), or it may be defined outside of its class
+function~(\ref{dcl.inline}), or it may be defined outside of its class
 definition if it has already been declared but not defined in its class
 definition. A member function definition that appears outside of the
 class definition shall appear in a namespace scope enclosing the class
@@ -832,7 +832,7 @@ See~\ref{basic.link}.
 There can be at most one definition of a non-inline member function in
 a program. There may be more than one
 \tcode{inline} member function definition in a program.
-See~\ref{basic.def.odr} and~\ref{dcl.fct.spec}.
+See~\ref{basic.def.odr} and~\ref{dcl.inline}.
 \end{note}
 
 \pnum

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -985,7 +985,7 @@ the implementation that inline substitution of the function body at the
 point of call is to be preferred to the usual function call mechanism.
 An implementation is not required to perform this inline substitution at
 the point of call; however, even if this inline substitution is omitted,
-the other rules for inline functions defined by~\ref{dcl.fct.spec} shall
+the other rules for inline functions specified in this section shall
 still be respected.
 
 \pnum

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2686,7 +2686,7 @@ explicitly stated otherwise.
 It is unspecified whether any
 non-member
 functions in the \Cpp standard library are defined as
-\tcode{inline}~(\ref{dcl.fct.spec}).
+\tcode{inline}~(\ref{dcl.inline}).
 
 \pnum
 A call to a non-member function signature
@@ -2724,7 +2724,7 @@ return *this;
 
 \pnum
 It is unspecified whether any member functions in the \Cpp standard library are defined as
-\tcode{inline}~(\ref{dcl.fct.spec}).
+\tcode{inline}~(\ref{dcl.inline}).
 
 \pnum
 For a non-virtual member function described in the \Cpp standard library,


### PR DESCRIPTION
The 'inline' specifier is defined in [dcl.inline];
adjust cross-references still pointing to [dcl.fct.spec].

Fixes #1458.