### PR TITLE
Use the Oxford comma in [class.copy.assign].

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1777,11 +1777,11 @@ The implicitly-defined copy/move constructor for a union
 \indextext{operator!move assignment|see{assignment operator, move}}%
 A user-declared \term{copy} assignment operator \tcode{X::operator=} is a
 non-static non-template member function of class \tcode{X} with exactly one
-parameter of type \tcode{X}, \tcode{X\&}, \tcode{const} \tcode{X\&},
-\tcode{volatile} \tcode{X\&} or \tcode{const} \tcode{volatile}
-\tcode{X\&}.\footnote{Because a template assignment operator or an assignment
-operator taking an rvalue reference parameter is never a copy assignment
-operator, the presence of such an assignment operator does not suppress the
+parameter of type \tcode{X}, \tcode{X\&}, \tcode{const X\&},
+\tcode{volatile X\&}, or \tcode{const volatile X\&}.\footnote{Because
+a template assignment operator or an assignment operator
+taking an rvalue reference parameter is never a copy assignment operator,
+the presence of such an assignment operator does not suppress the
 implicit declaration of a copy assignment operator. Such assignment operators
 participate in overload resolution with other assignment operators, including
 copy assignment operators, and, if selected, will be used to assign an object.}
@@ -1838,40 +1838,20 @@ if
 
 \begin{itemize}
 \item
-each direct base class
-\tcode{B}
-of
-\tcode{X}
+each direct base class \tcode{B} of \tcode{X}
 has a copy assignment operator whose parameter is of type
-\tcode{const}
-\tcode{B\&},
-\tcode{const}
-\tcode{volatile}
-\tcode{B\&}
-or
-\tcode{B},
-and
+\tcode{const B\&}, \tcode{const volatile B\&}, or \tcode{B}, and
 \item
-for all the non-static data members of
-\tcode{X}
-that are of a class type
-\tcode{M}
-(or array thereof),
+for all the non-static data members of \tcode{X}
+that are of a class type \tcode{M} (or array thereof),
 each such class type has a copy assignment operator whose parameter is of type
-\tcode{const}
-\tcode{M\&},
-\tcode{const}
-\tcode{volatile}
-\tcode{M\&}
-or
-\tcode{M}.\footnote{This implies that the reference parameter of the
+\tcode{const M\&}, \tcode{const volatile M\&},
+or \tcode{M}.\footnote{This implies that the reference parameter of the
 implicitly-declared copy assignment operator cannot bind to a
-\tcode{volatile}
-lvalue; see~\ref{diff.class}.}
+\tcode{volatile} lvalue; see~\ref{diff.class}.}
 \end{itemize}
 
-Otherwise, the implicitly-declared copy
-assignment operator
+Otherwise, the implicitly-declared copy assignment operator
 will have the form
 
 \begin{codeblock}


### PR DESCRIPTION
And turn a bunch of `\tcode{const} \tcode{X}` into `\tcode{const X}` on the assumption that this is better. (I see the latter style being used elsewhere, and it's certainly more readable in the TeX source.)