### PR TITLE
[meta.logical] clarify short-circuiting property

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -2186,7 +2186,7 @@ The class template \tcode{conjunction}
 forms the logical conjunction of its template type arguments.
 
 \pnum
-For the specialization \tcode{disjunction<>},
+For the specialization \tcode{conjunction<>},
 let $\tcode{B}_{i}$ be \tcode{true_type}.
 For a specialization \tcode{conjunction<$\tcode{B}_{1}$, $\dotsc$, $\tcode{B}_{N}$>},
 let $\tcode{B}_{i}$ be

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -2194,6 +2194,23 @@ to exist\iref{temp.inst} for $i < j \leq N$.
 This is analogous to the short-circuiting behavior of
 the built-in operator \tcode{\&\&}.
 \end{note}
+\begin{note}
+This allows types without a \tcode{value} static data member
+to be template arguments for \tcode{conjunction}, as long as an
+earlier argument evaluates to \tcode{false}, for example:
+\begin{codeblock}
+template<class T>
+  concept HasValue = requires { { T::value } -> std::convertible_to<bool>; };
+template<class T>
+  using maybe_value = std::conjunction<std::bool_constant<HasValue<T>>, T>;
+
+struct X { };
+
+static_assert( ! maybe_value<X>::value );       // OK, \tcode{X::value} not used
+static_assert( ! maybe_value<int>::value );     // OK, \tcode{int::value} not used
+static_assert( maybe_value<std::true_type>::value );
+\end{codeblock}
+\end{note}
 
 \pnum
 Every template type argument

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -2188,7 +2188,7 @@ For a specialization \tcode{conjunction<$\tcode{B}_{1}$, $\dotsc$, $\tcode{B}_{N
 if there is a template type argument $\tcode{B}_{i}$
 for which \tcode{bool($\tcode{B}_{i}$::value)} is \tcode{false},
 then instantiating \tcode{conjunction<$\tcode{B}_{1}$, $\dotsc$, $\tcode{B}_{N}$>::value}
-does not require the instantiation of \tcode{$\tcode{B}_{j}$::value} for $j > i$.
+does not require the instantiation of \tcode{$\tcode{B}_{j}$::value} for $i < j \leq N$.
 \begin{note}
 This is analogous to the short-circuiting behavior of
 the built-in operator \tcode{\&\&}.
@@ -2240,7 +2240,7 @@ For a specialization \tcode{disjunction<$\tcode{B}_{1}$, $\dotsc$, $\tcode{B}_{N
 if there is a template type argument $\tcode{B}_{i}$
 for which \tcode{bool($\tcode{B}_{i}$::value)} is \tcode{true},
 then instantiating \tcode{disjunction<$\tcode{B}_{1}$, $\dotsc$, $\tcode{B}_{N}$>::value}
-does not require the instantiation of \tcode{$\tcode{B}_{j}$::value} for $j > i$.
+does not require the instantiation of \tcode{$\tcode{B}_{j}$::value} for $i < j \leq N$.
 \begin{note}
 This is analogous to the short-circuiting behavior of
 the built-in operator \tcode{||}.

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -374,6 +374,8 @@ namespace std {
   template<class... B> struct conjunction;
   template<class... B> struct disjunction;
   template<class B> struct negation;
+  template<> struct conjunction : true_type { };
+  template<> struct disjunction : false_type { };
 
   // \ref{meta.unary.cat}, primary type categories
   template<class T>
@@ -2184,12 +2186,27 @@ The class template \tcode{conjunction}
 forms the logical conjunction of its template type arguments.
 
 \pnum
+For the specialization \tcode{disjunction<>},
+let $\tcode{B}_{i}$ be \tcode{true_type}.
 For a specialization \tcode{conjunction<$\tcode{B}_{1}$, $\dotsc$, $\tcode{B}_{N}$>},
-if there is a template type argument $\tcode{B}_{i}$
-for which \tcode{bool($\tcode{B}_{i}$::value)} is \tcode{false},
-then instantiating \tcode{conjunction<$\tcode{B}_{1}$, $\dotsc$, $\tcode{B}_{N}$>::value}
-does not require a definition of \tcode{$\tcode{B}_{j}$::value}
-to exist\iref{temp.inst} for $i < j \leq N$.
+let $\tcode{B}_{i}$ be
+the first type in \tcode{$\tcode{B}_{1}$, $\dotsc$, $\tcode{B}_{N}$}
+for which \tcode{$\tcode{B}_{i}$::value} is \tcode{false},
+or $\tcode{B}_{N}$ if there is no such type.
+
+\pnum
+The specialization
+\tcode{conjunction<$\tcode{B}_{1}$, $\dotsc$, $\tcode{B}_{N}$>}
+has a public and unambiguous base class of type $\tcode{B}_{i}$.
+\begin{note}
+This means a specialization of \tcode{conjunction}
+does not necessarily inherit from
+either \tcode{true_type} or \tcode{false_type}.
+\end{note}
+
+\pnum
+Instantiation of \tcode{$\tcode{B}_{j}$::value} is required for $1 \leq j \leq i$.
+Instantiation of \tcode{$\tcode{B}_{k}$::value} is not required for $i < k \leq N$.
 \begin{note}
 This is analogous to the short-circuiting behavior of
 the built-in operator \tcode{\&\&}.
@@ -2213,33 +2230,14 @@ static_assert( maybe_value<std::true_type>::value );
 \end{note}
 
 \pnum
-Every template type argument
-for which \tcode{$\tcode{B}_{i}$::value} is instantiated
+Every template type argument $\tcode{B}_{j}$ for $1 \leq j \leq i$
 shall be usable as a base class and
-shall have a member \tcode{value} which
-is convertible to \tcode{bool},
-is not hidden, and
-is unambiguously available in the type.
-
-\pnum
-The specialization \tcode{conjunction<$\tcode{B}_{1}$, $\dotsc$, $\tcode{B}_{N}$>}
-has a public and unambiguous base that is either
-\begin{itemize}
-\item
-the first type $\tcode{B}_{i}$ in the list \tcode{true_type, $\tcode{B}_{1}$, $\dotsc$, $\tcode{B}_{N}$}
-for which \tcode{bool($\tcode{B}_{i}$::value)} is \tcode{false}, or
-\item
-if there is no such $\tcode{B}_{i}$, the last type in the list.
-\end{itemize}
-\begin{note}
-This means a specialization of \tcode{conjunction}
-does not necessarily inherit from
-either \tcode{true_type} or \tcode{false_type}.
-\end{note}
+shall have a member \tcode{value} such that
+\tcode{bool($B_j$::value)} is a constant expression.
 
 \pnum
 The member names of the base class, other than \tcode{conjunction} and
-\tcode{operator=}, shall not be hidden and shall be unambiguously available
+\tcode{operator=}, are not hidden and are unambiguously available
 in \tcode{conjunction}.
 \end{itemdescr}
 
@@ -2254,34 +2252,18 @@ The class template \tcode{disjunction}
 forms the logical disjunction of its template type arguments.
 
 \pnum
+For the specialization \tcode{disjunction<>},
+let $\tcode{B}_{i}$ be \tcode{false_type}.
 For a specialization \tcode{disjunction<$\tcode{B}_{1}$, $\dotsc$, $\tcode{B}_{N}$>},
-if there is a template type argument $\tcode{B}_{i}$
-for which \tcode{bool($\tcode{B}_{i}$::value)} is \tcode{true},
-then instantiating \tcode{disjunction<$\tcode{B}_{1}$, $\dotsc$, $\tcode{B}_{N}$>::value}
-does not require a definition of \tcode{$\tcode{B}_{j}$::value}
-to exist\iref{temp.inst} for $i < j \leq N$.
-\begin{note}
-This is analogous to the short-circuiting behavior of
-the built-in operator \tcode{||}.
-\end{note}
+let $\tcode{B}_{i}$ be
+the first type in \tcode{$\tcode{B}_{1}$, $\dotsc$, $\tcode{B}_{N}$}
+for which \tcode{$\tcode{B}_{i}$::value} is \tcode{true},
+or $\tcode{B}_{N}$ if there is no such type.
 
 \pnum
-Every template type argument
-for which \tcode{$\tcode{B}_{i}$::value} is instantiated
-shall be usable as a base class and
-shall have a member \tcode{value} which
-is convertible to \tcode{bool},
-is not hidden, and
-is unambiguously available in the type.
-
-\pnum
-The specialization \tcode{disjunction<$\tcode{B}_{1}$, $\dotsc$, $\tcode{B}_{N}$>}
-has a public and unambiguous base that is either
-\begin{itemize}
-\item the first type $\tcode{B}_{i}$ in the list \tcode{false_type, $\tcode{B}_{1}$, $\dotsc$, $\tcode{B}_{N}$}
-for which \tcode{bool($\tcode{B}_{i}$::value)} is \tcode{true}, or
-\item if there is no such $\tcode{B}_{i}$, the last type in the list.
-\end{itemize}
+The specialization
+\tcode{disjunction<$\tcode{B}_{1}$, $\dotsc$, $\tcode{B}_{N}$>}
+has a public and unambiguous base class of type $\tcode{B}_{i}$.
 \begin{note}
 This means a specialization of \tcode{disjunction}
 does not necessarily inherit from
@@ -2289,9 +2271,26 @@ either \tcode{true_type} or \tcode{false_type}.
 \end{note}
 
 \pnum
+Instantiation of \tcode{$\tcode{B}_{j}$::value} is required for $1 \leq j \leq i$.
+Instantiation of \tcode{$\tcode{B}_{k}$::value} is not required for $i < k \leq N$.
+\begin{note}
+This is analogous to the short-circuiting behavior of
+the built-in operator \tcode{||}.
+This allows types without a \tcode{value} static data member
+to be template arguments for \tcode{disjunction}, as long as an
+earlier argument evaluates to \tcode{true},
+\end{note}
+
+\pnum
+Every template type argument $\tcode{B}_{j}$ for $1 \leq j \leq i$
+shall be usable as a base class and
+shall have a member \tcode{value} such that
+\tcode{bool($B_j$::value)} is a constant expression.
+
+\pnum
 The member names of the base class,
 other than \tcode{disjunction} and \tcode{operator=},
-shall not be hidden and shall be unambiguously available in \tcode{disjunction}.
+are not hidden and are unambiguously available in \tcode{disjunction}.
 \end{itemdescr}
 
 \indexlibraryglobal{negation}%

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -2188,7 +2188,8 @@ For a specialization \tcode{conjunction<$\tcode{B}_{1}$, $\dotsc$, $\tcode{B}_{N
 if there is a template type argument $\tcode{B}_{i}$
 for which \tcode{bool($\tcode{B}_{i}$::value)} is \tcode{false},
 then instantiating \tcode{conjunction<$\tcode{B}_{1}$, $\dotsc$, $\tcode{B}_{N}$>::value}
-does not require the instantiation of \tcode{$\tcode{B}_{j}$::value} for $i < j \leq N$.
+does not require a definition of \tcode{$\tcode{B}_{j}$::value}
+to exist\iref{temp.inst} for $i < j \leq N$.
 \begin{note}
 This is analogous to the short-circuiting behavior of
 the built-in operator \tcode{\&\&}.
@@ -2240,7 +2241,8 @@ For a specialization \tcode{disjunction<$\tcode{B}_{1}$, $\dotsc$, $\tcode{B}_{N
 if there is a template type argument $\tcode{B}_{i}$
 for which \tcode{bool($\tcode{B}_{i}$::value)} is \tcode{true},
 then instantiating \tcode{disjunction<$\tcode{B}_{1}$, $\dotsc$, $\tcode{B}_{N}$>::value}
-does not require the instantiation of \tcode{$\tcode{B}_{j}$::value} for $i < j \leq N$.
+does not require a definition of \tcode{$\tcode{B}_{j}$::value}
+to exist\iref{temp.inst} for $i < j \leq N$.
 \begin{note}
 This is analogous to the short-circuiting behavior of
 the built-in operator \tcode{||}.

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -2223,9 +2223,9 @@ template<class T>
 
 struct X { };
 
-static_assert( ! maybe_value<X>::value );       // OK, \tcode{X::value} not used
-static_assert( ! maybe_value<int>::value );     // OK, \tcode{int::value} not used
-static_assert( maybe_value<std::true_type>::value );
+static_assert(!maybe_value<X>::value);      // OK, \tcode{X::value} not used
+static_assert(!maybe_value<int>::value);    // OK, \tcode{int::value} not used
+static_assert(maybe_value<std::true_type>::value);
 \end{codeblock}
 \end{note}
 


### PR DESCRIPTION
This implements the clarification I suggested in https://github.com/cplusplus/draft/issues/2548#issuecomment-443689234 (because if `Bj` is not a template then talking about "instantiation of `Bj::value" doesn't make sense) and the improvement to the inequality that Thomas suggested at https://github.com/cplusplus/draft/pull/2549#discussion_r238262056

It also adds an example showing a consequence of this property.