### PR TITLE
Incosistency in tuple_size/tuple_element struct/class. 

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -3088,8 +3088,8 @@ namespace std {
     constexpr void swap(array<T, N>& x, array<T, N>& y) noexcept(noexcept(x.swap(y)));
 
   // \ref{array.tuple}, tuple interface to class template \tcode{array}
-  template<class T> class tuple_size;
-  template<size_t I, class T> class tuple_element;
+  template<class T> struct tuple_size;
+  template<size_t I, class T> struct tuple_element;
   template<class T, size_t N>
     struct tuple_size<array<T, N>>;
   template<size_t I, class T, size_t N>

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -120,8 +120,8 @@ namespace std {
     constexpr @\seebelow@ make_pair(T1&&, T2&&);
 
   // \ref{pair.astuple}, tuple-like access to pair
-  template<class T> class tuple_size;
-  template<size_t I, class T> class tuple_element;
+  template<class T> struct tuple_size;
+  template<size_t I, class T> struct tuple_element;
 
   template<class T1, class T2> struct tuple_size<pair<T1, T2>>;
   template<size_t I, class T1, class T2> struct tuple_element<I, pair<T1, T2>>;
@@ -1018,20 +1018,20 @@ namespace std {
     constexpr T make_from_tuple(Tuple&& t);
 
   // \ref{tuple.helper}, tuple helper classes
-  template<class T> class tuple_size;                  // not defined
-  template<class T> class tuple_size<const T>;
-  template<class T> class tuple_size<volatile T>;
-  template<class T> class tuple_size<const volatile T>;
+  template<class T> struct tuple_size;                  // not defined
+  template<class T> struct tuple_size<const T>;
+  template<class T> struct tuple_size<volatile T>;
+  template<class T> struct tuple_size<const volatile T>;
 
-  template<class... Types> class tuple_size<tuple<Types...>>;
+  template<class... Types> struct tuple_size<tuple<Types...>>;
 
-  template<size_t I, class T> class tuple_element;     // not defined
-  template<size_t I, class T> class tuple_element<I, const T>;
-  template<size_t I, class T> class tuple_element<I, volatile T>;
-  template<size_t I, class T> class tuple_element<I, const volatile T>;
+  template<size_t I, class T> struct tuple_element;     // not defined
+  template<size_t I, class T> struct tuple_element<I, const T>;
+  template<size_t I, class T> struct tuple_element<I, volatile T>;
+  template<size_t I, class T> struct tuple_element<I, const volatile T>;
 
   template<size_t I, class... Types>
-    class tuple_element<I, tuple<Types...>>;
+    struct tuple_element<I, tuple<Types...>>;
 
   template<size_t I, class T>
     using tuple_element_t = typename tuple_element<I, T>::type;
@@ -1794,14 +1794,13 @@ for some \tcode{N}.
 \indexlibrary{\idxcode{tuple_size}}%
 \begin{itemdecl}
 template<class... Types>
-  class tuple_size<tuple<Types...>> : public integral_constant<size_t, sizeof...(Types)> { };
+  struct tuple_size<tuple<Types...>> : public integral_constant<size_t, sizeof...(Types)> { };
 \end{itemdecl}
 
 \indexlibrary{\idxcode{tuple_element}}%
 \begin{itemdecl}
 template<size_t I, class... Types>
-  class tuple_element<I, tuple<Types...>> {
-  public:
+  struct tuple_element<I, tuple<Types...>> {
     using type = TI;
   };
 \end{itemdecl}
@@ -1819,9 +1818,9 @@ where indexing is zero-based.
 
 \indexlibrary{\idxcode{tuple_size}}%
 \begin{itemdecl}
-template<class T> class tuple_size<const T>;
-template<class T> class tuple_size<volatile T>;
-template<class T> class tuple_size<const volatile T>;
+template<class T> struct tuple_size<const T>;
+template<class T> struct tuple_size<volatile T>;
+template<class T> struct tuple_size<const volatile T>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1857,9 +1856,9 @@ are included.
 
 \indexlibrary{\idxcode{tuple_element}}%
 \begin{itemdecl}
-template<size_t I, class T> class tuple_element<I, const T>;
-template<size_t I, class T> class tuple_element<I, volatile T>;
-template<size_t I, class T> class tuple_element<I, const volatile T>;
+template<size_t I, class T> struct tuple_element<I, const T>;
+template<size_t I, class T> struct tuple_element<I, volatile T>;
+template<size_t I, class T> struct tuple_element<I, const volatile T>;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
It was declared as structures and specializations were classes. All tuple_size and tuple_elements are now structures.

Touched sections: pair.astuple and tuple.helper