### PR TITLE
[class.copy.ctor] Add missing cross-references to Annex D

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1620,7 +1620,7 @@ constructor or move assignment operator, the implicitly declared copy
 constructor is defined as deleted; otherwise, it is defined as
 defaulted\iref{dcl.fct.def}.
 The latter case is deprecated if the class has a user-declared copy assignment
-operator or a user-declared destructor.
+operator or a user-declared destructor \iref{depr.impldec}.
 
 \pnum
 The implicitly-declared copy constructor for a class
@@ -1866,7 +1866,7 @@ constructor or move assignment operator, the implicitly declared copy
 assignment operator is defined as deleted; otherwise, it is defined as
 defaulted\iref{dcl.fct.def}.
 The latter case is deprecated if the class has a user-declared copy constructor
-or a user-declared destructor.
+or a user-declared destructor \iref{depr.impldec}.
 The implicitly-declared copy assignment operator for a class
 \tcode{X}
 will have the form


### PR DESCRIPTION
Add the missing cross-references to corresponding Annex D entry
for the deprecated implicit declaration of copy constructor and
copy assignment operator when either the destructor or other
copy operation is user-declared.