### PR TITLE
[diff] Use plural form of \diffref for changes affecting multiple subclauses.

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -248,7 +248,7 @@ widespread commercially.
 \howwide
 Common.
 
-\diffref{expr.post.incr}, \ref{expr.pre.incr}
+\diffrefs{expr.post.incr}{expr.pre.incr}
 \change
 Decrement operator is not allowed with \tcode{bool} operand.
 \rationale Feature with surprising semantics.
@@ -256,7 +256,7 @@ Decrement operator is not allowed with \tcode{bool} operand.
 a \tcode{bool} lvalue (for instance, via the C typedef in \tcode{<stdbool.h>})
 is ill-formed in this International Standard.
 
-\diffref{expr.sizeof}, \ref{expr.cast}
+\diffrefs{expr.sizeof}{expr.cast}
 \change Types must be defined in declarations, not in expressions.\\
 In C, a sizeof expression or cast expression may define a new type.
 For example,
@@ -274,7 +274,7 @@ Syntactic transformation.
 \howwide
 Seldom.
 
-\diffref{expr.cond}, \ref{expr.ass}, \ref{expr.comma}
+\diffrefs{expr.cond}{expr.ass}, \ref{expr.comma}
 \indextext{conversion!lvalue-to-rvalue}%
 \indextext{rvalue!lvalue conversion to}%
 \indextext{lvalue}%
@@ -305,7 +305,7 @@ Rare.
 
 \rSec2[diff.stat]{\ref{stmt.stmt}: statements}
 
-\diffref{stmt.switch}, \ref{stmt.goto}
+\diffrefs{stmt.switch}{stmt.goto}
 \change It is now invalid to jump past a declaration with explicit or implicit initializer (except across entire block not entered).
 \rationale
 Constructors used in initializers may allocate
@@ -993,7 +993,7 @@ int x[] = { 2.0 };
 
 \rSec2[diff.cpp03.special]{\ref{special}: special member functions}
 
-\diffref{class.ctor}, \ref{class.dtor}, \ref{class.copy}
+\diffrefs{class.ctor}{class.dtor}, \ref{class.copy}
 \change Implicitly-declared special member functions are defined as deleted
 when the implicit definition would have been ill-formed.
 \rationale Improves template argument deduction failure.
@@ -1151,7 +1151,7 @@ Valid \CppIII{} code, compiled without traceable pointer support,
 that interacts with newer \Cpp{} code using regions declared reachable may
 have different runtime behavior.
 
-\diffref{refwrap}, \ref{arithmetic.operations}, \ref{comparisons},
+\diffrefs{refwrap}{arithmetic.operations}, \ref{comparisons},
 \ref{logical.operations}, \ref{bitwise.operations}
 \change Standard function object types no longer derived from
 \tcode{std::unary_function} or \tcode{std::binary_function}.
@@ -1213,7 +1213,7 @@ of \tcode{size() == 0};
 Valid \CppIII{} code that attempts to explicitly instantiate a container using
 a user-defined type with no default constructor may fail to compile.
 
-\diffref{sequence.reqmts}, \ref{associative.reqmts}
+\diffrefs{sequence.reqmts}{associative.reqmts}
 \change Signature changes: from \tcode{void} return types.
 \rationale Old signature threw away useful information that may be expensive
 to recalculate.
@@ -1230,7 +1230,7 @@ Valid \CppIII{} code that relies on these functions returning \tcode{void}
 (e.g., code that creates a pointer to member function that points to one
 of these functions) will fail to compile with this International Standard.
 
-\diffref{sequence.reqmts}, \ref{associative.reqmts}
+\diffrefs{sequence.reqmts}{associative.reqmts}
 \change Signature changes: from \tcode{iterator} to \tcode{const_iterator}
 parameters.
 \rationale Overspecification.
@@ -1251,7 +1251,7 @@ The signatures of the following member functions changed from taking an
 Valid \CppIII{} code that uses these functions may fail to compile with this
 International Standard.
 
-\diffref{sequence.reqmts}, \ref{associative.reqmts}
+\diffrefs{sequence.reqmts}{associative.reqmts}
 \change Signature changes: \tcode{resize}.
 \rationale Performance, compatibility with move semantics.
 \effect
@@ -1285,7 +1285,7 @@ binary representation of the required template specializations of
 
 \rSec2[diff.cpp03.input.output]{\ref{input.output}: input/output library}
 
-\diffref{istream::sentry}, \ref{ostream::sentry}, \ref{iostate.flags}
+\diffrefs{istream::sentry}{ostream::sentry}, \ref{iostate.flags}
 \change Specify use of \tcode{explicit} in existing boolean conversion functions.
 \rationale Clarify intentions, avoid workarounds.
 \effect
@@ -1509,7 +1509,7 @@ int b0p = F(0p+0);  // ill-formed; equivalent to ``\tcode{int b0p = b0p + 0;}\!'
 
 \rSec2[diff.cpp14.expr]{\ref{expr}: expressions}
 
-\diffref{expr.post.incr}, \ref{expr.pre.incr}
+\diffrefs{expr.post.incr}{expr.pre.incr}
 \change
 Remove increment operator with \tcode{bool} operand.
 \rationale Obsolete feature with occasionally surprising semantics.
@@ -1518,7 +1518,7 @@ a \tcode{bool} lvalue is ill-formed in this International Standard.
 Note that this might occur when the lvalue has a type given by a template
 parameter.
 
-\diffref{expr.new}, \ref{expr.delete}
+\diffrefs{expr.new}{expr.delete}
 \change Dynamic allocation mechanism for over-aligned types.
 \rationale Simplify use of over-aligned types.
 \effect In \CppXIV{} code that uses a \grammarterm{new-expression}


### PR DESCRIPTION
Representative diff:

![t](https://user-images.githubusercontent.com/22357/42136647-c6da9f0c-7d5f-11e8-9c3c-e2466a0d29d8.png)
