### PR TITLE
[everywhere] Rework how we mark up inline references.

### DIFF
--- a/source/access.tex
+++ b/source/access.tex
@@ -69,8 +69,8 @@ referred to from declarations or expressions.
 \begin{note}
 Access control applies to names nominated by
 \tcode{friend}
-declarations~(\ref{class.friend}) and
-\grammarterm{using-declaration}{s}~(\ref{namespace.udecl}).
+declarations\iref{class.friend} and
+\grammarterm{using-declaration}{s}\iref{namespace.udecl}.
 \end{note}
 In the case of overloaded function names, access control is applied to
 the function selected by overload resolution.
@@ -109,7 +109,7 @@ established makes use of inaccessible member names or base classes,
 the construct is ill-formed.
 
 \pnum
-All access controls in Clause~\ref{class.access} affect the ability to access a class member
+All access controls in \ref{class.access} affect the ability to access a class member
 name from the declaration of a particular
 entity, including parts of the declaration preceding the name of the entity
 being declared and, if the entity is a class, the definitions of members of
@@ -167,14 +167,14 @@ must be deferred until the entire \grammarterm{base-specifier-list} has been see
 \pnum
 \indextext{argument!access checking and default}%
 \indextext{access control!default argument}%
-The names in a default argument~(\ref{dcl.fct.default}) are
+The names in a default argument\iref{dcl.fct.default} are
 bound at the point of declaration, and access is checked at that
 point rather than at any points of use of the default argument.
 Access checking for default arguments in function templates and in
 member functions of class templates is performed as described in~\ref{temp.inst}.
 
 \pnum
-The names in a default \grammarterm{template-argument}~(\ref{temp.param})
+The names in a default \grammarterm{template-argument}\iref{temp.param}
 have their access checked in the context in which they appear rather than at any
 points of use of the default \grammarterm{template-argument}. \begin{example}
 \begin{codeblock}
@@ -197,7 +197,7 @@ D <C<B> >* d;       // access error, \tcode{C::TT} is protected
 \pnum
 Member declarations can be labeled by an
 \grammarterm{access-specifier}
-(Clause~\ref{class.derived}):
+(\ref{class.derived}):
 
 \begin{ncbnftab}
 access-specifier \terminal{:} member-specification\opt
@@ -286,7 +286,7 @@ class C : public B {
 \indextext{base class!\idxcode{public}}
 
 \pnum
-If a class is declared to be a base class (Clause~\ref{class.derived}) for another class using the
+If a class is declared to be a base class\iref{class.derived} for another class using the
 \tcode{public}
 access specifier, the
 \tcode{public}
@@ -314,7 +314,7 @@ and
 \tcode{protected}
 members of the base class are accessible as
 \tcode{private}
-members of the derived class\footnote{As specified previously in Clause~\ref{class.access},
+members of the derived class\footnote{As specified previously in \ref{class.access},
 private members of a base class remain inaccessible even to derived classes
 unless
 \tcode{friend}
@@ -369,7 +369,7 @@ and
 \begin{note}
 A member of a private base class might be inaccessible as an inherited
 member name, but accessible directly.
-Because of the rules on pointer conversions~(\ref{conv.ptr}) and explicit casts~(\ref{expr.cast}), a conversion from a pointer to a derived class to a pointer
+Because of the rules on pointer conversions\iref{conv.ptr} and explicit casts\iref{expr.cast}, a conversion from a pointer to a derived class to a pointer
 to an inaccessible base class might be ill-formed if an implicit conversion
 is used, but well-formed if an explicit cast is used.
 For example,
@@ -491,7 +491,7 @@ up and found.
 \begin{note}
 This class can be explicit, e.g., when a
 \grammarterm{qualified-id}
-is used, or implicit, e.g., when a class member access operator~(\ref{expr.ref}) is used (including cases where an implicit
+is used, or implicit, e.g., when a class member access operator\iref{expr.ref} is used (including cases where an implicit
 ``\tcode{this->}''
 is
 added).
@@ -684,7 +684,7 @@ shall have one of the following forms:
 
 \begin{note} A \tcode{friend} declaration may be the
 \term{declaration} in a \grammarterm{template-declaration}
-(Clause~\ref{temp}, \ref{temp.friend}).\end{note} If the
+(\ref{temp}, \ref{temp.friend}).\end{note} If the
 type specifier in a \tcode{friend} declaration designates a (possibly
 cv-qualified) class type, that class is declared as a friend; otherwise, the
 \tcode{friend} declaration is ignored. \begin{example}
@@ -715,8 +715,8 @@ R<int> Ri;                      // OK: \tcode{"friend int;"} is ignored
 \pnum
 \indextext{friend function!linkage of}%
 A function first declared in a friend declaration
-has the linkage of the namespace of which it is a member~(\ref{basic.link}).
-Otherwise, the function retains its previous linkage~(\ref{dcl.stc}).
+has the linkage of the namespace of which it is a member\iref{basic.link}.
+Otherwise, the function retains its previous linkage\iref{dcl.stc}.
 
 \pnum
 \indextext{declaration!overloaded name and \tcode{friend}}%
@@ -744,7 +744,7 @@ class Y {
 \pnum
 \indextext{friend function!inline}%
 A function can be defined in a friend declaration of a class if and only if the
-class is a non-local class~(\ref{class.local}), the function name is unqualified,
+class is a non-local class\iref{class.local}, the function name is unqualified,
 and the function has namespace scope.
 \begin{example}
 
@@ -757,11 +757,11 @@ class M {
 \end{example}
 
 \pnum
-Such a function is implicitly an inline function~(\ref{dcl.inline}).
+Such a function is implicitly an inline function\iref{dcl.inline}.
 A
 \tcode{friend}
 function defined in a class is in the (lexical) scope of the class in which it is defined.
-A friend function defined outside the class is not~(\ref{basic.lookup.unqual}).
+A friend function defined outside the class is not\iref{basic.lookup.unqual}.
 
 \pnum
 No
@@ -779,7 +779,7 @@ appears in the
 \tcode{private},
 \tcode{protected}
 or
-\tcode{public}~(\ref{class.mem})
+\tcode{public}\iref{class.mem}
 portion of the class
 \grammarterm{member-specification}.
 
@@ -815,7 +815,7 @@ class D : public B  {
 \pnum
 \indextext{local class!friend}%
 \indextext{friend!local class and}%
-If a friend declaration appears in a local class~(\ref{class.local}) and the
+If a friend declaration appears in a local class\iref{class.local} and the
 name specified is an unqualified name, a prior declaration is looked
 up without considering scopes that are outside the innermost enclosing
 non-class scope.
@@ -853,17 +853,17 @@ void f() {
 \indextext{access control!\idxcode{protected}}%
 
 \pnum
-An additional access check beyond those described earlier in Clause~\ref{class.access}
+An additional access check beyond those described earlier in \ref{class.access}
 is applied when a non-static data member or non-static member function is a
-protected member of its naming class~(\ref{class.access.base}).\footnote{This
+protected member of its naming class\iref{class.access.base}.\footnote{This
 additional check does not apply to other members,
 e.g., static data members or enumerator member constants.}
 As described earlier, access to a protected member is granted because the
 reference occurs in a friend or member of some class \tcode{C}. If the access is
-to form a pointer to member~(\ref{expr.unary.op}), the
+to form a pointer to member\iref{expr.unary.op}, the
 \grammarterm{nested-name-specifier} shall denote \tcode{C} or a class derived from
 \tcode{C}. All other accesses involve a (possibly implicit) object
-expression~(\ref{expr.ref}). In this case, the class of the object expression shall be
+expression\iref{expr.ref}. In this case, the class of the object expression shall be
 \tcode{C} or a class derived from \tcode{C}.
 \begin{example}
 
@@ -916,7 +916,7 @@ void g(B* pb, D1* p1, D2* p2) {
 \indextext{access control!virtual function}
 
 \pnum
-The access rules (Clause~\ref{class.access}) for a virtual function are determined by its declaration
+The access rules\iref{class.access} for a virtual function are determined by its declaration
 and are not affected by the rules for a function that later overrides it.
 \begin{example}
 
@@ -984,7 +984,7 @@ access is allowed.
 \pnum
 A nested class is a member and as such has the same access rights as any other member.
 The members of an enclosing class have no special access to members of a nested
-class; the usual access rules (Clause~\ref{class.access}) shall be obeyed.
+class; the usual access rules\iref{class.access} shall be obeyed.
 \begin{example}
 \indextext{example!nested class definition}%
 

--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -5,7 +5,7 @@
 
 \pnum
 This Clause describes components that \Cpp programs may use to perform
-algorithmic operations on containers (Clause~\ref{containers}) and other sequences.
+algorithmic operations on containers\iref{containers} and other sequences.
 
 \pnum
 The following subclauses describe components for
@@ -1074,7 +1074,7 @@ If an algorithm's template parameter is named
 or
 \tcode{Input\-Iterator2},
 the template argument shall satisfy the
-requirements of an input iterator~(\ref{input.iterators}).
+requirements of an input iterator\iref{input.iterators}.
 \item
 If an algorithm's template parameter is named
 \tcode{OutputIterator},
@@ -1082,7 +1082,7 @@ If an algorithm's template parameter is named
 or
 \tcode{Output\-Iterator2},
 the template argument shall satisfy the requirements
-of an output iterator~(\ref{output.iterators}).
+of an output iterator\iref{output.iterators}.
 \item
 If an algorithm's template parameter is named
 \tcode{ForwardIterator},
@@ -1090,7 +1090,7 @@ If an algorithm's template parameter is named
 or
 \tcode{Forward\-Iterator2},
 the template argument shall satisfy the requirements
-of a forward iterator~(\ref{forward.iterators}).
+of a forward iterator\iref{forward.iterators}.
 \item
 If an algorithm's template parameter is named
 \tcode{BidirectionalIterator},
@@ -1098,7 +1098,7 @@ If an algorithm's template parameter is named
 or
 \tcode{BidirectionalIterator2},
 the template argument shall satisfy the requirements
-of a bidirectional iterator~(\ref{bidirectional.iterators}).
+of a bidirectional iterator\iref{bidirectional.iterators}.
 \item
 If an algorithm's template parameter is named
 \tcode{RandomAccessIterator},
@@ -1106,7 +1106,7 @@ If an algorithm's template parameter is named
 or
 \tcode{RandomAccessIterator2},
 the template argument shall satisfy the requirements
-of a random-access iterator~(\ref{random.access.iterators}).
+of a random-access iterator\iref{random.access.iterators}.
 \end{itemize}
 
 \pnum
@@ -1116,7 +1116,7 @@ section says that a value pointed to by any iterator passed
 as an argument is modified, then that algorithm has an additional
 type requirement:
 The type of that argument shall satisfy the requirements
-of a mutable iterator~(\ref{iterator.requirements}).
+of a mutable iterator\iref{iterator.requirements}.
 \begin{note}
 This requirement does not affect arguments that are named
 \tcode{OutputIterator},
@@ -1140,7 +1140,7 @@ suffix \tcode{_if} (which follows the suffix \tcode{_copy}).
 \pnum
 The
 \tcode{Predicate}
-parameter is used whenever an algorithm expects a function object~(\ref{function.objects})
+parameter is used whenever an algorithm expects a function object\iref{function.objects}
 that, when applied to the result
 of dereferencing the corresponding iterator, returns a value testable as
 \tcode{true}.
@@ -1150,7 +1150,7 @@ takes
 as its argument and \tcode{first}
 as its iterator argument, it should work correctly in the
 construct
-\tcode{pred(*first)} contextually converted to \tcode{bool} (Clause~\ref{conv}).
+\tcode{pred(*first)} contextually converted to \tcode{bool}\iref{conv}.
 The function object
 \tcode{pred}
 shall not apply any non-constant
@@ -1172,7 +1172,7 @@ In other words, if an algorithm takes
 as its argument and \tcode{first1} and \tcode{first2} as
 its iterator arguments, it should work correctly in
 the construct
-\tcode{binary_pred(*first1, *first2)} contextually converted to \tcode{bool} (Clause~\ref{conv}).
+\tcode{binary_pred(*first1, *first2)} contextually converted to \tcode{bool}\iref{conv}.
 \tcode{BinaryPredicate}
 always takes the first
 iterator's \tcode{value_type}
@@ -1180,7 +1180,7 @@ as its first argument, that is, in those cases when
 \tcode{T value}
 is part of the signature, it should work
 correctly in the
-construct \tcode{binary_pred(*first1, value)} contextually converted to \tcode{bool} (Clause~\ref{conv}).
+construct \tcode{binary_pred(*first1, value)} contextually converted to \tcode{bool}\iref{conv}.
 \tcode{binary_pred} shall not
 apply any non-constant function through the dereferenced iterators.
 
@@ -1189,7 +1189,7 @@ apply any non-constant function through the dereferenced iterators.
 Unless otherwise specified, algorithms that take function objects as arguments
 are permitted to copy those function objects freely. Programmers for whom object
 identity is important should consider using a wrapper class that points to a
-noncopied implementation object such as \tcode{reference_wrapper<T>}~(\ref{refwrap}), or some equivalent solution.
+noncopied implementation object such as \tcode{reference_wrapper<T>}\iref{refwrap}, or some equivalent solution.
 \end{note}
 
 \pnum
@@ -1290,7 +1290,7 @@ identity of the provided objects..
 
 \pnum
 Parallel algorithms have template parameters
-named \tcode{ExecutionPolicy}~(\ref{execpol})
+named \tcode{ExecutionPolicy}\iref{execpol}
 which describe the manner in which the execution of these algorithms may be
 parallelized and the manner in which they apply the element access functions.
 
@@ -1316,7 +1316,7 @@ This implies that user-supplied function objects should not rely on object
 identity of arguments for such input sequences. Users for whom the object
 identity of the arguments to these function objects is important should
 consider using a wrapping iterator that returns a non-copied implementation
-object such as \tcode{reference_wrapper<T>}~(\ref{refwrap}) or some equivalent
+object such as \tcode{reference_wrapper<T>}\iref{refwrap} or some equivalent
 solution.
 \end{note}
 
@@ -1334,8 +1334,8 @@ an execution policy object of type \tcode{execution::parallel_policy} are
 permitted to execute in either the invoking thread of execution or in a
 thread of execution implicitly
 created by the library to support parallel algorithm execution.
-If the threads of execution created by \tcode{thread}~(\ref{thread.thread.class}) provide concurrent
-forward progress guarantees~(\ref{intro.progress}), then a thread of execution
+If the threads of execution created by \tcode{thread}\iref{thread.thread.class} provide concurrent
+forward progress guarantees\iref{intro.progress}, then a thread of execution
 implicitly created by the library will provide parallel forward progress guarantees;
 otherwise, the provided forward progress guarantee is
 \impldef{forward progress guarantees for implicit threads of parallel algorithms (if not defined for \tcode{thread})}.
@@ -1440,7 +1440,7 @@ If an invocation of a parallel algorithm uses threads of execution implicitly
 created by the library, then the invoking thread of execution will either
 
 \begin{itemize}
-\item temporarily block with forward progress guarantee delegation~(\ref{intro.progress})
+\item temporarily block with forward progress guarantee delegation\iref{intro.progress}
       on the completion of these library-managed threads of execution, or
 \item eventually execute an element access function;
 \end{itemize}
@@ -2112,7 +2112,7 @@ if
 \tcode{InputIterator1}
 and
 \tcode{InputIterator2}
-meet the requirements of random access iterators~(\ref{random.access.iterators})
+meet the requirements of random access iterators\iref{random.access.iterators}
 and
 \tcode{last1 - first1 != last2 - first2},
 then
@@ -2431,7 +2431,7 @@ for which \tcode{pred(*i)} is \tcode{true}.
 \complexity Exactly \tcode{last - first} applications of the corresponding predicate.
 
 \pnum
-\remarks Stable~(\ref{algorithm.stable}).
+\remarks Stable\iref{algorithm.stable}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{copy_backward}}%
@@ -2606,7 +2606,7 @@ The two ranges \range{first1}{last1}
 and
 \range{first2}{first2 + (last1 - first1)}
 shall not overlap.
-\tcode{*(first1 + n)} shall be swappable with~(\ref{swappable.requirements})
+\tcode{*(first1 + n)} shall be swappable with\iref{swappable.requirements}
 \tcode{*(first2 + n)}.
 
 \pnum
@@ -2637,7 +2637,7 @@ template<class ForwardIterator1, class ForwardIterator2>
 \pnum
 \requires
 \tcode{a} and \tcode{b} shall be dereferenceable. \tcode{*a} shall be
-swappable with~(\ref{swappable.requirements}) \tcode{*b}.
+swappable with\iref{swappable.requirements} \tcode{*b}.
 
 \pnum
 \effects
@@ -2800,7 +2800,7 @@ The results of the expressions
 \tcode{*first}
 and
 \tcode{new_value}
-shall be writable~(\ref{iterator.requirements.general}) to the
+shall be writable\iref{iterator.requirements.general} to the
 \tcode{result}
 output iterator.
 The ranges
@@ -2862,7 +2862,7 @@ template<class ExecutionPolicy, class ForwardIterator, class Size, class T>
 \requires
 The expression
 \tcode{value}
-shall be writable~(\ref{iterator.requirements.general}) to the output iterator. The type
+shall be writable\iref{iterator.requirements.general} to the output iterator. The type
 \tcode{Size}
 shall be convertible to an integral type~(\ref{conv.integral}, \ref{class.conv}).
 
@@ -2975,7 +2975,7 @@ for which the following corresponding conditions hold:
 The end of the resulting range.
 
 \pnum
-\remarks Stable~(\ref{algorithm.stable}).
+\remarks Stable\iref{algorithm.stable}.
 
 \pnum
 \complexity
@@ -3050,7 +3050,7 @@ Exactly
 applications of the corresponding predicate.
 
 \pnum
-\remarks Stable~(\ref{algorithm.stable}).
+\remarks Stable\iref{algorithm.stable}.
 \end{itemdescr}
 
 \rSec2[alg.unique]{Unique}
@@ -3201,7 +3201,7 @@ template<class ExecutionPolicy, class BidirectionalIterator>
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{*first} shall be swappable~(\ref{swappable.requirements}).
+\tcode{*first} shall be swappable\iref{swappable.requirements}.
 
 \pnum
 \effects
@@ -3215,7 +3215,7 @@ to all pairs of iterators
 \pnum
 \requires
 \tcode{BidirectionalIterator} shall satisfy the requirements of
-\tcode{ValueSwappable}~(\ref{swappable.requirements}).
+\tcode{ValueSwappable}\iref{swappable.requirements}.
 
 \pnum
 \complexity
@@ -3290,7 +3290,7 @@ and
 \range{middle}{last}
 shall be valid ranges.
 \tcode{ForwardIterator} shall satisfy the requirements of
-\tcode{ValueSwappable}~(\ref{swappable.requirements}). The type of \tcode{*first} shall satisfy
+\tcode{ValueSwappable}\iref{swappable.requirements}. The type of \tcode{*first} shall satisfy
 the requirements of \tcode{MoveConstructible}
 (Table~\ref{tab:moveconstructible}) and the
 requirements of
@@ -3381,19 +3381,19 @@ template<class PopulationIterator, class SampleIterator,
 \requires
 \begin{itemize}
 \item
-\tcode{PopulationIterator} shall satisfy the requirements of an input iterator~(\ref{input.iterators}).
+\tcode{PopulationIterator} shall satisfy the requirements of an input iterator\iref{input.iterators}.
 \item
-\tcode{SampleIterator} shall satisfy the requirements of an output iterator~(\ref{output.iterators}).
+\tcode{SampleIterator} shall satisfy the requirements of an output iterator\iref{output.iterators}.
 \item
-\tcode{SampleIterator} shall satisfy the additional requirements of a random access iterator~(\ref{random.access.iterators})
-unless \tcode{PopulationIterator} satisfies the additional requirements of a forward iterator~(\ref{forward.iterators}).
+\tcode{SampleIterator} shall satisfy the additional requirements of a random access iterator\iref{random.access.iterators}
+unless \tcode{PopulationIterator} satisfies the additional requirements of a forward iterator\iref{forward.iterators}.
 \item
-\tcode{PopulationIterator}'s value type shall be writable~(\ref{iterator.requirements.general}) to \tcode{out}.
+\tcode{PopulationIterator}'s value type shall be writable\iref{iterator.requirements.general} to \tcode{out}.
 \item
 \tcode{Distance} shall be an integer type.
 \item
 \tcode{remove_reference_t<UniformRandomBitGenerator>}
-shall meet the requirements of a uniform random bit generator type~(\ref{rand.req.urng})
+shall meet the requirements of a uniform random bit generator type\iref{rand.req.urng}
 whose return type is convertible to \tcode{Distance}.
 \item
 \tcode{out} shall not be in the range \range{first}{last}.
@@ -3444,11 +3444,11 @@ template<class RandomAccessIterator, class UniformRandomBitGenerator>
 \pnum
 \requires
 \tcode{RandomAccessIterator} shall satisfy the requirements of
-\tcode{ValueSwappable}~(\ref{swappable.requirements}).
+\tcode{ValueSwappable}\iref{swappable.requirements}.
 The type
 \tcode{remove_reference_t<UniformRandomBitGenerator>}
 shall meet the requirements of a
-uniform random bit generator~(\ref{rand.req.urng}) type whose return type is
+uniform random bit generator\iref{rand.req.urng} type whose return type is
 convertible to
 \tcode{iterator_traits<Random\-Access\-Itera\-tor>::difference_type}.
 
@@ -3483,9 +3483,9 @@ and one that uses an
 \pnum
 \tcode{Compare}
 is a function object
-type~(\ref{function.objects}). The return value of the function call operation applied to
+type\iref{function.objects}. The return value of the function call operation applied to
 an object of type \tcode{Compare}, when contextually converted to
-\tcode{bool} (Clause~\ref{conv}),
+\tcode{bool}\iref{conv},
 yields \tcode{true} if the first argument of the call
 is less than the second, and
 \tcode{false}
@@ -3620,7 +3620,7 @@ template<class ExecutionPolicy, class RandomAccessIterator, class Compare>
 \pnum
 \requires
 \tcode{RandomAccessIterator} shall satisfy the requirements of
-\tcode{ValueSwappable}~(\ref{swappable.requirements}). The type
+\tcode{ValueSwappable}\iref{swappable.requirements}. The type
 of \tcode{*first} shall satisfy the requirements of
 \tcode{MoveConstructible} (Table~\ref{tab:moveconstructible}) and of
 \tcode{MoveAssignable} (Table~\ref{tab:moveassignable}).
@@ -3658,7 +3658,7 @@ template<class ExecutionPolicy, class RandomAccessIterator, class Compare>
 \pnum
 \requires
 \tcode{RandomAccessIterator} shall satisfy the requirements of
-\tcode{ValueSwappable}~(\ref{swappable.requirements}). The type
+\tcode{ValueSwappable}\iref{swappable.requirements}. The type
 of \tcode{*first} shall satisfy the requirements of
 \tcode{MoveConstructible} (Table~\ref{tab:moveconstructible}) and of
 \tcode{MoveAssignable} (Table~\ref{tab:moveassignable}).
@@ -3674,7 +3674,7 @@ comparisons, where
 $N = \tcode{last - first}$, but only $N \log N$ comparisons if there is enough extra memory.
 
 \pnum
-\remarks Stable~(\ref{algorithm.stable}).
+\remarks Stable\iref{algorithm.stable}.
 \end{itemdescr}
 
 \rSec3[partial.sort]{\tcode{partial_sort}}
@@ -3709,7 +3709,7 @@ template<class ExecutionPolicy, class RandomAccessIterator, class Compare>
 \pnum
 \requires
 \tcode{RandomAccessIterator} shall satisfy the requirements of
-\tcode{ValueSwappable}~(\ref{swappable.requirements}). The type
+\tcode{ValueSwappable}\iref{swappable.requirements}. The type
 of \tcode{*first} shall satisfy the requirements of
 \tcode{MoveConstructible} (Table~\ref{tab:moveconstructible}) and of
 \tcode{MoveAssignable} (Table~\ref{tab:moveassignable}).
@@ -3771,7 +3771,7 @@ template<class ExecutionPolicy, class ForwardIterator, class RandomAccessIterato
 \pnum
 \requires
 \tcode{RandomAccessIterator} shall satisfy the requirements of
-\tcode{ValueSwappable}~(\ref{swappable.requirements}). The type
+\tcode{ValueSwappable}\iref{swappable.requirements}. The type
 of \tcode{*result_first} shall satisfy the requirements of
 \tcode{MoveConstructible} (Table~\ref{tab:moveconstructible}) and of
 \tcode{Move\-Assignable} (Table~\ref{tab:moveassignable}).
@@ -3906,7 +3906,7 @@ template<class ExecutionPolicy, class RandomAccessIterator, class Compare>
 \pnum
 \requires
 \tcode{RandomAccessIterator} shall satisfy the requirements of
-\tcode{ValueSwappable}~(\ref{swappable.requirements}). The type
+\tcode{ValueSwappable}\iref{swappable.requirements}. The type
 of \tcode{*first} shall satisfy the requirements of
 \tcode{MoveConstructible} (Table~\ref{tab:moveconstructible}) and of
 \tcode{MoveAssignable} (Table~\ref{tab:moveassignable}).
@@ -4214,7 +4214,7 @@ template<class ExecutionPolicy, class ForwardIterator, class Predicate>
 \pnum
 \requires
 \tcode{ForwardIterator} shall satisfy the requirements of
-\tcode{ValueSwappable}~(\ref{swappable.requirements}).
+\tcode{ValueSwappable}\iref{swappable.requirements}.
 
 \pnum
 \effects Places all the elements in the range \range{first}{last} that satisfy \tcode{pred} before all the elements that do not satisfy it.
@@ -4253,7 +4253,7 @@ template<class ExecutionPolicy, class BidirectionalIterator, class Predicate>
 \pnum
 \requires
 \tcode{BidirectionalIterator} shall satisfy the requirements of
-\tcode{ValueSwappable}~(\ref{swappable.requirements}). The type
+\tcode{ValueSwappable}\iref{swappable.requirements}. The type
 of \tcode{*first} shall satisfy the requirements of
 \tcode{MoveConstructible} (Table~\ref{tab:moveconstructible}) and of
 \tcode{MoveAssignable} (Table~\ref{tab:moveassignable}).
@@ -4319,7 +4319,7 @@ template <class ExecutionPolicy, class ForwardIterator, class ForwardIterator1,
 \item
 For the overload with no \tcode{ExecutionPolicy}, \tcode{InputIterator}'s
 value type shall be \tcode{CopyAssignable} (Table~\ref{tab:copyassignable}),
-and shall be writable~(\ref{iterator.requirements.general}) to the \tcode{out_true}
+and shall be writable\iref{iterator.requirements.general} to the \tcode{out_true}
 and \tcode{out_false} \tcode{OutputIterator}s, and shall be convertible to
 \tcode{Predicate}'s argument type.
 
@@ -4424,7 +4424,7 @@ is \tcode{result + (last1 - first1) + (last2 - first2)}, such that the resulting
 \end{itemize}
 
 \pnum
-\remarks Stable~(\ref{algorithm.stable}).
+\remarks Stable\iref{algorithm.stable}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{inplace_merge}}%
@@ -4456,7 +4456,7 @@ template<class ExecutionPolicy, class BidirectionalIterator, class Compare>
 The ranges \range{first}{middle} and \range{middle}{last} shall be
 sorted with respect to \tcode{operator<} or \tcode{comp}.
 \tcode{BidirectionalIterator} shall satisfy the requirements of
-\tcode{ValueSwappable}~(\ref{swappable.requirements}). The type
+\tcode{ValueSwappable}\iref{swappable.requirements}. The type
 of \tcode{*first} shall satisfy the requirements of
 \tcode{MoveConstructible} (Table~\ref{tab:moveconstructible}) and of
 \tcode{MoveAssignable} (Table~\ref{tab:moveassignable}).
@@ -4494,7 +4494,7 @@ memory is available,  \bigoh{N \log N} comparisons.
 
 
 \pnum
-\remarks Stable~(\ref{algorithm.stable}).
+\remarks Stable\iref{algorithm.stable}.
 \end{itemdescr}
 
 \rSec2[alg.set.operations]{Set operations on sorted structures}
@@ -4502,7 +4502,7 @@ memory is available,  \bigoh{N \log N} comparisons.
 \pnum
 This section defines all the basic set operations on sorted structures.
 They also work with
-\tcode{multiset}s~(\ref{multiset})
+\tcode{multiset}s\iref{multiset}
 containing multiple copies of equivalent elements.
 The semantics of the set operations are generalized to
 \tcode{multiset}s
@@ -4908,7 +4908,7 @@ The range
 \range{first}{last}
 shall be a valid non-empty heap.
 \tcode{RandomAccessIterator} shall satisfy the requirements of
-\tcode{ValueSwappable}~(\ref{swappable.requirements}). The type
+\tcode{ValueSwappable}\iref{swappable.requirements}. The type
 of \tcode{*first} shall satisfy the requirements of
 \tcode{MoveConstructible} (Table~\ref{tab:moveconstructible}) and of
 \tcode{MoveAssignable} (Table~\ref{tab:moveassignable}).
@@ -4978,7 +4978,7 @@ template<class RandomAccessIterator, class Compare>
 \pnum
 \requires The range \range{first}{last} shall be a valid heap.
 \tcode{RandomAccessIterator} shall satisfy the requirements of
-\tcode{ValueSwappable}~(\ref{swappable.requirements}). The type
+\tcode{ValueSwappable}\iref{swappable.requirements}. The type
 of \tcode{*first} shall satisfy the requirements of
 \tcode{MoveConstructible} (Table~\ref{tab:moveconstructible}) and of
 \tcode{MoveAssignable} (Table~\ref{tab:moveassignable}).
@@ -5487,7 +5487,7 @@ template<class BidirectionalIterator, class Compare>
 \pnum
 \requires
 \tcode{BidirectionalIterator} shall satisfy the requirements of
-\tcode{ValueSwappable}~(\ref{swappable.requirements}).
+\tcode{ValueSwappable}\iref{swappable.requirements}.
 
 \pnum
 \effects
@@ -5529,7 +5529,7 @@ template<class BidirectionalIterator, class Compare>
 \pnum
 \requires
 \tcode{BidirectionalIterator} shall satisfy the requirements of
-\tcode{ValueSwappable}~(\ref{swappable.requirements}).
+\tcode{ValueSwappable}\iref{swappable.requirements}.
 
 \pnum
 \effects
@@ -5562,7 +5562,7 @@ swaps.
 \indextext{\idxhdr{cstdlib}}%
 \indexlibrary{\idxhdr{cstdlib}}%
 \begin{note}
-The header \tcode{<cstdlib>}~(\ref{cstdlib.syn})
+The header \tcode{<cstdlib>}\iref{cstdlib.syn}
 declares the functions described in this subclause.
 \end{note}
 
@@ -5590,7 +5590,7 @@ are of trivial type.
 
 \pnum
 \throws
-Any exception thrown by \tcode{compar()}~(\ref{res.on.exception.handling}).
+Any exception thrown by \tcode{compar()}\iref{res.on.exception.handling}.
 \end{itemdescr}
 
 \xref

--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -483,7 +483,7 @@ template <class T>
 \begin{itemdescr}
 \pnum
 \effects The argument does not carry a dependency to the return
-value~(\ref{intro.multithread}).
+value\iref{intro.multithread}.
 
 \pnum
 \returns \tcode{y}.
@@ -525,14 +525,14 @@ lock-free. A value of 1 indicates that the types are sometimes lock-free. A
 value of 2 indicates that the types are always lock-free.
 
 \pnum
-The function \tcode{atomic_is_lock_free}~(\ref{atomics.types.operations})
+The function \tcode{atomic_is_lock_free}\iref{atomics.types.operations}
 indicates whether the object is lock-free. In any given program execution, the
 result of the lock-free query shall be consistent for all pointers of the same
 type.
 
 \pnum
 Atomic operations that are not lock-free are considered to potentially
-block~(\ref{intro.progress}).
+block\iref{intro.progress}.
 
 \pnum
 \begin{note} Operations that are lock-free should also be address-free. That is,
@@ -583,7 +583,7 @@ namespace std {
 \indexlibrary{\idxcode{atomic}}%
 \pnum
 The template argument for
-\tcode{T} shall be trivially copyable~(\ref{basic.types}). \begin{note} Type arguments that are
+\tcode{T} shall be trivially copyable\iref{basic.types}. \begin{note} Type arguments that are
 not also statically initializable may be difficult to use. \end{note}
 
 \pnum
@@ -628,7 +628,7 @@ constexpr atomic(T desired) noexcept;
 \begin{itemdescr}
 \pnum
 \effects Initializes the object with the value \tcode{desired}.
-Initialization is not an atomic operation~(\ref{intro.multithread}).
+Initialization is not an atomic operation\iref{intro.multithread}.
 \begin{note} It is possible to have an access to an atomic object \tcode{A}
 race with its construction, for example by communicating the address of the
 just-constructed object \tcode{A} to another thread via
@@ -779,7 +779,7 @@ T exchange(T desired, memory_order order = memory_order_seq_cst) noexcept;
 \effects Atomically replaces the value pointed to by \tcode{this}
 with \tcode{desired}.
 Memory is affected according to the value of \tcode{order}.
-These operations are atomic read-modify-write operations~(\ref{intro.multithread}).
+These operations are atomic read-modify-write operations\iref{intro.multithread}.
 
 \pnum
 \returns Atomically returns the value pointed to by \tcode{this} immediately before the effects.
@@ -838,7 +838,7 @@ the contents of the memory in \tcode{expected} are replaced by the value
 read from the memory pointed to by \tcode{this} during the atomic comparison.
 If the operation returns \tcode{true}, these
 operations are atomic read-modify-write
-operations~(\ref{intro.multithread}) on the memory
+operations\iref{intro.multithread} on the memory
 pointed to by \tcode{this}.
 Otherwise, these operations are atomic load operations on that memory.
 
@@ -1070,7 +1070,7 @@ T fetch_@\placeholdernc{key}@(T operand, memory_order order = memory_order_seq_c
 \tcode{this} with the result of the computation applied to the
 value pointed to by \tcode{this} and the given \tcode{operand}.
 Memory is affected according to the value of \tcode{order}.
-These operations are atomic read-modify-write operations~(\ref{intro.multithread}).
+These operations are atomic read-modify-write operations\iref{intro.multithread}.
 
 \pnum
 \returns Atomically, the value pointed to by \tcode{this} immediately before the effects.
@@ -1205,7 +1205,7 @@ T* fetch_@\placeholdernc{key}@(ptrdiff_t operand, memory_order order = memory_or
 \tcode{this} with the result of the computation applied to the
 value pointed to by \tcode{this} and the given \tcode{operand}.
 Memory is affected according to the value of \tcode{order}.
-These operations are atomic read-modify-write operations~(\ref{intro.multithread}).
+These operations are atomic read-modify-write operations\iref{intro.multithread}.
 
 \pnum
 \returns Atomically, the value pointed to by \tcode{this} immediately before the effects.
@@ -1382,7 +1382,7 @@ bool atomic_flag::test_and_set(memory_order order = memory_order_seq_cst) noexce
 \begin{itemdescr}
 \pnum
 \effects Atomically sets the value pointed to by \tcode{object} or by \tcode{this} to \tcode{true}. Memory is affected according to the value of
-\tcode{order}. These operations are atomic read-modify-write operations~(\ref{intro.multithread}).
+\tcode{order}. These operations are atomic read-modify-write operations\iref{intro.multithread}.
 
 \pnum
 \returns Atomically, the value of the object immediately before the effects.

--- a/source/back.tex
+++ b/source/back.tex
@@ -54,7 +54,7 @@ are present in this document, with the exceptions described below.\\}
 \renewcommand{\indexname}{Index of grammar productions}
 \renewcommand{\preindexhook}{The first page number for each entry is the page in the
 general text where the grammar production is defined. The second page number is the
-corresponding page in the Grammar summary (Annex~\ref{gram}).\\}
+corresponding page in the Grammar summary\iref{gram}.\\}
 \renewcommand{\leftmark}{\indexname}
 {
 \raggedright

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -115,8 +115,8 @@ the
 \tcode{extern} specifier\iref{dcl.stc} or a
 \grammarterm{linkage-specification}\footnote{Appearing inside the braced-enclosed
 \grammarterm{declaration-seq} in a \grammarterm{linkage-specification} does
-not affect whether a declaration is a definition.}
-(\ref{dcl.link}) and neither an \grammarterm{initializer} nor a
+not affect whether a declaration is a definition.}\iref{dcl.link}
+and neither an \grammarterm{initializer} nor a
 \grammarterm{function-body},
 \item
 \indextext{declaration!static member@\tcode{static} member}%
@@ -401,8 +401,8 @@ type \tcode{T} (\ref{conv}, \ref{expr.type.conv},
 \ref{expr.dynamic.cast}, \ref{expr.static.cast}, \ref{expr.cast}), or
 \item an expression that is not a null pointer constant, and has type
 other than \cv{}~\tcode{void*}, is converted to the type pointer to \tcode{T}
-or reference to \tcode{T} using a standard conversion
-(\ref{conv}), a \tcode{dynamic_cast}\iref{expr.dynamic.cast} or
+or reference to \tcode{T} using a standard conversion\iref{conv},
+a \tcode{dynamic_cast}\iref{expr.dynamic.cast} or
 a \tcode{static_cast}\iref{expr.static.cast}, or
 \item a class member access operator is applied to an expression of type
 \tcode{T}\iref{expr.ref}, or
@@ -422,11 +422,11 @@ defined\iref{class.derived}, or
 \end{note}
 
 \pnum
-There can be more than one definition of a class type
-(\ref{class}), enumeration type\iref{dcl.enum}, inline function
+There can be more than one definition of a class type\iref{class},
+enumeration type\iref{dcl.enum}, inline function
 with external linkage\iref{dcl.inline}, inline variable with external
-linkage\iref{dcl.inline}, class template
-(\ref{temp}), non-static function template\iref{temp.fct},
+linkage\iref{dcl.inline}, class template\iref{temp},
+non-static function template\iref{temp.fct},
 concept\iref{temp.concept},
 static data member of a class template\iref{temp.static}, member
 function of a class template\iref{temp.mem.func}, or template
@@ -640,8 +640,8 @@ declares a block-scope array of two integers. \end{example} \end{note}
 \pnum
 The point of declaration for a class or class template first declared by a
 \grammarterm{class-specifier} is immediately after the \grammarterm{identifier} or
-\grammarterm{simple-template-id} (if any) in its \grammarterm{class-head}
-(\ref{class}). The point of declaration for an enumeration is
+\grammarterm{simple-template-id} (if any) in its \grammarterm{class-head}\iref{class}.
+The point of declaration for an enumeration is
 immediately after the \grammarterm{identifier} (if any) in either its
 \grammarterm{enum-specifier}\iref{dcl.enum} or its first
 \grammarterm{opaque-enum-declaration}\iref{dcl.enum}, whichever comes first.
@@ -945,8 +945,8 @@ class D {
 \pnum
 The name of a class member shall only be used as follows:
 \begin{itemize}
-\item in the scope of its class (as described above) or a class derived
-(\ref{class.derived}) from its class,
+\item in the scope of its class (as described above) or a class derived\iref{class.derived}
+from its class,
 \item after the \tcode{.} operator applied to an expression of the type
 of its class\iref{expr.ref} or a class derived from its class,
 \item after the \tcode{->} operator applied to a pointer to an object of
@@ -1101,8 +1101,8 @@ shall all declare functions;
 in the latter case,
 the declarations are said to form a set of overloaded
 functions\iref{over.load}. Overload resolution\iref{over.match}
-takes place after name lookup has succeeded. The access rules
-(\ref{class.access}) are considered only once name lookup and
+takes place after name lookup has succeeded. The access rules\iref{class.access}
+are considered only once name lookup and
 function overload resolution (if applicable) have succeeded. Only after
 name lookup, function overload resolution (if applicable) and access
 checking have succeeded are the attributes introduced by the name's
@@ -1428,8 +1428,8 @@ int N::j = i;       // \tcode{N::j == 4}
 \end{example}
 
 \pnum
-A name used in the handler for a \grammarterm{function-try-block}
-(\ref{except}) is looked up as if the name was used in the
+A name used in the handler for a \grammarterm{function-try-block}\iref{except}
+is looked up as if the name was used in the
 outermost block of the function definition. In particular, the function
 parameter names shall not be redeclared in the
 \grammarterm{exception-declaration} nor in the outermost block of a handler
@@ -2199,8 +2199,8 @@ only namespace names are considered.%
 
 \pnum
 \indextext{program}%
-A \defn{program} consists of one or more \defnx{translation units}{translation unit}
-(\ref{lex}) linked together. A translation unit consists
+A \defn{program} consists of one or more \defnx{translation units}{translation unit}\iref{lex}
+linked together. A translation unit consists
 of a sequence of declarations.
 
 \begin{bnf}
@@ -3971,8 +3971,8 @@ type, \ref{dcl.ref}. There are two types of references:
 \end{itemize}
 
 \item
-\defnx{classes}{class} containing a sequence of objects of various types
-(\ref{class}), a set of types, enumerations and functions for
+\defnx{classes}{class} containing a sequence of objects of various types\iref{class},
+a set of types, enumerations and functions for
 manipulating these objects\iref{class.mfct}, and a set of restrictions
 on the access to these entities\iref{class.access};
 

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -32,18 +32,18 @@ class member, bit-field, template, template specialization, namespace, or
 parameter pack.
 
 \pnum
-A \defn{name} is a use of an \grammarterm{identifier}~(\ref{lex.name}),
-\grammarterm{operator-function-id}~(\ref{over.oper}),
-\grammarterm{literal-operator-id}~(\ref{over.literal}),
-\grammarterm{conversion-function-id}~(\ref{class.conv.fct}), or
-\grammarterm{template-id}~(\ref{temp.names}) that denotes an entity or
+A \defn{name} is a use of an \grammarterm{identifier}\iref{lex.name},
+\grammarterm{operator-function-id}\iref{over.oper},
+\grammarterm{literal-operator-id}\iref{over.literal},
+\grammarterm{conversion-function-id}\iref{class.conv.fct}, or
+\grammarterm{template-id}\iref{temp.names} that denotes an entity or
 label~(\ref{stmt.goto}, \ref{stmt.label}).
 
 \pnum
 Every name that denotes an entity is introduced by a
 \defn{declaration}. Every name that denotes a label is introduced
-either by a \tcode{goto} statement~(\ref{stmt.goto}) or a
-\grammarterm{labeled-statement}~(\ref{stmt.label}).
+either by a \tcode{goto} statement\iref{stmt.goto} or a
+\grammarterm{labeled-statement}\iref{stmt.label}.
 
 \pnum
 A \defn{variable} is introduced by the
@@ -56,7 +56,7 @@ Some names denote types or templates. In general,
 whenever a name is encountered it is necessary to determine whether that name denotes
 one of these entities before continuing to parse the program that contains it. The
 process that determines this is called
-\defnx{name lookup}{lookup!name}~(\ref{basic.lookup}).
+\defnx{name lookup}{lookup!name}\iref{basic.lookup}.
 
 \pnum
 Two names are \defnx{the same}{name!same} if
@@ -67,8 +67,8 @@ the same operator, or
 \item they are \grammarterm{conversion-function-id}{s} formed
 with the same type, or
 \item they are \grammarterm{template-id}{s} that refer to the same class,
-function, or variable~(\ref{temp.type}), or
-\item they are the names of literal operators~(\ref{over.literal}) formed with
+function, or variable\iref{temp.type}, or
+\item they are the names of literal operators\iref{over.literal} formed with
 the same literal suffix identifier.
 \end{itemize}
 
@@ -77,7 +77,7 @@ the same literal suffix identifier.
 \indextext{linkage}%
 A name used in more than one translation unit can potentially
 refer to the same entity in these translation units depending on the
-linkage~(\ref{basic.link}) of the name specified in each
+linkage\iref{basic.link} of the name specified in each
 translation unit.
 
 \rSec1[basic.def]{Declarations and definitions}
@@ -86,17 +86,17 @@ translation unit.
 \indextext{declaration!definition versus}%
 \indextext{declaration}%
 \indextext{declaration!name}%
-A declaration (Clause~\ref{dcl.dcl}) may introduce
+A declaration\iref{dcl.dcl} may introduce
 one or more names into a translation
 unit or redeclare names introduced by previous declarations.
 If so, the
 declaration specifies the interpretation and attributes of these names.
 A declaration may also have effects including:
 \begin{itemize}
-\item a static assertion (Clause~\ref{dcl.dcl}),
-\item controlling template instantiation~(\ref{temp.explicit}),
-\item guiding template argument deduction for constructors~(\ref{temp.deduct.guide}),
-\item use of attributes (Clause~\ref{dcl.dcl}), and
+\item a static assertion\iref{dcl.dcl},
+\item controlling template instantiation\iref{temp.explicit},
+\item guiding template argument deduction for constructors\iref{temp.deduct.guide},
+\item use of attributes\iref{dcl.dcl}, and
 \item nothing (in the case of an \grammarterm{empty-declaration}).
 \end{itemize}
 
@@ -107,12 +107,12 @@ A declaration is a \defn{definition} unless
 \begin{itemize}
 \item
 it declares a function
-without specifying the function's body~(\ref{dcl.fct.def}),
+without specifying the function's body\iref{dcl.fct.def},
 \item
 it contains
 the
 \indextext{declaration!\idxcode{extern}}%
-\tcode{extern} specifier~(\ref{dcl.stc}) or a
+\tcode{extern} specifier\iref{dcl.stc} or a
 \grammarterm{linkage-specification}\footnote{Appearing inside the braced-enclosed
 \grammarterm{declaration-seq} in a \grammarterm{linkage-specification} does
 not affect whether a declaration is a definition.}
@@ -128,47 +128,47 @@ and the variable was defined within the class with the \tcode{constexpr}
 specifier (this usage is deprecated; see \ref{depr.static_constexpr}),
 \item
 \indextext{declaration!class name}%
-it is a class name declaration~(\ref{class.name}),
+it is a class name declaration\iref{class.name},
 \item
 it is an
 \indextext{declaration!opaque enum}%
-\grammarterm{opaque-enum-declaration}~(\ref{dcl.enum}),
+\grammarterm{opaque-enum-declaration}\iref{dcl.enum},
 \item
 it is a
 \indextext{parameter!template}\indextext{template parameter}%
-\grammarterm{template-parameter}~(\ref{temp.param}),
+\grammarterm{template-parameter}\iref{temp.param},
 \item
 it is a
 \indextext{declaration!parameter}\indextext{parameter declaration}%
-\grammarterm{parameter-declaration}~(\ref{dcl.fct}) in a function
+\grammarterm{parameter-declaration}\iref{dcl.fct} in a function
 \indextext{declarator}%
 declarator that is not the \grammarterm{declarator} of a
 \grammarterm{function-definition},
 \item
 it is a
 \indextext{declaration!\idxcode{typedef}}%
-\tcode{typedef} declaration~(\ref{dcl.typedef}),
+\tcode{typedef} declaration\iref{dcl.typedef},
 \item it is
-an \grammarterm{alias-declaration}~(\ref{dcl.typedef}),
+an \grammarterm{alias-declaration}\iref{dcl.typedef},
 \item it is
 a
-\grammarterm{using-declaration}~(\ref{namespace.udecl}),
+\grammarterm{using-declaration}\iref{namespace.udecl},
 \item it is
-a \grammarterm{deduction-guide}~(\ref{temp.deduct.guide}),
+a \grammarterm{deduction-guide}\iref{temp.deduct.guide},
 \item it is
-a \grammarterm{static_assert-declaration} (Clause~\ref{dcl.dcl}),
+a \grammarterm{static_assert-declaration}\iref{dcl.dcl},
 \item
 it is an
-\grammarterm{attribute-declaration} (Clause~\ref{dcl.dcl}),
+\grammarterm{attribute-declaration}\iref{dcl.dcl},
 \item
 it is an
-\grammarterm{empty-declaration} (Clause~\ref{dcl.dcl}),
+\grammarterm{empty-declaration}\iref{dcl.dcl},
 \item it is
-a \grammarterm{using-directive}~(\ref{namespace.udir}),
+a \grammarterm{using-directive}\iref{namespace.udir},
 \item it is
-an explicit instantiation declaration~(\ref{temp.explicit}), or
+an explicit instantiation declaration\iref{temp.explicit}, or
 \item it is
-an explicit specialization~(\ref{temp.expl.spec}) whose
+an explicit specialization\iref{temp.expl.spec} whose
 \grammarterm{declaration} is not a definition.
 \end{itemize}
 \begin{example} All but one of the following are definitions:
@@ -207,19 +207,19 @@ using N::d;                     // declares \tcode{d}
 \begin{note}
 \indextext{implementation-generated}%
 In some circumstances, \Cpp implementations implicitly define the
-default constructor~(\ref{class.ctor}),
-copy constructor~(\ref{class.copy}),
-move constructor~(\ref{class.copy}),
-copy assignment operator~(\ref{class.copy}),
-move assignment operator~(\ref{class.copy}),
-or destructor~(\ref{class.dtor}) member functions. \end{note}
+default constructor\iref{class.ctor},
+copy constructor\iref{class.copy},
+move constructor\iref{class.copy},
+copy assignment operator\iref{class.copy},
+move assignment operator\iref{class.copy},
+or destructor\iref{class.dtor} member functions. \end{note}
 \begin{example} Given
 
 \begin{codeblock}
 #include <string>
 
 struct C {
-  std::string s;              // \tcode{std::string} is the standard library class (Clause~\ref{strings})
+  std::string s;              // \tcode{std::string} is the standard library class\iref{strings}
 };
 
 int main() {
@@ -249,13 +249,13 @@ struct C {
 
 \pnum
 \begin{note} A class name can also be implicitly declared by an
-\grammarterm{elaborated-type-specifier}~(\ref{dcl.type.elab}).
+\grammarterm{elaborated-type-specifier}\iref{dcl.type.elab}.
 \end{note}
 
 \pnum
 \indextext{type!incomplete}%
 A program is ill-formed if the definition of any object gives the object
-an incomplete type~(\ref{basic.types}).
+an incomplete type\iref{basic.types}.
 
 \indextext{object!definition}%
 \indextext{function!definition}%
@@ -270,28 +270,28 @@ variable, function, class type, enumeration type, or template.
 
 \pnum
 An expression is \defn{potentially evaluated} unless it is an
-unevaluated operand (Clause~\ref{expr}) or a subexpression thereof.
+unevaluated operand\iref{expr} or a subexpression thereof.
 The set of \defn{potential results} of an expression \tcode{e} is
 defined as follows:
 \begin{itemize}
 \item If \tcode{e} is an
-\grammarterm{id-expression}~(\ref{expr.prim.id}), the set
+\grammarterm{id-expression}\iref{expr.prim.id}, the set
 contains only \tcode{e}.
-\item If \tcode{e} is a subscripting operation~(\ref{expr.sub}) with
+\item If \tcode{e} is a subscripting operation\iref{expr.sub} with
 an array operand, the set contains the potential results of that operand.
 \item If \tcode{e} is a class member access
-expression~(\ref{expr.ref}), the set contains the potential results of
+expression\iref{expr.ref}, the set contains the potential results of
 the object expression.
 \item If \tcode{e} is a pointer-to-member
-expression~(\ref{expr.mptr.oper}) whose second operand is a constant
+expression\iref{expr.mptr.oper} whose second operand is a constant
 expression, the set contains the potential results of the object
 expression.
 \item If \tcode{e} has the form \tcode{(e1)}, the set contains the
 potential results of \tcode{e1}.
 \item If \tcode{e} is a glvalue conditional
-expression~(\ref{expr.cond}), the set is the union of the sets of
+expression\iref{expr.cond}, the set is the union of the sets of
 potential results of the second and third operands.
-\item If \tcode{e} is a comma expression~(\ref{expr.comma}), the set
+\item If \tcode{e} is a comma expression\iref{expr.comma}, the set
 contains the potential results of the right operand.
 \item Otherwise, the set is empty.
 \end{itemize}
@@ -314,13 +314,13 @@ int n = b ? (1, S::x)  // \tcode{S::x} is not odr-used here
 \pnum
 A variable \tcode{x} whose name appears as a
 potentially-evaluated expression \tcode{ex} is \defn{odr-used} by \tcode{ex} unless
-applying the lvalue-to-rvalue conversion~(\ref{conv.lval}) to \tcode{x} yields
-a constant expression~(\ref{expr.const}) that does not invoke any non-trivial
+applying the lvalue-to-rvalue conversion\iref{conv.lval} to \tcode{x} yields
+a constant expression\iref{expr.const} that does not invoke any non-trivial
 functions
 and, if \tcode{x} is an object, \tcode{ex} is an element of
 the set of potential results of an expression \tcode{e}, where either the lvalue-to-rvalue
-conversion~(\ref{conv.lval}) is applied to \tcode{e}, or \tcode{e} is
-a discarded-value expression~(Clause \ref{expr}).
+conversion\iref{conv.lval} is applied to \tcode{e}, or \tcode{e} is
+a discarded-value expression\iref{expr}.
 \tcode{this} is odr-used if it appears as a potentially-evaluated expression
 (including as the result of the implicit transformation in the body of a non-static
 member function~(\ref{class.mfct.non-static})).
@@ -331,14 +331,14 @@ expression is odr-used if it is the unique lookup result or the selected
 member of a set of overloaded functions~(\ref{basic.lookup}, \ref{over.match}, \ref{over.over}),
 unless it is a pure virtual function and either
 its name is not explicitly qualified or
-the expression forms a pointer to member~(\ref{expr.unary.op}).
+the expression forms a pointer to member\iref{expr.unary.op}.
 \begin{note} This covers calls to named
-functions~(\ref{expr.call}), operator overloading (Clause~\ref{over}),
-user-defined conversions~(\ref{class.conv.fct}), allocation functions for
-placement \grammarterm{new-expression}{s}~(\ref{expr.new}), as well as non-default
-initialization~(\ref{dcl.init}). A constructor selected to copy or move an
+functions\iref{expr.call}, operator overloading\iref{over},
+user-defined conversions\iref{class.conv.fct}, allocation functions for
+placement \grammarterm{new-expression}{s}\iref{expr.new}, as well as non-default
+initialization\iref{dcl.init}. A constructor selected to copy or move an
 object of class type is odr-used even if the
-call is actually elided by the implementation~(\ref{class.copy}). \end{note} An allocation
+call is actually elided by the implementation\iref{class.copy}. \end{note} An allocation
 or deallocation function for a class is odr-used by a \grammarterm{new-expression}
 appearing in a potentially-evaluated expression as specified
 in~\ref{expr.new} and~\ref{class.free}. A deallocation function for a
@@ -349,7 +349,7 @@ function for a class is odr-used by the definition of a constructor of that
 class. A non-placement deallocation function for a class is odr-used by the
 definition of the destructor of that class, or by being selected by the
 lookup at the point of definition of a virtual
-destructor~(\ref{class.dtor}).\footnote{An implementation is not required
+destructor\iref{class.dtor}.\footnote{An implementation is not required
 to call allocation and
 deallocation functions from constructors or destructors; however, this
 is a permissible implementation technique.}
@@ -359,12 +359,12 @@ copy-assignment or move-assignment function for another class as specified
 in~\ref{class.copy}.
 A constructor for a class is odr-used as specified
 in~\ref{dcl.init}. A destructor for a class is odr-used if it is potentially
-invoked~(\ref{class.dtor}).
+invoked\iref{class.dtor}.
 
 \pnum
 Every program shall contain exactly one definition of every non-inline
 function or variable that is odr-used in that program
-outside of a discarded statement~(\ref{stmt.if}); no diagnostic required.
+outside of a discarded statement\iref{stmt.if}; no diagnostic required.
 The definition can appear explicitly in the program, it can be found in
 the standard or a user-defined library, or (when appropriate) it is
 implicitly defined (see~\ref{class.ctor}, \ref{class.dtor} and
@@ -388,48 +388,48 @@ X* x2;                          // use \tcode{X} in pointer formation
 describe in which contexts complete class types are required. A class
 type \tcode{T} must be complete if:
 \begin{itemize}
-\item an object of type \tcode{T} is defined~(\ref{basic.def}), or
+\item an object of type \tcode{T} is defined\iref{basic.def}, or
 \item a non-static class data member of type \tcode{T} is
-declared~(\ref{class.mem}), or
+declared\iref{class.mem}, or
 \item \tcode{T} is used as the allocated type or array element type in a
-\grammarterm{new-expression}~(\ref{expr.new}), or
+\grammarterm{new-expression}\iref{expr.new}, or
 \item an lvalue-to-rvalue conversion is applied to
 a glvalue referring
-to an object of type \tcode{T}~(\ref{conv.lval}), or
+to an object of type \tcode{T}\iref{conv.lval}, or
 \item an expression is converted (either implicitly or explicitly) to
-type \tcode{T} (Clause~\ref{conv}, \ref{expr.type.conv},
+type \tcode{T} (\ref{conv}, \ref{expr.type.conv},
 \ref{expr.dynamic.cast}, \ref{expr.static.cast}, \ref{expr.cast}), or
 \item an expression that is not a null pointer constant, and has type
 other than \cv{}~\tcode{void*}, is converted to the type pointer to \tcode{T}
 or reference to \tcode{T} using a standard conversion
-(Clause~\ref{conv}), a \tcode{dynamic_cast}~(\ref{expr.dynamic.cast}) or
-a \tcode{static_cast}~(\ref{expr.static.cast}), or
+(\ref{conv}), a \tcode{dynamic_cast}\iref{expr.dynamic.cast} or
+a \tcode{static_cast}\iref{expr.static.cast}, or
 \item a class member access operator is applied to an expression of type
-\tcode{T}~(\ref{expr.ref}), or
-\item the \tcode{typeid} operator~(\ref{expr.typeid}) or the
-\tcode{sizeof} operator~(\ref{expr.sizeof}) is applied to an operand of
+\tcode{T}\iref{expr.ref}, or
+\item the \tcode{typeid} operator\iref{expr.typeid} or the
+\tcode{sizeof} operator\iref{expr.sizeof} is applied to an operand of
 type \tcode{T}, or
 \item a function with a return type or argument type of type \tcode{T}
-is defined~(\ref{basic.def}) or called~(\ref{expr.call}), or
+is defined\iref{basic.def} or called\iref{expr.call}, or
 \item a class with a base class of type \tcode{T} is
-defined (Clause~\ref{class.derived}), or
-\item an lvalue of type \tcode{T} is assigned to~(\ref{expr.ass}), or
+defined\iref{class.derived}, or
+\item an lvalue of type \tcode{T} is assigned to\iref{expr.ass}, or
 \item the type \tcode{T} is the subject of an
-\tcode{alignof} expression~(\ref{expr.alignof}), or
+\tcode{alignof} expression\iref{expr.alignof}, or
 \item an \grammarterm{exception-declaration} has type \tcode{T}, reference to
-\tcode{T}, or pointer to \tcode{T}~(\ref{except.handle}).
+\tcode{T}, or pointer to \tcode{T}\iref{except.handle}.
 \end{itemize}
 \end{note}
 
 \pnum
 There can be more than one definition of a class type
-(Clause~\ref{class}), enumeration type~(\ref{dcl.enum}), inline function
-with external linkage~(\ref{dcl.inline}), inline variable with external
-linkage~(\ref{dcl.inline}), class template
-(Clause~\ref{temp}), non-static function template~(\ref{temp.fct}),
-concept~(\ref{temp.concept}),
-static data member of a class template~(\ref{temp.static}), member
-function of a class template~(\ref{temp.mem.func}), or template
+(\ref{class}), enumeration type\iref{dcl.enum}, inline function
+with external linkage\iref{dcl.inline}, inline variable with external
+linkage\iref{dcl.inline}, class template
+(\ref{temp}), non-static function template\iref{temp.fct},
+concept\iref{temp.concept},
+static data member of a class template\iref{temp.static}, member
+function of a class template\iref{temp.mem.func}, or template
 specialization for which some template parameters are not
 specified~(\ref{temp.spec}, \ref{temp.class.spec}) in a program provided
 that each definition appears in a different translation unit, and
@@ -442,14 +442,14 @@ tokens; and
 \item in each definition of \tcode{D}, corresponding names, looked up
 according to~\ref{basic.lookup}, shall refer to an entity defined within
 the definition of \tcode{D}, or shall refer to the same entity, after
-overload resolution~(\ref{over.match}) and after matching of partial
-template specialization~(\ref{temp.over}), except that a name can refer to
+overload resolution\iref{over.match} and after matching of partial
+template specialization\iref{temp.over}, except that a name can refer to
 \begin{itemize}
 \item
 a non-volatile \tcode{const} object with internal or no linkage if the object
 \begin{itemize}
 \item has the same literal type in all definitions of \tcode{D},
-\item is initialized with a constant expression~(\ref{expr.const}),
+\item is initialized with a constant expression\iref{expr.const},
 \item is not odr-used in any definition of \tcode{D}, and
 \item has the same value in all definitions of \tcode{D},
 \end{itemize}
@@ -479,7 +479,7 @@ requirement applies recursively)\footnote{\ref{dcl.fct.default}
 describes how default argument names are looked up.}; and
 
 \item if \tcode{D} is a class with an implicitly-declared
-constructor~(\ref{class.ctor}), it is as if the constructor was
+constructor\iref{class.ctor}, it is as if the constructor was
 implicitly defined in every translation unit where it is odr-used, and the
 implicit definition in every translation unit shall call the same
 constructor for a subobject of \tcode{D}.
@@ -514,8 +514,8 @@ D d2;                           // \tcode{X(int, int, int)} called by \tcode{D()
 If \tcode{D} is a template and is defined in more than one
 translation unit, then the preceding requirements
 shall apply both to names from the template's enclosing scope used in the
-template definition~(\ref{temp.nondep}), and also to dependent names at
-the point of instantiation~(\ref{temp.dep}). If the definitions of
+template definition\iref{temp.nondep}, and also to dependent names at
+the point of instantiation\iref{temp.dep}. If the definitions of
 \tcode{D} satisfy all these requirements, then the behavior is
 as if there were a single definition of \tcode{D}. If the definitions of
 \tcode{D} do not satisfy these requirements, then the behavior is
@@ -573,9 +573,9 @@ declaration of \tcode{j} is the same as its potential scope.
 \pnum
 The names declared by a declaration are introduced into the scope in
 which the declaration occurs, except that the presence of a
-\tcode{friend} specifier~(\ref{class.friend}), certain uses of the
-\grammarterm{elaborated-type-specifier}~(\ref{dcl.type.elab}), and
-\grammarterm{using-directive}{s}~(\ref{namespace.udir}) alter this general
+\tcode{friend} specifier\iref{class.friend}, certain uses of the
+\grammarterm{elaborated-type-specifier}\iref{dcl.type.elab}, and
+\grammarterm{using-directive}{s}\iref{namespace.udir} alter this general
 behavior.
 
 \pnum
@@ -589,17 +589,17 @@ name that is not a typedef name and the other declarations shall
 all refer to the same variable, non-static data member, or enumerator,
 or all refer to functions and function templates;
 in this case the class name or enumeration name is
-hidden~(\ref{basic.scope.hiding}). \begin{note} A namespace name or a
+hidden\iref{basic.scope.hiding}. \begin{note} A namespace name or a
 class template name must be unique in its declarative
-region~(\ref{namespace.alias}, Clause~\ref{temp}). \end{note}
+region~(\ref{namespace.alias}, \ref{temp}). \end{note}
 \end{itemize}
 \begin{note} These restrictions apply to the declarative region into which
 a name is introduced, which is not necessarily the same as the region in
 which the declaration occurs. In particular,
-\grammarterm{elaborated-type-specifier}{s}~(\ref{dcl.type.elab}) and
-friend declarations~(\ref{class.friend}) may introduce a (possibly not
+\grammarterm{elaborated-type-specifier}{s}\iref{dcl.type.elab} and
+friend declarations\iref{class.friend} may introduce a (possibly not
 visible) name into an enclosing namespace; these restrictions apply to
-that region. Local extern declarations~(\ref{basic.link}) may introduce
+that region. Local extern declarations\iref{basic.link} may introduce
 a name into the declarative region where the declaration appears and
 also introduce a (possibly not visible) name into an enclosing
 namespace; these restrictions apply to both regions. \end{note}
@@ -613,7 +613,7 @@ namespace; these restrictions apply to both regions. \end{note}
 \pnum
 \indextext{name!point of declaration}%
 The \defn{point of declaration} for a name is immediately after its
-complete declarator (Clause~\ref{dcl.decl}) and before its
+complete declarator\iref{dcl.decl} and before its
 \grammarterm{initializer} (if any), except as noted below. \begin{example}
 
 \begin{codeblock}
@@ -641,17 +641,17 @@ declares a block-scope array of two integers. \end{example} \end{note}
 The point of declaration for a class or class template first declared by a
 \grammarterm{class-specifier} is immediately after the \grammarterm{identifier} or
 \grammarterm{simple-template-id} (if any) in its \grammarterm{class-head}
-(Clause~\ref{class}). The point of declaration for an enumeration is
+(\ref{class}). The point of declaration for an enumeration is
 immediately after the \grammarterm{identifier} (if any) in either its
-\grammarterm{enum-specifier}~(\ref{dcl.enum}) or its first
-\grammarterm{opaque-enum-declaration}~(\ref{dcl.enum}), whichever comes first.
+\grammarterm{enum-specifier}\iref{dcl.enum} or its first
+\grammarterm{opaque-enum-declaration}\iref{dcl.enum}, whichever comes first.
 The point of declaration of an alias or alias template immediately
 follows the \grammarterm{type-id} to which the
 alias refers.
 
 \pnum
 The point of declaration of a \grammarterm{using-declarator} that does not name a
-constructor is immediately after the \grammarterm{using-declarator}~(\ref{namespace.udecl}).
+constructor is immediately after the \grammarterm{using-declarator}\iref{namespace.udecl}.
 
 \pnum
 \indextext{declaration!enumerator point of}%
@@ -715,18 +715,18 @@ See~\ref{basic.lookup.elab} and~\ref{dcl.type.elab}. \end{note}
 
 \pnum
 The point of declaration for an
-injected-class-name (Clause~\ref{class}) is immediately following
+injected-class-name\iref{class} is immediately following
 the opening brace of the class definition.
 
 \pnum
 The point of declaration for a function-local predefined
-variable~(\ref{dcl.fct.def}) is immediately before the
+variable\iref{dcl.fct.def} is immediately before the
 \grammarterm{function-body} of a function definition.
 
 \pnum
 The point of declaration for the variable or the structured bindings
 declared in the \grammarterm{for-range-declaration}
-of a range-based \tcode{for} statement~(\ref{stmt.ranged})
+of a range-based \tcode{for} statement\iref{stmt.ranged}
 is immediately after the \grammarterm{for-range-initializer}.
 
 \pnum
@@ -745,7 +745,7 @@ template<class T
 \pnum
 \begin{note} Friend declarations refer to functions or classes that are
 members of the nearest enclosing namespace, but they do not introduce
-new names into that namespace~(\ref{namespace.memdef}). Function
+new names into that namespace\iref{namespace.memdef}. Function
 declarations at block scope and variable declarations with the
 \tcode{extern} specifier at block scope refer to declarations that are
 members of an enclosing namespace, but they do not introduce new names
@@ -762,10 +762,10 @@ see~\ref{temp.point}.\end{note}%
 \pnum
 \indextext{scope!block}%
 \indextext{local scope|see{block scope}}%
-A name declared in a block~(\ref{stmt.block}) is local to that block; it has
+A name declared in a block\iref{stmt.block} is local to that block; it has
 \defn{block scope}.
 Its potential scope begins at its point of
-declaration~(\ref{basic.scope.pdecl}) and ends at the end of its block.
+declaration\iref{basic.scope.pdecl} and ends at the end of its block.
 A variable declared at block scope is a \defn{local variable}.
 
 \pnum
@@ -775,7 +775,7 @@ The potential scope of a function parameter name
 \grammarterm{lambda-declarator})
 or of a function-local predefined variable
 in a function
-definition~(\ref{dcl.fct.def}) begins at its point of declaration. If
+definition\iref{dcl.fct.def} begins at its point of declaration. If
 the function has a \grammarterm{function-try-block} the potential scope of
 a parameter
 or of a function-local predefined variable
@@ -808,7 +808,7 @@ see~\ref{stmt.select}.
 \indextext{scope!function prototype}%
 \indextext{function prototype}%
 In a function declaration, or in any function declarator except the
-declarator of a function definition~(\ref{dcl.fct.def}), names of
+declarator of a function definition\iref{dcl.fct.def}, names of
 parameters (if supplied) have function prototype scope, which terminates
 at the end of the nearest enclosing function declarator.
 
@@ -816,7 +816,7 @@ at the end of the nearest enclosing function declarator.
 
 \pnum
 \indextext{label!scope of}%
-Labels~(\ref{stmt.label}) have \defnx{function scope}{scope!function} and
+Labels\iref{stmt.label} have \defnx{function scope}{scope!function} and
 may be used anywhere in the function in which they are declared. Only
 labels have function scope.
 
@@ -831,8 +831,8 @@ namespace, and names introduced by these declarations into the
 declarative region of the namespace are said to be \defn{member
 names} of the namespace. A namespace member name has namespace scope.
 Its potential scope includes its namespace from the name's point of
-declaration~(\ref{basic.scope.pdecl}) onwards; and for each
-\grammarterm{using-directive}~(\ref{namespace.udir}) that nominates the
+declaration\iref{basic.scope.pdecl} onwards; and for each
+\grammarterm{using-directive}\iref{namespace.udir} that nominates the
 member's namespace, the member's potential scope includes that portion
 of the potential scope of the \grammarterm{using-directive} that follows
 the member's point of declaration. \begin{example}
@@ -865,7 +865,7 @@ namespace N {
 
 \pnum
 A namespace member can also be referred to after the \tcode{::} scope
-resolution operator~(\ref{expr.prim}) applied to the name of its
+resolution operator\iref{expr.prim} applied to the name of its
 namespace or the name of a namespace which nominates the member's
 namespace in a \grammarterm{using-directive}; see~\ref{namespace.qual}.
 
@@ -876,7 +876,7 @@ The outermost declarative region of a translation unit is also a
 namespace, called the \defn{global namespace}. A name declared in
 the global namespace has \defn{global namespace scope} (also called
 \defn{global scope}). The potential scope of such a name begins at
-its point of declaration~(\ref{basic.scope.pdecl}) and ends at the end
+its point of declaration\iref{basic.scope.pdecl} and ends at the end
 of the translation unit that is its declarative region.
 \indextext{name!global}%
 A name with global namespace scope is said to be a
@@ -913,7 +913,7 @@ definitions, and member function definitions, including the member function
 body and any portion of the
 declarator part of such definitions which follows the \grammarterm{declarator-id},
 including a \grammarterm{parameter-declaration-clause} and any default
-arguments~(\ref{dcl.fct.default})).
+arguments\iref{dcl.fct.default}).
 
 \pnum
 \begin{example}
@@ -946,12 +946,12 @@ class D {
 The name of a class member shall only be used as follows:
 \begin{itemize}
 \item in the scope of its class (as described above) or a class derived
-(Clause~\ref{class.derived}) from its class,
+(\ref{class.derived}) from its class,
 \item after the \tcode{.} operator applied to an expression of the type
-of its class~(\ref{expr.ref}) or a class derived from its class,
+of its class\iref{expr.ref} or a class derived from its class,
 \item after the \tcode{->} operator applied to a pointer to an object of
-its class~(\ref{expr.ref}) or a class derived from its class,
-\item after the \tcode{::} scope resolution operator~(\ref{expr.prim})
+its class\iref{expr.ref} or a class derived from its class,
+\item after the \tcode{::} scope resolution operator\iref{expr.prim}
 applied to the name of its class or a class derived from its class.
 \end{itemize}
 
@@ -960,7 +960,7 @@ applied to the name of its class or a class derived from its class.
 \indextext{scope!enumeration}
 
 \pnum
-The name of a scoped enumerator~(\ref{dcl.enum}) has
+The name of a scoped enumerator\iref{dcl.enum} has
 \defn{enumeration scope}. Its potential scope begins at
 its point of declaration and terminates at the end of the
 \grammarterm{enum-specifier}.
@@ -1002,7 +1002,7 @@ being hidden during qualified and unqualified name lookup.)
 
 \pnum
 The potential scope of a template parameter name begins at its point of
-declaration~(\ref{basic.scope.pdecl}) and ends at the end of its declarative region.
+declaration\iref{basic.scope.pdecl} and ends at the end of its declarative region.
 \begin{note} This implies that a \grammarterm{template-parameter} can be used in the
 declaration of subsequent \grammarterm{template-parameter}{s} and their default
 arguments but cannot be used in preceding \grammarterm{template-parameter}{s} or their
@@ -1029,7 +1029,7 @@ argument must be defined and not just declared when the class template is instan
 The declarative region of the name of a template parameter is nested within the
 immediately-enclosing declarative region. \begin{note} As a result, a
 \grammarterm{template-parameter} hides any entity with the same name in an enclosing
-scope~(\ref{basic.scope.hiding}). \begin{example}
+scope\iref{basic.scope.hiding}. \begin{example}
 
 \begin{codeblock}
 typedef int N;
@@ -1042,7 +1042,7 @@ non-type template parameter of the same type as the second template parameter of
 
 \pnum
 \begin{note} Because the name of a template parameter cannot be redeclared within its
-potential scope~(\ref{temp.local}), a template parameter's scope is often its potential
+potential scope\iref{temp.local}, a template parameter's scope is often its potential
 scope. However, it is still possible for a template parameter name to be hidden;
 see~\ref{temp.local}. \end{note}
 
@@ -1053,11 +1053,11 @@ see~\ref{temp.local}. \end{note}
 \indextext{name hiding}%
 \indextext{hiding|see{name hiding}}%
 A name can be hidden by an explicit declaration of that same name in a
-nested declarative region or derived class~(\ref{class.member.lookup}).
+nested declarative region or derived class\iref{class.member.lookup}.
 
 \pnum
 \indextext{name hiding}%
-A class name~(\ref{class.name}) or enumeration name~(\ref{dcl.enum}) can
+A class name\iref{class.name} or enumeration name\iref{dcl.enum} can
 be hidden by the name of a variable, data member, function, or enumerator declared in
 the same scope. If a class or enumeration name and a variable, data member, function,
 or enumerator are declared in the same scope (in any order) with the
@@ -1070,7 +1070,7 @@ at block scope
 hides
 the declaration of a member of the class with the same name;
 see~\ref{basic.scope.class}. The declaration of a member in a derived
-class (Clause~\ref{class.derived}) hides the declaration of a member of
+class\iref{class.derived} hides the declaration of a member of
 a base class of the same name; see~\ref{class.member.lookup}.
 
 \pnum
@@ -1090,30 +1090,30 @@ If a name is in scope and is not hidden it is said to be \defn{visible}.%
 
 \pnum
 The name lookup rules apply uniformly to all names (including
-\grammarterm{typedef-name}{s}~(\ref{dcl.typedef}),
-\grammarterm{namespace-name}{s}~(\ref{basic.namespace}), and
-\grammarterm{class-name}{s}~(\ref{class.name})) wherever the grammar allows
+\grammarterm{typedef-name}{s}\iref{dcl.typedef},
+\grammarterm{namespace-name}{s}\iref{basic.namespace}, and
+\grammarterm{class-name}{s}\iref{class.name}) wherever the grammar allows
 such names in the context discussed by a particular rule. Name lookup
-associates the use of a name with a set of declarations~(\ref{basic.def}) of
+associates the use of a name with a set of declarations\iref{basic.def} of
 that name.
 The declarations found by name lookup shall either all declare the same entity or
 shall all declare functions;
 in the latter case,
 the declarations are said to form a set of overloaded
-functions~(\ref{over.load}). Overload resolution~(\ref{over.match})
+functions\iref{over.load}. Overload resolution\iref{over.match}
 takes place after name lookup has succeeded. The access rules
-(Clause~\ref{class.access}) are considered only once name lookup and
+(\ref{class.access}) are considered only once name lookup and
 function overload resolution (if applicable) have succeeded. Only after
 name lookup, function overload resolution (if applicable) and access
 checking have succeeded are the attributes introduced by the name's
-declaration used further in expression processing (Clause~\ref{expr}).
+declaration used further in expression processing\iref{expr}.
 
 \pnum
 A name ``looked up in the context of an expression'' is looked up as an
 unqualified name in the scope where the expression is found.
 
 \pnum
-The injected-class-name of a class (Clause~\ref{class}) is also
+The injected-class-name of a class\iref{class} is also
 considered to be a member of that class for the purposes of name hiding
 and lookup.
 
@@ -1164,7 +1164,7 @@ namespace N {
 \end{codeblock}
 
 Because the expression is not a function call, the argument-dependent
-name lookup~(\ref{basic.lookup.argdep}) does not apply and the friend
+name lookup\iref{basic.lookup.argdep} does not apply and the friend
 function \tcode{f} is not found. \end{note}
 
 \pnum
@@ -1186,7 +1186,7 @@ a type or default argument in the
 \grammarterm{parameter-declaration-clause} or used in the function body.}
 shall be
 declared before its use in the block in which it is used or in one of
-its enclosing blocks~(\ref{stmt.block}) or shall be declared before its
+its enclosing blocks\iref{stmt.block} or shall be declared before its
 use in namespace \tcode{N} or, if \tcode{N} is a nested namespace, shall
 be declared before its use in one of \tcode{N}'s enclosing namespaces.
 \begin{example}
@@ -1218,18 +1218,18 @@ following the class name; such a name may be used in the
 shall be declared in one of the following ways:
 \begin{itemize}
 \item before its use in class \tcode{X} or be a member of a base class
-of \tcode{X}~(\ref{class.member.lookup}), or
+of \tcode{X}\iref{class.member.lookup}, or
 \item if \tcode{X} is a nested class of class
-\tcode{Y}~(\ref{class.nest}), before the definition of \tcode{X} in
+\tcode{Y}\iref{class.nest}, before the definition of \tcode{X} in
 \tcode{Y}, or shall be a member of a base class of \tcode{Y} (this
 lookup applies in turn to \tcode{Y}'s enclosing classes, starting with
 the innermost enclosing class),\footnote{This lookup applies whether the
 definition of \tcode{X} is
 nested within \tcode{Y}'s definition or whether \tcode{X}'s definition
 appears in a namespace scope enclosing \tcode{Y}'s
-definition~(\ref{class.nest}).}
+definition\iref{class.nest}.}
 or
-\item if \tcode{X} is a local class~(\ref{class.local}) or is a nested
+\item if \tcode{X} is a local class\iref{class.local} or is a nested
 class of a local class, before the definition of class \tcode{X} in a
 block enclosing the definition of class \tcode{X}, or
 \item if \tcode{X} is a member of namespace \tcode{N}, or is a nested
@@ -1278,7 +1278,7 @@ definitions.
 For the members of a class \tcode{X}, a name used in a member function
 body, in a default argument, in a \grammarterm{noexcept-specifier}, in the
 \grammarterm{brace-or-equal-initializer} of a non-static data
-member~(\ref{class.mem}), or in the definition of a class member
+member\iref{class.mem}, or in the definition of a class member
 outside of the definition of \tcode{X}, following the
 member's
 \grammarterm{declarator-id}\footnote{That is, an unqualified name that occurs,
@@ -1289,13 +1289,13 @@ type in the
 following ways:
 \begin{itemize}
 \item before its use in the block in which it is used or in an enclosing
-block~(\ref{stmt.block}), or
+block\iref{stmt.block}, or
 
 \item shall be a member of class \tcode{X} or be a member of a base
-class of \tcode{X}~(\ref{class.member.lookup}), or
+class of \tcode{X}\iref{class.member.lookup}, or
 
 \item if \tcode{X}
-is a nested class of class \tcode{Y}~(\ref{class.nest}), shall be a
+is a nested class of class \tcode{Y}\iref{class.nest}, shall be a
 member of \tcode{Y}, or shall be a member of a base class of \tcode{Y}
 (this lookup applies in turn to \tcode{Y}'s enclosing classes, starting
 with the innermost enclosing class),\footnote{This lookup applies whether
@@ -1304,7 +1304,7 @@ within the definition of class \tcode{X} or whether the member function
 is defined in a namespace scope enclosing \tcode{X}'s definition.}
 or
 
-\item if \tcode{X} is a local class~(\ref{class.local}) or is a nested
+\item if \tcode{X} is a local class\iref{class.local} or is a nested
 class of a local class, before the definition of class \tcode{X} in a
 block enclosing the definition of class \tcode{X}, or
 
@@ -1345,7 +1345,7 @@ definitions. \end{note}
 
 \pnum
 Name lookup for a name used in the definition of a \tcode{friend}
-function~(\ref{class.friend}) defined inline in the class granting
+function\iref{class.friend} defined inline in the class granting
 friendship shall proceed as described for lookup in member function
 definitions. If the \tcode{friend} function is not defined in the class
 granting friendship, name lookup in the \tcode{friend} function
@@ -1356,7 +1356,7 @@ function definitions.
 In a \tcode{friend} declaration naming a member function, a name used in
 the function declarator and not part of a \grammarterm{template-argument}
 in the \grammarterm{declarator-id} is first looked up in the scope of the
-member function's class~(\ref{class.member.lookup}). If it is not found,
+member function's class\iref{class.member.lookup}. If it is not found,
 or if the name is part of a
 \grammarterm{template-argument} in
 the \grammarterm{declarator-id}, the look up is
@@ -1382,10 +1382,10 @@ struct B {
 
 \pnum
 During the lookup for a name used as a default
-argument~(\ref{dcl.fct.default}) in a function
+argument\iref{dcl.fct.default} in a function
 \grammarterm{parameter-declaration-clause} or used in the
 \grammarterm{expression} of a \grammarterm{mem-initializer} for a
-constructor~(\ref{class.base.init}), the function parameter names are
+constructor\iref{class.base.init}, the function parameter names are
 visible and hide the names of entities declared in the block, class or
 namespace scopes containing the function declaration. \begin{note}
 \ref{dcl.fct.default} further describes the restrictions on the use of
@@ -1402,7 +1402,7 @@ scopes containing the \grammarterm{enum-specifier}.
 
 \pnum
 A name used in the definition of a \tcode{static} data member of class
-\tcode{X}~(\ref{class.static.data}) (after the \grammarterm{qualified-id}
+\tcode{X}\iref{class.static.data} (after the \grammarterm{qualified-id}
 of the static member) is looked up as if the name was used in a member
 function of \tcode{X}. \begin{note} \ref{class.static.data} further
 describes the restrictions on the use of names in the definition of a
@@ -1429,7 +1429,7 @@ int N::j = i;       // \tcode{N::j == 4}
 
 \pnum
 A name used in the handler for a \grammarterm{function-try-block}
-(Clause~\ref{except}) is looked up as if the name was used in the
+(\ref{except}) is looked up as if the name was used in the
 outermost block of the function definition. In particular, the function
 parameter names shall not be redeclared in the
 \grammarterm{exception-declaration} nor in the outermost block of a handler
@@ -1447,10 +1447,10 @@ described in~\ref{temp.res}. \end{note}
 
 \pnum
 When the \grammarterm{postfix-expression} in
-a function call~(\ref{expr.call}) is an \grammarterm{unqualified-id}, other namespaces not considered
-during the usual unqualified lookup~(\ref{basic.lookup.unqual}) may be
+a function call\iref{expr.call} is an \grammarterm{unqualified-id}, other namespaces not considered
+during the usual unqualified lookup\iref{basic.lookup.unqual} may be
 searched, and in those namespaces, namespace-scope friend function or
-function template declarations~(\ref{class.friend}) not otherwise
+function template declarations\iref{class.friend} not otherwise
 visible may be found.
 These modifications to the search depend on the types of the arguments
 (and for template template arguments, the namespace of the template
@@ -1518,7 +1518,7 @@ associated with \tcode{X}.
 associated namespaces and classes are those associated with the member
 type together with those associated with \tcode{X}.
 \end{itemize}
-If an associated namespace is an inline namespace~(\ref{namespace.def}), its
+If an associated namespace is an inline namespace\iref{namespace.def}, its
 enclosing namespace is also included in the set. If an associated namespace
 directly contains inline namespaces, those inline namespaces are also included
 in the set.
@@ -1534,7 +1534,7 @@ those of its type \grammarterm{template-argument}{s} and its template
 
 \pnum
 Let \placeholder{X} be the lookup set produced by unqualified
-lookup~(\ref{basic.lookup.unqual}) and let \placeholder{Y} be the lookup set produced
+lookup\iref{basic.lookup.unqual} and let \placeholder{Y} be the lookup set produced
 by argument dependent lookup (defined as follows). If \placeholder{X} contains
 \begin{itemize}
 \item a declaration of a class member, or
@@ -1568,7 +1568,7 @@ int main() {
 \pnum
 When considering an associated namespace, the lookup is the same as the
 lookup performed when the associated namespace is used as a
-qualifier~(\ref{namespace.qual}) except that:
+qualifier\iref{namespace.qual} except that:
 \begin{itemize}
 \item Any \grammarterm{using-directive}{s} in the associated namespace are
 ignored.
@@ -1576,7 +1576,7 @@ ignored.
 \item Any namespace-scope friend functions or friend function templates
 declared in associated classes are visible within their respective
 namespaces even if they are not visible during an ordinary
-lookup~(\ref{class.friend}).
+lookup\iref{class.friend}.
 
 \item All names except those of (possibly overloaded) functions and
 function templates are ignored.
@@ -1590,7 +1590,7 @@ function templates are ignored.
 \indextext{qualification!explicit}%
 The name of a class or namespace member
 or enumerator can be referred to after the
-\tcode{::} scope resolution operator~(\ref{expr.prim}) applied to a
+\tcode{::} scope resolution operator\iref{expr.prim} applied to a
 \grammarterm{nested-name-specifier} that denotes its class,
 namespace, or enumeration.
 If a
@@ -1617,7 +1617,7 @@ int main() {
 
 \pnum
 \begin{note} Multiply qualified names, such as \tcode{N1::N2::N3::n}, can
-be used to refer to members of nested classes~(\ref{class.nest}) or
+be used to refer to members of nested classes\iref{class.nest} or
 members of nested namespaces. \end{note}
 
 \pnum
@@ -1643,13 +1643,13 @@ X C::arr[number];   // ill-formed:
 \pnum
 \indextext{operator!scope resolution}%
 \indextext{scope resolution operator|see{operator, scope resolution}}%
-A name prefixed by the unary scope operator \tcode{::}~(\ref{expr.prim})
+A name prefixed by the unary scope operator \tcode{::}\iref{expr.prim}
 is looked up in global scope, in the translation unit where it is used.
 The name shall be declared in global namespace scope or shall be a name
 whose declaration is visible in global scope because of a
-\grammarterm{using-directive}~(\ref{namespace.qual}). The use of \tcode{::}
+\grammarterm{using-directive}\iref{namespace.qual}. The use of \tcode{::}
 allows a global name to be referred to even if its identifier has been
-hidden~(\ref{basic.scope.hiding}).
+hidden\iref{basic.scope.hiding}.
 
 \pnum
 A name prefixed by a \grammarterm{nested-name-specifier} that
@@ -1657,7 +1657,7 @@ nominates an enumeration type shall represent an \grammarterm{enumerator}
 of that enumeration.
 
 \pnum
-If a \grammarterm{pseudo-destructor-name}~(\ref{expr.pseudo}) contains a
+If a \grammarterm{pseudo-destructor-name}\iref{expr.pseudo} contains a
 \grammarterm{nested-name-specifier}, the \grammarterm{type-name}{s} are looked
 up as types in the scope designated by the
 \grammarterm{nested-name-specifier}. Similarly, in a
@@ -1699,11 +1699,11 @@ lookup proceeds after the \tcode{.} and \tcode{->} operators. \end{note}
 If the \grammarterm{nested-name-specifier} of a \grammarterm{qualified-id}
 nominates a class, the name specified after the
 \grammarterm{nested-name-specifier} is looked up in the scope of the
-class~(\ref{class.member.lookup}), except for the cases listed below.
+class\iref{class.member.lookup}, except for the cases listed below.
 The name shall represent one or more members of that class or of one of
-its base classes (Clause~\ref{class.derived}). \begin{note} A class member
+its base classes\iref{class.derived}. \begin{note} A class member
 can be referred to using a \grammarterm{qualified-id} at any point in its
-potential scope~(\ref{basic.scope.class}). \end{note} The exceptions to
+potential scope\iref{basic.scope.class}. \end{note} The exceptions to
 the name lookup rule above are the following:
 \begin{itemize}
 \item the lookup for a destructor is as specified
@@ -1719,9 +1719,9 @@ access (see~\ref{basic.lookup.classref});
 \grammarterm{postfix-expression} occurs.
 
 \item the lookup for a name specified in a
-\grammarterm{using-declaration}~(\ref{namespace.udecl}) also finds class or
+\grammarterm{using-declaration}\iref{namespace.udecl} also finds class or
 enumeration names hidden within the same
-scope~(\ref{basic.scope.hiding}).
+scope\iref{basic.scope.hiding}.
 \end{itemize}
 
 \pnum
@@ -1732,10 +1732,10 @@ function names are ignored include names appearing in a
 and the \grammarterm{nested-name-specifier} nominates a class \tcode{C}:
 \begin{itemize}
 \item if the name specified after the \grammarterm{nested-name-specifier},
-when looked up in \tcode{C}, is the injected-class-name of \tcode{C} (Clause~\ref{class}), or
+when looked up in \tcode{C}, is the injected-class-name of \tcode{C}\iref{class}, or
 \item
 in a \grammarterm{using-declarator} of
-a \grammarterm{using-declaration}~(\ref{namespace.udecl}) that is a \grammarterm{member-declaration},
+a \grammarterm{using-declaration}\iref{namespace.udecl} that is a \grammarterm{member-declaration},
 if the name specified after the \grammarterm{nested-name-specifier} is the same as the
 \grammarterm{identifier} or the \grammarterm{simple-template-id}'s
 \grammarterm{template-name} in the last component of the \grammarterm{nested-name-specifier},
@@ -1784,7 +1784,7 @@ entire \grammarterm{postfix-expression} occurs.
 For a namespace \tcode{X} and name \tcode{m}, the namespace-qualified lookup set
 $S(X, m)$ is defined as follows: Let $S'(X, m)$ be the set of all
 declarations of \tcode{m} in \tcode{X} and the inline namespace set of
-\tcode{X}~(\ref{namespace.def}). If $S'(X, m)$ is not empty, $S(X, m)$
+\tcode{X}\iref{namespace.def}. If $S'(X, m)$ is not empty, $S(X, m)$
 is $S'(X, m)$; otherwise, $S(X, m)$ is the union of $S(N_i, m)$ for
 all namespaces $N_i$ nominated by \grammarterm{using-directive}{s} in
 \tcode{X} and its inline namespace set.
@@ -1794,7 +1794,7 @@ Given \tcode{X::m} (where \tcode{X} is a user-declared namespace), or
 given \tcode{::m} (where X is the global namespace), if
 $S(X, m)$ is the empty set, the program is ill-formed. Otherwise, if
 $S(X, m)$ has exactly one member, or if the context of the reference is
-a \grammarterm{using-declaration}~(\ref{namespace.udecl}), $S(X, m)$
+a \grammarterm{using-declaration}\iref{namespace.udecl}, $S(X, m)$
 is the
 required set of declarations of \tcode{m}. Otherwise if the use of
 \tcode{m} is not one that allows a unique declaration to be chosen from
@@ -1969,7 +1969,7 @@ nested-name-specifier unqualified-id
 the
 \grammarterm{unqualified-id} shall name a member of the namespace
 designated by the \grammarterm{nested-name-specifier}
-or of an element of the inline namespace set~(\ref{namespace.def}) of that namespace.
+or of an element of the inline namespace set\iref{namespace.def} of that namespace.
 \begin{example}
 
 \begin{codeblock}
@@ -2012,10 +2012,10 @@ void B::f1(int){ }  // OK, defines \tcode{A::B::f1(int)}
 \indextext{type specifier!elaborated}
 
 \pnum
-An \grammarterm{elaborated-type-specifier}~(\ref{dcl.type.elab}) may be
+An \grammarterm{elaborated-type-specifier}\iref{dcl.type.elab} may be
 used to refer to a previously declared \grammarterm{class-name} or
 \grammarterm{enum-name} even though the name has been hidden by a non-type
-declaration~(\ref{basic.scope.hiding}).
+declaration\iref{basic.scope.hiding}.
 
 \pnum
 If the \grammarterm{elaborated-type-specifier} has no
@@ -2063,7 +2063,7 @@ struct Node {
 
 struct Data {
   struct Node* Node;            // OK: Refers to \tcode{Node} at global scope
-  friend struct ::Glob;         // error: \tcode{Glob} is not declared, cannot introduce a qualified type~(\ref{dcl.type.elab})
+  friend struct ::Glob;         // error: \tcode{Glob} is not declared, cannot introduce a qualified type\iref{dcl.type.elab}
   friend struct Glob;           // OK: Refers to (as yet) undeclared \tcode{Glob} at global scope.
   @\commentellip@
 };
@@ -2078,8 +2078,8 @@ struct Base {
 };
 
 struct Data;                    // OK: Redeclares \tcode{Data} at global scope
-struct ::Data;                  // error: cannot introduce a qualified type~(\ref{dcl.type.elab})
-struct Base::Data;              // error: cannot introduce a qualified type~(\ref{dcl.type.elab})
+struct ::Data;                  // error: cannot introduce a qualified type\iref{dcl.type.elab}
+struct Base::Data;              // error: cannot introduce a qualified type\iref{dcl.type.elab}
 struct Base::Datum;             // error: \tcode{Datum} undefined
 struct Base::Data* pBase;       // OK: refers to nested \tcode{Data}
 \end{codeblock}
@@ -2090,21 +2090,21 @@ struct Base::Data* pBase;       // OK: refers to nested \tcode{Data}
 
 \pnum
 \indextext{lookup!class member}%
-In a class member access expression~(\ref{expr.ref}), if the \tcode{.}
+In a class member access expression\iref{expr.ref}, if the \tcode{.}
 or \tcode{->} token is immediately followed by an \grammarterm{identifier}
 followed by a \tcode{<}, the identifier must be looked up to determine
 whether the \tcode{<} is the beginning of a template argument
-list~(\ref{temp.names}) or a less-than operator. The identifier is first
+list\iref{temp.names} or a less-than operator. The identifier is first
 looked up in the class of the object expression. If the identifier is
 not found, it is then looked up in the context of the entire
 \grammarterm{postfix-expression} and shall name a class template.
 
 \pnum
 If the \grammarterm{id-expression} in a class member
-access~(\ref{expr.ref}) is an \grammarterm{unqualified-id}, and the type of
+access\iref{expr.ref} is an \grammarterm{unqualified-id}, and the type of
 the object expression is of a class type \tcode{C}, the
 \grammarterm{unqualified-id} is looked up in the scope of class \tcode{C}.
-For a pseudo-destructor call~(\ref{expr.pseudo}),
+For a pseudo-destructor call\iref{expr.pseudo},
 the \grammarterm{unqualified-id} is looked up in the context of the complete
 \grammarterm{postfix-expression}.
 
@@ -2153,7 +2153,7 @@ as a \grammarterm{class-name} or \grammarterm{namespace-name}.
 
 \pnum
 If the \grammarterm{nested-name-specifier} contains a
-\grammarterm{simple-template-id}~(\ref{temp.names}), the names in its
+\grammarterm{simple-template-id}\iref{temp.names}, the names in its
 \grammarterm{template-argument}{s} are looked up in the context in which the
 entire \grammarterm{postfix-expression} occurs.
 
@@ -2200,7 +2200,7 @@ only namespace names are considered.%
 \pnum
 \indextext{program}%
 A \defn{program} consists of one or more \defnx{translation units}{translation unit}
-(Clause~\ref{lex}) linked together. A translation unit consists
+(\ref{lex}) linked together. A translation unit consists
 of a sequence of declarations.
 
 \begin{bnf}
@@ -2238,7 +2238,7 @@ cannot be referred to by names from other scopes.
 \indextext{\idxcode{const}!linkage of}%
 \indextext{linkage!\idxcode{inline} and}%
 \indextext{\idxcode{inline}!linkage of}%
-A name having namespace scope~(\ref{basic.scope.namespace}) has internal
+A name having namespace scope\iref{basic.scope.namespace} has internal
 linkage if it is the name of
 \begin{itemize}
 \item
@@ -2262,13 +2262,13 @@ has the same linkage as the enclosing namespace if it is the name of
 \item a variable; or
 \item a function; or
 \item \indextext{class!linkage of}%
-a named class (Clause~\ref{class}), or an unnamed class defined in a
+a named class\iref{class}, or an unnamed class defined in a
 typedef declaration in which the class has the typedef name for linkage
-purposes~(\ref{dcl.typedef}); or
+purposes\iref{dcl.typedef}; or
 \item \indextext{enumeration!linkage of}%
-a named enumeration~(\ref{dcl.enum}), or an unnamed enumeration defined
+a named enumeration\iref{dcl.enum}, or an unnamed enumeration defined
 in a typedef declaration in which the enumeration has the typedef name
-for linkage purposes~(\ref{dcl.typedef}); or
+for linkage purposes\iref{dcl.typedef}; or
 \item a template.
 \end{itemize}
 
@@ -2276,7 +2276,7 @@ for linkage purposes~(\ref{dcl.typedef}); or
 In addition, a member function, static data member, a named class or
 enumeration of class scope, or an unnamed class or enumeration defined
 in a class-scope typedef declaration such that the class or enumeration
-has the typedef name for linkage purposes~(\ref{dcl.typedef}), has
+has the typedef name for linkage purposes\iref{dcl.typedef}, has
 the same linkage, if any, as the name of the class of which it is a
 member.
 
@@ -2337,37 +2337,37 @@ void q() { @\commentellip@ }          // some other, unrelated \tcode{q}
 \pnum
 \indextext{linkage!no}%
 Names not covered by these rules have no linkage. Moreover, except as
-noted, a name declared at block scope~(\ref{basic.scope.block}) has no
+noted, a name declared at block scope\iref{basic.scope.block} has no
 linkage. A type is said to have linkage if and only if:
 \begin{itemize}
 \item it is a class or enumeration type that is named (or has a name for
-linkage purposes~(\ref{dcl.typedef})) and the name has linkage; or
+linkage purposes\iref{dcl.typedef}) and the name has linkage; or
 
 \item it is an unnamed class or unnamed enumeration that is a member of a class
 with linkage; or
 
-\item it is a specialization of a class template (Clause~\ref{temp})\footnote{A class
+\item it is a specialization of a class template\iref{temp}\footnote{A class
 template has the linkage of the innermost enclosing class or namespace in which
 it is declared.};
 or
 
-\item it is a fundamental type~(\ref{basic.fundamental}); or
+\item it is a fundamental type\iref{basic.fundamental}; or
 
-\item it is a compound type~(\ref{basic.compound}) other than a class or
+\item it is a compound type\iref{basic.compound} other than a class or
 enumeration, compounded exclusively from types that have linkage; or
 
-\item it is a cv-qualified~(\ref{basic.type.qualifier}) version of a
+\item it is a cv-qualified\iref{basic.type.qualifier} version of a
 type that has linkage.
 \end{itemize}
 A type without linkage shall not be used as the type of a variable or
 function with external linkage unless
 \begin{itemize}
-\item the entity has C language linkage~(\ref{dcl.link}), or
+\item the entity has C language linkage\iref{dcl.link}, or
 
 \item the entity is declared within an unnamed
-namespace~(\ref{namespace.def}), or
+namespace\iref{namespace.def}, or
 
-\item the entity is not odr-used~(\ref{basic.def.odr}) or is defined in
+\item the entity is not odr-used\iref{basic.def.odr} or is defined in
 the same translation unit.
 \end{itemize}
 \begin{note}
@@ -2400,7 +2400,7 @@ void f() {
 \end{example}
 
 \pnum
-Two names that are the same (Clause~\ref{basic}) and that are declared
+Two names that are the same\iref{basic} and that are declared
 in different scopes shall denote the same variable, function,
 type, template or namespace if
 \begin{itemize}
@@ -2411,26 +2411,26 @@ linkage and are declared in the same translation unit; and
 not by inheritance, of the same class; and
 
 \item when both names denote functions, the parameter-type-lists of the
-functions~(\ref{dcl.fct}) are identical; and
+functions\iref{dcl.fct} are identical; and
 
 \item when both names denote function templates, the
-signatures~(\ref{temp.over.link}) are the same.
+signatures\iref{temp.over.link} are the same.
 \end{itemize}
 
 \pnum
 \indextext{consistency!type declaration}%
 \indextext{declaration!multiple}%
 After all adjustments of types (during which
-typedefs~(\ref{dcl.typedef}) are replaced by their definitions), the
+typedefs\iref{dcl.typedef} are replaced by their definitions), the
 types specified by all declarations referring to a given variable or
 function shall be identical, except that declarations for an array
 object can specify array types that differ by the presence or absence of
-a major array bound~(\ref{dcl.array}). A violation of this rule on type
+a major array bound\iref{dcl.array}. A violation of this rule on type
 identity does not require a diagnostic.
 
 \pnum
 \begin{note} Linkage to non-\Cpp declarations can be achieved using a
-\grammarterm{linkage-specification}~(\ref{dcl.link}). \end{note}%
+\grammarterm{linkage-specification}\iref{dcl.link}. \end{note}%
 \indextext{linkage|)}
 
 \rSec1[basic.start]{Start and termination}
@@ -2444,7 +2444,7 @@ A program shall contain a global function called \tcode{main}.
 Executing a program starts a main thread of execution~(\ref{intro.multithread}, \ref{thread.threads})
 in which the \tcode{main} function is invoked,
 and in which variables of static storage duration
-might be initialized~(\ref{basic.start.static}) and destroyed~(\ref{basic.start.term}).
+might be initialized\iref{basic.start.static} and destroyed\iref{basic.start.term}.
 It is \impldef{defining \tcode{main} in freestanding environment}
 whether a program in a freestanding environment is required to define a \tcode{main}
 function. \begin{note} In a freestanding environment, start-up and termination is
@@ -2467,7 +2467,7 @@ An implementation shall allow both
 
 \indextext{\idxcode{argc}}%
 \indextext{\idxcode{argv}}%
-as the type of \tcode{main}~(\ref{dcl.fct}).
+as the type of \tcode{main}\iref{dcl.fct}.
 \indextext{\idxcode{main} function!parameters to}%
 \indextext{environment!program}%
 In the latter form, for purposes of exposition, the first function
@@ -2477,7 +2477,7 @@ arguments passed to the program from the environment in which the
 program is run. If
 \tcode{argc} is nonzero these arguments shall be supplied in
 \tcode{argv[0]} through \tcode{argv[argc-1]} as pointers to the initial
-characters of null-terminated multibyte strings (\ntmbs{}s)~(\ref{multibyte.strings})
+characters of null-terminated multibyte strings (\ntmbs{}s)\iref{multibyte.strings}
 and \tcode{argv[0]} shall be the pointer to
 the initial character of a \ntmbs that represents the name used to
 invoke the program or \tcode{""}. The value of \tcode{argc} shall be
@@ -2489,12 +2489,12 @@ is recommended that any further (optional) parameters be added after
 The function \tcode{main} shall not be used within
 a program.
 \indextext{\idxcode{main} function!implementation-defined linkage of}%
-The linkage~(\ref{basic.link}) of \tcode{main} is
+The linkage\iref{basic.link} of \tcode{main} is
 \impldef{linkage of \tcode{main}}. A program that defines \tcode{main} as
 deleted or that declares \tcode{main} to be
 \tcode{inline}, \tcode{static}, or \tcode{constexpr} is ill-formed.
 The \tcode{main} function shall not be declared with a
-\grammarterm{linkage-specification}~(\ref{dcl.link}).  A program that
+\grammarterm{linkage-specification}\iref{dcl.link}.  A program that
 declares a variable \tcode{main} at global scope or that declares the name
 \tcode{main} with C language linkage (in any namespace) is ill-formed.
 The name \tcode{main} is
@@ -2508,8 +2508,8 @@ namespaces. \end{example}
 \indextext{termination!program}%
 Terminating the program
 without leaving the current block (e.g., by calling the function
-\tcode{std::exit(int)}~(\ref{support.start.term})) does not destroy any
-objects with automatic storage duration~(\ref{class.dtor}). If
+\tcode{std::exit(int)}\iref{support.start.term}) does not destroy any
+objects with automatic storage duration\iref{class.dtor}. If
 \tcode{std::exit} is called to end a program during the destruction of
 an object with static or thread storage duration, the program has undefined
 behavior.
@@ -2550,13 +2550,13 @@ if a variable or temporary object with static or thread storage duration
 is initialized by a constant initializer for the entity.
 \indextext{initialization!runtime}%
 If constant initialization is not performed, a variable with static
-storage duration~(\ref{basic.stc.static}) or thread storage
-duration~(\ref{basic.stc.thread}) is zero-initialized~(\ref{dcl.init}).
+storage duration\iref{basic.stc.static} or thread storage
+duration\iref{basic.stc.thread} is zero-initialized\iref{dcl.init}.
 Together, zero-initialization and constant initialization are called
 \indextext{initialization!dynamic}%
 \defn{static initialization};
 all other initialization is \defn{dynamic initialization}.
-All static initialization strongly happens before~(\ref{intro.races})
+All static initialization strongly happens before\iref{intro.races}
 any dynamic initialization.
 \begin{note} The dynamic initialization of non-local variables is described
 in~\ref{basic.start.dynamic}; that of local static variables is described
@@ -2626,8 +2626,8 @@ unordered initialization, and \tcode{V} is defined before \tcode{W} in
 every translation unit in which \tcode{W} is defined, then
 \begin{itemize}
 \item
-if the program starts a thread~(\ref{intro.multithread})
-other than the main thread~(\ref{basic.start.main}),
+if the program starts a thread\iref{intro.multithread}
+other than the main thread\iref{basic.start.main},
 the initialization of \tcode{V}
 strongly happens before
 the initialization of \tcode{W};
@@ -2657,7 +2657,7 @@ ordered variables concurrently with another sequence.
 \pnum
 \indextext{non-initialization odr-use|see{odr-use, non-initialization}}%
 A \defnx{non-initialization odr-use}{odr-use!non-initialization}
-is an odr-use~(\ref{basic.def.odr}) not caused directly or indirectly by
+is an odr-use\iref{basic.def.odr} not caused directly or indirectly by
 the initialization of a non-local static or thread storage duration variable.
 
 \pnum
@@ -2743,7 +2743,7 @@ in which threads and at which points in the program such deferred dynamic initia
 \pnum
 If the initialization of a non-local variable with static or thread storage duration
 exits via
-an exception, \tcode{std::terminate} is called~(\ref{except.terminate}).%
+an exception, \tcode{std::terminate} is called\iref{except.terminate}.%
 \indextext{program!start|)}
 
 \rSec2[basic.start.term]{Termination}
@@ -2752,18 +2752,18 @@ an exception, \tcode{std::terminate} is called~(\ref{except.terminate}).%
 \indextext{program!termination|(}%
 \indextext{object!destructor static}%
 \indextext{\idxcode{main} function!return from}%
-Destructors~(\ref{class.dtor}) for initialized objects
-(that is, objects whose lifetime~(\ref{basic.life}) has begun)
+Destructors\iref{class.dtor} for initialized objects
+(that is, objects whose lifetime\iref{basic.life} has begun)
 with static storage duration,
 and functions registered with \tcode{std::atexit},
 are called as part of a call to
 \indextext{\idxcode{exit}}%
 \indexlibrary{\idxcode{exit}}%
-\tcode{std::exit}~(\ref{support.start.term}).
+\tcode{std::exit}\iref{support.start.term}.
 The call to \tcode{std::exit} is sequenced before
 the invocations of the destructors and the registered functions.
 \begin{note}
-Returning from \tcode{main} invokes \tcode{std::exit}~(\ref{basic.start.main}).
+Returning from \tcode{main} invokes \tcode{std::exit}\iref{basic.start.main}.
 \end{note}
 
 \pnum
@@ -2789,7 +2789,7 @@ object with static storage duration initialized during the construction
 of the subobjects is destroyed.
 If the destruction of an object with static or thread storage duration
 exits via an exception,
-\tcode{std::terminate} is called~(\ref{except.terminate}).
+\tcode{std::terminate} is called\iref{except.terminate}.
 
 \pnum
 If a function contains a block-scope object of static or thread storage duration that has been
@@ -2815,9 +2815,9 @@ the call to the function passed to the first \tcode{std::atexit} call.
 
 \pnum
 If there is a use of a standard library object or function not permitted within signal
-handlers~(\ref{support.runtime}) that does not happen before~(\ref{intro.multithread})
+handlers\iref{support.runtime} that does not happen before\iref{intro.multithread}
 completion of destruction of objects with static storage duration and execution of
-\tcode{std::atexit} registered functions~(\ref{support.start.term}), the program has
+\tcode{std::atexit} registered functions\iref{support.start.term}, the program has
 undefined behavior. \begin{note} If there is a use of an object with static storage
 duration that does not happen before the object's destruction, the program has undefined
 behavior. Terminating every thread before a call to \tcode{std::exit} or the exit from
@@ -2857,10 +2857,10 @@ one of the following:
 \indextext{storage duration!automatic}%
 \indextext{storage duration!dynamic}%
 Static, thread, and automatic storage durations are associated with objects
-introduced by declarations~(\ref{basic.def}) and implicitly created by
-the implementation~(\ref{class.temporary}). The dynamic storage duration
+introduced by declarations\iref{basic.def} and implicitly created by
+the implementation\iref{class.temporary}. The dynamic storage duration
 is associated with objects created by a
-\grammarterm{new-expression}~(\ref{expr.new}).
+\grammarterm{new-expression}\iref{expr.new}.
 
 \pnum
 The storage duration categories apply to references as well.
@@ -2869,7 +2869,7 @@ The storage duration categories apply to references as well.
 When the end of the duration of a region of storage is reached,
 the values of all pointers
 representing the address of any part of that region of storage
-become invalid pointer values~(\ref{basic.compound}).
+become invalid pointer values\iref{basic.compound}.
 Indirection through an invalid pointer value and
 passing an invalid pointer value to a deallocation function
 have undefined behavior.
@@ -2919,7 +2919,7 @@ the current thread.
 
 \pnum
 A variable with thread storage duration shall be initialized before
-its first odr-use~(\ref{basic.def.odr}) and, if constructed, shall be destroyed on thread exit.
+its first odr-use\iref{basic.def.odr} and, if constructed, shall be destroyed on thread exit.
 
 \rSec2[basic.stc.auto]{Automatic storage duration}
 
@@ -2948,11 +2948,11 @@ specified in~\ref{class.copy}.
 
 \pnum
 Objects can be created dynamically during program
-execution~(\ref{intro.execution}), using
+execution\iref{intro.execution}, using
 \indextext{\idxcode{new}}%
-\grammarterm{new-expression}{s}~(\ref{expr.new}), and destroyed using
+\grammarterm{new-expression}{s}\iref{expr.new}, and destroyed using
 \indextext{\idxcode{delete}}%
-\grammarterm{delete-expression}{s}~(\ref{expr.delete}). A \Cpp implementation
+\grammarterm{delete-expression}{s}\iref{expr.delete}. A \Cpp implementation
 provides access to, and management of, dynamic storage via the global
 \defn{allocation functions} \tcode{operator new} and \tcode{operator
 new[]} and the global \defn{deallocation functions} \tcode{operator
@@ -2965,11 +2965,11 @@ do not perform allocation or deallocation.
 \pnum
 The library provides default definitions for the global allocation and
 deallocation functions. Some global allocation and deallocation
-functions are replaceable~(\ref{new.delete}). A \Cpp program shall
+functions are replaceable\iref{new.delete}. A \Cpp program shall
 provide at most one definition of a replaceable allocation or
 deallocation function. Any such function definition replaces the default
-version provided in the library~(\ref{replacement.functions}). The
-following allocation and deallocation functions~(\ref{support.dynamic})
+version provided in the library\iref{replacement.functions}. The
+following allocation and deallocation functions\iref{support.dynamic}
 are implicitly declared in global scope in each translation unit of a
 program.
 
@@ -3008,7 +3008,7 @@ or \tcode{std::align_val_t}
 is ill-formed unless the name has been declared
 by including the appropriate header. \end{note} Allocation and/or
 deallocation functions may also be declared and defined for any
-class~(\ref{class.free}).
+class\iref{class.free}.
 
 \pnum
 Any allocation and/or deallocation functions defined in a \Cpp program,
@@ -3024,9 +3024,9 @@ An allocation function shall be a class member function or a global
 function; a program is ill-formed if an allocation function is declared
 in a namespace scope other than global scope or declared static in
 global scope. The return type shall be \tcode{void*}. The first
-parameter shall have type \tcode{std::size_t}~(\ref{support.types}). The
+parameter shall have type \tcode{std::size_t}\iref{support.types}. The
 first parameter shall not have an associated default
-argument~(\ref{dcl.fct.default}). The value of the first parameter shall
+argument\iref{dcl.fct.default}. The value of the first parameter shall
 be interpreted as the requested size of the allocation. An allocation
 function can be a function template. Such a template shall declare its
 return type and first parameter as specified above (that is, template
@@ -3042,12 +3042,12 @@ allocated storage on return from the allocation function. The order,
 contiguity, and initial value of storage allocated by successive calls
 to an allocation function are unspecified. The pointer returned shall be
 suitably aligned so that it can be converted to a pointer to any
-suitable complete object type~(\ref{new.delete.single})
+suitable complete object type\iref{new.delete.single}
 and then used to access the object or array in the
 storage allocated (until the storage is explicitly deallocated by a call
 to a corresponding deallocation function). Even if the size of the space
 requested is zero, the request can fail. If the request succeeds, the
-value returned shall be a non-null pointer value~(\ref{conv.ptr})
+value returned shall be a non-null pointer value\iref{conv.ptr}
 \tcode{p0} different from any previously returned value \tcode{p1},
 unless that value \tcode{p1} was subsequently passed to an
 \tcode{operator} \tcode{delete}.
@@ -3064,30 +3064,30 @@ to return a non-null pointer.}
 
 \pnum
 An allocation function that fails to allocate storage can invoke the
-currently installed new-handler function~(\ref{new.handler}), if any.
+currently installed new-handler function\iref{new.handler}, if any.
 \begin{note}
 \indextext{\idxcode{new_handler}}%
 A program-supplied allocation function can obtain the address of the
 currently installed \tcode{new_handler} using the
-\tcode{std::get_new_handler} function~(\ref{set.new.handler}). \end{note}
+\tcode{std::get_new_handler} function\iref{set.new.handler}. \end{note}
 If an allocation function that has a non-throwing
-exception specification~(\ref{except.spec})
+exception specification\iref{except.spec}
 fails to allocate storage, it shall return a null pointer. Any other
 allocation function that fails to allocate storage shall indicate
-failure only by throwing an exception~(\ref{except.throw}) of a type
-that would match a handler~(\ref{except.handle}) of type
-\tcode{std::bad_alloc}~(\ref{bad.alloc}).
+failure only by throwing an exception\iref{except.throw} of a type
+that would match a handler\iref{except.handle} of type
+\tcode{std::bad_alloc}\iref{bad.alloc}.
 
 \pnum
 A global allocation function is only called as the result of a new
-expression~(\ref{expr.new}), or called directly using the function call
-syntax~(\ref{expr.call}), or called indirectly through calls to the
+expression\iref{expr.new}, or called directly using the function call
+syntax\iref{expr.call}, or called indirectly through calls to the
 functions in the \Cpp standard library. \begin{note} In particular, a
 global allocation function is not called to allocate storage for objects
-with static storage duration~(\ref{basic.stc.static}), for objects or references
-with thread storage duration~(\ref{basic.stc.thread}), for objects of
-type \tcode{std::type_info}~(\ref{expr.typeid}), or for an
-exception object~(\ref{except.throw}).
+with static storage duration\iref{basic.stc.static}, for objects or references
+with thread storage duration\iref{basic.stc.thread}, for objects of
+type \tcode{std::type_info}\iref{expr.typeid}, or for an
+exception object\iref{except.throw}.
 \end{note}
 
 \rSec3[basic.stc.dynamic.deallocation]{Deallocation functions}
@@ -3141,7 +3141,7 @@ supplied in the standard library, the call has no effect.
 
 \pnum
 If the argument given to a deallocation function in the standard library
-is a pointer that is not the null pointer value~(\ref{conv.ptr}), the
+is a pointer that is not the null pointer value\iref{conv.ptr}, the
 deallocation function shall deallocate the storage referenced by the
 pointer, ending the duration of the region of storage.
 
@@ -3153,11 +3153,11 @@ pointer, ending the duration of the region of storage.
 A \defn{traceable pointer object} is
 \begin{itemize}
 \item an object of an object pointer
-type~(\ref{basic.compound}), or
+type\iref{basic.compound}, or
 \item an object of an integral type that is at least as large as \tcode{std::intptr_t},
 or
 \item a sequence of elements in an array of narrow character
-type~(\ref{basic.fundamental}), where the size and alignment of the sequence
+type\iref{basic.fundamental}, where the size and alignment of the sequence
 match those of some object pointer type.
 \end{itemize}
 
@@ -3178,7 +3178,7 @@ because indirection through pointers to memory allocated by \tcode{std::malloc} 
   subobjects) designated by an lvalue resulting from indirection
   through a safely-derived pointer value;
 
-\item the result of well-defined pointer arithmetic~(\ref{expr.add}) using a safely-derived pointer
+\item the result of well-defined pointer arithmetic\iref{expr.add} using a safely-derived pointer
 value;
 
 \item the result of a well-defined pointer
@@ -3225,7 +3225,7 @@ safety}, in which case a pointer value referring to an object with dynamic
 storage duration that is not a safely-derived pointer
 value is an invalid pointer value unless
 the referenced complete object has previously been declared
-reachable~(\ref{util.dynamic.safety}). \begin{note}
+reachable\iref{util.dynamic.safety}. \begin{note}
 The effect of using an invalid pointer value (including passing it to a
 deallocation function) is undefined, see~\ref{basic.stc}.
 This is true even if the unsafely-derived pointer value might compare equal to
@@ -3240,7 +3240,7 @@ safety} whether an implementation has relaxed or strict pointer safety.%
 \pnum
 \indextext{storage duration!class member}%
 The storage duration of subobjects and reference members
-is that of their complete object~(\ref{intro.object}).
+is that of their complete object\iref{intro.object}.
 \indextext{storage duration|)}%
 
 \rSec1[basic.life]{Object lifetime}
@@ -3266,9 +3266,9 @@ or as described in \ref{class.union}.
 The lifetime of an object \placeholder{o} of type \tcode{T} ends when:
 \begin{itemize}
 \item if \tcode{T} is a class type with a non-trivial
-destructor~(\ref{class.dtor}), the destructor call starts, or
+destructor\iref{class.dtor}, the destructor call starts, or
 \item the storage which the object occupies is released,
-or is reused by an object that is not nested within \placeholder{o}~(\ref{intro.object}).
+or is reused by an object that is not nested within \placeholder{o}\iref{intro.object}.
 \end{itemize}
 
 \pnum
@@ -3298,7 +3298,7 @@ object of a class type with a non-trivial destructor. For an object of a
 class type with a non-trivial destructor, the program is not required to
 call the destructor explicitly before the storage which the object
 occupies is reused or released; however, if there is no explicit call to
-the destructor or if a \grammarterm{delete-expression}~(\ref{expr.delete})
+the destructor or if a \grammarterm{delete-expression}\iref{expr.delete}
 is not used to release the storage, the destructor shall not be
 implicitly called and any program that depends on the side effects
 produced by the destructor has undefined behavior.
@@ -3307,7 +3307,7 @@ produced by the destructor has undefined behavior.
 Before the lifetime of an object has started but after the storage which
 the object will occupy has been allocated\footnote{For example, before the
 construction of a global object of
-non-POD class type~(\ref{class.cdtor}).}
+non-POD class type\iref{class.cdtor}.}
 or, after the lifetime of an object has ended and before the storage
 which the object occupied is reused or released, any pointer that represents the address of
 the storage location where the object will be or was located may be
@@ -3315,7 +3315,7 @@ used but only in limited ways.
 For an object under construction or destruction, see~\ref{class.cdtor}.
 Otherwise, such
 a pointer refers to allocated
-storage~(\ref{basic.stc.dynamic.deallocation}), and using the pointer as
+storage\iref{basic.stc.dynamic.deallocation}, and using the pointer as
 if the pointer were of type \tcode{void*}, is
 well-defined. Indirection through such a pointer is permitted but the resulting lvalue may only be used in
 limited ways, as described below. The
@@ -3328,19 +3328,19 @@ program has undefined behavior if:
   the pointer is used to access a non-static data member or call a
   non-static member function of the object, or
 \item
-  the pointer is implicitly converted~(\ref{conv.ptr}) to a pointer
+  the pointer is implicitly converted\iref{conv.ptr} to a pointer
   to a virtual base class, or
 \item
   the pointer is used as the operand of a
-  \tcode{static_cast}~(\ref{expr.static.cast}), except when the conversion
+  \tcode{static_cast}\iref{expr.static.cast}, except when the conversion
   is to pointer to \cv{}~\tcode{void}, or to pointer to \cv{}~\tcode{void}
   and subsequently to pointer to
   \cv{}~\tcode{char},
   \cv{}~\tcode{unsigned char}, or
-  \cv{}~\tcode{std::byte}~(\ref{cstddef.syn}), or
+  \cv{}~\tcode{std::byte}\iref{cstddef.syn}, or
 \item
   the pointer is used as the operand of a
-  \tcode{dynamic_cast}~(\ref{expr.dynamic.cast}).
+  \tcode{dynamic_cast}\iref{expr.dynamic.cast}.
 \end{itemize}
 \begin{example}
 \begin{codeblock}
@@ -3381,15 +3381,15 @@ object may be used but only in limited ways.
 For an object under construction or destruction, see~\ref{class.cdtor}.
 Otherwise, such
 a glvalue refers to
-allocated storage~(\ref{basic.stc.dynamic.deallocation}), and using the
+allocated storage\iref{basic.stc.dynamic.deallocation}, and using the
 properties of the glvalue that do not depend on its value is
 well-defined. The program has undefined behavior if:
 \begin{itemize}
 \item the glvalue is used to access the object, or
 \item the glvalue is used to call a non-static member function of the object, or
-\item the glvalue is bound to a reference to a virtual base class~(\ref{dcl.init.ref}), or
+\item the glvalue is bound to a reference to a virtual base class\iref{dcl.init.ref}, or
 \item the glvalue is used as the operand of a
-\tcode{dynamic_cast}~(\ref{expr.dynamic.cast}) or as the operand of
+\tcode{dynamic_cast}\iref{expr.dynamic.cast} or as the operand of
 \tcode{typeid}.
 \end{itemize}
 
@@ -3412,7 +3412,7 @@ location which the original object occupied, and
 class type, does not contain any non-static data member whose type is
 const-qualified or a reference type, and
 
-\item the original object was a most derived object~(\ref{intro.object})
+\item the original object was a most derived object\iref{intro.object}
 of type \tcode{T} and the new object is a most derived object of type
 \tcode{T} (that is, they are not base class subobjects).
 \end{itemize}
@@ -3443,13 +3443,13 @@ c1.f();                         // well-defined; \tcode{c1} refers to a new obje
 If these conditions are not met,
 a pointer to the new object can be obtained from
 a pointer that represents the address of its storage
-by calling \tcode{std::launder}~(\ref{support.dynamic}).
+by calling \tcode{std::launder}\iref{support.dynamic}.
 \end{note}
 
 \pnum
 If a program ends the lifetime of an object of type \tcode{T} with
-static~(\ref{basic.stc.static}), thread~(\ref{basic.stc.thread}),
-or automatic~(\ref{basic.stc.auto})
+static\iref{basic.stc.static}, thread\iref{basic.stc.thread},
+or automatic\iref{basic.stc.auto}
 storage duration and if \tcode{T} has a non-trivial destructor,\footnote{That
 is, an object for which a destructor will be called
 implicitly---upon exit from the block for an object with
@@ -3497,7 +3497,7 @@ void h() {
 
 \pnum
 In this section, ``before'' and ``after'' refer to the ``happens before''
-relation~(\ref{intro.multithread}). \begin{note} Therefore, undefined behavior results
+relation\iref{intro.multithread}. \begin{note} Therefore, undefined behavior results
 if an object that is being constructed in one thread is referenced from another
 thread without adequate synchronization. \end{note}%
 \indextext{object lifetime|)}
@@ -3511,9 +3511,9 @@ thread without adequate synchronization. \end{note}%
 impose requirements on implementations regarding the representation
 of types.
 There are two kinds of types: fundamental types and compound types.
-Types describe objects~(\ref{intro.object}),
-references~(\ref{dcl.ref}),
-or functions~(\ref{dcl.fct}).
+Types describe objects\iref{intro.object},
+references\iref{dcl.ref},
+or functions\iref{dcl.fct}.
 \end{note}
 
 \pnum
@@ -3521,13 +3521,13 @@ or functions~(\ref{dcl.fct}).
 \indextext{type!trivially copyable}%
 For any object (other than a base-class subobject) of trivially copyable type
 \tcode{T}, whether or not the object holds a valid value of type
-\tcode{T}, the underlying bytes~(\ref{intro.memory}) making up the
+\tcode{T}, the underlying bytes\iref{intro.memory} making up the
 object can be copied into an array of
 \tcode{char},
 \tcode{unsigned char}, or
-\tcode{std::byte}~(\ref{cstddef.syn}).%
+\tcode{std::byte}\iref{cstddef.syn}.%
 \footnote{By using, for example, the library
-functions~(\ref{headers}) \tcode{std::memcpy} or \tcode{std::memmove}.}
+functions\iref{headers} \tcode{std::memcpy} or \tcode{std::memmove}.}
 If the content of that array
 is copied back into the object, the object shall
 subsequently hold its original value. \begin{example}
@@ -3544,9 +3544,9 @@ std::memcpy(&obj, buf, N);      // at this point, each subobject of \tcode{obj} 
 For any trivially copyable type \tcode{T}, if two pointers to \tcode{T} point to
 distinct \tcode{T} objects \tcode{obj1} and \tcode{obj2}, where neither
 \tcode{obj1} nor \tcode{obj2} is a base-class subobject, if the underlying
-bytes~(\ref{intro.memory}) making up
+bytes\iref{intro.memory} making up
 \tcode{obj1} are copied into \tcode{obj2},\footnote{By using, for example,
-the library functions~(\ref{headers}) \tcode{std::memcpy} or \tcode{std::memmove}.}
+the library functions\iref{headers} \tcode{std::memcpy} or \tcode{std::memmove}.}
  \tcode{obj2} shall subsequently hold the same value as
 \tcode{obj1}. \begin{example}
 
@@ -3584,13 +3584,13 @@ with that of ISO/IEC 9899 Programming Language C.}
 \pnum
 \indextext{type!incompletely-defined object}%
 A class that has been declared but not defined, an enumeration type in certain
-contexts~(\ref{dcl.enum}), or an array of unknown
+contexts\iref{dcl.enum}, or an array of unknown
 bound or of incomplete element type, is an
 \defnx{incompletely-defined object type}{object type!incompletely-defined}.%
 \footnote{The size and layout of an instance of an incompletely-defined
 object type is unknown.}
 Incompletely-defined object types and \cv{}~\tcode{void} are
-\defnx{incomplete types}{type!incomplete}~(\ref{basic.fundamental}).
+\defnx{incomplete types}{type!incomplete}\iref{basic.fundamental}.
 Objects shall not be defined to have an
 incomplete type.
 
@@ -3646,26 +3646,26 @@ An \defn{object type} is a (possibly cv-qualified) type that is not
 a function type, not a reference type, and not \cv{}~\tcode{void}.
 
 \pnum
-Arithmetic types~(\ref{basic.fundamental}), enumeration types, pointer
-types, pointer to member types~(\ref{basic.compound}),
+Arithmetic types\iref{basic.fundamental}, enumeration types, pointer
+types, pointer to member types\iref{basic.compound},
 \tcode{std::nullptr_t},
 and
-cv-qualified~(\ref{basic.type.qualifier}) versions of these
+cv-qualified\iref{basic.type.qualifier} versions of these
 types are collectively called
 \defnx{scalar types}{scalar type}. Scalar types,
-POD classes (Clause~\ref{class}), arrays of such types and
+POD classes\iref{class}, arrays of such types and
 cv-qualified versions of these
 types are collectively called
 \defnx{POD types}{type!POD}.
-Cv-unqualified scalar types, trivially copyable class types (Clause~\ref{class}), arrays of
+Cv-unqualified scalar types, trivially copyable class types\iref{class}, arrays of
 such types, and cv-qualified versions of these
 types are collectively called \defn{trivially
 copyable types}.
-Scalar types, trivial class types (Clause~\ref{class}),
+Scalar types, trivial class types\iref{class},
 arrays of such types and cv-qualified versions of these
 types are collectively called
 \defn{trivial types}. Scalar types, standard-layout class
-types (Clause~\ref{class}), arrays of such types and
+types\iref{class}, arrays of such types and
 cv-qualified versions of these types
 are collectively called \defn{standard-layout types}.
 
@@ -3676,14 +3676,14 @@ A type is a \defn{literal type} if it is:
 \item a scalar type; or
 \item a reference type; or
 \item an array of literal type; or
-\item a possibly cv-qualified class type (Clause~\ref{class}) that
+\item a possibly cv-qualified class type\iref{class} that
 has all of the following properties:
 \begin{itemize}
 \item it has a trivial destructor,
-\item it is either a closure type~(\ref{expr.prim.lambda.closure}),
-an aggregate type~(\ref{dcl.init.aggr}), or
+\item it is either a closure type\iref{expr.prim.lambda.closure},
+an aggregate type\iref{dcl.init.aggr}, or
 has at least one constexpr constructor or constructor template
-(possibly inherited~(\ref{namespace.udecl}) from a base class)
+(possibly inherited\iref{namespace.udecl} from a base class)
 that is not a copy or move constructor,
 \item if it is a union, at least one of its non-static data members is
 of non-volatile literal type, and
@@ -3705,8 +3705,8 @@ will usable in a constant expression.
 Two types \cvqual{cv1} \tcode{T1} and \cvqual{cv2} \tcode{T2} are
 \defn{layout-compatible} types
 if \tcode{T1} and \tcode{T2} are the same type,
-layout-compatible enumerations~(\ref{dcl.enum}), or
-layout-compatible standard-layout class types~(\ref{class.mem}).
+layout-compatible enumerations\iref{dcl.enum}, or
+layout-compatible standard-layout class types\iref{class.mem}.
 
 \rSec2[basic.fundamental]{Fundamental types}
 
@@ -3735,7 +3735,7 @@ three distinct types, collectively called
 \defnx{narrow character types}{type!narrow character}.
 A \tcode{char}, a \tcode{signed char}, and an
 \tcode{unsigned char} occupy the same amount of storage and have the
-same alignment requirements~(\ref{basic.align}); that is, they have the
+same alignment requirements\iref{basic.align}; that is, they have the
 same object representation. For narrow character types, all bits of the object
 representation participate in the value representation.
 \begin{note}
@@ -3752,7 +3752,7 @@ char}; which one is \impldef{representation of \tcode{char}}.
 For each value \placeholder{i} of type \tcode{unsigned char} in the range
 0 to 255 inclusive, there exists a value \placeholder{j} of type
 \tcode{char} such that the result of an integral
-conversion~(\ref{conv.integral}) from \placeholder{i} to \tcode{char} is
+conversion\iref{conv.integral} from \placeholder{i} to \tcode{char} is
 \placeholder{j}, and the result of an integral conversion from
 \placeholder{j} to \tcode{unsigned char} is \placeholder{i}.
 
@@ -3800,7 +3800,7 @@ there exists a corresponding (but different)
 ``\tcode{unsigned int}'', ``\tcode{unsigned long int}'', and
 ``\tcode{unsigned long long int}'', each of
 which occupies the same amount of storage and has the same alignment
-requirements~(\ref{basic.align}) as the corresponding signed integer
+requirements\iref{basic.align} as the corresponding signed integer
 type\footnote{See~\ref{dcl.type.simple} regarding the correspondence between types and
 the sequences of \grammarterm{type-specifier}{s} that designate them.};
 that is, each signed integer type has the same object representation as
@@ -3848,9 +3848,9 @@ that can be represented by the resulting unsigned integer type.}
 \indextext{type!underlying!\idxcode{char32_t}}%
 Type \tcode{wchar_t} is a distinct type whose values can represent
 distinct codes for all members of the largest extended character set
-specified among the supported locales~(\ref{locale}). Type
+specified among the supported locales\iref{locale}. Type
 \tcode{wchar_t} shall have the same size, signedness, and alignment
-requirements~(\ref{basic.align}) as one of the other integral types,
+requirements\iref{basic.align} as one of the other integral types,
 called its \defnx{underlying type}{type!underlying!\idxcode{wchar_t}}. Types \tcode{char16_t} and
 \tcode{char32_t} denote distinct types with the same size, signedness,
 and alignment as \tcode{uint_least16_t} and \tcode{uint_least32_t},
@@ -3865,13 +3865,13 @@ uninitialized automatic object, might cause it to behave as if it is
 neither \tcode{true} nor \tcode{false}.}
 \begin{note} There are no \tcode{signed}, \tcode{unsigned}, \tcode{short},
 or \tcode{long bool} types or values. \end{note} Values of type
-\tcode{bool} participate in integral promotions~(\ref{conv.prom}).
+\tcode{bool} participate in integral promotions\iref{conv.prom}.
 
 \pnum
 Types \tcode{bool}, \tcode{char}, \tcode{char16_t}, \tcode{char32_t},
 \tcode{wchar_t}, and the signed and unsigned integer types are
 collectively called
-\defnx{integral}{integral type} types.\footnote{Therefore, enumerations~(\ref{dcl.enum}) are not integral; however,
+\defnx{integral}{integral type} types.\footnote{Therefore, enumerations\iref{dcl.enum} are not integral; however,
 enumerations can be promoted to integral types as specified
 in~\ref{conv.prom}.}
 A synonym for integral type is
@@ -3914,7 +3914,7 @@ Integral and floating types are collectively
 called \defnx{arithmetic}{type!arithmetic} types.
 \indextext{\idxcode{numeric_limits}!specializations for arithmetic types}%
 Specializations of the standard library template
-\tcode{std::numeric_limits}~(\ref{support.limits}) shall specify the
+\tcode{std::numeric_limits}\iref{support.limits} shall specify the
 maximum and minimum values of each arithmetic type for an
 implementation.
 
@@ -3924,19 +3924,19 @@ A type \cv{}~\tcode{void}
 is an incomplete type that cannot be completed; such a type has
 an empty set of values. It is used as the return
 type for functions that do not return a value. Any expression can be
-explicitly converted to type \cv{}~\tcode{void}~(\ref{expr.cast}).
+explicitly converted to type \cv{}~\tcode{void}\iref{expr.cast}.
 An expression of type \cv{}~\tcode{void} shall
-be used only as an expression statement~(\ref{stmt.expr}), as an operand
-of a comma expression~(\ref{expr.comma}), as a second or third operand
-of \tcode{?:}~(\ref{expr.cond}), as the operand of
+be used only as an expression statement\iref{stmt.expr}, as an operand
+of a comma expression\iref{expr.comma}, as a second or third operand
+of \tcode{?:}\iref{expr.cond}, as the operand of
 \tcode{typeid}, \tcode{noexcept}, or \tcode{decltype}, as
-the expression in a return statement~(\ref{stmt.return}) for a function
+the expression in a return statement\iref{stmt.return} for a function
 with the return type \cv{}~\tcode{void}, or as the operand of an explicit conversion
 to type \cv{}~\tcode{void}.
 
 \pnum
 A value of type \tcode{std::nullptr_t} is a null pointer
-constant~(\ref{conv.ptr}). Such values participate in the pointer and the
+constant\iref{conv.ptr}. Such values participate in the pointer and the
 pointer to member conversions~(\ref{conv.ptr}, \ref{conv.mem}).
 \tcode{sizeof(std::nullptr_t)} shall be equal to \tcode{sizeof(void*)}.
 
@@ -3972,9 +3972,9 @@ type, \ref{dcl.ref}. There are two types of references:
 
 \item
 \defnx{classes}{class} containing a sequence of objects of various types
-(Clause~\ref{class}), a set of types, enumerations and functions for
-manipulating these objects~(\ref{class.mfct}), and a set of restrictions
-on the access to these entities (Clause~\ref{class.access});
+(\ref{class}), a set of types, enumerations and functions for
+manipulating these objects\iref{class.mfct}, and a set of restrictions
+on the access to these entities\iref{class.access};
 
 \item
 \defnx{unions}{\idxcode{union}}, which are classes capable of containing objects of
@@ -3998,7 +3998,7 @@ These methods of constructing types can be applied recursively;
 restrictions are mentioned in~\ref{dcl.ptr}, \ref{dcl.array},
 \ref{dcl.fct}, and~\ref{dcl.ref}. Constructing a type such that the number of
 bytes in its object representation exceeds the maximum value representable in
-the type \tcode{std::size_t}~(\ref{support.types}) is ill-formed.
+the type \tcode{std::size_t}\iref{support.types} is ill-formed.
 
 \pnum
 \indextext{terminology!pointer}%
@@ -4014,16 +4014,16 @@ class \tcode{X} is called a ``pointer to \tcode{X}''. \end{example}
 Except for pointers to static members, text referring to ``pointers''
 does not apply to pointers to members. Pointers to incomplete types are
 allowed although there are restrictions on what can be done with
-them~(\ref{basic.align}).
+them\iref{basic.align}.
 \indextext{address}%
 Every value of pointer type is one of the following:
 \begin{itemize}
 \item
 a \defn{pointer to} an object or function (the pointer is said to \defn{point} to the object or function), or
 \item
-a \defn{pointer past the end of} an object~(\ref{expr.add}), or
+a \defn{pointer past the end of} an object\iref{expr.add}, or
 \item
-the \defn{null pointer value}~(\ref{conv.ptr}) for that type, or
+the \defn{null pointer value}\iref{conv.ptr} for that type, or
 \item
 an \defn{invalid pointer value}.
 \end{itemize}
@@ -4031,14 +4031,14 @@ A value of a
 pointer type
 that is a pointer to or past the end of an object
 \defn{represents the address} of
-the first byte in memory~(\ref{intro.memory}) occupied by the object%
+the first byte in memory\iref{intro.memory} occupied by the object%
 \footnote{For an object that is not within its lifetime,
 this is the first byte in memory that it will occupy or used to occupy.}
 or the first byte in memory
 after the end of the storage occupied by the object,
 respectively.
 \begin{note}
-A pointer past the end of an object~(\ref{expr.add})
+A pointer past the end of an object\iref{expr.add}
 is not considered to point to an unrelated object
 of the object's type
 that might be located at that address.
@@ -4047,7 +4047,7 @@ when the storage it denotes
 reaches the end of its storage duration;
 see \ref{basic.stc}.
 \end{note}
-For purposes of pointer arithmetic~(\ref{expr.add})
+For purposes of pointer arithmetic\iref{expr.add}
 and comparison~(\ref{expr.rel}, \ref{expr.eq}),
 a pointer past the end of the last element of
 an array \tcode{x} of $n$ elements
@@ -4057,8 +4057,8 @@ The value representation of
 pointer types is \impldef{value representation of pointer types}. Pointers to
 layout-compatible types shall
 have the same value representation and alignment
-requirements~(\ref{basic.align}).
-\begin{note} Pointers to over-aligned types~(\ref{basic.align}) have no special
+requirements\iref{basic.align}.
+\begin{note} Pointers to over-aligned types\iref{basic.align} have no special
 representation, but their range of valid values is restricted by the extended
 alignment requirement.\end{note}
 
@@ -4069,12 +4069,12 @@ Two objects \placeholder{a} and \placeholder{b} are \defn{pointer-interconvertib
 they are the same object, or
 \item
 one is a union object and
-the other is a non-static data member of that object~(\ref{class.union}), or
+the other is a non-static data member of that object\iref{class.union}, or
 \item
 one is a standard-layout class object and
 the other is the first non-static data member of that object, or,
 if the object has no non-static data members,
-the first base class subobject of that object~(\ref{class.mem}), or
+the first base class subobject of that object\iref{class.mem}, or
 \item
 there exists an object \placeholder{c} such that
 \placeholder{a} and \placeholder{c} are pointer-interconvertible, and
@@ -4084,7 +4084,7 @@ If two objects are pointer-interconvertible,
 then they have the same address,
 and it is possible to obtain a pointer to one
 from a pointer to the other
-via a \tcode{reinterpret_cast}~(\ref{expr.reinterpret.cast}).
+via a \tcode{reinterpret_cast}\iref{expr.reinterpret.cast}.
 \begin{note}
 An array object and its first element are not pointer-interconvertible,
 even though they have the same address.
@@ -4093,7 +4093,7 @@ even though they have the same address.
 \pnum
 \indextext{pointer|seealso{\tcode{void*}}}%
 \indextext{\idxcode{void*}!type}%
-A pointer to \cv-qualified~(\ref{basic.type.qualifier}) or \cv-unqualified
+A pointer to \cv-qualified\iref{basic.type.qualifier} or \cv-unqualified
 \tcode{void}
 can be used to point to objects of
 unknown type. Such a pointer shall be able to hold any object pointer.
@@ -4110,15 +4110,15 @@ requirements as \cv{}~\tcode{char*}.
 A type mentioned in~\ref{basic.fundamental} and~\ref{basic.compound} is
 a \defnx{cv-unqualified type}{type!cv-unqualified}. Each type which is a
 cv-unqualified complete or incomplete object type or is
-\tcode{void}~(\ref{basic.types}) has three corresponding cv-qualified
+\tcode{void}\iref{basic.types} has three corresponding cv-qualified
 versions of its type: a \defn{const-qualified} version, a
 \defn{volatile-qualified} version, and a
 \defn{const-volatile-qualified} version. The
-type of an object~(\ref{intro.object}) includes the \grammarterm{cv-qualifier}{s}
-specified in the \grammarterm{decl-specifier-seq}~(\ref{dcl.spec}),
-\grammarterm{declarator} (Clause~\ref{dcl.decl}),
-\grammarterm{type-id}~(\ref{dcl.name}), or
-\grammarterm{new-type-id}~(\ref{expr.new}) when the object is created.
+type of an object\iref{intro.object} includes the \grammarterm{cv-qualifier}{s}
+specified in the \grammarterm{decl-specifier-seq}\iref{dcl.spec},
+\grammarterm{declarator}\iref{dcl.decl},
+\grammarterm{type-id}\iref{dcl.name}, or
+\grammarterm{new-type-id}\iref{expr.new} when the object is created.
 \begin{itemize}
 \item A \defnx{const object}{object!const} is an object of type \tcode{const T} or a
   non-mutable subobject of such an object.
@@ -4135,17 +4135,17 @@ specified in the \grammarterm{decl-specifier-seq}~(\ref{dcl.spec}),
 The cv-qualified or
 cv-unqualified versions of a type
 are distinct types; however, they shall have the same representation and
-alignment requirements~(\ref{basic.align}).\footnote{The same representation
+alignment requirements\iref{basic.align}.\footnote{The same representation
 and alignment requirements are meant to imply
 interchangeability as arguments to functions, return values from
 functions, and non-static data members of unions.}
 
 \pnum
 \indextext{array!\idxcode{const}}%
-A compound type~(\ref{basic.compound}) is not cv-qualified by the
+A compound type\iref{basic.compound} is not cv-qualified by the
 cv-qualifiers (if any) of the types from which it is compounded. Any
 cv-qualifiers applied to an array type
-affect the array element type~(\ref{dcl.array}).
+affect the array element type\iref{dcl.array}.
 
 \pnum
 See~\ref{dcl.fct} and~\ref{class.this} regarding function
@@ -4225,7 +4225,7 @@ or computes the value of the operand of an operator,
 as specified by the context in which it appears.
 \item An \defn{xvalue} is a glvalue that denotes an object or bit-field whose resources can be reused (usually because it is near the end of its lifetime).
 \begin{example}
-Certain kinds of expressions involving rvalue references~(\ref{dcl.ref}) yield xvalues,
+Certain kinds of expressions involving rvalue references\iref{dcl.ref} yield xvalues,
 such as a call to a function whose return type is an rvalue reference
 or a cast to an rvalue reference type.
 \end{example}
@@ -4244,7 +4244,7 @@ Despite their names, these terms classify expressions, not values.
 Every expression belongs to exactly one of the fundamental classifications in this
 taxonomy: lvalue, xvalue, or prvalue. This property of an expression is called
 its \defn{value category}. \begin{note} The discussion of each built-in operator in
-Clause~\ref{expr} indicates the category of the value it yields and the value categories
+\ref{expr} indicates the category of the value it yields and the value categories
 of the operands it expects. For example, the built-in assignment operators expect that
 the left operand is an lvalue and that the right operand is a prvalue and yield an
 lvalue as the result. User-defined operators are functions, and the categories of
@@ -4264,7 +4264,7 @@ has no result object.
 \begin{note}
 Except when the prvalue is the operand of a \grammarterm{decltype-specifier},
 a prvalue of class or array type always has a result object.
-For a discarded prvalue, a temporary object is materialized; see Clause~\ref{expr}.
+For a discarded prvalue, a temporary object is materialized; see \ref{expr}.
 \end{note}
 The \defnx{result}{result!glvalue} of a glvalue is the entity denoted by the expression.
 
@@ -4277,8 +4277,8 @@ An attempt to bind an rvalue reference to an lvalue is not such a context; see~\
 \end{note}
 \begin{note}
 There are no prvalue bit-fields; if a bit-field is converted to a
-prvalue~(\ref{conv.lval}), a prvalue of the type of the bit-field is
-created, which might then be promoted~(\ref{conv.prom}).
+prvalue\iref{conv.lval}, a prvalue of the type of the bit-field is
+created, which might then be promoted\iref{conv.prom}.
 \end{note}
 
 \pnum
@@ -4293,13 +4293,13 @@ temporaries in~\ref{class.temporary} indicates the behavior of lvalues
 and rvalues in other significant contexts.
 
 \pnum
-Unless otherwise indicated~(\ref{expr.call}),
+Unless otherwise indicated\iref{expr.call},
 a prvalue shall always have complete type or the \tcode{void} type.
 A glvalue shall not have type \cv{}~\tcode{void}.
 \begin{note}
 A glvalue may have complete or incomplete non-\tcode{void} type.
 Class and array prvalues can have cv-qualified types; other prvalues
-always have cv-unqualified types. See Clause~\ref{expr}.
+always have cv-unqualified types. See \ref{expr}.
 \end{note}
 
 \pnum
@@ -4349,14 +4349,14 @@ may be allocated. An \defn{alignment} is an \impldef{alignment}
 integer value representing the number of bytes between successive addresses
 at which a given object can be allocated. An object type imposes an alignment
 requirement on every object of that type; stricter alignment can be requested
-using the alignment specifier~(\ref{dcl.align}).
+using the alignment specifier\iref{dcl.align}.
 
 \pnum
 \indextext{alignment!fundamental}%
 A \defn{fundamental alignment} is represented by an alignment
 less than or equal to the greatest alignment supported by the implementation in
 all contexts, which is equal to
-\tcode{alignof(std::max_align_t)}~(\ref{support.types}).
+\tcode{alignof(std::max_align_t)}\iref{support.types}.
 The alignment required for a type might be different when it is used as the type
 of a complete object and when it is used as the type of a subobject. \begin{example}
 \begin{codeblock}
@@ -4379,13 +4379,13 @@ requirement of the type in the complete-object case.
 An \defn{extended alignment} is represented by an alignment
 greater than \tcode{alignof(std::max_align_t)}. It is \impldef{support for extended alignments}
 whether any extended alignments are supported and the contexts in which they are
-supported~(\ref{dcl.align}). A type having an extended alignment
+supported\iref{dcl.align}. A type having an extended alignment
 requirement is an \defnx{over-aligned type}{type!over-aligned}. \begin{note}
 Every over-aligned type is or contains a class type
 to which extended alignment applies (possibly through a non-static data member).
 \end{note}
 A \defn{new-extended alignment} is represented by
-an alignment greater than \mname{STDCPP_DEFAULT_NEW_ALIGNMENT}~(\ref{cpp.predefined}).
+an alignment greater than \mname{STDCPP_DEFAULT_NEW_ALIGNMENT}\iref{cpp.predefined}.
 
 \pnum
 Alignments are represented as values of the type \tcode{std::size_t}.
@@ -4403,11 +4403,11 @@ requirement also satisfies any weaker valid alignment requirement.
 
 \pnum
 The alignment requirement of a complete type can be queried using an
-\tcode{alignof} expression~(\ref{expr.alignof}). Furthermore,
-the narrow character types~(\ref{basic.fundamental}) shall have the weakest
+\tcode{alignof} expression\iref{expr.alignof}. Furthermore,
+the narrow character types\iref{basic.fundamental} shall have the weakest
 alignment requirement.
 \begin{note} This enables the narrow character types to be used as the
-underlying type for an aligned memory area~(\ref{dcl.align}).\end{note}
+underlying type for an aligned memory area\iref{dcl.align}.\end{note}
 
 \pnum
 Comparing alignments is meaningful and provides the obvious results:
@@ -4419,9 +4419,9 @@ Comparing alignments is meaningful and provides the obvious results:
 \end{itemize}
 
 \pnum
-\begin{note} The runtime pointer alignment function~(\ref{ptr.align})
+\begin{note} The runtime pointer alignment function\iref{ptr.align}
 can be used to obtain an aligned pointer within a buffer; the aligned-storage templates
-in the library~(\ref{meta.trans.other}) can be used to obtain aligned storage.
+in the library\iref{meta.trans.other} can be used to obtain aligned storage.
 \end{note}
 
 \pnum

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -80,8 +80,8 @@ whenever it is named.
 
 \pnum
 If a class is marked with the \grammarterm{class-virt-specifier} \tcode{final} and it appears
-as a \grammarterm{class-or-decltype} in a \grammarterm{base-clause}
-(\ref{class.derived}), the program is ill-formed. Whenever a
+as a \grammarterm{class-or-decltype} in a \grammarterm{base-clause}\iref{class.derived},
+the program is ill-formed. Whenever a
 \grammarterm{class-key} is followed by a \grammarterm{class-head-name}, the
 \grammarterm{identifier} \tcode{final}, and a colon or left brace, \tcode{final} is
 interpreted as a \grammarterm{class-virt-specifier}. \begin{example}
@@ -928,8 +928,8 @@ Also see~\ref{temp.arg}.
 
 \pnum
 A non-static member function may be called for an object of
-its class type, or for an object of a class derived
-(\ref{class.derived}) from its class type, using the class member
+its class type, or for an object of a class derived\iref{class.derived}
+from its class type, using the class member
 access syntax~(\ref{expr.ref}, \ref{over.match.call}). A non-static
 member function may also be called directly using the function call
 syntax~(\ref{expr.call}, \ref{over.match.call}) from within
@@ -1181,8 +1181,8 @@ members and non-static member functions.
 
 
 \pnum
-Static members obey the usual class member access rules
-(\ref{class.access}). When used in the declaration of a class
+Static members obey the usual class member access rules\iref{class.access}.
+When used in the declaration of a class
 member, the \tcode{static} specifier shall only be used in the member
 declarations that appear within the \grammarterm{member-specification} of
 the class definition.

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -13,7 +13,7 @@
 \indextext{object class|seealso{class object}}%
 A class is a type.
 \indextext{name class|see{class name}}%
-Its name becomes a \grammarterm{class-name}~(\ref{class.name}) within its
+Its name becomes a \grammarterm{class-name}\iref{class.name} within its
 scope.
 
 \begin{bnf}
@@ -23,7 +23,7 @@ scope.
 \end{bnf}
 
 \grammarterm{Class-specifier}{s} and
-\grammarterm{elaborated-type-specifier}{s}~(\ref{dcl.type.elab}) are used to
+\grammarterm{elaborated-type-specifier}{s}\iref{dcl.type.elab} are used to
 make \grammarterm{class-name}{s}. An object of a class consists of a
 (possibly empty) sequence of members and base class objects.
 
@@ -81,7 +81,7 @@ whenever it is named.
 \pnum
 If a class is marked with the \grammarterm{class-virt-specifier} \tcode{final} and it appears
 as a \grammarterm{class-or-decltype} in a \grammarterm{base-clause}
-(Clause~\ref{class.derived}), the program is ill-formed. Whenever a
+(\ref{class.derived}), the program is ill-formed. Whenever a
 \grammarterm{class-key} is followed by a \grammarterm{class-head-name}, the
 \grammarterm{identifier} \tcode{final}, and a colon or left brace, \tcode{final} is
 interpreted as a \grammarterm{class-virt-specifier}. \begin{example}
@@ -115,7 +115,7 @@ as equality comparison, can be defined by the user; see~\ref{over.oper}.
 A \term{union} is a class defined with the \grammarterm{class-key}
 \tcode{union};
 \indextext{access control!\idxcode{union} default member}%
-it holds at most one data member at a time~(\ref{class.union}).
+it holds at most one data member at a time\iref{class.union}.
 \begin{note}
 Aggregates of class type are described in~\ref{dcl.init.aggr}.
 \end{note}
@@ -132,11 +132,11 @@ and move assignment operator~(\ref{class.copy}, \ref{over.ass})
 is either deleted or trivial,
 \item that has at least one non-deleted copy constructor, move constructor,
 copy assignment operator, or move assignment operator, and
-\item that has a trivial, non-deleted destructor~(\ref{class.dtor}).
+\item that has a trivial, non-deleted destructor\iref{class.dtor}.
 \end{itemize}
 
 A \term{trivial class} is a class that is trivially copyable and
-has one or more default constructors~(\ref{class.ctor}),
+has one or more default constructors\iref{class.ctor},
 all of which are either trivial or deleted and
 at least one of which is not deleted.
 \begin{note} In particular, a trivially copyable or trivial class does not have
@@ -149,10 +149,10 @@ A class \tcode{S} is a \defn{standard-layout class} if it:
 \item has no non-static data members of type non-standard-layout class
 (or array of such types) or reference,
 
-\item has no virtual functions~(\ref{class.virtual}) and no
-virtual base classes~(\ref{class.mi}),
+\item has no virtual functions\iref{class.virtual} and no
+virtual base classes\iref{class.mi},
 
-\item has the same access control (Clause~\ref{class.access})
+\item has the same access control\iref{class.access}
 for all non-static data members,
 
 \item has no non-standard-layout base classes,
@@ -166,13 +166,13 @@ its base classes first declared in the same class, and
 as a base class.\footnote{This ensures that two subobjects that have the
 same class type and that
 belong to the same most derived object are not allocated at the same
-address~(\ref{expr.eq}).}
+address\iref{expr.eq}.}
 \end{itemize}
 
 $M(\mathtt{X})$ is defined as follows:
 \begin{itemize}
 \item If \tcode{X} is a non-union class type with no (possibly
-inherited (Clause~\ref{class.derived})) non-static data members, the set
+inherited\iref{class.derived}) non-static data members, the set
 $M(\mathtt{X})$ is empty.
 
 \item If \tcode{X} is a non-union class type whose first non-static data
@@ -268,7 +268,7 @@ If a \grammarterm{class-head-name} contains a \grammarterm{nested-name-specifier
 the \grammarterm{class-specifier} shall refer to a class that was
 previously declared directly in the class or namespace to which the
 \grammarterm{nested-name-specifier} refers,
-or in an element of the inline namespace set~(\ref{namespace.def}) of that namespace
+or in an element of the inline namespace set\iref{namespace.def} of that namespace
 (i.e., not merely inherited or
 introduced by a \grammarterm{using-declaration}), and the
 \grammarterm{class-specifier} shall appear in a namespace enclosing the
@@ -309,7 +309,7 @@ int f(Y);
 \end{codeblock}
 
 \indextext{overloading}%
-declare an overloaded (Clause~\ref{over}) function \tcode{f()} and not
+declare an overloaded\iref{over} function \tcode{f()} and not
 simply a single function \tcode{f()} twice. For the same reason,
 
 \begin{codeblock}
@@ -327,11 +327,11 @@ A class declaration introduces the class name into the scope where
 \indextext{name hiding!class definition}%
 it is declared and hides any
 class, variable, function, or other declaration of that name in an
-enclosing scope~(\ref{basic.scope}). If a class name is declared in a
+enclosing scope\iref{basic.scope}. If a class name is declared in a
 scope where a variable, function, or enumerator of the same name is also
 declared, then when both declarations are in scope, the class can be
 referred to only using an
-\grammarterm{elaborated-type-specifier}~(\ref{basic.lookup.elab}).
+\grammarterm{elaborated-type-specifier}\iref{basic.lookup.elab}.
 \begin{example}
 \begin{codeblock}
 struct stat {
@@ -392,7 +392,7 @@ operator functions in~\ref{over.oper}.
 \indextext{class name!elaborated}%
 \indextext{elaborated type specifier|see{class name, elaborated}}%
 \begin{note}
-An \grammarterm{elaborated-type-specifier}~(\ref{dcl.type.elab}) can also
+An \grammarterm{elaborated-type-specifier}\iref{dcl.type.elab} can also
 be used as a \grammarterm{type-specifier} as part of a declaration. It
 differs from a class declaration in that if a class of the elaborated
 name is in scope the elaborated name will refer to it.
@@ -428,7 +428,7 @@ class. Such artistry with names can be confusing and is best avoided.
 
 \pnum
 \indextext{class name!\idxcode{typedef}}%
-A \grammarterm{typedef-name}~(\ref{dcl.typedef}) that names a class type,
+A \grammarterm{typedef-name}\iref{dcl.typedef} that names a class type,
 or a cv-qualified version thereof, is also a \grammarterm{class-name}. If a
 \grammarterm{typedef-name} that names a cv-qualified class type is used
 where a \grammarterm{class-name} is required, the cv-qualifiers are
@@ -494,10 +494,10 @@ The \grammarterm{member-specification} in a class definition declares the
 full set of members of the class; no member can be added elsewhere.
 A \defn{direct member} of a class \tcode{X} is a member of \tcode{X}
 that was first declared within the \grammarterm{member-specification} of \tcode{X},
-including anonymous union objects~(\ref{class.union.anon}) and direct members thereof.
+including anonymous union objects\iref{class.union.anon} and direct members thereof.
 Members of a class are data members, member
-functions~(\ref{class.mfct}), nested types, enumerators,
-and member templates~(\ref{temp.mem}) and specializations thereof.
+functions\iref{class.mfct}, nested types, enumerators,
+and member templates\iref{temp.mem} and specializations thereof.
 \begin{note}
 A specialization of a static data member template is a static data member.
 A specialization of a member function template is a member function.
@@ -508,14 +508,14 @@ A specialization of a member class template is a nested class.
 A \grammarterm{member-declaration} does not declare new members of the class
 if it is
 \begin{itemize}
-\item a friend declaration~(\ref{class.friend}),
+\item a friend declaration\iref{class.friend},
 \item a \grammarterm{static_assert-declaration},
-\item a \grammarterm{using-declaration}~(\ref{namespace.udecl}), or
+\item a \grammarterm{using-declaration}\iref{namespace.udecl}, or
 \item an \grammarterm{empty-declaration}.
 \end{itemize}
 For any other \grammarterm{member-declaration},
 each declared entity
-that is not an unnamed bit-field~(\ref{class.bit})
+that is not an unnamed bit-field\iref{class.bit}
 is a member of the class,
 and each such \grammarterm{member-declaration}
 shall either
@@ -527,10 +527,10 @@ A \defn{data member} is a non-function member introduced by a
 \grammarterm{member-declarator}.
 A \defn{member function} is a member that is a function.
 Nested types are classes~(\ref{class.name}, \ref{class.nest}) and
-enumerations~(\ref{dcl.enum}) declared in the class and arbitrary types
-declared as members by use of a typedef declaration~(\ref{dcl.typedef})
+enumerations\iref{dcl.enum} declared in the class and arbitrary types
+declared as members by use of a typedef declaration\iref{dcl.typedef}
 or \grammarterm{alias-declaration}.
-The enumerators of an unscoped enumeration~(\ref{dcl.enum}) defined in the class
+The enumerators of an unscoped enumeration\iref{dcl.enum} defined in the class
 are members of the class.
 
 \indextext{member!static}%
@@ -540,14 +540,14 @@ are members of the class.
 A data member or member function
 may be declared \tcode{static} in its \grammarterm{member-declaration},
 in which case it is a \defn{static member} (see~\ref{class.static})
-(a \defn{static data member}~(\ref{class.static.data}) or
-\defn{static member function}~(\ref{class.static.mfct}), respectively)
+(a \defn{static data member}\iref{class.static.data} or
+\defn{static member function}\iref{class.static.mfct}, respectively)
 of the class.
 Any other data member or member function is a \defn{non-static member}
 (a \defn{non-static data member} or
 \defn{non-static member function}~(\ref{class.mfct.non-static}), respectively).
 \begin{note} A non-static data member of non-reference
-type is a member subobject of a class object~(\ref{intro.object}).\end{note}
+type is a member subobject of a class object\iref{intro.object}.\end{note}
 
 \pnum
 A member shall not be declared twice in the
@@ -561,13 +561,13 @@ redeclared with an \grammarterm{enum-specifier}{}.
 \end{itemize}
 \begin{note}
 A single name can denote several member functions provided their types
-are sufficiently different (Clause~\ref{over}).
+are sufficiently different\iref{over}.
 \end{note}
 
 \pnum
 \indextext{completely defined}%
 A class is considered a completely-defined object
-type~(\ref{basic.types}) (or complete type) at the closing \tcode{\}} of
+type\iref{basic.types} (or complete type) at the closing \tcode{\}} of
 the \grammarterm{class-specifier}.
 Within the class
 \grammarterm{member-specification}, the class is regarded as complete
@@ -639,9 +639,9 @@ shall contain a \grammarterm{type-specifier} that is not a \grammarterm{cv-quali
 The
 \grammarterm{member-declarator-list} can be omitted only after a
 \grammarterm{class-specifier} or an \grammarterm{enum-specifier} or in a
-\tcode{friend} declaration~(\ref{class.friend}). A
+\tcode{friend} declaration\iref{class.friend}. A
 \grammarterm{pure-specifier} shall be used only in the declaration of a
-virtual function~(\ref{class.virtual})
+virtual function\iref{class.virtual}
 that is not a \tcode{friend} declaration.
 
 \pnum
@@ -654,7 +654,7 @@ A \grammarterm{virt-specifier-seq} shall contain at most one of each
 \grammarterm{virt-specifier}.
 A \grammarterm{virt-specifier-seq}
 shall appear only in the declaration of a virtual member
-function~(\ref{class.virtual}).
+function\iref{class.virtual}.
 
 \pnum
 \indextext{class object!member}%
@@ -709,17 +709,17 @@ of the \tcode{tword} member of the \tcode{right} subtree of \tcode{s}.
 \pnum
 \indextext{layout!class object}%
 Non-static data members of a (non-union) class
-with the same access control (Clause~\ref{class.access})
+with the same access control\iref{class.access}
 are allocated so that later
 members have higher addresses within a class object.
 \indextext{allocation!unspecified}%
 The order of allocation of non-static data members
 with different access control
-is unspecified (Clause~\ref{class.access}).
+is unspecified\iref{class.access}.
 Implementation alignment requirements might cause two adjacent members
 not to be allocated immediately after each other; so might requirements
-for space for managing virtual functions~(\ref{class.virtual}) and
-virtual base classes~(\ref{class.mi}).
+for space for managing virtual functions\iref{class.virtual} and
+virtual base classes\iref{class.mi}.
 
 \pnum
 If \tcode{T} is the name of a class, then each of the following shall
@@ -731,7 +731,7 @@ have a name different from \tcode{T}:
 \item every member function of class \tcode{T}
 \begin{note}
 This restriction does not apply to constructors, which do not have
-names~(\ref{class.ctor})
+names\iref{class.ctor}
 \end{note};
 
 \item every member of class \tcode{T} that is itself a type;
@@ -747,11 +747,11 @@ unscoped enumerated type; and
 
 \pnum
 In addition, if class \tcode{T} has a user-declared
-constructor~(\ref{class.ctor}), every non-static data member of class
+constructor\iref{class.ctor}, every non-static data member of class
 \tcode{T} shall have a name different from \tcode{T}.
 
 \pnum
-The \defn{common initial sequence} of two standard-layout struct (Clause~\ref{class})
+The \defn{common initial sequence} of two standard-layout struct\iref{class}
 types is the longest sequence of non-static data
 members and bit-fields in declaration order, starting with the first
 such entity in each of the structs, such that corresponding entities
@@ -772,19 +772,19 @@ The common initial sequence of \tcode{A} and \tcode{E} is empty.
 \end{example}
 
 \pnum
-Two standard-layout struct (Clause~\ref{class}) types are
+Two standard-layout struct\iref{class} types are
 \defnx{layout-compatible classes}{layout-compatible!class} if
 their common initial sequence comprises all members and bit-fields of
-both classes~(\ref{basic.types}).
+both classes\iref{basic.types}.
 
 \pnum
 Two standard-layout unions are layout-compatible if they
 have the same number of non-static data members and corresponding
 non-static data members (in any order) have layout-compatible
-types~(\ref{basic.types}).
+types\iref{basic.types}.
 
 \pnum
-In a standard-layout union with an active member~(\ref{class.union})
+In a standard-layout union with an active member\iref{class.union}
 of struct type \tcode{T1}, it is permitted to read a non-static
 data member \tcode{m} of another union member of struct type \tcode{T2}
 provided \tcode{m} is part of the common initial sequence of \tcode{T1} and \tcode{T2};
@@ -802,7 +802,7 @@ int f() {
 \end{example}
 \begin{note}
 Reading a volatile object through a non-volatile glvalue has
-undefined behavior~(\ref{dcl.type.cv}).
+undefined behavior\iref{dcl.type.cv}.
 \end{note}
 
 \pnum
@@ -824,16 +824,16 @@ pointer-interconvertible~(\ref{basic.compound}, \ref{expr.static.cast}).
 \pnum
 \indextext{member function!inline}%
 \indextext{definition!member function}%
-A member function may be defined~(\ref{dcl.fct.def}) in its class
+A member function may be defined\iref{dcl.fct.def} in its class
 definition, in which case it is an \term{inline} member
-function~(\ref{dcl.inline}), or it may be defined outside of its class
+function\iref{dcl.inline}, or it may be defined outside of its class
 definition if it has already been declared but not defined in its class
 definition. A member function definition that appears outside of the
 class definition shall appear in a namespace scope enclosing the class
 definition. Except for member function definitions that appear outside
 of a class definition, and except for explicit specializations of member
 functions of class templates and member function
-templates~(\ref{temp.spec}) appearing outside of the class definition, a
+templates\iref{temp.spec} appearing outside of the class definition, a
 member function shall not be redeclared.
 
 \pnum
@@ -843,7 +843,7 @@ declaration in the class definition or its definition outside of the
 class definition declares the function as \tcode{inline} or \tcode{constexpr}.
 \begin{note}
 Member functions of a class in namespace scope have the linkage of that class.
-Member functions of a local class~(\ref{class.local}) have no linkage.
+Member functions of a local class\iref{class.local} have no linkage.
 See~\ref{basic.link}.
 \end{note}
 
@@ -863,7 +863,7 @@ name using the \tcode{::} operator.
 \begin{note}
 A name used in a member function definition (that is, in the
 \grammarterm{parameter-declaration-clause} including the default
-arguments~(\ref{dcl.fct.default}) or in the member function body) is looked up
+arguments\iref{dcl.fct.default} or in the member function body) is looked up
 as described in~\ref{basic.lookup}.
 \end{note}
 \begin{example}
@@ -929,7 +929,7 @@ Also see~\ref{temp.arg}.
 \pnum
 A non-static member function may be called for an object of
 its class type, or for an object of a class derived
-(Clause~\ref{class.derived}) from its class type, using the class member
+(\ref{class.derived}) from its class type, using the class member
 access syntax~(\ref{expr.ref}, \ref{over.match.call}). A non-static
 member function may also be called directly using the function call
 syntax~(\ref{expr.call}, \ref{over.match.call}) from within
@@ -943,34 +943,34 @@ object that is not of type \tcode{X}, or of a type derived from
 \tcode{X}, the behavior is undefined.
 
 \pnum
-When an \grammarterm{id-expression}~(\ref{expr.prim}) that is not part of a
-class member access syntax~(\ref{expr.ref}) and not used to form a
-pointer to member~(\ref{expr.unary.op}) is used in
+When an \grammarterm{id-expression}\iref{expr.prim} that is not part of a
+class member access syntax\iref{expr.ref} and not used to form a
+pointer to member\iref{expr.unary.op} is used in
 a member of class \tcode{X} in a context where \tcode{this} can be
-used~(\ref{expr.prim.this}),
+used\iref{expr.prim.this},
 if name
-lookup~(\ref{basic.lookup}) resolves the name in the
+lookup\iref{basic.lookup} resolves the name in the
 \grammarterm{id-expression} to a non-static non-type member of some class
 \tcode{C},
 and if either the \grammarterm{id-expression} is potentially evaluated or
 \tcode{C} is \tcode{X} or a base class of \tcode{X},
 the \grammarterm{id-expression} is transformed into a class
-member access expression~(\ref{expr.ref}) using
-\tcode{(*this)}~(\ref{class.this}) as the \grammarterm{postfix-expression}
+member access expression\iref{expr.ref} using
+\tcode{(*this)}\iref{class.this} as the \grammarterm{postfix-expression}
 to the left of the \tcode{.} operator.
 \begin{note}
 If \tcode{C} is not \tcode{X} or a base class of \tcode{X}, the class
 member access expression is ill-formed.
 \end{note}
 Similarly during name lookup, when an
-\grammarterm{unqualified-id}~(\ref{expr.prim}) used in the definition of a
+\grammarterm{unqualified-id}\iref{expr.prim} used in the definition of a
 member function for class \tcode{X} resolves to a static member,
 an enumerator or a nested type of class \tcode{X} or of a base class of
 \tcode{X}, the \grammarterm{unqualified-id} is transformed into a
-\grammarterm{qualified-id}~(\ref{expr.prim}) in which the
+\grammarterm{qualified-id}\iref{expr.prim} in which the
 \grammarterm{nested-name-specifier} names the class of the member function.
 These transformations do not apply in the
-template definition context~(\ref{temp.dep.type}).
+template definition context\iref{temp.dep.type}.
 \indextext{example!member function}%
 \begin{example}
 
@@ -1005,15 +1005,15 @@ call \tcode{n1.set("abc",\&n2,0)}, \tcode{tword} refers to
 \tcode{n1.tword}, and in the call \tcode{n2.set("def",0,0)}, it refers
 to \tcode{n2.tword}. The functions \tcode{strlen}, \tcode{perror}, and
 \tcode{strcpy} are not members of the class \tcode{tnode} and should be
-declared elsewhere.\footnote{See, for example, \tcode{<cstring>}~(\ref{c.strings}).}
+declared elsewhere.\footnote{See, for example, \tcode{<cstring>}\iref{c.strings}.}
 \end{example}
 
 \pnum
 A non-static member function may be declared \tcode{const},
 \tcode{volatile}, or \tcode{const} \tcode{volatile}. These
 \grammarterm{cv-qualifier}{s} affect the type of the \tcode{this}
-pointer~(\ref{class.this}). They also affect the function
-type~(\ref{dcl.fct}) of the member function; a member function declared
+pointer\iref{class.this}. They also affect the function
+type\iref{dcl.fct} of the member function; a member function declared
 \tcode{const} is a \term{const} member function, a member function
 declared \tcode{volatile} is a \term{volatile} member function and a
 member function declared \tcode{const} \tcode{volatile} is a
@@ -1032,11 +1032,11 @@ struct X {
 \end{example}
 
 \pnum
-A non-static member function may be declared with a \grammarterm{ref-qualifier}~(\ref{dcl.fct}); see~\ref{over.match.funcs}.
+A non-static member function may be declared with a \grammarterm{ref-qualifier}\iref{dcl.fct}; see~\ref{over.match.funcs}.
 
 \pnum
 A non-static member function may be declared
-\term{virtual}~(\ref{class.virtual}) or \term{pure virtual}~(\ref{class.abstract}).
+\term{virtual}\iref{class.virtual} or \term{pure virtual}\iref{class.abstract}.
 
 \rSec3[class.this]{The \tcode{this} pointer}%
 \indextext{\idxcode{this}}
@@ -1044,7 +1044,7 @@ A non-static member function may be declared
 
 \pnum
 \indextext{this pointer@\tcode{this} pointer|see{\tcode{this}}}%
-In the body of a non-static~(\ref{class.mfct}) member function, the
+In the body of a non-static\iref{class.mfct} member function, the
 keyword \tcode{this} is a prvalue expression whose value is the
 address of the object for which the function is called.
 \indextext{\idxcode{this}!type of}%
@@ -1082,13 +1082,13 @@ called. This is not allowed in a \tcode{const} member function because
 \end{example}
 
 \pnum
-Similarly, \tcode{volatile} semantics~(\ref{dcl.type.cv}) apply in
+Similarly, \tcode{volatile} semantics\iref{dcl.type.cv} apply in
 \tcode{volatile} member functions when accessing the object and its
 non-static data members.
 
 \pnum
 A cv-qualified member function can be called on an
-object-expression~(\ref{expr.ref}) only if the object-expression is as
+object-expression\iref{expr.ref} only if the object-expression is as
 cv-qualified or less-cv-qualified than the member function.
 \begin{example}
 
@@ -1111,7 +1111,7 @@ and \tcode{s::g()} is a non-\tcode{const} member function, that is,
 \indextext{\idxcode{const}!destructor and}%
 \indextext{\idxcode{volatile}!constructor and}%
 \indextext{\idxcode{volatile}!destructor and}%
-Constructors~(\ref{class.ctor}) and destructors~(\ref{class.dtor}) shall
+Constructors\iref{class.ctor} and destructors\iref{class.dtor} shall
 not be declared \tcode{const}, \tcode{volatile} or \tcode{const}
 \tcode{volatile}. \begin{note} However, these functions can be invoked to
 create and destroy objects with cv-qualified types,
@@ -1124,7 +1124,7 @@ see~\ref{class.ctor} and~\ref{class.dtor}.
 \pnum
 A static member \tcode{s} of class \tcode{X} may be referred to
 using the \grammarterm{qualified-id} expression \tcode{X::s}; it is not
-necessary to use the class member access syntax~(\ref{expr.ref}) to
+necessary to use the class member access syntax\iref{expr.ref} to
 refer to a static member. A static member may be
 referred to using the class member access syntax, in which case the
 object expression is evaluated.
@@ -1145,7 +1145,7 @@ void f() {
 
 \pnum
 A static member may be referred to directly in the scope of its
-class or in the scope of a class derived (Clause~\ref{class.derived})
+class or in the scope of a class derived\iref{class.derived}
 from its class; in this case, the static member is referred to
 as if a \grammarterm{qualified-id} expression was used, with the
 \grammarterm{nested-name-specifier} of the \grammarterm{qualified-id} naming
@@ -1165,9 +1165,9 @@ int Y::i = g();                 // equivalent to \tcode{Y::g();}
 \end{example}
 
 \pnum
-If an \grammarterm{unqualified-id}~(\ref{expr.prim}) is used in the
+If an \grammarterm{unqualified-id}\iref{expr.prim} is used in the
 definition of a static member following the member's
-\grammarterm{declarator-id}, and name lookup~(\ref{basic.lookup.unqual})
+\grammarterm{declarator-id}, and name lookup\iref{basic.lookup.unqual}
 finds that the \grammarterm{unqualified-id} refers to a static
 member, enumerator, or nested type of the member's class (or of a base
 class of the member's class), the \grammarterm{unqualified-id} is
@@ -1182,7 +1182,7 @@ members and non-static member functions.
 
 \pnum
 Static members obey the usual class member access rules
-(Clause~\ref{class.access}). When used in the declaration of a class
+(\ref{class.access}). When used in the declaration of a class
 member, the \tcode{static} specifier shall only be used in the member
 declarations that appear within the \grammarterm{member-specification} of
 the class definition.
@@ -1202,11 +1202,11 @@ functions.
 \pnum
 \begin{note}
 A static member function does not have a \tcode{this}
-pointer~(\ref{class.this}).
+pointer\iref{class.this}.
 \end{note}
 A static member function shall not be \tcode{virtual}. There
 shall not be a static and a non-static member function with the
-same name and the same parameter types~(\ref{over.load}). A
+same name and the same parameter types\iref{over.load}. A
 static member function shall not be declared \tcode{const},
 \tcode{volatile}, or \tcode{const volatile}.
 
@@ -1235,7 +1235,7 @@ In the definition at namespace scope, the name of the static
 data member shall be qualified by its class name using the \tcode{::}
 operator. The \grammarterm{initializer} expression in the definition of a
 static data member is in the scope of its
-class~(\ref{basic.scope.class}).
+class\iref{basic.scope.class}.
 \indextext{example!static member}%
 \begin{example}
 
@@ -1273,9 +1273,9 @@ of integral or enumeration type,
 its declaration in the class definition can specify a
 \grammarterm{brace-or-equal-initializer} in which every
 \grammarterm{initializer-clause} that is an \grammarterm{assignment-expression}
-is a constant expression~(\ref{expr.const}).
+is a constant expression\iref{expr.const}.
 The member shall still be defined in a namespace scope if
-it is odr-used~(\ref{basic.def.odr}) in the program and the
+it is odr-used\iref{basic.def.odr} in the program and the
 namespace scope definition shall not contain an \grammarterm{initializer}.
 An inline static data member may be defined in the class definition
 and may specify a \grammarterm{brace-or-equal-initializer}. If the
@@ -1287,7 +1287,7 @@ static data members shall not specify a \grammarterm{brace-or-equal-initializer}
 \pnum
 \begin{note}
 There shall be exactly one definition of a static data member
-that is odr-used~(\ref{basic.def.odr}) in a program; no diagnostic is required.
+that is odr-used\iref{basic.def.odr} in a program; no diagnostic is required.
 \end{note}
 Unnamed classes and classes contained directly
 or indirectly within unnamed classes shall not contain static
@@ -1295,7 +1295,7 @@ data members.
 
 \pnum
 \begin{note}
-Static data members of a class in namespace scope have the linkage of that class~(\ref{basic.link}). A local class cannot have static data members~(\ref{class.local}).
+Static data members of a class in namespace scope have the linkage of that class\iref{basic.link}. A local class cannot have static data members\iref{class.local}.
 \end{note}
 
 \pnum
@@ -1305,7 +1305,7 @@ non-local variables~(\ref{basic.start.static}, \ref{basic.start.dynamic},
 
 \pnum
 A static data member shall not be
-\tcode{mutable}~(\ref{dcl.stc}).
+\tcode{mutable}\iref{dcl.stc}.
 
 \rSec2[class.bit]{Bit-fields}%
 \indextext{bit-field}
@@ -1326,8 +1326,8 @@ attribute is not part of the type of the class member. The
 with a value greater than or equal to zero. The
 value of the integral constant expression may
 be larger than the number of bits in the object
-representation~(\ref{basic.types}) of the bit-field's type; in such
-cases the extra bits are padding bits~(\ref{basic.types}).
+representation\iref{basic.types} of the bit-field's type; in such
+cases the extra bits are padding bits\iref{basic.types}.
 \indextext{allocation!implementation-defined bit-field}%
 Allocation of bit-fields within a class object is
 \impldef{allocation of bit-fields within a class object}.
@@ -1360,7 +1360,7 @@ when declaring an unnamed bit-field may the value of the
 \pnum
 \indextext{bit-field!type of}%
 A bit-field shall not be a static member. A bit-field shall have
-integral or enumeration type~(\ref{basic.fundamental}).
+integral or enumeration type\iref{basic.fundamental}.
 \indextext{Boolean}%
 A \tcode{bool} value can successfully be stored in a bit-field of any
 nonzero size.
@@ -1371,7 +1371,7 @@ so there are no pointers to bit-fields.
 \indextext{restriction!address of bit-field}%
 \indextext{restriction!pointer to bit-field}%
 A non-const reference shall not be bound to a
-bit-field~(\ref{dcl.init.ref}).
+bit-field\iref{dcl.init.ref}.
 \begin{note}
 If the initializer for a reference of type \tcode{const} \tcode{T\&} is
 an lvalue that refers to a bit-field, the reference is bound to a
@@ -1385,7 +1385,7 @@ type \tcode{bool} of any size (including a one bit bit-field), the
 original \tcode{bool} value and the value of the bit-field shall compare
 equal. If the value of an enumerator is stored into a bit-field of the
 same enumeration type and the number of bits in the bit-field is large
-enough to hold all the values of that enumeration type~(\ref{dcl.enum}),
+enough to hold all the values of that enumeration type\iref{dcl.enum},
 the original enumerator value and the value of the bit-field shall
 compare equal.
 \begin{example}
@@ -1488,10 +1488,10 @@ class E::I2 { };                // definition of nested class
 
 \pnum
 \indextext{friend function!nested class}%
-Like a member function, a friend function~(\ref{class.friend}) defined
+Like a member function, a friend function\iref{class.friend} defined
 within a nested class is in the lexical scope of that class; it obeys
 the same rules for name binding as a static member function of that
-class~(\ref{class.static}), but it has no special access rights to
+class\iref{class.static}, but it has no special access rights to
 members of an enclosing class.
 
 \rSec2[class.nested.type]{Nested type names}
@@ -1527,13 +1527,13 @@ X::I e;                         // OK
 In a union,
 a non-static data member is \defnx{active}{active!union member}
 if its name refers to an object
-whose lifetime has begun and has not ended~(\ref{basic.life}).
+whose lifetime has begun and has not ended\iref{basic.life}.
 At most one of the non-static data members of an object of union type
 can be active at any
 time, that is, the value of at most one of the non-static data members can be
 stored in a union at any time. \begin{note} One special guarantee is made in order to
 simplify the use of unions: If a standard-layout union contains several standard-layout
-structs that share a common initial sequence~(\ref{class.mem}), and
+structs that share a common initial sequence\iref{class.mem}, and
 if a non-static data member of an object of this standard-layout union type
 is active and is one of the standard-layout structs,
 it is permitted to inspect the common initial sequence
@@ -1558,21 +1558,21 @@ union object have the same address.
 \indextext{destructor!\idxcode{union}}%
 A union can have member functions (including constructors and destructors),
 \indextext{restriction!\idxcode{union}}%
-but it shall not have virtual~(\ref{class.virtual}) functions. A union shall not have
+but it shall not have virtual\iref{class.virtual} functions. A union shall not have
 base classes. A union shall not be used as a base class.
 \indextext{restriction!\idxcode{union}}%
 If a union contains a non-static data member of
 reference type the program is ill-formed.
-\begin{note} Absent default member initializers~(\ref{class.mem}),
+\begin{note} Absent default member initializers\iref{class.mem},
 if any non-static data member of a union has a non-trivial
-default constructor~(\ref{class.ctor}),
-copy constructor~(\ref{class.copy}),
-move constructor~(\ref{class.copy}),
-copy assignment operator~(\ref{class.copy}),
-move assignment operator~(\ref{class.copy}),
-or destructor~(\ref{class.dtor}), the corresponding member function
+default constructor\iref{class.ctor},
+copy constructor\iref{class.copy},
+move constructor\iref{class.copy},
+copy assignment operator\iref{class.copy},
+move assignment operator\iref{class.copy},
+or destructor\iref{class.dtor}, the corresponding member function
 of the union must be user-provided or it will
-be implicitly deleted~(\ref{dcl.fct.def.delete}) for the union. \end{note}
+be implicitly deleted\iref{dcl.fct.def.delete} for the union. \end{note}
 
 \pnum
 \begin{example} Consider the following union:
@@ -1585,7 +1585,7 @@ union U {
 };
 \end{codeblock}
 
-Since \tcode{std::string}~(\ref{string.classes}) declares non-trivial versions of all of the special
+Since \tcode{std::string}\iref{string.classes} declares non-trivial versions of all of the special
 member functions, \tcode{U} will have an implicitly deleted default constructor,
 copy/move constructor,
 copy/move assignment operator, and destructor.
@@ -1594,7 +1594,7 @@ must be user-provided.\end{example}
 
 \pnum
 When the left operand of an assignment operator
-involves a member access expression~(\ref{expr.ref})
+involves a member access expression\iref{expr.ref}
 that nominates a union member,
 it may begin the lifetime of that union member,
 as described below.
@@ -1620,8 +1620,8 @@ and empty otherwise.
 Otherwise, $S(\mathtt{E})$ is empty.
 \end{itemize}
 In an assignment expression of the form \tcode{E1 = E2}
-that uses either the built-in assignment operator~(\ref{expr.ass})
-or a trivial assignment operator~(\ref{class.copy}),
+that uses either the built-in assignment operator\iref{expr.ass}
+or a trivial assignment operator\iref{class.copy},
 for each element \tcode{X} of $S($\tcode{E1}$)$,
 if modification of \tcode{X} would have undefined behavior under~\ref{basic.life},
 an object of the type of \tcode{X} is implicitly created
@@ -1632,7 +1632,7 @@ the value computation of the left and right operands
 and before the assignment.
 \begin{note}
 This ends the lifetime of the previously-active
-member of the union, if any~(\ref{basic.life}).
+member of the union, if any\iref{basic.life}.
 \end{note}
 \begin{example}
 \begin{codeblock}
@@ -1649,7 +1649,7 @@ int f() {
 struct X { const int a; int b; };
 union Y { X x; int k; };
 void g() {
-  Y y = { { 1, 2 } };   // OK, \tcode{y.x} is active union member~(\ref{class.mem})
+  Y y = { { 1, 2 } };   // OK, \tcode{y.x} is active union member\iref{class.mem}
   int n = y.x.a;
   y.k = 4;              // OK: ends lifetime of \tcode{y.x}, \tcode{y.k} is active member of union
   y.x.b = n;            // undefined behavior: \tcode{y.x.b} modified outside its lifetime,
@@ -1725,7 +1725,7 @@ allowed in a declaration of an anonymous union in a class scope.
 \indextext{access control!anonymous \tcode{union}}%
 \indextext{restriction!anonymous \tcode{union}}%
 An anonymous union shall not have \tcode{private} or \tcode{protected}
-members (Clause~\ref{class.access}). An anonymous union shall not have
+members\iref{class.access}. An anonymous union shall not have
 member functions.
 
 \pnum
@@ -1786,7 +1786,7 @@ its enclosing scope.
 The local class is in the scope of the enclosing scope, and has the same
 access to names outside the function as does the enclosing function.
 Declarations in a local class
-shall not odr-use~(\ref{basic.def.odr}) a variable with automatic storage
+shall not odr-use\iref{basic.def.odr} a variable with automatic storage
 duration from an
 enclosing scope.
 \begin{example}
@@ -1815,7 +1815,7 @@ local* p = 0;                   // error: \tcode{local} not in scope
 
 \pnum
 An enclosing function has no special access to members of the local
-class; it obeys the usual access rules (Clause~\ref{class.access}).
+class; it obeys the usual access rules\iref{class.access}.
 \indextext{member function!local class}%
 Member functions of a local class shall be defined within their class
 definition, if they are defined at all.

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -8,7 +8,7 @@
 This subclause lists the differences between \Cpp and
 ISO C, by the chapters of this document.
 
-\rSec2[diff.lex]{Clause~\ref{lex}: lexical conventions}
+\rSec2[diff.lex]{\ref{lex}: lexical conventions}
 
 \ref{lex.key}
 \change New Keywords\\
@@ -94,7 +94,7 @@ void f(char*) {
 Programs that have a legitimate reason to treat string literals
 as pointers to potentially modifiable memory are probably rare.
 
-\rSec2[diff.basic]{Clause \ref{basic}: basic concepts}
+\rSec2[diff.basic]{\ref{basic}: basic concepts}
 
 \ref{basic.def}
 \change \Cpp does not have ``tentative definitions'' as in C.\\
@@ -195,7 +195,7 @@ International Standard.
 \howwide
 Common.
 
-\rSec2[diff.conv]{Clause \ref{conv}: standard conversions}
+\rSec2[diff.conv]{\ref{conv}: standard conversions}
 
 \ref{conv.ptr}
 \change Converting \tcode{void*} to a pointer-to-object type requires casting.
@@ -232,7 +232,7 @@ programming practice to add the cast when assigning pointer-to-void to pointer-t
 Some ISO C translators will give a warning
 if the cast is not used.
 
-\rSec2[diff.expr]{Clause \ref{expr}: expressions}
+\rSec2[diff.expr]{\ref{expr}: expressions}
 
 \ref{expr.call}
 \change Implicit declaration of functions is not allowed.
@@ -303,7 +303,7 @@ Programs must add explicit casts to the appropriate rvalue.
 \howwide
 Rare.
 
-\rSec2[diff.stat]{Clause \ref{stmt.stmt}: statements}
+\rSec2[diff.stat]{\ref{stmt.stmt}: statements}
 
 \ref{stmt.switch}, \ref{stmt.goto}
 \change It is now invalid to jump past a declaration with explicit or implicit initializer (except across entire block not entered).
@@ -349,7 +349,7 @@ Seldom.
 For several years, many existing C implementations have produced warnings in
 this case.
 
-\rSec2[diff.dcl]{Clause \ref{dcl.dcl}: declarations}
+\rSec2[diff.dcl]{\ref{dcl.dcl}: declarations}
 
 \ref{dcl.stc}
 \change In \Cpp, the \tcode{static} or \tcode{extern} specifiers can only be applied to names of objects or functions.\\
@@ -533,7 +533,7 @@ enumerator is taken.
 Taking the size of an enumerator is not a
 common C coding practice.
 
-\rSec2[diff.decl]{Clause \ref{dcl.decl}: declarators}
+\rSec2[diff.decl]{\ref{dcl.decl}: declarators}
 
 \ref{dcl.fct}
 \change In \Cpp, a function declared with an empty parameter list takes no arguments.
@@ -661,7 +661,7 @@ string terminating \tcode{'\textbackslash 0'}.
 Seldom.
 This style of array initialization is seen as poor coding style.
 
-\rSec2[diff.class]{Clause \ref{class}: classes}
+\rSec2[diff.class]{\ref{class}: classes}
 
 \ref{class.name} [see also \ref{dcl.typedef}]
 \change In \Cpp, a class declaration introduces the class name into the scope where it is
@@ -788,7 +788,7 @@ Either the type or the struct member has to be renamed.
 \howwide
 Seldom.
 
-\rSec2[diff.special]{Clause \ref{special}: special member functions}
+\rSec2[diff.special]{\ref{special}: special member functions}
 
 \ref{class.copy}
 \change Copying volatile objects.
@@ -836,7 +836,7 @@ can be used.
 \howwide
 Seldom.
 
-\rSec2[diff.cpp]{Clause \ref{cpp}: preprocessing directives}
+\rSec2[diff.cpp]{\ref{cpp}: preprocessing directives}
 
 \ref{cpp.predefined}
 \change Whether \mname{STDC} is defined and if so, what its value is, are
@@ -863,7 +863,7 @@ This subclause lists the differences between \Cpp and
 ISO \CppIII (ISO/IEC 14882:2003, \doccite{Programming Languages --- \Cpp}),
 by the chapters of this document.
 
-\rSec2[diff.cpp03.lex]{Clause \ref{lex}: lexical conventions}
+\rSec2[diff.cpp03.lex]{\ref{lex}: lexical conventions}
 
 \ref{lex.pptoken}
 \change New kinds of string literals.
@@ -922,7 +922,7 @@ Standard.
 Certain integer literals larger than can be represented by \tcode{long} could
 change from an unsigned integer type to \tcode{signed long long}.
 
-\rSec2[diff.cpp03.conv]{Clause~\ref{conv}: standard conversions}
+\rSec2[diff.cpp03.conv]{\ref{conv}: standard conversions}
 
 \ref{conv.ptr}
 \change Only literals are integer null pointer constants.
@@ -939,7 +939,7 @@ template<int N> void g() {
 }
 \end{codeblock}
 
-\rSec2[diff.cpp03.expr]{Clause \ref{expr}: expressions}
+\rSec2[diff.cpp03.expr]{\ref{expr}: expressions}
 
 \ref{expr.mul}
 \change Specify rounding for results of integer \tcode{/} and \tcode{\%}.
@@ -962,7 +962,7 @@ struct S { operator int(); };
 bool b2 = &S::operator int && false;  // previously \tcode{false}, now ill-formed
 \end{codeblock}
 
-\rSec2[diff.cpp03.dcl.dcl]{Clause \ref{dcl.dcl}: declarations}
+\rSec2[diff.cpp03.dcl.dcl]{\ref{dcl.dcl}: declarations}
 
 \ref{dcl.spec}
 \change Remove \tcode{auto} as a storage class specifier.
@@ -973,7 +973,7 @@ specifier may be invalid in this International Standard. In this International
 Standard, \tcode{auto} indicates that the type of a variable is to be deduced
 from its initializer expression.
 
-\rSec2[diff.cpp03.dcl.decl]{Clause \ref{dcl.decl}: declarators}
+\rSec2[diff.cpp03.dcl.decl]{\ref{dcl.decl}: declarators}
 
 \ref{dcl.init.list}
 \change Narrowing restrictions in aggregate initializers.
@@ -988,7 +988,7 @@ conversion:
 int x[] = { 2.0 };
 \end{codeblock}
 
-\rSec2[diff.cpp03.special]{Clause \ref{special}: special member functions}
+\rSec2[diff.cpp03.special]{\ref{special}: special member functions}
 
 \ref{class.ctor}, \ref{class.dtor}, \ref{class.copy}
 \change Implicitly-declared special member functions are defined as deleted
@@ -1008,7 +1008,7 @@ particular, destructors that throw exceptions will call \tcode{std::terminate}
 (without calling \tcode{std::unexpected}) if their exception specification is
 non-throwing.
 
-\rSec2[diff.cpp03.temp]{Clause \ref{temp}: templates}
+\rSec2[diff.cpp03.temp]{\ref{temp}: templates}
 
 \ref{temp.param}
 \change Remove \tcode{export}.
@@ -1043,7 +1043,7 @@ X< Y< 1 >> 2 > > x;
 A valid \CppIII program could get a different result than this
 International Standard.
 
-\rSec2[diff.cpp03.library]{Clause \ref{library}: library introduction}
+\rSec2[diff.cpp03.library]{\ref{library}: library introduction}
 
 \ref{library} -- \ref{\lastlibchapter}
 \change New reserved identifiers.
@@ -1117,7 +1117,7 @@ Names of attribute identifiers may not be used as macro names. Valid \Cpp
 \tcode{carries_dependency}, or \tcode{noreturn} as macros is invalid in this
 International Standard.
 
-\rSec2[diff.cpp03.language.support]{Clause \ref{language.support}:
+\rSec2[diff.cpp03.language.support]{\ref{language.support}:
 language support library}
 
 \ref{new.delete.single}
@@ -1163,7 +1163,7 @@ Valid \CppIII code that assumes that global \tcode{operator new} only
 throws \tcode{std::bad_alloc} may execute differently in this International
 Standard.
 
-\rSec2[diff.cpp03.diagnostics]{Clause \ref{diagnostics}: diagnostics library}
+\rSec2[diff.cpp03.diagnostics]{\ref{diagnostics}: diagnostics library}
 
 \ref{errno}
 \change Thread-local error numbers.
@@ -1172,7 +1172,7 @@ Standard.
 \tcode{errno} being the same across threads may change behavior in this
 International Standard.
 
-\rSec2[diff.cpp03.utilities]{Clause \ref{utilities}: general utilities library}
+\rSec2[diff.cpp03.utilities]{\ref{utilities}: general utilities library}
 
 \ref{util.dynamic.safety}
 \change Minimal support for garbage-collected regions.
@@ -1193,7 +1193,7 @@ Valid \CppIII code that depends on function object types being derived from
 \tcode{unary_function} or \tcode{binary_function} may fail to compile
 in this International Standard.
 
-\rSec2[diff.cpp03.strings]{Clause \ref{strings}: strings library}
+\rSec2[diff.cpp03.strings]{\ref{strings}: strings library}
 
 \ref{string.classes}
 \change \tcode{basic_string} requirements no longer allow reference-counted
@@ -1211,7 +1211,7 @@ Valid \CppIII code may execute differently in this International Standard.
 Some \tcode{const} member functions, such as \tcode{data} and \tcode{c_str},
 no longer invalidate iterators.
 
-\rSec2[diff.cpp03.containers]{Clause \ref{containers}: containers library}
+\rSec2[diff.cpp03.containers]{\ref{containers}: containers library}
 
 \ref{container.requirements}
 \change Complexity of \tcode{size()} member functions now constant.
@@ -1292,7 +1292,7 @@ by value, and an additional overload of \tcode{resize} has been added. Valid
 \CppIII code that uses this function may fail to compile with this International
 Standard.
 
-\rSec2[diff.cpp03.algorithms]{Clause \ref{algorithms}: algorithms library}
+\rSec2[diff.cpp03.algorithms]{\ref{algorithms}: algorithms library}
 
 \ref{algorithms.general}
 \change Result state of inputs after application of some algorithms.
@@ -1304,7 +1304,7 @@ International Standard. For example, \tcode{std::remove} and
 \tcode{std::remove_if} may leave the tail of the input sequence with a
 different set of values than previously.
 
-\rSec2[diff.cpp03.numerics]{Clause \ref{numerics}: numerics library}
+\rSec2[diff.cpp03.numerics]{\ref{numerics}: numerics library}
 
 \ref{complex.numbers}
 \change Specified representation of complex numbers.
@@ -1314,7 +1314,7 @@ Valid \CppIII code that uses implementation-specific knowledge about the
 binary representation of the required template specializations of
 \tcode{std::complex} may not be compatible with this International Standard.
 
-\rSec2[diff.cpp03.input.output]{Clause \ref{input.output}: input/output library}
+\rSec2[diff.cpp03.input.output]{\ref{input.output}: input/output library}
 
 \ref{istream::sentry},
 \ref{ostream::sentry},
@@ -1370,7 +1370,7 @@ This subclause lists the differences between \Cpp and
 ISO \CppXI (ISO/IEC 14882:2011, \doccite{Programming Languages --- \Cpp}),
 by the chapters of this document.
 
-\rSec2[diff.cpp11.lex]{Clause \ref{lex}: lexical conventions}
+\rSec2[diff.cpp11.lex]{\ref{lex}: lexical conventions}
 
 \ref{lex.ppnumber}
 \change \grammarterm{pp-number} can contain one or more single quotes.
@@ -1388,7 +1388,7 @@ int x[2] = { M(1'2,3'4, 5) };
 // \tcode{int x[2] = \{ 3'4, 5 \};} --- this International Standard
 \end{codeblock}
 
-\rSec2[diff.cpp11.basic]{Clause \ref{basic}: basic concepts}
+\rSec2[diff.cpp11.basic]{\ref{basic}: basic concepts}
 
 \ref{basic.stc.dynamic.deallocation}
 \change New usual (non-placement) deallocator.
@@ -1403,17 +1403,17 @@ void operator delete(void*, std::size_t) noexcept;
 
 In this International Standard, however, the declaration of \tcode{operator delete}
 might match a predefined usual (non-placement)
-\tcode{operator delete}~(\ref{basic.stc.dynamic}). If so, the
+\tcode{operator delete}\iref{basic.stc.dynamic}. If so, the
 program is ill-formed, as it was for class member allocation functions and
-deallocation functions~(\ref{expr.new}).
+deallocation functions\iref{expr.new}.
 
-\rSec2[diff.cpp11.expr]{Clause \ref{expr}: expressions}
+\rSec2[diff.cpp11.expr]{\ref{expr}: expressions}
 
 \ref{expr.cond}
 \change A conditional expression with a throw expression as its second or third
 operand keeps the type and value category of the other operand.
-\rationale Formerly mandated conversions (lvalue-to-rvalue~(\ref{conv.lval}),
-array-to-pointer~(\ref{conv.array}), and function-to-pointer~(\ref{conv.func})
+\rationale Formerly mandated conversions (lvalue-to-rvalue\iref{conv.lval},
+array-to-pointer\iref{conv.array}, and function-to-pointer\iref{conv.func}
 standard conversions), especially the creation of the temporary due to
 lvalue-to-rvalue conversion, were considered gratuitous and surprising.
 \effect Valid \CppXI code that relies on the conversions may behave differently
@@ -1441,7 +1441,7 @@ sizeof(true ? "" : throw 0)
 In \CppXI, the expression yields \tcode{sizeof(const char*)}. In this
 International Standard, it yields \tcode{sizeof(const char[1])}.
 
-\rSec2[diff.cpp11.dcl.dcl]{Clause \ref{dcl.dcl}: declarations}
+\rSec2[diff.cpp11.dcl.dcl]{\ref{dcl.dcl}: declarations}
 
 \ref{dcl.constexpr}
 \change \tcode{constexpr} non-static member functions are not implicitly
@@ -1461,7 +1461,7 @@ struct S {
 };
 \end{codeblock}
 
-\rSec2[diff.cpp11.dcl.decl]{Clause \ref{dcl.decl}: declarators}
+\rSec2[diff.cpp11.dcl.decl]{\ref{dcl.decl}: declarators}
 
 \ref{dcl.init.aggr}
 \change Classes with default member initializers can be aggregates.
@@ -1482,7 +1482,7 @@ S b{a};  // uses copy constructor in \CppXI,
          // performs aggregate initialization in this International Standard
 \end{codeblock}
 
-\rSec2[diff.cpp11.library]{Clause \ref{library}: library introduction}
+\rSec2[diff.cpp11.library]{\ref{library}: library introduction}
 
 \ref{headers}
 \change New header.
@@ -1492,7 +1492,7 @@ The \Cpp header \tcode{<shared_mutex>} is new.
 Valid \CppXI code that \tcode{\#include}{s} a header with that name may be
 invalid in this International Standard.
 
-\rSec2[diff.cpp11.input.output]{Clause \ref{input.output}: input/output library}
+\rSec2[diff.cpp11.input.output]{\ref{input.output}: input/output library}
 
 \ref{c.files}
 \change \tcode{gets} is not defined.
@@ -1509,7 +1509,7 @@ This subclause lists the differences between \Cpp and
 ISO \CppXIV (ISO/IEC 14882:2014, \doccite{Programming Languages --- \Cpp}),
 by the chapters of this document.
 
-\rSec2[diff.cpp14.lex]{Clause \ref{lex}: lexical conventions}
+\rSec2[diff.cpp14.lex]{\ref{lex}: lexical conventions}
 
 \ref{lex.phases}
 \indextext{trigraph sequence}%
@@ -1538,7 +1538,7 @@ in this International Standard.
 int b0p = F(0p+0);  // ill-formed; equivalent to ``\tcode{int b0p = b0p + 0;}\!'' in \CppXIV
 \end{codeblock}
 
-\rSec2[diff.cpp14.expr]{Clause \ref{expr}: expressions}
+\rSec2[diff.cpp14.expr]{\ref{expr}: expressions}
 
 \ref{expr.post.incr}, \ref{expr.pre.incr}
 \change
@@ -1561,7 +1561,7 @@ In this International Standard,
 \tcode{::operator new(std::size_t, std::align_val_t)}
 is used instead.
 
-\rSec2[diff.cpp14.dcl.dcl]{Clause \ref{dcl.dcl}: declarations}
+\rSec2[diff.cpp14.dcl.dcl]{\ref{dcl.dcl}: declarations}
 
 \ref{dcl.stc}
 \indextext{\idxcode{register} storage class}%
@@ -1583,7 +1583,7 @@ auto x1{1};    // was \tcode{std::initializer_list<int>}, now \tcode{int}
 auto x2{1, 2}; // was \tcode{std::initializer_list<int>}, now ill-formed
 \end{codeblock}
 
-\rSec2[diff.cpp14.decl]{Clause \ref{dcl.decl}: declarators}
+\rSec2[diff.cpp14.decl]{\ref{dcl.decl}: declarators}
 
 \ref{dcl.fct}
 \change Make exception specifications be part of the type system.
@@ -1621,7 +1621,7 @@ derived d1{};       // Error. The code was well-formed before.
 derived d2;         // still OK
 \end{codeblock}
 
-\rSec2[diff.cpp14.special]{Clause \ref{special}: special member functions}
+\rSec2[diff.cpp14.special]{\ref{special}: special member functions}
 
 \ref{class.inhctor.init}
 \change
@@ -1648,7 +1648,7 @@ B b(42L); // now calls \tcode{B(int)}, used to call \tcode{B<long>(long)},
           // in \tcode{A<long>(long)}.
 \end{codeblock}
 
-\rSec2[diff.cpp14.temp]{Clause \ref{temp}: templates}
+\rSec2[diff.cpp14.temp]{\ref{temp}: templates}
 
 \ref{temp.deduct.type}
 \change Allowance to deduce from the type of a non-type template argument.
@@ -1667,7 +1667,7 @@ void bar(A<0> *p) {
 }
 \end{codeblock}
 
-\rSec2[diff.cpp14.except]{Clause \ref{except}: exception handling}
+\rSec2[diff.cpp14.except]{\ref{except}: exception handling}
 
 \ref{except.spec}
 \change Remove dynamic exception specifications.
@@ -1688,7 +1688,7 @@ will call \tcode{terminate}
 rather than \tcode{unexpected}
 and might not perform stack unwinding prior to such a call.
 
-\rSec2[diff.cpp14.library]{Clause \ref{library}: library introduction}
+\rSec2[diff.cpp14.library]{\ref{library}: library introduction}
 
 \ref{namespace.future}
 \change New reserved namespaces.
@@ -1701,7 +1701,7 @@ is reserved for future standardization.
 Valid \CppXIV code that uses such a top-level namespace,
 e.g., \tcode{std2}, may be invalid in this International Standard.
 
-\rSec2[diff.cpp14.utilities]{Clause \ref{utilities}: general utilities library}
+\rSec2[diff.cpp14.utilities]{\ref{utilities}: general utilities library}
 
 \ref{func.wrap}
 \change Constructors taking allocators removed.
@@ -1727,7 +1727,7 @@ std::unique_ptr<int[]> arr(new int[1]);
 std::shared_ptr<int> ptr(std::move(arr)); // error: \tcode{int(*)[]} is not compatible with \tcode{int*}
 \end{codeblock}
 
-\rSec2[diff.cpp14.string]{Clause \ref{strings}: strings library}
+\rSec2[diff.cpp14.string]{\ref{strings}: strings library}
 
 \ref{basic.string}
 \change Non-const \tcode{.data()} member added.
@@ -1748,7 +1748,7 @@ string s;
 int x = f(s.data()); // ill-formed; previously well-formed
 \end{codeblock}
 
-\rSec2[diff.cpp14.containers]{Clause \ref{containers}: containers library}
+\rSec2[diff.cpp14.containers]{\ref{containers}: containers library}
 
 \ref{associative.reqmts}
 \change Requirements change:
@@ -1775,7 +1775,7 @@ int main() {
 }
 \end{codeblock}
 
-\rSec2[diff.cpp14.depr]{Annex~\ref{depr}: compatibility features}
+\rSec2[diff.cpp14.depr]{\ref{depr}: compatibility features}
 
 \change
 The class templates
@@ -1810,7 +1810,7 @@ This subclause lists the differences between \Cpp and
 ISO \CppXVII (ISO/IEC 14882:2017, \doccite{Programming Languages --- \Cpp}),
 by the chapters of this document.
 
-\rSec2[diff.cpp17.lex]{Clause~\ref{lex}: lexical conventions}
+\rSec2[diff.cpp17.lex]{\ref{lex}: lexical conventions}
 
 \ref{lex.key}
 \change New keywords.\\
@@ -1818,7 +1818,7 @@ by the chapters of this document.
 The \tcode{requires} keyword is added
 to introduce constraints through a \grammarterm{requires-clause} or
 a \grammarterm{requires-expression}. The \tcode{concept} keyword is
-added to enable the definition of concepts~(\ref{temp.concept}).
+added to enable the definition of concepts\iref{temp.concept}.
 \effect
 Valid ISO \CppXVII code using \tcode{concept} or \tcode{requires}
 as an identifier is not valid in this International Standard.
@@ -1848,18 +1848,18 @@ and \tcode{<threads.h>}\indextext{\idxhdr{threads.h}},
 nor are the C headers themselves part of \Cpp.
 
 \pnum
-The \Cpp headers \tcode{<ccomplex>}\indextext{\idxhdr{ccomplex}}~(\ref{depr.ccomplex.syn})
-and \tcode{<ctgmath>}\indextext{\idxhdr{ctgmath}}~(\ref{depr.ctgmath.syn}), as well
+The \Cpp headers \tcode{<ccomplex>}\indextext{\idxhdr{ccomplex}}\iref{depr.ccomplex.syn}
+and \tcode{<ctgmath>}\indextext{\idxhdr{ctgmath}}\iref{depr.ctgmath.syn}, as well
 as their corresponding C headers \tcode{<complex.h>}\indextext{\idxhdr{complex.h}}
 and \tcode{<tgmath.h>}\indextext{\idxhdr{tgmath.h}}, do not contain any of the
 content from the C standard library and instead merely include other headers
 from the \Cpp standard library.
 
 \pnum
-The headers \tcode{<ciso646>}, \tcode{<cstdalign>}~(\ref{depr.cstdalign.syn}),
-and \tcode{<cstdbool>}~(\ref{depr.cstdbool.syn}) are meaningless in \Cpp. Use of
+The headers \tcode{<ciso646>}, \tcode{<cstdalign>}\iref{depr.cstdalign.syn},
+and \tcode{<cstdbool>}\iref{depr.cstdbool.syn} are meaningless in \Cpp. Use of
 the \Cpp headers \tcode{<ccomplex>}, \tcode{<cstdalign>}, \tcode{<cstdbool>},
-and \tcode{<ctgmath>} is deprecated~(\ref{depr.c.headers}).
+and \tcode{<ctgmath>} is deprecated\iref{depr.c.headers}.
 
 \rSec2[diff.mods.to.definitions]{Modifications to definitions}
 
@@ -1869,9 +1869,9 @@ and \tcode{<ctgmath>} is deprecated~(\ref{depr.c.headers}).
 The types \tcode{char16_t} and \tcode{char32_t}
 are distinct types rather than typedefs to existing integral types.
 The tokens \tcode{char16_t} and \tcode{char32_t}
-are keywords in this International Standard~(\ref{lex.key}).
+are keywords in this International Standard\iref{lex.key}.
 They do not appear as macro names defined in
-\tcode{<cuchar>}\indexlibrary{\idxhdr{cuchar}}~(\ref{cuchar.syn}).
+\tcode{<cuchar>}\indexlibrary{\idxhdr{cuchar}}\iref{cuchar.syn}.
 
 \rSec3[diff.wchar.t]{Type \tcode{wchar_t}}
 
@@ -1879,19 +1879,19 @@ They do not appear as macro names defined in
 The type \tcode{wchar_t} is a distinct type rather than a typedef to an
 existing integral type.
 The token \tcode{wchar_t}
-is a keyword in this International Standard~(\ref{lex.key}).
+is a keyword in this International Standard\iref{lex.key}.
 It does not appear as a type name defined in any of
-\tcode{<cstddef>}~(\ref{cstddef.syn})\indexlibrary{\idxhdr{cstddef}},
-\tcode{<cstdlib>}~(\ref{cstdlib.syn})\indexlibrary{\idxhdr{cstdlib}},
-or \tcode{<cwchar>}~(\ref{cwchar.syn})\indexlibrary{\idxhdr{cwchar}}.
+\tcode{<cstddef>}\iref{cstddef.syn}\indexlibrary{\idxhdr{cstddef}},
+\tcode{<cstdlib>}\iref{cstdlib.syn}\indexlibrary{\idxhdr{cstdlib}},
+or \tcode{<cwchar>}\iref{cwchar.syn}\indexlibrary{\idxhdr{cwchar}}.
 
 \rSec3[diff.header.assert.h]{Header \tcode{<assert.h>}}
 \indexlibrary{\idxhdr{assert.h}}%
 
 \pnum
 The token \tcode{static_assert} is a keyword in this International
-Standard~(\ref{lex.key}). It does not appear as a macro name defined
-in \tcode{<cassert>}\indexlibrary{\idxhdr{cassert}}~(\ref{cassert.syn}).
+Standard\iref{lex.key}. It does not appear as a macro name defined
+in \tcode{<cassert>}\indexlibrary{\idxhdr{cassert}}\iref{cassert.syn}.
 
 \rSec3[diff.header.iso646.h]{Header \tcode{<iso646.h>}}
 \indexlibrary{\idxhdr{iso646.h}}%
@@ -1911,7 +1911,7 @@ The tokens
 and
 \tcode{xor_eq}
 are keywords in this International
-Standard~(\ref{lex.key}).
+Standard\iref{lex.key}.
 They do not appear as macro names defined in
 \tcode{<ciso646>}.
 \indexlibrary{\idxhdr{ciso646}}%
@@ -1921,17 +1921,17 @@ They do not appear as macro names defined in
 
 \pnum
 The token \tcode{alignas} is a keyword in this International
-Standard~(\ref{lex.key}). It does not appear as a macro name defined
-in \tcode{<cstdalign>}\indexlibrary{\idxhdr{cstdalign}}~(\ref{depr.cstdalign.syn}).
+Standard\iref{lex.key}. It does not appear as a macro name defined
+in \tcode{<cstdalign>}\indexlibrary{\idxhdr{cstdalign}}\iref{depr.cstdalign.syn}.
 
 \rSec3[diff.header.stdbool.h]{Header \tcode{<stdbool.h>}}
 \indexlibrary{\idxhdr{stdbool.h}}%
 
 \pnum
 The tokens \tcode{bool}, \tcode{true}, and \tcode{false}
-are keywords in this International Standard~(\ref{lex.key}).
+are keywords in this International Standard\iref{lex.key}.
 They do not appear as macro names defined in
-\tcode{<cstdbool>}\indexlibrary{\idxhdr{cstdbool}}~(\ref{depr.cstdbool.syn}).
+\tcode{<cstdbool>}\indexlibrary{\idxhdr{cstdbool}}\iref{depr.cstdbool.syn}.
 
 \rSec3[diff.null]{Macro \tcode{NULL}}
 
@@ -1939,20 +1939,20 @@ They do not appear as macro names defined in
 The macro
 \tcode{NULL},
 defined in any of
-\tcode{<clocale>}~(\ref{c.locales})\indexlibrary{\idxhdr{clocale}},
-\tcode{<cstddef>}~(\ref{cstddef.syn})\indexlibrary{\idxhdr{cstddef}},
-\tcode{<cstdio>}~(\ref{cstdio.syn})\indexlibrary{\idxhdr{cstdio}},
-\tcode{<cstdlib>}~(\ref{cstdlib.syn})\indexlibrary{\idxhdr{cstdlib}},
-\tcode{<cstring>}~(\ref{cstring.syn})\indexlibrary{\idxhdr{cstring}},
-\tcode{<ctime>}~(\ref{ctime.syn})\indexlibrary{\idxhdr{ctime}},
-or \tcode{<cwchar>}~(\ref{cwchar.syn})\indexlibrary{\idxhdr{cwchar}},
+\tcode{<clocale>}\iref{c.locales}\indexlibrary{\idxhdr{clocale}},
+\tcode{<cstddef>}\iref{cstddef.syn}\indexlibrary{\idxhdr{cstddef}},
+\tcode{<cstdio>}\iref{cstdio.syn}\indexlibrary{\idxhdr{cstdio}},
+\tcode{<cstdlib>}\iref{cstdlib.syn}\indexlibrary{\idxhdr{cstdlib}},
+\tcode{<cstring>}\iref{cstring.syn}\indexlibrary{\idxhdr{cstring}},
+\tcode{<ctime>}\iref{ctime.syn}\indexlibrary{\idxhdr{ctime}},
+or \tcode{<cwchar>}\iref{cwchar.syn}\indexlibrary{\idxhdr{cwchar}},
 is an \impldef{definition of \tcode{NULL}} \Cpp null pointer constant in
-this International Standard~(\ref{support.types}).
+this International Standard\iref{support.types}.
 
 \rSec2[diff.mods.to.declarations]{Modifications to declarations}
 
 \pnum
-Header \tcode{<cstring>}~(\ref{cstring.syn})\indexlibrary{\idxhdr{cstring}}:
+Header \tcode{<cstring>}\iref{cstring.syn}\indexlibrary{\idxhdr{cstring}}:
 The following functions have different declarations:
 
 \begin{itemize}
@@ -1966,7 +1966,7 @@ The following functions have different declarations:
 Subclause \ref{cstring.syn} describes the changes.
 
 \pnum
-Header \tcode{<cwchar>}~(\ref{cwchar.syn})\indexlibrary{\idxhdr{cwchar}}:
+Header \tcode{<cwchar>}\iref{cwchar.syn}\indexlibrary{\idxhdr{cwchar}}:
 The following functions have different declarations:
 
 \begin{itemize}
@@ -1980,14 +1980,14 @@ The following functions have different declarations:
 Subclause \ref{cwchar.syn} describes the changes.
 
 \pnum
-Header \tcode{<cstddef>}~(\ref{cstddef.syn})\indexlibrary{\idxhdr{cstddef}}
+Header \tcode{<cstddef>}\iref{cstddef.syn}\indexlibrary{\idxhdr{cstddef}}
 declares the name \tcode{nullptr_t} in addition to the names declared in
 \tcode{<stddef.h>} in the C standard library.
 
 \rSec2[diff.mods.to.behavior]{Modifications to behavior}
 
 \pnum
-Header \tcode{<cstdlib>}~(\ref{cstdlib.syn})\indexlibrary{\idxhdr{cstdlib}}:
+Header \tcode{<cstdlib>}\iref{cstdlib.syn}\indexlibrary{\idxhdr{cstdlib}}:
 The following functions have different behavior:
 
 \begin{itemize}
@@ -1999,7 +1999,7 @@ The following functions have different behavior:
 Subclause \ref{support.start.term} describes the changes.
 
 \pnum
-Header \tcode{<csetjmp>}~(\ref{csetjmp.syn})\indexlibrary{\idxhdr{csetjmp}}:
+Header \tcode{<csetjmp>}\iref{csetjmp.syn}\indexlibrary{\idxhdr{csetjmp}}:
 The following functions have different behavior:
 
 \begin{itemize}
@@ -2013,7 +2013,7 @@ Subclause \ref{csetjmp.syn} describes the changes.
 
 \pnum
 The macro \tcode{offsetof}, defined in
-\tcode{<cstddef>}~(\ref{cstddef.syn})\indexlibrary{\idxhdr{cstddef}},
+\tcode{<cstddef>}\iref{cstddef.syn}\indexlibrary{\idxhdr{cstddef}},
 accepts a restricted set of \tcode{\placeholder{type}} arguments in this International Standard.
 Subclause \ref{support.types.layout} describes the change.
 

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -59,7 +59,7 @@ For the components affected by this subclause that declare an \tcode{allocator_t
 objects stored in these components shall be constructed using the function
 \tcode{allocator_traits<allocator_type>::rebind_traits<U>::\brk{}construct}
 and destroyed using the function
-\tcode{allocator_traits<allocator_type>::rebind_traits<U>::\brk{}destroy}~(\ref{allocator.traits.members}),
+\tcode{allocator_traits<allocator_type>::rebind_traits<U>::\brk{}destroy}\iref{allocator.traits.members},
 where \tcode{U} is either \tcode{allocator_type::value_type} or
 an internal type used by the container.
 These functions are called only for the
@@ -269,7 +269,7 @@ Those entries marked ``(Note A)'' or ``(Note B)''
 have linear complexity for \tcode{array} and have constant complexity
 for all other standard containers.
 \begin{note}
-The algorithm \tcode{equal()} is defined in Clause~\ref{algorithms}.
+The algorithm \tcode{equal()} is defined in \ref{algorithms}.
 \end{note}
 
 \pnum
@@ -356,7 +356,7 @@ swap.
 
 \pnum
 If the iterator type of a container belongs to the bidirectional or
-random access iterator categories~(\ref{iterator.requirements}),
+random access iterator categories\iref{iterator.requirements},
 the container is called
 \term{reversible}
 and satisfies the additional requirements
@@ -453,9 +453,9 @@ within that container.
 \pnum
 \indextext{container!contiguous}%
 A \defn{contiguous container}
-is a container that supports random access iterators~(\ref{random.access.iterators})
+is a container that supports random access iterators\iref{random.access.iterators}
 and whose member types \tcode{iterator} and \tcode{const_iterator}
-are contiguous iterators~(\ref{iterator.requirements.general}).
+are contiguous iterators\iref{iterator.requirements.general}.
 
 \pnum
 Table~\ref{tab:containers.optional.operations} lists operations that are provided
@@ -504,7 +504,7 @@ Table~\ref{tab:containers.optional.operations} unless otherwise stated.
 \end{libreqtab5}
 
 \begin{note}
-The algorithm \tcode{lexicographical_compare()} is defined in Clause~\ref{algorithms}.
+The algorithm \tcode{lexicographical_compare()} is defined in \ref{algorithms}.
 \end{note}
 
 \pnum
@@ -712,7 +712,7 @@ as an allocator unless it satisfies both of the following conditions:
 
 \begin{itemize}
 \item The \grammarterm{qualified-id} \tcode{A::value_type}
-is valid and denotes a type~(\ref{temp.deduct}).
+is valid and denotes a type\iref{temp.deduct}.
 
 \item The expression \tcode{declval<A\&>().allocate(size_t\{\})}
 is well-formed when treated as an unevaluated operand.
@@ -721,7 +721,7 @@ is well-formed when treated as an unevaluated operand.
 \rSec2[container.requirements.dataraces]{Container data races}
 
 \pnum
-For purposes of avoiding data races~(\ref{res.on.data.races}), implementations shall
+For purposes of avoiding data races\iref{res.on.data.races}, implementations shall
 consider the following functions to be \tcode{const}: \tcode{begin}, \tcode{end},
 \tcode{rbegin}, \tcode{rend}, \tcode{front}, \tcode{back}, \tcode{data}, \tcode{find},
 \tcode{lower_bound}, \tcode{upper_bound}, \tcode{equal_range}, \tcode{at} and, except in
@@ -775,7 +775,7 @@ and \ref{tab:containers.sequence.optional},
 \tcode{u} denotes the name of a variable being declared,
 \tcode{A} denotes \tcode{X::allocator_type} if
 the \grammarterm{qualified-id} \tcode{X::allocator_type} is valid and denotes a
-type~(\ref{temp.deduct}) and
+type\iref{temp.deduct} and
 \tcode{allocator<T>} if it doesn't,
 \tcode{i} and \tcode{j}
 denote iterators satisfying input iterator requirements
@@ -825,7 +825,7 @@ The complexities of the expressions are sequence dependent.
                     &
  \requires\ \tcode{T} shall be \tcode{EmplaceConstructible} into \tcode{X} from \tcode{*i}.
  For \tcode{vector}, if the iterator does
- not meet the forward iterator requirements~(\ref{forward.iterators}), \tcode{T}
+ not meet the forward iterator requirements\iref{forward.iterators}, \tcode{T}
  shall also be
  \tcode{MoveInsertable} into \tcode{X}.
  Each iterator in the range \range{i}{j} shall be dereferenced exactly once.\br
@@ -881,7 +881,7 @@ The complexities of the expressions are sequence dependent.
  \requires\ \tcode{T} shall be \tcode{EmplaceConstructible} into \tcode{X} from \tcode{*i}.
  For \tcode{vector} and \tcode{deque}, \tcode{T} shall also be
  \tcode{MoveInsertable} into \tcode{X}, \tcode{MoveConstructible}, \tcode{MoveAssignable},
- and swappable~(\ref{swappable.requirements}).
+ and swappable\iref{swappable.requirements}.
  Each iterator in the range \range{i}{j} shall be dereferenced exactly once.\br
  \requires \tcode{i} and \tcode{j} are not iterators into \tcode{a}.\br
  Inserts copies of elements in \tcode{[i, j)} before \tcode{p}  \\ \rowsep
@@ -913,7 +913,7 @@ The complexities of the expressions are sequence dependent.
  \tcode{void}           &
  \requires\ \tcode{T} shall be \tcode{EmplaceConstructible} into \tcode{X} from \tcode{*i}
  and assignable from \tcode{*i}. For \tcode{vector}, if the iterator does not
- meet the forward iterator requirements~(\ref{forward.iterators}), \tcode{T}
+ meet the forward iterator requirements\iref{forward.iterators}, \tcode{T}
  shall also be
  \tcode{MoveInsertable} into \tcode{X}.\br
  Each iterator in the range \range{i}{j} shall be dereferenced exactly once.\br
@@ -990,7 +990,7 @@ If no such element exists,
 is returned.
 
 \pnum
-For every sequence container defined in this Clause and in Clause~\ref{strings}:
+For every sequence container defined in this Clause and in \ref{strings}:
 \begin{itemize}
 \item If the constructor
 \begin{codeblock}
@@ -1193,8 +1193,8 @@ if
 
 \pnum
 A \term{node handle} is an object that accepts ownership of a single element
-from an associative container~(\ref{associative.reqmts}) or an unordered
-associative container~(\ref{unord.req}). It may be used to transfer that
+from an associative container\iref{associative.reqmts} or an unordered
+associative container\iref{unord.req}. It may be used to transfer that
 ownership to another container with compatible nodes.  Containers with
 compatible nodes have the same node handle type. Elements may be transferred in
 either direction between container types in the same row of
@@ -1488,7 +1488,7 @@ Each associative container is parameterized on
 \tcode{Key}
 and an ordering relation
 \tcode{Compare}
-that induces a strict weak ordering~(\ref{alg.sorting}) on
+that induces a strict weak ordering\iref{alg.sorting} on
 elements of
 \tcode{Key}.
 In addition,
@@ -1557,7 +1557,7 @@ are the same type.
 
 \pnum
 The associative containers meet all the requirements of Allocator-aware
-containers~(\ref{container.requirements.general}), except that for
+containers\iref{container.requirements.general}, except that for
 \tcode{map} and \tcode{multimap}, the requirements placed on \tcode{value_type}
 in Table~\ref{tab:containers.container.requirements} apply instead to \tcode{key_type}
 and \tcode{mapped_type}. \begin{note} For example, in some cases \tcode{key_type} and \tcode{mapped_type}
@@ -1580,7 +1580,7 @@ when \tcode{X} supports multiple keys,
 \tcode{a_tran} denotes a possibly \tcode{const} value of type \tcode{X}
 when the \grammarterm{qualified-id}
 \tcode{X::key_compare::is_transparent} is valid
-and denotes a type~(\ref{temp.deduct}),
+and denotes a type\iref{temp.deduct},
 \tcode{i} and \tcode{j}
 satisfy input iterator requirements and refer to elements
 implicitly convertible to
@@ -1594,7 +1594,7 @@ denotes a valid range,
 \tcode{t} denotes a value of type \tcode{X::value_type},
 \tcode{k} denotes a value of type \tcode{X::key_type}
 and \tcode{c} denotes a possibly \tcode{const} value of type \tcode{X::key_compare};
-\tcode{kl} is a value such that \tcode{a} is partitioned~(\ref{alg.sorting})
+\tcode{kl} is a value such that \tcode{a} is partitioned\iref{alg.sorting}
 with respect to \tcode{c(r, kl)}, with \tcode{r} the key value of \tcode{e}
 and \tcode{e} in \tcode{a};
 \tcode{ku} is a value such that \tcode{a} is partitioned with respect to
@@ -2033,7 +2033,7 @@ its constructor.
 The member function templates \tcode{find}, \tcode{count}, \tcode{lower_bound},
 \tcode{upper_bound}, and \tcode{equal_range} shall not participate in overload
 resolution unless the \grammarterm{qualified-id} \tcode{Compare::is_transparent} is valid
-and denotes a type~(\ref{temp.deduct}).
+and denotes a type\iref{temp.deduct}.
 
 \pnum
 A deduction guide for an associative container shall not participate in overload resolution
@@ -2086,7 +2086,7 @@ four unordered associative containers: \tcode{unordered_set},
 \indextext{unordered associative containers!requirements}%
 \indextext{requirements!container!not required for unordered associated containers}%
 Unordered associative containers conform to the requirements for
-Containers~(\ref{container.requirements}), except that
+Containers\iref{container.requirements}, except that
 the expressions
 \tcode{a == b} and \tcode{a != b} have different semantics than for the other
 container types.
@@ -2094,7 +2094,7 @@ container types.
 \pnum
 Each unordered associative container is parameterized by \tcode{Key},
 by a function object type \tcode{Hash} that meets the \tcode{Hash}
-requirements~(\ref{hash.requirements}) and acts as a hash function for
+requirements\iref{hash.requirements} and acts as a hash function for
 argument values of type \tcode{Key}, and by a binary predicate \tcode{Pred}
 that induces an equivalence relation on values of type \tcode{Key}.
 Additionally, \tcode{unordered_map} and \tcode{unordered_multimap} associate
@@ -2174,7 +2174,7 @@ equivalent elements.
 
 \pnum
 The unordered associative containers meet all the requirements of Allocator-aware
-containers~(\ref{container.requirements.general}), except that for
+containers\iref{container.requirements.general}, except that for
 \tcode{unordered_map} and \tcode{unordered_multimap}, the requirements placed on \tcode{value_type}
 in Table~\ref{tab:containers.container.requirements} apply instead to \tcode{key_type}
 and \tcode{mapped_type}. \begin{note} For example, \tcode{key_type} and \tcode{mapped_type}
@@ -3116,24 +3116,24 @@ namespace std {
 \indextext{\idxcode{array}!contiguous storage}%
 The header \tcode{<array>} defines a class template for storing fixed-size
 sequences of objects.
-An \tcode{array} is a contiguous container~(\ref{container.requirements.general}).
+An \tcode{array} is a contiguous container\iref{container.requirements.general}.
 An instance of \tcode{array<T, N>} stores \tcode{N} elements of type \tcode{T},
 so that \tcode{size() == N} is an invariant.
 
 \pnum
 \indextext{\idxcode{array}!initialization}%
 \indextext{\idxcode{array}!as aggregate}%
-An \tcode{array} is an aggregate~(\ref{dcl.init.aggr}) that can be
+An \tcode{array} is an aggregate\iref{dcl.init.aggr} that can be
 list-initialized with up
 to \tcode{N} elements whose types are convertible to \tcode{T}.
 
 \pnum
 \indextext{requirements!container}%
 An \tcode{array} satisfies all of the requirements of a container and
-of a reversible container~(\ref{container.requirements}), except that a default
+of a reversible container\iref{container.requirements}, except that a default
 constructed \tcode{array} object is not empty and that \tcode{swap} does not have constant
 complexity. An \tcode{array} satisfies some of the requirements of a sequence
-container~(\ref{sequence.reqmts}).
+container\iref{sequence.reqmts}.
 Descriptions are provided here
 only for operations on \tcode{array} that are not described in
 one of these tables and
@@ -3211,7 +3211,7 @@ namespace std {
 \pnum
 \indextext{\idxcode{array}!initialization}%
 \indextext{requirements!container}%
-The conditions for an aggregate~(\ref{dcl.init.aggr}) shall be
+The conditions for an aggregate\iref{dcl.init.aggr} shall be
 met. Class \tcode{array} relies on the implicitly-declared special
 member functions~(\ref{class.ctor}, \ref{class.dtor}, and \ref{class.copy}) to
 conform to the container requirements table in~\ref{container.requirements}.
@@ -3372,7 +3372,7 @@ where indexing is zero-based.
 A
 \indexlibrary{\idxcode{deque}}%
 \tcode{deque}
-is a sequence container that supports random access iterators~(\ref{random.access.iterators}).
+is a sequence container that supports random access iterators\iref{random.access.iterators}.
 In addition, it supports constant time insert and erase operations at the beginning or the end;
 insert and erase in the middle take linear time.
 That is, a deque is especially optimized for pushing and popping elements at the beginning and end.
@@ -3383,7 +3383,7 @@ A
 \tcode{deque}
 satisfies all of the requirements of a container, of a reversible container
 (given in tables in~\ref{container.requirements}), of a sequence container,
-including the optional sequence container requirements~(\ref{sequence.reqmts}), and of an allocator-aware container (Table~\ref{tab:containers.allocatoraware}).
+including the optional sequence container requirements\iref{sequence.reqmts}, and of an allocator-aware container (Table~\ref{tab:containers.allocatoraware}).
 Descriptions are provided here only for operations on
 \tcode{deque}
 that are not described in one of these tables
@@ -3927,7 +3927,7 @@ namespace std {
 \pnum
 An incomplete type \tcode{T} may be used when instantiating \tcode{forward_list}
 if the allocator satisfies the
-allocator completeness requirements~(\ref{allocator.requirements.completeness}).
+allocator completeness requirements\iref{allocator.requirements.completeness}.
 \tcode{T} shall be complete before any member of the resulting specialization
 of \tcode{forward_list} is referenced.
 
@@ -4349,7 +4349,7 @@ Invalidates only the iterators and references to the erased elements.
 predicate.
 
 \pnum
-\remarks Stable~(\ref{algorithm.stable}).
+\remarks Stable\iref{algorithm.stable}.
 
 \pnum
 \complexity Exactly \tcode{distance(begin(), end())} applications of the corresponding
@@ -4387,7 +4387,7 @@ template <class Compare> void merge(forward_list&& x, Compare comp);
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{comp} defines a strict weak ordering~(\ref{alg.sorting}), and \tcode{*this}
+\requires \tcode{comp} defines a strict weak ordering\iref{alg.sorting}, and \tcode{*this}
 and \tcode{x} are both sorted according to this ordering.
 \tcode{get_allocator() == x.get_allocator()}.
 
@@ -4401,7 +4401,7 @@ refer to their elements, but they now behave as iterators into \tcode{*this}, no
 \tcode{x}.
 
 \pnum
-\remarks Stable~(\ref{algorithm.stable}). The behavior is undefined if
+\remarks Stable\iref{algorithm.stable}. The behavior is undefined if
 \tcode{get_allocator() != x.get_allocator()}.
 
 \pnum
@@ -4418,7 +4418,7 @@ template <class Compare> void sort(Compare comp);
 \begin{itemdescr}
 \pnum
 \requires \tcode{operator<} (for the version with no arguments) or \tcode{comp} (for the
-version with a comparison argument) defines a strict weak ordering~(\ref{alg.sorting}).
+version with a comparison argument) defines a strict weak ordering\iref{alg.sorting}.
 
 \pnum
 \effects Sorts the list according to the \tcode{operator<} or the \tcode{comp} function object.
@@ -4426,7 +4426,7 @@ If an exception is thrown, the order of the elements in \tcode{*this} is unspeci
 Does not affect the validity of iterators and references.
 
 \pnum
-\remarks Stable~(\ref{algorithm.stable}).
+\remarks Stable\iref{algorithm.stable}.
 
 \pnum
 \complexity Approximately $N \log N$ comparisons, where $N$ is \tcode{distance(begin(), end())}.
@@ -4471,7 +4471,7 @@ A
 is a sequence container that supports
 bidirectional iterators and allows constant time insert and erase
 operations anywhere within the sequence, with storage management handled
-automatically. Unlike vectors~(\ref{vector}) and deques~(\ref{deque}),
+automatically. Unlike vectors\iref{vector} and deques\iref{deque},
 fast random access to list elements is not supported, but many
 algorithms only need sequential access anyway.
 
@@ -4480,7 +4480,7 @@ A \tcode{list} satisfies all of the requirements of a container, of
 a reversible container (given in two tables in
 \ref{container.requirements}), of a sequence container,
 including most of the optional sequence container
-requirements~(\ref{sequence.reqmts}), and of an allocator-aware container
+requirements\iref{sequence.reqmts}, and of an allocator-aware container
 (Table~\ref{tab:containers.allocatoraware}).
 The exceptions are the
 \tcode{operator[]}
@@ -4646,7 +4646,7 @@ namespace std {
 \pnum
 An incomplete type \tcode{T} may be used when instantiating \tcode{list}
 if the allocator satisfies the
-allocator completeness requirements~(\ref{allocator.requirements.completeness}).
+allocator completeness requirements\iref{allocator.requirements.completeness}.
 \tcode{T} shall be complete before any member of the resulting specialization
 of \tcode{list} is referenced.
 
@@ -5014,7 +5014,7 @@ or
 \tcode{pred(*i) != false}.
 
 \pnum
-\remarks Stable~(\ref{algorithm.stable}).
+\remarks Stable\iref{algorithm.stable}.
 
 \pnum
 \complexity
@@ -5067,7 +5067,7 @@ template <class Compare> void merge(list&& x, Compare comp);
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{comp} shall define a strict weak ordering~(\ref{alg.sorting}), and both the list and the argument list shall be
+\tcode{comp} shall define a strict weak ordering\iref{alg.sorting}, and both the list and the argument list shall be
 sorted according to this ordering.
 
 \pnum
@@ -5083,7 +5083,7 @@ refer to their elements, but they now behave as iterators into \tcode{*this}, no
 \tcode{x}.
 
 \pnum
-\remarks Stable~(\ref{algorithm.stable}). If \tcode{(\&x != this)} the range \tcode{[x.begin(), x.end())}
+\remarks Stable\iref{algorithm.stable}. If \tcode{(\&x != this)} the range \tcode{[x.begin(), x.end())}
 is empty after the merge.
 No elements are copied by this operation. The behavior is undefined if
 \tcode{get_allocator() != x.get_allocator()}.
@@ -5129,7 +5129,7 @@ version)
 or
 \tcode{comp}
 (for the second version)
-shall define a strict weak ordering~(\ref{alg.sorting}).
+shall define a strict weak ordering\iref{alg.sorting}.
 
 \pnum
 \effects
@@ -5139,7 +5139,7 @@ the order of the elements in \tcode{*this} is unspecified.
 Does not affect the validity of iterators and references.
 
 \pnum
-\remarks Stable~(\ref{algorithm.stable}).
+\remarks Stable\iref{algorithm.stable}.
 
 \pnum
 \complexity
@@ -5182,10 +5182,10 @@ to improve efficiency.
 A \tcode{vector} satisfies all of the requirements of a container and of a
 reversible container (given in two tables in~\ref{container.requirements}), of a
 sequence container, including most of the optional sequence container
-requirements~(\ref{sequence.reqmts}), of an allocator-aware container
+requirements\iref{sequence.reqmts}, of an allocator-aware container
 (Table~\ref{tab:containers.allocatoraware}),
 and, for an element type other than \tcode{bool},
-of a contiguous container~(\ref{container.requirements.general}).
+of a contiguous container\iref{container.requirements.general}.
 The exceptions are the
 \tcode{push_front}, \tcode{pop_front}, and \tcode{emplace_front} member functions, which are not
 provided. Descriptions are provided here only for operations on \tcode{vector}
@@ -5325,7 +5325,7 @@ namespace std {
 \pnum
 An incomplete type \tcode{T} may be used when instantiating \tcode{vector}
 if the allocator satisfies the
-allocator completeness requirements~(\ref{allocator.requirements.completeness}).
+allocator completeness requirements\iref{allocator.requirements.completeness}.
 \tcode{T} shall be complete before any member of the resulting specialization
 of \tcode{vector} is referenced.
 
@@ -5791,7 +5791,7 @@ Unless described below, all operations have the same requirements and
 semantics as the primary \tcode{vector} template, except that operations
 dealing with the \tcode{bool} value type map to bit values in the
 container storage and
-\tcode{allocator_traits::construct}~(\ref{allocator.traits.members})
+\tcode{allocator_traits::construct}\iref{allocator.traits.members}
 is not used to construct these values.
 
 \pnum
@@ -5840,7 +5840,7 @@ template <class Allocator> struct hash<vector<bool, Allocator>>;
 
 \begin{itemdescr}
 \pnum
-The specialization is enabled~(\ref{unord.hash}).
+The specialization is enabled\iref{unord.hash}.
 \end{itemdescr}
 
 \rSec1[associative]{Associative containers}
@@ -6031,8 +6031,8 @@ on the keys. The \tcode{map} class supports bidirectional iterators.
 \pnum
 A
 \tcode{map}
-satisfies all of the requirements of a container, of a reversible container~(\ref{container.requirements}), of
-an associative container~(\ref{associative.reqmts}), and of an allocator-aware container (Table~\ref{tab:containers.allocatoraware}).
+satisfies all of the requirements of a container, of a reversible container\iref{container.requirements}, of
+an associative container\iref{associative.reqmts}, and of an allocator-aware container (Table~\ref{tab:containers.allocatoraware}).
 A
 \tcode{map}
 also provides most operations described in~\ref{associative.reqmts}
@@ -6581,8 +6581,8 @@ supports bidirectional iterators.
 \pnum
 A
 \tcode{multimap} satisfies all of the requirements of a container and of a
-reversible container~(\ref{container.requirements}), of an associative
-container~(\ref{associative.reqmts}), and of an allocator-aware container
+reversible container\iref{container.requirements}, of an associative
+container\iref{associative.reqmts}, and of an allocator-aware container
 (Table~\ref{tab:containers.allocatoraware}).
 A
 \tcode{multimap}
@@ -6910,8 +6910,8 @@ supports bidirectional iterators.
 
 \pnum
 A \tcode{set} satisfies all of the requirements of a container, of a reversible
-container~(\ref{container.requirements}), of an associative
-container~(\ref{associative.reqmts}), and of an allocator-aware container
+container\iref{container.requirements}, of an associative
+container\iref{associative.reqmts}, and of an allocator-aware container
 (Table~\ref{tab:containers.allocatoraware}).
 A
 \tcode{set}
@@ -7198,8 +7198,8 @@ supports bidirectional iterators.
 
 \pnum
 A \tcode{multiset} satisfies all of the requirements of a container, of a
-reversible container~(\ref{container.requirements}), of an associative
-container~(\ref{associative.reqmts}), and of an allocator-aware container
+reversible container\iref{container.requirements}, of an associative
+container\iref{associative.reqmts}, and of an allocator-aware container
 (Table~\ref{tab:containers.allocatoraware}).
 \tcode{multiset}
 also provides most operations described in~\ref{associative.reqmts}
@@ -9248,9 +9248,9 @@ and
 can be used to instantiate
 \tcode{queue}.
 In particular,
-\tcode{list}~(\ref{list})
+\tcode{list}\iref{list}
 and
-\tcode{deque}~(\ref{deque})
+\tcode{deque}\iref{deque}
 can be used.
 
 \begin{codeblock}
@@ -9500,15 +9500,15 @@ and
 can be used to instantiate
 \tcode{priority_queue}.
 In particular,
-\tcode{vector}~(\ref{vector})
+\tcode{vector}\iref{vector}
 and
-\tcode{deque}~(\ref{deque})
+\tcode{deque}\iref{deque}
 can be used.
 Instantiating
 \tcode{priority_queue}
 also involves supplying a function or function object for making
 priority comparisons; the library assumes that the function or function
-object defines a strict weak ordering~(\ref{alg.sorting}).
+object defines a strict weak ordering\iref{alg.sorting}.
 
 \begin{codeblock}
 namespace std {
@@ -9592,7 +9592,7 @@ explicit priority_queue(const Compare& x = Compare(), Container&& y = Container(
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{x} shall define a strict weak ordering~(\ref{alg.sorting}).
+\tcode{x} shall define a strict weak ordering\iref{alg.sorting}.
 
 \pnum
 \effects
@@ -9620,7 +9620,7 @@ template <class InputIterator>
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{x} shall define a strict weak ordering~(\ref{alg.sorting}).
+\tcode{x} shall define a strict weak ordering\iref{alg.sorting}.
 
 \pnum
 \effects
@@ -9804,10 +9804,10 @@ and
 can be used to instantiate
 \tcode{stack}.
 In particular,
-\tcode{vector}~(\ref{vector}),
-\tcode{list}~(\ref{list})
+\tcode{vector}\iref{vector},
+\tcode{list}\iref{list}
 and
-\tcode{deque}~(\ref{deque})
+\tcode{deque}\iref{deque}
 can be used.
 
 \rSec3[stack.defn]{\tcode{stack} definition}

--- a/source/conversions.tex
+++ b/source/conversions.tex
@@ -518,8 +518,8 @@ The pointer value\iref{basic.compound} is unchanged by this conversion.
 \pnum
 A prvalue of type ``pointer to \cvqual{cv} \tcode{D}'', where \tcode{D}
 is a class type, can be converted to a prvalue of type ``pointer to
-\cvqual{cv} \tcode{B}'', where \tcode{B} is a base class
-(\ref{class.derived}) of \tcode{D}. If \tcode{B} is an
+\cvqual{cv} \tcode{B}'', where \tcode{B} is a base class\iref{class.derived}
+of \tcode{D}. If \tcode{B} is an
 inaccessible\iref{class.access} or
 ambiguous\iref{class.member.lookup} base class of \tcode{D}, a program
 that necessitates this conversion is ill-formed. The result of the
@@ -548,8 +548,8 @@ followed by a qualification conversion\iref{conv.qual}.
 A prvalue of type ``pointer to member of \tcode{B} of type \cvqual{cv}
 \tcode{T}'', where \tcode{B} is a class type, can be converted to
 a prvalue of type ``pointer to member of \tcode{D} of type \cvqual{cv}
-\tcode{T}'', where \tcode{D} is a derived class
-(\ref{class.derived}) of \tcode{B}. If \tcode{B} is an
+\tcode{T}'', where \tcode{D} is a derived class\iref{class.derived}
+of \tcode{B}. If \tcode{B} is an
 inaccessible\iref{class.access},
 ambiguous\iref{class.member.lookup}, or virtual\iref{class.mi} base
 class of \tcode{D}, or a base class of a virtual base class of

--- a/source/conversions.tex
+++ b/source/conversions.tex
@@ -9,7 +9,7 @@
 \indextext{conversion!standard|(}%
 \indextext{conversion!implicit}%
 Standard conversions are implicit conversions with built-in meaning.
-Clause~\ref{conv} enumerates the full set of such conversions. A
+\ref{conv} enumerates the full set of such conversions. A
 \indextext{sequence!standard conversion}%
 \term{standard conversion sequence} is a sequence of standard
 conversions in the following order:
@@ -41,14 +41,14 @@ types in several contexts:
 
 \begin{itemize}
 \item When used as operands of operators. The operator's requirements
-for its operands dictate the destination type (Clause~\ref{expr}).
+for its operands dictate the destination type\iref{expr}.
 
 \item When used in the condition of an \tcode{if} statement or iteration
 statement~(\ref{stmt.select}, \ref{stmt.iter}). The destination type is
 \tcode{bool}.
 
 \item When used in the expression of a \tcode{switch} statement. The
-destination type is integral~(\ref{stmt.select}).
+destination type is integral\iref{stmt.select}.
 
 \item When used as the source expression for an initialization (which
 includes use as an argument in a function call and use as the expression
@@ -63,7 +63,7 @@ An expression \tcode{e} can be
 \indextext{conversion!implicit}%
 \term{implicitly converted} to a type \tcode{T} if and only if the
 declaration \tcode{T t=e;} is well-formed, for some invented temporary
-variable \tcode{t}~(\ref{dcl.init}).
+variable \tcode{t}\iref{dcl.init}.
 
 \pnum
 Certain language constructs require that an expression be converted to a Boolean
@@ -71,7 +71,7 @@ value. An expression \tcode{e} appearing in such a context is said to be
 \indextext{conversion!contextual to \tcode{bool}}%
 \term{contextually converted to \tcode{bool}} and is well-formed if and only if
 the declaration \tcode{bool t(e);} is well-formed, for some invented temporary
-variable \tcode{t}~(\ref{dcl.init}).
+variable \tcode{t}\iref{dcl.init}.
 
 \pnum
 Certain language constructs require conversion to a value having
@@ -92,7 +92,7 @@ The effect of any implicit
 conversion is the same as performing the corresponding declaration and initialization
 and then using the temporary variable as the result of the conversion.
 The result is an lvalue if \tcode{T} is an lvalue reference
-type or an rvalue reference to function type~(\ref{dcl.ref}),
+type or an rvalue reference to function type\iref{dcl.ref},
 an xvalue if \tcode{T} is an rvalue reference to object type,
 and a prvalue otherwise. The expression \tcode{e}
 is used as a glvalue if and only if the initialization uses it as a glvalue.
@@ -101,7 +101,7 @@ is used as a glvalue if and only if the initialization uses it as a glvalue.
 \begin{note}
 For class types, user-defined conversions are considered as well;
 see~\ref{class.conv}. In general, an implicit conversion
-sequence~(\ref{over.best.ics}) consists of a standard conversion
+sequence\iref{over.best.ics} consists of a standard conversion
 sequence followed by a user-defined conversion followed by another
 standard conversion sequence.
 \end{note}
@@ -119,7 +119,7 @@ descriptions of those operators and contexts.
 \pnum
 \indextext{conversion!lvalue-to-rvalue}%
 \indextext{type!incomplete}%
-A glvalue~(\ref{basic.lval}) of a non-function, non-array type \tcode{T}
+A glvalue\iref{basic.lval} of a non-function, non-array type \tcode{T}
 can be converted to
 a prvalue.\footnote{For historical reasons, this conversion is called the ``lvalue-to-rvalue''
 conversion, even though that name does not accurately reflect the taxonomy
@@ -141,7 +141,7 @@ is applied to an expression \tcode{e}, and either
 \item the evaluation of \tcode{e} results in the evaluation of a member
       \tcode{ex} of the set of potential results of \tcode{e}, and \tcode{ex}
       names a variable \tcode{x} that is not odr-used by
-      \tcode{ex}~(\ref{basic.def.odr}),
+      \tcode{ex}\iref{basic.def.odr},
 \end{itemize}
 the value contained in the referenced object is not accessed.
 \begin{example}
@@ -165,11 +165,11 @@ following rules:
 \begin{itemize}
 
 \item If \tcode{T} is \cv{}~\tcode{std::nullptr_t}, the result is a
-null pointer constant~(\ref{conv.ptr}).
+null pointer constant\iref{conv.ptr}.
 \begin{note}
 Since no value is fetched from memory,
-there is no side effect for a volatile access~(\ref{intro.execution}), and
-an inactive member of a union~(\ref{class.union}) may be accessed.
+there is no side effect for a volatile access\iref{intro.execution}, and
+an inactive member of a union\iref{class.union} may be accessed.
 \end{note}
 
 \item Otherwise, if \tcode{T} has a class
@@ -199,7 +199,7 @@ See also~\ref{basic.lval}.\end{note}
 An lvalue or rvalue of type ``array of \tcode{N} \tcode{T}'' or ``array
 of unknown bound of \tcode{T}'' can be converted to a prvalue of type
 ``pointer to \tcode{T}''.
-The temporary materialization conversion~(\ref{conv.rval}) is applied.
+The temporary materialization conversion\iref{conv.rval} is applied.
 The result is a pointer to the first element of the array.
 
 \rSec1[conv.func]{Function-to-pointer conversion}
@@ -222,7 +222,7 @@ is overloaded.
 
 \pnum
 A prvalue of type \tcode{T} can be converted to an xvalue of type \tcode{T}.
-This conversion initializes a temporary object~(\ref{class.temporary}) of type \tcode{T} from the prvalue
+This conversion initializes a temporary object\iref{class.temporary} of type \tcode{T} from the prvalue
 by evaluating the prvalue with the temporary object as its result object,
 and produces an xvalue denoting the temporary object.
 \tcode{T} shall be a complete type.
@@ -250,12 +250,12 @@ such that \tcode{T} is
 ``$cv_0$ $P_0$ $cv_1$ $P_1$ $\cdots$ $cv_{n-1}$ $P_{n-1}$ $cv_n$ \tcode{U}'' for $n > 0$,
 \end{indented}
 where
-each $cv_i$ is a set of cv-qualifiers~(\ref{basic.type.qualifier}), and
+each $cv_i$ is a set of cv-qualifiers\iref{basic.type.qualifier}, and
 each $P_i$ is
-``pointer to''~(\ref{dcl.ptr}),
-``pointer to member of class $C_i$ of type''~(\ref{dcl.mptr}),
+``pointer to''\iref{dcl.ptr},
+``pointer to member of class $C_i$ of type''\iref{dcl.mptr},
 ``array of $N_i$'', or
-``array of unknown bound of''~(\ref{dcl.array}).
+``array of unknown bound of''\iref{dcl.array}.
 If $P_i$ designates an array,
 the cv-qualifiers $cv_{i+1}$ on the element type are also taken as
 the cv-qualifiers $cv_i$ of the array.
@@ -327,7 +327,7 @@ of \tcode{X} of type \cvqual{cv2} \tcode{T}'' if ``\cvqual{cv2}
 \pnum
 \begin{note}
 Function types (including those used in pointer to member function
-types) are never cv-qualified~(\ref{dcl.fct}).
+types) are never cv-qualified\iref{dcl.fct}.
 \end{note}
 \indextext{conversion!qualification|)}
 
@@ -337,7 +337,7 @@ types) are never cv-qualified~(\ref{dcl.fct}).
 \indextext{promotion!integral}%
 A prvalue of an integer type other than \tcode{bool}, \tcode{char16_t},
 \tcode{char32_t}, or \tcode{wchar_t} whose integer conversion
-rank~(\ref{conv.rank}) is less than the rank of \tcode{int} can be
+rank\iref{conv.rank} is less than the rank of \tcode{int} can be
 converted to a prvalue of type \tcode{int} if \tcode{int} can represent
 all the values of the source type; otherwise, the source prvalue can be
 converted to a prvalue of type \tcode{unsigned int}.
@@ -347,7 +347,7 @@ converted to a prvalue of type \tcode{unsigned int}.
 \indextext{type!underlying!\idxcode{char16_t}}%
 \indextext{type!underlying!\idxcode{char32_t}}%
 A prvalue of type \tcode{char16_t}, \tcode{char32_t}, or
-\tcode{wchar_t}~(\ref{basic.fundamental}) can be converted to a prvalue
+\tcode{wchar_t}\iref{basic.fundamental} can be converted to a prvalue
 of the first of the following types that can represent all the values of
 its underlying type: \tcode{int}, \tcode{unsigned int}, \tcode{long int},
 \tcode{unsigned long int}, \tcode{long long int},
@@ -359,26 +359,26 @@ to a prvalue of its underlying type.
 \pnum
 \indextext{type!underlying!enumeration}%
 A prvalue of an unscoped enumeration type whose underlying type is not
-fixed~(\ref{dcl.enum}) can be converted to a prvalue of the first of the following
+fixed\iref{dcl.enum} can be converted to a prvalue of the first of the following
 types that can represent all the values of the enumeration (i.e., the values in the
 range $b_\text{min}$ to $b_\text{max}$ as described in~\ref{dcl.enum}): \tcode{int},
 \tcode{unsigned int}, \tcode{long int}, \tcode{unsigned long int},
 \tcode{long long int}, or \tcode{unsigned long long int}. If none of the types in that
 list can represent all the values of the enumeration, a prvalue of an unscoped
 enumeration type can be converted to a prvalue of the extended integer type with lowest
-integer conversion rank~(\ref{conv.rank}) greater than the rank of \tcode{long long}
+integer conversion rank\iref{conv.rank} greater than the rank of \tcode{long long}
 in which all the values of the enumeration can be represented. If there are
 two such extended types, the signed one is chosen.
 
 \pnum
 A prvalue of an unscoped enumeration type whose underlying type is
-fixed~(\ref{dcl.enum}) can be converted to a prvalue of its underlying type. Moreover,
+fixed\iref{dcl.enum} can be converted to a prvalue of its underlying type. Moreover,
 if integral promotion can be applied to its underlying type, a prvalue of an unscoped
 enumeration type whose underlying type is fixed can also be converted to a prvalue of
 the promoted underlying type.
 
 \pnum
-A prvalue for an integral bit-field~(\ref{class.bit}) can be converted
+A prvalue for an integral bit-field\iref{class.bit} can be converted
 to a prvalue of type \tcode{int} if \tcode{int} can represent all the
 values of the bit-field; otherwise, it can be converted to
 \tcode{unsigned int} if \tcode{unsigned int} can represent all the
@@ -492,7 +492,7 @@ source type is \tcode{bool}, the value \tcode{false} is converted to zero and th
 \indextext{pointer!zero}%
 \indextext{constant!null pointer}%
 \indextext{value!null pointer}%
-A \term{null pointer constant} is an integer literal~(\ref{lex.icon}) with
+A \term{null pointer constant} is an integer literal\iref{lex.icon} with
 value zero
 or a prvalue of type \tcode{std::nullptr_t}. A null pointer constant can be
 converted to a pointer type; the
@@ -505,7 +505,7 @@ Two null pointer values of the same type shall compare
 equal. The conversion of a null pointer constant to a pointer to
 cv-qualified type is a single conversion, and not the sequence of a
 pointer conversion followed by a qualification
-conversion~(\ref{conv.qual}). A null pointer constant of integral type
+conversion\iref{conv.qual}. A null pointer constant of integral type
 can be converted to a prvalue of type \tcode{std::nullptr_t}.
 \begin{note} The resulting prvalue is not a null pointer value. \end{note}
 
@@ -513,15 +513,15 @@ can be converted to a prvalue of type \tcode{std::nullptr_t}.
 A prvalue of type ``pointer to \cvqual{cv} \tcode{T}'', where \tcode{T}
 is an object type, can be converted to a prvalue of type ``pointer to
 \cvqual{cv} \tcode{void}''.
-The pointer value~(\ref{basic.compound}) is unchanged by this conversion.
+The pointer value\iref{basic.compound} is unchanged by this conversion.
 
 \pnum
 A prvalue of type ``pointer to \cvqual{cv} \tcode{D}'', where \tcode{D}
 is a class type, can be converted to a prvalue of type ``pointer to
 \cvqual{cv} \tcode{B}'', where \tcode{B} is a base class
-(Clause~\ref{class.derived}) of \tcode{D}. If \tcode{B} is an
-inaccessible (Clause~\ref{class.access}) or
-ambiguous~(\ref{class.member.lookup}) base class of \tcode{D}, a program
+(\ref{class.derived}) of \tcode{D}. If \tcode{B} is an
+inaccessible\iref{class.access} or
+ambiguous\iref{class.member.lookup} base class of \tcode{D}, a program
 that necessitates this conversion is ill-formed. The result of the
 conversion is a pointer to the base class subobject of the derived class
 object. The null pointer value is converted to the null pointer value of
@@ -533,7 +533,7 @@ the destination type.
 \indextext{conversion!pointer to member}%
 \indextext{constant!null pointer}%
 \indextext{value!null member pointer}%
-A null pointer constant~(\ref{conv.ptr}) can be converted to a pointer
+A null pointer constant\iref{conv.ptr} can be converted to a pointer
 to member type; the result is the \term{null member pointer value}
 of that type and is distinguishable from any pointer to member not
 created from a null pointer constant.
@@ -542,16 +542,16 @@ Two null member pointer values of
 the same type shall compare equal. The conversion of a null pointer
 constant to a pointer to member of cv-qualified type is a single
 conversion, and not the sequence of a pointer to member conversion
-followed by a qualification conversion~(\ref{conv.qual}).
+followed by a qualification conversion\iref{conv.qual}.
 
 \pnum
 A prvalue of type ``pointer to member of \tcode{B} of type \cvqual{cv}
 \tcode{T}'', where \tcode{B} is a class type, can be converted to
 a prvalue of type ``pointer to member of \tcode{D} of type \cvqual{cv}
 \tcode{T}'', where \tcode{D} is a derived class
-(Clause~\ref{class.derived}) of \tcode{B}. If \tcode{B} is an
-inaccessible (Clause~\ref{class.access}),
-ambiguous~(\ref{class.member.lookup}), or virtual~(\ref{class.mi}) base
+(\ref{class.derived}) of \tcode{B}. If \tcode{B} is an
+inaccessible\iref{class.access},
+ambiguous\iref{class.member.lookup}, or virtual\iref{class.mi} base
 class of \tcode{D}, or a base class of a virtual base class of
 \tcode{D}, a program that necessitates this conversion is ill-formed.
 The result of the conversion refers to the same member as the pointer to
@@ -566,7 +566,7 @@ converted to the null member pointer value of the destination
 type.\footnote{The rule for conversion of pointers to members (from pointer to member
 of base to pointer to member of derived) appears inverted compared to
 the rule for pointers to objects (from pointer to derived to pointer to
-base)~(\ref{conv.ptr}, Clause~\ref{class.derived}). This inversion is
+base)~(\ref{conv.ptr}, \ref{class.derived}). This inversion is
 necessary to ensure type safety. Note that a pointer to member is not
 an object pointer or a function pointer
 and the rules for conversions
@@ -604,7 +604,7 @@ A prvalue of arithmetic, unscoped enumeration, pointer, or pointer to member
 type can be converted to a prvalue of type \tcode{bool}. A zero value, null
 pointer value, or null member pointer value is converted to \tcode{false}; any
 other value is converted to \tcode{true}. For
-direct-initialization~(\ref{dcl.init}), a prvalue of type
+direct-initialization\iref{dcl.init}, a prvalue of type
 \tcode{std::nullptr_t} can be converted to a prvalue of type
 \tcode{bool}; the resulting value is \tcode{false}.
 
@@ -645,7 +645,7 @@ standard integer types.
 \indextext{type!\idxcode{char32_t}}%
 \item The ranks of \tcode{char16_t}, \tcode{char32_t}, and
 \tcode{wchar_t} shall equal the ranks of their underlying
-types~(\ref{basic.fundamental}).
+types\iref{basic.fundamental}.
 
 \item The rank of any extended signed integer type relative to another
 extended signed integer type with the same size is \impldef{rank of extended signed
@@ -660,7 +660,7 @@ rank than \tcode{T3}, then \tcode{T1} shall have greater rank than
 
 \begin{note}
 The integer conversion rank is used in the definition of the integral
-promotions~(\ref{conv.prom}) and the usual arithmetic
-conversions (Clause~\ref{expr}).
+promotions\iref{conv.prom} and the usual arithmetic
+conversions\iref{expr}.
 \end{note}%
 \indextext{conversion!standard|)}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -81,7 +81,7 @@ the form
 \grammarterm{linkage-specification}{s} are described in~\ref{dcl.link}.
 \grammarterm{Function-definition}{s} are described in~\ref{dcl.fct.def} and
 \grammarterm{template-declaration}{s} and
-\grammarterm{deduction-guide}{s} are described in Clause~\ref{temp}.
+\grammarterm{deduction-guide}{s} are described in \ref{temp}.
 \grammarterm{Namespace-definition}{s} are described in~\ref{namespace.def},
 \grammarterm{using-declaration}{s} are described in~\ref{namespace.udecl} and
 \grammarterm{using-directive}{s} are described in~\ref{namespace.udir}.
@@ -101,7 +101,7 @@ Attributes are described in~\ref{dcl.attr}.
 \grammarterm{decl-specifier}{s}, the principal components of
 a \grammarterm{decl-specifier-seq}, are described in~\ref{dcl.spec}.
 \grammarterm{declarator}{s}, the components of an
-\grammarterm{init-declarator-list}, are described in Clause~\ref{dcl.decl}.
+\grammarterm{init-declarator-list}, are described in \ref{dcl.decl}.
 The \grammarterm{attribute-specifier-seq}
 appertains to each of the entities declared by
 the \grammarterm{declarator}{s}
@@ -122,12 +122,12 @@ is \impldef{meaning of attribute declaration}.
 \pnum
 \indextext{declaration}%
 \indextext{scope}%
-A declaration occurs in a scope~(\ref{basic.scope}); the scope rules are
+A declaration occurs in a scope\iref{basic.scope}; the scope rules are
 summarized in~\ref{basic.lookup}. A declaration that declares a function
 or defines a class, namespace, template, or function also has one or
 more scopes nested within it. These nested scopes, in turn, can have
 declarations nested within them. Unless otherwise stated, utterances in
-Clause~\ref{dcl.dcl} about components in, of, or contained by a
+\ref{dcl.dcl} about components in, of, or contained by a
 declaration or subcomponent thereof refer only to those components of
 the declaration that are \emph{not} nested within scopes nested within
 the declaration.
@@ -137,10 +137,10 @@ the declaration.
 \indextext{declarator}%
 In a \grammarterm{simple-declaration}, the optional
 \grammarterm{init-declarator-list} can be omitted only when declaring a
-class (Clause~\ref{class}) or enumeration~(\ref{dcl.enum}), that is,
+class\iref{class} or enumeration\iref{dcl.enum}, that is,
 when the \grammarterm{decl-specifier-seq} contains either a
 \grammarterm{class-specifier}, an \grammarterm{elaborated-type-specifier} with
-a \grammarterm{class-key}~(\ref{class.name}), or an
+a \grammarterm{class-key}\iref{class.name}, or an
 \grammarterm{enum-specifier}. In these cases and whenever a
 \grammarterm{class-specifier} or \grammarterm{enum-specifier} is present in
 the \grammarterm{decl-specifier-seq}, the identifiers in these specifiers
@@ -162,14 +162,14 @@ typedef class { };  // ill-formed
 In a \grammarterm{static_assert-declaration}, the
 \grammarterm{constant-expression} shall be
 a contextually converted constant expression
-of type \tcode{bool}~(\ref{expr.const}).
+of type \tcode{bool}\iref{expr.const}.
 If the value of the expression when
 so converted is \tcode{true}, the declaration has no
 effect. Otherwise, the program is ill-formed, and the resulting
-diagnostic message~(\ref{intro.compliance}) shall include the text of
+diagnostic message\iref{intro.compliance} shall include the text of
 the \grammarterm{string-literal}, if one is supplied,
 except that characters not in the basic
-source character set~(\ref{lex.charset}) are not required to appear in
+source character set\iref{lex.charset} are not required to appear in
 the diagnostic message.
 \begin{example}
 
@@ -182,9 +182,9 @@ An \grammarterm{empty-declaration} has no effect.
 
 \pnum
 A \grammarterm{simple-declaration} with an \grammarterm{identifier-list} is called
-a \defn{structured binding declaration}~(\ref{dcl.struct.bind}).
+a \defn{structured binding declaration}\iref{dcl.struct.bind}.
 The \grammarterm{decl-specifier-seq} shall
-contain only the \grammarterm{type-specifier} \tcode{auto}~(\ref{dcl.spec.auto})
+contain only the \grammarterm{type-specifier} \tcode{auto}\iref{dcl.spec.auto}
 and \grammarterm{cv-qualifier}{s}.
 The \grammarterm{initializer} shall be
 of the form ``\tcode{=} \grammarterm{assignment-expression}'',
@@ -199,10 +199,10 @@ Each \grammarterm{init-declarator} in the \grammarterm{init-declarator-list}
 contains exactly one \grammarterm{declarator-id}, which is the name
 declared by that \grammarterm{init-declarator} and hence one of the names
 declared by the declaration. The
-\grammarterm{defining-type-specifier}{s}~(\ref{dcl.type}) in the
+\grammarterm{defining-type-specifier}{s}\iref{dcl.type} in the
 \grammarterm{decl-specifier-seq} and the recursive \grammarterm{declarator}
 structure of the \grammarterm{init-declarator} describe a
-type~(\ref{dcl.meaning}), which is then associated with the name being
+type\iref{dcl.meaning}, which is then associated with the name being
 declared by the \grammarterm{init-declarator}.
 
 \pnum
@@ -210,10 +210,10 @@ If the \grammarterm{decl-specifier-seq} contains the \tcode{typedef}
 specifier, the declaration is called a \term{typedef declaration} and the name
 of each \grammarterm{init-declarator}
 is declared to be a \grammarterm{typedef-name}, synonymous with its
-associated type~(\ref{dcl.typedef}). If the
+associated type\iref{dcl.typedef}. If the
 \grammarterm{decl-specifier-seq} contains no \tcode{typedef} specifier, the
 declaration is called a \term{function declaration} if
-the type associated with the name is a function type~(\ref{dcl.fct}) and
+the type associated with the name is a function type\iref{dcl.fct} and
 an \term{object declaration} otherwise.
 
 \pnum
@@ -222,11 +222,11 @@ Syntactic components beyond those found in the general form of
 declaration are added to a function declaration to make a
 \grammarterm{function-definition}. An object declaration, however, is also
 a definition unless it contains the \tcode{extern} specifier and has no
-initializer~(\ref{basic.def}).
+initializer\iref{basic.def}.
 \indextext{initialization!definition and}%
 A
 definition causes the appropriate amount of storage to be reserved and
-any appropriate initialization~(\ref{dcl.init}) to be done.
+any appropriate initialization\iref{dcl.init} to be done.
 
 \pnum
 A \grammarterm{nodeclspec-function-declaration} shall declare a
@@ -234,9 +234,9 @@ constructor, destructor, or conversion function.\footnote{The
 ``implicit int'' rule of C is no longer supported.}
 \begin{note}
 A \grammarterm{nodeclspec-function-declaration} can only be used in a
-\grammarterm{template-declaration}~(Clause~\ref{temp}),
-\grammarterm{explicit-instantiation}~(\ref{temp.explicit}), or
-\grammarterm{explicit-specialization}~(\ref{temp.expl.spec}).
+\grammarterm{template-declaration}\iref{temp},
+\grammarterm{explicit-instantiation}\iref{temp.explicit}, or
+\grammarterm{explicit-specialization}\iref{temp.expl.spec}.
 \end{note}
 
 \rSec1[dcl.spec]{Specifiers}%
@@ -265,7 +265,7 @@ The specifiers that can be used in a declaration are
 
 The optional \grammarterm{attribute-specifier-seq} in a \grammarterm{decl-specifier-seq}
 appertains to the type determined by the preceding
-\grammarterm{decl-specifier}{s}~(\ref{dcl.meaning}). The \grammarterm{attribute-specifier-seq}
+\grammarterm{decl-specifier}{s}\iref{dcl.meaning}. The \grammarterm{attribute-specifier-seq}
 affects the type only for the declaration it appears in, not other declarations involving the
 same type.
 
@@ -348,25 +348,25 @@ of the declaration shall not be
 empty (except for an anonymous union declared in a named namespace or in the
 global namespace, which shall be declared
 \indextext{specifier!\idxcode{static}}%
-\tcode{static}~(\ref{class.union.anon})). The
+\tcode{static}\iref{class.union.anon}). The
 \grammarterm{storage-class-specifier} applies to the name declared by each
 \grammarterm{init-declarator} in the list and not to any names declared by
 other specifiers. A \grammarterm{storage-class-specifier}
 other than \tcode{thread_local}
 shall not be
-specified in an explicit specialization~(\ref{temp.expl.spec}) or an
-explicit instantiation~(\ref{temp.explicit}) directive.
+specified in an explicit specialization\iref{temp.expl.spec} or an
+explicit instantiation\iref{temp.explicit} directive.
 
 \pnum
 \begin{note}
 A variable declared without a \grammarterm{storage-class-specifier}
 at block scope or declared as a function parameter
-has automatic storage duration by default~(\ref{basic.stc.auto}).
+has automatic storage duration by default\iref{basic.stc.auto}.
 \end{note}
 
 \pnum
 The \tcode{thread_local} specifier
-indicates that the named entity has thread storage duration~(\ref{basic.stc.thread}). It
+indicates that the named entity has thread storage duration\iref{basic.stc.thread}. It
 shall be applied only
 to the names of variables of namespace
 or block scope and to the names of static data members.
@@ -378,13 +378,13 @@ When \tcode{thread_local} is applied to a variable of block scope the
 \pnum
 \indextext{restriction!\idxcode{static}}%
 The \tcode{static} specifier can be applied only to names of variables and
-functions and to anonymous unions~(\ref{class.union.anon}). There can be no
+functions and to anonymous unions\iref{class.union.anon}. There can be no
 \tcode{static} function declarations within a block, nor any
 \tcode{static} function parameters. A \tcode{static} specifier used in
 the declaration of a variable declares the variable to have static storage
-duration~(\ref{basic.stc.static}), unless accompanied by the
+duration\iref{basic.stc.static}, unless accompanied by the
 \tcode{thread_local} specifier, which declares the variable to have thread
-storage duration~(\ref{basic.stc.thread}). A \tcode{static} specifier can be
+storage duration\iref{basic.stc.thread}. A \tcode{static} specifier can be
 used in declarations of class members;~\ref{class.static} describes its
 effect.
 \indextext{\idxcode{static}!linkage of}%
@@ -471,7 +471,7 @@ void h() {
 
 \pnum
 The \tcode{mutable} specifier shall appear only in the declaration of
-a non-static data member~(\ref{class.mem})
+a non-static data member\iref{class.mem}
 whose type is neither const-qualified nor a reference type.
 \begin{example}
 \begin{codeblock}
@@ -486,7 +486,7 @@ class X {
 The \tcode{mutable} specifier on a class data member nullifies a
 \tcode{const} specifier applied to the containing class object and
 permits modification of the mutable class member even though the rest of
-the object is \tcode{const}~(\ref{dcl.type.cv}).
+the object is \tcode{const}\iref{dcl.type.cv}.
 
 \rSec2[dcl.fct.spec]{Function specifiers}%
 \indextext{specifier!function}%
@@ -520,14 +520,14 @@ see~\ref{class.conv.ctor} and~\ref{class.conv.fct}.
 \pnum
 Declarations containing the \grammarterm{decl-specifier} \tcode{typedef}
 declare identifiers that can be used later for naming
-fundamental~(\ref{basic.fundamental}) or compound~(\ref{basic.compound})
+fundamental\iref{basic.fundamental} or compound\iref{basic.compound}
 types. The \tcode{typedef} specifier shall not be
 combined in a \grammarterm{decl-specifier-seq} with any other kind of
 specifier except a \grammarterm{defining-type-specifier}, and it shall not be used in the
 \grammarterm{decl-specifier-seq} of a
-\grammarterm{parameter-declaration}~(\ref{dcl.fct}) nor in the
+\grammarterm{parameter-declaration}\iref{dcl.fct} nor in the
 \grammarterm{decl-specifier-seq} of a
-\grammarterm{function-definition}~(\ref{dcl.fct.def}).
+\grammarterm{function-definition}\iref{dcl.fct.def}.
 If a \tcode{typedef} specifier appears in a declaration without a \grammarterm{declarator},
 the program is ill-formed.
 
@@ -540,13 +540,13 @@ A name declared with the \tcode{typedef} specifier becomes a
 \grammarterm{typedef-name}. Within the scope of its declaration, a
 \grammarterm{typedef-name} is syntactically equivalent to a keyword and
 names the type associated with the identifier in the way described in
-Clause~\ref{dcl.decl}.
+\ref{dcl.decl}.
 \indextext{declaration!typedef@\tcode{typedef} as type}%
 \indextext{equivalence!type}%
 \indextext{synonym!type name as}%
 A \grammarterm{typedef-name} is thus a synonym for another type. A
 \grammarterm{typedef-name} does not introduce a new type the way a class
-declaration~(\ref{class.name}) or enum declaration does.
+declaration\iref{class.name} or enum declaration does.
 \begin{example}
 \indextext{example!\idxcode{typedef}}%
 After
@@ -664,12 +664,12 @@ class complex { @\commentellip@ };    // error: redefinition
 \begin{note}
 \indextext{class name!\idxcode{typedef}}%
 A \grammarterm{typedef-name} that names a class type, or a cv-qualified
-version thereof, is also a \grammarterm{class-name}~(\ref{class.name}). If
+version thereof, is also a \grammarterm{class-name}\iref{class.name}. If
 a \grammarterm{typedef-name} is used to identify the subject of an
-\grammarterm{elaborated-type-specifier}~(\ref{dcl.type.elab}), a class
-definition (Clause~\ref{class}), a constructor
-declaration~(\ref{class.ctor}), or a destructor
-declaration~(\ref{class.dtor}), the program is ill-formed.
+\grammarterm{elaborated-type-specifier}\iref{dcl.type.elab}, a class
+definition\iref{class}, a constructor
+declaration\iref{class.ctor}, or a destructor
+declaration\iref{class.dtor}, the program is ill-formed.
 \end{note}
 \begin{example}
 
@@ -693,7 +693,7 @@ struct T * p;                   // error
 If the typedef declaration defines an unnamed class (or enum), the first
 \grammarterm{typedef-name} declared by the declaration to be that class
 type (or enum type) is used to denote the class type (or enum type) for
-linkage purposes only~(\ref{basic.link}).
+linkage purposes only\iref{basic.link}.
 \begin{example}
 
 \begin{codeblock}
@@ -717,7 +717,7 @@ a variable or variable template or
 the declaration of a
 function or function template.
 A function or static data member declared with the \tcode{constexpr}
-specifier is implicitly an inline function or variable~(\ref{dcl.inline}).
+specifier is implicitly an inline function or variable\iref{dcl.inline}.
 If any declaration of a function or function template has
 a \tcode{constexpr} specifier,
 then all its declarations shall contain the \tcode{constexpr} specifier. \begin{note} An
@@ -738,7 +738,7 @@ constexpr pixel::pixel(int a)
   : x(a), y(x)                  // OK: definition
   { square(x); }
 constexpr pixel small(2);       // error: \tcode{square} not defined, so \tcode{small(2)}
-                                // not constant~(\ref{expr.const}) so \tcode{constexpr} not satisfied
+                                // not constant\iref{expr.const} so \tcode{constexpr} not satisfied
 
 constexpr void square(int &x) { // OK: definition
   x *= x;
@@ -767,7 +767,7 @@ requirements:
 
 \begin{itemize}
 \item
-it shall not be virtual~(\ref{class.virtual});
+it shall not be virtual\iref{class.virtual};
 
 \item
 its return type shall be a literal type;
@@ -784,7 +784,7 @@ that does not contain
 \begin{itemize}
 \item an \grammarterm{asm-definition},
 \item a \tcode{goto} statement,
-\item an identifier label~(\ref{stmt.label}),
+\item an identifier label\iref{stmt.label},
 \item a \grammarterm{try-block}, or
 \item a definition of a variable
 of non-literal type or
@@ -848,10 +848,10 @@ constexpr function;
 
 \item
 every non-variant non-static data member and base class subobject
-shall be initialized~(\ref{class.base.init});
+shall be initialized\iref{class.base.init};
 
 \item
-if the class is a union having variant members~(\ref{class.union}), exactly one of them
+if the class is a union having variant members\iref{class.union}, exactly one of them
 shall be initialized;
 
 \item
@@ -882,8 +882,8 @@ For a constexpr function or constexpr constructor
 that is neither defaulted nor a template,
 if no argument values exist such that
 an invocation of the function or constructor could be an evaluated subexpression of a core
-constant expression~(\ref{expr.const}), or,
-for a constructor, a constant initializer for some object~(\ref{basic.start.static}),
+constant expression\iref{expr.const}, or,
+for a constructor, a constant initializer for some object\iref{basic.start.static},
 the program is ill-formed, no diagnostic required.
 \begin{example}
 \begin{codeblock}
@@ -924,9 +924,9 @@ non-constexpr function in all respects except that
 \begin{itemize}
 \item
 a call to a constexpr
-function can appear in a constant expression~(\ref{expr.const}) and
+function can appear in a constant expression\iref{expr.const} and
 \item
-copy elision is mandatory in a constant expression~(\ref{class.copy}).
+copy elision is mandatory in a constant expression\iref{class.copy}.
 \end{itemize}
 
 \pnum
@@ -949,7 +949,7 @@ shall have literal type and
 shall be initialized.
 In any \tcode{constexpr} variable declaration,
 the full-expression of the initialization
-shall be a constant expression~(\ref{expr.const}).
+shall be a constant expression\iref{expr.const}.
 \begin{example}
 \begin{codeblock}
 struct pixel {
@@ -997,7 +997,7 @@ been declared inline.
 \pnum
 An inline function or variable shall be defined in every translation unit in which
 it is odr-used and shall have exactly the same definition in every
-case~(\ref{basic.def.odr}).
+case\iref{basic.def.odr}.
 \begin{note}
 A call to the inline function or a use of the inline variable may be encountered before its definition
 appears in the translation unit.
@@ -1056,7 +1056,7 @@ The optional \grammarterm{attribute-specifier-seq} in a \grammarterm{type-specif
 or a \grammarterm{defining-type-specifier-seq}
 appertains
 to the type denoted by the preceding \grammarterm{type-specifier}{s}
-or \grammarterm{defining-type-specifier}{s}~(\ref{dcl.meaning}). The
+or \grammarterm{defining-type-specifier}{s}\iref{dcl.meaning}. The
 \grammarterm{attribute-specifier-seq} affects the type only for the declaration it appears in,
 not other declarations involving the same type.
 
@@ -1107,7 +1107,7 @@ and
 are discussed
 in
 \ref{dcl.enum},
-Clause~\ref{class},
+\ref{class},
 and
 \ref{temp.res}, respectively. The remaining
 \grammarterm{type-specifier}{s} are discussed in the rest of this section.
@@ -1135,8 +1135,8 @@ these could be introduced by typedefs.\end{note}
 
 \pnum
 \begin{note}
-Declaring a variable \tcode{const} can affect its linkage~(\ref{dcl.stc})
-and its usability in constant expressions~(\ref{expr.const}). As
+Declaring a variable \tcode{const} can affect its linkage\iref{dcl.stc}
+and its usability in constant expressions\iref{expr.const}. As
 described in~\ref{dcl.init}, the definition of an object or subobject
 of const-qualified type must specify an initializer or be subject to
 default-initialization.
@@ -1150,14 +1150,14 @@ the object referenced is a non-const object and can be modified through
 some other access path.
 \begin{note}
 Cv-qualifiers are supported by the type system so that they cannot be
-subverted without casting~(\ref{expr.const.cast}).
+subverted without casting\iref{expr.const.cast}.
 \end{note}
 
 \pnum
 \indextext{const object@\tcode{const}-object!undefined change to}%
-Except that any class member declared \tcode{mutable}~(\ref{dcl.stc})
+Except that any class member declared \tcode{mutable}\iref{dcl.stc}
 can be modified, any attempt to modify a \tcode{const} object during its
-lifetime~(\ref{basic.life}) results in undefined behavior.
+lifetime\iref{basic.life} results in undefined behavior.
 \begin{example}
 \begin{codeblock}
 const int ci = 3;                       // cv-qualified (initialized as required)
@@ -1279,19 +1279,19 @@ The simple type specifiers are
 \indextext{\idxgram{lambda-introducer}}%
 The \grammarterm{simple-type-specifier} \tcode{auto}
 is a placeholder for
-a type to be deduced~(\ref{dcl.spec.auto}).
+a type to be deduced\iref{dcl.spec.auto}.
 \indextext{deduction!class template arguments}%
 A \grammarterm{type-specifier} of the form
 \tcode{typename}\opt{} \grammarterm{nested-name-specifier}\opt{} \grammarterm{template-name}
 is a placeholder for
-a deduced class type~(\ref{dcl.type.class.deduct}).
+a deduced class type\iref{dcl.type.class.deduct}.
 The \grammarterm{template-name} shall name a class template
 that is not an injected-class-name.
 The other
 \grammarterm{simple-type-specifier}{s}
 specify either a previously-declared type, a type determined from an
 expression, or one of the
-fundamental types~(\ref{basic.fundamental}).
+fundamental types\iref{basic.fundamental}.
 Table~\ref{tab:simple.type.specifiers}
  summarizes the valid combinations of
 \grammarterm{simple-type-specifier}{s}
@@ -1361,14 +1361,14 @@ For an expression \tcode{e}, the type denoted by \tcode{decltype(e)} is defined 
 
 \begin{itemize}
 \item if \tcode{e} is an unparenthesized \grammarterm{id-expression}
-naming a structured binding~(\ref{dcl.struct.bind}),
+naming a structured binding\iref{dcl.struct.bind},
 \tcode{decltype(e)} is the referenced type as given in
 the specification of the structured binding declaration;
 
 \item otherwise, if \tcode{e} is an unparenthesized \grammarterm{id-expression} or
 an unparenthesized
 class
-member access~(\ref{expr.ref}), \tcode{decltype(e)} is the
+member access\iref{expr.ref}, \tcode{decltype(e)} is the
 type of the entity named by \tcode{e}. If there is no such entity, or
 if \tcode{e} names a set of overloaded functions, the program is
 ill-formed;
@@ -1384,7 +1384,7 @@ is \tcode{T\&}, where \tcode{T} is the type of \tcode{e};
 \end{itemize}
 
 The operand of the \tcode{decltype} specifier is an unevaluated
-operand (Clause~\ref{expr}).
+operand\iref{expr}.
 
 \begin{example}
 \begin{codeblock}
@@ -1405,7 +1405,7 @@ in~\ref{dcl.spec.auto}.
 
 \pnum
 If the operand of a \grammarterm{decltype-specifier} is a prvalue,
-the temporary materialization conversion is not applied~(\ref{conv.rval})
+the temporary materialization conversion is not applied\iref{conv.rval}
 and no result object is provided for the prvalue.
 The type of the prvalue may be incomplete.
 \begin{note}
@@ -1437,7 +1437,7 @@ template<class T> auto f(T)     // \#2
   -> void;
 auto g() -> void {
   f(42);                        // OK: calls \#2. (\#1 is not a viable candidate: type deduction
-                                // fails~(\ref{temp.deduct}) because \tcode{A<int>::\tilde{}A()} is implicitly used in its
+                                // fails\iref{temp.deduct} because \tcode{A<int>::\tilde{}A()} is implicitly used in its
                                 // \grammarterm{decltype-specifier})
 }
 template<class T> auto q(T)
@@ -1472,8 +1472,8 @@ An \grammarterm{attribute-specifier-seq} shall not appear in an \grammarterm{ela
 unless the latter is the sole constituent of a declaration.
 If an \grammarterm{elaborated-type-specifier} is the sole constituent of a
 declaration, the declaration is ill-formed unless it is an explicit
-specialization~(\ref{temp.expl.spec}), an explicit
-instantiation~(\ref{temp.explicit}) or it has one of the following
+specialization\iref{temp.expl.spec}, an explicit
+instantiation\iref{temp.explicit} or it has one of the following
 forms:
 
 \begin{ncsimplebnf}
@@ -1509,7 +1509,7 @@ This implies that, within a class template with a template
 friend class T;
 \end{codeblock}
 
-is ill-formed. However, the similar declaration \tcode{friend T;} is allowed~(\ref{class.friend}).
+is ill-formed. However, the similar declaration \tcode{friend T;} is allowed\iref{class.friend}.
 \end{note}
 
 \pnum
@@ -1523,11 +1523,11 @@ the form of \grammarterm{elaborated-type-specifier} that declares a
 as referring to the definition of the class. Thus, in any
 \grammarterm{elaborated-type-specifier}, the \tcode{enum} keyword
 shall be
-used to refer to an enumeration~(\ref{dcl.enum}), the \tcode{union}
+used to refer to an enumeration\iref{dcl.enum}, the \tcode{union}
 \grammarterm{class-key} shall be used to refer to a union
-(Clause~\ref{class}), and either the \tcode{class} or \tcode{struct}
+(\ref{class}), and either the \tcode{class} or \tcode{struct}
 \grammarterm{class-key} shall be used to refer to a class
-(Clause~\ref{class}) declared using the \tcode{class} or \tcode{struct}
+(\ref{class}) declared using the \tcode{class} or \tcode{struct}
 \grammarterm{class-key}. \begin{example}
 
 \begin{codeblock}
@@ -1546,28 +1546,28 @@ designate a placeholder type that will be replaced later by deduction
 from an initializer. The \tcode{auto}
 \grammarterm{type-specifier} is also used to
 introduce a function type having a \grammarterm{trailing-return-type} or to
-signify that a lambda is a generic lambda~(\ref{expr.prim.lambda}).
+signify that a lambda is a generic lambda\iref{expr.prim.lambda}.
 The \tcode{auto} \grammarterm{type-specifier} is also used to introduce a
-structured binding declaration~(\ref{dcl.struct.bind}).
+structured binding declaration\iref{dcl.struct.bind}.
 
 \pnum
 The placeholder type can appear with a function declarator in the
 \grammarterm{decl-specifier-seq}, \grammarterm{type-specifier-seq},
 \grammarterm{conversion-function-id}, or \grammarterm{trailing-return-type},
 in any context where such a declarator is valid. If the function declarator
-includes a \grammarterm{trailing-return-type}~(\ref{dcl.fct}), that
+includes a \grammarterm{trailing-return-type}\iref{dcl.fct}, that
 \grammarterm{trailing-return-type} specifies
 the declared return type of the function. Otherwise, the function declarator
 shall declare a function. If the declared return type of the
 function contains a placeholder type, the return type of the function is
 deduced from non-discarded \tcode{return} statements, if any, in the body
-of the function~(\ref{stmt.if}).
+of the function\iref{stmt.if}.
 
 \pnum
 The type of a variable declared using \tcode{auto} or \tcode{decltype(auto)} is
 deduced from its initializer.
 This use is allowed
-in an initializing declaration~(\ref{dcl.init}) of a variable.
+in an initializing declaration\iref{dcl.init} of a variable.
 \tcode{auto} or \tcode{decltype(auto)} shall appear as one of the
 \grammarterm{decl-specifier}{s} in the
 \grammarterm{decl-specifier-seq} and the
@@ -1601,11 +1601,11 @@ auto h();                       // OK: \tcode{h}'s return type will be deduced w
 A placeholder type can also be used
 in the \grammarterm{type-specifier-seq} in
 the \grammarterm{new-type-id} or \grammarterm{type-id} of a
-\grammarterm{new-expression}~(\ref{expr.new})
+\grammarterm{new-expression}\iref{expr.new}
 and as a \grammarterm{decl-specifier}
 of the \grammarterm{parameter-declaration}{'s}
 \grammarterm{decl-specifier-seq}
-in a \grammarterm{template-parameter}~(\ref{temp.param}).
+in a \grammarterm{template-parameter}\iref{temp.param}.
 
 \pnum
 A program that uses \tcode{auto} or \tcode{decltype(auto)} in a context not
@@ -1615,7 +1615,7 @@ explicitly allowed in this section is ill-formed.
 If the \grammarterm{init-declarator-list} contains more than one
 \grammarterm{init-declarator}, they shall all form declarations of
 variables. The type of each declared variable is determined
-by placeholder type deduction~(\ref{dcl.type.auto.deduct}),
+by placeholder type deduction\iref{dcl.type.auto.deduct},
 and if the type that replaces the placeholder type is not the
 same in each deduction, the program is ill-formed.
 
@@ -1671,7 +1671,7 @@ body contains a \tcode{return} statement with a non-type-dependent operand.
 \begin{note} Therefore, any use of a specialization of the function template will
 cause an implicit instantiation. Any errors that arise from this instantiation
 are not in the immediate context of the function type and can result in the
-program being ill-formed~(\ref{temp.deduct}). \end{note}
+program being ill-formed\iref{temp.deduct}. \end{note}
 \begin{example}
 \begin{codeblock}
 template <class T> auto f(T t) { return t; }    // return type deduced at instantiation time
@@ -1714,10 +1714,10 @@ auto frf(int i) { return i; }                   // not a friend of \tcode{A<int>
 
 \pnum
 A function declared with a return type that uses a placeholder type shall not
-be \tcode{virtual}~(\ref{class.virtual}).
+be \tcode{virtual}\iref{class.virtual}.
 
 \pnum
-An explicit instantiation declaration~(\ref{temp.explicit}) does not cause the
+An explicit instantiation declaration\iref{temp.explicit} does not cause the
 instantiation of an entity declared using a placeholder type, but it also does
 not prevent that entity from being instantiated as needed to determine its
 type.
@@ -1777,7 +1777,7 @@ or with an operand of type \tcode{void},
 
 \pnum
 If the deduction is for a \tcode{return} statement
-and \tcode{e} is a \grammarterm{braced-init-list}~(\ref{dcl.init.list}),
+and \tcode{e} is a \grammarterm{braced-init-list}\iref{dcl.init.list},
 the program is ill-formed.
 
 \pnum
@@ -1790,7 +1790,7 @@ Obtain \tcode{P} from
 invented type template parameter \tcode{U} or,
 if the initialization is copy-list-initialization, with
 \tcode{std::initializer_list<U>}. Deduce a value for \tcode{U} using the rules
-of template argument deduction from a function call~(\ref{temp.deduct.call}),
+of template argument deduction from a function call\iref{temp.deduct.call},
 where \tcode{P} is a
 function template parameter type and
 the corresponding argument is \tcode{e}.
@@ -1850,10 +1850,10 @@ decltype(auto)*x7d = &i;        // error, declared type is not plain \tcode{decl
 If a placeholder for a deduced class type
 appears as a \grammarterm{decl-specifier}
 in the \grammarterm{decl-specifier-seq}
-of an initializing declaration~(\ref{dcl.init}) of a variable,
+of an initializing declaration\iref{dcl.init} of a variable,
 the placeholder is replaced by the return type
 of the function selected by overload resolution
-for class template deduction~(\ref{over.match.class.deduct}).
+for class template deduction\iref{over.match.class.deduct}.
 If the \grammarterm{decl-specifier-seq}
 is followed by an \grammarterm{init-declarator-list}
 or \grammarterm{member-declarator-list}
@@ -1865,10 +1865,10 @@ A placeholder for a deduced class type
 can also be used
 in the \grammarterm{type-specifier-seq}
 in the \grammarterm{new-type-id} or \grammarterm{type-id}
-of a \grammarterm{new-expression}~(\ref{expr.new}),
+of a \grammarterm{new-expression}\iref{expr.new},
 or
 as the \grammarterm{simple-type-specifier}
-in an explicit type conversion (functional notation)~(\ref{expr.type.conv}).
+in an explicit type conversion (functional notation)\iref{expr.type.conv}.
 A placeholder for a deduced class type
 shall not appear in any other context.
 
@@ -1896,7 +1896,7 @@ container e{5, 6};                      // error, \tcode{int} is not an iterator
 \indextext{\idxcode{enum}!type of}
 
 \pnum
-An enumeration is a distinct type~(\ref{basic.compound}) with named
+An enumeration is a distinct type\iref{basic.compound} with named
 constants. Its name becomes an \grammarterm{enum-name} within its scope.
 
 \begin{bnf}
@@ -1977,7 +1977,7 @@ type. \begin{example}
 \end{note}
 If an \grammarterm{opaque-enum-declaration} contains
 a \grammarterm{nested-name-specifier},
-the declaration shall be an explicit specialization~(\ref{temp.expl.spec}).
+the declaration shall be an explicit specialization\iref{temp.expl.spec}.
 
 \pnum
 \indextext{constant!enumeration}%
@@ -2056,7 +2056,7 @@ prior to the closing brace is the underlying
 type
 and the \grammarterm{constant-expression} in the \grammarterm{enumerator-definition}
 shall be a converted constant expression of the underlying
-type~(\ref{expr.const}).
+type\iref{expr.const}.
 If the underlying
 type is not fixed,
 the type of each enumerator prior to the closing brace is determined as
@@ -2066,7 +2066,7 @@ follows:
 \item If an
 initializer is specified for an enumerator, the
 \grammarterm{constant-expression} shall be an integral constant
-expression~(\ref{expr.const}). If the expression has
+expression\iref{expr.const}. If the expression has
 unscoped enumeration type, the enumerator has the underlying type of that
 enumeration type, otherwise it has the same type as the expression.
 
@@ -2083,7 +2083,7 @@ is ill-formed.
 
 \pnum
 An enumeration whose underlying type is fixed is an incomplete type from its
-point of declaration~(\ref{basic.scope.pdecl}) to immediately after its
+point of declaration\iref{basic.scope.pdecl} to immediately after its
 \grammarterm{enum-base} (if any), at which point it becomes a complete type.
 An enumeration whose underlying type is not fixed is an incomplete type from
 its point of declaration to immediately after the closing \tcode{\}} of its
@@ -2133,7 +2133,7 @@ if they have the same underlying type.
 
 \pnum
 The value of an enumerator or an object of an unscoped enumeration type is
-converted to an integer by integral promotion~(\ref{conv.prom}).
+converted to an integer by integral promotion\iref{conv.prom}.
 \begin{example}
 \indextext{example!enumeration}%
 \begin{codeblock}
@@ -2218,7 +2218,7 @@ If an \grammarterm{enum-head} contains a \grammarterm{nested-name-specifier},
 the \grammarterm{enum-specifier} shall refer to an enumeration
 that was previously declared directly in the class or namespace
 to which the \grammarterm{nested-name-specifier} refers, or
-in an element of the inline namespace set~(\ref{namespace.def})
+in an element of the inline namespace set\iref{namespace.def}
 of that namespace (i.e., not merely inherited or introduced by a
 \grammarterm{using-declaration}), and
 the \grammarterm{enum-specifier} shall appear in
@@ -2286,12 +2286,12 @@ see~\ref{basic.scope.namespace}.
 
 \pnum
 Every \grammarterm{namespace-definition} shall appear in the global scope
-or in a namespace scope~(\ref{basic.scope.namespace}).
+or in a namespace scope\iref{basic.scope.namespace}.
 
 \pnum
 In a \grammarterm{named-namespace-definition},
 the \grammarterm{identifier} is the name of the namespace.
-If the \grammarterm{identifier}, when looked up~(\ref{basic.lookup.unqual}),
+If the \grammarterm{identifier}, when looked up\iref{basic.lookup.unqual},
 refers to a \grammarterm{namespace-name} (but not a \grammarterm{namespace-alias})
 that was introduced in the namespace
 in which the \grammarterm{named-namespace-definition} appears
@@ -2361,15 +2361,15 @@ appertains to the namespace being defined or extended.
 Members of an inline namespace can be used in most respects as though they were members
 of the enclosing namespace. Specifically, the inline namespace and its enclosing
 namespace are both added to the set of associated namespaces used in
-argument-dependent lookup~(\ref{basic.lookup.argdep}) whenever one of them is,
-and a \grammarterm{using-directive}~(\ref{namespace.udir}) that names the inline
+argument-dependent lookup\iref{basic.lookup.argdep} whenever one of them is,
+and a \grammarterm{using-directive}\iref{namespace.udir} that names the inline
 namespace is implicitly inserted into the enclosing namespace as for an unnamed
-namespace~(\ref{namespace.unnamed}). Furthermore, each
+namespace\iref{namespace.unnamed}. Furthermore, each
 member of the inline namespace can subsequently be partially
-specialized~(\ref{temp.class.spec}), explicitly
-instantiated~(\ref{temp.explicit}), or explicitly specialized~(\ref{temp.expl.spec}) as
+specialized\iref{temp.class.spec}, explicitly
+instantiated\iref{temp.explicit}, or explicitly specialized\iref{temp.expl.spec} as
 though it were a member of the enclosing namespace. Finally, looking up a name in the
-enclosing namespace via explicit qualification~(\ref{namespace.qual}) will include
+enclosing namespace via explicit qualification\iref{namespace.qual} will include
 members of the inline namespace brought in by the \grammarterm{using-directive} even if
 there are declarations of that name in the enclosing namespace.
 
@@ -2459,17 +2459,17 @@ void h() {
 
 \pnum
 A declaration in a namespace \tcode{N} (excluding declarations in nested scopes)
-whose \grammarterm{declarator-id} is an \grammarterm{unqualified-id}~(\ref{dcl.meaning}),
-whose \grammarterm{class-head-name} (Clause \ref{class}) or
-\grammarterm{enum-head-name}~(\ref{dcl.enum}) is an \grammarterm{identifier}, or
+whose \grammarterm{declarator-id} is an \grammarterm{unqualified-id}\iref{dcl.meaning},
+whose \grammarterm{class-head-name}\iref{class} or
+\grammarterm{enum-head-name}\iref{dcl.enum} is an \grammarterm{identifier}, or
 whose \grammarterm{elaborated-type-specifier} is of the form \grammarterm{class-key}
-\grammarterm{attribute-specifier-seq}\opt{} \grammarterm{identifier}~(\ref{dcl.type.elab}), or
+\grammarterm{attribute-specifier-seq}\opt{} \grammarterm{identifier}\iref{dcl.type.elab}, or
 that is an \grammarterm{opaque-enum-declaration},
 declares (or redeclares) its \grammarterm{unqualified-id} or
 \grammarterm{identifier} as a member of \tcode{N}.
 \begin{note}
-An explicit instantiation~(\ref{temp.explicit}) or
-explicit specialization~(\ref{temp.expl.spec}) of a template
+An explicit instantiation\iref{temp.explicit} or
+explicit specialization\iref{temp.expl.spec} of a template
 does not introduce a name and thus may be declared using an
 \grammarterm{unqualified-id} in a member of the enclosing namespace set,
 if the primary template is declared in an inline namespace.
@@ -2491,7 +2491,7 @@ namespace X {
 \pnum
 Members of a named namespace can also be
 defined outside that namespace by explicit
-qualification~(\ref{namespace.qual}) of the name being defined, provided
+qualification\iref{namespace.qual} of the name being defined, provided
 that the entity being defined was already declared in the namespace and
 the definition appears after the point of declaration in a namespace
 that encloses the declaration's namespace.
@@ -2519,15 +2519,15 @@ If a \tcode{friend} declaration in a non-local class first declares a
 class, function, class template or function template\footnote{this implies that the name of the class or function is unqualified.}
 the friend is a member of the innermost enclosing
 namespace. The \tcode{friend} declaration does not by itself make the name
-visible to unqualified lookup~(\ref{basic.lookup.unqual}) or qualified
-lookup~(\ref{basic.lookup.qual}). \begin{note} The name of the friend will be
+visible to unqualified lookup\iref{basic.lookup.unqual} or qualified
+lookup\iref{basic.lookup.qual}. \begin{note} The name of the friend will be
 visible in its namespace if a matching declaration is provided at namespace
 scope (either before or after the class definition granting friendship).
 \end{note} If a friend
 function or function template is called, its name may be found by the
 name lookup that considers functions from namespaces and classes
 associated with the types of the function
-arguments~(\ref{basic.lookup.argdep}). If the
+arguments\iref{basic.lookup.argdep}. If the
 name in a \tcode{friend} declaration is neither qualified nor a
 \grammarterm{template-id} and the declaration is a function or an
 \grammarterm{elaborated-type-specifier}, the lookup to determine whether
@@ -2728,11 +2728,11 @@ Since destructors do not have names, a
 destructor for a base class. Since specializations of member templates
 for conversion functions are not found by name lookup, they are not
 considered when a \grammarterm{using-declaration} specifies a conversion
-function~(\ref{temp.mem}).
+function\iref{temp.mem}.
 \end{note}
 If a constructor or assignment operator brought from a base class into a derived class
 has the signature of a copy/move constructor or assignment operator
-for the derived class~(\ref{class.copy}),
+for the derived class\iref{class.copy},
 the \grammarterm{using-declaration} does not by itself
 suppress the implicit declaration of the derived class member;
 the member from the base class is hidden or overridden
@@ -2781,7 +2781,7 @@ void f() {
 \pnum
 Members declared by a \grammarterm{using-declaration} can be referred to by
 explicit qualification just like other member
-names~(\ref{namespace.qual}).
+names\iref{namespace.qual}.
 \begin{example}
 \begin{codeblock}
 void f();
@@ -2835,8 +2835,8 @@ members added to the namespace after the \grammarterm{using-declaration}
 are not in the set of introduced declarations, so they are not
 considered when a use of the name is made. Thus, additional
 overloads added after the \grammarterm{using-declaration} are ignored, but
-default function arguments~(\ref{dcl.fct.default}), default template
-arguments~(\ref{temp.param}), and template specializations~(\ref{temp.class.spec},
+default function arguments\iref{dcl.fct.default}, default template
+arguments\iref{temp.param}, and template specializations~(\ref{temp.class.spec},
 \ref{temp.expl.spec}) are considered. \end{note}
 \begin{example}
 
@@ -2868,13 +2868,13 @@ primary class template and then considering all partial specializations
 of that template. If a \grammarterm{using-declaration} names a class
 template, partial specializations introduced after the
 \grammarterm{using-declaration} are effectively visible because the primary
-template is visible~(\ref{temp.class.spec}).
+template is visible\iref{temp.class.spec}.
 \end{note}
 
 \pnum
 Since a \grammarterm{using-declaration} is a declaration, the restrictions
 on declarations of the same name in the same declarative
-region~(\ref{basic.scope}) also apply to \grammarterm{using-declaration}{s}.
+region\iref{basic.scope} also apply to \grammarterm{using-declaration}{s}.
 \begin{example}
 
 \begin{codeblock}
@@ -2910,7 +2910,7 @@ void func() {
 
 \pnum
 If a function declaration in namespace scope or block scope has the same
-name and the same parameter-type-list~(\ref{dcl.fct}) as
+name and the same parameter-type-list\iref{dcl.fct} as
 a function introduced by a \grammarterm{using-declaration}, and the
 declarations do not declare the same function, the program is
 ill-formed. If a function template declaration in namespace scope has
@@ -2953,7 +2953,7 @@ When a \grammarterm{using-declarator} brings declarations from a base class into
 a derived class, member functions and member function templates in
 the derived class override and/or hide member functions and member
 function templates with the same name,
-parameter-type-list~(\ref{dcl.fct}), cv-qualification, and \grammarterm{ref-qualifier} (if any) in a base
+parameter-type-list\iref{dcl.fct}, cv-qualification, and \grammarterm{ref-qualifier} (if any) in a base
 class (rather than conflicting).
 Such hidden or overridden declarations are excluded from the set of
 declarations introduced by the \grammarterm{using-declarator}.
@@ -3021,15 +3021,15 @@ This has no effect on the type of the function, and in all other
 respects the function remains a member of the base class.
 Likewise, constructors that are introduced by a \grammarterm{using-declaration}
 are treated as though they were constructors of the derived class
-when looking up the constructors of the derived class~(\ref{class.qual})
+when looking up the constructors of the derived class\iref{class.qual}
 or forming a set of overload candidates~(\ref{over.match.ctor}, \ref{over.match.copy}, \ref{over.match.list}).
 If such a constructor is selected to perform the initialization
 of an object of class type, all subobjects other than the base class
 from which the constructor originated
-are implicitly initialized~(\ref{class.inhctor.init}).
+are implicitly initialized\iref{class.inhctor.init}.
 \begin{note}
 A member of a derived class is sometimes preferred to a member of a base class
-if they would otherwise be ambiguous~(\ref{over.match.best}).
+if they would otherwise be ambiguous\iref{over.match.best}.
 \end{note}
 
 \pnum
@@ -3102,9 +3102,9 @@ public:
 
 \pnum
 If a \grammarterm{using-declarator} uses the keyword \tcode{typename} and
-specifies a dependent name~(\ref{temp.dep}), the name introduced by the
+specifies a dependent name\iref{temp.dep}, the name introduced by the
 \grammarterm{using-declaration} is treated as a
-\grammarterm{typedef-name}~(\ref{dcl.typedef}).%
+\grammarterm{typedef-name}\iref{dcl.typedef}.%
 \indextext{using-declaration|)}
 
 \rSec2[namespace.udir]{Using directive}%
@@ -3129,7 +3129,7 @@ The optional \grammarterm{attribute-specifier-seq} appertains to the \grammarter
 A \grammarterm{using-directive} specifies that the names in the nominated
 namespace can be used in the scope in which the
 \grammarterm{using-directive} appears after the \grammarterm{using-directive}.
-During unqualified name lookup~(\ref{basic.lookup.unqual}), the names
+During unqualified name lookup\iref{basic.lookup.unqual}, the names
 appear as if they were declared in the nearest enclosing namespace which
 contains both the \grammarterm{using-directive} and the nominated
 namespace.
@@ -3172,7 +3172,7 @@ void f4() {
 \end{example}
 
 \pnum
-For unqualified lookup~(\ref{basic.lookup.unqual}), the
+For unqualified lookup\iref{basic.lookup.unqual}, the
 \grammarterm{using-directive} is transitive: if a scope contains a
 \grammarterm{using-directive} that nominates a second namespace that itself
 contains \grammarterm{using-directive}{s}, the effect is as if the
@@ -3225,7 +3225,7 @@ namespace B {
 
 
 \pnum
-If a namespace is extended~(\ref{namespace.def}) after a
+If a namespace is extended\iref{namespace.def} after a
 \grammarterm{using-directive} for that namespace is given, the additional
 members of the extended namespace and the members of namespaces
 nominated by \grammarterm{using-directive}{s} in the
@@ -3279,7 +3279,7 @@ signature, even if one is in a namespace reachable through
 \grammarterm{using-directive}{s} in the namespace of the other.\footnote{During
 name lookup in a class hierarchy, some ambiguities may be
 resolved by considering whether one member hides the other along some
-paths~(\ref{class.member.lookup}). There is no such disambiguation when
+paths\iref{class.member.lookup}. There is no such disambiguation when
 considering the set of names found as a result of following
 \grammarterm{using-directive}{s}.}
 \begin{example}
@@ -3359,7 +3359,7 @@ different language linkages are distinct types even if they are
 otherwise identical.
 
 \pnum
-Linkage~(\ref{basic.link}) between \Cpp and  non-\Cpp code fragments can
+Linkage\iref{basic.link} between \Cpp and  non-\Cpp code fragments can
 be achieved using a \grammarterm{linkage-specification}:
 
 \indextext{\idxgram{linkage-specification}}%
@@ -3407,7 +3407,7 @@ extern "C" {
 Linkage specifications nest. When linkage specifications nest, the
 innermost one determines the language linkage. A linkage specification
 does not establish a scope. A \grammarterm{linkage-specification} shall
-occur only in namespace scope~(\ref{basic.scope}). In a
+occur only in namespace scope\iref{basic.scope}. In a
 \grammarterm{linkage-specification}, the specified language linkage applies
 to the function types of all function declarators, function names with
 external linkage, and variable names with external linkage declared
@@ -3478,7 +3478,7 @@ extern "C" {
 
 \pnum
 If two declarations declare functions with the same name and
-parameter-type-list~(\ref{dcl.fct}) to be members of the same
+parameter-type-list\iref{dcl.fct} to be members of the same
 namespace or declare objects with the same name to be members of the same
 namespace and the declarations give the names different language linkages, the
 program is ill-formed; no diagnostic is required if the declarations appear in
@@ -3542,7 +3542,7 @@ A declaration directly contained in a
 \grammarterm{linkage-specification}
 is treated as if it contains the
 \tcode{extern}
-specifier~(\ref{dcl.stc}) for the purpose of determining the linkage of the
+specifier\iref{dcl.stc} for the purpose of determining the linkage of the
 declared name and whether it is a definition. Such a declaration shall
 not specify a storage class.
 \begin{example}
@@ -3688,30 +3688,30 @@ affects the tokens in an \grammarterm{attribute-argument-clause}.
 \pnum
 In an \grammarterm{attribute-list}, an ellipsis may appear only if that
 \grammarterm{attribute}'s specification permits it. An \grammarterm{attribute} followed
-by an ellipsis is a pack expansion~(\ref{temp.variadic}).
+by an ellipsis is a pack expansion\iref{temp.variadic}.
 An \grammarterm{attribute-specifier} that contains no \grammarterm{attribute}{s} has no
 effect. The order in which the \grammarterm{attribute-token}{s} appear in an
 \grammarterm{attribute-list} is not significant. If a
-keyword~(\ref{lex.key})
-or an alternative token~(\ref{lex.digraph}) that satisfies the syntactic requirements
-of an \grammarterm{identifier}~(\ref{lex.name}) is
+keyword\iref{lex.key}
+or an alternative token\iref{lex.digraph} that satisfies the syntactic requirements
+of an \grammarterm{identifier}\iref{lex.name} is
 contained in
 an \grammarterm{attribute-token}, it is considered an identifier. No name
-lookup~(\ref{basic.lookup}) is performed on any of the identifiers contained in an
+lookup\iref{basic.lookup} is performed on any of the identifiers contained in an
 \grammarterm{attribute-token}. The \grammarterm{attribute-token} determines additional
 requirements on the \grammarterm{attribute-argument-clause} (if any).
 
 \pnum
 Each \grammarterm{attribute-specifier-seq} is said to \defn{appertain} to some entity or
 statement, identified by the syntactic context where it appears
-(Clause~\ref{stmt.stmt}, Clause~\ref{dcl.dcl},
-Clause~\ref{dcl.decl}). If an \grammarterm{attribute-specifier-seq} that appertains to some
+(\ref{stmt.stmt}, \ref{dcl.dcl},
+\ref{dcl.decl}). If an \grammarterm{attribute-specifier-seq} that appertains to some
 entity or statement contains an \grammarterm{attribute} or \grammarterm{alignment-specifier} that
 is not allowed to apply to that
 entity or statement, the program is ill-formed. If an \grammarterm{attribute-specifier-seq}
-appertains to a friend declaration~(\ref{class.friend}), that declaration shall be a
+appertains to a friend declaration\iref{class.friend}, that declaration shall be a
 definition. No \grammarterm{attribute-specifier-seq} shall appertain to an explicit
-instantiation~(\ref{temp.explicit}).
+instantiation\iref{temp.explicit}.
 
 \pnum
 For an \grammarterm{attribute-token}
@@ -3753,15 +3753,15 @@ void f() {
 An \grammarterm{alignment-specifier}
 may be applied to a variable
 or to a class data member, but it shall not be applied to a bit-field, a function
-parameter, or an \grammarterm{exception-declaration}~(\ref{except.handle}).
+parameter, or an \grammarterm{exception-declaration}\iref{except.handle}.
 An \grammarterm{alignment-specifier} may also be applied to the declaration or
 definition of a class (in an
-\grammarterm{elaborated-type-specifier}~(\ref{dcl.type.elab}) or
-\grammarterm{class-head} (Clause~\ref{class}), respectively) and to the
+\grammarterm{elaborated-type-specifier}\iref{dcl.type.elab} or
+\grammarterm{class-head}\iref{class}, respectively) and to the
 declaration or definition of an enumeration (in an
 \grammarterm{opaque-enum-declaration} or \grammarterm{enum-head},
-respectively~(\ref{dcl.enum})).
-An \grammarterm{alignment-specifier} with an ellipsis is a pack expansion~(\ref{temp.variadic}).
+respectively\iref{dcl.enum}).
+An \grammarterm{alignment-specifier} with an ellipsis is a pack expansion\iref{temp.variadic}.
 
 \pnum
 When the \grammarterm{alignment-specifier} is of the form
@@ -3771,7 +3771,7 @@ When the \grammarterm{alignment-specifier} is of the form
 \item the \grammarterm{constant-expression} shall be an integral constant expression
 
 \item if the constant expression does not evaluate to an alignment
-value~(\ref{basic.align}), or evaluates to an extended alignment and
+value\iref{basic.align}, or evaluates to an extended alignment and
 the implementation does not support that alignment in the context of the
 declaration, the program is ill-formed.
 \end{itemize}
@@ -3779,7 +3779,7 @@ declaration, the program is ill-formed.
 \pnum
 An \grammarterm{alignment-specifier} of the form
 \tcode{alignas(} \grammarterm{type-id} \tcode{)} has the same
-effect as \tcode{alignas(\brk{}alignof(} \grammarterm{type-id}~\tcode{))}~(\ref{expr.alignof}).
+effect as \tcode{alignas(\brk{}alignof(} \grammarterm{type-id}~\tcode{))}\iref{expr.alignof}.
 
 \pnum
 The alignment requirement of an entity is the strictest nonzero alignment
@@ -3858,8 +3858,8 @@ in each \grammarterm{attribute-list} and no
 applied to the \grammarterm{declarator-id} of a
 \grammarterm{parameter-declaration} in a function declaration or lambda, in
 which case it specifies that the initialization of the parameter carries a
-dependency to~(\ref{intro.multithread}) each lvalue-to-rvalue
-conversion~(\ref{conv.lval}) of that object. The attribute may also be applied
+dependency to\iref{intro.multithread} each lvalue-to-rvalue
+conversion\iref{conv.lval} of that object. The attribute may also be applied
 to the \grammarterm{declarator-id} of a function declaration, in which case it
 specifies that the return value, if any, carries a dependency to the evaluation
 of the function call expression.
@@ -3977,14 +3977,14 @@ to the name or entity. \end{note}
 
 \pnum
 The \grammarterm{attribute-token} \tcode{fallthrough}
-may be applied to a null statement~(\ref{stmt.expr});
+may be applied to a null statement\iref{stmt.expr};
 \indextext{statement!fallthrough}
 such a statement is a fallthrough statement.
 The \grammarterm{attribute-token} \tcode{fallthrough}
 shall appear at most once in each \grammarterm{attribute-list} and
 no \grammarterm{attribute-argument-clause} shall be present.
 A fallthrough statement may only appear within
-an enclosing \tcode{switch} statement~(\ref{stmt.switch}).
+an enclosing \tcode{switch} statement\iref{stmt.switch}.
 The next statement that would be executed after a fallthrough statement
 shall be a labeled statement whose label is a case label or
 default label for the same \tcode{switch} statement.
@@ -4077,7 +4077,7 @@ A nodiscard call is a function call expression that
 calls a function previously declared \tcode{nodiscard}, or
 whose return type is a possibly cv-qualified class or enumeration type
 marked \tcode{nodiscard}. Appearance of a nodiscard call as
-a potentially-evaluated discarded-value expression (Clause~\ref{expr})
+a potentially-evaluated discarded-value expression\iref{expr}
 is discouraged unless explicitly cast to \tcode{void}.
 Implementations should issue a warning in such cases.
 This is typically because discarding the return value

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1524,10 +1524,10 @@ as referring to the definition of the class. Thus, in any
 \grammarterm{elaborated-type-specifier}, the \tcode{enum} keyword
 shall be
 used to refer to an enumeration\iref{dcl.enum}, the \tcode{union}
-\grammarterm{class-key} shall be used to refer to a union
-(\ref{class}), and either the \tcode{class} or \tcode{struct}
-\grammarterm{class-key} shall be used to refer to a class
-(\ref{class}) declared using the \tcode{class} or \tcode{struct}
+\grammarterm{class-key} shall be used to refer to a union\iref{class},
+and either the \tcode{class} or \tcode{struct}
+\grammarterm{class-key} shall be used to refer to a class\iref{class}
+declared using the \tcode{class} or \tcode{struct}
 \grammarterm{class-key}. \begin{example}
 
 \begin{codeblock}

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -282,8 +282,7 @@ returning
 
 \pnum
 A type can also be named (often more easily) by using a
-\tcode{typedef}
-(\ref{dcl.typedef}).
+\tcode{typedef}\iref{dcl.typedef}.
 
 \rSec1[dcl.ambig.res]{Ambiguity resolution}%
 \indextext{ambiguity!declaration versus cast}%
@@ -495,8 +494,7 @@ the type specifiers
 \tcode{int}
 \tcode{unsigned}
 determine the type
-``\tcode{unsigned int}''
-(\ref{dcl.type.simple}).
+``\tcode{unsigned int}''\iref{dcl.type.simple}.
 \end{example}
 
 \pnum
@@ -791,8 +789,7 @@ There shall be no references to references,
 no arrays of references, and no pointers to references.
 \indextext{initialization!reference}%
 The declaration of a reference shall contain an
-\grammarterm{initializer}
-(\ref{dcl.init.ref})
+\grammarterm{initializer}\iref{dcl.init.ref}
 except when the declaration contains an explicit
 \tcode{extern}
 specifier\iref{dcl.stc},
@@ -984,8 +981,8 @@ this type shall not be a reference type, \cv{}~\tcode{void},
 a function type or an abstract class type.
 \indextext{declaration!array}%
 If the
-\grammarterm{constant-expression}
-(\ref{expr.const}) is present, it shall be a converted constant
+\grammarterm{constant-expression}\iref{expr.const}
+is present, it shall be a converted constant
 expression of type \tcode{std::size_t} and
 its value shall be greater than zero.
 The constant expression specifies the
@@ -1080,8 +1077,8 @@ In both cases the bound is calculated from the number
 \indextext{array size!default}%
 of initial elements (say,
 \tcode{N})
-supplied
-(\ref{dcl.init.aggr}), and the type of the identifier of
+supplied\iref{dcl.init.aggr},
+and the type of the identifier of
 \tcode{D}
 is ``array of
 \tcode{N}
@@ -1524,8 +1521,7 @@ int fseek(FILE*, long, int);
 
 declares a function taking three arguments of the specified types,
 and returning
-\tcode{int}
-(\ref{dcl.type}).
+\tcode{int}\iref{dcl.type}.
 \end{example}
 
 \pnum
@@ -1744,8 +1740,7 @@ A default argument shall be specified only in the
 of a function declaration
 or \grammarterm{lambda-declarator}
 or in a
-\grammarterm{template-parameter}
-(\ref{temp.param});
+\grammarterm{template-parameter}\iref{temp.param};
 in the latter case, the \grammarterm{initializer-clause} shall be an
 \grammarterm{assignment-expression}.
 A default argument shall not be specified for a parameter pack.
@@ -1969,8 +1964,8 @@ int (*p2)() = &f;                   // error: type mismatch
 \end{codeblock}
 \end{example}
 When a declaration of a function is introduced by way of a
-\grammarterm{using-declaration}
-(\ref{namespace.udecl}), any default argument information associated
+\grammarterm{using-declaration}\iref{namespace.udecl},
+any default argument information associated
 with the declaration is made known as well.
 If the function is redeclared
 thereafter in the namespace with additional default arguments,
@@ -2890,8 +2885,8 @@ that is the destination of the copy-initialization.
 Otherwise, if the source type
 is a (possibly cv-qualified) class type, conversion functions are
 considered.
-The applicable conversion functions are enumerated
-(\ref{over.match.conv}), and the best one is chosen through overload
+The applicable conversion functions are enumerated\iref{over.match.conv},
+and the best one is chosen through overload
 resolution\iref{over.match}.
 The user-defined conversion so selected
 is called to convert the initializer expression into the
@@ -3209,8 +3204,8 @@ but nonetheless \Cpp does not have zero length arrays.}
 \begin{note}
 A default member initializer does not determine the bound for a member
 array of unknown bound.  Since the default member initializer is
-ignored if a suitable \grammarterm{mem-initializer} is present
-(\ref{class.base.init}), the default member initializer is not
+ignored if a suitable \grammarterm{mem-initializer} is present\iref{class.base.init},
+the default member initializer is not
 considered to initialize the array of unknown bound.
 \begin{example}
 \begin{codeblock}
@@ -3604,8 +3599,8 @@ Argument passing\iref{expr.call}
 and function value return\iref{stmt.return} are initializations.
 
 \pnum
-The initializer can be omitted for a reference only in a parameter declaration
-(\ref{dcl.fct}), in the declaration of a function return type, in the declaration of
+The initializer can be omitted for a reference only in a parameter declaration\iref{dcl.fct},
+in the declaration of a function return type, in the declaration of
 a class member within its class definition\iref{class.mem}, and where the
 \tcode{extern}
 specifier is explicitly used.
@@ -3677,8 +3672,8 @@ then the reference is bound to the initializer expression lvalue in the
 first case and to the lvalue result of the conversion
 in the second case (or, in either case, to the appropriate base class subobject of the object).
 \begin{note}
-The usual lvalue-to-rvalue\iref{conv.lval}, array-to-pointer
-(\ref{conv.array}), and function-to-pointer\iref{conv.func} standard
+The usual lvalue-to-rvalue\iref{conv.lval}, array-to-pointer\iref{conv.array},
+and function-to-pointer\iref{conv.func} standard
 conversions are not needed, and therefore are suppressed, when such
 direct bindings to lvalues are done.
 \end{note}

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -35,7 +35,7 @@ each of which can have an initializer.
 The three components of a
 \grammarterm{simple-declaration}
 are the
-attributes~(\ref{dcl.attr}), the
+attributes\iref{dcl.attr}, the
 specifiers
 (\grammarterm{decl-specifier-seq};
 \ref{dcl.spec}) and the declarators
@@ -84,7 +84,7 @@ struct S { ... };
 S S;
 S T;                    // error
 \end{codeblock}
-Another exception is when \tcode{T} is \tcode{auto}~(\ref{dcl.spec.auto}),
+Another exception is when \tcode{T} is \tcode{auto}\iref{dcl.spec.auto},
 for example:
 \begin{codeblock}
 auto i = 1, j = 2.0;    // error: deduced types for \tcode{i} and \tcode{j} do not match
@@ -97,10 +97,10 @@ auto j = 2.0;           // OK: \tcode{j} deduced to have type \tcode{double}
 \end{note}
 
 \pnum
-The optional \grammarterm{requires-clause} (Clause~\ref{temp}) in an
+The optional \grammarterm{requires-clause}\iref{temp} in an
 \grammarterm{init-declarator} or \grammarterm{member-declarator}
 shall not be present when the declarator does not declare a
-function~(\ref{dcl.fct}).
+function\iref{dcl.fct}.
 %
 When present after a declarator, the \grammarterm{requires-clause}
 is called the \defnx{trailing \grammarterm{requires-clause}{}}{%
@@ -407,14 +407,14 @@ shall be a simple
 except for the declaration of some special functions~(\ref{class.ctor},
 \ref{class.conv}, \ref{class.dtor}, \ref{over.oper}) and
 for the declaration of template specializations
-or partial specializations~(\ref{temp.spec}).
+or partial specializations\iref{temp.spec}.
 When the
 \grammarterm{declarator-id}
 is qualified, the declaration shall refer to a previously declared member
 of the class or namespace to which the qualifier refers (or,
 in the case of a namespace,
 of an element of the inline namespace
-set of that namespace~(\ref{namespace.def})) or to a specialization thereof; the member
+set of that namespace\iref{namespace.def}) or to a specialization thereof; the member
 shall not merely have been introduced by a
 \grammarterm{using-declaration}
 in the scope of the class or namespace nominated by the
@@ -563,7 +563,7 @@ is ``\placeholder{derived-declarator-type-list} \grammarterm{cv-qualifier-seq} p
 The
 \grammarterm{cv-qualifier}{s}
 apply to the pointer and not to the object pointed to.
-Similarly, the optional \grammarterm{attribute-specifier-seq}~(\ref{dcl.attr.grammar}) appertains to the pointer and not to the object pointed to.
+Similarly, the optional \grammarterm{attribute-specifier-seq}\iref{dcl.attr.grammar} appertains to the pointer and not to the object pointed to.
 
 \pnum
 \begin{example}
@@ -643,7 +643,7 @@ Forming a pointer to reference type is ill-formed; see~\ref{dcl.ref}.
 Forming a function pointer type is ill-formed if the function type has
 \grammarterm{cv-qualifier}{s} or a \grammarterm{ref-qualifier};
 see~\ref{dcl.fct}.
-Since the address of a bit-field~(\ref{class.bit}) cannot be taken,
+Since the address of a bit-field\iref{class.bit} cannot be taken,
 a pointer can never point to a bit-field.
 \end{note}
 
@@ -676,7 +676,7 @@ The optional \grammarterm{attribute-specifier-seq} appertains to the reference t
 Cv-qualified references are ill-formed except when the cv-qualifiers
 are introduced through the use of a
 \grammarterm{typedef-name}~(\ref{dcl.typedef}, \ref{temp.param}) or
-\grammarterm{decltype-specifier}~(\ref{dcl.type.simple}),
+\grammarterm{decltype-specifier}\iref{dcl.type.simple},
 in which case the cv-qualifiers are ignored.
 \begin{example}
 
@@ -783,7 +783,7 @@ See also~\ref{dcl.init.ref}.
 
 \pnum
 It is unspecified whether or not
-a reference requires storage~(\ref{basic.stc}).
+a reference requires storage\iref{basic.stc}.
 
 \pnum
 \indextext{restriction!reference}%
@@ -795,9 +795,9 @@ The declaration of a reference shall contain an
 (\ref{dcl.init.ref})
 except when the declaration contains an explicit
 \tcode{extern}
-specifier~(\ref{dcl.stc}),
-is a class member~(\ref{class.mem}) declaration within a class definition,
-or is the declaration of a parameter or a return type~(\ref{dcl.fct}); see~\ref{basic.def}.
+specifier\iref{dcl.stc},
+is a class member\iref{class.mem} declaration within a class definition,
+or is the declaration of a parameter or a return type\iref{dcl.fct}; see~\ref{basic.def}.
 A reference shall be initialized to refer to a valid object or function.
 \begin{note}
 \indextext{reference!null}%
@@ -812,7 +812,7 @@ to a bit-field.
 \pnum
 \indextext{reference collapsing}%
 If a \grammarterm{typedef-name}~(\ref{dcl.typedef}, \ref{temp.param})
-or a \grammarterm{decltype-specifier}~(\ref{dcl.type.simple}) denotes a type \tcode{TR} that
+or a \grammarterm{decltype-specifier}\iref{dcl.type.simple} denotes a type \tcode{TR} that
 is a reference to a type \tcode{T}, an attempt to create the type ``lvalue reference to \cv{}~\tcode{TR}''
 creates the type ``lvalue reference to \tcode{T}'', while an attempt to create
 the type ``rvalue reference to \cv{}~\tcode{TR}'' creates the type \tcode{TR}.
@@ -870,7 +870,7 @@ then the type of the identifier of
 is ``\placeholder{derived-declarator-type-list} \grammarterm{cv-qualifier-seq} pointer to member of class
 \grammarterm{nested-name-specifier} of type
 \tcode{T}''.
-The optional \grammarterm{attribute-specifier-seq}~(\ref{dcl.attr.grammar}) appertains to the
+The optional \grammarterm{attribute-specifier-seq}\iref{dcl.attr.grammar} appertains to the
 pointer-to-member.
 
 \pnum
@@ -938,7 +938,7 @@ obj.*pmi = 7;       // assign \tcode{7} to an integer member of \tcode{obj}
 
 \pnum
 A pointer to member shall not point to a static member
-of a class~(\ref{class.static}),
+of a class\iref{class.static},
 a member with reference type,
 or
 ``\cv{}~\tcode{void}''.
@@ -1070,12 +1070,12 @@ the constant expressions that specify the bounds
 of the arrays may be omitted.
 In addition to declarations in which an incomplete object type is allowed,
 an array bound may be omitted in some cases in the declaration of a function
-parameter~(\ref{dcl.fct}).
+parameter\iref{dcl.fct}.
 An array bound may also be omitted
 when the declarator is followed by an
-\grammarterm{initializer}~(\ref{dcl.init}) or
+\grammarterm{initializer}\iref{dcl.init} or
 when a declarator for a static data member is followed by a
-\grammarterm{brace-or-equal-initializer}~(\ref{class.mem}).
+\grammarterm{brace-or-equal-initializer}\iref{class.mem}.
 In both cases the bound is calculated from the number
 \indextext{array size!default}%
 of initial elements (say,
@@ -1150,14 +1150,14 @@ Objects of array types cannot be modified, see~\ref{basic.lval}.
 
 \pnum
 \begin{note}
-Except where it has been declared for a class~(\ref{over.sub}),
+Except where it has been declared for a class\iref{over.sub},
 the subscript operator
 \tcode{[]}
 is interpreted
 in such a way that
 \tcode{E1[E2]}
 is identical to
-\tcode{*((E1)+(E2))}~(\ref{expr.sub}).
+\tcode{*((E1)+(E2))}\iref{expr.sub}.
 Because of the conversion rules
 that apply to
 \tcode{+},
@@ -1192,7 +1192,7 @@ $i \times j \times \dotsb \times k$,
 then
 \tcode{E}
 appearing in an expression
-that is subject to the array-to-pointer conversion~(\ref{conv.array})
+that is subject to the array-to-pointer conversion\iref{conv.array}
 is converted to
 a pointer to an $(n-1)$-dimensional
 array with rank
@@ -1287,7 +1287,7 @@ function of
 returning \tcode{T}'',
 where the optional \tcode{noexcept} is present
 if and only if
-the exception specification~(\ref{except.spec}) is non-throwing.
+the exception specification\iref{except.spec} is non-throwing.
 The optional \grammarterm{attribute-specifier-seq}
 appertains to the function type.
 
@@ -1388,7 +1388,7 @@ If the
 \indextext{argument list!variable}%
 \indextext{parameter list!variable}%
 terminates with an ellipsis or a function parameter
-pack~(\ref{temp.variadic}), the number of arguments shall be equal
+pack\iref{temp.variadic}, the number of arguments shall be equal
 to or greater than the number of parameters that do not have a default
 argument and are not function parameter packs.
 Where syntactically correct and where ``\tcode{...}'' is not
@@ -1466,10 +1466,10 @@ shall appear only as:
 or \grammarterm{alias-declaration},
 
 \item the \grammarterm{type-id} in the default argument of a
-\grammarterm{type-parameter}~(\ref{temp.param}), or
+\grammarterm{type-parameter}\iref{temp.param}, or
 
 \item the \grammarterm{type-id} of a \grammarterm{template-argument} for a
-\grammarterm{type-parameter}~(\ref{temp.arg.type}).
+\grammarterm{type-parameter}\iref{temp.arg.type}.
 \end{itemize}
 \begin{example}
 
@@ -1505,8 +1505,8 @@ struct S {
 The return type, the parameter-type-list, the \grammarterm{ref-qualifier},
 the \grammarterm{cv-qualifier-seq}, and
 the exception specification,
-but not the default arguments~(\ref{dcl.fct.default})
-or \grammarterm{requires-clause}{s}~(Clause~\ref{temp}),
+but not the default arguments\iref{dcl.fct.default}
+or \grammarterm{requires-clause}{s}\iref{temp},
 are part of the function type.
 \begin{note}
 Function types are checked during the assignments and initializations of
@@ -1531,9 +1531,9 @@ and returning
 \pnum
 \indextext{overloading}%
 A single name can be used for several different functions in a single scope;
-this is function overloading (Clause~\ref{over}).
+this is function overloading\iref{over}.
 All declarations for a function shall have equivalent return types,
-parameter-type-lists, and \grammarterm{requires-clause}{s}~(\ref{temp.over.link}).
+parameter-type-lists, and \grammarterm{requires-clause}{s}\iref{temp.over.link}.
 
 \pnum
 \indextext{function return type|see{return type}}%
@@ -1550,12 +1550,12 @@ definition shall not be an incomplete
 (possibly cv-qualified) class type
 in the context of the function definition
 unless the function is
-deleted~(\ref{dcl.fct.def.delete}).
+deleted\iref{dcl.fct.def.delete}.
 
 \pnum
 \indextext{typedef!function}%
 A typedef of function type may be used to declare a function but shall not be
-used to define a function~(\ref{dcl.fct.def}).
+used to define a function\iref{dcl.fct.def}.
 \begin{example}
 
 \begin{codeblock}
@@ -1568,14 +1568,14 @@ void fv() { }       // OK: definition of \tcode{fv}
 
 \pnum
 An identifier can optionally be provided as a parameter name;
-if present in a function definition~(\ref{dcl.fct.def}), it names a parameter.
+if present in a function definition\iref{dcl.fct.def}, it names a parameter.
 \begin{note}
 In particular, parameter names are also optional in function definitions
 and names used for a parameter in different declarations and the definition
 of a function need not be the same.
 If a parameter name is present in a function declaration that is not a definition,
 it cannot be used outside of
-its function declarator because that is the extent of its potential scope~(\ref{basic.scope.proto}).
+its function declarator because that is the extent of its potential scope\iref{basic.scope.proto}.
 \end{note}
 
 \pnum
@@ -1669,13 +1669,13 @@ A \grammarterm{declarator-id} or \grammarterm{abstract-declarator}
 containing an ellipsis shall only
 be used in a \grammarterm{parameter-declaration}. Such a
 \grammarterm{parameter-declaration} is a parameter
-pack~(\ref{temp.variadic}). When it is part of a
+pack\iref{temp.variadic}. When it is part of a
 \grammarterm{parameter-declaration-clause}, the parameter pack is a
-function parameter pack~(\ref{temp.variadic}). \begin{note}
+function parameter pack\iref{temp.variadic}. \begin{note}
 Otherwise, the \grammarterm{parameter-declaration} is part of a
 \grammarterm{template-parameter-list} and the parameter pack is a
 template parameter pack; see~\ref{temp.param}. \end{note}
-A function parameter pack is a pack expansion~(\ref{temp.variadic}).
+A function parameter pack is a pack expansion\iref{temp.variadic}.
 \begin{example}
 
 \begin{codeblock}
@@ -1819,7 +1819,7 @@ declaration of the function or function template in the translation unit.
 The default argument has the
 same semantic constraints as the initializer in a
 declaration of a variable of the parameter type, using the
-copy-initialization semantics~(\ref{dcl.init}).
+copy-initialization semantics\iref{dcl.init}.
 The names in the
 default argument are bound, and the semantic constraints are checked,
 at the point where the default argument appears.
@@ -1852,7 +1852,7 @@ In member function declarations,
 names in default arguments are looked up
 as described in~\ref{basic.lookup.unqual}.
 Access checking applies to names in default arguments as
-described in Clause~\ref{class.access}.
+described in \ref{class.access}.
 \end{note}
 
 \pnum
@@ -1861,8 +1861,8 @@ default arguments in a member function definition that appears
 outside of the class definition
 are added to the set of default arguments provided by the
 member function declaration in the class definition;
-the program is ill-formed if a default constructor~(\ref{class.ctor}),
-copy or move constructor, or copy or move assignment operator~(\ref{class.copy})
+the program is ill-formed if a default constructor\iref{class.ctor},
+copy or move constructor, or copy or move assignment operator\iref{class.copy}
 is so declared.
 Default arguments for a member function of a class template
 shall be specified on the initial declaration of the member
@@ -1929,8 +1929,8 @@ int h(int a, int b = sizeof(a));    // OK, unevaluated operand
 \end{codeblock}
 \end{example}
 A non-static member shall not appear in a default argument unless it appears as
-the \grammarterm{id-expression} of a class member access expression~(\ref{expr.ref}) or
-unless it is used to form a pointer to member~(\ref{expr.unary.op}).
+the \grammarterm{id-expression} of a class member access expression\iref{expr.ref} or
+unless it is used to form a pointer to member\iref{expr.unary.op}.
 \begin{example}
 The declaration of
 \tcode{X::mem1()}
@@ -1951,7 +1951,7 @@ The declaration of
 \tcode{X::mem2()}
 is meaningful, however, since no object is needed to access the static member
 \tcode{X::b}.
-Classes, objects, and members are described in Clause~\ref{class}.
+Classes, objects, and members are described in \ref{class}.
 \end{example}
 A default argument is not part of the
 type of a function.
@@ -1981,7 +1981,7 @@ is in scope.
 
 \pnum
 \indextext{argument and virtual function!default}%
-A virtual function call~(\ref{class.virtual}) uses the default
+A virtual function call\iref{class.virtual} uses the default
 arguments in the declaration of the virtual function determined
 by the static type of the pointer or reference denoting the
 object.
@@ -2037,7 +2037,7 @@ the non-terminal \grammarterm{function-body}.
 The optional \grammarterm{attribute-specifier-seq} in a \grammarterm{function-definition}
 appertains to the function.
 A \grammarterm{virt-specifier-seq} can be part of a \grammarterm{function-definition}
-only if it is a \grammarterm{member-declaration}~(\ref{class.mem}).
+only if it is a \grammarterm{member-declaration}\iref{class.mem}.
 
 \pnum
 In a \grammarterm{function-definition},
@@ -2119,8 +2119,8 @@ from \mname{func}} string.
 It is unspecified whether such a variable has an address
 distinct from that of any other object in the program.\footnote{Implementations are
 permitted to provide additional predefined variables with names that are reserved to the
-implementation~(\ref{lex.name}). If a predefined variable is not
-odr-used~(\ref{basic.def.odr}), its string value need not be present in the program image.}
+implementation\iref{lex.name}. If a predefined variable is not
+odr-used\iref{basic.def.odr}, its string value need not be present in the program image.}
 \begin{example}
 \begin{codeblock}
 struct S {
@@ -2166,7 +2166,7 @@ declaration would be.
 If a function that is explicitly defaulted is declared with a
 \grammarterm{noexcept-specifier} that does not produce
 the same exception specification
-as the implicit declaration~(\ref{except.spec}), then
+as the implicit declaration\iref{except.spec}, then
 
 \begin{itemize}
 \item if the function is explicitly defaulted on its first declaration, it is defined as deleted;
@@ -2245,7 +2245,7 @@ implicitly or explicitly and forming a pointer or pointer-to-member to the
 function. It applies even for references in expressions that are not
 potentially-evaluated. If a function is overloaded, it is referenced only if the
 function is selected by overload resolution. The implicit
-odr-use~(\ref{basic.def.odr}) of a virtual function does not, by itself,
+odr-use\iref{basic.def.odr} of a virtual function does not, by itself,
 constitute a reference. \end{note}
 
 \pnum
@@ -2293,12 +2293,12 @@ moveonly q(*p);                 // error, deleted copy constructor
 \end{example}
 
 \pnum
-A deleted function is implicitly an inline function~(\ref{dcl.inline}). \begin{note} The
-one-definition rule~(\ref{basic.def.odr}) applies to deleted definitions. \end{note}
+A deleted function is implicitly an inline function\iref{dcl.inline}. \begin{note} The
+one-definition rule\iref{basic.def.odr} applies to deleted definitions. \end{note}
 A deleted definition of a function shall be the first declaration of the function or,
 for an explicit specialization of a function template, the first declaration of that
 specialization.
-An implicitly declared allocation or deallocation function~(\ref{basic.stc.dynamic})
+An implicitly declared allocation or deallocation function\iref{basic.stc.dynamic}
 shall not be defined as deleted.
 \begin{example}
 \begin{codeblock}
@@ -2318,7 +2318,7 @@ sometype::sometype() = delete;  // ill-formed; not first declaration
 A structured binding declaration introduces the \grammarterm{identifier}{s}
 \tcode{v}$_0$, \tcode{v}$_1$, \tcode{v}$_2$, ...
 of the
-\grammarterm{identifier-list} as names~(\ref{basic.scope.declarative}),
+\grammarterm{identifier-list} as names\iref{basic.scope.declarative},
 called \defn{structured binding}{s}.
 Let \cv{} denote the
 \grammarterm{cv-qualifier}{s} in the \grammarterm{decl-specifier-seq}. First, a
@@ -2342,7 +2342,7 @@ from the corresponding structured binding declaration.
 The type of the \grammarterm{id-expression}
 \tcode{e} is called \tcode{E}.
 \begin{note}
-\tcode{E} is never a reference type (Clause~\ref{expr}).
+\tcode{E} is never a reference type\iref{expr}.
 \end{note}
 
 \pnum
@@ -2372,13 +2372,13 @@ and
 the number of elements in
 the \grammarterm{identifier-list} shall be equal to the value of that
 expression. The \grammarterm{unqualified-id} \tcode{get} is looked up
-in the scope of \tcode{E} by class member access lookup~(\ref{basic.lookup.classref}),
+in the scope of \tcode{E} by class member access lookup\iref{basic.lookup.classref},
 and if that finds at least one declaration, the initializer is
 \tcode{e.get<i>()}. Otherwise, the initializer is \tcode{get<i>(e)},
-where \tcode{get} is looked up in the associated namespaces~(\ref{basic.lookup.argdep}).
+where \tcode{get} is looked up in the associated namespaces\iref{basic.lookup.argdep}.
 In either case, \tcode{get<i>} is interpreted as a \grammarterm{template-id}.
 \begin{note}
-Ordinary unqualified lookup~(\ref{basic.lookup.unqual}) is not performed.
+Ordinary unqualified lookup\iref{basic.lookup.unqual} is not performed.
 \end{note}
 In either case, \tcode{e} is an lvalue if the type of the entity \tcode{e}
 is an lvalue reference and an xvalue otherwise. Given the type $\tcode{T}_i$
@@ -2422,8 +2422,8 @@ The process of initialization described in the
 remainder of~\ref{dcl.init}
 applies also to initializations
 specified by other syntactic contexts, such as the initialization
-of function parameters~(\ref{expr.call}) or
-the initialization of return values~(\ref{stmt.return}).
+of function parameters\iref{expr.call} or
+the initialization of return values\iref{stmt.return}.
 
 \begin{bnf}
 \nontermdef{initializer}\br
@@ -2527,7 +2527,7 @@ means:
 \item
 if
 \tcode{T}
-is a scalar type~(\ref{basic.types}), the
+is a scalar type\iref{basic.types}, the
 object
 is initialized to the value obtained by converting the integer literal \tcode{0}
 (zero) to
@@ -2541,7 +2541,7 @@ to a pointer type results in a null pointer value.
 if
 \tcode{T}
 is a (possibly cv-qualified) non-union class type,
-its padding bits~(\ref{basic.types}) are initialized to zero bits and
+its padding bits\iref{basic.types} are initialized to zero bits and
 each non-static data member,
 each non-virtual base class subobject, and,
 if the object is not a base class subobject,
@@ -2552,7 +2552,7 @@ is zero-initialized;
 if
 \tcode{T}
 is a (possibly cv-qualified) union type,
-its padding bits~(\ref{basic.types}) are initialized to zero bits and
+its padding bits\iref{basic.types} are initialized to zero bits and
 the
 object's first non-static named
 data member
@@ -2580,11 +2580,11 @@ means:
 \item
 If
 \tcode{T}
-is a (possibly cv-qualified) class type (Clause~\ref{class}),
+is a (possibly cv-qualified) class type\iref{class},
 constructors are considered. The applicable constructors are
-enumerated~(\ref{over.match.ctor}), and the best one for the
+enumerated\iref{over.match.ctor}, and the best one for the
 \grammarterm{initializer} \tcode{()} is chosen through
-overload resolution~(\ref{over.match}). The constructor thus selected
+overload resolution\iref{over.match}. The constructor thus selected
 is called, with an empty argument list, to initialize the object.
 
 \item
@@ -2634,8 +2634,8 @@ means:
 \item
 if
 \tcode{T}
-is a (possibly cv-qualified) class type (Clause~\ref{class}) with
-either no default constructor~(\ref{class.ctor}) or a default
+is a (possibly cv-qualified) class type\iref{class} with
+either no default constructor\iref{class.ctor} or a default
 constructor that is user-provided or deleted, then the object is default-initialized;
 
 \item
@@ -2704,7 +2704,7 @@ If no initializer is specified for an object, the object is default-initialized.
 When storage for an object with automatic or dynamic storage duration
 is obtained, the object has an \term{indeterminate value}, and if
 no initialization is performed for the object, that object retains an
-indeterminate value until that value is replaced~(\ref{expr.ass}).
+indeterminate value until that value is replaced\iref{expr.ass}.
 \begin{note} Objects with static or thread storage duration are zero-initialized,
 see~\ref{basic.start.static}. \end{note}
 If an indeterminate value is produced by an evaluation, the behavior is
@@ -2713,17 +2713,17 @@ undefined except in the following cases:
 \begin{itemize}
 \item
 If an indeterminate value of
-unsigned narrow character type~(\ref{basic.fundamental})
-or \tcode{std::byte} type~(\ref{cstddef.syn})
+unsigned narrow character type\iref{basic.fundamental}
+or \tcode{std::byte} type\iref{cstddef.syn}
 is produced by the evaluation of:
 \begin{itemize}
-\item the second or third operand of a conditional expression~(\ref{expr.cond}),
-\item the right operand of a comma expression~(\ref{expr.comma}),
+\item the second or third operand of a conditional expression\iref{expr.cond},
+\item the right operand of a comma expression\iref{expr.comma},
 \item the operand of a cast or conversion~(\ref{conv.integral},
 \ref{expr.type.conv}, \ref{expr.static.cast}, \ref{expr.cast}) to an
 unsigned narrow character type
-or \tcode{std::byte} type~(\ref{cstddef.syn}), or
-\item a discarded-value expression (Clause~\ref{expr}),
+or \tcode{std::byte} type\iref{cstddef.syn}, or
+\item a discarded-value expression\iref{expr},
 \end{itemize}
 then the result of the operation is an indeterminate value.
 
@@ -2732,7 +2732,7 @@ If an indeterminate value of
 unsigned narrow character type
 or \tcode{std::byte} type
 is produced by the evaluation of the right
-operand of a simple assignment operator~(\ref{expr.ass}) whose first operand
+operand of a simple assignment operator\iref{expr.ass} whose first operand
 is an lvalue of
 unsigned narrow character type
 or \tcode{std::byte} type,
@@ -2792,14 +2792,14 @@ parenthesized initializer shall be a single expression.
 \indextext{initialization!direct}%
 The initialization that occurs in the \tcode{=} form of a
 \grammarterm{brace-or-equal-initializer} or
-\grammarterm{condition}~(\ref{stmt.select}),
+\grammarterm{condition}\iref{stmt.select},
 as well as in argument passing, function return,
-throwing an exception~(\ref{except.throw}),
-handling an exception~(\ref{except.handle}),
-and aggregate member initialization~(\ref{dcl.init.aggr}),
+throwing an exception\iref{except.throw},
+handling an exception\iref{except.handle},
+and aggregate member initialization\iref{dcl.init.aggr},
 is called
 \defn{copy-initialization}.
-\begin{note} Copy-initialization may invoke a move~(\ref{class.copy}). \end{note}
+\begin{note} Copy-initialization may invoke a move\iref{class.copy}. \end{note}
 
 \pnum
 The initialization that occurs in the forms
@@ -2809,11 +2809,11 @@ T x{a};
 \end{codeblock}
 as well as in
 \tcode{new}
-expressions~(\ref{expr.new}),
+expressions\iref{expr.new},
 \tcode{static_cast}
-expressions~(\ref{expr.static.cast}),
-functional notation type conversions~(\ref{expr.type.conv}),
-\grammarterm{mem-initializer}{s}~(\ref{class.base.init}), and
+expressions\iref{expr.static.cast},
+functional notation type conversions\iref{expr.type.conv},
+\grammarterm{mem-initializer}{s}\iref{class.base.init}, and
 the \grammarterm{braced-init-list} form of a \grammarterm{condition}
 is called
 \defn{direct-initialization}.
@@ -2832,7 +2832,7 @@ source type is not defined.
 \item
 If the initializer is a (non-parenthesized) \grammarterm{braced-init-list}
 or is \tcode{=} \grammarterm{braced-init-list}, the object or reference
-is list-initialized~(\ref{dcl.init.list}).
+is list-initialized\iref{dcl.init.list}.
 \item
 If the destination type is a reference type, see~\ref{dcl.init.ref}.
 \item
@@ -2863,8 +2863,8 @@ or if it is copy-initialization where the cv-unqualified version of the source
 type is the same class as, or a derived class of, the class of the destination,
 constructors are considered.
 The applicable constructors
-are enumerated~(\ref{over.match.ctor}), and the best one is chosen
-through overload resolution~(\ref{over.match}).
+are enumerated\iref{over.match.ctor}, and the best one is chosen
+through overload resolution\iref{over.match}.
 The constructor so selected
 is called to initialize the object, with the initializer
 expression or \grammarterm{expression-list} as its argument(s).
@@ -2875,7 +2875,7 @@ Otherwise (i.e., for the remaining copy-initialization cases),
 user-defined conversion sequences that can convert from the
 source type to the destination type or (when a conversion function
 is used) to a derived class thereof are enumerated as described in~\ref{over.match.copy}, and the best one is chosen through overload
-resolution~(\ref{over.match}).  If the conversion cannot be done or
+resolution\iref{over.match}.  If the conversion cannot be done or
 is ambiguous, the initialization is ill-formed.  The function
 selected is called with the initializer expression as its
 argument; if the function is a constructor, the call is a prvalue
@@ -2892,7 +2892,7 @@ is a (possibly cv-qualified) class type, conversion functions are
 considered.
 The applicable conversion functions are enumerated
 (\ref{over.match.conv}), and the best one is chosen through overload
-resolution~(\ref{over.match}).
+resolution\iref{over.match}.
 The user-defined conversion so selected
 is called to convert the initializer expression into the
 object being initialized.
@@ -2901,7 +2901,7 @@ ambiguous, the initialization is ill-formed.
 \item
 Otherwise, the initial value of the object being initialized is
 the (possibly converted) value of the initializer expression.
-Standard conversions (Clause~\ref{conv}) will be used, if necessary,
+Standard conversions\iref{conv} will be used, if necessary,
 to convert the initializer expression to the cv-unqualified version of
 the destination type;
 no user-defined conversions are considered.
@@ -2931,12 +2931,12 @@ int c = b;
 
 \pnum
 An \grammarterm{initializer-clause} followed by an ellipsis is a
-pack expansion~(\ref{temp.variadic}).
+pack expansion\iref{temp.variadic}.
 
 \pnum
 If the initializer is a parenthesized \grammarterm{expression-list},
 the expressions are evaluated in the order
-specified for function calls~(\ref{expr.call}).
+specified for function calls\iref{expr.call}.
 
 \pnum
 The same \grammarterm{identifier}
@@ -2950,8 +2950,8 @@ even if no constructor of the object's class
 is invoked for the initialization.
 \begin{note}
 Such an object might have been value-initialized
-or initialized by aggregate initialization~(\ref{dcl.init.aggr})
-or by an inherited constructor~(\ref{class.inhctor.init}).
+or initialized by aggregate initialization\iref{dcl.init.aggr}
+or by an inherited constructor\iref{class.inhctor.init}.
 \end{note}
 
 \pnum
@@ -2960,9 +2960,9 @@ whether from an explicit initializer or by default-initialization,
 is called the \defn{initializing declaration} of that variable.
 \begin{note}
 In most cases
-this is the defining declaration~(\ref{basic.def}) of the variable,
+this is the defining declaration\iref{basic.def} of the variable,
 but the initializing declaration
-of a non-inline static data member~(\ref{class.static.data})
+of a non-inline static data member\iref{class.static.data}
 might be the declaration within the class definition
 and not the definition at namespace scope.
 \end{note}
@@ -2977,16 +2977,16 @@ and not the definition at namespace scope.
 \indextext{\idxcode{\{\}}!initializer list}
 
 \pnum
-An \defn{aggregate} is an array or a class (Clause~\ref{class}) with
+An \defn{aggregate} is an array or a class\iref{class} with
 \begin{itemize}
 \item
-no user-provided, \tcode{explicit}, or inherited constructors~(\ref{class.ctor}),
+no user-provided, \tcode{explicit}, or inherited constructors\iref{class.ctor},
 \item
-no private or protected non-static data members (Clause~\ref{class.access}),
+no private or protected non-static data members\iref{class.access},
 \item
-no virtual functions~(\ref{class.virtual}), and
+no virtual functions\iref{class.virtual}, and
 \item
-no virtual, private, or protected base classes~(\ref{class.mi}).
+no virtual, private, or protected base classes\iref{class.mi}.
 \end{itemize}
 \begin{note}
 Aggregate initialization does not allow accessing
@@ -3001,7 +3001,7 @@ The \term{elements} of an aggregate are:
 for an array, the array elements in increasing subscript order, or
 \item
 for a class, the direct base classes in declaration order,
-followed by the direct non-static data members~(\ref{class.mem})
+followed by the direct non-static data members\iref{class.mem}
 that are not members of an anonymous union, in declaration order.
 \end{itemize}
 
@@ -3050,7 +3050,7 @@ If that initializer is of the form
 \grammarterm{assignment-expression} or
 \tcode{= }\grammarterm{assignment-expression}
 and
-a narrowing conversion~(\ref{dcl.init.list}) is required
+a narrowing conversion\iref{dcl.init.list} is required
 to convert the expression, the program is ill-formed.
 \begin{note} If an initializer is itself an initializer list,
 the element is list-initialized, which will result in a recursive application
@@ -3106,11 +3106,11 @@ each element that is not an explicitly initialized element
 is initialized as follows:
 \begin{itemize}
 \item
-If the element has a default member initializer~(\ref{class.mem}),
+If the element has a default member initializer\iref{class.mem},
 the element is initialized from that initializer.
 \item
 Otherwise, if the element is not a reference, the element
-is copy-initialized from an empty initializer list~(\ref{dcl.init.list}).
+is copy-initialized from an empty initializer list\iref{dcl.init.list}.
 \item
 Otherwise, the program is ill-formed.
 \end{itemize}
@@ -3188,7 +3188,7 @@ where
 \tcode{n}
 shall be greater than zero, is defined as having
 \tcode{n}
-elements~(\ref{dcl.array}).
+elements\iref{dcl.array}.
 \begin{example}
 
 \begin{codeblock}
@@ -3311,7 +3311,7 @@ When initializing a multi-dimensional array,
 the
 \grammarterm{initializer-clause}{s}
 initialize the elements with the last (rightmost) index of the array
-varying the fastest~(\ref{dcl.array}).
+varying the fastest\iref{dcl.array}.
 \begin{example}
 
 \begin{codeblock}
@@ -3426,7 +3426,7 @@ and
 \end{example}
 
 \pnum
-All implicit type conversions (Clause~\ref{conv}) are considered when
+All implicit type conversions\iref{conv} are considered when
 initializing the element with an \grammarterm{assignment-expression}.
 If the
 \grammarterm{assignment-expression}
@@ -3474,7 +3474,7 @@ returns.
 \indextext{initialization!array of class objects}%
 \begin{note}
 An aggregate array or an aggregate class may contain elements of a
-class type with a user-provided constructor~(\ref{class.ctor}).
+class type with a user-provided constructor\iref{class.ctor}.
 Initialization of these aggregate objects is described in~\ref{class.expl.init}.
 \end{note}
 
@@ -3516,7 +3516,7 @@ union is a member of another aggregate.
 \indextext{initialization!character array}
 
 \pnum
-An array of narrow character type~(\ref{basic.fundamental}),
+An array of narrow character type\iref{basic.fundamental},
 \tcode{char16_t} array,
 \tcode{char32_t} array,
 or \tcode{wchar_t} array
@@ -3524,7 +3524,7 @@ can be initialized by a
 narrow string literal, \tcode{char16_t} string literal, \tcode{char32_t} string
 literal, or wide string literal,
 respectively, or by an appropriately-typed string literal enclosed in
-braces~(\ref{lex.string}).
+braces\iref{lex.string}.
 \indextext{initialization!character array}%
 Successive
 characters of the
@@ -3564,14 +3564,14 @@ is ill-formed since there is no space for the implied trailing
 
 \pnum
 If there are fewer initializers than there are array elements, each element not
-explicitly initialized shall be zero-initialized~(\ref{dcl.init}).
+explicitly initialized shall be zero-initialized\iref{dcl.init}.
 
 \rSec2[dcl.init.ref]{References}%
 \indextext{initialization!reference}
 
 \pnum
 A variable whose declared type is
-``reference to type \tcode{T}''~(\ref{dcl.ref})
+``reference to type \tcode{T}''\iref{dcl.ref}
 shall be initialized.
 \begin{example}
 
@@ -3596,17 +3596,17 @@ void f() {
 A reference cannot be changed to refer to another object after initialization.
 \indextext{assignment!reference}%
 \begin{note}
-Assignment to a reference assigns to the object referred to by the reference~(\ref{expr.ass}).
+Assignment to a reference assigns to the object referred to by the reference\iref{expr.ass}.
 \end{note}
 \indextext{argument passing!reference and}%
-Argument passing~(\ref{expr.call})
+Argument passing\iref{expr.call}
 \indextext{\idxcode{return}!reference and}%
-and function value return~(\ref{stmt.return}) are initializations.
+and function value return\iref{stmt.return} are initializations.
 
 \pnum
 The initializer can be omitted for a reference only in a parameter declaration
 (\ref{dcl.fct}), in the declaration of a function return type, in the declaration of
-a class member within its class definition~(\ref{class.mem}), and where the
+a class member within its class definition\iref{class.mem}, and where the
 \tcode{extern}
 specifier is explicitly used.
 \indextext{declaration!extern@\tcode{extern} reference}%
@@ -3642,7 +3642,7 @@ is a base class of
 \tcode{T2},
 a program that necessitates such a binding is ill-formed if
 \tcode{T1}
-is an inaccessible (Clause~\ref{class.access}) or ambiguous~(\ref{class.member.lookup})
+is an inaccessible\iref{class.access} or ambiguous\iref{class.member.lookup}
 base class of
 \tcode{T2}.
 
@@ -3668,17 +3668,17 @@ is a class type), where \tcode{T1} is not reference-related to \tcode{T2}, and c
 to an lvalue of type ``\cvqual{cv3} \tcode{T3}'', where
 ``\cvqual{cv1} \tcode{T1}'' is reference-compatible with
 ``\cvqual{cv3} \tcode{T3}''\footnote{This requires a conversion
-function~(\ref{class.conv.fct}) returning a reference type.}
+function\iref{class.conv.fct} returning a reference type.}
 (this conversion is selected by enumerating the applicable conversion
-functions~(\ref{over.match.ref}) and choosing the best one through overload
-resolution~(\ref{over.match})),
+functions\iref{over.match.ref} and choosing the best one through overload
+resolution\iref{over.match}),
 \end{itemize}
 then the reference is bound to the initializer expression lvalue in the
 first case and to the lvalue result of the conversion
 in the second case (or, in either case, to the appropriate base class subobject of the object).
 \begin{note}
-The usual lvalue-to-rvalue~(\ref{conv.lval}), array-to-pointer
-(\ref{conv.array}), and function-to-pointer~(\ref{conv.func}) standard
+The usual lvalue-to-rvalue\iref{conv.lval}, array-to-pointer
+(\ref{conv.array}), and function-to-pointer\iref{conv.func} standard
 conversions are not needed, and therefore are suppressed, when such
 direct bindings to lvalues are done.
 \end{note}
@@ -3734,8 +3734,8 @@ the value of the initializer expression in the first case and
 the result of the conversion in the second case
 is called the converted initializer.
 If the converted initializer is a prvalue,
-its type \tcode{T4} is adjusted to type ``\cvqual{cv1} \tcode{T4}''~(\ref{conv.qual})
-and the temporary materialization conversion~(\ref{conv.rval}) is applied.
+its type \tcode{T4} is adjusted to type ``\cvqual{cv1} \tcode{T4}''\iref{conv.qual}
+and the temporary materialization conversion\iref{conv.rval} is applied.
 In any case,
 the reference is bound to the resulting glvalue
 (or to an appropriate base class subobject).
@@ -3859,16 +3859,16 @@ copy-initialization context is called \defn{copy-list-initialization}. \begin{no
 List-initialization can be used
 
 \begin{itemize}
-\item as the initializer in a variable definition~(\ref{dcl.init})
-\item as the initializer in a \grammarterm{new-expression}~(\ref{expr.new})
-\item in a return statement~(\ref{stmt.return})
-\item as a \grammarterm{for-range-initializer}~(\ref{stmt.iter})
-\item as a function argument~(\ref{expr.call})
-\item as a subscript~(\ref{expr.sub})
+\item as the initializer in a variable definition\iref{dcl.init}
+\item as the initializer in a \grammarterm{new-expression}\iref{expr.new}
+\item in a return statement\iref{stmt.return}
+\item as a \grammarterm{for-range-initializer}\iref{stmt.iter}
+\item as a function argument\iref{expr.call}
+\item as a subscript\iref{expr.sub}
 \item as an argument to a constructor invocation~(\ref{dcl.init}, \ref{expr.type.conv})
-\item as an initializer for a non-static data member~(\ref{class.mem})
-\item in a \grammarterm{mem-initializer}~(\ref{class.base.init})
-\item on the right-hand side of an assignment~(\ref{expr.ass})
+\item as an initializer for a non-static data member\iref{class.mem}
+\item in a \grammarterm{mem-initializer}\iref{class.base.init}
+\item on the right-hand side of an assignment\iref{expr.ass}
 \end{itemize}
 
 \begin{example}
@@ -3888,17 +3888,17 @@ std::map<std::string,int> anim = { {"bear",4}, {"cassowary",2}, {"tiger",7} };
 A constructor is an \defn{initializer-list constructor} if its first parameter is
 of type \tcode{std::initializer_list<E>} or reference to possibly cv-qualified
 \tcode{std::initializer_list<E>} for some type \tcode{E}, and either there are no other
-parameters or else all other parameters have default arguments~(\ref{dcl.fct.default}).
+parameters or else all other parameters have default arguments\iref{dcl.fct.default}.
 \begin{note} Initializer-list constructors are favored over other constructors in
-list-initialization~(\ref{over.match.list}). Passing an initializer list as the argument
+list-initialization\iref{over.match.list}. Passing an initializer list as the argument
 to the constructor template \tcode{template<class T> C(T)} of a class \tcode{C} does not
 create an initializer-list constructor, because an initializer list argument causes the
-corresponding parameter to be a non-deduced context~(\ref{temp.deduct.call}). \end{note}
+corresponding parameter to be a non-deduced context\iref{temp.deduct.call}. \end{note}
 The template
 \tcode{std::initializer_list} is not predefined; if the header
 \tcode{<initializer_list>} is not included prior to a use of
 \tcode{std::initializer_list} --- even an implicit use in which the type is not
-named~(\ref{dcl.spec.auto}) --- the program is ill-formed.
+named\iref{dcl.spec.auto} --- the program is ill-formed.
 
 \pnum
 List-initialization of an object or reference of type \tcode{T} is defined as follows:
@@ -3913,7 +3913,7 @@ of the \grammarterm{designated-initializer-list}
 shall form a subsequence
 of the ordered \grammarterm{identifier}{s}
 in the direct non-static data members of \tcode{T}.
-Aggregate initialization is performed~(\ref{dcl.init.aggr}).
+Aggregate initialization is performed\iref{dcl.init.aggr}.
 \begin{example}
 \begin{codeblock}
 struct A { int x; int y; int z; };
@@ -3930,11 +3930,11 @@ copy-list-initialization, or by direct-initialization for
 direct-list-initialization).
 
 \item Otherwise, if \tcode{T} is a character array and the initializer list has a
-single element that is an appropriately-typed string literal~(\ref{dcl.init.string}),
+single element that is an appropriately-typed string literal\iref{dcl.init.string},
 initialization is performed as described in that section.
 
 \item Otherwise, if \tcode{T} is an aggregate, aggregate initialization is
-performed~(\ref{dcl.init.aggr}).
+performed\iref{dcl.init.aggr}.
 
 \begin{example}
 \begin{codeblock}
@@ -4001,10 +4001,10 @@ S s3 { };                           // OK: invoke \#2
 \end{example}
 
 \item Otherwise, if \tcode{T} is an enumeration
-with a fixed underlying type~(\ref{dcl.enum}),
+with a fixed underlying type\iref{dcl.enum},
 the \grammarterm{initializer-list} has a single element \tcode{v}, and
 the initialization is direct-list-initialization,
-the object is initialized with the value \tcode{T(v)}~(\ref{expr.type.conv});
+the object is initialized with the value \tcode{T(v)}\iref{expr.type.conv};
 if a narrowing conversion is required to convert \tcode{v}
 to the underlying type of \tcode{T}, the program is ill-formed.
 \begin{example}
@@ -4105,7 +4105,7 @@ int k { };                          // initialize to 0
 \pnum
 Within the \grammarterm{initializer-list} of a \grammarterm{braced-init-list},
 the \grammarterm{initializer-clause}{s}, including any that result from pack
-expansions~(\ref{temp.variadic}), are evaluated in the order in which they
+expansions\iref{temp.variadic}, are evaluated in the order in which they
 appear. That is, every value computation and side effect associated with a
 given \grammarterm{initializer-clause} is sequenced before every value
 computation and side effect associated with any \grammarterm{initializer-clause}
@@ -4119,14 +4119,14 @@ arguments of a call. \end{note}
 \pnum
 An object of type \tcode{std::initializer_list<E>} is constructed from
 an initializer list as if
-the implementation generated and materialized~(\ref{conv.rval})
+the implementation generated and materialized\iref{conv.rval}
 a prvalue of type ``array of $N$ \tcode{const E}'',
 where $N$ is the number of elements in the
 initializer list. Each element of that array is copy-initialized with the
 corresponding element of the initializer list, and the
 \tcode{std::initializer_list<E>} object is constructed to refer to that array.
 \begin{note} A constructor or conversion function selected for the copy shall be
-accessible (Clause~\ref{class.access}) in the context of the initializer list.
+accessible\iref{class.access} in the context of the initializer list.
 \end{note}
 If a narrowing conversion is required to initialize any of the elements, the program is ill-formed. \begin{example}
 \begin{codeblock}
@@ -4147,7 +4147,7 @@ assuming that the implementation can construct an \tcode{initializer_list} objec
 
 \pnum
 The array has the same lifetime as any other temporary
-object~(\ref{class.temporary}), except that initializing an
+object\iref{class.temporary}, except that initializing an
 \tcode{initializer_list} object from the array extends the lifetime of
 the array exactly like binding a reference to a temporary.
 \begin{example}
@@ -4175,7 +4175,7 @@ so the array persists for the lifetime of the variable.
 For \tcode{i4}, the \tcode{initializer_list} object is initialized in
 the constructor's \grammarterm{ctor-initializer} as if by binding
 a temporary array to a reference member, so the program is
-ill-formed~(\ref{class.base.init}).
+ill-formed\iref{class.base.init}.
 \end{example}
 \begin{note}
 The implementation is free to allocate the array in read-only memory if an explicit array with the same initializer could be so allocated. \end{note}

--- a/source/derived.tex
+++ b/source/derived.tex
@@ -592,8 +592,8 @@ indirectly from \tcode{Base}, a member function \tcode{vf} with the same
 name, parameter-type-list\iref{dcl.fct}, cv-qualification, and ref-qualifier
 (or absence of same) as
 \tcode{Base::vf} is declared, then \tcode{Derived::vf} is also virtual
-(whether or not it is so declared) and it \term{overrides}\footnote{A function with the same name but a different parameter list
-(\ref{over}) as a virtual function is not necessarily virtual and
+(whether or not it is so declared) and it \term{overrides}\footnote{A function with the same name but a different parameter list\iref{over}
+as a virtual function is not necessarily virtual and
 does not override. The use of the \tcode{virtual} specifier in the
 declaration of an overriding function is legal but redundant (has empty
 semantics). Access control\iref{class.access} is not considered in

--- a/source/derived.tex
+++ b/source/derived.tex
@@ -56,7 +56,7 @@ The optional \grammarterm{attribute-specifier-seq} appertains to the \grammarter
 \indextext{type!incomplete}%
 A \grammarterm{class-or-decltype} shall denote
 a class type that is not
-an incompletely defined class (Clause~\ref{class}).
+an incompletely defined class\iref{class}.
 The class denoted by the \grammarterm{class-or-decltype} of
 a \grammarterm{base-specifier} is called a
 \indextext{base class!direct}%
@@ -65,7 +65,7 @@ for the class being defined.
 \indextext{base class}%
 \indextext{derivation|see{inheritance}}%
 During the lookup for a base class name, non-type names are
-ignored~(\ref{basic.scope.hiding}). If the name found is not a
+ignored\iref{basic.scope.hiding}. If the name found is not a
 \grammarterm{class-name}, the program is ill-formed. A class \tcode{B} is a
 base class of a class \tcode{D} if it is a direct base class of
 \tcode{D} or a direct base class of one of \tcode{D}'s base classes.
@@ -75,7 +75,7 @@ class but not a direct base class. A class is said to be (directly or
 indirectly) \term{derived} from its (direct or indirect) base
 classes.
 \begin{note}
-See Clause~\ref{class.access} for the meaning of
+See \ref{class.access} for the meaning of
 \grammarterm{access-specifier}.
 \end{note}
 \indextext{access control!base class member}%
@@ -88,18 +88,18 @@ by the derived class. Constructors of a base class
 can also be inherited as described in~\ref{namespace.udecl}.
 Inherited members can be referred to in
 expressions in the same manner as other members of the derived class,
-unless their names are hidden or ambiguous~(\ref{class.member.lookup}).
+unless their names are hidden or ambiguous\iref{class.member.lookup}.
 \indextext{operator!scope resolution}%
 \begin{note}
-The scope resolution operator \tcode{::}~(\ref{expr.prim}) can be used
+The scope resolution operator \tcode{::}\iref{expr.prim} can be used
 to refer to a direct or indirect base member explicitly. This allows
 access to a name that has been redeclared in the derived class. A
 derived class can itself serve as a base class subject to access
 control; see~\ref{class.access.base}. A pointer to a derived class can be
 implicitly converted to a pointer to an accessible unambiguous base
-class~(\ref{conv.ptr}). An lvalue of a derived class type can be bound
+class\iref{conv.ptr}. An lvalue of a derived class type can be bound
 to a reference to an accessible unambiguous base
-class~(\ref{dcl.init.ref}).
+class\iref{dcl.init.ref}.
 \end{note}
 
 \pnum
@@ -133,11 +133,11 @@ Here, an object of class \tcode{Derived2} will have a subobject of class
 
 \pnum
 A \grammarterm{base-specifier} followed by an ellipsis is a pack
-expansion~(\ref{temp.variadic}).
+expansion\iref{temp.variadic}.
 
 \pnum
 The order in which the base class subobjects are allocated in the most
-derived object~(\ref{intro.object}) is unspecified.
+derived object\iref{intro.object} is unspecified.
 \begin{note}
 \indextext{directed acyclic graph|see{DAG}}%
 \indextext{lattice|see{DAG, subobject}}%
@@ -161,14 +161,14 @@ constructors; see~\ref{class.base.init}.
 
 \pnum
 \begin{note}
-A base class subobject might have a layout~(\ref{basic.stc}) different
+A base class subobject might have a layout\iref{basic.stc} different
 from the layout of a most derived object of the same type. A base class
-subobject might have a polymorphic behavior~(\ref{class.cdtor})
+subobject might have a polymorphic behavior\iref{class.cdtor}
 different from the polymorphic behavior of a most derived object of the
-same type. A base class subobject may be of zero size (Clause~\ref{class});
+same type. A base class subobject may be of zero size\iref{class};
 however, two subobjects that have the same class type and that belong to
 the same most derived object must not be allocated at the same
-address~(\ref{expr.eq}).
+address\iref{expr.eq}.
 \end{note}
 
 \rSec1[class.mi]{Multiple base classes}
@@ -194,8 +194,8 @@ class D : public A, public B, public C { @\commentellip@ };
 \indextext{initialization!order of}%
 \begin{note}
 The order of derivation is not significant except as specified by the
-semantics of initialization by constructor~(\ref{class.base.init}),
-cleanup~(\ref{class.dtor}), and storage
+semantics of initialization by constructor\iref{class.base.init},
+cleanup\iref{class.dtor}, and storage
 layout~(\ref{class.mem}, \ref{class.access.spec}).
 \end{note}
 
@@ -232,7 +232,7 @@ A base class specifier that does not contain the keyword
 class specifier that contains the keyword \tcode{virtual} specifies a
 \defnx{virtual base class}{base class!virtual}. For each distinct occurrence of a
 non-virtual base class in the class lattice of the most derived class,
-the most derived object~(\ref{intro.object}) shall contain a
+the most derived object\iref{intro.object} shall contain a
 corresponding distinct base class subobject of that type. For each
 distinct base class that is specified virtual, the most derived object
 shall contain a single base class subobject of that type.
@@ -260,7 +260,7 @@ void C::f() { A::next = B::next; }      // well-formed
 \end{codeblock}
 Without the \tcode{A::} or \tcode{B::} qualifiers, the definition of
 \tcode{C::f} above would be ill-formed because of
-ambiguity~(\ref{class.member.lookup}).
+ambiguity\iref{class.member.lookup}.
 \end{note}
 
 \pnum
@@ -324,13 +324,13 @@ by \tcode{X} and \tcode{Y}, as shown in Figure~\ref{fig:virtnonvirt}.
 
 \pnum
 Member name lookup determines the meaning of a name
-(\grammarterm{id-expression}) in a class scope~(\ref{basic.scope.class}).
+(\grammarterm{id-expression}) in a class scope\iref{basic.scope.class}.
 Name lookup can result in an \term{ambiguity}, in which case the
 program is ill-formed. For an \grammarterm{id-expression}, name lookup
 begins in the class scope of \tcode{this}; for a
 \grammarterm{qualified-id}, name lookup begins in the scope of the
 \grammarterm{nested-name-specifier}. Name lookup takes place before access
-control~(\ref{basic.lookup}, Clause~\ref{class.access}).
+control~(\ref{basic.lookup}, \ref{class.access}).
 
 \pnum
 The following steps define the result of name lookup for a member name
@@ -344,7 +344,7 @@ subobjects where declarations of these members (possibly including
 \grammarterm{using-declaration}{s}) were found. In the declaration set,
 \grammarterm{using-declaration}{s} are replaced by the
 set of designated members that are not hidden or overridden by members of the
-derived class~(\ref{namespace.udecl}),
+derived class\iref{namespace.udecl},
 and type declarations (including injected-class-names) are
 replaced by the types they designate. $S(f,C)$ is calculated as follows:
 
@@ -355,13 +355,13 @@ declaration set contains every declaration of \tcode{f} declared in
 which the lookup occurs.
 \begin{note}
 Looking up a name in an
-\grammarterm{elaborated-type-specifier}~(\ref{basic.lookup.elab}) or
-\grammarterm{base-specifier} (Clause~\ref{class.derived}), for instance,
+\grammarterm{elaborated-type-specifier}\iref{basic.lookup.elab} or
+\grammarterm{base-specifier}\iref{class.derived}, for instance,
 ignores all non-type declarations, while looking up a name in a
-\grammarterm{nested-name-specifier}~(\ref{basic.lookup.qual}) ignores
+\grammarterm{nested-name-specifier}\iref{basic.lookup.qual} ignores
 function, variable, and enumerator declarations. As another example,
 looking up a name in a
-\grammarterm{using-declaration}~(\ref{namespace.udecl}) includes the
+\grammarterm{using-declaration}\iref{namespace.udecl} includes the
 declaration of a class or enumeration that would ordinarily be hidden by
 another declaration of that name in the same scope.
 \end{note}
@@ -422,7 +422,7 @@ $S(x,D)$ is discarded in the first merge step.
 \pnum
 \indextext{access control!overload resolution and}%
 If the name of an overloaded function is unambiguously found,
-overload resolution~(\ref{over.match}) also takes place before access
+overload resolution\iref{over.match} also takes place before access
 control.
 \indextext{example!scope resolution operator}%
 \indextext{example!explicit qualification}%
@@ -589,20 +589,20 @@ called a \term{polymorphic class}.
 If a virtual member function \tcode{vf} is declared in a class
 \tcode{Base} and in a class \tcode{Derived}, derived directly or
 indirectly from \tcode{Base}, a member function \tcode{vf} with the same
-name, parameter-type-list~(\ref{dcl.fct}), cv-qualification, and ref-qualifier
+name, parameter-type-list\iref{dcl.fct}, cv-qualification, and ref-qualifier
 (or absence of same) as
 \tcode{Base::vf} is declared, then \tcode{Derived::vf} is also virtual
 (whether or not it is so declared) and it \term{overrides}\footnote{A function with the same name but a different parameter list
-(Clause~\ref{over}) as a virtual function is not necessarily virtual and
+(\ref{over}) as a virtual function is not necessarily virtual and
 does not override. The use of the \tcode{virtual} specifier in the
 declaration of an overriding function is legal but redundant (has empty
-semantics). Access control (Clause~\ref{class.access}) is not considered in
+semantics). Access control\iref{class.access} is not considered in
 determining overriding.}
 \tcode{Base::vf}. For convenience we say that any virtual function
 overrides itself.
 \indextext{overrider!final}%
 A virtual member function \tcode{C::vf} of a class object \tcode{S} is a \defn{final
-overrider} unless the most derived class~(\ref{intro.object}) of which \tcode{S} is a
+overrider} unless the most derived class\iref{intro.object} of which \tcode{S} is a
 base class subobject (if any) declares or inherits another member function that overrides
 \tcode{vf}. In a derived class, if a virtual member function of a base class subobject
 has more than one final overrider the program is ill-formed.
@@ -695,7 +695,7 @@ A virtual function shall not have a \grammarterm{requires-clause}.
 \begin{example}
 \begin{codeblock}
 struct A {
-  virtual void f() requires true; // error: virtual function cannot be constrained~(\ref{temp.constr.decl})
+  virtual void f() requires true; // error: virtual function cannot be constrained\iref{temp.constr.decl}
 };
 \end{codeblock}
 \end{example}
@@ -735,7 +735,7 @@ complete at the point of declaration of \tcode{D::f} or shall be the
 class type \tcode{D}. When the overriding function is called as the
 final overrider of the overridden function, its result is converted to
 the type returned by the (statically chosen) overridden
-function~(\ref{expr.call}).
+function\iref{expr.call}.
 \begin{example}
 \indextext{example!virtual function}%
 \begin{codeblock}
@@ -787,13 +787,13 @@ The interpretation of the call of a virtual function depends on the type
 of the object for which it is called (the dynamic type), whereas the
 interpretation of a call of a non-virtual member function depends only
 on the type of the pointer or reference denoting that object (the static
-type)~(\ref{expr.call}).
+type)\iref{expr.call}.
 \end{note}
 
 \pnum
 \begin{note}
 The \tcode{virtual} specifier implies membership, so a virtual function
-cannot be a non-member~(\ref{dcl.fct.spec}) function. Nor can a virtual
+cannot be a non-member\iref{dcl.fct.spec} function. Nor can a virtual
 function be a static member, since a virtual function call relies on a
 specific object for determining which function to invoke. A virtual
 function declared in one class can be declared a \tcode{friend} in
@@ -803,8 +803,8 @@ another class.
 \pnum
 \indextext{definition!virtual function}%
 A virtual function declared in a class shall be defined, or declared
-pure~(\ref{class.abstract}) in that class, or both; no diagnostic is
-required~(\ref{basic.def.odr}).
+pure\iref{class.abstract} in that class, or both; no diagnostic is
+required\iref{basic.def.odr}.
 \indextext{friend!\tcode{virtual} and}%
 
 \pnum
@@ -894,7 +894,7 @@ void foe() {
 \pnum
 \indextext{operator!scope resolution}%
 \indextext{virtual function call}%
-Explicit qualification with the scope operator~(\ref{expr.prim})
+Explicit qualification with the scope operator\iref{expr.prim}
 suppresses the virtual call mechanism.
 \begin{example}
 \begin{codeblock}
@@ -913,7 +913,7 @@ and not
 \end{example}
 
 \pnum
-A function with a deleted definition~(\ref{dcl.fct.def}) shall
+A function with a deleted definition\iref{dcl.fct.def} shall
 not override a function that does not have a deleted definition. Likewise,
 a function that does not have a deleted definition shall not override a
 function with a deleted definition.%
@@ -941,12 +941,12 @@ Such a function might be inherited: see below.
 \end{note}
 \indextext{virtual function!pure}%
 A virtual function is specified \term{pure} by using a
-\grammarterm{pure-specifier}~(\ref{class.mem}) in the function declaration
+\grammarterm{pure-specifier}\iref{class.mem} in the function declaration
 in the class definition.
 \indextext{definition!pure virtual function}%
 A pure virtual function need be defined only if called with, or as if
-with~(\ref{class.dtor}), the \grammarterm{qualified-id}
-syntax~(\ref{expr.prim}).
+with\iref{class.dtor}, the \grammarterm{qualified-id}
+syntax\iref{expr.prim}.
 \begin{example}
 \indextext{example!pure virtual function}%
 \begin{codeblock}
@@ -1029,7 +1029,7 @@ pure.
 Member functions can be called from a constructor (or destructor) of an
 abstract class;
 \indextext{virtual function call!undefined pure}%
-the effect of making a virtual call~(\ref{class.virtual}) to a pure
+the effect of making a virtual call\iref{class.virtual} to a pure
 virtual function directly or indirectly for the object being created (or
 destroyed) from such a constructor (or destructor) is undefined.%
 \indextext{derived class|)}

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -24,7 +24,7 @@ as summarized in Table~\ref{tab:diagnostics.lib.summary}.
 \rSec1[std.exceptions]{Exception classes}
 
 \pnum
-The \Cpp standard library provides classes to be used to report certain errors~(\ref{res.on.exception.handling}) in
+The \Cpp standard library provides classes to be used to report certain errors\iref{res.on.exception.handling} in
 \Cpp programs.
 In the error model reflected in these classes, errors are divided into two
 broad categories:
@@ -567,13 +567,13 @@ is not defined.
 
 \pnum
 An expression \tcode{assert(E)}
-is a constant subexpression~(\ref{defns.const.subexpr}), if
+is a constant subexpression\iref{defns.const.subexpr}, if
 \begin{itemize}
 \item
 \tcode{NDEBUG} is defined at the point where \tcode{assert}
 is last defined or redefined, or
 \item
-\tcode{E} contextually converted to \tcode{bool}~(Clause~\ref{conv})
+\tcode{E} contextually converted to \tcode{bool}\iref{conv}
 is a constant subexpression that evaluates to the value \tcode{true}.
 \end{itemize}
 
@@ -769,7 +769,7 @@ the operating system or other low-level application program interfaces.
 
 \pnum
 Components described in this subclause shall not change the value of
-\tcode{errno}~(\ref{errno}).
+\tcode{errno}\iref{errno}.
 Implementations should leave the error states provided by other
 libraries unchanged.
 
@@ -1077,7 +1077,7 @@ bool operator<(const error_category& rhs) const noexcept;
 \pnum
 \returns \tcode{less<const error_category*>()(this, \&rhs)}.
 
-\begin{note} \tcode{less}~(\ref{comparisons}) provides a total ordering for pointers. \end{note}
+\begin{note} \tcode{less}\iref{comparisons} provides a total ordering for pointers. \end{note}
 \end{itemdescr}
 
 \rSec3[syserr.errcat.derived]{Program defined classes derived from \tcode{error_category}}
@@ -1383,7 +1383,7 @@ As if by: \tcode{os << ec.category().name() << ':' << ec.value();}
 \pnum
 The class \tcode{error_condition} describes an object used to hold values identifying
 error conditions. \begin{note} \tcode{error_condition} values are portable abstractions,
-while \tcode{error_code} values~(\ref{syserr.errcode}) are implementation specific. \end{note}
+while \tcode{error_code} values\iref{syserr.errcode} are implementation specific. \end{note}
 
 \indexlibrary{\idxcode{error_condition}}%
 \begin{codeblock}
@@ -1649,7 +1649,7 @@ template <> struct hash<error_condition>;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum The specializations are enabled~(\ref{unord.hash}).
+\pnum The specializations are enabled\iref{unord.hash}.
 \end{itemdescr}
 
 \rSec2[syserr.syserr]{Class \tcode{system_error}}
@@ -1665,7 +1665,7 @@ application program interfaces.
 \pnum
 \begin{note}
 If an error represents an out-of-memory condition, implementations are
-encouraged to throw an exception object of type \tcode{bad_alloc}~(\ref{bad.alloc}) rather
+encouraged to throw an exception object of type \tcode{bad_alloc}\iref{bad.alloc} rather
 than \tcode{system_error}.
 \end{note}
 \indexlibrary{\idxcode{system_error}}%

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -49,14 +49,14 @@ or in functions called from the handler's try block.
 \end{bnf}
 
 The optional \grammarterm{attribute-specifier-seq} in an \grammarterm{exception-declaration}
-appertains to the parameter of the catch clause~(\ref{except.handle}).
+appertains to the parameter of the catch clause\iref{except.handle}.
 
 \pnum
 \indextext{exception handling!try block}%
 \indextext{exception handling!handler}%
 \indextext{try block|see{exception handling, try block}}%
 \indextext{handler|see{exception handling, handler}}%
-A \grammarterm{try-block} is a \grammarterm{statement} (Clause~\ref{stmt.stmt}).
+A \grammarterm{try-block} is a \grammarterm{statement}\iref{stmt.stmt}.
 \begin{note} Within this Clause
 ``try block'' is taken to mean both \grammarterm{try-block} and
 \grammarterm{function-try-block}. \end{note}
@@ -181,7 +181,7 @@ try : i(f(ii)), d(id) {
 
 \pnum
 In this section, ``before'' and ``after'' refer to the
-``sequenced before'' relation~(\ref{intro.execution}).
+``sequenced before'' relation\iref{intro.execution}.
 
 \rSec1[except.throw]{Throwing an exception}%
 \indextext{exception handling!throwing}%
@@ -191,12 +191,12 @@ In this section, ``before'' and ``after'' refer to the
 Throwing an exception transfers control to a handler.
 \begin{note}
 An exception can be thrown from one of the following contexts:
-\grammarterm{throw-expression}{s}~(\ref{expr.throw}),
-allocation functions~(\ref{basic.stc.dynamic.allocation}),
-\tcode{dynamic_cast}~(\ref{expr.dynamic.cast}),
-\tcode{typeid}~(\ref{expr.typeid}),
-\grammarterm{new-expression}{s}~(\ref{expr.new}), and standard library
-functions~(\ref{structure.specifications}).
+\grammarterm{throw-expression}{s}\iref{expr.throw},
+allocation functions\iref{basic.stc.dynamic.allocation},
+\tcode{dynamic_cast}\iref{expr.dynamic.cast},
+\tcode{typeid}\iref{expr.typeid},
+\grammarterm{new-expression}{s}\iref{expr.new}, and standard library
+functions\iref{structure.specifications}.
 \end{note}
 An object is passed and the type of that object determines which handlers
 can catch it.
@@ -244,7 +244,7 @@ try {
 \indextext{exception handling!handler}%
 \indextext{exception handling!nearest handler}%
 When an exception is thrown, control is transferred to the nearest handler with
-a matching type~(\ref{except.handle}); ``nearest'' means the handler
+a matching type\iref{except.handle}; ``nearest'' means the handler
 for which the
 \grammarterm{compound-statement} or
 \grammarterm{ctor-initializer}
@@ -259,7 +259,7 @@ called the
 \defnx{exception object}{exception handling!exception object}.
 An lvalue denoting the temporary is used to initialize the
 variable declared in the matching
-\grammarterm{handler}~(\ref{except.handle}).
+\grammarterm{handler}\iref{except.handle}.
 If the type of the exception object would
 be an incomplete type or a pointer to an incomplete
 type other than \cv{}~\tcode{void} the program is ill-formed.
@@ -283,7 +283,7 @@ immediately after the destruction of the object (if any)
 declared in the \grammarterm{exception-declaration} in the handler;
 
 \item
-when an object of type \tcode{std::exception_ptr}~(\ref{propagation})
+when an object of type \tcode{std::exception_ptr}\iref{propagation}
 that refers to the exception object is destroyed,
 before the destructor of \tcode{std::exception_ptr} returns.
 \end{itemize}
@@ -291,7 +291,7 @@ before the destructor of \tcode{std::exception_ptr} returns.
 Among all points of potential destruction for the exception object,
 there is an unspecified last one
 where the exception object is destroyed.
-All other points happen before that last one~(\ref{intro.races}).
+All other points happen before that last one\iref{intro.races}.
 \begin{note}
 No other thread synchronization is implied in exception handling.
 \end{note}
@@ -309,14 +309,14 @@ When the thrown object is a class object, the constructor selected for
 the copy-initialization as well as the constructor selected for
 a copy-initialization considering the thrown object as an lvalue
 shall be non-deleted and accessible, even if the copy/move operation is
-elided~(\ref{class.copy}).
-The destructor is potentially invoked~(\ref{class.dtor}).
+elided\iref{class.copy}.
+The destructor is potentially invoked\iref{class.dtor}.
 
 \pnum
 \indextext{exception handling!rethrow}%
 \indextext{rethrow|see{exception handling, rethrow}}%
 An exception is considered caught when a handler for that exception
-becomes active~(\ref{except.handle}).
+becomes active\iref{except.handle}.
 \begin{note}
 An exception can have active handlers and still be considered uncaught if
 it is rethrown.
@@ -326,16 +326,16 @@ it is rethrown.
 \indextext{exception handling!terminate called@\tcode{terminate} called}%
 \indextext{\idxcode{terminate}!called}%
 If the exception handling mechanism
-handling an uncaught exception~(\ref{except.uncaught})
+handling an uncaught exception\iref{except.uncaught}
 directly invokes a function that exits via an
-exception, \tcode{std::terminate} is called~(\ref{except.terminate}).
+exception, \tcode{std::terminate} is called\iref{except.terminate}.
 \begin{example}
 \begin{codeblock}
 struct C {
   C() { }
   C(const C&) {
     if (std::uncaught_exceptions()) {
-      throw 0;      // throw during copy to handler's \grammarterm{exception-declaration} object~(\ref{except.handle})
+      throw 0;      // throw during copy to handler's \grammarterm{exception-declaration} object\iref{except.handle}
     }
   }
 };
@@ -343,7 +343,7 @@ struct C {
 int main() {
   try {
     throw C();      // calls \tcode{std::terminate()} if construction of the handler's
-                    // \grammarterm{exception-declaration} object is not elided~(\ref{class.copy})
+                    // \grammarterm{exception-declaration} object is not elided\iref{class.copy}
   } catch(C) { }
 }
 \end{codeblock}
@@ -370,7 +370,7 @@ The destructor is invoked for each automatic object of class type constructed,
 but not yet destroyed,
 since the try block was entered.
 If an exception is thrown during the destruction of temporaries or
-local variables for a \tcode{return} statement~(\ref{stmt.return}),
+local variables for a \tcode{return} statement\iref{stmt.return},
 the destructor for the returned object (if any) is also invoked.
 The objects are destroyed in the reverse order of the completion
 of their construction.
@@ -392,7 +392,7 @@ A f() {
 }
 \end{codeblock}
 At \#1, the returned object of type \tcode{A} is constructed.
-Then, the local variable \tcode{b} is destroyed~(\ref{stmt.jump}).
+Then, the local variable \tcode{b} is destroyed\iref{stmt.jump}.
 Next, the local variable \tcode{y} is destroyed,
 causing stack unwinding,
 resulting in the destruction of the returned object,
@@ -407,7 +407,7 @@ is terminated by an exception,
 the destructor is invoked for
 each of the object's direct subobjects
 and, for a complete object, virtual base class subobjects,
-whose initialization has completed~(\ref{dcl.init})
+whose initialization has completed\iref{dcl.init}
 and whose destructor has not yet begun execution,
 except that in the case of destruction, the variant members of a
 union-like class are not destroyed.
@@ -427,8 +427,8 @@ Such destruction is sequenced before entering a handler of the
 
 \pnum
 \begin{note}
-If the object was allocated by a \grammarterm{new-expression}~(\ref{expr.new}),
-the matching deallocation function~(\ref{basic.stc.dynamic.deallocation}),
+If the object was allocated by a \grammarterm{new-expression}\iref{expr.new},
+the matching deallocation function\iref{basic.stc.dynamic.deallocation},
 if any, is called to free the storage occupied by the object.
 \end{note}
 
@@ -502,12 +502,12 @@ that can be converted to \tcode{T} by one or more of
 \begin{itemize}
 
 \item%
-a standard pointer conversion~(\ref{conv.ptr}) not involving conversions
+a standard pointer conversion\iref{conv.ptr} not involving conversions
 to pointers to private or protected or ambiguous classes
 \item%
-a function pointer conversion~(\ref{conv.fctptr})
+a function pointer conversion\iref{conv.fctptr}
 \item%
-a qualification conversion~(\ref{conv.qual}), or
+a qualification conversion\iref{conv.qual}, or
 
 \end{itemize}
 
@@ -522,7 +522,7 @@ A
 whose operand is an integer literal with value zero does not match a handler of
 pointer or pointer to member type.
 A handler of reference to array or function type
-is never a match for any exception object~(\ref{expr.throw}).
+is never a match for any exception object\iref{expr.throw}.
 \end{note}
 
 \begin{example}
@@ -610,7 +610,7 @@ is called;
 whether or not the stack is unwound before this call to
 \tcode{std::terminate()}
 is \impldef{stack unwinding before call to
-\tcode{std::terminate()}}~(\ref{except.terminate}).
+\tcode{std::terminate()}}\iref{except.terminate}.
 
 \pnum
 Referring to any non-static member or base class of an object
@@ -628,7 +628,7 @@ Exceptions thrown in destructors of objects with static storage duration or in
 constructors of namespace-scope objects with static storage duration are not caught by a
 \grammarterm{function-try-block}
 on
-the \tcode{main} function~(\ref{basic.start.main}).
+the \tcode{main} function\iref{basic.start.main}.
 Exceptions thrown in destructors of objects with thread storage duration or in constructors of namespace-scope objects with thread storage duration are not caught by a
 \grammarterm{function-try-block}
 on the initial function of the thread.
@@ -660,9 +660,9 @@ of type \tcode{E}, as follows:
 \begin{itemize}
 \item
 if \tcode{T} is a base class of \tcode{E}, the variable is
-copy-initialized~(\ref{dcl.init}) from the corresponding base class subobject
+copy-initialized\iref{dcl.init} from the corresponding base class subobject
 of the exception object;
-\item otherwise, the variable is copy-initialized~(\ref{dcl.init})
+\item otherwise, the variable is copy-initialized\iref{dcl.init}
 from the exception object.
 \end{itemize}
 
@@ -697,7 +697,7 @@ otherwise it has a
 The exception specification is either defined implicitly,
 or defined explicitly
 by using a \grammarterm{noexcept-specifier}
-as a suffix of a function declarator~(\ref{dcl.fct}).
+as a suffix of a function declarator\iref{dcl.fct}.
 
 \begin{bnf}
 \nontermdef{noexcept-specifier}\br
@@ -710,19 +710,19 @@ as a suffix of a function declarator~(\ref{dcl.fct}).
 \indextext{exception specification!noexcept!constant expression and}%
 In a \grammarterm{noexcept-specifier}, the \grammarterm{constant-expression},
 if supplied, shall be a contextually converted constant expression
-of type \tcode{bool}~(\ref{expr.const});
+of type \tcode{bool}\iref{expr.const};
 that constant expression is the exception specification of
 the function type in which the \grammarterm{noexcept-specifier} appears.
 A \tcode{(} token that follows \tcode{noexcept} is part of the
 \grammarterm{noexcept-specifier} and does not commence an
-initializer~(\ref{dcl.init}).
+initializer\iref{dcl.init}.
 The \grammarterm{noexcept-specifier} \tcode{noexcept}
 without a \grammarterm{constant-expression}
 is
 equivalent to the \grammarterm{noexcept-specifier}
 \tcode{noexcept(true)}.
 The \grammarterm{noexcept-specifier} \tcode{throw()}
-is deprecated~(\ref{depr.except.spec}), and
+is deprecated\iref{depr.except.spec}, and
 equivalent to the \grammarterm{noexcept-specifier}
 \tcode{noexcept(true)}.
 
@@ -736,7 +736,7 @@ in which cases the exception specification
 is as specified below
 and no other declaration for that function
 shall have a \grammarterm{noexcept-specifier}.
-In an explicit instantiation~(\ref{temp.explicit})
+In an explicit instantiation\iref{temp.explicit}
 a \grammarterm{noexcept-specifier} may be specified,
 but is not required.
 If a \grammarterm{noexcept-specifier} is specified
@@ -784,10 +784,10 @@ has a non-throwing exception specification.
 \indextext{exception handling!terminate called@\tcode{terminate} called}%
 \indextext{\idxcode{terminate}!called}%
 Whenever an exception is thrown
-and the search for a handler~(\ref{except.handle})
+and the search for a handler\iref{except.handle}
 encounters the outermost block of a function with a
 non-throwing exception specification,
-the function \tcode{std::terminate()} is called~(\ref{except.terminate}).
+the function \tcode{std::terminate()} is called\iref{except.terminate}.
 \begin{note}
 An implementation shall not reject an expression merely because, when
 executed, it throws or might
@@ -815,7 +815,7 @@ An expression \tcode{e} is
 
 \begin{itemize}
 \item
-\tcode{e} is a function call~(\ref{expr.call})
+\tcode{e} is a function call\iref{expr.call}
 whose \grammarterm{postfix-expression}
 has a function type,
 or a pointer-to-function type,
@@ -826,24 +826,24 @@ or
 (such as an overloaded operator,
 an allocation function in a \grammarterm{new-expression},
 a constructor for a function argument,
-or a destructor if \tcode{e} is a full-expression~(\ref{intro.execution}))
+or a destructor if \tcode{e} is a full-expression\iref{intro.execution})
 that is potentially-throwing,
 or
 \item
-\tcode{e} is a \grammarterm{throw-expression}~(\ref{expr.throw}),
+\tcode{e} is a \grammarterm{throw-expression}\iref{expr.throw},
 or
 \item
 \tcode{e} is a \tcode{dynamic_cast} expression that casts to a reference type and
-requires a runtime check~(\ref{expr.dynamic.cast}),
+requires a runtime check\iref{expr.dynamic.cast},
 or
 \item
 \tcode{e} is a \tcode{typeid} expression applied to a
 (possibly parenthesized) built-in unary \tcode{*} operator
 applied to a pointer to a
-polymorphic class type~(\ref{expr.typeid}),
+polymorphic class type\iref{expr.typeid},
 or
 \item
-any of the immediate subexpressions~(\ref{intro.execution})
+any of the immediate subexpressions\iref{intro.execution}
 of \tcode{e} is potentially-throwing.
 \end{itemize}
 
@@ -870,7 +870,7 @@ for a default constructor, a default member initializer.
 \begin{note}
 Even though destructors for fully-constructed subobjects
 are invoked when an exception is thrown
-during the execution of a constructor~(\ref{except.ctor}),
+during the execution of a constructor\iref{except.ctor},
 their exception specifications do not contribute
 to the exception specification of the constructor,
 because an exception thrown from such a destructor
@@ -895,7 +895,7 @@ the invocation of any assignment operator
 in the implicit definition is potentially-throwing.
 
 \pnum
-A deallocation function~(\ref{basic.stc.dynamic.deallocation})
+A deallocation function\iref{basic.stc.dynamic.deallocation}
 with no explicit \grammarterm{noexcept-specifier}
 has a non-throwing exception specification.
 
@@ -939,7 +939,7 @@ An exception specification is considered to be \defnx{needed}{needed!exception s
 \item in an expression, the function is the unique lookup result or the selected
 member of a set of overloaded functions~(\ref{basic.lookup}, \ref{over.match}, \ref{over.over});
 
-\item the function is odr-used~(\ref{basic.def.odr}) or, if it appears in an
+\item the function is odr-used\iref{basic.def.odr} or, if it appears in an
 unevaluated operand, would be odr-used if the expression were
 potentially-evaluated;
 
@@ -969,12 +969,12 @@ needed.
 \rSec1[except.special]{Special functions}
 
 \pnum
-The function \tcode{std::terminate()}~(\ref{except.terminate})
+The function \tcode{std::terminate()}\iref{except.terminate}
 is used by the exception
 handling mechanism for coping with errors related to the exception handling
 mechanism itself. The function
-\tcode{std::current_exception()}~(\ref{propagation}) and the class
-\tcode{std::nested_exception}~(\ref{except.nested}) can be used by a program to
+\tcode{std::current_exception()}\iref{propagation} and the class
+\tcode{std::nested_exception}\iref{except.nested} can be used by a program to
 capture the currently handled exception.
 
 \rSec2[except.terminate]{The \tcode{std::terminate()} function}
@@ -990,54 +990,54 @@ for less subtle error handling techniques. \begin{note} These situations are:
 when the exception handling mechanism, after completing
 the initialization of the exception object
 but before
-activation of a handler for the exception~(\ref{except.throw}),
+activation of a handler for the exception\iref{except.throw},
 calls a function that exits
 via an exception, or
 
 \item%
-when the exception handling mechanism cannot find a handler for a thrown exception~(\ref{except.handle}), or
+when the exception handling mechanism cannot find a handler for a thrown exception\iref{except.handle}, or
 
-\item when the search for a handler~(\ref{except.handle}) encounters the
+\item when the search for a handler\iref{except.handle} encounters the
 outermost block of a function
-with a non-throwing exception specification~(\ref{except.spec}), or
+with a non-throwing exception specification\iref{except.spec}, or
 
 \item%
-when the destruction of an object during stack unwinding~(\ref{except.ctor})
+when the destruction of an object during stack unwinding\iref{except.ctor}
 terminates by throwing an exception, or
 
 \item%
 when initialization of a non-local
-variable with static or thread storage duration~(\ref{basic.start.dynamic})
+variable with static or thread storage duration\iref{basic.start.dynamic}
 exits via an exception, or
 
 \item%
 when destruction of an object with static or thread storage duration exits
-via an exception~(\ref{basic.start.term}), or
+via an exception\iref{basic.start.term}, or
 
 \item%
 when execution of a function registered with
 \tcode{std::atexit} or \tcode{std::at_quick_exit}
-exits via an exception~(\ref{support.start.term}), or
+exits via an exception\iref{support.start.term}, or
 
 \item%
 when a
-\grammarterm{throw-expression}~(\ref{expr.throw})
+\grammarterm{throw-expression}\iref{expr.throw}
 with no operand attempts to rethrow an exception and no exception is being
-handled~(\ref{except.throw}), or
+handled\iref{except.throw}, or
 
 \item%
 when the function \tcode{std::nested_exception::rethrow_nested} is called for an object
-that has captured no exception~(\ref{except.nested}), or
+that has captured no exception\iref{except.nested}, or
 
 \item%
 when execution of the initial function of a thread exits via
-an exception~(\ref{thread.thread.constr}), or
+an exception\iref{thread.thread.constr}, or
 
 \item%
 for a parallel algorithm whose \tcode{ExecutionPolicy} specifies such
 behavior~(\ref{execpol.seq}, \ref{execpol.par}, \ref{execpol.parunseq}),
-when execution of an element access function~(\ref{algorithms.parallel.defns})
-of the parallel algorithm exits via an exception~(\ref{algorithms.parallel.exceptions}), or
+when execution of an element access function\iref{algorithms.parallel.defns}
+of the parallel algorithm exits via an exception\iref{algorithms.parallel.exceptions}, or
 
 \item%
 when the destructor or the copy assignment operator is invoked on an object
@@ -1057,16 +1057,16 @@ fails to meet a postcondition.
 \indextext{\idxcode{terminate}}%
 In such cases,
 \tcode{std::terminate()}
-is called~(\ref{exception.terminate}).
+is called\iref{exception.terminate}.
 In the situation where no matching handler is found, it is
 \impldef{stack unwinding before call to \tcode{std::terminate()}} whether or not the
 stack is unwound
 before
 \tcode{std::terminate()}
 is called.
-In the situation where the search for a handler~(\ref{except.handle}) encounters the
+In the situation where the search for a handler\iref{except.handle} encounters the
 outermost block of a function
-with a non-throwing exception specification~(\ref{except.spec}), it is
+with a non-throwing exception specification\iref{except.spec}, it is
 \impldef{whether stack is unwound before calling \tcode{std::ter\-mi\-nate()}
 when a \tcode{noexcept} specification
 is violated}
@@ -1085,12 +1085,12 @@ will eventually cause a call to
 
 \pnum
 An exception is considered uncaught
-after completing the initialization of the exception object~(\ref{except.throw})
-until completing the activation of a handler for the exception~(\ref{except.handle}).
+after completing the initialization of the exception object\iref{except.throw}
+until completing the activation of a handler for the exception\iref{except.handle}.
 This includes stack unwinding.
 If an exception is rethrown~(\ref{expr.throw}, \ref{propagation}),
 it is considered uncaught from the point of rethrow
 until the rethrown exception is caught.
-The function \tcode{std::uncaught_exceptions()}~(\ref{uncaught.exceptions})
+The function \tcode{std::uncaught_exceptions()}\iref{uncaught.exceptions}
 returns the number of uncaught exceptions in the current thread.%
 \indextext{exception handling|)}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -680,8 +680,8 @@ void abssort(float* x, unsigned N) {
 \pnum
 A \grammarterm{lambda-expression} is a prvalue
 whose result object is called the \defn{closure object}. A
-\grammarterm{lambda-expression} shall not appear in an unevaluated operand
-(\ref{expr}), in a \grammarterm{template-argument},
+\grammarterm{lambda-expression} shall not appear in an unevaluated operand\iref{expr},
+in a \grammarterm{template-argument},
 in an \grammarterm{alias-declaration},
 in a typedef declaration, or in the declaration of a function or function
 template outside its function body and default arguments.
@@ -1836,8 +1836,8 @@ template<typename T> concept D = requires (T t) {
 \end{example}
 
 \pnum
-A local parameter shall only appear as an unevaluated operand
-(\ref{expr}) within the \grammarterm{constraint-expression}.
+A local parameter shall only appear as an unevaluated operand\iref{expr}
+within the \grammarterm{constraint-expression}.
 \begin{example}
 \begin{codeblock}
 template<typename T> concept C = requires (T a) {
@@ -2028,8 +2028,8 @@ The access of the constructor, conversion functions or destructor is
 checked at the point of call in the calling function. If a constructor
 or destructor for a function parameter throws an exception, the search
 for a handler starts in the scope of the calling function; in
-particular, if the function called has a \grammarterm{function-try-block}
-(\ref{except}) with a handler that could handle the exception,
+particular, if the function called has a \grammarterm{function-try-block}\iref{except}
+with a handler that could handle the exception,
 this handler is not considered.
 \end{example}
 
@@ -2275,8 +2275,8 @@ In either case, the
 \grammarterm{id-expression} shall name a member of the class or of one of
 its base classes.
 \begin{note}
-Because the name of a class is inserted in its class scope
-(\ref{class}), the name of a class is also considered a nested
+Because the name of a class is inserted in its class scope\iref{class},
+the name of a class is also considered a nested
 member of that class.
 \end{note}
 \begin{note}
@@ -2785,8 +2785,8 @@ the enumeration type.
 \indextext{cast!derived class}%
 A prvalue of type ``pointer to \cvqual{cv1} \tcode{B}'', where \tcode{B}
 is a class type, can be converted to a prvalue of type ``pointer to
-\cvqual{cv2} \tcode{D}'', where \tcode{D} is a class derived
-(\ref{class.derived}) from \tcode{B},
+\cvqual{cv2} \tcode{D}'', where \tcode{D} is a class derived\iref{class.derived}
+from \tcode{B},
 if \cvqual{cv2} is the same cv-qualification as,
 or greater cv-qualification than, \cvqual{cv1}.
 If \tcode{B} is a virtual base class of \tcode{D} or
@@ -3279,8 +3279,8 @@ result is the type of the promoted operand.
 \pnum
 \indextext{operator!logical negation}%
 The operand of the logical negation operator \tcode{!} is contextually
-converted to \tcode{bool}
-(\ref{conv}); its value is \tcode{true}
+converted to \tcode{bool}\iref{conv};
+its value is \tcode{true}
 if the converted operand is \tcode{false} and \tcode{false} otherwise.
 The type of the result is \tcode{bool}.
 
@@ -4000,8 +4000,8 @@ interpreted as the second alternative.\footnote{A lambda expression with a
 empty square brackets can follow the \tcode{delete} keyword if the lambda expression is
 enclosed in parentheses.}
 The operand shall be of pointer to object type or of class type. If of
-class type, the operand is contextually implicitly converted
-(\ref{conv}) to a pointer to object
+class type, the operand is contextually implicitly converted\iref{conv}
+to a pointer to object
 type.\footnote{This implies that an object
 cannot be deleted using a pointer of type
 \tcode{void*} because \tcode{void} is not an object type.}
@@ -4748,8 +4748,8 @@ If at least one of the operands is a pointer,
 pointer conversions\iref{conv.ptr},
 function pointer conversions\iref{conv.fctptr}, and
 qualification conversions\iref{conv.qual}
-are performed on both operands to bring them to their composite pointer type
-(\ref{expr}). Comparing pointers is defined as follows:
+are performed on both operands to bring them to their composite pointer type\iref{expr}.
+Comparing pointers is defined as follows:
 
 \begin{itemize}
 \item

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -16,7 +16,7 @@
 \pnum
 \indextext{expression|(}%
 \begin{note}
-Clause~\ref{expr} defines the syntax, order of evaluation, and meaning
+\ref{expr} defines the syntax, order of evaluation, and meaning
 of expressions.\footnote{The precedence of operators is not directly specified, but it can be
 derived from the syntax.}
 An expression is a sequence of operators and operands that specifies a
@@ -28,18 +28,18 @@ effects.
 \indextext{operator!overloaded}%
 \begin{note}
 Operators can be overloaded, that is, given meaning when applied to
-expressions of class type~(Clause \ref{class}) or enumeration
-type~(\ref{dcl.enum}). Uses of overloaded operators are transformed into
+expressions of class type\iref{class} or enumeration
+type\iref{dcl.enum}. Uses of overloaded operators are transformed into
 function calls as described in~\ref{over.oper}. Overloaded operators
-obey the rules for syntax and evaluation order specified in Clause~\ref{expr},
+obey the rules for syntax and evaluation order specified in \ref{expr},
 but the requirements of operand type and value category are replaced
 by the rules for function call. Relations between operators, such as
 \tcode{++a} meaning \tcode{a+=1}, are not guaranteed for overloaded
-operators~(\ref{over.oper}).
+operators\iref{over.oper}.
 \end{note}
 
 \pnum
-Clause~\ref{expr} defines the effects of operators when applied to types
+\ref{expr} defines the effects of operators when applied to types
 for which they have not been overloaded. Operator overloading shall not
 modify the rules for the \defnx{built-in operators}{operators!built-in},
 that is, for operators applied to types for which they are defined by this
@@ -48,7 +48,7 @@ resolution, and as part of that process user-defined conversions will be
 considered where necessary to convert the operands to types appropriate
 for the built-in operator. If a built-in operator is selected, such
 conversions will be applied to the operands before the operation is
-considered further according to the rules in Clause~\ref{expr};
+considered further according to the rules in \ref{expr};
 see~\ref{over.match.oper}, \ref{over.built}.
 
 \pnum
@@ -129,20 +129,20 @@ appear~(\ref{expr.prim.req},
 \ref{expr.sizeof},
 \ref{expr.unary.noexcept},
 \ref{dcl.type.simple},
-Clause \ref{temp}).
+\ref{temp}).
 An unevaluated operand is not evaluated.
 \begin{note}
 In an unevaluated operand, a non-static class member may be
-named~(\ref{expr.prim}) and naming of objects or functions does not, by
-itself, require that a definition be provided~(\ref{basic.def.odr}).
-An unevaluated operand is considered a full-expression~(\ref{intro.execution}).
+named\iref{expr.prim} and naming of objects or functions does not, by
+itself, require that a definition be provided\iref{basic.def.odr}.
+An unevaluated operand is considered a full-expression\iref{intro.execution}.
 \end{note}
 
 \pnum
 Whenever a glvalue expression appears as an operand of an operator that
 expects a prvalue for that operand, the
-lvalue-to-rvalue~(\ref{conv.lval}), array-to-pointer~(\ref{conv.array}),
-or function-to-pointer~(\ref{conv.func}) standard conversions are
+lvalue-to-rvalue\iref{conv.lval}, array-to-pointer\iref{conv.array},
+or function-to-pointer\iref{conv.func} standard conversions are
 applied to convert the expression to a prvalue.
 \begin{note}
 Because cv-qualifiers are removed from the type of an expression of
@@ -154,7 +154,7 @@ a prvalue expression of type \tcode{int} is required.
 \pnum
 Whenever a prvalue expression appears as an operand of an operator that
 expects a glvalue for that operand, the
-temporary materialization conversion~(\ref{conv.rval}) is
+temporary materialization conversion\iref{conv.rval} is
 applied to convert the expression to an xvalue.
 
 \pnum
@@ -166,7 +166,7 @@ This pattern is called the \term{usual arithmetic conversions},
 which are defined as follows:
 
 \begin{itemize}
-\item If either operand is of scoped enumeration type~(\ref{dcl.enum}), no conversions
+\item If either operand is of scoped enumeration type\iref{dcl.enum}, no conversions
 are performed; if the other operand does not have the same type, the expression is
 ill-formed.
 
@@ -179,7 +179,7 @@ converted to \tcode{double}.
 \item Otherwise, if either operand is \tcode{float}, the other shall be
 converted to \tcode{float}.
 
-\item Otherwise, the integral promotions~(\ref{conv.prom}) shall be
+\item Otherwise, the integral promotions\iref{conv.prom} shall be
 performed on both operands.\footnote{As a consequence, operands of type \tcode{bool}, \tcode{char16_t},
 \tcode{char32_t}, \tcode{wchar_t}, or an enumerated type are converted
 to some integral type.}
@@ -214,9 +214,9 @@ integer type.
 \pnum
 In some contexts, an expression only appears for its side effects. Such an
 expression is called a \defn{discarded-value expression}.
-The array-to-pointer~(\ref{conv.array})
-and function-to-pointer~(\ref{conv.func}) standard conversions are not
-applied. The lvalue-to-rvalue conversion~(\ref{conv.lval}) is applied
+The array-to-pointer\iref{conv.array}
+and function-to-pointer\iref{conv.func} standard conversions are not
+applied. The lvalue-to-rvalue conversion\iref{conv.lval} is applied
 if and only if
 the expression is a glvalue of volatile-qualified type and it is one of the
 following:
@@ -224,14 +224,14 @@ following:
 \begin{itemize}
 \item \tcode{(} \grammarterm{expression} \tcode{)}, where
   \grammarterm{expression} is one of these expressions,
-\item \grammarterm{id-expression}~(\ref{expr.prim.id}),
-\item subscripting~(\ref{expr.sub}),
-\item class member access~(\ref{expr.ref}),
-\item indirection~(\ref{expr.unary.op}),
-\item pointer-to-member operation~(\ref{expr.mptr.oper}),
-\item conditional expression~(\ref{expr.cond}) where both the second and the
+\item \grammarterm{id-expression}\iref{expr.prim.id},
+\item subscripting\iref{expr.sub},
+\item class member access\iref{expr.ref},
+\item indirection\iref{expr.unary.op},
+\item pointer-to-member operation\iref{expr.mptr.oper},
+\item conditional expression\iref{expr.cond} where both the second and the
       third operands are one of these expressions, or
-\item comma expression~(\ref{expr.comma}) where the right operand is one of
+\item comma expression\iref{expr.comma} where the right operand is one of
       these expressions.
 \end{itemize}
 
@@ -239,7 +239,7 @@ following:
 above covers only operators with built-in meaning.
 \end{note}
 If the expression is a prvalue after this optional conversion,
-the temporary materialization conversion~(\ref{conv.rval}) is applied.
+the temporary materialization conversion\iref{conv.rval} is applied.
 \begin{note}
 If the expression is an lvalue of
 class type, it must have a volatile copy constructor to initialize the
@@ -258,7 +258,7 @@ and~\ref{expr.ass}.}
 \pnum
 The \defnx{cv-combined type}{type!cv-combined} of two types \tcode{T1} and \tcode{T2}
 is a type \tcode{T3}
-similar to \tcode{T1} whose cv-qualification signature~(\ref{conv.qual}) is:
+similar to \tcode{T1} whose cv-qualification signature\iref{conv.qual} is:
 \begin{itemize}
 \item
 for every $i > 0$, $cv^3_i$ is the union of
@@ -306,7 +306,7 @@ other type is ``pointer to function'', where the function types are otherwise th
 \item
 if \tcode{T1} is ``pointer to \cvqual{cv1} \tcode{C1}'' and \tcode{T2} is ``pointer to
 \cvqual{cv2} \tcode{C2}'', where \tcode{C1} is reference-related to \tcode{C2} or \tcode{C2} is
-reference-related to \tcode{C1}~(\ref{dcl.init.ref}), the cv-combined type
+reference-related to \tcode{C1}\iref{dcl.init.ref}, the cv-combined type
 of \tcode{T1} and \tcode{T2} or the cv-combined type of \tcode{T2} and \tcode{T1},
 respectively;
 
@@ -314,11 +314,11 @@ respectively;
 if \tcode{T1} is ``pointer to member of \tcode{C1} of type \cvqual{cv1} \tcode{U1}'' and \tcode{T2} is
 ``pointer to member of \tcode{C2} of type \cvqual{cv2} \tcode{U2}'' where \tcode{C1} is
 reference-related to \tcode{C2} or \tcode{C2} is reference-related to
-\tcode{C1}~(\ref{dcl.init.ref}), the cv-combined type of \tcode{T2} and \tcode{T1} or the cv-combined type
+\tcode{C1}\iref{dcl.init.ref}, the cv-combined type of \tcode{T2} and \tcode{T1} or the cv-combined type
 of \tcode{T1} and \tcode{T2}, respectively;
 
 \item
-if \tcode{T1} and \tcode{T2} are similar types~(\ref{conv.qual}), the cv-combined type of \tcode{T1} and
+if \tcode{T1} and \tcode{T2} are similar types\iref{conv.qual}, the cv-combined type of \tcode{T1} and
 \tcode{T2};
 
 \item
@@ -361,7 +361,7 @@ A
 \indextext{constant}%
 \grammarterm{literal}
 is a primary expression.
-Its type depends on its form~(\ref{lex.literal}).
+Its type depends on its form\iref{lex.literal}.
 A string literal is an lvalue; all other literals are prvalues.
 
 \rSec2[expr.prim.this]{This}
@@ -369,8 +369,8 @@ A string literal is an lvalue; all other literals are prvalues.
 \pnum
 \indextext{\idxcode{this}}%
 The keyword \tcode{this} names a pointer to the object for which a non-static member
-function~(\ref{class.this}) is invoked or a non-static data member's
-initializer~(\ref{class.mem}) is evaluated.
+function\iref{class.this} is invoked or a non-static data member's
+initializer\iref{class.mem} is evaluated.
 
 \pnum
 If a declaration declares a member function or member function template of a
@@ -386,7 +386,7 @@ occur until the complete declarator is known. \end{note}
 \begin{note}
 In a \grammarterm{trailing-return-type},
 the class being defined is not required to be complete
-for purposes of class member access~(\ref{expr.ref}).
+for purposes of class member access\iref{expr.ref}.
 Class members declared later are not visible.
 \begin{example}
 \begin{codeblock}
@@ -402,9 +402,9 @@ template auto A::f(int t) -> decltype(t + g());
 
 \pnum
 Otherwise, if a \grammarterm{member-declarator} declares a non-static data
-member~(\ref{class.mem}) of a class \tcode{X}, the expression \tcode{this} is
+member\iref{class.mem} of a class \tcode{X}, the expression \tcode{this} is
 a prvalue of type ``pointer to \tcode{X}'' within the
-optional default member initializer~(\ref{class.mem}). It shall not appear elsewhere
+optional default member initializer\iref{class.mem}. It shall not appear elsewhere
 in the \grammarterm{member-declarator}.
 
 \pnum
@@ -451,7 +451,7 @@ An \grammarterm{id-expression} is a restricted form of a
 \grammarterm{primary-expression}.
 \begin{note}
 An \grammarterm{id-expression} can appear after \tcode{.} and \tcode{->}
-operators~(\ref{expr.ref}).
+operators\iref{expr.ref}.
 \end{note}
 
 \pnum
@@ -459,13 +459,13 @@ An \grammarterm{id-expression} that denotes a non-static data member or
 non-static member function of a class can only be used:
 
 \begin{itemize}
-\item as part of a class member access~(\ref{expr.ref}) in which the
+\item as part of a class member access\iref{expr.ref} in which the
 object expression
 refers to the member's class\footnote{This also applies when the object expression
 is an implicit \tcode{(*this)}~(\ref{class.mfct.non-static}).} or a class derived from
 that class, or
 
-\item to form a pointer to member~(\ref{expr.unary.op}), or
+\item to form a pointer to member\iref{expr.unary.op}, or
 
 \item if that \grammarterm{id-expression} denotes a non-static data member
 and it appears in an unevaluated operand.
@@ -483,12 +483,12 @@ int j = sizeof(S::m + 42);      // OK
 
 \pnum
 An \grammarterm{id-expression}
-that denotes the specialization of a concept~(\ref{temp.concept})
+that denotes the specialization of a concept\iref{temp.concept}
 results in a prvalue of type \tcode{bool}.
 The expression is \tcode{true} if
 the concept's normalized
-\grammarterm{constraint-expression}~(\ref{temp.constr.decl})
-is satisfied~(\ref{temp.constr.constr})
+\grammarterm{constraint-expression}\iref{temp.constr.decl}
+is satisfied\iref{temp.constr.constr}
 by the specified template arguments
 and \tcode{false} otherwise.
 \begin{example}
@@ -499,10 +499,10 @@ static_assert(C<int>);  // OK
 \end{example}
 \begin{note}
 A concept's constraints are also considered
-when using a template name~(\ref{temp.names})
-and during overload resolution (Clause~\ref{over}),
+when using a template name\iref{temp.names}
+and during overload resolution\iref{over},
 and they are compared
-during the the partial ordering of constraints~(\ref{temp.constr.order}).
+during the the partial ordering of constraints\iref{temp.constr.order}.
 \end{note}
 
 \pnum
@@ -526,7 +526,7 @@ In each case, the constraints of \tcode{f} are not satisfied.
 In the declaration of \tcode{p2},
 those constraints are required to be satisfied
 even though
-\tcode{f} is an unevaluated operand (Clause~\ref{expr}).
+\tcode{f} is an unevaluated operand\iref{expr}.
 \end{example}
 
 \rSec3[expr.prim.id.unqual]{Unqualified names}
@@ -545,7 +545,7 @@ even though
 \pnum
 \indextext{identifier}%
 An \grammarterm{identifier} is an \grammarterm{id-expression} provided it has
-been suitably declared (Clause~\ref{dcl.dcl}).
+been suitably declared\iref{dcl.dcl}.
 \begin{note}
 For \grammarterm{operator-function-id}{s}, see~\ref{over.oper}; for
 \grammarterm{conversion-function-id}{s}, see~\ref{class.conv.fct}; for
@@ -560,7 +560,7 @@ class member access expression~(\ref{class.mfct.non-static}).
 The type of the expression is the type of the \grammarterm{identifier}. The
 result is the entity denoted by the identifier. The expression is an lvalue
 if the entity is a function, variable, or data member and a prvalue otherwise;
-it is a bit-field if the identifier designates a bit-field~(\ref{dcl.struct.bind}).
+it is a bit-field if the identifier designates a bit-field\iref{dcl.struct.bind}.
 
 \rSec3[expr.prim.id.qual]{Qualified names}
 
@@ -592,9 +592,9 @@ type.
 
 \pnum
 A \grammarterm{nested-name-specifier} that denotes a class, optionally
-followed by the keyword \tcode{template}~(\ref{temp.names}), and then
-followed by the name of a member of either that class~(\ref{class.mem})
-or one of its base classes (Clause~\ref{class.derived}), is a
+followed by the keyword \tcode{template}\iref{temp.names}, and then
+followed by the name of a member of either that class\iref{class.mem}
+or one of its base classes\iref{class.derived}, is a
 \indextext{id!qualified}%
 \grammarterm{qualified-id};~\ref{class.qual} describes name lookup for
 class members that appear in \grammarterm{qualified-id}{s}. The result is the
@@ -603,24 +603,24 @@ an lvalue if the member is a static member function or a data member and a
 prvalue otherwise.
 \begin{note}
 A class member can be referred to using a \grammarterm{qualified-id} at any
-point in its potential scope~(\ref{basic.scope.class}).
+point in its potential scope\iref{basic.scope.class}.
 \end{note}
 Where
 \grammarterm{class-name} \tcode{::\tilde}~\grammarterm{class-name} is used,
 the two \grammarterm{class-name}{s} shall refer to the same class; this
-notation names the destructor~(\ref{class.dtor}).
+notation names the destructor\iref{class.dtor}.
 The form \tcode{\tilde}~\grammarterm{decltype-specifier} also denotes the destructor,
 but it shall not be used as the \grammarterm{unqualified-id} in a \grammarterm{qualified-id}.
 \begin{note}
 A \grammarterm{typedef-name} that names a class is a
-\grammarterm{class-name}~(\ref{class.name}).
+\grammarterm{class-name}\iref{class.name}.
 \end{note}
 
 \pnum
 The \grammarterm{nested-name-specifier} \tcode{::} names the global namespace.
 A \grammarterm{nested-name-specifier} that names a
-namespace~(\ref{basic.namespace}), optionally followed by the keyword
-\tcode{template}~(\ref{temp.names}), and then followed by the name of a member
+namespace\iref{basic.namespace}, optionally followed by the keyword
+\tcode{template}\iref{temp.names}, and then followed by the name of a member
 of that namespace (or the name of a member of a namespace made visible by a
 \grammarterm{using-directive}), is a
 \indextext{id!qualified}%
@@ -631,7 +631,7 @@ is an lvalue if the member is a function or a variable and a prvalue otherwise.
 
 \pnum
 A \grammarterm{nested-name-specifier} that denotes an
-enumeration~(\ref{dcl.enum}), followed by the name of an
+enumeration\iref{dcl.enum}, followed by the name of an
 enumerator of that enumeration, is a \grammarterm{qualified-id}
 that refers to the enumerator. The result is the enumerator. The type
 of the result is the type of the enumeration. The result is a prvalue.
@@ -681,7 +681,7 @@ void abssort(float* x, unsigned N) {
 A \grammarterm{lambda-expression} is a prvalue
 whose result object is called the \defn{closure object}. A
 \grammarterm{lambda-expression} shall not appear in an unevaluated operand
-(Clause~\ref{expr}), in a \grammarterm{template-argument},
+(\ref{expr}), in a \grammarterm{template-argument},
 in an \grammarterm{alias-declaration},
 in a typedef declaration, or in the declaration of a function or function
 template outside its function body and default arguments.
@@ -690,7 +690,7 @@ The intention is to prevent lambdas from appearing in a signature.
 \end{note}
 \begin{note}
 A closure object behaves like a function
-object~(\ref{function.objects}).\end{note}
+object\iref{function.objects}.\end{note}
 
 \pnum
 In the \grammarterm{decl-specifier-seq} of the \grammarterm{lambda-declarator},
@@ -739,9 +739,9 @@ whose properties are described below.
 The closure type is declared in the smallest block
 scope, class scope, or namespace scope that contains the corresponding
 \grammarterm{lambda-expression}. \begin{note} This determines the set of namespaces and
-classes associated with the closure type~(\ref{basic.lookup.argdep}). The parameter
+classes associated with the closure type\iref{basic.lookup.argdep}. The parameter
 types of a \grammarterm{lambda-declarator} do not affect these associated namespaces and
-classes. \end{note} The closure type is not an aggregate type~(\ref{dcl.init.aggr}).
+classes. \end{note} The closure type is not an aggregate type\iref{dcl.init.aggr}.
 An implementation may define the closure type differently from what
 is described below provided this does not alter the observable behavior of the program
 other than by changing:
@@ -749,12 +749,12 @@ other than by changing:
 \begin{itemize}
 \item the size and/or alignment of the closure type,
 
-\item whether the closure type is trivially copyable (Clause~\ref{class}),
+\item whether the closure type is trivially copyable\iref{class},
 
-\item whether the closure type is a standard-layout class (Clause~\ref{class}),
+\item whether the closure type is a standard-layout class\iref{class},
 or
 
-\item whether the closure type is a POD class (Clause~\ref{class}).
+\item whether the closure type is a POD class\iref{class}.
 \end{itemize}
 
 An implementation shall not add members of rvalue reference type to the closure
@@ -762,12 +762,12 @@ type.
 
 \pnum
 The closure type for a non-generic \grammarterm{lambda-expression} has a public
-inline function call operator~(\ref{over.call}) whose parameters and return type
+inline function call operator\iref{over.call} whose parameters and return type
 are described by the \grammarterm{lambda-expression}'s
 \grammarterm{parameter-declaration-clause} and \grammarterm{trailing-return-type}
 respectively.
 For a generic lambda, the closure type has a public inline function call
-operator member template~(\ref{temp.mem}) whose
+operator member template\iref{temp.mem} whose
 \grammarterm{template-parameter-list} consists of
 the specified \grammarterm{template-parameter-list}, if any,
 to which is appended one invented type
@@ -775,7 +775,7 @@ to which is appended one invented type
 lambda's \grammarterm{parameter-declaration-clause}, in order of appearance.
 The invented type \grammarterm{template-parameter} is a parameter pack if
 the corresponding \grammarterm{parameter-declaration} declares a function
-parameter pack~(\ref{dcl.fct}). The return type and function parameters of the
+parameter pack\iref{dcl.fct}. The return type and function parameters of the
 function call operator template are derived from the
 \grammarterm{lambda-expression}{'s} \grammarterm{trailing-return-type} and
 \grammarterm{parameter-declaration-clause} by replacing each occurrence of
@@ -816,7 +816,7 @@ The function call operator or any given operator template specialization
 is a constexpr function if either
 the corresponding \grammarterm{lambda-expression}{'s}
 \grammarterm{parameter-declaration-clause} is followed by \tcode{constexpr}, or
-it satisfies the requirements for a constexpr function~(\ref{dcl.constexpr}).
+it satisfies the requirements for a constexpr function\iref{dcl.constexpr}.
 \begin{note} Names referenced in
 the \grammarterm{lambda-declarator} are looked up in the context in which the
 \grammarterm{lambda-expression} appears. \end{note}
@@ -865,7 +865,7 @@ static_assert(add(one)(one)() == monoid(2)()); // OK
 The closure type for a non-generic \grammarterm{lambda-expression} with no
 \grammarterm{lambda-capture}
 has a conversion function to pointer to
-function with \Cpp language linkage~(\ref{dcl.link}) having
+function with \Cpp language linkage\iref{dcl.link} having
 the same parameter and return types as the closure type's function call operator.
 The conversion is to ``pointer to \tcode{noexcept} function''
 if the function call operator
@@ -958,7 +958,7 @@ GL_int(3);                // OK: same as \tcode{GL(3)}
 \pnum
 The conversion function or conversion function template is public,
 constexpr, non-virtual, non-explicit, const, and has a non-throwing exception
-specification~(\ref{except.spec}).
+specification\iref{except.spec}.
 \begin{example}
 \begin{codeblock}
 auto Fwd = [](int (*fp)(int), auto a) { return fp(a); };
@@ -974,9 +974,9 @@ static_assert(Fwd(NC,3) == 3); // ill-formed
 
 \pnum
 The \grammarterm{lambda-expression}'s \grammarterm{compound-statement} yields the
-\grammarterm{function-body}~(\ref{dcl.fct.def}) of the function call operator, but for
-purposes of name lookup~(\ref{basic.lookup}), determining the type and value of
-\tcode{this}~(\ref{class.this}) and transforming \grammarterm{id-expression}{s}
+\grammarterm{function-body}\iref{dcl.fct.def} of the function call operator, but for
+purposes of name lookup\iref{basic.lookup}, determining the type and value of
+\tcode{this}\iref{class.this} and transforming \grammarterm{id-expression}{s}
 referring to non-static class members into class member access expressions using
 \tcode{(*this)}~(\ref{class.mfct.non-static}), the \grammarterm{compound-statement} is
 considered in the context of the \grammarterm{lambda-expression}. \begin{example}
@@ -1001,19 +1001,19 @@ with semantics as described in~\ref{dcl.fct.def.general}.
 \pnum
 The closure type associated with a \grammarterm{lambda-expression} has no
 default constructor and a deleted copy assignment operator. It has a
-defaulted copy constructor and a defaulted move constructor~(\ref{class.copy}).
+defaulted copy constructor and a defaulted move constructor\iref{class.copy}.
 \begin{note} These special member functions are implicitly defined as
 usual, and might therefore be defined as deleted. \end{note}
 
 \pnum
 The closure type associated with a \grammarterm{lambda-expression} has an
-implicitly-declared destructor~(\ref{class.dtor}).
+implicitly-declared destructor\iref{class.dtor}.
 
 \pnum
 A member of a closure type shall not be
-explicitly instantiated~(\ref{temp.explicit}),
-explicitly specialized~(\ref{temp.expl.spec}), or
-named in a \tcode{friend} declaration~(\ref{class.friend}).
+explicitly instantiated\iref{temp.explicit},
+explicitly specialized\iref{temp.expl.spec}, or
+named in a \tcode{friend} declaration\iref{class.friend}.
 
 \rSec3[expr.prim.lambda.capture]{Captures}%
 
@@ -1096,7 +1096,7 @@ void S2::f(int i) {
 
 \pnum
 A \grammarterm{lambda-expression} whose smallest enclosing scope is a block
-scope~(\ref{basic.scope.block}) is a \defn{local lambda expression}; any other
+scope\iref{basic.scope.block} is a \defn{local lambda expression}; any other
 \grammarterm{lambda-expression} shall not have a \grammarterm{capture-default} or
 \grammarterm{simple-capture} in its
 \grammarterm{lambda-introducer}. The \defn{reaching scope} of a local lambda expression
@@ -1106,7 +1106,7 @@ its parameters. \begin{note} This reaching scope includes any intervening
 
 \pnum
 The \grammarterm{identifier} in a \grammarterm{simple-capture} is looked up using the
-usual rules for unqualified name lookup~(\ref{basic.lookup.unqual}); each such lookup
+usual rules for unqualified name lookup\iref{basic.lookup.unqual}; each such lookup
 shall find an entity.  An entity that is designated by a
 \grammarterm{simple-capture}
 is said to be \defn{explicitly captured}, and shall be \tcode{*this}
@@ -1170,11 +1170,11 @@ non-static data member), is said to \defnx{implicitly capture}{capture!implicit}
 the entity (i.e.,
 \tcode{*this} or a variable) if the \grammarterm{compound-statement}:
 \begin{itemize}
-\item odr-uses~(\ref{basic.def.odr}) the entity (in the case of a variable),
-\item odr-uses~(\ref{basic.def.odr}) \tcode{this}
+\item odr-uses\iref{basic.def.odr} the entity (in the case of a variable),
+\item odr-uses\iref{basic.def.odr} \tcode{this}
 (in the case of the object designated by \tcode{*this}), or
 \item names the entity in a potentially-evaluated
-expression~(\ref{basic.def.odr}) where the enclosing full-expression depends on
+expression\iref{basic.def.odr} where the enclosing full-expression depends on
 a generic lambda parameter declared within the reaching scope of the
 \grammarterm{lambda-expression}.
 \end{itemize}
@@ -1204,11 +1204,11 @@ in implicit capture. \end{note}
 
 \pnum
 An entity is \defn{captured} if it is captured explicitly or implicitly. An entity
-captured by a \grammarterm{lambda-expression} is odr-used~(\ref{basic.def.odr}) in the scope
+captured by a \grammarterm{lambda-expression} is odr-used\iref{basic.def.odr} in the scope
 containing the \grammarterm{lambda-expression}. If \tcode{*this} is captured by a local
 lambda expression, its nearest enclosing function shall be a non-static member function.
 If a \grammarterm{lambda-expression} or an instantiation of the function call
-operator template of a generic lambda odr-uses~(\ref{basic.def.odr}) \tcode{this} or a
+operator template of a generic lambda odr-uses\iref{basic.def.odr} \tcode{this} or a
 variable with automatic storage duration from its reaching scope, that
 entity shall be captured by the \grammarterm{lambda-expression}. If a
 \grammarterm{lambda-expression} captures an entity and that entity is not defined or
@@ -1299,7 +1299,7 @@ A member of an anonymous union shall not be captured by copy.
 
 \pnum
 Every \grammarterm{id-expression} within the \grammarterm{compound-statement} of a
-\grammarterm{lambda-expression} that is an odr-use~(\ref{basic.def.odr}) of an
+\grammarterm{lambda-expression} that is an odr-use\iref{basic.def.odr} of an
 entity captured by copy is transformed into an access to the corresponding unnamed data
 member of the closure type.
 \begin{note} An \grammarterm{id-expression} that is not an odr-use refers to
@@ -1308,7 +1308,7 @@ an \grammarterm{id-expression} does not cause the implicit capture of the
 entity. \end{note}
 If \tcode{*this} is captured by copy, each odr-use of \tcode{this} is
 transformed into a pointer to the corresponding unnamed data member of the closure type,
-cast~(\ref{expr.cast}) to the type of \tcode{this}. \begin{note} The cast ensures that the
+cast\iref{expr.cast} to the type of \tcode{this}. \begin{note} The cast ensures that the
 transformed expression is a prvalue. \end{note}
 An \grammarterm{id-expression} within
 the \grammarterm{compound-statement} of a \grammarterm{lambda-expression}
@@ -1424,7 +1424,7 @@ after the lifetime of the entity has ended is likely to result in undefined beha
 
 \pnum
 A \grammarterm{simple-capture} followed by an ellipsis is a pack
-expansion~(\ref{temp.variadic}). An \grammarterm{init-capture} followed by an
+expansion\iref{temp.variadic}. An \grammarterm{init-capture} followed by an
 ellipsis is ill-formed.
 \begin{example}
 \begin{codeblock}
@@ -1442,7 +1442,7 @@ void f(Args... args) {
 
 \pnum
 A fold expression performs a fold of a template parameter
-pack~(\ref{temp.variadic}) over a binary operator.
+pack\iref{temp.variadic} over a binary operator.
 
 \begin{bnf}
 \nontermdef{fold-expression}\br
@@ -1474,7 +1474,7 @@ Unary left folds and unary right folds
 are collectively called \defnx{unary folds}{unary fold}.
 In a unary fold,
 the \grammarterm{cast-expression}
-shall contain an unexpanded parameter pack~(\ref{temp.variadic}).
+shall contain an unexpanded parameter pack\iref{temp.variadic}.
 
 \pnum
 \indextext{fold!binary}%
@@ -1515,7 +1515,7 @@ bool f(Args ...args) {
 \pnum
 A \grammarterm{requires-expression} provides a concise way to express
 requirements on template arguments
-that can be checked by name lookup~(\ref{basic.lookup})
+that can be checked by name lookup\iref{basic.lookup}
 or by checking properties of types and expressions.
 
 \begin{bnf}
@@ -1551,7 +1551,7 @@ or by checking properties of types and expressions.
 A \grammarterm{requires-expression} is a prvalue of type \tcode{bool}
 whose value is described below.
 Expressions appearing within a \grammarterm{requirement-body}
-are unevaluated operands (Clause~\ref{expr}).
+are unevaluated operands\iref{expr}.
 
 \pnum
 \begin{example}
@@ -1565,7 +1565,7 @@ template<typename T>
   };
 \end{codeblock}
 A \grammarterm{requires-expression} can also be used in a
-\grammarterm{requires-clause} (Clause~\ref{temp}) as a way of writing ad hoc
+\grammarterm{requires-clause}\iref{temp} as a way of writing ad hoc
 constraints on template arguments such as the one below:
 \begin{codeblock}
 template<typename T>
@@ -1579,7 +1579,7 @@ introduces the \grammarterm{requires-expression}.
 
 \pnum
 A \grammarterm{requires-expression} may introduce local parameters using a
-\grammarterm{parameter-declaration-clause}~(\ref{dcl.fct}).
+\grammarterm{parameter-declaration-clause}\iref{dcl.fct}.
 A local parameter of a \grammarterm{requires-expression} shall not have a
 default argument.
 Each name introduced by a local parameter is in scope from the point
@@ -1649,7 +1649,7 @@ the validity of an \grammarterm{expression}.
 \begin{note}
 The enclosing \grammarterm{requires-expression} will evaluate to \tcode{false}
 if substitution of template arguments into the \grammarterm{expression} fails.
-The \grammarterm{expression} is an unevaluated operand (Clause \ref{expr}).
+The \grammarterm{expression} is an unevaluated operand\iref{expr}.
 \end{note}
 \begin{example}
 \begin{codeblock}
@@ -1689,7 +1689,7 @@ template<typename T> concept C = requires {
 
 \pnum
 A \grammarterm{type-requirement} that names a class template specialization
-does not require that type to be complete~(\ref{basic.types}).
+does not require that type to be complete\iref{basic.types}.
 
 \rSec3[expr.prim.req.compound]{Compound requirements}
 \indextext{requirement!compound}%
@@ -1716,7 +1716,7 @@ semantic properties proceed in the following order:
 into the \grammarterm{expression} is performed.
 
 \item If the \tcode{noexcept} specifier is present,
-\tcode{E} shall not be a potentially-throwing expression~(\ref{except.spec}).
+\tcode{E} shall not be a potentially-throwing expression\iref{except.spec}.
 
 \item If the \grammarterm{return-type-requirement} is present, then:
 
@@ -1733,7 +1733,7 @@ If conversion fails, the enclosing \grammarterm{requires-expression}
 is \tcode{false}.
 
 \item If the \grammarterm{return-type-requirement}
-starts with a \grammarterm{constrained-parameter}~(\ref{temp.param}),
+starts with a \grammarterm{constrained-parameter}\iref{temp.param},
 the \grammarterm{expression} is deduced against
 an invented function template \tcode{F}
 using the rules in \ref{temp.deduct.call}.
@@ -1819,7 +1819,7 @@ that \tcode{g(x)} is non-throwing.
 A \grammarterm{nested-requirement} can be used
 to specify additional constraints in terms of local parameters.
 The \grammarterm{constraint-expression}
-shall be satisfied~(\ref{temp.constr.decl})
+shall be satisfied\iref{temp.constr.decl}
 by the substituted template arguments, if any.
 Substitution of template arguments into a \grammarterm{nested-requirement}
 does not result in substitution into the \grammarterm{constraint-expression}
@@ -1832,12 +1832,12 @@ template<typename T> concept D = requires (T t) {
   requires C<decltype (+t)>;
 };
 \end{codeblock}
-\tcode{D<T>} is satisfied if \tcode{sizeof(decltype (+t)) == 1}~(\ref{temp.constr.atomic}).
+\tcode{D<T>} is satisfied if \tcode{sizeof(decltype (+t)) == 1}\iref{temp.constr.atomic}.
 \end{example}
 
 \pnum
 A local parameter shall only appear as an unevaluated operand
-(Clause~\ref{expr}) within the \grammarterm{constraint-expression}.
+(\ref{expr}) within the \grammarterm{constraint-expression}.
 \begin{example}
 \begin{codeblock}
 template<typename T> concept C = requires (T a) {
@@ -1899,7 +1899,7 @@ Postfix expressions group left-to-right.
 \tcode{static_cast}, \tcode{reinterpret_cast}, or
 \tcode{const_cast} may be the product of replacing a
 \tcode{>{>}} token by two consecutive \tcode{>}
-tokens~(\ref{temp.names}).\end{note}
+tokens\iref{temp.names}.\end{note}
 
 \rSec2[expr.sub]{Subscripting}
 
@@ -1941,17 +1941,17 @@ have function type or function pointer type.
 For a call to a non-member function or to a static member function,
 the postfix expression shall be either an lvalue that refers to a
 function (in which case the function-to-pointer standard
-conversion~(\ref{conv.func}) is suppressed on the postfix expression),
+conversion\iref{conv.func} is suppressed on the postfix expression),
 or it shall have function pointer type. Calling a function through an
 expression whose function type is different
 from the function type of the called function's
-definition results in undefined behavior~(\ref{dcl.link}). For a call to a non-static
+definition results in undefined behavior\iref{dcl.link}. For a call to a non-static
 member function,
 the postfix expression shall be an
 implicit~(\ref{class.mfct.non-static}, \ref{class.static}) or explicit
-class member access~(\ref{expr.ref}) whose \grammarterm{id-expression} is a
+class member access\iref{expr.ref} whose \grammarterm{id-expression} is a
 function member name, or a pointer-to-member
-expression~(\ref{expr.mptr.oper}) selecting a function member; the call is as a member of
+expression\iref{expr.mptr.oper} selecting a function member; the call is as a member of
 the class object referred to by the
 object expression. In the case of an implicit class
 member access, the implied object is the one pointed to by \tcode{this}.
@@ -1960,11 +1960,11 @@ A member function call of the form \tcode{f()} is interpreted as
 \tcode{(*this).f()} (see~\ref{class.mfct.non-static}).
 \end{note}
 If a function or member function name is used, the name can be
-overloaded (Clause~\ref{over}), in which case the appropriate function
+overloaded\iref{over}, in which case the appropriate function
 shall be selected according to the rules in~\ref{over.match}. If the selected
 function is non-virtual, or if the \grammarterm{id-expression} in the class
 member access expression is a \grammarterm{qualified-id}, that function is
-called. Otherwise, its final overrider~(\ref{class.virtual}) in the dynamic type
+called. Otherwise, its final overrider\iref{class.virtual} in the dynamic type
 of the object expression is called; such a call is referred to as a
 \defnx{virtual function call}{function!virtual function call}.
 \begin{note}
@@ -1978,13 +1978,13 @@ an object under construction or destruction.
 \pnum
 \begin{note}
 If a function or member function name is used, and name
-lookup~(\ref{basic.lookup}) does not find a declaration of that name,
+lookup\iref{basic.lookup} does not find a declaration of that name,
 the program is ill-formed. No function is implicitly declared by such a
 call.
 \end{note}
 
 \pnum
-If the \grammarterm{postfix-expression} designates a destructor~(\ref{class.dtor}),
+If the \grammarterm{postfix-expression} designates a destructor\iref{class.dtor},
 the type of the function call expression is \tcode{void}; otherwise, the
 type of the function call expression is the return type of the
 statically chosen function (i.e., ignoring the \tcode{virtual} keyword),
@@ -1996,13 +1996,13 @@ This return type shall be an object type, a reference type or \cv{}~\tcode{void}
 \indextext{function argument|see{argument}}%
 \indextext{function parameter|see{parameter}}%
 \indextext{initialization!parameter}%
-When a function is called, each parameter~(\ref{dcl.fct}) shall be
+When a function is called, each parameter\iref{dcl.fct} shall be
 initialized~(\ref{dcl.init}, \ref{class.copy}, \ref{class.ctor}) with
 its corresponding argument.
 If the function is a non-static member
-function, the \tcode{this} parameter of the function~(\ref{class.this})
+function, the \tcode{this} parameter of the function\iref{class.this}
 shall be initialized with a pointer to the object of the call, converted
-as if by an explicit type conversion~(\ref{expr.cast}).
+as if by an explicit type conversion\iref{expr.cast}.
 \begin{note}
 There is no access or ambiguity checking on this conversion; the access
 checking and disambiguation are done as part of the (possibly implicit)
@@ -2029,7 +2029,7 @@ checked at the point of call in the calling function. If a constructor
 or destructor for a function parameter throws an exception, the search
 for a handler starts in the scope of the calling function; in
 particular, if the function called has a \grammarterm{function-try-block}
-(Clause~\ref{except}) with a handler that could handle the exception,
+(\ref{except}) with a handler that could handle the exception,
 this handler is not considered.
 \end{example}
 
@@ -2081,7 +2081,7 @@ but it is unspecified whether the value of \tcode{j} is 1 or 2.
 
 \pnum
 The result of a function call is the
-result of the operand of the evaluated \tcode{return} statement~(\ref{stmt.return})
+result of the operand of the evaluated \tcode{return} statement\iref{stmt.return}
 in the called function (if any),
 except in a virtual function call if the return type of the
 final overrider is different from the return type of the statically
@@ -2098,7 +2098,7 @@ converted to the return type of the statically chosen function.
 \indextext{argument!reference}%
 A function can change the values of its non-const parameters, but these
 changes cannot affect the values of the arguments except where a
-parameter is of a reference type~(\ref{dcl.ref}); if the reference is to
+parameter is of a reference type\iref{dcl.ref}; if the reference is to
 a const-qualified type, \tcode{const_cast} is required to be used to
 cast away the constness in order to modify the argument's value. Where a
 parameter is of \tcode{const} reference type a temporary object is
@@ -2112,9 +2112,9 @@ pointer parameters.
 \indextext{declaration!ellipsis in function}%
 \indextext{parameter list!variable}%
 A function can be declared to accept fewer arguments (by declaring default
-arguments~(\ref{dcl.fct.default})) or more arguments (by using the ellipsis,
-\tcode{...}, or a function parameter pack~(\ref{dcl.fct})) than the number of
-parameters in the function definition~(\ref{dcl.fct.def}).
+arguments\iref{dcl.fct.default}) or more arguments (by using the ellipsis,
+\tcode{...}, or a function parameter pack\iref{dcl.fct}) than the number of
+parameters in the function definition\iref{dcl.fct.def}.
 \begin{note}
 This implies that, except where the ellipsis (\tcode{...}) or a function
 parameter pack is used, a parameter is available for each argument.
@@ -2124,35 +2124,35 @@ parameter pack is used, a parameter is available for each argument.
 \indextext{ellipsis!conversion sequence}%
 When there is no parameter for a given argument, the argument is passed
 in such a way that the receiving function can obtain the value of the
-argument by invoking \tcode{va_arg}~(\ref{support.runtime}).
+argument by invoking \tcode{va_arg}\iref{support.runtime}.
 \begin{note} This paragraph does not apply to arguments passed to a function parameter pack.
-Function parameter packs are expanded during template instantiation~(\ref{temp.variadic}),
+Function parameter packs are expanded during template instantiation\iref{temp.variadic},
 thus each such argument has a corresponding parameter when a function template
 specialization is actually called. \end{note}
 The
-lvalue-to-rvalue~(\ref{conv.lval}), array-to-pointer~(\ref{conv.array}),
-and function-to-pointer~(\ref{conv.func}) standard conversions are
+lvalue-to-rvalue\iref{conv.lval}, array-to-pointer\iref{conv.array},
+and function-to-pointer\iref{conv.func} standard conversions are
 performed on the argument expression.
 An argument that has type \cv{}~\tcode{std::nullptr_t} is converted
-to type \tcode{void*}~(\ref{conv.ptr}).
+to type \tcode{void*}\iref{conv.ptr}.
 After these conversions, if the
 argument does not have arithmetic, enumeration, pointer, pointer to
 member, or class type, the program is ill-formed. Passing a potentially-evaluated
-argument of class type (Clause~\ref{class}) having a non-trivial
+argument of class type\iref{class} having a non-trivial
 copy constructor, a non-trivial move constructor,
 or a
 non-trivial destructor, with no corresponding parameter, is conditionally-supported with
 \impldef{passing argument of class type through ellipsis} semantics. If the argument has
 integral or enumeration type that is subject to the integral
-promotions~(\ref{conv.prom}), or a floating-point type that is subject to the
-floating-point promotion~(\ref{conv.fpprom}), the value of the argument is converted to the
+promotions\iref{conv.prom}, or a floating-point type that is subject to the
+floating-point promotion\iref{conv.fpprom}, the value of the argument is converted to the
 promoted type before the call. These promotions are referred to as
 the \defnx{default argument promotions}{promotion!default argument promotion}.
 
 \pnum
 \indextext{function call!recursive}%
 Recursive calls are permitted, except to the \tcode{main}
-function~(\ref{basic.start.main}).
+function\iref{basic.start.main}.
 
 \pnum
 A function call is an lvalue
@@ -2168,8 +2168,8 @@ otherwise.
 \indextext{type conversion, explicit|see{casting}}%
 \indextext{conversion explicit type|see{casting}}%
 \indextext{casting}%
-A \grammarterm{simple-type-specifier}~(\ref{dcl.type.simple}) or
-\grammarterm{typename-specifier}~(\ref{temp.res}) followed
+A \grammarterm{simple-type-specifier}\iref{dcl.type.simple} or
+\grammarterm{typename-specifier}\iref{temp.res} followed
 by a parenthesized optional \grammarterm{expression-list} or
 by a \grammarterm{braced-init-list}
 (the initializer)
@@ -2180,14 +2180,14 @@ If the type is a placeholder
 for a deduced class type,
 it is replaced by the return type
 of the function selected by overload resolution
-for class template deduction~(\ref{over.match.class.deduct})
+for class template deduction\iref{over.match.class.deduct}
 for the remainder of this section.
 
 \pnum
 If the initializer is a parenthesized single expression,
 the type conversion expression is equivalent (in
 definedness, and if defined in meaning) to the corresponding cast
-expression~(\ref{expr.cast}).
+expression\iref{expr.cast}.
 \indextext{type!incomplete}%
 If the type is \cv{}~\tcode{void}
 and the initializer is \tcode{()},
@@ -2195,7 +2195,7 @@ the expression is a prvalue of the specified type
 that performs no initialization.
 Otherwise,
 the expression is a prvalue of the specified type
-whose result object is direct-initialized~(\ref{dcl.init})
+whose result object is direct-initialized\iref{dcl.init}
 with the initializer.
 For an expression of the form \tcode{T()},
 \tcode{T} shall not be an array type.
@@ -2244,7 +2244,7 @@ shall designate the same scalar type (ignoring cv-qualification).
 \indextext{arrow operator|see{operator, class member access}}%
 A postfix expression followed by a dot \tcode{.} or an arrow \tcode{->},
 optionally followed by the keyword
-\tcode{template}~(\ref{temp.names}), and then followed by an
+\tcode{template}\iref{temp.names}, and then followed by an
 \grammarterm{id-expression}, is a postfix expression. The postfix
 expression before the dot or arrow is evaluated;\footnote{If the class member
 access expression is evaluated, the subexpression evaluation happens even if the
@@ -2265,7 +2265,7 @@ In both cases, the class type shall be complete
 unless the class member access appears in the definition of that class.
 \begin{note}
 If the class is incomplete, lookup in the complete class type
-is required to refer to the same declaration~(\ref{basic.scope.class}).
+is required to refer to the same declaration\iref{basic.scope.class}.
 \end{note}
 The expression \tcode{E1->E2} is
 converted to the equivalent form \tcode{(*(E1)).E2}; the remainder of
@@ -2276,7 +2276,7 @@ In either case, the
 its base classes.
 \begin{note}
 Because the name of a class is inserted in its class scope
-(Clause~\ref{class}), the name of a class is also considered a nested
+(\ref{class}), the name of a class is also considered a nested
 member of that class.
 \end{note}
 \begin{note}
@@ -2324,7 +2324,7 @@ is ``\cvqual{vq12} \tcode{T}''. If \tcode{E2} is not declared to be a
 ``\cvqual{cq12} \cvqual{vq12} \tcode{T}''.
 
 \item If \tcode{E2} is a (possibly overloaded) member function, function
-overload resolution~(\ref{over.match}) is used to determine whether
+overload resolution\iref{over.match} is used to determine whether
 \tcode{E1.E2} refers to a static or a non-static member function.
 
 \begin{itemize}
@@ -2340,9 +2340,9 @@ function and the type of \tcode{E2} is ``function of
 parameter-type-list \cvqual{cv} \grammarterm{ref-qualifier}\opt{} returning \tcode{T}'', then
 \tcode{E1.E2} is a prvalue. The expression designates a
 non-static member function. The expression can be used only as the
-left-hand operand of a member function call~(\ref{class.mfct}).
+left-hand operand of a member function call\iref{class.mfct}.
 \begin{note} Any redundant set of parentheses surrounding the expression
-is ignored~(\ref{expr.prim}). \end{note} The type of \tcode{E1.E2} is
+is ignored\iref{expr.prim}. \end{note} The type of \tcode{E1.E2} is
 ``function of parameter-type-list \cvqual{cv} returning \tcode{T}''.
 \end{itemize}
 
@@ -2357,8 +2357,8 @@ is \tcode{T}, the expression \tcode{E1.E2} is a prvalue. The type of
 \pnum
 If \tcode{E2} is a non-static data member or a non-static member
 function, the program is ill-formed if the class of which \tcode{E2} is
-directly a member is an ambiguous base~(\ref{class.member.lookup}) of
-the naming class~(\ref{class.access.base}) of \tcode{E2}.
+directly a member is an ambiguous base\iref{class.member.lookup} of
+the naming class\iref{class.access.base} of \tcode{E2}.
 \begin{note}
 The program is also ill-formed if the naming class is an ambiguous base of the class type
 of the object expression; see~\ref{class.access.base}.
@@ -2421,7 +2421,7 @@ converting the expression \tcode{v} to type \tcode{T}.
 \indextext{type!incomplete}%
 \tcode{T} shall be a pointer or reference to a complete class type, or
 ``pointer to \cvqual{cv} \tcode{void}''. The \tcode{dynamic_cast} operator shall not cast
-away constness~(\ref{expr.const.cast}).
+away constness\iref{expr.const.cast}.
 
 \pnum
 If \tcode{T} is a pointer type, \tcode{v} shall be a prvalue of a
@@ -2451,7 +2451,7 @@ subobject of the \tcode{D} object pointed to by \tcode{v}. Similarly, if
 type \cvqual{cv2} \tcode{D} such that \tcode{B} is a base class of
 \tcode{D}, the result is the unique \tcode{B} subobject of the \tcode{D}
 object referred to by \tcode{v}.\footnote{The most derived
-object~(\ref{intro.object}) pointed or referred to by
+object\iref{intro.object} pointed or referred to by
 \tcode{v} can contain other \tcode{B} objects as base classes, but these
 are ignored.}
 In both the pointer and
@@ -2471,7 +2471,7 @@ void foo(D* dp) {
 
 \pnum
 Otherwise, \tcode{v} shall be a pointer to or a glvalue of a polymorphic
-type~(\ref{class.virtual}).
+type\iref{class.virtual}.
 
 \pnum
 If \tcode{T} is ``pointer to \cvqual{cv} \tcode{void}'', then the result
@@ -2503,8 +2503,8 @@ runtime check \term{fails}.
 \pnum
 The value of a failed cast to pointer type is the null pointer value of
 the required result type. A failed cast to reference type throws
-an exception~(\ref{except.throw}) of a type that would match a
-handler~(\ref{except.handle}) of type \tcode{std::bad_cast}~(\ref{bad.cast}).
+an exception\iref{except.throw} of a type that would match a
+handler\iref{except.handle} of type \tcode{std::bad_cast}\iref{bad.cast}.
 
 \indextext{\idxcode{bad_cast}}%
 \indexlibrary{\idxcode{bad_cast}}%
@@ -2549,7 +2549,7 @@ applied to an object under construction or destruction.
 The result of a \tcode{typeid} expression is an lvalue of static type
 \indextext{\idxcode{type_info}}%
 \indexlibrary{\idxcode{type_info}}%
-\tcode{const} \tcode{std::type_info}~(\ref{type.info}) and dynamic type \tcode{const}
+\tcode{const} \tcode{std::type_info}\iref{type.info} and dynamic type \tcode{const}
 \tcode{std::type_info} or \tcode{const} \term{name} where \term{name} is an
 \impldef{derived type for \tcode{typeid}} class publicly derived from
 \tcode{std::type_info} which preserves the behavior described
@@ -2561,33 +2561,33 @@ of the program. Whether or not the destructor is called for the
 
 \pnum
 When \tcode{typeid} is applied to a glvalue expression whose type is a
-polymorphic class type~(\ref{class.virtual}), the result refers to a
+polymorphic class type\iref{class.virtual}, the result refers to a
 \tcode{std::type_info} object representing the type of the most derived
-object~(\ref{intro.object}) (that is, the dynamic type) to which the
+object\iref{intro.object} (that is, the dynamic type) to which the
 glvalue refers. If the glvalue expression is obtained by applying the
 unary \tcode{*} operator to a pointer\footnote{If \tcode{p} is an expression of
 pointer type, then \tcode{*p},
 \tcode{(*p)}, \tcode{*(p)}, \tcode{((*p))}, \tcode{*((p))}, and so on
 all meet this requirement.}
-and the pointer is a null pointer value~(\ref{conv.ptr}), the
-\tcode{typeid} expression throws an exception~(\ref{except.throw}) of
+and the pointer is a null pointer value\iref{conv.ptr}, the
+\tcode{typeid} expression throws an exception\iref{except.throw} of
 a type that would match a handler of type
 \indextext{\idxcode{bad_typeid}}%
 \indexlibrary{\idxcode{bad_typeid}}%
 \tcode{std::bad_typeid}
-exception~(\ref{bad.typeid}).
+exception\iref{bad.typeid}.
 
 \pnum
 When \tcode{typeid} is applied to an expression other than a glvalue of
 a polymorphic class type, the result refers to a \tcode{std::type_info}
 object representing the static type of the expression.
-Lvalue-to-rvalue~(\ref{conv.lval}), array-to-pointer~(\ref{conv.array}),
-and function-to-pointer~(\ref{conv.func}) conversions are not applied to
+Lvalue-to-rvalue\iref{conv.lval}, array-to-pointer\iref{conv.array},
+and function-to-pointer\iref{conv.func} conversions are not applied to
 the expression.
 If the expression is a prvalue,
-the temporary materialization conversion~(\ref{conv.rval})
+the temporary materialization conversion\iref{conv.rval}
 is applied.
-The expression is an unevaluated operand (Clause~\ref{expr}).
+The expression is an unevaluated operand\iref{expr}.
 
 \pnum
 When \tcode{typeid} is applied to a \grammarterm{type-id}, the result
@@ -2619,7 +2619,7 @@ typeid(D)  == typeid(const D&); // yields \tcode{true}
 \end{example}
 
 \pnum
-If the header \tcode{<typeinfo>}~(\ref{type.info}) is not included prior
+If the header \tcode{<typeinfo>}\iref{type.info} is not included prior
 to a use of \tcode{typeid}, the program is ill-formed.
 
 \pnum
@@ -2641,20 +2641,20 @@ If \tcode{T} is an lvalue reference type
 or an rvalue reference to function type, the result is an lvalue;
 if \tcode{T} is an rvalue reference to object type, the result is an xvalue;
 otherwise, the result is a prvalue. The \tcode{static_cast} operator shall not cast
-away constness~(\ref{expr.const.cast}).
+away constness\iref{expr.const.cast}.
 
 \pnum
 \indextext{cast!static!reference}%
 \indextext{cast!reference}%
 An lvalue of type ``\cvqual{cv1} \tcode{B}'', where \tcode{B} is a class
 type, can be cast to type ``reference to \cvqual{cv2} \tcode{D}'', where
-\tcode{D} is a class derived (Clause~\ref{class.derived}) from \tcode{B},
+\tcode{D} is a class derived\iref{class.derived} from \tcode{B},
 if \cvqual{cv2} is the
 same cv-qualification as, or greater cv-qualification than,
 \cvqual{cv1}. If \tcode{B} is a virtual base class of \tcode{D}
 or a base class of a virtual base class of \tcode{D},
 or if no valid standard conversion from ``pointer to \tcode{D}''
-to ``pointer to \tcode{B}'' exists~(\ref{conv.ptr}), the program is ill-formed.
+to ``pointer to \tcode{B}'' exists\iref{conv.ptr}, the program is ill-formed.
 An xvalue of type
 ``\cvqual{cv1} \tcode{B}'' can be cast to type ``rvalue reference to
 \cvqual{cv2} \tcode{D}'' with the same constraints as for an lvalue of
@@ -2679,28 +2679,28 @@ An lvalue
 of type ``\cvqual{cv1} \tcode{T1}'' can be cast to type ``rvalue
 reference to \cvqual{cv2} \tcode{T2}'' if ``\cvqual{cv2} \tcode{T2}'' is
 reference-compatible with ``\cvqual{cv1}
-\tcode{T1}''~(\ref{dcl.init.ref}). If the value is not a bit-field,
+\tcode{T1}''\iref{dcl.init.ref}. If the value is not a bit-field,
 the result refers to the object or the specified base class subobject
-thereof; otherwise, the lvalue-to-rvalue conversion~(\ref{conv.lval})
+thereof; otherwise, the lvalue-to-rvalue conversion\iref{conv.lval}
 is applied to the bit-field and the resulting prvalue is used as the
 \grammarterm{expression} of the \tcode{static_cast} for the remainder of this section.
-If \tcode{T2} is an inaccessible (Clause~\ref{class.access}) or
-ambiguous~(\ref{class.member.lookup}) base class of \tcode{T1},
+If \tcode{T2} is an inaccessible\iref{class.access} or
+ambiguous\iref{class.member.lookup} base class of \tcode{T1},
 a program that necessitates such a cast is ill-formed.
 
 \pnum
 An expression \tcode{e} can be explicitly converted to a type \tcode{T}
-if there is an implicit conversion sequence~(\ref{over.best.ics})
+if there is an implicit conversion sequence\iref{over.best.ics}
 from \tcode{e} to \tcode{T}, or
-if overload resolution for a direct-initialization~(\ref{dcl.init})
+if overload resolution for a direct-initialization\iref{dcl.init}
 of an object or reference of type \tcode{T} from \tcode{e}
-would find at least one viable function~(\ref{over.match.viable}).
+would find at least one viable function\iref{over.match.viable}.
 If \tcode{T} is a reference type, the effect is
 the same as performing the declaration and initialization
 \begin{codeblock}
  T t(e);
 \end{codeblock}
-for some invented temporary variable \tcode{t}~(\ref{dcl.init})
+for some invented temporary variable \tcode{t}\iref{dcl.init}
 and then using the temporary variable as the result of the conversion.
 Otherwise, the result object is direct-initialized from \tcode{e}.
 \begin{note}
@@ -2716,10 +2716,10 @@ listed below. No other conversion shall be performed explicitly using a
 \pnum
 Any expression can be explicitly converted to type \cv{}~\tcode{void},
 in which case it becomes a discarded-value
-expression (Clause~\ref{expr}).
+expression\iref{expr}.
 \begin{note}
 However, if the value is in a temporary
-object~(\ref{class.temporary}), the destructor for that
+object\iref{class.temporary}, the destructor for that
 object is
 not executed until the usual time, and the value of the object is
 preserved for the purpose of executing the destructor.
@@ -2727,13 +2727,13 @@ preserved for the purpose of executing the destructor.
 
 
 \pnum
-The inverse of any standard conversion sequence (Clause~\ref{conv}) not containing an
-lvalue-to-rvalue~(\ref{conv.lval}),
-array-to-pointer~(\ref{conv.array}),
-function-to-pointer~(\ref{conv.func}),
-null pointer~(\ref{conv.ptr}), null member pointer~(\ref{conv.mem}),
-boolean~(\ref{conv.bool}), or
-function pointer~(\ref{conv.fctptr})
+The inverse of any standard conversion sequence\iref{conv} not containing an
+lvalue-to-rvalue\iref{conv.lval},
+array-to-pointer\iref{conv.array},
+function-to-pointer\iref{conv.func},
+null pointer\iref{conv.ptr}, null member pointer\iref{conv.mem},
+boolean\iref{conv.bool}, or
+function pointer\iref{conv.fctptr}
 conversion, can be performed explicitly using \tcode{static_cast}. A
 program is ill-formed if it uses \tcode{static_cast} to perform the
 inverse of an ill-formed standard conversion sequence.
@@ -2749,16 +2749,16 @@ void f() {
 \end{example}
 
 \pnum
-The lvalue-to-rvalue~(\ref{conv.lval}),
-array-to-pointer~(\ref{conv.array}), and
-function-to-pointer~(\ref{conv.func}) conversions are applied to the
+The lvalue-to-rvalue\iref{conv.lval},
+array-to-pointer\iref{conv.array}, and
+function-to-pointer\iref{conv.func} conversions are applied to the
 operand. Such a \tcode{static_cast} is subject to the restriction that
 the explicit conversion does not cast away
-constness~(\ref{expr.const.cast}), and the following additional rules
+constness\iref{expr.const.cast}, and the following additional rules
 for specific cases:
 
 \pnum
-A value of a scoped enumeration type~(\ref{dcl.enum}) can be explicitly converted to an
+A value of a scoped enumeration type\iref{dcl.enum} can be explicitly converted to an
 integral type. When that type is \cv{}~\tcode{bool}, the resulting value is
 \tcode{false} if the original value is zero and \tcode{true} for all other
 values. For the remaining integral types, the value is unchanged if the
@@ -2773,11 +2773,11 @@ value to the floating-point type.
 \indextext{enumeration type!\idxcode{static_cast}!conversion to}%
 A value of integral or enumeration type can be explicitly converted to
 a complete enumeration type. The value is unchanged if the original value is
-within the range of the enumeration values~(\ref{dcl.enum}). Otherwise,
+within the range of the enumeration values\iref{dcl.enum}. Otherwise,
 the behavior is undefined.
 A value of floating-point type can also be explicitly converted to an enumeration type.
 The resulting value is the same as converting the original value to the
-underlying type of the enumeration~(\ref{conv.fpint}), and subsequently to
+underlying type of the enumeration\iref{conv.fpint}, and subsequently to
 the enumeration type.
 
 \pnum
@@ -2786,14 +2786,14 @@ the enumeration type.
 A prvalue of type ``pointer to \cvqual{cv1} \tcode{B}'', where \tcode{B}
 is a class type, can be converted to a prvalue of type ``pointer to
 \cvqual{cv2} \tcode{D}'', where \tcode{D} is a class derived
-(Clause~\ref{class.derived}) from \tcode{B},
+(\ref{class.derived}) from \tcode{B},
 if \cvqual{cv2} is the same cv-qualification as,
 or greater cv-qualification than, \cvqual{cv1}.
 If \tcode{B} is a virtual base class of \tcode{D} or
 a base class of a virtual base class of \tcode{D}, or
 if no valid standard conversion from ``pointer to \tcode{D}''
-to ``pointer to \tcode{B}'' exists~(\ref{conv.ptr}), the program is ill-formed.
-The null pointer value~(\ref{conv.ptr}) is converted
+to ``pointer to \tcode{B}'' exists\iref{conv.ptr}, the program is ill-formed.
+The null pointer value\iref{conv.ptr} is converted
 to the null pointer value of the destination type. If the prvalue of type
 ``pointer to \cvqual{cv1} \tcode{B}'' points to a \tcode{B} that is
 actually a subobject of an object of type \tcode{D}, the resulting
@@ -2805,7 +2805,7 @@ behavior is undefined.
 A prvalue of type ``pointer to member of \tcode{D} of type \cvqual{cv1}
 \tcode{T}'' can be converted to a prvalue of type ``pointer to member of
 \tcode{B} of type \cvqual{cv2} \tcode{T}'', where \tcode{B} is a base
-class (Clause~\ref{class.derived}) of \tcode{D},
+class\iref{class.derived} of \tcode{D},
 if \cvqual{cv2} is the same cv-qualification
 as, or greater cv-qualification than, \cvqual{cv1}.\footnote{Function types
 (including those used in pointer to member function
@@ -2813,8 +2813,8 @@ types) are never cv-qualified; see~\ref{dcl.fct}.}
 If no valid standard conversion
 from ``pointer to member of \tcode{B} of type \tcode{T}''
 to ``pointer to member of \tcode{D} of type \tcode{T}''
-exists~(\ref{conv.mem}), the program is ill-formed.
-The null member pointer value~(\ref{conv.mem}) is converted to the null
+exists\iref{conv.mem}, the program is ill-formed.
+The null member pointer value\iref{conv.mem} is converted to the null
 member pointer value of the destination type. If class \tcode{B}
 contains the original member, or is a base or derived class of the class
 containing the original member, the resulting pointer to member points
@@ -2837,7 +2837,7 @@ If the original pointer value represents the address
 then the resulting pointer value is unspecified.
 Otherwise, if the original pointer value points to an object \placeholder{a},
 and there is an object \placeholder{b} of type \tcode{T} (ignoring cv-qualification)
-that is pointer-interconvertible~(\ref{basic.compound}) with \placeholder{a},
+that is pointer-interconvertible\iref{basic.compound} with \placeholder{a},
 the result is a pointer to \placeholder{b}.
 Otherwise, the pointer value is unchanged by the conversion.
 \begin{example}
@@ -2861,14 +2861,14 @@ result of converting the expression \tcode{v} to type \tcode{T}.
 If \tcode{T} is an lvalue reference type or an rvalue reference to function type, the result is an lvalue;
 if \tcode{T} is an rvalue reference to object type, the result is an xvalue;
 otherwise, the result is a prvalue and the
-lvalue-to-rvalue~(\ref{conv.lval}), array-to-pointer~(\ref{conv.array}),
-and function-to-pointer~(\ref{conv.func}) standard conversions are
+lvalue-to-rvalue\iref{conv.lval}, array-to-pointer\iref{conv.array},
+and function-to-pointer\iref{conv.func} standard conversions are
 performed on the expression \tcode{v}. Conversions that can be performed explicitly
 using \tcode{reinterpret_cast} are listed below. No other conversion can
 be performed explicitly using \tcode{reinterpret_cast}.
 
 \pnum
-The \tcode{reinterpret_cast} operator shall not cast away constness~(\ref{expr.const.cast}).
+The \tcode{reinterpret_cast} operator shall not cast away constness\iref{expr.const.cast}.
 An expression of integral, enumeration, pointer, or pointer-to-member type
 can be explicitly converted to its own type; such a cast yields the value of
 its operand.
@@ -2917,7 +2917,7 @@ to a function pointer of a different type.
 \indextext{function call!undefined}%
 \begin{note}
 The effect of calling a function through a pointer to a function
-type~(\ref{dcl.fct}) that is not the same as the type used in the
+type\iref{dcl.fct} that is not the same as the type used in the
 definition of the function is undefined.
 \end{note}
 Except that converting
@@ -2956,7 +2956,7 @@ type and back, possibly with different cv-qualification, shall yield the origina
 pointer value.
 
 \pnum
-The null pointer value~(\ref{conv.ptr}) is converted to the null pointer value
+The null pointer value\iref{conv.ptr} is converted to the null pointer value
 of the destination type.
 \begin{note}
 A null pointer constant of type \tcode{std::nullptr_t} cannot be converted to a
@@ -2973,7 +2973,7 @@ can be explicitly converted to a prvalue of a different type ``pointer to member
 function types or both object types.\footnote{\tcode{T1} and \tcode{T2} may have
 different \cv-qualifiers, subject to
 the overall restriction that a \tcode{reinterpret_cast} cannot cast away
-constness.} The null member pointer value~(\ref{conv.mem}) is converted to the
+constness.} The null member pointer value\iref{conv.mem} is converted to the
 null member pointer value of the destination type. The result of this
 conversion is unspecified, except in the following cases:
 
@@ -3003,8 +3003,8 @@ type. \begin{note} That is, for lvalues, a reference cast
 \tcode{*} operators (and similarly for
 \tcode{reinterpret_cast<T\&\&>(x)}). \end{note} No
 temporary is created, no copy is made, and
-constructors~(\ref{class.ctor}) or conversion
-functions~(\ref{class.conv}) are not called.\footnote{This
+constructors\iref{class.ctor} or conversion
+functions\iref{class.conv} are not called.\footnote{This
 is sometimes referred to as a \defn{type pun}.}
 
 \rSec2[expr.const.cast]{Const cast}
@@ -3017,8 +3017,8 @@ The result of the expression \tcode{const_cast<T>(v)} is of type
 lvalue;
 if \tcode{T} is an rvalue reference to object type, the result is an xvalue;
 otherwise, the result is a prvalue and the
-lvalue-to-rvalue~(\ref{conv.lval}), array-to-pointer~(\ref{conv.array}),
-and function-to-pointer~(\ref{conv.func}) standard conversions are
+lvalue-to-rvalue\iref{conv.lval}, array-to-pointer\iref{conv.array},
+and function-to-pointer\iref{conv.func} standard conversions are
 performed on the expression \tcode{v}. Conversions that can be performed explicitly using
 \tcode{const_cast} are listed below. No other conversion shall be
 performed explicitly using \tcode{const_cast}.
@@ -3030,7 +3030,7 @@ to its own type using a \tcode{const_cast} operator.
 \end{note}
 
 \pnum
-For two similar types \tcode{T1} and \tcode{T2}~(\ref{conv.qual}),
+For two similar types \tcode{T1} and \tcode{T2}\iref{conv.qual},
 a prvalue of type \tcode{T1} may be explicitly
 converted to the type \tcode{T2} using a \tcode{const_cast}. The result
 of a \tcode{const_cast} refers to the original entity.
@@ -3064,12 +3064,12 @@ explicitly converted to an xvalue of type \tcode{T2} using the cast
 
 The result of a reference \tcode{const_cast} refers
 to the original object if the operand is a glvalue and
-to the result of applying the temporary materialization conversion~(\ref{conv.rval}) otherwise.
+to the result of applying the temporary materialization conversion\iref{conv.rval} otherwise.
 
 \pnum
-A null pointer value~(\ref{conv.ptr}) is converted to the null pointer
+A null pointer value\iref{conv.ptr} is converted to the null pointer
 value of the destination type. The null member pointer
-value~(\ref{conv.mem}) is converted to the null member pointer value of
+value\iref{conv.mem} is converted to the null member pointer value of
 the destination type.
 
 \pnum
@@ -3079,7 +3079,7 @@ pointer, lvalue or pointer to data member resulting from a
 \tcode{const_cast} that casts away a const-qualifier\footnote{\tcode{const_cast}
 is not limited to conversions that cast away a
 const-qualifier.}
-may produce undefined behavior~(\ref{dcl.type.cv}).
+may produce undefined behavior\iref{dcl.type.cv}.
 \end{note}
 
 \pnum
@@ -3087,7 +3087,7 @@ may produce undefined behavior~(\ref{dcl.type.cv}).
 A conversion from a type \tcode{T1} to a type \tcode{T2}
 \defnx{casts away constness}{casting away constness}
 if \tcode{T1} and \tcode{T2} are different,
-there is a cv-decomposition~(\ref{conv.qual}) of \tcode{T1}
+there is a cv-decomposition\iref{conv.qual} of \tcode{T1}
 yielding \placeholder{n} such that
 \tcode{T2} has a cv-decomposition of the form
 
@@ -3199,11 +3199,11 @@ If the operand is a \grammarterm{qualified-id} naming a non-static or variant me
 of some class \tcode{C} with type \tcode{T}, the result has type ``pointer to member
 of class \tcode{C} of type \tcode{T}'' and is a prvalue designating \tcode{C::m}.
 Otherwise, if the type of the expression is \tcode{T}, the result has type ``pointer to
-\tcode{T}'' and is a prvalue that is the address of the designated object~(\ref{intro.memory})
+\tcode{T}'' and is a prvalue that is the address of the designated object\iref{intro.memory}
 or a pointer to the designated function. \begin{note} In particular, the address of an
 object of type ``\cv{}~\tcode{T}'' is ``pointer to \cv{}~\tcode{T}'', with the same
 cv-qualification. \end{note}
-For purposes of pointer arithmetic~(\ref{expr.add}) and
+For purposes of pointer arithmetic\iref{expr.add} and
 comparison~(\ref{expr.rel}, \ref{expr.eq}),
 an object that is not an array element whose
 address is taken in this way is considered to belong to an array with one
@@ -3222,7 +3222,7 @@ bool b = p2 > p1;   // defined behavior, with value \tcode{true}
 \end{example}
 \begin{note}
 A pointer to member formed from a \tcode{mutable} non-static data
-member~(\ref{dcl.stc}) does not reflect the \tcode{mutable} specifier
+member\iref{dcl.stc} does not reflect the \tcode{mutable} specifier
 associated with the non-static data member.
 \end{note}
 
@@ -3237,7 +3237,7 @@ expression of type ``pointer to member''. Neither does
 \tcode{qualified-id}, because there is no implicit conversion from a
 \grammarterm{qualified-id} for a non-static member function to the type
 ``pointer to member function'' as there is from an lvalue of function
-type to the type ``pointer to function''~(\ref{conv.func}). Nor is
+type to the type ``pointer to function''\iref{conv.func}. Nor is
 \tcode{\&unqualified-id} a pointer to member, even within the scope of
 the \grammarterm{unqualified-id}'s class.
 \end{note}
@@ -3250,7 +3250,7 @@ called. The operand of \tcode{\&} shall not be a bit-field.
 
 \pnum
 \indextext{overloaded function!address of}%
-The address of an overloaded function (Clause~\ref{over}) can be taken
+The address of an overloaded function\iref{over} can be taken
 only in a context that uniquely determines which version of the
 overloaded function is referred to (see~\ref{over.over}).
 \begin{note}
@@ -3280,7 +3280,7 @@ result is the type of the promoted operand.
 \indextext{operator!logical negation}%
 The operand of the logical negation operator \tcode{!} is contextually
 converted to \tcode{bool}
-(Clause~\ref{conv}); its value is \tcode{true}
+(\ref{conv}); its value is \tcode{true}
 if the converted operand is \tcode{false} and \tcode{false} otherwise.
 The type of the result is \tcode{bool}.
 
@@ -3322,8 +3322,8 @@ bit-field if the operand is a bit-field.
 The expression \tcode{++x} is equivalent to \tcode{x+=1}.
 \indextext{operator!\idxcode{+=}}%
 \begin{note}
-See the discussions of addition~(\ref{expr.add}) and assignment
-operators~(\ref{expr.ass}) for information on conversions.
+See the discussions of addition\iref{expr.add} and assignment
+operators\iref{expr.ass} for information on conversions.
 \end{note}
 
 \pnum
@@ -3345,7 +3345,7 @@ For postfix increment and decrement, see~\ref{expr.post.incr}.
 \indextext{byte}%
 The \tcode{sizeof} operator yields the number of bytes in the object
 representation of its operand. The operand is either an expression,
-which is an unevaluated operand (Clause~\ref{expr}), or a parenthesized
+which is an unevaluated operand\iref{expr}, or a parenthesized
 \grammarterm{type-id}.
 \indextext{type!incomplete}%
 The \tcode{sizeof} operator shall not be applied to an expression that
@@ -3355,7 +3355,7 @@ types, or to a glvalue that designates a bit-field.
 \tcode{sizeof(char)}, \tcode{sizeof(signed char)} and
 \tcode{sizeof(unsigned char)} are \tcode{1}. The result of
 \tcode{sizeof} applied to any other fundamental
-type~(\ref{basic.fundamental}) is \impldef{\tcode{sizeof} applied to
+type\iref{basic.fundamental} is \impldef{\tcode{sizeof} applied to
 fundamental types
 other than \tcode{char}, \tcode{signed char}, and \tcode{unsigned char}}.
 \begin{note}
@@ -3376,7 +3376,7 @@ of the referenced type.
 When applied to a class, the result is the number of bytes in an object
 of that class including any padding required for placing objects of that
 type in an array. The size of a most derived class shall be greater than
-zero~(\ref{intro.object}). The result of applying \tcode{sizeof} to a
+zero\iref{intro.object}. The result of applying \tcode{sizeof} to a
 base class subobject is the size of the base class type.\footnote{The actual
 size of a base class subobject may be less than the result of
 applying \tcode{sizeof} to the subobject, due to virtual base classes
@@ -3391,19 +3391,19 @@ The \tcode{sizeof} operator can be applied to a pointer to a function,
 but shall not be applied directly to a function.
 
 \pnum
-The lvalue-to-rvalue~(\ref{conv.lval}),
-array-to-pointer~(\ref{conv.array}), and
-function-to-pointer~(\ref{conv.func}) standard conversions are not
+The lvalue-to-rvalue\iref{conv.lval},
+array-to-pointer\iref{conv.array}, and
+function-to-pointer\iref{conv.func} standard conversions are not
 applied to the operand of \tcode{sizeof}.
 If the operand is a prvalue,
-the temporary materialization conversion~(\ref{conv.rval})
+the temporary materialization conversion\iref{conv.rval}
 is applied.
 
 \pnum
 The identifier in a \tcode{sizeof...} expression shall name a parameter
 pack. The \tcode{sizeof...} operator yields the number of arguments
 provided for the parameter pack \grammarterm{identifier}.
-A \tcode{sizeof...} expression is a pack expansion~(\ref{temp.variadic}).
+A \tcode{sizeof...} expression is a pack expansion\iref{temp.variadic}.
 \begin{example}
 
 \begin{codeblock}
@@ -3434,7 +3434,7 @@ The result of \tcode{sizeof} and \tcode{sizeof...} is a constant of type
 \indextext{storage management|see{\tcode{new}, \tcode{delete}}}%
 \indextext{\idxcode{new}}%
 The \grammarterm{new-expression} attempts to create an object of the
-\grammarterm{type-id}~(\ref{dcl.name}) or \grammarterm{new-type-id} to which
+\grammarterm{type-id}\iref{dcl.name} or \grammarterm{new-type-id} to which
 it is applied. The type of that object is the \defnx{allocated type}{type!allocated}.
 \indextext{type!incomplete}%
 This type shall be a complete object type, but not an abstract class
@@ -3487,7 +3487,7 @@ object created by the \grammarterm{new-expression} has a cv-qualified type.
 
 \indextext{storage duration!dynamic}%
 Entities created by a \grammarterm{new-expression} have dynamic storage
-duration~(\ref{basic.stc.dynamic}).
+duration\iref{basic.stc.dynamic}.
 \begin{note}
 \indextext{\idxcode{new}!scoping and}%
 The lifetime of such an entity is not necessarily restricted to the
@@ -3499,7 +3499,7 @@ returns a pointer to the object created. If it is an array, the
 the array.
 
 \pnum
-If a placeholder type~(\ref{dcl.spec.auto}) appears in the
+If a placeholder type\iref{dcl.spec.auto} appears in the
 \grammarterm{type-specifier-seq} of a \grammarterm{new-type-id} or
 \grammarterm{type-id} of a \grammarterm{new-expression},
 the allocated type is deduced as follows:
@@ -3509,7 +3509,7 @@ and
 \tcode{T} be the \grammarterm{new-type-id} or \grammarterm{type-id} of
 the \grammarterm{new-expression}, then the allocated type is the type
 deduced for the variable \tcode{x} in the invented
-declaration~(\ref{dcl.spec.auto}):
+declaration\iref{dcl.spec.auto}:
 
 \begin{codeblock}
 T x @\textrm{\placeholder{init}}@ ;
@@ -3560,7 +3560,7 @@ is ill-formed because the binding is
 
 Instead, the explicitly parenthesized version of the \tcode{new}
 operator can be used to create objects of compound
-types~(\ref{basic.compound}):
+types\iref{basic.compound}:
 
 \begin{codeblock}
 new (int (*[10])());
@@ -3588,7 +3588,7 @@ to the associated array type.
 \pnum
 Every \grammarterm{constant-expression} in a
 \grammarterm{noptr-new-declarator} shall be a converted constant
-expression~(\ref{expr.const}) of type \tcode{std::size_t} and
+expression\iref{expr.const} of type \tcode{std::size_t} and
 shall evaluate to a strictly positive value.
 \indextext{\idxcode{new}}%
 The \grammarterm{expression} in a \grammarterm{noptr-new-declarator} is
@@ -3613,19 +3613,19 @@ the expression is of non-class type and its value before converting to
 
 \item
 the expression is of class type and its value before application of the second
-standard conversion~(\ref{over.ics.user})\footnote{If the conversion function
+standard conversion\iref{over.ics.user}\footnote{If the conversion function
 returns a signed integer type, the second standard conversion converts to the
 unsigned type \tcode{std::size_t} and thus thwarts any attempt to detect a
 negative value afterwards.} is less than zero;
 
 \item
 its value is such that the size of the allocated object would exceed the
-\impldef{maximum size of an allocated object} limit (Annex~\ref{implimits}); or
+\impldef{maximum size of an allocated object} limit\iref{implimits}; or
 
 \item
 the \grammarterm{new-initializer} is a \grammarterm{braced-init-list} and the
 number of array elements for which initializers are provided (including the
-terminating \tcode{'\textbackslash 0'} in a string literal~(\ref{lex.string})) exceeds the
+terminating \tcode{'\textbackslash 0'} in a string literal\iref{lex.string}) exceeds the
 number of elements to initialize.
 \end{itemize}
 
@@ -3639,13 +3639,13 @@ otherwise, an allocation function is not called; instead
 \begin{itemize}
 \item
 if the allocation function that would have been called
-has a non-throwing exception specification~(\ref{except.spec}),
+has a non-throwing exception specification\iref{except.spec},
 the value of the \grammarterm{new-expression}
 is the null pointer value of the required result type;
 \item
 otherwise, the \grammarterm{new-expression} terminates by throwing an
-exception of a type that would match a handler~(\ref{except.handle}) of type
-\tcode{std::bad_array_new_length}~(\ref{new.badlength}).
+exception of a type that would match a handler\iref{except.handle} of type
+\tcode{std::bad_array_new_length}\iref{new.badlength}.
 \end{itemize}
 \end{itemize}
 When the value of the \grammarterm{expression} is zero, the allocation
@@ -3653,10 +3653,10 @@ function is called to allocate an array with no elements.
 
 \pnum
 A \grammarterm{new-expression} may obtain storage for the object by calling an
-allocation function~(\ref{basic.stc.dynamic.allocation}). If
+allocation function\iref{basic.stc.dynamic.allocation}. If
 the \grammarterm{new-expression} terminates by throwing an exception, it
 may release storage by calling a deallocation
-function~(\ref{basic.stc.dynamic.deallocation}). If the allocated type
+function\iref{basic.stc.dynamic.deallocation}. If the allocated type
 is a non-array type, the allocation function's name is
 \indextext{\idxcode{operator new}}%
 \indextext{\idxcode{operator delete}}%
@@ -3673,8 +3673,8 @@ An implementation shall provide default definitions for the global
 allocation
 functions~(\ref{basic.stc.dynamic}, \ref{new.delete.single}, \ref{new.delete.array}).
 A \Cpp program can provide alternative definitions of
-these functions~(\ref{replacement.functions}) and/or class-specific
-versions~(\ref{class.free}).
+these functions\iref{replacement.functions} and/or class-specific
+versions\iref{class.free}.
 The set of allocation and deallocation functions that may be called
 by a \grammarterm{new-expression}
 may include functions that do not perform allocation or deallocation;
@@ -3758,7 +3758,7 @@ the difference between the
 result of the \grammarterm{new-expression} and the address returned by the
 allocation function shall be an integral multiple of the
 strictest fundamental
-alignment requirement~(\ref{basic.align}) of any object type whose size
+alignment requirement\iref{basic.align} of any object type whose size
 is no greater than the size of the array being created.
 \begin{note}
 \indextext{allocation!alignment storage}%
@@ -3840,19 +3840,19 @@ invocation of \tcode{new} to another.
 \pnum
 \begin{note}
 Unless an allocation function has a non-throwing
-exception specification~(\ref{except.spec}),
+exception specification\iref{except.spec},
 it indicates failure to allocate storage by throwing a
 \indextext{\idxcode{bad_alloc}}%
 \indexlibrary{\idxcode{bad_alloc}}%
 \tcode{std::bad_alloc} exception~(\ref{basic.stc.dynamic.allocation},
-Clause~\ref{except}, \ref{bad.alloc});
+\ref{except}, \ref{bad.alloc});
 it returns a non-null pointer otherwise. If the allocation function
 has a non-throwing exception specification,
 it returns null to indicate failure to allocate storage
 and a non-null pointer otherwise.
 \end{note}
 If the allocation function is a non-allocating
-form~(\ref{new.delete.placement}) that returns null,
+form\iref{new.delete.placement} that returns null,
 the behavior is undefined.
 Otherwise,
 if the allocation function returns null, initialization shall not be
@@ -3881,7 +3881,7 @@ initializes that object as follows:
 
 \begin{itemize}
 \item If the \grammarterm{new-initializer} is omitted, the object is
-default-initialized~(\ref{dcl.init}). \begin{note} If no initialization
+default-initialized\iref{dcl.init}. \begin{note} If no initialization
 is performed, the object has an indeterminate value. \end{note}
 
 \item Otherwise, the \grammarterm{new-initializer} is interpreted according to
@@ -3901,10 +3901,10 @@ value computation of the
 \pnum
 If the \grammarterm{new-expression} creates an object or an array of
 objects of class type, access and ambiguity control are done for the
-allocation function, the deallocation function~(\ref{class.free}), and
-the constructor~(\ref{class.ctor}). If the \grammarterm{new-expression}
+allocation function, the deallocation function\iref{class.free}, and
+the constructor\iref{class.ctor}. If the \grammarterm{new-expression}
 creates an array of objects of class type, the destructor is potentially
-invoked~(\ref{class.dtor}).
+invoked\iref{class.dtor}.
 
 \pnum
 \indextext{\idxcode{new}!exception and}%
@@ -3935,19 +3935,19 @@ function's name is looked up in the global scope.
 \pnum
 A declaration of a placement deallocation function matches the
 declaration of a placement allocation function if it has the same number
-of parameters and, after parameter transformations~(\ref{dcl.fct}), all
+of parameters and, after parameter transformations\iref{dcl.fct}, all
 parameter types except the first are identical. If
 the lookup finds a single matching deallocation function, that function
 will be called; otherwise, no deallocation function will be called. If
 the lookup finds a usual deallocation
 function
-with a parameter of type \tcode{std::size_t}~(\ref{basic.stc.dynamic.deallocation})
+with a parameter of type \tcode{std::size_t}\iref{basic.stc.dynamic.deallocation}
 and that function,
 considered as a placement deallocation function, would have been
 selected as a match for the allocation function, the program is
 ill-formed. For a non-placement allocation function, the normal deallocation
 function lookup is used to find the matching deallocation
-function~(\ref{expr.delete})
+function\iref{expr.delete}
 \begin{example}
 
 \begin{codeblock}
@@ -3984,7 +3984,7 @@ If the copy is elided in one place, it need not be elided in the other.
 \indextext{expression!\idxcode{delete}}%
 \indextext{\idxcode{delete}}%
 The \grammarterm{delete-expression} operator destroys a most derived
-object~(\ref{intro.object}) or array created by a
+object\iref{intro.object} or array created by a
 \grammarterm{new-expression}.
 
 \begin{bnf}
@@ -4001,7 +4001,7 @@ empty square brackets can follow the \tcode{delete} keyword if the lambda expres
 enclosed in parentheses.}
 The operand shall be of pointer to object type or of class type. If of
 class type, the operand is contextually implicitly converted
-(Clause~\ref{conv}) to a pointer to object
+(\ref{conv}) to a pointer to object
 type.\footnote{This implies that an object
 cannot be deleted using a pointer of type
 \tcode{void*} because \tcode{void} is not an object type.}
@@ -4020,8 +4020,8 @@ In the first alternative
 be a null pointer value, a pointer to a non-array object
 created by a previous \grammarterm{new-expression},
 or a pointer to a
-subobject~(\ref{intro.object}) representing a base class of such an
-object (Clause~\ref{class.derived}). If not, the behavior is undefined.
+subobject\iref{intro.object} representing a base class of such an
+object\iref{class.derived}. If not, the behavior is undefined.
 \indextext{array!\idxcode{delete}}%
 \indextext{\idxcode{delete}!array}%
 In the second alternative (\term{delete array}), the value of the
@@ -4041,7 +4041,7 @@ match the type of the object allocated by \tcode{new}, not the syntax of the
 \begin{note}
 A pointer to a \tcode{const} type can be the operand of a
 \grammarterm{delete-expression}; it is not necessary to cast away the
-constness~(\ref{expr.const.cast}) of the pointer expression before it is
+constness\iref{expr.const.cast} of the pointer expression before it is
 used as the operand of the \grammarterm{delete-expression}.
 \end{note}
 
@@ -4080,9 +4080,9 @@ null pointer value, then:
 \begin{itemize}
 \item
 If the allocation call for the \grammarterm{new-expression} for the object to
-be deleted was not omitted and the allocation was not extended~(\ref{expr.new}), the
+be deleted was not omitted and the allocation was not extended\iref{expr.new}, the
 \grammarterm{delete-expression} shall call a deallocation
-function~(\ref{basic.stc.dynamic.deallocation}). The value returned from the
+function\iref{basic.stc.dynamic.deallocation}. The value returned from the
 allocation call of the \grammarterm{new-expression} shall be passed as the
 first argument to the deallocation function.
 
@@ -4112,19 +4112,19 @@ called as described above.
 \begin{note}
 An implementation provides default definitions of the global
 deallocation functions \tcode{operator delete} for
-non-arrays~(\ref{new.delete.single}) and
+non-arrays\iref{new.delete.single} and
 \indextext{\idxcode{operator delete}}%
-\tcode{operator delete[]} for arrays~(\ref{new.delete.array}). A \Cpp
+\tcode{operator delete[]} for arrays\iref{new.delete.array}. A \Cpp
 program can provide alternative definitions of these
-functions~(\ref{replacement.functions}), and/or class-specific
-versions~(\ref{class.free}).
+functions\iref{replacement.functions}, and/or class-specific
+versions\iref{class.free}.
 \end{note}
 
 \pnum
 When the keyword \tcode{delete} in a \grammarterm{delete-expression} is
 preceded by the unary \tcode{::} operator, the deallocation function's name is looked
 up in global scope. Otherwise, the lookup considers class-specific deallocation
-functions~(\ref{class.free}). If no class-specific deallocation function is found,
+functions\iref{class.free}. If no class-specific deallocation function is found,
 the deallocation function's name is looked up in global scope.
 
 \pnum
@@ -4159,7 +4159,7 @@ When a \grammarterm{delete-expression}
 is executed, the selected deallocation function shall be called with
 the address of the most-derived object in the \term{delete object} case, or
 the address of the object suitably adjusted for
-the array allocation overhead~(\ref{expr.new}) in the \term{delete array} case,
+the array allocation overhead\iref{expr.new} in the \term{delete array} case,
 as its first argument.
 If a deallocation function
 with a parameter of type \tcode{std::align_val_t}
@@ -4213,8 +4213,8 @@ element type.
 \indextext{\idxcode{noexcept}}%
 \indextext{expression!\idxcode{noexcept}}%
 The \tcode{noexcept} operator determines whether the evaluation of its operand,
-which is an unevaluated operand (Clause~\ref{expr}), can throw an
-exception~(\ref{except.throw}).
+which is an unevaluated operand\iref{expr}, can throw an
+exception\iref{except.throw}.
 
 \begin{bnf}
 \nontermdef{noexcept-expression}\br
@@ -4227,7 +4227,7 @@ and is a prvalue.
 
 \pnum
 The result of the \tcode{noexcept} operator is \tcode{true}
-unless the \grammarterm{expression} is potentially-throwing~(\ref{except.spec}).
+unless the \grammarterm{expression} is potentially-throwing\iref{except.spec}.
 \indextext{expression!unary|)}
 
 \rSec1[expr.cast]{Explicit type conversion (cast notation)}%
@@ -4241,12 +4241,12 @@ is an rvalue reference to object type; otherwise the result is a prvalue.
 \begin{note}
 If \tcode{T} is a non-class type that is cv-qualified, the
 \grammarterm{cv-qualifier}{s} are discarded when determining the type of the
-resulting prvalue; see Clause~\ref{expr}.
+resulting prvalue; see \ref{expr}.
 \end{note}
 
 \pnum
 An explicit type conversion can be expressed using functional
-notation~(\ref{expr.type.conv}), a type conversion operator
+notation\iref{expr.type.conv}, a type conversion operator
 (\tcode{dynamic_cast}, \tcode{static_cast}, \tcode{reinterpret_cast},
 \tcode{const_cast}), or the \term{cast} notation.
 
@@ -4258,7 +4258,7 @@ notation~(\ref{expr.type.conv}), a type conversion operator
 
 \pnum
 Any type conversion not mentioned below and not explicitly defined by
-the user~(\ref{class.conv}) is ill-formed.
+the user\iref{class.conv} is ill-formed.
 
 \pnum
 The conversions performed by
@@ -4267,10 +4267,10 @@ The conversions performed by
 \indextext{cast!const}%
 \indextext{cast!static}%
 \indextext{cast!reinterpret}%
-\item a \tcode{const_cast}~(\ref{expr.const.cast}),
-\item a \tcode{static_cast}~(\ref{expr.static.cast}),
+\item a \tcode{const_cast}\iref{expr.const.cast},
+\item a \tcode{static_cast}\iref{expr.static.cast},
 \item a \tcode{static_cast} followed by a \tcode{const_cast},
-\item a \tcode{reinterpret_cast}~(\ref{expr.reinterpret.cast}), or
+\item a \tcode{reinterpret_cast}\iref{expr.reinterpret.cast}, or
 \item a \tcode{reinterpret_cast} followed by a \tcode{const_cast},
 \end{itemize}
 
@@ -4429,7 +4429,7 @@ whose second operand is a pointer to a data member is an lvalue if the first
 operand is an lvalue and an xvalue otherwise. The result of a \tcode{.*} expression whose
 second operand is a pointer to a member function is a prvalue.
 If the second operand is the null
-member pointer value~(\ref{conv.mem}), the behavior is undefined.
+member pointer value\iref{conv.mem}, the behavior is undefined.
 
 \rSec1[expr.mul]{Multiplicative operators}%
 \indextext{expression!multiplicative operators}%
@@ -4555,7 +4555,7 @@ When two pointers to elements of the same array object are subtracted,
 the type of the result is an \impldef{type of \tcode{ptrdiff_t}} signed
 integral type; this type shall be the same type that is defined as
 \tcode{std::ptrdiff_t} in the \tcode{<cstddef>}
-header~(\ref{support.types}).
+header\iref{support.types}.
 If the expressions \tcode{P} and \tcode{Q}
 point to, respectively,
 elements
@@ -4575,7 +4575,7 @@ the behavior is undefined.
 \pnum
 For addition or subtraction, if the expressions \tcode{P} or \tcode{Q} have
 type ``pointer to \cv{}~\tcode{T}'', where \tcode{T} and the array element type
-are not similar~(\ref{conv.qual}), the behavior is undefined.
+are not similar\iref{conv.qual}, the behavior is undefined.
 \begin{note} In particular, a pointer to a base class cannot be used for
 pointer arithmetic when the array contains objects of a derived class type.
 \end{note}
@@ -4677,9 +4677,9 @@ yield \tcode{false} or \tcode{true}. The type of the result is
 \pnum
 The usual arithmetic conversions are performed on operands of arithmetic
 or enumeration type. If both operands are pointers, pointer
-conversions~(\ref{conv.ptr}) and qualification conversions~(\ref{conv.qual})
+conversions\iref{conv.ptr} and qualification conversions\iref{conv.qual}
 are performed to bring
-them to their composite pointer type (Clause~\ref{expr}).
+them to their composite pointer type\iref{expr}.
 After conversions, the operands shall have the same type.
 
 \pnum
@@ -4700,7 +4700,7 @@ compares greater.
 object, or to subobjects of such members, recursively,
 the pointer to the later declared member compares greater provided the
 two members
-have the same access control (Clause~\ref{class.access})
+have the same access control\iref{class.access}
 and provided their class is not a union.
 
 \item Otherwise, neither pointer compares greater than the other.
@@ -4708,7 +4708,7 @@ and provided their class is not a union.
 \end{itemize}
 
 \pnum
-If two operands \tcode{p} and \tcode{q} compare equal~(\ref{expr.eq}),
+If two operands \tcode{p} and \tcode{q} compare equal\iref{expr.eq},
 \tcode{p<=q} and \tcode{p>=q} both yield \tcode{true} and \tcode{p<q} and
 \tcode{p>q} both yield \tcode{false}. Otherwise, if a pointer \tcode{p}
 compares greater than a pointer \tcode{q}, \tcode{p>=q}, \tcode{p>q},
@@ -4745,11 +4745,11 @@ same type after the specified conversions have been applied.
 \indextext{comparison!pointer}%
 \indextext{comparison!pointer to function}%
 If at least one of the operands is a pointer,
-pointer conversions~(\ref{conv.ptr}),
-function pointer conversions~(\ref{conv.fctptr}), and
-qualification conversions~(\ref{conv.qual})
+pointer conversions\iref{conv.ptr},
+function pointer conversions\iref{conv.fctptr}, and
+qualification conversions\iref{conv.qual}
 are performed on both operands to bring them to their composite pointer type
-(Clause~\ref{expr}). Comparing pointers is defined as follows:
+(\ref{expr}). Comparing pointers is defined as follows:
 
 \begin{itemize}
 \item
@@ -4761,7 +4761,7 @@ see~\ref{expr.unary.op}.} the result of the comparison is unspecified.
 \item
 Otherwise, if the pointers are both null, both point to the same
 \indextext{address}%
-function, or both represent the same address~(\ref{basic.compound}),
+function, or both represent the same address\iref{basic.compound},
 they compare equal.
 \item
 Otherwise, the pointers compare unequal.
@@ -4769,9 +4769,9 @@ Otherwise, the pointers compare unequal.
 
 \pnum
 If at least one of the operands is a pointer to member, pointer to member
-conversions~(\ref{conv.mem}) and qualification
-conversions~(\ref{conv.qual}) are performed on both operands to bring them to
-their composite pointer type (Clause~\ref{expr}).
+conversions\iref{conv.mem} and qualification
+conversions\iref{conv.qual} are performed on both operands to bring them to
+their composite pointer type\iref{expr}.
 Comparing pointers to members is defined as follows:
 
 \begin{itemize}
@@ -4804,12 +4804,12 @@ bool b1 = (bx == cx);   // unspecified
 \end{example}
 
 \item
-If both refer to (possibly different) members of the same union~(\ref{class.union}),
+If both refer to (possibly different) members of the same union\iref{class.union},
 they compare equal.
 
 \item
 Otherwise, two pointers to members compare equal if they would refer to the same member of
-the same most derived object~(\ref{intro.object}) or the same subobject if
+the same most derived object\iref{intro.object} or the same subobject if
 indirection with a hypothetical object of the associated
 class type were performed, otherwise they compare unequal.
 \begin{example}
@@ -4912,8 +4912,8 @@ operator applies only to integral or unscoped enumeration operands.
 
 \pnum
 The \tcode{\&\&} operator groups left-to-right. The operands are both
-contextually converted to \tcode{bool}
-(Clause~\ref{conv}). The
+contextually converted to \tcode{bool}\iref{conv}.
+The
 result is \tcode{true} if both operands are \tcode{true} and
 \tcode{false} otherwise. Unlike \tcode{\&}, \tcode{\&\&} guarantees
 left-to-right evaluation: the second operand is not evaluated if the
@@ -4943,8 +4943,8 @@ value computation and side effect associated with the second expression.
 
 \pnum
 The \tcode{||} operator groups left-to-right. The operands are both
-contextually converted to \tcode{bool}
-(Clause~\ref{conv}). It returns
+contextually converted to \tcode{bool}\iref{conv}.
+It returns
 \tcode{true} if either of its operands is \tcode{true}, and
 \tcode{false} otherwise. Unlike \tcode{|}, \tcode{||} guarantees
 left-to-right evaluation; moreover, the second operand is not evaluated
@@ -4974,8 +4974,8 @@ and side effect associated with the second expression.
 
 \pnum
 Conditional expressions group right-to-left. The first expression is
-contextually converted to \tcode{bool}
-(Clause~\ref{conv}). It is
+contextually converted to \tcode{bool}\iref{conv}.
+It is
 evaluated and if it is \tcode{true}, the result of the conditional
 expression is the value of the second expression, otherwise that of the
 third expression. Only one of the second and third expressions is
@@ -4992,7 +4992,7 @@ one of the following shall hold:
 \begin{itemize}
 \indextext{conditional-expression!throw-expression in}%
 \item The second or the third operand (but not both) is a (possibly
-parenthesized) \grammarterm{throw-expression}~(\ref{expr.throw}); the result
+parenthesized) \grammarterm{throw-expression}\iref{expr.throw}; the result
 is of the type and value category of the other.
 The \grammarterm{conditional-expression}
 is a bit-field if that operand is a bit-field.
@@ -5016,7 +5016,7 @@ Otherwise, if the second and third operand have different types and
 either has (possibly cv-qualified) class type, or if both
 are glvalues of the same value category and the same type except for
 cv-qualification, an attempt is made to
-form an implicit conversion sequence~(\ref{over.best.ics}) from
+form an implicit conversion sequence\iref{over.best.ics} from
 each of those operands to the type of the other.
 \begin{note}
 Properties such as access, whether an operand is a bit-field, or whether
@@ -5031,7 +5031,7 @@ of the operand expression \tcode{E2} as follows:
 \item If \tcode{E2} is an lvalue, the target type is
 ``lvalue reference to \tcode{T2}'', subject to the
 constraint that in the conversion the reference must bind
-directly~(\ref{dcl.init.ref}) to an lvalue.
+directly\iref{dcl.init.ref} to an lvalue.
 
 \item If \tcode{E2} is an xvalue, the target type is
 ``rvalue reference to \tcode{T2}'',
@@ -5048,9 +5048,9 @@ the target type is \tcode{T2},
 
 \item otherwise, the target type is the type that \tcode{E2} would have
 after applying the
-lvalue-to-rvalue~(\ref{conv.lval}),
-array-to-pointer~(\ref{conv.array}), and
-function-to-pointer~(\ref{conv.func})
+lvalue-to-rvalue\iref{conv.lval},
+array-to-pointer\iref{conv.array}, and
+function-to-pointer\iref{conv.func}
 standard conversions.
 \end{itemize}
 \end{itemize}
@@ -5088,8 +5088,8 @@ are used in place of the original operands for the remainder of this
 section.
 
 \pnum
-Lvalue-to-rvalue~(\ref{conv.lval}), array-to-pointer~(\ref{conv.array}),
-and function-to-pointer~(\ref{conv.func}) standard conversions are
+Lvalue-to-rvalue\iref{conv.lval}, array-to-pointer\iref{conv.array},
+and function-to-pointer\iref{conv.func} standard conversions are
 performed on the second and third operands. After those conversions, one
 of the following shall hold:
 
@@ -5102,17 +5102,17 @@ the usual arithmetic conversions are performed to bring them to a common
 type, and the result is of that type.
 
 \item One or both of the second and third operands have pointer type;
-pointer conversions~(\ref{conv.ptr}),
-function pointer conversions~(\ref{conv.fctptr}), and
-qualification conversions~(\ref{conv.qual})
+pointer conversions\iref{conv.ptr},
+function pointer conversions\iref{conv.fctptr}, and
+qualification conversions\iref{conv.qual}
 are performed to bring them to their
-composite pointer type (Clause~\ref{expr}). The result is of the composite
+composite pointer type\iref{expr}. The result is of the composite
 pointer type.
 
 \item One or both of the second and third operands have pointer to member type;
-pointer to member conversions~(\ref{conv.mem}) and qualification
-conversions~(\ref{conv.qual}) are performed to bring them to their composite
-pointer type (Clause~\ref{expr}). The result is of the composite pointer type.
+pointer to member conversions\iref{conv.mem} and qualification
+conversions\iref{conv.qual} are performed to bring them to their composite
+pointer type\iref{expr}. The result is of the composite pointer type.
 
 \item
 Both the second and third operands have type \tcode{std::nullptr_t} or one has
@@ -5136,7 +5136,7 @@ A \grammarterm{throw-expression} is of type \tcode{void}.
 
 \pnum
 Evaluating a \grammarterm{throw-expression} with an operand throws an
-exception~(\ref{except.throw}); the type of the exception object is determined by removing
+exception\iref{except.throw}; the type of the exception object is determined by removing
 any top-level \grammarterm{cv-qualifier}{s} from the static type of the
 operand and adjusting the type
 from ``array of \tcode{T}'' or function type \tcode{T}
@@ -5146,7 +5146,7 @@ to ``pointer to \tcode{T}''.
 \indextext{exception handling!rethrow}%
 A
 \grammarterm{throw-expression}
-with no operand rethrows the currently handled exception~(\ref{except.handle}).
+with no operand rethrows the currently handled exception\iref{except.handle}.
 The exception is reactivated with the existing exception object;
 no new exception object is created.
 The exception is no longer considered to be caught.
@@ -5171,7 +5171,7 @@ If no exception is presently being handled,
 evaluating a
 \grammarterm{throw-expression}
 with no operand calls
-\tcode{std::\brk{}terminate()}~(\ref{except.terminate}).
+\tcode{std::\brk{}terminate()}\iref{except.terminate}.
 
 \rSec1[expr.ass]{Assignment and compound assignment operators}%
 \indextext{expression!assignment and compound assignment}
@@ -5230,7 +5230,7 @@ that of the object referred to by the left operand.
 \pnum
 \indextext{assignment!conversion by}%
 If the left operand is not of class type, the expression is implicitly
-converted (Clause~\ref{conv}) to the cv-unqualified type of the left
+converted\iref{conv} to the cv-unqualified type of the left
 operand.
 
 \pnum
@@ -5311,7 +5311,7 @@ The comma operator groups left-to-right.
 
 A pair of expressions separated by a comma is evaluated left-to-right;
 the left expression is
-a discarded-value expression (Clause~\ref{expr}).
+a discarded-value expression\iref{expr}.
 Every
 \indextext{value computation}%
 value computation and side effect
@@ -5322,14 +5322,14 @@ The type and value of the
 result are the type and value of the right operand; the result is of the same
 value category as its right operand, and is a bit-field if its
 right operand is a bit-field.
-If the right operand is a temporary expression~(\ref{class.temporary}),
+If the right operand is a temporary expression\iref{class.temporary},
 the result is a temporary expression.
 
 \pnum
 In contexts where comma is given a special meaning, \begin{example} in
-lists of arguments to functions~(\ref{expr.call}) and lists of
-initializers~(\ref{dcl.init}) \end{example} the comma operator as
-described in Clause~\ref{expr} can appear only in parentheses.
+lists of arguments to functions\iref{expr.call} and lists of
+initializers\iref{dcl.init} \end{example} the comma operator as
+described in \ref{expr} can appear only in parentheses.
 \begin{example}
 
 \begin{codeblock}
@@ -5363,11 +5363,11 @@ during translation.\end{note}
 An expression \tcode{e} is a
 \defnx{core constant expression}{expression!core constant}
 unless the evaluation of \tcode{e}, following the rules of the abstract
-machine~(\ref{intro.execution}), would evaluate one of the following expressions:
+machine\iref{intro.execution}, would evaluate one of the following expressions:
 
 \begin{itemize}
 \item
-\tcode{this}~(\ref{expr.prim.this}), except in a constexpr
+\tcode{this}\iref{expr.prim.this}, except in a constexpr
 function or a constexpr constructor that is being evaluated as part
 of \tcode{e};
 
@@ -5375,8 +5375,8 @@ of \tcode{e};
 an invocation of a function other than
 a constexpr constructor for a literal class,
 a constexpr function,
-or an implicit invocation of a trivial destructor~(\ref{class.dtor})
-\begin{note} Overload resolution~(\ref{over.match})
+or an implicit invocation of a trivial destructor\iref{class.dtor}
+\begin{note} Overload resolution\iref{over.match}
 is applied as usual \end{note};
 
 \item
@@ -5387,23 +5387,23 @@ undefined constexpr constructor;
 an invocation of an instantiated constexpr function or
 constexpr constructor that fails to satisfy the requirements
 for a constexpr function or
-constexpr constructor~(\ref{dcl.constexpr});
+constexpr constructor\iref{dcl.constexpr};
 
 \item
 an expression that would exceed the implementation-defined
-limits (see Annex~\ref{implimits});
+limits (see \ref{implimits});
 
 \item
 an operation that would have undefined behavior
-as specified in Clauses~\ref{intro} through~\ref{cpp}
+as specified in \ref{intro} through \ref{cpp}
 of this International Standard \begin{note} including,
-for example, signed integer overflow~(Clause \ref{expr}), certain
-pointer arithmetic~(\ref{expr.add}), division by
-zero~(\ref{expr.mul}), or certain shift operations~(\ref{expr.shift})
+for example, signed integer overflow\iref{expr}, certain
+pointer arithmetic\iref{expr.add}, division by
+zero\iref{expr.mul}, or certain shift operations\iref{expr.shift}
 \end{note};
 
 \item
-an lvalue-to-rvalue conversion~(\ref{conv.lval}) unless
+an lvalue-to-rvalue conversion\iref{conv.lval} unless
 it is applied to
 
 \begin{itemize}
@@ -5414,7 +5414,7 @@ it is applied to
 
   \item
   a non-volatile glvalue that refers to a subobject of a string
-  literal~(\ref{lex.string}), or
+  literal\iref{lex.string}, or
 
   \item
   a non-volatile glvalue that refers to a non-volatile object
@@ -5427,7 +5427,7 @@ it is applied to
 \end{itemize}
 
 \item
-an lvalue-to-rvalue conversion~(\ref{conv.lval})
+an lvalue-to-rvalue conversion\iref{conv.lval}
 that is applied to a glvalue
 that refers to a non-active member of a union or a subobject thereof;
 
@@ -5438,8 +5438,8 @@ for a union whose active member (if any) is mutable,
 unless the lifetime of the union object began within the evaluation of \tcode{e};
 
 \item
-an assignment expression~(\ref{expr.ass})
-or invocation of an assignment operator~(\ref{class.copy})
+an assignment expression\iref{expr.ass}
+or invocation of an assignment operator\iref{class.copy}
 that would change the active member of a union;
 
 \item
@@ -5476,7 +5476,7 @@ void g() {
 If the odr-use occurs in an invocation
 of a function call operator of a closure type,
 it no longer refers to \tcode{this} or to an enclosing automatic variable
-due to the transformation~(\ref{expr.prim.lambda.capture})
+due to the transformation\iref{expr.prim.lambda.capture}
 of the \grammarterm{id-expression} into
 an access of the corresponding data member.
 \begin{example}
@@ -5496,13 +5496,13 @@ static_assert(bind(monad(2))(monad)() == monad(2)());
 a conversion from type \cv{}~\tcode{void*} to a pointer-to-object type;
 
 \item
-a dynamic cast~(\ref{expr.dynamic.cast});
+a dynamic cast\iref{expr.dynamic.cast};
 
 \item
-a \tcode{reinterpret_cast}~(\ref{expr.reinterpret.cast});
+a \tcode{reinterpret_cast}\iref{expr.reinterpret.cast};
 
 \item
-a pseudo-destructor call~(\ref{expr.pseudo});
+a pseudo-destructor call\iref{expr.pseudo};
 
 \item
 modification of an object~(\ref{expr.ass}, \ref{expr.post.incr},
@@ -5512,26 +5512,26 @@ that refers to a non-volatile object
 whose lifetime began within the evaluation of \tcode{e};
 
 \item
-a typeid expression~(\ref{expr.typeid}) whose operand is a glvalue of a
+a typeid expression\iref{expr.typeid} whose operand is a glvalue of a
 polymorphic class type;
 
 \item
-a \grammarterm{new-expression}~(\ref{expr.new});
+a \grammarterm{new-expression}\iref{expr.new};
 
 \item
-a \grammarterm{delete-expression}~(\ref{expr.delete});
+a \grammarterm{delete-expression}\iref{expr.delete};
 
 \item
-a relational~(\ref{expr.rel}) or equality~(\ref{expr.eq})
+a relational\iref{expr.rel} or equality\iref{expr.eq}
 operator where the result is unspecified; or
 
 \item
-a \grammarterm{throw-expression}~(\ref{expr.throw}).
+a \grammarterm{throw-expression}\iref{expr.throw}.
 \end{itemize}
 
 If \tcode{e} satisfies the constraints of a core constant expression, but
 evaluation of \tcode{e} would evaluate an operation that has undefined behavior
-as specified in Clauses~\ref{library} through~\ref{\lastlibchapter} of this
+as specified in \ref{library} through \ref{\lastlibchapter} of this
 International Standard, it is unspecified whether \tcode{e} is a core constant
 expression.
 
@@ -5581,9 +5581,9 @@ is an expression of integral or
 unscoped enumeration type, implicitly converted to a prvalue, where the converted expression is a core constant expression.
 \begin{note}
 Such expressions may be
-used as bit-field lengths~(\ref{class.bit}), as enumerator
-initializers if the underlying type is not fixed~(\ref{dcl.enum}),
-and as alignments~(\ref{dcl.align}).
+used as bit-field lengths\iref{class.bit}, as enumerator
+initializers if the underlying type is not fixed\iref{dcl.enum},
+and as alignments\iref{dcl.align}.
 \end{note}
 
 \pnum
@@ -5595,30 +5595,30 @@ implicit conversion sequence contains only
 
 \begin{itemize}
 \item user-defined conversions,
-\item lvalue-to-rvalue conversions~(\ref{conv.lval}),
-\item array-to-pointer conversions~(\ref{conv.array}),
-\item function-to-pointer conversions~(\ref{conv.func}),
-\item qualification conversions~(\ref{conv.qual}),
-\item integral promotions~(\ref{conv.prom}),
-\item integral conversions~(\ref{conv.integral}) other than narrowing conversions~(\ref{dcl.init.list}),
-\item null pointer conversions~(\ref{conv.ptr}) from \tcode{std::nullptr_t},
-\item null member pointer conversions~(\ref{conv.mem}) from \tcode{std::nullptr_t}, and
-\item function pointer conversions~(\ref{conv.fctptr}),
+\item lvalue-to-rvalue conversions\iref{conv.lval},
+\item array-to-pointer conversions\iref{conv.array},
+\item function-to-pointer conversions\iref{conv.func},
+\item qualification conversions\iref{conv.qual},
+\item integral promotions\iref{conv.prom},
+\item integral conversions\iref{conv.integral} other than narrowing conversions\iref{dcl.init.list},
+\item null pointer conversions\iref{conv.ptr} from \tcode{std::nullptr_t},
+\item null member pointer conversions\iref{conv.mem} from \tcode{std::nullptr_t}, and
+\item function pointer conversions\iref{conv.fctptr},
 \end{itemize}
 
 and where the reference binding (if any) binds directly.
 \begin{note}
 Such expressions may be used in \tcode{new}
-expressions~(\ref{expr.new}), as case expressions~(\ref{stmt.switch}),
+expressions\iref{expr.new}, as case expressions\iref{stmt.switch},
 as enumerator initializers if the underlying type is
-fixed~(\ref{dcl.enum}), as array bounds~(\ref{dcl.array}), and
+fixed\iref{dcl.enum}, as array bounds\iref{dcl.array}, and
 as non-type template
-arguments~(\ref{temp.arg}).
+arguments\iref{temp.arg}.
 \end{note}
 \indextext{contextually converted constant expression of type \tcode{bool}|see{conversion, contextual}}%
 \indextext{conversion!contextual to constant expression of type \tcode{bool}}%
 A \term{contextually converted constant expression of type \tcode{bool}} is
-an expression, contextually converted to \tcode{bool}~(Clause\ref{conv}),
+an expression, contextually converted to \tcode{bool}\iref{conv},
 where the converted expression is a constant expression and
 the conversion sequence contains only the conversions above.
 
@@ -5639,7 +5639,7 @@ satisfies the following constraints:
   \item
   if the value is of pointer type, it contains
   the address of an object with static storage duration,
-  the address past the end of such an object~(\ref{expr.add}),
+  the address past the end of such an object\iref{expr.add},
   the address of a function,
   or a null pointer value, and
 
@@ -5676,7 +5676,7 @@ It is unspecified whether the value of \tcode{f()} will be \tcode{true} or \tcod
 \pnum
 If an expression of literal class type is used in a context where an
 integral constant expression is required, then that expression is
-contextually implicitly converted (Clause~\ref{conv}) to an integral or unscoped
+contextually implicitly converted\iref{conv} to an integral or unscoped
 enumeration type
 and the selected conversion function shall be \tcode{constexpr}. \begin{example}
 \begin{codeblock}

--- a/source/future.tex
+++ b/source/future.tex
@@ -433,20 +433,18 @@ If
 \tcode{n < 0},
 \tcode{N} is
 \tcode{INT_MAX}.\footnote{The function signature
+\indexlibrary{\idxcode{strlen}}%
 \tcode{strlen(const char*)}
 is declared in
-\tcode{<cstring>}
-\indexlibrary{\idxcode{strlen}}%
 \indextext{\idxhdr{cstring}}%
 \indexlibrary{\idxhdr{cstring}}%
-(\ref{cstring.syn}).
+\tcode{<cstring>}\iref{cstring.syn}.
 The macro
 \tcode{INT_MAX}
 is defined in
-\tcode{<climits>}
 \indextext{\idxhdr{climits}}%
 \indexlibrary{\idxhdr{climits}}%
-(\ref{climits.syn}).}
+\tcode{<climits>}\iref{climits.syn}.}
 \end{itemize}
 
 \pnum
@@ -1044,13 +1042,12 @@ contains an \ntbs whose first element is designated by \tcode{s}.
 \indextext{NTBS}%
 The constructor is
 \tcode{strstreambuf(s, n, s + std::strlen(s))}.\footnote{The function signature
+\indexlibrary{\idxcode{strlen}}%
 \tcode{strlen(const char*)}
 is declared in
-\tcode{<cstring>}
-\indexlibrary{\idxcode{strlen}}%
 \indextext{\idxhdr{cstring}}%
 \indexlibrary{\idxhdr{cstring}}%
-(\ref{cstring.syn}).}
+\tcode{<cstring>}\iref{cstring.syn}.}
 \end{itemize}
 \end{itemdescr}
 

--- a/source/future.tex
+++ b/source/future.tex
@@ -12,7 +12,7 @@ is defined as:
 Normative for the current edition of this International Standard,
 but having been identified as a candidate for removal from future revisions.
 An implementation may declare library names and entities described in this section with the
-\tcode{deprecated} attribute~(\ref{dcl.attr.deprecated}).
+\tcode{deprecated} attribute\iref{dcl.attr.deprecated}.
 
 \rSec1[depr.static_constexpr]{Redeclaration of \tcode{static constexpr} data members}
 
@@ -41,7 +41,7 @@ definition of a copy assignment operator
 as defaulted is deprecated if the class has a user-declared
 copy constructor or a user-declared destructor~(\ref{class.dtor}, \ref{class.copy}).
 In a future revision of this International Standard, these implicit definitions
-could become deleted~(\ref{dcl.fct.def}).
+could become deleted\iref{dcl.fct.def}.
 
 \rSec1[depr.except.spec]{Deprecated exception specifications}
 
@@ -53,10 +53,10 @@ The \grammarterm{noexcept-specifier} \tcode{throw()} is deprecated.
 \pnum
 For compatibility with prior \Cpp International Standards,
 the \Cpp standard library provides headers
-\tcode{<ccomplex>}~(\ref{depr.ccomplex.syn}),
-\tcode{<cstdalign>}~(\ref{depr.cstdalign.syn}),
-\tcode{<cstdbool>}~(\ref{depr.cstdbool.syn}),
-and \tcode{<ctgmath>}~(\ref{depr.ctgmath.syn}).
+\tcode{<ccomplex>}\iref{depr.ccomplex.syn},
+\tcode{<cstdalign>}\iref{depr.cstdalign.syn},
+\tcode{<cstdbool>}\iref{depr.cstdbool.syn},
+and \tcode{<ctgmath>}\iref{depr.ctgmath.syn}.
 The use of these headers is deprecated.
 
 \rSec2[depr.ccomplex.syn]{Header \tcode{<ccomplex>} synopsis}
@@ -69,7 +69,7 @@ The use of these headers is deprecated.
 \pnum
 The header \tcode{<ccomplex>}
 behaves as if it simply includes the header
-\tcode{<complex>}~(\ref{complex.syn}).
+\tcode{<complex>}\iref{complex.syn}.
 
 \rSec2[depr.cstdalign.syn]{Header \tcode{<cstdalign>} synopsis}
 
@@ -116,8 +116,8 @@ define macros named \tcode{bool}, \tcode{true}, or \tcode{false}.
 
 \pnum
 The header \tcode{<ctgmath>} simply includes the headers
-\tcode{<complex>}~(\ref{complex.syn})
-and \tcode{<cmath>}~(\ref{cmath.syn}).
+\tcode{<complex>}\iref{complex.syn}
+and \tcode{<cmath>}\iref{cmath.syn}.
 
 \pnum
 \begin{note} The overloads provided in C by type-generic macros are already
@@ -185,12 +185,12 @@ the corresponding
 header is placed within
 the global namespace scope,
 except for the functions described in \ref{sf.cmath},
-the declaration of \tcode{std::byte}~(\ref{cstddef.syn}), and
+the declaration of \tcode{std::byte}\iref{cstddef.syn}, and
 the functions and function templates described in \ref{support.types.byteops}.
 It is unspecified whether these names are first declared or defined within
-namespace scope~(\ref{basic.scope.namespace}) of the namespace
+namespace scope\iref{basic.scope.namespace} of the namespace
 \tcode{std} and are then injected into the global namespace scope by
-explicit \grammarterm{using-declaration}{s}~(\ref{namespace.udecl}).
+explicit \grammarterm{using-declaration}{s}\iref{namespace.udecl}.
 \indextext{namespace}%
 
 \pnum
@@ -1288,7 +1288,7 @@ bool uncaught_exception() noexcept;
 \rSec2[depr.weak.result_type]{Weak result types}
 
 \pnum
-A call wrapper~(\ref{func.def}) may have a \defn{weak result type}.
+A call wrapper\iref{func.def} may have a \defn{weak result type}.
 If it does, the type of its member type \tcode{result_type}
 is based on the type \tcode{T} of the wrapper's target object:
 \begin{itemize}
@@ -1297,7 +1297,7 @@ is based on the type \tcode{T} of the wrapper's target object:
 \item if \tcode{T} is a pointer to member function,
 \tcode{result_type} shall be a synonym for the return type of \tcode{T};
 \item if \tcode{T} is a class type
-and the \grammarterm{qualified-id} \tcode{T::result_type} is valid and denotes a type~(\ref{temp.deduct}),
+and the \grammarterm{qualified-id} \tcode{T::result_type} is valid and denotes a type\iref{temp.deduct},
 then \tcode{result_type} shall be a synonym for \tcode{T::result_type};
 \item otherwise \tcode{result_type} shall not be defined.
 \end{itemize}
@@ -1315,7 +1315,7 @@ for function objects that take one argument and
 for function objects that take two arguments.
 
 \pnum
-The following member names are defined in addition to names specified in Clause~\ref{function.objects}:
+The following member names are defined in addition to names specified in \ref{function.objects}:
 
 \indexlibrarymember{result_type}{owner_less}%
 \indexlibrarymember{first_argument_type}{owner_less}%
@@ -1529,7 +1529,7 @@ namespace std {
 
 \indexlibrary{\idxcode{reference_wrapper}!weak result type}%
 \pnum
-\tcode{reference_wrapper<T>} has a weak result type~(\ref{depr.weak.result_type}).
+\tcode{reference_wrapper<T>} has a weak result type\iref{depr.weak.result_type}.
 If \tcode{T} is a function type,
 \tcode{result_type} shall be a synonym for the return type of \tcode{T}.
 
@@ -1543,7 +1543,7 @@ only if the type \tcode{T} is any of the following:
 \item a function type or a pointer to function type taking one argument of type \tcode{T1}
 \item a pointer to member function \tcode{R T0::f()} \cv{} (where \cv{} represents the member function's cv-qualifiers); the type \tcode{T1} is \cv{}~\tcode{T0*}
 \item a class type where the \grammarterm{qualified-id} \tcode{T::argument_type}
-is valid and denotes a type~(\ref{temp.deduct});
+is valid and denotes a type\iref{temp.deduct};
 the type \tcode{T1} is \tcode{T::argument_type}.
 \end{itemize}
 
@@ -1560,7 +1560,7 @@ only if the type \tcode{T} is any of the following:
 \item a pointer to member function \tcode{R T0::f(T2)} \cv{} (where \cv{} represents the member function's cv-qualifiers); the type \tcode{T1} is \cv{}~\tcode{T0*}
 \item a class type where the \grammarterm{qualified-id}{s}
 \tcode{T::first_argument_type} and \tcode{T::second_argument_type}
-are both valid and both denote types~(\ref{temp.deduct});
+are both valid and both denote types\iref{temp.deduct};
 the type \tcode{T1} is \tcode{T::first_argument_type} and
 the type \tcode{T2} is \tcode{T::second_argument_type}.
 \end{itemize}
@@ -1568,19 +1568,19 @@ the type \tcode{T2} is \tcode{T::second_argument_type}.
 \indexlibrarymember{result_type}{hash}%
 \indexlibrarymember{argument_type}{hash}%
 \pnum
-All enabled specializations \tcode{hash<Key>} of \tcode{hash}~(\ref{unord.hash})
+All enabled specializations \tcode{hash<Key>} of \tcode{hash}\iref{unord.hash}
 provide two nested types, \tcode{result_type} and \tcode{argument_type},
 which shall be synonyms for \tcode{size_t} and \tcode{Key}, respectively.
 
 \indexlibrary{\idxcode{bind}!weak result type}%
 \pnum
 The forwarding call wrapper \tcode{g}
-returned by a call to \tcode{bind(f, bound_args...)}~(\ref{func.bind.bind})
-shall have a weak result type~(\ref{depr.weak.result_type}).
+returned by a call to \tcode{bind(f, bound_args...)}\iref{func.bind.bind}
+shall have a weak result type\iref{depr.weak.result_type}.
 
 \pnum
 The forwarding call wrapper \tcode{g}
-returned by a call to \tcode{bind<R>(f, bound_args...)}~(\ref{func.bind.bind})
+returned by a call to \tcode{bind<R>(f, bound_args...)}\iref{func.bind.bind}
 shall have a nested type \tcode{result_type} defined as a synonym for \tcode{R}.
 
 \indexlibrarymember{result_type}{mem_fn}%
@@ -1620,7 +1620,7 @@ and taking one argument of type \tcode{T1},
 where \tcode{Ret} is \tcode{pm}{'s} return type.
 
 \pnum
-The following member names are defined in addition to names specified in Clause~\ref{containers}:
+The following member names are defined in addition to names specified in \ref{containers}:
 
 \indexlibrarymember{result_type}{map::value_compare}%
 \indexlibrarymember{first_argument_type}{map::value_compare}%
@@ -1674,7 +1674,7 @@ namespace std {
 \pnum
 Negators \tcode{not1} and \tcode{not2}
 take a unary and a binary predicate, respectively,
-and return their logical negations~(\ref{expr.unary.op}).
+and return their logical negations\iref{expr.unary.op}.
 
 \indexlibrary{\idxcode{unary_negate}}%
 \indexlibrarymember{argument_type}{unary_negate}%
@@ -1814,11 +1814,11 @@ T* allocate(size_t n, const void* hint);
 A pointer to the initial element of an array of storage of size \tcode{n}
 \tcode{* sizeof(T)}, aligned appropriately for objects of type \tcode{T}.
 It is \impldef{support for over-aligned types} whether over-aligned types are
-supported~(\ref{basic.align}).
+supported\iref{basic.align}.
 
 \pnum
 \remarks
-The storage is obtained by calling \tcode{::operator new(std::size_t)}~(\ref{new.delete}),
+The storage is obtained by calling \tcode{::operator new(std::size_t)}\iref{new.delete},
 but it is unspecified when or how often this function is called.
 
 \pnum
@@ -1900,7 +1900,7 @@ results into uninitialized memory. The template parameter
 \tcode{OutputIterator} is required to have its \tcode{operator*} return an
 object for which \tcode{operator\&} is defined and returns a pointer to
 \tcode{T}, and is also required to satisfy the requirements of an output
-iterator~(\ref{output.iterators}).
+iterator\iref{output.iterators}.
 
 \indexlibrary{\idxcode{raw_storage_iterator}!constructor}%
 \begin{itemdecl}
@@ -2026,7 +2026,7 @@ template <class T>
 Obtains a pointer to uninitialized, contiguous storage for $N$ adjacent
 objects of type \tcode{T}, for some non-negative number $N$.
 It is \impldef{support for over-aligned types} whether over-aligned types are
-supported~(\ref{basic.align}).
+supported\iref{basic.align}.
 
 \pnum
 \remarks
@@ -2100,9 +2100,9 @@ For \tcode{result_of<Fn(ArgTypes...)>},
 \cv{}~\tcode{void}, or arrays of unknown bound.
 
 \pnum
-\tcode{is_literal_type<T>} is a \tcode{UnaryTypeTrait}~(\ref{meta.rqmts})
+\tcode{is_literal_type<T>} is a \tcode{UnaryTypeTrait}\iref{meta.rqmts}
 with a base characteristic of \tcode{true_type}
-if \tcode{T} is a literal type~(\ref{basic.types}), and
+if \tcode{T} is a literal type\iref{basic.types}, and
 \tcode{false_type} otherwise.
 The partial specialization \tcode{result_of<Fn(ArgTypes...)>} is a
 \tcode{TransformationTrait} whose member typedef \tcode{type} is defined

--- a/source/grammar.tex
+++ b/source/grammar.tex
@@ -17,10 +17,10 @@ to weed out syntactically valid but meaningless constructs.
 \pnum
 \indextext{keyword}%
 New context-dependent keywords are introduced into a program by
-\tcode{typedef}~(\ref{dcl.typedef}),
-\tcode{namespace}~(\ref{namespace.def}),
-class~(Clause \ref{class}), enumeration~(\ref{dcl.enum}), and
-\tcode{template}~(Clause \ref{temp})
+\tcode{typedef}\iref{dcl.typedef},
+\tcode{namespace}\iref{namespace.def},
+class\iref{class}, enumeration\iref{dcl.enum}, and
+\tcode{template}\iref{temp}
 declarations.
 
 \begin{ncbnf}

--- a/source/grammar.tex
+++ b/source/grammar.tex
@@ -3,10 +3,10 @@
 \pnum
 \indextext{grammar}%
 \indextext{summary!syntax}%
-This summary of \Cpp\  grammar is intended to be an aid to comprehension.
+This summary of \Cpp grammar is intended to be an aid to comprehension.
 It is not an exact statement of the language.
 In particular, the grammar described here accepts
-a superset of valid \Cpp\  constructs.
+a superset of valid \Cpp constructs.
 Disambiguation rules~(\ref{stmt.ambig}, \ref{dcl.spec}, \ref{class.member.lookup})
 must be applied to distinguish expressions from declarations.
 Further, access control, ambiguity, and type rules must be used
@@ -54,9 +54,8 @@ template-name:\br
 \end{ncbnf}
 
 Note that a
-\grammarterm{typedef-name}\
+\grammarterm{typedef-name}
 naming a class is also a
-\grammarterm{class-name}\
-(\ref{class.name}).
+\grammarterm{class-name}\iref{class.name}.
 
 \FlushAndPrintGrammar

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -603,8 +603,8 @@ used to access them.
 \indextext{subobject}%
 Objects can contain other objects, called \defnx{subobjects}{subobject}.
 A subobject can be
-a \defn{member subobject}\iref{class.mem}, a \defn{base class subobject}
-(\ref{class.derived}), or an array element.
+a \defn{member subobject}\iref{class.mem}, a \defn{base class subobject}\iref{class.derived},
+or an array element.
 \indextext{object!complete}%
 An object that is not a subobject of any other object is called a \defn{complete
 object}.

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -56,8 +56,8 @@ to be used in the natural sciences and technology}
 The library described in Clause 7 of ISO/IEC 9899:2011
 is hereinafter called the
 \defnx{C standard library}{C!standard library}.%
-\footnote{With the qualifications noted in Clauses~\ref{\firstlibchapter}
-through~\ref{\lastlibchapter} and in~\ref{diff.library}, the C standard
+\footnote{With the qualifications noted in \ref{\firstlibchapter}
+through \ref{\lastlibchapter} and in \ref{diff.library}, the C standard
 library is a subset of the \Cpp standard library.}
 
 \pnum
@@ -91,8 +91,8 @@ at the following addresses:
 
 \pnum
 \ref{definitions}
-defines additional terms that are used only in Clauses~\ref{library}
-through~\ref{\lastlibchapter} and Annex~\ref{depr}.
+defines additional terms that are used only in \ref{library}
+through \ref{\lastlibchapter} and \ref{depr}.
 
 \pnum
 Terms that are used only in a small portion of this document
@@ -109,18 +109,18 @@ defined.
 \indexdefn{argument!function call expression}
 \definition{argument}{defns.argument}
 \defncontext{function call expression} expression in the
-comma-separated list bounded by the parentheses~(\ref{expr.call})
+comma-separated list bounded by the parentheses\iref{expr.call}
 
 \indexdefn{argument}%
 \indexdefn{argument!function-like macro}%
 \definition{argument}{defns.argument.macro}
 \defncontext{function-like macro} sequence of preprocessing tokens in the
-comma-separated list bounded by the parentheses~(\ref{cpp.replace})
+comma-separated list bounded by the parentheses\iref{cpp.replace}
 
 \indexdefn{argument}%
 \indexdefn{argument!throw expression}%
 \definition{argument}{defns.argument.throw}
-\defncontext{throw expression} the operand of \tcode{throw}~(\ref{expr.throw})
+\defncontext{throw expression} the operand of \tcode{throw}\iref{expr.throw}
 
 \indexdefn{argument}%
 \indexdefn{argument!template instantiation}%
@@ -129,7 +129,7 @@ comma-separated list bounded by the parentheses~(\ref{cpp.replace})
 \grammarterm{constant-expression},
 \grammarterm{type-id}, or
 \grammarterm{id-expression} in the comma-separated
-list bounded by the angle brackets~(\ref{temp.arg})
+list bounded by the angle brackets\iref{temp.arg}
 
 \indexdefn{block}%
 \definition{block}{defns.block}
@@ -150,13 +150,13 @@ implementation's output messages
 
 \indexdefn{type!dynamic}%
 \definition{dynamic type}{defns.dynamic.type}
-\defncontext{glvalue} type of the most derived object~(\ref{intro.object}) to which the
+\defncontext{glvalue} type of the most derived object\iref{intro.object} to which the
 glvalue refers\\
 \begin{example}
-If a pointer~(\ref{dcl.ptr}) \tcode{p} whose static type is ``pointer to
+If a pointer\iref{dcl.ptr} \tcode{p} whose static type is ``pointer to
 class \tcode{B}'' is pointing to an object of class \tcode{D}, derived
-from \tcode{B} (Clause~\ref{class.derived}), the dynamic type of the
-expression \tcode{*p} is ``\tcode{D}''. References~(\ref{dcl.ref}) are
+from \tcode{B}\iref{class.derived}, the dynamic type of the
+expression \tcode{*p} is ``\tcode{D}''. References\iref{dcl.ref} are
 treated similarly.
 \end{example}
 
@@ -166,7 +166,7 @@ treated similarly.
 
 \indexdefn{program!ill-formed}%
 \definition{ill-formed program}{defns.ill.formed}
-program that is not well-formed~(\ref{defns.well.formed})
+program that is not well-formed\iref{defns.well.formed}
 
 \indexdefn{behavior!implementation-defined}%
 \definition{implementation-defined behavior}{defns.impl.defined}
@@ -188,7 +188,7 @@ sequence of one or more bytes representing a member of the extended
 character set of either the source or the execution environment\\
 \begin{note} The
 extended character set is a superset of the basic character
-set~(\ref{lex.charset}).\end{note}
+set\iref{lex.charset}.\end{note}
 
 \indexdefn{parameter}%
 \indexdefn{parameter!function}%
@@ -214,10 +214,10 @@ following the macro name
 \definition{signature}{defns.signature}
 \defncontext{function}
 name,
-parameter type list~(\ref{dcl.fct}),
+parameter type list\iref{dcl.fct},
 enclosing namespace (if any),
 and
-\grammarterm{requires-clause}~(\ref{temp.constr.decl}) (if any)
+\grammarterm{requires-clause}\iref{temp.constr.decl} (if any)
 \begin{note} Signatures are used as a basis for
 name mangling and linking.\end{note}
 
@@ -225,12 +225,12 @@ name mangling and linking.\end{note}
 \definition{signature}{defns.signature.templ}
 \defncontext{function template}
 name,
-parameter type list~(\ref{dcl.fct}),
+parameter type list\iref{dcl.fct},
 enclosing namespace (if any),
 return type,
 \grammarterm{template-head},
 and
-\grammarterm{requires-clause}~(\ref{temp.constr.decl}) (if any)
+\grammarterm{requires-clause}\iref{temp.constr.decl} (if any)
 
 \indexdefn{signature}%
 \definition{signature}{defns.signature.spec}
@@ -241,25 +241,25 @@ and its template arguments (whether explicitly specified or deduced)
 \definition{signature}{defns.signature.member}
 \defncontext{class member function}
 name,
-parameter type list~(\ref{dcl.fct}),
+parameter type list\iref{dcl.fct},
 class of which the function is a member,
 \cv-qualifiers (if any),
 \grammarterm{ref-qualifier} (if any),
 and
-\grammarterm{requires-clause}~(\ref{temp.constr.decl}) (if any)
+\grammarterm{requires-clause}\iref{temp.constr.decl} (if any)
 
 \indexdefn{signature}%
 \definition{signature}{defns.signature.member.templ}
 \defncontext{class member function template}
 name,
-parameter type list~(\ref{dcl.fct}),
+parameter type list\iref{dcl.fct},
 class of which the function is a member,
 \cv-qualifiers (if any),
 \grammarterm{ref-qualifier} (if any),
 return type (if any),
 \grammarterm{template-head},
 and
-\grammarterm{requires-clause}~(\ref{temp.constr.decl}) (if any)
+\grammarterm{requires-clause}\iref{temp.constr.decl} (if any)
 
 \indexdefn{signature}%
 \definition{signature}{defns.signature.member.spec}
@@ -268,7 +268,7 @@ of which it is a specialization and its template arguments (whether explicitly s
 
 \indexdefn{type!static}%
 \definition{static type}{defns.static.type}
-type of an expression~(\ref{basic.types}) resulting from
+type of an expression\iref{basic.types} resulting from
 analysis of the program without considering execution semantics\\
 \begin{note} The
 static type of an expression depends only on the form of the program in
@@ -294,7 +294,7 @@ diagnostic message), to terminating a translation or execution (with the
 issuance of a diagnostic message). Many erroneous program constructs do
 not engender undefined behavior; they are required to be diagnosed.
 Evaluation of a constant expression never exhibits behavior explicitly
-specified as undefined~(\ref{expr.const}).
+specified as undefined\iref{expr.const}.
 \end{note}
 
 \indexdefn{behavior!unspecified}%
@@ -309,7 +309,7 @@ possible behaviors is usually delineated by this International Standard.
 \indexdefn{program!well-formed}%
 \definition{well-formed program}{defns.well.formed}
 \Cpp  program constructed according to the syntax rules, diagnosable
-semantic rules, and the one-definition rule~(\ref{basic.def.odr}).%
+semantic rules, and the one-definition rule\iref{basic.def.odr}.%
 \indextext{definitions|)}
 
 \rSec0[intro]{General principles}
@@ -359,7 +359,7 @@ execution of programs. Such requirements have the following meaning:
 If a program contains no violations of the rules in this
 International Standard, a conforming implementation shall,
 within its resource limits, accept and correctly execute\footnote{``Correct execution'' can include undefined behavior, depending on
-the data being processed; see Clause~\ref{intro.defs} and~\ref{intro.execution}.}
+the data being processed; see \ref{intro.defs} and~\ref{intro.execution}.}
 that program.
 \item
 \indextext{message!diagnostic}%
@@ -385,7 +385,7 @@ see~\ref{temp.deduct}.
 \indextext{conformance requirements!classes}%
 \indextext{conformance requirements!class templates}%
 For classes and class templates, the library Clauses specify partial
-definitions. Private members~(Clause~\ref{class.access}) are not
+definitions. Private members\iref{class.access} are not
 specified, but each implementation shall supply them to complete the
 definitions according to the description in the library Clauses.
 
@@ -396,15 +396,15 @@ consistent with the descriptions in the library Clauses.
 
 \pnum
 The names defined in the library have namespace
-scope~(\ref{basic.namespace}). A \Cpp  translation
-unit~(\ref{lex.phases}) obtains access to these names by including the
-appropriate standard library header~(\ref{cpp.include}).
+scope\iref{basic.namespace}. A \Cpp  translation
+unit\iref{lex.phases} obtains access to these names by including the
+appropriate standard library header\iref{cpp.include}.
 
 \pnum
 The templates, classes, functions, and objects in the library have
-external linkage~(\ref{basic.link}). The implementation provides
+external linkage\iref{basic.link}. The implementation provides
 definitions for standard library entities, as necessary, while combining
-translation units to form a complete \Cpp  program~(\ref{lex.phases}).%
+translation units to form a complete \Cpp  program\iref{lex.phases}.%
 \indextext{conformance requirements!library|)}
 
 \pnum
@@ -414,7 +414,7 @@ International Standard defines the set of available libraries. A freestanding
 implementation is one in which execution may take place without the benefit of
 an operating system, and has an \impldef{required libraries for freestanding
 implementation} set of libraries that includes certain language-support
-libraries~(\ref{compliance}).
+libraries\iref{compliance}.
 
 \pnum
 A conforming implementation may have extensions (including
@@ -437,27 +437,27 @@ see~\ref{intro.execution}.}%
 \pnum
 \indextext{standard!structure of|(}%
 \indextext{standard!structure of}%
-Clauses~\ref{lex} through~\ref{cpp} describe the \Cpp  programming
+\ref{lex} through \ref{cpp} describe the \Cpp  programming
 language. That description includes detailed syntactic specifications in
-a form described in~\ref{syntax}. For convenience, Annex~\ref{gram}
+a form described in~\ref{syntax}. For convenience, \ref{gram}
 repeats all such syntactic specifications.
 
 \pnum
-Clauses~\ref{\firstlibchapter} through~\ref{\lastlibchapter} and Annex~\ref{depr}
+\ref{\firstlibchapter} through \ref{\lastlibchapter} and \ref{depr}
 (the \defn{library clauses}) describe the \Cpp standard library.
 That description includes detailed descriptions of the
 entities and macros
-that constitute the library, in a form described in Clause~\ref{library}.
+that constitute the library, in a form described in \ref{library}.
 
 \pnum
-Annex~\ref{implimits} recommends lower bounds on the capacity of conforming
+\ref{implimits} recommends lower bounds on the capacity of conforming
 implementations.
 
 \pnum
-Annex~\ref{diff} summarizes the evolution of \Cpp  since its first
+\ref{diff} summarizes the evolution of \Cpp  since its first
 published description, and explains in detail the differences between
 \Cpp  and C\@. Certain features of \Cpp  exist solely for compatibility
-purposes; Annex~\ref{depr} describes those features.
+purposes; \ref{depr} describes those features.
 
 \pnum
 Throughout this document, each example is introduced by
@@ -510,7 +510,7 @@ The fundamental storage unit in the \Cpp memory model is the
 \defn{byte}.
 A byte is at least large enough to contain any member of the basic
 \indextext{character set!basic execution}%
-execution character set~(\ref{lex.charset})
+execution character set\iref{lex.charset}
 and the eight-bit code units of the Unicode UTF-8 encoding form
 and is composed of a contiguous sequence of
 bits,\footnote{The number of bits in a byte is reported by the macro
@@ -531,7 +531,7 @@ sequence of adjacent bit-fields all having nonzero width. \begin{note} Various
 features of the language, such as references and virtual functions, might
 involve additional memory locations that are not accessible to programs but are
 managed by the implementation. \end{note} Two or more threads of
-execution~(\ref{intro.multithread}) can access separate memory
+execution\iref{intro.multithread} can access separate memory
 locations without interfering with each other.
 
 \pnum
@@ -573,38 +573,38 @@ bit-fields \tcode{b} and \tcode{c} cannot be concurrently modified, but
 The constructs in a \Cpp program create, destroy, refer to, access, and
 manipulate objects.
 An \defn{object} is created
-by a definition~(\ref{basic.def}),
-by a \grammarterm{new-expression}~(\ref{expr.new}),
-when implicitly changing the active member of a union~(\ref{class.union}),
+by a definition\iref{basic.def},
+by a \grammarterm{new-expression}\iref{expr.new},
+when implicitly changing the active member of a union\iref{class.union},
 or
 when a temporary object is created~(\ref{conv.rval}, \ref{class.temporary}).
 An object occupies a region of storage
-in its period of construction~(\ref{class.cdtor}),
-throughout its lifetime~(\ref{basic.life}),
+in its period of construction\iref{class.cdtor},
+throughout its lifetime\iref{basic.life},
 and
-in its period of destruction~(\ref{class.cdtor}).
+in its period of destruction\iref{class.cdtor}.
 \begin{note} A function is not an object, regardless of whether or not it
 occupies storage in the way that objects do. \end{note}
 The properties of an
 object are determined when the object is created. An object can have a
-name~(Clause~\ref{basic}). An object has a storage
-duration~(\ref{basic.stc}) which influences its
-lifetime~(\ref{basic.life}). An object has a
-type~(\ref{basic.types}).
+name\iref{basic}. An object has a storage
+duration\iref{basic.stc} which influences its
+lifetime\iref{basic.life}. An object has a
+type\iref{basic.types}.
 Some objects are
-polymorphic~(\ref{class.virtual}); the implementation
+polymorphic\iref{class.virtual}; the implementation
 generates information associated with each such object that makes it
 possible to determine that object's type during program execution. For
 other objects, the interpretation of the values found therein is
-determined by the type of the \grammarterm{expression}{s} (Clause~\ref{expr})
+determined by the type of the \grammarterm{expression}{s}\iref{expr}
 used to access them.
 
 \pnum
 \indextext{subobject}%
 Objects can contain other objects, called \defnx{subobjects}{subobject}.
 A subobject can be
-a \defn{member subobject}~(\ref{class.mem}), a \defn{base class subobject}
-(Clause~\ref{class.derived}), or an array element.
+a \defn{member subobject}\iref{class.mem}, a \defn{base class subobject}
+(\ref{class.derived}), or an array element.
 \indextext{object!complete}%
 An object that is not a subobject of any other object is called a \defn{complete
 object}.
@@ -623,7 +623,7 @@ the new object is of the same type as \placeholder{e} (ignoring cv-qualification
 \end{itemize}
 \begin{note}
 If the subobject contains a reference member or a \tcode{const} subobject,
-the name of the original subobject cannot be used to access the new object~(\ref{basic.life}).
+the name of the original subobject cannot be used to access the new object\iref{basic.life}.
 \end{note}
 \begin{example}
 \begin{codeblock}
@@ -631,7 +631,7 @@ struct X { const int n; };
 union U { X x; float f; };
 void tong() {
   U u = {{ 1 }};
-  u.f = 5.f;                          // OK, creates new subobject of \tcode{u}~(\ref{class.union})
+  u.f = 5.f;                          // OK, creates new subobject of \tcode{u}\iref{class.union}
   X *p = new (&u.x) X {2};            // OK, creates new subobject of \tcode{u}
   assert(p->n == 2);                  // OK
   assert(*std::launder(&u.x.n) == 2); // OK
@@ -642,10 +642,10 @@ void tong() {
 
 \pnum
 \indextext{object!providing storage for}%
-If a complete object is created~(\ref{expr.new})
+If a complete object is created\iref{expr.new}
 in storage associated with another object \placeholder{e}
 of type ``array of $N$ \tcode{unsigned char}'' or
-of type ``array of $N$ \tcode{std::byte}''~(\ref{cstddef.syn}),
+of type ``array of $N$ \tcode{std::byte}''\iref{cstddef.syn},
 that array \defn{provides storage}
 for the created object if:
 \begin{itemize}
@@ -660,7 +660,7 @@ there is no smaller array object that satisfies these constraints.
 If that portion of the array
 previously provided storage for another object,
 the lifetime of that object ends
-because its storage was reused~(\ref{basic.life}).
+because its storage was reused\iref{basic.life}.
 \end{note}
 \begin{example}
 \begin{codeblock}
@@ -714,7 +714,7 @@ of the (unique) object that contains \tcode{x}.
 \end{itemize}
 
 \pnum
-If a complete object, a data member~(\ref{class.mem}), or an array element is of
+If a complete object, a data member\iref{class.mem}, or an array element is of
 class type, its type is considered the \defn{most derived
 class}, to distinguish it from the class type of any base class subobject;
 an object of a most derived class type or of a non-class type is called a
@@ -722,10 +722,10 @@ an object of a most derived class type or of a non-class type is called a
 
 \pnum
 \indextext{most derived object!bit-field}%
-Unless it is a bit-field~(\ref{class.bit}), a most derived object shall have a
+Unless it is a bit-field\iref{class.bit}, a most derived object shall have a
 nonzero size and shall occupy one or more bytes of storage. Base class
 subobjects may have zero size. An object of trivially copyable or
-standard-layout type~(\ref{basic.types}) shall occupy contiguous bytes of
+standard-layout type\iref{basic.types} shall occupy contiguous bytes of
 storage.
 
 \pnum
@@ -744,7 +744,7 @@ and they are of different types;
 otherwise, they have distinct addresses.\footnote{Under the ``as-if'' rule an
 implementation is allowed to store two objects at the same machine address or
 not store an object at all if the program cannot observe the
-difference~(\ref{intro.execution}).}
+difference\iref{intro.execution}.}
 
 \begin{example}
 \begin{codeblock}
@@ -757,7 +757,7 @@ const bool b = &test1 != &test2;      // always \tcode{true}
 \pnum
 \begin{note}
 \Cpp  provides a variety of fundamental types and several ways of composing
-new types from existing types~(\ref{basic.types}).
+new types from existing types\iref{basic.types}.
 \end{note}%
 \indextext{object model|)}
 
@@ -802,7 +802,7 @@ abstract machine that corresponds to that implementation (referred to as the
 Certain other aspects and operations of the abstract machine are
 described in this International Standard as unspecified (for example,
 evaluation of expressions in a \grammarterm{new-initializer} if the allocation
-function fails to allocate memory~(\ref{expr.new})). Where possible, this
+function fails to allocate memory\iref{expr.new}). Where possible, this
 International Standard defines a set of allowable behaviors. These
 define the nondeterministic aspects of the abstract machine. An instance
 of the abstract machine can thus have more than one possible execution
@@ -831,7 +831,7 @@ operation).
 
 \pnum
 An instance of each object with automatic storage
-duration~(\ref{basic.stc.auto}) is associated with each entry into its
+duration\iref{basic.stc.auto} is associated with each entry into its
 block. Such an object exists and retains its last-stored value during
 the execution of the block and while the block is suspended (by a call
 of a function or receipt of a signal).
@@ -931,20 +931,20 @@ used for the initialization of \tcode{b} are \tcode{5} and \tcode{1+1}.
 The \defnx{immediate subexpressions}{immediate subexpression} of an expression \tcode{e} are
 \begin{itemize}
 \item
-the constituent expressions of \tcode{e}'s operands (Clause \ref{expr}),
+the constituent expressions of \tcode{e}'s operands\iref{expr},
 \item
 any function call that \tcode{e} implicitly invokes,
 \item
-if \tcode{e} is a \grammarterm{lambda-expression}~(\ref{expr.prim.lambda}),
+if \tcode{e} is a \grammarterm{lambda-expression}\iref{expr.prim.lambda},
 the initialization of the entities captured by copy and
 the constituent expressions of the \grammarterm{initializer} of the \grammarterm{init-capture}{s},
 \item
-if \tcode{e} is a function call~(\ref{expr.call}) or implicitly invokes a function,
-the constituent expressions of each default argument~(\ref{dcl.fct.default})
+if \tcode{e} is a function call\iref{expr.call} or implicitly invokes a function,
+the constituent expressions of each default argument\iref{dcl.fct.default}
 used in the call, or
 \item
-if \tcode{e} creates an aggregate object~(\ref{dcl.init.aggr}),
-the constituent expressions of each default member initializer~(\ref{class.mem})
+if \tcode{e} creates an aggregate object\iref{dcl.init.aggr},
+the constituent expressions of each default member initializer\iref{class.mem}
 used in the initialization.
 \end{itemize}
 
@@ -961,16 +961,16 @@ are not subexpressions of the \grammarterm{lambda-expression}.
 A \defn{full-expression} is
 \begin{itemize}
 \item
-an unevaluated operand (Clause \ref{expr}),
+an unevaluated operand\iref{expr},
 \item
-a \grammarterm{constant-expression}~(\ref{expr.const}),
+a \grammarterm{constant-expression}\iref{expr.const},
 \item
-an \grammarterm{init-declarator} (Clause \ref{dcl.decl}) or
-a \grammarterm{mem-initializer}~(\ref{class.base.init}),
+an \grammarterm{init-declarator}\iref{dcl.decl} or
+a \grammarterm{mem-initializer}\iref{class.base.init},
 including the constituent expressions of the initializer,
 \item
 an invocation of a destructor generated at the end of the lifetime
-of an object other than a temporary object~(\ref{class.temporary}), or
+of an object other than a temporary object\iref{class.temporary}, or
 \item
 an expression that is not a subexpression of another expression and
 that is not otherwise part of a full-expression.
@@ -1017,14 +1017,14 @@ struct B {
 \begin{note} The evaluation of a full-expression can include the
 evaluation of subexpressions that are not lexically part of the
 full-expression. For example, subexpressions involved in evaluating
-default arguments~(\ref{dcl.fct.default}) are considered to
+default arguments\iref{dcl.fct.default} are considered to
 be created in the expression that calls the function, not the expression
 that defines the default argument. \end{note}
 
 \pnum
 \indextext{value computation|(}%
 Reading an object designated by a \tcode{volatile}
-glvalue~(\ref{basic.lval}), modifying an object, calling a library I/O
+glvalue\iref{basic.lval}, modifying an object, calling a library I/O
 function, or calling a function that does any of those operations are
 all
 \defn{side effects}, which are changes in the state of the execution
@@ -1040,7 +1040,7 @@ may not have completed yet.
 
 \pnum
 \defnx{Sequenced before}{sequenced before} is an asymmetric, transitive, pair-wise relation between
-evaluations executed by a single thread~(\ref{intro.multithread}), which induces
+evaluations executed by a single thread\iref{intro.multithread}, which induces
 a partial order among those evaluations. Given any two evaluations \placeholder{A} and
 \placeholder{B}, if \placeholder{A} is sequenced before \placeholder{B}
 (or, equivalently, \placeholder{B} is \defn{sequenced after} \placeholder{A}),
@@ -1085,10 +1085,10 @@ evaluations. \end{note} The value computations of the operands of an
 operator are sequenced before the value computation of the result of the
 operator. If a
 \indextext{side effects}%
-side effect on a memory location~(\ref{intro.memory}) is unsequenced
+side effect on a memory location\iref{intro.memory} is unsequenced
 relative to either another side effect on the same memory location or
 a value computation using the value of any object in the same memory location,
-and they are not potentially concurrent~(\ref{intro.multithread}),
+and they are not potentially concurrent\iref{intro.multithread},
 the behavior is undefined.
 \begin{note}
 The next section imposes similar, but more complex restrictions on
@@ -1134,7 +1134,7 @@ unit.
 \begin{example}
 Evaluation of a \grammarterm{new-expression} invokes one or more allocation
 and constructor functions; see~\ref{expr.new}. For another example,
-invocation of a conversion function~(\ref{class.conv.fct}) can arise in
+invocation of a conversion function\iref{class.conv.fct} can arise in
 contexts in which no function call syntax appears.
 \end{example}
 The sequencing constraints on the execution of the called function (as
@@ -1165,9 +1165,9 @@ subsequently executed by the thread. \begin{note} When one thread creates anothe
 the initial call to the top-level function of the new thread is executed by the
 new thread, not by the creating thread. \end{note} Every thread in a program can
 potentially access every object and function in a program.\footnote{An object
-with automatic or thread storage duration~(\ref{basic.stc}) is associated with
+with automatic or thread storage duration\iref{basic.stc} is associated with
 one specific thread, and can be accessed by a different thread only indirectly
-through a pointer or reference~(\ref{basic.compound}).} Under a hosted
+through a pointer or reference\iref{basic.compound}.} Under a hosted
 implementation, a \Cpp program can have more than one thread running
 concurrently. The execution of each thread proceeds as defined by the remainder
 of this International Standard. The execution of the entire program consists of an execution
@@ -1196,12 +1196,12 @@ simpler view for more restricted programs. \end{note}
 
 \pnum
 Two expression evaluations \defn{conflict} if one of them modifies a memory
-location~(\ref{intro.memory}) and the other one reads or modifies the same
+location\iref{intro.memory} and the other one reads or modifies the same
 memory location.
 
 \pnum
-The library defines a number of atomic operations (Clause~\ref{atomics}) and
-operations on mutexes (Clause~\ref{thread}) that are specially identified as
+The library defines a number of atomic operations\iref{atomics} and
+operations on mutexes\iref{thread} that are specially identified as
 synchronization operations. These operations play a special role in making
 assignments in one thread visible to another. A synchronization operation on one
 or more memory locations is either a consume operation, an acquire operation, a
@@ -1247,7 +1247,7 @@ every subsequent operation
 \pnum
 Certain library calls \defn{synchronize with} other library calls performed by
 another thread. For example, an atomic store-release synchronizes with a
-load-acquire that takes its value from the store~(\ref{atomics.order}).
+load-acquire that takes its value from the store\iref{atomics.order}.
 \begin{note} Except in the specified cases, reading a later value does not
 necessarily ensure visibility as described below. Such a requirement would
 sometimes interfere with efficient implementation. \end{note} \begin{note} The
@@ -1265,7 +1265,7 @@ the value of \placeholder{A} is used as an operand of \placeholder{B}, unless:
 \begin{itemize}
 \item
 \placeholder{B} is an invocation of any specialization of
-\tcode{std::kill_dependency}~(\ref{atomics.order}), or
+\tcode{std::kill_dependency}\iref{atomics.order}, or
 \item
 \placeholder{A} is the left operand of a built-in logical AND (\tcode{\&\&},
 see~\ref{expr.log.and}) or logical OR (\tcode{||}, see~\ref{expr.log.or})
@@ -1275,7 +1275,7 @@ operator, or
 operator, or
 \item
 \placeholder{A} is the left operand of the built-in comma (\tcode{,})
-operator~(\ref{expr.comma}); \end{itemize} or
+operator\iref{expr.comma}; \end{itemize} or
 \item
 \placeholder{A} writes a scalar object or bit-field \placeholder{M}, \placeholder{B} reads the value
 written by \placeholder{A} from \placeholder{M}, and \placeholder{A} is sequenced before \placeholder{B}, or
@@ -1533,12 +1533,12 @@ empty loops, even when termination cannot be proven. \end{note}
 
 \pnum
 Executions of atomic functions
-that are either defined to be lock-free~(\ref{atomics.flag})
-or indicated as lock-free~(\ref{atomics.lockfree})
+that are either defined to be lock-free\iref{atomics.flag}
+or indicated as lock-free\iref{atomics.lockfree}
 are \defnx{lock-free executions}{lock-free execution}.
 \begin{itemize}
 \item
-  If there is only one thread that is not blocked~(\ref{defns.block})
+  If there is only one thread that is not blocked\iref{defns.block}
   in a standard library function,
   a lock-free execution in that thread shall complete.
   \begin{note}
@@ -1583,7 +1583,7 @@ an \defn{execution step}:
 \end{itemize}
 
 \pnum
-An invocation of a standard library function that blocks~(\ref{defns.block})
+An invocation of a standard library function that blocks\iref{defns.block}
 is considered to continuously execute execution steps while waiting for the
 condition that it blocks on to be satisfied.
 \begin{example}
@@ -1621,8 +1621,8 @@ this will happen in an unspecified but finite amount of time.
 It is \impldef{whether the thread that executes \tcode{main} and the threads created
 by \tcode{std::thread} provide concurrent forward progress guarantees} whether the
 implementation-created thread of execution that executes
-\tcode{main}~(\ref{basic.start.main}) and the threads of execution created by
-\tcode{std::thread}~(\ref{thread.thread.class}) provide concurrent forward progress
+\tcode{main}\iref{basic.start.main} and the threads of execution created by
+\tcode{std::thread}\iref{thread.thread.class} provide concurrent forward progress
 guarantees.
 \begin{note}
 General-purpose implementations should provide these guarantees.

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -53,7 +53,7 @@ is an alias (e.g. a typedef) for \textbf{B} or that \textbf{A} is defined in ter
 \rSec2[iostream.limits.imbue]{Imbue limitations}
 
 \pnum
-No function described in Clause~\ref{input.output} except for
+No function described in \ref{input.output} except for
 \tcode{ios_base::imbue}
 and \tcode{basic_filebuf::pubimbue}
 causes any instance of
@@ -61,8 +61,8 @@ causes any instance of
 or
 \tcode{basic_streambuf::imbue}
 to be called.
-If any user function called from a function declared in Clause~\ref{input.output} or
-as an overriding virtual function of any class declared in Clause~\ref{input.output}
+If any user function called from a function declared in \ref{input.output} or
+as an overriding virtual function of any class declared in \ref{input.output}
 calls
 \tcode{imbue},
 the behavior is undefined.
@@ -70,7 +70,7 @@ the behavior is undefined.
 \rSec2[iostreams.limits.pos]{Positioning type limitations}
 
 \pnum
-The classes of Clause~\ref{input.output} with template arguments
+The classes of \ref{input.output} with template arguments
 \tcode{charT}
 and
 \tcode{traits}
@@ -92,7 +92,7 @@ are other types is
 \tcode{streampos} or when \tcode{traits::\brk{}off_type} is not \tcode{streamoff}}.
 
 \pnum
-In the classes of Clause~\ref{input.output}, a template parameter with name
+In the classes of \ref{input.output}, a template parameter with name
 \tcode{charT} represents a member of the set of types containing \tcode{char}, \tcode{wchar_t},
 and any other \impldef{set of character types that iostreams templates can be instantiated for}
 character types that satisfy the requirements for a character on which any of
@@ -102,9 +102,9 @@ the iostream components can be instantiated.
 
 \pnum
 Concurrent access to a stream object~(\ref{string.streams}, \ref{file.streams}), stream buffer
-object~(\ref{stream.buffers}), or C Library stream~(\ref{c.files}) by multiple threads may result in
-a data race~(\ref{intro.multithread}) unless otherwise specified~(\ref{iostream.objects}).
-\begin{note} Data races result in undefined behavior~(\ref{intro.multithread}). \end{note}
+object\iref{stream.buffers}, or C Library stream\iref{c.files} by multiple threads may result in
+a data race\iref{intro.multithread} unless otherwise specified\iref{iostream.objects}.
+\begin{note} Data races result in undefined behavior\iref{intro.multithread}. \end{note}
 
 \pnum
 If one thread makes a library call \textit{a} that writes a value to a stream
@@ -402,7 +402,7 @@ The header
 \tcode{<iostream>}
 declares objects that associate objects with the
 standard C streams provided for by the functions declared in
-\tcode{<cstdio>}~(\ref{c.files}), and includes all the headers necessary to use
+\tcode{<cstdio>}\iref{c.files}, and includes all the headers necessary to use
 these objects.
 \indexlibrary{\idxhdr{cstdio}}%
 
@@ -410,7 +410,7 @@ these objects.
 The objects are constructed and the associations are established at some
 time prior to or during the first time an object of class
 \tcode{ios_base::Init} is constructed, and in any case before the body
-of \tcode{main}~(\ref{basic.start.main}) begins execution.\footnote{If it is possible for them to do so, implementations should
+of \tcode{main}\iref{basic.start.main} begins execution.\footnote{If it is possible for them to do so, implementations should
 initialize the objects earlier than required.}
 The objects are not destroyed during program execution.\footnote{Constructors and destructors for static objects can
 access these objects to read input from
@@ -431,7 +431,7 @@ follows the same semantics as mixing such operations on
 as specified in the C standard library.
 
 \pnum
-Concurrent access to a synchronized~(\ref{ios.members.static}) standard iostream object's formatted and unformatted input~(\ref{istream}) and output~(\ref{ostream}) functions or a standard C stream by multiple threads shall not result in a data race~(\ref{intro.multithread}). \begin{note} Users must still synchronize concurrent use of these objects and streams by multiple threads if they wish to avoid interleaved characters. \end{note}
+Concurrent access to a synchronized\iref{ios.members.static} standard iostream object's formatted and unformatted input\iref{istream} and output\iref{ostream} functions or a standard C stream by multiple threads shall not result in a data race\iref{intro.multithread}. \begin{note} Users must still synchronize concurrent use of these objects and streams by multiple threads if they wish to avoid interleaved characters. \end{note}
 
 \xref ISO C 7.21.2
 
@@ -452,7 +452,7 @@ associated with the object
 declared in
 \indextext{\idxhdr{cstdio}}%
 \indexlibrary{\idxhdr{cstdio}}%
-\tcode{<cstdio>}~(\ref{cstdio.syn}).
+\tcode{<cstdio>}\iref{cstdio.syn}.
 
 \pnum
 After the object
@@ -462,7 +462,7 @@ is initialized,
 returns
 \tcode{\&cout}.
 Its state is otherwise the same as required for
-\tcode{basic_ios<char>::init}~(\ref{basic.ios.cons}).
+\tcode{basic_ios<char>::init}\iref{basic.ios.cons}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{cout}}%
@@ -480,7 +480,7 @@ associated with the object
 declared in
 \indextext{\idxhdr{cstdio}}%
 \indexlibrary{\idxhdr{cstdio}}%
-\tcode{<cstdio>}~(\ref{cstdio.syn}).
+\tcode{<cstdio>}\iref{cstdio.syn}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{cerr}}%
@@ -498,7 +498,7 @@ associated with the object
 declared in
 \indextext{\idxhdr{cstdio}}%
 \indexlibrary{\idxhdr{cstdio}}%
-\tcode{<cstdio>}~(\ref{cstdio.syn}).
+\tcode{<cstdio>}\iref{cstdio.syn}.
 
 \pnum
 After the object
@@ -507,7 +507,7 @@ is initialized,
 \tcode{cerr.flags() \& unitbuf}
 is nonzero and \tcode{cerr.tie()} returns \tcode{\&cout}.
 Its state is otherwise the same as required for
-\tcode{basic_ios<char>::init}~(\ref{basic.ios.cons}).
+\tcode{basic_ios<char>::init}\iref{basic.ios.cons}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{clog}}%
@@ -525,7 +525,7 @@ associated with the object
 declared in
 \indextext{\idxhdr{cstdio}}%
 \indexlibrary{\idxhdr{cstdio}}%
-\tcode{<cstdio>}~(\ref{cstdio.syn}).
+\tcode{<cstdio>}\iref{cstdio.syn}.
 \end{itemdescr}
 
 \rSec2[wide.stream.objects]{Wide stream objects}
@@ -545,7 +545,7 @@ associated with the object
 declared in
 \indextext{\idxhdr{cstdio}}%
 \indexlibrary{\idxhdr{cstdio}}%
-\tcode{<cstdio>}~(\ref{cstdio.syn}).
+\tcode{<cstdio>}\iref{cstdio.syn}.
 
 \pnum
 After the object
@@ -555,7 +555,7 @@ is initialized,
 returns
 \tcode{\&wcout}.
 Its state is otherwise the same as required for
-\tcode{basic_ios<wchar_t>::init}~(\ref{basic.ios.cons}).
+\tcode{basic_ios<wchar_t>::init}\iref{basic.ios.cons}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{wcout}}%
@@ -573,7 +573,7 @@ associated with the object
 declared in
 \indextext{\idxhdr{cstdio}}%
 \indexlibrary{\idxhdr{cstdio}}%
-\tcode{<cstdio>}~(\ref{cstdio.syn}).
+\tcode{<cstdio>}\iref{cstdio.syn}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{wcerr}}%
@@ -591,7 +591,7 @@ associated with the object
 declared in
 \indextext{\idxhdr{cstdio}}%
 \indexlibrary{\idxhdr{cstdio}}%
-\tcode{<cstdio>}~(\ref{cstdio.syn}).
+\tcode{<cstdio>}\iref{cstdio.syn}.
 
 \pnum
 After the object
@@ -600,7 +600,7 @@ is initialized,
 \tcode{wcerr.flags() \& unitbuf}
 is nonzero and \tcode{wcerr.tie()} returns \tcode{\&wcout}.
 Its state is otherwise the same as required for
-\tcode{basic_ios<wchar_t>::init}~(\ref{basic.ios.cons}).
+\tcode{basic_ios<wchar_t>::init}\iref{basic.ios.cons}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{wclog}}%
@@ -618,7 +618,7 @@ associated with the object
 declared in
 \indextext{\idxhdr{cstdio}}%
 \indexlibrary{\idxhdr{cstdio}}%
-\tcode{<cstdio>}~(\ref{cstdio.syn}).
+\tcode{<cstdio>}\iref{cstdio.syn}.
 \end{itemdescr}
 
 \rSec1[iostreams.base]{Iostreams base classes}
@@ -959,7 +959,7 @@ using fmtflags = @\textit{T1}@;
 \pnum
 The type
 \tcode{fmtflags}
-is a bitmask type~(\ref{bitmask.types}).
+is a bitmask type\iref{bitmask.types}.
 Setting its elements has the effects indicated in Table~\ref{tab:iostreams.fmtflags.effects}.
 
 \begin{libefftab}{\tcode{fmtflags} effects}{tab:iostreams.fmtflags.effects}
@@ -1022,7 +1022,7 @@ using iostate = @\textit{T2}@;
 \pnum
 The type
 \tcode{iostate}
-is a bitmask type~(\ref{bitmask.types})
+is a bitmask type\iref{bitmask.types}
 that contains the elements indicated in Table~\ref{tab:iostreams.iostate.effects}.
 
 \begin{libefftab}{\tcode{iostate} effects}{tab:iostreams.iostate.effects}
@@ -1058,7 +1058,7 @@ using openmode = @\textit{T3}@;
 \pnum
 The type
 \tcode{openmode}
-is a bitmask type~(\ref{bitmask.types}).
+is a bitmask type\iref{bitmask.types}.
 It contains the elements indicated in Table~\ref{tab:iostreams.openmode.effects}.
 
 \begin{libefftab}{\tcode{openmode} effects}{tab:iostreams.openmode.effects}
@@ -1088,7 +1088,7 @@ using seekdir = @\textit{T4}@;
 \pnum
 The type
 \tcode{seekdir}
-is an enumerated type~(\ref{enumerated.types})
+is an enumerated type\iref{enumerated.types}
 that contains the elements indicated in Table~\ref{tab:iostreams.seekdir.effects}.
 
 \begin{libefftabmean}{\tcode{seekdir} effects}{tab:iostreams.seekdir.effects}
@@ -1122,10 +1122,10 @@ The class
 \tcode{Init}
 describes an object whose construction
 ensures the construction of the eight objects declared in
-\tcode{<io\-stream>}~(\ref{iostream.objects}) that associate file
+\tcode{<io\-stream>}\iref{iostream.objects} that associate file
 stream buffers with the standard C streams
 provided for by the functions declared in
-\tcode{<cstdio>}~(\ref{cstdio.syn}).
+\tcode{<cstdio>}\iref{cstdio.syn}.
 
 \pnum
 For the sake of exposition, the maintained data is presented here as:
@@ -1320,7 +1320,7 @@ locale imbue(const locale& loc);
 \pnum
 \effects
 Calls each registered callback pair
-\tcode{(fn, index)}~(\ref{ios.base.callback})
+\tcode{(fn, index)}\iref{ios.base.callback}
 as
 \tcode{(*fn)(imbue_event, *this, index)}
 at such a time that a call to
@@ -1366,7 +1366,7 @@ bool sync_with_stdio(bool sync = true);
 \pnum
 \returns
 \tcode{true}
-if the previous state of the standard iostream objects~(\ref{iostream.objects})
+if the previous state of the standard iostream objects\iref{iostream.objects}
 was synchronized and otherwise returns
 \tcode{false}.
 The first time it is called,
@@ -1432,7 +1432,7 @@ static int xalloc();
 \pnum
 \remarks
 Concurrent access to this function by multiple threads shall not result in a data
-race~(\ref{intro.multithread}).
+race\iref{intro.multithread}.
 \end{itemdescr}
 
 \indexlibrarymember{iword}{ios_base}%
@@ -1544,10 +1544,10 @@ void register_callback(event_callback fn, int index);
 Registers the pair
 \tcode{(fn, index)}
 such that during calls to
-\tcode{imbue()}~(\ref{ios.base.locales}),
+\tcode{imbue()}\iref{ios.base.locales},
 \tcode{copyfmt()},
 or
-\tcode{\~{}ios_base()}~(\ref{ios.base.cons}),
+\tcode{\~{}ios_base()}\iref{ios.base.cons},
 the function
 \tcode{fn}
 is called with argument
@@ -1598,7 +1598,7 @@ the behavior is undefined.
 Destroys an object of class
 \tcode{ios_base}.
 Calls each registered callback pair
-\tcode{(fn, index)}~(\ref{ios.base.callback}) as
+\tcode{(fn, index)}\iref{ios.base.callback} as
 \tcode{(*fn)(\brk{}erase_event, *this, index)}
 at such time that any
 \tcode{ios_base}
@@ -1841,7 +1841,7 @@ basic_ios();
 \pnum
 \effects
 Constructs an object of class
-\tcode{basic_ios}~(\ref{ios.base.cons})
+\tcode{basic_ios}\iref{ios.base.cons}
 leaving its member objects uninitialized. The object
 shall be initialized by calling
 \tcode{basic_ios::init}
@@ -1977,12 +1977,12 @@ locale imbue(const locale& loc);
 \pnum
 \effects
 Calls
-\tcode{ios_base::imbue(loc)}~(\ref{ios.base.locales})
+\tcode{ios_base::imbue(loc)}\iref{ios.base.locales}
 and
 if
 \tcode{rdbuf() != 0}
 then
-\tcode{rdbuf()->pubimbue(loc)}~(\ref{streambuf.locales}).
+\tcode{rdbuf()->pubimbue(loc)}\iref{streambuf.locales}.
 
 \pnum
 \returns
@@ -2226,7 +2226,7 @@ otherwise
 If \tcode{((state | (rdbuf() ? goodbit : badbit)) \& exceptions()) == 0},
 returns.
 Otherwise, the function throws an object of class
-\tcode{basic_ios::failure}~(\ref{ios::failure}),
+\tcode{basic_ios::failure}\iref{ios::failure},
 constructed with
 \impldef{argument values to construct \tcode{basic_ios::failure}}
 argument values.%
@@ -2243,7 +2243,7 @@ void setstate(iostate state);
 Calls
 \tcode{clear(rdstate() | state)}
 (which may throw
-\tcode{basic_ios::failure}~(\ref{ios::failure})).
+\tcode{basic_ios::failure}\iref{ios::failure}).
 \end{itemdescr}
 
 \indexlibrarymember{good}{basic_ios}%
@@ -3199,7 +3199,7 @@ streamsize in_avail();
 If a read position is available, returns
 \tcode{egptr() - gptr()}.
 Otherwise returns
-\tcode{showmanyc()}~(\ref{streambuf.virt.get}).
+\tcode{showmanyc()}\iref{streambuf.virt.get}.
 \end{itemdescr}
 
 \indexlibrarymember{snextc}{basic_streambuf}%
@@ -3610,7 +3610,7 @@ The pointers may then be reset as appropriate.
 \pnum
 \returns
 \tcode{-1} on failure.
-What constitutes failure is determined by each derived class~(\ref{filebuf.virtuals}).
+What constitutes failure is determined by each derived class\iref{filebuf.virtuals}.
 
 \pnum
 \default
@@ -4146,7 +4146,7 @@ namespace std {
   template <class charT, class traits = char_traits<charT>>
   class basic_istream : virtual public basic_ios<charT, traits> {
   public:
-    // types (inherited from \tcode{basic_ios}~(\ref{ios})):
+    // types (inherited from \tcode{basic_ios}\iref{ios}):
     using char_type   = charT;
     using int_type    = typename traits::int_type;
     using pos_type    = typename traits::pos_type;
@@ -4273,7 +4273,7 @@ returns
 then the input function, except as explicitly noted otherwise, completes its actions and does
 \tcode{setstate(eofbit)},
 which may throw
-\tcode{ios_base::failure}~(\ref{iostate.flags}), before returning.
+\tcode{ios_base::failure}\iref{iostate.flags}, before returning.
 
 \pnum
 If one of these called functions throws an exception, then unless explicitly noted otherwise,
@@ -4302,7 +4302,7 @@ explicit basic_istream(basic_streambuf<charT, traits>* sb);
 \effects
 Constructs an object of class
 \tcode{basic_istream}, initializing the base class subobject with
-\tcode{basic_ios::init(sb)}~(\ref{basic.ios.cons}).
+\tcode{basic_ios::init(sb)}\iref{basic.ios.cons}.
 
 \pnum
 \postconditions
@@ -4481,7 +4481,7 @@ otherwise,
 During preparation, the constructor may call
 \tcode{setstate(failbit)}
 (which may throw
-\tcode{ios_base::\brk{}failure}~(\ref{iostate.flags}))\footnote{The sentry
+\tcode{ios_base::\brk{}failure}\iref{iostate.flags})\footnote{The sentry
 constructor and destructor
 can also perform additional
 \indextext{implementation-dependent}%
@@ -4569,7 +4569,7 @@ operator>>(void*& val);
 \pnum
 As in the case of the inserters, these extractors depend on the
 locale's
-\tcode{num_get<>}~(\ref{locale.num.get}) object to perform parsing the input
+\tcode{num_get<>}\iref{locale.num.get} object to perform parsing the input
 stream data.
 These extractors behave as formatted input functions (as described in~\ref{istream.formatted.reqmts}).  After a sentry object is constructed, the
 conversion occurs as if performed by the following code fragment:
@@ -4669,7 +4669,7 @@ This extractor does not behave as a formatted input function
 \pnum
 \returns
 \tcode{pf(*this)}.\footnote{See, for example, the function signature
-\tcode{ws(basic_istream\&)}~(\ref{istream.manip}).%
+\tcode{ws(basic_istream\&)}\iref{istream.manip}.%
 \indexlibrary{\idxcode{ws}}}%
 \end{itemdescr}
 
@@ -4702,7 +4702,7 @@ basic_istream<charT, traits>& operator>>(ios_base& (*pf)(ios_base&));
 \effects
 Calls
 \tcode{pf(*this)}.\footnote{See, for example, the function signature
-\tcode{dec(ios_base\&)}~(\ref{basefield.manip}).}
+\tcode{dec(ios_base\&)}\iref{basefield.manip}.}
 This extractor does not behave as a formatted input function
 (as described in~\ref{istream.formatted.reqmts}).
 
@@ -4767,7 +4767,7 @@ then calls
 If the function extracted no characters, it calls
 \tcode{setstate(failbit)},
 which may throw
-\tcode{ios_base::\brk{}failure}~(\ref{iostate.flags}).
+\tcode{ios_base::\brk{}failure}\iref{iostate.flags}.
 
 \pnum
 \returns
@@ -4809,11 +4809,11 @@ basic_istream<charT, traits>& operator>>(basic_streambuf<charT, traits>* sb);
 \begin{itemdescr}
 \pnum
 \effects
-Behaves as an unformatted input function~(\ref{istream.unformatted}).
+Behaves as an unformatted input function\iref{istream.unformatted}.
 If \tcode{sb} is null, calls
 \tcode{setstate(fail\-bit)},
 which may throw
-\tcode{ios_base::failure}~(\ref{iostate.flags}).
+\tcode{ios_base::failure}\iref{iostate.flags}.
 After a sentry object is constructed, extracts
 characters from
 \tcode{*this}
@@ -4833,14 +4833,14 @@ an exception occurs (in which case the exception is caught).
 If the function inserts no characters, it calls
 \tcode{setstate(failbit)},
 which may throw
-\tcode{ios_base::\brk{}failure}~(\ref{iostate.flags}).
+\tcode{ios_base::\brk{}failure}\iref{iostate.flags}.
 If it inserted no characters because it caught
 an exception thrown while extracting characters from
 \tcode{*this}
 and
 \tcode{failbit}
 is on in
-\tcode{exceptions()}~(\ref{iostate.flags}),
+\tcode{exceptions()}\iref{iostate.flags},
 then the caught exception is rethrown.
 
 \pnum
@@ -4930,7 +4930,7 @@ a character \tcode{c}, if one is available.
 Otherwise, the function calls
 \tcode{setstate(failbit)},
 which may throw
-\tcode{ios_base::failure}~(\ref{iostate.flags}),
+\tcode{ios_base::failure}\iref{iostate.flags},
 
 \pnum
 \returns
@@ -4958,7 +4958,7 @@ and
 Otherwise, the function calls
 \tcode{setstate(failbit)}
 (which may throw
-\tcode{ios_base::failure}~(\ref{iostate.flags})).
+\tcode{ios_base::failure}\iref{iostate.flags}).
 
 \pnum
 \returns
@@ -5002,7 +5002,7 @@ character \tcode{c}
 If the function stores no characters, it calls
 \tcode{setstate(failbit)}
 (which may throw
-\tcode{ios_base::\brk{}failure}~(\ref{iostate.flags})).
+\tcode{ios_base::\brk{}failure}\iref{iostate.flags}).
 In any case, if \tcode{n} is greater than zero it then stores a null character
 into the next successive location of the array.
 
@@ -5061,7 +5061,7 @@ an exception occurs
 If the function inserts no characters, it calls
 \tcode{setstate(failbit)},
 which may throw
-\tcode{ios_base::\brk{}failure}~(\ref{iostate.flags}).
+\tcode{ios_base::\brk{}failure}\iref{iostate.flags}.
 
 \pnum
 \returns
@@ -5133,7 +5133,7 @@ This is different behavior than the historical AT\&T implementation.}
 If the function extracts no characters, it calls
 \tcode{setstate(failbit)}
 (which may throw
-\tcode{ios_base::\brk{}failure}~(\ref{iostate.flags})).\footnote{This implies an
+\tcode{ios_base::\brk{}failure}\iref{iostate.flags}).\footnote{This implies an
 empty input line will not cause
 \tcode{failbit}
 to be set.}
@@ -5203,7 +5203,7 @@ characters and discards them.
 Characters are extracted until any of the following occurs:
 \begin{itemize}
 \item
-\tcode{n != numeric_limits<streamsize>::max()}~(\ref{numeric.limits})
+\tcode{n != numeric_limits<streamsize>::max()}\iref{numeric.limits}
 and
 \tcode{n} characters have been extracted so far
 \item
@@ -5211,7 +5211,7 @@ end-of-file occurs on the input sequence
 (in which case the function calls
 \tcode{setstate(eofbit)},
 which may throw
-\tcode{ios_base::failure}~(\ref{iostate.flags}));
+\tcode{ios_base::failure}\iref{iostate.flags});
 \item
 \tcode{traits::eq_int_type(traits::to_int_type(c), delim)}
 for the next available input character \tcode{c}
@@ -5283,7 +5283,7 @@ end-of-file occurs on the input sequence
 (in which case the function calls
 \tcode{setstate(failbit | eofbit)},
 which may throw
-\tcode{ios_base::failure}~(\ref{iostate.flags})).
+\tcode{ios_base::failure}\iref{iostate.flags}).
 \end{itemize}
 
 \pnum
@@ -5315,7 +5315,7 @@ If
 calls
 \tcode{setstate(eofbit)}
 (which may throw
-\tcode{ios_base::failure}~(\ref{iostate.flags})),
+\tcode{ios_base::failure}\iref{iostate.flags}),
 and extracts no characters;
 \begin{itemize}
 \item
@@ -5363,7 +5363,7 @@ returns
 calls
 \tcode{setstate(badbit)}
 (which may throw
-\tcode{ios_base::failure}~(\ref{iostate.flags})).
+\tcode{ios_base::failure}\iref{iostate.flags}).
 \begin{note}
 This
 function extracts no characters, so the value returned by the next call to
@@ -5405,7 +5405,7 @@ returns
 calls
 \tcode{setstate(badbit)}
 (which may throw
-\tcode{ios_base::failure}~(\ref{iostate.flags})).
+\tcode{ios_base::failure}\iref{iostate.flags}).
 \begin{note}
 This
 function extracts no characters, so the value returned by the next call to
@@ -5440,7 +5440,7 @@ and, if that function returns \tcode{-1}
 calls
 \tcode{setstate(badbit)}
 (which may throw
-\tcode{ios_base::failure}~(\ref{iostate.flags}),
+\tcode{ios_base::failure}\iref{iostate.flags},
 and returns
 \tcode{-1}.
 Otherwise, returns zero.
@@ -5532,12 +5532,12 @@ template <class charT, class traits>
 \begin{itemdescr}
 \pnum
 \effects
-Behaves as an unformatted input function~(\ref{istream.unformatted}), except that it does not count the number of characters extracted and
+Behaves as an unformatted input function\iref{istream.unformatted}, except that it does not count the number of characters extracted and
 does not affect the value returned by subsequent calls to \tcode{is.gcount()}. After
 constructing a sentry object extracts characters as long as the next available
 character \tcode{c} is whitespace or until there are no more characters in the sequence.
 Whitespace characters are distinguished with the same criterion as used by
-\tcode{sentry::sentry}~(\ref{istream::sentry}).
+\tcode{sentry::sentry}\iref{istream::sentry}.
 If
 \tcode{ws}
 stops extracting characters because there are no more available it sets
@@ -5624,9 +5624,9 @@ explicit basic_iostream(basic_streambuf<charT, traits>* sb);
 \effects
 Constructs an object of class \tcode{basic_iostream},
 initializing the base class subobjects with
-\tcode{basic_istream<charT, traits>(sb)}~(\ref{istream})
+\tcode{basic_istream<charT, traits>(sb)}\iref{istream}
 and
-\tcode{basic_ostream<charT, traits>(sb)}~(\ref{ostream}).
+\tcode{basic_ostream<charT, traits>(sb)}\iref{ostream}.
 
 \pnum
 \postconditions
@@ -5706,7 +5706,7 @@ namespace std {
   template <class charT, class traits = char_traits<charT>>
   class basic_ostream : virtual public basic_ios<charT, traits> {
   public:
-    // types (inherited from \tcode{basic_ios}~(\ref{ios})):
+    // types (inherited from \tcode{basic_ios}\iref{ios}):
     using char_type   = charT;
     using int_type    = typename traits::int_type;
     using pos_type    = typename traits::pos_type;
@@ -5851,7 +5851,7 @@ explicit basic_ostream(basic_streambuf<charT, traits>* sb);
 \effects
 Constructs an object of class
 \tcode{basic_ostream}, initializing the base class subobject with
-\tcode{basic_ios<charT, traits>::init(sb)}~(\ref{basic.ios.cons}).
+\tcode{basic_ios<charT, traits>::init(sb)}\iref{basic.ios.cons}.
 
 \pnum
 \postconditions
@@ -5969,7 +5969,7 @@ otherwise,
 During preparation, the constructor may call
 \tcode{setstate(failbit)}
 (which may throw
-\tcode{ios_base::\brk{}failure}~(\ref{iostate.flags}))\footnote{The
+\tcode{ios_base::\brk{}failure}\iref{iostate.flags})\footnote{The
 \tcode{sentry}
 constructor and destructor
 can also perform additional
@@ -6271,7 +6271,7 @@ in~\ref{ostream.formatted.reqmts}).
 \returns
 \tcode{pf(*this)}.\footnote{See, for example, the function signature
 \indexlibrary{\idxcode{endl}}%
-\tcode{endl(basic_ostream\&)}~(\ref{ostream.manip}).}
+\tcode{endl(basic_ostream\&)}\iref{ostream.manip}.}
 \end{itemdescr}
 
 \indexlibrarymember{operator<<}{basic_ostream}%
@@ -6292,7 +6292,7 @@ behave as a formatted output function (as described in~\ref{ostream.formatted.re
 \returns
 \tcode{*this}.\footnote{See, for example, the function signature
 \indexlibrary{\idxcode{dec}}%
-\tcode{dec(ios_base\&)}~(\ref{basefield.manip}).}
+\tcode{dec(ios_base\&)}\iref{basefield.manip}.}
 \end{itemdescr}
 
 \indexlibrarymember{operator<<}{basic_ostream}%
@@ -6321,7 +6321,7 @@ basic_ostream<charT, traits>& operator<<(basic_streambuf<charT, traits>* sb);
 \begin{itemdescr}
 \pnum
 \effects
-Behaves as an unformatted output function~(\ref{ostream.unformatted}).
+Behaves as an unformatted output function\iref{ostream.unformatted}.
 After the sentry object is
 constructed, if
 \tcode{sb} is null calls
@@ -6349,7 +6349,7 @@ an exception occurs while getting a character from \tcode{sb}.
 If the function inserts no characters, it calls
 \tcode{setstate(failbit)}
 (which may throw
-\tcode{ios_base::\brk{}failure}~(\ref{iostate.flags})).
+\tcode{ios_base::\brk{}failure}\iref{iostate.flags}).
 If an exception was thrown while extracting a character,
 the function sets
 \tcode{failbit}
@@ -6378,7 +6378,7 @@ return *this << s;
 \end{codeblock}
 where \tcode{s} is an
 \impldef{NTCTS in \tcode{basic_ostream<charT, traits>\& op\-er\-ator<<(nullptr_t)}}
-NTCTS~(\ref{defns.ntcts}).
+NTCTS\iref{defns.ntcts}.
 \end{itemdescr}
 
 \rSec4[ostream.inserters.character]{Character inserter function templates}
@@ -6402,7 +6402,7 @@ template<class traits>
 \begin{itemdescr}
 \pnum
 \effects
-Behaves as a formatted output function~(\ref{ostream.formatted.reqmts})
+Behaves as a formatted output function\iref{ostream.formatted.reqmts}
 of \tcode{out}. Constructs a character sequence \tcode{seq}.
 If \tcode{c} has type
 \tcode{char}
@@ -6445,7 +6445,7 @@ template<class traits>
 Behaves like a formatted inserter (as described in~\ref{ostream.formatted.reqmts}) of \tcode{out}.
 Creates a character sequence \tcode{seq} of \tcode{n} characters
 starting at \tcode{s}, each widened using
-\tcode{out.widen()}~(\ref{basic.ios.members}),
+\tcode{out.widen()}\iref{basic.ios.members},
 where \tcode{n} is the number that would be computed as if by:
 \begin{itemize}
 \item
@@ -6526,7 +6526,7 @@ and
 Otherwise, calls
 \tcode{setstate(badbit)}
 (which may throw
-\tcode{ios_base::failure}~(\ref{iostate.flags})).
+\tcode{ios_base::failure}\iref{iostate.flags}).
 
 \pnum
 \returns
@@ -6558,7 +6558,7 @@ inserting in the output sequence fails
 (in which case the function calls
 \tcode{setstate(badbit)},
 which may throw
-\tcode{ios_base::failure}~(\ref{iostate.flags})).
+\tcode{ios_base::failure}\iref{iostate.flags}).
 \end{itemize}
 
 \pnum
@@ -6584,7 +6584,7 @@ If that function returns -1
 calls
 \tcode{setstate(badbit)}
 (which may throw
-\tcode{ios_base::failure}~(\ref{iostate.flags})).
+\tcode{ios_base::failure}\iref{iostate.flags}).
 Otherwise, if the sentry object returns \tcode{false}, does nothing.
 
 \pnum
@@ -6947,11 +6947,11 @@ template <class moneyT> @\unspec@ get_money(moneyT& mon, bool intl = false);
 \begin{itemdescr}
 \pnum
 \requires The type \tcode{moneyT} shall be either \tcode{long double} or a
-specialization of the \tcode{basic_string} template (Clause~\ref{strings}).
+specialization of the \tcode{basic_string} template\iref{strings}.
 
 \pnum
 \effects The expression \tcode{in >> get_money(mon, intl)} described below
-behaves as a formatted input function~(\ref{istream.formatted.reqmts}).
+behaves as a formatted input function\iref{istream.formatted.reqmts}.
 
 \pnum
 \returns An object of unspecified type such that if
@@ -6987,13 +6987,13 @@ template <class moneyT> @\unspec@ put_money(const moneyT& mon, bool intl = false
 \begin{itemdescr}
 \pnum
 \requires The type \tcode{moneyT} shall be either \tcode{long double} or a
-specialization of the \tcode{basic_string} template (Clause~\ref{strings}).
+specialization of the \tcode{basic_string} template\iref{strings}.
 
 \pnum
 \returns An object of unspecified type such that if
 \tcode{out} is an object of type \tcode{basic_ostream<charT, traits>}
 then the expression \tcode{out << put_money(mon, intl)} behaves as a
-formatted output function~(\ref{ostream.formatted.reqmts}) that calls
+formatted output function\iref{ostream.formatted.reqmts} that calls
 \tcode{f(out, mon, intl)}, where the function \tcode{f} is defined as:
 
 \begin{codeblock}
@@ -7113,7 +7113,7 @@ of \tcode{basic_ostream} with member type \tcode{char_type} the same as
 \tcode{charT} and with member type \tcode{traits_type}, which in the second and third
 forms is the same as \tcode{traits}, then the expression
 \tcode{out << quoted(s, delim, escape)}
-behaves as a formatted output function~(\ref{ostream.formatted.reqmts})
+behaves as a formatted output function\iref{ostream.formatted.reqmts}
 of \tcode{out}. This forms a character sequence \tcode{seq}, initially
 consisting of the following elements:
 \begin{itemize}
@@ -7148,8 +7148,8 @@ template <class charT, class traits, class Allocator>
 and \tcode{traits}, respectively, then the expression
 \tcode{in >> quoted(s, delim, escape)} behaves as if it extracts the following
 characters from \tcode{in} using
-\tcode{operator>>(basic_istream<charT, traits>\&, charT\&)}~(\ref{istream.extractors})
-which may throw \tcode{ios_base::failure}~(\ref{ios::failure}):
+\tcode{operator>>(basic_istream<charT, traits>\&, charT\&)}\iref{istream.extractors}
+which may throw \tcode{ios_base::failure}\iref{ios::failure}:
 \begin{itemize}
 \item If the first character extracted is equal to \tcode{delim}, as
 determined by \tcode{traits_type::eq}, then:
@@ -7334,7 +7334,7 @@ explicit basic_stringbuf(
 Constructs an object of class
 \tcode{basic_stringbuf},
 initializing the base class with
-\tcode{basic_streambuf()}~(\ref{streambuf.cons}), and initializing
+\tcode{basic_streambuf()}\iref{streambuf.cons}, and initializing
 \tcode{mode}
 with \tcode{which}.
 
@@ -7356,7 +7356,7 @@ explicit basic_stringbuf(
 Constructs an object of class
 \tcode{basic_stringbuf},
 initializing the base class with
-\tcode{basic_streambuf()}~(\ref{streambuf.cons}), and initializing
+\tcode{basic_streambuf()}\iref{streambuf.cons}, and initializing
 \tcode{mode}
 with \tcode{which}.
 Then calls \tcode{str(s)}.
@@ -7700,7 +7700,7 @@ Table~\ref{tab:iostreams.newoff.values}.
 If
 \tcode{(newoff + off) < 0},
 or if \tcode{newoff + off} refers to an uninitialized
-character~(\ref{stringbuf.members}),
+character\iref{stringbuf.members},
 the positioning operation fails.
 Otherwise, the function assigns
 \tcode{xbeg + newoff + off}
@@ -7829,9 +7829,9 @@ explicit basic_istringstream(ios_base::openmode which = ios_base::in);
 Constructs an object of class
 \tcode{basic_istringstream<charT, traits>},
 initializing the base class with
-\tcode{basic_istream<charT, traits>(\&sb)}~(\ref{istream})
+\tcode{basic_istream<charT, traits>(\&sb)}\iref{istream}
 and initializing \tcode{sb} with
-\tcode{basic_string\-buf<charT, traits, Allocator>(which | ios_base::in))}~(\ref{stringbuf.cons}).
+\tcode{basic_string\-buf<charT, traits, Allocator>(which | ios_base::in))}\iref{stringbuf.cons}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_istringstream}!constructor}%
@@ -7847,9 +7847,9 @@ explicit basic_istringstream(
 Constructs an object of class
 \tcode{basic_istringstream<charT, traits>},
 initializing the base class with
-\tcode{basic_istream<charT, traits>(\&sb)}~(\ref{istream})
+\tcode{basic_istream<charT, traits>(\&sb)}\iref{istream}
 and initializing \tcode{sb} with
-\tcode{basic_string\-buf<charT, traits, Allocator>(str, which | ios_base::in))}~(\ref{stringbuf.cons}).
+\tcode{basic_string\-buf<charT, traits, Allocator>(str, which | ios_base::in))}\iref{stringbuf.cons}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_istringstream}!constructor}%
@@ -8017,9 +8017,9 @@ explicit basic_ostringstream(
 Constructs an object of class
 \tcode{basic_ostringstream<charT, traits>},
 initializing the base class with
-\tcode{basic_ostream<charT, traits>(\&sb)}~(\ref{ostream})
+\tcode{basic_ostream<charT, traits>(\&sb)}\iref{ostream}
 and initializing \tcode{sb} with
-\tcode{basic_string\-buf<charT, traits, Allocator>(which | ios_base::out))}~(\ref{stringbuf.cons}).
+\tcode{basic_string\-buf<charT, traits, Allocator>(which | ios_base::out))}\iref{stringbuf.cons}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_ostringstream}!constructor}%
@@ -8035,9 +8035,9 @@ explicit basic_ostringstream(
 Constructs an object of class
 \tcode{basic_ostringstream<charT, traits>},
 initializing the base class with
-\tcode{basic_ostream<charT, traits>(\&sb)}~(\ref{ostream})
+\tcode{basic_ostream<charT, traits>(\&sb)}\iref{ostream}
 and initializing \tcode{sb} with
-\tcode{basic_string\-buf<charT, traits, Allocator>(str, which | ios_base::out))}~(\ref{stringbuf.cons}).
+\tcode{basic_string\-buf<charT, traits, Allocator>(str, which | ios_base::out))}\iref{stringbuf.cons}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_ostringstream}!constructor}%
@@ -8206,7 +8206,7 @@ explicit basic_stringstream(
 Constructs an object of class
 \tcode{basic_stringstream<charT, traits>},
 initializing the base class with
-\tcode{basic_iostream<charT, traits>(\&sb)}~(\ref{iostream.cons})
+\tcode{basic_iostream<charT, traits>(\&sb)}\iref{iostream.cons}
 and initializing
 \tcode{sb}
 with
@@ -8226,7 +8226,7 @@ explicit basic_stringstream(
 Constructs an object of class
 \tcode{basic_stringstream<charT, traits>},
 initializing the base class with
-\tcode{basic_iostream<charT, traits>(\&sb)}~(\ref{iostream.cons})
+\tcode{basic_iostream<charT, traits>(\&sb)}\iref{iostream.cons}
 and initializing
 \tcode{sb}
 with
@@ -8386,7 +8386,7 @@ object converts those multibyte sequences into wide character sequences.
 
 \pnum
 In this subclause, member functions taking arguments of \tcode{const filesystem::path::value_type*}
-are only be provided on systems where \tcode{filesystem::path::value_type}~(\ref{fs.class.path}) is not \tcode{char}.
+are only be provided on systems where \tcode{filesystem::path::value_type}\iref{fs.class.path} is not \tcode{char}.
 \begin{note}
 These functions enable class \tcode{path} support for systems with a wide native path character type, such as \tcode{wchar_t}.
 \end{note}
@@ -8512,7 +8512,7 @@ basic_filebuf();
 Constructs an object of class
 \tcode{basic_filebuf<charT, traits>},
 initializing the base class with
-\tcode{basic_streambuf<charT, traits>()}~(\ref{streambuf.cons}).
+\tcode{basic_streambuf<charT, traits>()}\iref{streambuf.cons}.
 
 \pnum
 \postconditions
@@ -8702,7 +8702,7 @@ and
 are declared, in
 \indextext{\idxhdr{cstdio}}%
 \indexlibrary{\idxhdr{cstdio}}%
-\tcode{<cstdio>}~(\ref{cstdio.syn}).}
+\tcode{<cstdio>}\iref{cstdio.syn}.}
 
 \pnum
 If the repositioning operation fails, calls
@@ -8787,7 +8787,7 @@ streamsize showmanyc() override;
 \pnum
 \effects
 Behaves the same as
-\tcode{basic_streambuf::showmanyc()}~(\ref{streambuf.virtuals}).
+\tcode{basic_streambuf::showmanyc()}\iref{streambuf.virtuals}.
 \indexlibrary{\idxcode{showmanyc}!\idxcode{basic_streambuf}}%
 
 \pnum
@@ -9144,7 +9144,7 @@ void imbue(const locale& loc) override;
 If the file is not positioned at its beginning and the encoding of the current
 locale as determined by
 \tcode{a_codecvt.encoding()}
-is state-dependent~(\ref{locale.codecvt.virtuals})
+is state-dependent\iref{locale.codecvt.virtuals}
 then that facet is the same as
 the corresponding facet of \tcode{loc}.
 
@@ -9241,9 +9241,9 @@ basic_ifstream();
 Constructs an object of class
 \tcode{basic_ifstream<charT, traits>},
 initializing the base class with
-\tcode{basic_istream<charT, traits>(\&sb)}~(\ref{istream.cons})
+\tcode{basic_istream<charT, traits>(\&sb)}\iref{istream.cons}
 and initializing \tcode{sb} with
-\tcode{basic_filebuf<charT, traits>())}~(\ref{filebuf.cons}).
+\tcode{basic_filebuf<charT, traits>())}\iref{filebuf.cons}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_ifstream}!constructor}%
@@ -9260,9 +9260,9 @@ explicit basic_ifstream(const filesystem::path::value_type* s,
 Constructs an object of class
 \tcode{basic_ifstream<charT, traits>},
 initializing the base class with
-\tcode{basic_istream<charT, traits>(\&sb)}~(\ref{istream.cons})
+\tcode{basic_istream<charT, traits>(\&sb)}\iref{istream.cons}
 and initializing \tcode{sb} with
-\tcode{basic_filebuf<charT, traits>())}~(\ref{filebuf.cons}),
+\tcode{basic_filebuf<charT, traits>())}\iref{filebuf.cons},
 then calls
 \tcode{rdbuf()->open(s, mode | ios_base::in)}.
 If that function returns a null pointer, calls
@@ -9378,7 +9378,7 @@ calls \tcode{clear()},
 otherwise calls
 \tcode{setstate(failbit)}
 (which may throw
-\tcode{ios_base::failure})~(\ref{iostate.flags}).
+\tcode{ios_base::failure})\iref{iostate.flags}.
 \end{itemdescr}
 
 \indexlibrarymember{open}{basic_ifstream}%
@@ -9407,7 +9407,7 @@ a null pointer,
 calls
 \tcode{setstate(failbit)}
 (which may throw
-\tcode{ios_base::failure})~(\ref{iostate.flags}).
+\tcode{ios_base::failure})\iref{iostate.flags}.
 \end{itemdescr}
 
 \rSec2[ofstream]{Class template \tcode{basic_ofstream}}
@@ -9489,9 +9489,9 @@ basic_ofstream();
 Constructs an object of class
 \tcode{basic_ofstream<charT, traits>},
 initializing the base class with
-\tcode{basic_ostream<charT, traits>(\&sb)}~(\ref{ostream.cons})
+\tcode{basic_ostream<charT, traits>(\&sb)}\iref{ostream.cons}
 and initializing \tcode{sb} with
-\tcode{basic_filebuf<charT, traits>())}~(\ref{filebuf.cons}).
+\tcode{basic_filebuf<charT, traits>())}\iref{filebuf.cons}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_ofstream}!constructor}%
@@ -9508,9 +9508,9 @@ explicit basic_ofstream(const filesystem::path::value_type* s,
 Constructs an object of class
 \tcode{basic_ofstream<charT, traits>},
 initializing the base class with
-\tcode{basic_ostream<charT, traits>(\&sb)}~(\ref{ostream.cons})
+\tcode{basic_ostream<charT, traits>(\&sb)}\iref{ostream.cons}
 and initializing \tcode{sb} with
-\tcode{basic_filebuf<charT, traits>())}~(\ref{filebuf.cons}),
+\tcode{basic_filebuf<charT, traits>())}\iref{filebuf.cons},
 then calls
 \tcode{rdbuf()->open(s, mode | ios_base::out)}.
 If that function returns a null pointer, calls
@@ -9626,7 +9626,7 @@ calls \tcode{clear()},
 otherwise calls
 \tcode{setstate(\brk{}failbit)}
 (which may throw
-\tcode{ios_base::failure})~(\ref{iostate.flags}).
+\tcode{ios_base::failure})\iref{iostate.flags}.
 \end{itemdescr}
 
 \indexlibrarymember{close}{basic_ofstream}%
@@ -9642,7 +9642,7 @@ Calls
 and, if that function fails (returns a null pointer), calls
 \tcode{setstate(\brk{}failbit)}
 (which may throw
-\tcode{ios_base::failure})~(\ref{iostate.flags}).
+\tcode{ios_base::failure})\iref{iostate.flags}.
 \end{itemdescr}
 
 \indexlibrarymember{open}{basic_ofstream}%
@@ -9746,7 +9746,7 @@ basic_fstream();
 Constructs an object of class
 \tcode{basic_fstream<charT, traits>},
 initializing the base class with
-\tcode{basic_iostream<charT, traits>(\&sb)}~(\ref{iostream.cons})
+\tcode{basic_iostream<charT, traits>(\&sb)}\iref{iostream.cons}
 and initializing
 \tcode{sb}
 with
@@ -9769,7 +9769,7 @@ explicit basic_fstream(
 Constructs an object of class
 \tcode{basic_fstream<charT, traits>},
 initializing the base class with
-\tcode{basic_iostream<charT, traits>(\&sb)}~(\ref{iostream.cons})
+\tcode{basic_iostream<charT, traits>(\&sb)}\iref{iostream.cons}
 and initializing
 \tcode{sb}
 with
@@ -9893,7 +9893,7 @@ If that function does not return a null pointer calls \tcode{clear()},
 otherwise calls
 \tcode{setstate(failbit)}
 (which may throw
-\tcode{ios_base::failure})~(\ref{iostate.flags}).
+\tcode{ios_base::failure})\iref{iostate.flags}.
 \end{itemdescr}
 
 \indexlibrarymember{open}{basic_fstream}%
@@ -9926,7 +9926,7 @@ returns a null pointer,
 calls
 \tcode{setstate(failbit)}
 (which may throw
-\tcode{ios_base::failure})~(\ref{iostate.flags}).
+\tcode{ios_base::failure})\iref{iostate.flags}.
 \end{itemdescr}
 
 \rSec1[filesystems]{File systems}
@@ -9945,7 +9945,7 @@ implementable, so the conformance subclauses take that into account.
 
 \rSec3[fs.conform.9945]{POSIX conformance}
 \pnum
-Some behavior is specified by reference to POSIX~(\ref{fs.norm.ref}). How such behavior is actually implemented is unspecified.
+Some behavior is specified by reference to POSIX\iref{fs.norm.ref}. How such behavior is actually implemented is unspecified.
 \begin{note} This constitutes an ``as if'' rule allowing implementations
 to call native
 operating system or other APIs. \end{note}
@@ -9974,7 +9974,7 @@ but instead are required to report an error as described above.
 \rSec3[fs.conform.os]{Operating system dependent behavior conformance}
 \pnum
 Some behavior is specified as being
-operating system dependent~(\ref{fs.def.osdep}). The operating system an
+operating system dependent\iref{fs.def.osdep}. The operating system an
 implementation is dependent upon is
 \impldef{operating system on which implementation depends}.
 
@@ -9985,7 +9985,7 @@ system emulator rather than the actual underlying operating system.
 \rSec3[fs.race.behavior]{File system race behavior}
 
 \pnum
-Behavior is undefined if calls to functions provided by this subclause introduce a file system race~(\ref{fs.def.race}).
+Behavior is undefined if calls to functions provided by this subclause introduce a file system race\iref{fs.def.race}.
 
 \pnum
 If the possibility of a file system race would make it unreliable for a
@@ -10025,7 +10025,7 @@ other files, possibly including other directory files.
 \definition{file}{fs.def.file}
 An object within a file system that holds user or system data. Files can be written to, or read from, or both. A file
 has certain attributes, including type. File types include regular files
-and directories. Other types of files, such as symbolic links~(\ref{fs.def.symlink}),
+and directories. Other types of files, such as symbolic links\iref{fs.def.symlink},
 may be supported by the implementation.
 
 \definition{file system}{fs.def.filesystem}
@@ -10054,7 +10054,7 @@ The following characteristics of filenames are operating system dependent:
 \end{itemize}
 
 \definition{hard link}{fs.def.hardlink}
-A link~(\ref{fs.def.link}) to an existing file. Some
+A link\iref{fs.def.link} to an existing file. Some
 file systems support multiple hard links to a file. If the last hard link to a
 file is removed, the file itself is removed.
 \begin{note} A hard link can be thought of as a shared-ownership smart
@@ -10065,8 +10065,8 @@ An object that associates a filename with a file. Several links can associate na
 
 \definition{native encoding}{fs.def.native.encode}
 For narrow character strings, the operating system dependent current encoding
-for pathnames~(\ref{fs.def.pathname}). For wide character strings, the implementation-defined execution
-wide-character set encoding~(\ref{lex.charset}).
+for pathnames\iref{fs.def.pathname}. For wide character strings, the implementation-defined execution
+wide-character set encoding\iref{lex.charset}.
 
 \definition{native pathname format}{fs.def.native}
 The operating system dependent pathname format accepted by the host operating system.
@@ -10083,7 +10083,7 @@ Normalization of a generic format pathname means:
 \item Replace each slash character in the \grammarterm{root-name} with a \grammarterm{preferred-separator}.
 \item Replace each \grammarterm{directory-separator} with a \grammarterm{preferred-separator}.
 \begin{note}
-The generic pathname grammar~(\ref{fs.path.generic}) defines \grammarterm{directory-separator} as one or more slashes and \grammarterm{preferred-separator}{s}.
+The generic pathname grammar\iref{fs.path.generic} defines \grammarterm{directory-separator} as one or more slashes and \grammarterm{preferred-separator}{s}.
 \end{note}
 \item Remove each \grammarterm{dot} filename and any immediately following \grammarterm{directory-separator}.
 \item As long as any appear, remove a non-\grammarterm{dot-dot} filename immediately followed by a \grammarterm{directory-separator} and a \grammarterm{dot-dot} filename, along with any immediately following \grammarterm{directory-separator}.
@@ -10119,7 +10119,7 @@ The maximum number of elements in the sequence is operating system dependent.
 
 \definition{pathname}{fs.def.pathname}
 A character string that represents the name of a path. Pathnames are
-formatted according to the generic pathname format grammar~(\ref{fs.path.generic}) or an
+formatted according to the generic pathname format grammar\iref{fs.path.generic} or an
 operating system dependent
 native pathname format.
 
@@ -10132,7 +10132,7 @@ pathnames that resolve to the same file.
 
 \definition{relative path}{fs.def.rel.path}
 A path that is not absolute, and as such, only unambiguously
-identifies the location of a file when resolved~(\ref{fs.def.pathres}) relative to
+identifies the location of a file when resolved\iref{fs.def.pathres} relative to
 an implied starting location. The elements of a path that determine if it is
 relative are operating system dependent.
 \begin{note}
@@ -10161,7 +10161,7 @@ unless \tcode{EcharT} is one of the encoded character types.
 
 \pnum
 Template parameters named \tcode{InputIterator} shall meet the
-input iterator requirements~(\ref{input.iterators}) and shall
+input iterator requirements\iref{input.iterators} and shall
 have a value type that is one of the encoded character types.
 
 \pnum
@@ -10173,7 +10173,7 @@ they are not included as permitted types. \end{note}
 
 \pnum
 Template parameters named \tcode{Allocator} shall meet the
-Allocator requirements~(\ref{allocator.requirements}).
+Allocator requirements\iref{allocator.requirements}.
 
 \rSec3[fs.req.namespace]{Namespaces and headers}
 
@@ -10407,7 +10407,7 @@ namespace std::filesystem {
 
 \pnum
 \tcode{\textit{trivial-clock}} is an \impldef{type of filesystem trivial clock} type
-that satisfies the \tcode{TrivialClock} requirements~(\ref{time.clock.req})
+that satisfies the \tcode{TrivialClock} requirements\iref{time.clock.req}
 and that is capable of representing and measuring file time values.
 Implementations should ensure that the resolution and range of
 \tcode{file_time_type} reflect the operating system dependent resolution and range
@@ -10471,8 +10471,8 @@ handle errors as follows, unless otherwise specified:
 
 \indexlibrary{\idxcode{path}}%
 \pnum
-An object of class \tcode{path} represents a path~(\ref{fs.def.path})
-and contains a pathname~(\ref{fs.def.pathname}).
+An object of class \tcode{path} represents a path\iref{fs.def.path}
+and contains a pathname\iref{fs.def.pathname}.
 Such an object is concerned only with the lexical and syntactic aspects
 of a path. The path does not necessarily exist in external storage, and the
 pathname is not necessarily valid for the current operating
@@ -10631,7 +10631,7 @@ operating system dependent encoded character type used to represent pathnames.
 \indexlibrarymember{preferred_separator}{path}%
 \pnum
 The value of the \tcode{preferred_separator} member
-is the operating system dependent \grammarterm{preferred-separator} character~(\ref{fs.path.generic}).
+is the operating system dependent \grammarterm{preferred-separator} character\iref{fs.path.generic}.
 
 \pnum
 \begin{example}
@@ -10709,15 +10709,15 @@ multiple successive \grammarterm{directory-separator} characters are considered 
 be the same as one \grammarterm{directory-separator} character.
 
 \pnum
-The filename \grammarterm{dot}~(\ref{fs.def.filename}) is treated as a reference to the current directory.
-The filename \grammarterm{dot-dot}~(\ref{fs.def.filename}) is treated as a reference to the parent directory.
+The filename \grammarterm{dot}\iref{fs.def.filename} is treated as a reference to the current directory.
+The filename \grammarterm{dot-dot}\iref{fs.def.filename} is treated as a reference to the parent directory.
 What the filename \grammarterm{dot-dot} refers to
 relative to \grammarterm{root-directory} is \impldef{meaning of \grammarterm{dot-dot} in \grammarterm{root-directory}}.
 Specific filenames may have special meanings for a particular operating system.
 
 \pnum
 A \grammarterm{root-name} identifies the
-starting location for pathname resolution~(\ref{fs.def.pathres}).
+starting location for pathname resolution\iref{fs.def.pathres}.
 If there are no operating system dependent \grammarterm{root-name}{s},
 at least one \impldefrootname{} \grammarterm{root-name} is required.
 \begin{note} Many operating systems define a name
@@ -10758,8 +10758,8 @@ because on these systems:
 \pnum
 Several functions are defined to accept \term{detected-format} arguments,
 which are character sequences. A detected-format argument represents a path
-using either a pathname in the generic format~(\ref{fs.path.generic})
-or a pathname in the native format~(\ref{fs.def.native}).
+using either a pathname in the generic format\iref{fs.path.generic}
+or a pathname in the native format\iref{fs.def.native}.
 Such an argument is taken to be in the generic format if and only if
 it matches the generic format and is not acceptable to the operating system
 as a native path.
@@ -10790,7 +10790,7 @@ otherwise it shall be treated as a path to a regular file.
 
 \pnum
 \begin{note}
-A path stores a native format pathname~(\ref{fs.path.native.obs})
+A path stores a native format pathname\iref{fs.path.native.obs}
 and acts as if it also stores a generic format pathname,
 related as given below.
 The implementation may generate the generic format pathname
@@ -10828,7 +10828,7 @@ For the argument or return value, the method of conversion and the encoding
 to be converted to is determined
 by its value type:
 \begin{itemize}
-\item \tcode{char}: The encoding is the native narrow encoding~(\ref{fs.def.native.encode}).
+\item \tcode{char}: The encoding is the native narrow encoding\iref{fs.def.native.encode}.
 The method of conversion, if any, is operating system dependent.
 \begin{note}
 For POSIX-based operating systems \tcode{path::value_type} is \tcode{char}
@@ -10843,7 +10843,7 @@ standard library functions that perform file operations using narrow character
 strings to identify paths. Changing this behavior would be surprising and error
 prone.
 \end{note}
-\item \tcode{wchar_t}: The encoding is the native wide encoding~(\ref{fs.def.native.encode}).
+\item \tcode{wchar_t}: The encoding is the native wide encoding\iref{fs.def.native.encode}.
 The method of conversion is unspecified.
 \begin{note}
 For Windows-based operating systems \tcode{path::value_type} is \tcode{wchar_t}
@@ -10865,7 +10865,7 @@ if already of type \tcode{path::value_type}.
 \rSec3[fs.path.req]{\tcode{path} requirements}
 
 \pnum
-In addition to the requirements~(\ref{fs.req}),
+In addition to the requirements\iref{fs.req},
 function template parameters named \tcode{Source}
 shall be one of:
 \begin{itemize}
@@ -10898,12 +10898,12 @@ shall not participate in overload resolution unless either
 \tcode{basic_string} or \tcode{basic_string_view}, or
 \item
 the \grammarterm{qualified-id} \tcode{iterator_traits<decay_t<Source>>::value_type} is valid and
-denotes a possibly \tcode{const} encoded character type~(\ref{temp.deduct}).
+denotes a possibly \tcode{const} encoded character type\iref{temp.deduct}.
 \end{itemize}
 
 \pnum
 \begin{note}
-See path conversions~(\ref{fs.path.cvt})
+See path conversions\iref{fs.path.cvt}
 for how the value types above and their encodings convert to
 \tcode{path::value_type} and its encoding.
 \end{note}
@@ -10954,8 +10954,8 @@ path(string_type&& source, format fmt = auto_format);
 \effects
 Constructs an object of class \tcode{path}
 for which the pathname in the detected-format of \tcode{source}
-has the original value of \tcode{source}~(\ref{fs.path.fmt.cvt}),
-converting format if required~(\ref{fs.path.fmt.cvt}).
+has the original value of \tcode{source}\iref{fs.path.fmt.cvt},
+converting format if required\iref{fs.path.fmt.cvt}.
 \tcode{source} is left in a valid but unspecified state.
 \end{itemdescr}
 
@@ -10969,9 +10969,9 @@ template <class InputIterator>
 
 \begin{itemdescr}
 \pnum
-\effects Let \tcode{s} be the effective range of \tcode{source}~(\ref{fs.path.req})
-or the range \range{first}{last}, with the encoding converted if required~(\ref{fs.path.cvt}).
-Finds the detected-format of \tcode{s}~(\ref{fs.path.fmt.cvt})
+\effects Let \tcode{s} be the effective range of \tcode{source}\iref{fs.path.req}
+or the range \range{first}{last}, with the encoding converted if required\iref{fs.path.cvt}.
+Finds the detected-format of \tcode{s}\iref{fs.path.fmt.cvt}
 and constructs an object of class \tcode{path}
 for which the pathname in that format is \tcode{s}.
 \end{itemdescr}
@@ -10998,7 +10998,7 @@ follows:
 \begin{itemize}
 \item
 If \tcode{value_type} is \tcode{wchar_t}, converts to the native
-wide encoding~(\ref{fs.def.native.encode}) using the \tcode{codecvt<\brk{}wchar_t, char, mbstate_t>}
+wide encoding\iref{fs.def.native.encode} using the \tcode{codecvt<\brk{}wchar_t, char, mbstate_t>}
 facet of \tcode{loc}.
 \item
 Otherwise a conversion is performed using the
@@ -11007,7 +11007,7 @@ conversion to the current narrow encoding.
 \end{itemize}
 
 \pnum
-Finds the detected-format of \tcode{s}~(\ref{fs.path.fmt.cvt})
+Finds the detected-format of \tcode{s}\iref{fs.path.fmt.cvt}
 and constructs an object of class \tcode{path}
 for which the pathname in that format is \tcode{s}.
 
@@ -11024,7 +11024,7 @@ fs::create_directory(fs::path(latin1_string, latin1_locale));
 For POSIX-based operating systems, the path is constructed by first using
 \tcode{latin1_facet} to convert ISO/IEC 8859-1 encoded
 \tcode{latin1_string} to a wide character string in the native wide
-encoding~(\ref{fs.def.native.encode}). The resulting wide string is then
+encoding\iref{fs.def.native.encode}. The resulting wide string is then
 converted to a narrow character
 pathname string in the current native narrow encoding. If the
 native wide encoding is UTF-16 or UTF-32, and the current native narrow
@@ -11108,9 +11108,9 @@ template <class InputIterator>
 \begin{itemdescr}
 \pnum
 \effects
-Let \tcode{s} be the effective range of \tcode{source}~(\ref{fs.path.req})
-or the range \range{first}{last}, with the encoding converted if required~(\ref{fs.path.cvt}).
-Finds the detected-format of \tcode{s}~(\ref{fs.path.fmt.cvt})
+Let \tcode{s} be the effective range of \tcode{source}\iref{fs.path.req}
+or the range \range{first}{last}, with the encoding converted if required\iref{fs.path.cvt}.
+Finds the detected-format of \tcode{s}\iref{fs.path.fmt.cvt}
 and sets the pathname in that format to \tcode{s}.
 
 \pnum
@@ -11380,7 +11380,7 @@ void swap(path& rhs) noexcept;
 \rSec4[fs.path.native.obs]{\tcode{path} native format observers}
 
 \pnum
-The string returned by all native format observers is in the native pathname format~(\ref{fs.def.native}).
+The string returned by all native format observers is in the native pathname format\iref{fs.def.native}.
 
 \indexlibrarymember{native}{path}%
 \begin{itemdecl}
@@ -11463,7 +11463,7 @@ The encoding of the string returned by \tcode{u8string()} is always UTF-8.
 
 \pnum
 Generic format observer functions return strings formatted according to the
-generic pathname format~(\ref{fs.path.generic}).
+generic pathname format\iref{fs.path.generic}.
 A single slash (\tcode{'/'}) character is used as
 the \grammarterm{directory-separator}.
 
@@ -11809,7 +11809,7 @@ bool is_absolute() const;
 \begin{itemdescr}
 \pnum
 \returns \tcode{true} if the pathname in the native format
-  contains an absolute path~(\ref{fs.def.absolute.path}), else \tcode{false}.
+  contains an absolute path\iref{fs.def.absolute.path}, else \tcode{false}.
 
 \pnum
 \begin{example} \tcode{path("/").is_absolute()} is
@@ -11837,7 +11837,7 @@ path lexically_normal() const;
 \begin{itemdescr}
 \pnum
 \returns A path whose pathname in the generic format is
-the normal form~(\ref{fs.def.normal.form}) of the pathname
+the normal form\iref{fs.def.normal.form} of the pathname
 in the generic format of \tcode{*this}.
 
 \pnum
@@ -11861,8 +11861,8 @@ path lexically_relative(const path& base) const;
 \begin{itemdescr}
 \pnum
 \returns \tcode{*this} made relative to \tcode{base}.
-Does not resolve~(\ref{fs.def.pathres}) symlinks.
-Does not first normalize~(\ref{fs.def.normal.form}) \tcode{*this} or \tcode{base}.
+Does not resolve\iref{fs.def.pathres} symlinks.
+Does not first normalize\iref{fs.def.normal.form} \tcode{*this} or \tcode{base}.
 
 \pnum
 \effects
@@ -11911,7 +11911,7 @@ but that does not affect \tcode{path} equality.
   use the operational function \tcode{relative()}. \end{note}
 
 \pnum
-\begin{note} If normalization~(\ref{fs.def.normal.form}) is needed
+\begin{note} If normalization\iref{fs.def.normal.form} is needed
   to ensure consistent matching of elements,
   apply \tcode{lexically_normal()} to
   \tcode{*this}, \tcode{base}, or both. \end{note}
@@ -11932,7 +11932,7 @@ path lexically_proximate(const path& base) const;
   use the operational function \tcode{proximate()}. \end{note}
 
 \pnum
-\begin{note} If normalization~(\ref{fs.def.normal.form}) is needed
+\begin{note} If normalization\iref{fs.def.normal.form} is needed
   to ensure consistent matching of elements,
   apply \tcode{lexically_normal()} to
   \tcode{*this}, \tcode{base}, or both. \end{note}
@@ -11943,11 +11943,11 @@ path lexically_proximate(const path& base) const;
 \indexlibrary{\idxcode{path}!\idxcode{iterator}}%
 \pnum
 Path iterators iterate over the elements of the pathname
-in the generic format~(\ref{fs.path.generic}).
+in the generic format\iref{fs.path.generic}.
 
 \pnum
 A \tcode{path::iterator} is a constant iterator satisfying all the
-requirements of a bidirectional iterator~(\ref{bidirectional.iterators})
+requirements of a bidirectional iterator\iref{bidirectional.iterators}
 except that,
 for dereferenceable iterators \tcode{a} and \tcode{b}
 of type \tcode{path::iterator}
@@ -12078,7 +12078,7 @@ bool operator==(const path& lhs, const path& rhs) noexcept;
 which considers the two path's lexical representations only.
 \begin{example} \tcode{path("foo") == "bar"} is never \tcode{true}. \end{example}
 \item Equivalence is determined by the \tcode{equivalent()} non-member function, which
-determines if two paths resolve~(\ref{fs.def.pathres}) to the same file system entity.
+determines if two paths resolve\iref{fs.def.pathres} to the same file system entity.
 \begin{example}
 \tcode{equivalent("foo", "bar")} will be \tcode{true} when both paths resolve to the same file.
 \end{example}
@@ -12167,7 +12167,7 @@ template <class InputIterator>
 \returns
 \begin{itemize}
 \item If \tcode{value_type} is \tcode{char} and the current native
-      narrow encoding~(\ref{fs.def.native.encode}) is UTF-8,
+      narrow encoding\iref{fs.def.native.encode} is UTF-8,
       return \tcode{path(source)} or \tcode{path(first, last)};
       otherwise,
 \item if \tcode{value_type} is \tcode{wchar_t} and the
@@ -12183,7 +12183,7 @@ template <class InputIterator>
 \end{itemize}
 
 \pnum
-\remarks Argument format conversion~(\ref{fs.path.fmt.cvt}) applies to the
+\remarks Argument format conversion\iref{fs.path.fmt.cvt} applies to the
   arguments for these functions. How Unicode encoding conversions are performed is
   unspecified.
 
@@ -12413,7 +12413,7 @@ The file exists but the type could not be determined \\
 \indexlibrary{\idxcode{copy_options}}%
 \pnum
 The \tcode{enum class} type \tcode{copy_options}
-is a bitmask type~(\ref{bitmask.types}) that specifies bitmask constants used to control the semantics of
+is a bitmask type\iref{bitmask.types} that specifies bitmask constants used to control the semantics of
 copy operations. The constants are specified in option groups with the meanings listed in Table~\ref{tab:fs.enum.copy_options}.
 Constant \tcode{none} is shown in each option group for purposes of exposition;
 implementations shall provide only a single definition.
@@ -12468,7 +12468,7 @@ implementations shall provide only a single definition.
 \indexlibrary{\idxcode{perms}}%
 \pnum
 The \tcode{enum class} type \tcode{perms}
-is a bitmask type~(\ref{bitmask.types}) that specifies bitmask constants used to identify file
+is a bitmask type\iref{bitmask.types} that specifies bitmask constants used to identify file
 permissions, with the meanings listed in Table~\ref{tab:fs.enum.perms}.
 
 \begin{floattable}
@@ -12527,7 +12527,7 @@ permissions, with the meanings listed in Table~\ref{tab:fs.enum.perms}.
 \indexlibrary{\idxcode{perm_options}}%
 \pnum
 The \tcode{enum class} type \tcode{perm_options}
-is a bitmask type~(\ref{bitmask.types}) that specifies bitmask constants used to
+is a bitmask type\iref{bitmask.types} that specifies bitmask constants used to
 control the semantics of permissions operations,
 with the meanings listed in Table~\ref{tab:enum.perm_options}.
 The bitmask constants are bitmask elements.
@@ -12558,7 +12558,7 @@ passed to \tcode{permissions}.
 \indexlibrary{\idxcode{directory_options}}%
 \pnum
 The \tcode{enum class} type \tcode{directory_options} is a bitmask
-  type~(\ref{bitmask.types}) that specifies bitmask constants used to identify
+  type\iref{bitmask.types} that specifies bitmask constants used to identify
   directory traversal options, with the meanings listed in Table~\ref{tab:fs.enum.directory_options}.
 
 \begin{floattable}
@@ -12749,13 +12749,13 @@ such as hard link count, status, symlink status, file size, and last write time.
 Implementations should store such additional file attributes
 during directory iteration if their values are available
 and storing the values would allow the implementation to eliminate file system accesses
-by \tcode{directory_entry} observer functions~(\ref{fs.op.funcs}).
+by \tcode{directory_entry} observer functions\iref{fs.op.funcs}.
 Such stored file attribute values are said to be \defnx{cached}{file attributes!cached}.
 
 \pnum
 \begin{note}
 For purposes of exposition,
-class \tcode{directory_iterator}~(\ref{fs.class.directory_iterator})
+class \tcode{directory_iterator}\iref{fs.class.directory_iterator}
 is shown above as a friend of class \tcode{directory_entry}.
 Friendship allows the \tcode{directory_iterator} implementation to cache
 already available attribute values
@@ -12858,7 +12858,7 @@ void refresh(error_code& ec) noexcept;
 \begin{itemdescr}
 \pnum
 \effects Stores the current values of any cached attributes of the file \tcode{p} resolves to.
-If an error occurs, an error is reported~(\ref{fs.err.report})
+If an error occurs, an error is reported\iref{fs.err.report}
 and the values of any cached attributes are unspecified.
 
 \pnum
@@ -12866,7 +12866,7 @@ and the values of any cached attributes are unspecified.
 
 \pnum
 \begin{note}
-Implementations of \tcode{directory_iterator}~(\ref{fs.class.directory_iterator})
+Implementations of \tcode{directory_iterator}\iref{fs.class.directory_iterator}
 are prohibited from directly or indirectly calling the \tcode{refresh} function
 since it must access the external file system,
 and the objective of caching is to avoid unnecessary file system accesses.
@@ -13159,7 +13159,7 @@ bool operator>=(const directory_entry& rhs) const noexcept;
 \pnum
 An object of type \tcode{directory_iterator} provides an iterator for a
 sequence of \tcode{directory_entry} elements representing the
-path and any cached attribute values~(\ref{fs.class.directory_entry})
+path and any cached attribute values\iref{fs.class.directory_entry}
 for each file in a directory
 or in an \impldef{type of a directory-like file} directory-like file type.
 \begin{note} For iteration into sub-directories, see class \tcode{recursive_directory_iterator}
@@ -13201,7 +13201,7 @@ namespace std::filesystem {
 
 \pnum
  \tcode{directory_iterator} satisfies the requirements of an input
-iterator~(\ref{input.iterators}).
+iterator\iref{input.iterators}.
 
 \pnum
 If an iterator of type \tcode{directory_iterator} reports an error or
@@ -13232,7 +13232,7 @@ increments of a \tcode{directory_iterator} is unspecified.
 
 \pnum
 Constructors and non-const \tcode{directory_iterator} member functions
-store the values of any cached attributes~(\ref{fs.class.directory_entry})
+store the values of any cached attributes\iref{fs.class.directory_entry}
 in the \tcode{directory_entry} element returned by \tcode{operator*()}.
 \tcode{directory_iterator} member functions shall not directly or indirectly call
 any \tcode{directory_entry} \tcode{refresh} function.
@@ -13343,7 +13343,7 @@ directory_iterator& increment(error_code& ec) noexcept;
 
 \pnum
 \effects As specified for the prefix increment operation of
-Input iterators~(\ref{input.iterators}).
+Input iterators\iref{input.iterators}.
 
 \pnum
 \returns \tcode{*this}.
@@ -13630,7 +13630,7 @@ recursive_directory_iterator& increment(error_code& ec) noexcept;
 \begin{itemdescr}
 \pnum
 \effects As specified for the prefix increment operation of
-Input iterators~(\ref{input.iterators}),
+Input iterators\iref{input.iterators},
 except that:
 
 \begin{itemize}
@@ -13723,7 +13723,7 @@ Filesystem operation functions query or modify files, including directories,
 in external storage.
 
 \pnum
-\begin{note} Because hardware failures, network failures, file system races~(\ref{fs.def.race}),
+\begin{note} Because hardware failures, network failures, file system races\iref{fs.def.race},
 and many other kinds of errors occur frequently in file system operations, users should be aware
 that any filesystem operation function, no matter how apparently innocuous, may encounter
 an error; see~\ref{fs.err.report}. \end{note}
@@ -13739,7 +13739,7 @@ path absolute(const path& p, error_code& ec);
 \begin{itemdescr}
 \pnum
 \effects Composes an absolute path referencing the same file system location
-as \tcode{p} according to the operating system~(\ref{fs.conform.os}).
+as \tcode{p} according to the operating system\iref{fs.conform.os}.
 
 \pnum
 \returns The composed path.
@@ -13758,7 +13758,7 @@ unless an error occurs.
 \begin{note}
 To resolve symlinks,
 or perform other sanitization which might require queries to secondary storage,
-such as hard disks, consider \tcode{canonical}~(\ref{fs.op.canonical}).
+such as hard disks, consider \tcode{canonical}\iref{fs.op.canonical}.
 \end{note}
 
 \pnum
@@ -13835,7 +13835,7 @@ void copy(const path& from, const path& to, copy_options options,
 
 \begin{itemdescr}
 \pnum
-\requires At most one element from each option group~(\ref{fs.enum.copy.opts})
+\requires At most one element from each option group\iref{fs.enum.copy.opts}
   is set in \tcode{options}.
 
 \pnum
@@ -13860,7 +13860,7 @@ Effects are then as follows:
 \begin{itemize}
 \item
 If \tcode{f.type()} or \tcode{t.type()} is an implementation-defined
-file type~(\ref{fs.enum.file_type}), then the effects are
+file type\iref{fs.enum.file_type}, then the effects are
 \impldef{effect of \tcode{filesystem::copy}}.
 
 \item
@@ -13997,7 +13997,7 @@ bool copy_file(const path& from, const path& to, copy_options options,
 \begin{itemdescr}
 \pnum
 \requires At most one element from each
-  option group~(\ref{fs.enum.copy.opts}) is set
+  option group\iref{fs.enum.copy.opts} is set
   in \tcode{options}.
 
 \pnum
@@ -14025,7 +14025,7 @@ Otherwise, copy the contents and attributes of the file \tcode{from}
 \item \tcode{exists(to)} is \tcode{false}, or
 \item \tcode{(options \& copy_options::overwrite_existing) != copy_options::none}, or
 \item \tcode{(options \& copy_options::update_existing) \: \: != copy_options::none} and \tcode{from}
-      is more recent than \tcode{to}, determined as if by use of the \tcode{last_write_time} function~(\ref{fs.op.last_write_time}).
+      is more recent than \tcode{to}, determined as if by use of the \tcode{last_write_time} function\iref{fs.op.last_write_time}.
 \end{itemize}
 
 \item
@@ -14380,7 +14380,7 @@ uintmax_t file_size(const path& p, error_code& ec) noexcept;
 \returns
 \begin{itemize}
 \item
-  If \tcode{exists(p)} is \tcode{false}, an error is reported~(\ref{fs.err.report}).
+  If \tcode{exists(p)} is \tcode{false}, an error is reported\iref{fs.err.report}.
 \item
   Otherwise, if \tcode{is_regular_file(p)}, the size in bytes of the file
   \tcode{p} resolves to, determined as if by the value of the POSIX \tcode{stat}
@@ -15099,7 +15099,7 @@ Otherwise,
 \item Otherwise, if the attributes indicate a socket, as if by POSIX
       \tcode{S_ISSOCK}, returns \tcode{file_status(file_type::socket, prms)}.
 \item Otherwise, if the attributes indicate an implementation-defined
-      file type~(\ref{fs.enum.file_type}),
+      file type\iref{fs.enum.file_type},
       returns \tcode{file_status(file_type::\placeholdernc{A}, prms)},
       where \tcode{\placeholdernc{A}} is the constant for the
       \impldef{file type of the file argument of \tcode{filesystem::status}} file type.
@@ -15201,7 +15201,7 @@ path weakly_canonical(const path& p, error_code& ec);
 \begin{itemdescr}
 \pnum
 \returns \tcode{p} with symlinks resolved and
-  the result normalized~(\ref{fs.def.normal.form}).
+  the result normalized\iref{fs.def.normal.form}.
 
 \pnum
 \effects Using \tcode{status(p)} or \tcode{status(p, ec)}, respectively,
@@ -15220,7 +15220,7 @@ path weakly_canonical(const path& p, error_code& ec);
   \tcode{path()} is returned at the first error occurrence, if any.
 
 \pnum
-\postconditions The returned path is in normal form~(\ref{fs.def.normal.form}).
+\postconditions The returned path is in normal form\iref{fs.def.normal.form}.
 
 \pnum
 \remarks Implementations should
@@ -15384,7 +15384,7 @@ are the same as the C standard library header \tcode{<stdio.h>}.
 
 \pnum
 Calls to the function \tcode{tmpnam} with an argument that is a null pointer value may
-introduce a data race~(\ref{res.on.data.races}) with other calls to \tcode{tmpnam} with
+introduce a data race\iref{res.on.data.races} with other calls to \tcode{tmpnam} with
 an argument that is a null pointer value.
 
 \xref ISO C 7.21
@@ -15545,7 +15545,7 @@ The header \tcode{<cinttypes>} includes the header \tcode{<cstdint>} instead
 of \tcode{<stdint.h>}, and
 \item
 if and only if the type \tcode{intmax_t} designates an extended integer
-type~(\ref{basic.fundamental}), the following function signatures are added:
+type\iref{basic.fundamental}, the following function signatures are added:
 \begin{codeblock}
 intmax_t abs(intmax_t);
 imaxdiv_t div(intmax_t, intmax_t);

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -392,10 +392,9 @@ In this Clause, the type name \tcode{FILE} refers to
 the type
 \tcode{FILE}
 declared in
-\tcode{<cstdio>}
 \indextext{\idxhdr{cstdio}}%
 \indexlibrary{\idxhdr{cstdio}}%
-(\ref{cstdio.syn}).
+\tcode{<cstdio>}\iref{cstdio.syn}.
 
 \pnum
 The header
@@ -13162,8 +13161,8 @@ sequence of \tcode{directory_entry} elements representing the
 path and any cached attribute values\iref{fs.class.directory_entry}
 for each file in a directory
 or in an \impldef{type of a directory-like file} directory-like file type.
-\begin{note} For iteration into sub-directories, see class \tcode{recursive_directory_iterator}
-(\ref{fs.class.rec.dir.itr}). \end{note}
+\begin{note} For iteration into sub-directories, see class \tcode{recursive_directory_iterator}\iref{fs.class.rec.dir.itr}.
+\end{note}
 
 \begin{codeblock}
 namespace std::filesystem {

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -5,9 +5,9 @@
 
 \pnum
 This Clause describes components that \Cpp programs may use to perform
-iterations over containers (Clause \ref{containers}),
-streams~(\ref{iostream.format}),
-and stream buffers~(\ref{stream.buffers}).
+iterations over containers\iref{containers},
+streams\iref{iostream.format},
+and stream buffers\iref{stream.buffers}.
 
 \pnum
 The following subclauses describe
@@ -249,7 +249,7 @@ denotes a value of value type
 \tcode{o}
 denotes a value of some type that is writable to the output iterator.
 \begin{note} For an iterator type \tcode{X} there must be an instantiation
-of \tcode{iterator_traits<X>}~(\ref{iterator.traits}). \end{note}
+of \tcode{iterator_traits<X>}\iref{iterator.traits}. \end{note}
 
 \rSec2[iterator.iterators]{Iterator}
 
@@ -258,7 +258,7 @@ The \tcode{Iterator} requirements form the basis of the iterator concept
 taxonomy; every iterator satisfies the \tcode{Iterator} requirements. This
 set of requirements specifies operations for dereferencing and incrementing
 an iterator. Most algorithms will require additional operations to
-read~(\ref{input.iterators}) or write~(\ref{output.iterators}) values, or
+read\iref{input.iterators} or write\iref{output.iterators} values, or
 to provide a richer set of iterator movements~(\ref{forward.iterators},
 \ref{bidirectional.iterators}, \ref{random.access.iterators}).
 
@@ -267,8 +267,8 @@ A type \tcode{X} satisfies the \tcode{Iterator} requirements if:
 
 \begin{itemize}
 \item \tcode{X} satisfies the \tcode{CopyConstructible}, \tcode{CopyAssignable}, and
-\tcode{Destructible} requirements~(\ref{utility.arg.requirements}) and lvalues
-of type \tcode{X} are swappable~(\ref{swappable.requirements}), and
+\tcode{Destructible} requirements\iref{utility.arg.requirements} and lvalues
+of type \tcode{X} are swappable\iref{swappable.requirements}, and
 
 \item the expressions in Table~\ref{tab:iterator.requirements} are valid and have
 the indicated semantics.
@@ -307,7 +307,7 @@ A class or pointer type
 satisfies the requirements of an input iterator for the value type
 \tcode{T}
 if
-\tcode{X} satisfies the \tcode{Iterator}~(\ref{iterator.iterators}) and
+\tcode{X} satisfies the \tcode{Iterator}\iref{iterator.iterators} and
 \tcode{EqualityComparable} (Table~\ref{tab:equalitycomparable}) requirements and
 the expressions in Table~\ref{tab:iterator.input.requirements} are valid and have
 the indicated semantics.
@@ -412,7 +412,7 @@ class template.
 A class or pointer type
 \tcode{X}
 satisfies the requirements of an output iterator
-if \tcode{X} satisfies the \tcode{Iterator} requirements~(\ref{iterator.iterators})
+if \tcode{X} satisfies the \tcode{Iterator} requirements\iref{iterator.iterators}
 and the expressions in Table~\ref{tab:iterator.output.requirements}
 are valid and have the indicated semantics.
 
@@ -480,10 +480,10 @@ A class or pointer type
 satisfies the requirements of a forward iterator if
 
 \begin{itemize}
-\item \tcode{X} satisfies the requirements of an input iterator~(\ref{input.iterators}),
+\item \tcode{X} satisfies the requirements of an input iterator\iref{input.iterators},
 
 \item \tcode{X} satisfies the \tcode{DefaultConstructible}
-requirements~(\ref{utility.arg.requirements}),
+requirements\iref{utility.arg.requirements},
 
 \item if \tcode{X} is a mutable iterator, \tcode{reference} is a reference to \tcode{T};
 if \tcode{X} is a constant iterator, \tcode{reference} is a reference to \tcode{const T},
@@ -904,7 +904,7 @@ iterator_traits<Iterator>::pointer
 may be defined as \tcode{void}.
 
 \pnum
-If \tcode{Iterator} has valid~(\ref{temp.deduct}) member
+If \tcode{Iterator} has valid\iref{temp.deduct} member
 types \tcode{difference_type}, \tcode{value_type}, \tcode{pointer},
 \tcode{reference}, and \tcode{iterator_category},
 \tcode{iterator_traits<Iterator>}
@@ -1254,27 +1254,27 @@ namespace std {
 \pnum
 The template parameter
 \tcode{Iterator}
-shall meet all the requirements of a Bidirectional Iterator~(\ref{bidirectional.iterators}).
+shall meet all the requirements of a Bidirectional Iterator\iref{bidirectional.iterators}.
 
 \pnum
 Additionally,
 \tcode{Iterator}
-shall meet the requirements of a random access iterator~(\ref{random.access.iterators})
+shall meet the requirements of a random access iterator\iref{random.access.iterators}
 if any of the members
 \tcode{operator+}~(\ref{reverse.iter.op+}),
 \tcode{operator-}~(\ref{reverse.iter.op-}),
 \tcode{operator+=}~(\ref{reverse.iter.op+=}),
 \tcode{operator-=}~(\ref{reverse.iter.op-=}),
-\tcode{operator[]}~(\ref{reverse.iter.opindex}),
+\tcode{operator[]}\iref{reverse.iter.opindex},
 or the non-member operators
 \tcode{operator<}~(\ref{reverse.iter.op<}),
 \tcode{operator>}~(\ref{reverse.iter.op>}),\\
 \tcode{operator<=}~(\ref{reverse.iter.op<=}),
 \tcode{operator>=}~(\ref{reverse.iter.op>=}),
-\tcode{operator-}~(\ref{reverse.iter.opdiff})
+\tcode{operator-}\iref{reverse.iter.opdiff}
 or
-\tcode{operator+}~(\ref{reverse.iter.opsum})
-are referenced in a way that requires instantiation~(\ref{temp.inst}).
+\tcode{operator+}\iref{reverse.iter.opsum}
+are referenced in a way that requires instantiation\iref{temp.inst}.
 
 \rSec3[reverse.iter.ops]{\tcode{reverse_iterator} operations}
 
@@ -2197,11 +2197,11 @@ otherwise as a synonym for \tcode{\placeholder{R}}.
 
 \pnum
 The template parameter \tcode{Iterator} shall meet
-the requirements of an input iterator~(\ref{input.iterators}).
+the requirements of an input iterator\iref{input.iterators}.
 Additionally, if any of the bidirectional or random access traversal
 functions are instantiated, the template parameter shall meet the
-requirements for a Bidirectional Iterator~(\ref{bidirectional.iterators})
-or a Random Access Iterator~(\ref{random.access.iterators}), respectively.
+requirements for a Bidirectional Iterator\iref{bidirectional.iterators}
+or a Random Access Iterator\iref{random.access.iterators}, respectively.
 
 \rSec3[move.iter.ops]{\tcode{move_iterator} operations}
 
@@ -2562,7 +2562,7 @@ and prints the partial sums onto
 \indexlibrary{\idxcode{istream_iterator}}%
 The class template
 \tcode{istream_iterator}
-is an input iterator~(\ref{input.iterators}) that
+is an input iterator\iref{input.iterators} that
 reads (using
 \tcode{operator>>})
 successive elements from the input stream for which it was constructed.
@@ -2953,7 +2953,7 @@ ostream_iterator& operator++(int);
 The
 class template
 \tcode{istreambuf_iterator}
-defines an input iterator~(\ref{input.iterators}) that
+defines an input iterator\iref{input.iterators} that
 reads successive
 \textit{characters}
 from the streambuf for which it was constructed.

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -30,10 +30,10 @@
 \indextext{compilation!separate|(}%
 The text of the program is kept in units called
 \defnx{source files}{source file} in this International
-Standard. A source file together with all the headers~(\ref{headers})
-and source files included~(\ref{cpp.include}) via the preprocessing
+Standard. A source file together with all the headers\iref{headers}
+and source files included\iref{cpp.include} via the preprocessing
 directive \tcode{\#include}, less any source lines skipped by any of the
-conditional inclusion~(\ref{cpp.cond}) preprocessing directives, is
+conditional inclusion\iref{cpp.cond} preprocessing directives, is
 called a \defn{translation unit}.
 \begin{note} A \Cpp program need not all be translated at the same time.
 \end{note}
@@ -41,12 +41,12 @@ called a \defn{translation unit}.
 \pnum
 \begin{note} Previously translated translation units and instantiation
 units can be preserved individually or in libraries. The separate
-translation units of a program communicate~(\ref{basic.link}) by (for
+translation units of a program communicate\iref{basic.link} by (for
 example) calls to functions whose identifiers have external linkage,
 manipulation of objects whose identifiers have external linkage, or
 manipulation of data files. Translation units can be separately
 translated and then later linked to produce an executable
-program~(\ref{basic.link}). \end{note}%
+program\iref{basic.link}. \end{note}%
 \indextext{compilation!separate|)}
 
 \rSec1[lex.phases]{Phases of translation}%
@@ -68,14 +68,14 @@ The set of physical source file characters accepted is \impldef{physical source 
 characters}.
 Any
 source file character not in the basic source character
-set~(\ref{lex.charset}) is replaced by the
+set\iref{lex.charset} is replaced by the
 \indextext{universal character name}\grammarterm{universal-character-name} that
 designates that character. An implementation may use any internal
 encoding, so long as an actual extended character encountered in the
 source file, and the same extended character expressed in the source
 file as a \grammarterm{universal-character-name} (e.g., using the \tcode{\textbackslash
 uXXXX} notation), are handled equivalently
-except where this replacement is reverted~(\ref{lex.pptoken}) in a raw string literal.
+except where this replacement is reverted\iref{lex.pptoken} in a raw string literal.
 
 \indextext{line splicing}%
 \item Each instance of a backslash character (\textbackslash)
@@ -93,7 +93,7 @@ shall be processed as if an additional new-line character were appended
 to the file.
 
 \item The source file is decomposed into preprocessing
-tokens~(\ref{lex.pptoken}) and sequences of white-space characters
+tokens\iref{lex.pptoken} and sequences of white-space characters
 (including comments). A source file shall not end in a partial
 preprocessing token or in a partial comment.\footnote{A partial preprocessing
 token would arise from a source file
@@ -117,7 +117,7 @@ directive.
 expanded, and \tcode{_Pragma} unary operator expressions are executed.
 If a character sequence that matches the syntax of a
 \grammarterm{universal-character-name} is produced by token
-concatenation~(\ref{cpp.concat}), the behavior is undefined. A
+concatenation\iref{cpp.concat}, the behavior is undefined. A
 \tcode{\#include} preprocessing directive causes the named header or
 source file to be processed from phase 1 through phase 4, recursively.
 All preprocessing directives are then deleted.
@@ -135,11 +135,11 @@ non-corresponding source characters to the same execution character.}
 
 \item White-space characters separating tokens are no longer
 significant. Each preprocessing token is converted into a
-token~(\ref{lex.token}). The resulting tokens are syntactically and
+token\iref{lex.token}. The resulting tokens are syntactically and
 semantically analyzed and translated as a translation unit. \begin{note}
 The process of analyzing and translating the tokens may occasionally
 result in one token being replaced by a sequence of other
-tokens~(\ref{temp.names}).\end{note} \begin{note} Source files, translation
+tokens\iref{temp.names}.\end{note} \begin{note} Source files, translation
 units and translated translation units need not necessarily be stored as
 files, nor need there be any one-to-one correspondence between these
 entities and any external representation. The description is conceptual
@@ -150,7 +150,7 @@ as follows: \begin{note} Some or all of these may be supplied from a
 library. \end{note} Each translated translation unit is examined to
 produce a list of required instantiations. \begin{note} This may include
 instantiations which have been explicitly
-requested~(\ref{temp.explicit}). \end{note} The definitions of the
+requested\iref{temp.explicit}. \end{note} The definitions of the
 required templates are located. It is \impldef{whether source of translation units must
 be available to locate template definitions} whether the
 source of the translation units containing these definitions is required
@@ -221,7 +221,7 @@ a character or
 string literal corresponds to a control character (in either of the
 ranges 0x00--0x1F or 0x7F--0x9F, both inclusive) or to a character in the basic
 source character set, the program is ill-formed.\footnote{A sequence of characters resembling a \grammarterm{universal-character-name} in an
-\grammarterm{r-char-sequence}~(\ref{lex.string}) does not form a
+\grammarterm{r-char-sequence}\iref{lex.string} does not form a
 \grammarterm{universal-character-name}.}
 
 \pnum
@@ -262,7 +262,7 @@ are locale-specific.%
 \end{bnf}
 
 \pnum
-Each preprocessing token that is converted to a token~(\ref{lex.token})
+Each preprocessing token that is converted to a token\iref{lex.token}
 shall have the lexical form of a keyword, an identifier, a literal, an
 operator, or a punctuator.
 
@@ -278,9 +278,9 @@ separated by
 \indextext{space!white}%
 white space;
 \indextext{comment}%
-this consists of comments~(\ref{lex.comment}), or white-space
+this consists of comments\iref{lex.comment}, or white-space
 characters (space, horizontal tab, new-line, vertical tab, and
-form-feed), or both. As described in Clause~\ref{cpp}, in certain
+form-feed), or both. As described in \ref{cpp}, in certain
 circumstances during translation phase 4, white space (or the absence
 thereof) serves as more than preprocessing token separation. White space
 can appear within a preprocessing token only as part of a header name or
@@ -313,8 +313,8 @@ itself and not as the first character of the alternative token \tcode{<:}.
 the next preprocessing token is the longest sequence of
 characters that could constitute a preprocessing token, even if that
 would cause further lexical analysis to fail,
-except that a \grammarterm{header-name}~(\ref{lex.header}) is only formed
-within a \tcode{\#include} directive~(\ref{cpp.include}).
+except that a \grammarterm{header-name}\iref{lex.header} is only formed
+within a \tcode{\#include} directive\iref{cpp.include}.
 \end{itemize}
 
 \begin{example}
@@ -356,7 +356,7 @@ keywords are colloquially known as ``digraphs''. }
 
 \pnum
 In all respects of the language, each alternative token behaves the
-same, respectively, as its primary token, except for its spelling.\footnote{Thus the ``stringized'' values~(\ref{cpp.stringize}) of
+same, respectively, as its primary token, except for its spelling.\footnote{Thus the ``stringized'' values\iref{cpp.stringize} of
 \tcode{[} and \tcode{<:} will be different, maintaining the source
 spelling, but the tokens can otherwise be freely interchanged. }
 The set of alternative tokens is defined in
@@ -501,8 +501,8 @@ depending on the implementation.}%
 
 \pnum
 Preprocessing number tokens lexically include all integer literal
-tokens~(\ref{lex.icon}) and all floating literal
-tokens~(\ref{lex.fcon}).
+tokens\iref{lex.icon} and all floating literal
+tokens\iref{lex.fcon}.
 
 \pnum
 A preprocessing number does not have a type or a value; it acquires both
@@ -666,7 +666,7 @@ reserved to the implementation for use as a name in the global namespace.%
 \indextext{keyword|(}%
 The identifiers shown in Table~\ref{tab:keywords} are reserved for use
 as keywords (that is, they are unconditionally treated as keywords in
-phase 7) except in an \grammarterm{attribute-token}~(\ref{dcl.attr.grammar}):
+phase 7) except in an \grammarterm{attribute-token}\iref{dcl.attr.grammar}:
 
 \begin{floattable}{Keywords}{tab:keywords}
 {lllll}
@@ -770,7 +770,7 @@ are reserved for future use.\end{note}
 \pnum
 Furthermore, the alternative representations shown in
 Table~\ref{tab:alternative.representations} for certain operators and
-punctuators~(\ref{lex.digraph}) are reserved and shall not be used
+punctuators\iref{lex.digraph} are reserved and shall not be used
 otherwise:
 
 
@@ -806,7 +806,7 @@ are converted into tokens for operators and punctuators:
 \end{bnfkeywordtab}
 
 Each \grammarterm{preprocessing-op-or-punc} is converted to a single token
-in translation phase 7~(\ref{lex.phases}).%
+in translation phase 7\iref{lex.phases}.%
 \indextext{punctuator|)}%
 \indextext{operator|)}
 
@@ -1037,7 +1037,7 @@ and \tcode{ll} or \tcode{LL}  &
 
 \pnum
 If an integer literal cannot be represented by any type in its list and
-an extended integer type~(\ref{basic.fundamental}) can represent its value, it may have that
+an extended integer type\iref{basic.fundamental} can represent its value, it may have that
 extended integer type. If all of the types in the list for the integer literal
 are signed, the extended integer type shall be signed. If all of the
 types in the list for the integer literal are unsigned, the extended integer
@@ -1545,11 +1545,11 @@ string literals. A narrow string literal has type
 \indextext{literal!string!type of}%
 ``array of \placeholder{n} \tcode{const char}'', where \placeholder{n} is the size of
 the string as defined below, and has static storage
-duration~(\ref{basic.stc}).
+duration\iref{basic.stc}.
 
 \pnum
 For a UTF-8 string literal, each successive element of the object
-representation~(\ref{basic.types}) has the value of the corresponding
+representation\iref{basic.types} has the value of the corresponding
 code unit of the UTF-8 encoding of the string.
 
 \pnum
@@ -1591,7 +1591,7 @@ is initialized with the given characters.
 
 \pnum
 \indextext{concatenation!string}%
-In translation phase 6~(\ref{lex.phases}), adjacent \grammarterm{string-literal}{s} are concatenated. If
+In translation phase 6\iref{lex.phases}, adjacent \grammarterm{string-literal}{s} are concatenated. If
 both \grammarterm{string-literal}{s} have the same \grammarterm{encoding-prefix}, the resulting concatenated string literal has
 that \grammarterm{encoding-prefix}. If one \grammarterm{string-literal} has no \grammarterm{encoding-prefix}, it is treated as a \grammarterm{string-literal} of
 the same \grammarterm{encoding-prefix} as the other operand. If a UTF-8 string literal token is adjacent to a
@@ -1643,12 +1643,12 @@ after concatenation (and not the single hexadecimal character
 \indextext{\idxcode{0}!string terminator}%
 \indextext{\idxcode{0}!null character|see {character, null}}%
 After any necessary concatenation, in translation phase
-7~(\ref{lex.phases}), \tcode{'\textbackslash 0'} is appended to every
+7\iref{lex.phases}, \tcode{'\textbackslash 0'} is appended to every
 string literal so that programs that scan a string can find its end.
 
 \pnum
 Escape sequences and \grammarterm{universal-character-name}{s} in non-raw string literals
-have the same meaning as in character literals~(\ref{lex.ccon}), except that
+have the same meaning as in character literals\iref{lex.ccon}, except that
 the single quote \tcode{'} is representable either by itself or by the escape sequence
 \tcode{\textbackslash'}, and the double quote \tcode{"} shall be preceded by a
 \tcode{\textbackslash},
@@ -1771,11 +1771,11 @@ characters that could match that non-terminal.
 
 \pnum
 A \grammarterm{user-defined-literal} is treated as a call to a literal operator or
-literal operator template~(\ref{over.literal}). To determine the form of this call for a
+literal operator template\iref{over.literal}. To determine the form of this call for a
 given \grammarterm{user-defined-literal} \placeholder{L} with \grammarterm{ud-suffix} \placeholder{X},
 the \grammarterm{literal-operator-id} whose literal suffix identifier is \placeholder{X} is
 looked up in the context of \placeholder{L} using the rules for unqualified name
-lookup~(\ref{basic.lookup.unqual}). Let \placeholder{S} be the set of declarations found by
+lookup\iref{basic.lookup.unqual}. Let \placeholder{S} be the set of declarations found by
 this lookup. \placeholder{S} shall not be empty.
 
 \pnum
@@ -1789,7 +1789,7 @@ operator "" @\placeholder{X}@(@\placeholder{n}@ULL)
 \end{codeblock}
 
 Otherwise, \placeholder{S} shall contain a raw literal operator or a literal operator
-template~(\ref{over.literal}) but not both. If \placeholder{S} contains a raw literal operator,
+template\iref{over.literal} but not both. If \placeholder{S} contains a raw literal operator,
 the literal \placeholder{L} is treated as a call of the form
 
 \begin{codeblock}
@@ -1819,7 +1819,7 @@ operator "" @\placeholder{X}@(@\placeholder{f}@L)
 \end{codeblock}
 
 Otherwise, \placeholder{S} shall contain a raw literal operator or a literal operator
-template~(\ref{over.literal}) but not both. If \placeholder{S} contains a raw literal operator,
+template\iref{over.literal} but not both. If \placeholder{S} contains a raw literal operator,
 the \grammarterm{literal} \placeholder{L} is treated as a call of the form
 
 \begin{codeblock}
@@ -1852,7 +1852,7 @@ operator "" @\placeholder{X}@(@\placeholder{str}{}@, @\placeholder{len}{}@)
 \pnum
 If \placeholder{L} is a \grammarterm{user-defined-character-literal}, let \placeholder{ch} be the
 literal without its \grammarterm{ud-suffix}.
-\placeholder{S} shall contain a literal operator~(\ref{over.literal}) whose only parameter has
+\placeholder{S} shall contain a literal operator\iref{over.literal} whose only parameter has
 the type of \placeholder{ch} and the
 literal \placeholder{L} is treated as a call
 of the form
@@ -1879,7 +1879,7 @@ int main() {
 \end{example}
 
 \pnum
-In translation phase 6~(\ref{lex.phases}), adjacent string literals are concatenated and
+In translation phase 6\iref{lex.phases}, adjacent string literals are concatenated and
 \grammarterm{user-defined-string-literal}{s} are considered string literals for that
 purpose. During concatenation, \grammarterm{ud-suffix}{es} are removed and ignored and
 the concatenation process occurs as described in~\ref{lex.string}. At the end of phase

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1302,15 +1302,17 @@ The supplied version of the header
 \indextext{\idxhdr{cstdlib}}%
 \indexlibrary{\idxhdr{cstdlib}}%
 shall declare at least the functions
-\tcode{abort},
-\tcode{atexit},
-\tcode{at_quick_exit},
-\tcode{exit},
-and \tcode{quick_exit}
 \indexlibrary{\idxcode{abort}}%
+\tcode{abort},
 \indexlibrary{\idxcode{atexit}}%
+\tcode{atexit},
+\indexlibrary{\idxcode{at_quick_exit}}%
+\tcode{at_quick_exit},
 \indexlibrary{\idxcode{exit}}%
-(\ref{support.start.term}).
+\tcode{exit},
+and
+\indexlibrary{\idxcode{quick_exit}}%
+\tcode{quick_exit}\iref{support.start.term}.
 The other headers listed in this table shall meet the same requirements as for a hosted implementation.
 
 \rSec2[using]{Using the library}

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -11,16 +11,16 @@ how a well-formed \Cpp program makes use of the library, and
 how a conforming implementation may provide the entities in the library.
 
 \pnum
-The following subclauses describe the definitions~(\ref{definitions}), method of
-description~(\ref{description}), and organization~(\ref{organization}) of the
-library. Clause~\ref{requirements}, Clauses~\ref{\firstlibchapter}
-through~\ref{\lastlibchapter}, and Annex~\ref{depr} specify the contents of the
+The following subclauses describe the definitions\iref{definitions}, method of
+description\iref{description}, and organization\iref{organization} of the
+library. \ref{requirements}, \ref{\firstlibchapter}
+through \ref{\lastlibchapter}, and \ref{depr} specify the contents of the
 library, as well as library requirements and constraints on both well-formed
 \Cpp programs and conforming implementations.
 
 \pnum
 Detailed specifications for each of the components in the library are in
-Clauses~\ref{\firstlibchapter}--\ref{\lastlibchapter}, as shown in
+\ref{\firstlibchapter}--\ref{\lastlibchapter}, as shown in
 Table~\ref{tab:library.categories}.
 
 \begin{libsumtabbase}{Library categories}{tab:library.categories}{Clause}{Category}
@@ -40,24 +40,24 @@ Table~\ref{tab:library.categories}.
 \end{libsumtabbase}
 
 \pnum
-The language support library (Clause~\ref{language.support}) provides components that are
+The language support library\iref{language.support} provides components that are
 required by certain parts of the \Cpp language, such as memory allocation~(\ref{expr.new},
-\ref{expr.delete}) and exception processing (Clause~\ref{except}).
+\ref{expr.delete}) and exception processing\iref{except}.
 
 \pnum
-The diagnostics library (Clause~\ref{diagnostics}) provides a consistent framework for
+The diagnostics library\iref{diagnostics} provides a consistent framework for
 reporting errors in a \Cpp program, including predefined exception classes.
 
 \pnum
-The general utilities library (Clause~\ref{utilities}) includes components used
+The general utilities library\iref{utilities} includes components used
 by other library elements, such as a predefined storage allocator for dynamic
-storage management~(\ref{basic.stc.dynamic}), and components used
+storage management\iref{basic.stc.dynamic}, and components used
 as infrastructure
 in \Cpp programs,
 such as tuples, function wrappers, and time facilities.
 
 \pnum
-The strings library (Clause~\ref{strings}) provides support for manipulating text represented
+The strings library\iref{strings} provides support for manipulating text represented
 as sequences of type
 \tcode{char},
 sequences of type
@@ -69,16 +69,16 @@ sequences of type
 and sequences of any other character-like type.
 
 \pnum
-The localization library (Clause~\ref{localization}) provides extended internationalization
+The localization library\iref{localization} provides extended internationalization
 support for text processing.
 
 \pnum
-The containers (Clause~\ref{containers}), iterators (Clause~\ref{iterators}),
-and algorithms (Clause~\ref{algorithms}) libraries provide a \Cpp program with access
+The containers\iref{containers}, iterators\iref{iterators},
+and algorithms\iref{algorithms} libraries provide a \Cpp program with access
 to a subset of the most widely used algorithms and data structures.
 
 \pnum
-The numerics library (Clause~\ref{numerics}) provides
+The numerics library\iref{numerics} provides
 numeric algorithms and complex number components that extend support for numeric processing.
 The
 \tcode{valarray}
@@ -89,21 +89,21 @@ potentially implemented as parallel operations on platforms that support such pr
 The random number component provides facilities for generating pseudo-random numbers.
 
 \pnum
-The input/output library (Clause~\ref{input.output}) provides the
+The input/output library\iref{input.output} provides the
 \tcode{iostream}
 components that are the primary mechanism for \Cpp program input and output.
 They can be used with other elements of the library, particularly
 strings, locales, and iterators.
 
 \pnum
-The regular expressions library (Clause~\ref{re}) provides regular expression matching and searching.
+The regular expressions library\iref{re} provides regular expression matching and searching.
 
 \pnum
-The atomic operations library (Clause~\ref{atomics}) allows more fine-grained
+The atomic operations library\iref{atomics} allows more fine-grained
 concurrent access to shared data than is possible with locks.
 
 \pnum
-The thread support library (Clause~\ref{thread}) provides components to create
+The thread support library\iref{thread} provides components to create
 and manage threads, including mutual exclusion and interthread communication.
 
 \rSec1[library.c]{The C standard library}
@@ -129,20 +129,20 @@ are the same unless otherwise stated.
 
 \pnum
 \begin{note}
-Clause \ref{intro.defs} defines additional terms used elsewhere in this International Standard.
+\ref{intro.defs} defines additional terms used elsewhere in this International Standard.
 \end{note}
 
 \def\definition{\definitionx{\subsection}}%
 
 \definition{arbitrary-positional stream}{defns.arbitrary.stream}
 \indexdefn{stream!arbitrary-positional}%
-a stream (described in Clause~\ref{input.output}) that can seek to any integral position within
+a stream (described in \ref{input.output}) that can seek to any integral position within
 the length of the stream\\
 \begin{note} Every arbitrary-positional stream is also a repositional stream. \end{note}
 
 \definition{character}{defns.character}
 \indexdefn{character}%
-\defncontext{Clauses~\ref{strings}, \ref{localization}, \ref{input.output}, and~\ref{re}}
+\defncontext{\ref{strings}, \ref{localization}, \ref{input.output}, and~\ref{re}}
 any object which,
 when treated sequentially,
 can represent text\\
@@ -166,13 +166,13 @@ represent a
 \begin{note}
 It is used for one of the template parameters of the string,
 iostream, and regular expression class templates.
-A character container type is a POD~(\ref{basic.types}) type.
+A character container type is a POD\iref{basic.types} type.
 \end{note}
 
 \definition{comparison function}{defns.comparison}
 \indexdefn{function!comparison}%
-an operator function~(\ref{over.oper}) for any of the equality~(\ref{expr.eq}) or
-relational~(\ref{expr.rel}) operators
+an operator function\iref{over.oper} for any of the equality\iref{expr.eq} or
+relational\iref{expr.rel} operators
 
 \definition{component}{defns.component}
 \indexdefn{component}%
@@ -192,8 +192,8 @@ strings are referred to as the
 \indexdefn{constant subexpression}%
 an expression whose evaluation as subexpression of a
 \grammarterm{conditional-expression}
-\tcode{CE}~(\ref{expr.cond}) would not prevent \tcode{CE}
-from being a core constant expression~(\ref{expr.const})
+\tcode{CE}\iref{expr.cond} would not prevent \tcode{CE}
+from being a core constant expression\iref{expr.const}
 
 \definition{deadlock}{defns.deadlock}
 \indexdefn{deadlock}%
@@ -218,8 +218,8 @@ semantics
 
 \definition{direct-non-list-initialization}{defns.direct-non-list-init}
 \indexdefn{direct-non-list-initialization}%
-a direct-initialization~(\ref{dcl.init})
-that is not list-initialization~(\ref{dcl.init.list})
+a direct-initialization\iref{dcl.init}
+that is not list-initialization\iref{dcl.init.list}
 
 \definition{handler function}{defns.handler}
 \indexdefn{function!handler}%
@@ -229,11 +229,11 @@ whose definition may be provided by a \Cpp program\\
 \begin{note}
 A \Cpp program may designate a handler function at various points in its execution by
 supplying a pointer to the function when calling any of the library functions that install
-handler functions (Clause~\ref{language.support}).
+handler functions\iref{language.support}.
 \end{note}
 
 \definition{iostream class templates}{defns.iostream.templates}
-templates, defined in Clause~\ref{input.output},
+templates, defined in \ref{input.output},
 that take two template arguments\\
 \begin{note}
 The arguments are named
@@ -253,7 +253,7 @@ necessary to implement the iostream class templates.
 
 \definition{modifier function}{defns.modifier}
 \indexdefn{function!modifier}%
-a class member function~(\ref{class.mfct}) other than a constructor,
+a class member function\iref{class.mfct} other than a constructor,
 assignment operator, or destructor
 that alters the state of an object of the class
 
@@ -276,12 +276,12 @@ value
 
 \definition{observer function}{defns.observer}
 \indexdefn{function!observer}%
-a class member function~(\ref{class.mfct}) that accesses the state of an object of the class
+a class member function\iref{class.mfct} that accesses the state of an object of the class
 but does not alter that state\\
 \begin{note}
 Observer functions are specified as
 \tcode{const}
-member functions~(\ref{class.this}).
+member functions\iref{class.this}.
 \end{note}
 
 \definition{referenceable type}{defns.referenceable}
@@ -298,13 +298,13 @@ a
 whose definition is provided by a \Cpp program\\
 \begin{note}
 Only one definition for such a function is in effect for the duration of the program's
-execution, as the result of creating the program~(\ref{lex.phases}) and resolving the
-definitions of all translation units~(\ref{basic.link}).
+execution, as the result of creating the program\iref{lex.phases} and resolving the
+definitions of all translation units\iref{basic.link}.
 \end{note}
 
 \definition{repositional stream}{defns.repositional.stream}
 \indexdefn{stream!repositional}%
-a stream (described in Clause~\ref{input.output}) that can seek to a position that was
+a stream (described in \ref{input.output}) that can seek to a position that was
 previously encountered
 
 \definition{required behavior}{defns.required.behavior}
@@ -357,8 +357,8 @@ and \tcode{x.front()} can be called only if \tcode{x.empty()} returns
 \pnum
 This subclause describes the conventions used to specify the \Cpp standard
 library. \ref{structure} describes the structure of the normative
-Clauses~\ref{\firstlibchapter} through~\ref{\lastlibchapter} and
-Annex~\ref{depr}. \ref{conventions} describes other editorial conventions.
+\ref{\firstlibchapter} through \ref{\lastlibchapter} and
+\ref{depr}. \ref{conventions} describes other editorial conventions.
 
 \rSec2[structure]{Structure of each clause}
 
@@ -428,7 +428,7 @@ defined''. That is, whether the operator is a member is unspecified.
 Requirements are stated in terms of well-defined expressions that define valid terms of
 the types that satisfy the requirements. For every set of well-defined expression
 requirements there is a table that specifies an initial set of the valid expressions and
-their semantics. Any generic algorithm (Clause~\ref{algorithms}) that uses the
+their semantics. Any generic algorithm\iref{algorithms} that uses the
 well-defined expression requirements is described in terms of the valid expressions for
 its template type parameters.
 
@@ -482,7 +482,7 @@ preconditions, there will be no \requires paragraph.}
 \begin{itemize}
 \item \requires the preconditions for calling the function
 \item \effects the actions performed by the function
-\item \sync the synchronization operations~(\ref{intro.multithread}) applicable to the function
+\item \sync the synchronization operations\iref{intro.multithread} applicable to the function
 \item \postconditions the observable results established by the function
 \item \returns a description of the value(s) returned by the function
 \item \throws any exceptions thrown by the function, and the conditions that would cause the exception
@@ -508,7 +508,7 @@ element in the code sequence.
 
 \pnum
 For non-reserved replacement and handler functions,
-Clause~\ref{language.support} specifies two behaviors for the functions in question:
+\ref{language.support} specifies two behaviors for the functions in question:
 their required and default behavior.
 The
 \term{default behavior}
@@ -535,7 +535,7 @@ the requirements.
 \pnum
 Error conditions specify conditions where a function may fail. The conditions
 are listed, together with a suitable explanation, as the \tcode{enum class errc}
-constants~(\ref{syserr}).
+constants\iref{syserr}.
 
 \rSec3[structure.see.also]{C library}
 
@@ -550,8 +550,8 @@ of this International Standard and the ISO C standard.
 This subclause describes several editorial conventions used to describe the contents
 of the \Cpp standard library.
 These conventions are for describing
-implementation-defined types~(\ref{type.descriptions}),
-and member functions~(\ref{functions.within.classes}).
+implementation-defined types\iref{type.descriptions},
+and member functions\iref{functions.within.classes}.
 
 \rSec3[type.descriptions]{Type descriptions}
 
@@ -573,15 +573,15 @@ may be supplied as arguments by a \Cpp program when instantiating template compo
 the library.
 
 \pnum
-Certain types defined in Clause~\ref{input.output} are used to describe implementation-defined types.
+Certain types defined in \ref{input.output} are used to describe implementation-defined types.
 \indextext{types!implementation-defined}%
 They are based on other types, but with added constraints.
 
 \rSec4[expos.only.types]{Exposition-only types}
 
 \pnum
-Several types defined in Clauses~\ref{\firstlibchapter} through~\ref{\lastlibchapter}
-and Annex~\ref{depr} that are used as function parameter or return types are defined
+Several types defined in \ref{\firstlibchapter} through \ref{\lastlibchapter}
+and \ref{depr} that are used as function parameter or return types are defined
 for the purpose of exposition only in order to capture their language linkage. The
 declarations of such types are followed by a comment ending in \textit{exposition only}.
 \begin{example}
@@ -597,12 +597,12 @@ that takes a callback parameter with C language linkage.
 \rSec4[enumerated.types]{Enumerated types}
 
 \pnum
-Several types defined in Clause~\ref{input.output} are
+Several types defined in \ref{input.output} are
 \term{enumerated types}.
 \indextext{type!enumerated}%
 Each enumerated type may be implemented as an enumeration or as a synonym for
 an enumeration.\footnote{Such as an integer type, with constant integer
-values~(\ref{basic.fundamental}).}
+values\iref{basic.fundamental}.}
 
 \pnum
 The enumerated type \tcode{\placeholder{enumerated}} can be written:
@@ -628,14 +628,14 @@ All such elements have distinct values.
 \rSec4[bitmask.types]{Bitmask types}
 
 \pnum
-Several types defined in Clauses~\ref{\firstlibchapter} through~\ref{\lastlibchapter}
-and Annex~\ref{depr} are
+Several types defined in \ref{\firstlibchapter} through \ref{\lastlibchapter}
+and \ref{depr} are
 \term{bitmask types}.
 \indextext{type!bitmask}%
 Each bitmask type can be implemented as an
 enumerated type that overloads certain operators, as an integer type,
 or as a
-\tcode{bitset}~(\ref{template.bitset}).
+\tcode{bitset}\iref{template.bitset}.
 \indextext{type!enumerated}%
 
 \pnum
@@ -739,8 +739,8 @@ character sequence and a value of one of the floating-point types.
 It is used
 in the character sequence to denote the beginning of a fractional part.
 It is
-represented in Clauses~\ref{\firstlibchapter} through~\ref{\lastlibchapter}
-and Annex~\ref{depr} by a period,
+represented in \ref{\firstlibchapter} through \ref{\lastlibchapter}
+and \ref{depr} by a period,
 \indextext{period}%
 \tcode{'.'},
 which is
@@ -748,25 +748,25 @@ also its value in the \tcode{"C"}
 locale, but may change during program
 execution by a call to
 \tcode{setlocale(int, const char*)},\footnote{declared in
-\tcode{<clocale>}~(\ref{c.locales}).
+\tcode{<clocale>}\iref{c.locales}.
 \indextext{\idxcode{setlocale}}%
 \indexlibrary{\idxcode{setlocale}}%
 \indextext{\idxhdr{clocale}}%
 \indexlibrary{\idxhdr{clocale}}}
 or by a change to a
 \tcode{locale}
-object, as described in Clauses~\ref{locales} and~\ref{input.output}.
+object, as described in \ref{locales} and \ref{input.output}.
 \item
 A
 \term{character sequence}
-is an array object~(\ref{dcl.array}) \tcode{\placeholdernc{A}} that
+is an array object\iref{dcl.array} \tcode{\placeholdernc{A}} that
 can be declared as
 \tcode{\placeholdernc{T\;A}[\placeholder{N}]},
 where \tcode{\placeholder{T}} is any of the types
 \tcode{char},
 \tcode{unsigned char},
 or
-\tcode{signed char}~(\ref{basic.fundamental}), optionally qualified by any combination of
+\tcode{signed char}\iref{basic.fundamental}, optionally qualified by any combination of
 \tcode{const}
 or
 \tcode{volatile}.
@@ -794,7 +794,7 @@ character); no other element in the sequence has the value zero.%
 \indexlibrary{\idxhdr{cstring}}%
 \indextext{NTBS}\footnote{Many of the objects manipulated by
 function signatures declared in
-\tcode{<cstring>}~(\ref{c.strings}) are character sequences or \ntbs{}s.
+\tcode{<cstring>}\iref{c.strings} are character sequences or \ntbs{}s.
 \indextext{\idxhdr{cstring}}%
 \indexlibrary{\idxhdr{cstring}}%
 The size of some of these character sequences is limited by
@@ -850,8 +850,8 @@ is an \ntmbs with static storage duration.
 \rSec3[functions.within.classes]{Functions within classes}
 
 \pnum
-For the sake of exposition, Clauses~\ref{\firstlibchapter} through~\ref{\lastlibchapter}
-and Annex~\ref{depr} do not describe copy/move constructors, assignment
+For the sake of exposition, \ref{\firstlibchapter} through \ref{\lastlibchapter}
+and \ref{depr} do not describe copy/move constructors, assignment
 operators, or (non-virtual) destructors with the same apparent
 semantics as those that can be generated by default~(\ref{class.ctor}, \ref{class.dtor}, \ref{class.copy}).
 \indextext{constructor!copy}%
@@ -864,19 +864,19 @@ signatures, or for virtual destructors that can be generated by default.
 \pnum
 For the sake of exposition, the library clauses sometimes annotate
 constructors with \EXPLICIT{}. Such a constructor is conditionally declared
-as either explicit or non-explicit~(\ref{class.conv.ctor}).
+as either explicit or non-explicit\iref{class.conv.ctor}.
 \begin{note} This is typically implemented by declaring two such constructors,
 of which at most one participates in overload resolution. \end{note}
 
 \rSec3[objects.within.classes]{Private members}
 
 \pnum
-Clauses~\ref{\firstlibchapter} through~\ref{\lastlibchapter} and
-Annex~\ref{depr} do not specify the representation of classes, and intentionally
-omit specification of class members~(\ref{class.mem}). An implementation may
+\ref{\firstlibchapter} through \ref{\lastlibchapter} and
+\ref{depr} do not specify the representation of classes, and intentionally
+omit specification of class members\iref{class.mem}. An implementation may
 define static or non-static class members, or both, as needed to implement the
-semantics of the member functions specified in Clauses~\ref{\firstlibchapter}
-through~\ref{\lastlibchapter} and Annex~\ref{depr}.
+semantics of the member functions specified in \ref{\firstlibchapter}
+through \ref{\lastlibchapter} and \ref{depr}.
 
 \pnum
 For the sake of exposition,
@@ -896,7 +896,7 @@ An implementation may use any technique that provides equivalent observable beha
 
 \pnum
 This subclause specifies requirements that apply to the entire \Cpp standard library.
-Clauses~\ref{\firstlibchapter} through~\ref{\lastlibchapter} and Annex~\ref{depr}
+\ref{\firstlibchapter} through \ref{\lastlibchapter} and \ref{depr}
 specify the requirements of individual entities within the library.
 
 \pnum
@@ -925,7 +925,7 @@ standard library.
 \pnum
 The \Cpp standard library provides definitions
 for the entities and macros described in the synopses
-of the \Cpp standard library headers~(\ref{headers}).
+of the \Cpp standard library headers\iref{headers}.
 
 \pnum
 All library entities except
@@ -935,9 +935,9 @@ and
 are defined within the namespace
 \tcode{std}
 or namespaces nested within namespace
-\tcode{std}.\footnote{The C standard library headers (Annex~\ref{depr.c.headers}) also define
+\tcode{std}.\footnote{The C standard library headers\iref{depr.c.headers} also define
 names within the global namespace, while the \Cpp headers for C library
-facilities~(\ref{headers}) may also define names within the global namespace.}%
+facilities\iref{headers} may also define names within the global namespace.}%
 \indextext{namespace}
 It is unspecified whether names declared in a specific namespace are declared
 directly in that namespace or in an inline namespace inside that
@@ -960,7 +960,7 @@ is meant.
 Each element of the \Cpp standard library is declared or defined (as appropriate) in a
 \term{header}.\footnote{A header is not necessarily a source file, nor are the
 sequences delimited by \tcode{<} and \tcode{>} in header names necessarily valid source
-file names~(\ref{cpp.include}).}
+file names\iref{cpp.include}.}
 
 \pnum
 The \Cpp standard library provides the
@@ -1105,18 +1105,18 @@ for any of these C headers:
 \end{floattable}
 
 \pnum
-Except as noted in Clauses~\ref{library} through~\ref{\lastlibchapter}
-and Annex~\ref{depr}, the contents of each header \tcode{c\placeholder{name}} is
+Except as noted in \ref{library} through \ref{\lastlibchapter}
+and \ref{depr}, the contents of each header \tcode{c\placeholder{name}} is
 the same as that of the corresponding header \tcode{\placeholder{name}.h} as
-specified in the C standard library (Clause~\ref{intro.refs}).
+specified in the C standard library\iref{intro.refs}.
 In the \Cpp standard library, however, the
 declarations (except for names which are defined as macros in C) are within
-namespace scope~(\ref{basic.scope.namespace}) of the namespace \tcode{std}.
+namespace scope\iref{basic.scope.namespace} of the namespace \tcode{std}.
 It is unspecified whether these names (including any overloads added in
-Clauses~\ref{\firstlibchapter} through~\ref{\lastlibchapter} and Annex~\ref{depr})
+\ref{\firstlibchapter} through \ref{\lastlibchapter} and \ref{depr})
 are first declared within the global namespace scope
 and are then injected into namespace \tcode{std} by explicit
-\grammarterm{using-declaration}{s}~(\ref{namespace.udecl}).
+\grammarterm{using-declaration}{s}\iref{namespace.udecl}.
 
 \pnum
 Names which are defined as macros in C shall be defined as macros in the \Cpp
@@ -1270,7 +1270,7 @@ These names are also subject to the restrictions of~\ref{macro.names}.
 Two kinds of implementations are defined:
 \term{hosted}
 and
-\term{freestanding}~(\ref{intro.compliance}).
+\term{freestanding}\iref{intro.compliance}.
 For a hosted implementation, this International Standard
 \indextext{implementation!hosted}%
 describes the set of available headers.
@@ -1321,7 +1321,7 @@ The other headers listed in this table shall meet the same requirements as for a
 This section describes how a \Cpp program gains access to the facilities of the
 \Cpp standard library. \ref{using.headers} describes effects during translation
 phase 4, while~\ref{using.linkage} describes effects during phase
-8~(\ref{lex.phases}).
+8\iref{lex.phases}.
 
 \rSec3[using.headers]{Headers}
 
@@ -1330,12 +1330,12 @@ The entities in the \Cpp standard library are defined in headers,
 whose contents are made available to a translation unit when it contains the appropriate
 \indextext{unit!translation}%
 \tcode{\#include}
-preprocessing directive~(\ref{cpp.include}).%
+preprocessing directive\iref{cpp.include}.%
 \indextext{\idxcode{\#include}}%
 \indextext{source file}
 
 \pnum
-A translation unit may include library headers in any order (Clause~\ref{lex}).
+A translation unit may include library headers in any order\iref{lex}.
 \indextext{unit!translation}%
 Each may be included more than once, with no effect different from
 being included exactly once, except that the effect of including either
@@ -1362,10 +1362,10 @@ declared in that header. No diagnostic is required.
 \rSec3[using.linkage]{Linkage}
 
 \pnum
-Entities in the \Cpp standard library have external linkage~(\ref{basic.link}).
+Entities in the \Cpp standard library have external linkage\iref{basic.link}.
 Unless otherwise specified, objects and functions have the default
 \tcode{extern "C++"}
-linkage~(\ref{dcl.link}).
+linkage\iref{dcl.link}.
 
 \pnum
 \indextext{library!C standard}%
@@ -1394,8 +1394,8 @@ the program prior to program startup.
 \indextext{startup!program}%
 \pnum
 See also
-replacement functions~(\ref{replacement.functions}),
-runtime changes~(\ref{handler.functions}).
+replacement functions\iref{replacement.functions},
+runtime changes\iref{handler.functions}.
 
 \rSec2[utility.requirements]{Requirements on types and expressions}
 
@@ -1431,8 +1431,8 @@ type \tcode{const T}.
 \pnum
 In general, a default constructor is not required. Certain container class
 member function signatures specify \tcode{T()} as a default argument.
-\tcode{T()} shall be a well-defined expression~(\ref{dcl.init}) if one of those
-signatures is called using the default argument~(\ref{dcl.fct.default}).
+\tcode{T()} shall be a well-defined expression\iref{dcl.init} if one of those
+signatures is called using the default argument\iref{dcl.fct.default}.
 
 \indextext{requirements!\idxcode{EqualityComparable}}%
 \begin{concepttable}{\tcode{EqualityComparable} requirements}{equalitycomparable}
@@ -1460,7 +1460,7 @@ If \tcode{a == b} and \tcode{b == c}, then \tcode{a == c}.
 \hdstyle{Expression}  &   \hdstyle{Return type} &   \hdstyle{Requirement} \\ \capsep
 \tcode{a < b}   &
 convertible to \tcode{bool} &
-\tcode{<} is a strict weak ordering relation~(\ref{alg.sorting})    \\
+\tcode{<} is a strict weak ordering relation\iref{alg.sorting}    \\
 \end{concepttable}
 
 \enlargethispage{-3\baselineskip}
@@ -1557,13 +1557,13 @@ evaluated in the context described below, and
 \pnum
 The context in which \tcode{swap(t, u)} and \tcode{swap(u, t)} are evaluated shall
 ensure that a binary non-member function named ``swap'' is selected via overload
-resolution~(\ref{over.match}) on a candidate set that includes:
+resolution\iref{over.match} on a candidate set that includes:
 
 \begin{itemize}
 \item the two \tcode{swap} function templates defined in
-\tcode{<utility>}~(\ref{utility}) and
+\tcode{<utility>}\iref{utility} and
 
-\item the lookup set produced by argument-dependent lookup~(\ref{basic.lookup.argdep}).
+\item the lookup set produced by argument-dependent lookup\iref{basic.lookup.argdep}.
 \end{itemize}
 
 \begin{note} If \tcode{T} and \tcode{U} are both fundamental types or arrays of
@@ -1581,7 +1581,7 @@ An rvalue or lvalue \tcode{t} is \defn{swappable} if and only if \tcode{t} is
 swappable with any rvalue or lvalue, respectively, of type \tcode{T}.
 
 \pnum
-A type \tcode{X} satisfying any of the iterator requirements~(\ref{iterator.requirements})
+A type \tcode{X} satisfying any of the iterator requirements\iref{iterator.requirements}
 satisfies the requirements of \tcode{ValueSwappable} if,
 for any dereferenceable object
 \tcode{x} of type \tcode{X},
@@ -1642,7 +1642,7 @@ A type \tcode{P} meets the requirements of \tcode{NullablePointer} if:
 \tcode{DefaultConstructible}, \tcode{CopyConstructible}, \tcode{CopyAssignable},
 and \tcode{Destructible},
 
-\item lvalues of type \tcode{P} are swappable~(\ref{swappable.requirements}),
+\item lvalues of type \tcode{P} are swappable\iref{swappable.requirements},
 
 \item the expressions shown in Table~\ref{tab:nullablepointer} are
 valid and have the indicated semantics, and
@@ -1658,7 +1658,7 @@ indeterminate values may cause undefined behavior. \end{note}
 
 \pnum
 An object \tcode{p} of type \tcode{P} can be contextually converted to
-\tcode{bool} (Clause~\ref{conv}). The effect shall be as if \tcode{p != nullptr}
+\tcode{bool}\iref{conv}. The effect shall be as if \tcode{p != nullptr}
 had been evaluated in place of \tcode{p}.
 
 \pnum
@@ -1716,9 +1716,9 @@ Expression  &   Return type   &   Operational semantics \\ \capsep
 A type \tcode{H} meets the \tcode{Hash} requirements if:
 
 \begin{itemize}
-\item it is a function object type~(\ref{function.objects}),
+\item it is a function object type\iref{function.objects},
 \item it satisfies the requirements of \tcode{CopyConstructible} and
-  \tcode{Destructible}~(\ref{utility.arg.requirements}), and
+  \tcode{Destructible}\iref{utility.arg.requirements}, and
 \item the expressions shown in Table~\ref{tab:hash}
 are valid and have the indicated semantics.
 \end{itemize}
@@ -1756,14 +1756,14 @@ which are class-type objects that encapsulate the information about an allocatio
 This information includes the knowledge of pointer types, the type of their
 difference, the type of the size of objects in this allocation model, as well
 as the memory allocation and deallocation primitives for it. All of the
-string types (Clause~\ref{strings}),
-containers (Clause~\ref{containers}) (except array),
-string buffers and string streams (Clause~\ref{input.output}), and
-\tcode{match_results} (Clause~\ref{re}) are parameterized in terms of
+string types\iref{strings},
+containers\iref{containers} (except array),
+string buffers and string streams\iref{input.output}, and
+\tcode{match_results}\iref{re} are parameterized in terms of
 allocators.
 
 \pnum
-The class template \tcode{allocator_traits}~(\ref{allocator.traits}) supplies
+The class template \tcode{allocator_traits}\iref{allocator.traits} supplies
 a uniform interface to all allocator types.
 Table~\ref{tab:desc.var.def} describes the types manipulated
 through allocators. Table~\ref{tab:utilities.allocator.requirements}
@@ -1790,7 +1790,7 @@ and \tcode{std::forward}, respectively.
 \hline
 \lhdr{Variable} &   \rhdr{Definition}   \\  \capsep
 \endhead
-\tcode{T, U, C}    &   any \cv-unqualified object type~(\ref{basic.types})       \\ \rowsep
+\tcode{T, U, C}    &   any \cv-unqualified object type\iref{basic.types}       \\ \rowsep
 \tcode{X}       &   an Allocator class for type \tcode{T}   \\ \rowsep
 \tcode{Y}       &   the corresponding Allocator class for type \tcode{U}    \\ \rowsep
 \tcode{XX}      &   the type \tcode{allocator_traits<X>}    \\ \rowsep
@@ -2039,21 +2039,21 @@ If \tcode{X::propagate_on_container_move_assignment::value} is \tcode{true},
 \tcode{MoveAssignable} requirements (Table~\ref{tab:moveassignable})
 and the move operation shall not throw exceptions.
 If \tcode{X::propagate_on_container_swap::value} is \tcode{true},
-lvalues of type \tcode{X} shall be swappable~(\ref{swappable.requirements})
+lvalues of type \tcode{X} shall be swappable\iref{swappable.requirements}
 and the \tcode{swap} operation shall not throw exceptions.
 
 \pnum
 An allocator type \tcode{X} shall satisfy the requirements of
-\tcode{CopyConstructible}~(\ref{utility.arg.requirements}).
+\tcode{CopyConstructible}\iref{utility.arg.requirements}.
 The \tcode{X::pointer}, \tcode{X::const_pointer}, \tcode{X::void_pointer}, and
 \tcode{X::const_void_pointer} types shall satisfy the requirements of
-\tcode{NullablePointer}~(\ref{nullablepointer.requirements}).
+\tcode{NullablePointer}\iref{nullablepointer.requirements}.
 No constructor,
 comparison function, copy operation, move operation, or swap operation on
 these pointer types shall exit via an exception. \tcode{X::pointer} and \tcode{X::const_pointer} shall also
 satisfy the requirements for
-a random access iterator~(\ref{random.access.iterators}) and of
-a contiguous iterator~(\ref{iterator.requirements.general}).
+a random access iterator\iref{random.access.iterators} and of
+a contiguous iterator\iref{iterator.requirements.general}.
 
 \pnum
 Let \tcode{x1} and \tcode{x2} denote objects of (possibly different) types
@@ -2136,7 +2136,7 @@ whether or not \tcode{T} is a complete type:
 
 \begin{itemize}
 \item \tcode{X} is a complete type, and
-\item all the member types of \tcode{allocator_traits<X>}~(\ref{allocator.traits})
+\item all the member types of \tcode{allocator_traits<X>}\iref{allocator.traits}
   other than \tcode{value_type} are complete types.
 \end{itemize}
 
@@ -2147,11 +2147,11 @@ whether or not \tcode{T} is a complete type:
 \pnum
 This section describes restrictions on \Cpp programs that use the facilities of
 the \Cpp standard library. The following subclauses specify constraints on the
-program's use of namespaces~(\ref{namespace.std}), its use of various reserved
-names~(\ref{reserved.names}), its use of headers~(\ref{alt.headers}), its use of
-standard library classes as base classes~(\ref{derived.classes}), its
-definitions of replacement functions~(\ref{replacement.functions}), and its
-installation of handler functions during execution~(\ref{handler.functions}).
+program's use of namespaces\iref{namespace.std}, its use of various reserved
+names\iref{reserved.names}, its use of headers\iref{alt.headers}, its use of
+standard library classes as base classes\iref{derived.classes}, its
+definitions of replacement functions\iref{replacement.functions}, and its
+installation of handler functions during execution\iref{handler.functions}.
 
 \rSec3[namespace.constraints]{Namespace use}
 
@@ -2199,7 +2199,7 @@ and the instantiation meets the standard library requirements for the
 original template.
 
 \pnum
-A translation unit shall not declare namespace \tcode{std} to be an inline namespace~(\ref{namespace.def}).
+A translation unit shall not declare namespace \tcode{std} to be an inline namespace\iref{namespace.def}.
 
 \rSec4[namespace.posix]{Namespace \tcode{posix}}
 
@@ -2403,7 +2403,7 @@ shall be identical to
 \rSec4[usrlit.suffix]{User-defined literal suffixes}
 
 \pnum
-Literal suffix identifiers~(\ref{over.literal}) that do not start with an underscore are reserved for future standardization.
+Literal suffix identifiers\iref{over.literal} that do not start with an underscore are reserved for future standardization.
 
 \rSec3[alt.headers]{Headers}
 
@@ -2411,7 +2411,7 @@ Literal suffix identifiers~(\ref{over.literal}) that do not start with an unders
 If a file with a name
 equivalent to the derived file name for one of the \Cpp standard library headers
 is not provided as part of the implementation, and a file with that name
-is placed in any of the standard places for a source file to be included~(\ref{cpp.include}),
+is placed in any of the standard places for a source file to be included\iref{cpp.include},
 the behavior is undefined.%
 \indextext{source file}%
 \indextext{undefined}
@@ -2424,19 +2424,19 @@ Virtual member function signatures defined
 for a base class in the \Cpp standard
 \indextext{class!base}%
 \indextext{library!C++ standard}%
-library may be overridden in a derived class defined in the program~(\ref{class.virtual}).
+library may be overridden in a derived class defined in the program\iref{class.virtual}.
 
 \rSec3[replacement.functions]{Replacement functions}
 
 \pnum
 \indextext{definition!alternate}%
-Clauses~\ref{\firstlibchapter} through~\ref{\lastlibchapter} and Annex~\ref{depr}
+\ref{\firstlibchapter} through \ref{\lastlibchapter} and \ref{depr}
 describe the behavior of numerous functions defined by
 the \Cpp standard library.
 Under some circumstances,
 \indextext{library!C++ standard}%
 however, certain of these function descriptions also apply to replacement functions defined
-in the program~(\ref{definitions}).
+in the program\iref{definitions}.
 
 \pnum
 A \Cpp program may provide the definition for any of the following
@@ -2482,7 +2482,7 @@ operator delete[](void*, std::align_val_t, const std::nothrow_t&)
 
 \pnum
 The program's definitions are used instead of the default versions supplied by
-the implementation~(\ref{support.dynamic}).
+the implementation\iref{support.dynamic}.
 Such replacement occurs prior to program startup~(\ref{basic.def.odr}, \ref{basic.start}).
 \indextext{startup!program}%
 The program's declarations shall not be specified as
@@ -2493,7 +2493,7 @@ No diagnostic is required.
 
 \pnum
 The \Cpp standard library provides a default version of the following handler
-function (Clause~\ref{language.support}):
+function\iref{language.support}:
 
 \begin{itemize}
 \item
@@ -2544,7 +2544,7 @@ In particular, the effects are undefined in the following cases:
 
 \begin{itemize}
 \item
-for replacement functions~(\ref{new.delete}), if the installed replacement function does not
+for replacement functions\iref{new.delete}, if the installed replacement function does not
 implement the semantics of the applicable
 \required
 paragraph.
@@ -2568,7 +2568,7 @@ in the applicable
 \required
 paragraph.
 \item
-if an incomplete type~(\ref{basic.types}) is used as a template
+if an incomplete type\iref{basic.types} is used as a template
 argument when instantiating a template component, unless specifically
 allowed for that component.
 \end{itemize}
@@ -2604,7 +2604,7 @@ If a function argument binds to an rvalue reference parameter, the implementatio
 assume that this parameter is a unique reference to this argument.
 \begin{note}
 If the parameter is a generic parameter of the form \tcode{T\&\&} and an lvalue of type
-\tcode{A} is bound, the argument binds to an lvalue reference~(\ref{temp.deduct.call})
+\tcode{A} is bound, the argument binds to an lvalue reference\iref{temp.deduct.call}
 and thus is not covered by the previous sentence. \end{note} \begin{note} If a program casts
 an lvalue to an xvalue while passing that lvalue to a library function (e.g. by calling the function
 with the argument \tcode{std::move(x)}), the program
@@ -2625,7 +2625,7 @@ specified as being shareable without data races or the user supplies a locking m
 
 \pnum
 If an object of a standard library type is accessed, and
-the beginning of the object's lifetime~(\ref{basic.life})
+the beginning of the object's lifetime\iref{basic.life}
 does not happen before the access, or
 the access does not happen before the end of the object's lifetime,
 the behavior is undefined unless otherwise specified.
@@ -2670,10 +2670,10 @@ those other headers.
 \pnum
 Certain types and macros are defined in more than one header.
 Every such entity shall be defined such that any header that defines it may be
-included after any other header that also defines it~(\ref{basic.def.odr}).
+included after any other header that also defines it\iref{basic.def.odr}.
 
 \pnum
-The C standard library headers~(\ref{depr.c.headers})
+The C standard library headers\iref{depr.c.headers}
 shall include only their corresponding \Cpp standard library header,
 as described in~\ref{headers}.
 
@@ -2701,12 +2701,12 @@ explicitly stated otherwise.
 It is unspecified whether any
 non-member
 functions in the \Cpp standard library are defined as
-\tcode{inline}~(\ref{dcl.inline}).
+\tcode{inline}\iref{dcl.inline}.
 
 \pnum
 A call to a non-member function signature
-described in Clauses~\ref{\firstlibchapter} through~\ref{\lastlibchapter} and
-Annex~\ref{depr} shall behave as if the implementation declared no additional
+described in \ref{\firstlibchapter} through \ref{\lastlibchapter} and
+\ref{depr} shall behave as if the implementation declared no additional
 non-member function signatures.\footnote{A valid \Cpp program always
 calls the expected library non-member function. An implementation may
 also define additional non-member functions that would otherwise not
@@ -2720,13 +2720,13 @@ with additional default arguments.
 Unless otherwise specified,
 calls made by functions in the standard library to non-operator, non-member functions
 do not use functions from another namespace which are found through
-\term{argument-dependent name lookup}~(\ref{basic.lookup.argdep}).
+\term{argument-dependent name lookup}\iref{basic.lookup.argdep}.
 \begin{note}
 The phrase ``unless otherwise specified'' applies to cases such as
-the swappable with requirements~(\ref{swappable.requirements}).
+the swappable with requirements\iref{swappable.requirements}.
 The exception for overloaded operators allows argument-dependent lookup
 in cases like that of
-\tcode{ostream_iterator::operator=}~(\ref{ostream.iterator.ops}):
+\tcode{ostream_iterator::operator=}\iref{ostream.iterator.ops}:
 
 \effects
 \begin{codeblock}
@@ -2741,7 +2741,7 @@ return *this;
 
 \pnum
 It is unspecified whether any member functions in the \Cpp standard library are defined as
-\tcode{inline}~(\ref{dcl.inline}).
+\tcode{inline}\iref{dcl.inline}.
 
 \pnum
 For a non-virtual member function described in the \Cpp standard library,
@@ -2760,7 +2760,7 @@ or add additional signatures for a member function name.
 
 \pnum
 This International Standard explicitly requires that certain standard library functions are
-\tcode{constexpr}~(\ref{dcl.constexpr}). An implementation shall not declare
+\tcode{constexpr}\iref{dcl.constexpr}. An implementation shall not declare
 any standard library function signature as \tcode{constexpr} except for those where
 it is explicitly required.
 Within any header that provides any non-defining declarations of constexpr
@@ -2798,19 +2798,19 @@ library may be recursively reentered.
 
 \pnum
 This section specifies requirements that implementations shall meet to prevent data
-races~(\ref{intro.multithread}).
+races\iref{intro.multithread}.
 Every standard library function shall meet each requirement unless otherwise specified.
 Implementations may prevent data races in cases other than those specified below.
 
 \pnum
 A \Cpp standard library function shall not directly or indirectly access
-objects~(\ref{intro.multithread}) accessible by threads other than the current thread
+objects\iref{intro.multithread} accessible by threads other than the current thread
 unless the objects are accessed directly or indirectly via the function's arguments,
 including \tcode{this}.
 
 \pnum
 A \Cpp standard library function shall not directly or indirectly modify
-objects~(\ref{intro.multithread}) accessible by threads other than the current thread
+objects\iref{intro.multithread} accessible by threads other than the current thread
 unless the objects are accessed directly or indirectly via the function's non-const
 arguments, including \tcode{this}.
 
@@ -2837,7 +2837,7 @@ not visible to users and are protected against data races.
 \pnum
 Unless otherwise specified, \Cpp standard library functions shall perform all operations
 solely within the current thread if those operations have effects that are
-visible~(\ref{intro.multithread}) to users.
+visible\iref{intro.multithread} to users.
 
 \pnum
 \begin{note} This allows implementations to parallelize operations if there are no visible
@@ -2849,7 +2849,7 @@ side effects. \end{note}
 \pnum
 \indextext{protection}%
 It is unspecified whether any function signature or class described in
-Clauses~\ref{\firstlibchapter} through~\ref{\lastlibchapter} and Annex~\ref{depr} is a
+\ref{\firstlibchapter} through \ref{\lastlibchapter} and \ref{depr} is a
 \tcode{friend}
 of another class in the \Cpp standard library.
 \indextext{specifier!\idxcode{friend}}
@@ -2886,8 +2886,8 @@ Every base class not specified as
 Unless explicitly stated otherwise, types with distinct names shall be distinct
 types.\footnote{There is an implicit exception to this rule for types that are
 described as synonyms for basic integral types, such as
-\tcode{size_t}~(\ref{support.types}) and
-\tcode{streamoff}~(\ref{stream.types}).}
+\tcode{size_t}\iref{support.types} and
+\tcode{streamoff}\iref{stream.types}.}
 \end{itemize}
 
 \pnum
@@ -2922,7 +2922,7 @@ except when such a function calls a program-supplied function that throws an
 exception.\footnote{The functions
 \tcode{qsort()}
 and
-\tcode{bsearch()}~(\ref{alg.c.library}) meet this condition.}
+\tcode{bsearch()}\iref{alg.c.library} meet this condition.}
 
 \pnum
 Destructor operations defined in the \Cpp standard library
@@ -2945,7 +2945,7 @@ potentially-throwing exception specification} exceptions.%
 can report a failure to allocate storage by throwing an exception of type
 \tcode{bad_alloc},
 or a class derived from
-\tcode{bad_alloc}~(\ref{bad.alloc}).}
+\tcode{bad_alloc}\iref{bad.alloc}.}
 Implementations should
 report errors by throwing exceptions of or derived
 from the standard exception classes~(\ref{bad.alloc},
@@ -2964,7 +2964,7 @@ by adding a non-throwing exception specification.
 \indextext{pointer!to traceable object}%
 Objects constructed by the standard library that may hold a user-supplied pointer value
 or an integer of type \tcode{std::intptr_t} shall store such values in a traceable
-pointer location~(\ref{basic.stc.dynamic.safety}). \begin{note} Other libraries are
+pointer location\iref{basic.stc.dynamic.safety}. \begin{note} Other libraries are
 strongly encouraged to do the same, since not doing so may result in accidental use of
 pointers that are not safely derived. Libraries that store pointers outside the user's
 address space should make it appear that they are stored and retrieved from a traceable
@@ -2974,7 +2974,7 @@ pointer location. \end{note}
 
 \pnum
 Certain functions in the \Cpp standard library report errors via a
-\tcode{std::error_code}~(\ref{syserr.errcode.overview}) object. That object's
+\tcode{std::error_code}\iref{syserr.errcode.overview} object. That object's
 \tcode{category()} member shall return \tcode{std::system_category()} for
 errors originating from the operating system, or a reference to an
 \impldef{\tcode{error_category} for errors originating outside the
@@ -2992,6 +2992,6 @@ may provide enums for the associated values. \end{example}
 
 \pnum
 Objects of types defined in the \Cpp standard library may be moved
-from~(\ref{class.copy}). Move operations may be explicitly specified or
+from\iref{class.copy}. Move operations may be explicitly specified or
 implicitly generated. Unless otherwise specified, such moved-from objects shall
 be placed in a valid but unspecified state.

--- a/source/limits.tex
+++ b/source/limits.tex
@@ -124,10 +124,10 @@ Full-expressions evaluated within a core constant expression [1\,048\,576].
 Template arguments in a template declaration [1\,024].
 \item%
 Recursively nested template instantiations, including substitution
-during template argument deduction~(\ref{temp.deduct}) [1\,024].
+during template argument deduction\iref{temp.deduct} [1\,024].
 \item%
 Handlers per try block [256].
 \item%
-Number of placeholders~(\ref{func.bind.place}) [10].
+Number of placeholders\iref{func.bind.place} [10].
 
 \end{itemize}

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -840,8 +840,8 @@ facet.
 \remarks
 This member operator template (and therefore
 \tcode{locale}
-itself) satisfies requirements for a comparator predicate template argument
-(\ref{algorithms}) applied to strings.
+itself) satisfies requirements for a comparator predicate template argument\iref{algorithms}
+applied to strings.
 
 \pnum
 \returns

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -224,7 +224,7 @@ facet with the
 function template
 \tcode{has_facet<Facet>()}.
 User-defined facets may be installed in a locale, and used identically as
-may standard facets~(\ref{facets.examples}).
+may standard facets\iref{facets.examples}.
 
 \pnum
 \begin{note}
@@ -250,7 +250,7 @@ and
 so that given a locale
 object \tcode{loc} a \Cpp program can call
 \tcode{isspace(c, loc)}.
-(This eases upgrading existing extractors~(\ref{istream.formatted}).)
+(This eases upgrading existing extractors\iref{istream.formatted}.)
 \end{itemize}
 \end{note}
 
@@ -282,7 +282,7 @@ Whether there is one global locale object for the entire program or one global l
 object per thread is \impldef{whether locale object is global or per-thread}.
 Implementations should provide one global locale object per
 thread. If there is a single global locale object for the entire program,
-implementations are not required to avoid data races on it~(\ref{res.on.data.races}).
+implementations are not required to avoid data races on it\iref{res.on.data.races}.
 
 \rSec3[locale.types]{\tcode{locale} types}
 
@@ -445,7 +445,7 @@ or
 \tcode{OutputIterator}
 indicates the set of
 all possible specializations on parameters that satisfy the
-requirements of an Input Iterator or an Output Iterator, respectively~(\ref{iterator.requirements}).
+requirements of an Input Iterator or an Output Iterator, respectively\iref{iterator.requirements}.
 A template parameter with name
 \tcode{C}
 represents the set
@@ -574,7 +574,7 @@ One initialization strategy is for
 to initialize each facet's
 \tcode{id}
 member the first time an instance of the facet is installed into a locale.
-This depends only on static storage being zero before constructors run~(\ref{basic.start.static}).
+This depends only on static storage being zero before constructors run\iref{basic.start.static}.
 \end{note}
 
 \rSec3[locale.cons]{\tcode{locale} constructors and destructor}
@@ -841,7 +841,7 @@ facet.
 This member operator template (and therefore
 \tcode{locale}
 itself) satisfies requirements for a comparator predicate template argument
-(Clause~\ref{algorithms}) applied to strings.
+(\ref{algorithms}) applied to strings.
 
 \pnum
 \returns
@@ -1007,7 +1007,7 @@ use_facet<ctype<charT>>(loc).is(ctype_base::@\placeholder{F}@, c)
 
 where \tcode{\placeholder{F}} is the
 \tcode{ctype_base::mask}
-value corresponding to that function~(\ref{category.ctype}).\footnote{When
+value corresponding to that function\iref{category.ctype}.\footnote{When
 used in a loop, it is faster to cache the
 \tcode{ctype<>}
 facet and use it directly, or use the vector form of
@@ -1062,7 +1062,7 @@ argument whose members
 and
 \indexlibrary{\idxcode{width}!\idxcode{ios_base}}%
 \tcode{width()},
-specify the format of the corresponding datum~(\ref{ios.base}).
+specify the format of the corresponding datum\iref{ios.base}.
 Those functions which need to use other facets call its member
 \tcode{getloc()}
 to retrieve the locale imbued there.
@@ -1117,7 +1117,7 @@ namespace std {
 \pnum
 The type
 \tcode{mask}
-is a bitmask type~(\ref{bitmask.types}).
+is a bitmask type\iref{bitmask.types}.
 
 \rSec3[locale.ctype]{Class template \tcode{ctype}}
 
@@ -1178,7 +1178,7 @@ members are required to use
 for character classing during input parsing.
 
 \pnum
-The specializations required in Table~\ref{tab:localization.category.facets}~(\ref{locale.category}), namely
+The specializations required in Table~\ref{tab:localization.category.facets}\iref{locale.category}, namely
 \tcode{ctype<char>}
 and
 \tcode{ctype<wchar_t>},
@@ -1426,7 +1426,7 @@ value or values.\footnote{The char argument of
 is intended to accept values derived from character literals for conversion
 to the locale's encoding.}
 The only characters for which unique transformations are required
-are those in the basic source character set~(\ref{lex.charset}).
+are those in the basic source character set\iref{lex.charset}.
 
 For any named
 \tcode{ctype}
@@ -1470,7 +1470,7 @@ values to the corresponding
 \tcode{char}
 value or values.
 
-For any character \tcode{c} in the basic source character set~(\ref{lex.charset})
+For any character \tcode{c} in the basic source character set\iref{lex.charset}
 the transformation is such that
 
 \begin{codeblock}
@@ -1821,7 +1821,7 @@ virtual const char* do_narrow(const char* low, const char* high,
 These functions are described identically as those members of the
 same name in the
 \tcode{ctype}
-class template~(\ref{locale.ctype.members}).
+class template\iref{locale.ctype.members}.
 
 \rSec3[locale.codecvt]{Class template \tcode{codecvt}}
 
@@ -1899,7 +1899,7 @@ The
 argument selects the pair of character encodings being mapped between.
 
 \pnum
-The specializations required in Table~\ref{tab:localization.category.facets}~(\ref{locale.category})
+The specializations required in Table~\ref{tab:localization.category.facets}\iref{locale.category}
 convert the implementation-defined native character set.
 \tcode{codecvt<char, char, mbstate_t>}
 implements a degenerate conversion;
@@ -2066,7 +2066,7 @@ unchanged, and there are no changes to the values in
 A
 \tcode{codecvt}
 facet that is used by
-\tcode{basic_filebuf}~(\ref{file.streams}) shall have the property that if
+\tcode{basic_filebuf}\iref{file.streams} shall have the property that if
 \begin{codeblock}
 do_out(state, from, from_end, from_next, to, to_end, to_next)
 \end{codeblock}
@@ -2323,7 +2323,7 @@ and
 \tcode{num_get}
 in the subclauses of~\ref{category.numeric} only apply to the
 specializations required in Tables~\ref{tab:localization.category.facets}
-and~\ref{tab:localization.required.specializations}~(\ref{locale.category}), namely
+and~\ref{tab:localization.required.specializations}\iref{locale.category}, namely
 \tcode{num_get<char>},
 \tcode{num_get<wchar_t>},
 \tcode{num_get<C, InputIterator>},
@@ -2333,7 +2333,7 @@ and
 \tcode{num_put<C, OutputIterator>}.
 These specializations refer to the
 \tcode{ios_base\&}
-argument for formatting specifications~(\ref{locale.categories}),
+argument for formatting specifications\iref{locale.categories},
 and to its imbued locale for the
 \tcode{numpunct<>}
 facet to identify all numeric punctuation preferences,
@@ -2857,7 +2857,7 @@ The details of this operation occur in several stages:
 Stage 1:
 Determine a printf conversion specifier \tcode{spec} and
 determine the characters that would be printed by
-\tcode{printf}~(\ref{c.files})
+\tcode{printf}\iref{c.files}
 given this conversion specifier for
 
 \begin{codeblock}
@@ -3129,7 +3129,7 @@ namespace std {
 \pnum
 \tcode{numpunct<>}
 specifies numeric punctuation.
-The specializations required in Table~\ref{tab:localization.category.facets}~(\ref{locale.category}), namely
+The specializations required in Table~\ref{tab:localization.category.facets}\iref{locale.category}, namely
 \tcode{numpunct<\brk{}wchar_t>}
 and
 \tcode{numpunct<char>},
@@ -3370,12 +3370,12 @@ collation (comparison) and hashing of strings.
 A locale member function template,
 \tcode{operator()},
 uses the collate facet to allow a locale to act directly as the predicate
-argument for standard algorithms (Clause~\ref{algorithms}) and containers operating on strings.
-The specializations required in Table~\ref{tab:localization.category.facets}~(\ref{locale.category}), namely
+argument for standard algorithms\iref{algorithms} and containers operating on strings.
+The specializations required in Table~\ref{tab:localization.category.facets}\iref{locale.category}, namely
 \tcode{collate<char>}
 and
 \tcode{collate<wchar_t>},
-apply lexicographic ordering~(\ref{alg.lex.comparison}).
+apply lexicographic ordering\iref{alg.lex.comparison}.
 
 \pnum
 Each function compares a string of characters
@@ -3434,12 +3434,12 @@ int do_compare(const charT* low1, const charT* high1,
 if the first string is greater than the second,
 \tcode{-1}
 if less, zero otherwise.
-The specializations required in Table~\ref{tab:localization.category.facets}~(\ref{locale.category}), namely
+The specializations required in Table~\ref{tab:localization.category.facets}\iref{locale.category}, namely
 \tcode{collate<char>}
 and
 \tcode{collate<wchar_t>},
 implement
-a lexicographical comparison~(\ref{alg.lex.comparison}).
+a lexicographical comparison\iref{alg.lex.comparison}.
 \end{itemdescr}
 
 \indexlibrarymember{collate}{do_transform}%
@@ -3513,7 +3513,7 @@ and
 \tcode{time_get}
 in the subclauses of~\ref{category.time} only apply to the
 specializations required in Tables~\ref{tab:localization.category.facets}
-and~\ref{tab:localization.required.specializations}~(\ref{locale.category}).
+and~\ref{tab:localization.required.specializations}\iref{locale.category}.
 Their members use their
 \tcode{ios_base\&},
 \tcode{ios_base::iostate\&},
@@ -4122,7 +4122,7 @@ and
 \tcode{money_get}
 in the subclauses of~\ref{category.monetary} only apply to the
 specializations required in Tables~\ref{tab:localization.category.facets}
-and~\ref{tab:localization.required.specializations}~(\ref{locale.category}).
+and~\ref{tab:localization.required.specializations}\iref{locale.category}.
 Their members use their
 \tcode{ios_base\&},
 \tcode{ios_base::io\-state\&},
@@ -4826,7 +4826,7 @@ pattern do_neg_format() const;
 \begin{itemdescr}
 \pnum
 \returns
-The specializations required in Table~\ref{tab:localization.required.specializations}~(\ref{locale.category}), namely
+The specializations required in Table~\ref{tab:localization.required.specializations}\iref{locale.category}, namely
 \tcode{moneypunct<char>},
 \tcode{moneypunct<\brk{}wchar_t>},
 \tcode{moneypunct<char, true>},
@@ -5291,7 +5291,7 @@ are the same as the C standard library header \tcode{<locale.h>}.
 
 \pnum
 Calls to the function \tcode{setlocale} may introduce a data
-race~(\ref{res.on.data.races}) with other calls to \tcode{setlocale} or with calls to
+race\iref{res.on.data.races} with other calls to \tcode{setlocale} or with calls to
 the functions listed in Table~\ref{tab:setlocale.data.races}.
 
 \xref ISO C 7.11

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -67,20 +67,29 @@
 % the range [0,5].  (If it proves necessary, it wouldn't take much
 % programming to raise the limit from 5 to something larger.)
 
+% Set the xref label for a clause to be "Clause n", not just "n".
+\makeatletter
+\newcommand{\customlabel}[2]{%
+\protected@write \@auxout {}{\string \newlabel {#1}{{#2}{\thepage}{#2}{#1}{}} }%
+\hypertarget{#1}{}%
+}
+\makeatother
+\newcommand{\clauselabel}[1]{\customlabel{#1}{Clause \thechapter}}
+\newcommand{\annexlabel}[1]{\customlabel{#1}{Annex \thechapter}}
 
 % The basic sectioning command.  Example:
 %    \Sec1[intro.scope]{Scope}
 % defines a first-level section whose name is "Scope" and whose short
 % tag is intro.scope.  The square brackets are mandatory.
 \def\Sec#1[#2]#3{%
-\ifcase#1\let\s=\chapter
-      \or\let\s=\section
-      \or\let\s=\subsection
-      \or\let\s=\subsubsection
-      \or\let\s=\paragraph
-      \or\let\s=\subparagraph
+\ifcase#1\let\s=\chapter\let\l=\clauselabel
+      \or\let\s=\section\let\l=\label
+      \or\let\s=\subsection\let\l=\label
+      \or\let\s=\subsubsection\let\l=\label
+      \or\let\s=\paragraph\let\l=\label
+      \or\let\s=\subparagraph\let\l=\label
       \fi%
-\s[#3]{#3\hfill[#2]}\label{#2}\addxref{#2}}
+\s[#3]{#3\hfill[#2]}\l{#2}\addxref{#2}}
 
 % A convenience feature (mostly for the convenience of the Project
 % Editor, to make it easy to move around large blocks of text):
@@ -237,6 +246,9 @@
 
 %% Cross reference
 \newcommand{\xref}{\textsc{See also:}\xspace}
+
+%% Inline parenthesized reference
+\newcommand{\iref}[1]{\nolinebreak[3] (\ref{#1})}
 
 %% NTBS, etc.
 \newcommand{\NTS}[1]{\textsc{#1}\xspace}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -116,7 +116,7 @@ storage and use the copy constructor to initialize each element.
 If the distinction between initialization and assignment is important
 for a class, or if it fails to satisfy any of
 the other conditions listed above, the programmer should use
-\tcode{vector}~(\ref{vector}) instead of
+\tcode{vector}\iref{vector} instead of
 \tcode{valarray}
 for that class.
 \end{note}
@@ -221,7 +221,7 @@ are the same as the C standard library header \tcode{<fenv.h>}.
 \begin{note}
 This International Standard does not require an implementation to support the
 \tcode{FENV_ACCESS} pragma;
-it is \impldef{whether pragma \tcode{FENV_ACCESS} is supported}~(\ref{cpp.pragma})
+it is \impldef{whether pragma \tcode{FENV_ACCESS} is supported}\iref{cpp.pragma}
 whether the pragma is supported. As a consequence,
 it is \impldef{whether \tcode{<cfenv>} functions can be used to manage floating-point status}
 whether these functions can be used to test floating-point status flags,
@@ -233,9 +233,9 @@ floating-point evaluation in constant expressions.
 
 \pnum
 The floating-point environment has thread storage
-duration~(\ref{basic.stc.thread}). The initial state for a thread's floating-point
+duration\iref{basic.stc.thread}. The initial state for a thread's floating-point
 environment is the state of the floating-point environment of the thread that constructs
-the corresponding \tcode{thread} object~(\ref{thread.thread.class}) at the time it
+the corresponding \tcode{thread} object\iref{thread.thread.class} at the time it
 constructed the object. \begin{note} That is, the child thread gets the floating-point
 state of the parent thread at the time of the child's creation. \end{note}
 
@@ -263,7 +263,7 @@ for any type other than \tcode{float}, \tcode{double}, or \tcode{long double} is
 The specializations
 \tcode{complex<float>},
 \tcode{complex<double>}, and
-\tcode{complex<long double>} are literal types~(\ref{basic.types}).
+\tcode{complex<long double>} are literal types\iref{basic.types}.
 
 \pnum
 If the result of a function is not mathematically defined or not in
@@ -869,13 +869,13 @@ where
 \tcode{u}
 is the real part and
 \tcode{v}
-is the imaginary part~(\ref{istream.formatted}).
+is the imaginary part\iref{istream.formatted}.
 
 \pnum
 If bad input is encountered, calls
 \tcode{is.setstate(ios_base::failbit)}
 (which may throw
-\tcode{ios::failure}~(\ref{iostate.flags})).
+\tcode{ios::failure}\iref{iostate.flags}).
 
 \pnum
 \returns
@@ -1419,7 +1419,7 @@ and to templates producing such types when instantiated.
 \pnum
 \indextext{\idxcode{result_type}!entity characterization based on}%
 Each of the entities specified via this subclause
-has an associated arithmetic type~(\ref{basic.fundamental})
+has an associated arithmetic type\iref{basic.fundamental}
 identified as \tcode{result_type}.
 With \tcode{T} as the \tcode{result_type}
 thus associated with such an entity,
@@ -1498,21 +1498,21 @@ the effect of instantiating a template:
     is undefined unless the corresponding template argument
     is cv-unqualified and
     satisfies the requirements
-    of seed sequence~(\ref{rand.req.seedseq}).
+    of seed sequence\iref{rand.req.seedseq}.
   \item
     that has a template type parameter
     named \tcode{URBG}
     is undefined unless the corresponding template argument
     is cv-unqualified and
     satisfies the requirements
-    of uniform random bit generator~(\ref{rand.req.urng}).
+    of uniform random bit generator\iref{rand.req.urng}.
   \item
     that has a template type parameter
     named \tcode{Engine}
     is undefined unless the corresponding template argument
     is cv-unqualified and
     satisfies the requirements
-    of random number engine~(\ref{rand.req.eng}).
+    of random number engine\iref{rand.req.eng}.
   \item
     that has a template type parameter
     named \tcode{RealType}
@@ -1637,7 +1637,7 @@ In that Table and throughout this section:
 \indextext{\idxcode{result_type}!seed sequence requirement}%
 \tcode{S::result_type}
   & \tcode{T}
-  & \tcode{T} is an unsigned integer type~(\ref{basic.fundamental})
+  & \tcode{T} is an unsigned integer type\iref{basic.fundamental}
     of at least 32 bits.
   & compile-time
   \\ \rowsep
@@ -1764,7 +1764,7 @@ In that Table and throughout this section:
 \indextext{\idxcode{result_type}!uniform random bit generator requirement}%
 \tcode{G::result_type}
   & \tcode{T}
-  & \tcode{T} is an unsigned integer type~(\ref{basic.fundamental}).
+  & \tcode{T} is an unsigned integer type\iref{basic.fundamental}.
   & compile-time
   \\ \rowsep
 \tcode{g()}%
@@ -1850,7 +1850,7 @@ An engine's state may be established via
 \pnum
 A class \tcode{E}
 that satisfies the requirements
-of a uniform random bit generator~(\ref{rand.req.urng})
+of a uniform random bit generator\iref{rand.req.urng}
 also satisfies the requirements
 of a \techterm{random number engine}
 if the expressions shown
@@ -1871,7 +1871,7 @@ In that Table and throughout this section:
     \tcode{s} is a value of \tcode{T};
   \item
     \tcode{q} is an lvalue
-    satisfying the requirements of a seed sequence~(\ref{rand.req.seedseq});
+    satisfying the requirements of a seed sequence\iref{rand.req.seedseq};
   \item
     \tcode{z} is a value
     of type \tcode{unsigned long long};
@@ -1884,7 +1884,7 @@ In that Table and throughout this section:
     \tcode{basic_istream<charT,} \tcode{traits>};
 \end{enumeratea}
 where \tcode{charT} and \tcode{traits} are constrained
-according to Clause~\ref{strings} and Clause~\ref{input.output}.
+according to \ref{strings} and \ref{input.output}.
 
 \begin{libreqtab4d}
   {Random number engine requirements}
@@ -2038,7 +2038,7 @@ according to Clause~\ref{strings} and Clause~\ref{input.output}.
     ensures that \tcode{v}'s state is unchanged by the operation
     and
     calls \tcode{is.setstate(ios::failbit)}
-    (which may throw \tcode{ios::failure}~(\ref{iostate.flags})).
+    (which may throw \tcode{ios::failure}\iref{iostate.flags}).
     If a textual representation written via \tcode{os << x}
     was subsequently read via \tcode{is >> v},
     then \tcode{x == v}
@@ -2267,7 +2267,7 @@ In that Table and throughout this section,
   \item
     \tcode{g}, \tcode{g1}, and \tcode{g2} are lvalues of a type
     satisfying the requirements
-    of a uniform random bit generator~(\ref{rand.req.urng});
+    of a uniform random bit generator\iref{rand.req.urng};
   \item
     \tcode{os} is an lvalue of the type of some class template specialization
     \tcode{basic_ostream<charT,} \tcode{traits>};
@@ -2277,7 +2277,7 @@ In that Table and throughout this section,
     \tcode{basic_istream<charT,} \tcode{traits>};
 \end{enumeratea}
 where \tcode{charT} and \tcode{traits} are constrained
-according to Clauses~\ref{strings} and \ref{input.output}.
+according to \ref{strings} and \ref{input.output}.
 
 \begin{libreqtab4d}
   {Random number distribution requirements}
@@ -2299,7 +2299,7 @@ according to Clauses~\ref{strings} and \ref{input.output}.
 \indextext{\idxcode{result_type}!random number distribution requirement}%
 \tcode{D::result_type}
   & \tcode{T}
-  & \tcode{T} is an arithmetic type~(\ref{basic.fundamental}).
+  & \tcode{T} is an arithmetic type\iref{basic.fundamental}.
   & compile-time
   \\ \rowsep
 \tcode{D::param_type}
@@ -2425,7 +2425,7 @@ according to Clauses~\ref{strings} and \ref{input.output}.
     ensures that \tcode{d} is unchanged by the operation
     and
     calls \tcode{is.setstate(ios::failbit)}
-    (which may throw \tcode{ios::failure}~(\ref{iostate.flags})).
+    (which may throw \tcode{ios::failure}\iref{iostate.flags}).
 
     \requires \tcode{is} provides a textual representation
     that was previously written
@@ -2670,7 +2670,7 @@ namespace std {
 Each type instantiated
 from a class template specified in this section~\ref{rand.eng}
 satisfies the requirements
-of a random number engine~(\ref{rand.req.eng}) type.
+of a random number engine\iref{rand.req.eng} type.
 
 \pnum
 Except where specified otherwise,
@@ -2712,7 +2712,7 @@ if any such required relationship fails to hold.
 
 \pnum
 For every random number engine and for every random number engine adaptor \tcode{X}
-defined in this subclause~(\ref{rand.eng}) and in subclause~\ref{rand.adapt}:
+defined in this subclause\iref{rand.eng} and in subclause~\ref{rand.adapt}:
 
 \begin{itemize}
 \item
@@ -3220,7 +3220,7 @@ template<class Sseq> explicit subtract_with_carry_engine(Sseq& q);
 Each type instantiated
 from a class template specified in this section~\ref{rand.adapt}
 satisfies the requirements
-of a random number engine adaptor~(\ref{rand.req.adapt}) type.
+of a random number engine adaptor\iref{rand.req.adapt} type.
 
 \pnum
 Except where specified otherwise,
@@ -4027,7 +4027,7 @@ template<class RandomAccessIterator>
 
 \begin{itemdescr}
 \pnum\requires \tcode{RandomAccessIterator}
-  shall meet the requirements of a mutable random access iterator~(\ref{random.access.iterators}).
+  shall meet the requirements of a mutable random access iterator\iref{random.access.iterators}.
   Moreover,
   \tcode{iterator_traits<RandomAccessIterator>::value_type}
   shall denote an unsigned integer type
@@ -4133,7 +4133,7 @@ template<class OutputIterator>
 \begin{itemdescr}
 \pnum\requires
   \tcode{OutputIterator} shall satisfy the requirements
-  of an output iterator~(\ref{output.iterators}).
+  of an output iterator\iref{output.iterators}.
   Moreover,
   the expression
   \tcode{*dest = rt}
@@ -4240,7 +4240,7 @@ template<class RealType, size_t bits, class URBG>
 Each type instantiated
 from a class template specified in this section~\ref{rand.dist}
 satisfies the requirements
-of a random number distribution~(\ref{rand.req.dist}) type.
+of a random number distribution\iref{rand.req.dist} type.
 
 \pnum
 Descriptions are provided in this section~\ref{rand.dist}
@@ -5868,7 +5868,7 @@ template<class InputIterator>
 \begin{itemdescr}
 \pnum\requires
   \tcode{InputIterator} shall satisfy the requirements
-  of an input iterator~(\ref{input.iterators}).
+  of an input iterator\iref{input.iterators}.
   Moreover,
   \tcode{iterator_traits<InputIterator>::value_type}
   shall denote a type that is convertible to \tcode{double}.
@@ -5903,7 +5903,7 @@ template<class UnaryOperation>
 \begin{itemdescr}
 \pnum\requires
  Each instance of type \tcode{UnaryOperation}
- shall be a function object~(\ref{function.objects})
+ shall be a function object\iref{function.objects}
  whose return type shall be convertible to \tcode{double}.
  Moreover,
  \tcode{double} shall be convertible
@@ -6083,7 +6083,7 @@ template<class UnaryOperation>
 \begin{itemdescr}
 \pnum\requires
  Each instance of type \tcode{UnaryOperation}
- shall be a function object~(\ref{function.objects})
+ shall be a function object\iref{function.objects}
  whose return type shall be convertible to \tcode{double}.
  Moreover,
  \tcode{double} shall be convertible
@@ -6118,7 +6118,7 @@ template<class UnaryOperation>
 \begin{itemdescr}
 \pnum\requires
  Each instance of type \tcode{UnaryOperation}
- shall be a function object~(\ref{function.objects})
+ shall be a function object\iref{function.objects}
  whose return type shall be convertible to \tcode{double}.
  Moreover,
  \tcode{double} shall be convertible
@@ -6304,7 +6304,7 @@ template<class UnaryOperation>
 \begin{itemdescr}
 \pnum\requires
  Each instance of type \tcode{UnaryOperation}
- shall be a function object~(\ref{function.objects})
+ shall be a function object\iref{function.objects}
  whose return type shall be convertible to \tcode{double}.
  Moreover,
  \tcode{double} shall be convertible
@@ -6339,7 +6339,7 @@ template<class UnaryOperation>
 \begin{itemdescr}
 \pnum\requires
  Each instance of type \tcode{UnaryOperation}
- shall be a function object~(\ref{function.objects})
+ shall be a function object\iref{function.objects}
  whose return type shall be convertible to \tcode{double}.
  Moreover,
  \tcode{double} shall be convertible
@@ -6392,7 +6392,7 @@ vector<result_type> densities() const;
 \indextext{\idxhdr{cstdlib}}%
 \indexlibrary{\idxhdr{cstdlib}}%
 \begin{note}
-The header \tcode{<cstdlib>}~(\ref{cstdlib.syn})
+The header \tcode{<cstdlib>}\iref{cstdlib.syn}
 declares the functions described in this subclause.
 \end{note}
 
@@ -6417,11 +6417,11 @@ may specify that particular library functions may call
 \tcode{rand}.
 It is \impldef{whether \tcode{rand} may introduce a data race}
 whether the \tcode{rand} function
-may introduce data races~(\ref{res.on.data.races}).
+may introduce data races\iref{res.on.data.races}.
 \begin{note}
 \indexlibrary{\idxcode{rand}!discouraged}%
 The other random
-number generation facilities in this International Standard~(\ref{rand}) are often preferable
+number generation facilities in this International Standard\iref{rand} are often preferable
 to \tcode{rand}, because \tcode{rand}'s underlying algorithm is unspecified.
 Use of \tcode{rand} therefore continues to be non-portable, with unpredictable
 and oft-questionable quality and performance.
@@ -6594,7 +6594,7 @@ const member functions of
 are also applicable to this type.
 This return type shall not add
 more than two levels of template nesting over the most deeply nested
-argument type.\footnote{Annex~\ref{implimits} recommends a minimum number
+argument type.\footnote{\ref{implimits} recommends a minimum number
 of recursively nested template
 instantiations.
 This requirement thus indirectly suggests a minimum
@@ -6607,7 +6607,7 @@ additional functions and operators as follows:
 \item
 for every function taking a
 \tcode{const valarray<T>\&} other than \tcode{begin} and
-\tcode{end}~(\ref{valarray.range}),
+\tcode{end}\iref{valarray.range},
 identical functions taking the replacement types shall be added;
 \item
 for every function taking two
@@ -6632,7 +6632,7 @@ objects.
 
 \pnum
 These library functions are permitted to throw a
-\tcode{bad_alloc}~(\ref{bad.alloc}) exception if there are not sufficient resources available
+\tcode{bad_alloc}\iref{bad.alloc} exception if there are not sufficient resources available
 to carry out the operation.
 Note that the exception is not mandated.
 
@@ -6792,7 +6792,7 @@ explicit valarray(size_t n);
 \pnum
 \effects
 Constructs a \tcode{valarray} that has length \tcode{n}.
-Each element of the array is value-initialized~(\ref{dcl.init}).
+Each element of the array is value-initialized\iref{dcl.init}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{valarray}!constructor}%
@@ -6815,7 +6815,7 @@ valarray(const T* p, size_t n);
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{p} points to an array~(\ref{dcl.array}) of at least
+\tcode{p} points to an array\iref{dcl.array} of at least
 \tcode{n} elements.
 
 \effects
@@ -7034,7 +7034,7 @@ and other techniques to generate efficient
 \pnum
 The reference returned by the subscript operator for an array shall
 be valid until the member function
-\tcode{resize(size_t, T)}~(\ref{valarray.members}) is called for that array or until the lifetime of
+\tcode{resize(size_t, T)}\iref{valarray.members} is called for that array or until the lifetime of
 that array ends, whichever happens first.
 \end{itemdescr}
 
@@ -7441,7 +7441,7 @@ places, with zero fill.
 \pnum
 \begin{example}
 If the argument has the value -2,
-the first two elements of the result will be value-initialized~(\ref{dcl.init}); the third element of the result will be assigned the value
+the first two elements of the result will be value-initialized\iref{dcl.init}; the third element of the result will be assigned the value
 of the first element of the argument; etc.
 \end{example}
 \end{itemdescr}
@@ -8525,20 +8525,20 @@ object refers.
 \pnum
 In the \tcode{begin} and \tcode{end} function templates that follow, \unspec{1}
 is a type that meets the requirements of a mutable random access
-iterator~(\ref{random.access.iterators})
-and of a contiguous iterator~(\ref{iterator.requirements.general})
+iterator\iref{random.access.iterators}
+and of a contiguous iterator\iref{iterator.requirements.general}
 whose \tcode{value_type} is the template
 parameter \tcode{T} and whose \tcode{reference} type is \tcode{T\&}. \unspec{2} is a
 type that meets the requirements of a constant random access
-iterator~(\ref{random.access.iterators})
-and of a contiguous iterator~(\ref{iterator.requirements.general})
+iterator\iref{random.access.iterators}
+and of a contiguous iterator\iref{iterator.requirements.general}
 whose \tcode{value_type} is the template
 parameter \tcode{T} and whose \tcode{reference} type is \tcode{const T\&}.
 
 \pnum
 The iterators returned by \tcode{begin} and \tcode{end} for an array
 are guaranteed to be valid until the member function
-\tcode{resize(size_t, T)}~(\ref{valarray.members}) is called for that
+\tcode{resize(size_t, T)}\iref{valarray.members} is called for that
 array or until the lifetime of that array ends, whichever happens
 first.
 
@@ -8802,7 +8802,7 @@ namespace std {
 
 \pnum
 The requirements on the types of algorithms' arguments that are
-described in the introduction to Clause~\ref{algorithms} also
+described in the introduction to \ref{algorithms} also
 apply to the following algorithms.
 
 \pnum
@@ -8812,7 +8812,7 @@ Throughout this subclause, the parameters
 \tcode{BinaryOperation1},
 and \tcode{BinaryOperation2}
 are used
-whenever an algorithm expects a function object~(\ref{function.objects}).
+whenever an algorithm expects a function object\iref{function.objects}.
 
 \pnum
 \begin{note}
@@ -9157,7 +9157,7 @@ template <class InputIterator, class OutputIterator, class BinaryOperation>
 \tcode{InputIterator}'s value type shall be constructible from the type of \tcode{*first}.
 The result of the expression \tcode{acc + *i} or \tcode{binary_op(acc, *i)} shall be
 implicitly convertible to \tcode{InputIterator}'s value type. \tcode{acc}
-shall be writable~(\ref{iterator.requirements.general}) to the \tcode{result} output iterator.
+shall be writable\iref{iterator.requirements.general} to the \tcode{result} output iterator.
 In the ranges
 \crange{first}{last}
 and
@@ -9601,7 +9601,7 @@ template <class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2,
 For the overloads with no \tcode{ExecutionPolicy}, \tcode{InputIterator}'s value
 type shall be \tcode{MoveAssignable} (Table~\ref{tab:moveassignable}) and shall
 be constructible from the type of \tcode{*first}. \tcode{acc} (defined below)
-shall be writable~(\ref{iterator.requirements.general}) to the \tcode{result}
+shall be writable\iref{iterator.requirements.general} to the \tcode{result}
 output iterator.  The result of the expression \tcode{val - acc} or
 \tcode{binary_op(val, acc)} shall be writable to the \tcode{result} output iterator.
 
@@ -10505,7 +10505,7 @@ a three-dimensional hypotenuse function~(\ref{c.math.hypot3}) and
 the mathematical special functions described in \ref{sf.cmath}.
 \begin{note}
 Several functions have additional overloads in this International Standard,
-but they have the same behavior as in the C standard library~(\ref{library.c}).
+but they have the same behavior as in the C standard library\iref{library.c}.
 \end{note}
 
 \pnum
@@ -10516,7 +10516,7 @@ there shall be additional overloads sufficient to ensure:
   \item If any argument of arithmetic type
     corresponding to a \tcode{double} parameter
     has type \tcode{long double},
-    then all arguments of arithmetic type~(\ref{basic.fundamental})
+    then all arguments of arithmetic type\iref{basic.fundamental}
     corresponding to \tcode{double} parameters
     are effectively cast to \tcode{long double}.
   \item Otherwise, if any argument of arithmetic type
@@ -10545,8 +10545,8 @@ ISO C 7.12
 \indextext{\idxhdr{cmath}}%
 \indexlibrary{\idxhdr{cmath}}%
 \begin{note}
-The headers \tcode{<cstdlib>}~(\ref{cstdlib.syn}) and
-\tcode{<cmath>}~(\ref{cmath.syn})
+The headers \tcode{<cstdlib>}\iref{cstdlib.syn} and
+\tcode{<cmath>}\iref{cmath.syn}
 declare the functions described in this subclause.
 \end{note}
 
@@ -10573,7 +10573,7 @@ for the functions \tcode{abs}, \tcode{labs}, \tcode{llabs},
 If \tcode{abs()} is called with an argument of type \tcode{X}
 for which \tcode{is_unsigned_v<X>} is \tcode{true} and
 if \tcode{X} cannot be converted to \tcode{int}
-by integral promotion~(\ref{conv.prom}), the program is ill-formed.
+by integral promotion\iref{conv.prom}, the program is ill-formed.
 \begin{note}
 Arguments that can be promoted to \tcode{int} are permitted for compatibility with C.
 \end{note}

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -52,7 +52,7 @@ two such non-overloadable declarations in the same scope.
 This restriction applies to explicit declarations in a scope, and between
 such declarations and
 declarations made through a
-\grammarterm{using-declaration}~(\ref{namespace.udecl}).
+\grammarterm{using-declaration}\iref{namespace.udecl}.
 It does not apply to sets of functions fabricated as a result of
 name lookup (e.g., because of
 \grammarterm{using-directive}{s})
@@ -67,21 +67,21 @@ Certain function declarations cannot be overloaded:
 \item
 \indextext{return type!overloading and}%
 Function declarations that differ only in the return type,
-the exception specification~(\ref{except.spec}), or both
+the exception specification\iref{except.spec}, or both
 cannot be overloaded.
 \item
 \indextext{\idxcode{static}!overloading and}%
 Member function declarations with the same name and the same
-parameter-type-list~(\ref{dcl.fct}) cannot be overloaded if any of them is a
+parameter-type-list\iref{dcl.fct} cannot be overloaded if any of them is a
 \tcode{static}
-member function declaration~(\ref{class.static}).
+member function declaration\iref{class.static}.
 Likewise, member function template declarations with the same name,
 the same parameter-type-list, and the same template parameter lists cannot be
 overloaded if any of them is a
 \tcode{static}
 member function template declaration.
 The types of the implicit object parameters constructed for the member
-functions for the purpose of overload resolution~(\ref{over.match.funcs})
+functions for the purpose of overload resolution\iref{over.match.funcs}
 are not considered when comparing parameter-type-lists for enforcement of
 this rule.
 In contrast, if there is no
@@ -107,10 +107,10 @@ class X {
 \end{example}
 
 \item Member function declarations with the same name and the same
-parameter-type-list~(\ref{dcl.fct}) as well as member function template
+parameter-type-list\iref{dcl.fct} as well as member function template
 declarations with the same name, the same parameter-type-list, and
 the same template parameter lists cannot be overloaded if any of them, but not
-all, have a \grammarterm{ref-qualifier}~(\ref{dcl.fct}). \begin{example}
+all, have a \grammarterm{ref-qualifier}\iref{dcl.fct}. \begin{example}
 
 \begin{codeblock}
 class Y {
@@ -132,7 +132,7 @@ class Y {
 \begin{note}
 As specified in~\ref{dcl.fct},
 function declarations that have equivalent parameter declarations
-and \grammarterm{requires-clause}{s}, if any~(\ref{temp.constr.decl}),
+and \grammarterm{requires-clause}{s}, if any\iref{temp.constr.decl},
 declare
 the same function and therefore cannot
 be overloaded:
@@ -144,7 +144,7 @@ Parameter declarations that differ only in the use of equivalent typedef
 ``types'' are equivalent.
 A
 \tcode{typedef}
-is not a separate type, but only a synonym for another type~(\ref{dcl.typedef}).
+is not a separate type, but only a synonym for another type\iref{dcl.typedef}.
 \begin{example}
 \begin{codeblock}
 typedef int Int;
@@ -178,9 +178,9 @@ versus an array
 \tcode{[]}
 are equivalent.
 That is, the array declaration is adjusted to become a pointer
-declaration~(\ref{dcl.fct}).
+declaration\iref{dcl.fct}.
 Only the second and subsequent array dimensions are significant in
-parameter types~(\ref{dcl.array}).
+parameter types\iref{dcl.array}.
 \begin{example}
 
 \begin{codeblock}
@@ -201,7 +201,7 @@ int g(char(*)[20]);             // different from \tcode{g(char(*)[10]);}
 \indextext{function!overloading and pointer versus}%
 Parameter declarations that differ only in that one is a function type
 and the other is a pointer to the same function type are equivalent.
-That is, the function type is adjusted to become a pointer to function type~(\ref{dcl.fct}).
+That is, the function type is adjusted to become a pointer to function type\iref{dcl.fct}.
 \begin{example}
 
 \begin{codeblock}
@@ -308,8 +308,8 @@ void prog () {
 
 \pnum
 Two function declarations of the same name refer to the same function if they
-are in the same scope and have equivalent parameter declarations~(\ref{over.load})
-and equivalent \grammarterm{requires-clause}{s}, if any~(\ref{temp.constr.decl}).
+are in the same scope and have equivalent parameter declarations\iref{over.load}
+and equivalent \grammarterm{requires-clause}{s}, if any\iref{temp.constr.decl}.
 A function member of a derived class is
 \textit{not}
 in the same scope as a function member of the same name in a base class.
@@ -421,29 +421,29 @@ contexts within the language:
 
 \begin{itemize}
 \item
-invocation of a function named in the function call syntax~(\ref{over.call.func});
+invocation of a function named in the function call syntax\iref{over.call.func};
 \item
 invocation of a function call operator, a pointer-to-function
 conversion function, a reference-to-pointer-to-function conversion
 function, or a reference-to-function
 conversion function on a class object named in the function
-call syntax~(\ref{over.call.object});
+call syntax\iref{over.call.object};
 \item
-invocation of the operator referenced in an expression~(\ref{over.match.oper});
+invocation of the operator referenced in an expression\iref{over.match.oper};
 \item
-invocation of a constructor for default- or direct-initialization~(\ref{dcl.init})
-of a class object~(\ref{over.match.ctor});
+invocation of a constructor for default- or direct-initialization\iref{dcl.init}
+of a class object\iref{over.match.ctor};
 \item
 invocation of a user-defined conversion for
-copy-initialization~(\ref{dcl.init}) of a class object~(\ref{over.match.copy});
+copy-initialization\iref{dcl.init} of a class object\iref{over.match.copy};
 \item
 invocation of a conversion function for initialization of an object of a
-non-class type from an expression of class type~(\ref{over.match.conv}); and
+non-class type from an expression of class type\iref{over.match.conv}; and
 \item
 invocation of a conversion function for conversion to a glvalue
 or class prvalue
-to which a reference~(\ref{dcl.init.ref})
-will be directly bound~(\ref{over.match.ref}).
+to which a reference\iref{dcl.init.ref}
+will be directly bound\iref{over.match.ref}.
 \end{itemize}
 
 Each of these contexts defines the set of candidate functions and
@@ -458,10 +458,10 @@ First, a subset of the candidate functions (those that have
 the proper number of arguments and meet certain other
 conditions) is selected to form a set of
 \indextext{function!viable}%
-viable functions~(\ref{over.match.viable}).
+viable functions\iref{over.match.viable}.
 \item
 Then the best viable function is selected based on the
-implicit conversion sequences~(\ref{over.best.ics}) needed to
+implicit conversion sequences\iref{over.best.ics} needed to
 match each argument to the corresponding parameter of each
 viable function.
 \end{itemize}
@@ -472,7 +472,7 @@ resolution succeeds and produces it as the result.
 Otherwise
 overload resolution fails and the invocation is ill-formed.
 When overload resolution succeeds,
-and the best viable function is not accessible (Clause~\ref{class.access}) in the context
+and the best viable function is not accessible\iref{class.access} in the context
 in which it is used,
 the program is ill-formed.
 
@@ -561,7 +561,7 @@ discarded).
 \begin{note}
 No actual type is established for the implicit object parameter
 of a static member function, and no attempt will be made to determine a
-conversion sequence for that parameter~(\ref{over.match.best}).
+conversion sequence for that parameter\iref{over.match.best}.
 \end{note}
 
 \pnum
@@ -584,7 +584,7 @@ an rvalue can be bound to the parameter
 as long as in all other respects the argument can be
 converted to the type of the implicit object parameter.
 \begin{note} The fact that such an argument is an rvalue does not
-affect the ranking of implicit conversion sequences~(\ref{over.ics.rank}).
+affect the ranking of implicit conversion sequences\iref{over.ics.rank}.
 \end{note}
 \end{itemize}
 
@@ -627,7 +627,7 @@ contain
 no template parameter types.
 Therefore, except where specified otherwise,
 function template specializations
-and non-template functions~(\ref{dcl.fct}) are treated equivalently
+and non-template functions\iref{dcl.fct} are treated equivalently
 for the remainder of overload resolution.}
 A given name can refer to one or more function templates and also
 to a set of overloaded non-template functions.
@@ -636,7 +636,7 @@ candidate functions generated from each function template are combined
 with the set of non-template candidate functions.
 
 \pnum
-A defaulted move special function~(\ref{class.copy}) that is
+A defaulted move special function\iref{class.copy} that is
 defined as deleted is excluded from the set of candidate functions in all
 contexts.
 
@@ -644,7 +644,7 @@ contexts.
 \indextext{overloading!resolution!function call syntax|(}
 
 \pnum
-In a function call~(\ref{expr.call})
+In a function call\iref{expr.call}
 
 \begin{ncsimplebnf}
 postfix-expression \terminal{(} expression-list\opt{} \terminal{)}
@@ -699,12 +699,12 @@ construct
 is generally equivalent to
 \tcode{(*A).B},
 the rest of
-Clause~\ref{over} assumes, without loss of generality, that all member
+\ref{over} assumes, without loss of generality, that all member
 function calls have been normalized to the form that uses an
 object and the
 \tcode{.}
 operator.
-Furthermore, Clause~\ref{over} assumes that
+Furthermore, \ref{over} assumes that
 the
 \grammarterm{postfix-expression}
 that is the left operand of the
@@ -724,7 +724,7 @@ in the call is looked up as a
 member function of
 \tcode{T}
 following the rules for looking up names in
-classes~(\ref{class.member.lookup}).
+classes\iref{class.member.lookup}.
 The function declarations found by that lookup constitute the set of
 candidate functions.
 The argument list is the
@@ -733,7 +733,7 @@ in the call augmented by the addition of the left operand of
 the
 \tcode{.}
 operator in the normalized member function call as the
-implied object argument~(\ref{over.match.funcs}).
+implied object argument\iref{over.match.funcs}.
 
 \pnum
 In unqualified function calls, the name is not qualified by an
@@ -744,7 +744,7 @@ operator and has the more general form of a
 \grammarterm{primary-expression}.
 The name is looked up in the context of the function
 call following the normal rules for name lookup in function
-calls~(\ref{basic.lookup}).
+calls\iref{basic.lookup}.
 The function declarations found by that lookup constitute the
 set of candidate functions.
 Because of the rules for name lookup, the set of candidate functions
@@ -761,7 +761,7 @@ In case (2), the argument list is the
 in the call augmented by the addition of an implied object
 argument as in a qualified function call.
 If the keyword
-\tcode{this}~(\ref{class.this}) is in scope and refers to
+\tcode{this}\iref{class.this} is in scope and refers to
 class
 \tcode{T},
 or a derived class of
@@ -909,7 +909,7 @@ int i = a(1);                   // calls \tcode{f1} via pointer returned from co
 \pnum
 If no operand of an operator in an expression has a type that is a class
 or an enumeration, the operator is assumed to be a built-in operator
-and interpreted according to Clause~\ref{expr}.
+and interpreted according to \ref{expr}.
 \begin{note}
 Because
 \tcode{.},
@@ -918,11 +918,11 @@ and
 \tcode{::}
 cannot be overloaded,
 these operators are always built-in operators interpreted according to
-Clause~\ref{expr}.
+\ref{expr}.
 \tcode{?:}
 cannot be overloaded, but the rules in this subclause are used to determine
 the conversions to be applied to the second and third operands when they
-have class or enumeration type~(\ref{expr.cond}).
+have class or enumeration type\iref{expr.cond}.
 \end{note}
 \begin{example}
 
@@ -956,7 +956,7 @@ to the equivalent function-call notation as summarized in
 Table~\ref{tab:over.rel.op.func}
 (where \tcode{@} denotes one of the operators covered in the specified subclause).
 However, the operands are sequenced in the order prescribed
-for the built-in operator (Clause~\ref{expr}).
+for the built-in operator\iref{expr}.
 
 \begin{floattable}{Relationship between operator and function call notation}{tab:over.rel.op.func}
 {l|m|m|m}
@@ -993,14 +993,14 @@ If
 \tcode{T1}
 is a complete class type or a class currently being defined, the set of member candidates is the
 result of the qualified lookup of
-\tcode{T1::operator@}~(\ref{over.call.func}); otherwise, the set of member
+\tcode{T1::operator@}\iref{over.call.func}; otherwise, the set of member
 candidates is empty.
 \item
 The set of non-member candidates is the result of the unqualified lookup of
 \tcode{operator@}
 in the context of
 the expression according to the usual rules for name
-lookup in unqualified function calls~(\ref{basic.lookup.argdep}) except
+lookup in unqualified function calls\iref{basic.lookup.argdep} except
 that all member functions are ignored.
 However, if no operand has a class type, only those non-member
 functions in the lookup set that have a first parameter of type
@@ -1086,9 +1086,9 @@ void m() {
 If a built-in candidate is selected by overload resolution, the
 operands of class type are converted to the types of the corresponding parameters
 of the selected operation function, except that the second standard conversion
-sequence of a user-defined conversion sequence~(\ref{over.ics.user}) is not applied.
+sequence of a user-defined conversion sequence\iref{over.ics.user} is not applied.
 Then the operator is treated as the corresponding
-built-in operator and interpreted according to Clause~\ref{expr}.
+built-in operator and interpreted according to \ref{expr}.
 \begin{example}
 \begin{codeblock}
 struct X {
@@ -1135,7 +1135,7 @@ or the operator
 \tcode{->},
 and there are no viable functions, then the operator is
 assumed to be the built-in operator and interpreted according to
-Clause~\ref{expr}.
+\ref{expr}.
 
 \pnum
 \begin{note}
@@ -1166,10 +1166,10 @@ void B::f() {
 \indextext{overloading!resolution!initialization}
 
 \pnum
-When objects of class type are direct-initialized~(\ref{dcl.init}),
+When objects of class type are direct-initialized\iref{dcl.init},
 copy-initialized from an expression of the same or a
-derived class type~(\ref{dcl.init}),
-or default-initialized~(\ref{dcl.init}),
+derived class type\iref{dcl.init},
+or default-initialized\iref{dcl.init},
 overload resolution selects the constructor.
 For direct-initialization or default-initialization
 that is not in the context of copy-initialization, the
@@ -1177,7 +1177,7 @@ candidate functions are
 all the constructors of the class of the object being
 initialized.
 For copy-initialization, the candidate functions are all
-the converting constructors~(\ref{class.conv.ctor}) of that
+the converting constructors\iref{class.conv.ctor} of that
 class.
 The argument list is the
 \grammarterm{expression-list} or \grammarterm{assignment-expression}
@@ -1204,7 +1204,7 @@ the candidate functions are selected as follows:
 
 \begin{itemize}
 \item
-The converting constructors~(\ref{class.conv.ctor}) of
+The converting constructors\iref{class.conv.ctor} of
 \tcode{T}
 are candidate functions.
 \item
@@ -1213,7 +1213,7 @@ When the type of the initializer expression is a class type
 the non-explicit conversion functions of
 \tcode{S}
 and its base classes are considered.
-When initializing a temporary object~(\ref{class.mem})
+When initializing a temporary object\iref{class.mem}
 to be bound to the first parameter of a constructor
 where the parameter is of type
 ``reference to possibly \cv-qualified \tcode{T}''
@@ -1277,11 +1277,11 @@ and yield type
 \tcode{T}
 or a type that can be converted to type
 \tcode{T}
-via a standard conversion sequence~(\ref{over.ics.scs})
+via a standard conversion sequence\iref{over.ics.scs}
 are candidate functions.
 For direct-initialization, those explicit conversion functions that are not
 hidden within \tcode{S} and yield type \tcode{T} or a type that can be converted
-to type \tcode{T} with a qualification conversion~(\ref{conv.qual}) are also
+to type \tcode{T} with a qualification conversion\iref{conv.qual} are also
 candidate functions.
 Conversion functions that return a cv-qualified type
 are considered to yield the cv-unqualified version of that type
@@ -1334,7 +1334,7 @@ and yield type ``lvalue reference to \cvqual{cv2} \tcode{T2}''
 ``\cvqual{cv2} \tcode{T2}''
 or ``rvalue reference to \cvqual{cv2} \tcode{T2}'' (when initializing an
 rvalue reference or an lvalue reference to function),
-where ``\cvqual{cv1} \tcode{T}'' is reference-compatible~(\ref{dcl.init.ref})
+where ``\cvqual{cv1} \tcode{T}'' is reference-compatible\iref{dcl.init.ref}
 with ``\cvqual{cv2} \tcode{T2}'',
 are candidate functions. For direct-initialization, those explicit
 conversion functions that are not hidden within \tcode{S} and yield
@@ -1342,7 +1342,7 @@ type ``lvalue reference to \cvqual{cv2} \tcode{T2}'' or ``\cvqual{cv2}
 \tcode{T2}'' or ``rvalue reference to \cvqual{cv2} \tcode{T2}'',
 respectively, where \tcode{T2} is the same type as \tcode{T} or can be
 converted to type \tcode{T} with a qualification
-conversion~(\ref{conv.qual}), are also candidate functions.
+conversion\iref{conv.qual}, are also candidate functions.
 
 \end{itemize}
 
@@ -1364,7 +1364,7 @@ constructor in two phases:
 
 \begin{itemize}
 \item
-Initially, the candidate functions are the initializer-list constructors~(\ref{dcl.init.list})
+Initially, the candidate functions are the initializer-list constructors\iref{dcl.init.list}
 of the class \tcode{T} and
 the argument list consists of the initializer list as a single argument.
 
@@ -1389,7 +1389,7 @@ resolution. \end{note}
 \indextext{deduction!class template arguments}%
 
 \pnum
-When resolving a placeholder for a deduced class type~(\ref{dcl.type.class.deduct})
+When resolving a placeholder for a deduced class type\iref{dcl.type.class.deduct}
 where the \grammarterm{template-name} names a primary class template \tcode{C},
 a set of functions and function templates is formed comprising:
 \begin{itemize}
@@ -1502,11 +1502,11 @@ B b{(int*)0, (char*)0};         // OK, deduces \tcode{B<char*>}
 
 \pnum
 From the set of candidate functions constructed for a given
-context~(\ref{over.match.funcs}), a set of viable functions is
+context\iref{over.match.funcs}, a set of viable functions is
 chosen, from which the best function will be selected by
 comparing argument conversion sequences
-and associated constraints~(\ref{temp.constr.decl})
-for the best fit~(\ref{over.match.best}).
+and associated constraints\iref{temp.constr.decl}
+for the best fit\iref{over.match.best}.
 The selection of viable functions considers
 associated constraints, if any, and
 relationships between arguments and function parameters other
@@ -1531,10 +1531,10 @@ parameters are viable.
 A candidate function having fewer than
 \textit{m}
 parameters is
-viable only if it has an ellipsis in its parameter list~(\ref{dcl.fct}).
+viable only if it has an ellipsis in its parameter list\iref{dcl.fct}.
 For the purposes of overload resolution,
 any argument for which there is no corresponding parameter is
-considered to ``match the ellipsis''~(\ref{over.ics.ellipsis}) .
+considered to ``match the ellipsis''\iref{over.ics.ellipsis} .
 \item
 A candidate function having more than
 \textit{m}
@@ -1542,7 +1542,7 @@ parameters is viable
 only if the
 \textit{(m+1)}-st
 parameter has a default
-argument~(\ref{dcl.fct.default}).\footnote{According to~\ref{dcl.fct.default},
+argument\iref{dcl.fct.default}.\footnote{According to~\ref{dcl.fct.default},
 parameters following the
 \textit{(m+1)}-st
 parameter must also have default arguments.}
@@ -1555,14 +1555,14 @@ parameters.
 
 \pnum
 Second, for a function to be viable, if it has associated constraints,
-those constraints shall be satisfied~(\ref{temp.constr.decl}).
+those constraints shall be satisfied\iref{temp.constr.decl}.
 
 \pnum
 Third, for
 \tcode{F}
 to be a viable function, there shall exist for each
 argument an
-\term{implicit conversion sequence}~(\ref{over.best.ics}) that
+\term{implicit conversion sequence}\iref{over.best.ics} that
 converts that argument to the corresponding parameter of
 \tcode{F}.
 If the parameter has reference type, the implicit conversion sequence
@@ -1651,7 +1651,7 @@ float x = a;        // ambiguous: both possibilities require conversions,
 or, if not that,
 
 \item the context is an initialization by conversion function for direct
-reference binding~(\ref{over.match.ref}) of a reference to function type, the
+reference binding\iref{over.match.ref} of a reference to function type, the
 return type of \tcode{F1} is the same kind of reference (i.e. lvalue or rvalue)
 as the reference being initialized, and the return type of \tcode{F2} is not
 \begin{example}
@@ -1721,11 +1721,11 @@ or, if not that,
 
 \item
 \tcode{F1} is generated from a
-\grammarterm{deduction-guide}~(\ref{over.match.class.deduct})
+\grammarterm{deduction-guide}\iref{over.match.class.deduct}
 and \tcode{F2} is not, or, if not that,
 
 \item
-\tcode{F1} is the copy deduction candidate~(\ref{over.match.class.deduct})
+\tcode{F1} is the copy deduction candidate\iref{over.match.class.deduct}
 and \tcode{F2} is not, or, if not that,
 
 \item
@@ -1857,7 +1857,7 @@ to convert an argument in a function call to the type of the
 corresponding parameter of the function being called.
 The
 sequence of conversions is an implicit conversion as defined in
-Clause~\ref{conv}, which means it is governed by the rules for
+\ref{conv}, which means it is governed by the rules for
 initialization of an object or reference by a single
 expression~(\ref{dcl.init}, \ref{dcl.init.ref}).
 
@@ -1868,7 +1868,7 @@ are converted to match the corresponding properties of the
 parameter.
 Other properties, such as the lifetime, storage class,
 alignment, accessibility of the argument, whether the argument is a bit-field,
-and whether a function is deleted~(\ref{dcl.fct.def.delete}), are ignored.
+and whether a function is deleted\iref{dcl.fct.def.delete}, are ignored.
 So, although an implicit
 conversion sequence can be defined for a given argument-parameter
 pair, the conversion from the argument to the parameter might still
@@ -1882,13 +1882,13 @@ sequence is one of the following forms:
 \begin{itemize}
 \item
 a
-\term{standard conversion sequence}~(\ref{over.ics.scs}),
+\term{standard conversion sequence}\iref{over.ics.scs},
 \item
 a
-\term{user-defined conversion sequence}~(\ref{over.ics.user}), or
+\term{user-defined conversion sequence}\iref{over.ics.user}, or
 \item
 an
-\term{ellipsis conversion sequence}~(\ref{over.ics.ellipsis}).
+\term{ellipsis conversion sequence}\iref{over.ics.ellipsis}.
 \end{itemize}
 
 \pnum
@@ -1939,7 +1939,7 @@ argument expression to a prvalue of the type of
 the parameter.
 \begin{note}
 When the parameter has a class type, this is a conceptual conversion
-defined for the purposes of Clause~\ref{over}; the actual initialization is
+defined for the purposes of \ref{over}; the actual initialization is
 defined in terms of constructors and is not a conversion.
 \end{note}
 Any difference in top-level cv-qualification is
@@ -1966,7 +1966,7 @@ Conversion from the derived class to the base class.
 There is no such standard conversion; this derived-to-base Conversion exists
 only in the description of implicit conversion sequences.
 \end{note}
-A derived-to-base Conversion has Conversion rank~(\ref{over.ics.scs}).
+A derived-to-base Conversion has Conversion rank\iref{over.ics.scs}.
 
 \pnum
 In all contexts, when converting to the implicit object parameter
@@ -1976,7 +1976,7 @@ only standard conversion sequences are allowed.
 \pnum
 If no conversions are required to match an argument to a
 parameter type, the implicit conversion sequence is the standard
-conversion sequence consisting of the identity conversion~(\ref{over.ics.scs}).
+conversion sequence consisting of the identity conversion\iref{over.ics.scs}.
 
 \pnum
 If no sequence of conversions can be found to convert an argument
@@ -2024,7 +2024,7 @@ are defined in the following subclauses.
 
 \pnum
 Table~\ref{tab:over.conversions}
-summarizes the conversions defined in Clause~\ref{conv} and
+summarizes the conversions defined in \ref{conv} and
 partitions them into four disjoint categories: Lvalue Transformation,
 Qualification Adjustment, Promotion, and Conversion.
 \begin{note}
@@ -2039,7 +2039,7 @@ value category or cv-qualification of the type.
 
 \pnum
 \begin{note}
-As described in Clause~\ref{conv},
+As described in \ref{conv},
 a standard conversion sequence is either the Identity conversion
 by itself (that is, no conversion) or consists of one to three
 conversions from the other
@@ -2059,10 +2059,10 @@ Each conversion in Table~\ref{tab:over.conversions}
 also has an associated rank (Exact
 Match, Promotion, or Conversion).
 These are used
-to rank standard conversion sequences~(\ref{over.ics.rank}).
+to rank standard conversion sequences\iref{over.ics.rank}.
 The rank of a conversion sequence is determined by considering the
 rank of each conversion in the sequence and the rank of any reference
-binding~(\ref{over.ics.ref}).
+binding\iref{over.ics.ref}.
 If any of those has Conversion rank, the
 sequence has Conversion rank; otherwise, if any of those has Promotion rank,
 the sequence has Promotion rank; otherwise, the sequence has Exact
@@ -2092,14 +2092,14 @@ Boolean conversions             &                               &               
 \pnum
 A user-defined conversion sequence consists of an initial
 standard conversion sequence followed by a user-defined
-conversion~(\ref{class.conv}) followed by a second standard
+conversion\iref{class.conv} followed by a second standard
 conversion sequence.
 If the user-defined conversion is specified
-by a constructor~(\ref{class.conv.ctor}), the initial standard
+by a constructor\iref{class.conv.ctor}, the initial standard
 conversion sequence converts the source type to the type required
 by the argument of the constructor.
 If the user-defined
-conversion is specified by a conversion function~(\ref{class.conv.fct}), the
+conversion is specified by a conversion function\iref{class.conv.fct}, the
 initial standard conversion sequence
 converts the source type to the implicit object parameter of the
 conversion function.
@@ -2137,11 +2137,11 @@ specification of the function called (see~\ref{expr.call}).
 \rSec4[over.ics.ref]{Reference binding}
 
 \pnum
-When a parameter of reference type binds directly~(\ref{dcl.init.ref}) to an
+When a parameter of reference type binds directly\iref{dcl.init.ref} to an
 argument expression, the implicit conversion sequence is the identity conversion,
 unless the argument expression has a type that is a derived class of the parameter
 type, in which case the implicit conversion sequence is a derived-to-base
-Conversion~(\ref{over.best.ics}).
+Conversion\iref{over.best.ics}.
 \begin{example}
 
 \begin{codeblock}
@@ -2154,7 +2154,7 @@ int i = f(b);       // calls \tcode{f(B\&)}, an exact match, rather than \tcode{
 \end{example}
 If the parameter binds directly to the result of
 applying a conversion function to the argument expression, the implicit
-conversion sequence is a user-defined conversion sequence~(\ref{over.ics.user}),
+conversion sequence is a user-defined conversion sequence\iref{over.ics.user},
 with the second standard conversion sequence either an identity conversion or,
 if the conversion function returns an entity of a type that is a derived class
 of the parameter type, a derived-to-base Conversion.
@@ -2203,13 +2203,13 @@ lvalue and finds an exact
 match with the parameter.
 If the function is selected by overload
 resolution, the call will nonetheless be ill-formed because of
-the prohibition on binding a non-\tcode{const} lvalue reference to a bit-field~(\ref{dcl.init.ref}).
+the prohibition on binding a non-\tcode{const} lvalue reference to a bit-field\iref{dcl.init.ref}.
 \end{example}
 
 \rSec4[over.ics.list]{List-initialization sequence}
 
 \pnum
-When an argument is an initializer list~(\ref{dcl.init.list}), it is not an
+When an argument is an initializer list\iref{dcl.init.list}, it is not an
 expression and special rules apply for converting it to a parameter type.
 
 \pnum
@@ -2217,7 +2217,7 @@ If the initializer list is a \grammarterm{designated-initializer-list},
 a conversion is only possible if
 the parameter has an aggregate type
 that can be initialized from the initializer list
-according to the rules for aggregate initialization~(\ref{dcl.init.aggr}),
+according to the rules for aggregate initialization\iref{dcl.init.aggr},
 in which case the implicit conversion sequence is
 a user-defined conversion sequence
 whose second standard conversion sequence
@@ -2227,7 +2227,7 @@ Aggregate initialization does not require that
 the members are declared in designation order.
 If, after overload resolution, the order does not match
 for the selected overload,
-the initialization of the parameter will be ill-formed~(\ref{dcl.init.list}).
+the initialization of the parameter will be ill-formed\iref{dcl.init.list}.
 \begin{example}
 \begin{codeblock}
 struct A { int x, y; };
@@ -2239,7 +2239,7 @@ void g(B b);               // \#4
 void h() {
   f({.x = 1, .y = 2}, 0);  // OK; calls \#1
   f({.y = 2, .x = 1}, 0);  // error: selects \#1, initialization of \tcode{a} fails
-                           // due to non-matching member order~(\ref{dcl.init.list})
+                           // due to non-matching member order\iref{dcl.init.list}
   g({.x = 1, .y = 2});     // error: ambiguous between \#3 and \#4
 }
 \end{codeblock}
@@ -2258,7 +2258,7 @@ Otherwise, if the parameter type is a character array%
 \footnote{Since there are no parameters of array type,
 this will only occur as the referenced type of a reference parameter.}
 and the initializer list has a single element that is an appropriately-typed
-string literal~(\ref{dcl.init.string}), the implicit conversion
+string literal\iref{dcl.init.string}, the implicit conversion
 sequence is the identity conversion.
 
 \pnum
@@ -2356,7 +2356,7 @@ i({ {1,2}, {"bar"} });  // OK: \tcode{i(D(A(std::initializer_list<int>\{1,2\}), 
 \pnum
 Otherwise, if the parameter has an aggregate type which can be initialized from
 the initializer list according to the rules for aggregate
-initialization~(\ref{dcl.init.aggr}), the implicit conversion sequence is a
+initialization\iref{dcl.init.aggr}, the implicit conversion sequence is a
 user-defined conversion sequence with the second standard conversion
 sequence an identity conversion. \begin{example}
 \begin{codeblock}
@@ -2440,13 +2440,13 @@ When comparing the basic forms of implicit conversion sequences
 
 \begin{itemize}
 \item
-a standard conversion sequence~(\ref{over.ics.scs}) is a better
+a standard conversion sequence\iref{over.ics.scs} is a better
 conversion sequence than a user-defined conversion sequence
 or an ellipsis conversion sequence, and
 \item
-a user-defined conversion sequence~(\ref{over.ics.user}) is a
+a user-defined conversion sequence\iref{over.ics.user} is a
 better conversion sequence than an ellipsis conversion
-sequence~(\ref{over.ics.ellipsis}).
+sequence\iref{over.ics.ellipsis}.
 \end{itemize}
 
 \pnum
@@ -2513,7 +2513,7 @@ have the same rank and are distinguishable by the rules
 in the paragraph below,
 or, if not that,
 
-\item \tcode{S1} and \tcode{S2} are reference bindings~(\ref{dcl.init.ref}) and
+\item \tcode{S1} and \tcode{S2} are reference bindings\iref{dcl.init.ref} and
 neither refers to an implicit object parameter of a non-static member function
 declared without a \grammarterm{ref-qualifier},
 and \tcode{S1} binds an rvalue reference to an
@@ -2547,7 +2547,7 @@ a.p();                          // calls \tcode{A::p()\&}
 or, if not that,
 
 \item
-\tcode{S1} and \tcode{S2} are reference bindings~(\ref{dcl.init.ref}) and
+\tcode{S1} and \tcode{S2} are reference bindings\iref{dcl.init.ref} and
 \tcode{S1} binds an lvalue reference to a function lvalue and \tcode{S2} binds
 an rvalue reference to a function lvalue
 \begin{example}
@@ -2567,7 +2567,7 @@ and
 differ only in their qualification conversion and yield similar types
 \tcode{T1}
 and
-\tcode{T2}~(\ref{conv.qual}), respectively, and the cv-qualification signature of type
+\tcode{T2}\iref{conv.qual}, respectively, and the cv-qualification signature of type
 \tcode{T1}
 is a proper subset of the cv-qualification signature of type
 \tcode{T2}
@@ -2585,7 +2585,7 @@ or, if not that,
 \tcode{S1}
 and
 \tcode{S2}
-are reference bindings~(\ref{dcl.init.ref}), and the types to which the references
+are reference bindings\iref{dcl.init.ref}, and the types to which the references
 refer are the same type except for top-level cv-qualifiers, and the type to
 which the reference initialized by
 \tcode{S2}
@@ -2810,7 +2810,7 @@ A function template name is considered to name a set of overloaded functions
 in such contexts.
 A function with type \tcode{F} is selected for the function type \tcode{FT}
 of the target type required in the context if \tcode{F}
-(after possibly applying the function pointer conversion~(\ref{conv.fctptr}))
+(after possibly applying the function pointer conversion\iref{conv.fctptr})
 is identical to \tcode{FT}.
 \begin{note}
 That is, the class of which the function is a member is ignored when matching a
@@ -2823,19 +2823,19 @@ The target can be
 an object or reference being initialized~(\ref{dcl.init}, \ref{dcl.init.ref},
 \ref{dcl.init.list}),
 \item
-the left side of an assignment~(\ref{expr.ass}),
+the left side of an assignment\iref{expr.ass},
 \item
-a parameter of a function~(\ref{expr.call}),
+a parameter of a function\iref{expr.call},
 \item
-a parameter of a user-defined operator~(\ref{over.oper}),
+a parameter of a user-defined operator\iref{over.oper},
 \item
-the return value of a function, operator function, or conversion~(\ref{stmt.return}),
+the return value of a function, operator function, or conversion\iref{stmt.return},
 \item
 an explicit type conversion~(\ref{expr.type.conv}, \ref{expr.static.cast},
 \ref{expr.cast}), or
 \item
 a non-type
-\grammarterm{template-parameter}~(\ref{temp.arg.nontype}).
+\grammarterm{template-parameter}\iref{temp.arg.nontype}.
 \end{itemize}
 
 The overloaded function name can be preceded by the
@@ -2845,12 +2845,12 @@ An overloaded function name shall not be used without arguments in contexts
 other than those listed.
 \begin{note}
 Any redundant set of parentheses surrounding the overloaded function name is
-ignored~(\ref{expr.prim}).
+ignored\iref{expr.prim}.
 \end{note}
 
 \pnum
 If the name is a function template, template argument deduction is
-done~(\ref{temp.deduct.funcaddr}), and if the argument deduction succeeds,
+done\iref{temp.deduct.funcaddr}, and if the argument deduction succeeds,
 the
 resulting template argument list is
 used to generate a single
@@ -2882,7 +2882,7 @@ described in~\ref{expr.unary.op}.
 \pnum
 All functions with
 associated constraints
-that are not satisfied~(\ref{temp.constr.decl})
+that are not satisfied\iref{temp.constr.decl}
 are eliminated from the set of selected functions.
 If more than one function in the set remains,
 all function template specializations
@@ -3016,8 +3016,8 @@ the operator named in its
 \end{bnfkeywordtab}
 
 \begin{note}
-The last two operators are function call~(\ref{expr.call})
-and subscripting~(\ref{expr.sub}).
+The last two operators are function call\iref{expr.call}
+and subscripting\iref{expr.sub}.
 The operators
 \tcode{new[]},
 \tcode{delete[]},
@@ -3050,7 +3050,7 @@ nor can the preprocessing symbols
 \tcode{\#}
 and
 \tcode{\#\#}
-(Clause~\ref{cpp}).
+(\ref{cpp}).
 
 \pnum
 \indextext{call!operator function}%
@@ -3058,7 +3058,7 @@ Operator functions are usually not called directly; instead they are invoked
 to evaluate the operators they implement~(\ref{over.unary} -- \ref{over.inc}).
 They can be explicitly called, however, using the
 \grammarterm{operator-function-id}
-as the name of the function in the function call syntax~(\ref{expr.call}).
+as the name of the function in the function call syntax\iref{expr.call}.
 \begin{example}
 
 \begin{codeblock}
@@ -3118,7 +3118,7 @@ this is not required by operator functions.
 
 \pnum
 \indextext{argument!overloaded operator and default}%
-An operator function cannot have default arguments~(\ref{dcl.fct.default}),
+An operator function cannot have default arguments\iref{dcl.fct.default},
 except where explicitly stated below.
 Operator
 functions cannot have more or fewer parameters than the
@@ -3138,7 +3138,7 @@ operators obeying the rules of~\ref{over.unary} or~\ref{over.binary}.%
 
 \pnum
 A prefix unary operator shall be implemented by a
-non-static member function~(\ref{class.mfct}) with no parameters or a
+non-static member function\iref{class.mfct} with no parameters or a
 non-member function with one parameter.
 \indextext{unary operator!interpretation of}%
 Thus, for any prefix unary operator
@@ -3170,7 +3170,7 @@ operator from an enclosing scope, and vice versa.
 
 \pnum
 A binary operator shall be implemented either by a non-static member
-function~(\ref{class.mfct})
+function\iref{class.mfct}
 with one parameter or by a non-member function with two parameters.
 \indextext{binary operator!interpretation of}%
 Thus, for any binary operator
@@ -3194,7 +3194,7 @@ non-static member function with
 exactly one parameter.
 Because a copy assignment operator
 \tcode{operator=}
-is implicitly declared for a class if not declared by the user~(\ref{class.copy}),
+is implicitly declared for a class if not declared by the user\iref{class.copy},
 a base class assignment operator is always hidden by the copy assignment
 operator of the derived class.
 
@@ -3272,7 +3272,7 @@ if
 \tcode{T2,}
 \tcode{T3)}
 exists and if the operator is selected as the best match function by
-the overload resolution mechanism~(\ref{over.match.best}).
+the overload resolution mechanism\iref{over.match.best}.
 
 \rSec2[over.sub]{Subscripting}%
 \indextext{subscripting operator!overloaded}%
@@ -3298,7 +3298,7 @@ of type
 if
 \tcode{T::op\-er\-a\-tor[]\-(T1)}
 exists and if the operator is selected as the best match function by
-the overload resolution mechanism~(\ref{over.match.best}).
+the overload resolution mechanism\iref{over.match.best}.
 \begin{example}
 \begin{codeblock}
 struct X {
@@ -3337,7 +3337,7 @@ of type
 if
 \tcode{T::operator->()}
 exists and if the operator is selected as the best match function by
-the overload resolution mechanism~(\ref{over.match}).
+the overload resolution mechanism\iref{over.match}.
 
 \rSec2[over.inc]{Increment and decrement}
 \indextext{increment operator!overloaded|see{overloading, increment operator}}%
@@ -3433,8 +3433,8 @@ such a literal suffix identifier is ill-formed, no diagnostic required.
 A declaration whose \grammarterm{declarator-id} is a
 \grammarterm{literal-operator-id} shall be a declaration of a namespace-scope
 function or function template (it could be a friend
-function~(\ref{class.friend})), an explicit instantiation or specialization of a
-function template, or a \grammarterm{using-declaration}~(\ref{namespace.udecl}).
+function\iref{class.friend}), an explicit instantiation or specialization of a
+function template, or a \grammarterm{using-declaration}\iref{namespace.udecl}.
 A function declared with a \grammarterm{literal-operator-id} is a \term{literal
 operator}. A function template declared with a \grammarterm{literal-operator-id}
 is a \term{literal operator template}.
@@ -3457,7 +3457,7 @@ const char16_t*, std::size_t
 const char32_t*, std::size_t
 \end{codeblock}
 
-If a parameter has a default argument~(\ref{dcl.fct.default}), the program is
+If a parameter has a default argument\iref{dcl.fct.default}, the program is
 ill-formed.
 
 \pnum
@@ -3469,14 +3469,14 @@ The declaration of a literal operator template shall have an empty
 \grammarterm{parameter-declaration-clause} and its
 \grammarterm{template-parameter-list} shall have a single
 \grammarterm{template-parameter} that is a non-type template parameter
-pack~(\ref{temp.variadic}) with element type \tcode{char}.
+pack\iref{temp.variadic} with element type \tcode{char}.
 
 \pnum
 Literal operators and literal operator templates shall not have C language linkage.
 
 \pnum
 \begin{note} Literal operators and literal operator templates are usually invoked
-implicitly through user-defined literals~(\ref{lex.ext}). However, except for
+implicitly through user-defined literals\iref{lex.ext}. However, except for
 the constraints described above, they are ordinary namespace-scope functions and
 function templates. In particular, they are looked up like ordinary functions
 and function templates and they follow the same overload resolution rules. Also,
@@ -3492,8 +3492,8 @@ string operator "" _i18n(const char*, std::size_t); // OK
 template <char...> double operator "" _\u03C0();    // OK: UCN for lowercase pi
 float operator ""_e(const char*);                   // OK
 float operator ""E(const char*);                    // error: reserved literal suffix~(\ref{usrlit.suffix}, \ref{lex.ext})
-double operator""_Bq(long double);                  // OK: does not use the reserved identifier \tcode{_Bq}~(\ref{lex.name})
-double operator"" _Bq(long double);                 // uses the reserved identifier \tcode{_Bq}~(\ref{lex.name})
+double operator""_Bq(long double);                  // OK: does not use the reserved identifier \tcode{_Bq}\iref{lex.name}
+double operator"" _Bq(long double);                 // uses the reserved identifier \tcode{_Bq}\iref{lex.name}
 float operator " " B(const char*);                  // error: non-empty \grammarterm{string-literal}
 string operator "" 5X(const char*, std::size_t);    // error: invalid literal suffix identifier
 double operator "" _miles(double);                  // error: invalid \grammarterm{parameter-declaration-clause}
@@ -3508,7 +3508,7 @@ extern "C" void operator "" _m(long double);        // error: C language linkage
 
 \pnum
 The candidate operator functions that represent the built-in operators
-defined in Clause~\ref{expr} are specified in this subclause.
+defined in \ref{expr} are specified in this subclause.
 These candidate
 functions participate in the operator overload resolution process as
 described in~\ref{over.match.oper} and are used for no other purpose.
@@ -3526,7 +3526,7 @@ more permissive than the built-in operators themselves.
 As
 described in~\ref{over.match.oper}, after a built-in operator is selected
 by overload resolution the expression is subject to the requirements for
-the built-in operator given in Clause~\ref{expr}, and therefore to any
+the built-in operator given in \ref{expr}, and therefore to any
 additional semantic constraints given there.
 If there is a user-written
 candidate with the same name and parameter types as a built-in
@@ -3540,7 +3540,7 @@ is hidden and is not included in the set of candidate functions.
 In this subclause, the term
 \defn{promoted integral type}
 is used to refer to those integral types which are preserved by
-integral promotion~(\ref{conv.prom}) (including e.g.
+integral promotion\iref{conv.prom} (including e.g.
 \tcode{int}
 and
 \tcode{long}

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -3049,8 +3049,7 @@ The following operators cannot be overloaded:
 nor can the preprocessing symbols
 \tcode{\#}
 and
-\tcode{\#\#}
-(\ref{cpp}).
+\tcode{\#\#}\iref{cpp}.
 
 \pnum
 \indextext{call!operator function}%

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -141,7 +141,7 @@ conditionally-supported with
 semantics.
 
 \pnum
-When in a group that is skipped~(\ref{cpp.cond}), the directive
+When in a group that is skipped\iref{cpp.cond}, the directive
 syntax is relaxed to allow any sequence of preprocessing tokens to occur between
 the directive name and the following new-line character.
 
@@ -267,7 +267,7 @@ in any context not mentioned in this section.
 Each preprocessing token that remains (in the list of preprocessing tokens that
 will become the controlling expression)
 after all macro replacements have occurred
-shall be in the lexical form of a token~(\ref{lex.token}).
+shall be in the lexical form of a token\iref{lex.token}.
 
 \pnum
 Preprocessing directives of the forms
@@ -314,7 +314,7 @@ are replaced with the \grammarterm{pp-number}
 and then each preprocessing token is converted into a token.
 \begin{note}
 An alternative
-token~(\ref{lex.digraph}) is not an identifier,
+token\iref{lex.digraph} is not an identifier,
 even when its spelling consists entirely of letters and underscores.
 Therefore it is not subject to this replacement.
 \end{note}
@@ -326,14 +326,14 @@ using arithmetic that has at least the ranges specified
 in~\ref{support.limits}. For the purposes of this token conversion and evaluation
 all signed and unsigned integer types
 act as if they have the same representation as, respectively,
-\tcode{intmax_t} or \tcode{uintmax_t}~(\ref{cstdint}).
+\tcode{intmax_t} or \tcode{uintmax_t}\iref{cstdint}.
 \begin{note}
 Thus on an
 implementation where \tcode{std::numeric_limits<int>::max()} is \tcode{0x7FFF}
 and \tcode{std::numeric_limits<unsigned int>::max()} is \tcode{0xFFFF},
 the integer literal \tcode{0x8000} is signed and positive within a \tcode{\#if}
 expression even though it is unsigned in translation phase
-7~(\ref{lex.phases}).
+7\iref{lex.phases}.
 \end{note}
 This includes interpreting character literals, which may involve
 converting escape sequences into execution character set members.
@@ -528,7 +528,7 @@ preprocessing token is \impldef{search locations for \tcode{""""} header}.
 \pnum
 The implementation shall provide unique mappings for
 sequences consisting of one or more
-\grammarterm{nondigit}{s} or \grammarterm{digit}{s}~(\ref{lex.name})
+\grammarterm{nondigit}{s} or \grammarterm{digit}{s}\iref{lex.name}
 followed by a period
 (\tcode{.})
 and a single
@@ -678,7 +678,7 @@ not sequences possibly containing identifier-like subsequences
 (see \ref{lex.phases}, translation phases),
 they are never scanned for macro names or parameters.}
 to be replaced by the replacement list of preprocessing tokens
-that constitute the remainder of the directive.\footnote{An alternative token~(\ref{lex.digraph}) is not an identifier,
+that constitute the remainder of the directive.\footnote{An alternative token\iref{lex.digraph} is not an identifier,
 even when its spelling consists entirely of letters and underscores.
 Therefore it is not possible to define a macro
 whose name is the same as that of an alternative token.}
@@ -811,7 +811,7 @@ SDEF(foo);          // replaced by \tcode{S foo;}
 SDEF(bar, 1, 2);    // replaced by \tcode{S bar = \{ 1, 2 \};}
 
 #define H1(X, ...) X __VA_OPT__(##) __VA_ARGS__ // ill-formed: \tcode{\#\#} may not appear at
-                                                // the beginning of a replacement list~(\ref{cpp.concat})
+                                                // the beginning of a replacement list\iref{cpp.concat}
 #define H2(X, Y, ...) __VA_OPT__(X ## Y,) __VA_ARGS__
 
 H2(a, b, c, d)      // replaced by \tcode{ab, c, d}
@@ -1191,7 +1191,7 @@ The
 \term{line number}
 of the current source line is one greater than
 the number of new-line characters read or introduced
-in translation phase 1~(\ref{lex.phases})
+in translation phase 1\iref{lex.phases}
 while processing the source file to the current token.
 
 \pnum
@@ -1340,7 +1340,7 @@ by a call to \tcode{operator new(std::size_t)}
 or \tcode{operator new[](std::size_t)}.
 \begin{note}
 Larger alignments will be passed to
-\tcode{operator new(std::size_t, std::align_val_t)}, etc.~(\ref{expr.new}).
+\tcode{operator new(std::size_t, std::align_val_t)}, etc.\iref{expr.new}.
 \end{note}
 
 \indextext{__TIME__@\mname{TIME}}%
@@ -1388,12 +1388,12 @@ all amendments and technical corrigenda as of the specified year and month.
 \indextext{__STDCPP_STRICT_POINTER_SAFETY__@\mname{STDCPP_STRICT_POINTER_SAFETY}}%
 \item \mname{STDCPP_STRICT_POINTER_SAFETY}\\
 Defined, and has the value integer literal 1, if and only if the implementation
-has strict pointer safety~(\ref{basic.stc.dynamic.safety}).
+has strict pointer safety\iref{basic.stc.dynamic.safety}.
 
 \indextext{__STDCPP_THREADS__@\mname{STDCPP_THREADS}}%
 \item \mname{STDCPP_THREADS}\\
 Defined, and has the value integer literal 1, if and only if a program
-can have more than one thread of execution~(\ref{intro.multithread}).
+can have more than one thread of execution\iref{intro.multithread}.
 
 \end{description}
 

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -12,7 +12,7 @@ searching.
 
 \pnum
 The following subclauses describe a basic regular expression class template and its
-traits that can handle char-like~(\ref{strings.general}) template arguments,
+traits that can handle char-like\iref{strings.general} template arguments,
 two specializations of this class template that handle sequences of \tcode{char} and \tcode{wchar_t},
 a class template that holds the
 result of a regular expression match, a series of algorithms that allow a character
@@ -88,12 +88,12 @@ been marked by parenthesis.
 \pnum
 This subclause defines requirements on classes representing regular
 expression traits.  \begin{note} The class template
-\tcode{regex_traits}, defined in Clause~\ref{re.traits},
+\tcode{regex_traits}, defined in \ref{re.traits},
 satisfies these requirements.  \end{note}
 
 \pnum
 The class template \tcode{basic_regex}, defined in
-Clause~\ref{re.regex}, needs a set of related types and
+\ref{re.regex}, needs a set of related types and
 functions to complete the definition of its semantics. These types
 and functions are provided as a set of member \grammarterm{typedef-name}{s} and functions
 in the template parameter \tcode{traits} used by the \tcode{basic_regex} class
@@ -115,8 +115,8 @@ defining types and functions for the character container
 type \tcode{charT}; \tcode{u} is an object of
 type \tcode{X}; \tcode{v} is an object of type \tcode{const
 X}; \tcode{p} is a value of type \tcode{const charT*}; \tcode{I1}
-and \tcode{I2} are input iterators~(\ref{input.iterators});
-\tcode{F1} and \tcode{F2} are forward iterators~(\ref{forward.iterators});
+and \tcode{I2} are input iterators\iref{input.iterators};
+\tcode{F1} and \tcode{F2} are forward iterators\iref{forward.iterators};
 \tcode{c} is a value of type \tcode{const charT};
 \tcode{s} is an object of type \tcode{X::string_type};
 \tcode{cs} is an object of type \tcode{const X::string_type};
@@ -150,7 +150,7 @@ and \tcode{loc} is an object of type \tcode{X::locale_type}.
   & A type that represents the locale used by the traits class. \indextext{locale}
  \\ \rowsep
 \tcode{X::char_class_type}
- & A bitmask type~(\ref{bitmask.types}).
+ & A bitmask type\iref{bitmask.types}.
  & A bitmask type representing a particular character classification.
    \indextext{regular expression traits!\idxcode{char_class_type}}%
    \indextext{\idxcode{char_class_type}!regular expression traits}%
@@ -251,7 +251,7 @@ and \tcode{loc} is an object of type \tcode{X::locale_type}.
 Class template \tcode{regex_traits} satisfies the requirements for a
 regular expression traits class when it is specialized for
 \tcode{char} or \tcode{wchar_t}.  This class template is described in
-the header \tcode{<regex>}, and is described in Clause~\ref{re.traits}.
+the header \tcode{<regex>}, and is described in \ref{re.traits}.
 \end{note}
 
 \rSec1[re.syn]{Header \tcode{<regex>} synopsis}
@@ -655,7 +655,7 @@ namespace std::regex_constants {
 \indexlibrary{\idxcode{syntax_option_type}!\idxcode{grep}}%
 \indexlibrary{\idxcode{syntax_option_type}!\idxcode{egrep}}%
 The type \tcode{syntax_option_type} is an \impldef{type of \tcode{syntax_option_type}} bitmask
-type~(\ref{bitmask.types}). Setting its elements has the effects listed in
+type\iref{bitmask.types}. Setting its elements has the effects listed in
 Table~\ref{tab:re:syntaxoption}.  A valid value of type
 \tcode{syntax_option_type} shall have at most one of the grammar elements
 \tcode{ECMAScript}, \tcode{basic}, \tcode{extended}, \tcode{awk}, \tcode{grep}, \tcode{egrep}, set.
@@ -789,7 +789,7 @@ namespace std::regex_constants {
 \pnum
 \indexlibrary{\idxcode{match_flag_type}}%
 The type \tcode{match_flag_type} is an
-\impldef{type of \tcode{regex_constants::match_flag_type}} bitmask type~(\ref{bitmask.types}).
+\impldef{type of \tcode{regex_constants::match_flag_type}} bitmask type\iref{bitmask.types}.
 The constants of that type, except for \tcode{match_default} and
 \tcode{format_default}, are bitmask elements. The \tcode{match_default} and
 \tcode{format_default} constants are empty bitmasks.
@@ -851,7 +851,7 @@ The expression shall only match a sub-sequence that begins at
 \tcode{match_prev_avail} &
 \verb!--first! is a valid iterator position. When this flag is
 set the flags \tcode{match_not_bol} and \tcode{match_not_bow} shall be ignored by the
-regular expression algorithms~(\ref{re.alg}) and iterators~(\ref{re.iter}).
+regular expression algorithms\iref{re.alg} and iterators\iref{re.iter}.
 \\ \rowsep
 %
 \indexlibrary{\idxcode{format_default}}%
@@ -912,7 +912,7 @@ namespace std::regex_constants {
 \indexlibrary{\idxcode{error_type}}%
 \indexlibrary{\idxcode{regex_constants}!\idxcode{error_type}}%
 The type \tcode{error_type} is an \impldef{type of
-\tcode{regex_constants::error_type}} enumerated type~(\ref{enumerated.types}).
+\tcode{regex_constants::error_type}} enumerated type\iref{enumerated.types}.
 Values of type \tcode{error_type} represent the error
 conditions described in Table~\ref{tab:re:errortype}:
 
@@ -1054,7 +1054,7 @@ namespace std {
 \indextext{\idxcode{regex_traits}!specializations}%
 The specializations \tcode{regex_traits<char>} and
 \tcode{regex_traits<wchar_t>} shall be valid and shall satisfy the
-requirements for a regular expression traits class~(\ref{re.req}).
+requirements for a regular expression traits class\iref{re.req}.
 
 \indexlibrarymember{regex_traits}{char_class_type}%
 \begin{itemdecl}
@@ -1736,7 +1736,7 @@ template <class InputIterator>
 \begin{itemdescr}
 \pnum
 \requires  The type \tcode{InputIterator} shall satisfy the requirements for an Input
-Iterator~(\ref{input.iterators}).
+Iterator\iref{input.iterators}.
 
 \pnum
 \returns \tcode{assign(string_type(first, last), f)}.
@@ -2832,7 +2832,7 @@ template <class OutputIter>
 \begin{itemdescr}
 \pnum
 \requires \tcode{ready() == true} and \tcode{OutputIter} shall satisfy the requirements for an
-Output Iterator~(\ref{output.iterators}).
+Output Iterator\iref{output.iterators}.
 
 \pnum
 \effects Copies the character sequence \range{fmt_first}{fmt_last} to
@@ -2982,7 +2982,7 @@ other is not. If both match results are ready, returns \tcode{true} only if:
 \tcode{m1.suffix() == m2.suffix()}.
 \end{itemize}
 \end{itemize}
-\begin{note} The algorithm \tcode{equal} is defined in Clause~\ref{algorithms}. \end{note}
+\begin{note} The algorithm \tcode{equal} is defined in \ref{algorithms}. \end{note}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator"!=}!\idxcode{match_results}}%
@@ -3020,7 +3020,7 @@ template <class BidirectionalIterator, class Allocator, class charT, class trait
 \begin{itemdescr}
 \pnum
 \requires The type \tcode{BidirectionalIterator} shall satisfy the requirements
-of a Bidirectional Iterator~(\ref{bidirectional.iterators}).
+of a Bidirectional Iterator\iref{bidirectional.iterators}.
 
 \pnum
 \effects  Determines whether there is a match between the
@@ -3203,7 +3203,7 @@ template <class BidirectionalIterator, class Allocator, class charT, class trait
 \begin{itemdescr}
 \pnum
 \requires Type \tcode{BidirectionalIterator} shall satisfy the requirements of a Bidirectional
-Iterator~(\ref{bidirectional.iterators}).
+Iterator\iref{bidirectional.iterators}.
 
 \pnum
 \effects Determines whether there is some sub-sequence within \range{first}{last} that matches
@@ -4166,8 +4166,8 @@ to an integral value, this is accomplished by calling \tcode{traits_inst.value}.
 The behavior of the internal finite state machine representation when used to match a
 sequence of characters is as described in ECMA-262.
 The behavior is modified according
-to any match_flag_type flags~(\ref{re.matchflag}) specified when using the regular expression
-object in one of the regular expression algorithms~(\ref{re.alg}). The behavior is also
+to any match_flag_type flags\iref{re.matchflag} specified when using the regular expression
+object in one of the regular expression algorithms\iref{re.alg}. The behavior is also
 localized by interaction with the traits class template parameter as follows:
 \begin{itemize}
 \item During matching of a regular expression finite state machine

--- a/source/special.tex
+++ b/source/special.tex
@@ -15,14 +15,14 @@
 \indextext{constructor!move}%
 \indextext{assignment operator!copy}%
 \indextext{assignment operator!move}%
-The default constructor~(\ref{class.ctor}),
-copy constructor and copy assignment operator~(\ref{class.copy}),
-move constructor and move assignment operator~(\ref{class.copy}),
-and destructor~(\ref{class.dtor}) are
+The default constructor\iref{class.ctor},
+copy constructor and copy assignment operator\iref{class.copy},
+move constructor and move assignment operator\iref{class.copy},
+and destructor\iref{class.dtor} are
 \term{special member functions}.
 \begin{note} The implementation will implicitly declare these member functions for some class
 types when the program does not explicitly declare them.
-The implementation will implicitly define them if they are odr-used~(\ref{basic.def.odr}).
+The implementation will implicitly define them if they are odr-used\iref{basic.def.odr}.
 See~\ref{class.ctor}, \ref{class.dtor} and~\ref{class.copy}. \end{note}
 An implicitly-declared special member function is declared at the closing
 \tcode{\}} of the \grammarterm{class-specifier}.
@@ -55,7 +55,7 @@ Often such special member functions are called implicitly.
 
 \pnum
 \indextext{access control!member function and}%
-Special member functions obey the usual access rules (Clause~\ref{class.access}).
+Special member functions obey the usual access rules\iref{class.access}.
 \begin{example}
 Declaring a constructor
 \tcode{protected}
@@ -64,7 +64,7 @@ ensures that only derived classes and friends can create objects using it.
 
 \pnum
 For a class, its non-static data members, its non-virtual direct base classes,
-and, if the class is not abstract~(\ref{class.abstract}), its virtual base
+and, if the class is not abstract\iref{class.abstract}, its virtual base
 classes are called its \term{potentially constructed subobjects}.
 
 \rSec1[class.ctor]{Constructors}%
@@ -74,7 +74,7 @@ classes are called its \term{potentially constructed subobjects}.
 \pnum
 Constructors do not have names.
 In a declaration of a constructor, the \grammarterm{declarator} is a
-function declarator~(\ref{dcl.fct}) of the form
+function declarator\iref{dcl.fct} of the form
 
 \begin{ncbnf}
 ptr-declarator \terminal{(} parameter-declaration-clause \terminal{)} noexcept-specifier\opt attribute-specifier-seq\opt
@@ -89,20 +89,20 @@ one of the following forms:
 \item
 in a \grammarterm{member-declaration} that belongs to the
 \grammarterm{member-specification} of a class but is not a friend
-declaration~(\ref{class.friend}), the \grammarterm{id-expression} is the
-injected-class-name (Clause~\ref{class}) of the immediately-enclosing class;
+declaration\iref{class.friend}, the \grammarterm{id-expression} is the
+injected-class-name\iref{class} of the immediately-enclosing class;
 
 \item
 in a \grammarterm{member-declaration} that belongs to the
 \grammarterm{member-specification} of a class template but is not a friend
 declaration, the \grammarterm{id-expression} is a \grammarterm{class-name} that
-names the current instantiation~(\ref{temp.dep.type}) of the
+names the current instantiation\iref{temp.dep.type} of the
 immediately-enclosing class template; or
 
 \item
 in a declaration at namespace scope or in a friend declaration, the
 \grammarterm{id-expression} is a \grammarterm{qualified-id} that names a
-constructor~(\ref{class.qual}).
+constructor\iref{class.qual}.
 \end{itemize}
 
 The \grammarterm{class-name} shall not be a \grammarterm{typedef-name}. In a constructor
@@ -124,7 +124,7 @@ S::S() { }          // defines the constructor
 A constructor is used to initialize objects of its class type.
 Because constructors do not have names, they are never found during
 name lookup; however an explicit type conversion using the functional
-notation~(\ref{expr.type.conv}) will cause a constructor to be called to
+notation\iref{expr.type.conv} will cause a constructor to be called to
 initialize an object.
 \begin{note}
 For initialization of objects of class type see~\ref{class.init}.
@@ -144,9 +144,9 @@ object.
 \tcode{const}
 and
 \tcode{volatile}
-semantics~(\ref{dcl.type.cv}) are not applied on an object under construction.
+semantics\iref{dcl.type.cv} are not applied on an object under construction.
 They come into effect when the constructor for the
-most derived object~(\ref{intro.object}) ends.
+most derived object\iref{intro.object} ends.
 
 \pnum
 \indextext{constructor!inheritance of}%
@@ -167,7 +167,7 @@ has a default argument
 If there is no user-declared constructor for class
 \tcode{X},
 a non-explicit constructor having no parameters is implicitly declared
-as defaulted~(\ref{dcl.fct.def}).
+as defaulted\iref{dcl.fct.def}.
 An implicitly-declared default constructor is an
 \tcode{inline}
 \tcode{public}
@@ -186,7 +186,7 @@ with a non-trivial default constructor and
 no variant member of the anonymous union containing \tcode{M}
 has a default member initializer,
 
-\item any non-static data member with no default member initializer~(\ref{class.mem}) is
+\item any non-static data member with no default member initializer\iref{class.mem} is
 of reference type,
 
 \item any non-variant non-static data member of const-qualified type (or array
@@ -218,11 +218,11 @@ if it is not user-provided and if:
 
 \begin{itemize}
 \item
-its class has no virtual functions~(\ref{class.virtual}) and no virtual base
-classes~(\ref{class.mi}), and
+its class has no virtual functions\iref{class.virtual} and no virtual base
+classes\iref{class.mi}, and
 
 \item no non-static data member of its class has
-a default member initializer~(\ref{class.mem}), and
+a default member initializer\iref{class.mem}, and
 
 \item
 all the direct base classes of its class have trivial default constructors, and
@@ -241,18 +241,18 @@ A default constructor
 that is defaulted and not defined as deleted
 is
 \term{implicitly defined}
-when it is odr-used~(\ref{basic.def.odr})
-to create an object of its class type~(\ref{intro.object})
+when it is odr-used\iref{basic.def.odr}
+to create an object of its class type\iref{intro.object}
 or when it is explicitly defaulted after its first declaration.
 The implicitly-defined default constructor performs the set of
 initializations of the class that would be performed by a user-written default
 constructor for that class with no
-\grammarterm{ctor-initializer}~(\ref{class.base.init}) and an empty
+\grammarterm{ctor-initializer}\iref{class.base.init} and an empty
 \grammarterm{compound-statement}.
 If that user-written default constructor would be ill-formed,
 the program is ill-formed.
 If that user-written default constructor would satisfy the requirements
-of a constexpr constructor~(\ref{dcl.constexpr}), the implicitly-defined
+of a constexpr constructor\iref{dcl.constexpr}, the implicitly-defined
 default constructor is \tcode{constexpr}.
 Before the defaulted default constructor for a class is
 implicitly defined,
@@ -260,7 +260,7 @@ all the non-user-provided default constructors for its base classes and
 its non-static data members shall have been implicitly defined.
 \begin{note}
 An implicitly-declared default constructor has an
-exception specification~(\ref{except.spec}).
+exception specification\iref{except.spec}.
 An explicitly-defaulted definition might have an
 implicit exception specification, see~\ref{dcl.fct.def}.
 \end{note}
@@ -269,16 +269,16 @@ implicit exception specification, see~\ref{dcl.fct.def}.
 \indextext{constructor!implicitly called}%
 Default constructors are called implicitly to create class objects of static, thread,
 or automatic storage duration~(\ref{basic.stc.static}, \ref{basic.stc.thread}, \ref{basic.stc.auto}) defined
-without an initializer~(\ref{dcl.init}),
-are called to create class objects of dynamic storage duration~(\ref{basic.stc.dynamic}) created by a
+without an initializer\iref{dcl.init},
+are called to create class objects of dynamic storage duration\iref{basic.stc.dynamic} created by a
 \grammarterm{new-expression}
 in which the
 \grammarterm{new-initializer}
-is omitted~(\ref{expr.new}), or
-are called when the explicit type conversion syntax~(\ref{expr.type.conv}) is
+is omitted\iref{expr.new}, or
+are called when the explicit type conversion syntax\iref{expr.type.conv} is
 used.
 A program is ill-formed if the default constructor for an object
-is implicitly used and the constructor is not accessible (Clause~\ref{class.access}).
+is implicitly used and the constructor is not accessible\iref{class.access}.
 
 \pnum
 \begin{note}
@@ -300,7 +300,7 @@ The address of a constructor shall not be taken.
 \pnum
 \indextext{object!unnamed}%
 \indextext{constructor!explicit call}%
-A functional notation type conversion~(\ref{expr.type.conv}) can be used
+A functional notation type conversion\iref{expr.type.conv} can be used
 to create new objects of its type.
 \begin{note}
 The syntax looks like an explicit call of the constructor.
@@ -377,25 +377,25 @@ D d = D(1);                     // value of \tcode{d.b} is unspecified
 Temporary objects are created
 \begin{itemize}
 \item
-when a prvalue is materialized so that it can be used as a glvalue~(\ref{conv.rval}),
+when a prvalue is materialized so that it can be used as a glvalue\iref{conv.rval},
 \item
 when needed by the implementation to pass or return an object of trivially-copyable type (see below),
 and
 \item
-when throwing an exception~(\ref{except.throw}).
+when throwing an exception\iref{except.throw}.
 \begin{note}
 The lifetime of exception objects is described in~\ref{except.throw}.
 \end{note}
 \end{itemize}
 Even when the creation of the temporary object is
-unevaluated (Clause~\ref{expr}),
+unevaluated\iref{expr},
 all the semantic restrictions shall be respected as if the temporary object
 had been created and later destroyed.
 \begin{note}
-This includes accessibility (Clause~\ref{class.access}) and whether it is deleted,
+This includes accessibility\iref{class.access} and whether it is deleted,
 for the constructor selected and for the destructor. However, in the special
 case of the operand of a
-\grammarterm{decltype-specifier}~(\ref{expr.call}), no temporary is introduced,
+\grammarterm{decltype-specifier}\iref{expr.call}, no temporary is introduced,
 so the foregoing does not apply to such a prvalue.
 \end{note}
 
@@ -414,11 +414,11 @@ when performing member access on a class prvalue~(\ref{expr.ref}, \ref{expr.mptr
 \item
 when performing an array-to-pointer conversion or subscripting on an array prvalue~(\ref{conv.array}, \ref{expr.sub}),
 \item
-when initializing an object of type \tcode{std::initializer_list<T>} from a \grammarterm{braced-init-list}~(\ref{dcl.init.list}),
+when initializing an object of type \tcode{std::initializer_list<T>} from a \grammarterm{braced-init-list}\iref{dcl.init.list},
 \item
 for certain unevaluated operands~(\ref{expr.typeid}, \ref{expr.sizeof}), and
 \item
-when a prvalue appears as a discarded-value expression (Clause~\ref{expr}).
+when a prvalue appears as a discarded-value expression\iref{expr}.
 \end{itemize}
 \end{note}
 \begin{example} Consider the following code:
@@ -494,10 +494,10 @@ When an implementation introduces a temporary object of a class that has a
 non-trivial constructor~(\ref{class.ctor}, \ref{class.copy}), it shall ensure that
 a constructor is called for the temporary object.
 Similarly, the destructor shall be called for a temporary with a non-trivial
-destructor~(\ref{class.dtor}).
+destructor\iref{class.dtor}.
 Temporary objects are destroyed as the last step
 in evaluating
-the full-expression~(\ref{intro.execution})
+the full-expression\iref{intro.execution}
 that (lexically) contains the point where
 they were created.
 This is true even if that evaluation ends in throwing an exception.
@@ -515,7 +515,7 @@ subexpression.
 There are three contexts in which temporaries are destroyed at a different
 point than the end of the full-expression.
 The first context is when a default constructor is called to initialize
-an element of an array with no corresponding initializer~(\ref{dcl.init}).
+an element of an array with no corresponding initializer\iref{dcl.init}.
 The second context is when a copy constructor is called to copy an element of
 an array while the entire array is copied~(\ref{expr.prim.lambda.capture}, \ref{class.copy}).
 In either case, if the constructor has one or more default arguments,
@@ -525,7 +525,7 @@ sequenced before the construction of the next array element, if any.
 \pnum
 The third context is when a reference is bound to a
 temporary object.\footnote{The same rules apply to initialization of an
-  \tcode{initializer_list} object~(\ref{dcl.init.list}) with its
+  \tcode{initializer_list} object\iref{dcl.init.list} with its
   underlying temporary array.}
 The temporary object to which the reference is bound or the temporary object
 that is the complete object of a subobject to which the reference is bound
@@ -534,36 +534,36 @@ to which the reference is bound
 was obtained through one of the following:
 \begin{itemize}
 \item
-  a temporary materialization conversion~(\ref{conv.rval}),
+  a temporary materialization conversion\iref{conv.rval},
 \item
   \tcode{(} \grammarterm{expression} \tcode{)},
   where \grammarterm{expression} is one of these expressions,
 \item
-  subscripting~(\ref{expr.sub}) of an array operand,
+  subscripting\iref{expr.sub} of an array operand,
   where that operand is one of these expressions,
 \item
-  a class member access~(\ref{expr.ref}) using the \tcode{.} operator
+  a class member access\iref{expr.ref} using the \tcode{.} operator
   where the left operand is one of these expressions and
   the right operand designates a non-static data member of non-reference type,
 \item
-  a pointer-to-member operation~(\ref{expr.mptr.oper}) using the \tcode{.*} operator
+  a pointer-to-member operation\iref{expr.mptr.oper} using the \tcode{.*} operator
   where the left operand is one of these expressions and
   the right operand is a pointer to data member of non-reference type,
 \item
-  a \tcode{const_cast}~(\ref{expr.const.cast}),
-  \tcode{static_cast}~(\ref{expr.static.cast}),
-  \tcode{dynamic_cast}~(\ref{expr.dynamic.cast}), or
-  \tcode{reinterpret_cast}~(\ref{expr.reinterpret.cast})
+  a \tcode{const_cast}\iref{expr.const.cast},
+  \tcode{static_cast}\iref{expr.static.cast},
+  \tcode{dynamic_cast}\iref{expr.dynamic.cast}, or
+  \tcode{reinterpret_cast}\iref{expr.reinterpret.cast}
   converting, without a user-defined conversion,
   a glvalue operand that is one of these expressions
   to a glvalue that refers
   to the object designated by the operand, or
   to its complete object or a subobject thereof,
 \item
-  a conditional expression~(\ref{expr.cond}) that is a glvalue
+  a conditional expression\iref{expr.cond} that is a glvalue
   where the second or third operand is one of these expressions, or
 \item
-  a comma expression~(\ref{expr.comma}) that is a glvalue
+  a comma expression\iref{expr.comma} that is a glvalue
   where the right operand is one of these expressions.
 \end{itemize}
 \begin{example}
@@ -602,12 +602,12 @@ const S& s = S{1};             // both \tcode{S} and \tcode{int} temporaries hav
 
 The exceptions to this lifetime rule are:
 \begin{itemize}
-\item A temporary object bound to a reference parameter in a function call~(\ref{expr.call})
+\item A temporary object bound to a reference parameter in a function call\iref{expr.call}
 persists until the completion of the full-expression containing the call.
 
-\item The lifetime of a temporary bound to the returned value in a function return statement~(\ref{stmt.return}) is not extended; the temporary is destroyed at the end of the full-expression in the return statement.
+\item The lifetime of a temporary bound to the returned value in a function return statement\iref{stmt.return} is not extended; the temporary is destroyed at the end of the full-expression in the return statement.
 
-\item A temporary bound to a reference in a \grammarterm{new-initializer}~(\ref{expr.new}) persists until the completion of the full-expression containing the \grammarterm{new-initializer}. \begin{example}
+\item A temporary bound to a reference in a \grammarterm{new-initializer}\iref{expr.new} persists until the completion of the full-expression containing the \grammarterm{new-initializer}. \begin{example}
 \begin{codeblock}
 struct S { int mi; const std::pair<int,int>& mp; };
 S a { 1, {2,3} };
@@ -735,14 +735,14 @@ Type conversions of class objects can be specified by constructors and
 by conversion functions.
 These conversions are called
 \term{user-defined conversions}
-and are used for implicit type conversions (Clause~\ref{conv}),
-for initialization~(\ref{dcl.init}),
+and are used for implicit type conversions\iref{conv},
+for initialization\iref{dcl.init},
 and for explicit type conversions~(\ref{expr.cast}, \ref{expr.static.cast}).
 
 \pnum
 User-defined conversions are applied only where they are unambiguous~(\ref{class.member.lookup}, \ref{class.conv.fct}).
-Conversions obey the access control rules (Clause~\ref{class.access}).
-Access control is applied after ambiguity resolution~(\ref{basic.lookup}).
+Conversions obey the access control rules\iref{class.access}.
+Access control is applied after ambiguity resolution\iref{basic.lookup}.
 
 \pnum
 \begin{note}
@@ -775,7 +775,7 @@ User-defined conversions are used implicitly only if they are unambiguous.
 \indextext{name hiding!user-defined conversion and}%
 A conversion function in a derived class does not hide a conversion function
 in a base class unless the two functions convert to the same type.
-Function overload resolution~(\ref{over.match.best}) selects the best
+Function overload resolution\iref{over.match.best} selects the best
 conversion function to perform the conversion.
 \begin{example}
 \begin{codeblock}
@@ -830,12 +830,12 @@ void f(X arg) {
 \pnum
 \begin{note}
 An explicit constructor constructs objects just like non-explicit
-constructors, but does so only where the direct-initialization syntax~(\ref{dcl.init})
+constructors, but does so only where the direct-initialization syntax\iref{dcl.init}
 or where casts~(\ref{expr.static.cast}, \ref{expr.cast}) are explicitly
 used; see also~\ref{over.match.copy}.
 A default constructor may be an explicit constructor; such a constructor
 will be used to perform default-initialization
-or value-initialization~(\ref{dcl.init}).
+or value-initialization\iref{dcl.init}.
 \begin{example}
 \begin{codeblock}
 struct Z {
@@ -861,7 +861,7 @@ Z a6 = { 3, 4 };                // error: no implicit conversion
 \pnum
 A
 non-explicit
-copy/move constructor~(\ref{class.copy}) is a converting constructor.
+copy/move constructor\iref{class.copy} is a converting constructor.
 \begin{note}
 An implicitly-declared copy/move constructor is not an explicit constructor;
 it may be called for implicit type conversions.
@@ -899,14 +899,14 @@ A \grammarterm{decl-specifier} in the \grammarterm{decl-specifier-seq}
 of a conversion function (if any) shall be neither
 a \grammarterm{defining-type-specifier} nor \tcode{static}.
 \indextext{conversion!type of}%
-The type of the conversion function~(\ref{dcl.fct}) is
+The type of the conversion function\iref{dcl.fct} is
 ``function taking no parameter returning
 \grammarterm{conversion-type-id}''.
 A conversion function is never used to convert a (possibly cv-qualified) object
 to the (possibly cv-qualified) same object type (or a reference to it),
 to a (possibly cv-qualified) base class of that type (or a reference to it),
 or to (possibly cv-qualified) void.\footnote{These conversions are considered
-as standard conversions for the purposes of overload resolution~(\ref{over.best.ics}, \ref{over.ics.ref}) and therefore initialization~(\ref{dcl.init}) and explicit casts~(\ref{expr.static.cast}). A conversion to \tcode{void} does not invoke any conversion function~(\ref{expr.static.cast}).
+as standard conversions for the purposes of overload resolution~(\ref{over.best.ics}, \ref{over.ics.ref}) and therefore initialization\iref{dcl.init} and explicit casts\iref{expr.static.cast}. A conversion to \tcode{void} does not invoke any conversion function\iref{expr.static.cast}.
 Even though never directly called to perform a conversion,
 such conversion functions can be declared and can potentially
 be reached through a call to a virtual conversion function in a base class.}
@@ -928,7 +928,7 @@ In all three cases the value assigned will be converted by
 \end{example}
 
 \pnum
-A conversion function may be explicit~(\ref{dcl.fct.spec}), in which case it is only considered as a user-defined conversion for direct-initialization~(\ref{dcl.init}). Otherwise, user-defined conversions are not restricted to use in assignments and initializations.
+A conversion function may be explicit\iref{dcl.fct.spec}, in which case it is only considered as a user-defined conversion for direct-initialization\iref{dcl.init}. Otherwise, user-defined conversions are not restricted to use in assignments and initializations.
 \begin{example}
 \begin{codeblock}
 class Y { };
@@ -991,7 +991,7 @@ Conversion functions can be virtual.
 \pnum
 \indextext{conversion!deduced return type of user-defined}%
 A conversion function template shall not have a
-deduced return type~(\ref{dcl.spec.auto}).
+deduced return type\iref{dcl.spec.auto}.
 \begin{example}
 \begin{codeblock}
 struct S {
@@ -1008,7 +1008,7 @@ struct S {
 
 \pnum
 In a declaration of a destructor, the \grammarterm{declarator} is a
-function declarator~(\ref{dcl.fct}) of the form
+function declarator\iref{dcl.fct} of the form
 
 \begin{ncbnf}
 ptr-declarator \terminal{(} parameter-declaration-clause \terminal{)} noexcept-specifier\opt attribute-specifier-seq\opt
@@ -1023,16 +1023,16 @@ one of the following forms:
 \item
 in a \grammarterm{member-declaration} that belongs to the
 \grammarterm{member-specification} of a class but is not a friend
-declaration~(\ref{class.friend}), the \grammarterm{id-expression} is
+declaration\iref{class.friend}, the \grammarterm{id-expression} is
 \tcode{\~}\grammarterm{class-name} and the \grammarterm{class-name} is the
-injected-class-name (Clause~\ref{class}) of the immediately-enclosing class;
+injected-class-name\iref{class} of the immediately-enclosing class;
 
 \item
 in a \grammarterm{member-declaration} that belongs to the
 \grammarterm{member-specification} of a class template but is not a friend
 declaration, the \grammarterm{id-expression} is
 \tcode{\~}\grammarterm{class-name} and the \grammarterm{class-name} names the
-current instantiation~(\ref{temp.dep.type}) of the immediately-enclosing class template; or
+current instantiation\iref{temp.dep.type} of the immediately-enclosing class template; or
 
 \item
 in a declaration at namespace scope or in a friend declaration, the
@@ -1042,7 +1042,7 @@ same class as the \grammarterm{nested-name-specifier}.
 \end{itemize}
 
 The \grammarterm{class-name} shall not be a \grammarterm{typedef-name}. A
-destructor shall take no arguments~(\ref{dcl.fct}).
+destructor shall take no arguments\iref{dcl.fct}.
 Each \grammarterm{decl-specifier} of the \grammarterm{decl-specifier-seq}
 of a destructor declaration (if any) shall be \tcode{friend}, \tcode{inline}, or
 \tcode{virtual}.
@@ -1063,14 +1063,14 @@ object.
 \tcode{const}
 and
 \tcode{volatile}
-semantics~(\ref{dcl.type.cv}) are not applied on an object under destruction.
+semantics\iref{dcl.type.cv} are not applied on an object under destruction.
 They stop being in effect when the destructor for the
-most derived object~(\ref{intro.object}) starts.
+most derived object\iref{intro.object} starts.
 
 \pnum
 \begin{note}
 A declaration of a destructor that does not have a \grammarterm{noexcept-specifier}
-has the same exception specification as if had been implicitly declared~(\ref{except.spec}).
+has the same exception specification as if had been implicitly declared\iref{except.spec}.
 \end{note}
 
 \pnum
@@ -1078,7 +1078,7 @@ has the same exception specification as if had been implicitly declared~(\ref{ex
 \indextext{destructor!default}%
 If a class has no user-declared
 destructor, a destructor is implicitly
-declared as defaulted~(\ref{dcl.fct.def}).
+declared as defaulted\iref{dcl.fct.def}.
 An implicitly-declared destructor is an
 \tcode{inline}
 \tcode{public}
@@ -1122,7 +1122,7 @@ A destructor
 that is defaulted and not defined as deleted
 is
 \term{implicitly defined}
-when it is odr-used~(\ref{basic.def.odr})
+when it is odr-used\iref{basic.def.odr}
 or when it is explicitly defaulted after its first declaration.
 
 \pnum
@@ -1145,7 +1145,7 @@ direct non-variant non-static data members, the destructors for
 \tcode{X}'s
 non-virtual direct base classes and, if
 \tcode{X}
-is the type of the most derived class~(\ref{class.base.init}),
+is the type of the most derived class\iref{class.base.init},
 its destructor calls the destructors for
 \tcode{X}'s
 virtual base classes.
@@ -1156,7 +1156,7 @@ Bases and members are destroyed in the reverse order of the completion of
 their constructor (see~\ref{class.base.init}).
 A
 \tcode{return}
-statement~(\ref{stmt.return}) in a destructor might not directly return to the
+statement\iref{stmt.return} in a destructor might not directly return to the
 caller; before transferring control to the caller, the destructors for the
 members and bases are called.
 \indextext{order of execution!destructor and array}%
@@ -1167,9 +1167,9 @@ construction (see~\ref{class.init}).
 \indextext{destructor!virtual}%
 \indextext{destructor!pure virtual}%
 A destructor can be declared
-\tcode{virtual}~(\ref{class.virtual})
+\tcode{virtual}\iref{class.virtual}
 or pure
-\tcode{virtual}~(\ref{class.abstract});
+\tcode{virtual}\iref{class.abstract};
 if any objects of that class or any derived class are created in the program,
 the destructor shall be defined.
 If a class has a base class with a virtual destructor, its  destructor
@@ -1189,11 +1189,11 @@ A destructor is invoked implicitly
 
 \begin{itemize}
 
-\item for a constructed object with static storage duration~(\ref{basic.stc.static}) at program termination~(\ref{basic.start.term}),
+\item for a constructed object with static storage duration\iref{basic.stc.static} at program termination\iref{basic.start.term},
 
-\item for a constructed object with thread storage duration~(\ref{basic.stc.thread}) at thread exit,
+\item for a constructed object with thread storage duration\iref{basic.stc.thread} at thread exit,
 
-\item for a constructed object with automatic storage duration~(\ref{basic.stc.auto}) when the block in which an object is created exits~(\ref{stmt.dcl}),
+\item for a constructed object with automatic storage duration\iref{basic.stc.auto} when the block in which an object is created exits\iref{stmt.dcl},
 
 \item for a constructed temporary object when its lifetime ends~(\ref{conv.rval}, \ref{class.temporary}).
 \end{itemize}
@@ -1202,8 +1202,8 @@ A destructor is invoked implicitly
 \indextext{destructor!explicit call}%
 In each case, the context of the invocation is the context of the construction of
 the object. A destructor is also invoked implicitly through use of a
-\grammarterm{delete-expression}~(\ref{expr.delete}) for a constructed object allocated
-by a \grammarterm{new-expression}~(\ref{expr.new}); the context of the invocation is the
+\grammarterm{delete-expression}\iref{expr.delete} for a constructed object allocated
+by a \grammarterm{new-expression}\iref{expr.new}; the context of the invocation is the
 \grammarterm{delete-expression}.
 \begin{note} An array of class type contains several subobjects for each of which
 the destructor is invoked. \end{note}
@@ -1215,15 +1215,15 @@ or not accessible from the context of the invocation.
 
 \pnum
 At the point of definition of a virtual destructor (including an implicit
-definition~(\ref{class.copy})), the non-array deallocation function is
+definition\iref{class.copy}), the non-array deallocation function is
 determined as if for the expression \tcode{delete this} appearing in a
 non-virtual destructor of the destructor's class (see~\ref{expr.delete}).
 If the lookup fails or if the deallocation function has
-a deleted definition~(\ref{dcl.fct.def}), the program is ill-formed.
+a deleted definition\iref{dcl.fct.def}, the program is ill-formed.
 \begin{note}
 This assures that a deallocation function corresponding to the dynamic type of an
 object is available for the
-\grammarterm{delete-expression}~(\ref{class.free}).
+\grammarterm{delete-expression}\iref{class.free}.
 \end{note}
 
 \pnum
@@ -1234,7 +1234,7 @@ followed by a
 \grammarterm{type-name} or \grammarterm{decltype-specifier}
 that denotes the destructor's class type.
 The invocation of a destructor is subject to the usual rules for member
-functions~(\ref{class.mfct});
+functions\iref{class.mfct};
 that is, if the object is not of the destructor's class type and
 not of a class derived from the destructor's class type (including when
 the destructor is invoked via a null pointer value), the program has
@@ -1266,11 +1266,11 @@ void f() {
 \end{example}
 \begin{note}
 An explicit destructor call must always be written using
-a member access operator~(\ref{expr.ref}) or a \grammarterm{qualified-id}~(\ref{expr.prim});
+a member access operator\iref{expr.ref} or a \grammarterm{qualified-id}\iref{expr.prim};
 in particular, the
 \grammarterm{unary-expression}
 \tcode{\~{}X()}
-in a member function is not an explicit destructor call~(\ref{expr.unary.op}).
+in a member function is not an explicit destructor call\iref{expr.unary.op}.
 \end{note}
 
 \pnum
@@ -1305,7 +1305,7 @@ void g() {                      // rare, specialized use:
 \pnum
 Once a destructor is invoked for an object, the object no longer exists;
 the behavior is undefined if the destructor is invoked
-for an object whose lifetime has ended~(\ref{basic.life}).
+for an object whose lifetime has ended\iref{basic.life}.
 \begin{example}
 If the destructor for an automatic object is explicitly invoked,
 and the block is subsequently left in a manner that would ordinarily
@@ -1316,7 +1316,7 @@ invoke implicit destruction of the object, the behavior is undefined.
 \begin{note}
 \indextext{fundamental type!destructor and}%
 The notation for explicit call of a destructor can be used for any scalar type
-name~(\ref{expr.pseudo}).
+name\iref{expr.pseudo}.
 Allowing this makes it possible to write code without having to know if a
 destructor exists for a given type.
 For example:
@@ -1359,7 +1359,7 @@ void foo(int i) {
 \pnum
 \indextext{\idxcode{delete}}%
 When an object is deleted with a
-\grammarterm{delete-expression}~(\ref{expr.delete}),
+\grammarterm{delete-expression}\iref{expr.delete},
 a deallocation function
 \indextext{function!deallocation}%
 (\tcode{operator delete()}
@@ -1368,16 +1368,16 @@ for non-array objects or
 \tcode{operator delete[]()}
 \indextext{\idxcode{operator delete}}%
 for arrays) is (implicitly) called to reclaim the storage occupied by
-the object~(\ref{basic.stc.dynamic.deallocation}).
+the object\iref{basic.stc.dynamic.deallocation}.
 
 \pnum
 Class-specific deallocation function lookup is a part of general deallocation
-function lookup~(\ref{expr.delete}) and occurs as follows.
+function lookup\iref{expr.delete} and occurs as follows.
 If the \grammarterm{delete-expression}
 is used to deallocate a class object whose static type has a virtual
 destructor, the deallocation function is the one selected at the point
 of definition of the dynamic type's virtual
-destructor~(\ref{class.dtor}).\footnote{A similar provision is not needed for
+destructor\iref{class.dtor}.\footnote{A similar provision is not needed for
 the array version of \tcode{operator} \tcode{delete} because~\ref{expr.delete}
 requires that in this situation, the static type of the object to be deleted be
 the same as its dynamic type.
@@ -1390,7 +1390,7 @@ or array thereof, the static and dynamic types of the object shall be
 identical and the deallocation function's name is looked up in the scope of
 \tcode{T}.
 If this lookup fails to find the name, general deallocation function
-lookup~(\ref{expr.delete}) continues.
+lookup\iref{expr.delete} continues.
 If the result of the lookup is ambiguous or inaccessible, or if the lookup
 selects a placement deallocation function, the program is ill-formed.
 
@@ -1496,7 +1496,7 @@ the delete expression would have been ill-formed.
 \pnum
 \begin{note}
 If a deallocation function has no explicit \grammarterm{noexcept-specifier}, it
-has a non-throwing exception specification~(\ref{except.spec}).
+has a non-throwing exception specification\iref{except.spec}.
 \end{note}
 
 \rSec1[class.init]{Initialization}%
@@ -1569,7 +1569,7 @@ complex g = { 1, 2 };           // initialize by a call of \tcode{complex(double
 \end{example}
 \begin{note}
 \indextext{initialization!overloaded assignment and}%
-Overloading of the assignment operator~(\ref{over.ass})
+Overloading of the assignment operator\iref{over.ass}
 has no effect on initialization.
 \end{note}
 
@@ -1799,7 +1799,7 @@ D d(10);
 \begin{note}
 The initialization
 performed by each \grammarterm{mem-initializer}
-constitutes a full-expression~(\ref{intro.execution}).
+constitutes a full-expression\iref{intro.execution}.
 Any expression in
 a
 \grammarterm{mem-initializer}
@@ -1833,10 +1833,10 @@ then
 
 \begin{itemize}
 \item if the entity is a non-static data member that has
-a default member initializer~(\ref{class.mem}) and either
+a default member initializer\iref{class.mem} and either
 
 \begin{itemize}
-\item the constructor's class is a union~(\ref{class.union}), and no other variant
+\item the constructor's class is a union\iref{class.union}, and no other variant
 member of that union is designated by a \grammarterm{mem-initializer-id} or
 
 \item the constructor's class is not a union, and, if the entity is a member of an
@@ -1847,12 +1847,12 @@ anonymous union, no other member of that union is designated by a
 the entity is initialized from its default member initializer
 as specified in~\ref{dcl.init};
 
-\item otherwise, if the entity is an anonymous union or a variant member~(\ref{class.union.anon}), no initialization is performed;
+\item otherwise, if the entity is an anonymous union or a variant member\iref{class.union.anon}, no initialization is performed;
 
-\item otherwise, the entity is default-initialized~(\ref{dcl.init}).
+\item otherwise, the entity is default-initialized\iref{dcl.init}.
 \end{itemize}
 
-\begin{note} An abstract class~(\ref{class.abstract}) is never a most derived
+\begin{note} An abstract class\iref{class.abstract} is never a most derived
 class, thus its constructors never initialize virtual base classes, therefore the
 corresponding \grammarterm{mem-initializer}{s} may be omitted. \end{note}
 An attempt to initialize more than one non-static data member of a union renders the
@@ -1933,9 +1933,9 @@ A a2(1);                // OK, unfortunately
 
 \pnum
 In a non-delegating constructor, the destructor for each potentially constructed
-subobject of class type is potentially invoked~(\ref{class.dtor}).
+subobject of class type is potentially invoked\iref{class.dtor}.
 \begin{note} This provision ensures that destructors can be called for fully-constructed
-subobjects in case an exception is thrown~(\ref{except.ctor}). \end{note}
+subobjects in case an exception is thrown\iref{except.ctor}. \end{note}
 
 \pnum
 In a non-delegating constructor, initialization
@@ -1943,7 +1943,7 @@ proceeds in the following order:
 \begin{itemize}
 \item
 \indextext{initialization!order of virtual base class}%
-First, and only for the constructor of the most derived class~(\ref{intro.object}),
+First, and only for the constructor of the most derived class\iref{intro.object},
 virtual base classes are initialized in the order they appear on a
 depth-first left-to-right traversal of the directed acyclic graph of
 base classes,
@@ -2069,8 +2069,8 @@ Member functions (including virtual member functions, \ref{class.virtual}) can b
 called for an object under construction.
 Similarly, an object under construction can be the operand of the
 \tcode{typeid}
-operator~(\ref{expr.typeid}) or of a
-\tcode{dynamic_cast}~(\ref{expr.dynamic.cast}).
+operator\iref{expr.typeid} or of a
+\tcode{dynamic_cast}\iref{expr.dynamic.cast}.
 However, if these operations are performed in a
 \grammarterm{ctor-initializer}
 (or in a function called directly or indirectly from a
@@ -2122,7 +2122,7 @@ of an object under construction.
 \pnum
 \indextext{initializer!pack expansion}%
 A \grammarterm{mem-initializer} followed by an ellipsis is
-a pack expansion~(\ref{temp.variadic}) that initializes the base
+a pack expansion\iref{temp.variadic} that initializes the base
 classes specified by a pack expansion in the \grammarterm{base-specifier-list}
 for the class. \begin{example}
 
@@ -2142,7 +2142,7 @@ public:
 \pnum
 When a constructor for type \tcode{B} is invoked
 to initialize an object of a different type \tcode{D}
-(that is, when the constructor was inherited~(\ref{namespace.udecl})),
+(that is, when the constructor was inherited\iref{namespace.udecl}),
 initialization proceeds as if a defaulted default constructor
 were used to initialize the \tcode{D} object and
 each base class subobject from which the constructor was inherited,
@@ -2336,8 +2336,8 @@ struct E : C, D, X {
 \indextext{virtual function call!destructor and}%
 \indextext{construction!virtual function call}%
 \indextext{destruction!virtual function call}%
-Member functions, including virtual functions~(\ref{class.virtual}), can be called
-during construction or destruction~(\ref{class.base.init}).
+Member functions, including virtual functions\iref{class.virtual}, can be called
+during construction or destruction\iref{class.base.init}.
 When a virtual function is called directly or indirectly from a constructor
 or from a destructor,
 including during the construction or destruction of the class's non-static data
@@ -2347,7 +2347,7 @@ destruction,
 the function called is the
 final overrider in the constructor's or destructor's class and not one
 overriding it in a more-derived class.
-If the virtual function call uses an explicit class member access~(\ref{expr.ref})
+If the virtual function call uses an explicit class member access\iref{expr.ref}
 and the object expression refers to
 the complete object of \tcode{x} or one of that object's base class subobjects
 but not \tcode{x} or one of its base class subobjects, the behavior
@@ -2391,11 +2391,11 @@ B::B(V* v, A* a) {
 \indextext{\idxcode{typeid}!destruction and}%
 The
 \tcode{typeid}
-operator~(\ref{expr.typeid}) can be used during construction or destruction~(\ref{class.base.init}).
+operator\iref{expr.typeid} can be used during construction or destruction\iref{class.base.init}.
 When
 \tcode{typeid}
 is used in a constructor (including the
-\grammarterm{mem-initializer} or default member initializer~(\ref{class.mem})
+\grammarterm{mem-initializer} or default member initializer\iref{class.mem}
 for a non-static data member)
 or in a destructor, or used in a function called (directly or indirectly) from
 a constructor or destructor, if the operand of
@@ -2416,8 +2416,8 @@ bases, the behavior is undefined.
 \indextext{destruction!dynamic cast and}%
 \indextext{cast!dynamic!construction and}%
 \indextext{cast!dynamic!destruction and}%
-\tcode{dynamic_cast}s~(\ref{expr.dynamic.cast}) can be used during construction
-or destruction~(\ref{class.base.init}). When a
+\tcode{dynamic_cast}s\iref{expr.dynamic.cast} can be used during construction
+or destruction\iref{class.base.init}. When a
 \tcode{dynamic_cast}
 is used in a constructor (including the
 \grammarterm{mem-initializer} or default member initializer
@@ -2467,11 +2467,11 @@ B::B(V* v, A* a) {
 
 \pnum
 A class object can be copied or moved in two ways:
-by initialization~(\ref{class.ctor}, \ref{dcl.init}), including for function argument passing~(\ref{expr.call}) and for function value return~(\ref{stmt.return});
-and by assignment~(\ref{expr.ass}).
+by initialization~(\ref{class.ctor}, \ref{dcl.init}), including for function argument passing\iref{expr.call} and for function value return\iref{stmt.return};
+and by assignment\iref{expr.ass}.
 Conceptually, these two operations are implemented by a
-copy/move constructor~(\ref{class.ctor})
-and copy/move assignment operator~(\ref{over.ass}).
+copy/move constructor\iref{class.ctor}
+and copy/move assignment operator\iref{over.ass}.
 
 \pnum
 \indextext{constructor!copy!inaccessible}%
@@ -2480,7 +2480,7 @@ and copy/move assignment operator~(\ref{over.ass}).
 \indextext{assignment operator!move!inaccessible}%
 A program is ill-formed if the copy/move constructor or the copy/move assignment
 operator for an object is implicitly odr-used and the special member function
-is not accessible (Clause~\ref{class.access}).
+is not accessible\iref{class.access}.
 \begin{note}
 Copying/moving one object into another using the copy/move constructor or
 the copy/move assignment operator does not change the layout or size of either
@@ -2506,7 +2506,7 @@ constructor if its first parameter is of type
 or
 \tcode{const volatile X\&},
 and either there are no other parameters
-or else all other parameters have default arguments~(\ref{dcl.fct.default}).
+or else all other parameters have default arguments\iref{dcl.fct.default}.
 \begin{example}
 \tcode{X::X(const X\&)}
 and
@@ -2529,7 +2529,7 @@ A non-template constructor for class \tcode{X} is a move constructor if its
 first parameter is of type \tcode{X\&\&}, \tcode{const X\&\&},
 \tcode{volatile X\&\&}, or \tcode{const volatile X\&\&}, and either there are
 no other parameters or else all other parameters have default
-arguments~(\ref{dcl.fct.default}).
+arguments\iref{dcl.fct.default}.
 \begin{example} \tcode{Y::Y(Y\&\&)} is a move constructor.
 \begin{codeblock}
 struct Y {
@@ -2619,7 +2619,7 @@ a non-explicit one is declared \term{implicitly}.
 If the class definition declares a move
 constructor or move assignment operator, the implicitly declared copy
 constructor is defined as deleted; otherwise, it is defined as
-defaulted~(\ref{dcl.fct.def}).
+defaulted\iref{dcl.fct.def}.
 The latter case is deprecated if the class has a user-declared copy assignment
 operator or a user-declared destructor.
 
@@ -2688,14 +2688,14 @@ An implicitly-declared copy/move constructor is an
 \tcode{public}
 member of its class.
 A defaulted copy/\brk{}move constructor for a class
-  \tcode{X} is defined as deleted~(\ref{dcl.fct.def.delete}) if \tcode{X} has:
+  \tcode{X} is defined as deleted\iref{dcl.fct.def.delete} if \tcode{X} has:
 \begin{itemize}
 \item a variant member with a non-trivial corresponding constructor and
   \tcode{X} is a union-like class,
 
 \item a potentially constructed subobject type
   \tcode{M} (or array thereof) that cannot be copied/moved because
-  overload resolution~(\ref{over.match}), as applied to find
+  overload resolution\iref{over.match}, as applied to find
   \tcode{M}'s
   corresponding constructor, results in an ambiguity or
   a function that is deleted or inaccessible from the
@@ -2728,8 +2728,8 @@ if it is not user-provided and if:
 \item
 class
 \tcode{X}
-has no virtual functions~(\ref{class.virtual})
-and no virtual base classes~(\ref{class.mi}), and
+has no virtual functions\iref{class.virtual}
+and no virtual base classes\iref{class.mi}, and
 
 \item
 the constructor selected to copy/move each direct base class subobject is trivial, and
@@ -2752,14 +2752,14 @@ A copy/move constructor
 that is defaulted and not defined as deleted
 is
 \term{implicitly defined}
-if it is odr-used~(\ref{basic.def.odr})
+if it is odr-used\iref{basic.def.odr}
 or when it is explicitly defaulted after its first declaration.
 \begin{note}
 The copy/move constructor is implicitly defined even if the implementation elided
 its odr-use~(\ref{basic.def.odr}, \ref{class.temporary}).
 \end{note}
 If the implicitly-defined constructor would satisfy the requirements of a
-constexpr constructor~(\ref{dcl.constexpr}), the implicitly-defined
+constexpr constructor\iref{dcl.constexpr}, the implicitly-defined
 constructor is \tcode{constexpr}.
 
 \pnum
@@ -2770,7 +2770,7 @@ potentially constructed subobjects
 shall have been implicitly defined.
 \begin{note}
 An implicitly-declared copy/move constructor has an
-implied exception specification~(\ref{except.spec}).
+implied exception specification\iref{except.spec}.
 \end{note}
 
 \pnum
@@ -2804,7 +2804,7 @@ the implicitly-defined copy/move constructor (see~\ref{class.base.init}).
 
 \pnum
 The implicitly-defined copy/move constructor for a union
-\tcode{X} copies the object representation~(\ref{basic.types}) of \tcode{X}.%
+\tcode{X} copies the object representation\iref{basic.types} of \tcode{X}.%
 \indextext{constructor!move|)}%
 \indextext{constructor!copy|)}
 
@@ -2867,7 +2867,7 @@ If the class definition does not explicitly declare a copy assignment operator,
 one is declared \term{implicitly}. If the class definition declares a move
 constructor or move assignment operator, the implicitly declared copy
 assignment operator is defined as deleted; otherwise, it is defined as
-defaulted~(\ref{dcl.fct.def}).
+defaulted\iref{dcl.fct.def}.
 The latter case is deprecated if the class has a user-declared copy constructor
 or a user-declared destructor.
 The implicitly-declared copy assignment operator for a class
@@ -3005,7 +3005,7 @@ class \tcode{X} is defined as deleted if \tcode{X} has:
 \item a direct non-static data member of class type \tcode{M}
   (or array thereof) or a direct base class \tcode{M}
   that cannot be copied/moved because overload resolution
- ~(\ref{over.match}), as applied to find \tcode{M}'s corresponding
+ \iref{over.match}, as applied to find \tcode{M}'s corresponding
   assignment operator, results in an ambiguity or
   a function that is deleted or inaccessible from the
   defaulted assignment operator.
@@ -3020,9 +3020,9 @@ overload resolution~(\ref{over.match}, \ref{over.over}).
 Because a copy/move assignment operator is implicitly declared for a class
 if not declared by the user,
 a base class copy/move assignment operator is always hidden
-by the corresponding assignment operator of a derived class~(\ref{over.ass}).
+by the corresponding assignment operator of a derived class\iref{over.ass}.
 A
-\grammarterm{using-declaration}~(\ref{namespace.udecl}) that brings in from a base class an assignment operator
+\grammarterm{using-declaration}\iref{namespace.udecl} that brings in from a base class an assignment operator
 with a parameter type that could be that of a
 copy/move assignment operator for the
 derived class is not considered an explicit declaration of such an
@@ -3046,8 +3046,8 @@ if it is not user-provided and if:
 \item
 class
 \tcode{X}
-has no virtual functions~(\ref{class.virtual})
-and no virtual base classes~(\ref{class.mi}), and
+has no virtual functions\iref{class.virtual}
+and no virtual base classes\iref{class.mi}, and
 
 \item the assignment operator selected to copy/move each direct
 base class subobject is trivial, and
@@ -3071,7 +3071,7 @@ that is defaulted and not defined as deleted
 is
 \term{implicitly defined}
 when
-it is odr-used~(\ref{basic.def.odr}) (e.g., when it is selected by overload resolution
+it is odr-used\iref{basic.def.odr} (e.g., when it is selected by overload resolution
 to assign to an object of its class type)
 or when it is explicitly defaulted after its first declaration.
 The implicitly-defined copy/move assignment operator is \tcode{constexpr} if
@@ -3097,7 +3097,7 @@ its direct base classes and
 its non-static data members shall have been implicitly defined.
 \begin{note}
 An implicitly-declared copy/move assignment operator has an
-implied exception specification~(\ref{except.spec}).
+implied exception specification\iref{except.spec}.
 \end{note}
 
 \pnum
@@ -3147,7 +3147,7 @@ is assigned twice by the implicitly-defined copy/move assignment operator for
 
 \pnum
 The implicitly-defined copy assignment operator for a
-union \tcode{X} copies the object representation~(\ref{basic.types}) of \tcode{X}.%
+union \tcode{X} copies the object representation\iref{basic.types} of \tcode{X}.%
 \indextext{assignment operator!move|)}%
 \indextext{assignment operator!copy|)}
 
@@ -3188,24 +3188,24 @@ eliminate multiple copies):
 when the \grammarterm{expression} is the name of a non-volatile
 automatic object (other than a function parameter or a variable
 introduced by the \grammarterm{exception-declaration} of a
-\grammarterm{handler}~(\ref{except.handle}))
+\grammarterm{handler}\iref{except.handle})
 with the same type (ignoring cv-qualification) as
 the function return type, the copy/move operation can be
 omitted by constructing the automatic object directly
 into the function call's return object
 
-\item in a \grammarterm{throw-expression}~(\ref{expr.throw}), when the operand
+\item in a \grammarterm{throw-expression}\iref{expr.throw}, when the operand
 is the name of a non-volatile automatic object
 (other than a function or catch-clause parameter)
 whose scope does not extend beyond the end of the innermost enclosing
 \grammarterm{try-block} (if there is one), the copy/move operation from the
-operand to the exception object~(\ref{except.throw}) can be omitted by
+operand to the exception object\iref{except.throw} can be omitted by
 constructing the automatic object directly into the exception object
 
 \item when the \grammarterm{exception-declaration} of an
-exception handler (Clause~\ref{except}) declares an object of the same
+exception handler\iref{except} declares an object of the same
 type (except for cv-qualification) as the exception
-object~(\ref{except.throw}), the copy operation can be omitted by treating
+object\iref{except.throw}, the copy operation can be omitted by treating
 the \grammarterm{exception-declaration} as an alias for the exception
 object if the meaning of the program will be unchanged except for the execution
 of constructors and destructors for the object declared by the
@@ -3215,8 +3215,8 @@ always an lvalue.  \end{note}
 \end{itemize}
 Copy elision is required
 where an expression is evaluated in a context
-requiring a constant expression~(\ref{expr.const})
-and in constant initialization~(\ref{basic.start.static}).
+requiring a constant expression\iref{expr.const}
+and in constant initialization\iref{basic.start.static}.
 \begin{note}
 Copy elision might not be performed
 if the same expression
@@ -3279,13 +3279,13 @@ move construction from the local automatic object to \tcode{t2} that is elided.
 \pnum
 In the following copy-initialization contexts, a move operation might be used instead of a copy operation:
 \begin{itemize}
-\item If the \grammarterm{expression} in a \tcode{return} statement~(\ref{stmt.return})
+\item If the \grammarterm{expression} in a \tcode{return} statement\iref{stmt.return}
 is a (possibly parenthesized) \grammarterm{id-expression}
 that names an object with automatic storage duration declared in the body
 or \grammarterm{parameter-declaration-clause} of the innermost enclosing
 function or \grammarterm{lambda-expression}, or
 
-\item if the operand of a \grammarterm{throw-expression}~(\ref{expr.throw})
+\item if the operand of a \grammarterm{throw-expression}\iref{expr.throw}
 is the name of a non-volatile automatic object
 (other than a function or catch-clause parameter)
 whose scope does not extend beyond the end of the innermost enclosing

--- a/source/special.tex
+++ b/source/special.tex
@@ -201,8 +201,8 @@ of const-qualified type (or array thereof),
 \item any potentially constructed subobject, except for a non-static data member
 with a \grammarterm{brace-or-equal-initializer}, has
 class type \tcode{M} (or array thereof) and either \tcode{M}
-has no default constructor or overload resolution
-(\ref{over.match}) as applied to find \tcode{M}'s corresponding
+has no default constructor or overload resolution\iref{over.match}
+as applied to find \tcode{M}'s corresponding
 constructor results in an ambiguity or in a function that is deleted or
 inaccessible from the defaulted default constructor, or
 

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -35,7 +35,7 @@ The optional \grammarterm{attribute-specifier-seq} appertains to the respective 
 \indextext{\idxgram{condition}{s}!rules for}%
 The rules for \grammarterm{condition}{s} apply both to
 \grammarterm{selection-statement}{s} and to the \tcode{for} and \tcode{while}
-statements~(\ref{stmt.iter}). The \grammarterm{declarator} shall not
+statements\iref{stmt.iter}. The \grammarterm{declarator} shall not
 specify a function or an array. The \grammarterm{decl-specifier-seq} shall not
 define a class or enumeration. If the \tcode{auto} \grammarterm{type-specifier} appears in
 the \grammarterm{decl-specifier-seq},
@@ -67,7 +67,7 @@ else {
 The value of a \grammarterm{condition} that is an initialized declaration
 in a statement other than a \tcode{switch} statement is the value of the
 declared variable
-contextually converted to \tcode{bool} (Clause~\ref{conv}).
+contextually converted to \tcode{bool}\iref{conv}.
 If that
 conversion is ill-formed, the program is ill-formed. The value of a
 \grammarterm{condition} that is an initialized declaration in a
@@ -122,7 +122,7 @@ identifiers.
 \begin{note}
 A label may have the same name as another declaration in the same scope or a
 \grammarterm{template-parameter} from an enclosing scope. Unqualified name
-lookup~(\ref{basic.lookup.unqual}) ignores labels.
+lookup\iref{basic.lookup.unqual} ignores labels.
 \end{note}
 
 \pnum
@@ -143,7 +143,7 @@ Expression statements have the form
 \end{bnf}
 
 The expression is
-a discarded-value expression (Clause~\ref{expr}).
+a discarded-value expression\iref{expr}.
 All
 \indextext{side effects}%
 side effects from an expression statement
@@ -157,7 +157,7 @@ Most statements are expression statements --- usually assignments or
 function calls. A null statement is useful to carry a label just before
 the \tcode{\}} of a compound statement and to supply a null body to an
 iteration statement such as a \tcode{while}
-statement~(\ref{stmt.while}).
+statement\iref{stmt.while}.
 \end{note}
 
 \rSec1[stmt.block]{Compound statement or block}%
@@ -180,9 +180,9 @@ provided.
     statement-seq statement
 \end{bnf}
 
-A compound statement defines a block scope~(\ref{basic.scope}).
+A compound statement defines a block scope\iref{basic.scope}.
 \begin{note}
-A declaration is a \grammarterm{statement}~(\ref{stmt.dcl}).
+A declaration is a \grammarterm{statement}\iref{stmt.dcl}.
 \end{note}
 
 \rSec1[stmt.select]{Selection statements}%
@@ -205,13 +205,13 @@ See~\ref{dcl.meaning} for the optional \grammarterm{attribute-specifier-seq} in 
 \begin{note}
 An \grammarterm{init-statement} ends with a semicolon.
 \end{note}
-In Clause~\ref{stmt.stmt}, the term \term{substatement} refers to
+In \ref{stmt.stmt}, the term \term{substatement} refers to
 the contained \grammarterm{statement} or \grammarterm{statement}{s} that appear
 in the syntax notation.
 \indextext{scope!\idxgram{selection-statement}}%
 The substatement in a \grammarterm{selection-statement} (each substatement,
 in the \tcode{else} form of the \tcode{if} statement) implicitly defines
-a block scope~(\ref{basic.scope}). If the substatement in a
+a block scope\iref{basic.scope}. If the substatement in a
 selection-statement is a single statement and not a
 \grammarterm{compound-statement}, it is as if it was rewritten to be a
 compound-statement containing the original substatement.
@@ -237,7 +237,7 @@ Thus after the \tcode{if} statement, \tcode{i} is no longer in scope.
 \indextext{statement!\idxcode{if}}
 
 \pnum
-If the condition~(\ref{stmt.select}) yields \tcode{true} the first
+If the condition\iref{stmt.select} yields \tcode{true} the first
 substatement is executed. If the \tcode{else} part of the selection
 statement is present and the condition yields \tcode{false}, the second
 substatement is executed. If the first substatement is reached via a
@@ -251,23 +251,23 @@ an \tcode{else} part.\footnote{In other words, the \tcode{else} is associated wi
 \pnum
 If the \tcode{if} statement is of the form \tcode{if constexpr}, the value
 of the condition shall be a contextually
-converted constant expression of type \tcode{bool}~(\ref{expr.const}); this
+converted constant expression of type \tcode{bool}\iref{expr.const}; this
 form is called a \defn{constexpr if} statement. If the value of the
 converted condition is \tcode{false}, the first substatement is a
 \defn{discarded statement}, otherwise the second substatement, if
 present, is a discarded statement. During the instantiation of an
-enclosing templated entity (Clause~\ref{temp}), if the condition is
+enclosing templated entity\iref{temp}, if the condition is
 not value-dependent after its instantiation, the discarded substatement
 (if any) is not instantiated.
 \begin{note}
-Odr-uses~(\ref{basic.def.odr}) in a discarded statement do not require
+Odr-uses\iref{basic.def.odr} in a discarded statement do not require
 an entity to be defined.
 \end{note}
 A \tcode{case} or \tcode{default} label appearing within such an
 \tcode{if} statement shall be associated with a \tcode{switch}
-statement~(\ref{stmt.switch}) within the same \tcode{if} statement.
-A label~(\ref{stmt.label}) declared in a substatement of a constexpr if
-statement shall only be referred to by a statement~(\ref{stmt.goto}) in
+statement\iref{stmt.switch} within the same \tcode{if} statement.
+A label\iref{stmt.label} declared in a substatement of a constexpr if
+statement shall only be referred to by a statement\iref{stmt.goto} in
 the same substatement.
 \begin{example}
 \begin{codeblock}
@@ -336,10 +336,10 @@ several statements depending on the value of a condition.
 \pnum
 The condition shall be of integral type, enumeration type, or class
 type. If of class type, the
-condition is contextually implicitly converted (Clause~\ref{conv}) to
+condition is contextually implicitly converted\iref{conv} to
 an integral or enumeration type.
 If the (possibly converted) type is subject to integral
-promotions~(\ref{conv.prom}), the condition is converted
+promotions\iref{conv.prom}, the condition is converted
 to the promoted type.
 Any
 statement within the \tcode{switch} statement can be labeled with one or
@@ -351,7 +351,7 @@ more case labels as follows:
 \end{ncbnf}
 
 where the \grammarterm{constant-expression} shall be
-a converted constant expression~(\ref{expr.const}) of the
+a converted constant expression\iref{expr.const} of the
 adjusted type of the switch condition. No two of the case constants in
 the same switch shall have the same value after conversion.
 
@@ -453,7 +453,7 @@ An \grammarterm{init-statement} ends with a semicolon.
 
 \pnum
 The substatement in an \grammarterm{iteration-statement} implicitly defines
-a block scope~(\ref{basic.scope}) which is entered and exited each time
+a block scope\iref{basic.scope} which is entered and exited each time
 through the loop.
 
 \indextext{scope!\idxgram{iteration-statement}}%
@@ -498,7 +498,7 @@ void f() {
 
 \pnum
 In the \tcode{while} statement the substatement is executed repeatedly
-until the value of the condition~(\ref{stmt.select}) becomes
+until the value of the condition\iref{stmt.select} becomes
 \tcode{false}. The test takes place before each execution of the
 substatement.
 
@@ -506,7 +506,7 @@ substatement.
 \indextext{statement!declaration in \tcode{while}}%
 When the condition of a \tcode{while} statement is a declaration, the scope of
 the variable that is declared extends from its point of
-declaration~(\ref{basic.scope.pdecl}) to the end of the \tcode{while}
+declaration\iref{basic.scope.pdecl} to the end of the \tcode{while}
 \grammarterm{statement}. A \tcode{while} statement of the form
 
 \begin{codeblock}
@@ -553,7 +553,7 @@ fails.
 \indextext{statement!\idxcode{do}}
 
 \pnum
-The expression is contextually converted to \tcode{bool} (Clause~\ref{conv});
+The expression is contextually converted to \tcode{bool}\iref{conv};
 if that conversion is ill-formed, the program is ill-formed.
 
 \pnum
@@ -592,7 +592,7 @@ iteration statement) will execute \grammarterm{expression} before
 re-evaluating \grammarterm{condition}.
 \begin{note}
 Thus the first statement specifies initialization for the loop; the
-condition~(\ref{stmt.select}) specifies a test, sequenced before each
+condition\iref{stmt.select} specifies a test, sequenced before each
 iteration, such that the loop is exited when the condition becomes
 \tcode{false}; the expression often specifies incrementing that is
 sequenced after each iteration.
@@ -671,15 +671,15 @@ incomplete type, the program is ill-formed;
 \item if the \grammarterm{for-range-initializer} is an expression of
 class type \tcode{C}, the \grammarterm{unqualified-id}{s}
 \tcode{begin} and \tcode{end} are looked up in the scope of \tcode{C}
-as if by class member access lookup~(\ref{basic.lookup.classref}), and if either
+as if by class member access lookup\iref{basic.lookup.classref}, and if either
 (or both) finds at least one declaration, \placeholder{begin-expr} and
 \placeholder{end-expr} are \tcode{__range.begin()} and \tcode{__range.end()},
 respectively;
 
 \item otherwise, \placeholder{begin-expr} and \placeholder{end-expr} are \tcode{begin(__range)}
 and \tcode{end(__range)}, respectively, where \tcode{begin} and \tcode{end} are looked
-up in the associated namespaces~(\ref{basic.lookup.argdep}).
-\begin{note} Ordinary unqualified lookup~(\ref{basic.lookup.unqual}) is not
+up in the associated namespaces\iref{basic.lookup.argdep}.
+\begin{note} Ordinary unqualified lookup\iref{basic.lookup.unqual} is not
 performed. \end{note}
 \end{itemize}
 \end{itemize}
@@ -724,7 +724,7 @@ Jump statements unconditionally transfer control.
 \indextext{local variable!destruction of}%
 \indextext{scope!destructor and exit from}%
 On exit from a scope (however accomplished), objects with automatic storage
-duration~(\ref{basic.stc.auto}) that have been constructed in that scope are destroyed
+duration\iref{basic.stc.auto} that have been constructed in that scope are destroyed
 in the reverse order of their construction. \begin{note} For temporaries,
 see~\ref{class.temporary}. \end{note} Transfer out of a loop, out of a block, or back
 past
@@ -739,7 +739,7 @@ However, the program can be terminated (by calling
 \tcode{std::exit()} or
 \indextext{\idxcode{abort}}%
 \indexlibrary{\idxcode{abort}}%
-\tcode{std::abort()}~(\ref{support.start.term}), for example) without
+\tcode{std::abort()}\iref{support.start.term}, for example) without
 destroying class objects with automatic storage duration.
 \end{note}
 
@@ -813,8 +813,8 @@ A function returns to its caller by the \tcode{return} statement.
 The \grammarterm{expr-or-braced-init-list}
 of a return statement is called its operand. A return statement with
 no operand shall be used only in a function whose return type is
-\cv{}~\tcode{void}, a constructor~(\ref{class.ctor}), or a
-destructor~(\ref{class.dtor}).
+\cv{}~\tcode{void}, a constructor\iref{class.ctor}, or a
+destructor\iref{class.dtor}.
 \indextext{\idxcode{return}!constructor and}%
 \indextext{\idxcode{return}!constructor and}%
 A return statement with an operand of type \tcode{void} shall be used only
@@ -824,13 +824,13 @@ in a function whose return type is not \cv{}~\tcode{void};
 \indextext{conversion!return type}%
 the return statement initializes the
 glvalue result or prvalue result object of the (explicit or implicit) function call
-by copy-initialization~(\ref{dcl.init}) from the operand.
+by copy-initialization\iref{dcl.init} from the operand.
 \begin{note}
 A return statement can involve
 an invocation of a constructor to perform a copy or move of the operand
 if it is not a prvalue or if its type differs from the return type of the function.
 A copy operation associated with a return statement may be elided or
-converted to a move operation if an automatic storage duration variable is returned~(\ref{class.copy}).
+converted to a move operation if an automatic storage duration variable is returned\iref{class.copy}.
 \end{note}
 \begin{example}
 \begin{codeblock}
@@ -845,14 +845,14 @@ a destructor, or
 a function with a \cv{}~\tcode{void} return type is
 equivalent to a \tcode{return} with no operand.
 Otherwise, flowing off the end of a function
-other than \tcode{main}~(\ref{basic.start.main})
+other than \tcode{main}\iref{basic.start.main}
 results in undefined behavior.
 
 \pnum
 The copy-initialization of the result of the call is sequenced before the
 destruction of temporaries at the end of the full-expression established
 by the operand of the return statement, which, in turn, is sequenced
-before the destruction of local variables~(\ref{stmt.jump}) of the block
+before the destruction of local variables\iref{stmt.jump} of the block
 enclosing the return statement.
 
 \rSec2[stmt.goto]{The \tcode{goto} statement}%
@@ -862,7 +862,7 @@ enclosing the return statement.
 The \tcode{goto} statement unconditionally transfers control to the
 statement labeled by the identifier. The identifier shall be a
 \indextext{label}%
-label~(\ref{stmt.label}) located in the current function.
+label\iref{stmt.label} located in the current function.
 
 \rSec1[stmt.dcl]{Declaration statement}%
 \indextext{statement!declaration}
@@ -887,11 +887,11 @@ which it resumes its force.
 \pnum
 \indextext{block!initialization in}%
 \indextext{initialization!automatic}%
-Variables with automatic storage duration~(\ref{basic.stc.auto}) are
+Variables with automatic storage duration\iref{basic.stc.auto} are
 initialized each time their \grammarterm{declaration-statement} is executed.
 \indextext{local variable!destruction of}%
 Variables with automatic storage duration declared in the block are
-destroyed on exit from the block~(\ref{stmt.jump}).
+destroyed on exit from the block\iref{stmt.jump}.
 
 \pnum
 \indextext{initialization!jump past}%
@@ -902,7 +902,7 @@ declarations with initialization. A program that jumps\footnote{The transfer fro
 from a point where a variable with automatic storage duration is
 not in scope to a point where it is in scope is ill-formed unless the
 variable has scalar type, class type with a trivial default constructor and a trivial destructor, a cv-qualified version of one of these types, or an array of one of the preceding types and is declared without an
-\grammarterm{initializer}~(\ref{dcl.init}).
+\grammarterm{initializer}\iref{dcl.init}.
 \begin{example}
 
 \begin{codeblock}
@@ -926,8 +926,8 @@ lx:
 \indextext{initialization!local \tcode{static}}%
 \indextext{initialization!local \tcode{thread_local}}%
 Dynamic initialization of a block-scope variable with
-static storage duration~(\ref{basic.stc.static}) or
-thread storage duration~(\ref{basic.stc.thread}) is performed
+static storage duration\iref{basic.stc.static} or
+thread storage duration\iref{basic.stc.thread} is performed
 the first time control passes through its declaration; such a variable is
 considered initialized upon the completion of its initialization. If the
 initialization exits by throwing an exception, the initialization is not
@@ -967,7 +967,7 @@ static and thread storage duration are destroyed.
 There is an ambiguity in the grammar involving
 \grammarterm{expression-statement}{s} and \grammarterm{declaration}{s}: An
 \grammarterm{expression-statement} with a function-style explicit type
-conversion~(\ref{expr.type.conv}) as its leftmost subexpression can be
+conversion\iref{expr.type.conv} as its leftmost subexpression can be
 indistinguishable from a \grammarterm{declaration} where the first
 \grammarterm{declarator} starts with a \tcode{(}. In those cases the
 \grammarterm{statement} is a \grammarterm{declaration}.
@@ -982,7 +982,7 @@ to determine whether this is the case. This resolves the meaning
 of many examples.
 \begin{example}
 Assuming \tcode{T} is a
-\grammarterm{simple-type-specifier}~(\ref{dcl.type}),
+\grammarterm{simple-type-specifier}\iref{dcl.type},
 
 \begin{codeblock}
 T(a)->m = 7;        // expression-statement

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -5,7 +5,7 @@
 
 \pnum
 This Clause describes components for manipulating sequences of
-any non-array POD~(\ref{basic.types}) type.
+any non-array POD\iref{basic.types} type.
 Such types are called \term{char-like types},\indextext{char-like type}
 and objects of
 char-like types are called \term{char-like objects}\indextext{char-like object} or
@@ -45,8 +45,8 @@ and
 that satisfy those requirements.
 
 \pnum
-Most classes specified in Clauses~\ref{string.classes}
-and~\ref{input.output} need a set of related types and functions to complete
+Most classes specified in \ref{string.classes}
+and \ref{input.output} need a set of related types and functions to complete
 the definition of their semantics.  These types and functions are provided as a
 set of member \grammarterm{typedef-name}{s} and functions in the template
 parameter \tcode{traits} used by each such template.  This subclause defines the
@@ -218,7 +218,7 @@ using char_type = CHAR_T;
 The type
 \tcode{char_type}
 is used to refer to the character container type
-in the implementation of the library classes defined in~\ref{string.classes} and Clause~\ref{input.output}.
+in the implementation of the library classes defined in~\ref{string.classes} and \ref{input.output}.
 \end{itemdescr}
 
 \indexlibrarymember{int_type}{char_traits}%
@@ -307,7 +307,7 @@ and
 
 \pnum
 The requirements for the members of these specializations are given in
-Clause~\ref{char.traits.require}.
+\ref{char.traits.require}.
 
 \rSec3[char.traits.specializations.char]{\tcode{struct char_traits<char>}}
 
@@ -839,10 +839,10 @@ member functions of
 \tcode{Allocator}
 class passed as a template parameter to allocate and free storage for the
 contained char-like objects.\footnote{\tcode{Allocator::value_type} must name the same type
-as \tcode{charT}~(\ref{string.require}).}
+as \tcode{charT}\iref{string.require}.}
 
 \pnum
-A \tcode{basic_string} is a contiguous container~(\ref{container.requirements.general}).
+A \tcode{basic_string} is a contiguous container\iref{container.requirements.general}.
 
 \pnum
 In all cases,
@@ -857,13 +857,13 @@ kinds of errors, each associated with an exception type:
 a
 \term{length}
 error is associated with exceptions of type
-\tcode{length_error}~(\ref{length.error});
+\tcode{length_error}\iref{length.error};
 \indexlibrary{\idxcode{length_error}}%
 \item
 an
 \term{out-of-range}
 error is associated with exceptions of type
-\tcode{out_of_range}~(\ref{out.of.range}).
+\tcode{out_of_range}\iref{out.of.range}.
 \indexlibrary{\idxcode{out_of_range}}%
 \end{itemize}
 
@@ -1163,7 +1163,7 @@ objects as needed. The \tcode{Allocator} object used shall be
 obtained as described in \ref{container.requirements.general}.
 In every specialization \tcode{basic_string<charT, traits, Allocator>},
 the type \tcode{traits} shall satisfy
-the character traits requirements~(\ref{char.traits}), and
+the character traits requirements\iref{char.traits}, and
 the type \tcode{traits::char_type} shall name the same type as \tcode{charT}.
 
 \pnum
@@ -1174,8 +1174,8 @@ invalidated by the following uses of that \tcode{basic_string} object:
 \begin{itemize}
 \item as an argument to any standard library function taking a reference to non-const
 \tcode{basic_string} as an argument.\footnote{For example, as an argument to non-member
-functions \tcode{swap()}~(\ref{string.special}),
-\tcode{operator>{}>()}~(\ref{string.io}), and \tcode{getline()}~(\ref{string.io}), or as
+functions \tcode{swap()}\iref{string.special},
+\tcode{operator>{}>()}\iref{string.io}, and \tcode{getline()}\iref{string.io}, or as
 an argument to \tcode{basic_string::swap()}.}
 
 \item Calling non-const member functions, except
@@ -1486,7 +1486,7 @@ template<class InputIterator,
 \pnum
 \remarks Shall not participate in overload resolution if
 \tcode{InputIterator} is a type that does not qualify as an input iterator,
-or if \tcode{Allocator} is a type that does not qualify as an allocator~(\ref{container.requirements.general}).
+or if \tcode{Allocator} is a type that does not qualify as an allocator\iref{container.requirements.general}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{basic_string}%
@@ -1535,7 +1535,7 @@ basic_string& operator=(basic_string&& str)
 \begin{itemdescr}
 \pnum
 \effects
-Move assigns as a sequence container~(\ref{container.requirements}),
+Move assigns as a sequence container\iref{container.requirements},
 except that iterators, pointers and references may be invalidated.
 
 \pnum
@@ -4225,7 +4225,7 @@ template<class charT, class traits, class Allocator>
 \begin{itemdescr}
 \pnum
 \effects
-Behaves as a formatted input function~(\ref{istream.formatted.reqmts}).
+Behaves as a formatted input function\iref{istream.formatted.reqmts}.
 After constructing a
 \tcode{sentry}
 object, if the sentry converts to \tcode{true}, calls
@@ -4266,7 +4266,7 @@ object is destroyed.
 If the function extracts no characters, it calls
 \tcode{is.setstate(ios::failbit)},
 which may throw
-\tcode{ios_base::fail\-ure}~(\ref{iostate.flags}).
+\tcode{ios_base::fail\-ure}\iref{iostate.flags}.
 
 \pnum
 \returns
@@ -4304,7 +4304,7 @@ template<class charT, class traits, class Allocator>
 \begin{itemdescr}
 \pnum
 \effects
-Behaves as an unformatted input function~(\ref{istream.unformatted}),
+Behaves as an unformatted input function\iref{istream.unformatted},
 except that it does not affect the value returned by subsequent calls to
 \tcode{basic_istream<>::gcount()}.
 After constructing a
@@ -4329,13 +4329,13 @@ for the next available input character
 \textit{c}
 (in which case,
 \textit{c}
-is extracted but not appended)~(\ref{iostate.flags})
+is extracted but not appended)\iref{iostate.flags}
 \item
 \tcode{str.max_size()}
 characters are stored
 (in which case,
 the function calls
-\tcode{is.setstate(ios_base::fail\-bit))}~(\ref{iostate.flags})
+\tcode{is.setstate(ios_base::fail\-bit))}\iref{iostate.flags}
 \end{itemize}
 
 \pnum
@@ -4349,7 +4349,7 @@ object is destroyed.
 If the function extracts no characters, it calls
 \tcode{is.setstate(ios_base::fail\-bit)}
 which may throw
-\tcode{ios_base::fail\-ure}~(\ref{iostate.flags}).
+\tcode{ios_base::fail\-ure}\iref{iostate.flags}.
 
 \pnum
 \returns
@@ -4636,7 +4636,7 @@ The same suffix \tcode{s} is used for \tcode{chrono::duration} literals denoting
 \rSec1[string.view]{String view classes}
 
 \pnum
-The class template \tcode{basic_string_view} describes an object that can refer to a constant contiguous sequence of char-like~(\ref{strings.general}) objects with the first element of the sequence at position zero.
+The class template \tcode{basic_string_view} describes an object that can refer to a constant contiguous sequence of char-like\iref{strings.general} objects with the first element of the sequence at position zero.
 In the rest of this section, the type of the char-like objects held in a \tcode{basic_string_view} object is designated by \tcode{charT}.
 
 \pnum
@@ -4818,7 +4818,7 @@ private:
 \end{codeblock}
 
 \pnum
-In every specialization \tcode{basic_string_view<charT, traits>}, the type \tcode{traits} shall satisfy the character traits requirements~(\ref{char.traits}),
+In every specialization \tcode{basic_string_view<charT, traits>}, the type \tcode{traits} shall satisfy the character traits requirements\iref{char.traits},
 and the type \tcode{traits::char_type} shall name the same type as \tcode{charT}.
 
 \rSec3[string.view.cons]{Construction and assignment}
@@ -4891,15 +4891,15 @@ using const_iterator = @\impdefx{type of \tcode{basic_string_view::const_iterato
 \begin{itemdescr}
 \pnum
 A type that meets the requirements
-of a constant random access iterator~(\ref{random.access.iterators}) and
-of a contiguous iterator~(\ref{iterator.requirements.general})
+of a constant random access iterator\iref{random.access.iterators} and
+of a contiguous iterator\iref{iterator.requirements.general}
 whose \tcode{value_type} is the template parameter \tcode{charT}.
 
 \pnum
 For a \tcode{basic_string_view str}, any operation that invalidates a pointer in the range \range{str.data()}{str.data() + str.size()} invalidates pointers, iterators, and references returned from \tcode{str}'s member functions.
 
 \pnum
-All requirements on container iterators~(\ref{container.requirements}) apply to \tcode{basic_string_view::const_iterator} as well.
+All requirements on container iterators\iref{container.requirements} apply to \tcode{basic_string_view::const_iterator} as well.
 \end{itemdescr}
 
 \indexlibrarymember{begin}{basic_string_view}%
@@ -5611,7 +5611,7 @@ template<class charT, class traits>
 \pnum
 \effects
 Behaves as a formatted output
-function~(\ref{ostream.formatted.reqmts}) of \tcode{os}. Forms a character sequence
+function\iref{ostream.formatted.reqmts} of \tcode{os}. Forms a character sequence
 \tcode{seq}, initially consisting of the elements defined by the range
 \range{str.begin()}{str.end()}. Determines padding for \tcode{seq}
 as described in~\ref{ostream.formatted.reqmts}.
@@ -5640,10 +5640,10 @@ template<> struct hash<wstring_view>;
 
 \begin{itemdescr}
 \pnum
-The specialization is enabled~(\ref{unord.hash}).
+The specialization is enabled\iref{unord.hash}.
 \begin{note}
 The hash value of a string view object is equal to the hash value of
-the corresponding string object~(\ref{basic.string.hash}).
+the corresponding string object\iref{basic.string.hash}.
 \end{note}
 \end{itemdescr}
 
@@ -5872,19 +5872,19 @@ are the same as the C standard library header \tcode{<string.h>}.
 
 \pnum
 The functions \tcode{strerror} and \tcode{strtok} are not required to avoid data
-races~(\ref{res.on.data.races}).
+races\iref{res.on.data.races}.
 
 \pnum
 \indextext{signal-safe!\idxcode{memcpy}}%
 \indextext{signal-safe!\idxcode{memmove}}%
-The functions \tcode{memcpy} and \tcode{memmove} are signal-safe~(\ref{support.signal}).
+The functions \tcode{memcpy} and \tcode{memmove} are signal-safe\iref{support.signal}.
 
 \pnum
 \begin{note}
 The functions
 \tcode{strchr}, \tcode{strpbrk}, \tcode{strrchr}, \tcode{strstr}, and \tcode{memchr},
 have different signatures in this International Standard,
-but they have the same behavior as in the C standard library~(\ref{library.c}).
+but they have the same behavior as in the C standard library\iref{library.c}.
 \end{note}
 
 \xref ISO C 7.24
@@ -6054,7 +6054,7 @@ are the same as the C standard library header
 The functions
 \tcode{wcschr}, \tcode{wcspbrk}, \tcode{wcsrchr}, \tcode{wcsstr}, and \tcode{wmemchr}
 have different signatures in this International Standard,
-but they have the same behavior as in the C standard library~(\ref{library.c}).
+but they have the same behavior as in the C standard library\iref{library.c}.
 \end{note}
 
 \xref ISO C 7.29
@@ -6099,8 +6099,8 @@ are the same as the C standard library header
 \indextext{\idxhdr{cwchar}}%
 \indexlibrary{\idxhdr{cwchar}}%
 \begin{note}
-The headers \tcode{<cstdlib>}~(\ref{cstdlib.syn})
-and \tcode{<cwchar>}~(\ref{cwchar.syn})
+The headers \tcode{<cstdlib>}\iref{cstdlib.syn}
+and \tcode{<cwchar>}\iref{cwchar.syn}
 declare the functions described in this subclause.
 \end{note}
 
@@ -6138,7 +6138,7 @@ These functions have the semantics specified in the C standard library.
 \pnum
 \remarks
 Calls to these functions
-may introduce a data race~(\ref{res.on.data.races})
+may introduce a data race\iref{res.on.data.races}
 with other calls to the same function.
 \end{itemdescr}
 
@@ -6166,7 +6166,7 @@ These functions have the semantics specified in the C standard library.
 \remarks
 Calling these functions
 with an \tcode{mbstate_t*} argument that is a null pointer value
-may introduce a data race~(\ref{res.on.data.races})
+may introduce a data race\iref{res.on.data.races}
 with other calls to the same function
 with an \tcode{mbstate_t*} argument that is a null pointer value.
 \end{itemdescr}

--- a/source/styles.tex
+++ b/source/styles.tex
@@ -86,7 +86,7 @@
 
 %%--------------------------------------------------
 % set heading style for annexes
-\newcommand{\Annex}[3]{\chapter[#2]{(#3)\protect\\#2\hfill[#1]}\relax\label{#1}}
+\newcommand{\Annex}[3]{\chapter[#2]{(#3)\protect\\#2\hfill[#1]}\relax\annexlabel{#1}}
 \newcommand{\infannex}[2]{\Annex{#1}{#2}{informative}\addxref{#1}}
 \newcommand{\normannex}[2]{\Annex{#1}{#2}{normative}\addxref{#1}}
 

--- a/source/support.tex
+++ b/source/support.tex
@@ -88,7 +88,7 @@ The contents and meaning of the header \tcode{<cstddef>} are the same as
 the C standard library header \tcode{<stddef.h>},
 except that it does not declare the type \tcode{wchar_t},
 that it also declares the type \tcode{byte}
-and its associated operations~(\ref{support.types.byteops}),
+and its associated operations\iref{support.types.byteops},
 and as noted in
 \ref{support.types.nullptr} and
 \ref{support.types.layout}.
@@ -253,7 +253,7 @@ and except as noted in
 \ref{c.math.abs}.
 \begin{note}
 Several functions have additional overloads in this International Standard,
-but they have the same behavior as in the C standard library~(\ref{library.c}).
+but they have the same behavior as in the C standard library\iref{library.c}.
 \end{note}
 
 \xref ISO C 7.22
@@ -296,14 +296,14 @@ the C standard library header \tcode{<stddef.h>}, but
 accepts a restricted set of \tcode{\placeholder{type}}
 arguments in this International Standard.
 Use of the \tcode{offsetof} macro with a \tcode{\placeholder{type}}
-other than a standard-layout class (Clause~\ref{class})
+other than a standard-layout class\iref{class}
 is conditionally-supported.\footnote{Note that \tcode{offsetof}
 is required to work as specified even if unary
 \tcode{operator\&}
 is overloaded for any of the types involved.}
 The expression \tcode{offsetof(\placeholder{type}, \placeholder{member-designator})}
-is never type-dependent~(\ref{temp.dep.expr}) and it is
-value-dependent~(\ref{temp.dep.constexpr}) if and only if \tcode{\placeholder{type}} is
+is never type-dependent\iref{temp.dep.expr} and it is
+value-dependent\iref{temp.dep.constexpr} if and only if \tcode{\placeholder{type}} is
 dependent. The result of applying the \tcode{offsetof} macro to
 a static data member or a function member is undefined.
 No operation invoked by the \tcode{offsetof} macro shall throw an exception and
@@ -319,12 +319,12 @@ hold the difference of two subscripts in an array object, as described in~\ref{e
 The type \tcode{size_t} is an
 \impldef{type of \tcode{size_t}}
 unsigned integer type that is large enough
-to contain the size in bytes of any object~(\ref{expr.sizeof}).
+to contain the size in bytes of any object\iref{expr.sizeof}.
 
 \pnum
 \begin{note}
 It is recommended that implementations choose types for \tcode{ptrdiff_t} and \tcode{size_t}
-whose integer conversion ranks~(\ref{conv.rank}) are no greater than that of
+whose integer conversion ranks\iref{conv.rank} are no greater than that of
 \tcode{signed long int} unless a larger size is necessary to contain all the possible values.
 \end{note}
 
@@ -333,7 +333,7 @@ The type
 \indexlibrary{\idxcode{max_align_t}}%
 \tcode{max_align_t} is a POD type whose alignment requirement
 is at least as great as that of every scalar type, and whose alignment
-requirement is supported in every context~(\ref{basic.align}).
+requirement is supported in every context\iref{basic.align}.
 
 \xref ISO C 7.19
 
@@ -495,11 +495,11 @@ template <class IntType>
 
 \pnum
 The headers
-\tcode{<limits>}~(\ref{limits.syn}),
-\tcode{<climits>}~(\ref{climits.syn}), and
-\tcode{<cfloat>}~(\ref{cfloat.syn})
+\tcode{<limits>}\iref{limits.syn},
+\tcode{<climits>}\iref{climits.syn}, and
+\tcode{<cfloat>}\iref{cfloat.syn}
 supply characteristics of imple\-mentation-dependent
-arithmetic types~(\ref{basic.fundamental}).
+arithmetic types\iref{basic.fundamental}.
 
 \rSec2[limits.syn]{Header \tcode{<limits>} synopsis}
 \indextext{\idxhdr{limits}}%
@@ -718,13 +718,13 @@ the specialization on the unqualified type \tcode{T}.
 
 \pnum
 Non-arithmetic standard types, such as
-\tcode{complex<T>}~(\ref{complex}), shall not have specializations.
+\tcode{complex<T>}\iref{complex}, shall not have specializations.
 
 \rSec3[numeric.limits.members]{\tcode{numeric_limits} members}
 
 \pnum
 \indextext{signal-safe!\idxcode{numeric_limits} members}%
-Each member function defined in this subclause is signal-safe~(\ref{support.signal}).
+Each member function defined in this subclause is signal-safe\iref{support.signal}.
 
 \indexlibrarymember{min}{numeric_limits}%
 \begin{itemdecl}
@@ -1159,7 +1159,7 @@ static constexpr bool is_bounded;
 \begin{itemdescr}
 \pnum
 \tcode{true} if the set of values representable by the type is finite.\footnote{Required by LIA-1.}
-\begin{note} All fundamental types~(\ref{basic.fundamental}) are bounded. This member would be \tcode{false} for arbitrary
+\begin{note} All fundamental types\iref{basic.fundamental} are bounded. This member would be \tcode{false} for arbitrary
 precision types.\end{note}
 
 \pnum
@@ -1181,7 +1181,7 @@ integer multiple of \tcode{max() - min() + 1}.
 
 \pnum
 \begin{example}
-\tcode{is_modulo} is \tcode{false} for signed integer types~(\ref{basic.fundamental})
+\tcode{is_modulo} is \tcode{false} for signed integer types\iref{basic.fundamental}
 unless an implementation, as an extension to this International Standard,
 defines signed integer overflow to wrap.
 \end{example}
@@ -1602,7 +1602,7 @@ the C standard library header \tcode{<stdint.h>}.
 \pnum
 \indextext{\idxhdr{cstdlib}}%
 \begin{note}
-The header \tcode{<cstdlib>}~(\ref{cstdlib.syn})
+The header \tcode{<cstdlib>}\iref{cstdlib.syn}
 declares the functions described in this subclause.
 \end{note}
 
@@ -1620,9 +1620,9 @@ This function has the semantics specified in the C standard library.
 \remarks
 The program is terminated without executing destructors for objects of automatic,
 thread, or static storage duration and without calling functions passed to
-\tcode{atexit()}~(\ref{basic.start.term}).
+\tcode{atexit()}\iref{basic.start.term}.
 \indextext{signal-safe!\idxcode{_Exit}}%
-The function \tcode{_Exit} is signal-safe~(\ref{support.signal}).
+The function \tcode{_Exit} is signal-safe\iref{support.signal}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{abort}}%
@@ -1640,9 +1640,9 @@ This function has the semantics specified in the C standard library.
 The program is terminated without executing destructors for objects of
 automatic, thread, or static storage
 duration and without calling functions passed to
-\tcode{atexit()}~(\ref{basic.start.term}).
+\tcode{atexit()}\iref{basic.start.term}.
 \indextext{signal-safe!\idxcode{abort}}%
-The function \tcode{abort} is signal-safe~(\ref{support.signal}).
+The function \tcode{abort} is signal-safe\iref{support.signal}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{atexit}}%
@@ -1659,9 +1659,9 @@ The
 functions register the function pointed to by \tcode{f}
 to be called without arguments at normal program termination.
 It is unspecified whether a call to \tcode{atexit()} that does not
-happen before~(\ref{intro.multithread}) a call to \tcode{exit()} will succeed.
+happen before\iref{intro.multithread} a call to \tcode{exit()} will succeed.
 \begin{note} The \tcode{atexit()} functions do not introduce a data
-race~(\ref{res.on.data.races}). \end{note}
+race\iref{res.on.data.races}. \end{note}
 
 \pnum
 \implimits
@@ -1693,7 +1693,7 @@ are called.\footnote{A function is called for every time it is registered.}
 See~\ref{basic.start.term} for the order of destructions and calls.
 (Automatic objects are not destroyed as a result of calling
 \tcode{exit()}.)\footnote{Objects with automatic storage duration are all destroyed in a program whose
-\tcode{main} function~(\ref{basic.start.main})
+\tcode{main} function\iref{basic.start.main}
 contains no automatic objects and executes the call to
 \tcode{exit()}.
 Control can be transferred directly to such a
@@ -1702,7 +1702,7 @@ by throwing an exception that is caught in
 \tcode{main}.}
 
 If control leaves a registered function called by \tcode{exit} because the function does
-not provide a handler for a thrown exception, \tcode{std::terminate()} shall be called~(\ref{except.terminate}).%
+not provide a handler for a thrown exception, \tcode{std::terminate()} shall be called\iref{except.terminate}.%
 \indexlibrary{\idxcode{terminate}}%
 
 \item
@@ -1747,9 +1747,9 @@ int at_quick_exit(@\placeholder{atexit-handler}@* f) noexcept;
 \effects The \tcode{at_quick_exit()} functions register the function pointed to by \tcode{f}
 to be called without arguments when \tcode{quick_exit} is called.
 It is unspecified whether a call to \tcode{at_quick_exit()} that does not
-happen before~(\ref{intro.multithread}) all calls to \tcode{quick_exit} will succeed. \begin{note} The
+happen before\iref{intro.multithread} all calls to \tcode{quick_exit} will succeed. \begin{note} The
 \tcode{at_quick_exit()} functions do not introduce a
-data race~(\ref{res.on.data.races}). \end{note}
+data race\iref{res.on.data.races}. \end{note}
 \begin{note}
 The order of registration may be indeterminate if \tcode{at_quick_exit} was called from more
 than one thread.
@@ -1796,7 +1796,7 @@ The standard file buffers are not flushed.
 \pnum
 \remarks
 \indextext{signal-safe!\idxcode{quick_exit}}%
-The function \tcode{quick_exit} is signal-safe~(\ref{support.signal})
+The function \tcode{quick_exit} is signal-safe\iref{support.signal}
 when the functions registered with \tcode{at_quick_exit} are.
 \end{itemdescr}
 
@@ -1896,9 +1896,9 @@ void* operator new(std::size_t size, std::align_val_t alignment);
 \pnum
 \effects
 The
-allocation functions~(\ref{basic.stc.dynamic.allocation})
+allocation functions\iref{basic.stc.dynamic.allocation}
 called by a
-\grammarterm{new-expression}~(\ref{expr.new})
+\grammarterm{new-expression}\iref{expr.new}
 to allocate
 \tcode{size} bytes of storage.
 The second form is called for a type with new-extended alignment,
@@ -1915,7 +1915,7 @@ provided the object's type does not have new-extended alignment.
 
 \pnum
 \required
-Return a non-null pointer to suitably aligned storage~(\ref{basic.stc.dynamic}),
+Return a non-null pointer to suitably aligned storage\iref{basic.stc.dynamic},
 or else throw a
 \tcode{bad_alloc}
 \indexlibrary{\idxcode{bad_alloc}}%
@@ -1936,12 +1936,12 @@ is unspecified.
 \item
 Returns a pointer to the allocated storage if the attempt is successful.
 Otherwise, if the
-current \tcode{new_handler}~(\ref{get.new.handler}) is
+current \tcode{new_handler}\iref{get.new.handler} is
 a null pointer value, throws
 \tcode{bad_alloc}.
 \item
 Otherwise, the function calls the current
-\tcode{new_handler} function~(\ref{new.handler}).
+\tcode{new_handler} function\iref{new.handler}.
 If the called function returns, the loop repeats.
 \item
 The loop terminates when an attempt to allocate the requested storage is
@@ -1973,7 +1973,7 @@ exception.
 
 \pnum
 \required
-Return a non-null pointer to suitably aligned storage~(\ref{basic.stc.dynamic}),
+Return a non-null pointer to suitably aligned storage\iref{basic.stc.dynamic},
 or else return a null pointer.
 Each of these nothrow versions of
 \tcode{operator new}
@@ -2012,9 +2012,9 @@ void operator delete(void* ptr, std::size_t size, std::align_val_t alignment) no
 \pnum
 \effects
 The
-deallocation functions~(\ref{basic.stc.dynamic.deallocation})
+deallocation functions\iref{basic.stc.dynamic.deallocation}
 called by a
-\grammarterm{delete-expression}~(\ref{expr.delete})
+\grammarterm{delete-expression}\iref{expr.delete}
 to render the value of \tcode{ptr} invalid.
 
 \pnum
@@ -2045,7 +2045,7 @@ which has not been invalidated by an intervening call to
 
 \pnum
 \requires
-If an implementation has strict pointer safety~(\ref{basic.stc.dynamic.safety})
+If an implementation has strict pointer safety\iref{basic.stc.dynamic.safety}
 then \tcode{ptr} shall be a safely-derived pointer.
 
 \pnum
@@ -2111,7 +2111,7 @@ void operator delete(void* ptr, std::align_val_t alignment, const std::nothrow_t
 \pnum
 \effects
 The
-deallocation functions~(\ref{basic.stc.dynamic.deallocation})
+deallocation functions\iref{basic.stc.dynamic.deallocation}
 called by the implementation
 to render the value of \tcode{ptr} invalid
 when the constructor invoked from a nothrow
@@ -2135,7 +2135,7 @@ which has not been invalidated by an intervening call to
 
 \pnum
 \requires
-If an implementation has strict pointer safety~(\ref{basic.stc.dynamic.safety})
+If an implementation has strict pointer safety\iref{basic.stc.dynamic.safety}
 then \tcode{ptr} shall be a safely-derived pointer.
 
 \pnum
@@ -2166,9 +2166,9 @@ void* operator new[](std::size_t size, std::align_val_t alignment);
 \pnum
 \effects
 The
-allocation functions~(\ref{basic.stc.dynamic.allocation})
+allocation functions\iref{basic.stc.dynamic.allocation}
 called by the array form of a
-\grammarterm{new-expression}~(\ref{expr.new})
+\grammarterm{new-expression}\iref{expr.new}
 to allocate
 \tcode{size} bytes of storage.
 The second form is called for a type with new-extended alignment,
@@ -2235,7 +2235,7 @@ exception.
 
 \pnum
 \required
-Return a non-null pointer to suitably aligned storage~(\ref{basic.stc.dynamic}),
+Return a non-null pointer to suitably aligned storage\iref{basic.stc.dynamic},
 or else return a null pointer.
 Each of these nothrow versions of
 \tcode{operator new[]}
@@ -2266,7 +2266,7 @@ void operator delete[](void* ptr, std::size_t size, std::align_val_t alignment) 
 \pnum
 \effects
 The
-deallocation functions~(\ref{basic.stc.dynamic.deallocation})
+deallocation functions\iref{basic.stc.dynamic.deallocation}
 called by the array form of a
 \grammarterm{delete-expression}
 to render the value of \tcode{ptr} invalid.
@@ -2299,7 +2299,7 @@ which has not been invalidated by an intervening call to
 
 \pnum
 \requires
-If an implementation has strict pointer safety~(\ref{basic.stc.dynamic.safety})
+If an implementation has strict pointer safety\iref{basic.stc.dynamic.safety}
 then \tcode{ptr} shall be a safely-derived pointer.
 
 \pnum
@@ -2346,7 +2346,7 @@ void operator delete[](void* ptr, std::align_val_t alignment, const std::nothrow
 \pnum
 \effects
 The
-deallocation functions~(\ref{basic.stc.dynamic.deallocation})
+deallocation functions\iref{basic.stc.dynamic.deallocation}
 called by the implementation
 to render the value of \tcode{ptr} invalid
 when the constructor invoked from a nothrow
@@ -2370,7 +2370,7 @@ which has not been invalidated by an intervening call to
 
 \pnum
 \requires
-If an implementation has strict pointer safety~(\ref{basic.stc.dynamic.safety})
+If an implementation has strict pointer safety\iref{basic.stc.dynamic.safety}
 then \tcode{ptr} shall be a safely-derived pointer.
 
 \pnum
@@ -2393,7 +2393,7 @@ respectively.
 
 \pnum
 These functions are reserved; a \Cpp program may not define functions that displace
-the versions in the \Cpp standard library~(\ref{constraints}).
+the versions in the \Cpp standard library\iref{constraints}.
 The provisions of~\ref{basic.stc.dynamic} do not apply to these reserved
 placement forms of \tcode{operator new} and \tcode{operator delete}.
 
@@ -2449,7 +2449,7 @@ Intentionally performs no action.
 
 \pnum
 \requires
-If an implementation has strict pointer safety~(\ref{basic.stc.dynamic.safety})
+If an implementation has strict pointer safety\iref{basic.stc.dynamic.safety}
 then \tcode{ptr} shall be a safely-derived pointer.
 
 \pnum
@@ -2457,7 +2457,7 @@ then \tcode{ptr} shall be a safely-derived pointer.
 Default function called when any part of the initialization in a
 placement \grammarterm{new-expression} that invokes the library's
 non-array placement operator new
-terminates by throwing an exception~(\ref{expr.new}).
+terminates by throwing an exception\iref{expr.new}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{delete}!\idxcode{operator}}%
@@ -2472,7 +2472,7 @@ Intentionally performs no action.
 
 \pnum
 \requires
-If an implementation has strict pointer safety~(\ref{basic.stc.dynamic.safety})
+If an implementation has strict pointer safety\iref{basic.stc.dynamic.safety}
 then \tcode{ptr} shall be a safely-derived pointer.
 
 \pnum
@@ -2480,7 +2480,7 @@ then \tcode{ptr} shall be a safely-derived pointer.
 Default function called when any part of the initialization in a
 placement \grammarterm{new-expression} that invokes the library's
 array placement operator new
-terminates by throwing an exception~(\ref{expr.new}).
+terminates by throwing an exception\iref{expr.new}.
 \end{itemdescr}
 
 \rSec3[new.delete.dataraces]{Data races}
@@ -2494,10 +2494,10 @@ the library
 versions of \tcode{operator delete}, user replacement
 versions of \tcode{operator delete}, the C standard library function
 \tcode{free}, and the C standard library function \tcode{realloc} shall not
-introduce a data race~(\ref{res.on.data.races}).
+introduce a data race\iref{res.on.data.races}.
 Calls to these functions that allocate or deallocate a particular unit
 of storage shall occur in a single total order, and each such deallocation call
-shall happen before~(\ref{intro.multithread}) the next allocation (if any) in
+shall happen before\iref{intro.multithread} the next allocation (if any) in
 this order.
 
 \rSec2[alloc.errors]{Storage allocation errors}
@@ -2561,7 +2561,7 @@ An \impldef{return value of \tcode{bad_alloc::what}} \ntbs.
 
 \pnum
 \remarks
-The message may be a null-terminated multibyte string~(\ref{multibyte.strings}),
+The message may be a null-terminated multibyte string\iref{multibyte.strings},
 suitable for conversion and display as a
 \tcode{wstring}~(\ref{string.classes}, \ref{locale.codecvt}).
 \end{itemdescr}
@@ -2583,7 +2583,7 @@ namespace std {
 The class \tcode{bad_array_new_length} defines the type of objects thrown as
 exceptions by the implementation to report an attempt to allocate an array of size
 less than zero or
-greater than an \impldef{maximum size of an allocated object} limit~(\ref{expr.new}).
+greater than an \impldef{maximum size of an allocated object} limit\iref{expr.new}.
 
 \indexlibrary{\idxcode{bad_array_new_length}!constructor}%
 \begin{itemdecl}
@@ -2607,7 +2607,7 @@ An \impldef{return value of \tcode{bad_array_new_length::what}} \ntbs.
 
 \pnum
 \remarks
-The message may be a null-terminated multibyte string~(\ref{multibyte.strings}),
+The message may be a null-terminated multibyte string\iref{multibyte.strings},
 suitable for conversion and display as a
 \tcode{wstring}~(\ref{string.classes}, \ref{locale.codecvt}).
 \end{itemdescr}
@@ -2626,7 +2626,7 @@ The type of a
 to be called by
 \tcode{operator new()}
 or
-\tcode{operator new[]()}~(\ref{new.delete}) when they cannot satisfy a request for additional storage.
+\tcode{operator new[]()}\iref{new.delete} when they cannot satisfy a request for additional storage.
 
 \pnum
 \required
@@ -2694,8 +2694,8 @@ template <class T> constexpr T* launder(T* p) noexcept;
 \pnum
 \requires
 \tcode{p} represents the address \placeholder{A} of a byte in memory.
-An object \placeholder{X} that is within its lifetime~(\ref{basic.life})
-and whose type is similar~(\ref{conv.qual}) to \tcode{T}
+An object \placeholder{X} that is within its lifetime\iref{basic.life}
+and whose type is similar\iref{conv.qual} to \tcode{T}
 is located at the address \placeholder{A}.
 All bytes of storage that would be reachable through the result
 are reachable through \tcode{p} (see below).
@@ -2738,7 +2738,7 @@ See~\ref{basic.life}.
 struct X { const int n; };
 X *p = new X{3};
 const int a = p->n;
-new (p) X{5};                       // \tcode{p} does not point to new object~(\ref{basic.life}) because \tcode{X::n} is \tcode{const}
+new (p) X{5};                       // \tcode{p} does not point to new object\iref{basic.life} because \tcode{X::n} is \tcode{const}
 const int b = p->n;                 // undefined behavior
 const int c = std::launder(p)->n;   // OK
 \end{codeblock}
@@ -2842,7 +2842,7 @@ namespace std {
 \pnum
 The class
 \tcode{type_info}
-describes type information generated by the implementation~(\ref{expr.typeid}).
+describes type information generated by the implementation\iref{expr.typeid}.
 Objects of this class effectively store a pointer to a name for the type, and
 an encoded value suitable for comparing two types for equality or collating order.
 The names, encoding rule, and collating sequence for types are all unspecified
@@ -2923,7 +2923,7 @@ An \impldef{return value of \tcode{type_info::name()}} \ntbs.
 
 \pnum
 \remarks
-The message may be a null-terminated multibyte string~(\ref{multibyte.strings}),
+The message may be a null-terminated multibyte string\iref{multibyte.strings},
 suitable for conversion and display as a
 \tcode{wstring}~(\ref{string.classes}, \ref{locale.codecvt})
 \end{itemdescr}
@@ -2950,7 +2950,7 @@ defines the type of objects thrown
 as exceptions by the implementation to report the execution of an invalid
 \indextext{cast!dynamic}%
 \tcode{dynamic_cast}
-expression~(\ref{expr.dynamic.cast}).
+expression\iref{expr.dynamic.cast}.
 
 \indexlibrary{\idxcode{bad_cast}!constructor}%
 \begin{itemdecl}
@@ -2990,7 +2990,7 @@ An \impldef{return value of \tcode{bad_cast::what}} \ntbs.
 
 \pnum
 \remarks
-The message may be a null-terminated multibyte string~(\ref{multibyte.strings}),
+The message may be a null-terminated multibyte string\iref{multibyte.strings},
 suitable for conversion and display as a
 \tcode{wstring}~(\ref{string.classes}, \ref{locale.codecvt})
 \end{itemdescr}
@@ -3017,7 +3017,7 @@ defines the type of objects
 thrown as exceptions by the implementation to report a null pointer
 in a
 \tcode{typeid}
-expression~(\ref{expr.typeid}).
+expression\iref{expr.typeid}.
 
 \indexlibrary{\idxcode{bad_typeid}!constructor}%
 \begin{itemdecl}
@@ -3057,7 +3057,7 @@ An \impldef{return value of \tcode{bad_typeid::what}} \ntbs.
 
 \pnum
 \remarks
-The message may be a null-terminated multibyte string~(\ref{multibyte.strings}),
+The message may be a null-terminated multibyte string\iref{multibyte.strings},
 suitable for conversion and display as a
 \tcode{wstring}~(\ref{string.classes}, \ref{locale.codecvt})
 \end{itemdescr}
@@ -3184,7 +3184,7 @@ An \impldef{return value of \tcode{exception::what}} \ntbs.
 
 \pnum
 \remarks
-The message may be a null-terminated multibyte string~(\ref{multibyte.strings}),
+The message may be a null-terminated multibyte string\iref{multibyte.strings},
 suitable for conversion and display as a
 \tcode{wstring}~(\ref{string.classes}, \ref{locale.codecvt}).
 The return value remains valid until the exception object from which
@@ -3212,7 +3212,7 @@ The class
 \tcode{bad_exception}
 defines the type of the object
 referenced by the \tcode{exception_ptr}
-returned from a call to \tcode{current_exception}~(\ref{propagation})
+returned from a call to \tcode{current_exception}\iref{propagation}
 when the currently active exception object fails to copy.
 
 \indexlibrary{\idxcode{bad_exception}!constructor}%
@@ -3253,7 +3253,7 @@ An \impldef{return value of \tcode{bad_exception::what}} \ntbs.
 
 \pnum
 \remarks
-The message may be a null-terminated multibyte string~(\ref{multibyte.strings}),
+The message may be a null-terminated multibyte string\iref{multibyte.strings},
 suitable for conversion and display as a
 \tcode{wstring}~(\ref{string.classes}, \ref{locale.codecvt}).
 \end{itemdescr}
@@ -3334,7 +3334,7 @@ terminate_handler get_terminate() noexcept;
 \pnum
 \remarks
 Called by the implementation when exception
-handling must be abandoned for any of several reasons~(\ref{except.terminate}).
+handling must be abandoned for any of several reasons\iref{except.terminate}.
 May also be called directly by the program.
 
 \pnum
@@ -3357,13 +3357,13 @@ int uncaught_exceptions() noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-The number of uncaught exceptions~(\ref{except.uncaught}).
+The number of uncaught exceptions\iref{except.uncaught}.
 
 \pnum
 \remarks
 When \tcode{uncaught_exceptions() > 0},
 throwing an exception can result in a call of\\
-\tcode{std::terminate()}~(\ref{except.terminate}).
+\tcode{std::terminate()}\iref{except.terminate}.
 \end{itemdescr}
 
 \rSec2[propagation]{Exception propagation}
@@ -3379,7 +3379,7 @@ The type \tcode{exception_ptr} can be used to refer to an exception object.
 
 \pnum
 \tcode{exception_ptr} shall satisfy the requirements of
-\tcode{NullablePointer}~(\ref{nullablepointer.requirements}).
+\tcode{NullablePointer}\iref{nullablepointer.requirements}.
 
 \pnum
 Two non-null values of type \tcode{exception_ptr} are equivalent and compare equal if and
@@ -3417,7 +3417,7 @@ exception_ptr current_exception() noexcept;
 \begin{itemdescr}
 \pnum
 \returns An \tcode{exception_ptr} object that refers to
-the currently handled exception~(\ref{except.handle}) or a copy of the currently
+the currently handled exception\iref{except.handle} or a copy of the currently
 handled exception, or a null \tcode{exception_ptr} object if no exception is being
 handled. The referenced object shall remain valid at least as long as there is an
 \tcode{exception_ptr} object that refers to it.
@@ -3580,7 +3580,7 @@ if (auto p = dynamic_cast<const nested_exception*>(addressof(e)))
 The header \tcode{<initializer_list>} defines a class template and several
 support functions related to list-initialization~(see \ref{dcl.init.list}).
 \indextext{signal-safe!\idxcode{initializer_list} functions}%
-All functions specified in this subclause are signal-safe~(\ref{support.signal}).
+All functions specified in this subclause are signal-safe\iref{support.signal}.
 
 \rSec2[initializer_list.syn]{Header \tcode{<initializer_list>} synopsis}
 \indexlibrary{\idxcode{initializer_list}}%
@@ -3727,8 +3727,8 @@ provide further compatibility with C code.
 \pnum
 Calls to the function
 \indexlibrary{\idxcode{getenv}}%
-\tcode{getenv}~(\ref{cstdlib.syn}) shall not introduce a data
-race~(\ref{res.on.data.races}) provided that nothing modifies the environment.
+\tcode{getenv}\iref{cstdlib.syn} shall not introduce a data
+race\iref{res.on.data.races} provided that nothing modifies the environment.
 \begin{note} Calls to the POSIX functions
 \indexlibrary{\idxcode{setenv}}%
 \tcode{setenv} and
@@ -3737,7 +3737,7 @@ race~(\ref{res.on.data.races}) provided that nothing modifies the environment.
 environment. \end{note}
 
 \pnum
-A call to the \tcode{setlocale} function~(\ref{c.locales})
+A call to the \tcode{setlocale} function\iref{c.locales}
 may introduce a data race with other
 calls to the \tcode{setlocale} function or with calls to functions that are
 affected by the current C locale. The implementation shall behave as if no
@@ -3786,8 +3786,8 @@ is required to work as specified even if unary
 \tcode{operator\&}
 is overloaded for the type of
 \tcode{parmN}.}
-If the parameter \tcode{parmN} is a pack expansion~(\ref{temp.variadic}) or
-an entity resulting from a lambda capture~(\ref{expr.prim.lambda}),
+If the parameter \tcode{parmN} is a pack expansion\iref{temp.variadic} or
+an entity resulting from a lambda capture\iref{expr.prim.lambda},
 the program is ill-formed, no diagnostic required.
 If the parameter
 \tcode{parmN}
@@ -3883,7 +3883,7 @@ invocation of the signal handler so installed.
 
 \pnum
 A \defn{plain lock-free atomic operation} is
-an invocation of a function \tcode{f} from Clause~\ref{atomics},
+an invocation of a function \tcode{f} from \ref{atomics},
 such that:
 
 \begin{itemize}
@@ -3932,10 +3932,10 @@ control entering a \grammarterm{try-block} or \grammarterm{function-try-block};
 \item
 initialization of a variable with static storage duration
 requiring dynamic initialization~(\ref{basic.start.dynamic}, \ref{stmt.dcl})%
-\footnote{Such initialization might occur because it is the first odr-use~(\ref{basic.def.odr}) of that variable.}; or
+\footnote{Such initialization might occur because it is the first odr-use\iref{basic.def.odr} of that variable.}; or
 
 \item
-waiting for the completion of the initialization of a variable with static storage duration~(\ref{stmt.dcl}).
+waiting for the completion of the initialization of a variable with static storage duration\iref{stmt.dcl}.
 \end{itemize}
 
 A signal handler invocation has undefined behavior if it includes

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -944,8 +944,7 @@ D<B<int> > db;
 A
 \grammarterm{simple-template-id}
 that names a class template specialization is a
-\grammarterm{class-name}
-(\ref{class}).
+\grammarterm{class-name}\iref{class}.
 
 \pnum
 A \grammarterm{template-id} that names an alias template
@@ -3017,8 +3016,7 @@ the primary template.
 \end{example}
 
 \pnum
-A class template partial specialization may be constrained
-(\ref{temp}).
+A class template partial specialization may be constrained\iref{temp}.
 \begin{example}
 \begin{codeblock}
 template<typename T> concept C = true;

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -62,7 +62,7 @@ an alias for a family of types, or a concept.
 \grammarterm{template-declaration}
 may be the product of replacing a
 \tcode{>{>}} token by two consecutive \tcode{>}
-tokens~(\ref{temp.names}).\end{note}
+tokens\iref{temp.names}.\end{note}
 
 \pnum
 The
@@ -135,7 +135,7 @@ a class template declaration, if the
 class name
 is a
 \grammarterm{simple-template-id},
-the declaration declares a class template partial specialization~(\ref{temp.class.spec}).
+the declaration declares a class template partial specialization\iref{temp.class.spec}.
 \end{note}
 
 \pnum
@@ -149,30 +149,30 @@ no declarator is permitted.
 
 \pnum
 \indextext{template name!linkage of}%
-A template name has linkage~(\ref{basic.link}).
+A template name has linkage\iref{basic.link}.
 Specializations (explicit or implicit) of
 a template that has internal linkage are
 distinct from all specializations in other translation
 units.
-A template, a template explicit specialization~(\ref{temp.expl.spec}), and a class
+A template, a template explicit specialization\iref{temp.expl.spec}, and a class
 template partial specialization shall not have C linkage. Use of a linkage specification
 other than \tcode{"C"} or \tcode{"C++"} with any of these constructs is
 conditionally-supported, with
 \impldef{semantics of linkage specification on templates} semantics.
-Template definitions shall obey the one-definition rule~(\ref{basic.def.odr}).
+Template definitions shall obey the one-definition rule\iref{basic.def.odr}.
 \begin{note}
 Default arguments for function templates and for member functions of
 class templates are considered definitions for the purpose of template
-instantiation~(\ref{temp.decls}) and must also obey the one-definition rule.
+instantiation\iref{temp.decls} and must also obey the one-definition rule.
 \end{note}
 
 \pnum
 A class template shall not have the same name as any other
 template, class, function, variable, enumeration, enumerator, namespace, or
-type in the same scope~(\ref{basic.scope}), except as specified in~\ref{temp.class.spec}.
+type in the same scope\iref{basic.scope}, except as specified in~\ref{temp.class.spec}.
 Except that a function template can be overloaded either by non-template
-functions~(\ref{dcl.fct}) with the same name or by other function templates
-with the same name~(\ref{temp.over}),
+functions\iref{dcl.fct} with the same name or by other function templates
+with the same name\iref{temp.over},
 a template name declared in namespace scope or in class scope shall be unique
 in that scope.
 
@@ -182,11 +182,11 @@ A \defn{templated entity} is
 
 \begin{itemize}
 \item a template,
-\item an entity defined~(\ref{basic.def}) or created~(\ref{class.temporary})
+\item an entity defined\iref{basic.def} or created\iref{class.temporary}
       in a templated entity,
 \item a member of a templated entity,
 \item an enumerator for an enumeration that is a templated entity, or
-\item the closure type of a \grammarterm{lambda-expression}~(\ref{expr.prim.lambda.closure})
+\item the closure type of a \grammarterm{lambda-expression}\iref{expr.prim.lambda.closure}
       appearing in the declaration of a templated entity.
 \end{itemize}
 
@@ -200,13 +200,13 @@ A \grammarterm{template-declaration} is written
 in terms of its template parameters.
 The optional \grammarterm{requires-clause} following a
 \grammarterm{template-parameter-list} allows the specification of
-constraints~(\ref{temp.constr.decl}) on template arguments~(\ref{temp.arg}).
+constraints\iref{temp.constr.decl} on template arguments\iref{temp.arg}.
 The \grammarterm{requires-clause} introduces the
 \grammarterm{constraint-expression} that results from interpreting
 the \grammarterm{constraint-logical-or-expression} as a
 \grammarterm{constraint-expression}.
 The \grammarterm{constraint-logical-or-expression} of a
-\grammarterm{requires-clause} is an unevaluated operand (Clause~\ref{expr}).
+\grammarterm{requires-clause} is an unevaluated operand\iref{expr}.
 \begin{note}
 The expression in a \grammarterm{requires-clause}
 uses a restricted grammar to avoid ambiguities.
@@ -224,8 +224,8 @@ int f();    // error: parentheses required around \tcode{==} expression
 A function template, member function of a class template, variable template,
 or static data
 member of a class template shall be defined in every translation unit in
-which it is implicitly instantiated~(\ref{temp.inst}) unless the
-corresponding specialization is explicitly instantiated~(\ref{temp.explicit})
+which it is implicitly instantiated\iref{temp.inst} unless the
+corresponding specialization is explicitly instantiated\iref{temp.explicit}
 in some translation unit; no diagnostic is required.
 
 \rSec1[temp.param]{Template parameters}
@@ -285,7 +285,7 @@ is:
 \grammarterm{type-parameter}
 may be the product of replacing a
 \tcode{>{>}} token by two consecutive \tcode{>}
-tokens~(\ref{temp.names}).\end{note}
+tokens\iref{temp.names}.\end{note}
 
 \pnum
 There is no semantic difference between
@@ -382,14 +382,14 @@ types:
 
 \item \tcode{std::nullptr_t}, or
 
-\item a type that contains a placeholder type~(\ref{dcl.spec.auto}).
+\item a type that contains a placeholder type\iref{dcl.spec.auto}.
 \end{itemize}
 
 \pnum
 \begin{note}
 Other types are disallowed either explicitly below or implicitly by
 the rules governing the form of
-\grammarterm{template-argument}{s}~(\ref{temp.arg}).
+\grammarterm{template-argument}{s}\iref{temp.arg}.
 \end{note}
 The top-level
 \grammarterm{cv-qualifier}{s}
@@ -470,7 +470,7 @@ as described below.
 A \grammarterm{constrained-parameter} declares
 a template parameter
 whose kind (type, non-type, template) and type
-match that of the prototype parameter~(\ref{temp.concept})
+match that of the prototype parameter\iref{temp.concept}
 of the concept designated by
 the \grammarterm{qualified-concept-name} in
 the \grammarterm{constrained-parameter}.
@@ -494,7 +494,7 @@ having the same \grammarterm{template-parameter-list} as \tcode{X},
 excluding default template arguments.
 
 \item If the \grammarterm{qualified-concept-name} is followed by an ellipsis,
-then the declared parameter is a template parameter pack~(\ref{temp.variadic}).
+then the declared parameter is a template parameter pack\iref{temp.variadic}.
 \end{itemize}
 
 \begin{example}
@@ -516,7 +516,7 @@ template<C5... Cs> void f6();   // OK, \tcode{Cs} is a template parameter pack o
 
 \pnum
 A \grammarterm{constrained-parameter} introduces
-a \grammarterm{constraint-expression}~(\ref{temp.constr.decl}).
+a \grammarterm{constraint-expression}\iref{temp.constr.decl}.
 The expression is derived from
 the \grammarterm{qualified-concept-name} \tcode{Q} in
 the \grammarterm{constrained-parameter},
@@ -525,8 +525,8 @@ the declared template parameter \tcode{P}.
 
 \begin{itemize}
 \item First, a template argument \tcode{A} is formed from \tcode{P}.
-If \tcode{P} declares a template parameter pack~(\ref{temp.variadic})
-and \tcode{C} is a variadic concept~(\ref{temp.concept}),
+If \tcode{P} declares a template parameter pack\iref{temp.variadic}
+and \tcode{C} is a variadic concept\iref{temp.concept},
 then \tcode{A} is the pack expansion \tcode{P...}.
 Otherwise,
 \tcode{A} is the \grammarterm{id-expression} \tcode{P}.
@@ -544,7 +544,7 @@ and \tcode{E} is \tcode{C<A, A$_1$, A$_2$, ..., A$_n$>}.
 \item Finally, if \tcode{P} declares a template parameter pack
 and \tcode{C} is not a variadic concept,
 \tcode{E} is adjusted to be the \grammarterm{fold-expression}
-\tcode{(E \&\& ...)}~(\ref{expr.prim.fold}).
+\tcode{(E \&\& ...)}\iref{expr.prim.fold}.
 \end{itemize}
 
 \tcode{E} is the introduced \grammarterm{constraint-expression}.
@@ -565,7 +565,7 @@ template<C3<int> T> struct s4;  // associates \tcode{C3<T, int>}
 A
 \defnx{default template-argument}{\idxgram{template-argument}!default}
 is a
-\grammarterm{template-argument}~(\ref{temp.arg}) specified after
+\grammarterm{template-argument}\iref{temp.arg} specified after
 \tcode{=}
 in a
 \grammarterm{template-parameter}.
@@ -574,7 +574,7 @@ A default
 may be specified for any kind of
 \grammarterm{template-parameter}
 (type, non-type, template)
-that is not a template parameter pack~(\ref{temp.variadic}).
+that is not a template parameter pack\iref{temp.variadic}.
 A default
 \grammarterm{template-argument}
 may be specified in a template declaration.
@@ -618,7 +618,7 @@ The set of default
 \grammarterm{template-argument}{s}
 available for use is obtained by merging the default arguments
 from all prior declarations of the template in the
-same way default function arguments are~(\ref{dcl.fct.default}).
+same way default function arguments are\iref{dcl.fct.default}.
 \begin{example}
 
 \begin{codeblock}
@@ -650,9 +650,9 @@ is a template parameter pack, it shall be the last
 A template parameter pack of a function template shall not be followed by
 another
 template parameter unless that template parameter can be deduced from the
-parameter-type-list~(\ref{dcl.fct}) of the function template or has a
-default argument~(\ref{temp.deduct}).
-A template parameter of a deduction guide template~(\ref{temp.deduct.guide})
+parameter-type-list\iref{dcl.fct} of the function template or has a
+default argument\iref{temp.deduct}.
+A template parameter of a deduction guide template\iref{temp.deduct.guide}
 that does not have a default argument
 shall be deducible
 from the parameter-type-list
@@ -736,8 +736,8 @@ If a \grammarterm{template-parameter} is a
 \grammarterm{type-parameter} with an ellipsis prior to its
 optional \grammarterm{identifier} or is a
 \grammarterm{parameter-declaration} that declares a parameter
-pack~(\ref{dcl.fct}), then the \grammarterm{template-parameter}
-is a template parameter pack~(\ref{temp.variadic}).
+pack\iref{dcl.fct}, then the \grammarterm{template-parameter}
+is a template parameter pack\iref{temp.variadic}.
 A template parameter pack that is a \grammarterm{parameter-declaration} whose type
 contains one or more unexpanded parameter packs is a pack expansion. Similarly,
 a template parameter pack that is a \grammarterm{type-parameter} with a
@@ -763,7 +763,7 @@ template<class... T, T... Values> struct static_array;// error: \tcode{Values} e
 \rSec1[temp.names]{Names of template specializations}
 
 \pnum
-A template specialization~(\ref{temp.spec}) can be referred to by a
+A template specialization\iref{temp.spec} can be referred to by a
 \grammarterm{template-id}:
 
 \begin{bnf}
@@ -797,7 +797,7 @@ A template specialization~(\ref{temp.spec}) can be referred to by a
 \end{bnf}
 
 \begin{note}
-The name lookup rules~(\ref{basic.lookup}) are used to associate the use of
+The name lookup rules\iref{basic.lookup} are used to associate the use of
 a name with a template declaration;
 that is, to identify a name as a
 \grammarterm{template-name}.
@@ -811,7 +811,7 @@ the name must be known to refer to a template.
 
 \pnum
 \indextext{\idxcode{<}!template and}%
-After name lookup~(\ref{basic.lookup}) finds that a name is a
+After name lookup\iref{basic.lookup} finds that a name is a
 \grammarterm{template-name}
 or that an \grammarterm{operator-function-id} or a \grammarterm{literal-operator-id} refers to a set of
 overloaded functions any member of which is a function template,
@@ -860,19 +860,19 @@ a \grammarterm{qualified-id}
 if it appears outside of a \grammarterm{template-argument-list} or
 \grammarterm{decltype-specifier}.
 In a \grammarterm{qualified-id} of a \grammarterm{declarator-id} or
-in a \grammarterm{qualified-id} formed by a \grammarterm{class-head-name} (Clause~\ref{class}) or
-\grammarterm{enum-head-name}~(\ref{dcl.enum}),
+in a \grammarterm{qualified-id} formed by a \grammarterm{class-head-name}\iref{class} or
+\grammarterm{enum-head-name}\iref{dcl.enum},
 the keyword \tcode{template} shall not appear at the top level.
 In a \grammarterm{qualified-id} used as the name in a
-\grammarterm{typename-specifier}~(\ref{temp.res}),
-\grammarterm{elaborated-type-specifier}~(\ref{dcl.type.elab}),
-\grammarterm{using-declaration}~(\ref{namespace.udecl}), or
-\grammarterm{class-or-decltype} (Clause~\ref{class.derived}),
+\grammarterm{typename-specifier}\iref{temp.res},
+\grammarterm{elaborated-type-specifier}\iref{dcl.type.elab},
+\grammarterm{using-declaration}\iref{namespace.udecl}, or
+\grammarterm{class-or-decltype}\iref{class.derived},
 an optional keyword \tcode{template} appearing at the top level is ignored.
 In these contexts, a \tcode{<} token is always assumed to introduce a
 \grammarterm{template-argument-list}.
 In all other contexts, when naming a template specialization of
-a member of an unknown specialization~(\ref{temp.dep.type}),
+a member of an unknown specialization\iref{temp.dep.type},
 the member template name shall be prefixed by the keyword \tcode{template}.
 \begin{example}
 
@@ -945,7 +945,7 @@ A
 \grammarterm{simple-template-id}
 that names a class template specialization is a
 \grammarterm{class-name}
-(Clause~\ref{class}).
+(\ref{class}).
 
 \pnum
 A \grammarterm{template-id} that names an alias template
@@ -959,14 +959,14 @@ or
 a constrained template \grammarterm{template-parameter},
 %%% FIXME: Do we need to say this?
 but not a member template
-that is a member of an unknown specialization~(\ref{temp.res}),
+that is a member of an unknown specialization\iref{temp.res},
 and
 all \grammarterm{template-argument}{s}
 in the \grammarterm{simple-template-id}
-are non-dependent~(\ref{temp.dep.temp}),
-the associated constraints~(\ref{temp.constr.decl})
+are non-dependent\iref{temp.dep.temp},
+the associated constraints\iref{temp.constr.decl}
 of the constrained template
-shall be satisfied~(\ref{temp.constr.constr}).
+shall be satisfied\iref{temp.constr.constr}.
 \begin{example}
 \begin{codeblock}
 template<typename T> concept C1 = sizeof(T) != sizeof(int);
@@ -1016,7 +1016,7 @@ shall match the type and form specified for the corresponding
 parameter declared by the template in its
 \grammarterm{template-parameter-list}.
 When the parameter declared by the template is a template
-parameter pack~(\ref{temp.variadic}), it will correspond to zero or more
+parameter pack\iref{temp.variadic}, it will correspond to zero or more
 \grammarterm{template-argument}{s}.
 \begin{example}
 \begin{codeblock}
@@ -1142,7 +1142,7 @@ Tuple* u;                       // syntax error
 \end{example}
 
 \pnum
-An explicit destructor call~(\ref{class.dtor}) for an object that has a type
+An explicit destructor call\iref{class.dtor} for an object that has a type
 that is a class template specialization may explicitly specify the
 \grammarterm{template-argument}{s}.
 \begin{example}
@@ -1181,7 +1181,7 @@ the program is ill-formed.
 \pnum
 When a \grammarterm{simple-template-id} does not name a function,
 a default \grammarterm{template-argument} is
-implicitly instantiated~(\ref{temp.inst})
+implicitly instantiated\iref{temp.inst}
 when the value of that default argument is needed.
 \begin{example}
 \begin{codeblock}
@@ -1193,7 +1193,7 @@ The default argument for \tcode{U} is instantiated to form the type \tcode{S<boo
 
 \pnum
 A \grammarterm{template-argument} followed by an ellipsis is
-a pack expansion~(\ref{temp.variadic}).
+a pack expansion\iref{temp.variadic}.
 
 \rSec2[temp.arg.type]{Template type arguments}
 
@@ -1228,7 +1228,7 @@ void f() {
 \end{codeblock}
 \end{example}
 \begin{note}
-A template type argument may be an incomplete type~(\ref{basic.types}).
+A template type argument may be an incomplete type\iref{basic.types}.
 \end{note}
 
 \rSec2[temp.arg.nontype]{Template non-type arguments}
@@ -1238,9 +1238,9 @@ If the type of a \grammarterm{template-parameter}
 contains a placeholder type~(\ref{dcl.spec.auto}, \ref{temp.param}),
 the deduced parameter type is determined
 from the type of the \grammarterm{template-argument}
-by placeholder type deduction~(\ref{dcl.type.auto.deduct}).
+by placeholder type deduction\iref{dcl.type.auto.deduct}.
 If a deduced parameter type is not permitted
-for a \grammarterm{template-parameter} declaration~(\ref{temp.param}),
+for a \grammarterm{template-parameter} declaration\iref{temp.param},
 the program is ill-formed.
 
 \pnum
@@ -1250,25 +1250,25 @@ for a non-type
 \grammarterm{template-parameter}
 shall be
 a converted
-constant expression~(\ref{expr.const})
+constant expression\iref{expr.const}
 of the type of the \grammarterm{template-parameter}.
 For a non-type \grammarterm{template-parameter} of reference or pointer type,
 the value of the constant expression shall not refer to
 (or for a pointer type, shall not be the address of):
 
 \begin{itemize}
-\item a subobject~(\ref{intro.object}),
-\item a temporary object~(\ref{class.temporary}),
-\item a string literal~(\ref{lex.string}),
-\item the result of a \tcode{typeid} expression~(\ref{expr.typeid}), or
-\item a predefined \tcode{__func__} variable~(\ref{dcl.fct.def.general}).
+\item a subobject\iref{intro.object},
+\item a temporary object\iref{class.temporary},
+\item a string literal\iref{lex.string},
+\item the result of a \tcode{typeid} expression\iref{expr.typeid}, or
+\item a predefined \tcode{__func__} variable\iref{dcl.fct.def.general}.
 \end{itemize}
 
 \begin{note}
 If the \grammarterm{template-argument}
 represents a set of overloaded functions
 (or a pointer or member pointer to such),
-the matching function is selected from the set~(\ref{over.over}).
+the matching function is selected from the set\iref{over.over}.
 \end{note}
 
 \pnum
@@ -1303,7 +1303,7 @@ B<2.5> b3;                      // error: template parameter type cannot be \tco
 
 \pnum
 \begin{note}
-A string literal~(\ref{lex.string})
+A string literal\iref{lex.string}
 is not an acceptable
 \grammarterm{template-argument}.
 \begin{example}
@@ -1378,7 +1378,7 @@ considered even if their parameter lists match that of the template template
 parameter.
 
 \pnum
-Any partial specializations~(\ref{temp.class.spec}) associated with the
+Any partial specializations\iref{temp.class.spec} associated with the
 primary class template or primary variable template are considered when a
 specialization based on the template
 \grammarterm{template-parameter}
@@ -1413,10 +1413,10 @@ matches the corresponding template parameter in the
 \grammarterm{template-parameter-list} of \tcode{P}.
 Two template parameters match if they are of the same kind (type, non-type, template),
 for non-type \grammarterm{template-parameter}{s}, their types are
-equivalent~(\ref{temp.over.link}), and for template \grammarterm{template-parameter}{s},
+equivalent\iref{temp.over.link}, and for template \grammarterm{template-parameter}{s},
 each of their corresponding \grammarterm{template-parameter}{s} matches, recursively.
 When \tcode{P}'s \grammarterm{template-parameter-list} contains a template parameter
-pack~(\ref{temp.variadic}), the template parameter pack will match zero or more template
+pack\iref{temp.variadic}, the template parameter pack will match zero or more template
 parameters or template parameter packs in the \grammarterm{template-parameter-list} of
 \tcode{A} with the same type and form as the template parameter pack in \tcode{P}
 (ignoring whether those template parameters are template parameter packs).
@@ -1485,7 +1485,7 @@ the function template corresponding to \tcode{P}
 is at least as specialized as
 the function template corresponding to \tcode{A}
 according to the partial ordering rules
-for function templates~(\ref{temp.func.order}).
+for function templates\iref{temp.func.order}.
 Given an invented class template \tcode{X}
 with the template parameter list of \tcode{A} (including default arguments):
 
@@ -1502,7 +1502,7 @@ for each template parameter \tcode{PP}
 in the template parameter list of the function template,
 a corresponding template argument \tcode{AA} is formed.
 If \tcode{PP} declares a parameter pack,
-then \tcode{AA} is the pack expansion \tcode{PP...}~(\ref{temp.variadic});
+then \tcode{AA} is the pack expansion \tcode{PP...}\iref{temp.variadic};
 otherwise, \tcode{AA} is the \grammarterm{id-expression} \tcode{PP}.
 \end{itemize}
 If the rewrite produces an invalid type,
@@ -1516,7 +1516,7 @@ This section defines the meaning of constraints on template arguments.
 The abstract syntax and satisfaction rules are defined
 in \ref{temp.constr.constr}.
 Constraints are associated with declarations in \ref{temp.constr.decl}.
-Declarations are partially ordered by their associated constraints~(\ref{temp.constr.order}).
+Declarations are partially ordered by their associated constraints\iref{temp.constr.order}.
 \end{note}
 
 \rSec2[temp.constr.constr]{Constraints}
@@ -1527,22 +1527,22 @@ operands that specifies requirements on template arguments.
 The operands of a logical operation are constraints.
 There are three different kinds of constraints:
 \begin{itemize}
-\item conjunctions~(\ref{temp.constr.op}),
-\item disjunctions~(\ref{temp.constr.op}), and
-\item atomic constraints~(\ref{temp.constr.atomic})
+\item conjunctions\iref{temp.constr.op},
+\item disjunctions\iref{temp.constr.op}, and
+\item atomic constraints\iref{temp.constr.atomic}
 \end{itemize}
 
 \pnum
-In order for a constrained template to be instantiated~(\ref{temp.spec}),
-its associated constraints~(\ref{temp.constr.decl})
+In order for a constrained template to be instantiated\iref{temp.spec},
+its associated constraints\iref{temp.constr.decl}
 shall be satisfied as described in the following subsections.
 \begin{note}
 Forming the name of a specialization of
 a class template,
 a variable template, or
-an alias template~(\ref{temp.names})
+an alias template\iref{temp.names}
 requires the satisfaction of its constraints.
-Overload resolution~(\ref{over.match.viable})
+Overload resolution\iref{over.match.viable}
 requires the satisfaction of constraints
 on functions and function templates.
 \end{note}
@@ -1599,7 +1599,7 @@ void f(int);
 
 f('a'); // OK: calls \tcode{f(int)}
 \end{codeblock}
-In the satisfaction of the associated constraints~(\ref{temp.constr.decl})
+In the satisfaction of the associated constraints\iref{temp.constr.decl}
 of \tcode{f}, the constraint \tcode{sizeof(char) > 1} is not satisfied;
 the second operand is not checked for satisfaction.
 \end{example}
@@ -1613,11 +1613,11 @@ and a mapping from the template parameters
 that appear within \tcode{E} to
 template arguments involving the
 template parameters of the constrained entity,
-called the \defn{parameter mapping}~(\ref{temp.constr.decl}).
+called the \defn{parameter mapping}\iref{temp.constr.decl}.
 \begin{note}
-Atomic constraints are formed by constraint normalization~(\ref{temp.constr.normal}).
-\tcode{E} is never a logical AND expression~(\ref{expr.log.and})
-nor a logical OR expression~(\ref{expr.log.or}).
+Atomic constraints are formed by constraint normalization\iref{temp.constr.normal}.
+\tcode{E} is never a logical AND expression\iref{expr.log.and}
+nor a logical OR expression\iref{expr.log.or}.
 \end{note}
 
 \pnum
@@ -1636,7 +1636,7 @@ the parameter mapping and template arguments are
 first substituted into its expression.
 If substitution results in an invalid type or expression,
 the constraint is not satisfied.
-Otherwise, the lvalue-to-rvalue conversion~(\ref{conv.lval})
+Otherwise, the lvalue-to-rvalue conversion\iref{conv.lval}
 is performed if necessary,
 and \tcode{E} shall be a constant expression of type \tcode{bool}.
 The constraint is satisfied if and only if evaluation of \tcode{E}
@@ -1665,8 +1665,8 @@ void g() {
 \rSec2[temp.constr.decl]{Constrained declarations}
 
 \pnum
-A template declaration (Clause~\ref{temp})
-or function declaration~(\ref{dcl.fct})
+A template declaration\iref{temp}
+or function declaration\iref{dcl.fct}
 can be constrained by the use of a \grammarterm{requires-clause}.
 This allows the specification of constraints for that declaration as
 an expression:
@@ -1692,35 +1692,35 @@ A template's \defn{associated constraints} are defined as follows:
 the declaration has no associated constraints.
 
 \item Otherwise, if there is a single introduced \grammarterm{constraint-expression},
-the associated constraints are the normal form~(\ref{temp.constr.normal})
+the associated constraints are the normal form\iref{temp.constr.normal}
 of that expression.
 
 \item Otherwise, the associated constraints are the normal form of a logical
-AND expression~(\ref{expr.log.and}) whose operands are in the
+AND expression\iref{expr.log.and} whose operands are in the
 following order:
 
 \begin{itemize}
 \item
 the \grammarterm{constraint-expression} introduced by each
-\grammarterm{constrained-parameter}~(\ref{temp.param}) in the
+\grammarterm{constrained-parameter}\iref{temp.param} in the
 declaration's \grammarterm{template-parameter-list}, in
 order of appearance, and
 
 \item
 the \grammarterm{constraint-expression} introduced
 by a \grammarterm{requires-clause} following a
-\grammarterm{template-parameter-list} (Clause~\ref{temp}), and
+\grammarterm{template-parameter-list}\iref{temp}, and
 
 \item
 the \grammarterm{constraint-expression} introduced by a trailing
-\grammarterm{requires-clause} (Clause~\ref{dcl.decl})
-of a function declaration~(\ref{dcl.fct}).
+\grammarterm{requires-clause}\iref{dcl.decl}
+of a function declaration\iref{dcl.fct}.
 \end{itemize}
 \end{itemize}
 
 The formation of the associated constraints
 establishes the order in which constraints are instantiated when checking
-for satisfaction~(\ref{temp.constr.constr}).
+for satisfaction\iref{temp.constr.constr}.
 \begin{example}
 \begin{codeblock}
 template<typename T> concept C = true;
@@ -1757,7 +1757,7 @@ and those of
 
 \pnum
 The \defn{normal form} of an \grammarterm{expression} \tcode{E} is
-a constraint~(\ref{temp.constr.constr}) that is defined as follows:
+a constraint\iref{temp.constr.constr} that is defined as follows:
 %
 \begin{itemize}
 \item
@@ -1766,7 +1766,7 @@ the normal form of \tcode{E}.
 
 \item
 The normal form of an expression \tcode{E1 || E2} is
-the disjunction~(\ref{temp.constr.op}) of
+the disjunction\iref{temp.constr.op} of
 the normal forms of \tcode{E1} and \tcode{E2}.
 
 \item
@@ -1817,11 +1817,11 @@ is called
 \begin{note}
 Normalization of \grammarterm{constraint-expression}{s}
 is performed
-when determining the associated constraints~(\ref{temp.constr.constr})
+when determining the associated constraints\iref{temp.constr.constr}
 of a declaration
 and
 when evaluating the value of an \grammarterm{id-expression}
-that names a concept specialization~(\ref{expr.prim.id}).
+that names a concept specialization\iref{expr.prim.id}.
 \end{note}
 
 \pnum
@@ -1851,12 +1851,12 @@ The associated constraints of \#3 are
 \pnum
 A constraint $P$ is said to subsume another constraint $Q$
 if it can be determined that $P$ implies $Q$, up to
-the identity~(\ref{temp.constr.atomic})
+the identity\iref{temp.constr.atomic}
 of atomic constraints in $P$ and $Q$,
 as described below.
 \begin{example}
 Subsumption does not determine if the atomic constraint
-\tcode{N >= 0}~(\ref{temp.constr.atomic}) subsumes \tcode{N > 0} for some
+\tcode{N >= 0}\iref{temp.constr.atomic} subsumes \tcode{N > 0} for some
 integral template argument \tcode{N}.
 \end{example}
 
@@ -1906,7 +1906,7 @@ rules described in \ref{temp.constr.atomic}.
 \end{itemize}
 %
 \begin{example}
-Let $A$ and $B$ be atomic constraints~(\ref{temp.constr.atomic}).
+Let $A$ and $B$ be atomic constraints\iref{temp.constr.atomic}.
 %
 The constraint $A \land B$ subsumes $A$, but $A$ does not subsume $A \land B$.
 %
@@ -1921,11 +1921,11 @@ The subsumption relation defines a partial ordering on constraints.
 This partial ordering is used to determine
 
 \begin{itemize}
-\item the best viable candidate of non-template functions~(\ref{over.match.best}),
-\item the address of a non-template function~(\ref{over.over}),
-\item the matching of template template arguments~(\ref{temp.arg.template}),
-\item the partial ordering of class template specializations~(\ref{temp.class.order}), and
-\item the partial ordering of function templates~(\ref{temp.func.order}).
+\item the best viable candidate of non-template functions\iref{over.match.best},
+\item the address of a non-template function\iref{over.over},
+\item the matching of template template arguments\iref{temp.arg.template},
+\item the partial ordering of class template specializations\iref{temp.class.order}, and
+\item the partial ordering of function templates\iref{temp.func.order}.
 \end{itemize}
 \end{note}
 
@@ -2036,11 +2036,11 @@ declares \tcode{y} and \tcode{z} to be of the same type.
 \end{example}
 
 \pnum
-If an expression $e$ is type-dependent~(\ref{temp.dep.expr}),
+If an expression $e$ is type-dependent\iref{temp.dep.expr},
 \tcode{decltype($e$)}
 denotes a unique dependent type. Two such \grammarterm{decltype-specifier}{s}
 refer to the same type only if their \grammarterm{expression}{s} are
-equivalent~(\ref{temp.over.link}).
+equivalent\iref{temp.over.link}.
 \begin{note} However, such a type may be aliased,
 e.g., by a \grammarterm{typedef-name}. \end{note}
 
@@ -2062,14 +2062,14 @@ template<class T1, int I> void sort<T1, I>(T1 data[I]);         // error
 \end{codeblock}
 \end{example}
 \begin{note}
-However, this syntax is allowed in class template partial specializations~(\ref{temp.class.spec}).
+However, this syntax is allowed in class template partial specializations\iref{temp.class.spec}.
 \end{note}
 
 \pnum
 For purposes of name lookup and instantiation,
 default arguments,
 \grammarterm{partial-concept-id}{s},
-\grammarterm{requires-clause}{s} (Clause~\ref{temp}),
+\grammarterm{requires-clause}{s}\iref{temp},
 and
 \grammarterm{noexcept-specifier}{s}
 of function templates
@@ -2092,7 +2092,7 @@ default arguments
 or
 \grammarterm{noexcept-specifier}{s}.
 For the purpose of instantiation, the substatements of a constexpr if
-statement~(\ref{stmt.if}) are considered definitions.
+statement\iref{stmt.if} are considered definitions.
 
 \pnum
 Because an \grammarterm{alias-declaration} cannot declare a
@@ -2144,7 +2144,7 @@ a member template of a class
 template is defined outside of the class template definition,
 the member definition is defined as a template definition in which the
 \grammarterm{template-head} is equivalent to that
-of the class template~(\ref{temp.over.link}).
+of the class template\iref{temp.over.link}.
 The names of the template parameters used in the definition of the member may
 be different from the template parameter names used in the class
 template definition.
@@ -2202,7 +2202,7 @@ specialization,
 explicit specialization or explicit
 instantiation of a class template, the
 \grammarterm{class-key}
-shall agree in kind with the original class template declaration~(\ref{dcl.type.elab}).
+shall agree in kind with the original class template declaration\iref{dcl.type.elab}.
 
 \rSec3[temp.mem.func]{Member functions of class templates}
 
@@ -2284,7 +2284,7 @@ A member class of a class template may be defined outside the class template
 definition in which it is declared.
 \begin{note}
 The member class must be defined before its first use that requires
-an instantiation~(\ref{temp.inst}).
+an instantiation\iref{temp.inst}.
 For example,
 
 \begin{codeblock}
@@ -2363,7 +2363,7 @@ template definition shall be specified with
 a \grammarterm{template-head} equivalent to that
 of the class template followed by
 a \grammarterm{template-head} equivalent to that
-of the member template~(\ref{temp.over.link}).
+of the member template\iref{temp.over.link}.
 \begin{example}
 \begin{codeblock}
 template<class T> struct string {
@@ -2394,11 +2394,11 @@ void S<T>::g(U) { }     // error: no matching function in \tcode{S<T>}
 
 \pnum
 A local class of non-closure type shall not have member templates.
-Access control rules (Clause~\ref{class.access})
+Access control rules\iref{class.access}
 apply to member template names.
 A destructor shall not be a member
 template.
-A non-template member function~(\ref{dcl.fct}) with a given name
+A non-template member function\iref{dcl.fct} with a given name
 and type and a member function template of the same name, which could be
 used to generate a specialization of the same type, can both be
 declared in a class.
@@ -2494,7 +2494,7 @@ conversion function templates
 visible in the
 context of the use are considered.
 For each such operator, if argument
-deduction succeeds~(\ref{temp.deduct.conv}), the resulting specialization is
+deduction succeeds\iref{temp.deduct.conv}, the resulting specialization is
 used as if found by name lookup.
 
 \pnum
@@ -2504,8 +2504,8 @@ conversion function template
 in a base class.
 
 \pnum
-Overload resolution~(\ref{over.ics.rank}) and partial
-ordering~(\ref{temp.func.order}) are used to select the best conversion function
+Overload resolution\iref{over.ics.rank} and partial
+ordering\iref{temp.func.order} are used to select the best conversion function
 among multiple
 specializations of conversion function templates
 and/or non-template
@@ -2556,13 +2556,13 @@ depends on the context in which the expansion occurs. Pack
 expansions can occur in the following contexts:
 
 \begin{itemize}
-\item In a function parameter pack~(\ref{dcl.fct}); the pattern is the
+\item In a function parameter pack\iref{dcl.fct}; the pattern is the
 \grammarterm{parameter-declaration} without the ellipsis.
 
-\item In a \grammarterm{using-declaration}~(\ref{namespace.udecl});
+\item In a \grammarterm{using-declaration}\iref{namespace.udecl};
 the pattern is a \grammarterm{using-declarator}.
 
-\item In a template parameter pack that is a pack expansion~(\ref{temp.param}):
+\item In a template parameter pack that is a pack expansion\iref{temp.param}:
 
 \begin{itemize}
 \item if the template parameter pack is a \grammarterm{parameter-declaration};
@@ -2573,32 +2573,32 @@ the pattern is the \grammarterm{parameter-declaration} without the ellipsis;
 \grammarterm{type-parameter} without the ellipsis.
 \end{itemize}
 
-\item In an \grammarterm{initializer-list}~(\ref{dcl.init});
+\item In an \grammarterm{initializer-list}\iref{dcl.init};
 the pattern is an \grammarterm{initializer-clause}.
 
-\item In a \grammarterm{base-specifier-list} (Clause~\ref{class.derived});
+\item In a \grammarterm{base-specifier-list}\iref{class.derived};
 the pattern is a \grammarterm{base-specifier}.
 
-\item In a \grammarterm{mem-initializer-list}~(\ref{class.base.init}) for a
+\item In a \grammarterm{mem-initializer-list}\iref{class.base.init} for a
 \grammarterm{mem-initializer} whose \grammarterm{mem-initializer-id} denotes a
 base class; the pattern is the \grammarterm{mem-initializer}.
 
-\item In a \grammarterm{template-argument-list}~(\ref{temp.arg});
+\item In a \grammarterm{template-argument-list}\iref{temp.arg};
 the pattern is a \grammarterm{template-argument}.
 
-\item In an \grammarterm{attribute-list}~(\ref{dcl.attr.grammar}); the pattern is
+\item In an \grammarterm{attribute-list}\iref{dcl.attr.grammar}; the pattern is
 an \grammarterm{attribute}.
 
-\item In an \grammarterm{alignment-specifier}~(\ref{dcl.align}); the pattern is
+\item In an \grammarterm{alignment-specifier}\iref{dcl.align}; the pattern is
 the \grammarterm{alignment-specifier} without the ellipsis.
 
-\item In a \grammarterm{capture-list}~(\ref{expr.prim.lambda}); the pattern is
+\item In a \grammarterm{capture-list}\iref{expr.prim.lambda}; the pattern is
 a \grammarterm{capture}.
 
-\item In a \tcode{sizeof...} expression~(\ref{expr.sizeof}); the pattern is an
+\item In a \tcode{sizeof...} expression\iref{expr.sizeof}; the pattern is an
 \grammarterm{identifier}.
 
-\item In a \grammarterm{fold-expression}~(\ref{expr.prim.fold});
+\item In a \grammarterm{fold-expression}\iref{expr.prim.fold};
 the pattern is the \grammarterm{cast-expression}
 that contains an unexpanded parameter pack.
 \end{itemize}
@@ -2673,7 +2673,7 @@ follows:
 \begin{itemize}
 \item
 if the pack is a template parameter pack, the element is a template
-parameter~(\ref{temp.param}) of the corresponding kind (type or
+parameter\iref{temp.param} of the corresponding kind (type or
 non-type) designating the type or value from the template
 argument; otherwise,
 
@@ -2706,7 +2706,7 @@ template void f<>();    // OK: \tcode{X<>} has no base classes
 \end{example}
 
 \pnum
-The instantiation of a \tcode{sizeof...} expression~(\ref{expr.sizeof}) produces
+The instantiation of a \tcode{sizeof...} expression\iref{expr.sizeof} produces
 an integral constant containing the number of elements in the parameter pack
 it expands.
 
@@ -2801,7 +2801,7 @@ if the name of the friend is a \grammarterm{qualified-id} and a matching
 function template
 is found in the specified class
 or namespace, the friend declaration refers to
-the deduced specialization of that function template~(\ref{temp.deduct.decl}), otherwise,
+the deduced specialization of that function template\iref{temp.deduct.decl}, otherwise,
 \item
 the name shall be an \grammarterm{unqualified-id} that declares (or redeclares) a
 non-template function.
@@ -2882,8 +2882,8 @@ class A {
 
 \pnum
 A template friend declaration specifies that all specializations of that
-template, whether they are implicitly instantiated~(\ref{temp.inst}), partially
-specialized~(\ref{temp.class.spec}) or explicitly specialized~(\ref{temp.expl.spec}),
+template, whether they are implicitly instantiated\iref{temp.inst}, partially
+specialized\iref{temp.class.spec} or explicitly specialized\iref{temp.expl.spec},
 are friends of the class containing the template friend declaration.
 \begin{example}
 \begin{codeblock}
@@ -2943,7 +2943,7 @@ class C {
 
 \pnum
 \begin{note}
-A friend declaration may first declare a member of an enclosing namespace scope~(\ref{temp.inject}).
+A friend declaration may first declare a member of an enclosing namespace scope\iref{temp.inject}.
 \end{note}
 
 \pnum
@@ -2988,7 +2988,7 @@ of the class template named in the
 A partial specialization of a class template provides an alternative definition
 of the template that is used instead of the primary definition when the
 arguments in a specialization match those given in the partial
-specialization~(\ref{temp.class.spec.match}).
+specialization\iref{temp.class.spec.match}.
 The primary template shall be declared before any specializations of
 that template.
 A partial specialization shall be declared before the first use of a class template
@@ -2999,7 +2999,7 @@ occurs; no diagnostic is required.
 \pnum
 Each class template partial specialization is a distinct template and
 definitions shall be provided for the members of a template partial
-specialization~(\ref{temp.class.spec.mfunc}).
+specialization\iref{temp.class.spec.mfunc}.
 
 \pnum
 \begin{example}
@@ -3018,7 +3018,7 @@ the primary template.
 
 \pnum
 A class template partial specialization may be constrained
-(Clause~\ref{temp}).
+(\ref{temp}).
 \begin{example}
 \begin{codeblock}
 template<typename T> concept C = true;
@@ -3032,7 +3032,7 @@ Both partial specializations are more specialized than the primary template.
 from the template argument list of the class template specialization succeeds,
 while the reverse does not.
 \#2 is more specialized because the template arguments are equivalent,
-but the partial specialization is more constrained~(\ref{temp.constr.order}).
+but the partial specialization is more constrained\iref{temp.constr.order}.
 \end{example}
 
 \pnum
@@ -3140,14 +3140,14 @@ template< int X > class A<X,&array> { };        // error
 \end{example}
 \item
 The specialization shall be more specialized than the primary
-template~(\ref{temp.class.order}).
+template\iref{temp.class.order}.
 
 \item
 The template parameter list of a specialization shall not contain default
 template argument values.\footnote{There is no way in which they could be used.}
 \item
 An argument shall not contain an unexpanded parameter pack. If
-an argument is a pack expansion~(\ref{temp.variadic}), it shall be
+an argument is a pack expansion\iref{temp.variadic}, it shall be
 the last argument in the template argument list.
 \end{itemize}
 
@@ -3168,7 +3168,7 @@ If exactly one matching specialization is found, the instantiation is
 generated from that specialization.
 \item
 If more than one matching specialization is found,
-the partial order rules~(\ref{temp.class.order}) are used to determine
+the partial order rules\iref{temp.class.order} are used to determine
 whether one of the specializations is more specialized than the
 others.
 If none of the specializations is more specialized than all of the
@@ -3182,9 +3182,9 @@ primary template.
 \pnum
 A partial specialization matches a given actual template argument
 list if the template arguments of the partial specialization can be
-deduced from the actual template argument list~(\ref{temp.deduct}),
+deduced from the actual template argument list\iref{temp.deduct},
 and the deduced template arguments satisfy the associated constraints
-of the partial specialization, if any~(\ref{temp.constr.decl}).
+of the partial specialization, if any\iref{temp.constr.decl}.
 \begin{example}
 \begin{codeblock}
 template<class T1, class T2, int I> class A             { };    // \#1
@@ -3247,13 +3247,13 @@ For two class template partial specializations,
 the first is \defn{more specialized} than the second if, given the following
 rewrite to two function templates, the first function template is more
 specialized than the second according to the ordering rules for function
-templates~(\ref{temp.func.order}):
+templates\iref{temp.func.order}:
 
 \begin{itemize}
 \item
 Each of the two
 function templates has the same template parameters
-and associated constraints~(\ref{temp.constr.decl})
+and associated constraints\iref{temp.constr.decl}
 as the corresponding partial specialization.
 \item
 Each function template
@@ -3416,7 +3416,7 @@ template<class T> void sort(Array<T>&);
 
 \pnum
 A function template can be overloaded with other function templates
-and with non-template functions~(\ref{dcl.fct}).
+and with non-template functions\iref{dcl.fct}.
 A non-template function is not
 related to a function template
 (i.e., it is never considered to be a specialization),
@@ -3426,7 +3426,7 @@ declarations of non-template functions do not merely guide
 overload resolution of
 function template specializations
 with the same name.
-If such a non-template function is odr-used~(\ref{basic.def.odr}) in a program, it must be defined;
+If such a non-template function is odr-used\iref{basic.def.odr} in a program, it must be defined;
 it will not be implicitly instantiated using the function template definition.}
 
 \rSec3[temp.over.link]{Function template overloading}
@@ -3462,11 +3462,11 @@ void h(int* p) {
 
 \pnum
 Such specializations are distinct functions and do not violate the one-definition
-rule~(\ref{basic.def.odr}).
+rule\iref{basic.def.odr}.
 
 \pnum
 The signature of a function template
-is defined in Clause~\ref{intro.defs}.
+is defined in \ref{intro.defs}.
 The names of the template parameters are significant only for establishing
 the relationship between the template parameters and the rest of the
 signature.
@@ -3514,11 +3514,11 @@ For example, a template type parameter can be used in the
 Two expressions involving template parameters are considered
 \defnx{equivalent}{equivalent!expressions}
 if two function definitions containing the expressions would satisfy
-the one-definition rule~(\ref{basic.def.odr}), except that the tokens used
+the one-definition rule\iref{basic.def.odr}, except that the tokens used
 to name the template parameters may differ as long as a token used to
 name a template parameter in one expression is replaced by another token
 that names the same template parameter in the other expression. For
-determining whether two dependent names~(\ref{temp.dep}) are
+determining whether two dependent names\iref{temp.dep} are
 equivalent, only the name itself is considered, not the result of name
 lookup in the context of the template. If multiple declarations of the
 same function template differ in the result of this name lookup, the
@@ -3570,7 +3570,7 @@ are equivalent, the rules above are used to compare expressions
 involving template parameters.
 Two \grammarterm{template-head}{s} are
 \defnx{functionally equivalent}{functionally equivalent!\idxgram{template-head}{s}}
-if they accept and are satisfied by~(\ref{temp.constr.constr})
+if they accept and are satisfied by\iref{temp.constr.constr}
 the same set of template argument lists.
 
 \pnum
@@ -3636,7 +3636,7 @@ template <int I> void f(A<I>, A<I+1+2+3+4>);
 \indextext{ordering!function template partial|see{template, function, partial ordering}}%
 If a function template is overloaded,
 the use of a function template specialization might be ambiguous because
-template argument deduction~(\ref{temp.deduct}) may associate the function
+template argument deduction\iref{temp.deduct} may associate the function
 template specialization with more than one function template declaration.
 \defnx{Partial ordering}{template!function!partial ordering}
 of overloaded function template declarations is used in the following contexts
@@ -3645,7 +3645,7 @@ refers:
 
 \begin{itemize}
 \item
-during overload resolution for a call to a function template specialization~(\ref{over.match.best});
+during overload resolution for a call to a function template specialization\iref{over.match.best};
 \item
 when the address of a function template specialization is taken;
 \item
@@ -3654,8 +3654,8 @@ function template
 specialization
 is selected to match a placement operator new~(\ref{basic.stc.dynamic.deallocation}, \ref{expr.new});
 \item
-when a friend function declaration~(\ref{temp.friend}), an
-explicit instantiation~(\ref{temp.explicit}) or an explicit specialization~(\ref{temp.expl.spec}) refers to
+when a friend function declaration\iref{temp.friend}, an
+explicit instantiation\iref{temp.explicit} or an explicit specialization\iref{temp.expl.spec} refers to
 a function template specialization.
 \end{itemize}
 
@@ -3674,7 +3674,7 @@ the more constrained template as described by the rules in
 
 \pnum
 To produce the transformed template, for each type, non-type, or template
-template parameter (including template parameter packs~(\ref{temp.variadic})
+template parameter (including template parameter packs\iref{temp.variadic}
 thereof) synthesize a unique type, value, or class template
 respectively and substitute it for each occurrence of that parameter
 in the function type of the template.
@@ -3802,7 +3802,7 @@ void h(int i) {
 
 \pnum
 A \grammarterm{template-declaration} in which the \grammarterm{declaration} is an
-\grammarterm{alias-declaration} (Clause~\ref{dcl.dcl}) declares the
+\grammarterm{alias-declaration}\iref{dcl.dcl} declares the
 \grammarterm{identifier} to be an \defn{alias template}.
 An alias template is a name for a family of
 types. The name of the alias template is a \grammarterm{template-name}.
@@ -3896,20 +3896,20 @@ T f2(T x) { return x; }
 
 \pnum
 A \grammarterm{concept-definition}
-shall appear at namespace scope~(\ref{basic.scope.namespace}).
+shall appear at namespace scope\iref{basic.scope.namespace}.
 
 \pnum
-A concept shall not have associated constraints~(\ref{temp.constr.decl}).
+A concept shall not have associated constraints\iref{temp.constr.decl}.
 
 \pnum
-A concept is not instantiated~(\ref{temp.spec}).
+A concept is not instantiated\iref{temp.spec}.
 A program that
-explicitly instantiates~(\ref{temp.explicit}),
-explicitly specializes~(\ref{temp.expl.spec}),
+explicitly instantiates\iref{temp.explicit},
+explicitly specializes\iref{temp.expl.spec},
 or partially specializes a concept is ill-formed.
 \begin{note}
 An \grammarterm{id-expression} that denotes a concept specialization
-is evaluated as an expression~(\ref{expr.prim.id}).
+is evaluated as an expression\iref{expr.prim.id}.
 \end{note}
 
 \pnum
@@ -3933,7 +3933,7 @@ The name of the template itself,
 and names declared within the template itself.
 \item
 Names dependent on a
-\grammarterm{template-parameter}~(\ref{temp.dep}).
+\grammarterm{template-parameter}\iref{temp.dep}.
 \item
 Names from scopes which are visible within the template definition.
 \end{itemize}
@@ -3975,7 +3975,7 @@ template<class T> class Y {
 
 \pnum
 When a \grammarterm{qualified-id} is intended to refer to a type
-that is not a member of the current instantiation~(\ref{temp.dep.type})
+that is not a member of the current instantiation\iref{temp.dep.type}
 and its \grammarterm{nested-name-specifier}
 refers to a dependent type,
 it shall be
@@ -4002,7 +4002,7 @@ prefixed by
 does not denote a type
 or a class template,
 the specialization is ill-formed.
-The usual qualified name lookup~(\ref{basic.lookup.qual}) is used to find the
+The usual qualified name lookup\iref{basic.lookup.qual} is used to find the
 \grammarterm{qualified-id}
 even in the presence of
 \tcode{typename}.
@@ -4030,7 +4030,7 @@ void foo() {
 
 \pnum
 A qualified name used as the name in a
-\grammarterm{class-or-decltype} (Clause~\ref{class.derived})
+\grammarterm{class-or-decltype}\iref{class.derived}
 or an
 \grammarterm{elaborated-type-specifier}
 is implicitly assumed to name a type, without the use of the
@@ -4084,10 +4084,10 @@ member of a class template following the \grammarterm{declarator-id}, the keywor
 is not required when referring to the name of a previously
 declared member of the class template that declares a type
 or a class template.
-\begin{note} Such names can be found using unqualified name lookup~(\ref{basic.lookup.unqual}),
-class member lookup~(\ref{class.qual}) into the current instantiation~(\ref{temp.dep.type}),
-or class member access expression lookup~(\ref{basic.lookup.classref}) when the
-type of the object expression is the current instantiation~(\ref{temp.dep.expr}).
+\begin{note} Such names can be found using unqualified name lookup\iref{basic.lookup.unqual},
+class member lookup\iref{class.qual} into the current instantiation\iref{temp.dep.type},
+or class member access expression lookup\iref{basic.lookup.classref} when the
+type of the object expression is the current instantiation\iref{temp.dep.expr}.
 \end{note}
 \begin{example}
 
@@ -4109,7 +4109,7 @@ The program is ill-formed, no diagnostic required, if:
 \begin{itemize}
 \item
 no valid specialization can be generated for a template
-or a substatement of a constexpr if statement~(\ref{stmt.if}) within a template
+or a substatement of a constexpr if statement\iref{stmt.if} within a template
 and the template is not instantiated, or
 \item
 no substitution of template arguments
@@ -4144,7 +4144,7 @@ was a pack expansion and the corresponding pack is empty, or
 \item an instantiation uses a default argument or default template argument
 that had not been defined at the point at which the template was defined, or
 
-\item constant expression evaluation~(\ref{expr.const}) within the template
+\item constant expression evaluation\iref{expr.const} within the template
 instantiation uses
   \begin{itemize}
   \item the value of a \tcode{const} object of integral or unscoped enumeration type or
@@ -4198,7 +4198,7 @@ When looking for the declaration of a name used in a template definition,
 the usual lookup rules~(\ref{basic.lookup.unqual}, \ref{basic.lookup.argdep})
 are used for non-dependent names.
 The lookup of names dependent on the template parameters
-is postponed until the actual template argument is known~(\ref{temp.dep}).
+is postponed until the actual template argument is known\iref{temp.dep}.
 \begin{example}
 
 \begin{codeblock}
@@ -4250,7 +4250,7 @@ needed to print
 \tcode{p[i]}
 cannot be known until it is known what type
 \tcode{T}
-is~(\ref{temp.dep}).
+is\iref{temp.dep}.
 \end{example}
 
 \pnum
@@ -4289,14 +4289,14 @@ void h() {
 For purposes of name lookup, default arguments and
 \grammarterm{noexcept-specifier}{s} of function templates and default
 arguments and \grammarterm{noexcept-specifier}{s} of
-member functions of class templates are considered definitions~(\ref{temp.decls}).
+member functions of class templates are considered definitions\iref{temp.decls}.
 \end{note}
 
 \rSec2[temp.local]{Locally declared names}
 
 \pnum
 Like normal (non-template) classes, class templates have an
-injected-class-name (Clause~\ref{class}).
+injected-class-name\iref{class}.
 The
 injected-class-name can be used
 as a \grammarterm{template-name} or a \grammarterm{type-name}.
@@ -4356,7 +4356,7 @@ Third<Base<int> > t;            // OK: default argument uses injected-class-name
 \end{example}
 
 \pnum
-A lookup that finds an injected-class-name~(\ref{class.member.lookup}) can result in an ambiguity in
+A lookup that finds an injected-class-name\iref{class.member.lookup} can result in an ambiguity in
 certain cases (for example, if it is found in more than one
 base class).
 If all of the injected-class-names that are
@@ -4468,14 +4468,14 @@ template<class C> void N::B<C>::f(C) {
 \pnum
 In the definition of a class template or in the definition of a member of such
 a template that appears outside of the template definition,
-for each non-dependent base class~(\ref{temp.dep.type}),
+for each non-dependent base class\iref{temp.dep.type},
 if the name of the base class
 or the name of a member of the
 base class is the same as the name of a
 \grammarterm{template-parameter},
 the base class name or member name hides the
 \grammarterm{template-parameter}
-name~(\ref{basic.scope.hiding}).
+name\iref{basic.scope.hiding}.
 \begin{example}
 
 \begin{codeblock}
@@ -4510,7 +4510,7 @@ An expressions may be
 \defnx{type-dependent}{expression!type-dependent}
 (that is, its type may depend on a template parameter) or
 \defnx{value-dependent}{expression!value-dependent}
-(that is, its value when evaluated as a constant expression~(\ref{expr.const})
+(that is, its value when evaluated as a constant expression\iref{expr.const}
 may depend on a template parameter)
 as described in this subclause.
 In an expression of the form:
@@ -4532,14 +4532,14 @@ if
 \begin{itemize}
 \item
 any of the expressions in the \grammarterm{expression-list} is a pack
-expansion~(\ref{temp.variadic}),
+expansion\iref{temp.variadic},
 
 \item
 any of the expressions
 or \grammarterm{braced-init-list}{s}
 in the
 \grammarterm{expression-list}
-is type-dependent~(\ref{temp.dep.expr}), or
+is type-dependent\iref{temp.dep.expr}, or
 
 \item
 the \grammarterm{unqualified-id}
@@ -4550,7 +4550,7 @@ on a template parameter.
 If an operand of an operator is a type-dependent expression, the operator
 also denotes a dependent name.
 Such names are unbound and
-are looked up at the point of the template instantiation~(\ref{temp.point}) in
+are looked up at the point of the template instantiation\iref{temp.point} in
 both the context of the template definition and the
 context of the point of instantiation.
 
@@ -4580,7 +4580,7 @@ explicitly depend on the
 
 \pnum
 In the definition of a class or class template,
-the scope of a dependent base class~(\ref{temp.dep.type})
+the scope of a dependent base class\iref{temp.dep.type}
 is not examined during unqualified
 name lookup either at the point of definition of the
 class template or member or during an instantiation of
@@ -4649,7 +4649,7 @@ if it is
 \item
 in the definition of a class template, a nested class of a class template,
 a member of a class template, or a member of a nested class of a class template,
-the injected-class-name (Clause~\ref{class}) of the class template or nested class,
+the injected-class-name\iref{class} of the class template or nested class,
 \item
 in the definition of a primary class template
 or a member of a primary class template, the name of the
@@ -4668,7 +4668,7 @@ the partial specialization enclosed in
 \tcode{<>} (or an equivalent template alias specialization).
 If the \textit{n}th template parameter is
 a parameter pack, the \textit{n}th template argument is a pack
-expansion~(\ref{temp.variadic}) whose pattern is the name of
+expansion\iref{temp.variadic} whose pattern is the name of
 the parameter pack.
 \end{itemize}
 
@@ -4680,8 +4680,8 @@ template argument has the value of the
 \textit{n}th
 template parameter of the class template.
 If the \textit{n}th template parameter is a template
-parameter pack~(\ref{temp.variadic}), the \textit{n}th template argument is a pack
-expansion~(\ref{temp.variadic}) whose pattern is the name of
+parameter pack\iref{temp.variadic}, the \textit{n}th template argument is a pack
+expansion\iref{temp.variadic} whose pattern is the name of
 the template parameter pack.
 
 \pnum
@@ -4780,9 +4780,9 @@ see below. \end{note}
 
 \item
 An \grammarterm{id-expression} denoting the member in a class member access
-expression~(\ref{expr.ref}) for which the type of the object expression is the
+expression\iref{expr.ref} for which the type of the object expression is the
 current instantiation, and the \grammarterm{id-expression}, when looked
-up~(\ref{basic.lookup.classref}), refers to at least one member of a class
+up\iref{basic.lookup.classref}, refers to at least one member of a class
 that is the current
 instantiation or a non-dependent base class thereof. \begin{note} If no such
 member is found, and the current instantiation has any dependent base classes,
@@ -4831,7 +4831,7 @@ find any member of a class that is the current instantiation or a non-dependent
 base class thereof.
 
 \item An \grammarterm{id-expression} denoting the member in a class member access
-expression~(\ref{expr.ref}) in which either
+expression\iref{expr.ref} in which either
 \begin{itemize}
 \item the type of the object expression is the current instantiation, the
 current instantiation has at least one dependent base class, and name lookup
@@ -4922,11 +4922,11 @@ in which either the template name is a template parameter or any of the
 template arguments is a dependent type or an expression that is type-dependent
 or value-dependent or is a pack expansion
 \begin{note}
-This includes an injected-class-name (Clause \ref{class}) of a class template
+This includes an injected-class-name\iref{class} of a class template
 used without a \grammarterm{template-argument-list}.
 \end{note}, or
 \item denoted by \tcode{decltype(}\grammarterm{expression}{}\tcode{)},
-where \grammarterm{expression} is type-dependent~(\ref{temp.dep.expr}).
+where \grammarterm{expression} is type-dependent\iref{temp.dep.expr}.
 \end{itemize}
 
 \pnum
@@ -4946,7 +4946,7 @@ subexpression is type-dependent.
 \pnum
 \tcode{this}
 is type-dependent if the class type of the enclosing member function is
-dependent~(\ref{temp.dep.type}).
+dependent\iref{temp.dep.type}.
 
 \pnum
 An
@@ -4966,7 +4966,7 @@ an
 associated by name lookup with
 a non-type \grammarterm{template-parameter}
 declared with a type
-that contains a placeholder type~(\ref{dcl.spec.auto}),
+that contains a placeholder type\iref{dcl.spec.auto},
 
 \item
 an \grammarterm{identifier} associated by name lookup with one or more
@@ -4975,13 +4975,13 @@ with a return type that contains a placeholder type,
 
 \item
 an \grammarterm{identifier} associated by name lookup with
-a structured binding declaration~(\ref{dcl.struct.bind}) whose
+a structured binding declaration\iref{dcl.struct.bind} whose
 \grammarterm{brace-or-equal-initializer} is type-dependent,
 
 \item
 the
 \grammarterm{identifier}
-\tcode{__func__}~(\ref{dcl.fct.def.general}), where any enclosing function is a
+\tcode{__func__}\iref{dcl.fct.def.general}, where any enclosing function is a
 template, a member of a class template, or a generic lambda,
 
 \item
@@ -5004,7 +5004,7 @@ that names a member of an unknown specialization;
 
 or if it names a dependent member of the current instantiation that is a static
 data member of type
-``array of unknown bound of \tcode{T}'' for some \tcode{T}~(\ref{temp.static}).
+``array of unknown bound of \tcode{T}'' for some \tcode{T}\iref{temp.static}.
 Expressions of the following forms are type-dependent only if the type
 specified by the
 \grammarterm{type-id},
@@ -5048,7 +5048,7 @@ postfix-expression \terminal{->} pseudo-destructor-name\br
 see~\ref{support.types}.\end{note}
 
 \pnum
-A class member access expression~(\ref{expr.ref}) is
+A class member access expression\iref{expr.ref} is
 type-dependent if
 the expression refers to a member of the current instantiation and
 the type of the referenced member is dependent, or the class member access
@@ -5166,7 +5166,7 @@ An expression of the form \tcode{\&}\grammarterm{qualified-id} where the
 instantiation is value-dependent.
 An expression of the form \tcode{\&}\grammarterm{cast-expression}
 is also value-dependent if evaluating \grammarterm{cast-expression}
-as a core constant expression~(\ref{expr.const}) succeeds and
+as a core constant expression\iref{expr.const} succeeds and
 the result of the evaluation refers to a templated entity
 that is an object with static or thread storage duration or a member function.
 
@@ -5236,7 +5236,7 @@ Declarations that are visible at the point of definition of the
 template.
 \item
 Declarations from namespaces associated with the types of the
-function arguments both from the instantiation context~(\ref{temp.point})
+function arguments both from the instantiation context\iref{temp.point}
 and from the definition context.
 \end{itemize}
 
@@ -5320,7 +5320,7 @@ within a translation unit.
 A specialization for any template may have points of instantiation in multiple
 translation units.
 If two different points of instantiation give a template specialization
-different meanings according to the one-definition rule~(\ref{basic.def.odr}),
+different meanings according to the one-definition rule\iref{basic.def.odr},
 the program is ill-formed, no diagnostic required.
 
 \rSec3[temp.dep.candidate]{Candidate functions}
@@ -5334,11 +5334,11 @@ rules~(\ref{basic.lookup.unqual}, \ref{basic.lookup.argdep}) except that:
 
 \begin{itemize}
 \item
-For the part of the lookup using unqualified name lookup~(\ref{basic.lookup.unqual}),
+For the part of the lookup using unqualified name lookup\iref{basic.lookup.unqual},
 only function declarations
 from the template definition context are found.
 \item
-For the part of the lookup using associated namespaces~(\ref{basic.lookup.argdep}),
+For the part of the lookup using associated namespaces\iref{basic.lookup.argdep},
 only function declarations found in either the template
 definition context or the template instantiation context are found.
 \end{itemize}
@@ -5361,9 +5361,9 @@ instantiation.
 \pnum
 As with non-template classes, the names of namespace-scope friend
 functions of a class template specialization are not visible during
-an ordinary lookup unless explicitly declared at namespace scope~(\ref{class.friend}).
+an ordinary lookup unless explicitly declared at namespace scope\iref{class.friend}.
 Such names may be found under the rules for associated
-classes~(\ref{basic.lookup.argdep}).\footnote{Friend declarations do not
+classes\iref{basic.lookup.argdep}.\footnote{Friend declarations do not
 introduce new names into any scope, either
 when the template is declared or when it is instantiated.}
 \begin{example}
@@ -5440,10 +5440,10 @@ template<> int B<>::x = 1;              // specialize for \tcode{T == int}
 
 \pnum
 An instantiated template specialization can be either implicitly
-instantiated~(\ref{temp.inst}) for a given argument list or be explicitly
-instantiated~(\ref{temp.explicit}).
+instantiated\iref{temp.inst} for a given argument list or be explicitly
+instantiated\iref{temp.explicit}.
 A specialization is a class, function, or class member that is either
-instantiated or explicitly specialized~(\ref{temp.expl.spec}).
+instantiated or explicitly specialized\iref{temp.expl.spec}.
 
 \pnum
 For a given template and a given set of
@@ -5491,7 +5491,7 @@ of type
 
 \pnum
 If a function declaration acquired its function type through
-a dependent type~(\ref{temp.dep.type}) without using the syntactic form of
+a dependent type\iref{temp.dep.type} without using the syntactic form of
 a function declarator, the program is ill-formed.
 \begin{example}
 
@@ -5509,8 +5509,8 @@ A<function> a;      // ill-formed: would declare \tcode{A<function>::t} as a sta
 \pnum
 \indextext{instantiation!template implicit}%
 Unless a class template specialization has been explicitly
-instantiated~(\ref{temp.explicit}) or explicitly
-specialized~(\ref{temp.expl.spec}),
+instantiated\iref{temp.explicit} or explicitly
+specialized\iref{temp.expl.spec},
 the class template specialization is implicitly instantiated when the
 specialization is referenced in a context that requires a completely-defined
 object type or when the completeness of the class type affects the semantics
@@ -5539,8 +5539,8 @@ void g(D<int>* p, D<char>* pp, D<double>* ppp) {
 \end{codeblock}
 \end{example}
 If a class template has been declared, but not defined,
-at the point of instantiation~(\ref{temp.point}),
-the instantiation yields an incomplete class type~(\ref{basic.types}).
+at the point of instantiation\iref{temp.point},
+the instantiation yields an incomplete class type\iref{basic.types}.
 \begin{example}
 \begin{codeblock}
 template<class T> class X;
@@ -5549,7 +5549,7 @@ X<char> ch;         // error: incomplete type \tcode{X<char>}
 \end{example}
 \begin{note}
 Within a template declaration,
-a local class~(\ref{class.local}) or enumeration and the members of
+a local class\iref{class.local} or enumeration and the members of
 a local class are never considered to be entities that can be separately
 instantiated (this includes their default arguments,
 \grammarterm{noexcept-specifier}{s}, and non-static data member
@@ -5665,7 +5665,7 @@ variable template is implicitly instantiated when the variable template is
 referenced in a context that requires the value of the default argument.
 
 \pnum
-If the function selected by overload resolution~(\ref{over.match})
+If the function selected by overload resolution\iref{over.match}
 can be determined without instantiating a class template definition,
 it is unspecified whether that instantiation actually takes place.
 \begin{example}
@@ -5689,14 +5689,14 @@ void g(S<int>& sr) {
 \pnum
 If a function template or a member function template specialization is used in
 a way that involves overload resolution,
-a declaration of the specialization is implicitly instantiated~(\ref{temp.over}).
+a declaration of the specialization is implicitly instantiated\iref{temp.over}.
 
 \pnum
 An implementation shall not implicitly instantiate a function template,
 a variable template,
 a member template, a non-virtual member function, a member class, a
 static data member of a class template, or a substatement of a constexpr if
-statement~(\ref{stmt.if}), unless such instantiation is required.
+statement\iref{stmt.if}, unless such instantiation is required.
 It is unspecified whether or not an implementation implicitly instantiates a
 virtual member function of a class template if the virtual member function would
 not otherwise be instantiated.
@@ -5758,7 +5758,7 @@ an initializer used in a function template specialization with the same scope,
 the same template parameters and the same access as that of the function template
 \tcode{f}
 used at that point, except that the scope in which a closure type is
-declared~(\ref{expr.prim.lambda.closure}) -- and therefore its associated namespaces --
+declared\iref{expr.prim.lambda.closure} -- and therefore its associated namespaces --
 remain as determined from the context of the definition for the default
 argument.
 This analysis is called
@@ -5788,7 +5788,7 @@ void g(A a, A b, A c) {
 \pnum
 The \grammarterm{noexcept-specifier} of a function template specialization
 is not instantiated along with the function declaration; it is instantiated
-when needed~(\ref{except.spec}). If such an
+when needed\iref{except.spec}. If such an
 \grammarterm{noexcept-specifier} is needed but has not yet been
 instantiated, the dependent names are looked up, the semantics constraints are
 checked, and the instantiation of any template used in the
@@ -5802,7 +5802,7 @@ of instantiating the declaration of the specialization at that point.
 
 \pnum
 There is an \impldef{maximum depth of recursive template instantiations} quantity
-that specifies the limit on the total depth of recursive instantiations~(\ref{implimits}),
+that specifies the limit on the total depth of recursive instantiations\iref{implimits},
 which could involve more than one template.
 The result of an infinite recursion in instantiation is undefined.
 \begin{example}
@@ -5827,7 +5827,7 @@ as specified in \ref{temp.constr.decl} and \ref{temp.constr.atomic}
 when determining whether the constraints are satisfied.
 \begin{note}
 The satisfaction of constraints is determined during name lookup or overload
-resolution~(\ref{over.match}).
+resolution\iref{over.match}.
 \end{note}
 \begin{example}
 \begin{codeblock}
@@ -5846,7 +5846,7 @@ S<char[8]> s2;          // OK, calls \#2
 When \tcode{S<char>} is instantiated, both constructors are part of the
 specialization. Their constraints are not satisfied, and
 they suppress the implicit declaration of a default constructor for
-\tcode{S<char>}~(\ref{class.ctor}), so there is no viable constructor
+\tcode{S<char>}\iref{class.ctor}, so there is no viable constructor
 for \tcode{s1}.
 \end{example}
 \begin{example}
@@ -5935,7 +5935,7 @@ An explicit instantiation shall appear in an enclosing namespace
 of its template. If the name declared in the explicit
 instantiation is an unqualified name, the explicit instantiation
 shall appear in the namespace where its template is declared or, if that
-namespace is inline~(\ref{namespace.def}), any namespace from its enclosing
+namespace is inline\iref{namespace.def}, any namespace from its enclosing
 namespace set.
 \begin{note}
 Regarding qualified names in declarators, see~\ref{dcl.meaning}.
@@ -5969,7 +5969,7 @@ specialization of the entity with the same template arguments.
 If the
 \grammarterm{declaration}
 of the explicit instantiation names an implicitly-declared special member
-function (Clause~\ref{special}), the program is ill-formed.
+function\iref{special}, the program is ill-formed.
 
 \pnum
 The \grammarterm{declaration} in an \grammarterm{explicit-instantiation} and the \grammarterm{declaration} produced by the corresponding substitution into the templated function, variable, or class are two declarations of the same entity.
@@ -5987,7 +5987,7 @@ template int av<int>;        // OK, variable with type \tcode{int} can be redecl
 
 template<typename T> auto f() {}
 template void f<int>();      // error: function with deduced return type
-                             // redeclared with non-deduced return type~(\ref{dcl.spec.auto})
+                             // redeclared with non-deduced return type\iref{dcl.spec.auto}
 \end{codeblock}
 \end{example}
 \end{note}
@@ -6034,7 +6034,7 @@ A trailing
 \grammarterm{template-argument}
 can be left unspecified in an explicit instantiation of a function template
 specialization or of a member function template specialization provided
-it can be deduced from the type of a function parameter~(\ref{temp.deduct}).
+it can be deduced from the type of a function parameter\iref{temp.deduct}.
 \begin{example}
 \begin{codeblock}
 template<class T> class Array { @\commentellip@ };
@@ -6048,13 +6048,13 @@ template void sort<>(Array<int>&);
 \pnum
 \begin{note}
 An explicit instantiation of a constrained template
-shall satisfy that template's associated constraints~(\ref{temp.constr.decl}).
+shall satisfy that template's associated constraints\iref{temp.constr.decl}.
 The satisfaction of constraints is determined
 % FIXME: What is a "template name"? Does this mean "simple-template-id"?
 when forming the template name of an explicit instantiation
-in which all template arguments are specified~(\ref{temp.names}),
+in which all template arguments are specified\iref{temp.names},
 or, for explicit instantiations of function templates,
-during template argument deduction~(\ref{temp.deduct.decl})
+during template argument deduction\iref{temp.deduct.decl}
 when one or more trailing template arguments are left unspecified.
 \end{note}
 
@@ -6080,7 +6080,7 @@ members that have been defined at the point of instantiation.
 
 \pnum
 Except for inline functions and variables, declarations with types deduced from their
-initializer or return value~(\ref{dcl.spec.auto}), \tcode{const} variables of
+initializer or return value\iref{dcl.spec.auto}, \tcode{const} variables of
 literal types,
 variables of reference types, and class template specializations,
 explicit instantiation declarations have the
@@ -6088,7 +6088,7 @@ effect of suppressing the implicit instantiation
 of the definition of the entity to which they refer.
 \begin{note} The intent is that an inline function that is the
 subject of an explicit instantiation declaration will still be implicitly
-instantiated when odr-used~(\ref{basic.def.odr}) so that the body can be considered for inlining, but
+instantiated when odr-used\iref{basic.def.odr} so that the body can be considered for inlining, but
 that no out-of-line copy of the inline function would be generated in the
 translation unit.\end{note}
 
@@ -6097,7 +6097,7 @@ If an entity is the subject of both an explicit instantiation declaration
 and an explicit instantiation definition in the same translation unit, the
 definition shall follow the declaration. An entity that is the subject of an
 explicit instantiation declaration and that is also used
-in a way that would otherwise cause an implicit instantiation~(\ref{temp.inst})
+in a way that would otherwise cause an implicit instantiation\iref{temp.inst}
 in the translation unit
 shall be the subject of an explicit instantiation definition somewhere in the
 program; otherwise the program is ill-formed, no diagnostic required.
@@ -6237,7 +6237,7 @@ in this case, the definition of the class template shall
 precede the explicit specialization for the member of the class
 template.
 If such an explicit specialization for the member of a class template names an
-implicitly-declared special member function (Clause~\ref{special}),
+implicitly-declared special member function\iref{special},
 the program is ill-formed.
 
 \pnum
@@ -6391,7 +6391,7 @@ A
 \grammarterm{simple-template-id}
 that names a class template explicit specialization that has been declared but
 not defined can be used exactly like the names of other incompletely-defined
-classes~(\ref{basic.types}).
+classes\iref{basic.types}.
 \begin{example}
 
 \begin{codeblock}
@@ -6425,18 +6425,18 @@ template<> void sort(Array<int>&);
 \pnum
 \begin{note}
 An explicit specialization of a constrained template
-shall satisfy that template's associated constraints~(\ref{temp.constr.decl}).
+shall satisfy that template's associated constraints\iref{temp.constr.decl}.
 The satisfaction of constraints is determined
 when forming the template name of an explicit specialization
-in which all template arguments are specified~(\ref{temp.names}),
+in which all template arguments are specified\iref{temp.names},
 or, for explicit specializations of function templates,
-during template argument deduction~(\ref{temp.deduct.decl})
+during template argument deduction\iref{temp.deduct.decl}
 when one or more trailing template arguments are left unspecified.
 \end{note}
 
 \pnum
 A function with the same name as a template and a type that exactly matches that
-of a template specialization is not an explicit specialization~(\ref{temp.fct}).
+of a template specialization is not an explicit specialization\iref{temp.fct}.
 
 \pnum
 An explicit specialization of a function or variable template is inline
@@ -6684,12 +6684,12 @@ in a friend declaration.
 \end{itemize}
 
 \pnum
-Trailing template arguments that can be deduced~(\ref{temp.deduct}) or
+Trailing template arguments that can be deduced\iref{temp.deduct} or
 obtained from default
 \grammarterm{template-argument}{s}
 may be omitted from the list of explicit
 \grammarterm{template-argument}{s}.
-A trailing template parameter pack~(\ref{temp.variadic}) not otherwise deduced will be
+A trailing template parameter pack\iref{temp.variadic} not otherwise deduced will be
 deduced to an empty sequence of template arguments.
 If all of the template arguments can be deduced, they may all be omitted;
 in this case, the empty template argument list
@@ -6721,7 +6721,7 @@ void h() {
 \begin{note}
 An empty template argument list can be used to indicate that a given
 use refers to a specialization of a function template even when a
-non-template function~(\ref{dcl.fct}) is visible that would otherwise be used.
+non-template function\iref{dcl.fct} is visible that would otherwise be used.
 For example:
 
 \begin{codeblock}
@@ -6758,7 +6758,7 @@ void g() {
 \end{example}
 
 \pnum
-Implicit conversions (Clause~\ref{conv}) will be performed on a function argument
+Implicit conversions\iref{conv} will be performed on a function argument
 to convert it to the type of the corresponding function parameter if
 the parameter type contains no
 \grammarterm{template-parameter}{s}
@@ -6795,9 +6795,9 @@ argument list for these function templates.
 
 \pnum
 \begin{note}
-For simple function names, argument dependent lookup~(\ref{basic.lookup.argdep})
+For simple function names, argument dependent lookup\iref{basic.lookup.argdep}
 applies even when the function name is not visible within the scope of the call.
-This is because the call still has the syntactic form of a function call~(\ref{basic.lookup.unqual}).
+This is because the call still has the syntactic form of a function call\iref{basic.lookup.unqual}.
 But when a function template with explicit template arguments is used,
 the call does not have the correct syntactic form unless there is a function
 template with that name visible at the point of the call.
@@ -6971,8 +6971,8 @@ the template parameter list of the template and the function type
 are replaced with the corresponding deduced
 or default argument values. If the substitution results in an
 invalid type, as described above, type deduction fails.
-If the function template has associated constraints~(\ref{temp.constr.decl}),
-those constraints are checked for satisfaction~(\ref{temp.constr.constr}).
+If the function template has associated constraints\iref{temp.constr.decl},
+those constraints are checked for satisfaction\iref{temp.constr.constr}.
 If the constraints are not satisfied, type deduction fails.
 
 \pnum
@@ -7146,7 +7146,7 @@ or array type.
 
 \item
 Attempting to create a function type in which a parameter type or the return type is an
-abstract class type~(\ref{class.abstract}).
+abstract class type\iref{class.abstract}.
 \end{itemize}
 \end{note}
 
@@ -7155,12 +7155,12 @@ abstract class type~(\ref{class.abstract}).
 In the following example,
 assuming a \tcode{signed char}
 cannot represent the value 1000,
-a narrowing conversion~(\ref{dcl.init.list})
+a narrowing conversion\iref{dcl.init.list}
 would be required
 to convert the \grammarterm{template-argument}
 of type \tcode{int} to \tcode{signed char},
 therefore substitution fails for the
-second template~(\ref{temp.arg.nontype}).
+second template\iref{temp.arg.nontype}.
 
 \begin{codeblock}
 template <int> int f(int);
@@ -7184,14 +7184,14 @@ If removing references and cv-qualifiers from \tcode{P} gives
 \tcode{std::initializer_list<P$'$>}
 or \tcode{P$'$[N]}
 for some \tcode{P$'$} and \tcode{N} and the
-argument is a non-empty initializer list~(\ref{dcl.init.list}), then deduction is
+argument is a non-empty initializer list\iref{dcl.init.list}, then deduction is
 performed instead for each element of the initializer list, taking
 \tcode{P$'$} as a function template parameter type and the initializer
 element as its argument,
 and in the \tcode{P$'$[N]} case, if \tcode{N} is a non-type template parameter,
 \tcode{N} is deduced from the length of the initializer list.
 Otherwise, an initializer list argument causes the
-parameter to be considered a non-deduced context~(\ref{temp.deduct.type}).
+parameter to be considered a non-deduced context\iref{temp.deduct.type}.
 \begin{example}
 \begin{codeblock}
 template<class T> void f(std::initializer_list<T>);
@@ -7228,7 +7228,7 @@ as the corresponding function template parameter type.
 Each deduction deduces template arguments for subsequent positions in
 the template parameter packs expanded by the function parameter pack.
 When a function parameter pack appears in a non-deduced
-context~(\ref{temp.deduct.type}), the type of that parameter pack is
+context\iref{temp.deduct.type}, the type of that parameter pack is
 never deduced.
 \begin{example}
 \begin{codeblock}
@@ -7256,7 +7256,7 @@ is not a reference type:
 If
 \tcode{A}
 is an array type, the pointer type produced by the array-to-pointer
-standard conversion~(\ref{conv.array}) is used in place of
+standard conversion\iref{conv.array} is used in place of
 \tcode{A}
 for type deduction;
 otherwise,
@@ -7264,7 +7264,7 @@ otherwise,
 If
 \tcode{A}
 is a function type, the pointer type produced by the
-function-to-pointer standard conversion~(\ref{conv.func}) is used in place
+function-to-pointer standard conversion\iref{conv.func} is used in place
 of
 \tcode{A}
 for type
@@ -7302,7 +7302,7 @@ int n3 = g(i);                  // calls \tcode{g<const int>(const volatile int\
 A \defn{forwarding reference}
 is an rvalue reference to a cv-unqualified template parameter
 that does not represent a template parameter of a class template
-(during class template argument deduction~(\ref{over.match.class.deduct})).
+(during class template argument deduction\iref{over.match.class.deduct}).
 If \tcode{P} is a forwarding reference and the argument is an
 lvalue, the type ``lvalue reference to \tcode{A}'' is used in place of \tcode{A} for type
 deduction. \begin{example}
@@ -7358,8 +7358,8 @@ The transformed \tcode{A}
 can be another pointer or pointer to member type that can be converted
 to the deduced
 \tcode{A}
-via a function pointer conversion~(\ref{conv.fctptr}) and/or
-qualification conversion~(\ref{conv.qual}).
+via a function pointer conversion\iref{conv.fctptr} and/or
+qualification conversion\iref{conv.qual}.
 
 \item
 If
@@ -7483,7 +7483,7 @@ will be checked during overload resolution.
 
 \pnum
 Template arguments can be deduced from the type specified when taking
-the address of an overloaded function~(\ref{over.over}).
+the address of an overloaded function\iref{over.over}.
 The function template's function type and the specified type
 are used as the types of
 \tcode{P}
@@ -7493,7 +7493,7 @@ and the deduction is done as
 described in~\ref{temp.deduct.type}.
 
 \pnum
-A placeholder type~(\ref{dcl.spec.auto}) in the return type of a
+A placeholder type\iref{dcl.spec.auto} in the return type of a
 function template is a non-deduced context. If template argument
 deduction succeeds for such a function, the return type is determined
 from instantiation of the function body.
@@ -7527,7 +7527,7 @@ is not a reference type:
 If
 \tcode{P}
 is an array type, the pointer type produced by the
-array-to-pointer standard conversion~(\ref{conv.array}) is used in place of
+array-to-pointer standard conversion\iref{conv.array} is used in place of
 \tcode{P}
 for type
 deduction; otherwise,
@@ -7535,7 +7535,7 @@ deduction; otherwise,
 If
 \tcode{P}
 is a function type, the pointer type produced by the
-function-to-pointer standard conversion~(\ref{conv.func}) is used in place of
+function-to-pointer standard conversion\iref{conv.func} is used in place of
 \tcode{P}
 for
 type deduction; otherwise,
@@ -7667,7 +7667,7 @@ after a function has been selected.}
 In the context of a call to a conversion function, the return types of
 the conversion function templates are used.
 \item
-In other contexts~(\ref{temp.func.order}) the function template's function
+In other contexts\iref{temp.func.order} the function template's function
 type is used.
 \end{itemize}
 
@@ -7952,7 +7952,7 @@ deduction is being done.
 \item
 A function parameter for which argument deduction cannot be done because the
 associated function argument is a function, or a set of overloaded
-functions~(\ref{over.over}), and one or more of the following apply:
+functions\iref{over.over}, and one or more of the following apply:
 \begin{itemize}
 \item
 more than one function matches the function parameter type (resulting in
@@ -7963,8 +7963,8 @@ no function matches the function parameter type, or
 the set of functions supplied as an argument contains one or more function templates.
 \end{itemize}
 \item A function parameter for which the associated argument is an initializer
-list~(\ref{dcl.init.list}) but the parameter does not have
-a type for which deduction from an initializer list is specified~(\ref{temp.deduct.call}).
+list\iref{dcl.init.list} but the parameter does not have
+a type for which deduction from an initializer list is specified\iref{temp.deduct.call}.
 \begin{example}
 \begin{codeblock}
 template<class T> void g(T);
@@ -8120,7 +8120,7 @@ TT<>
 where
 \tcode{(T)}
 represents
-a parameter-type-list~(\ref{dcl.fct})
+a parameter-type-list\iref{dcl.fct}
 where at least one parameter type contains a
 \tcode{T},
 and
@@ -8156,7 +8156,7 @@ of $\texttt{P}_i$ is compared with each remaining argument in the
 template argument list of \tcode{A}. Each comparison deduces
 template arguments for subsequent positions in the template parameter
 packs expanded by $\texttt{P}_i$.
-During partial ordering~(\ref{temp.deduct.partial}), if $\texttt{A}_i$ was
+During partial ordering\iref{temp.deduct.partial}, if $\texttt{A}_i$ was
 originally a pack expansion:
 
 \begin{itemize}
@@ -8183,16 +8183,16 @@ template struct A<int, int*>; // selects \#2
 \pnum
 Similarly, if \tcode{P} has a form that contains
 \tcode{(T)}, then each parameter type $\texttt{P}_i$
-of the respective parameter-type-list~(\ref{dcl.fct}) of
+of the respective parameter-type-list\iref{dcl.fct} of
 \tcode{P} is compared with the corresponding parameter type
 $\texttt{A}_i$ of the corresponding parameter-type-list
 of \tcode{A}.
 If \tcode{P} and \tcode{A} are function types that originated from deduction when
-taking the address of a function template~(\ref{temp.deduct.funcaddr}) or when
-deducing template arguments from a function declaration~(\ref{temp.deduct.decl})
+taking the address of a function template\iref{temp.deduct.funcaddr} or when
+deducing template arguments from a function declaration\iref{temp.deduct.decl}
 and $\texttt{P}_i$ and $\texttt{A}_i$ are parameters of the top-level
 parameter-type-list of \tcode{P} and \tcode{A}, respectively,
-$\texttt{P}_i$ is adjusted if it is a forwarding reference~(\ref{temp.deduct.call})
+$\texttt{P}_i$ is adjusted if it is a forwarding reference\iref{temp.deduct.call}
 and $\texttt{A}_i$ is an lvalue reference, in which case the type of
 $\texttt{P}_i$ is changed to be the template parameter type (i.e., \tcode{T\&\&} is
 changed to simply \tcode{T}). \begin{note} As a result, when $\texttt{P}_i$ is \tcode{T\&\&}
@@ -8217,7 +8217,7 @@ each remaining parameter type in the parameter-type-list
 of \tcode{A}. Each comparison deduces template arguments for
 subsequent positions in the template parameter packs expanded by the
 function parameter pack.
-During partial ordering~(\ref{temp.deduct.partial}), if $\texttt{A}_i$ was
+During partial ordering\iref{temp.deduct.partial}, if $\texttt{A}_i$ was
 originally a function parameter pack:
 
 \begin{itemize}
@@ -8474,7 +8474,7 @@ f(ab);              // calls \tcode{f(A<B>)}
 \pnum
 \begin{note}
 Template argument deduction involving parameter
-packs~(\ref{temp.variadic}) can deduce zero or more arguments for
+packs\iref{temp.variadic} can deduce zero or more arguments for
 each parameter pack.
 \end{note}
 \begin{example}
@@ -8503,8 +8503,8 @@ int fv = f(g);                  // OK; \tcode{Types} contains \tcode{int}, \tcod
 In a declaration whose \grammarterm{declarator-id} refers to a specialization
 of a function template, template argument deduction is performed to identify
 the specialization to which the declaration refers. Specifically, this is done
-for explicit instantiations~(\ref{temp.explicit}), explicit specializations~(\ref{temp.expl.spec}),
-and certain friend declarations~(\ref{temp.friend}). This is also done to
+for explicit instantiations\iref{temp.explicit}, explicit specializations\iref{temp.expl.spec},
+and certain friend declarations\iref{temp.friend}. This is also done to
 determine whether a deallocation function template specialization matches a placement
 \tcode{operator new}~(\ref{basic.stc.dynamic.deallocation}, \ref{expr.new}).
 In all these cases, \tcode{P} is the type of the function template being considered
@@ -8516,7 +8516,7 @@ deduction is done as described in~\ref{temp.deduct.type}.
 
 \pnum
 If, for the set of function templates so considered, there is either no match or
-more than one match after partial ordering has been considered~(\ref{temp.func.order}),
+more than one match after partial ordering has been considered\iref{temp.func.order},
 deduction fails and, in the declaration cases, the
 program is ill-formed.
 
@@ -8527,8 +8527,8 @@ program is ill-formed.
 A function template can be overloaded either by (non-template) functions of its
 name or by (other) function templates of the same name.
 When a call to that name is written (explicitly, or implicitly using the
-operator notation), template argument deduction~(\ref{temp.deduct})
-and checking of any explicit template arguments~(\ref{temp.arg}) are performed
+operator notation), template argument deduction\iref{temp.deduct}
+and checking of any explicit template arguments\iref{temp.arg} are performed
 for each function template to find the template argument values (if any) that
 can be used with that function template to instantiate a function template
 specialization that can be invoked with the call arguments.
@@ -8660,9 +8660,9 @@ is present in some translation unit.
 Deduction guides are used
 when a \grammarterm{template-name} appears
 as a type specifier
-for a deduced class type~(\ref{dcl.type.class.deduct}).
+for a deduced class type\iref{dcl.type.class.deduct}.
 Deduction guides are not found by name lookup.
-Instead, when performing class template argument deduction~(\ref{over.match.class.deduct}),
+Instead, when performing class template argument deduction\iref{over.match.class.deduct},
 any deduction guides declared for the class template are considered.
 
 \begin{bnf}
@@ -8692,7 +8692,7 @@ S x{A()};           // \tcode{x} is of type \tcode{S<short, int>}
 The same restrictions apply
 to the \grammarterm{parameter-declaration-clause}
 of a deduction guide
-as in a function declaration~(\ref{dcl.fct}).
+as in a function declaration\iref{dcl.fct}.
 The \grammarterm{simple-template-id}
 shall name a class template specialization.
 The \grammarterm{template-name}

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -975,8 +975,8 @@ blocking. If ownership is not obtained, there is no effect and \tcode{try_lock()
 immediately returns. An implementation may fail to obtain the lock even if it is not
 held by any other thread. \begin{note} This spurious failure is normally uncommon, but
 allows interesting implementations based on a simple
-compare and exchange
-(\ref{atomics}). \end{note}
+compare and exchange\iref{atomics}.
+\end{note}
 An implementation should ensure that \tcode{try_lock()} does not consistently return \tcode{false}
 in the absence of contending mutex acquisitions.
 

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -5,7 +5,7 @@
 
 \pnum
 The following subclauses describe components to create and manage
-threads~(\ref{intro.multithread}), perform mutual exclusion, and communicate conditions
+threads\iref{intro.multithread}, perform mutual exclusion, and communicate conditions
 and values
 between threads, as summarized in Table~\ref{tab:thread.lib.summary}.
 
@@ -32,7 +32,7 @@ the template argument shall return a value that is convertible to \tcode{bool}.
 
 \pnum
 Some functions described in this Clause are specified to throw exceptions of type
-\tcode{system_error}~(\ref{syserr.syserr}). Such exceptions shall be thrown if
+\tcode{system_error}\iref{syserr.syserr}. Such exceptions shall be thrown if
 any of the function's error conditions is detected or
 a call to
 an operating system or other underlying API results in an error that prevents the
@@ -48,7 +48,7 @@ perform the operation. Assume that, during the execution of this function, an \t
 of \tcode{EPERM} is reported by a POSIX API call used by the implementation. Since POSIX
 specifies an \tcode{errno} of \tcode{EPERM} when ``the caller does not have the privilege
 to perform the operation'', the implementation maps \tcode{EPERM} to an
-\tcode{error_condition} of \tcode{operation_not_permitted}~(\ref{syserr}) and an exception
+\tcode{error_condition} of \tcode{operation_not_permitted}\iref{syserr} and an exception
 of type \tcode{system_error} is thrown.
 \end{example}
 
@@ -129,7 +129,7 @@ and hardware. The finest resolution provided by an implementation is called the
 
 \pnum
 Implementation-provided clocks that are used for these functions shall meet the
-\tcode{TrivialClock} requirements~(\ref{time.clock.req}).
+\tcode{TrivialClock} requirements\iref{time.clock.req}.
 
 \pnum
 A function that takes an argument which specifies a timeout will throw if,
@@ -155,12 +155,12 @@ execution agent model because they do not determine or store the agent's ID (e.g
 ordinary spin lock). \end{note}
 
 \pnum
-The standard library templates \tcode{unique_lock}~(\ref{thread.lock.unique}),
-\tcode{shared_lock}~(\ref{thread.lock.shared}),
-\tcode{scoped_lock}~(\ref{thread.lock.scoped}),
-\tcode{lock_guard}~(\ref{thread.lock.guard}), \tcode{lock},
-\tcode{try_lock}~(\ref{thread.lock.algorithm}), and
-\tcode{condition_variable_any}~(\ref{thread.condition.condvarany}) all operate on user-supplied
+The standard library templates \tcode{unique_lock}\iref{thread.lock.unique},
+\tcode{shared_lock}\iref{thread.lock.shared},
+\tcode{scoped_lock}\iref{thread.lock.scoped},
+\tcode{lock_guard}\iref{thread.lock.guard}, \tcode{lock},
+\tcode{try_lock}\iref{thread.lock.algorithm}, and
+\tcode{condition_variable_any}\iref{thread.condition.condvarany} all operate on user-supplied
 lockable objects. The \tcode{BasicLockable} requirements, the \tcode{Lockable} requirements,
 and the \tcode{TimedLockable} requirements list the requirements imposed by these library types
 in order to acquire or release ownership of a \tcode{lock} by a given execution agent.
@@ -227,8 +227,8 @@ exception is thrown then a lock shall not have been acquired for the current exe
 A type \tcode{L} meets the \tcode{TimedLockable} requirements if it meets the \tcode{Lockable}
 requirements and the following expressions are well-formed and have the specified semantics
 (\tcode{m} denotes a value of type \tcode{L}, \tcode{rel_time} denotes a value of an
-instantiation of \tcode{duration}~(\ref{time.duration}), and \tcode{abs_time} denotes a value
-of an instantiation of \tcode{time_point}~(\ref{time.point})).
+instantiation of \tcode{duration}\iref{time.duration}, and \tcode{abs_time} denotes a value
+of an instantiation of \tcode{time_point}\iref{time.point}).
 
 \begin{itemdecl}
 m.try_lock_for(rel_time)
@@ -237,7 +237,7 @@ m.try_lock_for(rel_time)
 \begin{itemdescr}
 \pnum
 \effects Attempts to acquire a lock for the current execution agent within the relative
-timeout~(\ref{thread.req.timing}) specified by \tcode{rel_time}. The function shall not return
+timeout\iref{thread.req.timing} specified by \tcode{rel_time}. The function shall not return
 within the timeout specified by \tcode{rel_time} unless it has obtained a lock on \tcode{m}
 for the current execution agent. If an exception is thrown then a lock shall not have been
 acquired for the current execution agent.
@@ -256,7 +256,7 @@ m.try_lock_until(abs_time)
 \begin{itemdescr}
 \pnum
 \effects Attempts to acquire a lock for the current execution agent before the absolute
-timeout~(\ref{thread.req.timing}) specified by \tcode{abs_time}. The function shall not return
+timeout\iref{thread.req.timing} specified by \tcode{abs_time}. The function shall not return
 before the timeout specified by \tcode{abs_time} unless it has obtained a lock on \tcode{m} for
 the current execution agent. If an exception is thrown then a lock shall not have been acquired
 for the current execution agent.
@@ -389,14 +389,14 @@ namespace std {
 \pnum An object of type \tcode{thread::id} provides a unique identifier for
 each thread of execution and a single distinct value for all \tcode{thread}
 objects that do not represent a thread of
-execution~(\ref{thread.thread.class}). Each thread of execution has an
+execution\iref{thread.thread.class}. Each thread of execution has an
 associated \tcode{thread::id} object that is not equal to the
 \tcode{thread::id} object of any other thread of execution and that is not
 equal to the \tcode{thread::id} object of any \tcode{thread} object that
 does not represent threads of execution.
 
 \pnum
-\tcode{thread::id} shall be a trivially copyable class (Clause~\ref{class}).
+\tcode{thread::id} shall be a trivially copyable class\iref{class}.
 The library may reuse the value of a \tcode{thread::id} of a terminated thread that can no longer be joined.
 
 \pnum
@@ -495,7 +495,7 @@ template <> struct hash<thread::id>;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum The specialization is enabled~(\ref{unord.hash}).
+\pnum The specialization is enabled\iref{unord.hash}.
 \end{itemdescr}
 
 \rSec3[thread.thread.constr]{\tcode{thread} constructors}
@@ -525,7 +525,7 @@ template <class F, class... Args> explicit thread(F&& f, Args&&... args);
 \placeholdernc{DECAY_COPY}(\brk{}%
 std::forward<F>(f)),
 \placeholdernc{DECAY_COPY}(\brk{}%
-std::forward<Args>(\brk{}args))...)}~(\ref{func.require}) shall be
+std::forward<Args>(\brk{}args))...)}\iref{func.require} shall be
 a va\-lid expression.
 
 \pnum
@@ -654,7 +654,7 @@ void join();
 \effects\ Blocks until the thread represented by \tcode{*this} has completed.
 
 \pnum
-\sync The completion of the thread represented by \tcode{*this} synchronizes with~(\ref{intro.multithread})
+\sync The completion of the thread represented by \tcode{*this} synchronizes with\iref{intro.multithread}
 the corresponding successful
 \tcode{join()} return. \begin{note} Operations on
 \tcode{*this} are not synchronized. \end{note}
@@ -664,7 +664,7 @@ the corresponding successful
 
 \pnum
 \throws \tcode{system_error} when
-an exception is required~(\ref{thread.req.exception}).
+an exception is required\iref{thread.req.exception}.
 
 \pnum
 \errors
@@ -693,7 +693,7 @@ implementation shall release any owned resources.
 \pnum\postconditions \tcode{get_id() == id()}.
 
 \pnum\throws \tcode{system_error} when
-an exception is required~(\ref{thread.req.exception}).
+an exception is required\iref{thread.req.exception}.
 
 \pnum \errors
 \begin{itemize}
@@ -787,14 +787,14 @@ template <class Clock, class Duration>
 
 \begin{itemdescr}
 \pnum
-\effects Blocks the calling thread for the absolute timeout~(\ref{thread.req.timing}) specified
+\effects Blocks the calling thread for the absolute timeout\iref{thread.req.timing} specified
 by \tcode{abs_time}.
 
 \pnum
 \sync None.
 
 \pnum
-\throws Timeout-related exceptions~(\ref{thread.req.timing}).
+\throws Timeout-related exceptions\iref{thread.req.timing}.
 \end{itemdescr}
 
 \indexlibrarymember{sleep_for}{this_thread}%
@@ -805,14 +805,14 @@ template <class Rep, class Period>
 
 \begin{itemdescr}
 \pnum
-\effects Blocks the calling thread for the relative timeout~(\ref{thread.req.timing}) specified
+\effects Blocks the calling thread for the relative timeout\iref{thread.req.timing} specified
 by \tcode{rel_time}.
 
 \pnum
 \sync None.
 
 \pnum
-\throws Timeout-related exceptions~(\ref{thread.req.timing}).
+\throws Timeout-related exceptions\iref{thread.req.timing}.
 \end{itemdescr}
 
 \rSec1[thread.mutex]{Mutual exclusion}
@@ -820,7 +820,7 @@ by \tcode{rel_time}.
 \pnum
 This section provides mechanisms for mutual exclusion: mutexes, locks, and call
 once. These mechanisms ease the production of race-free
-programs~(\ref{intro.multithread}).
+programs\iref{intro.multithread}.
 
 \rSec2[mutex.syn]{Header \tcode{<mutex>} synopsis}
 \indextext{\idxhdr{mutex}}%
@@ -878,7 +878,7 @@ namespace std {
 
 \pnum
 A mutex object facilitates protection against data races and allows safe synchronization of
-data between execution agents~(\ref{thread.req.lockable}).
+data between execution agents\iref{thread.req.lockable}.
 An execution agent \term{owns} a mutex from the time it successfully calls one of the
 lock functions until it calls unlock. Mutexes can be either recursive or non-recursive, and can
 grant simultaneous ownership to one or many execution agents. Both
@@ -894,7 +894,7 @@ They shall meet the requirements set out in this section. In this description, \
 denotes an object of a mutex type.
 
 \pnum
-The mutex types shall meet the \tcode{Lockable} requirements~(\ref{thread.req.lockable.req}).
+The mutex types shall meet the \tcode{Lockable} requirements\iref{thread.req.lockable.req}.
 
 \pnum
 The mutex types shall be \tcode{DefaultConstructible} and \tcode{Destructible}. If
@@ -915,9 +915,9 @@ construction is incorrect.
 \pnum
 The implementation shall provide lock and unlock operations, as described below.
 For purposes of determining the existence of a data race, these behave as
-atomic operations~(\ref{intro.multithread}). The lock and unlock operations on
+atomic operations\iref{intro.multithread}. The lock and unlock operations on
 a single mutex shall appear to occur in a single total order. \begin{note} This
-can be viewed as the modification order~(\ref{intro.multithread}) of the
+can be viewed as the modification order\iref{intro.multithread} of the
 mutex. \end{note}
 \begin{note} Construction and
 destruction of an object of a mutex type need not be thread-safe; other
@@ -944,11 +944,11 @@ thread does not own the mutex.
 
 \pnum
 \sync Prior \tcode{unlock()} operations on the same object shall
-\term{synchronize with}~(\ref{intro.multithread}) this operation.
+\term{synchronize with}\iref{intro.multithread} this operation.
 
 \pnum
 \throws \tcode{system_error} when
-an exception is required~(\ref{thread.req.exception}).
+an exception is required\iref{thread.req.exception}.
 
 \pnum \errors
 \begin{itemize}
@@ -976,7 +976,7 @@ immediately returns. An implementation may fail to obtain the lock even if it is
 held by any other thread. \begin{note} This spurious failure is normally uncommon, but
 allows interesting implementations based on a simple
 compare and exchange
-(Clause~\ref{atomics}). \end{note}
+(\ref{atomics}). \end{note}
 An implementation should ensure that \tcode{try_lock()} does not consistently return \tcode{false}
 in the absence of contending mutex acquisitions.
 
@@ -989,7 +989,7 @@ thread, otherwise \tcode{false}.
 
 \pnum
 \sync If \tcode{try_lock()} returns \tcode{true}, prior \tcode{unlock()} operations
-on the same object \term{synchronize with}~(\ref{intro.multithread}) this operation.
+on the same object \term{synchronize with}\iref{intro.multithread} this operation.
 \begin{note} Since \tcode{lock()} does not synchronize with a failed subsequent
 \tcode{try_lock()}, the visibility rules are weak enough that little would be
 known about the state after a failure, even in the absence of spurious failures. \end{note}
@@ -1012,7 +1012,7 @@ The expression \tcode{m.unlock()} shall be well-formed and have the following se
 \returntype \tcode{void}.
 
 \pnum
-\sync This operation synchronizes with~(\ref{intro.multithread}) subsequent
+\sync This operation synchronizes with\iref{intro.multithread} subsequent
 lock operations that obtain ownership on the same object.
 
 \pnum
@@ -1061,8 +1061,8 @@ contains a mutex that is used to protect the reference count.
 
 \pnum
 The class \tcode{mutex} shall satisfy all of the mutex
-requirements~(\ref{thread.mutex.requirements}). It shall be a standard-layout
-class (Clause~\ref{class}).
+requirements\iref{thread.mutex.requirements}. It shall be a standard-layout
+class\iref{class}.
 
 \pnum
 \begin{note} A program may deadlock if the thread that owns a \tcode{mutex} object calls
@@ -1105,8 +1105,8 @@ thread to acquire ownership of that object will fail (for \tcode{try_lock()}) or
 
 \pnum
 The class \tcode{recursive_mutex} shall satisfy all of the mutex
-requirements~(\ref{thread.mutex.requirements}). It shall be a standard-layout
-class (Clause~\ref{class}).
+requirements\iref{thread.mutex.requirements}. It shall be a standard-layout
+class\iref{class}.
 
 \pnum
 A thread that owns a \tcode{recursive_mutex} object may acquire additional levels of
@@ -1135,13 +1135,13 @@ The \defn{timed mutex types} are the standard library types \tcode{timed_mutex},
 meet the requirements set out below.
 In this description, \tcode{m} denotes an object of a mutex type,
 \tcode{rel_time} denotes an object of an
-instantiation of \tcode{duration}~(\ref{time.duration}), and \tcode{abs_time} denotes an
+instantiation of \tcode{duration}\iref{time.duration}, and \tcode{abs_time} denotes an
 object of an
-instantiation of \tcode{time_point}~(\ref{time.point}).
+instantiation of \tcode{time_point}\iref{time.point}.
 
 \pnum
 The timed mutex types shall meet the \tcode{TimedLockable}
-requirements~(\ref{thread.req.lockable.timed}).
+requirements\iref{thread.req.lockable.timed}.
 
 \pnum
 The expression \tcode{m.try_lock_for(rel_time)} shall be well-formed and have the
@@ -1155,7 +1155,7 @@ own the mutex.
 
 \pnum
 \effects The function attempts to obtain ownership of the mutex within the
-relative timeout~(\ref{thread.req.timing})
+relative timeout\iref{thread.req.timing}
 specified by \tcode{rel_time}. If the time specified by \tcode{rel_time} is less than or
 equal to \tcode{rel_time.zero()}, the function attempts to obtain ownership without blocking (as if by calling
 \tcode{try_lock()}). The function shall return within the timeout specified by
@@ -1172,9 +1172,9 @@ lock is available, but implementations are expected to make a strong effort to d
 
 \pnum
 \sync If \tcode{try_lock_for()} returns \tcode{true}, prior \tcode{unlock()} operations
-on the same object \term{synchronize with}~(\ref{intro.multithread}) this operation.
+on the same object \term{synchronize with}\iref{intro.multithread} this operation.
 
-\pnum\throws Timeout-related exceptions~(\ref{thread.req.timing}).
+\pnum\throws Timeout-related exceptions\iref{thread.req.timing}.
 \end{itemdescr}
 
 \pnum
@@ -1191,7 +1191,7 @@ mutex.
 \effects The function attempts to obtain ownership of the mutex. If
 \tcode{abs_time} has already passed, the function attempts to obtain ownership
 without blocking (as if by calling \tcode{try_lock()}). The function shall
-return before the absolute timeout~(\ref{thread.req.timing}) specified by
+return before the absolute timeout\iref{thread.req.timing} specified by
 \tcode{abs_time} only if it has obtained ownership of the mutex object.
 \begin{note} As with \tcode{try_lock()}, there is no guarantee that ownership will
 be obtained if the lock is available, but implementations are expected to make a
@@ -1204,10 +1204,10 @@ strong effort to do so. \end{note}
 
 \pnum
 \sync If \tcode{try_lock_until()} returns \tcode{true}, prior \tcode{unlock()}
-operations on the same object \term{synchronize with}~(\ref{intro.multithread})
+operations on the same object \term{synchronize with}\iref{intro.multithread}
 this operation.
 
-\pnum\throws Timeout-related exceptions~(\ref{thread.req.timing}).
+\pnum\throws Timeout-related exceptions\iref{thread.req.timing}.
 \end{itemdescr}
 
 \rSec4[thread.timedmutex.class]{Class \tcode{timed_mutex}}
@@ -1248,8 +1248,8 @@ failed to obtain ownership).
 
 \pnum
 The class \tcode{timed_mutex} shall satisfy all of the timed mutex
-requirements~(\ref{thread.timedmutex.requirements}). It shall be a standard-layout
-class (Clause~\ref{class}).
+requirements\iref{thread.timedmutex.requirements}. It shall be a standard-layout
+class\iref{class}.
 
 \pnum
 The behavior of a program is undefined if:
@@ -1299,8 +1299,8 @@ times out (having failed to obtain ownership).
 
 \pnum
 The class \tcode{recursive_timed_mutex} shall satisfy all of the timed mutex
-requirements~(\ref{thread.timedmutex.requirements}). It shall be a standard-layout
-class (Clause~\ref{class}).
+requirements\iref{thread.timedmutex.requirements}. It shall be a standard-layout
+class\iref{class}.
 
 \pnum
 A thread that owns a \tcode{recursive_timed_mutex} object may acquire additional
@@ -1330,7 +1330,7 @@ The behavior of a program is undefined if:
 \pnum
 The standard library types \tcode{shared_mutex} and \tcode{shared_timed_mutex}
 are \defn{shared mutex types}. Shared mutex types shall meet the requirements of
-mutex types~(\ref{thread.mutex.requirements.mutex}), and additionally
+mutex types\iref{thread.mutex.requirements.mutex}, and additionally
 shall meet the requirements set out below. In this description,
 \tcode{m} denotes an object of a shared mutex type.
 
@@ -1367,10 +1367,10 @@ If an exception is thrown then a shared lock shall not have been acquired for th
 \returntype \tcode{void}.
 
 \pnum
-\sync Prior \tcode{unlock()} operations on the same object shall synchronize with~(\ref{intro.multithread}) this operation.
+\sync Prior \tcode{unlock()} operations on the same object shall synchronize with\iref{intro.multithread} this operation.
 
 \pnum
-\throws \tcode{system_error} when an exception is required~(\ref{thread.req.exception}).
+\throws \tcode{system_error} when an exception is required\iref{thread.req.exception}.
 
 \pnum
 \errors
@@ -1394,7 +1394,7 @@ The expression \tcode{m.unlock_shared()} shall be well-formed and have the follo
 \returntype \tcode{void}.
 
 \pnum
-\sync This operation synchronizes with~(\ref{intro.multithread}) subsequent
+\sync This operation synchronizes with\iref{intro.multithread} subsequent
 \tcode{lock()} operations that obtain ownership on the same object.
 
 \pnum
@@ -1423,7 +1423,7 @@ otherwise.
 
 \pnum
 \sync If \tcode{try_lock_shared()} returns \tcode{true}, prior \tcode{unlock()}
-operations on the same object synchronize with~(\ref{intro.multithread}) this
+operations on the same object synchronize with\iref{intro.multithread} this
 operation.
 
 \pnum
@@ -1465,8 +1465,8 @@ with shared ownership semantics.
 
 \pnum
 The class \tcode{shared_mutex} shall satisfy all of the
-shared mutex requirements~(\ref{thread.sharedmutex.requirements}).
-It shall be a standard-layout class (Clause~\ref{class}).
+shared mutex requirements\iref{thread.sharedmutex.requirements}.
+It shall be a standard-layout class\iref{class}.
 
 \pnum
 The behavior of a program is undefined if:
@@ -1484,14 +1484,14 @@ The behavior of a program is undefined if:
 \pnum
 The standard library type \tcode{shared_timed_mutex} is a
 \defn{shared timed mutex type}. Shared timed mutex types shall meet the requirements of
-timed mutex types~(\ref{thread.timedmutex.requirements}),
-shared mutex types~(\ref{thread.sharedmutex.requirements}), and additionally
+timed mutex types\iref{thread.timedmutex.requirements},
+shared mutex types\iref{thread.sharedmutex.requirements}, and additionally
 shall meet the requirements set out below. In this description,
 \tcode{m} denotes an object of a shared timed mutex type,
 \tcode{rel_type} denotes an object of an instantiation of
-\tcode{duration}~(\ref{time.duration}), and
+\tcode{duration}\iref{time.duration}, and
 \tcode{abs_time} denotes an object of an instantiation of
-\tcode{time_point}~(\ref{time.point}).
+\tcode{time_point}\iref{time.point}.
 
 \pnum
 The expression \tcode{m.try_lock_shared_for(rel_time)} shall be well-formed and
@@ -1504,7 +1504,7 @@ have the following semantics:
 \pnum
 \effects Attempts to obtain
 shared lock ownership for the calling thread within the relative
-timeout~(\ref{thread.req.timing}) specified by \tcode{rel_time}. If the time
+timeout\iref{thread.req.timing} specified by \tcode{rel_time}. If the time
 specified by \tcode{rel_time} is less than or equal to \tcode{rel_time.zero()},
 the function attempts to obtain ownership without blocking (as if by calling
 \tcode{try_lock_shared()}). The function shall return within the timeout
@@ -1524,10 +1524,10 @@ the current thread.
 \pnum
 \sync If \tcode{try_lock_shared_for()} returns \tcode{true}, prior
 \tcode{unlock()} operations on the same object synchronize
-with~(\ref{intro.multithread}) this operation.
+with\iref{intro.multithread} this operation.
 
 \pnum
-\throws Timeout-related exceptions~(\ref{thread.req.timing}).
+\throws Timeout-related exceptions\iref{thread.req.timing}.
 \end{itemdescr}
 
 \pnum
@@ -1542,7 +1542,7 @@ and have the following semantics:
 \effects The function attempts to obtain shared ownership of the mutex. If
 \tcode{abs_time} has already passed, the function attempts to obtain shared
 ownership without blocking (as if by calling \tcode{try_lock_shared()}). The
-function shall return before the absolute timeout~(\ref{thread.req.timing})
+function shall return before the absolute timeout\iref{thread.req.timing}
 specified by \tcode{abs_time} only if it has obtained shared ownership of the
 mutex object. \begin{note} As with \tcode{try_lock()}, there is no guarantee that
 ownership will be obtained if the lock is available, but implementations are
@@ -1559,10 +1559,10 @@ the current thread.
 \pnum
 \sync If \tcode{try_lock_shared_until()} returns \tcode{true}, prior
 \tcode{unlock()} operations on the same object synchronize
-with~(\ref{intro.multithread}) this operation.
+with\iref{intro.multithread} this operation.
 
 \pnum
-\throws Timeout-related exceptions~(\ref{thread.req.timing}).
+\throws Timeout-related exceptions\iref{thread.req.timing}.
 \end{itemdescr}
 
 \rSec4[thread.sharedtimedmutex.class]{Class \tcode{shared_timed_mutex}}
@@ -1607,8 +1607,8 @@ ownership semantics.
 
 \pnum
 The class \tcode{shared_timed_mutex} shall satisfy all of the
-shared timed mutex requirements~(\ref{thread.sharedtimedmutex.requirements}).
-It shall be a standard-layout class (Clause~\ref{class}).
+shared timed mutex requirements\iref{thread.sharedtimedmutex.requirements}.
+It shall be a standard-layout class\iref{class}.
 
 \pnum
 The behavior of a program is undefined if:
@@ -1681,11 +1681,11 @@ namespace std {
 \pnum
 An object of type \tcode{lock_guard} controls the ownership of a lockable object
 within a scope. A \tcode{lock_guard} object maintains ownership of a lockable
-object throughout the \tcode{lock_guard} object's lifetime~(\ref{basic.life}).
+object throughout the \tcode{lock_guard} object's lifetime\iref{basic.life}.
 The behavior of a program is undefined if the lockable object referenced by
 \tcode{pm} does not exist for the entire lifetime of the \tcode{lock_guard}
 object. The supplied \tcode{Mutex} type shall meet the \tcode{BasicLockable}
-requirements~(\ref{thread.req.lockable.basic}).
+requirements\iref{thread.req.lockable.basic}.
 
 \indexlibrary{\idxcode{lock_guard}!constructor}%
 \begin{itemdecl}
@@ -1760,15 +1760,15 @@ namespace std {
 \pnum
 An object of type \tcode{scoped_lock} controls the ownership of lockable objects
 within a scope. A \tcode{scoped_lock} object maintains ownership of lockable
-objects throughout the \tcode{scoped_lock} object's lifetime~(\ref{basic.life}).
+objects throughout the \tcode{scoped_lock} object's lifetime\iref{basic.life}.
 The behavior of a program is undefined if the lockable objects referenced by
 \tcode{pm} do not exist for the entire lifetime of the \tcode{scoped_lock}
 object.
 When \tcode{sizeof...(MutexTypes)} is \tcode{1},
 the supplied \tcode{Mutex} type
-shall meet the \tcode{BasicLockable} requirements~(\ref{thread.req.lockable.basic}).
+shall meet the \tcode{BasicLockable} requirements\iref{thread.req.lockable.basic}.
 Otherwise, each of the mutex types
-shall meet the \tcode{Lockable} requirements~(\ref{thread.req.lockable.req}).
+shall meet the \tcode{Lockable} requirements\iref{thread.req.lockable.req}.
 
 \indexlibrary{\idxcode{scoped_lock}!constructor}%
 \begin{itemdecl}
@@ -1882,16 +1882,16 @@ acquisition, to another \tcode{unique_lock} object. Objects of type \tcode{uniqu
 copyable but are movable. The behavior of a program is undefined if the contained pointer
 \tcode{pm} is not null and the lockable object pointed
 to by \tcode{pm} does not exist for the entire remaining
-lifetime~(\ref{basic.life}) of the \tcode{unique_lock} object. The supplied
+lifetime\iref{basic.life} of the \tcode{unique_lock} object. The supplied
 \tcode{Mutex} type shall meet the \tcode{BasicLockable}
-requirements~(\ref{thread.req.lockable.basic}).
+requirements\iref{thread.req.lockable.basic}.
 
 \pnum
 \begin{note} \tcode{unique_lock<Mutex>} meets the \tcode{BasicLockable} requirements. If \tcode{Mutex}
-meets the \tcode{Lockable} requirements~(\ref{thread.req.lockable.req}),
+meets the \tcode{Lockable} requirements\iref{thread.req.lockable.req},
 \tcode{unique_lock<Mutex>} also meets the \tcode{Lockable} requirements;
 if \tcode{Mutex}
-meets the \tcode{TimedLockable} requirements~(\ref{thread.req.lockable.timed}),
+meets the \tcode{TimedLockable} requirements\iref{thread.req.lockable.timed},
 \tcode{unique_lock<Mutex>} also meets the \tcode{TimedLockable} requirements. \end{note}
 
 \rSec4[thread.lock.unique.cons]{\tcode{unique_lock} constructors, destructor, and assignment}
@@ -1947,7 +1947,7 @@ unique_lock(mutex_type& m, try_to_lock_t);
 \pnum
 \requires
 The supplied \tcode{Mutex} type shall meet the \tcode{Lockable}
-requirements~(\ref{thread.req.lockable.req}).
+requirements\iref{thread.req.lockable.req}.
 If \tcode{mutex_type} is not a recursive mutex the calling thread does not own the mutex.
 
 \pnum
@@ -1987,7 +1987,7 @@ template <class Clock, class Duration>
 \pnum
 \requires If \tcode{mutex_type} is not a recursive mutex the calling thread
 does not own the mutex. The supplied \tcode{Mutex} type shall meet the
-\tcode{TimedLockable} requirements~(\ref{thread.req.lockable.timed}).
+\tcode{TimedLockable} requirements\iref{thread.req.lockable.timed}.
 
 \pnum
 \effects Constructs an object of type \tcode{unique_lock} and calls \tcode{m.try_lock_until(abs_time)}.
@@ -2007,7 +2007,7 @@ template <class Rep, class Period>
 \begin{itemdescr}
 \pnum
 \requires If \tcode{mutex_type} is not a recursive mutex the calling thread does not own the mutex.
-The supplied \tcode{Mutex} type shall meet the \tcode{TimedLockable} requirements~(\ref{thread.req.lockable.timed}).
+The supplied \tcode{Mutex} type shall meet the \tcode{TimedLockable} requirements\iref{thread.req.lockable.timed}.
 
 \pnum
 \effects Constructs an object of type \tcode{unique_lock} and calls \tcode{m.try_lock_for(rel_time)}.
@@ -2069,7 +2069,7 @@ void lock();
 \pnum
 \throws
 Any exception thrown by \tcode{pm->lock()}. \tcode{system_error} when an exception
-is required~(\ref{thread.req.exception}).
+is required\iref{thread.req.exception}.
 
 \pnum
 \errors
@@ -2088,7 +2088,7 @@ bool try_lock();
 \begin{itemdescr}
 \pnum
 \requires The supplied \tcode{Mutex} shall meet the \tcode{Lockable}
-requirements~(\ref{thread.req.lockable.req}).
+requirements\iref{thread.req.lockable.req}.
 
 \pnum
 \effects As if by \tcode{pm->try_lock()}.
@@ -2102,7 +2102,7 @@ the call to \tcode{try_lock()}.
 \pnum
 \throws
 Any exception thrown by \tcode{pm->try_lock()}. \tcode{system_error} when an exception
-is required~(\ref{thread.req.exception}).
+is required\iref{thread.req.exception}.
 
 \pnum
 \errors
@@ -2122,7 +2122,7 @@ template <class Clock, class Duration>
 \begin{itemdescr}
 \pnum
 \requires The supplied \tcode{Mutex} type shall meet the \tcode{TimedLockable}
-requirements~(\ref{thread.req.lockable.timed}).
+requirements\iref{thread.req.lockable.timed}.
 
 \pnum
 \effects As if by \tcode{pm->try_lock_until(abs_time)}.
@@ -2136,7 +2136,7 @@ the call to \tcode{try_lock_until(abs_time)}.
 
 \pnum
 \throws Any exception thrown by \tcode{pm->try_lock_until()}. \tcode{system_error} when an
-exception is required~(\ref{thread.req.exception}).
+exception is required\iref{thread.req.exception}.
 
 \pnum
 \errors
@@ -2155,7 +2155,7 @@ template <class Rep, class Period>
 
 \begin{itemdescr}
 \pnum
-\requires The supplied \tcode{Mutex} type shall meet the \tcode{TimedLockable} requirements~(\ref{thread.req.lockable.timed}).
+\requires The supplied \tcode{Mutex} type shall meet the \tcode{TimedLockable} requirements\iref{thread.req.lockable.timed}.
 
 \pnum
 \effects As if by \tcode{pm->try_lock_for(rel_time)}.
@@ -2168,7 +2168,7 @@ template <class Rep, class Period>
 
 \pnum
 \throws Any exception thrown by \tcode{pm->try_lock_for()}. \tcode{system_error} when an
-exception is required~(\ref{thread.req.exception}).
+exception is required\iref{thread.req.exception}.
 
 \pnum
 \errors
@@ -2190,7 +2190,7 @@ void unlock();
 \pnum\postconditions \tcode{owns == false}.
 
 \pnum\throws \tcode{system_error} when
-an exception is required~(\ref{thread.req.exception}).
+an exception is required\iref{thread.req.exception}.
 
 \pnum \errors
 \begin{itemize}
@@ -2327,13 +2327,13 @@ acquisition, to another \tcode{shared_lock} object. Objects of type
 \tcode{shared_lock} are not copyable but are movable. The behavior of a program
 is undefined if the contained pointer \tcode{pm} is not null and the lockable
 object pointed to by \tcode{pm} does not exist for the entire remaining
-lifetime~(\ref{basic.life}) of the \tcode{shared_lock} object. The supplied
+lifetime\iref{basic.life} of the \tcode{shared_lock} object. The supplied
 \tcode{Mutex} type shall meet the shared mutex
-requirements~(\ref{thread.sharedtimedmutex.requirements}).
+requirements\iref{thread.sharedtimedmutex.requirements}.
 
 \pnum
 \begin{note} \tcode{shared_lock<Mutex>} meets the \tcode{TimedLockable}
-requirements~(\ref{thread.req.lockable.timed}). \end{note}
+requirements\iref{thread.req.lockable.timed}. \end{note}
 
 \rSec4[thread.lock.shared.cons]{\tcode{shared_lock} constructors, destructor, and assignment}
 
@@ -2508,7 +2508,7 @@ void lock();
 
 \pnum
 \throws Any exception thrown by \tcode{pm->lock_shared()}.
-\tcode{system_error} when an exception is required~(\ref{thread.req.exception}).
+\tcode{system_error} when an exception is required\iref{thread.req.exception}.
 
 \pnum
 \errors
@@ -2537,7 +2537,7 @@ the call to \tcode{pm->try_lock_shared()}.
 
 \pnum
 \throws Any exception thrown by \tcode{pm->try_lock_shared()}.
-\tcode{system_error} when an exception is required~(\ref{thread.req.exception}).
+\tcode{system_error} when an exception is required\iref{thread.req.exception}.
 
 \pnum
 \errors
@@ -2569,7 +2569,7 @@ the call to \tcode{pm->try_lock_shared_until(abs_time)}.
 
 \pnum
 \throws Any exception thrown by \tcode{pm->try_lock_shared_until(abs_time)}.
-\tcode{system_error} when an exception is required~(\ref{thread.req.exception}).
+\tcode{system_error} when an exception is required\iref{thread.req.exception}.
 
 \pnum
 \errors
@@ -2597,7 +2597,7 @@ template <class Rep, class Period>
 \postconditions \tcode{owns == res}, where \tcode{res} is the value returned by the call to \tcode{pm->try_lock_shared_for(rel_time)}.
 
 \pnum
-\throws Any exception thrown by \tcode{pm->try_lock_shared_for(rel_time)}. \tcode{system_error} when an exception is required~(\ref{thread.req.exception}).
+\throws Any exception thrown by \tcode{pm->try_lock_shared_for(rel_time)}. \tcode{system_error} when an exception is required\iref{thread.req.exception}.
 
 \pnum
 \errors
@@ -2621,7 +2621,7 @@ void unlock();
 \postconditions \tcode{owns == false}.
 
 \pnum
-\throws \tcode{system_error} when an exception is required~(\ref{thread.req.exception}).
+\throws \tcode{system_error} when an exception is required\iref{thread.req.exception}.
 
 \pnum
 \errors
@@ -2817,12 +2817,12 @@ earlier returning execution. \end{note}
 
 \pnum
 \sync For any given \tcode{once_flag}: all active executions occur in a total
-order; completion of an active execution synchronizes with~(\ref{intro.multithread})
+order; completion of an active execution synchronizes with\iref{intro.multithread}
 the start of the next one in this total order; and the returning execution
 synchronizes with the return from all passive executions.
 
 \pnum\throws \tcode{system_error} when
-an exception is required~(\ref{thread.req.exception}), or any exception thrown by \tcode{func}.
+an exception is required\iref{thread.req.exception}, or any exception thrown by \tcode{func}.
 
 \pnum
 \begin{example}
@@ -2998,7 +2998,7 @@ namespace std {
 \end{codeblock}
 
 \pnum
-The class \tcode{condition_variable} shall be a standard-layout class (Clause~\ref{class}).
+The class \tcode{condition_variable} shall be a standard-layout class\iref{class}.
 
 \indexlibrary{\idxcode{condition_variable}!constructor}%
 \begin{itemdecl}
@@ -3010,7 +3010,7 @@ condition_variable();
 \effects Constructs an object of type \tcode{condition_variable}.
 
 \pnum
-\throws \tcode{system_error} when an exception is required~(\ref{thread.req.exception}).
+\throws \tcode{system_error} when an exception is required\iref{thread.req.exception}.
 
 \pnum
 \errors
@@ -3085,7 +3085,7 @@ or a call to \tcode{notify_all()}, or spuriously.
 \pnum
 \remarks
 If the function fails to meet the postcondition, \tcode{terminate()}
-shall be called~(\ref{except.terminate}).
+shall be called\iref{except.terminate}.
 \begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
 
 \pnum
@@ -3124,7 +3124,7 @@ while (!pred())
 \pnum
 \remarks
 If the function fails to meet the postcondition, \tcode{terminate()}
-shall be called~(\ref{except.terminate}).
+shall be called\iref{except.terminate}.
 \begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
 
 \pnum
@@ -3165,7 +3165,7 @@ When unblocked, calls \tcode{lock.lock()} (possibly blocking on the lock), then 
 
 \item
 The function will unblock when signaled by a call to \tcode{notify_one()}, a call to \tcode{notify_all()},
-expiration of the absolute timeout~(\ref{thread.req.timing}) specified by \tcode{abs_time},
+expiration of the absolute timeout\iref{thread.req.timing} specified by \tcode{abs_time},
 or spuriously.
 
 \item
@@ -3175,7 +3175,7 @@ If the function exits via an exception, \tcode{lock.lock()} shall be called prio
 \pnum
 \remarks
 If the function fails to meet the postcondition, \tcode{terminate()}
-shall be called~(\ref{except.terminate}).
+shall be called\iref{except.terminate}.
 \begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
 
 \pnum
@@ -3184,11 +3184,11 @@ is locked by the calling thread.
 
 \pnum
 \returns \tcode{cv_status::timeout} if
-the absolute timeout~(\ref{thread.req.timing}) specified by \tcode{abs_time} expired,
+the absolute timeout\iref{thread.req.timing} specified by \tcode{abs_time} expired,
 otherwise \tcode{cv_status::no_timeout}.
 
 \pnum\throws Timeout-related
-exceptions~(\ref{thread.req.timing}).
+exceptions\iref{thread.req.timing}.
 
 \end{itemdescr}
 
@@ -3218,13 +3218,13 @@ return wait_until(lock, chrono::steady_clock::now() + rel_time);
 
 \pnum
 \returns \tcode{cv_status::timeout} if
-the relative timeout~(\ref{thread.req.timing}) specified by \tcode{rel_time} expired,
+the relative timeout\iref{thread.req.timing} specified by \tcode{rel_time} expired,
 otherwise \tcode{cv_status::no_timeout}.
 
 \pnum
 \remarks
 If the function fails to meet the postcondition, \tcode{terminate()}
-shall be called~(\ref{except.terminate}).
+shall be called\iref{except.terminate}.
 \begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
 
 \pnum
@@ -3233,7 +3233,7 @@ is locked by the calling thread.
 
 \pnum
 \throws Timeout-related
-exceptions~(\ref{thread.req.timing}).
+exceptions\iref{thread.req.timing}.
 
 \end{itemdescr}
 
@@ -3269,7 +3269,7 @@ return true;
 \pnum
 \remarks
 If the function fails to meet the postcondition, \tcode{terminate()}
-shall be called~(\ref{except.terminate}).
+shall be called\iref{except.terminate}.
 \begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
 
 \pnum
@@ -3282,7 +3282,7 @@ is locked by the calling thread.
 
 \pnum
 \throws Timeout-related
-exceptions~(\ref{thread.req.timing}) or any exception thrown by \tcode{pred}.
+exceptions\iref{thread.req.timing} or any exception thrown by \tcode{pred}.
 
 \end{itemdescr}
 
@@ -3321,7 +3321,7 @@ timeout has already expired. \end{note}
 \pnum
 \remarks
 If the function fails to meet the postcondition, \tcode{terminate()}
-shall be called~(\ref{except.terminate}).
+shall be called\iref{except.terminate}.
 \begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
 
 \pnum
@@ -3334,7 +3334,7 @@ regardless of whether the timeout was triggered. \end{note}
 
 \pnum
 \throws Timeout-related
-exceptions~(\ref{thread.req.timing}) or any exception thrown by \tcode{pred}.
+exceptions\iref{thread.req.timing} or any exception thrown by \tcode{pred}.
 
 \end{itemdescr}
 
@@ -3342,7 +3342,7 @@ exceptions~(\ref{thread.req.timing}) or any exception thrown by \tcode{pred}.
 
 \pnum
 A \tcode{Lock} type shall meet the \tcode{BasicLockable}
-requirements~(\ref{thread.req.lockable.basic}). \begin{note} All of the standard
+requirements\iref{thread.req.lockable.basic}. \begin{note} All of the standard
 mutex types meet this requirement. If a \tcode{Lock} type other than one of the
 standard mutex types or a \tcode{unique_lock} wrapper for a standard mutex type
 is used with \tcode{condition_variable_any}, the user must ensure that any
@@ -3392,7 +3392,7 @@ condition_variable_any();
 
 \pnum
 \throws \tcode{bad_alloc} or \tcode{system_error} when an exception is
-required~(\ref{thread.req.exception}).
+required\iref{thread.req.exception}.
 
 \pnum
 \errors
@@ -3469,7 +3469,7 @@ a call to \tcode{notify_all()}, or spuriously.
 \pnum
 \remarks
 If the function fails to meet the postcondition, \tcode{terminate()}
-shall be called~(\ref{except.terminate}).
+shall be called\iref{except.terminate}.
 \begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
 
 \pnum\postconditions \tcode{lock} is locked by the calling thread.
@@ -3511,7 +3511,7 @@ When unblocked, calls \tcode{lock.lock()} (possibly blocking on the lock) and re
 
 \item
 The function will unblock when signaled by a call to \tcode{notify_one()}, a call to \tcode{notify_all()},
-expiration of the absolute timeout~(\ref{thread.req.timing}) specified by \tcode{abs_time},
+expiration of the absolute timeout\iref{thread.req.timing} specified by \tcode{abs_time},
 or spuriously.
 
 \item
@@ -3521,7 +3521,7 @@ If the function exits via an exception, \tcode{lock.lock()} shall be called prio
 \pnum
 \remarks
 If the function fails to meet the postcondition, \tcode{terminate()}
-shall be called~(\ref{except.terminate}).
+shall be called\iref{except.terminate}.
 \begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
 
 \pnum
@@ -3529,12 +3529,12 @@ shall be called~(\ref{except.terminate}).
 
 \pnum
 \returns \tcode{cv_status::timeout} if
-the absolute timeout~(\ref{thread.req.timing}) specified by \tcode{abs_time} expired,
+the absolute timeout\iref{thread.req.timing} specified by \tcode{abs_time} expired,
 otherwise \tcode{cv_status::no_timeout}.
 
 \pnum
 \throws Timeout-related
-exceptions~(\ref{thread.req.timing}).
+exceptions\iref{thread.req.timing}.
 
 \end{itemdescr}
 
@@ -3553,13 +3553,13 @@ return wait_until(lock, chrono::steady_clock::now() + rel_time);
 
 \pnum
 \returns \tcode{cv_status::timeout} if
-the relative timeout~(\ref{thread.req.timing}) specified by \tcode{rel_time} expired,
+the relative timeout\iref{thread.req.timing} specified by \tcode{rel_time} expired,
 otherwise \tcode{cv_status::no_timeout}.
 
 \pnum
 \remarks
 If the function fails to meet the postcondition, \tcode{terminate()}
-shall be called~(\ref{except.terminate}).
+shall be called\iref{except.terminate}.
 \begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
 
 \pnum
@@ -3567,7 +3567,7 @@ shall be called~(\ref{except.terminate}).
 
 \pnum
 \throws Timeout-related
-exceptions~(\ref{thread.req.timing}).
+exceptions\iref{thread.req.timing}.
 
 \end{itemdescr}
 
@@ -3692,7 +3692,7 @@ namespace std {
 \end{codeblock}
 
 \pnum
-The \tcode{enum} type \tcode{launch} is a bitmask type~(\ref{bitmask.types}) with
+The \tcode{enum} type \tcode{launch} is a bitmask type\iref{bitmask.types} with
 elements \tcode{launch::async} and \tcode{launch::deferred}.
 \begin{note} Implementations can provide bitmasks to specify restrictions on task
 interaction by functions launched by \tcode{async()} applicable to a
@@ -3807,7 +3807,7 @@ shared state. A \defn{waiting function} of an asynchronous return object is one
 that potentially blocks to wait for the shared state to be made
 ready.
 If a waiting function can return before the state is made ready because of a
-timeout~(\ref{thread.req.lockable}), then it is a \term{timed waiting function}, otherwise
+timeout\iref{thread.req.lockable}, then it is a \term{timed waiting function}, otherwise
 it is a \term{non-timed waiting function}.
 
 \pnum
@@ -3878,25 +3878,25 @@ the state object.
 \pnum
 Calls to functions that successfully set the stored result of a shared
 state synchronize
-with~(\ref{intro.multithread}) calls to functions
+with\iref{intro.multithread} calls to functions
 successfully detecting the ready state resulting from that setting.
 The storage of the result
 (whether normal or exceptional) into the shared state
-synchronizes with~(\ref{intro.multithread})
+synchronizes with\iref{intro.multithread}
 the successful return from a call to a waiting function on the shared state.
 
 \pnum
 Some functions (e.g., \tcode{promise::set_value_at_thread_exit}) delay making
 the shared state ready until the calling thread exits. The destruction of
-each of that thread's objects with thread storage duration~(\ref{basic.stc.thread})
+each of that thread's objects with thread storage duration\iref{basic.stc.thread}
 is sequenced before making that shared state ready.
 
 \pnum
-Access to the result of the same shared state may conflict~(\ref{intro.multithread}).
+Access to the result of the same shared state may conflict\iref{intro.multithread}.
 \begin{note} This explicitly specifies that the result of the shared state is
 visible in the objects that reference this state in the sense of data race
-avoidance~(\ref{res.on.data.races}). For example, concurrent accesses through
-references returned by \tcode{shared_future::get()}~(\ref{futures.shared_future})
+avoidance\iref{res.on.data.races}. For example, concurrent accesses through
+references returned by \tcode{shared_future::get()}\iref{futures.shared_future}
 must either use read-only operations or provide additional synchronization.
 \end{note}
 
@@ -3959,7 +3959,7 @@ template <class R, class Alloc>
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{Alloc} shall be an Allocator~(\ref{allocator.requirements}).
+\requires \tcode{Alloc} shall be an Allocator\iref{allocator.requirements}.
 \end{itemdescr}
 
 
@@ -3999,7 +3999,7 @@ of \tcode{rhs} (if any) to the newly-constructed object.
 \begin{itemdescr}
 \pnum
 \effects
-Abandons any shared state~(\ref{futures.state}).
+Abandons any shared state\iref{futures.state}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{promise}%
@@ -4010,7 +4010,7 @@ promise& operator=(promise&& rhs) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Abandons any shared state~(\ref{futures.state}) and then as if
+Abandons any shared state\iref{futures.state} and then as if
 \tcode{promise(std::move(rhs)).swap(*this)}.
 
 \pnum
@@ -4069,7 +4069,7 @@ void promise<void>::set_value();
 \begin{itemdescr}
 \pnum
 \effects Atomically stores the value \tcode{r} in the shared state and
-makes that state ready~(\ref{futures.state}).
+makes that state ready\iref{futures.state}.
 
 \pnum
 \throws
@@ -4101,7 +4101,7 @@ void set_exception(exception_ptr p);
 
 \pnum
 \effects Atomically stores the exception pointer \tcode{p} in the shared state
-and makes that state ready~(\ref{futures.state}).
+and makes that state ready\iref{futures.state}.
 
 \pnum
 \throws \tcode{future_error} if its shared state
@@ -4196,7 +4196,7 @@ The class template \tcode{future} defines a type for asynchronous return objects
 do not share their shared state with other asynchronous return objects.
 A default-constructed \tcode{future} object has no
 shared state. A \tcode{future} object with shared state can be created by
-functions on asynchronous providers~(\ref{futures.state}) or by the move constructor
+functions on asynchronous providers\iref{futures.state} or by the move constructor
 and shares its shared state with
 the original asynchronous provider. The result (value or exception) of
 a \tcode{future} object
@@ -4299,7 +4299,7 @@ constructor invocation.
 \effects
 \begin{itemize}
 \item
-Releases any shared state~(\ref{futures.state});
+Releases any shared state\iref{futures.state};
 \item
 destroys \tcode{*this}.
 \end{itemize}
@@ -4315,7 +4315,7 @@ future& operator=(future&& rhs) noexcept;
 \effects
 \begin{itemize}
 \item
-Releases any shared state~(\ref{futures.state}).
+Releases any shared state\iref{futures.state}.
 \item
 move assigns the contents of \tcode{rhs} to \tcode{*this}.
 \end{itemize}
@@ -4364,7 +4364,7 @@ the return type and return value of the member function \tcode{get}.
 \begin{itemize}
 \item \tcode{wait()}{s} until the shared state is ready, then retrieves the
 value stored in the shared state;
-\item releases any shared state~(\ref{futures.state}).
+\item releases any shared state\iref{futures.state}.
 \end{itemize}
 
 \pnum
@@ -4418,10 +4418,10 @@ template <class Rep, class Period>
 \begin{itemdescr}
 \pnum
 \effects
-None if the shared state contains a deferred function~(\ref{futures.async}),
+None if the shared state contains a deferred function\iref{futures.async},
 otherwise
 blocks until the shared state is ready or until
-the relative timeout~(\ref{thread.req.timing}) specified by \tcode{rel_time} has expired.
+the relative timeout\iref{thread.req.timing} specified by \tcode{rel_time} has expired.
 
 \pnum
 \returns
@@ -4433,13 +4433,13 @@ function.
 \item \tcode{future_status::ready} if the shared state is ready.
 
 \item \tcode{future_status::timeout} if the function is returning because the
-relative timeout~(\ref{thread.req.timing})
+relative timeout\iref{thread.req.timing}
 specified by \tcode{rel_time} has expired.
 \end{itemize}
 
 \pnum
 \throws
-timeout-related exceptions~(\ref{thread.req.timing}).
+timeout-related exceptions\iref{thread.req.timing}.
 \end{itemdescr}
 
 \indexlibrarymember{wait_until}{future}%
@@ -4451,10 +4451,10 @@ template <class Clock, class Duration>
 \begin{itemdescr}
 \pnum
 \effects
-None if the shared state contains a deferred function~(\ref{futures.async}),
+None if the shared state contains a deferred function\iref{futures.async},
 otherwise
 blocks until the shared state is ready or until
-the absolute timeout~(\ref{thread.req.timing}) specified by \tcode{abs_time} has expired.
+the absolute timeout\iref{thread.req.timing} specified by \tcode{abs_time} has expired.
 
 \pnum
 \returns
@@ -4466,13 +4466,13 @@ function.
 \item \tcode{future_status::ready} if the shared state is ready.
 
 \item \tcode{future_status::timeout} if the function is returning because the
-absolute timeout~(\ref{thread.req.timing})
+absolute timeout\iref{thread.req.timing}
 specified by \tcode{abs_time} has expired.
 \end{itemize}
 
 \pnum
 \throws
-timeout-related exceptions~(\ref{thread.req.timing}).
+timeout-related exceptions\iref{thread.req.timing}.
 \end{itemdescr}
 
 
@@ -4486,7 +4486,7 @@ object has no shared state. A \tcode{shared_future} object with
 shared state can
 be created
 by conversion from a \tcode{future} object and shares its shared state with the
-original asynchronous provider~(\ref{futures.state}) of the shared state.
+original asynchronous provider\iref{futures.state} of the shared state.
 The result (value or exception) of a \tcode{shared_future} object
 can be set by
 calling a respective function on an
@@ -4599,7 +4599,7 @@ the constructor invocation.
 \effects
 \begin{itemize}
 \item
-Releases any shared state~(\ref{futures.state});
+Releases any shared state\iref{futures.state};
 \item
 destroys \tcode{*this}.
 \end{itemize}
@@ -4615,7 +4615,7 @@ shared_future& operator=(shared_future&& rhs) noexcept;
 \effects
 \begin{itemize}
 \item
-Releases any shared state~(\ref{futures.state});
+Releases any shared state\iref{futures.state};
 \item
 move assigns the contents of \tcode{rhs} to \tcode{*this}.
 \end{itemize}
@@ -4642,7 +4642,7 @@ shared_future& operator=(const shared_future& rhs) noexcept;
 \effects
 \begin{itemize}
 \item
-Releases any shared state~(\ref{futures.state});
+Releases any shared state\iref{futures.state};
 \item
 assigns the contents of \tcode{rhs} to \tcode{*this}. \begin{note} As a result,
 \tcode{*this} refers to the same shared state as \tcode{rhs}
@@ -4671,7 +4671,7 @@ the return type and return value of the member function \tcode{get}.
 \begin{note}
 Access to a value object stored in the shared state is
 unsynchronized, so programmers should apply only those operations on \tcode{R} that do not
-introduce a data race~(\ref{intro.multithread}).
+introduce a data race\iref{intro.multithread}.
 \end{note}
 
 \pnum
@@ -4731,10 +4731,10 @@ template <class Rep, class Period>
 \begin{itemdescr}
 \pnum
 \effects
-None if the shared state contains a deferred function~(\ref{futures.async}),
+None if the shared state contains a deferred function\iref{futures.async},
 otherwise
 blocks until the shared state is ready or until
-the relative timeout~(\ref{thread.req.timing}) specified by
+the relative timeout\iref{thread.req.timing} specified by
 \tcode{rel_time} has expired.
 
 \pnum
@@ -4747,13 +4747,13 @@ function.
 \item \tcode{future_status::ready} if the shared state is ready.
 
 \item \tcode{future_status::timeout} if the function is returning because the
-relative timeout~(\ref{thread.req.timing})
+relative timeout\iref{thread.req.timing}
 specified by \tcode{rel_time} has expired.
 \end{itemize}
 
 \pnum
 \throws
-timeout-related exceptions~(\ref{thread.req.timing}).
+timeout-related exceptions\iref{thread.req.timing}.
 \end{itemdescr}
 
 \indexlibrarymember{wait_until}{shared_future}%
@@ -4765,10 +4765,10 @@ template <class Clock, class Duration>
 \begin{itemdescr}
 \pnum
 \effects
-None if the shared state contains a deferred function~(\ref{futures.async}),
+None if the shared state contains a deferred function\iref{futures.async},
 otherwise
 blocks until the shared state is ready or until the
-absolute timeout~(\ref{thread.req.timing}) specified by
+absolute timeout\iref{thread.req.timing} specified by
 \tcode{abs_time} has expired.
 
 \pnum
@@ -4781,13 +4781,13 @@ function.
 \item \tcode{future_status::ready} if the shared state is ready.
 
 \item \tcode{future_status::timeout} if the function is returning because the
-absolute timeout~(\ref{thread.req.timing})
+absolute timeout\iref{thread.req.timing}
 specified by \tcode{abs_time} has expired.
 \end{itemize}
 
 \pnum
 \throws
-timeout-related exceptions~(\ref{thread.req.timing}).
+timeout-related exceptions\iref{thread.req.timing}.
 \end{itemdescr}
 
 \rSec2[futures.async]{Function template \tcode{async}}
@@ -4869,7 +4869,7 @@ is stored as the exceptional result
 in the shared state.
 The shared state is not
 made ready until the function has completed. The first call to a
-non-timed waiting function~(\ref{futures.state})
+non-timed waiting function\iref{futures.state}
 on an asynchronous return object referring to
 this shared state shall invoke the
 deferred function in the thread that called the waiting function.
@@ -4899,12 +4899,12 @@ Regardless of the provided \tcode{policy} argument,
 \begin{itemize}
 \item
 the invocation of \tcode{async}
-synchronizes with~(\ref{intro.multithread}) the invocation of \tcode{f}. \begin{note}
+synchronizes with\iref{intro.multithread} the invocation of \tcode{f}. \begin{note}
 This statement applies even when the corresponding \tcode{future} object is moved to
 another thread. \end{note}; and
 
 \item
-the completion of the function \tcode{f} is sequenced before~(\ref{intro.multithread}) the
+the completion of the function \tcode{f} is sequenced before\iref{intro.multithread} the
 shared state is made ready. \begin{note} \tcode{f} might not be called at all,
 so its completion might never happen. \end{note}
 \end{itemize}
@@ -4916,11 +4916,11 @@ If the implementation chooses the \tcode{launch::async} policy,
 a call to a waiting function on an asynchronous return
 object that shares the shared state created by this \tcode{async} call shall
 block until the associated thread has completed, as if joined, or else time
-out~(\ref{thread.thread.member});
+out\iref{thread.thread.member};
 
 \item
 the associated thread completion
-synchronizes with~(\ref{intro.multithread})
+synchronizes with\iref{intro.multithread}
 the return from
 the first function
 that successfully detects the ready status of the shared state or
@@ -5038,7 +5038,7 @@ template <class F>
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{\placeholdernc{INVOKE}<R>(f, t$_1$, t$_2$, $\dotsc$, t$_N$)}~(\ref{func.require}), where \tcode{t$_1$, t$_2$, $\dotsc$, t$_N$} are values
+\tcode{\placeholdernc{INVOKE}<R>(f, t$_1$, t$_2$, $\dotsc$, t$_N$)}\iref{func.require}, where \tcode{t$_1$, t$_2$, $\dotsc$, t$_N$} are values
 of the corresponding types in \tcode{ArgTypes...}, shall be a valid expression. Invoking
 a copy of \tcode{f} shall behave the same as invoking \tcode{f}.
 
@@ -5088,7 +5088,7 @@ packaged_task& operator=(packaged_task&& rhs) noexcept;
 \effects
 \begin{itemize}
 \item
-Releases any shared state~(\ref{futures.state});
+Releases any shared state\iref{futures.state};
 \item
 calls \tcode{packaged_task(std::move(rhs)).swap(*this)}.
 \end{itemize}
@@ -5102,7 +5102,7 @@ calls \tcode{packaged_task(std::move(rhs)).swap(*this)}.
 \begin{itemdescr}
 \pnum
 \effects
-Abandons any shared state~(\ref{futures.state}).
+Abandons any shared state\iref{futures.state}.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{packaged_task}%
@@ -5160,7 +5160,7 @@ void operator()(ArgTypes... args);
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{\placeholdernc{INVOKE}<R>(f, t$_1$, t$_2$, $\dotsc$, t$_N$)}~(\ref{func.require}),
+\effects As if by \tcode{\placeholdernc{INVOKE}<R>(f, t$_1$, t$_2$, $\dotsc$, t$_N$)}\iref{func.require},
 where \tcode{f} is the
 stored task of \tcode{*this} and
 \tcode{t$_1$, t$_2$, $\dotsc$, t$_N$} are the values in \tcode{args...}. If the task returns normally,
@@ -5190,12 +5190,12 @@ void make_ready_at_thread_exit(ArgTypes... args);
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{\placeholdernc{INVOKE}<R>(f, t$_1$, t$_2$, $\dotsc$, t$_N$)}~(\ref{func.require}),
+\effects As if by \tcode{\placeholdernc{INVOKE}<R>(f, t$_1$, t$_2$, $\dotsc$, t$_N$)}\iref{func.require},
 where \tcode{f} is the stored task and
 \tcode{t$_1$, t$_2$, $\dotsc$, t$_N$} are the values in \tcode{args...}. If the task returns normally,
 the return value is stored as the asynchronous result in the shared state of
 \tcode{*this}, otherwise the exception thrown by the task is stored. In either
-case, this shall be done without making that state ready~(\ref{futures.state}) immediately. Schedules
+case, this shall be done without making that state ready\iref{futures.state} immediately. Schedules
 the shared state to be made ready when the current thread exits,
 after all objects of thread storage duration associated with the current thread
 have been destroyed.
@@ -5222,7 +5222,7 @@ void reset();
 \effects As if \tcode{*this = packaged_task(std::move(f))}, where
 \tcode{f} is the task stored in
 \tcode{*this}. \begin{note} This constructs a new shared state for \tcode{*this}. The
-old state is abandoned~(\ref{futures.state}). \end{note}
+old state is abandoned\iref{futures.state}. \end{note}
 
 \pnum
 \throws
@@ -5257,5 +5257,5 @@ template <class R, class Alloc>
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{Alloc} shall be an Allocator~(\ref{allocator.requirements}).
+\requires \tcode{Alloc} shall be an Allocator\iref{allocator.requirements}.
 \end{itemdescr}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -165,7 +165,7 @@ namespace std {
     explicit piecewise_construct_t() = default;
   };
   inline constexpr piecewise_construct_t piecewise_construct{};
-  template <class... Types> class tuple;        // defined in \tcode{<tuple>}~(\ref{tuple.syn})
+  template <class... Types> class tuple;        // defined in \tcode{<tuple>}\iref{tuple.syn}
 
   // in-place construction
   struct in_place_t {
@@ -192,7 +192,7 @@ and various function templates that operate on \tcode{pair} objects.
 
 \pnum
 The type \tcode{chars_format}
-is a bitmask type~(\ref{bitmask.types})
+is a bitmask type\iref{bitmask.types}
 with elements
 \tcode{scientific},
 \tcode{fixed},
@@ -318,7 +318,7 @@ unless \tcode{is_swappable_v<T>} is \tcode{true}.
 
 \pnum
 \requires
-\tcode{a[i]} shall be swappable with~(\ref{swappable.requirements}) \tcode{b[i]}
+\tcode{a[i]} shall be swappable with\iref{swappable.requirements} \tcode{b[i]}
 for all \tcode{i} in the range \range{0}{N}.
 
 \pnum
@@ -353,7 +353,7 @@ of forwarding functions.
 \indextext{signal-safe!\idxcode{forward}}%
 \indextext{signal-safe!\idxcode{move}}%
 \indextext{signal-safe!\idxcode{move_if_noexcept}}%
-All functions specified in this subclause are signal-safe~(\ref{support.signal}).
+All functions specified in this subclause are signal-safe\iref{support.signal}.
 
 \indexlibrary{\idxcode{forward}}%
 \begin{itemdecl}
@@ -467,7 +467,7 @@ template <class T> constexpr add_const_t<T>& as_const(T& t) noexcept;
 
 \pnum
 The library provides the function template \tcode{declval} to simplify the definition of
-expressions which occur as unevaluated operands (Clause~\ref{expr}).
+expressions which occur as unevaluated operands\iref{expr}.
 
 \indexlibrary{\idxcode{declval}}%
 \begin{itemdecl}
@@ -476,7 +476,7 @@ template <class T> add_rvalue_reference_t<T> declval() noexcept;    // as uneval
 
 \begin{itemdescr}
 \pnum
-\remarks If this function is odr-used~(\ref{basic.def.odr}), the program is ill-formed.
+\remarks If this function is odr-used\iref{basic.def.odr}, the program is ill-formed.
 
 \pnum
 \remarks The template parameter \tcode{T} of \tcode{declval} may be an incomplete type.
@@ -489,7 +489,7 @@ template <class To, class From> decltype(static_cast<To>(declval<From>())) conve
 \end{codeblock}
 declares a function template \tcode{convert} which only participates in overloading if the
 type \tcode{From} can be explicitly converted to type \tcode{To}. For another example see class
-template \tcode{common_type}~(\ref{meta.trans.other}).
+template \tcode{common_type}\iref{meta.trans.other}.
 \end{example}
 
 \rSec1[intseq]{Compile-time integer sequences}
@@ -822,7 +822,7 @@ void swap(pair& p) noexcept(@\seebelow@);
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{first} shall be swappable with~(\ref{swappable.requirements})
+\tcode{first} shall be swappable with\iref{swappable.requirements}
 \tcode{p.first} and \tcode{second} shall be swappable with \tcode{p.second}.
 
 \pnum
@@ -1045,7 +1045,7 @@ inline constexpr piecewise_construct_t piecewise_construct{};
 The \tcode{struct} \tcode{piecewise_construct_t} is an empty structure type
 used as a unique type to disambiguate constructor and function overloading. Specifically,
 \tcode{pair} has a constructor with \tcode{piecewise_construct_t} as the
-first argument, immediately followed by two \tcode{tuple}~(\ref{tuple}) arguments used
+first argument, immediately followed by two \tcode{tuple}\iref{tuple} arguments used
 for piecewise construction of the elements of the \tcode{pair} object.
 
 \rSec1[tuple]{Tuples}
@@ -1479,11 +1479,11 @@ template <class Alloc, class U1, class U2>
 \begin{itemdescr}
 \pnum
 \requires \tcode{Alloc} shall meet the requirements for an
-\tcode{Allocator}~(\ref{allocator.requirements}).
+\tcode{Allocator}\iref{allocator.requirements}.
 
 \pnum
 \effects Equivalent to the preceding constructors except that each element is constructed with
-uses-allocator construction~(\ref{allocator.uses.construction}).
+uses-allocator construction\iref{allocator.uses.construction}.
 \end{itemdescr}
 
 \rSec3[tuple.assign]{Assignment}
@@ -1635,7 +1635,7 @@ void swap(tuple& rhs) noexcept(@\seebelow@);
 \begin{itemdescr}
 \pnum
 \requires
-Each element in \tcode{*this} shall be swappable with~(\ref{swappable.requirements})
+Each element in \tcode{*this} shall be swappable with\iref{swappable.requirements}
 the corresponding element in \tcode{rhs}.
 
 \pnum
@@ -1847,7 +1847,7 @@ template <class T> struct tuple_size;
 \begin{itemdescr}
 \pnum
 \remarks All specializations of \tcode{tuple_size} shall meet the
-\tcode{UnaryTypeTrait} requirements~(\ref{meta.rqmts}) with a
+\tcode{UnaryTypeTrait} requirements\iref{meta.rqmts} with a
 base characteristic of \tcode{integral_constant<size_t, N>}
 for some \tcode{N}.
 \end{itemdescr}
@@ -1890,7 +1890,7 @@ template <class T> class tuple_size<const volatile T>;
 Let \tcode{\placeholder{TS}} denote \tcode{tuple_size<T>} of the \cv-unqualified type \tcode{T}.
 If the expression \tcode{\placeholder{TS}::value} is well-formed
 when treated as an unevaluated operand, then each
-of the three templates shall meet the \tcode{UnaryTypeTrait} requirements~(\ref{meta.rqmts})
+of the three templates shall meet the \tcode{UnaryTypeTrait} requirements\iref{meta.rqmts}
 with a base characteristic of
 \begin{codeblock}
 integral_constant<size_t, @\placeholder{TS}@::value>
@@ -1926,7 +1926,7 @@ template <size_t I, class T> class tuple_element<I, const volatile T>;
 \pnum
 Let \tcode{\placeholder{TE}} denote \tcode{tuple_element_t<I, T>} of the \cv-unqualified type \tcode{T}. Then
 each of the three templates shall meet the \tcode{TransformationTrait}
-requirements~(\ref{meta.rqmts}) with a member typedef \tcode{type} that names the following
+requirements\iref{meta.rqmts} with a member typedef \tcode{type} that names the following
 type:
 
 \begin{itemize}
@@ -2140,7 +2140,7 @@ template <class... Types, class Alloc>
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{Alloc} shall be an \tcode{Allocator}~(\ref{allocator.requirements}).
+\requires \tcode{Alloc} shall be an \tcode{Allocator}\iref{allocator.requirements}.
 
 \pnum
 \begin{note} Specialization of this trait informs other library components that
@@ -2366,7 +2366,7 @@ constexpr optional(nullopt_t) noexcept;
 \pnum
 \remarks
 No contained value is initialized.
-For every object type \tcode{T} these constructors shall be constexpr constructors~(\ref{dcl.constexpr}).
+For every object type \tcode{T} these constructors shall be constexpr constructors\iref{dcl.constexpr}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{optional}!constructor}%
@@ -3731,7 +3731,7 @@ template <class T> struct hash<optional<T>>;
 
 \begin{itemdescr}
 \pnum
-The specialization \tcode{hash<optional<T>>} is enabled~(\ref{unord.hash})
+The specialization \tcode{hash<optional<T>>} is enabled\iref{unord.hash}
 if and only if \tcode{hash<remove_const_t<T>>} is enabled.
 When enabled, for an object \tcode{o} of type \tcode{optional<T>},
 if \tcode{bool(o) == true}, then \tcode{hash<optional<T>>()(o)}
@@ -4543,7 +4543,7 @@ void swap(variant& rhs) noexcept(@\seebelow@);
 
 \begin{itemdescr}
 \pnum
-\requires Lvalues of type $\tcode{T}_i$ shall be swappable~(\ref{swappable.requirements}) and
+\requires Lvalues of type $\tcode{T}_i$ shall be swappable\iref{swappable.requirements} and
 \tcode{is_move_constructible_v<$\tcode{T}_i$>} shall be \tcode{true} for all $i$.
 
 \pnum
@@ -4590,7 +4590,7 @@ template <class T> struct variant_size;
 \pnum
 \remarks
 All specializations of \tcode{variant_size} shall meet the
-\tcode{UnaryTypeTrait} requirements~(\ref{meta.rqmts})
+\tcode{UnaryTypeTrait} requirements\iref{meta.rqmts}
 with a base characteristic of \tcode{integral_constant<size_t, N>} for some \tcode{N}.
 \end{itemdescr}
 
@@ -4605,7 +4605,7 @@ template <class T> class variant_size<const volatile T>;
 \pnum
 Let \tcode{VS} denote \tcode{variant_size<T>} of the cv-unqualified
 type \tcode{T}. Then each of the three templates shall meet the
-\tcode{UnaryTypeTrait} requirements~(\ref{meta.rqmts}) with a
+\tcode{UnaryTypeTrait} requirements\iref{meta.rqmts} with a
 base characteristic of \tcode{integral_constant<size_t, VS::value>}.
 \end{itemdescr}
 
@@ -4627,7 +4627,7 @@ template <size_t I, class T> class variant_alternative<I, const volatile T>;
 \pnum
 Let \tcode{VA} denote \tcode{variant_alternative<I, T>} of the
 cv-unqualified type \tcode{T}. Then each of the three templates shall
-meet the \tcode{TransformationTrait} requirements~(\ref{meta.rqmts}) with a
+meet the \tcode{TransformationTrait} requirements\iref{meta.rqmts} with a
 member typedef \tcode{type} that names the following type:
 \begin{itemize}
 \item for the first specialization, \tcode{add_const_t<VA::type>},
@@ -4903,7 +4903,7 @@ The expression in the \effects element shall be a valid expression of the same
 \pnum
 \effects
 Let \tcode{is...} be \tcode{vars.index()...}. Returns \tcode{\placeholdernc{INVOKE}(forward<Visitor>(vis), get<is>(}\brk{}
-\tcode{forward<Variants>(vars))...);}~(\ref{func.require}).
+\tcode{forward<Variants>(vars))...);}\iref{func.require}.
 
 \pnum
 \remarks
@@ -5022,7 +5022,7 @@ template <class... Types> struct hash<variant<Types...>>;
 
 \begin{itemdescr}
 \pnum
-The specialization \tcode{hash<variant<Types...>>} is enabled~(\ref{unord.hash})
+The specialization \tcode{hash<variant<Types...>>} is enabled\iref{unord.hash}
 if and only if every specialization in \tcode{hash<remove_const_t<Types>>...} is enabled.
 The member functions are not guaranteed to be \tcode{noexcept}.
 \end{itemdescr}
@@ -5034,7 +5034,7 @@ template <> struct hash<monostate>;
 
 \begin{itemdescr}
 \pnum
-The specialization is enabled~(\ref{unord.hash}).
+The specialization is enabled\iref{unord.hash}.
 \end{itemdescr}
 
 
@@ -5096,7 +5096,7 @@ public:
 \end{codeblock}
 
 \pnum
-Objects of type \tcode{bad_any_cast} are thrown by a failed \tcode{any_cast}~(\ref{any.nonmembers}).
+Objects of type \tcode{bad_any_cast} are thrown by a failed \tcode{any_cast}\iref{any.nonmembers}.
 
 \indexlibrarymember{what}{bad_any_cast}%
 \begin{itemdecl}
@@ -5109,7 +5109,7 @@ const char* what() const noexcept override;
 
 \pnum
 \remarks
-The message may be a null-terminated multibyte string~(\ref{multibyte.strings}),
+The message may be a null-terminated multibyte string\iref{multibyte.strings},
 suitable for conversion and display as a wstring~(\ref{string.classes}, \ref{locale.codecvt}).
 \end{itemdescr}
 
@@ -5663,7 +5663,7 @@ bool is_string(const any& operand) {
 
 \begin{codeblock}
 #include <string>
-#include <iosfwd>   // for \tcode{istream}~(\ref{istream.syn}), \tcode{ostream}~(\ref{ostream.syn}), see \ref{iosfwd.syn}
+#include <iosfwd>   // for \tcode{istream}\iref{istream.syn}, \tcode{ostream}\iref{ostream.syn}, see \ref{iosfwd.syn}
 
 namespace std {
   template <size_t N> class bitset;
@@ -5806,19 +5806,19 @@ errors, each associated with a distinct exception:
 an
 \term{invalid-argument}
 error is associated with exceptions of type
-\tcode{invalid_argument}~(\ref{invalid.argument});
+\tcode{invalid_argument}\iref{invalid.argument};
 \indexlibrary{\idxcode{invalid_argument}}%
 \item
 an
 \term{out-of-range}
 error is associated with exceptions of type
-\tcode{out_of_range}~(\ref{out.of.range});
+\tcode{out_of_range}\iref{out.of.range};
 \indexlibrary{\idxcode{out_of_range}}%
 \item
 an
 \term{overflow}
 error is associated with exceptions of type
-\tcode{overflow_error}~(\ref{overflow.error}).
+\tcode{overflow_error}\iref{overflow.error}.
 \indexlibrary{\idxcode{overflow_error}}%
 \end{itemize}
 
@@ -5850,7 +5850,7 @@ Constructs an object of class
 initializing the first \tcode{M} bit positions to the corresponding bit
 values in \tcode{val}.
 \tcode{M} is the smaller of \tcode{N} and the number of bits in the value
-representation~(\ref{basic.types}) of \tcode{unsigned long long}.
+representation\iref{basic.types} of \tcode{unsigned long long}.
 If \tcode{M < N}, the remaining bit positions are initialized to zero.
 \end{itemdescr}
 
@@ -6405,7 +6405,7 @@ is equivalent to
 
 \pnum
 \remarks For the purpose of determining the presence of a data
-race~(\ref{intro.multithread}), any access or update through the resulting
+race\iref{intro.multithread}, any access or update through the resulting
 reference potentially accesses or modifies, respectively, the entire
 underlying bitset.
 \end{itemdescr}
@@ -6418,7 +6418,7 @@ template <size_t N> struct hash<bitset<N>>;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum The specialization is enabled~(\ref{unord.hash}).
+\pnum The specialization is enabled\iref{unord.hash}.
 \end{itemdescr}
 
 
@@ -6466,7 +6466,7 @@ template <class charT, class traits, size_t N>
 
 \begin{itemdescr}
 \pnum
-A formatted input function~(\ref{istream.formatted}).
+A formatted input function\iref{istream.formatted}.
 
 \pnum
 \effects
@@ -6495,7 +6495,7 @@ nor
 If no characters are stored in \tcode{str}, calls
 \tcode{is.setstate(ios_base::failbit)}
 (which may throw
-\tcode{ios_base::failure}~(\ref{iostate.flags})).
+\tcode{ios_base::failure}\iref{iostate.flags}).
 
 \pnum
 \returns
@@ -6526,8 +6526,8 @@ os << x.template to_string<charT, traits, allocator<charT>>(
 
 \pnum
 This subclause describes the contents of the header
-\tcode{<memory>}~(\ref{memory.syn}) and some
-of the contents of the header \tcode{<cstdlib>}~(\ref{cstdlib.syn}).
+\tcode{<memory>}\iref{memory.syn} and some
+of the contents of the header \tcode{<cstdlib>}\iref{cstdlib.syn}.
 
 \rSec2[memory.syn]{Header \tcode{<memory>} synopsis}
 
@@ -6540,7 +6540,7 @@ uninitialized memory
 buffers~(\ref{pointer.traits}--\ref{specialized.algorithms}).
 The header also defines the templates
 \tcode{unique_ptr}, \tcode{shared_ptr}, \tcode{weak_ptr}, and various function
-templates that operate on objects of these types~(\ref{smartptr}).
+templates that operate on objects of these types\iref{smartptr}.
 
 \indextext{\idxhdr{memory}}%
 \indexlibrary{\idxhdr{memory}}%
@@ -6876,7 +6876,7 @@ using element_type = @\seebelow@;
 \pnum
 \ctype \tcode{Ptr::element_type} if
 the \grammarterm{qualified-id} \tcode{Ptr::element_type} is valid and denotes a
-type~(\ref{temp.deduct}); otherwise, \tcode{T} if
+type\iref{temp.deduct}; otherwise, \tcode{T} if
 \tcode{Ptr} is a class template instantiation of the form \tcode{SomePointer<T, Args>},
 where \tcode{Args} is zero or more type arguments; otherwise, the specialization is
 ill-formed.
@@ -6891,7 +6891,7 @@ using difference_type = @\seebelow@;
 \pnum
 \ctype \tcode{Ptr::difference_type} if
 the \grammarterm{qualified-id} \tcode{Ptr::difference_type} is valid and denotes a
-type~(\ref{temp.deduct}); otherwise,
+type\iref{temp.deduct}; otherwise,
 \tcode{ptrdiff_t}.
 \end{itemdescr}
 
@@ -6904,7 +6904,7 @@ template <class U> using rebind = @\seebelow@;
 \pnum
 \templalias \tcode{Ptr::rebind<U>} if
 the \grammarterm{qualified-id} \tcode{Ptr::rebind<U>} is valid and denotes a
-type~(\ref{temp.deduct}); otherwise,
+type\iref{temp.deduct}; otherwise,
 \tcode{SomePointer<U, Args>} if
 \tcode{Ptr} is a class template instantiation of the form \tcode{SomePointer<T, Args>},
 where \tcode{Args} is zero or more type arguments; otherwise, the instantiation of
@@ -6948,11 +6948,11 @@ void declare_reachable(void* p);
 \begin{itemdescr}
 \pnum
 \requires \tcode{p} shall be a safely-derived
-pointer~(\ref{basic.stc.dynamic.safety}) or a null pointer value.
+pointer\iref{basic.stc.dynamic.safety} or a null pointer value.
 
 \pnum
 \effects If \tcode{p} is not null, the complete object referenced by \tcode{p}
-is subsequently declared reachable~(\ref{basic.stc.dynamic.safety}).
+is subsequently declared reachable\iref{basic.stc.dynamic.safety}.
 
 \pnum
 \throws May throw \tcode{bad_alloc} if the system cannot allocate
@@ -6968,7 +6968,7 @@ template <class T> T* undeclare_reachable(T* p);
 \pnum
 \requires If \tcode{p} is not null, the complete object referenced by \tcode{p}
 shall have been previously declared reachable, and shall be
-live~(\ref{basic.life}) from the time of the call until the last
+live\iref{basic.life} from the time of the call until the last
 \tcode{undeclare_reachable(p)} call on the object.
 
 \pnum
@@ -7041,7 +7041,7 @@ pointer_safety get_pointer_safety() noexcept;
 \begin{itemdescr}
 \pnum
 \returns \tcode{pointer_safety::strict} if the implementation has strict pointer
-safety~(\ref{basic.stc.dynamic.safety}). It is
+safety\iref{basic.stc.dynamic.safety}. It is
 \impldef{whether \tcode{get_pointer_safety} returns
 \tcode{pointer_safety::relaxed} or
 \tcode{pointer_safety::\brk{}preferred} if the implementation has relaxed pointer safety}
@@ -7108,7 +7108,7 @@ The \tcode{allocator_arg_t} struct is an empty structure type used as a unique t
 disambiguate constructor and function overloading. Specifically, several types (see
 \tcode{tuple}~\ref{tuple}) have constructors with \tcode{allocator_arg_t} as the first
 argument, immediately followed by an argument of a type that satisfies the
-\tcode{Allocator} requirements~(\ref{allocator.requirements}).
+\tcode{Allocator} requirements\iref{allocator.requirements}.
 
 \rSec2[allocator.uses]{\tcode{uses_allocator}}
 
@@ -7123,9 +7123,9 @@ template <class T, class Alloc> struct uses_allocator;
 \pnum
 \remarks Automatically detects whether \tcode{T} has a nested \tcode{allocator_type} that
 is convertible from \tcode{Alloc}. Meets the \tcode{BinaryTypeTrait}
-requirements~(\ref{meta.rqmts}). The implementation shall provide a definition that is
+requirements\iref{meta.rqmts}. The implementation shall provide a definition that is
 derived from \tcode{true_type} if the \grammarterm{qualified-id} \tcode{T::allocator_type}
-is valid and denotes a type~(\ref{temp.deduct}) and
+is valid and denotes a type\iref{temp.deduct} and
 \tcode{is_convertible_v<Alloc, T::allocator_type> != false}, otherwise it shall be
 derived from \tcode{false_type}. A program may specialize this template to derive from
 \tcode{true_type} for a user-defined type \tcode{T} that does not have a nested
@@ -7230,7 +7230,7 @@ using pointer = @\seebelow@;
 \pnum
 \ctype \tcode{Alloc::pointer} if
 the \grammarterm{qualified-id} \tcode{Alloc::pointer} is valid and denotes a
-type~(\ref{temp.deduct}); otherwise, \tcode{value_type*}.
+type\iref{temp.deduct}; otherwise, \tcode{value_type*}.
 \end{itemdescr}
 
 \indexlibrarymember{const_pointer}{allocator_traits}%
@@ -7242,7 +7242,7 @@ using const_pointer = @\seebelow@;
 \pnum
 \ctype \tcode{Alloc::const_pointer} if
 the \grammarterm{qualified-id} \tcode{Alloc::const_pointer} is valid and denotes a
-type~(\ref{temp.deduct}); otherwise,
+type\iref{temp.deduct}; otherwise,
 \tcode{pointer_traits<pointer>::rebind<\brk{}const value_type>}.
 \end{itemdescr}
 
@@ -7255,7 +7255,7 @@ using void_pointer = @\seebelow@;
 \pnum
 \ctype \tcode{Alloc::void_pointer} if
 the \grammarterm{qualified-id} \tcode{Alloc::void_pointer} is valid and denotes a
-type~(\ref{temp.deduct}); otherwise,
+type\iref{temp.deduct}; otherwise,
 \tcode{pointer_traits<pointer>::rebind<\brk{}void>}.
 \end{itemdescr}
 
@@ -7268,7 +7268,7 @@ using const_void_pointer = @\seebelow@;
 \pnum
 \ctype \tcode{Alloc::const_void_pointer} if
 the \grammarterm{qualified-id} \tcode{Alloc::const_void_pointer} is valid and denotes a
-type~(\ref{temp.deduct}); otherwise,
+type\iref{temp.deduct}; otherwise,
 \tcode{pointer_traits<pointer>::\brk{}rebind<const void>}.
 \end{itemdescr}
 
@@ -7281,7 +7281,7 @@ using difference_type = @\seebelow@;
 \pnum
 \ctype \tcode{Alloc::difference_type} if
 the \grammarterm{qualified-id} \tcode{Alloc::difference_type} is valid and denotes a
-type~(\ref{temp.deduct}); otherwise,
+type\iref{temp.deduct}; otherwise,
 \tcode{pointer_traits<pointer>::dif\-ference_type}.
 \end{itemdescr}
 
@@ -7294,7 +7294,7 @@ using size_type = @\seebelow@;
 \pnum
 \ctype \tcode{Alloc::size_type} if
 the \grammarterm{qualified-id} \tcode{Alloc::size_type} is valid and denotes a
-type~(\ref{temp.deduct}); otherwise,
+type\iref{temp.deduct}; otherwise,
 \tcode{make_unsigned_t<difference_type>}.
 \end{itemdescr}
 
@@ -7307,7 +7307,7 @@ using propagate_on_container_copy_assignment = @\seebelow@;
 \pnum
 \ctype \tcode{Alloc::propagate_on_container_copy_assignment} if
 the \grammarterm{qualified-id} \tcode{Alloc::propagate_on_container_copy_assignment} is valid and denotes a
-type~(\ref{temp.deduct}); otherwise
+type\iref{temp.deduct}; otherwise
 \tcode{false_type}.
 \end{itemdescr}
 
@@ -7320,7 +7320,7 @@ using propagate_on_container_move_assignment = @\seebelow@;
 \pnum
 \ctype \tcode{Alloc::propagate_on_container_move_assignment} if
 the \grammarterm{qualified-id} \tcode{Alloc::propagate_on_container_move_assignment} is valid and denotes a
-type~(\ref{temp.deduct}); otherwise
+type\iref{temp.deduct}; otherwise
 \tcode{false_type}.
 \end{itemdescr}
 
@@ -7333,7 +7333,7 @@ using propagate_on_container_swap = @\seebelow@;
 \pnum
 \ctype \tcode{Alloc::propagate_on_container_swap} if
 the \grammarterm{qualified-id} \tcode{Alloc::propagate_on_container_swap} is valid and denotes a
-type~(\ref{temp.deduct}); otherwise
+type\iref{temp.deduct}; otherwise
 \tcode{false_type}.
 \end{itemdescr}
 
@@ -7346,7 +7346,7 @@ using is_always_equal = @\seebelow@;
 \pnum
 \ctype \tcode{Alloc::is_always_equal} if
 the \grammarterm{qualified-id} \tcode{Alloc::is_always_equal}
-is valid and denotes a type~(\ref{temp.deduct});
+is valid and denotes a type\iref{temp.deduct};
 otherwise \tcode{is_empty<Alloc>::type}.
 \end{itemdescr}
 
@@ -7359,7 +7359,7 @@ template <class T> using rebind_alloc = @\seebelow@;
 \pnum
 \templalias \tcode{Alloc::rebind<T>::other} if
 the \grammarterm{qualified-id} \tcode{Alloc::rebind<T>::other} is valid and denotes a
-type~(\ref{temp.deduct}); otherwise,
+type\iref{temp.deduct}; otherwise,
 \tcode{Alloc<T, Args>} if \tcode{Alloc} is a class template instantiation
 of the form \tcode{Alloc<U, Args>}, where \tcode{Args} is zero or more type arguments;
 otherwise, the instantiation of \tcode{rebind_alloc} is ill-formed.
@@ -7451,7 +7451,7 @@ well-formed; otherwise, \tcode{rhs}.
 
 \pnum
 All specializations of the default allocator satisfy the
-allocator completeness requirements~(\ref{allocator.requirements.completeness}).
+allocator completeness requirements\iref{allocator.requirements.completeness}.
 
 \indexlibrary{\idxcode{allocator}}%
 \begin{codeblock}
@@ -7477,7 +7477,7 @@ namespace std {
 
 \pnum
 Except for the destructor, member functions of the default allocator shall not introduce
-data races~(\ref{intro.multithread}) as a result of concurrent calls to those member
+data races\iref{intro.multithread} as a result of concurrent calls to those member
 functions from different threads. Calls to these functions that allocate or deallocate a
 particular unit of storage shall occur in a single total order, and each such
 deallocation call shall happen before the next allocation (if any) in this order.
@@ -7495,7 +7495,7 @@ A pointer to the initial element of an array of storage of size \tcode{n}
 
 \pnum
 \remarks
-the storage is obtained by calling \tcode{::operator new}~(\ref{new.delete}),
+the storage is obtained by calling \tcode{::operator new}\iref{new.delete},
 but it is unspecified when or how often this
 function is called.
 
@@ -7523,7 +7523,7 @@ Deallocates the storage referenced by \tcode{p} .
 \pnum
 \remarks
 Uses
-\tcode{::operator delete}~(\ref{new.delete}),
+\tcode{::operator delete}\iref{new.delete},
 but it is unspecified
 when this function is called.
 \end{itemdescr}
@@ -7563,11 +7563,11 @@ the names of template parameters are used to express type requirements.
 \item
 If an algorithm's template parameter is named \tcode{InputIterator},
 the template argument shall satisfy the requirements
-of an input iterator~(\ref{input.iterators}).
+of an input iterator\iref{input.iterators}.
 \item
 If an algorithm's template parameter is named \tcode{ForwardIterator},
 the template argument shall satisfy the requirements
-of a forward iterator~(\ref{forward.iterators}), and
+of a forward iterator\iref{forward.iterators}, and
 is required to have the property that no exceptions are thrown
 from increment, assignment, comparison, or indirection through valid iterators.
 \end{itemize}
@@ -7588,7 +7588,7 @@ presence of an overloaded \tcode{operator\&}.
 
 \pnum
 \remarks An expression \tcode{addressof(E)}
-is a constant subexpression~(\ref{defns.const.subexpr})
+is a constant subexpression\iref{defns.const.subexpr}
 if \tcode{E} is an lvalue constant subexpression.
 \end{itemdescr}
 
@@ -7855,7 +7855,7 @@ return first;
 \pnum
 \indextext{\idxhdr{cstdlib}}%
 \begin{note}
-The header \tcode{<cstdlib>}~(\ref{cstdlib.syn})
+The header \tcode{<cstdlib>}\iref{cstdlib.syn}
 declares the functions described in this subclause.
 \end{note}
 
@@ -7878,7 +7878,7 @@ These functions have the semantics specified in the C standard library.
 \pnum
 \remarks
 These functions do not attempt to allocate
-storage by calling \tcode{::operator new()}~(\ref{support.dynamic}).
+storage by calling \tcode{::operator new()}\iref{support.dynamic}.
 \indexlibrary{\idxcode{new}!\idxcode{operator}}%
 
 \pnum
@@ -7926,7 +7926,7 @@ A \defn{unique pointer} is an object that owns another object and
 manages that other object through a pointer. More precisely, a unique pointer
 is an object \textit{u} that stores a pointer to a second object \textit{p} and
 will dispose of \textit{p} when \textit{u} is itself destroyed (e.g., when
-leaving block scope~(\ref{stmt.dcl})). In this context, \textit{u} is said
+leaving block scope\iref{stmt.dcl}). In this context, \textit{u} is said
 to \defn{own} \tcode{p}.
 
 \pnum
@@ -8177,7 +8177,7 @@ namespace std {
 The default type for the template parameter \tcode{D} is
 \tcode{default_delete}. A client-supplied template argument
 \tcode{D} shall be a function
-object type~(\ref{function.objects}), lvalue reference to function, or
+object type\iref{function.objects}, lvalue reference to function, or
 lvalue reference to function object type
 for which, given
 a value \tcode{d} of type \tcode{D} and a value
@@ -8191,14 +8191,14 @@ the requirements of \tcode{Destructible} (Table~\ref{tab:destructible}).
 
 \pnum
 If the \grammarterm{qualified-id} \tcode{remove_reference_t<D>::pointer} is valid and denotes a
-type~(\ref{temp.deduct}), then \tcode{unique_ptr<T,
+type\iref{temp.deduct}, then \tcode{unique_ptr<T,
 D>::pointer} shall be a synonym for \tcode{remove_reference_t<D>::pointer}. Otherwise
 \tcode{unique_ptr<T, D>::pointer} shall be a synonym for \tcode{element_type*}. The type \tcode{unique_ptr<T,
 D>::pointer} shall
-satisfy the requirements of \tcode{NullablePointer}~(\ref{nullablepointer.requirements}).
+satisfy the requirements of \tcode{NullablePointer}\iref{nullablepointer.requirements}.
 
 \pnum
-\begin{example} Given an allocator type \tcode{X}~(\ref{allocator.requirements}) and
+\begin{example} Given an allocator type \tcode{X}\iref{allocator.requirements} and
 letting \tcode{A} be a synonym for \tcode{allocator_traits<X>}, the types \tcode{A::pointer},
 \tcode{A::const_pointer}, \tcode{A::void_pointer}, and \tcode{A::const_void_pointer}
 may be used as \tcode{unique_ptr<T, D>::pointer}. \end{example}
@@ -8255,7 +8255,7 @@ returns a reference to the stored deleter.
 \remarks If \tcode{is_pointer_v<deleter_type>} is \tcode{true} or
 \tcode{is_default_constructible_v<deleter_type>} is \tcode{false},
 this constructor shall not participate in overload resolution.
-If class template argument deduction~(\ref{over.match.class.deduct})
+If class template argument deduction\iref{over.match.class.deduct}
 would select the function template corresponding to this constructor,
 then the program is ill-formed.
 \end{itemdescr}
@@ -8311,7 +8311,7 @@ deleter. If \tcode{D} is a reference type then \tcode{get_deleter()}
 returns a reference to the lvalue \tcode{d}.
 
 \pnum
-\remarks If class template argument deduction~(\ref{over.match.class.deduct})
+\remarks If class template argument deduction\iref{over.match.class.deduct}
 would select a function template corresponding to either of these constructors,
 then the program is ill-formed.
 
@@ -8600,7 +8600,7 @@ void swap(unique_ptr& u) noexcept;
 \begin{itemdescr}
 \pnum
 \requires \tcode{get_deleter()} shall be
-swappable~(\ref{swappable.requirements}) and shall
+swappable\iref{swappable.requirements} and shall
 not throw an exception
 under \tcode{swap}.
 
@@ -8931,8 +8931,8 @@ common_type_t<typename unique_ptr<T1, D1>::pointer,
               typename unique_ptr<T2, D2>::pointer>
 \end{codeblock}
 Then the specialization
-\tcode{less<\placeholder{CT}>} shall be a function object type~(\ref{function.objects}) that
-induces a strict weak ordering~(\ref{alg.sorting}) on the pointer values.
+\tcode{less<\placeholder{CT}>} shall be a function object type\iref{function.objects} that
+induces a strict weak ordering\iref{alg.sorting} on the pointer values.
 
 \pnum
 \returns \tcode{less<\placeholder{CT}>()(x.get(), y.get())}.
@@ -9013,8 +9013,8 @@ template <class T, class D>
 \begin{itemdescr}
 \pnum
 \requires The specialization \tcode{less<unique_ptr<T, D>::pointer>} shall be
-a function object type~(\ref{function.objects}) that induces a strict weak
-ordering~(\ref{alg.sorting}) on the pointer values.
+a function object type\iref{function.objects} that induces a strict weak
+ordering\iref{alg.sorting} on the pointer values.
 
 \pnum
 \returns
@@ -9290,7 +9290,7 @@ In the constructor definitions below,
 enables \tcode{shared_from_this} with \tcode{p},
 for a pointer \tcode{p} of type \tcode{Y*},
 means that if \tcode{Y} has an unambiguous and accessible base class
-that is a specialization of \tcode{enable_shared_from_this}~(\ref{util.smartptr.enab}),
+that is a specialization of \tcode{enable_shared_from_this}\iref{util.smartptr.enab},
 then \tcode{remove_cv_t<Y>*} shall be implicitly convertible to \tcode{T*} and
 the constructor evaluates the statement:
 \begin{codeblock}
@@ -9298,7 +9298,7 @@ if (p != nullptr && p->weak_this.expired())
   p->weak_this = shared_ptr<remove_cv_t<Y>>(*this, const_cast<remove_cv_t<Y>*>(p));
 \end{codeblock}
 The assignment to the \tcode{weak_this} member is not atomic and
-conflicts with any potentially concurrent access to the same object~(\ref{intro.multithread}).
+conflicts with any potentially concurrent access to the same object\iref{intro.multithread}.
 
 \indexlibrary{\idxcode{shared_ptr}!constructor}%
 \begin{itemdecl}
@@ -9363,7 +9363,7 @@ template <class D, class A> shared_ptr(nullptr_t p, D d, A a);
 initialized with \tcode{std::move(d)} shall not throw exceptions.
 The expression \tcode{d(p)}
 shall have well-defined behavior and shall not throw exceptions.
-\tcode{A} shall be an allocator~(\ref{allocator.requirements}).
+\tcode{A} shall be an allocator\iref{allocator.requirements}.
 
 \pnum\effects  Constructs a \tcode{shared_ptr} object that owns the
 object \tcode{p} and the deleter \tcode{d}.
@@ -9766,7 +9766,7 @@ template<class T, class A, ...>
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{A} shall be an allocator~(\ref{allocator.requirements}).
+\requires \tcode{A} shall be an allocator\iref{allocator.requirements}.
 
 \pnum
 \effects Allocates memory for an object of type \tcode{T}
@@ -10873,7 +10873,7 @@ template <class T, class D> struct hash<unique_ptr<T, D>>;
 \begin{itemdescr}
 \pnum
 Letting \tcode{UP} be \tcode{unique_ptr<T,D>},
-the specialization \tcode{hash<UP>} is enabled~(\ref{unord.hash})
+the specialization \tcode{hash<UP>} is enabled\iref{unord.hash}
 if and only if \tcode{hash<typename UP::pointer>} is enabled.
 When enabled, for an object \tcode{p} of type \tcode{UP},
 \tcode{hash<UP>()(p)} shall evaluate to
@@ -11020,8 +11020,8 @@ virtual void* do_allocate(size_t bytes, size_t alignment) = 0;
 
 \pnum
 \returns
-A derived class shall implement this function to return a pointer to allocated storage~(\ref{basic.stc.dynamic.deallocation}) with a size of at least \tcode{bytes}.
-The returned storage is aligned to the specified alignment, if such alignment is supported~(\ref{basic.align});
+A derived class shall implement this function to return a pointer to allocated storage\iref{basic.stc.dynamic.deallocation} with a size of at least \tcode{bytes}.
+The returned storage is aligned to the specified alignment, if such alignment is supported\iref{basic.align};
 otherwise it is aligned to \tcode{max_align}.
 
 \pnum
@@ -11094,7 +11094,7 @@ bool operator!=(const memory_resource& a, const memory_resource& b) noexcept;
 
 \pnum
 A specialization of class template \tcode{pmr::polymorphic_allocator}
-conforms to the \tcode{Allocator} requirements~(\ref{allocator.requirements}).
+conforms to the \tcode{Allocator} requirements\iref{allocator.requirements}.
 Constructed with different memory resources,
 different instances of the same specialization of \tcode{pmr::polymorphic_allocator}
 can exhibit entirely different allocation behavior.
@@ -11278,7 +11278,7 @@ template <class T1, class T2, class... Args1, class... Args2>
 \pnum
 \begin{note}
 This member function and the \tcode{construct} member functions that follow
-are overloads for piecewise construction of pairs~(\ref{pairs.pair}).
+are overloads for piecewise construction of pairs\iref{pairs.pair}.
 \end{note}
 
 \pnum
@@ -11290,7 +11290,7 @@ The following description can be summarized as
 constructing a \tcode{pair<T1, T2>} object
 in the storage whose address is represented by \tcode{p},
 as if by separate uses-allocator construction
-with allocator \tcode{resource()}~(\ref{allocator.uses.construction})
+with allocator \tcode{resource()}\iref{allocator.uses.construction}
 of \tcode{p->first} using the elements of \tcode{x}
 and \tcode{p->second} using the elements of \tcode{y}.
 \end{note}
@@ -11696,7 +11696,7 @@ size_t max_blocks_per_chunk;
 \begin{itemdescr}
 \pnum
 The maximum number of blocks that will be allocated at once
-from the upstream memory resource~(\ref{mem.res.monotonic.buffer})
+from the upstream memory resource\iref{mem.res.monotonic.buffer}
 to replenish a pool.
 If the value of \tcode{max_blocks_per_chunk} is zero or
 is greater than an \impldef{largest supported value to configure the maximum number of blocks to replenish a pool}
@@ -11829,10 +11829,10 @@ void* do_allocate(size_t bytes, size_t alignment) override;
 \begin{itemdescr}
 \pnum
 \returns
-A pointer to allocated storage~(\ref{basic.stc.dynamic.deallocation})
+A pointer to allocated storage\iref{basic.stc.dynamic.deallocation}
 with a size of at least \tcode{bytes}.
 The size and alignment of the allocated memory shall meet the requirements
-for a class derived from \tcode{memory_resource}~(\ref{mem.res}).
+for a class derived from \tcode{memory_resource}\iref{mem.res}.
 
 \pnum
 \effects
@@ -12053,10 +12053,10 @@ void* do_allocate(size_t bytes, size_t alignment) override;
 \begin{itemdescr}
 \pnum
 \returns
-A pointer to allocated storage~(\ref{basic.stc.dynamic.deallocation})
+A pointer to allocated storage\iref{basic.stc.dynamic.deallocation}
 with a size of at least \tcode{bytes}.
 The size and alignment of the allocated memory shall meet the requirements
-for a class derived from \tcode{memory_resource}~(\ref{mem.res}).
+for a class derived from \tcode{memory_resource}\iref{mem.res}.
 
 \pnum
 \effects
@@ -12717,13 +12717,13 @@ template <class OuterA1, class OuterA2, class... InnerAllocs>
 
 \pnum
 A \indexdefn{function object!type}\term{function object type} is an object
-type~(\ref{basic.types}) that can be the type of the
+type\iref{basic.types} that can be the type of the
 \grammarterm{postfix-expression} in a function call
 (\ref{expr.call}, \ref{over.match.call}).\footnote{Such a type is a function
 pointer or a class type which has a member \tcode{operator()} or a class type
 which has a conversion to a pointer to function.} A \defn{function object} is an
 object of a function object type. In the places where one would expect to pass a
-pointer to a function to an algorithmic template (Clause~\ref{algorithms}), the
+pointer to a function to an algorithmic template\iref{algorithms}, the
 interface is specified to accept a function object. This not only makes
 algorithmic templates work with pointers to functions, but also enables them to
 work with arbitrary function objects.
@@ -12900,7 +12900,7 @@ parenthesized comma-separated list of zero or more argument types.
 
 \pnum
 \indexdefn{callable type}%
-A \term{callable type} is a function object type~(\ref{function.objects}) or a pointer to member.
+A \term{callable type} is a function object type\iref{function.objects} or a pointer to member.
 
 \pnum
 \indexdefn{callable object}%
@@ -12967,7 +12967,7 @@ to \tcode{R}.
 \indextext{call wrapper!forwarding}%
 \indextext{simple call wrapper}%
 \indextext{forwarding call wrapper}%
-Every call wrapper~(\ref{func.def}) shall be
+Every call wrapper\iref{func.def} shall be
 \tcode{MoveConstructible}.
 A \term{forwarding call wrapper} is a
 call wrapper that can be called with an arbitrary argument list
@@ -13001,7 +13001,7 @@ template <class F, class... Args>
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{\placeholdernc{INVOKE}(std::forward<F>(f), std::forward<Args>(args)...)}~(\ref{func.require}).
+\tcode{\placeholdernc{INVOKE}(std::forward<F>(f), std::forward<Args>(args)...)}\iref{func.require}.
 \end{itemdescr}
 
 \rSec2[refwrap]{Class template \tcode{reference_wrapper}}
@@ -13042,7 +13042,7 @@ namespace std {
 around a reference to an object or function of type \tcode{T}.
 
 \pnum
-\tcode{reference_wrapper<T>} shall be a trivially copyable type~(\ref{basic.types}).
+\tcode{reference_wrapper<T>} shall be a trivially copyable type\iref{basic.types}.
 
 \rSec3[refwrap.const]{\tcode{reference_wrapper} construct/copy/destroy}
 
@@ -13109,7 +13109,7 @@ template <class... ArgTypes>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{\placeholdernc{INVOKE}(get(), std::forward<ArgTypes>(args)...)}.~(\ref{func.require})
+\pnum\returns \tcode{\placeholdernc{INVOKE}(get(), std::forward<ArgTypes>(args)...)}.\iref{func.require}
 \end{itemdescr}
 
 
@@ -13969,7 +13969,7 @@ explicit @\placeholdernc{call_wrapper}@(F&& f);
 \requires
 \tcode{FD} shall satisfy the requirements of \tcode{MoveConstructible}.
 \tcode{is_constructible_v<FD, F>} shall be \tcode{true}.
-\tcode{fd} shall be a callable object~(\ref{func.def}).
+\tcode{fd} shall be a callable object\iref{func.def}.
 
 \pnum
 \effects
@@ -14039,7 +14039,7 @@ uses \tcode{is_bind_expression} to detect subexpressions.
 
 \pnum
 Instantiations of the \tcode{is_bind_expression} template shall meet
-the \tcode{UnaryTypeTrait} requirements~(\ref{meta.rqmts}). The implementation
+the \tcode{UnaryTypeTrait} requirements\iref{meta.rqmts}. The implementation
 shall provide a definition that has a base characteristic of
 \tcode{true_type} if \tcode{T} is a type returned from \tcode{bind},
 otherwise it shall have a base characteristic of \tcode{false_type}.
@@ -14063,7 +14063,7 @@ The class template \tcode{is_placeholder} can be used to detect the standard pla
 
 \pnum
 Instantiations of the \tcode{is_placeholder} template shall meet
-the \tcode{UnaryTypeTrait} requirements~(\ref{meta.rqmts}). The implementation
+the \tcode{UnaryTypeTrait} requirements\iref{meta.rqmts}. The implementation
 shall provide a definition that has the base characteristic of
 \tcode{integral_constant<int, \placeholder{J}>} if \tcode{T} is the type of
 \tcode{std::placeholders::_\placeholder{J}}, otherwise it shall have a
@@ -14103,14 +14103,14 @@ template<class F, class... BoundArgs>
 \tcode{is_constructible_v<FD, F>} shall be \tcode{true}. For each $\tcode{T}_i$
 in \tcode{BoundArgs}, \tcode{is_cons\-tructible_v<$\tcode{TD}_i$, $\tcode{T}_i$>} shall be \tcode{true}.
 \tcode{\placeholdernc{INVOKE}(fd, $\tcode{w}_1$, $\tcode{w}_2$, $\dotsc$,
-$\tcode{w}_N$)}~(\ref{func.require}) shall be a valid expression for some
+$\tcode{w}_N$)}\iref{func.require} shall be a valid expression for some
 values $\tcode{w}_1$, $\tcode{w}_2$, $\dotsc{}$, $\tcode{w}_N$, where
 $N$ has the value \tcode{sizeof...(bound_args)}.
 The cv-qualifiers \cv{} of the call wrapper \tcode{g},
 as specified below, shall be neither \tcode{volatile} nor \tcode{const volatile}.
 
 \pnum\returns
-A forwarding call wrapper \tcode{g}~(\ref{func.require}).
+A forwarding call wrapper \tcode{g}\iref{func.require}.
 The effect of \tcode{g($\tcode{u}_1$, $\tcode{u}_2$, $\dotsc$, $\tcode{u}_M$)} shall
 be
 \begin{codeblock}
@@ -14153,7 +14153,7 @@ as specified below, shall be neither \tcode{volatile} nor \tcode{const volatile}
 
 \pnum
 \returns
-A forwarding call wrapper \tcode{g}~(\ref{func.require}).
+A forwarding call wrapper \tcode{g}\iref{func.require}.
 The effect of
 \tcode{g($\tcode{u}_1$, $\tcode{u}_2$, $\dotsc$, $\tcode{u}_M$)} shall be
 \begin{codeblock}
@@ -14248,9 +14248,9 @@ template<class R, class T> @\unspec@ mem_fn(R T::* pm) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns A simple call wrapper~(\ref{func.def}) \tcode{fn}
+\returns A simple call wrapper\iref{func.def} \tcode{fn}
 such that the expression \tcode{fn(t, a$_2$, $\dotsc$, a$_N$)} is equivalent
-to \tcode{\placeholdernc{INVOKE}(pm, t, a$_2$, $\dotsc$, a$_N$)}~(\ref{func.require}).
+to \tcode{\placeholdernc{INVOKE}(pm, t, a$_2$, $\dotsc$, a$_N$)}\iref{func.require}.
 \end{itemdescr}
 \indextext{function object!\idxcode{mem_fn}|)}
 
@@ -14266,7 +14266,7 @@ encapsulates arbitrary callable objects.
 
 \pnum
 An exception of type \tcode{bad_function_call} is thrown by
-\tcode{function::operator()}~(\ref{func.wrap.func.inv})
+\tcode{function::operator()}\iref{func.wrap.func.inv}
 when the function wrapper object has no target.
 
 \begin{codeblock}
@@ -14365,23 +14365,23 @@ namespace std {
 \pnum
 The \tcode{function} class template provides polymorphic wrappers that
 generalize the notion of a function pointer. Wrappers can store, copy,
-and call arbitrary callable objects~(\ref{func.def}), given a call
-signature~(\ref{func.def}), allowing functions to be first-class objects.
+and call arbitrary callable objects\iref{func.def}, given a call
+signature\iref{func.def}, allowing functions to be first-class objects.
 
 \pnum
 \indextext{callable type}%
-A callable type~(\ref{func.def}) \tcode{F}
+A callable type\iref{func.def} \tcode{F}
 is \defn{Lvalue-Callable} for argument
 types \tcode{ArgTypes}
 and return type \tcode{R}
 if the expression
 \tcode{\placeholdernc{INVOKE}<R>(declval<F\&>(), declval<ArgTypes>()...)},
-considered as an unevaluated operand (Clause~\ref{expr}), is
-well formed~(\ref{func.require}).
+considered as an unevaluated operand\iref{expr}, is
+well formed\iref{func.require}.
 
 \pnum
 The \tcode{function} class template is a call
-wrapper~(\ref{func.def}) whose call signature~(\ref{func.def})
+wrapper\iref{func.def} whose call signature\iref{func.def}
 is \tcode{R(ArgTypes...)}.
 
 \pnum
@@ -14467,7 +14467,7 @@ template<class F> function(F f);
 
 \pnum
 \remarks This constructor template shall not participate in overload resolution unless
-\tcode{F} is Lvalue-Callable~(\ref{func.wrap.func}) for argument types
+\tcode{F} is Lvalue-Callable\iref{func.wrap.func} for argument types
 \tcode{ArgTypes...} and return type \tcode{R}.
 
 \pnum
@@ -14570,7 +14570,7 @@ template<class F> function& operator=(F&& f);
 
 \pnum\remarks This assignment operator shall not participate in overload
 resolution unless \tcode{decay_t<F>} is
-Lvalue-Callable~(\ref{func.wrap.func}) for argument types \tcode{ArgTypes...} and
+Lvalue-Callable\iref{func.wrap.func} for argument types \tcode{ArgTypes...} and
 return type \tcode{R}.
 \end{itemdescr}
 
@@ -14628,8 +14628,8 @@ R operator()(ArgTypes... args) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{\placeholdernc{INVOKE}<R>(f, std::forward<ArgTypes>(args)...)}~(\ref{func.require}),
-where \tcode{f} is the target object~(\ref{func.def}) of \tcode{*this}.
+\returns \tcode{\placeholdernc{INVOKE}<R>(f, std::forward<ArgTypes>(args)...)}\iref{func.require},
+where \tcode{f} is the target object\iref{func.def} of \tcode{*this}.
 
 \pnum\throws
 \tcode{bad_function_call} if \tcode{!*this}; otherwise, any
@@ -14701,7 +14701,7 @@ template<class R, class... ArgTypes>
 \rSec2[func.search]{Searchers}
 
 \pnum
-This subclause provides function object types~(\ref{function.objects}) for
+This subclause provides function object types\iref{function.objects} for
 operations that search for a sequence \range{pat\textunderscore\nobreak first}{pat_last} in another
 sequence \range{first}{last} that is provided to the object's function call
 operator.  The first sequence (the pattern to be searched for) is provided to
@@ -14981,7 +14981,7 @@ At most \tcode{(last - first) * (pat_last_ - pat_first_)} applications of the pr
 \indexlibrary{\idxcode{hash}}%
 \indextext{\idxcode{hash}!instantiation restrictions}%
 The unordered associative containers defined in \ref{unord} use
-specializations of the class template \tcode{hash}~(\ref{functional.syn})
+specializations of the class template \tcode{hash}\iref{functional.syn}
 as the default hash function.
 
 \pnum
@@ -15012,7 +15012,7 @@ these values are \tcode{false}:
 \tcode{is_copy_assignable_v<H>}, and
 \tcode{is_move_assignable_v<H>}.
 Disabled specializations of \tcode{hash}
-are not function object types~(\ref{function.objects}).
+are not function object types\iref{function.objects}.
 \begin{note}
 This means that the specialization of \tcode{hash} exists, but
 any attempts to use it as a \tcode{Hash} will be ill-formed.
@@ -15021,11 +15021,11 @@ any attempts to use it as a \tcode{Hash} will be ill-formed.
 \pnum
 An enabled specialization \tcode{hash<Key>} will:
 \begin{itemize}
-\item satisfy the \tcode{Hash} requirements~(\ref{hash.requirements}),
+\item satisfy the \tcode{Hash} requirements\iref{hash.requirements},
 with \tcode{Key} as the function
 call argument type, the \tcode{Default\-Constructible} requirements (Table~\ref{tab:defaultconstructible}),
 the \tcode{CopyAssignable} requirements (Table~\ref{tab:copyassignable}),
-\item be swappable~(\ref{swappable.requirements}) for lvalues,
+\item be swappable\iref{swappable.requirements} for lvalues,
 \item satisfy the requirement that if \tcode{k1 == k2} is \tcode{true}, \tcode{h(k1) == h(k2)} is
 also \tcode{true}, where \tcode{h} is an object of type \tcode{hash<Key>} and \tcode{k1} and \tcode{k2}
 are objects of type \tcode{Key};
@@ -15051,7 +15051,7 @@ type transformations allow certain properties of types to be manipulated.
 
 \pnum
 \indextext{signal-safe!type traits}%
-All functions specified in this subclause are signal-safe~(\ref{support.signal}).
+All functions specified in this subclause are signal-safe\iref{support.signal}.
 
 \rSec2[meta.rqmts]{Requirements}
 
@@ -15064,7 +15064,7 @@ property being described. It shall be \tcode{DefaultConstructible},
 and publicly and unambiguously derived, directly or indirectly, from
 its \defn{base characteristic}, which is
 a specialization of the template
-\tcode{integral_constant}~(\ref{meta.help}), with
+\tcode{integral_constant}\iref{meta.help}, with
 the arguments to the template \tcode{integral_constant} determined by the
 requirements for the particular property being described.
 The member names of the base characteristic shall not be hidden and shall be
@@ -15080,7 +15080,7 @@ and publicly and unambiguously derived, directly or
 indirectly, from
 its \term{base characteristic}, which is a specialization
 of the template
-\tcode{integral_constant}~(\ref{meta.help}), with
+\tcode{integral_constant}\iref{meta.help}, with
 the arguments to the template \tcode{integral_constant} determined by the
 requirements for the particular relationship being described.
 The member names of the base characteristic shall not be hidden and shall be
@@ -15519,7 +15519,7 @@ properties of a type at compile time.
 
 \pnum
 Each of these templates shall be a
-\tcode{UnaryTypeTrait}~(\ref{meta.rqmts})
+\tcode{UnaryTypeTrait}\iref{meta.rqmts}
 with a base characteristic of
 \tcode{true_type} if the corresponding condition is \tcode{true}, otherwise
 \tcode{false_type}.
@@ -15555,35 +15555,35 @@ has a \tcode{value} member that evaluates to \tcode{true}.
 \indexlibrary{\idxcode{is_null_pointer}}%
 \tcode{template <class T>}\br
  \tcode{struct is_null_pointer;}                &
-\tcode{T} is \tcode{nullptr_t}~(\ref{basic.fundamental})       &   \\ \rowsep
+\tcode{T} is \tcode{nullptr_t}\iref{basic.fundamental}       &   \\ \rowsep
 \indexlibrary{\idxcode{is_integral}}%
 \tcode{template <class T>}\br
  \tcode{struct is_integral;}        &
-\tcode{T} is an integral type~(\ref{basic.fundamental})                 &   \\ \rowsep
+\tcode{T} is an integral type\iref{basic.fundamental}                 &   \\ \rowsep
 \indexlibrary{\idxcode{is_floating_point}}%
 \tcode{template <class T>}\br
  \tcode{struct is_floating_point;}  &
-\tcode{T} is a floating-point type~(\ref{basic.fundamental})            &   \\ \rowsep
+\tcode{T} is a floating-point type\iref{basic.fundamental}            &   \\ \rowsep
 \indexlibrary{\idxcode{is_array}}%
 \tcode{template <class T>}\br
  \tcode{struct is_array;}           &
-\tcode{T} is an array type~(\ref{basic.compound}) of known or unknown extent    &
-Class template \tcode{array}~(\ref{array})
+\tcode{T} is an array type\iref{basic.compound} of known or unknown extent    &
+Class template \tcode{array}\iref{array}
 is not an array type.                   \\ \rowsep
 \indexlibrary{\idxcode{is_pointer}}%
 \tcode{template <class T>}\br
  \tcode{struct is_pointer;}         &
-\tcode{T} is a pointer type~(\ref{basic.compound})                      &
+\tcode{T} is a pointer type\iref{basic.compound}                      &
 Includes pointers to functions
 but not pointers to non-static members.                        \\ \rowsep
 \indexlibrary{\idxcode{is_lvalue_reference}}%
 \tcode{template <class T>}\br
  \tcode{struct is_lvalue_reference;}    &
- \tcode{T} is an lvalue reference type~(\ref{dcl.ref})   &   \\ \rowsep
+ \tcode{T} is an lvalue reference type\iref{dcl.ref}   &   \\ \rowsep
 \indexlibrary{\idxcode{is_rvalue_reference}}%
 \tcode{template <class T>}\br
  \tcode{struct is_rvalue_reference;}    &
- \tcode{T} is an rvalue reference type~(\ref{dcl.ref})   &   \\ \rowsep
+ \tcode{T} is an rvalue reference type\iref{dcl.ref}   &   \\ \rowsep
 \indexlibrary{\idxcode{is_member_object_pointer}}%
 \tcode{template <class T>}\br
  \tcode{struct is_member_object_pointer;}&
@@ -15595,19 +15595,19 @@ but not pointers to non-static members.                        \\ \rowsep
 \indexlibrary{\idxcode{is_enum}}%
 \tcode{template <class T>}\br
  \tcode{struct is_enum;}            &
-\tcode{T} is an enumeration type~(\ref{basic.compound})                 &   \\ \rowsep
+\tcode{T} is an enumeration type\iref{basic.compound}                 &   \\ \rowsep
 \indexlibrary{\idxcode{is_union}}%
 \tcode{template <class T>}\br
  \tcode{struct is_union;}           &
-\tcode{T} is a union type~(\ref{basic.compound})                        &   \\ \rowsep
+\tcode{T} is a union type\iref{basic.compound}                        &   \\ \rowsep
 \indexlibrary{\idxcode{is_class}}%
 \tcode{template <class T>}\br
  \tcode{struct is_class;}           &
-\tcode{T} is a non-union class type~(\ref{basic.compound}) & \\ \rowsep
+\tcode{T} is a non-union class type\iref{basic.compound} & \\ \rowsep
 \indexlibrary{\idxcode{is_function}}%
 \tcode{template <class T>}\br
  \tcode{struct is_function;}        &
-\tcode{T} is a function type~(\ref{basic.compound})                     &   \\
+\tcode{T} is a function type\iref{basic.compound}                     &   \\
 \end{libreqtab3e}
 
 \rSec3[meta.unary.comp]{Composite type traits}
@@ -15635,23 +15635,23 @@ For any given type \tcode{T}, the result of applying one of these templates to
 \indexlibrary{\idxcode{is_arithmetic}}%
 \tcode{template <class T>}\br
  \tcode{struct is_arithmetic;}          &
- \tcode{T} is an arithmetic type~(\ref{basic.fundamental})              &   \\ \rowsep
+ \tcode{T} is an arithmetic type\iref{basic.fundamental}              &   \\ \rowsep
 \indexlibrary{\idxcode{is_fundamental}}%
 \tcode{template <class T>}\br
  \tcode{struct is_fundamental;}         &
- \tcode{T} is a fundamental type~(\ref{basic.fundamental})              &   \\ \rowsep
+ \tcode{T} is a fundamental type\iref{basic.fundamental}              &   \\ \rowsep
 \indexlibrary{\idxcode{is_object}}%
 \tcode{template <class T>}\br
  \tcode{struct is_object;}              &
- \tcode{T} is an object type~(\ref{basic.types})                            &   \\ \rowsep
+ \tcode{T} is an object type\iref{basic.types}                            &   \\ \rowsep
 \indexlibrary{\idxcode{is_scalar}}%
 \tcode{template <class T>}\br
  \tcode{struct is_scalar;}              &
- \tcode{T} is a scalar type~(\ref{basic.types})                         &   \\ \rowsep
+ \tcode{T} is a scalar type\iref{basic.types}                         &   \\ \rowsep
 \indexlibrary{\idxcode{is_compound}}%
 \tcode{template <class T>}\br
  \tcode{struct is_compound;}            &
- \tcode{T} is a compound type~(\ref{basic.compound})                        &   \\ \rowsep
+ \tcode{T} is a compound type\iref{basic.compound}                        &   \\ \rowsep
 \indexlibrary{\idxcode{is_member_pointer}}%
 \tcode{template <class T>}\br
  \tcode{struct is_member_pointer;}      &
@@ -15680,7 +15680,7 @@ the argument must be a complete type.
 For the purpose of defining the templates in this subclause,
 a function call expression \tcode{declval<T>()} for any type \tcode{T}
 is considered to be a trivial~(\ref{basic.types}, \ref{special}) function call
-that is not an odr-use~(\ref{basic.def.odr}) of \tcode{declval}
+that is not an odr-use\iref{basic.def.odr} of \tcode{declval}
 in the context of the corresponding definition
 notwithstanding the restrictions of~\ref{declval}.
 
@@ -15696,39 +15696,39 @@ notwithstanding the restrictions of~\ref{declval}.
 \indexlibrary{\idxcode{is_const}}%
 \tcode{template <class T>}\br
  \tcode{struct is_const;}               &
- \tcode{T} is const-qualified~(\ref{basic.type.qualifier})                  &   \\ \rowsep
+ \tcode{T} is const-qualified\iref{basic.type.qualifier}                  &   \\ \rowsep
 
 \indexlibrary{\idxcode{is_volatile}}%
 \tcode{template <class T>}\br
  \tcode{struct is_volatile;}            &
- \tcode{T} is volatile-qualified~(\ref{basic.type.qualifier})                   &   \\ \rowsep
+ \tcode{T} is volatile-qualified\iref{basic.type.qualifier}                   &   \\ \rowsep
 
 
 \indexlibrary{\idxcode{is_trivial}}%
 \tcode{template <class T>}\br
  \tcode{struct is_trivial;}                 &
- \tcode{T} is a trivial type~(\ref{basic.types})     &
+ \tcode{T} is a trivial type\iref{basic.types}     &
  \tcode{remove_all_extents_t<T>} shall be a complete
  type or \cv{}~\tcode{void}.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_trivially_copyable}}%
 \tcode{template <class T>}\br
  \tcode{struct is_trivially_copyable;}      &
- \tcode{T} is a trivially copyable type~(\ref{basic.types}) &
+ \tcode{T} is a trivially copyable type\iref{basic.types} &
  \tcode{remove_all_extents_t<T>} shall be a complete type or
  \cv{}~\tcode{void}.                               \\ \rowsep
 
 \indexlibrary{\idxcode{is_standard_layout}}%
 \tcode{template <class T>}\br
  \tcode{struct is_standard_layout;}                 &
- \tcode{T} is a standard-layout type~(\ref{basic.types})   &
+ \tcode{T} is a standard-layout type\iref{basic.types}   &
  \tcode{remove_all_extents_t<T>} shall be a complete
  type or \cv{}~\tcode{void}.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_pod}}%
 \tcode{template <class T>}\br
  \tcode{struct is_pod;}                 &
- \tcode{T} is a POD type~(\ref{basic.types})                                &
+ \tcode{T} is a POD type\iref{basic.types}                                &
  \tcode{remove_all_extents_t<T>} shall be a complete
  type or \cv{}~\tcode{void}.                \\ \rowsep
 
@@ -15744,27 +15744,27 @@ notwithstanding the restrictions of~\ref{declval}.
 \indexlibrary{\idxcode{is_polymorphic}}%
 \tcode{template <class T>}\br
  \tcode{struct is_polymorphic;}         &
- \tcode{T} is a polymorphic class~(\ref{class.virtual})                             &
+ \tcode{T} is a polymorphic class\iref{class.virtual}                             &
  If \tcode{T} is a non-union class type, \tcode{T} shall be a complete type.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_abstract}}%
 \tcode{template <class T>}\br
  \tcode{struct is_abstract;}            &
- \tcode{T} is an abstract class~(\ref{class.abstract})                              &
+ \tcode{T} is an abstract class\iref{class.abstract}                              &
  If \tcode{T} is a non-union class type, \tcode{T} shall be a complete type.                \\ \rowsep
 
 \indexlibrary{\idxcode{is_final}}%
 \tcode{template <class T>}\br
  \tcode{struct is_final;}               &
  \tcode{T} is a class type marked with the \grammarterm{class-virt-specifier}
- \tcode{final} (Clause~\ref{class}). \begin{note} A union is a class type that
+ \tcode{final}\iref{class}. \begin{note} A union is a class type that
  can be marked with \tcode{final}. \end{note}                                        &
  If \tcode{T} is a class type, \tcode{T} shall be a complete type.                          \\ \rowsep
 
 \indexlibrary{\idxcode{is_aggregate}}%
 \tcode{template <class T>}\br
   \tcode{struct is_aggregate;}           &
- \tcode{T} is an aggregate type~(\ref{dcl.init.aggr}) &
+ \tcode{T} is an aggregate type\iref{dcl.init.aggr} &
  \tcode{remove_all_extents_t<T>} shall be a complete type or \cv~\tcode{void}.              \\ \rowsep
 
 \indexlibrary{\idxcode{is_signed}!class}%
@@ -15802,7 +15802,7 @@ notwithstanding the restrictions of~\ref{declval}.
 \indexlibrary{\idxcode{is_copy_constructible}}%
 \tcode{template <class T>}\br
   \tcode{struct is_copy_constructible;} &
-  For a referenceable type \tcode{T}~(\ref{defns.referenceable}), the same result as
+  For a referenceable type \tcode{T}\iref{defns.referenceable}, the same result as
   \tcode{is_constructible_v<T, const T\&>}, otherwise \tcode{false}. &
   \tcode{T} shall be a complete type, \cv{}~\tcode{void},
   or an array of unknown bound. \\ \rowsep
@@ -15820,7 +15820,7 @@ notwithstanding the restrictions of~\ref{declval}.
   \tcode{struct is_assignable;} &
   The expression \tcode{declval<T>() =} \tcode{declval<U>()} is well-formed
   when treated as an unevaluated
-  operand (Clause~\ref{expr}). Access checking is performed as if in a context
+  operand\iref{expr}. Access checking is performed as if in a context
   unrelated to \tcode{T} and \tcode{U}. Only the validity of the immediate context
   of the assignment expression is considered. \begin{note} The compilation of the
   expression can result in side effects such as the instantiation of class template
@@ -15851,9 +15851,9 @@ notwithstanding the restrictions of~\ref{declval}.
   \tcode{struct is_swappable_with;} &
   The expressions \tcode{swap(declval<T>(), declval<U>())} and
   \tcode{swap(declval<U>(), declval<T>())} are each well-formed
-  when treated as an unevaluated operand (Clause~\ref{expr})
+  when treated as an unevaluated operand\iref{expr}
   in an overload-resolution context
-  for swappable values~(\ref{swappable.requirements}).
+  for swappable values\iref{swappable.requirements}.
   Access checking is performed as if in a context
   unrelated to \tcode{T} and \tcode{U}.
   Only the validity of the immediate context
@@ -15888,7 +15888,7 @@ notwithstanding the restrictions of~\ref{declval}.
   for which the expression
   \tcode{declval<U\&>().\~U()}
   is well-formed
-  when treated as an unevaluated operand (Clause \ref{expr}),
+  when treated as an unevaluated operand\iref{expr},
   where \tcode{U} is
   \tcode{remove_all_extents_t<T>}. &
   \tcode{T} shall be a complete type, \cv{}~\tcode{void},
@@ -15972,7 +15972,7 @@ notwithstanding the restrictions of~\ref{declval}.
  \tcode{is_constructible_v<T,} \tcode{ Args...>} is \tcode{true}
  and the
  variable definition for \tcode{is_constructible}, as defined below, is known not to
- throw any exceptions~(\ref{expr.unary.noexcept}).
+ throw any exceptions\iref{expr.unary.noexcept}.
  &
  \tcode{T} and all types in the parameter pack \tcode{Args}
  shall be complete types, \cv{}~\tcode{void},
@@ -16007,7 +16007,7 @@ notwithstanding the restrictions of~\ref{declval}.
 \tcode{template <class T, class U>}\br
   \tcode{struct is_nothrow_assignable;} &
   \tcode{is_assignable_v<T, U>} is \tcode{true} and the assignment is known not to
-  throw any exceptions~(\ref{expr.unary.noexcept}). &
+  throw any exceptions\iref{expr.unary.noexcept}. &
   \tcode{T} and \tcode{U} shall be complete types, \cv{}~\tcode{void},
   or arrays of unknown bound. \\ \rowsep
 
@@ -16035,7 +16035,7 @@ notwithstanding the restrictions of~\ref{declval}.
   \tcode{is_swappable_with_v<T, U>} is \tcode{true} and
   each \tcode{swap} expression of the definition of
   \tcode{is_swappable_with<T, U>} is known not to throw
-  any exceptions~(\ref{expr.unary.noexcept}). &
+  any exceptions\iref{expr.unary.noexcept}. &
   \tcode{T} and \tcode{U} shall be complete types,
   \cv{}~\tcode{void}, or
   arrays of unknown bound. \\ \rowsep
@@ -16054,7 +16054,7 @@ notwithstanding the restrictions of~\ref{declval}.
 \tcode{template <class T>}\br
   \tcode{struct is_nothrow_destructible;} &
   \tcode{is_destructible_v<T>} is \tcode{true} and the indicated destructor is known
-  not to throw any exceptions~(\ref{expr.unary.noexcept}). &
+  not to throw any exceptions\iref{expr.unary.noexcept}. &
   \tcode{T} shall be a complete type,
   \cv{}~\tcode{void}, or an array of unknown
   bound.                \\ \rowsep
@@ -16062,7 +16062,7 @@ notwithstanding the restrictions of~\ref{declval}.
 \indexlibrary{\idxcode{has_virtual_destructor}}%
 \tcode{template <class T>}\br
  \tcode{struct has_virtual_destructor;} &
- \tcode{T} has a virtual destructor~(\ref{class.dtor}) &
+ \tcode{T} has a virtual destructor\iref{class.dtor} &
  If \tcode{T} is a non-union class type, \tcode{T} shall be a complete type.                \\ \rowsep
 
 \indexlibrary{\idxcode{has_unique_object_representations}}%
@@ -16171,7 +16171,7 @@ properties of types at compile time.
  struct alignment_of;}      &
  \tcode{alignof(T)}.\br
  \requires{}
- \tcode{alignof(T)} shall be a valid expression~(\ref{expr.alignof})  \\  \rowsep
+ \tcode{alignof(T)} shall be a valid expression\iref{expr.alignof}  \\  \rowsep
 
 \indexlibrary{\idxcode{rank}}%
 \tcode{template <class T>\br
@@ -16186,12 +16186,12 @@ properties of types at compile time.
  If \tcode{T} is not an array type, or if it has rank less
  than or equal to \tcode{I}, or if \tcode{I} is 0 and \tcode{T}
  has type ``array of unknown bound of \tcode{U}'', then
- 0; otherwise, the bound~(\ref{dcl.array}) of the \tcode{I}'th dimension of
+ 0; otherwise, the bound\iref{dcl.array} of the \tcode{I}'th dimension of
 \tcode{T}, where indexing of \tcode{I} is zero-based \\
 \end{libreqtab2a}
 
 \pnum
-Each of these templates shall be a \tcode{UnaryTypeTrait}~(\ref{meta.rqmts}) with a
+Each of these templates shall be a \tcode{UnaryTypeTrait}\iref{meta.rqmts} with a
 base characteristic of \tcode{integral_constant<size_t, Value>}.
 
 \pnum
@@ -16227,7 +16227,7 @@ relationships between types at compile time.
 
 \pnum
 Each of these templates shall be a
-\tcode{BinaryTypeTrait}~(\ref{meta.rqmts})
+\tcode{BinaryTypeTrait}\iref{meta.rqmts}
 with a base characteristic of
 \tcode{true_type} if the corresponding condition is true, otherwise
 \tcode{false_type}.
@@ -16247,7 +16247,7 @@ with a base characteristic of
 \indexlibrary{\idxcode{is_base_of}}%
 \tcode{template <class Base, class Derived>}\br
  \tcode{struct is_base_of;}                 &
- \tcode{Base} is a base class of \tcode{Derived} (Clause~\ref{class.derived})
+ \tcode{Base} is a base class of \tcode{Derived}\iref{class.derived}
  without regard to cv-qualifiers
  or \tcode{Base} and \tcode{Derived} are not unions and
  name the same class type
@@ -16311,7 +16311,7 @@ not possibly cv-qualified versions of the same type,
 For the purpose of defining the templates in this subclause,
 a function call expression \tcode{declval<T>()} for any type \tcode{T}
 is considered to be a trivial~(\ref{basic.types}, \ref{special}) function call
-that is not an odr-use~(\ref{basic.def.odr}) of \tcode{declval}
+that is not an odr-use\iref{basic.def.odr} of \tcode{declval}
 in the context of the corresponding definition
 notwithstanding the restrictions of~\ref{declval}.
 
@@ -16364,7 +16364,7 @@ type to another following some predefined rule.
 
 \pnum
 Each of the templates in this subclause shall be a
-\tcode{TransformationTrait}~(\ref{meta.rqmts}).
+\tcode{TransformationTrait}\iref{meta.rqmts}.
 
 \rSec3[meta.trans.cv]{Const-volatile modifications}
 
@@ -16452,11 +16452,11 @@ Each of the templates in this subclause shall be a
 \indexlibrary{\idxcode{add_lvalue_reference}}%
 \tcode{template <class T>\br
  struct add_lvalue_reference;}                     &
- If \tcode{T} names a referenceable type~(\ref{defns.referenceable}) then
+ If \tcode{T} names a referenceable type\iref{defns.referenceable} then
  the member typedef \tcode{type} names \tcode{T\&};
  otherwise, \tcode{type} names \tcode{T}.
  \begin{note}
- This rule reflects the semantics of reference collapsing~(\ref{dcl.ref}).
+ This rule reflects the semantics of reference collapsing\iref{dcl.ref}.
  \end{note}\\ \rowsep
 
 \indexlibrary{\idxcode{add_rvalue_reference}}%
@@ -16465,7 +16465,7 @@ Each of the templates in this subclause shall be a
  If \tcode{T} names a referenceable type then
  the member typedef \tcode{type} names \tcode{T\&\&};
  otherwise, \tcode{type} names \tcode{T}.
- \begin{note} This rule reflects the semantics of reference collapsing~(\ref{dcl.ref}).
+ \begin{note} This rule reflects the semantics of reference collapsing\iref{dcl.ref}.
  For example, when a type \tcode{T} names a type \tcode{T1\&}, the type
  \tcode{add_rvalue_reference_t<T>} is not an rvalue reference.
  \end{note} \\
@@ -16485,13 +16485,13 @@ Each of the templates in this subclause shall be a
 \tcode{template <class T>}\br
  \tcode{struct make_signed;} &
  If \tcode{T} names a (possibly cv-qualified) signed integer
- type~(\ref{basic.fundamental}) then the member typedef
+ type\iref{basic.fundamental} then the member typedef
  \tcode{type} names the type \tcode{T}; otherwise,
  if \tcode{T} names a (possibly cv-qualified) unsigned integer
  type then \tcode{type} names the corresponding
  signed integer type, with the same cv-qualifiers as \tcode{T};
  otherwise, \tcode{type} names the signed integer type with smallest
- rank~(\ref{conv.rank}) for which
+ rank\iref{conv.rank} for which
  \tcode{sizeof(T) == sizeof(type)}, with the same
  cv-qualifiers as \tcode{T}.\br
  \requires{} \tcode{T} shall be a (possibly cv-qualified)
@@ -16502,13 +16502,13 @@ Each of the templates in this subclause shall be a
 \tcode{template <class T>}\br
  \tcode{struct make_unsigned;} &
  If \tcode{T} names a (possibly cv-qualified) unsigned integer
- type~(\ref{basic.fundamental}) then the member typedef
+ type\iref{basic.fundamental} then the member typedef
  \tcode{type} names the type \tcode{T}; otherwise,
  if \tcode{T} names a (possibly cv-qualified) signed integer
  type then \tcode{type} names the corresponding
  unsigned integer type, with the same cv-qualifiers as \tcode{T};
  otherwise, \tcode{type} names the unsigned integer type with smallest
- rank~(\ref{conv.rank}) for which
+ rank\iref{conv.rank} for which
  \tcode{sizeof(T) == sizeof(type)}, with the same
  cv-qualifiers as \tcode{T}.\br
  \requires{} \tcode{T} shall be a (possibly cv-qualified)
@@ -16586,7 +16586,7 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
 \indexlibrary{\idxcode{add_pointer}}%
 \tcode{template <class T>\br
  struct add_pointer;}                       &
- If \tcode{T} names a referenceable type~(\ref{defns.referenceable}) or a
+ If \tcode{T} names a referenceable type\iref{defns.referenceable} or a
  \cv{}~\tcode{void} type then
  the member typedef \tcode{type} names the same type as
  \tcode{remove_reference_t<T>*};
@@ -16613,7 +16613,7 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
  &
  The value of \textit{default-alignment} shall be the most
  stringent alignment requirement for any \Cpp object type whose size
- is no greater than \tcode{Len}~(\ref{basic.types}).
+ is no greater than \tcode{Len}\iref{basic.types}.
  The member typedef \tcode{type} shall be a POD type
  suitable for use as uninitialized storage for any object whose size
  is at most \tcode{Len} and whose alignment is a divisor of \tcode{Align}.\br
@@ -16641,8 +16641,8 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
  \tcode{remove_extent_t<U>*}. If \tcode{is_function_v<U>} is \tcode{true},
  the member typedef \tcode{type} shall equal \tcode{add_pointer_t<U>}. Otherwise
  the member typedef \tcode{type} equals \tcode{remove_cv_t<U>}.
- \begin{note} This behavior is similar to the lvalue-to-rvalue~(\ref{conv.lval}),
- array-to-pointer~(\ref{conv.array}), and function-to-pointer~(\ref{conv.func})
+ \begin{note} This behavior is similar to the lvalue-to-rvalue\iref{conv.lval},
+ array-to-pointer\iref{conv.array}, and function-to-pointer\iref{conv.func}
  conversions applied when an lvalue expression is used as an rvalue, but also
  strips \cv-qualifiers from class types in order to more closely model by-value
  argument passing. \end{note}
@@ -16676,14 +16676,14 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
  &
  The member typedef \tcode{type} names the underlying type
  of \tcode{T}.\br
- \requires{} \tcode{T} shall be a complete enumeration type~(\ref{dcl.enum}) \\ \rowsep
+ \requires{} \tcode{T} shall be a complete enumeration type\iref{dcl.enum} \\ \rowsep
 
 \tcode{template <class Fn,}\br
  \tcode{class... ArgTypes>}\br
  \tcode{struct invoke_result;}
  &
  If the expression \tcode{\placeholdernc{INVOKE}(declval<Fn>(), declval<ArgTypes>()...)}
- is well formed when treated as an unevaluated operand (Clause~\ref{expr}),
+ is well formed when treated as an unevaluated operand\iref{expr},
  the member typedef \tcode{type} names the type
  \tcode{decltype(\placeholdernc{INVOKE}(declval<Fn>(), declval<ArgTypes>()...))};
  otherwise, there shall be no member \tcode{type}. Access checking is
@@ -16718,7 +16718,7 @@ struct aligned_storage {
 
 \pnum
 It is \impldef{support for extended alignment} whether any extended alignment is
-supported~(\ref{basic.align}).
+supported\iref{basic.align}.
 
 \indexlibrary{\idxcode{common_type}}%
 \pnum
@@ -17207,8 +17207,8 @@ the typedef shall not be defined.
 
 \pnum
 \indexlibrary{\idxcode{chrono}}%
-This subclause describes the chrono library~(\ref{time.syn}) and various C
-functions~(\ref{ctime.syn}) that provide generally useful time
+This subclause describes the chrono library\iref{time.syn} and various C
+functions\iref{ctime.syn} that provide generally useful time
 utilities.
 
 \rSec2[time.syn]{Header \tcode{<chrono>} synopsis}
@@ -17406,7 +17406,7 @@ The origin of the clock's \tcode{time_point} is referred to as the clock's \defn
 \pnum
 In Table~\ref{tab:time.clock} \tcode{C1} and \tcode{C2} denote clock types. \tcode{t1} and
 \tcode{t2} are values returned by \tcode{C1::now()} where the call returning \tcode{t1} happens
-before~(\ref{intro.multithread}) the call returning \tcode{t2} and both of these calls
+before\iref{intro.multithread} the call returning \tcode{t2} and both of these calls
 occur
 before \tcode{C1::time_point::max()}.
 \begin{note} This means \tcode{C1} did not wrap around between \tcode{t1} and
@@ -17459,7 +17459,7 @@ SI definition is a measure of the quality of implementation. \end{note}
 A type \tcode{TC} meets the \tcode{TrivialClock} requirements if:
 
 \begin{itemize}
-\item \tcode{TC} satisfies the \tcode{Clock} requirements~(\ref{time.clock.req}),
+\item \tcode{TC} satisfies the \tcode{Clock} requirements\iref{time.clock.req},
 
 \item the types \tcode{TC::rep}, \tcode{TC::duration}, and \tcode{TC::time_point}
 satisfy the requirements of \tcode{EqualityCom\-parable} (Table~\ref{tab:equalitycomparable}),
@@ -17468,11 +17468,11 @@ satisfy the requirements of \tcode{EqualityCom\-parable} (Table~\ref{tab:equalit
 \tcode{CopyCon\-structible} (Table~\ref{tab:copyconstructible}),
 \tcode{CopyAssignable} (Table~\ref{tab:copyassignable}),
 \tcode{Destructible} (Table~\ref{tab:destructible}), and the requirements of
-numeric types~(\ref{numeric.requirements}). \begin{note} This means, in particular,
+numeric types\iref{numeric.requirements}. \begin{note} This means, in particular,
 that operations on these types will not throw exceptions. \end{note}
 
 \item lvalues of the types \tcode{TC::rep}, \tcode{TC::duration}, and
-\tcode{TC::time_point} are swappable~(\ref{swappable.requirements}),
+\tcode{TC::time_point} are swappable\iref{swappable.requirements},
 
 \item the function \tcode{TC::now()} does not throw exceptions, and
 
@@ -18403,7 +18403,7 @@ public:
 \end{codeblock}
 
 \pnum
-\tcode{Clock} shall meet the Clock requirements~(\ref{time.clock.req}).
+\tcode{Clock} shall meet the Clock requirements\iref{time.clock.req}.
 
 \pnum
 If \tcode{Duration} is not an instance of \tcode{duration},
@@ -18717,7 +18717,7 @@ unless \tcode{ToDuration} is a specialization of \tcode{duration}, and
 \pnum
 The types defined in this subclause shall satisfy the
 \tcode{TrivialClock}
-requirements~(\ref{time.clock.req}).
+requirements\iref{time.clock.req}.
 
 \rSec3[time.clock.system]{Class \tcode{system_clock}}
 \indexlibrary{\idxcode{system_clock}}%
@@ -18889,7 +18889,7 @@ The contents of the header \tcode{<ctime>} are the same as the C standard librar
 \pnum
 The functions \tcode{asctime}, \tcode{ctime}, \tcode{gmtime}, and
 \tcode{localtime} are not required to avoid data
-races~(\ref{res.on.data.races}).
+races\iref{res.on.data.races}.
 
 \xref ISO C 7.27
 
@@ -18935,8 +18935,8 @@ namespace std {
 \pnum
 The class \tcode{type_index} provides a simple wrapper for
 \tcode{type_info} which can be used as an index type in associative
-containers~(\ref{associative}) and in unordered associative
-containers~(\ref{unord}).
+containers\iref{associative} and in unordered associative
+containers\iref{unord}.
 
 \rSec2[type.index.members]{\tcode{type_index} members}
 
@@ -19326,7 +19326,7 @@ If there are several such representations,
 the representation with the smallest difference from
 the floating-point argument value is chosen,
 resolving any remaining ties using rounding according to
-\tcode{round_to_nearest}~(\ref{round.style}).
+\tcode{round_to_nearest}\iref{round.style}.
 
 \pnum
 The functions taking a \tcode{chars_format} parameter
@@ -19469,7 +19469,7 @@ the member \tcode{ec} of the return value
 is equal to \tcode{errc::result_out_of_range}.
 Otherwise,
 \tcode{value} is set to the parsed value,
-after rounding according to \tcode{round_to_nearest}~(\ref{round.style}), and
+after rounding according to \tcode{round_to_nearest}\iref{round.style}, and
 the member \tcode{ec} is value-initialized.
 
 \indexlibrary{\idxcode{from_chars}}%


### PR DESCRIPTION
Visual changes:

 * The "Clause" and "Annex" in "Clause N" and "Annex N" are now part of
   the hyperlink.
 * Fewer words are hyphenated (we prefer to move an inline reference
   across a line break rather than hyphenating a word)
 * Some spurious "Clause"s and "Annex"es are gone and some missing ones
   are now present.

LaTeX-level changes:

Instead of "some text~(\ref{blah})", we now use "some text\iref{blah}".
Instead of "Clause~\ref{blah}", we now use simply "\ref{blah}", and the
"Clause" prefix is automatically added (likewise for "Annex").

For multi-reference parentheticals, use "some text (\ref{a}, \ref{b})".
A longer orphaned parenthetical is not really a big deal.

~s should now generally not be used near \ref's.