### PR TITLE
[temp.local] Fix example not to name the constructor.

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -4392,7 +4392,7 @@ template <class T> struct Derived: public Base<T> {
 };
 
 template<class T, template<class> class U = T::template Base> struct Third { };
-Third<Base<int> > t;                    // OK: default argument uses injected-class-name as a template
+Third<Derived<int> > t;                 // OK: default argument uses injected-class-name as a template
 \end{codeblock}
 \end{example}
 


### PR DESCRIPTION
Fixes #1900.