### PR TITLE
[meta.const.eval] Fix typo in function name

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -18479,7 +18479,7 @@ to either \tcode{endian::big} or \tcode{endian::little}.
 
 \rSec2[meta.const.eval]{Constant evaluation context}
 \begin{itemdecl}
-constexpr bool is_constant_evaluation() noexcept;
+constexpr bool is_constant_evaluated() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
The function name is spelled as `std::is_constant_evaluated()` in other places of the draft standard and in the original [p0595r2](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0595r2.html) proposal, so I think this can be treated as an obvious typo.