### PR TITLE
Fix spacing after full stops that LaTeX mistakenly thinks are mid-sentence.

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -556,7 +556,7 @@ Common in old programs, but already known to be obsolescent.
 \diffref{dcl.init.aggr}
 \change
 In \Cpp{}, designated initialization support is restricted
-compared to the corresponding functionality in C.
+compared to the corresponding functionality in C\@.
 In \Cpp{},
 designators for non-static data members
 must be specified in declaration order,

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -10713,8 +10713,8 @@ operating system or other APIs. \end{note}
 
 \pnum
 Implementations should provide such behavior as it is defined by
-POSIX. Implementations shall document any behavior that differs from the
-behavior defined by POSIX. Implementations that do not support exact POSIX
+POSIX\@. Implementations shall document any behavior that differs from the
+behavior defined by POSIX\@. Implementations that do not support exact POSIX
 behavior should provide behavior as close to POSIX behavior as is reasonable given the
 limitations of actual operating systems and file systems. If an implementation cannot provide any
 reasonable behavior, the implementation shall report an error as specified in~\ref{fs.err.report}.
@@ -10769,7 +10769,7 @@ is unreasonable for a program to detect them prior to calling the function.
 \pnum
 This subclause mentions commercially
 available operating systems for purposes of exposition.\footnote{
-POSIX\textregistered\ is a registered trademark of The IEEE.
+POSIX\textregistered\ is a registered trademark of The IEEE\@.
 Windows\textregistered\ is a registered trademark of Microsoft Corporation.
 This information is given for the convenience of users of this document and
 does not constitute an endorsement by ISO or IEC of these
@@ -11584,14 +11584,14 @@ shall be one of:
 \item \tcode{basic_string_view<EcharT, traits>}. A function
   argument \tcode{const Source\&} \tcode{source} shall have an
   effective range \range{source.begin()}{source.end()}.
-\item A type meeting the \oldconcept{InputIterator} requirements that iterates over a NTCTS.
+\item A type meeting the \oldconcept{InputIterator} requirements that iterates over a NTCTS\@.
   The value type shall be an encoded character type. A function argument
   \tcode{const Source\&} \tcode{source} shall have an effective range
   \range{source}{end} where \tcode{end} is the first
   iterator value with an element value equal to
   \tcode{iterator_traits<Source>::value_type()}.
 \item A character array that after array-to-pointer decay results in a
-  pointer to the start of a NTCTS. The value type shall be an encoded character type. A
+  pointer to the start of a NTCTS\@. The value type shall be an encoded character type. A
   function argument \tcode{const Source\&} \tcode{source} shall
   have an effective range \range{source}{end} where
   \tcode{end} is the first iterator value with an element value equal to

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -983,7 +983,7 @@ template<class T> complex<T> polar(const T& rho, const T& theta = T());
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{rho} shall be non-negative and non-NaN. \tcode{theta} shall be finite.
+\tcode{rho} shall be non-negative and non-NaN\@. \tcode{theta} shall be finite.
 
 \pnum
 \returns

--- a/source/time.tex
+++ b/source/time.tex
@@ -2976,10 +2976,10 @@ namespace std::chrono {
 \pnum
 The clock \tcode{tai_clock} measures seconds since 1958-01-01 00:00:00
 and is offset 10s ahead of UTC at this date.
-That is, 1958-01-01 00:00:00 TAI is equivalent to 1957-12-31 23:59:50 UTC.
-Leap seconds are not inserted into TAI.
+That is, 1958-01-01 00:00:00 TAI is equivalent to 1957-12-31 23:59:50 UTC\@.
+Leap seconds are not inserted into TAI\@.
 Therefore every time a leap second is inserted into UTC,
-UTC falls another second behind TAI.
+UTC falls another second behind TAI\@.
 For example by 2000-01-01 there had been 22 leap seconds inserted
 so 2000-01-01 00:00:00 UTC is equivalent to 2000-01-01 00:00:32 TAI
 (22s plus the initial 10s offset).
@@ -3165,10 +3165,10 @@ namespace std::chrono {
 
 \pnum
 The clock \tcode{gps_clock} measures
-seconds since the first Sunday of January, 1980 00:00:00 UTC.
-Leap seconds are not inserted into GPS.
+seconds since the first Sunday of January, 1980 00:00:00 UTC\@.
+Leap seconds are not inserted into GPS\@.
 Therefore every time a leap second is inserted into UTC,
-UTC falls another second behind GPS.
+UTC falls another second behind GPS\@.
 Aside from the offset from \tcode{1958y/January/1} to \tcode{1980y/January/Sunday[1]},
 GPS is behind TAI by 19s due to the 10s offset between 1958 and 1970
 and the additional 9 leap seconds inserted between 1970 and 1980.
@@ -10804,7 +10804,7 @@ it is left-padded with \tcode{0} to four digits.
 \\ \rowsep
 \tcode{\%z} &
 The offset from UTC in the ISO 8601 format.
-For example \tcode{-0430} refers to 4 hours 30 minutes behind UTC.
+For example \tcode{-0430} refers to 4 hours 30 minutes behind UTC\@.
 If the offset is zero, \tcode{+0000} is used.
 The modified commands \tcode{\%Ez} and  \tcode{\%Oz}
 insert a \tcode{:} between the hours and minutes: \tcode{-04:30}.
@@ -11181,7 +11181,7 @@ the locale's alternative representation.
 \tcode{\%z} &
 The offset from UTC in the format \tcode{[+|-]hh[mm]}.
 For example \tcode{-0430} refers to 4 hours 30 minutes behind UTC,
-and \tcode{04} refers to 4 hours ahead of UTC.
+and \tcode{04} refers to 4 hours ahead of UTC\@.
 The modified commands \tcode{\%Ez} and \tcode{\%Oz}
 parse a \tcode{:} between the hours and minutes
 and render leading zeroes on the hour field optional:


### PR DESCRIPTION
Without the `\@`, LaTeX thinks these are mid-sentence periods because they are preceded by a capital letter. Consequently, it applies word-spacing instead of sentence-spacing.

See Rule 2 at https://tex.stackexchange.com/a/55112.

The only visual effect is an ever-so-slightly wider space after these periods.

(Incidentally, this also helps cxxdraft-htmlgen's sentence splitting, since I'm making it use the same heuristic as LaTeX.)