### PR TITLE
[basic.lval]/9 all prvalues can have cv-qualified types CWG2481

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -269,8 +269,6 @@ that class shall not be an abstract class\iref{class.abstract}.
 A glvalue shall not have type \cv{}~\tcode{void}.
 \begin{note}
 A glvalue may have complete or incomplete non-\tcode{void} type.
-Class and array prvalues can have cv-qualified types; other prvalues
-always have cv-unqualified types. See \ref{expr.prop}.
 \end{note}
 
 \pnum


### PR DESCRIPTION
[dcl.init.ref]/5.3: "If the converted initializer is a prvalue, its type T4 is adjusted to type “cv1 T4” and the temporary materialization conversion is applied."
The cv-qualifiers of the reference being initialized are added to the initializer prvalue's type.

[expr.type]/2: "If a prvalue initially has the type “cv T”, where T is a cv-unqualified non-class, non-array type, the type of the expression is adjusted to T prior to any further analysis."
is not applicable here, because it says "initially", so it strips qualifiers only when a prvalue is formed, but [dcl.init.ref]/5.3 does not form a new prvalue, it adjusts the type of an existing one.