### PR TITLE
[class] Split paragraph defining standard-layout class

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -166,14 +166,15 @@ for all non-static data members,
 \item has all non-static data members and bit-fields in the class and
 its base classes first declared in the same class, and
 
-\item has no element of the set $M(\mathtt{S})$ of types (defined below)
-as a base class.\footnote{This ensures that two subobjects that have the
-same class type and that
+\item has no element of the set $M(\mathtt{S})$ of types
+as a base class,
+where for any type \tcode{X}, $M(\mathtt{X})$ is defined as follows.\footnote{
+This ensures that two subobjects that have the same class type and that
 belong to the same most derived object are not allocated at the same
 address\iref{expr.eq}.}
-\end{itemize}
+\begin{note} $M(\mathtt{X})$ is the set of the types of all non-base-class subobjects
+that may be at a zero offset in \tcode{X}. \end{note}
 
-$M(\mathtt{X})$ is defined as follows:
 \begin{itemize}
 \item If \tcode{X} is a non-union class type with no (possibly
 inherited\iref{class.derived}) non-static data members, the set
@@ -198,10 +199,9 @@ and the elements of $M(\mathtt{X}_e)$.
 
 \item If \tcode{X} is a non-class, non-array type, the set $M(\mathtt{X})$ is empty.
 \end{itemize}
+\end{itemize}
 
-\begin{note} $M(\mathtt{X})$ is the set of the types of all non-base-class subobjects
-that may be at a zero offset in \tcode{X}. \end{note}
-
+\pnum
 \begin{example}
 \begin{codeblock}
    struct B { int i; };         // standard-layout class


### PR DESCRIPTION
This paragraph seems excessively long:

![spectacle tj2604](https://user-images.githubusercontent.com/1254480/39921351-7a351706-5512-11e8-9e1e-0ecbbade16c3.png)
