### PR TITLE
Fix misuses of \grammarterm.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -37,7 +37,7 @@ A \defn{name} is a use of an \grammarterm{identifier}~(\ref{lex.name}),
 \grammarterm{literal-operator-id}~(\ref{over.literal}),
 \grammarterm{conversion-function-id}~(\ref{class.conv.fct}), or
 \grammarterm{template-id}~(\ref{temp.names}) that denotes an entity or
-\grammarterm{label}~(\ref{stmt.goto}, \ref{stmt.label}).
+label~(\ref{stmt.goto}, \ref{stmt.label}).
 
 \pnum
 Every name that denotes an entity is introduced by a
@@ -3156,8 +3156,7 @@ match those of some object pointer type.
 \end{itemize}
 
 \pnum
-\indextext{safely-derived pointer}%
-A pointer value is a \grammarterm{safely-derived pointer} to a dynamic object only if it
+A pointer value is a \defn{safely-derived pointer} to a dynamic object only if it
 has an object pointer type and it is one of the following:
 \begin{itemize}
 \item the value returned by a call to the \Cpp standard library implementation of
@@ -3191,9 +3190,8 @@ pointer value.
 
 \pnum
 \indextext{integer representation}%
-\indextext{safely-derived pointer!integer representation}%
-\indextext{pointer, integer representation of safely-derived}%
-An integer value is an \grammarterm{integer representation of a safely-derived pointer}
+\indextext{pointer!integer representation of safely-derived}%
+An integer value is an \defnx{integer representation of a safely-derived pointer}{safely-derived pointer!integer representation}
 only if its type is at least as large as \tcode{std::intptr_t} and it is one of the
 following:
 
@@ -4146,7 +4144,7 @@ types that have \grammarterm{cv-qualifier}{s}.
 
 \pnum
 There is a partial ordering on cv-qualifiers, so that a type can be
-said to be \grammarterm{more cv-qualified} than another.
+said to be \defn{more cv-qualified} than another.
 Table~\ref{tab:relations.on.const.and.volatile} shows the relations that
 constitute this ordering.
 

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -144,9 +144,8 @@ at least one of which is not deleted.
 virtual functions or virtual base classes.\end{note}
 
 \indextext{class!standard-layout}%
-\indextext{standard-layout class}%
 \pnum
-A class \tcode{S} is a \grammarterm{standard-layout class} if it:
+A class \tcode{S} is a \defn{standard-layout class} if it:
 \begin{itemize}
 \item has no non-static data members of type non-standard-layout class
 (or array of such types) or reference,
@@ -213,14 +212,12 @@ in \tcode{X}. \end{note}
 \end{example}
 
 \indextext{struct!standard-layout}%
-\indextext{standard-layout struct}%
 \indextext{union!standard-layout}%
-\indextext{standard-layout union}%
 \pnum
-A \grammarterm{standard-layout struct} is a standard-layout class
+A \defn{standard-layout struct} is a standard-layout class
 defined with the \grammarterm{class-key} \tcode{struct} or the
 \grammarterm{class-key} \tcode{class}.
-A \grammarterm{standard-layout union} is a standard-layout class
+A \defn{standard-layout union} is a standard-layout class
 defined with the
 \grammarterm{class-key} \tcode{union}.
 
@@ -1328,7 +1325,7 @@ others.
 \pnum
 \indextext{bit-field!unnamed}%
 A declaration for a bit-field that omits the \grammarterm{identifier}
-declares an \grammarterm{unnamed} bit-field. Unnamed bit-fields are not
+declares an \defn{unnamed bit-field}. Unnamed bit-fields are not
 members and cannot be initialized.
 \begin{note}
 An unnamed bit-field is useful for padding to conform to

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -255,7 +255,7 @@ returning
 
 \pnum
 A type can also be named (often more easily) by using a
-\grammarterm{typedef}
+\tcode{typedef}
 (\ref{dcl.typedef}).
 
 \rSec1[dcl.ambig.res]{Ambiguity resolution}%
@@ -2475,9 +2475,8 @@ linkage that has an \grammarterm{initializer} is ill-formed.
 \indextext{initialization!default}%
 \indextext{variable!indeterminate uninitialized}%
 \indextext{initialization!zero-initialization}%
-\indextext{zero-initialization}%
 To
-\grammarterm{zero-initialize}
+\defnx{zero-initialize}{zero-initialization}
 an object or reference of type
 \tcode{T}
 means:
@@ -2527,9 +2526,8 @@ is a reference type, no initialization is performed.
 \end{itemize}
 
 \pnum
-\indextext{default-initialization}%
 To
-\grammarterm{default-initialize}
+\defnx{default-initialize}{default-initialization}
 an object of type
 \tcode{T}
 means:
@@ -2582,9 +2580,8 @@ const-qualified type \tcode{T},
 \tcode{T} shall be a const-default-constructible class type or array thereof.
 
 \pnum
-\indextext{value-initialization}%
 To
-\defn{value-initialize}
+\defnx{value-initialize}{value-initialization}
 an object of type
 \tcode{T}
 means:
@@ -3738,7 +3735,7 @@ list}, and the comma-separated \grammarterm{initializer-clause}{s} of the list a
 called the \term{elements} of the initializer list. An initializer list may be empty.
 List-initialization can occur in direct-initialization or copy-initialization contexts;
 list-initialization in a direct-initialization context is called
-\grammarterm{direct-list-initialization} and list-initialization in a
+\defn{direct-list-initialization} and list-initialization in a
 copy-initialization context is called \defn{copy-list-initialization}. \begin{note}
 List-initialization can be used
 

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -370,7 +370,7 @@ initializer~(\ref{class.mem}) is evaluated.
 If a declaration declares a member function or member function template of a
 class \tcode{X}, the expression \tcode{this} is a prvalue of type ``pointer to
 \grammarterm{cv-qualifier-seq} \tcode{X}'' between the optional
-\grammarterm{cv-qualifer-seq} and the end of the \grammarterm{function-definition},
+\grammarterm{cv-qualifier-seq} and the end of the \grammarterm{function-definition},
 \grammarterm{member-declarator}, or \grammarterm{declarator}. It shall not appear
 before the optional \grammarterm{cv-qualifier-seq} and it shall not appear within
 the declaration of a static member function (although its type and value category

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -1842,7 +1842,7 @@ a
 \term{standard conversion sequence}~(\ref{over.ics.scs}),
 \item
 a
-\grammarterm{user-defined conversion sequence}~(\ref{over.ics.user}), or
+\term{user-defined conversion sequence}~(\ref{over.ics.user}), or
 \item
 an
 \term{ellipsis conversion sequence}~(\ref{over.ics.ellipsis}).

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -392,7 +392,7 @@ statements contained within the (compound) substatement, but this is not
 required.
 \indextext{statement!declaration in \tcode{switch}}%
 Declarations can appear in the substatement of a
-\grammarterm{switch-statement}.
+\tcode{switch} statement.
 \end{note}
 
 \pnum

--- a/source/support.tex
+++ b/source/support.tex
@@ -2958,7 +2958,7 @@ The class
 defines the type of objects thrown
 as exceptions by the implementation to report the execution of an invalid
 \indextext{cast!dynamic}%
-\grammarterm{dynamic-cast}
+\tcode{dynamic_cast}
 expression~(\ref{expr.dynamic.cast}).
 
 \indexlibrary{\idxcode{bad_cast}!constructor}%
@@ -3025,7 +3025,7 @@ The class
 defines the type of objects
 thrown as exceptions by the implementation to report a null pointer
 in a
-\grammarterm{typeid}
+\tcode{typeid}
 expression~(\ref{expr.typeid}).
 
 \indexlibrary{\idxcode{bad_typeid}!constructor}%

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -378,7 +378,7 @@ is a
 in a
 \grammarterm{template-parameter}.
 A default
-\grammarterm{tem\-plate-argument}
+\grammarterm{template-argument}
 may be specified for any kind of
 \grammarterm{template-parameter}
 (type, non-type, template)
@@ -868,7 +868,7 @@ list can be empty.
 In that case the empty
 \tcode{<>}
 brackets shall still be used as the
-\grammarterm{template-argument-list.}
+\grammarterm{template-argument-list}.
 \begin{example}
 
 \begin{codeblock}
@@ -3556,9 +3556,9 @@ value of
 template parameters (as determined by the template arguments) and this determines
 the context for name lookup for certain names.
 An expressions may be
-\grammarterm{type-dependent}
+\defnx{type-dependent}{expression!type-dependent}
 (that is, its type may depend on a template parameter) or
-\grammarterm{value-dependent}
+\defnx{value-dependent}{expression!value-dependent}
 (that is, its value when evaluated as a constant expression~(\ref{expr.const})
 may depend on a template parameter)
 as described in this subclause.


### PR DESCRIPTION
Thereby also improving the index.