### PR TITLE
[dcl.attr.depend] Remove paragraph break before end of example.

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3928,7 +3928,6 @@ but its first parameter does not. Therefore, function \tcode{h}'s first call to
 \tcode{g} carries a dependency into \tcode{g}, but its second call does not. The
 implementation might need to insert a fence prior to the second call to
 \tcode{g}.
-
 \end{example}%
 \indextext{attribute|)}%
 \indextext{declaration|)}


### PR DESCRIPTION
The paragraph break is visible in the PDF.