### PR TITLE
[expr.static.cast] Say 'lvalue denoting ...' instead of 'lvalue to ...'

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3591,7 +3591,7 @@ struct D : public B { };
 D d;
 B &br = d;
 
-static_cast<D&>(br);            // produces lvalue to the original \tcode{d} object
+static_cast<D&>(br);            // produces lvalue denoting the original \tcode{d} object
 \end{codeblock}
 \end{example}
 


### PR DESCRIPTION
"[lx]value denoting ..." is already used in half a dozen other places, "lvalue to ..." is not used anywhere else.