### PR TITLE
[dcl.attr.contract.cond] example fails to return

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -8454,11 +8454,10 @@ int f(int x)
   return ++x;                   // undefined behavior
 }
 
-int g(int * p)
-  [[ensures r: p != nullptr]]
+void g(int * p)
+  [[ensures: p != nullptr]]
 {
   *p = 42;                      // OK, \tcode{p} is not modified
-  return *p;
 }
 
 int h(int x)

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -8458,7 +8458,7 @@ int g(int * p)
   [[ensures r: p != nullptr]]
 {
   *p = 42;                      // OK, \tcode{p} is not modified
-  return p;
+  return *p;
 }
 
 int h(int x)

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -8458,6 +8458,7 @@ int g(int * p)
   [[ensures r: p != nullptr]]
 {
   *p = 42;                      // OK, \tcode{p} is not modified
+  return p;
 }
 
 int h(int x)


### PR DESCRIPTION
The function in the example returns int but fails to actually return.