### PR TITLE
P1084R2 Today’s return-type-requirements Are Insufficient

### DIFF
--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -479,8 +479,7 @@ template<class LHS, class RHS>
     is_lvalue_reference_v<LHS> &&
     CommonReference<const remove_reference_t<LHS>&, const remove_reference_t<RHS>&> &&
     requires(LHS lhs, RHS&& rhs) {
-      lhs = std::forward<RHS>(rhs);
-      requires Same<decltype(lhs = std::forward<RHS>(rhs)), LHS>;
+      { lhs = std::forward<RHS>(rhs) } -> Same<LHS>;
     };
 \end{itemdecl}
 
@@ -757,19 +756,19 @@ template<class B>
     requires(const remove_reference_t<B>& b1,
              const remove_reference_t<B>& b2, const bool a) {
       requires ConvertibleTo<const remove_reference_t<B>&, bool>;
-      !b1;      requires ConvertibleTo<decltype(!b1), bool>;
-      b1 &&  a; requires Same<decltype(b1 &&  a), bool>;
-      b1 ||  a; requires Same<decltype(b1 ||  a), bool>;
-      b1 && b2; requires Same<decltype(b1 && b2), bool>;
-       a && b2; requires Same<decltype( a && b2), bool>;
-      b1 || b2; requires Same<decltype(b1 || b2), bool>;
-       a || b2; requires Same<decltype( a || b2), bool>;
-      b1 == b2; requires ConvertibleTo<decltype(b1 == b2), bool>;
-      b1 ==  a; requires ConvertibleTo<decltype(b1 ==  a), bool>;
-       a == b2; requires ConvertibleTo<decltype( a == b2), bool>;
-      b1 != b2; requires ConvertibleTo<decltype(b1 != b2), bool>;
-      b1 !=  a; requires ConvertibleTo<decltype(b1 !=  a), bool>;
-       a != b2; requires ConvertibleTo<decltype( a != b2), bool>;
+      { !b1 } -> ConvertibleTo<bool>;
+      { b1 &&  a } -> Same<bool>;
+      { b1 ||  a } -> Same<bool>;
+      { b1 && b2 } -> Same<bool>;
+      {  a && b2 } -> Same<bool>;
+      { b1 || b2 } -> Same<bool>;
+      {  a || b2 } -> Same<bool>;
+      { b1 == b2 } -> ConvertibleTo<bool>;
+      { b1 ==  a } -> ConvertibleTo<bool>;
+      {  a == b2 } -> ConvertibleTo<bool>;
+      { b1 != b2 } -> ConvertibleTo<bool>;
+      { b1 !=  a } -> ConvertibleTo<bool>;
+      {  a != b2 } -> ConvertibleTo<bool>;
     };
 \end{itemdecl}
 
@@ -811,10 +810,10 @@ template<class T, class U>
   concept @\placeholder{weakly-equality-comparable-with}@ = // \expos
     requires(const remove_reference_t<T>& t,
              const remove_reference_t<U>& u) {
-      t == u; requires Boolean<decltype(t == u)>;
-      t != u; requires Boolean<decltype(t != u)>;
-      u == t; requires Boolean<decltype(u == t)>;
-      u != t; requires Boolean<decltype(u != t)>;
+      { t == u } -> Boolean;
+      { t != u } -> Boolean;
+      { u == t } -> Boolean;
+      { u != t } -> Boolean;
     };
 \end{itemdecl}
 
@@ -888,10 +887,10 @@ template<class T>
     EqualityComparable<T> &&
     requires(const remove_reference_t<T>& a,
              const remove_reference_t<T>& b) {
-      a <  b; requires Boolean<decltype(a <  b)>;
-      a >  b; requires Boolean<decltype(a >  b)>;
-      a <= b; requires Boolean<decltype(a <= b)>;
-      a >= b; requires Boolean<decltype(a >= b)>;
+      { a <  b } -> Boolean;
+      { a >  b } -> Boolean;
+      { a <= b } -> Boolean;
+      { a >= b } -> Boolean;
     };
 \end{itemdecl}
 
@@ -925,14 +924,14 @@ template<class T, class U>
     EqualityComparableWith<T, U> &&
     requires(const remove_reference_t<T>& t,
              const remove_reference_t<U>& u) {
-      t <  u; requires Boolean<decltype(t <  u)>;
-      t >  u; requires Boolean<decltype(t >  u)>;
-      t <= u; requires Boolean<decltype(t <= u)>;
-      t >= u; requires Boolean<decltype(t >= u)>;
-      u <  t; requires Boolean<decltype(u <  t)>;
-      u >  t; requires Boolean<decltype(u >  t)>;
-      u <= t; requires Boolean<decltype(u <= t)>;
-      u >= t; requires Boolean<decltype(u >= t)>;
+      { t <  u } -> Boolean;
+      { t >  u } -> Boolean;
+      { t <= u } -> Boolean;
+      { t >= u } -> Boolean;
+      { u <  t } -> Boolean;
+      { u >  t } -> Boolean;
+      { u <= t } -> Boolean;
+      { u >= t } -> Boolean;
     };
 \end{itemdecl}
 

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2597,7 +2597,7 @@ does not require that type to be complete\iref{basic.types}.
 \begin{bnf}
 \nontermdef{return-type-requirement}\br
     trailing-return-type\br
-    \terminal{->} \opt{cv-qualifier-seq} constrained-parameter \opt{cv-qualifier-seq} \opt{abstract-declarator}
+    \terminal{->} qualified-concept-name
 \end{bnf}
 
 \pnum
@@ -2607,44 +2607,55 @@ of template arguments (if any) and verification of
 semantic properties proceed in the following order:
 
 \begin{itemize}
-\item Substitution of template arguments (if any)
+\item
+Substitution of template arguments (if any)
 into the \grammarterm{expression} is performed.
 
-\item If the \tcode{noexcept} specifier is present,
+\item
+If the \tcode{noexcept} specifier is present,
 \tcode{E} shall not be a potentially-throwing expression\iref{except.spec}.
 
-\item If the \grammarterm{return-type-requirement} is present, then:
+\item
+If the \grammarterm{return-type-requirement} is present, then:
 
 \begin{itemize}
-\item Substitution of template arguments (if any)
+\item
+Substitution of template arguments (if any)
 into the \grammarterm{return-type-requirement} is performed.
 
-\item If the \grammarterm{return-type-requirement} is a
-\grammarterm{trailing-return-type},
+\item
+If the \grammarterm{return-type-requirement} is a
+\grammarterm{trailing-return-type}\iref{dcl.decl},
 %%% FIXME: is -> shall be
 \tcode{E} is implicitly convertible to
 the type named by the \grammarterm{trailing-return-type}.
 If conversion fails, the enclosing \grammarterm{requires-expression}
 is \tcode{false}.
 
-\item If the \grammarterm{return-type-requirement}
-starts with a \grammarterm{constrained-parameter}\iref{temp.param},
-the \grammarterm{expression} is deduced against
-an invented function template \tcode{F}
-using the rules in \ref{temp.deduct.call}.
-\tcode{F} is a \tcode{void} function template
-with a single type template parameter \tcode{T}
-declared with the \grammarterm{constrained-parameter}.
-A \grammarterm{cv-qualifier-seq} \cv{} is formed
-as the union of \tcode{const} and \tcode{volatile} specifiers
-around the \grammarterm{constrained-parameter}.
-\tcode{F} has a single parameter
-whose \grammarterm{type-specifier} is \cv{}~\tcode{T}
-followed by the \grammarterm{abstract-declarator}.
-%%% FIXME: Remove this; if deduction fails, the construct should
-%%% be ill-formed.
-If deduction fails,
-the enclosing \grammarterm{requires-expression} is \tcode{false}.
+\item
+If the \grammarterm{return-type-requirement} is
+a \grammarterm{qualified-concept-name}\iref{temp.param} of the form
+\opt{\grammarterm{nested-name-specifier}} \grammarterm{concept-name},
+the concept it denotes shall be satisfied with
+\tcode{decltype((E))} as its sole argument.
+If the \grammarterm{return-type-requirement} is
+a \grammarterm{qualified-concept-name} of the form
+\opt{\grammarterm{nested-name-specifier}} \grammarterm{concept-name}
+\tcode{<} \opt{\grammarterm{template-argument-list}} \tcode{>},
+the concept it denotes shall be satisfied with
+\tcode{decltype((E))} as its first argument and with
+the elements, in the order listed, of
+the \grammarterm{template-argument-list}
+comprising the concept's subsequent arguments.
+\begin{note}
+Thus, requirements of the form
+\tcode{\{ E \} -> Concept;} or of the form
+\tcode{\{ E \} -> Concept<>;} are equivalent to
+\tcode{E; requires Concept<decltype((E))>;}
+while a requirements of the form
+\tcode{\{ E \} -> Concept<A$_1$, A$_2$, $\cdots$, A$_n$>;} is equivalent to
+\tcode{E; requires Concept<decltype((E)), A$_1$, A$_2$, $\cdots$, A$_n$>;}.
+\end{note}
 \end{itemize}
 \end{itemize}
 
@@ -2672,32 +2683,13 @@ that \tcode{*x} is implicitly convertible to
 \tcode{typename T::inner}.
 
 \begin{codeblock}
-template<typename T, typename U> concept C3 = requires (T t, U u) {
-  t == u;
-};
-template<typename T> concept C4 = requires(T x) {
-  {*x} -> C3<int> const&;
-};
-\end{codeblock}
-The \grammarterm{compound-requirement}
-requires that \tcode{*x} be deduced
-as an argument for the invented function:
-\begin{codeblock}
-template<C3<int> X> void f(X const&);
-\end{codeblock}
-In this case, deduction only succeeds if
-an expression of the type deduced for \tcode{X}
-can be compared to an \tcode{int}
-with the \tcode{==} operator.
-
-\begin{codeblock}
-template<typename T> concept C5 =
+template<typename T> concept C3 =
   requires(T x) {
     {g(x)} noexcept;
   };
 \end{codeblock}
 
-The \grammarterm{compound-requirement} in \tcode{C5}
+The \grammarterm{compound-requirement} in \tcode{C3}
 requires that \tcode{g(x)} is a valid expression and
 that \tcode{g(x)} is non-throwing.
 \end{example}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2633,12 +2633,12 @@ If conversion fails, the enclosing \grammarterm{requires-expression}
 is \tcode{false}.
 
 \item
-If the \grammarterm{return-type-requirement} is
+If the \grammarterm{return-type-requirement} has
 a \grammarterm{qualified-concept-name}\iref{temp.param} of the form
 \opt{\grammarterm{nested-name-specifier}} \grammarterm{concept-name},
 the concept it denotes shall be satisfied with
 \tcode{decltype((E))} as its sole argument.
-If the \grammarterm{return-type-requirement} is
+If the \grammarterm{return-type-requirement} has
 a \grammarterm{qualified-concept-name} of the form
 \opt{\grammarterm{nested-name-specifier}} \grammarterm{concept-name}
 \tcode{<} \opt{\grammarterm{template-argument-list}} \tcode{>},


### PR DESCRIPTION
[expr.prim.req.compound] Renamed C5 to C3 in remaining example.

Fixes #2397.