### PR TITLE
[mem.res.private] Remove misleading 'typical' in note.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -10980,8 +10980,8 @@ A derived class shall implement this function to return \tcode{true} if memory a
 otherwise \tcode{false}.
 \begin{note}
 The most-derived type of \tcode{other} might not match the type of \tcode{this}.
-For a derived class \tcode{D}, a typical implementation of this function
-will immediately return \tcode{false}
+For a derived class \tcode{D}, an implementation of this function
+could immediately return \tcode{false}
 if \tcode{dynamic_cast<const D*>(\&other) == nullptr}.\end{note}
 \end{itemdescr}
 


### PR DESCRIPTION
Fixes #1698.