### PR TITLE
[basic.stc.dynamic.allocation] Fix cross-reference for get_new_handler

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3329,7 +3329,7 @@ currently installed new-handler function\iref{new.handler}, if any.
 \indextext{\idxcode{new_handler}}%
 A program-supplied allocation function can obtain the address of the
 currently installed \tcode{new_handler} using the
-\tcode{std::get_new_handler} function\iref{set.new.handler}. \end{note}
+\tcode{std::get_new_handler} function\iref{get.new.handler}. \end{note}
 An allocation function that has a non-throwing
 exception specification\iref{except.spec}
 indicates failure by returning


### PR DESCRIPTION
Fixes #2491.