### PR TITLE
[temp.param] fix spaceship example

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -415,7 +415,6 @@ Otherwise, if it is of class type \tcode{T},
 it is an lvalue and has type \tcode{const T}\iref{expr.prim.id.unqual}.
 \end{note}
 \begin{example}
-
 \begin{codeblock}
 struct A { friend auto operator<=>(const A&, const A&) = default; };
 template<const X& x, int i, A a> void f() {

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -417,7 +417,7 @@ it is an lvalue and has type \tcode{const T}\iref{expr.prim.id.unqual}.
 \begin{example}
 
 \begin{codeblock}
-struct A { auto operator<=>(A, A) = default; };
+struct A { friend auto operator<=>(const A&, const A&) = default; };
 template<const X& x, int i, A a> void f() {
   i++;                          // error: change of template-parameter value
 


### PR DESCRIPTION
A two parameter spaceship can't be a member, and the parameter types for a defaulted operator can only be const C& ([class.compare.default]p1).