### PR TITLE
[cpp, lex, over] Make bnf indentation in source match presentation.

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -796,15 +796,15 @@ are converted into tokens for operators and punctuators:
 %% Ed. note: character protrusion would misalign various operators.
 \microtypesetup{protrusion=false}\obeyspaces
 \nontermdef{preprocessing-op-or-punc} \textnormal{one of}\br
-\terminal{\{        \}        [        ]        \#        \#\#       (        )}\br
-\terminal{<:       :>       <\%       \%>       \%:       \%:\%:     ;        :        ...}\br
-\terminal{new      delete   ?        ::       .        .*       ->       ->*      \~}\br
-\terminal{!        +        -        *        /        \%        \caret{}        \&        |}\br
-\terminal{=        +=       -=       *=       /=       \%=       \caret{}=       \&=       |=}\br
-\terminal{==       !=       <        >        <=       >=       <=>      \&\&       ||}\br
-\terminal{<<       >>       <<=      >>=      ++       --       ,}\br
-\terminal{and      or       xor      not      bitand   bitor    compl}\br
-\terminal{and_eq   or_eq    xor_eq   not_eq}
+    \terminal{\{        \}        [        ]        \#        \#\#       (        )}\br
+    \terminal{<:       :>       <\%       \%>       \%:       \%:\%:     ;        :        ...}\br
+    \terminal{new      delete   ?        ::       .        .*       ->       ->*      \~}\br
+    \terminal{!        +        -        *        /        \%        \caret{}        \&        |}\br
+    \terminal{=        +=       -=       *=       /=       \%=       \caret{}=       \&=       |=}\br
+    \terminal{==       !=       <        >        <=       >=       <=>      \&\&       ||}\br
+    \terminal{<<       >>       <<=      >>=      ++       --       ,}\br
+    \terminal{and      or       xor      not      bitand   bitor    compl}\br
+    \terminal{and_eq   or_eq    xor_eq   not_eq}
 \end{bnf}
 
 Each \grammarterm{preprocessing-op-or-punc} is converted to a single token

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -3077,11 +3077,11 @@ the operator named in its
 %% Ed. note: character protrusion would misalign various operators.
 \microtypesetup{protrusion=false}\obeyspaces
 \nontermdef{operator} \textnormal{one of}\br
-\terminal{new      delete   new[]    delete[] (\rlap{\,)}        [\rlap{\,]}        ->       ->*      \~}\br
-\terminal{!        +        -        *        /        \%        \caret{}        \&        |}\br
-\terminal{=        +=       -=       *=       /=       \%=       \caret{}=       \&=       |=}\br
-\terminal{==       !=       <        >        <=       >=       <=>      \&\&       ||}\br
-\terminal{<<       >>       <<=      >>=      ++       --       ,}\br
+    \terminal{new      delete   new[]    delete[] (\rlap{\,)}        [\rlap{\,]}        ->       ->*      \~}\br
+    \terminal{!        +        -        *        /        \%        \caret{}        \&        |}\br
+    \terminal{=        +=       -=       *=       /=       \%=       \caret{}=       \&=       |=}\br
+    \terminal{==       !=       <        >        <=       >=       <=>      \&\&       ||}\br
+    \terminal{<<       >>       <<=      >>=      ++       --       ,}\br
 \end{bnf}
 \begin{note}
 The last two operators are function call\iref{expr.call}

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -49,16 +49,16 @@ within what would otherwise be an invocation of a function-like macro.
 
 \begin{bnf}\obeyspaces
 \nontermdef{control-line}\br
-\terminal{\# include} pp-tokens new-line\br
-\terminal{\# define } identifier replacement-list new-line\br
-\terminal{\# define } identifier lparen \opt{identifier-list} \terminal{)} replacement-list new-line\br
-\terminal{\# define } identifier lparen \terminal{... )} replacement-list new-line\br
-\terminal{\# define } identifier lparen identifier-list \terminal{, ... )} replacement-list new-line\br
-\terminal{\# undef  } identifier new-line\br
-\terminal{\# line   } pp-tokens new-line\br
-\terminal{\# error  } \opt{pp-tokens} new-line\br
-\terminal{\# pragma } \opt{pp-tokens} new-line\br
-\terminal{\# }new-line
+    \terminal{\# include} pp-tokens new-line\br
+    \terminal{\# define } identifier replacement-list new-line\br
+    \terminal{\# define } identifier lparen \opt{identifier-list} \terminal{)} replacement-list new-line\br
+    \terminal{\# define } identifier lparen \terminal{... )} replacement-list new-line\br
+    \terminal{\# define } identifier lparen identifier-list \terminal{, ... )} replacement-list new-line\br
+    \terminal{\# undef  } identifier new-line\br
+    \terminal{\# line   } pp-tokens new-line\br
+    \terminal{\# error  } \opt{pp-tokens} new-line\br
+    \terminal{\# pragma } \opt{pp-tokens} new-line\br
+    \terminal{\# }new-line
 \end{bnf}
 
 \begin{bnf}
@@ -68,9 +68,9 @@ within what would otherwise be an invocation of a function-like macro.
 
 \begin{bnf}\obeyspaces
 \nontermdef{if-group}\br
-\terminal{\# if     } constant-expression new-line \opt{group}\br
-\terminal{\# ifdef  } identifier new-line \opt{group}\br
-\terminal{\# ifndef } identifier new-line \opt{group}
+    \terminal{\# if     } constant-expression new-line \opt{group}\br
+    \terminal{\# ifdef  } identifier new-line \opt{group}\br
+    \terminal{\# ifndef } identifier new-line \opt{group}
 \end{bnf}
 
 \begin{bnf}
@@ -81,17 +81,17 @@ within what would otherwise be an invocation of a function-like macro.
 
 \begin{bnf}\obeyspaces
 \nontermdef{elif-group}\br
-\terminal{\# elif   } constant-expression new-line \opt{group}
+    \terminal{\# elif   } constant-expression new-line \opt{group}
 \end{bnf}
 
 \begin{bnf}\obeyspaces
 \nontermdef{else-group}\br
-\terminal{\# else   } new-line \opt{group}
+    \terminal{\# else   } new-line \opt{group}
 \end{bnf}
 
 \begin{bnf}\obeyspaces
 \nontermdef{endif-line}\br
-\terminal{\# endif  } new-line
+    \terminal{\# endif  } new-line
 \end{bnf}
 
 \begin{bnf}


### PR DESCRIPTION
Same as #1362:
- makes the source look nicer and more consistent
- no visual difference in PDF
- makes life easier for cxxdraft-htmlgen