### PR TITLE
[expr.new] Use 'object', not 'entity', for new-expression.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4369,19 +4369,6 @@ object created by the \grammarterm{new-expression} has a cv-qualified type.
     braced-init-list
 \end{bnf}
 
-\indextext{storage duration!dynamic}%
-Entities created by a \grammarterm{new-expression} have dynamic storage
-duration\iref{basic.stc.dynamic}.
-\begin{note}
-\indextext{\idxcode{new}!scoping and}%
-The lifetime of such an entity is not necessarily restricted to the
-scope in which it is created.
-\end{note}
-If the entity is a non-array object, the result of the \grammarterm{new-expression}
-is a pointer to the object created. If it is an array, the result of the
-\grammarterm{new-expression} is a pointer to the initial element of
-the array.
-
 \pnum
 If a placeholder type\iref{dcl.spec.auto} appears in the
 \grammarterm{type-specifier-seq} of a \grammarterm{new-type-id} or
@@ -4454,6 +4441,18 @@ allocates an array of \tcode{10} pointers to functions (taking no
 argument and returning \tcode{int}).
 \end{example}
 \end{note}
+
+\pnum
+\indextext{storage duration!dynamic}%
+Objects created by a \grammarterm{new-expression} have dynamic storage
+duration\iref{basic.stc.dynamic}.
+\begin{note}
+\indextext{\idxcode{new}!scoping and}%
+The lifetime of such an object is not necessarily restricted to the
+scope in which it is created.
+\end{note}
+When the allocated object is not an array, the result of the \grammarterm{new-expression}
+is a pointer to the object created.
 
 \pnum
 \indextext{array!\idxcode{new}}%


### PR DESCRIPTION
The term 'entity' is too generic here.
Also move the specification of the non-array return
value just before the array case, after the description
of the parsing disambiguation.

Fixes #2279.