### PR TITLE
[expr.compound] Expression operators do not 'return' results.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3636,9 +3636,9 @@ duration\iref{basic.stc.dynamic}.
 The lifetime of such an entity is not necessarily restricted to the
 scope in which it is created.
 \end{note}
-If the entity is a non-array object, the \grammarterm{new-expression}
-returns a pointer to the object created. If it is an array, the
-\grammarterm{new-expression} returns a pointer to the initial element of
+If the entity is a non-array object, the result of the \grammarterm{new-expression}
+is a pointer to the object created. If it is an array, the result of the
+\grammarterm{new-expression} is a pointer to the initial element of
 the array.
 
 \pnum
@@ -5085,7 +5085,7 @@ value computation and side effect associated with the second expression.
 \pnum
 The \tcode{||} operator groups left-to-right. The operands are both
 contextually converted to \tcode{bool}\iref{conv}.
-It returns
+The result is
 \tcode{true} if either of its operands is \tcode{true}, and
 \tcode{false} otherwise. Unlike \tcode{|}, \tcode{||} guarantees
 left-to-right evaluation; moreover, the second operand is not evaluated
@@ -5334,7 +5334,7 @@ The assignment operator (\tcode{=}) and the compound assignment
 operators all group right-to-left.
 \indextext{assignment!and lvalue}%
 All
-require a modifiable lvalue as their left operand and return an lvalue
+require a modifiable lvalue as their left operand; their result is an lvalue
 referring to the left operand. The result in all cases is a bit-field if
 the left operand is a bit-field. In all cases, the assignment is
 sequenced after the


### PR DESCRIPTION
Fixes #1476.