### PR TITLE
P0771R1 std::function move constructor should be noexcept

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -14678,7 +14678,7 @@ namespace std {
     function() noexcept;
     function(nullptr_t) noexcept;
     function(const function&);
-    function(function&&);
+    function(function&&) noexcept;
     template<class F> function(F);
 
     function& operator=(const function&);
@@ -14800,7 +14800,7 @@ to an object and a member function pointer. \end{note}
 
 \indexlibrary{\idxcode{function}!constructor}%
 \begin{itemdecl}
-function(function&& f);
+function(function&& f) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -14811,11 +14811,6 @@ the target of \tcode{f} before the construction, and
 \tcode{f} is in a valid state with an unspecified value.
 
 \pnum
-\throws Shall not throw exceptions if \tcode{f}'s target is
-a specialization of \tcode{reference_wrapper} or
-a function pointer. Otherwise, may throw \tcode{bad_alloc} or
-any exception thrown by the copy or move constructor
-of the stored callable object.
 \begin{note} Implementations should avoid the use of
 dynamically allocated memory for small callable objects, for example,
 where \tcode{f}'s target is an object holding only a pointer or reference


### PR DESCRIPTION
Fixes #2422.