### PR TITLE
[temp.concept]: Use note; no syntax for explicit specialization, etc.

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -3980,13 +3980,13 @@ A concept shall not have associated constraints\iref{temp.constr.decl}.
 
 \pnum
 A concept is not instantiated\iref{temp.spec}.
-A program that
-explicitly instantiates\iref{temp.explicit},
-explicitly specializes\iref{temp.expl.spec},
-or partially specializes a concept is ill-formed.
 \begin{note}
 An \grammarterm{id-expression} that denotes a concept specialization
 is evaluated as an expression\iref{expr.prim.id}.
+A concept cannot be
+explicitly instantiated\iref{temp.explicit},
+explicitly specialized\iref{temp.expl.spec},
+or partially specialized.
 \end{note}
 
 \pnum


### PR DESCRIPTION
Explicit specialization, etc. of a concept cannot be formed
syntactically. As such, a further rule to prevent such constructs is
redundant as normative text.

Implements the proposed direction from core/2017/07/2719.