### PR TITLE
[views.general] Remove redundant introduction for span.

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -9691,8 +9691,6 @@ unless \tcode{is_swappable_v<Container>} is \tcode{true}.
 
 \pnum
 The header \tcode{<span>} defines the view \tcode{span}.
-A \tcode{span} is a view over a contiguous sequence of objects,
-the storage of which is owned by some other object.
 
 \rSec2[span.syn]{Header \tcode{<span>} synopsis}%
 \indexhdr{span}%


### PR DESCRIPTION
Fixes #2026.