### PR TITLE
[temp.spec] Fix cross-reference to one-definition rule.

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -5508,7 +5508,7 @@ For a given template and a given set of
 an explicit instantiation definition shall appear at most once in a program,
 \item
 an explicit specialization shall be defined at most once
-in a program (according to~\ref{basic.def.odr}), and
+in a program, as specified in \ref{basic.def.odr}, and
 \item
 both an explicit instantiation and a declaration of an
 explicit specialization shall not appear in a program unless


### PR DESCRIPTION
Fixes #1860.