### PR TITLE
[Editorial] Clarify UTF-8 character literal definition

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -1136,11 +1136,11 @@ begins with \tcode{u8}, such as \tcode{u8'w'},
 \indextext{prefix!\idxcode{u8}}%
 is a character literal of type \tcode{char},
 known as a \defn{UTF-8 character literal}.
-The value of a UTF-8 character literal
+The value of a UTF-8 character literal containing a single \grammarterm{c-char}
 is equal to its ISO 10646 code point value,
 provided that the code point value
-is representable with a single UTF-8 code unit
-(that is, provided it is in the C0 Controls and Basic Latin Unicode block).
+is representable with a single UTF-8 code unit.
+(That is, provided it is in the C0 Controls and Basic Latin Unicode block.)
 If the value is not representable with a single UTF-8 code unit,
 the program is ill-formed.
 A UTF-8 character literal containing multiple \grammarterm{c-char}{s} is ill-formed.


### PR DESCRIPTION
In [lex.ccon], the definition of UTF-8 character literals almost parallels the definition of `char16_t` literals, but there are a few differences.

One of the differences was that the definition of UTF-8 character literals was missing a few words, making a later pronoun lack an antecedent which made sense.