### PR TITLE
[expr.reinterpret.cast] Define reinterpret_cast from nullptr_t in terms of reinterpret_cast<void*> rather than c-style cast

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3118,7 +3118,7 @@ It is intended to be unsurprising to those who know the addressing
 structure of the underlying machine.
 \end{note} A value of type \tcode{std::nullptr_t} can be converted to an integral
 type; the conversion has the same meaning and validity as a conversion of
-\tcode{(void*)0} to the integral type. \begin{note} A \tcode{reinterpret_cast}
+\tcode{reinterpret_cast<void*>(0)} to the integral type. \begin{note} A \tcode{reinterpret_cast}
 cannot be used to convert a value of any type to the type
 \tcode{std::nullptr_t}. \end{note}
 


### PR DESCRIPTION
It seems clearer to directly use the specific cast rather than relying on the equivalence of the c-style cast.