### PR TITLE
[expr.pre] Add note on operator regrouping here,

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -70,6 +70,53 @@ adjustable by a library function.
 \end{note}
 
 \pnum
+\indextext{operator!precedence of}%
+\indextext{expression!order of evaluation of}%
+\begin{note}
+The implementation may regroup operators according to
+the usual mathematical rules only
+where the operators really are associative or commutative.\footnote{Overloaded
+operators are never assumed to be associative or commutative.}
+For example, in the following fragment
+\begin{codeblock}
+int a, b;
+@\commentellip@
+a = a + 32760 + b + 5;
+\end{codeblock}
+the expression statement behaves exactly the same as
+\begin{codeblock}
+a = (((a + 32760) + b) + 5);
+\end{codeblock}
+due to the associativity and precedence of these operators. Thus, the
+result of the sum \tcode{(a + 32760)} is next added to \tcode{b}, and
+that result is then added to 5 which results in the value assigned to
+\tcode{a}. On a machine in which overflows produce an exception and in
+which the range of values representable by an \tcode{int} is
+\crange{-32768}{+32767}, the implementation cannot rewrite this
+expression as
+\begin{codeblock}
+a = ((a + b) + 32765);
+\end{codeblock}
+since if the values for \tcode{a} and \tcode{b} were, respectively,
+-32754 and -15, the sum \tcode{a + b} would produce an exception while
+the original expression would not; nor can the expression be rewritten
+either as
+\begin{codeblock}
+a = ((a + 32765) + b);
+\end{codeblock}
+or
+\begin{codeblock}
+a = (a + (b + 32765));
+\end{codeblock}
+since the values for \tcode{a} and \tcode{b} might have been,
+respectively, 4 and -8 or -17 and 12. However on a machine in which
+overflows do not produce an exception and in which the results of
+overflows are reversible, the above expression statement can be
+rewritten by the implementation in any of the above ways because the
+same result will occur.
+\end{note}
+
+\pnum
 The values of the floating operands and the results of floating
 expressions may be represented in greater precision and range than that
 required by the type; the types are not changed\

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -551,51 +551,6 @@ These collectively are referred to as the
 \begin{note} More stringent correspondences between abstract and actual
 semantics may be defined by each implementation. \end{note}
 
-\pnum
-\indextext{operator!precedence of}%
-\indextext{expression!order of evaluation of}%
-\begin{note} Operators can be regrouped according to the usual
-mathematical rules only where the operators really are associative or
-commutative.\footnote{Overloaded operators are never assumed to be associative or
-commutative. }
-For example, in the following fragment
-\begin{codeblock}
-int a, b;
-@\commentellip@
-a = a + 32760 + b + 5;
-\end{codeblock}
-the expression statement behaves exactly the same as
-\begin{codeblock}
-a = (((a + 32760) + b) + 5);
-\end{codeblock}
-due to the associativity and precedence of these operators. Thus, the
-result of the sum \tcode{(a + 32760)} is next added to \tcode{b}, and
-that result is then added to 5 which results in the value assigned to
-\tcode{a}. On a machine in which overflows produce an exception and in
-which the range of values representable by an \tcode{int} is
-\crange{-32768}{+32767}, the implementation cannot rewrite this
-expression as
-\begin{codeblock}
-a = ((a + b) + 32765);
-\end{codeblock}
-since if the values for \tcode{a} and \tcode{b} were, respectively,
--32754 and -15, the sum \tcode{a + b} would produce an exception while
-the original expression would not; nor can the expression be rewritten
-either as
-\begin{codeblock}
-a = ((a + 32765) + b);
-\end{codeblock}
-or
-\begin{codeblock}
-a = (a + (b + 32765));
-\end{codeblock}
-since the values for \tcode{a} and \tcode{b} might have been,
-respectively, 4 and -8 or -17 and 12. However on a machine in which
-overflows do not produce an exception and in which the results of
-overflows are reversible, the above expression statement can be
-rewritten by the implementation in any of the above ways because the
-same result will occur. \end{note}
-
 \rSec1[intro.structure]{Structure of this document}
 
 \pnum


### PR DESCRIPTION
moved from [intro.abstract].

Fixes #2251.