### PR TITLE
[basic] Use less monospace in index entries.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -119,7 +119,7 @@ not affect whether a declaration is a definition.}
 (\ref{dcl.link}) and neither an \grammarterm{initializer} nor a
 \grammarterm{function-body},
 \item
-\indextext{declaration!\idxcode{static member}}%
+\indextext{declaration!static member@\tcode{static} member}%
 it declares a non-inline static data member in a class
 definition (\ref{class.mem},~\ref{class.static}),
 \item
@@ -2525,7 +2525,7 @@ thread storage duration are initialized as a consequence of thread execution.
 Within each of these phases of initiation, initialization occurs as follows.
 
 \pnum
-\indextext{initialization!\idxcode{static object}}%
+\indextext{initialization!static object@\tcode{static} object}%
 \indextext{initialization!constant}%
 A \defn{constant initializer} for an object \tcode{o} is an expression that is a
 constant expression, except that it may also invoke constexpr constructors
@@ -2856,14 +2856,14 @@ appears to be unused, except that a class object or its copy/move may be
 eliminated as specified in~\ref{class.copy}.
 
 \pnum
-\indextext{object!\idxcode{local static}}%
+\indextext{object!local static@local \tcode{static}}%
 The keyword \tcode{static} can be used to declare a local variable with
 static storage duration. \begin{note} \ref{stmt.dcl} describes the
 initialization of local \tcode{static} variables; \ref{basic.start.term}
 describes the destruction of local \tcode{static} variables. \end{note}
 
 \pnum
-\indextext{member!\idxcode{class static}}%
+\indextext{member!class static@class \tcode{static}}%
 The keyword \tcode{static} applied to a class data member in a class
 definition gives the data member static storage duration.
 


### PR DESCRIPTION
![diff](http://eel.is/idxcode2.png)

The other two are similar (but harder to show due to reflow caused by this last one.)