### PR TITLE
Change stable names for Filesystem subclause

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -8384,7 +8384,7 @@ object converts those multibyte sequences into wide character sequences.
 
 \pnum
 In this subclause, member functions taking arguments of \tcode{const filesystem::path::value_type*}
-are only be provided on systems where \tcode{filesystem::path::value_type}~(\ref{class.path}) is not \tcode{char}.
+are only be provided on systems where \tcode{filesystem::path::value_type}~(\ref{fs.class.path}) is not \tcode{char}.
 \begin{note}
 These functions enable class \tcode{path} support for systems with a wide native path character type, such as \tcode{wchar_t}.
 \end{note}
@@ -10084,7 +10084,7 @@ Normalization of a generic format pathname means:
 \item Replace each slash character in the \grammarterm{root-name} with a \grammarterm{preferred-separator}.
 \item Replace each \grammarterm{directory-separator} with a \grammarterm{preferred-separator}.
 \begin{note}
-The generic pathname grammar~(\ref{path.generic}) defines \grammarterm{directory-separator} as one or more slashes and \grammarterm{preferred-separator}{s}.
+The generic pathname grammar~(\ref{fs.path.generic}) defines \grammarterm{directory-separator} as one or more slashes and \grammarterm{preferred-separator}{s}.
 \end{note}
 \item Remove each \grammarterm{dot} filename and any immediately following \grammarterm{directory-separator}.
 \item As long as any appear, remove a non-\grammarterm{dot-dot} filename immediately followed by a \grammarterm{directory-separator} and a \grammarterm{dot-dot} filename, along with any immediately following \grammarterm{directory-separator}.
@@ -10120,7 +10120,7 @@ The maximum number of elements in the sequence is operating system dependent.
 
 \definition{pathname}{fs.def.pathname}
 A character string that represents the name of a path. Pathnames are
-formatted according to the generic pathname format grammar~(\ref{path.generic}) or an
+formatted according to the generic pathname format grammar~(\ref{fs.path.generic}) or an
 operating system dependent
 native pathname format.
 
@@ -10131,7 +10131,7 @@ pathnames that resolve to the same file.
 \begin{example} POSIX specifies the mechanism in section 4.11, Pathname resolution.
 \end{example}
 
-\definition{relative path}{fs.def.relative-path}
+\definition{relative path}{fs.def.rel.path}
 A path that is not absolute, and as such, only unambiguously
 identifies the location of a file when resolved~(\ref{fs.def.pathres}) relative to
 an implied starting location. The elements of a path that determine if it is
@@ -10188,10 +10188,10 @@ subclause are assumed to be qualified with \tcode{::std::filesystem::}.
 
 \begin{codeblock}
 namespace std::filesystem {
-  // \ref{class.path}, paths
+  // \ref{fs.class.path}, paths
   class path;
 
-  // \ref{path.non-member}, \tcode{path} non-member functions
+  // \ref{fs.path.nonmember}, \tcode{path} non-member functions
   void swap(path& lhs, path& rhs) noexcept;
   size_t hash_value(const path& p) noexcept;
 
@@ -10204,7 +10204,7 @@ namespace std::filesystem {
 
   path operator/ (const path& lhs, const path& rhs);
 
-  // \ref{path.io}, \tcode{path} inserter and extractor
+  // \ref{fs.path.io}, \tcode{path} inserter and extractor
   template <class charT, class traits>
     basic_ostream<charT, traits>&
       operator<<(basic_ostream<charT, traits>& os, const path& p);
@@ -10212,33 +10212,33 @@ namespace std::filesystem {
     basic_istream<charT, traits>&
       operator>>(basic_istream<charT, traits>& is, path& p);
 
-  // \ref{path.factory}, \tcode{path} factory functions
+  // \ref{fs.path.factory}, \tcode{path} factory functions
   template <class Source>
     path u8path(const Source& source);
   template <class InputIterator>
     path u8path(InputIterator first, InputIterator last);
 
-  // \ref{class.filesystem_error}, filesystem errors
+  // \ref{fs.class.filesystem_error}, filesystem errors
   class filesystem_error;
 
-  // \ref{class.directory_entry}, directory entries
+  // \ref{fs.class.directory_entry}, directory entries
   class directory_entry;
 
-  // \ref{class.directory_iterator}, directory iterators
+  // \ref{fs.class.directory_iterator}, directory iterators
   class directory_iterator;
 
-  // \ref{directory_iterator.nonmembers}, range access for directory iterators
+  // \ref{fs.dir.itr.nonmembers}, range access for directory iterators
   directory_iterator begin(directory_iterator iter) noexcept;
   directory_iterator end(const directory_iterator&) noexcept;
 
-  // \ref{class.rec.dir.itr}, recursive directory iterators
+  // \ref{fs.class.rec.dir.itr}, recursive directory iterators
   class recursive_directory_iterator;
 
-  // \ref{rec.dir.itr.nonmembers}, range access for recursive directory iterators
+  // \ref{fs.rec.dir.itr.nonmembers}, range access for recursive directory iterators
   recursive_directory_iterator begin(recursive_directory_iterator iter) noexcept;
   recursive_directory_iterator end(const recursive_directory_iterator&) noexcept;
 
-  // \ref{class.file_status}, file status
+  // \ref{fs.class.file_status}, file status
   class file_status;
 
   struct space_info {
@@ -10468,7 +10468,7 @@ handle errors as follows, unless otherwise specified:
   \tcode{error_code\&} argument.
 \end{itemize}
 
-\rSec2[class.path]{Class \tcode{path}}
+\rSec2[fs.class.path]{Class \tcode{path}}
 
 \indexlibrary{\idxcode{path}}%
 \pnum
@@ -10492,10 +10492,10 @@ namespace std::filesystem {
     using string_type = basic_string<value_type>;
     static constexpr value_type preferred_separator = @\seebelow@;
 
-    // \ref{enum.path.format}, enumeration \tcode{format}
+    // \ref{fs.enum.path.format}, enumeration \tcode{format}
     enum format;
 
-    // \ref{path.construct}, constructors and destructor
+    // \ref{fs.path.construct}, constructors and destructor
     path() noexcept;
     path(const path& p);
     path(path&& p) noexcept;
@@ -10510,7 +10510,7 @@ namespace std::filesystem {
       path(InputIterator first, InputIterator last, const locale& loc, format fmt = auto_format);
     ~path();
 
-    // \ref{path.assign}, assignments
+    // \ref{fs.path.assign}, assignments
     path& operator=(const path& p);
     path& operator=(path&& p) noexcept;
     path& operator=(string_type&& source);
@@ -10522,7 +10522,7 @@ namespace std::filesystem {
     template <class InputIterator>
       path& assign(InputIterator first, InputIterator last);
 
-    // \ref{path.append}, appends
+    // \ref{fs.path.append}, appends
     path& operator/=(const path& p);
     template <class Source>
       path& operator/=(const Source& source);
@@ -10531,7 +10531,7 @@ namespace std::filesystem {
     template <class InputIterator>
       path& append(InputIterator first, InputIterator last);
 
-    // \ref{path.concat}, concatenation
+    // \ref{fs.path.concat}, concatenation
     path& operator+=(const path& x);
     path& operator+=(const string_type& x);
     path& operator+=(basic_string_view<value_type> x);
@@ -10546,7 +10546,7 @@ namespace std::filesystem {
     template <class InputIterator>
       path& concat(InputIterator first, InputIterator last);
 
-    // \ref{path.modifiers}, modifiers
+    // \ref{fs.path.modifiers}, modifiers
     void  clear() noexcept;
     path& make_preferred();
     path& remove_filename();
@@ -10554,7 +10554,7 @@ namespace std::filesystem {
     path& replace_extension(const path& replacement = path());
     void  swap(path& rhs) noexcept;
 
-    // \ref{path.native.obs}, native format observers
+    // \ref{fs.path.native.obs}, native format observers
     const string_type& native() const noexcept;
     const value_type*  c_str() const noexcept;
     operator string_type() const;
@@ -10569,7 +10569,7 @@ namespace std::filesystem {
     std::u16string u16string() const;
     std::u32string u32string() const;
 
-    // \ref{path.generic.obs}, generic format observers
+    // \ref{fs.path.generic.obs}, generic format observers
     template <class EcharT, class traits = char_traits<EcharT>,
               class Allocator = allocator<EcharT>>
       basic_string<EcharT, traits, Allocator>
@@ -10580,13 +10580,13 @@ namespace std::filesystem {
     std::u16string generic_u16string() const;
     std::u32string generic_u32string() const;
 
-    // \ref{path.compare}, compare
+    // \ref{fs.path.compare}, compare
     int  compare(const path& p) const noexcept;
     int  compare(const string_type& s) const;
     int  compare(basic_string_view<value_type> s) const;
     int  compare(const value_type* s) const;
 
-    // \ref{path.decompose}, decomposition
+    // \ref{fs.path.decompose}, decomposition
     path root_name() const;
     path root_directory() const;
     path root_path() const;
@@ -10596,7 +10596,7 @@ namespace std::filesystem {
     path stem() const;
     path extension() const;
 
-    // \ref{path.query}, query
+    // \ref{fs.path.query}, query
     bool empty() const noexcept;
     bool has_root_name() const;
     bool has_root_directory() const;
@@ -10609,12 +10609,12 @@ namespace std::filesystem {
     bool is_absolute() const;
     bool is_relative() const;
 
-    // \ref{path.gen}, generation
+    // \ref{fs.path.gen}, generation
     path lexically_normal() const;
     path lexically_relative(const path& base) const;
     path lexically_proximate(const path& base) const;
 
-    // \ref{path.itr}, iterators
+    // \ref{fs.path.itr}, iterators
     class iterator;
     using const_iterator = iterator;
 
@@ -10632,7 +10632,7 @@ operating system dependent encoded character type used to represent pathnames.
 \indexlibrarymember{preferred_separator}{path}%
 \pnum
 The value of the \tcode{preferred_separator} member
-is the operating system dependent \grammarterm{preferred-separator} character~(\ref{path.generic}).
+is the operating system dependent \grammarterm{preferred-separator} character~(\ref{fs.path.generic}).
 
 \pnum
 \begin{example}
@@ -10644,7 +10644,7 @@ For Windows-based operating systems,
 \tcode{preferred_separator} is the backslash character (\tcode{L'\textbackslash\textbackslash'}).
 \end{example}
 
-\rSec3[path.generic]{Generic pathname format}
+\rSec3[fs.path.generic]{Generic pathname format}
 
 \begin{ncbnf}
 \nontermdef{pathname}\br
@@ -10739,9 +10739,9 @@ On a POSIX-like operating system, it is impossible to have a
 without an intervening \grammarterm{root-directory} element.
 \end{note}
 
-\rSec3[path.cvt]{\tcode{path} conversions}
+\rSec3[fs.path.cvt]{\tcode{path} conversions}
 
-\rSec4[path.fmt.cvt]{\tcode{path} argument format conversions}
+\rSec4[fs.path.fmt.cvt]{\tcode{path} argument format conversions}
 
 \pnum
 \begin{note}
@@ -10758,7 +10758,7 @@ because on these systems:
 \pnum
 Several functions are defined to accept \term{detected-format} arguments,
 which are character sequences. A detected-format argument represents a path
-using either a pathname in the generic format~(\ref{path.generic})
+using either a pathname in the generic format~(\ref{fs.path.generic})
 or a pathname in the native format~(\ref{fs.def.native}).
 Such an argument is taken to be in the generic format if and only if
 it matches the generic format and is not acceptable to the operating system
@@ -10790,7 +10790,7 @@ otherwise it shall be treated as a path to a regular file.
 
 \pnum
 \begin{note}
-A path stores a native format pathname~(\ref{path.native.obs})
+A path stores a native format pathname~(\ref{fs.path.native.obs})
 and acts as if it also stores a generic format pathname,
 related as given below.
 The implementation may generate the generic format pathname
@@ -10817,7 +10817,7 @@ it is the result of converting \placeholder{p}.
 \end{note}
 
 
-\rSec4[path.type.cvt]{\tcode{path} type and encoding conversions}
+\rSec4[fs.path.type.cvt]{\tcode{path} type and encoding conversions}
 
 \pnum
 For member function arguments that take character sequences representing
@@ -10862,7 +10862,7 @@ characters, the resulting converted characters, if any, are unspecified.
 Implementations should not modify member function arguments
 if already of type \tcode{path::value_type}.
 
-\rSec3[path.req]{\tcode{path} requirements}
+\rSec3[fs.path.req]{\tcode{path} requirements}
 
 \pnum
 In addition to the requirements~(\ref{fs.req}),
@@ -10903,7 +10903,7 @@ denotes a possibly \tcode{const} encoded character type~(\ref{temp.deduct}).
 
 \pnum
 \begin{note}
-See path conversions~(\ref{path.cvt})
+See path conversions~(\ref{fs.path.cvt})
 for how the value types above and their encodings convert to
 \tcode{path::value_type} and its encoding.
 \end{note}
@@ -10912,9 +10912,9 @@ for how the value types above and their encodings convert to
 Arguments of type \tcode{Source}
 shall not be null pointers.
 
-\rSec3[path.member]{\tcode{path} members}
+\rSec3[fs.path.member]{\tcode{path} members}
 
-\rSec4[path.construct]{\tcode{path} constructors}
+\rSec4[fs.path.construct]{\tcode{path} constructors}
 
 \indexlibrary{\idxcode{path}!constructor}%
 \begin{itemdecl}
@@ -10954,8 +10954,8 @@ path(string_type&& source, format fmt = auto_format);
 \effects
 Constructs an object of class \tcode{path}
 for which the pathname in the detected-format of \tcode{source}
-has the original value of \tcode{source}~(\ref{path.fmt.cvt}),
-converting format if required~(\ref{path.fmt.cvt}).
+has the original value of \tcode{source}~(\ref{fs.path.fmt.cvt}),
+converting format if required~(\ref{fs.path.fmt.cvt}).
 \tcode{source} is left in a valid but unspecified state.
 \end{itemdescr}
 
@@ -10969,9 +10969,9 @@ template <class InputIterator>
 
 \begin{itemdescr}
 \pnum
-\effects Let \tcode{s} be the effective range of \tcode{source}~(\ref{path.req})
-or the range \range{first}{last}, with the encoding converted if required~(\ref{path.cvt}).
-Finds the detected-format of \tcode{s}~(\ref{path.fmt.cvt})
+\effects Let \tcode{s} be the effective range of \tcode{source}~(\ref{fs.path.req})
+or the range \range{first}{last}, with the encoding converted if required~(\ref{fs.path.cvt}).
+Finds the detected-format of \tcode{s}~(\ref{fs.path.fmt.cvt})
 and constructs an object of class \tcode{path}
 for which the pathname in that format is \tcode{s}.
 \end{itemdescr}
@@ -11007,7 +11007,7 @@ conversion to the current narrow encoding.
 \end{itemize}
 
 \pnum
-Finds the detected-format of \tcode{s}~(\ref{path.fmt.cvt})
+Finds the detected-format of \tcode{s}~(\ref{fs.path.fmt.cvt})
 and constructs an object of class \tcode{path}
 for which the pathname in that format is \tcode{s}.
 
@@ -11040,7 +11040,7 @@ converted to their Unicode representation.
 \end{example}
 \end{itemdescr}
 
-\rSec4[path.assign]{\tcode{path} assignments}
+\rSec4[fs.path.assign]{\tcode{path} assignments}
 
 \indexlibrarymember{operator=}{path}%
 \begin{itemdecl}
@@ -11108,16 +11108,16 @@ template <class InputIterator>
 \begin{itemdescr}
 \pnum
 \effects
-Let \tcode{s} be the effective range of \tcode{source}~(\ref{path.req})
-or the range \range{first}{last}, with the encoding converted if required~(\ref{path.cvt}).
-Finds the detected-format of \tcode{s}~(\ref{path.fmt.cvt})
+Let \tcode{s} be the effective range of \tcode{source}~(\ref{fs.path.req})
+or the range \range{first}{last}, with the encoding converted if required~(\ref{fs.path.cvt}).
+Finds the detected-format of \tcode{s}~(\ref{fs.path.fmt.cvt})
 and sets the pathname in that format to \tcode{s}.
 
 \pnum
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\rSec4[path.append]{\tcode{path} appends}
+\rSec4[fs.path.append]{\tcode{path} appends}
 
 \pnum
 The append operations use \tcode{operator/=} to denote their semantic effect of appending
@@ -11200,7 +11200,7 @@ template <class InputIterator>
 \effects Equivalent to: \tcode{return operator/=(path(first, last));}
 \end{itemdescr}
 
-\rSec4[path.concat]{\tcode{path} concatenation}
+\rSec4[fs.path.concat]{\tcode{path} concatenation}
 
 \indexlibrarymember{operator+=}{path}%
 \indexlibrarymember{concat}{path}%
@@ -11241,7 +11241,7 @@ template <class InputIterator>
 \effects Equivalent to \tcode{return *this += path(first, last)}.
 \end{itemdescr}
 
-\rSec4[path.modifiers]{\tcode{path} modifiers}
+\rSec4[fs.path.modifiers]{\tcode{path} modifiers}
 
 \indexlibrarymember{clear}{path}%
 \begin{itemdecl}
@@ -11351,7 +11351,7 @@ path& replace_extension(const path& replacement = path());
 \pnum
 \effects
   \begin{itemize}
-\item Any existing \tcode{extension()(}\ref{path.decompose}\tcode{)} is removed from the
+\item Any existing \tcode{extension()(}\ref{fs.path.decompose}\tcode{)} is removed from the
     pathname in the generic format,
     then
 \item If \tcode{replacement} is not empty and does not begin with a dot
@@ -11377,7 +11377,7 @@ void swap(path& rhs) noexcept;
 \complexity Constant time.
 \end{itemdescr}
 
-\rSec4[path.native.obs]{\tcode{path} native format observers}
+\rSec4[fs.path.native.obs]{\tcode{path} native format observers}
 
 \pnum
 The string returned by all native format observers is in the native pathname format~(\ref{fs.def.native}).
@@ -11432,7 +11432,7 @@ template <class EcharT, class traits = char_traits<EcharT>,
 \pnum
 \remarks All memory allocation, including for the return value, shall
 be performed by \tcode{a}. Conversion, if any, is specified by
-\ref{path.cvt}.
+\ref{fs.path.cvt}.
 \end{itemdescr}
 
 \indexlibrarymember{string}{path}%
@@ -11454,16 +11454,16 @@ std::u32string u32string() const;
 
 \pnum
 \remarks Conversion, if any, is performed as specified
-by \ref{path.cvt}.
+by \ref{fs.path.cvt}.
 The encoding of the string returned by \tcode{u8string()} is always UTF-8.
 \end{itemdescr}
 
 
-\rSec4[path.generic.obs]{\tcode{path} generic format observers}
+\rSec4[fs.path.generic.obs]{\tcode{path} generic format observers}
 
 \pnum
 Generic format observer functions return strings formatted according to the
-generic pathname format (\ref{path.generic}).
+generic pathname format (\ref{fs.path.generic}).
 The forward slash (\tcode{'/'}) character is used as
 the \grammarterm{directory-separator} character.
 
@@ -11490,7 +11490,7 @@ template <class EcharT, class traits = char_traits<EcharT>,
 \pnum
 \remarks All memory allocation, including for the return value, shall
 be performed by \tcode{a}. Conversion, if any, is specified by
-\ref{path.cvt}.
+\ref{fs.path.cvt}.
 \end{itemdescr}
 
 \indexlibrarymember{generic_string}{path}%
@@ -11511,12 +11511,12 @@ std::u32string generic_u32string() const;
 \returns The pathname in the generic format.
 
 \pnum
-\remarks Conversion, if any, is specified by~\ref{path.cvt}.
+\remarks Conversion, if any, is specified by~\ref{fs.path.cvt}.
 The encoding of the string returned by \tcode{generic_u8string()} is always
 UTF-8.
 \end{itemdescr}
 
-\rSec4[path.compare]{\tcode{path} compare}
+\rSec4[fs.path.compare]{\tcode{path} compare}
 
 \indexlibrarymember{compare}{path}%
 \begin{itemdecl}
@@ -11564,7 +11564,7 @@ int compare(const value_type* s) const
 \returns \tcode{compare(path(s))}.
 \end{itemdescr}
 
-\rSec4[path.decompose]{\tcode{path} decomposition}
+\rSec4[fs.path.decompose]{\tcode{path} decomposition}
 
 \indexlibrarymember{root_name}{path}%
 \begin{itemdecl}
@@ -11709,7 +11709,7 @@ even though the generic format pathnames are the same.
 \end{note}
 \end{itemdescr}
 
-\rSec4[path.query]{\tcode{path} query}
+\rSec4[fs.path.query]{\tcode{path} query}
 
 \indexlibrarymember{empty}{path}%
 \begin{itemdecl}
@@ -11827,7 +11827,7 @@ bool is_relative() const;
 \returns \tcode{!is_absolute()}.
 \end{itemdescr}
 
-\rSec4[path.gen]{\tcode{path} generation}
+\rSec4[fs.path.gen]{\tcode{path} generation}
 
 \indexlibrarymember{lexically_normal}{path}%
 \begin{itemdecl}
@@ -11938,12 +11938,12 @@ path lexically_proximate(const path& base) const;
   \tcode{*this}, \tcode{base}, or both. \end{note}
 \end{itemdescr}
 
-\rSec3[path.itr]{\tcode{path} iterators}
+\rSec3[fs.path.itr]{\tcode{path} iterators}
 
 \indexlibrary{\idxcode{path}!\idxcode{iterator}}%
 \pnum
 Path iterators iterate over the elements of the pathname
-in the generic format~(\ref{path.generic}).
+in the generic format~(\ref{fs.path.generic}).
 
 \pnum
 A \tcode{path::iterator} is a constant iterator satisfying all the
@@ -11998,7 +11998,7 @@ iterator end() const;
 \returns The end iterator.
 \end{itemdescr}
 
-\rSec3[path.non-member]{\tcode{path} non-member functions}
+\rSec3[fs.path.nonmember]{\tcode{path} non-member functions}
 
 \indexlibrary{\idxcode{swap}!\idxcode{path}}%
 \begin{itemdecl}
@@ -12108,7 +12108,7 @@ path operator/ (const path& lhs, const path& rhs);
 \effects Equivalent to: \tcode{return path(lhs) /= rhs;}
 \end{itemdescr}
 
-\rSec4[path.io]{\tcode{path} inserter and extractor}
+\rSec4[fs.path.io]{\tcode{path} inserter and extractor}
 
 \indexlibrarymember{operator<<}{path}%
 \begin{itemdecl}
@@ -12147,7 +12147,7 @@ p = tmp;
 \returns \tcode{is}.
 \end{itemdescr}
 
-\rSec4[path.factory]{\tcode{path} factory functions}
+\rSec4[fs.path.factory]{\tcode{path} factory functions}
 
 \indexlibrary{\idxcode{u8path}}%
 \begin{itemdecl}
@@ -12183,7 +12183,7 @@ template <class InputIterator>
 \end{itemize}
 
 \pnum
-\remarks Argument format conversion (\ref{path.fmt.cvt}) applies to the
+\remarks Argument format conversion (\ref{fs.path.fmt.cvt}) applies to the
   arguments for these functions. How Unicode encoding conversions are performed is
   unspecified.
 
@@ -12211,7 +12211,7 @@ For Windows-based operating systems a conversion from UTF-8 to
 \end{itemdescr}
 
 
-\rSec2[class.filesystem_error]{Class \tcode{filesystem_error}}
+\rSec2[fs.class.filesystem_error]{Class \tcode{filesystem_error}}
 
 \indexlibrary{\idxcode{filesystem_error}}%
 \begin{codeblock}
@@ -12344,7 +12344,7 @@ const char* what() const noexcept override;
 
 \rSec2[fs.enum]{Enumerations}
 
-\rSec3[enum.path.format]{Enum \tcode{path::format}}
+\rSec3[fs.enum.path.format]{Enum \tcode{path::format}}
 
 \pnum
 This enum specifies constants used to identify the format of the character
@@ -12367,15 +12367,15 @@ sequence, with the meanings listed in Table~\ref{tab:enum.path.format}.
   \end{note} \\\rowsep
 \end{floattable}
 
-\rSec3[enum.file_type]{Enum class \tcode{file_type}}
+\rSec3[fs.enum.file_type]{Enum class \tcode{file_type}}
 
 \indexlibrary{\idxcode{file_type}}%
 \pnum
 This enum class specifies constants used to identify file types,
-with the meanings listed in Table~\ref{tab:enum.file_type}.
+with the meanings listed in Table~\ref{tab:fs.enum.file_type}.
 
 \begin{floattable}
-{Enum class \tcode{file_type}}{tab:enum.file_type}
+{Enum class \tcode{file_type}}{tab:fs.enum.file_type}
 {lp{4.5in}}
 \topline
 \lhdr{Constant}	&
@@ -12408,20 +12408,20 @@ to separately identify each of those additional file types \\ \rowsep
 The file exists but the type could not be determined \\
 \end{floattable}
 
-\rSec3[enum.copy_options]{Enum class \tcode{copy_options}}
+\rSec3[fs.enum.copy.opts]{Enum class \tcode{copy_options}}
 
 \indexlibrary{\idxcode{copy_options}}%
 \pnum
 The \tcode{enum class} type \tcode{copy_options}
 is a bitmask type~(\ref{bitmask.types}) that specifies bitmask constants used to control the semantics of
-copy operations. The constants are specified in option groups with the meanings listed in Table~\ref{tab:enum.copy_options}.
+copy operations. The constants are specified in option groups with the meanings listed in Table~\ref{tab:fs.enum.copy_options}.
 Constant \tcode{none} is shown in each option group for purposes of exposition;
 implementations shall provide only a single definition. Calling a
 library function with more than a single constant for an option
 group results in undefined behavior.
 
 \begin{floattable}
-{Enum class \tcode{copy_options}}{tab:enum.copy_options}
+{Enum class \tcode{copy_options}}{tab:fs.enum.copy_options}
 {lp{4in}}
 \topline
 \ohdrx{2}{Option group controlling \tcode{copy_file} function effects for existing target files} \\ \rowsep
@@ -12465,16 +12465,16 @@ group results in undefined behavior.
     Make hard links instead of copies of files.  \\
 \end{floattable}
 
-\rSec3[enum.perms]{Enum class \tcode{perms}}
+\rSec3[fs.enum.perms]{Enum class \tcode{perms}}
 
 \indexlibrary{\idxcode{perms}}%
 \pnum
 The \tcode{enum class} type \tcode{perms}
 is a bitmask type~(\ref{bitmask.types}) that specifies bitmask constants used to identify file
-permissions, with the meanings listed in Table~\ref{tab:enum.perms}.
+permissions, with the meanings listed in Table~\ref{tab:fs.enum.perms}.
 
 \begin{floattable}
-{Enum class \tcode{perms}}{tab:enum.perms}
+{Enum class \tcode{perms}}{tab:fs.enum.perms}
 {lrlp{3.2in}}
 \topline
 \lhdr{Name}	& \chdr{Value}		& \chdr{POSIX}	& \rhdr{Definition or notes}	\\
@@ -12524,7 +12524,7 @@ permissions, with the meanings listed in Table~\ref{tab:enum.perms}.
   is created without specifying the permissions \\ \rowsep
 \end{floattable}
 
-\rSec3[enum.perm_options]{Enum class \tcode{perm_options}}
+\rSec3[fs.enum.perm.opts]{Enum class \tcode{perm_options}}
 
 \indexlibrary{\idxcode{perm_options}}%
 \pnum
@@ -12555,16 +12555,16 @@ passed to \tcode{permissions}.
 \end{floattable}
 
 
-\rSec3[enum.directory_options]{Enum class \tcode{directory_options}}
+\rSec3[fs.enum.dir.opts]{Enum class \tcode{directory_options}}
 
 \indexlibrary{\idxcode{directory_options}}%
 \pnum
 The \tcode{enum class} type \tcode{directory_options} is a bitmask
   type~(\ref{bitmask.types}) that specifies bitmask constants used to identify
-  directory traversal options, with the meanings listed in Table~\ref{tab:enum.directory_options}.
+  directory traversal options, with the meanings listed in Table~\ref{tab:fs.enum.directory_options}.
 
 \begin{floattable}
-{Enum class \tcode{directory_options}}{tab:enum.directory_options}
+{Enum class \tcode{directory_options}}{tab:fs.enum.directory_options}
 {lp{3in}}
 \topline
 \lhdr{Name}	&
@@ -12578,14 +12578,14 @@ Follow rather than skip directory symlinks. \\ \rowsep
 Skip directories that would otherwise result in permission denied. \\
 \end{floattable}
 
-\rSec2[class.file_status]{Class \tcode{file_status}}
+\rSec2[fs.class.file_status]{Class \tcode{file_status}}
 
 \indexlibrary{\idxcode{file_status}}%
 \begin{codeblock}
 namespace std::filesystem {
   class file_status {
   public:
-    // \ref{file_status.cons}, constructors and destructor
+    // \ref{fs.file_status.cons}, constructors and destructor
     file_status() noexcept : file_status(file_type::none) {}
     explicit file_status(file_type ft,
                          perms prms = perms::unknown) noexcept;
@@ -12597,11 +12597,11 @@ namespace std::filesystem {
     file_status& operator=(const file_status&) noexcept = default;
     file_status& operator=(file_status&&) noexcept = default;
 
-    // \ref{file_status.mods}, modifiers
+    // \ref{fs.file_status.mods}, modifiers
     void       type(file_type ft) noexcept;
     void       permissions(perms prms) noexcept;
 
-    // \ref{file_status.obs}, observers
+    // \ref{fs.file_status.obs}, observers
     file_type  type() const noexcept;
     perms      permissions() const noexcept;
   };
@@ -12611,7 +12611,7 @@ namespace std::filesystem {
 \pnum
 An object of type \tcode{file_status} stores information about the type
 and permissions of a file.
-\rSec3[file_status.cons]{\tcode{file_status} constructors}
+\rSec3[fs.file_status.cons]{\tcode{file_status} constructors}
 
 \indexlibrary{\idxcode{file_status}!constructor}%
 \begin{itemdecl}
@@ -12623,7 +12623,7 @@ explicit file_status(file_type ft, perms prms = perms::unknown) noexcept;
 \postconditions \tcode{type() == ft} and \tcode{permissions() == prms}.
 \end{itemdescr}
 
-\rSec3[file_status.obs]{\tcode{file_status} observers}
+\rSec3[fs.file_status.obs]{\tcode{file_status} observers}
 
 \indexlibrarymember{type}{file_status}%
 \begin{itemdecl}
@@ -12647,7 +12647,7 @@ perms permissions() const noexcept;
   \tcode{operator=}, or \tcode{permissions(perms)} function.
 \end{itemdescr}
 
-\rSec3[file_status.mods]{\tcode{file_status} modifiers}
+\rSec3[fs.file_status.mods]{\tcode{file_status} modifiers}
 
 \indexlibrarymember{type}{file_status}%
 \begin{itemdecl}
@@ -12669,14 +12669,14 @@ void permissions(perms prms) noexcept;
 \postconditions \tcode{permissions() == prms}.
 \end{itemdescr}
 
-\rSec2[class.directory_entry]{Class \tcode{directory_entry}}
+\rSec2[fs.class.directory_entry]{Class \tcode{directory_entry}}
 
 \indexlibrary{\idxcode{directory_entry}}%
 \begin{codeblock}
 namespace std::filesystem {
   class directory_entry {
   public:
-    // \ref{directory_entry.cons}, constructors and destructor
+    // \ref{fs.dir.entry.cons}, constructors and destructor
     directory_entry() noexcept = default;
     directory_entry(const directory_entry&) = default;
     directory_entry(directory_entry&&) noexcept = default;
@@ -12688,7 +12688,7 @@ namespace std::filesystem {
     directory_entry& operator=(const directory_entry&) = default;
     directory_entry& operator=(directory_entry&&) noexcept = default;
 
-    // \ref{directory_entry.mods}, modifiers
+    // \ref{fs.dir.entry.mods}, modifiers
     void assign(const path& p);
     void assign(const path& p, error_code& ec);
     void replace_filename(const path& p);
@@ -12696,7 +12696,7 @@ namespace std::filesystem {
     void refresh();
     void refresh(error_code& ec) noexcept;
 
-    // \ref{directory_entry.obs}, observers
+    // \ref{fs.dir.entry.obs}, observers
     const path& path() const noexcept;
     operator const path&() const noexcept;
     bool exists() const;
@@ -12757,7 +12757,7 @@ Such stored file attribute values are said to be \defnx{cached}{file attributes!
 \pnum
 \begin{note}
 For purposes of exposition,
-class \tcode{directory_iterator}~(\ref{class.directory_iterator})
+class \tcode{directory_iterator}~(\ref{fs.class.directory_iterator})
 is shown above as a friend of class \tcode{directory_entry}.
 Friendship allows the \tcode{directory_iterator} implementation to cache
 already available attribute values
@@ -12797,7 +12797,7 @@ The code is portable to any implementation,
 regardless of whether or not it employs caching.
 \end{example}
 
-\rSec3[directory_entry.cons]{\tcode{directory_entry} constructors}
+\rSec3[fs.dir.entry.cons]{\tcode{directory_entry} constructors}
 
 \indexlibrary{\idxcode{directory_entry}!constructor}%
 \begin{itemdecl}
@@ -12818,7 +12818,7 @@ otherwise \tcode{path() == std::filesystem::path()}.
 \throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
-\rSec3[directory_entry.mods]{\tcode{directory_entry} modifiers}
+\rSec3[fs.dir.entry.mods]{\tcode{directory_entry} modifiers}
 
 \indexlibrarymember{assign}{directory_entry}%
 \begin{itemdecl}
@@ -12868,14 +12868,14 @@ and the values of any cached attributes are unspecified.
 
 \pnum
 \begin{note}
-Implementations of \tcode{directory_iterator}~(\ref{class.directory_iterator})
+Implementations of \tcode{directory_iterator}~(\ref{fs.class.directory_iterator})
 are prohibited from directly or indirectly calling the \tcode{refresh} function
 since it must access the external file system,
 and the objective of caching is to avoid unnecessary file system accesses.
 \end{note}
 \end{itemdescr}
 
-\rSec3[directory_entry.obs]{\tcode{directory_entry} observers}
+\rSec3[fs.dir.entry.obs]{\tcode{directory_entry} observers}
 
 \pnum
 Unqualified function names in the \returns elements of the
@@ -13155,17 +13155,17 @@ bool operator>=(const directory_entry& rhs) const noexcept;
 \returns \tcode{pathobject >= rhs.pathobject}.
 \end{itemdescr}
 
-\rSec2[class.directory_iterator]{Class \tcode{directory_iterator}}
+\rSec2[fs.class.directory_iterator]{Class \tcode{directory_iterator}}
 
 \indexlibrary{\idxcode{directory_iterator}}%
 \pnum
 An object of type \tcode{directory_iterator} provides an iterator for a
 sequence of \tcode{directory_entry} elements representing the
-path and any cached attribute values~(\ref{class.directory_entry})
+path and any cached attribute values~(\ref{fs.class.directory_entry})
 for each file in a directory
 or in an \impldef{type of a directory-like file} directory-like file type.
 \begin{note} For iteration into sub-directories, see class \tcode{recursive_directory_iterator}
-(\ref{class.rec.dir.itr}). \end{note}
+(\ref{fs.class.rec.dir.itr}). \end{note}
 
 \begin{codeblock}
 namespace std::filesystem {
@@ -13177,7 +13177,7 @@ namespace std::filesystem {
     using pointer           = const directory_entry*;
     using reference         = const directory_entry&;
 
-    // \ref{directory_iterator.members}, member functions
+    // \ref{fs.dir.itr.members}, member functions
     directory_iterator() noexcept;
     explicit directory_iterator(const path& p);
     directory_iterator(const path& p, directory_options options);
@@ -13234,13 +13234,13 @@ increments of a \tcode{directory_iterator} is unspecified.
 
 \pnum
 Constructors and non-const \tcode{directory_iterator} member functions
-store the values of any cached attributes~(\ref{class.directory_entry})
+store the values of any cached attributes~(\ref{fs.class.directory_entry})
 in the \tcode{directory_entry} element returned by \tcode{operator*()}.
 \tcode{directory_iterator} member functions shall not directly or indirectly call
 any \tcode{directory_entry} \tcode{refresh} function.
 \begin{note}
 The exact mechanism for storing cached attribute values is not exposed to users.
-For exposition, class \tcode{directory_iterator} is shown in \ref{class.directory_entry}
+For exposition, class \tcode{directory_iterator} is shown in \ref{fs.class.directory_entry}
 as a friend of class \tcode{directory_entry}.
 \end{note}
 
@@ -13262,7 +13262,7 @@ result in an iterator referencing the removed or added directory entry. See
 POSIX \tcode{readdir_r}.
 \end{note}
 
-\rSec3[directory_iterator.members]{\tcode{directory_iterator} members}
+\rSec3[fs.dir.itr.members]{\tcode{directory_iterator} members}
 
 \indexlibrary{\idxcode{directory_iterator}!constructor}%
 \begin{itemdecl}
@@ -13355,7 +13355,7 @@ Input iterators~(\ref{input.iterators}).
 
 \end{itemdescr}
 
-\rSec3[directory_iterator.nonmembers]{\tcode{directory_iterator} non-member functions}
+\rSec3[fs.dir.itr.nonmembers]{\tcode{directory_iterator} non-member functions}
 
 \pnum
 These functions enable range access for \tcode{directory_iterator}.
@@ -13380,7 +13380,7 @@ directory_iterator end(const directory_iterator&) noexcept;
 \returns \tcode{directory_iterator()}.
 \end{itemdescr}
 
-\rSec2[class.rec.dir.itr]{Class \tcode{recursive_directory_iterator}}
+\rSec2[fs.class.rec.dir.itr]{Class \tcode{recursive_directory_iterator}}
 
 \indexlibrary{\idxcode{recursive_directory_iterator}}%
 \pnum
@@ -13399,7 +13399,7 @@ namespace std::filesystem {
     using pointer           = const directory_entry*;
     using reference         = const directory_entry&;
 
-    // \ref{rec.dir.itr.members}, constructors and destructor
+    // \ref{fs.rec.dir.itr.members}, constructors and destructor
     recursive_directory_iterator() noexcept;
     explicit recursive_directory_iterator(const path& p);
     recursive_directory_iterator(const path& p, directory_options options);
@@ -13410,7 +13410,7 @@ namespace std::filesystem {
     recursive_directory_iterator(recursive_directory_iterator&& rhs) noexcept;
     ~recursive_directory_iterator();
 
-    // \ref{rec.dir.itr.members}, observers
+    // \ref{fs.rec.dir.itr.members}, observers
     directory_options  options() const;
     int                depth() const;
     bool               recursion_pending() const;
@@ -13418,7 +13418,7 @@ namespace std::filesystem {
     const directory_entry& operator*() const;
     const directory_entry* operator->() const;
 
-    // \ref{rec.dir.itr.members}, modifiers
+    // \ref{fs.rec.dir.itr.members}, modifiers
     recursive_directory_iterator&
       operator=(const recursive_directory_iterator& rhs);
     recursive_directory_iterator&
@@ -13449,7 +13449,7 @@ as a \tcode{directory_iterator} unless otherwise specified.
 \begin{note} If the directory structure being iterated over contains cycles
 then the end iterator may be unreachable. \end{note}
 
-\rSec3[rec.dir.itr.members]{\tcode{recursive_directory_iterator} members}
+\rSec3[fs.rec.dir.itr.members]{\tcode{recursive_directory_iterator} members}
 
 \indexlibrary{\idxcode{recursive_directory_iterator}!constructor}%
 \begin{itemdecl}
@@ -13692,7 +13692,7 @@ void disable_recursion_pending();
   unwanted recursion into a directory. \end{note}
 \end{itemdescr}
 
-\rSec3[rec.dir.itr.nonmembers]{\tcode{recursive_directory_iterator} non-member functions}
+\rSec3[fs.rec.dir.itr.nonmembers]{\tcode{recursive_directory_iterator} non-member functions}
 
 \pnum
 These functions enable use of \tcode{recursive_directory_iterator}
@@ -13839,7 +13839,7 @@ void copy(const path& from, const path& to, copy_options options,
 
 \begin{itemdescr}
 \pnum
-\requires At most one constant from each option group (\ref{enum.copy_options})
+\requires At most one constant from each option group (\ref{fs.enum.copy.opts})
   is present in \tcode{options}.
 
 \pnum
@@ -13864,7 +13864,7 @@ Effects are then as follows:
 \begin{itemize}
 \item
 If \tcode{f.type()} or \tcode{t.type()} is an implementation-defined
-file type~(\ref{enum.file_type}), then the effects are
+file type~(\ref{fs.enum.file_type}), then the effects are
 \impldef{effect of \tcode{filesystem::copy}}.
 
 \item
@@ -14001,7 +14001,7 @@ bool copy_file(const path& from, const path& to, copy_options options,
 \begin{itemdescr}
 \pnum
 \requires At most one constant from each \tcode{copy_options}
-  option group (\ref{enum.copy_options}) is present
+  option group (\ref{fs.enum.copy.opts}) is present
   in \tcode{options}.
 
 \pnum
@@ -15106,7 +15106,7 @@ Otherwise,
 \item Otherwise, if the attributes indicate a socket, as if by POSIX
       \tcode{S_ISSOCK}, returns \tcode{file_status(file_type::socket, prms)}.
 \item Otherwise, if the attributes indicate an implementation-defined
-      file type~(\ref{enum.file_type}),
+      file type~(\ref{fs.enum.file_type}),
       returns \tcode{file_status(file_type::\placeholdernc{A}, prms)},
       where \tcode{\placeholdernc{A}} is the constant for the
       \impldef{file type of the file argument of \tcode{filesystem::status}} file type.


### PR DESCRIPTION
Addresses #1502 

This doesn't change the [class.*] names mentioned in the issue: [class.directory_entry], [class.rec.dir.itr], [class.directory_iterator], [class.file_status], [class.filesystem_status], [class.path]