### PR TITLE
[lex] Complete index redirects to 'backslash character'.

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -1200,8 +1200,8 @@ the question mark \tcode{?},\footnote{Using an escape sequence for a question ma
 is supported for compatibility with ISO \CppXIV and ISO C.}
 and the backslash
 \indextext{backslash character}%
-\indextext{\idxcode{\textbackslash}|see{backslash}}%
-\indextext{escape character|see{backslash}}%
+\indextext{\idxcode{\textbackslash}|see{backslash character}}%
+\indextext{escape character|see{backslash character}}%
 \tcode{\textbackslash}, can be represented according to
 Table~\ref{tab:escape.sequences}.
 \indextext{escape sequence!undefined}%


### PR DESCRIPTION
The redirects should probably point to the indexed phrase "backslash character" (line 1202).

(Since cxxdraft-htmlgen linkifies index redirects, this also fixes broken links on http://eel.is/c++draft/generalindex)