### PR TITLE
[allocator.requirements] relocate example to end of subclause

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2289,6 +2289,15 @@ arguments for which its \tcode{construct} or \tcode{destroy} members may be
 called. If a type cannot be used with a particular allocator, the allocator
 class or the call to \tcode{construct} or \tcode{destroy} may fail to instantiate.
 
+\pnum
+If the alignment associated with a specific over-aligned type is not
+supported by an allocator, instantiation of the allocator for that type may
+fail. The allocator also may silently ignore the requested alignment.
+\begin{note} Additionally, the member function \tcode{allocate}
+for that type may fail by throwing an object of type
+\tcode{bad_alloc}.\end{note}
+
+\pnum
 \begin{example} The following is an allocator class template supporting the minimal
 interface that satisfies the requirements of
 \tref{utilities.allocator.requirements}:
@@ -2311,14 +2320,6 @@ template<class T, class U>
 bool operator!=(const SimpleAllocator<T>&, const SimpleAllocator<U>&);
 \end{codeblock}
 \end{example}
-
-\pnum
-If the alignment associated with a specific over-aligned type is not
-supported by an allocator, instantiation of the allocator for that type may
-fail. The allocator also may silently ignore the requested alignment.
-\begin{note} Additionally, the member function \tcode{allocate}
-for that type may fail by throwing an object of type
-\tcode{bad_alloc}.\end{note}
 
 \rSec4[allocator.requirements.completeness]{Allocator completeness requirements}
 


### PR DESCRIPTION
and add paragraph number.

Fixes #2639.