### PR TITLE
P1464R1 Mandating the Standard Library: Clause 22 - Iterators library

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1764,7 +1764,7 @@ the indicated semantics.
 \tcode{*r}          &
   unspecified       &
                             &
-  \requires \tcode{r} is dereferenceable.  \\ \rowsep
+  \expects \tcode{r} is dereferenceable.  \\ \rowsep
 
 \tcode{++r}         &
   \tcode{X\&}       &
@@ -1830,23 +1830,23 @@ has property
 \tcode{a != b}                  &
  contextually convertible to \tcode{bool}    &
  \tcode{!(a == b)}                              &
- \requires \orange{a}{b} is in the domain of \tcode{==}. \\ \rowsep
+ \expects \orange{a}{b} is in the domain of \tcode{==}. \\ \rowsep
 
 \tcode{*a}                      &
  \tcode{reference}, convertible to \tcode{T}       &
                                 &
- \requires \tcode{a} is dereferenceable.\br
+ \expects \tcode{a} is dereferenceable.\br
  The expression\br \tcode{(void)*a, *a} is equivalent to \tcode{*a}.\br
  If \tcode{a == b} and \orange{a}{b} is in the domain of \tcode{==}
  then \tcode{*a} is equivalent to \tcode{*b}.  \\ \rowsep
 \tcode{a->m}                    &
                                 &
  \tcode{(*a).m}                                &
- \requires \tcode{a} is dereferenceable. \\ \rowsep
+ \expects \tcode{a} is dereferenceable. \\ \rowsep
 \tcode{++r}                     &
  \tcode{X\&}                    &
                                 &
- \requires \tcode{r} is dereferenceable.\br
+ \expects \tcode{r} is dereferenceable.\br
  \ensures \tcode{r} is dereferenceable or \tcode{r} is past-the-end;\br
  any copies of the previous value of \tcode{r} are no longer
  required to be dereferenceable nor to be in the domain of \tcode{==}.    \\ \rowsep
@@ -1905,14 +1905,14 @@ are valid and have the indicated semantics.
 \tcode{*r = o}      &
  result is not used &
                     &
- \remarks\ After this operation \tcode{r} is not required to be dereferenceable.\br
+ \remarks After this operation \tcode{r} is not required to be dereferenceable.\br
  \ensures \tcode{r} is incrementable. \\ \rowsep
 
 \tcode{++r}         &
  \tcode{X\&}        &
                     &
  \tcode{addressof(r) == addressof(++r)}.\br
- \remarks\ After this operation \tcode{r} is not required to be dereferenceable.\br
+ \remarks After this operation \tcode{r} is not required to be dereferenceable.\br
  \ensures \tcode{r} is incrementable. \\ \rowsep
 
 \tcode{r++}         &
@@ -1920,12 +1920,12 @@ are valid and have the indicated semantics.
  \tcode{\{ X tmp = r;}\br
  \tcode{  ++r;}\br
  \tcode{  return tmp; \}}   &
- \remarks\ After this operation \tcode{r} is not required to be dereferenceable.\br
+ \remarks After this operation \tcode{r} is not required to be dereferenceable.\br
  \ensures \tcode{r} is incrementable. \\ \rowsep
 
 \tcode{*r++ = o}    &
  result is not used &&
- \remarks\ After this operation \tcode{r} is not required to be dereferenceable.\br
+ \remarks After this operation \tcode{r} is not required to be dereferenceable.\br
  \ensures \tcode{r} is incrementable. \\
 \end{libreqtab4b}
 
@@ -2048,7 +2048,7 @@ the following expressions are valid as shown in \tref{iterator.bidirectional.req
 \tcode{\dcr r}      &
  \tcode{X\&}        &
                     &
- \requires there exists \tcode{s} such that \tcode{r == ++s}.\br
+ \expects there exists \tcode{s} such that \tcode{r == ++s}.\br
  \ensures \tcode{r} is dereferenceable.\br
  \tcode{\dcr(++r) == r}.\br
  \tcode{\dcr r == \dcr s} implies \tcode{r == s}.\br
@@ -2111,7 +2111,7 @@ the following expressions are valid as shown in \tref{iterator.random.access.req
 \tcode{r -= n}      &
  \tcode{X\&}        &
  \tcode{return r += -n;}    &
- \requires the absolute value of \tcode{n} is in the range of
+ \expects the absolute value of \tcode{n} is in the range of
  representable values of \tcode{difference_type}.   \\ \rowsep
 
 \tcode{a - n}       &
@@ -2122,7 +2122,7 @@ the following expressions are valid as shown in \tref{iterator.random.access.req
 \tcode{b - a}       &
  \tcode{difference_type}   &
  \tcode{return n}   &
- \requires there exists a value \tcode{n} of type \tcode{difference_type} such that \tcode{a + n == b}.\br
+ \expects there exists a value \tcode{n} of type \tcode{difference_type} such that \tcode{a + n == b}.\br
  \tcode{b == a + (b - a)}.  \\ \rowsep
 
 \tcode{a[n]}        &
@@ -3269,7 +3269,7 @@ template<class Iterator1, class Iterator2>
 \begin{itemdescr}
 \pnum
 \constraints
-The expression \tcode{x.base() == y.base()} shall be valid and
+\tcode{x.base() == y.base()} is well-formed and
 convertible to \tcode{bool}.
 
 \pnum
@@ -3288,7 +3288,7 @@ template<class Iterator1, class Iterator2>
 \begin{itemdescr}
 \pnum
 \constraints
-The expression \tcode{x.base() != y.base()} shall be valid and
+\tcode{x.base() != y.base()} is well-formed and
 convertible to \tcode{bool}.
 
 \pnum
@@ -3307,7 +3307,7 @@ template<class Iterator1, class Iterator2>
 \begin{itemdescr}
 \pnum
 \constraints
-The expression \tcode{x.base() > y.base()} shall be valid and
+\tcode{x.base() > y.base()} is well-formed and
 convertible to \tcode{bool}.
 
 \pnum
@@ -3326,7 +3326,7 @@ template<class Iterator1, class Iterator2>
 \begin{itemdescr}
 \pnum
 \constraints
-The expression \tcode{x.base() < y.base()} shall be valid and
+\tcode{x.base() < y.base()} is well-formed and
 convertible to \tcode{bool}.
 
 \pnum
@@ -3345,7 +3345,7 @@ template<class Iterator1, class Iterator2>
 \begin{itemdescr}
 \pnum
 \constraints
-The expression \tcode{x.base() >= y.base()} shall be valid and
+\tcode{x.base() >= y.base()} is well-formed and
 convertible to \tcode{bool}.
 
 \pnum
@@ -3364,7 +3364,7 @@ template<class Iterator1, class Iterator2>
 \begin{itemdescr}
 \pnum
 \constraints
-The expression \tcode{x.base() <= y.base()} shall be valid and
+\tcode{x.base() <= y.base()} is well-formed and
 convertible to \tcode{bool}.
 
 \pnum
@@ -4014,12 +4014,11 @@ template<class U> constexpr move_iterator(const move_iterator<U>& u);
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{move_iterator}, initializing
-\tcode{current} with \tcode{u.base()}.
+\mandates \tcode{U} is convertible to \tcode{Iterator}.
 
 \pnum
-\requires \tcode{U} shall be convertible to
-\tcode{Iterator}.
+\effects Constructs a \tcode{move_iterator}, initializing
+\tcode{current} with \tcode{u.base()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{move_iterator}%
@@ -4029,12 +4028,11 @@ template<class U> constexpr move_iterator& operator=(const move_iterator<U>& u);
 
 \begin{itemdescr}
 \pnum
-\effects Assigns \tcode{u.base()} to
-\tcode{current}.
+\mandates \tcode{U} is convertible to \tcode{Iterator}.
 
 \pnum
-\requires \tcode{U} shall be convertible to
-\tcode{Iterator}.
+\effects Assigns \tcode{u.base()} to
+\tcode{current}.
 \end{itemdescr}
 
 \rSec3[move.iter.op.conv]{Conversion}
@@ -4206,7 +4204,7 @@ template<Sentinel<Iterator> S>
 \begin{itemdescr}
 \pnum
 \constraints
-The expression \tcode{x.base() == y.base()} shall be valid and
+\tcode{x.base() == y.base()} is well-formed and
 convertible to \tcode{bool}.
 
 \pnum
@@ -4229,7 +4227,7 @@ template<Sentinel<Iterator> S>
 \begin{itemdescr}
 \pnum
 \constraints
-The expression \tcode{x.base() == y.base()} shall be valid and
+\tcode{x.base() == y.base()} is well-formed and
 convertible to \tcode{bool}.
 
 \pnum
@@ -4245,7 +4243,7 @@ constexpr bool operator<(const move_iterator<Iterator1>& x, const move_iterator<
 \begin{itemdescr}
 \pnum
 \constraints
-The expression \tcode{x.base() < y.base()} shall be valid and
+\tcode{x.base() < y.base()} is well-formed and
 convertible to \tcode{bool}.
 
 \pnum
@@ -4261,7 +4259,7 @@ constexpr bool operator>(const move_iterator<Iterator1>& x, const move_iterator<
 \begin{itemdescr}
 \pnum
 \constraints
-The expression \tcode{y.base() < x.base()} shall be valid and
+\tcode{y.base() < x.base()} is well-formed and
 convertible to \tcode{bool}.
 
 \pnum
@@ -4277,7 +4275,7 @@ constexpr bool operator<=(const move_iterator<Iterator1>& x, const move_iterator
 \begin{itemdescr}
 \pnum
 \constraints
-The expression \tcode{y.base() < x.base()} shall be valid and
+\tcode{y.base() < x.base()} is well-formed and
 convertible to \tcode{bool}.
 
 \pnum
@@ -4293,7 +4291,7 @@ constexpr bool operator>=(const move_iterator<Iterator1>& x, const move_iterator
 \begin{itemdescr}
 \pnum
 \constraints
-The expression \tcode{x.base() < y.base()} shall be valid and
+\tcode{x.base() < y.base()} is well-formed and
 convertible to \tcode{bool}.
 
 \pnum
@@ -4331,7 +4329,7 @@ template<class Iterator>
 \begin{itemdescr}
 \pnum
 \constraints
-The expression \tcode{x + n} shall be valid and have type \tcode{Iterator}.
+\tcode{x + n} is well-formed and has type \tcode{Iterator}.
 
 \pnum
 \returns \tcode{x + n}.
@@ -5661,10 +5659,6 @@ istream_iterator(const istream_iterator& x) = default;
 
 \begin{itemdescr}
 \pnum
-\effects
-Constructs a copy of \tcode{x}.
-
-\pnum
 \ensures \tcode{in_stream == x.in_stream} is \tcode{true}.
 
 \pnum
@@ -5745,6 +5739,9 @@ istream_iterator operator++(int);
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+\expects \tcode{in_stream != nullptr} is \tcode{true}.
+
 \pnum
 \effects Equivalent to:
 \begin{codeblock}
@@ -5868,29 +5865,6 @@ ostream_iterator(ostream_type& s, const charT* delimiter);
 \effects
 Initializes \tcode{out_stream} with \tcode{addressof(s)} and
 \tcode{delim} with \tcode{delimiter}.
-\end{itemdescr}
-
-
-\indexlibrary{\idxcode{ostream_iterator}!constructor}%
-\begin{itemdecl}
-ostream_iterator(const ostream_iterator& x);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-Constructs a copy of \tcode{x}.
-\end{itemdescr}
-
-\indexlibrary{\idxcode{ostream_iterator}!destructor}%
-\begin{itemdecl}
-~ostream_iterator();
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-The iterator is destroyed.
 \end{itemdescr}
 
 \rSec3[ostream.iterator.ops]{Operations}
@@ -6248,9 +6222,9 @@ ostreambuf_iterator(ostream_type& s) noexcept;
 
 \begin{itemdescr}
 \pnum
-\requires
+\expects
 \tcode{s.rdbuf()}
-shall not be a null pointer.
+is not a null pointer.
 
 \pnum
 \effects
@@ -6265,9 +6239,9 @@ ostreambuf_iterator(streambuf_type* s) noexcept;
 
 \begin{itemdescr}
 \pnum
-\requires
+\expects
 \tcode{s}
-shall not be a null pointer.
+is not a null pointer.
 
 \pnum
 \effects


### PR DESCRIPTION
Fixes #2702.

FYI: "current" was changed to "base()" in commit 597b69001.