### PR TITLE
[macros, lex, over] Dissolve bnfkeytab environments. Use a fixed-width (\fw{...}) code field instead.

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -792,18 +792,20 @@ The lexical representation of \Cpp{} programs includes a number of
 preprocessing tokens which are used in the syntax of the preprocessor or
 are converted into tokens for operators and punctuators:
 
-\begin{bnfkeywordtab}
+\begin{bnf}
+%% Ed. note: character protrusion would misalign various operators.
+\microtypesetup{protrusion=false}\obeyspaces
 \nontermdef{preprocessing-op-or-punc} \textnormal{one of}\br
-\>\{ \>\} \>[ \>] \>\# \>\#\# \>( \>)\br
-\><: \>:> \><\% \>\%> \>\%: \>\%:\%: \>; \>: \>.{..}\br
-\>new \>delete \>? \>:: \>. \>.* \>-> \>->* \>\~\br
-\>! \>+ \>- \>* \>/ \>\% \>\caret \>\& \>|\br
-\>= \>+= \>-= \>*= \>/= \>\%= \>\caret= \>\&= \>|=\br
-\>== \>!= \>< \>> \><= \>>= \><=> \>\&\& \>||\br
-\><< \>>> \><<= \>>>= \>++ \>-{-} \>,\br
-\>and \>or \>xor \>not \>bitand \>bitor \>compl\br
-\>and_eq \>or_eq \>xor_eq \>not_eq
-\end{bnfkeywordtab}
+\terminal{\{        \}        [        ]        \#        \#\#       (        )}\br
+\terminal{<:       :>       <\%       \%>       \%:       \%:\%:     ;        :        ...}\br
+\terminal{new      delete   ?        ::       .        .*       ->       ->*      \~}\br
+\terminal{!        +        -        *        /        \%        \caret{}        \&        |}\br
+\terminal{=        +=       -=       *=       /=       \%=       \caret{}=       \&=       |=}\br
+\terminal{==       !=       <        >        <=       >=       <=>      \&\&       ||}\br
+\terminal{<<       >>       <<=      >>=      ++       --       ,}\br
+\terminal{and      or       xor      not      bitand   bitor    compl}\br
+\terminal{and_eq   or_eq    xor_eq   not_eq}
+\end{bnf}
 
 Each \grammarterm{preprocessing-op-or-punc} is converted to a single token
 in translation phase 7\iref{lex.phases}.%

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -428,17 +428,18 @@
 \setlength{\BnfRest}{2\BnfIndent}
 \newcommand{\BnfNontermshape}{\small\rmfamily\itshape}
 \newcommand{\BnfTermshape}{\small\ttfamily\upshape}
-\newcommand{\bnfindent}{\hspace*{\bnfindentfirst}}
 
 \newenvironment{bnfbase}
  {
  \newcommand{\nontermdef}[1]{{\BnfNontermshape##1\itcorr}\indexgrammar{\idxgram{##1}}\textnormal{:}}
  \newcommand{\terminal}[1]{{\BnfTermshape ##1}}
  \newcommand{\descr}[1]{\textnormal{##1}}
+ \newcommand{\bnfindent}{\hspace*{\bnfindentfirst}}
  \newcommand{\bnfindentfirst}{\BnfIndent}
  \newcommand{\bnfindentinc}{\BnfInc}
  \newcommand{\bnfindentrest}{\BnfRest}
  \newcommand{\br}{\hfill\\*}
+ \newcommand{\fw}[1]{\makebox[1.75\bnfindentfirst][l]{\BnfTermshape ##1}} % fixed-width box
  \widowpenalties 1 10000
  \frenchspacing
  }

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -3073,14 +3073,16 @@ the operator named in its
     \terminal{operator} operator
 \end{bnf}
 
-\begin{bnfkeywordtab}
+\begin{bnf}
+%% Ed. note: character protrusion would misalign various operators.
+\microtypesetup{protrusion=false}\obeyspaces
 \nontermdef{operator} \textnormal{one of}\br
-\>new\>delete\>new[]\>delete[]\>(\,)\>[\,]\>->\>->*\>\~\br
-\>!\>+\>-\>*\>/\>\%\>\caret\>\&\>|\br
-\>=\>+=\>-=\>*=\>/=\>\%=\>\caret=\>\&=\>|=\br
-\>={=}\>!=\><\>>\><=\>>=\><=>\>\&\&\>|{|}\br
-\><<\>>>\><<=\>>>=\>++\>-{-}\>,\br
-\end{bnfkeywordtab}
+\terminal{new      delete   new[]    delete[] (\rlap{\,)}        [\rlap{\,]}        ->       ->*      \~}\br
+\terminal{!        +        -        *        /        \%        \caret{}        \&        |}\br
+\terminal{=        +=       -=       *=       /=       \%=       \caret{}=       \&=       |=}\br
+\terminal{==       !=       <        >        <=       >=       <=>      \&\&       ||}\br
+\terminal{<<       >>       <<=      >>=      ++       --       ,}\br
+\end{bnf}
 \begin{note}
 The last two operators are function call\iref{expr.call}
 and subscripting\iref{expr.sub}.
@@ -3097,21 +3099,17 @@ are formed from more than one token.
 
 \pnum
 Both the unary and binary forms of
-
-\begin{codeblock}
-+    -    *     &
-\end{codeblock}
-
+\begin{ncsimplebnf}\obeyspaces
+\terminal{+      -      *      \&}
+\end{ncsimplebnf}
 can be overloaded.
 
 \pnum
 \indextext{restriction!operator overloading}%
 The following operators cannot be overloaded:
-
-\begin{codeblock}
-.    .*   ::    ?:
-\end{codeblock}
-
+\begin{ncsimplebnf}\obeyspaces
+\terminal{.      .*     ::     ?:}
+\end{ncsimplebnf}
 nor can the preprocessing symbols
 \tcode{\#}
 and


### PR DESCRIPTION
Before/after:

![image](https://user-images.githubusercontent.com/6378233/38281941-2bf48520-37a5-11e8-9dff-c5d9fef86f28.png)

![image](https://user-images.githubusercontent.com/6378233/38281954-42c04cd0-37a5-11e8-8f8b-43620c48f54a.png)
