### PR TITLE
P0969R0 editorial fix

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -6111,19 +6111,20 @@ Otherwise,
 all of \tcode{E}'s non-static data members
 shall be direct members of \tcode{E} or
 of the same base class of \tcode{E},
-well-formed when named as \tcode{e.\placeholder{name}}
-in the context of the structured binding,
 \tcode{E} shall not have an anonymous union member, and
 the number of elements in the \grammarterm{identifier-list} shall be
 equal to the number of non-static data members of \tcode{E}.
-Designating the non-static data members of \tcode{E} as
-\tcode{m}$_0$, \tcode{m}$_1$, \tcode{m}$_2$, ...
+For a class \tcode{E} whose non-static data members are named
+$\tcode{m}_0$, $\tcode{m}_1$, $\tcode{m}_2$, ...
 (in declaration order),
 each \tcode{v}$_i$ is the
-name of an lvalue that refers to the member \tcode{m}$_i$ of \tcode{e} and
-whose type is \cv{}~$\tcode{T}_i$, where $\tcode{T}_i$ is the declared type of
-that member; the referenced type is \cv{}~$\tcode{T}_i$. The lvalue is a
-bit-field if that member is a bit-field.
+name of an lvalue that refers to $\tcode{e.m}_i$ and
+whose type is \cv{}~$\tcode{T}_i$,
+where $\tcode{T}_i$ is the declared type of $\tcode{m}_i$;
+the referenced type is \cv{}~$\tcode{T}_i$.
+Each such expression $\tcode{e.m}_i$ shall be well-formed
+in the context of the structured binding declaration.
+The lvalue is a bit-field if that member is a bit-field.
 \begin{example}
 \begin{codeblock}
 struct S { int x1 : 2; volatile double y1; };


### PR DESCRIPTION
Proposed editorial improvement to [dcl.struct.bind]p4:

 * removes unusual grammar construction "[...], well-formed [...]"
 * defines the `name` placeholder used in the `e.name` expressions