### PR TITLE
[variant] Move 'Otherwise' to start of following bullet.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -4238,19 +4238,20 @@ Let $j$ be \tcode{rhs.index()}.
 \effects
 \begin{itemize}
 \item
-If neither \tcode{*this} nor \tcode{rhs} holds a value, there is no effect.  Otherwise,
+If neither \tcode{*this} nor \tcode{rhs} holds a value, there is no effect.
 \item
-if \tcode{*this} holds a value but \tcode{rhs} does not, destroys the value
-contained in \tcode{*this} and sets \tcode{*this} to not hold a value.  Otherwise,
+Otherwise, if \tcode{*this} holds a value but \tcode{rhs} does not, destroys the value
+contained in \tcode{*this} and sets \tcode{*this} to not hold a value.
 \item
-if \tcode{index() == $j$}, assigns the value contained in \tcode{rhs}
-to the value contained in \tcode{*this}. Otherwise,
+Otherwise, if \tcode{index() == $j$}, assigns the value contained in \tcode{rhs}
+to the value contained in \tcode{*this}.
 \item
-if either \tcode{is_nothrow_copy_constructible_v<$\tcode{T}_j$>} or
-\tcode{!is_nothrow_move_constructible_v<$\tcode{T}_j$>} is \tcode{true},
-equivalent to \tcode{emplace<$j$>(get<$j$>(rhs))}. Otherwise,
+Otherwise, if either \tcode{is_nothrow_copy_constructible_v<$\tcode{T}_j$>}
+is \tcode{true} or
+\tcode{is_nothrow_move_con\-structible_v<$\tcode{T}_j$>} is \tcode{false},
+equivalent to \tcode{emplace<$j$>(get<$j$>(rhs))}.
 \item
-equivalent to \tcode{operator=(variant(rhs))}.
+Otherwise, equivalent to \tcode{operator=(variant(rhs))}.
 \end{itemize}
 
 \pnum
@@ -4280,15 +4281,15 @@ Let $j$ be \tcode{rhs.index()}.
 \effects
 \begin{itemize}
 \item
-If neither \tcode{*this} nor \tcode{rhs} holds a value, there is no effect. Otherwise,
+If neither \tcode{*this} nor \tcode{rhs} holds a value, there is no effect.
 \item
-if \tcode{*this} holds a value but \tcode{rhs} does not, destroys the value
-contained in \tcode{*this} and sets \tcode{*this} to not hold a value. Otherwise,
+Otherwise, if \tcode{*this} holds a value but \tcode{rhs} does not, destroys the value
+contained in \tcode{*this} and sets \tcode{*this} to not hold a value.
 \item
-if \tcode{index() == $j$}, assigns \tcode{get<$j$>(std::move(rhs))} to
-the value contained in \tcode{*this}. Otherwise,
+Otherwise, if \tcode{index() == $j$}, assigns \tcode{get<$j$>(std::move(rhs))} to
+the value contained in \tcode{*this}.
 \item
-equivalent to \tcode{emplace<$j$>(get<$j$>(std::move(rhs)))}.
+Otherwise, equivalent to \tcode{emplace<$j$>(get<$j$>(std::move(rhs)))}.
 \end{itemize}
 
 \pnum
@@ -4329,13 +4330,13 @@ assignment.
 \begin{itemize}
 \item
 If \tcode{*this} holds a $\tcode{T}_j$, assigns \tcode{std::forward<T>(t)} to
-the value contained in \tcode{*this}. Otherwise,
+the value contained in \tcode{*this}.
 \item
-if \tcode{is_nothrow_constructible_v<$\tcode{T}_j$, T> ||}
+Otherwise, if \tcode{is_nothrow_constructible_v<$\tcode{T}_j$, T> ||}
 \tcode{!is_nothrow_move_constructible_v<$\tcode{T}_j$>} is \tcode{true},
-equivalent to \tcode{emplace<$j$>(std::forward<T>(t))}. Otherwise,
+equivalent to \tcode{emplace<$j$>(std::forward<T>(t))}.
 \item
-equivalent to \tcode{operator=(variant(std::forward<T>(t)))}.
+Otherwise, equivalent to \tcode{operator=(variant(std::forward<T>(t)))}.
 \end{itemize}
 
 \pnum
@@ -4553,11 +4554,11 @@ void swap(variant& rhs) noexcept(@\seebelow@);
 \effects
 \begin{itemize}
 \item
-if \tcode{valueless_by_exception() \&\& rhs.valueless_by_exception()} no effect. Otherwise,
+If \tcode{valueless_by_exception() \&\& rhs.valueless_by_exception()} no effect.
 \item
-if \tcode{index() == rhs.index()}, calls \tcode{swap(get<$i$>(*this), get<$i$>(rhs))} where $i$ is \tcode{index()}. Otherwise,
+Otherwise, if \tcode{index() == rhs.index()}, calls \tcode{swap(get<$i$>(*this), get<$i$>(rhs))} where $i$ is \tcode{index()}.
 \item
-exchanges values of \tcode{rhs} and \tcode{*this}.
+Otherwise, exchanges values of \tcode{rhs} and \tcode{*this}.
 \end{itemize}
 
 \pnum


### PR DESCRIPTION
Also slightly rephrases one bullet to avoid "overfull hbox".

Fixes #1398.