### PR TITLE
Add Foreword.

### DIFF
--- a/source/front.tex
+++ b/source/front.tex
@@ -18,3 +18,5 @@
 \listoftables
 \newpage
 \listoffigures
+
+\input{preface}

--- a/source/preface.tex
+++ b/source/preface.tex
@@ -1,0 +1,120 @@
+%!TEX root = std.tex
+\chapter{Foreword}
+
+ISO (the International Organization for Standardization)
+is a worldwide federation of national standards bodies (ISO member bodies).
+The work of preparing International Standards
+is normally carried out through ISO technical committees.
+Each member body interested in a subject
+for which a technical committee has been established
+has the right to be represented on that committee.
+International organizations,
+governmental and non-governmental,
+in liaison with ISO,
+also take part in the work.
+ISO collaborates closely with
+the International Electrotechnical Commission (IEC)
+on all matters of electrotechnical standardization.
+
+%ISO (the International Organization for Standardization) and IEC (the
+%International Electrotechnical Commission) form the specialized system for
+%worldwide standardization. National bodies that are members of ISO or IEC
+%participate in the development of International Standards through technical
+%committees established by the respective organization to deal with particular
+%fields of technical activity. ISO and IEC technical committees collaborate in
+%fields of mutual interest. Other international organizations, governmental and
+%non-governmental, in liaison with ISO and IEC, also take part in the work. In
+%the field of information technology, ISO and IEC have established a joint
+%technical committee, ISO/IEC JTC 1.
+
+The procedures used to develop this document and those intended for its further
+maintenance are described in the ISO/IEC Directives, Part 1. In particular the
+different approval criteria needed for the different types of ISO documents should
+be noted. This document was drafted in accordance with the editorial rules of
+the ISO/IEC Directives, Part 2
+(see \href{http://www.iso.org/directives}{\tcode{www.iso.org/directives}}).
+
+Attention is drawn to the possibility that some of the elements of this
+document may be the subject of patent rights. ISO shall not be held
+responsible for identifying any or all such patent rights. Details of any
+patent rights identified during the development of the document will be in the
+Introduction and/or on the ISO list of patent declarations received
+(see \href{http://www.iso.org/patents}{\tcode{www.iso.org/patents}}).
+
+Any trade name used in this document is information given for the convenience
+of users and does not constitute an endorsement.
+
+For an explanation on
+the voluntary nature of standards,
+the meaning of ISO specific terms and expressions related
+to conformity assessment, as well as information about ISO's adherence
+to the World Trade Organization (WTO) principles
+in the Technical Barriers to Trade (TBT) see the following URL:
+\href{http://www.iso.org/iso/foreword.html}{\tcode{www.iso.org/iso/foreword.html}}.
+
+This document was prepared by
+Technical Committee ISO/IEC JTC 1, \textit{Information technology},
+Subcommittee SC 22, \textit{Programming languages, their environments and system software interfaces}.
+
+This fifth edition cancels and replaces the fourth edition
+(ISO/IEC 14882:2014), which has been technically revised.
+
+The main changes compared to the previous edition are as follows:
+
+\begin{itemize}
+% language changes
+\item expression evaluation order is specified in more cases
+\item removal of trigraphs
+\item adjustments to value categories resulting in copy elision being mandatory
+\item additional character and floating point literal syntaxes
+\item lambda expressions extended to permit capture of \tcode{*this} and use in constant expressions
+\item initializer statements for \tcode{if} and \tcode{switch} statements
+\item addition of constexpr if statements
+\item range-based \tcode{for} statement generalized to support heterogeneous \tcode{begin} and \tcode{end} types
+\item addition of structured bindings
+\item addition of inline variables
+\item list initialization extended to support enumerations and aggregates with base classes
+\item message in \tcode{static_assert} is now optional
+\item addition of nested namespace definition syntax
+\item extended support for attributes
+\item exception specifications are now part of function types
+\item template argument deduction is now supported for class templates
+\item addition of fold expressions
+\item pack expansion can be performed on using declarations
+\item permitted forms of template parameters and template arguments have been generalized
+\item dynamic allocation is supported for over-aligned types
+\item preprocessor can detect presence of header files with \tcode{__has_include}
+% library changes
+\item new utility functions, types, and templates in the standard library, including
+\begin{itemize}
+  \item \tcode{clamp}
+  \item \tcode{invoke}
+  \item a \tcode{std::byte} type
+  \item \tcode{not_fn}
+  \item a \tcode{void_t} alias template
+  \item \tcode{conjunction}, \tcode{disjunction}, and \tcode{negation} templates
+  \item \tcode{is_invocable} and \tcode{invoke_result} type traits
+  \item \tcode{is_swappable} type trait
+\end{itemize}
+\item extended constant expression evaluation support in the standard library
+\item improved hashing support
+\item elementary conversion functions between strings and numeric types added
+\item constructors for \tcode{pair} and \tcode{tuple} are conditionally-explicit
+\item added single-element containers \tcode{any}, \tcode{optional}, and \tcode{variant}
+\item \tcode{shared_ptr}{s} of array types now supported
+\item additional algorithms for managing uninitialized memory
+\item addition of polymorphic memory resources
+\item addition of substring search facilities providing the Boyer-Moore and Boyer-Moore-Horspool search algorithms
+\item addition of variable templates for type traits
+\item addition of a non-owning string view template
+\item ability to splice elements between containers for maps and sets
+\item better support for element insertion in unique-key maps
+\item support for incomplete types in containers
+\item addition of parallel algorithms
+\item addition of \tcode{sample} algorithm
+\item addition of mathematical special functions, and \tcode{gcd}, \tcode{lcm}, and three-argument \tcode{hypot} functions
+\item addition of support for operations on file systems
+\item addition of shared mutexes and variadic lock guards
+% annexes
+\item removal of deprecated features
+\end{itemize}


### PR DESCRIPTION
Fixes ISO 16 (C++17 DIS)

The main wording was supplied by the TC secretariat; the list of changes has been reviewed by the relevant working group chairs for correctness.