### PR TITLE
[class.virtual] Correct function names in example comments.

### DIFF
--- a/source/derived.tex
+++ b/source/derived.tex
@@ -767,10 +767,10 @@ void g() {
   bp->vf1();                    // calls \tcode{Derived::vf1()}
   bp->vf2();                    // calls \tcode{Base::vf2()}
   bp->f();                      // calls \tcode{Base::f()} (not virtual)
-  B*  p = bp->vf4();            // calls \tcode{Derived::pf()} and converts the
+  B*  p = bp->vf4();            // calls \tcode{Derived::vf4()} and converts the
                                 // result to \tcode{B*}
   Derived*  dp = &d;
-  D*  q = dp->vf4();            // calls \tcode{Derived::pf()} and does not
+  D*  q = dp->vf4();            // calls \tcode{Derived::vf4()} and does not
                                 // convert the result to \tcode{B*}
   dp->vf2();                    // ill-formed: argument mismatch
 }


### PR DESCRIPTION
Fixes #1740.