### PR TITLE
Use 'subclause', not 'section'.

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -1112,7 +1112,7 @@ of a random-access iterator\iref{random.access.iterators}.
 \pnum
 If an algorithm's
 \effects
-section says that a value pointed to by any iterator passed
+element specifies that a value pointed to by any iterator passed
 as an argument is modified, then that algorithm has an additional
 type requirement:
 The type of that argument shall satisfy the requirements
@@ -1226,7 +1226,7 @@ return distance(a, b);
 \rSec1[algorithms.parallel]{Parallel algorithms}
 
 \pnum
-This section describes components that \Cpp programs may use to perform
+This subclause describes components that \Cpp programs may use to perform
 operations on containers and other sequences in parallel.
 
 \rSec2[algorithms.parallel.defns]{Terms and definitions}
@@ -3937,7 +3937,7 @@ the predicate, and \bigoh{N \log N} swaps, where $N = \tcode{last - first}$.
 \rSec2[alg.binary.search]{Binary search}
 
 \pnum
-All of the algorithms in this section are versions of binary search
+All of the algorithms in this subclause are versions of binary search
 and assume that the sequence being searched is partitioned with respect to
 an expression formed by binding the search key to an argument of the
 implied or explicit comparison function.
@@ -4496,7 +4496,7 @@ memory is available,  \bigoh{N \log N} comparisons.
 \rSec2[alg.set.operations]{Set operations on sorted structures}
 
 \pnum
-This section defines all the basic set operations on sorted structures.
+This subclause defines all the basic set operations on sorted structures.
 They also work with
 \tcode{multiset}s\iref{multiset}
 containing multiple copies of equivalent elements.

--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -1413,7 +1413,7 @@ void atomic_flag::clear(memory_order order = memory_order_seq_cst) noexcept;
 \rSec1[atomics.fences]{Fences}
 
 \pnum
-This section introduces synchronization primitives called \term{fences}. Fences can have
+This subclause introduces synchronization primitives called \term{fences}. Fences can have
 acquire semantics, release semantics, or both. A fence with acquire semantics is called
 an \term{acquire fence}. A fence with release semantics is called a \term{release
 fence}.

--- a/source/back.tex
+++ b/source/back.tex
@@ -25,8 +25,8 @@ called \defn{LIA-1} in this document.
 
 \clearpage
 \renewcommand{\glossaryname}{Cross references}
-\renewcommand{\preglossaryhook}{This annex lists each section label and the
-corresponding section number and page number, in alphabetical order by label.\\}
+\renewcommand{\preglossaryhook}{This annex lists each clause or subclause label and the
+corresponding clause or subclause number and page number, in alphabetical order by label.\\}
 \twocolglossary
 \renewcommand{\leftmark}{\glossaryname}
 {
@@ -37,7 +37,7 @@ corresponding section number and page number, in alphabetical order by label.\\}
 \clearpage
 \input{xrefdelta}
 \renewcommand{\glossaryname}{Cross references from ISO \CppXVII}
-\renewcommand{\preglossaryhook}{All section labels from
+\renewcommand{\preglossaryhook}{All clause and subclause labels from
 ISO \CppXVII (ISO/IEC 14882:2017, \doccite{Programming Languages --- \Cpp})
 are present in this document, with the exceptions described below.\\}
 \renewcommand{\leftmark}{\glossaryname}
@@ -74,7 +74,7 @@ corresponding page in the Grammar summary\iref{gram}.\\}
 }
 
 \clearpage
-\renewcommand{\preindexhook}{The entries in this section are rough descriptions; exact
+\renewcommand{\preindexhook}{The entries in this index are rough descriptions; exact
 specifications are at the indicated page in the general text.\\}
 \renewcommand{\indexname}{Index of implementation-defined behavior}
 \renewcommand{\leftmark}{\indexname}

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2947,7 +2947,7 @@ void h() {
 \end{example}
 
 \pnum
-In this section, ``before'' and ``after'' refer to the ``happens before''
+In this subclause, ``before'' and ``after'' refer to the ``happens before''
 relation\iref{intro.multithread}. \begin{note} Therefore, undefined behavior results
 if an object that is being constructed in one thread is referenced from another
 thread without adequate synchronization. \end{note}%
@@ -3286,7 +3286,7 @@ has an object pointer type and it is one of the following:
 \item the value returned by a call to the \Cpp standard library implementation of
 \tcode{::operator new(std::\brk{}size_t)} or
 \tcode{::operator new(std::size_t, std::align_val_t)}%
-;\footnote{This section does not impose restrictions
+;\footnote{This subclause does not impose restrictions
 on indirection through pointers to memory not allocated by \tcode{::operator new}. This
 maintains the ability of many \Cpp implementations to use binary libraries and
 components written in other languages. In particular, this applies to C binaries,
@@ -3771,7 +3771,7 @@ signed integer types and extended
 unsigned integer types are collectively called the
 \defnx{extended integer types}{extended integer type}.
 The signed and unsigned integer types shall satisfy
-the constraints given in the C standard, section 5.2.4.2.1.
+the constraints given in the C standard, subclause 5.2.4.2.1.
 
 \pnum
 \indextext{arithmetic!\idxcode{unsigned}}%
@@ -4410,7 +4410,7 @@ a value computation using the value of any object in the same memory location,
 and they are not potentially concurrent\iref{intro.multithread},
 the behavior is undefined.
 \begin{note}
-The next section imposes similar, but more complex restrictions on
+The next subclause imposes similar, but more complex restrictions on
 potentially concurrent computations.
 \end{note}
 
@@ -4509,7 +4509,7 @@ The value of an object visible to a thread \placeholder{T} at a particular point
 initial value of the object, a value assigned to the object by \placeholder{T}, or a
 value assigned to the object by another thread, according to the rules below.
 \begin{note} In some cases, there may instead be undefined behavior. Much of this
-section is motivated by the desire to support atomic operations with explicit
+subclause is motivated by the desire to support atomic operations with explicit
 and detailed visibility constraints. However, it also implicitly supports a
 simpler view for more restricted programs. \end{note}
 

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -7502,7 +7502,7 @@ supports forward iterators.
 An \tcode{unordered_map} satisfies all of the requirements of a container, of an unordered associative container, and of an allocator-aware container (Table~\ref{tab:containers.allocatoraware}). It provides the operations described in the preceding requirements table for unique keys; that is, an \tcode{unordered_map} supports the \tcode{a_uniq} operations in that table, not the \tcode{a_eq} operations. For an \tcode{unordered_map<Key, T>} the \tcode{key type} is \tcode{Key}, the mapped type is \tcode{T}, and the value type is \tcode{pair<const Key, T>}.
 
 \pnum
-This section only describes operations on \tcode{unordered_map} that
+This subclause only describes operations on \tcode{unordered_map} that
 are not described in one of the requirement tables, or for which there
 is additional semantic information.
 
@@ -8062,7 +8062,7 @@ For an \tcode{unordered_multimap<Key, T>} the \tcode{key type} is \tcode{Key}, t
 mapped type is \tcode{T}, and the value type is \tcode{pair<const Key, T>}.
 
 \pnum
-This section only describes operations on \tcode{unordered_multimap}
+This subclause only describes operations on \tcode{unordered_multimap}
 that are not described in one of the requirement tables, or for which
 there is additional semantic information.
 
@@ -8406,7 +8406,7 @@ supports forward iterators.
 An \tcode{unordered_set} satisfies all of the requirements of a container, of an unordered associative container, and of an allocator-aware container (Table~\ref{tab:containers.allocatoraware}). It provides the operations described in the preceding requirements table for unique keys; that is, an \tcode{unordered_set} supports the \tcode{a_uniq} operations in that table, not the \tcode{a_eq} operations. For an \tcode{unordered_set<Key>} the \tcode{key type} and the value type are both \tcode{Key}. The \tcode{iterator} and \tcode{const_iterator} types are both constant iterator types. It is unspecified whether they are the same type.
 
 \pnum
-This section only describes operations on \tcode{unordered_set} that
+This subclause only describes operations on \tcode{unordered_set} that
 are not described in one of the requirement tables, or for which there
 is additional semantic information.
 
@@ -8709,7 +8709,7 @@ both \tcode{Key}. The \tcode{iterator} and \tcode{const_iterator} types are both
 constant iterator types. It is unspecified whether they are the same type.
 
 \pnum
-This section only describes operations on \tcode{unordered_multiset} that
+This subclause only describes operations on \tcode{unordered_multiset} that
 are not described in one of the requirement tables, or for which there
 is additional semantic information.
 

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -977,7 +977,7 @@ the implementation that inline substitution of the function body at the
 point of call is to be preferred to the usual function call mechanism.
 An implementation is not required to perform this inline substitution at
 the point of call; however, even if this inline substitution is omitted,
-the other rules for inline functions specified in this section shall
+the other rules for inline functions specified in this subclause shall
 still be respected.
 
 \pnum
@@ -1110,7 +1110,7 @@ in
 \ref{class},
 and
 \ref{temp.res}, respectively. The remaining
-\grammarterm{type-specifier}{s} are discussed in the rest of this section.
+\grammarterm{type-specifier}{s} are discussed in the rest of this subclause.
 \end{note}
 
 \rSec3[dcl.type.cv]{The \grammarterm{cv-qualifier}{s}}%
@@ -1609,7 +1609,7 @@ in a \grammarterm{template-parameter}\iref{temp.param}.
 
 \pnum
 A program that uses \tcode{auto} or \tcode{decltype(auto)} in a context not
-explicitly allowed in this section is ill-formed.
+explicitly allowed in this subclause is ill-formed.
 
 \pnum
 If the \grammarterm{init-declarator-list} contains more than one

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -3018,7 +3018,7 @@ a narrowing conversion\iref{dcl.init.list} is required
 to convert the expression, the program is ill-formed.
 \begin{note} If an initializer is itself an initializer list,
 the element is list-initialized, which will result in a recursive application
-of the rules in this section if the element is an aggregate. \end{note}
+of the rules in this subclause if the element is an aggregate. \end{note}
 \end{itemize}
 \begin{example}
 \begin{codeblock}
@@ -3895,7 +3895,7 @@ direct-list-initialization).
 
 \item Otherwise, if \tcode{T} is a character array and the initializer list has a
 single element that is an appropriately-typed string literal\iref{dcl.init.string},
-initialization is performed as described in that section.
+initialization is performed as described in that subclause.
 
 \item Otherwise, if \tcode{T} is an aggregate, aggregate initialization is
 performed\iref{dcl.init.aggr}.

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -939,7 +939,7 @@ to identify the source and encoding of a particular category of error code.
 Classes may be derived from \tcode{error_category} to support
 categories of errors in addition to those defined in this document.
 Such classes shall behave as specified in this
-subclause. \begin{note} \tcode{error_category} objects are
+subclause~\ref{syserr.errcat}. \begin{note} \tcode{error_category} objects are
 passed by reference, and two such objects
 are equal if they have the same address. This means that applications using
 custom \tcode{error_category} types should create a single object of each

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -180,7 +180,7 @@ try : i(f(ii)), d(id) {
 \end{example}
 
 \pnum
-In this section, ``before'' and ``after'' refer to the
+In this Clause, ``before'' and ``after'' refer to the
 ``sequenced before'' relation\iref{intro.execution}.
 
 \rSec1[except.throw]{Throwing an exception}%
@@ -362,7 +362,7 @@ Consequently, destructors should generally catch exceptions and not let them pro
 \indextext{unwinding!stack}%
 As control passes from the point where an exception is thrown
 to a handler,
-destructors are invoked by a process, specified in this section, called
+destructors are invoked by a process, specified in this subclause, called
 \defn{stack unwinding}.
 
 \pnum

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2324,7 +2324,7 @@ for a deduced class type,
 it is replaced by the return type
 of the function selected by overload resolution
 for class template deduction\iref{over.match.class.deduct}
-for the remainder of this section.
+for the remainder of this subclause.
 
 \pnum
 If the initializer is a parenthesized single expression,
@@ -2826,7 +2826,7 @@ reference-compatible with ``\cvqual{cv1}
 the result refers to the object or the specified base class subobject
 thereof; otherwise, the lvalue-to-rvalue conversion\iref{conv.lval}
 is applied to the bit-field and the resulting prvalue is used as the
-\grammarterm{expression} of the \tcode{static_cast} for the remainder of this section.
+\grammarterm{expression} of the \tcode{static_cast} for the remainder of this subclause.
 If \tcode{T2} is an inaccessible\iref{class.access} or
 ambiguous\iref{class.member.lookup} base class of \tcode{T1},
 a program that necessitates such a cast is ill-formed.
@@ -3168,7 +3168,7 @@ performed explicitly using \tcode{const_cast}.
 
 \pnum
 \begin{note}
-Subject to the restrictions in this section, an expression may be cast
+Subject to the restrictions in this subclause, an expression may be cast
 to its own type using a \tcode{const_cast} operator.
 \end{note}
 
@@ -4156,7 +4156,7 @@ The \grammarterm{delete-expression}'s result has type
 If the operand has a class type, the operand is converted to a pointer
 type by calling the above-mentioned conversion function, and the
 converted operand is used in place of the original operand for the
-remainder of this section.
+remainder of this subclause.
 In the first alternative
 (\defnx{delete object}{object!delete}), the value of the operand of \tcode{delete} may
 be a null pointer value, a pointer to a non-array object
@@ -5149,7 +5149,7 @@ Otherwise, if the second and third operand are glvalue bit-fields
 of the same value category and
 of types \cvqual{cv1} \tcode{T} and \cvqual{cv2} \tcode{T}, respectively,
 the operands are considered to be of type \cvqual{cv} \tcode{T}
-for the remainder of this section,
+for the remainder of this subclause,
 where \cvqual{cv} is the union of \cvqual{cv1} and \cvqual{cv2}.
 
 \pnum
@@ -5206,7 +5206,7 @@ and further checking is performed as described below.
 Otherwise, if exactly one conversion sequence can be formed,
 that conversion is applied to the chosen operand
 and the converted operand is used in place of the original operand for
-the remainder of this section.
+the remainder of this subclause.
 \begin{note}
 The conversion might be ill-formed even if an implicit conversion
 sequence could be formed.
@@ -5226,7 +5226,7 @@ to be applied to the operands~(\ref{over.match.oper}, \ref{over.built}).
 If the overload resolution fails, the program is ill-formed. Otherwise,
 the conversions thus determined are applied, and the converted operands
 are used in place of the original operands for the remainder of this
-section.
+subclause.
 
 \pnum
 Lvalue-to-rvalue\iref{conv.lval}, array-to-pointer\iref{conv.array},

--- a/source/future.tex
+++ b/source/future.tex
@@ -11,7 +11,7 @@ These are deprecated features, where
 is defined as:
 Normative for the current edition of this International Standard,
 but having been identified as a candidate for removal from future revisions.
-An implementation may declare library names and entities described in this section with the
+An implementation may declare library names and entities described in this Clause with the
 \tcode{deprecated} attribute\iref{dcl.attr.deprecated}.
 
 \rSec1[depr.static_constexpr]{Redeclaration of \tcode{static constexpr} data members}

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -578,8 +578,6 @@ overflows are reversible, the above expression statement can be
 rewritten by the implementation in any of the above ways because the
 same result will occur. \end{note}
 
-
-
 \rSec1[intro.structure]{Structure of this document}
 
 \pnum

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -8493,7 +8493,7 @@ Otherwise the behavior is undefined.
 \pnum
 In order to support file I/O and multibyte/wide character conversion,
 conversions are performed using members of a facet, referred to as
-\tcode{a_codecvt} in following sections, obtained as if by
+\tcode{a_codecvt} in following subclauses, obtained as if by
 
 \begin{codeblock}
 const codecvt<charT, char, typename traits::state_type>& a_codecvt =
@@ -10734,7 +10734,7 @@ which is said to be \term{normalized}.
 
 \pnum
 \begin{note}
-The format conversions described in this section
+The format conversions described in this subclause
 are not applied on POSIX-based operating systems
 because on these systems:
 \begin{itemize}

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -3069,7 +3069,7 @@ of the iterator for some possible future access to get the character.
 \rSec3[istreambuf.iterator.cons]{\tcode{istreambuf_iterator} constructors}
 
 \pnum
-For each \tcode{istreambuf_iterator} constructor in this section,
+For each \tcode{istreambuf_iterator} constructor in this subclause,
 an end-of-stream iterator is constructed if and only if
 the exposition-only member \tcode{sbuf_} is initialized with a null pointer value.
 

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -956,7 +956,7 @@ support multiple configurations of the library.}
 Whenever a name \tcode{x} defined in the standard library is mentioned,
 the name \tcode{x} is assumed to be fully qualified as
 \tcode{::std::x},
-unless explicitly described otherwise. For example, if the \effects section
+unless explicitly described otherwise. For example, if the \effects element
 for library function \tcode{F} is described as calling library function \tcode{G},
 the function
 \tcode{::std::G}
@@ -1327,7 +1327,7 @@ The other headers listed in this table shall meet the same requirements as for a
 \rSec3[using.overview]{Overview}
 
 \pnum
-This section describes how a \Cpp program gains access to the facilities of the
+Subclause \ref{using} describes how a \Cpp program gains access to the facilities of the
 \Cpp standard library. \ref{using.headers} describes effects during translation
 phase 4, while~\ref{using.linkage} describes effects during phase
 8\iref{lex.phases}.
@@ -2151,7 +2151,7 @@ whether or not \tcode{T} is a complete type:
 \rSec3[constraints.overview]{Overview}
 
 \pnum
-This section describes restrictions on \Cpp programs that use the facilities of
+Subclause \ref{constraints} describes restrictions on \Cpp programs that use the facilities of
 the \Cpp standard library. The following subclauses specify constraints on the
 program's use of namespaces\iref{namespace.std}, its use of various reserved
 names\iref{reserved.names}, its use of headers\iref{alt.headers}, its use of
@@ -2654,7 +2654,7 @@ paragraph specifies throwing an exception when the precondition is violated.
 \rSec3[conforming.overview]{Overview}
 
 \pnum
-This section describes the constraints upon, and latitude of, implementations of the \Cpp standard library.
+Subclause \ref{conforming} describes the constraints upon, and latitude of, implementations of the \Cpp standard library.
 
 \pnum
 An implementation's use of headers is discussed in~\ref{res.on.headers}, its use
@@ -2803,7 +2803,7 @@ library may be recursively reentered.
 \rSec3[res.on.data.races]{Data race avoidance}
 
 \pnum
-This section specifies requirements that implementations shall meet to prevent data
+This subclause specifies requirements that implementations shall meet to prevent data
 races\iref{intro.multithread}.
 Every standard library function shall meet each requirement unless otherwise specified.
 Implementations may prevent data races in cases other than those specified below.

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -1320,7 +1320,7 @@ ensure, for a call with at least one argument of type \tcode{complex<T>}:
 \indexlibrary{complex!literals}%
 \indexlibrary{literals!complex}%
 \pnum
-This section describes literal suffixes for constructing complex number literals.
+This subclause describes literal suffixes for constructing complex number literals.
 The suffixes \tcode{i}, \tcode{il}, and \tcode{if} create complex numbers of
 the types \tcode{complex<double>}, \tcode{complex<long double>}, and
 \tcode{complex<float>} respectively, with their imaginary part denoted by the
@@ -1467,7 +1467,7 @@ Further:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%
-%% Requirements section
+%% Requirements subclause
 %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -1477,7 +1477,7 @@ Further:
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%
-%%  general requirements section
+%%  general requirements subclause
 %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -1587,8 +1587,8 @@ if the expressions shown
 in Table~\ref{tab:SeedSequence}
 are valid and have the indicated semantics,
 and if \tcode{S} also satisfies all other requirements
-of this section \ref{rand.req.seedseq}.
-In that Table and throughout this section:
+of this subclause \ref{rand.req.seedseq}.
+In that Table and throughout this subclause:
 \begin{enumeratea}
   \item
     \tcode{T} is the type named by
@@ -1728,8 +1728,8 @@ if the expressions shown
 in Table~\ref{tab:UniformRandomBitGenerator}
 are valid and have the indicated semantics,
 and if \tcode{G} also satisfies all other requirements
-of this section \ref{rand.req.urng}.
-In that Table and throughout this section:
+of this subclause \ref{rand.req.urng}.
+In that Table and throughout this subclause:
 \begin{enumeratea}
   \item
     \tcode{T} is the type named by
@@ -1806,7 +1806,7 @@ A \techterm{random number engine}
 is a uniform random bit generator
 that additionally meets the requirements
 (e.g., for seeding and for input/output)
-specified in this section.
+specified in this subclause.
 
 \pnum
 At any given time,
@@ -1852,8 +1852,8 @@ if the expressions shown
 in Table~\ref{tab:RandomEngine}
 are valid and have the indicated semantics,
 and if \tcode{E} also satisfies all other requirements
-of this section \ref{rand.req.eng}.
-In that Table and throughout this section:
+of this subclause \ref{rand.req.eng}.
+In that Table and throughout this subclause:
 \begin{enumeratea}
   \item
     \tcode{T} is the type named by
@@ -2236,8 +2236,8 @@ in Table~\ref{tab:RandomDistribution}
 are valid and have the indicated semantics,
 and if \tcode{D} and its associated types
 also satisfy all other requirements
-of this section \ref{rand.req.dist}.
-In that Table and throughout this section,
+of this subclause \ref{rand.req.dist}.
+In that Table and throughout this subclause,
 \begin{enumeratea}
   \item
     \tcode{T} is the type named by
@@ -2499,7 +2499,7 @@ using distribution_type =  D;
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%
-%% Header synopsis section
+%% Header synopsis subclause
 %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -2652,7 +2652,7 @@ namespace std {
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%
-%% Engine class templates section
+%% Engine class templates subclause
 %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -2663,30 +2663,30 @@ namespace std {
 
 \pnum
 Each type instantiated
-from a class template specified in this section~\ref{rand.eng}
+from a class template specified in this subclause~\ref{rand.eng}
 satisfies the requirements
 of a random number engine\iref{rand.req.eng} type.
 
 \pnum
 Except where specified otherwise,
 the complexity of each function
-specified in this section~\ref{rand.eng}
+specified in this subclause~\ref{rand.eng}
 is constant.
 
 \pnum
 Except where specified otherwise,
-no function described in this section~\ref{rand.eng}
+no function described in this subclause~\ref{rand.eng}
 throws an exception.
 
 \pnum
-Every function described in this section~\ref{rand.eng}
+Every function described in this subclause~\ref{rand.eng}
 that has a function parameter \tcode{q} of type \tcode{Sseq\&}
 for a template type parameter named \tcode{Sseq}
 that is different from type \tcode{seed_seq}
 throws what and when the invocation of \tcode{q.generate} throws.
 
 \pnum
-Descriptions are provided in this section~\ref{rand.eng}
+Descriptions are provided in this subclause~\ref{rand.eng}
 only for engine operations
 that are not described in \ref{rand.req.eng}
 or for operations where there is additional semantic information.
@@ -2698,7 +2698,7 @@ and for equality and inequality operators
 are not shown in the synopses.
 
 \pnum
-Each template specified in this section~\ref{rand.eng}
+Each template specified in this subclause~\ref{rand.eng}
 requires one or more relationships,
 involving the value(s) of its non-type template parameter(s), to hold.
 A program instantiating any of these templates
@@ -2790,7 +2790,7 @@ template<class UIntType, UIntType a, UIntType c, UIntType m>
 If the template parameter
 \tcode{m} is $0$,
 the modulus $m$
-used throughout this section~\ref{rand.eng.lcong}
+used throughout this subclause~\ref{rand.eng.lcong}
 \indextext{\idxcode{linear_congruential_engine}!modulus}
 is \tcode{numeric_limits<result_type>::max()} plus $1$.
 \begin{note}
@@ -3201,7 +3201,7 @@ template<class Sseq> explicit subtract_with_carry_engine(Sseq& q);
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%
-%% Engine adaptors class templates section
+%% Engine adaptors class templates subclause
 %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -3213,32 +3213,32 @@ template<class Sseq> explicit subtract_with_carry_engine(Sseq& q);
 
 \pnum
 Each type instantiated
-from a class template specified in this section~\ref{rand.adapt}
+from a class template specified in this subclause~\ref{rand.adapt}
 satisfies the requirements
 of a random number engine adaptor\iref{rand.req.adapt} type.
 
 \pnum
 Except where specified otherwise,
 the complexity of each function
-specified in this section~\ref{rand.adapt}
+specified in this subclause~\ref{rand.adapt}
 is constant.
 
 \pnum
 Except where specified otherwise,
-no function described in this section~\ref{rand.adapt}
+no function described in this subclause~\ref{rand.adapt}
 throws an exception.
 
 \pnum
-Every function described in this section~\ref{rand.adapt}
+Every function described in this subclause~\ref{rand.adapt}
 that has a function parameter \tcode{q} of type \tcode{Sseq\&}
 for a template type parameter named \tcode{Sseq}
 that is different from type \tcode{seed_seq}
 throws what and when the invocation of \tcode{q.generate} throws.
 
 \pnum
-Descriptions are provided in this section~\ref{rand.adapt}
+Descriptions are provided in this subclause~\ref{rand.adapt}
 only for adaptor operations
-that are not described in section~\ref{rand.req.adapt}
+that are not described in subclause~\ref{rand.req.adapt}
 or for operations where there is additional semantic information.
 In particular,
 declarations for copy constructors,
@@ -3248,7 +3248,7 @@ and for equality and inequality operators
 are not shown in the synopses.
 
 \pnum
-Each template specified in this section~\ref{rand.adapt}
+Each template specified in this subclause~\ref{rand.adapt}
 requires one or more relationships,
 involving the value(s) of its non-type template parameter(s), to hold.
 A program instantiating any of these templates
@@ -3352,7 +3352,7 @@ followed by
 
 \pnum
 In addition to its behavior
-pursuant to section~\ref{rand.req.adapt},
+pursuant to subclause~\ref{rand.req.adapt},
 each constructor%
 \indexlibrary{\idxcode{discard_block_engine}!constructor}
 that is not a copy constructor
@@ -3605,7 +3605,7 @@ followed by
 
 \pnum
 In addition to its behavior
-pursuant to section~\ref{rand.req.adapt},
+pursuant to subclause~\ref{rand.req.adapt},
 each constructor%
 \indexlibrary{\idxcode{shuffle_order_engine}!constructor}
 that is not a copy constructor
@@ -3618,7 +3618,7 @@ with values returned by successive invocations of \tcode{e()}.%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%
-%% Engines with predefined parameters section
+%% Engines with predefined parameters subclause
 %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -3805,7 +3805,7 @@ is \impldef{type of \tcode{default_random_engine}}.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%
-%% random_device class section
+%% random_device class subclause
 %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -3917,7 +3917,7 @@ result_type operator()();
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%
-%% utilities section
+%% utilities subclause
 %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -4154,7 +4154,7 @@ What and when \tcode{OutputIterator} operations of \tcode{dest} throw.
 \pnum
  Each function instantiated
  from the template
- described in this section~\ref{rand.util.canonical}
+ described in this subclause~\ref{rand.util.canonical}
  maps the result of one or more invocations
  of a supplied uniform random bit generator \tcode{g}
  to one member
@@ -4220,7 +4220,7 @@ template<class RealType, size_t bits, class URBG>
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%
-%% Distribution class templates section
+%% Distribution class templates subclause
 %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -4233,12 +4233,12 @@ template<class RealType, size_t bits, class URBG>
 
 \pnum
 Each type instantiated
-from a class template specified in this section~\ref{rand.dist}
+from a class template specified in this subclause~\ref{rand.dist}
 satisfies the requirements
 of a random number distribution\iref{rand.req.dist} type.
 
 \pnum
-Descriptions are provided in this section~\ref{rand.dist}
+Descriptions are provided in this subclause~\ref{rand.dist}
 only for distribution operations
 that are not described in \ref{rand.req.dist}
 or for operations where there is additional semantic information.
@@ -4257,13 +4257,13 @@ of the specified distributions are
 \pnum
 The value of each probability density function $p(z)$
 and of each discrete probability function $P(z_i)$
-specified in this section
+specified in this subclause
 is $0$
 everywhere outside its stated domain.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%
-%% Uniform distributions section
+%% Uniform distributions subclause
 %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -4451,7 +4451,7 @@ result_type b() const;
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%
-%% Bernoulli distributions section
+%% Bernoulli distributions subclause
 %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -4788,7 +4788,7 @@ double p() const;
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%
-%% Poisson distributions section
+%% Poisson distributions subclause
 %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -5225,7 +5225,7 @@ RealType b() const;
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%
-%% Normal distributions section
+%% Normal distributions subclause
 %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -5762,7 +5762,7 @@ RealType n() const;
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%
-%% Sampling distributions section
+%% Sampling distributions subclause
 %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -8057,7 +8057,7 @@ The default constructor is equivalent to
 The constructor with arguments builds a
 \tcode{gslice}
 based on a specification of start, lengths, and strides, as explained
-in the previous section.
+in the previous subclause.
 \end{itemdescr}
 
 \rSec3[gslice.access]{\tcode{gslice} access functions}

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -1359,7 +1359,7 @@ the implicit object parameter of the conversion functions.
 \pnum
 When objects of non-aggregate class type \tcode{T} are
 list-initialized such that \ref{dcl.init.list} specifies that overload resolution
-is performed according to the rules in this section, overload resolution selects the
+is performed according to the rules in this subclause, overload resolution selects the
 constructor in two phases:
 
 \begin{itemize}
@@ -2373,7 +2373,7 @@ f( {1.0} );             // error: narrowing
 
 \pnum
 Otherwise, if the parameter is a reference, see~\ref{over.ics.ref}. \begin{note}
-The rules in this section will apply for initializing the underlying temporary
+The rules in this subclause will apply for initializing the underlying temporary
 for the reference. \end{note} \begin{example}
 \begin{codeblock}
 struct A {
@@ -3555,7 +3555,7 @@ integral promotions.
 \end{note}
 
 \pnum
-In the remainder of this section, \cvqual{vq} represents either
+In the remainder of this subclause, \cvqual{vq} represents either
 \tcode{volatile} or no cv-qualifier.
 
 \pnum

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -261,7 +261,7 @@ The \tcode{\#ifdef} and \tcode{\#ifndef} directives, and
 the \tcode{defined} conditional inclusion operator,
 shall treat \xname{has_include} as if it were the name of a defined macro.
 The identifier \xname{has_include} shall not appear
-in any context not mentioned in this section.
+in any context not mentioned in this subclause.
 
 \pnum
 Each preprocessing token that remains (in the list of preprocessing tokens that

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -4544,7 +4544,7 @@ The same suffix \tcode{s} is used for \tcode{chrono::duration} literals denoting
 
 \pnum
 The class template \tcode{basic_string_view} describes an object that can refer to a constant contiguous sequence of char-like\iref{strings.general} objects with the first element of the sequence at position zero.
-In the rest of this section, the type of the char-like objects held in a \tcode{basic_string_view} object is designated by \tcode{charT}.
+In the rest of this subclause, the type of the char-like objects held in a \tcode{basic_string_view} object is designated by \tcode{charT}.
 
 \pnum
 \begin{note}
@@ -5196,11 +5196,11 @@ Equivalent to: \tcode{return substr(pos1, n1).compare(basic_string_view(s, n2));
 \rSec3[string.view.find]{Searching}
 
 \pnum
-This section specifies the \tcode{basic_string_view} member functions named
+This subclause specifies the \tcode{basic_string_view} member functions named
 \tcode{find}, \tcode{rfind}, \tcode{find_first_of}, \tcode{find_last_of}, \tcode{find_first_not_of}, and \tcode{find_last_not_of}.
 
 \pnum
-Member functions in this section have complexity \bigoh{\tcode{size() * str.size()}} at worst,
+Member functions in this subclause have complexity \bigoh{\tcode{size() * str.size()}} at worst,
 although implementations should do better.
 
 \pnum

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1514,7 +1514,7 @@ then \tcode{P} is not at least as specialized as \tcode{A}.
 
 \pnum
 \begin{note}
-This section defines the meaning of constraints on template arguments.
+This subclause defines the meaning of constraints on template arguments.
 The abstract syntax and satisfaction rules are defined
 in \ref{temp.constr.constr}.
 Constraints are associated with declarations in \ref{temp.constr.decl}.
@@ -7519,7 +7519,7 @@ as described in~\ref{temp.deduct.type}.
 \pnum
 If \tcode{P} is a reference type, the type referred to by \tcode{P} is used in place
 of \tcode{P} for type deduction and for any further references to or transformations of
-\tcode{P} in the remainder of this section.
+\tcode{P} in the remainder of this subclause.
 
 \pnum
 If

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -818,7 +818,7 @@ by \tcode{rel_time}.
 \rSec1[thread.mutex]{Mutual exclusion}
 
 \pnum
-This section provides mechanisms for mutual exclusion: mutexes, locks, and call
+This subclause provides mechanisms for mutual exclusion: mutexes, locks, and call
 once. These mechanisms ease the production of race-free
 programs\iref{intro.multithread}.
 
@@ -890,7 +890,7 @@ recursive and non-recursive mutexes are supplied.
 The \defn{mutex types} are the standard library types \tcode{mutex},
 \tcode{recursive_mutex}, \tcode{timed_mutex}, \tcode{recursive_timed_mutex},
 \tcode{shared_mutex}, and \tcode{shared_timed_mutex}.
-They shall meet the requirements set out in this section. In this description, \tcode{m}
+They shall meet the requirements set out in this subclause. In this description, \tcode{m}
 denotes an object of a mutex type.
 
 \pnum

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -5044,7 +5044,7 @@ The specialization is enabled\iref{unord.hash}.
 \rSec1[any]{Storage for any type}
 
 \pnum
-This section describes components that \Cpp programs may use to perform operations on objects of a discriminated type.
+This subclause describes components that \Cpp programs may use to perform operations on objects of a discriminated type.
 
 \pnum
 \begin{note}
@@ -10585,7 +10585,7 @@ weak_ptr<T const> weak_from_this() const noexcept;
 \pnum
 Concurrent access to a \tcode{shared_ptr} object from multiple threads does not
 introduce a data race if the access is done exclusively via the functions in
-this section and the instance is passed as their first argument.
+this subclause and the instance is passed as their first argument.
 
 \pnum
 The meaning of the arguments of type \tcode{memory_order} is explained in~\ref{atomics.order}.
@@ -15459,7 +15459,7 @@ with a base characteristic of
 
 \pnum
 The primary type categories correspond to the descriptions given in
-section~\ref{basic.types} of the \Cpp standard.
+subclause~\ref{basic.types} of the \Cpp standard.
 
 \pnum
 For any given type \tcode{T}, the result of applying one of these templates to
@@ -15545,7 +15545,7 @@ but not pointers to non-static members.                        \\ \rowsep
 
 \pnum
 These templates provide convenient compositions of the primary type
-categories, corresponding to the descriptions given in section~\ref{basic.types}.
+categories, corresponding to the descriptions given in subclause~\ref{basic.types}.
 
 \pnum
 For any given type \tcode{T}, the result of applying one of these templates to
@@ -18166,7 +18166,7 @@ for which \tcode{t \% 2 == 0}.
 \rSec3[time.duration.literals]{Suffixes for duration literals}
 
 \pnum
-This section describes literal suffixes for constructing duration literals. The
+This subclause describes literal suffixes for constructing duration literals. The
 suffixes \tcode{h}, \tcode{min}, \tcode{s}, \tcode{ms}, \tcode{us}, \tcode{ns}
 denote duration values of the corresponding types \tcode{hours}, \tcode{minutes},
 \tcode{seconds}, \tcode{milliseconds}, \tcode{microseconds}, and \tcode{nanoseconds}


### PR DESCRIPTION
The ISO Directives, Part 2, prescribe the term 'subclause'.

Fixes #307.