### PR TITLE
[over.match.copy] Clarify candidate function selection for references.

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -281,8 +281,8 @@ Seldom.
 \change The result of a conditional expression, an assignment expression, or a comma expression may be an lvalue.
 \rationale
 \Cpp{} is an object-oriented language, placing relatively
-more emphasis on lvalues.  For example, functions may
-return lvalues.
+more emphasis on lvalues.  For example, function calls may
+yield lvalues.
 \effect
 Change to semantics of well-defined feature.  Some C
 expressions that implicitly rely on lvalue-to-rvalue

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -1271,15 +1271,10 @@ and yield a type whose cv-unqualified version is the same type as
 \tcode{T}
 or is a derived class thereof
 are candidate functions.
-Conversion functions that return ``reference to
-\tcode{X}''
-return
-lvalues or xvalues, depending on the type of reference, of type
-\tcode{X}
-and are therefore considered to yield
-\tcode{X}
-for this
-process of selecting candidate functions.
+A call to a conversion function returning ``reference to \tcode{X}''
+is a glvalue of type \tcode{X}, and such a conversion function is
+therefore considered to yield \tcode{X} for this process of selecting
+candidate functions.
 \end{itemize}
 
 \pnum
@@ -1330,17 +1325,10 @@ candidate functions.
 Conversion functions that return a cv-qualified type
 are considered to yield the cv-unqualified version of that type
 for this process of selecting candidate functions.
-Conversion functions that return ``reference to
-\cvqual{cv2}
-\tcode{X}''
-return
-lvalues or xvalues, depending on the type of reference, of type
-``\cvqual{cv2}
-\tcode{X}''
-and are therefore considered to yield
-\tcode{X}
-for this
-process of selecting candidate functions.
+A call to a conversion function returning ``reference to \tcode{X}''
+is a glvalue of type \tcode{X}, and such a conversion function is
+therefore considered to yield \tcode{X} for this process of selecting
+candidate functions.
 \end{itemize}
 
 \pnum


### PR DESCRIPTION
Fixes #2053.