### PR TITLE
[allocator.uses.construction] the argument name is alloc, not allocator

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -7431,7 +7431,7 @@ three conventions for passing \tcode{alloc} to a constructor:
   then uses-allocator construction chooses this constructor form.
 \item
   Otherwise, if \tcode{T} has a constructor invocable as
-  \tcode{T(args..., allocator)} (trailing-allocator convention),
+  \tcode{T(args..., alloc)} (trailing-allocator convention),
   then uses-allocator construction chooses this constructor form.
 \end{itemize}
 


### PR DESCRIPTION
there is nothing called "allocator" in this section, but there is an allocator called "alloc"