### PR TITLE
[dcl.dcl] Capitalize grammarterms that start a sentence.

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -98,9 +98,9 @@ attribute-specifier-seq\opt decl-specifier-seq\opt init-declarator-list\opt{} \t
 
 is divided into three parts.
 Attributes are described in~\ref{dcl.attr}.
-\grammarterm{decl-specifier}{s}, the principal components of
+\grammarterm{Decl-specifier}{s}, the principal components of
 a \grammarterm{decl-specifier-seq}, are described in~\ref{dcl.spec}.
-\grammarterm{declarator}{s}, the components of an
+\grammarterm{Declarator}{s}, the components of an
 \grammarterm{init-declarator-list}, are described in Clause~\ref{dcl.decl}.
 The \grammarterm{attribute-specifier-seq}
 appertains to each of the entities declared by


### PR DESCRIPTION
See [dcl.dcl]/1, [dcl.fct.spec]/1, and [class]/1 for existing examples of capitalized grammarterms that start sentences.