### PR TITLE
[lex.ccon, stmt.ranged] Fix index entries that misuse \idxcode.

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -1248,7 +1248,7 @@ character. There is no limit to the number of digits in a hexadecimal
 sequence. A sequence of octal or hexadecimal digits is terminated by the
 first character that is not an octal digit or a hexadecimal digit,
 respectively.
-\indextext{literal!implementation-defined value of \idxcode{char}}%
+\indextext{literal!implementation-defined value of char@implementation-defined value of \tcode{char}}%
 The value of a character literal is \impldef{value of character literal outside range of
 corresponding type} if it falls outside of the \impldef{range defined for character literals}
 range defined for \tcode{char} (for character literals with no prefix) or

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -609,7 +609,7 @@ int j = i;          // \tcode{j = 42}
 \end{example}
 
 \rSec2[stmt.ranged]{The range-based \tcode{for} statement}%
-\indextext{statement!range based \idxcode{for}}
+\indextext{statement!range based for@range based \tcode{for}}
 
 \pnum
 The range-based \tcode{for} statement


### PR DESCRIPTION
![diff](http://eel.is/idxcode.png)