### PR TITLE
[atomics.types.operations]/20 Replace "E.g." at start of sentence with "For example".

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -1651,7 +1651,7 @@ do {
 \end{example}
 \begin{example} Because the expected value is updated only on failure,
 code releasing the memory containing the \tcode{expected} value on success will work.
-E.g. list head insertion will act atomically and would not introduce a
+For example, list head insertion will act atomically and would not introduce a
 data race in the following code:
 \begin{codeblock}
 do {


### PR DESCRIPTION
See #2557.
Fixes #2555.