### PR TITLE
[dcl.init] Prepend 'Otherwise' to a bullet

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4372,7 +4372,7 @@ and the initializer is a string literal, see~\ref{dcl.init.string}.
 \item
 Otherwise, if the destination type is an array, the program is ill-formed.
 \item
-If the destination type is a (possibly cv-qualified) class type:
+Otherwise, if the destination type is a (possibly cv-qualified) class type:
 
 \begin{itemize}
 \item


### PR DESCRIPTION
Fixes #2673.