### PR TITLE
[basic.life] Adjust subclause heading

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2826,7 +2826,7 @@ new types from existing types\iref{basic.types}.
 \end{note}%
 \indextext{object model|)}
 
-\rSec2[basic.life]{Object lifetime}
+\rSec2[basic.life]{Object and reference lifetime}
 
 \pnum
 \indextext{object lifetime|(}%
@@ -2855,8 +2855,9 @@ or is reused by an object that is not nested within \placeholder{o}\iref{intro.o
 \end{itemize}
 
 \pnum
+\indextext{reference lifetime}%
 The lifetime of a reference begins when its initialization is complete.
-The lifetime of a reference ends as if it were a scalar object.
+The lifetime of a reference ends as if it were a scalar object requiring storage.
 
 \pnum
 \begin{note} \ref{class.base.init}


### PR DESCRIPTION
and clarify that references are treated as-if requiring storage.

Fixes #2601.