### PR TITLE
[time.clock.req] Simplify requirements for Cpp17TrivialClock.

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -36,8 +36,8 @@ The
 and
 \tcode{valarray}
 components are parameterized by the type of information they contain and manipulate.
-A \Cpp{} program shall instantiate these components only with
-a cv-unqualified object type \tcode{T}
+A \Cpp{} program shall instantiate these components only with a numeric type.
+A \defnadj{numeric}{type} is a cv-unqualified object type \tcode{T}
 that satisfies the
 \oldconcept{DefaultConstructible},
 \oldconcept{CopyConstructible},

--- a/source/time.tex
+++ b/source/time.tex
@@ -1085,12 +1085,9 @@ A type \tcode{TC} meets the \oldconcept{TrivialClock} requirements if:
 \item \tcode{TC} satisfies the \oldconcept{Clock} requirements\iref{time.clock.req},
 
 \item the types \tcode{TC::rep}, \tcode{TC::duration}, and \tcode{TC::time_point}
-satisfy the \oldconcept{EqualityComparable} (\tref{equalitycomparable}),
-\oldconcept{LessThanComparable} (\tref{lessthancomparable}),
-\oldconcept{DefaultConstructible} (\tref{defaultconstructible}),
-\oldconcept{\-Copy\-Con\-structible} (\tref{copyconstructible}),
-\oldconcept{CopyAssignable} (\tref{copyassignable}), and
-\oldconcept{Destructible} (\tref{destructible}) requirements and the requirements of
+satisfy the \oldconcept{EqualityComparable} (\tref{equalitycomparable}) and
+\oldconcept{LessThanComparable} (\tref{lessthancomparable})
+requirements and the requirements of
 numeric types\iref{numeric.requirements}. \begin{note} This means, in particular,
 that operations on these types will not throw exceptions. \end{note}
 

--- a/source/time.tex
+++ b/source/time.tex
@@ -1085,7 +1085,7 @@ A type \tcode{TC} meets the \oldconcept{TrivialClock} requirements if:
 \item \tcode{TC} satisfies the \oldconcept{Clock} requirements\iref{time.clock.req},
 
 \item the types \tcode{TC::rep}, \tcode{TC::duration}, and \tcode{TC::time_point}
-satisfy the \oldconcept{EqualityComparable} (\tref{equalitycomparable}) and
+meet the \oldconcept{EqualityComparable} (\tref{equalitycomparable}) and
 \oldconcept{LessThanComparable} (\tref{lessthancomparable})
 requirements and the requirements of
 numeric types\iref{numeric.requirements}. \begin{note} This means, in particular,


### PR DESCRIPTION
Fixes #2734.