### PR TITLE
[forwardlist.modifiers] Remove index entry for forward_list::erased

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -4171,7 +4171,6 @@ erased, or \tcode{end()} if no such element exists.
 \throws Nothing.
 \end{itemdescr}
 
-\indexlibrarymember{erased}{forward_list}%
 \begin{itemdecl}
 iterator erase_after(const_iterator position, const_iterator last);
 \end{itemdecl}


### PR DESCRIPTION
There is no such member. The previous overload of forward_list::erase is
already indexed.