### PR TITLE
[any.modifiers] fix emplace return type for 'any'

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -5547,9 +5547,9 @@ public:
 
   // \ref{any.modifiers}, modifiers
   template <class T, class... Args>
-    decay_t<ValueType>& emplace(Args&& ...);
+    decay_t<T>& emplace(Args&& ...);
   template <class T, class U, class... Args>
-    decay_t<ValueType>& emplace(initializer_list<U>, Args&&...);
+    decay_t<T>& emplace(initializer_list<U>, Args&&...);
   void reset() noexcept;
   void swap(any& rhs) noexcept;
 
@@ -5807,7 +5807,7 @@ Any exception thrown by the selected constructor of \tcode{VT}.
 \indexlibrarymember{emplace}{any}%
 \begin{itemdecl}
 template <class T, class... Args>
-  decay_t<ValueType>& emplace(Args&&... args);
+  decay_t<T>& emplace(Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5845,7 +5845,7 @@ This function shall not participate in overload resolution unless
 \indexlibrarymember{emplace}{any}%
 \begin{itemdecl}
 template <class T, class U, class... Args>
-  decay_t<ValueType>& emplace(initializer_list<U> il, Args&&... args);
+  decay_t<T>& emplace(initializer_list<U> il, Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
LWG issue 2857 was applied verbatim, without noticing
that 'ValueType' had been previously changed to 'T'.
This makes things consistent by choosing 'T' as the
simpler form, more consistent with 'optional' and
'variant'.