### PR TITLE
[ostream.manip,time] Replace "can not" with "cannot"

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -6700,7 +6700,7 @@ calls \tcode{buf->set_emit_on_sync(true)}.
 Otherwise this manipulator has no effect.
 \begin{note}
 To work around the issue that the
-\tcode{Allocator} template argument can not be deduced,
+\tcode{Allocator} template argument cannot be deduced,
 implementations can introduce an intermediate base class
 to \tcode{basic_osyncbuf} that manages its \tcode{emit_on_sync} flag.
 \end{note}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -26431,7 +26431,7 @@ It is safe to call this function from multiple threads at one time.
 \pnum
 \throws
 \tcode{runtime_error} if for any reason
-a reference can not be returned to a valid \tcode{tzdb_list}
+a reference cannot be returned to a valid \tcode{tzdb_list}
 containing one or more valid \tcode{tzdb}s.
 \end{itemdescr}
 
@@ -26516,7 +26516,7 @@ This function is thread-safe with respect to
 \pnum
 \throws
 \tcode{runtime_error} if for any reason
-a reference can not be returned to a valid \tcode{tzdb}.
+a reference cannot be returned to a valid \tcode{tzdb}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{remote_version}}%
@@ -26753,7 +26753,7 @@ except that it is guaranteed not to be in the range \range{begin}{end}
 The \tcode{abbrev} data member indicates
 the current abbreviation used for the associated \tcode{time_zone} and \tcode{time_point}.
 Abbreviations are not unique among the \tcode{time_zones},
-and so one can not reliably map abbreviations back to a \tcode{time_zone} and UTC offset.
+and so one cannot reliably map abbreviations back to a \tcode{time_zone} and UTC offset.
 
 \indexlibrarymember{operator<<}{sys_info}
 \begin{itemdecl}
@@ -28161,7 +28161,7 @@ Equivalent to \tcode{\%H:\%M}.
 \tcode{\%S} &
 Seconds as a decimal number.
 If the number of seconds is less than \tcode{10}, the result is prefixed with \tcode{0}.
-If the precision of the input can not be exactly represented with seconds,
+If the precision of the input cannot be exactly represented with seconds,
 then the format is a decimal floating point number with a fixed format
 and a precision matching that of the precision of the input
 (or to a microseconds precision if the conversion to floating point decimal seconds


### PR DESCRIPTION
"can not" represents the (technical) ability not to do something, whereas "cannot" is the (technical) inability to do something. We mean the latter.