### PR TITLE
[string.cons] Consolidate two functions into one description

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -1240,7 +1240,10 @@ is left in a valid state with an unspecified value.
 
 \indexlibrary{\idxcode{basic_string}!constructor}%
 \begin{itemdecl}
-basic_string(const basic_string& str, size_type pos, const Allocator& a = Allocator());
+basic_string(const basic_string& str, size_type pos,
+             const Allocator& a = Allocator());
+basic_string(const basic_string& str, size_type pos, size_type n,
+             const Allocator& a = Allocator());
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1255,26 +1258,8 @@ if
 Constructs an object of class
 \tcode{basic_string}
 and determines the effective length \tcode{rlen} of the initial string
-value as \tcode{str.size() - pos},
-as indicated in Table~\ref{tab:strings.ctr.2}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{basic_string}!constructor}%
-\begin{itemdecl}
-basic_string(const basic_string& str, size_type pos, size_type n,
-             const Allocator& a = Allocator());
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\throws
-\tcode{out_of_range} if \tcode{pos > str.size()}.
-
-\pnum
-\effects
-Constructs an object of class \tcode{basic_string}
-and determines the effective length \tcode{rlen} of the initial string
-value as the smaller of \tcode{n} and \tcode{str.size() - pos},
+value as \tcode{str.size() - pos} in the first form and
+as the smaller of \tcode{str.size() - pos} and \tcode{n} in the second form,
 as indicated in Table~\ref{tab:strings.ctr.2}.
 
 \begin{libefftabvalue}


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/6378233/24324076/b8f08928-1123-11e7-9a85-bbf1379f0781.png)


Superficially, this change removes a fair amount of duplication in the specification.

More importantly, though, this may be a step towards getting rid of those string effect tables that seem awkward and presentationally wasteful.