### PR TITLE
Use \commentellip macro for omitted program text.

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -75,12 +75,12 @@ One exception is when a name introduced by one of the
 \grammarterm{decl-specifier}{s} are used in a subsequent declaration,
 they do not have the same meaning, as in
 \begin{codeblock}
-struct S { ... };
+struct S { @\commentellip@ };
 S S, T;                 // declare two instances of \tcode{struct S}
 \end{codeblock}
 which is not equivalent to
 \begin{codeblock}
-struct S { ... };
+struct S { @\commentellip@ };
 S S;
 S T;                    // error
 \end{codeblock}
@@ -2027,7 +2027,7 @@ is the
 \tcode{c)}
 is the
 \grammarterm{declarator};
-\tcode{\{ /* ...\ */ \}}
+\tcode{\{ \commentellip{} \}}
 is the
 \grammarterm{function-body}.
 \end{example}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1092,11 +1092,11 @@ The behavior of the conversion function of \tcode{glambda} above is like
 that of the following conversion function:
 \begin{codeblock}
 struct Closure {
-  template<class T> auto operator()(T t) const { ... }
+  template<class T> auto operator()(T t) const { @\commentellip@ }
   template<class T> static auto lambda_call_operator_invoker(T a) {
     // forwards execution to \tcode{operator()(a)} and therefore has
     // the same return type deduced
-    ...
+    @\commentellip@
   }
   template<class T> using fptr_t =
      decltype(lambda_call_operator_invoker(declval<T>())) (*)(T);

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -368,8 +368,8 @@ An implementation can avoid this circularity by substituting equivalent
 types.
 One way to do this might be
 \begin{codeblock}
-template<class stateT> class fpos { ... };      // depends on nothing
-using _STATE = ... ;             // implementation private declaration of \tcode{stateT}
+template<class stateT> class fpos { @\commentellip@ };      // depends on nothing
+using _STATE = @\commentellip@ ;             // implementation private declaration of \tcode{stateT}
 
 using streampos = fpos<_STATE>;
 


### PR DESCRIPTION
Fixes #1390.