### PR TITLE
[class.bit] Bit-fields of sufficient width can store any value of an …

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -2938,10 +2938,10 @@ the original value and the value of the bit-field compare equal.
 If the value \tcode{true} or \tcode{false} is stored into a bit-field of
 type \tcode{bool} of any size (including a one bit bit-field), the
 original \tcode{bool} value and the value of the bit-field compare
-equal. If the value of an enumerator is stored into a bit-field of the
-same enumeration type and the width is large
+equal. If a value of an enumeration type is stored into a bit-field of the
+same type and the width is large
 enough to hold all the values of that enumeration type\iref{dcl.enum},
-the original enumerator value and the value of the bit-field compare equal.
+the original value and the value of the bit-field compare equal.
 \begin{example}
 
 \begin{codeblock}


### PR DESCRIPTION
…enumeration,

not just values of enumerators.

Fixes #2380.