### PR TITLE
[expr.prim.this] Do not mention 'declarator';

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1127,8 +1127,8 @@ initializer\iref{class.mem} is evaluated.
 If a declaration declares a member function or member function template of a
 class \tcode{X}, the expression \tcode{this} is a prvalue of type ``pointer to
 \grammarterm{cv-qualifier-seq} \tcode{X}'' between the optional
-\grammarterm{cv-qualifier-seq} and the end of the \grammarterm{function-definition},
-\grammarterm{member-declarator}, or \grammarterm{declarator}. It shall not appear
+\grammarterm{cv-qualifier-seq} and the end of the \grammarterm{function-definition}
+or \grammarterm{member-declarator}. It shall not appear
 before the optional \grammarterm{cv-qualifier-seq} and it shall not appear within
 the declaration of a static member function (although its type and value category
 are defined within a static member function as they are within a non-static


### PR DESCRIPTION
'member-declarator' suffices.

Fixes #2306.