### PR TITLE
[temp.spec]/2 dead wording

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -5483,23 +5483,6 @@ a member template is referred to as
 \defn{template instantiation}.
 
 \pnum
-A function instantiated from a function template is called an instantiated
-function.
-A class instantiated from a class template is called an instantiated class.
-A member function, a member class, a member enumeration, or a static data member of a class template
-instantiated from the member definition of the class template is called,
-respectively, an instantiated member function, member class, member enumeration, or static data
-member.
-A member function instantiated from a member function template is called an
-instantiated member function.
-A member class instantiated from a member class template is called an
-instantiated member class.
-A variable instantiated from a variable template is called an
-instantiated variable.
-A static data member instantiated from a static data member template
-is called an instantiated static data member.
-
-\pnum
 An explicit specialization may be declared for a function template,
 a class template, a member of a class template or a member template.
 An explicit specialization declaration is introduced by


### PR DESCRIPTION
The terms defined in [temp.spec]/2 are defined, but never used again, anywhere in the standard. This is possibly a case of dead wording. 

[Here](http://eel.is/c++draft/temp.spec#2) is a link to the section in question.