### PR TITLE
[range.view] Add complexity requirement normatively

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -867,6 +867,11 @@ template<class T>
 
 \begin{itemdescr}
 \pnum
+\tcode{T} models \libconcept{View} only if the complexity
+for each initialization and assignment required by \libconcept{Copyable<T>}
+is constant time.
+
+\pnum
 For a type \tcode{T}, the default value of \tcode{enable_view<T>} is:
 \begin{itemize}
 

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -850,6 +850,10 @@ copying the container copies the elements,
 which cannot be done in constant time.
 \end{example}
 
+\pnum
+Since the difference between \libconcept{Range} and \libconcept{View} is largely
+semantic, the two are differentiated with the help of \tcode{enable_view}.
+
 \indexlibrary{\idxcode{enable_view}}%
 \indexlibrary{\idxcode{View}}%
 \begin{itemdecl}
@@ -862,10 +866,6 @@ template<class T>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-Since the difference between \libconcept{Range} and \libconcept{View} is largely
-semantic, the two are differentiated with the help of \tcode{enable_view}.
-
 \pnum
 For a type \tcode{T}, the default value of \tcode{enable_view<T>} is:
 \begin{itemize}


### PR DESCRIPTION
And drive-by move description above the definitions.
Also, could a \pnum be missing after the list in the example?