### PR TITLE
[ios.base] Disambiguate parameters from static data members

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -814,16 +814,16 @@ namespace std {
 
     // \ref{ios.base.storage}, storage
     static int xalloc();
-    long&  iword(int index);
-    void*& pword(int index);
+    long&  iword(int idx);
+    void*& pword(int idx);
 
     // destructor
     virtual ~ios_base();
 
     // \ref{ios.base.callback}, callbacks
     enum event { erase_event, imbue_event, copyfmt_event };
-    using event_callback = void (*)(event, ios_base&, int index);
-    void register_callback(event_callback fn, int index);
+    using event_callback = void (*)(event, ios_base&, int idx);
+    void register_callback(event_callback fn, int idx);
 
     ios_base(const ios_base&) = delete;
     ios_base& operator=(const ios_base&) = delete;
@@ -1327,9 +1327,9 @@ locale imbue(const locale& loc);
 \pnum
 \effects
 Calls each registered callback pair
-\tcode{(fn, index)}\iref{ios.base.callback}
+\tcode{(fn, idx)}\iref{ios.base.callback}
 as
-\tcode{(*fn)(imbue_event, *this, index)}
+\tcode{(*fn)(imbue_event, *this, idx)}
 at such a time that a call to
 \tcode{ios_base::getloc()}
 from within
@@ -1542,14 +1542,14 @@ for the same object, the earlier return value may no longer be valid.
 
 \indexlibrarymember{register_callback}{ios_base}%
 \begin{itemdecl}
-void register_callback(event_callback fn, int index);
+void register_callback(event_callback fn, int idx);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \effects
 Registers the pair
-\tcode{(fn, index)}
+\tcode{(fn, idx)}
 such that during calls to
 \tcode{imbue()}\iref{ios.base.locales},
 \tcode{copyfmt()},
@@ -1558,7 +1558,7 @@ or
 the function
 \tcode{fn}
 is called with argument
-\tcode{index}.
+\tcode{idx}.
 Functions registered are called when an event occurs, in opposite order of
 registration.
 Functions registered while a callback function is active are not called until the next event.
@@ -1605,8 +1605,8 @@ the behavior is undefined.
 Destroys an object of class
 \tcode{ios_base}.
 Calls each registered callback pair
-\tcode{(fn, index)}\iref{ios.base.callback} as
-\tcode{(*fn)(\brk{}erase_event, *this, index)}
+\tcode{(fn, idx)}\iref{ios.base.callback} as
+\tcode{(*fn)(\brk{}erase_event, *this, idx)}
 at such time that any
 \tcode{ios_base}
 member function called from within
@@ -2063,8 +2063,8 @@ Otherwise assigns to the member objects of
 the corresponding member objects of \tcode{rhs} as follows:
 
 \begin{itemize}
-\item calls each registered callback pair \tcode{(fn, index)} as
-\tcode{(*fn)(erase_event, *this, index)};
+\item calls each registered callback pair \tcode{(fn, idx)} as
+\tcode{(*fn)(erase_event, *this, idx)};
 
 \item then, assigns to the member objects of \tcode{*this} the corresponding member objects of
 \tcode{rhs}, except that
@@ -2084,7 +2084,7 @@ objects;
 \end{itemize}
 
 \item then, calls each callback pair that was copied from \tcode{rhs} as
-\tcode{(*fn)(copyfmt_event, *this, index)};
+\tcode{(*fn)(copyfmt_event, *this, idx)};
 
 \item then, calls \tcode{exceptions(rhs.exceptions())}.
 


### PR DESCRIPTION
Renames parameters named "index" to "idx".

Fixes #1955.