### PR TITLE
Remove trailing whitespace.

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -99,17 +99,17 @@ auto j = 2.0;           // OK: \tcode{j} deduced to have type \tcode{double}
 \pnum
 The optional \grammarterm{requires-clause} (Clause~\ref{temp}) in an
 \grammarterm{init-declarator} or \grammarterm{member-declarator}
-shall not be present when the declarator does not declare a 
+shall not be present when the declarator does not declare a
 function (\ref{dcl.fct}).
-% 
-When present after a declarator, the \grammarterm{requires-clause} 
+%
+When present after a declarator, the \grammarterm{requires-clause}
 is called the \defnx{trailing \grammarterm{requires-clause}{}}{%
 trailing requires-clause@trailing \grammarterm{requires-clause}}.
 The trailing \grammarterm{requires-clause} introduces the
 \grammarterm{constraint-expression} that results from interpreting
 its \grammarterm{constraint-logical-or-expression} as a
 \grammarterm{constraint-expression}.
-% 
+%
 \begin{example}
 \begin{codeblock}
 void f1(int a) requires true;               // OK
@@ -117,7 +117,7 @@ auto f2(int a) -> bool requires true;       // OK
 auto f3(int a) requires true -> bool;       // error: \grammarterm{requires-clause} precedes \grammarterm{trailing-return-type}
 void (*pf)() requires true;                 // error: constraint on a variable
 void g(int (*)() requires true);            // error: constraint on a \grammarterm{parameter-declaration}
-  
+
 auto* p = new void(*)(char) requires true;  // error: not a function declaration
 \end{codeblock}
 \end{example}
@@ -1430,7 +1430,7 @@ contains a mechanism for accessing arguments passed using the ellipsis
 \indextext{type!function}%
 A single name can be used for several different functions in a single scope;
 this is function overloading (Clause~\ref{over}).
-All declarations for a function shall have equivalent return types, 
+All declarations for a function shall have equivalent return types,
 parameter-type-lists, and \grammarterm{requires-clause}{s} (\ref{temp.over.link}).
 The type of a function is determined using the following rules.
 The type of each parameter (including function parameter packs) is

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -484,7 +484,7 @@ int j = sizeof(S::m + 42);      // OK
 \pnum
 An \grammarterm{id-expression}
 that denotes the specialization of a concept~(\ref{temp.concept})
-results in a prvalue of type \tcode{bool}. 
+results in a prvalue of type \tcode{bool}.
 The expression is \tcode{true} if
 the concept's normalized~(\ref{temp.constr.decl})
 \grammarterm{constraint-expression}
@@ -1513,7 +1513,7 @@ bool f(Args ...args) {
 \indextext{expression!requires|(}%
 
 \pnum
-A \grammarterm{requires-expression} provides a concise way to express 
+A \grammarterm{requires-expression} provides a concise way to express
 requirements on template arguments
 that can be checked by name lookup~(\ref{basic.lookup})
 or by checking properties of types and expressions.
@@ -1564,37 +1564,37 @@ template<typename T>
     {*i} -> const typename T::type&;
   };
 \end{codeblock}
-A \grammarterm{requires-expression} can also be used in a 
-\grammarterm{requires-clause} (Clause~\ref{temp}) as a way of writing ad hoc 
+A \grammarterm{requires-expression} can also be used in a
+\grammarterm{requires-clause} (Clause~\ref{temp}) as a way of writing ad hoc
 constraints on template arguments such as the one below:
 \begin{codeblock}
 template<typename T>
   requires requires (T x) { x + x; }
     T add(T a, T b) { return a + b; }
 \end{codeblock}
-The first \tcode{requires} introduces the 
+The first \tcode{requires} introduces the
 \grammarterm{requires-clause}, and the second
 introduces the \grammarterm{requires-expression}.
 \end{example}
 
 \pnum
 A \grammarterm{requires-expression} may introduce local parameters using a
-\grammarterm{parameter-declaration-clause}~(\ref{dcl.fct}). 
-A local parameter of a \grammarterm{requires-expression} shall not have a 
+\grammarterm{parameter-declaration-clause}~(\ref{dcl.fct}).
+A local parameter of a \grammarterm{requires-expression} shall not have a
 default argument.
 Each name introduced by a local parameter is in scope from the point
 of its declaration until the closing brace of the
 \grammarterm{requirement-body}.
 These parameters have no linkage, storage, or lifetime; they are only used
 as notation for the purpose of defining \grammarterm{requirement}{}s.
-The \grammarterm{parameter-declaration-clause} of a 
+The \grammarterm{parameter-declaration-clause} of a
 \grammarterm{requirement-parameter-list}
 shall not terminate with an ellipsis.
 \begin{example}
 \begin{codeblock}
 template<typename T>
 concept C = requires(T t, ...) {    // error: terminates with an ellipsis
-  t; 
+  t;
 };
 \end{codeblock}
 \end{example}
@@ -1603,12 +1603,12 @@ concept C = requires(T t, ...) {    // error: terminates with an ellipsis
 \indextext{requirement}%
 The \grammarterm{requirement-body} contains
 a sequence of \grammarterm{requirement}{}s.
-These \grammarterm{requirement}{}s may refer to local 
-parameters, template parameters, and any other declarations visible from the 
-enclosing context. 
+These \grammarterm{requirement}{}s may refer to local
+parameters, template parameters, and any other declarations visible from the
+enclosing context.
 
 \pnum
-The substitution of template arguments into a \grammarterm{requires-expression} 
+The substitution of template arguments into a \grammarterm{requires-expression}
 may result in the formation of invalid types or expressions in its
 requirements or the violation of the semantic constraints of those requirements.
 In such cases, the \grammarterm{requires-expression} evaluates to \tcode{false};
@@ -1623,8 +1623,8 @@ If a \grammarterm{requires-expression} contains invalid types or expressions in
 its requirements, and it does not appear within the declaration of a templated
 entity, then the program is ill-formed.
 \end{note}
-If the substitution of template arguments into a \grammarterm{requirement} 
-would always result in a substitution failure, the program is ill-formed; 
+If the substitution of template arguments into a \grammarterm{requirement}
+would always result in a substitution failure, the program is ill-formed;
 no diagnostic required.
 \begin{example}
 \begin{codeblock}
@@ -1687,12 +1687,12 @@ template<typename T> concept C = requires {
 \end{example}
 
 \pnum
-A type requirement that names a class template specialization 
+A type requirement that names a class template specialization
 does not require that type to be complete~(\ref{basic.types}).
 
 \rSec3[expr.prim.req.compound]{Compound requirements}
 \indextext{requirement!compound}%
-      
+
 \begin{bnf}
 \nontermdef{compound-requirement}\br
     \terminal{\{} expression \terminal{\}} \terminal{noexcept}\opt{} return-type-requirement\opt{} \terminal{;}
@@ -1723,7 +1723,7 @@ into the \grammarterm{expression} is performed.
 \item Substitution of template arguments (if any)
 into the \grammarterm{return-type-requirement} is performed.
 
-\item If the \grammarterm{return-type-requirement} is a 
+\item If the \grammarterm{return-type-requirement} is a
 \grammarterm{trailing-return-type},
 %%% FIXME: is -> shall be
 \tcode{E} is implicitly convertible to
@@ -1738,7 +1738,7 @@ an invented function template \tcode{F}
 using the rules in \ref{temp.deduct.call}.
 \tcode{F} is a \tcode{void} function template
 with a single type template parameter \tcode{T}
-declared with the \grammarterm{constrained-parameter}. 
+declared with the \grammarterm{constrained-parameter}.
 A \grammarterm{cv-qualifier-seq} \cv{} is formed
 as the union of \tcode{const} and \tcode{volatile} specifiers
 around the \grammarterm{constrained-parameter}.
@@ -1758,7 +1758,7 @@ template<typename T> concept C1 = requires(T x) {
   {x++};
 };
 \end{codeblock}
-The \grammarterm{compound-requirement} in \tcode{C1} 
+The \grammarterm{compound-requirement} in \tcode{C1}
 requires that \tcode{x++} is a valid expression.
 It is equivalent to a \grammarterm{simple-requirement}
 with the same \grammarterm{expression}.
@@ -1769,7 +1769,7 @@ template<typename T> concept C2 = requires(T x) {
 };
 \end{codeblock}
 
-The \grammarterm{compound-requirement} in \tcode{C2} 
+The \grammarterm{compound-requirement} in \tcode{C2}
 requires that \tcode{*x} is a valid expression,
 that \tcode{typename T::inner} is a valid type, and
 that \tcode{*x} is implicitly convertible to
@@ -1801,7 +1801,7 @@ template<typename T> concept C5 =
   };
 \end{codeblock}
 
-The \grammarterm{compound-requirement} in \tcode{C5} 
+The \grammarterm{compound-requirement} in \tcode{C5}
 requires that \tcode{g(x)} is a valid expression and
 that \tcode{g(x)} is non-throwing.
 \end{example}
@@ -1835,7 +1835,7 @@ template<typename T> concept D = requires (T t) {
 \end{example}
 
 \pnum
-A local parameter shall only appear as an unevaluated operand 
+A local parameter shall only appear as an unevaluated operand
 (Clause~\ref{expr}) within the \grammarterm{constraint-expression}.
 \begin{example}
 \begin{codeblock}

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -1554,7 +1554,7 @@ parameters.
 \end{itemize}
 
 \pnum
-Second, for a function to be viable, if it has associated constraints, 
+Second, for a function to be viable, if it has associated constraints,
 those constraints shall be satisfied (\ref{temp.constr.decl}).
 
 \pnum
@@ -1691,9 +1691,9 @@ according to the partial ordering rules described in~\ref{temp.func.order},
 or, if not that,
 
 \item
-\tcode{F1} and \tcode{F2} are non-template functions with the same 
-parameter-type-lists, and  \tcode{F1} is more constrained than \tcode{F2} 
-according to the partial ordering of constraints described in 
+\tcode{F1} and \tcode{F2} are non-template functions with the same
+parameter-type-lists, and  \tcode{F1} is more constrained than \tcode{F2}
+according to the partial ordering of constraints described in
 \ref{temp.constr.order}, or if not that,
 
 \item
@@ -2883,7 +2883,7 @@ described in~\ref{expr.unary.op}.
 All functions whose
 associated constraints are not satisfied~(\ref{temp.constr.decl})
 are eliminated from the set of selected functions.
-If more than one function in the set remains, 
+If more than one function in the set remains,
 all function template specializations
 in the set
 are eliminated if the set also contains a function that is not a
@@ -2892,7 +2892,7 @@ Any given non-template function
 \tcode{F0}
 is eliminated if the set contains a second
 non-template function that
-is more constrained than 
+is more constrained than
 \tcode{F0}
 according to
 the partial ordering rules of \ref{temp.constr.order}.

--- a/source/special.tex
+++ b/source/special.tex
@@ -545,11 +545,11 @@ was obtained through one of the following:
   a class member access~(\ref{expr.ref}) using the \tcode{.} operator
   where the left operand is one of these expressions and
   the right operand designates a non-static data member of non-reference type,
-\item 
+\item
   a pointer-to-member operation~(\ref{expr.mptr.oper}) using the \tcode{.*} operator
   where the left operand is one of these expressions and
   the right operand is a pointer to data member of non-reference type,
-\item 
+\item
   a \tcode{const_cast}~(\ref{expr.const.cast}),
   \tcode{static_cast}~(\ref{expr.static.cast}),
   \tcode{dynamic_cast}~(\ref{expr.dynamic.cast}), or
@@ -559,10 +559,10 @@ was obtained through one of the following:
   to a glvalue that refers
   to the object designated by the operand, or
   to its complete object or a subobject thereof,
-\item 
+\item
   a conditional expression~(\ref{expr.cond}) that is a glvalue
   where the second or third operand is one of these expressions, or
-\item 
+\item
   a comma expression~(\ref{expr.comma}) that is a glvalue
   where the right operand is one of these expressions.
 \end{itemize}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -197,7 +197,7 @@ templated entity is a templated entity.
 
 \pnum
 A \grammarterm{template-declaration} is written
-in terms of its template parameters. 
+in terms of its template parameters.
 The optional \grammarterm{requires-clause} following a
 \grammarterm{template-parameter-list} allows the specification of
 constraints~(\ref{temp.constr.decl}) on template arguments~(\ref{temp.arg}).
@@ -482,7 +482,7 @@ as follows.
 
 \begin{itemize}
 \item If \tcode{X} is a type \grammarterm{template-parameter},
-the declared parameter is a type \grammarterm{template-parameter}. 
+the declared parameter is a type \grammarterm{template-parameter}.
 
 \item If \tcode{X} is a non-type \grammarterm{template-parameter},
 the declared parameter is a non-type \grammarterm{template-parameter}
@@ -531,11 +531,11 @@ then \tcode{A} is the pack expansion \tcode{P...}.
 Otherwise,
 \tcode{A} is the \grammarterm{id-expression} \tcode{P}.
 
-% FIXME: This does not guarantee that the expression has the same 
+% FIXME: This does not guarantee that the expression has the same
 % namespace qualification as Q.
 \item Then, an \grammarterm{id-expression} \tcode{E} is formed as follows.
 If \tcode{Q} is a \grammarterm{concept-name},
-then \tcode{E} is \tcode{C<A>}. 
+then \tcode{E} is \tcode{C<A>}.
 Otherwise,
 \tcode{Q} is a \grammarterm{partial-concept-id}
 of the form \tcode{C<A$_1$, A$_2$, ..., A$_n$>},
@@ -962,7 +962,7 @@ but not a member template
 that is a member of an unknown specialization~(\ref{temp.res}),
 and
 all \grammarterm{template-argument}{s}
-in the \grammarterm{simple-template-id} 
+in the \grammarterm{simple-template-id}
 are non-dependent~(\ref{temp.dep.temp}),
 the associated constraints
 of the constrained template
@@ -1514,7 +1514,7 @@ then \tcode{P} is not at least as specialized as \tcode{A}.
 \begin{note}
 This section defines the meaning of constraints on template arguments.
 The abstract syntax and satisfaction rules are defined
-in \ref{temp.constr.constr}. 
+in \ref{temp.constr.constr}.
 Constraints are associated with declarations in \ref{temp.constr.decl}.
 Declarations are partially ordered by their associated constraints~(\ref{temp.constr.order}).
 \end{note}
@@ -1522,7 +1522,7 @@ Declarations are partially ordered by their associated constraints~(\ref{temp.co
 \rSec2[temp.constr.constr]{Constraints}
 
 \pnum
-A \defn{constraint} is a sequence of logical operations and 
+A \defn{constraint} is a sequence of logical operations and
 operands that specifies requirements on template arguments.
 The operands of a logical operation are constraints.
 There are three different kinds of constraints:
@@ -1537,7 +1537,7 @@ In order for a constrained template to be instantiated~(\ref{temp.spec}),
 its associated constraints shall be \defn{satisfied}~(\ref{temp.constr.decl}).
 \begin{note}
 Forming the name of a specialization of
-a class template, 
+a class template,
 a variable template, or
 an alias template~(\ref{temp.names})
 requires the satisfaction of its constraints.
@@ -1545,7 +1545,7 @@ Overload resolution~(\ref{over.match.viable})
 requires the satisfaction of constraints
 on functions and function templates.
 \end{note}
-The rules for determining the satisfaction of different kinds of 
+The rules for determining the satisfaction of different kinds of
 constraints are defined in the following subsections.
 
 \rSec3[temp.constr.op]{Logical operations}
@@ -1553,19 +1553,19 @@ constraints are defined in the following subsections.
 \pnum
 There are two binary logical operations on constraints: conjunction
 and disjunction.
-\begin{note} 
+\begin{note}
 These logical operations have no corresponding \Cpp syntax.
 For the purpose of exposition, conjunction is spelled
-using the symbol $\land$ and disjunction is spelled using the 
-symbol $\lor$. 
-The operands of these operations are called the left 
+using the symbol $\land$ and disjunction is spelled using the
+symbol $\lor$.
+The operands of these operations are called the left
 and right operands. In the constraint $A \land B$,
 $A$ is the left operand, and $B$ is the right operand.
 \end{note}
 
 \pnum
-A \defn{conjunction} is a constraint taking two 
-operands. 
+A \defn{conjunction} is a constraint taking two
+operands.
 To determine if a conjunction is satisfied, the satisfaction of
 the first operand is checked.
 If that is not satisfied, the conjunction is not satisfied.
@@ -1573,9 +1573,9 @@ Otherwise, the conjunction is satisfied if and only if the second
 operand is satisfied.
 
 \pnum
-A \defn{disjunction} is a constraint taking two 
-operands. 
-% 
+A \defn{disjunction} is a constraint taking two
+operands.
+%
 To determine if a disjunction is satisfied, the satisfaction of
 the first operand is checked.
 If that is satisfied, the disjunction is satisfied.
@@ -1596,8 +1596,8 @@ void f(int);
 
 f('a'); // OK: calls \tcode{f(int)}
 \end{codeblock}
-In the satisfaction of the associated constraints (\ref{temp.constr.decl}) 
-of \tcode{f}, the constraint \tcode{sizeof(char) > 1} is not satisfied; 
+In the satisfaction of the associated constraints (\ref{temp.constr.decl})
+of \tcode{f}, the constraint \tcode{sizeof(char) > 1} is not satisfied;
 the second operand is not checked for satisfaction.
 \end{example}
 
@@ -1627,7 +1627,7 @@ and the targets of the parameter mappings are equivalent
 according to the rules for expressions described in \ref{temp.over.link}.
 
 \pnum
-Determining if a constraint is satisfied entails the substitution 
+Determining if a constraint is satisfied entails the substitution
 of the parameter mapping and template arguments into that constraint.
 If substitution results in an invalid type or expression,
 the constraint is not satisfied.
@@ -1638,7 +1638,7 @@ The constraint is satisfied if and only if evaluation of \tcode{E}
 results in \tcode{true}.
 \begin{example}
 \begin{codeblock}
-template<typename T> 
+template<typename T>
   concept C = sizeof(T) == 4 && !true; // requires atomic constraints
                                        // \tcode{sizeof(T) == 4} and \tcode{!true}
 
@@ -1665,7 +1665,7 @@ void g() {
 \pnum
 A template declaration (Clause~\ref{temp})
 or function declaration~(\ref{dcl.fct})
-can be constrained by the use of a \grammarterm{requires-clause}. 
+can be constrained by the use of a \grammarterm{requires-clause}.
 This allows the specification of constraints for that declaration as
 an expression:
 
@@ -1675,10 +1675,10 @@ an expression:
 \end{bnf}
 
 \pnum
-Constraints can also be associated with a declaration through the use of 
-\grammarterm{constrained-parameter}{s} in a 
+Constraints can also be associated with a declaration through the use of
+\grammarterm{constrained-parameter}{s} in a
 \grammarterm{template-parameter-list}.
-Each of these forms introduces additional \grammarterm{constraint-expression}{s} 
+Each of these forms introduces additional \grammarterm{constraint-expression}{s}
 that are used to constrain the declaration.
 
 \pnum
@@ -1693,31 +1693,31 @@ the declaration has no associated constraints.
 the associated constraints are the normal form~(\ref{temp.constr.normal})
 of that expression.
 
-\item Otherwise, the associated constraints are the normal form of a logical 
-AND expression~(\ref{expr.log.and}) whose operands are in the 
+\item Otherwise, the associated constraints are the normal form of a logical
+AND expression~(\ref{expr.log.and}) whose operands are in the
 following order:
 
 \begin{itemize}
 \item
 the \grammarterm{constraint-expression} introduced by each
-\grammarterm{constrained-parameter}~(\ref{temp.param}) in the 
+\grammarterm{constrained-parameter}~(\ref{temp.param}) in the
 declaration's \grammarterm{template-parameter-list}, in
 order of appearance, and
 
 \item
 the \grammarterm{constraint-expression} introduced
-by a \grammarterm{requires-clause} following a 
+by a \grammarterm{requires-clause} following a
 \grammarterm{template-parameter-list} (Clause~\ref{temp}), and
 
 \item
-the \grammarterm{constraint-expression} introduced by a trailing 
-\grammarterm{requires-clause} (Clause~\ref{dcl.decl}) 
+the \grammarterm{constraint-expression} introduced by a trailing
+\grammarterm{requires-clause} (Clause~\ref{dcl.decl})
 of a function declaration~(\ref{dcl.fct}).
 \end{itemize}
 \end{itemize}
 
 The formation of the associated constraints
-establishes the order in which constraints are instantiated when checking 
+establishes the order in which constraints are instantiated when checking
 for satisfaction~(\ref{temp.constr.constr}).
 \begin{example}
 \begin{codeblock}
@@ -1744,9 +1744,9 @@ are \tcode{C1<T> $\land$ C2<T>}.
 template<C1 T> requires C2<T> void f6();
 template<C2 T> requires C1<T> void f7();
 \end{codeblock}
-The associated constraints of 
+The associated constraints of
 \tcode{f6} are \tcode{C1<T> $\land$ C2<T>},
-and those of 
+and those of
 \tcode{f7} are \tcode{C2<T> $\land$ C1<T>}.
 \end{example}
 
@@ -1758,14 +1758,14 @@ Determining a declaration's
 associated constraints~(\ref{temp.constr.constr})
 requires that their \grammarterm{constraint-expression}{s}
 are \defnx{normalized}{normalization|see{constraint, normalization}}.
-% 
-Normalization transforms a \grammarterm{constraint-expression} into a 
+%
+Normalization transforms a \grammarterm{constraint-expression} into a
 sequence of conjunctions and disjunctions (\ref{temp.constr.op})
 of atomic constraints (\ref{temp.constr.atomic}).
-% 
-The \defn{normal form} of an \grammarterm{expression} \tcode{E} is 
+%
+The \defn{normal form} of an \grammarterm{expression} \tcode{E} is
 defined as follows:
-% 
+%
 \begin{itemize}
 \item
 The normal form of an expression \tcode{( E )} is
@@ -1827,7 +1827,7 @@ template<C2 U> void f1(U);      // \#1
 template<C3 U> void f2(U);      // \#2
 template<C4 U> void f3(U);      // \#3
 \end{codeblock}
-The associated constraints of \#1 are 
+The associated constraints of \#1 are
 $\tcode{sizeof(T) == 1}$ (with mapping \tcode{T}$\mapsto$\tcode{U}) $\land \tcode{1 == 2}$,
 those of \#2 are
 $\tcode{requires \{ typename T::type; \}}$ (with mapping \tcode{T}$\mapsto$\tcode{U}),
@@ -1840,14 +1840,14 @@ $\tcode{requires (T x) \{ ++x; \}}$ (with mapping \tcode{T}$\mapsto$\tcode{U}).
 \indextext{subsume|see{constraint, subsumption}}
 
 \pnum
-A constraint $P$ is said to subsume another constraint $Q$ 
-if it can be determined that $P$ implies $Q$, up to 
+A constraint $P$ is said to subsume another constraint $Q$
+if it can be determined that $P$ implies $Q$, up to
 the identity~(\ref{temp.constr.atomic})
 of atomic constraints in $P$ and $Q$,
 as described below.
 \begin{example}
-Subsumption does not determine if the atomic constraint 
-\tcode{N >= 0} (\ref{temp.constr.atomic}) subsumes \tcode{N > 0} for some 
+Subsumption does not determine if the atomic constraint
+\tcode{N >= 0} (\ref{temp.constr.atomic}) subsumes \tcode{N > 0} for some
 integral template argument \tcode{N}.
 \end{example}
 
@@ -1856,65 +1856,65 @@ In order to determine if a constraint $P$ subsumes a constraint $Q$,
 $P$ is transformed into disjunctive normal form, and
 $Q$ is transformed into conjunctive normal form\footnote{%
 A constraint is in disjunctive normal form when it is a disjunction of
-clauses where each clause is a conjunction of atomic constraints. 
-% 
-Similarly, a constraint is in conjunctive normal form when it is a conjunction 
+clauses where each clause is a conjunction of atomic constraints.
+%
+Similarly, a constraint is in conjunctive normal form when it is a conjunction
 of clauses where each clause is a disjunction of atomic constraints.
-% 
+%
 \begin{example}
 Let $A$, $B$, and $C$ be atomic constraints, which can be grouped
 using parentheses.
-% 
-The constraint $A \land (B \lor C)$ is in 
+%
+The constraint $A \land (B \lor C)$ is in
 conjunctive normal form.
-% 
+%
 Its conjunctive clauses are $A$ and $(B \lor C)$.
-% 
+%
 The disjunctive normal form of the constraint
-$A \land (B \lor C)$ 
+$A \land (B \lor C)$
 is
 $(A \land B) \lor (A \land C)$.
-% 
-Its disjunctive clauses are $(A \land B)$ and 
+%
+Its disjunctive clauses are $(A \land B)$ and
 $(A \land C)$.
 \end{example}%
 }.
-% 
+%
 Then, $P$ \defnx{subsumes}{constraint!subsumption} $Q$ if and only if
 \begin{itemize}
-\item for every disjunctive clause $P_i$ in the disjunctive normal 
-form of $P$, $P_i$ subsumes every conjunctive clause $Q_j$ 
+\item for every disjunctive clause $P_i$ in the disjunctive normal
+form of $P$, $P_i$ subsumes every conjunctive clause $Q_j$
 in the conjuctive normal form of $Q$, where
 
 \item
-a disjunctive clause $P_i$ subsumes a conjunctive clause $Q_j$ if and only 
-if there exists an atomic constraint $P_{ia}$ in $P_i$ for which there exists 
+a disjunctive clause $P_i$ subsumes a conjunctive clause $Q_j$ if and only
+if there exists an atomic constraint $P_{ia}$ in $P_i$ for which there exists
 an atomic constraint $Q_{jb}$ in $Q_j$ such that $P_{ia}$ subsumes $Q_{jb}$.
 
 \item an atomic constraint $A$ subsumes another atomic constraint
 $B$ if and only if the $A$ and $B$ are identical using the
 rules described in \ref{temp.constr.atomic}.
 \end{itemize}
-% 
+%
 \begin{example}
 Let $A$ and $B$ be atomic constraints (\ref{temp.constr.atomic}).
-% 
+%
 The constraint $A \land B$ subsumes $A$, but $A$ does not subsume $A \land B$.
-% 
+%
 The constraint $A$ subsumes $A \lor B$, but $A \lor B$ does not subsume $A$.
-% 
+%
 Also note that every constraint subsumes itself.
 \end{example}
 
 \pnum
 \begin{note}
-The subsumption relation defines a partial ordering on constraints. 
+The subsumption relation defines a partial ordering on constraints.
 This partial ordering is used to determine
 
 \begin{itemize}
-\item the best viable candidate of non-template functions~(\ref{over.match.best}), 
-\item the address of a non-template function~(\ref{over.over}), 
-\item the matching of template template arguments~(\ref{temp.arg.template}), 
+\item the best viable candidate of non-template functions~(\ref{over.match.best}),
+\item the address of a non-template function~(\ref{over.over}),
+\item the matching of template template arguments~(\ref{temp.arg.template}),
 \item the partial ordering of class template specializations~(\ref{temp.class.order}), and
 \item the partial ordering of function templates~(\ref{temp.func.order}).
 \end{itemize}
@@ -1929,7 +1929,7 @@ partially ordered by their associated constraints~(\ref{temp.constr.decl}),
 \tcode{D1} is \defn{at least as constrained} as \tcode{D2} if
 
 \begin{itemize}
-\item \tcode{D1} and \tcode{D2} are both constrained declarations and 
+\item \tcode{D1} and \tcode{D2} are both constrained declarations and
 \tcode{D1}'s associated constraints subsume those of \tcode{D2}; or
 
 \item \tcode{D2} has no associated constraints.
@@ -2237,9 +2237,9 @@ template<typename T> struct S {
   void g() requires C<T>;
 };
 
-template<typename T> 
+template<typename T>
   void S<T>::f() requires C<T> { }  // OK
-template<typename T> 
+template<typename T>
   void S<T>::g() { }                // error: no matching function in \tcode{S<T>}
 \end{codeblock}
 \end{example}
@@ -2376,9 +2376,9 @@ template<C1 T> struct S {
   template<C2 U> void g(U);
 };
 
-template<C1 T> template<C2 U> 
+template<C1 T> template<C2 U>
 void S<T>::f(U) { }     // OK
-template<C1 T> template<typename U> 
+template<C1 T> template<typename U>
 void S<T>::g(U) { }     // error: no matching function in \tcode{S<T>}
 \end{codeblock}
 \end{example}
@@ -3014,7 +3014,7 @@ A class template partial specialization may be constrained
 \begin{codeblock}
 template<typename T> concept C = true;
 
-template<typename T> struct X { }; 
+template<typename T> struct X { };
 template<typename T> struct X<T*> { };  // \#1
 template<C T> struct X<T> { };          // \#2
 \end{codeblock}
@@ -3876,7 +3876,7 @@ template<typename T>
 concept C = requires(T x) {
   { x == x } -> bool;
 };
-template<typename T> 
+template<typename T>
   requires C<T> // \tcode{C} constrains \tcode{f1(T)} in \grammarterm{constraint-expression}
 T f1(T x) { return x; }
 template<C T>   // \tcode{C} constrains \tcode{f2(T)} as a \grammarterm{constrained-parameter}
@@ -3892,11 +3892,11 @@ shall appear at namespace scope~(\ref{basic.scope.namespace}).
 A concept shall not have associated constraints~(\ref{temp.constr.decl}).
 
 \pnum
-A concept is not instantiated~(\ref{temp.spec}). 
+A concept is not instantiated~(\ref{temp.spec}).
 A program that
 explicitly instantiates~(\ref{temp.explicit}),
 explicitly specializes~(\ref{temp.expl.spec}),
-or partially specializes a concept is ill-formed. 
+or partially specializes a concept is ill-formed.
 \begin{note}
 An \grammarterm{id-expression} that denotes a concept specialization
 is evaluated as an expression~(\ref{expr.prim.id}).
@@ -5842,21 +5842,21 @@ for \tcode{s1}.
 \begin{example}
 \begin{codeblock}
 template<typename T> struct S1 {
-  template<typename U> 
-    requires false 
+  template<typename U>
+    requires false
   struct Inner1;    // ill-formed, no diagnostic required
 };
 
 template<typename T> struct S2 {
-  template<typename U> 
+  template<typename U>
     requires (sizeof(T[-(int)sizeof(T)]) > 1)
   struct Inner2;    // ill-formed, no diagnostic required
 };
 \end{codeblock}
 The class \tcode{S1<T>::Inner1} is ill-formed, no diagnostic required, because
 it has no valid specializations.
-\tcode{S2} is ill-formed, no diagnostic required, since no substitution into 
-the constraints of its \tcode{Inner2} template would result in a valid 
+\tcode{S2} is ill-formed, no diagnostic required, since no substitution into
+the constraints of its \tcode{Inner2} template would result in a valid
 expression.
 \end{example}
 
@@ -6055,8 +6055,8 @@ instantiation of the same kind (declaration or definition) of each
 of its members (not including members inherited from base classes and members
 that are templates) that has not been previously explicitly specialized in
 the translation unit containing the explicit instantiation,
-provided that the associated constraints, if any, 
-of that member are satisfied by the template arguments of the explicit 
+provided that the associated constraints, if any,
+of that member are satisfied by the template arguments of the explicit
 instantiation~(\ref{temp.constr.decl}),
 except as described below.
 \begin{note} In addition, it will typically be an explicit instantiation of certain
@@ -6416,7 +6416,7 @@ template<> void sort(Array<int>&);
 \begin{note}
 An explicit specialization of a constrained template
 shall satisfy that template's associated constraints~(\ref{temp.constr.decl}).
-The satisfaction of constraints is determined 
+The satisfaction of constraints is determined
 when forming the template name of an explicit specialization
 in which all template arguments are specified~(\ref{temp.names}),
 or, for explicit specializations of function templates,


### PR DESCRIPTION
No visual difference.

Makes the check-whitespace CI check pass again.