### PR TITLE
[streambuf.virt.put] Fix logic in overflow() effects specification.

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -3939,7 +3939,7 @@ Consumes some initial subsequence of the characters of the
 The pending sequence is defined as the concatenation of
 \begin{itemize}
 \item
-the empty sequence if \tcode{pbase()} is not null, otherwise the
+the empty sequence if \tcode{pbase()} is null, otherwise the
 \tcode{pptr() - pbase()}
 characters beginning at
 \tcode{pbase()}, followed by


### PR DESCRIPTION
The problem was introduced by commit 0b640ed8.