### PR TITLE
[localization, diff] Omit superfluous 'return 0;' in main.

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1114,7 +1114,6 @@ int main() {
   delete i;                     // single-object delete
   int* a = new int[3];
   delete [] a;                  // array delete
-  return 0;
 }
 \end{codeblock}
 
@@ -1323,7 +1322,6 @@ with this International Standard. For example:
 int main() {
   int flag = std::ios_base::hex;
   std::cout.setf(flag);         // error: \tcode{setf} does not take argument of type \tcode{int}
-  return 0;
 }
 \end{codeblock}
 

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -5626,7 +5626,6 @@ int main() {
   wchar_t c = use_facet<wctype>(loc).widen('!');
   if (!use_facet<My::JCtype>(loc).is_kanji(c))
     cout << "no it isn't!" << endl;
-  return 0;
 }
 \end{codeblock}
 
@@ -5667,7 +5666,6 @@ int main(int argc, char** argv) {
   locale loc(locale(""), new My::BoolNames(""));
   cout.imbue(loc);
   cout << boolalpha << "Any arguments today? " << (argc > 1) << endl;
-  return 0;
 }
 \end{codeblock}
 \end{example}


### PR DESCRIPTION
As far as I can tell, these are the only 4 occurrences (out of 33 `main` functions in the document).