### PR TITLE
Simplify definition of "data race"

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5037,11 +5037,6 @@ and detailed visibility constraints. However, it also implicitly supports a
 simpler view for more restricted programs. \end{note}
 
 \pnum
-Two expression evaluations \defn{conflict} if one of them modifies a memory
-location\iref{intro.memory} and the other one reads or modifies the same
-memory location.
-
-\pnum
 The library defines a number of atomic operations\iref{atomics} and
 operations on mutexes\iref{thread} that are specially identified as
 synchronization operations. These operations play a special role in making
@@ -5304,15 +5299,19 @@ suitably chosen modification orders and the ``happens before'' relation derived
 as described above, satisfy the resulting constraints as imposed here. \end{note}
 
 \pnum
-Two actions are \defn{potentially concurrent} if
+Two actions \defn{conflict} if one of them modifies a memory
+location\iref{intro.memory}, the other one reads or modifies the same
+memory location, and at least one of them is not atomic.
+
+\pnum
+Two actions are \defn{potentially concurrent} if they are unsequenced, and
 \begin{itemize}
 \item they are performed by different threads, or
-\item they are unsequenced, at least one is performed by a signal handler, and
+\item at least one is performed by a signal handler, and
 they are not both performed by the same signal handler invocation.
 \end{itemize}
 The execution of a program contains a \defn{data race} if it contains two
-potentially concurrent conflicting actions, at least one of which is not atomic,
-and neither happens before the other,
+potentially concurrent conflicting actions,
 except for the special case for signal handlers described below.
 Any such data race results in undefined
 behavior. \begin{note} It can be shown that programs that correctly use mutexes

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5304,10 +5304,11 @@ location\iref{intro.memory}, the other one reads or modifies the same
 memory location, and at least one of them is not atomic.
 
 \pnum
-Two actions are \defn{potentially concurrent} if they are unsequenced, and
+Two actions are \defn{potentially concurrent} if
 \begin{itemize}
-\item they are performed by different threads, or
-\item at least one is performed by a signal handler, and
+\item they are performed by different threads, and neither happens before the
+other, or
+\item they are unsequenced, at least one is performed by a signal handler, and
 they are not both performed by the same signal handler invocation.
 \end{itemize}
 The execution of a program contains a \defn{data race} if it contains two


### PR DESCRIPTION
... by moving details into the definitions of "conflict" and "potentially concurrent".

I believe this change is editorial (has no normative impact), but I'm going to solicit feedback from SG1 since it changes the meanings of "conflict" and "potentially concurrent" in a way that could affect usages outside the standard.