### PR TITLE
[expr.dynamic.cast] Remove redundant statements on casting away constness

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2671,9 +2671,8 @@ type referred to by \tcode{T}. If \tcode{T} is an rvalue reference type,
 result is an xvalue of the type referred to by \tcode{T}.
 
 \pnum
-If the type of \tcode{v} is the same as \tcode{T}, or it is
-the same as \tcode{T} except that the class object type in \tcode{T} is
-more cv-qualified than the class object type in \tcode{v}, the result is
+If the type of \tcode{v} is the same as \tcode{T} (ignoring cv-qualifications),
+the result is
 \tcode{v} (converted if necessary).
 
 \pnum
@@ -2693,8 +2692,7 @@ object\iref{intro.object} pointed or referred to by
 \tcode{v} can contain other \tcode{B} objects as base classes, but these
 are ignored.}
 In both the pointer and
-reference cases, the program is ill-formed if \cvqual{cv2} has greater
-cv-qualification than \cvqual{cv1} or if \tcode{B} is an inaccessible or
+reference cases, the program is ill-formed if \tcode{B} is an inaccessible or
 ambiguous base class of \tcode{D}.
 \begin{example}
 


### PR DESCRIPTION
and fix the null pointer provision.

Fixes #1934.