### PR TITLE
Order library comparisons canonically

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -2979,15 +2979,15 @@ namespace std {
   template<class T, class Allocator>
     bool operator==(const deque<T, Allocator>& x, const deque<T, Allocator>& y);
   template<class T, class Allocator>
-    bool operator< (const deque<T, Allocator>& x, const deque<T, Allocator>& y);
-  template<class T, class Allocator>
     bool operator!=(const deque<T, Allocator>& x, const deque<T, Allocator>& y);
+  template<class T, class Allocator>
+    bool operator< (const deque<T, Allocator>& x, const deque<T, Allocator>& y);
   template<class T, class Allocator>
     bool operator> (const deque<T, Allocator>& x, const deque<T, Allocator>& y);
   template<class T, class Allocator>
-    bool operator>=(const deque<T, Allocator>& x, const deque<T, Allocator>& y);
-  template<class T, class Allocator>
     bool operator<=(const deque<T, Allocator>& x, const deque<T, Allocator>& y);
+  template<class T, class Allocator>
+    bool operator>=(const deque<T, Allocator>& x, const deque<T, Allocator>& y);
 
   template<class T, class Allocator>
     void swap(deque<T, Allocator>& x, deque<T, Allocator>& y)
@@ -3014,15 +3014,15 @@ namespace std {
   template<class T, class Allocator>
     bool operator==(const forward_list<T, Allocator>& x, const forward_list<T, Allocator>& y);
   template<class T, class Allocator>
-    bool operator< (const forward_list<T, Allocator>& x, const forward_list<T, Allocator>& y);
-  template<class T, class Allocator>
     bool operator!=(const forward_list<T, Allocator>& x, const forward_list<T, Allocator>& y);
+  template<class T, class Allocator>
+    bool operator< (const forward_list<T, Allocator>& x, const forward_list<T, Allocator>& y);
   template<class T, class Allocator>
     bool operator> (const forward_list<T, Allocator>& x, const forward_list<T, Allocator>& y);
   template<class T, class Allocator>
-    bool operator>=(const forward_list<T, Allocator>& x, const forward_list<T, Allocator>& y);
-  template<class T, class Allocator>
     bool operator<=(const forward_list<T, Allocator>& x, const forward_list<T, Allocator>& y);
+  template<class T, class Allocator>
+    bool operator>=(const forward_list<T, Allocator>& x, const forward_list<T, Allocator>& y);
 
   template<class T, class Allocator>
     void swap(forward_list<T, Allocator>& x, forward_list<T, Allocator>& y)
@@ -3049,15 +3049,15 @@ namespace std {
   template<class T, class Allocator>
     bool operator==(const list<T, Allocator>& x, const list<T, Allocator>& y);
   template<class T, class Allocator>
-    bool operator< (const list<T, Allocator>& x, const list<T, Allocator>& y);
-  template<class T, class Allocator>
     bool operator!=(const list<T, Allocator>& x, const list<T, Allocator>& y);
+  template<class T, class Allocator>
+    bool operator< (const list<T, Allocator>& x, const list<T, Allocator>& y);
   template<class T, class Allocator>
     bool operator> (const list<T, Allocator>& x, const list<T, Allocator>& y);
   template<class T, class Allocator>
-    bool operator>=(const list<T, Allocator>& x, const list<T, Allocator>& y);
-  template<class T, class Allocator>
     bool operator<=(const list<T, Allocator>& x, const list<T, Allocator>& y);
+  template<class T, class Allocator>
+    bool operator>=(const list<T, Allocator>& x, const list<T, Allocator>& y);
 
   template<class T, class Allocator>
     void swap(list<T, Allocator>& x, list<T, Allocator>& y)
@@ -3084,15 +3084,15 @@ namespace std {
   template<class T, class Allocator>
     bool operator==(const vector<T, Allocator>& x, const vector<T, Allocator>& y);
   template<class T, class Allocator>
-    bool operator< (const vector<T, Allocator>& x, const vector<T, Allocator>& y);
-  template<class T, class Allocator>
     bool operator!=(const vector<T, Allocator>& x, const vector<T, Allocator>& y);
+  template<class T, class Allocator>
+    bool operator< (const vector<T, Allocator>& x, const vector<T, Allocator>& y);
   template<class T, class Allocator>
     bool operator> (const vector<T, Allocator>& x, const vector<T, Allocator>& y);
   template<class T, class Allocator>
-    bool operator>=(const vector<T, Allocator>& x, const vector<T, Allocator>& y);
-  template<class T, class Allocator>
     bool operator<=(const vector<T, Allocator>& x, const vector<T, Allocator>& y);
+  template<class T, class Allocator>
+    bool operator>=(const vector<T, Allocator>& x, const vector<T, Allocator>& y);
 
   template<class T, class Allocator>
     void swap(vector<T, Allocator>& x, vector<T, Allocator>& y)
@@ -5769,19 +5769,19 @@ namespace std {
     bool operator==(const map<Key, T, Compare, Allocator>& x,
                     const map<Key, T, Compare, Allocator>& y);
   template<class Key, class T, class Compare, class Allocator>
-    bool operator< (const map<Key, T, Compare, Allocator>& x,
+    bool operator!=(const map<Key, T, Compare, Allocator>& x,
                     const map<Key, T, Compare, Allocator>& y);
   template<class Key, class T, class Compare, class Allocator>
-    bool operator!=(const map<Key, T, Compare, Allocator>& x,
+    bool operator< (const map<Key, T, Compare, Allocator>& x,
                     const map<Key, T, Compare, Allocator>& y);
   template<class Key, class T, class Compare, class Allocator>
     bool operator> (const map<Key, T, Compare, Allocator>& x,
                     const map<Key, T, Compare, Allocator>& y);
   template<class Key, class T, class Compare, class Allocator>
-    bool operator>=(const map<Key, T, Compare, Allocator>& x,
+    bool operator<=(const map<Key, T, Compare, Allocator>& x,
                     const map<Key, T, Compare, Allocator>& y);
   template<class Key, class T, class Compare, class Allocator>
-    bool operator<=(const map<Key, T, Compare, Allocator>& x,
+    bool operator>=(const map<Key, T, Compare, Allocator>& x,
                     const map<Key, T, Compare, Allocator>& y);
 
   template<class Key, class T, class Compare, class Allocator>
@@ -5798,19 +5798,19 @@ namespace std {
     bool operator==(const multimap<Key, T, Compare, Allocator>& x,
                     const multimap<Key, T, Compare, Allocator>& y);
   template<class Key, class T, class Compare, class Allocator>
-    bool operator< (const multimap<Key, T, Compare, Allocator>& x,
+    bool operator!=(const multimap<Key, T, Compare, Allocator>& x,
                     const multimap<Key, T, Compare, Allocator>& y);
   template<class Key, class T, class Compare, class Allocator>
-    bool operator!=(const multimap<Key, T, Compare, Allocator>& x,
+    bool operator< (const multimap<Key, T, Compare, Allocator>& x,
                     const multimap<Key, T, Compare, Allocator>& y);
   template<class Key, class T, class Compare, class Allocator>
     bool operator> (const multimap<Key, T, Compare, Allocator>& x,
                     const multimap<Key, T, Compare, Allocator>& y);
   template<class Key, class T, class Compare, class Allocator>
-    bool operator>=(const multimap<Key, T, Compare, Allocator>& x,
+    bool operator<=(const multimap<Key, T, Compare, Allocator>& x,
                     const multimap<Key, T, Compare, Allocator>& y);
   template<class Key, class T, class Compare, class Allocator>
-    bool operator<=(const multimap<Key, T, Compare, Allocator>& x,
+    bool operator>=(const multimap<Key, T, Compare, Allocator>& x,
                     const multimap<Key, T, Compare, Allocator>& y);
 
   template<class Key, class T, class Compare, class Allocator>
@@ -5846,19 +5846,19 @@ namespace std {
     bool operator==(const set<Key, Compare, Allocator>& x,
                     const set<Key, Compare, Allocator>& y);
   template<class Key, class Compare, class Allocator>
-    bool operator< (const set<Key, Compare, Allocator>& x,
+    bool operator!=(const set<Key, Compare, Allocator>& x,
                     const set<Key, Compare, Allocator>& y);
   template<class Key, class Compare, class Allocator>
-    bool operator!=(const set<Key, Compare, Allocator>& x,
+    bool operator< (const set<Key, Compare, Allocator>& x,
                     const set<Key, Compare, Allocator>& y);
   template<class Key, class Compare, class Allocator>
     bool operator> (const set<Key, Compare, Allocator>& x,
                     const set<Key, Compare, Allocator>& y);
   template<class Key, class Compare, class Allocator>
-    bool operator>=(const set<Key, Compare, Allocator>& x,
+    bool operator<=(const set<Key, Compare, Allocator>& x,
                     const set<Key, Compare, Allocator>& y);
   template<class Key, class Compare, class Allocator>
-    bool operator<=(const set<Key, Compare, Allocator>& x,
+    bool operator>=(const set<Key, Compare, Allocator>& x,
                     const set<Key, Compare, Allocator>& y);
 
   template<class Key, class Compare, class Allocator>
@@ -5874,19 +5874,19 @@ namespace std {
     bool operator==(const multiset<Key, Compare, Allocator>& x,
                     const multiset<Key, Compare, Allocator>& y);
   template<class Key, class Compare, class Allocator>
-    bool operator< (const multiset<Key, Compare, Allocator>& x,
+    bool operator!=(const multiset<Key, Compare, Allocator>& x,
                     const multiset<Key, Compare, Allocator>& y);
   template<class Key, class Compare, class Allocator>
-    bool operator!=(const multiset<Key, Compare, Allocator>& x,
+    bool operator< (const multiset<Key, Compare, Allocator>& x,
                     const multiset<Key, Compare, Allocator>& y);
   template<class Key, class Compare, class Allocator>
     bool operator> (const multiset<Key, Compare, Allocator>& x,
                     const multiset<Key, Compare, Allocator>& y);
   template<class Key, class Compare, class Allocator>
-    bool operator>=(const multiset<Key, Compare, Allocator>& x,
+    bool operator<=(const multiset<Key, Compare, Allocator>& x,
                     const multiset<Key, Compare, Allocator>& y);
   template<class Key, class Compare, class Allocator>
-    bool operator<=(const multiset<Key, Compare, Allocator>& x,
+    bool operator>=(const multiset<Key, Compare, Allocator>& x,
                     const multiset<Key, Compare, Allocator>& y);
 
   template<class Key, class Compare, class Allocator>
@@ -8852,15 +8852,15 @@ namespace std {
   template<class T, class Container>
     bool operator==(const queue<T, Container>& x, const queue<T, Container>& y);
   template<class T, class Container>
-    bool operator< (const queue<T, Container>& x, const queue<T, Container>& y);
-  template<class T, class Container>
     bool operator!=(const queue<T, Container>& x, const queue<T, Container>& y);
+  template<class T, class Container>
+    bool operator< (const queue<T, Container>& x, const queue<T, Container>& y);
   template<class T, class Container>
     bool operator> (const queue<T, Container>& x, const queue<T, Container>& y);
   template<class T, class Container>
-    bool operator>=(const queue<T, Container>& x, const queue<T, Container>& y);
-  template<class T, class Container>
     bool operator<=(const queue<T, Container>& x, const queue<T, Container>& y);
+  template<class T, class Container>
+    bool operator>=(const queue<T, Container>& x, const queue<T, Container>& y);
 
   template<class T, class Container>
     void swap(queue<T, Container>& x, queue<T, Container>& y) noexcept(noexcept(x.swap(y)));
@@ -8882,15 +8882,15 @@ namespace std {
   template<class T, class Container>
     bool operator==(const stack<T, Container>& x, const stack<T, Container>& y);
   template<class T, class Container>
-    bool operator< (const stack<T, Container>& x, const stack<T, Container>& y);
-  template<class T, class Container>
     bool operator!=(const stack<T, Container>& x, const stack<T, Container>& y);
+  template<class T, class Container>
+    bool operator< (const stack<T, Container>& x, const stack<T, Container>& y);
   template<class T, class Container>
     bool operator> (const stack<T, Container>& x, const stack<T, Container>& y);
   template<class T, class Container>
-    bool operator>=(const stack<T, Container>& x, const stack<T, Container>& y);
-  template<class T, class Container>
     bool operator<=(const stack<T, Container>& x, const stack<T, Container>& y);
+  template<class T, class Container>
+    bool operator>=(const stack<T, Container>& x, const stack<T, Container>& y);
 
   template<class T, class Container>
     void swap(stack<T, Container>& x, stack<T, Container>& y) noexcept(noexcept(x.swap(y)));
@@ -9084,18 +9084,6 @@ template<class T, class Container>
 \tcode{x.c < y.c}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{queue}}%
-\begin{itemdecl}
-template<class T, class Container>
-  bool operator<=(const queue<T, Container>& x, const queue<T, Container>& y);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-\tcode{x.c <= y.c}.
-\end{itemdescr}
-
 \indexlibrary{\idxcode{operator>}!\idxcode{queue}}%
 \begin{itemdecl}
 template<class T, class Container>
@@ -9106,6 +9094,18 @@ template<class T, class Container>
 \pnum
 \returns
 \tcode{x.c > y.c}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{operator<=}!\idxcode{queue}}%
+\begin{itemdecl}
+template<class T, class Container>
+  bool operator<=(const queue<T, Container>& x, const queue<T, Container>& y);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\tcode{x.c <= y.c}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator>=}!\idxcode{queue}}%
@@ -9631,18 +9631,6 @@ template<class T, class Container>
 \tcode{x.c < y.c}.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{stack}}%
-\begin{itemdecl}
-template<class T, class Container>
-  bool operator<=(const stack<T, Container>& x, const stack<T, Container>& y);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-\tcode{x.c <= y.c}.
-\end{itemdescr}
-
 \indexlibrary{\idxcode{operator>}!\idxcode{stack}}%
 \begin{itemdecl}
 template<class T, class Container>
@@ -9653,6 +9641,18 @@ template<class T, class Container>
 \pnum
 \returns
 \tcode{x.c > y.c}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{operator<=}!\idxcode{stack}}%
+\begin{itemdecl}
+template<class T, class Container>
+  bool operator<=(const stack<T, Container>& x, const stack<T, Container>& y);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\tcode{x.c <= y.c}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator>=}!\idxcode{stack}}%
@@ -9714,9 +9714,9 @@ namespace std {
   template<class T, ptrdiff_t X, class U, ptrdiff_t Y>
     constexpr bool operator<(span<T, X> l, span<U, Y> r);
   template<class T, ptrdiff_t X, class U, ptrdiff_t Y>
-    constexpr bool operator<=(span<T, X> l, span<U, Y> r);
-  template<class T, ptrdiff_t X, class U, ptrdiff_t Y>
     constexpr bool operator>(span<T, X> l, span<U, Y> r);
+  template<class T, ptrdiff_t X, class U, ptrdiff_t Y>
+    constexpr bool operator<=(span<T, X> l, span<U, Y> r);
   template<class T, ptrdiff_t X, class U, ptrdiff_t Y>
     constexpr bool operator>=(span<T, X> l, span<U, Y> r);
 
@@ -10316,17 +10316,6 @@ return lexicographical_compare(l.begin(), l.end(), r.begin(), r.end());
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{operator<=}!\idxcode{span}}%
-\begin{itemdecl}
-template<class T, ptrdiff_t X, class U, ptrdiff_t Y>
-  constexpr bool operator<=(span<T, X> l, span<U, Y> r);
-\end{itemdecl}
-\begin{itemdescr}
-\pnum
-\effects
-Equivalent to: \tcode{return !(r < l);}
-\end{itemdescr}
-
 \indexlibrary{\idxcode{operator>}!\idxcode{span}}%
 \begin{itemdecl}
 template<class T, ptrdiff_t X, class U, ptrdiff_t Y>
@@ -10336,6 +10325,17 @@ template<class T, ptrdiff_t X, class U, ptrdiff_t Y>
 \pnum
 \effects
 Equivalent to: \tcode{return (r < l);}
+\end{itemdescr}
+
+\indexlibrary{\idxcode{operator<=}!\idxcode{span}}%
+\begin{itemdecl}
+template<class T, ptrdiff_t X, class U, ptrdiff_t Y>
+  constexpr bool operator<=(span<T, X> l, span<U, Y> r);
+\end{itemdecl}
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return !(r < l);}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator>=}!\idxcode{span}}%

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -887,8 +887,6 @@ namespace std {
   error_condition make_error_condition(errc e) noexcept;
 
   // \ref{syserr.compare}, comparison functions
-  bool operator<(const error_code& lhs, const error_code& rhs) noexcept;
-  bool operator<(const error_condition& lhs, const error_condition& rhs) noexcept;
   bool operator==(const error_code& lhs, const error_code& rhs) noexcept;
   bool operator==(const error_code& lhs, const error_condition& rhs) noexcept;
   bool operator==(const error_condition& lhs, const error_code& rhs) noexcept;
@@ -897,6 +895,8 @@ namespace std {
   bool operator!=(const error_code& lhs, const error_condition& rhs) noexcept;
   bool operator!=(const error_condition& lhs, const error_code& rhs) noexcept;
   bool operator!=(const error_condition& lhs, const error_condition& rhs) noexcept;
+  bool operator< (const error_code& lhs, const error_code& rhs) noexcept;
+  bool operator< (const error_condition& lhs, const error_condition& rhs) noexcept;
 
   // \ref{syserr.hash}, hash support
   template<class T> struct hash;
@@ -957,7 +957,7 @@ namespace std {
 
     bool operator==(const error_category& rhs) const noexcept;
     bool operator!=(const error_category& rhs) const noexcept;
-    bool operator<(const error_category& rhs) const noexcept;
+    bool operator< (const error_category& rhs) const noexcept;
   };
 
   const error_category& generic_category() noexcept;
@@ -1549,34 +1549,6 @@ error_condition make_error_condition(errc e) noexcept;
 
 \rSec2[syserr.compare]{Comparison functions}
 
-\indexlibrarymember{operator<}{error_code}%
-\begin{itemdecl}
-bool operator<(const error_code& lhs, const error_code& rhs) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-\begin{codeblock}
-lhs.category() < rhs.category() ||
-(lhs.category() == rhs.category() && lhs.value() < rhs.value())
-\end{codeblock}
-\end{itemdescr}
-
-\indexlibrarymember{operator<}{error_condition}%
-\begin{itemdecl}
-bool operator<(const error_condition& lhs, const error_condition& rhs) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-\begin{codeblock}
-lhs.category() < rhs.category() ||
-(lhs.category() == rhs.category() && lhs.value() < rhs.value())
-\end{codeblock}
-\end{itemdescr}
-
 \indexlibrarymember{operator==}{error_code}%
 \begin{itemdecl}
 bool operator==(const error_code& lhs, const error_code& rhs) noexcept;
@@ -1643,6 +1615,34 @@ bool operator!=(const error_condition& lhs, const error_condition& rhs) noexcept
 \begin{itemdescr}
 \pnum
 \returns \tcode{!(lhs == rhs)}.
+\end{itemdescr}
+
+\indexlibrarymember{operator<}{error_code}%
+\begin{itemdecl}
+bool operator<(const error_code& lhs, const error_code& rhs) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\begin{codeblock}
+lhs.category() < rhs.category() ||
+(lhs.category() == rhs.category() && lhs.value() < rhs.value())
+\end{codeblock}
+\end{itemdescr}
+
+\indexlibrarymember{operator<}{error_condition}%
+\begin{itemdecl}
+bool operator<(const error_condition& lhs, const error_condition& rhs) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\begin{codeblock}
+lhs.category() < rhs.category() ||
+(lhs.category() == rhs.category() && lhs.value() < rhs.value())
+\end{codeblock}
 \end{itemdescr}
 
 \rSec2[syserr.hash]{System error hash support}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -12735,6 +12735,43 @@ size_t hash_value (const path& p) noexcept;
   for two paths, \tcode{p1 == p2} then \tcode{hash_value(p1) == hash_value(p2)}.
 \end{itemdescr}
 
+\indexlibrarymember{operator==}{path}%
+\begin{itemdecl}
+bool operator==(const path& lhs, const path& rhs) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns \tcode{!(lhs < rhs) \&\& !(rhs < lhs)}.
+
+\indextext{path equality}
+\pnum
+\begin{note} Path equality and path equivalence have different semantics.
+\begin{itemize}
+\item Equality is determined by the \tcode{path} non-member \tcode{operator==},
+which considers the two paths' lexical representations only.
+\begin{example} \tcode{path("foo") == "bar"} is never \tcode{true}. \end{example}
+\item Equivalence is determined by the \tcode{equivalent()} non-member function, which
+determines if two paths resolve\iref{fs.class.path} to the same file system entity.
+\begin{example}
+\tcode{equivalent("foo", "bar")} will be \tcode{true} when both paths resolve to the same file.
+\end{example}
+\end{itemize}
+Programmers wishing to determine if two paths are ``the same'' must decide if
+  ``the same'' means ``the same representation'' or ``resolve to the same actual
+  file'', and choose the appropriate function accordingly. \end{note}
+\end{itemdescr}
+
+\indexlibrarymember{operator"!=}{path}%
+\begin{itemdecl}
+bool operator!=(const path& lhs, const path& rhs) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns \tcode{!(lhs == rhs)}.
+\end{itemdescr}
+
 \indexlibrarymember{operator<}{path}%
 \begin{itemdecl}
 bool operator< (const path& lhs, const path& rhs) noexcept;
@@ -12773,43 +12810,6 @@ bool operator>=(const path& lhs, const path& rhs) noexcept;
 \begin{itemdescr}
 \pnum
 \returns \tcode{!(lhs < rhs)}.
-\end{itemdescr}
-
-\indexlibrarymember{operator==}{path}%
-\begin{itemdecl}
-bool operator==(const path& lhs, const path& rhs) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{!(lhs < rhs) \&\& !(rhs < lhs)}.
-
-\indextext{path equality}
-\pnum
-\begin{note} Path equality and path equivalence have different semantics.
-\begin{itemize}
-\item Equality is determined by the \tcode{path} non-member \tcode{operator==},
-which considers the two paths' lexical representations only.
-\begin{example} \tcode{path("foo") == "bar"} is never \tcode{true}. \end{example}
-\item Equivalence is determined by the \tcode{equivalent()} non-member function, which
-determines if two paths resolve\iref{fs.class.path} to the same file system entity.
-\begin{example}
-\tcode{equivalent("foo", "bar")} will be \tcode{true} when both paths resolve to the same file.
-\end{example}
-\end{itemize}
-Programmers wishing to determine if two paths are ``the same'' must decide if
-  ``the same'' means ``the same representation'' or ``resolve to the same actual
-  file'', and choose the appropriate function accordingly. \end{note}
-\end{itemdescr}
-
-\indexlibrarymember{operator"!=}{path}%
-\begin{itemdecl}
-bool operator!=(const path& lhs, const path& rhs) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{!(lhs == rhs)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator/}{path}%
@@ -13391,11 +13391,11 @@ namespace std::filesystem {
     file_status symlink_status() const;
     file_status symlink_status(error_code& ec) const noexcept;
 
-    bool operator< (const directory_entry& rhs) const noexcept;
     bool operator==(const directory_entry& rhs) const noexcept;
     bool operator!=(const directory_entry& rhs) const noexcept;
-    bool operator<=(const directory_entry& rhs) const noexcept;
+    bool operator< (const directory_entry& rhs) const noexcept;
     bool operator> (const directory_entry& rhs) const noexcept;
+    bool operator<=(const directory_entry& rhs) const noexcept;
     bool operator>=(const directory_entry& rhs) const noexcept;
 
   private:
@@ -13788,16 +13788,6 @@ bool operator< (const directory_entry& rhs) const noexcept;
 \returns \tcode{pathobject < rhs.pathobject}.
 \end{itemdescr}
 
-\indexlibrarymember{operator<=}{directory_entry}%
-\begin{itemdecl}
-bool operator<=(const directory_entry& rhs) const noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{pathobject <= rhs.pathobject}.
-\end{itemdescr}
-
 \indexlibrarymember{operator>}{directory_entry}%
 \begin{itemdecl}
 bool operator> (const directory_entry& rhs) const noexcept;
@@ -13806,6 +13796,16 @@ bool operator> (const directory_entry& rhs) const noexcept;
 \begin{itemdescr}
 \pnum
 \returns \tcode{pathobject > rhs.pathobject}.
+\end{itemdescr}
+
+\indexlibrarymember{operator<=}{directory_entry}%
+\begin{itemdecl}
+bool operator<=(const directory_entry& rhs) const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns \tcode{pathobject <= rhs.pathobject}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>=}{directory_entry}%
@@ -14939,7 +14939,7 @@ path current_path(error_code& ec);
 
 \pnum
 \begin{note} The current path as returned by many operating systems is a dangerous
-  global variable. It may be changed unexpectedly by a third-party or system
+  global variable. It may be changed unexpectedly by third-party or system
   library functions, or by another thread. \end{note}
 \end{itemdescr}
 

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -738,11 +738,11 @@ namespace std {
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
   template<class Iterator1, class Iterator2>
-    constexpr bool operator<(
+    constexpr bool operator!=(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
   template<class Iterator1, class Iterator2>
-    constexpr bool operator!=(
+    constexpr bool operator<(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
   template<class Iterator1, class Iterator2>
@@ -750,11 +750,11 @@ namespace std {
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
   template<class Iterator1, class Iterator2>
-    constexpr bool operator>=(
+    constexpr bool operator<=(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
   template<class Iterator1, class Iterator2>
-    constexpr bool operator<=(
+    constexpr bool operator>=(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
 
@@ -794,10 +794,10 @@ namespace std {
     constexpr bool operator<(
       const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
   template<class Iterator1, class Iterator2>
-    constexpr bool operator<=(
+    constexpr bool operator>(
       const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
   template<class Iterator1, class Iterator2>
-    constexpr bool operator>(
+    constexpr bool operator<=(
       const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
   template<class Iterator1, class Iterator2>
     constexpr bool operator>=(
@@ -1224,11 +1224,11 @@ namespace std {
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
   template<class Iterator1, class Iterator2>
-    constexpr bool operator<(
+    constexpr bool operator!=(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
   template<class Iterator1, class Iterator2>
-    constexpr bool operator!=(
+    constexpr bool operator<(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
   template<class Iterator1, class Iterator2>
@@ -1236,11 +1236,11 @@ namespace std {
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
   template<class Iterator1, class Iterator2>
-    constexpr bool operator>=(
+    constexpr bool operator<=(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
   template<class Iterator1, class Iterator2>
-    constexpr bool operator<=(
+    constexpr bool operator>=(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
   template<class Iterator1, class Iterator2>
@@ -1529,20 +1529,6 @@ template<class Iterator1, class Iterator2>
 \tcode{x.current == y.current}.
 \end{itemdescr}
 
-\indexlibrarymember{operator<}{reverse_iterator}%
-\begin{itemdecl}
-template<class Iterator1, class Iterator2>
-  constexpr bool operator<(
-    const reverse_iterator<Iterator1>& x,
-    const reverse_iterator<Iterator2>& y);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-\tcode{x.current > y.current}.
-\end{itemdescr}
-
 \indexlibrarymember{operator"!=}{reverse_iterator}%
 \begin{itemdecl}
 template<class Iterator1, class Iterator2>
@@ -1555,6 +1541,20 @@ template<class Iterator1, class Iterator2>
 \pnum
 \returns
 \tcode{x.current != y.current}.
+\end{itemdescr}
+
+\indexlibrarymember{operator<}{reverse_iterator}%
+\begin{itemdecl}
+template<class Iterator1, class Iterator2>
+  constexpr bool operator<(
+    const reverse_iterator<Iterator1>& x,
+    const reverse_iterator<Iterator2>& y);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\tcode{x.current > y.current}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>}{reverse_iterator}%
@@ -1571,20 +1571,6 @@ template<class Iterator1, class Iterator2>
 \tcode{x.current < y.current}.
 \end{itemdescr}
 
-\indexlibrarymember{operator>=}{reverse_iterator}%
-\begin{itemdecl}
-template<class Iterator1, class Iterator2>
-  constexpr bool operator>=(
-    const reverse_iterator<Iterator1>& x,
-    const reverse_iterator<Iterator2>& y);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-\tcode{x.current <= y.current}.
-\end{itemdescr}
-
 \indexlibrarymember{operator<=}{reverse_iterator}%
 \begin{itemdecl}
 template<class Iterator1, class Iterator2>
@@ -1597,6 +1583,20 @@ template<class Iterator1, class Iterator2>
 \pnum
 \returns
 \tcode{x.current >= y.current}.
+\end{itemdescr}
+
+\indexlibrarymember{operator>=}{reverse_iterator}%
+\begin{itemdecl}
+template<class Iterator1, class Iterator2>
+  constexpr bool operator>=(
+    const reverse_iterator<Iterator1>& x,
+    const reverse_iterator<Iterator2>& y);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\tcode{x.current <= y.current}.
 \end{itemdescr}
 
 \rSec3[reverse.iter.nonmember]{Non-member functions}
@@ -2116,10 +2116,10 @@ namespace std {
     constexpr bool operator<(
       const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
   template<class Iterator1, class Iterator2>
-    constexpr bool operator<=(
+    constexpr bool operator>(
       const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
   template<class Iterator1, class Iterator2>
-    constexpr bool operator>(
+    constexpr bool operator<=(
       const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
   template<class Iterator1, class Iterator2>
     constexpr bool operator>=(
@@ -2416,17 +2416,6 @@ constexpr bool operator<(const move_iterator<Iterator1>& x, const move_iterator<
 \returns \tcode{x.base() < y.base()}.
 \end{itemdescr}
 
-\indexlibrarymember{operator<=}{move_iterator}%
-\begin{itemdecl}
-template<class Iterator1, class Iterator2>
-constexpr bool operator<=(const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{!(y < x)}.
-\end{itemdescr}
-
 \indexlibrarymember{operator>}{move_iterator}%
 \begin{itemdecl}
 template<class Iterator1, class Iterator2>
@@ -2436,6 +2425,17 @@ constexpr bool operator>(const move_iterator<Iterator1>& x, const move_iterator<
 \begin{itemdescr}
 \pnum
 \returns \tcode{y < x}.
+\end{itemdescr}
+
+\indexlibrarymember{operator<=}{move_iterator}%
+\begin{itemdecl}
+template<class Iterator1, class Iterator2>
+constexpr bool operator<=(const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns \tcode{!(y < x)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>=}{move_iterator}%

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -845,7 +845,7 @@ of which at most one participates in overload resolution. \end{note}
 
 \pnum
 In this library, whenever a declaration is provided for an \tcode{operator!=},
-\tcode{operator>}, \tcode{operator>=}, or \tcode{operator<=}
+\tcode{operator>}, \tcode{operator<=}, or \tcode{operator>=}
 for a type \tcode{T},
 its requirements and semantics are as follows,
 unless explicitly specified otherwise.

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -7585,8 +7585,8 @@ operator to the corresponding elements of the argument arrays.
 \indexlibrarymember{operator==}{valarray}%
 \indexlibrarymember{operator"!=}{valarray}%
 \indexlibrarymember{operator<}{valarray}%
-\indexlibrarymember{operator<=}{valarray}%
 \indexlibrarymember{operator>}{valarray}%
+\indexlibrarymember{operator<=}{valarray}%
 \indexlibrarymember{operator>=}{valarray}%
 \indexlibrarymember{operator\&\&}{valarray}%
 \indexlibrarymember{operator"|"|}{valarray}%

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -3747,12 +3747,12 @@ there exist candidate operator functions of the form
 @\placeholder{LR}@      operator/(@\placeholder{L}@, @\placeholder{R}@);
 @\placeholder{LR}@      operator+(@\placeholder{L}@, @\placeholder{R}@);
 @\placeholder{LR}@      operator-(@\placeholder{L}@, @\placeholder{R}@);
+bool    operator==(@\placeholder{L}@, @\placeholder{R}@);
+bool    operator!=(@\placeholder{L}@, @\placeholder{R}@);
 bool    operator<(@\placeholder{L}@, @\placeholder{R}@);
 bool    operator>(@\placeholder{L}@, @\placeholder{R}@);
 bool    operator<=(@\placeholder{L}@, @\placeholder{R}@);
 bool    operator>=(@\placeholder{L}@, @\placeholder{R}@);
-bool    operator==(@\placeholder{L}@, @\placeholder{R}@);
-bool    operator!=(@\placeholder{L}@, @\placeholder{R}@);
 \end{codeblock}
 
 where
@@ -3809,12 +3809,12 @@ For every \tcode{\placeholder{T}}, where \tcode{\placeholder{T}} is an enumerati
 there exist candidate operator functions of the form
 
 \begin{codeblock}
+bool    operator==(@\placeholder{T}@, @\placeholder{T}@);
+bool    operator!=(@\placeholder{T}@, @\placeholder{T}@);
 bool    operator<(@\placeholder{T}@, @\placeholder{T}@);
 bool    operator>(@\placeholder{T}@, @\placeholder{T}@);
 bool    operator<=(@\placeholder{T}@, @\placeholder{T}@);
 bool    operator>=(@\placeholder{T}@, @\placeholder{T}@);
-bool    operator==(@\placeholder{T}@, @\placeholder{T}@);
-bool    operator!=(@\placeholder{T}@, @\placeholder{T}@);
 @\placeholdernc{R}@       operator<=>(@\placeholder{T}@, @\placeholder{T}@);
 \end{codeblock}
 

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -302,11 +302,11 @@ namespace std {
   template<class BiIter>
     bool operator<(const sub_match<BiIter>& lhs, const sub_match<BiIter>& rhs);
   template<class BiIter>
+    bool operator>(const sub_match<BiIter>& lhs, const sub_match<BiIter>& rhs);
+  template<class BiIter>
     bool operator<=(const sub_match<BiIter>& lhs, const sub_match<BiIter>& rhs);
   template<class BiIter>
     bool operator>=(const sub_match<BiIter>& lhs, const sub_match<BiIter>& rhs);
-  template<class BiIter>
-    bool operator>(const sub_match<BiIter>& lhs, const sub_match<BiIter>& rhs);
 
   template<class BiIter, class ST, class SA>
     bool operator==(
@@ -325,11 +325,11 @@ namespace std {
       const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& lhs,
       const sub_match<BiIter>& rhs);
   template<class BiIter, class ST, class SA>
-    bool operator>=(
+    bool operator<=(
       const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& lhs,
       const sub_match<BiIter>& rhs);
   template<class BiIter, class ST, class SA>
-    bool operator<=(
+    bool operator>=(
       const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& lhs,
       const sub_match<BiIter>& rhs);
 
@@ -350,11 +350,11 @@ namespace std {
       const sub_match<BiIter>& lhs,
       const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& rhs);
   template<class BiIter, class ST, class SA>
-    bool operator>=(
+    bool operator<=(
       const sub_match<BiIter>& lhs,
       const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& rhs);
   template<class BiIter, class ST, class SA>
-    bool operator<=(
+    bool operator>=(
       const sub_match<BiIter>& lhs,
       const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& rhs);
 
@@ -371,10 +371,10 @@ namespace std {
     bool operator>(const typename iterator_traits<BiIter>::value_type* lhs,
                    const sub_match<BiIter>& rhs);
   template<class BiIter>
-    bool operator>=(const typename iterator_traits<BiIter>::value_type* lhs,
+    bool operator<=(const typename iterator_traits<BiIter>::value_type* lhs,
                     const sub_match<BiIter>& rhs);
   template<class BiIter>
-    bool operator<=(const typename iterator_traits<BiIter>::value_type* lhs,
+    bool operator>=(const typename iterator_traits<BiIter>::value_type* lhs,
                     const sub_match<BiIter>& rhs);
 
   template<class BiIter>
@@ -390,10 +390,10 @@ namespace std {
     bool operator>(const sub_match<BiIter>& lhs,
                    const typename iterator_traits<BiIter>::value_type* rhs);
   template<class BiIter>
-    bool operator>=(const sub_match<BiIter>& lhs,
+    bool operator<=(const sub_match<BiIter>& lhs,
                     const typename iterator_traits<BiIter>::value_type* rhs);
   template<class BiIter>
-    bool operator<=(const sub_match<BiIter>& lhs,
+    bool operator>=(const sub_match<BiIter>& lhs,
                     const typename iterator_traits<BiIter>::value_type* rhs);
 
   template<class BiIter>
@@ -409,10 +409,10 @@ namespace std {
     bool operator>(const typename iterator_traits<BiIter>::value_type& lhs,
                    const sub_match<BiIter>& rhs);
   template<class BiIter>
-    bool operator>=(const typename iterator_traits<BiIter>::value_type& lhs,
+    bool operator<=(const typename iterator_traits<BiIter>::value_type& lhs,
                     const sub_match<BiIter>& rhs);
   template<class BiIter>
-    bool operator<=(const typename iterator_traits<BiIter>::value_type& lhs,
+    bool operator>=(const typename iterator_traits<BiIter>::value_type& lhs,
                     const sub_match<BiIter>& rhs);
 
   template<class BiIter>
@@ -428,10 +428,10 @@ namespace std {
     bool operator>(const sub_match<BiIter>& lhs,
                    const typename iterator_traits<BiIter>::value_type& rhs);
   template<class BiIter>
-    bool operator>=(const sub_match<BiIter>& lhs,
+    bool operator<=(const sub_match<BiIter>& lhs,
                     const typename iterator_traits<BiIter>::value_type& rhs);
   template<class BiIter>
-    bool operator<=(const sub_match<BiIter>& lhs,
+    bool operator>=(const sub_match<BiIter>& lhs,
                     const typename iterator_traits<BiIter>::value_type& rhs);
 
   template<class charT, class ST, class BiIter>
@@ -1933,6 +1933,16 @@ template<class BiIter>
 \pnum\returns \tcode{lhs.compare(rhs) < 0}.
 \end{itemdescr}
 
+\indexlibrarymember{sub_match}{operator>}%
+\begin{itemdecl}
+template<class BiIter>
+  bool operator>(const sub_match<BiIter>& lhs, const sub_match<BiIter>& rhs);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum\returns \tcode{lhs.compare(rhs) > 0}.
+\end{itemdescr}
+
 \indexlibrarymember{sub_match}{operator<=}%
 \begin{itemdecl}
 template<class BiIter>
@@ -1951,16 +1961,6 @@ template<class BiIter>
 
 \begin{itemdescr}
 \pnum\returns \tcode{lhs.compare(rhs) >= 0}.
-\end{itemdescr}
-
-\indexlibrarymember{sub_match}{operator>}%
-\begin{itemdecl}
-template<class BiIter>
-  bool operator>(const sub_match<BiIter>& lhs, const sub_match<BiIter>& rhs);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum\returns \tcode{lhs.compare(rhs) > 0}.
 \end{itemdescr}
 
 \indexlibrarymember{sub_match}{operator==}%
@@ -2019,18 +2019,6 @@ template<class BiIter, class ST, class SA>
 \pnum\returns \tcode{rhs < lhs}.
 \end{itemdescr}
 
-\indexlibrarymember{sub_match}{operator>=}%
-\begin{itemdecl}
-template<class BiIter, class ST, class SA>
-  bool operator>=(
-      const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& lhs,
-      const sub_match<BiIter>& rhs);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum\returns \tcode{!(lhs < rhs)}.
-\end{itemdescr}
-
 \indexlibrarymember{sub_match}{operator<=}%
 \begin{itemdecl}
 template<class BiIter, class ST, class SA>
@@ -2041,6 +2029,18 @@ template<class BiIter, class ST, class SA>
 
 \begin{itemdescr}
 \pnum\returns \tcode{!(rhs < lhs)}.
+\end{itemdescr}
+
+\indexlibrarymember{sub_match}{operator>=}%
+\begin{itemdecl}
+template<class BiIter, class ST, class SA>
+  bool operator>=(
+      const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& lhs,
+      const sub_match<BiIter>& rhs);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum\returns \tcode{!(lhs < rhs)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator==}{sub_match}%
@@ -2101,18 +2101,6 @@ template<class BiIter, class ST, class SA>
 \pnum\returns \tcode{rhs < lhs}.
 \end{itemdescr}
 
-\indexlibrarymember{operator>=}{sub_match}%
-\begin{itemdecl}
-template<class BiIter, class ST, class SA>
-  bool operator>=(
-      const sub_match<BiIter>& lhs,
-      const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& rhs);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum\returns \tcode{!(lhs < rhs)}.
-\end{itemdescr}
-
 \indexlibrarymember{operator<=}{sub_match}%
 \begin{itemdecl}
 template<class BiIter, class ST, class SA>
@@ -2123,6 +2111,18 @@ template<class BiIter, class ST, class SA>
 
 \begin{itemdescr}
 \pnum\returns \tcode{!(rhs < lhs)}.
+\end{itemdescr}
+
+\indexlibrarymember{operator>=}{sub_match}%
+\begin{itemdecl}
+template<class BiIter, class ST, class SA>
+  bool operator>=(
+      const sub_match<BiIter>& lhs,
+      const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& rhs);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum\returns \tcode{!(lhs < rhs)}.
 \end{itemdescr}
 
 \indexlibrarymember{sub_match}{operator==}%
@@ -2169,17 +2169,6 @@ template<class BiIter>
 \pnum\returns \tcode{rhs < lhs}.
 \end{itemdescr}
 
-\indexlibrarymember{sub_match}{operator>=}%
-\begin{itemdecl}
-template<class BiIter>
-  bool operator>=(const typename iterator_traits<BiIter>::value_type* lhs,
-                  const sub_match<BiIter>& rhs);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum\returns \tcode{!(lhs < rhs)}.
-\end{itemdescr}
-
 \indexlibrarymember{sub_match}{operator<=}%
 \begin{itemdecl}
 template<class BiIter>
@@ -2189,6 +2178,17 @@ template<class BiIter>
 
 \begin{itemdescr}
 \pnum\returns \tcode{!(rhs < lhs)}.
+\end{itemdescr}
+
+\indexlibrarymember{sub_match}{operator>=}%
+\begin{itemdecl}
+template<class BiIter>
+  bool operator>=(const typename iterator_traits<BiIter>::value_type* lhs,
+                  const sub_match<BiIter>& rhs);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum\returns \tcode{!(lhs < rhs)}.
 \end{itemdescr}
 
 \indexlibrarymember{sub_match}{operator==}%
@@ -2235,17 +2235,6 @@ template<class BiIter>
 \pnum\returns \tcode{rhs < lhs}.
 \end{itemdescr}
 
-\indexlibrarymember{sub_match}{operator>=}%
-\begin{itemdecl}
-template<class BiIter>
-  bool operator>=(const sub_match<BiIter>& lhs,
-                  const typename iterator_traits<BiIter>::value_type* rhs);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum\returns \tcode{!(lhs < rhs)}.
-\end{itemdescr}
-
 \indexlibrarymember{sub_match}{operator<=}%
 \begin{itemdecl}
 template<class BiIter>
@@ -2256,6 +2245,17 @@ template<class BiIter>
 \begin{itemdescr}
 \pnum
 \returns \tcode{!(rhs < lhs)}.
+\end{itemdescr}
+
+\indexlibrarymember{sub_match}{operator>=}%
+\begin{itemdecl}
+template<class BiIter>
+  bool operator>=(const sub_match<BiIter>& lhs,
+                  const typename iterator_traits<BiIter>::value_type* rhs);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum\returns \tcode{!(lhs < rhs)}.
 \end{itemdescr}
 
 \indexlibrarymember{sub_match}{operator==}%
@@ -2306,18 +2306,6 @@ template<class BiIter>
 \returns \tcode{rhs < lhs}.
 \end{itemdescr}
 
-\indexlibrarymember{sub_match}{operator>=}%
-\begin{itemdecl}
-template<class BiIter>
-  bool operator>=(const typename iterator_traits<BiIter>::value_type& lhs,
-                  const sub_match<BiIter>& rhs);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{!(lhs < rhs)}.
-\end{itemdescr}
-
 \indexlibrarymember{sub_match}{operator<=}%
 \begin{itemdecl}
 template<class BiIter>
@@ -2328,6 +2316,18 @@ template<class BiIter>
 \begin{itemdescr}
 \pnum
 \returns \tcode{!(rhs < lhs)}.
+\end{itemdescr}
+
+\indexlibrarymember{sub_match}{operator>=}%
+\begin{itemdecl}
+template<class BiIter>
+  bool operator>=(const typename iterator_traits<BiIter>::value_type& lhs,
+                  const sub_match<BiIter>& rhs);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns \tcode{!(lhs < rhs)}.
 \end{itemdescr}
 
 \indexlibrarymember{sub_match}{operator==}%
@@ -2378,18 +2378,6 @@ template<class BiIter>
 \returns \tcode{rhs < lhs}.
 \end{itemdescr}
 
-\indexlibrarymember{sub_match}{operator>=}%
-\begin{itemdecl}
-template<class BiIter>
-  bool operator>=(const sub_match<BiIter>& lhs,
-                  const typename iterator_traits<BiIter>::value_type& rhs);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{!(lhs < rhs)}.
-\end{itemdescr}
-
 \indexlibrarymember{sub_match}{operator<=}%
 \begin{itemdecl}
 template<class BiIter>
@@ -2400,6 +2388,18 @@ template<class BiIter>
 \begin{itemdescr}
 \pnum
 \returns \tcode{!(rhs < lhs)}.
+\end{itemdescr}
+
+\indexlibrarymember{sub_match}{operator>=}%
+\begin{itemdecl}
+template<class BiIter>
+  bool operator>=(const sub_match<BiIter>& lhs,
+                  const typename iterator_traits<BiIter>::value_type& rhs);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns \tcode{!(lhs < rhs)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_ostream}}%

--- a/source/support.tex
+++ b/source/support.tex
@@ -4022,14 +4022,14 @@ namespace std {
     friend constexpr bool operator==(partial_ordering v, @\unspec@) noexcept;
     friend constexpr bool operator!=(partial_ordering v, @\unspec@) noexcept;
     friend constexpr bool operator< (partial_ordering v, @\unspec@) noexcept;
-    friend constexpr bool operator<=(partial_ordering v, @\unspec@) noexcept;
     friend constexpr bool operator> (partial_ordering v, @\unspec@) noexcept;
+    friend constexpr bool operator<=(partial_ordering v, @\unspec@) noexcept;
     friend constexpr bool operator>=(partial_ordering v, @\unspec@) noexcept;
     friend constexpr bool operator==(@\unspec@, partial_ordering v) noexcept;
     friend constexpr bool operator!=(@\unspec@, partial_ordering v) noexcept;
     friend constexpr bool operator< (@\unspec@, partial_ordering v) noexcept;
-    friend constexpr bool operator<=(@\unspec@, partial_ordering v) noexcept;
     friend constexpr bool operator> (@\unspec@, partial_ordering v) noexcept;
+    friend constexpr bool operator<=(@\unspec@, partial_ordering v) noexcept;
     friend constexpr bool operator>=(@\unspec@, partial_ordering v) noexcept;
     friend constexpr partial_ordering operator<=>(partial_ordering v, @\unspec@) noexcept;
     friend constexpr partial_ordering operator<=>(@\unspec@, partial_ordering v) noexcept;
@@ -4059,14 +4059,14 @@ The result is independent of the \tcode{is_ordered} member.
 
 \indexlibrarymember{operator==}{partial_ordering}%
 \indexlibrarymember{operator<}{partial_ordering}%
-\indexlibrarymember{operator<=}{partial_ordering}%
 \indexlibrarymember{operator>}{partial_ordering}%
+\indexlibrarymember{operator<=}{partial_ordering}%
 \indexlibrarymember{operator>=}{partial_ordering}%
 \begin{itemdecl}
 constexpr bool operator==(partial_ordering v, @\unspec@) noexcept;
 constexpr bool operator< (partial_ordering v, @\unspec@) noexcept;
-constexpr bool operator<=(partial_ordering v, @\unspec@) noexcept;
 constexpr bool operator> (partial_ordering v, @\unspec@) noexcept;
+constexpr bool operator<=(partial_ordering v, @\unspec@) noexcept;
 constexpr bool operator>=(partial_ordering v, @\unspec@) noexcept;
 \end{itemdecl}
 
@@ -4078,14 +4078,14 @@ For \tcode{operator@}, \tcode{v.is_ordered \&\& v.value @ 0}.
 
 \indexlibrarymember{operator==}{partial_ordering}%
 \indexlibrarymember{operator<}{partial_ordering}%
-\indexlibrarymember{operator<=}{partial_ordering}%
 \indexlibrarymember{operator>}{partial_ordering}%
+\indexlibrarymember{operator<=}{partial_ordering}%
 \indexlibrarymember{operator>=}{partial_ordering}%
 \begin{itemdecl}
 constexpr bool operator==(@\unspec@, partial_ordering v) noexcept;
 constexpr bool operator< (@\unspec@, partial_ordering v) noexcept;
-constexpr bool operator<=(@\unspec@, partial_ordering v) noexcept;
 constexpr bool operator> (@\unspec@, partial_ordering v) noexcept;
+constexpr bool operator<=(@\unspec@, partial_ordering v) noexcept;
 constexpr bool operator>=(@\unspec@, partial_ordering v) noexcept;
 \end{itemdecl}
 
@@ -4164,14 +4164,14 @@ namespace std {
     friend constexpr bool operator==(weak_ordering v, @\unspec@) noexcept;
     friend constexpr bool operator!=(weak_ordering v, @\unspec@) noexcept;
     friend constexpr bool operator< (weak_ordering v, @\unspec@) noexcept;
-    friend constexpr bool operator<=(weak_ordering v, @\unspec@) noexcept;
     friend constexpr bool operator> (weak_ordering v, @\unspec@) noexcept;
+    friend constexpr bool operator<=(weak_ordering v, @\unspec@) noexcept;
     friend constexpr bool operator>=(weak_ordering v, @\unspec@) noexcept;
     friend constexpr bool operator==(@\unspec@, weak_ordering v) noexcept;
     friend constexpr bool operator!=(@\unspec@, weak_ordering v) noexcept;
     friend constexpr bool operator< (@\unspec@, weak_ordering v) noexcept;
-    friend constexpr bool operator<=(@\unspec@, weak_ordering v) noexcept;
     friend constexpr bool operator> (@\unspec@, weak_ordering v) noexcept;
+    friend constexpr bool operator<=(@\unspec@, weak_ordering v) noexcept;
     friend constexpr bool operator>=(@\unspec@, weak_ordering v) noexcept;
     friend constexpr weak_ordering operator<=>(weak_ordering v, @\unspec@) noexcept;
     friend constexpr weak_ordering operator<=>(@\unspec@, weak_ordering v) noexcept;
@@ -4213,15 +4213,15 @@ value < 0  ? partial_ordering::less :
 \indexlibrarymember{operator==}{weak_ordering}%
 \indexlibrarymember{operator"!=}{weak_ordering}%
 \indexlibrarymember{operator<}{weak_ordering}%
-\indexlibrarymember{operator<=}{weak_ordering}%
 \indexlibrarymember{operator>}{weak_ordering}%
+\indexlibrarymember{operator<=}{weak_ordering}%
 \indexlibrarymember{operator>=}{weak_ordering}%
 \begin{itemdecl}
 constexpr bool operator==(weak_ordering v, @\unspec@) noexcept;
 constexpr bool operator!=(weak_ordering v, @\unspec@) noexcept;
 constexpr bool operator< (weak_ordering v, @\unspec@) noexcept;
-constexpr bool operator<=(weak_ordering v, @\unspec@) noexcept;
 constexpr bool operator> (weak_ordering v, @\unspec@) noexcept;
+constexpr bool operator<=(weak_ordering v, @\unspec@) noexcept;
 constexpr bool operator>=(weak_ordering v, @\unspec@) noexcept;
 \end{itemdecl}
 
@@ -4234,15 +4234,15 @@ constexpr bool operator>=(weak_ordering v, @\unspec@) noexcept;
 \indexlibrarymember{operator==}{weak_ordering}%
 \indexlibrarymember{operator"!=}{weak_ordering}%
 \indexlibrarymember{operator<}{weak_ordering}%
-\indexlibrarymember{operator<=}{weak_ordering}%
 \indexlibrarymember{operator>}{weak_ordering}%
+\indexlibrarymember{operator<=}{weak_ordering}%
 \indexlibrarymember{operator>=}{weak_ordering}%
 \begin{itemdecl}
 constexpr bool operator==(@\unspec@, weak_ordering v) noexcept;
 constexpr bool operator!=(@\unspec@, weak_ordering v) noexcept;
 constexpr bool operator< (@\unspec@, weak_ordering v) noexcept;
-constexpr bool operator<=(@\unspec@, weak_ordering v) noexcept;
 constexpr bool operator> (@\unspec@, weak_ordering v) noexcept;
+constexpr bool operator<=(@\unspec@, weak_ordering v) noexcept;
 constexpr bool operator>=(@\unspec@, weak_ordering v) noexcept;
 \end{itemdecl}
 
@@ -4313,14 +4313,14 @@ namespace std {
     friend constexpr bool operator==(strong_ordering v, @\unspec@) noexcept;
     friend constexpr bool operator!=(strong_ordering v, @\unspec@) noexcept;
     friend constexpr bool operator< (strong_ordering v, @\unspec@) noexcept;
-    friend constexpr bool operator<=(strong_ordering v, @\unspec@) noexcept;
     friend constexpr bool operator> (strong_ordering v, @\unspec@) noexcept;
+    friend constexpr bool operator<=(strong_ordering v, @\unspec@) noexcept;
     friend constexpr bool operator>=(strong_ordering v, @\unspec@) noexcept;
     friend constexpr bool operator==(@\unspec@, strong_ordering v) noexcept;
     friend constexpr bool operator!=(@\unspec@, strong_ordering v) noexcept;
     friend constexpr bool operator< (@\unspec@, strong_ordering v) noexcept;
-    friend constexpr bool operator<=(@\unspec@, strong_ordering v) noexcept;
     friend constexpr bool operator> (@\unspec@, strong_ordering v) noexcept;
+    friend constexpr bool operator<=(@\unspec@, strong_ordering v) noexcept;
     friend constexpr bool operator>=(@\unspec@, strong_ordering v) noexcept;
     friend constexpr strong_ordering operator<=>(strong_ordering v, @\unspec@) noexcept;
     friend constexpr strong_ordering operator<=>(@\unspec@, strong_ordering v) noexcept;
@@ -4389,15 +4389,15 @@ value < 0  ? weak_ordering::less :
 \indexlibrarymember{operator==}{strong_ordering}%
 \indexlibrarymember{operator"!=}{strong_ordering}%
 \indexlibrarymember{operator<}{strong_ordering}%
-\indexlibrarymember{operator<=}{strong_ordering}%
 \indexlibrarymember{operator>}{strong_ordering}%
+\indexlibrarymember{operator<=}{strong_ordering}%
 \indexlibrarymember{operator>=}{strong_ordering}%
 \begin{itemdecl}
 constexpr bool operator==(strong_ordering v, @\unspec@) noexcept;
 constexpr bool operator!=(strong_ordering v, @\unspec@) noexcept;
 constexpr bool operator< (strong_ordering v, @\unspec@) noexcept;
-constexpr bool operator<=(strong_ordering v, @\unspec@) noexcept;
 constexpr bool operator> (strong_ordering v, @\unspec@) noexcept;
+constexpr bool operator<=(strong_ordering v, @\unspec@) noexcept;
 constexpr bool operator>=(strong_ordering v, @\unspec@) noexcept;
 \end{itemdecl}
 
@@ -4410,15 +4410,15 @@ constexpr bool operator>=(strong_ordering v, @\unspec@) noexcept;
 \indexlibrarymember{operator==}{strong_ordering}%
 \indexlibrarymember{operator"!=}{strong_ordering}%
 \indexlibrarymember{operator<}{strong_ordering}%
-\indexlibrarymember{operator<=}{strong_ordering}%
 \indexlibrarymember{operator>}{strong_ordering}%
+\indexlibrarymember{operator<=}{strong_ordering}%
 \indexlibrarymember{operator>=}{strong_ordering}%
 \begin{itemdecl}
 constexpr bool operator==(@\unspec@, strong_ordering v) noexcept;
 constexpr bool operator!=(@\unspec@, strong_ordering v) noexcept;
 constexpr bool operator< (@\unspec@, strong_ordering v) noexcept;
-constexpr bool operator<=(@\unspec@, strong_ordering v) noexcept;
 constexpr bool operator> (@\unspec@, strong_ordering v) noexcept;
+constexpr bool operator<=(@\unspec@, strong_ordering v) noexcept;
 constexpr bool operator>=(@\unspec@, strong_ordering v) noexcept;
 \end{itemdecl}
 

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -375,8 +375,8 @@ namespace std {
   bool operator==(thread::id x, thread::id y) noexcept;
   bool operator!=(thread::id x, thread::id y) noexcept;
   bool operator<(thread::id x, thread::id y) noexcept;
-  bool operator<=(thread::id x, thread::id y) noexcept;
   bool operator>(thread::id x, thread::id y) noexcept;
+  bool operator<=(thread::id x, thread::id y) noexcept;
   bool operator>=(thread::id x, thread::id y) noexcept;
 
   template<class charT, class traits>
@@ -447,6 +447,15 @@ bool operator<(thread::id x, thread::id y) noexcept;
 \returns A value such that \tcode{operator<} is a total ordering as described in~\ref{alg.sorting}.
 \end{itemdescr}
 
+\indexlibrarymember{operator>}{thread::id}%
+\begin{itemdecl}
+bool operator>(thread::id x, thread::id y) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum\returns \tcode{y < x}.
+\end{itemdescr}
+
 \indexlibrarymember{operator<=}{thread::id}%
 \begin{itemdecl}
 bool operator<=(thread::id x, thread::id y) noexcept;
@@ -455,15 +464,6 @@ bool operator<=(thread::id x, thread::id y) noexcept;
 \begin{itemdescr}
 \pnum
 \returns \tcode{!(y < x)}.
-\end{itemdescr}
-
-\indexlibrarymember{operator>}{thread::id}%
-\begin{itemdecl}
-bool operator>(thread::id x, thread::id y) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum\returns \tcode{y < x}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>=}{thread::id}%

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -105,15 +105,15 @@ namespace std {
   template<class T1, class T2>
     constexpr bool operator==(const pair<T1, T2>&, const pair<T1, T2>&);
   template<class T1, class T2>
-    constexpr bool operator< (const pair<T1, T2>&, const pair<T1, T2>&);
-  template<class T1, class T2>
     constexpr bool operator!=(const pair<T1, T2>&, const pair<T1, T2>&);
+  template<class T1, class T2>
+    constexpr bool operator< (const pair<T1, T2>&, const pair<T1, T2>&);
   template<class T1, class T2>
     constexpr bool operator> (const pair<T1, T2>&, const pair<T1, T2>&);
   template<class T1, class T2>
-    constexpr bool operator>=(const pair<T1, T2>&, const pair<T1, T2>&);
-  template<class T1, class T2>
     constexpr bool operator<=(const pair<T1, T2>&, const pair<T1, T2>&);
+  template<class T1, class T2>
+    constexpr bool operator>=(const pair<T1, T2>&, const pair<T1, T2>&);
 
   template<class T1, class T2>
     void swap(pair<T1, T2>& x, pair<T1, T2>& y) noexcept(noexcept(x.swap(y)));
@@ -768,6 +768,17 @@ template<class T1, class T2>
 \tcode{x.first == y.first \&\& x.second == y.second}.
 \end{itemdescr}
 
+\indexlibrarymember{operator"!=}{pair}%
+\begin{itemdecl}
+template<class T1, class T2>
+  constexpr bool operator!=(const pair<T1, T2>& x, const pair<T1, T2>& y);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns \tcode{!(x == y)}.
+\end{itemdescr}
+
 \indexlibrarymember{operator<}{pair}%
 \begin{itemdecl}
 template<class T1, class T2>
@@ -778,17 +789,6 @@ template<class T1, class T2>
 \pnum
 \returns
 \tcode{x.first < y.first || (!(y.first < x.first) \&\& x.second < y.second)}.
-\end{itemdescr}
-
-\indexlibrarymember{operator"!=}{pair}%
-\begin{itemdecl}
-template<class T1, class T2>
-  constexpr bool operator!=(const pair<T1, T2>& x, const pair<T1, T2>& y);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{!(x == y)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>}{pair}%
@@ -802,17 +802,6 @@ template<class T1, class T2>
 \returns \tcode{y < x}.
 \end{itemdescr}
 
-\indexlibrarymember{operator>=}{pair}%
-\begin{itemdecl}
-template<class T1, class T2>
-  constexpr bool operator>=(const pair<T1, T2>& x, const pair<T1, T2>& y);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{!(x < y)}.
-\end{itemdescr}
-
 \indexlibrarymember{operator<=}{pair}%
 \begin{itemdecl}
 template<class T1, class T2>
@@ -822,6 +811,17 @@ template<class T1, class T2>
 \begin{itemdescr}
 \pnum
 \returns \tcode{!(y < x)}.
+\end{itemdescr}
+
+\indexlibrarymember{operator>=}{pair}%
+\begin{itemdecl}
+template<class T1, class T2>
+  constexpr bool operator>=(const pair<T1, T2>& x, const pair<T1, T2>& y);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns \tcode{!(x < y)}.
 \end{itemdescr}
 
 
@@ -1051,9 +1051,9 @@ namespace std {
   template<class... TTypes, class... UTypes>
     constexpr bool operator==(const tuple<TTypes...>&, const tuple<UTypes...>&);
   template<class... TTypes, class... UTypes>
-    constexpr bool operator<(const tuple<TTypes...>&, const tuple<UTypes...>&);
-  template<class... TTypes, class... UTypes>
     constexpr bool operator!=(const tuple<TTypes...>&, const tuple<UTypes...>&);
+  template<class... TTypes, class... UTypes>
+    constexpr bool operator<(const tuple<TTypes...>&, const tuple<UTypes...>&);
   template<class... TTypes, class... UTypes>
     constexpr bool operator>(const tuple<TTypes...>&, const tuple<UTypes...>&);
   template<class... TTypes, class... UTypes>
@@ -1976,6 +1976,15 @@ performed after the first equality comparison that evaluates to
 \tcode{false}.
 \end{itemdescr}
 
+\indexlibrarymember{operator"!=}{tuple}%
+\begin{itemdecl}
+template<class... TTypes, class... UTypes>
+  constexpr bool operator!=(const tuple<TTypes...>& t, const tuple<UTypes...>& u);
+\end{itemdecl}
+\begin{itemdescr}
+\pnum\returns \tcode{!(t == u)}.
+\end{itemdescr}
+
 \indexlibrarymember{operator<}{tuple}%
 \begin{itemdecl}
 template<class... TTypes, class... UTypes>
@@ -2001,15 +2010,6 @@ u$_{\mathrm{tail}}$)}, where \tcode{r$_{\mathrm{tail}}$} for some
 tuple \tcode{r} is a tuple containing all but the first element
 of \tcode{r}.  For any two zero-length tuples \tcode{e}
 and \tcode{f}, \tcode{e < f} returns \tcode{false}.
-\end{itemdescr}
-
-\indexlibrarymember{operator"!=}{tuple}%
-\begin{itemdecl}
-template<class... TTypes, class... UTypes>
-  constexpr bool operator!=(const tuple<TTypes...>& t, const tuple<UTypes...>& u);
-\end{itemdecl}
-\begin{itemdescr}
-\pnum\returns \tcode{!(t == u)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>}{tuple}%
@@ -2141,10 +2141,10 @@ namespace std {
   template<class T> constexpr bool operator!=(nullopt_t, const optional<T>&) noexcept;
   template<class T> constexpr bool operator<(const optional<T>&, nullopt_t) noexcept;
   template<class T> constexpr bool operator<(nullopt_t, const optional<T>&) noexcept;
-  template<class T> constexpr bool operator<=(const optional<T>&, nullopt_t) noexcept;
-  template<class T> constexpr bool operator<=(nullopt_t, const optional<T>&) noexcept;
   template<class T> constexpr bool operator>(const optional<T>&, nullopt_t) noexcept;
   template<class T> constexpr bool operator>(nullopt_t, const optional<T>&) noexcept;
+  template<class T> constexpr bool operator<=(const optional<T>&, nullopt_t) noexcept;
+  template<class T> constexpr bool operator<=(nullopt_t, const optional<T>&) noexcept;
   template<class T> constexpr bool operator>=(const optional<T>&, nullopt_t) noexcept;
   template<class T> constexpr bool operator>=(nullopt_t, const optional<T>&) noexcept;
 
@@ -2155,10 +2155,10 @@ namespace std {
   template<class T, class U> constexpr bool operator!=(const T&, const optional<U>&);
   template<class T, class U> constexpr bool operator<(const optional<T>&, const U&);
   template<class T, class U> constexpr bool operator<(const T&, const optional<U>&);
-  template<class T, class U> constexpr bool operator<=(const optional<T>&, const U&);
-  template<class T, class U> constexpr bool operator<=(const T&, const optional<U>&);
   template<class T, class U> constexpr bool operator>(const optional<T>&, const U&);
   template<class T, class U> constexpr bool operator>(const T&, const optional<U>&);
+  template<class T, class U> constexpr bool operator<=(const optional<T>&, const U&);
+  template<class T, class U> constexpr bool operator<=(const T&, const optional<U>&);
   template<class T, class U> constexpr bool operator>=(const optional<T>&, const U&);
   template<class T, class U> constexpr bool operator>=(const T&, const optional<U>&);
 
@@ -3329,28 +3329,6 @@ template<class T> constexpr bool operator<(nullopt_t, const optional<T>& x) noex
 \tcode{bool(x)}.
 \end{itemdescr}
 
-\indexlibrarymember{operator<=}{optional}%
-\begin{itemdecl}
-template<class T> constexpr bool operator<=(const optional<T>& x, nullopt_t) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-\tcode{!x}.
-\end{itemdescr}
-
-\indexlibrarymember{operator<=}{optional}%
-\begin{itemdecl}
-template<class T> constexpr bool operator<=(nullopt_t, const optional<T>& x) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-\tcode{true}.
-\end{itemdescr}
-
 \indexlibrarymember{operator>}{optional}%
 \begin{itemdecl}
 template<class T> constexpr bool operator>(const optional<T>& x, nullopt_t) noexcept;
@@ -3371,6 +3349,28 @@ template<class T> constexpr bool operator>(nullopt_t, const optional<T>& x) noex
 \pnum
 \returns
 \tcode{false}.
+\end{itemdescr}
+
+\indexlibrarymember{operator<=}{optional}%
+\begin{itemdecl}
+template<class T> constexpr bool operator<=(const optional<T>& x, nullopt_t) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\tcode{!x}.
+\end{itemdescr}
+
+\indexlibrarymember{operator<=}{optional}%
+\begin{itemdecl}
+template<class T> constexpr bool operator<=(nullopt_t, const optional<T>& x) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\tcode{true}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>=}{optional}%
@@ -3496,38 +3496,6 @@ its result shall be convertible to \tcode{bool}.
 Equivalent to: \tcode{return bool(x) ?\ v < *x :\ false;}
 \end{itemdescr}
 
-\indexlibrarymember{operator<=}{optional}%
-\begin{itemdecl}
-template<class T, class U> constexpr bool operator<=(const optional<T>& x, const U& v);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\requires
-The expression \tcode{*x <= v} shall be well-formed and
-its result shall be convertible to \tcode{bool}.
-
-\pnum
-\effects
-Equivalent to: \tcode{return bool(x) ?\ *x <= v :\ true;}
-\end{itemdescr}
-
-\indexlibrarymember{operator<=}{optional}%
-\begin{itemdecl}
-template<class T, class U> constexpr bool operator<=(const T& v, const optional<U>& x);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\requires
-The expression \tcode{v <= *x} shall be well-formed and
-its result shall be convertible to \tcode{bool}.
-
-\pnum
-\effects
-Equivalent to: \tcode{return bool(x) ?\ v <= *x :\ false;}
-\end{itemdescr}
-
 \indexlibrarymember{operator>}{optional}%
 \begin{itemdecl}
 template<class T, class U> constexpr bool operator>(const optional<T>& x, const U& v);
@@ -3558,6 +3526,38 @@ its result shall be convertible to \tcode{bool}.
 \pnum
 \effects
 Equivalent to: \tcode{return bool(x) ?\ v > *x :\ true;}
+\end{itemdescr}
+
+\indexlibrarymember{operator<=}{optional}%
+\begin{itemdecl}
+template<class T, class U> constexpr bool operator<=(const optional<T>& x, const U& v);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\requires
+The expression \tcode{*x <= v} shall be well-formed and
+its result shall be convertible to \tcode{bool}.
+
+\pnum
+\effects
+Equivalent to: \tcode{return bool(x) ?\ *x <= v :\ true;}
+\end{itemdescr}
+
+\indexlibrarymember{operator<=}{optional}%
+\begin{itemdecl}
+template<class T, class U> constexpr bool operator<=(const T& v, const optional<U>& x);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\requires
+The expression \tcode{v <= *x} shall be well-formed and
+its result shall be convertible to \tcode{bool}.
+
+\pnum
+\effects
+Equivalent to: \tcode{return bool(x) ?\ v <= *x :\ false;}
 \end{itemdescr}
 
 \indexlibrarymember{operator>=}{optional}%
@@ -3763,12 +3763,12 @@ namespace std {
   struct monostate;
 
   // \ref{variant.monostate.relops}, \tcode{monostate} relational operators
+  constexpr bool operator==(monostate, monostate) noexcept;
+  constexpr bool operator!=(monostate, monostate) noexcept;
   constexpr bool operator<(monostate, monostate) noexcept;
   constexpr bool operator>(monostate, monostate) noexcept;
   constexpr bool operator<=(monostate, monostate) noexcept;
   constexpr bool operator>=(monostate, monostate) noexcept;
-  constexpr bool operator==(monostate, monostate) noexcept;
-  constexpr bool operator!=(monostate, monostate) noexcept;
 
   // \ref{variant.specalg}, specialized algorithms
   template<class... Types>
@@ -4885,19 +4885,19 @@ a \tcode{variant} to make the \tcode{variant} type default constructible.
 
 \rSec2[variant.monostate.relops]{\tcode{monostate} relational operators}
 
+\indexlibrary{\idxcode{operator==}!\idxcode{monostate}}%
+\indexlibrary{\idxcode{operator"!=}!\idxcode{monostate}}%
 \indexlibrary{\idxcode{operator<}!\idxcode{monostate}}%
 \indexlibrary{\idxcode{operator>}!\idxcode{monostate}}%
 \indexlibrary{\idxcode{operator<=}!\idxcode{monostate}}%
 \indexlibrary{\idxcode{operator>=}!\idxcode{monostate}}%
-\indexlibrary{\idxcode{operator==}!\idxcode{monostate}}%
-\indexlibrary{\idxcode{operator"!=}!\idxcode{monostate}}%
 \begin{itemdecl}
+constexpr bool operator==(monostate, monostate) noexcept { return true; }
+constexpr bool operator!=(monostate, monostate) noexcept { return false; }
 constexpr bool operator<(monostate, monostate) noexcept { return false; }
 constexpr bool operator>(monostate, monostate) noexcept { return false; }
 constexpr bool operator<=(monostate, monostate) noexcept { return true; }
 constexpr bool operator>=(monostate, monostate) noexcept { return true; }
-constexpr bool operator==(monostate, monostate) noexcept { return true; }
-constexpr bool operator!=(monostate, monostate) noexcept { return false; }
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6633,9 +6633,9 @@ namespace std {
   template<class T1, class D1, class T2, class D2>
     bool operator<(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
   template<class T1, class D1, class T2, class D2>
-    bool operator<=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
-  template<class T1, class D1, class T2, class D2>
     bool operator>(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
+  template<class T1, class D1, class T2, class D2>
+    bool operator<=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
   template<class T1, class D1, class T2, class D2>
     bool operator>=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
 
@@ -6652,13 +6652,13 @@ namespace std {
   template<class T, class D>
     bool operator<(nullptr_t, const unique_ptr<T, D>& y);
   template<class T, class D>
-    bool operator<=(const unique_ptr<T, D>& x, nullptr_t);
-  template<class T, class D>
-    bool operator<=(nullptr_t, const unique_ptr<T, D>& y);
-  template<class T, class D>
     bool operator>(const unique_ptr<T, D>& x, nullptr_t);
   template<class T, class D>
     bool operator>(nullptr_t, const unique_ptr<T, D>& y);
+  template<class T, class D>
+    bool operator<=(const unique_ptr<T, D>& x, nullptr_t);
+  template<class T, class D>
+    bool operator<=(nullptr_t, const unique_ptr<T, D>& y);
   template<class T, class D>
     bool operator>=(const unique_ptr<T, D>& x, nullptr_t);
   template<class T, class D>
@@ -6727,13 +6727,13 @@ namespace std {
   template<class T>
     bool operator<(nullptr_t, const shared_ptr<T>& y) noexcept;
   template<class T>
-    bool operator<=(const shared_ptr<T>& x, nullptr_t) noexcept;
-  template<class T>
-    bool operator<=(nullptr_t, const shared_ptr<T>& y) noexcept;
-  template<class T>
     bool operator>(const shared_ptr<T>& x, nullptr_t) noexcept;
   template<class T>
     bool operator>(nullptr_t, const shared_ptr<T>& y) noexcept;
+  template<class T>
+    bool operator<=(const shared_ptr<T>& x, nullptr_t) noexcept;
+  template<class T>
+    bool operator<=(nullptr_t, const shared_ptr<T>& y) noexcept;
   template<class T>
     bool operator>=(const shared_ptr<T>& x, nullptr_t) noexcept;
   template<class T>
@@ -8891,17 +8891,6 @@ to \tcode{CT} or \tcode{unique_ptr<T2, D2>::pointer} is not implicitly
 convertible to \tcode{CT}, the program is ill-formed.
 \end{itemdescr}
 
-\indexlibrarymember{operator<=}{unique_ptr}%
-\begin{itemdecl}
-template<class T1, class D1, class T2, class D2>
-  bool operator<=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{!(y < x)}.
-\end{itemdescr}
-
 \indexlibrarymember{operator>}{unique_ptr}%
 \begin{itemdecl}
 template<class T1, class D1, class T2, class D2>
@@ -8911,6 +8900,17 @@ template<class T1, class D1, class T2, class D2>
 \begin{itemdescr}
 \pnum
 \returns \tcode{y < x}.
+\end{itemdescr}
+
+\indexlibrarymember{operator<=}{unique_ptr}%
+\begin{itemdecl}
+template<class T1, class D1, class T2, class D2>
+  bool operator<=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns \tcode{!(y < x)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>=}{unique_ptr}%
@@ -17545,10 +17545,10 @@ namespace std {
       constexpr bool operator< (const duration<Rep1, Period1>& lhs,
                                 const duration<Rep2, Period2>& rhs);
     template<class Rep1, class Period1, class Rep2, class Period2>
-      constexpr bool operator<=(const duration<Rep1, Period1>& lhs,
+      constexpr bool operator> (const duration<Rep1, Period1>& lhs,
                                 const duration<Rep2, Period2>& rhs);
     template<class Rep1, class Period1, class Rep2, class Period2>
-      constexpr bool operator> (const duration<Rep1, Period1>& lhs,
+      constexpr bool operator<=(const duration<Rep1, Period1>& lhs,
                                 const duration<Rep2, Period2>& rhs);
     template<class Rep1, class Period1, class Rep2, class Period2>
       constexpr bool operator>=(const duration<Rep1, Period1>& lhs,
@@ -17622,10 +17622,10 @@ namespace std {
        constexpr bool operator< (const time_point<Clock, Duration1>& lhs,
                                  const time_point<Clock, Duration2>& rhs);
     template<class Clock, class Duration1, class Duration2>
-       constexpr bool operator<=(const time_point<Clock, Duration1>& lhs,
+       constexpr bool operator> (const time_point<Clock, Duration1>& lhs,
                                  const time_point<Clock, Duration2>& rhs);
     template<class Clock, class Duration1, class Duration2>
-       constexpr bool operator> (const time_point<Clock, Duration1>& lhs,
+       constexpr bool operator<=(const time_point<Clock, Duration1>& lhs,
                                  const time_point<Clock, Duration2>& rhs);
     template<class Clock, class Duration1, class Duration2>
        constexpr bool operator>=(const time_point<Clock, Duration1>& lhs,
@@ -18565,7 +18565,7 @@ template<class Rep>
 
 \pnum
 The \tcode{duration} template uses the \tcode{duration_values} trait to
-construct special values of the durations representation (\tcode{Rep}). This is
+construct special values of the duration's representation (\tcode{Rep}). This is
 done because the representation might be a class type with behavior which
 requires some other implementation to return these special values. In that case,
 the author of that class type should specialize \tcode{duration_values} to
@@ -19189,18 +19189,6 @@ template<class Rep1, class Period1, class Rep2, class Period2>
 \returns \tcode{CT(lhs).count() < CT(rhs).count()}.
 \end{itemdescr}
 
-\indexlibrarymember{operator<=}{duration}%
-\begin{itemdecl}
-template<class Rep1, class Period1, class Rep2, class Period2>
-  constexpr bool operator<=(const duration<Rep1, Period1>& lhs,
-                            const duration<Rep2, Period2>& rhs);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{!(rhs < lhs)}.
-\end{itemdescr}
-
 \indexlibrarymember{operator>}{duration}%
 \begin{itemdecl}
 template<class Rep1, class Period1, class Rep2, class Period2>
@@ -19211,6 +19199,18 @@ template<class Rep1, class Period1, class Rep2, class Period2>
 \begin{itemdescr}
 \pnum
 \returns \tcode{rhs < lhs}.
+\end{itemdescr}
+
+\indexlibrarymember{operator<=}{duration}%
+\begin{itemdecl}
+template<class Rep1, class Period1, class Rep2, class Period2>
+  constexpr bool operator<=(const duration<Rep1, Period1>& lhs,
+                            const duration<Rep2, Period2>& rhs);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns \tcode{!(rhs < lhs)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>=}{duration}%
@@ -19862,18 +19862,6 @@ template<class Clock, class Duration1, class Duration2>
 \returns \tcode{lhs.time_since_epoch() < rhs.time_since_epoch()}.
 \end{itemdescr}
 
-\indexlibrarymember{operator<=}{time_point}%
-\begin{itemdecl}
-template<class Clock, class Duration1, class Duration2>
-  constexpr bool operator<=(const time_point<Clock, Duration1>& lhs,
-                            const time_point<Clock, Duration2>& rhs);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{!(rhs < lhs)}.
-\end{itemdescr}
-
 \indexlibrarymember{operator>}{time_point}%
 \begin{itemdecl}
 template<class Clock, class Duration1, class Duration2>
@@ -19884,6 +19872,18 @@ template<class Clock, class Duration1, class Duration2>
 \begin{itemdescr}
 \pnum
 \returns \tcode{rhs < lhs}.
+\end{itemdescr}
+
+\indexlibrarymember{operator<=}{time_point}%
+\begin{itemdecl}
+template<class Clock, class Duration1, class Duration2>
+  constexpr bool operator<=(const time_point<Clock, Duration1>& lhs,
+                            const time_point<Clock, Duration2>& rhs);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns \tcode{!(rhs < lhs)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>=}{time_point}%
@@ -28719,8 +28719,8 @@ namespace std {
     bool operator==(const type_index& rhs) const noexcept;
     bool operator!=(const type_index& rhs) const noexcept;
     bool operator< (const type_index& rhs) const noexcept;
-    bool operator<= (const type_index& rhs) const noexcept;
     bool operator> (const type_index& rhs) const noexcept;
+    bool operator<= (const type_index& rhs) const noexcept;
     bool operator>= (const type_index& rhs) const noexcept;
     size_t hash_code() const noexcept;
     const char* name() const noexcept;
@@ -28782,16 +28782,6 @@ bool operator<(const type_index& rhs) const noexcept;
 \returns \tcode{target->before(*rhs.target)}.
 \end{itemdescr}
 
-\indexlibrarymember{operator<=}{type_index}%
-\begin{itemdecl}
-bool operator<=(const type_index& rhs) const noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns \tcode{!rhs.target->before(*target)}.
-\end{itemdescr}
-
 \indexlibrarymember{operator>}{type_index}%
 \begin{itemdecl}
 bool operator>(const type_index& rhs) const noexcept;
@@ -28800,6 +28790,16 @@ bool operator>(const type_index& rhs) const noexcept;
 \begin{itemdescr}
 \pnum
 \returns \tcode{rhs.target->before(*target)}.
+\end{itemdescr}
+
+\indexlibrarymember{operator<=}{type_index}%
+\begin{itemdecl}
+bool operator<=(const type_index& rhs) const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns \tcode{!rhs.target->before(*target)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>=}{type_index}%


### PR DESCRIPTION
The order [`==`, `!=`, `<`, `>`, `<=`, `>=`] seems to be most common. Let's make it canonical and use it uniformly.
