### PR TITLE
P1463R1 Mandating the Standard Library: Clause 21 - Containers library

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -98,7 +98,7 @@ denotes a non-const rvalue of type \tcode{X}.
 \tcode{X::value_type}       &
  \tcode{T}                  &
                             &
- \requires\ \tcode{T} is \oldconcept{Erasable} from \tcode{X} (see~\ref{container.requirements.general}, below) &
+ \expects \tcode{T} is \oldconcept{Erasable} from \tcode{X} (see~\ref{container.requirements.general}, below) &
  compile time               \\ \rowsep
 
 \tcode{X::reference}        &
@@ -155,7 +155,7 @@ denotes a non-const rvalue of type \tcode{X}.
 \tcode{X(a)}                &
                             &
                             &
- \requires \tcode{T} is \oldconcept{CopyInsertable}
+ \expects \tcode{T} is \oldconcept{CopyInsertable}
  into \tcode{X} (see below).\br \ensures \tcode{a == X(a)}.         &
  linear                     \\ \rowsep
 
@@ -163,7 +163,7 @@ denotes a non-const rvalue of type \tcode{X}.
 \tcode{X u = a;}            &
                             &
                             &
- \requires \tcode{T} is \oldconcept{CopyInsertable}
+ \expects \tcode{T} is \oldconcept{CopyInsertable}
  into \tcode{X} (see below).\br
  \ensures \tcode{u == a}       &
  linear                     \\ \rowsep
@@ -172,21 +172,21 @@ denotes a non-const rvalue of type \tcode{X}.
 \tcode{X u = rv;}            &
                             &
                             &
-  \ensures \tcode{u} shall be equal to the value that \tcode{rv} had before this construction
+  \ensures \tcode{u} is equal to the value that \tcode{rv} had before this construction
                             &
   (Note B)                  \\ \rowsep
 
 \tcode{a = rv}              &
   \tcode{X\&}               &
   All existing elements of \tcode{a} are either move assigned to or destroyed   &
-  \tcode{a} shall be equal to the value that \tcode{rv}
+  \ensures \tcode{a} is equal to the value that \tcode{rv}
   had before this assignment   &
    linear                     \\ \rowsep
 
 \tcode{a.\~X()}    &
  \tcode{void}               &
                             &
- the destructor is applied to every element of \tcode{a}; any memory obtained is deallocated. &
+ \effects destroys every element of \tcode{a}; any memory obtained is deallocated. &
  linear                     \\ \rowsep
 
 \tcode{a.begin()}           &
@@ -217,7 +217,7 @@ denotes a non-const rvalue of type \tcode{X}.
  convertible to \tcode{bool}    &
  \tcode{==} is an equivalence relation.
  \tcode{equal(\brk{}a.begin(), a.end(), b.begin(), b.end())} &
- \requires\ \tcode{T} is \oldconcept{\-Equal\-ity\-Compar\-a\-ble} &
+ \expects \tcode{T} meets the \oldconcept{\-Equal\-ity\-Compar\-a\-ble} requirements &
  Constant if \tcode{a.size() != b.size()},
  linear otherwise                                   \\ \rowsep
 
@@ -230,7 +230,7 @@ denotes a non-const rvalue of type \tcode{X}.
 \tcode{a.swap(b)}          &
  \tcode{void}               &
                             &
- exchanges the contents of \tcode{a} and \tcode{b}          &
+ \effects exchanges the contents of \tcode{a} and \tcode{b}          &
  (Note A)                   \\ \rowsep
 
 \tcode{swap(a, b)}          &
@@ -488,7 +488,7 @@ are implemented by constexpr functions.
 \tcode{a < b}                   &
  convertible to \tcode{bool}    &
  \tcode{lexicographical_compare( a.begin(), a.end(), b.begin(), b.end())} &
- \requires \tcode{<} is defined for values of \tcode{T}. \tcode{<} is a total ordering relationship.    &
+ \expects \tcode{<} is defined for values of type (possibly \tcode{const}) \tcode{T}. \tcode{<} is a total ordering relationship.    &
  linear                     \\ \rowsep
 
 \tcode{a > b}                   &
@@ -627,7 +627,7 @@ non-const rvalue of type \tcode{X}, and \tcode{m} is a value of type \tcode{A}.
 
 \tcode{allocator_type}		&
   \tcode{A}								&
-  \requires \tcode{allocator_type::value_type} is the same as \tcode{X::value_type}.					&
+  \mandates \tcode{allocator_type::value_type} is the same as \tcode{X::value_type}.					&
   compile time										\\ \rowsep
 
 \tcode{get_-} \tcode{allocator()}	&
@@ -638,7 +638,7 @@ non-const rvalue of type \tcode{X}, and \tcode{m} is a value of type \tcode{A}.
 \tcode{X()}\br
 \tcode{X u;}							&
 													&
-  \requires\ \tcode{A} is \oldconcept{DefaultConstructible}.\br
+  \expects \tcode{A} meets the \oldconcept{DefaultConstructible} requirements.\br
   \ensures \tcode{u.empty()} returns \tcode{true},
   \tcode{u.get_allocator() == A()} &
   constant												\\ \rowsep
@@ -655,7 +655,7 @@ constant												\\
 \tcode{X(t, m)}\br
 \tcode{X u(t, m);}				&
                           &
-\requires\ \tcode{T} is \oldconcept{CopyInsertable} into \tcode{X}.\br
+\expects \tcode{T} is \oldconcept{CopyInsertable} into \tcode{X}.\br
 \ensures \tcode{u == t}, \tcode{u.get_allocator() == m} &
 linear													\\ \rowsep
 
@@ -663,24 +663,24 @@ linear													\\ \rowsep
 \tcode{X u(rv);}
            &
            &
-  \ensures \tcode{u} shall have the same elements as \tcode{rv} had before this
-  construction; the value of \tcode{u.get_allocator()} shall be the same as the
+  \ensures \tcode{u} has the same elements as \tcode{rv} had before this
+  construction; the value of \tcode{u.get_allocator()} is the same as the
   value of \tcode{rv.get_allocator()} before this construction. &
   constant                            \\ \rowsep
 
 \tcode{X(rv, m)}\br
 \tcode{X u(rv, m);}			&
 												&
-  \requires\ \tcode{T} is
+  \expects \tcode{T} is
   \oldconcept{MoveInsertable} into \tcode{X}.\br
-  \ensures \tcode{u} shall have the same elements,
+  \ensures \tcode{u} has the same elements,
   or copies of the elements, that \tcode{rv} had before
   this construction, \tcode{u.get_allocator() == m}												&
   constant if \tcode{m ==} \tcode{rv.get_allocator()}, otherwise linear	\\ \rowsep
 
 \tcode{a = t}             &
   \tcode{X\&}             &
-  \requires\ \tcode{T} is
+  \expects \tcode{T} is
   \oldconcept{CopyInsertable} into \tcode{X}
   and \oldconcept{CopyAssignable}.\br
   \ensures \tcode{a == t}    &
@@ -688,21 +688,22 @@ linear													\\ \rowsep
 
 \tcode{a = rv}          &
   \tcode{X\&}           &
-  \requires\ If \tcode{allocator_-}\br
+  \expects If \tcode{allocator_-}\br
   \tcode{traits<allocator_type>}\br
   \tcode{::propagate_on_container_-}\br
   \tcode{move_assignment::value} is\br
   \tcode{false}, \tcode{T} is
   \oldconcept{MoveInsertable} into \tcode{X} and
-  \oldconcept{MoveAssignable}. All existing elements of \tcode{a}
+  \oldconcept{MoveAssignable}.\br
+  \effects All existing elements of \tcode{a}
   are either move assigned to or destroyed.\br
-  \ensures \tcode{a} shall be equal to the value that \tcode{rv} had before
+  \ensures \tcode{a} is equal to the value that \tcode{rv} had before
   this assignment.      &
   linear                \\ \rowsep
 
 \tcode{a.swap(b)}       &
   \tcode{void}          &
-  exchanges the contents of \tcode{a} and \tcode{b} &
+  \effects exchanges the contents of \tcode{a} and \tcode{b} &
   constant      \\ \rowsep
 
 \end{libreqtab4a}
@@ -828,23 +829,23 @@ The complexities of the expressions are sequence dependent.
 \tcode{X(n, t)}\br
 \tcode{X u(n, t);}   &
                 &
- \requires\ \tcode{T} shall be
+ \expects \tcode{T} is
  \oldconcept{CopyInsertable} into \tcode{X}.\br
  \ensures \tcode{distance(begin(), end()) == n}\br
- Constructs a sequence container with \tcode{n} copies of \tcode{t}  \\ \rowsep
+ \effects Constructs a sequence container with \tcode{n} copies of \tcode{t}  \\ \rowsep
 
 \tcode{X(i, j)}\br
 \tcode{X u(i, j);}   &
                     &
- \requires\ \tcode{T} shall be \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.
+ \expects \tcode{T} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.
  For \tcode{vector}, if the iterator does
  not meet the \oldconcept{\-Forward\-Iterator} requirements\iref{forward.iterators}, \tcode{T}
- shall also be
- \oldconcept{MoveInsertable} into \tcode{X}.
- Each iterator in the range \range{i}{j} shall be dereferenced exactly once.\br
+ is also
+ \oldconcept{MoveInsertable} into \tcode{X}.\br
  \ensures \tcode{distance(begin(), end()) ==}
  \tcode{distance(i, j)}\br
- Constructs a sequence container equal to the range \tcode{[i, j)}    \\ \rowsep
+ \effects Constructs a sequence container equal to the range \tcode{[i, j)}.
+ Each iterator in the range \range{i}{j} is dereferenced exactly once. \\ \rowsep
 
 \tcode{X(il)}      &
                     &
@@ -852,20 +853,20 @@ The complexities of the expressions are sequence dependent.
 
 \tcode{a = il}     &
   \tcode{X\&}               &
-  \requires\ \tcode{T} is
+  \expects \tcode{T} is
   \oldconcept{CopyInsertable} into \tcode{X}
-  and \oldconcept{CopyAssignable}.
-  Assigns the range \range{il.begin()}{il.end()} into \tcode{a}. All existing
+  and \oldconcept{CopyAssignable}.\br
+  \effects Assigns the range \range{il.begin()}{il.end()} into \tcode{a}. All existing
   elements of \tcode{a} are either assigned to or destroyed.\br
   \returns\ \tcode{*this}.
   \\ \rowsep
 
 \tcode{a.emplace(p, args)}  &
  \tcode{iterator}            &
- \requires\ \tcode{T} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}. For \tcode{vector} and \tcode{deque},
+ \expects \tcode{T} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}. For \tcode{vector} and \tcode{deque},
  \tcode{T} is also
- \oldconcept{MoveInsertable} into \tcode{X} and \oldconcept{MoveAssignable}.
- \effects\ Inserts an object of type \tcode{T} constructed with
+ \oldconcept{MoveInsertable} into \tcode{X} and \oldconcept{MoveAssignable}.\br
+ \effects Inserts an object of type \tcode{T} constructed with
  \tcode{std::forward<\brk{}Args\brk{}>(\brk{}args)...} before \tcode{p}.
  \begin{note} \tcode{args} may directly or indirectly refer to
  a value in \tcode{a}. \end{note}
@@ -873,34 +874,34 @@ The complexities of the expressions are sequence dependent.
 
 \tcode{a.insert(p,t)}   &
  \tcode{iterator}       &
- \requires\ \tcode{T} shall be
+ \expects \tcode{T} is
  \oldconcept{CopyInsertable} into \tcode{X}. For \tcode{vector} and \tcode{deque},
- \tcode{T} shall also be \oldconcept{CopyAssignable}.\br
+ \tcode{T} is also \oldconcept{CopyAssignable}.\br
  \effects\ Inserts a copy of \tcode{t} before \tcode{p}. \\ \rowsep
 
 \tcode{a.insert(p,rv)}   &
  \tcode{iterator}       &
- \requires\ \tcode{T} shall be
+ \expects \tcode{T} is
  \oldconcept{MoveInsertable} into \tcode{X}. For \tcode{vector} and \tcode{deque},
-  \tcode{T} shall also be \oldconcept{MoveAssignable}.\br
+  \tcode{T} is also \oldconcept{MoveAssignable}.\br
  \effects\ Inserts a copy of \tcode{rv} before \tcode{p}. \\ \rowsep
 
 \tcode{a.insert(p,n,t)}     &
  \tcode{iterator}               &
- \requires\ \tcode{T} shall be
+ \expects \tcode{T} is
  \oldconcept{CopyInsertable} into \tcode{X}
  and \oldconcept{CopyAssignable}.\br
- Inserts \tcode{n} copies of \tcode{t} before \tcode{p}. \\ \rowsep
+ \effects Inserts \tcode{n} copies of \tcode{t} before \tcode{p}. \\ \rowsep
 
 \tcode{a.insert(p,i,j)}    &
  \tcode{iterator}           &
- \requires\ \tcode{T} shall be \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.
- For \tcode{vector} and \tcode{deque}, \tcode{T} shall also be
+ \expects \tcode{T} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.
+ For \tcode{vector} and \tcode{deque}, \tcode{T} is also
  \oldconcept{MoveInsertable} into \tcode{X}, \oldconcept{MoveConstructible}, \oldconcept{MoveAssignable},
  and swappable\iref{swappable.requirements}.
- Each iterator in the range \range{i}{j} shall be dereferenced exactly once.\br
- \requires \tcode{i} and \tcode{j} are not iterators into \tcode{a}.\br
- Inserts copies of elements in \tcode{[i, j)} before \tcode{p}  \\ \rowsep
+ Neither \tcode{i} nor \tcode{j} are iterators into \tcode{a}.\br
+ \effects Inserts copies of elements in \tcode{[i, j)} before \tcode{p}.
+ Each iterator in the range \range{i}{j} shall be dereferenced exactly once.  \\ \rowsep
 
 \tcode{a.insert(p, il)}  &
   \tcode{iterator}            &
@@ -908,37 +909,38 @@ The complexities of the expressions are sequence dependent.
 
 \tcode{a.erase(q)}  &
  \tcode{iterator}   &
- \requires\ For \tcode{vector} and \tcode{deque},
- \tcode{T} shall be \oldconcept{MoveAssignable}.\br
+ \expects For \tcode{vector} and \tcode{deque},
+ \tcode{T} is \oldconcept{MoveAssignable}.\br
  \effects\ Erases the element pointed to by \tcode{q}. \\ \rowsep
 
 \tcode{a.erase(q1,q2)}  &
  \tcode{iterator}   &
- \requires\ For \tcode{vector} and \tcode{deque},
- \tcode{T} shall be \oldconcept{MoveAssignable}.\br
+ \expects For \tcode{vector} and \tcode{deque},
+ \tcode{T} is \oldconcept{MoveAssignable}.\br
  \effects\ Erases the elements in the range \tcode{[q1, q2)}.  \\ \rowsep
 
 \tcode{a.clear()}   &
  \tcode{void}       &
- Destroys all elements in \tcode{a}. Invalidates all references, pointers, and
+ \effects Destroys all elements in \tcode{a}. Invalidates all references, pointers, and
  iterators referring to the elements of \tcode{a} and may invalidate the past-the-end iterator.\br
- \ensures \tcode{a.empty()} returns \tcode{true}.\br
+ \ensures \tcode{a.empty()} is \tcode{true}.\br
  \complexity Linear.      \\ \rowsep
 
 \tcode{a.assign(i,j)}   &
  \tcode{void}           &
- \requires\ \tcode{T} shall be \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}
+ \expects \tcode{T} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}
  and assignable from \tcode{*i}. For \tcode{vector}, if the iterator does not
  meet the forward iterator requirements\iref{forward.iterators}, \tcode{T}
- shall also be
- \oldconcept{MoveInsertable} into \tcode{X}.\br
- Each iterator in the range \range{i}{j} shall be dereferenced exactly once.\br
- \requires \tcode{i}, \tcode{j} are not iterators into \tcode{a}.\br
- Replaces elements in \tcode{a} with a copy of \tcode{[i, j)}.\br
+ is also
+ \oldconcept{MoveInsertable} into \tcode{X}.
+ Neither \tcode{i} nor \tcode{j} are iterators into \tcode{a}.\br
+ \effects
+ Replaces elements in \tcode{a} with a copy of \tcode{[i, j)}.
  Invalidates all references, pointers and iterators
  referring to the elements of \tcode{a}.
  For \tcode{vector} and \tcode{deque},
- also invalidates the past-the-end iterator.  \\ \rowsep
+ also invalidates the past-the-end iterator.
+ Each iterator in the range \range{i}{j} shall be dereferenced exactly once.  \\ \rowsep
 
 \tcode{a.assign(il)}    &
   \tcode{void}          &
@@ -946,11 +948,11 @@ The complexities of the expressions are sequence dependent.
 
 \tcode{a.assign(n,t)}   &
  \tcode{void}           &
- \requires\ \tcode{T} shall be
+ \expects \tcode{T} is
  \oldconcept{CopyInsertable} into \tcode{X}
- and \oldconcept{CopyAssignable}.\br
- \requires \tcode{t} is not a reference into \tcode{a}.\br
- Replaces elements in \tcode{a} with \tcode{n} copies of \tcode{t}.\br
+ and \oldconcept{CopyAssignable}.
+ \tcode{t} is not a reference into \tcode{a}.\br
+ \effects Replaces elements in \tcode{a} with \tcode{n} copies of \tcode{t}.
  Invalidates all references, pointers and iterators
  referring to the elements of \tcode{a}.
  For \tcode{vector} and \tcode{deque},
@@ -1087,9 +1089,9 @@ time.
 
 \tcode{a.emplace_\-front(args)}      &
  \tcode{reference}                &
- Prepends an object of type \tcode{T} constructed with \tcode{std::forward<\brk{}Args\brk{}>(\brk{}args)...}.\br
- \requires\ \tcode{T} shall be \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}.\br
- \returns{} \tcode{a.front()}.  &
+ \effects Prepends an object of type \tcode{T} constructed with \tcode{std::forward<\brk{}Args\brk{}>(\brk{}args)...}.\br
+ \expects \tcode{T} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}.\br
+ \returns \tcode{a.front()}.  &
  \tcode{deque},
  \tcode{forward_list},
  \tcode{list}
@@ -1097,11 +1099,11 @@ time.
 
 \tcode{a.emplace_\-back(args)}      &
  \tcode{reference}                &
- Appends an object of type \tcode{T} constructed with \tcode{std::forward<\brk{}Args\brk{}>(\brk{}args)...}.\br
- \requires\ \tcode{T} shall be \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}. For \tcode{vector}, \tcode{T}
- shall also be
+ \effects Appends an object of type \tcode{T} constructed with \tcode{std::forward<\brk{}Args\brk{}>(\brk{}args)...}.\br
+ \expects \tcode{T} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}. For \tcode{vector}, \tcode{T}
+ is also
  \oldconcept{MoveInsertable} into \tcode{X}.\br
- \returns{} \tcode{a.back()}.  &
+ \returns \tcode{a.back()}.  &
  \tcode{deque},
  \tcode{list},
  \tcode{vector}
@@ -1109,8 +1111,8 @@ time.
 
 \tcode{a.push_front(t)} &
   \tcode{void}          &
-  Prepends a copy of \tcode{t}.\br
-  \requires\ \tcode{T} shall be
+  \effects Prepends a copy of \tcode{t}.\br
+  \expects \tcode{T} is
   \oldconcept{CopyInsertable} into \tcode{X}.
     &
   \tcode{deque},
@@ -1120,8 +1122,8 @@ time.
 
 \tcode{a.push_front(rv)} &
   \tcode{void}          &
-  Prepends a copy of \tcode{rv}.\br
-  \requires\ \tcode{T} shall be
+  \effects Prepends a copy of \tcode{rv}.\br
+  \expects \tcode{T} is
   \oldconcept{MoveInsertable} into \tcode{X}.
     &
   \tcode{deque},
@@ -1131,8 +1133,8 @@ time.
 
 \tcode{a.push_back(t)} &
   \tcode{void}          &
-  Appends a copy of \tcode{t}.\br
-  \requires\ \tcode{T} shall be
+  \effects Appends a copy of \tcode{t}.\br
+  \expects \tcode{T} is
   \oldconcept{CopyInsertable} into \tcode{X}.
     &
   \tcode{basic_string},
@@ -1143,8 +1145,8 @@ time.
 
 \tcode{a.push_back(rv)} &
   \tcode{void}          &
-  Appends a copy of \tcode{rv}.\br
-  \requires\ \tcode{T} shall be
+  \effects Appends a copy of \tcode{rv}.\br
+  \expects \tcode{T} is
   \oldconcept{MoveInsertable} into \tcode{X}.
     &
   \tcode{basic_string},
@@ -1155,8 +1157,8 @@ time.
 
 \tcode{a.pop_front()}      &
  \tcode{void}               &
- Destroys the first element.\br
- \requires\ \tcode{a.empty()} shall be \tcode{false}. &
+ \effects Destroys the first element.\br
+ \expects \tcode{a.empty()} is \tcode{false}. &
  \tcode{deque},
  \tcode{forward_list},
  \tcode{list}
@@ -1164,8 +1166,8 @@ time.
 
 \tcode{a.pop_back()}       &
  \tcode{void}               &
- Destroys the last element.\br
- \requires\ \tcode{a.empty()} shall be \tcode{false}. &
+ \effects Destroys the last element.\br
+ \expects \tcode{a.empty()} is \tcode{false}. &
  \tcode{basic_string},
  \tcode{deque},
  \tcode{list},
@@ -1317,8 +1319,8 @@ public:
 
 \begin{itemdescr}
 \pnum
-\requires Either \tcode{!alloc_}, or
-\tcode{ator_traits::propagate_on_container_move_assignment}
+\expects Either \tcode{!alloc_}, or
+\tcode{ator_traits::propagate_on_container_move_assignment::value}
 is \tcode{true}, or \tcode{alloc_ ==  nh.alloc_}.
 
 \pnum
@@ -1332,8 +1334,9 @@ calling \tcode{ator_traits::rebind_traits<container_node_type>::deallocate}.
 \item
 Assigns \tcode{nh.ptr_} to \tcode{ptr_}.
 \item
-If \tcode{!alloc\textunderscore} or \tcode{ator_traits::propagate_on_container_move_assignment}
-is \tcode{true}, move assigns \tcode{nh.alloc_} to \tcode{alloc_}.
+If \tcode{!alloc\textunderscore} or \tcode{ator_traits::propagate_on_container_move_assignment::value}
+is \tcode{true}, \linebreak
+move assigns \tcode{nh.alloc_} to \tcode{alloc_}.
 \item
 Assigns
 \tcode{nullptr} to \tcode{nh.ptr_} and assigns \tcode{nullopt} to
@@ -1367,7 +1370,7 @@ value_type& value() const;
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{empty() == false}.
+\expects \tcode{empty() == false}.
 
 \pnum
 \returns A reference to the \tcode{value_type} subobject in the
@@ -1383,7 +1386,7 @@ key_type& key() const;
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{empty() == false}.
+\expects \tcode{empty() == false}.
 
 \pnum
 \returns A non-const reference to the \tcode{key_type} member of the
@@ -1403,7 +1406,7 @@ mapped_type& mapped() const;
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{empty() == false}.
+\expects \tcode{empty() == false}.
 
 \pnum
 \returns A reference to the \tcode{mapped_type} member of the
@@ -1421,7 +1424,7 @@ allocator_type get_allocator() const;
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{empty() == false}.
+\expects \tcode{empty() == false}.
 
 \pnum
 \returns \tcode{*alloc_}.
@@ -1458,13 +1461,13 @@ void swap(@\placeholdernc{node-handle}@& nh)
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{!alloc_}, or \tcode{!nh.alloc_}, or
-\tcode{ator_traits::propagate_on_container_swap} is \tcode{true},
+\expects \tcode{!alloc_}, or \tcode{!nh.alloc_}, or
+\tcode{ator_traits::propagate_on_container_swap::value} is \tcode{true},
 or \tcode{alloc_ == nh.alloc_}.
 
 \pnum
 \effects Calls \tcode{swap(ptr_, nh.ptr_)}. If \tcode{!alloc_}, or
-\tcode{!nh.alloc_}, or \tcode{ator_traits::propagate_on_container_swap}
+\tcode{!nh.alloc_}, or \tcode{ator_traits::propagate_on_container_swap::value}
 is \tcode{true} calls \tcode{swap(alloc_, nh.alloc_)}.
 \end{itemdescr}
 
@@ -1661,18 +1664,18 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 \indexordmem{value_type}%
 \tcode{X::value_type} (\tcode{set} and \tcode{multiset} only) &
  \tcode{Key}            &
-  \requires\ \tcode{value_type} is \oldconcept{Erasable} from \tcode{X} &
+  \expects \tcode{value_type} is \oldconcept{Erasable} from \tcode{X} &
   compile time \\ \rowsep
 
 \tcode{X::value_type} (\tcode{map} and \tcode{multimap} only) &
  \tcode{pair<const Key, T>}            &
-  \requires\ \tcode{value_type} is \oldconcept{Erasable} from \tcode{X} &
+  \expects \tcode{value_type} is \oldconcept{Erasable} from \tcode{X} &
   compile time \\ \rowsep
 
 \indexordmem{key_compare}%
 \tcode{X::key_compare}  &
   \tcode{Compare}       &
-  \requires\ \tcode{key_compare} is \oldconcept{CopyConstructible}. &
+  \expects \tcode{key_compare} is \oldconcept{CopyConstructible}. &
   compile time   \\ \rowsep
 
 \indexordmem{value_compare}%
@@ -1704,7 +1707,7 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 
 \tcode{X()}\br\tcode{X u;}                      &
                                                 &
-  \requires\ \tcode{key_compare} is \oldconcept{DefaultConstructible}.\br
+  \expects \tcode{key_compare} meets the \oldconcept{DefaultConstructible} requirements.\br
   \effects\ Constructs an empty container.
   Uses \tcode{Compare()} as a comparison object  &
   constant                                       \\ \rowsep
@@ -1712,7 +1715,7 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 \tcode{X(i,j,c)}\br
 \tcode{X~u(i,j,c);}     &
                         &
-  \requires\ \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.\br
+  \expects \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.\br
   \effects\ Constructs an empty container and inserts elements from the
   range \tcode{[i, j)} into it; uses \tcode{c} as a comparison object. &
   $N \log N$ in general, where $N$ has the value \tcode{distance(i, j)};
@@ -1720,7 +1723,7 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 
 \tcode{X(i,j)}\br\tcode{X~u(i,j);}    &
                                     &
-  \requires\ \tcode{key_compare} is \oldconcept{DefaultConstructible}.
+  \expects \tcode{key_compare} meets the \oldconcept{DefaultConstructible} requirements.
   \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.\br
   \effects\ Same as above, but uses \tcode{Compare()} as a comparison object.  &
   same as above                      \\ \rowsep
@@ -1737,7 +1740,7 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 
 \tcode{a = il}     &
   \tcode{X\&}               &
-  \requires\ \tcode{value_type} is
+  \expects \tcode{value_type} is
   \oldconcept{CopyInsertable} into \tcode{X}
   and \oldconcept{CopyAssignable}.\br
   \effects Assigns the range \range{il.begin()}{il.end()} into \tcode{a}. All
@@ -1749,19 +1752,19 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 \indexordmem{key_comp}%
 \tcode{b.key_comp()}       &
  \tcode{X::key_compare}    &
- returns the comparison object out of which \tcode{b} was constructed. &
+ \returns the comparison object out of which \tcode{b} was constructed. &
  constant                   \\ \rowsep
 
 \indexordmem{value_comp}%
 \tcode{b.value_comp()}     &
  \tcode{X::value_compare}  &
- returns an object of \tcode{value_compare} constructed out of the comparison object &
+ \returns an object of \tcode{value_compare} constructed out of the comparison object &
  constant                   \\ \rowsep
 
 \indexordmem{emplace}%
 \tcode{a_uniq.\brk{}emplace(\brk{}args)} &
  \tcode{pair<\brk{}iterator, bool>} &
-  \requires\ \tcode{value_type} shall be \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}.\br
+  \expects \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}.\br
   \effects\ Inserts a \tcode{value_type} object \tcode{t} constructed with
   \tcode{std::forward<\brk{}Args\brk{}>(\brk{}args)...} if and only if there is no
   element in the container with key equivalent to the key of \tcode{t}.
@@ -1773,7 +1776,7 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 
 \tcode{a_eq.\brk{}emplace(\brk{}args)}  &
  \tcode{iterator}    &
- \requires\ \tcode{value_type} shall be \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}.\br
+ \expects \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}.\br
  \effects\ Inserts a \tcode{value_type} object \tcode{t} constructed with
  \tcode{std::forward<\brk{}Args\brk{}>(\brk{}args)...} and returns the iterator pointing
  to the newly inserted element.
@@ -1795,8 +1798,8 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 \indexordmem{insert}%
 \tcode{a_uniq.\brk{}insert(\brk{}t)}      &
   \tcode{pair<\brk{}iterator, bool>}   &
-  \requires\ If \tcode{t} is a non-const rvalue, \tcode{value_type} shall be
-  \oldconcept{MoveInsertable} into \tcode{X}; otherwise, \tcode{value_type} shall be
+  \expects If \tcode{t} is a non-const rvalue, \tcode{value_type} is
+  \oldconcept{MoveInsertable} into \tcode{X}; otherwise, \tcode{value_type} is
   \oldconcept{CopyInsertable} into \tcode{X}.\br
   \effects\ Inserts \tcode{t} if and only if there is no element in the container
   with key equivalent to the key of \tcode{t}. The \tcode{bool} component of
@@ -1808,8 +1811,8 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 
 \tcode{a_eq.\brk{}insert(\brk{}t)}        &
   \tcode{iterator}               &
-  \requires\ If \tcode{t} is a non-const rvalue, \tcode{value_type} shall be
-  \oldconcept{MoveInsertable} into \tcode{X}; otherwise, \tcode{value_type} shall be
+  \expects If \tcode{t} is a non-const rvalue, \tcode{value_type} is
+  \oldconcept{MoveInsertable} into \tcode{X}; otherwise, \tcode{value_type} is
   \oldconcept{CopyInsertable} into \tcode{X}.\br
   \effects\ Inserts \tcode{t} and returns the iterator pointing
   to the newly inserted element.
@@ -1820,8 +1823,8 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 
 \tcode{a.\brk{}insert(\brk{}p, t)}                         &
   \tcode{iterator}               &
-  \requires\ If \tcode{t} is a non-const rvalue, \tcode{value_type} shall be
-  \oldconcept{MoveInsertable} into \tcode{X}; otherwise, \tcode{value_type} shall be
+  \expects If \tcode{t} is a non-const rvalue, \tcode{value_type} is
+  \oldconcept{MoveInsertable} into \tcode{X}; otherwise, \tcode{value_type} is
   \oldconcept{CopyInsertable} into \tcode{X}.\br
   \effects\ Inserts \tcode{t} if and only if there is no element with key
   equivalent to the key of \tcode{t} in containers with unique keys;
@@ -1834,9 +1837,9 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 
 \tcode{a.\brk{}insert(\brk{}i, j)}          &
   \tcode{void}                   &
-  \requires\ \tcode{value_type} shall be \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.\br
-  \requires \tcode{i}, \tcode{j} are not iterators into \tcode{a}.
-  inserts each element from the range \range{i}{j} if and only if there
+  \expects \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.
+  Neither \tcode{i} nor \tcode{j} are iterators into \tcode{a}.\br
+  \effects Inserts each element from the range \range{i}{j} if and only if there
   is no element with key equivalent to the key of that element in containers
   with unique keys; always inserts that element in containers with equivalent keys.  &
   $N \log (\tcode{a.size()} + N)$, where $N$ has the value \tcode{distance(i, j)} \\ \rowsep
@@ -1848,9 +1851,9 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 
 \tcode{a_uniq.\brk{}insert(\brk{}nh)}           &
  \tcode{insert_return_type}   &
- \requires \tcode{nh} is empty or
+ \expects \tcode{nh} is empty or
  \tcode{a_uniq.get_allocator() == nh.get_allocator()}.\br
- \effects{} If \tcode{nh} is empty, has no effect. Otherwise, inserts the
+ \effects If \tcode{nh} is empty, has no effect. Otherwise, inserts the
  element owned by \tcode{nh} if and only if there is no element in the
  container with a key equivalent to \tcode{nh.key()}.\br
  \ensures If \tcode{nh} is empty, \tcode{inserted} is \tcode{false},
@@ -1864,9 +1867,9 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 
 \tcode{a_eq.\brk{}insert(\brk{}nh)}           &
  \tcode{iterator}   &
- \requires \tcode{nh} is empty or
+ \expects \tcode{nh} is empty or
  \tcode{a_eq.get_allocator() == nh.get_allocator()}.\br
- \effects{} If \tcode{nh} is empty, has no effect and returns \tcode{a_eq.end()}.
+ \effects If \tcode{nh} is empty, has no effect and returns \tcode{a_eq.end()}.
  Otherwise, inserts the element owned by \tcode{nh} and returns an iterator
  pointing to the newly inserted element. If a range containing elements with
  keys equivalent to \tcode{nh.key()} exists in \tcode{a_eq}, the element is
@@ -1876,9 +1879,9 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 
 \tcode{a.\brk{}insert(\brk{}p, nh)}           &
  \tcode{iterator}   &
- \requires \tcode{nh} is empty or
+ \expects \tcode{nh} is empty or
  \tcode{a.get_allocator() == nh.get_allocator()}.\br
- \effects{} If \tcode{nh} is empty, has no effect and returns \tcode{a.end()}.
+ \effects If \tcode{nh} is empty, has no effect and returns \tcode{a.end()}.
  Otherwise, inserts the element owned by \tcode{nh} if and only if there
  is no element with key equivalent to \tcode{nh.key()} in containers with
  unique keys; always inserts the element owned by \tcode{nh} in containers
@@ -1892,22 +1895,22 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 \indexordmem{extract}%
 \tcode{a.\brk{}extract(\brk{}k)}              &
  \tcode{node_type}             &
- removes the first element in the container with key equivalent to \tcode{k}.
- Returns a \tcode{node_type} owning the element if found, otherwise an empty
+ \effects Removes the first element in the container with key equivalent to \tcode{k}.\br
+ \returns A \tcode{node_type} owning the element if found, otherwise an empty
  \tcode{node_type}. &
  $\log (\tcode{a.size()})$       \\ \rowsep
 
 \tcode{a.\brk{}extract(\brk{}q)}              &
  \tcode{node_type}             &
- removes the element pointed to by \tcode{q}.
- Returns a \tcode{node_type} owning that element. &
+ \effects Removes the element pointed to by \tcode{q}.\br
+ \returns A \tcode{node_type} owning that element. &
  amortized constant       \\ \rowsep
 
 \indexordmem{merge}%
 \tcode{a.merge(a2)}              &
  \tcode{void}             &
- \requires \tcode{a.get_allocator() == a2.get_allocator()}.\br
- Attempts to extract each element in \tcode{a2} and insert it into \tcode{a}
+ \expects \tcode{a.get_allocator() == a2.get_allocator()}.\br
+ \effects Attempts to extract each element in \tcode{a2} and insert it into \tcode{a}
  using the comparison object of \tcode{a}. In containers with unique keys,
  if there is an element in \tcode{a} with key equivalent to the key of an
  element from \tcode{a2}, then that element is not extracted from \tcode{a2}.\br
@@ -1915,26 +1918,29 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
  refer to those same elements but as members of \tcode{a}. Iterators referring
  to the transferred elements will continue to refer to their elements, but
  they now behave as iterators into \tcode{a}, not into \tcode{a2}.\br
- \throws{} Nothing unless the comparison object throws.  &
+ \throws Nothing unless the comparison object throws.  &
  $N \log(\tcode{a.size()+} N)$, where $N$ has the value \tcode{a2.size()}.    \\ \rowsep
 
 \indexordmem{erase}%
 \tcode{a.erase(k)}              &
  \tcode{size_type}             &
- erases all elements in the container with key equivalent to
- \tcode{k}. returns the number of erased elements.  &
+ \effects Erases all elements in the container with key equivalent to
+ \tcode{k}.\br
+ \returns The number of erased elements.  &
  $\log (\tcode{a.size()}) + \tcode{a.count(k)}$       \\ \rowsep
 
 \tcode{a.erase(q)}              &
  \tcode{iterator}               &
- erases the element pointed to by \tcode{q}. Returns an iterator pointing to
+ \effects Erases the element pointed to by \tcode{q}.\br
+ \returns An iterator pointing to
  the element immediately following \tcode{q} prior to the element being erased.
  If no such element exists, returns \tcode{a.end()}.     &
  amortized constant             \\ \rowsep
 
 \tcode{a.erase(r)}              &
  \tcode{iterator}               &
- erases the element pointed to by \tcode{r}. Returns an iterator pointing to
+ \effects Erases the element pointed to by \tcode{r}.\br
+ \returns An iterator pointing to
  the element immediately following \tcode{r} prior to the element being erased.
  If no such element exists, returns \tcode{a.end()}.     &
  amortized constant             \\ \rowsep
@@ -1942,7 +1948,8 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 \tcode{a.erase(}\br
  \tcode{q1, q2)}  &
  \tcode{iterator}        &
- erases all the elements in the range \range{q1}{q2}. Returns an iterator pointing to
+ \effects Erases all the elements in the range \range{q1}{q2}.\br
+ \returns An iterator pointing to
  the element pointed to by \tcode{q2} prior to any elements being erased. If no such element
  exists, \tcode{a.end()} is returned.  &
  $\log(\tcode{a.size()}) + N$, where $N$ has the value \tcode{distance(q1, q2)}.    \\ \rowsep
@@ -1950,35 +1957,35 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 \indexordmem{clear}%
 \tcode{a.clear()}       &
  \tcode{void}           &
- \tcode{a.erase(a.begin(),a.end())}\br
- \ensures \tcode{a.empty()} returns \tcode{true}.  &
+ \effects Equivalent to \tcode{a.erase(a.begin(), a.end())}.\br
+ \ensures \tcode{a.empty()} is \tcode{true}.  &
  linear in \tcode{a.size()}.  \\ \rowsep
 
 \indexordmem{find}%
 \tcode{b.find(k)}       &
  \tcode{iterator}; \tcode{const_iterator} for constant \tcode{b}.  &
- returns an iterator pointing to an element with the key equivalent
- to \tcode{k}, or \tcode{b.end()} if such an element is not found    &
+ \returns An iterator pointing to an element with the key equivalent
+ to \tcode{k}, or \tcode{b.end()} if such an element is not found.    &
  logarithmic            \\ \rowsep
 
 \tcode{a_tran.}\br
  \tcode{find(ke)}       &
  \tcode{iterator}; \tcode{const_iterator} for constant \tcode{a_tran}.  &
- returns an iterator pointing to an element with key \tcode{r} such that
+ \returns An iterator pointing to an element with key \tcode{r} such that
  \tcode{!c(r, ke) \&\& !c(ke, r)}, or \tcode{a_tran.end()} if such an element
- is not found    &
+ is not found.    &
  logarithmic            \\ \rowsep
 
 \indexordmem{count}%
 \tcode{b.count(k)}        &
  \tcode{size_type}        &
- returns the number of elements with key equivalent to \tcode{k}    &
+ \returns The number of elements with key equivalent to \tcode{k}.    &
  $\log (\tcode{b.size()}) + \tcode{b.count(k)}$   \\ \rowsep
 
 \tcode{a_tran.}\br
  \tcode{count(ke)}        &
  \tcode{size_type}        &
- returns the number of elements with key \tcode{r} such that
+ \returns The number of elements with key \tcode{r} such that
  \tcode{!c(r, ke) \&\& !c(ke, r)}    &
  $\log (\tcode{a_tran.size()}) + \tcode{a_tran.count(ke)}$   \\ \rowsep
 
@@ -1986,19 +1993,19 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 \tcode{b.}\br
  \tcode{contains(k)}  &
  \tcode{bool}         &
- equivalent to \tcode{b.find(k) != b.end()}  &
+ \effects Equivalent to: \tcode{return b.find(k) != b.end();}  &
  logarithmic            \\ \rowsep
 
 \tcode{a_tran.}\br
  \tcode{con\-tains(ke)} &
  \tcode{bool}         &
- equivalent to \tcode{a_tran.find(ke) != a_tran.end()}  &
+ \effects Equivalent to: \tcode{return a_tran.find(ke) != a_tran.end();}  &
  logarithmic            \\ \rowsep
 
 \indexordmem{lower_bound}%
 \tcode{b.lower_bound(k)}   &
  \tcode{iterator}; \tcode{const_iterator} for constant \tcode{b}.  &
- returns an iterator pointing to the first element with
+ \returns An iterator pointing to the first element with
  key not less than \tcode{k},
  or \tcode{b.end()} if such an element is not found.   &
  logarithmic            \\ \rowsep
@@ -2006,7 +2013,7 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 \tcode{a_tran.}\br
  \tcode{lower_bound(kl)}   &
  \tcode{iterator}; \tcode{const_iterator} for constant \tcode{a_tran}.  &
- returns an iterator pointing to the first element with
+ \returns An iterator pointing to the first element with
  key \tcode{r} such that \tcode{!c(r, kl)},
  or \tcode{a_tran.end()} if such an element is not found.   &
  logarithmic            \\ \rowsep
@@ -2014,7 +2021,7 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 \indexordmem{upper_bound}%
 \tcode{b.upper_bound(k)}       &
  \tcode{iterator}; \tcode{const_iterator} for constant \tcode{b}.  &
- returns an iterator pointing to the first element with
+ \returns An iterator pointing to the first element with
  key greater than \tcode{k},
  or \tcode{b.end()} if such an element is not found.   &
  logarithmic                    \\ \rowsep
@@ -2022,7 +2029,7 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 \tcode{a_tran.}\br
  \tcode{upper_bound(ku)}       &
  \tcode{iterator}; \tcode{const_iterator} for constant \tcode{a_tran}.  &
- returns an iterator pointing to the first element with
+ \returns An iterator pointing to the first element with
  key \tcode{r} such that \tcode{c(ku, r)},
  or \tcode{a_tran.end()} if such an element is not found.   &
  logarithmic                    \\ \rowsep
@@ -2031,15 +2038,15 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 \tcode{b.equal_range(k)}       &
  \tcode{pair<\brk{}iterator, iterator>};
  \tcode{pair<\brk{}const_iterator, const_iterator>} for constant \tcode{b}.     &
- equivalent to \tcode{make_pair(b.lower_bound(k), b.upper_bound(k))}.    &
+ \effects Equivalent to: \tcode{return make_pair(b.lower_bound(k), b.upper_bound(k));}    &
  logarithmic                    \\ \rowsep
 
 \tcode{a_tran.}\br
  \tcode{equal_range(ke)}       &
  \tcode{pair<\brk{}iterator, iterator>};
  \tcode{pair<\brk{}const_iterator, const_iterator>} for constant \tcode{a_tran}.     &
- equivalent to \tcode{make_pair(}\br
- \tcode{a_tran.lower_bound(ke), a_tran.upper_bound(ke))}.    &
+ \effects Equivalent to: \tcode{return make_pair(}\br
+ \tcode{a_tran.lower_bound(ke), a_tran.upper_bound(ke));}    &
  logarithmic                    \\
 \end{libreqtab4b}
 
@@ -2332,18 +2339,18 @@ In \tref{HashRequirements}:
 \indexunordmem{value_type}%
 \tcode{X::value_type} (\tcode{unordered_set} and \tcode{unordered_multiset} only) &
  \tcode{Key}            &
-  \requires\ \tcode{value_type} is \oldconcept{Erasable} from \tcode{X} &
+  \expects \tcode{value_type} is \oldconcept{Erasable} from \tcode{X} &
   compile time \\ \rowsep
 
 \tcode{X::value_type} (\tcode{unordered_map} and \tcode{unordered_multimap} only) &
  \tcode{pair<const Key, T>}            &
-  \requires\ \tcode{value_type} is \oldconcept{Erasable} from \tcode{X} &
+  \expects \tcode{value_type} is \oldconcept{Erasable} from \tcode{X} &
   compile time \\ \rowsep
 
 \indexunordmem{hasher}%
 \tcode{X::hasher}
 &   \tcode{Hash}
-&   \tcode{Hash} shall be a unary function object type such that the expression
+&   \expects \tcode{Hash} is a unary function object type such that the expression
     \tcode{hf(k)} has type \tcode{size_t}.%
 &   compile time
 \\ \rowsep
@@ -2353,8 +2360,8 @@ In \tref{HashRequirements}:
 &   \tcode{Hash::transparent_key_equal} if such a \grammarterm{qualified-id}
     is valid and denotes a type\iref{temp.deduct};
     otherwise, \tcode{Pred}.
-&   \requires\ \tcode{Pred} is \oldconcept{CopyConstructible}.\br
-    \tcode{Pred} shall be a binary predicate that takes two arguments
+&   \expects \tcode{Pred} meets the \oldconcept{CopyConstructible} requirements.\br
+    \tcode{Pred} is a binary predicate that takes two arguments
     of type \tcode{Key}.  \tcode{Pred} is an equivalence relation.%
 &   compile time
 \\ \rowsep
@@ -2403,7 +2410,7 @@ equality predicate.
 %
 \tcode{X(n, hf)}\br \tcode{X a(n, hf);}
 &   \tcode{X}
-&   \requires\ \tcode{key_equal} is \oldconcept{DefaultConstructible}.\br
+&   \expects \tcode{key_equal} meets the \oldconcept{DefaultConstructible} requirements.\br
     \effects\ Constructs an empty container with at least \tcode{n} buckets,
 using \tcode{hf} as the hash function and \tcode{key_equal()} as the key
 equality predicate.
@@ -2412,7 +2419,7 @@ equality predicate.
 %
 \tcode{X(n)}\br \tcode{X a(n);}
 &   \tcode{X}
-&   \requires\ \tcode{hasher} and \tcode{key_equal} are \oldconcept{DefaultConstructible}.\br
+&   \expects \tcode{hasher} and \tcode{key_equal} meet the \oldconcept{DefaultConstructible} requirements.\br
     \effects\ Constructs an empty container with at least \tcode{n} buckets,
 using \tcode{hasher()} as the hash function and \tcode{key_equal()}
 as the key equality predicate.
@@ -2421,7 +2428,7 @@ as the key equality predicate.
 %
 \tcode{X()}\br \tcode{X a;}
 &   \tcode{X}
-&   \requires\ \tcode{hasher} and \tcode{key_equal} are \oldconcept{DefaultConstructible}.\br
+&   \expects \tcode{hasher} and \tcode{key_equal} meet the \oldconcept{DefaultConstructible} requirements.\br
     \effects\ Constructs an empty container with an unspecified number of
   buckets, using \tcode{hasher()} as the hash function and
   \tcode{key_equal()} as the key equality predicate.
@@ -2430,7 +2437,7 @@ as the key equality predicate.
 %
 \tcode{X(i, j, n, hf, eq)}\br \tcode{X a(i, j, n, hf, eq);}
 &   \tcode{X}
-&   \requires\ \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.\br
+&   \expects \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.\br
     \effects\ Constructs an empty container with at least \tcode{n} buckets,
 using \tcode{hf} as the hash function and \tcode{eq} as the key
 equality predicate, and inserts elements from \tcode{[i, j)} into it.
@@ -2440,7 +2447,7 @@ equality predicate, and inserts elements from \tcode{[i, j)} into it.
 %
 \tcode{X(i, j, n, hf)}\br \tcode{X a(i, j, n, hf);}
 &   \tcode{X}
-&   \requires\ \tcode{key_equal} is \oldconcept{DefaultConstructible}.
+&   \expects \tcode{key_equal} meets the \oldconcept{DefaultConstructible} requirements.
     \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.\br
     \effects\ Constructs an empty container with at least \tcode{n} buckets,
 using \tcode{hf} as the hash function and \tcode{key_equal()} as the key
@@ -2451,7 +2458,7 @@ equality predicate, and inserts elements from \tcode{[i, j)} into it.
 %
 \tcode{X(i, j, n)}\br \tcode{X a(i, j, n);}
 &   \tcode{X}
-&   \requires\ \tcode{hasher} and \tcode{key_equal} are \oldconcept{DefaultConstructible}.
+&   \expects \tcode{hasher} and \tcode{key_equal} meet the \oldconcept{DefaultConstructible} requirements.
     \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.\br
     \effects\ Constructs an empty container with at least \tcode{n} buckets,
 using \tcode{hasher()} as the hash function and \tcode{key_equal()}
@@ -2463,7 +2470,7 @@ into it.
 %
 \tcode{X(i, j)}\br \tcode{X a(i, j);}
 &   \tcode{X}
-&   \requires\ \tcode{hasher} and \tcode{key_equal} are \oldconcept{DefaultConstructible}.
+&   \expects \tcode{hasher} and \tcode{key_equal} meet the \oldconcept{DefaultConstructible} requirements.
     \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.\br
     \effects\ Constructs an empty container with an unspecified number of
 buckets, using \tcode{hasher()} as the hash function and
@@ -2515,7 +2522,7 @@ from \tcode{[i, j)} into it.
 %
 \tcode{a = il}
 &   \tcode{X\&}
-&   \requires\ \tcode{value_type} is
+&   \expects \tcode{value_type} is
 \oldconcept{CopyInsertable} into \tcode{X}
 and \oldconcept{CopyAssignable}.\br
     \effects\ Assigns the range \range{il.begin()}{il.end()} into \tcode{a}. All
@@ -2526,14 +2533,14 @@ and \oldconcept{CopyAssignable}.\br
 \indexunordmem{hash_function}%
 \tcode{b.hash_function()}
 &   \tcode{hasher}
-&   Returns \tcode{b}'s hash function.%
+&   \returns \tcode{b}'s hash function.%
 &   constant
 \\ \rowsep
 %
 \indexunordmem{key_eq}%
 \tcode{b.key_eq()}
 &   \tcode{key_equal}
-&   Returns \tcode{b}'s key equality predicate.%
+&   \returns \tcode{b}'s key equality predicate.%
 &   constant
 \\ \rowsep
 %
@@ -2541,7 +2548,7 @@ and \oldconcept{CopyAssignable}.\br
 \indexunordmem{emplace}%
 \tcode{a_uniq.} \tcode{emplace(args)} &
   \tcode{pair<iterator,} \tcode{bool>} &
-  \requires\ \tcode{value_type} shall be \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}.\br
+  \expects \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}.\br
   \effects\ Inserts a \tcode{value_type} object \tcode{t} constructed with
   \tcode{std::forward<\brk{}Args\brk{}>(\brk{}args)...} if and only if there is no
   element in the container with key equivalent to the key of \tcode{t}.
@@ -2554,7 +2561,7 @@ and \oldconcept{CopyAssignable}.\br
 
 \tcode{a_eq.}\tcode{emplace(args)}  &
   \tcode{iterator}    &
-  \requires\ \tcode{value_type} shall be \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}.\br
+  \expects \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}.\br
   \effects\ Inserts a \tcode{value_type} object \tcode{t} constructed with
   \tcode{std::forward<\brk{}Args>(\brk{}args)...} and returns the iterator pointing
   to the newly inserted element.    &
@@ -2564,7 +2571,7 @@ and \oldconcept{CopyAssignable}.\br
 \indexunordmem{emplace_hint}%
 \tcode{a.emplace_hint(p, args)}  &
   \tcode{iterator}    &
-  \requires\ \tcode{value_type} shall be \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}.\br
+  \expects \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}.\br
   \effects\ Equivalent to \tcode{a.emplace(} \tcode{std::forward<\brk{}Args>(\brk{}args)...)}.
   Return value is an iterator pointing to the element with the key equivalent
   to the newly inserted element. The \tcode{const_iterator} \tcode{p}
@@ -2576,8 +2583,8 @@ and \oldconcept{CopyAssignable}.\br
 \indexunordmem{insert}%
 \tcode{a_uniq.insert(t)}
 &   \tcode{pair<iterator, bool>}
-&   \requires\ If \tcode{t} is a non-const rvalue, \tcode{value_type} shall be
-    \oldconcept{MoveInsertable} into \tcode{X}; otherwise, \tcode{value_type} shall be
+&   \expects If \tcode{t} is a non-const rvalue, \tcode{value_type} is
+    \oldconcept{MoveInsertable} into \tcode{X}; otherwise, \tcode{value_type} is
     \oldconcept{CopyInsertable} into \tcode{X}.\br
     \effects\ Inserts \tcode{t} if and only if there is no element in the container
     with key equivalent to the key of \tcode{t}.  The \tcode{bool}
@@ -2589,8 +2596,8 @@ and \oldconcept{CopyAssignable}.\br
 %
 \tcode{a_eq.insert(t)}
 &   \tcode{iterator}
-&   \requires\ If \tcode{t} is a non-const rvalue, \tcode{value_type} shall be
-    \oldconcept{MoveInsertable} into \tcode{X}; otherwise, \tcode{value_type} shall be
+&   \expects If \tcode{t} is a non-const rvalue, \tcode{value_type} is
+    \oldconcept{MoveInsertable} into \tcode{X}; otherwise, \tcode{value_type} is
     \oldconcept{CopyInsertable} into \tcode{X}.\br
     \effects\ Inserts \tcode{t}, and returns an iterator pointing to the newly
     inserted element.
@@ -2599,8 +2606,8 @@ and \oldconcept{CopyAssignable}.\br
 %
 \tcode{a.insert(p, t)}
 &   \tcode{iterator}
-&   \requires\ If \tcode{t} is a non-const rvalue, \tcode{value_type} shall be
-    \oldconcept{MoveInsertable} into \tcode{X}; otherwise, \tcode{value_type} shall be
+&   \expects If \tcode{t} is a non-const rvalue, \tcode{value_type} is
+    \oldconcept{MoveInsertable} into \tcode{X}; otherwise, \tcode{value_type} is
     \oldconcept{CopyInsertable} into \tcode{X}.\br
     \effects Equivalent to \tcode{a.insert(t)}.  Return value is an iterator pointing
 to the element with the key equivalent to that of \tcode{t}.  The
@@ -2611,8 +2618,8 @@ start.  Implementations are permitted to ignore the hint.%
 %
 \tcode{a.insert(i, j)}
 &   \tcode{void}
-&   \requires\ \tcode{value_type} shall be \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.\br
-    \requires \tcode{i} and \tcode{j} are not iterators in \tcode{a}.\br
+&   \expects \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.
+    Neither \tcode{i} nor \tcode{j} are iterators into \tcode{a}.\br
     \effects Equivalent to \tcode{a.insert(t)} for each element in \tcode{[i,j)}.%
 &   Average case \bigoh{N}, where $N$ is \tcode{distance(i, j)}.
     Worst case \bigoh{N(\tcode{a.size()}\brk{}+\brk{}1)}.
@@ -2627,9 +2634,9 @@ start.  Implementations are permitted to ignore the hint.%
 \tcode{a_uniq.}\br
  \tcode{insert(nh)}           &
  \tcode{insert_return_type}   &
- \requires \tcode{nh} is empty or
+ \expects \tcode{nh} is empty or
  \tcode{a_uniq.get_allocator() == nh.get_allocator()}.\br
- \effects{} If \tcode{nh} is empty, has no effect. Otherwise, inserts the
+ \effects If \tcode{nh} is empty, has no effect. Otherwise, inserts the
  element owned by \tcode{nh} if and only if there is no element in the
  container with a key equivalent to \tcode{nh.key()}.\br
  \ensures If \tcode{nh} is empty, \tcode{inserted} is \tcode{false},
@@ -2644,9 +2651,9 @@ start.  Implementations are permitted to ignore the hint.%
 \tcode{a_eq.}\br
  \tcode{insert(nh)}           &
  \tcode{iterator}   &
- \requires \tcode{nh} is empty or
+ \expects \tcode{nh} is empty or
  \tcode{a_eq.get_allocator() == nh.get_allocator()}.\br
- \effects{} If \tcode{nh} is empty, has no effect and returns \tcode{a_eq.end()}.
+ \effects If \tcode{nh} is empty, has no effect and returns \tcode{a_eq.end()}.
  Otherwise, inserts the element owned by \tcode{nh} and returns an iterator
  pointing to the newly inserted element.\br
  \ensures \tcode{nh} is empty. &
@@ -2654,9 +2661,9 @@ start.  Implementations are permitted to ignore the hint.%
 %
 \tcode{a.insert(q, nh)}           &
  \tcode{iterator}   &
- \requires \tcode{nh} is empty or
+ \expects \tcode{nh} is empty or
  \tcode{a.get_allocator() == nh.get_allocator()}.\br
- \effects{} If \tcode{nh} is empty, has no effect and returns \tcode{a.end()}.
+ \effects If \tcode{nh} is empty, has no effect and returns \tcode{a.end()}.
  Otherwise, inserts the element owned by \tcode{nh} if and only if there
  is no element with key equivalent to \tcode{nh.key()} in containers with
  unique keys; always inserts the element owned by \tcode{nh} in containers
@@ -2670,21 +2677,21 @@ start.  Implementations are permitted to ignore the hint.%
 \indexunordmem{extract}%
 \tcode{a.extract(k)}              &
  \tcode{node_type}             &
- Removes an element in the container with key equivalent to \tcode{k}.
- Returns a \tcode{node_type} owning the element if found, otherwise an empty
+ \effects Removes an element in the container with key equivalent to \tcode{k}.\br
+ \returns A \tcode{node_type} owning the element if found, otherwise an empty
  \tcode{node_type}. &
  Average case \bigoh{1}, worst case \bigoh{\tcode{a.size()}}.  \\ \rowsep
 %
 \tcode{a.extract(q)}              &
  \tcode{node_type}             &
- Removes the element pointed to by \tcode{q}.
- Returns a \tcode{node_type} owning that element. &
+ \effects Removes the element pointed to by \tcode{q}.\br
+ \returns A \tcode{node_type} owning that element. &
  Average case \bigoh{1}, worst case \bigoh{\tcode{a.size()}}.  \\ \rowsep
 %
 \indexunordmem{merge}%
 \tcode{a.merge(a2)}              &
  \tcode{void}             &
- \requires \tcode{a.get_allocator() == a2.get_allocator()}.\br
+ \expects \tcode{a.get_allocator() == a2.get_allocator()}.\br
  Attempts to extract each element in \tcode{a2} and insert it into \tcode{a}
  using the hash function and key equality predicate of \tcode{a}.
  In containers with unique keys, if there is an element in \tcode{a} with
@@ -2701,31 +2708,31 @@ start.  Implementations are permitted to ignore the hint.%
 \indexunordmem{erase}%
 \tcode{a.erase(k)}
 &   \tcode{size_type}
-&   Erases all elements with key equivalent to \tcode{k}.  Returns
-the number of elements erased.
+&   \effects Erases all elements with key equivalent to \tcode{k}.\br
+    \returns The number of elements erased.
 &   Average case \bigoh{\tcode{a.count(k)}}.  Worst case
     \bigoh{\tcode{a.size()}}.
 \\ \rowsep
 %
 \tcode{a.erase(q)}
 &   \tcode{iterator}
-&   Erases the element pointed to by \tcode{q}. Returns the
-    iterator immediately following \tcode{q} prior to the erasure.
+&   \effects Erases the element pointed to by \tcode{q}.\br
+    \returns The iterator immediately following \tcode{q} prior to the erasure.
 &   Average case \bigoh{1}, worst case \bigoh{\tcode{a.size()}}.
 \\ \rowsep
 %
 \tcode{a.erase(r)}
 &   \tcode{iterator}
-&   Erases the element pointed to by \tcode{r}. Returns the
-    iterator immediately following \tcode{r} prior to the erasure.
+&   \effects Erases the element pointed to by \tcode{r}.\br
+    \returns The iterator immediately following \tcode{r} prior to the erasure.
 &   Average case \bigoh{1}, worst case \bigoh{\tcode{a.size()}}.
 \\ \rowsep
 %
 \tcode{a.erase(q1, q2)}
 &   \tcode{iterator}
-&   Erases all elements in the range \tcode{[q1, q2)}. Returns
-    the iterator immediately following the erased elements prior to the
-    erasure.%
+&   \effects Erases all elements in the range \tcode{[q1, q2)}.\br
+    \returns The iterator immediately following the erased elements prior to the
+    erasure.
 &   Average case linear in \tcode{distance(q1, q2)},
     worst case \bigoh{\tcode{a.size()}}.
 \\ \rowsep
@@ -2733,23 +2740,23 @@ the number of elements erased.
 \indexunordmem{clear}%
 \tcode{a.clear()}
 & \tcode{void}
-& Erases all elements in the container.
-   \ensures \tcode{a.empty()} returns \tcode{true}%
+& \effects Erases all elements in the container.
+   \ensures \tcode{a.empty()} is \tcode{true}%
 & Linear in \tcode{a.size()}.
 \\ \rowsep
 %
 \indexunordmem{find}%
 \tcode{b.find(k)}
 &   \tcode{iterator}; \br \tcode{const_iterator} for const \tcode{b}.
-&   Returns an iterator pointing to an element with key equivalent to
-    \tcode{k}, or \tcode{b.end()} if no such element exists.%
+&   \returns An iterator pointing to an element with key equivalent to
+    \tcode{k}, or \tcode{b.end()} if no such element exists.
 &   Average case \bigoh{1}, worst case \bigoh{\tcode{b.size()}}.
 \\ \rowsep
 %
 \tcode{a_tran.find(ke)}
 &   \tcode{iterator}; \br \tcode{const_iterator} for const \tcode{a_tran}.
-&   Returns an iterator pointing to an element with key equivalent to
-    \tcode{ke}, or \tcode{a_tran.end()} if no such element exists.%
+&   \returns An iterator pointing to an element with key equivalent to
+    \tcode{ke}, or \tcode{a_tran.end()} if no such element exists.
 &   Average case \bigoh{1},
     worst case \bigoh{\tcode{a_tran.}\br{}\tcode{size()}}. % avoid wverfull
 \\ \rowsep
@@ -2757,13 +2764,13 @@ the number of elements erased.
 \indexunordmem{count}%
 \tcode{b.count(k)}
 &   \tcode{size_type}
-&   Returns the number of elements with key equivalent to \tcode{k}.%
+&   \returns The number of elements with key equivalent to \tcode{k}.%
 &   Average case \bigoh{\tcode{b.count(k)}}, worst case \bigoh{\tcode{b.size()}}.
 \\ \rowsep
 %
 \tcode{a_tran.count(ke)}
 &   \tcode{size_type}
-&   Returns the number of elements with key equivalent to \tcode{ke}.%
+&   \returns The number of elements with key equivalent to \tcode{ke}.%
 &   Average case
     \bigoh{\tcode{a_tran.}\br{}\tcode{count(ke)}}, % avoid overfull
     worst case \bigoh{\tcode{a_tran.}\br{}\tcode{size()}}. % avoid overfull
@@ -2787,7 +2794,7 @@ the number of elements erased.
 \tcode{b.equal_range(k)}
 &   \tcode{pair<iterator, iterator>}; \br
     \tcode{pair<const_iterator, const_iterator>} for const \tcode{b}.
-&   Returns a range containing all elements with keys equivalent to
+&   \returns A range containing all elements with keys equivalent to
     \tcode{k}.  Returns \tcode{make_pair(b.end(), b.end())} if
     no such elements exist.%
 &   Average case \bigoh{\tcode{b.count(k)}}.  Worst case
@@ -2797,7 +2804,7 @@ the number of elements erased.
 \tcode{a_tran.equal_range(ke)}
 &   \tcode{pair<iterator, iterator>}; \br
     \tcode{pair<const_iterator, const_iterator>} for const \tcode{a_tran}.
-&   Returns a range containing all elements with keys equivalent to
+&   \returns A range containing all elements with keys equivalent to
     \tcode{ke}.  Returns \tcode{make_pair(a_tran.end(), a_tran.end())} if
     no such elements exist.%
 &   Average case
@@ -2807,14 +2814,14 @@ the number of elements erased.
 \indexunordmem{bucket_count}%
 \tcode{b.bucket_count()}
 &   \tcode{size_type}
-&   Returns the number of buckets that \tcode{b} contains.%
+&   \returns The number of buckets that \tcode{b} contains.%
 &   Constant
 \\ \rowsep
 %
 \indexunordmem{max_bucket_count}%
 \tcode{b.max_bucket_count()}
 &   \tcode{size_type}
-&   Returns an upper bound on the number of buckets that \tcode{b} might
+&   \returns An upper bound on the number of buckets that \tcode{b} might
     ever contain.%
 &   Constant
 \\ \rowsep
@@ -2823,18 +2830,18 @@ the number of elements erased.
 \tcode{b.bucket(k)}
 & \tcode{size_type}
 &
-  \requires \tcode{b.bucket_count() > 0}.\br
-    Returns the index of the bucket in which elements with keys equivalent
+  \expects \tcode{b.bucket_count() > 0}.\br
+    \returns The index of the bucket in which elements with keys equivalent
     to \tcode{k} would be found, if any such element existed.
-    \ensures the return value shall be in the range \tcode{[0, b.bucket_count())}.%
+    \ensures The return value shall be in the range \tcode{[0, b.bucket_count())}.%
 & Constant
 \\ \rowsep
 %
 \indexunordmem{bucket_size}%
 \tcode{b.bucket_size(n)}
 &   \tcode{size_type}
-&   \requires \tcode{n} shall be in the range \tcode{[0, b.bucket_count())}.
-    Returns the number of elements in the $\tcode{n}^\text{th}$ bucket.%
+&   \expects \tcode{n} shall be in the range \tcode{[0, b.bucket_count())}.
+    \returns The number of elements in the $\tcode{n}^\text{th}$ bucket.%
 &   \bigoh{\tcode{b.bucket_}\-\tcode{size(n)}}
 \\ \rowsep
 %
@@ -2842,8 +2849,8 @@ the number of elements erased.
 \tcode{b.begin(n)}
 &   \tcode{local_iterator}; \br
     \tcode{const_local_iterator} for const \tcode{b}.
-&   \requires \tcode{n} shall be in the range \tcode{[0, b.bucket_count())}.
-    \tcode{b.begin(n)} returns an iterator referring to the
+&   \expects \tcode{n} is in the range \tcode{[0, b.bucket_count())}.\br
+    \returns An iterator referring to the
     first element in the bucket. If the bucket is empty, then
     \tcode{b.begin(n) == b.end(n)}.%
 &   Constant
@@ -2853,8 +2860,8 @@ the number of elements erased.
 \tcode{b.end(n)}
 &   \tcode{local_iterator}; \br
     \tcode{const_local_iterator} for const \tcode{b}.
-&   \requires \tcode{n} shall be in the range \tcode{[0, b.bucket_count())}.
-    \tcode{b.end(n)} returns an iterator which is the past-the-end
+&   \expects \tcode{n} is in the range \tcode{[0, b.bucket_count())}.\br
+    \returns An iterator which is the past-the-end
     value for the bucket.%
 &   Constant
 \\ \rowsep
@@ -2862,8 +2869,8 @@ the number of elements erased.
 \indexunordmem{cbegin}%
 \tcode{b.cbegin(n)}
 &   \tcode{const_local_iterator}
-&   \requires \tcode{n} shall be in the range \tcode{[0, b.bucket_count())}.
-    \tcode{b.cbegin(n)} returns an iterator referring to the
+&   \expects \tcode{n} shall be in the range \tcode{[0, b.bucket_count())}.\br
+    \returns An iterator referring to the
     first element in the bucket. If the bucket is empty, then
     \tcode{b.cbegin(n) == b.cend(n)}.%
 &   Constant
@@ -2872,8 +2879,8 @@ the number of elements erased.
 \indexunordmem{cend}%
 \tcode{b.cend(n)}
 &   \tcode{const_local_iterator}
-&   \requires \tcode{n} shall be in the range \tcode{[0, b.bucket_count())}.%
-    \tcode{b.cend(n)} returns an iterator which is the past-the-end
+&   \expects \tcode{n} is in the range \tcode{[0, b.bucket_count())}.%
+    \returns An iterator which is the past-the-end
     value for the bucket.%
 &   Constant
 \\ \rowsep
@@ -2881,14 +2888,14 @@ the number of elements erased.
 \indexunordmem{load_factor}%
 \tcode{b.load_factor()}
 &   \tcode{float}
-&   Returns the average number of elements per bucket.%
+&   \returns The average number of elements per bucket.%
 &   Constant
 \\ \rowsep
 %
 \indexunordmem{max_load_factor}%
 \tcode{b.max_load_factor()}
 &   \tcode{float}
-&   Returns a positive number that the container attempts to keep the load factor
+&   \returns A positive number that the container attempts to keep the load factor
     less than or equal to. The container automatically increases the
     number of buckets as necessary to keep the load factor below this
     number.%
@@ -2897,7 +2904,7 @@ the number of elements erased.
 %
 \tcode{a.max_load_factor(z)}
 &   \tcode{void}
-&   \requires \tcode{z} shall be positive.
+&   \expects \tcode{z} is positive.
     May change the container's maximum load factor, using \tcode{z} as a hint.%
 & Constant
 \\ \rowsep
@@ -3395,7 +3402,7 @@ template<class T, class... U>
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\requires \tcode{(is_same_v<T, U> \&\& ...)} is \tcode{true}. Otherwise the program is ill-formed.
+\mandates \tcode{(is_same_v<T, U> \&\& ...)} is \tcode{true}.
 \end{itemdescr}
 
 \rSec3[array.members]{Member functions}
@@ -3457,9 +3464,8 @@ template<class T, size_t N>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\remarks
-This function shall not participate in overload resolution
-unless \tcode{N == 0} or \tcode{is_swappable_v<T>} is \tcode{true}.
+\pnum
+\constraints \tcode{N == 0} or \tcode{is_swappable_v<T>} is \tcode{true}.
 
 \pnum\effects
 As if by \tcode{x.swap(y)}.
@@ -3501,10 +3507,11 @@ tuple_element<I, array<T, N>>::type
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{I < N}. The program is ill-formed if \tcode{I} is out of bounds.
+\mandates
+\tcode{I < N} is \tcode{true}.
 
 \pnum
-\cvalue  The type T.
+\value  The type T.
 \end{itemdescr}
 
 \indexlibrarymember{array}{get}%
@@ -3521,7 +3528,8 @@ template<size_t I, class T, size_t N>
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{I < N}. The program is ill-formed if \tcode{I} is out of bounds.
+\mandates
+\tcode{I < N} is \tcode{true}.
 
 \pnum
 \returns A reference to the $\tcode{I}^\text{th}$ element of \tcode{a},
@@ -3697,7 +3705,8 @@ explicit deque(size_type n, const Allocator& = Allocator());
 \tcode{n} default-inserted elements using the specified allocator.
 
 \pnum
-\requires \tcode{T} shall be \oldconcept{DefaultInsertable} into \tcode{*this}.
+\expects
+\tcode{T} is \oldconcept{DefaultInsertable} into \tcode{*this}.
 
 \pnum
 \complexity Linear in \tcode{n}.
@@ -3717,7 +3726,8 @@ with \tcode{n} copies of \tcode{value},
 using the specified allocator.
 
 \pnum
-\requires \tcode{T} shall be \oldconcept{CopyInsertable} into \tcode{*this}.
+\expects
+\tcode{T} is \oldconcept{CopyInsertable} into \tcode{*this}.
 
 \pnum
 \complexity
@@ -3752,12 +3762,13 @@ void resize(size_type sz);
 
 \begin{itemdescr}
 \pnum
+\expects
+\tcode{T} is \oldconcept{MoveInsertable} and \oldconcept{DefaultInsertable} into \tcode{*this}.
+
+\pnum
 \effects If \tcode{sz < size()}, erases the last \tcode{size() - sz} elements
 from the sequence. Otherwise,
 appends \tcode{sz - size()} default-inserted elements to the sequence.
-
-\pnum
-\requires \tcode{T} shall be \oldconcept{MoveInsertable} and \oldconcept{DefaultInsertable} into \tcode{*this}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{resize}!\idxcode{deque}}%
@@ -3767,13 +3778,13 @@ void resize(size_type sz, const T& c);
 
 \begin{itemdescr}
 \pnum
+\expects
+\tcode{T} is \oldconcept{CopyInsertable} into \tcode{*this}.
+
+\pnum
 \effects If \tcode{sz < size()}, erases the last \tcode{size() - sz} elements
 from the sequence. Otherwise,
 appends \tcode{sz - size()} copies of \tcode{c} to the sequence.
-
-\pnum
-\requires \tcode{T} shall be
-\oldconcept{CopyInsertable} into \tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{shrink_to_fit}{deque}%
@@ -3783,7 +3794,8 @@ void shrink_to_fit();
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{T} shall be \oldconcept{MoveInsertable} into \tcode{*this}.
+\expects
+\tcode{T} is \oldconcept{MoveInsertable} into \tcode{*this}.
 
 \pnum
 \effects \tcode{shrink_to_fit} is a non-binding request to reduce memory use
@@ -4103,11 +4115,11 @@ explicit forward_list(size_type n, const Allocator& = Allocator());
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{forward_list} object with \tcode{n}
-default-inserted elements using the specified allocator.
+\expects \tcode{T} is \oldconcept{DefaultInsertable} into \tcode{*this}.
 
 \pnum
-\requires \tcode{T} shall be \oldconcept{DefaultInsertable} into \tcode{*this}.
+\effects Constructs a \tcode{forward_list} object with \tcode{n}
+default-inserted elements using the specified allocator.
 
 \pnum
 \complexity Linear in \tcode{n}.
@@ -4120,10 +4132,10 @@ forward_list(size_type n, const T& value, const Allocator& = Allocator());
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{forward_list} object with \tcode{n} copies of \tcode{value} using the specified allocator.
+\expects \tcode{T} is \oldconcept{CopyInsertable} into \tcode{*this}.
 
 \pnum
-\requires \tcode{T} shall be \oldconcept{CopyInsertable} into \tcode{*this}.
+\effects Constructs a \tcode{forward_list} object with \tcode{n} copies of \tcode{value} using the specified allocator.
 
 \pnum
 \complexity Linear in \tcode{n}.
@@ -4232,7 +4244,7 @@ iterator insert_after(const_iterator position, T&& x);
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{position} is \tcode{before_begin()} or is a dereferenceable
+\expects \tcode{position} is \tcode{before_begin()} or is a dereferenceable
 iterator in the range \range{begin()}{end()}.
 
 \pnum
@@ -4249,7 +4261,7 @@ iterator insert_after(const_iterator position, size_type n, const T& x);
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{position} is \tcode{before_begin()} or is a dereferenceable
+\expects \tcode{position} is \tcode{before_begin()} or is a dereferenceable
 iterator in the range \range{begin()}{end()}.
 
 \pnum
@@ -4268,9 +4280,9 @@ template<class InputIterator>
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{position} is \tcode{before_begin()} or is a dereferenceable
+\expects \tcode{position} is \tcode{before_begin()} or is a dereferenceable
 iterator in the range \range{begin()}{end()}.
-\tcode{first} and \tcode{last} are not iterators in \tcode{*this}.
+Neither \tcode{first} nor \tcode{last} are iterators in \tcode{*this}.
 
 \pnum
 \effects Inserts copies of elements in \range{first}{last} after \tcode{position}.
@@ -4303,7 +4315,7 @@ template<class... Args>
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{position} is \tcode{before_begin()} or is a dereferenceable
+\expects \tcode{position} is \tcode{before_begin()} or is a dereferenceable
 iterator in the range \range{begin()}{end()}.
 
 \pnum
@@ -4321,7 +4333,7 @@ iterator erase_after(const_iterator position);
 
 \begin{itemdescr}
 \pnum
-\requires The iterator following \tcode{position} is dereferenceable.
+\expects The iterator following \tcode{position} is dereferenceable.
 
 \pnum
 \effects Erases the element pointed to by the iterator following \tcode{position}.
@@ -4340,7 +4352,7 @@ iterator erase_after(const_iterator position, const_iterator last);
 
 \begin{itemdescr}
 \pnum
-\requires All iterators in the range \orange{position}{last} are dereferenceable.
+\expects All iterators in the range \orange{position}{last} are dereferenceable.
 
 \pnum
 \effects Erases the elements in the range \orange{position}{last}.
@@ -4359,12 +4371,12 @@ void resize(size_type sz);
 
 \begin{itemdescr}
 \pnum
+\expects \tcode{T} is \oldconcept{DefaultInsertable} into \tcode{*this}.
+
+\pnum
 \effects If \tcode{sz < distance(begin(), end())}, erases the last \tcode{distance(begin(),
 end()) - sz} elements from the list. Otherwise, inserts \tcode{sz - distance(begin(), end())} default-inserted
 elements at the end of the list.
-
-\pnum
-\requires \tcode{T} shall be \oldconcept{DefaultInsertable} into \tcode{*this}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -4373,12 +4385,12 @@ void resize(size_type sz, const value_type& c);
 
 \begin{itemdescr}
 \pnum
+\expects \tcode{T} is \oldconcept{CopyInsertable} into \tcode{*this}.
+
+\pnum
 \effects If \tcode{sz < distance(begin(), end())}, erases the last \tcode{distance(begin(),
 end()) - sz} elements from the list. Otherwise, inserts \tcode{sz - distance(begin(), end())}
 copies of \tcode{c} at the end of the list.
-
-\pnum
-\requires \tcode{T} shall be \oldconcept{CopyInsertable} into \tcode{*this}.
 \end{itemdescr}
 
 
@@ -4413,10 +4425,10 @@ void splice_after(const_iterator position, forward_list&& x);
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{position} is \tcode{before_begin()} or is a dereferenceable
+\expects \tcode{position} is \tcode{before_begin()} or is a dereferenceable
 iterator in the range \range{begin()}{end()}.
-\tcode{get_allocator() == x.get_allocator()}.
-\tcode{addressof(x) != this}.
+\tcode{get_allocator() == x.get_allocator()} is \tcode{true}.
+\tcode{addressof(x) != this} is \tcode{true}.
 
 \pnum
 \effects Inserts the contents of \tcode{x} after
@@ -4440,10 +4452,10 @@ void splice_after(const_iterator position, forward_list&& x, const_iterator i);
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{position} is \tcode{before_begin()} or is a dereferenceable
+\expects \tcode{position} is \tcode{before_begin()} or is a dereferenceable
 iterator in the range \range{begin()}{end()}.
 The iterator following \tcode{i} is a dereferenceable iterator in \tcode{x}.
-\tcode{get_allocator() == x.get_allocator()}.
+\tcode{get_allocator() == x.get_allocator()} is \tcode{true}.
 
 \pnum
 \effects Inserts the element following \tcode{i} into \tcode{*this}, following
@@ -4470,11 +4482,11 @@ void splice_after(const_iterator position, forward_list&& x,
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{position} is \tcode{before_begin()} or is a
+\expects \tcode{position} is \tcode{before_begin()} or is a
 dereferenceable iterator in the range \range{begin()}{end()}. \orange{first}{last} is a
 valid range in \tcode{x}, and all iterators in the range \orange{first}{last} are
 dereferenceable. \tcode{position} is not an iterator in the range \orange{first}{last}.
-\tcode{get_allocator() == x.get_allocator()}.
+\tcode{get_allocator() == x.get_allocator()} is \tcode{true}.
 
 \pnum
 \effects Inserts elements in the range \orange{first}{last} after \tcode{position} and
@@ -4550,7 +4562,7 @@ template<class Compare> void merge(forward_list&& x, Compare comp);
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{*this} and \tcode{x} are both sorted with respect to
+\expects \tcode{*this} and \tcode{x} are both sorted with respect to
 the comparator \tcode{operator<} (for the first two overloads) or
 \tcode{comp} (for the last two overloads), and
 \tcode{get_allocator() == x.get_allocator()} is \tcode{true}.
@@ -4565,8 +4577,7 @@ refer to their elements, but they now behave as iterators into \tcode{*this}, no
 \tcode{x}.
 
 \pnum
-\remarks Stable\iref{algorithm.stable}. The behavior is undefined if
-\tcode{get_allocator() != x.get_allocator()}.
+\remarks Stable\iref{algorithm.stable}.
 
 \pnum
 \complexity At most \tcode{distance(begin(),
@@ -4828,11 +4839,11 @@ explicit list(size_type n, const Allocator& = Allocator());
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{list} with
-\tcode{n} default-inserted elements using the specified allocator.
+\expects \tcode{T} is \oldconcept{DefaultInsertable} into \tcode{*this}.
 
 \pnum
-\requires \tcode{T} shall be \oldconcept{DefaultInsertable} into \tcode{*this}.
+\effects Constructs a \tcode{list} with
+\tcode{n} default-inserted elements using the specified allocator.
 
 \pnum
 \complexity
@@ -4847,6 +4858,9 @@ list(size_type n, const T& value, const Allocator& = Allocator());
 
 \begin{itemdescr}
 \pnum
+\expects \tcode{T} is \oldconcept{CopyInsertable} into \tcode{*this}.
+
+\pnum
 \effects
 Constructs a
 \tcode{list}
@@ -4855,9 +4869,6 @@ with
 copies of
 \tcode{value},
 using the specified allocator.
-
-\pnum
-\requires \tcode{T} shall be \oldconcept{CopyInsertable} into \tcode{*this}.
 
 \pnum
 \complexity
@@ -4894,6 +4905,9 @@ void resize(size_type sz);
 
 \begin{itemdescr}
 \pnum
+\expects \tcode{T} is \oldconcept{DefaultInsertable} into \tcode{*this}.
+
+\pnum
 \effects
 If \tcode{size() < sz},
 appends \tcode{sz - size()} default-inserted elements to the
@@ -4905,11 +4919,6 @@ list<T>::iterator it = begin();
 advance(it, sz);
 erase(it, end());
 \end{codeblock}
-
-
-\pnum
-\requires \tcode{T} shall be
-\oldconcept{DefaultInsertable} into \tcode{*this}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{resize}!\idxcode{list}}%
@@ -4918,6 +4927,9 @@ void resize(size_type sz, const T& c);
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+\expects \tcode{T} is \oldconcept{CopyInsertable} into \tcode{*this}.
+
 \pnum
 \effects
 As if by:
@@ -4932,9 +4944,6 @@ else if (sz < size()) {
 else
   ;                 // do nothing
 \end{codeblock}
-
-\pnum
-\requires \tcode{T} shall be \oldconcept{CopyInsertable} into \tcode{*this}.
 \end{itemdescr}
 
 \rSec3[list.modifiers]{Modifiers}
@@ -5029,8 +5038,8 @@ void splice(const_iterator position, list&& x);
 
 \begin{itemdescr}
 \pnum
-\requires
-\tcode{addressof(x) != this}.
+\expects
+\tcode{addressof(x) != this} is \tcode{true}.
 
 \pnum
 \effects
@@ -5067,10 +5076,8 @@ void splice(const_iterator position, list&& x, const_iterator i);
 
 \begin{itemdescr}
 \pnum
-\requires
-\tcode{i}
-is a valid dereferenceable iterator of
-\tcode{x}.
+\expects
+\tcode{i} is a valid dereferenceable iterator of \tcode{x}.
 
 \pnum
 \effects
@@ -5116,14 +5123,9 @@ void splice(const_iterator position, list&& x, const_iterator first,
 
 \begin{itemdescr}
 \pnum
-\requires
-\tcode{[first, last)}
-is a valid range in
-\tcode{x}.
-The program has undefined behavior if
-\tcode{position}
-is an iterator in the range
-\range{first}{last}.
+\expects
+\tcode{[first, last)} is a valid range in \tcode{x}.
+\tcode{position} is not an iterator in the range \range{first}{last}.
 
 \pnum
 \effects
@@ -5232,11 +5234,12 @@ template<class Compare> void merge(list&& x, Compare comp);
 
 \begin{itemdescr}
 \pnum
-\requires
+\expects
 Both the list and the argument list
 shall be sorted with respect to
 the comparator \tcode{operator<} (for the first two overloads) or
 \tcode{comp} (for the last two overloads).
+\tcode{get_allocator() != x.get_allocator()} is \tcode{true}.
 
 \pnum
 \effects
@@ -5253,8 +5256,7 @@ refer to their elements, but they now behave as iterators into \tcode{*this}, no
 \pnum
 \remarks Stable\iref{algorithm.stable}. If \tcode{addressof(x) != this}, the range \tcode{[x.begin(), x.end())}
 is empty after the merge.
-No elements are copied by this operation. The behavior is undefined if
-\tcode{get_allocator() != x.get_allocator()}.
+No elements are copied by this operation.
 
 \pnum
 \complexity
@@ -5507,11 +5509,11 @@ explicit vector(size_type n, const Allocator& = Allocator());
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{vector} with \tcode{n}
-default-inserted elements using the specified allocator.
+\expects \tcode{T} is \oldconcept{DefaultInsertable} into \tcode{*this}.
 
 \pnum
-\requires \tcode{T} shall be \oldconcept{DefaultInsertable} into \tcode{*this}.
+\effects Constructs a \tcode{vector} with \tcode{n}
+default-inserted elements using the specified allocator.
 
 \pnum
 \complexity Linear in \tcode{n}.
@@ -5525,12 +5527,12 @@ vector(size_type n, const T& value,
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{vector} with \tcode{n}
-copies of \tcode{value}, using the specified allocator.
+\expects \tcode{T} is
+\oldconcept{CopyInsertable} into \tcode{*this}.
 
 \pnum
-\requires \tcode{T} shall be
-\oldconcept{CopyInsertable} into \tcode{*this}.
+\effects Constructs a \tcode{vector} with \tcode{n}
+copies of \tcode{value}, using the specified allocator.
 
 \pnum
 \complexity Linear in \tcode{n}.
@@ -5593,7 +5595,7 @@ void reserve(size_type n);
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{T} shall be \oldconcept{MoveInsertable} into \tcode{*this}.
+\expects \tcode{T} is \oldconcept{MoveInsertable} into \tcode{*this}.
 
 \pnum
 \effects
@@ -5645,7 +5647,7 @@ void shrink_to_fit();
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{T} shall be \oldconcept{MoveInsertable} into \tcode{*this}.
+\expects \tcode{T} is \oldconcept{MoveInsertable} into \tcode{*this}.
 
 \pnum
 \effects \tcode{shrink_to_fit} is a non-binding request to reduce
@@ -5698,13 +5700,13 @@ void resize(size_type sz);
 
 \begin{itemdescr}
 \pnum
+\expects \tcode{T} is
+\oldconcept{MoveInsertable} and \oldconcept{DefaultInsertable} into \tcode{*this}.
+
+\pnum
 \effects If \tcode{sz < size()}, erases the last \tcode{size() - sz} elements
 from the sequence. Otherwise,
 appends \tcode{sz - size()} default-inserted elements to the sequence.
-
-\pnum
-\requires \tcode{T} shall be
-\oldconcept{MoveInsertable} and \oldconcept{DefaultInsertable} into \tcode{*this}.
 
 \pnum
 \remarks If an exception is thrown other than by the move constructor of a non-\oldconcept{CopyInsertable}
@@ -5718,13 +5720,13 @@ void resize(size_type sz, const T& c);
 
 \begin{itemdescr}
 \pnum
+\pnum
+\expects \tcode{T} is
+\oldconcept{CopyInsertable} into \tcode{*this}.
+
 \effects If \tcode{sz < size()}, erases the last \tcode{size() - sz} elements
 from the sequence. Otherwise,
 appends \tcode{sz - size()} copies of \tcode{c} to the sequence.
-
-\pnum
-\requires \tcode{T} shall be
-\oldconcept{CopyInsertable} into \tcode{*this}.
 
 \pnum
 \remarks If an exception is thrown there are no effects.
@@ -6563,16 +6565,14 @@ template<class P>
 
 \begin{itemdescr}
 \pnum
+\constraints
+\tcode{is_constructible_v<value_type, P\&\&>} is \tcode{true}.
+
+\pnum
 \effects
 The first form is equivalent to
 \tcode{return emplace(std::forward<P>(x))}. The second form is
 equivalent to \tcode{return emplace_hint(position, std::forward<P>(x))}.
-
-\pnum
-\remarks
-These signatures shall not participate in overload resolution
-unless \tcode{is_constructible_v<value_type, P\&\&>} is
-\tcode{true}.
 \end{itemdescr}
 
 \indexlibrarymember{try_emplace}{map}%
@@ -6585,8 +6585,8 @@ template<class... Args>
 
 \begin{itemdescr}
 \pnum
-\requires
-\tcode{value_type} shall be \oldconcept{EmplaceConstructible} into \tcode{map}
+\expects
+\tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{map}
 from \tcode{piecewise_construct}, \tcode{for\-ward_as_tuple(k)},
 \tcode{forward_as_tuple(std::forward<Args>(args)...)}.
 
@@ -6623,8 +6623,8 @@ template<class... Args>
 
 \begin{itemdescr}
 \pnum
-\requires
-\tcode{value_type} shall be \oldconcept{EmplaceConstructible} into \tcode{map}
+\expects
+\tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{map}
 from \tcode{piecewise_construct}, \tcode{for\-ward_as_tuple(std::move(k))},
 \tcode{forward_as_tuple(std::forward<Args>(args)...)}.
 
@@ -6661,9 +6661,12 @@ template<class M>
 
 \begin{itemdescr}
 \pnum
-\requires
-\tcode{is_assignable_v<mapped_type\&, M\&\&>} shall be \tcode{true}.
-\tcode{value_type} shall be \oldconcept{Emplace\-Constructible} into \tcode{map}
+\mandates
+\tcode{is_assignable_v<mapped_type\&, M\&\&>} is \tcode{true}.
+
+\pnum
+\expects
+\tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{map}
 from \tcode{k}, \tcode{forward<M>(obj)}.
 
 \pnum
@@ -6698,9 +6701,12 @@ template<class M>
 
 \begin{itemdescr}
 \pnum
-\requires
-\tcode{is_assignable_v<mapped_type\&, M\&\&>} shall be \tcode{true}.
-\tcode{value_type} shall be \oldconcept{Emplace\-Constructible} into \tcode{map}
+\mandates
+\tcode{is_assignable_v<mapped_type\&, M\&\&>} is \tcode{true}.
+
+\pnum
+\expects
+\tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{map}
 from \tcode{move(k)}, \tcode{forward<M>(obj)}.
 
 \pnum
@@ -7038,16 +7044,14 @@ template<class P> iterator insert(const_iterator position, P&& x);
 
 \begin{itemdescr}
 \pnum
+\mandates
+\tcode{is_constructible_v<value_type, P\&\&>} is \tcode{true}.
+
+\pnum
 \effects
 The first form is equivalent to
 \tcode{return emplace(std::forward<P>(x))}. The second form is
 equivalent to \tcode{return emplace_hint(position, std::forward<P>(x))}.
-
-\pnum
-\remarks
-These signatures shall not participate in overload resolution
-unless \tcode{is_constructible_v<value_type, P\&\&>} is
-\tcode{true}.
 \end{itemdescr}
 
 \rSec3[multimap.erasure]{Erasure}
@@ -8165,12 +8169,13 @@ template<class P>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\effects Equivalent to: \tcode{return emplace(std::forward<P>(obj));}
 
 \pnum
-\remarks This signature shall not participate in overload resolution
-unless \tcode{is_constructible_v<value_type, P\&\&>} is \tcode{true}.
+\constraints
+\tcode{is_constructible_v<value_type, P\&\&>} is \tcode{true}.
+
+\pnum
+\effects Equivalent to: \tcode{return emplace(std::forward<P>(obj));}
 \end{itemdescr}
 
 \indexlibrarymember{unordered_map}{insert}%
@@ -8181,12 +8186,12 @@ template<class P>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
-\tcode{return emplace_hint(hint, std::forward<P>(obj));}
+\constraints
+\tcode{is_constructible_v<value_type, P\&\&>} is \tcode{true}.
 
 \pnum
-\remarks This signature shall not participate in overload resolution
-unless \tcode{is_constructible_v<value_type, P\&\&>} is \tcode{true}.
+\effects Equivalent to:
+\tcode{return emplace_hint(hint, std::forward<P>(obj));}
 \end{itemdescr}
 
 \indexlibrarymember{try_emplace}{unordered_map}%
@@ -8199,8 +8204,8 @@ template<class... Args>
 
 \begin{itemdescr}
 \pnum
-\requires
-\tcode{value_type} shall be \oldconcept{EmplaceConstructible} into \tcode{unordered_map}
+\expects
+\tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{unordered_map}
 from \tcode{piecewise_con\-struct}, \tcode{forward_as_tuple(k)},
 \tcode{forward_as_tuple(std::forward<Args>(args)...)}.
 
@@ -8237,8 +8242,8 @@ template<class... Args>
 
 \begin{itemdescr}
 \pnum
-\requires
-\tcode{value_type} shall be \oldconcept{EmplaceConstructible} into \tcode{unordered_map}
+\expects
+\tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{unordered_map}
 from \tcode{piecewise_con\-struct}, \tcode{forward_as_tuple(std::move(k))},
 \tcode{forward_as_tuple(std::forward<Args>(args)...)}.
 
@@ -8275,10 +8280,13 @@ template<class M>
 
 \begin{itemdescr}
 \pnum
-\requires
-\tcode{is_assignable_v<mapped_type\&, M\&\&>} shall be \tcode{true}.
-\tcode{value_type} shall be \oldconcept{Emplace\-Constructible} into \tcode{unordered_map}
-from \tcode{k}, \tcode{std::forward<M>(obj)}.
+\mandates
+\tcode{is_assignable_v<mapped_type\&, M\&\&>} is \tcode{true}.
+
+\pnum
+\expects
+\tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{unordered_map}
+from \tcode{k}, \tcode{std::forward<M>\brk{}(obj)}.
 
 \pnum
 \effects
@@ -8312,10 +8320,12 @@ template<class M>
 
 \begin{itemdescr}
 \pnum
-\requires
-\tcode{is_assignable_v<mapped_type\&, M\&\&>} shall be \tcode{true}.
-\tcode{value_type} shall be \oldconcept{Emplace\-Constructible} into \tcode{unordered_map}
-from \tcode{std::move(k)}, \tcode{std::forward<M>(obj)}.
+\mandates
+\tcode{is_assignable_v<mapped_type\&, M\&\&>} is \tcode{true}.
+
+\expects
+\tcode{value_type} is \oldconcept{Emplace\-Constructible} into \tcode{unordered_map}
+from \tcode{std::move(k)}, \tcode{std::\brk{}forward<M>(obj)}.
 
 \pnum
 \effects
@@ -8687,11 +8697,11 @@ template<class P>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return emplace(std::forward<P>(obj));}
+\constraints
+\tcode{is_constructible_v<value_type, P\&\&>} is \tcode{true}.
 
 \pnum
-\remarks This signature shall not participate in overload resolution
-unless \tcode{is_constructible_v<value_type, P\&\&>} is \tcode{true}.
+\effects Equivalent to: \tcode{return emplace(std::forward<P>(obj));}
 \end{itemdescr}
 
 \indexlibrarymember{unordered_multimap}{insert}%
@@ -8702,12 +8712,12 @@ template<class P>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
-\tcode{return emplace_hint(hint, std::forward<P>(obj));}
+\constraints
+\tcode{is_constructible_v<value_type, P\&\&>} is \tcode{true}.
 
 \pnum
-\remarks This signature shall not participate in overload resolution
-unless \tcode{is_constructible_v<value_type, P\&\&>} is \tcode{true}.
+\effects Equivalent to:
+\tcode{return emplace_hint(hint, std::forward<P>(obj));}
 \end{itemdescr}
 
 \rSec3[unord.multimap.erasure]{Erasure}
@@ -9701,9 +9711,8 @@ template<class T, class Container>
 
 \begin{itemdescr}
 \pnum
-\remarks
-This function shall not participate in overload resolution
-unless \tcode{is_swappable_v<Container>} is \tcode{true}.
+\constraints
+\tcode{is_swappable_v<Container>} is \tcode{true}.
 
 \pnum
 \effects As if by \tcode{x.swap(y)}.
@@ -9816,8 +9825,8 @@ priority_queue(const Compare& x, Container&& y);
 
 \begin{itemdescr}
 \pnum
-\requires
-\tcode{x} shall define a strict weak ordering\iref{alg.sorting}.
+\expects
+\tcode{x} defines a strict weak ordering\iref{alg.sorting}.
 
 \pnum
 \effects
@@ -9841,8 +9850,8 @@ template<class InputIterator>
 
 \begin{itemdescr}
 \pnum
-\requires
-\tcode{x} shall define a strict weak ordering\iref{alg.sorting}.
+\expects
+\tcode{x} defines a strict weak ordering\iref{alg.sorting}.
 
 \pnum
 \effects
@@ -10005,9 +10014,8 @@ template<class T, class Container, class Compare>
 
 \begin{itemdescr}
 \pnum
-\remarks
-This function shall not participate in overload resolution
-unless \tcode{is_swappable_v<Container>} is \tcode{true} and
+\constraints
+\tcode{is_swappable_v<Container>} is \tcode{true} and
 \tcode{is_swappable_v<Compare>} is \tcode{true}.
 
 \pnum
@@ -10250,9 +10258,8 @@ template<class T, class Container>
 
 \begin{itemdescr}
 \pnum
-\remarks
-This function shall not participate in overload resolution
-unless \tcode{is_swappable_v<Container>} is \tcode{true}.
+\constraints
+\tcode{is_swappable_v<Container>} is \tcode{true}.
 
 \pnum
 \effects As if by \tcode{x.swap(y)}.
@@ -10428,13 +10435,12 @@ constexpr span() noexcept;
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\ensures
-\tcode{size() == 0 \&\& data() == nullptr}.
+\constraints
+\tcode{Extent <= 0} is \tcode{true}.
 
 \pnum
-\remarks
-This constructor shall not participate in overload resolution
-unless \tcode{Extent <= 0} is \tcode{true}.
+\ensures
+\tcode{size() == 0 \&\& data() == nullptr}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{span}!constructor}%
@@ -10443,9 +10449,9 @@ constexpr span(pointer ptr, index_type count);
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\requires \range{ptr}{ptr + count} shall be a valid range.
+\expects \range{ptr}{ptr + count} is a valid range.
 If \tcode{extent} is not equal to \tcode{dynamic_extent},
-then \tcode{count} shall be equal to \tcode{extent}.
+then \tcode{count} is equal to \tcode{extent}.
 
 \pnum
 \effects
@@ -10466,10 +10472,10 @@ constexpr span(pointer first, pointer last);
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\requires
-\range{first}{last} shall be a valid range.
+\expects
+\range{first}{last} is a valid range.
 If \tcode{extent} is not equal to \tcode{dynamic_extent},
-then \tcode{last - first} shall be equal to \tcode{extent}.
+then \tcode{last - first} is equal to \tcode{extent}.
 
 \pnum
 \effects
@@ -10492,20 +10498,19 @@ template<size_t N> constexpr span(const array<value_type, N>& arr) noexcept;
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
+\constraints
+\begin{itemize}
+\item \tcode{extent == dynamic_extent || N == extent} is \tcode{true}, and
+\item \tcode{remove_pointer_t<decltype(data(arr))>(*)[]} is convertible to \tcode{ElementType(*)[]}.
+\end{itemize}
+
+\pnum
 \effects
 Constructs a \tcode{span} that is a view over the supplied array.
 
 \pnum
 \ensures
 \tcode{size() == N \&\& data() == data(arr)}.
-
-\pnum
-\remarks
-These constructors shall not participate in overload resolution unless:
-\begin{itemize}
-\item \tcode{extent == dynamic_extent || N == extent} is \tcode{true}, and
-\item \tcode{remove_pointer_t<decltype(data(arr))>(*)[]} is convertible to \tcode{ElementType(*)[]}.
-\end{itemize}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{span}!constructor}%
@@ -10515,8 +10520,19 @@ template<class Container> constexpr span(const Container& cont);
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\requires
-\range{data(cont)}{data(cont) + size(cont)} shall be a valid range.
+\constraints
+\begin{itemize}
+\item \tcode{extent == dynamic_extent} is \tcode{true},
+\item \tcode{Container} is not a specialization of \tcode{span},
+\item \tcode{Container} is not a specialization of \tcode{array},
+\item \tcode{is_array_v<Container>} is \tcode{false},
+\item \tcode{data(cont)} and \tcode{size(cont)} are both well-formed, and
+\item \tcode{remove_pointer_t<decltype(data(cont))>(*)[]} is convertible to \tcode{ElementType(*)[]}.
+\end{itemize}
+
+\pnum
+\expects
+\range{data(cont)}{data(cont) + size(cont)} is a valid range.
 
 \pnum
 \effects
@@ -10529,18 +10545,6 @@ Constructs a \tcode{span} that is a view over the range \range{data(cont)}{data(
 \pnum
 \throws
 What and when \tcode{data(cont)} and \tcode{size(cont)} throw.
-
-\pnum
-\remarks
-These constructors shall not participate in overload resolution unless:
-\begin{itemize}
-\item \tcode{extent == dynamic_extent} is \tcode{true},
-\item \tcode{Container} is not a specialization of \tcode{span},
-\item \tcode{Container} is not a specialization of \tcode{array},
-\item \tcode{is_array_v<Container>} is \tcode{false},
-\item \tcode{data(cont)} and \tcode{size(cont)} are both well-formed, and
-\item \tcode{remove_pointer_t<decltype(data(cont))>(*)[]} is convertible to \tcode{ElementType(*)[]}.
-\end{itemize}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{span}!constructor}%
@@ -10560,6 +10564,13 @@ template<class OtherElementType, ptrdiff_t OtherExtent>
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
+\constraints
+\begin{itemize}
+\item \tcode{Extent == dynamic_extent || Extent == OtherExtent} is \tcode{true}, and
+\item \tcode{OtherElementType(*)[]} is convertible to \tcode{ElementType(*)[]}.
+\end{itemize}
+
+\pnum
 \effects
 Constructs a \tcode{span} that is a view over the range
 \range{s.data()}{s.data() + s.size()}.
@@ -10567,14 +10578,6 @@ Constructs a \tcode{span} that is a view over the range
 \pnum
 \ensures
 \tcode{size() == s.size() \&\& data() == s.data()}.
-
-\pnum
-\remarks
-This constructor shall not participate in overload resolution unless:
-\begin{itemize}
-\item \tcode{Extent == dynamic_extent || Extent == OtherExtent} is \tcode{true}, and
-\item \tcode{OtherElementType(*)[]} is convertible to \tcode{ElementType(*)[]}.
-\end{itemize}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator=}!\idxcode{span}}%
@@ -10595,8 +10598,8 @@ template<ptrdiff_t Count> constexpr span<element_type, Count> first() const;
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\requires
-\tcode{0 <= Count \&\& Count <= size()}.
+\expects
+\tcode{0 <= Count \&\& Count <= size()} is \tcode{true}.
 
 \pnum
 \effects
@@ -10609,8 +10612,8 @@ template<ptrdiff_t Count> constexpr span<element_type, Count> last() const;
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\requires
-\tcode{0 <= Count \&\& Count <= size()}.
+\expects
+\tcode{0 <= Count \&\& Count <= size()} is \tcode{true}.
 
 \pnum
 \effects
@@ -10624,11 +10627,12 @@ template<ptrdiff_t Offset, ptrdiff_t Count = dynamic_extent>
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\requires
+\expects
 \begin{codeblock}
 (0 <= Offset && Offset <= size())
 && (Count == dynamic_extent || Count >= 0 && Offset + Count <= size())
 \end{codeblock}
+is \tcode{true}.
 
 \pnum
 \effects
@@ -10654,8 +10658,8 @@ constexpr span<element_type, dynamic_extent> first(index_type count) const;
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\requires
-\tcode{0 <= count \&\& count <= size()}.
+\expects
+\tcode{0 <= count \&\& count <= size()} is \tcode{true}.
 
 \pnum
 \effects
@@ -10668,8 +10672,8 @@ constexpr span<element_type, dynamic_extent> last(index_type count) const;
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\requires
-\tcode{0 <= count 0 \&\& count <= size()}.
+\expects
+\tcode{0 <= count 0 \&\& count <= size()} is \tcode{true}.
 
 \pnum
 \effects
@@ -10683,11 +10687,12 @@ constexpr span<element_type, dynamic_extent> subspan(
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\requires
+\expects
 \begin{codeblock}
 (0 <= offset && offset <= size())
 && (count == dynamic_extent || count >= 0 && offset + count <= size())
 \end{codeblock}
+is \tcode{true}.
 
 \pnum
 \effects
@@ -10739,8 +10744,8 @@ constexpr reference operator()(index_type idx) const;
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\requires
-\tcode{0 <= idx \&\& idx < size()}.
+\expects
+\tcode{0 <= idx \&\& idx < size()} is \tcode{true}.
 
 \pnum
 \effects
@@ -10870,11 +10875,10 @@ template<class ElementType, ptrdiff_t Extent>
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\effects
-Equivalent to: \tcode{return \{reinterpret_cast<byte*>(s.data()), s.size_bytes()\};}
+\constraints
+\tcode{is_const_v<ElementType>} is \tcode{false}.
 
 \pnum
-\remarks
-This function shall not participate in overload resolution unless
-\tcode{is_const_v<ElementType>} is \tcode{false}.
+\effects
+Equivalent to: \tcode{return \{reinterpret_cast<byte*>(s.data()), s.size_bytes()\};}
 \end{itemdescr}


### PR DESCRIPTION
Used capital letters after descriptive element headers.

Fixes #2701.