### PR TITLE
[class.spaceship] Use math mode for the entire formula,

### DIFF
--- a/source/special.tex
+++ b/source/special.tex
@@ -3338,16 +3338,16 @@ in the order of their declaration in the \grammarterm{member-specification} of \
 form a list of subobjects.
 In that list, any subobject of array type is recursively expanded
 to the sequence of its elements, in the order of increasing subscript.
-Let \tcode{x}$_i$ be an lvalue denoting the $i^\textrm{th}$ element
+Let $\tcode{x}_i$ be an lvalue denoting the $i^\text{th}$ element
 in the expanded list of subobjects for an object \tcode{x}
 (of length $n$),
-where \tcode{x}$_i$ is
+where $\tcode{x}_i$ is
 formed by a sequence of
 derived-to-base conversions\iref{over.best.ics},
 class member access expressions\iref{expr.ref}, and
 array subscript expressions\iref{expr.sub} applied to \tcode{x}.
-The type of the expression \tcode{x}$_i$ \tcode{<=>} \tcode{x}$_i$
-is denoted by \tcode{R}$_i$.
+The type of the expression $\tcode{x}_i$ \tcode{<=>} $\tcode{x}_i$
+is denoted by $\tcode{R}_i$.
 It is unspecified
 whether virtual base class subobjects are compared more than once.
 
@@ -3357,11 +3357,11 @@ of a defaulted three-way comparison operator function
 is \tcode{auto},
 then the return type is deduced as
 the common comparison type (see below) of
-\tcode{R}$_0$, \tcode{R}$_1$, $\cdots$, \tcode{R}$_{n-1}$.
+$\tcode{R}_0$, $\tcode{R}_1$, $\dotsc$, $\tcode{R}_{n-1}$.
 \begin{note}
 Otherwise,
 the program will be ill-formed
-if the expression \tcode{x}$_i$ \tcode{<=>} \tcode{x}$_i$
+if the expression $\tcode{x}_i$ \tcode{<=>} $\tcode{x}_i$
 is not implicitly convertible to the declared return type for any $i$.
 \end{note}
 If the return type is deduced as \tcode{void},
@@ -3372,46 +3372,46 @@ The return value \tcode{V} of type \tcode{R}
 of the defaulted three-way comparison operator function
 with parameters \tcode{x} and \tcode{y} of the same type
 is determined by comparing corresponding elements
-\tcode{x}$_i$ and \tcode{y}$_i$
+$\tcode{x}_i$ and $\tcode{y}_i$
 in the expanded lists of subobjects for \tcode{x} and \tcode{y}
 until the first index $i$
-where \tcode{x}$_i$ \tcode{<=>} \tcode{y}$_i$
-yields a result value \tcode{v}$_i$ where \tcode{v}$_i$\tcode{ != 0},
+where $\tcode{x}_i$ \tcode{<=>} $\tcode{y}_i$
+yields a result value $\tcode{v}_i$ where $\tcode{v}_i \mathrel{\tcode{!=}} 0$,
 contextually converted to \tcode{bool}, yields \tcode{true};
-\tcode{V} is \tcode{v}$_i$ converted to \tcode{R}.
+\tcode{V} is $\tcode{v}_i$ converted to \tcode{R}.
 If no such index exists, \tcode{V} is
 \tcode{std::strong_ordering::equal} converted to \tcode{R}.
 
 \pnum
 The \defn{common comparison type} \tcode{U}
 of a possibly-empty list of $n$ types
-\tcode{T}$_0$, \tcode{T}$_1$, $\cdots$, \tcode{T}$_{n-1}$
+$\tcode{T}_0$, $\tcode{T}_1$, $\dotsc$, $\tcode{T}_{n-1}$
 is defined as follows:
 
 \begin{itemize}
 \item
-If any \tcode{T}$_i$
+If any $\tcode{T}_i$
 is not a comparison category type\iref{cmp.categories},
 \tcode{U} is \tcode{void}.
 
 \item
 Otherwise, if
-at least one \tcode{T}$_i$ is \tcode{std::weak_equality}, or
-at least one \tcode{T}$_i$ is \tcode{std::strong_equality} and
-at least one \tcode{T}$_j$ is \tcode{std::partial_ordering} or
+at least one $\tcode{T}_i$ is \tcode{std::weak_equality}, or
+at least one $\tcode{T}_i$ is \tcode{std::strong_equality} and
+at least one $\tcode{T}_j$ is \tcode{std::partial_ordering} or
                               \tcode{std::weak_ordering},
 \tcode{U} is \tcode{std::weak_equality}\iref{cmp.weakeq}.
 
 \item
-Otherwise, if at least one \tcode{T}$_i$ is \tcode{std::strong_equality},
+Otherwise, if at least one $\tcode{T}_i$ is \tcode{std::strong_equality},
 \tcode{U} is \tcode{std::strong_equality}\iref{cmp.strongeq}.
 
 \item
-Otherwise, if at least one \tcode{T}$_i$ is \tcode{std::partial_ordering},
+Otherwise, if at least one $\tcode{T}_i$ is \tcode{std::partial_ordering},
 \tcode{U} is \tcode{std::partial_ordering}\iref{cmp.partialord}.
 
 \item
-Otherwise, if at least one \tcode{T}$_i$ is \tcode{std::weak_ordering},
+Otherwise, if at least one $\tcode{T}_i$ is \tcode{std::weak_ordering},
 \tcode{U} is \tcode{std::weak_ordering}\iref{cmp.weakord}.
 
 \item


### PR DESCRIPTION
not just for the subscript.
Also use \dotsc, not center dots, for comma-separated lists.