### PR TITLE
[dcl.init] Clarify standard conversions for built-in types

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4488,7 +4488,7 @@ the initial value of the object being initialized is \tcode{false}.
 \item
 Otherwise, the initial value of the object being initialized is
 the (possibly converted) value of the initializer expression.
-Standard conversions\iref{conv} will be used, if necessary,
+A standard conversion sequence\iref{conv} will be used, if necessary,
 to convert the initializer expression to the cv-unqualified version of
 the destination type;
 no user-defined conversions are considered.


### PR DESCRIPTION
Fixes #2374.