### PR TITLE
[unord.req], [fs.path.io] Fix "Effects: Equivalent to" styles

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -2509,7 +2509,7 @@ and \tcode{CopyAssignable}.\br
 &   \requires\ If \tcode{t} is a non-const rvalue expression, \tcode{value_type} shall be
     \tcode{MoveInsertable} into \tcode{X}; otherwise, \tcode{value_type} shall be
     \tcode{CopyInsertable} into \tcode{X}.\br
-    \effects\ Equivalent to a.insert(t).  Return value is an iterator pointing
+    \effects Equivalent to \tcode{a.insert(t)}.  Return value is an iterator pointing
 to the element with the key equivalent to that of \tcode{t}.  The
 iterator \tcode{p} is a hint pointing to where the search should
 start.  Implementations are permitted to ignore the hint.%
@@ -2521,8 +2521,8 @@ start.  Implementations are permitted to ignore the hint.%
 \tcode{a.insert(i, j)}
 &   \tcode{void}
 &   \requires\ \tcode{value_type} shall be \tcode{EmplaceConstructible} into \tcode{X} from \tcode{*i}.\br
-    \requires \tcode{i} and \tcode{j} are not iterators in \tcode{a}.
-    Equivalent to \tcode{a.insert(t)} for each element in \tcode{[i,j)}.%
+    \requires \tcode{i} and \tcode{j} are not iterators in \tcode{a}.\br
+    \effects Equivalent to \tcode{a.insert(t)} for each element in \tcode{[i,j)}.%
     \indextext{unordered associative containers!\idxcode{insert}}%
     \indextext{\idxcode{insert}!unordered associative containers}%
 &   Average case \bigoh{N}, where $N$ is \tcode{distance(i, j)}.

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -12702,7 +12702,7 @@ template <class charT, class traits>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{os << quoted(p.string<charT, traits>());}
+\effects Equivalent to \tcode{os << quoted(p.string<charT, traits>())}.
 \begin{note} The \tcode{quoted} function is described in~\ref{quoted.manip}. \end{note}
 
 \pnum


### PR DESCRIPTION
Some other places that might require change (wording relative to N4700):
- [string.view.modifiers] p2: Maybe convert to code block, but there are others like this.
- [string.view.modifiers] p4: Convert to expression style. Unlike the above, this is unique.
- [mem.poly.allocator.mem] p1: Maybe this was meant to be an _Effects:_ element.