### PR TITLE
macros: Remove unused SectionDepthBase functionality.

### DIFF
--- a/source/macros.tex
+++ b/source/macros.tex
@@ -68,11 +68,11 @@
 % programming to raise the limit from 5 to something larger.)
 
 
-% The basic sectioning command.  Example:
-%    \Sec1[intro.scope]{Scope}
+% The sectioning command.  Example:
+%    \rSec1[intro.scope]{Scope}
 % defines a first-level section whose name is "Scope" and whose short
 % tag is intro.scope.  The square brackets are mandatory.
-\def\Sec#1[#2]#3{%
+\def\rSec#1[#2]#3{%
 \ifcase#1\let\s=\chapter
       \or\let\s=\section
       \or\let\s=\subsection
@@ -81,22 +81,6 @@
       \or\let\s=\subparagraph
       \fi%
 \s[#3]{#3\hfill[#2]}\label{#2}\addxref{#2}}
-
-% A convenience feature (mostly for the convenience of the Project
-% Editor, to make it easy to move around large blocks of text):
-% the \rSec macro is just like the \Sec macro, except that depths
-% relative to a global variable, SectionDepthBase.  So, for example,
-% if SectionDepthBase is 1,
-%   \rSec1[temp.arg.type]{Template type arguments}
-% is equivalent to
-%   \Sec2[temp.arg.type]{Template type arguments}
-\newcounter{SectionDepthBase}
-\newcounter{scratch}
-
-\def\rSec#1[#2]#3{%
-\setcounter{scratch}{#1}
-\addtocounter{scratch}{\value{SectionDepthBase}}
-\Sec{\arabic{scratch}}[#2]{#3}}
 
 %%--------------------------------------------------
 % Indexing


### PR DESCRIPTION
No visual difference, because the functionality is unused (and always was, as far as I can tell).