### PR TITLE
[defns.well.formed] remove full stop

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -307,7 +307,7 @@ possible behaviors is usually delineated by this International Standard.
 \indexdefn{program!well-formed}%
 \definition{well-formed program}{defns.well.formed}
 \Cpp  program constructed according to the syntax rules, diagnosable
-semantic rules, and the one-definition rule\iref{basic.def.odr}.%
+semantic rules, and the one-definition rule\iref{basic.def.odr}%
 \indextext{definitions|)}
 
 \rSec0[intro]{General principles}


### PR DESCRIPTION
Per Directives Part 2, 16.5.5, definitions "shall not [...] end with a full stop".