### PR TITLE
[dcl.init,over.match.ctor] Clarify copy-initialization for empty argu…

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -2759,19 +2759,15 @@ is called
 \begin{note} Copy-initialization may invoke a move\iref{class.copy}. \end{note}
 
 \pnum
-The initialization that occurs in the forms
-\begin{codeblock}
-T x(a);
-T x{a};
-\end{codeblock}
-as well as in
-\tcode{new}
-expressions\iref{expr.new},
-\tcode{static_cast}
-expressions\iref{expr.static.cast},
-functional notation type conversions\iref{expr.type.conv},
-\grammarterm{mem-initializer}{s}\iref{class.base.init}, and
-the \grammarterm{braced-init-list} form of a \grammarterm{condition}
+The initialization that occurs
+\begin{itemize}
+\item for an \grammarterm{initializer} that is a
+parenthesized \grammarterm{expression-list} or a \grammarterm{braced-init-list},
+\item for a \grammarterm{new-initializer}\iref{expr.new},
+\item in a \tcode{static_cast} expression\iref{expr.static.cast},
+\item in a functional notation type conversion\iref{expr.type.conv}, and
+\item in the \grammarterm{braced-init-list} form of a \grammarterm{condition}
+\end{itemize}
 is called
 \defn{direct-initialization}.
 

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -1219,7 +1219,8 @@ that is not in the context of copy-initialization, the
 candidate functions are
 all the constructors of the class of the object being
 initialized.
-For copy-initialization, the candidate functions are all
+For copy-initialization (including default initialization
+in the context of copy-initialization), the candidate functions are all
 the converting constructors\iref{class.conv.ctor} of that
 class.
 The argument list is the


### PR DESCRIPTION
…ments.

Also turn the enumeration of direct-initialization cases into
a bulleted list, referring to grammar non-terminals.

Fixes #1911.