### PR TITLE
Clarify the contexts where void expressions appear

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3719,7 +3719,7 @@ when initializing an object of type \tcode{std::initializer_list<T>} from a \gra
 \item
 for certain unevaluated operands~(\ref{expr.typeid}, \ref{expr.sizeof}), and
 \item
-when a prvalue appears as a discarded-value expression\iref{expr.prop}.
+when a prvalue that has type other than \cv{}~\tcode{void} appears as a discarded-value expression\iref{expr.prop}.
 \end{itemize}
 \end{note}
 \begin{example} Consider the following code:

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -140,7 +140,8 @@ Expressions are categorized according to the taxonomy in Figure~\ref{fig:categor
 \item A \defn{glvalue} is an expression whose evaluation determines the identity of an object, bit-field, or function.
 \item A \defn{prvalue} is an expression whose evaluation initializes an object or a bit-field,
 or computes the value of an operand of an operator,
-as specified by the context in which it appears.
+as specified by the context in which it appears,
+or an expression that has type \cv{}~\tcode{void}.
 \item An \defn{xvalue} is a glvalue that denotes an object or bit-field whose resources can be reused (usually because it is near the end of its lifetime).
 \item An \defn{lvalue} is a glvalue that is not an xvalue.
 \item An \defn{rvalue} is a prvalue or an xvalue.
@@ -210,22 +211,23 @@ are xvalues. The expression \tcode{ar} is an lvalue.
 \end{example}
 
 \pnum
+The \defnx{result}{result!glvalue} of a glvalue is the entity denoted by the expression.
 The \defnx{result}{result!prvalue} of a prvalue
-is the value that the expression stores into its context.
+is the value that the expression stores into its context;
+a prvalue that has type \cv{}~\tcode{void} has no result.
 A prvalue whose result is the value \placeholder{V}
 is sometimes said to have or name the value \placeholder{V}.
-The \defn{result object} of a prvalue
-is the object initialized by the prvalue;
+The \defn{result object} of a prvalue is the object initialized by the prvalue;
 a non-discarded prvalue
-that is used to compute the value of an operand of a built-in operator or
-that has type \cv{}~\tcode{void}
+that is used to compute the value of an operand of a built-in operator
+or a prvalue that has type \cv{}~\tcode{void}
 has no result object.
 \begin{note}
 Except when the prvalue is the operand of a \grammarterm{decltype-specifier},
 a prvalue of class or array type always has a result object.
-For a discarded prvalue, a temporary object is materialized; see \ref{expr.context}.
+For a discarded prvalue that has type other than \cv{}~\tcode{void},
+a temporary object is materialized; see \ref{expr.context}.
 \end{note}
-The \defnx{result}{result!glvalue} of a glvalue is the entity denoted by the expression.
 
 \pnum
 Whenever a glvalue appears as an operand of an operator that


### PR DESCRIPTION
This pull request will:
* remove void expressions from temporary object materialization;
* add void expressions to the prvalue definition and precise that they have no results/result objects.