### PR TITLE
P1286R2 Contra CWG DR1778

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5926,7 +5926,9 @@ is allowed to differ from the type \tcode{T}$_2$ it would have had
 if it were implicitly declared, as follows:
 \begin{itemize}
 \item
-  \tcode{T}$_1$ and \tcode{T}$_2$ may have differing \grammarterm{ref-qualifier}{s}; and
+  \tcode{T}$_1$ and \tcode{T}$_2$ may have differing \grammarterm{ref-qualifier}{s};
+\item
+  \tcode{T}$_1$ and \tcode{T}$_2$ may have differing exception specifications; and
 \item
   if \tcode{T}$_2$ has a parameter of type \tcode{const C\&},
   the corresponding parameter of \tcode{T}$_1$ may be of type \tcode{C\&}.
@@ -5961,12 +5963,24 @@ struct S {
   constexpr S() = default;              // ill-formed: implicit \tcode{S()} is not \tcode{constexpr}
   S(int a = 0) = default;               // ill-formed: default argument
   void operator=(const S&) = default;   // ill-formed: non-matching return type
-  ~S() noexcept(false) = default;       // deleted: exception specification does not match
+  ~S() noexcept(false) = default;       // OK, despite mismatched exception specification
 private:
   int i;
   S(S&);                                // OK: private copy constructor
 };
 S::S(S&) = default;                     // OK: defines copy constructor
+
+struct T {
+  T();
+  T(T &&) noexcept(false);
+};
+struct U {
+  T t;
+  U();
+  U(U &&) noexcept = default;
+};
+U u1;
+U u2 = static_cast<U&&>(u1);            // OK, calls \tcode{std::terminate} if \tcode{T::T(T\&\&)} throws
 \end{codeblock}
 \end{example}
 


### PR DESCRIPTION
Also fixes CWG1778.

[dcl.fct.def.default]/2 Remove "and" from previous bullet.

Fixes #2683.