### PR TITLE
Fixed text in [temp.mem.func]/1 example, which was not updated by CWG249

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -2182,7 +2182,7 @@ public:
 };
 \end{codeblock}
 
-declares three function templates.
+declares three member functions of a class template.
 The subscript function might be defined like this:
 
 \begin{codeblock}


### PR DESCRIPTION
It appears that [CWG 249](https://wg21.link/cwg249) fixed only the normative text, but did not also fix the following example.