### PR TITLE
[grammar index] Fix warnings; prefer listing bold page locators.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
       docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && pdflatex std";
       docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && makeindex generalindex";
       docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && makeindex libraryindex";
-      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && makeindex grammarindex";
+      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && xindy -M idxbfpage -M texindy -C utf8 -L english -t grammarindex.ilg grammarindex.idx";
       docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && makeindex impldefindex";
       docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && pdflatex std";
       docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && makeindex -s basic.gst -o xrefindex.gls xrefindex.glo";

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,11 @@ script:
       docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && pdflatex std";
       docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && pdflatex std";
       docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && pdflatex std";
-      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && makeindex generalindex";
-      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && makeindex libraryindex";
-      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && xindy -M idxbfpage -M texindy -C utf8 -L english -t grammarindex.ilg grammarindex.idx";
-      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && makeindex impldefindex";
-      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && pdflatex std";
+      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && xindy -M texindy -M idxbfpage -C utf8 -L english -t generalindex.ilg generalindex.idx";
+      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && xindy -M texindy -M idxbfpage -C utf8 -L english -t headerindex.ilg headerindex.idx";
+      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && xindy -M texindy -M idxbfpage -C utf8 -L english -t libraryindex.ilg libraryindex.idx";
+      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && xindy -M texindy -M idxbfpage -C utf8 -L english -t grammarindex.ilg grammarindex.idx";
+      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && xindy -M texindy -M idxbfpage -C utf8 -L english -t impldefindex.ilg impldefindex.idx";
       docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && makeindex -s basic.gst -o xrefindex.gls xrefindex.glo";
       docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && makeindex -s basic.gst -o xrefdelta.gls xrefdelta.glo";
       docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && pdflatex std";

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Getting Started on Debian-based Systems
 
 Install the following packages:
 
-   sudo apt-get install latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
+   sudo apt-get install latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended xindy
 
 -------------------------
 Getting Started on Fedora
@@ -40,7 +40,7 @@ Getting Started on Fedora
 
 Install the following packages:
 
-   dnf install texlive texlive-isodate texlive-relsize texlive-ulem texlive-fixme texlive-extract
+   dnf install texlive texlive-isodate texlive-relsize texlive-ulem texlive-fixme texlive-extract texlive-xindy
 
 -----------------------------
 Getting Started on Arch Linux
@@ -75,6 +75,7 @@ If you can't use latexmk or make for some reason, you can run LaTeX manually ins
 #. run ``makeindex generalindex``
 #. run ``makeindex libraryindex``
 #. run ``makeindex grammarindex``
+#. run ``xindy -M idxbfpage -M texindy -C utf8 -L english -t grammarindex.ilg grammarindex.idx``
 #. run ``makeindex impldefindex``
 #. run ``pdflatex std`` once more.
 #. run ``makeindex -s basic.gst -o xrefindex.gls xrefindex.glo``

--- a/source/Makefile
+++ b/source/Makefile
@@ -37,12 +37,11 @@ reindex:
 	$(STDPDF)
 	$(STDPDF)
 	$(STDPDF)
-	makeindex generalindex
-	makeindex headerindex
-	makeindex libraryindex
-	xindy -M idxbfpage -M texindy -C utf8 -L english -t grammarindex.ilg grammarindex.idx
-	makeindex impldefindex
-	$(STDPDF)
+	xindy -M texindy -M idxbfpage -C utf8 -L english -t generalindex.ilg generalindex.idx
+	xindy -M texindy -M idxbfpage -C utf8 -L english -t headerindex.ilg headerindex.idx
+	xindy -M texindy -M idxbfpage -C utf8 -L english -t libraryindex.ilg libraryindex.idx
+	xindy -M texindy -M idxbfpage -C utf8 -L english -t grammarindex.ilg grammarindex.idx
+	xindy -M texindy -M idxbfpage -C utf8 -L english -t impldefindex.ilg impldefindex.idx
 	makeindex -s basic.gst -o xrefindex.gls xrefindex.glo
 	makeindex -s basic.gst -o xrefdelta.gls xrefdelta.glo
 	$(STDPDF)

--- a/source/Makefile
+++ b/source/Makefile
@@ -40,7 +40,7 @@ reindex:
 	makeindex generalindex
 	makeindex headerindex
 	makeindex libraryindex
-	makeindex grammarindex
+	xindy -M idxbfpage -M texindy -C utf8 -L english -t grammarindex.ilg grammarindex.idx
 	makeindex impldefindex
 	$(STDPDF)
 	makeindex -s basic.gst -o xrefindex.gls xrefindex.glo

--- a/source/access.tex
+++ b/source/access.tex
@@ -3,9 +3,9 @@
 \indextext{access control|(}
 
 \indextext{protection|see{access control}}
-\indextext{\idxcode{private}|see{access control, \tcode{private}}}
-\indextext{\idxcode{protected}|see{access control, \tcode{protected}}}
-\indextext{\idxcode{public}|see{access control, \tcode{public}}}
+\indextext{\idxcode{private}|see{access control!\tcode{private}}}
+\indextext{\idxcode{protected}|see{access control!\tcode{protected}}}
+\indextext{\idxcode{public}|see{access control!\tcode{public}}}
 
 \pnum
 A member of a class can be
@@ -36,7 +36,7 @@ and local classes.}
 
 \pnum
 \indextext{access control!member name}%
-\indextext{default access control|see{access control, default}}%
+\indextext{default access control|see{access control!default}}%
 \indextext{access control!default}%
 Members of a class defined with the keyword
 \tcode{class}

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -877,7 +877,7 @@ see~\ref{stmt.select}.
 
 \pnum
 \indextext{scope!function parameter}%
-\indextext{scope!function prototype|see{scope, function parameter}}%
+\indextext{scope!function prototype|see{scope!function parameter}}%
 \indextext{parameter!scope of}%
 A function parameter
 (including one appearing in a
@@ -1751,7 +1751,7 @@ X C::arr[number];   // ill-formed:
 
 \pnum
 \indextext{operator!scope resolution}%
-\indextext{scope resolution operator|see{operator, scope resolution}}%
+\indextext{scope resolution operator|see{operator!scope resolution}}%
 A name prefixed by the unary scope operator \tcode{::}\iref{expr.prim.id.qual}
 is looked up in global scope, in the translation unit where it is used.
 The name shall be declared in global namespace scope or shall be a name
@@ -3531,7 +3531,7 @@ requirement of the type in the complete-object case.
 \pnum
 \indextext{alignment!extended}%
 \indextext{alignment!new-extended}%
-\indextext{over-aligned type|see{type, over-aligned}}%
+\indextext{over-aligned type|see{type!over-aligned}}%
 An \defn{extended alignment} is represented by an alignment
 greater than \tcode{alignof(std::max_align_t)}. It is \impldef{support for extended alignments}
 whether any extended alignments are supported and the contexts in which they are
@@ -3791,7 +3791,7 @@ layout-compatible standard-layout class types\iref{class.mem}.
 \pnum
 \indextext{type!fundamental}%
 \indextext{type!integral}%
-\indextext{floating-point type|see{type, floating-point}}%
+\indextext{floating-point type|see{type!floating-point}}%
 \indextext{type!implementation-defined \tcode{sizeof}}%
 \indextext{type!Boolean}%
 \indextext{type!\idxcode{char}}%
@@ -3915,13 +3915,13 @@ reduced modulo the number that is one greater than the largest value
 that can be represented by the resulting unsigned integer type.}
 
 \pnum
-\indextext{\idxcode{char16_t}|see{type, \tcode{char16_t}}}%
-\indextext{\idxcode{char32_t}|see{type, \tcode{char32_t}}}%
-\indextext{\idxcode{wchar_t}|see{type, \tcode{wchar_t}}}%
+\indextext{\idxcode{char16_t}|see{type!\tcode{char16_t}}}%
+\indextext{\idxcode{char32_t}|see{type!\tcode{char32_t}}}%
+\indextext{\idxcode{wchar_t}|see{type!\tcode{wchar_t}}}%
 \indextext{type!\idxcode{char16_t}}%
 \indextext{type!\idxcode{char32_t}}%
 \indextext{type!\idxcode{wchar_t}}%
-\indextext{underlying type|see{type, underlying}}%
+\indextext{underlying type|see{type!underlying}}%
 \indextext{type!underlying!\idxcode{char16_t}}%
 \indextext{type!underlying!\idxcode{char32_t}}%
 Type \tcode{wchar_t} is a distinct type whose values can represent
@@ -4103,10 +4103,10 @@ a \defn{pointer to} an object or function (the pointer is said to \defn{point} t
 \item
 a \defn{pointer past the end of} an object\iref{expr.add}, or
 \item
-\indextext{null pointer value|see{value, null pointer}}
+\indextext{null pointer value|see{value!null pointer}}
 the \defnx{null pointer value}{value!null pointer}\iref{conv.ptr} for that type, or
 \item
-\indextext{invalid pointer value|see{value, invalid pointer}}
+\indextext{invalid pointer value|see{value!invalid pointer}}
 an \defnx{invalid pointer value}{value!invalid pointer}.
 \end{itemize}
 A value of a
@@ -5399,7 +5399,7 @@ ordered variables concurrently with another sequence.
 \end{note}
 
 \pnum
-\indextext{non-initialization odr-use|see{odr-use, non-initialization}}%
+\indextext{non-initialization odr-use|see{odr-use!non-initialization}}%
 A \defnx{non-initialization odr-use}{odr-use!non-initialization}
 is an odr-use\iref{basic.def.odr} not caused directly or indirectly by
 the initialization of a non-local static or thread storage duration variable.

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -4,7 +4,7 @@
 
 \gramSec[gram.class]{Classes}
 
-\indextext{class!member function|see{member function, class}}
+\indextext{class!member function|see{member function!class}}
 
 \pnum
 \indextext{\idxcode{\{\}}!class declaration}%
@@ -128,7 +128,7 @@ it holds at most one data member at a time\iref{class.union}.
 Aggregates of class type are described in~\ref{dcl.init.aggr}.
 \end{note}
 
-\indextext{trivial class|see{class, trivial}}%
+\indextext{trivial class|see{class!trivial}}%
 \pnum
 A \defnx{trivially copyable class}{class!trivially copyable} is a class:
 
@@ -148,7 +148,7 @@ at least one of which is not deleted.
 \begin{note} In particular, a trivially copyable or trivial class does not have
 virtual functions or virtual base classes.\end{note}
 
-\indextext{standard-layout|see{class, standard-layout}}%
+\indextext{standard-layout|see{class!standard-layout}}%
 \pnum
 A class \tcode{S} is a \defnx{standard-layout class}{class!standard-layout} if it:
 \begin{itemize}
@@ -385,7 +385,7 @@ operator functions in~\ref{over.oper}.
 
 \pnum
 \indextext{class name!elaborated}%
-\indextext{elaborated type specifier|see{class name, elaborated}}%
+\indextext{elaborated type specifier|see{class name!elaborated}}%
 \begin{note}
 An \grammarterm{elaborated-type-specifier}\iref{dcl.type.elab} can also
 be used as a \grammarterm{type-specifier} as part of a declaration. It

--- a/source/conversions.tex
+++ b/source/conversions.tex
@@ -1,9 +1,9 @@
 %!TEX root = std.tex
 \rSec0[conv]{Standard conversions}
 
-\indextext{implicit conversion|see{conversion, implicit}}
-\indextext{contextually converted to bool|see{conversion, contextual}}
-\indextext{rvalue!lvalue conversion to|see{conversion, lvalue-to-rvalue}}%
+\indextext{implicit conversion|see{conversion!implicit}}
+\indextext{contextually converted to bool|see{conversion!contextual}}
+\indextext{rvalue!lvalue conversion to|see{conversion!lvalue-to-rvalue}}%
 
 \pnum
 \indextext{conversion!standard|(}%
@@ -191,8 +191,8 @@ See also~\ref{basic.lval}.\end{note}
 
 \pnum
 \indextext{conversion!array-to-pointer}%
-\indextext{decay!array|see{conversion, array-to-pointer}}%
-\indextext{decay!function|see{conversion, function-to-pointer}}%
+\indextext{decay!array|see{conversion!array-to-pointer}}%
+\indextext{decay!function|see{conversion!function-to-pointer}}%
 An lvalue or rvalue of type ``array of \tcode{N} \tcode{T}'' or ``array
 of unknown bound of \tcode{T}'' can be converted to a prvalue of type
 ``pointer to \tcode{T}''.
@@ -486,8 +486,8 @@ source type is \tcode{bool}, the value \tcode{false} is converted to zero and th
 
 \pnum
 \indextext{conversion!pointer}%
-\indextext{null pointer conversion|see{conversion, null pointer}}%
-\indextext{pointer!zero|see{value, null pointer}}%
+\indextext{null pointer conversion|see{conversion!null pointer}}%
+\indextext{pointer!zero|see{value!null pointer}}%
 \indextext{value!null pointer}%
 A \defnx{null pointer constant}{constant!null pointer} is an integer literal\iref{lex.icon} with
 value zero
@@ -528,7 +528,7 @@ the destination type.
 
 \pnum
 \indextext{conversion!pointer-to-member}%
-\indextext{null member pointer conversion|see{conversion, null member pointer}}%
+\indextext{null member pointer conversion|see{conversion!null member pointer}}%
 \indextext{constant!null pointer}%
 A null pointer constant\iref{conv.ptr} can be converted to a
 pointer-to-member

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4,7 +4,7 @@
 
 \gramSec[gram.dcl]{Declarations}
 
-\indextext{linkage specification|see{specification, linkage}}
+\indextext{linkage specification|see{specification!linkage}}
 
 \pnum
 Declarations generally specify how names are to be interpreted. Declarations have
@@ -2050,7 +2050,7 @@ declaration.
 
 \pnum
 \indextext{\idxcode{enum}!type of}%
-\indextext{\idxcode{enum}!underlying type|see{type, underlying}}%
+\indextext{\idxcode{enum}!underlying type|see{type!underlying}}%
 Each enumeration defines a type that is different from all other types.
 Each enumeration also has an \defnx{underlying type}{type!underlying!enumeration}.
 The underlying type can be explicitly specified using an \grammarterm{enum-base}.
@@ -2304,7 +2304,7 @@ that was introduced in the namespace
 in which the \grammarterm{named-namespace-definition} appears
 or that was introduced in a member of the inline namespace set of that namespace,
 the \grammarterm{namespace-definition}
-\indextext{extend|see{namespace, extend}}
+\indextext{extend|see{namespace!extend}}
 \defnx{extends}{namespace!extend} the previously-declared namespace.
 Otherwise, the \grammarterm{identifier} is introduced
 as a \grammarterm{namespace-name} into the declarative region

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -489,7 +489,10 @@ the object is const\iref{dcl.type.cv}.
 
 \rSec2[dcl.fct.spec]{Function specifiers}%
 \indextext{specifier!function}%
-\indextext{function|seealso{friend function; member function; inline function; virtual function}}
+\indextext{function|seealso{friend function}}
+\indextext{function|seealso{member function}}
+\indextext{function|seealso{inline function}}
+\indextext{function|seealso{virtual function}}
 
 \pnum
 A

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -5,11 +5,11 @@
 \gramSec[gram.decl]{Declarators}
 
 \indextext{initialization!class object|seealso{constructor}}%
-\indextext{\idxcode{*}|see{declarator, pointer}}
-\indextext{\idxcode{\&}|see{declarator, reference}}%
-\indextext{\idxcode{::*}|see{declarator, pointer-to-member}}%
-\indextext{\idxcode{[]}|see{declarator, array}}%
-\indextext{\idxcode{()}|see{declarator, function}}%
+\indextext{\idxcode{*}|see{declarator!pointer}}
+\indextext{\idxcode{\&}|see{declarator!reference}}%
+\indextext{\idxcode{::*}|see{declarator!pointer-to-member}}%
+\indextext{\idxcode{[]}|see{declarator!array}}%
+\indextext{\idxcode{()}|see{declarator!function}}%
 
 \pnum
 A declarator declares a single variable, function, or type, within a declaration.
@@ -102,7 +102,7 @@ The optional \grammarterm{requires-clause}\iref{temp} in an
 shall not be present when the declarator does not declare a
 function\iref{dcl.fct}.
 %
-\indextext{trailing requires-clause@trailing \textit{requires-clause}|see{\textit{requires-clause}, trailing}}%
+\indextext{trailing requires-clause@trailing \textit{requires-clause}|see{\textit{requires-clause}!trailing}}%
 When present after a declarator, the \grammarterm{requires-clause}
 is called the \defnx{trailing \grammarterm{requires-clause}}{%
 \idxgram{requires-clause}!trailing}.

--- a/source/derived.tex
+++ b/source/derived.tex
@@ -4,9 +4,9 @@
 
 \gramSec[gram.derived]{Derived classes}
 
-\indextext{virtual base class|see{base class, virtual}}
-\indextext{virtual function|see{function, virtual}}
-\indextext{dynamic binding|see{function, virtual}}
+\indextext{virtual base class|see{base class!virtual}}
+\indextext{virtual function|see{function!virtual}}
+\indextext{dynamic binding|see{function!virtual}}
 
 \pnum
 \indextext{base class}%
@@ -136,7 +136,7 @@ The order in which the base class subobjects are allocated in the most
 derived object\iref{intro.object} is unspecified.
 \begin{note}
 \indextext{directed acyclic graph|see{DAG}}%
-\indextext{lattice|see{DAG, subobject}}%
+\indextext{lattice|see{DAG!subobject}}%
 A derived class and its base class subobjects can be represented by a
 directed acyclic graph (DAG) where an arrow means ``directly derived
 from''. An arrow need not have a physical representation in memory.

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -4,8 +4,8 @@
 
 \gramSec[gram.except]{Exception handling}
 
-\indextext{exception object|see{exception handling, exception object}}%
-\indextext{object!exception|see{exception handling, exception object}}
+\indextext{exception object|see{exception handling!exception object}}%
+\indextext{object!exception|see{exception handling!exception object}}
 
 \pnum
 Exception handling provides a way of transferring control and information
@@ -54,8 +54,8 @@ appertains to the parameter of the catch clause\iref{except.handle}.
 \pnum
 \indextext{exception handling!try block}%
 \indextext{exception handling!handler}%
-\indextext{try block|see{exception handling, try block}}%
-\indextext{handler|see{exception handling, handler}}%
+\indextext{try block|see{exception handling!try block}}%
+\indextext{handler|see{exception handling!handler}}%
 A \grammarterm{try-block} is a \grammarterm{statement}\iref{stmt.stmt}.
 \begin{note} Within this Clause
 ``try block'' is taken to mean both \grammarterm{try-block} and
@@ -140,7 +140,7 @@ will result in executing
 \end{example}
 
 \pnum
-\indextext{function try block|see{exception handling, function try block}}%
+\indextext{function try block|see{exception handling!function try block}}%
 \indextext{exception handling!function try block}%
 A
 \grammarterm{function-try-block}
@@ -185,7 +185,7 @@ In this Clause, ``before'' and ``after'' refer to the
 
 \rSec1[except.throw]{Throwing an exception}%
 \indextext{exception handling!throwing}%
-\indextext{throwing|see{exception handling, throwing}}
+\indextext{throwing|see{exception handling!throwing}}
 
 \pnum
 Throwing an exception transfers control to a handler.
@@ -314,7 +314,7 @@ The destructor is potentially invoked\iref{class.dtor}.
 
 \pnum
 \indextext{exception handling!rethrow}%
-\indextext{rethrow|see{exception handling, rethrow}}%
+\indextext{rethrow|see{exception handling!rethrow}}%
 An exception is considered caught when a handler for that exception
 becomes active\iref{except.handle}.
 \begin{note}
@@ -355,8 +355,8 @@ Consequently, destructors should generally catch exceptions and not let them pro
 
 \rSec1[except.ctor]{Constructors and destructors}%
 \indextext{exception handling!constructors and destructors}%
-\indextext{constructor!exception handling|see{exception handling, constructors and destructors}}%
-\indextext{destructor!exception handling|see{exception handling, constructors and destructors}}
+\indextext{constructor!exception handling|see{exception handling!constructors and destructors}}%
+\indextext{destructor!exception handling|see{exception handling!constructors and destructors}}
 
 \pnum
 \indextext{unwinding!stack}%
@@ -597,7 +597,7 @@ is entered due to a throw. A handler is no longer considered active when the
 catch clause exits.
 
 \pnum
-\indextext{currently handled exception|see{exception handling, currently handled exception}}%
+\indextext{currently handled exception|see{exception handling!currently handled exception}}%
 The exception with the most recently activated handler that is
 still active is called the
 \defnx{currently handled exception}{exception handling!currently handled exception}.

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3675,9 +3675,12 @@ The result of \tcode{sizeof} and \tcode{sizeof...} is a constant of type
 
 \pnum
 \indextext{expression!\idxcode{new}}%
-\indextext{free store|seealso{\tcode{new}!\tcode{delete}}}%
-\indextext{memory management|seealso{\tcode{new}!\tcode{delete}}}%
-\indextext{storage management|see{\tcode{new}!\tcode{delete}}}%
+\indextext{free store|seealso{\tcode{new}}}%
+\indextext{free store|seealso{\tcode{delete}}}%
+\indextext{memory management|seealso{\tcode{new}}}%
+\indextext{memory management|seealso{\tcode{delete}}}%
+\indextext{storage management|see{\tcode{new}}}%
+\indextext{storage management|see{\tcode{delete}}}%
 \indextext{\idxcode{new}}%
 The \grammarterm{new-expression} attempts to create an object of the
 \grammarterm{type-id}\iref{dcl.name} or \grammarterm{new-type-id} to which

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5,13 +5,13 @@
 
 \indextext{\idxcode{operator new}|seealso{\tcode{new}}}%
 \indextext{\idxcode{operator delete}|seealso{\tcode{delete}}}%
-\indextext{usual arithmetic conversions|see{conversion, usual arithmetic}}%
-\indextext{\idxcode{==}|see{operator, equality}}%
-\indextext{\idxcode{"!=}|see{operator, inequality}}
-\indextext{\idxcode{static_cast}|see{cast, static}}%
-\indextext{\idxcode{dynamic_cast}|see{cast, dynamic}}%
-\indextext{\idxcode{const_cast}|see{cast, const}}%
-\indextext{\idxcode{reinterpret_cast}|see{cast, reinterpret}}
+\indextext{usual arithmetic conversions|see{conversion!usual arithmetic}}%
+\indextext{\idxcode{==}|see{operator!equality}}%
+\indextext{\idxcode{"!=}|see{operator!inequality}}
+\indextext{\idxcode{static_cast}|see{cast!static}}%
+\indextext{\idxcode{dynamic_cast}|see{cast!dynamic}}%
+\indextext{\idxcode{const_cast}|see{cast!const}}%
+\indextext{\idxcode{reinterpret_cast}|see{cast!reinterpret}}
 
 \rSec1[expr.pre]{Preamble}
 
@@ -736,7 +736,7 @@ void f() {
 \rSec3[expr.prim.id.qual]{Qualified names}
 
 \indextext{operator!scope resolution}%
-\indextext{\idxcode{::}|see{operator, scope resolution}}%
+\indextext{\idxcode{::}|see{operator!scope resolution}}%
 %
 \begin{bnf}
 \nontermdef{qualified-id}\br
@@ -2134,7 +2134,7 @@ tokens\iref{temp.names}.\end{note}
 
 \pnum
 \indextext{operator!subscripting}%
-\indextext{\idxcode{[]}|see{operator, subscripting}}%
+\indextext{\idxcode{[]}|see{operator!subscripting}}%
 A postfix expression followed by an expression in square brackets is a
 postfix expression. One of the expressions shall be a glvalue of type ``array of
 \tcode{T}'' or a prvalue of type ``pointer
@@ -2161,7 +2161,7 @@ A \grammarterm{braced-init-list} shall not be used with the built-in subscript o
 \pnum
 \indextext{expression!function call}%
 \indextext{operator!function call}%
-\indextext{\idxcode{()}|see{operator, function call}}%
+\indextext{\idxcode{()}|see{operator!function call}}%
 A function call is a postfix expression followed by parentheses
 containing a possibly empty, comma-separated list of
 \grammarterm{initializer-clause}{s} which
@@ -2475,11 +2475,11 @@ shall designate the same scalar type (ignoring cv-qualification).
 \indextext{syntax!class member}%
 \indextext{semantics!class member}%
 \indextext{operator!class member access}%
-\indextext{\idxcode{.}|see{operator, class member access}}%
-\indextext{dot operator|see{operator, class member access}}%
+\indextext{\idxcode{.}|see{operator!class member access}}%
+\indextext{dot operator|see{operator!class member access}}%
 \indextext{operator!class member access}%
-\indextext{\idxcode{->}|see{operator, class member access}}%
-\indextext{arrow operator|see{operator, class member access}}%
+\indextext{\idxcode{->}|see{operator!class member access}}%
+\indextext{arrow operator|see{operator!class member access}}%
 A postfix expression followed by a dot \tcode{.} or an arrow \tcode{->},
 optionally followed by the keyword
 \tcode{template}\iref{temp.names}, and then followed by an
@@ -2607,7 +2607,7 @@ of the object expression; see~\ref{class.access.base}.
 \pnum
 \indextext{expression!increment}%
 \indextext{operator!increment}%
-\indextext{\idxcode{++}|see{operator, increment}}%
+\indextext{\idxcode{++}|see{operator!increment}}%
 \indextext{postfix \tcode{++}}%
 The value of a postfix \tcode{++} expression is the value of its
 operand.
@@ -2641,7 +2641,7 @@ and~\ref{expr.ass}.
 \pnum
 \indextext{expression!decrement}%
 \indextext{operator!decrement}%
-\indextext{\idxcode{\dcr}|see{operator, decrement}}%
+\indextext{\idxcode{\dcr}|see{operator!decrement}}%
 \indextext{postfix \tcode{\dcr}}%
 The operand of postfix \tcode{\dcr} is decremented analogously to the
 postfix \tcode{++} operator.
@@ -3391,17 +3391,17 @@ Expressions with unary operators group right-to-left.
 \end{bnf}
 
 \indextext{operator!indirection}%
-\indextext{\idxcode{*}|see{operator, indirection}}%
+\indextext{\idxcode{*}|see{operator!indirection}}%
 \indextext{operator!address-of}%
-\indextext{\idxcode{\&}|see{operator, address-of}}%
+\indextext{\idxcode{\&}|see{operator!address-of}}%
 \indextext{operator!unary minus}%
-\indextext{\idxcode{-}|see{operator, unary minus}}%
+\indextext{\idxcode{-}|see{operator!unary minus}}%
 \indextext{operator!unary plus}%
-\indextext{\idxcode{+}|see{operator, unary plus}}%
+\indextext{\idxcode{+}|see{operator!unary plus}}%
 \indextext{operator!logical negation}%
-\indextext{\idxcode{"!}|see{operator, logical negation}}%
+\indextext{\idxcode{"!}|see{operator!logical negation}}%
 \indextext{operator!ones' complement}%
-\indextext{~@\tcode{\~}|see{operator, ones' complement}}%
+\indextext{~@\tcode{\~}|see{operator!ones' complement}}%
 \indextext{operator!increment}%
 \indextext{operator!decrement}%
 %
@@ -3675,9 +3675,9 @@ The result of \tcode{sizeof} and \tcode{sizeof...} is a constant of type
 
 \pnum
 \indextext{expression!\idxcode{new}}%
-\indextext{free store|seealso{\tcode{new}, \tcode{delete}}}%
-\indextext{memory management|seealso{\tcode{new}, \tcode{delete}}}%
-\indextext{storage management|see{\tcode{new}, \tcode{delete}}}%
+\indextext{free store|seealso{\tcode{new}!\tcode{delete}}}%
+\indextext{memory management|seealso{\tcode{new}!\tcode{delete}}}%
+\indextext{storage management|see{\tcode{new}!\tcode{delete}}}%
 \indextext{\idxcode{new}}%
 The \grammarterm{new-expression} attempts to create an object of the
 \grammarterm{type-id}\iref{dcl.name} or \grammarterm{new-type-id} to which
@@ -4023,7 +4023,7 @@ above, plus the size for the extended call had it not been extended, plus any
 padding necessary to align the allocated objects within the allocated memory.
 
 \pnum
-\indextext{placement new-expression@placement \gterm{new-expression}|see{\gterm{new-expression}, placement}}%
+\indextext{placement new-expression@placement \gterm{new-expression}|see{\gterm{new-expression}!placement}}%
 The \grammarterm{new-placement} syntax is used to supply additional
 arguments to an allocation function; such an expression is called
 a \defnx{placement \grammarterm{new-expression}}{\idxgram{new-expression}!placement}.
@@ -4118,7 +4118,7 @@ necessarily be the same as that of the block if the object is an array.
 \indextext{\idxcode{new}!initialization and}%
 \indextext{\idxcode{new}!constructor and}%
 \indextext{\idxcode{new}!default constructor and}%
-\indextext{default constructor|see{constructor, default}}%
+\indextext{default constructor|see{constructor!default}}%
 \indextext{trivial type}%
 \indextext{trivial class type}%
 A \grammarterm{new-expression} that creates an object of type \tcode{T}
@@ -4579,9 +4579,9 @@ of the cast.
 \indextext{expression!pointer-to-member}%
 \indextext{pointer to member}%
 \indextext{operator!pointer to member}%
-\indextext{\idxcode{.*}|see{operator, pointer to member}}%
+\indextext{\idxcode{.*}|see{operator!pointer to member}}%
 \indextext{operator!pointer to member}%
-\indextext{\idxcode{->*}|see{operator, pointer to member}}%
+\indextext{\idxcode{->*}|see{operator!pointer to member}}%
 The pointer-to-member operators \tcode{->*} and \tcode{.*} group
 left-to-right.
 
@@ -4682,12 +4682,12 @@ The multiplicative operators \tcode{*}, \tcode{/}, and \tcode{\%} group
 left-to-right.
 
 \indextext{operator!multiplication}%
-\indextext{\idxcode{*}|see{operator, multiplication}}%
+\indextext{\idxcode{*}|see{operator!multiplication}}%
 \indextext{operator!division}%
-\indextext{\idxcode{/}|see{operator, division}}%
+\indextext{\idxcode{/}|see{operator!division}}%
 \indextext{operator!remainder}%
-\indextext{\idxcode{\%}|see{operator, remainder}}%
-\indextext{remainder operator|see{operator, remainder}}%
+\indextext{\idxcode{\%}|see{operator!remainder}}%
+\indextext{remainder operator|see{operator!remainder}}%
 %
 \begin{bnf}
 \nontermdef{multiplicative-expression}\br
@@ -4729,11 +4729,11 @@ usual arithmetic conversions\iref{expr.arith.conv} are performed for operands of
 enumeration type.
 
 \indextext{operator!addition}%
-\indextext{addition operator|see{operator, addition}}%
-\indextext{\idxcode{+}|see{operator, addition}}%
+\indextext{addition operator|see{operator!addition}}%
+\indextext{\idxcode{+}|see{operator!addition}}%
 \indextext{operator!subtraction}%
-\indextext{subtraction operator|see{operator, subtraction}}%
-\indextext{\idxcode{-}|see{operator, subtraction}}%
+\indextext{subtraction operator|see{operator!subtraction}}%
+\indextext{\idxcode{-}|see{operator!subtraction}}%
 %
 \begin{bnf}
 \nontermdef{additive-expression}\br
@@ -4834,16 +4834,16 @@ converted to the type \tcode{std::ptrdiff_t}.
 \pnum
 \indextext{expression!left-shift-operator}%
 \indextext{expression!right-shift-operator}%
-\indextext{shift operator!left|see{operator, left shift}}%
-\indextext{shift operator!right|see{operator, right shift}}%
-\indextext{right shift operator|see{operator, right shift}}%
-\indextext{left shift operator|see{operator, left shift}}%
+\indextext{shift operator!left|see{operator!left shift}}%
+\indextext{shift operator!right|see{operator!right shift}}%
+\indextext{right shift operator|see{operator!right shift}}%
+\indextext{left shift operator|see{operator!left shift}}%
 The shift operators \tcode{<<} and \tcode{>>} group left-to-right.
 
 \indextext{operator!left shift}%
-\indextext{\idxcode{<<}|see{operator, left shift}}%
+\indextext{\idxcode{<<}|see{operator!left shift}}%
 \indextext{operator!right shift}%
-\indextext{\idxcode{>>}|see{operator, right shift}}%
+\indextext{\idxcode{>>}|see{operator!right shift}}%
 %
 \begin{bnf}
 \nontermdef{shift-expression}\br
@@ -4888,7 +4888,7 @@ The expression \tcode{E1} is sequenced before the expression \tcode{E2}.
 \pnum
 The three-way comparison operator groups left-to-right.
 
-\indextext{\idxcode{<=>}|see{operator, three-way comparison}}%
+\indextext{\idxcode{<=>}|see{operator!three-way comparison}}%
 \indextext{operator!three-way comparison}%
 \indextext{operator!spaceship}%
 
@@ -5039,13 +5039,13 @@ The relational operators group left-to-right.
 \end{example}
 
 \indextext{operator!less than}%
-\indextext{\idxcode{<}|see{operator, less than}}%
+\indextext{\idxcode{<}|see{operator!less than}}%
 \indextext{operator!greater than}%
-\indextext{\idxcode{>}|see{operator, greater than}}%
+\indextext{\idxcode{>}|see{operator!greater than}}%
 \indextext{operator!less than or equal to}%
-\indextext{\idxcode{<=}|see{operator, less than or equal to}}%
+\indextext{\idxcode{<=}|see{operator!less than or equal to}}%
 \indextext{operator!greater than or equal to}%
-\indextext{\idxcode{>=}|see{operator, greater than or equal to}}%
+\indextext{\idxcode{>=}|see{operator!greater than or equal to}}%
 %
 \begin{bnf}
 \nontermdef{relational-expression}\br
@@ -5242,7 +5242,7 @@ false.
 \indextext{expression!bitwise AND}%
 \indextext{operator!bitwise}%
 \indextext{operator!bitwise AND}%
-\indextext{\idxcode{\&}|see{operator, bitwise AND}}%
+\indextext{\idxcode{\&}|see{operator!bitwise AND}}%
 
 \begin{bnf}
 \nontermdef{and-expression}\br
@@ -5258,7 +5258,7 @@ applies only to integral or unscoped enumeration operands.
 \rSec2[expr.xor]{Bitwise exclusive OR operator}%
 \indextext{expression!bitwise exclusive OR}%
 \indextext{operator!bitwise exclusive OR}%
-\indextext{\idxcode{\caret}|see{operator, bitwise exclusive OR}}
+\indextext{\idxcode{\caret}|see{operator!bitwise exclusive OR}}
 
 \begin{bnf}
 \nontermdef{exclusive-or-expression}\br
@@ -5274,7 +5274,7 @@ operator applies only to integral or unscoped enumeration operands.
 \rSec2[expr.or]{Bitwise inclusive OR operator}%
 \indextext{expression!bitwise inclusive OR}%
 \indextext{operator!bitwise inclusive OR}%
-\indextext{\idxcode{"|}|see{operator, bitwise inclusive OR}}
+\indextext{\idxcode{"|}|see{operator!bitwise inclusive OR}}
 
 \begin{bnf}
 \nontermdef{inclusive-or-expression}\br
@@ -5290,7 +5290,7 @@ operator applies only to integral or unscoped enumeration operands.
 \rSec2[expr.log.and]{Logical AND operator}%
 \indextext{expression!logical AND}%
 \indextext{operator!logical AND}%
-\indextext{\idxcode{\&\&}|see{operator, logical AND}}%
+\indextext{\idxcode{\&\&}|see{operator!logical AND}}%
 
 \begin{bnf}
 \nontermdef{logical-and-expression}\br
@@ -5321,7 +5321,7 @@ value computation and side effect associated with the second expression.
 \rSec2[expr.log.or]{Logical OR operator}%
 \indextext{expression!logical OR}%
 \indextext{operator!logical OR}%
-\indextext{\idxcode{"|"|}|see{operator, logical OR}}%
+\indextext{\idxcode{"|"|}|see{operator!logical OR}}%
 
 \begin{bnf}
 \nontermdef{logical-or-expression}\br
@@ -5352,7 +5352,7 @@ and side effect associated with the second expression.
 \rSec2[expr.cond]{Conditional operator}%
 \indextext{expression!conditional operator}%
 \indextext{operator!conditional expression}%
-\indextext{\idxcode{?:}|see{operator, conditional expression}}%
+\indextext{\idxcode{?:}|see{operator!conditional expression}}%
 
 \begin{bnf}
 \nontermdef{conditional-expression}\br
@@ -5684,9 +5684,9 @@ a = { 1 } = b;            // syntax error
 \rSec2[expr.comma]{Comma operator}%
 \indextext{expression!comma}%
 \indextext{operator!comma}%
-\indextext{comma operator|see{operator, comma}}%
-\indextext{\idxcode{,}|see{operator, comma}}%
-\indextext{sequencing operator|see{operator, comma}}%
+\indextext{comma operator|see{operator!comma}}%
+\indextext{\idxcode{,}|see{operator!comma}}%
+\indextext{sequencing operator|see{operator!comma}}%
 
 \pnum
 The comma operator groups left-to-right.
@@ -6032,7 +6032,7 @@ fixed\iref{dcl.enum}, as array bounds\iref{dcl.array}, and
 as non-type template
 arguments\iref{temp.arg}.
 \end{note}
-\indextext{contextually converted constant expression of type \tcode{bool}|see{conversion, contextual}}%
+\indextext{contextually converted constant expression of type \tcode{bool}|see{conversion!contextual}}%
 \indextext{conversion!contextual to constant expression of type \tcode{bool}}%
 A \term{contextually converted constant expression of type \tcode{bool}} is
 an expression, contextually converted to \tcode{bool}\iref{conv},

--- a/source/idxbfpage.xdy
+++ b/source/idxbfpage.xdy
@@ -22,3 +22,13 @@
 ;(define-crossref-class "see" :unverified)
 ;(define-crossref-class "seealso" :unverified)
 
+; put 'see' and 'see also' entries at the bottom of the list
+
+(define-location-class-order (("roman-page-numbers"
+                               "arabic-page-numbers"
+                               "alpha-page-numbers"
+                               "Roman-page-numbers"
+                               "Alpha-page-numbers")
+                              ("see"
+                               "seealso"))
+

--- a/source/idxbfpage.xdy
+++ b/source/idxbfpage.xdy
@@ -1,0 +1,15 @@
+; list of allowed attributes
+
+(define-attributes (("idxbfpage" "default")))
+
+; define format to use for locations
+
+(markup-locref :open "\idxbfpage{" :close "}" :attr "idxbfpage")
+
+; location list separators
+
+(markup-locref-list :sep ", ")
+(markup-range :open "\idxpagerange{" :sep "}{" :close "}")
+
+(merge-to "default" "idxbfpage" :drop)
+

--- a/source/idxbfpage.xdy
+++ b/source/idxbfpage.xdy
@@ -13,3 +13,12 @@
 
 (merge-to "default" "idxbfpage" :drop)
 
+; hyperlink page numbers
+
+(markup-locref :open "\hyperpage{" :close "}")
+
+; ignore warnings about dangling cross-references
+
+;(define-crossref-class "see" :unverified)
+;(define-crossref-class "seealso" :unverified)
+

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -21,7 +21,7 @@ overloading, function name overloading, references, free store
 management operators, and additional library facilities.%
 \indextext{scope|)}
 
-\indextext{normative references|see{references, normative}}%
+\indextext{normative references|see{references!normative}}%
 \rSec0[intro.refs]{Normative references}
 
 \pnum
@@ -335,28 +335,28 @@ semantic rules, and the one-definition rule\iref{basic.def.odr}%
 
 \rSec0[intro]{General principles}
 
-\indextext{diagnostic message|see{message, diagnostic}}%
-\indexdefn{conditionally-supported behavior|see{behavior, con\-ditionally-supported}}%
-\indextext{dynamic type|see{type, dynamic}}%
-\indextext{static type|see{type, static}}%
-\indextext{ill-formed program|see{program, ill-formed}}%
-\indextext{well-formed program|see{program, well-formed}}%
-\indextext{implementation-defined behavior|see{behavior, im\-plementation-defined}}%
-\indextext{undefined behavior|see{behavior, undefined}}%
-\indextext{unspecified behavior|see{behavior, unspecified}}%
-\indextext{implementation limits|see{limits, implementation}}%
-\indextext{locale-specific behavior|see{behavior, locale-spe\-cific}}%
-\indextext{multibyte character|see{character, multibyte}}%
+\indextext{diagnostic message|see{message!diagnostic}}%
+\indexdefn{conditionally-supported behavior|see{behavior!con\-ditionally-supported}}%
+\indextext{dynamic type|see{type!dynamic}}%
+\indextext{static type|see{type!static}}%
+\indextext{ill-formed program|see{program!ill-formed}}%
+\indextext{well-formed program|see{program!well-formed}}%
+\indextext{implementation-defined behavior|see{behavior!im\-plementation-defined}}%
+\indextext{undefined behavior|see{behavior!undefined}}%
+\indextext{unspecified behavior|see{behavior!unspecified}}%
+\indextext{implementation limits|see{limits!implementation}}%
+\indextext{locale-specific behavior|see{behavior!locale-spe\-cific}}%
+\indextext{multibyte character|see{character!multibyte}}%
 \indextext{object|seealso{object model}}%
 \indextext{subobject|seealso{object model}}%
 \indextext{derived class!most|see{most derived class}}%
 \indextext{derived object!most|see{most derived object}}%
 \indextext{program execution!as-if rule|see{as-if rule}}%
-\indextext{observable behavior|see{behavior, observable}}%
-\indextext{precedence of operator|see{operator, precedence of}}%
-\indextext{order of evaluation in expression|see{expression, order of evaluation of}}%
-\indextext{atomic operations|see{operation, atomic}}%
-\indextext{multiple threads|see{threads, multiple}}%
+\indextext{observable behavior|see{behavior!observable}}%
+\indextext{precedence of operator|see{operator!precedence of}}%
+\indextext{order of evaluation in expression|see{expression!order of evaluation of}}%
+\indextext{atomic operations|see{operation!atomic}}%
+\indextext{multiple threads|see{threads!multiple}}%
 \rSec1[intro.compliance]{Implementation compliance}
 
 \pnum

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -11383,7 +11383,7 @@ without an intervening \grammarterm{root-directory} element.
 
 \pnum
 \indextext{path!normalization|(}%
-\defnx{Normalization}{normalization!path|see{path, normalization}} of a generic format pathname means:
+\defnx{Normalization}{normalization!path|see{path!normalization}} of a generic format pathname means:
 
 \begin{enumerate}
 \item If the path is empty, stop.

--- a/source/latexmkrc
+++ b/source/latexmkrc
@@ -1,4 +1,14 @@
+@default_files = ("std.tex");
+
+# Use pdfLaTeX
+$pdf_mode = 1;
+
+# Compile glossaries with makeindex
 add_cus_dep('glo', 'gls', 0, 'makeglo2gls');
 sub makeglo2gls {
     system("makeindex -s basic.gst -o '$_[0]'.gls '$_[0]'.glo");
 }
+
+# Compile indexes with xindy
+$makeindex = "xindy %O -M texindy -M idxbfpage -C utf8 -L english -t %B.ilg -o %D %S";
+

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -3,25 +3,25 @@
 
 \gramSec[gram.lex]{Lexical conventions}
 
-\indextext{lexical conventions|see{conventions, lexical}}
-\indextext{translation!separate|see{compilation, separate}}
-\indextext{separate translation|see{compilation, separate}}
-\indextext{separate compilation|see{compilation, separate}}
-\indextext{phases of translation|see{translation, phases}}
-\indextext{source file character|see{character, source file}}
-\indextext{alternative token|see{token, alternative}}
-\indextext{digraph|see{token, alternative}}
-\indextext{integer literal|see{literal, integer}}
-\indextext{character literal|see{literal, character}}
-\indextext{floating literal|see{literal, floating}}
-\indextext{floating-point literal|see{literal, floating}}
-\indextext{string literal|see{literal, string}}
-\indextext{boolean literal|see{literal, boolean}}
-\indextext{pointer literal|see{literal, pointer}}
-\indextext{user-defined literal|see{literal, user-defined}}
-\indextext{file, source|see{source file}}
-\indextext{null character|see{character, null}}
-\indextext{null wide character|see{wide-character, null}}
+\indextext{lexical conventions|see{conventions!lexical}}
+\indextext{translation!separate|see{compilation!separate}}
+\indextext{separate translation|see{compilation!separate}}
+\indextext{separate compilation|see{compilation!separate}}
+\indextext{phases of translation|see{translation!phases}}
+\indextext{source file character|see{character!source file}}
+\indextext{alternative token|see{token!alternative}}
+\indextext{digraph|see{token!alternative}}
+\indextext{integer literal|see{literal!integer}}
+\indextext{character literal|see{literal!character}}
+\indextext{floating literal|see{literal!floating}}
+\indextext{floating-point literal|see{literal!floating}}
+\indextext{string literal|see{literal!string}}
+\indextext{boolean literal|see{literal!boolean}}
+\indextext{pointer literal|see{literal!pointer}}
+\indextext{user-defined literal|see{literal!user-defined}}
+\indextext{file!source|see{source file}}
+\indextext{null character|see{character!null}}
+\indextext{null wide character|see{wide-character!null}}
 
 \rSec1[lex.separate]{Separate translation}
 
@@ -636,7 +636,7 @@ token as a regular \grammarterm{identifier}.
 \end{floattable}
 
 \pnum
-\indextext{\idxcode{_}|see{character, underscore}}%
+\indextext{\idxcode{_}|see{character!underscore}}%
 \indextext{character!underscore!in identifier}%
 \indextext{reserved identifier}%
 In addition, some identifiers are reserved for use by \Cpp{}
@@ -1121,7 +1121,7 @@ set has type \tcode{char}, with value equal to the
 numerical value of the encoding of the \grammarterm{c-char} in the
 execution character set. An ordinary character literal that contains
 more than one \grammarterm{c-char} is a
-\indextext{multicharacter literal|see{literal, multicharacter}}%
+\indextext{multicharacter literal|see{literal!multicharacter}}%
 \defnx{multicharacter literal}{literal!multicharacter}.
 A multicharacter literal, or an ordinary character literal containing
 a single \grammarterm{c-char} not representable in the execution
@@ -1636,9 +1636,9 @@ after concatenation (and not the single hexadecimal character
 \end{example}
 
 \pnum
-\indextext{\idxcode{0}|seealso{zero, null}}%
+\indextext{\idxcode{0}|seealso{zero!null}}%
 \indextext{\idxcode{0}!string terminator}%
-\indextext{\idxcode{0}!null character|see{character, null}}%
+\indextext{\idxcode{0}!null character|see{character!null}}%
 After any necessary concatenation, in translation phase
 7\iref{lex.phases}, \tcode{'\textbackslash 0'} is appended to every
 string literal so that programs that scan a string can find its end.

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -1638,7 +1638,7 @@ after concatenation (and not the single hexadecimal character
 \pnum
 \indextext{\idxcode{0}|seealso{zero, null}}%
 \indextext{\idxcode{0}!string terminator}%
-\indextext{\idxcode{0}!null character|see {character, null}}%
+\indextext{\idxcode{0}!null character|see{character, null}}%
 After any necessary concatenation, in translation phase
 7\iref{lex.phases}, \tcode{'\textbackslash 0'} is appended to every
 string literal so that programs that scan a string can find its end.

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -768,7 +768,7 @@ A character sequence can be designated by a pointer value
 
 \rSec5[byte.strings]{Byte strings}
 
-\indextext{string!null-terminated byte|see{\ntbs{}}}%
+\indextext{string!null-terminated byte|see{NTBS}}%
 \pnum
 A \defnx{null-terminated byte string}{NTBS@\ntbs{}},
 or \ntbs{},
@@ -805,7 +805,7 @@ is a static \ntbs{}.}
 
 \rSec5[multibyte.strings]{Multibyte strings}
 
-\indextext{string!null-terminated multibyte|see{\ntmbs{}}}%
+\indextext{string!null-terminated multibyte|see{NTMBS}}%
 \pnum
 A \defnx{null-terminated multibyte string}{NTMBS@\ntmbs{}},
 or \ntmbs{},

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -160,6 +160,7 @@
 % \impldefplain passes the argument directly to the index, allowing you to
 % use special indexing instructions (!, @, |).
 \newcommand{\impldefplain}[1]{\index[impldefindex]{#1}implementation-defined}
+\newcommand{\idxpagerange}[2]{#1--#2}
 
 % appearance
 \newcommand{\idxcode}[1]{#1@\tcode{#1}}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -10681,7 +10681,7 @@ if \tcode{l >= 128}.
 \indexlibrary{\idxcode{beta}}%
 \indexlibrary{\idxcode{betaf}}%
 \indexlibrary{\idxcode{betal}}%
-\indextext{Eulerian integral of the first kind|see{\tcode{beta}}}%
+\indextext{Eulerian integral of the first kind|see{beta}}%
 \indextext{beta functions $\mathsf{B}$}%
 \begin{itemdecl}
 double       beta(double x, double y);

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -10681,7 +10681,7 @@ if \tcode{l >= 128}.
 \indexlibrary{\idxcode{beta}}%
 \indexlibrary{\idxcode{betaf}}%
 \indexlibrary{\idxcode{betal}}%
-\indextext{Eulerian integral of the first kind|see{beta}}%
+\indextext{Eulerian integral of the first kind|see{beta functions $\mathsf{B}$}}%
 \indextext{beta functions $\mathsf{B}$}%
 \begin{itemdecl}
 double       beta(double x, double y);

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -388,7 +388,7 @@ public:
 
 \rSec1[over.match]{Overload resolution}%
 \indextext{overloading!resolution|(}%
-\indextext{resolution|see{overloading, resolution}}%
+\indextext{resolution|see{overloading!resolution}}%
 \indextext{ambiguity!overloaded function}
 
 \pnum
@@ -1921,7 +1921,7 @@ void use() {
 
 \rSec3[over.best.ics]{Implicit conversion sequences}%
 \indextext{overloading!resolution!implicit conversions and|(}
-\indextext{implicit conversion sequence|see{conversion sequence, implicit}}
+\indextext{implicit conversion sequence|see{conversion sequence!implicit}}
 
 \pnum
 An \defnx{implicit conversion sequence}{conversion sequence!implicit}
@@ -3050,8 +3050,8 @@ void (*p2)(B*) = &g;            // error
 
 \rSec1[over.oper]{Overloaded operators}%
 \indextext{overloading!operator|(}%
-\indextext{overloaded operator|see{overloading, operator}}%
-\indextext{operator overloading|see{overloading, operator}}
+\indextext{overloaded operator|see{overloading!operator}}%
+\indextext{operator overloading|see{overloading!operator}}
 
 \pnum
 \indextext{operator!overloaded}%
@@ -3405,8 +3405,8 @@ exists and if the operator is selected as the best match function by
 the overload resolution mechanism\iref{over.match}.
 
 \rSec2[over.inc]{Increment and decrement}
-\indextext{increment operator!overloaded|see{overloading, increment operator}}%
-\indextext{decrement operator!overloaded|see{overloading, decrement operator}}%
+\indextext{increment operator!overloaded|see{overloading!increment operator}}%
+\indextext{decrement operator!overloaded|see{overloading!decrement operator}}%
 \indextext{prefix ++ and -{-} overloading@prefix \tcode{++} and \tcode{\dcr}!overloading}%
 \indextext{postfix ++ and -{-} overloading@postfix \tcode{++} and \tcode{\dcr}!overloading}%
 

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -185,7 +185,7 @@ has been replaced.\end{example}
 
 \rSec1[cpp.cond]{Conditional inclusion}%
 \indextext{preprocessing directive!conditional inclusion}%
-\indextext{inclusion!conditional|see{preprocessing directive, conditional inclusion}}
+\indextext{inclusion!conditional|see{preprocessing directive!conditional inclusion}}
 
 \indextext{\idxcode{defined}}%
 \begin{bnf}
@@ -442,7 +442,7 @@ only if it is available:
 \rSec1[cpp.include]{Source file inclusion}
 \indextext{preprocessing directive!header inclusion}
 \indextext{preprocessing directive!source-file inclusion}
-\indextext{inclusion!source file|see{preprocessing directives, source-file inclusion}}%
+\indextext{inclusion!source file|see{preprocessing directives!source-file inclusion}}%
 \indextext{\idxcode{\#include}}%
 
 \pnum
@@ -582,8 +582,8 @@ directives:
 
 \rSec1[cpp.replace]{Macro replacement}%
 \indextext{macro!replacement|(}%
-\indextext{replacement!macro|see{macro, replacement}}%
-\indextext{preprocessing directive!macro replacement|see{macro, replacement}}
+\indextext{replacement!macro|see{macro!replacement}}%
+\indextext{preprocessing directive!macro replacement|see{macro!replacement}}
 
 \pnum
 \indextext{macro!replacement list}%
@@ -594,7 +594,7 @@ where all white-space separations are considered identical.
 
 \pnum
 An identifier currently defined as an
-\indextext{object-like macro|see{macro, object-like}}%
+\indextext{object-like macro|see{macro!object-like}}%
 \indextext{macro!object-like}%
 object-like macro (see below) may be redefined by another
 \tcode{\#define}
@@ -602,7 +602,7 @@ preprocessing directive provided that the second definition is an
 object-like macro definition and the two replacement lists
 are identical, otherwise the program is ill-formed.
 Likewise, an identifier currently defined as a
-\indextext{function-like macro|see{macro, function-like}}%
+\indextext{function-like macro|see{macro!function-like}}%
 \indextext{macro!function-like}%
 function-like macro (see below) may be redefined by another
 \tcode{\#define}
@@ -644,7 +644,7 @@ shall be uniquely declared within its scope.
 The identifier immediately following the
 \tcode{define}
 is called the
-\indextext{name!macro|see{macro, name}}%
+\indextext{name!macro|see{macro!name}}%
 \defnx{macro name}{macro!name}.
 There is one name space for macro names.
 Any white-space characters preceding or following the
@@ -742,7 +742,7 @@ one more than the number of parameters in the macro definition (excluding the
 
 \rSec2[cpp.subst]{Argument substitution}%
 \indextext{macro!argument substitution}%
-\indextext{argument substitution|see{macro, argument substitution}}%
+\indextext{argument substitution|see{macro!argument substitution}}%
 
 \pnum
 After the arguments for the invocation of a function-like macro have
@@ -930,7 +930,7 @@ consisting of two adjacent sharp signs, but this new token is not the
 
 \rSec2[cpp.rescan]{Rescanning and further replacement}%
 \indextext{macro!rescanning and replacement}%
-\indextext{rescanning and replacement|see{macro, rescanning and replacement}}
+\indextext{rescanning and replacement|see{macro!rescanning and replacement}}
 
 \pnum
 After all parameters in the replacement list have been substituted and \tcode{\#} and \tcode{\#\#} processing has taken
@@ -960,7 +960,7 @@ specified in~\ref{cpp.pragma.op} below.
 
 \rSec2[cpp.scope]{Scope of macro definitions}%
 \indextext{macro!scope of definition}%
-\indextext{scope!macro definition|see{macro, scope of definition}}
+\indextext{scope!macro definition|see{macro!scope of definition}}
 
 \pnum
 A macro definition lasts
@@ -1177,7 +1177,7 @@ puts("The first, second, and third items.");
 
 \rSec1[cpp.line]{Line control}%
 \indextext{preprocessing directive!line control}%
-\indextext{\idxcode{\#line}|see{preprocessing directives, line control}}
+\indextext{\idxcode{\#line}|see{preprocessing directives!line control}}
 
 \pnum
 The string literal of a
@@ -1239,7 +1239,7 @@ otherwise, the result is processed as appropriate.
 
 \rSec1[cpp.error]{Error directive}%
 \indextext{preprocessing directive!error}%
-\indextext{\idxcode{\#error}|see{preprocessing directives, error}}
+\indextext{\idxcode{\#error}|see{preprocessing directives!error}}
 
 \pnum
 A preprocessing directive of the form
@@ -1254,7 +1254,7 @@ and renders the program ill-formed.
 
 \rSec1[cpp.pragma]{Pragma directive}%
 \indextext{preprocessing directive!pragma}%
-\indextext{\idxcode{\#pragma}|see{preprocessing directives, pragma}}
+\indextext{\idxcode{\#pragma}|see{preprocessing directives!pragma}}
 
 \pnum
 A preprocessing directive of the form
@@ -1283,7 +1283,7 @@ has no effect.
 
 \rSec1[cpp.predefined]{Predefined macro names}
 \indextext{macro!predefined}%
-\indextext{name!predefined macro|see{macro, predefined}}
+\indextext{name!predefined macro|see{macro!predefined}}
 
 \pnum
 The following macro names shall be defined by the implementation:
@@ -1421,7 +1421,7 @@ underscore.
 
 \rSec1[cpp.pragma.op]{Pragma operator}%
 \indextext{macro!pragma operator}%
-\indextext{operator!pragma|see{macro, pragma operator}}
+\indextext{operator!pragma|see{macro!pragma operator}}
 
 \pnum
 A unary operator expression of the form:

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -819,7 +819,7 @@ H2(a, b, c, d)      // replaced by \tcode{ab, c, d}
 
 \rSec2[cpp.stringize]{The \tcode{\#} operator}%
 \indextext{\#\#0 operator@\tcode{\#} operator}%
-\indextext{stringize|see{\tcode{\#} operator}}
+\indextext{stringize|see{\#\#0 operator}}
 
 \pnum
 Each
@@ -866,7 +866,7 @@ operators is unspecified.
 
 \rSec2[cpp.concat]{The \tcode{\#\#} operator}%
 \indextext{\#\#1 operator@\tcode{\#\#} operator}%
-\indextext{concatenation!macro argument|see{\tcode{\#\#} operator}}
+\indextext{concatenation!macro argument|see{\#\#1 operator}}
 
 \pnum
 A

--- a/source/special.tex
+++ b/source/special.tex
@@ -3,11 +3,11 @@
 
 \gramSec[gram.special]{Special member functions}
 
-\indextext{\idxcode{X(X\&)}|see{constructor, copy}}%
+\indextext{\idxcode{X(X\&)}|see{constructor!copy}}%
 \indextext{~@\tcode{\~}|see{destructor}}%
-\indextext{assignment!copy|see{assignment operator, copy}}%
-\indextext{assignment!move|see{assignment operator, move}}%
-\indextext{implicitly-declared default constructor|see{constructor, default}}
+\indextext{assignment!copy|see{assignment operator!copy}}%
+\indextext{assignment!move|see{assignment operator!move}}%
+\indextext{implicitly-declared default constructor|see{constructor!default}}
 
 \pnum
 \indextext{constructor!default}%
@@ -361,7 +361,7 @@ D d = D(1);                     // value of \tcode{d.b} is unspecified
 \pnum
 \indextext{object temporary|see{temporary}}%
 \indextext{temporary}%
-\indextext{optimization of temporary|see{temporary, elimination of}}%
+\indextext{optimization of temporary|see{temporary!elimination of}}%
 \indextext{temporary!elimination of}%
 \indextext{temporary!implementation-defined generation of}%
 Temporary objects are created
@@ -439,7 +439,7 @@ void h() {
 }
 \end{codeblock}
 
-\indextext{class object copy|see{constructor, copy}}%
+\indextext{class object copy|see{constructor!copy}}%
 \indextext{constructor!copy}%
 \tcode{X(2)} is constructed in the space used to hold \tcode{f()}'s argument and
 \tcode{Y(3)} is constructed in the space used to hold \tcode{g()}'s argument.
@@ -723,8 +723,8 @@ shall be destroyed before
 
 \pnum
 \indextext{conversion!class}%
-\indextext{constructor, conversion by|see{conversion, user-defined}}%
-\indextext{conversion function|see{conversion, user-defined}}%
+\indextext{constructor!conversion by|see{conversion!user-defined}}%
+\indextext{conversion function|see{conversion!user-defined}}%
 \indextext{conversion!implicit}%
 Type conversions of class objects can be specified by constructors and
 by conversion functions.
@@ -863,7 +863,7 @@ it may be called for implicit type conversions.
 
 \rSec2[class.conv.fct]{Conversion functions}%
 \indextext{function!conversion}%
-\indextext{fundamental type conversion|see{conversion, user-defined}}%
+\indextext{fundamental type conversion|see{conversion!user-defined}}%
 \indextext{conversion!user-defined}%
 
 \pnum
@@ -1062,7 +1062,7 @@ has the same exception specification as if had been implicitly declared\iref{exc
 \end{note}
 
 \pnum
-\indextext{generated destructor|see{destructor, default}}%
+\indextext{generated destructor|see{destructor!default}}%
 \indextext{destructor!default}%
 If a class has no user-declared
 destructor, a destructor is implicitly
@@ -2469,8 +2469,8 @@ object.
 \pnum
 \indextext{constructor!copy|(}%
 \indextext{constructor!move|(}%
-\indextext{copy!class object|see{constructor, copy}}%
-\indextext{move!class object|see{constructor, move}}%
+\indextext{copy!class object|see{constructor!copy}}%
+\indextext{move!class object|see{constructor!move}}%
 A non-template constructor for class
 \tcode{X}
 is
@@ -2790,10 +2790,10 @@ The implicitly-defined copy/move constructor for a union
 \indextext{assignment operator!copy|(}%
 \indextext{assignment operator!move|(}%
 \indextext{special member function|see{assignment operator}}%
-\indextext{copy!class object|see{assignment operator, copy}}%
-\indextext{move!class object|see{assignment operator, move}}%
-\indextext{operator!copy assignment|see{assignment operator, copy}}%
-\indextext{operator!move assignment|see{assignment operator, move}}%
+\indextext{copy!class object|see{assignment operator!copy}}%
+\indextext{move!class object|see{assignment operator!move}}%
+\indextext{operator!copy assignment|see{assignment operator!copy}}%
+\indextext{operator!move assignment|see{assignment operator!move}}%
 A user-declared \term{copy} assignment operator \tcode{X::operator=} is a
 non-static non-template member function of class \tcode{X} with exactly one
 parameter of type \tcode{X}, \tcode{X\&}, \tcode{const} \tcode{X\&},
@@ -3129,8 +3129,8 @@ union \tcode{X} copies the object representation\iref{basic.types} of \tcode{X}.
 
 \pnum
 \indextext{temporary!elimination of}%
-\indextext{elision!copy constructor|see{constructor, copy, elision}}%
-\indextext{elision!move constructor|see{constructor, move, elision}}%
+\indextext{elision!copy constructor|see{constructor!copy!elision}}%
+\indextext{elision!move constructor|see{constructor!move!elision}}%
 \indextext{constructor!copy!elision}%
 \indextext{constructor!move!elision}%
 When certain criteria are met, an implementation is
@@ -3150,8 +3150,8 @@ optimization.\footnote{Because only one object is destroyed instead of two,
 and one copy/move constructor
 is not executed, there is still one object destroyed for each one constructed.}
 This elision of copy/move operations, called
-\indexdefn{copy elision|see{constructor, copy, elision}}%
-\indexdefn{elision!copy|see{constructor, copy, elision}}%
+\indexdefn{copy elision|see{constructor!copy!elision}}%
+\indexdefn{elision!copy|see{constructor!copy!elision}}%
 \indexdefn{constructor!copy!elision}\indexdefn{constructor!move!elision}\term{copy elision},
 is permitted in the
 following circumstances (which may be combined to

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -4,7 +4,7 @@
 
 \gramSec[gram.stmt]{Statements}
 
-\indextext{block statement|see{statement, compound}}
+\indextext{block statement|see{statement!compound}}
 
 \pnum
 Except as indicated, statements are executed in sequence.

--- a/source/std.tex
+++ b/source/std.tex
@@ -40,7 +40,8 @@
             linktocpage=true,
             colorlinks=true,
             linkcolor=blue,
-            plainpages=false
+            plainpages=false,
+            hyperindex=false
            ]{hyperref}
 \usepackage{memhfixc}     % fix interactions between hyperref and memoir
 \usepackage[active,header=false,handles=false,copydocumentclass=false,generate=std-gram.ext,extract-cmdline={gramSec},extract-env={bnftab,simplebnf,bnf,bnfkeywordtab}]{extract} % Grammar extraction
@@ -56,6 +57,7 @@
 \input{macros}
 \input{tables}
 
+\xindyindex
 \makeindex[generalindex]
 \makeindex[headerindex]
 \makeindex[libraryindex]

--- a/source/support.tex
+++ b/source/support.tex
@@ -611,9 +611,9 @@ namespace std {
 }
 \end{codeblock}
 
-\indextext{denormalized value|see{number, subnormal}}%
-\indextext{value!denormalized|see{number, subnormal}}%
-\indextext{subnormal number|see{number, subnormal}}%
+\indextext{denormalized value|see{number!subnormal}}%
+\indextext{value!denormalized|see{number!subnormal}}%
+\indextext{subnormal number|see{number!subnormal}}%
 \indextext{number!subnormal}%
 \pnum
 The presence or absence of subnormal numbers (variable number of exponent bits)
@@ -4853,7 +4853,7 @@ for every pointer-to-atomic argument \tcode{A} passed to \tcode{f},
 \end{itemize}
 
 \pnum
-\indextext{signal-safe!evaluation|see{evaluation, signal-safe}}%
+\indextext{signal-safe!evaluation|see{evaluation!signal-safe}}%
 An evaluation is \defnx{signal-safe}{evaluation!signal-safe} unless it includes one of the following:
 
 \begin{itemize}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1635,7 +1635,7 @@ nor a logical OR expression\iref{expr.log.or}.
 
 \pnum
 Two atomic constraints are
-\indextext{identical!atomic constraints|see{atomic constraint, identical}}%
+\indextext{identical!atomic constraints|see{atomic constraint!identical}}%
 \defnx{identical}{atomic constraint!identical}
 if they are formed from the same
 \grammarterm{expression}
@@ -1825,7 +1825,7 @@ whose parameter mapping is the identity mapping.
 The process of obtaining the normal form of a
 \grammarterm{constraint-expression}
 is called
-\defnx{normalization}{normalization!constraint|see{constraint, normalization}}.
+\defnx{normalization}{normalization!constraint|see{constraint!normalization}}.
 \begin{note}
 Normalization of \grammarterm{constraint-expression}{s}
 is performed
@@ -1858,7 +1858,7 @@ The associated constraints of \#3 are
 \indextext{constraint!normalization|)}
 
 \rSec2[temp.constr.order]{Partial ordering by constraints}
-\indextext{subsume|see{constraint, subsumption}}
+\indextext{subsume|see{constraint!subsumption}}
 
 \pnum
 A constraint $P$ \defnx{subsumes}{constraint!subsumption} a constraint $Q$
@@ -2567,7 +2567,7 @@ The number of elements of an \grammarterm{init-capture} pack
 is the number of elements in the pack expansion of its \grammarterm{initializer}.
 
 \pnum
-\indextext{pattern|see{pack expansion, pattern}}%
+\indextext{pattern|see{pack expansion!pattern}}%
 A \defn{pack expansion}
 consists of a \defnx{pattern}{pack expansion!pattern} and an ellipsis, the instantiation of which
 produces zero or more instantiations of the pattern in a list (described below).
@@ -3016,7 +3016,7 @@ A non-template friend declaration shall not have a \grammarterm{requires-clause}
 
 \pnum
 \indextext{specialization!class template partial}%
-\indextext{primary class template|see{template, primary}}%
+\indextext{primary class template|see{template!primary}}%
 A
 \defnx{primary class template}{template!primary}
 declaration is one in which the class template name is an
@@ -3562,7 +3562,7 @@ For example, a template type parameter can be used in the
 \end{note}
 
 \pnum
-\indextext{expression!equivalent|see{equivalent, expressions}}%
+\indextext{expression!equivalent|see{equivalent!expressions}}%
 Two expressions involving template parameters are considered
 \defnx{equivalent}{equivalent!expressions}
 if two function definitions containing the expressions would satisfy
@@ -3601,7 +3601,7 @@ template <class T> void spam(decltype([]{}) (*s)[sizeof(T)]);
 template <class T> void spam(decltype([]{}) (*s)[sizeof(T)]);
 \end{codeblock}
 \end{example}
-\indextext{expression!functionally equivalent|see{functionally equivalent, expressions}}%
+\indextext{expression!functionally equivalent|see{functionally equivalent!expressions}}%
 Two expressions involving template parameters that are not equivalent are
 \defnx{functionally equivalent}{functionally equivalent!expressions}
 if, for any given set of template arguments, the evaluation of the
@@ -3638,7 +3638,7 @@ if they accept and are satisfied by\iref{temp.constr.constr}
 the same set of template argument lists.
 
 \pnum
-\indextext{template!function!equivalent|see{equivalent, function template}}%
+\indextext{template!function!equivalent|see{equivalent!function template}}%
 Two function templates are
 \defnx{equivalent}{equivalent!function templates}
 if they
@@ -3652,7 +3652,7 @@ that are equivalent using the rules described above to compare
 expressions involving
 template parameters.
 \indextext{equivalent!functionally|see{functionally equivalent}}%
-\indextext{template!function!functionally equivalent|see{functionally equivalent, function template}}%
+\indextext{template!function!functionally equivalent|see{functionally equivalent!function template}}%
 Two function templates are
 \defnx{functionally equivalent}{functionally equivalent!function templates}
 if they
@@ -3697,7 +3697,7 @@ template <int I> void f(A<I>, A<I+1+2+3+4>);
 
 \pnum
 \indextext{overloading!resolution!template}%
-\indextext{ordering!function template partial|see{template, function, partial ordering}}%
+\indextext{ordering!function template partial|see{template!function!partial ordering}}%
 If a function template is overloaded,
 the use of a function template specialization might be ambiguous because
 template argument deduction\iref{temp.deduct} may associate the function
@@ -3992,7 +3992,7 @@ or partially specialized.
 \pnum
 The first declared template parameter of a concept definition is its
 \defnx{prototype parameter}{prototype parameter!concept}.
-\indextext{variadic concept|see{concept, variadic}}%
+\indextext{variadic concept|see{concept!variadic}}%
 A \defnx{variadic concept}{concept!variadic}
 is a concept whose prototype parameter
 is a template parameter pack.
@@ -4602,7 +4602,7 @@ template<class B, class a> struct X : A {
 \rSec2[temp.dep]{Dependent names}
 
 \pnum
-\indextext{dependent name|see{name, dependent}}%
+\indextext{dependent name|see{name!dependent}}%
 Inside a template, some constructs have semantics which may differ from one
 instantiation to another.
 Such a construct
@@ -4852,7 +4852,7 @@ template <class T1, class T2, int I> struct B {
 \end{example}
 
 \pnum
-\indextext{dependent base class|see{base class, dependent}}%
+\indextext{dependent base class|see{base class!dependent}}%
 A \defnx{dependent base class}{base class!dependent} is a base class that is a dependent type and is
 not the current instantiation.
 \begin{note}
@@ -4876,7 +4876,7 @@ template<class T> struct A<T>::B::C : A<T> {
 \end{note}
 
 \pnum
-\indextext{member of the current instantiation|see{current instantiation, member of the}}%
+\indextext{member of the current instantiation|see{current instantiation!member of the}}%
 A name is a
 \defnx{member of the current instantiation}{current instantiation!member of the}
 if it is
@@ -4931,7 +4931,7 @@ template <class T> int A<T>::f() {
 \end{codeblock}
 \end{example}
 
-\indextext{dependent member of the current instantiation|see{current instantiation, dependent member of the}}%
+\indextext{dependent member of the current instantiation|see{current instantiation!dependent member of the}}%
 A name is a \defnx{dependent member of the current instantiation}{current instantiation!dependent member of the} if it is a
 member of the current instantiation that, when looked up, refers to at least
 one member of a class that is the current instantiation.

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -3765,7 +3765,7 @@ const char* what() const noexcept;
 
 \pnum
 Many of the classes introduced in this subclause use some state to communicate results. This
-\indextext{shared state|see{future, shared state}}
+\indextext{shared state|see{future!shared state}}
 \defnx{shared state}{future!shared state} consists of some state information and some (possibly not
 yet evaluated) \term{result}, which can be a (possibly void) value or an exception. \begin{note}
 Futures, promises, and tasks defined in this clause reference such shared state. \end{note}


### PR DESCRIPTION
**WORK IN PROGRESS &mdash; DO NOT MERGE YET**

Fixes issue #1917.

For this PR I used xindy only for the grammar terms index. But we could use it for the other indices as well.

I think latexmk may still use makeindex for all the indices. I don't know if it can be configured to use xindy for just the grammar index or not. (I don't use latexmk much. I'll have to check the docs.)