### PR TITLE
[basic.def] 'class name declaration' is undefined.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -112,7 +112,8 @@ A declaration may also have effects including:
 \pnum
 \indextext{declaration!function}%
 \indextext{definition}%
-A declaration is a \defn{definition} unless
+Each entity declared by a \grammarterm{declaration} is
+also \defnx{defined}{define} by that declaration unless:
 \begin{itemize}
 \item
 it declares a function
@@ -137,7 +138,7 @@ and the variable was defined within the class with the \tcode{constexpr}
 specifier (this usage is deprecated; see \ref{depr.static_constexpr}),
 \item
 \indextext{declaration!class name}%
-it is a class name declaration\iref{class.name},
+it is introduced by an \grammarterm{elaborated-type-specifier}\iref{class.name},
 \item
 it is an
 \indextext{declaration!opaque enum}%
@@ -180,6 +181,7 @@ an explicit instantiation declaration\iref{temp.explicit}, or
 an explicit specialization\iref{temp.expl.spec} whose
 \grammarterm{declaration} is not a definition.
 \end{itemize}
+A declaration is said to be a \defn{definition} of each entity that it defines.
 \begin{example} All but one of the following are definitions:
 \indextext{example!definition}%
 \begin{codeblock}


### PR DESCRIPTION
Fixes #1641.