### PR TITLE
[over.match,over.match.ref] Drop obsolete mention of class prvalues.

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -439,9 +439,8 @@ copy-initialization\iref{dcl.init} of a class object\iref{over.match.copy};
 invocation of a conversion function for initialization of an object of a
 non-class type from an expression of class type\iref{over.match.conv}; and
 \item
-invocation of a conversion function for conversion to a glvalue
-or class prvalue
-to which a reference\iref{dcl.init.ref}
+invocation of a conversion function for conversion
+in which a reference\iref{dcl.init.ref}
 will be directly bound\iref{over.match.ref}.
 \end{itemize}
 
@@ -1343,7 +1342,7 @@ the implicit object parameter of the conversion functions.
 
 \pnum
 Under the conditions specified in~\ref{dcl.init.ref}, a reference can be bound directly
-to a glvalue or class prvalue that is the result of applying a conversion
+to the result of applying a conversion
 function to an initializer expression.
 Overload resolution is used to select the
 conversion function to be invoked.


### PR DESCRIPTION
Fixes #2046.