### PR TITLE
Atomic cmpxchg note clarification

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -931,7 +931,8 @@ would not, the strong one is preferable.
 \begin{note} The \tcode{memcpy} and \tcode{memcmp} semantics of the compare-and-exchange
 operations may result in failed comparisons for values that compare equal with
 \tcode{operator==} if the underlying type has padding bits, trap bits, or alternate
-representations of the same value.\end{note}
+representations of the same value. Notably, floating-point \tcode{-0.} and \tcode{0.}
+will compare not-equal and NaNs with the same payload will compare equal.\end{note}
 \end{itemdescr}
 
 \rSec2[atomics.types.int]{Specializations for integers}

--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -933,7 +933,9 @@ operations may result in failed comparisons for values that compare equal with
 \tcode{operator==} if the underlying type has padding bits, trap bits, or alternate
 representations of the same value. Notably, on implementations conforming to
 ISO/IEC/IEEE 60559, floating-point \tcode{-0.0} and \tcode{+0.0}
-will compare not-equal and NaNs with the same payload will compare equal.\end{note}
+will not compare equal with \tcode{memcmp} but will compare equal with \tcode{operator==},
+and NaNs with the same payload will compare equal with \tcode{memcmp} but will not
+compare equal with \tcode{operator==}.\end{note}
 \end{itemdescr}
 
 \rSec2[atomics.types.int]{Specializations for integers}

--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -931,7 +931,7 @@ would not, the strong one is preferable.
 \begin{note} The \tcode{memcpy} and \tcode{memcmp} semantics of the compare-and-exchange
 operations may result in failed comparisons for values that compare equal with
 \tcode{operator==} if the underlying type has padding bits, trap bits, or alternate
-representations of the same value. Notably, floating-point \tcode{-0.} and \tcode{0.}
+representations of the same value. Notably, floating-point \tcode{-0.0} and \tcode{+0.0}
 will compare not-equal and NaNs with the same payload will compare equal.\end{note}
 \end{itemdescr}
 

--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -931,7 +931,8 @@ would not, the strong one is preferable.
 \begin{note} The \tcode{memcpy} and \tcode{memcmp} semantics of the compare-and-exchange
 operations may result in failed comparisons for values that compare equal with
 \tcode{operator==} if the underlying type has padding bits, trap bits, or alternate
-representations of the same value. Notably, floating-point \tcode{-0.0} and \tcode{+0.0}
+representations of the same value. Notably, on implementations conforming to
+ISO/IEC/IEEE 60559, floating-point \tcode{-0.0} and \tcode{+0.0}
 will compare not-equal and NaNs with the same payload will compare equal.\end{note}
 \end{itemdescr}
 


### PR DESCRIPTION
We now have explicit floating-point specializations for atomic. We had cmpxchg for them before, but people are now looking at increased usage and are confused about what the behavior is for `-0.` with `0.`, as well as NaNs. I propose clarifying the note to make this extra clear. This is a note and is therefore purely editorial, and would be a waste of SG1's time.