### PR TITLE
[expr.new] A new-expression might not invoke a constructor

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4824,7 +4824,8 @@ value computation of the
 If the \grammarterm{new-expression} creates an object or an array of
 objects of class type, access and ambiguity control are done for the
 allocation function, the deallocation function\iref{class.free}, and
-the constructor\iref{class.ctor}. If the \grammarterm{new-expression}
+the constructor\iref{class.ctor} selected for the initialization (if any).
+If the \grammarterm{new-expression}
 creates an array of objects of class type, the destructor is potentially
 invoked\iref{class.dtor}.
 


### PR DESCRIPTION
Fixes #2484.