### PR TITLE
[dcl.struct.bind] Clarify that structured bindings are entities (as contrast to names)

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -2294,8 +2294,8 @@ sometype::sometype() = delete;  // ill-formed; not first declaration
 A structured binding declaration introduces the \grammarterm{identifier}{s}
 \tcode{v}$_0$, \tcode{v}$_1$, \tcode{v}$_2$, ...
 of the
-\grammarterm{identifier-list} as names\iref{basic.scope.declarative},
-called \defn{structured binding}{s}.
+\grammarterm{identifier-list} as names\iref{basic.scope.declarative}
+of \defn{structured binding}{s}.
 Let \cv{} denote the
 \grammarterm{cv-qualifier}{s} in the \grammarterm{decl-specifier-seq}. First, a
 variable with a unique name \tcode{e} is introduced. If the


### PR DESCRIPTION
[basic]/3:

> An *entity* is a value, object, reference, structured binding, function, enumerator, type, class member, bit-field, template, template specialization, namespace, or parameter pack.

The term "structured binding" is consistently used to denote a kind of entity, e.g. [dcl.type.simple]/(4.1):

> if e is an unparenthesized id-expression naming a structured binding, ...

Saying that something names a name would be nonsense.