### PR TITLE
[intro.defs] Default template arguments are not part of the signature

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -251,7 +251,7 @@ name,
 parameter type list\iref{dcl.fct},
 enclosing namespace (if any),
 return type,
-\grammarterm{template-head},
+\grammarterm{template-head} (excluding default template arguments),
 and
 trailing \grammarterm{requires-clause}\iref{dcl.decl} (if any)
 
@@ -280,7 +280,7 @@ class of which the function is a member,
 \cv-qualifiers (if any),
 \grammarterm{ref-qualifier} (if any),
 return type (if any),
-\grammarterm{template-head},
+\grammarterm{template-head} (excluding default template arguments),
 and
 trailing \grammarterm{requires-clause}\iref{dcl.decl} (if any)
 


### PR DESCRIPTION
Fixes #1702.