### PR TITLE
Remove \tilde in favour of \~.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1775,7 +1775,7 @@ up as types in the scope designated by the
 \grammarterm{qualified-id} of the form:
 
 \begin{ncbnf}
-nested-name-specifier\opt{} class-name \terminal{::} \terminal{\tilde} class-name
+nested-name-specifier\opt{} class-name \terminal{::} \terminal{\~} class-name
 \end{ncbnf}
 
 the second \grammarterm{class-name} is looked up in the same scope as the

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1442,7 +1442,7 @@ template<class T> auto f(T)     // \#2
   -> void;
 auto g() -> void {
   f(42);                        // OK: calls \#2. (\#1 is not a viable candidate: type deduction
-                                // fails\iref{temp.deduct} because \tcode{A<int>::\tilde{}A()} is implicitly used in its
+                                // fails\iref{temp.deduct} because \tcode{A<int>::\~{}A()} is implicitly used in its
                                 // \grammarterm{decltype-specifier})
 }
 template<class T> auto q(T)

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -671,8 +671,8 @@ even though
     operator-function-id\br
     conversion-function-id\br
     literal-operator-id\br
-    \terminal{\tilde} class-name\br
-    \terminal{\tilde} decltype-specifier\br
+    \terminal{\~} class-name\br
+    \terminal{\~} decltype-specifier\br
     template-id
 \end{bnf}
 
@@ -686,7 +686,7 @@ For \grammarterm{operator-function-id}{s}, see~\ref{over.oper}; for
 \grammarterm{literal-operator-id}{s}, see~\ref{over.literal}; for
 \grammarterm{template-id}{s}, see~\ref{temp.names}. A \grammarterm{class-name}
 or \grammarterm{decltype-specifier}
-prefixed by \tcode{\tilde} denotes a destructor; see~\ref{class.dtor}.
+prefixed by \tcode{\~} denotes a destructor; see~\ref{class.dtor}.
 Within the definition of a non-static member function, an
 \grammarterm{identifier} that names a non-static member is transformed to a
 class member access expression~(\ref{class.mfct.non-static}).
@@ -777,10 +777,10 @@ A class member can be referred to using a \grammarterm{qualified-id} at any
 point in its potential scope\iref{basic.scope.class}.
 \end{note}
 Where
-\grammarterm{class-name} \tcode{::\tilde}~\grammarterm{class-name} is used,
+\grammarterm{class-name} \tcode{::\~}~\grammarterm{class-name} is used,
 the two \grammarterm{class-name}{s} shall refer to the same class; this
 notation names the destructor\iref{class.dtor}.
-The form \tcode{\tilde}~\grammarterm{decltype-specifier} also denotes the destructor,
+The form \tcode{\~}~\grammarterm{decltype-specifier} also denotes the destructor,
 but it shall not be used as the \grammarterm{unqualified-id} in a \grammarterm{qualified-id}.
 \begin{note}
 A \grammarterm{typedef-name} that names a class is a
@@ -2107,10 +2107,10 @@ Postfix expressions group left-to-right.
 
 \begin{bnf}
 \nontermdef{pseudo-destructor-name}\br
-    nested-name-specifier\opt{} type-name \terminal{::\,\tilde} type-name\br
-    nested-name-specifier \terminal{template} simple-template-id \terminal{::\,\tilde} type-name\br
-    \terminal{\tilde} type-name\br
-    \terminal{\tilde} decltype-specifier
+    nested-name-specifier\opt{} type-name \terminal{::\,\~} type-name\br
+    nested-name-specifier \terminal{template} simple-template-id \terminal{::\,\~} type-name\br
+    \terminal{\~} type-name\br
+    \terminal{\~} decltype-specifier
 \end{bnf}
 
 \pnum
@@ -2444,7 +2444,7 @@ the two \grammarterm{type-name}{s} in a \grammarterm{pseudo-destructor-name} of
 the form
 
 \begin{ncbnf}
-nested-name-specifier\opt{} type-name \terminal{::\,\tilde} type-name
+nested-name-specifier\opt{} type-name \terminal{::\,\~} type-name
 \end{ncbnf}
 
 shall designate the same scalar type (ignoring cv-qualification).
@@ -3385,13 +3385,13 @@ Expressions with unary operators group right-to-left.
 \indextext{operator!logical negation}%
 \indextext{\idxcode{"!}|see{operator, logical negation}}%
 \indextext{operator!ones' complement}%
-\indextext{~@\tcode{\tilde}|see{operator, ones' complement}}%
+\indextext{~@\tcode{\~}|see{operator, ones' complement}}%
 \indextext{operator!increment}%
 \indextext{operator!decrement}%
 %
 \begin{bnf}
 \nontermdef{unary-operator} \textnormal{one of}\br
-    \terminal{*  \&  +  -  !  \tilde}
+    \terminal{*  \&  +  -  !  \~}
 \end{bnf}
 
 \rSec3[expr.unary.op]{Unary operators}

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -796,7 +796,7 @@ are converted into tokens for operators and punctuators:
 \nontermdef{preprocessing-op-or-punc} \textnormal{one of}\br
 \>\{ \>\} \>[ \>] \>\# \>\#\# \>( \>)\br
 \><: \>:> \><\% \>\%> \>\%: \>\%:\%: \>; \>: \>.{..}\br
-\>new \>delete \>? \>:: \>. \>.* \>-> \>->* \>\tilde\br
+\>new \>delete \>? \>:: \>. \>.* \>-> \>->* \>\~\br
 \>! \>+ \>- \>* \>/ \>\% \>\caret \>\& \>|\br
 \>= \>+= \>-= \>*= \>/= \>\%= \>\caret= \>\&= \>|=\br
 \>== \>!= \>< \>> \><= \>>= \><=> \>\&\& \>||\br

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -199,8 +199,6 @@
 \newcommand{\bigoh}[1]{\ensuremath{\mathscr{O}(#1)}}
 
 % Make all tildes a little larger to avoid visual similarity with hyphens.
-% FIXME: Remove \tilde in favour of \~.
-\renewcommand{\tilde}{\textasciitilde}
 \renewcommand{\~}{\textasciitilde}
 \let\OldTextAsciiTilde\textasciitilde
 \renewcommand{\textasciitilde}{\protect\raisebox{-0.17ex}{\larger\OldTextAsciiTilde}}

--- a/source/special.tex
+++ b/source/special.tex
@@ -4,7 +4,7 @@
 \gramSec[gram.special]{Special member functions}
 
 \indextext{\idxcode{X(X\&)}|see{constructor, copy}}%
-\indextext{~@\tcode{\tilde}|see{destructor}}%
+\indextext{~@\tcode{\~}|see{destructor}}%
 \indextext{assignment!copy|see{assignment operator, copy}}%
 \indextext{assignment!move|see{assignment operator, move}}%
 \indextext{implicitly-declared default constructor|see{constructor, default}}


### PR DESCRIPTION
This was a FIXME in macros.tex.

No visible difference.