### PR TITLE
[dcl.init.aggr] Add example for anonymous union

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4497,6 +4497,18 @@ the anonymous union object is initialized by the
 where \placeholder{D} is the \grammarterm{designated-initializer-clause}
 naming a member of the anonymous union object.
 There shall be only one such \grammarterm{designated-initializer-clause}.
+\begin{example}
+\begin{codeblock}
+struct C {
+  union {
+    int a;
+    const char* p;
+  };
+  int x;
+} c = { .a = 2, .x = 3 };
+\end{codeblock}
+initializes \tcode{c.a} with 1 and \tcode{c.x} with 3.
+\end{example}
 \item
 Otherwise, the element is copy-initialized
 from the corresponding \grammarterm{initializer-clause}
@@ -4511,7 +4523,6 @@ to convert the expression, the program is ill-formed.
 \begin{note} If an initializer is itself an initializer list,
 the element is list-initialized, which will result in a recursive application
 of the rules in this subclause if the element is an aggregate. \end{note}
-\end{itemize}
 \begin{example}
 \begin{codeblock}
 struct A {
@@ -4555,6 +4566,7 @@ initializes
 \tcode{d2.b3} with 42,
 \tcode{d2.d} with 4.
 \end{example}
+\end{itemize}
 
 \pnum
 For a non-union aggregate,


### PR DESCRIPTION
initialized by a designated-initializer-list.

Fixes #2345.