### PR TITLE
[concept.swappable] remove wrongly included text

### DIFF
--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -604,24 +604,6 @@ includes:
 \end{itemize}
 \end{itemdescr}
 
-\begin{itemdescr}
-\pnum
-This subclause provides definitions for swappable types and expressions. In
-these definitions, let \tcode{t} denote an expression of type \tcode{T}, and let
-\tcode{u} denote an expression of type \tcode{U}.
-
-\pnum
-An object \tcode{t} is \defn{swappable with} an object \tcode{u} if and only if
-\tcode{\libconcept{SwappableWith}<T, U>} is satisfied.
-\tcode{Swappable\-With<T, U>} is satisfied only if given distinct objects
-\tcode{t2} equal to \tcode{t} and \tcode{u2} equal to \tcode{u}, after
-evaluating either \tcode{ranges::swap(t, u)} or \tcode{ranges::swap(u, t)},
-\tcode{t2} is equal to \tcode{u} and \tcode{u2} is equal to \tcode{t}.
-
-\pnum
-An rvalue or lvalue \tcode{t} is \defn{swappable} if and only if \tcode{t} is
-swappable with any rvalue or lvalue, respectively, of type \tcode{T}.
-
 \pnum
 \begin{example}
 User code can ensure that the evaluation of \tcode{swap} calls
@@ -667,7 +649,6 @@ int main() {
 }
 \end{codeblock}
 \end{example}
-\end{itemdescr}
 
 \rSec2[concept.destructible]{Concept \libconcept{Destructible}}
 


### PR DESCRIPTION
These paragraphs are in magenta in P0898R3 and are not meant to be included into the IS working draft.