### PR TITLE
[stmt.iter,stmt.select] Add formatting for grammar terms

### DIFF
--- a/source/statements.tex
+++ b/source/statements.tex
@@ -215,9 +215,9 @@ in the syntax notation.
 The substatement in a \grammarterm{selection-statement} (each substatement,
 in the \tcode{else} form of the \tcode{if} statement) implicitly defines
 a block scope\iref{basic.scope}. If the substatement in a
-selection-statement is a single statement and not a
+\grammarterm{selection-statement} is a single statement and not a
 \grammarterm{compound-statement}, it is as if it was rewritten to be a
-compound-statement containing the original substatement.
+\grammarterm{compound-statement} containing the original substatement.
 \begin{example}
 
 \begin{codeblock}
@@ -443,14 +443,14 @@ An \grammarterm{init-statement} ends with a semicolon.
 \end{note}
 
 \pnum
+\indextext{scope!\idxgram{iteration-statement}}%
 The substatement in an \grammarterm{iteration-statement} implicitly defines
 a block scope\iref{basic.scope} which is entered and exited each time
 through the loop.
-
-\indextext{scope!\idxgram{iteration-statement}}%
-If the substatement in an iteration-statement is a single statement and
-not a \grammarterm{compound-statement}, it is as if it was rewritten to be
-a compound-statement containing the original statement.
+If the substatement in an \grammarterm{iteration-statement} is
+a single statement and not a \grammarterm{compound-statement},
+it is as if it was rewritten to be
+a \grammarterm{compound-statement} containing the original statement.
 \begin{example}
 
 \begin{codeblock}


### PR DESCRIPTION
and avoid starting a new paragraph after a single sentence.

Fixes #2753.