### PR TITLE
[class.mfct.non-static], [class.this] Define and use cv member function.

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -988,15 +988,18 @@ declared elsewhere.\footnote{See, for example, \tcode{<cstring>}~(\ref{c.strings
 \end{example}
 
 \pnum
+\indextext{member function!const}%
+\indextext{member function!volatile}%
+\indextext{member function!const volatile}%
 A non-static member function may be declared \tcode{const},
 \tcode{volatile}, or \tcode{const} \tcode{volatile}. These
 \grammarterm{cv-qualifier}{s} affect the type of the \tcode{this}
 pointer~(\ref{class.this}). They also affect the function
 type~(\ref{dcl.fct}) of the member function; a member function declared
-\tcode{const} is a \term{const} member function, a member function
-declared \tcode{volatile} is a \term{volatile} member function and a
+\tcode{const} is a \defn{const member function}, a member function
+declared \tcode{volatile} is a \defn{volatile member function} and a
 member function declared \tcode{const} \tcode{volatile} is a
-\term{const volatile} member function.
+\defn{const volatile member function}.
 \begin{example}
 
 \begin{codeblock}
@@ -1006,8 +1009,8 @@ struct X {
 };
 \end{codeblock}
 
-\tcode{X::g} is a \tcode{const} member function and \tcode{X::h} is a
-\tcode{const} \tcode{volatile} member function.
+\tcode{X::g} is a const member function and \tcode{X::h} is a
+const volatile member function.
 \end{example}
 
 \pnum
@@ -1029,17 +1032,14 @@ address of the object for which the function is called.
 \indextext{\idxcode{this}!type of}%
 The type of \tcode{this} in a member function of a class \tcode{X} is
 \tcode{X*}.
-\indextext{member function!\idxcode{const}}%
 If the member function is declared \tcode{const}, the type of
 \tcode{this} is \tcode{const} \tcode{X*},
-\indextext{member function!\idxcode{volatile}}%
 if the member function is declared \tcode{volatile}, the type of
 \tcode{this} is \tcode{volatile} \tcode{X*}, and if the member function
 is declared \tcode{const} \tcode{volatile}, the type of \tcode{this} is
 \tcode{const} \tcode{volatile} \tcode{X*}.
-\indextext{member function!\idxcode{const}}%
-\begin{note} Thus in a \tcode{const} member function, the object for which the function is
-called is accessed through a \tcode{const} access path. \end{note}
+\begin{note} Thus in a const member function, the object for which the function is
+called is accessed through a const access path. \end{note}
 \begin{example}
 
 \begin{codeblock}
@@ -1055,14 +1055,14 @@ int s::f() const { return a; }
 
 The \tcode{a++} in the body of \tcode{s::h} is ill-formed because it
 tries to modify (a part of) the object for which \tcode{s::h()} is
-called. This is not allowed in a \tcode{const} member function because
+called. This is not allowed in a const member function because
 \tcode{this} is a pointer to \tcode{const}; that is, \tcode{*this} has
 \tcode{const} type.
 \end{example}
 
 \pnum
 Similarly, \tcode{volatile} semantics~(\ref{dcl.type.cv}) apply in
-\tcode{volatile} member functions when accessing the object and its
+volatile member functions when accessing the object and its
 non-static data members.
 
 \pnum
@@ -1081,7 +1081,7 @@ void k(s& x, const s& y) {
 \end{codeblock}
 
 The call \tcode{y.g()} is ill-formed because \tcode{y} is \tcode{const}
-and \tcode{s::g()} is a non-\tcode{const} member function, that is,
+and \tcode{s::g()} is a non-const member function, that is,
 \tcode{s::g()} is less-qualified than the object-expression \tcode{y}.
 \end{example}
 


### PR DESCRIPTION
Fixes #447.