### PR TITLE
[fs.path.decompose] 'root-path' is not a grammar non-terminal     

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -12190,7 +12190,7 @@ path relative_path() const;
 \pnum
 \returns A \tcode{path} composed from the pathname in the generic format,
 if \tcode{empty()} is \tcode{false}, beginning
-with the first \grammarterm{filename} after \grammarterm{root-path}. Otherwise, \tcode{path()}.
+with the first \grammarterm{filename} after \tcode{root_path()}. Otherwise, \tcode{path()}.
 \end{itemdescr}
 
 \indexlibrarymember{parent_path}{path}%


### PR DESCRIPTION
Use the function call root_path() instead.