### PR TITLE
Do not use \tcode for non-syntax.

### DIFF
--- a/source/access.tex
+++ b/source/access.tex
@@ -12,18 +12,18 @@ A member of a class can be
 \begin{itemize}
 \item
 \indextext{access control!\idxcode{private}}%
-\tcode{private};
+private;
 that is, its name can be used only by members and friends
 of the class in which it is declared.
 \item
 \indextext{access control!\idxcode{protected}}%
-\tcode{protected};
+protected;
 that is, its name can be used only by members and friends
 of the class in which it is declared, by classes derived from that class, and by their
 friends (see~\ref{class.protected}).
 \item
 \indextext{access control!\idxcode{public}}%
-\tcode{public};
+public;
 that is, its name can be used anywhere without access restriction.
 \end{itemize}
 
@@ -44,12 +44,8 @@ are
 \tcode{private}
 by default.
 Members of a class defined with the keywords
-\tcode{struct}
-or
-\tcode{union}
-are
-\tcode{public}
-by default.
+\tcode{struct} or \tcode{union}
+are public by default.
 \begin{example}
 
 \begin{codeblock}
@@ -68,8 +64,7 @@ Access control is applied uniformly to all names, whether the names are
 referred to from declarations or expressions.
 \begin{note}
 Access control applies to names nominated by
-\tcode{friend}
-declarations\iref{class.friend} and
+friend declarations\iref{class.friend} and
 \grammarterm{using-declaration}{s}\iref{namespace.udecl}.
 \end{note}
 In the case of overloaded function names, access control is applied to
@@ -289,35 +284,23 @@ class C : public B {
 If a class is declared to be a base class\iref{class.derived} for another class using the
 \tcode{public}
 access specifier, the
-\tcode{public}
-members of the base class are accessible as
-\tcode{public}
-members of the derived class and
-\tcode{protected}
-members of the base class are accessible as
-\tcode{protected}
-members of the derived class.
+public members of the base class are accessible as
+public members of the derived class and
+protected members of the base class are accessible as
+protected members of the derived class.
 If a class is declared to be a base class for another class using the
 \tcode{protected}
 access specifier, the
-\tcode{public}
-and
-\tcode{protected}
-members of the base class are accessible as
-\tcode{protected}
-members of the derived class.
+public and protected members of the base class are accessible as
+protected members of the derived class.
 If a class is declared to be a base class for another class using the
-\tcode{private}
+private
 access specifier, the
-\tcode{public}
-and
-\tcode{protected}
-members of the base class are accessible as
-\tcode{private}
+public and protected
+members of the base class are accessible as private
 members of the derived class.\footnote{As specified previously in \ref{class.access},
 private members of a base class remain inaccessible even to derived classes
-unless
-\tcode{friend}
+unless friend
 declarations within the base class definition are used to grant access explicitly.}
 
 \pnum
@@ -673,7 +656,7 @@ class A {
 \end{example}
 
 \pnum
-A \tcode{friend} declaration that does not declare a function
+A friend declaration that does not declare a function
 shall have one of the following forms:
 
 \begin{ncsimplebnf}
@@ -682,12 +665,12 @@ shall have one of the following forms:
 \terminal{friend} typename-specifier \terminal{;}
 \end{ncsimplebnf}
 
-\begin{note} A \tcode{friend} declaration may be the
+\begin{note} A friend declaration may be the
 \term{declaration} in a \grammarterm{template-declaration}
 (\ref{temp}, \ref{temp.friend}).\end{note} If the
 type specifier in a \tcode{friend} declaration designates a (possibly
 cv-qualified) class type, that class is declared as a friend; otherwise, the
-\tcode{friend} declaration is ignored. \begin{example}
+friend declaration is ignored. \begin{example}
 
 \begin{codeblock}
 class C;
@@ -720,8 +703,7 @@ Otherwise, the function retains its previous linkage\iref{dcl.stc}.
 
 \pnum
 \indextext{declaration!overloaded name and \tcode{friend}}%
-When a
-\tcode{friend}
+When a friend
 declaration refers to an overloaded name or operator, only the function specified
 by the parameter types becomes a friend.
 A member function of a class
@@ -758,8 +740,7 @@ class M {
 
 \pnum
 Such a function is implicitly an inline function\iref{dcl.inline}.
-A
-\tcode{friend}
+A friend
 function defined in a class is in the (lexical) scope of the class in which it is defined.
 A friend function defined outside the class is not\iref{basic.lookup.unqual}.
 
@@ -775,11 +756,7 @@ of a friend declaration.
 A name nominated by a friend declaration shall be accessible in the scope of the
 class containing the friend declaration.
 The meaning of the friend declaration is the same whether the friend declaration
-appears in the
-\tcode{private},
-\tcode{protected}
-or
-\tcode{public}\iref{class.mem}
+appears in the private, protected, or public\iref{class.mem}
 portion of the class
 \grammarterm{member-specification}.
 

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1264,7 +1264,7 @@ namespace N {
 \end{example}
 \begin{note}
 When looking for a prior declaration of a class
-or function introduced by a \tcode{friend} declaration, scopes outside
+or function introduced by a friend declaration, scopes outside
 of the innermost enclosing namespace scope are not considered;
 see~\ref{namespace.memdef}. \end{note} \begin{note} \ref{basic.scope.class}
 further describes the restrictions on the use of names in a class
@@ -1344,16 +1344,16 @@ describes the restrictions on the use of names in local class
 definitions. \end{note}
 
 \pnum
-Name lookup for a name used in the definition of a \tcode{friend}
+Name lookup for a name used in the definition of a friend
 function\iref{class.friend} defined inline in the class granting
 friendship shall proceed as described for lookup in member function
-definitions. If the \tcode{friend} function is not defined in the class
-granting friendship, name lookup in the \tcode{friend} function
+definitions. If the friend function is not defined in the class
+granting friendship, name lookup in the friend function
 definition shall proceed as described for lookup in namespace member
 function definitions.
 
 \pnum
-In a \tcode{friend} declaration naming a member function, a name used in
+In a friend declaration naming a member function, a name used in
 the function declarator and not part of a \grammarterm{template-argument}
 in the \grammarterm{declarator-id} is first looked up in the scope of the
 member function's class\iref{class.member.lookup}. If it is not found,

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -383,7 +383,7 @@ class Vector {
   friend Vector operator*(const Matrix&, const Vector&);
 };
 \end{codeblock}
-Declaration of \tcode{friend}s is described in~\ref{class.friend},
+Declaration of friends is described in~\ref{class.friend},
 operator functions in~\ref{over.oper}.
 \end{example}
 \end{note}
@@ -639,10 +639,10 @@ shall contain a \grammarterm{type-specifier} that is not a \grammarterm{cv-quali
 The
 \grammarterm{member-declarator-list} can be omitted only after a
 \grammarterm{class-specifier} or an \grammarterm{enum-specifier} or in a
-\tcode{friend} declaration\iref{class.friend}. A
+friend declaration\iref{class.friend}. A
 \grammarterm{pure-specifier} shall be used only in the declaration of a
 virtual function\iref{class.virtual}
-that is not a \tcode{friend} declaration.
+that is not a friend declaration.
 
 \pnum
 The optional \grammarterm{attribute-specifier-seq} in a \grammarterm{member-declaration}
@@ -851,7 +851,7 @@ See~\ref{basic.link}.
 \begin{note}
 There can be at most one definition of a non-inline member function in
 a program. There may be more than one
-\tcode{inline} member function definition in a program.
+inline member function definition in a program.
 See~\ref{basic.def.odr} and~\ref{dcl.inline}.
 \end{note}
 
@@ -889,11 +889,11 @@ declared in class \tcode{X}.
 \pnum
 \begin{note}
 A \tcode{static} local variable or local type in a member function always refers to
-the same entity, whether or not the member function is \tcode{inline}.
+the same entity, whether or not the member function is inline.
 \end{note}
 
 \pnum
-Previously declared member functions may be mentioned in \tcode{friend} declarations.
+Previously declared member functions may be mentioned in friend declarations.
 
 \pnum
 \indextext{local class!member function in}%
@@ -1724,7 +1724,7 @@ block-scope variable, or with no storage class. A storage class is not
 allowed in a declaration of an anonymous union in a class scope.
 \indextext{access control!anonymous \tcode{union}}%
 \indextext{restriction!anonymous \tcode{union}}%
-An anonymous union shall not have \tcode{private} or \tcode{protected}
+An anonymous union shall not have private or protected
 members\iref{class.access}. An anonymous union shall not have
 member functions.
 

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1519,7 +1519,7 @@ present in the
 declaration to which the name in the
 \grammarterm{elaborated-type-specifier} refers. This rule also applies to
 the form of \grammarterm{elaborated-type-specifier} that declares a
-\grammarterm{class-name} or \tcode{friend} class since it can be construed
+\grammarterm{class-name} or friend class since it can be construed
 as referring to the definition of the class. Thus, in any
 \grammarterm{elaborated-type-specifier}, the \tcode{enum} keyword
 shall be
@@ -2515,10 +2515,10 @@ namespace R {
 \end{example}
 
 \pnum
-If a \tcode{friend} declaration in a non-local class first declares a
+If a friend declaration in a non-local class first declares a
 class, function, class template or function template\footnote{this implies that the name of the class or function is unqualified.}
 the friend is a member of the innermost enclosing
-namespace. The \tcode{friend} declaration does not by itself make the name
+namespace. The friend declaration does not by itself make the name
 visible to unqualified lookup\iref{basic.lookup.unqual} or qualified
 lookup\iref{basic.lookup.qual}. \begin{note} The name of the friend will be
 visible in its namespace if a matching declaration is provided at namespace
@@ -2528,12 +2528,12 @@ function or function template is called, its name may be found by the
 name lookup that considers functions from namespaces and classes
 associated with the types of the function
 arguments\iref{basic.lookup.argdep}. If the
-name in a \tcode{friend} declaration is neither qualified nor a
+name in a friend declaration is neither qualified nor a
 \grammarterm{template-id} and the declaration is a function or an
 \grammarterm{elaborated-type-specifier}, the lookup to determine whether
 the entity has been previously declared shall not consider any scopes
 outside the innermost enclosing namespace. \begin{note} The other forms of
-\tcode{friend} declarations cannot declare a new member of the innermost
+friend declarations cannot declare a new member of the innermost
 enclosing namespace and thus follow the usual lookup rules.
 \end{note}
 \begin{example}

--- a/source/derived.tex
+++ b/source/derived.tex
@@ -792,7 +792,7 @@ The \tcode{virtual} specifier implies membership, so a virtual function
 cannot be a non-member\iref{dcl.fct.spec} function. Nor can a virtual
 function be a static member, since a virtual function call relies on a
 specific object for determining which function to invoke. A virtual
-function declared in one class can be declared a \tcode{friend} in
+function declared in one class can be declared a friend~(\ref{class.friend}) in
 another class.
 \end{note}
 

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1148,7 +1148,7 @@ implicitly-declared destructor\iref{class.dtor}.
 A member of a closure type shall not be
 explicitly instantiated\iref{temp.explicit},
 explicitly specialized\iref{temp.expl.spec}, or
-named in a \tcode{friend} declaration\iref{class.friend}.
+named in a friend declaration\iref{class.friend}.
 
 \rSec3[expr.prim.lambda.capture]{Captures}%
 
@@ -2629,14 +2629,14 @@ check logically executes as follows:
 
 \begin{itemize}
 \item If, in the most derived object pointed (referred) to by \tcode{v},
-\tcode{v} points (refers) to a \tcode{public} base class subobject of a
+\tcode{v} points (refers) to a public base class subobject of a
 \tcode{C} object, and if only one object of type \tcode{C} is derived
 from the subobject pointed (referred) to by \tcode{v} the result points (refers) to that \tcode{C} object.
 
-\item Otherwise, if \tcode{v} points (refers) to a \tcode{public} base
+\item Otherwise, if \tcode{v} points (refers) to a public base
 class subobject of the most derived object, and the type of the most
 derived object has a base class, of type \tcode{C}, that is unambiguous
-and \tcode{public}, the result points (refers) to the
+and public, the result points (refers) to the
 \tcode{C} subobject of the most derived object.
 
 \item Otherwise, the

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2707,7 +2707,7 @@ explicitly stated otherwise.
 It is unspecified whether any
 non-member
 functions in the \Cpp standard library are defined as
-\tcode{inline}\iref{dcl.inline}.
+inline\iref{dcl.inline}.
 
 \pnum
 A call to a non-member function signature
@@ -2747,7 +2747,7 @@ return *this;
 
 \pnum
 It is unspecified whether any member functions in the \Cpp standard library are defined as
-\tcode{inline}\iref{dcl.inline}.
+inline\iref{dcl.inline}.
 
 \pnum
 For a non-virtual member function described in the \Cpp standard library,
@@ -2856,8 +2856,7 @@ side effects. \end{note}
 \indextext{protection}%
 It is unspecified whether any function signature or class described in
 \ref{\firstlibchapter} through \ref{\lastlibchapter} and \ref{depr} is a
-\tcode{friend}
-of another class in the \Cpp standard library.
+friend of another class in the \Cpp standard library.
 \indextext{specifier!\idxcode{friend}}
 
 \rSec3[derivation]{Derived classes}

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -1583,7 +1583,7 @@ A specialization
 is provided so that the member functions on type
 \tcode{char}
 can be implemented
-\tcode{inline}.\footnote{Only the
+inline.\footnote{Only the
 \tcode{char}
 (not
 \tcode{unsigned char}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -6746,12 +6746,6 @@ template is neither a
 matrix class nor a field class.
 However, it is a very useful building block for designing such classes.}
 
-\pnum
-An implementation is permitted to qualify any of the functions declared in
-\tcode{<valarray>}
-as
-\tcode{inline}.
-
 \rSec3[valarray.cons]{\tcode{valarray} constructors}
 
 \indexlibrary{\idxcode{valarray}!constructor}%

--- a/source/special.tex
+++ b/source/special.tex
@@ -57,8 +57,7 @@ Often such special member functions are called implicitly.
 \indextext{access control!member function and}%
 Special member functions obey the usual access rules\iref{class.access}.
 \begin{example}
-Declaring a constructor
-\tcode{protected}
+Declaring a constructor protected
 ensures that only derived classes and friends can create objects using it.
 \end{example}
 
@@ -168,9 +167,7 @@ If there is no user-declared constructor for class
 a non-explicit constructor having no parameters is implicitly declared
 as defaulted\iref{dcl.fct.def}.
 An implicitly-declared default constructor is an
-\tcode{inline}
-\tcode{public}
-member of its class.
+inline public member of its class.
 
 \pnum
 A defaulted default constructor for class \tcode{X} is defined as deleted if:
@@ -1081,9 +1078,7 @@ If a class has no user-declared
 destructor, a destructor is implicitly
 declared as defaulted\iref{dcl.fct.def}.
 An implicitly-declared destructor is an
-\tcode{inline}
-\tcode{public}
-member of its class.
+inline public member of its class.
 
 \pnum
 A defaulted destructor for a class
@@ -1488,9 +1483,7 @@ the statically visible deallocation function is required to be accessible.
 For the call on line ``// 1'' above,
 if
 \tcode{B::operator delete()}
-had been
-\tcode{private},
-the delete expression would have been ill-formed.
+had been private, the delete expression would have been ill-formed.
 \end{example}
 
 \pnum
@@ -2683,9 +2676,7 @@ X::X(X&&)
 
 \pnum
 An implicitly-declared copy/move constructor is an
-\tcode{inline}
-\tcode{public}
-member of its class.
+inline public member of its class.
 A defaulted copy/\brk{}move constructor for a class
   \tcode{X} is defined as deleted\iref{dcl.fct.def.delete} if \tcode{X} has:
 \begin{itemize}
@@ -2985,9 +2976,7 @@ has the return type
 it returns the object for which the assignment operator is invoked, that is,
 the object assigned to.
 An implicitly-declared copy/move assignment operator is an
-\tcode{inline}
-\tcode{public}
-member of its class.
+inline public member of its class.
 
 \pnum
 A defaulted copy/move assignment operator for


### PR DESCRIPTION
This applies to inline, public, protected, private, and friend.

Fixes #106.