### PR TITLE
[std] Review cross-references to [expr.prim]

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -952,7 +952,7 @@ namespace N {
 
 \pnum
 A namespace member can also be referred to after the \tcode{::} scope
-resolution operator\iref{expr.prim} applied to the name of its
+resolution operator\iref{expr.prim.id.qual} applied to the name of its
 namespace or the name of a namespace which nominates the member's
 namespace in a \grammarterm{using-directive}; see~\ref{namespace.qual}.
 
@@ -1038,7 +1038,7 @@ from its class,
 of its class\iref{expr.ref} or a class derived from its class,
 \item after the \tcode{->} operator applied to a pointer to an object of
 its class\iref{expr.ref} or a class derived from its class,
-\item after the \tcode{::} scope resolution operator\iref{expr.prim}
+\item after the \tcode{::} scope resolution operator\iref{expr.prim.id.qual}
 applied to the name of its class or a class derived from its class.
 \end{itemize}
 
@@ -1699,7 +1699,7 @@ function templates are ignored.
 \indextext{qualification!explicit}%
 The name of a class or namespace member
 or enumerator can be referred to after the
-\tcode{::} scope resolution operator\iref{expr.prim} applied to a
+\tcode{::} scope resolution operator\iref{expr.prim.id.qual} applied to a
 \grammarterm{nested-name-specifier} that denotes its class,
 namespace, or enumeration.
 If a
@@ -1752,7 +1752,7 @@ X C::arr[number];   // ill-formed:
 \pnum
 \indextext{operator!scope resolution}%
 \indextext{scope resolution operator|see{operator, scope resolution}}%
-A name prefixed by the unary scope operator \tcode{::}\iref{expr.prim}
+A name prefixed by the unary scope operator \tcode{::}\iref{expr.prim.id.qual}
 is looked up in global scope, in the translation unit where it is used.
 The name shall be declared in global namespace scope or shall be a name
 whose declaration is visible in global scope because of a

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -660,7 +660,7 @@ reference to an object of class \tcode{C}.
 
 \pnum
 \begin{note}
-See~\ref{expr.prim} for restrictions on the use of non-static data
+See~\ref{expr.prim.id} for restrictions on the use of non-static data
 members and non-static member functions.
 \end{note}
 
@@ -941,7 +941,7 @@ object that is not of type \tcode{X}, or of a type derived from
 \tcode{X}, the behavior is undefined.
 
 \pnum
-When an \grammarterm{id-expression}\iref{expr.prim} that is not part of a
+When an \grammarterm{id-expression}\iref{expr.prim.id} that is not part of a
 class member access syntax\iref{expr.ref} and not used to form a
 pointer to member\iref{expr.unary.op} is used in
 a member of class \tcode{X} in a context where \tcode{this} can be
@@ -961,11 +961,11 @@ If \tcode{C} is not \tcode{X} or a base class of \tcode{X}, the class
 member access expression is ill-formed.
 \end{note}
 Similarly during name lookup, when an
-\grammarterm{unqualified-id}\iref{expr.prim} used in the definition of a
+\grammarterm{unqualified-id}\iref{expr.prim.id.unqual} used in the definition of a
 member function for class \tcode{X} resolves to a static member,
 an enumerator or a nested type of class \tcode{X} or of a base class of
 \tcode{X}, the \grammarterm{unqualified-id} is transformed into a
-\grammarterm{qualified-id}\iref{expr.prim} in which the
+\grammarterm{qualified-id}\iref{expr.prim.id.qual} in which the
 \grammarterm{nested-name-specifier} names the class of the member function.
 These transformations do not apply in the
 template definition context\iref{temp.dep.type}.
@@ -1162,7 +1162,7 @@ int Y::i = g();                 // equivalent to \tcode{Y::g();}
 \end{example}
 
 \pnum
-If an \grammarterm{unqualified-id}\iref{expr.prim} is used in the
+If an \grammarterm{unqualified-id}\iref{expr.prim.id.unqual} is used in the
 definition of a static member following the member's
 \grammarterm{declarator-id}, and name lookup\iref{basic.lookup.unqual}
 finds that the \grammarterm{unqualified-id} refers to a static
@@ -1172,7 +1172,7 @@ transformed into a \grammarterm{qualified-id} expression in which the
 \grammarterm{nested-name-specifier} names the class scope from which the
 member is referenced.
 \begin{note}
-See~\ref{expr.prim} for restrictions on the use of non-static data
+See~\ref{expr.prim.id} for restrictions on the use of non-static data
 members and non-static member functions.
 \end{note}
 
@@ -1412,7 +1412,7 @@ is local to its enclosing class.
 \indextext{nested class!scope of}%
 The nested class is in the scope of its enclosing class.
 \begin{note}
-See~\ref{expr.prim} for restrictions on the use of non-static data
+See~\ref{expr.prim.id} for restrictions on the use of non-static data
 members and non-static member functions.
 \end{note}
 

--- a/source/derived.tex
+++ b/source/derived.tex
@@ -88,7 +88,7 @@ expressions in the same manner as other members of the derived class,
 unless their names are hidden or ambiguous\iref{class.member.lookup}.
 \indextext{operator!scope resolution}%
 \begin{note}
-The scope resolution operator \tcode{::}\iref{expr.prim} can be used
+The scope resolution operator \tcode{::}\iref{expr.prim.id.qual} can be used
 to refer to a direct or indirect base member explicitly. This allows
 access to a name that has been redeclared in the derived class. A
 derived class can itself serve as a base class subject to access
@@ -885,7 +885,7 @@ void foe() {
 \pnum
 \indextext{operator!scope resolution}%
 \indextext{virtual function call}%
-Explicit qualification with the scope operator\iref{expr.prim}
+Explicit qualification with the scope operator\iref{expr.prim.id.qual}
 suppresses the virtual call mechanism.
 \begin{example}
 \begin{codeblock}
@@ -935,7 +935,7 @@ in the class definition.
 \indextext{definition!pure virtual function}%
 A pure virtual function need be defined only if called with, or as if
 with\iref{class.dtor}, the \grammarterm{qualified-id}
-syntax\iref{expr.prim}.
+syntax\iref{expr.prim.id.qual}.
 \begin{example}
 \begin{codeblock}
 class point { @\commentellip@ };

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -377,7 +377,7 @@ appear~(\ref{expr.prim.req},
 An unevaluated operand is not evaluated.
 \begin{note}
 In an unevaluated operand, a non-static class member may be
-named\iref{expr.prim} and naming of objects or functions does not, by
+named\iref{expr.prim.id} and naming of objects or functions does not, by
 itself, require that a definition be provided\iref{basic.def.odr}.
 An unevaluated operand is considered a full-expression\iref{intro.execution}.
 \end{note}
@@ -2580,7 +2580,7 @@ parameter-type-list \cv{} \opt{\grammarterm{ref-qualifier}} returning \tcode{T}'
 non-static member function. The expression can be used only as the
 left-hand operand of a member function call\iref{class.mfct}.
 \begin{note} Any redundant set of parentheses surrounding the expression
-is ignored\iref{expr.prim}. \end{note} The type of \tcode{E1.E2} is
+is ignored\iref{expr.prim.paren}. \end{note} The type of \tcode{E1.E2} is
 ``function of parameter-type-list \cv{} returning \tcode{T}''.
 \end{itemize}
 

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -2912,7 +2912,7 @@ An overloaded function name shall not be used without arguments in contexts
 other than those listed.
 \begin{note}
 Any redundant set of parentheses surrounding the overloaded function name is
-ignored\iref{expr.prim}.
+ignored\iref{expr.prim.paren}.
 \end{note}
 
 \pnum

--- a/source/special.tex
+++ b/source/special.tex
@@ -1251,7 +1251,7 @@ void f() {
 \end{example}
 \begin{note}
 An explicit destructor call must always be written using
-a member access operator\iref{expr.ref} or a \grammarterm{qualified-id}\iref{expr.prim};
+a member access operator\iref{expr.ref} or a \grammarterm{qualified-id}\iref{expr.prim.id.qual};
 in particular, the
 \grammarterm{unary-expression}
 \tcode{\~{}X()}


### PR DESCRIPTION
Cross-references to [expr.prim] should instead point to one
of its subclauses.