### PR TITLE
P0929R2 Checking for abstract class types

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -262,8 +262,11 @@ A class name can also be implicitly declared by an
 
 \pnum
 \indextext{type!incomplete}%
-A program is ill-formed if the definition of any object gives the object
-an incomplete type\iref{basic.types}.
+In the definition of an object,
+the type of that object shall not be
+an incomplete type\iref{basic.types},
+an abstract class type\iref{class.abstract}, or
+a (possibly multi-dimensional) array thereof.
 
 \indextext{object!definition}%
 \indextext{function!definition}%

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -649,10 +649,15 @@ function\iref{class.virtual}.
 
 \pnum
 \indextext{class object!member}%
-Non-static data members shall not have
-incomplete types. In particular, a class \tcode{C} shall not contain a
-non-static member of class \tcode{C}, but it can contain a pointer or
-reference to an object of class \tcode{C}.
+The type of a non-static data member shall not be an
+incomplete type\iref{basic.types},
+an abstract class type\iref{class.abstract},
+or a (possibly multi-dimensional) array thereof.
+\begin{note}
+In particular, a class \tcode{C} cannot contain
+a non-static member of class \tcode{C},
+but it can contain a pointer or reference to an object of class \tcode{C}.
+\end{note}
 
 \pnum
 \begin{note}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1413,7 +1413,7 @@ in~\ref{dcl.spec.auto}.
 If the operand of a \grammarterm{decltype-specifier} is a prvalue,
 the temporary materialization conversion is not applied\iref{conv.rval}
 and no result object is provided for the prvalue.
-The type of the prvalue may be incomplete.
+The type of the prvalue may be incomplete or an abstract class type.
 \begin{note}
 As a result, storage is not allocated for the prvalue and it is not destroyed.
 Thus, a class type is not instantiated

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -1478,12 +1478,6 @@ to functions.
 
 \pnum
 Types shall not be defined in return or parameter types.
-The type of a parameter or the return type for a function
-definition shall not be an incomplete or abstract
-(possibly cv-qualified) class type
-in the context of the function definition
-unless the function is
-deleted\iref{dcl.fct.def.delete}.
 
 \pnum
 \indextext{typedef!function}%
@@ -1989,6 +1983,11 @@ or \grammarterm{declarator} \tcode{;}
 shall be a well-formed function declaration
 as described in~\ref{dcl.fct}.
 A function shall be defined only in namespace or class scope.
+The type of a parameter or the return type for a function
+definition shall not be
+an incomplete or abstract (possibly cv-qualified) class type
+in the context of the function definition
+unless the function is deleted\iref{dcl.fct.def.delete}.
 
 \pnum
 \begin{example}

--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -972,7 +972,7 @@ the program is ill-formed.
 is called the array
 \term{element type};
 this type shall not be a reference type, \cv{}~\tcode{void},
-a function type or an abstract class type.
+or a function type.
 \indextext{declaration!array}%
 If the
 \grammarterm{constant-expression}\iref{expr.const}
@@ -1479,7 +1479,7 @@ to functions.
 \pnum
 Types shall not be defined in return or parameter types.
 The type of a parameter or the return type for a function
-definition shall not be an incomplete
+definition shall not be an incomplete or abstract
 (possibly cv-qualified) class type
 in the context of the function definition
 unless the function is

--- a/source/derived.tex
+++ b/source/derived.tex
@@ -922,16 +922,21 @@ provide a variety of implementations.
 \end{note}
 
 \pnum
-An \defnx{abstract class}{class!abstract} is a class that can be used only
-as a base class of some other class; no objects of an abstract class can
-be created except as subobjects of a class derived from it. A class is
-abstract if it has at least one \term{pure virtual function}.
+A virtual function is specified as
+a \defnx{pure virtual function}{function!virtual!pure} by using a
+\grammarterm{pure-specifier}\iref{class.mem} in the function declaration
+in the class definition.
 \begin{note}
 Such a function might be inherited: see below.
 \end{note}
-A virtual function is specified \defnx{pure}{function!virtual!pure} by using a
-\grammarterm{pure-specifier}\iref{class.mem} in the function declaration
-in the class definition.
+A class is an \defnx{abstract class}{class!abstract}
+if it has at least one pure virtual function.
+\begin{note}
+An abstract class can be used only as a base class of some other class;
+no objects of an abstract class can be created
+except as subobjects of a class
+derived from it~(\ref{basic.def}, \ref{class.mem}).
+\end{note}
 \indextext{definition!pure virtual function}%
 A pure virtual function need be defined only if called with, or as if
 with\iref{class.dtor}, the \grammarterm{qualified-id}
@@ -962,19 +967,18 @@ struct C {
 \end{example}
 
 \pnum
-\indextext{class!pointer to abstract}%
-An abstract class shall not be used as a parameter type, as a function
-return type, or as the type of an explicit conversion. Pointers and
-references to an abstract class can be declared.
-\begin{example}
-\begin{codeblock}
-shape x;                        // error: object of abstract class
-shape* p;                       // OK
-shape f();                      // error
-void g(shape);                  // error
-shape& h(shape&);               // OK
-\end{codeblock}
-\end{example}
+\begin{note}
+An abstract class type cannot be used
+as a parameter or return type of
+a function being defined\iref{dcl.fct} or called\iref{expr.call},
+except as specified in \ref{dcl.type.simple}.
+Further, an abstract class type cannot be used as
+the type of an explicit type conversion~(\ref{expr.static.cast},
+\ref{expr.reinterpret.cast}, \ref{expr.const.cast}),
+because the resulting prvalue would be of abstract class type\iref{basic.lval}.
+However, pointers and references to abstract class types
+can appear in such contexts.
+\end{note}
 
 \pnum
 \indextext{function!virtual!pure}%

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -260,9 +260,11 @@ called the
 An lvalue denoting the temporary is used to initialize the
 variable declared in the matching
 \grammarterm{handler}\iref{except.handle}.
-If the type of the exception object would
-be an incomplete type or a pointer to an incomplete
-type other than \cv{}~\tcode{void} the program is ill-formed.
+If the type of the exception object would be
+an incomplete type,
+an abstract class type\iref{class.abstract},
+or a pointer to an incomplete type other than \cv{}~\tcode{void}
+the program is ill-formed.
 
 \pnum
 \indextext{exception handling!memory}%

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -213,8 +213,10 @@ temporaries in~\ref{class.temporary} indicates the behavior of lvalues
 and rvalues in other significant contexts.
 
 \pnum
-Unless otherwise indicated\iref{expr.call},
-a prvalue shall always have complete type or the \tcode{void} type.
+Unless otherwise indicated\iref{dcl.type.simple},
+a prvalue shall always have complete type or the \tcode{void} type;
+if it has a class type or (possibly multi-dimensional) array of class type,
+that class shall not be an abstract class\iref{class.abstract}.
 A glvalue shall not have type \cv{}~\tcode{void}.
 \begin{note}
 A glvalue may have complete or incomplete non-\tcode{void} type.
@@ -2264,12 +2266,12 @@ class member access operator.
 See~\ref{class.member.lookup}, \ref{class.access.base},
 and~\ref{expr.ref}.
 \end{note}
-When a function is called, the parameters that have object type shall
-have completely-defined object type.
+When a function is called, the type of any parameter
+shall not be a class type that is either incomplete or abstract.
 \begin{note}
-this still allows a parameter to be a pointer or reference to an
-incomplete class type. However, it prevents a passed-by-value parameter
-to have an incomplete class type.
+This still allows a parameter to be a pointer or reference to such
+a type. However, it prevents a passed-by-value parameter
+to have an incomplete or abstract class type.
 \end{note}
 It is \impldef{whether the lifetime of a parameter ends when the callee
 returns or at the end of the enclosing full-expression} whether the

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -7282,7 +7282,7 @@ Type deduction may fail for the following reasons:
 \item Attempting to instantiate a pack expansion containing multiple packs of differing lengths.
 \item
 Attempting to create an array with an element type that is \tcode{void}, a
-function type, a reference type, or an abstract class type, or attempting
+function type, or a reference type, or attempting
 to create an array with a size that is zero or negative.
 \begin{example}
 \begin{codeblock}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -7376,10 +7376,6 @@ int i2 = f<int,1>(0);           // can't conv \tcode{1} to \tcode{int*}
 Attempting to create a function type in which a parameter has a type
 of \tcode{void}, or in which the return type is a function type
 or array type.
-
-\item
-Attempting to create a function type in which a parameter type or the return type is an
-abstract class type\iref{class.abstract}.
 \end{itemize}
 \end{note}
 


### PR DESCRIPTION
Added cross-reference from the new use of 'abstract class
type' in [except.throw], pointing to [class.abstract].

Fixes #2117.