### PR TITLE
[meta.unary.prop] Fix index entry for is_aggregate.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -15926,7 +15926,7 @@ notwithstanding the restrictions of~\ref{declval}.
  can be marked with \tcode{final}. \end{note}                                        &
  If \tcode{T} is a class type, \tcode{T} shall be a complete type.                          \\ \rowsep
 
-\indexlibrary{\idxcode{is_aggregate_signed}!class}%
+\indexlibrary{\idxcode{is_aggregate}}%
 \tcode{template <class T>}\br
   \tcode{struct is_aggregate;}           &
  \tcode{T} is an aggregate type~(\ref{dcl.init.aggr}) &


### PR DESCRIPTION
Looks like a copy-paste mistake, because the next one is is_signed.

Note that '!class' makes sense for is_signed's index entry because there is also an entry for 'is_signed!numeric_limits', but there is no other is_aggregate in the stdlib, so I removed the '!class' (making it consistent with the index entries for e.g. is_final and is_abstract).