### PR TITLE
[class.temporary] Repair example

### DIFF
--- a/source/special.tex
+++ b/source/special.tex
@@ -571,6 +571,7 @@ was obtained through one of the following:
 \begin{codeblock}
 template<typename T> using id = T;
 
+int i = 1;
 int&& a = id<int[3]>{1, 2, 3}[i];          // temporary array has same lifetime as \tcode{a}
 const int& b = static_cast<const int&>(0); // temporary \tcode{int} has same lifetime as \tcode{b}
 int&& c = cond ? id<int[3]>{1, 2, 3}[i] : static_cast<int&&>(0);


### PR DESCRIPTION
In p6.8, `i` was used without a prior declaration.