### PR TITLE
[structure.specifications] spell static_assert-declaration without \_

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -578,7 +578,7 @@ via a \grammarterm{constraint-expression}\iref{temp.constr.decl}.
 \begin{example}
 An implementation might express such a condition
 via the \grammarterm{constant-expression}
-in a \grammarterm{static\_assert-declaration}\iref{dcl.dcl}.
+in a \grammarterm{static_assert-declaration}\iref{dcl.dcl}.
 If the diagnostic is to be emitted only after the function
 has been selected by overload resolution,
 an implementation might express such a condition


### PR DESCRIPTION
This affects the grammar term index.