### PR TITLE
[range.prim,iterator.container] merge into preceding subclause

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -25,7 +25,6 @@ as summarized in \tref{iterators.lib.summary}.
 \ref{predef.iterators}      & Iterator adaptors         &                    \\
 \ref{stream.iterators}      & Stream iterators          &                    \\
 \ref{iterator.range}        & Range access              &                    \\
-\ref{iterator.container}    & Container and view access &                    \\
 \end{libsumtab}
 
 \rSec1[iterator.synopsis]{Header \tcode{<iterator>}\ synopsis}
@@ -437,7 +436,6 @@ namespace std {
   template<class C> constexpr auto crbegin(const C& c) -> decltype(std::rbegin(c));
   template<class C> constexpr auto crend(const C& c) -> decltype(std::rend(c));
 
-  // \ref{iterator.container}, container and view access
   template<class C> constexpr auto size(const C& c) -> decltype(c.size());
   template<class T, size_t N> constexpr size_t size(const T (&array)[N]) noexcept;
   template<class C> [[nodiscard]] constexpr auto empty(const C& c) -> decltype(c.empty());
@@ -6505,18 +6503,6 @@ template<class C> constexpr auto crend(const C& c) -> decltype(std::rend(c));
 \begin{itemdescr}
 \pnum \returns \tcode{std::rend(c)}.
 \end{itemdescr}
-
-\rSec1[iterator.container]{Container and view access}
-
-\pnum
-In addition to being available via inclusion of the \tcode{<iterator>} header,
-the function templates in \ref{iterator.container} are available
-when any of the following headers are included:
-\tcode{<array>}, \tcode{<deque>}, \tcode{<forward_list>}, \tcode{<list>},
-\tcode{<map>}, \tcode{<regex>}, \tcode{<set>}, \tcode{<span>}, \tcode{<string>},
-\tcode{<string_view>}, \tcode{<unordered_map>}, \tcode{<unordered_set>}, and \tcode{<vector>}.
-Each of these templates
-is a designated customization point\iref{namespace.std}.
 
 \indexlibrary{\idxcode{size(C\& c)}}%
 \begin{itemdecl}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -15,7 +15,6 @@ as summarized in \tref{range.summary}.
 
 \begin{libsumtab}{Ranges library summary}{tab:range.summary}
   \ref{range.access}       & Range access      & \tcode{<ranges>} \\
-  \ref{range.prim}         & Range primitives  & \\
   \ref{range.req}          & Requirements      & \\
   \ref{range.utility}      & Range utilities   & \\
   \ref{range.factories}    & Range factories   & \\
@@ -41,7 +40,6 @@ namespace std::ranges {
     inline constexpr @\unspec@ crbegin = @\unspec@;
     inline constexpr @\unspec@ crend = @\unspec@;
 
-    // \ref{range.prim}, range primitives
     inline constexpr @\unspec@ size = @\unspec@;
     inline constexpr @\unspec@ empty = @\unspec@;
     inline constexpr @\unspec@ data = @\unspec@;
@@ -480,14 +478,7 @@ the types \tcode{S} and \tcode{I} of
 model \libconcept{Sentinel<S, I>}.
 \end{note}
 
-\rSec1[range.prim]{Range primitives}
-
-\pnum
-In addition to being available via inclusion of the \tcode{<ranges>} header,
-the customization point objects in \ref{range.prim} are available
-when \tcode{<iterator>} is included.
-
-\rSec2[range.prim.size]{\tcode{size}}
+\rSec2[range.prim.size]{\tcode{ranges::size}}
 \pnum
 The name \tcode{size} denotes a customization point
 object\iref{customization.point.object}. The expression
@@ -545,7 +536,7 @@ Whenever \tcode{ranges::size(E)} is a valid expression, its
 type models \libconcept{Integral}.
 \end{note}
 
-\rSec2[range.prim.empty]{\tcode{empty}}
+\rSec2[range.prim.empty]{\tcode{ranges::empty}}
 \pnum
 The name \tcode{empty} denotes a customization point
 object\iref{customization.point.object}. The expression
@@ -580,7 +571,7 @@ Whenever \tcode{ranges::empty(E)} is a valid expression,
 it has type \tcode{bool}.
 \end{note}
 
-\rSec2[range.prim.data]{\tcode{data}}
+\rSec2[range.prim.data]{\tcode{ranges::data}}
 \pnum
 The name \tcode{data} denotes a customization point
 object\iref{customization.point.object}. The expression
@@ -615,7 +606,7 @@ Whenever \tcode{ranges::data(E)} is a valid expression, it
 has pointer to object type.
 \end{note}
 
-\rSec2[range.prim.cdata]{\tcode{cdata}}
+\rSec2[range.prim.cdata]{\tcode{ranges::cdata}}
 \pnum
 The name \tcode{cdata} denotes a customization point
 object\iref{customization.point.object}. The expression

--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -196,6 +196,8 @@
 
 \movedxref{thread.decaycopy}{expos.only.func}
 
+\movedxref{iterator.container}{iterator.range}
+
 % Deprecated features.
 %\deprxref{old.label}  (if moved to depr.old.label, otherwise use \movedxref)
 


### PR DESCRIPTION
Fixes #2614.