### PR TITLE
[filesystems] 'dot' and 'dot-dot' are not \grammarterms

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -10543,8 +10543,8 @@ that contain information about
 other files, possibly including other directory files.
 The \defn{parent directory} of a directory is
 the directory that both contains a
-directory entry for the given directory and is represented by the filename
-\grammarterm{dot-dot} in the given directory.
+directory entry for the given directory and is represented by the dot-dot
+filename\iref{fs.path.generic} in the given directory.
 The \defn{parent directory}
 of other types of files is a directory containing a directory
 entry for the file under discussion.
@@ -11231,7 +11231,7 @@ any operating system dependent \grammarterm{root-name}{s}}}
 
 \pnum
 A \defn{filename} is
-the name of a file. Filenames \grammarterm{dot} and \grammarterm{dot-dot},
+the name of a file. The \defnx{dot}{dot!filename} and \defnx{dot-dot}{dot-dot!filename} filenames,
 consisting solely of one and two period characters respectively,
 have special meaning.
 The following characteristics of filenames are operating system dependent:
@@ -11259,10 +11259,10 @@ multiple successive \grammarterm{directory-separator} characters are considered 
 be the same as one \grammarterm{directory-separator} character.
 
 \pnum
-The filename \grammarterm{dot} is treated as a reference to the current directory.
-The filename \grammarterm{dot-dot} is treated as a reference to the parent directory.
-What the filename \grammarterm{dot-dot} refers to
-relative to \grammarterm{root-directory} is \impldef{meaning of \grammarterm{dot-dot} in \grammarterm{root-directory}}.
+The dot filename is treated as a reference to the current directory.
+The dot-dot filename is treated as a reference to the parent directory.
+What the dot-dot filename refers to
+relative to \grammarterm{root-directory} is \impldef{meaning of dot-dot in \grammarterm{root-directory}}.
 Specific filenames may have special meanings for a particular operating system.
 
 \pnum
@@ -11300,14 +11300,14 @@ without an intervening \grammarterm{root-directory} element.
 \begin{note}
 The generic pathname grammar\iref{fs.path.generic} defines \grammarterm{directory-separator} as one or more slashes and \grammarterm{preferred-separator}{s}.
 \end{note}
-\item Remove each \grammarterm{dot} filename and any immediately following \grammarterm{directory-separator}.
-\item As long as any appear, remove a non-\grammarterm{dot-dot} filename immediately followed by a \grammarterm{directory-separator} and a \grammarterm{dot-dot} filename, along with any immediately following \grammarterm{directory-separator}.
-\item If there is a \grammarterm{root-directory}, remove all \grammarterm{dot-dot} filenames and any \grammarterm{directory-separator}{s} immediately following them.
+\item Remove each dot filename and any immediately following \grammarterm{directory-separator}.
+\item As long as any appear, remove a non-dot-dot filename immediately followed by a \grammarterm{directory-separator} and a dot-dot filename, along with any immediately following \grammarterm{directory-separator}.
+\item If there is a \grammarterm{root-directory}, remove all dot-dot filenames and any \grammarterm{directory-separator}{s} immediately following them.
 \begin{note}
-These \grammarterm{dot-dot} filenames attempt to refer to nonexistent parent directories.
+These dot-dot filenames attempt to refer to nonexistent parent directories.
 \end{note}
-\item If the last filename is \grammarterm{dot-dot}, remove any trailing \grammarterm{directory-separator}.
-\item If the path is empty, add a \grammarterm{dot}.
+\item If the last filename is dot-dot, remove any trailing \grammarterm{directory-separator}.
+\item If the path is empty, add a dot.
 \end{enumerate}
 
 The result of normalization is a path in \defnx{normal form}{normal form!path},
@@ -12462,7 +12462,7 @@ Then,
 \begin{itemize}
 \item if \tcode{a == end()} and \tcode{b == base.end()}, returns \tcode{path(".")}; otherwise
 \item let \tcode{n} be the number of \grammarterm{filename} elements in \range{b}{base.end()}
-that are not \grammarterm{dot} or \grammarterm{dot-dot} minus the number that are \grammarterm{dot-dot}.
+that are not dot or dot-dot minus the number that are dot-dot.
 If \tcode{n<0,} returns \tcode{path()}; otherwise
 \item returns an object of class \tcode{path} that is default-constructed, followed by
 \begin{itemize}
@@ -13807,8 +13807,8 @@ The result of calling the \tcode{path()} member of the \tcode{directory_entry} o
 constructed with filename of the directory entry appended as if by \tcode{operator/=}.
 
 \pnum
-Directory iteration shall not yield directory entries for the current (\grammarterm{dot})
-and parent (\grammarterm{dot-dot}) directories.
+Directory iteration shall not yield directory entries for the current (dot)
+and parent (dot-dot) directories.
 
 \pnum
 The order of directory entries obtained by dereferencing successive
@@ -14371,7 +14371,7 @@ path canonical(const path& p, error_code& ec);
 \begin{itemdescr}
 \pnum
 \effects Converts \tcode{p} to an absolute
-path that has no symbolic link, \grammarterm{dot}, or \grammarterm{dot-dot} elements
+path that has no symbolic link, dot, or dot-dot elements
 in its pathname in the generic format.
 
 \pnum


### PR DESCRIPTION
Fixes #1527.