### PR TITLE
[time.syn] Add comments pointing to specification of literal operators

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -18410,9 +18410,6 @@ namespace std {
   inline namespace literals {
   inline namespace chrono_literals {
     // \ref{time.duration.literals}, suffixes for duration literals
-    constexpr chrono::year operator""y(unsigned long long y) noexcept;
-    constexpr chrono::day  operator""d(unsigned long long d) noexcept;
-
     constexpr chrono::hours                                 operator""h(unsigned long long);
     constexpr chrono::duration<@\unspec,@ ratio<3600, 1>> operator""h(long double);
 
@@ -18430,6 +18427,12 @@ namespace std {
 
     constexpr chrono::nanoseconds                 operator""ns(unsigned long long);
     constexpr chrono::duration<@\unspec,@ nano> operator""ns(long double);
+
+    // \ref{time.cal.day.nonmembers}, non-member functions
+    constexpr chrono::day  operator""d(unsigned long long d) noexcept;
+
+    // \ref{time.cal.year.nonmembers}, non-member functions
+    constexpr chrono::year operator""y(unsigned long long y) noexcept;
   }
   }
 


### PR DESCRIPTION
Fixes #2017.