### PR TITLE
[output.iterators] Strike useless sentence from note

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -481,10 +481,6 @@ They should be
 \term{single pass}
 algorithms.
 Equality and inequality might not be defined.
-Algorithms that take output iterators can be used with ostreams as the destination
-for placing data through the
-\tcode{ostream_iterator}
-class as well as with insert iterators and insert pointers.
 \end{note}
 
 \rSec2[forward.iterators]{Forward iterators}


### PR DESCRIPTION
There's no such thing as an "insert ~~iterator~~pointer," and the rest of this sentence isn't much better. Let's just strike it.