### PR TITLE
[fs.path.append] Fix examples to show correct results for Windows

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -11861,21 +11861,23 @@ Otherwise, modifies \tcode{*this} as if by these steps:
 \begin{example}
 Even if \tcode{//host} is interpreted as a \grammarterm{root-name},
 both of the paths \tcode{path("//host")/"foo"} and \tcode{path("//host/")/"foo"}
-equal \tcode{"//host/foo"}.
+equal \tcode{"//host/foo"} (although the former might use backslash as the
+preferred separator).
 
 Expression examples:
 \begin{codeblock}
 // On POSIX,
-path("foo") / "";     // yields \tcode{"foo/"}
-path("foo") / "/bar"; // yields \tcode{"/bar"}
-// On Windows, backslashes replace slashes in the above yields
+path("foo") /= path("");        // yields \tcode{path("foo/")}
+path("foo") /= path("/bar");    // yields \tcode{path("/bar")}
 
 // On Windows,
-path("foo") / "c:/bar";  // yields \tcode{"c:/bar"}
-path("foo") / "c:";      // yields \tcode{"c:"}
-path("c:") / "";         // yields \tcode{"c:"}
-path("c:foo") / "/bar";  // yields \tcode{"c:/bar"}
-path("c:foo") / "c:bar"; // yields \tcode{"c:foo/bar"}
+path("foo") /= path("");        // yields \tcode{path("foo\textbackslash\textbackslash{}")}
+path("foo") /= path("/bar");    // yields \tcode{path("/bar")}
+path("foo") /= path("c:/bar");  // yields \tcode{path("c:/bar")}
+path("foo") /= path("c:");      // yields \tcode{path("c:")}
+path("c:") /= path("");         // yields \tcode{path("c:")}
+path("c:foo") /= path("/bar");  // yields \tcode{path("c:/bar")}
+path("c:foo") /= path("c:bar"); // yields \tcode{path("c:foo\textbackslash\textbackslash{}bar")}
 \end{codeblock}
 \end{example}
 


### PR DESCRIPTION
The examples for path::append show the wrong results for Windows, not matching the description of the function. This has been discussed with Billy O'Neal who confirmed the correct results.