### PR TITLE
Do not use code font for constexpr constructor and constexpr function

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -870,7 +870,7 @@ for a non-delegating constructor, every constructor selected to initialize non-s
 data members and base class subobjects shall be a constexpr constructor;
 
 \item
-for a delegating constructor, the target constructor shall be a \tcode{constexpr}
+for a delegating constructor, the target constructor shall be a constexpr
 constructor.
 \end{itemize}
 
@@ -916,9 +916,9 @@ struct D : B {
 If the instantiated template specialization of a constexpr function
 template
 or member function of a class template
-would fail to satisfy the requirements for a \tcode{constexpr}
+would fail to satisfy the requirements for a constexpr
 function or constexpr constructor,
-that specialization is still a constexpr function or \tcode{constexpr}
+that specialization is still a constexpr function or constexpr
 constructor, even though a call to such a function cannot appear in a constant
 expression. If no specialization of the template would satisfy the
 requirements for a constexpr function or constexpr constructor
@@ -931,7 +931,7 @@ A call to a constexpr function produces the same result as a call to an equivale
 non-constexpr function in all respects except that
 \begin{itemize}
 \item
-a call to a \tcode{constexpr}
+a call to a constexpr
 function can appear in a constant expression~(\ref{expr.const}) and
 \item
 copy elision is mandatory in a constant expression~(\ref{class.copy}).

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4878,7 +4878,7 @@ machine~(\ref{intro.execution}), would evaluate one of the following expressions
 
 \begin{itemize}
 \item
-\tcode{this}~(\ref{expr.prim.this}), except in a \tcode{constexpr}
+\tcode{this}~(\ref{expr.prim.this}), except in a constexpr
 function or a constexpr constructor that is being evaluated as part
 of \tcode{e};
 

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2746,7 +2746,7 @@ This International Standard explicitly requires that certain standard library fu
 \tcode{constexpr}~(\ref{dcl.constexpr}). An implementation shall not declare
 any standard library function signature as \tcode{constexpr} except for those where
 it is explicitly required.
-Within any header that provides any non-defining declarations of \tcode{constexpr}
+Within any header that provides any non-defining declarations of constexpr
 functions or constructors an implementation shall provide corresponding definitions.
 
 \rSec3[algorithm.stable]{Requirements for stable algorithms}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2743,7 +2743,7 @@ Any exception thrown by the selected constructor of \tcode{T}.
 
 \pnum
 \remarks
-If \tcode{T}'s constructor selected for the initialization is a constexpr constructor, this constructor shall be a \tcode{constexpr} constructor.
+If \tcode{T}'s constructor selected for the initialization is a constexpr constructor, this constructor shall be a constexpr constructor.
 This constructor shall not participate in overload resolution
 unless \tcode{is_constructible_v<T, Args...>} is \tcode{true}.
 \end{itemdescr}
@@ -2770,7 +2770,7 @@ Any exception thrown by the selected constructor of \tcode{T}.
 \pnum
 \remarks
 This constructor shall not participate in overload resolution unless \tcode{is_constructible_v<T, initializer_list<U>\&, Args\&\&...>} is \tcode{true}.
-If \tcode{T}'s constructor selected for the initialization is a constexpr constructor, this constructor shall be a \tcode{constexpr} constructor.
+If \tcode{T}'s constructor selected for the initialization is a constexpr constructor, this constructor shall be a constexpr constructor.
 \end{itemdescr}
 
 \pnum


### PR DESCRIPTION
Completes #1153, which missed entries with a newline in-between, and utilities.tex.