### PR TITLE
[complex.numbers] Use \xref for references to the C standard.

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -995,7 +995,8 @@ template<class T> complex<T> proj(const complex<T>& x);
 
 \pnum
 \remarks
-Behaves the same as the C function \tcode{cproj}, defined in 7.3.9.4.
+Behaves the same as the C function \tcode{cproj}.
+\xref ISO C 7.3.9.5
 \end{itemdescr}
 
 \indexlibrary{\idxcode{polar}!\idxcode{complex}}%
@@ -1031,8 +1032,8 @@ template<class T> complex<T> acos(const complex<T>& x);
 
 \pnum
 \remarks
-Behaves the same as C function \tcode{cacos},
-defined in 7.3.5.1.
+Behaves the same as the C function \tcode{cacos}.
+\xref ISO C 7.3.5.1
 \end{itemdescr}
 
 \indexlibrary{\idxcode{asin}!\idxcode{complex}}%
@@ -1047,8 +1048,8 @@ template<class T> complex<T> asin(const complex<T>& x);
 
 \pnum
 \remarks
-Behaves the same as C function \tcode{casin},
-defined in 7.3.5.2.
+Behaves the same as the C function \tcode{casin}.
+\xref ISO C 7.3.5.2
 \end{itemdescr}
 
 \indexlibrary{\idxcode{atan}!\idxcode{complex}}%
@@ -1063,8 +1064,8 @@ template<class T> complex<T> atan(const complex<T>& x);
 
 \pnum
 \remarks
-Behaves the same as C function \tcode{catan},
-defined in 7.3.5.3.
+Behaves the same as the C function \tcode{catan}.
+\xref ISO C 7.3.5.3
 \end{itemdescr}
 
 \indexlibrary{\idxcode{acosh}!\idxcode{complex}}%
@@ -1079,8 +1080,8 @@ template<class T> complex<T> acosh(const complex<T>& x);
 
 \pnum
 \remarks
-Behaves the same as C function \tcode{cacosh},
-defined in 7.3.6.1.
+Behaves the same as the C function \tcode{cacosh}.
+\xref ISO C 7.3.6.1
 \end{itemdescr}
 
 \indexlibrary{\idxcode{asinh}!\idxcode{complex}}%
@@ -1095,8 +1096,8 @@ template<class T> complex<T> asinh(const complex<T>& x);
 
 \pnum
 \remarks
-Behaves the same as C function \tcode{casinh},
-defined in 7.3.6.2.
+Behaves the same as the C function \tcode{casinh}.
+\xref ISO C 7.3.6.2
 \end{itemdescr}
 
 \indexlibrary{\idxcode{atanh}!\idxcode{complex}}%
@@ -1111,8 +1112,8 @@ template<class T> complex<T> atanh(const complex<T>& x);
 
 \pnum
 \remarks
-Behaves the same as C function \tcode{catanh},
-defined in 7.3.6.3.
+Behaves the same as the C function \tcode{catanh}.
+\xref ISO C 7.3.6.3
 \end{itemdescr}
 
 \indexlibrary{\idxcode{cos}!\idxcode{complex}}%


### PR DESCRIPTION
Fixes #1822.