### PR TITLE
[specialized.algorithms] Rename voidify's parameter

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -8103,8 +8103,8 @@ Some algorithms defined in this clause make use of the exposition-only function
 \tcode{\placeholdernc{voidify}}:
 \begin{codeblock}
 template<class T>
-  void* @\placeholdernc{voidify}@(T& ptr) noexcept {
-    return const_cast<void*>(static_cast<const volatile void*>(addressof(ptr)));
+  void* @\placeholdernc{voidify}@(T& obj) noexcept {
+    return const_cast<void*>(static_cast<const volatile void*>(addressof(obj)));
   }
 \end{codeblock}
 


### PR DESCRIPTION
`ptr` is an odd name for a parameter that is a reference to storage for an object.