### PR TITLE
[over.ics.ref] Use 'implicit conversion sequence',

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -2266,8 +2266,8 @@ in top-level cv-qualification is subsumed by the initialization itself and
 does not constitute a conversion.
 
 \pnum
-Except for an implicit object parameter, for which see~\ref{over.match.funcs}, a
-standard conversion sequence cannot be formed if it requires
+Except for an implicit object parameter, for which see~\ref{over.match.funcs},
+an implicit conversion sequence cannot be formed if it requires
 binding an lvalue reference
 other than a reference to a non-volatile \tcode{const} type
 to an rvalue
@@ -2283,7 +2283,7 @@ reference (see~\ref{dcl.init.ref}).
 \pnum
 Other restrictions on binding a reference to a particular argument
 that are not based on the types of the reference and the argument
-do not affect the formation of a standard conversion
+do not affect the formation of an implicit conversion
 sequence, however.
 \begin{example}
 A function with an ``lvalue reference to \tcode{int}'' parameter can


### PR DESCRIPTION
not 'standard conversion sequence' where applicable.

Fixes #2388.