### PR TITLE
[dcl.typedef] Use 'redeclare', not 'redefine'

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -613,7 +613,7 @@ is the \grammarterm{declaration} of a \grammarterm{template-declaration}.
 \pnum
 \indextext{redefinition!\idxcode{typedef}}%
 In a given non-class scope, a \tcode{typedef} specifier can be used to
-redefine the name of any type declared in that scope to refer to the
+redeclare the name of any type declared in that scope to refer to the
 type to which it already refers.
 \begin{example}
 
@@ -627,7 +627,7 @@ typedef I I;
 
 \pnum
 In a given class scope, a \tcode{typedef} specifier can be used to
-redefine any \grammarterm{class-name} declared in that scope that is not
+redeclare any \grammarterm{class-name} declared in that scope that is not
 also a \grammarterm{typedef-name} to refer to the type to which it already
 refers.
 \begin{example}
@@ -642,7 +642,7 @@ struct S {
 \end{example}
 
 \pnum
-If a \tcode{typedef} specifier is used to redefine in a given scope an
+If a \tcode{typedef} specifier is used to redeclare in a given scope an
 entity that can be referenced using an \grammarterm{elaborated-type-specifier},
 the entity can continue to be referenced by an
 \grammarterm{elaborated-type-specifier} or as an enumeration or class name
@@ -659,7 +659,7 @@ struct S { };                   // OK
 
 \pnum
 In a given scope, a \tcode{typedef} specifier shall not be used to
-redefine the name of any type declared in that scope to refer to a
+redeclare the name of any type declared in that scope to refer to a
 different type.
 \begin{example}
 \begin{codeblock}


### PR DESCRIPTION
Fixed #2584.