### PR TITLE
P0668R5 Revising the C++ memory model

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -379,75 +379,90 @@ an acquire operation on \placeholder{M} and takes its value from any side effect
 release sequence headed by \placeholder{A}.
 
 \pnum
-There shall be a single total order \placeholder{S} on all \tcode{memory_order::seq_cst}
-operations, consistent with the ``happens before'' order and modification orders for all
-affected locations, such that each \tcode{memory_order::seq_cst} operation
-\placeholder{B} that loads a
-value from an atomic object \placeholder{M}
-observes one of the following values:
-
+An atomic operation \placeholder{A} on some atomic object \placeholder{M} is
+\defn{coherence-ordered before}
+another atomic operation \placeholder{B} on \placeholder{M} if
 \begin{itemize}
-\item the result of the last modification \placeholder{A} of \placeholder{M} that precedes
-\placeholder{B} in \placeholder{S}, if it exists, or
-
-\item if \placeholder{A} exists, the result of some modification of \placeholder{M}
-that is not
-\tcode{memory_order::seq_cst} and that does not happen before \placeholder{A}, or
-
-\item if \placeholder{A} does not exist, the result of some modification of \placeholder{M}
-that is not
-\tcode{memory_order::seq_cst}.
+\item \placeholder{A} is a modification, and
+\placeholder{B} reads the value stored by \placeholder{A}, or
+\item \placeholder{A} precedes \placeholder{B}
+in the modification order of \placeholder{M}, or
+\item \placeholder{A} and \placeholder{B} are not
+the same atomic read-modify-write operation, and
+there exists an atomic modification \placeholder{X} of \placeholder{M}
+such that \placeholder{A} reads the value stored by \placeholder{X} and
+\placeholder{X} precedes \placeholder{B}
+in the modification order of \placeholder{M}, or
+\item there exists an atomic modification \placeholder{X} of \placeholder{M}
+such that \placeholder{A} is coherence-ordered before \placeholder{X} and
+\placeholder{X} is coherence-ordered before \placeholder{B}.
 \end{itemize}
 
-\begin{note} Although it is not explicitly required that \placeholder{S} include locks, it can
-always be extended to an order that does include lock and unlock operations, since the
-ordering between those is already included in the ``happens before'' ordering. \end{note}
-
 \pnum
-For an atomic operation \placeholder{B} that reads the value of an atomic object \placeholder{M},
-if there is a \tcode{memory_order::seq_cst} fence \placeholder{X} sequenced before \placeholder{B},
-then \placeholder{B} observes either the last \tcode{memory_order::seq_cst} modification of
-\placeholder{M} preceding \placeholder{X} in the total order \placeholder{S} or a later modification of
-\placeholder{M} in its modification order.
-
-\pnum
-For atomic operations \placeholder{A} and \placeholder{B} on an atomic object \placeholder{M}, where
-\placeholder{A} modifies \placeholder{M} and \placeholder{B} takes its value, if there is a
-\tcode{memory_order::seq_cst} fence \placeholder{X} such that \placeholder{A} is sequenced before
-\placeholder{X} and \placeholder{B} follows \placeholder{X} in \placeholder{S}, then \placeholder{B} observes
-either the effects of \placeholder{A} or a later modification of \placeholder{M} in its
-modification order.
-
-\pnum
-For atomic operations \placeholder{A} and \placeholder{B} on an atomic object \placeholder{M}, where
-\placeholder{A} modifies \placeholder{M} and \placeholder{B} takes its value, if there are
-\tcode{memory_order::seq_cst} fences \placeholder{X} and \placeholder{Y} such that \placeholder{A} is
-sequenced before \placeholder{X}, \placeholder{Y} is sequenced before \placeholder{B}, and \placeholder{X}
-precedes \placeholder{Y} in \placeholder{S}, then \placeholder{B} observes either the effects of
-\placeholder{A} or a later modification of \placeholder{M} in its modification order.
-
-\pnum
-For atomic modifications \placeholder{A} and \placeholder{B} of an atomic object \placeholder{M},
-\placeholder{B} occurs later than \placeholder{A} in the modification order of \placeholder{M} if:
-
+There is a single total order \placeholder{S}
+on all \tcode{memory_order::seq_cst} operations, including fences,
+that satisfies the following constraints.
+First, if \placeholder{A} and \placeholder{B} are
+\tcode{memory_order::seq_cst} operations and
+\placeholder{A} strongly happens before \placeholder{B},
+then \placeholder{A} precedes \placeholder{B} in \placeholder{S}.
+Second, for every pair of atomic operations \placeholder{A} and
+\placeholder{B} on an object \placeholder{M},
+where \placeholder{A} is coherence-ordered before \placeholder{B},
+the following four conditions are required to be satisfied by \placeholder{S}:
 \begin{itemize}
-\item there is a \tcode{memory_order::seq_cst} fence \placeholder{X} such that \placeholder{A}
-is sequenced before \placeholder{X}, and \placeholder{X} precedes \placeholder{B} in \placeholder{S}, or
-\item there is a \tcode{memory_order::seq_cst} fence \placeholder{Y} such that \placeholder{Y}
-is sequenced before \placeholder{B}, and \placeholder{A} precedes \placeholder{Y} in \placeholder{S}, or
-\item there are \tcode{memory_order::seq_cst} fences \placeholder{X} and \placeholder{Y} such that \placeholder{A}
-is sequenced before \placeholder{X}, \placeholder{Y} is sequenced before \placeholder{B},
-and \placeholder{X} precedes \placeholder{Y} in \placeholder{S}.
+\item if \placeholder{A} and \placeholder{B} are both
+\tcode{memory_order::seq_cst} operations,
+then \placeholder{A} precedes \placeholder{B} in \placeholder{S}; and
+\item if \placeholder{A} is a \tcode{memory_order::seq_cst} operation and
+\placeholder{B} happens before
+a \tcode{memory_order::seq_cst} fence \placeholder{Y},
+then \placeholder{A} precedes \placeholder{Y} in \placeholder{S}; and
+\item if a \tcode{memory_order::seq_cst} fence \placeholder{X}
+happens before \placeholder{A} and
+\placeholder{B} is a \tcode{memory_order::seq_cst} operation,
+then \placeholder{X} precedes \placeholder{B} in \placeholder{S}; and
+\item if a \tcode{memory_order::seq_cst} fence \placeholder{X}
+happens before \placeholder{A} and
+\placeholder{B} happens before
+a \tcode{memory_order::seq_cst} fence \placeholder{Y},
+then \placeholder{X} precedes \placeholder{Y} in \placeholder{S}.
 \end{itemize}
 
+\pnum
+\begin{note}
+This definition ensures that \placeholder{S} is consistent with
+the modification order of any atomic object \placeholder{M}.
+It also ensures that
+a \tcode{memory_order::seq_cst} load \placeholder{A} of \placeholder{M}
+gets its value either from the last modification of \placeholder{M}
+that precedes \placeholder{A} in \placeholder{S} or
+from some non-\tcode{memory_order::seq_cst} modification of \placeholder{M}
+that does not happen before any modification of \placeholder{M}
+that precedes \placeholder{A} in \placeholder{S}.
+\end{note}
 
 \pnum
-\begin{note} \tcode{memory_order::seq_cst} ensures sequential consistency only for a
-program that is free of data races and uses exclusively \tcode{memory_order::seq_cst}
-operations. Any use of weaker ordering will invalidate this guarantee unless extreme
-care is used. In particular, \tcode{memory_order::seq_cst} fences ensure a total order
-only for the fences themselves. Fences cannot, in general, be used to restore sequential
-consistency for atomic operations with weaker ordering specifications. \end{note}
+\begin{note}
+We do not require that \placeholder{S} be consistent with
+``happens before''\iref{intro.races}.
+This allows more efficient implementation
+of \tcode{memory_order::acquire} and \tcode{memory_order::release}
+on some machine architectures.
+It can produce surprising results
+when these are mixed with \tcode{memory_order::seq_cst} accesses.
+\end{note}
+
+\pnum
+\begin{note}
+\tcode{memory_order::seq_cst} ensures sequential consistency only
+for a program that is free of data races and
+uses exclusively \tcode{memory_order::seq_cst} atomic operations.
+Any use of weaker ordering will invalidate this guarantee
+unless extreme care is used.
+In many cases, \tcode{memory_order::seq_cst} atomic operations are reorderable
+with respect to other atomic operations performed by the same thread.
+\end{note}
 
 \pnum
 Implementations should ensure that no ``out-of-thin-air'' values are computed that

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5193,17 +5193,39 @@ in the ``happens before'' relation. \begin{note} This cycle would otherwise be
 possible only through the use of consume operations. \end{note}
 
 \pnum
-An evaluation \placeholder{A} \defn{strongly happens before} an evaluation \placeholder{B}
+An evaluation \placeholder{A} \defn{simply happens before} an evaluation \placeholder{B}
 if either
 \begin{itemize}
 \item \placeholder{A} is sequenced before \placeholder{B}, or
 \item \placeholder{A} synchronizes with \placeholder{B}, or
-\item \placeholder{A} strongly happens before \placeholder{X} and \placeholder{X} strongly happens before \placeholder{B}.
+\item \placeholder{A} simply happens before \placeholder{X} and
+\placeholder{X} simply happens before \placeholder{B}.
 \end{itemize}
 \begin{note}
 In the absence of consume operations,
-the happens before and strongly happens before relations are identical.
-Strongly happens before essentially excludes consume operations.
+the happens before and simply happens before relations are identical.
+\end{note}
+
+\pnum
+An evaluation \placeholder{A} \defn{strongly happens before}
+an evaluation \placeholder{D} if, either
+\begin{itemize}
+\item \placeholder{A} is sequenced before \placeholder{D}, or
+\item \placeholder{A} synchronizes with \placeholder{D}, and
+both \placeholder{A} and \placeholder{D} are
+sequentially consistent atomic operations\iref{atomics.order}, or
+\item there are evaluations \placeholder{B} and \placeholder{C}
+such that \placeholder{A} is sequenced before \placeholder{B},
+\placeholder{B} simply happens before \placeholder{C}, and
+\placeholder{C} is sequenced before \placeholder{D}, or
+\item there is an evaluation \placeholder{B} such that
+\placeholder{A} strongly happens before \placeholder{B}, and
+\placeholder{B} strongly happens before \placeholder{D}.
+\end{itemize}
+\begin{note}
+Informally, if \placeholder{A} strongly happens before \placeholder{B},
+then \placeholder{A} appears to be evaluated before \placeholder{B}
+in all contexts. Strongly happens before excludes consume operations.
 \end{note}
 
 \pnum


### PR DESCRIPTION
The paper did not highlight two changes of "strongly happens before"
to "simply happens before" in the definition of "simply happens before".

Fixes #2395.