### PR TITLE
Replace "this International Standard" with "this document" when

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -1231,7 +1231,7 @@ operations on containers and other sequences in parallel.
 
 \rSec2[algorithms.parallel.defns]{Terms and definitions}
 \pnum
-A \defn{parallel algorithm} is a function template listed in this International Standard with
+A \defn{parallel algorithm} is a function template listed in this document with
 a template parameter named \tcode{ExecutionPolicy}.
 
 \pnum

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3273,8 +3273,8 @@ The lifetime of a reference ends as if it were a scalar object.
 describes the lifetime of base and member subobjects. \end{note}
 
 \pnum
-The properties ascribed to objects and references throughout this International
-Standard apply for a given object or reference only during its lifetime. \begin{note}
+The properties ascribed to objects and references throughout this document
+apply for a given object or reference only during its lifetime. \begin{note}
 In particular, before the lifetime of an object starts and after its
 lifetime ends there are significant restrictions on the use of the
 object, as described below, in~\ref{class.base.init} and
@@ -3849,8 +3849,8 @@ respectively, in \tcode{<cstdint>}, called the underlying types.
 \pnum
 \indextext{Boolean type}%
 Values of type \tcode{bool} are either \tcode{true} or
-\tcode{false}.\footnote{Using a \tcode{bool} value in ways described by this International
-Standard as ``undefined'', such as by examining the value of an
+\tcode{false}.\footnote{Using a \tcode{bool} value in ways described by this document
+as ``undefined'', such as by examining the value of an
 uninitialized automatic object, might cause it to behave as if it is
 neither \tcode{true} nor \tcode{false}.}
 \begin{note} There are no \tcode{signed}, \tcode{unsigned}, \tcode{short},
@@ -3875,7 +3875,7 @@ and 1, in which the values represented by successive bits are additive,
 begin with 1, and are multiplied by successive integral power of 2,
 except perhaps for the bit with the highest position. (Adapted from the
 \doccite{American National Dictionary for Information Processing Systems}.)}
-\begin{example} This International Standard permits two's complement,
+\begin{example} This document permits two's complement,
 ones' complement and signed magnitude representations for integral types.
 \end{example}
 
@@ -3897,7 +3897,7 @@ representation of floating-point types is \impldef{value representation of
 floating-point types}.
 \indextext{floating-point type!implementation-defined}%
 \begin{note}
-This International Standard imposes no requirements on the accuracy of
+This document imposes no requirements on the accuracy of
 floating-point operations; see also~\ref{support.limits}.
 \end{note}
 Integral and floating types are collectively
@@ -4158,7 +4158,7 @@ constitute this ordering.
 \end{floattable}
 
 \pnum
-In this International Standard, the notation \cv{} (or
+In this document, the notation \cv{} (or
 \cvqual{cv1}, \cvqual{cv2}, etc.), used in the description of types,
 represents an arbitrary set of cv-qualifiers, i.e., one of
 \{\tcode{const}\}, \{\tcode{volatile}\}, \{\tcode{const},

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -191,7 +191,7 @@ of such problems.
 Those problems not found by typesafe linkage will continue to
 function properly,
 according to the ``layout compatibility rules'' of this
-International Standard.
+document.
 \howwide
 Common.
 
@@ -1075,8 +1075,8 @@ this International Standard.
 \change Additional restrictions on macro names.
 \rationale Avoid hard to diagnose or non-portable constructs.
 \effect
-Names of attribute identifiers may not be used as macro names. Valid \Cpp
-2003 code that defines \tcode{override}, \tcode{final},
+Names of attribute identifiers may not be used as macro names. Valid \CppIII
+code that defines \tcode{override}, \tcode{final},
 \tcode{carries_dependency}, or \tcode{noreturn} as macros is invalid in this
 International Standard.
 

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3378,7 +3378,7 @@ be achieved using a \grammarterm{linkage-specification}:
 \end{bnf}
 
 The \grammarterm{string-literal} indicates the required language linkage.
-This International Standard specifies the semantics for the
+This document specifies the semantics for the
 \grammarterm{string-literal}{s} \tcode{"C"} and \tcode{"C++"}. Use of a
 \grammarterm{string-literal} other than \tcode{"C"} or \tcode{"C++"} is
 conditionally-supported, with \impldef{semantics of linkage specifiers} semantics.
@@ -3722,7 +3722,7 @@ instantiation~(\ref{temp.explicit}).
 \pnum
 For an \grammarterm{attribute-token}
 (including an \grammarterm{attribute-scoped-token})
-not specified in this International Standard, the
+not specified in this document, the
 behavior is \impldef{behavior of non-standard attributes}.
 Any \grammarterm{attribute-token} that is not recognized by the implementation
 is ignored.

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -937,8 +937,7 @@ conversions, respectively.
 The class \tcode{error_category} serves as a base class for types used
 to identify the source and encoding of a particular category of error code.
 Classes may be derived from \tcode{error_category} to support
-categories of errors in addition to those defined in this International
-Standard.
+categories of errors in addition to those defined in this document.
 Such classes shall behave as specified in this
 subclause. \begin{note} \tcode{error_category} objects are
 passed by reference, and two such objects

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4972,7 +4972,7 @@ limits (see Annex~\ref{implimits});
 \item
 an operation that would have undefined behavior
 as specified in Clauses~\ref{intro} through~\ref{cpp}
-of this International Standard \begin{note} including,
+of this document \begin{note} including,
 for example, signed integer overflow~(Clause \ref{expr}), certain
 pointer arithmetic~(\ref{expr.add}), division by
 zero~(\ref{expr.mul}), or certain shift operations~(\ref{expr.shift})
@@ -5108,7 +5108,7 @@ a \grammarterm{throw-expression}~(\ref{expr.throw}).
 If \tcode{e} satisfies the constraints of a core constant expression, but
 evaluation of \tcode{e} would evaluate an operation that has undefined behavior
 as specified in Clauses~\ref{library} through~\ref{\lastlibchapter} of this
-International Standard, it is unspecified whether \tcode{e} is a core constant
+document, it is unspecified whether \tcode{e} is a core constant
 expression.
 
 \begin{example}
@@ -5231,7 +5231,7 @@ a temporary object whose value satisfies the above constraints, or it is a
 function.
 
 \pnum
-\begin{note} Since this International Standard
+\begin{note} Since this document
 imposes no restrictions on the accuracy of floating-point operations, it is unspecified whether the
 evaluation of a floating-point expression during translation yields the same result as the
 evaluation of the same expression (or the same operations on the same values) during program

--- a/source/future.tex
+++ b/source/future.tex
@@ -1307,7 +1307,7 @@ then \tcode{result_type} shall be a synonym for \tcode{T::result_type};
 \pnum
 To enable old function adaptors to manipulate function objects
 that take one or two arguments,
-many of the function objects in this International Standard
+many of the function objects in this document
 correspondingly provide \grammarterm{typedef-name}{s}
 \tcode{argument_type} and \tcode{result_type}
 for function objects that take one argument and

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -267,12 +267,12 @@ satisfy a condition that one or more blocked threads of execution are waiting fo
 
 \indexdefn{behavior!undefined}%
 \definition{undefined behavior}{defns.undefined}
-behavior for which this International Standard
+behavior for which this document
 imposes no requirements
 
 \begin{defnote}
 Undefined behavior may be expected when
-this International Standard omits any explicit
+this document omits any explicit
 definition of behavior or when a program uses an erroneous construct or erroneous data.
 Permissible undefined behavior ranges
 from ignoring the situation completely with unpredictable results, to
@@ -293,7 +293,7 @@ depends on the implementation
 \begin{defnote}
 The implementation is not required to
 document which behavior occurs. The range of
-possible behaviors is usually delineated by this International Standard.
+possible behaviors is usually delineated by this document.
 \end{defnote}
 
 \indexdefn{program!well-formed}%
@@ -333,34 +333,34 @@ semantic rules, and the one-definition rule~(\ref{basic.def.odr}).%
 \indextext{conformance requirements!general|(}%
 The set of
 \defn{diagnosable rules}
-consists of all syntactic and semantic rules in this International
-Standard except for those rules containing an explicit notation that
+consists of all syntactic and semantic rules in this document
+except for those rules containing an explicit notation that
 ``no diagnostic is required'' or which are described as resulting in
 ``undefined behavior''.
 
 \pnum
 \indextext{conformance requirements!method of description}%
-Although this International Standard states only requirements on \Cpp
+Although this document states only requirements on \Cpp
 implementations, those requirements are often easier to understand if
 they are phrased as requirements on programs, parts of programs, or
 execution of programs. Such requirements have the following meaning:
 \begin{itemize}
 \item
 If a program contains no violations of the rules in this
-International Standard, a conforming implementation shall,
+document, a conforming implementation shall,
 within its resource limits, accept and correctly execute\footnote{``Correct execution'' can include undefined behavior, depending on
 the data being processed; see Clause~\ref{intro.defs} and~\ref{intro.execution}.}
 that program.
 \item
 \indextext{message!diagnostic}%
 If a program contains a violation of any diagnosable rule or an occurrence
-of a construct described in this International Standard as ``conditionally-supported'' when
+of a construct described in this document as ``conditionally-supported'' when
 the implementation does not support that construct, a conforming implementation
 shall issue at least one diagnostic message.
 \item
 \indextext{behavior!undefined}%
 If a program contains a violation of a rule for which no diagnostic
-is required, this International Standard places no requirement on
+is required, this document places no requirement on
 implementations with respect to that program.
 \end{itemize}
 \begin{note}
@@ -400,7 +400,7 @@ translation units to form a complete \Cpp  program~(\ref{lex.phases}).%
 \pnum
 Two kinds of implementations are defined: a \defn{hosted implementation} and a
 \defn{freestanding implementation}. For a hosted implementation, this
-International Standard defines the set of available libraries. A freestanding
+document defines the set of available libraries. A freestanding
 implementation is one in which execution may take place without the benefit of
 an operating system, and has an \impldef{required libraries for freestanding
 implementation} set of libraries that includes certain language-support
@@ -411,7 +411,7 @@ A conforming implementation may have extensions (including
 additional library functions), provided they do not alter the
 behavior of any well-formed program.
 Implementations are required to diagnose programs that use such
-extensions that are ill-formed according to this International Standard.
+extensions that are ill-formed according to this document.
 Having done so, however, they can compile and execute such programs.
 
 \pnum
@@ -756,9 +756,9 @@ new types from existing types~(\ref{basic.types}).
 \pnum
 \indextext{program execution|(}%
 \indextext{program execution!abstract machine}%
-The semantic descriptions in this International Standard define a
-parameterized nondeterministic abstract machine. This International
-Standard places no requirement on the structure of conforming
+The semantic descriptions in this document define a
+parameterized nondeterministic abstract machine. This document
+places no requirement on the structure of conforming
 implementations. In particular, they need not copy or emulate the
 structure of the abstract machine.
 \indextext{as-if rule}%
@@ -766,7 +766,7 @@ structure of the abstract machine.
 Rather, conforming implementations are required to emulate (only) the observable
 behavior of the abstract machine as explained below.\footnote{This provision is
 sometimes called the ``as-if'' rule, because an implementation is free to
-disregard any requirement of this International Standard as long as the result
+disregard any requirement of this document as long as the result
 is \emph{as if} the requirement had been obeyed, as far as can be determined
 from the observable behavior of the program. For instance, an actual
 implementation need not evaluate part of an expression if it can deduce that its
@@ -778,7 +778,7 @@ observable behavior of the program are produced.}
 \indextext{behavior!implementation-defined}%
 \pnum
 Certain aspects and operations of the abstract machine are described in this
-International Standard as implementation-defined (for example,
+document as implementation-defined (for example,
 \tcode{sizeof(int)}). These constitute the parameters of the abstract machine.
 Each implementation shall include documentation describing its characteristics
 and behavior in these respects.\footnote{This documentation also includes
@@ -790,20 +790,20 @@ abstract machine that corresponds to that implementation (referred to as the
 \indextext{behavior!unspecified}%
 \pnum
 Certain other aspects and operations of the abstract machine are
-described in this International Standard as unspecified (for example,
+described in this document as unspecified (for example,
 evaluation of expressions in a \grammarterm{new-initializer} if the allocation
 function fails to allocate memory~(\ref{expr.new})). Where possible, this
-International Standard defines a set of allowable behaviors. These
+document defines a set of allowable behaviors. These
 define the nondeterministic aspects of the abstract machine. An instance
 of the abstract machine can thus have more than one possible execution
 for a given program and a given input.
 
 \indextext{behavior!undefined}%
 \pnum
-Certain other operations are described in this International Standard as
+Certain other operations are described in this document as
 undefined (for example, the effect of
 attempting to modify a \tcode{const} object).
-\begin{note} This International Standard imposes no requirements on the
+\begin{note} This document imposes no requirements on the
 behavior of programs that contain undefined behavior. \end{note}
 
 \indextext{program!well-formed}%
@@ -814,7 +814,7 @@ produce the same observable behavior as one of the possible executions
 of the corresponding instance of the abstract machine with the
 same program and the same input.
 \indextext{behavior!undefined}%
-However, if any such execution contains an undefined operation, this International Standard places no
+However, if any such execution contains an undefined operation, this document places no
 requirement on the implementation executing that program with that input
 (not even with regard to operations preceding the first undefined
 operation).
@@ -1160,7 +1160,7 @@ one specific thread, and can be accessed by a different thread only indirectly
 through a pointer or reference~(\ref{basic.compound}).} Under a hosted
 implementation, a \Cpp program can have more than one thread running
 concurrently. The execution of each thread proceeds as defined by the remainder
-of this International Standard. The execution of the entire program consists of an execution
+of this document. The execution of the entire program consists of an execution
 of all of its threads. \begin{note} Usually the execution can be viewed as an
 interleaving of all its threads. However, some kinds of atomic operations, for
 example, allow executions inconsistent with a simple interleaving, as described
@@ -1490,7 +1490,7 @@ in \placeholder{B}.
 \pnum
 \begin{note} Compiler transformations that introduce assignments to a potentially
 shared memory location that would not be modified by the abstract machine are
-generally precluded by this International Standard, since such an assignment might overwrite
+generally precluded by this document, since such an assignment might overwrite
 another assignment by a different thread in cases in which an abstract machine
 execution would not have encountered a data race. This includes implementations
 of data member assignment that overwrite adjacent members in separate memory
@@ -1501,7 +1501,7 @@ rules. \end{note}
 \pnum
 \begin{note} Transformations that introduce a speculative read of a potentially
 shared memory location may not preserve the semantics of the \Cpp program as
-defined in this International Standard, since they potentially introduce a data race. However,
+defined in this document, since they potentially introduce a data race. However,
 they are typically valid in the context of an optimizing compiler that targets a
 specific machine with well-defined semantics for data races. They would be
 invalid for a hypothetical machine that is not tolerant of races or provides

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -72,7 +72,7 @@ This ensures that every
 function template
 that takes iterators
 works as well with regular pointers.
-This International Standard defines
+This document defines
 five categories of iterators, according to the operations
 defined on them:
 \techterm{input iterators},

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -29,8 +29,8 @@
 \indextext{conventions!lexical|(}%
 \indextext{compilation!separate|(}%
 The text of the program is kept in units called
-\defnx{source files}{source file} in this International
-Standard. A source file together with all the headers~(\ref{headers})
+\defnx{source files}{source file} in this document.
+A source file together with all the headers~(\ref{headers})
 and source files included~(\ref{cpp.include}) via the preprocessing
 directive \tcode{\#include}, less any source lines skipped by any of the
 conditional inclusion~(\ref{cpp.cond}) preprocessing directives, is
@@ -817,7 +817,7 @@ in translation phase 7~(\ref{lex.phases}).%
 \indextext{constant}%
 \indextext{literal!constant}%
 There are several kinds of literals.\footnote{The term ``literal'' generally designates, in this
-International Standard, those tokens that are called ``constants'' in
+document, those tokens that are called ``constants'' in
 ISO C. }
 
 \begin{bnf}

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -117,9 +117,9 @@ suitably adjusted to ensure static type safety.
 The descriptions of many library functions rely on the C standard library for
 the semantics of those functions.
 In some cases,
-the signatures specified in this International Standard
+the signatures specified in this document
 may be different from the signatures in the C standard library,
-and additional overloads may be declared in this International Standard,
+and additional overloads may be declared in this document,
 but the behavior and the preconditions
 (including any preconditions implied by the use of an
 ISO C \tcode{restrict} qualifier)
@@ -129,7 +129,7 @@ are the same unless otherwise stated.
 
 \pnum
 \begin{note}
-Clause \ref{intro.defs} defines additional terms used elsewhere in this International Standard.
+Clause \ref{intro.defs} defines additional terms used elsewhere in this document.
 \end{note}
 
 \def\definition{\definitionx{\subsection}}%
@@ -561,7 +561,7 @@ constants~(\ref{syserr}).
 
 \pnum
 Paragraphs labeled ``\xref'' contain cross-references to the relevant portions
-of this International Standard and the ISO C standard.
+of the ISO C standard.
 
 \rSec2[conventions]{Other conventions}
 \indextext{conventions}%
@@ -1291,7 +1291,7 @@ Two kinds of implementations are defined:
 \term{hosted}
 and
 \term{freestanding}~(\ref{intro.compliance}).
-For a hosted implementation, this International Standard
+For a hosted implementation, this document
 \indextext{implementation!hosted}%
 describes the set of available headers.
 
@@ -2191,7 +2191,7 @@ and the specialization meets the standard library requirements
 for the original template and is not explicitly prohibited.\footnote{Any
 library code that instantiates other library templates
 must be prepared to work adequately with any user-supplied specialization
-that meets the minimum requirements of this International Standard.}
+that meets the minimum requirements of this document.}
 
 \pnum
 The behavior of a \Cpp program is undefined if it declares
@@ -2550,7 +2550,7 @@ any of the \tcode{set_*} functions shall synchronize with subsequent calls to th
 In certain cases (replacement functions, handler functions, operations on types used to
 instantiate standard library template components), the \Cpp standard library depends on
 components supplied by a \Cpp program.
-If these components do not meet their requirements, this International Standard places no requirements
+If these components do not meet their requirements, this document places no requirements
 on the implementation.
 
 \pnum
@@ -2760,7 +2760,7 @@ It is unspecified whether any member functions in the \Cpp standard library are 
 For a non-virtual member function described in the \Cpp standard library,
 an implementation may declare a different set of member function signatures,
 provided that any call to the member function that would select
-an overload from the set of declarations described in this International Standard
+an overload from the set of declarations described in this document
 behaves as if that overload were selected.
 \begin{note}
 For instance, an implementation may add parameters with default values,
@@ -2772,7 +2772,7 @@ or add additional signatures for a member function name.
 \rSec3[constexpr.functions]{Constexpr functions and constructors}
 
 \pnum
-This International Standard explicitly requires that certain standard library functions are
+This document explicitly requires that certain standard library functions are
 \tcode{constexpr}~(\ref{dcl.constexpr}). An implementation shall not declare
 any standard library function signature as \tcode{constexpr} except for those where
 it is explicitly required.
@@ -2803,7 +2803,7 @@ original order).
 \rSec3[reentrancy]{Reentrancy}
 
 \pnum
-Except where explicitly specified in this International Standard, it is \impldef{which functions in
+Except where explicitly specified in this document, it is \impldef{which functions in
 the \Cpp standard library may be recursively reentered} which functions in the \Cpp standard
 library may be recursively reentered.
 

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -219,7 +219,7 @@ namespace std {
 The contents and meaning of the header \tcode{<cfenv>}
 are the same as the C standard library header \tcode{<fenv.h>}.
 \begin{note}
-This International Standard does not require an implementation to support the
+This document does not require an implementation to support the
 \tcode{FENV_ACCESS} pragma;
 it is \impldef{whether pragma \tcode{FENV_ACCESS} is supported}~(\ref{cpp.pragma})
 whether the pragma is supported. As a consequence,
@@ -227,7 +227,7 @@ it is \impldef{whether \tcode{<cfenv>} functions can be used to manage floating-
 whether these functions can be used to test floating-point status flags,
 set floating-point control modes, or run under non-default mode settings.
 If the pragma is used to enable control over the floating-point environment,
-this International Standard does not specify the effect on
+this document does not specify the effect on
 floating-point evaluation in constant expressions.
 \end{note}
 
@@ -6416,7 +6416,7 @@ may introduce data races~(\ref{res.on.data.races}).
 \begin{note}
 \indexlibrary{\idxcode{rand}!discouraged}%
 The other random
-number generation facilities in this International Standard~(\ref{rand}) are often preferable
+number generation facilities in this document~(\ref{rand}) are often preferable
 to \tcode{rand}, because \tcode{rand}'s underlying algorithm is unspecified.
 Use of \tcode{rand} therefore continues to be non-portable, with unpredictable
 and oft-questionable quality and performance.
@@ -10499,7 +10499,7 @@ with the addition of
 a three-dimensional hypotenuse function~(\ref{c.math.hypot3}) and
 the mathematical special functions described in \ref{sf.cmath}.
 \begin{note}
-Several functions have additional overloads in this International Standard,
+Several functions have additional overloads in this document,
 but they have the same behavior as in the C standard library~(\ref{library.c}).
 \end{note}
 

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -5883,7 +5883,7 @@ The functions \tcode{memcpy} and \tcode{memmove} are signal-safe~(\ref{support.s
 \begin{note}
 The functions
 \tcode{strchr}, \tcode{strpbrk}, \tcode{strrchr}, \tcode{strstr}, and \tcode{memchr},
-have different signatures in this International Standard,
+have different signatures in this document,
 but they have the same behavior as in the C standard library~(\ref{library.c}).
 \end{note}
 
@@ -6053,7 +6053,7 @@ are the same as the C standard library header
 \begin{note}
 The functions
 \tcode{wcschr}, \tcode{wcspbrk}, \tcode{wcsrchr}, \tcode{wcsstr}, and \tcode{wmemchr}
-have different signatures in this International Standard,
+have different signatures in this document,
 but they have the same behavior as in the C standard library~(\ref{library.c}).
 \end{note}
 

--- a/source/support.tex
+++ b/source/support.tex
@@ -252,7 +252,7 @@ and except as noted in
 \ref{c.math.rand}, and
 \ref{c.math.abs}.
 \begin{note}
-Several functions have additional overloads in this International Standard,
+Several functions have additional overloads in this document,
 but they have the same behavior as in the C standard library~(\ref{library.c}).
 \end{note}
 
@@ -294,7 +294,7 @@ The macro
 has the same semantics as the corresponding macro in
 the C standard library header \tcode{<stddef.h>}, but
 accepts a restricted set of \tcode{\placeholder{type}}
-arguments in this International Standard.
+arguments in this document.
 Use of the \tcode{offsetof} macro with a \tcode{\placeholder{type}}
 other than a standard-layout class (Clause~\ref{class})
 is conditionally-supported.\footnote{Note that \tcode{offsetof}
@@ -1182,7 +1182,7 @@ integer multiple of \tcode{max() - min() + 1}.
 \pnum
 \begin{example}
 \tcode{is_modulo} is \tcode{false} for signed integer types~(\ref{basic.fundamental})
-unless an implementation, as an extension to this International Standard,
+unless an implementation, as an extension to this document,
 defines signed integer overflow to wrap.
 \end{example}
 
@@ -3772,7 +3772,7 @@ The restrictions that ISO C places on the second parameter to the
 macro in header
 \indexlibrary{\idxhdr{stdarg.h}}%
 \tcode{<stdarg.h>}
-are different in this International Standard.
+are different in this document.
 The parameter
 \tcode{parmN}
 is the rightmost parameter in the variable parameter list
@@ -3820,7 +3820,7 @@ standard library header \tcode{<setjmp.h>}.
 The function signature
 \indexlibrary{\idxcode{longjmp}}%
 \tcode{longjmp(jmp_buf jbuf, int val)}
-has more restricted behavior in this International Standard.
+has more restricted behavior in this document.
 A \tcode{setjmp}/\tcode{longjmp} call pair has undefined
 behavior if replacing the \tcode{setjmp} and \tcode{longjmp}
 by \tcode{catch} and \tcode{throw} would invoke any non-trivial destructors for any automatic

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -3214,7 +3214,7 @@ Otherwise, no diagnostic shall be issued for a template
 for which a valid specialization can be generated.
 \begin{note}
 If a template is instantiated, errors will be diagnosed according
-to the other rules in this International Standard.
+to the other rules in this document.
 Exactly when these errors are diagnosed is a quality of implementation issue.
 \end{note}
 \begin{example}

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -4882,7 +4882,7 @@ exploited. \end{note}
 
 \item
 If no value is set in the launch policy, or a value is set that is neither specified
-in this International Standard nor by the implementation, the behavior is undefined.
+in this document nor by the implementation, the behavior is undefined.
 \end{itemize}
 
 \pnum


### PR DESCRIPTION
referring to the document as a body of text.

Cases where that phrasing is used to compare this standard to other
revisions of the C++ standard retain this phrasing for clarity.

Fixes ISO 20 (C++17 DIS)