### PR TITLE
[dcl.mptr] Add index entry for pointer to member clause

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -835,7 +835,8 @@ see~\ref{dcl.fct}.
 \end{note}
 
 \rSec2[dcl.mptr]{Pointers to members}%
-\indextext{declarator!pointer-to-member}
+\indextext{declarator!pointer-to-member}%
+\indextext{pointer to member}%
 
 \pnum
 In a declaration


### PR DESCRIPTION
There is already an index entry for 'pointer to member', but
it does not point to 11.3.3 [dcl.mptr] that provides the rules
for the declarator.  This bit me just today when I could not
find the magic words to find exactly this clause, so adding
an extra reference under the existing index entry.