### PR TITLE
P1023R0 constexpr comparison operators for std::array

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -2965,17 +2965,17 @@ namespace std {
   template<class T, size_t N> struct array;
 
   template<class T, size_t N>
-    bool operator==(const array<T, N>& x, const array<T, N>& y);
+    constexpr bool operator==(const array<T, N>& x, const array<T, N>& y);
   template<class T, size_t N>
-    bool operator!=(const array<T, N>& x, const array<T, N>& y);
+    constexpr bool operator!=(const array<T, N>& x, const array<T, N>& y);
   template<class T, size_t N>
-    bool operator< (const array<T, N>& x, const array<T, N>& y);
+    constexpr bool operator< (const array<T, N>& x, const array<T, N>& y);
   template<class T, size_t N>
-    bool operator> (const array<T, N>& x, const array<T, N>& y);
+    constexpr bool operator> (const array<T, N>& x, const array<T, N>& y);
   template<class T, size_t N>
-    bool operator<=(const array<T, N>& x, const array<T, N>& y);
+    constexpr bool operator<=(const array<T, N>& x, const array<T, N>& y);
   template<class T, size_t N>
-    bool operator>=(const array<T, N>& x, const array<T, N>& y);
+    constexpr bool operator>=(const array<T, N>& x, const array<T, N>& y);
   template<class T, size_t N>
     void swap(array<T, N>& x, array<T, N>& y) noexcept(noexcept(x.swap(y)));
 


### PR DESCRIPTION
Fixes #2135 