### PR TITLE
[access] Remove inappropriate uses of \term

### DIFF
--- a/source/access.tex
+++ b/source/access.tex
@@ -90,13 +90,13 @@ void f() {
 \end{note}
 
 \pnum
-It should be noted that it is
-\term{access}
-to members and base classes that is controlled, not their
-\term{visibility}.
+\begin{note}
+Access to members and base classes is controlled, not their
+visibility\iref{basic.scope.hiding}.
 Names of members are still visible, and implicit conversions to base
 classes are still considered, when those members and base classes are
 inaccessible.
+\end{note}
 The interpretation of a given construct is
 established without regard to access control.
 If the interpretation
@@ -389,9 +389,9 @@ A base class
 of
 \tcode{N}
 is
-\term{accessible}
+\defn{accessible}
 at
-\term{R},
+\placeholder{R},
 if
 \begin{itemize}
 \item
@@ -400,7 +400,7 @@ an invented public member of
 would be a public member of
 \tcode{N}, or
 \item
-\term{R}
+\placeholder{R}
 occurs in a member or friend of class
 \tcode{N},
 and an invented public member of
@@ -408,7 +408,7 @@ and an invented public member of
 would be a private or protected member of
 \tcode{N}, or
 \item
-\term{R}
+\placeholder{R}
 occurs in a member or friend of a class
 \tcode{P}
 derived from
@@ -425,13 +425,13 @@ such that
 is a base class of
 \tcode{S}
 accessible at
-\term{R}
+\placeholder{R}
 and
 \tcode{S}
 is a base class of
 \tcode{N}
 accessible at
-\term{R}.
+\placeholder{R}.
 \end{itemize}
 
 \begin{example}
@@ -492,7 +492,7 @@ of the
 A member
 \tcode{m}
 is accessible at the point
-\term{R}
+\placeholder{R}
 when named in class
 \tcode{N}
 if
@@ -507,7 +507,7 @@ is public, or
 as a member of
 \tcode{N}
 is private, and
-\term{R}
+\placeholder{R}
 occurs in a member or friend of class
 \tcode{N},
 or
@@ -516,7 +516,7 @@ or
 as a member of
 \tcode{N}
 is protected, and
-\term{R}
+\placeholder{R}
 occurs in a member or friend of class
 \tcode{N},
 or in a member of a class
@@ -534,11 +534,11 @@ there exists a base class
 of
 \tcode{N}
 that is accessible at
-\term{R},
+\placeholder{R},
 and
 \tcode{m}
 is accessible at
-\term{R}
+\placeholder{R}
 when named in class
 \tcode{B}.
 \begin{example}


### PR DESCRIPTION
Also turns a "It should be noted that ..." sentence into a proper note.

Partially addresses #329.