### PR TITLE
Remove "shall equal"s naming from conditional/decay/enable_if

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16925,10 +16925,10 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
 \tcode{template<class T>\br struct decay;}
  &
  Let \tcode{U} be \tcode{remove_reference_t<T>}. If \tcode{is_array_v<U>} is
- \tcode{true}, the member typedef \tcode{type} shall equal
+ \tcode{true}, the member typedef \tcode{type} names
  \tcode{remove_extent_t<U>*}. If \tcode{is_function_v<U>} is \tcode{true},
- the member typedef \tcode{type} shall equal \tcode{add_pointer_t<U>}. Otherwise
- the member typedef \tcode{type} equals \tcode{remove_cv_t<U>}.
+ the member typedef \tcode{type} names \tcode{add_pointer_t<U>}. Otherwise
+ the member typedef \tcode{type} names \tcode{remove_cv_t<U>}.
  \begin{note} This behavior is similar to the lvalue-to-rvalue\iref{conv.lval},
  array-to-pointer\iref{conv.array}, and function-to-pointer\iref{conv.func}
  conversions applied when an lvalue is used as an rvalue, but also
@@ -16940,15 +16940,15 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
 \tcode{template<bool B, class T = void>} \tcode{struct enable_if;}
  &
  If \tcode{B} is \tcode{true}, the member typedef \tcode{type}
- shall equal \tcode{T}; otherwise, there shall be no member
+ names \tcode{T}; otherwise, there shall be no member
  \tcode{type}. \\ \rowsep
 
 \tcode{template<bool B, class T,}
  \tcode{class F>}\br
  \tcode{struct conditional;}
  &
- If \tcode{B} is \tcode{true},  the member typedef \tcode{type} shall equal \tcode{T}.
- If \tcode{B} is \tcode{false}, the member typedef \tcode{type} shall equal \tcode{F}. \\ \rowsep
+ If \tcode{B} is \tcode{true},  the member typedef \tcode{type} names \tcode{T}.
+ If \tcode{B} is \tcode{false}, the member typedef \tcode{type} names \tcode{F}. \\ \rowsep
 
  \tcode{template<class... T>} \tcode{struct common_type;}
  &

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16940,7 +16940,7 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
 \tcode{template<bool B, class T = void>} \tcode{struct enable_if;}
  &
  If \tcode{B} is \tcode{true}, the member typedef \tcode{type}
- names \tcode{T}; otherwise, there shall be no member
+ names \tcode{T}; otherwise, there is no member
  \tcode{type}. \\ \rowsep
 
 \tcode{template<bool B, class T,}


### PR DESCRIPTION
Instead of saying "shall equal", which implies a condition on the user, we should say "names" or "is".

This change uses 'names', since that's what `identity` uses: The member typedef `type` names the type `T`.
Suggestion from Alisdair.