### PR TITLE
[iterators.general] Fixup Iterators library summary table

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -19,10 +19,12 @@ and stream iterators,
 as summarized in \tref{iterators.lib.summary}.
 
 \begin{libsumtab}{Iterators library summary}{tab:iterators.lib.summary}
-\ref{iterator.requirements} & Requirements        &                           \\ \rowsep
-\ref{iterator.primitives} & Iterator primitives   &   \tcode{<iterator>}      \\
-\ref{predef.iterators} & Predefined iterators     &                           \\
-\ref{stream.iterators} & Stream iterators         &                           \\
+\ref{iterator.requirements} & Requirements              &                    \\ \rowsep
+\ref{iterator.primitives}   & Iterator primitives       & \tcode{<iterator>} \\
+\ref{predef.iterators}      & Iterator adaptors         &                    \\
+\ref{stream.iterators}      & Stream iterators          &                    \\
+\ref{iterator.range}        & Range access              &                    \\
+\ref{iterator.container}    & Container and view access &                    \\
 \end{libsumtab}
 
 


### PR DESCRIPTION
by correcting the title for [predef.iterators] to "Iterator adaptors", and adding rows for [iterator.range] and [iterator.container].