### PR TITLE
[conv.lval] Improve the note about std::nullptr_t case

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -631,9 +631,9 @@ following rules:
 \item If \tcode{T} is \cv{}~\tcode{std::nullptr_t}, the result is a
 null pointer constant\iref{conv.ptr}.
 \begin{note}
-Since no value is fetched from memory,
-there is no side effect for a volatile access\iref{intro.execution}, and
-an inactive member of a union\iref{class.union} may be accessed.
+Since the conversion does not read the object,
+there is no side effect even if \tcode{T} is volatile-qualified\iref{intro.execution}, and
+the glvalue can refer to an inactive member of a union\iref{class.union}.
 \end{note}
 
 \item Otherwise, if \tcode{T} has a class

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -631,7 +631,7 @@ following rules:
 \item If \tcode{T} is \cv{}~\tcode{std::nullptr_t}, the result is a
 null pointer constant\iref{conv.ptr}.
 \begin{note}
-Since the conversion does not read the object,
+Since the conversion does not access the object to which the glvalue refers,
 there is no side effect even if \tcode{T} is volatile-qualified\iref{intro.execution}, and
 the glvalue can refer to an inactive member of a union\iref{class.union}.
 \end{note}


### PR DESCRIPTION
The meaning of "fetched from memory" is vague, and the two uses of term
"access" [defns.access] are inappropreate here because
  - it causes undefined behavior to access an inactive member of a
    union, based on the rule of out-of-lifetime object [basic.life]:
    > The program has undefined behavior if:
    >   - the glvalue is used to access the object, or
  - it implies reading the referenced object of std::nullptr_t,
    which is defined to be a side effect for volatile-qualified case.
    [intro.execution]
    > Reading an object designated by a volatile glvalue, ... are all
    > side effects, ...

---

The change blindly assumes that "no value is fetched from memory" is
true and rephrases it as "the conversion does not read the object", but
I'm not sure how it is true. In fact, gcc 8.2 emits read instruction for
volatile-qualified case https://godbolt.org/z/uhn72l (clang 7.0.0
doesn't), and both gcc 8.2 and clang 7.0.0 reads a member subobject of
type std::nullptr_t https://godbolt.org/z/fqBU-H.

FYI: The note was added by CWG issue 2140 for C++17.
https://wg21.cmeerw.net/cwg/issue2140
commit 28c12a81642138f0f25e8942298b03b4516d2a9a
