### PR TITLE
Drop redundant 'expression'

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1051,7 +1051,7 @@ virtual\iref{class.virtual} or pure virtual\iref{class.abstract}.
 \pnum
 \indextext{this pointer@\tcode{this} pointer|see{\tcode{this}}}%
 In the body of a non-static\iref{class.mfct} member function, the
-keyword \tcode{this} is a prvalue expression whose value is the
+keyword \tcode{this} is a prvalue whose value is the
 address of the object for which the function is called.
 \indextext{\idxcode{this}!type of}%
 The type of \tcode{this} in a member function of a class \tcode{X} is

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -1776,7 +1776,7 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 
 \tcode{a_uniq.\brk{}insert(\brk{}t)}      &
   \tcode{pair<\brk{}iterator, bool>}   &
-  \requires\ If \tcode{t} is a non-const rvalue expression, \tcode{value_type} shall be
+  \requires\ If \tcode{t} is a non-const rvalue, \tcode{value_type} shall be
   \oldconcept{MoveInsertable} into \tcode{X}; otherwise, \tcode{value_type} shall be
   \oldconcept{CopyInsertable} into \tcode{X}.\br
   \effects\ Inserts \tcode{t} if and only if there is no element in the container
@@ -1789,7 +1789,7 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 
 \tcode{a_eq.\brk{}insert(\brk{}t)}        &
   \tcode{iterator}               &
-  \requires\ If \tcode{t} is a non-const rvalue expression, \tcode{value_type} shall be
+  \requires\ If \tcode{t} is a non-const rvalue, \tcode{value_type} shall be
   \oldconcept{MoveInsertable} into \tcode{X}; otherwise, \tcode{value_type} shall be
   \oldconcept{CopyInsertable} into \tcode{X}.\br
   \effects\ Inserts \tcode{t} and returns the iterator pointing
@@ -1801,7 +1801,7 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 
 \tcode{a.\brk{}insert(\brk{}p, t)}                         &
   \tcode{iterator}               &
-  \requires\ If \tcode{t} is a non-const rvalue expression, \tcode{value_type} shall be
+  \requires\ If \tcode{t} is a non-const rvalue, \tcode{value_type} shall be
   \oldconcept{MoveInsertable} into \tcode{X}; otherwise, \tcode{value_type} shall be
   \oldconcept{CopyInsertable} into \tcode{X}.\br
   \effects\ Inserts \tcode{t} if and only if there is no element with key
@@ -2521,7 +2521,7 @@ and \oldconcept{CopyAssignable}.\br
 \indexunordmem{insert}%
 \tcode{a_uniq.insert(t)}
 &   \tcode{pair<iterator, bool>}
-&   \requires\ If \tcode{t} is a non-const rvalue expression, \tcode{value_type} shall be
+&   \requires\ If \tcode{t} is a non-const rvalue, \tcode{value_type} shall be
     \oldconcept{MoveInsertable} into \tcode{X}; otherwise, \tcode{value_type} shall be
     \oldconcept{CopyInsertable} into \tcode{X}.\br
     \effects\ Inserts \tcode{t} if and only if there is no element in the container
@@ -2534,7 +2534,7 @@ and \oldconcept{CopyAssignable}.\br
 %
 \tcode{a_eq.insert(t)}
 &   \tcode{iterator}
-&   \requires\ If \tcode{t} is a non-const rvalue expression, \tcode{value_type} shall be
+&   \requires\ If \tcode{t} is a non-const rvalue, \tcode{value_type} shall be
     \oldconcept{MoveInsertable} into \tcode{X}; otherwise, \tcode{value_type} shall be
     \oldconcept{CopyInsertable} into \tcode{X}.\br
     \effects\ Inserts \tcode{t}, and returns an iterator pointing to the newly
@@ -2544,7 +2544,7 @@ and \oldconcept{CopyAssignable}.\br
 %
 \tcode{a.insert(p, t)}
 &   \tcode{iterator}
-&   \requires\ If \tcode{t} is a non-const rvalue expression, \tcode{value_type} shall be
+&   \requires\ If \tcode{t} is a non-const rvalue, \tcode{value_type} shall be
     \oldconcept{MoveInsertable} into \tcode{X}; otherwise, \tcode{value_type} shall be
     \oldconcept{CopyInsertable} into \tcode{X}.\br
     \effects Equivalent to \tcode{a.insert(t)}.  Return value is an iterator pointing

--- a/source/conversions.tex
+++ b/source/conversions.tex
@@ -274,7 +274,7 @@ such that corresponding $P_i$ components are the same
 and the types denoted by \tcode{U} are the same.
 
 \pnum
-A prvalue expression of type $\tcode{T}_1$
+A prvalue of type $\tcode{T}_1$
 can be converted to type $\tcode{T}_2$
 if the following conditions are satisfied,
 % NB: forbid line break between 'where' and 'cv'

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -181,7 +181,7 @@ For a discarded prvalue, a temporary object is materialized; see \ref{expr.prop}
 The \defnx{result}{result!glvalue} of a glvalue is the entity denoted by the expression.
 
 \pnum
-Whenever a glvalue expression appears as an operand of an operator that
+Whenever a glvalue appears as an operand of an operator that
 expects a prvalue for that operand, the
 lvalue-to-rvalue\iref{conv.lval}, array-to-pointer\iref{conv.array},
 or function-to-pointer\iref{conv.func} standard conversions are
@@ -192,8 +192,8 @@ An attempt to bind an rvalue reference to an lvalue is not such a context; see~\
 \begin{note}
 Because cv-qualifiers are removed from the type of an expression of
 non-class type when the expression is converted to a prvalue, an lvalue
-expression of type \tcode{const int} can, for example, be used where
-a prvalue expression of type \tcode{int} is required.
+of type \tcode{const int} can, for example, be used where
+a prvalue of type \tcode{int} is required.
 \end{note}
 \begin{note}
 There are no prvalue bit-fields; if a bit-field is converted to a
@@ -202,7 +202,7 @@ created, which might then be promoted\iref{conv.prom}.
 \end{note}
 
 \pnum
-Whenever a prvalue expression appears as an operand of an operator that
+Whenever a prvalue appears as an operand of an operator that
 expects a glvalue for that operand, the
 temporary materialization conversion\iref{conv.rval} is
 applied to convert the expression to an xvalue.
@@ -229,7 +229,7 @@ An lvalue is \defn{modifiable} unless its type is const-qualified
 or is a function type.
 \begin{note}
 A program that attempts
-to modify an object through a nonmodifiable lvalue expression or through an rvalue expression
+to modify an object through a nonmodifiable lvalue or through an rvalue
 is ill-formed~(\ref{expr.ass}, \ref{expr.post.incr}, \ref{expr.pre.incr}).
 \end{note}
 
@@ -2826,11 +2826,11 @@ of the program. Whether or not the destructor is called for the
 \tcode{std::type_info} object at the end of the program is unspecified.
 
 \pnum
-When \tcode{typeid} is applied to a glvalue expression whose type is a
+When \tcode{typeid} is applied to a glvalue whose type is a
 polymorphic class type\iref{class.virtual}, the result refers to a
 \tcode{std::type_info} object representing the type of the most derived
 object\iref{intro.object} (that is, the dynamic type) to which the
-glvalue refers. If the glvalue expression is obtained by applying the
+glvalue refers. If the glvalue is obtained by applying the
 unary \tcode{*} operator to a pointer\footnote{If \tcode{p} is an expression of
 pointer type, then \tcode{*p},
 \tcode{(*p)}, \tcode{*(p)}, \tcode{((*p))}, \tcode{*((p))}, and so on
@@ -3265,7 +3265,7 @@ yields the original pointer-to-member value.
 \pnum
 \indextext{cast!reinterpret!reference}%
 \indextext{cast!reference}%
-A glvalue expression of type \tcode{T1},
+A glvalue of type \tcode{T1},
 designating an object \placeholder{x},
 can be cast to the type ``reference to \tcode{T2}''
 if an expression of type ``pointer to \tcode{T1}''

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -270,7 +270,7 @@ the range of representable values for its type, the behavior is
 undefined.
 
 \pnum
-If \tcode{z} is an lvalue expression of type \cv{} \tcode{complex<T>} then:
+If \tcode{z} is an lvalue of type \cv{} \tcode{complex<T>} then:
 
 \begin{itemize}
 \item the expression \tcode{reinterpret_cast<\cv{} T(\&)[2]>(z)} shall be well-formed,

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16961,7 +16961,7 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
  the member typedef \tcode{type} equals \tcode{remove_cv_t<U>}.
  \begin{note} This behavior is similar to the lvalue-to-rvalue\iref{conv.lval},
  array-to-pointer\iref{conv.array}, and function-to-pointer\iref{conv.func}
- conversions applied when an lvalue expression is used as an rvalue, but also
+ conversions applied when an lvalue is used as an rvalue, but also
  strips \cv-qualifiers from class types in order to more closely model by-value
  argument passing. \end{note}
  \\ \rowsep


### PR DESCRIPTION
when calling out a value category.

Fixes #2069.