### PR TITLE
[temp.arg.nontype] Use struct instead of class to make example valid

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1377,7 +1377,7 @@ X<const char*, "Studebaker"> x; // error: string literal as template-argument
 const char p[] = "Vivisectionist";
 X<const char*, p> y;            // OK
 
-class A {
+struct A {
   constexpr A(const char*) {}
   auto operator<=>(A, A) = default;
 };


### PR DESCRIPTION
This is an editorial fix.

[P0732R2](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0732r2.pdf) was merged in Rapperswil, but one example is invalid because the constructor for A is private, so it can't be constructed from the string literal.
