### PR TITLE
[dcl.init.aggr] initializer-list (grammar) is never empty

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4669,7 +4669,7 @@ An empty initializer list
 \tcode{\{\}}
 shall not be used as the \grammarterm{initializer-clause}
 for an array of unknown bound.\footnote{The syntax provides for empty
-\grammarterm{initializer-list}{s},
+initializer lists,
 but nonetheless \Cpp{} does not have zero length arrays.}
 \begin{note}
 A default member initializer does not determine the bound for a member


### PR DESCRIPTION
Fixes #2335.