### PR TITLE
Consistently use repeated \indextext for index redirects with multiple targets.

### DIFF
--- a/source/conversions.tex
+++ b/source/conversions.tex
@@ -194,7 +194,8 @@ See also~\ref{basic.lval}.\end{note}
 
 \pnum
 \indextext{conversion!array-to-pointer}%
-\indextext{decay|see{conversion, array to pointer; conversion, function to pointer}}%
+\indextext{decay|see{conversion, array to pointer}}%
+\indextext{decay|see{conversion, function to pointer}}%
 An lvalue or rvalue of type ``array of \tcode{N} \tcode{T}'' or ``array
 of unknown bound of \tcode{T}'' can be converted to a prvalue of type
 ``pointer to \tcode{T}''.

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4104,7 +4104,8 @@ converted to the type \tcode{std::ptrdiff_t}.
 \pnum
 \indextext{expression!left-shift-operator}%
 \indextext{expression!right-shift-operator}%
-\indextext{shift operator|see{operator, left shift; operator, right shift}}%
+\indextext{shift operator|see{operator, left shift}}%
+\indextext{shift operator|see{operator, right shift}}%
 \indextext{right shift operator|see{operator, right shift}}%
 \indextext{left shift operator|see{operator, left shift}}%
 The shift operators \tcode{<<} and \tcode{>>} group left-to-right.

--- a/source/special.tex
+++ b/source/special.tex
@@ -3,8 +3,11 @@
 
 \gramSec[gram.special]{Special member functions}
 
-\indextext{special member function|see{constructor, destructor, inline function,
-user-defined conversion, virtual function}}%
+\indextext{special member function|see{constructor}}%
+\indextext{special member function|see{destructor}}%
+\indextext{special member function|see{inline function}}%
+\indextext{special member function|see{user-defined conversion}}%
+\indextext{special member function|see{virtual function}}%
 \indextext{\idxcode{X(X\&)}|see{constructor, copy}}%
 \indextext{~@\tcode{\tilde}|see{destructor}}%
 \indextext{assignment!copy|see{assignment operator, copy}}%
@@ -2395,8 +2398,10 @@ B::B(V* v, A* a) {
 \indextext{construction|)}%
 
 \rSec1[class.copy]{Copying and moving class objects}%
-\indextext{copy!class object|see{constructor, copy; assignment, copy}}%
-\indextext{move!class object|see{constructor, move; assignment, move}}%
+\indextext{copy!class object|see{constructor, copy}}%
+\indextext{copy!class object|see{assignment, copy}}%
+\indextext{move!class object|see{constructor, move}}%
+\indextext{move!class object|see{assignment, move}}%
 \indextext{operator!copy assignment|see{assignment, copy}}%
 \indextext{operator!move assignment|see{assignment, move}}
 
@@ -3102,8 +3107,10 @@ optimization.\footnote{Because only one object is destroyed instead of two,
 and one copy/move constructor
 is not executed, there is still one object destroyed for each one constructed.}
 This elision of copy/move operations, called
-\indexdefn{copy elision|see{constructor, copy, elision; constructor, move, elision}}%
-\indexdefn{elision!copy|see{constructor, copy, elision; constructor, move, elision}}%
+\indexdefn{copy elision|see{constructor, copy, elision}}%
+\indexdefn{copy elision|see{constructor, move, elision}}%
+\indexdefn{elision!copy|see{constructor, copy, elision}}%
+\indexdefn{elision!copy|see{constructor, move, elision}}%
 \indexdefn{constructor!copy!elision}\indexdefn{constructor!move!elision}\term{copy elision},
 is permitted in the
 following circumstances (which may be combined to


### PR DESCRIPTION
Addresses #1391.

![diff](http://eel.is/seesee.png)