### PR TITLE
Remove uses of 'concept' with ordinary English meaning.

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -1350,7 +1350,7 @@ parallelized and the manner in which they apply the element access functions.
 If an object is modified by an element access function,
 the algorithm will perform no other unsynchronized accesses to that object.
 The modifying element access functions are those
-which are specified as modifying the object in the relevant concept.
+which are specified as modifying the object.
 \begin{note}
 For example,
 \tcode{swap()}, \tcode{++}, \tcode{--}, \tcode{@=}, and assignments

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1,7 +1,7 @@
 %!TEX root = std.tex
-\rSec0[basic]{Basic concepts}
+\rSec0[basic]{Basics}
 
-\gramSec[gram.basic]{Basic concepts}
+\gramSec[gram.basic]{Basics}
 
 \pnum
 \begin{note} This Clause presents the basic concepts of the \Cpp{} language.

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -269,7 +269,7 @@ of \tcode{iterator_traits<X>}\iref{iterator.traits}. \end{note}
 \rSec2[iterator.iterators]{Iterator}
 
 \pnum
-The \tcode{Iterator} requirements form the basis of the iterator concept
+The \tcode{Iterator} requirements form the basis of the iterator
 taxonomy; every iterator satisfies the \tcode{Iterator} requirements. This
 set of requirements specifies operations for dereferencing and incrementing
 an iterator. Most algorithms will require additional operations to


### PR DESCRIPTION
Fixed #1659.