### PR TITLE
support LuaLaTeX

### DIFF
--- a/source/std.tex
+++ b/source/std.tex
@@ -5,6 +5,15 @@
 %% basics
 \documentclass[a4paper,10pt,oneside,openany,final]{memoir}
 
+\usepackage{ifluatex}
+\ifluatex
+\RequirePackage{pdftexcmds}
+\makeatletter
+\let\pdfshellescape\pdf@shellescape
+\let\pdffilesize\pdf@filesize
+\makeatother
+\fi
+
 \usepackage[american]
            {babel}        % needed for iso dates
 \usepackage[iso,american]


### PR DESCRIPTION
`LuaLaTeX `does not know `\pdfshellescape` and `\pdffilesize`
Using `ifluatex`, `pdftexcmds` and some `\defs` fixes that.

(similar reasoning as the XeTeX PR #1637 but smaller implementation)