### PR TITLE
Support XeTeX.

### DIFF
--- a/source/std.tex
+++ b/source/std.tex
@@ -30,9 +30,9 @@
 \usepackage{xspace}
 \usepackage{lmodern}
 \usepackage[T1]{fontenc}
-\usepackage[pdftex, final]{graphicx}
-\usepackage[pdftex,
-            pdftitle={C++ International Standard},
+\usepackage{ifxetex}
+\usepackage[final]{graphicx}
+\usepackage[pdftitle={C++ International Standard},
             pdfsubject={C++ International Standard},
             pdfcreator={Richard Smith},
             bookmarks=true,
@@ -48,9 +48,11 @@
 \usepackage{memhfixc}     % fix interactions between hyperref and memoir
 \usepackage[active,header=false,handles=false,copydocumentclass=false,generate=std-gram.ext,extract-cmdline={gramSec},extract-env={bnftab,simplebnf,bnf,bnfkeywordtab}]{extract} % Grammar extraction
 
-\pdfminorversion=5
-\pdfcompresslevel=9
-\pdfobjcompresslevel=2
+\ifxetex\else
+  \pdfminorversion=5
+  \pdfcompresslevel=9
+  \pdfobjcompresslevel=2
+\fi
 
 \renewcommand\RSsmallest{5.5pt}  % smallest font size for relsize
 
@@ -80,7 +82,9 @@
 
 %%--------------------------------------------------
 %% turn off all ligatures inside \texttt
-\DisableLigatures{encoding = T1, family = tt*}
+\ifxetex\else
+  \DisableLigatures{encoding = T1, family = tt*}
+\fi
 
 \begin{document}
 \chapterstyle{cppstd}


### PR DESCRIPTION
graphicx and hyperref can detect pdf engines by themselves.
microtype font expansion doesn't work with xetex yet.