### PR TITLE
[array.syn] Add reference to [array.tuple]

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -3011,6 +3011,7 @@ namespace std {
   template<class T, size_t N>
     void swap(array<T, N>& x, array<T, N>& y) noexcept(noexcept(x.swap(y)));
 
+  // \ref{array.tuple}, tuple interface to class template \tcode{array}
   template<class T> class tuple_size;
   template<size_t I, class T> class tuple_element;
   template<class T, size_t N>


### PR DESCRIPTION
I retain the heading removed in #1933, since fixes to #1242 don't change them in the synopses.