### PR TITLE
[expr.typeid, time.syn, class.access.base] Replace \term with \placeholder where appropriate.

### DIFF
--- a/source/access.tex
+++ b/source/access.tex
@@ -391,7 +391,7 @@ of
 is
 \term{accessible}
 at
-\term{R},
+\placeholder{R},
 if
 \begin{itemize}
 \item
@@ -400,7 +400,7 @@ an invented public member of
 would be a public member of
 \tcode{N}, or
 \item
-\term{R}
+\placeholder{R}
 occurs in a member or friend of class
 \tcode{N},
 and an invented public member of
@@ -408,7 +408,7 @@ and an invented public member of
 would be a private or protected member of
 \tcode{N}, or
 \item
-\term{R}
+\placeholder{R}
 occurs in a member or friend of a class
 \tcode{P}
 derived from
@@ -425,13 +425,13 @@ such that
 is a base class of
 \tcode{S}
 accessible at
-\term{R}
+\placeholder{R}
 and
 \tcode{S}
 is a base class of
 \tcode{N}
 accessible at
-\term{R}.
+\placeholder{R}.
 \end{itemize}
 
 \begin{example}
@@ -492,7 +492,7 @@ of the
 A member
 \tcode{m}
 is accessible at the point
-\term{R}
+\placeholder{R}
 when named in class
 \tcode{N}
 if
@@ -507,7 +507,7 @@ is public, or
 as a member of
 \tcode{N}
 is private, and
-\term{R}
+\placeholder{R}
 occurs in a member or friend of class
 \tcode{N},
 or
@@ -516,7 +516,7 @@ or
 as a member of
 \tcode{N}
 is protected, and
-\term{R}
+\placeholder{R}
 occurs in a member or friend of class
 \tcode{N},
 or in a member of a class
@@ -534,11 +534,11 @@ there exists a base class
 of
 \tcode{N}
 that is accessible at
-\term{R},
+\placeholder{R},
 and
 \tcode{m}
 is accessible at
-\term{R}
+\placeholder{R}
 when named in class
 \tcode{B}.
 \begin{example}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2770,7 +2770,7 @@ The result of a \tcode{typeid} expression is an lvalue of static type
 \indextext{\idxcode{type_info}}%
 \indexlibrary{\idxcode{type_info}}%
 \tcode{const} \tcode{std::type_info}\iref{type.info} and dynamic type \tcode{const}
-\tcode{std::type_info} or \tcode{const} \term{name} where \term{name} is an
+\tcode{std::type_info} or \tcode{const} \placeholder{name} where \placeholder{name} is an
 \impldef{derived type for \tcode{typeid}} class publicly derived from
 \tcode{std::type_info} which preserves the behavior described
 in~\ref{type.info}.\footnote{The recommended name for such a class is

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -17543,12 +17543,12 @@ namespace std {
       constexpr ToDuration round(const duration<Rep, Period>& d);
 
     // convenience typedefs
-    using nanoseconds  = duration<@\term{signed integer type of at least 64 bits}@, nano>;
-    using microseconds = duration<@\term{signed integer type of at least 55 bits}@, micro>;
-    using milliseconds = duration<@\term{signed integer type of at least 45 bits}@, milli>;
-    using seconds      = duration<@\term{signed integer type of at least 35 bits}@>;
-    using minutes      = duration<@\term{signed integer type of at least 29 bits}@, ratio<  60>>;
-    using hours        = duration<@\term{signed integer type of at least 23 bits}@, ratio<3600>>;
+    using nanoseconds  = duration<@\placeholder{signed integer type of at least 64 bits}@, nano>;
+    using microseconds = duration<@\placeholder{signed integer type of at least 55 bits}@, micro>;
+    using milliseconds = duration<@\placeholder{signed integer type of at least 45 bits}@, milli>;
+    using seconds      = duration<@\placeholder{signed integer type of at least 35 bits}@>;
+    using minutes      = duration<@\placeholder{signed integer type of at least 29 bits}@, ratio<  60>>;
+    using hours        = duration<@\placeholder{signed integer type of at least 23 bits}@, ratio<3600>>;
 
     // \ref{time.point.nonmember}, \tcode{time_point} arithmetic
     template<class Clock, class Duration1, class Rep2, class Period2>


### PR DESCRIPTION
No visible difference.