### PR TITLE
P1020R1 Smart pointer creation with default initialization

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -6676,12 +6676,19 @@ namespace std {
   template<class T, class D = default_delete<T>> class unique_ptr;
   template<class T, class D> class unique_ptr<T[], D>;
 
-  template<class T, class... Args> unique_ptr<T>
-    make_unique(Args&&... args);                                                // \tcode{T} is not array
-  template<class T> unique_ptr<T>
-    make_unique(size_t n);                                                      // \tcode{T} is \tcode{U[]}
+  template<class T, class... Args>
+    unique_ptr<T> make_unique(Args&&... args);                                  // \tcode{T} is not array
+  template<class T>
+    unique_ptr<T> make_unique(size_t n);                                        // \tcode{T} is \tcode{U[]}
   template<class T, class... Args>
     @\unspecnc@ make_unique(Args&&...) = delete;                                // \tcode{T} is \tcode{U[N]}
+
+  template<class T>
+    unique_ptr<T> make_unique_default_init();                                   // \tcode{T} is not array
+  template<class T>
+    unique_ptr<T> make_unique_default_init(size_t n);                           // \tcode{T} is \tcode{U[]}
+  template<class T, class... Args>
+    @\unspecnc@ make_unique_default_init(Args&&...) = delete;                   // \tcode{T} is \tcode{U[N]}
 
   template<class T, class D>
     void swap(unique_ptr<T, D>& x, unique_ptr<T, D>& y) noexcept;
@@ -6755,10 +6762,20 @@ namespace std {
     shared_ptr<T> allocate_shared(const A& a, size_t N,
                                   const remove_extent_t<T>& u);                 // \tcode{T} is \tcode{U[]}
 
-  template<class T> shared_ptr<T>
-    make_shared(const remove_extent_t<T>& u);                                   // \tcode{T} is \tcode{U[N]}
+  template<class T>
+    shared_ptr<T> make_shared(const remove_extent_t<T>& u);                     // \tcode{T} is \tcode{U[N]}
   template<class T, class A>
     shared_ptr<T> allocate_shared(const A& a, const remove_extent_t<T>& u);     // \tcode{T} is \tcode{U[N]}
+
+  template<class T>
+    shared_ptr<T> make_shared_default_init();                                   // \tcode{T} is not \tcode{U[]}
+  template<class T, class A>
+    shared_ptr<T> allocate_shared_default_init(const A& a);                     // \tcode{T} is not \tcode{U[]}
+
+  template<class T>
+    shared_ptr<T> make_shared_default_init(size_t N);                           // \tcode{T} is \tcode{U[]}
+  template<class T, class A>
+    shared_ptr<T> allocate_shared_default_init(const A& a, size_t N);           // \tcode{T} is \tcode{U[]}
 
   // \ref{util.smartptr.shared.cmp}, \tcode{shared_ptr} comparisons
   template<class T, class U>
@@ -8906,6 +8923,47 @@ template<class T, class... Args> @\unspec@ make_unique(Args&&...) = delete;
 
 \end{itemdescr}
 
+\indexlibrary{\idxcode{make_unique}}%
+\begin{itemdecl}
+template<class T> unique_ptr<T> make_unique_default_init();
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\tcode{T} is not an array.
+
+\pnum
+\returns
+\tcode{unique_ptr<T>(new T)}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{make_unique}}%
+\begin{itemdecl}
+template<class T> unique_ptr<T> make_unique_default_init(size_t n);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\tcode{T} is an array of unknown bound.
+
+\pnum
+\returns
+\tcode{unique_ptr<T>(new remove_extent_t<T>[n])}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{make_unique}}%
+\begin{itemdecl}
+template<class T, class... Args> @\unspec@ make_unique_default_init(Args&&...) = delete;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\tcode{T} is an array of known bound.
+\end{itemdescr}
+
 \rSec3[unique.ptr.special]{Specialized algorithms}
 
 \indexlibrary{\idxcode{swap(unique_ptr\&, unique_ptr\&)}}%
@@ -9737,8 +9795,11 @@ are both empty.
 \rSec3[util.smartptr.shared.create]{Creation}
 
 \pnum
-The common requirements that apply to
-all \tcode{make_shared} and \tcode{allocate_shared} overloads,
+The common requirements that apply to all
+\tcode{make_shared},
+\tcode{allocate_shared},
+\tcode{make_shared_default_init}, and
+\tcode{allocate_shared_default_init} overloads,
 unless specified otherwise, are described below.
 
 \indexlibrary{\idxcode{make_shared}}%
@@ -9748,6 +9809,10 @@ template<class T, ...>
   shared_ptr<T> make_shared(@\placeholdernc{args}@);
 template<class T, class A, ...>
   shared_ptr<T> allocate_shared(const A& a, @\placeholdernc{args}@);
+template<class T, ...>
+  shared_ptr<T> make_shared_default_init(@\placeholdernc{args}@);
+template<class T, class A, ...>
+  shared_ptr<T> allocate_shared_default_init(const A& a, @\placeholdernc{args}@);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9760,7 +9825,8 @@ requirements (\tref{utilities.allocator.requirements}).
 (or \tcode{U[N]} when \tcode{T} is \tcode{U[]},
 where \tcode{N} is determined from \placeholder{args} as specified by the concrete overload).
 The object is initialized from \placeholder{args} as specified by the concrete overload.
-The \tcode{allocate_shared} templates use a copy of \tcode{a}
+The \tcode{allocate_shared} and \tcode{allocate_shared_default_init} templates
+use a copy of \tcode{a}
 (rebound for an unspecified \tcode{value_type}) to allocate memory.
 If an exception is thrown, the functions have no effect.
 
@@ -9836,6 +9902,13 @@ an exception thrown from \tcode{allocate} or from the initialization of the obje
   \tcode{a2} of type \tcode{A2} is a rebound copy of
   the allocator \tcode{a} passed to \tcode{allocate_shared}
   such that its \tcode{value_type} is \tcode{remove_cv_t<U>}.
+\item
+  When a (sub)object of non-array type \tcode{U} is initialized by
+  \tcode{make_shared_default_init} or\linebreak % avoid Overfull
+  \tcode{allocate_shared_default_init},
+  it is initialized via the expression \tcode{::new(pv) U},
+  where \tcode{pv} has type \tcode{void*} and
+  points to storage suitable to hold an object of type \tcode{U}.
 \item
   Array elements are initialized in ascending order of their addresses.
 \item
@@ -10017,6 +10090,65 @@ shared_ptr<double[6][2]> q = make_shared<double[6][2]>({1.0, 0.0});
   // \tcode{shared_ptr} to a \tcode{double[6][2]}, where each double[2] element is \tcode{\{1.0, 0.0\}}
 shared_ptr<vector<int>[4]> r = make_shared<vector<int>[4]>({1, 2});
   // \tcode{shared_ptr} to a \tcode{vector<int>[4]}, where each vector has contents \tcode{\{1, 2\}}
+\end{codeblock}
+\end{example}
+\end{itemdescr}
+
+\indexlibrary{\idxcode{make_shared}}%
+\indexlibrary{\idxcode{allocate_shared}}%
+\begin{itemdecl}
+template<class T>
+  shared_ptr<T> make_shared_default_init();
+template<class T, class A>
+  shared_ptr<T> allocate_shared_default_init(const A& a);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\tcode{T} is not an array of unknown bound.
+
+\pnum
+\returns
+A \tcode{shared_ptr} to an object of type \tcode{T}.
+
+\pnum
+\begin{example}
+\begin{codeblock}
+struct X { double data[1024]; };
+shared_ptr<X> p = make_shared_default_init<X>();
+  // \tcode{shared_ptr} to a default-initialized \tcode{X}, where each element in \tcode{X::data} has an indeterminate value
+
+shared_ptr<double[1024]> q = make_shared_default_init<double[1024]>();
+  // \tcode{shared_ptr} to a default-initialized \tcode{double[1024]}, where each element has an indeterminate value
+\end{codeblock}
+\end{example}
+\end{itemdescr}
+
+\indexlibrary{\idxcode{make_shared}}%
+\indexlibrary{\idxcode{allocate_shared}}%
+\begin{itemdecl}
+template<class T>
+  shared_ptr<T> make_shared_default_init(size_t N);
+template<class T, class A>
+  shared_ptr<T> allocate_shared_default_init(const A& a, size_t N);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\tcode{T} is an array of unknown bound.
+
+\pnum
+\returns
+A \tcode{shared_ptr} to an object of type \tcode{U[N]},
+where \tcode{U} is \tcode{remove_extent_t<T>}.
+
+\pnum
+\begin{example}
+\begin{codeblock}
+shared_ptr<double[]> p = make_shared_default_init<double[]>(1024);
+  // \tcode{shared_ptr} to a default-initialized \tcode{double[1024]}, where each element has an indeterminate value
 \end{codeblock}
 \end{example}
 \end{itemdescr}


### PR DESCRIPTION
[memory.syn] Move return types to before function names for consistency.

Fixes #2424.