### PR TITLE
[diff.cpp17.depr] apparent typo in p0619r4: raw_memory_iterator

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -2073,7 +2073,7 @@ A valid \CppXVII{} program that directly makes use of the \tcode{pointer},
 \tcode{allocate} with an additional hint argument, may fail to compile.
 
 \nodiffref
-\change Remove \tcode{raw_memory_iterator}.
+\change Remove \tcode{raw_storage_iterator}.
 \rationale
 The iterator encouraged use of algorithms that might throw exceptions, but did
 not return the number of elements successfully constructed that might need to


### PR DESCRIPTION
Pretty sure p0619 meant to say `raw_storage_iterator` there, since that's what was actually removed.