### PR TITLE
[gram.cpp] Add space before comma in bnf.

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -53,7 +53,7 @@ within what would otherwise be an invocation of a function-like macro.
 \>\terminal{\# define}\>\>identifier replacement-list new-line\br
 \>\terminal{\# define}\>\>identifier lparen identifier-list\opt{} \terminal{)} replacement-list new-line\br
 \>\terminal{\# define}\>\>identifier lparen \terminal{... )} replacement-list new-line\br
-\>\terminal{\# define}\>\>identifier lparen identifier-list, \terminal{... )} replacement-list new-line\br
+\>\terminal{\# define}\>\>identifier lparen identifier-list \terminal{, ... )} replacement-list new-line\br
 \>\terminal{\# undef}\>\>identifier new-line\br
 \>\terminal{\# line}\>\>pp-tokens new-line\br
 \>\terminal{\# error}\>\>pp-tokens\opt new-line\br


### PR DESCRIPTION
For consistency with [line 691](https://github.com/cplusplus/draft/blob/master/source/preprocessor.tex#L691) and all other code commas in the bnf.