### PR TITLE
[time.syn][time.zone] Various editorial fixes

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -18288,7 +18288,7 @@ namespace std {
       bool operator==(const zoned_time<Duration1, TimeZonePtr>& x,
                       const zoned_time<Duration2, TimeZonePtr>& y);
 
-    template<class Duration1, class Duration, class TimeZonePtr2>
+    template<class Duration1, class Duration2, class TimeZonePtr>
       bool operator!=(const zoned_time<Duration1, TimeZonePtr>& x,
                       const zoned_time<Duration2, TimeZonePtr>& y);
 
@@ -26040,7 +26040,7 @@ outputs to \tcode{os} according to the format
 for (hours h : {1h, 18h}) {
   time_of_day<hours> tod(h);
   os << tod << '\n';
-  tod.make12()
+  tod.make12();
   os << tod << '\n';
 }
 \end{codeblock}
@@ -26081,7 +26081,7 @@ outputs to \tcode{os} according to the format
 for (minutes m : {68min, 1095min}) {
   time_of_day<minutes> tod(m);
   os << tod << '\n';
-  tod.make12()
+  tod.make12();
   os << tod << '\n';
 }
 \end{codeblock}
@@ -26122,7 +26122,7 @@ outputs to \tcode{os} according to the format
 for (seconds s : {4083s, 65745s}) {
   time_of_day<seconds> tod(s);
   os << tod << '\n';
-  tod.make12()
+  tod.make12();
   os << tod << '\n';
 }
 \end{codeblock}
@@ -26163,7 +26163,7 @@ outputs to \tcode{os} according to the format
 for (milliseconds ms : {4083007ms, 65745123ms}) {
   time_of_day<seconds> tod(ms);
   os << tod << '\n';
-  tod.make12()
+  tod.make12();
   os << tod << '\n';
 }
 \end{codeblock}
@@ -27070,7 +27070,7 @@ namespace std::chrono {
     explicit zoned_time(string_view name);
 
     template<class Duration2>
-      zoned_time(const zoned_time<Duration2>& zt) noexcept;
+      zoned_time(const zoned_time<Duration2, TimeZonePtr>& zt) noexcept;
 
     zoned_time(TimeZonePtr z,    const sys_time<Duration>& st);
     zoned_time(string_view name, const sys_time<Duration>& st);
@@ -27215,7 +27215,7 @@ default constructing \tcode{tp_}.
 \end{itemdescr}
 
 \begin{itemdecl}
-template<class Duration2, TimeZonePtr2>
+template<class Duration2>
   zoned_time(const zoned_time<Duration2, TimeZonePtr>& y) noexcept;
 \end{itemdecl}
 
@@ -27272,7 +27272,7 @@ zoned_time(TimeZonePtr z, const local_time<Duration>& tp);
 \remarks
 This constructor does not participate in overload resolution unless
 \begin{codeblock}
-declval<TimeZonePtr&>()->to_sys(local_time<Duration>{})
+decltype(declval<TimeZonePtr&>()->to_sys(local_time<Duration>{}))
 \end{codeblock}
 is convertible to \tcode{sys_time<duration>}.
 
@@ -27336,7 +27336,7 @@ Equivalent to construction with \tcode{\{traits::locate_zone(name), tp, c\}}.
 \end{itemdescr}
 
 \begin{itemdecl}
-template<class Duration2, TimeZonePtr2>
+template<class Duration2, class TimeZonePtr2>
   zoned_time(TimeZonePtr z, const zoned_time<Duration2, TimeZonePtr2>& y);
 \end{itemdecl}
 
@@ -27355,7 +27355,7 @@ initializing \tcode{zone_} with \tcode{std::move(z)} and \tcode{tp_} with \tcode
 \end{itemdescr}
 
 \begin{itemdecl}
-template<class Duration2, TimeZonePtr2>
+template<class Duration2, class TimeZonePtr2>
   zoned_time(TimeZonePtr z, const zoned_time<Duration2, TimeZonePtr2>& y, choose);
 \end{itemdecl}
 
@@ -27521,12 +27521,24 @@ template<class Duration1, class Duration2, class TimeZonePtr>
 \returns \tcode{x.zone_ == y.zone_ \&\& x.tp_ == y.tp_}.
 \end{itemdescr}
 
+\indexlibrarymember{operator"!=}{zoned_time}%
+\begin{itemdecl}
+template<class Duration1, class Duration2, class TimeZonePtr>
+  bool operator!=(const zoned_time<Duration1, TimeZonePtr>& x,
+                  const zoned_time<Duration2, TimeZonePtr>& y);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns \tcode{!(x == y)}.
+\end{itemdescr}
+
 \indexlibrarymember{operator<<}{zoned_time}%
 \begin{itemdecl}
 template<class charT, class traits, class Duration, class TimeZonePtr>
   basic_ostream<charT, traits>&
     operator<<(basic_ostream<charT, traits>& os,
-               const zoned_time<Duration, TimeZonePtr>& t)
+               const zoned_time<Duration, TimeZonePtr>& t);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -27629,7 +27641,7 @@ Produces the output:
 
 \indexlibrarymember{date}{leap}%
 \begin{itemdecl}
-constexpr sys_seconds date() const noexcept
+constexpr sys_seconds date() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -27641,7 +27653,7 @@ constexpr sys_seconds date() const noexcept
 
 \indexlibrarymember{operator==}{leap}%
 \begin{itemdecl}
-constexpr bool operator==(const leap& x, const leap& y) noexcept
+constexpr bool operator==(const leap& x, const leap& y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -27651,7 +27663,7 @@ constexpr bool operator==(const leap& x, const leap& y) noexcept
 
 \indexlibrarymember{operator<}{leap}%
 \begin{itemdecl}
-constexpr bool operator<(const leap& x, const leap& y) noexcept
+constexpr bool operator<(const leap& x, const leap& y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -27663,7 +27675,7 @@ constexpr bool operator<(const leap& x, const leap& y) noexcept
 \indexlibrarymember{operator==}{sys_time}%
 \begin{itemdecl}
 template<class Duration>
-  constexpr bool operator==(const leap& x, const sys_time<Duration>& y) noexcept
+  constexpr bool operator==(const leap& x, const sys_time<Duration>& y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -27675,7 +27687,7 @@ template<class Duration>
 \indexlibrarymember{operator==}{sys_time}%
 \begin{itemdecl}
 template<class Duration>
-  constexpr bool operator==(const sys_time<Duration>& x, const leap& y) noexcept
+  constexpr bool operator==(const sys_time<Duration>& x, const leap& y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -27687,7 +27699,7 @@ template<class Duration>
 \indexlibrarymember{operator"!=}{sys_time}%
 \begin{itemdecl}
 template<class Duration>
-  constexpr bool operator!=(const leap& x, const sys_time<Duration>& y) noexcept
+  constexpr bool operator!=(const leap& x, const sys_time<Duration>& y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -27699,7 +27711,7 @@ template<class Duration>
 \indexlibrarymember{operator"!=}{sys_time}%
 \begin{itemdecl}
 template<class Duration>
-  constexpr bool operator!=(const sys_time<Duration>& x, const leap& y) noexcept
+  constexpr bool operator!=(const sys_time<Duration>& x, const leap& y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -27711,7 +27723,7 @@ template<class Duration>
 \indexlibrarymember{operator<}{sys_time}%
 \begin{itemdecl}
 template<class Duration>
-  constexpr bool operator<(const leap& x, const sys_time<Duration>& y) noexcept
+  constexpr bool operator<(const leap& x, const sys_time<Duration>& y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -27723,7 +27735,7 @@ template<class Duration>
 \indexlibrarymember{operator<}{sys_time}%
 \begin{itemdecl}
 template<class Duration>
-  constexpr bool operator<(const sys_time<Duration>& x, const leap& y) noexcept
+  constexpr bool operator<(const sys_time<Duration>& x, const leap& y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -27735,7 +27747,7 @@ template<class Duration>
 \indexlibrarymember{operator>}{sys_time}%
 \begin{itemdecl}
 template<class Duration>
-  constexpr bool operator>(const leap& x, const sys_time<Duration>& y) noexcept
+  constexpr bool operator>(const leap& x, const sys_time<Duration>& y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -27747,7 +27759,7 @@ template<class Duration>
 \indexlibrarymember{operator>}{sys_time}%
 \begin{itemdecl}
 template<class Duration>
-  constexpr bool operator>(const sys_time<Duration>& x, const leap& y) noexcept
+  constexpr bool operator>(const sys_time<Duration>& x, const leap& y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -27759,7 +27771,7 @@ template<class Duration>
 \indexlibrarymember{operator<=}{sys_time}%
 \begin{itemdecl}
 template<class Duration>
-  constexpr bool operator<=(const leap& x, const sys_time<Duration>& y) noexcept
+  constexpr bool operator<=(const leap& x, const sys_time<Duration>& y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -27771,7 +27783,7 @@ template<class Duration>
 \indexlibrarymember{operator<=}{sys_time}%
 \begin{itemdecl}
 template<class Duration>
-  constexpr bool operator<=(const sys_time<Duration>& x, const leap& y) noexcept
+  constexpr bool operator<=(const sys_time<Duration>& x, const leap& y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -27783,7 +27795,7 @@ template<class Duration>
 \indexlibrarymember{operator>=}{sys_time}%
 \begin{itemdecl}
 template<class Duration>
-  constexpr bool operator>=(const leap& x, const sys_time<Duration>& y) noexcept
+  constexpr bool operator>=(const leap& x, const sys_time<Duration>& y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -27795,7 +27807,7 @@ template<class Duration>
 \indexlibrarymember{operator>=}{sys_time}%
 \begin{itemdecl}
 template<class Duration>
-  constexpr bool operator>=(const sys_time<Duration>& x, const leap& y) noexcept
+  constexpr bool operator>=(const sys_time<Duration>& x, const leap& y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -27831,7 +27843,7 @@ A \tcode{link} specifies an alternative name for a \tcode{time_zone}.
 
 \indexlibrarymember{name}{link}%
 \begin{itemdecl}
-string_view name() const noexcept
+string_view name() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -27842,7 +27854,7 @@ The alternative name for the time zone.
 
 \indexlibrarymember{target}{link}%
 \begin{itemdecl}
-string_view target() const noexcept
+string_view target() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -27856,7 +27868,7 @@ this \tcode{link} provides an alternative name.
 
 \indexlibrarymember{operator==}{link}%
 \begin{itemdecl}
-bool operator==(const link& x, const link& y) noexcept
+bool operator==(const link& x, const link& y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -27866,7 +27878,7 @@ bool operator==(const link& x, const link& y) noexcept
 
 \indexlibrarymember{operator<}{link}%
 \begin{itemdecl}
-bool operator<(const link& x, const link& y) noexcept
+bool operator<(const link& x, const link& y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
- Add missing semicolons.
- Write out `operator!=` for `zoned_time`. [operators] does not apply because this comparison is heterogeneous (can have different `Duration` types).
- Fixes `TimeZonePtr2`-related typos in `zoned_time`.