### PR TITLE
Clarifying "the value of the expression" in simple assignment expression

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5593,8 +5593,8 @@ single compound assignment operator.
 \end{bnf}
 
 \pnum
-In simple assignment (\tcode{=}), the value of the expression replaces
-that of the object referred to by the left operand.
+In simple assignment (\tcode{=}), the result of the right operand replaces
+the value of the object referred to by the left operand.
 
 \pnum
 \indextext{assignment!conversion by}%


### PR DESCRIPTION
To quote [expr.ass]p2,

    In simple assignment (=), the value of the expression replaces that of the
    object referred to by the left operand.

End quote.

I think "the value of the expression" means the right operand of a simple
assignment, not the whole simple assignment expression, because [expr.ass]p2
describes the semantics of a simple assignment and because of the following
that I quote from Footnote 64 in 6.3.2.1/1 of WG14 N1570, the latest publicly
available draft of the C11 standard accessible at
http://open-std.org/jtc1/sc22/wg14/www/standards:

    The name ‘‘lvalue’’ comes originally from the assignment expression E1 =
    E2, [...] What is sometimes called ‘‘rvalue’’ is in this International
    Standard described as the ‘‘value of an expression’’.

End quote.

Since this ISO C++ draft does not have such a footnote, I propose to rewrite
[expr.ass]p2 as given in this commit.  Richard Smith has reviewed my proposal
and made my original rewrite more precise at https://goo.gl/tvD8Pu.