### PR TITLE
[algorithms.parallel.defns] Fix cross-reference to [algorithms.requirements]

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -1304,7 +1304,7 @@ algorithm, if required by the specification.
 
 \item
 Operations on those function objects required by the specification.
-\begin{note} See~\ref{algorithms.general}.\end{note}
+\begin{note} See~\ref{algorithms.requirements}.\end{note}
 \end{itemize}
 
 These functions are herein called \defn{element access functions}.


### PR DESCRIPTION
When [algorithms.general] was split into three subclauses (#1230) the
requirements moved to a new subclause, [algorithms.requirements]. That
invalidated the cross-reference in [algorithms.parallel.defns].