### PR TITLE
Fix decay index redirects.

### DIFF
--- a/source/conversions.tex
+++ b/source/conversions.tex
@@ -194,8 +194,8 @@ See also~\ref{basic.lval}.\end{note}
 
 \pnum
 \indextext{conversion!array-to-pointer}%
-\indextext{decay!array|see{conversion, array to pointer}}%
-\indextext{decay!function|see{conversion, function to pointer}}%
+\indextext{decay!array|see{conversion, array-to-pointer}}%
+\indextext{decay!function|see{conversion, function-to-pointer}}%
 An lvalue or rvalue of type ``array of \tcode{N} \tcode{T}'' or ``array
 of unknown bound of \tcode{T}'' can be converted to a prvalue of type
 ``pointer to \tcode{T}''.


### PR DESCRIPTION
The mismatch currently causes broken links at [eel.is/c++draft/generalindex](http://eel.is/c++draft/generalindex#:decay).