### PR TITLE
[cmp.categories,time.cal] Change "explicit constexpr" to "constexpr e…

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -4098,7 +4098,7 @@ namespace std {
     int value;  // \expos
 
     // exposition-only constructor
-    explicit constexpr weak_equality(eq v) noexcept : value(int(v)) {}  // \expos
+    constexpr explicit weak_equality(eq v) noexcept : value(int(v)) {}  // \expos
 
   public:
     // valid values
@@ -4175,7 +4175,7 @@ namespace std {
     int value;  // \expos
 
     // exposition-only constructor
-    explicit constexpr strong_equality(eq v) noexcept : value(int(v)) {}    // \expos
+    constexpr explicit strong_equality(eq v) noexcept : value(int(v)) {}    // \expos
 
   public:
     // valid values
@@ -4273,11 +4273,11 @@ namespace std {
     bool is_ordered;    // \expos
 
     // exposition-only constructors
-    explicit constexpr
+    constexpr explicit
       partial_ordering(eq v) noexcept : value(int(v)), is_ordered(true) {}      // \expos
-    explicit constexpr
+    constexpr explicit
       partial_ordering(ord v) noexcept : value(int(v)), is_ordered(true) {}     // \expos
-    explicit constexpr
+    constexpr explicit
       partial_ordering(ncmp v) noexcept : value(int(v)), is_ordered(false) {}   // \expos
 
   public:
@@ -4419,8 +4419,8 @@ namespace std {
     int value;  // \expos
 
     // exposition-only constructors
-    explicit constexpr weak_ordering(eq v) noexcept : value(int(v)) {}  // \expos
-    explicit constexpr weak_ordering(ord v) noexcept : value(int(v)) {} // \expos
+    constexpr explicit weak_ordering(eq v) noexcept : value(int(v)) {}  // \expos
+    constexpr explicit weak_ordering(ord v) noexcept : value(int(v)) {} // \expos
 
   public:
     // valid values
@@ -4565,8 +4565,8 @@ namespace std {
     int value;  // \expos
 
     // exposition-only constructors
-    explicit constexpr strong_ordering(eq v) noexcept : value(int(v)) {}    // \expos
-    explicit constexpr strong_ordering(ord v) noexcept : value(int(v)) {}   // \expos
+    constexpr explicit strong_ordering(eq v) noexcept : value(int(v)) {}    // \expos
+    constexpr explicit strong_ordering(ord v) noexcept : value(int(v)) {}   // \expos
 
   public:
     // valid values

--- a/source/time.tex
+++ b/source/time.tex
@@ -3974,7 +3974,7 @@ namespace std::chrono {
     unsigned char d_;           // \expos
   public:
     day() = default;
-    explicit constexpr day(unsigned d) noexcept;
+    constexpr explicit day(unsigned d) noexcept;
 
     constexpr day& operator++()    noexcept;
     constexpr day  operator++(int) noexcept;
@@ -3984,7 +3984,7 @@ namespace std::chrono {
     constexpr day& operator+=(const days& d) noexcept;
     constexpr day& operator-=(const days& d) noexcept;
 
-    explicit constexpr operator unsigned() const noexcept;
+    constexpr explicit operator unsigned() const noexcept;
     constexpr bool ok() const noexcept;
   };
 }
@@ -4008,7 +4008,7 @@ which represent a difference between two \tcode{day} objects.
 
 \indexlibrary{\idxcode{day}!constructor}%
 \begin{itemdecl}
-explicit constexpr day(unsigned d) noexcept;
+constexpr explicit day(unsigned d) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4099,7 +4099,7 @@ constexpr day& operator-=(const days& d) noexcept;
 
 \indexlibrarymember{operator unsigned}{day}%
 \begin{itemdecl}
-explicit constexpr operator unsigned() const noexcept;
+constexpr explicit operator unsigned() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4264,7 +4264,7 @@ namespace std::chrono {
     unsigned char m_;           // \expos
   public:
     month() = default;
-    explicit constexpr month(unsigned m) noexcept;
+    constexpr explicit month(unsigned m) noexcept;
 
     constexpr month& operator++()    noexcept;
     constexpr month  operator++(int) noexcept;
@@ -4274,7 +4274,7 @@ namespace std::chrono {
     constexpr month& operator+=(const months& m) noexcept;
     constexpr month& operator-=(const months& m) noexcept;
 
-    explicit constexpr operator unsigned() const noexcept;
+    constexpr explicit operator unsigned() const noexcept;
     constexpr bool ok() const noexcept;
   };
 }
@@ -4298,7 +4298,7 @@ which represent a difference between two \tcode{month} objects.
 
 \indexlibrary{\idxcode{month}!constructor}%
 \begin{itemdecl}
-explicit constexpr month(unsigned m) noexcept;
+constexpr explicit month(unsigned m) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4389,7 +4389,7 @@ constexpr month& operator-=(const months& m) noexcept;
 
 \indexlibrarymember{operator unsigned}{month}%
 \begin{itemdecl}
-explicit constexpr month::operator unsigned() const noexcept;
+constexpr explicit month::operator unsigned() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4567,7 +4567,7 @@ namespace std::chrono {
     short y_;                   // \expos
   public:
     year() = default;
-    explicit constexpr year(int y) noexcept;
+    constexpr explicit year(int y) noexcept;
 
     constexpr year& operator++()    noexcept;
     constexpr year  operator++(int) noexcept;
@@ -4582,7 +4582,7 @@ namespace std::chrono {
 
     constexpr bool is_leap() const noexcept;
 
-    explicit constexpr operator int() const noexcept;
+    constexpr explicit operator int() const noexcept;
     constexpr bool ok() const noexcept;
 
     static constexpr year min() noexcept;
@@ -4608,7 +4608,7 @@ which represent a difference between two \tcode{year} objects.
 
 \indexlibrary{\idxcode{year}!constructor}%
 \begin{itemdecl}
-explicit constexpr year(int y) noexcept;
+constexpr explicit year(int y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4729,7 +4729,7 @@ constexpr bool is_leap() const noexcept;
 
 \indexlibrarymember{operator int}{year}%
 \begin{itemdecl}
-explicit constexpr operator int() const noexcept;
+constexpr explicit operator int() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4914,9 +4914,9 @@ namespace std::chrono {
     unsigned char wd_;          // \expos
   public:
     weekday() = default;
-    explicit constexpr weekday(unsigned wd) noexcept;
+    constexpr explicit weekday(unsigned wd) noexcept;
     constexpr weekday(const sys_days& dp) noexcept;
-    explicit constexpr weekday(const local_days& dp) noexcept;
+    constexpr explicit weekday(const local_days& dp) noexcept;
 
     constexpr weekday& operator++()    noexcept;
     constexpr weekday  operator++(int) noexcept;
@@ -4926,7 +4926,7 @@ namespace std::chrono {
     constexpr weekday& operator+=(const days& d) noexcept;
     constexpr weekday& operator-=(const days& d) noexcept;
 
-    explicit constexpr operator unsigned() const noexcept;
+    constexpr explicit operator unsigned() const noexcept;
     constexpr bool ok() const noexcept;
 
     constexpr weekday_indexed operator[](unsigned index) const noexcept;
@@ -4958,7 +4958,7 @@ with no beginning and no end.
 
 \indexlibrary{\idxcode{weekday}!constructor}%
 \begin{itemdecl}
-explicit constexpr weekday(unsigned wd) noexcept;
+constexpr explicit weekday(unsigned wd) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4991,7 +4991,7 @@ by storing \tcode{4} in \tcode{wd_}.
 
 \indexlibrary{\idxcode{weekday}!constructor}%
 \begin{itemdecl}
-explicit constexpr weekday(const local_days& dp) noexcept;
+constexpr explicit weekday(const local_days& dp) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5087,7 +5087,7 @@ constexpr weekday& operator-=(const days& d) noexcept;
 
 \indexlibrarymember{operator unsigned}{weekday}%
 \begin{itemdecl}
-explicit constexpr operator unsigned() const noexcept;
+constexpr explicit operator unsigned() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5397,7 +5397,7 @@ namespace std::chrono {
     chrono::weekday wd_;                // \expos
 
     public:
-    explicit constexpr weekday_last(const chrono::weekday& wd) noexcept;
+    constexpr explicit weekday_last(const chrono::weekday& wd) noexcept;
 
     constexpr chrono::weekday weekday() const noexcept;
     constexpr bool ok() const noexcept;
@@ -5427,7 +5427,7 @@ static_assert(wdl.weekday() == Sunday);
 
 \indexlibrary{\idxcode{weekday_last}!constructor}%
 \begin{itemdecl}
-explicit constexpr weekday_last(const chrono::weekday& wd) noexcept;
+constexpr explicit weekday_last(const chrono::weekday& wd) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5655,7 +5655,7 @@ namespace std::chrono {
     chrono::month m_;                   // \expos
 
   public:
-    explicit constexpr month_day_last(const chrono::month& m) noexcept;
+    constexpr explicit month_day_last(const chrono::month& m) noexcept;
 
     constexpr chrono::month month() const noexcept;
     constexpr bool ok() const noexcept;
@@ -5684,7 +5684,7 @@ static_assert(mdl.month() == February);
 
 \indexlibrary{\idxcode{month_day_last}!constructor}%
 \begin{itemdecl}
-explicit constexpr month_day_last(const chrono::month& m) noexcept;
+constexpr explicit month_day_last(const chrono::month& m) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6272,7 +6272,7 @@ namespace std::chrono {
                              const chrono::day& d) noexcept;
     constexpr year_month_day(const year_month_day_last& ymdl) noexcept;
     constexpr year_month_day(const sys_days& dp) noexcept;
-    explicit constexpr year_month_day(const local_days& dp) noexcept;
+    constexpr explicit year_month_day(const local_days& dp) noexcept;
 
     constexpr year_month_day& operator+=(const months& m) noexcept;
     constexpr year_month_day& operator-=(const months& m) noexcept;
@@ -6284,7 +6284,7 @@ namespace std::chrono {
     constexpr chrono::day   day()   const noexcept;
 
     constexpr          operator sys_days()   const noexcept;
-    explicit constexpr operator local_days() const noexcept;
+    constexpr explicit operator local_days() const noexcept;
     constexpr bool ok() const noexcept;
   };
 }
@@ -6364,7 +6364,7 @@ is \tcode{true}.
 
 \indexlibrary{\idxcode{year_month_day}!constructor}%
 \begin{itemdecl}
-explicit constexpr year_month_day(const local_days& dp) noexcept;
+constexpr explicit year_month_day(const local_days& dp) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6496,7 +6496,7 @@ static_assert(year_month_day{sys_days{2017y/January/32}} == 2017y/February/1);
 
 \indexlibrarymember{operator local_days}{year_month_day}%
 \begin{itemdecl}
-explicit constexpr operator local_days() const noexcept;
+constexpr explicit operator local_days() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6710,7 +6710,7 @@ namespace std::chrono {
     constexpr chrono::day            day()            const noexcept;
 
     constexpr          operator sys_days()   const noexcept;
-    explicit constexpr operator local_days() const noexcept;
+    constexpr explicit operator local_days() const noexcept;
     constexpr bool ok() const noexcept;
   };
 }
@@ -6858,7 +6858,7 @@ constexpr operator sys_days() const noexcept;
 
 \indexlibrarymember{operator local_days}{year_month_day_last}%
 \begin{itemdecl}
-explicit constexpr operator local_days() const noexcept;
+constexpr explicit operator local_days() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6996,7 +6996,7 @@ namespace std::chrono {
     constexpr year_month_weekday(const chrono::year& y, const chrono::month& m,
                                  const chrono::weekday_indexed& wdi) noexcept;
     constexpr year_month_weekday(const sys_days& dp) noexcept;
-    explicit constexpr year_month_weekday(const local_days& dp) noexcept;
+    constexpr explicit year_month_weekday(const local_days& dp) noexcept;
 
     constexpr year_month_weekday& operator+=(const months& m) noexcept;
     constexpr year_month_weekday& operator-=(const months& m) noexcept;
@@ -7010,7 +7010,7 @@ namespace std::chrono {
     constexpr chrono::weekday_indexed weekday_indexed() const noexcept;
 
     constexpr          operator sys_days()   const noexcept;
-    explicit constexpr operator local_days() const noexcept;
+    constexpr explicit operator local_days() const noexcept;
     constexpr bool ok() const noexcept;
   };
 }
@@ -7066,7 +7066,7 @@ for which \tcode{ymdl.ok()} is \tcode{true},
 
 \indexlibrary{\idxcode{year_month_weekday}!constructor}%
 \begin{itemdecl}
-explicit constexpr year_month_weekday(const local_days& dp) noexcept;
+constexpr explicit year_month_weekday(const local_days& dp) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7203,7 +7203,7 @@ Otherwise the returned value is unspecified.
 
 \indexlibrarymember{operator local_days}{year_month_weekday}%
 \begin{itemdecl}
-explicit constexpr operator local_days() const noexcept;
+constexpr explicit operator local_days() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7343,7 +7343,7 @@ namespace std::chrono {
     constexpr chrono::weekday_last weekday_last() const noexcept;
 
     constexpr          operator sys_days()   const noexcept;
-    explicit constexpr operator local_days() const noexcept;
+    constexpr explicit operator local_days() const noexcept;
     constexpr bool ok() const noexcept;
   };
 }
@@ -7488,7 +7488,7 @@ Otherwise the returned value is unspecified.
 
 \indexlibrarymember{operator local_days}{year_month_weekday_last}%
 \begin{itemdecl}
-explicit constexpr operator local_days() const noexcept;
+constexpr explicit operator local_days() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8102,11 +8102,11 @@ namespace std::chrono {
     using precision = chrono::hours;
 
     time_of_day() = default;
-    explicit constexpr time_of_day(chrono::hours since_midnight) noexcept;
+    constexpr explicit time_of_day(chrono::hours since_midnight) noexcept;
 
     constexpr chrono::hours hours() const noexcept;
 
-    explicit constexpr operator  precision()   const noexcept;
+    constexpr explicit operator  precision()   const noexcept;
     constexpr          precision to_duration() const noexcept;
 
     constexpr void make24() noexcept;
@@ -8122,7 +8122,7 @@ This specialization handles hours since midnight.
 
 \indexlibrary{\idxcode{time_of_day<hours>}!constructor}%
 \begin{itemdecl}
-explicit constexpr time_of_day(chrono::hours since_midnight) noexcept;
+constexpr explicit time_of_day(chrono::hours since_midnight) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8148,7 +8148,7 @@ constexpr chrono::hours hours() const noexcept;
 
 \indexlibrarymember{operator precision}{time_of_day<hours>}%
 \begin{itemdecl}
-explicit constexpr operator precision() const noexcept;
+constexpr explicit operator precision() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8203,12 +8203,12 @@ namespace std::chrono {
     using precision = chrono::minutes;
 
     time_of_day() = default;
-    explicit constexpr time_of_day(chrono::minutes since_midnight) noexcept;
+    constexpr explicit time_of_day(chrono::minutes since_midnight) noexcept;
 
     constexpr chrono::hours    hours()   const noexcept;
     constexpr chrono::minutes  minutes() const noexcept;
 
-    explicit constexpr operator precision()    const noexcept;
+    constexpr explicit operator precision()    const noexcept;
     constexpr          precision to_duration() const noexcept;
 
     constexpr void make24() noexcept;
@@ -8224,7 +8224,7 @@ This specialization handles hours and minutes since midnight.
 
 \indexlibrary{\idxcode{time_of_day<minutes>}!constructor}%
 \begin{itemdecl}
-explicit constexpr time_of_day(minutes since_midnight) noexcept;
+constexpr explicit time_of_day(minutes since_midnight) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8264,7 +8264,7 @@ constexpr chrono::minutes minutes() const noexcept;
 
 \indexlibrarymember{operator precision}{time_of_day<minutes>}%
 \begin{itemdecl}
-explicit constexpr operator precision() const noexcept;
+constexpr explicit operator precision() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8319,13 +8319,13 @@ namespace std::chrono {
     using precision = chrono::seconds;
 
     time_of_day() = default;
-    explicit constexpr time_of_day(chrono::seconds since_midnight) noexcept;
+    constexpr explicit time_of_day(chrono::seconds since_midnight) noexcept;
 
     constexpr chrono::hours   hours()   const noexcept;
     constexpr chrono::minutes minutes() const noexcept;
     constexpr chrono::seconds seconds() const noexcept;
 
-    explicit constexpr operator  precision()   const noexcept;
+    constexpr explicit operator  precision()   const noexcept;
     constexpr          precision to_duration() const noexcept;
 
     constexpr void make24() noexcept;
@@ -8341,7 +8341,7 @@ This specialization handles hours, minutes, and seconds since midnight.
 
 \indexlibrary{\idxcode{time_of_day<seconds>}!constructor}%
 \begin{itemdecl}
-explicit constexpr time_of_day(seconds since_midnight) noexcept;
+constexpr explicit time_of_day(seconds since_midnight) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8396,7 +8396,7 @@ The stored second of \tcode{*this}.
 
 \indexlibrarymember{operator precision}{time_of_day<seconds>}%
 \begin{itemdecl}
-explicit constexpr operator precision() const noexcept;
+constexpr explicit operator precision() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8452,14 +8452,14 @@ namespace std::chrono {
     using precision = duration<Rep, Period>;
 
     time_of_day() = default;
-    explicit constexpr time_of_day(precision since_midnight) noexcept;
+    constexpr explicit time_of_day(precision since_midnight) noexcept;
 
     constexpr chrono::hours     hours()      const noexcept;
     constexpr chrono::minutes   minutes()    const noexcept;
     constexpr chrono::seconds   seconds()    const noexcept;
     constexpr precision subseconds() const noexcept;
 
-    explicit constexpr operator  precision()   const noexcept;
+    constexpr explicit operator  precision()   const noexcept;
     constexpr          precision to_duration() const noexcept;
 
     constexpr void make24() noexcept;
@@ -8480,7 +8480,7 @@ Typical uses are with \tcode{milliseconds}, \tcode{microseconds} and \tcode{nano
 
 \indexlibrary{\idxcode{time_of_day<\placeholder{sub-second duration}>}!constructor}%
 \begin{itemdecl}
-explicit constexpr time_of_day(precision since_midnight) noexcept;
+constexpr explicit time_of_day(precision since_midnight) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8548,7 +8548,7 @@ The stored subsecond of \tcode{*this}.
 
 \indexlibrarymember{operator precision}{time_of_day<\placeholder{sub-second duration}>}%
 \begin{itemdecl}
-explicit constexpr operator precision() const noexcept;
+constexpr explicit operator precision() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
…xplicit"

Per discussion in #2371.