### PR TITLE
[futures.async] remove parens from DECAY_COPY()

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -4838,7 +4838,7 @@ If \tcode{launch::async} is set in \tcode{policy}, calls
 \tcode{\placeholdernc{DECAY_COPY}(std::forward<Args>(args))...)}
 (\ref{func.require}, \ref{thread.thread.constr})
 as if in a new thread of execution represented by a \tcode{thread} object
-with the calls to \tcode{\placeholdernc{DECAY_COPY}()} being evaluated in the thread that called \tcode{async}.
+with the calls to \tcode{\placeholder{DECAY_COPY}} being evaluated in the thread that called \tcode{async}.
 Any return value
 is stored as the result in the
 shared state. Any exception propagated from


### PR DESCRIPTION
We're referring to the function name, not trying to call it with no arguments.