### PR TITLE
[utility.syn,pairs.spec,tuple.syn,tuple.creation] Use unwrap_ref_deca…

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -117,7 +117,8 @@ namespace std {
     void swap(pair<T1, T2>& x, pair<T1, T2>& y) noexcept(noexcept(x.swap(y)));
 
   template<class T1, class T2>
-    constexpr @\seebelow@ make_pair(T1&&, T2&&);
+    constexpr pair<unwrap_ref_decay_t<T1>,
+                   unwrap_ref_decay_t<T2>> make_pair(T1&&, T2&&);
 
   // \ref{pair.astuple}, tuple-like access to pair
   template<class T> class tuple_size;
@@ -850,7 +851,8 @@ This function shall not participate in overload resolution unless
 \indexlibrary{\idxcode{make_pair}}%
 \begin{itemdecl}
 template<class T1, class T2>
-  constexpr pair<V1, V2> make_pair(T1&& x, T2&& y);
+  constexpr pair<unwrap_ref_decay_t<T1>,
+                 unwrap_ref_decay_t<T2>> make_pair(T1&& x, T2&& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -997,7 +999,7 @@ namespace std {
   inline constexpr @\unspec@ ignore;
 
   template<class... TTypes>
-    constexpr tuple<VTypes...> make_tuple(TTypes&&...);
+    constexpr tuple<unwrap_ref_decay_t<TTypes>...> make_tuple(TTypes&&...);
 
   template<class... TTypes>
     constexpr tuple<TTypes&&...> forward_as_tuple(TTypes&&...) noexcept;
@@ -1596,7 +1598,7 @@ order, where indexing is zero-based.
 \indexlibrary{\idxcode{tuple}!\idxcode{make_tuple}}%
 \begin{itemdecl}
 template<class... TTypes>
-  constexpr tuple<VTypes...> make_tuple(TTypes&&... t);
+  constexpr tuple<unwrap_ref_decay_t<TTypes>...> make_tuple(TTypes&&... t);
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
…y consistently

...in declarations and definitions of make_pair and make_tuple.