### PR TITLE
[over.match.funcs] Remove the number of overload resolution contexts

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -481,7 +481,7 @@ the program is ill-formed.
 \pnum
 The subclauses of~\ref{over.match.funcs} describe
 the set of candidate functions and the argument list submitted to
-overload resolution in each of the seven contexts in which
+overload resolution in each context in which
 overload resolution is used.
 The source transformations and constructions defined
 in these subclauses are only for the purpose of describing the


### PR DESCRIPTION
from the introductory text.

It has become out of date relative to the actual number, and listing a
number here is not useful.

Fixes NB JP 5 (C++17 DIS)