### PR TITLE
[lib] \xref may refer to standards other than C

### DIFF
--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -557,7 +557,7 @@ The contents are the same as the C standard library header
 except that a macro named \tcode{static_assert}
 is not defined.
 
-\xref ISO C 7.2
+\xrefc{7.2}
 
 \rSec2[assertions.assert]{The \tcode{assert} macro}
 
@@ -752,7 +752,7 @@ A separate \tcode{errno} value shall be provided for each thread.
 \pnum
 The meaning of the macros in this header is defined by the POSIX standard.
 
-\xref ISO C 7.5
+\xrefc{7.5}
 
 \rSec1[syserr]{System error support}
 

--- a/source/future.tex
+++ b/source/future.tex
@@ -87,7 +87,7 @@ standard library header \tcode{<stdalign.h>}, with the following changes:
 The header \tcode{<cstdalign>} and the header \tcode{<stdalign.h>} shall not
 define a macro named \tcode{alignas}.
 
-\xref ISO C 7.15
+\xrefc{7.15}
 
 \rSec2[depr.cstdbool.syn]{Header \tcode{<cstdbool>} synopsis}
 
@@ -104,7 +104,7 @@ standard library header \tcode{<stdbool.h>}, with the following changes:
 The header \tcode{<cstdbool>} and the header \tcode{<stdbool.h>} shall not
 define macros named \tcode{bool}, \tcode{true}, or \tcode{false}.
 
-\xref ISO C 7.18
+\xrefc{7.18}
 
 \rSec2[depr.ctgmath.syn]{Header \tcode{<ctgmath>} synopsis}
 

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -449,7 +449,7 @@ as specified in the C standard library.
 \pnum
 Concurrent access to a synchronized\iref{ios.members.static} standard iostream object's formatted and unformatted input\iref{istream} and output\iref{ostream} functions or a standard C stream by multiple threads shall not result in a data race\iref{intro.multithread}. \begin{note} Users must still synchronize concurrent use of these objects and streams by multiple threads if they wish to avoid interleaved characters. \end{note}
 
-\xref ISO C 7.21.2
+\xrefc{7.21.2}
 
 \rSec2[narrow.stream.objects]{Narrow stream objects}
 
@@ -16063,7 +16063,7 @@ Calls to the function \tcode{tmpnam} with an argument that is a null pointer val
 introduce a data race\iref{res.on.data.races} with other calls to \tcode{tmpnam} with
 an argument that is a null pointer value.
 
-\xref ISO C 7.21
+\xrefc{7.21}
 
 \rSec2[cinttypes.syn]{Header \tcode{<cinttypes>} synopsis}
 
@@ -16228,4 +16228,4 @@ which shall have the same semantics as the function signatures
 \tcode{imaxdiv_t imaxdiv(intmax_t, intmax_t)}, respectively.
 \end{itemize}
 
-\xref ISO C 7.8
+\xrefc{7.8}

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -540,7 +540,7 @@ constants\iref{syserr}.
 
 \pnum
 Paragraphs labeled ``\textsc{See also}'' contain cross-references to the relevant portions
-of the ISO C standard.
+of other standards\iref{intro.refs}.
 
 \rSec2[conventions]{Other conventions}
 \indextext{conventions}%

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -5290,7 +5290,7 @@ Calls to the function \tcode{setlocale} may introduce a data
 race\iref{res.on.data.races} with other calls to \tcode{setlocale} or with calls to
 the functions listed in Table~\ref{tab:setlocale.data.races}.
 
-\xref ISO C 7.11
+\xrefc{7.11}
 
 \begin{floattable}
 {Potential \tcode{setlocale} data races}

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -253,6 +253,7 @@
 
 %% Cross reference
 \newcommand{\xref}{\textsc{See also:}\space}
+\newcommand{\xrefc}[1]{\xref{} ISO C #1}
 
 %% Inline parenthesized reference
 \newcommand{\iref}[1]{\nolinebreak[3] (\ref{#1})}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -242,7 +242,7 @@ state of the parent thread at the time of the child's creation. \end{note}
 A separate floating-point environment shall be maintained for each thread. Each function
 accesses the environment corresponding to its calling thread.
 
-\xref ISO C 7.6
+\xrefc{7.6}
 
 \rSec1[complex.numbers]{Complex numbers}
 
@@ -992,7 +992,7 @@ template<class T> complex<T> proj(const complex<T>& x);
 \pnum
 \remarks
 Behaves the same as the C function \tcode{cproj}.
-\xref ISO C 7.3.9.5
+\xrefc{7.3.9.5}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{polar}!\idxcode{complex}}%
@@ -1029,7 +1029,7 @@ template<class T> complex<T> acos(const complex<T>& x);
 \pnum
 \remarks
 Behaves the same as the C function \tcode{cacos}.
-\xref ISO C 7.3.5.1
+\xrefc{7.3.5.1}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{asin}!\idxcode{complex}}%
@@ -1045,7 +1045,7 @@ template<class T> complex<T> asin(const complex<T>& x);
 \pnum
 \remarks
 Behaves the same as the C function \tcode{casin}.
-\xref ISO C 7.3.5.2
+\xrefc{7.3.5.2}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{atan}!\idxcode{complex}}%
@@ -1061,7 +1061,7 @@ template<class T> complex<T> atan(const complex<T>& x);
 \pnum
 \remarks
 Behaves the same as the C function \tcode{catan}.
-\xref ISO C 7.3.5.3
+\xrefc{7.3.5.3}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{acosh}!\idxcode{complex}}%
@@ -1077,7 +1077,7 @@ template<class T> complex<T> acosh(const complex<T>& x);
 \pnum
 \remarks
 Behaves the same as the C function \tcode{cacosh}.
-\xref ISO C 7.3.6.1
+\xrefc{7.3.6.1}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{asinh}!\idxcode{complex}}%
@@ -1093,7 +1093,7 @@ template<class T> complex<T> asinh(const complex<T>& x);
 \pnum
 \remarks
 Behaves the same as the C function \tcode{casinh}.
-\xref ISO C 7.3.6.2
+\xrefc{7.3.6.2}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{atanh}!\idxcode{complex}}%
@@ -1109,7 +1109,7 @@ template<class T> complex<T> atanh(const complex<T>& x);
 \pnum
 \remarks
 Behaves the same as the C function \tcode{catanh}.
-\xref ISO C 7.3.6.3
+\xrefc{7.3.6.3}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{cos}!\idxcode{complex}}%
@@ -6417,7 +6417,7 @@ and oft-questionable quality and performance.
 \end{note}
 \end{itemdescr}
 
-\xref ISO C 7.22.2
+\xrefc{7.22.2}
 
 \indextext{random number generation|)}
 
@@ -10524,7 +10524,7 @@ Arguments that can be promoted to \tcode{int} are permitted for compatibility wi
 \end{note}
 \end{itemdescr}
 
-\xref ISO C 7.12.7.2, 7.22.6.1
+\xrefc{7.12.7.2, 7.22.6.1}
 
 \rSec2[c.math.hypot3]{Three-dimensional hypotenuse}
 

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -696,22 +696,23 @@ sensitive.
 \tcode{ECMAScript} &
 Specifies that the grammar recognized by the regular expression engine
 shall be that used by ECMAScript in ECMA-262, as modified in~\ref{re.grammar}.
+\newline \xref ECMA-262 15.10
 \indextext{ECMAScript}%
 \indexlibrary{\idxcode{syntax_option_type}!\idxcode{ECMAScript}}%
 \\ \rowsep
 %
 \tcode{basic} &
 Specifies that the grammar recognized by the regular expression engine
-shall be that used by basic regular expressions in POSIX, Base Definitions and
-Headers, Section 9, Regular Expressions.
+shall be that used by basic regular expressions in POSIX.
+\newline \xref POSIX, Base Definitions and Headers, Section 9.3
 \indextext{POSIX!regular expressions}%
 \indexlibrary{\idxcode{syntax_option_type}!\idxcode{basic}}%
 \\ \rowsep
 %
 \tcode{extended} &
 Specifies that the grammar recognized by the regular expression engine
-shall be that used by extended regular expressions in POSIX, Base Definitions and
-Headers, Section 9, Regular Expressions.
+shall be that used by extended regular expressions in POSIX.
+\newline \xref POSIX, Base Definitions and Headers, Section 9.4
 \indextext{POSIX!extended regular expressions}%
 \indexlibrary{\idxcode{syntax_option_type}!\idxcode{extended}}%
 \\ \rowsep
@@ -4224,4 +4225,5 @@ iterator range \range{first}{last} if
 \indextext{regular expression traits!\idxcode{lookup_classname}}%
 \indextext{\idxcode{lookup_classname}!regular expression traits}%
 \end{itemize}
+\xref ECMA-262 15.10
 \indextext{regular expression|)}

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -5957,7 +5957,7 @@ namespace std {
 The contents and meaning of the header \tcode{<cctype>}
 are the same as the C standard library header \tcode{<ctype.h>}.
 
-\xref ISO C 7.4
+\xrefc{7.4}
 
 \rSec2[cwctype.syn]{Header \tcode{<cwctype>} synopsis}
 
@@ -6018,7 +6018,7 @@ namespace std {
 The contents and meaning of the header \tcode{<cwctype>}
 are the same as the C standard library header \tcode{<wctype.h>}.
 
-\xref ISO C 7.30
+\xrefc{7.30}
 
 \rSec2[cstring.syn]{Header \tcode{<cstring>} synopsis}
 
@@ -6104,7 +6104,7 @@ have different signatures in this document,
 but they have the same behavior as in the C standard library\iref{library.c}.
 \end{note}
 
-\xref ISO C 7.24
+\xrefc{7.24}
 
 \rSec2[cwchar.syn]{Header \tcode{<cwchar>} synopsis}
 
@@ -6272,7 +6272,7 @@ have different signatures in this document,
 but they have the same behavior as in the C standard library\iref{library.c}.
 \end{note}
 
-\xref ISO C 7.29
+\xrefc{7.29}
 
 \rSec2[cuchar.syn]{Header \tcode{<cuchar>} synopsis}
 
@@ -6302,7 +6302,7 @@ are the same as the C standard library header
 \tcode{<uchar.h>}, except that it does not declare types \tcode{char16_t} nor
 \tcode{char32_t}.
 
-\xref ISO C 7.28
+\xrefc{7.28}
 
 \rSec2[c.mb.wcs]{Multibyte / wide string and character conversion functions}
 
@@ -6332,7 +6332,7 @@ size_t wcstombs(char* s, const wchar_t* pwcs, size_t n);
 These functions have the semantics specified in the C standard library.
 \end{itemdescr}
 
-\xref ISO C 7.22.7.1, 7.22.8, 7.29.6.2.1
+\xrefc{7.22.7.1, 7.22.8, 7.29.6.2.1}
 
 \indexlibrary{\idxcode{mbtowc}}%
 \indexlibrary{\idxcode{wctomb}}%
@@ -6353,7 +6353,7 @@ may introduce a data race\iref{res.on.data.races}
 with other calls to the same function.
 \end{itemdescr}
 
-\xref ISO C 7.22.7
+\xrefc{7.22.7}
 
 \indexlibrary{\idxcode{mbrlen}}%
 \indexlibrary{\idxcode{mbrstowcs}}%
@@ -6382,4 +6382,4 @@ with other calls to the same function
 with an \tcode{mbstate_t*} argument that is a null pointer value.
 \end{itemdescr}
 
-\xref ISO C 7.29.6.3
+\xrefc{7.29.6.3}

--- a/source/support.tex
+++ b/source/support.tex
@@ -95,7 +95,7 @@ and as noted in
 \ref{support.types.nullptr} and
 \ref{support.types.layout}.
 
-\xref ISO C 7.19
+\xrefc{7.19}
 
 \rSec2[cstdlib.syn]{Header \tcode{<cstdlib>} synopsis}
 
@@ -257,7 +257,7 @@ Several functions have additional overloads in this document,
 but they have the same behavior as in the C standard library\iref{library.c}.
 \end{note}
 
-\xref ISO C 7.22
+\xrefc{7.22}
 
 \rSec2[support.types.nullptr]{Null pointers}
 
@@ -284,7 +284,7 @@ and
 but not
 \tcode{(void*)0}.}
 
-\xref ISO C 7.19
+\xrefc{7.19}
 
 \rSec2[support.types.layout]{Sizes, alignments, and offsets}
 
@@ -336,7 +336,7 @@ The type
 is at least as great as that of every scalar type, and whose alignment
 requirement is supported in every context\iref{basic.align}.
 
-\xref ISO C 7.19
+\xrefc{7.19}
 
 \rSec2[support.types.byteops]{\tcode{byte} type operations}
 
@@ -1416,7 +1416,7 @@ The types of the constants defined by macros in \tcode{<climits>} are not
 required to match the types to which the macros refer.
 \end{note}
 
-\xref ISO C 5.2.4.2.1
+\xrefc{5.2.4.2.1}
 
 \rSec2[cfloat.syn]{Header \tcode{<cfloat>} synopsis}
 
@@ -1507,7 +1507,7 @@ required to match the types to which the macros refer.
 The header \tcode{<cfloat>} defines all macros the same as
 the C standard library header \tcode{<float.h>}.
 
-\xref ISO C 5.2.4.2.2
+\xrefc{5.2.4.2.2}
 
 \rSec1[cstdint]{Integer types}
 
@@ -1604,7 +1604,7 @@ plus function macros of the form:
 The header defines all types and macros the same as
 the C standard library header \tcode{<stdint.h>}.
 
-\xref ISO C 7.20
+\xrefc{7.20}
 
 \rSec1[support.start.term]{Start and termination}
 
@@ -1806,7 +1806,7 @@ The function \tcode{quick_exit} is signal-safe\iref{support.signal}
 when the functions registered with \tcode{at_quick_exit} are.
 \end{itemdescr}
 
-\xref ISO C 7.22.4
+\xrefc{7.22.4}
 
 \rSec1[support.dynamic]{Dynamic memory management}
 
@@ -4746,7 +4746,7 @@ is of a reference type, or of a type that is not compatible with the
 type that results when passing an argument for which there is no
 parameter, the behavior is undefined.
 
-\xref ISO C 7.16.1.1
+\xrefc{7.16.1.1}
 
 \rSec2[csetjmp.syn]{Header \tcode{<csetjmp>} synopsis}
 
@@ -4778,7 +4778,7 @@ behavior if replacing the \tcode{setjmp} and \tcode{longjmp}
 by \tcode{catch} and \tcode{throw} would invoke any non-trivial destructors for any automatic
 objects.
 
-\xref ISO C 7.13
+\xrefc{7.13}
 
 \rSec2[csignal.syn]{Header \tcode{<csignal>} synopsis}
 
@@ -4894,4 +4894,4 @@ The function \tcode{signal} is signal-safe if it is invoked
 with the first argument equal to the signal number
 corresponding to the signal that caused the invocation of the handler.
 
-\xref ISO C 7.14
+\xrefc{7.14}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -7923,7 +7923,7 @@ deallocate storage by calling
 \tcode{::operator delete()}\indexlibrary{\idxcode{delete}!\idxcode{operator}}.
 \end{itemdescr}
 
-\xref ISO C 7.22.3
+\xrefc{7.22.3}
 
 \rSec1[smartptr]{Smart pointers}
 
@@ -28690,7 +28690,7 @@ The functions \tcode{asctime}, \tcode{ctime}, \tcode{gmtime}, and
 \tcode{localtime} are not required to avoid data
 races\iref{res.on.data.races}.
 
-\xref ISO C 7.27
+\xrefc{7.27}
 
 \rSec1[type.index]{Class \tcode{type_index}}
 
@@ -29228,7 +29228,7 @@ with the given precision.
 \throws Nothing.
 \end{itemdescr}
 
-\xref ISO C 7.21.6.1
+\xrefc{7.21.6.1}
 
 \rSec2[charconv.from.chars]{Primitive numeric input conversion}
 
@@ -29346,4 +29346,4 @@ closest to the value of the string matching the pattern.
 \throws Nothing.
 \end{itemdescr}
 
-\xref ISO C 7.22.1.3, 7.22.1.4
+\xrefc{7.22.1.3, 7.22.1.4}


### PR DESCRIPTION
Also, use \xrefc instead of \xref ISO C to refer to the ISO C standard.

Fixes #1822.