### PR TITLE
[vector.cons] vector(Allocator) should be noexcept

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -5231,7 +5231,7 @@ of \tcode{vector} is referenced.
 
 \indexlibrary{\idxcode{vector}!constructor}
 \begin{itemdecl}
-explicit vector(const Allocator&);
+explicit vector(const Allocator&) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
This fixes an oversight in the wording of
N4258 Cleaning‐up noexcept in the Library,
which updated the overview, but not the description.

Fixes #2178.