### PR TITLE
P1164R1 Make create_directory() Intuitive

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -14742,8 +14742,6 @@ bool create_directories(const path& p, error_code& ec);
 \returns \tcode{true} if a new directory was created
   for the directory \tcode{p} resolves to,
   otherwise \tcode{false}.
-  The signature with argument \tcode{ec}
-  returns \tcode{false} if an error occurs.
 
 \pnum
 \throws As specified in~\ref{fs.err.report}.
@@ -14765,13 +14763,13 @@ bool create_directory(const path& p, error_code& ec) noexcept;
 \begin{itemdescr}
 \pnum
 \effects Creates the directory \tcode{p} resolves to,
-  as if by POSIX \tcode{mkdir()} with a second argument of
+  as if by POSIX \tcode{mkdir} with a second argument of
   \tcode{static_cast<int>(perms::all)}.
-  Creation failure because \tcode{p} already exists is not an error.
+  If \tcode{mkdir} fails because \tcode{p} resolves to an existing directory,
+  no error is reported. Otherwise on failure an error is reported.
 
 \pnum
 \returns \tcode{true} if a new directory was created, otherwise \tcode{false}.
-  The signature with argument \tcode{ec} returns \tcode{false} if an error occurs.
 
 \pnum
 \throws As specified in~\ref{fs.err.report}.
@@ -14789,7 +14787,8 @@ bool create_directory(const path& p, const path& existing_p, error_code& ec) noe
   directory \tcode{p} resolves to, with
   attributes copied from directory \tcode{existing_p}. The set of attributes
   copied is operating system dependent.
-  Creation failure because \tcode{p} already exists is not an error.
+  If \tcode{mkdir} fails because \tcode{p} resolves to an existing directory,
+  no error is reported. Otherwise on failure an error is reported.
 \begin{note} For POSIX-based operating systems, the
       attributes are those copied by native API \tcode{stat(existing_p.c_str(), \&attributes_stat)}
       followed by \tcode{mkdir(p.c_str(), attributes_stat.st_mode)}. For
@@ -14798,8 +14797,9 @@ bool create_directory(const path& p, const path& existing_p, error_code& ec) noe
 \end{note}
 
 \pnum
-\returns \tcode{true} if a new directory was created, otherwise \tcode{false}.
-  The signature with argument \tcode{ec} returns \tcode{false} if an error occurs.
+\returns \tcode{true} if a new directory was created
+  with attributes copied from directory \tcode{existing_p},
+  otherwise \tcode{false}.
 
 \pnum
 \throws As specified in~\ref{fs.err.report}.


### PR DESCRIPTION
For create_directory copying attributes from existing_p,
- Removed 'already' from failure description, to align with
simple create_directory.
- Removed 'The signature with argument ec returns false
if an error occurs.'; this was struck in the parallel cases
and is omitted entirely (not shown as struck) in the editing
instructions.

Fixes #2703.