### PR TITLE
[conv.prom] b_min and b_max are no longer defined in [dcl.enum]

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -6435,7 +6435,7 @@ value 0.
 For an enumeration whose underlying type is fixed, the values of
 the enumeration are the values of the underlying type. Otherwise,
 the values of the enumeration are the values representable by
-a hypothetical integer types with minimal range exponent $M$
+a hypothetical integer type with minimal range exponent $M$
 such that all enumerators can be represented.
 The width of the smallest bit-field large enough to hold all the values of the
 enumeration type is $M$.

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -825,9 +825,8 @@ to a prvalue of its underlying type.
 \pnum
 \indextext{type!underlying!enumeration}%
 A prvalue of an unscoped enumeration type whose underlying type is not
-fixed\iref{dcl.enum} can be converted to a prvalue of the first of the following
-types that can represent all the values of the enumeration (i.e., the values in the
-range $b_\text{min}$ to $b_\text{max}$ as described in~\ref{dcl.enum}): \tcode{int},
+fixed can be converted to a prvalue of the first of the following
+types that can represent all the values of the enumeration\iref{dcl.enum}: \tcode{int},
 \tcode{unsigned int}, \tcode{long int}, \tcode{unsigned long int},
 \tcode{long long int}, or \tcode{unsigned long long int}. If none of the types in that
 list can represent all the values of the enumeration, a prvalue of an unscoped


### PR DESCRIPTION
Fixes #2751.