### PR TITLE
[dcl.init.ref] Avoid use of 'underlying type' for references

### DIFF
--- a/source/declarators.tex
+++ b/source/declarators.tex
@@ -3793,7 +3793,7 @@ double&& rrd3 = i3;                 // \tcode{rrd3} refers to temporary with val
 
 In all cases except the last
 (i.e., implicitly converting the initializer expression
-to the underlying type of the reference),
+to the referenced type),
 the reference is said to \defn{bind directly} to the
 initializer expression.
 


### PR DESCRIPTION
Fixes #2180.