### PR TITLE
[namespace.udecl] Demote normative duplication to notes

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3043,24 +3043,28 @@ D2 d2(0);           // calls \tcode{D2::D2(int)}
 
 \pnum
 \indextext{overloading!using-declaration and}%
+\begin{note}
 For the purpose of forming a set of candidates during overload resolution,
 the functions that are
 introduced by a \grammarterm{using-declaration} into a derived class
-are treated as though they were members of the derived class. In
-particular, the implicit \tcode{this} parameter shall be treated as if
-it were a pointer to the derived class rather than to the base class.
+are treated as though they were members of the derived class\iref{class.member.lookup}. In
+particular, the implicit object parameter is treated as if
+it were a reference to the derived class rather than to the base class\iref{over.match.funcs}.
 This has no effect on the type of the function, and in all other
 respects the function remains a member of the base class.
-Likewise, constructors that are introduced by a \grammarterm{using-declaration}
+\end{note}
+
+\pnum
+Constructors that are introduced by a \grammarterm{using-declaration}
 are treated as though they were constructors of the derived class
 when looking up the constructors of the derived class\iref{class.qual}
 or forming a set of overload candidates~(\ref{over.match.ctor}, \ref{over.match.copy}, \ref{over.match.list}).
+\begin{note}
 If such a constructor is selected to perform the initialization
 of an object of class type, all subobjects other than the base class
 from which the constructor originated
 are implicitly initialized\iref{class.inhctor.init}.
-\begin{note}
-A member of a derived class is sometimes preferred to a member of a base class
+A constructor of a derived class is sometimes preferred to a member of a base class
 if they would otherwise be ambiguous\iref{over.match.best}.
 \end{note}
 

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3064,7 +3064,7 @@ If such a constructor is selected to perform the initialization
 of an object of class type, all subobjects other than the base class
 from which the constructor originated
 are implicitly initialized\iref{class.inhctor.init}.
-A constructor of a derived class is sometimes preferred to a member of a base class
+A constructor of a derived class is sometimes preferred to a constructor of a base class
 if they would otherwise be ambiguous\iref{over.match.best}.
 \end{note}
 


### PR DESCRIPTION
The effects of using-declarations naming member functions
are discussed in other parts of the standard.
The effects of initializing with an inherited constructor are
discussed elsewhere, too.

Fixes #1975.