### PR TITLE
[class.union] Only standard-layout unions are pointer-interconvertible

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1526,9 +1526,9 @@ The size of a union is sufficient to contain the largest
 of its non-static data members. Each non-static data member is allocated
 as if it were the sole member of a struct.
 \begin{note}
-A union object and its non-static data members are
+A standard-layout union object and its non-static data members are
 pointer-interconvertible~(\ref{basic.compound}, \ref{expr.static.cast}).
-As a consequence, all non-static data members of a
+As a consequence, all non-static data members of such a
 union object have the same address.
 \end{note}
 


### PR DESCRIPTION
with their members.

Fixes #1624.