### PR TITLE
Add Travis CI check for whitespace at the ends of lines.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,12 +38,8 @@ script:
   - popd
   # Fail if there is whitespace at the ends of any lines
   - if [ "$BUILD_TYPE" = "check-whitespace" ]; then
-      export TEST_STATUS=0;
-      grep '\s$' source/*.tex && export TEST_STATUS=1;
-    fi;
-    if [ "0$TEST_STATUS" != "00" ]; then
-      false;
-    fi;
+      ! grep '\s$' source/*.tex;
+    fi
   # Check to see if generated files are out-dated
   - pushd source
   - for FIGURE in *.dot; do

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   - BUILD_TYPE=make      # build using Makefile
   - BUILD_TYPE=manual    # build manually
   - BUILD_TYPE=complete  # build manually and regenerate figures, grammer, and cross-references
+  - BUILD_TYPE=check-whitespace  # check for whitespace at the ends of lines
 
 script:
   # Build std.pdf
@@ -35,6 +36,14 @@ script:
       pdflatex std;
     fi
   - popd
+  # Fail if there is whitespace at the ends of any lines
+  - if [ "$BUILD_TYPE" = "check-whitespace" ]; then
+      export TEST_STATUS=0;
+      grep '\s$' source/*.tex && export TEST_STATUS=1;
+    fi;
+    if [ "0$TEST_STATUS" != "00" ]; then
+      false;
+    fi;
   # Check to see if generated files are out-dated
   - pushd source
   - for FIGURE in *.dot; do


### PR DESCRIPTION
Per @tkoeppe's [suggestion](https://github.com/cplusplus/draft/pull/1468#issuecomment-280022177).

This adds a new build type to the Travis CI build which only checks for whitespace at the ends of lines. If it finds any, it will fail the build.

Having this test as a separate 'build type' makes it easy to determine whether the whitespace test failed or whether the PDF compilation failed.

Note: If we plan on adding more tests in the future (e.g., checks for other nonconformant usage)—which I'm in favor of—then I'd recommend we migrate the code from `.travis-ci.yml` to a separate shell script where we can write more succinct code. (Travis CI wraps the `.travis-ci.yml` code in its own function and hijacks the exit code `$?` variable, so we have to capture it to test it later. Within our own shell script, this isn't a problem.)
