### PR TITLE
Update the descriptions of `map`s indexing operators to use `mapped_t…

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -6109,10 +6109,10 @@ namespace std {
     size_type max_size() const noexcept;
 
     // \ref{map.access}, element access
-    T& operator[](const key_type& x);
-    T& operator[](key_type&& x);
-    T&       at(const key_type& x);
-    const T& at(const key_type& x) const;
+    mapped_type& operator[](const key_type& x);
+    mapped_type& operator[](key_type&& x);
+    mapped_type&       at(const key_type& x);
+    const mapped_type& at(const key_type& x) const;
 
     // \ref{map.modifiers}, modifiers
     template<class... Args> pair<iterator, bool> emplace(Args&&... args);
@@ -6279,7 +6279,7 @@ is \tcode{last - first}.
 
 \indexlibrary{\idxcode{operator[]}!\idxcode{map}}%
 \begin{itemdecl}
-T& operator[](const key_type& x);
+mapped_type& operator[](const key_type& x);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6290,7 +6290,7 @@ Equivalent to: \tcode{return try_emplace(x).first->second;}
 
 \indexlibrary{\idxcode{operator[]}!\idxcode{map}}%
 \begin{itemdecl}
-T& operator[](key_type&& x);
+mapped_type& operator[](key_type&& x);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6301,8 +6301,8 @@ Equivalent to: \tcode{return try_emplace(move(x)).first->second;}
 
 \indexlibrary{\idxcode{at}!\idxcode{map}}%
 \begin{itemdecl}
-T&       at(const key_type& x);
-const T& at(const key_type& x) const;
+mapped_type&       at(const key_type& x);
+const mapped_type& at(const key_type& x) const;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
…ype` rather than `T`

`unordered_map` already uses `mapped_type`. I'm going to change `flat_map` to do so, too.  We use `mapped_type` in other places. The description (line 6311) even says "a reference to the mapped_type".