### PR TITLE
Consistent comma after e.g. and i.e.

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -4057,7 +4057,7 @@ template <class ExecutionPolicy, class InputIterator, class Predicate>
 \pnum
 \returns \tcode{true} if
 \range{first}{last} is empty or if
-\range{first}{last} is partitioned by \tcode{pred}, i.e. if all elements that satisfy \tcode{pred} appear before those that do not.
+\range{first}{last} is partitioned by \tcode{pred}, i.e., if all elements that satisfy \tcode{pred} appear before those that do not.
 
 \pnum
 \complexity Linear. At most \tcode{last - first} applications of \tcode{pred}.
@@ -4194,7 +4194,7 @@ template<class ForwardIterator, class Predicate>
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{ForwardIterator}'s value type shall be convertible to \tcode{Predicate}'s argument type. \range{first}{last} shall be partitioned by \tcode{pred}, i.e. all elements that satisfy \tcode{pred} shall appear before those that do not.
+\requires \tcode{ForwardIterator}'s value type shall be convertible to \tcode{Predicate}'s argument type. \range{first}{last} shall be partitioned by \tcode{pred}, i.e., all elements that satisfy \tcode{pred} shall appear before those that do not.
 
 \pnum
 \returns An iterator \tcode{mid} such that \tcode{all_of(first, mid, pred)} and \tcode{none_of(mid, last, pred)} are both \tcode{true}.

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -2257,7 +2257,7 @@ sometype* q = new sometype[3];  // error, deleted class \tcode{operator new[]}
 \end{example}
 
 \begin{example}
-One can make a class uncopyable, i.e. move-only, by using deleted
+One can make a class uncopyable, i.e., move-only, by using deleted
 definitions of the copy constructor and copy assignment operator, and then
 providing defaulted definitions of the move constructor and move assignment operator.
 \begin{codeblock}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -39,7 +39,7 @@ as summarized in Table~\ref{tab:iostreams.lib.summary}.
 \pnum
 Figure~\ref{fig:streampos} illustrates relationships among various types
 described in this clause. A line from \textbf{A} to \textbf{B} indicates that \textbf{A}
-is an alias (e.g. a typedef) for \textbf{B} or that \textbf{A} is defined in terms of
+is an alias (e.g., a typedef) for \textbf{B} or that \textbf{A} is defined in terms of
 \textbf{B}.
 
 \begin{importgraphic}

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2596,7 +2596,7 @@ assume that this parameter is a unique reference to this argument.
 If the parameter is a generic parameter of the form \tcode{T\&\&} and an lvalue of type
 \tcode{A} is bound, the argument binds to an lvalue reference~(\ref{temp.deduct.call})
 and thus is not covered by the previous sentence. \end{note} \begin{note} If a program casts
-an lvalue to an xvalue while passing that lvalue to a library function (e.g. by calling the function
+an lvalue to an xvalue while passing that lvalue to a library function (e.g., by calling the function
 with the argument \tcode{std::move(x)}), the program
 is effectively asking that function to treat that lvalue as a temporary. The implementation
 is free to optimize away aliasing checks which might be needed if the argument was

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -1624,7 +1624,7 @@ or, if not that,
 
 \item the context is an initialization by conversion function for direct
 reference binding (\ref{over.match.ref}) of a reference to function type, the
-return type of \tcode{F1} is the same kind of reference (i.e. lvalue or rvalue)
+return type of \tcode{F1} is the same kind of reference (i.e., lvalue or rvalue)
 as the reference being initialized, and the return type of \tcode{F2} is not
 \begin{example}
 \begin{codeblock}

--- a/source/tables.tex
+++ b/source/tables.tex
@@ -49,7 +49,7 @@
 
 % General Usage: TITLE is the title of the table, XREF is the
 % cross-reference for the table. LAYOUT is a sequence of column
-% type specifiers (e.g. cp{1.0}c), without '|' for the left edge
+% type specifiers (e.g., cp{1.0}c), without '|' for the left edge
 % or right edge.
 
 % usage: \begin{floattablebase}{TITLE}{XREF}{COLUMNS}{PLACEMENT}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -626,7 +626,7 @@ as the end of the \grammarterm{template-argument-list} and completes
 the \grammarterm{template-id}. \begin{note} The second \tcode{>}
 token produced by this replacement rule may terminate an enclosing
 \grammarterm{template-id} construct or it may be part of a different
-construct (e.g. a cast).\end{note}
+construct (e.g., a cast).\end{note}
 \begin{example}
 
 \begin{codeblock}

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -99,13 +99,13 @@ during the timeout, the behavior should be as follows:
 
 \begin{itemize}
 \item
-if $C_a > C_t$, the waiting function should wake as soon as possible, i.e. $C_a + D_i + D_m$,
+if $C_a > C_t$, the waiting function should wake as soon as possible, i.e., $C_a + D_i + D_m$,
 since the timeout is already satisfied. \begin{note} This specification may result in the total
 duration of the wait decreasing when measured against a steady clock. \end{note}
 
 \item
 if $C_a <= C_t$, the waiting function should not time out until \tcode{Clock::now()} returns a
-time $C_n >= C_t$, i.e. waking at $C_t + D_i + D_m$. \begin{note} When the clock is adjusted
+time $C_n >= C_t$, i.e., waking at $C_t + D_i + D_m$. \begin{note} When the clock is adjusted
 backwards, this specification may result in the total duration of the wait increasing when
 measured against a steady clock. When the clock is adjusted forwards, this specification may
 result in the total duration of the wait decreasing when measured against a steady clock.
@@ -147,7 +147,7 @@ the implementation as specified in~\ref{time.clock} do not throw exceptions.
 An \defn{execution agent} is an entity such as a thread that may perform work in parallel with
 other execution agents. \begin{note} Implementations or users may introduce other kinds of
 agents such as processes or thread-pool tasks. \end{note} The calling agent is determined by
-context, e.g. the calling thread that contains the call, and so on.
+context, e.g., the calling thread that contains the call, and so on.
 
 \pnum
 \begin{note} Some lockable objects are ``agent oblivious'' in that they work for any

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -5166,7 +5166,7 @@ expressions of the \effects element.
 \pnum
 \complexity
 For \tcode{sizeof...(Variants) <= 1}, the invocation of the callable object is
-implemented in constant time, i.e. it does not depend on \tcode{sizeof...(Types).}
+implemented in constant time, i.e., it does not depend on \tcode{sizeof...(Types).}
 For \tcode{sizeof...(Variants) > 1}, the invocation of the callable object has
 no complexity requirements.
 \end{itemdescr}
@@ -5315,7 +5315,7 @@ This section describes components that \Cpp programs may use to perform operatio
 \pnum
 \begin{note}
 The discriminated type may contain values of different types but does not attempt conversion between them,
-i.e. \tcode{5} is held strictly as an \tcode{int} and is not implicitly convertible either to \tcode{"5"} or to \tcode{5.0}.
+i.e., \tcode{5} is held strictly as an \tcode{int} and is not implicitly convertible either to \tcode{"5"} or to \tcode{5.0}.
 This indifference to interpretation but awareness of type effectively allows safe, generic containers of single values, with no scope for surprises from ambiguous conversions.
 \end{note}
 


### PR DESCRIPTION
After grepping to determine the preferred idiom, it seems clear that
the standard prefers to follow both e.g. and i.e. with a comma, rather
than omit it.  This patch applies that rule to the few places that
were missing the comma, including in LaTeX comments only for the editors'
benefit.