### PR TITLE
[input.output] Avoid colons in stable labels

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1278,7 +1278,7 @@ binary representation of the required template specializations of
 
 \rSec2[diff.cpp03.input.output]{\ref{input.output}: input/output library}
 
-\diffrefs{istream::sentry}{ostream::sentry}, \ref{iostate.flags}
+\diffrefs{istream.sentry}{ostream.sentry}, \ref{iostate.flags}
 \change Specify use of \tcode{explicit} in existing boolean conversion functions.
 \rationale Clarify intentions, avoid workarounds.
 \effect
@@ -1294,7 +1294,7 @@ following conditions:
 \item initializing a \tcode{const bool\&} which would bind to a temporary object.
 \end{itemize}
 
-\diffref{ios::failure}
+\diffref{ios.failure}
 \change Change base class of \tcode{std::ios_base::failure}.
 \rationale More detailed error messages.
 \effect

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -748,7 +748,7 @@ namespace std {
   public:
     class failure; // see below
 
-    // \ref{ios::fmtflags}, \tcode{fmtflags}
+    // \ref{ios.fmtflags}, \tcode{fmtflags}
     using fmtflags = @\textit{T1}@;
     static constexpr fmtflags boolalpha = @\unspec@;
     static constexpr fmtflags dec = @\unspec@;
@@ -769,14 +769,14 @@ namespace std {
     static constexpr fmtflags basefield = @\seebelow@;
     static constexpr fmtflags floatfield = @\seebelow@;
 
-    // \ref{ios::iostate}, \tcode{iostate}
+    // \ref{ios.iostate}, \tcode{iostate}
     using iostate = @\textit{T2}@;
     static constexpr iostate badbit = @\unspec@;
     static constexpr iostate eofbit = @\unspec@;
     static constexpr iostate failbit = @\unspec@;
     static constexpr iostate goodbit = @\seebelow@;
 
-    // \ref{ios::openmode}, \tcode{openmode}
+    // \ref{ios.openmode}, \tcode{openmode}
     using openmode = @\textit{T3}@;
     static constexpr openmode app = @\unspec@;
     static constexpr openmode ate = @\unspec@;
@@ -785,7 +785,7 @@ namespace std {
     static constexpr openmode out = @\unspec@;
     static constexpr openmode trunc = @\unspec@;
 
-    // \ref{ios::seekdir}, \tcode{seekdir}
+    // \ref{ios.seekdir}, \tcode{seekdir}
     using seekdir = @\textit{T4}@;
     static constexpr seekdir beg = @\unspec@;
     static constexpr seekdir cur = @\unspec@;
@@ -889,7 +889,7 @@ arbitrary-length pointer array maintained for the private use of the program.
 
 \rSec3[ios.types]{Types}
 
-\rSec4[ios::failure]{Class \tcode{ios_base::failure}}
+\rSec4[ios.failure]{Class \tcode{ios_base::failure}}
 
 \indexlibrary{\idxcode{ios_base::failure}}%
 \indexlibrary{\idxcode{ios_base}!\idxcode{failure}}%
@@ -952,7 +952,7 @@ Constructs an object of class
 \tcode{failure} by constructing the base class with \tcode{msg} and \tcode{ec}.
 \end{itemdescr}
 
-\rSec4[ios::fmtflags]{Type \tcode{ios_base::fmtflags}}
+\rSec4[ios.fmtflags]{Type \tcode{ios_base::fmtflags}}
 
 \indexlibrarymember{fmtflags}{ios_base}%
 \begin{itemdecl}
@@ -1015,7 +1015,7 @@ also defines the constants indicated in \tref{iostreams.fmtflags.constants}.
 \end{floattable}
 \end{itemdescr}
 
-\rSec4[ios::iostate]{Type \tcode{ios_base::iostate}}
+\rSec4[ios.iostate]{Type \tcode{ios_base::iostate}}
 
 \indexlibrarymember{iostate}{ios_base}%
 \begin{itemdecl}
@@ -1051,7 +1051,7 @@ the value zero.
 \end{itemize}
 \end{itemdescr}
 
-\rSec4[ios::openmode]{Type \tcode{ios_base::openmode}}
+\rSec4[ios.openmode]{Type \tcode{ios_base::openmode}}
 
 \indexlibrarymember{openmode}{ios_base}%
 \begin{itemdecl}
@@ -1081,7 +1081,7 @@ It contains the elements indicated in \tref{iostreams.openmode.effects}.
 \end{libefftab}
 \end{itemdescr}
 
-\rSec4[ios::seekdir]{Type \tcode{ios_base::seekdir}}
+\rSec4[ios.seekdir]{Type \tcode{ios_base::seekdir}}
 
 \indexlibrarymember{seekdir}{ios_base}%
 \begin{itemdecl}
@@ -1105,7 +1105,7 @@ that contains the elements indicated in \tref{iostreams.seekdir.effects}.
 \end{libefftabmean}
 \end{itemdescr}
 
-\rSec4[ios::Init]{Class \tcode{ios_base::Init}}
+\rSec4[ios.init]{Class \tcode{ios_base::Init}}
 
 \indexlibrary{\idxcode{ios_base::Init}}%
 \indexlibrary{\idxcode{ios_base}!\idxcode{Init}}%
@@ -2256,7 +2256,7 @@ otherwise
 If \tcode{((state | (rdbuf() ? goodbit : badbit)) \& exceptions()) == 0},
 returns.
 Otherwise, the function throws an object of class
-\tcode{basic_ios::failure}\iref{ios::failure},
+\tcode{basic_ios::failure}\iref{ios.failure},
 constructed with
 \impldef{argument values to construct \tcode{basic_ios::failure}}
 argument values.%
@@ -2273,7 +2273,7 @@ void setstate(iostate state);
 Calls
 \tcode{clear(rdstate() | state)}
 (which may throw
-\tcode{basic_ios::failure}\iref{ios::failure}).
+\tcode{basic_ios::failure}\iref{ios.failure}).
 \end{itemdescr}
 
 \indexlibrarymember{good}{basic_ios}%
@@ -4206,7 +4206,7 @@ namespace std {
     explicit basic_istream(basic_streambuf<charT, traits>* sb);
     virtual ~basic_istream();
 
-    // \ref{istream::sentry}, prefix/suffix
+    // \ref{istream.sentry}, prefix/suffix
     class sentry;
 
     // \ref{istream.formatted}, formatted input
@@ -4417,7 +4417,7 @@ Exchanges the values returned by \tcode{gcount()} and
 \tcode{rhs.gcount()}.
 \end{itemdescr}
 
-\rSec4[istream::sentry]{Class \tcode{basic_istream::sentry}}
+\rSec4[istream.sentry]{Class \tcode{basic_istream::sentry}}
 
 \indexlibrary{\idxcode{basic_istream::sentry}}%
 \indexlibrary{\idxcode{sentry}!\idxcode{basic_istream}}%
@@ -5587,7 +5587,7 @@ does not affect the value returned by subsequent calls to \tcode{is.gcount()}. A
 constructing a sentry object extracts characters as long as the next available
 character \tcode{c} is whitespace or until there are no more characters in the sequence.
 Whitespace characters are distinguished with the same criterion as used by
-\tcode{sentry::sentry}\iref{istream::sentry}.
+\tcode{sentry::sentry}\iref{istream.sentry}.
 If
 \tcode{ws}
 stops extracting characters because there are no more available it sets
@@ -5767,7 +5767,7 @@ namespace std {
     explicit basic_ostream(basic_streambuf<char_type, traits>* sb);
     virtual ~basic_ostream();
 
-    // \ref{ostream::sentry}, prefix/suffix
+    // \ref{ostream.sentry}, prefix/suffix
     class sentry;
 
     // \ref{ostream.formatted}, formatted output
@@ -5963,7 +5963,7 @@ void swap(basic_ostream& rhs);
 \effects Calls \tcode{basic_ios<charT, traits>::swap(rhs)}.
 \end{itemdescr}
 
-\rSec4[ostream::sentry]{Class \tcode{basic_ostream::sentry}}
+\rSec4[ostream.sentry]{Class \tcode{basic_ostream::sentry}}
 
 \indexlibrary{\idxcode{basic_ostream::sentry}}%
 \indexlibrary{\idxcode{sentry}!\idxcode{basic_ostream}}%
@@ -7271,7 +7271,7 @@ and \tcode{traits}, respectively, then the expression
 \tcode{in >> quoted(s, delim, escape)} behaves as if it extracts the following
 characters from \tcode{in} using
 \tcode{operator>>(basic_istream<charT, traits>\&, charT\&)}\iref{istream.extractors}
-which may throw \tcode{ios_base::failure}\iref{ios::failure}:
+which may throw \tcode{ios_base::failure}\iref{ios.failure}:
 \begin{itemize}
 \item If the first character extracted is equal to \tcode{delim}, as
 determined by \tcode{traits_type::eq}, then:

--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -185,6 +185,15 @@
 \movedxref{string.op<=}{string.cmp}
 \movedxref{string.op>=}{string.cmp}
 
+\movedxref{istream::sentry}{istream.sentry}
+\movedxref{ostream::sentry}{ostream.sentry}
+\movedxref{ios::failure}{ios.failure}
+\movedxref{ios::fmtflatgs}{ios.fmtflags}
+\movedxref{ios::iostate}{ios.iostate}
+\movedxref{ios::openmode}{ios.openmode}
+\movedxref{ios::seekdir}{ios.seekdir}
+\movedxref{ios::Init}{ios.init}
+
 % Deprecated features.
 %\deprxref{old.label}  (if moved to depr.old.label, otherwise use \movedxref)
 


### PR DESCRIPTION
Partially addresses #1498.