### PR TITLE
[output.iterators] Remove misleading italics from note

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -476,11 +476,9 @@ are valid and have the indicated semantics.
 The only valid use of an
 \tcode{operator*}
 is on the left side of the assignment statement.
-\textit{Assignment through the same value of the iterator happens only once.}
+Assignment through the same value of the iterator happens only once.
 Algorithms on output iterators should never attempt to pass through the same iterator twice.
-They should be
-\term{single pass}
-algorithms.
+They should be single-pass algorithms.
 Equality and inequality might not be defined.
 \end{note}
 


### PR DESCRIPTION
Since LWG asked me to remove these from P0896's `OutputIterator`, they probably don't belong in *`Cpp17OutputIterator`* either.