### PR TITLE
For 'signal-safe', refer to [support.signal] (21.10.4), not [csignal.syn] (21.10.3).

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -5877,7 +5877,7 @@ races~(\ref{res.on.data.races}).
 \pnum
 \indextext{signal-safe!\idxcode{memcpy}}%
 \indextext{signal-safe!\idxcode{memmove}}%
-The functions \tcode{memcpy} and \tcode{memmove} are signal-safe~(\ref{csignal.syn}).
+The functions \tcode{memcpy} and \tcode{memmove} are signal-safe~(\ref{support.signal}).
 
 \pnum
 \begin{note}

--- a/source/support.tex
+++ b/source/support.tex
@@ -724,7 +724,7 @@ Non-arithmetic standard types, such as
 
 \pnum
 \indextext{signal-safe!\idxcode{numeric_limits} members}%
-Each member function defined in this subclause is signal-safe~(\ref{csignal.syn}).
+Each member function defined in this subclause is signal-safe~(\ref{support.signal}).
 
 \indexlibrarymember{min}{numeric_limits}%
 \begin{itemdecl}
@@ -1622,7 +1622,7 @@ The program is terminated without executing destructors for objects of automatic
 thread, or static storage duration and without calling functions passed to
 \tcode{atexit()}~(\ref{basic.start.term}).
 \indextext{signal-safe!\idxcode{_Exit}}%
-The function \tcode{_Exit} is signal-safe~(\ref{csignal.syn}).
+The function \tcode{_Exit} is signal-safe~(\ref{support.signal}).
 \end{itemdescr}
 
 \indexlibrary{\idxcode{abort}}%
@@ -1642,7 +1642,7 @@ automatic, thread, or static storage
 duration and without calling functions passed to
 \tcode{atexit()}~(\ref{basic.start.term}).
 \indextext{signal-safe!\idxcode{abort}}%
-The function \tcode{abort} is signal-safe~(\ref{csignal.syn}).
+The function \tcode{abort} is signal-safe~(\ref{support.signal}).
 \end{itemdescr}
 
 \indexlibrary{\idxcode{atexit}}%
@@ -1796,7 +1796,7 @@ The standard file buffers are not flushed.
 \pnum
 \remarks
 \indextext{signal-safe!\idxcode{quick_exit}}%
-The function \tcode{quick_exit} is signal-safe~(\ref{csignal.syn})
+The function \tcode{quick_exit} is signal-safe~(\ref{support.signal})
 when the functions registered with \tcode{at_quick_exit} are.
 \end{itemdescr}
 
@@ -3580,7 +3580,7 @@ if (auto p = dynamic_cast<const nested_exception*>(addressof(e)))
 The header \tcode{<initializer_list>} defines a class template and several
 support functions related to list-initialization~(see \ref{dcl.init.list}).
 \indextext{signal-safe!\idxcode{initializer_list} functions}%
-All functions specified in this subclause are signal-safe~(\ref{csignal.syn}).
+All functions specified in this subclause are signal-safe~(\ref{support.signal}).
 
 \rSec2[initializer_list.syn]{Header \tcode{<initializer_list>} synopsis}
 \indexlibrary{\idxcode{initializer_list}}%

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -418,7 +418,7 @@ of forwarding functions.
 \indextext{signal-safe!\idxcode{forward}}%
 \indextext{signal-safe!\idxcode{move}}%
 \indextext{signal-safe!\idxcode{move_if_noexcept}}%
-All functions specified in this subclause are signal-safe~(\ref{csignal.syn}).
+All functions specified in this subclause are signal-safe~(\ref{support.signal}).
 
 \indexlibrary{\idxcode{forward}}%
 \begin{itemdecl}
@@ -15223,7 +15223,7 @@ type transformations allow certain properties of types to be manipulated.
 
 \pnum
 \indextext{signal-safe!type traits}%
-All functions specified in this subclause are signal-safe~(\ref{csignal.syn}).
+All functions specified in this subclause are signal-safe~(\ref{support.signal}).
 
 \rSec2[meta.rqmts]{Requirements}
 


### PR DESCRIPTION
(Because [support.signal] is where 'signal-safe' is defined.)