### PR TITLE
[time.syn] Rename to [chrono.syn], consistent with header name

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -17443,11 +17443,11 @@ the typedef shall not be defined.
 
 \pnum
 \indexlibrary{\idxcode{chrono}}%
-This subclause describes the chrono library\iref{time.syn} and various C
+This subclause describes the chrono library\iref{chrono.syn} and various C
 functions\iref{ctime.syn} that provide generally useful time
 utilities.
 
-\rSec2[time.syn]{Header \tcode{<chrono>} synopsis}
+\rSec2[chrono.syn]{Header \tcode{<chrono>} synopsis}
 
 \indexhdr{chrono}%
 \indexlibrary{\idxcode{treat_as_floating_point_v}}%

--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -117,6 +117,9 @@
 \removedxref{unord.set.swap}
 \removedxref{unord.multiset.swap}
 
+% Renamed time.syn to chrono.syn, matching the name of the header.
+\movedxref{time.syn}{chrono.syn}
+
 % Deprecated features.
 %\deprxref{old.label}  (if moved to depr.old.label, otherwise use \movedxref)
 


### PR DESCRIPTION
Fixes #1958.