### PR TITLE
[depr.locale.category] Replace tcode environments with codeblock environments.

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -2317,20 +2317,20 @@ The \tcode{ctype} locale category includes the following facets
 as if they were specified
 in table \tref{localization.category.facets} of \ref{locale.category}.
 
-\begin{tcode}
+\begin{codeblock}
 codecvt<char16_t, char, mbstate_t>
 codecvt<char32_t, char, mbstate_t>
-\end{tcode}
+\end{codeblock}
 
 \pnum
 The \tcode{ctype} locale category includes the following facets
 as if they were specified
 in table \tref{localization.required.specializations} of \ref{locale.category}.
 
-\begin{tcode}
+\begin{codeblock}
 codecvt_byname<char16_t, char, mbstate_t>
 codecvt_byname<char32_t, char, mbstate_t>
-\end{tcode}
+\end{codeblock}
 
 \pnum
 The following class template specializations are required


### PR DESCRIPTION
tcode is not used as an environment anywhere else, so I doubt it was really intended here.