### PR TITLE
[variant.visit] qualify std::forward for consistency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   - BUILD_TYPE=make      # build using Makefile
   - BUILD_TYPE=complete  # build manually and regenerate figures, grammar, and cross-references
   - BUILD_TYPE=check-whitespace  # check for whitespace at the ends of lines
+  - BUILD_TYPE=check-newlines  # check for blank lines at the ends of files
 
 script:
   # Build std.pdf
@@ -37,6 +38,10 @@ script:
   # Fail if there is whitespace at the ends of any lines
   - if [ "$BUILD_TYPE" = "check-whitespace" ]; then
       ! grep '\s$' source/*.tex;
+    fi
+  # Fail if there are blank lines at the ends of any files
+  - if [ "$BUILD_TYPE" = "check-newlines" ]; then
+      for f in source/*.tex; do [ $(tail -c 2 $f | wc -l) -eq 1 ] || exit 1; done;
     fi
   # Check to see if generated files are out-dated
   - pushd source

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -4845,8 +4845,10 @@ The expression in the \effects element shall be a valid expression of the same
 
 \pnum
 \effects
-Let \tcode{is...} be \tcode{vars.index()...}. Returns \tcode{\placeholdernc{INVOKE}(forward<Visitor>(vis), get<is>(}\brk{}
-\tcode{forward<Variants>(vars))...);}\iref{func.require}.
+Let \tcode{is...} be \tcode{vars.index()...}. Returns:
+\begin{codeblock}
+@\placeholdernc{INVOKE}@(std::forward<Visitor>(vis), get<is>(std::forward<Variants>(vars))...) // see \ref{func.require}
+\end{codeblock}
 
 \pnum
 \remarks
@@ -19782,4 +19784,3 @@ closest to the value of the string matching the pattern.
 \end{itemdescr}
 
 \xref ISO C 7.22.1.3, 7.22.1.4
-


### PR DESCRIPTION
...because Library always qualifies `move` and `forward`.

Also, my editor hates extra newlines at end-of-file. 