### PR TITLE
[expr.prim.id.qual] Redirect '::' index entry directly to 'operator, scope resolution'.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -508,7 +508,7 @@ it is a bit-field if the identifier designates a bit-field~(\ref{dcl.decomp}).
 \rSec3[expr.prim.id.qual]{Qualified names}
 
 \indextext{operator!scope resolution}%
-\indextext{\idxcode{::}|see{scope resolution operator}}%
+\indextext{\idxcode{::}|see{operator, scope resolution}}%
 %
 \begin{bnf}
 \nontermdef{qualified-id}\br


### PR DESCRIPTION
The index entry for "::" redirects to "scope resolution operator", but the index entry for "scope resolution operator" is [itself](https://github.com/cplusplus/draft/blob/master/source/basic.tex#L1637) a redirect to "operator, scope resolution". Might as well redirect "::" directly to "operator, scope resolution" and save the reader a hop. :)