### PR TITLE
Fix for typo in code example in [class.copy.elision] section of document

### DIFF
--- a/source/special.tex
+++ b/source/special.tex
@@ -3240,7 +3240,7 @@ constexpr A g() {
 constexpr A a;          // well-formed, \tcode{a.p} points to \tcode{a}
 constexpr A b = g();    // well-formed, \tcode{b.p} points to \tcode{b}
 
-void g() {
+void h() {
   A c = g();            // well-formed, \tcode{c.p} may point to \tcode{c} or to an ephemeral temporary
 }
 \end{codeblock}


### PR DESCRIPTION
In one of the code examples in the [class.copy.elision] section of the document:
As a result of what appears to have been a typo, the function g was
defined twice in the code example.  The second definition of g has been
renamed to h to fix this problem.