### PR TITLE
[over.best.ics] p6, [over.ics.ref] p1 Fix case

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -2017,12 +2017,12 @@ When the parameter has a class type and the argument expression has a
 derived class type, the implicit conversion sequence is a
 derived-to-base
 \indextext{conversion!derived-to-base}%
-Conversion from the derived class to the base class.
+conversion from the derived class to the base class.
 \begin{note}
-There is no such standard conversion; this derived-to-base Conversion exists
+There is no such standard conversion; this derived-to-base conversion exists
 only in the description of implicit conversion sequences.
 \end{note}
-A derived-to-base Conversion has Conversion rank\iref{over.ics.scs}.
+A derived-to-base conversion has Conversion rank\iref{over.ics.scs}.
 
 \pnum
 In all contexts, when converting to the implicit object parameter
@@ -2212,7 +2212,7 @@ applying a conversion function to the argument expression, the implicit
 conversion sequence is a user-defined conversion sequence\iref{over.ics.user},
 with the second standard conversion sequence either an identity conversion or,
 if the conversion function returns an entity of a type that is a derived class
-of the parameter type, a derived-to-base Conversion.
+of the parameter type, a derived-to-base conversion.
 
 \pnum
 When a parameter of reference type is not bound directly to an argument


### PR DESCRIPTION
To avoid confusion, occurrence of "derived-to-base conversion" should not be with capital letter "C", which implies the name of a conversion category. The rank is already specified at the end of the paragraph.