### PR TITLE
[basic.start,except] Harmonize references to std::terminate

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5512,9 +5512,10 @@ It is \impldef{threads and program points at which deferred dynamic initializati
 in which threads and at which points in the program such deferred dynamic initialization occurs.
 
 \pnum
-If the initialization of a non-local variable with static or thread storage duration
-exits via
-an exception, \tcode{std::terminate} is called\iref{except.terminate}.%
+If the initialization of
+a non-local variable with static or thread storage duration
+exits via an exception,
+the function \tcode{std::terminate} is called\iref{except.terminate}.%
 \indextext{program!start|)}
 
 \rSec3[basic.start.term]{Termination}
@@ -5560,7 +5561,7 @@ object with static storage duration initialized during the construction
 of the subobjects is destroyed.
 If the destruction of an object with static or thread storage duration
 exits via an exception,
-\tcode{std::terminate} is called\iref{except.terminate}.
+the function \tcode{std::terminate} is called\iref{except.terminate}.
 
 \pnum
 If a function contains a block-scope object of static or thread storage duration that has been

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4041,7 +4041,7 @@ that are allowed in a \grammarterm{contract-attribute-specifier}
 are modifications of non-volatile objects
 whose lifetime began and ended within the evaluation of the predicate.
 An evaluation of a predicate that exits via an exception
-invokes \tcode{std::terminate()}\iref{except.terminate}.
+invokes the function \tcode{std::terminate}\iref{except.terminate}.
 The behavior of any other side effect is undefined.
 \begin{example}
 \begin{codeblock}
@@ -4340,7 +4340,7 @@ and a contract is violated on a call to a function
 with a non-throwing exception specification,
 then the behavior is as if the exception escaped the function body.
 \begin{note}
-The function \tcode{std::terminate()} is invoked\iref{except.terminate}.
+The function \tcode{std::terminate} is invoked\iref{except.terminate}.
 \end{note}
 \begin{example}
 \begin{codeblock}
@@ -4359,7 +4359,7 @@ A translation may be performed with one of the following
 \term{off} or \term{on}.
 A translation with violation continuation mode set to \term{off}
 terminates execution
-by invoking \tcode{std::terminate()}\iref{except.terminate}
+by invoking the function \tcode{std::terminate}\iref{except.terminate}
 after completing the execution of the violation handler.
 A translation with a violation continuation mode set to \term{on}
 continues execution after completing the execution of the violation handler.

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -330,7 +330,7 @@ it is rethrown.
 If the exception handling mechanism
 handling an uncaught exception\iref{except.uncaught}
 directly invokes a function that exits via an
-exception, \tcode{std::terminate} is called\iref{except.terminate}.
+exception, the function \tcode{std::terminate} is called\iref{except.terminate}.
 \begin{example}
 \begin{codeblock}
 struct C {
@@ -344,7 +344,7 @@ struct C {
 
 int main() {
   try {
-    throw C();      // calls \tcode{std::terminate()} if construction of the handler's
+    throw C();      // calls \tcode{std::terminate} if construction of the handler's
                     // \grammarterm{exception-declaration} object is not elided\iref{class.copy}
   } catch(C) { }
 }
@@ -595,7 +595,7 @@ initialization is complete for the parameter (if any) of the catch clause.
 The stack will have been unwound at that point.
 \end{note}
 Also, an implicit handler is considered active when
-\tcode{std::terminate()}
+the function \tcode{std::terminate}
 is entered due to a throw. A handler is no longer considered active when the
 catch clause exits.
 
@@ -608,12 +608,12 @@ still active is called the
 \pnum
 If no matching handler is found,
 the function
-\tcode{std::terminate()}
+\tcode{std::terminate}
 is called;
 whether or not the stack is unwound before this call to
-\tcode{std::terminate()}
+\tcode{std::terminate}
 is \impldef{stack unwinding before call to
-\tcode{std::terminate()}}\iref{except.terminate}.
+\tcode{std::terminate}}\iref{except.terminate}.
 
 \pnum
 Referring to any non-static member or base class of an object
@@ -785,7 +785,7 @@ Whenever an exception is thrown
 and the search for a handler\iref{except.handle}
 encounters the outermost block of a function with a
 non-throwing exception specification,
-the function \tcode{std::terminate()} is called\iref{except.terminate}.
+the function \tcode{std::terminate} is called\iref{except.terminate}.
 \begin{note}
 An implementation shall not reject an expression merely because, when
 executed, it throws or might
@@ -872,7 +872,7 @@ during the execution of a constructor\iref{except.ctor},
 their exception specifications do not contribute
 to the exception specification of the constructor,
 because an exception thrown from such a destructor
-would call \tcode{std::terminate}
+would call the function \tcode{std::terminate}
 rather than escape the constructor~(\ref{except.throw}, \ref{except.terminate}).
 \end{note}
 
@@ -976,7 +976,7 @@ needed.
 \rSec1[except.special]{Special functions}
 
 \pnum
-The function \tcode{std::terminate()}\iref{except.terminate}
+The function \tcode{std::terminate}\iref{except.terminate}
 is used by the exception
 handling mechanism for coping with errors related to the exception handling
 mechanism itself. The function
@@ -984,7 +984,7 @@ mechanism itself. The function
 \tcode{std::nested_exception}\iref{except.nested} can be used by a program to
 capture the currently handled exception.
 
-\rSec2[except.terminate]{The \tcode{std::terminate()} function}
+\rSec2[except.terminate]{The \tcode{std::terminate} function}
 
 \pnum
 \indextext{\idxcode{terminate}}%
@@ -1076,29 +1076,29 @@ fails to meet a postcondition.
 \pnum
 \indextext{\idxcode{terminate}}%
 In such cases,
-\tcode{std::terminate()}
+the function \tcode{std::terminate}
 is called\iref{exception.terminate}.
 In the situation where no matching handler is found, it is
-\impldef{stack unwinding before call to \tcode{std::terminate()}} whether or not the
+\impldef{stack unwinding before call to \tcode{std::terminate}} whether or not the
 stack is unwound
 before
-\tcode{std::terminate()}
+\tcode{std::terminate}
 is called.
 In the situation where the search for a handler\iref{except.handle} encounters the
 outermost block of a function
 with a non-throwing exception specification\iref{except.spec}, it is
-\impldef{whether stack is unwound before calling \tcode{std::ter\-mi\-nate()}
+\impldef{whether stack is unwound before calling the function \tcode{std::terminate}
 when a \tcode{noexcept} specification
 is violated}
 whether the stack is unwound, unwound partially, or not unwound at all
-before \tcode{std::terminate()} is called.
+before the function \tcode{std::terminate} is called.
 In all other situations, the stack shall not be unwound before
-\tcode{std::terminate()}
+the function \tcode{std::terminate}
 is called.
 An implementation is not permitted to finish stack unwinding
 prematurely based on a determination that the unwind process
-will eventually cause a call to
-\tcode{std::terminate()}.
+will eventually cause a call to the function
+\tcode{std::terminate}.
 
 \rSec2[except.uncaught]{The \tcode{std::uncaught_exceptions()} function}%
 \indexlibrary{\idxcode{uncaught_exceptions}}

--- a/source/support.tex
+++ b/source/support.tex
@@ -1885,7 +1885,7 @@ by throwing an exception that is caught in
 \tcode{main}.}
 
 If control leaves a registered function called by \tcode{exit} because the function does
-not provide a handler for a thrown exception, \tcode{std::terminate()} shall be called\iref{except.terminate}.%
+not provide a handler for a thrown exception, the function \tcode{std::terminate} shall be called\iref{except.terminate}.%
 \indexlibrary{\idxcode{terminate}}%
 
 \item
@@ -1962,7 +1962,7 @@ reverse order of their registration, except that a function shall be called afte
 previously registered functions that had already been called at the time it was
 registered. Objects shall not be destroyed as a result of calling \tcode{quick_exit}.
 If control leaves a registered function called by \tcode{quick_exit} because the
-function does not provide a handler for a thrown exception, \tcode{std::terminate()} shall
+function does not provide a handler for a thrown exception, the function \tcode{std::terminate} shall
 be called.\indexlibrary{\idxcode{terminate}}
 \begin{note}
 A function registered via \tcode{at_quick_exit}
@@ -3645,8 +3645,8 @@ The number of uncaught exceptions\iref{except.uncaught}.
 \pnum
 \remarks
 When \tcode{uncaught_exceptions() > 0},
-throwing an exception can result in a call of\\
-\tcode{std::terminate()}\iref{except.terminate}.
+throwing an exception can result in a call of the function
+\tcode{std::terminate}\iref{except.terminate}.
 \end{itemdescr}
 
 \rSec2[propagation]{Exception propagation}
@@ -3801,7 +3801,7 @@ nested_exception() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects If \tcode{nested_ptr()} returns a null pointer, the function calls \tcode{std::terminate()}.
+\effects If \tcode{nested_ptr()} returns a null pointer, the function calls the function \tcode{std::terminate}.
 Otherwise, it throws the stored exception captured by \tcode{*this}.
 \end{itemdescr}
 


### PR DESCRIPTION
Fixes #2150.