### PR TITLE
Clarify a note on cmpxchg

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -903,9 +903,7 @@ would not, the strong one is preferable.
 \begin{note} The \tcode{memcpy} and \tcode{memcmp} semantics of the compare-and-exchange
 operations may result in failed comparisons for values that compare equal with
 \tcode{operator==} if the underlying type has padding bits, trap bits, or alternate
-representations of the same value. Thus, \tcode{compare_exchange_strong} should be used
-with extreme care. On the other hand, \tcode{compare_exchange_weak} should converge
-rapidly. \end{note}
+representations of the same value.\end{note}
 \end{itemdescr}
 
 \rSec2[atomics.types.int]{Specializations for integers}


### PR DESCRIPTION
The "thus" part absolutely does not follow from the preceding note text, and isn't even correct on its own. Since this is a note I assume this is an editorial change and doesn't need an issue.