### PR TITLE
[re.results.state] fix bad index for match_result

### DIFF
--- a/source/regex.tex
+++ b/source/regex.tex
@@ -2650,7 +2650,7 @@ are indicated in Table~\ref{tab:re:results:assign}.
 
 \rSec2[re.results.state]{\tcode{match_results} state}
 
-\indexlibrarymember{match_results}{state}%
+\indexlibrarymember{match_results}{ready}%
 \begin{itemdecl}
 bool ready() const;
 \end{itemdecl}


### PR DESCRIPTION
Correctly index match_result::ready, instead of the
non-existant match_result::status.