### PR TITLE
Remove [expr.sizeof]/3

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4319,10 +4319,6 @@ array. This implies that the size of an array of \term{n} elements is
 \term{n} times the size of an element.
 
 \pnum
-The \tcode{sizeof} operator can be applied to a pointer to a function,
-but shall not be applied directly to a function.
-
-\pnum
 The lvalue-to-rvalue\iref{conv.lval},
 array-to-pointer\iref{conv.array}, and
 function-to-pointer\iref{conv.func} standard conversions are not


### PR DESCRIPTION
[expr.sizeof]/1 already covers the "shall not" part using more formal wording: "The sizeof operator shall not be applied to an expression that has function or incomplete type, to the parenthesized name of such types"
And I don't see why applying to a pointer to a function has to be explicitly and normatively allowed.