### PR TITLE
[temp.func.order] Adjust example to rules in [temp.deduct.partial].

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -3818,7 +3818,7 @@ template<class T, class... U> void g(T*, U...);         // \#3
 template<class T            > void g(T);                // \#4
 
 void h(int i) {
-  f(&i);                                                // error: ambiguous
+  f(&i);                                                // OK: calls \#2
   g(&i);                                                // OK: calls \#3
 }
 \end{codeblock}


### PR DESCRIPTION
Fixes #2559.