### PR TITLE
[func.not_fn], [func.bind_front] fix phrasing of \mandates and \expects

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -15261,11 +15261,11 @@ In the text that follows:
 \pnum
 \mandates
 \tcode{is_constructible_v<FD, F> \&\& is_move_constructible_v<FD>}
-shall be true.
+is true.
 
 \pnum
 \expects
-\tcode{FD} shall meet the requirements of \oldconcept{MoveConstructible}.
+\tcode{FD} meets the \oldconcept{MoveConstructible} requirements.
 
 \pnum
 \returns
@@ -15312,14 +15312,14 @@ In the text that follows:
 conjunction_v<is_constructible<FD, F>, is_move_constructible<FD>,
               is_constructible<BoundArgs, Args>..., is_move_constructible<BoundArgs>...>
 \end{codeblock}
-shall be true.
+is true.
 
 \pnum
 \expects
-\tcode{FD} shall meet the requirements of \oldconcept{MoveConstructible}.
+\tcode{FD} meets the \oldconcept{MoveConstructible} requirements.
 For each $\tcode{T}_i$ in \tcode{BoundArgs},
 if $\tcode{T}_i$ is an object type,
-$\tcode{T}_i$ shall meet the requirements of \oldconcept{MoveConstructible}.
+$\tcode{T}_i$ meets the \oldconcept{MoveConstructible} requirements.
 
 \pnum
 \returns


### PR DESCRIPTION
The Mandates: element should just state its condition, not say that it
"shall be true". Cpp17 concept requirements should be phrased as "X meets the
Y requirements" not "X shall meet the requirements of Y".