### PR TITLE
[std] Allow linebreaks before \ref in select places

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1091,7 +1091,7 @@ If a name is in scope and is not hidden it is said to be \defn{visible}.%
 \pnum
 The name lookup rules apply uniformly to all names (including
 \grammarterm{typedef-name}{s}~(\ref{dcl.typedef}),
-\grammarterm{namespace-name}{s}~(\ref{basic.namespace}), and
+\grammarterm{namespace-name}{s} (\ref{basic.namespace}), and
 \grammarterm{class-name}{s}~(\ref{class.name})) wherever the grammar allows
 such names in the context discussed by a particular rule. Name lookup
 associates the use of a name with a set of declarations~(\ref{basic.def}) of
@@ -2508,7 +2508,7 @@ namespaces. \end{example}
 \indextext{termination!program}%
 Terminating the program
 without leaving the current block (e.g., by calling the function
-\tcode{std::exit(int)}~(\ref{support.start.term})) does not destroy any
+\tcode{std::exit(int)} (\ref{support.start.term})) does not destroy any
 objects with automatic storage duration~(\ref{class.dtor}). If
 \tcode{std::exit} is called to end a program during the destruction of
 an object with static or thread storage duration, the program has undefined

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1942,7 +1942,7 @@ defined in any of
 \tcode{<clocale>}~(\ref{c.locales})\indexlibrary{\idxhdr{clocale}},
 \tcode{<cstddef>}~(\ref{cstddef.syn})\indexlibrary{\idxhdr{cstddef}},
 \tcode{<cstdio>}~(\ref{cstdio.syn})\indexlibrary{\idxhdr{cstdio}},
-\tcode{<cstdlib>}~(\ref{cstdlib.syn})\indexlibrary{\idxhdr{cstdlib}},
+\tcode{<cstdlib>} (\ref{cstdlib.syn})\indexlibrary{\idxhdr{cstdlib}},
 \tcode{<cstring>}~(\ref{cstring.syn})\indexlibrary{\idxhdr{cstring}},
 \tcode{<ctime>}~(\ref{ctime.syn})\indexlibrary{\idxhdr{ctime}},
 or \tcode{<cwchar>}~(\ref{cwchar.syn})\indexlibrary{\idxhdr{cwchar}},

--- a/source/conversions.tex
+++ b/source/conversions.tex
@@ -327,7 +327,7 @@ of \tcode{X} of type \cvqual{cv2} \tcode{T}'' if ``\cvqual{cv2}
 \pnum
 \begin{note}
 Function types (including those used in pointer to member function
-types) are never cv-qualified~(\ref{dcl.fct}).
+types) are never cv-qualified (\ref{dcl.fct}).
 \end{note}
 \indextext{conversion!qualification|)}
 

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -235,7 +235,7 @@ constructor, destructor, or conversion function.\footnote{The
 \begin{note}
 A \grammarterm{nodeclspec-function-declaration} can only be used in a
 \grammarterm{template-declaration}~(Clause~\ref{temp}),
-\grammarterm{explicit-instantiation}~(\ref{temp.explicit}), or
+\grammarterm{explicit-instantiation} (\ref{temp.explicit}), or
 \grammarterm{explicit-specialization}~(\ref{temp.expl.spec}).
 \end{note}
 

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -1982,7 +1982,7 @@ and
 if
 \tcode{rdbuf() != 0}
 then
-\tcode{rdbuf()->pubimbue(loc)}~(\ref{streambuf.locales}).
+\tcode{rdbuf()->pubimbue(loc)} (\ref{streambuf.locales}).
 
 \pnum
 \returns
@@ -3199,7 +3199,7 @@ streamsize in_avail();
 If a read position is available, returns
 \tcode{egptr() - gptr()}.
 Otherwise returns
-\tcode{showmanyc()}~(\ref{streambuf.virt.get}).
+\tcode{showmanyc()} (\ref{streambuf.virt.get}).
 \end{itemdescr}
 
 \indexlibrarymember{snextc}{basic_streambuf}%
@@ -9378,7 +9378,7 @@ calls \tcode{clear()},
 otherwise calls
 \tcode{setstate(failbit)}
 (which may throw
-\tcode{ios_base::failure})~(\ref{iostate.flags}).
+\tcode{ios_base::failure}) (\ref{iostate.flags}).
 \end{itemdescr}
 
 \indexlibrarymember{open}{basic_ifstream}%
@@ -9626,7 +9626,7 @@ calls \tcode{clear()},
 otherwise calls
 \tcode{setstate(\brk{}failbit)}
 (which may throw
-\tcode{ios_base::failure})~(\ref{iostate.flags}).
+\tcode{ios_base::failure}) (\ref{iostate.flags}).
 \end{itemdescr}
 
 \indexlibrarymember{close}{basic_ofstream}%
@@ -11464,7 +11464,7 @@ The encoding of the string returned by \tcode{u8string()} is always UTF-8.
 
 \pnum
 Generic format observer functions return strings formatted according to the
-generic pathname format~(\ref{fs.path.generic}).
+generic pathname format (\ref{fs.path.generic}).
 A single slash (\tcode{'/'}) character is used as
 the \grammarterm{directory-separator}.
 

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -875,7 +875,7 @@ is the imaginary part~(\ref{istream.formatted}).
 If bad input is encountered, calls
 \tcode{is.setstate(ios_base::failbit)}
 (which may throw
-\tcode{ios::failure}~(\ref{iostate.flags})).
+\tcode{ios::failure} (\ref{iostate.flags})).
 
 \pnum
 \returns

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -2102,7 +2102,7 @@ the call to \tcode{try_lock()}.
 \pnum
 \throws
 Any exception thrown by \tcode{pm->try_lock()}. \tcode{system_error} when an exception
-is required~(\ref{thread.req.exception}).
+is required (\ref{thread.req.exception}).
 
 \pnum
 \errors

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -7661,7 +7661,7 @@ using void_pointer = @\seebelow@;
 \pnum
 \ctype \tcode{Alloc::void_pointer} if
 the \grammarterm{qualified-id} \tcode{Alloc::void_pointer} is valid and denotes a
-type~(\ref{temp.deduct}); otherwise,
+type (\ref{temp.deduct}); otherwise,
 \tcode{pointer_traits<pointer>::rebind<\brk{}void>}.
 \end{itemdescr}
 


### PR DESCRIPTION
Avoids 'Overfull \hbox' warnings.

Partially reverts commit bf363db2cd687cac2efb5d4ed161cf0583b93f19.