### PR TITLE
[csetjmp.syn] Restrictions cannot be mandatory

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -3821,10 +3821,12 @@ The function signature
 \indexlibrary{\idxcode{longjmp}}%
 \tcode{longjmp(jmp_buf jbuf, int val)}
 has more restricted behavior in this document.
+\begin{note}
 A \tcode{setjmp}/\tcode{longjmp} call pair has undefined
 behavior if replacing the \tcode{setjmp} and \tcode{longjmp}
 by \tcode{catch} and \tcode{throw} would invoke any non-trivial destructors for any automatic
 objects.
+\end{note}
 
 \xref ISO C 7.13
 


### PR DESCRIPTION
The explanation is imprecise, but it seems to be unhelpful anyway.