### PR TITLE
"cv-qualified versions of cv-unqualified scalar types" are just "scalar types"

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4123,7 +4123,7 @@ and
 cv-qualified\iref{basic.type.qualifier} versions of these
 types are collectively called
 \defnx{scalar types}{scalar type}.
-Cv-unqualified scalar types, trivially copyable class types\iref{class.prop},
+Scalar types, trivially copyable class types\iref{class.prop},
 arrays of such types, and cv-qualified versions of these
 types are collectively called \defn{trivially copyable types}.
 Scalar types, trivial class types\iref{class.prop},


### PR DESCRIPTION
This seems to be cruft accidentally left over from the dueling resolutions of CWG 1746 (which added "cv-unqualified") and CWG 2094 (which added "and cv-qualified versions of these types").

Editorial.