### PR TITLE
Change the return type of monotonic_buffer_resource's deleted assignment

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -12116,7 +12116,7 @@ public:
 
   virtual ~monotonic_buffer_resource();
 
-  monotonic_buffer_resource
+  monotonic_buffer_resource&
     operator=(const monotonic_buffer_resource&) = delete;
 
   void release();


### PR DESCRIPTION
... to `monotonic_buffer_resource&` for consistency with the default definition of the builtin assignment operator. This change has no normative effect, it only eliminates the inconsistency as a potential source of confusion.

Since the return type of deleted functions is not observable, this change is editorial.
