### PR TITLE
Simplifying [class.rel] wording.

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -6863,7 +6863,8 @@ or a function that is deleted or inaccessible from the operator function,
 or
 
 \item
-\tcode{x <=> y @ 0} is ill-formed.
+the operator \tcode{@}
+cannot be applied to the return type of \tcode{x <=> y}.
 \end{itemize}
 
 Otherwise, the operator function yields

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -6863,7 +6863,7 @@ or a function that is deleted or inaccessible from the operator function,
 or
 
 \item
-\tcode{x <=> y @ 0} cannot be converted to \tcode{bool}.
+\tcode{x <=> y @ 0} is ill-formed.
 \end{itemize}
 
 Otherwise, the operator function yields

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -6858,22 +6858,16 @@ is defined as deleted if
 \item
 overload resolution\iref{over.match},
 as applied to \tcode{x <=> y}
-(also considering synthesized candidates with reversed order of parameters\iref{over.match.oper}),
 results in an ambiguity
 or a function that is deleted or inaccessible from the operator function,
 or
 
 \item
-the operator \tcode{@}
-cannot be applied to the return type of \tcode{x <=> y} or \tcode{y <=> x}.
+\tcode{x <=> y @ 0} cannot be converted to \tcode{bool}.
 \end{itemize}
 
 Otherwise, the operator function yields
-\tcode{x <=> y @ 0}
-if an \tcode{operator<=>}
-with the original order of parameters was selected, or
-\tcode{0 @ y <=> x}
-otherwise.
+\tcode{x <=> y @ 0}.
 
 \pnum
 \begin{example}


### PR DESCRIPTION
`x` and `y` have the same type (this is in the context of a defaulted relational operator, so they have to be per [class.compare]/1). So either `x <=> y` finds something or it doesn't - there's no situation where we'd select the reversed candidate `y <=> x`, so we can simplify this wording. Same thing Richard pointed out http://lists.isocpp.org/core/2019/03/5706.php about defaulted `!=`.

Also, we never changed that `x <=> y @ 0` is actually convertible to `bool`, so added that too. 