### PR TITLE
P1141R2 Yet another approach for constrained declarations

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1273,8 +1273,8 @@ The simple type specifiers are
     \terminal{float}\br
     \terminal{double}\br
     \terminal{void}\br
-    \terminal{auto}\br
-    decltype-specifier
+    decltype-specifier\br
+    placeholder-type-specifier
 \end{bnf}
 
 \begin{bnf}
@@ -1286,8 +1286,13 @@ The simple type specifiers are
 
 \begin{bnf}
 \nontermdef{decltype-specifier}\br
-  \terminal{decltype} \terminal{(} expression \terminal{)}\br
-  \terminal{decltype} \terminal{(} \terminal{auto} \terminal{)}
+  \terminal{decltype} \terminal{(} expression \terminal{)}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{placeholder-type-specifier}\br
+  \opt{type-constraint} \terminal{auto}\br
+  \opt{type-constraint} \terminal{decltype} \terminal{(} \terminal{auto} \terminal{)}
 \end{bnf}
 
 \pnum
@@ -1309,7 +1314,7 @@ The simple type specifiers are
 \indextext{type specifier!\idxcode{decltype}}%
 \indextext{\idxgram{type-name}}%
 \indextext{\idxgram{lambda-introducer}}%
-The \grammarterm{simple-type-specifier} \tcode{auto}
+A \grammarterm{placeholder-type-specifier}
 is a placeholder for
 a type to be deduced\iref{dcl.spec.auto}.
 \indextext{deduction!class template arguments}%
@@ -1373,10 +1378,10 @@ and the types they specify.
 \tcode{double}                    & ``\tcode{double}''                \\
 \tcode{long double}               & ``\tcode{long double}''           \\
 \tcode{void}                      & ``\tcode{void}''                  \\
-\tcode{auto}                      & placeholder for a type to be deduced\\
-\tcode{decltype(auto)}            & placeholder for a type to be deduced\\
 \tcode{decltype(}\grammarterm{expression}\tcode{)}
                                   & the type as defined below\\
+\grammarterm{placeholder-type-specifier}
+                                  & placeholder for a type to be deduced\\
 \end{simpletypetable}
 
 \pnum
@@ -1582,15 +1587,19 @@ enum E x = E::a;                // OK
 \indextext{type specifier!\idxcode{auto}}
 
 \pnum
-The \tcode{auto} and \tcode{decltype(auto)} \grammarterm{type-specifier}{s}
-are used to
-designate a placeholder type that will be replaced later by deduction
-from an initializer. The \tcode{auto}
-\grammarterm{type-specifier} is also used to
-introduce a function type having a \grammarterm{trailing-return-type} or to
-signify that a lambda is a generic lambda\iref{expr.prim.lambda}.
-The \tcode{auto} \grammarterm{type-specifier} is also used to introduce a
-structured binding declaration\iref{dcl.struct.bind}.
+A \grammarterm{placeholder-type-specifier}
+designates a placeholder type that will be replaced later by deduction
+from an initializer.
+
+\pnum
+A \grammarterm{placeholder-type-specifier} of the form
+\opt{\grammarterm{type-constraint}} \tcode{auto}
+can be used in the \grammarterm{decl-specifier-seq} of
+a \grammarterm{parameter-declaration} of
+a function declaration or \grammarterm{lambda-expression} and
+signifies that the function is
+an abbreviated function template\iref{dcl.fct} or
+the lambda is a generic lambda\iref{expr.prim.lambda}.
 
 \pnum
 The placeholder type can appear with a function declarator in the
@@ -1606,11 +1615,11 @@ deduced from non-discarded \tcode{return} statements, if any, in the body
 of the function\iref{stmt.if}.
 
 \pnum
-The type of a variable declared using \tcode{auto} or \tcode{decltype(auto)} is
+The type of a variable declared using a placeholder type is
 deduced from its initializer.
 This use is allowed
 in an initializing declaration\iref{dcl.init} of a variable.
-\tcode{auto} or \tcode{decltype(auto)} shall appear as one of the
+The placeholder type shall appear as one of the
 \grammarterm{decl-specifier}{s} in the
 \grammarterm{decl-specifier-seq} and the
 \grammarterm{decl-specifier-seq}
@@ -1638,6 +1647,9 @@ auto g() { return 0.0; }        // OK: \tcode{g} returns \tcode{double}
 auto h();                       // OK: \tcode{h}'s return type will be deduced when it is defined
 \end{codeblock}
 \end{example}
+The \tcode{auto} \grammarterm{type-specifier}
+can also be used to introduce
+a structured binding declaration\iref{dcl.struct.bind}.
 
 \pnum
 A placeholder type can also be used
@@ -1650,7 +1662,7 @@ of the \grammarterm{parameter-declaration}{'s}
 in a \grammarterm{template-parameter}\iref{temp.param}.
 
 \pnum
-A program that uses \tcode{auto} or \tcode{decltype(auto)} in a context not
+A program that uses a placeholder type in a context not
 explicitly allowed in this subclause is ill-formed.
 
 \pnum
@@ -1819,7 +1831,8 @@ and \tcode{e} is the corresponding template argument.
 In the case of a \tcode{return} statement with no operand
 or with an operand of type \tcode{void},
 \tcode{T} shall be either
-\tcode{decltype(auto)} or \cv{}~\tcode{auto}.
+\opt{\grammarterm{type-constraint}} \tcode{decltype(auto)} or
+\cv{}~\opt{\grammarterm{type-constraint}} \tcode{auto}.
 
 \pnum
 If the deduction is for a \tcode{return} statement
@@ -1827,13 +1840,15 @@ and \tcode{e} is a \grammarterm{braced-init-list}\iref{dcl.init.list},
 the program is ill-formed.
 
 \pnum
-If the placeholder is the \tcode{auto} \grammarterm{type-specifier}, the
-deduced type
+If the \grammarterm{placeholder-type-specifier} is of the form
+\opt{\grammarterm{type-constraint}} \tcode{auto},
+the deduced type
 $\mathtt{T}'$ replacing \tcode{T}
 is determined using the rules for template argument deduction.
 Obtain \tcode{P} from
-\tcode{T} by replacing the occurrences of \tcode{auto} with either a new
-invented type template parameter \tcode{U} or,
+\tcode{T} by replacing the occurrences of
+\opt{\grammarterm{type-constraint}} \tcode{auto} with either
+a new invented type template parameter \tcode{U} or,
 if the initialization is copy-list-initialization, with
 \tcode{std::initializer_list<U>}. Deduce a value for \tcode{U} using the rules
 of template argument deduction from a function call\iref{temp.deduct.call},
@@ -1865,7 +1880,8 @@ template <class U> void f(const U& u);
 \end{example}
 
 \pnum
-If the placeholder is the \tcode{decltype(auto)} \grammarterm{type-specifier},
+If the \grammarterm{placeholder-type-specifier} is of the form
+\opt{\grammarterm{type-constraint}} \tcode{decltype(auto)},
 \tcode{T} shall be the
 placeholder alone. The type deduced for \tcode{T} is
 determined as described in~\ref{dcl.type.simple}, as though
@@ -1888,6 +1904,12 @@ auto          *x7a = &i;        // \tcode{decltype(x7a)} is \tcode{int*}
 decltype(auto)*x7d = &i;        // error, declared type is not plain \tcode{decltype(auto)}
 \end{codeblock}
 \end{example}
+
+\pnum
+For a \grammarterm{placeholder-type-specifier} with
+a \grammarterm{type-constraint},
+if the type deduced for the placeholder does not satisfy its
+immediately-declared constraint\iref{temp}, the program is ill-formed.
 
 \rSec3[dcl.type.class.deduct]{Deduced class template specialization types}
 \indextext{deduction!class template arguments}%
@@ -3529,6 +3551,91 @@ A \term{non-template function} is a function that is not a function template
 specialization. \begin{note} A function template is not a function. \end{note}
 
 \pnum
+\indextext{abbreviated!template function|see{template, function, abbreviated}}%
+An \defnx{abbreviated function template}{template!function!abbreviated}
+is a function declaration whose \grammarterm{parameter-type-list} includes
+one or more placeholders\iref{dcl.spec.auto}.
+An abbreviated function template is equivalent to
+a function template\iref{temp.over.link}
+whose \grammarterm{template-parameter-list} includes
+one invented type \grammarterm{template-parameter}
+for each occurrence of a placeholder type in
+the \grammarterm{decl-specifier-seq} of
+a \grammarterm{parameter-declaration} in
+the function's parameter-type-list, in order of appearance.
+For a \grammarterm{placeholder-type-specifier} of the form \tcode{auto},
+the invented parameter is
+an unconstrained \grammarterm{type-parameter}.
+For a \grammarterm{placeholder-type-specifier} of the form
+\grammarterm{type-constraint} \tcode{auto},
+the invented parameter is a \grammarterm{type-parameter} with
+that \grammarterm{type-constraint}.
+The invented type \grammarterm{template-parameter} is
+a template parameter pack
+if the corresponding \grammarterm{parameter-declaration}
+declares a function parameter pack\iref{dcl.fct}.
+If the placeholder contains \tcode{decltype(auto)},
+the program is ill-formed.
+The adjusted function parameters of an abbreviated function template
+are derived from the \grammarterm{parameter-declaration-clause} by
+replacing each occurrence of a placeholder with
+the name of the corresponding invented \grammarterm{template-parameter}.
+\begin{example}
+\begin{codeblock}
+template<typename T>     concept C1 = /* ... */;
+template<typename T>     concept C2 = /* ... */;
+template<typename... Ts> concept C3 = /* ... */;
+
+void g1(const C1 auto*, C2 auto&);
+void g2(C1 auto&...);
+void g3(C3 auto...);
+void g4(C3 auto);
+\end{codeblock}
+
+These declarations are functionally equivalent (but not equivalent) to
+the following declarations.
+\begin{codeblock}
+template<C1 T, C2 U> void g1(const T*, U&);
+template<C1... Ts>   void g2(Ts&...);
+template<C3... Ts>   void g3(Ts...);
+template<C3 T>       void g4(T);
+\end{codeblock}
+
+Abbreviated function templates can be specialized like all function templates.
+\begin{codeblock}
+template<> void g1<int>(const int*, const double&); // OK, specialization of \tcode{g1<int, const double>}
+\end{codeblock}
+\end{example}
+
+\pnum
+An abbreviated function template can have a \grammarterm{template-head}.
+The invented \grammarterm{template-parameters} are
+appended to the \grammarterm{template-parameter-list} after
+the explicitly declared \grammarterm{template-parameters}.
+\begin{example}
+\begin{codeblock}
+template<typename> concept C = /* ... */;
+
+template <typename T, C U>
+  void g(T x, U y, C auto z);
+\end{codeblock}
+
+This is functionally equivalent to each of the following two declarations.
+\begin{codeblock}
+template<typename T, C U, C W>
+  void g(T x, U y, W z);
+
+template<typename T, typename U, typename W>
+  requires C<U> && C<W>
+  void g(T x, U y, W z);
+\end{codeblock}
+\end{example}
+
+\pnum
+A function declaration at block scope
+shall not declare an abbreviated function template.
+
+\pnum
 A \grammarterm{declarator-id} or \grammarterm{abstract-declarator}
 containing an ellipsis shall only
 be used in a \grammarterm{parameter-declaration}.
@@ -3541,7 +3648,6 @@ Otherwise, the \grammarterm{parameter-declaration} is part of a
 template parameter pack; see~\ref{temp.param}.
 A function parameter pack is a pack expansion\iref{temp.variadic}.
 \begin{example}
-
 \begin{codeblock}
 template<typename... T> void f(T (* ...t)(int, int));
 

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1258,6 +1258,8 @@ The simple type specifiers are
 \nontermdef{simple-type-specifier}\br
     \opt{nested-name-specifier} type-name\br
     nested-name-specifier \terminal{template} simple-template-id\br
+    decltype-specifier\br
+    placeholder-type-specifier\br
     \opt{nested-name-specifier} template-name\br
     \terminal{char}\br
     \terminal{char8_t}\br
@@ -1272,27 +1274,14 @@ The simple type specifiers are
     \terminal{unsigned}\br
     \terminal{float}\br
     \terminal{double}\br
-    \terminal{void}\br
-    decltype-specifier\br
-    placeholder-type-specifier
+    \terminal{void}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{type-name}\br
     class-name\br
     enum-name\br
-    typedef-name\br
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{decltype-specifier}\br
-  \terminal{decltype} \terminal{(} expression \terminal{)}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{placeholder-type-specifier}\br
-  \opt{type-constraint} \terminal{auto}\br
-  \opt{type-constraint} \terminal{decltype} \terminal{(} \terminal{auto} \terminal{)}
+    typedef-name
 \end{bnf}
 
 \pnum
@@ -1310,8 +1299,6 @@ The simple type specifiers are
 \indextext{type specifier!\idxcode{float}}%
 \indextext{type specifier!\idxcode{double}}%
 \indextext{type specifier!\idxcode{void}}%
-\indextext{type specifier!\idxcode{auto}}%
-\indextext{type specifier!\idxcode{decltype}}%
 \indextext{\idxgram{type-name}}%
 \indextext{\idxgram{lambda-introducer}}%
 A \grammarterm{placeholder-type-specifier}
@@ -1342,7 +1329,10 @@ and the types they specify.
 \hdstyle{Specifier(s)}            &   \hdstyle{Type}                  \\ \capsep
 \grammarterm{type-name}           & the type named                    \\
 \grammarterm{simple-template-id}  & the type as defined in~\ref{temp.names}\\
-\grammarterm{template-name}       & placeholder for a type to be deduced\\
+\grammarterm{decltype-specifier}  & the type as defined in~\ref{dcl.type.decltype}\\
+\grammarterm{placeholder-type-specifier}
+                                  & the type as defined in~\ref{dcl.spec.auto}\\
+\grammarterm{template-name}       & the type as defined in~\ref{dcl.type.class.deduct}\\
 \tcode{char}                      & ``\tcode{char}''                  \\
 \tcode{unsigned char}             & ``\tcode{unsigned char}''         \\
 \tcode{signed char}               & ``\tcode{signed char}''           \\
@@ -1378,10 +1368,6 @@ and the types they specify.
 \tcode{double}                    & ``\tcode{double}''                \\
 \tcode{long double}               & ``\tcode{long double}''           \\
 \tcode{void}                      & ``\tcode{void}''                  \\
-\tcode{decltype(}\grammarterm{expression}\tcode{)}
-                                  & the type as defined below\\
-\grammarterm{placeholder-type-specifier}
-                                  & placeholder for a type to be deduced\\
 \end{simpletypetable}
 
 \pnum
@@ -1392,6 +1378,100 @@ It is \impldef{signedness of \tcode{char}} whether objects of \tcode{char} type 
 represented as signed or unsigned quantities. The \tcode{signed} specifier
 forces \tcode{char} objects to be signed; it is redundant in other contexts.
 \end{note}
+
+\rSec3[dcl.type.elab]{Elaborated type specifiers}%
+\indextext{type specifier!elaborated}%
+\indextext{\idxcode{typename}}%
+\indextext{type specifier!\idxcode{enum}}
+
+\begin{bnf}
+\nontermdef{elaborated-type-specifier}\br
+    class-key \opt{attribute-specifier-seq} \opt{nested-name-specifier} identifier\br
+    class-key simple-template-id\br
+    class-key nested-name-specifier \opt{\terminal{template}} simple-template-id\br
+    \terminal{enum} \opt{nested-name-specifier} identifier
+\end{bnf}
+
+\pnum
+\indextext{class name!elaborated}%
+\indextext{name!elaborated!\idxcode{enum}}%
+An \grammarterm{attribute-specifier-seq} shall not appear in an \grammarterm{elaborated-type-specifier}
+unless the latter is the sole constituent of a declaration.
+If an \grammarterm{elaborated-type-specifier} is the sole constituent of a
+declaration, the declaration is ill-formed unless it is an explicit
+specialization\iref{temp.expl.spec}, an explicit
+instantiation\iref{temp.explicit} or it has one of the following
+forms:
+
+\begin{ncsimplebnf}
+class-key \opt{attribute-specifier-seq} identifier \terminal{;}\br
+\terminal{friend} class-key \terminal{\opt{::}} identifier \terminal{;}\br
+\terminal{friend} class-key \terminal{\opt{::}} simple-template-id \terminal{;}\br
+\terminal{friend} class-key nested-name-specifier identifier \terminal{;}\br
+\terminal{friend} class-key nested-name-specifier \terminal{\opt{template}} simple-template-id \terminal{;}
+\end{ncsimplebnf}
+
+In the first case, the \grammarterm{attribute-specifier-seq}, if any, appertains
+to the class being declared; the attributes in the
+\grammarterm{attribute-specifier-seq} are thereafter considered attributes of
+the class whenever it is named.
+
+\pnum
+\begin{note}
+\ref{basic.lookup.elab} describes how name lookup proceeds for the
+\grammarterm{identifier} in an \grammarterm{elaborated-type-specifier}.
+\end{note}
+If the \grammarterm{identifier} or \grammarterm{simple-template-id}
+resolves to a \grammarterm{class-name} or
+\grammarterm{enum-name}, the \grammarterm{elaborated-type-specifier}
+introduces it into the declaration the same way a
+\grammarterm{simple-type-specifier} introduces
+its \grammarterm{type-name}\iref{dcl.type.simple}.
+If the \grammarterm{identifier} or \grammarterm{simple-template-id} resolves to a
+\grammarterm{typedef-name} (\ref{dcl.typedef}, \ref{temp.names}),
+the \grammarterm{elaborated-type-specifier} is ill-formed.
+\begin{note}
+This implies that, within a class template with a template
+\grammarterm{type-parameter} \tcode{T}, the declaration
+
+\begin{codeblock}
+friend class T;
+\end{codeblock}
+
+is ill-formed. However, the similar declaration \tcode{friend T;} is allowed\iref{class.friend}.
+\end{note}
+
+\pnum
+The \grammarterm{class-key} or \tcode{enum} keyword
+present in the
+\grammarterm{elaborated-type-specifier} shall agree in kind with the
+declaration to which the name in the
+\grammarterm{elaborated-type-specifier} refers. This rule also applies to
+the form of \grammarterm{elaborated-type-specifier} that declares a
+\grammarterm{class-name} or friend class since it can be construed
+as referring to the definition of the class. Thus, in any
+\grammarterm{elaborated-type-specifier}, the \tcode{enum} keyword
+shall be
+used to refer to an enumeration\iref{dcl.enum}, the \tcode{union}
+\grammarterm{class-key} shall be used to refer to a union\iref{class},
+and either the \tcode{class} or \tcode{struct}
+\grammarterm{class-key} shall be used to refer to a class\iref{class}
+declared using the \tcode{class} or \tcode{struct}
+\grammarterm{class-key}. \begin{example}
+
+\begin{codeblock}
+enum class E { a, b };
+enum E x = E::a;                // OK
+\end{codeblock}
+\end{example}
+
+\rSec3[dcl.type.decltype]{Decltype specifiers}%
+\indextext{type specifier!\idxcode{decltype}}%
+
+\begin{bnf}
+\nontermdef{decltype-specifier}\br
+  \terminal{decltype} \terminal{(} expression \terminal{)}
+\end{bnf}
 
 \pnum
 \indextext{type specifier!\idxcode{decltype}}%
@@ -1497,94 +1577,15 @@ void r() {
 \end{codeblock}
 \end{example}
 
-\rSec3[dcl.type.elab]{Elaborated type specifiers}%
-\indextext{type specifier!elaborated}%
-\indextext{\idxcode{typename}}%
-\indextext{type specifier!\idxcode{enum}}
+\rSec3[dcl.spec.auto]{Placeholder type specifiers}%
+\indextext{type specifier!\idxcode{auto}}
+\indextext{type specifier!\idxcode{decltype(auto)}}%
 
 \begin{bnf}
-\nontermdef{elaborated-type-specifier}\br
-    class-key \opt{attribute-specifier-seq} \opt{nested-name-specifier} identifier\br
-    class-key simple-template-id\br
-    class-key nested-name-specifier \opt{\terminal{template}} simple-template-id\br
-    \terminal{enum} \opt{nested-name-specifier} identifier
+\nontermdef{placeholder-type-specifier}\br
+  \opt{type-constraint} \terminal{auto}\br
+  \opt{type-constraint} \terminal{decltype} \terminal{(} \terminal{auto} \terminal{)}
 \end{bnf}
-
-\pnum
-\indextext{class name!elaborated}%
-\indextext{name!elaborated!\idxcode{enum}}%
-An \grammarterm{attribute-specifier-seq} shall not appear in an \grammarterm{elaborated-type-specifier}
-unless the latter is the sole constituent of a declaration.
-If an \grammarterm{elaborated-type-specifier} is the sole constituent of a
-declaration, the declaration is ill-formed unless it is an explicit
-specialization\iref{temp.expl.spec}, an explicit
-instantiation\iref{temp.explicit} or it has one of the following
-forms:
-
-\begin{ncsimplebnf}
-class-key \opt{attribute-specifier-seq} identifier \terminal{;}\br
-\terminal{friend} class-key \terminal{\opt{::}} identifier \terminal{;}\br
-\terminal{friend} class-key \terminal{\opt{::}} simple-template-id \terminal{;}\br
-\terminal{friend} class-key nested-name-specifier identifier \terminal{;}\br
-\terminal{friend} class-key nested-name-specifier \terminal{\opt{template}} simple-template-id \terminal{;}
-\end{ncsimplebnf}
-
-In the first case, the \grammarterm{attribute-specifier-seq}, if any, appertains
-to the class being declared; the attributes in the
-\grammarterm{attribute-specifier-seq} are thereafter considered attributes of
-the class whenever it is named.
-
-\pnum
-\begin{note}
-\ref{basic.lookup.elab} describes how name lookup proceeds for the
-\grammarterm{identifier} in an \grammarterm{elaborated-type-specifier}.
-\end{note}
-If the \grammarterm{identifier} or \grammarterm{simple-template-id}
-resolves to a \grammarterm{class-name} or
-\grammarterm{enum-name}, the \grammarterm{elaborated-type-specifier}
-introduces it into the declaration the same way a
-\grammarterm{simple-type-specifier} introduces
-its \grammarterm{type-name}\iref{dcl.type.simple}.
-If the \grammarterm{identifier} or \grammarterm{simple-template-id} resolves to a
-\grammarterm{typedef-name} (\ref{dcl.typedef}, \ref{temp.names}),
-the \grammarterm{elaborated-type-specifier} is ill-formed.
-\begin{note}
-This implies that, within a class template with a template
-\grammarterm{type-parameter} \tcode{T}, the declaration
-
-\begin{codeblock}
-friend class T;
-\end{codeblock}
-
-is ill-formed. However, the similar declaration \tcode{friend T;} is allowed\iref{class.friend}.
-\end{note}
-
-\pnum
-The \grammarterm{class-key} or \tcode{enum} keyword
-present in the
-\grammarterm{elaborated-type-specifier} shall agree in kind with the
-declaration to which the name in the
-\grammarterm{elaborated-type-specifier} refers. This rule also applies to
-the form of \grammarterm{elaborated-type-specifier} that declares a
-\grammarterm{class-name} or friend class since it can be construed
-as referring to the definition of the class. Thus, in any
-\grammarterm{elaborated-type-specifier}, the \tcode{enum} keyword
-shall be
-used to refer to an enumeration\iref{dcl.enum}, the \tcode{union}
-\grammarterm{class-key} shall be used to refer to a union\iref{class},
-and either the \tcode{class} or \tcode{struct}
-\grammarterm{class-key} shall be used to refer to a class\iref{class}
-declared using the \tcode{class} or \tcode{struct}
-\grammarterm{class-key}. \begin{example}
-
-\begin{codeblock}
-enum class E { a, b };
-enum E x = E::a;                // OK
-\end{codeblock}
-\end{example}
-
-\rSec3[dcl.spec.auto]{The \tcode{auto} specifier}%
-\indextext{type specifier!\idxcode{auto}}
 
 \pnum
 A \grammarterm{placeholder-type-specifier}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2630,7 +2630,7 @@ does not require that type to be complete\iref{basic.types}.
 \begin{bnf}
 \nontermdef{return-type-requirement}\br
     trailing-return-type\br
-    \terminal{->} qualified-concept-name
+    \terminal{->} type-constraint
 \end{bnf}
 
 \pnum
@@ -2666,20 +2666,12 @@ If conversion fails, the enclosing \grammarterm{requires-expression}
 is \tcode{false}.
 
 \item
-If the \grammarterm{return-type-requirement} has
-a \grammarterm{qualified-concept-name}\iref{temp.param} of the form
-\opt{\grammarterm{nested-name-specifier}} \grammarterm{concept-name},
-the concept it denotes shall be satisfied with
-\tcode{decltype((E))} as its sole argument.
-If the \grammarterm{return-type-requirement} has
-a \grammarterm{qualified-concept-name} of the form
-\opt{\grammarterm{nested-name-specifier}} \grammarterm{concept-name}
-\tcode{<} \opt{\grammarterm{template-argument-list}} \tcode{>},
-the concept it denotes shall be satisfied with
-\tcode{decltype((E))} as its first argument and with
-the elements, in the order listed, of
-the \grammarterm{template-argument-list}
-comprising the concept's subsequent arguments.
+If the \grammarterm{return-type-requirement}
+is of the form \tcode{->} \grammarterm{type-constraint}, then
+the contextually-determined type being constrained
+is \tcode{decltype((E))}.
+The immediately-declared constraint\iref{temp} of \tcode{decltype((E))}
+shall be satisfied.
 \begin{note}
 Thus, requirements of the form
 \tcode{\{ E \} -> Concept;} or of the form

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2672,18 +2672,27 @@ the contextually-determined type being constrained
 is \tcode{decltype((E))}.
 The immediately-declared constraint\iref{temp} of \tcode{decltype((E))}
 shall be satisfied.
-\begin{note}
-Thus, requirements of the form
-\tcode{\{ E \} -> Concept;} or of the form
-\tcode{\{ E \} -> Concept<>;} are equivalent to
-\tcode{E; requires Concept<decltype((E))>;}
-while a requirements of the form
-\tcode{\{ E \} -> Concept<A$_1$, A$_2$, $\cdots$, A$_n$>;} is equivalent to
-\tcode{E; requires Concept<decltype((E)), A$_1$, A$_2$, $\cdots$, A$_n$>;}.
-\end{note}
+\begin{example}
+Given concepts \tcode{C} and \tcode{D},
+\begin{codeblock}
+requires {
+  { E1 } -> C;
+  { E2 } -> @D<A$_1$, $\cdots$, A$_n$>@;
+};
+\end{codeblock}
+is equivalent to
+\begin{codeblock}
+requires {
+  E1; requires C<decltype((E1))>;
+  E2; requires @D<decltype((E2)), A$_1$, $\cdots$, A$_n$>@;
+};
+\end{codeblock}
+(including in the case where $n$ is zero).
+\end{example}
 \end{itemize}
 \end{itemize}
 
+\pnum
 \begin{example}
 \begin{codeblock}
 template<typename T> concept C1 = requires(T x) {

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1584,8 +1584,9 @@ auto x3 = []()->auto&& { return j; }; // OK: return type is \tcode{int\&}
 
 \pnum
 A lambda is a \defn{generic lambda}
-if the \tcode{auto} \grammarterm{type-specifier} appears as one of the
-\grammarterm{decl-specifier}{s} in the \grammarterm{decl-specifier-seq} of a
+if there is a \grammarterm{decl-specifier} that is
+a \grammarterm{placeholder-type-specifier} in
+the \grammarterm{decl-specifier-seq} of a
 \grammarterm{parameter-declaration} of the \grammarterm{lambda-expression},
 or if the lambda has a \grammarterm{template-parameter-list}.
 \begin{example}
@@ -1626,33 +1627,25 @@ An implementation shall not add members of rvalue reference type to the closure
 type.
 
 \pnum
-The closure type for a non-generic \grammarterm{lambda-expression} has a public
-inline function call operator\iref{over.call} whose parameters and return type
+The closure type for a \grammarterm{lambda-expression} has a public
+inline function call operator (for a non-generic lambda) or
+function call operator template (for a generic lambda)\iref{over.call}
+whose parameters and return type
 are described by the \grammarterm{lambda-expression}'s
 \grammarterm{parameter-declaration-clause} and \grammarterm{trailing-return-type}
-respectively.
-For a generic lambda, the closure type has a public inline function call
-operator member template\iref{temp.mem} whose
+respectively, and whose
 \grammarterm{template-parameter-list} consists of
-the specified \grammarterm{template-parameter-list}, if any,
-to which is appended one invented type
-\grammarterm{template-parameter} for each occurrence of \tcode{auto} in the
-lambda's \grammarterm{parameter-declaration-clause}, in order of appearance.
-The invented type \grammarterm{template-parameter} is a template parameter pack if
-the corresponding \grammarterm{parameter-declaration} declares a function
-parameter pack\iref{dcl.fct}. The return type and function parameters of the
-function call operator template are derived from the
-\grammarterm{lambda-expression}{'s} \grammarterm{trailing-return-type} and
-\grammarterm{parameter-declaration-clause} by replacing each occurrence of
-\tcode{auto} in the \grammarterm{decl-specifier}{s} of the
-\grammarterm{parameter-declaration-clause} with the name of the corresponding
-invented \grammarterm{template-parameter}.
+the specified \grammarterm{template-parameter-list}, if any.
 The \grammarterm{requires-clause} of the function call operator template
 is the \grammarterm{requires-clause} immediately following
 \tcode{<}~\grammarterm{template-parameter-list}{}~\tcode{>}, if any.
 The trailing \grammarterm{requires-clause} of the function call operator
 or operator template is the \grammarterm{requires-clause}
 following the \grammarterm{lambda-declarator}, if any.
+\begin{note}
+The function call operator for a generic lambda might be
+an abbreviated function template\iref{dcl.fct}.
+\end{note}
 \begin{example}
 \begin{codeblock}
 auto glambda = [](auto a, auto&& b) { return a < b; };
@@ -1737,8 +1730,10 @@ static_assert(add(one)(one)() == monoid(2)()); // OK
 \end{example}
 
 \pnum
+\begin{note}
 The function call operator or operator template may be constrained\iref{temp.constr.decl}
-by a \grammarterm{constrained-parameter}\iref{temp.param}, a \grammarterm{requires-clause}\iref{temp},
+by a \grammarterm{type-constraint}\iref{temp.param},
+a \grammarterm{requires-clause}\iref{temp},
 or a trailing \grammarterm{requires-clause}\iref{dcl.decl}.
 \begin{example}
 \begin{codeblock}
@@ -1748,12 +1743,13 @@ template <typename A, typename B> concept C3 = @\commentellip@;
 
 auto f = []<typename T1, C1 T2> requires C2<sizeof(T1) + sizeof(T2)>
          (T1 a1, T1 b1, T2 a2, auto a3, auto a4) requires C3<decltype(a4), T2> {
-  // \tcode{T2} is a constrained parameter,
+  // \tcode{T2} is constrained by a \grammarterm{type-constraint}.
   // \tcode{T1} and \tcode{T2} are constrained by a \grammarterm{requires-clause}, and
   // \tcode{T2} and the type of \tcode{a4} are constrained by a trailing \grammarterm{requires-clause}.
 };
 \end{codeblock}
 \end{example}
+\end{note}
 
 \pnum
 The closure type for a non-generic \grammarterm{lambda-expression} with no

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -57,6 +57,12 @@ an alias for a family of types, or a concept.
   identifier
 \end{bnf}
 
+\begin{bnf}
+\nontermdef{type-constraint}\br
+  \opt{nested-name-specifier} concept-name\br
+  \opt{nested-name-specifier} concept-name \terminal{<} \opt{template-argument-list} \terminal{>}
+\end{bnf}
+
 \begin{note} The \tcode{>} token following the
 \grammarterm{template-parameter-list} of a
 \grammarterm{template-declaration}
@@ -146,6 +152,23 @@ explicit specialization, or explicit instantiation the
 in the declaration shall contain at most one declarator.
 When such a declaration is used to declare a class template,
 no declarator is permitted.
+
+\pnum
+A \grammarterm{type-constraint} \tcode{Q} that designates a concept \tcode{C}
+can be used to constrain a
+contextually-determined type or template type parameter pack \tcode{T}
+with a \grammarterm{constraint-expression} \tcode{E} defined as follows.
+If \tcode{Q} is of the form \tcode{C<A$_1$, $\cdots$, A$_n$>},
+then let \tcode{E$'$} be \tcode{C<T, A$_1$, $\cdots$, A$_n$>}.
+Otherwise, let \tcode{E$'$} be \tcode{C<T>}.
+If \tcode{T} is not a pack,
+then \tcode{E} is \tcode{E$'$},
+otherwise \tcode{E} is \tcode{(E$'$ \&\& ...)}.
+This \grammarterm{constraint-expression} \tcode{E} is called the
+\defnx{immediately-declared constraint}{constraint!immediately-declared}
+of \tcode{T}.
+The concept designated by a \grammarterm{type-constraint}
+shall be a type concept\iref{temp.concept}.
 
 \pnum
 \indextext{template name!linkage of}%
@@ -238,14 +261,15 @@ is:
 \begin{bnf}
 \nontermdef{template-parameter}\br
   type-parameter\br
-  parameter-declaration\br
-  constrained-parameter
+  parameter-declaration
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{type-parameter}\br
   type-parameter-key \opt{\terminal{...}} \opt{identifier}\br
   type-parameter-key \opt{identifier} \terminal{=} type-id\br
+  type-constraint \opt{\terminal{...}} \opt{identifier}\br
+  type-constraint \opt{identifier} \terminal{=} type-id\br
   template-head type-parameter-key \opt{\terminal{...}} \opt{identifier}\br
   template-head type-parameter-key \opt{identifier} \terminal{=} id-expression
 \end{bnf}
@@ -254,23 +278,6 @@ is:
 \nontermdef{type-parameter-key}\br
   \terminal{class}\br
   \terminal{typename}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{constrained-parameter}\br
-  qualified-concept-name \terminal{...} \opt{identifier}\br
-  qualified-concept-name \opt{identifier} \opt{default-template-argument}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{qualified-concept-name}\br
-  \opt{nested-name-specifier} concept-name\br
-  \opt{nested-name-specifier} partial-concept-id
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{partial-concept-id}\br
-  concept-name \terminal{<} \opt{template-argument-list} \terminal{>}
 \end{bnf}
 
 \begin{bnf}
@@ -466,107 +473,27 @@ S<v> z;                         // OK due to both adjustment and conversion
 \end{example}
 
 \pnum
-A \grammarterm{partial-concept-id} is
-a \grammarterm{concept-name} followed by
-a sequence of \grammarterm{template-argument}{s}.
-These template arguments
-are used to form a \grammarterm{constraint-expression}
-as described below.
-
-\pnum
-A \grammarterm{constrained-parameter} declares
-a template parameter
-whose kind (type, non-type, template) and type
-match that of the prototype parameter\iref{temp.concept}
-of the concept designated by
-the \grammarterm{qualified-concept-name} in
-the \grammarterm{constrained-parameter}.
-Let \tcode{X} be the prototype parameter of the designated concept.
-The declared template parameter is determined by
-the kind of \tcode{X} (type, non-type, template)
-and the optional ellipsis in the \grammarterm{constrained-parameter}
-as follows.
-
-\begin{itemize}
-\item If \tcode{X} is a type \grammarterm{template-parameter},
-the declared parameter is a type \grammarterm{template-parameter}.
-
-\item If \tcode{X} is a non-type \grammarterm{template-parameter},
-the declared parameter is a non-type \grammarterm{template-parameter}
-having the same type as \tcode{X}.
-
-\item If \tcode{X} is a template \grammarterm{template-parameter},
-the declared parameter is a template \grammarterm{template-parameter}
-having the same \grammarterm{template-parameter-list} as \tcode{X},
-excluding default template arguments.
-
-\item If the \grammarterm{qualified-concept-name} is followed by an ellipsis,
-then the declared parameter is a template parameter pack\iref{temp.variadic}.
-\end{itemize}
-
-\begin{example}
-\begin{codeblock}
-template<typename T> concept C1 = true;
-template<template<typename> class X> concept C2 = true;
-template<int N> concept C3 = true;
-template<typename... Ts> concept C4 = true;
-template<char... Cs> concept C5 = true;
-
-template<C1 T> void f1();       // OK, \tcode{T} is a type \grammarterm{template-parameter}
-template<C2 X> void f2();       // OK, \tcode{X} is a template with one \grammarterm{type-parameter}
-template<C3 N> void f3();       // OK, \tcode{N} has type \tcode{int}
-template<C4... Ts> void f4();   // OK, \tcode{Ts} is a template parameter pack of types
-template<C4 T> void f5();       // OK, \tcode{T} is a type \grammarterm{template-parameter}
-template<C5... Cs> void f6();   // OK, \tcode{Cs} is a template parameter pack of \tcode{char}s
-\end{codeblock}
-\end{example}
-
-\pnum
-A \grammarterm{constrained-parameter} introduces
-a \grammarterm{constraint-expression}\iref{temp.constr.decl}.
-The expression is derived from
-the \grammarterm{qualified-concept-name} \tcode{Q} in
-the \grammarterm{constrained-parameter},
-its designated concept \tcode{C}, and
-the declared template parameter \tcode{P}.
-
-\begin{itemize}
-\item First, a template argument \tcode{A} is formed from \tcode{P}.
-If \tcode{P} declares a template parameter pack\iref{temp.variadic}
-and \tcode{C} is a variadic concept\iref{temp.concept},
-then \tcode{A} is the pack expansion \tcode{P...}.
-Otherwise,
-\tcode{A} is the \grammarterm{id-expression} \tcode{P}.
-
-% FIXME: This does not guarantee that the expression has the same
-% namespace qualification as Q.
-\item Then, an \grammarterm{id-expression} \tcode{E} is formed as follows.
-If \tcode{Q} is a \grammarterm{concept-name},
-then \tcode{E} is \tcode{C<A>}.
-Otherwise,
-\tcode{Q} is a \grammarterm{partial-concept-id}
-of the form \tcode{C<A$_1$, A$_2$, ..., A$_n$>},
-and \tcode{E} is \tcode{C<A, A$_1$, A$_2$, ..., A$_n$>}.
-
-\item Finally, if \tcode{P} declares a template parameter pack
-and \tcode{C} is not a variadic concept,
-\tcode{E} is adjusted to be the \grammarterm{fold-expression}
-\tcode{(E \&\& ...)}\iref{expr.prim.fold}.
-\end{itemize}
-
-\tcode{E} is the introduced \grammarterm{constraint-expression}.
+A \grammarterm{type-parameter} that starts with a \grammarterm{type-constraint}
+introduces the immediately-declared constraint\iref{temp} of the parameter.
 \begin{example}
 \begin{codeblock}
 template<typename T> concept C1 = true;
 template<typename... Ts> concept C2 = true;
 template<typename T, typename U> concept C3 = true;
 
-template<C1 T> struct s1;       // associates \tcode{C1<T>}
-template<C1... T> struct s2;    // associates \tcode{(C1<T> \&\& ...)}
-template<C2... T> struct s3;    // associates \tcode{C2<T...>}
-template<C3<int> T> struct s4;  // associates \tcode{C3<T, int>}
+template<C1 T> struct s1;              // associates \tcode{C1<T>}
+template<C1... T> struct s2;           // associates \tcode{(C1<T> \&\& ...)}
+template<C2... T> struct s3;           // associates \tcode{(C2<T> \&\& ...)}
+template<C3<int> T> struct s4;         // associates \tcode{C3<T, int>}
+template<C3<int>... T> struct s5;      // associates \tcode{(C3<T, int> \&\& ...)}
 \end{codeblock}
 \end{example}
+
+\pnum
+A non-type template parameter declared with a type that
+contains a placeholder type with a \grammarterm{type-constraint}
+introduces the immediately-declared constraint of
+the invented type corresponding to the placeholder\iref{dcl.fct}.
 
 \pnum
 A
@@ -599,26 +526,6 @@ specifies a default
 \grammarterm{template-argument},
 that declaration shall be a definition and shall be the only declaration of
 the function template in the translation unit.
-
-\pnum
-The default \grammarterm{template-argument}
-of a \grammarterm{constrained-parameter}
-shall match the kind (type, non-type, template)
-of the declared template parameter.
-\begin{example}
-\begin{codeblock}
-template<typename T> concept C1 = true;
-template<int N> concept C2 = true;
-template<template<typename> class X> concept C3 = true;
-
-template<typename T> struct S0;
-
-template<C1 T = int> struct S1; // OK
-template<C2 N = 0> struct S2;   // OK
-template<C3 X = S0> struct S3;  // OK
-template<C1 T = 0> struct S4;   // error: default argument is not a type
-\end{codeblock}
-\end{example}
 
 \pnum
 The set of default
@@ -749,7 +656,10 @@ A template parameter pack that is a \grammarterm{parameter-declaration} whose ty
 contains one or more unexpanded packs is a pack expansion. Similarly,
 a template parameter pack that is a \grammarterm{type-parameter} with a
 \grammarterm{template-parameter-list} containing one or more unexpanded
-packs is a pack expansion. A template parameter pack that is a pack
+packs is a pack expansion.
+A type parameter pack with a \grammarterm{type-constraint} that
+contains an unexpanded parameter pack is a pack expansion.
+A template parameter pack that is a pack
 expansion shall not expand a template parameter pack declared in the same
 \grammarterm{template-parameter-list}.
 \begin{example}
@@ -1743,7 +1653,7 @@ an expression:
 
 \pnum
 Constraints can also be associated with a declaration through the use of
-\grammarterm{constrained-parameter}{s} in a
+\grammarterm{type-constraint}{s} in a
 \grammarterm{template-parameter-list}.
 Each of these forms introduces additional \grammarterm{constraint-expression}{s}
 that are used to constrain the declaration.
@@ -1766,20 +1676,25 @@ following order:
 
 \begin{itemize}
 \item
-the \grammarterm{constraint-expression} introduced by each
-\grammarterm{constrained-parameter}\iref{temp.param} in the
-declaration's \grammarterm{template-parameter-list}, in
-order of appearance, and
+the \grammarterm{constraint-expression} introduced by
+each \grammarterm{type-constraint}\iref{temp.param} in
+the declaration's \grammarterm{template-parameter-list},
+in order of appearance, and
 
 \item
-the \grammarterm{constraint-expression} introduced
-by a \grammarterm{requires-clause} following a
-\grammarterm{template-parameter-list}\iref{temp}, and
+the \grammarterm{constraint-expression} introduced by
+a \grammarterm{requires-clause} following
+a \grammarterm{template-parameter-list}\iref{temp}, and
 
 \item
-the \grammarterm{constraint-expression} introduced by a trailing
-\grammarterm{requires-clause}\iref{dcl.decl}
-of a function declaration\iref{dcl.fct}.
+the \grammarterm{constraint-expression} introduced by
+each \grammarterm{type-constraint} in
+the parameter-type-list of a function declaration, and
+
+\item
+the \grammarterm{constraint-expression} introduced by
+a trailing \grammarterm{requires-clause}\iref{dcl.decl} of
+a function declaration\iref{dcl.fct}.
 \end{itemize}
 \end{itemize}
 
@@ -2117,7 +2032,7 @@ However, this syntax is allowed in class template partial specializations\iref{t
 \pnum
 For purposes of name lookup and instantiation,
 default arguments,
-\grammarterm{partial-concept-id}{s},
+\grammarterm{type-constraint}{s},
 \grammarterm{requires-clause}{s}\iref{temp},
 and
 \grammarterm{noexcept-specifier}{s}
@@ -2127,7 +2042,7 @@ of member functions of class templates
 are considered definitions;
 each
 default argument,
-\grammarterm{partial-concept-id}{s},
+\grammarterm{type-constraint},
 \grammarterm{requires-clause},
 or
 \grammarterm{noexcept-specifier}
@@ -2136,7 +2051,7 @@ which is unrelated
 to the templated function definition or
 to any other
 default arguments
-\grammarterm{partial-concept-id}{s},
+\grammarterm{type-constraint}{s},
 \grammarterm{requires-clause}{s},
 or
 \grammarterm{noexcept-specifier}{s}.
@@ -2636,12 +2551,14 @@ the pattern is a \grammarterm{using-declarator}.
 \item In a template parameter pack that is a pack expansion\iref{temp.param}:
 
 \begin{itemize}
-\item if the template parameter pack is a \grammarterm{parameter-declaration};
+\item
+if the template parameter pack is a \grammarterm{parameter-declaration};
 the pattern is the \grammarterm{parameter-declaration} without the ellipsis;
 
-\item if the template parameter pack is a \grammarterm{type-parameter} with a
-\grammarterm{template-parameter-list}; the pattern is the corresponding
-\grammarterm{type-parameter} without the ellipsis.
+\item
+if the template parameter pack is a \grammarterm{type-parameter};
+the pattern is the corresponding \grammarterm{type-parameter}
+without the ellipsis.
 \end{itemize}
 
 \item In an \grammarterm{initializer-list}\iref{dcl.init};
@@ -4019,7 +3936,7 @@ template<typename T>
   requires C<T>     // \tcode{C} constrains \tcode{f1(T)} in \grammarterm{constraint-expression}
 T f1(T x) { return x; }
 
-template<C T>       // \tcode{C} constrains \tcode{f2(T)} as a \grammarterm{constrained-parameter}
+template<C T>       // \tcode{C}, as a \grammarterm{type-constraint}, constrains \tcode{f2(T)}
 T f2(T x) { return x; }
 \end{codeblock}
 \end{example}
@@ -4045,10 +3962,10 @@ or partially specialized.
 \pnum
 The first declared template parameter of a concept definition is its
 \defnx{prototype parameter}{prototype parameter!concept}.
-\indextext{variadic concept|see{concept, variadic}}%
-A \defnx{variadic concept}{concept!variadic}
+\indextext{type concept|see{concept, type}}%
+A \defnx{type concept}{concept!type}
 is a concept whose prototype parameter
-is a template parameter pack.
+is a type \grammarterm{template-parameter}.
 
 \rSec1[temp.res]{Name resolution}
 
@@ -4277,7 +4194,7 @@ or a substatement of a constexpr if statement\iref{stmt.if} within a template
 and the template is not instantiated, or
 \item
 no substitution of template arguments
-into a \grammarterm{partial-concept-id} or \grammarterm{requires-clause}
+into a \grammarterm{type-constraint} or \grammarterm{requires-clause}
 would result in a valid expression, or
 \item
 every valid specialization of a variadic template requires an empty template
@@ -5753,7 +5670,7 @@ a local class are never considered to be entities that can be separately
 instantiated (this includes their default arguments,
 \grammarterm{noexcept-specifier}{s}, and non-static data member
 initializers, if any,
-but not their \grammarterm{partial-concept-id}{s} or \grammarterm{requires-clause}{s}).
+but not their \grammarterm{type-constraint}{s} or \grammarterm{requires-clause}{s}).
 As a result, the dependent names are looked up, the
 semantic constraints are checked, and any templates used are instantiated as
 part of the instantiation of the entity within which the local class or
@@ -6080,7 +5997,7 @@ template<class T> class X {
 \end{example}
 
 \pnum
-The \grammarterm{partial-concept-id}{s} and \grammarterm{requires-clause}
+The \grammarterm{type-constraint}{s} and \grammarterm{requires-clause}
 of a template specialization or member function
 are not instantiated along with the specialization or function itself,
 even for a member function of a local class;

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -280,13 +280,6 @@ is:
   \terminal{typename}
 \end{bnf}
 
-\begin{bnf}
-\nontermdef{default-template-argument}\br
-  \terminal{=} type-id\br
-  \terminal{=} id-expression\br
-  \terminal{=} initializer-clause
-\end{bnf}
-
 \begin{note} The \tcode{>} token following the
 \grammarterm{template-parameter-list} of a
 \grammarterm{type-parameter}


### PR DESCRIPTION
[dcl.fct] Replaced the reference to the non-existant section 17.6.5 with
    [temp.over.link] where function template equivalence is defined.
[temp] Clarified "This" as being the "type-constraint Q".
[temp.param] Add reference to "immediately-declared constraint".
[temp.param] Add reference to "the invented type corresponding to the placeholder".
[temp.constr.decl] Added "a" to and "and" after the new item in the bulletted list.

Fixes #2407.
Note: you might want to fix the spelling of "bulletted" in the commit message when committing to master :)