### PR TITLE
[temp.mem.func] Remove inappropriate parentheses in 'Array<T>::operator[]()'.

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -2220,7 +2220,7 @@ of the type of the object for which the member function is called.
 The
 \grammarterm{template-argument}
 for
-\tcode{Array<T>::operator[]()}
+\tcode{Array<T>::operator[]}
 will be determined by the
 \tcode{Array}
 to which the subscripting operation is applied.
@@ -2229,8 +2229,8 @@ to which the subscripting operation is applied.
 Array<int> v1(20);
 Array<dcomplex> v2(30);
 
-v1[3] = 7;                              // \tcode{Array<int>::operator[]()}
-v2[3] = dcomplex(7,8);                  // \tcode{Array<dcomplex>::operator[]()}
+v1[3] = 7;                              // \tcode{Array<int>::operator[]}
+v2[3] = dcomplex(7,8);                  // \tcode{Array<dcomplex>::operator[]}
 \end{codeblock}
 \end{example}
 


### PR DESCRIPTION
Per [Specification-Style-Guidelines/describing-function-calls](https://github.com/cplusplus/draft/wiki/Specification-Style-Guidelines#describing-function-calls).