### PR TITLE
[support.runtime, list.ops] Move non-code punctuation out of \tcode.

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -5003,7 +5003,7 @@ template <class Predicate> void remove_if(Predicate pred);
 \pnum
 \effects
 Erases all the elements in the list referred by a list iterator \tcode{i} for which the
-following conditions hold: \tcode{*i == value, pred(*i) != false}.
+following conditions hold: \tcode{*i == value}, \tcode{pred(*i) != false}.
 Invalidates only the iterators and references to the erased elements.
 
 \pnum

--- a/source/support.tex
+++ b/source/support.tex
@@ -3729,7 +3729,7 @@ Headers
 \tcode{<csignal>} (signal handling),
 \tcode{<cstdarg>} (variable arguments),
 and
-\tcode{<cstdlib>} (runtime environment \tcode{getenv, system}),
+\tcode{<cstdlib>} (runtime environment \tcode{getenv}, \tcode{system}),
 provide further compatibility with C code.
 
 \pnum


### PR DESCRIPTION
![diffs](http://eel.is/tcodepunct.png)