### PR TITLE
[dcl.fct.def.delete] Adjust 'onlydouble' example.

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -2226,12 +2226,13 @@ odr-use\iref{basic.def.odr} of a virtual function does not, by itself,
 constitute a reference. \end{note}
 
 \pnum
-\begin{example} One can enforce non-default-initialization and non-integral
-initialization with
+\begin{example} One can prevent default initialization and
+initialization by non-\tcode{double}s with
 \begin{codeblock}
 struct onlydouble {
   onlydouble() = delete;                // OK, but redundant
-  onlydouble(std::intmax_t) = delete;
+  template<class T>
+    onlydouble(T) = delete;
   onlydouble(double);
 };
 \end{codeblock}


### PR DESCRIPTION
Fixes #1925.