### PR TITLE
P1248R1 Remove CommonReference requirement from StrictWeakOrdering (a…

### DIFF
--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -1080,34 +1080,8 @@ template<class F, class... Args>
 template<class R, class T, class U>
   concept Relation =
     Predicate<R, T, T> && Predicate<R, U, U> &&
-    CommonReference<const remove_reference_t<T>&, const remove_reference_t<U>&> &&
-    Predicate<R,
-      common_reference_t<const remove_reference_t<T>&, const remove_reference_t<U>&>,
-      common_reference_t<const remove_reference_t<T>&, const remove_reference_t<U>&>> &&
     Predicate<R, T, U> && Predicate<R, U, T>;
 \end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-Let
-\begin{itemize}
-\item \tcode{r} be an expression such that \tcode{decltype((r))} is \tcode{R},
-\item \tcode{t} be an expression such that \tcode{decltype((t))} is \tcode{T},
-\item \tcode{u} be an expression such that \tcode{decltype((u))} is \tcode{U},
-  and
-\item \tcode{C} be
-  \begin{codeblock}
-  common_reference_t<const remove_reference_t<T>&,
-                     const remove_reference_t<U>&>
-  \end{codeblock}
-\end{itemize}
-\tcode{\libconcept{Relation}<R, T, U>} is satisfied only if
-
-\begin{itemize}
-\item \tcode{bool(r(t, u)) == bool(r(C(t), C(u))).}
-\item \tcode{bool(r(u, t)) == bool(r(C(u), C(t))).}
-\end{itemize}
-\end{itemdescr}
 
 \rSec2[concept.strictweakorder]{Concept \libconcept{StrictWeakOrder}}
 


### PR DESCRIPTION
….k.a Fixing Relations)

Fixes #2426.

Comments on the paper:
It seems odd that we now have an itemdecl with no itemdescr.