### PR TITLE
Use \logop consistently.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5143,8 +5143,8 @@ the value of \placeholder{A} is used as an operand of \placeholder{B}, unless:
 \placeholder{B} is an invocation of any specialization of
 \tcode{std::kill_dependency}\iref{atomics.order}, or
 \item
-\placeholder{A} is the left operand of a built-in logical AND (\tcode{\&\&},
-see~\ref{expr.log.and}) or logical OR (\tcode{||}, see~\ref{expr.log.or})
+\placeholder{A} is the left operand of a built-in logical \logop{AND} (\tcode{\&\&},
+see~\ref{expr.log.and}) or logical \logop{OR} (\tcode{||}, see~\ref{expr.log.or})
 operator, or
 \item
 \placeholder{A} is the left operand of a conditional (\tcode{?:}, see~\ref{expr.cond})

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -13182,10 +13182,10 @@ passed to \tcode{permissions}.
   \tcode{permissions} shall replace the file's permission bits with \tcode{perm} \\ \rowsep
 \tcode{add} &
   \tcode{permissions} shall replace the file's permission bits with
-  the bitwise OR of \tcode{perm} and the file's current permission bits. \\ \rowsep
+  the bitwise \logop{OR} of \tcode{perm} and the file's current permission bits. \\ \rowsep
 \tcode{remove} &
   \tcode{permissions} shall replace the file's permission bits with
-  the bitwise AND of the complement of \tcode{perm} and the file's current permission bits. \\ \rowsep
+  the bitwise \logop{AND} of the complement of \tcode{perm} and the file's current permission bits. \\ \rowsep
 \tcode{nofollow} &
   \tcode{permissions} shall change the permissions of a symbolic link itself
   rather than the permissions of the file the link resolves to. \\

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1462,7 +1462,7 @@ evaluate lazily as the resulting view is iterated.
 Range adaptors are declared in namespace \tcode{std::ranges::view}.
 
 \pnum
-The bitwise or operator is overloaded for the purpose of creating adaptor chain
+The bitwise \logop{OR} operator is overloaded for the purpose of creating adaptor chain
 pipelines. The adaptors also support function call syntax with equivalent
 semantics.
 

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -206,7 +206,7 @@ and \tcode{loc} is an object of type \tcode{X::locale_type}.
   &  Converts the character sequence designated by the iterator range
    \range{F1}{F2} into a value of a bitmask type that can
     subsequently be passed to \tcode{isctype}. Values returned from
-    \tcode{lookup_classname} can be bitwise or'ed together; the
+    \tcode{lookup_classname} can be bitwise \logop{OR}'ed together; the
     resulting value represents membership in either of the
     corresponding character classes.
   If \tcode{b} is \tcode{true}, the returned bitmask is suitable for
@@ -4091,7 +4091,7 @@ that name is an empty string.
 \indexlibrary{regular expression traits!\idxcode{lookup_classname}}%
 \indexlibrary{\idxcode{lookup_classname}!regular expression traits}%
 The results from multiple calls
-to \tcode{traits_inst.lookup_classname} can be bitwise OR'ed
+to \tcode{traits_inst.lookup_classname} can be bitwise \logop{OR}'ed
 together and subsequently passed to \tcode{traits_inst.isctype}.
 
 \pnum

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1585,8 +1585,8 @@ template parameters of the constrained entity,
 called the \defn{parameter mapping}\iref{temp.constr.decl}.
 \begin{note}
 Atomic constraints are formed by constraint normalization\iref{temp.constr.normal}.
-\tcode{E} is never a logical AND expression\iref{expr.log.and}
-nor a logical OR expression\iref{expr.log.or}.
+\tcode{E} is never a logical \logop{AND} expression\iref{expr.log.and}
+nor a logical \logop{OR} expression\iref{expr.log.or}.
 \end{note}
 
 \pnum
@@ -1664,7 +1664,7 @@ the associated constraints are the normal form\iref{temp.constr.normal}
 of that expression.
 
 \item Otherwise, the associated constraints are the normal form of a logical
-AND expression\iref{expr.log.and} whose operands are in the
+\logop{AND} expression\iref{expr.log.and} whose operands are in the
 following order:
 
 \begin{itemize}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -3968,7 +3968,7 @@ Any exception thrown by move-constructing any $\tcode{T}_i$ for all $i$.
 
 \pnum
 \remarks
-The expression inside \tcode{noexcept} is equivalent to the logical AND of
+The expression inside \tcode{noexcept} is equivalent to the logical \logop{AND} of
 \tcode{is_nothrow_move_constructible_v<$\tcode{T}_i$>} for all $i$.
 This function shall not participate in overload resolution unless
 \tcode{is_move_constructible_v<$\tcode{T}_i$>} is \tcode{true} for all $i$.
@@ -4565,7 +4565,7 @@ $\tcode{T}_i$ with $i$ being \tcode{index()}.
 If an exception is thrown during the exchange of the values of \tcode{*this}
 and \tcode{rhs}, the states of the values of \tcode{*this} and of \tcode{rhs}
 are determined by the exception safety guarantee of \tcode{variant}'s move constructor.
-The expression inside \tcode{noexcept} is equivalent to the logical AND of
+The expression inside \tcode{noexcept} is equivalent to the logical \logop{AND} of
 \tcode{is_nothrow_move_constructible_v<$\tcode{T}_i$> \&\& is_nothrow_swappable_v<$\tcode{T}_i$>} for all $i$.
 \end{itemdescr}
 


### PR DESCRIPTION
For consistency and readability.