### PR TITLE
[containers] Rephrase deduction guide constraints

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -700,6 +700,31 @@ linear													\\ \rowsep
 
 \end{libreqtab4a}
 
+\pnum
+In this Clause the behavior of certain member functions and deduction guides
+depends on whether types qualify as input iterators or allocators.
+The extent to which an implementation determines that a type cannot be an input
+iterator is unspecified, except that as a minimum integral types shall not qualify
+as input iterators.
+Likewise, the extent to which an implementation determines that a type cannot be
+an allocator is unspecified, except that as a minimum a type \tcode{A} shall not qualify
+as an allocator unless it satisfies both of the following conditions:
+
+\begin{itemize}
+\item The \grammarterm{qualified-id} \tcode{A::value_type}
+is valid and denotes a type~(\ref{temp.deduct}).
+
+\item The expression \tcode{declval<A\&>().allocate(size_t\{\})}
+is well-formed when treated as an unevaluated operand.
+\end{itemize}
+
+\pnum
+\begin{note}
+Implementations may impose additional conditions which must be satisfied
+to qualify as an input iterator or an allocator.
+\end{note}
+
+
 \rSec2[container.requirements.dataraces]{Container data races}
 
 \pnum
@@ -1002,26 +1027,10 @@ iterator, then these functions
 shall not participate in overload resolution.
 
 \item A deduction guide for a sequence container shall not participate in overload resolution
-if it has an \tcode{InputIterator} template parameter that is called with a type that does not
-qualify as an input iterator,
-or if it has an \tcode{Allocator} template parameter that is called with a type that does not
-qualify as an allocator.
-\end{itemize}
-
-\pnum
-The extent to which an implementation determines that a type cannot be an input
-iterator is unspecified, except that as a minimum integral types shall not qualify
-as input iterators.
-Likewise, the extent to which an implementation determines that a type cannot be
-an allocator is unspecified, except that as a minimum a type \tcode{A} not satisfying
-both of the following conditions shall not qualify as an allocator:
-
-\begin{itemize}
-\item The \grammarterm{qualified-id} \tcode{A::value_type}
-is valid and denotes a type~(\ref{temp.deduct}).
-
-\item The expression \tcode{declval<A\&>().allocate(size_t\{\})}
-is well-formed when treated as an unevaluated operand.
+if it has an \tcode{InputIterator} template parameter and a type that does not
+qualify as an input iterator is deduced for that parameter,
+or if it has an \tcode{Allocator} template parameter and a type that does not
+qualify as an allocator is deduced for that parameter.
 \end{itemize}
 
 \pnum
@@ -2038,13 +2047,13 @@ A deduction guide for an associative container shall not participate in overload
 if any of the following are true:
 \begin{itemize}
 \item It has an \tcode{InputIterator} template parameter
-that is called with a type that does not qualify as an input iterator.
+and a type that does not qualify as an input iterator is deduced for that parameter.
 
 \item It has an \tcode{Allocator} template parameter
-that is called with a type that does not qualify as an allocator.
+and a type that does not qualify as an allocator is deduced for that parameter.
 
 \item It has a \tcode{Compare} template parameter
-that is called with a type that qualifies as an allocator.
+and a type that qualifies as an allocator is deduced for that parameter.
 \end{itemize}
 
 \indextext{associative containers!exception safety}%
@@ -2871,16 +2880,16 @@ A deduction guide for an unordered associative container shall not participate i
 if any of the following are true:
 \begin{itemize}
 \item It has an \tcode{InputIterator} template parameter
-that is called with a type that does not qualify as an input iterator.
+and a type that does not qualify as an input iterator is deduced for that parameter.
 
 \item It has an \tcode{Allocator} template parameter
-that is called with a type that does not qualify as an allocator.
+and a type that does not qualify as an allocator is deduced for that parameter.
 
 \item It has a \tcode{Hash} template parameter
-that is called with an integral type or a type that qualifies as an allocator.
+and an integral type or a type that qualifies as an allocator is deduced for that parameter.
 
 \item It has a \tcode{Pred} template parameter
-that is called with a type that qualifies as an allocator.
+and a type that qualifies as an allocator is deduced for that parameter.
 \end{itemize}
 
 \rSec3[unord.req.except]{Exception safety guarantees}
@@ -9164,10 +9173,10 @@ exception is thrown by the swap of the adaptor's \tcode{Container} or
 \pnum
 A deduction guide for a container adaptor shall not participate in overload resolution if any of the following are true:
 \begin{itemize}
-\item It has an \tcode{InputIterator} template parameter that is called with a type that does not qualify as an input iterator.
-\item It has a \tcode{Compare} template parameter that is called with a type that qualifies as an allocator.
-\item It has a \tcode{Container} template parameter that is called with a type that qualifies as an allocator.
-\item It has an \tcode{Allocator} template parameter that is called with a type that does not qualify as an allocator.
+\item It has an \tcode{InputIterator} template parameter and a type that does not qualify as an input iterator is deduced for that parameter.
+\item It has a \tcode{Compare} template parameter and a type that qualifies as an allocator is deduced for that parameter.
+\item It has a \tcode{Container} template parameter and a type that qualifies as an allocator is deduced for that parameter.
+\item It has an \tcode{Allocator} template parameter and a type that does not qualify as an allocator is deduced for that parameter.
 \item It has both \tcode{Container} and \tcode{Allocator} template parameters, and \tcode{uses_allocator_v<Container, Allocator>} is \tcode{false}.
 \end{itemize}
 


### PR DESCRIPTION
Replace "is called with" wording that doesn't apply to deduction guides.

Move rules about qualifying as input iterators or allocators to
[container.requirements.general].

Fixes #1524 