### PR TITLE
[temp.constr.order] In definition of 'subsumes', remove

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1850,50 +1850,34 @@ The associated constraints of \#3 are
 \indextext{subsume|see{constraint, subsumption}}
 
 \pnum
-A constraint $P$ is said to subsume another constraint $Q$
-if it can be determined that $P$ implies $Q$, up to
-the identity\iref{temp.constr.atomic}
-of atomic constraints in $P$ and $Q$,
-as described below.
-\begin{example}
-Subsumption does not determine if the atomic constraint
-\tcode{N >= 0}\iref{temp.constr.atomic} subsumes \tcode{N > 0} for some
-integral template argument \tcode{N}.
-\end{example}
-
-\pnum
-In order to determine if a constraint $P$ subsumes a constraint $Q$,
-$P$ is transformed into disjunctive normal form, and
-$Q$ is transformed into conjunctive normal form.\footnote{%
+A constraint $P$ \defnx{subsumes}{constraint!subsumption} a constraint $Q$
+if and only if,
+for every disjunctive clause $P_i$
+in the disjunctive normal form\footnote{
 A constraint is in disjunctive normal form when it is a disjunction of
 clauses where each clause is a conjunction of atomic constraints.
-%
-Similarly, a constraint is in conjunctive normal form when it is a conjunction
-of clauses where each clause is a disjunction of atomic constraints.
-%
 \begin{example}
-Let $A$, $B$, and $C$ be atomic constraints, which can be grouped
-using parentheses.
-%
-The constraint $A \land (B \lor C)$ is in
-conjunctive normal form.
-%
-Its conjunctive clauses are $A$ and $(B \lor C)$.
-%
-The disjunctive normal form of the constraint
+For atomic constraints $A$, $B$, and $C$, the disjunctive normal form
+of the constraint
 $A \land (B \lor C)$
 is
 $(A \land B) \lor (A \land C)$.
 %
-Its disjunctive clauses are $(A \land B)$ and
-$(A \land C)$.
+Its disjunctive clauses are $(A \land B)$ and $(A \land C)$.
 \end{example}%
 }
+of $P$, $P_i$ subsumes every conjunctive clause $Q_j$
+in the conjuctive normal form\footnote{
+A constraint is in conjunctive normal form when it is a conjunction
+of clauses where each clause is a disjunction of atomic constraints.
+\begin{example}
+For atomic constraints $A$, $B$, and $C$, the constraint
+$A \land (B \lor C)$ is in conjunctive normal form.
 %
-Then, $P$ \defnx{subsumes}{constraint!subsumption} $Q$ if and only if,
-for every disjunctive clause $P_i$ in the disjunctive normal
-form of $P$, $P_i$ subsumes every conjunctive clause $Q_j$
-in the conjuctive normal form of $Q$, where
+Its conjunctive clauses are $A$ and $(B \lor C)$.
+\end{example}%
+}
+of $Q$, where
 
 \begin{itemize}
 \item


### PR DESCRIPTION
confusing introductory paragraph.

Fixes #1699.