### PR TITLE
[dcl.dcl] Replace \term with  \defn or \defnx

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -207,14 +207,14 @@ declared by the \grammarterm{init-declarator}.
 
 \pnum
 If the \grammarterm{decl-specifier-seq} contains the \tcode{typedef}
-specifier, the declaration is called a \term{typedef declaration} and the name
+specifier, the declaration is called a \defnx{typedef declaration}{declaration!typedef} and the name
 of each \grammarterm{init-declarator}
 is declared to be a \grammarterm{typedef-name}, synonymous with its
 associated type\iref{dcl.typedef}. If the
 \grammarterm{decl-specifier-seq} contains no \tcode{typedef} specifier, the
-declaration is called a \term{function declaration} if
+declaration is called a \defnx{function declaration}{declaration!function} if
 the type associated with the name is a function type\iref{dcl.fct} and
-an \term{object declaration} otherwise.
+an \defnx{object declaration}{declaration!object} otherwise.
 
 \pnum
 \indextext{definition!declaration as}%
@@ -978,7 +978,7 @@ or definition of a variable or function.
 \indextext{inline function}%
 A function declaration~(\ref{dcl.fct}, \ref{class.mfct},
 \ref{class.friend}) with an \tcode{inline} specifier declares an
-\term{inline function}. The inline specifier indicates to
+\defnx{inline function}{function!inline}. The inline specifier indicates to
 the implementation that inline substitution of the function body at the
 point of call is to be preferred to the usual function call mechanism.
 An implementation is not required to perform this inline substitution at
@@ -988,7 +988,7 @@ still be respected.
 
 \pnum
 A variable declaration with an \tcode{inline} specifier declares an
-\term{inline variable}.
+\defnx{inline variable}{variable!inline}.
 
 \pnum
 A function defined within a class definition is an inline function.
@@ -1990,11 +1990,11 @@ the declaration shall be an explicit specialization\iref{temp.expl.spec}.
 \indextext{enumeration}%
 The enumeration type declared with an \grammarterm{enum-key}
 of only \tcode{enum} is an \defnx{unscoped enumeration}{enumeration!unscoped},
-and its \grammarterm{enumerator}{s} are \term{unscoped enumerators}.
+and its \grammarterm{enumerator}{s} are \defnx{unscoped enumerators}{enumerator!unscoped}.
 The \grammarterm{enum-key}{s} \tcode{enum class} and
 \tcode{enum struct} are semantically equivalent; an enumeration
 type declared with one of these is a \defnx{scoped enumeration}{enumeration!scoped},
-and its \grammarterm{enumerator}{s} are \term{scoped enumerators}.
+and its \grammarterm{enumerator}{s} are \defnx{scoped enumerators}{enumerator!scoped}.
 The optional \grammarterm{identifier} shall not be omitted in the declaration of a scoped enumeration.
 The \grammarterm{type-specifier-seq} of an \grammarterm{enum-base}
 shall name an integral type; any cv-qualification is ignored.
@@ -2328,7 +2328,7 @@ namespace Outer {
 \end{example}
 
 \pnum
-The \term{enclosing namespaces} of a declaration are those
+The \defnx{enclosing namespaces}{namespace!enclosing} of a declaration are those
 namespaces in which the declaration lexically appears, except for a
 redeclaration of a namespace member outside its original namespace
 (e.g., a definition as specified in~\ref{namespace.memdef}). Such a
@@ -2353,7 +2353,7 @@ namespace Q {
 \pnum
 If the optional initial \tcode{inline} keyword appears in a
 \grammarterm{namespace-definition} for a particular namespace, that namespace is
-declared to be an \term{inline namespace}. The \tcode{inline} keyword may be
+declared to be an \defnx{inline namespace}{namespace!inline}. The \tcode{inline} keyword may be
 used on a \grammarterm{namespace-definition} that extends a namespace
 only if it was previously used on the \grammarterm{namespace-definition}
 that initially declared the \grammarterm{namespace-name} for that namespace.
@@ -2383,9 +2383,9 @@ there are declarations of that name in the enclosing namespace.
 These properties are transitive: if a namespace \tcode{N} contains an inline namespace
 \tcode{M}, which in turn contains an inline namespace \tcode{O}, then the members of
 \tcode{O} can be used as though they were members of \tcode{M} or \tcode{N}.
-The \term{inline namespace set} of \tcode{N} is the transitive closure of all
+The \defn{inline namespace set} of \tcode{N} is the transitive closure of all
 inline namespaces in \tcode{N}.
-The \term{enclosing namespace set} of \tcode{O} is the set of namespaces
+The \defn{enclosing namespace set} of \tcode{O} is the set of namespaces
 consisting of the innermost non-inline namespace enclosing
 an inline namespace \tcode{O}, together with any intervening inline namespaces.
 
@@ -2670,7 +2670,7 @@ in the \grammarterm{using-declaration}{'s} declarative region.
 \end{note}
 \indextext{inheritance!\idxgram{using-declaration} and}%
 If the \grammarterm{using-declarator} names a constructor,
-it declares that the class \term{inherits} the set of constructor declarations
+it declares that the class \defnx{inherits}{constructor!inherited} the set of constructor declarations
 introduced by the \grammarterm{using-declarator} from the nominated base class.
 
 \pnum
@@ -3351,7 +3351,7 @@ an assembler.
 
 \pnum
 All function types, function names with external linkage, and variable
-names with external linkage have a \term{language linkage}.
+names with external linkage have a \defn{language linkage}.
 \begin{note}
 Some of the properties associated with an entity with language linkage
 are specific to each implementation and are not described here. For


### PR DESCRIPTION
Partially addresses #329.