### PR TITLE
Use 'anonymous union object' where appropriate.

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -861,7 +861,7 @@ shall be initialized;
 
 \item
 if the class is a union-like class, but is not a union, for each of its anonymous union
-members having variant members, exactly one of them shall be initialized;
+objects having variant members, exactly one of them shall be initialized;
 
 \item
 for a non-delegating constructor, every constructor selected to initialize non-static

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -2596,7 +2596,7 @@ if \tcode{T} is a union with at least one non-static data member,
 exactly one variant member has a default member initializer,
 \item
 if \tcode{T} is not a union,
-for each anonymous union member with at least one non-static data member (if any),
+for each anonymous union object with at least one non-static data member (if any),
 exactly one non-static data member has a default member initializer, and
 \item
 each potentially constructed base class of \tcode{T} is const-default-constructible.
@@ -3206,7 +3206,7 @@ struct S {
 \pnum
 \begin{note}
 Static data members,
-non-static data members of anonymous union members,
+non-static data members of anonymous union objects,
 and
 unnamed bit-fields
 are not considered elements of the aggregate.

--- a/source/special.tex
+++ b/source/special.tex
@@ -193,7 +193,7 @@ thereof) with no \grammarterm{brace-or-equal-initializer} does not have a user-p
 \item \tcode{X} is a union and all of its variant members are of const-qualified
 type (or array thereof),
 
-\item \tcode{X} is a non-union class and all members of any anonymous union member are
+\item \tcode{X} is a non-union class and all members of any anonymous union subobject are
 of const-qualified type (or array thereof),
 
 \item any potentially constructed subobject, except for a non-static data member


### PR DESCRIPTION
The term was introduced by CWG 1860.

Fixes #973.