### PR TITLE
[basic.life],[mem.res.private],[mem.res.pool.mem],[mem.res.monotonic.buffer] fix cross-references

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2877,7 +2877,7 @@ used but only in limited ways.
 For an object under construction or destruction, see~\ref{class.cdtor}.
 Otherwise, such
 a pointer refers to allocated
-storage\iref{basic.stc.dynamic.deallocation}, and using the pointer as
+storage\iref{basic.stc.dynamic.allocation}, and using the pointer as
 if the pointer were of type \tcode{void*}, is
 well-defined. Indirection through such a pointer is permitted but the resulting lvalue may only be used in
 limited ways, as described below. The
@@ -2943,7 +2943,7 @@ object may be used but only in limited ways.
 For an object under construction or destruction, see~\ref{class.cdtor}.
 Otherwise, such
 a glvalue refers to
-allocated storage\iref{basic.stc.dynamic.deallocation}, and using the
+allocated storage\iref{basic.stc.dynamic.allocation}, and using the
 properties of the glvalue that do not depend on its value is
 well-defined. The program has undefined behavior if:
 \begin{itemize}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -11245,7 +11245,7 @@ virtual void* do_allocate(size_t bytes, size_t alignment) = 0;
 
 \pnum
 \returns
-A derived class shall implement this function to return a pointer to allocated storage\iref{basic.stc.dynamic.deallocation} with a size of at least \tcode{bytes}.
+A derived class shall implement this function to return a pointer to allocated storage\iref{basic.stc.dynamic.allocation} with a size of at least \tcode{bytes}.
 The returned storage is aligned to the specified alignment, if such alignment is supported\iref{basic.align};
 otherwise it is aligned to \tcode{max_align}.
 
@@ -12052,7 +12052,7 @@ void* do_allocate(size_t bytes, size_t alignment) override;
 \begin{itemdescr}
 \pnum
 \returns
-A pointer to allocated storage\iref{basic.stc.dynamic.deallocation}
+A pointer to allocated storage\iref{basic.stc.dynamic.allocation}
 with a size of at least \tcode{bytes}.
 The size and alignment of the allocated memory shall meet the requirements
 for a class derived from \tcode{memory_resource}\iref{mem.res}.
@@ -12276,7 +12276,7 @@ void* do_allocate(size_t bytes, size_t alignment) override;
 \begin{itemdescr}
 \pnum
 \returns
-A pointer to allocated storage\iref{basic.stc.dynamic.deallocation}
+A pointer to allocated storage\iref{basic.stc.dynamic.allocation}
 with a size of at least \tcode{bytes}.
 The size and alignment of the allocated memory shall meet the requirements
 for a class derived from \tcode{memory_resource}\iref{mem.res}.


### PR DESCRIPTION
6.6.4.4.2 [basic.stc.dynamic.deallocation] only mentions "storage" once, in "the deallocation function shall deallocate the storage referenced by the pointer".

I think the references are supposed to be to 6.6.4.4.1 [basic.stc.dynamic.**allocation**] instead, which has lots to say about "allocated storage".

Fixes #1841 (assuming I'm right about the references being wrong).