### PR TITLE
[class.dtor] Clean up awkward '.. is the type of the class' phrasing.

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -2281,7 +2281,7 @@ direct non-variant non-static data members, the destructors for
 \tcode{X}'s
 non-virtual direct base classes and, if
 \tcode{X}
-is the type of the most derived class\iref{class.base.init},
+is the most derived class\iref{class.base.init},
 its destructor calls the destructors for
 \tcode{X}'s
 virtual base classes.


### PR DESCRIPTION
Bit simpler this way, and slightly shortens a pretty long sentence.