### PR TITLE
[temp.deduct.conv] Add missing formatting for 'noexcept'.

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -7770,11 +7770,11 @@ If the original \tcode{A} is a reference type,
 \item
 If the original \tcode{A} is a function pointer type,
 \tcode{A} can be ``pointer to function''
-even if the deduced \tcode{A} is ``pointer to noexcept function''.
+even if the deduced \tcode{A} is ``pointer to \tcode{noexcept} function''.
 \item
 If the original \tcode{A} is a pointer-to-member-function type,
 \tcode{A} can be ``pointer to member of type function''
-even if the deduced \tcode{A} is ``pointer to member of type noexcept function''.
+even if the deduced \tcode{A} is ``pointer to member of type \tcode{noexcept} function''.
 \item
 The deduced \tcode{A}
 can be another pointer or pointer-to-member type that


### PR DESCRIPTION
Fixes #2758.