### PR TITLE
[array.zero] paragraph 2 has confusing mathmatical notation using C++…

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -3378,7 +3378,7 @@ As if by \tcode{x.swap(y)}.
 \indextext{\idxcode{array}!zero sized}%
 \pnum\tcode{array} shall provide support for the special case \tcode{N == 0}.
 
-\pnum In the case that \tcode{N == 0}, \tcode{begin() == end() ==} unique value.
+\pnum In the case that \tcode{N == 0}, the return value of \tcode{begin()} and \tcode{end()} are the same unique value.
 The return value of \tcode{data()} is unspecified.
 
 \pnum


### PR DESCRIPTION
… syntax.

[array.zero] paragraph 2 says

> In the case that N == 0, begin() == end() == unique value.

The usage of double equals indicates this is a C++ expression.

But in C++, "a == b == c" means "(a==b) == c" which is "bool value == c".
Besides, it doesn't say anything about the result of that expression at all.

I think the intent of this wording is that, the return value of begin() and end() are the same unique value.