### PR TITLE
P0318R1 unwrap_ref_decay and unwrap_reference

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -852,14 +852,16 @@ This function shall not participate in overload resolution unless
 \indexlibrary{\idxcode{make_pair}}%
 \begin{itemdecl}
 template<class T1, class T2>
-  constexpr pair<V1, V2> make_pair(T1&& x, T2&& y);
+  constexpr pair<unwrap_ref_decay_t<T1>, unwrap_ref_decay_t<T2>> make_pair(T1&& x, T2&& y);
 \end{itemdecl}
 
 \begin{itemdescr}
-Let \tcode{Vi} be \tcode{unwrap_ref_decay_t<Ti>}.
-
 \pnum
-\returns \tcode{pair<V1, V2>(std::forward<T1>(x), std::forward<T2>(y))}.
+\returns
+\begin{codeblock}
+pair<unwrap_ref_decay_t<T1>,
+     unwrap_ref_decay_t<T2>>(std::forward<T1>(x), std::forward<T2>(y))
+\end{codeblock}
 \end{itemdescr}
 
 \pnum
@@ -997,7 +999,7 @@ namespace std {
   inline constexpr @\unspec@ ignore;
 
   template<class... TTypes>
-    constexpr tuple<VTypes...> make_tuple(TTypes&&...);
+    constexpr tuple<unwrap_ref_decay_t<TTypes>...> make_tuple(TTypes&&...);
 
   template<class... TTypes>
     constexpr tuple<TTypes&&...> forward_as_tuple(TTypes&&...) noexcept;
@@ -1608,15 +1610,12 @@ order, where indexing is zero-based.
 \indexlibrary{\idxcode{tuple}!\idxcode{make_tuple}}%
 \begin{itemdecl}
 template<class... TTypes>
-  constexpr tuple<VTypes...> make_tuple(TTypes&&... t);
+  constexpr tuple<unwrap_ref_decay_t<TTypes>...> make_tuple(TTypes&&... t);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-Let \tcode{VTypes...} be \tcode{unwrap_ref_decay_t<TTypes>...}.
-
-\pnum
-\returns \tcode{tuple<VTypes...>(std::forward<TTypes>(t)...)}.
+\returns \tcode{tuple<unwrap_ref_decay_t<TTypes>...>(std::forward<TTypes>(t)...)}.
 
 \pnum
 \begin{example}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -856,12 +856,10 @@ template<class T1, class T2>
 \end{itemdecl}
 
 \begin{itemdescr}
+Let \tcode{Vi} be \tcode{unwrap_ref_decay_t<Ti>}.
+
 \pnum
-\returns \tcode{pair<V1, V2>(std::forward<T1>(x), std::forward<T2>(y))},
-where \tcode{V1} and \tcode{V2} are determined as follows: Let \tcode{Ui} be
-\tcode{decay_t<Ti>} for each \tcode{Ti}. If \tcode{Ui} is a specialization
-of \tcode{reference_wrapper}, then \tcode{Vi} is \tcode{Ui::type\&},
-otherwise \tcode{Vi} is \tcode{Ui}.
+\returns \tcode{pair<V1, V2>(std::forward<T1>(x), std::forward<T2>(y))}.
 \end{itemdescr}
 
 \pnum
@@ -1615,10 +1613,7 @@ template<class... TTypes>
 
 \begin{itemdescr}
 \pnum
-The pack \tcode{VTypes} is defined as follows. Let \tcode{U}$_i$ be \tcode{decay_t<T$_i$>} for each
-\tcode{T}$_i$ in \tcode{TTypes}. If \tcode{U}$_i$ is a specialization of
-\tcode{reference_wrapper}, then \tcode{V}$_i$ in \tcode{VTypes} is \tcode{U$_i$::type\&},
-otherwise \tcode{V}$_i$ is \tcode{U}$_i$.
+Let \tcode{VTypes...} be \tcode{unwrap_ref_decay_t<TTypes>...}.
 
 \pnum
 \returns \tcode{tuple<VTypes...>(std::forward<TTypes>(t)...)}.
@@ -13033,6 +13028,8 @@ work with arbitrary function objects.
 \rSec2[functional.syn]{Header \tcode{<functional>} synopsis}
 
 \indexhdr{functional}%
+\indexlibrary{\idxcode{unwrap_ref_decay}}%
+\indexlibrary{\idxcode{unwrap_ref_decay_t}}%
 \begin{codeblock}
 namespace std {
   // \ref{func.invoke}, invoke
@@ -13050,6 +13047,10 @@ namespace std {
 
   template<class T> reference_wrapper<T> ref(reference_wrapper<T>) noexcept;
   template<class T> reference_wrapper<const T> cref(reference_wrapper<T>) noexcept;
+
+  template<class T> struct unwrap_reference;
+  template<class T> struct unwrap_ref_decay : unwrap_reference<decay_t<T>> {};
+  template<class T> using unwrap_ref_decay_t = typename unwrap_ref_decay<T>::type;
 
   // \ref{arithmetic.operations}, arithmetic operations
   template<class T = void> struct plus;
@@ -13407,7 +13408,6 @@ T& get() const noexcept;
 \pnum\returns The stored reference.
 \end{itemdescr}
 
-
 \rSec3[refwrap.invoke]{Invocation}
 
 \indexlibrarymember{operator()}{reference_wrapper}%
@@ -13459,6 +13459,20 @@ template<class T> reference_wrapper<const T> cref(reference_wrapper<T> t) noexce
 \begin{itemdescr}
 \pnum\returns \tcode{cref(t.get())}.
 \end{itemdescr}
+
+\rSec3[refwrap.unwrapref]{Transformation type trait \tcode{unwrap_reference}}
+
+\indexlibrary{\idxcode{unwrap_reference}}%
+\begin{itemdecl}
+template<class T>
+  struct unwrap_reference;
+\end{itemdecl}
+
+\pnum
+If \tcode{T} is
+a specialization \tcode{reference_wrapper<X>} for some type \tcode{X},
+the member typedef \tcode{type} of \tcode{unwrap_reference<T>} is \tcode{X\&},
+otherwise it is \tcode{T}.
 
 \rSec2[arithmetic.operations]{Arithmetic operations}
 


### PR DESCRIPTION
Add the type trait as subclause [refwrap.unwrapref],
instead of as a sibling of [refwrap].
Rephrase the wording to avoid referencing X before it
is introduced.
Do not refer to 'equals' as referring to types.

Fixes #2419.