### PR TITLE
Escape spaces following mid-sentence periods.

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -1651,7 +1651,7 @@ do {
 \end{example}
 \begin{example} Because the expected value is updated only on failure,
 code releasing the memory containing the \tcode{expected} value on success will work.
-E.g. list head insertion will act atomically and would not introduce a
+E.g.\ list head insertion will act atomically and would not introduce a
 data race in the following code:
 \begin{codeblock}
 do {

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -635,9 +635,9 @@ Ritchie: \doccite{The C Programming Language} (Prentice-Hall, 1978, ISBN
 
 \pnum
 Portions of the library Clauses of this document are based
-on work by P.J. Plauger, which was published as \doccite{The Draft
+on work by P.J.\ Plauger, which was published as \doccite{The Draft
 Standard \Cpp{}  Library} (Prentice-Hall, ISBN 0-13-117003-1, copyright
-\copyright 1995 P.J. Plauger).
+\copyright 1995 P.J.\ Plauger).
 
 \pnum
 POSIX\textregistered\ is a registered trademark of the Institute of Electrical and

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -6416,7 +6416,7 @@ shall be in scope at the point at which the member is defined.
 The definition of an explicitly specialized class is unrelated to the
 definition of a generated specialization.
 That is, its members need
-not have the same names, types, etc. as the members of a generated
+not have the same names, types, etc.\ as the members of a generated
 specialization.
 Members of an explicitly specialized
 class template are defined in the same manner as members of normal classes, and

--- a/source/time.tex
+++ b/source/time.tex
@@ -11157,7 +11157,7 @@ The modified command \tcode{\%EX} produces the locale's alternate time represent
 \tcode{\%y} &
 The last two decimal digits of the year.
 If the century is not otherwise specified
-(e.g.  with \tcode{\%C}),
+(e.g.\ with \tcode{\%C}),
 values in the range \crange{69}{99}
 are presumed to refer to the years 1969 to 1999,
 and values in the range \crange{00}{68}


### PR DESCRIPTION
Fixes #2555.