### PR TITLE
[dcl.dcl] Remove incorrect footnote about the implicit int rule.

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -230,8 +230,7 @@ any appropriate initialization\iref{dcl.init} to be done.
 
 \pnum
 A \grammarterm{nodeclspec-function-declaration} shall declare a
-constructor, destructor, or conversion function.\footnote{The
-``implicit int'' rule of C is no longer supported.}
+constructor, destructor, or conversion function.
 \begin{note}
 A \grammarterm{nodeclspec-function-declaration} can only be used in a
 \grammarterm{template-declaration}\iref{temp},


### PR DESCRIPTION
Fixes #2276.