### PR TITLE
[std] Replace use of 'structure' by 'class'

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2588,7 +2588,7 @@ in the same struct if all fields between them are also bit-fields of nonzero
 width. \end{note}
 
 \pnum
-\begin{example} A structure declared as
+\begin{example} A class declared as
 
 \begin{codeblock}
 struct {

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -15009,7 +15009,7 @@ Two paths are considered to resolve to the same file system entity if two
   candidate entities reside on the same device at the same location.
   \begin{note}
   On POSIX platforms, this is
-  determined as if by the values of the POSIX \tcode{stat} structure,
+  determined as if by the values of the POSIX \tcode{stat} class,
   obtained as if by \tcode{stat()} for the two paths, having equal \tcode{st_dev} values
   and equal \tcode{st_ino} values.
   \end{note}
@@ -15076,7 +15076,7 @@ If \tcode{exists(p)} is \tcode{false}, an error is reported\iref{fs.err.report}.
 \item
   If \tcode{is_regular_file(p)}, the size in bytes of the file
   \tcode{p} resolves to, determined as if by the value of the POSIX \tcode{stat}
-  structure member \tcode{st_size} obtained as if by POSIX \tcode{stat()}.
+  class member \tcode{st_size} obtained as if by POSIX \tcode{stat()}.
 \item
   Otherwise, the result is \impldef{result of \tcode{filesystem::file_size}}.
 \end{itemize}
@@ -15404,7 +15404,7 @@ file_time_type last_write_time(const path& p, error_code& ec) noexcept;
 \begin{itemdescr}
 \pnum
 \returns The time of last data modification of \tcode{p},
-  determined as if by the value of the POSIX \tcode{stat} structure member \tcode{st_mtime}
+  determined as if by the value of the POSIX \tcode{stat} class member \tcode{st_mtime}
   obtained as if by POSIX \tcode{stat()}.
   The signature with argument \tcode{ec} returns \tcode{file_time_type::min()}
   if an error occurs.

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -673,7 +673,7 @@ container sequence shall be performed without regard to case.
 Specifies that no sub-expressions shall be considered to be marked, so that
 when a regular expression is matched against a
 character container sequence, no sub-expression matches shall be
-stored in the supplied \tcode{match_results} structure.
+stored in the supplied \tcode{match_results} object.
 \indexlibrary{\idxcode{syntax_option_type}!\idxcode{nosubs}}%
 \\ \rowsep
 %

--- a/source/time.tex
+++ b/source/time.tex
@@ -9273,7 +9273,7 @@ namespace std::chrono {
 \end{codeblock}
 
 \pnum
-A \tcode{sys_info} structure can be obtained
+A \tcode{sys_info} object can be obtained
 from the combination of a \tcode{time_zone} and
 either a \tcode{sys_time} or \tcode{local_time}.
 It can also be obtained from a \tcode{zoned_time},
@@ -9283,7 +9283,7 @@ which is effectively a pair of a \tcode{time_zone} and \tcode{sys_time}.
 \begin{note}
 This type provides a low-level interface to time zone information.
 Typical conversions from \tcode{sys_time} to \tcode{local_time}
-will use this structure implicitly, not explicitly.
+will use this class implicitly, not explicitly.
 \end{note}
 
 \pnum
@@ -9367,7 +9367,7 @@ namespace std::chrono {
 \begin{note}
 This type provides a low-level interface to time zone information.
 Typical conversions from \tcode{local_time} to \tcode{sys_time}
-will use this structure implicitly, not explicitly.
+will use this class implicitly, not explicitly.
 \end{note}
 
 \pnum

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -964,7 +964,7 @@ inline constexpr piecewise_construct_t piecewise_construct{};
 \end{itemdecl}
 
 \pnum
-The \tcode{struct} \tcode{piecewise_construct_t} is an empty structure type
+The \tcode{struct} \tcode{piecewise_construct_t} is an empty class type
 used as a unique type to disambiguate constructor and function overloading. Specifically,
 \tcode{pair} has a constructor with \tcode{piecewise_construct_t} as the
 first argument, immediately followed by two \tcode{tuple}\iref{tuple} arguments used
@@ -3108,7 +3108,7 @@ inline constexpr nullopt_t nullopt(@\unspec@);
 \end{itemdecl}
 
 \pnum
-The struct \tcode{nullopt_t} is an empty structure type used as a unique type to indicate the state of not containing a value for \tcode{optional} objects.
+The struct \tcode{nullopt_t} is an empty class type used as a unique type to indicate the state of not containing a value for \tcode{optional} objects.
 In particular, \tcode{optional<T>} has a constructor with \tcode{nullopt_t} as a single argument;
 this indicates that an optional object not containing a value shall be constructed.
 
@@ -7122,7 +7122,7 @@ namespace std {
 \end{itemdecl}
 
 \pnum
-The \tcode{allocator_arg_t} struct is an empty structure type used as a unique type to
+The \tcode{allocator_arg_t} struct is an empty class type used as a unique type to
 disambiguate constructor and function overloading. Specifically, several types (see
 \tcode{tuple}~\ref{tuple}) have constructors with \tcode{allocator_arg_t} as the first
 argument, immediately followed by an argument of a type that satisfies the


### PR DESCRIPTION
Fixes #2289.

Both "empty structure type" and "empty class type" (i.e. the before and after phrases) are undefined.
It's unclear, for example, whether such an "empty" type may contain member typedefs or nested types.