### PR TITLE
[dcl.array] Rework description.

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2959,89 +2959,76 @@ There is no ``reference-to-member'' type in \Cpp{}.
 \indextext{declarator!array}
 
 \pnum
-In a declaration
-\tcode{T}
-\tcode{D}
-where
-\tcode{D}
-has the form
+In a declaration \tcode{T} \tcode{D} where \tcode{D} has the form
 
 \begin{ncsimplebnf}
 \terminal{D1} \terminal{[} \opt{constant-expression} \terminal{]} \opt{attribute-specifier-seq}
 \end{ncsimplebnf}
 
-and the type of the identifier in the declaration
-\tcode{T}
-\tcode{D1}
-is
-``\placeholder{derived-declarator-type-list}
-\tcode{T}'',
-then the type of the identifier of
-\tcode{D}
-is an array type; if the type of the identifier of \tcode{D}
-contains the \tcode{auto} \grammarterm{type-specifier},
-the program is ill-formed.
-\tcode{T}
-is called the array
-\term{element type};
-this type shall not be a reference type, \cv{}~\tcode{void},
-or a function type.
-\indextext{declaration!array}%
-If the
-\grammarterm{constant-expression}\iref{expr.const}
-is present, it shall be a converted constant
-expression of type \tcode{std::size_t} and
-its value shall be greater than zero.
-The constant expression specifies the
-\indextext{array!bound}%
+and the type of the contained \grammarterm{declarator-id}
+in the declaration \tcode{T} \tcode{D1}
+is ``\placeholder{derived-declarator-type-list} \tcode{T}'',
+the type of the \grammarterm{declarator-id} in \tcode{D} is
+``\placeholder{derived-declarator-type-list} array of \tcode{N} \tcode{T}''.
+The \grammarterm{constant-expression}
+shall be a converted constant expression of type \tcode{std::size_t}\iref{expr.const}.
 \indextext{bound, of array}%
-\term{bound}
-of (number of elements in) the array.
-If the value of the constant expression is
-\tcode{N},
-the array has
-\tcode{N}
-elements numbered
-\tcode{0}
-to
-\tcode{N-1},
-and the type of the identifier of
-\tcode{D}
-is ``\placeholder{derived-declarator-type-list} array of
-\tcode{N}
-\tcode{T}''.
-An object of array type contains a contiguously allocated non-empty set of
-\tcode{N}
-subobjects of type
-\tcode{T}.
-Except as noted below, if
-the constant expression is omitted, the type of the identifier of
-\tcode{D}
-is ``\placeholder{derived-declarator-type-list} array of unknown bound of
-\tcode{T}'',
-an incomplete object type.
-The type ``\placeholder{derived-declarator-type-list} array of
-\tcode{N}
-\tcode{T}''
-is a different type from the type
-``\placeholder{derived-declarator-type-list} array of unknown bound of
-\tcode{T}'',
-see~\ref{basic.types}.
-Any type of the form
-``\grammarterm{cv-qualifier-seq} array of
-\tcode{N}
-\tcode{T}''
-is adjusted to
-``array of
-\tcode{N}
-\grammarterm{cv-qualifier-seq}
-\tcode{T}'',
-and similarly for
-``array of unknown bound of
-\tcode{T}''.
-The optional \grammarterm{attribute-specifier-seq} appertains to the array.
-\begin{example}
+Its value \tcode{N} specifies the \defnx{array bound}{array!bound},
+i.e., the number of elements in the array;
+\tcode{N} shall be greater than zero.
 
+\pnum
+In a declaration \tcode{T} \tcode{D} where \tcode{D} has the form
+
+\begin{ncsimplebnf}
+\terminal{D1 [ ]} \opt{attribute-specifier-seq}
+\end{ncsimplebnf}
+
+and the type of the contained \grammarterm{declarator-id}
+in the declaration \tcode{T} \tcode{D1}
+is ``\placeholder{derived-declarator-type-list} \tcode{T}'',
+the type of the \grammarterm{declarator-id} in \tcode{D} is
+``\placeholder{derived-declarator-type-list} array of unknown bound of \tcode{T}'', except as specified below.
+
+\pnum
+\indextext{declaration!array}%
+A type of the form ``array of \tcode{N} \tcode{U}'' or
+``array of unknown bound of \tcode{U}'' is an \defn{array type}.
+The optional \grammarterm{attribute-specifier-seq}
+appertains to the array type.
+
+\pnum
+\tcode{U} is called the array \defn{element type};
+this type shall not be
+a placeholder type\iref{dcl.spec.auto},
+a reference type,
+a function type,
+an array of unknown bound, or
+\cv{}~\tcode{void}.
+\begin{note}
+An array can be constructed
+from one of the fundamental types (except \tcode{void}),
+from a pointer,
+from a pointer to member,
+from a class,
+from an enumeration type,
+or from an array of known bound.
+\end{note}
+\begin{example}
+\begin{codeblock}
+float fa[17], *afp[17];
+\end{codeblock}
+declares an array of \tcode{float} numbers and
+an array of pointers to \tcode{float} numbers.
+\end{example}
+
+\pnum
+Any type of the form
+``\grammarterm{cv-qualifier-seq} array of \tcode{N} \tcode{U}''
+is adjusted to
+``array of \tcode{N} \grammarterm{cv-qualifier-seq} \tcode{U}'',
+and similarly for ``array of unknown bound of \tcode{U}''.
+\begin{example}
 \begin{codeblock}
 typedef int A[5], AA[2][3];
 typedef const A CA;             // type is ``array of 5 \tcode{const int}''
@@ -3049,69 +3036,60 @@ typedef const AA CAA;           // type is ``array of 2 array of 3 \tcode{const 
 \end{codeblock}
 \end{example}
 \begin{note}
-An
-``array of
-\tcode{N}
-\grammarterm{cv-qualifier-seq}
-\tcode{T}''
+An ``array of \tcode{N} \grammarterm{cv-qualifier-seq} \tcode{U}''
 has cv-qualified type; see~\ref{basic.type.qualifier}.
 \end{note}
 
 \pnum
-An array can be constructed from one of the fundamental types
-(except
-\tcode{void}),
-from a pointer,
-from a pointer to member, from a class,
-from an enumeration type,
-or from another array.
+An object of type ``array of \tcode{N} \tcode{U}'' contains
+a contiguously allocated non-empty set
+of \tcode{N} subobjects of type \tcode{U},
+known as the \defnx{elements}{array!element} of the array,
+and numbered \tcode{0} to \tcode{N-1}.
 
 \pnum
-\indextext{declarator!multidimensional array}%
-When several ``array of'' specifications are adjacent, a
-multidimensional array
-type is created;
-only the first of
-the constant expressions that specify the bounds
-of the arrays may be omitted.
 In addition to declarations in which an incomplete object type is allowed,
 an array bound may be omitted in some cases in the declaration of a function
 parameter\iref{dcl.fct}.
 An array bound may also be omitted
-when the declarator is followed by an
-\grammarterm{initializer}\iref{dcl.init},
-when a declarator for a static data member is followed by a
-\grammarterm{brace-or-equal-initializer}\iref{class.mem},
-or in an explicit type conversion\iref{expr.type.conv}.
-In these cases, the bound is calculated from the number
+when an object (but not a non-static data member) of array type is initialized
+and the declarator is followed by an initializer
+(\ref{dcl.init}, \ref{class.mem}, \ref{expr.type.conv}, \ref{expr.new}).
 \indextext{array size!default}%
-of initial elements (say,
-\tcode{N})
+In these cases, the array bound is calculated
+from the number of initial elements (say, \tcode{N})
 supplied\iref{dcl.init.aggr},
-and the type of the identifier of
-\tcode{D}
-is ``array of
-\tcode{N}
-\tcode{T}''.
+and the type of the array is ``array of \tcode{N} \tcode{U}''.
+
+\pnum
 Furthermore, if there is a preceding declaration of the entity in the same
 scope in which the bound was specified, an omitted array bound is taken to
 be the same as in that earlier declaration, and similarly for the definition
 of a static data member of a class.
-
-\pnum
 \begin{example}
 \begin{codeblock}
-float fa[17], *afp[17];
+extern int x[10];
+struct S {
+  static int y[10];
+};
+
+int x[];                // OK: bound is 10
+int S::y[];             // OK: bound is 10
+
+void f() {
+  extern int x[];
+  int i = sizeof(x);    // error: incomplete object type
+}
 \end{codeblock}
-declares an array of
-\tcode{float}
-numbers and an array of
-pointers to
-\tcode{float}
-numbers.
 \end{example}
 
 \pnum
+\indextext{declarator!multidimensional array}%
+\begin{note}
+When several ``array of'' specifications are adjacent,
+a multidimensional array type is created;
+only the first of the constant expressions
+that specify the bounds of the arrays may be omitted.
 \begin{example}
 \begin{codeblock}
 int x3d[3][5][7];
@@ -3166,29 +3144,10 @@ the $\tcode{i}^\text{th}$ array element of
 \tcode{x3d}
 (an integer).
 \end{example}
-\begin{note}
 The first subscript in the declaration helps determine
 the amount of storage consumed by an array
 but plays no other part in subscript calculations.
 \end{note}
-
-\pnum
-\begin{example}
-\begin{codeblock}
-extern int x[10];
-struct S {
-  static int y[10];
-};
-
-int x[];                // OK: bound is 10
-int S::y[];             // OK: bound is 10
-
-void f() {
-  extern int x[];
-  int i = sizeof(x);    // error: incomplete object type
-}
-\end{codeblock}
-\end{example}
 
 \pnum
 \begin{note}


### PR DESCRIPTION
Group examples with the corresponding normative statements.
Clarify the meaning of 'array type'.
Use 'declarator-id' instead of 'identifier'.

Fixes #2175.