### PR TITLE
Convert "must"s in normative wording that do not indicate logical

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -1920,7 +1920,7 @@ basic_ostream<charT, traits>* tie(basic_ostream<charT, traits>* tiestr);
 \begin{itemdescr}
 \pnum
 \requires
-If \tcode{tiestr} is not null, \tcode{tiestr} must not be reachable by
+If \tcode{tiestr} is not null, \tcode{tiestr} shall not be reachable by
 traversing the linked list of tied stream objects starting from
 \tcode{tiestr->tie()}.
 
@@ -13801,7 +13801,7 @@ path canonical(const path& p, const path& base, error_code& ec);
 
 \begin{itemdescr}
 \pnum
-\effects Converts \tcode{p}, which must exist, to an absolute
+\effects Converts \tcode{p} to an absolute
 path that has no symbolic link, \grammarterm{dot}, or \grammarterm{dot-dot} elements
 in its pathname in the generic format.
 

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -337,7 +337,7 @@ behavior when it executes, the behavior is undefined.%
 
 \definition{reserved function}{defns.reserved.function}
 \indexdefn{function!reserved}%
-function, specified as part of the \Cpp standard library, that must be defined by the
+function, specified as part of the \Cpp standard library, that is defined by the
 implementation
 
 \begin{defnote}

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -1075,7 +1075,7 @@ The
 \tcode{put()}
 members make no provision for error reporting.
 (Any failures of the
-OutputIterator argument must be extracted from the returned iterator.)
+OutputIterator argument can be extracted from the returned iterator.)
 The
 \tcode{get()}
 members take an
@@ -3926,7 +3926,7 @@ and may be outside their valid range.
 \remarks It is unspecified whether multiple calls to
 \tcode{do_get()} with the
 address of the same \tcode{struct tm} object will update the current contents of
-the object or simply overwrite its members. Portable programs must zero
+the object or simply overwrite its members. Portable programs should zero
 out the object before invoking the function.
 
 \pnum

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -7044,7 +7044,7 @@ subset as a new \tcode{valarray} object. The non-const versions return a class
 template object which has reference semantics to the original array, working in
 conjunction with various overloads of \tcode{operator=} and other assigning
 operators to allow selective replacement (slicing) of the controlled sequence.
-In each case the selected element(s) must exist.
+In each case the selected element(s) shall exist.
 
 \indexlibrarymember{operator[]}{valarray}%
 \begin{itemdecl}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -3737,7 +3737,8 @@ parameter (i.e., has the same constant value or the same type
 as the template parameter) can be used in place of that
 template parameter in a reference to the current
 instantiation. In the case of a non-type template argument,
-the argument must have been given the value of the
+this only applies if
+the argument was given the value of the
 template parameter and not an expression in which the
 template parameter appears as a subexpression.
 \begin{example}
@@ -5810,24 +5811,27 @@ void g(double d) {
 \end{example}
 
 \pnum
-When an explicit template argument list is specified, the template
-arguments must be compatible with the template parameter list and must
-result in a valid function type as described below; otherwise type
+When an explicit template argument list is specified, if the template
+arguments are not compatible with the template parameter list or do
+not result in a valid function type as described below, type
 deduction fails.  Specifically, the following steps are performed when
 evaluating an explicitly specified template argument list with respect
 to a given function template:
 
 \begin{itemize}
-\item The specified template arguments must match the template parameters in
-kind (i.e., type, non-type, template). There
-must not be more arguments than there are parameters
-unless at least one parameter is a template parameter pack, and there shall be
-an argument for each non-pack parameter.
-Otherwise, type deduction fails.
+\item If the specified template arguments do not match the template
+parameters in
+kind (i.e., type, non-type, template), or if there
+are more arguments than there are parameters
+and no parameter is a template parameter pack, or if there is not
+an argument for each non-pack parameter,
+type deduction fails.
 
-\item Non-type arguments must match the types of the corresponding non-type
-template parameters, or must be convertible to the types of the
-corresponding non-type parameters as specified in~\ref{temp.arg.nontype}, otherwise type deduction fails.
+\item If any non-type argument does not match the type of the
+corresponding non-type
+template parameter, and is not convertible to the type of the
+corresponding non-type parameter as specified in~\ref{temp.arg.nontype},
+type deduction fails.
 
 \item The specified template argument values are substituted for the
 corresponding template parameters as specified below.
@@ -6739,8 +6743,9 @@ if \tcode{F} does not have a trailing parameter pack,
 then \tcode{F} is more specialized than \tcode{G}.
 
 \pnum
-In most cases, all template parameters must have values in order for
-deduction to succeed, but for partial ordering purposes a template
+In most cases,
+deduction fails if not all template parameters have values,
+but for partial ordering purposes a template
 parameter may remain without a value provided it is not used in the
 types being used for partial ordering.
 \begin{note}
@@ -6849,7 +6854,8 @@ to compose
 participate in template argument deduction.
 That is,
 they may be used to determine the value of a template argument, and
-the value so determined must be consistent with the values determined
+template argument deduction fails if
+the value so determined is not consistent with the values determined
 elsewhere.
 In certain contexts, however, the value does not
 participate in type deduction, but instead uses the values of template

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -2940,7 +2940,7 @@ all objects with thread storage duration associated with the current thread.
 \pnum
 \begin{note}
 The supplied lock will be held until the thread exits, and care
-must be taken to ensure that this does not cause deadlock due to lock
+should be taken to ensure that this does not cause deadlock due to lock
 ordering issues. After calling \tcode{notify_all_at_thread_exit} it is
 recommended that the thread should be exited as soon as possible, and
 that no blocking or time-consuming tasks are run on that thread.
@@ -3031,8 +3031,8 @@ limitation prevents initialization.
 threads shall have been notified; they may subsequently block on the lock specified in the
 wait.
 This relaxes the usual rules, which would have required all wait calls to happen before
-destruction. Only the notification to unblock the wait must happen before destruction.
-The user must take care to ensure that no threads wait on \tcode{*this} once the destructor has
+destruction. Only the notification to unblock the wait needs to happen before destruction.
+The user should take care to ensure that no threads wait on \tcode{*this} once the destructor has
 been started, especially when the waiting threads are calling the wait functions in a loop or
 using the overloads of \tcode{wait}, \tcode{wait_for}, or \tcode{wait_until} that take a predicate.
 \end{note}
@@ -3345,7 +3345,7 @@ A \tcode{Lock} type shall meet the \tcode{BasicLockable}
 requirements~(\ref{thread.req.lockable.basic}). \begin{note} All of the standard
 mutex types meet this requirement. If a \tcode{Lock} type other than one of the
 standard mutex types or a \tcode{unique_lock} wrapper for a standard mutex type
-is used with \tcode{condition_variable_any}, the user must ensure that any
+is used with \tcode{condition_variable_any}, the user should ensure that any
 necessary synchronization is in place with respect to the predicate associated
 with the \tcode{condition_variable_any} instance. \end{note}
 
@@ -3416,8 +3416,8 @@ privilege to perform the operation.
 threads shall have been notified; they may subsequently block on the lock specified in the
 wait.
 This relaxes the usual rules, which would have required all wait calls to happen before
-destruction. Only the notification to unblock the wait must happen before destruction.
-The user must take care to ensure that no threads wait on \tcode{*this} once the destructor has
+destruction. Only the notification to unblock the wait needs to happen before destruction.
+The user should take care to ensure that no threads wait on \tcode{*this} once the destructor has
 been started, especially when the waiting threads are calling the wait functions in a loop or
 using the overloads of \tcode{wait}, \tcode{wait_for}, or \tcode{wait_until} that take a predicate.
 \end{note}
@@ -4890,7 +4890,7 @@ in this International Standard nor by the implementation, the behavior is undefi
 \tcode{future<invoke_result_t<decay_t<F>, decay_t<Args>...>{>}} that refers
 to the shared state created by this call to \tcode{async}.
 \begin{note} If a future obtained from \tcode{async} is moved outside the local scope,
-other code that uses the future must be aware that the future's destructor may
+other code that uses the future should be aware that the future's destructor may
 block for the shared state to become ready. \end{note}
 
 \pnum

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -7398,7 +7398,7 @@ void declare_no_pointers(char* p, size_t n);
 \requires No bytes in the specified range
 are currently registered with
 \tcode{declare_no_pointers()}. If the specified range is in an allocated object,
-then it must be entirely within a single allocated object. The object must be
+then it shall be entirely within a single allocated object. The object shall be
 live until the corresponding \tcode{undeclare_no_pointers()} call. \begin{note} In
 a garbage-collecting implementation, the fact that a region in an object is
 registered with \tcode{declare_no_pointers()} should not prevent the object from
@@ -7428,12 +7428,12 @@ void undeclare_no_pointers(char* p, size_t n);
 
 \begin{itemdescr}
 \pnum
-\requires The same range must previously have been passed to
+\requires The same range shall previously have been passed to
 \tcode{declare_no_pointers()}.
 
 \pnum
 \effects Unregisters a range registered with \tcode{declare_no_pointers()} for
-destruction. It must be called before the lifetime of the object ends.
+destruction. It shall be called before the lifetime of the object ends.
 
 \pnum
 \throws Nothing.
@@ -8344,7 +8344,7 @@ invocation results in \textit{p}'s appropriate disposition (typically its deleti
 Let the notation \textit{u.p} denote the pointer stored by \textit{u}, and
 let \textit{u.d} denote the associated deleter. Upon request, \textit{u} can
 \defn{reset} (replace) \textit{u.p} and \textit{u.d} with another pointer and
-deleter, but must properly dispose of its owned object via the associated
+deleter, but properly disposes of its owned object via the associated
 deleter before such replacement is considered completed.
 
 \pnum
@@ -8359,7 +8359,7 @@ postconditions hold:
 transferred to \textit{u2.d}.
 \end{itemize}
 
-As in the case of a reset, \textit{u2} must properly dispose of its pre-transfer
+As in the case of a reset, \textit{u2} properly disposes of its pre-transfer
 owned object via the pre-transfer associated deleter before the ownership
 transfer is considered complete. \begin{note} A deleter's state need never be
 copied, only moved or swapped as ownership is transferred. \end{note}
@@ -9794,7 +9794,7 @@ stores \tcode{p} and shares ownership with \tcode{r}.
 
 \pnum
 \begin{note} To avoid the possibility of a dangling pointer, the
-user of this constructor must ensure that \tcode{p} remains valid at
+user of this constructor should ensure that \tcode{p} remains valid at
 least until the ownership group of \tcode{r} is destroyed. \end{note}
 
 \pnum
@@ -15841,7 +15841,7 @@ For all of the class templates \tcode{X} declared in this subclause,
 instantiating that template with a template-argument that is a class
 template specialization may result in the implicit instantiation of
 the template argument if and only if the semantics of \tcode{X} require that
-the argument must be a complete type.
+the argument is a complete type.
 
 \pnum
 For the purpose of defining the templates in this subclause,


### PR DESCRIPTION
necessity to a different form.

Normative requirements use "shall". Advice to users uses "should".
Description of the behavior of the implementation that does not of
itself constitute a requirement uses the imperative mood.

Fixes ISO 21 (C++17 DIS)