### PR TITLE
[dcl.init.aggr] Resolve grammar confusion around arrays of unknown bound

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4791,10 +4791,8 @@ brace-enclosed
 \grammarterm{initializer-list}
 containing
 \tcode{n}
-\grammarterm{initializer-clause}{s},
-where
-\tcode{n}
-shall be greater than zero, is defined as having
+\grammarterm{initializer-clause}{s}
+is defined as having
 \tcode{n}
 elements\iref{dcl.array}.
 \begin{example}
@@ -4808,11 +4806,9 @@ declares and initializes
 as a one-dimensional array that has three elements
 since no size was specified and there are three initializers.
 \end{example}
-An empty initializer list
-\tcode{\{\}}
-shall not be used as the \grammarterm{initializer-clause}
-for an array of unknown bound.\footnote{The syntax provides for empty
-initializer lists,
+An array of unknown bound shall not be initialized with
+an empty \grammarterm{braced-init-list} \tcode{\{\}}.%
+\footnote{The syntax provides for empty \grammarterm{braced-init-list}{s},
 but nonetheless \Cpp{} does not have zero length arrays.}
 \begin{note}
 A default member initializer does not determine the bound for a member


### PR DESCRIPTION
Fixes #2386.