### PR TITLE
Use \tcode for return/if/switch statement.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3984,7 +3984,7 @@ be used only as an expression statement\iref{stmt.expr}, as an operand
 of a comma expression\iref{expr.comma}, as a second or third operand
 of \tcode{?:}\iref{expr.cond}, as the operand of
 \tcode{typeid}, \tcode{noexcept}, or \tcode{decltype}, as
-the expression in a return statement\iref{stmt.return} for a function
+the expression in a \tcode{return} statement\iref{stmt.return} for a function
 with the return type \cv{}~\tcode{void}, or as the operand of an explicit conversion
 to type \cv{}~\tcode{void}.
 
@@ -5236,7 +5236,7 @@ behavior.
 \pnum
 \indextext{termination!program}%
 \indextext{\idxcode{main} function!return from}%
-A return statement in \tcode{main} has the effect of leaving the main
+A \tcode{return} statement\iref{stmt.return} in \tcode{main} has the effect of leaving the main
 function (destroying any objects with automatic storage duration) and
 calling \tcode{std::exit} with the return value as the argument.
 If control flows off the end of

--- a/source/conversions.tex
+++ b/source/conversions.tex
@@ -43,12 +43,12 @@ types in several contexts:
 \item When used as operands of operators. The operator's requirements
 for its operands dictate the destination type\iref{expr.compound}.
 
-\item When used in the condition of an \tcode{if} statement or iteration
-statement~(\ref{stmt.select}, \ref{stmt.iter}). The destination type is
+\item When used in the condition of an \tcode{if} statement\iref{stmt.if} or
+iteration statement\iref{stmt.iter}. The destination type is
 \tcode{bool}.
 
-\item When used in the expression of a \tcode{switch} statement. The
-destination type is integral\iref{stmt.select}.
+\item When used in the expression of a \tcode{switch} statement\iref{stmt.switch}.
+The destination type is integral.
 
 \item When used as the source expression for an initialization (which
 includes use as an argument in a function call and use as the expression

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -3843,7 +3843,7 @@ List-initialization can be used
 \begin{itemize}
 \item as the initializer in a variable definition\iref{dcl.init}
 \item as the initializer in a \grammarterm{new-expression}\iref{expr.new}
-\item in a return statement\iref{stmt.return}
+\item in a \tcode{return} statement\iref{stmt.return}
 \item as a \grammarterm{for-range-initializer}\iref{stmt.iter}
 \item as a function argument\iref{expr.call}
 \item as a subscript\iref{expr.sub}

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -634,7 +634,7 @@ Exceptions thrown in destructors of objects with thread storage duration or in c
 on the initial function of the thread.
 
 \pnum
-If a return statement appears in a handler of the
+If a \tcode{return} statement\iref{stmt.return} appears in a handler of the
 \grammarterm{function-try-block}
 of a
 constructor, the program is ill-formed.

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -514,7 +514,7 @@ Next, the semantics of the code sequence are determined by the \Fundescx{Require
 specified for the function invocations contained in the code sequence. The value
 returned from \tcode{F} is specified by \tcode{F}'s \Fundescx{Returns} element, or if \tcode{F}
 has no \Fundescx{Returns} element, a non-\tcode{void} return from \tcode{F} is specified by the
-\tcode{return} statements in the code sequence.
+\tcode{return} statements\iref{stmt.return} in the code sequence.
 If \tcode{F}'s semantics contains a \Fundescx{Throws},
 \Fundescx{Postconditions}, or \Fundescx{Complexity} element, then that supersedes any occurrences of that
 element in the code sequence.

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -351,8 +351,8 @@ directives}.
 Thus, the constant expression in the following
 \tcode{\#if}
 directive and
-\tcode{if}
-statement is not guaranteed to evaluate to the same value in these two
+\tcode{if} statement\iref{stmt.if}
+is not guaranteed to evaluate to the same value in these two
 contexts:
 \begin{codeblock}
 #if 'z' - 'a' == 25

--- a/source/special.tex
+++ b/source/special.tex
@@ -606,7 +606,7 @@ The exceptions to this lifetime rule are:
 \item A temporary object bound to a reference parameter in a function call\iref{expr.call}
 persists until the completion of the full-expression containing the call.
 
-\item The lifetime of a temporary bound to the returned value in a function return statement\iref{stmt.return} is not extended; the temporary is destroyed at the end of the full-expression in the return statement.
+\item The lifetime of a temporary bound to the returned value in a function \tcode{return} statement\iref{stmt.return} is not extended; the temporary is destroyed at the end of the full-expression in the \tcode{return} statement.
 
 \item A temporary bound to a reference in a \grammarterm{new-initializer}\iref{expr.new} persists until the completion of the full-expression containing the \grammarterm{new-initializer}.
 \begin{note} This may introduce a dangling reference. \end{note}

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -128,7 +128,7 @@ lookup\iref{basic.lookup.unqual} ignores labels.
 \pnum
 \indextext{label!\idxcode{case}}%
 \indextext{label!\idxcode{default}}%
-Case labels and default labels shall occur only in switch statements.
+Case labels and default labels shall occur only in \tcode{switch} statements.
 
 
 \rSec1[stmt.expr]{Expression statement}%
@@ -812,25 +812,25 @@ A function returns to its caller by the \tcode{return} statement.
 
 \pnum
 The \grammarterm{expr-or-braced-init-list}
-of a return statement is called its operand. A return statement with
+of a \tcode{return} statement is called its operand. A \tcode{return} statement with
 no operand shall be used only in a function whose return type is
 \cv{}~\tcode{void}, a constructor\iref{class.ctor}, or a
 destructor\iref{class.dtor}.
 \indextext{\idxcode{return}!constructor and}%
 \indextext{\idxcode{return}!constructor and}%
-A return statement with an operand of type \tcode{void} shall be used only
+A \tcode{return} statement with an operand of type \tcode{void} shall be used only
 in a function whose return type is \cv{}~\tcode{void}.
-A return statement with any other operand shall be used only
+A \tcode{return} statement with any other operand shall be used only
 in a function whose return type is not \cv{}~\tcode{void};
 \indextext{conversion!return type}%
-the return statement initializes the
+the \tcode{return} statement initializes the
 glvalue result or prvalue result object of the (explicit or implicit) function call
 by copy-initialization\iref{dcl.init} from the operand.
 \begin{note}
-A return statement can involve
+A \tcode{return} statement can involve
 an invocation of a constructor to perform a copy or move of the operand
 if it is not a prvalue or if its type differs from the return type of the function.
-A copy operation associated with a return statement may be elided or
+A copy operation associated with a \tcode{return} statement may be elided or
 converted to a move operation if an automatic storage duration variable is returned\iref{class.copy}.
 \end{note}
 \begin{example}
@@ -852,9 +852,9 @@ results in undefined behavior.
 \pnum
 The copy-initialization of the result of the call is sequenced before the
 destruction of temporaries at the end of the full-expression established
-by the operand of the return statement, which, in turn, is sequenced
+by the operand of the \tcode{return} statement, which, in turn, is sequenced
 before the destruction of local variables\iref{stmt.jump} of the block
-enclosing the return statement.
+enclosing the \tcode{return} statement.
 
 \rSec2[stmt.goto]{The \tcode{goto} statement}%
 \indextext{statement!\idxcode{goto}}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16591,7 +16591,7 @@ To test() {
 \begin{note} This requirement gives well-defined results for reference types, void
 types, array types, and function types.\end{note} Access checking is performed
 in a context unrelated to \tcode{To} and \tcode{From}. Only the validity of
-the immediate context of the \grammarterm{expression} of the \tcode{return} statement
+the immediate context of the \grammarterm{expression} of the \tcode{return} statement\iref{stmt.return}
 (including initialization of the returned object or reference) is considered. \begin{note} The
 initialization can result in side effects such as the
 instantiation of class template specializations and function template


### PR DESCRIPTION
Fixes #1305.