### PR TITLE
[expr.mptr.oper] Index second definition of 'object expression'.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3950,7 +3950,7 @@ The expression \tcode{E1->*E2} is converted into the equivalent form
 
 \pnum
 Abbreviating \term{pm-expression}{}\tcode{.*}\term{cast-expression} as \tcode{E1.*E2}, \tcode{E1}
-is called the \term{object expression}.
+is called the \defn{object expression}.
 If the dynamic type of \tcode{E1} does not
 contain the member to which
 \tcode{E2} refers, the behavior is undefined.


### PR DESCRIPTION
There are two things known as "object expression":
- the E1 in "E1.E2" ([expr.ref]/3)
- the E1 in "E1.*E2" ([expr.mptr.oper]/4)

Because currently only the first of these is indexed, this patch adds an entry for the second one.

![diff](http://eel.is/objectexpr.png)