### PR TITLE
Travis CI: Upgrade to newer TeX Live distribution.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,17 @@
 # Builds the C++ standard document on Travis CI <https://travis-ci.org/cplusplus/draft>
 #
 
+dist: trusty
+sudo: required
+language: cpp
+
+services:
+  - docker
+
+before_install:
+  - docker pull godbyk/texlive-basic:latest
+  - docker run -itd -v $TRAVIS_BUILD_DIR:/$TRAVIS_REPO_SLUG --name texlive-basic godbyk/texlive-basic
+
 env:
   - BUILD_TYPE=latexmk   # build using latexmk, also check for overfull hboxes
   - BUILD_TYPE=make      # build using Makefile
@@ -14,26 +25,26 @@ script:
   # Build std.pdf
   - pushd source
   - if [ "$BUILD_TYPE" = "latexmk" ]; then
-      latexmk -pdf std -silent;
+      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && latexmk -pdf std -silent";
       ! grep -Fe "Overfull \\hbox" std.log;
     fi
   - if [ "$BUILD_TYPE" = "make" ]; then
-      make -j2;
+      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && make -j2";
     fi
   - if [ "$BUILD_TYPE" = "complete" ]; then
       for FIGURE in *.dot; do
-        dot -o$(basename $FIGURE .dot).pdf -Tpdf $FIGURE;
+        docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && dot -o$(basename $FIGURE .dot).pdf -Tpdf $FIGURE";
       done;
-      pdflatex std;
-      pdflatex std;
-      pdflatex std;
-      makeindex generalindex;
-      makeindex libraryindex;
-      makeindex grammarindex;
-      makeindex impldefindex;
-      makeindex -s basic.gst -o xrefindex.gls xrefindex.glo
-      pdflatex std;
-      pdflatex std;
+      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && pdflatex std";
+      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && pdflatex std";
+      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && pdflatex std";
+      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && makeindex generalindex";
+      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && makeindex libraryindex";
+      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && makeindex grammarindex";
+      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && makeindex impldefindex";
+      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && makeindex -s basic.gst -o xrefindex.gls xrefindex.glo";
+      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && pdflatex std";
+      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && pdflatex std";
     fi
   - popd
   # Fail if there is whitespace at the ends of any lines
@@ -52,24 +63,8 @@ script:
   # Check to see if generated files are out-dated
   - pushd source
   - for FIGURE in *.dot; do
-      dot -o$(basename $FIGURE .dot).pdf -Tpdf $FIGURE;
+      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && dot -o$(basename $FIGURE .dot).pdf -Tpdf $FIGURE";
       git status --porcelain $(basename $FIGURE .dot).pdf;
     done
   - popd
 
-sudo: false
-
-addons:
-  apt:
-    packages:
-    - latexmk
-    - poppler-utils
-    - texlive-binaries
-    - texlive-fonts-recommended
-    - texlive-latex-base
-    - texlive-latex-extra
-    - texlive-latex-recommended
-    - texlive-generic-recommended
-    - texlive-binaries
-    - graphviz
-    - lmodern


### PR DESCRIPTION
This changes the Travis CI build server to use a Docker container that's running a newer version of Ubuntu (16.04) which comes with a newer version of TeX Live (2016).

This is, in part, to address issue #1830.

It will also allow us to easily upgrade TeX Live versions in the future by swapping in a newer Docker image.