### PR TITLE
[dcl.init] Rephrase "user-defined conversion sequence"

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4328,7 +4328,7 @@ If no constructor applies, or the overload resolution is
 ambiguous, the initialization is ill-formed.
 \item
 Otherwise (i.e., for the remaining copy-initialization cases),
-user-defined conversion functions and converting constructors that can convert from the
+user-defined conversions that can convert from the
 source type to the destination type or (when a conversion function
 is used) to a derived class thereof are enumerated as described in~\ref{over.match.copy},
 and the best one is chosen through overload resolution\iref{over.match}.

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4328,10 +4328,11 @@ If no constructor applies, or the overload resolution is
 ambiguous, the initialization is ill-formed.
 \item
 Otherwise (i.e., for the remaining copy-initialization cases),
-user-defined conversion sequences that can convert from the
+user-defined conversion functions and converting constructors that can convert from the
 source type to the destination type or (when a conversion function
-is used) to a derived class thereof are enumerated as described in~\ref{over.match.copy}, and the best one is chosen through overload
-resolution\iref{over.match}.  If the conversion cannot be done or
+is used) to a derived class thereof are enumerated as described in~\ref{over.match.copy},
+and the best one is chosen through overload resolution\iref{over.match}.
+If the conversion cannot be done or
 is ambiguous, the initialization is ill-formed.  The function
 selected is called with the initializer expression as its
 argument; if the function is a constructor, the call is a prvalue


### PR DESCRIPTION
1. The conversion sequence is "governed by" the rules defined here ([\[over.best.ics\]](http://eel.is/c++draft/over.best.ics#1.sentence-2)). Saying "conversion sequence" here will cause circular definition.
2. Overload resolution selects a function, not a conversion sequence.

Also perform a minor reflow to keep "overload" and "resolution" in the same line.