### PR TITLE
[fs.path.nonmember] Grammar

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -12658,7 +12658,7 @@ bool operator==(const path& lhs, const path& rhs) noexcept;
 \begin{note} Path equality and path equivalence have different semantics.
 \begin{itemize}
 \item Equality is determined by the \tcode{path} non-member \tcode{operator==},
-which considers the two path's lexical representations only.
+which considers the two paths' lexical representations only.
 \begin{example} \tcode{path("foo") == "bar"} is never \tcode{true}. \end{example}
 \item Equivalence is determined by the \tcode{equivalent()} non-member function, which
 determines if two paths resolve\iref{fs.class.path} to the same file system entity.


### PR DESCRIPTION
English plural possessives end with "s'".