### PR TITLE
[unord.map.overview], [unord.multimap.overview] Use iter_val_t inst…

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -7698,7 +7698,7 @@ namespace std {
            class Allocator = allocator<iter_to_alloc_t<InputIterator>>>
     unordered_map(InputIterator, InputIterator, typename @\seebelow@::size_type = @\seebelow@,
                   Hash = Hash(), Pred = Pred(), Allocator = Allocator())
-      -> unordered_map<iter_key_t<InputIterator>, iter_value_t<InputIterator>, Hash, Pred,
+      -> unordered_map<iter_key_t<InputIterator>, iter_val_t<InputIterator>, Hash, Pred,
                        Allocator>;
 
   template<class Key, class T, class Hash = hash<Key>,
@@ -8235,7 +8235,7 @@ namespace std {
     unordered_multimap(InputIterator, InputIterator,
                        typename @\seebelow@::size_type = @\seebelow@,
                        Hash = Hash(), Pred = Pred(), Allocator = Allocator())
-      -> unordered_multimap<iter_key_t<InputIterator>, iter_value_t<InputIterator>, Hash, Pred,
+      -> unordered_multimap<iter_key_t<InputIterator>, iter_val_t<InputIterator>, Hash, Pred,
                             Allocator>;
 
   template<class Key, class T, class Hash = hash<Key>,


### PR DESCRIPTION
…ead of iter_value_t

Fixes #1769.