### PR TITLE
[range.cmp] Deconfuse subclause heading.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -13790,7 +13790,7 @@ namespace std {
     inline constexpr int is_placeholder_v = is_placeholder<T>::value;
 
   namespace ranges {
-    // \ref{range.cmp}, range comparisons
+    // \ref{range.cmp}, concept-constrained comparisons
     template<class T = void>
       requires @\seebelow@
     struct equal_to;
@@ -14674,7 +14674,7 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 \pnum\returns \tcode{std::forward<T>(t) <= std::forward<U>(u)}.
 \end{itemdescr}
 
-\rSec2[range.cmp]{Range comparisons}
+\rSec2[range.cmp]{Concept-constrained comparisons}
 
 \pnum
 In this subclause, \tcode{\placeholdernc{BUILTIN_PTR_CMP}(T, $op$, U)} for types \tcode{T}


### PR DESCRIPTION
Fixes #2525.