### PR TITLE
[expr.new] Harmonize rules of constant array bounds > 0

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4791,7 +4791,7 @@ to the associated array type.
 Every \grammarterm{constant-expression} in a
 \grammarterm{noptr-new-declarator} shall be a converted constant
 expression\iref{expr.const} of type \tcode{std::size_t} and
-shall evaluate to a strictly positive value.
+its value shall be greater than zero.
 \begin{example}
 Given the definition \tcode{int n = 42},
 \tcode{new float[n][5]} is well-formed (because \tcode{n} is the


### PR DESCRIPTION
While "shall evaluate to a strictly positive value" is not wrong,
"shall be greater than zero" is easier and is used in [dcl.array] and
[dcl.init.aggr] to describe the same rule.

As a side note, I was surprized that negative bounds are not actually
banned by these "shall be greater than zero". It is now banned by a
narrowing conversion involved in a "converted constant expression of
type std::size_t" since approval of N3323(https://github.com/cplusplus/draft/commit/390dd7193de3d03e58e46d56216ff095f910f758#diff-baa06f0d56d1de4d541e8b3fca69df74).
Now these "shall be greater than zero" actually ban only zero.
But I think changing them to "shall not be zero" is not good (can be
more confusing).