### PR TITLE
[span.overview] fix reverse_iterator for span

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -9770,8 +9770,8 @@ namespace std {
     using reference = element_type&;
     using iterator = @\impdefx{type of \tcode{span::iterator}}@;
     using const_iterator = @\impdefx{type of \tcode{span::const_iterator}}@;
-    using reverse_iterator = reverse_iterator<iterator>;
-    using const_reverse_iterator = reverse_iterator<const_iterator>;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
     static constexpr index_type extent = Extent;
 
     // \ref{span.cons}, constructors, copy, and assignment


### PR DESCRIPTION
There is a common convention to omit 'std::' when not strictly needed,
other than for 'std::move' and 'std::forward'.  A third case is for
'reverse_iterator' and 'const_reverse_iterator' type aliases inside a
class definition, as the leading 'reverse_iterator' type alias hides
the 'std' version from the 'const_reverse_iterator' definition, and
subsequently fails to compile.  This patch restore the class definition
to a safely copy/pastable state.

An additional review indicated this convention has been applied correctly
for every othert potential occurrence in the library.