### PR TITLE
[expr.prim.lambda.capture] Move discusssion of capture-by-reference o…

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1310,14 +1310,6 @@ If \tcode{*this} is captured by copy, each odr-use of \tcode{this} is
 transformed into a pointer to the corresponding unnamed data member of the closure type,
 cast\iref{expr.cast} to the type of \tcode{this}. \begin{note} The cast ensures that the
 transformed expression is a prvalue. \end{note}
-An \grammarterm{id-expression} within
-the \grammarterm{compound-statement} of a \grammarterm{lambda-expression}
-that is an odr-use of a reference captured by reference
-refers to the entity to which the captured reference is bound and
-not to the captured reference.
-\begin{note} The validity of such captures is determined by
-the lifetime of the object to which the reference refers,
-not by the lifetime of the reference itself. \end{note}
 \begin{example}
 \begin{codeblock}
 void f(const int*);
@@ -1327,12 +1319,6 @@ void g() {
     int arr[N];     // OK: not an odr-use, refers to automatic variable
     f(&N);          // OK: causes \tcode{N} to be captured; \tcode{\&N} points to
                     // the corresponding member of the closure type
-  };
-}
-auto h(int &r) {
-  return [&] {
-    ++r;            // Valid after \tcode{h} returns if the lifetime of the
-                    // object to which \tcode{r} is bound has not ended
   };
 }
 \end{codeblock}
@@ -1351,6 +1337,26 @@ static_assert([](int n) { return [&n] { return ++n; }(); }(3) == 4);
 \end{codeblock}
 \end{example}
 A bit-field or a member of an anonymous union shall not be captured by reference.
+
+\pnum
+An \grammarterm{id-expression} within
+the \grammarterm{compound-statement} of a \grammarterm{lambda-expression}
+that is an odr-use of a reference captured by reference
+refers to the entity to which the captured reference is bound and
+not to the captured reference.
+\begin{note} The validity of such captures is determined by
+the lifetime of the object to which the reference refers,
+not by the lifetime of the reference itself. \end{note}
+\begin{example}
+\begin{codeblock}
+auto h(int &r) {
+  return [&] {
+    ++r;            // Valid after \tcode{h} returns if the lifetime of the
+                    // object to which \tcode{r} is bound has not ended
+  };
+}
+\end{codeblock}
+\end{example}
 
 \pnum
 If a \grammarterm{lambda-expression} \tcode{m2} captures an entity and that entity is


### PR DESCRIPTION
…f references

to after the introduction of 'capture by reference'.

Fixes #1785.