### PR TITLE
[conv,expr] Use \cv{} where appropriate

### DIFF
--- a/source/conversions.tex
+++ b/source/conversions.tex
@@ -80,7 +80,7 @@ context is said to be
 well-formed if and only if \tcode{e} can be implicitly converted to a type \tcode{T}
 that is determined as follows:
 \tcode{E} is searched for non-explicit conversion functions
-whose return type is \cvqual{cv} \tcode{T} or reference to \cvqual{cv}
+whose return type is \cv{} \tcode{T} or reference to \cv{}
 \tcode{T} such that \tcode{T} is allowed by the context.
 There shall be exactly one such \tcode{T}.
 
@@ -241,21 +241,21 @@ int k = X().n;      // OK, \tcode{X()} prvalue is converted to xvalue
 \pnum
 A \defn{cv-decomposition} of a type \tcode{T}
 is a sequence of
-$cv_i$ and $P_i$
+$\cv{}_i$ and $P_i$
 such that \tcode{T} is
 \begin{indented}
-``$cv_0$ $P_0$ $cv_1$ $P_1$ $\cdots$ $cv_{n-1}$ $P_{n-1}$ $cv_n$ \tcode{U}'' for $n > 0$,
+``$\cv{}_0$ $P_0$ $\cv{}_1$ $P_1$ $\cdots$ $\cv{}_{n-1}$ $P_{n-1}$ $\cv{}_n$ \tcode{U}'' for $n > 0$,
 \end{indented}
 where
-each $cv_i$ is a set of cv-qualifiers\iref{basic.type.qualifier}, and
+each $\cv{}_i$ is a set of cv-qualifiers\iref{basic.type.qualifier}, and
 each $P_i$ is
 ``pointer to''\iref{dcl.ptr},
 ``pointer to member of class $C_i$ of type''\iref{dcl.mptr},
 ``array of $N_i$'', or
 ``array of unknown bound of''\iref{dcl.array}.
 If $P_i$ designates an array,
-the cv-qualifiers $cv_{i+1}$ on the element type are also taken as
-the cv-qualifiers $cv_i$ of the array.
+the cv-qualifiers $\cv{}_{i+1}$ on the element type are also taken as
+the cv-qualifiers $\cv{}_i$ of the array.
 \begin{example}
 The type denoted by the \grammarterm{type-id} \tcode{const int **}
 has two cv-decompositions,
@@ -263,7 +263,7 @@ taking \tcode{U} as ``\tcode{int}'' and as ``pointer to \tcode{const int}''.
 \end{example}
 The $n$-tuple of cv-qualifiers after the first one
 in the longest cv-decomposition of \tcode{T}, that is,
-$cv_1, cv_2, \dotsc, cv_n$, is called the
+$\cv{}_1, \cv{}_2, \dotsc, \cv{}_n$, is called the
 \defn{cv-qualification signature} of \tcode{T}.
 
 \pnum
@@ -280,16 +280,16 @@ if the following conditions are satisfied,
 % NB: forbid line break between 'where' and 'cv'
 % to stop superscript j from running into
 % descender of p on the previous line.
-where~$cv_i^j$ denotes the cv-qualifiers in the cv-qualification signature of $\tcode{T}_j$:%
+where~$\cv{}_i^j$ denotes the cv-qualifiers in the cv-qualification signature of $\tcode{T}_j$:%
 \footnote{These rules ensure that const-safety is preserved by the conversion.}
 
 \begin{itemize}
 \item $\tcode{T}_1$ and $\tcode{T}_2$ are similar.
 
-\item For every $i > 0$, if \tcode{const} is in $\text{\cv}_i^1$ then \tcode{const} is in $\text{\cv}_i^2$, and similarly for \tcode{volatile}.
+\item For every $i > 0$, if \tcode{const} is in $\cv{}_i^1$ then \tcode{const} is in $\cv{}_i^2$, and similarly for \tcode{volatile}.
 
-\item If the $\text{\cv}_i^1$ and $\text{\cv}_i^2$ are different,
-then \tcode{const} is in every $\text{\cv}_k^2$ for $0 < k < i$.
+\item If the $\cv{}_i^1$ and $\cv{}_i^2$ are different,
+then \tcode{const} is in every $\cv{}_k^2$ for $0 < k < i$.
 \end{itemize}
 
 \begin{note}
@@ -507,15 +507,15 @@ can be converted to a prvalue of type \tcode{std::nullptr_t}.
 \begin{note} The resulting prvalue is not a null pointer value. \end{note}
 
 \pnum
-A prvalue of type ``pointer to \cvqual{cv} \tcode{T}'', where \tcode{T}
+A prvalue of type ``pointer to \cv{} \tcode{T}'', where \tcode{T}
 is an object type, can be converted to a prvalue of type ``pointer to
-\cvqual{cv} \tcode{void}''.
+\cv{} \tcode{void}''.
 The pointer value\iref{basic.compound} is unchanged by this conversion.
 
 \pnum
-A prvalue of type ``pointer to \cvqual{cv} \tcode{D}'', where \tcode{D}
+A prvalue of type ``pointer to \cv{} \tcode{D}'', where \tcode{D}
 is a class type, can be converted to a prvalue of type ``pointer to
-\cvqual{cv} \tcode{B}'', where \tcode{B} is a base class\iref{class.derived}
+\cv{} \tcode{B}'', where \tcode{B} is a base class\iref{class.derived}
 of \tcode{D}. If \tcode{B} is an
 inaccessible\iref{class.access} or
 ambiguous\iref{class.member.lookup} base class of \tcode{D}, a program
@@ -543,9 +543,9 @@ conversion, and not the sequence of a pointer-to-member conversion
 followed by a qualification conversion\iref{conv.qual}.
 
 \pnum
-A prvalue of type ``pointer to member of \tcode{B} of type \cvqual{cv}
+A prvalue of type ``pointer to member of \tcode{B} of type \cv{}
 \tcode{T}'', where \tcode{B} is a class type, can be converted to
-a prvalue of type ``pointer to member of \tcode{D} of type \cvqual{cv}
+a prvalue of type ``pointer to member of \tcode{D} of type \cv{}
 \tcode{T}'', where \tcode{D} is a derived class\iref{class.derived}
 of \tcode{B}. If \tcode{B} is an
 inaccessible\iref{class.access},
@@ -556,7 +556,7 @@ The result of the conversion refers to the same member as the pointer to
 member before the conversion took place, but it refers to the base class
 member as if it were a member of the derived class. The result refers to
 the member in \tcode{D}'s instance of \tcode{B}. Since the result has
-type ``pointer to member of \tcode{D} of type \cvqual{cv} \tcode{T}'',
+type ``pointer to member of \tcode{D} of type \cv{} \tcode{T}'',
 indirection through it with a \tcode{D} object is valid. The result is the same
 as if indirecting through the pointer to member of \tcode{B} with the
 \tcode{B} subobject of \tcode{D}. The null member pointer value is

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -286,13 +286,13 @@ is a type \tcode{T3}
 similar to \tcode{T1} whose cv-qualification signature\iref{conv.qual} is:
 \begin{itemize}
 \item
-for every $i > 0$, $cv^3_i$ is the union of
-$cv^1_i$ and $cv^2_i$;
+for every $i > 0$, $\cv{}^3_i$ is the union of
+$\cv{}^1_i$ and $\cv{}^2_i$;
 
 \item
-if the resulting $cv^3_i$ is different from
-$cv^1_i$ or $cv^2_i$, then
-\tcode{const} is added to every $cv^3_k$ for $0 < k < i$.
+if the resulting $\cv{}^3_i$ is different from
+$\cv{}^1_i$ or $\cv{}^2_i$, then
+\tcode{const} is added to every $\cv{}^3_k$ for $0 < k < i$.
 \end{itemize}
 
 \begin{note} Given similar types \tcode{T1} and \tcode{T2}, this
@@ -2455,7 +2455,7 @@ the \grammarterm{postfix-expression} before the dot or arrow.
 \pnum
 The left-hand side of the dot operator shall be of scalar type. The
 left-hand side of the arrow operator shall be of pointer to scalar type.
-This scalar type is the object type. The \cvqual{cv}-unqualified
+This scalar type is the object type. The cv-unqualified
 versions of the object type and of the type designated by the
 \grammarterm{pseudo-destructor-name} shall be the same type. Furthermore,
 the two \grammarterm{type-name}{s} in a \grammarterm{pseudo-destructor-name} of
@@ -2575,13 +2575,13 @@ member function. The type of \tcode{E1.E2} is the same type as that of
 
 \item Otherwise, if \tcode{E1.E2} refers to a non-static member
 function and the type of \tcode{E2} is ``function of
-parameter-type-list \cvqual{cv} \opt{\grammarterm{ref-qualifier}} returning \tcode{T}'', then
+parameter-type-list \cv{} \opt{\grammarterm{ref-qualifier}} returning \tcode{T}'', then
 \tcode{E1.E2} is a prvalue. The expression designates a
 non-static member function. The expression can be used only as the
 left-hand operand of a member function call\iref{class.mfct}.
 \begin{note} Any redundant set of parentheses surrounding the expression
 is ignored\iref{expr.prim}. \end{note} The type of \tcode{E1.E2} is
-``function of parameter-type-list \cvqual{cv} returning \tcode{T}''.
+``function of parameter-type-list \cv{} returning \tcode{T}''.
 \end{itemize}
 
 \item If \tcode{E2} is a nested type, the expression \tcode{E1.E2} is
@@ -2658,7 +2658,7 @@ The result of the expression \tcode{dynamic_cast<T>(v)} is the result of
 converting the expression \tcode{v} to type \tcode{T}.
 \indextext{type!incomplete}%
 \tcode{T} shall be a pointer or reference to a complete class type, or
-``pointer to \cvqual{cv} \tcode{void}''. The \tcode{dynamic_cast} operator shall not cast
+``pointer to \cv{} \tcode{void}''. The \tcode{dynamic_cast} operator shall not cast
 away constness\iref{expr.const.cast}.
 
 \pnum
@@ -2712,7 +2712,7 @@ Otherwise, \tcode{v} shall be a pointer to or a glvalue of a polymorphic
 type\iref{class.virtual}.
 
 \pnum
-If \tcode{T} is ``pointer to \cvqual{cv} \tcode{void}'', then the result
+If \tcode{T} is ``pointer to \cv{} \tcode{void}'', then the result
 is a pointer to the most derived object pointed to by \tcode{v}.
 Otherwise, a runtime check is applied to see if the object pointed or
 referred to by \tcode{v} can be converted to the type pointed or
@@ -3337,13 +3337,13 @@ yielding \placeholder{n} such that
 \tcode{T2} has a cv-decomposition of the form
 
 \begin{indented}
-$cv_0^2$ $P_0^2$ $cv_1^2$ $P_1^2$ $\cdots$ $cv_{n-1}^2$ $P_{n-1}^2$ $cv_n^2$ $\mathtt{U}_2$,
+$\cv{}_0^2$ $P_0^2$ $\cv{}_1^2$ $P_1^2$ $\cdots$ $\cv{}_{n-1}^2$ $P_{n-1}^2$ $\cv{}_n^2$ $\mathtt{U}_2$,
 \end{indented}
 
 and there is no qualification conversion that converts \tcode{T1} to
 
 \begin{indented}
-$cv_0^2$ $P_0^1$ $cv_1^2$ $P_1^1$ $\cdots$ $cv_{n-1}^2$ $P_{n-1}^1$ $cv_n^2$ $\mathtt{U}_1$.
+$\cv{}_0^2$ $P_0^1$ $\cv{}_1^2$ $P_1^1$ $\cdots$ $\cv{}_{n-1}^2$ $P_{n-1}^1$ $\cv{}_n^2$ $\mathtt{U}_1$.
 \end{indented}
 
 \pnum
@@ -3427,7 +3427,7 @@ result is ``\tcode{T}''.
 \begin{note}
 \indextext{type!incomplete}%
 Indirection through a pointer to an incomplete type (other than
-\cvqual{cv} \tcode{void}) is valid. The lvalue thus obtained can be
+\cv{} \tcode{void}) is valid. The lvalue thus obtained can be
 used in limited ways (to initialize a reference, for example); this
 lvalue must not be converted to a prvalue, see~\ref{conv.lval}.
 \end{note}
@@ -4622,9 +4622,9 @@ contain the member to which
 Otherwise, the expression \tcode{E1} is sequenced before the expression \tcode{E2}.
 
 \pnum
-The restrictions on \cvqual{cv-}qualification, and the manner in which
-the \cvqual{cv-}qualifiers of the operands are combined to produce the
-\cvqual{cv-}qualifiers of the result, are the same as the rules for
+The restrictions on cv-qualification, and the manner in which
+the cv-qualifiers of the operands are combined to produce the
+cv-qualifiers of the result, are the same as the rules for
 \tcode{E1.E2} given in~\ref{expr.ref}.
 \begin{note}
 It is not possible to use a pointer to member that refers to a
@@ -5397,9 +5397,9 @@ includes the case where both operands are \grammarterm{throw-expression}{s}.
 Otherwise, if the second and third operand are glvalue bit-fields
 of the same value category and
 of types \cvqual{cv1} \tcode{T} and \cvqual{cv2} \tcode{T}, respectively,
-the operands are considered to be of type \cvqual{cv} \tcode{T}
+the operands are considered to be of type \cv{} \tcode{T}
 for the remainder of this subclause,
-where \cvqual{cv} is the union of \cvqual{cv1} and \cvqual{cv2}.
+where \cv{} is the union of \cvqual{cv1} and \cvqual{cv2}.
 
 \pnum
 Otherwise, if the second and third operand have different types and

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -7800,15 +7800,15 @@ If
 \tcode{A}
 is a type
 \begin{indented}
-$\text{\cv}_{1,0}$ ``pointer to $\ldots$'' $\text{\cv}_{1,n-1}$ ``pointer to''
-$\text{\cv}_{1,n}$ \tcode{T1}
+$\cv{}_{1,0}$ ``pointer to $\ldots$'' $\cv{}_{1,n-1}$ ``pointer to''
+$\cv{}_{1,n}$ \tcode{T1}
 \end{indented}
 and
 \tcode{P}
 is a type
 \begin{indented}
-$\text{\cv}_{2,0}$ ``pointer to $\ldots$'' $\text{\cv}_{2,n-1}$ ``pointer to''
-$\text{\cv}_{2,n}$ \tcode{T2},
+$\cv{}_{2,0}$ ``pointer to $\ldots$'' $\cv{}_{2,n-1}$ ``pointer to''
+$\cv{}_{2,n}$ \tcode{T2},
 \end{indented}
 then the cv-unqualified
 \tcode{T1}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1681,8 +1681,8 @@ types in $\tcode{U}_i$. Let $\tcode{A}_{ik}$ be the ${k}^\text{th}$ type in $\tc
 $\tcode{A}_{ik}$ the following requirements shall be satisfied:
 \begin{itemize}
 \item If $\tcode{T}_i$ is deduced as an lvalue reference type, then
-      \tcode{is_constructible_v<$\tcode{A}_{ik}$, $cv_i\;\tcode{A}_{ik}$\&> == true}, otherwise
-\item \tcode{is_constructible_v<$\tcode{A}_{ik}$, $cv_i\;\tcode{A}_{ik}$\&\&> == true}.
+      \tcode{is_constructible_v<$\tcode{A}_{ik}$, $\cv{}_i\;\tcode{A}_{ik}$\&> == true}, otherwise
+\item \tcode{is_constructible_v<$\tcode{A}_{ik}$, $\cv{}_i\;\tcode{A}_{ik}$\&\&> == true}.
 \end{itemize}
 
 \pnum


### PR DESCRIPTION
Fixes #1474.