### PR TITLE
[fs.filesystem.syn] Fixes related to chrono::file_clock usage in <filesystem>

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -10797,6 +10797,8 @@ subclause are assumed to be qualified with \tcode{::std::filesystem::}.
 \indexhdr{filesystem}%
 
 \begin{codeblock}
+#include <chrono>  // see \ref{[time.syn}
+
 namespace std::filesystem {
   // \ref{fs.class.path}, paths
   class path;
@@ -11009,9 +11011,6 @@ namespace std::filesystem {
 \end{codeblock}
 
 \pnum
-\tcode{\textit{trivial-clock}} is an \impldef{type of filesystem trivial clock} type
-that satisfies the \oldconcept{TrivialClock} requirements\iref{time.clock.req}
-and that is capable of representing and measuring file time values.
 Implementations should ensure that the resolution and range of
 \tcode{file_time_type} reflect the operating system dependent resolution and range
 of file time values.

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -10797,8 +10797,6 @@ subclause are assumed to be qualified with \tcode{::std::filesystem::}.
 \indexhdr{filesystem}%
 
 \begin{codeblock}
-#include <chrono>  // see \ref{[time.syn}
-
 namespace std::filesystem {
   // \ref{fs.class.path}, paths
   class path;


### PR DESCRIPTION
The synopsis of <filesystem> refers to the types chrono::time_point and chrono::file_clock, so it must include <chrono> for their declarations
The removed paragraph refers to trivial-clock that has now been replaced by chrono::file_clock. The paragraph is now unnecessary since chrono::file_clock is fully described in [time.clock.file].
See also http://cplusplus.github.io/LWG/lwg-active.html#3145