### PR TITLE
[dcl.decl, temp.deduct.type] Fix inappropriate uses of \grammarterm.

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -2069,7 +2069,7 @@ void print(int a, int) {
 
 \pnum
 In the \grammarterm{function-body}, a
-\grammarterm{function-local predefined variable} denotes a block-scope object of static
+\defnx{function-local predefined variable}{variable!function-local predefined} denotes a block-scope object of static
 storage duration that is implicitly defined (see~\ref{basic.scope.block}).
 
 \pnum
@@ -2096,14 +2096,13 @@ void f(const char* s = __func__);   // error: \tcode{__func__} is undeclared
 \end{example}
 
 \rSec2[dcl.fct.def.default]{Explicitly-defaulted functions}%
-\indextext{definition!function!explicitly-defaulted}%
 
 \pnum
 A function definition whose
 \grammarterm{function-body}
 is of the form
 \tcode{= default ;}
-is called an \grammarterm{explicitly-defaulted} definition.
+is called an \defnx{explicitly-defaulted}{definition!function!explicitly-defaulted} definition.
 A function that is explicitly defaulted shall
 
 \begin{itemize}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -8101,7 +8101,7 @@ T
 T*
 T&
 T&&
-T[@\grammarterm{integer-constant}@]
+T[@\placeholder{integer-constant}@]
 @\grammarterm{template-name}@<T>  @\textrm{(where \tcode{\grammarterm{template-name}} refers to a class template)}@
 @\placeholder{type}@(T)
 T()


### PR DESCRIPTION
No visible change.