### PR TITLE
[dcl.attr.contract.check] Violation handlers are not 'user-provided'

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -8549,7 +8549,7 @@ If an assertion is violated, the source location of the violation is
 the source location of the statement to which the assertion is applied.
 
 \pnum
-If a user-provided violation handler exits by throwing an exception
+If a violation handler exits by throwing an exception
 and a contract is violated on a call to a function
 with a non-throwing exception specification,
 then the behavior is as if the exception escaped the function body.


### PR DESCRIPTION
The term is undefined, plus violation handlers are explicitly supposed not to be set by the program.

Fixes #2340.