### PR TITLE
P0340R3 Making std::underlying_type SFINAE-friendly

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -18183,9 +18183,10 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
 \tcode{template<class T>}\br
  \tcode{struct underlying_type;}
  &
- The member typedef \tcode{type} names the underlying type
- of \tcode{T}.\br
- \requires{} \tcode{T} shall be a complete enumeration type\iref{dcl.enum} \\ \rowsep
+ If \tcode{T} is an enumeration type, the member typedef \tcode{type} names
+ the underlying type of \tcode{T}\iref{dcl.enum};
+ otherwise, there is no member \tcode{type}.\br
+ \mandates \tcode{T} is not an incomplete enumeration type. \\ \rowsep
 
 \tcode{template<class Fn,}\br
  \tcode{class... ArgTypes>}\br


### PR DESCRIPTION
Fixes #2696.