### PR TITLE
Use 'well-formed' (with hyphen) consistently.

### DIFF
--- a/source/derived.tex
+++ b/source/derived.tex
@@ -866,7 +866,7 @@ struct Okay : VB1, VB2 {
 \end{codeblock}
 Both \tcode{VB1::f} and \tcode{VB2::f} override \tcode{A::f} but there
 is no overrider of both of them in class \tcode{Error}. This example is
-therefore ill-formed. Class \tcode{Okay} is well formed, however,
+therefore ill-formed. Class \tcode{Okay} is well-formed, however,
 because \tcode{Okay::f} is a final overrider.
 \end{example}
 

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -9673,7 +9673,7 @@ template <class ForwardIterator, class T>
 \pnum
 \requires \tcode{T} shall be convertible to \tcode{ForwardIterator}'s value
 type. The expression \tcode{++val}, where \tcode{val} has type \tcode{T}, shall
-be well formed.
+be well-formed.
 
 \pnum
 \effects For each element referred to by the iterator \tcode{i} in the range

--- a/source/special.tex
+++ b/source/special.tex
@@ -40,7 +40,7 @@ struct B : A {
   B& operator=(const B &);
 };
 B& B::operator=(const B& s) {
-  this->A::operator=(s);        // well formed
+  this->A::operator=(s);        // well-formed
   return *this;
 }
 \end{codeblock}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -4064,7 +4064,7 @@ nor a specialization of \tcode{in_place_index_t},
 unless \tcode{is_constructible_v<$\tcode{T}_j$, T>} is \tcode{true},
 and unless the expression
 \tcode{\placeholdernc{FUN}(}\brk\tcode{std::forward<T>(t))} (with \tcode{\placeholdernc{FUN}}
-being the above-mentioned set of imaginary functions) is well formed.
+being the above-mentioned set of imaginary functions) is well-formed.
 
 \pnum
 \begin{note}
@@ -4352,7 +4352,7 @@ This function shall not participate in overload resolution unless
 \tcode{is_assignable_v<$\tcode{T}_j$\&, T> \&\& is_constructible_v<$\tcode{T}_j$, T>} is \tcode{true},
 and unless the expression \tcode{\placeholdernc{FUN}(std::forward<T>(t))} (with
 \tcode{\placeholdernc{FUN}} being the above-mentioned set of imaginary functions)
-is well formed.
+is well-formed.
 
 \pnum
 \begin{note}
@@ -8369,9 +8369,9 @@ template <class U, class E> unique_ptr(unique_ptr<U, E>&& u) noexcept;
 \pnum
 \requires If \tcode{E} is not a reference type,
 construction of the deleter from an rvalue of type
-\tcode{E} shall be well formed and shall not throw an exception.
+\tcode{E} shall be well-formed and shall not throw an exception.
 Otherwise, \tcode{E} is a reference type and construction of the deleter from an
-lvalue of type \tcode{E} shall be well formed and shall not throw an exception.
+lvalue of type \tcode{E} shall be well-formed and shall not throw an exception.
 
 \pnum
 \remarks This constructor shall not participate in overload resolution unless:
@@ -8407,7 +8407,7 @@ to the stored deleter that was constructed from
 
 \begin{itemdescr}
 \pnum
-\requires The expression \tcode{get_deleter()(get())} shall be well formed,
+\requires The expression \tcode{get_deleter()(get())} shall be well-formed,
 shall have well-defined behavior, and shall not throw exceptions. \begin{note} The
 use of \tcode{default_delete} requires \tcode{T} to be a complete type.
 \end{note}
@@ -8578,7 +8578,7 @@ void reset(pointer p = pointer()) noexcept;
 
 \begin{itemdescr}
 \pnum
-\requires The expression \tcode{get_deleter()(get())} shall be well formed, shall have
+\requires The expression \tcode{get_deleter()(get())} shall be well-formed, shall have
 well-defined behavior, and shall not throw exceptions.
 
 \pnum
@@ -9654,7 +9654,7 @@ T& operator*() const noexcept;
 it is unspecified whether this
 member function is declared. If it is declared, it is unspecified what its
 return type is, except that the declaration (although not necessarily the
-definition) of the function shall be well formed.
+definition) of the function shall be well-formed.
 \end{itemdescr}
 
 \indexlibrarymember{operator->}{shared_ptr}%
@@ -9671,7 +9671,7 @@ T* operator->() const noexcept;
 it is unspecified whether this member function is declared.
 If it is declared, it is unspecified what its return type is,
 except that the declaration (although not necessarily the definition)
-of the function shall be well formed.
+of the function shall be well-formed.
 \end{itemdescr}
 
 \indexlibrarymember{operator[]}{shared_ptr}%
@@ -9689,7 +9689,7 @@ If \tcode{T} is \tcode{U[N]}, \tcode{i < N}.
 it is unspecified whether this member function is declared.
 If it is declared, it is unspecified what its return type is,
 except that the declaration (although not necessarily the definition)
-of the function shall be well formed.
+of the function shall be well-formed.
 
 \pnum\throws Nothing.
 \end{itemdescr}
@@ -10159,7 +10159,7 @@ template<class T, class U>
 \begin{itemdescr}
 \pnum
 \requires The expression \tcode{static_cast<T*>((U*)nullptr)} shall
-be well formed.
+be well-formed.
 
 \pnum
 \returns
@@ -10185,7 +10185,7 @@ template<class T, class U>
 \begin{itemdescr}
 \pnum
 \requires The expression \tcode{dynamic_cast<T*>((U*)nullptr)}
-shall be well formed and shall have well-defined behavior.
+shall be well-formed and shall have well-defined behavior.
 
 \pnum
 \returns
@@ -10212,7 +10212,7 @@ template<class T, class U>
 \begin{itemdescr}
 \pnum
 \requires The expression \tcode{const_cast<T*>((U*)nullptr)} shall
-be well formed.
+be well-formed.
 
 \pnum
 \returns
@@ -10237,7 +10237,7 @@ template<class T, class U>
 \begin{itemdescr}
 \pnum
 \requires The expression \tcode{reinterpret_cast<T*>((U*)nullptr)}
-shall be well formed.
+shall be well-formed.
 
 \pnum\returns
 \begin{codeblock}
@@ -11254,7 +11254,7 @@ Uses-allocator construction of \tcode{T}
 with allocator \tcode{resource()} (see~\ref{allocator.uses.construction})
 and constructor arguments \tcode{std::forward<Args>(args)...} is well-formed.
 \begin{note}
-Uses-allocator construction is always well formed
+Uses-allocator construction is always well-formed
 for types that do not use allocators.\end{note}
 
 \pnum
@@ -14371,7 +14371,7 @@ and return type \tcode{R}
 if the expression
 \tcode{\placeholdernc{INVOKE}<R>(declval<F\&>(), declval<ArgTypes>()...)},
 considered as an unevaluated operand\iref{expr}, is
-well formed\iref{func.require}.
+well-formed\iref{func.require}.
 
 \pnum
 The \tcode{function} class template is a call
@@ -16266,7 +16266,7 @@ not possibly cv-qualified versions of the same type,
 \tcode{template <class Fn, class... ArgTypes>}\br
  \tcode{struct is_invocable;}                      &
  The expression \tcode{\placeholdernc{INVOKE}(declval<Fn>(), declval<ArgTypes>()...)}
- is well formed when treated as an unevaluated operand                &
+ is well-formed when treated as an unevaluated operand                &
  \tcode{Fn} and all types in the parameter pack \tcode{ArgTypes}
  shall be complete types, \cv{}~\tcode{void}, or
  arrays of unknown bound.                                             \\ \rowsep
@@ -16275,7 +16275,7 @@ not possibly cv-qualified versions of the same type,
 \tcode{template <class R, class Fn, class... ArgTypes>}\br
  \tcode{struct is_invocable_r;}                      &
  The expression \tcode{\placeholdernc{INVOKE}<R>(declval<Fn>(), declval<ArgTypes>()...)}
- is well formed when treated as an unevaluated operand                &
+ is well-formed when treated as an unevaluated operand                &
  \tcode{Fn}, \tcode{R}, and all types in the parameter pack \tcode{ArgTypes}
  shall be complete types, \cv{}~\tcode{void}, or
  arrays of unknown bound.                                             \\ \rowsep
@@ -16677,7 +16677,7 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
  \tcode{struct invoke_result;}
  &
  If the expression \tcode{\placeholdernc{INVOKE}(declval<Fn>(), declval<ArgTypes>()...)}
- is well formed when treated as an unevaluated operand\iref{expr},
+ is well-formed when treated as an unevaluated operand\iref{expr},
  the member typedef \tcode{type} names the type
  \tcode{decltype(\placeholdernc{INVOKE}(declval<Fn>(), declval<ArgTypes>()...))};
  otherwise, there shall be no member \tcode{type}. Access checking is


### PR DESCRIPTION
Fixes #1618.