### PR TITLE
Fixed wording on [temp.class.spec.mfunc]/1 sentence 3

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -3337,7 +3337,7 @@ partial specialization.
 The template argument list of a member of a class template partial
 specialization shall match the template argument list of the class template
 partial specialization.
-A class template specialization is a distinct template.
+A class template partial specialization is a distinct template.
 The members of the class template partial specialization are
 unrelated to the members of the primary template.
 Class template partial specialization members that are used in a way that


### PR DESCRIPTION
Specializations are defined as classes and functions that are instantiated or explicitly specialized as stated on **[temp.spec]/4 sentence 2**. **[temp.class.spec.mfunc]/1 sentence 3** defines class template specializations as distinct templates, which is incorrect. 

Presumably, the intended meaning was that class template partial specializations are distinct templates, which would be correct.