### PR TITLE
Fix misuses of \grammarterm for other purposes

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2240,9 +2240,9 @@ void B::f(::A* a) {
 If the \grammarterm{id-expression} in a class member access is a
 \grammarterm{qualified-id} of the form
 \begin{codeblock}
-class-name-or-namespace-name::...
+@\placeholder{class-name-or-namespace-name}@::...
 \end{codeblock}
-the \grammarterm{class-name-or-namespace-name} following the \tcode{.} or
+the \placeholder{class-name-or-namespace-name} following the \tcode{.} or
 \tcode{->} operator is
 first looked up in the class of the object expression and the name, if found,
 is used. Otherwise it is looked up in the context of the entire
@@ -2253,9 +2253,9 @@ or namespace name. \end{note}
 \pnum
 If the \grammarterm{qualified-id} has the form
 \begin{codeblock}
-::class-name-or-namespace-name::...
+::@\placeholder{class-name-or-namespace-name}@::...
 \end{codeblock}
-the \grammarterm{class-name-or-namespace-name} is looked up in global scope
+the \placeholder{class-name-or-namespace-name} is looked up in global scope
 as a \grammarterm{class-name} or \grammarterm{namespace-name}.
 
 \pnum

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1961,7 +1961,7 @@ declared with the \grammarterm{constrained-parameter}.
 A \grammarterm{cv-qualifier-seq} \cv{} is formed
 as the union of \tcode{const} and \tcode{volatile} specifiers
 around the \grammarterm{constrained-parameter}.
-\tcode{F} has a single \grammarterm{parameter}
+\tcode{F} has a single parameter
 whose \grammarterm{type-specifier} is \cv{}~\tcode{T}
 followed by the \grammarterm{abstract-declarator}.
 %%% FIXME: Remove this; if deduction fails, the construct should

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -349,7 +349,7 @@ Alternative token representations are provided for some operators and
 punctuators.\footnote{\indextext{digraph}%
 These include ``digraphs'' and additional reserved words. The term
 ``digraph'' (token consisting of two characters) is not perfectly
-descriptive, since one of the alternative preprocessing-tokens is
+descriptive, since one of the alternative \grammarterm{preprocessing-token}s is
 \tcode{\%:\%:} and of course several primary tokens contain two
 characters. Nonetheless, those alternative tokens that aren't lexical
 keywords are colloquially known as ``digraphs''. }

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -832,11 +832,11 @@ of ($\tcode{P}_1, \dotsc, \tcode{P}_n$) returning \tcode{R}'',
 or the type
 ``reference to function of ($\tcode{P}_1, \dotsc, \tcode{P}_n$)
 returning \tcode{R}'', a \term{surrogate call function} with the unique name
-\grammarterm{call-function}
+\placeholder{call-function}
 and having the form
 
 \begin{ncbnf}
-\terminal{R} call-function \terminal{(} conversion-type-id \ %
+\terminal{R} \placeholder{call-function} \terminal{(} conversion-type-id \ %
 \terminal{F, P$_1$ a$_1$, $\dotsc$, P$_n$ a$_n$)} \terminal{\{ return F (a$_1$, $\dotsc$, a$_n$); \}}
 \end{ncbnf}
 

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -775,7 +775,7 @@ The identifier \mname{VA_OPT}
 shall always occur as part of the token sequence
 \mname{VA_OPT}\tcode{(}\placeholder{content}\tcode{)},
 where \placeholder{content} is
-an arbitrary sequence of \grammarterm{preprocessing-tokens}
+an arbitrary sequence of \grammarterm{preprocessing-token}s
 other than \mname{VA_OPT},
 which is terminated by the closing \tcode{)}
 and skips intervening pairs of matching left and right parentheses.


### PR DESCRIPTION
Partially addresses #1543.