### PR TITLE
[dcl.array]: delete note about non-modifiability of arrays

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -1178,7 +1178,6 @@ void f() {
 \pnum
 \begin{note}
 Conversions affecting expressions of array type are described in~\ref{conv.array}.
-Objects of array types cannot be modified, see~\ref{basic.lval}.
 \end{note}
 
 \pnum


### PR DESCRIPTION
[basic.lval]/10 says about (non-)modifiable lvalues (http://eel.is/c++draft/basic.lval#def:modifiable):
> An lvalue is modifiable unless its type is const-qualified or is a function type.

Nothing about arrays. 2 other places in [basic.lval] which mention arrays are:

> [ Note: Except when the prvalue is the operand of a decltype-specifier, a prvalue of class or **array** type always has a result object.
For a discarded prvalue, a temporary object is materialized; see [expr.prop]. — end note ]

> [ Note: A glvalue may have complete or incomplete non-void type. Class and **array** prvalues can have cv-qualified types; other prvalues always have cv-unqualified types. See [expr.prop]. — end note]

Probably the statement is an artifact from [the stone age](https://web.cs.dal.ca/~vlado/pl/cpp.txt), when [basic.lval] contained

> 14If  an expression can be used to modify the object to which it refers,
  the expression is called modifiable.

Well, one can't assign to (==modify) an array using an lvalue of array type (although nobody knows why), so the statement referring to [basic.lval] made sense at that time.

But currently, the statement "Objects of array types cannot be modified" is complete nonsense in this form; see also https://github.com/cplusplus/draft/issues/1988#issuecomment-376455226