### PR TITLE
[class.mem] Define complete-class context

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -991,12 +991,8 @@ A name with global namespace scope is said to be a
 \pnum
 The potential scope of a name declared in a class consists not
 only of the declarative region following the name's point of
-declaration, but also of all function bodies, default arguments,
-\grammarterm{noexcept-specifier}{s},
-default member initializers\iref{class.mem},
-and contract conditions\iref{dcl.attr.contract}
-in that class (including such
-things in nested classes).
+declaration, but also of all complete-class contexts\iref{class.mem}
+of that class.
 
 \pnum
 A name \tcode{N} used in a class \tcode{S} shall refer to the same
@@ -1336,13 +1332,11 @@ void A::N::f() {
 \end{example}
 
 \pnum
-A name used in the definition of a class \tcode{X} outside of a member
-function body, default argument, \grammarterm{noexcept-specifier},
-default member initializer\iref{class.mem},
-contract condition\iref{dcl.attr.contract},
-or nested class definition\footnote{This refers to unqualified names
-following the class name; such a name may be used in the
-\grammarterm{base-clause} or may be used in the class definition.}
+A name used in the definition of a class \tcode{X} outside of a
+complete-class context\iref{class.mem} of \tcode{X}\footnote{This
+refers to unqualified names following the class name;
+such a name may be used in the \grammarterm{base-clause} or
+may be used in the class definition.}
 shall be declared in one of the following ways:
 \begin{itemize}
 \item before its use in class \tcode{X} or be a member of a base class
@@ -1404,11 +1398,7 @@ definitions.
 
 \pnum
 For the members of a class \tcode{X}, a name used
-in a member function body,
-in a default argument,
-in a \grammarterm{noexcept-specifier},
-in a default member initializer\iref{class.mem},
-in a contract condition\iref{dcl.attr.contract}, or
+in a complete-class context\iref{class.mem} of \tcode{X} or
 in the definition of a class member outside of the definition of \tcode{X},
 following the member's
 \grammarterm{declarator-id}\footnote{That is, an unqualified name that occurs,

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -559,17 +559,27 @@ are sufficiently different\iref{over}.
 
 \pnum
 \indextext{completely defined}%
+A \defn{complete-class context} of a class is a
+\begin{itemize}
+\item function body\iref{dcl.fct.def.general},
+\item default argument\iref{dcl.fct.default},
+\item \grammarterm{noexcept-specifier}\iref{except.spec},
+\item contract condition\iref{dcl.attr.contract}, or
+\item default member initializer
+\end{itemize}
+within the \grammarterm{member-specification} of the class.
+\begin{note}
+A complete-class context of a nested class is also a complete-class
+context of any enclosing class, if the nested class is defined within
+the \grammarterm{member-specification} of the enclosing class.
+\end{note}
+
+\pnum
 A class is considered a completely-defined object
 type\iref{basic.types} (or complete type) at the closing \tcode{\}} of
 the \grammarterm{class-specifier}.
-Within the class
-\grammarterm{member-specification}, the class is regarded as complete
-within function bodies, default arguments,
-\grammarterm{noexcept-specifier}{s},
-default member initializers, and
-contract conditions\iref{dcl.attr.contract}
-(including such things in nested classes).
-Otherwise it is regarded as incomplete within its own class
+The class is regarded as complete within its complete-class contexts;
+otherwise it is regarded as incomplete within its own class
 \grammarterm{member-specification}.
 
 \pnum


### PR DESCRIPTION
and use it, instead of having separate redundant lists
in [basic.scope.class] and [basic.lookup.unqual].

Fixes #2107.