### PR TITLE
[expr.delete] Properly italicize the term 'delete array', as done elsewhere

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4136,11 +4136,13 @@ object\iref{intro.object} or array created by a
     \terminal{::}\opt{} \terminal{delete [ ]} cast-expression
 \end{bnf}
 
-The first alternative is for non-array objects, and the second is for arrays. Whenever
-the \tcode{delete} keyword is immediately followed by empty square brackets, it shall be
-interpreted as the second alternative.\footnote{A lambda expression with a
-\grammarterm{lambda-introducer} that consists of
-empty square brackets can follow the \tcode{delete} keyword if the lambda expression is
+The first alternative is a
+\defnx{single-object delete expression}{delete!single-object}, and the
+second is an \defnx{array delete expression}{delete!array}.
+Whenever the \tcode{delete} keyword is immediately followed by empty square
+brackets, it shall be interpreted as the second alternative.\footnote{A lambda
+expression with a \grammarterm{lambda-introducer} that consists of empty square
+brackets can follow the \tcode{delete} keyword if the lambda expression is
 enclosed in parentheses.}
 The operand shall be of pointer to object type or of class type. If of
 class type, the operand is contextually implicitly converted\iref{conv}
@@ -4152,23 +4154,20 @@ The \grammarterm{delete-expression}'s result has type
 \tcode{void}.
 
 \pnum
-\indextext{\idxcode{delete}!object}%
+\indextext{\idxcode{delete}!single-object}%
 If the operand has a class type, the operand is converted to a pointer
 type by calling the above-mentioned conversion function, and the
 converted operand is used in place of the original operand for the
 remainder of this subclause.
-In the first alternative
-(\defnx{delete object}{object!delete}), the value of the operand of \tcode{delete} may
-be a null pointer value, a pointer to a non-array object
+In a single-object delete expression, the value of the operand of
+\tcode{delete} may be a null pointer value, a pointer to a non-array object
 created by a previous \grammarterm{new-expression},
 or a pointer to a
 subobject\iref{intro.object} representing a base class of such an
 object\iref{class.derived}. If not, the behavior is undefined.
 \indextext{array!\idxcode{delete}}%
-In the second alternative (\defnx{delete array}{\idxcode{delete}!array}), the value of the
-operand of \tcode{delete}
-may be a null pointer value or a pointer value
-that resulted from
+In an array delete expression, the value of the operand of \tcode{delete}
+may be a null pointer value or a pointer value that resulted from
 a previous array \grammarterm{new-expression}.\footnote{For nonzero-length
 arrays, this is the same as a pointer to the first
 element of the array created by that \grammarterm{new-expression}.
@@ -4188,12 +4187,12 @@ used as the operand of the \grammarterm{delete-expression}.
 
 \pnum
 \indextext{\idxcode{delete}!undefined}%
-In the first alternative (\term{delete object}), if the static type of
-the object to be deleted is different from its dynamic type, the static type shall be
-a base class of the dynamic type of the object to be deleted and the static type shall
-have a virtual destructor or the behavior is undefined. In the second
-alternative (\term{delete array}) if the dynamic type of the object to
-be deleted differs from its static type, the behavior is undefined.
+In a single-object delete expression, if the static type of the object to be
+deleted is different from its dynamic type, the static type shall be a base
+class of the dynamic type of the object to be deleted and the static type shall
+have a virtual destructor or the behavior is undefined. In an array delete
+expression, if the dynamic type of the object to be deleted differs from its
+static type, the behavior is undefined.
 
 \pnum
 The \grammarterm{cast-expression} in a \grammarterm{delete-expression} shall
@@ -4298,9 +4297,9 @@ is selected.
 \pnum
 When a \grammarterm{delete-expression}
 is executed, the selected deallocation function shall be called with
-the address of the most-derived object in the \term{delete object} case, or
-the address of the object suitably adjusted for
-the array allocation overhead\iref{expr.new} in the \term{delete array} case,
+the address of the most-derived object in a single-object delete expression, or
+the address of the object suitably adjusted for the array allocation
+overhead\iref{expr.new} in an array delete expression,
 as its first argument.
 If a deallocation function
 with a parameter of type \tcode{std::align_val_t}


### PR DESCRIPTION
Elsewhere in this subclause, delete array and delete object are italicized on use; this makes this usage consistent. I spoke with Richard about it at the Kona meeting, and he mentioned this seemed like the correct way to fix it.