### PR TITLE
[temp.deduct.type] Use \cv instead of \grammarterm{cv-list}.

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -7024,7 +7024,7 @@ have one of the following forms:
 
 \begin{codeblock}
 T
-@\grammarterm{cv-list}@ T
+@\cv{}@ T
 T*
 T&
 T&&


### PR DESCRIPTION
See https://github.com/cplusplus/draft/blob/master/source/declarators.tex#L141