### PR TITLE
[istreambuf.iterator.proxy] correct title and remove default template…

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -2983,12 +2983,12 @@ namespace std {
 }
 \end{codeblock}
 
-\rSec3[istreambuf.iterator.proxy]{Class template \tcode{istreambuf_iterator::proxy}}
+\rSec3[istreambuf.iterator.proxy]{Class \tcode{istreambuf_iterator::proxy}}
 
 \indexlibrary{\idxcode{proxy}!\idxcode{istreambuf_iterator}}%
 \begin{codeblock}
 namespace std {
-  template<class charT, class traits = char_traits<charT>>
+  template<class charT, class traits>
   class istreambuf_iterator<charT, traits>::proxy { // \expos
     charT keep_;
     basic_streambuf<charT,traits>* sbuf_;


### PR DESCRIPTION
… argument

This is a class, not a class template. Also, the default template argument is 1) redundant and 2) ill-formed for violating [temp.param]p12.