### PR TITLE
[class.temporary] Remove note giving questionable implementation advice.

### DIFF
--- a/source/special.tex
+++ b/source/special.tex
@@ -537,13 +537,15 @@ persists until the completion of the full-expression containing the call.
 
 \item The lifetime of a temporary bound to the returned value in a function return statement~(\ref{stmt.return}) is not extended; the temporary is destroyed at the end of the full-expression in the return statement.
 
-\item A temporary bound to a reference in a \grammarterm{new-initializer}~(\ref{expr.new}) persists until the completion of the full-expression containing the \grammarterm{new-initializer}. \begin{example}
+\item A temporary bound to a reference in a \grammarterm{new-initializer}~(\ref{expr.new}) persists until the completion of the full-expression containing the \grammarterm{new-initializer}.
+\begin{note} This may introduce a dangling reference. \end{note}
+\begin{example}
 \begin{codeblock}
 struct S { int mi; const std::pair<int,int>& mp; };
 S a { 1, {2,3} };
 S* p = new S{ 1, {2,3} };   // Creates dangling reference
 \end{codeblock}
-\end{example} \begin{note} This may introduce a dangling reference, and implementations should issue a warning in such a case. \end{note}
+\end{example}
 \end{itemize}
 
 \pnum


### PR DESCRIPTION
And move the surviving part of the note to before the
corresponding example.
    
Fixes #1674.