### PR TITLE
[stringbuf.virtuals] Rephrase DR 453 resolution for seekoff

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -7675,14 +7675,16 @@ Otherwise &
 \end{libtab2}
 
 \pnum
-For a sequence to be positioned, if its next pointer
+For a sequence to be positioned,
+the function determines \tcode{newoff} as indicated in
+Table~\ref{tab:iostreams.newoff.values}.
+If the sequence's next pointer
 (either
 \tcode{gptr()}
 or
 \tcode{pptr()})
-is a null pointer and the new offset \tcode{newoff} is nonzero, the positioning
-operation fails. Otherwise, the function determines \tcode{newoff} as indicated in
-Table~\ref{tab:iostreams.newoff.values}.
+is a null pointer and \tcode{newoff} is nonzero,
+the positioning operation fails.
 
 \begin{libtab2}{\tcode{newoff} values}{tab:iostreams.newoff.values}
 {lp{2.0in}}{Condition}{\tcode{newoff} Value}


### PR DESCRIPTION
This avoids the requirement to compare newoff to zero when the value of
newoff hasn't been determined.