### PR TITLE
Clear up a note about condition variables

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -2848,8 +2848,8 @@ public:
 Condition variables provide synchronization primitives used to block a thread until
 notified by some other thread that some condition is met or until a system time is
 reached. Class \tcode{condition_variable} provides a condition variable that can only
-wait on an object of type \tcode{unique_lock<mutex>}, allowing maximum efficiency on some
-platforms. Class \tcode{condition_variable_any} provides a general condition variable
+wait on an object of type \tcode{unique_lock<mutex>}, allowing better efficiency on some
+implementations. Class \tcode{condition_variable_any} provides a general condition variable
 that can wait on objects of user-supplied lock types.
 
 \pnum

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -2848,9 +2848,9 @@ public:
 Condition variables provide synchronization primitives used to block a thread until
 notified by some other thread that some condition is met or until a system time is
 reached. Class \tcode{condition_variable} provides a condition variable that can only
-wait on an object of type \tcode{unique_lock<mutex>}, allowing better efficiency on some
-implementations. Class \tcode{condition_variable_any} provides a general condition variable
-that can wait on objects of user-supplied lock types.
+wait on an object of type \tcode{unique_lock<mutex>}, allowing the implementation
+to be more efficient. Class \tcode{condition_variable_any} provides a general
+condition variable that can wait on objects of user-supplied lock types.
 
 \pnum
 Condition variables permit concurrent invocation of the \tcode{wait}, \tcode{wait_for},


### PR DESCRIPTION
I've been looking far and wide but nowhere in the papers about condition variables have I found note about efficiency of them being platform dependent. The implementation of `std::condition_variable_any` in libc++ and in libstdc++ is a generalization of `std::condition_variable`, which points towards the efficiency being bound more to the implementation than the platform.