### PR TITLE
[error.reporting] Change \rSec3 to \rSec2

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -2747,7 +2747,7 @@ Calls \tcode{str.unsetf(ios_base::floatfield)}.
 \returns \tcode{str}.
 \end{itemdescr}
 
-\rSec3[error.reporting]{Error reporting}
+\rSec2[error.reporting]{Error reporting}
 
 \indexlibrarymember{make_error_code}{io_errc}%
 \begin{itemdecl}


### PR DESCRIPTION
Fixes #1953