### PR TITLE
[fs.class.filesystem_error] Rephrase para 1 to avoid "class defines t…

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -12814,9 +12814,8 @@ namespace std::filesystem {
 }
 \end{codeblock}
 \pnum
-The class \tcode{filesystem_error} defines the type of
-objects thrown as exceptions to report file system errors from functions described in this
-subclause.
+Functions described in this subclause throw objects of type \tcode{filesystem_error},
+or a type derived from \tcode{filesystem_error}, to report file system errors.
 
 \rSec3[fs.filesystem_error.members]{\tcode{filesystem_error} members}
 


### PR DESCRIPTION
…ype"