### PR TITLE
[styles] Improve automatic page breaking

### DIFF
--- a/source/layout.tex
+++ b/source/layout.tex
@@ -19,6 +19,12 @@
 \checkandfixthelayout
 
 %%--------------------------------------------------
+%% If there is insufficient stretchable vertical space on a page,
+%% TeX will not properly consider penalties for a good page break,
+%% even if \raggedbottom (default) is in effect.
+\addtolength{\topskip}{0pt plus 20pt}
+
+%%--------------------------------------------------
 %% Paragraph and bullet numbering
 
 \newcounter{Paras}

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -348,7 +348,9 @@
 % italics.  Arbitrary TeX commands can be used if they're
 % surrounded by @ signs.
 \newcommand{\CodeBlockSetup}{
- \lstset{escapechar=@, aboveskip=\parskip, belowskip=0pt}
+ \lstset{escapechar=@, aboveskip=\parskip, belowskip=0pt,
+         midpenalty=500, endpenalty=-50,
+         emptylinepenalty=-250, semicolonpenalty=0}
  \renewcommand{\tcode}[1]{\textup{\CodeStylex{##1}}}
  \renewcommand{\techterm}[1]{\textit{\CodeStylex{##1}}}
  \renewcommand{\term}[1]{\textit{##1}}
@@ -381,6 +383,9 @@
 {
  \lstset{escapechar=@,
  xleftmargin=0em,
+ midpenalty=500,
+ semicolonpenalty=-50,
+ endpenalty=3000,
  aboveskip=2ex,
  belowskip=0ex	% leave this alone: it keeps these things out of the
 				% footnote area
@@ -391,7 +396,7 @@
 
 \newenvironment{itemdescr}
 {
- \begin{indented}}
+ \begin{indented}[beginpenalty=3000, endpenalty=-300]}
 {
  \end{indented}
 }

--- a/source/styles.tex
+++ b/source/styles.tex
@@ -149,3 +149,196 @@
 %% set section numbering limit, toc limit
 \maxsecnumdepth{subparagraph}
 \setcounter{tocdepth}{1}
+
+%%--------------------------------------------------
+%% override some functions from the listings package to avoid bad page breaks
+%% (copied verbatim from listings.sty version 1.6 except where commented)
+\makeatletter
+\def\lst@Init#1{%
+    \begingroup
+    \ifx\lst@float\relax\else
+        \edef\@tempa{\noexpand\lst@beginfloat{lstlisting}[\lst@float]}%
+        \expandafter\@tempa
+    \fi
+    \ifx\lst@multicols\@empty\else
+        \edef\lst@next{\noexpand\multicols{\lst@multicols}}
+        \expandafter\lst@next
+    \fi
+    \ifhmode\ifinner \lst@boxtrue \fi\fi
+    \lst@ifbox
+        \lsthk@BoxUnsafe
+        \hbox to\z@\bgroup
+             $\if t\lst@boxpos \vtop
+        \else \if b\lst@boxpos \vbox
+        \else \vcenter \fi\fi
+        \bgroup \par\noindent
+    \else
+        \lst@ifdisplaystyle
+            \lst@EveryDisplay
+            % make penalty configurable
+            \par\lst@beginpenalty
+            \vspace\lst@aboveskip
+        \fi
+    \fi
+    \normalbaselines
+    \abovecaptionskip\lst@abovecaption\relax
+    \belowcaptionskip\lst@belowcaption\relax
+    \lst@MakeCaption t%
+    \lsthk@PreInit \lsthk@Init
+    \lst@ifdisplaystyle
+        \global\let\lst@ltxlabel\@empty
+        \if@inlabel
+            \lst@ifresetmargins
+                \leavevmode
+            \else
+                \xdef\lst@ltxlabel{\the\everypar}%
+                \lst@AddTo\lst@ltxlabel{%
+                    \global\let\lst@ltxlabel\@empty
+                    \everypar{\lsthk@EveryLine\lsthk@EveryPar}}%
+            \fi
+        \fi
+        % A section heading might have set \everypar to apply a \clubpenalty
+        % to the following paragraph, changing \everypar in the process.
+        % Unconditionally overriding \everypar is a bad idea.
+        % \everypar\expandafter{\lst@ltxlabel
+        %                      \lsthk@EveryLine\lsthk@EveryPar}%
+    \else
+        \everypar{}\let\lst@NewLine\@empty
+    \fi
+    \lsthk@InitVars \lsthk@InitVarsBOL
+    \lst@Let{13}\lst@MProcessListing
+    \let\lst@Backslash#1%
+    \lst@EnterMode{\lst@Pmode}{\lst@SelectCharTable}%
+    \lst@InitFinalize}
+
+\def\lst@DeInit{%
+    \lst@XPrintToken \lst@EOLUpdate
+    \global\advance\lst@newlines\m@ne
+    \lst@ifshowlines
+        \lst@DoNewLines
+    \else
+        \setbox\@tempboxa\vbox{\lst@DoNewLines}%
+    \fi
+    \lst@ifdisplaystyle \par\removelastskip \fi
+    \lsthk@ExitVars\everypar{}\lsthk@DeInit\normalbaselines\normalcolor
+    \lst@MakeCaption b%
+    \lst@ifbox
+        \egroup $\hss \egroup
+        \vrule\@width\lst@maxwidth\@height\z@\@depth\z@
+    \else
+        \lst@ifdisplaystyle
+            % make penalty configurable
+            \par\lst@endpenalty
+            \vspace\lst@belowskip
+        \fi
+    \fi
+    \ifx\lst@multicols\@empty\else
+        \def\lst@next{\global\let\@checkend\@gobble
+                      \endmulticols
+                      \global\let\@checkend\lst@@checkend}
+        \expandafter\lst@next
+    \fi
+    \ifx\lst@float\relax\else
+        \expandafter\lst@endfloat
+    \fi
+    \endgroup}
+
+
+\def\lst@NewLine{%
+    \ifx\lst@OutputBox\@gobble\else
+        \par
+        % add configurable penalties
+        \lst@ifeolsemicolon
+          \lst@semicolonpenalty
+          \lst@eolsemicolonfalse
+        \else
+          \lst@domidpenalty
+        \fi
+        % Manually apply EveryLine and EveryPar; do not depend on \everypar
+        \noindent \hbox{}\lsthk@EveryLine%
+        % \lsthk@EveryPar uses \refstepcounter which balloons the PDF
+    \fi
+    \global\advance\lst@newlines\m@ne
+    \lst@newlinetrue}
+
+% new macro for empty lines, avoiding an \hbox that cannot be discarded
+\def\lst@DoEmptyLine{%
+  \ifvmode\else\par\fi\lst@emptylinepenalty
+  \vskip\parskip
+  \vskip\baselineskip
+  % \lsthk@EveryLine has \lst@parshape, i.e. \parshape, which causes an \hbox
+  % \lsthk@EveryPar increments line counters; \refstepcounter balloons the PDF
+  \global\advance\lst@newlines\m@ne
+  \lst@newlinetrue}
+
+\def\lst@DoNewLines{
+    \@whilenum\lst@newlines>\lst@maxempty \do
+        {\lst@ifpreservenumber
+            \lsthk@OnEmptyLine
+            \global\advance\c@lstnumber\lst@advancelstnum
+         \fi
+         \global\advance\lst@newlines\m@ne}%
+    \@whilenum \lst@newlines>\@ne \do
+        % special-case empty printing of lines
+        {\lsthk@OnEmptyLine\lst@DoEmptyLine}%
+    \ifnum\lst@newlines>\z@ \lst@NewLine \fi}
+
+% add keys for configuring before/end vertical penalties
+\lst@Key{beginpenalty}\relax{\def\lst@beginpenalty{\penalty #1}}
+\let\lst@beginpenalty\@empty
+\lst@Key{midpenalty}\relax{\def\lst@midpenalty{\penalty #1}}
+\let\lst@midpenalty\@empty
+\lst@Key{endpenalty}\relax{\def\lst@endpenalty{\penalty #1}}
+\let\lst@endpenalty\@empty
+\lst@Key{emptylinepenalty}\relax{\def\lst@emptylinepenalty{\penalty #1}}
+\let\lst@emptylinepenalty\@empty
+\lst@Key{semicolonpenalty}\relax{\def\lst@semicolonpenalty{\penalty #1}}
+\let\lst@semicolonpenalty\@empty
+
+\lst@AddToHook{InitVars}{\let\lst@domidpenalty\@empty}
+\lst@AddToHook{InitVarsEOL}{\let\lst@domidpenalty\lst@midpenalty}
+
+% handle semicolons and closing braces (could be in \lstdefinelanguage as well)
+\def\lst@eolsemicolontrue{\global\let\lst@ifeolsemicolon\iftrue}
+\def\lst@eolsemicolonfalse{\global\let\lst@ifeolsemicolon\iffalse}
+\lst@AddToHook{InitVars}{
+  \global\let\lst@eolsemicolonpending\@empty
+  \lst@eolsemicolonfalse
+}
+% If we found a semicolon or closing brace while parsing the current line,
+% inform the subsequent \lst@NewLine about it for penalties.
+\lst@AddToHook{InitVarsEOL}{%
+  \ifx\lst@eolsemicolonpending\relax
+    \lst@eolsemicolontrue
+    \global\let\lst@eolsemicolonpending\@empty
+  \fi%
+}
+\lst@AddToHook{SelectCharTable}{%
+  % In theory, we should only detect trailing semicolons or braces,
+  % but that would require un-doing the marking for any other character.
+  % The next best thing is to undo the marking for closing parentheses,
+  % because loops or if statements are the only places where we will
+  % reasonably have a semicolon in the middle of a line, and those all
+  % end with a closing parenthesis.
+  \lst@DefSaveDef{41}\lstsaved@closeparen{%    handle closing parenthesis
+    \lstsaved@closeparen
+    \ifnum\lst@mode=\lst@Pmode    % regular processing mode (not a comment)
+      \global\let\lst@eolsemicolonpending\@empty  % undo semicolon setting
+    \fi%
+  }%
+  \lst@DefSaveDef{59}\lstsaved@semicolon{%     handle semicolon
+    \lstsaved@semicolon
+    \ifnum\lst@mode=\lst@Pmode    % regular processing mode (not a comment)
+      \global\let\lst@eolsemicolonpending\relax
+    \fi%
+  }%
+  \lst@DefSaveDef{125}\lstsaved@closebrace{%   handle closing brace
+    \lst@eolsemicolonfalse        % do not break before a closing brace
+    \lstsaved@closebrace          % might invoke \lst@NewLine
+    \ifnum\lst@mode=\lst@Pmode    % regular processing mode (not a comment)
+      \global\let\lst@eolsemicolonpending\relax
+    \fi%
+  }%
+}
+
+\makeatother

--- a/source/styles.tex
+++ b/source/styles.tex
@@ -103,7 +103,8 @@
 \setlength{\partopsep}{0pt}
 \newlist{indenthelper}{itemize}{1}
 \newlist{bnflist}{itemize}{1}
-\setlist[itemize]{parsep=\parskip, partopsep=0pt, itemsep=0pt, topsep=0pt}
+\setlist[itemize]{parsep=\parskip, partopsep=0pt, itemsep=0pt, topsep=0pt,
+                  beginpenalty=10 }
 \setlist[enumerate]{parsep=\parskip, partopsep=0pt, itemsep=0pt, topsep=0pt}
 \setlist[indenthelper]{parsep=\parskip, partopsep=0pt, itemsep=0pt, topsep=0pt, label={}}
 \setlist[bnflist]{parsep=\parskip, partopsep=0pt, itemsep=0pt, topsep=0pt, label={},

--- a/source/styles.tex
+++ b/source/styles.tex
@@ -154,6 +154,15 @@
 %% override some functions from the listings package to avoid bad page breaks
 %% (copied verbatim from listings.sty version 1.6 except where commented)
 \makeatletter
+
+\lst@CheckVersion{1.6}{\lst@CheckVersion{1.5b}{
+ \typeout{^^J%
+ ***^^J%
+ *** This file requires listings.sty version 1.6.^^J%
+ *** You have version \lst@version; exiting ...^^J%
+ ***^^J}%
+ \batchmode \@@end}}
+
 \def\lst@Init#1{%
     \begingroup
     \ifx\lst@float\relax\else


### PR DESCRIPTION
Strongly discourage breaking between itemdecl and itemdescr.
Mildly discourage breaking before an itemized list.
Add stretchable vertical space between paragraphs and before listings.
Allow substantial whitespace at the end of a page.

Fixes #1752.