### PR TITLE
[over.match.viable] Fix cross-reference to satisfaction of constraints

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -1585,8 +1585,8 @@ parameters.
 \end{itemize}
 
 \pnum
-Second, for a function to be viable, if it has associated constraints,
-those constraints shall be satisfied\iref{temp.constr.decl}.
+Second, for a function to be viable, if it has associated constraints\iref{temp.constr.decl},
+those constraints shall be satisfied\iref{temp.constr.constr}.
 
 \pnum
 Third, for


### PR DESCRIPTION
Right now, the cross-reference is not really pointing to the right place.