### PR TITLE
[rand.req.eng] Use \text, not \mbox, in math mode

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -1903,21 +1903,21 @@ according to \ref{strings} and \ref{input.output}.
     with the same initial state
     as all other default-constructed engines
     of type \tcode{E}.
-  & \bigoh{$\mbox{size of state}$}
+  & \bigoh{$\text{size of state}$}
   \\ \rowsep
 \tcode{E(x)}
 \indextext{copy constructor!random number engine requirement}
   &
   & Creates an engine
     that compares equal to \tcode{x}.
-  & \bigoh{$\mbox{size of state}$}
+  & \bigoh{$\text{size of state}$}
   \\ \rowsep
 \tcode{E(s)}%
 \indextext{constructor!random number engine requirement}
   &
   & Creates an engine
       with initial state determined by \tcode{s}.
-  & \bigoh{$\mbox{size of state}$}
+  & \bigoh{$\text{size of state}$}
   \\ \rowsep
 \tcode{E(q)}%
 \indextext{constructor!random number engine requirement}\footnote{  This constructor
@@ -1996,13 +1996,13 @@ according to \ref{strings} and \ref{input.output}.
     returns \tcode{true}
       if $ S_x = S_y $;
     else returns \tcode{false}.
-  & \bigoh{$\mbox{size of state}$}
+  & \bigoh{$\text{size of state}$}
   \\ \rowsep
 \tcode{x != y}%
 \indextext{\idxcode{operator"!=}!random number engine requirement}
   & \tcode{bool}
   & \tcode{!(x == y)}.
-  & \bigoh{$\mbox{size of state}$}
+  & \bigoh{$\text{size of state}$}
   \\ \rowsep
 \tcode{os << x}%
 \indextext{\idxcode{operator<<}!random number engine requirement}
@@ -2018,7 +2018,7 @@ according to \ref{strings} and \ref{input.output}.
     by one or more space characters.
 
     \postconditions The \tcode{os.}\textit{fmtflags} and fill character are unchanged.
-  & \bigoh{$\mbox{size of state}$}
+  & \bigoh{$\text{size of state}$}
   \\ \rowsep
 \tcode{is >> v}%
 \indextext{\idxcode{operator>>}!random number engine requirement}
@@ -2049,7 +2049,7 @@ according to \ref{strings} and \ref{input.output}.
     were respectively the same as those of \tcode{is}.
 
     \postconditions The \tcode{is.}\textit{fmtflags} are unchanged.
-  & \bigoh{$\mbox{size of state}$}
+  & \bigoh{$\text{size of state}$}
   \\
 \end{libreqtab4d}
 
@@ -2058,7 +2058,7 @@ according to \ref{strings} and \ref{input.output}.
 of \tcode{CopyConstructible} (Table~\ref{tab:copyconstructible})
 and \tcode{CopyAssignable} (Table~\ref{tab:copyassignable}) types.
 These operations shall each be of complexity
-no worse than \bigoh{\mbox{size of state}}.
+no worse than \bigoh{\text{size of state}}.
 
 
 \indextext{requirements!random number engine|)}


### PR DESCRIPTION
Fixes #1344.