### PR TITLE
[decl.init]/10 Fix specified initialization.

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4121,10 +4121,9 @@ of an entity
 of reference type is ill-formed.
 
 \pnum
-\begin{note} Every
-object of static storage duration is
-zero-initialized at program startup before any other initialization
-takes place.
+\begin{note} For every object of static storage duration,
+static initialization\iref{basic.start.static} is performed
+at program startup before any other initialization takes place.
 In some cases, additional initialization is done later.
 \end{note}
 


### PR DESCRIPTION
According to [basic.start.static]/2, for objects with static storage duration,
zero initialization performs only if constant initialization does not.
[decl.init]/10 can be generalized to static initialization.
This is an editorial note change.