### PR TITLE
Harmonize wording about reallocation invalidating pointers in `vector`

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -3635,8 +3635,9 @@ of a non-\tcode{CopyInsertable} \tcode{T} there are no effects.
 \complexity Linear in the size of the sequence.
 
 \pnum
-\remarks \tcode{shrink_to_fit} invalidates all the references, pointers, and iterators
-referring to the elements in the sequence as well as the past-the-end iterator.
+\remarks
+\tcode{shrink_to_fit} invalidates all the references, pointers, and iterators
+referring to the elements in the sequence, as well as the past-the-end iterator.
 \end{itemdescr}
 
 \rSec3[deque.modifiers]{\tcode{deque} modifiers}
@@ -5413,7 +5414,8 @@ may throw an appropriate exception.}
 \pnum
 \remarks
 Reallocation invalidates all the references, pointers, and iterators
-referring to the elements in the sequence.
+referring to the elements in the sequence, as well as the past-the-end iterator.
+\begin{note} If no reallocation takes place, they remain valid. \end{note}
 No reallocation shall take place during insertions that happen
 after a call to
 \tcode{reserve()}
@@ -5445,9 +5447,10 @@ of a non-\tcode{CopyInsertable} \tcode{T} there are no effects.
 \complexity Linear in the size of the sequence.
 
 \pnum
-\remarks Reallocation invalidates all the references, pointers, and iterators
-referring to the elements in the sequence as well as the past-the-end iterator.
-If no reallocation happens, they remain valid.
+\remarks
+Reallocation invalidates all the references, pointers, and iterators
+referring to the elements in the sequence, as well as the past-the-end iterator.
+\begin{note} If no reallocation takes place, they remain valid. \end{note}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{swap}!\idxcode{vector}}%
@@ -5551,8 +5554,11 @@ void push_back(T&& x);
 \remarks
 Causes reallocation if the new size is greater than the old capacity.
 Reallocation invalidates all the references, pointers, and iterators
-referring to the elements in the sequence.
-If no reallocation happens, all the iterators and references before the insertion point remain valid.
+referring to elements in the sequence, as well as the past-the-end iterator.
+If no reallocation happens, all references, pointers, and iterators
+referring to elements before the insertion point remain valid; all other
+references, pointers, and iterators referring to elements in the sequence,
+as well as the past-the-end iterator, are invalidated.
 If an exception is thrown other than by
 the copy constructor, move constructor,
 assignment operator, or move assignment operator of

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -1749,9 +1749,10 @@ by causing reallocation.
 \complexity Linear in the size of the sequence.
 
 \pnum
-\remarks Reallocation invalidates all the references, pointers, and iterators
-referring to the elements in the sequence as well as the past-the-end iterator.
-If no reallocation happens, they remain valid.
+\remarks
+Reallocation invalidates all the references, pointers, and iterators
+referring to the elements in the sequence, as well as the past-the-end iterator.
+\begin{note} If no reallocation takes place, they remain valid. \end{note}
 \end{itemdescr}
 
 \indexlibrarymember{clear}{basic_string}%


### PR DESCRIPTION
`reserve`, `shrink_to_fit`, and `push_back/emplace_back/insert`
all use versions of the same wording. This eliminates unintentional
differences between their wordings.

Prompted by Hubert Tong's mail "[isocpp-lib] Validity of vector
iterators after non-reallocating insertion".