### PR TITLE
[utilities, depr] Replace "member typedef" with "nested type" 

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -2102,7 +2102,7 @@ with a base characteristic of \tcode{true_type}
 if \tcode{T} is a literal type\iref{basic.types}, and
 \tcode{false_type} otherwise.
 The partial specialization \tcode{result_of<Fn(ArgTypes...)>} is a
-\tcode{TransformationTrait} whose member typedef \tcode{type} is defined
+\tcode{TransformationTrait} whose nested type \tcode{type} is defined
 if and only if \tcode{invoke_result<Fn, ArgTypes...>::type} is defined.
 If \tcode{type} is defined, it names the same type as \tcode{invoke_result_t<Fn, ArgTypes...>}.
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16534,7 +16534,7 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
  The value of \textit{default-alignment} shall be the most
  stringent alignment requirement for any \Cpp object type whose size
  is no greater than \tcode{Len}\iref{basic.types}.
- The member typedef \tcode{type} shall be a POD type
+ The nested type \tcode{type} shall be a POD type
  suitable for use as uninitialized storage for any object whose size
  is at most \tcode{Len} and whose alignment is a divisor of \tcode{Align}.\br
  \requires{} \tcode{Len} shall not be zero. \tcode{Align} shall be equal to
@@ -16545,7 +16545,7 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
   class... Types>\br
   struct aligned_union;}
   &
-  The member typedef \tcode{type} shall be a POD type suitable for use as
+  The nested type \tcode{type} shall be a POD type suitable for use as
   uninitialized storage for any object whose type is listed in \tcode{Types};
   its size shall be at least \tcode{Len}. The static member \tcode{alignment_value}
   shall be an integral constant of type \tcode{size_t} whose value is the

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1928,7 +1928,7 @@ template <size_t I, class T> class tuple_element<I, const volatile T>;
 \pnum
 Let \tcode{\placeholder{TE}} denote \tcode{tuple_element_t<I, T>} of the \cv-unqualified type \tcode{T}. Then
 each of the three templates shall meet the \tcode{TransformationTrait}
-requirements\iref{meta.rqmts} with a member typedef \tcode{type} that names the following
+requirements\iref{meta.rqmts} with a nested type \tcode{type} that names the following
 type:
 
 \begin{itemize}
@@ -4630,7 +4630,7 @@ template <size_t I, class T> class variant_alternative<I, const volatile T>;
 Let \tcode{VA} denote \tcode{variant_alternative<I, T>} of the
 cv-unqualified type \tcode{T}. Then each of the three templates shall
 meet the \tcode{TransformationTrait} requirements\iref{meta.rqmts} with a
-member typedef \tcode{type} that names the following type:
+nested type \tcode{type} that names the following type:
 \begin{itemize}
 \item for the first specialization, \tcode{add_const_t<VA::type>},
 \item for the second specialization, \tcode{add_volatile_t<VA::type>}, and
@@ -16302,7 +16302,7 @@ Each of the templates in this subclause shall be a
 \indexlibrary{\idxcode{remove_const}}%
 \tcode{template <class T>\br
  struct remove_const;}                  &
- The member typedef \tcode{type} names
+ The nested type \tcode{type} names
  the same type as \tcode{T}
  except that any top-level const-qualifier has been removed.
  \begin{example} \tcode{remove_const_t<const volatile int>} evaluates
@@ -16312,7 +16312,7 @@ Each of the templates in this subclause shall be a
 \indexlibrary{\idxcode{remove_volatile}}%
 \tcode{template <class T>\br
  struct remove_volatile;}               &
- The member typedef \tcode{type} names
+ The nested type \tcode{type} names
  the same type as \tcode{T}
  except that any top-level volatile-qualifier has been removed.
  \begin{example} \tcode{remove_volatile_t<const volatile int>}
@@ -16323,7 +16323,7 @@ Each of the templates in this subclause shall be a
 \indexlibrary{\idxcode{remove_cv}}%
 \tcode{template <class T>\br
  struct remove_cv;}                 &
- The member typedef \tcode{type} shall be the same as \tcode{T}
+ The nested type \tcode{type} shall be the same as \tcode{T}
  except that any top-level cv-qualifier has been removed.
  \begin{example} \tcode{remove_cv_t<const volatile int>}
  evaluates to \tcode{int}, whereas \tcode{remove_cv_t<const volatile int*>}
@@ -16348,7 +16348,7 @@ Each of the templates in this subclause shall be a
 \indexlibrary{\idxcode{add_cv}}%
 \tcode{template <class T>\br
  struct add_cv;}                    &
- The member typedef \tcode{type} names
+ The nested type \tcode{type} names
  the same type as
  \tcode{add_const_t<add_volatile_t<T>{>}}.                               \\
 \end{libreqtab2a}
@@ -16368,14 +16368,14 @@ Each of the templates in this subclause shall be a
 \tcode{template <class T>\br
  struct remove_reference;}                  &
  If \tcode{T} has type ``reference to \tcode{T1}'' then the
- member typedef \tcode{type} names \tcode{T1};
+ nested type \tcode{type} names \tcode{T1};
  otherwise, \tcode{type} names \tcode{T}.\\ \rowsep
 
 \indexlibrary{\idxcode{add_lvalue_reference}}%
 \tcode{template <class T>\br
  struct add_lvalue_reference;}                     &
  If \tcode{T} names a referenceable type\iref{defns.referenceable} then
- the member typedef \tcode{type} names \tcode{T\&};
+ the nested type \tcode{type} names \tcode{T\&};
  otherwise, \tcode{type} names \tcode{T}.
  \begin{note}
  This rule reflects the semantics of reference collapsing\iref{dcl.ref}.
@@ -16385,7 +16385,7 @@ Each of the templates in this subclause shall be a
 \tcode{template <class T>}\br
  \tcode{struct add_rvalue_reference;}    &
  If \tcode{T} names a referenceable type then
- the member typedef \tcode{type} names \tcode{T\&\&};
+ the nested type \tcode{type} names \tcode{T\&\&};
  otherwise, \tcode{type} names \tcode{T}.
  \begin{note} This rule reflects the semantics of reference collapsing\iref{dcl.ref}.
  For example, when a type \tcode{T} names a type \tcode{T1\&}, the type
@@ -16407,7 +16407,7 @@ Each of the templates in this subclause shall be a
 \tcode{template <class T>}\br
  \tcode{struct make_signed;} &
  If \tcode{T} names a (possibly cv-qualified) signed integer
- type\iref{basic.fundamental} then the member typedef
+ type\iref{basic.fundamental} then the nested type
  \tcode{type} names the type \tcode{T}; otherwise,
  if \tcode{T} names a (possibly cv-qualified) unsigned integer
  type then \tcode{type} names the corresponding
@@ -16424,7 +16424,7 @@ Each of the templates in this subclause shall be a
 \tcode{template <class T>}\br
  \tcode{struct make_unsigned;} &
  If \tcode{T} names a (possibly cv-qualified) unsigned integer
- type\iref{basic.fundamental} then the member typedef
+ type\iref{basic.fundamental} then the nested type
  \tcode{type} names the type \tcode{T}; otherwise,
  if \tcode{T} names a (possibly cv-qualified) signed integer
  type then \tcode{type} names the corresponding
@@ -16452,7 +16452,7 @@ Each of the templates in this subclause shall be a
 \tcode{template <class T>\br
  struct remove_extent;}                 &
  If \tcode{T} names a type ``array of \tcode{U}'',
- the member typedef \tcode{type} shall
+ the nested type \tcode{type} shall
  be \tcode{U}, otherwise \tcode{T}.
  \begin{note} For multidimensional arrays, only the first array dimension is
  removed. For a type ``array of \tcode{const U}'', the resulting type is
@@ -16501,7 +16501,7 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
 \tcode{template <class T>\br
  struct remove_pointer;}                    &
  If \tcode{T} has type ``(possibly cv-qualified) pointer
- to \tcode{T1}'' then the member typedef \tcode{type}
+ to \tcode{T1}'' then the nested type \tcode{type}
  names \tcode{T1}; otherwise, it names \tcode{T}.\\ \rowsep
 
 \indexlibrary{\idxcode{add_pointer}}%
@@ -16509,7 +16509,7 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
  struct add_pointer;}                       &
  If \tcode{T} names a referenceable type\iref{defns.referenceable} or a
  \cv{}~\tcode{void} type then
- the member typedef \tcode{type} names the same type as
+ the nested type \tcode{type} names the same type as
  \tcode{remove_reference_t<T>*};
  otherwise, \tcode{type} names \tcode{T}.             \\
 \end{libreqtab2a}
@@ -16557,10 +16557,10 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
 \tcode{template <class T>\br struct decay;}
  &
  Let \tcode{U} be \tcode{remove_reference_t<T>}. If \tcode{is_array_v<U>} is
- \tcode{true}, the member typedef \tcode{type} shall equal
+ \tcode{true}, the nested type \tcode{type} shall equal
  \tcode{remove_extent_t<U>*}. If \tcode{is_function_v<U>} is \tcode{true},
- the member typedef \tcode{type} shall equal \tcode{add_pointer_t<U>}. Otherwise
- the member typedef \tcode{type} equals \tcode{remove_cv_t<U>}.
+ the nested type \tcode{type} shall equal \tcode{add_pointer_t<U>}. Otherwise
+ the nested type \tcode{type} equals \tcode{remove_cv_t<U>}.
  \begin{note} This behavior is similar to the lvalue-to-rvalue\iref{conv.lval},
  array-to-pointer\iref{conv.array}, and function-to-pointer\iref{conv.func}
  conversions applied when an lvalue expression is used as an rvalue, but also
@@ -16571,7 +16571,7 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
 \indexlibrary{\idxcode{enable_if}}%
 \tcode{template <bool B, class T = void>} \tcode{struct enable_if;}
  &
- If \tcode{B} is \tcode{true}, the member typedef \tcode{type}
+ If \tcode{B} is \tcode{true}, the nested type \tcode{type}
  shall equal \tcode{T}; otherwise, there shall be no member
  \tcode{type}. \\ \rowsep
 
@@ -16579,8 +16579,8 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
  \tcode{class F>}\br
  \tcode{struct conditional;}
  &
- If \tcode{B} is \tcode{true},  the member typedef \tcode{type} shall equal \tcode{T}.
- If \tcode{B} is \tcode{false}, the member typedef \tcode{type} shall equal \tcode{F}. \\ \rowsep
+ If \tcode{B} is \tcode{true},  the nested type \tcode{type} shall equal \tcode{T}.
+ If \tcode{B} is \tcode{false}, the nested type \tcode{type} shall equal \tcode{F}. \\ \rowsep
 
  \tcode{template <class... T>} \tcode{struct common_type;}
  &
@@ -16594,7 +16594,7 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
 \tcode{template <class T>}\br
  \tcode{struct underlying_type;}
  &
- The member typedef \tcode{type} names the underlying type
+ The nested type \tcode{type} names the underlying type
  of \tcode{T}.\br
  \requires{} \tcode{T} shall be a complete enumeration type\iref{dcl.enum} \\ \rowsep
 
@@ -16604,7 +16604,7 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
  &
  If the expression \tcode{\placeholdernc{INVOKE}(declval<Fn>(), declval<ArgTypes>()...)}
  is well-formed when treated as an unevaluated operand\iref{expr},
- the member typedef \tcode{type} names the type
+ the nested type \tcode{type} names the type
  \tcode{decltype(\placeholdernc{INVOKE}(declval<Fn>(), declval<ArgTypes>()...))};
  otherwise, there shall be no member \tcode{type}. Access checking is
  performed as if in a context unrelated to \tcode{Fn} and


### PR DESCRIPTION
[class.mem]/3:

> Nested types are classes (12.1, 12.2.5) and enumerations (10.2) declared in the class and arbitrary types declared as members by use of a typedef declaration (10.1.3) or _alias-declaration_.

In most cases there's no normative change because the member must name a pre-existing type.

`aligned_storage` and `aligned_union` are special-cased because their member `type` may name a new type. In particular, `aligned_storage::type` is defined as a nested class type in both libstdc++ and libc++.