### PR TITLE
[rand, atomics] Don't needlessly escape underscores.

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -1239,7 +1239,7 @@ T operator++(int) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\effects Equivalent to: \tcode{return fetch\_add(1);}
+\effects Equivalent to: \tcode{return fetch_add(1);}
 \end{itemdescr}
 
 \indexlibrarymember{operator\dcr}{atomic<T*>}%
@@ -1250,7 +1250,7 @@ T operator--(int) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\effects Equivalent to: \tcode{return fetch\_sub(1);}
+\effects Equivalent to: \tcode{return fetch_sub(1);}
 \end{itemdescr}
 
 \indexlibrarymember{operator++}{atomic<T*>}%

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -1435,7 +1435,7 @@ that entity is characterized:
 If integer-valued,
 an entity may optionally be further characterized as
 \techterm{signed} or \techterm{unsigned},
-according to \tcode{numeric\_limits<T>::is\_signed}.
+according to \tcode{numeric_limits<T>::is_signed}.
 
 \pnum
 Unless otherwise specified,


### PR DESCRIPTION
No visible difference. The 'underscore' package already makes `_` in text behave as `\_`.

