### PR TITLE
[class] Replace \term with \defn or \defnx

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -67,10 +67,8 @@ declared immediately after the \grammarterm{class-name} is seen. The
 itself; this is known as the \defn{injected-class-name}.
 For purposes of access checking, the injected-class-name is treated as
 if it were a public member name.
-\indextext{definition!class}%
-A \grammarterm{class-specifier} is commonly referred to as a class
-definition.
-\indextext{definition!class}%
+A \grammarterm{class-specifier} is commonly referred to as a \defnx{class
+definition}{definition!class}.
 A class is considered defined after the closing brace of its
 \grammarterm{class-specifier} has been seen even though its member
 functions are in general not yet defined.
@@ -112,7 +110,7 @@ as equality comparison, can be defined by the user; see~\ref{over.oper}.
 \indextext{\idxcode{struct}!\tcode{class} versus}%
 \indextext{structure}%
 \indextext{\idxcode{union}!\tcode{class} versus}%
-A \term{union} is a class defined with the \grammarterm{class-key}
+A \defn{union} is a class defined with the \grammarterm{class-key}
 \tcode{union};
 \indextext{access control!\idxcode{union} default member}%
 it holds at most one data member at a time\iref{class.union}.
@@ -120,11 +118,9 @@ it holds at most one data member at a time\iref{class.union}.
 Aggregates of class type are described in~\ref{dcl.init.aggr}.
 \end{note}
 
-\indextext{class!trivial}%
-\indextext{trivial class}%
-\indextext{class!trivially copyable}%
+\indextext{trivial class|see{class, trivial}}%
 \pnum
-A \defn{trivially copyable class} is a class:
+A \defnx{trivially copyable class}{class!trivially copyable} is a class:
 
 \begin{itemize}
 \item where each copy constructor, move constructor, copy assignment operator,
@@ -135,16 +131,16 @@ copy assignment operator, or move assignment operator, and
 \item that has a trivial, non-deleted destructor\iref{class.dtor}.
 \end{itemize}
 
-A \term{trivial class} is a class that is trivially copyable and
+A \defnx{trivial class}{class!trivial} is a class that is trivially copyable and
 has one or more default constructors\iref{class.ctor},
 all of which are either trivial or deleted and
 at least one of which is not deleted.
 \begin{note} In particular, a trivially copyable or trivial class does not have
 virtual functions or virtual base classes.\end{note}
 
-\indextext{class!standard-layout}%
+\indextext{standard-layout|see{class, standard-layout}}%
 \pnum
-A class \tcode{S} is a \defn{standard-layout class} if it:
+A class \tcode{S} is a \defnx{standard-layout class}{class!standard-layout} if it:
 \begin{itemize}
 \item has no non-static data members of type non-standard-layout class
 (or array of such types) or reference,
@@ -210,13 +206,11 @@ in \tcode{X}. \end{note}
 \end{codeblock}
 \end{example}
 
-\indextext{struct!standard-layout}%
-\indextext{union!standard-layout}%
 \pnum
-A \defn{standard-layout struct} is a standard-layout class
+A \defnx{standard-layout struct}{struct!standard-layout} is a standard-layout class
 defined with the \grammarterm{class-key} \tcode{struct} or the
 \grammarterm{class-key} \tcode{class}.
-A \defn{standard-layout union} is a standard-layout class
+A \defnx{standard-layout union}{union!standard-layout} is a standard-layout class
 defined with the
 \grammarterm{class-key} \tcode{union}.
 
@@ -815,7 +809,7 @@ pointer-interconvertible~(\ref{basic.compound}, \ref{expr.static.cast}).
 \indextext{member function!inline}%
 \indextext{definition!member function}%
 A member function may be defined\iref{dcl.fct.def} in its class
-definition, in which case it is an \term{inline} member
+definition, in which case it is an inline member
 function\iref{dcl.inline}, or it may be defined outside of its class
 definition if it has already been declared but not defined in its class
 definition. A member function definition that appears outside of the
@@ -1029,7 +1023,7 @@ A non-static member function may be declared with a \grammarterm{ref-qualifier}\
 
 \pnum
 A non-static member function may be declared
-\term{virtual}\iref{class.virtual} or \term{pure virtual}\iref{class.abstract}.
+virtual\iref{class.virtual} or pure virtual\iref{class.abstract}.
 
 \rSec3[class.this]{The \tcode{this} pointer}%
 \indextext{\idxcode{this}}


### PR DESCRIPTION
and slightly adjust indexing.

Partially addresses #329.