### PR TITLE
[allocator.adaptor.syn] Fix index entries for scoped_allocator_adaptor member typedefs.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -12369,14 +12369,14 @@ allocator type so it can be substituted for the outer allocator type in most
 expressions. \end{note}
 
 \indexlibrary{\idxcode{scoped_allocator_adaptor}}%
-\indexlibrarymember{outer_allocator_type}{scoped_allocator}%
-\indexlibrarymember{value_type}{scoped_allocator}%
-\indexlibrarymember{size_type}{scoped_allocator}%
-\indexlibrarymember{difference_type}{scoped_allocator}%
-\indexlibrarymember{pointer}{scoped_allocator}%
-\indexlibrarymember{const_pointer}{scoped_allocator}%
-\indexlibrarymember{void_pointer}{scoped_allocator}%
-\indexlibrarymember{const_void_pointer}{scoped_allocator}%
+\indexlibrarymember{outer_allocator_type}{scoped_allocator_adaptor}%
+\indexlibrarymember{value_type}{scoped_allocator_adaptor}%
+\indexlibrarymember{size_type}{scoped_allocator_adaptor}%
+\indexlibrarymember{difference_type}{scoped_allocator_adaptor}%
+\indexlibrarymember{pointer}{scoped_allocator_adaptor}%
+\indexlibrarymember{const_pointer}{scoped_allocator_adaptor}%
+\indexlibrarymember{void_pointer}{scoped_allocator_adaptor}%
+\indexlibrarymember{const_void_pointer}{scoped_allocator_adaptor}%
 \begin{codeblock}
 namespace std {
   template <class OuterAlloc, class... InnerAllocs>


### PR DESCRIPTION
Unfortunately I forgot the `_adaptor` part in #1712 