### PR TITLE
[macros] Remove terms-and-definitions entries from TOC and bookmarks

### DIFF
--- a/source/macros.tex
+++ b/source/macros.tex
@@ -508,12 +508,11 @@
 }
 
 %%--------------------------------------------------
-%% Definitions section
-% usage: \definition{name}{xref}
-%\newcommand{\definition}[2]{\rSec2[#2]{#1}}
-% for ISO format, use:
+%% Definitions section for "Terms and definitions"
+\newcommand{\nocontentsline}[3]{}
+\newcommand{\tocless}[2]{\bgroup\let\addcontentsline=\nocontentsline#1{#2}\egroup}
 \newcommand{\definitionx}[3]{%
 \addxref{#3}%
-#1[#2]{\hfill[#3]}\vspace{-.3\onelineskip}\label{#3}\textbf{#2}\\%
+\tocless{#1[#2]}{\hfill[#3]}\vspace{-.3\onelineskip}\label{#3}\textbf{#2}\\*%
 }
 \newcommand{\defncontext}[1]{\textlangle#1\textrangle}


### PR DESCRIPTION
Following the approach of http://stackoverflow.com/a/2785740.