### PR TITLE
[diff.dcl] Remove space before colon.

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -446,7 +446,7 @@ conversion function.
 In the following example, the
 left-hand column presents valid C;
 the right-hand column presents
-equivalent \Cpp{} :
+equivalent \Cpp{}:
 
 \begin{codeblock}
 void f(const parm);            void f(const int parm);


### PR DESCRIPTION
The space is visible in the pdf.