### PR TITLE
Harmonize phrasings of "this destructor is trivial"

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -2659,7 +2659,7 @@ then this constructor is a trivial copy constructor.
 \effects
 The iterator is destroyed.
 If \tcode{is_trivially_destructible_v<T>} is \tcode{true},
-then this destructor is a trivial destructor.
+then this destructor is trivial.
 \end{itemdescr}
 
 \rSec3[istream.iterator.ops]{\tcode{istream_iterator} operations}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -517,9 +517,10 @@ The defaulted move and copy constructor, respectively, of \tcode{pair} shall
 be a constexpr function if and only if all required element-wise
 initializations for copy and move, respectively, would satisfy the
 requirements for a constexpr function.
-The destructor of \tcode{pair} shall be a trivial destructor if
-\tcode{(is_trivially_destructible_v<T1> \&\& is_trivially_destructible_v<T2>)}
-is \tcode{true}.
+
+\pnum
+If \tcode{(is_trivially_destructible_v<T1> \&\& is_trivially_destructible_v<T2>)}
+is \tcode{true}, then the destructor of \tcode{pair} is trivial.
 
 \indexlibrary{\idxcode{pair}!constructor}%
 \begin{itemdecl}
@@ -1162,6 +1163,13 @@ namespace std {
 \rSec3[tuple.cnstr]{Construction}
 
 \pnum
+In the descriptions that follow, let $i$ be in the range
+\range{0}{sizeof...(Types)} in order, $\tcode{T}_i$
+be the $i^\text{th}$ type in \tcode{Types}, and
+$\tcode{U}_i$ be the $i^\text{th}$ type in a template parameter pack named \tcode{UTypes}, where indexing
+is zero-based.
+
+\pnum
 For each \tcode{tuple} constructor, an exception is thrown only if the construction of
 one of the types in \tcode{Types} throws an exception.
 
@@ -1174,16 +1182,8 @@ defaulted move and copy constructor of \tcode{tuple<>} shall be
 constexpr functions.
 
 \pnum
-The destructor of \tcode{tuple} shall be a trivial destructor if
-\tcode{(is_trivially_destructible_v<Types> \&\& ...)}
-is \tcode{true}.
-
-\pnum
-In the constructor descriptions that follow, let $i$ be in the range
-\range{0}{sizeof...(Types)} in order, $\tcode{T}_i$
-be the $i^\text{th}$ type in \tcode{Types}, and
-$\tcode{U}_i$ be the $i^\text{th}$ type in a template parameter pack named \tcode{UTypes}, where indexing
-is zero-based.
+If \tcode{is_trivially_destructible_v<$\tcode{T}_i$>} is \tcode{true} for all $\tcode{T}_i$,
+then the destructor of \tcode{tuple} is trivial.
 
 \indexlibrary{\idxcode{tuple}!constructor}%
 \begin{itemdecl}
@@ -2544,7 +2544,7 @@ val->T::~T()
 
 \pnum
 \remarks
-If \tcode{is_trivially_destructible_v<T> == true} then this destructor shall be a trivial destructor.
+If \tcode{is_trivially_destructible_v<T>} is \tcode{true}, then this destructor is trivial.
 \end{itemdescr}
 
 \rSec3[optional.assign]{Assignment}
@@ -4162,8 +4162,8 @@ destroys the currently contained value.
 
 \pnum
 \remarks
-If \tcode{is_trivially_destructible_v<$\tcode{T}_i$> == true} for all $\tcode{T}_i$
-then this destructor shall be a trivial destructor.
+If \tcode{is_trivially_destructible_v<$\tcode{T}_i$>} is \tcode{true} for all $\tcode{T}_i$,
+then this destructor is trivial.
 \end{itemdescr}
 
 \rSec3[variant.assign]{Assignment}


### PR DESCRIPTION
Inspired by P0602 https://lichray.github.io/trivially_variant.html
Zhihao suggested I open an editorial issue if I want to harmonize
"trivially destructible" wording across the rest of the Standard,
so, here's that editorial issue.

I may have gotten carried away while harmonizing
http://eel.is/c++draft/tuple.cnstr#4
with
http://eel.is/c++draft/variant.ctor#1
but I think it's still "editorial."