### PR TITLE
[algorithms] Use math \min when computing complexities.

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -3390,7 +3390,7 @@ if no such iterator is found.
 \pnum
 \complexity
 For the overloads with no \tcode{ExecutionPolicy}, exactly
-\tcode{min((i - first) + 1, (last - first) - 1)}
+\[ \min(\tcode{(i - first) + 1}, \ \tcode{(last - first) - 1}) \]
 applications of the corresponding predicate, where \tcode{i} is
 \tcode{adjacent_find}'s
 return value.  For the overloads with an \tcode{ExecutionPolicy},
@@ -3552,12 +3552,12 @@ Let $E$ be:
 \returns
 \tcode{\{ first1 + n, first2 + n \}}, where \tcode{n} is the smallest integer
 such that $E$ holds,
-or \tcode{min(last1 - first1, last2 - first2)} if no such integer exists.
+or $\min(\tcode{last1 - first1}, \ \tcode{last2 - first2})$ if no such integer exists.
 
 \pnum
 \complexity
 At most
-\tcode{min(last1 - first1, last2 - first2)}
+$\min(\tcode{last1 - first1}, \ \tcode{last2 - first2})$
 applications of the corresponding predicate and any projections.
 \end{itemdescr}
 
@@ -3666,12 +3666,12 @@ no applications of the corresponding predicate and each projection; otherwise,
 \item
 For the overloads with no \tcode{ExecutionPolicy},
 at most
-$\min(\tcode{last1 - first1}, \tcode{last2 - first2})$
+$\min(\tcode{last1 - first1}, \ \tcode{last2 - first2})$
 applications of the corresponding predicate and any projections.
 
 \item
 For the overloads with an \tcode{ExecutionPolicy},
-\bigoh{\min(\tcode{last1 - first1}, \tcode{last2 - first2})} applications
+\bigoh{\min(\tcode{last1 - first1}, \ \tcode{last2 - first2})} applications
 of the corresponding predicate.
 \end{itemize}
 \end{itemdescr}
@@ -4399,7 +4399,7 @@ Let:
 \begin{itemize}
 \item \tcode{last2} be \tcode{first2 + (last1 - first1)} for the overloads with
   no parameter named \tcode{last2}, and
-\item $M$ be $\min(\tcode{last1 - first1}, \tcode{last2 - first2})$.
+\item $M$ be $\min(\tcode{last1 - first1}, \ \tcode{last2 - first2})$.
 \end{itemize}
 
 \pnum
@@ -4520,7 +4520,7 @@ Let:
 \item \tcode{last2} be \tcode{first2 + (last1 - first1)} for the overloads with
   parameter \tcode{first2} but no parameter \tcode{last2},
 \item $N$ be \tcode{last1 - first1} for unary transforms, or
-  $\min(\tcode{last1 - first1}, \tcode{last2 - first2})$ for binary transforms, and
+  $\min(\tcode{last1 - first1}, \ \tcode{last2 - first2})$ for binary transforms, and
 \item $E$ be
   \begin{itemize}
   \item \tcode{op(*(first1 + (i - result)))} for unary transforms defined in
@@ -5561,7 +5561,7 @@ whose return type is convertible to \tcode{Distance}.
 
 \pnum
 \effects
-Copies \tcode{min(last - first, n)} elements (the \defn{sample})
+Copies $\min(\tcode{last - first}, \ \tcode{n})$ elements (the \defn{sample})
 from \range{first}{last} (the \defn{population}) to \tcode{out}
 such that each possible sample has equal probability of appearance.
 \begin{note}
@@ -6137,7 +6137,7 @@ namespace ranges {
 
 \begin{itemdescr}
 \pnum
-Let $N$ be \tcode{min(last - first, result_last - result_first)}.
+Let $N$ be $\min(\tcode{last - first}, \ \tcode{result_last - result_first})$.
 Let \tcode{comp} be \tcode{less\{\}}, and
 \tcode{proj1} and \tcode{proj2} be \tcode{identity\{\}}
 for the overloads with no parameters by those names.


### PR DESCRIPTION
\tcode{min} is only appropriate when referring to the C++
function std::min.

Fixes #2385.