### PR TITLE
New placeholder macro that uses italics or slanted type depending on the context

### DIFF
--- a/source/macros.tex
+++ b/source/macros.tex
@@ -186,8 +186,36 @@
 \newcommand{\fakegrammarterm}[1]{\gterm{#1}}
 \newcommand{\grammarterm}[1]{\indexgram{\idxgram{#1}}\gterm{#1}}
 \newcommand{\grammartermnc}[1]{\indexgram{\idxgram{#1}}\gterm{#1\nocorr}}
-\newcommand{\placeholder}[1]{\textit{#1}}
-\newcommand{\placeholdernc}[1]{\textit{#1\nocorr}}
+\usepackage{xifthen}
+\usepackage{etoolbox}
+\makeatletter
+\let\std@phcorr\relax
+\newrobustcmd{\placeholder}[1]{%
+  \ifthenelse{\equal{\f@family}{\rmdefault}}{%
+    \textit{#1\std@phcorr}%
+  }{%
+    \ifthenelse{\equal{\f@family}{\ttdefault}}{%
+      \textsl{#1\std@phcorr}%
+    }{%
+      \ifthenelse{\equal{\f@family}{\sfdefault}}{%
+        \textit{#1\std@phcorr}%
+      }{%
+        \textit{#1\std@phcorr}%
+        \PackageWarning{std}{%
+          \string\placeholder\space macro used in unfamiliar environment.%
+          \MessageBreak \string\f@family\space is `\f@family'%
+        }%
+      }%
+    }%
+  }%
+}
+\newrobustcmd{\placeholdernc}[1]{%
+  \begingroup
+    \let\std@phcorr\nocorr
+    \placeholder{#1}%
+  \endgroup
+}
+\makeatother
 \newcommand{\defnxname}[1]{\indextext{\idxxname{#1}}\xname{#1}}
 \newcommand{\defnlibxname}[1]{\indexlibrary{\idxxname{#1}}\xname{#1}}
 

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -536,7 +536,7 @@ a va\-lid expression.
 This constructor shall not participate in overload resolution if \tcode{remove_cvref_t<F>}
 is the same type as \tcode{std::thread}.
 
-\pnum
+\pnum \sloppy
 \effects\ Constructs an object of type \tcode{thread}. The new thread of execution executes
 \tcode{%
 \placeholdernc{INVOKE}(\brk{}%
@@ -556,6 +556,7 @@ std::forward<F>(f)),
 std::forward<Args>(args))...)}
 termi\-nates with an uncaught exception, \tcode{terminate} shall be called.
 
+\fussy
 
 \pnum\sync The completion of the invocation of the constructor
 synchronizes with the beginning of the invocation of the copy of \tcode{f}.

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -3961,11 +3961,14 @@ template<class T> constexpr variant(T&& t) noexcept(@\seebelow@);
 
 \begin{itemdescr}
 \pnum
+\sloppy
 Let $\tcode{T}_j$ be a type that is determined as follows:
 build an imaginary function \tcode{\placeholdernc{FUN}($\tcode{T}_i$)} for each alternative type $\tcode{T}_i$. The overload \tcode{\placeholdernc{FUN}($\tcode{T}_j$)} selected by overload
 resolution for the expression \tcode{\placeholdernc{FUN}(std::forward<T>(\brk{}t))} defines
 the alternative $\tcode{T}_j$ which is the type of the contained value after
 construction.
+
+\fussy
 
 \pnum
 \effects
@@ -4256,12 +4259,15 @@ template<class T> variant& operator=(T&& t) noexcept(@\seebelow@);
 
 \begin{itemdescr}
 \pnum
+\sloppy
 Let $\tcode{T}_j$ be a type that is determined as follows:
 build an imaginary function \tcode{\placeholdernc{FUN}($\tcode{T}_i$)} for each alternative type
 $\tcode{T}_i$. The overload \tcode{\placeholdernc{FUN}($\tcode{T}_j$)} selected by overload
 resolution for the expression \tcode{\placeholdernc{FUN}(std::forward<T>(\brk{}t))} defines
 the alternative $\tcode{T}_j$ which is the type of the contained value after
 assignment.
+
+\fussy
 
 \pnum
 \effects


### PR DESCRIPTION
This PR demonstrates an option outlined in issue #1060: a smarter `\placeholder` macro that typesets the placeholder either italics or slanted depending on whether it's code or roman text.

 * In roman text, it sets the placeholder in italics.
 * In monospaced text, it sets the placeholder in slanted type.
 * In sans serif text, it sets the placeholder in italics.

A diff of the PDFs [is available here](http://kevin.godby.org/temp/cplusplus-draft/std-diff-placeholder.pdf). A sample of pages that differ include 29, 30, 433–435, 880–890.