### PR TITLE
[dcl.init] It is the 'initializer' who specifies an initial value for…

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -2388,7 +2388,7 @@ the type of the \grammarterm{id-expression} \tcode{y} is ``\tcode{const volatile
 \indextext{initialization|(}
 
 \pnum
-A declarator can specify an initial value for the
+An initializer can specify an initial value for the
 identifier being declared.
 The identifier designates a variable being initialized.
 The process of initialization described in the

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -2388,7 +2388,7 @@ the type of the \grammarterm{id-expression} \tcode{y} is ``\tcode{const volatile
 \indextext{initialization|(}
 
 \pnum
-An initializer can specify an initial value for the
+An initializer can be used to specify an initial value for the
 identifier being declared.
 The identifier designates a variable being initialized.
 The process of initialization described in the


### PR DESCRIPTION
… its 'preceding declarator' (#1615)