### PR TITLE
[lib] Use '(inclusive)', not other punctuation

### DIFF
--- a/source/locales.tex
+++ b/source/locales.tex
@@ -4231,8 +4231,8 @@ is
 or in the range from
 \tcode{'0'}
 through
-\tcode{'9'},
-inclusive)
+\tcode{'9'}
+(inclusive))
 stored in
 \tcode{digits}.
 \begin{example}
@@ -4664,8 +4664,8 @@ for
 in the range
 \tcode{'0'}
 through
-\tcode{'9'},
-inclusive, and
+\tcode{'9'}
+(inclusive) and
 \tcode{ct}
 is a reference of type
 \tcode{const ctype<charT>\&}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -3966,8 +3966,7 @@ result_type operator()();
 \begin{itemdescr}
 \pnum\returns A nondeterministic random value,
  uniformly distributed
- between \tcode{min()} and \tcode{max()},
- inclusive.
+ between \tcode{min()} and \tcode{max()} (inclusive).
  It is \impldef{how \tcode{random_device::operator()} generates values}
  how these values are generated.
 

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -5533,7 +5533,7 @@ The first of the following that applies (given the current conversion state):
 the multibyte character
 that corresponds to the U+0000 Unicode character
 (which is the value stored).
-\item between \tcode{1} and \tcode{n} inclusive,
+\item between \tcode{1} and \tcode{n} (inclusive),
 if the next n or fewer bytes complete a valid multibyte character
 (which is the value stored);
 the value returned is the number of bytes that complete the multibyte character.


### PR DESCRIPTION
to indicate inclusive ranges in prose.

Fixes #2672.