### PR TITLE
Improved typesetting of probability functions.

### DIFF
--- a/source/macros.tex
+++ b/source/macros.tex
@@ -220,6 +220,30 @@
 \newcommand{\rightshift}{\ensuremath{\mathbin{\mathsf{rshift}}}}
 \newcommand{\leftshift}[1]{\ensuremath{\mathbin{\mathsf{lshift}_{#1}}}}
 
+%% Probability functions
+\RequirePackage{mathtools}
+\makeatletter
+\newcommand{\std@makeactivechar}[2]{%
+  \begingroup
+  \lccode`\~=`#1%
+  \lowercase{\endgroup\def~}{#2}%
+  \mathcode`#1="8000%
+}
+\DeclarePairedDelimiterX\p@aux[1](){%
+  \begingroup
+    \std@makeactivechar{|}{\mathrel{\delimsize\vert}}%
+    #1%
+  \endgroup
+}
+\let\pilcrow\P% steal \P from pilcrow symbol
+\def\P#1{%
+  P\p@aux{#1}%
+}
+\def\p#1{%
+  p\p@aux{#1}%
+}
+\makeatother
+
 %% Notes and examples
 \newcommand{\noteintro}[1]{[\,\textit{#1:}\space}
 \newcommand{\noteoutro}[1]{\textit{\,---\,end #1}\,]}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -2207,7 +2207,7 @@ an associated \term{discrete probability function}
 $P(z_i)$.
 A distribution's specification
 identifies its associated probability function
-$p(z)$ or $P(z_i)$.
+$\p{z}$ or $\P{z_i}$.
 
 \pnum
 An associated probability function is typically expressed
@@ -2215,11 +2215,11 @@ using certain externally-supplied quantities
 known as the \term{parameters of the distribution}.
 Such distribution parameters are identified
 in this context by writing, for example,
-  $p(z\,|\,a,b)$ or $P(z_i\,|\,a,b)$,
+  $\p{z | a,b}$ or $\P{z_i | a,b}$,
   to name specific parameters,
 or by writing, for example,
-  $p(z\,|\left\{\tcode{p}\right\})$
-  or $P(z_i\,|\left\{\tcode{p}\right\})$,
+  $\p{z | \left\{\tcode{p}\right\}}$
+  or $\P{z_i | \left\{\tcode{p}\right\}}$,
   to denote a distribution's parameters \tcode{p} taken as a whole.
 
 \pnum
@@ -2344,9 +2344,9 @@ according to \ref{strings} and \ref{input.output}.
     with the same object \tcode{g}
     is randomly distributed
     according to the associated
-      $p(z\,|\left\{\texttt{p}\right\})$
+      $\p{z | \left\{\texttt{p}\right\}}$
     or
-      $P(z_i\,|\left\{\texttt{p}\right\})$
+      $\P{z_i | \left\{\texttt{p}\right\}}$
     function.
   & amortized constant number of invocations of \tcode{g}
   \\ \rowsep
@@ -2358,9 +2358,9 @@ according to \ref{strings} and \ref{input.output}.
     with the same objects \tcode{g} and \tcode{p}
     is randomly distributed
     according to the associated
-      $p(z\,|\left\{\texttt{p}\right\})$
+      $\p{z | \left\{\texttt{p}\right\}}$
     or
-      $P(z_i\,|\left\{\texttt{p}\right\})$
+      $\P{z_i | \left\{\texttt{p}\right\}}$
     function.
   & amortized constant number of invocations of \tcode{g}
   \\ \rowsep
@@ -4224,8 +4224,8 @@ of the specified distributions are
 \impldef{algorithms for producing the standard random number distributions}.
 
 \pnum
-The value of each probability density function $p(z)$
-and of each discrete probability function $P(z_i)$
+The value of each probability density function $\p{z}$
+and of each discrete probability function $\P{z_i}$
 specified in this subclause
 is $0$
 everywhere outside its stated domain.
@@ -4255,7 +4255,7 @@ distributed according to
 the constant discrete probability function%
 \indextext{discrete probability function!\idxcode{uniform_int_distribution}}%
 \indextext{\idxcode{uniform_int_distribution}!discrete probability function}%
-\[  P(i\,|\,a,b) = 1 / (b - a + 1) \text{ .} \]
+\[  \P{i | a,b} = 1 / (b - a + 1) \text{ .} \]
 
 \indexlibrary{\idxcode{uniform_int_distribution}}%
 \begin{codeblock}
@@ -4337,9 +4337,9 @@ distributed according to
 the constant probability density function%
 \indextext{probability density function!\idxcode{uniform_real_distribution}}%
 \indextext{\idxcode{uniform_real_distribution}!probability density function}%
-\[ p(x\,|\,a,b) = 1 / (b - a) \text{ .} \]
+\[ \p{x | a,b} = 1 / (b - a) \text{ .} \]
 \begin{note}
-This implies that $p(x\,|\,a,b)$ is undefined when \tcode{a == b}.
+This implies that $\p{x | a,b}$ is undefined when \tcode{a == b}.
 \end{note}
 
 \indexlibrary{\idxcode{uniform_real_distribution}}%
@@ -4436,7 +4436,7 @@ distributed according to
 the discrete probability function
 \indextext{discrete probability function!\idxcode{bernoulli_distribution}}%
 \indextext{\idxcode{bernoulli_distribution}!discrete probability function}%
-\[  P(b\,|\,p) = \left\{ \begin{array}{ll}
+\[  \P{b | p} = \left\{ \begin{array}{ll}
                           p     & \text{ if $b = \tcode{true}$, or} \\
                           1 - p & \text{ if $b = \tcode{false}$.}
                           \end{array}\right.
@@ -4509,7 +4509,7 @@ distributed according to
 the discrete probability function%
 \indextext{discrete probability function!\idxcode{binomial_distribution}}%
 \indextext{\idxcode{binomial_distribution}!discrete probability function}%
-\[ P(i\,|\,t,p) = \binom{t}{i} \cdot p^i \cdot (1-p)^{t-i} \text{ .} \]
+\[ \P{i | t,p} = \binom{t}{i} \cdot p^i \cdot (1-p)^{t-i} \text{ .} \]
 
 \indexlibrary{\idxcode{binomial_distribution}}%
 \begin{codeblock}
@@ -4589,7 +4589,7 @@ distributed according to
 the discrete probability function
 \indextext{discrete probability function!\idxcode{geometric_distribution}}%
 \indextext{\idxcode{geometric_distribution}!discrete probability function}%
-\[ P(i\,|\,p) = p \cdot (1-p)^{i} \text{ .} \]
+\[ \P{i | p} = p \cdot (1-p)^{i} \text{ .} \]
 
 \indexlibrary{\idxcode{geometric_distribution}}%
 \begin{codeblock}
@@ -4660,9 +4660,9 @@ distributed according to
 the discrete probability function
 \indextext{discrete probability function!\idxcode{negative_binomial_distribution}}%
 \indextext{\idxcode{negative_binomial_distribution}!discrete probability function}%
-\[ P(i\,|\,k,p) = \binom{k+i-1}{i} \cdot p^k \cdot (1-p)^i \text{ .} \]
+\[ \P{i | k,p} = \binom{k+i-1}{i} \cdot p^k \cdot (1-p)^i \text{ .} \]
 \begin{note}
-This implies that $P(i\,|\,k,p)$ is undefined when \tcode{p == 1}.
+This implies that $\P{i | k,p}$ is undefined when \tcode{p == 1}.
 \end{note}
 
 \indexlibrary{\idxcode{negative_binomial_distribution}}%
@@ -4758,7 +4758,7 @@ distributed according to
 the discrete probability function
 \indextext{discrete probability function!\idxcode{poisson_distribution}}%
 \indextext{\idxcode{poisson_distribution}!discrete probability function}%
-\[ P(i\,|\,\mu) = \frac{e^{-\mu} \mu^{i}}{i\,!} \text{ .} \]
+\[ \P{i | \mu} = \frac{e^{-\mu} \mu^{i}}{i\,!} \text{ .} \]
 The distribution parameter $\mu$
 is also known as this distribution's \term{mean}%
 \indextext{mean!\idxcode{poisson_distribution}}%
@@ -4833,7 +4833,7 @@ distributed according to
 the probability density function%
 \indextext{probability density function!\idxcode{exponential_distribution}}%
 \indextext{\idxcode{exponential_distribution}!probability density function}%
-\[ p(x\,|\,\lambda) = \lambda e^{-\lambda x} \text{ .} \]
+\[ \p{x | \lambda} = \lambda e^{-\lambda x} \text{ .} \]
 
 \indexlibrary{\idxcode{exponential_distribution}}%
 \begin{codeblock}
@@ -4903,7 +4903,7 @@ distributed according to
 the probability density function%
 \indextext{probability density function!\idxcode{gamma_distribution}}%
 \indextext{\idxcode{gamma_distribution}!probability density function}%
-\[ p(x\,|\,\alpha,\beta) =
+\[ \p{x | \alpha,\beta} =
      \frac{e^{-x/\beta}}{\beta^{\alpha} \cdot \Gamma(\alpha)} \, \cdot \, x^{\, \alpha-1}
      \text{ .} \]
 
@@ -4988,7 +4988,7 @@ distributed according to
 the probability density function%
 \indextext{probability density function!\idxcode{weibull_distribution}}%
 \indextext{\idxcode{weibull_distribution}!probability density function}%
-\[ p(x\,|\,a,b) = \frac{a}{b}
+\[ \p{x | a,b} = \frac{a}{b}
      \cdot \left(\frac{x}{b}\right)^{a-1}
      \cdot \, \exp\left( -\left(\frac{x}{b}\right)^a\right)
      \text{ .} \]
@@ -5080,7 +5080,7 @@ the probability density function\footnote{The distribution corresponding to
  distribution.}%
 \indextext{probability density function!\idxcode{extreme_value_distribution}}%
 \indextext{\idxcode{extreme_value_distribution}!probability density function}
-\[ p(x\,|\,a,b) = \frac{1}{b}
+\[ \p{x | a,b} = \frac{1}{b}
      \cdot \exp\left(\frac{a-x}{b} - \exp\left(\frac{a-x}{b}\right)\right)
      \text{ .} \]
 
@@ -5178,7 +5178,7 @@ the probability density function%
 \indextext{probability density function!\idxcode{normal_distribution}}%
 \indextext{\idxcode{normal_distribution}!probability density function}%
 \[%
- p(x\,|\,\mu,\sigma)
+ \p{x | \mu,\sigma}
       = \frac{1}{\sigma \sqrt{2\pi}}
         \cdot
         % e^{-(x-\mu)^2 / (2\sigma^2)}
@@ -5278,7 +5278,7 @@ distributed according to
 the probability density function%
 \indextext{probability density function!\idxcode{lognormal_distribution}}%
 \indextext{\idxcode{lognormal_distribution}!probability density function}%
-\[ p(x\,|\,m,s) = \frac{1}{s x \sqrt{2 \pi}}
+\[ \p{x | m,s} = \frac{1}{s x \sqrt{2 \pi}}
      \cdot \exp{\left(-\frac{(\ln{x} - m)^2}{2 s^2}\right)}
      \text{ .} \]
 
@@ -5363,7 +5363,7 @@ distributed according to
 the probability density function%
 \indextext{probability density function!\idxcode{chi_squared_distribution}}%
 \indextext{\idxcode{chi_squared_distribution}!probability density function}%
-\[ p(x\,|\,n) = \frac{x^{(n/2)-1} \cdot e^{-x/2}}{\Gamma(n/2) \cdot 2^{n/2}} \text{ .} \]
+\[ \p{x | n} = \frac{x^{(n/2)-1} \cdot e^{-x/2}}{\Gamma(n/2) \cdot 2^{n/2}} \text{ .} \]
 
 \indexlibrary{\idxcode{chi_squared_distribution}}%
 \begin{codeblock}
@@ -5434,7 +5434,7 @@ distributed according to
 the probability density function%
 \indextext{probability density function!\idxcode{cauchy_distribution}}%
 \indextext{\idxcode{cauchy_distribution}!probability density function}%
-\[  p(x\,|\,a,b) = \left(\pi b \left(1 + \left(\frac{x-a}{b} \right)^2 \, \right)\right)^{-1} \text{ .} \]
+\[  \p{x | a,b} = \left(\pi b \left(1 + \left(\frac{x-a}{b} \right)^2 \, \right)\right)^{-1} \text{ .} \]
 
 \indexlibrary{\idxcode{cauchy_distribution}}%
 \begin{codeblock}
@@ -5517,7 +5517,7 @@ distributed according to
 the probability density function%
 \indextext{probability density function!\idxcode{fisher_f_distribution}}%
 \indextext{\idxcode{fisher_f_distribution}!probability density function}%
-\[ p(x\,|\,m,n) = \frac{\Gamma\big((m+n)/2\big)}{\Gamma(m/2) \; \Gamma(n/2)}
+\[ \p{x | m,n} = \frac{\Gamma\big((m+n)/2\big)}{\Gamma(m/2) \; \Gamma(n/2)}
      \cdot \left(\frac{m}{n}\right)^{m/2}
      \cdot x^{(m/2)-1}
      \cdot \left(1 + \frac{m x}{n}\right)^{-(m + n)/2}
@@ -5604,7 +5604,7 @@ distributed according to
 the probability density function%
 \indextext{probability density function!\idxcode{student_t_distribution}}%
 \indextext{\idxcode{student_t_distribution}!probability density function}%
-\[ p(x\,|\,n) = \frac{1}{\sqrt{n \pi}}
+\[ \p{x | n} = \frac{1}{\sqrt{n \pi}}
      \cdot \frac{\Gamma\big((n+1)/2\big)}{\Gamma(n/2)}
      \cdot \left(1 + \frac{x^2}{n} \right)^{-(n+1)/2}
      \text{ .} \]
@@ -5692,7 +5692,7 @@ distributed according to
 the discrete probability function%
 \indextext{discrete probability function!\idxcode{discrete_distribution}}%
 \indextext{\idxcode{discrete_distribution}!discrete probability function}%
-\[  P(i \,|\, p_0, \dotsc, p_{n-1}) = p_i \text{ .} \]
+\[  \P{i | p_0, \dotsc, p_{n-1}} = p_i \text{ .} \]
 
 \pnum
 Unless specified otherwise,
@@ -5852,7 +5852,7 @@ $[ b_i, b_{i+1} )$
 according to the probability density function
 \indextext{probability density function!\idxcode{piecewise_constant_distribution}}%
 \indextext{\idxcode{piecewise_constant_distribution}!probability density function}%
-\[ p(x \,|\, b_0, \dotsc, b_n, \; \rho_0, \dotsc, \rho_{n-1}) = \rho_i
+\[ \p{x | b_0, \dotsc, b_n, \; \rho_0, \dotsc, \rho_{n-1}} = \rho_i
    \text{ , for $b_i \le x < b_{i+1}$.} \]
 
 \pnum
@@ -6065,7 +6065,7 @@ $[b_i, b_{i+1})$
 according to the probability density function
 \indextext{probability density function!\idxcode{piecewise_linear_distribution}}%
 \indextext{\idxcode{piecewise_linear_distribution}!probability density function}%
-\[ p(x \,|\, b_0, \dotsc, b_n, \; \rho_0, \dotsc, \rho_n)
+\[ \p{x | b_0, \dotsc, b_n, \; \rho_0, \dotsc, \rho_n}
      = \rho_{i}   \cdot {\frac{b_{i+1} - x}{b_{i+1} - b_i}}
      + \rho_{i+1} \cdot {\frac{x - b_i}{b_{i+1} - b_i}}
      \text{ , for $b_i \le x < b_{i+1}$.} \]


### PR DESCRIPTION
By using the new `\p` and `\P` macros, probability functions will be typeset
more consistently and cleanly.  The syntax of both macros is the same.
Examples:

    \p{z}
    \p{z | a, b}
    \p*{z | \frac{1}{2}}
    \p[\big]{\frac{A}{B}}

The pipe (`|`) will have the proper spacing automatically.
The `\p*` variant will autoscale the parentheses and vertical bar to fit the contents of the expressions.
You can specify a particular size using the `\p[<size>]` variant.
Possible sizes are `\big`, `\Big`, `\bigg`, and `\Bigg`.

The `p` or `P` is set in roman instead of italics, but this can be changed if you prefer _p_ and _P_.