### PR TITLE
[lex.charset] Change "short name" to "short identifier" to match ISO 10646

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -208,10 +208,10 @@ other characters.
 \end{bnf}
 
 The character designated by the \grammarterm{universal-character-name} \tcode{\textbackslash
-UNNNNNNNN} is that character whose character short name in ISO/IEC 10646 is
-\tcode{NNNNNNNN}; the character designated by the \grammarterm{universal-character-name}
-\tcode{\textbackslash uNNNN} is that character whose character short name in
-ISO/IEC 10646 is \tcode{0000NNNN}. If the hexadecimal value for a
+U00NNNNNN} is that character whose character short identifier in ISO/IEC 10646 is
+\tcode{NNNNNN}; the character designated by the \grammarterm{universal-character-name}
+\tcode{\textbackslash uNNNN} is that character whose character short identifier in
+ISO/IEC 10646 is \tcode{NNNN}. If the hexadecimal value for a
 \grammarterm{universal-character-name} corresponds to a surrogate code point (in the
 range 0xD800--0xDFFF, inclusive), the program is ill-formed. Additionally, if
 the hexadecimal value for a \grammarterm{universal-character-name} outside


### PR DESCRIPTION
ISO 10646 doesn't have a "short name" concept (there is a "Jamo short name" but that's something specific to the Hangul script; clearly not the intended meaning here). What ISO 10646 does have, is a "short identifier" concept, which is clearly what is intended here. I have made minimal changes to this wording in order to use the "short identifier" concept.

For clarity, I am reproducing here the relevant text from ISO 10646.

> a) The six-digit form of short identifier consists of the sequence of six hexadecimal digits that represents the code point of the character (see 6.2).
>
> b) The four-to-five-digit form of short identifier shall consist of the last four to five digits of the six-digit form. Leading zeroes beyond four digits are suppressed.
>
> c) The character “+” (PLUS SIGN) may, as an option, precede the digit form of short identifier.
>
> d) The prefix letter “U” (LATIN CAPITAL LETTER U) may, as an option, precede any of the three forms of short identifier defined in a) to c) above.
>
> The capital letters A to F, and U that appear within short identifiers may be replaced by the corresponding small letters.

Also note that "short identifier" is already used in [cpp.predefined], 2.4 (http://eel.is/c++draft/cpp.predefined#2.4)

Fixes #2109.