### PR TITLE
[dcl.array] Clarify that an array bound is deduced in an explicit typ…

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -1065,10 +1065,11 @@ an array bound may be omitted in some cases in the declaration of a function
 parameter\iref{dcl.fct}.
 An array bound may also be omitted
 when the declarator is followed by an
-\grammarterm{initializer}\iref{dcl.init} or
+\grammarterm{initializer}\iref{dcl.init},
 when a declarator for a static data member is followed by a
-\grammarterm{brace-or-equal-initializer}\iref{class.mem}.
-In both cases the bound is calculated from the number
+\grammarterm{brace-or-equal-initializer}\iref{class.mem},
+or in an explicit type conversion\iref{expr.type.conv}.
+In these cases, the bound is calculated from the number
 \indextext{array size!default}%
 of initial elements (say,
 \tcode{N})


### PR DESCRIPTION
…e conversion.

Fixes #2012.