### PR TITLE
[dcl.init] A declarator does not have an initializer.

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -2378,15 +2378,11 @@ the type of the \grammarterm{id-expression} \tcode{y} is ``\tcode{const volatile
 \indextext{initialization|(}
 
 \pnum
-A declarator can specify an initial value for the
-identifier being declared.
-The identifier designates a variable being initialized.
-The process of initialization described in the
-remainder of~\ref{dcl.init}
-applies also to initializations
-specified by other syntactic contexts, such as the initialization
-of function parameters\iref{expr.call} or
-the initialization of return values\iref{stmt.return}.
+The process of initialization described in this subclause applies to
+all initializations regardless of syntactic context, including the
+initialization of a function parameter\iref{expr.call}, the
+initialization of a return value\iref{stmt.return}, or when an
+initializer follows a declarator.
 
 \begin{bnf}
 \nontermdef{initializer}\br
@@ -2440,6 +2436,12 @@ the initialization of return values\iref{stmt.return}.
     expression\br
     braced-init-list
 \end{bnf}
+
+\begin{note}
+The rules in this subclause apply even if the grammar permits only
+the \grammarterm{brace-or-equal-initializer} form
+of \grammarterm{initializer} in a given context.
+\end{note}
 
 \pnum
 Except for objects declared with the \tcode{constexpr} specifier, for which see~\ref{dcl.constexpr},


### PR DESCRIPTION
Fixes #1615.