### PR TITLE
[util.sharedptr] Dissolve subclause and integrate contents into parent.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -9041,9 +9041,7 @@ unless \tcode{os << p.get()} is a valid expression.
 \end{itemdescr}
 
 \indextext{smart pointers|(}%
-\rSec2[util.smartptr]{Shared-ownership pointers}
-
-\rSec3[util.smartptr.weak.bad]{Class \tcode{bad_weak_ptr}}
+\rSec2[util.smartptr.weak.bad]{Class \tcode{bad_weak_ptr}}
 \indexlibrary{\idxcode{bad_weak_ptr}}%
 \begin{codeblock}
 namespace std {
@@ -9070,7 +9068,7 @@ bad_weak_ptr() noexcept;
 
 \end{itemdescr}
 
-\rSec3[util.smartptr.shared]{Class template \tcode{shared_ptr}}
+\rSec2[util.smartptr.shared]{Class template \tcode{shared_ptr}}
 
 \pnum
 \indexlibrary{\idxcode{shared_ptr}}%
@@ -9180,14 +9178,14 @@ themselves and not objects they refer to. Changes in \tcode{use_count()} do not
 reflect modifications that can introduce data races.
 
 \pnum
-For the purposes of subclause \ref{util.smartptr},
+For the purposes of subclause \ref{smartptr},
 a pointer type \tcode{Y*} is said to be
 \defnx{compatible with}{compatible with!\idxcode{shared_ptr}}
 a pointer type \tcode{T*} when either
 \tcode{Y*} is convertible to \tcode{T*} or
 \tcode{Y} is \tcode{U[N]} and \tcode{T} is \cv{}~\tcode{U[]}.
 
-\rSec4[util.smartptr.shared.const]{\tcode{shared_ptr} constructors}
+\rSec3[util.smartptr.shared.const]{\tcode{shared_ptr} constructors}
 
 \pnum
 In the constructor definitions below,
@@ -9395,7 +9393,7 @@ Otherwise, equivalent to \tcode{shared_ptr(r.release(), ref(r.get_deleter()))}.
 If an exception is thrown, the constructor has no effect.
 \end{itemdescr}
 
-\rSec4[util.smartptr.shared.dest]{\tcode{shared_ptr} destructor}
+\rSec3[util.smartptr.shared.dest]{\tcode{shared_ptr} destructor}
 
 \indexlibrary{\idxcode{shared_ptr}!destructor}%
 \begin{itemdecl}
@@ -9426,7 +9424,7 @@ all \tcode{shared_ptr} instances that shared ownership with
 \tcode{*this} will report a \tcode{use_count()} that is one less
 than its previous value. \end{note}
 
-\rSec4[util.smartptr.shared.assign]{\tcode{shared_ptr} assignment}
+\rSec3[util.smartptr.shared.assign]{\tcode{shared_ptr} assignment}
 
 \indexlibrarymember{operator=}{shared_ptr}%
 \begin{itemdecl}
@@ -9481,9 +9479,7 @@ template <class Y, class D> shared_ptr& operator=(unique_ptr<Y, D>&& r);
 \returns \tcode{*this}.
 \end{itemdescr}
 
-
-
-\rSec4[util.smartptr.shared.mod]{\tcode{shared_ptr} modifiers}
+\rSec3[util.smartptr.shared.mod]{\tcode{shared_ptr} modifiers}
 
 \indexlibrarymember{swap}{shared_ptr}%
 \begin{itemdecl}
@@ -9532,7 +9528,7 @@ template <class Y, class D, class A> void reset(Y* p, D d, A a);
 \effects  Equivalent to \tcode{shared_ptr(p, d, a).swap(*this)}.
 \end{itemdescr}
 
-\rSec4[util.smartptr.shared.obs]{\tcode{shared_ptr} observers}
+\rSec3[util.smartptr.shared.obs]{\tcode{shared_ptr} observers}
 \indexlibrarymember{get}{shared_ptr}%
 \begin{itemdecl}
 element_type* get() const noexcept;
@@ -9651,8 +9647,7 @@ are both empty.
 
 \end{itemdescr}
 
-
-\rSec4[util.smartptr.shared.create]{\tcode{shared_ptr} creation}
+\rSec3[util.smartptr.shared.create]{\tcode{shared_ptr} creation}
 
 \pnum
 The common requirements that apply to
@@ -9923,7 +9918,7 @@ shared_ptr<vector<int>[4]> r = make_shared<vector<int>[4]>({1, 2});
 \end{example}
 \end{itemdescr}
 
-\rSec4[util.smartptr.shared.cmp]{\tcode{shared_ptr} comparison}
+\rSec3[util.smartptr.shared.cmp]{\tcode{shared_ptr} comparison}
 
 \indexlibrarymember{operator==}{shared_ptr}%
 \begin{itemdecl}
@@ -10045,7 +10040,7 @@ The first function template returns \tcode{!(a < nullptr)}.
 The second function template returns \tcode{!(nullptr < a)}.
 \end{itemdescr}
 
-\rSec4[util.smartptr.shared.spec]{\tcode{shared_ptr} specialized algorithms}
+\rSec3[util.smartptr.shared.spec]{\tcode{shared_ptr} specialized algorithms}
 
 \indexlibrarymember{swap}{shared_ptr}%
 \begin{itemdecl}
@@ -10057,7 +10052,7 @@ template <class T>
 \pnum\effects  Equivalent to \tcode{a.swap(b)}.
 \end{itemdescr}
 
-\rSec4[util.smartptr.shared.cast]{\tcode{shared_ptr} casts}
+\rSec3[util.smartptr.shared.cast]{\tcode{shared_ptr} casts}
 
 \indexlibrarymember{static_pointer_cast}{shared_ptr}%
 \begin{itemdecl}
@@ -10163,7 +10158,7 @@ undefined behavior, attempting to delete the same object twice.
 \end{note}
 \end{itemdescr}
 
-\rSec4[util.smartptr.getdeleter]{\tcode{get_deleter}}
+\rSec3[util.smartptr.getdeleter]{\tcode{get_deleter}}
 
 \indexlibrarymember{get_deleter}{shared_ptr}%
 \begin{itemdecl}
@@ -10182,7 +10177,7 @@ the deleter until all \tcode{weak_ptr} instances that share ownership with
 \tcode{p} have been destroyed. \end{note}
 \end{itemdescr}
 
-\rSec4[util.smartptr.shared.io]{\tcode{shared_ptr} I/O}
+\rSec3[util.smartptr.shared.io]{\tcode{shared_ptr} I/O}
 
 \indexlibrarymember{operator<<}{shared_ptr}%
 \begin{itemdecl}
@@ -10196,7 +10191,7 @@ template <class E, class T, class Y>
 \pnum\returns  \tcode{os}.
 \end{itemdescr}
 
-\rSec3[util.smartptr.weak]{Class template \tcode{weak_ptr}}
+\rSec2[util.smartptr.weak]{Class template \tcode{weak_ptr}}
 
 \pnum
 \indexlibrary{\idxcode{weak_ptr}}%
@@ -10264,7 +10259,7 @@ Specializations of \tcode{weak_ptr} shall be \tcode{CopyConstructible} and
 containers.  The template parameter \tcode{T} of \tcode{weak_ptr} may be an
 incomplete type.
 
-\rSec4[util.smartptr.weak.const]{\tcode{weak_ptr} constructors}
+\rSec3[util.smartptr.weak.const]{\tcode{weak_ptr} constructors}
 
 \indexlibrary{\idxcode{weak_ptr}!constructor}%
 \begin{itemdecl}
@@ -10312,7 +10307,7 @@ template<class Y> weak_ptr(weak_ptr<Y>&& r) noexcept;
 \tcode{r} shall be empty. \tcode{r.use_count() == 0}.
 \end{itemdescr}
 
-\rSec4[util.smartptr.weak.dest]{\tcode{weak_ptr} destructor}
+\rSec3[util.smartptr.weak.dest]{\tcode{weak_ptr} destructor}
 
 \indexlibrary{\idxcode{weak_ptr}!destructor}%
 \begin{itemdecl}
@@ -10324,7 +10319,7 @@ template<class Y> weak_ptr(weak_ptr<Y>&& r) noexcept;
 effect on the object its stored pointer points to.
 \end{itemdescr}
 
-\rSec4[util.smartptr.weak.assign]{\tcode{weak_ptr} assignment}
+\rSec3[util.smartptr.weak.assign]{\tcode{weak_ptr} assignment}
 
 \indexlibrarymember{operator=}{weak_ptr}%
 \begin{itemdecl}
@@ -10354,7 +10349,7 @@ template<class Y> weak_ptr& operator=(weak_ptr<Y>&& r) noexcept;
 \pnum\returns  \tcode{*this}.
 \end{itemdescr}
 
-\rSec4[util.smartptr.weak.mod]{\tcode{weak_ptr} modifiers}
+\rSec3[util.smartptr.weak.mod]{\tcode{weak_ptr} modifiers}
 \indexlibrarymember{swap}{weak_ptr}%
 \begin{itemdecl}
 void swap(weak_ptr& r) noexcept;
@@ -10373,7 +10368,7 @@ void reset() noexcept;
 \pnum\effects  Equivalent to \tcode{weak_ptr().swap(*this)}.
 \end{itemdescr}
 
-\rSec4[util.smartptr.weak.obs]{\tcode{weak_ptr} observers}
+\rSec3[util.smartptr.weak.obs]{\tcode{weak_ptr} observers}
 \indexlibrarymember{use_count}{weak_ptr}%
 \begin{itemdecl}
 long use_count() const noexcept;
@@ -10425,7 +10420,7 @@ both empty.
 \end{itemdescr}
 
 
-\rSec4[util.smartptr.weak.spec]{\tcode{weak_ptr} specialized algorithms}
+\rSec3[util.smartptr.weak.spec]{\tcode{weak_ptr} specialized algorithms}
 
 \indexlibrarymember{swap}{weak_ptr}%
 \begin{itemdecl}
@@ -10437,7 +10432,7 @@ template<class T>
 \pnum\effects Equivalent to \tcode{a.swap(b)}.
 \end{itemdescr}
 
-\rSec3[util.smartptr.ownerless]{Class template \tcode{owner_less}}
+\rSec2[util.smartptr.ownerless]{Class template \tcode{owner_less}}
 
 \pnum
 The class template \tcode{owner_less} allows ownership-based mixed comparisons of shared
@@ -10488,7 +10483,7 @@ Note that
 both empty.
 \end{itemize} \end{note}
 
-\rSec3[util.smartptr.enab]{Class template \tcode{enable_shared_from_this}}
+\rSec2[util.smartptr.enab]{Class template \tcode{enable_shared_from_this}}
 
 \pnum
 \indexlibrary{\idxcode{enable_shared_from_this}}%
@@ -10578,7 +10573,7 @@ weak_ptr<T const> weak_from_this() const noexcept;
 \pnum\returns  \tcode{weak_this}.
 \end{itemdescr}
 
-\rSec3[util.smartptr.hash]{Smart pointer hash support}
+\rSec2[util.smartptr.hash]{Smart pointer hash support}
 
 \indexlibrary{\idxcode{hash}!\idxcode{unique_ptr}}%
 \begin{itemdecl}

--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -46,5 +46,8 @@
 \movedxref{array.fill}{array.members}
 \movedxref{array.swap}{array.members}
 
+% Contents of [util.smartptr] was integrated into the parent.
+\removedxref{util.smartptr}
+
 % Deprecated features.
 %\deprxref{old.label}  (if moved to depr.old.label, otherwise use \movedxref)


### PR DESCRIPTION
Fixes #252.