### PR TITLE
[temp] Add 'static' to examples for static data member template

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -111,11 +111,11 @@ struct matrix_constants {
   template<class T>
     using pauli = hermitian_matrix<T, 2>;
   template<class T>
-    constexpr pauli<T> sigma1 = { { 0, 1 }, { 1, 0 } };
+    constexpr static pauli<T> sigma1 = { { 0, 1 }, { 1, 0 } };
   template<class T>
-    constexpr pauli<T> sigma2 = { { 0, -1i }, { 1i, 0 } };
+    constexpr static pauli<T> sigma2 = { { 0, -1i }, { 1i, 0 } };
   template<class T>
-    constexpr pauli<T> sigma3 = { { 1, 0 }, { 0, -1 } };
+    constexpr static pauli<T> sigma3 = { { 1, 0 }, { 0, -1 } };
 };
 \end{codeblock}
 \end{example}


### PR DESCRIPTION
A non-static data member cannot be a template.