### PR TITLE
P0935R0 Eradicating unnecessarily explicit default constructors from the standard library

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -8979,8 +8979,9 @@ namespace std {
     Container c;
 
   public:
+    queue() : queue(Container()) {}
     explicit queue(const Container&);
-    explicit queue(Container&& = Container());
+    explicit queue(Container&&);
     template<class Alloc> explicit queue(const Alloc&);
     template<class Alloc> queue(const Container&, const Alloc&);
     template<class Alloc> queue(Container&&, const Alloc&);
@@ -9030,7 +9031,7 @@ explicit queue(const Container& cont);
 \end{itemdescr}
 
 \begin{itemdecl}
-explicit queue(Container&& cont = Container());
+explicit queue(Container&& cont);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9228,8 +9229,10 @@ namespace std {
     Compare comp;
 
   public:
+    priority_queue() : priority_queue(Compare()) {}
+    explicit priority_queue(const Compare& x) : priority_queue(x, Container()) {}
     priority_queue(const Compare& x, const Container&);
-    explicit priority_queue(const Compare& x = Compare(), Container&& = Container());
+    priority_queue(const Compare& x, Container&&);
     template<class InputIterator>
       priority_queue(InputIterator first, InputIterator last, const Compare& x,
                      const Container&);
@@ -9286,7 +9289,7 @@ namespace std {
 \indexlibrary{\idxcode{priority_queue}!constructor}%
 \begin{itemdecl}
 priority_queue(const Compare& x, const Container& y);
-explicit priority_queue(const Compare& x = Compare(), Container&& y = Container());
+priority_queue(const Compare& x, Container&& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9524,8 +9527,9 @@ namespace std {
     Container c;
 
   public:
+    stack() : stack(Container()) {}
     explicit stack(const Container&);
-    explicit stack(Container&& = Container());
+    explicit stack(Container&&);
     template<class Alloc> explicit stack(const Alloc&);
     template<class Alloc> stack(const Container&, const Alloc&);
     template<class Alloc> stack(Container&&, const Alloc&);
@@ -9572,7 +9576,7 @@ explicit stack(const Container& cont);
 
 \indexlibrary{\idxcode{stack}!constructor}%
 \begin{itemdecl}
-explicit stack(Container&& cont = Container());
+explicit stack(Container&& cont);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/future.tex
+++ b/source/future.tex
@@ -377,7 +377,8 @@ namespace std {
 namespace std {
   class strstreambuf : public basic_streambuf<char> {
   public:
-    explicit strstreambuf(streamsize alsize_arg = 0);
+    strstreambuf() : strstreambuf(0) {}
+    explicit strstreambuf(streamsize alsize_arg);
     strstreambuf(void* (*palloc_arg)(size_t), void (*pfree_arg)(void*));
     strstreambuf(char* gnext_arg, streamsize n, char* pbeg_arg = nullptr);
     strstreambuf(const char* gnext_arg, streamsize n);
@@ -486,7 +487,7 @@ if \tcode{pend} is not a null pointer, or \tcode{gend}.
 
 \indexlibrary{\idxcode{strstreambuf}!constructor}%
 \begin{itemdecl}
-explicit strstreambuf(streamsize alsize_arg = 0);
+explicit strstreambuf(streamsize alsize_arg);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2798,7 +2799,8 @@ namespace std {
       using state_type  = typename Codecvt::state_type;
       using int_type    = typename wide_string::traits_type::int_type;
 
-      explicit wstring_convert(Codecvt* pcvt = new Codecvt);
+      wstring_convert() : wstring_convert(new Codecvt) {}
+      explicit wstring_convert(Codecvt* pcvt);
       wstring_convert(Codecvt* pcvt, state_type state);
       explicit wstring_convert(const byte_string& byte_err,
                                const wide_string& wide_err = wide_string());
@@ -2992,7 +2994,7 @@ char_traits<Elem>, Wide_alloc>}.
 
 \indexlibrary{\idxcode{wstring_convert}!constructor}%
 \begin{itemdecl}
-explicit wstring_convert(Codecvt* pcvt = new Codecvt);
+explicit wstring_convert(Codecvt* pcvt);
 wstring_convert(Codecvt* pcvt, state_type state);
 explicit wstring_convert(const byte_string& byte_err,
     const wide_string& wide_err = wide_string());
@@ -3046,7 +3048,8 @@ namespace std {
     public:
       using state_type = typename Codecvt::state_type;
 
-      explicit wbuffer_convert(streambuf* bytebuf = nullptr,
+      wbuffer_convert() : wbuffer_convert(nullptr) {}
+      explicit wbuffer_convert(streambuf* bytebuf,
                                Codecvt* pcvt = new Codecvt,
                                state_type state = state_type());
 
@@ -3133,7 +3136,7 @@ The type shall be a synonym for \tcode{Codecvt::state_type}.
 \indexlibrary{\idxcode{wbuffer_convert}!constructor}%
 \begin{itemdecl}
 explicit wbuffer_convert(
-    streambuf* bytebuf = nullptr,
+    streambuf* bytebuf,
     Codecvt* pcvt = new Codecvt,
     state_type state = state_type());
 \end{itemdecl}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -7371,8 +7371,8 @@ namespace std {
     using allocator_type = Allocator;
 
     // \ref{stringbuf.cons}, constructors
-    explicit basic_stringbuf(
-      ios_base::openmode which = ios_base::in | ios_base::out);
+    basic_stringbuf() : basic_stringbuf(ios_base::in | ios_base::out) {}
+    explicit basic_stringbuf(ios_base::openmode which);
     explicit basic_stringbuf(
       const basic_string<charT, traits, Allocator>& str,
       ios_base::openmode which = ios_base::in | ios_base::out);
@@ -7439,8 +7439,7 @@ set if the output sequence can be written.
 
 \indexlibrary{\idxcode{basic_stringbuf}!constructor}%
 \begin{itemdecl}
-explicit basic_stringbuf(
-  ios_base::openmode which = ios_base::in | ios_base::out);
+explicit basic_stringbuf(ios_base::openmode which);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7891,8 +7890,8 @@ namespace std {
     using allocator_type = Allocator;
 
     // \ref{istringstream.cons}, constructors
-    explicit basic_istringstream(
-      ios_base::openmode which = ios_base::in);
+    basic_istringstream() : basic_istringstream(ios_base::in) {}
+    explicit basic_istringstream(ios_base::openmode which);
     explicit basic_istringstream(
       const basic_string<charT, traits, Allocator>& str,
       ios_base::openmode which = ios_base::in);
@@ -7937,7 +7936,7 @@ For the sake of exposition, the maintained data is presented here as:
 
 \indexlibrary{\idxcode{basic_istringstream}!constructor}%
 \begin{itemdecl}
-explicit basic_istringstream(ios_base::openmode which = ios_base::in);
+explicit basic_istringstream(ios_base::openmode which);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8078,8 +8077,8 @@ namespace std {
     using allocator_type = Allocator;
 
     // \ref{ostringstream.cons}, constructors
-    explicit basic_ostringstream(
-      ios_base::openmode which = ios_base::out);
+    basic_ostringstream() : basic_ostringstream(ios_base::out) {}
+    explicit basic_ostringstream(ios_base::openmode which);
     explicit basic_ostringstream(
       const basic_string<charT, traits, Allocator>& str,
       ios_base::openmode which = ios_base::out);
@@ -8124,8 +8123,7 @@ For the sake of exposition, the maintained data is presented here as:
 
 \indexlibrary{\idxcode{basic_ostringstream}!constructor}%
 \begin{itemdecl}
-explicit basic_ostringstream(
-  ios_base::openmode which = ios_base::out);
+explicit basic_ostringstream(ios_base::openmode which);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8266,8 +8264,8 @@ namespace std {
     using allocator_type = Allocator;
 
     // \ref{stringstream.cons}, constructors
-    explicit basic_stringstream(
-      ios_base::openmode which = ios_base::out | ios_base::in);
+    basic_stringstream() : basic_stringstream(ios_base::out | ios_base::in) {}
+    explicit basic_stringstream(ios_base::openmode which);
     explicit basic_stringstream(
       const basic_string<charT, traits, Allocator>& str,
       ios_base::openmode which = ios_base::out | ios_base::in);
@@ -8313,8 +8311,7 @@ For the sake of exposition, the maintained data is presented here as
 
 \indexlibrary{\idxcode{basic_stringstream}!constructor}%
 \begin{itemdecl}
-explicit basic_stringstream(
-  ios_base::openmode which = ios_base::out | ios_base::in);
+explicit basic_stringstream(ios_base::openmode which);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -2913,7 +2913,8 @@ template<class UIntType, UIntType a, UIntType c, UIntType m>
     static constexpr result_type default_seed = 1u;
 
     // constructors and seeding functions
-    explicit linear_congruential_engine(result_type s = default_seed);
+    linear_congruential_engine() : linear_congruential_engine(default_seed) {}
+    explicit linear_congruential_engine(result_type s);
     template<class Sseq> explicit linear_congruential_engine(Sseq& q);
     void seed(result_type s = default_seed);
     template<class Sseq> void seed(Sseq& q);
@@ -2951,7 +2952,7 @@ the value of \state{x}{i}.
 
 \indexlibrary{\idxcode{linear_congruential_engine}!constructor}%
 \begin{itemdecl}
-explicit linear_congruential_engine(result_type s = default_seed);
+explicit linear_congruential_engine(result_type s);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3081,7 +3082,8 @@ template<class UIntType, size_t w, size_t n, size_t m, size_t r,
     static constexpr result_type default_seed = 5489u;
 
     // constructors and seeding functions
-    explicit mersenne_twister_engine(result_type value = default_seed);
+    mersenne_twister_engine() : mersenne_twister_engine(default_seed) {}
+    explicit mersenne_twister_engine(result_type value);
     template<class Sseq> explicit mersenne_twister_engine(Sseq& q);
     void seed(result_type value = default_seed);
     template<class Sseq> void seed(Sseq& q);
@@ -3119,7 +3121,7 @@ in that order.
 
 \indexlibrary{\idxcode{mersenne_twister_engine}!constructor}%
 \begin{itemdecl}
-explicit mersenne_twister_engine(result_type value = default_seed);
+explicit mersenne_twister_engine(result_type value);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3238,7 +3240,8 @@ template<class UIntType, size_t w, size_t s, size_t r>
     static constexpr result_type default_seed = 19780503u;
 
     // constructors and seeding functions
-    explicit subtract_with_carry_engine(result_type value = default_seed);
+    subtract_with_carry_engine() : subtract_with_carry_engine(default_seed) {}
+    explicit subtract_with_carry_engine(result_type value);
     template<class Sseq> explicit subtract_with_carry_engine(Sseq& q);
     void seed(result_type value = default_seed);
     template<class Sseq> void seed(Sseq& q);
@@ -3268,7 +3271,7 @@ in that order, followed by $c$.
 
 \indexlibrary{\idxcode{subtract_with_carry_engine}!constructor}%
 \begin{itemdecl}
-explicit subtract_with_carry_engine(result_type value = default_seed);
+explicit subtract_with_carry_engine(result_type value);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3952,7 +3955,8 @@ public:
   static constexpr result_type max() { return numeric_limits<result_type>::max(); }
 
   // constructors
-  explicit random_device(const string& token = @\textit{implementation-defined}@);
+  random_device() : random_device(@\textit{implementation-defined}@) {}
+  explicit random_device(const string& token);
 
   // generating functions
   result_type operator()();
@@ -3969,15 +3973,15 @@ public:
 
 \indexlibrary{\idxcode{random_device}!constructor}%
 \begin{itemdecl}
-explicit random_device(const string& token = @\textit{implementation-defined}@);
+explicit random_device(const string& token);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum\effects Constructs a \tcode{random_device}
  nondeterministic uniform random bit generator object.
- The semantics and default value of the \tcode{token}
- parameter are
- \impldef{semantics and default value of \tcode{token} parameter to \tcode{random_device} constructor}.%
+ The semantics of the \tcode{token} parameter
+ and the token value used by the default constructor are
+ \impldef{semantics of \tcode{token} parameter and default token value used by \tcode{random_device} constructors}.%
 \footnote{The parameter is intended
    to allow an implementation to differentiate
    between different sources of randomness.
@@ -4413,7 +4417,8 @@ template<class IntType = int>
     using param_type  = @\unspec@;
 
     // constructors and reset functions
-    explicit uniform_int_distribution(IntType a = 0, IntType b = numeric_limits<IntType>::max());
+    uniform_int_distribution() : uniform_int_distribution(0) {}
+    explicit uniform_int_distribution(IntType a, IntType b = numeric_limits<IntType>::max());
     explicit uniform_int_distribution(const param_type& parm);
     void reset();
 
@@ -4436,7 +4441,7 @@ template<class IntType = int>
 
 \indexlibrary{\idxcode{uniform_int_distribution}!constructor}%
 \begin{itemdecl}
-explicit uniform_int_distribution(IntType a = 0, IntType b = numeric_limits<IntType>::max());
+explicit uniform_int_distribution(IntType a, IntType b = numeric_limits<IntType>::max());
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4498,7 +4503,8 @@ template<class RealType = double>
     using param_type  = @\unspec@;
 
     // constructors and reset functions
-    explicit uniform_real_distribution(RealType a = 0.0, RealType b = 1.0);
+    uniform_real_distribution() : uniform_real_distribution(0.0) {}
+    explicit uniform_real_distribution(RealType a, RealType b = 1.0);
     explicit uniform_real_distribution(const param_type& parm);
     void reset();
 
@@ -4521,7 +4527,7 @@ template<class RealType = double>
 
 \indexlibrary{\idxcode{uniform_real_distribution}!constructor}%
 \begin{itemdecl}
-explicit uniform_real_distribution(RealType a = 0.0, RealType b = 1.0);
+explicit uniform_real_distribution(RealType a, RealType b = 1.0);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4597,7 +4603,8 @@ public:
   using param_type  = @\unspec@;
 
   // constructors and reset functions
-  explicit bernoulli_distribution(double p = 0.5);
+  bernoulli_distribution() : bernoulli_distribution(0.5) {}
+  explicit bernoulli_distribution(double p);
   explicit bernoulli_distribution(const param_type& parm);
   void reset();
 
@@ -4619,7 +4626,7 @@ public:
 
 \indexlibrary{\idxcode{bernoulli_distribution}!constructor}%
 \begin{itemdecl}
-explicit bernoulli_distribution(double p = 0.5);
+explicit bernoulli_distribution(double p);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4667,7 +4674,8 @@ template<class IntType = int>
     using param_type  = @\unspec@;
 
     // constructors and reset functions
-    explicit binomial_distribution(IntType t = 1, double p = 0.5);
+    binomial_distribution() : binomial_distribution(1) {}
+    explicit binomial_distribution(IntType t, double p = 0.5);
     explicit binomial_distribution(const param_type& parm);
     void reset();
 
@@ -4690,7 +4698,7 @@ template<class IntType = int>
 
 \indexlibrary{\idxcode{binomial_distribution}!constructor}%
 \begin{itemdecl}
-explicit binomial_distribution(IntType t = 1, double p = 0.5);
+explicit binomial_distribution(IntType t, double p = 0.5);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4747,7 +4755,8 @@ template<class IntType = int>
     using param_type  = @\unspec@;
 
     // constructors and reset functions
-    explicit geometric_distribution(double p = 0.5);
+    geometric_distribution() : geometric_distribution(0.5) {}
+    explicit geometric_distribution(double p);
     explicit geometric_distribution(const param_type& parm);
     void reset();
 
@@ -4769,7 +4778,7 @@ template<class IntType = int>
 
 \indexlibrary{\idxcode{geometric_distribution}!constructor}%
 \begin{itemdecl}
-explicit geometric_distribution(double p = 0.5);
+explicit geometric_distribution(double p);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4821,7 +4830,8 @@ template<class IntType = int>
     using param_type  = @\unspec@;
 
     // constructor and reset functions
-    explicit negative_binomial_distribution(IntType k = 1, double p = 0.5);
+    negative_binomial_distribution() : negative_binomial_distribution(1) {}
+    explicit negative_binomial_distribution(IntType k, double p = 0.5);
     explicit negative_binomial_distribution(const param_type& parm);
     void reset();
 
@@ -4844,7 +4854,7 @@ template<class IntType = int>
 
 \indexlibrary{\idxcode{negative_binomial_distribution}!constructor}%
 \begin{itemdecl}
-explicit negative_binomial_distribution(IntType k = 1, double p = 0.5);
+explicit negative_binomial_distribution(IntType k, double p = 0.5);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4922,7 +4932,8 @@ template<class IntType = int>
     using param_type  = @\unspec@;
 
     // constructors and reset functions
-    explicit poisson_distribution(double mean = 1.0);
+    poisson_distribution() : poisson_distribution(1.0) {}
+    explicit poisson_distribution(double mean);
     explicit poisson_distribution(const param_type& parm);
     void reset();
 
@@ -4943,7 +4954,7 @@ template<class IntType = int>
 
 \indexlibrary{\idxcode{poisson_distribution}!constructor}%
 \begin{itemdecl}
-explicit poisson_distribution(double mean = 1.0);
+explicit poisson_distribution(double mean);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4991,7 +5002,8 @@ template<class RealType = double>
     using param_type  = @\unspec@;
 
     // constructors and reset functions
-    explicit exponential_distribution(RealType lambda = 1.0);
+    exponential_distribution() : exponential_distribution(1.0) {}
+    explicit exponential_distribution(RealType lambda);
     explicit exponential_distribution(const param_type& parm);
     void reset();
 
@@ -5013,7 +5025,7 @@ template<class RealType = double>
 
 \indexlibrary{\idxcode{exponential_distribution}!constructor}%
 \begin{itemdecl}
-explicit exponential_distribution(RealType lambda = 1.0);
+explicit exponential_distribution(RealType lambda);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5063,7 +5075,8 @@ template<class RealType = double>
     using param_type  = @\unspec@;
 
     // constructors and reset functions
-    explicit gamma_distribution(RealType alpha = 1.0, RealType beta = 1.0);
+    gamma_distribution() : gamma_distribution(1.0) {}
+    explicit gamma_distribution(RealType alpha, RealType beta = 1.0);
     explicit gamma_distribution(const param_type& parm);
     void reset();
 
@@ -5086,7 +5099,7 @@ template<class RealType = double>
 
 \indexlibrary{\idxcode{gamma_distribution}!constructor}%
 \begin{itemdecl}
-explicit gamma_distribution(RealType alpha = 1.0, RealType beta = 1.0);
+explicit gamma_distribution(RealType alpha, RealType beta = 1.0);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5149,7 +5162,8 @@ template<class RealType = double>
     using param_type  = @\unspec@;
 
     // constructor and reset functions
-    explicit weibull_distribution(RealType a = 1.0, RealType b = 1.0);
+    weibull_distribution() : weibull_distribution(1.0) {}
+    explicit weibull_distribution(RealType a, RealType b = 1.0);
     explicit weibull_distribution(const param_type& parm);
     void reset();
 
@@ -5171,7 +5185,7 @@ template<class RealType = double>
 
 \indexlibrary{\idxcode{weibull_distribution}!constructor}%
 \begin{itemdecl}
-explicit weibull_distribution(RealType a = 1.0, RealType b = 1.0);
+explicit weibull_distribution(RealType a, RealType b = 1.0);
 \end{itemdecl}%
 
 \begin{itemdescr}
@@ -5240,7 +5254,8 @@ template<class RealType = double>
     using param_type  = @\unspec@;
 
     // constructor and reset functions
-    explicit extreme_value_distribution(RealType a = 0.0, RealType b = 1.0);
+    extreme_value_distribution() : extreme_value_distribution(0.0) {}
+    explicit extreme_value_distribution(RealType a, RealType b = 1.0);
     explicit extreme_value_distribution(const param_type& parm);
     void reset();
 
@@ -5263,7 +5278,7 @@ template<class RealType = double>
 
 \indexlibrary{\idxcode{extreme_value_distribution}!constructor}%
 \begin{itemdecl}
-explicit extreme_value_distribution(RealType a = 0.0, RealType b = 1.0);
+explicit extreme_value_distribution(RealType a, RealType b = 1.0);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5353,7 +5368,8 @@ template<class RealType = double>
     using param_type  = @\unspec@;
 
     // constructors and reset functions
-    explicit normal_distribution(RealType mean = 0.0, RealType stddev = 1.0);
+    normal_distribution() : normal_distribution(0.0) {}
+    explicit normal_distribution(RealType mean, RealType stddev = 1.0);
     explicit normal_distribution(const param_type& parm);
     void reset();
 
@@ -5376,7 +5392,7 @@ template<class RealType = double>
 
 \indexlibrary{\idxcode{normal_distribution}!constructor}%
 \begin{itemdecl}
-explicit normal_distribution(RealType mean = 0.0, RealType stddev = 1.0);
+explicit normal_distribution(RealType mean, RealType stddev = 1.0);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5438,7 +5454,8 @@ template<class RealType = double>
     using param_type  = @\unspec@;
 
     // constructor and reset functions
-    explicit lognormal_distribution(RealType m = 0.0, RealType s = 1.0);
+    lognormal_distribution() : lognormal_distribution(0.0) {}
+    explicit lognormal_distribution(RealType m, RealType s = 1.0);
     explicit lognormal_distribution(const param_type& parm);
     void reset();
 
@@ -5461,7 +5478,7 @@ template<class RealType = double>
 
 \indexlibrary{\idxcode{lognormal_distribution}!constructor}%
 \begin{itemdecl}
-explicit lognormal_distribution(RealType m = 0.0, RealType s = 1.0);
+explicit lognormal_distribution(RealType m, RealType s = 1.0);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5521,7 +5538,8 @@ template<class RealType = double>
     using param_type  = @\unspec@;
 
     // constructor and reset functions
-    explicit chi_squared_distribution(RealType n = 1);
+    chi_squared_distribution() : chi_squared_distribution(1) {}
+    explicit chi_squared_distribution(RealType n);
     explicit chi_squared_distribution(const param_type& parm);
     void reset();
 
@@ -5543,7 +5561,7 @@ template<class RealType = double>
 
 \indexlibrary{\idxcode{chi_squared_distribution}!constructor}%
 \begin{itemdecl}
-explicit chi_squared_distribution(RealType n = 1);
+explicit chi_squared_distribution(RealType n);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5592,7 +5610,8 @@ template<class RealType = double>
     using param_type  = @\unspec@;
 
     // constructor and reset functions
-    explicit cauchy_distribution(RealType a = 0.0, RealType b = 1.0);
+    cauchy_distribution() : cauchy_distribution(0.0) {}
+    explicit cauchy_distribution(RealType a, RealType b = 1.0);
     explicit cauchy_distribution(const param_type& parm);
     void reset();
 
@@ -5615,7 +5634,7 @@ template<class RealType = double>
 
 \indexlibrary{\idxcode{cauchy_distribution}!constructor}%
 \begin{itemdecl}
-explicit cauchy_distribution(RealType a = 0.0, RealType b = 1.0);
+explicit cauchy_distribution(RealType a, RealType b = 1.0);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5679,7 +5698,8 @@ template<class RealType = double>
     using param_type  = @\unspec@;
 
     // constructor and reset functions
-    explicit fisher_f_distribution(RealType m = 1, RealType n = 1);
+    fisher_f_distribution() : fisher_f_distribution(1) {}
+    explicit fisher_f_distribution(RealType m, RealType n = 1);
     explicit fisher_f_distribution(const param_type& parm);
     void reset();
 
@@ -5702,7 +5722,7 @@ template<class RealType = double>
 
 \indexlibrary{\idxcode{fisher_f_distribution}!constructor}%
 \begin{itemdecl}
-explicit fisher_f_distribution(RealType m = 1, RealType n = 1);
+explicit fisher_f_distribution(RealType m, RealType n = 1);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5765,7 +5785,8 @@ template<class RealType = double>
     using param_type  = @\unspec@;
 
     // constructor and reset functions
-    explicit student_t_distribution(RealType n = 1);
+    student_t_distribution() : student_t_distribution(1) {}
+    explicit student_t_distribution(RealType n);
     explicit student_t_distribution(const param_type& parm);
     void reset();
 
@@ -5787,7 +5808,7 @@ template<class RealType = double>
 
 \indexlibrary{\idxcode{student_t_distribution}!constructor}%
 \begin{itemdecl}
-explicit student_t_distribution(RealType n = 1);
+explicit student_t_distribution(RealType n);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -2477,7 +2477,8 @@ namespace std {
       using string_type     = basic_string<char_type>;
 
       // \ref{re.results.const}, construct/copy/destroy
-      explicit match_results(const Allocator& a = Allocator());
+      match_results() : match_results(Allocator()) {}
+      explicit match_results(const Allocator&);
       match_results(const match_results& m);
       match_results(match_results&& m) noexcept;
       match_results& operator=(const match_results& m);
@@ -2542,7 +2543,7 @@ or member functions during the lifetime of the object.
 
 \indexlibrary{\idxcode{match_results}!constructor}%
 \begin{itemdecl}
-match_results(const Allocator& a = Allocator());
+explicit match_results(const Allocator& a);
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Fixes #2142 