### PR TITLE
[meta.rel] Add missing noexcept cross-refs for invokable traits

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -17652,7 +17652,7 @@ not possibly cv-qualified versions of the same type,
  \tcode{struct is_nothrow_invocable;}              &
  \tcode{is_invocable_v<}\br\tcode{Fn, ArgTypes...>} is \tcode{true} and
  the expression \tcode{\placeholdernc{INVOKE}(declval<Fn>(), declval<ArgTypes>()...)}
- is known not to throw any exceptions                                 &
+ is known not to throw any exceptions\iref{expr.unary.noexcept}       &
  \tcode{Fn} and all types in the template parameter pack \tcode{ArgTypes}
  shall be complete types, \cv{}~\tcode{void}, or
  arrays of unknown bound.                                             \\ \rowsep
@@ -17662,7 +17662,7 @@ not possibly cv-qualified versions of the same type,
  \tcode{struct is_nothrow_invocable_r;}              &
  \tcode{is_invocable_r_v<}\br\tcode{R, Fn, ArgTypes...>} is \tcode{true} and
  the expression \tcode{\placeholdernc{INVOKE}<R>(declval<Fn>(), declval<ArgTypes>()...)}
- is known not to throw any exceptions                                 &
+ is known not to throw any exceptions\iref{expr.unary.noexcept}       &
  \tcode{Fn}, \tcode{R}, and all types in the template parameter pack \tcode{ArgTypes}
  shall be complete types, \cv{}~\tcode{void}, or
  arrays of unknown bound.                                             \\


### PR DESCRIPTION
All the other traits that use the phrase 'is known not
to throw exceptions' also cross-reference the core
clause for the noexcept operator, so add the missing
cross reference to the more recently added traits.