### PR TITLE
Improves the spacing around bit operators.

### DIFF
--- a/source/macros.tex
+++ b/source/macros.tex
@@ -215,11 +215,11 @@
 %%--------------------------------------------------
 %% States and operators
 \newcommand{\state}[2]{\tcode{#1}\ensuremath{_{#2}}}
-\newcommand{\bitand}{\ensuremath{\, \mathsf{bitand} \,}}
-\newcommand{\bitor}{\ensuremath{\, \mathsf{bitor} \,}}
-\newcommand{\xor}{\ensuremath{\, \mathsf{xor} \,}}
-\newcommand{\rightshift}{\ensuremath{\, \mathsf{rshift} \,}}
-\newcommand{\leftshift}[1]{\ensuremath{\, \mathsf{lshift}_#1 \,}}
+\newcommand{\bitand}{\ensuremath{\mathbin{\mathsf{bitand}}}}
+\newcommand{\bitor}{\ensuremath{\mathbin{\mathsf{bitor}}}}
+\newcommand{\xor}{\ensuremath{\mathbin{\mathsf{xor}}}}
+\newcommand{\rightshift}{\ensuremath{\mathbin{\mathsf{rshift}}}}
+\newcommand{\leftshift}[1]{\ensuremath{\mathbin{\mathsf{lshift}_{#1}}}}
 
 %% Notes and examples
 \newcommand{\noteintro}[1]{[\,\textit{#1:}\space}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -1444,7 +1444,7 @@ use mathematical real numbers.
 \pnum
 Throughout this subclause,
 the operators
-\bitand, \bitor, and \xor
+\bitand, \bitor, and \xor{}
 denote the respective conventional bitwise operations.
 Further:
 
@@ -2883,7 +2883,7 @@ The state transition is performed as follows:
  \item
    With $\alpha = a \cdot (Y \bitand 1)$,
    set $X_i$ to
-     $X_{i+m-n} \, \xor \, (Y \rightshift 1) \, \xor \, \alpha$.
+     $X_{i+m-n} \xor (Y \rightshift 1) \xor \alpha$.
 \end{enumeratea}
 The sequence $X$ is initialized
 with the help of an initialization multiplier $f$.
@@ -2898,9 +2898,9 @@ The generation algorithm%
  \item
    Let $z_1 = X_i \xor \bigl(( X_i \rightshift u ) \bitand d\bigr)$.
  \item
-   Let $z_2 = z_1 \xor \bigl( (z_1 \leftshift{w} \, s) \bitand b \bigr)$.
+   Let $z_2 = z_1 \xor \bigl( (z_1 \leftshift{w} s) \bitand b \bigr)$.
  \item
-   Let $z_3 = z_2 \xor \bigl( (z_2 \leftshift{w} \, t) \bitand c \bigr)$.
+   Let $z_3 = z_2 \xor \bigl( (z_2 \leftshift{w} t) \bitand c \bigr)$.
  \item
    Let $z_4 = z_3 \xor ( z_3 \rightshift \ell )$.
 \end{enumeratea}
@@ -4007,7 +4007,7 @@ template<class RandomAccessIterator>
  in which
  each operation is to be carried out modulo $2^{32}$,
  each indexing operator applied to \tcode{begin} is to be taken modulo $n$,
- and $T(x)$ is defined as $x \, \xor \, (x \, \rightshift \, 27)$:
+ and $T(x)$ is defined as $x \xor (x \rightshift 27)$:
 
 \begin{enumeratea}
  \item


### PR DESCRIPTION
This PR improves the spacing around the bit operators `\bitand`, `\bitor`, `\xor`, `\rightshift`, and `\leftshift` by declaring them as `\mathbin` tokens.