### PR TITLE
Use 'one of' formulation for binary-digit

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -869,9 +869,8 @@ ISO C. }
 \end{bnf}
 
 \begin{bnf}
-\nontermdef{binary-digit}\br
-    \terminal{0}\br
-    \terminal{1}
+\nontermdef{binary-digit} \textnormal{one of}\br
+    \terminal{0  1}
 \end{bnf}
 
 \begin{bnf}


### PR DESCRIPTION
The grammar for literals consistently prefers using the 'one of' a set
formulation for character sets, rather than listing each character as
an option.  This holds for other parts of this grammar, even when the
set of options is just two items, such as hexadecimal-prefix,
unsigned-suffix, or long-suffix.

As binary-digit is the odd one out, this simple update makes it
consistent with the rest of the grammar specifications in this
clause.