### PR TITLE
[dcl.fct.def.general] Typeset placeholder consistently.

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -2076,9 +2076,9 @@ storage duration that is implicitly defined (see~\ref{basic.scope.block}).
 The function-local predefined variable \tcode{__func__} is
 defined as if a definition of the form
 \begin{codeblock}
-static const char __func__[] = "@\grammarterm{function-name}@";
+static const char __func__[] = "@\placeholder{function-name}@";
 \end{codeblock}
-had been provided, where \grammarterm{function-name} is an \impldef{string resulting
+had been provided, where \tcode{\placeholder{function-name}} is an \impldef{string resulting
 from \mname{func}} string.
 It is unspecified whether such a variable has an address
 distinct from that of any other object in the program.\footnote{Implementations are


### PR DESCRIPTION
Also change \grammarterm to \placeholder, because function-name is not a grammar term.

Diff:

![diff](http://eel.is/functionname.png)