### PR TITLE
[lib] Harmonize introductory comments in synopses

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -3157,7 +3157,7 @@ for operations where there is additional semantic information.
 namespace std {
   template <class T, size_t N>
   struct array {
-    //  types:
+    // types
     using value_type             = T;
     using pointer                = T*;
     using const_pointer          = const T*;
@@ -3175,7 +3175,7 @@ namespace std {
     void fill(const T& u);
     void swap(array&) noexcept(is_nothrow_swappable_v<T>);
 
-    // iterators:
+    // iterators
     constexpr iterator               begin() noexcept;
     constexpr const_iterator         begin() const noexcept;
     constexpr iterator               end() noexcept;
@@ -3191,12 +3191,12 @@ namespace std {
     constexpr const_reverse_iterator crbegin() const noexcept;
     constexpr const_reverse_iterator crend() const noexcept;
 
-    // capacity:
+    // capacity
     constexpr bool      empty() const noexcept;
     constexpr size_type size() const noexcept;
     constexpr size_type max_size() const noexcept;
 
-    // element access:
+    // element access
     constexpr reference       operator[](size_type n);
     constexpr const_reference operator[](size_type n) const;
     constexpr reference       at(size_type n);
@@ -3403,7 +3403,7 @@ namespace std {
   template <class T, class Allocator = allocator<T>>
   class deque {
   public:
-    // types:
+    // types
     using value_type             = T;
     using allocator_type         = Allocator;
     using pointer                = typename allocator_traits<Allocator>::pointer;
@@ -3441,7 +3441,7 @@ namespace std {
     void assign(initializer_list<T>);
     allocator_type get_allocator() const noexcept;
 
-    // iterators:
+    // iterators
     iterator               begin() noexcept;
     const_iterator         begin() const noexcept;
     iterator               end() noexcept;
@@ -3464,7 +3464,7 @@ namespace std {
     void      resize(size_type sz, const T& c);
     void      shrink_to_fit();
 
-    // element access:
+    // element access
     reference       operator[](size_type n);
     const_reference operator[](size_type n) const;
     reference       at(size_type n);
@@ -3785,7 +3785,7 @@ namespace std {
   template <class T, class Allocator = allocator<T>>
   class forward_list {
   public:
-    // types:
+    // types
     using value_type      = T;
     using allocator_type  = Allocator;
     using pointer         = typename allocator_traits<Allocator>::pointer;
@@ -3832,7 +3832,7 @@ namespace std {
     const_iterator cbefore_begin() const noexcept;
     const_iterator cend() const noexcept;
 
-    // capacity:
+    // capacity
     bool      empty() const noexcept;
     size_type max_size() const noexcept;
 
@@ -4479,7 +4479,7 @@ namespace std {
   template <class T, class Allocator = allocator<T>>
   class list {
   public:
-    // types:
+    // types
     using value_type             = T;
     using allocator_type         = Allocator;
     using pointer                = typename allocator_traits<Allocator>::pointer;
@@ -4516,7 +4516,7 @@ namespace std {
     void assign(initializer_list<T>);
     allocator_type get_allocator() const noexcept;
 
-    // iterators:
+    // iterators
     iterator               begin() noexcept;
     const_iterator         begin() const noexcept;
     iterator               end() noexcept;
@@ -4538,7 +4538,7 @@ namespace std {
     void      resize(size_type sz);
     void      resize(size_type sz, const T& c);
 
-    // element access:
+    // element access
     reference       front();
     const_reference front() const;
     reference       back();
@@ -5159,7 +5159,7 @@ namespace std {
   template <class T, class Allocator = allocator<T>>
   class vector {
   public:
-    // types:
+    // types
     using value_type             = T;
     using allocator_type         = Allocator;
     using pointer                = typename allocator_traits<Allocator>::pointer;
@@ -5197,7 +5197,7 @@ namespace std {
     void assign(initializer_list<T>);
     allocator_type get_allocator() const noexcept;
 
-    // iterators:
+    // iterators
     iterator               begin() noexcept;
     const_iterator         begin() const noexcept;
     iterator               end() noexcept;
@@ -5222,7 +5222,7 @@ namespace std {
     void      reserve(size_type n);
     void      shrink_to_fit();
 
-    // element access:
+    // element access
     reference       operator[](size_type n);
     const_reference operator[](size_type n) const;
     const_reference at(size_type n) const;
@@ -5630,7 +5630,7 @@ namespace std {
   template <class Allocator>
   class vector<bool, Allocator> {
   public:
-    // types:
+    // types
     using value_type             = bool;
     using allocator_type         = Allocator;
     using pointer                = @\impdef@;
@@ -5643,7 +5643,7 @@ namespace std {
     using reverse_iterator       = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
-    // bit reference:
+    // bit reference
     class reference {
       friend class vector;
       reference() noexcept;
@@ -5655,7 +5655,7 @@ namespace std {
       void flip() noexcept;     // flips the bit
     };
 
-    // construct/copy/destroy:
+    // construct/copy/destroy
     vector() : vector(Allocator()) { }
     explicit vector(const Allocator&);
     explicit vector(size_type n, const Allocator& = Allocator());
@@ -5677,7 +5677,7 @@ namespace std {
     void assign(initializer_list<bool>);
     allocator_type get_allocator() const noexcept;
 
-    // iterators:
+    // iterators
     iterator               begin() noexcept;
     const_iterator         begin() const noexcept;
     iterator               end() noexcept;
@@ -5692,7 +5692,7 @@ namespace std {
     const_reverse_iterator crbegin() const noexcept;
     const_reverse_iterator crend() const noexcept;
 
-    // capacity:
+    // capacity
     bool      empty() const noexcept;
     size_type size() const noexcept;
     size_type max_size() const noexcept;
@@ -5701,7 +5701,7 @@ namespace std {
     void      reserve(size_type n);
     void      shrink_to_fit();
 
-    // element access:
+    // element access
     reference       operator[](size_type n);
     const_reference operator[](size_type n) const;
     const_reference at(size_type n) const;
@@ -5711,7 +5711,7 @@ namespace std {
     reference       back();
     const_reference back() const;
 
-    // modifiers:
+    // modifiers
     template <class... Args> reference emplace_back(Args&&... args);
     void push_back(const bool& x);
     void pop_back();
@@ -6016,7 +6016,7 @@ namespace std {
             class Allocator = allocator<pair<const Key, T>>>
   class map {
   public:
-    // types:
+    // types
     using key_type               = Key;
     using mapped_type            = T;
     using value_type             = pair<const Key, T>;
@@ -6073,7 +6073,7 @@ namespace std {
     map& operator=(initializer_list<value_type>);
     allocator_type get_allocator() const noexcept;
 
-    // iterators:
+    // iterators
     iterator               begin() noexcept;
     const_iterator         begin() const noexcept;
     iterator               end() noexcept;
@@ -6089,7 +6089,7 @@ namespace std {
     const_reverse_iterator crbegin() const noexcept;
     const_reverse_iterator crend() const noexcept;
 
-    // capacity:
+    // capacity
     bool      empty() const noexcept;
     size_type size() const noexcept;
     size_type max_size() const noexcept;
@@ -6154,11 +6154,11 @@ namespace std {
     template<class C2>
       void merge(multimap<Key, T, C2, Allocator>&& source);
 
-    // observers:
+    // observers
     key_compare key_comp() const;
     value_compare value_comp() const;
 
-    // map operations:
+    // map operations
     iterator       find(const key_type& x);
     const_iterator find(const key_type& x) const;
     template <class K> iterator       find(const K& x);
@@ -6548,7 +6548,7 @@ namespace std {
             class Allocator = allocator<pair<const Key, T>>>
   class multimap {
   public:
-    // types:
+    // types
     using key_type               = Key;
     using mapped_type            = T;
     using value_type             = pair<const Key, T>;
@@ -6605,7 +6605,7 @@ namespace std {
     multimap& operator=(initializer_list<value_type>);
     allocator_type get_allocator() const noexcept;
 
-    // iterators:
+    // iterators
     iterator               begin() noexcept;
     const_iterator         begin() const noexcept;
     iterator               end() noexcept;
@@ -6621,7 +6621,7 @@ namespace std {
     const_reverse_iterator crbegin() const noexcept;
     const_reverse_iterator crend() const noexcept;
 
-    // capacity:
+    // capacity
     bool      empty() const noexcept;
     size_type size() const noexcept;
     size_type max_size() const noexcept;
@@ -6662,11 +6662,11 @@ namespace std {
     template<class C2>
       void merge(map<Key, T, C2, Allocator>&& source);
 
-    // observers:
+    // observers
     key_compare key_comp() const;
     value_compare value_comp() const;
 
-    // map operations:
+    // map operations
     iterator       find(const key_type& x);
     const_iterator find(const key_type& x) const;
     template <class K> iterator       find(const K& x);
@@ -6856,7 +6856,7 @@ namespace std {
             class Allocator = allocator<Key>>
   class set {
   public:
-    // types:
+    // types
     using key_type               = Key;
     using key_compare            = Compare;
     using value_type             = Key;
@@ -6901,7 +6901,7 @@ namespace std {
     set& operator=(initializer_list<value_type>);
     allocator_type get_allocator() const noexcept;
 
-    // iterators:
+    // iterators
     iterator               begin() noexcept;
     const_iterator         begin() const noexcept;
     iterator               end() noexcept;
@@ -6917,12 +6917,12 @@ namespace std {
     const_reverse_iterator crbegin() const noexcept;
     const_reverse_iterator crend() const noexcept;
 
-    // capacity:
+    // capacity
     bool      empty() const noexcept;
     size_type size() const noexcept;
     size_type max_size() const noexcept;
 
-    // modifiers:
+    // modifiers
     template <class... Args> pair<iterator, bool> emplace(Args&&... args);
     template <class... Args> iterator emplace_hint(const_iterator position, Args&&... args);
     pair<iterator,bool> insert(const value_type& x);
@@ -6956,11 +6956,11 @@ namespace std {
     template<class C2>
       void merge(multiset<Key, C2, Allocator>&& source);
 
-    // observers:
+    // observers
     key_compare key_comp() const;
     value_compare value_comp() const;
 
-    // set operations:
+    // set operations
     iterator       find(const key_type& x);
     const_iterator find(const key_type& x) const;
     template <class K> iterator       find(const K& x);
@@ -7124,7 +7124,7 @@ namespace std {
             class Allocator = allocator<Key>>
   class multiset {
   public:
-    // types:
+    // types
     using key_type               = Key;
     using key_compare            = Compare;
     using value_type             = Key;
@@ -7168,7 +7168,7 @@ namespace std {
     multiset& operator=(initializer_list<value_type>);
     allocator_type get_allocator() const noexcept;
 
-    // iterators:
+    // iterators
     iterator               begin() noexcept;
     const_iterator         begin() const noexcept;
     iterator               end() noexcept;
@@ -7184,12 +7184,12 @@ namespace std {
     const_reverse_iterator crbegin() const noexcept;
     const_reverse_iterator crend() const noexcept;
 
-    // capacity:
+    // capacity
     bool      empty() const noexcept;
     size_type size() const noexcept;
     size_type max_size() const noexcept;
 
-    // modifiers:
+    // modifiers
     template <class... Args> iterator emplace(Args&&... args);
     template <class... Args> iterator emplace_hint(const_iterator position, Args&&... args);
     iterator insert(const value_type& x);
@@ -7223,11 +7223,11 @@ namespace std {
     template<class C2>
       void merge(set<Key, C2, Allocator>&& source);
 
-    // observers:
+    // observers
     key_compare key_comp() const;
     value_compare value_comp() const;
 
-    // set operations:
+    // set operations
     iterator       find(const key_type& x);
     const_iterator find(const key_type& x) const;
     template <class K> iterator       find(const K& x);
@@ -7521,7 +7521,7 @@ namespace std {
             class Allocator = allocator<pair<const Key, T>>>
   class unordered_map {
   public:
-    // types:
+    // types
     using key_type             = Key;
     using mapped_type          = T;
     using value_type           = pair<const Key, T>;
@@ -7589,7 +7589,7 @@ namespace std {
     unordered_map& operator=(initializer_list<value_type>);
     allocator_type get_allocator() const noexcept;
 
-    // iterators:
+    // iterators
     iterator       begin() noexcept;
     const_iterator begin() const noexcept;
     iterator       end() noexcept;
@@ -7597,7 +7597,7 @@ namespace std {
     const_iterator cbegin() const noexcept;
     const_iterator cend() const noexcept;
 
-    // capacity:
+    // capacity
     bool      empty() const noexcept;
     size_type size() const noexcept;
     size_type max_size() const noexcept;
@@ -7655,11 +7655,11 @@ namespace std {
     template<class H2, class P2>
       void merge(unordered_multimap<Key, T, H2, P2, Allocator>&& source);
 
-    // observers:
+    // observers
     hasher hash_function() const;
     key_equal key_eq() const;
 
-    // map operations:
+    // map operations
     iterator       find(const key_type& k);
     const_iterator find(const key_type& k) const;
     size_type      count(const key_type& k) const;
@@ -7672,7 +7672,7 @@ namespace std {
     mapped_type& at(const key_type& k);
     const mapped_type& at(const key_type& k) const;
 
-    // bucket interface:
+    // bucket interface
     size_type bucket_count() const noexcept;
     size_type max_bucket_count() const noexcept;
     size_type bucket_size(size_type n) const;
@@ -7684,7 +7684,7 @@ namespace std {
     const_local_iterator cbegin(size_type n) const;
     const_local_iterator cend(size_type n) const;
 
-    // hash policy:
+    // hash policy
     float load_factor() const noexcept;
     float max_load_factor() const noexcept;
     void max_load_factor(float z);
@@ -8081,7 +8081,7 @@ namespace std {
             class Allocator = allocator<pair<const Key, T>>>
   class unordered_multimap {
   public:
-    // types:
+    // types
     using key_type             = Key;
     using mapped_type          = T;
     using value_type           = pair<const Key, T>;
@@ -8148,7 +8148,7 @@ namespace std {
     unordered_multimap& operator=(initializer_list<value_type>);
     allocator_type get_allocator() const noexcept;
 
-    // iterators:
+    // iterators
     iterator       begin() noexcept;
     const_iterator begin() const noexcept;
     iterator       end() noexcept;
@@ -8156,7 +8156,7 @@ namespace std {
     const_iterator cbegin() const noexcept;
     const_iterator cend() const noexcept;
 
-    // capacity:
+    // capacity
     bool      empty() const noexcept;
     size_type size() const noexcept;
     size_type max_size() const noexcept;
@@ -8197,18 +8197,18 @@ namespace std {
     template<class H2, class P2>
       void merge(unordered_map<Key, T, H2, P2, Allocator>&& source);
 
-    // observers:
+    // observers
     hasher hash_function() const;
     key_equal key_eq() const;
 
-    // map operations:
+    // map operations
     iterator       find(const key_type& k);
     const_iterator find(const key_type& k) const;
     size_type      count(const key_type& k) const;
     pair<iterator, iterator>             equal_range(const key_type& k);
     pair<const_iterator, const_iterator> equal_range(const key_type& k) const;
 
-    // bucket interface:
+    // bucket interface
     size_type bucket_count() const noexcept;
     size_type max_bucket_count() const noexcept;
     size_type bucket_size(size_type n) const;
@@ -8424,7 +8424,7 @@ namespace std {
             class Allocator = allocator<Key>>
   class unordered_set {
   public:
-    // types:
+    // types
     using key_type             = Key;
     using value_type           = Key;
     using hasher               = Hash;
@@ -8491,7 +8491,7 @@ namespace std {
     unordered_set& operator=(initializer_list<value_type>);
     allocator_type get_allocator() const noexcept;
 
-    // iterators:
+    // iterators
     iterator       begin() noexcept;
     const_iterator begin() const noexcept;
     iterator       end() noexcept;
@@ -8499,12 +8499,12 @@ namespace std {
     const_iterator cbegin() const noexcept;
     const_iterator cend() const noexcept;
 
-    // capacity:
+    // capacity
     bool      empty() const noexcept;
     size_type size() const noexcept;
     size_type max_size() const noexcept;
 
-    // modifiers:
+    // modifiers
     template <class... Args> pair<iterator, bool> emplace(Args&&... args);
     template <class... Args> iterator emplace_hint(const_iterator position, Args&&... args);
     pair<iterator, bool> insert(const value_type& obj);
@@ -8538,18 +8538,18 @@ namespace std {
     template<class H2, class P2>
       void merge(unordered_multiset<Key, H2, P2, Allocator>&& source);
 
-    // observers:
+    // observers
     hasher hash_function() const;
     key_equal key_eq() const;
 
-    // set operations:
+    // set operations
     iterator       find(const key_type& k);
     const_iterator find(const key_type& k) const;
     size_type      count(const key_type& k) const;
     pair<iterator, iterator>             equal_range(const key_type& k);
     pair<const_iterator, const_iterator> equal_range(const key_type& k) const;
 
-    // bucket interface:
+    // bucket interface
     size_type bucket_count() const noexcept;
     size_type max_bucket_count() const noexcept;
     size_type bucket_size(size_type n) const;
@@ -8561,7 +8561,7 @@ namespace std {
     const_local_iterator cbegin(size_type n) const;
     const_local_iterator cend(size_type n) const;
 
-    // hash policy:
+    // hash policy
     float load_factor() const noexcept;
     float max_load_factor() const noexcept;
     void max_load_factor(float z);
@@ -8727,7 +8727,7 @@ namespace std {
             class Allocator = allocator<Key>>
   class unordered_multiset {
   public:
-    // types:
+    // types
     using key_type             = Key;
     using value_type           = Key;
     using hasher               = Hash;
@@ -8793,7 +8793,7 @@ namespace std {
     unordered_multiset& operator=(initializer_list<value_type>);
     allocator_type get_allocator() const noexcept;
 
-    // iterators:
+    // iterators
     iterator       begin() noexcept;
     const_iterator begin() const noexcept;
     iterator       end() noexcept;
@@ -8801,12 +8801,12 @@ namespace std {
     const_iterator cbegin() const noexcept;
     const_iterator cend() const noexcept;
 
-    // capacity:
+    // capacity
     bool      empty() const noexcept;
     size_type size() const noexcept;
     size_type max_size() const noexcept;
 
-    // modifiers:
+    // modifiers
     template <class... Args> iterator emplace(Args&&... args);
     template <class... Args> iterator emplace_hint(const_iterator position, Args&&... args);
     iterator insert(const value_type& obj);
@@ -8840,18 +8840,18 @@ namespace std {
     template<class H2, class P2>
       void merge(unordered_set<Key, H2, P2, Allocator>&& source);
 
-    // observers:
+    // observers
     hasher hash_function() const;
     key_equal key_eq() const;
 
-    // set operations:
+    // set operations
     iterator       find(const key_type& k);
     const_iterator find(const key_type& k) const;
     size_type      count(const key_type& k) const;
     pair<iterator, iterator>             equal_range(const key_type& k);
     pair<const_iterator, const_iterator> equal_range(const key_type& k) const;
 
-    // bucket interface:
+    // bucket interface
     size_type bucket_count() const noexcept;
     size_type max_bucket_count() const noexcept;
     size_type bucket_size(size_type n) const;
@@ -8863,7 +8863,7 @@ namespace std {
     const_local_iterator cbegin(size_type n) const;
     const_local_iterator cend(size_type n) const;
 
-    // hash policy:
+    // hash policy
     float load_factor() const noexcept;
     float max_load_factor() const noexcept;
     void max_load_factor(float z);

--- a/source/future.tex
+++ b/source/future.tex
@@ -1106,7 +1106,7 @@ namespace std {
   class strstream
     : public basic_iostream<char> {
   public:
-    // Types
+    // types
     using char_type = char;
     using int_type  = char_traits<char>::int_type;
     using pos_type  = char_traits<char>::pos_type;
@@ -1118,7 +1118,7 @@ namespace std {
               ios_base::openmode mode = ios_base::in|ios_base::out);
     virtual ~strstream();
 
-    // Members:
+    // members
     strstreambuf* rdbuf() const;
     void freeze(bool freezefl = true);
     int pcount() const;
@@ -1753,7 +1753,7 @@ addition to those specified in \ref{default.allocator}:
 \indexlibrary{\idxcode{allocator}}%
 \begin{codeblock}
 namespace std {
-  // specialize for \tcode{void}:
+  // specialization for \tcode{void}
   template <> class allocator<void> {
   public:
     using value_type    = void;

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -809,10 +809,10 @@ namespace std {
     long&  iword(int index);
     void*& pword(int index);
 
-    // destructor:
+    // destructor
     virtual ~ios_base();
 
-    // \ref{ios.base.callback}, callbacks;
+    // \ref{ios.base.callback}, callbacks
     enum event { erase_event, imbue_event, copyfmt_event };
     using event_callback = void (*)(event, ios_base&, int index);
     void register_callback(event_callback fn, int index);
@@ -2932,7 +2932,7 @@ namespace std {
                           = ios_base::in | ios_base::out);
     int      pubsync();
 
-    // Get and put areas
+    // get and put areas
     // \ref{streambuf.pub.get}, get area
     streamsize in_avail();
     int_type snextc();
@@ -4145,7 +4145,7 @@ namespace std {
   template <class charT, class traits = char_traits<charT>>
   class basic_istream : virtual public basic_ios<charT, traits> {
   public:
-    // types (inherited from \tcode{basic_ios}\iref{ios}):
+    // types (inherited from \tcode{basic_ios}\iref{ios})
     using char_type   = charT;
     using int_type    = typename traits::int_type;
     using pos_type    = typename traits::pos_type;
@@ -5705,7 +5705,7 @@ namespace std {
   template <class charT, class traits = char_traits<charT>>
   class basic_ostream : virtual public basic_ios<charT, traits> {
   public:
-    // types (inherited from \tcode{basic_ios}\iref{ios}):
+    // types (inherited from \tcode{basic_ios}\iref{ios})
     using char_type   = charT;
     using int_type    = typename traits::int_type;
     using pos_type    = typename traits::pos_type;
@@ -12588,7 +12588,7 @@ namespace std::filesystem {
     file_status(file_status&&) noexcept = default;
     ~file_status();
 
-    // assignments:
+    // assignments
     file_status& operator=(const file_status&) noexcept = default;
     file_status& operator=(file_status&&) noexcept = default;
 
@@ -12679,7 +12679,7 @@ namespace std::filesystem {
     directory_entry(const path& p, error_code& ec);
     ~directory_entry();
 
-    // assignments:
+    // assignments
     directory_entry& operator=(const directory_entry&) = default;
     directory_entry& operator=(directory_entry&&) noexcept = default;
 

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -122,7 +122,7 @@ is an incomplete type that is defined in
 namespace std {
   class locale {
   public:
-    // types:
+    // types
     class facet;
     class id;
     using category = int;
@@ -133,7 +133,7 @@ namespace std {
       time     = 0x100, messages = 0x200,
       all = collate | ctype | monetary | numeric | time  | messages;
 
-    // construct/copy/destroy:
+    // construct/copy/destroy
     locale() noexcept;
     locale(const locale& other) noexcept;
     explicit locale(const char* std_name);
@@ -146,7 +146,7 @@ namespace std {
     const locale& operator=(const locale& other) noexcept;
     template <class Facet> locale combine(const locale& other) const;
 
-    // locale operations:
+    // locale operations
     basic_string<char> name() const;
 
     bool operator==(const locale& other) const;
@@ -156,7 +156,7 @@ namespace std {
       bool operator()(const basic_string<charT, traits, Allocator>& s1,
                       const basic_string<charT, traits, Allocator>& s2) const;
 
-    // global locale objects:
+    // global locale objects
     static       locale  global(const locale&);
     static const locale& classic();
   };

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -10435,7 +10435,7 @@ namespace std {
   long double  sph_legendrel(unsigned l, unsigned m, long double theta);
 
   // \ref{sf.cmath.sph_neumann}, spherical Neumann functions;
-  // spherical Bessel functions of the second kind:
+  // spherical Bessel functions of the second kind
   double       sph_neumann(unsigned n, double x);
   float        sph_neumannf(unsigned n, float x);
   long double  sph_neumannl(unsigned n, long double x);

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -1329,7 +1329,7 @@ namespace std {
   template <class charT, class traits = regex_traits<charT>>
     class basic_regex {
     public:
-      // types:
+      // types
       using value_type  =          charT;
       using traits_type =          traits;
       using string_type = typename traits::string_type;

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -878,7 +878,7 @@ namespace std {
            class Allocator = allocator<charT>>
   class basic_string {
   public:
-    // types:
+    // types
     using traits_type            = traits;
     using value_type             = charT;
     using allocator_type         = Allocator;

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -331,11 +331,11 @@ default construction, after being moved from, or after a successful call to \tco
 namespace std {
   class thread {
   public:
-    // types:
+    // types
     class id;
     using native_handle_type = @\impdefnc@;         // see~\ref{thread.req.native}
 
-    // construct/copy/destroy:
+    // construct/copy/destroy
     thread() noexcept;
     template <class F, class... Args> explicit thread(F&& f, Args&&... args);
     ~thread();
@@ -344,7 +344,7 @@ namespace std {
     thread& operator=(const thread&) = delete;
     thread& operator=(thread&&) noexcept;
 
-    // members:
+    // members
     void swap(thread&) noexcept;
     bool joinable() const noexcept;
     void join();
@@ -352,7 +352,7 @@ namespace std {
     id get_id() const noexcept;
     native_handle_type native_handle();                         // see~\ref{thread.req.native}
 
-    // static members:
+    // static members
     static unsigned int hardware_concurrency() noexcept;
   };
 }
@@ -380,7 +380,7 @@ namespace std {
     basic_ostream<charT, traits>&
       operator<<(basic_ostream<charT, traits>& out, thread::id id);
 
-  // Hash support
+  // hash support
   template <class T> struct hash;
   template <> struct hash<thread::id>;
 }
@@ -1443,12 +1443,12 @@ namespace std {
     shared_mutex(const shared_mutex&) = delete;
     shared_mutex& operator=(const shared_mutex&) = delete;
 
-    // Exclusive ownership
+    // exclusive ownership
     void lock();                // blocking
     bool try_lock();
     void unlock();
 
-    // Shared ownership
+    // shared ownership
     void lock_shared();         // blocking
     bool try_lock_shared();
     void unlock_shared();
@@ -1578,7 +1578,7 @@ namespace std {
     shared_timed_mutex(const shared_timed_mutex&) = delete;
     shared_timed_mutex& operator=(const shared_timed_mutex&) = delete;
 
-    // Exclusive ownership
+    // exclusive ownership
     void lock();                // blocking
     bool try_lock();
     template <class Rep, class Period>
@@ -1587,7 +1587,7 @@ namespace std {
       bool try_lock_until(const chrono::time_point<Clock, Duration>& abs_time);
     void unlock();
 
-    // Shared ownership
+    // shared ownership
     void lock_shared();         // blocking
     bool try_lock_shared();
     template <class Rep, class Period>

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -5701,7 +5701,7 @@ and manipulating fixed-size sequences of bits.
 namespace std {
   template<size_t N> class bitset {
   public:
-    // bit reference:
+    // bit reference
     class reference {
       friend class bitset;
       reference() noexcept;
@@ -5747,7 +5747,7 @@ namespace std {
     bitset<N>& flip() noexcept;
     bitset<N>& flip(size_t pos);
 
-    // element access:
+    // element access
     constexpr bool operator[](size_t pos) const;        // for \tcode{b[i];}
     reference operator[](size_t pos);                   // for \tcode{b[i];}
 
@@ -18658,7 +18658,7 @@ namespace std::chrono {
 
     static time_point now() noexcept;
 
-    // Map to C API
+    // map to C API
     static time_t      to_time_t  (const time_point& t) noexcept;
     static time_point  from_time_t(time_t t) noexcept;
   };


### PR DESCRIPTION
Even if no section reference is given, make them lowercase
and remove trailing colons.

Fixes #1709.