### PR TITLE
[lib] Avoid 'shall' and 'should' in footnotes.

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -728,19 +728,7 @@ is a synonym for one of the signed basic
 integral types.
 It is used to represent the number of characters transferred in an I/O
 operation, or the size of I/O buffers.\footnote{\tcode{streamsize}
-is used in most places where ISO C would use
-\tcode{size_t}.
-Most of the uses of
-\tcode{streamsize}
-could use
-\tcode{size_t},
-except for the
-\tcode{strstreambuf}
-constructors, which require negative values.
-It should probably be the signed type corresponding to
-\tcode{size_t}
-(which is what Posix.2 calls
-\tcode{ssize_t}).}
+is used in most places where ISO C would use \tcode{size_t}.}
 \end{itemdescr}
 
 \rSec2[ios.base]{Class \tcode{ios_base}}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -6818,7 +6818,7 @@ The elements are initialized with the values of the corresponding
 elements of \tcode{v}.\footnote{This copy constructor creates
 a distinct array rather than an alias.
 Implementations in which arrays share storage are permitted, but they
-shall implement a copy-on-reference mechanism to ensure that arrays are
+would need to implement a copy-on-reference mechanism to ensure that arrays are
 conceptually distinct.}
 \end{itemdescr}
 

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1292,11 +1292,12 @@ The following macro names shall be defined by the implementation:
 
 \indextext{__CPLUSPLUS@\xname{cplusplus}}%
 \item \xname{cplusplus}\\
-The integer literal \tcode{\cppver}.\footnote{It is intended that future
+The integer literal \tcode{\cppver}.
+\begin{note}
+It is intended that future
 versions of this International Standard will
 replace the value of this macro with a greater value.
-Non-conforming compilers should use a value with at most
-five decimal digits.}
+\end{note}
 
 \indextext{__DATE__@\mname{DATE}}%
 \item \mname{DATE}\\


### PR DESCRIPTION
Partially addresses #1414.