### PR TITLE
[utilities] Harmonize 'For T in Types' phrasing.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1913,7 +1913,7 @@ indexing is zero-based.
 
 \pnum
 \begin{note}[Note A]
-If a \tcode{T} in \tcode{Types} is some reference type \tcode{X\&},
+If a type \tcode{T} in \tcode{Types} is some reference type \tcode{X\&},
 the return type is \tcode{X\&}, not \tcode{X\&\&}.
 However, if the element type is a non-reference type \tcode{T},
 the return type is \tcode{T\&\&}.
@@ -1921,9 +1921,9 @@ the return type is \tcode{T\&\&}.
 
 \pnum
 \begin{note}[Note B]
-Constness is shallow. If a \tcode{T}
-in \tcode{Types} is some
-reference type \tcode{X\&}, the return type is \tcode{X\&}, not \tcode{const X\&}.
+Constness is shallow.
+If a type \tcode{T} in \tcode{Types} is some reference type \tcode{X\&},
+the return type is \tcode{X\&}, not \tcode{const X\&}.
 However, if the element type is a non-reference type \tcode{T},
 the return type is \tcode{const T\&}.
 This is consistent with how constness is defined to work
@@ -1945,12 +1945,12 @@ template<class T, class... Types>
 
 \begin{itemdescr}
 \pnum
-\requires The type \tcode{T} occurs exactly once in \tcode{Types...}.
+\requires The type \tcode{T} occurs exactly once in \tcode{Types}.
 Otherwise, the program is ill-formed.
 
 \pnum
 \returns A reference to the element of \tcode{t} corresponding to the type
-\tcode{T} in \tcode{Types...}.
+\tcode{T} in \tcode{Types}.
 
 \pnum
 \begin{example}
@@ -2101,8 +2101,8 @@ template<class... Types>
 \begin{itemdescr}
 \pnum
 \remarks This function shall not participate in overload resolution
-unless \tcode{is_swappable_v<$\tcode{T}_i$>} is \tcode{true}
-for all $i$, where $0 \leq i < \tcode{sizeof...(Types)}$.
+unless \tcode{is_swappable_v<T>} is \tcode{true}
+for every type \tcode{T} in \tcode{Types}.
 The expression inside \tcode{noexcept} is equivalent to:
 
 \begin{codeblock}
@@ -3878,10 +3878,10 @@ object's \defnx{contained value}{contained value!\idxcode{variant}}, is allocate
 Implementations are not permitted to use additional storage, such as dynamic
 memory, to allocate the contained value.
 The contained value shall be allocated in a region of the \tcode{variant}
-storage suitably aligned for all types in \tcode{Types...}.
+storage suitably aligned for all types in \tcode{Types}.
 
 \pnum
-All types in \tcode{Types...} shall be (possibly cv-qualified)
+All types in \tcode{Types} shall be (possibly cv-qualified)
 object types that are not arrays.
 
 \pnum
@@ -3892,7 +3892,7 @@ no template arguments is ill-formed.
 
 \pnum
 In the descriptions that follow, let $i$ be in the range \range{0}{sizeof...(Types)},
-and $\tcode{T}_i$ be the $i^\text{th}$ type in \tcode{Types...}.
+and $\tcode{T}_i$ be the $i^\text{th}$ type in \tcode{Types}.
 
 \indexlibrary{\idxcode{variant}!constructor}%
 \begin{itemdecl}
@@ -4070,7 +4070,7 @@ Any exception thrown by calling the selected constructor of \tcode{T}.
 \pnum
 \remarks
 This function shall not participate in overload resolution unless there is
-exactly one occurrence of \tcode{T} in \tcode{Types...} and
+exactly one occurrence of \tcode{T} in \tcode{Types} and
 \tcode{is_constructible_v<T, Args...>} is \tcode{true}.
 If \tcode{T}'s selected constructor is a constexpr constructor, this
 constructor shall be a constexpr constructor.
@@ -4100,7 +4100,7 @@ Any exception thrown by calling the selected constructor of \tcode{T}.
 \pnum
 \remarks
 This function shall not participate in overload resolution unless there is
-exactly one occurrence of \tcode{T} in \tcode{Types...} and
+exactly one occurrence of \tcode{T} in \tcode{Types} and
 \tcode{is_constructible_v<T, initializer_list<U>\&, Args...>} is \tcode{true}.
 If \tcode{T}'s selected constructor is a constexpr constructor, this
 constructor shall be a constexpr constructor.
@@ -4375,7 +4375,7 @@ template<class T, class... Args> T& emplace(Args&&... args);
 
 \begin{itemdescr}
 \pnum
-Let $I$ be the zero-based index of \tcode{T} in \tcode{Types...}.
+Let $I$ be the zero-based index of \tcode{T} in \tcode{Types}.
 
 \pnum
 \effects
@@ -4385,7 +4385,7 @@ Equivalent to: \tcode{return emplace<$I$>(std::forward<Args>(args)...);}
 \remarks
 This function shall not participate in overload resolution unless
 \tcode{is_constructible_v<T, Args...>} is \tcode{true}, and \tcode{T} occurs
-exactly once in \tcode{Types...}.
+exactly once in \tcode{Types}.
 \end{itemdescr}
 
 \indexlibrarymember{emplace}{variant}%
@@ -4395,7 +4395,7 @@ template<class T, class U, class... Args> T& emplace(initializer_list<U> il, Arg
 
 \begin{itemdescr}
 \pnum
-Let $I$ be the zero-based index of \tcode{T} in \tcode{Types...}.
+Let $I$ be the zero-based index of \tcode{T} in \tcode{Types}.
 
 \pnum
 \effects
@@ -4405,7 +4405,7 @@ Equivalent to: \tcode{return emplace<$I$>(il, std::forward<Args>(args)...);}
 \remarks
 This function shall not participate in overload resolution unless
 \tcode{is_constructible_v<T, initializer_list<U>\&, Args...>} is \tcode{true},
-and \tcode{T} occurs exactly once in \tcode{Types...}.
+and \tcode{T} occurs exactly once in \tcode{Types}.
 \end{itemdescr}
 
 \indexlibrarymember{emplace}{variant}%
@@ -4652,12 +4652,12 @@ template<class T, class... Types>
 \begin{itemdescr}
 \pnum
 \requires
-The type \tcode{T} occurs exactly once in \tcode{Types...}.
+The type \tcode{T} occurs exactly once in \tcode{Types}.
 Otherwise, the program is ill-formed.
 
 \pnum
 \returns
-\tcode{true} if \tcode{index()} is equal to the zero-based index of \tcode{T} in \tcode{Types...}.
+\tcode{true} if \tcode{index()} is equal to the zero-based index of \tcode{T} in \tcode{Types}.
 \end{itemdescr}
 
 \indexlibrarymember{get}{variant}%
@@ -4695,7 +4695,7 @@ template<class T, class... Types> constexpr const T&& get(const variant<Types...
 \begin{itemdescr}
 \pnum
 \requires
-The type \tcode{T} occurs exactly once in \tcode{Types...}.
+The type \tcode{T} occurs exactly once in \tcode{Types}.
 Otherwise, the program is ill-formed.
 
 \pnum
@@ -4741,13 +4741,13 @@ template<class T, class... Types>
 \begin{itemdescr}
 \pnum
 \requires
-The type \tcode{T} occurs exactly once in \tcode{Types...}.
+The type \tcode{T} occurs exactly once in \tcode{Types}.
 Otherwise, the program is ill-formed.
 
 \pnum
 \effects
 Equivalent to: \tcode{return get_if<$i$>(v);} with $i$ being the zero-based
-index of \tcode{T} in \tcode{Types...}.
+index of \tcode{T} in \tcode{Types}.
 \end{itemdescr}
 
 \rSec2[variant.relops]{Relational operators}


### PR DESCRIPTION
No '...' for a pack expansion should appear after 'Types',
and no index on 'T'.

Fixes #974.