### PR TITLE
Use 'trailing requires-clause'

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -1472,7 +1472,7 @@ The return type, the parameter-type-list, the \grammarterm{ref-qualifier},
 the \grammarterm{cv-qualifier-seq}, and
 the exception specification,
 but not the default arguments\iref{dcl.fct.default}
-or \grammarterm{requires-clause}{s}\iref{temp},
+or the trailing \grammarterm{requires-clause}\iref{dcl.decl},
 are part of the function type.
 \begin{note}
 Function types are checked during the assignments and initializations of

--- a/source/derived.tex
+++ b/source/derived.tex
@@ -687,7 +687,7 @@ struct D : B {
 \end{example}
 
 \pnum
-A virtual function shall not have a \grammarterm{requires-clause}.
+A virtual function shall not have a trailing \grammarterm{requires-clause}\iref{dcl.decl}.
 \begin{example}
 \begin{codeblock}
 struct A {

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -508,7 +508,7 @@ during the the partial ordering of constraints\iref{temp.constr.order}.
 \pnum
 A program that refers
 explicitly or implicitly
-to a function with a \grammarterm{requires-clause}
+to a function with a trailing \grammarterm{requires-clause}
 whose \grammarterm{constraint-expression} is not satisfied,
 other than to declare it,
 is ill-formed.

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -219,7 +219,7 @@ name,
 parameter type list\iref{dcl.fct},
 enclosing namespace (if any),
 and
-\grammarterm{requires-clause}\iref{temp.constr.decl} (if any)
+trailing \grammarterm{requires-clause}\iref{dcl.decl} (if any)
 
 \begin{defnote}
 Signatures are used as a basis for
@@ -235,7 +235,7 @@ enclosing namespace (if any),
 return type,
 \grammarterm{template-head},
 and
-\grammarterm{requires-clause}\iref{temp.constr.decl} (if any)
+trailing \grammarterm{requires-clause}\iref{dcl.decl} (if any)
 
 \indexdefn{signature}%
 \definition{signature}{defns.signature.spec}
@@ -251,7 +251,7 @@ class of which the function is a member,
 \cv-qualifiers (if any),
 \grammarterm{ref-qualifier} (if any),
 and
-\grammarterm{requires-clause}\iref{temp.constr.decl} (if any)
+trailing \grammarterm{requires-clause}\iref{dcl.decl} (if any)
 
 \indexdefn{signature}%
 \definition{signature}{defns.signature.member.templ}
@@ -264,7 +264,7 @@ class of which the function is a member,
 return type (if any),
 \grammarterm{template-head},
 and
-\grammarterm{requires-clause}\iref{temp.constr.decl} (if any)
+trailing \grammarterm{requires-clause}\iref{dcl.decl} (if any)
 
 \indexdefn{signature}%
 \definition{signature}{defns.signature.member.spec}

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -309,7 +309,7 @@ void prog () {
 \pnum
 Two function declarations of the same name refer to the same function if they
 are in the same scope and have equivalent parameter declarations\iref{over.load}
-and equivalent \grammarterm{requires-clause}{s}, if any\iref{temp.constr.decl}.
+and equivalent trailing \grammarterm{requires-clause}{s}, if any\iref{dcl.decl}.
 A function member of a derived class is
 \textit{not}
 in the same scope as a function member of the same name in a base class.


### PR DESCRIPTION
where the requires-clause in a template-head is not meant.

Fixes #1672.