### PR TITLE
[expr.spaceship] Fix typo for std::strong_equality::nonequal

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5053,7 +5053,7 @@ the result is
 \tcode{std::strong_equality::equal}
 if the (possibly converted) operands compare equal\iref{expr.eq}
 and
-\tcode{std::strong_equality::unequal}
+\tcode{std::strong_equality::nonequal}
 if they compare unequal,
 otherwise the result of the operator is unspecified.
 


### PR DESCRIPTION
Fixes #2206.