### PR TITLE
[time.duration.nonmember] Replace type designator CR with its definition

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -18180,7 +18180,7 @@ static constexpr duration max();
 
 \pnum
 In the function descriptions that follow, \tcode{CD} represents the return type
-of the function. \tcode{CR(A, B)} represents \tcode{common_type_t<A, B>}.
+of the function.
 
 \indexlibrary{\idxcode{common_type}}%
 \begin{itemdecl}
@@ -18216,7 +18216,7 @@ template<class Rep1, class Period, class Rep2>
 \begin{itemdescr}
 \pnum
 \remarks This operator shall not participate in overload
-resolution unless \tcode{Rep2} is implicitly convertible to \tcode{CR(Rep1, Rep2)}.
+resolution unless \tcode{Rep2} is implicitly convertible to \tcode{common_type_t<Rep1, Rep2>}.
 
 \pnum
 \returns \tcode{CD(CD(d).count() * s)}.
@@ -18232,7 +18232,7 @@ template<class Rep1, class Rep2, class Period>
 \begin{itemdescr}
 \pnum
 \remarks This operator shall not participate in overload
-resolution unless \tcode{Rep1} is implicitly convertible to \tcode{CR(Rep1, Rep2)}.
+resolution unless \tcode{Rep1} is implicitly convertible to \tcode{common_type_t<Rep1, Rep2>}.
 
 \pnum
 \returns \tcode{d * s}.
@@ -18248,7 +18248,7 @@ template<class Rep1, class Period, class Rep2>
 \begin{itemdescr}
 \pnum
 \remarks This operator shall not participate in overload
-resolution unless \tcode{Rep2} is implicitly convertible to \tcode{CR(Rep1, Rep2)}
+resolution unless \tcode{Rep2} is implicitly convertible to \tcode{common_type_t<Rep1, Rep2>}
 and \tcode{Rep2} is not a specialization of \tcode{duration}.
 
 \pnum
@@ -18277,7 +18277,7 @@ template<class Rep1, class Period, class Rep2>
 \begin{itemdescr}
 \pnum
 \remarks This operator shall not participate in overload
-resolution unless \tcode{Rep2} is implicitly convertible to \tcode{CR(Rep1, Rep2)} and
+resolution unless \tcode{Rep2} is implicitly convertible to \tcode{common_type_t<Rep1, Rep2>} and
 \tcode{Rep2} is not a specialization of \tcode{duration}.
 
 \pnum


### PR DESCRIPTION
Fixes #916.