### PR TITLE
[basic.start.main] Remove space before plural 's'.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2470,8 +2470,8 @@ arguments passed to the program from the environment in which the
 program is run. If
 \tcode{argc} is nonzero these arguments shall be supplied in
 \tcode{argv[0]} through \tcode{argv[argc-1]} as pointers to the initial
-characters of null-terminated multibyte strings (\ntmbs
-s)~(\ref{multibyte.strings}) and \tcode{argv[0]} shall be the pointer to
+characters of null-terminated multibyte strings (\ntmbs{}s)~(\ref{multibyte.strings})
+and \tcode{argv[0]} shall be the pointer to
 the initial character of a \ntmbs that represents the name used to
 invoke the program or \tcode{""}. The value of \tcode{argc} shall be
 non-negative. The value of \tcode{argv[argc]} shall be 0. \begin{note} It


### PR DESCRIPTION
![diff](http://eel.is/ntmbs.png)