### PR TITLE
Add an index entry for "extern template"

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -6137,6 +6137,7 @@ expression.
 
 \pnum
 \indextext{instantiation!explicit}%
+\indextext{\idxcode{extern template}|see{instantiation, explicit}}%
 A class, function, variable, or member template specialization can be explicitly
 instantiated from its template.
 A member function, member class or static data member of a class template can


### PR DESCRIPTION
If you forget (or never knew) what this construct is called, then the existing index entries don't help you locate it.