### PR TITLE
Fixed ref to effects of invalid pointer values.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3220,7 +3220,7 @@ value is an invalid pointer value unless
 the referenced complete object has previously been declared
 reachable~(\ref{util.dynamic.safety}). \begin{note}
 The effect of using an invalid pointer value (including passing it to a
-deallocation function) is undefined, see~\ref{basic.stc.dynamic.deallocation}.
+deallocation function) is undefined, see~\ref{basic.stc}.
 This is true even if the unsafely-derived pointer value might compare equal to
 some safely-derived pointer value. \end{note} It is
 \impldef{whether an implementation has relaxed or strict pointer


### PR DESCRIPTION
Updated the Note describing "invalid pointer values" to refer to [basic.stc] rather than [basic.stc.dynamic.deallocation].

The relevant description of "invalid pointer values" reads:
"Indirection through an invalid pointer value and passing an invalid pointer value to a deallocation function have undeﬁned behavior. Any other use of an invalid pointer value has implementation-deﬁned behavior."

Previously the reference was correct, as this text was in [basic.stc.dynamic.deallocation]/4, but the text was moved to [basic.stc]/4 by P0137R1; without updating the reference.

The Note also incorrectly claims that using an invalid pointer value is always undefined, when it can be implementation defined in certain cases, but I did not fix this in this commit; as updating the reference makes this nuance sufficiently clear.

This is an editorial issue as it only changes non-normative text.