### PR TITLE
[unique.ptr] Remove definition of 'transfers ownership'.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -7950,23 +7950,6 @@ deleter, but properly disposes of its owned object via the associated
 deleter before such replacement is considered completed.
 
 \pnum
-Additionally, \textit{u} can, upon request, \defn{transfer ownership} to another
-unique pointer \textit{u2}. Upon completion of such a transfer, the following
-postconditions hold:
-
-\begin{itemize}
-\item \textit{u2.p} is equal to the pre-transfer \textit{u.p},
-\item \textit{u.p} is equal to \tcode{nullptr}, and
-\item if the pre-transfer \textit{u.d} maintained state, such state has been
-transferred to \textit{u2.d}.
-\end{itemize}
-
-As in the case of a reset, \textit{u2} properly disposes of its pre-transfer
-owned object via the pre-transfer associated deleter before the ownership
-transfer is considered complete. \begin{note} A deleter's state need never be
-copied, only moved or swapped as ownership is transferred. \end{note}
-
-\pnum
 Each object of a type \tcode{U} instantiated from the \tcode{unique_ptr} template
 specified in this subclause has the strict ownership semantics, specified above,
 of a unique pointer. In partial satisfaction of these semantics, each such \tcode{U}
@@ -8305,15 +8288,16 @@ of the deleter from an rvalue of type \tcode{D} shall not
 throw an exception.
 
 \pnum
-\effects Constructs a \tcode{unique_ptr} by transferring ownership from
-\tcode{u} to \tcode{*this}. If \tcode{D} is a reference type, this
+\effects Constructs a \tcode{unique_ptr} from
+\tcode{u}. If \tcode{D} is a reference type, this
 deleter is copy constructed from \tcode{u}'s deleter; otherwise, this
 deleter is move constructed from \tcode{u}'s deleter. \begin{note} The
-deleter constructor can be implemented with \tcode{std::forward<D>}. \end{note}
+construction of the deleter can be implemented with \tcode{std::forward<D>}. \end{note}
 
 \pnum
 \postconditions \tcode{get()} yields the value \tcode{u.get()}
-yielded before the construction. \tcode{get_deleter()} returns a reference
+yielded before the construction. \tcode{u.get() == nullptr}.
+\tcode{get_deleter()} returns a reference
 to the stored deleter that was constructed from
 \tcode{u.get_deleter()}. If \tcode{D} is a reference type then
 \tcode{get_deleter()} and \tcode{u.get_deleter()} both reference
@@ -8344,15 +8328,15 @@ lvalue of type \tcode{E} shall be well-formed and shall not throw an exception.
 \end{itemize}
 
 \pnum
-\effects Constructs a \tcode{unique_ptr} by transferring ownership from \tcode{u}
-to \tcode{*this}. If \tcode{E} is a reference type, this deleter is copy constructed from
+\effects Constructs a \tcode{unique_ptr} from \tcode{u}.
+If \tcode{E} is a reference type, this deleter is copy constructed from
 \tcode{u}'s deleter; otherwise, this deleter is move constructed from \tcode{u}'s
 deleter. \begin{note} The deleter constructor can be implemented with
 \tcode{std::forward<E>}. \end{note}
 
 \pnum
 \postconditions \tcode{get()} yields the value \tcode{u.get()}
-yielded before the construction.
+yielded before the construction. \tcode{u.get() == nullptr}.
 \tcode{get_deleter()} returns a reference
 to the stored deleter that was constructed from
 \tcode{u.get_deleter()}.
@@ -8395,13 +8379,14 @@ requirements and assignment of the deleter from an
 lvalue of type \tcode{D} shall not throw an exception.
 
 \pnum
-\effects
-Transfers ownership from \tcode{u} to \tcode{*this} as if by calling
-\tcode{reset(u.release())} followed by
-\tcode{get_deleter() = std::forward<D>(u.get_deleter())}.
+\effects Calls \tcode{reset(u.release())} followed by
+\tcode{get_deleter() = std::forward<D>(u.get_dele\-ter())}.
 
 \pnum
 \returns \tcode{*this}.
+
+\pnum
+\postconditions \tcode{u.get() == nullptr}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{unique_ptr}%
@@ -8426,12 +8411,14 @@ of type \tcode{E} shall be well-formed and shall not throw an exception.
 \end{itemize}
 
 \pnum
-\effects Transfers ownership from \tcode{u} to \tcode{*this} as if by calling
-\tcode{reset(u.release())} followed by
-\tcode{get_deleter() = std::forward<E>(u.get_deleter())}.
+\effects Calls \tcode{reset(u.release())} followed by
+\tcode{get_deleter() = std::forward<E>(u.get_dele\-ter())}.
 
 \pnum
 \returns \tcode{*this}.
+
+\pnum
+\postconditions \tcode{u.get() == nullptr}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{unique_ptr}%


### PR DESCRIPTION
It is mostly subsumed by the detailed descriptions of the move
constructors and assignment operators.

Fixes #1643.