### PR TITLE
[dcl.init] Add index entry for direct-initialization.

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -2760,7 +2760,7 @@ functional notation type conversions~(\ref{expr.type.conv}),
 \grammarterm{mem-initializer}{s}~(\ref{class.base.init}), and
 the \grammarterm{braced-init-list} form of a \grammarterm{condition}
 is called
-\grammarterm{direct-initialization}.
+\defn{direct-initialization}.
 
 \pnum
 The semantics of initializers are as follows.


### PR DESCRIPTION
And fix \grammarterm misuse in the process.

Index entries do already exist for value-initialization, zero-initialization, list-initialization, default-initialization, and copy-initialization.