### PR TITLE
[(forward)list.modifiers] fix missing 'to' in 'referred [to] by'

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -4303,7 +4303,7 @@ template<class Predicate> void remove_if(Predicate pred);
 
 \begin{itemdescr}
 \pnum
-\effects Erases all the elements in the list referred by a list iterator \tcode{i} for
+\effects Erases all the elements in the list referred to by a list iterator \tcode{i} for
 which the following conditions hold: \tcode{*i == value} (for \tcode{remove()}),
 \tcode{pred(*i)} is \tcode{true} (for \tcode{remove_if()}).
 Invalidates only the iterators and references to the erased elements.
@@ -4937,7 +4937,7 @@ template<class Predicate> void remove_if(Predicate pred);
 \begin{itemdescr}
 \pnum
 \effects
-Erases all the elements in the list referred by a list iterator \tcode{i} for which the
+Erases all the elements in the list referred to by a list iterator \tcode{i} for which the
 following conditions hold: \tcode{*i == value}, \tcode{pred(*i) != false}.
 Invalidates only the iterators and references to the erased elements.
 


### PR DESCRIPTION
It's present in all other clauses of that form in this chapter.