### PR TITLE
P0487R1 Fixing operator>>(basic_istream&, CharT*) (LWG 2499)

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -2087,7 +2087,9 @@ Character array extraction only takes array types.
 Valid \CppXVII{} code may fail to compile in this International Standard:
 \begin{codeblock}
 auto p = new char[100];
-std::cin >> std::setw(20) >> p;
+char q[100];
+std::cin >> std::setw(20) >> p;        // ill-formed; previously well-formed
+std::cin >> std::setw(20) >> q;        // OK
 \end{codeblock}
 
 \diffref{ostream.inserters.character}

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -2079,6 +2079,17 @@ translation units compiled against \CppXVII{}, either failing to link or having 
 
 \rSec2[diff.cpp17.input.output]{\ref{input.output}: input/output library}
 
+\diffref{istream.extractors}
+\change
+Character array extraction only takes array types.
+\rationale Increase safety via preventing buffer overflow at compile time.
+\effect
+Valid \CppXVII{} code may fail to compile in this International Standard:
+\begin{codeblock}
+auto p = new char[100];
+std::cin >> std::setw(20) >> p;
+\end{codeblock}
+
 \diffref{ostream.inserters.character}
 \change
 Overload resolution for ostream inserters used with UTF-8 literals.

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -4270,12 +4270,12 @@ namespace std {
   template<class traits>
     basic_istream<char, traits>& operator>>(basic_istream<char, traits>&, signed char&);
 
-  template<class charT, class traits>
-    basic_istream<charT, traits>& operator>>(basic_istream<charT, traits>&, charT*);
-  template<class traits>
-    basic_istream<char, traits>& operator>>(basic_istream<char, traits>&, unsigned char*);
-  template<class traits>
-    basic_istream<char, traits>& operator>>(basic_istream<char, traits>&, signed char*);
+  template<class charT, class traits, size_t N>
+    basic_istream<charT, traits>& operator>>(basic_istream<charT, traits>&, charT(&)[N]);
+  template<class traits, size_t N>
+    basic_istream<char, traits>& operator>>(basic_istream<char, traits>&, unsigned char(&)[N]);
+  template<class traits, size_t N>
+    basic_istream<char, traits>& operator>>(basic_istream<char, traits>&, signed char(&)[N]);
 }
 \end{codeblock}
 
@@ -4756,12 +4756,12 @@ This extractor does not behave as a formatted input function
 
 \indexlibrarymember{operator>>}{basic_istream}%
 \begin{itemdecl}
-template<class charT, class traits>
-  basic_istream<charT, traits>& operator>>(basic_istream<charT, traits>& in, charT* s);
-template<class traits>
-  basic_istream<char, traits>& operator>>(basic_istream<char, traits>& in, unsigned char* s);
-template<class traits>
-  basic_istream<char, traits>& operator>>(basic_istream<char, traits>& in, signed char* s);
+template<class charT, class traits, size_t N>
+  basic_istream<charT, traits>& operator>>(basic_istream<charT, traits>& in, charT (&s)[N]);
+template<class traits, size_t N>
+  basic_istream<char, traits>& operator>>(basic_istream<char, traits>& in, unsigned char (&s)[N]);
+template<class traits, size_t N>
+  basic_istream<char, traits>& operator>>(basic_istream<char, traits>& in, signed char (&s)[N]);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4774,17 +4774,12 @@ After a
 object is constructed,
 \tcode{operator>>}
 extracts characters and stores them into
-successive locations of an array whose first element is designated by
 \tcode{s}.
 If
 \tcode{width()}
 is greater than zero, \tcode{n} is
-\tcode{width()}.
-Otherwise \tcode{n} is the number of elements
-of the largest array of
-\tcode{char_type}
-that can store a terminating
-\tcode{charT()}.
+\tcode{min(size_t(width()), N)}.
+Otherwise \tcode{n} is \tcode{N}.
 \tcode{n} is the maximum number of characters stored.
 
 \pnum


### PR DESCRIPTION
Also fixes LWG2499.

Fixes #2412.