### PR TITLE
[namespace.udir] Ambiguous lookup results are covered in [basic.lookup]

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3238,10 +3238,10 @@ extending \grammarterm{namespace-definition} can be used after the
 extending \grammarterm{namespace-definition}.
 
 \pnum
+\begin{note}
 If name lookup finds a declaration for a name in two different
 namespaces, and the declarations do not declare the same entity and do
-not declare functions, the use of the name is ill-formed.
-\begin{note}
+not declare functions or function templates, the use of the name is ill-formed\iref{basic.lookup}.
 In particular, the name of a variable, function or enumerator does not
 hide the name of a class or enumeration declared in a different
 namespace. For example,


### PR DESCRIPTION
Relegate a duplicate normative statement in [namespace.udir]
to a note and add a cross-reference to [basic.lookup].