### PR TITLE
[structure.specifications] Clarify that 'Mandates' conditions may or …

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -319,6 +319,10 @@ via a \grammarterm{constraint-expression}\iref{temp.constr.decl}.
 \item
 \mandates
 the conditions that, if not met, render the program ill-formed.
+\begin{note}
+This definition does not specify whether the conditions are
+checked before or after the function is selected by overload resolution.
+\end{note}
 \begin{example}
 An implementation can express such a condition
 via the \grammarterm{constant-expression}


### PR DESCRIPTION
…may not be SFINAE-able

Fixes #2382.