### PR TITLE
[algorithms.general] & [algorithm.syn] name "mutating sequence operat…

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -10,7 +10,7 @@ algorithmic operations on containers\iref{containers} and other sequences.
 \pnum
 The following subclauses describe components for
 non-modifying sequence operations,
-modifying sequence operations,
+mutating sequence operations,
 sorting and related operations,
 and algorithms from the ISO C library,
 as summarized in Table~\ref{tab:algorithms.summary}.
@@ -304,7 +304,7 @@ namespace std {
     ForwardIterator search(ForwardIterator first, ForwardIterator last,
                            const Searcher& searcher);
 
-  // \ref{alg.modifying.operations}, modifying sequence operations
+  // \ref{alg.modifying.operations}, mutating sequence operations
   // \ref{alg.copy}, copy
   template<class InputIterator, class OutputIterator>
     OutputIterator copy(InputIterator first, InputIterator last,


### PR DESCRIPTION
…ions" consistently

Despite the stable name "alg.modifying.operations," the section is titled "Mutating sequence operations."