### PR TITLE
[temp.dep.type] Clarify that a simple-template-id denotes a type

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -4972,8 +4972,7 @@ bound (if any) is value-dependent,
 \item
 a function type whose exception specification is value-dependent,
 \item
-a
-\grammarterm{simple-template-id}
+denoted by a \grammarterm{simple-template-id}
 in which either the template name is a template parameter or any of the
 template arguments is a dependent type or an expression that is type-dependent
 or value-dependent or is a pack expansion


### PR DESCRIPTION
It's not quite correct to say it "is" a type; in particular if the following "decltype" bullet also uses "denotes".