### PR TITLE
[depr.locale.category] Don't parenthesize reference after 'in'.

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -2334,7 +2334,7 @@ codecvt_byname<char32_t, char, mbstate_t>
 
 \pnum
 The following class template specializations are required
-in addition to those specified in \iref{locale.codecvt}.
+in addition to those specified in~\ref{locale.codecvt}.
 The specialization \tcode{codecvt<char16_t, char, mbstate_t>}
 converts between the UTF-16 and UTF-8 encoding forms, and
 the specialization \tcode{codecvt<char32_t, char, mbstate_t>}


### PR DESCRIPTION
For consistency, same as #1420.