### PR TITLE
[iterator.traits] Remove space between type and ref-qualifier

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -855,11 +855,11 @@ concept @\placeholder{cpp17-input-iterator}@ =
   @\placeholder{cpp17-iterator}@<I> && EqualityComparable<I> && requires(I i) {
     typename incrementable_traits<I>::difference_type;
     typename readable_traits<I>::value_type;
-    typename common_reference_t<iter_reference_t<I> &&,
-                                typename readable_traits<I>::value_type &>;
+    typename common_reference_t<iter_reference_t<I>&&,
+                                typename readable_traits<I>::value_type&>;
     *i++;
-    typename common_reference_t<decltype(*i++) &&,
-                                typename readable_traits<I>::value_type &>;
+    typename common_reference_t<decltype(*i++)&&,
+                                typename readable_traits<I>::value_type&>;
     requires SignedIntegral<typename incrementable_traits<I>::difference_type>;
   };
 


### PR DESCRIPTION
Or could the convention have changed for this kind of constraints?