### PR TITLE
[dcl.attr.contract.cond] References cannot be modified.

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -8475,7 +8475,7 @@ void f(int * p)
 
 \pnum
 If a postcondition odr-uses\iref{basic.def.odr}
-a parameter in its predicate
+a non-reference parameter in its predicate
 and the function body makes direct or indirect modifications of
 the value of that parameter,
 the behavior is undefined.


### PR DESCRIPTION
Avoid confusion caused by using the words "makes [...]
modifications of the value of [a] parameter" by excluding
references.

Fixes #2669.