### PR TITLE
[dcl.struct.bind,numarray] Use '\dotsc' for comma-separated lists

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -6165,7 +6165,7 @@ sometype::sometype() = delete;  // ill-formed; not first declaration
 
 \pnum
 A structured binding declaration introduces the \grammarterm{identifier}{s}
-\tcode{v}$_0$, \tcode{v}$_1$, \tcode{v}$_2$, ...
+$\tcode{v}_0$, $\tcode{v}_1$, $\tcode{v}_2, \dotsc$
 of the
 \grammarterm{identifier-list} as names\iref{basic.scope.declarative}
 of \defn{structured binding}{s}.
@@ -6263,7 +6263,7 @@ in the context of the structured binding,
 the number of elements in the \grammarterm{identifier-list} shall be
 equal to the number of non-static data members of \tcode{E}.
 Designating the non-static data members of \tcode{E} as
-\tcode{m}$_0$, \tcode{m}$_1$, \tcode{m}$_2$, ...
+$\tcode{m}_0$, $\tcode{m}_1$, $\tcode{m}_2, \dotsc$
 (in declaration order),
 each \tcode{v}$_i$ is the
 name of an lvalue that refers to the member \tcode{m}$_i$ of \tcode{e} and

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -7835,7 +7835,7 @@ parameter.
 \pnum
 \begin{example}
 \tcode{slice(3, 8, 2)}
-constructs a slice which selects elements 3, 5, 7, ... 17 from an array.
+constructs a slice which selects elements $3, 5, 7, \dotsc, 17$ from an array.
 \end{example}
 \end{itemdescr}
 
@@ -7913,7 +7913,7 @@ to a slice of the elements in
 For the slice shown, the elements
 selected from
 \tcode{a}
-are 1, 4, ..., 13.
+are $1, 4, \dotsc, 13$.
 \end{example}
 
 \rSec3[slice.arr.assign]{Assignment}


### PR DESCRIPTION
Fixes #2529.