### PR TITLE
Travis CI: Check for undefined references.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
   - BUILD_TYPE=make      # build using Makefile
   - BUILD_TYPE=complete  # build manually and regenerate figures, grammar, and cross-references
   - BUILD_TYPE=check-whitespace  # check for whitespace at the ends of lines
-  - BUILD_TYPE=check-newlines  # check for blank lines at the ends of files
+  - BUILD_TYPE=check-newlines    # check for blank lines at the ends of files
   - BUILD_TYPE=check-macro-use   # check for proper macro use
 
 script:
@@ -26,7 +26,8 @@ script:
   - pushd source
   - if [ "$BUILD_TYPE" = "latexmk" ]; then
       docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && latexmk -pdf std -silent";
-      ! grep -Fe "Overfull \\hbox" std.log;
+      ! grep -Fe "Overfull \\hbox" std.log &&
+      ! grep "LaTeX Warning..There were undefined references" std.log;
     fi
   - if [ "$BUILD_TYPE" = "make" ]; then
       docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && make -j2";


### PR DESCRIPTION
This adds a Travis CI check for undefined references (e.g., a `\ref` that points to a nonexistent `\label`).

This PR causes no change in the PDF output.