### PR TITLE
Fix header synopses

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -4105,7 +4105,7 @@ namespace std {
   @\textit{T1}@ resetiosflags(ios_base::fmtflags mask);
   @\textit{T2}@ setiosflags  (ios_base::fmtflags mask);
   @\textit{T3}@ setbase(int base);
-  template<charT> @\textit{T4}@ setfill(charT c);
+  template<class charT> @\textit{T4}@ setfill(charT c);
   @\textit{T5}@ setprecision(int n);
   @\textit{T6}@ setw(int n);
   template <class moneyT> @\textit{T7}@ get_money(moneyT& mon, bool intl = false);

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -10518,7 +10518,7 @@ namespace std::filesystem {
     template <class Source>
       path& operator=(const Source& source);
     template <class Source>
-      path& assign(const Source& source)
+      path& assign(const Source& source);
     template <class InputIterator>
       path& assign(InputIterator first, InputIterator last);
 

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -10163,7 +10163,7 @@ namespace std {
 
   float hypot(float x, float y);  // see \ref{library.c}
   double hypot(double x, double y);
-  long double hypot(double x, double y);  // see \ref{library.c}
+  long double hypot(long double x, long double y);  // see \ref{library.c}
   float hypotf(float x, float y);
   long double hypotl(long double x, long double y);
 

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -5844,17 +5844,17 @@ namespace std {
   int strncmp(const char* s1, const char* s2, size_t n);
   size_t strxfrm(char* s1, const char* s2, size_t n);
   const void* memchr(const void* s, int c, size_t n);  // see \ref{library.c}
-  void* memchr(void* s, int c, size_t n)  // see \ref{library.c}
-  const char* strchr(const char* s, int c)  // see \ref{library.c}
-  char* strchr(char* s, int c)  // see \ref{library.c}
+  void* memchr(void* s, int c, size_t n);  // see \ref{library.c}
+  const char* strchr(const char* s, int c);  // see \ref{library.c}
+  char* strchr(char* s, int c);  // see \ref{library.c}
   size_t strcspn(const char* s1, const char* s2);
-  const char* strpbrk(const char* s1, const char* s2)  // see \ref{library.c}
-  char* strpbrk(char* s1, const char* s2)  // see \ref{library.c}
-  const char* strrchr(const char* s, int c)  // see \ref{library.c}
-  char* strrchr(char* s, int c)  // see \ref{library.c}
+  const char* strpbrk(const char* s1, const char* s2);  // see \ref{library.c}
+  char* strpbrk(char* s1, const char* s2);  // see \ref{library.c}
+  const char* strrchr(const char* s, int c);  // see \ref{library.c}
+  char* strrchr(char* s, int c);  // see \ref{library.c}
   size_t strspn(const char* s1, const char* s2);
-  const char* strstr(const char* s1, const char* s2)  // see \ref{library.c}
-  char* strstr(char* s1, const char* s2)  // see \ref{library.c}
+  const char* strstr(const char* s1, const char* s2);  // see \ref{library.c}
+  char* strstr(char* s1, const char* s2);  // see \ref{library.c}
   char* strtok(char* s1, const char* s2);
   void* memset(void* s, int c, size_t n);
   char* strerror(int errnum);
@@ -6008,19 +6008,19 @@ namespace std {
   int wcsncmp(const wchar_t* s1, const wchar_t* s2, size_t n);
   size_t wcsxfrm(wchar_t* s1, const wchar_t* s2, size_t n);
   int wmemcmp(const wchar_t* s1, const wchar_t* s2, size_t n);
-  const wchar_t* wcschr(const wchar_t* s, wchar_t c)  // see \ref{library.c}
-  wchar_t* wcschr(wchar_t* s, wchar_t c)  // see \ref{library.c}
+  const wchar_t* wcschr(const wchar_t* s, wchar_t c);  // see \ref{library.c}
+  wchar_t* wcschr(wchar_t* s, wchar_t c);  // see \ref{library.c}
   size_t wcscspn(const wchar_t* s1, const wchar_t* s2);
-  const wchar_t* wcspbrk(const wchar_t* s1, const wchar_t* s2)  // see \ref{library.c}
-  wchar_t* wcspbrk(wchar_t* s1, const wchar_t* s2)  // see \ref{library.c}
-  const wchar_t* wcsrchr(const wchar_t* s, wchar_t c)  // see \ref{library.c}
-  wchar_t* wcsrchr(wchar_t* s, wchar_t c)  // see \ref{library.c}
+  const wchar_t* wcspbrk(const wchar_t* s1, const wchar_t* s2);  // see \ref{library.c}
+  wchar_t* wcspbrk(wchar_t* s1, const wchar_t* s2);  // see \ref{library.c}
+  const wchar_t* wcsrchr(const wchar_t* s, wchar_t c);  // see \ref{library.c}
+  wchar_t* wcsrchr(wchar_t* s, wchar_t c);  // see \ref{library.c}
   size_t wcsspn(const wchar_t* s1, const wchar_t* s2);
-  const wchar_t* wcsstr(const wchar_t* s1, const wchar_t* s2)  // see \ref{library.c}
-  wchar_t* wcsstr(wchar_t* s1, const wchar_t* s2)  // see \ref{library.c}
+  const wchar_t* wcsstr(const wchar_t* s1, const wchar_t* s2);  // see \ref{library.c}
+  wchar_t* wcsstr(wchar_t* s1, const wchar_t* s2);  // see \ref{library.c}
   wchar_t* wcstok(wchar_t* s1, const wchar_t* s2, wchar_t** ptr);
-  const wchar_t* wmemchr(const wchar_t* s, wchar_t c, size_t n)  // see \ref{library.c}
-  wchar_t* wmemchr(wchar_t* s, wchar_t c, size_t n)  // see \ref{library.c}
+  const wchar_t* wmemchr(const wchar_t* s, wchar_t c, size_t n);  // see \ref{library.c}
+  wchar_t* wmemchr(wchar_t* s, wchar_t c, size_t n);  // see \ref{library.c}
   size_t wcslen(const wchar_t* s);
   wchar_t* wmemset(wchar_t* s, wchar_t c, size_t n);
   size_t wcsftime(wchar_t* s, size_t maxsize, const wchar_t* format, const struct tm* timeptr);


### PR DESCRIPTION
Fix a few "compiler errors" in header synopses:
* missing semicolons in strings.tex
* parameter type in `long double hypot(...)`
* missing `class` in `template<class charT> T4 setfill(charT c);`