### PR TITLE
[contents,fs.req.namespace] Qualify only namespace-scope names LWG2818

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -927,7 +927,7 @@ support multiple configurations of the library.
 \end{footnote}
 
 \pnum
-Whenever an unqualified name is used
+Whenever an unqualified name other than \tcode{swap} is used
 in the specification of a declaration \tcode{D}
 in \ref{\firstlibchapter} through \ref{\lastlibchapter} or \ref{depr},
 its meaning is established
@@ -946,6 +946,9 @@ The reference to \tcode{is_array_v} in the specification of \tcode{std::to_array
 Operators in expressions\iref{over.match.oper} are not so constrained;
 see \ref{global.functions}.
 \end{note}
+The meaning of the unqualified name \tcode{swap} is established
+in an overload resolution context
+for swappable values\iref{swappable.requirements}.
 
 \rSec3[headers]{Headers}
 


### PR DESCRIPTION
It does not make sense to attempt to qualify class members
with a nested-name-specifier consisting of namespace-names.

Fixes #1793.