### PR TITLE
[algorithms] Compactify and reformat source with no visual change

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -25,18 +25,19 @@ as summarized in \tref{algorithms.summary}.
 
 \rSec1[algorithms.requirements]{Algorithms requirements}
 \pnum
-All of the algorithms are separated from the particular implementations of data structures and are
-parameterized by iterator types.
-Because of this, they can work with program-defined data structures, as long
-as these data structures have iterator types satisfying the assumptions on the algorithms.
+All of the algorithms
+are separated from the particular implementations of data structures and
+are parameterized by iterator types.
+Because of this, they can work with program-defined data structures,
+as long as these data structures have iterator types
+satisfying the assumptions on the algorithms.
 
 \pnum
-The entities defined in the \tcode{std::ranges} namespace
-in this Clause are not found by argument-dependent
-name lookup\iref{basic.lookup.argdep}. When found by
-unqualified\iref{basic.lookup.unqual} name lookup for the
-\grammarterm{postfix-expression} in a function call\iref{expr.call}, they
-inhibit argument-dependent name lookup.
+The entities defined in the \tcode{std::ranges} namespace in this Clause
+are not found by argument-dependent name lookup\iref{basic.lookup.argdep}.
+When found by unqualified\iref{basic.lookup.unqual} name lookup
+for the \grammarterm{postfix-expression} in a function call\iref{expr.call},
+they inhibit argument-dependent name lookup.
 
 \begin{example}
 \begin{codeblock}
@@ -47,151 +48,129 @@ void foo() {
 }
 \end{codeblock}
 The function call expression at \tcode{\#1} invokes \tcode{std::ranges::find},
-not \tcode{std::find}, despite that (a) the iterator type returned from \tcode{begin(vec)}
-and \tcode{end(vec)} may be associated with namespace \tcode{std} and (b)
-\tcode{std::find} is more specialized~(\ref{temp.func.order}) than
-\tcode{std::ranges::find} since the former requires its first two parameters to
-have the same type.
+not \tcode{std::find}, despite that
+(a) the iterator type returned from \tcode{begin(vec)} and \tcode{end(vec)}
+may be associated with namespace \tcode{std} and
+(b) \tcode{std::find} is more specialized\iref{temp.func.order} than
+\tcode{std::ranges::find} since the former requires
+its first two parameters to have the same type.
 \end{example}
 
 \pnum
-For purposes of determining the existence of data races, algorithms shall
-not modify objects referenced through an iterator argument unless the
-specification requires such modification.
+For purposes of determining the existence of data races,
+algorithms shall not modify objects referenced through an iterator argument
+unless the specification requires such modification.
 
 \pnum
 Throughout this Clause, where the template parameters are not constrained,
-the names of template parameters
-are used to express type requirements.
+the names of template parameters are used to express type requirements.
 \begin{itemize}
 \item
-If an algorithm's template parameter is named
-\tcode{InputIterator},
-\tcode{InputIterator1},
-or
-\tcode{Input\-Iterator2},
-the template argument shall satisfy the
-\oldconcept{InputIterator} requirements\iref{input.iterators}.
+  If an algorithm's template parameter is named
+  \tcode{InputIterator},
+  \tcode{InputIterator1}, or
+  \tcode{Input\-Iterator2},
+  the template argument shall satisfy the
+  \oldconcept{InputIterator} requirements\iref{input.iterators}.
 \item
-If an algorithm's template parameter is named
-\tcode{OutputIterator},
-\tcode{OutputIterator1},
-or
-\tcode{Output\-Iterator2},
-the template argument shall satisfy the
-\oldconcept{OutputIterator} requirements\iref{output.iterators}.
+  If an algorithm's template parameter is named
+  \tcode{OutputIterator},
+  \tcode{OutputIterator1}, or
+  \tcode{Output\-Iterator2},
+  the template argument shall satisfy the
+  \oldconcept{OutputIterator} requirements\iref{output.iterators}.
 \item
-If an algorithm's template parameter is named
-\tcode{ForwardIterator},
-\tcode{ForwardIterator1},
-or
-\tcode{Forward\-Iterator2},
-the template argument shall satisfy the
-\oldconcept{ForwardIterator} requirements\iref{forward.iterators}.
+  If an algorithm's template parameter is named
+  \tcode{ForwardIterator},
+  \tcode{ForwardIterator1}, or
+  \tcode{Forward\-Iterator2},
+  the template argument shall satisfy the
+  \oldconcept{ForwardIterator} requirements\iref{forward.iterators}.
 \item
-If an algorithm's template parameter is named
-\tcode{BidirectionalIterator},
-\tcode{Bidirectional\-Iterator1},
-or
-\tcode{BidirectionalIterator2},
-the template argument shall satisfy the
-\oldconcept{BidirectionalIterator} requirements\iref{bidirectional.iterators}.
+  If an algorithm's template parameter is named
+  \tcode{BidirectionalIterator},
+  \tcode{Bidirectional\-Iterator1}, or
+  \tcode{BidirectionalIterator2},
+  the template argument shall satisfy the
+  \oldconcept{BidirectionalIterator} requirements\iref{bidirectional.iterators}.
 \item
-If an algorithm's template parameter is named
-\tcode{RandomAccessIterator},
-\tcode{Random\-AccessIterator1},
-or
-\tcode{RandomAccessIterator2},
-the template argument shall satisfy the
-\oldconcept{RandomAccessIterator} requirements\iref{random.access.iterators}.
+  If an algorithm's template parameter is named
+  \tcode{RandomAccessIterator},
+  \tcode{Random\-AccessIterator1}, or
+  \tcode{RandomAccessIterator2},
+  the template argument shall satisfy the
+  \oldconcept{RandomAccessIterator} requirements\iref{random.access.iterators}.
 \end{itemize}
 
 \pnum
-If an algorithm's
-\effects
-element specifies that a value pointed to by any iterator passed
-as an argument is modified, then that algorithm has an additional
-type requirement:
-The type of that argument shall satisfy the requirements
-of a mutable iterator\iref{iterator.requirements}.
+If an algorithm's \effects element specifies
+that a value pointed to by any iterator passed as an argument is modified,
+then that algorithm has an additional type requirement:
+The type of that argument shall satisfy
+the requirements of a mutable iterator\iref{iterator.requirements}.
 \begin{note}
 This requirement does not affect arguments that are named
-\tcode{OutputIterator},
-\tcode{OutputIterator1},
-or
-\tcode{OutputIterator2},
-because output iterators must always be mutable, nor does it affect
-arguments that are constrained, for which mutability requirements are expressed
-explicitly.
+\tcode{OutputIterator}, \tcode{OutputIterator1}, or \tcode{OutputIterator2},
+because output iterators must always be mutable, nor
+does it affect arguments that are constrained,
+for which mutability requirements are expressed explicitly.
 \end{note}
 
 \pnum
-Both in-place and copying versions are provided for certain
-algorithms.\footnote{The decision whether to include a copying version was
-usually based on complexity considerations. When the cost of doing the operation
-dominates the cost of copy, the copying version is not included. For example,
-\tcode{sort_copy} is not included because the cost of sorting is much more
-significant, and users might as well do \tcode{copy} followed by \tcode{sort}.}
+Both in-place and copying versions are provided for certain algorithms.%
+\footnote{The decision whether to include a copying version was
+usually based on complexity considerations.
+When the cost of doing the operation dominates the cost of copy,
+the copying version is not included.
+For example, \tcode{sort_copy} is not included
+because the cost of sorting is much more significant,
+and users might as well do \tcode{copy} followed by \tcode{sort}.}
 When such a version is provided for \textit{algorithm} it is called
-\textit{algorithm\tcode{_copy}}. Algorithms that take predicates end with the
-suffix \tcode{_if} (which follows the suffix \tcode{_copy}).
+\textit{algorithm\tcode{_copy}}.
+Algorithms that take predicates end with the suffix \tcode{_if}
+(which follows the suffix \tcode{_copy}).
 
 \pnum
-When not otherwise constrained, the
-\tcode{Predicate}
-parameter is used whenever an algorithm expects a function object\iref{function.objects}
-that, when applied to the result
-of dereferencing the corresponding iterator, returns a value testable as
-\tcode{true}.
-In other words, if an algorithm
-takes
-\tcode{Predicate pred}
-as its argument and \tcode{first}
-as its iterator argument with value type \tcode{T},
+When not otherwise constrained, the \tcode{Predicate} parameter is used
+whenever an algorithm expects a function object\iref{function.objects} that,
+when applied to the result of dereferencing the corresponding iterator,
+returns a value testable as \tcode{true}.
+In other words,
+if an algorithm takes \tcode{Predicate pred} as its argument and
+\tcode{first} as its iterator argument with value type \tcode{T},
 it should work correctly in the construct
 \tcode{pred(*first)} contextually converted to \tcode{bool}\iref{conv}.
-The function object
-\tcode{pred}
-shall not apply any non-constant
-function through the dereferenced iterator.
-Given a glvalue \tcode{u} of type (possibly \tcode{const}) \tcode{T} that
-designates the same object as \tcode{*first},
+The function object \tcode{pred} shall not apply any non-constant function
+through the dereferenced iterator.
+Given a glvalue \tcode{u} of type (possibly \tcode{const}) \tcode{T}
+that designates the same object as \tcode{*first},
 \tcode{pred(u)} shall be a valid expression
 that is equal to \tcode{pred(*first)}.
 
 \pnum
-When not otherwise constrained, the
-\tcode{BinaryPredicate}
-parameter is used whenever an algorithm expects a function object that when applied to
-the result of dereferencing two corresponding iterators or to dereferencing an
-iterator and type
-\tcode{T}
-when
-\tcode{T}
-is part of the signature returns a value testable as
-\tcode{true}.
-In other words, if an algorithm takes
-\tcode{BinaryPredicate binary_pred}
-as its argument and \tcode{first1} and \tcode{first2} as
-its iterator arguments with respective value types \tcode{T1} and \tcode{T2},
+When not otherwise constrained, the \tcode{BinaryPredicate} parameter is used
+whenever an algorithm expects a function object that when applied
+to the result of dereferencing two corresponding iterators or
+to dereferencing an iterator and type \tcode{T}
+when \tcode{T} is part of the signature
+returns a value testable as \tcode{true}.
+In other words,
+if an algorithm takes \tcode{BinaryPredicate binary_pred} as its argument and
+\tcode{first1} and \tcode{first2} as its iterator arguments
+with respective value types \tcode{T1} and \tcode{T2},
 it should work correctly in the construct
 \tcode{binary_pred(*first1, *first2)} contextually converted to \tcode{bool}\iref{conv}.
 Unless otherwise specified,
-\tcode{BinaryPredicate}
-always takes the first
-iterator's \tcode{value_type}
-as its first argument, that is, in those cases when
-\tcode{T value}
-is part of the signature, it should work
-correctly in the
-construct \tcode{binary_pred(*first1, value)} contextually converted to \tcode{bool}\iref{conv}.
-\tcode{binary_pred} shall not
-apply any non-constant function through the dereferenced iterators.
-Given a glvalue \tcode{u} of type (possibly \tcode{const}) \tcode{T1} that
-designates the same object as \tcode{*first1}, and
-a glvalue \tcode{v} of type (possibly \tcode{const}) \tcode{T2} that
-designates the same object as
-\tcode{*first2},
+\tcode{BinaryPredicate} always takes the first iterator's \tcode{value_type}
+as its first argument, that is, in those cases when \tcode{T value}
+is part of the signature, it should work correctly in the construct
+\tcode{binary_pred(*first1, value)} contextually converted to \tcode{bool}\iref{conv}.
+\tcode{binary_pred} shall not apply any non-constant function
+through the dereferenced iterators.
+Given a glvalue \tcode{u} of type (possibly \tcode{const}) \tcode{T1}
+that designates the same object as \tcode{*first1}, and
+a glvalue \tcode{v} of type (possibly \tcode{const}) \tcode{T2}
+that designates the same object as \tcode{*first2},
 \tcode{binary_pred(u, *first2)},
 \tcode{binary_pred(*first1, v)}, and
 \tcode{binary_pred(u, v)}
@@ -213,33 +192,32 @@ whenever an algorithm expects a function object\iref{function.objects}.
 \pnum
 \begin{note}
 Unless otherwise specified, algorithms that take function objects as arguments
-are permitted to copy those function objects freely. Programmers for whom object
-identity is important should consider using a wrapper class that points to a
-noncopied implementation object such as \tcode{reference_wrapper<T>}\iref{refwrap}, or some equivalent solution.
+are permitted to copy those function objects freely.
+Programmers for whom object identity is important should consider
+using a wrapper class that points to a noncopied implementation object
+such as \tcode{reference_wrapper<T>}\iref{refwrap}, or some equivalent solution.
 \end{note}
 
 \pnum
 When the description of an algorithm gives an expression such as
-\tcode{*first == value}
-for a condition, the expression shall evaluate to
-either \tcode{true} or \tcode{false} in boolean contexts.
+\tcode{*first == value} for a condition, the expression
+shall evaluate to either \tcode{true} or \tcode{false} in boolean contexts.
 
 \pnum
 In the description of the algorithms, operator \tcode{+}
-is used for some of the iterator categories for which
-it does not have to be defined.
-In these cases the semantics of
-\tcode{a + n}
-are the same as those of
+is used for some of the iterator categories
+for which it does not have to be defined.
+In these cases the semantics of \tcode{a + n} are the same as those of
 \begin{codeblock}
 auto tmp = a;
 for (; n < 0; ++n) --tmp;
 for (; n > 0; --n) ++tmp;
 return tmp;
 \end{codeblock}
-Similarly, operator \tcode{-} is used for some
-combinations of iterators and sentinel types for which
-it does not have to be defined. If \range{a}{b} denotes a range,
+Similarly, operator \tcode{-} is used
+for some combinations of iterators and sentinel types
+for which it does not have to be defined.
+If \range{a}{b} denotes a range,
 the semantics of \tcode{b - a} in these cases are the same as those of
 \begin{codeblock}
 iter_difference_t<remove_reference_t<decltype(a)>> n = 0;
@@ -254,103 +232,108 @@ return n;
 \end{codeblock}
 
 \pnum
-In the description of algorithm return values, a sentinel value \tcode{s}
-denoting the end of a range \range{i}{s} is sometimes
-returned where an iterator is expected. In these cases, the semantics are as
-if the sentinel is converted into an iterator using
+In the description of algorithm return values,
+a sentinel value \tcode{s} denoting the end of a range \range{i}{s}
+is sometimes returned where an iterator is expected.
+In these cases,
+the semantics are as if the sentinel is converted into an iterator using
 \tcode{ranges::next(i, s)}.
 
 \pnum
 Overloads of algorithms that take \libconcept{Range} arguments\iref{range.range}
 behave as if they are implemented by calling \tcode{ranges::begin} and
-\tcode{ranges::end} on the \libconcept{Range}(s) and dispatching
-to the overload in namespace \tcode{ranges} that takes
-separate iterator and sentinel arguments.
+\tcode{ranges::end} on the \libconcept{Range}(s) and
+dispatching to the overload in namespace \tcode{ranges}
+that takes separate iterator and sentinel arguments.
 
 \pnum
 The number and order of deducible template parameters for algorithm declarations
 are unspecified, except where explicitly stated otherwise.
 \begin{note}
-Consequently, the algorithms may not be called with
-explicitly-specified template argument lists.
+Consequently, the algorithms may not
+be called with explicitly-specified template argument lists.
 \end{note}
 
 \pnum
-The class templates  \tcode{binary_transform_result},
-\tcode{for_each_result}, \tcode{minmax_result}, \tcode{mismatch_result},
+The class templates
+\tcode{binary_transform_result},
+\tcode{for_each_result},
+\tcode{minmax_result},
+\tcode{mismatch_result},
 \tcode{copy_result}, and
-\tcode{partition_copy_result} have the template parameters, data members, and
-special members specified above. They have no base classes or members other than
-those specified.
+\tcode{partition_copy_result}
+have the template parameters, data members, and special members specified above.
+They have no base classes or members other than those specified.
 
 \rSec1[algorithms.parallel]{Parallel algorithms}
 
 \pnum
-This subclause describes components that \Cpp{} programs may use to perform
-operations on containers and other sequences in parallel.
+This subclause describes components that \Cpp{} programs may use
+to perform operations on containers and other sequences in parallel.
 
 \rSec2[algorithms.parallel.defns]{Terms and definitions}
 \pnum
-A \defn{parallel algorithm} is a function template listed in this document with
-a template parameter named \tcode{ExecutionPolicy}.
+A \defn{parallel algorithm} is a function template listed in this document
+with a template parameter named \tcode{ExecutionPolicy}.
 
 \pnum
-Parallel algorithms access objects indirectly accessible via their arguments by
-invoking the following functions:
-
+Parallel algorithms access objects indirectly accessible via their arguments
+by invoking the following functions:
 \begin{itemize}
 \item
-All operations of the categories of the iterators that the algorithm is
-instantiated with.
-
+  All operations of the categories of the iterators
+  that the algorithm is instantiated with.
 \item
-Operations on those sequence elements that are required by its specification.
-
+  Operations on those sequence elements that are required by its specification.
 \item
-User-provided function objects to be applied during the execution of the
-algorithm, if required by the specification.
-
+  User-provided function objects
+  to be applied during the execution of the algorithm,
+  if required by the specification.
 \item
-Operations on those function objects required by the specification.
-\begin{note} See~\ref{algorithms.requirements}.\end{note}
+  Operations on those function objects required by the specification.
+\begin{note}
+See~\ref{algorithms.requirements}.
+\end{note}
 \end{itemize}
-
 These functions are herein called \defn{element access functions}.
 \begin{example}
 The \tcode{sort} function may invoke the following element access functions:
-
 \begin{itemize}
 \item
-Operations of the random-access iterator of the actual template argument
-(as per \ref{random.access.iterators}),
-as implied by the name of the template parameter \tcode{RandomAccessIterator}.
-
+  Operations of the random-access iterator of the actual template argument
+  (as per \ref{random.access.iterators}),
+  as implied by the name of the template parameter \tcode{RandomAccessIterator}.
 \item
-The \tcode{swap} function on the elements of the sequence (as per the
-preconditions specified in \ref{sort}).
-
+  The \tcode{swap} function on the elements of the sequence
+  (as per the preconditions specified in \ref{sort}).
 \item
-The user-provided \tcode{Compare} function object.
+  The user-provided \tcode{Compare} function object.
 \end{itemize}
 \end{example}
 
 \rSec2[algorithms.parallel.user]{Requirements on user-provided function objects}
 
 \pnum
-Unless otherwise specified, function objects passed into parallel algorithms as
-objects of type \tcode{Predicate}, \tcode{BinaryPredicate}, \tcode{Compare},
-\tcode{UnaryOperation}, \tcode{BinaryOperation}, \tcode{BinaryOperation1},
-\tcode{BinaryOperation2}, and the operators used by the analogous overloads to
-these parallel algorithms that could be formed by the invocation with the
-specified default predicate or operation (where applicable) shall not directly
-or indirectly modify objects via their arguments, nor shall they rely on the
-identity of the provided objects.
+Unless otherwise specified,
+function objects passed into parallel algorithms as objects of type
+\tcode{Predicate},
+\tcode{BinaryPredicate},
+\tcode{Compare},
+\tcode{UnaryOperation},
+\tcode{BinaryOperation},
+\tcode{BinaryOperation1},
+\tcode{BinaryOperation2}, and
+the operators used by the analogous overloads to these parallel algorithms
+that could be formed by the invocation
+with the specified default predicate or operation (where applicable)
+shall not directly or indirectly modify objects via their arguments,
+nor shall they rely on the identity of the provided objects.
 
 \rSec2[algorithms.parallel.exec]{Effect of execution policies on algorithm execution}
 
 \pnum
-Parallel algorithms have template parameters
-named \tcode{ExecutionPolicy}\iref{execpol}
+Parallel algorithms have
+template parameters named \tcode{ExecutionPolicy}\iref{execpol}
 which describe the manner in which the execution of these algorithms may be
 parallelized and the manner in which they apply the element access functions.
 
@@ -361,23 +344,28 @@ The modifying element access functions are those
 which are specified as modifying the object.
 \begin{note}
 For example,
-\tcode{swap()}, \tcode{++}, \tcode{--}, \tcode{@=}, and assignments
+\tcode{swap()},
+\tcode{++},
+\tcode{--},
+\tcode{@=}, and
+assignments
 modify the object.
-For the assignment and \tcode{@=} operators,
-only the left argument is modified.
+For the assignment and \tcode{@=} operators, only the left argument is modified.
 \end{note}
 
 \pnum
 Unless otherwise stated, implementations may make arbitrary copies of elements
-(with type \tcode{T}) from sequences where \tcode{is_trivially_copy_constructible_v<T>}
+(with type \tcode{T}) from sequences
+where \tcode{is_trivially_copy_constructible_v<T>}
 and \tcode{is_trivially_destructible_v<T>} are \tcode{true}.
 \begin{note}
-This implies that user-supplied function objects should not rely on object
-identity of arguments for such input sequences. Users for whom the object
-identity of the arguments to these function objects is important should
-consider using a wrapping iterator that returns a non-copied implementation
-object such as \tcode{reference_wrapper<T>}\iref{refwrap} or some equivalent
-solution.
+This implies that user-supplied function objects should not rely on
+object identity of arguments for such input sequences.
+Users for whom the object identity of the arguments to these function objects
+is important should consider using a wrapping iterator
+that returns a non-copied implementation object
+such as \tcode{reference_wrapper<T>}\iref{refwrap}
+or some equivalent solution.
 \end{note}
 
 \pnum
@@ -390,28 +378,30 @@ The invocations are not interleaved; see~\ref{intro.execution}.
 
 \pnum
 The invocations of element access functions in parallel algorithms invoked with
-an execution policy object of type \tcode{execution::parallel_policy} are
-permitted to execute in either the invoking thread of execution or in a
-thread of execution implicitly
-created by the library to support parallel algorithm execution.
-If the threads of execution created by \tcode{thread}\iref{thread.thread.class} provide concurrent
-forward progress guarantees\iref{intro.progress}, then a thread of execution
-implicitly created by the library will provide parallel forward progress guarantees;
+an execution policy object of type \tcode{execution::parallel_policy}
+are permitted to execute
+in either the invoking thread of execution or
+in a thread of execution implicitly created by the library
+to support parallel algorithm execution.
+If the threads of execution created by \tcode{thread}\iref{thread.thread.class}
+provide concurrent forward progress guarantees\iref{intro.progress},
+then a thread of execution implicitly created by the library will provide
+parallel forward progress guarantees;
 otherwise, the provided forward progress guarantee is
-\impldef{forward progress guarantees for implicit threads of parallel algorithms (if not defined for \tcode{thread})}.
-Any such
-invocations executing in the same thread of execution are indeterminately sequenced with
-respect to each other.
+\impldef{forward progress guarantees for
+implicit threads of parallel algorithms (if not defined for \tcode{thread})}.
+Any such invocations executing in the same thread of execution
+are indeterminately sequenced with respect to each other.
 \begin{note}
-It is the caller's responsibility to ensure that the
-invocation does not introduce data races or deadlocks.
+It is the caller's responsibility to ensure
+that the invocation does not introduce data races or deadlocks.
 \end{note}
 \begin{example}
 \begin{codeblock}
 int a[] = {0,1};
 std::vector<int> v;
 std::for_each(std::execution::par, std::begin(a), std::end(a), [&](int i) {
-  v.push_back(i*2+1); // incorrect: data race
+  v.push_back(i*2+1);                                 // incorrect: data race
 });
 \end{codeblock}
 The program above has a data race because of the unsynchronized access to the
@@ -428,8 +418,8 @@ std::for_each(std::execution::par, std::begin(a), std::end(a), [&](int) {
 });
 \end{codeblock}
 The above example depends on the order of execution of the iterations, and
-will not terminate if both iterations are executed sequentially on the same
-thread of execution.
+will not terminate if both iterations are executed sequentially
+on the same thread of execution.
 \end{example}
 \begin{example}
 \begin{codeblock}
@@ -441,38 +431,44 @@ std::for_each(std::execution::par, std::begin(a), std::end(a), [&](int) {
   ++x;
 });
 \end{codeblock}
-The above example synchronizes access to object \tcode{x} ensuring that it is
-incremented correctly.
+The above example synchronizes access to object \tcode{x}
+ensuring that it is incremented correctly.
 \end{example}
 
 \pnum
 The invocations of element access functions in parallel algorithms invoked with
 an execution policy of type \tcode{execution::parallel_unsequenced_policy} are
-permitted to execute in an unordered fashion in unspecified threads of execution, and
+permitted to execute
+in an unordered fashion in unspecified threads of execution, and
 unsequenced with respect to one another within each thread of execution.
-These threads of execution are either the invoking thread of execution or threads of
-execution implicitly created by the library; the latter will provide weakly parallel
-forward progress guarantees.
+These threads of execution are
+either the invoking thread of execution
+or threads of execution implicitly created by the library;
+the latter will provide weakly parallel forward progress guarantees.
 \begin{note}
-This means that multiple function object invocations may be interleaved on a
-single thread of execution, which overrides the usual guarantee from \ref{intro.execution}
+This means that multiple function object invocations may be interleaved
+on a single thread of execution,
+which overrides the usual guarantee from \ref{intro.execution}
 that function executions do not interleave with one another.
 \end{note}
-Since \tcode{execution::parallel_unsequenced_policy} allows the execution of element
-access functions to be interleaved on a single thread of execution, blocking synchronization,
-including the use of mutexes, risks deadlock. Thus, the synchronization with
-\tcode{execution::parallel_unsequenced_policy} is restricted as
-follows:
-A standard library function is \defn{vectorization-unsafe} if it is specified
-to synchronize with another function invocation, or another function invocation
-is specified to synchronize with it, and if it is not a memory allocation or
-deallocation function. Vectorization-unsafe standard library functions may not
-be invoked by user code called from \tcode{execution::parallel_unsequenced_policy}
-algorithms.
+Since \tcode{execution::parallel_unsequenced_policy} allows
+the execution of element access functions
+to be interleaved on a single thread of execution,
+blocking synchronization, including the use of mutexes, risks deadlock.
+Thus, the synchronization with \tcode{execution::parallel_unsequenced_policy}
+is restricted as follows:
+A standard library function is \defn{vectorization-unsafe}
+if it is specified to synchronize with another function invocation, or
+another function invocation is specified to synchronize with it, and
+if it is not a memory allocation or deallocation function.
+Vectorization-unsafe standard library functions may not be invoked by user code
+called from \tcode{execution::parallel_unsequenced_policy} algorithms.
 \begin{note}
-Implementations must ensure that internal synchronization inside standard
-library functions does not prevent forward progress when those functions are
-executed by threads of execution with weakly parallel forward progress guarantees.
+Implementations must ensure
+that internal synchronization inside standard library functions
+does not prevent forward progress
+when those functions are executed
+by threads of execution with weakly parallel forward progress guarantees.
 \end{note}
 \begin{example}
 \begin{codeblock}
@@ -484,77 +480,88 @@ std::for_each(std::execution::par_unseq, std::begin(a), std::end(a), [&](int) {
   ++x;
 });
 \end{codeblock}
-The above program may result in two consecutive calls to \tcode{m.lock()} on
-the same thread of execution (which may deadlock), because the applications of the function
-object are not guaranteed to run on different threads of execution.
+The above program may result in two consecutive calls to \tcode{m.lock()}
+on the same thread of execution (which may deadlock),
+because the applications of the function object are not guaranteed
+to run on different threads of execution.
 \end{example}
 \begin{note}
-The semantics of the \tcode{execution::parallel_policy} or the
-\tcode{execution::parallel_unsequenced_policy} invocation allow the implementation to
-fall back to sequential execution if the system cannot parallelize an algorithm
-invocation due to lack of resources.
+The semantics of the \tcode{execution::parallel_policy} or
+the \tcode{execution::parallel_unsequenced_policy} invocation
+allow the implementation to fall back to sequential execution
+if the system cannot parallelize an algorithm invocation
+due to lack of resources.
 \end{note}
 
 \pnum
-If an invocation of a parallel algorithm uses threads of execution implicitly
-created by the library, then the invoking thread of execution will either
-
+If an invocation of a parallel algorithm uses threads of execution
+implicitly created by the library,
+then the invoking thread of execution will either
 \begin{itemize}
-\item temporarily block with forward progress guarantee delegation\iref{intro.progress}
-      on the completion of these library-managed threads of execution, or
-\item eventually execute an element access function;
+\item
+  temporarily block
+  with forward progress guarantee delegation\iref{intro.progress}
+  on the completion of these library-managed threads of execution, or
+\item
+  eventually execute an element access function;
 \end{itemize}
-
 the thread of execution will continue to do so until the algorithm is finished.
 \begin{note}
 In blocking with forward progress guarantee delegation in this context,
-a thread of execution created by the library is considered to have
-finished execution as soon as it has finished the execution of the
-particular element access function that the invoking thread of execution
-logically depends on.
+a thread of execution created by the library
+is considered to have finished execution
+as soon as it has finished the execution
+of the particular element access function
+that the invoking thread of execution logically depends on.
 \end{note}
 
 \pnum
 The semantics of parallel algorithms invoked with an execution policy object of
-\impldef{additional execution policies supported by parallel algorithms} type are
-\impldef{semantics of parallel algorithms invoked with
+\impldef{additional execution policies supported by parallel algorithms} type
+are \impldef{semantics of parallel algorithms invoked with
 imple\-men\-tation-defined execution policies}.
 
 \rSec2[algorithms.parallel.exceptions]{Parallel algorithm exceptions}
 
 \pnum
-During the execution of a parallel algorithm, if temporary memory resources are
-required for parallelization and none are available, the algorithm throws a
-\tcode{bad_alloc} exception.
+During the execution of a parallel algorithm,
+if temporary memory resources are required for parallelization
+and none are available, the algorithm throws a \tcode{bad_alloc} exception.
 
 \pnum
-During the execution of a parallel algorithm, if the invocation of an element
-access function exits via an uncaught exception,
+During the execution of a parallel algorithm,
+if the invocation of an element access function exits via an uncaught exception,
 the behavior is determined by the \tcode{ExecutionPolicy}.
 
 \rSec2[algorithms.parallel.overloads]{\tcode{ExecutionPolicy} algorithm overloads}
 
 \pnum
-Parallel algorithms are algorithm overloads. Each parallel algorithm overload
-has an additional template type parameter named \tcode{ExecutionPolicy}, which
-is the first template parameter.
-Additionally, each parallel algorithm overload has an additional function
-parameter of type \tcode{ExecutionPolicy\&\&}, which is the first
-function parameter.
-\begin{note} Not all algorithms have parallel algorithm overloads.\end{note}
+Parallel algorithms are algorithm overloads.
+Each parallel algorithm overload
+has an additional template type parameter named \tcode{ExecutionPolicy},
+which is the first template parameter.
+Additionally, each parallel algorithm overload
+has an additional function parameter of type \tcode{ExecutionPolicy\&\&},
+which is the first function parameter.
+\begin{note}
+Not all algorithms have parallel algorithm overloads.
+\end{note}
 
 \pnum
-Unless otherwise specified, the semantics of \tcode{ExecutionPolicy} algorithm
-overloads are identical to their overloads without.
+Unless otherwise specified,
+the semantics of \tcode{ExecutionPolicy} algorithm overloads
+are identical to their overloads without.
 
 \pnum
-Unless otherwise specified, the complexity requirements of \tcode{ExecutionPolicy}
-algorithm overloads are relaxed from the complexity requirements of the overloads
-without as follows:
-when the guarantee says ``at most \placeholder{expr}'' or ``exactly \placeholder{expr}''
-and does not specify the number of assignments or swaps, and \placeholder{expr}
-is not already expressed with  \bigoh{} notation, the complexity of the algorithm
-shall be \bigoh{\placeholder{expr}}.
+Unless otherwise specified,
+the complexity requirements of \tcode{ExecutionPolicy} algorithm overloads
+are relaxed from the complexity requirements of the overloads without
+as follows:
+when the guarantee says ``at most \placeholder{expr}'' or
+``exactly \placeholder{expr}''
+and does not specify the number of assignments or swaps, and
+\placeholder{expr} is not already expressed with  \bigoh{} notation,
+the complexity of the algorithm shall be \bigoh{\placeholder{expr}}.
 
 \pnum
 Parallel algorithms shall not participate in overload resolution unless
@@ -2795,12 +2802,13 @@ for the overloads in namespace \tcode{std} and \tcode{std::ranges}, respectively
 
 \pnum
 \returns
-\tcode{false} if $E$ is \tcode{false} for some iterator \tcode{i} in the
-range \range{first}{last}, and \tcode{true} otherwise.
+\tcode{false} if $E$ is \tcode{false}
+for some iterator \tcode{i} in the range \range{first}{last}, and
+\tcode{true} otherwise.
 
 \pnum
-\complexity At most \tcode{last - first} applications of the predicate
-and any projection.
+\complexity
+At most \tcode{last - first} applications of the predicate and any projection.
 \end{itemdescr}
 
 \rSec2[alg.any_of]{Any of}
@@ -2864,12 +2872,13 @@ for the overloads in namespace \tcode{std} and \tcode{std::ranges}, respectively
 
 \pnum
 \returns
-\tcode{false} if $E$ is \tcode{true} for some iterator \tcode{i}
-in the range \range{first}{last}, and \tcode{true} otherwise.
+\tcode{false} if $E$ is \tcode{true}
+for some iterator \tcode{i} in the range \range{first}{last}, and
+\tcode{true} otherwise.
 
 \pnum
-\complexity At most \tcode{last - first} applications of the predicate
-and any projection.
+\complexity
+At most \tcode{last - first} applications of the predicate and any projection.
 \end{itemdescr}
 
 \rSec2[alg.foreach]{For each}
@@ -2882,23 +2891,23 @@ template<class InputIterator, class Function>
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{Function} shall satisfy the
-\oldconcept{MoveConstructible} requirements (\tref{moveconstructible}).
-\begin{note} \tcode{Function} need not meet the requirements of
-\oldconcept{CopyConstructible} (\tref{copyconstructible}). \end{note}
+\requires
+\tcode{Function} shall satisfy
+the \oldconcept{MoveConstructible} requirements (\tref{moveconstructible}).
+\begin{note}
+\tcode{Function} need not meet the requirements of
+\oldconcept{CopyConstructible} (\tref{copyconstructible}).
+\end{note}
 
 \pnum
 \effects
-Applies
-\tcode{f} to the result of dereferencing every iterator in the range
-\range{first}{last},
-starting from
-\tcode{first}
-and proceeding to
-\tcode{last - 1}.
-\begin{note} If the type of \tcode{first} satisfies the
-requirements of a mutable iterator, \tcode{f} may apply non-constant
-functions through the dereferenced iterator.\end{note}
+Applies \tcode{f} to the result of dereferencing
+every iterator in the range \range{first}{last},
+starting from \tcode{first} and proceeding to \tcode{last - 1}.
+\begin{note}
+If the type of \tcode{first} satisfies the requirements of a mutable iterator,
+\tcode{f} may apply non-constant functions through the dereferenced iterator.
+\end{note}
 
 \pnum
 \returns
@@ -2906,10 +2915,7 @@ functions through the dereferenced iterator.\end{note}
 
 \pnum
 \complexity
-Applies \tcode{f}
-exactly
-\tcode{last - first}
-times.
+Applies \tcode{f} exactly \tcode{last - first} times.
 
 \pnum
 \remarks
@@ -2931,8 +2937,8 @@ template<class ExecutionPolicy, class ForwardIterator, class Function>
 
 \pnum
 \effects
-Applies \tcode{f} to the result of dereferencing every iterator in the range
-\range{first}{last}.
+Applies \tcode{f} to the result of dereferencing
+every iterator in the range \range{first}{last}.
 \begin{note}
 If the type of \tcode{first} satisfies the requirements of a mutable iterator,
 \tcode{f} may apply non-constant functions through the dereferenced iterator.
@@ -2945,14 +2951,14 @@ Applies \tcode{f} exactly \tcode{last - first} times.
 \pnum
 \remarks
 If \tcode{f} returns a result, the result is ignored.
-Implementations do not
-have the freedom granted under \ref{algorithms.parallel.exec} to make arbitrary
-copies of elements from the input sequence.
+Implementations do not have
+the freedom granted under \ref{algorithms.parallel.exec}
+to make arbitrary copies of elements from the input sequence.
 
 \pnum
 \begin{note}
-Does not return a copy of its \tcode{Function} parameter, since
-parallelization may not permit efficient state accumulation.
+Does not return a copy of its \tcode{Function} parameter,
+since parallelization may not permit efficient state accumulation.
 \end{note}
 \end{itemdescr}
 
@@ -2973,18 +2979,12 @@ namespace ranges {
 \begin{itemdescr}
 \pnum
 \effects
-Calls
-\tcode{invoke(f, invoke(proj, *i))} for every iterator
-\tcode{i} in the range
-\range{first}{last},
-starting from
-\tcode{first}
-and proceeding to
-\tcode{last - 1}.
+Calls \tcode{invoke(f, invoke(proj, *i))}
+for every iterator \tcode{i} in the range \range{first}{last},
+starting from \tcode{first} and proceeding to \tcode{last - 1}.
 \begin{note}
-If the result of
-\tcode{invoke(proj, *i)} is a mutable reference, \tcode{f} may apply
-non-constant functions.
+If the result of \tcode{invoke(proj, *i)} is a mutable reference,
+\tcode{f} may apply non-constant functions.
 \end{note}
 
 \pnum
@@ -2993,10 +2993,7 @@ non-constant functions.
 
 \pnum
 \complexity
-Applies \tcode{f} and \tcode{proj}
-exactly
-\tcode{last - first}
-times.
+Applies \tcode{f} and \tcode{proj} exactly \tcode{last - first} times.
 
 \pnum
 \remarks
@@ -3004,8 +3001,8 @@ If \tcode{f} returns a result, the result is ignored.
 
 \pnum
 \begin{note}
-The overloads in namespace \tcode{ranges} require \tcode{Fun} to model
-\libconcept{CopyConstructible}.
+The overloads in namespace \tcode{ranges} require
+\tcode{Fun} to model \libconcept{CopyConstructible}.
 \end{note}
 \end{itemdescr}
 
@@ -3019,8 +3016,10 @@ template<class InputIterator, class Size, class Function>
 \pnum
 \requires
 \tcode{Function} shall satisfy the \oldconcept{MoveConstructible} requirements
-\begin{note} \tcode{Function} need not meet the requirements of
-\oldconcept{CopyConstructible}. \end{note}
+\begin{note}
+\tcode{Function} need not meet
+the requirements of \oldconcept{CopyConstructible}.
+\end{note}
 
 \pnum
 \requires
@@ -3028,8 +3027,8 @@ template<class InputIterator, class Size, class Function>
 
 \pnum
 \effects
-Applies \tcode{f} to the result of dereferencing every iterator in the range
-\range{first}{first + n} in order.
+Applies \tcode{f} to the result of dereferencing
+every iterator in the range \range{first}{first + n} in order.
 \begin{note}
 If the type of \tcode{first} satisfies the requirements of a mutable iterator,
 \tcode{f} may apply non-constant functions through the dereferenced iterator.
@@ -3062,8 +3061,8 @@ template<class ExecutionPolicy, class ForwardIterator, class Size, class Functio
 
 \pnum
 \effects
-Applies \tcode{f} to the result of dereferencing every iterator in the range
-\range{first}{first + n}.
+Applies \tcode{f} to the result of dereferencing
+every iterator in the range \range{first}{first + n}.
 \begin{note}
 If the type of \tcode{first} satisfies the requirements of a mutable iterator,
 \tcode{f} may apply non-constant functions through the dereferenced iterator.
@@ -3075,11 +3074,11 @@ If the type of \tcode{first} satisfies the requirements of a mutable iterator,
 
 \pnum
 \remarks
-If \tcode{f} returns a result, the result is ignored.  Implementations do not
-have the freedom granted under \ref{algorithms.parallel.exec} to make arbitrary
-copies of elements from the input sequence.
+If \tcode{f} returns a result, the result is ignored.
+Implementations do not have
+the freedom granted under \ref{algorithms.parallel.exec}
+to make arbitrary copies of elements from the input sequence.
 \end{itemdescr}
-
 
 \rSec2[alg.find]{Find}
 
@@ -3148,19 +3147,14 @@ Let $E$ be:
 
 \pnum
 \returns
-The first iterator
-\tcode{i}
-in the range
-\range{first}{last}
-for which
-$E$ is \tcode{true}.
+The first iterator \tcode{i} in the range \range{first}{last}
+for which $E$ is \tcode{true}.
 Returns \tcode{last} if no such iterator is found.
 
 \pnum
 \complexity
-At most
-\tcode{last - first}
-applications of the corresponding predicate and any projection.
+At most \tcode{last - first} applications
+of the corresponding predicate and any projection.
 \end{itemdescr}
 
 \rSec2[alg.find.end]{Find end}
@@ -3211,26 +3205,28 @@ namespace ranges {
 \pnum
 Let:
 \begin{itemize}
-\item \tcode{pred} be \tcode{equal_to\{\}} for the overloads with no parameter
-\tcode{pred}.
-
-\item $E$ be:
-\begin{itemize}
-\item \tcode{pred(*(i + n), *(first2 + n))}
-for the overloads in namespace \tcode{std},
-
-\item \tcode{invoke(pred, invoke(proj1, *(i + n)), invoke(proj2, *(first2 + n)))}
-for the overloads in namespace \tcode{ranges}.
-\end{itemize}
-
-\item \tcode{i} be \tcode{last1} if \range{first2}{last2} is empty,
-or if \tcode{(last2 - first2) > (last1 - first1)} is \tcode{true},
-or if there is no iterator
-in the range \range{first1}{last1 - (last2 - first2)}
-such that for every non-negative integer
-\tcode{n < (last2 - first2)}, $E$ is \tcode{true}.
-Otherwise \tcode{i} is the last such iterator
-in \range{first1}{last1 - (last2 - first2)}.
+\item
+  \tcode{pred} be \tcode{equal_to\{\}}
+  for the overloads with no parameter \tcode{pred}.
+\item
+  $E$ be:
+  \begin{itemize}
+  \item
+    \tcode{pred(*(i + n), *(first2 + n))}
+    for the overloads in namespace \tcode{std},
+  \item
+    \tcode{invoke(pred, invoke(proj1, *(i + n)), invoke(proj2, *(first2 + n)))}
+    for the overloads in namespace \tcode{ranges}.
+  \end{itemize}
+\item
+  \tcode{i} be \tcode{last1} if \range{first2}{last2} is empty,
+  or if \tcode{(last2 - first2) > (last1 - first1)} is \tcode{true},
+  or if there is no iterator
+  in the range \range{first1}{last1 - (last2 - first2)}
+  such that for every non-negative integer
+  \tcode{n < (last2 - first2)}, $E$ is \tcode{true}.
+  Otherwise \tcode{i} is the last such iterator
+  in \range{first1}{last1 - (last2 - first2)}.
 \end{itemize}
 
 \pnum
@@ -3310,22 +3306,17 @@ Finds an element that matches one of a set of values.
 
 \pnum
 \returns
-The first iterator
-\tcode{i}
-in the range \range{first1}{last1}
-such that for some
-iterator
-\tcode{j}
-in the range \range{first2}{last2} $E$ holds.
+The first iterator \tcode{i} in the range \range{first1}{last1}
+such that for some iterator \tcode{j} in the range \range{first2}{last2}
+$E$ holds.
 Returns \tcode{last1}
 if \range{first2}{last2} is empty or
 if no such iterator is found.
 
 \pnum
 \complexity
-At most
-\tcode{(last1-first1) * (last2-first2)}
-applications of the corresponding predicate and any projections.
+At most \tcode{(last1-first1) * (last2-first2)} applications
+of the corresponding predicate and any projections.
 \end{itemdescr}
 
 \rSec2[alg.adjacent.find]{Adjacent find}
@@ -3374,26 +3365,18 @@ Let $E$ be:
 
 \pnum
 \returns
-The first iterator
-\tcode{i}
-such that both
-\tcode{i}
-and
-\tcode{i + 1}
-are in
-the range
-\range{first}{last}
+The first iterator \tcode{i}
+such that both \tcode{i} and \tcode{i + 1} are in the range \range{first}{last}
 for which $E$ holds.
-Returns \tcode{last}
-if no such iterator is found.
+Returns \tcode{last} if no such iterator is found.
 
 \pnum
 \complexity
-For the overloads with no \tcode{ExecutionPolicy}, exactly
-\[ \min(\tcode{(i - first) + 1}, \ \tcode{(last - first) - 1}) \]
-applications of the corresponding predicate, where \tcode{i} is
-\tcode{adjacent_find}'s
-return value.  For the overloads with an \tcode{ExecutionPolicy},
+For the overloads with no \tcode{ExecutionPolicy},
+exactly \[ \min(\tcode{(i - first) + 1}, \ \tcode{(last - first) - 1}) \]
+applications of the corresponding predicate,
+where \tcode{i} is \tcode{adjacent_find}'s return value.
+For the overloads with an \tcode{ExecutionPolicy},
 \bigoh{\tcode{last - first}} applications of the corresponding predicate,
 and no more than twice as many applications of any projection.
 \end{itemdescr}
@@ -3443,28 +3426,29 @@ namespace ranges {
 \pnum
 Let $E$ be:
 \begin{itemize}
-\item \tcode{*i == value} for the overloads
+\item
+  \tcode{*i == value} for the overloads
   with no parameter \tcode{pred} or \tcode{proj},
-\item \tcode{pred(*i) != false} for the overloads
+\item
+  \tcode{pred(*i) != false} for the overloads
   with a parameter \tcode{pred} but no parameter \tcode{proj},
-\item \tcode{invoke(proj, *i) == value} for the overloads
+\item
+  \tcode{invoke(proj, *i) == value} for the overloads
   with a parameter \tcode{proj} but no parameter \tcode{pred},
-\item \tcode{invoke(pred, invoke(proj, *i)) != false} for the overloads
+\item
+  \tcode{invoke(pred, invoke(proj, *i)) != false} for the overloads
   with both parameters \tcode{proj} and \tcode{pred}.
 \end{itemize}
 
 \pnum
 \effects
-Returns the number of iterators
-\tcode{i}
-in the range \range{first}{last}
+Returns the number of iterators \tcode{i} in the range \range{first}{last}
 for which $E$ holds.
 
 \pnum
 \complexity
-Exactly
-\tcode{last - first}
-applications of the corresponding predicate and any projection.
+Exactly \tcode{last - first} applications
+of the corresponding predicate and any projection.
 \end{itemdescr}
 
 \rSec2[mismatch]{Mismatch}
@@ -3537,27 +3521,35 @@ namespace ranges {
 
 \begin{itemdescr}
 \pnum
-Let \tcode{last2} be \tcode{first2 + (last1 - first1)} for the overloads with no parameter \tcode{last2} or \tcode{r2}.
+Let \tcode{last2} be \tcode{first2 + (last1 - first1)}
+for the overloads with no parameter \tcode{last2} or \tcode{r2}.
 
 \pnum
 Let $E$ be:
 \begin{itemize}
 \setlength{\emergencystretch}{1em}
-\item \tcode{!(*(first1 + n) == *(first2 + n))} for the overloads with no parameter \tcode{pred},
-\item \tcode{pred(*(first1 + n), *(first2 + n)) == false} for the overloads with a parameter \tcode{pred} and no parameter \tcode{proj1},
-\item \tcode{!invoke(pred, invoke(proj1, *(first1 + n)), invoke(proj2, *(first2 + n)))} for the overloads with both parameters \tcode{pred} and \tcode{proj1}.
+\item
+  \tcode{!(*(first1 + n) == *(first2 + n))}
+  for the overloads with no parameter \tcode{pred},
+\item
+  \tcode{pred(*(first1 + n), *(first2 + n)) == false}
+  for the overloads with a parameter \tcode{pred} and
+  no parameter \tcode{proj1},
+\item
+  \tcode{!invoke(pred, invoke(proj1, *(first1 + n)), invoke(proj2, *(first2 + n)))}
+  for the overloads with both parameters \tcode{pred} and \tcode{proj1}.
 \end{itemize}
 
 \pnum
 \returns
-\tcode{\{ first1 + n, first2 + n \}}, where \tcode{n} is the smallest integer
-such that $E$ holds,
-or $\min(\tcode{last1 - first1}, \ \tcode{last2 - first2})$ if no such integer exists.
+\tcode{\{ first1 + n, first2 + n \}},
+where \tcode{n} is the smallest integer such that $E$ holds,
+or $\min(\tcode{last1 - first1}, \ \tcode{last2 - first2})$
+if no such integer exists.
 
 \pnum
 \complexity
-At most
-$\min(\tcode{last1 - first1}, \ \tcode{last2 - first2})$
+At most $\min(\tcode{last1 - first1}, \ \tcode{last2 - first2})$
 applications of the corresponding predicate and any projections.
 \end{itemdescr}
 
@@ -3622,57 +3614,56 @@ namespace ranges {
 \pnum
 Let:
 \begin{itemize}
-\item \tcode{last2} be \tcode{first2 + (last1 - first1)} for the overloads with no parameter \tcode{last2} or \tcode{r2},
-
-\item \tcode{pred} be \tcode{equal_to\{\}} for the overloads with no parameter \tcode{pred},
-
-\item $E$ be:
-\begin{itemize}
-\setlength{\emergencystretch}{1em}
-\item \tcode{pred(*i, *(first2 + (i - first1)))} for the overloads with no parameter \tcode{proj1},
-\item \tcode{invoke(pred, invoke(proj1, *i), invoke(proj2, *(first2 + (i - first1))))} for the overloads with parameter \tcode{proj1}.
-\end{itemize}
+\item
+  \tcode{last2} be \tcode{first2 + (last1 - first1)}
+  for the overloads with no parameter \tcode{last2} or \tcode{r2},
+\item
+  \tcode{pred} be \tcode{equal_to\{\}}
+  for the overloads with no parameter \tcode{pred},
+\item
+  $E$ be:
+  \begin{itemize}
+  \setlength{\emergencystretch}{1em}
+  \item
+    \tcode{pred(*i, *(first2 + (i - first1)))}
+    for the overloads with no parameter \tcode{proj1},
+  \item
+    \tcode{invoke(pred, invoke(proj1, *i), invoke(proj2, *(first2 + (i - first1))))}
+    for the overloads with parameter \tcode{proj1}.
+  \end{itemize}
 \end{itemize}
 
 \pnum
 \returns
-If
-\tcode{last1 - first1 != last2 - first2},
-return
-\tcode{false}.
-Otherwise return
-\tcode{true}
-if $E$ holds for every iterator
-\tcode{i}
-in the range \range{first1}{last1}
-Otherwise, returns
-\tcode{false}.
+If \tcode{last1 - first1 != last2 - first2}, return \tcode{false}.
+Otherwise return \tcode{true}
+if $E$ holds for every iterator \tcode{i} in the range \range{first1}{last1}
+Otherwise, returns \tcode{false}.
 
 \pnum
 \complexity
 If the types of \tcode{first1}, \tcode{last1}, \tcode{first2}, and \tcode{last2}:
 \begin{itemize}
-\item meet the \oldconcept{RandomAccessIterator}
-  requirements\iref{random.access.iterators}
+\item
+  meet the
+  \oldconcept{RandomAccessIterator} requirements\iref{random.access.iterators}
   for the overloads in namespace \tcode{std}, or
-\item pairwise model \tcode{SizedSentinel}\iref{iterator.concept.sizedsentinel} for the
-overloads in namespace \tcode{ranges},
+\item
+  pairwise model \tcode{SizedSentinel}\iref{iterator.concept.sizedsentinel}
+  for the overloads in namespace \tcode{ranges},
 \end{itemize}
-and
-\tcode{last1 - first1 != last2 - first2},
-then
-no applications of the corresponding predicate and each projection; otherwise,
+and \tcode{last1 - first1 != last2 - first2},
+then no applications of the corresponding predicate and each projection;
+otherwise,
 \begin{itemize}
 \item
-For the overloads with no \tcode{ExecutionPolicy},
-at most
-$\min(\tcode{last1 - first1}, \ \tcode{last2 - first2})$
-applications of the corresponding predicate and any projections.
-
+  For the overloads with no \tcode{ExecutionPolicy},
+  at most $\min(\tcode{last1 - first1}, \ \tcode{last2 - first2})$
+  applications of the corresponding predicate and any projections.
 \item
-For the overloads with an \tcode{ExecutionPolicy},
-\bigoh{\min(\tcode{last1 - first1}, \ \tcode{last2 - first2})} applications
-of the corresponding predicate.
+  For the overloads with an \tcode{ExecutionPolicy},
+  \bigoh{\min(\tcode{last1 - first1}, \ \tcode{last2 - first2})}
+  applications of the corresponding predicate.
 \end{itemize}
 \end{itemdescr}
 
@@ -3699,30 +3690,40 @@ template<class ForwardIterator1, class ForwardIterator2,
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{ForwardIterator1} and \tcode{ForwardIterator2} shall have the same
-value type. The comparison function shall be an equivalence relation.
+\requires
+\tcode{ForwardIterator1} and \tcode{ForwardIterator2} shall have
+the same value type.
+The comparison function shall be an equivalence relation.
 
 \pnum
-\remarks If \tcode{last2} was not given in the argument list, it denotes
-\tcode{first2 + (last1 - first1)} below.
+\remarks
+If \tcode{last2} was not given in the argument list,
+it denotes \tcode{first2 + (last1 - first1)} below.
 
 \pnum
-\returns If \tcode{last1 - first1 != last2 - first2}, return \tcode{false}.
-Otherwise return \tcode{true} if there exists a permutation of the elements in the
-range \range{first2}{first2 + (last1 - first1)}, beginning with \tcode{ForwardIterator2
-begin}, such that \tcode{equal(first1, last1, begin)} returns \tcode{true} or
-\tcode{equal(first1, last1, begin, pred)} returns \tcode{true}; otherwise, returns
-\tcode{false}.
+\returns
+If \tcode{last1 - first1 != last2 - first2}, return \tcode{false}.
+Otherwise return \tcode{true}
+if there exists a permutation of the elements
+in the range \range{first2}{first2 + (last1 - first1)},
+beginning with \tcode{ForwardIterator2 begin},
+such that \tcode{equal(first1, last1, begin)} returns \tcode{true} or
+\tcode{equal(first1, last1, begin, pred)} returns \tcode{true};
+otherwise, returns \tcode{false}.
 
 \pnum
-\complexity No applications of the corresponding predicate if \tcode{ForwardIterator1}
-and \tcode{Forward\-Iter\-ator2} meet the requirements of random access iterators and
+\complexity
+No applications of the corresponding predicate
+if \tcode{ForwardIterator1} and \tcode{Forward\-Iter\-ator2}
+meet the requirements of random access iterators and
 \tcode{last1 - first1 != last2 - first2}.
-Otherwise, exactly \tcode{last1 - first1} applications of the
-corresponding predicate if \tcode{equal(\brk{}first1, last1, first2, last2)}
-would return \tcode{true} if \tcode{pred} was not given in the argument list
-or \tcode{equal(first1, last1, first2, last2, pred)} would return \tcode{true} if pred was given in the argument list; otherwise, at
-worst \bigoh{N^2}, where $N$ has the value \tcode{last1 - first1}.
+Otherwise, exactly \tcode{last1 - first1} applications
+of the corresponding predicate
+if \tcode{equal(\brk{}first1, last1, first2, last2)} would return \tcode{true}
+if \tcode{pred} was not given in the argument list or
+\tcode{equal(first1, last1, first2, last2, pred)} would return \tcode{true}
+if \tcode{pred} was given in the argument list;
+otherwise, at worst \bigoh{N^2}, where $N$ has the value \tcode{last1 - first1}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{is_permutation}}%
@@ -3745,10 +3746,13 @@ namespace ranges {
 
 \begin{itemdescr}
 \pnum
-\returns If \tcode{last1 - first1 != last2 - first2}, return \tcode{false}.
-Otherwise return \tcode{true} if there exists a permutation of the elements in the
-range \range{first2}{last2}, bounded by \range{pfirst}{plast}, such that
-\tcode{ranges::equal(first1, last1, pfirst, plast, pred, proj1, proj2)} returns \tcode{true};
+\returns
+If \tcode{last1 - first1 != last2 - first2}, return \tcode{false}.
+Otherwise return \tcode{true} if there exists a permutation of the elements
+in the range \range{first2}{last2}, bounded by \range{pfirst}{plast},
+such that
+\tcode{ranges::equal(first1, last1, pfirst, plast, pred, proj1, proj2)}
+returns \tcode{true};
 otherwise, returns \tcode{false}.
 
 \pnum
@@ -3759,11 +3763,11 @@ No applications of the corresponding predicate and projections if:
 \item \tcode{S2} and \tcode{I2} model \libconcept{SizedSentinel}, and
 \item \tcode{last1 - first1 != last2 - first2}.
 \end{itemize}
-Otherwise, exactly \tcode{last1 - first1} applications of the
-corresponding predicate and projections if
-\tcode{ranges::equal(\brk{}first1, last1, first2, last2, pred, proj1, proj2)}
-would return \tcode{true}; otherwise, at
-worst \bigoh{N^2}, where $N$ has the value \tcode{last1 - first1}.
+Otherwise, exactly \tcode{last1 - first1} applications
+of the corresponding predicate and projections
+if \tcode{ranges::equal(\brk{}first1, last1, first2, last2, pred, proj1, proj2)}
+would return \tcode{true};
+otherwise, at worst \bigoh{N^2}, where $N$ has the value \tcode{last1 - first1}.
 \end{itemdescr}
 
 \rSec2[alg.search]{Search}
@@ -3798,25 +3802,18 @@ template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2,
 \begin{itemdescr}
 \pnum
 \returns
-The first iterator
-\tcode{i}
-in the range \range{first1}{last1 - (last2-first2)}
-such that for every non-negative integer
-\tcode{n}
-less than
-\tcode{last2 - first2}
+The first iterator \tcode{i} in the range \range{first1}{last1 - (last2-first2)}
+such that
+for every non-negative integer \tcode{n} less than \tcode{last2 - first2}
 the following corresponding conditions hold:
 \tcode{*(i + n) == *(first2 + n), pred(*(i + n), *(first2 + n)) != false}.
-Returns \tcode{first1}
-if \range{first2}{last2} is empty,
-otherwise returns \tcode{last1}
-if no such iterator is found.
+Returns \tcode{first1} if \range{first2}{last2} is empty,
+otherwise returns \tcode{last1} if no such iterator is found.
 
 \pnum
 \complexity
-At most
-\tcode{(last1 - first1) * (last2 - first2)}
-applications of the corresponding predicate.
+At most \tcode{(last1 - first1) * (last2 - first2)} applications
+of the corresponding predicate.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{search}}%
@@ -3842,28 +3839,25 @@ namespace ranges {
 \pnum
 \returns
 \begin{itemize}
-\item \tcode{\{i, i + (last2 - first2)\}}, where \tcode{i} is
-the first iterator in the range \range{first1}{last1 - (last2 - first2)}
-such that for every non-negative integer
-\tcode{n}
-less than
-\tcode{last2 - first2}
-the condition
+\item
+  \tcode{\{i, i + (last2 - first2)\}},
+  where \tcode{i} is
+  the first iterator in the range \range{first1}{last1 - (last2 - first2)}
+  such that
+  for every non-negative integer \tcode{n} less than \tcode{last2 - first2}
+  the condition
 \begin{codeblock}
 bool(invoke(pred, invoke(proj1, *(i + n)), invoke(proj2, *(first2 + n))))
 \end{codeblock}
-is \tcode{true}:
-
-\item Returns
-\tcode{\{last1, last1\}}
-if no such iterator exists.
+  is \tcode{true}:
+\item
+  Returns \tcode{\{last1, last1\}} if no such iterator exists.
 \end{itemize}
 
 \pnum
 \complexity
-At most
-\tcode{(last1 - first1) * (last2 - first2)}
-applications of the corresponding predicate and projections.
+At most \tcode{(last1 - first1) * (last2 - first2)} applications
+of the corresponding predicate and projections.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{search_n}}%
@@ -3896,29 +3890,20 @@ template<class ExecutionPolicy, class ForwardIterator, class Size, class T,
 \begin{itemdescr}
 \pnum
 \requires
-The type
-\tcode{Size}
+The type \tcode{Size}
 shall be convertible to integral type~(\ref{conv.integral}, \ref{class.conv}).
 
 \pnum
 \returns
-The first iterator
-\tcode{i}
-in the range \range{first}{last-count}
-such that for every non-negative integer
-\tcode{n}
-less than
-\tcode{count}
+The first iterator \tcode{i} in the range \range{first}{last-count}
+such that for every non-negative integer \tcode{n} less than \tcode{count}
 the following corresponding conditions hold:
 \tcode{*(i + n) == value, pred(*(i + n),value) != false}.
-Returns \tcode{last}
-if no such iterator is found.
+Returns \tcode{last} if no such iterator is found.
 
 \pnum
 \complexity
-At most
-\tcode{last - first}
-applications of the corresponding predicate.
+At most \tcode{last - first} applications of the corresponding predicate.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{search_n}}%
@@ -3942,22 +3927,17 @@ namespace ranges {
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{\{i, i + count\}} where \tcode{i} is the first iterator
-in the range \range{first}{last - count}
-such that for every non-negative integer
-\tcode{n}
-less than
-\tcode{count},
+\tcode{\{i, i + count\}}
+where \tcode{i} is the first iterator in the range \range{first}{last - count}
+such that for every non-negative integer \tcode{n} less than \tcode{count},
 the following condition holds:
 \tcode{invoke(pred, invoke(proj, *(i + n)), value)}.
-Returns \tcode{\{last, last\}}
-if no such iterator is found.
+Returns \tcode{\{last, last\}} if no such iterator is found.
 
 \pnum
 \complexity
-At most
-\tcode{last - first}
-applications of the corresponding predicate and projection.
+At most \tcode{last - first} applications
+of the corresponding predicate and projection.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{search}}%
@@ -3976,7 +3956,6 @@ Equivalent to: \tcode{return searcher(first, last).first;}
 \remarks
 \tcode{Searcher} need not meet the \oldconcept{CopyConstructible} requirements.
 \end{itemdescr}
-
 
 \rSec1[alg.modifying.operations]{Mutating sequence operations}
 
@@ -4005,24 +3984,29 @@ namespace ranges {
 Let $N$ be \tcode{last - first}.
 
 \pnum
-\requires \tcode{result} shall not be in the range \range{first}{last}.
+\requires
+\tcode{result} shall not be in the range \range{first}{last}.
 
 \pnum
-\effects Copies elements in the range \range{first}{last} into the range \range{result}{result + $N$} starting from \tcode{first} and proceeding to \tcode{last}.
-For each non-negative integer $n < N$, performs \tcode{*(result + $n$) = *(first + $n$)}.
+\effects
+Copies elements in the range \range{first}{last}
+into the range \range{result}{result + $N$}
+starting from \tcode{first} and proceeding to \tcode{last}.
+For each non-negative integer $n < N$,
+performs \tcode{*(result + $n$) = *(first + $n$)}.
 
 \pnum
 \returns
 \begin{itemize}
 \item
-\tcode{result + $N$} for the overload in namespace \tcode{std}, or
+  \tcode{result + $N$} for the overload in namespace \tcode{std}, or
 \item
-\tcode{\{last, result + $N$\}} for the overloads in
-namespace \tcode{ranges}.
+  \tcode{\{last, result + $N$\}} for the overloads in namespace \tcode{ranges}.
 \end{itemize}
 
 \pnum
-\complexity Exactly $N$ assignments.
+\complexity
+Exactly $N$ assignments.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{copy}}%
@@ -4035,20 +4019,24 @@ template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
 
 \begin{itemdescr}
 \pnum
-\requires The ranges \range{first}{last} and
-\range{result}{result + (last - first)} shall not overlap.
+\requires
+The ranges \range{first}{last} and \range{result}{result + (last - first)}
+shall not overlap.
 
 \pnum
-\effects Copies elements in the range \range{first}{last} into
-the range \range{result}{result + (last - first)}.
+\effects
+Copies elements in the range \range{first}{last}
+into the range \range{result}{result + (last - first)}.
 For each non-negative integer \tcode{n < (last - first)},
 performs \tcode{*(result + n) = *(first + n)}.
 
 \pnum
-\returns \tcode{result + (last - first)}.
+\returns
+\tcode{result + (last - first)}.
 
 \pnum
-\complexity Exactly \tcode{last - first} assignments.
+\complexity
+Exactly \tcode{last - first} assignments.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{copy_n}}%
@@ -4074,21 +4062,24 @@ namespace ranges {
 Let $M$ be $\max(\tcode{n}, 0)$.
 
 \pnum
-\effects For each non-negative integer
-$i < M$, performs \tcode{*(result + i) = *(first + i)}.
+\effects
+For each non-negative integer $i < M$,
+performs \tcode{*(result + i) = *(first + i)}.
 
 \pnum
 \returns
 \begin{itemize}
 \item
-\tcode{result + $M$} for the overloads in namespace \tcode{std}, or
+  \tcode{result + $M$}
+  for the overloads in namespace \tcode{std}, or
 \item
-\tcode{\{first + $M$, result + $M$\}}
+  \tcode{\{first + $M$, result + $M$\}}
   for the overload in namespace \tcode{ranges}.
 \end{itemize}
 
 \pnum
-\complexity Exactly $M$ assignments.
+\complexity
+Exactly $M$ assignments.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{copy_if}}%
@@ -4120,38 +4111,52 @@ namespace ranges {
 \pnum
 Let $E$ be:
 \begin{itemize}
-\item \tcode{bool(pred(*i))} for the overloads in namespace \tcode{std}, or
-\item \tcode{bool(invoke(pred, invoke(proj, *i)))} for the overloads in
-  namespace \tcode{ranges}.
+\item
+  \tcode{bool(pred(*i))}
+  for the overloads in namespace \tcode{std}, or
+\item
+  \tcode{bool(invoke(pred, invoke(proj, *i)))}
+  for the overloads in namespace \tcode{ranges}.
 \end{itemize}
 and $N$ be the number of iterators \tcode{i} in the range \range{first}{last}
 for which the condition $E$ holds.
 
 \pnum
-\requires The ranges \range{first}{last} and \range{result}{result + (last - first)} shall not overlap.
+\requires
+The ranges \range{first}{last} and \range{result}{result + (last - first)}
+shall not overlap.
 \begin{note}
-For the overload with an \tcode{ExecutionPolicy}, there may be a performance
-cost if \tcode{iterator_traits<ForwardIterator1>::value_type} is not
-\oldconcept{\-Move\-Constructible} (\tref{moveconstructible}).
+For the overload with an \tcode{ExecutionPolicy},
+there may be a performance cost
+if \tcode{iterator_traits<ForwardIterator1>::value_type}
+is not \oldconcept{\-Move\-Constructible} (\tref{moveconstructible}).
 \end{note}
 
 \pnum
-\effects Copies all of the elements referred to by the iterator \tcode{i} in the range \range{first}{last}
+\effects
+Copies all of the elements referred to
+by the iterator \tcode{i} in the range \range{first}{last}
 for which $E$ is \tcode{true}.
 
 \pnum
 \returns
 \begin{itemize}
-\item \tcode{result + $N$} for the overloads in namespace \tcode{std}, or
-\item \tcode{\{last, result + $N$\}}
+\item
+  \tcode{result + $N$}
+  for the overloads in namespace \tcode{std}, or
+\item
+  \tcode{\{last, result + $N$\}}
   for the overloads in namespace \tcode{ranges}.
 \end{itemize}
 
 \pnum
-\complexity Exactly \tcode{last - first} applications of the corresponding predicate and any projection.
+\complexity
+Exactly \tcode{last - first} applications
+of the corresponding predicate and any projection.
 
 \pnum
-\remarks Stable\iref{algorithm.stable}.
+\remarks
+Stable\iref{algorithm.stable}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{copy_backward}}%
@@ -4180,33 +4185,26 @@ Let $N$ be \tcode{last - first}.
 
 \pnum
 \requires
-\tcode{result}
-shall not be in the range
-\brange{first}{last}.
+\tcode{result} shall not be in the range \brange{first}{last}.
 
 \pnum
 \effects
 Copies elements in the range \range{first}{last}
-into the
-range \range{result - $N$}{result}
-starting from
-\tcode{last - 1}
-and proceeding to \tcode{first}.\footnote{\tcode{copy_backward}
-should be used instead of copy when \tcode{last}
-is in
-the range
-\range{result - $N$}{result}.}
-For each positive integer
-$n \le N$,
-performs
-\tcode{*(result - $n$) = *(last - $n$)}.
+into the range \range{result - $N$}{result}
+starting from \tcode{last - 1} and proceeding to \tcode{first}.%
+\footnote{\tcode{copy_backward} should be used instead of copy
+when \tcode{last} is in the range \range{result - $N$}{result}.}
+For each positive integer $n \le N$,
+performs \tcode{*(result - $n$) = *(last - $n$)}.
 
 \pnum
 \returns
 \begin{itemize}
-\item \tcode{result - $N$}
+\item
+  \tcode{result - $N$}
   for the overload in namespace \tcode{std}, or
-\item \tcode{\{last, result - $N$\}}
+\item
+  \tcode{\{last, result - $N$\}}
   for the overloads in namespace \tcode{ranges}.
 \end{itemize}
 
@@ -4239,35 +4237,35 @@ namespace ranges {
 \pnum
 Let $E$ be
 \begin{itemize}
-\item \tcode{std::move(*(first + $n$))} for the overload in namespace \tcode{std}, or
-\item \tcode{ranges::iter_move(first + $n$)} for the overloads in namespace \tcode{ranges}.
+\item
+  \tcode{std::move(*(first + $n$))}
+  for the overload in namespace \tcode{std}, or
+\item
+  \tcode{ranges::iter_move(first + $n$)}
+  for the overloads in namespace \tcode{ranges}.
 \end{itemize}
 Let $N$ be \tcode{last - first}.
 
 \pnum
 \requires
-\tcode{result}
-shall not be in the range
-\range{first}{last}.
+\tcode{result} shall not be in the range \range{first}{last}.
 
 \pnum
 \effects
 Moves elements in the range \range{first}{last}
 into the range \range{result}{result + $N$}
 starting from \tcode{first} and proceeding to \tcode{last}.
-For each non-negative integer
-$n < N$,
-performs
-\tcode{*(result + $n$) = $E$}.
+For each non-negative integer $n < N$, performs \tcode{*(result + $n$) = $E$}.
 
 \pnum
 \returns
 \begin{itemize}
 \item
-\tcode{result + $N$} for the overload in namespace \tcode{std}, or
+  \tcode{result + $N$}
+  for the overload in namespace \tcode{std}, or
 \item
-\tcode{\{last, result + $N$\}} for the overloads in
-  namespace \tcode{ranges}.
+  \tcode{\{last, result + $N$\}}
+  for the overloads in namespace \tcode{ranges}.
 \end{itemize}
 
 \pnum
@@ -4288,20 +4286,24 @@ template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
 Let $N$ be \tcode{last - first}.
 
 \pnum
-\requires The ranges \range{first}{last} and
-\range{result}{result + $N$} shall not overlap.
+\requires
+The ranges \range{first}{last} and \range{result}{result + $N$}
+shall not overlap.
 
 \pnum
-\effects Moves elements in the range \range{first}{last} into
-the range \range{result}{result + $N$}.
+\effects
+Moves elements in the range \range{first}{last}
+into the range \range{result}{result + $N$}.
 For each non-negative integer $n < N$,
 performs \tcode{*(result + $n$) = std::\brk{}move(*(first + $n$))}.
 
 \pnum
-\returns \tcode{result + $N$}.
+\returns
+\tcode{result + $N$}.
 
 \pnum
-\complexity Exactly $N$ assignments.
+\complexity
+Exactly $N$ assignments.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{move_backward}}%
@@ -4327,40 +4329,38 @@ namespace ranges {
 \pnum
 Let $E$ be
 \begin{itemize}
-\item \tcode{std::move(*(last - $n$))} for the overload in namespace \tcode{std}, or
-\item \tcode{ranges::iter_move(last - $n$)} for the overloads in namespace \tcode{ranges}.
+\item
+  \tcode{std::move(*(last - $n$))}
+  for the overload in namespace \tcode{std}, or
+\item
+  \tcode{ranges::iter_move(last - $n$)}
+  for the overloads in namespace \tcode{ranges}.
 \end{itemize}
 Let $N$ be \tcode{last - first}.
 
 \pnum
 \requires
-\tcode{result}
-shall not be in the range
-\brange{first}{last}.
+\tcode{result} shall not be in the range \brange{first}{last}.
 
 \pnum
 \effects
 Moves elements in the range \range{first}{last}
-into the
-range \range{result - $N$}{result}
-starting from
-\tcode{last - 1}
-and proceeding to \tcode{first}.\footnote{\tcode{move_backward}
-should be used instead of move when last
-is in
-the range
-\range{result - $N$}{result}.}
-For each positive integer
-$n \le N$,
-performs
-\tcode{*(result - $n$) = $E$}.
+into the range \range{result - $N$}{result}
+starting from \tcode{last - 1} and proceeding to \tcode{first}.%
+\footnote{\tcode{move_backward} should be used instead of move
+when \tcode{last} is in the range \range{result - $N$}{result}.}
+For each positive integer $n \le N$,
+performs \tcode{*(result - $n$) = $E$}.
 
 \pnum
 \returns
 \begin{itemize}
-\item \tcode{result - $N$} for the overload in namespace \tcode{std}, or
-\item \tcode{\{last, result - $N$\}} for the overloads
-  in namespace \tcode{ranges}.
+\item
+  \tcode{result - $N$}
+  for the overload in namespace \tcode{std}, or
+\item
+  \tcode{\{last, result - $N$\}}
+  for the overloads in namespace \tcode{ranges}.
 \end{itemize}
 
 \pnum
@@ -4398,16 +4398,15 @@ namespace ranges {
 \pnum
 Let:
 \begin{itemize}
-\item \tcode{last2} be \tcode{first2 + (last1 - first1)} for the overloads with
-  no parameter named \tcode{last2}, and
+\item
+  \tcode{last2} be \tcode{first2 + (last1 - first1)}
+  for the overloads with no parameter named \tcode{last2}, and
 \item $M$ be $\min(\tcode{last1 - first1}, \ \tcode{last2 - first2})$.
 \end{itemize}
 
 \pnum
 \requires
-The two ranges \range{first1}{last1}
-and
-\range{first2}{last2}
+The two ranges \range{first1}{last1} and \range{first2}{last2}
 shall not overlap.
 For the overloads in namespace \tcode{std},
 \tcode{*(first1 + $n$)} shall be swappable with\iref{swappable.requirements}
@@ -4415,20 +4414,24 @@ For the overloads in namespace \tcode{std},
 
 \pnum
 \effects
-For each non-negative integer $n < M$
-performs:
+For each non-negative integer $n < M$ performs:
 \begin{itemize}
-\item \tcode{swap(*(first1 + $n$), *(first2 + $n$))} for the overloads in
-  namespace \tcode{std}, or
-\item \tcode{ranges::iter_swap(first1 + $n$, first2 + $n$)} for the overloads
-  in namespace \tcode{ranges}.
+\item
+  \tcode{swap(*(first1 + $n$), *(first2 + $n$))}
+  for the overloads in namespace \tcode{std}, or
+\item
+  \tcode{ranges::iter_swap(first1 + $n$, first2 + $n$)}
+  for the overloads in namespace \tcode{ranges}.
 \end{itemize}
 
 \pnum
 \returns
 \begin{itemize}
-\item \tcode{last2} for the overloads in namespace \tcode{std}, or
-\item \tcode{\{first1 + $M$, first2 + $M$\}}
+\item
+  \tcode{last2}
+  for the overloads in namespace \tcode{std}, or
+\item
+  \tcode{\{first1 + $M$, first2 + $M$\}}
   for the overloads in namespace \tcode{ranges}.
 \end{itemize}
 
@@ -4518,60 +4521,66 @@ namespace ranges {
 Let:
 \begin{itemize}
 \setlength{\emergencystretch}{1em}
-\item \tcode{last2} be \tcode{first2 + (last1 - first1)} for the overloads with
-  parameter \tcode{first2} but no parameter \tcode{last2},
-\item $N$ be \tcode{last1 - first1} for unary transforms, or
+\item
+  \tcode{last2} be \tcode{first2 + (last1 - first1)}
+  for the overloads with parameter \tcode{first2}
+  but no parameter \tcode{last2},
+\item
+  $N$ be \tcode{last1 - first1} for unary transforms, or
   $\min(\tcode{last1 - first1}, \ \tcode{last2 - first2})$ for binary transforms, and
-\item $E$ be
+\item
+  $E$ be
   \begin{itemize}
-  \item \tcode{op(*(first1 + (i - result)))} for unary transforms defined in
-    namespace \tcode{std},
-  \item \tcode{binary_op(*(first1 + (i - result)), *(first2 + (i - result)))} for
-    binary transforms defined in namespace \tcode{std},
-  \item \tcode{invoke(op, invoke(proj, *(first1 + (i - result))))} for unary
-    transforms defined in namespace \tcode{ranges}, or
-  \item \tcode{invoke(binary_op, invoke(proj1, *(first1 + (i - result))), invoke(proj2,\linebreak *(first2 + (i - result))))}
+  \item
+    \tcode{op(*(first1 + (i - result)))}
+    for unary transforms defined in namespace \tcode{std},
+  \item
+    \tcode{binary_op(*(first1 + (i - result)), *(first2 + (i - result)))}
+    for binary transforms defined in namespace \tcode{std},
+  \item
+    \tcode{invoke(op, invoke(proj, *(first1 + (i - result))))}
+    for unary transforms defined in namespace \tcode{ranges}, or
+  \item
+    \tcode{invoke(binary_op, invoke(proj1, *(first1 + (i - result))), invoke(proj2,\linebreak *(first2 + (i - result))))}
     for binary transforms defined in namespace \tcode{ranges}.
   \end{itemize}
 \end{itemize}
 
 \pnum
 \requires
-\tcode{op} and \tcode{binary_op}
-shall not invalidate iterators or subranges, or modify elements in the ranges
+\tcode{op} and \tcode{binary_op} shall not invalidate iterators or subranges, or
+modify elements in the ranges
 \begin{itemize}
 \item \crange{first1}{first1 + $N$},
 \item \crange{first2}{first2 + $N$}, and
-\item \crange{result}{result + $N$}.\footnote{The use of fully
-closed ranges is intentional.}
+\item \crange{result}{result + $N$}.%
+\footnote{The use of fully closed ranges is intentional.}
 \end{itemize}
 
 \pnum
 \effects
-Assigns through every iterator
-\tcode{i}
-in the range
-\range{result}{result + $N$}
-a new
-corresponding value equal to $E$.
+Assigns through every iterator \tcode{i}
+in the range \range{result}{result + $N$}
+a new corresponding value equal to $E$.
 
 \pnum
 \returns
 \begin{itemize}
-\item \tcode{result + $N$}
+\item
+  \tcode{result + $N$}
   for the overloads defined in namespace \tcode{std},
-\item \tcode{\{first1 + $N$, result + $N$\}} for unary transforms
-  defined in namespace \tcode{ranges}, or
-\item \tcode{\{first1 + $N$, first2 + $N$, result + $N$\}} for binary
-  transforms defined in namespace \tcode{ranges}.
+\item
+  \tcode{\{first1 + $N$, result + $N$\}}
+  for unary transforms defined in namespace \tcode{ranges}, or
+\item \tcode{\{first1 + $N$, first2 + $N$, result + $N$\}}
+  for binary transforms defined in namespace \tcode{ranges}.
 \end{itemize}
 
 \pnum
 \complexity
-Exactly $N$ applications of
-\tcode{op} or \tcode{binary_op}, and any projections.
-This requirement also applies to the overload
-with an \tcode{ExecutionPolicy} .
+Exactly $N$ applications of \tcode{op} or \tcode{binary_op}, and
+any projections.
+This requirement also applies to the overload with an \tcode{ExecutionPolicy}.
 
 \pnum
 \remarks
@@ -4634,16 +4643,12 @@ Let $E$ be
 
 \pnum
 \requires
-The expression
-\tcode{*first = new_value}
-shall be valid.
+The expression \tcode{*first = new_value} shall be valid.
 
 \pnum
 \effects
-Substitutes elements referred by the iterator
-\tcode{i}
-in the range \range{first}{last}
-with \tcode{new_value},
+Substitutes elements referred by the iterator \tcode{i}
+in the range \range{first}{last} with \tcode{new_value},
 when $E$ is \tcode{true}.
 
 \pnum
@@ -4652,9 +4657,8 @@ when $E$ is \tcode{true}.
 
 \pnum
 \complexity
-Exactly
-\tcode{last - first}
-applications of the corresponding predicate and any projection.
+Exactly \tcode{last - first} applications
+of the corresponding predicate and any projection.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{replace_copy}}%
@@ -4733,46 +4737,34 @@ Let $E$ be
 
 \pnum
 \requires
-The results of the expressions
-\tcode{*first}
-and
-\tcode{new_value}
-shall be writable\iref{iterator.requirements.general} to the
-\tcode{result}
-output iterator.
-The ranges
-\range{first}{last}
-and
-\range{result}{result + (last - first)}
+The results of the expressions \tcode{*first} and \tcode{new_value}
+shall be writable\iref{iterator.requirements.general}
+to the \tcode{result} output iterator.
+The ranges \range{first}{last} and \range{result}{result + (last - first)}
 shall not overlap.
 
 \pnum
 \effects
-Assigns to every iterator
-\tcode{i}
-in the
-range
-\range{result}{result + (last - first)}
-either
-\tcode{new_value}
-or
-\tcode{*\brk(first + (i - result))}
+Assigns to every iterator \tcode{i}
+in the range \range{result}{result + (last - first)}
+either \tcode{new_value} or \tcode{*\brk(first + (i - result))}
 depending on whether $E$ holds.
 
 \pnum
 \returns
 \begin{itemize}
-\item \tcode{result + (last - first)} for the overloads in
-  namespace \tcode{std}, or
-\item \tcode{\{last, result + (last - first)\}} for the overloads in
-  namespace \tcode{ranges}.
+\item
+  \tcode{result + (last - first)}
+  for the overloads in namespace \tcode{std}, or
+\item
+  \tcode{\{last, result + (last - first)\}}
+  for the overloads in namespace \tcode{ranges}.
 \end{itemize}
 
 \pnum
 \complexity
-Exactly
-\tcode{last - first}
-applications of the corresponding predicate and any projection.
+Exactly \tcode{last - first} applications
+of the corresponding predicate and any projection.
 \end{itemdescr}
 
 \rSec2[alg.fill]{Fill}
@@ -4810,18 +4802,19 @@ Let $N$ be $\max(0, \tcode{n})$ for the \tcode{fill_n} algorithms, and
 
 \pnum
 \requires
-The expression
-\tcode{value}
-shall be writable\iref{iterator.requirements.general} to the output iterator. The type
-\tcode{Size}
-shall be convertible to an integral type~(\ref{conv.integral}, \ref{class.conv}).
+The expression \tcode{value}
+shall be writable\iref{iterator.requirements.general} to the output iterator.
+The type \tcode{Size} shall be convertible
+to an integral type~(\ref{conv.integral}, \ref{class.conv}).
 
 \pnum
 \effects
-Assigns \tcode{value} through all the iterators in the range \range{first}{first + $N$}.
+Assigns \tcode{value}
+through all the iterators in the range \range{first}{first + $N$}.
 
 \pnum
-\returns \tcode{first + $N$}.
+\returns
+\tcode{first + $N$}.
 
 \pnum
 \complexity
@@ -4867,8 +4860,8 @@ Let $N$ be $\max(0, \tcode{n})$ for the \tcode{generate_n} algorithms, and
 
 \pnum
 \requires
-\tcode{Size}
-shall be convertible to an integral type~(\ref{conv.integral}, \ref{class.conv}).
+\tcode{Size} shall be convertible
+to an integral type~(\ref{conv.integral}, \ref{class.conv}).
 
 \pnum
 \effects
@@ -4937,37 +4930,35 @@ Let $E$ be
 
 \pnum
 \requires
-For the algorithms in namespace \tcode{std}, the type of
-\tcode{*first}
-shall meet the \oldconcept{MoveAssignable}
-requirements (\tref{moveassignable}).
+For the algorithms in namespace \tcode{std},
+the type of \tcode{*first}
+shall meet the \oldconcept{MoveAssignable} requirements (\tref{moveassignable}).
 
 \pnum
 \effects
-Eliminates all the elements referred to by iterator
-\tcode{i}
-in the range \range{first}{last}
-for which $E$ holds.
+Eliminates all the elements referred to by iterator \tcode{i}
+in the range \range{first}{last} for which $E$ holds.
 
 \pnum
 \returns
 The end of the resulting range.
 
 \pnum
-\remarks Stable\iref{algorithm.stable}.
+\remarks
+Stable\iref{algorithm.stable}.
 
 \pnum
 \complexity
-Exactly
-\tcode{last - first}
-applications of the corresponding predicate and any projection.
+Exactly \tcode{last - first} applications
+of the corresponding predicate and any projection.
 
 \pnum
 \begin{note}
-Each element in the range \range{ret}{last}, where \tcode{ret} is
-the returned value, has a valid but unspecified state, because the algorithms
-can eliminate elements by moving from elements that were originally
-in that range.
+Each element in the range \range{ret}{last},
+where \tcode{ret} is the returned value,
+has a valid but unspecified state,
+because the algorithms can eliminate elements
+by moving from elements that were originally in that range.
 \end{note}
 \end{itemdescr}
 
@@ -5032,28 +5023,24 @@ Let $E$ be
 \end{itemize}
 
 \pnum
-Let $N$ be the number of elements in \range{first}{last} for which $E$ is \tcode{false}.
+Let $N$ be the number of elements in \range{first}{last}
+for which $E$ is \tcode{false}.
 
 \pnum
 \requires
-The ranges
-\range{first}{last}
-and
-\range{result}{result + (last - first)}
+The ranges \range{first}{last} and \range{result}{result + (last - first)}
 shall not overlap. The expression \tcode{*result = *first} shall be valid.
 \begin{note}
-For the overloads with an \tcode{ExecutionPolicy}, there may be a performance
-cost if \tcode{iterator_traits<ForwardIterator1>::value_type} does not meet the
-\oldconcept{\-Move\-Constructible} (\tref{moveconstructible}) requirements.
+For the overloads with an \tcode{ExecutionPolicy},
+there may be a performance cost
+if \tcode{iterator_traits<ForwardIterator1>::value_type} does not meet
+the \oldconcept{\-Move\-Constructible} (\tref{moveconstructible}) requirements.
 \end{note}
 
 \pnum
 \effects
-Copies all the elements referred to by the iterator
-\tcode{i}
-in the range
-\range{first}{last}
-for which $E$ is \tcode{false}.
+Copies all the elements referred to by the iterator \tcode{i}
+in the range \range{first}{last} for which $E$ is \tcode{false}.
 
 \pnum
 \returns
@@ -5064,12 +5051,12 @@ for which $E$ is \tcode{false}.
 
 \pnum
 \complexity
-Exactly
-\tcode{last - first}
-applications of the corresponding predicate and any projection.
+Exactly \tcode{last - first} applications
+of the corresponding predicate and any projection.
 
 \pnum
-\remarks Stable\iref{algorithm.stable}.
+\remarks
+Stable\iref{algorithm.stable}.
 \end{itemdescr}
 
 \rSec2[alg.unique]{Unique}
@@ -5104,13 +5091,16 @@ namespace ranges {
 
 \begin{itemdescr}
 \pnum
-Let \tcode{pred} be \tcode{equal_to\{\}} for the overloads with no
-parameter \tcode{pred}, and let $E$ be
+Let \tcode{pred} be \tcode{equal_to\{\}}
+for the overloads with no parameter \tcode{pred}, and
+let $E$ be
 \begin{itemize}
 \setlength{\emergencystretch}{1em}
-\item \tcode{bool(pred(*(i - 1), *i))}
+\item
+  \tcode{bool(pred(*(i - 1), *i))}
   for the overloads in namespace \tcode{std}, or
-\item \tcode{bool(invoke(comp, invoke(proj, *(i - 1)), invoke(proj, *i)))}
+\item
+  \tcode{bool(invoke(comp, invoke(proj, *(i - 1)), invoke(proj, *i)))}
   for the overloads in namespace \tcode{ranges}.
 \end{itemize}
 
@@ -5118,16 +5108,14 @@ parameter \tcode{pred}, and let $E$ be
 \requires
 For the overloads in namepace \tcode{std},
 \tcode{pred} shall be an equivalence relation and
-the type of \tcode{*first} shall meet the
-\oldconcept{MoveAssignable} requirements (\tref{moveassignable}).
+the type of \tcode{*first} shall meet
+the \oldconcept{MoveAssignable} requirements (\tref{moveassignable}).
 
 \pnum
 \effects
-For a nonempty range, eliminates all but the first element from every
-consecutive group of equivalent elements referred to by the iterator
-\tcode{i}
-in the range
-\range{first + 1}{last}
+For a nonempty range, eliminates all but the first element
+from every consecutive group of equivalent elements referred to
+by the iterator \tcode{i} in the range \range{first + 1}{last}
 for which $E$ is \tcode{true}.
 
 \pnum
@@ -5136,10 +5124,9 @@ The end of the resulting range.
 
 \pnum
 \complexity
-For nonempty ranges, exactly
-\tcode{(last - first) - 1}
-applications of the corresponding predicate
-and no more than twice as many applications of any projection.
+For nonempty ranges, exactly \tcode{(last - first) - 1} applications
+of the corresponding predicate and
+no more than twice as many applications of any projection.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{unique_copy}}%
@@ -5188,13 +5175,16 @@ namespace ranges {
 
 \begin{itemdescr}
 \pnum
-Let \tcode{pred} be \tcode{equal_to\{\}} for the overloads in
-namespace \tcode{std} with no parameter \tcode{pred}, and let $E$ be
+Let \tcode{pred} be \tcode{equal_to\{\}} for the overloads
+in namespace \tcode{std} with no parameter \tcode{pred}, and
+let $E$ be
 \begin{itemize}
 \setlength{\emergencystretch}{1em}
-\item \tcode{bool(pred(*i, *(i - 1)))}
+\item
+  \tcode{bool(pred(*i, *(i - 1)))}
   for the overloads in namespace \tcode{std}, or
-\item \tcode{bool(invoke(comp, invoke(proj, *i), invoke(proj, *(i - 1))))}
+\item
+  \tcode{bool(invoke(comp, invoke(proj, *i), invoke(proj, *(i - 1))))}
   for the overloads in namespace \tcode{ranges}.
 \end{itemize}
 
@@ -5202,48 +5192,42 @@ namespace \tcode{std} with no parameter \tcode{pred}, and let $E$ be
 \requires
 \begin{itemize}
 \item
-The ranges
-\range{first}{last}
-and
-\range{result}{result+(last-first)}
-shall not overlap.
-
+  The ranges \range{first}{last} and \range{result}{result+(last-first)}
+  shall not overlap.
 \item
-For the overloads in namespace \tcode{std}:
-\begin{itemize}
-\item
-The comparison function shall be an equivalence relation.
-
-\item
-The expression
-\tcode{*result = *first}
-shall be valid.
-
-\item
-For the overloads with no \tcode{ExecutionPolicy},
-let \tcode{T} be the value type of \tcode{InputIterator}.
-If \tcode{InputIterator} meets the \oldconcept{ForwardIterator} requirements,
-then there are no additional requirements for \tcode{T}.
-Otherwise, if \tcode{OutputIterator} meets the \oldconcept{ForwardIterator}
-requirements and its value type is the same as \tcode{T},
-then \tcode{T} shall meet the \oldconcept{CopyAssignable} (\tref{copyassignable}) requirements.
-Otherwise, \tcode{T} shall meet both the
-\oldconcept{CopyConstructible} (\tref{copyconstructible}) and \oldconcept{CopyAssignable} requirements.
-\begin{note}
-For the overloads with an \tcode{ExecutionPolicy}, there may be a performance
-cost if the value type of \tcode{ForwardIterator1} dos not meet both the
-\oldconcept{CopyConstructible} and \oldconcept{CopyAssignable} requirements.
-\end{note}
-\end{itemize}
+  For the overloads in namespace \tcode{std}:
+  \begin{itemize}
+  \item
+    The comparison function shall be an equivalence relation.
+  \item
+    The expression \tcode{*result = *first} shall be valid.
+  \item
+    For the overloads with no \tcode{ExecutionPolicy},
+    let \tcode{T} be the value type of \tcode{InputIterator}.
+    If \tcode{InputIterator} meets
+    the \oldconcept{ForwardIterator} requirements,
+    then there are no additional requirements for \tcode{T}.
+    Otherwise, if \tcode{OutputIterator} meets
+    the \oldconcept{ForwardIterator} requirements and
+    its value type is the same as \tcode{T},
+    then \tcode{T} shall meet
+    the \oldconcept{CopyAssignable} (\tref{copyassignable}) requirements.
+    Otherwise, \tcode{T} shall meet both
+    the \oldconcept{CopyConstructible} (\tref{copyconstructible}) and
+    \oldconcept{CopyAssignable} requirements.
+    \begin{note}
+    For the overloads with an \tcode{ExecutionPolicy},
+    there may be a performance cost
+    if the value type of \tcode{ForwardIterator1} does not meet both the
+    \oldconcept{CopyConstructible} and \oldconcept{CopyAssignable} requirements.
+    \end{note}
+  \end{itemize}
 \end{itemize}
 
 \pnum
 \effects
-Copies only the first element from every consecutive group of equal elements referred to by
-the iterator
-\tcode{i}
-in the range
-\range{first}{last}
+Copies only the first element from every consecutive group of equal elements
+referred to by the iterator \tcode{i} in the range \range{first}{last}
 for which $E$ holds.
 
 \pnum
@@ -5255,10 +5239,9 @@ for which $E$ holds.
 
 \pnum
 \complexity
-Exactly
-\tcode{last - first - 1}
-applications of the corresponding predicate
-and no more than twice as many applications of any projectionh.
+Exactly \tcode{last - first - 1} applications
+of the corresponding predicate
+and no more than twice as many applications of any projection.
 \end{itemdescr}
 
 \rSec2[alg.reverse]{Reverse}
@@ -5285,18 +5268,15 @@ namespace ranges {
 \pnum
 \requires
 For the overloads in namespace \tcode{std},
-\tcode{BidirectionalIterator} shall meet the
-\oldconcept{Value\-Swappable} requirements\iref{swappable.requirements}.
+\tcode{BidirectionalIterator} shall meet
+the \oldconcept{Value\-Swappable} requirements\iref{swappable.requirements}.
 
 \pnum
 \effects
-For each non-negative integer
-\tcode{i < (last - first) / 2},
-applies
-\tcode{std::iter_swap}, or
+For each non-negative integer \tcode{i < (last - first) / 2},
+applies \tcode{std::iter_swap}, or
 \tcode{ranges::\brk{}iter_swap} for the overloads in namespace \tcode{ranges},
-to all pairs of iterators
-\tcode{first + i, (last - i) - 1}.
+to all pairs of iterators \tcode{first + i, (last - i) - 1}.
 
 \pnum
 \returns
@@ -5304,9 +5284,7 @@ to all pairs of iterators
 
 \pnum
 \complexity
-Exactly
-\tcode{(last - first)/2}
-swaps.
+Exactly \tcode{(last - first)/2} swaps.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{reverse_copy}}%
@@ -5339,21 +5317,13 @@ Let $N$ be \tcode{last - first}.
 
 \pnum
 \requires
-The ranges
-\range{first}{last}
-and
-\range{result}{result + $N$}
+The ranges \range{first}{last} and \range{result}{result + $N$}
 shall not overlap.
 
 \pnum
 \effects
-Copies the range
-\range{first}{last}
-to the range
-\range{result}{result + $N$}
-such that
-for every non-negative integer
-\tcode{i < $N$}
+Copies the range \range{first}{last} to the range \range{result}{result + $N$}
+such that for every non-negative integer \tcode{i < $N$}
 the following assignment takes place:
 \tcode{*(result + $N$ - 1 - i) = *(first + i)}.
 
@@ -5361,10 +5331,9 @@ the following assignment takes place:
 \returns
 \begin{itemize}
 \item
-\tcode{result + $N$} for the overloads in namespace \tcode{std}, or
+  \tcode{result + $N$} for the overloads in namespace \tcode{std}, or
 \item
-\tcode{\{last, result + $N$\}} for the overloads
-  in namespace \tcode{ranges}.
+  \tcode{\{last, result + $N$\}} for the overloads in namespace \tcode{ranges}.
 \end{itemize}
 
 \pnum
@@ -5393,25 +5362,19 @@ namespace ranges {
 \begin{itemdescr}
 \pnum
 \requires
-\range{first}{middle}
-and
-\range{middle}{last}
-shall be valid ranges.
+\range{first}{middle} and \range{middle}{last} shall be valid ranges.
 For the overloads in namespace \tcode{std},
-\tcode{ForwardIterator} shall meet the
-\oldconcept{ValueSwappable} requirements\iref{swappable.requirements}, and
+\tcode{ForwardIterator} shall meet
+the \oldconcept{ValueSwappable} requirements\iref{swappable.requirements}, and
 the type of \tcode{*first} shall meet
 the \oldconcept{MoveConstructible} (\tref{moveconstructible}) and
 \oldconcept{MoveAssignable} (\tref{moveassignable}) requirements.
 
 \pnum
 \effects
-For each non-negative integer
-\tcode{i < (last - first)},
-places the element from the position
-\tcode{first + i}
-into position
-\tcode{first + (i + (last - middle)) \% (last - first)}.
+For each non-negative integer \tcode{i < (last - first)},
+places the element from the position \tcode{first + i}
+into position \tcode{first + (i + (last - middle)) \% (last - first)}.
 \begin{note}
 This is a left rotate.
 \end{note}
@@ -5419,17 +5382,17 @@ This is a left rotate.
 \pnum
 \returns
 \begin{itemize}
-\item \tcode{first + (last - middle)} for the overloads in
-  namespace \tcode{std}, or
-\item \tcode{\{first + (last - middle), last\}} for the overload in
-  namespace \tcode{ranges}.
+\item
+  \tcode{first + (last - middle)}
+  for the overloads in namespace \tcode{std}, or
+\item
+  \tcode{\{first + (last - middle), last\}}
+  for the overload in namespace \tcode{ranges}.
 \end{itemize}
 
 \pnum
 \complexity
-At most
-\tcode{last - first}
-swaps.
+At most \tcode{last - first} swaps.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -5442,7 +5405,8 @@ namespace ranges {
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \tcode{return ranges::rotate(ranges::begin(r), middle, ranges::end(r));}
 \end{itemdescr}
 
@@ -5472,36 +5436,24 @@ Let $N$ be \tcode{last - first}.
 
 \pnum
 \requires
-\range{first}{middle}
-and
-\range{middle}{last}
-shall be valid ranges.
-The ranges
-\range{first}{last}
-and
-\range{result}{result + $N$}
+\range{first}{middle} and \range{middle}{last} shall be valid ranges.
+The ranges \range{first}{last} and \range{result}{result + $N$}
 shall not overlap.
 
 \pnum
 \effects
-Copies the range
-\range{first}{last}
-to the range
-\range{result}{result + $N$}
-such that for each non-negative integer
-$i < N$
+Copies the range \range{first}{last} to the range \range{result}{result + $N$}
+such that for each non-negative integer $i < N$
 the following assignment takes place:
-\tcode{*(result + $i$) =  *(first +
-($i$ + (middle - first)) \% $N$)}.
+\tcode{*(result + $i$) =  *(first + ($i$ + (middle - first)) \% $N$)}.
 
 \pnum
 \returns
 \begin{itemize}
 \item
-\tcode{result + $N$} for the overloads in namespace \tcode{std}, or
+  \tcode{result + $N$} for the overloads in namespace \tcode{std}, or
 \item
-\tcode{\{last, result + $N$\}} for the overload in
-  namespace \tcode{ranges}.
+  \tcode{\{last, result + $N$\}} for the overload in namespace \tcode{ranges}.
 \end{itemize}
 
 \pnum
@@ -5520,7 +5472,8 @@ namespace ranges {
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return ranges::rotate_copy(ranges::begin(r), middle, ranges::end(r), result);
 \end{codeblock}
@@ -5542,22 +5495,27 @@ template<class PopulationIterator, class SampleIterator,
 \requires
 \begin{itemize}
 \item
-\tcode{PopulationIterator} shall satisfy the \oldconcept{InputIterator} requirements\iref{input.iterators}.
+  \tcode{PopulationIterator} shall satisfy
+  the \oldconcept{InputIterator} requirements\iref{input.iterators}.
 \item
-\tcode{SampleIterator} shall satisfy the \oldconcept{OutputIterator} requirements\iref{output.iterators}.
+  \tcode{SampleIterator} shall satisfy
+  the \oldconcept{OutputIterator} requirements\iref{output.iterators}.
 \item
-\tcode{SampleIterator} shall satisfy the \oldconcept{RandomAccessIterator} requirements\iref{random.access.iterators}
-unless \tcode{Pop\-ulat\-ion\-Iter\-ator} satisfies the \oldconcept{ForwardIterator} requirements\iref{forward.iterators}.
+  \tcode{SampleIterator} shall satisfy
+  the \oldconcept{RandomAccessIterator} requirements\iref{random.access.iterators}
+  unless \tcode{Pop\-ulat\-ion\-Iter\-ator} satisfies
+  the \oldconcept{ForwardIterator} requirements\iref{forward.iterators}.
 \item
-\tcode{PopulationIterator}'s value type shall be writable\iref{iterator.requirements.general} to \tcode{out}.
+  \tcode{PopulationIterator}'s value type shall be
+  writable\iref{iterator.requirements.general} to \tcode{out}.
 \item
-\tcode{Distance} shall be an integer type.
+  \tcode{Distance} shall be an integer type.
 \item
-\tcode{remove_reference_t<UniformRandomBitGenerator>}
-shall satisfy the requirements of a uniform random bit generator type\iref{rand.req.urng}
-whose return type is convertible to \tcode{Distance}.
+  \tcode{remove_reference_t<UniformRandomBitGenerator>} shall satisfy
+  the requirements of a uniform random bit generator type\iref{rand.req.urng}
+  whose return type is convertible to \tcode{Distance}.
 \item
-\tcode{out} shall not be in the range \range{first}{last}.
+  \tcode{out} shall not be in the range \range{first}{last}.
 \end{itemize}
 
 \pnum
@@ -5582,12 +5540,12 @@ The end of the resulting sample range.
 \remarks
 \begin{itemize}
 \item
-Stable if and only if \tcode{PopulationIterator} satisfies the
-\oldconcept{ForwardIterator} requirements.
+  Stable if and only if \tcode{PopulationIterator} satisfies
+  the \oldconcept{ForwardIterator} requirements.
 \item
-To the extent that the implementation of this function makes use of
-random numbers, the object \tcode{g} shall serve as the
-implementation's source of randomness.
+  To the extent that the implementation of this function makes use
+  of random numbers, the object \tcode{g} shall serve as
+  the implementation's source of randomness.
 \end{itemize}
 \end{itemdescr}
 
@@ -5618,20 +5576,18 @@ namespace ranges {
 For the overload in namespace \tcode{std}:
 \begin{itemize}
 \item
-\tcode{RandomAccessIterator} shall meet the
-\oldconcept{ValueSwappable} requirements\iref{swappable.requirements}.
+  \tcode{RandomAccessIterator} shall meet
+  the \oldconcept{ValueSwappable} requirements\iref{swappable.requirements}.
 \item
-The type
-\tcode{remove_reference_t<UniformRandomBitGenerator>}
-shall meet the
-uniform random bit generator\iref{rand.req.urng} requirements.
+  The type \tcode{remove_reference_t<UniformRandomBitGenerator>} shall meet
+  the uniform random bit generator\iref{rand.req.urng} requirements.
 \end{itemize}
 
 \pnum
 \effects
-Permutes the elements in the range
-\range{first}{last}
-such that each possible permutation of those elements has equal probability of appearance.
+Permutes the elements in the range \range{first}{last}
+such that each possible permutation of those elements
+has equal probability of appearance.
 
 \pnum
 \returns
@@ -5639,16 +5595,13 @@ such that each possible permutation of those elements has equal probability of a
 
 \pnum
 \complexity
-Exactly
-\tcode{(last - first) - 1}
-swaps.
+Exactly \tcode{(last - first) - 1} swaps.
 
 \pnum
 \remarks
-To the extent that the implementation of this function makes use of random
-numbers, the object referenced by \tcode{g} shall serve as the implementation's source of
-randomness.
-
+To the extent that the implementation of this function makes use
+of random numbers, the object referenced by \tcode{g} shall serve as
+the implementation's source of randomness.
 \end{itemdescr}
 
 \rSec2[alg.shift]{Shift}
@@ -5739,129 +5692,84 @@ At most \tcode{(last - first) - n} assignments or swaps.
 
 \pnum
 The operations in~\ref{alg.sorting} defined directly in namespace \tcode{std}
-have two versions: one that takes a function object of type
-\tcode{Compare}
-and one that uses an
-\tcode{operator<}.
+have two versions:
+one that takes a function object of type \tcode{Compare} and
+one that uses an \tcode{operator<}.
 
 \pnum
-\tcode{Compare}
-is a function object
-type\iref{function.objects}
-that meets the requirements for a template parameter named
-\tcode{BinaryPredicate}~\iref{algorithms.requirements}.
-The return value of the function call operation applied to
-an object of type \tcode{Compare}, when contextually converted to
-\tcode{bool}\iref{conv},
-yields \tcode{true} if the first argument of the call
-is less than the second, and
-\tcode{false}
-otherwise.
-\tcode{Compare comp}
-is used throughout for algorithms assuming an ordering relation.
+\tcode{Compare} is a function object type\iref{function.objects}
+that meets the requirements for a template parameter
+named \tcode{BinaryPredicate}~\iref{algorithms.requirements}.
+The return value of the function call operation
+applied to an object of type \tcode{Compare},
+when contextually converted to \tcode{bool}\iref{conv},
+yields \tcode{true}
+if the first argument of the call is less than the second, and
+\tcode{false} otherwise.
+\tcode{Compare comp} is used throughout
+for algorithms assuming an ordering relation.
 
 \pnum
-For all algorithms that take
-\tcode{Compare},
-there is a version that uses
-\tcode{operator<}
-instead.
-That is,
-\tcode{comp(*i, *j) != false}
-defaults to
-\tcode{*i < *j != false}.
+For all algorithms that take \tcode{Compare},
+there is a version that uses \tcode{operator<} instead.
+That is, \tcode{comp(*i, *j) != false} defaults to \tcode{*i < *j != false}.
 For algorithms other than those described in~\ref{alg.binary.search},
 \tcode{comp} shall induce a strict weak ordering on the values.
 
 \pnum
-The term
-\term{strict}
-refers to the
-requirement of an irreflexive relation (\tcode{!comp(x, x)} for all \tcode{x}),
-and the term
-\term{weak}
-to requirements that are not as strong as
-those for a total ordering,
-but stronger than those for a partial
-ordering.
-If we define
-\tcode{equiv(a, b)}
-as
-\tcode{!comp(a, b) \&\& !comp(b, a)},
-then the requirements are that
-\tcode{comp}
-and
-\tcode{equiv}
-both be transitive  relations:
+The term \term{strict} refers to the requirement
+of an irreflexive relation (\tcode{!comp(x, x)} for all \tcode{x}),
+and the term \term{weak} to requirements
+that are not as strong as those for a total ordering,
+but stronger than those for a partial ordering.
+If we define \tcode{equiv(a, b)} as \tcode{!comp(a, b) \&\& !comp(b, a)},
+then the requirements are that \tcode{comp} and \tcode{equiv}
+both be transitive relations:
 
 \begin{itemize}
-\item
-\tcode{comp(a, b) \&\& comp(b, c)}
-implies
-\tcode{comp(a, c)}
-\item
-\tcode{equiv(a, b) \&\& equiv(b, c)}
-implies
-\tcode{equiv(a, c)}
+\item \tcode{comp(a, b) \&\& comp(b, c)} implies \tcode{comp(a, c)}
+\item \tcode{equiv(a, b) \&\& equiv(b, c)} implies \tcode{equiv(a, c)}
 \end{itemize}
 \begin{note}
 Under these conditions, it can be shown that
 \begin{itemize}
 \item
-\tcode{equiv}
-is an equivalence relation,
+  \tcode{equiv} is an equivalence relation,
 \item
-\tcode{comp}
-induces a well-defined relation on the equivalence
-classes determined by
-\tcode{equiv}, and
+  \tcode{comp} induces a well-defined relation
+  on the equivalence classes determined by \tcode{equiv}, and
 \item
-the induced relation is a strict total ordering.
+  the induced relation is a strict total ordering.
 \end{itemize}
 \end{note}
 
 \pnum
-A sequence is
-\term{sorted with respect to a \tcode{comp} and \tcode{proj}}
+A sequence is \term{sorted with respect to a \tcode{comp} and \tcode{proj}}
 for a comparator and projection \tcode{comp} and \tcode{proj}
-if for every iterator
-\tcode{i}
-pointing to the sequence and every non-negative integer
-\tcode{n}
-such that
-\tcode{i + n}
-is a valid iterator pointing to an element of the sequence,
+if for every iterator \tcode{i} pointing to the sequence and
+every non-negative integer \tcode{n}
+such that \tcode{i + n} is a valid iterator
+pointing to an element of the sequence,
 \begin{codeblock}
 bool(invoke(comp, invoke(proj, *(i + n)), invoke(proj, *i)))
 \end{codeblock}
 is \tcode{false}.
 
 \pnum
-A sequence
-\range{start}{finish}
-is
-\term{partitioned with respect to an expression}
-\tcode{f(e)}
-if there exists an integer
-\tcode{n}
-such that for all
-\tcode{0 <= i < (finish - start)},
-\tcode{f(*(start + i))}
-is \tcode{true} if and only if
-\tcode{i < n}.
+A sequence \range{start}{finish} is
+\term{partitioned with respect to an expression} \tcode{f(e)}
+if there exists an integer \tcode{n}
+such that for all \tcode{0 <= i < (finish - start)},
+\tcode{f(*(start + i))} is \tcode{true} if and only if \tcode{i < n}.
 
 \pnum
-In the descriptions of the functions that deal with ordering relationships we frequently use a notion of
-equivalence to describe concepts such as stability.
-The equivalence to which we refer is not necessarily an
-\tcode{operator==},
+In the descriptions of the functions that deal with ordering relationships
+we frequently use a notion of equivalence to describe concepts
+such as stability.
+The equivalence to which we refer is not necessarily an \tcode{operator==},
 but an equivalence relation induced by the strict weak ordering.
-That is, two elements
-\tcode{a}
-and
-\tcode{b}
-are considered equivalent if and only if
-\tcode{!(a < b) \&\& !(b < a)}.
+That is, two elements \tcode{a} and \tcode{b} are considered equivalent
+if and only if \tcode{!(a < b) \&\& !(b < a)}.
 
 \rSec2[alg.sort]{Sorting}
 
@@ -5905,16 +5813,16 @@ for the overloads with no parameters by those names.
 \pnum
 \requires
 For the overloads in namespace \tcode{std},
-\tcode{RandomAccessIterator} shall meet the
-\oldconcept{Value\-Swappable} requirements\iref{swappable.requirements} and
-the type of \tcode{*first} shall meet the
-\oldconcept{MoveConstructible} (\tref{moveconstructible}) and
+\tcode{RandomAccessIterator} shall meet
+the \oldconcept{Value\-Swappable} requirements\iref{swappable.requirements} and
+the type of \tcode{*first} shall meet
+the \oldconcept{MoveConstructible} (\tref{moveconstructible}) and
 \oldconcept{MoveAssignable} (\tref{moveassignable}) requirements.
 
 \pnum
 \effects
-Sorts the elements in the range
-\range{first}{last} with respect to \tcode{comp} and \tcode{proj}.
+Sorts the elements in the range \range{first}{last}
+with respect to \tcode{comp} and \tcode{proj}.
 
 \pnum
 \returns
@@ -5965,10 +5873,10 @@ for the overloads with no parameters by those names.
 \pnum
 \requires
 For the overloads in namespace \tcode{std},
-\tcode{RandomAccessIterator} shall meet the
-\oldconcept{Value\-Swappable} requirements\iref{swappable.requirements} and
-the type of \tcode{*first} shall meet the
-\oldconcept{MoveConstructible} (\tref{moveconstructible}) and
+\tcode{RandomAccessIterator} shall meet
+the \oldconcept{Value\-Swappable} requirements\iref{swappable.requirements} and
+the type of \tcode{*first} shall meet
+the \oldconcept{MoveConstructible} (\tref{moveconstructible}) and
 \oldconcept{MoveAssignable} (\tref{moveassignable}) requirements.
 
 \pnum
@@ -5985,11 +5893,11 @@ with respect to \tcode{comp} and \tcode{proj}.
 Let $N$ be \tcode{last - first}.
 If enough extra memory is available, $N \log(N)$ comparisons.
 Otherwise, at most $N \log^2(N)$ comparisons.
-In either case, twice as many projections as
-the number of comparisons.
+In either case, twice as many projections as the number of comparisons.
 
 \pnum
-\remarks Stable\iref{algorithm.stable}.
+\remarks
+Stable\iref{algorithm.stable}.
 \end{itemdescr}
 
 \rSec3[partial.sort]{\tcode{partial_sort}}
@@ -6037,22 +5945,19 @@ for the overloads with no parameters by those names.
 \requires
 \range{first}{middle} and \range{middle}{last} shall be valid ranges.
 For the overloads in namespace \tcode{std},
-\tcode{RandomAccessIterator} shall meet the
-\oldconcept{ValueSwappable} requirements\iref{swappable.requirements} and
-the type of \tcode{*first} shall meet the
-\oldconcept{MoveConstructible} (\tref{moveconstructible}) and
+\tcode{RandomAccessIterator} shall meet
+the \oldconcept{ValueSwappable} requirements\iref{swappable.requirements} and
+the type of \tcode{*first} shall meet
+the \oldconcept{MoveConstructible} (\tref{moveconstructible}) and
 \oldconcept{MoveAssignable} (\tref{moveassignable}) requirements.
 
 \pnum
 \effects
-Places the first
-\tcode{middle - first}
-elements from the range
-\range{first}{last} as sorted with respect to \tcode{comp} and \tcode{proj}
-into the range
-\range{first}{middle}.
-The rest of the elements in the range
-\range{middle}{last}
+Places the first \tcode{middle - first} elements
+from the range \range{first}{last}
+as sorted with respect to \tcode{comp} and \tcode{proj}
+into the range \range{first}{middle}.
+The rest of the elements in the range \range{middle}{last}
 are placed in an unspecified order.
 \indextext{unspecified}%
 
@@ -6062,9 +5967,8 @@ are placed in an unspecified order.
 
 \pnum
 \complexity
-Approximately
-\tcode{(last - first) * log(middle - first)}
-comparisons, and twice as many projections.
+Approximately \tcode{(last - first) * log(middle - first)} comparisons, and
+twice as many projections.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -6078,7 +5982,8 @@ namespace ranges {
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return ranges::partial_sort(ranges::begin(r), middle, ranges::end(r), comp, proj);
 \end{codeblock}
@@ -6146,10 +6051,10 @@ for the overloads with no parameters by those names.
 \pnum
 \requires
 For the overloads in namespace \tcode{std},
-\tcode{RandomAccessIterator} shall meet the
-\oldconcept{Value\-Swappable} requirements\iref{swappable.requirements},
-the type of \tcode{*result_first} shall meet the
-\oldconcept{MoveConstructible} (\tref{moveconstructible}) and
+\tcode{RandomAccessIterator} shall meet
+the \oldconcept{Value\-Swappable} requirements\iref{swappable.requirements},
+the type of \tcode{*result_first} shall meet
+the \oldconcept{MoveConstructible} (\tref{moveconstructible}) and
 \oldconcept{\-Move\-Assignable} (\tref{moveassignable}) requirements,
 and the expression \tcode{*first}
 shall be writable\iref{iterator.requirements.general} to \tcode{result_first}.
@@ -6162,8 +6067,7 @@ after evaluating the assignment \tcode{*y2 = *b1}, let $E$ be the value of
 \begin{codeblock}
 bool(invoke(comp, invoke(proj1, *a1), invoke(proj2, *y2))).
 \end{codeblock}
-Then, after evaluating the assignment \tcode{*x2 = *a1},
-$E$ is equal to
+Then, after evaluating the assignment \tcode{*x2 = *a1}, $E$ is equal to
 \begin{codeblock}
 bool(invoke(comp, invoke(proj2, *x2), invoke(proj2, *y2))).
 \end{codeblock}
@@ -6175,8 +6079,8 @@ how it is ordered by \tcode{comp} and \tcode{proj1} or \tcode{proj2}.
 \pnum
 \effects
 Places the first $N$ elements
-as sorted with respect to \tcode{comp} and \tcode{proj2} into the range
-\range{result_first}{result_first + $N$}.
+as sorted with respect to \tcode{comp} and \tcode{proj2}
+into the range \range{result_first}{result_first + $N$}.
 
 \pnum
 \returns
@@ -6199,7 +6103,7 @@ template<class ForwardIterator>
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: return \tcode{is_sorted_until(first, last) == last;}
+Equivalent to: \tcode{return is_sorted_until(first, last) == last;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{is_sorted}}%
@@ -6263,7 +6167,8 @@ namespace ranges {
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \tcode{return ranges::is_sorted_until(first, last, comp, proj) == last;}
 \end{itemdescr}
 
@@ -6306,11 +6211,13 @@ for the overloads with no parameters by those names.
 
 \pnum
 \returns
-The last iterator \tcode{i} in \crange{first}{last} for which the
-range \range{first}{i} is sorted with respect to \tcode{comp} and \tcode{proj}.
+The last iterator \tcode{i} in \crange{first}{last}
+for which the range \range{first}{i}
+is sorted with respect to \tcode{comp} and \tcode{proj}.
 
 \pnum
-\complexity Linear.
+\complexity
+Linear.
 \end{itemdescr}
 
 \rSec2[alg.nth.element]{Nth element}
@@ -6352,32 +6259,22 @@ for the overloads with no parameters by those names.
 \requires
 \range{first}{nth} and \range{nth}{last} shall be valid ranges.
 For the overloads in namespace \tcode{std},
-\tcode{RandomAccessIterator} shall meet the
-\oldconcept{ValueSwappable} requirements\iref{swappable.requirements}, and
-the type of \tcode{*first} shall meet the
-\oldconcept{MoveConstructible} (\tref{moveconstructible}) and
+\tcode{RandomAccessIterator} shall meet
+the \oldconcept{ValueSwappable} requirements\iref{swappable.requirements}, and
+the type of \tcode{*first} shall meet
+the \oldconcept{MoveConstructible} (\tref{moveconstructible}) and
 \oldconcept{MoveAssignable} (\tref{moveassignable}) requirements.
 
 \pnum
 \effects
-After
-\tcode{nth_element}
-the element in the position pointed to by \tcode{nth}
-is the element that would be
-in that position
+After \tcode{nth_element} the element in the position pointed to by \tcode{nth}
+is the element that would be in that position
 if the whole range were sorted with respect to \tcode{comp} and \tcode{proj},
 unless \tcode{nth == last}.
-Also for every iterator
-\tcode{i}
-in the range
-\range{first}{nth}
-and every iterator
-\tcode{j}
-in the range
-\range{nth}{last}
+Also for every iterator \tcode{i} in the range \range{first}{nth}
+and every iterator \tcode{j} in the range \range{nth}{last}
 it holds that:
-\tcode{bool(invoke(comp, invoke(proj, *j), invoke(proj, *i)))}
-is \tcode{false}.
+\tcode{bool(invoke(comp, invoke(proj, *j), invoke(proj, *i)))} is \tcode{false}.
 
 \pnum
 \returns
@@ -6401,7 +6298,8 @@ namespace ranges {
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return ranges::nth_element(ranges::begin(r), nth, ranges::end(r), comp, proj);
 \end{codeblock}
@@ -6410,10 +6308,10 @@ return ranges::nth_element(ranges::begin(r), nth, ranges::end(r), comp, proj);
 \rSec2[alg.binary.search]{Binary search}
 
 \pnum
-All of the algorithms in this subclause are versions of binary search
-and assume that the sequence being searched is partitioned with respect to
-an expression formed by binding the search key to an argument of the
-comparison function.
+All of the algorithms in this subclause are versions of binary search and
+assume that the sequence being searched
+is partitioned with respect to an expression
+formed by binding the search key to an argument of the comparison function.
 They work on non-random access iterators minimizing the number of comparisons,
 which will be logarithmic for all types of iterators.
 They are especially appropriate for random access iterators,
@@ -6456,30 +6354,19 @@ for overloads with no parameters by those names.
 
 \pnum
 \requires
-The elements
-\tcode{e}
-of
-\range{first}{last}
+The elements \tcode{e} of \range{first}{last}
 shall be partitioned with respect to the expression
 \tcode{bool(invoke(comp, invoke(proj, e), value))}.
 
 \pnum
 \returns
-The furthermost iterator
-\tcode{i}
-in the range
-\crange{first}{last}
-such that for every iterator
-\tcode{j}
-in the range
-\range{first}{i},
+The furthermost iterator \tcode{i} in the range \crange{first}{last}
+such that for every iterator \tcode{j} in the range \range{first}{i},
 \tcode{bool(invoke(comp, invoke(proj, *j), value))} is \tcode{true}.
 
 \pnum
 \complexity
-At most
-$\log_2(\tcode{last - first}) + \bigoh{1}$
-comparisons and projections.
+At most $\log_2(\tcode{last - first}) + \bigoh{1}$ comparisons and projections.
 \end{itemdescr}
 
 \rSec3[upper.bound]{\tcode{upper_bound}}
@@ -6516,30 +6403,19 @@ for overloads with no parameters by those names.
 
 \pnum
 \requires
-The elements
-\tcode{e}
-of
-\range{first}{last}
+The elements \tcode{e} of \range{first}{last}
 shall be partitioned with respect to the expression
 \tcode{!bool(invoke(comp, value, invoke(proj, e)))}.
 
 \pnum
 \returns
-The furthermost iterator
-\tcode{i}
-in the range
-\crange{first}{last}
-such that for every iterator
-\tcode{j}
-in the range
-\range{first}{i},
+The furthermost iterator \tcode{i} in the range \crange{first}{last}
+such that for every iterator \tcode{j} in the range \range{first}{i},
 \tcode{!bool(invoke(comp, value, invoke(proj, *j)))} is \tcode{true}.
 
 \pnum
 \complexity
-At most
-$\log_2(\tcode{last - first}) + \bigoh{1}$
-comparisons and projections.
+At most $\log_2(\tcode{last - first}) + \bigoh{1}$ comparisons and projections.
 \end{itemdescr}
 
 \rSec3[equal.range]{\tcode{equal_range}}
@@ -6578,18 +6454,11 @@ for overloads with no parameters by those names.
 
 \pnum
 \requires
-The elements
-\tcode{e}
-of
-\range{first}{last}
+The elements \tcode{e} of \range{first}{last}
 shall be partitioned with respect to the expressions
-\tcode{bool(invoke(comp, invoke(proj, e), value))}
-and
+\tcode{bool(invoke(comp, invoke(proj, e), value))} and
 \tcode{!bool(invoke(comp, value, invoke(proj, e)))}.
-Also, for all elements
-\tcode{e}
-of
-\tcode{[first, last)},
+Also, for all elements \tcode{e} of \tcode{[first, last)},
 \tcode{bool(comp(e, value))} shall imply \tcode{!bool(comp(\brk{}value, e))}
 for the overloads in namespace \tcode{std}.
 
@@ -6611,8 +6480,7 @@ For the overloads in namespace \tcode{ranges}:
 \pnum
 \complexity
 At most
-$2 * \log_2(\tcode{last - first}) + \bigoh{1}$
-comparisons and projections.
+$2 * \log_2(\tcode{last - first}) + \bigoh{1}$ comparisons and projections.
 \end{itemdescr}
 
 \rSec3[binary.search]{\tcode{binary_search}}
@@ -6650,36 +6518,25 @@ for overloads with no parameters by those names.
 
 \pnum
 \requires
-The elements
-\tcode{e}
-of
-\range{first}{last}
+The elements \tcode{e} of \range{first}{last}
 shall be partitioned with respect to the expressions
 \tcode{bool(invoke(comp, invoke(proj, e), value))} and
 \tcode{!bool(invoke(comp, value, invoke(proj, e)))}.
-Also, for all elements
-\tcode{e}
-of
-\tcode{[first, last)},
-\tcode{bool(comp(e, value))}
-shall imply
-\tcode{!bool(comp(\brk{}value, e))}
+Also, for all elements \tcode{e} of \tcode{[first, last)},
+\tcode{bool(comp(e, value))} shall imply \tcode{!bool(comp(\brk{}value, e))}
 for the overloads in namespace \tcode{std}.
 
 \pnum
 \returns
-\tcode{true}
-if and only if for some iterator
-\tcode{i}
-in the range
-\range{first}{last},
-\tcode{!bool(invoke(comp, invoke(proj, *i), value)) \&\& !bool(invoke(comp, value, invoke(proj, *i)))} is \tcode{true}.
+\tcode{true} if and only if
+for some iterator \tcode{i} in the range \range{first}{last},
+\tcode{!bool(invoke(comp, invoke(proj, *i), value)) \&\&
+!bool(invoke(comp, value, invoke(proj, *i)))}
+is \tcode{true}.
 
 \pnum
 \complexity
-At most
-$\log_2(\tcode{last - first}) + \bigoh{1}$
-comparisons and projections.
+At most $\log_2(\tcode{last - first}) + \bigoh{1}$ comparisons and projections.
 \end{itemdescr}
 
 \rSec2[alg.partitions]{Partitions}
@@ -6704,18 +6561,19 @@ namespace ranges {
 
 \begin{itemdescr}
 \pnum
-Let \tcode{proj} be \tcode{identity\{\}} for
-the overloads with no parameter named \tcode{proj}.
+Let \tcode{proj} be \tcode{identity\{\}}
+for the overloads with no parameter named \tcode{proj}.
 
 \pnum
-\returns \tcode{true} if and only if
-the elements \tcode{e} of
-\range{first}{last} are partitioned with respect to the expression
+\returns
+\tcode{true} if and only if the elements \tcode{e} of \range{first}{last}
+are partitioned with respect to the expression
 \tcode{bool(invoke(pred, invoke(proj, e)))}.
 
 \pnum
-\complexity Linear. At most \tcode{last - first} applications of \tcode{pred}
-and \tcode{proj}.
+\complexity
+Linear.
+At most \tcode{last - first} applications of \tcode{pred} and \tcode{proj}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{partition}}%
@@ -6743,38 +6601,42 @@ namespace ranges {
 
 \begin{itemdescr}
 \pnum
-Let \tcode{proj} be \tcode{identity\{\}} for the overloads
-with no parameter named \tcode{proj}
+Let \tcode{proj} be \tcode{identity\{\}}
+for the overloads with no parameter named \tcode{proj}
 and let $E(x)$ be \tcode{bool(invoke(\brk{}pred, invoke(proj, $x$)))}.
 
 \pnum
 \requires
 For the overloads in namespace \tcode{std},
-\tcode{ForwardIterator} shall meet the
-\oldconcept{ValueSwappable} requirements\iref{swappable.requirements}.
+\tcode{ForwardIterator} shall meet
+the \oldconcept{ValueSwappable} requirements\iref{swappable.requirements}.
 
 \pnum
-\effects Places all the elements \tcode{e} in \range{first}{last}
+\effects
+Places all the elements \tcode{e} in \range{first}{last}
 that satisfy $E(\tcode{e})$ before all the elements that do not.
 
 \pnum
-\returns An iterator \tcode{i} such that $E(\tcode{*j})$ is \tcode{true}
-for every iterator \tcode{j} in
-\range{first}{i} and \tcode{false} for every iterator \tcode{j} in
-\range{i}{last}.
+\returns
+An iterator \tcode{i} such that $E(\tcode{*j})$ is
+\tcode{true} for every iterator \tcode{j} in \range{first}{i} and
+\tcode{false} for every iterator \tcode{j} in \range{i}{last}.
 
 \pnum
 \complexity Let $N = \tcode{last - first}$:
 \begin{itemize}
-\item For the overload with no \tcode{ExecutionPolicy}, exactly $N$ applications
-of the predicate and projection.  At most $N / 2$ swaps if the type of \tcode{first} meets the
-\oldconcept{BidirectionalIterator} requirements
-for the overloads in namespace \tcode{std} or
-models \libconcept{BidirectionalIterator} for the
-overloads in namespace \tcode{ranges},
-and at most $N$ swaps otherwise.
-\item For the overload with an \tcode{ExecutionPolicy},
-\bigoh{N \log N} swaps and \bigoh{N} applications of the predicate.
+\item
+  For the overload with no \tcode{ExecutionPolicy},
+  exactly $N$ applications of the predicate and projection.
+  At most $N / 2$ swaps if the type of \tcode{first} meets
+  the \oldconcept{BidirectionalIterator} requirements
+  for the overloads in namespace \tcode{std} or
+  models \libconcept{BidirectionalIterator}
+  for the overloads in namespace \tcode{ranges},
+  and at most $N$ swaps otherwise.
+\item
+  For the overload with an \tcode{ExecutionPolicy},
+  \bigoh{N \log N} swaps and \bigoh{N} applications of the predicate.
 \end{itemize}
 
 \end{itemdescr}
@@ -6803,52 +6665,44 @@ namespace ranges {
 
 \begin{itemdescr}
 \pnum
-\pnum
-Let \tcode{proj} be \tcode{identity\{\}} for the overloads
-with no parameter named \tcode{proj}
+Let \tcode{proj} be \tcode{identity\{\}}
+for the overloads with no parameter named \tcode{proj}
 and let $E(x)$ be \tcode{bool(invoke(\brk{}pred, invoke(proj, $x$)))}.
 
 \requires
 For the overloads in namespace \tcode{std},
-\tcode{BidirectionalIterator} shall meet the
-\oldconcept{Value\-Swappable} requirements\iref{swappable.requirements} and
-the type of \tcode{*first} shall meet the
-\oldconcept{MoveConstructible} (\tref{moveconstructible}) and
+\tcode{BidirectionalIterator} shall meet
+the \oldconcept{Value\-Swappable} requirements\iref{swappable.requirements} and
+the type of \tcode{*first} shall meet
+the \oldconcept{MoveConstructible} (\tref{moveconstructible}) and
 \oldconcept{MoveAssignable} (\tref{moveassignable}) requirements.
 
 \pnum
 \effects
 Places all the elements \tcode{e} in \range{first}{last}
-that satisfy $E(\tcode{e})$ before all the
-elements that do not.
+that satisfy $E(\tcode{e})$ before all the elements that do not.
 The relative order of the elements in both groups is preserved.
 
 \pnum
 \returns
-An iterator
-\tcode{i}
-such that for every iterator
-\tcode{j}
-in
-\range{first}{i},
+An iterator \tcode{i}
+such that for every iterator \tcode{j} in \range{first}{i},
 $E(\tcode{*j})$ is \tcode{true},
-and for every iterator
-\tcode{j}
-in the range
-\range{i}{last},
+and for every iterator \tcode{j} in the range \range{i}{last},
 $E(\tcode{*j})$ is \tcode{false},
 
 \pnum
 \complexity
 Let $N$ = \tcode{last - first}:
 \begin{itemize}
-\item For the overloads with no \tcode{ExecutionPolicy}, at most $N \log N$ swaps,
-but only \bigoh{N} swaps if there is enough extra memory.  Exactly $N$
-applications of the predicate and projection.
-\item For the overload with an \tcode{ExecutionPolicy},
-\bigoh{N \log N} swaps and \bigoh{N} applications of the predicate.
+\item
+  For the overloads with no \tcode{ExecutionPolicy}, at most $N \log N$ swaps,
+  but only \bigoh{N} swaps if there is enough extra memory.
+  Exactly $N$ applications of the predicate and projection.
+\item
+  For the overload with an \tcode{ExecutionPolicy},
+  \bigoh{N \log N} swaps and \bigoh{N} applications of the predicate.
 \end{itemize}
-
 \end{itemdescr}
 
 \indexlibrary{\idxcode{partition_copy}}%
@@ -6884,17 +6738,17 @@ namespace ranges {
 
 \begin{itemdescr}
 \pnum
-Let \tcode{proj} be \tcode{identity\{\}} for the overloads
-with no parameter named \tcode{proj}
-and let $E(x)$ be \tcode{bool(invoke(\brk{}pred, invoke(proj, $x$)))}.
+Let \tcode{proj} be \tcode{identity\{\}}
+for the overloads with no parameter named \tcode{proj} and
+let $E(x)$ be \tcode{bool(invoke(\brk{}pred, invoke(proj, $x$)))}.
 
 \pnum
 \requires
 The input range and output ranges shall not overlap.
 For the overloads in namespace \tcode{std},
-the expression \tcode{*first} shall be
-writable\iref{iterator.requirements.general} to
-\tcode{out_true} and \tcode{out_false}.
+the expression \tcode{*first}
+shall be writable\iref{iterator.requirements.general}
+to \tcode{out_true} and \tcode{out_false}.
 \begin{note}
 For the overload with an \tcode{ExecutionPolicy},
 there may be a performance cost if \tcode{first}'s value type
@@ -6903,7 +6757,10 @@ does not meet the \oldconcept{CopyConstructible} requirements.
 
 \pnum
 \effects
-For each iterator \tcode{i} in \range{first}{last}, copies \tcode{*i} to the output range beginning with \tcode{out_true} if \tcode{$E(\tcode{*i})$} is \tcode{true}, or to the output range beginning with \tcode{out_false} otherwise.
+For each iterator \tcode{i} in \range{first}{last},
+copies \tcode{*i} to the output range beginning with \tcode{out_true}
+if \tcode{$E(\tcode{*i})$} is \tcode{true}, or
+to the output range beginning with \tcode{out_false} otherwise.
 
 \pnum
 \returns
@@ -6916,8 +6773,8 @@ Returns
 \end{itemize}
 
 \pnum
-\complexity Exactly \tcode{last - first} applications of \tcode{pred}
-and \tcode{proj}.
+\complexity
+Exactly \tcode{last - first} applications of \tcode{pred} and \tcode{proj}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{partition_point}}%
@@ -6939,8 +6796,8 @@ namespace ranges {
 
 \begin{itemdescr}
 \pnum
-Let \tcode{proj} be \tcode{identity\{\}} for the overloads
-with no parameter named \tcode{proj}
+Let \tcode{proj} be \tcode{identity\{\}}
+for the overloads with no parameter named \tcode{proj}
 and let $E(x)$ be \tcode{bool(invoke(\brk{}pred, invoke(proj, $x$)))}.
 
 \pnum
@@ -6950,14 +6807,15 @@ shall be partitioned with respect to $E(\tcode{e})$.
 
 \pnum
 \returns
-An iterator \tcode{mid} such that
-$E(\tcode{*i})$ is \tcode{true} for all iterators \tcode{i}
-in \range{first}{mid}, and
+An iterator \tcode{mid}
+such that $E(\tcode{*i})$ is \tcode{true}
+for all iterators \tcode{i} in \range{first}{mid}, and
 \tcode{false} for all iterators \tcode{i} in \range{mid}{last}
 
 \pnum
-\complexity \bigoh{\log(\tcode{last - first})} applications of \tcode{pred}
-and \tcode{proj}.
+\complexity
+\bigoh{\log(\tcode{last - first})} applications
+of \tcode{pred} and \tcode{proj}.
 \end{itemdescr}
 
 \rSec2[alg.merge]{Merge}
@@ -7018,39 +6876,49 @@ Let \tcode{comp} be \tcode{less\{\}},
 for the overloads with no parameters by those names.
 
 \pnum
-\requires The ranges \range{first1}{last1} and \range{first2}{last2} shall be
-sorted with respect to \tcode{comp} and \tcode{proj1} or \tcode{proj2}, respectively.
+\requires
+The ranges \range{first1}{last1} and \range{first2}{last2}
+shall be sorted with respect to \tcode{comp} and \tcode{proj1} or \tcode{proj2},
+respectively.
 The resulting range shall not overlap with either of the original ranges.
 
 \pnum
-\effects Copies all the elements of the two ranges \range{first1}{last1} and
-\range{first2}{last2} into the range \range{result}{result_last}, where \tcode{result_last}
-is \tcode{result + $N$}.
-If an element \tcode{a} precedes \tcode{b} in an input range, \tcode{a} is
-copied into the output range before \tcode{b}. If \tcode{e1} is an element of
-\range{first1}{last1} and \tcode{e2} of \range{first2}{last2}, \tcode{e2} is
-copied into the output range before \tcode{e1} if and only if
+\effects
+Copies all the elements of the two ranges \range{first1}{last1} and
+\range{first2}{last2} into the range \range{result}{result_last},
+where \tcode{result_last} is \tcode{result + $N$}.
+If an element \tcode{a} precedes \tcode{b} in an input range,
+\tcode{a} is copied into the output range before \tcode{b}.
+If \tcode{e1} is an element of \range{first1}{last1} and
+\tcode{e2} of \range{first2}{last2},
+\tcode{e2} is copied into the output range before \tcode{e1} if and only if
 \tcode{bool(invoke(comp, invoke(proj2, e2), invoke(proj1, e1)))}
 is \tcode{true}.
 
 \pnum
 \returns
 \begin{itemize}
-\item \tcode{result_last} for the overloads in namespace \tcode{std}, or
-\item \tcode{\{last1, last2, result_last\}} for the overloads in
-  namespace \tcode{ranges}.
+\item
+  \tcode{result_last}
+  for the overloads in namespace \tcode{std}, or
+\item
+  \tcode{\{last1, last2, result_last\}}
+  for the overloads in namespace \tcode{ranges}.
 \end{itemize}
 
 \pnum
 \complexity
 \begin{itemize}
-\item For the overloads with no \tcode{ExecutionPolicy}, at most $N - 1$ comparisons
-and applications of each projection.
-\item For the overloads with an \tcode{ExecutionPolicy}, \bigoh{N} comparisons.
+\item
+  For the overloads with no \tcode{ExecutionPolicy},
+  at most $N - 1$ comparisons and applications of each projection.
+\item
+  For the overloads with an \tcode{ExecutionPolicy}, \bigoh{N} comparisons.
 \end{itemize}
 
 \pnum
-\remarks Stable\iref{algorithm.stable}.
+\remarks
+Stable\iref{algorithm.stable}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{inplace_merge}}%
@@ -7094,20 +6962,17 @@ for the overloads with no parameters by those names.
 \range{first}{middle} and \range{middle}{last} shall be valid ranges
 sorted with respect to \tcode{comp} and \tcode{proj}.
 For the overloads in namespace \tcode{std},
-\tcode{BidirectionalIterator} shall meet the
-\oldconcept{Value\-Swappable} requirements\iref{swappable.requirements} and
-the type of \tcode{*first} shall meet the
-\oldconcept{MoveConstructible} (\tref{moveconstructible}) and
+\tcode{BidirectionalIterator} shall meet
+the \oldconcept{Value\-Swappable} requirements\iref{swappable.requirements} and
+the type of \tcode{*first} shall meet
+the \oldconcept{MoveConstructible} (\tref{moveconstructible}) and
 \oldconcept{MoveAssignable} (\tref{moveassignable}) requirements.
 
 \pnum
 \effects
 Merges two sorted consecutive ranges
-\range{first}{middle}
-and
-\range{middle}{last},
-putting the result of the merge into the range
-\range{first}{last}.
+\range{first}{middle} and \range{middle}{last},
+putting the result of the merge into the range \range{first}{last}.
 The resulting range is sorted with respect to \tcode{comp} and \tcode{proj}.
 
 \pnum
@@ -7115,16 +6980,20 @@ The resulting range is sorted with respect to \tcode{comp} and \tcode{proj}.
 \tcode{last} for the overload in namespace \tcode{ranges}.
 
 \pnum
-\complexity Let $N = \tcode{last - first}$:
+\complexity
+Let $N = \tcode{last - first}$:
 \begin{itemize}
-\item For the overloads with no \tcode{ExecutionPolicy}, and if enough additional
-memory is available, exactly $N - 1$ comparisons.
-\item Otherwise, \bigoh{N \log N} comparisons.
+\item
+  For the overloads with no \tcode{ExecutionPolicy}, and
+  if enough additional memory is available, exactly $N - 1$ comparisons.
+\item
+  Otherwise, \bigoh{N \log N} comparisons.
 \end{itemize}
 In either case, twice as many projections as comparisons.
 
 \pnum
-\remarks Stable\iref{algorithm.stable}.
+\remarks
+Stable\iref{algorithm.stable}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7138,7 +7007,8 @@ namespace ranges {
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return ranges::inplace_merge(ranges::begin(r), middle, ranges::end(r), comp, proj);
 \end{codeblock}
@@ -7148,16 +7018,12 @@ return ranges::inplace_merge(ranges::begin(r), middle, ranges::end(r), comp, pro
 
 \pnum
 This subclause defines all the basic set operations on sorted structures.
-They also work with
-\tcode{multiset}s\iref{multiset}
+They also work with \tcode{multiset}s\iref{multiset}
 containing multiple copies of equivalent elements.
-The semantics of the set operations are generalized to
-\tcode{multiset}s
-in a standard way by defining
-\tcode{set_union()}
+The semantics of the set operations are generalized to \tcode{multiset}s
+in a standard way by defining \tcode{set_union()}
 to contain the maximum number of occurrences of every element,
-\tcode{set_intersection()}
-to contain the minimum, and so on.
+\tcode{set_intersection()} to contain the minimum, and so on.
 
 \rSec3[includes]{\tcode{includes}}
 
@@ -7206,9 +7072,8 @@ for the overloads with no parameters by those names.
 
 \pnum
 \requires
-The ranges \range{first1}{last1} and \range{first2}{last2}
-shall be sorted with respect to \tcode{comp}
-and \tcode{proj1} or \tcode{proj2}, respectively.
+The ranges \range{first1}{last1} and \range{first2}{last2} shall be sorted
+with respect to \tcode{comp} and \tcode{proj1} or \tcode{proj2}, respectively.
 
 \pnum
 \returns
@@ -7222,8 +7087,7 @@ remaining elements in the same order.
 
 \pnum
 \complexity
-At most
-\tcode{2 * ((last1 - first1) + (last2 - first2)) - 1}
+At most \tcode{2 * ((last1 - first1) + (last2 - first2)) - 1}
 comparisons and applications of each projection.
 \end{itemdescr}
 
@@ -7284,9 +7148,8 @@ for the overloads with no parameters by those names.
 
 \pnum
 \requires
-The ranges \range{first1}{last1} and \range{first2}{last2} shall be
-sorted with respect to \tcode{comp} and
-\tcode{proj1} or \tcode{proj2}, respectively.
+The ranges \range{first1}{last1} and \range{first2}{last2} shall be sorted
+with respect to \tcode{comp} and \tcode{proj1} or \tcode{proj2}, respectively.
 The resulting range shall not overlap with either of the original ranges.
 
 \pnum
@@ -7299,25 +7162,30 @@ that is, the set of elements that are present in one or both of the ranges.
 Let \tcode{result_last} be the end of the constructed range.
 Returns
 \begin{itemize}
-\item \tcode{result_last} for the overloads in namespace \tcode{std}, or
-\item \tcode{\{last1, last2, result_last\}} for the overloads in
-  namespace \tcode{ranges}.
+\item
+  \tcode{result_last}
+  for the overloads in namespace \tcode{std}, or
+\item
+  \tcode{\{last1, last2, result_last\}}
+  for the overloads in namespace \tcode{ranges}.
 \end{itemize}
 
 \pnum
 \complexity
-At most
-\tcode{2 * ((last1 - first1) + (last2 - first2)) - 1}
+At most \tcode{2 * ((last1 - first1) + (last2 - first2)) - 1}
 comparisons and applications of each projection.
 
 \pnum
 \remarks
 Stable\iref{algorithm.stable}.
-If \range{first1}{last1} contains $m$ elements that are equivalent to
-each other and \range{first2}{last2} contains $n$ elements that are equivalent
-to them, then all $m$ elements from the first range are copied to the output
-range, in order, and then the final $\max(n - m, 0)$ elements from the second range are
-copied to the output range, in order.
+If \range{first1}{last1} contains $m$ elements
+that are equivalent to each other and
+\range{first2}{last2} contains $n$ elements
+that are equivalent to them,
+then all $m$ elements from the first range
+are copied to the output range, in order, and
+then the final $\max(n - m, 0)$ elements from the second range
+are copied to the output range, in order.
 \end{itemdescr}
 
 \rSec3[set.intersection]{\tcode{set_intersection}}
@@ -7377,9 +7245,8 @@ for the overloads with no parameters by those names.
 
 \pnum
 \requires
-The ranges \range{first1}{last1} and \range{first2}{last2} shall be
-sorted with respect to \tcode{comp} and
-\tcode{proj1} or \tcode{proj2}, respectively.
+The ranges \range{first1}{last1} and \range{first2}{last2} shall be sorted
+with respect to \tcode{comp} and \tcode{proj1} or \tcode{proj2}, respectively.
 The resulting range shall not overlap with either of the original ranges.
 
 \pnum
@@ -7392,24 +7259,28 @@ that is, the set of elements that are present in both of the ranges.
 Let \tcode{result_last} be the end of the constructed range.
 Returns
 \begin{itemize}
-\item \tcode{result_last} for the overloads in namespace \tcode{std}, or
-\item \tcode{\{last1, last2, result_last\}} for the overloads in
-  namespace \tcode{ranges}.
+\item
+  \tcode{result_last}
+  for the overloads in namespace \tcode{std}, or
+\item
+  \tcode{\{last1, last2, result_last\}}
+  for the overloads in namespace \tcode{ranges}.
 \end{itemize}
 
 \pnum
 \complexity
-At most
-\tcode{2 * ((last1 - first1) + (last2 - first2)) - 1}
+At most \tcode{2 * ((last1 - first1) + (last2 - first2)) - 1}
 comparisons and applications of each projection.
 
 \pnum
 \remarks
 Stable\iref{algorithm.stable}.
-If \range{first1}{last1} contains $m$ elements that are equivalent to
-each other and \range{first2}{last2} contains $n$ elements that are equivalent
-to them, the first $\min(m, n)$ elements are copied from the first range
-to the output range, in order.
+If \range{first1}{last1} contains $m$ elements
+that are equivalent to each other and
+\range{first2}{last2} contains $n$ elements
+that are equivalent to them,
+the first $\min(m, n)$ elements
+are copied from the first range to the output range, in order.
 \end{itemdescr}
 
 \rSec3[set.difference]{\tcode{set_difference}}
@@ -7469,19 +7340,15 @@ for the overloads with no parameters by those names.
 
 \pnum
 \requires
-The ranges \range{first1}{last1} and \range{first2}{last2} shall be
-sorted with respect to \tcode{comp} and
-\tcode{proj1} or \tcode{proj2}, respectively.
+The ranges \range{first1}{last1} and \range{first2}{last2} shall be sorted
+with respect to \tcode{comp} and \tcode{proj1} or \tcode{proj2}, respectively.
 The resulting range shall not overlap with either of the original ranges.
 
 \pnum
 \effects
-Copies the elements of the range
-\range{first1}{last1}
-which are not present in the range
-\range{first2}{last2}
-to the range beginning at
-\tcode{result}.
+Copies the elements of the range \range{first1}{last1}
+which are not present in the range \range{first2}{last2}
+to the range beginning at \tcode{result}.
 The elements in the constructed range are sorted.
 
 \pnum
@@ -7489,29 +7356,26 @@ The elements in the constructed range are sorted.
 Let \tcode{result_last} be the end of the constructed range.
 Returns
 \begin{itemize}
-\item \tcode{result_last} for the overloads in namespace \tcode{std}, or
-\item \tcode{\{last1, result_last\}} for the overloads in
-  namespace \tcode{ranges}.
+\item
+  \tcode{result_last}
+  for the overloads in namespace \tcode{std}, or
+\item
+  \tcode{\{last1, result_last\}}
+  for the overloads in namespace \tcode{ranges}.
 \end{itemize}
 
 \pnum
 \complexity
-At most
-\tcode{2 * ((last1 - first1) + (last2 - first2)) - 1}
+At most \tcode{2 * ((last1 - first1) + (last2 - first2)) - 1}
 comparisons and applications of each projection.
 
 \pnum
 \remarks
-If
-\range{first1}{last1}
-contains $m$
-elements that are equivalent to each other and
-\range{first2}{last2}
-contains $n$
-elements that are equivalent to them, the last
-$\max(m - n, 0)$
-elements from
-\range{first1}{last1}
+If \range{first1}{last1} contains $m$ elements
+that are equivalent to each other and
+\range{first2}{last2} contains $n$ elements
+that are equivalent to them,
+the last $\max(m - n, 0)$ elements from \range{first1}{last1}
 is copied to the output range, in order.
 \end{itemdescr}
 
@@ -7574,23 +7438,17 @@ for the overloads with no parameters by those names.
 \pnum
 \requires
 The resulting range shall not overlap with either of the original ranges.
-The ranges \range{first1}{last1} and \range{first2}{last2} shall be
-sorted with respect to \tcode{comp} and
-\tcode{proj1} or \tcode{proj2}, respectively.
+The ranges \range{first1}{last1} and \range{first2}{last2} shall be sorted
+with respect to \tcode{comp} and \tcode{proj1} or \tcode{proj2}, respectively.
 The resulting range shall not overlap with either of the original ranges.
 
 \pnum
 \effects
-Copies the elements of the range
-\range{first1}{last1}
-that are not present in the range
-\range{first2}{last2},
-and the elements of the range
-\range{first2}{last2}
-that are not present in the range
-\range{first1}{last1}
-to the range beginning at
-\tcode{result}.
+Copies the elements of the range \range{first1}{last1}
+that are not present in the range \range{first2}{last2},
+and the elements of the range \range{first2}{last2}
+that are not present in the range \range{first1}{last1}
+to the range beginning at \tcode{result}.
 The elements in the constructed range are sorted.
 
 \pnum
@@ -7598,25 +7456,29 @@ The elements in the constructed range are sorted.
 Let \tcode{result_last} be the end of the constructed range.
 Returns
 \begin{itemize}
-\item \tcode{result_last} for the overloads in namespace \tcode{std}, or
-\item \tcode{\{last1, last2, result_last\}} for the overloads in
-  namespace \tcode{ranges}.
+\item
+  \tcode{result_last}
+  for the overloads in namespace \tcode{std}, or
+\item
+  \tcode{\{last1, last2, result_last\}}
+  for the overloads in namespace \tcode{ranges}.
 \end{itemize}
 
 \pnum
 \complexity
-At most
-\tcode{2 * ((last1 - first1) + (last2 - first2)) - 1}
+At most \tcode{2 * ((last1 - first1) + (last2 - first2)) - 1}
 comparisons and applications of each projection.
 
 \pnum
 \remarks
 Stable\iref{algorithm.stable}.
-If \range{first1}{last1} contains $m$ elements that are equivalent to each other and
-\range{first2}{last2} contains $n$ elements that are equivalent to them, then
-$|m - n|$ of those elements shall be copied to the output range: the last
-$m - n$ of these elements from \range{first1}{last1} if $m > n$, and the last
-$n - m$ of these elements from \range{first2}{last2} if $m < n$.
+If \range{first1}{last1} contains $m$ elements
+that are equivalent to each other and
+\range{first2}{last2} contains $n$ elements
+that are equivalent to them,
+then $|m - n|$ of those elements shall be copied to the output range:
+the last $m - n$ of these elements from \range{first1}{last1} if $m > n$, and
+the last $n - m$ of these elements from \range{first2}{last2} if $m < n$.
 In either case, the elements are copied in order.
 \end{itemdescr}
 
@@ -7630,27 +7492,22 @@ for a comparator and projection \tcode{comp} and \tcode{proj}
 if its elements are organized such that:
 
 \begin{itemize}
-\item With \tcode{$N$ = b - a}, for all $i$, $0 < i < N$,
-\tcode{bool(invoke(comp, invoke(proj, a[$\left \lfloor{\frac{i - 1}{2}}\right \rfloor$]), invoke(\brk{}proj, a[$i$])))}
-is \tcode{false}.
-\item \tcode{*a}
-may be removed by
-\tcode{pop_heap},
-or a new element added by
-\tcode{push_heap},
-in
-\bigoh{\log N}
-time.
+\item
+  With \tcode{$N$ = b - a}, for all $i$, $0 < i < N$,
+  \tcode{bool(invoke(comp, invoke(proj, a[$\left \lfloor{\frac{i - 1}{2}}\right \rfloor$]), invoke(\brk{}proj, a[$i$])))}
+  is \tcode{false}.
+\item
+  \tcode{*a} may be removed by \tcode{pop_heap}, or
+  a new element added by \tcode{push_heap},
+  in \bigoh{\log N} time.
 \end{itemize}
 
 \pnum
 These properties make heaps useful as priority queues.
 
 \pnum
-\tcode{make_heap}
-converts a range into a heap and
-\tcode{sort_heap}
-turns a heap into a sorted sequence.
+\tcode{make_heap} converts a range into a heap and
+\tcode{sort_heap} turns a heap into a sorted sequence.
 
 \rSec3[push.heap]{\tcode{push_heap}}
 
@@ -7684,22 +7541,17 @@ for the overloads with no parameters by those names.
 
 \pnum
 \requires
-The range
-\range{first}{last - 1}
+The range \range{first}{last - 1}
 shall be a valid heap with respect to \tcode{comp} and \tcode{proj}.
 For the overloads in namespace \tcode{std},
 the type of \tcode{*first} shall meet
-the \oldconcept{MoveConstructible} requirements
-(\tref{moveconstructible}) and the
-\oldconcept{MoveAssignable} requirements
-(\tref{moveassignable}).
+the \oldconcept{MoveConstructible} requirements (\tref{moveconstructible}) and
+the \oldconcept{MoveAssignable} requirements (\tref{moveassignable}).
 
 \pnum
 \effects
-Places the value in the location
-\tcode{last - 1}
-into the resulting heap
-\range{first}{last}.
+Places the value in the location \tcode{last - 1}
+into the resulting heap \range{first}{last}.
 
 \pnum
 \returns
@@ -7707,9 +7559,7 @@ into the resulting heap
 
 \pnum
 \complexity
-At most
-$\log(\tcode{last - first})$
-comparisons and twice as many projections.
+At most $\log(\tcode{last - first})$ comparisons and twice as many projections.
 \end{itemdescr}
 
 \rSec3[pop.heap]{\tcode{pop_heap}}
@@ -7744,14 +7594,13 @@ for the overloads with no parameters by those names.
 
 \pnum
 \requires
-The range
-\range{first}{last}
+The range \range{first}{last}
 shall be a valid non-empty heap with respect to \tcode{comp} and \tcode{proj}.
 For the overloads in namespace \tcode{std},
-\tcode{RandomAccessIterator} shall meet the
-\oldconcept{ValueSwappable} requirements\iref{swappable.requirements} and
-the type of \tcode{*first} shall met the
-\oldconcept{MoveConstructible} (\tref{moveconstructible}) and
+\tcode{RandomAccessIterator} shall meet
+the \oldconcept{ValueSwappable} requirements\iref{swappable.requirements} and
+the type of \tcode{*first} shall meet
+the \oldconcept{MoveConstructible} (\tref{moveconstructible}) and
 \oldconcept{MoveAssignable} (\tref{moveassignable}) requirements.
 
 \pnum
@@ -7769,9 +7618,8 @@ into a heap with respect to \tcode{comp} and \tcode{proj}.
 
 \pnum
 \complexity
-At most
-$2 \log(\tcode{last - first})$
-comparisons and twice as many projections.
+At most $2 \log(\tcode{last - first})$ comparisons and
+twice as many projections.
 \end{itemdescr}
 
 \rSec3[make.heap]{\tcode{make_heap}}
@@ -7808,15 +7656,13 @@ for the overloads with no parameters by those names.
 \requires
 For the overloads in namespace \tcode{std},
 the type of \tcode{*first} shall meet
-the \oldconcept{Move\-Constructible}
-(\tref{moveconstructible}) and
-\oldconcept{MoveAssignable}
-(\tref{moveassignable}) requirements.
+the \oldconcept{Move\-Constructible} (\tref{moveconstructible}) and
+\oldconcept{MoveAssignable} (\tref{moveassignable}) requirements.
 
 \pnum
 \effects
-Constructs a heap with respect to \tcode{comp} and \tcode{proj} out of the range
-\range{first}{last}.
+Constructs a heap with respect to \tcode{comp} and \tcode{proj}
+out of the range \range{first}{last}.
 
 \pnum
 \returns
@@ -7824,9 +7670,7 @@ Constructs a heap with respect to \tcode{comp} and \tcode{proj} out of the range
 
 \pnum
 \complexity
-At most
-$3(\tcode{last - first})$
-comparisons and twice as many projections.
+At most $3(\tcode{last - first})$ comparisons and twice as many projections.
 \end{itemdescr}
 
 \rSec3[sort.heap]{\tcode{sort_heap}}
@@ -7864,16 +7708,16 @@ for the overloads with no parameters by those names.
 The range \range{first}{last} shall be
 a valid heap with respect to \tcode{comp} and \tcode{proj}.
 For the overloads in namespace \tcode{std},
-\tcode{RandomAccessIterator} shall meet the
-\oldconcept{ValueSwappable} requirements\iref{swappable.requirements} and
-the type of \tcode{*first} shall meet the
-\oldconcept{MoveConst\-ruct\-ible} (\tref{moveconstructible}) and
+\tcode{RandomAccessIterator} shall meet
+the \oldconcept{ValueSwappable} requirements\iref{swappable.requirements} and
+the type of \tcode{*first} shall meet
+the \oldconcept{MoveConst\-ruct\-ible} (\tref{moveconstructible}) and
 \oldconcept{MoveAssignable} (\tref{moveassignable}) requirements.
 
 \pnum
 \effects
-Sorts elements in the heap
-\range{first}{last} with respect to \tcode{comp} and \tcode{proj}.
+Sorts elements in the heap \range{first}{last}
+with respect to \tcode{comp} and \tcode{proj}.
 
 \pnum
 \returns
@@ -7881,9 +7725,8 @@ Sorts elements in the heap
 
 \pnum
 \complexity
-At most $2N \log N$
-comparisons, where
-$N = \tcode{last - first}$, and twice as many projections.
+At most $2N \log N$ comparisons, where $N = \tcode{last - first}$, and
+twice as many projections.
 \end{itemdescr}
 
 \rSec3[is.heap]{\tcode{is_heap}}
@@ -7915,7 +7758,6 @@ Equivalent to:
 return is_heap_until(std::forward<ExecutionPolicy>(exec), first, last) == last;
 \end{codeblock}
 \end{itemdescr}
-
 
 \indexlibrary{\idxcode{is_heap}}%
 \begin{itemdecl}
@@ -7961,7 +7803,8 @@ namespace ranges {
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \tcode{return ranges::is_heap_until(first, last, comp, proj) == last;}
 \end{itemdescr}
 
@@ -8004,11 +7847,13 @@ for the overloads with no parameters by those names.
 
 \pnum
 \returns
-The last iterator \tcode{i} in \crange{first}{last} for which the
-range \range{first}{i} is a heap with respect to \tcode{comp} and \tcode{proj}.
+The last iterator \tcode{i} in \crange{first}{last}
+for which the range \range{first}{i}
+is a heap with respect to \tcode{comp} and \tcode{proj}.
 
 \pnum
-\complexity Linear.
+\complexity
+Linear.
 \end{itemdescr}
 
 
@@ -8040,8 +7885,8 @@ The smaller value.
 \pnum
 \remarks
 Returns the first argument when the arguments are equivalent.
-An invocation may explicitly specify an argument
-for the template parameter \tcode{T}
+An invocation may explicitly specify
+an argument for the template parameter \tcode{T}
 of the overloads in namespace \tcode{std}.
 
 \pnum
@@ -8077,12 +7922,15 @@ For the overloads in namespace \tcode{std},
 For the first form, type \tcode{T} shall be \oldconcept{LessThanComparable}.
 
 \pnum
-\returns The smallest value in the input range.
+\returns
+The smallest value in the input range.
 
 \pnum
-\remarks Returns a copy of the leftmost element when several elements are equivalent to the smallest.
-An invocation may explicitly specify an argument
-for the template parameter \tcode{T}
+\remarks
+Returns a copy of the leftmost element
+when several elements are equivalent to the smallest.
+An invocation may explicitly specify
+an argument for the template parameter \tcode{T}
 of the overloads in namespace \tcode{std}.
 
 \pnum
@@ -8117,8 +7965,8 @@ The larger value.
 \pnum
 \remarks
 Returns the first argument when the arguments are equivalent.
-An invocation may explicitly specify an argument
-for the template parameter \tcode{T}
+An invocation may explicitly specify
+an argument for the template parameter \tcode{T}
 of the overloads in namespace \tcode{std}.
 
 \pnum
@@ -8154,12 +8002,15 @@ For the overloads in namespace \tcode{std},
 For the first form, type \tcode{T} shall be \oldconcept{LessThanComparable}.
 
 \pnum
-\returns The largest value in the input range.
+\returns
+The largest value in the input range.
 
 \pnum
-\remarks Returns a copy of the leftmost element when several elements are equivalent to the largest.
-An invocation may explicitly specify an argument
-for the template parameter \tcode{T}
+\remarks
+Returns a copy of the leftmost element
+when several elements are equivalent to the largest.
+An invocation may explicitly specify
+an argument for the template parameter \tcode{T}
 of the overloads in namespace \tcode{std}.
 
 \pnum
@@ -8196,8 +8047,8 @@ For the first form, type \tcode{T} shall be
 
 \pnum
 \remarks
-An invocation may explicitly specify an argument
-for the template parameter \tcode{T}
+An invocation may explicitly specify
+an argument for the template parameter \tcode{T}
 of the overloads in namespace \tcode{std}.
 
 \pnum
@@ -8235,20 +8086,22 @@ For the first form, type \tcode{T} shall be \oldconcept{LessThanComparable}.
 
 \pnum
 \returns
-Let \tcode{X} be the return type. Returns
-\tcode{X{x, y}}, where \tcode{x} is a copy of the leftmost element with
-the smallest and \tcode{y} a copy of the rightmost element with the
-largest value in the input range.
+Let \tcode{X} be the return type.
+Returns \tcode{X{x, y}},
+where \tcode{x} is a copy of the leftmost element with the smallest and
+\tcode{y} a copy of the rightmost element with the largest value
+in the input range.
 
 \pnum
 \remarks
-An invocation may explicitly specify an argument
-for the template parameter \tcode{T}
+An invocation may explicitly specify
+an argument for the template parameter \tcode{T}
 of the overloads in namespace \tcode{std}.
 
 \pnum
 \complexity
-At most $(3/2)\tcode{ranges::distance(r)}$ applications of the corresponding predicate
+At most $(3/2)\tcode{ranges::distance(r)}$ applications
+of the corresponding predicate
 and twice as many applications of the projection, if any.
 \end{itemdescr}
 
@@ -8288,28 +8141,18 @@ for the overloads with no parameters by those names.
 
 \pnum
 \returns
-The first iterator
-\tcode{i}
-in the range
-\range{first}{last}
-such that for every iterator
-\tcode{j}
-in the range
-\range{first}{last},
+The first iterator \tcode{i} in the range \range{first}{last}
+such that for every iterator \tcode{j} in the range \range{first}{last},
 \begin{codeblock}
 bool(invoke(comp, invoke(proj, *j), invoke(proj, *i)))
 \end{codeblock}
 is \tcode{false}.
-Returns
-\tcode{last}
-if
-\tcode{first == last}.
+Returns \tcode{last} if \tcode{first == last}.
 
 \pnum
 \complexity
-Exactly
-$\max(\tcode{last - first - 1}, 0)$
-comparisons and twice as many projections.
+Exactly $\max(\tcode{last - first - 1}, 0)$ comparisons and
+twice as many projections.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{max_element}}%
@@ -8347,28 +8190,18 @@ for the overloads with no parameters by those names.
 
 \pnum
 \returns
-The first iterator
-\tcode{i}
-in the range
-\range{first}{last}
-such that for every iterator
-\tcode{j}
-in the range
-\range{first}{last},
+The first iterator \tcode{i} in the range \range{first}{last}
+such that for every iterator \tcode{j} in the range \range{first}{last},
 \begin{codeblock}
 bool(invoke(comp, invoke(proj, *i), invoke(proj, *j)))
 \end{codeblock}
 is \tcode{false}.
-Returns
-\tcode{last}
-if
-\tcode{first == last}.
+Returns \tcode{last} if \tcode{first == last}.
 
 \pnum
 \complexity
-Exactly
-$\max(\tcode{last - first - 1}, 0)$
-comparisons and twice as many projections.
+Exactly $\max(\tcode{last - first - 1}, 0)$ comparisons and
+twice as many projections.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{minmax_element}}%
@@ -8415,9 +8248,8 @@ in \range{first}{last} such that no iterator in the range refers to a larger ele
 \pnum
 \complexity
 Let $N$ be \tcode{last - first}.
-At most
-$\max(\bigl\lfloor{\frac{3}{2}} (N-1)\bigr\rfloor, 0)$
-comparisons and twice as many applications of the projection, if any.
+At most $\max(\bigl\lfloor{\frac{3}{2}} (N-1)\bigr\rfloor, 0)$ comparisons and
+twice as many applications of the projection, if any.
 \end{itemdescr}
 
 \rSec2[alg.clamp]{Bounded value}
@@ -8501,28 +8333,26 @@ namespace ranges {
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{true}
-if and only if the sequence of elements defined by the range
-\range{first1}{last1}
-is lexicographically less than the sequence of elements defined by the range
-\range{first2}{last2}.
+\tcode{true} if and only if
+the sequence of elements defined by the range \range{first1}{last1}
+is lexicographically less than
+the sequence of elements defined by the range \range{first2}{last2}.
 
 \pnum
 \complexity
-At most
-$2 \min(\tcode{last1 - first1}, \ \tcode{last2 - first2})$
-applications of the corresponding comparison and each projection, if any.
+At most $2 \min(\tcode{last1 - first1}, \ \tcode{last2 - first2})$ applications
+of the corresponding comparison and each projection, if any.
 
 \pnum
 \remarks
-If two sequences have the same number of elements and their corresponding
-elements (if any) are equivalent, then neither sequence is lexicographically
-less than the other.
-If one sequence is a proper prefix of the other, then the shorter sequence is
-lexicographically less than the longer sequence.
-Otherwise, the lexicographical comparison of the sequences yields the same
-result as the comparison of the first corresponding pair of
-elements that are not equivalent.
+If two sequences have the same number of elements and
+their corresponding elements (if any) are equivalent,
+then neither sequence is lexicographically less than the other.
+If one sequence is a proper prefix of the other,
+then the shorter sequence is lexicographically less than the longer sequence.
+Otherwise, the lexicographical comparison of the sequences yields
+the same result as the comparison
+of the first corresponding pair of elements that are not equivalent.
 
 \pnum
 \begin{example}
@@ -8538,10 +8368,10 @@ return first1 == last1 && first2 != last2;
 \end{example}
 
 \pnum
-\begin{note} An empty sequence is lexicographically less than any non-empty sequence, but
-not less than any empty sequence.
+\begin{note}
+An empty sequence is lexicographically less than any non-empty sequence,
+but not less than any empty sequence.
 \end{note}
-
 \end{itemdescr}
 
 \rSec2[alg.3way]{Three-way comparison algorithms}
@@ -8554,27 +8384,26 @@ template<class T, class U> constexpr auto compare_3way(const T& a, const U& b);
 \begin{itemdescr}
 \pnum
 \effects
-Compares two values and produces a result of the strongest applicable
-comparison category type:
+Compares two values and produces a result
+of the strongest applicable comparison category type:
 \begin{itemize}
 \item
-Returns \tcode{a <=> b} if that expression is well-formed.
+  Returns \tcode{a <=> b} if that expression is well-formed.
 \item
-Otherwise, if the expressions \tcode{a == b} and \tcode{a < b}
-are each well-formed and convertible to \tcode{bool},
-returns \tcode{strong_ordering::equal}
-when \tcode{a == b} is \tcode{true},
-otherwise returns \tcode{strong_ordering::less}
-when \tcode{a < b} is \tcode{true},
-and otherwise returns \tcode{strong_ordering::greater}.
+  Otherwise, if the expressions \tcode{a == b} and \tcode{a < b}
+  are each well-formed and convertible to \tcode{bool},
+  returns \tcode{strong_ordering::equal}
+  when \tcode{a == b} is \tcode{true},
+  otherwise returns \tcode{strong_ordering::less}
+  when \tcode{a < b} is \tcode{true},
+  and otherwise returns \tcode{strong_ordering::greater}.
 \item
-Otherwise, if the expression \tcode{a == b}
-is well-formed and convertible to \tcode{bool},
-returns \tcode{strong_equality::equal}
-when \tcode{a == b} is \tcode{true},
-and otherwise returns \tcode{strong_equality::nonequal}.
+  Otherwise, if the expression \tcode{a == b}
+  is well-formed and convertible to \tcode{bool},
+  returns \tcode{strong_equality::equal} when \tcode{a == b} is \tcode{true},
+  and otherwise returns \tcode{strong_equality::nonequal}.
 \item
-Otherwise, the function is defined as deleted.
+  Otherwise, the function is defined as deleted.
 \end{itemize}
 \end{itemdescr}
 
@@ -8597,8 +8426,7 @@ whose return type is a comparison category type.
 \pnum
 \effects
 Lexicographically compares two ranges and
-produces a result of the strongest applicable
-comparison category type.
+produces a result of the strongest applicable comparison category type.
 Equivalent to:
 \begin{codeblock}
 for ( ; b1 != e1 && b2 != e2; void(++b1), void(++b2) )
@@ -8665,16 +8493,15 @@ for overloads with no parameters by those names.
 \pnum
 \requires
 For the overloads in namespace \tcode{std},
-\tcode{BidirectionalIterator} shall meet the
-\oldconcept{Value\-Swappable} requirements\iref{swappable.requirements}.
+\tcode{BidirectionalIterator} shall meet
+the \oldconcept{Value\-Swappable} requirements\iref{swappable.requirements}.
 
 \pnum
 \effects
-Takes a sequence defined by the range
-\range{first}{last}
+Takes a sequence defined by the range \range{first}{last}
 and transforms it into the next permutation.
-The next permutation is found by assuming that the set of all permutations is
-lexicographically sorted with respect to \tcode{comp} and \tcode{proj}.
+The next permutation is found by assuming that the set of all permutations
+is lexicographically sorted with respect to \tcode{comp} and \tcode{proj}.
 If no such permutation exists,
 transforms the sequence into the first permutation;
 that is, the ascendingly-sorted one.
@@ -8685,9 +8512,7 @@ that is, the ascendingly-sorted one.
 
 \pnum
 \complexity
-At most
-\tcode{(last - first) / 2}
-swaps.
+At most \tcode{(last - first) / 2} swaps.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{prev_permutation}}%
@@ -8723,16 +8548,15 @@ for overloads with no parameters by those names.
 \pnum
 \requires
 For the overloads in namespace \tcode{std},
-\tcode{BidirectionalIterator} shall meet the
-\oldconcept{Value\-Swappable} requirements\iref{swappable.requirements}.
+\tcode{BidirectionalIterator} shall meet
+the \oldconcept{Value\-Swappable} requirements\iref{swappable.requirements}.
 
 \pnum
 \effects
-Takes a sequence defined by the range
-\range{first}{last}
+Takes a sequence defined by the range \range{first}{last}
 and transforms it into the previous permutation.
-The previous permutation is found by assuming that the set of all permutations is
-lexicographically sorted with respect to \tcode{comp} and \tcode{proj}.
+The previous permutation is found by assuming that the set of all permutations
+is lexicographically sorted with respect to \tcode{comp} and \tcode{proj}.
 If no such permutation exists,
 transforms the sequence into the last permutation;
 that is, the descendingly-sorted one.
@@ -8743,9 +8567,7 @@ that is, the descendingly-sorted one.
 
 \pnum
 \complexity
-At most
-\tcode{(last - first) / 2}
-swaps.
+At most \tcode{(last - first) / 2} swaps.
 \end{itemdescr}
 
 \rSec1[numeric.ops.overview]{Header \tcode{<numeric>} synopsis}
@@ -8981,15 +8803,16 @@ namespace std {
 
 \pnum
 \begin{note}
-The use of closed ranges as well as semi-open ranges to specify requirements
-throughout this subclause is intentional.
+The use of closed ranges as well as semi-open ranges
+to specify requirements throughout this subclause is intentional.
 \end{note}
 
 \rSec2[numerics.defns]{Definitions}
 
 \indexlibrary{generalized_noncommutative_sum@\tcode{\placeholder{GENERALIZED_NONCOMMUTATIVE_SUM}}}%
 \pnum
-Define \tcode{\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}(op, a1, ..., aN)} as follows:
+Define \tcode{\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}(op, a1, ..., aN)}
+as follows:
 \begin{itemize}
 \item
 \tcode{a1} when \tcode{N} is \tcode{1}, otherwise
@@ -9021,30 +8844,26 @@ template<class InputIterator, class T, class BinaryOperation>
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{T} shall satisfy the \oldconcept{CopyConstructible} (\tref{copyconstructible})
+\tcode{T} shall satisfy
+the \oldconcept{CopyConstructible} (\tref{copyconstructible})
 and \oldconcept{CopyAssignable} (\tref{copyassignable}) requirements.
-In the range
-\crange{first}{last},
-\tcode{binary_op}
-shall neither modify elements nor invalidate iterators or subranges.\footnote{The use of fully closed ranges is intentional.}
+In the range \crange{first}{last},
+\tcode{binary_op} shall neither modify elements
+nor invalidate iterators or subranges.%
+\footnote{The use of fully closed ranges is intentional.}
 
 \pnum
 \effects
-Computes its result by initializing the accumulator
-\tcode{acc}
-with the initial value
-\tcode{init}
+Computes its result by
+initializing the accumulator \tcode{acc} with the initial value \tcode{init}
 and then modifies it with
-\tcode{acc = std::move(acc) + *i}
-or
+\tcode{acc = std::move(acc) + *i} or
 \tcode{acc = binary_op(std::move(acc), *i)}
-for every iterator
-\tcode{i}
-in the range \range{first}{last}
-in order.\footnote{\tcode{accumulate}
-is similar to the APL reduction operator and Common Lisp reduce function, but
-it avoids the difficulty of defining the result of reduction on an empty
-sequence by always requiring an initial value.}
+for every iterator \tcode{i} in the range \range{first}{last} in order.%
+\footnote{\tcode{accumulate} is similar
+to the APL reduction operator and Common Lisp reduce function,
+but it avoids the difficulty of defining the result of reduction
+on an empty sequence by always requiring an initial value.}
 \end{itemdescr}
 
 \rSec2[reduce]{Reduce}
@@ -9128,17 +8947,21 @@ template<class ExecutionPolicy, class ForwardIterator, class T, class BinaryOper
 \pnum
 \requires
 \begin{itemize}
-\item \tcode{T} shall be \oldconcept{MoveConstructible} (\tref{moveconstructible}).
-\item All of \tcode{binary_op(init, *first)}, \tcode{binary_op(*first, init)},
-\tcode{binary_op(init, init)}, and \tcode{binary_op(*first, *first)} shall be
-convertible to \tcode{T}.
-\item \tcode{binary_op} shall neither invalidate iterators or subranges, nor modify
-elements in the range \crange{first}{last}.
+\item
+  \tcode{T} shall be \oldconcept{MoveConstructible} (\tref{moveconstructible}).
+\item
+  All of \tcode{binary_op(init, *first)}, \tcode{binary_op(*first, init)},
+  \tcode{binary_op(init, init)}, and \tcode{binary_op(*first, *first)}
+  shall be convertible to \tcode{T}.
+\item
+  \tcode{binary_op} shall neither invalidate iterators or subranges,
+  nor modify elements in the range \crange{first}{last}.
 \end{itemize}
 
 \pnum
 \returns
-\tcode{\placeholdernc{GENERALIZED_SUM}(binary_op, init, *i, ...)} for every \tcode{i} in \range{first}{last}.
+\tcode{\placeholdernc{GENERALIZED_SUM}(binary_op, init, *i, ...)}
+for every \tcode{i} in \range{first}{last}.
 
 \pnum
 \complexity
@@ -9147,9 +8970,10 @@ elements in the range \crange{first}{last}.
 \pnum
 \begin{note}
 The difference between \tcode{reduce} and \tcode{accumulate} is that
-\tcode{reduce} applies \tcode{binary_op} in an unspecified order, which yields
-a nondeterministic result for non-associative or non-commutative
-\tcode{binary_op} such as floating-point addition.
+\tcode{reduce} applies \tcode{binary_op} in an unspecified order,
+which yields a nondeterministic result
+for non-associative or non-commutative \tcode{binary_op}
+such as floating-point addition.
 \end{note}
 \end{itemdescr}
 
@@ -9171,34 +8995,24 @@ template<class InputIterator1, class InputIterator2, class T,
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{T} shall satisfy the \oldconcept{CopyConstructible} (\tref{copyconstructible})
+\tcode{T} shall satisfy
+the \oldconcept{CopyConstructible} (\tref{copyconstructible})
 and \oldconcept{CopyAssignable} (\tref{copyassignable}) requirements.
-In the ranges
-\crange{first1}{last1}
-and
+In the ranges \crange{first1}{last1} and
 \crange{first2}{first2 + (last1 - first1)}
-\tcode{binary_op1}
-and
-\tcode{binary_op2}
-shall neither modify elements nor invalidate iterators or subranges.\footnote{The use of fully closed ranges is intentional.}
+\tcode{binary_op1} and \tcode{binary_op2}
+shall neither modify elements nor invalidate iterators or subranges.%
+\footnote{The use of fully closed ranges is intentional.}
 
 \pnum
 \effects
-Computes its result by initializing the accumulator
-\tcode{acc}
-with the initial value
-\tcode{init}
+Computes its result by
+initializing the accumulator \tcode{acc} with the initial value \tcode{init}
 and then modifying it with
-\tcode{acc = std::move(acc) + (*i1) * (*i2)}
-or
+\tcode{acc = std::move(acc) + (*i1) * (*i2)} or
 \tcode{acc = binary_op1(std::move(acc), binary_op2(*i1, *i2))}
-for every iterator
-\tcode{i1}
-in the range \range{first1}{last1}
-and iterator
-\tcode{i2}
-in the range
-\range{first2}{first2 + (last1 - first1)}
+for every iterator \tcode{i1} in the range \range{first1}{last1}
+and iterator \tcode{i2} in the range \range{first2}{first2 + (last1 - first1)}
 in order.
 \end{itemdescr}
 
@@ -9213,7 +9027,8 @@ template<class InputIterator1, class InputIterator2, class T>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return transform_reduce(first1, last1, first2, init, plus<>(), multiplies<>());
 \end{codeblock}
@@ -9231,7 +9046,8 @@ template<class ExecutionPolicy,
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return transform_reduce(std::forward<ExecutionPolicy>(exec),
                         first1, last1, first2, init, plus<>(), multiplies<>());
@@ -9262,18 +9078,21 @@ template<class ExecutionPolicy,
 \pnum
 \requires
 \begin{itemize}
-\item \tcode{T} shall be \oldconcept{MoveConstructible} (\tref{moveconstructible}).
-\item All of
-\begin{itemize}
-\item \tcode{binary_op1(init, init)},
-\item \tcode{binary_op1(init, binary_op2(*first1, *first2))},
-\item \tcode{binary_op1(binary_op2(*first1, *first2), init)}, and
-\item \tcode{binary_op1(binary_op2(*first1, *first2), binary_op2(*first1, *first2))}
-\end{itemize}
-shall be convertible to \tcode{T}.
-\item Neither \tcode{binary_op1} nor \tcode{binary_op2} shall invalidate
-subranges, or modify elements in the ranges \crange{first1}{last1} and
-\crange{first2}{first2 + (last1 - first1)}.
+\item
+  \tcode{T} shall be \oldconcept{MoveConstructible} (\tref{moveconstructible}).
+\item
+  All of
+  \begin{itemize}
+  \item \tcode{binary_op1(init, init)},
+  \item \tcode{binary_op1(init, binary_op2(*first1, *first2))},
+  \item \tcode{binary_op1(binary_op2(*first1, *first2), init)}, and
+  \item \tcode{binary_op1(binary_op2(*first1, *first2), binary_op2(*first1, *first2))}
+  \end{itemize}
+  shall be convertible to \tcode{T}.
+\item
+  Neither \tcode{binary_op1} nor \tcode{binary_op2}
+  shall invalidate subranges, or modify elements in the ranges
+  \crange{first1}{last1} and \crange{first2}{first2 + (last1 - first1)}.
 \end{itemize}
 
 \pnum
@@ -9284,8 +9103,9 @@ subranges, or modify elements in the ranges \crange{first1}{last1} and
 for every iterator \tcode{i} in \range{first1}{last1}.
 
 \pnum
-\complexity \bigoh{\tcode{last1 - first1}} applications each of \tcode{binary_op1} and
-\tcode{binary_op2}.
+\complexity
+\bigoh{\tcode{last1 - first1}} applications each
+of \tcode{binary_op1} and \tcode{binary_op2}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{transform_reduce}}%
@@ -9306,17 +9126,20 @@ template<class ExecutionPolicy,
 \pnum
 \requires
 \begin{itemize}
-\item \tcode{T} shall be \oldconcept{MoveConstructible} (\tref{moveconstructible}).
-\item All of
-\begin{itemize}
-\item \tcode{binary_op(init, init)},
-\item \tcode{binary_op(init, unary_op(*first))},
-\item \tcode{binary_op(unary_op(*first), init)}, and
-\item \tcode{binary_op(unary_op(*first), unary_op(*first))}
-\end{itemize}
-shall be convertible to \tcode{T}.
-\item Neither \tcode{unary_op} nor \tcode{binary_op} shall invalidate subranges,
-or modify elements in the range \crange{first}{last}.
+\item
+  \tcode{T} shall be \oldconcept{MoveConstructible} (\tref{moveconstructible}).
+\item
+  All of
+  \begin{itemize}
+  \item \tcode{binary_op(init, init)},
+  \item \tcode{binary_op(init, unary_op(*first))},
+  \item \tcode{binary_op(unary_op(*first), init)}, and
+  \item \tcode{binary_op(unary_op(*first), unary_op(*first))}
+  \end{itemize}
+  shall be convertible to \tcode{T}.
+\item
+  Neither \tcode{unary_op} nor \tcode{binary_op} shall invalidate subranges,
+  or modify elements in the range \crange{first}{last}.
 \end{itemize}
 
 \pnum
@@ -9354,24 +9177,28 @@ template<class InputIterator, class OutputIterator, class BinaryOperation>
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{InputIterator}'s value type shall be constructible from the type of \tcode{*first}.
-The result of the expression \tcode{std::move(acc) + *i} or \tcode{binary_op(std::move(acc), *i)} shall be
-implicitly convertible to \tcode{InputIterator}'s value type. \tcode{acc}
-shall be writable\iref{iterator.requirements.general} to the \tcode{result} output iterator.
-In the ranges
-\crange{first}{last}
-and
-\crange{result}{result + (last - first)}
-\tcode{binary_op}
-shall neither modify elements nor invalidate iterators or subranges.\footnote{The use of fully closed ranges is intentional.
-}
+\tcode{InputIterator}'s value type shall be constructible
+from the type of \tcode{*first}.
+The result of the
+expression \tcode{std::move(acc) + *i} or \tcode{binary_op(std::move(acc), *i)}
+shall be implicitly convertible to \tcode{InputIterator}'s value type.
+\tcode{acc} shall be writable\iref{iterator.requirements.general} to
+the \tcode{result} output iterator.
+In the ranges \crange{first}{last} and \crange{result}{result + (last - first)}
+\tcode{binary_op} shall neither modify elements
+nor invalidate iterators or subranges.%
+\footnote{The use of fully closed ranges is intentional.}
 
 \pnum
-\effects For a non-empty range,
-the function creates an accumulator \tcode{acc} whose type is \tcode{InputIterator}'s
-value type, initializes it with \tcode{*first},
-and assigns the result to \tcode{*result}. For every iterator \tcode{i} in \range{first + 1}{last}
-in order, \tcode{acc} is then modified by \tcode{acc = std::move(acc) + *i} or \tcode{acc = binary_op(std::move(acc), *i)}
+\effects
+For a non-empty range,
+the function creates an accumulator \tcode{acc}
+whose type is \tcode{InputIterator}'s value type,
+initializes it with \tcode{*first},
+and assigns the result to \tcode{*result}.
+For every iterator \tcode{i} in \range{first + 1}{last} in order,
+\tcode{acc} is then modified by
+\tcode{acc = std::move(acc) + *i} or \tcode{acc = binary_op(std::move(acc), *i)}
 and the result is assigned to \tcode{*(result + (i - first))}.
 
 \pnum
@@ -9380,16 +9207,11 @@ and the result is assigned to \tcode{*(result + (i - first))}.
 
 \pnum
 \complexity
-Exactly
-\tcode{(last - first) - 1}
-applications of
-the binary operation.
+Exactly \tcode{(last - first) - 1} applications of the binary operation.
 
 \pnum
 \remarks
-\tcode{result}
-may be equal to
-\tcode{first}.
+\tcode{result} may be equal to \tcode{first}.
 \end{itemdescr}
 
 \rSec2[exclusive.scan]{Exclusive scan}
@@ -9426,7 +9248,6 @@ return exclusive_scan(std::forward<ExecutionPolicy>(exec),
 \end{codeblock}
 \end{itemdescr}
 
-
 \indexlibrary{\idxcode{exclusive_scan}}%
 \begin{itemdecl}
 template<class InputIterator, class OutputIterator, class T, class BinaryOperation>
@@ -9443,11 +9264,18 @@ template<class ExecutionPolicy,
 \pnum
 \requires
 \begin{itemize}
-\item \tcode{T} shall be \oldconcept{MoveConstructible} (\tref{moveconstructible}).
-\item All of \tcode{binary_op(init, init)}, \tcode{binary_op(init, *first)},
-and \tcode{binary_op(*first, *first)} shall be convertible to \tcode{T}.
-\item \tcode{binary_op} shall neither invalidate iterators or subranges, nor modify
-elements in the ranges \crange{first}{last} or \crange{result}{result + (last - first)}.
+\item
+  \tcode{T} shall be \oldconcept{MoveConstructible} (\tref{moveconstructible}).
+\item
+  All of
+  \tcode{binary_op(init, init)},
+  \tcode{binary_op(init, *first)},
+  and \tcode{binary_op(*first, *first)}
+  shall be convertible to \tcode{T}.
+\item
+  \tcode{binary_op} shall neither invalidate iterators or subranges,
+  nor modify elements in
+  the ranges \crange{first}{last} or \crange{result}{result + (last - first)}.
 \end{itemize}
 
 \pnum
@@ -9474,9 +9302,10 @@ The end of the resulting range beginning at \tcode{result}.
 \pnum
 \begin{note}
 The difference between \tcode{exclusive_scan} and \tcode{inclusive_scan} is
-that \tcode{exclusive_scan} excludes the $i^\text{th}$ input element from the
-$i^\text{th}$ sum. If \tcode{binary_op} is not mathematically associative, the
-behavior of \tcode{exclusive_scan} may be nondeterministic.
+that \tcode{exclusive_scan} excludes the $i^\text{th}$ input element
+from the $i^\text{th}$ sum.
+If \tcode{binary_op} is not mathematically associative,
+the behavior of \tcode{exclusive_scan} may be nondeterministic.
 \end{note}
 \end{itemdescr}
 
@@ -9512,7 +9341,6 @@ return inclusive_scan(std::forward<ExecutionPolicy>(exec), first, last, result, 
 \end{codeblock}
 \end{itemdescr}
 
-
 \indexlibrary{\idxcode{inclusive_scan}}%
 \begin{itemdecl}
 template<class InputIterator, class OutputIterator, class BinaryOperation>
@@ -9538,18 +9366,23 @@ template<class ExecutionPolicy,
 \pnum
 \requires
 \begin{itemize}
-\item If \tcode{init} is provided, \tcode{T} shall be \oldconcept{MoveConstructible}
-(\tref{moveconstructible}); otherwise, \tcode{ForwardIterator1}'s value
-type shall be \oldconcept{MoveConstructible}.
-
-\item If \tcode{init} is provided, all of \tcode{binary_op(init, init)},
-\tcode{binary_op(init, *first)}, and \tcode{binary_op(*first, *first)} shall be
-convertible to \tcode{T}; otherwise, \tcode{binary_op(*first, *first)} shall be
-convertible to \tcode{ForwardIterator1}'s value type.
-
-\item \tcode{binary_op} shall neither invalidate iterators or subranges, nor
-modify elements in the ranges \crange{first}{last} or
-\crange{result}{result + (last - first)}.
+\item
+  If \tcode{init} is provided,
+  \tcode{T} shall be \oldconcept{MoveConstructible} (\tref{moveconstructible});
+  otherwise, \tcode{ForwardIterator1}'s value type
+  shall be \oldconcept{MoveConstructible}.
+\item
+  If \tcode{init} is provided, all of
+  \tcode{binary_op(init, init)},
+  \tcode{binary_op(init, *first)}, and
+  \tcode{binary_op(*first, *first)}
+  shall be convertible to \tcode{T};
+  otherwise, \tcode{binary_op(*first, *first)}
+  shall be convertible to \tcode{ForwardIterator1}'s value type.
+\item
+  \tcode{binary_op} shall neither invalidate iterators or subranges,
+  nor modify elements in
+  the ranges \crange{first}{last} or \crange{result}{result + (last - first)}.
 \end{itemize}
 
 \pnum
@@ -9580,9 +9413,10 @@ The end of the resulting range beginning at \tcode{result}.
 \pnum
 \begin{note}
 The difference between \tcode{exclusive_scan} and \tcode{inclusive_scan} is
-that \tcode{inclusive_scan} includes the $i^\text{th}$ input element in the
-$i^\text{th}$ sum.  If \tcode{binary_op} is not mathematically associative, the
-behavior of \tcode{inclusive_scan} may be nondeterministic.
+that \tcode{inclusive_scan} includes the $i^\text{th}$ input element
+in the $i^\text{th}$ sum.
+If \tcode{binary_op} is not mathematically associative,
+the behavior of \tcode{inclusive_scan} may be nondeterministic.
 \end{note}
 \end{itemdescr}
 
@@ -9608,18 +9442,20 @@ template<class ExecutionPolicy,
 \pnum
 \requires
 \begin{itemize}
-\item \tcode{T} shall be \oldconcept{MoveConstructible} (\tref{moveconstructible}).
-\item All of
-\begin{itemize}
-\item \tcode{binary_op(init, init)},
-\item \tcode{binary_op(init, unary_op(*first))}, and
-\item \tcode{binary_op(unary_op(*first), unary_op(*first))}
-\end{itemize}
-shall be convertible to \tcode{T}.
-\item Neither \tcode{unary_op} nor \tcode{binary_op} shall invalidate iterators or
-subranges, or modify elements in the ranges
-\crange{first}{last} or
-\crange{result}{result + (last - first)}.
+\item
+  \tcode{T} shall be \oldconcept{MoveConstructible} (\tref{moveconstructible}).
+\item
+  All of
+  \begin{itemize}
+  \item \tcode{binary_op(init, init)},
+  \item \tcode{binary_op(init, unary_op(*first))}, and
+  \item \tcode{binary_op(unary_op(*first), unary_op(*first))}
+  \end{itemize}
+  shall be convertible to \tcode{T}.
+\item
+  Neither \tcode{unary_op} nor \tcode{binary_op} shall
+  invalidate iterators or subranges, or modify elements in
+  the ranges \crange{first}{last} or \crange{result}{result + (last - first)}.
 \end{itemize}
 
 \pnum
@@ -9638,8 +9474,8 @@ The end of the resulting range beginning at \tcode{result}.
 
 \pnum
 \complexity
-\bigoh{\tcode{last - first}} applications each of \tcode{unary_op} and
-\tcode{binary_op}.
+\bigoh{\tcode{last - first}} applications each
+of \tcode{unary_op} and \tcode{binary_op}.
 
 \pnum
 \remarks
@@ -9649,10 +9485,11 @@ The end of the resulting range beginning at \tcode{result}.
 \begin{note}
 The difference between \tcode{transform_exclusive_scan} and
 \tcode{transform_inclusive_scan} is that \tcode{transform_exclusive_scan}
-excludes the $i^\text{th}$ input element from the $i^\text{th}$ sum. If \tcode{binary_op} is not
-mathematically associative, the behavior of \tcode{transform_exclusive_scan}
-may be nondeterministic. \tcode{transform_exclusive_scan} does not apply
-\tcode{unary_op} to \tcode{init}.
+excludes the $i^\text{th}$ input element from the $i^\text{th}$ sum.
+If \tcode{binary_op} is not mathematically associative,
+the behavior of \tcode{transform_exclusive_scan} may be nondeterministic.
+\tcode{transform_exclusive_scan}
+does not apply \tcode{unary_op} to \tcode{init}.
 \end{note}
 \end{itemdescr}
 
@@ -9692,23 +9529,25 @@ template<class ExecutionPolicy,
 \pnum
 \requires
 \begin{itemize}
-\item If \tcode{init} is provided, \tcode{T} shall be \oldconcept{MoveConstructible}
-(\tref{moveconstructible}); otherwise, \tcode{ForwardIterator1}'s value
-type shall be \oldconcept{MoveConstructible}.
-
-\item If \tcode{init} is provided, all of
-\begin{itemize}
-\item \tcode{binary_op(init, init)},
-\item \tcode{binary_op(init, unary_op(*first))}, and
-\item \tcode{binary_op(unary_op(*first), unary_op(*first))}
-\end{itemize}
-shall be convertible to
-\tcode{T}; otherwise, \tcode{binary_op(unary_op(*first), unary_op(*first))}
-shall be convertible to \tcode{ForwardIterator1}'s value type.
-
-\item Neither \tcode{unary_op} nor \tcode{binary_op} shall invalidate iterators
-or subranges, nor modify elements in the ranges \crange{first}{last} or
-\crange{result}{result + (last - first)}.
+\item
+  If \tcode{init} is provided, \tcode{T} shall be
+  \oldconcept{MoveConstructible} (\tref{moveconstructible});
+  otherwise, \tcode{ForwardIterator1}'s value type shall be
+  \oldconcept{MoveConstructible}.
+\item
+  If \tcode{init} is provided, all of
+  \begin{itemize}
+  \item \tcode{binary_op(init, init)},
+  \item \tcode{binary_op(init, unary_op(*first))}, and
+  \item \tcode{binary_op(unary_op(*first), unary_op(*first))}
+  \end{itemize}
+  shall be convertible to \tcode{T};
+  otherwise, \tcode{binary_op(unary_op(*first), unary_op(*first))}
+  shall be convertible to \tcode{ForwardIterator1}'s value type.
+\item
+  Neither \tcode{unary_op} nor \tcode{binary_op} shall
+  invalidate iterators or subranges, nor modify elements in
+  the ranges \crange{first}{last} or \crange{result}{result + (last - first)}.
 \end{itemize}
 
 \pnum
@@ -9730,8 +9569,8 @@ The end of the resulting range beginning at \tcode{result}.
 
 \pnum
 \complexity
-\bigoh{\tcode{last - first}} applications each of \tcode{unary_op} and
-\tcode{binary_op}.
+\bigoh{\tcode{last - first}} applications each
+of \tcode{unary_op} and \tcode{binary_op}.
 
 \pnum
 \remarks
@@ -9741,10 +9580,11 @@ The end of the resulting range beginning at \tcode{result}.
 \begin{note}
 The difference between \tcode{transform_exclusive_scan} and
 \tcode{transform_inclusive_scan} is that \tcode{transform_inclusive_scan}
-includes the $i^\text{th}$ input element in the $i^\text{th}$ sum. If \tcode{binary_op} is not
-mathematically associative, the behavior of \tcode{transform_inclusive_scan}
-may be nondeterministic. \tcode{transform_inclusive_scan} does not apply
-\tcode{unary_op} to \tcode{init}.
+includes the $i^\text{th}$ input element in the $i^\text{th}$ sum.
+If \tcode{binary_op} is not mathematically associative,
+the behavior of \tcode{transform_inclusive_scan} may be nondeterministic.
+\tcode{transform_inclusive_scan} does not
+apply \tcode{unary_op} to \tcode{init}.
 \end{note}
 \end{itemdescr}
 
@@ -9783,36 +9623,38 @@ that denotes an object of type \tcode{minus<>}.
 \requires
 \begin{itemize}
 \item
-For the overloads with no \tcode{ExecutionPolicy},
-\tcode{T} shall be \oldconcept{MoveAssignable} (\tref{moveassignable}) and shall
-be constructible from the type of \tcode{*first}. \tcode{acc} (defined below)
-shall be writable\iref{iterator.requirements.general} to the \tcode{result}
-output iterator.  The result of the expression
-\tcode{binary_op(val, std::move(acc))} shall be writable to the \tcode{result} output iterator.
-
+  For the overloads with no \tcode{ExecutionPolicy},
+  \tcode{T} shall be \oldconcept{MoveAssignable} (\tref{moveassignable}) and
+  shall be constructible from the type of \tcode{*first}.
+  \tcode{acc} (defined below) shall be
+  writable\iref{iterator.requirements.general}
+  to the \tcode{result} output iterator.
+  The result of the expression \tcode{binary_op(val, std::move(acc))}
+  shall be writable to the \tcode{result} output iterator.
 \item
-For the overloads with an \tcode{ExecutionPolicy},
-the result of the expressions \tcode{binary_op(*first, *first)} and
-\tcode{*first} shall be writable to \tcode{result}.
-
+  For the overloads with an \tcode{ExecutionPolicy},
+  the result of the expressions \tcode{binary_op(*first, *first)} and
+  \tcode{*first} shall be writable to \tcode{result}.
 \item
-For all overloads, in the ranges
-\crange{first}{last}
-and
-\crange{result}{result + (last - first)},
-\tcode{binary_op}
-shall neither modify elements nor invalidate iterators or
-subranges.\footnote{The use of fully closed ranges is intentional.}
+  For all overloads, in the ranges \crange{first}{last}
+  and \crange{result}{result + (last - first)},
+  \tcode{binary_op} shall neither modify elements
+  nor invalidate iterators or subranges.%
+  \footnote{The use of fully closed ranges is intentional.}
 \end{itemize}
 
 \pnum
-\effects For the overloads with no \tcode{ExecutionPolicy} and a non-empty range,
+\effects
+For the overloads with no \tcode{ExecutionPolicy} and a non-empty range,
 the function creates an accumulator \tcode{acc} of type \tcode{T},
 initializes it with \tcode{*first},
-and assigns the result to \tcode{*result}. For every iterator \tcode{i} in \range{first + 1}{last}
-in order, creates an object \tcode{val} whose type is \tcode{T}, initializes it
-with \tcode{*i}, computes \tcode{binary_op(val, std::move(acc))}, assigns the result
-to \tcode{*(result + (i - first))}, and move assigns from \tcode{val} to \tcode{acc}.
+and assigns the result to \tcode{*result}.
+For every iterator \tcode{i} in \range{first + 1}{last} in order,
+creates an object \tcode{val} whose type is \tcode{T},
+initializes it with \tcode{*i},
+computes \tcode{binary_op(val, std::move(acc))},
+assigns the result to \tcode{*(result + (i - first))}, and
+move assigns from \tcode{val} to \tcode{acc}.
 
 \pnum
 For the overloads with an \tcode{ExecutionPolicy} and a non-empty range,
@@ -9826,16 +9668,15 @@ performs \tcode{*(result + d) = binary_op(*(first + d), *(first + (d - 1)))}.
 
 \pnum
 \complexity
-Exactly
-\tcode{(last - first) - 1}
-applications of
-the binary operation.
+Exactly \tcode{(last - first) - 1} applications of the binary operation.
 
 \pnum
 \remarks
-For the overloads with no \tcode{ExecutionPolicy}, \tcode{result} may be equal
-to \tcode{first}.  For the overloads with an \tcode{ExecutionPolicy}, the ranges
-\range{first}{last} and \range{result}{result + (last - first)} shall not overlap.
+For the overloads with no \tcode{ExecutionPolicy},
+\tcode{result} may be equal to \tcode{first}.
+For the overloads with an \tcode{ExecutionPolicy},
+the ranges \range{first}{last} and \range{result}{result + (last - first)}
+shall not overlap.
 \end{itemdescr}
 
 \rSec2[numeric.iota]{Iota}
@@ -9848,17 +9689,21 @@ template<class ForwardIterator, class T>
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{T} shall be convertible to \tcode{ForwardIterator}'s value
-type. The expression \tcode{++val}, where \tcode{val} has type \tcode{T}, shall
-be well-formed.
+\requires
+\tcode{T} shall be convertible to \tcode{ForwardIterator}'s value type.
+The expression \tcode{++val}, where \tcode{val} has type \tcode{T},
+shall be well-formed.
 
 \pnum
-\effects For each element referred to by the iterator \tcode{i} in the range
-\range{first}{last}, assigns \tcode{*i = value} and increments \tcode{value} as
-if by \tcode{++value}.
+\effects
+For each element referred to by the iterator \tcode{i}
+in the range \range{first}{last},
+assigns \tcode{*i = value} and increments \tcode{value}
+as if by \tcode{++value}.
 
 \pnum
-\complexity Exactly \tcode{last - first} increments and assignments.
+\complexity
+Exactly \tcode{last - first} increments and assignments.
 \end{itemdescr}
 
 \rSec2[numeric.ops.gcd]{Greatest common divisor}
@@ -9872,10 +9717,13 @@ template<class M, class N>
 \begin{itemdescr}
 \pnum
 \requires
-$|\tcode{m}|$ and $|\tcode{n}|$ shall
-be representable as a value of \tcode{common_type_t<M, N>}.
-\begin{note} These requirements ensure, for example,
-that $\tcode{gcd(m, m)} = |\tcode{m}|$ is representable as a value of type \tcode{M}. \end{note}
+$|\tcode{m}|$ and $|\tcode{n}|$
+shall be representable as a value of \tcode{common_type_t<M, N>}.
+\begin{note}
+These requirements ensure, for example,
+that $\tcode{gcd(m, m)} = |\tcode{m}|$
+is representable as a value of type \tcode{M}.
+\end{note}
 
 \pnum
 \remarks
@@ -9884,8 +9732,8 @@ if either is \cv{}~\tcode{bool}, the program is ill-formed.
 
 \pnum
 \returns
-Zero when \tcode{m} and \tcode{n} are both zero.
-Otherwise, returns the greatest common divisor of $|\tcode{m}|$ and $|\tcode{n}|$.
+Zero when \tcode{m} and \tcode{n} are both zero. Otherwise,
+returns the greatest common divisor of $|\tcode{m}|$ and $|\tcode{n}|$.
 
 \pnum
 \throws
@@ -9903,8 +9751,8 @@ template<class M, class N>
 \begin{itemdescr}
 \pnum
 \requires
-$|\tcode{m}|$ and $|\tcode{n}|$ shall
-be representable as a value of \tcode{common_type_t<M, N>}.
+$|\tcode{m}|$ and $|\tcode{n}|$
+shall be representable as a value of \tcode{common_type_t<M, N>}.
 The least common multiple of $|\tcode{m}|$ and $|\tcode{n}|$
 shall be representable as a value of type \tcode{common_type_t<M,N>}.
 
@@ -9951,8 +9799,7 @@ These functions have the semantics specified in the C standard library.
 \pnum
 \remarks
 The behavior is undefined
-unless the objects in the array pointed to by \tcode{base}
-are of trivial type.
+unless the objects in the array pointed to by \tcode{base} are of trivial type.
 
 \pnum
 \throws


### PR DESCRIPTION
except:
Move \begin{note} and \end{note} to lines of its own.
[alg.unique] fix two English-level typos
[alg.transform] remove superfluous space before period
[alg.partitions] remove duplicate \pnum
[alg.is_permutation,alg.move,is.sorted] add missing \tcode
[algorithms.parallel.exec] move comment in example

Fixes #2509.