### PR TITLE
[class.member.lookup] 'unqualified-id' is the correct complement for …

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -4264,8 +4264,8 @@ destroyed) from such a constructor (or destructor) is undefined.%
 \pnum
 Member name lookup determines the meaning of a name
 (\grammarterm{id-expression}) in a class scope\iref{basic.scope.class}.
-Name lookup can result in an \term{ambiguity}, in which case the
-program is ill-formed. For an \grammarterm{id-expression}, name lookup
+Name lookup can result in an ambiguity, in which case the
+program is ill-formed. For an \grammarterm{unqualified-id}, name lookup
 begins in the class scope of \tcode{this}; for a
 \grammarterm{qualified-id}, name lookup begins in the scope of the
 \grammarterm{nested-name-specifier}. Name lookup takes place before access


### PR DESCRIPTION
…'qualified-id'

Fixes #2303.