### PR TITLE
[iosfwd.syn] Change char_traits from 'class' to 'struct'.

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -169,12 +169,12 @@ library call \textit{b} such that this does not result in a data race, then
 \indexlibrary{\idxcode{u32streampos}}%
 \begin{codeblock}
 namespace std {
-  template<class charT> class char_traits;
-  template<> class char_traits<char>;
-  template<> class char_traits<char8_t>;
-  template<> class char_traits<char16_t>;
-  template<> class char_traits<char32_t>;
-  template<> class char_traits<wchar_t>;
+  template<class charT> struct char_traits;
+  template<> struct char_traits<char>;
+  template<> struct char_traits<char8_t>;
+  template<> struct char_traits<char16_t>;
+  template<> struct char_traits<char32_t>;
+  template<> struct char_traits<wchar_t>;
 
   template<class T> class allocator;
 


### PR DESCRIPTION
Fixes #2561.