### PR TITLE
[reverse.iterators] Use the public accessor function,

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -3305,12 +3305,12 @@ template<class Iterator1, class Iterator2>
 \begin{itemdescr}
 \pnum
 \constraints
-The expression \tcode{x.current == y.current} shall be valid and
+The expression \tcode{x.base() == y.base()} shall be valid and
 convertible to \tcode{bool}.
 
 \pnum
 \returns
-\tcode{x.current == y.current}.
+\tcode{x.base() == y.base()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator"!=}{reverse_iterator}%
@@ -3324,12 +3324,12 @@ template<class Iterator1, class Iterator2>
 \begin{itemdescr}
 \pnum
 \constraints
-The expression \tcode{x.current != y.current} shall be valid and
+The expression \tcode{x.base() != y.base()} shall be valid and
 convertible to \tcode{bool}.
 
 \pnum
 \returns
-\tcode{x.current != y.current}.
+\tcode{x.base() != y.base()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<}{reverse_iterator}%
@@ -3343,12 +3343,12 @@ template<class Iterator1, class Iterator2>
 \begin{itemdescr}
 \pnum
 \constraints
-The expression \tcode{x.current > y.current} shall be valid and
+The expression \tcode{x.base() > y.base()} shall be valid and
 convertible to \tcode{bool}.
 
 \pnum
 \returns
-\tcode{x.current > y.current}.
+\tcode{x.base() > y.base()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>}{reverse_iterator}%
@@ -3362,12 +3362,12 @@ template<class Iterator1, class Iterator2>
 \begin{itemdescr}
 \pnum
 \constraints
-The expression \tcode{x.current < y.current} shall be valid and
+The expression \tcode{x.base() < y.base()} shall be valid and
 convertible to \tcode{bool}.
 
 \pnum
 \returns
-\tcode{x.current < y.current}.
+\tcode{x.base() < y.base()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=}{reverse_iterator}%
@@ -3381,12 +3381,12 @@ template<class Iterator1, class Iterator2>
 \begin{itemdescr}
 \pnum
 \constraints
-The expression \tcode{x.current >= y.current} shall be valid and
+The expression \tcode{x.base() >= y.base()} shall be valid and
 convertible to \tcode{bool}.
 
 \pnum
 \returns
-\tcode{x.current >= y.current}.
+\tcode{x.base() >= y.base()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>=}{reverse_iterator}%
@@ -3400,12 +3400,12 @@ template<class Iterator1, class Iterator2>
 \begin{itemdescr}
 \pnum
 \constraints
-The expression \tcode{x.current <= y.current} shall be valid and
+The expression \tcode{x.base() <= y.base()} shall be valid and
 convertible to \tcode{bool}.
 
 \pnum
 \returns
-\tcode{x.current <= y.current}.
+\tcode{x.base() <= y.base()}.
 \end{itemdescr}
 
 \rSec3[reverse.iter.nonmember]{Non-member functions}
@@ -3421,7 +3421,7 @@ template<class Iterator1, class Iterator2>
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{y.current - x.current}.
+\tcode{y.base() - x.base()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+}{reverse_iterator}%
@@ -3435,7 +3435,7 @@ template<class Iterator>
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{reverse_iterator<Iterator>(x.current - n)}.
+\tcode{reverse_iterator<Iterator>(x.base() - n)}.
 \end{itemdescr}
 
 \indexlibrarymember{iter_move}{reverse_iterator}%
@@ -3448,7 +3448,7 @@ friend constexpr iter_rvalue_reference_t<Iterator>
 \pnum
 \effects Equivalent to:
 \begin{codeblock}
-auto tmp = i.current;
+auto tmp = i.base();
 return ranges::iter_move(--tmp);
 \end{codeblock}
 
@@ -3472,8 +3472,8 @@ template<IndirectlySwappable<Iterator> Iterator2>
 \pnum
 \effects Equivalent to:
 \begin{codeblock}
-auto xtmp = x.current;
-auto ytmp = y.current;
+auto xtmp = x.base();
+auto ytmp = y.base();
 ranges::iter_swap(--xtmp, --ytmp);
 \end{codeblock}
 


### PR DESCRIPTION
not the exposition-only member 'current', from non-member functions.

Fixes #2579.