### PR TITLE
[dcl.attr.nodiscard] Clarify example with reference return type.

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4104,7 +4104,8 @@ void test_missiles() {
   launch_missiles();
 }
 error_info &foo();
-void f() { foo(); }             // reference type, warning not encouraged
+void f() { foo(); }             // warning not encouraged: not a nodiscard call, because neither
+                                // the (reference) return type nor the function is declared nodiscard
 \end{codeblock}
 \end{example}
 


### PR DESCRIPTION
Add rationale why a warning is not encouraged for this case.

Fixes #1470.