### PR TITLE
[time.zone.db.remote] replace "this section" with "this subclause"

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -26472,7 +26472,7 @@ for example via \tcode{current_zone()}.
 While the program is running,
 the implementation may choose to update the time zone database.
 This update shall not impact the program in any way
-unless the program calls the functions in this section.
+unless the program calls the functions in this subclause.
 This potentially updated time zone database
 is referred to as the \defn{remote time zone database}.
 


### PR DESCRIPTION
ISO directives say we need to refer to subclauses not sections or chapters or anything else.