### PR TITLE
[string.streams], [file.streams] Use simple-template-id when naming b…

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -7827,9 +7827,9 @@ explicit basic_istringstream(ios_base::openmode which = ios_base::in);
 Constructs an object of class
 \tcode{basic_istringstream<charT, traits>},
 initializing the base class with
-\tcode{basic_istream(\&sb)}
+\tcode{basic_istream<charT, traits>(\&sb)}~(\ref{istream})
 and initializing \tcode{sb} with
-\tcode{basic_stringbuf<charT, traits, Alloca\-tor>(which | ios_base::in))}~(\ref{stringbuf.cons}).
+\tcode{basic_string\-buf<charT, traits, Allocator>(which | ios_base::in))}~(\ref{stringbuf.cons}).
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_istringstream}!constructor}%
@@ -7845,9 +7845,9 @@ explicit basic_istringstream(
 Constructs an object of class
 \tcode{basic_istringstream<charT, traits>},
 initializing the base class with
-\tcode{basic_istream(\&sb)}
+\tcode{basic_istream<charT, traits>(\&sb)}~(\ref{istream})
 and initializing \tcode{sb} with
-\tcode{basic_stringbuf<charT, traits, Alloca\-tor>(str, which | ios_base::in))}~(\ref{stringbuf.cons}).
+\tcode{basic_string\-buf<charT, traits, Allocator>(str, which | ios_base::in))}~(\ref{stringbuf.cons}).
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_istringstream}!constructor}%
@@ -8013,11 +8013,11 @@ explicit basic_ostringstream(
 \pnum
 \effects
 Constructs an object of class
-\tcode{basic_ostringstream},
+\tcode{basic_ostringstream<charT, traits>},
 initializing the base class with
-\tcode{basic_ostream(\brk{}\&sb)}
+\tcode{basic_ostream<charT, traits>(\&sb)}~(\ref{ostream})
 and initializing \tcode{sb} with
-\tcode{basic_stringbuf<charT, traits, Allocator>(which | \brk{}ios_base::out))}~(\ref{stringbuf.cons}).
+\tcode{basic_string\-buf<charT, traits, Allocator>(which | ios_base::out))}~(\ref{stringbuf.cons}).
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_ostringstream}!constructor}%
@@ -8033,9 +8033,9 @@ explicit basic_ostringstream(
 Constructs an object of class
 \tcode{basic_ostringstream<charT, traits>},
 initializing the base class with
-\tcode{basic_ostream(\&sb)}
+\tcode{basic_ostream<charT, traits>(\&sb)}~(\ref{ostream})
 and initializing \tcode{sb} with
-\tcode{basic_stringbuf<charT, traits, Alloca\-tor>(str, which | ios_base::out))}~(\ref{stringbuf.cons}).
+\tcode{basic_string\-buf<charT, traits, Allocator>(str, which | ios_base::out))}~(\ref{stringbuf.cons}).
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_ostringstream}!constructor}%
@@ -8204,11 +8204,11 @@ explicit basic_stringstream(
 Constructs an object of class
 \tcode{basic_stringstream<charT, traits>},
 initializing the base class with
-\tcode{basic_iostream(\&sb)}
+\tcode{basic_iostream<charT, traits>(\&sb)}~(\ref{iostream.cons})
 and initializing
 \tcode{sb}
 with
-\tcode{basic_stringbuf<charT, traits, Alloca\-tor>(which)}.
+\tcode{basic_string\-buf<charT, traits, Allocator>(which)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_stringstream}!constructor}%
@@ -8224,11 +8224,11 @@ explicit basic_stringstream(
 Constructs an object of class
 \tcode{basic_stringstream<charT, traits>},
 initializing the base class with
-\tcode{basic_iostream(\&sb)}
+\tcode{basic_iostream<charT, traits>(\&sb)}~(\ref{iostream.cons})
 and initializing
 \tcode{sb}
 with
-\tcode{basic_stringbuf<charT, traits, Alloca\-tor>(str, which)}.
+\tcode{basic_string\-buf<charT, traits, Allocator>(str, which)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_stringstream}!constructor}%
@@ -9238,10 +9238,9 @@ basic_ifstream();
 Constructs an object of class
 \tcode{basic_ifstream<charT, traits>},
 initializing the base class with
-\tcode{basic_istream(\&sb)}
+\tcode{basic_istream<charT, traits>(\&sb)}~(\ref{istream.cons})
 and initializing \tcode{sb} with
-\tcode{basic_filebuf<charT, traits>())}~(\ref{istream.cons},
-\ref{filebuf.cons}).
+\tcode{basic_filebuf<charT, traits>())}~(\ref{filebuf.cons}).
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_ifstream}!constructor}%
@@ -9256,12 +9255,11 @@ explicit basic_ifstream(const filesystem::path::value_type* s,
 \pnum
 \effects
 Constructs an object of class
-\tcode{basic_ifstream},
+\tcode{basic_ifstream<charT, traits>},
 initializing the base class with
-\tcode{basic_istream(\&sb)}
+\tcode{basic_istream<charT, traits>(\&sb)}~(\ref{istream.cons})
 and initializing \tcode{sb} with
-\tcode{basic_filebuf<charT, traits>())}~(\ref{istream.cons},
-\ref{filebuf.cons}),
+\tcode{basic_filebuf<charT, traits>())}~(\ref{filebuf.cons}),
 then calls
 \tcode{rdbuf()->open(s, mode | ios_base::in)}.
 If that function returns a null pointer, calls
@@ -9488,10 +9486,9 @@ basic_ofstream();
 Constructs an object of class
 \tcode{basic_ofstream<charT, traits>},
 initializing the base class with
-\tcode{basic_ostream(\&sb)}
+\tcode{basic_ostream<charT, traits>(\&sb)}~(\ref{ostream.cons})
 and initializing \tcode{sb} with
-\tcode{basic_filebuf<charT, traits>())}~(\ref{ostream.cons},
-\ref{filebuf.cons}).
+\tcode{basic_filebuf<charT, traits>())}~(\ref{filebuf.cons}).
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_ofstream}!constructor}%
@@ -9508,10 +9505,9 @@ explicit basic_ofstream(const filesystem::path::value_type* s,
 Constructs an object of class
 \tcode{basic_ofstream<charT, traits>},
 initializing the base class with
-\tcode{basic_ostream(\&sb)}
+\tcode{basic_ostream<charT, traits>(\&sb)}~(\ref{ostream.cons})
 and initializing \tcode{sb} with
-\tcode{basic_filebuf<charT, traits>())}~(\ref{ostream.cons},
-\ref{filebuf.cons}),
+\tcode{basic_filebuf<charT, traits>())}~(\ref{filebuf.cons}),
 then calls
 \tcode{rdbuf()->open(s, mode | ios_base::out)}.
 If that function returns a null pointer, calls
@@ -9747,7 +9743,7 @@ basic_fstream();
 Constructs an object of class
 \tcode{basic_fstream<charT, traits>},
 initializing the base class with
-\tcode{basic_iostream(\&sb)}
+\tcode{basic_iostream<charT, traits>(\&sb)}~(\ref{iostream.cons})
 and initializing
 \tcode{sb}
 with
@@ -9770,7 +9766,7 @@ explicit basic_fstream(
 Constructs an object of class
 \tcode{basic_fstream<charT, traits>},
 initializing the base class with
-\tcode{basic_iostream(\&sb)}
+\tcode{basic_iostream<charT, traits>(\&sb)}~(\ref{iostream.cons})
 and initializing
 \tcode{sb}
 with


### PR DESCRIPTION
…ase classes.

Fixes #1551.