### PR TITLE
[expr] Use 'possibly converted' for discarded-value expression.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -233,7 +233,7 @@ following:
 \begin{note} Using an overloaded operator causes a function call; the
 above covers only operators with built-in meaning.
 \end{note}
-If the expression is a prvalue after this optional conversion,
+If the (possibly converted) expression is a prvalue,
 the temporary materialization conversion~(\ref{conv.rval}) is applied.
 \begin{note}
 If the expression is an lvalue of


### PR DESCRIPTION
Fixes #1597.