### PR TITLE
[over.oper] Remove incorrect and redundant sentence in a note.

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -3072,8 +3072,6 @@ the operator named in its
     \terminal{<<       >>       <<=      >>=      ++       --       ,}\br
 \end{bnf}
 \begin{note}
-The last two operators are function call\iref{expr.call}
-and subscripting\iref{expr.sub}.
 The operators
 \tcode{new[]},
 \tcode{delete[]},
@@ -3081,6 +3079,8 @@ The operators
 and
 \tcode{[]}
 are formed from more than one token.
+The latter two operators are function call\iref{expr.call}
+and subscripting\iref{expr.sub}.
 \end{note}
 \indextext{operator!subscripting}%
 \indextext{operator!function call}%


### PR DESCRIPTION
Fixes #2038.