### PR TITLE
[re.general] Refer to table as done in the other clauses

### DIFF
--- a/source/regex.tex
+++ b/source/regex.tex
@@ -18,7 +18,7 @@ a class template that holds the
 result of a regular expression match, a series of algorithms that allow a character
 sequence to be operated upon by a regular expression,
 and two iterator types for
-enumerating regular expression matches, as described in \tref{re.lib.summary}.
+enumerating regular expression matches, as summarized in \tref{re.lib.summary}.
 
 \begin{libsumtab}{Regular expressions library summary}{tab:re.lib.summary}
 \ref{re.def}        &   Definitions                 &                       \\


### PR DESCRIPTION
This change refers to the table introducing the first-level subclauses as done in the summary of the other clauses.