### PR TITLE
Use "denotes a type" in utilities library clause

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -1432,7 +1432,7 @@ is no greater than \tcode{Len}\iref{basic.types}.
 to \exposid{default-alignment}.
 
 \pnum
-The member typedef \tcode{type} is a trivial standard-layout type
+The member typedef \tcode{type} denotes a trivial standard-layout type
 suitable for use as uninitialized storage for any object
 whose size is at most \tcode{Len} and
 whose alignment is a divisor of \tcode{Align}.
@@ -1472,7 +1472,7 @@ Each type in the template parameter pack \tcode{Types}
 is a complete object type.
 
 \pnum
-The member typedef \tcode{type} is a trivial standard-layout type
+The member typedef \tcode{type} denotes a trivial standard-layout type
 suitable for use as uninitialized storage for any object
 whose type is listed in \tcode{Types};
 its size shall be at least \tcode{Len}.

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -1799,16 +1799,16 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
  struct remove_pointer;}                    &
  If \tcode{T} has type ``(possibly cv-qualified) pointer
  to \tcode{T1}'' then the member typedef \tcode{type}
- names \tcode{T1}; otherwise, it names \tcode{T}.\\ \rowsep
+ denotes \tcode{T1}; otherwise, it denotes \tcode{T}.\\ \rowsep
 
 \indexlibraryglobal{add_pointer}%
 \tcode{template<class T>\br
  struct add_pointer;}                       &
- If \tcode{T} names a referenceable type\iref{defns.referenceable} or a
+ If \tcode{T} is a referenceable type\iref{defns.referenceable} or a
  \cv{}~\keyword{void} type then
- the member typedef \tcode{type} names the same type as
+ the member typedef \tcode{type} denotes
  \tcode{remove_reference_t<T>*};
- otherwise, \tcode{type} names \tcode{T}.             \\
+ otherwise, \tcode{type} denotes \tcode{T}.             \\
 \end{libreqtab2a}
 
 \rSec3[meta.trans.other]{Other transformations}

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -1661,15 +1661,15 @@ Each of the templates in \ref{meta.trans} shall be a
 \tcode{template<class T>\br
  struct remove_reference;}                  &
  If \tcode{T} has type ``reference to \tcode{T1}'' then the
- member typedef \tcode{type} names \tcode{T1};
- otherwise, \tcode{type} names \tcode{T}.\\ \rowsep
+ member typedef \tcode{type} denotes \tcode{T1};
+ otherwise, \tcode{type} denotes \tcode{T}.\\ \rowsep
 
 \indexlibraryglobal{add_lvalue_reference}%
 \tcode{template<class T>\br
  struct add_lvalue_reference;}                     &
- If \tcode{T} names a referenceable type\iref{defns.referenceable} then
- the member typedef \tcode{type} names \tcode{T\&};
- otherwise, \tcode{type} names \tcode{T}.
+ If \tcode{T} is a referenceable type\iref{defns.referenceable} then
+ the member typedef \tcode{type} denotes \tcode{T\&};
+ otherwise, \tcode{type} denotes \tcode{T}.
  \begin{tailnote}
  This rule reflects the semantics of reference collapsing\iref{dcl.ref}.
  \end{tailnote}
@@ -1678,13 +1678,13 @@ Each of the templates in \ref{meta.trans} shall be a
 \indexlibraryglobal{add_rvalue_reference}%
 \tcode{template<class T>}\br
  \tcode{struct add_rvalue_reference;}    &
- If \tcode{T} names a referenceable type then
- the member typedef \tcode{type} names \tcode{T\&\&};
- otherwise, \tcode{type} names \tcode{T}.
+ If \tcode{T} is a referenceable type then
+ the member typedef \tcode{type} denotes \tcode{T\&\&};
+ otherwise, \tcode{type} denotes \tcode{T}.
  \begin{tailnote}
 This rule reflects the semantics of reference collapsing\iref{dcl.ref}.
- For example, when a type \tcode{T} names a type \tcode{T1\&}, the type
- \tcode{add_rvalue_reference_t<T>} is not an rvalue reference.
+ For example, when a type \tcode{T} is a reference type \tcode{T1\&},
+ the type \tcode{add_rvalue_reference_t<T>} is not an rvalue reference.
  \end{tailnote}
 \\
 \end{libreqtab2a}

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -1341,7 +1341,7 @@ properties of types at compile time.
 \indexlibraryglobal{rank}%
 \tcode{template<class T>\br
  struct rank;}      &
- If \tcode{T} names an array type, an integer value representing
+ If \tcode{T} is an array type, an integer value representing
  the number of dimensions of \tcode{T}; otherwise, 0. \\    \rowsep
 
 \indexlibraryglobal{extent}%

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -1587,9 +1587,8 @@ Each of the templates in \ref{meta.trans} shall be a
 \indexlibraryglobal{remove_const}%
 \tcode{template<class T>\br
  struct remove_const;}                  &
- The member typedef \tcode{type} names
- the same type as \tcode{T}
- except that any top-level const-qualifier has been removed.
+ The member typedef \tcode{type} denotes the type formed
+ by removing any top-level const-qualifier from \tcode{T}.
  \begin{tailexample}
 \tcode{remove_const_t<const volatile int>} evaluates
  to \tcode{volatile int}, whereas \tcode{remove_const_t<const int*>} evaluates to
@@ -1600,9 +1599,8 @@ Each of the templates in \ref{meta.trans} shall be a
 \indexlibraryglobal{remove_volatile}%
 \tcode{template<class T>\br
  struct remove_volatile;}               &
- The member typedef \tcode{type} names
- the same type as \tcode{T}
- except that any top-level volatile-qualifier has been removed.
+ The member typedef \tcode{type} denotes the type formed
+ by removing any top-level volatile-qualifier from \tcode{T}.
  \begin{tailexample}
 \tcode{remove_volatile_t<const volatile int>}
  evaluates to \tcode{const int},
@@ -1613,8 +1611,8 @@ Each of the templates in \ref{meta.trans} shall be a
 \indexlibraryglobal{remove_cv}%
 \tcode{template<class T>\br
  struct remove_cv;}                 &
- The member typedef \tcode{type} shall be the same as \tcode{T}
- except that any top-level cv-qualifier has been removed.
+ The member typedef \tcode{type} denotes the type formed
+ by removing any top-level cv-qualifiers from \tcode{T}.
  \begin{tailexample}
 \tcode{remove_cv_t<const volatile int>}
  evaluates to \tcode{int}, whereas \tcode{remove_cv_t<const volatile int*>}
@@ -1626,23 +1624,20 @@ Each of the templates in \ref{meta.trans} shall be a
 \tcode{template<class T>\br
  struct add_const;}                 &
  If \tcode{T} is a reference, function, or top-level const-qualified
- type, then \tcode{type} names
- the same type as \tcode{T}, otherwise
+ type, then \tcode{type} denotes \tcode{T}, otherwise
  \tcode{T const}.                                                           \\  \rowsep
 
 \indexlibraryglobal{add_volatile}%
 \tcode{template<class T>\br
  struct add_volatile;}                  &
  If \tcode{T} is a reference, function, or top-level volatile-qualified
- type, then \tcode{type} names
- the same type as \tcode{T}, otherwise
+ type, then \tcode{type} denotes \tcode{T}, otherwise
  \tcode{T volatile}.                                                            \\  \rowsep
 
 \indexlibraryglobal{add_cv}%
 \tcode{template<class T>\br
  struct add_cv;}                    &
- The member typedef \tcode{type} names
- the same type as
+ The member typedef \tcode{type} denotes
  \tcode{add_const_t<add_volatile_t<T>>}.                               \\
 \end{libreqtab2a}
 

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -1923,8 +1923,9 @@ argument passing.
  &
  If \tcode{T} is
  a specialization \tcode{reference_wrapper<X>} for some type \tcode{X},
- the member typedef \tcode{type} of \tcode{unwrap_reference<T>} is \tcode{X\&},
- otherwise it is \tcode{T}. \\ \rowsep
+ the member typedef \tcode{type} of \tcode{unwrap_reference<T>}
+ denotes \tcode{X\&},
+ otherwise \tcode{type} denotes \tcode{T}. \\ \rowsep
 
 \indexlibraryglobal{unwrap_ref_decay}%
 \tcode{template<class T>} \tcode{unwrap_ref_decay;}

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -1745,9 +1745,9 @@ This rule reflects the semantics of reference collapsing\iref{dcl.ref}.
 \indexlibraryglobal{remove_extent}%
 \tcode{template<class T>\br
  struct remove_extent;}                 &
- If \tcode{T} names a type ``array of \tcode{U}'',
- the member typedef \tcode{type} shall
- be \tcode{U}, otherwise \tcode{T}.
+ If \tcode{T} is a type ``array of \tcode{U}'',
+ the member typedef \tcode{type} denotes \tcode{U},
+ otherwise \tcode{T}.
  \begin{tailnote}
 For multidimensional arrays, only the first array dimension is
  removed. For a type ``array of \tcode{const U}'', the resulting type is
@@ -1759,7 +1759,7 @@ For multidimensional arrays, only the first array dimension is
 \tcode{template<class T>\br
  struct remove_all_extents;}                &
  If \tcode{T} is ``multi-dimensional array of \tcode{U}'', the resulting member
- typedef \tcode{type} is \tcode{U}, otherwise \tcode{T}.                                       \\
+ typedef \tcode{type} denotes \tcode{U}, otherwise \tcode{T}.                                       \\
 \end{libreqtab2a}
 
 \pnum

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -1826,12 +1826,12 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
 \tcode{template<class T>\br
  struct type_identity;}
  &
- The member typedef \tcode{type} names the type \tcode{T}. \\ \rowsep
+ The member typedef \tcode{type} denotes \tcode{T}. \\ \rowsep
 
 \indexlibraryglobal{remove_cvref}%
 \tcode{template<class T>\br struct remove_cvref;}
  &
- The member typedef \tcode{type} names the same type as
+ The member typedef \tcode{type} denotes
  \tcode{remove_cv_t<remove_reference_t<T>>}.
  \\ \rowsep
 
@@ -1895,7 +1895,7 @@ argument passing.
 \tcode{template<class T>}\br
  \tcode{struct underlying_type;}
  &
- If \tcode{T} is an enumeration type, the member typedef \tcode{type} names
+ If \tcode{T} is an enumeration type, the member typedef \tcode{type} denotes
  the underlying type of \tcode{T}\iref{dcl.enum};
  otherwise, there is no member \tcode{type}.\br
  \mandates \tcode{T} is not an incomplete enumeration type. \\ \rowsep
@@ -1906,7 +1906,7 @@ argument passing.
  &
  If the expression \tcode{\placeholdernc{INVOKE}(declval<Fn>(), declval<ArgTypes>()...)}
  is well-formed when treated as an unevaluated operand\iref{term.unevaluated.operand},
- the member typedef \tcode{type} names the type
+ the member typedef \tcode{type} denotes the type
  \tcode{decltype(\placeholdernc{INVOKE}(declval<Fn>(), declval<ArgTypes>()...))};
  otherwise, there shall be no member \tcode{type}. Access checking is
  performed as if in a context unrelated to \tcode{Fn} and

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -1839,10 +1839,10 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
 \tcode{template<class T>\br struct decay;}
  &
  Let \tcode{U} be \tcode{remove_reference_t<T>}. If \tcode{is_array_v<U>} is
- \tcode{true}, the member typedef \tcode{type} equals
+ \tcode{true}, the member typedef \tcode{type} denotes
  \tcode{remove_extent_t<U>*}. If \tcode{is_function_v<U>} is \tcode{true},
- the member typedef \tcode{type} equals \tcode{add_pointer_t<U>}. Otherwise
- the member typedef \tcode{type} equals \tcode{remove_cv_t<U>}.
+ the member typedef \tcode{type} denotes \tcode{add_pointer_t<U>}. Otherwise
+ the member typedef \tcode{type} denotes \tcode{remove_cv_t<U>}.
 \begin{tailnote}
 This behavior is similar to the lvalue-to-rvalue\iref{conv.lval},
 array-to-pointer\iref{conv.array}, and function-to-pointer\iref{conv.func}
@@ -1856,15 +1856,15 @@ argument passing.
 \tcode{template<bool B, class T = void>} \tcode{struct enable_if;}
  &
  If \tcode{B} is \tcode{true}, the member typedef \tcode{type}
- shall equal \tcode{T}; otherwise, there shall be no member
+ denotes \tcode{T}; otherwise, there shall be no member
  \tcode{type}. \\ \rowsep
 
 \tcode{template<bool B, class T,}
  \tcode{class F>}\br
  \tcode{struct conditional;}
  &
- If \tcode{B} is \tcode{true},  the member typedef \tcode{type} shall equal \tcode{T}.
- If \tcode{B} is \tcode{false}, the member typedef \tcode{type} shall equal \tcode{F}. \\ \rowsep
+ If \tcode{B} is \tcode{true},  the member typedef \tcode{type} denotes \tcode{T}.
+ If \tcode{B} is \tcode{false}, the member typedef \tcode{type} denotes \tcode{F}. \\ \rowsep
 
  \tcode{template<class... T>} \tcode{struct common_type;}
  &

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -1702,13 +1702,13 @@ This rule reflects the semantics of reference collapsing\iref{dcl.ref}.
 \indexlibraryglobal{make_signed}%
 \tcode{template<class T>}\br
  \tcode{struct make_signed;} &
- If \tcode{T} names a (possibly cv-qualified) signed integer
+ If \tcode{T} is a (possibly cv-qualified) signed integer
  type\iref{basic.fundamental} then the member typedef
- \tcode{type} names the type \tcode{T}; otherwise,
- if \tcode{T} names a (possibly cv-qualified) unsigned integer
- type then \tcode{type} names the corresponding
+ \tcode{type} denotes \tcode{T}; otherwise,
+ if \tcode{T} is a (possibly cv-qualified) unsigned integer
+ type then \tcode{type} denotes the corresponding
  signed integer type, with the same cv-qualifiers as \tcode{T};
- otherwise, \tcode{type} names the signed integer type with smallest
+ otherwise, \tcode{type} denotes the signed integer type with smallest
  rank\iref{conv.rank} for which
  \tcode{sizeof(T) == sizeof(type)}, with the same
  cv-qualifiers as \tcode{T}.\br
@@ -1718,13 +1718,13 @@ This rule reflects the semantics of reference collapsing\iref{dcl.ref}.
 \indexlibraryglobal{make_unsigned}%
 \tcode{template<class T>}\br
  \tcode{struct make_unsigned;} &
- If \tcode{T} names a (possibly cv-qualified) unsigned integer
+ If \tcode{T} is a (possibly cv-qualified) unsigned integer
  type\iref{basic.fundamental} then the member typedef
- \tcode{type} names the type \tcode{T}; otherwise,
- if \tcode{T} names a (possibly cv-qualified) signed integer
- type then \tcode{type} names the corresponding
+ \tcode{type} denotes \tcode{T}; otherwise,
+ if \tcode{T} is a (possibly cv-qualified) signed integer
+ type then \tcode{type} denotes the corresponding
  unsigned integer type, with the same cv-qualifiers as \tcode{T};
- otherwise, \tcode{type} names the unsigned integer type with smallest
+ otherwise, \tcode{type} denotes the unsigned integer type with smallest
  rank\iref{conv.rank} for which
  \tcode{sizeof(T) == sizeof(type)}, with the same
  cv-qualifiers as \tcode{T}.\br


### PR DESCRIPTION
This replaces #2354, in line with the editorial meeting decision.