### PR TITLE
[re.traits] Use \placeholdernc for a placeholder.

### DIFF
--- a/source/regex.tex
+++ b/source/regex.tex
@@ -1023,7 +1023,7 @@ namespace std {
       using char_type       = charT;
       using string_type     = basic_string<char_type>;
       using locale_type     = locale;
-      using char_class_type = @{\itshape bitmask_type}@;
+      using char_class_type = @\placeholdernc{bitmask_type}@;
 
       regex_traits();
       static size_t length(const char_type* p);


### PR DESCRIPTION
Slightly changes whitespace:
![diff](http://eel.is/bitmasktype.png)