### PR TITLE
[cmp.syn] Rename to [compare.syn] to match the header name

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -3710,7 +3710,7 @@ template<class E> constexpr const E* end(initializer_list<E> il) noexcept;
 
 \rSec1[cmp]{Comparisons}
 
-\rSec2[cmp.syn]{Header \tcode{<compare>} synopsis}
+\rSec2[compare.syn]{Header \tcode{<compare>} synopsis}
 
 \pnum
 The header \tcode{<compare>} specifies types, objects, and functions


### PR DESCRIPTION
Fixes #1991.