### PR TITLE
[container.list/forward_list] fix missing 'to' in 'referred [to] by'

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -3852,11 +3852,11 @@ namespace std {
     void splice_after(const_iterator position, forward_list&& x,
                       const_iterator first, const_iterator last);
 
-    void remove(const T& value);
-    template<class Predicate> void remove_if(Predicate pred);
+    size_type remove(const T& value);
+    template<class Predicate> size_type remove_if(Predicate pred);
 
-    void unique();
-    template<class BinaryPredicate> void unique(BinaryPredicate binary_pred);
+    size_type unique();
+    template<class BinaryPredicate> size_type unique(BinaryPredicate binary_pred);
 
     void merge(forward_list& x);
     void merge(forward_list&& x);
@@ -4297,8 +4297,8 @@ behave as iterators into \tcode{*this}, not into \tcode{x}.
 \indexlibrarymember{remove}{forward_list}%
 \indexlibrarymember{remove_if}{forward_list}%
 \begin{itemdecl}
-void remove(const T& value);
-template<class Predicate> void remove_if(Predicate pred);
+size_type remove(const T& value);
+template<class Predicate> size_type remove_if(Predicate pred);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4307,6 +4307,9 @@ template<class Predicate> void remove_if(Predicate pred);
 which the following conditions hold: \tcode{*i == value} (for \tcode{remove()}),
 \tcode{pred(*i)} is \tcode{true} (for \tcode{remove_if()}).
 Invalidates only the iterators and references to the erased elements.
+
+\pnum
+\returns The number of erased elements.
 
 \pnum
 \throws Nothing unless an exception is thrown by the equality comparison or the
@@ -4322,8 +4325,8 @@ predicate.
 
 \indexlibrarymember{unique}{forward_list}%
 \begin{itemdecl}
-void unique();
-template<class BinaryPredicate> void unique(BinaryPredicate pred);
+size_type unique();
+template<class BinaryPredicate> size_type unique(BinaryPredicate pred);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4333,6 +4336,9 @@ group of equal elements referred to by the iterator \tcode{i} in the range \rang
 1}{last} for which \tcode{*i == *(i-1)} (for the version with no arguments) or \tcode{pred(*i,
 *(i - 1))} (for the version with a predicate argument) holds.
 Invalidates only the iterators and references to the erased elements.
+
+\pnum
+\returns The number of erased elements.
 
 \pnum
 \throws Nothing unless an exception is thrown by the equality comparison or the predicate.
@@ -4543,12 +4549,12 @@ namespace std {
     void splice(const_iterator position, list& x, const_iterator first, const_iterator last);
     void splice(const_iterator position, list&& x, const_iterator first, const_iterator last);
 
-    void remove(const T& value);
-    template<class Predicate> void remove_if(Predicate pred);
+    size_type remove(const T& value);
+    template<class Predicate> size_type remove_if(Predicate pred);
 
-    void unique();
+    size_type unique();
     template<class BinaryPredicate>
-      void unique(BinaryPredicate binary_pred);
+      size_type unique(BinaryPredicate binary_pred);
 
     void merge(list& x);
     void merge(list&& x);
@@ -4930,8 +4936,8 @@ otherwise, linear time.
 
 \indexlibrary{\idxcode{remove}!\idxcode{list}}%
 \begin{itemdecl}
-void remove(const T& value);
-template<class Predicate> void remove_if(Predicate pred);
+size_type remove(const T& value);
+template<class Predicate> size_type remove_if(Predicate pred);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4940,6 +4946,10 @@ template<class Predicate> void remove_if(Predicate pred);
 Erases all the elements in the list referred to by a list iterator \tcode{i} for which the
 following conditions hold: \tcode{*i == value}, \tcode{pred(*i) != false}.
 Invalidates only the iterators and references to the erased elements.
+
+\pnum
+\returns
+The number of erased elements.
 
 \pnum
 \throws
@@ -4960,8 +4970,8 @@ applications of the corresponding predicate.
 
 \indexlibrary{\idxcode{unique}!\idxcode{list}}%
 \begin{itemdecl}
-void unique();
-template<class BinaryPredicate> void unique(BinaryPredicate binary_pred);
+size_type unique();
+template<class BinaryPredicate> size_type unique(BinaryPredicate binary_pred);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4973,6 +4983,10 @@ consecutive group of equal elements referred to by the iterator \tcode{i} in the
 \tcode{unique} with no arguments) or \tcode{pred(*i, *(i - 1))} (for the version of
 \tcode{unique} with a predicate argument) holds.
 Invalidates only the iterators and references to the erased elements.
+
+\pnum
+\returns
+The number of erased elements.
 
 \pnum
 \throws

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -4303,7 +4303,7 @@ template<class Predicate> void remove_if(Predicate pred);
 
 \begin{itemdescr}
 \pnum
-\effects Erases all the elements in the list referred by a list iterator \tcode{i} for
+\effects Erases all the elements in the list referred to by a list iterator \tcode{i} for
 which the following conditions hold: \tcode{*i == value} (for \tcode{remove()}),
 \tcode{pred(*i)} is \tcode{true} (for \tcode{remove_if()}).
 Invalidates only the iterators and references to the erased elements.
@@ -4937,7 +4937,7 @@ template<class Predicate> void remove_if(Predicate pred);
 \begin{itemdescr}
 \pnum
 \effects
-Erases all the elements in the list referred by a list iterator \tcode{i} for which the
+Erases all the elements in the list referred to by a list iterator \tcode{i} for which the
 following conditions hold: \tcode{*i == value}, \tcode{pred(*i) != false}.
 Invalidates only the iterators and references to the erased elements.
 


### PR DESCRIPTION
It's present in all other clauses of that form in this section.