### PR TITLE
[expr] Fix cross-references for 'composite pointer type'

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5787,7 +5787,7 @@ The usual arithmetic conversions\iref{expr.arith.conv} are performed on operands
 or enumeration type. If both operands are pointers, pointer
 conversions\iref{conv.ptr} and qualification conversions\iref{conv.qual}
 are performed to bring
-them to their composite pointer type\iref{expr.prop}.
+them to their composite pointer type\iref{expr.type}.
 After conversions, the operands shall have the same type.
 
 \pnum
@@ -5867,7 +5867,7 @@ If at least one of the operands is a pointer,
 pointer conversions\iref{conv.ptr},
 function pointer conversions\iref{conv.fctptr}, and
 qualification conversions\iref{conv.qual}
-are performed on both operands to bring them to their composite pointer type\iref{expr.prop}.
+are performed on both operands to bring them to their composite pointer type\iref{expr.type}.
 Comparing pointers is defined as follows:
 
 \begin{itemize}
@@ -5890,7 +5890,7 @@ Otherwise, the pointers compare unequal.
 If at least one of the operands is a pointer to member, pointer-to-member
 conversions\iref{conv.mem} and qualification
 conversions\iref{conv.qual} are performed on both operands to bring them to
-their composite pointer type\iref{expr.prop}.
+their composite pointer type\iref{expr.type}.
 Comparing pointers to members is defined as follows:
 
 \begin{itemize}
@@ -6254,13 +6254,13 @@ pointer conversions\iref{conv.ptr},
 function pointer conversions\iref{conv.fctptr}, and
 qualification conversions\iref{conv.qual}
 are performed to bring them to their
-composite pointer type\iref{expr.prop}. The result is of the composite
+composite pointer type\iref{expr.type}. The result is of the composite
 pointer type.
 
 \item One or both of the second and third operands have pointer-to-member type;
 pointer to member conversions\iref{conv.mem} and qualification
 conversions\iref{conv.qual} are performed to bring them to their composite
-pointer type\iref{expr.prop}. The result is of the composite pointer type.
+pointer type\iref{expr.type}. The result is of the composite pointer type.
 
 \item
 Both the second and third operands have type \tcode{std::nullptr_t} or one has


### PR DESCRIPTION
to refer to [expr.type], not [expr.prop].

Fixes #2391.