### PR TITLE
Delete redundant and wrong example

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -95,11 +95,6 @@ Expressions are categorized according to the taxonomy in Figure~\ref{fig:categor
 or computes the value of the operand of an operator,
 as specified by the context in which it appears.
 \item An \defn{xvalue} is a glvalue that denotes an object or bit-field whose resources can be reused (usually because it is near the end of its lifetime).
-\begin{example}
-Certain kinds of expressions involving rvalue references\iref{dcl.ref} yield xvalues,
-such as a call to a function whose return type is an rvalue reference
-or a cast to an rvalue reference type.
-\end{example}
 \item An \defn{lvalue} is a glvalue that is not an xvalue.
 \item An \defn{rvalue} is a prvalue or an xvalue.
 \end{itemize}


### PR DESCRIPTION
1. Returning/casting to rvalue reference of *object type* is an xvalue. The example misses the "object type" part.
2. A(n almost, the PR is waiting to be merged) complete and correct list of xvalue expressions is just 2 (or 3? I'm bad at counting) paragraph below. So, fixing the example is not rational, better to delete it.