### PR TITLE
[basic.lval] Add array subscripting to note enumerating xvalues.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -131,16 +131,20 @@ Despite their names, these terms classify expressions, not values.
 An expression is an xvalue if it is:
 \begin{itemize}
 \item the result of calling a function, whether implicitly or explicitly,
-whose return type is an rvalue reference to object type,
+whose return type is an rvalue reference to object type\iref{expr.call},
 
-\item a cast to an rvalue reference to object type,
+\item a cast to an rvalue reference to object type
+(\ref{expr.dynamic.cast}, \ref{expr.static.cast}, \ref{expr.reinterpret.cast},
+\ref{expr.const.cast}, \ref{expr.cast}),
+
+\item a subscripting operation with an xvalue array operand\iref{expr.sub},
 
 \item a class member access expression designating a non-static data member
 of non-reference type
-in which the object expression is an xvalue, or
+in which the object expression is an xvalue\iref{expr.ref}, or
 
 \item a \tcode{.*} pointer-to-member expression in which the first operand is
-an xvalue and the second operand is a pointer to data member.
+an xvalue and the second operand is a pointer to data member\iref{expr.mptr.oper}.
 \end{itemize}
 In general, the effect of this rule is that named rvalue references are
 treated as lvalues and unnamed rvalue references to objects are treated as


### PR DESCRIPTION
Also add cross-references pointing to the normative statements.

Fixes #2044.