### PR TITLE
Consistently use math mode for index notation and ellipses in INVOKE expressions

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -5038,7 +5038,7 @@ template <class F>
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{\placeholdernc{INVOKE}<R>(f, t1, t2, ..., tN)}, where \tcode{t1, t2, ..., tN} are values
+\tcode{\placeholdernc{INVOKE}<R>(f, t$_1$, t$_2$, $\dotsc$, t$_N$)}, where \tcode{t$_1$, t$_2$, $\dotsc$, t$_N$} are values
 of the corresponding types in \tcode{ArgTypes...}, shall be a valid expression. Invoking
 a copy of \tcode{f} shall behave the same as invoking \tcode{f}.
 
@@ -5160,10 +5160,10 @@ void operator()(ArgTypes... args);
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{\placeholdernc{INVOKE}<R>(f, t1, t2, ..., tN)},
+\effects As if by \tcode{\placeholdernc{INVOKE}<R>(f, t$_1$, t$_2$, $\dotsc$, t$_N$)},
 where \tcode{f} is the
 stored task of \tcode{*this} and
-\tcode{t1, t2, ..., tN} are the values in \tcode{args...}. If the task returns normally,
+\tcode{t$_1$, t$_2$, $\dotsc$, t$_N$} are the values in \tcode{args...}. If the task returns normally,
 the return value is stored as the asynchronous result in the shared state of
 \tcode{*this}, otherwise the exception thrown by the task is stored. The
 shared state of \tcode{*this} is made ready, and any threads blocked in a
@@ -5190,9 +5190,9 @@ void make_ready_at_thread_exit(ArgTypes... args);
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{\placeholdernc{INVOKE}<R>(f, t1, t2, ..., tN)},
+\effects As if by \tcode{\placeholdernc{INVOKE}<R>(f, t$_1$, t$_2$, $\dotsc$, t$_N$)},
 where \tcode{f} is the stored task and
-\tcode{t1, t2, ..., tN} are the values in \tcode{args...}. If the task returns normally,
+\tcode{t$_1$, t$_2$, $\dotsc$, t$_N$} are the values in \tcode{args...}. If the task returns normally,
 the return value is stored as the asynchronous result in the shared state of
 \tcode{*this}, otherwise the exception thrown by the task is stored. In either
 case, this shall be done without making that state ready~(\ref{futures.state}) immediately. Schedules

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -13094,42 +13094,42 @@ A \term{target object} is the callable object held by a call wrapper.
 
 \pnum
 \indexlibrary{invoke@\tcode{\placeholder{INVOKE}}}%
-Define \tcode{\placeholdernc{INVOKE}(f, t1, t2, ..., tN)} as follows:
+Define \tcode{\placeholdernc{INVOKE}(f, t$_1$, t$_2$, $\dotsc$, t$_N$)} as follows:
 
 \begin{itemize}
-\item \tcode{(t1.*f)(t2, ..., tN)} when \tcode{f} is a pointer to a
+\item \tcode{(t$_1$.*f)(t$_2$, $\dotsc$, t$_N$)} when \tcode{f} is a pointer to a
 member function of a class \tcode{T}
-and \tcode{is_base_of_v<T, decay_t<decltype(t1)>>} is \tcode{true};
+and \tcode{is_base_of_v<T, decay_t<decltype(t$_1$)>>} is \tcode{true};
 
-\item \tcode{(t1.get().*f)(t2, ..., tN)} when \tcode{f} is a pointer to a
+\item \tcode{(t$_1$.get().*f)(t$_2$, $\dotsc$, t$_N$)} when \tcode{f} is a pointer to a
 member function of a class \tcode{T}
-and \tcode{decay_t<decltype(t1)>} is a specialization of \tcode{reference_wrapper};
+and \tcode{decay_t<decltype(t$_1$)>} is a specialization of \tcode{reference_wrapper};
 
-\item \tcode{((*t1).*f)(t2, ..., tN)} when \tcode{f} is a pointer to a
+\item \tcode{((*t$_1$).*f)(t$_2$, $\dotsc$, t$_N$)} when \tcode{f} is a pointer to a
 member function of a class \tcode{T}
-and \tcode{t1} does not satisfy the previous two items;
+and \tcode{t$_1$} does not satisfy the previous two items;
 
-\item \tcode{t1.*f} when \tcode{N == 1} and \tcode{f} is a pointer to
+\item \tcode{t$_1$.*f} when \tcode{N == 1} and \tcode{f} is a pointer to
 data member of a class \tcode{T}
-and \tcode{is_base_of_v<T, decay_t<decltype(t1)>>} is \tcode{true};
+and \tcode{is_base_of_v<T, decay_t<decltype(t$_1$)>>} is \tcode{true};
 
-\item \tcode{t1.get().*f} when \tcode{N == 1} and \tcode{f} is a pointer to
+\item \tcode{t$_1$.get().*f} when \tcode{N == 1} and \tcode{f} is a pointer to
 data member of a class \tcode{T}
-and \tcode{decay_t<decltype(t1)>} is a specialization of \tcode{reference_wrapper};
+and \tcode{decay_t<decltype(t$_1$)>} is a specialization of \tcode{reference_wrapper};
 
-\item \tcode{(*t1).*f} when \tcode{N == 1} and \tcode{f} is a pointer to
+\item \tcode{(*t$_1$).*f} when \tcode{N == 1} and \tcode{f} is a pointer to
 data member of a class \tcode{T}
-and \tcode{t1} does not satisfy the previous two items;
+and \tcode{t$_1$} does not satisfy the previous two items;
 
-\item \tcode{f(t1, t2, ..., tN)} in all other cases.
+\item \tcode{f(t$_1$, t$_2$, $\dotsc$, t$_N$)} in all other cases.
 \end{itemize}
 
 \pnum
 \indexlibrary{invoke@\tcode{\placeholder{INVOKE}}}%
-Define \tcode{\placeholdernc{INVOKE}<R>(f, t1, t2, ..., tN)} as
-\tcode{static_cast<void>(\placeholdernc{INVOKE}(f, t1, t2, ..., tN))}
+Define \tcode{\placeholdernc{INVOKE}<R>(f, t$_1$, t$_2$, $\dotsc$, t$_N$)} as
+\tcode{static_cast<void>(\placeholdernc{INVOKE}(f, t$_1$, t$_2$, $\dotsc$, t$_N$))}
 if \tcode{R} is \cv{}~\tcode{void}, otherwise
-\tcode{\placeholdernc{INVOKE}(f, t1, t2, ..., tN)} implicitly converted
+\tcode{\placeholdernc{INVOKE}(f, t$_1$, t$_2$, $\dotsc$, t$_N$)} implicitly converted
 to \tcode{R}.
 
 \pnum

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -14421,8 +14421,8 @@ template<class R, class T> @\unspec@ mem_fn(R T::* pm) noexcept;
 \begin{itemdescr}
 \pnum
 \returns A simple call wrapper~(\ref{func.def}) \tcode{fn}
-such that the expression \tcode{fn(t, a2, ..., aN)} is equivalent
-to \tcode{\placeholdernc{INVOKE}(pm, t, a2, ..., aN)}~(\ref{func.require}).
+such that the expression \tcode{fn(t, a$_2$, $\dotsc$, a$_N$)} is equivalent
+to \tcode{\placeholdernc{INVOKE}(pm, t, a$_2$, $\dotsc$, a$_N$)}~(\ref{func.require}).
 \end{itemdescr}
 \indextext{function object!\idxcode{mem_fn}|)}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -14274,22 +14274,22 @@ template<class F, class... BoundArgs>
 \requires
 \tcode{is_constructible_v<FD, F>} shall be \tcode{true}. For each $\tcode{T}_i$
 in \tcode{BoundArgs}, \tcode{is_cons\-tructible_v<$\tcode{TD}_i$, $\tcode{T}_i$>} shall be \tcode{true}.
-\tcode{\placeholdernc{INVOKE}(fd, $\tcode{w}_1$, $\tcode{w}_2$, \ldots,
+\tcode{\placeholdernc{INVOKE}(fd, $\tcode{w}_1$, $\tcode{w}_2$, $\dotsc$,
 $\tcode{w}_N$)}~(\ref{func.require}) shall be a valid expression for some
-values $\tcode{w}_1$, $\tcode{w}_2$, \ldots, $\tcode{w}_N$, where
+values $\tcode{w}_1$, $\tcode{w}_2$, $\dotsc{}$, $\tcode{w}_N$, where
 $N$ has the value \tcode{sizeof...(bound_args)}.
 The cv-qualifiers \cv{} of the call wrapper \tcode{g},
 as specified below, shall be neither \tcode{volatile} nor \tcode{const volatile}.
 
 \pnum\returns
 A forwarding call wrapper \tcode{g}~(\ref{func.require}).
-The effect of \tcode{g($\tcode{u}_1$, $\tcode{u}_2$, \ldots, $\tcode{u}_M$)} shall
+The effect of \tcode{g($\tcode{u}_1$, $\tcode{u}_2$, $\dotsc$, $\tcode{u}_M$)} shall
 be
 \begin{codeblock}
-@\placeholdernc{INVOKE}@(fd, std::forward<@$\tcode{V}_1$@>(@$\tcode{v}_1$@), std::forward<@$\tcode{V}_2$@>(@$\tcode{v}_2$@), @\ldots @, std::forward<@$\tcode{V}_N$@>(@$\tcode{v}_N$@))
+@\placeholdernc{INVOKE}@(fd, std::forward<@$\tcode{V}_1$@>(@$\tcode{v}_1$@), std::forward<@$\tcode{V}_2$@>(@$\tcode{v}_2$@), @$\dotsc$@, std::forward<@$\tcode{V}_N$@>(@$\tcode{v}_N$@))
 \end{codeblock}
 where the values and types of the bound
-arguments $\tcode{v}_1$, $\tcode{v}_2$, \ldots, $\tcode{v}_N$ are determined as specified below.
+arguments $\tcode{v}_1$, $\tcode{v}_2$, $\dotsc$, $\tcode{v}_N$ are determined as specified below.
 The copy constructor and move constructor of the forwarding call wrapper shall throw an
 exception if and only if the corresponding constructor of \tcode{FD} or of any of the types
 $\tcode{TD}_i$ throws an exception.
@@ -14316,9 +14316,9 @@ template<class R, class F, class... BoundArgs>
 \requires
 \tcode{is_constructible_v<FD, F>} shall be \tcode{true}. For each $\tcode{T}_i$
 in \tcode{BoundArgs}, \tcode{is_con\-structible_v<$\tcode{TD}_i$, $\tcode{T}_i$>} shall be \tcode{true}.
-\tcode{\placeholdernc{INVOKE}(fd, $\tcode{w}_1$, $\tcode{w}_2$, \ldots, $\tcode{w}_N$)} shall be  a valid
+\tcode{\placeholdernc{INVOKE}(fd, $\tcode{w}_1$, $\tcode{w}_2$, $\dotsc$, $\tcode{w}_N$)} shall be  a valid
 expression for some
-values $\tcode{w}_1$, $\tcode{w}_2$, \ldots, $\tcode{w}_N$, where
+values $\tcode{w}_1$, $\tcode{w}_2$, $\dotsc$, $\tcode{w}_N$, where
 $N$ has the value \tcode{sizeof...(bound_args)}.
 The cv-qualifiers \cv{} of the call wrapper \tcode{g},
 as specified below, shall be neither \tcode{volatile} nor \tcode{const volatile}.
@@ -14327,12 +14327,12 @@ as specified below, shall be neither \tcode{volatile} nor \tcode{const volatile}
 \returns
 A forwarding call wrapper \tcode{g}~(\ref{func.require}).
 The effect of
-\tcode{g($\tcode{u}_1$, $\tcode{u}_2$, \ldots, $\tcode{u}_M$)} shall be
+\tcode{g($\tcode{u}_1$, $\tcode{u}_2$, $\dotsc$, $\tcode{u}_M$)} shall be
 \begin{codeblock}
-@\placeholdernc{INVOKE}@<R>(fd, std::forward<@$\tcode{V}_1$@>(@$\tcode{v}_1$@), std::forward<@$\tcode{V}_2$@>(@$\tcode{v}_2$@), @\ldots @, std::forward<@$\tcode{V}_N$@>(@$\tcode{v}_N$@))
+@\placeholdernc{INVOKE}@<R>(fd, std::forward<@$\tcode{V}_1$@>(@$\tcode{v}_1$@), std::forward<@$\tcode{V}_2$@>(@$\tcode{v}_2$@), @$\dotsc$@, std::forward<@$\tcode{V}_N$@>(@$\tcode{v}_N$@))
 \end{codeblock}
 where the values and types of the bound
-arguments $\tcode{v}_1$, $\tcode{v}_2$, \ldots, $\tcode{v}_N$ are determined as specified below.
+arguments $\tcode{v}_1$, $\tcode{v}_2$, $\dotsc$, $\tcode{v}_N$ are determined as specified below.
 The copy constructor and move constructor of the forwarding call wrapper shall throw an
 exception if and only if the corresponding constructor of \tcode{FD} or of any of the types
 $\tcode{TD}_i$ throws an exception.
@@ -14350,8 +14350,8 @@ that all of \tcode{FD} and $\tcode{TD}_i$ are \tcode{MoveConstructible}. \end{no
 
 \pnum
 \indextext{bound arguments}%
-The values of the \techterm{bound arguments} $\tcode{v}_1$, $\tcode{v}_2$, \ldots, $\tcode{v}_N$ and their
-corresponding types $\tcode{V}_1$, $\tcode{V}_2$, \ldots, $\tcode{V}_N$ depend on the
+The values of the \techterm{bound arguments} $\tcode{v}_1$, $\tcode{v}_2$, $\dotsc$, $\tcode{v}_N$ and their
+corresponding types $\tcode{V}_1$, $\tcode{V}_2$, $\dotsc$, $\tcode{V}_N$ depend on the
 types $\tcode{TD}_i$ derived from
 the call to \tcode{bind} and the
 cv-qualifiers \cv{} of the call wrapper \tcode{g} as follows:


### PR DESCRIPTION
This changes pseudocode expressions of the form `INVOKE(f, t1, t2, ..., tN)` so that the index notation and ellipsis are in math mode, and so not mistaken for C++ variables or the `...` token.

[func.require]:
![func require](https://cloud.githubusercontent.com/assets/1254480/24111203/a22daa34-0d8d-11e7-9fe9-8187b50683c4.png)
and:
![func require2](https://cloud.githubusercontent.com/assets/1254480/24111212/a604b4c2-0d8d-11e7-972c-94da5bbba258.png)
[func.bind] already formatted the indices this way, but used code font for the `...` between the metavariables:
![func bind](https://cloud.githubusercontent.com/assets/1254480/24111219/aa836386-0d8d-11e7-946a-1a7023730dcb.png)
[func.memfn]:
![func memfn](https://cloud.githubusercontent.com/assets/1254480/24111224/adfc8100-0d8d-11e7-85aa-8d01cb6c5de7.png)
[futures.task.members]:
![futures task members](https://cloud.githubusercontent.com/assets/1254480/24111226/b0ca1d3e-0d8d-11e7-9260-475f3f1b8ada.png)
and:
![futures task members2](https://cloud.githubusercontent.com/assets/1254480/24111229/b325bc5a-0d8d-11e7-8c4f-1cd19a6af96b.png)

