### PR TITLE
Fix lambda-declarator

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1458,7 +1458,7 @@ by the \grammarterm{nested-name-specifier}.
 
 \begin{bnf}
 \nontermdef{lambda-declarator}\br
-    \terminal{(} parameter-declaration-clause \terminal{)} \opt{decl-specifier-seq}\br
+    \terminal{(} parameter-declaration-clause \terminal{)} \opt{decl-specifier-seq} \opt{attribute-specifier-seq}\br
     \bnfindent\opt{noexcept-specifier} \opt{attribute-specifier-seq} \opt{trailing-return-type}
 \end{bnf}
 


### PR DESCRIPTION
The following code is well-formed.
```
[] () constexpr [[using std:]] noexcept {};
```
But the following code is currently ill-formed.
```
[] () [[using std:]] noexcept {};
```
I think it should be well-formed.