### PR TITLE
[unord.req] Move library name index entries to library name index.

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -2224,8 +2224,8 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 \endhead
 %%
 \tcode{X::key_type}   &
-\indextext{unordered associative containers!\idxcode{key_type}}%
-\indextext{\idxcode{key_type}!unordered associative containers}%
+\indexlibrary{unordered associative containers!\idxcode{key_type}}%
+\indexlibrary{\idxcode{key_type}!unordered associative containers}%
   \tcode{Key}         &
                       &
   compile time        \\ \rowsep
@@ -2249,8 +2249,8 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 &   \tcode{Hash}
 &   \tcode{Hash} shall be a unary function object type such that the expression
     \tcode{hf(k)} has type \tcode{size_t}.%
-    \indextext{unordered associative containers!\idxcode{hasher}}%
-    \indextext{\idxcode{hasher}!unordered associative containers}%
+    \indexlibrary{unordered associative containers!\idxcode{hasher}}%
+    \indexlibrary{\idxcode{hasher}!unordered associative containers}%
 &   compile time
 \\ \rowsep
 %
@@ -2259,8 +2259,8 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 &   \requires\ \tcode{Pred} is \tcode{CopyConstructible}.\br
     \tcode{Pred} shall be a binary predicate that takes two arguments
     of type \tcode{Key}.  \tcode{Pred} is an equivalence relation.%
-    \indextext{unordered associative containers!\idxcode{key_equal}}%
-    \indextext{\idxcode{key_equal}!unordered associative containers}%
+    \indexlibrary{unordered associative containers!\idxcode{key_equal}}%
+    \indexlibrary{\idxcode{key_equal}!unordered associative containers}%
 &   compile time
 \\ \rowsep
 %
@@ -2271,8 +2271,8 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 &   A \tcode{local_iterator} object may be used to iterate through a
     single bucket, but may not be used to iterate across
     buckets.%
-    \indextext{unordered associative containers!\idxcode{local_iterator}}%
-    \indextext{\idxcode{local_iterator}!unordered associative containers}%
+    \indexlibrary{unordered associative containers!\idxcode{local_iterator}}%
+    \indexlibrary{\idxcode{local_iterator}!unordered associative containers}%
 &   compile time
 \\ \rowsep
 %
@@ -2283,8 +2283,8 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 &   A \tcode{const_local_iterator} object may be used to iterate through a
     single bucket, but may not be used to iterate across
     buckets.%
-    \indextext{unordered associative containers!\idxcode{const_local_iterator}}%
-    \indextext{\idxcode{const_local_iterator}!unordered associative containers}%
+    \indexlibrary{unordered associative containers!\idxcode{const_local_iterator}}%
+    \indexlibrary{\idxcode{const_local_iterator}!unordered associative containers}%
 &   compile time
 \\ \rowsep
 %
@@ -2428,16 +2428,16 @@ and \tcode{CopyAssignable}.\br
 \tcode{b.hash_function()}
 &   \tcode{hasher}
 &   Returns \tcode{b}'s hash function.%
-    \indextext{unordered associative containers!\idxcode{hash_function}}%
-    \indextext{\idxcode{hash_function}!unordered associative containers}%
+    \indexlibrary{unordered associative containers!\idxcode{hash_function}}%
+    \indexlibrary{\idxcode{hash_function}!unordered associative containers}%
 &   constant
 \\ \rowsep
 %
 \tcode{b.key_eq()}
 &   \tcode{key_equal}
 &   Returns \tcode{b}'s key equality predicate.%
-    \indextext{unordered associative containers!\idxcode{key_eq}}%
-    \indextext{\idxcode{key_eq}!unordered associative containers}%
+    \indexlibrary{unordered associative containers!\idxcode{key_eq}}%
+    \indexlibrary{\idxcode{key_eq}!unordered associative containers}%
 &   constant
 \\ \rowsep
 %
@@ -2485,8 +2485,8 @@ and \tcode{CopyAssignable}.\br
     component of the returned pair indicates whether the insertion
     takes place, and the \tcode{iterator} component points to the element
     with key equivalent to the key of \tcode{t}.%
-    \indextext{unordered associative containers!\idxcode{insert}}%
-    \indextext{\idxcode{insert}!unordered associative containers}%
+    \indexlibrary{unordered associative containers!\idxcode{insert}}%
+    \indexlibrary{\idxcode{insert}!unordered associative containers}%
 &   Average case \bigoh{1}, worst case \bigoh{\tcode{a_uniq.}\br\tcode{size()}}.
 \\ \rowsep
 %
@@ -2497,8 +2497,8 @@ and \tcode{CopyAssignable}.\br
     \tcode{CopyInsertable} into \tcode{X}.\br
     \effects\ Inserts \tcode{t}, and returns an iterator pointing to the newly
     inserted element.
-    \indextext{unordered associative containers!\idxcode{insert}}%
-    \indextext{\idxcode{insert}!unordered associative containers}%
+    \indexlibrary{unordered associative containers!\idxcode{insert}}%
+    \indexlibrary{\idxcode{insert}!unordered associative containers}%
 &   Average case \bigoh{1}, worst case \bigoh{\tcode{a_eq.}\br\tcode{size()}}.
 \\ \rowsep
 %
@@ -2511,8 +2511,8 @@ and \tcode{CopyAssignable}.\br
 to the element with the key equivalent to that of \tcode{t}.  The
 iterator \tcode{p} is a hint pointing to where the search should
 start.  Implementations are permitted to ignore the hint.%
-    \indextext{unordered associative containers!\idxcode{insert}}%
-    \indextext{\idxcode{insert}!unordered associative containers}%
+    \indexlibrary{unordered associative containers!\idxcode{insert}}%
+    \indexlibrary{\idxcode{insert}!unordered associative containers}%
 &   Average case \bigoh{1}, worst case \bigoh{\tcode{a.size()}}.
 \\ \rowsep
 %
@@ -2521,8 +2521,8 @@ start.  Implementations are permitted to ignore the hint.%
 &   \requires\ \tcode{value_type} shall be \tcode{EmplaceConstructible} into \tcode{X} from \tcode{*i}.\br
     \requires \tcode{i} and \tcode{j} are not iterators in \tcode{a}.
     Equivalent to \tcode{a.insert(t)} for each element in \tcode{[i,j)}.%
-    \indextext{unordered associative containers!\idxcode{insert}}%
-    \indextext{\idxcode{insert}!unordered associative containers}%
+    \indexlibrary{unordered associative containers!\idxcode{insert}}%
+    \indexlibrary{\idxcode{insert}!unordered associative containers}%
 &   Average case \bigoh{N}, where $N$ is \tcode{distance(i, j)}.
     Worst case \bigoh{N(\tcode{a.size()}\brk{}+\brk{}1)}.
 \\ \rowsep
@@ -2618,8 +2618,8 @@ the number of elements erased.
 &   \tcode{iterator}
 &   Erases the element pointed to by \tcode{q}. Returns the
     iterator immediately following \tcode{q} prior to the erasure.
-    \indextext{unordered associative containers!\idxcode{erase}}%
-    \indextext{\idxcode{erase}!unordered associative containers}%
+    \indexlibrary{unordered associative containers!\idxcode{erase}}%
+    \indexlibrary{\idxcode{erase}!unordered associative containers}%
 &   Average case \bigoh{1}, worst case \bigoh{\tcode{a.size()}}.
 \\ \rowsep
 %
@@ -2627,8 +2627,8 @@ the number of elements erased.
 &   \tcode{iterator}
 &   Erases the element pointed to by \tcode{r}. Returns the
     iterator immediately following \tcode{r} prior to the erasure.
-    \indextext{unordered associative containers!\idxcode{erase}}%
-    \indextext{\idxcode{erase}!unordered associative containers}%
+    \indexlibrary{unordered associative containers!\idxcode{erase}}%
+    \indexlibrary{\idxcode{erase}!unordered associative containers}%
 &   Average case \bigoh{1}, worst case \bigoh{\tcode{a.size()}}.
 \\ \rowsep
 %
@@ -2637,8 +2637,8 @@ the number of elements erased.
 &   Erases all elements in the range \tcode{[q1, q2)}. Returns
     the iterator immediately following the erased elements prior to the
     erasure.%
-    \indextext{unordered associative containers!\idxcode{erase}}%
-    \indextext{\idxcode{erase}!unordered associative containers}%
+    \indexlibrary{unordered associative containers!\idxcode{erase}}%
+    \indexlibrary{\idxcode{erase}!unordered associative containers}%
 &   Average case linear in \tcode{distance(q1, q2)},
     worst case \bigoh{\tcode{a.size()}}.
 \\ \rowsep
@@ -2647,8 +2647,8 @@ the number of elements erased.
 & \tcode{void}
 & Erases all elements in the container.
    \postconditions \tcode{a.empty()} returns \tcode{true}%
-    \indextext{unordered associative containers!\idxcode{clear}}%
-    \indextext{\idxcode{clear}!unordered associative containers}%
+    \indexlibrary{unordered associative containers!\idxcode{clear}}%
+    \indexlibrary{\idxcode{clear}!unordered associative containers}%
 & Linear in \tcode{a.size()}.
 \\ \rowsep
 %
@@ -2656,16 +2656,16 @@ the number of elements erased.
 &   \tcode{iterator}; \br \tcode{const_iterator} for const \tcode{b}.
 &   Returns an iterator pointing to an element with key equivalent to
     \tcode{k}, or \tcode{b.end()} if no such element exists.%
-    \indextext{unordered associative containers!\idxcode{find}}%
-    \indextext{\idxcode{find}!unordered associative containers}%
+    \indexlibrary{unordered associative containers!\idxcode{find}}%
+    \indexlibrary{\idxcode{find}!unordered associative containers}%
 &   Average case \bigoh{1}, worst case \bigoh{\tcode{b.size()}}.
 \\ \rowsep
 %
 \tcode{b.count(k)}
 &   \tcode{size_type}
 &   Returns the number of elements with key equivalent to \tcode{k}.%
-    \indextext{unordered associative containers!\idxcode{count}}%
-    \indextext{\idxcode{count}!unordered associative containers}%
+    \indexlibrary{unordered associative containers!\idxcode{count}}%
+    \indexlibrary{\idxcode{count}!unordered associative containers}%
 &   Average case \bigoh{\tcode{b.count(k)}}, worst case \bigoh{\tcode{b.size()}}.
 \\ \rowsep
 %
@@ -2675,8 +2675,8 @@ the number of elements erased.
 &   Returns a range containing all elements with keys equivalent to
     \tcode{k}.  Returns \tcode{make_pair(b.end(), b.end())} if
     no such elements exist.%
-    \indextext{unordered associative containers!\idxcode{equal_range}}%
-    \indextext{\idxcode{equal_range}!unordered associative containers}%
+    \indexlibrary{unordered associative containers!\idxcode{equal_range}}%
+    \indexlibrary{\idxcode{equal_range}!unordered associative containers}%
 &   Average case \bigoh{\tcode{b.count(k)}}.  Worst case
     \bigoh{\tcode{b.size()}}.
 \\ \rowsep
@@ -2684,8 +2684,8 @@ the number of elements erased.
 \tcode{b.bucket_count()}
 &   \tcode{size_type}
 &   Returns the number of buckets that \tcode{b} contains.%
-    \indextext{unordered associative containers!\idxcode{bucket_count}}%
-    \indextext{\idxcode{bucket_count}!unordered associative containers}%
+    \indexlibrary{unordered associative containers!\idxcode{bucket_count}}%
+    \indexlibrary{\idxcode{bucket_count}!unordered associative containers}%
 &   Constant
 \\ \rowsep
 %
@@ -2693,8 +2693,8 @@ the number of elements erased.
 &   \tcode{size_type}
 &   Returns an upper bound on the number of buckets that \tcode{b} might
     ever contain.%
-    \indextext{unordered associative containers!\idxcode{max_bucket_count}}%
-    \indextext{\idxcode{max_bucket_count}!unordered associative containers}%
+    \indexlibrary{unordered associative containers!\idxcode{max_bucket_count}}%
+    \indexlibrary{\idxcode{max_bucket_count}!unordered associative containers}%
 &   Constant
 \\ \rowsep
 %
@@ -2705,8 +2705,8 @@ the number of elements erased.
     Returns the index of the bucket in which elements with keys equivalent
     to \tcode{k} would be found, if any such element existed.
     \postconditions the return value shall be in the range \tcode{[0, b.bucket_count())}.%
-    \indextext{unordered associative containers!\idxcode{bucket}}%
-    \indextext{\idxcode{bucket}!unordered associative containers}%
+    \indexlibrary{unordered associative containers!\idxcode{bucket}}%
+    \indexlibrary{\idxcode{bucket}!unordered associative containers}%
 & Constant
 \\ \rowsep
 %
@@ -2714,8 +2714,8 @@ the number of elements erased.
 &   \tcode{size_type}
 &   \requires \tcode{n} shall be in the range \tcode{[0, b.bucket_count())}.
     Returns the number of elements in the $\texttt{n}^{\textrm{ th}}$ bucket.%
-    \indextext{unordered associative containers!\idxcode{bucket_size}}%
-    \indextext{\idxcode{bucket_size}!unordered associative containers}%
+    \indexlibrary{unordered associative containers!\idxcode{bucket_size}}%
+    \indexlibrary{\idxcode{bucket_size}!unordered associative containers}%
 &   \bigoh{\tcode{b.bucket_}\-\tcode{size(n)}}
 \\ \rowsep
 %
@@ -2726,8 +2726,8 @@ the number of elements erased.
     \tcode{b.begin(n)} returns an iterator referring to the
     first element in the bucket. If the bucket is empty, then
     \tcode{b.begin(n) == b.end(n)}.%
-    \indextext{unordered associative containers!\idxcode{begin}}%
-    \indextext{\idxcode{begin}!unordered associative containers}%
+    \indexlibrary{unordered associative containers!\idxcode{begin}}%
+    \indexlibrary{\idxcode{begin}!unordered associative containers}%
 &   Constant
 \\ \rowsep
 %
@@ -2737,8 +2737,8 @@ the number of elements erased.
 &   \requires \tcode{n} shall be in the range \tcode{[0, b.bucket_count())}.
     \tcode{b.end(n)} returns an iterator which is the past-the-end
     value for the bucket.%
-    \indextext{unordered associative containers!\idxcode{end}}%
-    \indextext{\idxcode{end}!unordered associative containers}%
+    \indexlibrary{unordered associative containers!\idxcode{end}}%
+    \indexlibrary{\idxcode{end}!unordered associative containers}%
 &   Constant
 \\ \rowsep
 %
@@ -2747,24 +2747,24 @@ the number of elements erased.
 &   \requires \tcode{n} shall be in the range \tcode{[0, b.bucket_count())}.
     Note: \tcode{[b.cbegin(n), b.cend(n))} is a valid range containing
     all of the elements in the $\texttt{n}^{\textrm{ th}}$ bucket.%
-    \indextext{unordered associative containers!\idxcode{cbegin}}%
-    \indextext{\idxcode{cbegin}!unordered associative containers}%
+    \indexlibrary{unordered associative containers!\idxcode{cbegin}}%
+    \indexlibrary{\idxcode{cbegin}!unordered associative containers}%
 &   Constant
 \\ \rowsep
 %
 \tcode{b.cend(n)}
 &   \tcode{const_local_iterator}
 &   \requires \tcode{n} shall be in the range \tcode{[0, b.bucket_count())}.%
-    \indextext{unordered associative containers!\idxcode{cend}}%
-    \indextext{\idxcode{cend}!unordered associative containers}%
+    \indexlibrary{unordered associative containers!\idxcode{cend}}%
+    \indexlibrary{\idxcode{cend}!unordered associative containers}%
 &   Constant
 \\ \rowsep
 %
 \tcode{b.load_factor()}
 &   \tcode{float}
 &   Returns the average number of elements per bucket.%
-    \indextext{unordered associative containers!\idxcode{load_factor}}%
-    \indextext{\idxcode{load_factor}!unordered associative containers}%
+    \indexlibrary{unordered associative containers!\idxcode{load_factor}}%
+    \indexlibrary{\idxcode{load_factor}!unordered associative containers}%
 &   Constant
 \\ \rowsep
 %
@@ -2774,8 +2774,8 @@ the number of elements erased.
     less than or equal to. The container automatically increases the
     number of buckets as necessary to keep the load factor below this
     number.%
-    \indextext{unordered associative containers!\idxcode{max_load_factor}}%
-    \indextext{\idxcode{max_load_factor}!unordered associative containers}%
+    \indexlibrary{unordered associative containers!\idxcode{max_load_factor}}%
+    \indexlibrary{\idxcode{max_load_factor}!unordered associative containers}%
 &   Constant
 \\ \rowsep
 %
@@ -2790,8 +2790,8 @@ the number of elements erased.
 & \tcode{void}
 & \postconditions \tcode{a.bucket_count() >= a.size() / a.max_load_factor()} and
         \tcode{a.bucket_count() >= n}.%
-    \indextext{unordered associative containers!\idxcode{rehash}}%
-    \indextext{\idxcode{rehash}!unordered associative containers}%
+    \indexlibrary{unordered associative containers!\idxcode{rehash}}%
+    \indexlibrary{\idxcode{rehash}!unordered associative containers}%
 & Average case linear in \tcode{a.size()}, worst case quadratic.
 \\ \rowsep
 


### PR DESCRIPTION
Library names such as `max_bucket_count` and `rehash` are currently absent from the index of library names, because their index entries use \indextext instead of \indexlibrary.