### PR TITLE
[library] Add a noun 'subclause' or 'annex' to references that are used as nouns

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1126,12 +1126,12 @@ macros in \Cpp standard library headers.\footnote{In particular, including the
 standard header \tcode{<iso646.h>} or \tcode{<ciso646>} has no effect.}
 
 \pnum
-\ref{depr.c.headers}, C standard library headers, describes the effects of using
-the \tcode{\placeholder{name}.h} (C header) form in a \Cpp program.\footnote{ The
+Annex~\ref{depr.c.headers}, C standard library headers, describes the effects of using
+the \tcode{\placeholder{name}.h} (C header) form in a \Cpp program.\footnote{The
 \tcode{".h"} headers dump all their names into the global namespace, whereas the
 newer forms keep their names in namespace \tcode{std}. Therefore, the newer
 forms are the preferred forms for all uses except for \Cpp programs which are
-intended to be strictly compatible with C. }
+intended to be strictly compatible with C.}
 
 \pnum
 Annex K of the C standard describes a large number of functions,
@@ -1153,7 +1153,7 @@ is declared in the global namespace.
 \pnum
 Table~\ref{tab:c.annex.k.names} lists the Annex K names
 that may be declared in some header.
-These names are also subject to the restrictions of~\ref{macro.names}.
+These names are also subject to the restrictions of subclause~\ref{macro.names}.
 
 \begin{floattable}{C standard Annex K names}{tab:c.annex.k.names}
 {llll}
@@ -1307,9 +1307,9 @@ The other headers listed in this table shall meet the same requirements as for a
 \rSec3[using.overview]{Overview}
 
 \pnum
-This section describes how a \Cpp program gains access to the facilities of the
-\Cpp standard library. \ref{using.headers} describes effects during translation
-phase 4, while~\ref{using.linkage} describes effects during phase
+This subclause describes how a \Cpp program gains access to the facilities of the
+\Cpp standard library. Clause~\ref{using.headers} describes effects during translation
+phase 4, while Clause~\ref{using.linkage} describes effects during phase
 8\iref{lex.phases}.
 
 \rSec3[using.headers]{Headers}
@@ -1389,15 +1389,15 @@ runtime changes\iref{handler.functions}.
 \rSec2[utility.requirements]{Requirements on types and expressions}
 
 \pnum
-\ref{utility.arg.requirements}
+Subclause~\ref{utility.arg.requirements}
 describes requirements on types and expressions used to instantiate templates
 defined in the \Cpp standard library.
-\ref{swappable.requirements} describes the requirements on swappable types and
+Subclause~\ref{swappable.requirements} describes the requirements on swappable types and
 swappable expressions.
-\ref{nullablepointer.requirements} describes the requirements on pointer-like
+Subclause~\ref{nullablepointer.requirements} describes the requirements on pointer-like
 types that support null values.
-\ref{hash.requirements} describes the requirements on hash function objects.
-\ref{allocator.requirements} describes the requirements on storage
+Subclause~\ref{hash.requirements} describes the requirements on hash function objects.
+Subclause~\ref{allocator.requirements} describes the requirements on storage
 allocators.
 
 \rSec3[utility.arg.requirements]{Template argument requirements}
@@ -2640,12 +2640,12 @@ paragraph specifies throwing an exception when the precondition is violated.
 This section describes the constraints upon, and latitude of, implementations of the \Cpp standard library.
 
 \pnum
-An implementation's use of headers is discussed in~\ref{res.on.headers}, its use
-of macros in~\ref{res.on.macro.definitions}, non-member functions
-in~\ref{global.functions}, member functions in~\ref{member.functions}, data race
-avoidance in~\ref{res.on.data.races}, access specifiers
-in~\ref{protection.within.classes}, class derivation in~\ref{derivation}, and
-exceptions in~\ref{res.on.exception.handling}.
+An implementation's use of headers is discussed in subclause~\ref{res.on.headers}, its use
+of macros in subclause~\ref{res.on.macro.definitions}, non-member functions
+in subclause~\ref{global.functions}, member functions in subclause~\ref{member.functions}, data race
+avoidance in subclause~\ref{res.on.data.races}, access specifiers
+in subclause~\ref{protection.within.classes}, class derivation in subclause~\ref{derivation}, and
+exceptions in subclause~\ref{res.on.exception.handling}.
 
 \rSec3[res.on.headers]{Headers}
 
@@ -2664,13 +2664,13 @@ included after any other header that also defines it\iref{basic.def.odr}.
 \pnum
 The C standard library headers\iref{depr.c.headers}
 shall include only their corresponding \Cpp standard library header,
-as described in~\ref{headers}.
+as described in subclause~\ref{headers}.
 
 \rSec3[res.on.macro.definitions]{Restrictions on macro definitions}
 \indextext{restriction}%
 
 \pnum
-The names and global function signatures described in~\ref{contents} are
+The names and global function signatures described in subclause~\ref{contents} are
 reserved to the implementation.
 \indextext{argument}%
 \indextext{header!C}%


### PR DESCRIPTION
It is awkward to treat symbols or references like complete nouns. This change adds the words "subclause" or "annex" when references are used.