### PR TITLE
[atomics.types.operations] Avoid inappropriate use of 'underlying type'

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -1661,7 +1661,7 @@ would not, the strong one is preferable.
 \begin{note}
 Under cases where the \tcode{memcpy} and \tcode{memcmp} semantics of the compare-and-exchange
 operations apply, the outcome might be failed comparisons for values that compare equal with
-\tcode{operator==} if the underlying type has trap bits or alternate
+\tcode{operator==} if the value representation has trap bits or alternate
 representations of the same value. Notably, on implementations conforming to
 ISO/IEC/IEEE 60559, floating-point \tcode{-0.0} and \tcode{+0.0}
 will not compare equal with \tcode{memcmp} but will compare equal with \tcode{operator==},


### PR DESCRIPTION
Fixes #2057.