### PR TITLE
[rand.util.seedseq] Typo "for( " should be "for ("

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -4096,7 +4096,7 @@ template<class InputIterator>
 \pnum\effects Constructs a \tcode{seed_seq} object
  by the following algorithm:
 \begin{codeblock}
-for( InputIterator s = begin; s != end; ++s)
+for (InputIterator s = begin; s != end; ++s)
  v.push_back((*s)@$\bmod 2^{32}$@);
 \end{codeblock}%
 \end{itemdescr}


### PR DESCRIPTION
...for consistency with the other `for` loops in the IS.