### PR TITLE
[dcl.enum] use indefinite article before "fixed underlying type"

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2028,7 +2028,7 @@ The optional \grammarterm{attribute-specifier-seq} in an
 An \grammarterm{opaque-enum-declaration} is either a redeclaration
 of an enumeration in the current scope or a declaration of a new enumeration.
 \begin{note} An enumeration declared by an
-\grammarterm{opaque-enum-declaration} has fixed underlying type and is a
+\grammarterm{opaque-enum-declaration} has a fixed underlying type and is a
 complete type. The list of enumerators can be provided in a later redeclaration
 with an \grammarterm{enum-specifier}. \end{note} A scoped enumeration
 shall not be later redeclared as unscoped or with a different underlying type.


### PR DESCRIPTION
Everywhere else we say that an enumeration type has _a_ fixed underlying type.