### PR TITLE
[swappable.requirements] Mark up the swappable requirement in code font

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -3188,7 +3188,7 @@ template<class ExecutionPolicy, class BidirectionalIterator>
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{*first} shall be swappable~(\ref{swappable.requirements}).
+\tcode{*first} shall be \tcode{swappable}~(\ref{swappable.requirements}).
 
 \pnum
 \effects

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -339,12 +339,12 @@ container type other than \tcode{array}, shall exchange the values of \tcode{a} 
 \tcode{b} without invoking any move, copy, or swap operations on the individual
 container elements.
 Lvalues of any \tcode{Compare}, \tcode{Pred}, or \tcode{Hash} types
-belonging to \tcode{a} and \tcode{b} shall be swappable
+belonging to \tcode{a} and \tcode{b} shall be \tcode{swappable}
 and shall be exchanged by calling \tcode{swap}
 as described in~\ref{swappable.requirements}. If
 \tcode{allocator_traits<allocator_type>::propagate_on_container_swap::value} is
 \tcode{true}, then
-lvalues of type \tcode{allocator_type} shall be swappable and
+lvalues of type \tcode{allocator_type} shall be \tcode{swappable} and
 the allocators of \tcode{a} and \tcode{b} shall also be exchanged
 by calling \tcode{swap} as described in~\ref{swappable.requirements}.
 Otherwise, the allocators shall not be swapped, and the behavior is
@@ -863,7 +863,7 @@ The complexities of the expressions are sequence dependent.
  \requires\ \tcode{T} shall be \tcode{EmplaceConstructible} into \tcode{X} from \tcode{*i}.
  For \tcode{vector} and \tcode{deque}, \tcode{T} shall also be
  \tcode{MoveInsertable} into \tcode{X}, \tcode{MoveConstructible}, \tcode{MoveAssignable},
- and swappable~(\ref{swappable.requirements}).
+ and \tcode{swappable}~(\ref{swappable.requirements}).
  Each iterator in the range \range{i}{j} shall be dereferenced exactly once.\br
  \requires \tcode{i} and \tcode{j} are not iterators into \tcode{a}.\br
  Inserts copies of elements in \tcode{[i, j)} before \tcode{p}  \\ \rowsep

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -268,7 +268,7 @@ A type \tcode{X} satisfies the \tcode{Iterator} requirements if:
 \begin{itemize}
 \item \tcode{X} satisfies the \tcode{CopyConstructible}, \tcode{CopyAssignable}, and
 \tcode{Destructible} requirements~(\ref{utility.arg.requirements}) and lvalues
-of type \tcode{X} are swappable (\ref{swappable.requirements}), and
+of type \tcode{X} are \tcode{swappable} (\ref{swappable.requirements}), and
 
 \item the expressions in Table~\ref{tab:iterator.requirements} are valid and have
 the indicated semantics.

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1534,7 +1534,7 @@ Expression      &   Post-condition  \\ \capsep
 \rSec3[swappable.requirements]{\tcode{Swappable} requirements}
 
 \pnum
-This subclause provides definitions for swappable types and expressions. In these
+This subclause provides definitions for \tcode{swappable} types and expressions. In these
 definitions, let \tcode{t} denote an expression of type \tcode{T}, and let \tcode{u}
 denote an expression of type \tcode{U}.
 
@@ -1571,7 +1571,7 @@ scope, the overall lookup set described above is equivalent to that of the
 qualified name lookup applied to the expression \tcode{std::swap(t, u)} or
 \tcode{std::swap(u, t)} as appropriate. \end{note}
 
-\begin{note} It is unspecified whether a library component that has a swappable
+\begin{note} It is unspecified whether a library component that has a \tcode{swappable}
 requirement includes the header \tcode{<utility>} to ensure an appropriate
 evaluation context. \end{note}
 
@@ -1584,7 +1584,7 @@ A type \tcode{X} satisfying any of the iterator requirements~(\ref{iterator.requ
 satisfies the requirements of \tcode{ValueSwappable} if,
 for any dereferenceable object
 \tcode{x} of type \tcode{X},
-\tcode{*x} is swappable.
+\tcode{*x} is \tcode{swappable}.
 
 \begin{example} User code can ensure that the evaluation of \tcode{swap} calls
 is performed in an appropriate context under the various conditions as follows:
@@ -1599,7 +1599,7 @@ void value_swap(T&& t, U&& u) {
                                                 // for rvalues and lvalues
 }
 
-// Requires: lvalues of \tcode{T} shall be swappable.
+// Requires: lvalues of \tcode{T} shall be \tcode{swappable}.
 template <class T>
 void lv_swap(T& t1, T& t2) {
   using std::swap;
@@ -1641,7 +1641,7 @@ A type \tcode{P} meets the requirements of \tcode{NullablePointer} if:
 \tcode{DefaultConstructible}, \tcode{CopyConstructible}, \tcode{CopyAssignable},
 and \tcode{Destructible},
 
-\item lvalues of type \tcode{P} are swappable~(\ref{swappable.requirements}),
+\item lvalues of type \tcode{P} are \tcode{swappable}~(\ref{swappable.requirements}),
 
 \item the expressions shown in Table~\ref{tab:nullablepointer} are
 valid and have the indicated semantics, and
@@ -2036,7 +2036,7 @@ If \tcode{X::propagate_on_container_move_assignment::value} is \tcode{true},
 \tcode{MoveAssignable} requirements (Table~\ref{tab:moveassignable})
 and the move operation shall not throw exceptions.
 If \tcode{X::propagate_on_container_swap::value} is \tcode{true},
-lvalues of type \tcode{X} shall be swappable~(\ref{swappable.requirements})
+lvalues of type \tcode{X} shall be \tcode{swappable}~(\ref{swappable.requirements})
 and the \tcode{swap} operation shall not throw exceptions.
 
 \pnum

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -3273,7 +3273,7 @@ void swap(optional& rhs) noexcept(@\seebelow@);
 \begin{itemdescr}
 \pnum
 \requires
-Lvalues of type \tcode{T} shall be swappable and \tcode{is_move_constructible_v<T>} is \tcode{true}.
+Lvalues of type \tcode{T} shall be \tcode{swappable} and \tcode{is_move_constructible_v<T>} is \tcode{true}.
 
 \pnum
 \effects
@@ -4929,7 +4929,7 @@ void swap(variant& rhs) noexcept(@\seebelow@);
 
 \begin{itemdescr}
 \pnum
-\requires Lvalues of type $\tcode{T}_i$ shall be swappable~(\ref{swappable.requirements}) and
+\requires Lvalues of type $\tcode{T}_i$ shall be \tcode{swappable}~(\ref{swappable.requirements}) and
 \tcode{is_move_constructible_v<$\tcode{T}_i$>} shall be \tcode{true} for all $i$.
 
 \pnum
@@ -9003,7 +9003,7 @@ void swap(unique_ptr& u) noexcept;
 \begin{itemdescr}
 \pnum
 \requires \tcode{get_deleter()} shall be
-swappable~(\ref{swappable.requirements}) and shall
+\tcode{swappable}~(\ref{swappable.requirements}) and shall
 not throw an exception
 under \tcode{swap}.
 
@@ -15197,7 +15197,7 @@ An enabled specialization \tcode{hash<Key>} will:
 with \tcode{Key} as the function
 call argument type, the \tcode{Default\-Constructible} requirements (Table~\ref{tab:defaultconstructible}),
 the \tcode{CopyAssignable} requirements (Table~\ref{tab:copyassignable}),
-\item be swappable~(\ref{swappable.requirements}) for lvalues,
+\item be \tcode{swappable}~(\ref{swappable.requirements}) for lvalues,
 \item satisfy the requirement that if \tcode{k1 == k2} is \tcode{true}, \tcode{h(k1) == h(k2)} is
 also \tcode{true}, where \tcode{h} is an object of type \tcode{hash<Key>} and \tcode{k1} and \tcode{k2}
 are objects of type \tcode{Key};
@@ -16018,7 +16018,7 @@ notwithstanding the restrictions of~\ref{declval}.
   \tcode{swap(declval<U>(), declval<T>())} are each well-formed
   when treated as an unevaluated operand (Clause~\ref{expr})
   in an overload-resolution context
-  for swappable values~(\ref{swappable.requirements}).
+  for \tcode{swappable} values~(\ref{swappable.requirements}).
   Access checking is performed as if in a context
   unrelated to \tcode{T} and \tcode{U}.
   Only the validity of the immediate context
@@ -17601,7 +17601,7 @@ numeric types~(\ref{numeric.requirements}). \begin{note} This means, in particul
 that operations on these types will not throw exceptions. \end{note}
 
 \item lvalues of the types \tcode{TC::rep}, \tcode{TC::duration}, and
-\tcode{TC::time_point} are swappable~(\ref{swappable.requirements}),
+\tcode{TC::time_point} are \tcode{swappable}~(\ref{swappable.requirements}),
 
 \item the function \tcode{TC::now()} does not throw exceptions, and
 


### PR DESCRIPTION
Requiements like CopyConstrible and MoveAssignable are usually marked
up in code font.  This PR applies the same pattern to the swappable
requirement, but not 'swappable with'.  The need for this change was
most obvious for types that combined the swappble requirement with
others, such as MoveConstructible.