### PR TITLE
Fixed title of [dcl.constexpr] section to include consteval

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -735,8 +735,9 @@ typedef decltype([]{}) C;       // the closure type has no name for linkage purp
 The \tcode{friend} specifier is used to specify access to class members;
 see~\ref{class.friend}.
 
-\rSec2[dcl.constexpr]{The \tcode{constexpr} specifier}%
+\rSec2[dcl.constexpr]{The \tcode{constexpr} and \tcode{consteval} specifiers}%
 \indextext{specifier!\idxcode{constexpr}}
+\indextext{specifier!\idxcode{consteval}}
 
 \pnum
 The \tcode{constexpr} specifier shall be applied only to


### PR DESCRIPTION
The [dcl.constexpr] section was recently expanded to describe the consteval specifier. I believe the title of the section should reflect that.