### PR TITLE
[basic.lval,expr.delete] 'dynamic type' refers to lvalues, not objects

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -2242,9 +2242,10 @@ non-virtual destructor of the destructor's class (see~\ref{expr.delete}).
 If the lookup fails or if the deallocation function has
 a deleted definition\iref{dcl.fct.def}, the program is ill-formed.
 \begin{note}
-This assures that a deallocation function corresponding to the dynamic type of an
-object is available for the
-\grammarterm{delete-expression}\iref{class.free}.
+This assures that a deallocation function
+is available for a \grammarterm{delete-expression}\iref{class.free},
+even if the static type of the object to which the operand points
+is a base class of the object to be deleted.
 \end{note}
 
 \pnum

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -306,7 +306,7 @@ The intent of this list is to specify those circumstances in which an
 object can or cannot be aliased.
 \end{footnote}
 \begin{itemize}
-\item the dynamic type of the object,
+\item \cv{} \tcode{T}
 
 \item a type that is the signed or unsigned type corresponding to the
 dynamic type of the object, or
@@ -3102,10 +3102,10 @@ called. Otherwise, its final overrider\iref{class.virtual} in the dynamic type
 of the object expression is called; such a call is referred to as a
 \defnx{virtual function call}{function!virtual function call}.
 \begin{note}
-The dynamic type is the type of the object referred to by the
-current value of the object expression. \ref{class.cdtor}~describes the
-behavior of virtual function calls when the object expression
-refers to
+The dynamic type is the type of the most derived object referred to by the
+current value of the object expression\iref{defns.dynamic.type}.
+\ref{class.cdtor}~describes the behavior of virtual function calls
+when the object expression refers to
 an object under construction or destruction.
 \end{note}
 
@@ -4028,10 +4028,10 @@ contains the original member, or is a base or derived class of the class
 containing the original member, the resulting pointer to member points
 to the original member. Otherwise, the behavior is undefined.
 \begin{note}
-Although class \tcode{B} need not contain the original member, the
-dynamic type of the object with which indirection through the pointer
-to member is performed must contain the original member;
-see~\ref{expr.mptr.oper}.
+Although class \tcode{B} need not contain the original member,
+the dynamic type of the object expression
+appearing in a pointer-to-member operation
+must contain the original member; see~\ref{expr.mptr.oper}.
 \end{note}
 
 \pnum
@@ -5537,6 +5537,8 @@ If the operand has a class type, the operand is converted to a pointer
 type by calling the above-mentioned conversion function, and the
 converted operand is used in place of the original operand for the
 remainder of this subclause.
+The lvalue formed by indirection of the operand is said to refer
+to the object to be deleted.
 In a single-object delete expression, the value of the operand of
 \keyword{delete} may be a null pointer value,
 a pointer value
@@ -5569,14 +5571,15 @@ used as the operand of the \grammarterm{delete-expression}.
 
 \pnum
 \indextext{\idxcode{delete}!undefined}%
-In a single-object delete expression, if the static type of the object to be
-deleted is not similar\iref{conv.qual} to its dynamic type
+In a single-object delete expression, if the static type of the lvalue
+that refers to the object to be deleted is not similar\iref{conv.qual} to its dynamic type
 and the selected deallocation function (see below)
 is not a destroying operator delete,
 the static type shall be a base
 class of the dynamic type of the object to be deleted and the static type shall
-have a virtual destructor or the behavior is undefined. In an array delete
-expression, if the dynamic type of the object to be deleted is not similar to
+have a virtual destructor or the behavior is undefined.
+In an array delete expression, if the dynamic type of the lvalue
+that refers to the first element of the object to be deleted is not similar to
 its static type, the behavior is undefined.
 
 \pnum


### PR DESCRIPTION
Fixes #2190.