### PR TITLE
Reword [over.ics.rank]/3.2.3

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -2516,8 +2516,8 @@ or, if not that,
 \item \tcode{S1} and \tcode{S2} are reference bindings\iref{dcl.init.ref} and
 neither refers to an implicit object parameter of a non-static member function
 declared without a \grammarterm{ref-qualifier},
-and \tcode{S1} binds an rvalue reference to an
-rvalue and \tcode{S2} binds an lvalue reference
+and \tcode{S1} binds an rvalue reference and 
+\tcode{S2} binds an lvalue reference to an rvalue
 \begin{example}
 \begin{codeblock}
 int i;


### PR DESCRIPTION
The wording here is awkward. The intent is, I think, to prefer binding an rvalue to an rvalue reference than to an lvalue reference, but the phrase "to an rvalue" is attached to the rvalue reference part (to which it is redundant). Would be clearer to attach it to the lvalue reference part.