### PR TITLE
[basic.scope.pdecl] Change "type-id" to "defining-type-id"

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -734,7 +734,7 @@ immediately after the \grammarterm{identifier} (if any) in either its
 \grammarterm{enum-specifier}\iref{dcl.enum} or its first
 \grammarterm{opaque-enum-declaration}\iref{dcl.enum}, whichever comes first.
 The point of declaration of an alias or alias template immediately
-follows the \grammarterm{type-id} to which the
+follows the \grammarterm{defining-type-id} to which the
 alias refers.
 
 \pnum


### PR DESCRIPTION
... now that _alias-declaration_ uses the _defining-type-id_ nonterminal.