### PR TITLE
[lex] Correctly cite ISO/IEC 10646

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -544,7 +544,7 @@ token.%
 \indextext{name}%
 An identifier is an arbitrarily long sequence of letters and digits.
 Each \grammarterm{universal-character-name} in an identifier shall designate a
-character whose encoding in ISO 10646 falls into one of the ranges
+character whose encoding in ISO/IEC 10646 falls into one of the ranges
 specified in \tref{charname.allowed}.
 The initial element shall not be a \grammarterm{universal-character-name}
 designating a character whose encoding falls into one of the ranges
@@ -1141,7 +1141,7 @@ begins with \tcode{u8}, such as \tcode{u8'w'},
 is a character literal of type \tcode{char},
 known as a \defn{UTF-8 character literal}.
 The value of a UTF-8 character literal
-is equal to its ISO 10646 code point value,
+is equal to its ISO/IEC 10646 code point value,
 provided that the code point value
 is representable with a single UTF-8 code unit
 (that is, provided it is in the C0 Controls and Basic Latin Unicode block).
@@ -1158,7 +1158,7 @@ begins with the letter \tcode{u}, such as \tcode{u'x'},
 \indextext{prefix!\idxcode{u}}%
 is a character literal of type \tcode{char16_t}. The value
 of a \tcode{char16_t} character literal containing a single \grammarterm{c-char} is
-equal to its ISO 10646 code point value, provided that the code point value is
+equal to its ISO/IEC 10646 code point value, provided that the code point value is
 representable with a single 16-bit code unit (that is, provided it is in the
 basic multi-lingual plane). If the value is not representable
 with a single 16-bit code unit, the program is ill-formed. A \tcode{char16_t} character literal
@@ -1173,7 +1173,7 @@ begins with the letter \tcode{U}, such as \tcode{U'y'},
 \indextext{prefix!\idxcode{U}}%
 is a character literal of type \tcode{char32_t}. The value of a
 \tcode{char32_t} character literal containing a single \grammarterm{c-char} is equal
-to its ISO 10646 code point value. A \tcode{char32_t} character literal containing
+to its ISO/IEC 10646 code point value. A \tcode{char32_t} character literal containing
 multiple \grammarterm{c-char}{s} is ill-formed.
 
 \pnum


### PR DESCRIPTION
Fixes #2101.