### PR TITLE
[basic.def.odr] Adds note that x may be part of a qualified id

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -367,9 +367,9 @@ an expression or conversion as follows:
 \end{itemize}
 
 \pnum
-A variable \tcode{x} whose name appears as a
-potentially-evaluated expression \tcode{e}
-is \defnx{odr-used}{odr-use} by \tcode{e} unless
+A potentially-evaluated \grammarterm{id-expression}
+\tcode{e} that denotes a variable \tcode{x}
+\defnx{odr-uses}{odr-use} \tcode{x} unless
 \begin{itemize}
 \item
   \tcode{x} is a reference that is


### PR DESCRIPTION
Following from https://stackoverflow.com/questions/47952024
I'm sure there's a better way to word this.