### PR TITLE
[move.iterators] Dissolve single-item subclauses.

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -2155,9 +2155,7 @@ functions are instantiated, the template parameter shall satisfy the
 requirements for a Bidirectional Iterator\iref{bidirectional.iterators}
 or a Random Access Iterator\iref{random.access.iterators}, respectively.
 
-\rSec3[move.iter.ops]{\tcode{move_iterator} operations}
-
-\rSec4[move.iter.op.const]{\tcode{move_iterator} constructors}
+\rSec3[move.iter.cons]{\tcode{move_iterator} construction and assignment}
 
 \indexlibrary{\idxcode{move_iterator}!constructor}%
 \begin{itemdecl}
@@ -2200,8 +2198,6 @@ template<class U> constexpr move_iterator(const move_iterator<U>& u);
 \tcode{Iterator}.
 \end{itemdescr}
 
-\rSec4[move.iter.op=]{\tcode{move_iterator::operator=}}
-
 \indexlibrarymember{operator=}{move_iterator}%
 \begin{itemdecl}
 template<class U> constexpr move_iterator& operator=(const move_iterator<U>& u);
@@ -2217,7 +2213,7 @@ template<class U> constexpr move_iterator& operator=(const move_iterator<U>& u);
 \tcode{Iterator}.
 \end{itemdescr}
 
-\rSec4[move.iter.op.conv]{\tcode{move_iterator} conversion}
+\rSec3[move.iter.op.conv]{\tcode{move_iterator} conversion}
 
 \indexlibrarymember{base}{move_iterator}%
 \begin{itemdecl}
@@ -2229,7 +2225,7 @@ constexpr Iterator base() const;
 \returns \tcode{current}.
 \end{itemdescr}
 
-\rSec4[move.iter.op.star]{\tcode{move_iterator::operator*}}
+\rSec3[move.iter.elem]{\tcode{move_iterator} element access}
 
 \indexlibrarymember{operator*}{move_iterator}%
 \begin{itemdecl}
@@ -2241,8 +2237,6 @@ constexpr reference operator*() const;
 \returns \tcode{static_cast<reference>(*current)}.
 \end{itemdescr}
 
-\rSec4[move.iter.op.ref]{\tcode{move_iterator::operator->}}
-
 \indexlibrarymember{operator->}{move_iterator}%
 \begin{itemdecl}
 constexpr pointer operator->() const;
@@ -2253,7 +2247,17 @@ constexpr pointer operator->() const;
 \returns \tcode{current}.
 \end{itemdescr}
 
-\rSec4[move.iter.op.incr]{\tcode{move_iterator::operator++}}
+\indexlibrarymember{operator[]}{move_iterator}%
+\begin{itemdecl}
+constexpr @\unspec@ operator[](difference_type n) const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns \tcode{std::move(current[n])}.
+\end{itemdescr}
+
+\rSec3[move.iter.nav]{\tcode{move_iterator} navigation}
 
 \indexlibrarymember{operator++}{move_iterator}%
 \begin{itemdecl}
@@ -2284,8 +2288,6 @@ return tmp;
 \end{codeblock}
 \end{itemdescr}
 
-\rSec4[move.iter.op.decr]{\tcode{move_iterator::operator-{-}}}
-
 \indexlibrarymember{operator\dcr}{move_iterator}%
 \begin{itemdecl}
 constexpr move_iterator& operator--();
@@ -2315,8 +2317,6 @@ return tmp;
 \end{codeblock}
 \end{itemdescr}
 
-\rSec4[move.iter.op.+]{\tcode{move_iterator::operator+}}
-
 \indexlibrarymember{operator+}{move_iterator}%
 \begin{itemdecl}
 constexpr move_iterator operator+(difference_type n) const;
@@ -2326,8 +2326,6 @@ constexpr move_iterator operator+(difference_type n) const;
 \pnum
 \returns \tcode{move_iterator(current + n)}.
 \end{itemdescr}
-
-\rSec4[move.iter.op.+=]{\tcode{move_iterator::operator+=}}
 
 \indexlibrarymember{operator+=}{move_iterator}%
 \begin{itemdecl}
@@ -2342,8 +2340,6 @@ constexpr move_iterator& operator+=(difference_type n);
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\rSec4[move.iter.op.-]{\tcode{move_iterator::operator-}}
-
 \indexlibrarymember{operator-}{move_iterator}%
 \begin{itemdecl}
 constexpr move_iterator operator-(difference_type n) const;
@@ -2353,8 +2349,6 @@ constexpr move_iterator operator-(difference_type n) const;
 \pnum
 \returns \tcode{move_iterator(current - n)}.
 \end{itemdescr}
-
-\rSec4[move.iter.op.-=]{\tcode{move_iterator::operator-=}}
 
 \indexlibrarymember{operator-=}{move_iterator}%
 \begin{itemdecl}
@@ -2369,19 +2363,7 @@ constexpr move_iterator& operator-=(difference_type n);
 \returns \tcode{*this}.
 \end{itemdescr}
 
-\rSec4[move.iter.op.index]{\tcode{move_iterator::operator[]}}
-
-\indexlibrarymember{operator[]}{move_iterator}%
-\begin{itemdecl}
-constexpr @\unspec@ operator[](difference_type n) const;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{std::move(current[n])}.
-\end{itemdescr}
-
-\rSec4[move.iter.op.comp]{\tcode{move_iterator} comparisons}
+\rSec3[move.iter.op.comp]{\tcode{move_iterator} comparisons}
 
 \indexlibrarymember{operator==}{move_iterator}%
 \begin{itemdecl}
@@ -2449,7 +2431,7 @@ constexpr bool operator>=(const move_iterator<Iterator1>& x, const move_iterator
 \returns \tcode{!(x < y)}.
 \end{itemdescr}
 
-\rSec4[move.iter.nonmember]{\tcode{move_iterator} non-member functions}
+\rSec3[move.iter.nonmember]{\tcode{move_iterator} non-member functions}
 
 \indexlibrarymember{operator-}{move_iterator}%
 \begin{itemdecl}

--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -103,6 +103,23 @@
 
 \removedxref{reverse.iter.ops}
 
+% Single-item [move.iterators] subclauses were dissolved.
+\movedxref{move.iter.op=}{move.iter.cons}
+\movedxref{move.iter.op.const}{move.iter.cons}
+
+\movedxref{move.iter.op.star}{move.iter.elem}
+\movedxref{move.iter.op.ref}{move.iter.elem}
+\movedxref{move.iter.op.index}{move.iter.elem}
+
+\movedxref{move.iter.op.+}{move.iter.nav}
+\movedxref{move.iter.op.-}{move.iter.nav}
+\movedxref{move.iter.op.incr}{move.iter.nav}
+\movedxref{move.iter.op.+=}{move.iter.nav}
+\movedxref{move.iter.op.decr}{move.iter.nav}
+\movedxref{move.iter.op.-=}{move.iter.nav}
+
+\removedxref{move.iter.ops}
+
 % Individual swap sections were removed.
 \removedxref{deque.special}
 \removedxref{forwardlist.special}


### PR DESCRIPTION
Fixes #1429.