### PR TITLE
Fixed example about [[likely]] attribute

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4079,7 +4079,7 @@ int f(int n) {
     g(1);
     [[fallthrough]];
 
-  [[likely]] case 2:            // \tcode{n == 3} is considered to be arbitrarily more
+  [[likely]] case 2:            // \tcode{n == 2} is considered to be arbitrarily more
     g(2);                       // likely than any other value of \tcode{n}
     break;
   }


### PR DESCRIPTION
The comment in the example is not consistent with the commented code.