### PR TITLE
[diff.mods.to.headers] De-index non-existent headers

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1926,9 +1926,9 @@ in~\ref{depr.c.headers}, but their use is deprecated in \Cpp{}.
 
 \pnum
 There are no \Cpp{} headers for the C headers
-\tcode{<stdatomic.h>}\indexhdr{stdatomic.h},
-\tcode{<stdnoreturn.h>}\indexhdr{stdnoreturn.h},
-and \tcode{<threads.h>}\indexhdr{threads.h},
+\tcode{<stdatomic.h>},
+\tcode{<stdnoreturn.h>},
+and \tcode{<threads.h>},
 nor are the C headers themselves part of \Cpp{}.
 
 \pnum

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1129,9 +1129,6 @@ The facilities of the C standard library are provided in the
 additional headers shown in Table~\ref{tab:cpp.c.headers}.%
 \footnote{It is intentional that there is no \Cpp{} header
 for any of these C headers:
-\indexhdr{stdatomic.h}%
-\indexhdr{stdnoreturn.h}%
-\indexhdr{threads.h}%
 \tcode{<stdatomic.h>},
 \tcode{<stdnoreturn.h>},
 \tcode{<threads.h>}.}


### PR DESCRIPTION
Three C11 headers are called out as not being part of C++.
They should not be listed in the index of headers, which
currently points to the two places that explicitly state
these headers do not exist.