### PR TITLE
[re.regex] Avoid duplicate list of constants

### DIFF
--- a/source/regex.tex
+++ b/source/regex.tex
@@ -1336,29 +1336,18 @@ namespace std {
       using flag_type   =          regex_constants::syntax_option_type;
       using locale_type = typename traits::locale_type;
 
-      // \ref{re.regex.const}, constants
-      static constexpr regex_constants::syntax_option_type
-        icase = regex_constants::icase;
-      static constexpr regex_constants::syntax_option_type
-        nosubs = regex_constants::nosubs;
-      static constexpr regex_constants::syntax_option_type
-        optimize = regex_constants::optimize;
-      static constexpr regex_constants::syntax_option_type
-        collate = regex_constants::collate;
-      static constexpr regex_constants::syntax_option_type
-        ECMAScript = regex_constants::ECMAScript;
-      static constexpr regex_constants::syntax_option_type
-        basic = regex_constants::basic;
-      static constexpr regex_constants::syntax_option_type
-        extended = regex_constants::extended;
-      static constexpr regex_constants::syntax_option_type
-        awk = regex_constants::awk;
-      static constexpr regex_constants::syntax_option_type
-        grep = regex_constants::grep;
-      static constexpr regex_constants::syntax_option_type
-        egrep = regex_constants::egrep;
-      static constexpr regex_constants::syntax_option_type
-        multiline = regex_constants::multiline;
+      // \ref{re.synopt}, constants
+      static constexpr flag_type icase = regex_constants::icase;
+      static constexpr flag_type nosubs = regex_constants::nosubs;
+      static constexpr flag_type optimize = regex_constants::optimize;
+      static constexpr flag_type collate = regex_constants::collate;
+      static constexpr flag_type ECMAScript = regex_constants::ECMAScript;
+      static constexpr flag_type basic = regex_constants::basic;
+      static constexpr flag_type extended = regex_constants::extended;
+      static constexpr flag_type awk = regex_constants::awk;
+      static constexpr flag_type grep = regex_constants::grep;
+      static constexpr flag_type egrep = regex_constants::egrep;
+      static constexpr flag_type multiline = regex_constants::multiline;
 
       // \ref{re.regex.construct}, construct/copy/destroy
       basic_regex();
@@ -1415,28 +1404,6 @@ namespace std {
       -> basic_regex<typename iterator_traits<ForwardIterator>::value_type>;
 }
 \end{codeblock}
-
-\rSec2[re.regex.const]{\tcode{basic_regex} constants}
-\indexlibrary{\idxcode{basic_regex}!constants}%
-
-\begin{codeblock}
-static constexpr regex_constants::syntax_option_type icase = regex_constants::icase;
-static constexpr regex_constants::syntax_option_type nosubs = regex_constants::nosubs;
-static constexpr regex_constants::syntax_option_type optimize = regex_constants::optimize;
-static constexpr regex_constants::syntax_option_type collate = regex_constants::collate;
-static constexpr regex_constants::syntax_option_type ECMAScript = regex_constants::ECMAScript;
-static constexpr regex_constants::syntax_option_type basic = regex_constants::basic;
-static constexpr regex_constants::syntax_option_type extended = regex_constants::extended;
-static constexpr regex_constants::syntax_option_type awk = regex_constants::awk;
-static constexpr regex_constants::syntax_option_type grep = regex_constants::grep;
-static constexpr regex_constants::syntax_option_type egrep = regex_constants::egrep;
-static constexpr regex_constants::syntax_option_type multiline = regex_constants::multiline;
-\end{codeblock}
-
-\pnum
-\indexlibrary{\idxcode{basic_regex}!constants}%
-The static constant members are provided as synonyms for the constants
-declared in namespace \tcode{regex_constants}.
 
 \rSec2[re.regex.construct]{\tcode{basic_regex} constructors}
 

--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -49,6 +49,9 @@
 % Contents of [util.smartptr] was integrated into the parent.
 \removedxref{util.smartptr}
 
+% Avoid duplication with synopsis.
+\movedxref{re.regex.const}{re.regex}
+
 % Deprecated free-function atomic access to shared pointers
 \movedxref{util.smartptr.shared.atomic}{depr.util.smartptr.shared.atomic}
 


### PR DESCRIPTION
Shorten the synopsis and remove [re.regex.const].

Fixes #1163.