### PR TITLE
Motions 2019 02 lwg 2

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -2662,13 +2662,16 @@ namespace std {
                      ForwardIterator first, ForwardIterator last, Compare comp);
 
   namespace ranges {
+    template<class I>
+    using minmax_element_result = minmax_result<I>;
+
     template<ForwardIterator I, Sentinel<I> S, class Proj = identity,
              IndirectStrictWeakOrder<projected<I, Proj>> Comp = ranges::less<>>
-      constexpr minmax_result<I>
+      constexpr minmax_element_result<I>
         minmax_element(I first, S last, Comp comp = {}, Proj proj = {});
     template<ForwardRange R, class Proj = identity,
              IndirectStrictWeakOrder<projected<iterator_t<R>, Proj>> Comp = ranges::less<>>
-      constexpr minmax_result<safe_iterator_t<R>>
+      constexpr minmax_element_result<safe_iterator_t<R>>
         minmax_element(R&& r, Comp comp = {}, Proj proj = {});
   }
 

--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -1350,8 +1350,18 @@ namespace std {
 
 \indexlibrary{\idxcode{atomic}}%
 \pnum
-The template argument for
-\tcode{T} shall be trivially copyable\iref{basic.types}. \begin{note} Type arguments that are
+The template argument for \tcode{T} shall meet the
+\oldconcept{CopyConstructible} and \oldconcept{CopyAssignable} requirements.
+The program is ill-formed if any of
+\begin{itemize}
+\item \tcode{is_trivially_copyable_v<T>},
+\item \tcode{is_copy_constructible_v<T>},
+\item \tcode{is_move_constructible_v<T>},
+\item \tcode{is_copy_assignable_v<T>}, or
+\item \tcode{is_move_assignable_v<T>}
+\end{itemize}
+is \tcode{false}.
+\begin{note} Type arguments that are
 not also statically initializable may be difficult to use. \end{note}
 
 \pnum

--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -273,13 +273,18 @@ classifications, and fundamental type properties.
 \indexlibrary{\idxcode{Same}}%
 \begin{itemdecl}
 template<class T, class U>
-  concept Same = is_same_v<T, U>;
+  concept @\placeholdernc{same-impl}@ = is_same_v<T, U>;    // \expos
+
+template<class T, class U>
+  concept Same = @\placeholdernc{same-impl}@<T, U> && @\placeholdernc{same-impl}@<U, T>;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
+\begin{note}
 \tcode{\libconcept{Same}<T, U>} subsumes \tcode{\libconcept{Same}<U, T>} and
 vice versa.
+\end{note}
 \end{itemdescr}
 
 \rSec2[concept.derivedfrom]{Concept \libconcept{DerivedFrom}}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -3790,15 +3790,23 @@ void shrink_to_fit();
 but does not change the size of the sequence.
 \begin{note} The request is non-binding to allow latitude for
 implementation-specific optimizations. \end{note}
-If an exception is thrown other than by the move constructor
-of a non-\oldconcept{CopyInsertable} \tcode{T} there are no effects.
+If the size is equal to the old capacity, or
+if an exception is thrown other than by the move constructor
+of a non-\oldconcept{CopyInsertable} \tcode{T},
+then there are no effects.
 
 \pnum
-\complexity Linear in the size of the sequence.
+\complexity
+If the size is not equal to the old capacity,
+linear in the size of the sequence;
+otherwise constant.
 
 \pnum
-\remarks \tcode{shrink_to_fit} invalidates all the references, pointers, and iterators
-referring to the elements in the sequence as well as the past-the-end iterator.
+\remarks
+If the size is not equal to the old capacity,
+then invalidates all the references, pointers, and iterators
+referring to the elements in the sequence,
+as well as the past-the-end iterator.
 \end{itemdescr}
 
 \rSec3[deque.modifiers]{Modifiers}
@@ -5620,13 +5628,14 @@ may throw an appropriate exception.}
 \pnum
 \remarks
 Reallocation invalidates all the references, pointers, and iterators
-referring to the elements in the sequence.
+referring to the elements in the sequence, as well as the past-the-end iterator.
+\begin{note}
+If no reallocation happens, they remain valid.
+\end{note}
 No reallocation shall take place during insertions that happen
-after a call to
-\tcode{reserve()}
-until the time when an insertion would make the size of the vector
-greater than the value of
-\tcode{capacity()}.
+after a call to \tcode{reserve()}
+until an insertion would make the size of the vector
+greater than the value of \tcode{capacity()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{shrink_to_fit}!\idxcode{vector}}%
@@ -5649,12 +5658,16 @@ If an exception is thrown other than by the move constructor
 of a non-\oldconcept{CopyInsertable} \tcode{T} there are no effects.
 
 \pnum
-\complexity Linear in the size of the sequence.
+\complexity
+If reallocation happens,
+linear in the size of the sequence.
 
 \pnum
 \remarks Reallocation invalidates all the references, pointers, and iterators
 referring to the elements in the sequence as well as the past-the-end iterator.
+\begin{note}
 If no reallocation happens, they remain valid.
+\end{note}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{swap}!\idxcode{vector}}%
@@ -5758,8 +5771,13 @@ void push_back(T&& x);
 \remarks
 Causes reallocation if the new size is greater than the old capacity.
 Reallocation invalidates all the references, pointers, and iterators
-referring to the elements in the sequence.
-If no reallocation happens, all the iterators and references before the insertion point remain valid.
+referring to the elements in the sequence, as well as the past-the-end iterator.
+If no reallocation happens, then
+references, pointers, and iterators
+before the insertion point remain valid
+but those at or after the insertion point,
+including the past-the-end iterator,
+are invalidated.
 If an exception is thrown other than by
 the copy constructor, move constructor,
 assignment operator, or move assignment operator of
@@ -5773,7 +5791,10 @@ Otherwise, if an exception is thrown by the move constructor of a non-\oldconcep
 
 \pnum
 \complexity
-The complexity is linear in the number of elements inserted plus the distance
+If reallocation happens,
+linear in the number of elements of the resulting vector;
+otherwise,
+linear in the number of elements inserted plus the distance
 to the end of the vector.
 \end{itemdescr}
 

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10327,7 +10327,9 @@ namespace std {
     using index_type = ptrdiff_t;
     using difference_type = ptrdiff_t;
     using pointer = element_type*;
+    using const_pointer = const element_type*;
     using reference = element_type&;
+    using const_reference = const element_type&;
     using iterator = @\impdefx{type of \tcode{span::iterator}}@;
     using const_iterator = @\impdefx{type of \tcode{span::const_iterator}}@;
     using reverse_iterator = std::reverse_iterator<iterator>;

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -5149,7 +5149,7 @@ not into
 \pnum
 \complexity
 Constant time if
-\tcode{\&x == this};
+\tcode{addressof(x) == this};
 otherwise, linear time.
 \end{itemdescr}
 

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10515,8 +10515,6 @@ template<class Container> constexpr span(const Container& cont);
 \pnum
 \requires
 \range{data(cont)}{data(cont) + size(cont)} shall be a valid range.
-If \tcode{extent} is not equal to \tcode{dynamic_extent},
-then \tcode{size(cont)} shall be equal to \tcode{extent}.
 
 \pnum
 \effects
@@ -10534,6 +10532,7 @@ What and when \tcode{data(cont)} and \tcode{size(cont)} throw.
 \remarks
 These constructors shall not participate in overload resolution unless:
 \begin{itemize}
+\item \tcode{extent == dynamic_extent} is \tcode{true},
 \item \tcode{Container} is not a specialization of \tcode{span},
 \item \tcode{Container} is not a specialization of \tcode{array},
 \item \tcode{is_array_v<Container>} is \tcode{false},

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -1702,8 +1702,8 @@ system_error(error_code ec, const string& what_arg);
 \effects Constructs an object of class \tcode{system_error}.
 
 \pnum
-\ensures \tcode{code() == ec} and
-\tcode{string(what()).find(what_arg) != string::npos}.
+\ensures \tcode{code() == ec} and\newline
+\tcode{string_view(what()).find(what_arg.c_str()) != string_view::npos}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{system_error}!constructor}%
@@ -1717,7 +1717,7 @@ system_error(error_code ec, const char* what_arg);
 
 \pnum
 \ensures \tcode{code() == ec} and
-\tcode{string(what()).find(what_arg) != string::npos}.
+\tcode{string_view(what()).find(what_arg) != string_view::npos}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{system_error}!constructor}%
@@ -1744,7 +1744,7 @@ system_error(int ev, const error_category& ecat, const string& what_arg);
 
 \pnum
 \ensures \raggedright \tcode{code() == error_code(ev, ecat)} and\linebreak
-\tcode{string(what()).find(what_arg) != string::npos}.
+\tcode{string_view(what()).find(what_arg.c_str()) != string_view::npos}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{system_error}!constructor}%
@@ -1758,7 +1758,7 @@ system_error(int ev, const error_category& ecat, const char* what_arg);
 
 \pnum
 \ensures \raggedright \tcode{code() == error_code(ev, ecat)} and\linebreak
-\tcode{string(what()).find(what_arg) != string::npos}.
+\tcode{string_view(what()).find(what_arg) != string_view::npos}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{system_error}!constructor}%

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -12904,7 +12904,7 @@ filesystem_error(const string& what_arg, error_code ec);
 \item \tcode{code() == ec},
 \item \tcode{path1().empty() == true},
 \item \tcode{path2().empty() == true}, and
-\item \tcode{string_view(what()).find(what_arg)} \tcode{!= string_view::npos}.
+\item \tcode{string_view(what()).find(what_arg.c_str())} \tcode{!= string_view::npos}.
 \end{itemize}
 \end{itemdescr}
 
@@ -12920,7 +12920,7 @@ filesystem_error(const string& what_arg, const path& p1, error_code ec);
 \item \tcode{code() == ec},
 \item \tcode{path1()} returns a reference to the stored copy of \tcode{p1},
 \item \tcode{path2().empty() == true}, and
-\item \tcode{string_view(what()).find(what_arg)} \tcode{!= string_view::npos}.
+\item \tcode{string_view(what()).find(what_arg.c_str())} \tcode{!= string_view::npos}.
 \end{itemize}
 \end{itemdescr}
 
@@ -12936,7 +12936,7 @@ filesystem_error(const string& what_arg, const path& p1, const path& p2, error_c
 \item \tcode{code() == ec},
 \item \tcode{path1()} returns a reference to the stored copy of \tcode{p1},
 \item \tcode{path2()} returns a reference to the stored copy of \tcode{p2}, and
-\item \tcode{string_view(what()).find(what_arg)} \tcode{!= string_view::npos}.
+\item \tcode{string_view(what()).find(what_arg.c_str())} \tcode{!= string_view::npos}.
 \end{itemize}
 \end{itemdescr}
 

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -319,9 +319,10 @@ not defined by the implementation
 
 \definition{program-defined type}{defns.prog.def.type}
 \indexdefn{type!program-defined}%
-class type or enumeration type
+non-closure class type or enumeration type
 that is not part of the C++ standard library and
 not defined by the implementation,
+or a closure type of a non-implementation-provided lambda expression,
 or an instantiation of a program-defined specialization
 
 \begin{defnote}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -36,70 +36,21 @@ The
 and
 \tcode{valarray}
 components are parameterized by the type of information they contain and manipulate.
-A \Cpp{} program shall instantiate these components only with a type
-\tcode{T}
+A \Cpp{} program shall instantiate these components only with
+a cv-unqualified object type \tcode{T}
 that satisfies the
-following requirements:\footnote{In other words, value types.
+\oldconcept{DefaultConstructible},
+\oldconcept{CopyConstructible},
+\oldconcept{CopyAssignable}, and
+\oldconcept{Destructible}
+requirements\iref{utility.arg.requirements}.%
+\footnote{In other words, value types.
 These include arithmetic types,
 pointers, the library class
 \tcode{complex},
 and instantiations of
 \tcode{valarray}
 for value types.}
-
-\begin{itemize}
-\item \tcode{T} is not an abstract class (it has no pure virtual member functions);
-\item \tcode{T} is not a reference type;
-\item \tcode{T} is not cv-qualified;
-\item If \tcode{T} is a class, it has a public default constructor;
-\item If \tcode{T} is a class, it has a public copy constructor with the signature \tcode{T::T(const T\&)}
-\item If \tcode{T} is a class, it has a public destructor;
-\item If \tcode{T} is a class, it has a public assignment operator whose signature is either
-\tcode{T\& T::operator=(const T\&)}
-or
-\tcode{T\& T::operator=(T)}
-\item If \tcode{T} is a class, its assignment operator, copy and default constructors,
-and destructor shall correspond to each other in the following sense:
- \begin{itemize}
- \item Initialization of raw storage using the copy constructor
-   on the value of \tcode{T()}, however obtained,
-   is semantically equivalent to value-initialization of the same raw storage.
- \item Initialization of raw storage using the default constructor,
-   followed by assignment,
-   is semantically equivalent to initialization of raw storage using the copy constructor.
- \item Destruction of an object,
-   followed by initialization of its raw storage using the copy constructor,
-    is semantically equivalent to assignment to the original object.
- \end{itemize}
-
-\begin{note}
-This rule states, in part, that there shall not be any subtle differences in the semantics
-of initialization versus assignment.
-This gives an implementation
-considerable flexibility in how arrays are initialized.
-
-\begin{example}
-An implementation is allowed to initialize a
-\tcode{valarray}
-by allocating storage using the
-\tcode{new}
-operator (which
-implies a call to the default constructor for each element) and then
-assigning each element its value.
-Or the implementation can allocate raw
-storage and use the copy constructor to initialize each element.
-\end{example}
-
-If the distinction between initialization and assignment is important
-for a class, or if it fails to satisfy any of
-the other conditions listed above, the programmer should use
-\tcode{vector}\iref{vector} instead of
-\tcode{valarray}
-for that class.
-\end{note}
-\item If \tcode{T} is a class, it does not overload unary
-\tcode{operator\&}.
-\end{itemize}
 
 \pnum
 If any operation on \tcode{T}
@@ -7026,12 +6977,12 @@ such that the value of \tcode{i} is less than the length of \tcode{a}.
 
 \pnum
 \remarks
-The expression \tcode{\&a[i+j] == \&a[i] + j}
+The expression \tcode{addressof(a[i+j]) == addressof(a[i]) + j}
 evaluates to \tcode{true} for all \tcode{size_t i} and \tcode{size_t j}
 such that \tcode{i+j < a.size()}.
 
 \pnum
-The expression \tcode{\&a[i] != \&b[j]}
+The expression \tcode{addressof(a[i]) != addressof(b[j])}
 evaluates to \tcode{true} for any two arrays
 \tcode{a} and \tcode{b} and for any
 \tcode{size_t i} and \tcode{size_t j}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2387,6 +2387,8 @@ namespace std::ranges {
     friend constexpr sentinel_t<R> end(@\placeholder{ref-view}@ r)
     { return r.end(); }
   };
+  template<class R>
+    @\placeholder{ref-view}@(R&) -> @\placeholder{ref-view}@<R>;
 }
 \end{codeblock}
 

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1254,6 +1254,9 @@ constexpr subrange(I i, S s) requires (!StoreSize);
 
 \begin{itemdescr}
 \pnum
+\expects \range{i}{s} is a valid range.
+
+\pnum
 \effects Initializes \tcode{begin_} with \tcode{i} and \tcode{end_} with
 \tcode{s}.
 \end{itemdescr}
@@ -1266,7 +1269,8 @@ constexpr subrange(I i, S s, iter_difference_t<I> n)
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{n == ranges::distance(i, s)}.
+\expects \range{i}{s} is a valid range, and
+\tcode{n == ranges::distance(i, s)}.
 
 \pnum
 \effects Initializes \tcode{begin_} with \tcode{i} and \tcode{end_} with

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -4539,7 +4539,7 @@ constexpr bool starts_with(basic_string_view x) const noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return compare(0, npos, x) == 0;}
+Equivalent to: \tcode{return substr(0, x.size()) == x;}
 \end{itemdescr}
 
 \indexlibrarymember{starts_with}{basic_string_view}%
@@ -4550,7 +4550,7 @@ constexpr bool starts_with(charT x) const noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return starts_with(basic_string_view(addressof(x), 1));}
+Equivalent to: \tcode{return !empty() \&\& traits::eq(front(), x);}
 \end{itemdescr}
 
 \indexlibrarymember{starts_with}{basic_string_view}%
@@ -4586,7 +4586,7 @@ constexpr bool ends_with(charT x) const noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return ends_with(basic_string_view(addressof(x), 1));}
+Equivalent to: \tcode{return !empty() \&\& traits::eq(back(), x);}
 \end{itemdescr}
 
 \indexlibrarymember{ends_with}{basic_string_view}%

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -1653,12 +1653,14 @@ It does not increase \tcode{capacity()}, but may reduce \tcode{capacity()}
 by causing reallocation.
 
 \pnum
-\complexity Linear in the size of the sequence.
+\complexity If the size is not equal to the old capacity,
+linear in the size of the sequence;
+otherwise constant.
 
 \pnum
 \remarks Reallocation invalidates all the references, pointers, and iterators
-referring to the elements in the sequence as well as the past-the-end iterator.
-If no reallocation happens, they remain valid.
+referring to the elements in the sequence, as well as the past-the-end iterator.
+\begin{note} If no reallocation happens, they remain valid. \end{note}
 \end{itemdescr}
 
 \indexlibrarymember{clear}{basic_string}%


### PR DESCRIPTION
Fixes #2711.

Drafting notes:
* LWG3180: I didn't indent "using" (as we had discussed in Kona), in order to be consistent with the existing coding style.
* LWG3112: I used `\hfill\break` to workaround an Overfull issue.  Is there a better way to do this?