### PR TITLE
[dcl.init.ref]/5 Prevent prvalue type adjustment CWG2481

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5319,8 +5319,8 @@ copy-initialization, is then used to direct-initialize the reference.
 For this direct-initialization, user-defined conversions are not considered.
 \item
 Otherwise,
-the initializer expression is implicitly converted to a prvalue
-of type ``\cvqual{cv1} \tcode{T1}''.
+the initializer expression is implicitly converted to a prvalue of type \tcode{T1},
+then the type of the resulting prvalue is adjusted to ``\cvqual{cv1} \tcode{T1}''.
 The temporary materialization conversion is applied and the reference is
 bound to the result.
 \end{itemize}


### PR DESCRIPTION
Fresh prvalues could fall prey to [expr.type]/2: "If a prvalue initially has the type “cv T”, where T is a cv-unqualified non-class, non-array type, the type of the expression is adjusted to T prior to any further analysis."

I've also rewritten the sentence in the semantic line breaks style.

However, this would be a wrong fix if it is decided to restore the "no cv-qualified non-class non-array prvalues" status quo (see #2655).

See CWG2481