### PR TITLE
[mem.res.class] Add default constructor

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -11183,6 +11183,7 @@ namespace std::pmr {
     static constexpr size_t max_align = alignof(max_align_t);   // \expos
 
   public:
+    memory_resource() = default;
     memory_resource(const memory_resource&) = default;
     virtual ~memory_resource();
 


### PR DESCRIPTION
The addition of a copy constructor by P0619R4 caused the default
constructor to be suppressed, which was not intended.