### PR TITLE
[conv.lval] Move a misplaced note

### DIFF
--- a/source/conversions.tex
+++ b/source/conversions.tex
@@ -141,6 +141,11 @@ is applied to an expression \tcode{e}, and either
       \tcode{ex}\iref{basic.def.odr},
 \end{itemize}
 the value contained in the referenced object is not accessed.
+\begin{note}
+Since no value is fetched from memory,
+there is no side effect for a volatile access\iref{intro.execution}, and
+an inactive member of a union\iref{class.union} may be accessed.
+\end{note}
 \begin{example}
 \begin{codeblock}
 struct S { int n; };
@@ -163,11 +168,6 @@ following rules:
 
 \item If \tcode{T} is \cv{}~\tcode{std::nullptr_t}, the result is a
 null pointer constant\iref{conv.ptr}.
-\begin{note}
-Since no value is fetched from memory,
-there is no side effect for a volatile access\iref{intro.execution}, and
-an inactive member of a union\iref{class.union} may be accessed.
-\end{note}
 
 \item Otherwise, if \tcode{T} has a class
 type, the conversion copy-initializes the result object from


### PR DESCRIPTION
Not sure should the Note follow the Example or vice versa.