### PR TITLE
[class.copy.assign] Remove extraneous space before the first word of para 1

### DIFF
--- a/source/special.tex
+++ b/source/special.tex
@@ -2814,7 +2814,7 @@ The implicitly-defined copy/move constructor for a union
 \indextext{copy!class object|see{assignment operator, copy}}%
 \indextext{move!class object|see{assignment operator, move}}%
 \indextext{operator!copy assignment|see{assignment operator, copy}}%
-\indextext{operator!move assignment|see{assignment operator, move}}
+\indextext{operator!move assignment|see{assignment operator, move}}%
 A user-declared \term{copy} assignment operator \tcode{X::operator=} is a
 non-static non-template member function of class \tcode{X} with exactly one
 parameter of type \tcode{X}, \tcode{X\&}, \tcode{const} \tcode{X\&},


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/456873/30190600-1ef9cc30-93f0-11e7-8cb1-f92c5281e7ba.png)

After:
![image](https://user-images.githubusercontent.com/456873/30190622-368a32cc-93f0-11e7-8894-8bbfee138a0c.png)

