### PR TITLE
[algorithm.syn] Relocate the "partitions" algorithms

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -585,49 +585,6 @@ namespace std {
                   ForwardIterator first, ForwardIterator last,
                   typename iterator_traits<ForwardIterator>::difference_type n);
 
-  // \ref{alg.partitions}, partitions
-  template<class InputIterator, class Predicate>
-    constexpr bool is_partitioned(InputIterator first, InputIterator last, Predicate pred);
-  template<class ExecutionPolicy, class ForwardIterator, class Predicate>
-    bool is_partitioned(ExecutionPolicy&& exec, // see \ref{algorithms.parallel.overloads}
-                        ForwardIterator first, ForwardIterator last, Predicate pred);
-
-  template<class ForwardIterator, class Predicate>
-    constexpr ForwardIterator partition(ForwardIterator first,
-                                        ForwardIterator last,
-                                        Predicate pred);
-  template<class ExecutionPolicy, class ForwardIterator, class Predicate>
-    ForwardIterator partition(ExecutionPolicy&& exec, // see \ref{algorithms.parallel.overloads}
-                              ForwardIterator first,
-                              ForwardIterator last,
-                              Predicate pred);
-  template<class BidirectionalIterator, class Predicate>
-    BidirectionalIterator stable_partition(BidirectionalIterator first,
-                                           BidirectionalIterator last,
-                                           Predicate pred);
-  template<class ExecutionPolicy, class BidirectionalIterator, class Predicate>
-    BidirectionalIterator stable_partition(ExecutionPolicy&& exec, // see \ref{algorithms.parallel.overloads}
-                                           BidirectionalIterator first,
-                                           BidirectionalIterator last,
-                                           Predicate pred);
-  template<class InputIterator, class OutputIterator1,
-           class OutputIterator2, class Predicate>
-    constexpr pair<OutputIterator1, OutputIterator2>
-      partition_copy(InputIterator first, InputIterator last,
-                     OutputIterator1 out_true, OutputIterator2 out_false,
-                     Predicate pred);
-  template<class ExecutionPolicy, class ForwardIterator, class ForwardIterator1,
-           class ForwardIterator2, class Predicate>
-    pair<ForwardIterator1, ForwardIterator2>
-      partition_copy(ExecutionPolicy&& exec, // see \ref{algorithms.parallel.overloads}
-                     ForwardIterator first, ForwardIterator last,
-                     ForwardIterator1 out_true, ForwardIterator2 out_false,
-                     Predicate pred);
-  template<class ForwardIterator, class Predicate>
-    constexpr ForwardIterator
-      partition_point(ForwardIterator first, ForwardIterator last,
-                      Predicate pred);
-
   // \ref{alg.sorting}, sorting and related operations
   // \ref{alg.sort}, sorting
   template<class RandomAccessIterator>
@@ -780,6 +737,49 @@ namespace std {
     constexpr bool
       binary_search(ForwardIterator first, ForwardIterator last,
                     const T& value, Compare comp);
+
+  // \ref{alg.partitions}, partitions
+  template<class InputIterator, class Predicate>
+    constexpr bool is_partitioned(InputIterator first, InputIterator last, Predicate pred);
+  template<class ExecutionPolicy, class ForwardIterator, class Predicate>
+    bool is_partitioned(ExecutionPolicy&& exec, // see \ref{algorithms.parallel.overloads}
+                        ForwardIterator first, ForwardIterator last, Predicate pred);
+
+  template<class ForwardIterator, class Predicate>
+    constexpr ForwardIterator partition(ForwardIterator first,
+                                        ForwardIterator last,
+                                        Predicate pred);
+  template<class ExecutionPolicy, class ForwardIterator, class Predicate>
+    ForwardIterator partition(ExecutionPolicy&& exec, // see \ref{algorithms.parallel.overloads}
+                              ForwardIterator first,
+                              ForwardIterator last,
+                              Predicate pred);
+  template<class BidirectionalIterator, class Predicate>
+    BidirectionalIterator stable_partition(BidirectionalIterator first,
+                                           BidirectionalIterator last,
+                                           Predicate pred);
+  template<class ExecutionPolicy, class BidirectionalIterator, class Predicate>
+    BidirectionalIterator stable_partition(ExecutionPolicy&& exec, // see \ref{algorithms.parallel.overloads}
+                                           BidirectionalIterator first,
+                                           BidirectionalIterator last,
+                                           Predicate pred);
+  template<class InputIterator, class OutputIterator1,
+           class OutputIterator2, class Predicate>
+    constexpr pair<OutputIterator1, OutputIterator2>
+      partition_copy(InputIterator first, InputIterator last,
+                     OutputIterator1 out_true, OutputIterator2 out_false,
+                     Predicate pred);
+  template<class ExecutionPolicy, class ForwardIterator, class ForwardIterator1,
+           class ForwardIterator2, class Predicate>
+    pair<ForwardIterator1, ForwardIterator2>
+      partition_copy(ExecutionPolicy&& exec, // see \ref{algorithms.parallel.overloads}
+                     ForwardIterator first, ForwardIterator last,
+                     ForwardIterator1 out_true, ForwardIterator2 out_false,
+                     Predicate pred);
+  template<class ForwardIterator, class Predicate>
+    constexpr ForwardIterator
+      partition_point(ForwardIterator first, ForwardIterator last,
+                      Predicate pred);
 
   // \ref{alg.merge}, merge
   template<class InputIterator1, class InputIterator2, class OutputIterator>


### PR DESCRIPTION
between the "binary_search" family and the "merge" family, to agree with
the order of the detailed specifiations as reordered by #1245.

Fixes #2218.