### PR TITLE
[dcl.type.cv] Do not use \grammarterm in heading

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1119,7 +1119,7 @@ and
 \grammarterm{type-specifier}{s} are discussed in the rest of this subclause.
 \end{note}
 
-\rSec3[dcl.type.cv]{The \grammarterm{cv-qualifier}{s}}%
+\rSec3[dcl.type.cv]{The \fakegrammarterm{cv-qualifier}{s}}%
 \indextext{specifier!cv-qualifier}%
 \indextext{initialization!\idxcode{const}}%
 \indextext{type specifier!\idxcode{const}}%


### PR DESCRIPTION
\fakegrammarterm is the right approach here.

Fixes #1945.