### PR TITLE
[basic.link] Entities declared in an unnamed namespace

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2338,7 +2338,10 @@ void q() { @\commentellip@ }          // some other, unrelated \tcode{q}
 \indextext{linkage!no}%
 Names not covered by these rules have no linkage. Moreover, except as
 noted, a name declared at block scope\iref{basic.scope.block} has no
-linkage. A type is said to have linkage if and only if:
+linkage.
+
+\pnum
+A type is said to have linkage if and only if:
 \begin{itemize}
 \item it is a class or enumeration type that is named (or has a name for
 linkage purposes\iref{dcl.typedef}) and the name has linkage; or
@@ -2363,9 +2366,6 @@ A type without linkage shall not be used as the type of a variable or
 function with external linkage unless
 \begin{itemize}
 \item the entity has C language linkage\iref{dcl.link}, or
-
-\item the entity is declared within an unnamed
-namespace\iref{namespace.def}, or
 
 \item the entity is not odr-used\iref{basic.def.odr} or is defined in
 the same translation unit.


### PR DESCRIPTION
never have external linkage.

Fixes #1797.