### PR TITLE
[expr.prim.lambda,depr.capture.this] Replace 'lambda expression'

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -854,7 +854,8 @@ by the \grammarterm{nested-name-specifier}.
 \end{bnf}
 
 \pnum
-Lambda expressions provide a concise way to create simple function objects.
+A \grammarterm{lambda-expression} provides
+a concise way to create a simple function object.
 \begin{example}
 \begin{codeblock}
 #include <algorithm>
@@ -1307,16 +1308,13 @@ void S2::f(int i) {
 \end{example}
 
 \pnum
-A \grammarterm{lambda-expression}
-is a \defn{local lambda expression}
-if its innermost enclosing scope is a block scope\iref{basic.scope.block},
-or if it appears within a default member initializer
+A \grammarterm{lambda-expression} shall not have
+a \grammarterm{capture-default} or \grammarterm{simple-capture}
+in its \grammarterm{lambda-introducer}
+unless its innermost enclosing scope is a block scope\iref{basic.scope.block}
+or it appears within a default member initializer
 and its innermost enclosing scope is
-the corresponding class scope\iref{basic.scope.class};
-any other
-\grammarterm{lambda-expression} shall not have a \grammarterm{capture-default} or
-\grammarterm{simple-capture} in its
-\grammarterm{lambda-introducer}.
+the corresponding class scope\iref{basic.scope.class}.
 
 \pnum
 The \grammarterm{identifier} in a \grammarterm{simple-capture} is looked up using the
@@ -1622,7 +1620,8 @@ non-static data member of \tcode{m1}'s closure type;
 \tcode{m2} captures the same
 entity captured by \tcode{m1}.
 \end{itemize}
-\begin{example} The nested lambda expressions and invocations below will output
+\begin{example}
+The nested \grammarterm{lambda-expression}s and invocations below will output
 \tcode{123234}.
 \begin{codeblock}
 int a = 1, b = 1, c = 1;
@@ -4269,10 +4268,10 @@ The first alternative is a
 \defnx{single-object delete expression}{delete!single-object}, and the
 second is an \defnx{array delete expression}{delete!array}.
 Whenever the \tcode{delete} keyword is immediately followed by empty square
-brackets, it shall be interpreted as the second alternative.\footnote{A lambda
-expression with a \grammarterm{lambda-introducer} that consists of empty square
-brackets can follow the \tcode{delete} keyword if the lambda expression is
-enclosed in parentheses.}
+brackets, it shall be interpreted as the second alternative.\footnote{A
+\grammarterm{lambda-expression} with a \grammarterm{lambda-introducer}
+that consists of empty square brackets can follow the \tcode{delete} keyword
+if the \grammarterm{lambda-expression} is enclosed in parentheses.}
 The operand shall be of pointer to object type or of class type. If of
 class type, the operand is contextually implicitly converted\iref{conv}
 to a pointer to object

--- a/source/future.tex
+++ b/source/future.tex
@@ -39,7 +39,7 @@ auto cmp = e <=> f;             // ill-formed
 
 \pnum
 For compatibility with prior \Cpp{} International Standards,
-a lambda expression with \grammarterm{capture-default}
+a \grammarterm{lambda-expression} with \grammarterm{capture-default}
 \tcode{=}\iref{expr.prim.lambda.capture} may implicitly capture
 \tcode{*this} by reference.
 \begin{example}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -3986,9 +3986,10 @@ B<short> b;         // error: instantiation of \tcode{B<short>} uses own type vi
 \end{example}
 
 \pnum
-The type of a lambda expression appearing in an alias template declaration
-is different between instantiations of that template, even when the lambda
-expression is not dependent.
+The type of a \grammarterm{lambda-expression}
+appearing in an alias template declaration
+is different between instantiations of that template,
+even when the \grammarterm{lambda-expression} is not dependent.
 \begin{example}
 \begin{codeblock}
 template <class T>


### PR DESCRIPTION
with the grammar term 'lambda-expression'.
Also remove the unused definition of 'local lambda expression'.

Fixes #2094.