### PR TITLE
[span.overview] Move requirements on types to after the synposis.

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -9807,13 +9807,6 @@ A \tcode{span} is a view over a contiguous sequence of objects,
 the storage of which is owned by some other object.
 
 \pnum
-\tcode{ElementType} is required to be a complete object type that is not an abstract class type.
-
-\pnum
-If \tcode{Extent} is negative and not equal to \tcode{dynamic_extent},
-the program is ill-formed.
-
-\pnum
 The iterator types \tcode{span::iterator} and \tcode{span::const_iterator} are
 random access iterators\iref{random.access.iterators},
 contiguous iterators\iref{iterator.requirements.general}, and
@@ -9915,6 +9908,14 @@ namespace std {
     span(const Container&) -> span<const typename Container::value_type>;
 }
 \end{codeblock}
+
+\pnum
+\tcode{ElementType} is required to be
+a complete object type that is not an abstract class type.
+
+\pnum
+If \tcode{Extent} is negative and not equal to \tcode{dynamic_extent},
+the program is ill-formed.
 
 \rSec3[span.cons]{Constructors, copy, and assignment}
 


### PR DESCRIPTION
As described in [structure.specifications].

Fixes #2235.