### PR TITLE
[numerics] Use absolute-value markers in math mode.

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -9690,10 +9690,10 @@ template <class M, class N>
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{|m|} and \tcode{|n|} shall
+$|\tcode{m}|$ and $|\tcode{n}|$ shall
 be representable as a value of \tcode{common_type_t<M, N>}.
 \begin{note} These requirements ensure, for example,
-that \tcode{gcd(m, m) = |m|} is representable as a value of type \tcode{M}. \end{note}
+that $\tcode{gcd(m, m)} = |\tcode{m}|$ is representable as a value of type \tcode{M}. \end{note}
 
 \pnum
 \remarks
@@ -9703,7 +9703,7 @@ if either is \cv{}~\tcode{bool}, the program is ill-formed.
 \pnum
 \returns
 Zero when \tcode{m} and \tcode{n} are both zero.
-Otherwise, returns the greatest common divisor of \tcode{|m|} and \tcode{|n|}.
+Otherwise, returns the greatest common divisor of $|\tcode{m}|$ and $|\tcode{n}|$.
 
 \pnum
 \throws
@@ -9721,9 +9721,9 @@ template <class M, class N>
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{|m|} and \tcode{|n|} shall
+$|\tcode{m}|$ and $|\tcode{n}|$ shall
 be representable as a value of \tcode{common_type_t<M, N>}.
-The least common multiple of \tcode{|m|} and \tcode{|n|}
+The least common multiple of $|\tcode{m}|$ and $|\tcode{n}|$
 shall be representable as a value of type \tcode{common_type_t<M,N>}.
 
 \pnum
@@ -9734,7 +9734,7 @@ if either is \cv{}~\tcode{bool} the program is ill-formed.
 \pnum
 \returns
 Zero when either \tcode{m} or \tcode{n} is zero.
-Otherwise, returns the least common multiple of \tcode{|m|} and \tcode{|n|}.
+Otherwise, returns the least common multiple of $|\tcode{m}|$ and $|\tcode{n}|$.
 
 \pnum
 \throws


### PR DESCRIPTION
Fixes #1537.