### PR TITLE
P0476R2 Bit-casting object representations

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1026,6 +1026,7 @@ shown in \tref{cpp.library.headers}.
 \tcode{<any>} \\
 \tcode{<array>} \\
 \tcode{<atomic>} \\
+\tcode{<bit>} \\
 \tcode{<bitset>} \\
 \tcode{<charconv>} \\
 \tcode{<chrono>} \\
@@ -1038,8 +1039,8 @@ shown in \tref{cpp.library.headers}.
 \tcode{<exception>} \\
 \tcode{<execution>} \\
 \tcode{<filesystem>} \\
-\tcode{<forward_list>} \\
 \columnbreak
+\tcode{<forward_list>} \\
 \tcode{<fstream>} \\
 \tcode{<functional>} \\
 \tcode{<future>} \\
@@ -1056,8 +1057,8 @@ shown in \tref{cpp.library.headers}.
 \tcode{<map>} \\
 \tcode{<memory>} \\
 \tcode{<memory_resource>} \\
-\tcode{<mutex>} \\
 \columnbreak
+\tcode{<mutex>} \\
 \tcode{<new>} \\
 \tcode{<numeric>} \\
 \tcode{<optional>} \\
@@ -1074,8 +1075,8 @@ shown in \tref{cpp.library.headers}.
 \tcode{<stack>} \\
 \tcode{<stdexcept>} \\
 \tcode{<streambuf>} \\
-\tcode{<string>} \\
 \columnbreak
+\tcode{<string>} \\
 \tcode{<string_view>} \\
 \tcode{<strstream>} \\
 \tcode{<syncstream>} \\
@@ -1093,7 +1094,6 @@ shown in \tref{cpp.library.headers}.
 \tcode{<vector>} \\
 \tcode{<version>} \\
 \end{multicolfloattable}
-
 
 \pnum
 The facilities of the C standard library are provided in the
@@ -1310,6 +1310,7 @@ include at least the headers shown in \tref{cpp.headers.freestanding}.
 \ref{support.initlist}   & Initializer lists         & \tcode{<initializer_list>} \\ \rowsep
 \ref{support.runtime}    & Other runtime support     & \tcode{<cstdarg>}          \\ \rowsep
 \ref{meta}               & Type traits               & \tcode{<type_traits>}      \\ \rowsep
+\ref{bit}                & Bit manipulation          & \tcode{<bit>}              \\ \rowsep
 \ref{atomics}            & Atomics                   & \tcode{<atomic>}           \\ \rowsep
 \ref{depr.cstdalign.syn}, \ref{depr.cstdbool.syn} & Deprecated headers & \tcode{<cstdalign>} \tcode{<cstdbool>} \\
 \end{libsumtab}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -21,6 +21,7 @@ as summarized in \tref{numerics.lib.summary}.
 \ref{numeric.requirements}  & Requirements &           \\ \rowsep
 \ref{cfenv}           & Floating-point environment & \tcode{<cfenv>}  \\ \rowsep
 \ref{complex.numbers} & Complex numbers & \tcode{<complex>} \\ \rowsep
+\ref{bit}   & Bit manipulation & \tcode{<bit>} \\ \rowsep
 \ref{rand}  & Random number generation & \tcode{<random>} \\ \rowsep
 \ref{numarray}  & Numeric arrays     & \tcode{<valarray>}  \\ \rowsep
 \ref{numeric.ops} & Generalized numeric operations  & \tcode{<numeric>} \\ \rowsep
@@ -1360,6 +1361,64 @@ constexpr complex<float> operator""if(unsigned long long d);
 \tcode{complex<float>\{0.0f, static_cast<float>(d)\}}.
 \end{itemdescr}
 
+
+\rSec1[bit]{Bit manipulation}
+
+\rSec2[bit.general]{General}
+
+\pnum
+The header \tcode{<bit>} provides components to access,
+manipulate and process both individual bits and bit sequences.
+
+\rSec2[bit.syn]{Header \tcode{<bit>} synopsis}
+\indexhdr{bit}%
+\begin{codeblock}
+namespace std {
+  // \ref{bit.cast}, \tcode{bit_cast}
+  template<typename To, typename From>
+    constexpr To bit_cast(const From& from) noexcept;
+}
+\end{codeblock}
+
+\rSec2[bit.cast]{Function template \tcode{bit_cast}}
+
+\indexlibrary{\idxcode{bit_cast}}%
+\begin{itemdecl}
+template<typename To, typename From>
+  constexpr To bit_cast(const From& from) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+An object of type \tcode{To}.
+Each bit of the value representation of the result
+is equal to the corresponding bit in the object representation
+of \tcode{from}. Padding bits of the \tcode{To} object are unspecified.
+If there is no value of type \tcode{To} corresponding to the
+value representation produced, the behavior is undefined.
+If there are multiple such values, which value is produced is unspecified.
+
+\pnum
+\remarks
+This function shall not participate in overload resolution unless:
+\begin{itemize}
+\item \tcode{sizeof(To) == sizeof(From)} is \tcode{true};
+\item \tcode{is_trivially_copyable_v<To>} is \tcode{true}; and
+\item \tcode{is_trivially_copyable_v<From>} is \tcode{true}.
+\end{itemize}
+This function shall be \tcode{constexpr} if and only if
+\tcode{To}, \tcode{From}, and the types of all subobjects
+of \tcode{To} and \tcode{From} are types \tcode{T} such that:
+\begin{itemize}
+\item \tcode{is_union_v<T>} is \tcode{false};
+\item \tcode{is_pointer_v<T>} is \tcode{false};
+\item \tcode{is_member_pointer_v<T>} is \tcode{false};
+\item \tcode{is_volatile_v<T>} is \tcode{false}; and
+\item \tcode{T} has no non-static data members of reference type.
+\end{itemize}
+\end{itemdescr}
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -1372,7 +1431,6 @@ constexpr complex<float> operator""if(unsigned long long d);
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
 
 \rSec1[rand]{Random number generation}
 


### PR DESCRIPTION
Editorial changes:
* Added an entry into Table tab:numerics.lib.summary.
* Renamed heading "bit manipulation library" to just "bit manipulation".
* Reordered itemdescr elements to the canonical order.

Fixes #2131.

TODO: add feature test macros once CWG-15 has been merged.