### PR TITLE
[temp] Use 'deduced as' instead of 'deduced to'

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -6864,7 +6864,7 @@ obtained from default
 may be omitted from the list of explicit
 \grammarterm{template-argument}{s}.
 A trailing template parameter pack\iref{temp.variadic} not otherwise deduced will be
-deduced to an empty sequence of template arguments.
+deduced as an empty sequence of template arguments.
 If all of the template arguments can be deduced, they may all be omitted;
 in this case, the empty template argument list
 \tcode{<>}
@@ -6880,13 +6880,13 @@ is an lvalue for the function template specialization.
 template<class X, class Y> X f(Y);
 template<class X, class Y, class ... Z> X g(Y);
 void h() {
-  int i = f<int>(5.6);          // \tcode{Y} is deduced to be \tcode{double}
+  int i = f<int>(5.6);          // \tcode{Y} deduced as \tcode{double}
   int j = f(5.6);               // ill-formed: \tcode{X} cannot be deduced
-  f<void>(f<int, bool>);        // \tcode{Y} for outer \tcode{f} deduced to be \tcode{int (*)(bool)}
+  f<void>(f<int, bool>);        // \tcode{Y} for outer \tcode{f} deduced as \tcode{int (*)(bool)}
   f<void>(f<int>);              // ill-formed: \tcode{f<int>} does not denote a single function template specialization
-  int k = g<int>(5.6);          // \tcode{Y} is deduced to be double, \tcode{Z} is deduced to an empty sequence
-  f<void>(g<int, bool>);        // \tcode{Y} for outer \tcode{f} is deduced to be \tcode{int (*)(bool)},
-                                // \tcode{Z} is deduced to an empty sequence
+  int k = g<int>(5.6);          // \tcode{Y} deduced as double; \tcode{Z} deduced as an empty sequence
+  f<void>(g<int, bool>);        // \tcode{Y} for outer \tcode{f} deduced as \tcode{int (*)(bool)},
+                                // \tcode{Z} deduced as an empty sequence
 }
 \end{codeblock}
 \end{example}
@@ -6923,8 +6923,8 @@ template<class X, class Y, class Z> X f(Y,Z);
 template<class ... Args> void f2();
 void g() {
   f<int,const char*,double>("aa",3.0);
-  f<int,const char*>("aa",3.0); // \tcode{Z} is deduced to be \tcode{double}
-  f<int>("aa",3.0);             // \tcode{Y} is deduced to be \tcode{const char*}, and \tcode{Z} is deduced to be \tcode{double}
+  f<int,const char*>("aa",3.0); // \tcode{Z} deduced as \tcode{double}
+  f<int>("aa",3.0);             // \tcode{Y} deduced as \tcode{const char*}; \tcode{Z} deduced as \tcode{double}
   f("aa",3.0);                  // error: \tcode{X} cannot be deduced
   f2<char, short, int, long>(); // OK
 }
@@ -6973,7 +6973,7 @@ sequence contains explicitly specified template arguments.
 template<class ... Types> void f(Types ... values);
 
 void g() {
-  f<int*, float*>(0, 0, 0);     // \tcode{Types} is deduced to the sequence \tcode{int*}, \tcode{float*}, \tcode{int}
+  f<int*, float*>(0, 0, 0);     // \tcode{Types} deduced as the sequence \tcode{int*}, \tcode{float*}, \tcode{int}
 }
 \end{codeblock}
 \end{example}
@@ -7360,25 +7360,25 @@ parameter to be considered a non-deduced context\iref{temp.deduct.type}.
 \begin{example}
 \begin{codeblock}
 template<class T> void f(std::initializer_list<T>);
-f({1,2,3});                     // \tcode{T} deduced to \tcode{int}
-f({1,"asdf"});                  // error: \tcode{T} deduced to both \tcode{int} and \tcode{const char*}
+f({1,2,3});                     // \tcode{T} deduced as \tcode{int}
+f({1,"asdf"});                  // error: \tcode{T} deduced as both \tcode{int} and \tcode{const char*}
 
 template<class T> void g(T);
 g({1,2,3});                     // error: no argument deduced for \tcode{T}
 
 template<class T, int N> void h(T const(&)[N]);
-h({1,2,3});                     // \tcode{T} deduced to \tcode{int}, \tcode{N} deduced to \tcode{3}
+h({1,2,3});                     // \tcode{T} deduced as \tcode{int}; \tcode{N} deduced as \tcode{3}
 
 template<class T> void j(T const(&)[3]);
-j({42});                        // \tcode{T} deduced to \tcode{int}, array bound not considered
+j({42});                        // \tcode{T} deduced as \tcode{int}; array bound not considered
 
 struct Aggr { int i; int j; };
 template<int N> void k(Aggr const(&)[N]);
 k({1,2,3});                     // error: deduction fails, no conversion from \tcode{int} to \tcode{Aggr}
-k({{1},{2},{3}});               // OK, \tcode{N} deduced to \tcode{3}
+k({{1},{2},{3}});               // OK, \tcode{N} deduced as \tcode{3}
 
 template<int M, int N> void m(int const(&)[M][N]);
-m({{1,2},{3,4}});               // \tcode{M} and \tcode{N} both deduced to \tcode{2}
+m({{1,2},{3,4}});               // \tcode{M} and \tcode{N} both deduced as \tcode{2}
 
 template<class T, int N> void n(T const(&)[N], T);
 n({{1},{2},{3}},Aggr());        // OK, \tcode{T} is \tcode{Aggr}, \tcode{N} is \tcode{3}
@@ -7403,8 +7403,8 @@ template<class T1, class ... Types> void g1(Types ..., T1);
 
 void h(int x, float& y) {
   const int z = x;
-  f(x, y, z);                   // \tcode{Types} is deduced to \tcode{int}, \tcode{float}, \tcode{const int}
-  g(x, y, z);                   // \tcode{T1} is deduced to \tcode{int}; \tcode{Types} is deduced to \tcode{float}, \tcode{int}
+  f(x, y, z);                   // \tcode{Types} deduced as \tcode{int}, \tcode{float}, \tcode{const int}
+  g(x, y, z);                   // \tcode{T1} deduced as \tcode{int}; \tcode{Types} deduced as \tcode{float}, \tcode{int}
   g1(x, y, z);                  // error: \tcode{Types} is not deduced
   g1<int, int, int>(x, y, z);   // OK, no deduction occurs
 }
@@ -7792,7 +7792,7 @@ struct A {
   template <class T> operator T***();
 };
 A a;
-const int * const * const * p1 = a;     // \tcode{T} is deduced as \tcode{int}, not \tcode{const int}
+const int * const * const * p1 = a;     // \tcode{T} deduced as \tcode{int}, not \tcode{const int}
 \end{codeblock}
 \end{example}
 
@@ -8449,7 +8449,7 @@ template<typename T, T n> struct C<A<n>> {
 };
 
 using R = long;
-using R = C<A<2>>::Q;           // OK; \tcode{T} was deduced to \tcode{long} from the
+using R = C<A<2>>::Q;           // OK; \tcode{T} was deduced as \tcode{long} from the
                                 // template argument value in the type \tcode{A<2>}
 \end{codeblock}
 \end{example}
@@ -8462,7 +8462,7 @@ template<typename T, T n> struct S<int[n]> {
 };
 
 using V = decltype(sizeof 0);
-using V = S<int[42]>::Q;        // OK; \tcode{T} was deduced to \tcode{std::size_t} from the type \tcode{int[42]}
+using V = S<int[42]>::Q;        // OK; \tcode{T} was deduced as \tcode{std::size_t} from the type \tcode{int[42]}
 \end{codeblock}
 \end{example}
 
@@ -8488,11 +8488,11 @@ template<int i> void f3(int (&a)[i][20]);
 
 void g() {
   int v[10][20];
-  f1(v);                        // OK: \tcode{i} deduced to be \tcode{20}
+  f1(v);                        // OK: \tcode{i} deduced as \tcode{20}
   f1<20>(v);                    // OK
   f2(v);                        // error: cannot deduce template-argument \tcode{i}
   f2<10>(v);                    // OK
-  f3(v);                        // OK: \tcode{i} deduced to be \tcode{10}
+  f3(v);                        // OK: \tcode{i} deduced as \tcode{10}
 }
 \end{codeblock}
 \end{note}
@@ -8534,8 +8534,8 @@ A<int> a;
 B<77>  b;
 
 int    x = deduce<77>(a.xm, 62, b.ym);
-// \tcode{T} is deduced to be \tcode{int}, \tcode{a.xm} must be convertible to \tcode{A<int>::X}
-// \tcode{i} is explicitly specified to be \tcode{77}, \tcode{b.ym} must be convertible to \tcode{B<77>::Y}
+// \tcode{T} deduced as \tcode{int}; \tcode{a.xm} must be convertible to \tcode{A<int>::X}
+// \tcode{i} is explicitly specified to be \tcode{77}; \tcode{b.ym} must be convertible to \tcode{B<77>::Y}
 \end{codeblock}
 \end{note}
 


### PR DESCRIPTION
in comments explaining examples

Fixes #2390.