### PR TITLE
[range.refinements] Rephrase heading to not use 'common range'

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -81,7 +81,7 @@ namespace std::ranges {
   template<class T>
     concept View = @\seebelow@;
 
-  // \ref{range.refinements}, common range refinements
+  // \ref{range.refinements}, other range refinements
   template<class R, class T>
     concept OutputRange = @\seebelow@;
 
@@ -895,7 +895,7 @@ to \tcode{true} for types which model \libconcept{View},
 and \tcode{false} for types which do not.
 \end{itemdescr}
 
-\rSec2[range.refinements]{Common range refinements}
+\rSec2[range.refinements]{Other range refinements}
 
 \pnum
 The \tcode{OutputRange} concept specifies requirements of a


### PR DESCRIPTION
'Common range' means iterator and end marker have the same type;
see [range.req.general].  This is not what this subclause is about.

Fixes #2590.