### PR TITLE
[intro.refs] Remove redundant reference to C11 Technical Corrigendum 1.

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -38,8 +38,6 @@ Standard Ecma-262, third edition, 1999.
 \item ISO/IEC 2382 (all parts), \doccite{Information technology ---
 Vocabulary}
 \item ISO/IEC 9899:2011, \doccite{Programming languages --- C}
-\item ISO/IEC 9899:2011/Cor.1:2012(E), \doccite{Programming languages --- C,
-Technical Corrigendum 1}
 \item ISO/IEC 9945:2003, \doccite{Information Technology --- Portable
 Operating System Interface (POSIX)}
 \item ISO/IEC 10646-1:1993, \doccite{Information technology ---


### PR DESCRIPTION
When making a normative reference to another document, all relevant
Technical Corrigenda are assumed and need not be listed explicitly.

Fixes ISO 1 (C++17 DIS)