### PR TITLE
empty xrefdelta.gls

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,9 @@ If you can't use latexmk or make for some reason, you can run LaTeX manually ins
 #. run ``makeindex libraryindex``
 #. run ``makeindex grammarindex``
 #. run ``makeindex impldefindex``
+#. run ``pdflatex std`` once more.
 #. run ``makeindex -s basic.gst -o xrefindex.gls xrefindex.glo``
+#. run ``makeindex -s basic.gst -o xrefdelta.gls xrefdelta.glo``
 #. run ``pdflatex std`` twice more.
 
 Generated input files

--- a/source/Makefile
+++ b/source/Makefile
@@ -42,6 +42,7 @@ reindex:
 	makeindex libraryindex
 	makeindex grammarindex
 	makeindex impldefindex
+	$(STDPDF)
 	makeindex -s basic.gst -o xrefindex.gls xrefindex.glo
 	makeindex -s basic.gst -o xrefdelta.gls xrefdelta.glo
 	$(STDPDF)


### PR DESCRIPTION
using "make reindex" in a clean directory generates an empty xrefdelta.gls file and therefore no "Cross references from ISO C++ 2017". An additional pdflatex seems needed before "makeindex -s basic.gst -o xrefdelta.gls xrefdelta.glo". Also added to README.rst.