### PR TITLE
[enumerated.types,bitmask.types] Use \vdots and \ldots instead of ...…

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -606,13 +606,13 @@ values\iref{basic.fundamental}.}
 The enumerated type \tcode{\placeholder{enumerated}} can be written:
 
 \begin{codeblock}
-enum @\placeholder{enumerated}@ { @$\tcode{\placeholder{V}}_{0}$@, @$\tcode{\placeholder{V}}_{1}$@, @$\tcode{\placeholder{V}}_{2}$@, @$\tcode{\placeholder{V}}_{3}$@, ..... };
+enum @\placeholder{enumerated}@ { @$\tcode{\placeholder{V}}_{0}$@, @$\tcode{\placeholder{V}}_{1}$@, @$\tcode{\placeholder{V}}_{2}$@, @$\tcode{\placeholder{V}}_{3}$@, @$\ldots$@ };
 
 inline const @$\tcode{\placeholder{enumerated C}}_{0}$@(@$\tcode{\placeholder{V}}_{0}$@);
 inline const @$\tcode{\placeholder{enumerated C}}_{1}$@(@$\tcode{\placeholder{V}}_{1}$@);
 inline const @$\tcode{\placeholder{enumerated C}}_{2}$@(@$\tcode{\placeholder{V}}_{2}$@);
 inline const @$\tcode{\placeholder{enumerated C}}_{3}$@(@$\tcode{\placeholder{V}}_{3}$@);
-  .....
+  @\vdots@
 \end{codeblock}
 
 \pnum
@@ -642,14 +642,14 @@ The bitmask type \tcode{\placeholder{bitmask}} can be written:
 // For exposition only.
 // \tcode{int_type} is an integral type capable of representing all values of the bitmask type.
 enum @\placeholder{bitmask}@ : int_type {
-  @$\tcode{\placeholder{V}}_{0}$@ = 1 << 0, @$\tcode{\placeholder{V}}_{1}$@ = 1 << 1, @$\tcode{\placeholder{V}}_{2}$@ = 1 << 2, @$\tcode{\placeholder{V}}_{3}$@ = 1 << 3, .....
+  @$\tcode{\placeholder{V}}_{0}$@ = 1 << 0, @$\tcode{\placeholder{V}}_{1}$@ = 1 << 1, @$\tcode{\placeholder{V}}_{2}$@ = 1 << 2, @$\tcode{\placeholder{V}}_{3}$@ = 1 << 3, @$\ldots$@
 };
 
 inline constexpr @$\tcode{\placeholder{bitmask C}}_{0}$@(@$\tcode{\placeholder{V}}_{0}{}$@);
 inline constexpr @$\tcode{\placeholder{bitmask C}}_{1}$@(@$\tcode{\placeholder{V}}_{1}{}$@);
 inline constexpr @$\tcode{\placeholder{bitmask C}}_{2}$@(@$\tcode{\placeholder{V}}_{2}{}$@);
 inline constexpr @$\tcode{\placeholder{bitmask C}}_{3}$@(@$\tcode{\placeholder{V}}_{3}{}$@);
-  .....
+  @\vdots@
 
 constexpr @\placeholder{bitmask}{}@ operator&(@\placeholder{bitmask}{}@ X, @\placeholder{bitmask}{}@ Y) {
   return static_cast<@\placeholder{bitmask}{}@>(


### PR DESCRIPTION
….. mega-ellipses.

Partially addresses #1390.