### PR TITLE
[expr.sizeof]/2: there are no expressions of reference type

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4300,7 +4300,7 @@ and~\ref{basic.types} for the definition of \term{object representation}.
 
 \pnum
 \indextext{reference!\idxcode{sizeof}}%
-When applied to a reference or a reference type, the result is the size
+When applied to a reference type, the result is the size
 of the referenced type.
 \indextext{class object!\idxcode{sizeof}}%
 When applied to a class, the result is the number of bytes in an object


### PR DESCRIPTION
because
> If an expression initially has the type “reference to T” ([dcl.ref], [dcl.init.ref]), the type is adjusted to T prior to any further analysis.

Fixes #2652.