### PR TITLE
[except.handle] Add index entry for 'active handler'.

### DIFF
--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -586,8 +586,8 @@ handler continues in a dynamically surrounding try block
 of the same thread.
 
 \pnum
-A handler is considered active when initialization is complete for
-the parameter (if any) of the catch clause.
+A handler is considered \defnx{active}{exception handling!handler!active} when
+initialization is complete for the parameter (if any) of the catch clause.
 \begin{note}
 The stack will have been unwound at that point.
 \end{note}


### PR DESCRIPTION
I think an index entry for this term would be useful because it is used in 18.1p4 ([except.throw]), but not defined until 18.3p7 ([except.handle]).

![diff](http://eel.is/active.png)