### PR TITLE
[over.match.oper] Add a note for conversions on synthesized candidates.

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -497,7 +497,7 @@ The set of candidate functions can contain both member and non-member
 functions to be resolved against the same argument list.
 So that argument and parameter lists are comparable within this
 heterogeneous set, a member function is considered to have an
-extra parameter, called the
+extra first parameter, called the
 \defn{implicit object parameter},
 which represents the object for which the member function has been
 called.
@@ -509,13 +509,8 @@ but constructors do not.
 Similarly, when appropriate, the context can construct an
 argument list that contains an
 \defn{implied object argument}
-to denote
+as the first argument in the list to denote
 the object to be operated on.
-Since arguments and parameters are
-associated by position within their respective lists, the
-convention is that the implicit object parameter, if present, is
-always the first parameter and the implied object argument, if
-present, is always the first argument.
 
 \pnum
 For non-static member functions, the type of the implicit object
@@ -1089,6 +1084,11 @@ and
 synthesized \tcode{operator<=>} candidates
 are not considered for the recursive lookups.
 \end{itemize}
+\begin{note}
+A candidate synthesized from a member candidate has its implicit
+object parameter as the second parameter, thus implicit conversions
+are considered for the first, but not for the second, parameter.
+\end{note}
 
 \pnum
 The argument list contains all of the


### PR DESCRIPTION
Fixes #1926.