### PR TITLE
[containers,utilities] Mark exposition-only names

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -1236,7 +1236,7 @@ the allocator of the container when the element was extracted. If a node handle
 is empty, it contains no allocator.
 
 \pnum
-Class \tcode{\placeholder{node_handle}} is for exposition only. An implementation is
+Class \tcode{\placeholder{node-handle}} is for exposition only. An implementation is
 permitted to provide equivalent functionality without providing a class with
 this name.
 
@@ -1249,7 +1249,7 @@ undefined.
 
 \begin{codeblock}
 template<@\unspecnc@>
-class @\placeholder{node_handle}@ {
+class @\placeholder{node-handle}@ {
 public:
   // These type declarations are described in Tables \ref{tab:containers.associative.requirements} and \ref{tab:HashRequirements}.
   using value_type     = @\seebelownc{}@;     // not present for map containers
@@ -1266,12 +1266,12 @@ private:
 
 public:
   // \ref{container.node.cons}, constructors, copy, and assignment
-  constexpr @\placeholdernc{node_handle}@() noexcept : ptr_(), alloc_() {}
-  @\placeholdernc{node_handle}@(@\placeholdernc{node_handle}@&&) noexcept;
-  @\placeholdernc{node_handle}@& operator=(@\placeholdernc{node_handle}@&&);
+  constexpr @\placeholdernc{node-handle}@() noexcept : ptr_(), alloc_() {}
+  @\placeholdernc{node-handle}@(@\placeholdernc{node-handle}@&&) noexcept;
+  @\placeholdernc{node-handle}@& operator=(@\placeholdernc{node-handle}@&&);
 
   // \ref{container.node.dtor}, destructor
-  ~@\placeholdernc{node_handle}@();
+  ~@\placeholdernc{node-handle}@();
 
   // \ref{container.node.observers}, observers
   value_type& value() const;            // not present for map containers
@@ -1283,11 +1283,11 @@ public:
   [[nodiscard]] bool empty() const noexcept;
 
   // \ref{container.node.modifiers}, modifiers
-  void swap(@\placeholdernc{node_handle}@&)
+  void swap(@\placeholdernc{node-handle}@&)
     noexcept(ator_traits::propagate_on_container_swap::value ||
              ator_traits::is_always_equal::value);
 
-  friend void swap(@\placeholdernc{node_handle}@& x, @\placeholdernc{node_handle}@& y) noexcept(noexcept(x.swap(y))) {
+  friend void swap(@\placeholdernc{node-handle}@& x, @\placeholdernc{node-handle}@& y) noexcept(noexcept(x.swap(y))) {
     x.swap(y);
   }
 };
@@ -1296,19 +1296,19 @@ public:
 \rSec3[container.node.cons]{Constructors, copy, and assignment}
 
 \begin{itemdecl}
-@\placeholdernc{node_handle}@(@\placeholdernc{node_handle}@&& nh) noexcept;
+@\placeholdernc{node-handle}@(@\placeholdernc{node-handle}@&& nh) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{\placeholder{node_handle}} object initializing
+\effects Constructs a \tcode{\placeholder{node-handle}} object initializing
 \tcode{ptr_} with \tcode{nh.ptr_}.  Move constructs \tcode{alloc_} with
 \tcode{nh.alloc_}.  Assigns \tcode{nullptr} to \tcode{nh.ptr_} and assigns
 \tcode{nullopt} to \tcode{nh.alloc_}.
 \end{itemdescr}
 
 \begin{itemdecl}
-@\placeholdernc{node_handle}@& operator=(@\placeholdernc{node_handle}@&& nh);
+@\placeholdernc{node-handle}@& operator=(@\placeholdernc{node-handle}@&& nh);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1344,7 +1344,7 @@ Assigns
 \rSec3[container.node.dtor]{Destructor}
 
 \begin{itemdecl}
-~@\placeholdernc{node_handle}@();
+~@\placeholdernc{node-handle}@();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1447,7 +1447,7 @@ explicit operator bool() const noexcept;
 \rSec3[container.node.modifiers]{Modifiers}
 
 \begin{itemdecl}
-void swap(@\placeholdernc{node_handle}@& nh)
+void swap(@\placeholdernc{node-handle}@& nh)
   noexcept(ator_traits::propagate_on_container_swap::value ||
            ator_traits::is_always_equal::value);
 \end{itemdecl}
@@ -1469,11 +1469,11 @@ is \tcode{true} calls \tcode{swap(alloc_, nh.alloc_)}.
 \pnum
 The associative containers with unique keys and the unordered containers with unique keys
 have a member function \tcode{insert} that returns a nested type \tcode{insert_return_type}.
-That return type is a specialization of the type specified in this subclause.
+That return type is a specialization of the template specified in this subclause.
 
 \begin{codeblock}
 template<class Iterator, class NodeType>
-struct @\placeholder{INSERT_RETURN_TYPE}@
+struct @\placeholder{insert-return-type}@
 {
   Iterator position;
   bool     inserted;
@@ -1482,8 +1482,8 @@ struct @\placeholder{INSERT_RETURN_TYPE}@
 \end{codeblock}
 
 \pnum
-The name \tcode{\placeholder{INSERT_RETURN_TYPE}} is exposition only.
-\tcode{\placeholder{INSERT_RETURN_TYPE}} has the template parameters,
+The name \tcode{\placeholder{insert-return-type}} is exposition only.
+\tcode{\placeholder{insert-return-type}} has the template parameters,
 data members, and special members specified above.
 It has no base classes or members other than those specified.
 
@@ -1681,7 +1681,7 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 
 \indexordmem{node_type}%
 \tcode{X::node_type} &
- a specialization of a \tcode{\placeholder{node_handle}}
+ a specialization of a \tcode{\placeholder{node-handle}}
  class template, such that the public nested types are
  the same types as the corresponding types in \tcode{X}. &
  see~\ref{container.node} &
@@ -2360,7 +2360,7 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 %
 \indexunordmem{node_type}%
 \tcode{X::node_type} &
- a specialization of a \tcode{\placeholder{node_handle}}
+ a specialization of a \tcode{\placeholder{node-handle}}
  class template, such that the public nested types are
  the same types as the corresponding types in \tcode{X}. &
  see~\ref{container.node} &
@@ -6047,7 +6047,7 @@ namespace std {
     using reverse_iterator       = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
     using node_type              = @\unspec@;
-    using insert_return_type     = @\placeholdernc{INSERT_RETURN_TYPE}@<iterator, node_type>;
+    using insert_return_type     = @\placeholdernc{insert-return-type}@<iterator, node_type>;
 
     class value_compare {
       friend class map;
@@ -6862,7 +6862,7 @@ namespace std {
     using reverse_iterator       = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
     using node_type              = @\unspec@;
-    using insert_return_type     = @\placeholdernc{INSERT_RETURN_TYPE}@<iterator, node_type>;
+    using insert_return_type     = @\placeholdernc{insert-return-type}@<iterator, node_type>;
 
     // \ref{set.cons}, construct/copy/destroy
     set() : set(Compare()) { }
@@ -7502,7 +7502,7 @@ namespace std {
     using local_iterator       = @\impdefx{type of \tcode{unordered_map::local_iterator}}@; // see \ref{container.requirements}
     using const_local_iterator = @\impdefx{type of \tcode{unordered_map::const_local_iterator}}@; // see \ref{container.requirements}
     using node_type            = @\unspec@;
-    using insert_return_type   = @\placeholdernc{INSERT_RETURN_TYPE}@<iterator, node_type>;
+    using insert_return_type   = @\placeholdernc{insert-return-type}@<iterator, node_type>;
 
     // \ref{unord.map.cnstr}, construct/copy/destroy
     unordered_map();
@@ -8377,7 +8377,7 @@ namespace std {
     using local_iterator       = @\impdefx{type of \tcode{unordered_set::local_iterator}}@; // see \ref{container.requirements}
     using const_local_iterator = @\impdefx{type of \tcode{unordered_set::const_local_iterator}}@; // see \ref{container.requirements}
     using node_type            = @\unspec@;
-    using insert_return_type   = @\placeholdernc{INSERT_RETURN_TYPE}@<iterator, node_type>;
+    using insert_return_type   = @\placeholdernc{insert-return-type}@<iterator, node_type>;
 
     // \ref{unord.set.cnstr}, construct/copy/destroy
     unordered_set();

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1729,14 +1729,14 @@ template<class F, class Tuple>
 Given the exposition-only function:
 \begin{codeblock}
 template<class F, class Tuple, size_t... I>
-constexpr decltype(auto)
-    apply_impl(F&& f, Tuple&& t, index_sequence<I...>) {                // exposition only
+constexpr decltype(auto) @\placeholdernc{apply-impl}@(F&& f, Tuple&& t, index_sequence<I...>) {
+                                                                        // \expos
   return @\placeholdernc{INVOKE}@(std::forward<F>(f), std::get<I>(std::forward<Tuple>(t))...);  // see \ref{func.require}
 }
 \end{codeblock}
 Equivalent to:
 \begin{codeblock}
-return apply_impl(std::forward<F>(f), std::forward<Tuple>(t),
+return @\placeholdernc{apply-impl}@(std::forward<F>(f), std::forward<Tuple>(t),
                   make_index_sequence<tuple_size_v<remove_reference_t<Tuple>>>{});
 \end{codeblock}
 \end{itemdescr}
@@ -1753,13 +1753,13 @@ template<class T, class Tuple>
 Given the exposition-only function:
 \begin{codeblock}
 template<class T, class Tuple, size_t... I>
-constexpr T make_from_tuple_impl(Tuple&& t, index_sequence<I...>) {     // exposition only
+constexpr T @\placeholdernc{make-from-tuple-impl}@(Tuple&& t, index_sequence<I...>) {     // exposition only
   return T(get<I>(std::forward<Tuple>(t))...);
 }
 \end{codeblock}
 Equivalent to:
 \begin{codeblock}
-return make_from_tuple_impl<T>(
+return @\placeholdernc{make-from-tuple-impl}@<T>(
            forward<Tuple>(t),
            make_index_sequence<tuple_size_v<remove_reference_t<Tuple>>>{});
 \end{codeblock}
@@ -14196,18 +14196,18 @@ template<class F> @\unspec@ not_fn(F&& f);
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return \placeholder{call_wrapper}(std::forward<F>(f));}
-where \tcode{\placeholder{call_wrapper}} is an exposition only class defined as follows:
+Equivalent to: \tcode{return \placeholder{call-wrapper}(std::forward<F>(f));}
+where \tcode{\placeholder{call-wrapper}} is an exposition only class defined as follows:
 \begin{codeblock}
-class @\placeholder{call_wrapper}@ {
+class @\placeholder{call-wrapper}@ {
   using FD = decay_t<F>;
   FD fd;
 
-  explicit @\placeholder{call_wrapper}@(F&& f);
+  explicit @\placeholder{call-wrapper}@(F&& f);
 
 public:
-  @\placeholder{call_wrapper}@(@\placeholder{call_wrapper}@&&) = default;
-  @\placeholder{call_wrapper}@(const @\placeholder{call_wrapper}@&) = default;
+  @\placeholder{call-wrapper}@(@\placeholder{call-wrapper}@&&) = default;
+  @\placeholder{call-wrapper}@(const @\placeholder{call-wrapper}@&) = default;
 
   template<class... Args>
     auto operator()(Args&&...) &
@@ -14229,7 +14229,7 @@ public:
 \end{itemdescr}
 
 \begin{itemdecl}
-explicit @\placeholdernc{call_wrapper}@(F&& f);
+explicit @\placeholdernc{call-wrapper}@(F&& f);
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
with italics teletype and use hyphens, not underscores,
to highlight that these are not standard-prescribed names.

Fixes #2014.

There is also a drive-by that adjusts "type" to "template".