### PR TITLE
[ostream.manip] fix "basic_osyncbuf" typo

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -6694,7 +6694,7 @@ template<class charT, class traits>
 \pnum
 \effects
 If \tcode{os.rdbuf()} is a
-\tcode{basic_osyncbuf<charT, traits, Allocator>*},
+\tcode{basic_syncbuf<charT, traits, Allocator>*},
 called \tcode{buf} for the purpose of exposition,
 calls \tcode{buf->set_emit_on_sync(true)}.
 Otherwise this manipulator has no effect.
@@ -6702,7 +6702,7 @@ Otherwise this manipulator has no effect.
 To work around the issue that the
 \tcode{Allocator} template argument can not be deduced,
 implementations can introduce an intermediate base class
-to \tcode{basic_osyncbuf} that manages its \tcode{emit_on_sync} flag.
+to \tcode{basic_syncbuf} that manages its \tcode{emit_on_sync} flag.
 \end{note}
 
 \pnum
@@ -6720,7 +6720,7 @@ template<class charT, class traits>
 \pnum
 \effects
 If \tcode{os.rdbuf()} is a
-\tcode{basic_osyncbuf<charT, traits, Allocator>*},
+\tcode{basic_syncbuf<charT, traits, Allocator>*},
 called \tcode{buf} for the purpose of exposition,
 calls \tcode{buf->set_emit_on_sync(false)}.
 Otherwise this manipulator has no effect.
@@ -6741,7 +6741,7 @@ template<class charT, class traits>
 \effects
 Calls \tcode{os.flush()}.
 Then, if \tcode{os.rdbuf()} is a
-\tcode{basic_osyncbuf<charT, traits, Allocator>*},
+\tcode{basic_syncbuf<charT, traits, Allocator>*},
 called \tcode{buf} for the purpose of exposition,
 calls \tcode{buf->emit()}.
 


### PR DESCRIPTION
Fixes #1962.