### PR TITLE
[expr.and][expr.or][expr.xor] Add grouping sentence to the binary and/or/xor operators.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5982,6 +5982,7 @@ false.
 \end{bnf}
 
 \pnum
+The \tcode{\&} operator groups left-to-right.
 The operands shall be of integral or unscoped enumeration type.
 The usual arithmetic conversions\iref{expr.arith.conv} are performed.
 Given the coefficients $\tcode{x}_i$ and $\tcode{y}_i$
@@ -6006,6 +6007,7 @@ The result is the bitwise \logop{AND} function of the operands.
 \end{bnf}
 
 \pnum
+The \tcode{\^} operator groups left-to-right.
 The operands shall be of integral or unscoped enumeration type.
 The usual arithmetic conversions\iref{expr.arith.conv} are performed.
 Given the coefficients $\tcode{x}_i$ and $\tcode{y}_i$
@@ -6031,6 +6033,7 @@ The result is the bitwise exclusive \logop{OR} function of the operands.
 \end{bnf}
 
 \pnum
+The \tcode{|} operator groups left-to-right.
 The operands shall be of integral or unscoped enumeration type.
 The usual arithmetic conversions\iref{expr.arith.conv} are performed.
 Given the coefficients $\tcode{x}_i$ and $\tcode{y}_i$


### PR DESCRIPTION
It seems like every binary expression has a sentence which says which way the operator groups, except for and, or and xor.

For consistency, add a sentence saying that they group left-to-right.