### PR TITLE
[rand.dist.uni.real] Correct a typo

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -4502,7 +4502,7 @@ explicit uniform_real_distribution(RealType a, RealType b = 1.0);
 
 \begin{itemdescr}
 \pnum\requires
- $\tcode{a} \leq \tcode{b}$
+ $\tcode{a} < \tcode{b}$
  and
  $\tcode{b} - \tcode{a} \leq \tcode{numeric_limits<RealType>::max()}$.
 


### PR DESCRIPTION
The uniform_­real_­distribution produces numbers such that a ≤ x < b.
However, the requirement in [rand.dist.uni.real]p2 as written would permit a and b to be equal.