### PR TITLE
[cpp] Change index redirect from '#' to '# operator' (and same for ##).

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -768,7 +768,7 @@ the preprocessing tokens used to replace it.
 
 \rSec2[cpp.stringize]{The \tcode{\#} operator}%
 \indextext{\#\#0 operator@\tcode{\#} operator}%
-\indextext{stringize|see{\tcode{\#}}}
+\indextext{stringize|see{\tcode{\#} operator}}
 
 \pnum
 Each
@@ -815,7 +815,7 @@ operators is unspecified.
 
 \rSec2[cpp.concat]{The \tcode{\#\#} operator}%
 \indextext{\#\#1 operator@\tcode{\#\#} operator}%
-\indextext{concatenation!macro argument|see{\tcode{\#\#}}}
+\indextext{concatenation!macro argument|see{\tcode{\#\#} operator}}
 
 \pnum
 A


### PR DESCRIPTION
Same type of fix as #1495.