### PR TITLE
Spell 'well-defined' with a hyphen when it is an adjective.

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -1604,7 +1604,7 @@ at such time that any
 \tcode{ios_base}
 member function called from within
 \tcode{fn}
-has well defined results.
+has well-defined results.
 \end{itemdescr}
 
 \rSec2[fpos]{Class template \tcode{fpos}}
@@ -2722,7 +2722,7 @@ ios_base& hexfloat(ios_base& str);
 \pnum
 \begin{note} The more obvious use of
 \tcode{ios_base::hex} to specify hexadecimal floating-point format would
-change the meaning of existing well defined programs. \CppIII
+change the meaning of existing well-defined programs. \CppIII
 gives no meaning to the combination of \tcode{fixed} and
 \tcode{scientific}.\end{note}
 

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -725,7 +725,7 @@ unsigned hardware_concurrency() noexcept;
 \pnum
 \returns The number of hardware thread contexts. \begin{note} This value should
 only be considered to be a hint. \end{note} If this value is not computable or
-well defined an implementation should return 0.
+well defined, an implementation should return 0.
 \end{itemdescr}
 
 \rSec3[thread.thread.algorithm]{\tcode{thread} specialized algorithms}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -10351,7 +10351,7 @@ template<class T, class U>
 \begin{itemdescr}
 \pnum
 \requires The expression \tcode{dynamic_cast<T*>((U*)nullptr)}
-shall be well formed and shall have well defined behavior.
+shall be well formed and shall have well-defined behavior.
 
 \pnum
 \returns
@@ -16511,7 +16511,7 @@ To test() {
 }
 \end{codeblock}
 
-\begin{note} This requirement gives well defined results for reference types, void
+\begin{note} This requirement gives well-defined results for reference types, void
 types, array types, and function types.\end{note} Access checking is performed
 in a context unrelated to \tcode{To} and \tcode{From}. Only the validity of
 the immediate context of the \grammarterm{expression} of the \tcode{return} statement


### PR DESCRIPTION
Fixes #1587.