### PR TITLE
[dcl.spec.auto] Use of undeduced placeholder types

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1651,14 +1651,14 @@ auto* g() { }                   // error, cannot deduce \tcode{auto*} from \tcod
 \end{example}
 
 \pnum
-If the type of an entity with an undeduced placeholder type is needed to
-determine the type of an expression, the program is ill-formed. Once a
+If the name of an entity with an undeduced placeholder type appears in an
+expression, the program is ill-formed.  Once a
 non-discarded \tcode{return} statement has been seen in a function, however, the return type deduced
 from that statement can be used in the rest of the function, including in other
 \tcode{return} statements.
 \begin{example}
 \begin{codeblock}
-auto n = n;                     // error, \tcode{n}'s type is unknown
+auto n = n;                     // error, \tcode{n}'s initializer refers to \tcode{n}
 auto f();
 void g() { &f; }                // error, \tcode{f}'s return type is unknown
 auto sum(int i) {


### PR DESCRIPTION
As discussed for CWG 2285, variables declared with a
placeholder type should never reference itself in the
initializer.  Similarly, clarify the treatment of
deduced function return types.

Fixes #1942.