### PR TITLE
[re.regex.construct] Add default argument to itemdecl

### DIFF
--- a/source/regex.tex
+++ b/source/regex.tex
@@ -1478,7 +1478,7 @@ within the expression.
 
 \indexlibrary{\idxcode{basic_regex}!constructor}%
 \begin{itemdecl}
-basic_regex(const charT* p, size_t len, flag_type f);
+basic_regex(const charT* p, size_t len, flag_type f = regex_constants::ECMAScript);
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
The class synopsis shows this default argument, so it should be repeated in the itemdecl too.