### PR TITLE
[alg.find.end,alg.search] Remove redundant 'Effects' paragraphs

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -3234,10 +3234,6 @@ in \range{first1}{last1 - (last2 - first2)}.
 \end{itemize}
 
 \pnum
-\effects
-Finds a subsequence of equal values in a sequence.
-
-\pnum
 \returns
 \begin{itemize}
 \item \tcode{i} for the overloads in namespace \tcode{std}, and
@@ -3801,10 +3797,6 @@ template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2,
 
 \begin{itemdescr}
 \pnum
-\effects
-Finds a subsequence of equal values in a sequence.
-
-\pnum
 \returns
 The first iterator
 \tcode{i}
@@ -3847,10 +3839,6 @@ namespace ranges {
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\effects
-Finds a subsequence of equal values in a sequence.
-
 \pnum
 \returns
 \begin{itemize}
@@ -3913,10 +3901,6 @@ The type
 shall be convertible to integral type~(\ref{conv.integral}, \ref{class.conv}).
 
 \pnum
-\effects
-Finds a subsequence of equal values in a sequence.
-
-\pnum
 \returns
 The first iterator
 \tcode{i}
@@ -3956,10 +3940,6 @@ namespace ranges {
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\effects
-Finds a subsequence of equal values in a sequence.
-
 \pnum
 \returns
 \tcode{\{i, i + count\}} where \tcode{i} is the first iterator


### PR DESCRIPTION
which were using the term 'subsequence' incorrectly.

Fixes #2377.