### PR TITLE
[intro] Promote "Scope", "Normative references", "Terms and definitions"

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -1,31 +1,6 @@
 %!TEX root = std.tex
-\rSec0[intro]{General}
 
-\indextext{diagnostic message|see{message, diagnostic}}%
-\indexdefn{conditionally-supported behavior|see{behavior, con\-ditionally-supported}}%
-\indextext{dynamic type|see{type, dynamic}}%
-\indextext{static type|see{type, static}}%
-\indextext{ill-formed program|see{program, ill-formed}}%
-\indextext{well-formed program|see{program, well-formed}}%
-\indextext{implementation-defined behavior|see{behavior, im\-plementation-defined}}%
-\indextext{undefined behavior|see{behavior, undefined}}%
-\indextext{unspecified behavior|see{behavior, unspecified}}%
-\indextext{implementation limits|see{limits, implementation}}%
-\indextext{locale-specific behavior|see{behavior, locale-spe\-cific}}%
-\indextext{multibyte character|see{character, multibyte}}%
-\indextext{object|seealso{object model}}%
-\indextext{subobject|seealso{object model}}%
-\indextext{derived class!most|see{most derived class}}%
-\indextext{derived object!most|see{most derived object}}%
-\indextext{program execution!as-if rule|see{as-if rule}}%
-\indextext{observable behavior|see{behavior, observable}}%
-\indextext{precedence of operator|see{operator, precedence of}}%
-\indextext{order of evaluation in expression|see{expression, order of evaluation of}}%
-\indextext{atomic operations|see{operation, atomic}}%
-\indextext{multiple threads|see{threads, multiple}}%
-\indextext{normative references|see{references, normative}}
-
-\rSec1[intro.scope]{Scope}
+\rSec0[intro.scope]{Scope}
 
 \pnum
 \indextext{scope|(}%
@@ -46,7 +21,8 @@ overloading, function name overloading, references, free store
 management operators, and additional library facilities.%
 \indextext{scope|)}
 
-\rSec1[intro.refs]{Normative references}
+\indextext{normative references|see{references, normative}}%
+\rSec0[intro.refs]{Normative references}
 
 \pnum
 \indextext{references!normative|(}%
@@ -91,7 +67,7 @@ The ECMAScript Language Specification described in Standard Ecma-262 is
 hereinafter called \defn{ECMA-262}.
 \indextext{references!normative|)}
 
-\rSec1[intro.defs]{Terms and definitions}
+\rSec0[intro.defs]{Terms and definitions}
 
 \pnum
 \indextext{definitions|(}%
@@ -111,6 +87,8 @@ through~\ref{\lastlibchapter} and Annex~\ref{depr}.
 Terms that are used only in a small portion of this International
 Standard are defined where they are used and italicized where they are
 defined.
+
+\def\definition{\definitionx{\section}}%
 
 \indexdefn{access}%
 \definition{access}{defns.access}
@@ -300,6 +278,30 @@ possible behaviors is usually delineated by this International Standard.
 semantic rules, and the one-definition rule~(\ref{basic.def.odr}).%
 \indextext{definitions|)}
 
+\rSec0[intro]{General principles}
+
+\indextext{diagnostic message|see{message, diagnostic}}%
+\indexdefn{conditionally-supported behavior|see{behavior, con\-ditionally-supported}}%
+\indextext{dynamic type|see{type, dynamic}}%
+\indextext{static type|see{type, static}}%
+\indextext{ill-formed program|see{program, ill-formed}}%
+\indextext{well-formed program|see{program, well-formed}}%
+\indextext{implementation-defined behavior|see{behavior, im\-plementation-defined}}%
+\indextext{undefined behavior|see{behavior, undefined}}%
+\indextext{unspecified behavior|see{behavior, unspecified}}%
+\indextext{implementation limits|see{limits, implementation}}%
+\indextext{locale-specific behavior|see{behavior, locale-spe\-cific}}%
+\indextext{multibyte character|see{character, multibyte}}%
+\indextext{object|seealso{object model}}%
+\indextext{subobject|seealso{object model}}%
+\indextext{derived class!most|see{most derived class}}%
+\indextext{derived object!most|see{most derived object}}%
+\indextext{program execution!as-if rule|see{as-if rule}}%
+\indextext{observable behavior|see{behavior, observable}}%
+\indextext{precedence of operator|see{operator, precedence of}}%
+\indextext{order of evaluation in expression|see{expression, order of evaluation of}}%
+\indextext{atomic operations|see{operation, atomic}}%
+\indextext{multiple threads|see{threads, multiple}}%
 \rSec1[intro.compliance]{Implementation compliance}
 
 \pnum

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -9937,37 +9937,39 @@ products.
 
 \rSec2[fs.definitions]{Terms and definitions}
 
-\definitionx{absolute path}{fs.def.absolute.path}
+\def\definition{\definitionx{\subsubsection}}%
+
+\definition{absolute path}{fs.def.absolute.path}
 A path that unambiguously
 identifies the location of a file without reference to an additional starting
 location. The elements of a path that determine if it is absolute are
 operating system dependent.
 
-\definitionx{canonical path}{fs.def.canonical.path}
+\definition{canonical path}{fs.def.canonical.path}
 An absolute path that has no elements that are symbolic links, and no \grammarterm{dot} or
 \grammarterm{dot-dot} elements~(\ref{path.generic}).
 
-\definitionx{directory}{fs.def.directory}
+\definition{directory}{fs.def.directory}
 A file within a file system that acts as a container of directory entries
 that contain information about
 other files, possibly including other directory files.
 
-\definitionx{file}{fs.def.file}
+\definition{file}{fs.def.file}
 An object within a file system that holds user or system data. Files can be written to, or read from, or both. A file
 has certain attributes, including type. File types include regular files
 and directories. Other types of files, such as symbolic links~(\ref{fs.def.symlink}),
 may be supported by the implementation.
 
-\definitionx{file system}{fs.def.filesystem}
+\definition{file system}{fs.def.filesystem}
 A collection of files and certain of their attributes.
 
-\definitionx{file system race}{fs.def.race}
+\definition{file system race}{fs.def.race}
 The condition that occurs
 when multiple threads, processes, or computers interleave access and
 modification of
 the same object within a file system.
 
-\definitionx{filename}{fs.def.filename}
+\definition{filename}{fs.def.filename}
 The name of a file. Filenames \grammarterm{dot} and \grammarterm{dot-dot} have special meaning. The
 following characteristics of filenames are operating system dependent:
 \begin{itemize}
@@ -9981,27 +9983,27 @@ following characteristics of filenames are operating system dependent:
   files, such as directories.
 \end{itemize}
 
-\definitionx{hard link}{fs.def.hardlink}
+\definition{hard link}{fs.def.hardlink}
 A link~(\ref{fs.def.link}) to an existing file. Some
 file systems support multiple hard links to a file. If the last hard link to a
 file is removed, the file itself is removed.
 \begin{note} A hard link can be thought of as a shared-ownership smart
 pointer to a file.\end{note}
 
-\definitionx{link}{fs.def.link}
+\definition{link}{fs.def.link}
 A directory entry  that associates a
 filename with a file. A link is either a hard link~(\ref{fs.def.hardlink}) or a
 symbolic link~(\ref{fs.def.symlink}).
 
-\definitionx{native encoding}{fs.def.native.encode}
+\definition{native encoding}{fs.def.native.encode}
 For narrow character strings, the operating system dependent current encoding
 for pathnames~(\ref{fs.def.pathname}). For wide character strings, the implementation-defined execution
 wide-character set encoding~(\ref{lex.charset}).
 
-\definitionx{native pathname format}{fs.def.native}
+\definition{native pathname format}{fs.def.native}
 The operating system dependent pathname format accepted by the host operating system.
 
-\definitionx{normal form}{fs.def.normal.form}
+\definition{normal form}{fs.def.normal.form}
 A path with no redundant current directory (\grammarterm{dot}) elements,
 no redundant parent directory (\grammarterm{dot-dot}) elements, and
 no redundant \grammarterm{directory-separator}{s}.
@@ -10017,20 +10019,20 @@ supports operating systems like OpenVMS
 that use different syntax for directory names and regular file names.
 \end{note}
 
-\definitionx{operating system dependent behavior}{fs.def.osdep}
+\definition{operating system dependent behavior}{fs.def.osdep}
 Behavior that is dependent upon the behavior
 and characteristics of an operating system. See~\ref{fs.conform.os}.
 
-\definitionx{parent directory}{fs.def.parent}
+\definition{parent directory}{fs.def.parent}
 \defncontext{of a directory} the directory that both contains a
 directory entry for the given directory and is represented by the filename
 \grammarterm{dot-dot} in the given directory.
 
-\definitionx{parent directory}{fs.def.parent.other}
+\definition{parent directory}{fs.def.parent.other}
 \defncontext{of other types of files} a directory containing a directory
 entry for the file under discussion.
 
-\definitionx{path}{fs.def.path}
+\definition{path}{fs.def.path}
 A sequence of elements that identify
 the location of a file within a filesystem.
 The elements are the
@@ -10039,20 +10041,20 @@ The elements are the
 and an optional sequence of filenames.
 The maximum number of elements in the sequence is operating system dependent.
 
-\definitionx{pathname}{fs.def.pathname}
+\definition{pathname}{fs.def.pathname}
 A character string that represents the name of a path. Pathnames are
 formatted according to the generic pathname format grammar~(\ref{path.generic}) or an
 operating system dependent
 native pathname format.
 
-\definitionx{pathname resolution}{fs.def.pathres}
+\definition{pathname resolution}{fs.def.pathres}
 Pathname resolution is the operating system dependent mechanism for resolving
 a pathname to a particular file in a file hierarchy. There may be multiple
 pathnames that resolve to the same file.
 \begin{example} POSIX specifies the mechanism in section 4.11, Pathname resolution.
 \end{example}
 
-\definitionx{relative path}{fs.def.relative-path}
+\definition{relative path}{fs.def.relative-path}
 A path that is not absolute, and as such, only unambiguously
 identifies the location of a file when resolved~(\ref{fs.def.pathres}) relative to
 an implied starting location. The elements of a path that determine if it is
@@ -10061,7 +10063,7 @@ relative are operating system dependent.
 Pathnames ``.'' and ``..'' are relative paths.
 \end{note}
 
-\definitionx{symbolic link}{fs.def.symlink}
+\definition{symbolic link}{fs.def.symlink}
 A type of file with the
 property that when the file is encountered during pathname resolution, a string
 stored by the file is used to modify the pathname resolution.

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -130,6 +130,8 @@ are the same unless otherwise stated.
 \pnum
 \begin{note} \ref{intro.defs} defines additional terms used elsewhere in this International Standard. \end{note}
 
+\def\definition{\definitionx{\subsection}}%
+
 \definition{arbitrary-positional stream}{defns.arbitrary.stream}
 \indexdefn{stream!arbitrary-positional}%
 a stream (described in Clause~\ref{input.output}) that can seek to any integral position within

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -512,12 +512,8 @@
 % usage: \definition{name}{xref}
 %\newcommand{\definition}[2]{\rSec2[#2]{#1}}
 % for ISO format, use:
-\newcommand{\definition}[2]{%
-\addxref{#2}%
-\subsection[#1]{\hfill[#2]}\vspace{-.3\onelineskip}\label{#2}\textbf{#1}\\%
-}
-\newcommand{\definitionx}[2]{%
-\addxref{#2}%
-\subsubsection[#1]{\hfill[#2]}\vspace{-.3\onelineskip}\label{#2}\textbf{#1}\\%
+\newcommand{\definitionx}[3]{%
+\addxref{#3}%
+#1[#2]{\hfill[#3]}\vspace{-.3\onelineskip}\label{#3}\textbf{#2}\\%
 }
 \newcommand{\defncontext}[1]{\textlangle#1\textrangle}


### PR DESCRIPTION
to top-level clauses per ISO directives.

Modify \definition macro so we can more easily have definitions at
different depths in different lists.