### PR TITLE
[atomics.types.operations] Remove spurious paragraph break.

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -921,7 +921,6 @@ spurious failure enables implementation of compare-and-exchange on a broader cla
 machines, e.g., load-locked store-conditional machines. A
 consequence of spurious failure is that nearly all uses of weak compare-and-exchange
 will be in a loop.
-
 When a compare-and-exchange is in a loop, the weak version will yield better performance
 on some platforms. When a weak compare-and-exchange would require a loop and a strong one
 would not, the strong one is preferable.


### PR DESCRIPTION
Fixes #1833.