### PR TITLE
Capitalize after "Effects:"/"Returns:"/"Throws:"/"Requires:".

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -11682,7 +11682,7 @@ path extension() const;
 
 \begin{itemdescr}
 \pnum
-\returns a path whose pathname in the generic format is
+\returns A path whose pathname in the generic format is
 the suffix of \tcode{filename()} not included in \tcode{stem()}.
 
 \pnum

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -1137,7 +1137,7 @@ template <class ForwardIterator>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns a sequence of one or more characters that
+\pnum\returns A sequence of one or more characters that
 represents the collating element consisting of the character
 sequence designated by the iterator range \range{first}{last}.
 Returns an empty string if the character sequence is not a
@@ -1152,7 +1152,7 @@ template <class ForwardIterator>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns an unspecified value that represents
+\pnum\returns An unspecified value that represents
 the character classification named by the character sequence
 designated by the iterator range \range{first}{last}.
 If the parameter \tcode{icase} is \tcode{true} then the returned mask identifies the
@@ -1240,7 +1240,7 @@ int value(charT ch, int radix) const;
 \requires  The value of \tcode{radix} shall be 8, 10, or 16.
 
 \pnum
-\returns the value represented by the digit \tcode{ch} in base
+\returns The value represented by the digit \tcode{ch} in base
 \tcode{radix} if the character \tcode{ch} is a valid digit in base
 \tcode{radix}; otherwise returns \tcode{-1}.
 \end{itemdescr}
@@ -1259,7 +1259,7 @@ different locale than the one currently in use invalidates all cached
 data held by \tcode{*this}. \end{note}
 
 \pnum
-\returns if no locale has been previously imbued then a copy of the
+\returns If no locale has been previously imbued then a copy of the
 global locale in effect at the time of construction of \tcode{*this},
 otherwise a copy of the last argument passed to \tcode{imbue}.
 
@@ -1275,7 +1275,7 @@ locale_type getloc() const;
 
 \begin{itemdescr}
 \pnum
-\returns if no locale has been imbued then a copy of the global locale
+\returns If no locale has been imbued then a copy of the global locale
 in effect at the time of construction of \tcode{*this}, otherwise a copy of
 the last argument passed to \tcode{imbue}.
 \end{itemdescr}

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -4391,7 +4391,7 @@ unsigned long long stoull(const string& str, size_t* idx = nullptr, int base = 1
 
 \begin{itemdescr}
 \pnum
-\effects the first two functions call \tcode{strtol(str.c_str(), ptr, base)},
+\effects The first two functions call \tcode{strtol(str.c_str(), ptr, base)},
 and the last three functions call \tcode{strtoul(str.c_str(), ptr, base)},
 \tcode{strtoll(str.c_str(), ptr, base)}, and \tcode{strtoull(\brk{}str.c_str(), ptr,
 base)}, respectively. Each function returns the converted result, if any. The
@@ -4488,7 +4488,7 @@ unsigned long long stoull(const wstring& str, size_t* idx = nullptr, int base = 
 
 \begin{itemdescr}
 \pnum
-\effects the first two functions call \tcode{wcstol(str.c_str(), ptr, base)},
+\effects The first two functions call \tcode{wcstol(str.c_str(), ptr, base)},
 and the last three functions call \tcode{wcstoul(str.c_str(), ptr, base)},
 \tcode{wcstoll(str.c_str(), ptr, base)}, and \tcode{wcstoull(\brk{}str.c_str(), ptr,
 base)}, respectively. Each function returns the converted result, if any. The

--- a/source/support.tex
+++ b/source/support.tex
@@ -2592,7 +2592,7 @@ bad_array_new_length() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects constructs an object of class \tcode{bad_array_new_length}.
+\effects Constructs an object of class \tcode{bad_array_new_length}.
 \end{itemdescr}
 
 \indexlibrarymember{what}{bad_array_new_length}%

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -3972,7 +3972,7 @@ template <class Allocator>
 
 \begin{itemdescr}
 \pnum
-\effects constructs a \tcode{promise} object and a shared state. The second
+\effects Constructs a \tcode{promise} object and a shared state. The second
 constructor uses the allocator \tcode{a} to allocate memory for the shared
 state.
 \end{itemdescr}
@@ -3984,7 +3984,7 @@ promise(promise&& rhs) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects constructs a new \tcode{promise} object and transfers ownership of the shared state
+\effects Constructs a new \tcode{promise} object and transfers ownership of the shared state
 of \tcode{rhs} (if any) to the newly-constructed object.
 
 \pnum
@@ -4382,7 +4382,7 @@ value stored in the shared state;
 \end{itemize}
 
 \pnum
-\throws the stored exception, if an exception was stored in the shared state.
+\throws The stored exception, if an exception was stored in the shared state.
 
 \pnum
 \postconditions \tcode{valid() == false}.
@@ -4698,7 +4698,7 @@ shared state.
 \end{itemize}
 
 \pnum
-\throws the stored exception, if an exception was stored in the shared state.
+\throws The stored exception, if an exception was stored in the shared state.
 \end{itemdescr}
 
 \indexlibrarymember{valid}{shared_future}%
@@ -5142,7 +5142,7 @@ future<R> get_future();
 \returns A \tcode{future} object that shares the same shared state as \tcode{*this}.
 
 \pnum
-\throws a \tcode{future_error} object if an error occurs.
+\throws A \tcode{future_error} object if an error occurs.
 
 \pnum
 \errors
@@ -5171,7 +5171,7 @@ function waiting for
 the shared state of \tcode{*this} to become ready are unblocked.
 
 \pnum
-\throws a \tcode{future_error} exception object if there is no shared
+\throws A \tcode{future_error} exception object if there is no shared
 state or the stored task has already been invoked.
 
 \pnum

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -8506,7 +8506,7 @@ template <class U> default_delete(const default_delete<U[]>& other) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-constructs a \tcode{default_delete} object from another \tcode{default_delete<U[]>} object.
+Constructs a \tcode{default_delete} object from another \tcode{default_delete<U[]>} object.
 
 \pnum
 \remarks
@@ -12703,7 +12703,7 @@ template <class T1, class T2, class... Args1, class... Args2>
 
 \begin{itemdescr}
 \pnum
-\requires all of the types in \tcode{Args1} and \tcode{Args2} shall be
+\requires All of the types in \tcode{Args1} and \tcode{Args2} shall be
 \tcode{CopyConstructible} (Table~\ref{tab:copyconstructible}).
 
 \pnum
@@ -14596,7 +14596,7 @@ function(const function& f);
 \tcode{*this} targets a copy of \tcode{f.target()}.
 
 \pnum
-\throws shall not throw exceptions if \tcode{f}'s target is
+\throws Shall not throw exceptions if \tcode{f}'s target is
 a specialization of \tcode{reference_wrapper} or
 a function pointer. Otherwise, may throw \tcode{bad_alloc}
 or any exception thrown by the copy constructor of the stored callable object.
@@ -14619,7 +14619,7 @@ the target of \tcode{f} before the construction, and
 \tcode{f} is in a valid state with an unspecified value.
 
 \pnum
-\throws shall not throw exceptions if \tcode{f}'s target is
+\throws Shall not throw exceptions if \tcode{f}'s target is
 a specialization of \tcode{reference_wrapper} or
 a function pointer. Otherwise, may throw \tcode{bad_alloc} or
 any exception thrown by the copy or move constructor
@@ -14662,7 +14662,7 @@ where \tcode{f} is an object holding only a pointer or
 reference to an object and a member function pointer. \end{note}
 
 \pnum
-\throws shall not throw exceptions when \tcode{f} is a function pointer
+\throws Shall not throw exceptions when \tcode{f} is a function pointer
 or a \tcode{reference_wrapper<T>} for some \tcode{T}. Otherwise,
 may throw \tcode{bad_alloc} or any exception thrown by \tcode{F}'s copy
 or move constructor.
@@ -14777,7 +14777,7 @@ void swap(function& other) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects interchanges the targets of \tcode{*this} and \tcode{other}.
+\pnum\effects Interchanges the targets of \tcode{*this} and \tcode{other}.
 \end{itemdescr}
 
 \rSec4[func.wrap.func.cap]{\tcode{function} capacity}


### PR DESCRIPTION
For consistency.