### PR TITLE
[basic.lookup,over.call.func] Clarify lookup rules for function calls.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1209,8 +1209,8 @@ checking have succeeded are the attributes introduced by the name's
 declaration used further in expression processing\iref{expr}.
 
 \pnum
-A name ``looked up in the context of an expression'' is looked up as an
-unqualified name in the scope where the expression is found.
+A name ``looked up in the context of an expression'' is looked up
+in the scope where the expression is found.
 
 \pnum
 The injected-class-name of a class\iref{class} is also
@@ -2209,15 +2209,17 @@ or \tcode{->} token is immediately followed by an \grammarterm{identifier}
 followed by a \tcode{<}, the identifier must be looked up to determine
 whether the \tcode{<} is the beginning of a template argument
 list\iref{temp.names} or a less-than operator. The identifier is first
-looked up in the class of the object expression. If the identifier is
-not found, it is then looked up in the context of the entire
+looked up in the class of the object expression\iref{class.member.lookup}.
+If the identifier is not found,
+it is then looked up in the context of the entire
 \grammarterm{postfix-expression} and shall name a class template.
 
 \pnum
 If the \grammarterm{id-expression} in a class member
 access\iref{expr.ref} is an \grammarterm{unqualified-id}, and the type of
 the object expression is of a class type \tcode{C}, the
-\grammarterm{unqualified-id} is looked up in the scope of class \tcode{C}.
+\grammarterm{unqualified-id} is looked up
+in the scope of class \tcode{C}\iref{class.member.lookup}.
 
 \pnum
 If the \grammarterm{unqualified-id} is \tcode{\~}\grammarterm{type-name}, the
@@ -2248,7 +2250,8 @@ If the \grammarterm{id-expression} in a class member access is a
 \end{codeblock}
 the \tcode{\placeholder{class-name-or-namespace-name}} following the \tcode{.} or
 \tcode{->} operator is
-first looked up in the class of the object expression and the name, if found,
+first looked up in the class of the object expression\iref{class.member.lookup}
+and the name, if found,
 is used. Otherwise it is looked up in the context of the entire
 \grammarterm{postfix-expression}. \begin{note} See~\ref{basic.lookup.qual}, which
 describes the lookup of a name before \tcode{::}, which will only find a type
@@ -2271,7 +2274,9 @@ entire \grammarterm{postfix-expression} occurs.
 \pnum
 If the \grammarterm{id-expression} is a \grammarterm{conversion-function-id},
 its \grammarterm{conversion-type-id}
-is first looked up in the class of the object expression and the name, if
+is first looked up
+in the class of the object expression\iref{class.member.lookup}
+and the name, if
 found, is used. Otherwise it is looked up in the context
 of the entire \grammarterm{postfix-expression}.
 In each of these lookups, only names that denote types or templates whose

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -772,8 +772,8 @@ or
 operator and has the more general form of a
 \grammarterm{primary-expression}.
 The name is looked up in the context of the function
-call following the normal rules for name lookup in function
-calls\iref{basic.lookup}.
+call following the normal rules for name lookup
+in expressions\iref{basic.lookup}.
 The function declarations found by that lookup constitute the
 set of candidate functions.
 Because of the rules for name lookup, the set of candidate functions


### PR DESCRIPTION
Also add cross-references to [class.member.lookup] when
talking about 'looked up in the class of the object expression'
in [basic.lookup.classref].

Fixes #2365.