### PR TITLE
[numeric.ops] Move [numerics.defns] to the point-of-use.

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -6058,6 +6058,28 @@ The use of closed ranges as well as semi-open ranges to specify requirements
 throughout this subclause is intentional.
 \end{note}
 
+\rSec2[numerics.defns]{Definitions}
+
+\indexlibrary{generalized_noncommutative_sum@\tcode{\placeholder{GENERALIZED_NONCOMMUTATIVE_SUM}}}%
+\pnum
+Define \tcode{\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}(op, a1, ..., aN)} as follows:
+\begin{itemize}
+\item
+\tcode{a1} when \tcode{N} is \tcode{1}, otherwise
+
+\item
+\tcode{op(\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}(op, a1, ..., aK),} \\
+\tcode{\phantom{op(}\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}(op, aM, ..., aN))}
+for any \tcode{K} where $1 < \mathtt{K}+1 = \mathtt{M} \leq \mathtt{N}$.
+\end{itemize}
+
+\indexlibrary{generalized_sum@\tcode{\placeholder{GENERALIZED_SUM}}}%
+\pnum
+Define \tcode{\placeholdernc{GENERALIZED_SUM}(op, a1, ..., aN)} as
+\tcode{\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}(op, b1, ..., bN)},
+where
+\tcode{b1, ..., bN} may be any permutation of \tcode{a1, ..., aN}.
+
 \rSec2[accumulate]{Accumulate}
 
 \indexlibrary{\idxcode{accumulate}}%

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -17,7 +17,6 @@ and mathematical functions for floating-point types,
 as summarized in \tref{numerics.lib.summary}.
 
 \begin{libsumtab}{Numerics library summary}{tab:numerics.lib.summary}
-\ref{numerics.defns}        & Definitions  &           \\
 \ref{numeric.requirements}  & Requirements &           \\ \rowsep
 \ref{cfenv}           & Floating-point environment & \tcode{<cfenv>}  \\ \rowsep
 \ref{complex.numbers} & Complex numbers & \tcode{<complex>} \\ \rowsep
@@ -27,28 +26,6 @@ as summarized in \tref{numerics.lib.summary}.
 \ref{c.math}  & Mathematical functions for & \tcode{<cmath>}   \\
               & floating-point types       & \tcode{<cstdlib>} \\
 \end{libsumtab}
-
-\rSec1[numerics.defns]{Definitions}
-
-\indexlibrary{generalized_noncommutative_sum@\tcode{\placeholder{GENERALIZED_NONCOMMUTATIVE_SUM}}}%
-\pnum
-Define \tcode{\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}(op, a1, ..., aN)} as follows:
-\begin{itemize}
-\item
-\tcode{a1} when \tcode{N} is \tcode{1}, otherwise
-
-\item
-\tcode{op(\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}(op, a1, ..., aK),} \\
-\tcode{\phantom{op(}\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}(op, aM, ..., aN))}
-for any \tcode{K} where $1 < \mathtt{K}+1 = \mathtt{M} \leq \mathtt{N}$.
-\end{itemize}
-
-\indexlibrary{generalized_sum@\tcode{\placeholder{GENERALIZED_SUM}}}%
-\pnum
-Define \tcode{\placeholdernc{GENERALIZED_SUM}(op, a1, ..., aN)} as
-\tcode{\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}(op, b1, ..., bN)},
-where
-\tcode{b1, ..., bN} may be any permutation of \tcode{a1, ..., aN}.
 
 \rSec1[numeric.requirements]{Numeric type requirements}
 \indextext{requirements!numeric type}


### PR DESCRIPTION
Fixes #2376.