### PR TITLE
[utilities] Remove \placeholder when naming a specific type

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1811,19 +1811,19 @@ template<class T> class tuple_size<const volatile T>;
 
 \begin{itemdescr}
 \pnum
-Let \tcode{\placeholder{TS}} denote \tcode{tuple_size<T>} of the \cv-unqualified type \tcode{T}.
-If the expression \tcode{\placeholder{TS}::value} is well-formed
+Let \tcode{TS} denote \tcode{tuple_size<T>} of the \cv-unqualified type \tcode{T}.
+If the expression \tcode{TS::value} is well-formed
 when treated as an unevaluated operand, then each
 of the three templates shall meet the \tcode{UnaryTypeTrait} requirements\iref{meta.rqmts}
 with a base characteristic of
 \begin{codeblock}
-integral_constant<size_t, @\placeholder{TS}@::value>
+integral_constant<size_t, TS::value>
 \end{codeblock}
 Otherwise, they shall have no member \tcode{value}.
 
 \pnum
 Access checking is performed as if in a context
-unrelated to \tcode{\placeholder{TS}} and \tcode{T}.
+unrelated to \tcode{TS} and \tcode{T}.
 Only the validity of the immediate context of the expression is considered.
 \begin{note}
 The compilation of the expression can result in side effects
@@ -1848,18 +1848,18 @@ template<size_t I, class T> class tuple_element<I, const volatile T>;
 
 \begin{itemdescr}
 \pnum
-Let \tcode{\placeholder{TE}} denote \tcode{tuple_element_t<I, T>} of the \cv-unqualified type \tcode{T}. Then
+Let \tcode{TE} denote \tcode{tuple_element_t<I, T>} of the \cv-unqualified type \tcode{T}. Then
 each of the three templates shall meet the \tcode{TransformationTrait}
 requirements\iref{meta.rqmts} with a member typedef \tcode{type} that names the following
 type:
 
 \begin{itemize}
 \item
-for the first specialization, \tcode{add_const_t<\placeholder{TE}>},
+for the first specialization, \tcode{add_const_t<TE>},
 \item
-for the second specialization, \tcode{add_volatile_t<\placeholder{TE}>}, and
+for the second specialization, \tcode{add_volatile_t<TE>}, and
 \item
-for the third specialization, \tcode{add_cv_t<\placeholder{TE}>}.
+for the third specialization, \tcode{add_cv_t<TE>}.
 \end{itemize}
 
 \pnum
@@ -8877,22 +8877,22 @@ template<class T1, class D1, class T2, class D2>
 
 \begin{itemdescr}
 \pnum
-\requires Let \tcode{\placeholder{CT}} denote
+\requires Let \tcode{CT} denote
 \begin{codeblock}
 common_type_t<typename unique_ptr<T1, D1>::pointer,
               typename unique_ptr<T2, D2>::pointer>
 \end{codeblock}
 Then the specialization
-\tcode{less<\placeholder{CT}>} shall be a function object type\iref{function.objects} that
+\tcode{less<CT>} shall be a function object type\iref{function.objects} that
 induces a strict weak ordering\iref{alg.sorting} on the pointer values.
 
 \pnum
-\returns \tcode{less<\placeholder{CT}>()(x.get(), y.get())}.
+\returns \tcode{less<CT>()(x.get(), y.get())}.
 
 \pnum
 \remarks If \tcode{unique_ptr<T1, D1>::pointer} is not implicitly convertible
-to \tcode{\placeholder{CT}} or \tcode{unique_ptr<T2, D2>::pointer} is not implicitly
-convertible to \tcode{\placeholder{CT}}, the program is ill-formed.
+to \tcode{CT} or \tcode{unique_ptr<T2, D2>::pointer} is not implicitly
+convertible to \tcode{CT}, the program is ill-formed.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=}{unique_ptr}%
@@ -18294,7 +18294,7 @@ template<class Rep1, class Period1, class Rep2, class Period2>
 \rSec3[time.duration.comparisons]{\tcode{duration} comparisons}
 
 \pnum
-In the function descriptions that follow, \tcode{\placeholder{CT}} represents
+In the function descriptions that follow, \tcode{CT} represents
 \tcode{common_type_t<A, B>}, where \tcode{A} and \tcode{B} are the types of
 the two arguments to the function.
 
@@ -18307,7 +18307,7 @@ template<class Rep1, class Period1, class Rep2, class Period2>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{\placeholder{CT}(lhs).count() == \placeholder{CT}(rhs).count()}.
+\returns \tcode{CT(lhs).count() == CT(rhs).count()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator"!=}{duration}%
@@ -18331,7 +18331,7 @@ template<class Rep1, class Period1, class Rep2, class Period2>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{\placeholder{CT}(lhs).count() < \placeholder{CT}(rhs).count()}.
+\returns \tcode{CT(lhs).count() < CT(rhs).count()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=}{duration}%
@@ -18760,7 +18760,7 @@ template<class Clock, class Duration1, class Rep2, class Period2>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{\placeholder{CT}(lhs.time_since_epoch() + rhs)}, where \tcode{\placeholder{CT}} is the type of the return value.
+\returns \tcode{CT(lhs.time_since_epoch() + rhs)}, where \tcode{CT} is the type of the return value.
 \end{itemdescr}
 
 \indexlibrarymember{operator+}{time_point}%
@@ -18786,8 +18786,8 @@ template<class Clock, class Duration1, class Rep2, class Period2>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{\placeholder{CT}(lhs.time_since_epoch() - rhs)},
-where \tcode{\placeholder{CT}} is the type of the return value.
+\returns \tcode{CT(lhs.time_since_epoch() - rhs)},
+where \tcode{CT} is the type of the return value.
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{time_point}%


### PR DESCRIPTION
Partially addresses #916.