### PR TITLE
[string.classes] Remove class name repeated in subheadings

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -1142,7 +1142,7 @@ namespace std {
 }
 \end{codeblock}
 
-\rSec3[string.require]{\tcode{basic_string} general requirements}
+\rSec3[string.require]{General requirements}
 
 \pnum
 If any operation would cause \tcode{size()} to
@@ -1191,7 +1191,7 @@ and
 \tcode{rend}.
 \end{itemize}
 
-\rSec3[string.cons]{\tcode{basic_string} constructors and assignment operators}
+\rSec3[string.cons]{Constructors and assignment operators}
 
 \indexlibrary{\idxcode{basic_string}!constructor}%
 \begin{itemdecl}
@@ -1526,7 +1526,7 @@ basic_string& operator=(initializer_list<charT> il);
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\rSec3[string.iterators]{\tcode{basic_string} iterator support}
+\rSec3[string.iterators]{Iterator support}
 
 \indexlibrarymember{begin}{basic_string}%
 \indexlibrarymember{cbegin}{basic_string}%
@@ -1586,7 +1586,7 @@ An iterator which is semantically equivalent to
 \tcode{reverse_iterator(begin())}.
 \end{itemdescr}
 
-\rSec3[string.capacity]{\tcode{basic_string} capacity}
+\rSec3[string.capacity]{Capacity}
 
 \indexlibrarymember{size}{basic_string}%
 \begin{itemdecl}
@@ -1780,7 +1780,7 @@ erase(begin(), end());
 \tcode{size() == 0}.
 \end{itemdescr}
 
-\rSec3[string.access]{\tcode{basic_string} element access}
+\rSec3[string.access]{Element access}
 
 \indexlibrarymember{operator[]}{basic_string}%
 \begin{itemdecl}
@@ -1855,7 +1855,7 @@ charT& back();
 Equivalent to: \tcode{return operator[](size() - 1);}
 \end{itemdescr}
 
-\rSec3[string.modifiers]{\tcode{basic_string} modifiers}
+\rSec3[string.modifiers]{Modifiers}
 
 \rSec4[string.op+=]{\tcode{basic_string::operator+=}}
 
@@ -2909,9 +2909,9 @@ contains the same sequence of characters that was in \tcode{s},
 \complexity Constant time.
 \end{itemdescr}
 
-\rSec3[string.ops]{\tcode{basic_string} string operations}
+\rSec3[string.ops]{String operations}
 
-\rSec4[string.accessors]{\tcode{basic_string} accessors}
+\rSec4[string.accessors]{Accessors}
 
 \indexlibrarymember{c_str}{basic_string}%
 \indexlibrarymember{data}{basic_string}%
@@ -3651,7 +3651,7 @@ return basic_string_view<charT, traits>(data(), size()).ends_with(x);
 \end{codeblock}
 \end{itemdescr}
 
-\rSec2[string.nonmembers]{\tcode{basic_string} non-member functions}
+\rSec2[string.nonmembers]{Non-member functions}
 
 \indexlibrary{\idxcode{basic_string}}
 


### PR DESCRIPTION
Partially addresses #1242.