### PR TITLE
P1025R1 Update the reference to the Unicode standard

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -2673,7 +2673,7 @@ For the facet \tcode{codecvt_utf8}\indexlibrary{\idxcode{codecvt_utf8}}:
 \begin{itemize}
 \item
   The facet shall convert between UTF-8 multibyte sequences
-  and UCS2 or UCS4 (depending on the size of \tcode{Elem})
+  and UCS2 or UTF-32 (depending on the size of \tcode{Elem})
   within the program.
 \item
   Endianness shall not affect how multibyte sequences are read or written.
@@ -2686,7 +2686,7 @@ For the facet \tcode{codecvt_utf16}\indexlibrary{\idxcode{codecvt_utf16}}:
 \begin{itemize}
 \item
   The facet shall convert between UTF-16 multibyte sequences
-  and UCS2 or UCS4 (depending on the size of \tcode{Elem})
+  and UCS2 or UTF-32 (depending on the size of \tcode{Elem})
   within the program.
 \item
   Multibyte sequences shall be read or written

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -50,6 +50,8 @@ Information interchange --- Representation of dates and times}
 \item ISO/IEC 9899:2011, \doccite{Programming languages --- C}
 \item ISO/IEC 9945:2003, \doccite{Information Technology --- Portable
 Operating System Interface (POSIX)}
+\item ISO/IEC 10646, \doccite{Information technology ---
+Universal Coded Character Set (UCS)}
 \item ISO/IEC 10646-1:1993, \doccite{Information technology ---
 Universal Multiple-Octet Coded Character Set (UCS) --- Part 1:
 Architecture and Basic Multilingual Plane}
@@ -76,6 +78,12 @@ hereinafter called \defn{POSIX}.
 The ECMAScript Language Specification described in Standard Ecma-262 is
 hereinafter called \defn{ECMA-262}.
 \indextext{references!normative|)}
+
+\pnum
+\begin{note}
+References to ISO/IEC 10646-1:1993 are used only
+to support deprecated features\iref{depr.locale.stdcvt}.
+\end{note}
 
 \rSec0[intro.defs]{Terms and definitions}
 


### PR DESCRIPTION
Changes were applied to [depr.locale.stdcvt.req] instead of
[depr.locale.stdcvt].

Fixes #2120.