### PR TITLE
[cpp.subst] Introduce grammar non-terminal 'va-opt-replacement'

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -810,6 +810,12 @@ one more than the number of parameters in the macro definition (excluding the
 \indextext{macro!argument substitution}%
 \indextext{argument substitution|see{macro, argument substitution}}%
 
+\indextext{__VA_OPT__@\mname{VA_OPT}}%
+\begin{bnf}
+\nontermdef{va-opt-replacement}\br
+    \terminal{\mname{VA_OPT} (} \opt{pp-tokens} \terminal{)}
+\end{bnf}
+
 \pnum
 After the arguments for the invocation of a function-like macro have
 been identified, argument substitution takes place.
@@ -819,10 +825,10 @@ followed by a \tcode{\#\#} preprocessing token, the preprocessing tokens
 naming the parameter are replaced by a token sequence determined as follows:
 \begin{itemize}
 \item
-  If the parameter is of the form
-  \mname{VA_OPT}\tcode{(}\placeholder{content}\tcode{)},
+  If the parameter is of the form \grammarterm{va-opt-replacement},
   the replacement preprocessing tokens are the
-  preprocessing token sequence for the corresponding argument.
+  preprocessing token sequence for the corresponding argument,
+  as specified below.
 \item
   Otherwise, the replacement preprocessing tokens are the
   preprocessing tokens of corresponding argument after all
@@ -850,18 +856,16 @@ the preprocessing tokens used to replace it.
 \indextext{__VA_OPT__@\mname{VA_OPT}}%
 The identifier \mname{VA_OPT}
 shall always occur as part of the preprocessing token sequence
-\mname{VA_OPT}\tcode{(}\placeholder{cont\-ent}\tcode{)},
-where \placeholder{content} is
-an arbitrary sequence of \grammarterm{preprocessing-token}s
-other than \mname{VA_OPT},
-which is terminated by the closing \tcode{)}
-and skips intervening pairs of matching left and right parentheses.
-If \placeholder{content} would be ill-formed
+\grammarterm{va-opt-replacement};
+its closing \tcode{)} is determined by skipping
+intervening pairs of matching left and right parentheses
+in its \grammarterm{pp-tokens}.
+The \grammarterm{pp-tokens} of a \grammarterm{va-opt-replacement}
+shall not contain \mname{VA_OPT}.
+If the \grammarterm{pp-tokens} would be ill-formed
 as the replacement list of the current function-like macro,
 the program is ill-formed.
-The preprocessing token sequence
-\mname{VA_OPT}\tcode{(}\placeholder{content}\tcode{)}
-shall be treated as if it were a parameter,
+A \grammarterm{va-opt-replacement} is treated as if it were a parameter,
 and the preprocessing token sequence for the corresponding
 argument is defined as follows.
 If the substitution of \mname{VA_ARGS} as neither an operand
@@ -869,7 +873,7 @@ of \tcode{\#} nor \tcode{\#\#} consists of no preprocessing tokens,
 the argument consists of
 a single placemarker preprocessing token~(\ref{cpp.concat}, \ref{cpp.rescan}).
 Otherwise, the argument consists of
-the results of the expansion of \placeholder{content}
+the results of the expansion of the contained \grammarterm{pp-tokens}
 as the replacement list of the current function-like macro
 before removal of placemarker tokens, rescanning, and further replacement.
 \begin{note}


### PR DESCRIPTION
to avoid repeated quotes of the token sequence.

Fixes #2185.