### PR TITLE
P1032R1 Misc constexpr bits

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -463,6 +463,10 @@ are contiguous iterators\iref{iterator.requirements.general}.
 for some types of containers but not others. Those containers for which the
 listed operations are provided shall implement the semantics described in
 \tref{containers.optional.operations} unless otherwise stated.
+If the iterators passed to \tcode{lexicographical_compare}
+satisfy the constexpr iterator requirements\iref{iterator.requirements.general}
+then the operations described in \tref{containers.optional.operations}
+are implemented by constexpr functions.
 
 \begin{libreqtab5}
 {Optional container operations}
@@ -3009,7 +3013,7 @@ namespace std {
   template<class T, size_t N>
     constexpr bool operator>=(const array<T, N>& x, const array<T, N>& y);
   template<class T, size_t N>
-    void swap(array<T, N>& x, array<T, N>& y) noexcept(noexcept(x.swap(y)));
+    constexpr void swap(array<T, N>& x, array<T, N>& y) noexcept(noexcept(x.swap(y)));
 
   template<class T> class tuple_size;
   template<size_t I, class T> class tuple_element;
@@ -3235,8 +3239,8 @@ namespace std {
 
     // no explicit construct/copy/destroy for aggregate type
 
-    void fill(const T& u);
-    void swap(array&) noexcept(is_nothrow_swappable_v<T>);
+    constexpr void fill(const T& u);
+    constexpr void swap(array&) noexcept(is_nothrow_swappable_v<T>);
 
     // iterators
     constexpr iterator               begin() noexcept;
@@ -3326,7 +3330,7 @@ non-empty array, \tcode{data()} \tcode{==} \tcode{addressof(front())}.
 
 \indexlibrarymember{array}{fill}%
 \begin{itemdecl}
-void fill(const T& u);
+constexpr void fill(const T& u);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3336,7 +3340,7 @@ void fill(const T& u);
 
 \indexlibrarymember{array}{swap}%
 \begin{itemdecl}
-void swap(array& y) noexcept(is_nothrow_swappable_v<T>);
+constexpr void swap(array& y) noexcept(is_nothrow_swappable_v<T>);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3356,7 +3360,7 @@ become associated with the other container.
 \indexlibrarymember{array}{swap}%
 \begin{itemdecl}
 template<class T, size_t N>
-  void swap(array<T, N>& x, array<T, N>& y) noexcept(noexcept(x.swap(y)));
+  constexpr void swap(array<T, N>& x, array<T, N>& y) noexcept(noexcept(x.swap(y)));
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -768,15 +768,16 @@ namespace std {
 
   template<class Container> class back_insert_iterator;
   template<class Container>
-    back_insert_iterator<Container> back_inserter(Container& x);
+    constexpr back_insert_iterator<Container> back_inserter(Container& x);
 
   template<class Container> class front_insert_iterator;
   template<class Container>
-    front_insert_iterator<Container> front_inserter(Container& x);
+    constexpr front_insert_iterator<Container> front_inserter(Container& x);
 
   template<class Container> class insert_iterator;
   template<class Container>
-    insert_iterator<Container> inserter(Container& x, typename Container::iterator i);
+    constexpr insert_iterator<Container>
+      inserter(Container& x, typename Container::iterator i);
 
   template<class Iterator> class move_iterator;
   template<class Iterator1, class Iterator2>
@@ -1704,17 +1705,17 @@ namespace std {
     using reference         = void;
     using container_type    = Container;
 
-    explicit back_insert_iterator(Container& x);
-    back_insert_iterator& operator=(const typename Container::value_type& value);
-    back_insert_iterator& operator=(typename Container::value_type&& value);
+    constexpr explicit back_insert_iterator(Container& x);
+    constexpr back_insert_iterator& operator=(const typename Container::value_type& value);
+    constexpr back_insert_iterator& operator=(typename Container::value_type&& value);
 
-    back_insert_iterator& operator*();
-    back_insert_iterator& operator++();
-    back_insert_iterator  operator++(int);
+    constexpr back_insert_iterator& operator*();
+    constexpr back_insert_iterator& operator++();
+    constexpr back_insert_iterator  operator++(int);
   };
 
   template<class Container>
-    back_insert_iterator<Container> back_inserter(Container& x);
+    constexpr back_insert_iterator<Container> back_inserter(Container& x);
 }
 \end{codeblock}
 
@@ -1722,7 +1723,7 @@ namespace std {
 
 \indexlibrary{\idxcode{back_insert_iterator}!constructor}%
 \begin{itemdecl}
-explicit back_insert_iterator(Container& x);
+constexpr explicit back_insert_iterator(Container& x);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1735,7 +1736,7 @@ with \tcode{addressof(x)}.
 
 \indexlibrarymember{operator=}{back_insert_iterator}%
 \begin{itemdecl}
-back_insert_iterator& operator=(const typename Container::value_type& value);
+constexpr back_insert_iterator& operator=(const typename Container::value_type& value);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1750,7 +1751,7 @@ As if by: \tcode{container->push_back(value);}
 
 \indexlibrarymember{operator=}{back_insert_iterator}%
 \begin{itemdecl}
-back_insert_iterator& operator=(typename Container::value_type&& value);
+constexpr back_insert_iterator& operator=(typename Container::value_type&& value);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1765,7 +1766,7 @@ As if by: \tcode{container->push_back(std::move(value));}
 
 \indexlibrarymember{operator*}{back_insert_iterator}%
 \begin{itemdecl}
-back_insert_iterator& operator*();
+constexpr back_insert_iterator& operator*();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1776,8 +1777,8 @@ back_insert_iterator& operator*();
 
 \indexlibrarymember{operator++}{back_insert_iterator}%
 \begin{itemdecl}
-back_insert_iterator& operator++();
-back_insert_iterator  operator++(int);
+constexpr back_insert_iterator& operator++();
+constexpr back_insert_iterator  operator++(int);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1791,7 +1792,7 @@ back_insert_iterator  operator++(int);
 \indexlibrary{\idxcode{back_inserter}}%
 \begin{itemdecl}
 template<class Container>
-  back_insert_iterator<Container> back_inserter(Container& x);
+  constexpr back_insert_iterator<Container> back_inserter(Container& x);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1818,17 +1819,17 @@ namespace std {
     using reference         = void;
     using container_type    = Container;
 
-    explicit front_insert_iterator(Container& x);
-    front_insert_iterator& operator=(const typename Container::value_type& value);
-    front_insert_iterator& operator=(typename Container::value_type&& value);
+    constexpr explicit front_insert_iterator(Container& x);
+    constexpr front_insert_iterator& operator=(const typename Container::value_type& value);
+    constexpr front_insert_iterator& operator=(typename Container::value_type&& value);
 
-    front_insert_iterator& operator*();
-    front_insert_iterator& operator++();
-    front_insert_iterator  operator++(int);
+    constexpr front_insert_iterator& operator*();
+    constexpr front_insert_iterator& operator++();
+    constexpr front_insert_iterator  operator++(int);
   };
 
   template<class Container>
-    front_insert_iterator<Container> front_inserter(Container& x);
+    constexpr front_insert_iterator<Container> front_inserter(Container& x);
 }
 \end{codeblock}
 
@@ -1836,7 +1837,7 @@ namespace std {
 
 \indexlibrary{\idxcode{front_insert_iterator}!constructor}%
 \begin{itemdecl}
-explicit front_insert_iterator(Container& x);
+constexpr explicit front_insert_iterator(Container& x);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1849,7 +1850,7 @@ with \tcode{addressof(x)}.
 
 \indexlibrarymember{operator=}{front_insert_iterator}%
 \begin{itemdecl}
-front_insert_iterator& operator=(const typename Container::value_type& value);
+constexpr front_insert_iterator& operator=(const typename Container::value_type& value);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1864,7 +1865,7 @@ As if by: \tcode{container->push_front(value);}
 
 \indexlibrarymember{operator=}{front_insert_iterator}%
 \begin{itemdecl}
-front_insert_iterator& operator=(typename Container::value_type&& value);
+constexpr front_insert_iterator& operator=(typename Container::value_type&& value);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1879,7 +1880,7 @@ As if by: \tcode{container->push_front(std::move(value));}
 
 \indexlibrarymember{operator*}{front_insert_iterator}%
 \begin{itemdecl}
-front_insert_iterator& operator*();
+constexpr front_insert_iterator& operator*();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1890,8 +1891,8 @@ front_insert_iterator& operator*();
 
 \indexlibrarymember{operator++}{front_insert_iterator}%
 \begin{itemdecl}
-front_insert_iterator& operator++();
-front_insert_iterator  operator++(int);
+constexpr front_insert_iterator& operator++();
+constexpr front_insert_iterator  operator++(int);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1905,7 +1906,7 @@ front_insert_iterator  operator++(int);
 \indexlibrary{\idxcode{front_inserter}}%
 \begin{itemdecl}
 template<class Container>
-  front_insert_iterator<Container> front_inserter(Container& x);
+  constexpr front_insert_iterator<Container> front_inserter(Container& x);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1933,17 +1934,18 @@ namespace std {
     using reference         = void;
     using container_type    = Container;
 
-    insert_iterator(Container& x, typename Container::iterator i);
-    insert_iterator& operator=(const typename Container::value_type& value);
-    insert_iterator& operator=(typename Container::value_type&& value);
+    constexpr insert_iterator(Container& x, typename Container::iterator i);
+    constexpr insert_iterator& operator=(const typename Container::value_type& value);
+    constexpr insert_iterator& operator=(typename Container::value_type&& value);
 
-    insert_iterator& operator*();
-    insert_iterator& operator++();
-    insert_iterator& operator++(int);
+    constexpr insert_iterator& operator*();
+    constexpr insert_iterator& operator++();
+    constexpr insert_iterator& operator++(int);
   };
 
   template<class Container>
-    insert_iterator<Container> inserter(Container& x, typename Container::iterator i);
+    constexpr insert_iterator<Container>
+      inserter(Container& x, typename Container::iterator i);
 }
 \end{codeblock}
 
@@ -1951,7 +1953,7 @@ namespace std {
 
 \indexlibrary{\idxcode{insert_iterator}!constructor}%
 \begin{itemdecl}
-insert_iterator(Container& x, typename Container::iterator i);
+constexpr insert_iterator(Container& x, typename Container::iterator i);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1966,7 +1968,7 @@ with \tcode{i}.
 
 \indexlibrarymember{operator=}{insert_iterator}%
 \begin{itemdecl}
-insert_iterator& operator=(const typename Container::value_type& value);
+constexpr insert_iterator& operator=(const typename Container::value_type& value);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1985,7 +1987,7 @@ iter = container->insert(iter, value);
 
 \indexlibrarymember{operator=}{insert_iterator}%
 \begin{itemdecl}
-insert_iterator& operator=(typename Container::value_type&& value);
+constexpr insert_iterator& operator=(typename Container::value_type&& value);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2004,7 +2006,7 @@ iter = container->insert(iter, std::move(value));
 
 \indexlibrarymember{operator*}{insert_iterator}%
 \begin{itemdecl}
-insert_iterator& operator*();
+constexpr insert_iterator& operator*();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2015,8 +2017,8 @@ insert_iterator& operator*();
 
 \indexlibrarymember{operator++}{insert_iterator}%
 \begin{itemdecl}
-insert_iterator& operator++();
-insert_iterator& operator++(int);
+constexpr insert_iterator& operator++();
+constexpr insert_iterator& operator++(int);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2030,7 +2032,8 @@ insert_iterator& operator++(int);
 \indexlibrary{\idxcode{inserter}}%
 \begin{itemdecl}
 template<class Container>
-  insert_iterator<Container> inserter(Container& x, typename Container::iterator i);
+  constexpr insert_iterator<Container>
+    inserter(Container& x, typename Container::iterator i);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -333,9 +333,9 @@ namespace std {
     static constexpr size_t length(const char_type* s);
     static constexpr const char_type* find(const char_type* s, size_t n,
                                            const char_type& a);
-    static char_type* move(char_type* s1, const char_type* s2, size_t n);
-    static char_type* copy(char_type* s1, const char_type* s2, size_t n);
-    static char_type* assign(char_type* s, size_t n, char_type a);
+    static constexpr char_type* move(char_type* s1, const char_type* s2, size_t n);
+    static constexpr char_type* copy(char_type* s1, const char_type* s2, size_t n);
+    static constexpr char_type* assign(char_type* s, size_t n, char_type a);
 
     static constexpr int_type not_eof(int_type c) noexcept;
     static constexpr char_type to_char_type(int_type c) noexcept;
@@ -457,9 +457,9 @@ namespace std {
     static constexpr size_t length(const char_type* s);
     static constexpr const char_type* find(const char_type* s, size_t n,
                                            const char_type& a);
-    static char_type* move(char_type* s1, const char_type* s2, size_t n);
-    static char_type* copy(char_type* s1, const char_type* s2, size_t n);
-    static char_type* assign(char_type* s, size_t n, char_type a);
+    static constexpr char_type* move(char_type* s1, const char_type* s2, size_t n);
+    static constexpr char_type* copy(char_type* s1, const char_type* s2, size_t n);
+    static constexpr char_type* assign(char_type* s, size_t n, char_type a);
 
     static constexpr int_type not_eof(int_type c) noexcept;
     static constexpr char_type to_char_type(int_type c) noexcept;
@@ -507,9 +507,9 @@ namespace std {
     static constexpr size_t length(const char_type* s);
     static constexpr const char_type* find(const char_type* s, size_t n,
                                            const char_type& a);
-    static char_type* move(char_type* s1, const char_type* s2, size_t n);
-    static char_type* copy(char_type* s1, const char_type* s2, size_t n);
-    static char_type* assign(char_type* s, size_t n, char_type a);
+    static constexpr char_type* move(char_type* s1, const char_type* s2, size_t n);
+    static constexpr char_type* copy(char_type* s1, const char_type* s2, size_t n);
+    static constexpr char_type* assign(char_type* s, size_t n, char_type a);
 
     static constexpr int_type not_eof(int_type c) noexcept;
     static constexpr char_type to_char_type(int_type c) noexcept;
@@ -557,9 +557,9 @@ namespace std {
     static constexpr size_t length(const char_type* s);
     static constexpr const char_type* find(const char_type* s, size_t n,
                                            const char_type& a);
-    static char_type* move(char_type* s1, const char_type* s2, size_t n);
-    static char_type* copy(char_type* s1, const char_type* s2, size_t n);
-    static char_type* assign(char_type* s, size_t n, char_type a);
+    static constexpr char_type* move(char_type* s1, const char_type* s2, size_t n);
+    static constexpr char_type* copy(char_type* s1, const char_type* s2, size_t n);
+    static constexpr char_type* assign(char_type* s, size_t n, char_type a);
 
     static constexpr int_type not_eof(int_type c) noexcept;
     static constexpr char_type to_char_type(int_type c) noexcept;
@@ -4997,7 +4997,7 @@ public:
   constexpr void swap(basic_string_view& s) noexcept;
 
   // \ref{string.view.ops}, string operations
-  size_type copy(charT* s, size_type n, size_type pos = 0) const;
+  constexpr size_type copy(charT* s, size_type n, size_type pos = 0) const;
 
   constexpr basic_string_view substr(size_type pos = 0, size_type n = npos) const;
 
@@ -5392,7 +5392,7 @@ Exchanges the values of \tcode{*this} and \tcode{s}.
 
 \indexlibrarymember{copy}{basic_string_view}%
 \begin{itemdecl}
-size_type copy(charT* s, size_type n, size_type pos = 0) const;
+constexpr size_type copy(charT* s, size_type n, size_type pos = 0) const;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/support.tex
+++ b/source/support.tex
@@ -575,6 +575,9 @@ the values of these macros with greater values.
   \tcode{<complex>} \\ \rowsep
 \defnlibxname{cpp_lib_concepts}                             & \tcode{201806L} &
   \tcode{<concepts>} \\ \rowsep
+\defnlibxname{cpp_lib_constexpr_misc}                       & \tcode{201811L} &
+  \tcode{<array>} \tcode{<functional>} \tcode{<iterator>}
+  \tcode{<string_view>} \tcode{<tuple>} \tcode{<utility>} \\ \rowsep
 \defnlibxname{cpp_lib_constexpr_swap_algorithms}            & \tcode{201806L} &
   \tcode{<algorithm>} \\ \rowsep
 \defnlibxname{cpp_lib_destroying_delete}                    & \tcode{201806L} &

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -114,7 +114,7 @@ namespace std {
     constexpr bool operator>=(const pair<T1, T2>&, const pair<T1, T2>&);
 
   template<class T1, class T2>
-    void swap(pair<T1, T2>& x, pair<T1, T2>& y) noexcept(noexcept(x.swap(y)));
+    constexpr void swap(pair<T1, T2>& x, pair<T1, T2>& y) noexcept(noexcept(x.swap(y)));
 
   template<class T1, class T2>
     constexpr @\seebelow@ make_pair(T1&&, T2&&);
@@ -479,25 +479,26 @@ namespace std {
 
     pair(const pair&) = default;
     pair(pair&&) = default;
-    explicit(@\seebelow@) constexpr pair();
-    explicit(@\seebelow@) constexpr pair(const T1& x, const T2& y);
+    constexpr explicit(@\seebelow@) pair();
+    constexpr explicit(@\seebelow@) pair(const T1& x, const T2& y);
     template<class U1, class U2>
-      explicit(@\seebelow@) constexpr pair(U1&& x, U2&& y);
+      constexpr explicit(@\seebelow@) pair(U1&& x, U2&& y);
     template<class U1, class U2>
-      explicit(@\seebelow@) constexpr pair(const pair<U1, U2>& p);
+      constexpr explicit(@\seebelow@) pair(const pair<U1, U2>& p);
     template<class U1, class U2>
-      explicit(@\seebelow@) constexpr pair(pair<U1, U2>&& p);
+      constexpr explicit(@\seebelow@) pair(pair<U1, U2>&& p);
     template<class... Args1, class... Args2>
-      pair(piecewise_construct_t, tuple<Args1...> first_args, tuple<Args2...> second_args);
+      constexpr pair(piecewise_construct_t,
+                     tuple<Args1...> first_args, tuple<Args2...> second_args);
 
-    pair& operator=(const pair& p);
+    constexpr pair& operator=(const pair& p);
     template<class U1, class U2>
-      pair& operator=(const pair<U1, U2>& p);
-    pair& operator=(pair&& p) noexcept(@\seebelow@);
+      constexpr pair& operator=(const pair<U1, U2>& p);
+    constexpr pair& operator=(pair&& p) noexcept(@\seebelow@);
     template<class U1, class U2>
-      pair& operator=(pair<U1, U2>&& p);
+      constexpr pair& operator=(pair<U1, U2>&& p);
 
-    void swap(pair& p) noexcept(@\seebelow@);
+    constexpr void swap(pair& p) noexcept(@\seebelow@);
   };
 
   template<class T1, class T2>
@@ -522,7 +523,7 @@ is \tcode{true}, then the destructor of \tcode{pair} is trivial.
 
 \indexlibrary{\idxcode{pair}!constructor}%
 \begin{itemdecl}
-explicit(@\seebelow@) constexpr pair();
+constexpr explicit(@\seebelow@) pair();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -547,7 +548,7 @@ can be initialized with \tcode{\{\}}. \end{note}
 
 \indexlibrary{\idxcode{pair}!constructor}%
 \begin{itemdecl}
-explicit(@\seebelow@) constexpr pair(const T1& x, const T2& y);
+constexpr explicit(@\seebelow@) pair(const T1& x, const T2& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -568,7 +569,7 @@ The expression inside \tcode{explicit} is equivalent to:
 
 \indexlibrary{\idxcode{pair}!constructor}%
 \begin{itemdecl}
-template<class U1, class U2> explicit(@\seebelow@) constexpr pair(U1&& x, U2&& y);
+template<class U1, class U2> constexpr explicit(@\seebelow@) pair(U1&& x, U2&& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -591,7 +592,7 @@ The expression inside \tcode{explicit} is equivalent to:
 
 \indexlibrary{\idxcode{pair}!constructor}%
 \begin{itemdecl}
-template<class U1, class U2> explicit(@\seebelow@) constexpr pair(const pair<U1, U2>& p);
+template<class U1, class U2> constexpr explicit(@\seebelow@) pair(const pair<U1, U2>& p);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -611,7 +612,7 @@ The expression inside explicit is equivalent to:
 
 \indexlibrary{\idxcode{pair}!constructor}%
 \begin{itemdecl}
-template<class U1, class U2> explicit(@\seebelow@) constexpr pair(pair<U1, U2>&& p);
+template<class U1, class U2> constexpr explicit(@\seebelow@) pair(pair<U1, U2>&& p);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -635,7 +636,8 @@ The expression inside explicit is equivalent to:
 \indexlibrary{\idxcode{pair}!constructor}%
 \begin{itemdecl}
 template<class... Args1, class... Args2>
-  pair(piecewise_construct_t, tuple<Args1...> first_args, tuple<Args2...> second_args);
+  constexpr pair(piecewise_construct_t,
+                 tuple<Args1...> first_args, tuple<Args2...> second_args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -656,7 +658,7 @@ arguments for \tcode{first} and \tcode{second} are each provided in a separate
 
 \indexlibrarymember{operator=}{pair}%
 \begin{itemdecl}
-pair& operator=(const pair& p);
+constexpr pair& operator=(const pair& p);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -674,7 +676,7 @@ and \tcode{is_copy_assignable_v<second_type>} is \tcode{true}.
 
 \indexlibrarymember{operator=}{pair}%
 \begin{itemdecl}
-template<class U1, class U2> pair& operator=(const pair<U1, U2>& p);
+template<class U1, class U2> constexpr pair& operator=(const pair<U1, U2>& p);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -692,7 +694,7 @@ and \tcode{is_assignable_v<second_type\&, const U2\&>} is \tcode{true}.
 
 \indexlibrarymember{operator=}{pair}%
 \begin{itemdecl}
-pair& operator=(pair&& p) noexcept(@\seebelow@);
+constexpr pair& operator=(pair&& p) noexcept(@\seebelow@);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -718,7 +720,7 @@ is_nothrow_move_assignable_v<T1> && is_nothrow_move_assignable_v<T2>
 
 \indexlibrarymember{operator=}{pair}%
 \begin{itemdecl}
-template<class U1, class U2> pair& operator=(pair<U1, U2>&& p);
+template<class U1, class U2> constexpr pair& operator=(pair<U1, U2>&& p);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -738,7 +740,7 @@ and \tcode{is_assignable_v<second_type\&, U2\&\&>} is \tcode{true}.
 
 \indexlibrarymember{swap}{pair}%
 \begin{itemdecl}
-void swap(pair& p) noexcept(@\seebelow@);
+constexpr void swap(pair& p) noexcept(@\seebelow@);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -833,7 +835,7 @@ template<class T1, class T2>
 \indexlibrary{\idxcode{swap}!\idxcode{pair}}%
 \begin{itemdecl}
 template<class T1, class T2>
-  void swap(pair<T1, T2>& x, pair<T1, T2>& y) noexcept(noexcept(x.swap(y)));
+  constexpr void swap(pair<T1, T2>& x, pair<T1, T2>& y) noexcept(noexcept(x.swap(y)));
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1072,7 +1074,7 @@ namespace std {
 
   // \ref{tuple.special}, specialized algorithms
   template<class... Types>
-    void swap(tuple<Types...>& x, tuple<Types...>& y) noexcept(@\seebelow@);
+    constexpr void swap(tuple<Types...>& x, tuple<Types...>& y) noexcept(@\seebelow@);
 
   // \ref{tuple.helper}, tuple helper classes
   template<class T>
@@ -1089,60 +1091,66 @@ namespace std {
   class tuple {
   public:
     // \ref{tuple.cnstr}, \tcode{tuple} construction
-    explicit(@\seebelow@) constexpr tuple();
-    explicit(@\seebelow@) constexpr tuple(const Types&...);          // only if \tcode{sizeof...(Types) >= 1}
+    constexpr explicit(@\seebelow@) tuple();
+    constexpr explicit(@\seebelow@) tuple(const Types&...);         // only if \tcode{sizeof...(Types) >= 1}
     template<class... UTypes>
-      explicit(@\seebelow@) constexpr tuple(UTypes&&...);            // only if \tcode{sizeof...(Types) >= 1}
+      constexpr explicit(@\seebelow@) tuple(UTypes&&...);           // only if \tcode{sizeof...(Types) >= 1}
 
     tuple(const tuple&) = default;
     tuple(tuple&&) = default;
 
     template<class... UTypes>
-      explicit(@\seebelow@) constexpr tuple(const tuple<UTypes...>&);
+      constexpr explicit(@\seebelow@) tuple(const tuple<UTypes...>&);
     template<class... UTypes>
-      explicit(@\seebelow@) constexpr tuple(tuple<UTypes...>&&);
+      constexpr explicit(@\seebelow@) tuple(tuple<UTypes...>&&);
 
     template<class U1, class U2>
-      explicit(@\seebelow@) constexpr tuple(const pair<U1, U2>&);    // only if \tcode{sizeof...(Types) == 2}
+      constexpr explicit(@\seebelow@) tuple(const pair<U1, U2>&);   // only if \tcode{sizeof...(Types) == 2}
     template<class U1, class U2>
-      explicit(@\seebelow@) constexpr tuple(pair<U1, U2>&&);         // only if \tcode{sizeof...(Types) == 2}
+      constexpr explicit(@\seebelow@) tuple(pair<U1, U2>&&);        // only if \tcode{sizeof...(Types) == 2}
 
     // allocator-extended constructors
     template<class Alloc>
-      tuple(allocator_arg_t, const Alloc& a);
+      constexpr tuple(allocator_arg_t, const Alloc& a);
     template<class Alloc>
-      explicit(@\seebelow@) tuple(allocator_arg_t, const Alloc& a, const Types&...);
+      constexpr explicit(@\seebelow@)
+        tuple(allocator_arg_t, const Alloc& a, const Types&...);
     template<class Alloc, class... UTypes>
-      explicit(@\seebelow@) tuple(allocator_arg_t, const Alloc& a, UTypes&&...);
+      constexpr explicit(@\seebelow@)
+        tuple(allocator_arg_t, const Alloc& a, UTypes&&...);
     template<class Alloc>
-      tuple(allocator_arg_t, const Alloc& a, const tuple&);
+      constexpr tuple(allocator_arg_t, const Alloc& a, const tuple&);
     template<class Alloc>
-      tuple(allocator_arg_t, const Alloc& a, tuple&&);
+      constexpr tuple(allocator_arg_t, const Alloc& a, tuple&&);
     template<class Alloc, class... UTypes>
-      explicit(@\seebelow@) tuple(allocator_arg_t, const Alloc& a, const tuple<UTypes...>&);
+      constexpr explicit(@\seebelow@)
+        tuple(allocator_arg_t, const Alloc& a, const tuple<UTypes...>&);
     template<class Alloc, class... UTypes>
-      explicit(@\seebelow@) tuple(allocator_arg_t, const Alloc& a, tuple<UTypes...>&&);
+      constexpr explicit(@\seebelow@)
+        tuple(allocator_arg_t, const Alloc& a, tuple<UTypes...>&&);
     template<class Alloc, class U1, class U2>
-      explicit(@\seebelow@) tuple(allocator_arg_t, const Alloc& a, const pair<U1, U2>&);
+      constexpr explicit(@\seebelow@)
+        tuple(allocator_arg_t, const Alloc& a, const pair<U1, U2>&);
     template<class Alloc, class U1, class U2>
-      explicit(@\seebelow@) tuple(allocator_arg_t, const Alloc& a, pair<U1, U2>&&);
+      constexpr explicit(@\seebelow@)
+        tuple(allocator_arg_t, const Alloc& a, pair<U1, U2>&&);
 
     // \ref{tuple.assign}, \tcode{tuple} assignment
-    tuple& operator=(const tuple&);
-    tuple& operator=(tuple&&) noexcept(@\seebelow@);
+    constexpr tuple& operator=(const tuple&);
+    constexpr tuple& operator=(tuple&&) noexcept(@\seebelow@);
 
     template<class... UTypes>
-      tuple& operator=(const tuple<UTypes...>&);
+      constexpr tuple& operator=(const tuple<UTypes...>&);
     template<class... UTypes>
-      tuple& operator=(tuple<UTypes...>&&);
+      constexpr tuple& operator=(tuple<UTypes...>&&);
 
     template<class U1, class U2>
-      tuple& operator=(const pair<U1, U2>&);            // only if \tcode{sizeof...(Types) == 2}
+      constexpr tuple& operator=(const pair<U1, U2>&);            // only if \tcode{sizeof...(Types) == 2}
     template<class U1, class U2>
-      tuple& operator=(pair<U1, U2>&&);                 // only if \tcode{sizeof...(Types) == 2}
+      constexpr tuple& operator=(pair<U1, U2>&&);                 // only if \tcode{sizeof...(Types) == 2}
 
     // \ref{tuple.swap}, \tcode{tuple} swap
-    void swap(tuple&) noexcept(@\seebelow@);
+    constexpr void swap(tuple&) noexcept(@\seebelow@);
   };
 
   template<class... UTypes>
@@ -1185,7 +1193,7 @@ then the destructor of \tcode{tuple} is trivial.
 
 \indexlibrary{\idxcode{tuple}!constructor}%
 \begin{itemdecl}
-explicit(@\seebelow@) constexpr tuple();
+constexpr explicit(@\seebelow@) tuple();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1207,7 +1215,7 @@ a \tcode{const $\tcode{T}_i$\&} can be initialized with \tcode{\{\}}. \end{note}
 
 \indexlibrary{\idxcode{tuple}!constructor}%
 \begin{itemdecl}
-explicit(@\seebelow@) constexpr tuple(const Types&...);
+constexpr explicit(@\seebelow@) tuple(const Types&...);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1227,7 +1235,7 @@ The expression inside \tcode{explicit} is equivalent to:
 
 \indexlibrary{\idxcode{tuple}!constructor}%
 \begin{itemdecl}
-template<class... UTypes> explicit(@\seebelow@) constexpr tuple(UTypes&&... u);
+template<class... UTypes> constexpr explicit(@\seebelow@) tuple(UTypes&&... u);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1276,7 +1284,7 @@ tuple(tuple&& u) = default;
 
 \indexlibrary{\idxcode{tuple}!constructor}%
 \begin{itemdecl}
-template<class... UTypes> explicit(@\seebelow@) constexpr tuple(const tuple<UTypes...>& u);
+template<class... UTypes> constexpr explicit(@\seebelow@) tuple(const tuple<UTypes...>& u);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1305,7 +1313,7 @@ The expression inside \tcode{explicit} is equivalent to:
 
 \indexlibrary{\idxcode{tuple}!constructor}%
 \begin{itemdecl}
-template<class... UTypes> explicit(@\seebelow@) constexpr tuple(tuple<UTypes...>&& u);
+template<class... UTypes> constexpr explicit(@\seebelow@) tuple(tuple<UTypes...>&& u);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1338,7 +1346,7 @@ The expression inside \tcode{explicit} is equivalent to:
 \indexlibrary{\idxcode{tuple}!constructor}%
 \indexlibrary{\idxcode{pair}}%
 \begin{itemdecl}
-template<class U1, class U2> explicit(@\seebelow@) constexpr tuple(const pair<U1, U2>& u);
+template<class U1, class U2> constexpr explicit(@\seebelow@) tuple(const pair<U1, U2>& u);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1362,7 +1370,7 @@ The expression inside \tcode{explicit} is equivalent to:
 \indexlibrary{\idxcode{tuple}!constructor}%
 \indexlibrary{\idxcode{pair}}%
 \begin{itemdecl}
-template<class U1, class U2> explicit(@\seebelow@) constexpr tuple(pair<U1, U2>&& u);
+template<class U1, class U2> constexpr explicit(@\seebelow@) tuple(pair<U1, U2>&& u);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1387,23 +1395,29 @@ The expression inside \tcode{explicit} is equivalent to:
 \indexlibrary{\idxcode{tuple}!constructor}%
 \begin{itemdecl}
 template<class Alloc>
-  tuple(allocator_arg_t, const Alloc& a);
+  constexpr tuple(allocator_arg_t, const Alloc& a);
 template<class Alloc>
-  explicit(@\seebelow@) tuple(allocator_arg_t, const Alloc& a, const Types&...);
+  constexpr explicit(@\seebelow@)
+    tuple(allocator_arg_t, const Alloc& a, const Types&...);
 template<class Alloc, class... UTypes>
-  explicit(@\seebelow@) tuple(allocator_arg_t, const Alloc& a, UTypes&&...);
+  constexpr explicit(@\seebelow@)
+    tuple(allocator_arg_t, const Alloc& a, UTypes&&...);
 template<class Alloc>
-  tuple(allocator_arg_t, const Alloc& a, const tuple&);
+  constexpr tuple(allocator_arg_t, const Alloc& a, const tuple&);
 template<class Alloc>
-  tuple(allocator_arg_t, const Alloc& a, tuple&&);
+  constexpr tuple(allocator_arg_t, const Alloc& a, tuple&&);
 template<class Alloc, class... UTypes>
-  explicit(@\seebelow@) tuple(allocator_arg_t, const Alloc& a, const tuple<UTypes...>&);
+  constexpr explicit(@\seebelow@)
+    tuple(allocator_arg_t, const Alloc& a, const tuple<UTypes...>&);
 template<class Alloc, class... UTypes>
-  explicit(@\seebelow@) tuple(allocator_arg_t, const Alloc& a, tuple<UTypes...>&&);
+  constexpr explicit(@\seebelow@)
+    tuple(allocator_arg_t, const Alloc& a, tuple<UTypes...>&&);
 template<class Alloc, class U1, class U2>
-  explicit(@\seebelow@) tuple(allocator_arg_t, const Alloc& a, const pair<U1, U2>&);
+  constexpr explicit(@\seebelow@)
+    tuple(allocator_arg_t, const Alloc& a, const pair<U1, U2>&);
 template<class Alloc, class U1, class U2>
-  explicit(@\seebelow@) tuple(allocator_arg_t, const Alloc& a, pair<U1, U2>&&);
+  constexpr explicit(@\seebelow@)
+    tuple(allocator_arg_t, const Alloc& a, pair<U1, U2>&&);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1428,7 +1442,7 @@ template parameter pack named \tcode{UTypes}, where indexing is zero-based.
 
 \indexlibrarymember{operator=}{tuple}%
 \begin{itemdecl}
-tuple& operator=(const tuple& u);
+constexpr tuple& operator=(const tuple& u);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1446,7 +1460,7 @@ element of \tcode{*this}.
 
 \indexlibrarymember{operator=}{tuple}%
 \begin{itemdecl}
-tuple& operator=(tuple&& u) noexcept(@\seebelow@);
+constexpr tuple& operator=(tuple&& u) noexcept(@\seebelow@);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1473,7 +1487,7 @@ where $\mathtt{T}_i$ is the $i^\text{th}$ type in \tcode{Types}.
 
 \indexlibrarymember{operator=}{tuple}%
 \begin{itemdecl}
-template<class... UTypes> tuple& operator=(const tuple<UTypes...>& u);
+template<class... UTypes> constexpr tuple& operator=(const tuple<UTypes...>& u);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1492,7 +1506,7 @@ of \tcode{*this}.
 
 \indexlibrarymember{operator=}{tuple}%
 \begin{itemdecl}
-template<class... UTypes> tuple& operator=(tuple<UTypes...>&& u);
+template<class... UTypes> constexpr tuple& operator=(tuple<UTypes...>&& u);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1512,7 +1526,7 @@ template<class... UTypes> tuple& operator=(tuple<UTypes...>&& u);
 \indexlibrarymember{operator=}{tuple}%
 \indexlibrary{\idxcode{pair}}%
 \begin{itemdecl}
-template<class U1, class U2> tuple& operator=(const pair<U1, U2>& u);
+template<class U1, class U2> constexpr tuple& operator=(const pair<U1, U2>& u);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1534,7 +1548,7 @@ second type $\tcode{T}_1$ in \tcode{Types}.
 \indexlibrarymember{operator=}{tuple}%
 \indexlibrary{\idxcode{pair}}%
 \begin{itemdecl}
-template<class U1, class U2> tuple& operator=(pair<U1, U2>&& u);
+template<class U1, class U2> constexpr tuple& operator=(pair<U1, U2>&& u);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1559,7 +1573,7 @@ type $\tcode{T}_1$ in \tcode{Types}.
 
 \indexlibrarymember{swap}{tuple}%
 \begin{itemdecl}
-void swap(tuple& rhs) noexcept(@\seebelow@);
+constexpr void swap(tuple& rhs) noexcept(@\seebelow@);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2085,7 +2099,7 @@ a nested \tcode{allocator_type}. \end{note}
 \indexlibrary{\idxcode{swap}}%
 \begin{itemdecl}
 template<class... Types>
-  void swap(tuple<Types...>& x, tuple<Types...>& y) noexcept(@\seebelow@);
+  constexpr void swap(tuple<Types...>& x, tuple<Types...>& y) noexcept(@\seebelow@);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -15056,11 +15070,11 @@ In general, the Boyer-Moore searcher will use more memory and give better runtim
 template<class ForwardIterator1, class BinaryPredicate = equal_to<>>
   class default_searcher {
   public:
-    default_searcher(ForwardIterator1 pat_first, ForwardIterator1 pat_last,
-                     BinaryPredicate pred = BinaryPredicate());
+    constexpr default_searcher(ForwardIterator1 pat_first, ForwardIterator1 pat_last,
+                               BinaryPredicate pred = BinaryPredicate());
 
     template<class ForwardIterator2>
-      pair<ForwardIterator2, ForwardIterator2>
+      constexpr pair<ForwardIterator2, ForwardIterator2>
         operator()(ForwardIterator2 first, ForwardIterator2 last) const;
 
   private:
@@ -15072,8 +15086,8 @@ template<class ForwardIterator1, class BinaryPredicate = equal_to<>>
 
 \indexlibrary{\idxcode{default_searcher}!constructor}%
 \begin{itemdecl}
-default_searcher(ForwardIterator pat_first, ForwardIterator pat_last,
-                 BinaryPredicate pred = BinaryPredicate());
+constexpr default_searcher(ForwardIterator pat_first, ForwardIterator pat_last,
+                           BinaryPredicate pred = BinaryPredicate());
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -15093,7 +15107,7 @@ Any exception thrown by the copy constructor of \tcode{BinaryPredicate} or
 \indexlibrarymember{operator()}{default_searcher}%
 \begin{itemdecl}
 template<class ForwardIterator2>
-  pair<ForwardIterator2, ForwardIterator2>
+  constexpr pair<ForwardIterator2, ForwardIterator2>
     operator()(ForwardIterator2 first, ForwardIterator2 last) const;
 \end{itemdecl}
 


### PR DESCRIPTION
[tuple], [pairs.pair] Fixed relative order of 'explicit' and 'constexpr'

Change 9: formatting and grammar fixes, replaced meaningless phrase
"operations are constexpr" with intended "operations are implemented
with constexpr functions" after consultation with LWG.

Change 10: green line editing instruction ignored, there do not appear
to be any other places that need changes.

Fixes #2417