### PR TITLE
Move plural 's' out of \grammarterm.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -883,7 +883,7 @@ The potential scope of a name declared in a class consists not
 only of the declarative region following the name's point of
 declaration, but also of all function bodies, default arguments,
 \grammarterm{noexcept-specifier}{s}, and
-\grammarterm{brace-or-equal-initializers} of non-static data members
+\grammarterm{brace-or-equal-initializer}{s} of non-static data members
 in that class (including such
 things in nested classes).
 
@@ -1778,7 +1778,7 @@ $S(X, m)$ is defined as follows: Let $S'(X, m)$ be the set of all
 declarations of \tcode{m} in \tcode{X} and the inline namespace set of
 \tcode{X}~(\ref{namespace.def}). If $S'(X, m)$ is not empty, $S(X, m)$
 is $S'(X, m)$; otherwise, $S(X, m)$ is the union of $S(N_i, m)$ for
-all namespaces $N_i$ nominated by \grammarterm{using-directives} in
+all namespaces $N_i$ nominated by \grammarterm{using-directive}{s} in
 \tcode{X} and its inline namespace set.
 
 \pnum

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -492,7 +492,7 @@ the object is \tcode{const}~(\ref{dcl.type.cv}).
 \indextext{function|seealso{friend function; member function; inline function; virtual function}}
 
 \pnum
-\grammarterm{Function-specifiers}
+\grammarterm{Function-specifier}{s}
 can be used only in function declarations.
 
 \begin{bnf}

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -70,8 +70,8 @@ where \tcode{T} is a \grammarterm{decl-specifier-seq}
 and each \tcode{Di} is an \grammarterm{init-declarator}.
 One exception is when a name introduced by one of the
 \grammarterm{declarator}{s} hides a type name used by the
-\grammarterm{decl-specifiers}, so that when the same
-\grammarterm{decl-specifiers} are used in a subsequent declaration,
+\grammarterm{decl-specifier}{s}, so that when the same
+\grammarterm{decl-specifier}{s} are used in a subsequent declaration,
 they do not have the same meaning, as in
 \begin{codeblock}
 struct S { ... };

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -493,7 +493,7 @@ if
 The \grammarterm{handler} is of type \cv{}~\tcode{T} or
 \cv{}~\tcode{T\&} and
 \tcode{E} and \tcode{T}
-are the same type (ignoring the top-level \grammarterm{cv-qualifiers}), or
+are the same type (ignoring the top-level \grammarterm{cv-qualifier}{s}), or
 \item%
 the \grammarterm{handler} is of type \cv{}~\tcode{T} or
 \cv{}~\tcode{T\&} and

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3755,7 +3755,7 @@ reference type or an rvalue reference to function type and an xvalue if \tcode{T
 is an rvalue reference to object type; otherwise the result is a prvalue.
 \begin{note}
 If \tcode{T} is a non-class type that is cv-qualified, the
-\grammarterm{cv-qualifiers} are discarded when determining the type of the
+\grammarterm{cv-qualifier}{s} are discarded when determining the type of the
 resulting prvalue; see Clause~\ref{expr}.
 \end{note}
 

--- a/source/special.tex
+++ b/source/special.tex
@@ -1890,13 +1890,13 @@ Then, direct base classes are initialized in declaration order
 as they appear in the
 \grammarterm{base-specifier-list}
 (regardless of the order of the
-\grammarterm{mem-initializers}).
+\grammarterm{mem-initializer}{s}).
 \item
 \indextext{initialization!order of member}%
 Then, non-static data members are initialized in the order
 they were declared in the class definition
 (again regardless of the order of the
-\grammarterm{mem-initializers}).
+\grammarterm{mem-initializer}{s}).
 \item
 Finally, the \grammarterm{compound-statement} of the constructor
 body  is executed.

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -638,7 +638,7 @@ where
 \item
 if the \grammarterm{for-range-initializer} is an \grammarterm{expression},
 it is regarded as if it were surrounded by parentheses (so that a comma operator
-cannot be reinterpreted as delimiting two \grammarterm{init-declarators});
+cannot be reinterpreted as delimiting two \grammarterm{init-declarator}{s});
 
 \item \tcode{__range}, \tcode{__begin}, and \tcode{__end} are variables defined for
 exposition only; and


### PR DESCRIPTION
Found a bunch more, not sure why I missed these in #1462.