### PR TITLE
[intro.abstract] Move \indextext under \pnum

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -477,8 +477,8 @@ value is not used and that no
 side effects affecting the
 observable behavior of the program are produced.}
 
-\indextext{behavior!implementation-defined}%
 \pnum
+\indextext{behavior!implementation-defined}%
 Certain aspects and operations of the abstract machine are described in this
 document as implementation-defined (for example,
 \tcode{sizeof(int)}). These constitute the parameters of the abstract machine.
@@ -489,8 +489,8 @@ See~\ref{intro.compliance}.} Such documentation shall define the instance of the
 abstract machine that corresponds to that implementation (referred to as the
 ``corresponding instance'' below).
 
-\indextext{behavior!unspecified}%
 \pnum
+\indextext{behavior!unspecified}%
 Certain other aspects and operations of the abstract machine are
 described in this document as unspecified (for example,
 order of evaluation of arguments in a function call\iref{expr.call}).
@@ -500,17 +500,17 @@ define the nondeterministic aspects of the abstract machine. An instance
 of the abstract machine can thus have more than one possible execution
 for a given program and a given input.
 
-\indextext{behavior!undefined}%
 \pnum
+\indextext{behavior!undefined}%
 Certain other operations are described in this document as
 undefined (for example, the effect of
 attempting to modify a const object).
 \begin{note} This document imposes no requirements on the
 behavior of programs that contain undefined behavior. \end{note}
 
+\pnum
 \indextext{program!well-formed}%
 \indextext{behavior!observable}%
-\pnum
 A conforming implementation executing a well-formed program shall
 produce the same observable behavior as one of the possible executions
 of the corresponding instance of the abstract machine with the
@@ -521,8 +521,8 @@ requirement on the implementation executing that program with that input
 (not even with regard to operations preceding the first undefined
 operation).
 
-\indextext{conformance requirements}
 \pnum
+\indextext{conformance requirements}%
 The least requirements on a conforming implementation are:
 \begin{itemize}
 \item


### PR DESCRIPTION
Currently index entries point to the end of the previous paragraph, see pic. ![image](https://user-images.githubusercontent.com/38548419/40606617-95168154-626e-11e8-87e9-7b491efaedfe.png)