### PR TITLE
[rand] Use \dotsc, not \ldots for comma-separated lists

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -2980,7 +2980,7 @@ The textual representation%
 of \state{x}{i}
 consists of
 the values of
- $X_{i-n}, \ldots, X_{i-1}$,
+ $X_{i-n}, \dotsc, X_{i-1}$,
 in that order.
 
 \indexlibrary{\idxcode{mersenne_twister_engine}!constructor}%
@@ -2991,7 +2991,7 @@ explicit mersenne_twister_engine(result_type value = default_seed);
 \begin{itemdescr}
 \pnum\effects Constructs a \tcode{mersenne_twister_engine} object.
 Sets $X_{-n}$ to $\tcode{value} \bmod 2^w$.
- Then, iteratively for $i = 1\!-\!n,\ldots,-1$,
+ Then, iteratively for $i = 1\!-\!n,\dotsc,-1$,
  sets $X_i$
  to
 \[%
@@ -3018,7 +3018,7 @@ template<class Sseq> explicit mersenne_twister_engine(Sseq& q);
  and $a$ an array (or equivalent)
  of length $ n \cdot k $,
  invokes \tcode{q.generate($a+0$, $a+n \cdot k$)}
- and then, iteratively for $i = -n,\ldots,-1$,
+ and then, iteratively for $i = -n,\dotsc,-1$,
  sets $X_i$
  to $ \left(\sum_{j=0}^{k-1}a_{k(i+n)+j} \cdot 2^{32j} \right) \bmod 2^w $.
  Finally,
@@ -3135,7 +3135,7 @@ The textual representation%
 \indextext{\idxcode{subtract_with_carry_engine}!textual representation}%
 \indextext{textual representation!\idxcode{subtract_with_carry_engine}}
 consists of the values of
- $X_{i-r}, \ldots, X_{i-1}$,
+ $X_{i-r}, \dotsc, X_{i-1}$,
 in that order, followed by $c$.
 
 
@@ -3147,7 +3147,7 @@ explicit subtract_with_carry_engine(result_type value = default_seed);
 \begin{itemdescr}
 \pnum\effects Constructs a \tcode{subtract_with_carry_engine} object.
  Sets the values of
- $ X_{-r}, \ldots, X_{-1} $,
+ $ X_{-r}, \dotsc, X_{-1} $,
  in that order, as specified below.
  If $X_{-1}$ is then $0$,
  sets $c$ to $1$;
@@ -3161,7 +3161,7 @@ linear_congruential_engine<result_type,
                           40014u,0u,2147483563u> e(value == 0u ? default_seed : value);
 \end{codeblock}
  Then, to set each $X_k$,
- obtain new values $ z_0, \ldots, z_{n-1} $
+ obtain new values $ z_0, \dotsc, z_{n-1} $
  from $n = \lceil w/32 \rceil $ successive invocations
  of \tcode{e} taken modulo $2^{32}$.
  Set $X_k$ to $ \left( \sum_{j=0}^{n-1} z_j \cdot 2^{32j}\right) \bmod m$.
@@ -3184,7 +3184,7 @@ template<class Sseq> explicit subtract_with_carry_engine(Sseq& q);
  and $a$ an array (or equivalent)
  of length $ r \cdot k $,
  invokes \tcode{q.generate($a+0$, $a+r \cdot k$)}
- and then, iteratively for $i = -r, \ldots, -1$,
+ and then, iteratively for $i = -r, \dotsc, -1$,
  sets $X_i$
  to $ \left(\sum_{j=0}^{k-1}a_{k(i+r)+j} \cdot 2^{32j} \right) \bmod m $.
  If $X_{-1}$ is then $0$,
@@ -3604,7 +3604,7 @@ pursuant to subclause~\ref{rand.req.adapt},
 each constructor%
 \indexlibrary{\idxcode{shuffle_order_engine}!constructor}
 that is not a copy constructor
-initializes $\tcode{V[0]}, \ldots, \tcode{V[k-1]}$ and $Y$,
+initializes $\tcode{V[0]}, \dotsc, \tcode{V[k-1]}$ and $Y$,
 in that order,
 with values returned by successive invocations of \tcode{e()}.%
 \indextext{random number generation!engines|)}
@@ -3879,7 +3879,7 @@ double entropy() const noexcept;
  returns $0.0$.
  Otherwise, returns an entropy estimate\footnote{If a device has $n$ states
    whose respective probabilities are
-   $ P_0, \ldots, P_{n-1} $,
+   $ P_0, \dotsc, P_{n-1} $,
    the device entropy $S$ is defined as\\
    $ S = - \sum_{i=0}^{n-1} P_i \cdot \log P_i $.}
  for the random numbers returned by \tcode{operator()},
@@ -4050,7 +4050,7 @@ template<class RandomAccessIterator>
  \item
    With $m$ as the larger of $s + 1$ and $n$,
    transform the elements of the range:
-   iteratively for $ k = 0, \ldots, m-1 $,
+   iteratively for $ k = 0, \dotsc, m-1 $,
    calculate values
    \begin{eqnarray*}
      r_1 & = &
@@ -4077,7 +4077,7 @@ template<class RandomAccessIterator>
  \item
    Transform the elements of the range again,
    beginning where the previous step ended:
-   iteratively for $ k = m, \ldots, m\!+\!n\!-\!1 $,
+   iteratively for $ k = m, \dotsc, m\!+\!n\!-\!1 $,
    calculate values
    \begin{eqnarray*}
      r_3 & = &
@@ -4195,7 +4195,7 @@ template<class RealType, size_t bits, class URBG>
 
 \pnum\effects
  Invokes \tcode{g()} $k$ times
- to obtain values $ g_0, \ldots, g_{k-1} $, respectively.
+ to obtain values $ g_0, \dotsc, g_{k-1} $, respectively.
  Calculates a quantity
  \[
    S = \sum_{i=0}^{k-1} (g_i - \tcode{g.min()})
@@ -5782,7 +5782,7 @@ the discrete probability function%
 \indextext{discrete probability function!\idxcode{discrete_distribution}}%
 \indextext{\idxcode{discrete_distribution}!discrete probability function}%
 \[%
- P(i\,|\,p_0,\ldots,p_{n-1})
+ P(i\,|\,p_0,\dotsc,p_{n-1})
       = p_i
 \; \mbox{.}
 \]
@@ -5790,7 +5790,7 @@ the discrete probability function%
 \pnum
 Unless specified otherwise,
 the distribution parameters are calculated as:
- $p_k = {w_k / S} \; \mbox{  for } k = 0, \ldots, n\!-\!1$ ,
+ $p_k = {w_k / S} \; \mbox{  for } k = 0, \dotsc, n\!-\!1$ ,
 in which
 the values $w_k$,
 commonly known as the \techterm{weights}%
@@ -5910,7 +5910,7 @@ template<class UnaryOperation>
  let $ w_0 = 1 $.
  Otherwise,
  let $ w_k = \tcode{fw}(\tcode{xmin} + k \cdot \delta + \delta / 2) $
- for $ k = 0, \ldots, n\!-\!1 $.
+ for $ k = 0, \dotsc, n\!-\!1 $.
 
 \pnum\complexity
  The number of invocations of \tcode{fw} shall not exceed $n$.
@@ -5925,7 +5925,7 @@ vector<double> probabilities() const;
 \pnum\returns A \tcode{vector<double>}
  whose \tcode{size} member returns $n$
  and whose $ \tcode{operator[]} $ member returns $p_k$
- when invoked with argument $k$ for $k = 0, \ldots, n\!-\!1 $.
+ when invoked with argument $k$ for $k = 0, \dotsc, n\!-\!1 $.
 \end{itemdescr}
 
 
@@ -5947,7 +5947,7 @@ according to the probability density function
 \indextext{probability density function!\idxcode{piecewise_constant_distribution}}%
 \indextext{\idxcode{piecewise_constant_distribution}!probability density function}%
 \[%
- p(x\,|\,b_0,\ldots,b_n,\;\rho_0,\ldots,\rho_{n-1})
+ p(x\,|\,b_0,\dotsc,b_n,\;\rho_0,\dotsc,\rho_{n-1})
       = \rho_i
 \; \mbox{,}
 \mbox{ for } b_i \le x < b_{i+1}
@@ -5961,13 +5961,13 @@ also known as this distribution's \techterm{interval boundaries}%
 \indextext{interval boundaries!\idxcode{piecewise_constant_distribution}}%
 , shall satisfy the relation
  $ b_i < b_{i+1} $
-for $i = 0, \ldots, n\!-\!1 $.
+for $i = 0, \dotsc, n\!-\!1 $.
 Unless specified otherwise,
 the remaining $n$ distribution parameters are calculated as:
 \[%
  \rho_k = \;
    \frac{w_k}{S \cdot (b_{k+1}-b_k)}
-   \; \mbox{ for } k = 0, \ldots, n\!-\!1,
+   \; \mbox{ for } k = 0, \dotsc, n\!-\!1,
 \]
 in which the values $w_k$,
 commonly known as the \techterm{weights}%
@@ -6089,10 +6089,10 @@ template<class UnaryOperation>
  and $ b_1 = 1 $.
  Otherwise,
  let $\bigl[\tcode{bl.begin()}, \tcode{bl.end()}\bigr)$
- form a sequence $ b_0, \ldots, b_n $,
+ form a sequence $ b_0, \dotsc, b_n $,
  and
  let $ w_k = \tcode{fw}\bigl(\bigl(b_{k+1} + b_k\bigr) / 2\bigr) $
- for $ k = 0, \ldots, n\!-\!1 $.
+ for $ k = 0, \dotsc, n\!-\!1 $.
 
 \pnum\complexity
  The number of invocations of \tcode{fw} shall not exceed $n$.
@@ -6120,8 +6120,8 @@ template<class UnaryOperation>
 \pnum\effects Constructs a \tcode{piecewise_constant_distribution} object
  with parameters taken or calculated
  from the following values:
- Let $ b_k = \tcode{xmin} + k \cdot \delta $ for $ k = 0, \ldots, n $,
- and $ w_k = \tcode{fw}(b_k + \delta / 2) $ for $ k = 0, \ldots, n\!-\!1 $.
+ Let $ b_k = \tcode{xmin} + k \cdot \delta $ for $ k = 0, \dotsc, n $,
+ and $ w_k = \tcode{fw}(b_k + \delta / 2) $ for $ k = 0, \dotsc, n\!-\!1 $.
 
 \pnum\complexity
  The number of invocations of \tcode{fw} shall not exceed $n$.
@@ -6136,7 +6136,7 @@ vector<result_type> intervals() const;
 \pnum\returns A \tcode{vector<result_type>}
  whose \tcode{size} member returns $n + 1$
  and whose $ \tcode{operator[]} $ member returns $b_k$
- when invoked with argument $k$ for $k = 0, \ldots, n $.
+ when invoked with argument $k$ for $k = 0, \dotsc, n $.
 \end{itemdescr}
 
 \indexlibrarymember{densities}{piecewise_constant_distribution}%
@@ -6148,7 +6148,7 @@ vector<result_type> densities() const;
 \pnum\returns A \tcode{vector<result_type>}
  whose \tcode{size} member returns $n$
  and whose $ \tcode{operator[]} $ member returns $\rho_k$
- when invoked with argument $k$ for $k = 0, \ldots, n\!-\!1 $.
+ when invoked with argument $k$ for $k = 0, \dotsc, n\!-\!1 $.
 \end{itemdescr}
 
 
@@ -6170,7 +6170,7 @@ according to the probability density function
 \indextext{probability density function!\idxcode{piecewise_linear_distribution}}%
 \indextext{\idxcode{piecewise_linear_distribution}!probability density function}%
 \[%
- p(x\,|\,b_0,\ldots,b_n,\;\rho_0,\ldots,\rho_n)
+ p(x\,|\,b_0,\dotsc,b_n,\;\rho_0,\dotsc,\rho_n)
       = \rho_i     \cdot {\frac{b_{i+1} - x}{b_{i+1} - b_i}}
       + \rho_{i+1} \cdot {\frac{x - b_i}{b_{i+1} - b_i}}
 \; \mbox{,}
@@ -6185,10 +6185,10 @@ also known as this distribution's \techterm{interval boundaries}%
 \indextext{interval boundaries!\idxcode{piecewise_linear_distribution}}%
 , shall satisfy the relation
  $ b_i < b_{i+1} $
-for $i = 0, \ldots, n\!-\!1 $.
+for $i = 0, \dotsc, n\!-\!1 $.
 Unless specified otherwise,
 the remaining $n+1$ distribution parameters are calculated as
-$ \rho_k = {w_k / S} \; \mbox{ for } k = 0, \ldots, n $,
+$ \rho_k = {w_k / S} \; \mbox{ for } k = 0, \dotsc, n $,
 in which the values $w_k$,
 commonly known as the \techterm{weights at boundaries}%
 \indextext{\idxcode{piecewise_linear_distribution}!weights at boundaries}%
@@ -6310,10 +6310,10 @@ template<class UnaryOperation>
  and $ b_1 = 1 $.
  Otherwise,
  let $\bigl[\tcode{bl.begin(),} \tcode{bl.end()}\bigr)$
- form a sequence $ b_0, \ldots, b_n $,
+ form a sequence $ b_0, \dotsc, b_n $,
  and
  let $ w_k = \tcode{fw}(b_k) $
- for $ k = 0, \ldots, n $.
+ for $ k = 0, \dotsc, n $.
 
 \pnum\complexity
  The number of invocations of \tcode{fw} shall not exceed $n+1$.
@@ -6341,8 +6341,8 @@ template<class UnaryOperation>
 \pnum\effects Constructs a \tcode{piecewise_linear_distribution} object
  with parameters taken or calculated
  from the following values:
- Let $ b_k = \tcode{xmin} + k \cdot \delta $ for $ k = 0, \ldots, n $,
- and $ w_k = \tcode{fw}(b_k) $ for $ k = 0, \ldots, n $.
+ Let $ b_k = \tcode{xmin} + k \cdot \delta $ for $ k = 0, \dotsc, n $,
+ and $ w_k = \tcode{fw}(b_k) $ for $ k = 0, \dotsc, n $.
 
 \pnum\complexity
  The number of invocations of \tcode{fw} shall not exceed $n+1$.
@@ -6357,7 +6357,7 @@ vector<result_type> intervals() const;
 \pnum\returns A \tcode{vector<result_type>}
  whose \tcode{size} member returns $n + 1$
  and whose $ \tcode{operator[]} $ member returns $b_k$
- when invoked with argument $k$ for $k = 0, \ldots, n $.
+ when invoked with argument $k$ for $k = 0, \dotsc, n $.
 \end{itemdescr}
 
 \indexlibrarymember{densities}{piecewise_linear_distribution}%
@@ -6369,7 +6369,7 @@ vector<result_type> densities() const;
 \pnum\returns A \tcode{vector<result_type>}
  whose \tcode{size} member returns $n$
  and whose $ \tcode{operator[]} $ member returns $\rho_k$
- when invoked with argument $k$ for $ k = 0, \ldots, n $.
+ when invoked with argument $k$ for $ k = 0, \dotsc, n $.
 \end{itemdescr}%
 %
 \indextext{random number distributions!sampling|)}%


### PR DESCRIPTION
Fixes #2032.

No differences with diffpdf "appearance" mode.