### PR TITLE
[lib] Remove space between 'template' and argument list.

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -3140,9 +3140,9 @@ namespace std {
     void swap(deque<T, Allocator>& x, deque<T, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 
-  template <class T, class Allocator, class U>
+  template<class T, class Allocator, class U>
     void erase(deque<T, Allocator>& c, const U& value);
-  template <class T, class Allocator, class Predicate>
+  template<class T, class Allocator, class Predicate>
     void erase_if(deque<T, Allocator>& c, Predicate pred);
 
   namespace pmr {
@@ -3180,9 +3180,9 @@ namespace std {
     void swap(forward_list<T, Allocator>& x, forward_list<T, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 
-  template <class T, class Allocator, class U>
+  template<class T, class Allocator, class U>
     void erase(forward_list<T, Allocator>& c, const U& value);
-  template <class T, class Allocator, class Predicate>
+  template<class T, class Allocator, class Predicate>
     void erase_if(forward_list<T, Allocator>& c, Predicate pred);
 
   namespace pmr {
@@ -3220,9 +3220,9 @@ namespace std {
     void swap(list<T, Allocator>& x, list<T, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 
-  template <class T, class Allocator, class U>
+  template<class T, class Allocator, class U>
     void erase(list<T, Allocator>& c, const U& value);
-  template <class T, class Allocator, class Predicate>
+  template<class T, class Allocator, class Predicate>
     void erase_if(list<T, Allocator>& c, Predicate pred);
 
   namespace pmr {
@@ -3260,9 +3260,9 @@ namespace std {
     void swap(vector<T, Allocator>& x, vector<T, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 
-  template <class T, class Allocator, class U>
+  template<class T, class Allocator, class U>
     void erase(vector<T, Allocator>& c, const U& value);
-  template <class T, class Allocator, class Predicate>
+  template<class T, class Allocator, class Predicate>
     void erase_if(vector<T, Allocator>& c, Predicate pred);
 
   // \ref{vector.bool}, class \tcode{vector<bool>}
@@ -3911,7 +3911,7 @@ Nothing unless an exception is thrown by the assignment operator of
 
 \indexlibrary{\idxcode{erase}!\idxcode{deque}}%
 \begin{itemdecl}
-template <class T, class Allocator, class U>
+template<class T, class Allocator, class U>
   void erase(deque<T, Allocator>& c, const U& value);
 \end{itemdecl}
 
@@ -3923,7 +3923,7 @@ Equivalent to: \tcode{c.erase(remove(c.begin(), c.end(), value), c.end());}
 
 \indexlibrary{\idxcode{erase_if}!\idxcode{deque}}%
 \begin{itemdecl}
-template <class T, class Allocator, class Predicate>
+template<class T, class Allocator, class Predicate>
   void erase_if(deque<T, Allocator>& c, Predicate pred);
 \end{itemdecl}
 
@@ -4621,7 +4621,7 @@ Does not affect the validity of iterators and references.
 
 \indexlibrary{\idxcode{erase}!\idxcode{forward_list}}%
 \begin{itemdecl}
-template <class T, class Allocator, class U>
+template<class T, class Allocator, class U>
   void erase(forward_list<T, Allocator>& c, const U& value);
 \end{itemdecl}
 
@@ -4633,7 +4633,7 @@ Equivalent to: \tcode{erase_if(c, [\&](auto\& elem) { return elem == value; });}
 
 \indexlibrary{\idxcode{erase_if}!\idxcode{forward_list}}%
 \begin{itemdecl}
-template <class T, class Allocator, class Predicate>
+template<class T, class Allocator, class Predicate>
   void erase_if(forward_list<T, Allocator>& c, Predicate pred);
 \end{itemdecl}
 
@@ -5313,7 +5313,7 @@ comparisons, where
 
 \indexlibrary{\idxcode{erase}!\idxcode{list}}%
 \begin{itemdecl}
-template <class T, class Allocator, class U>
+template<class T, class Allocator, class U>
   void erase(list<T, Allocator>& c, const U& value);
 \end{itemdecl}
 
@@ -5325,7 +5325,7 @@ Equivalent to: \tcode{erase_if(c, [\&](auto\& elem) { return elem == value; });}
 
 \indexlibrary{\idxcode{erase_if}!\idxcode{list}}%
 \begin{itemdecl}
-template <class T, class Allocator, class Predicate>
+template<class T, class Allocator, class Predicate>
   void erase_if(list<T, Allocator>& c, Predicate pred);
 \end{itemdecl}
 
@@ -5830,7 +5830,7 @@ assignment operator or move assignment operator of
 
 \indexlibrary{\idxcode{erase}!\idxcode{vector}}%
 \begin{itemdecl}
-template <class T, class Allocator, class U>
+template<class T, class Allocator, class U>
   void erase(vector<T, Allocator>& c, const U& value);
 \end{itemdecl}
 
@@ -5842,7 +5842,7 @@ Equivalent to: \tcode{c.erase(remove(c.begin(), c.end(), value), c.end());}
 
 \indexlibrary{\idxcode{erase_if}!\idxcode{vector}}%
 \begin{itemdecl}
-template <class T, class Allocator, class Predicate>
+template<class T, class Allocator, class Predicate>
   void erase_if(vector<T, Allocator>& c, Predicate pred);
 \end{itemdecl}
 
@@ -6088,7 +6088,7 @@ namespace std {
               map<Key, T, Compare, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 
-  template <class Key, class T, class Compare, class Allocator, class Predicate>
+  template<class Key, class T, class Compare, class Allocator, class Predicate>
     void erase_if(map<Key, T, Compare, Allocator>& c, Predicate pred);
 
   // \ref{multimap}, class template \tcode{multimap}
@@ -6120,7 +6120,7 @@ namespace std {
               multimap<Key, T, Compare, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 
-  template <class Key, class T, class Compare, class Allocator, class Predicate>
+  template<class Key, class T, class Compare, class Allocator, class Predicate>
     void erase_if(multimap<Key, T, Compare, Allocator>& c, Predicate pred);
 
   namespace pmr {
@@ -6171,7 +6171,7 @@ namespace std {
               set<Key, Compare, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 
-  template <class Key, class Compare, class Allocator, class Predicate>
+  template<class Key, class Compare, class Allocator, class Predicate>
     void erase_if(set<Key, Compare, Allocator>& c, Predicate pred);
 
   // \ref{multiset}, class template \tcode{multiset}
@@ -6202,7 +6202,7 @@ namespace std {
               multiset<Key, Compare, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 
-  template <class Key, class Compare, class Allocator, class Predicate>
+  template<class Key, class Compare, class Allocator, class Predicate>
     void erase_if(multiset<Key, Compare, Allocator>& c, Predicate pred);
 
   namespace pmr {
@@ -6735,7 +6735,7 @@ respectively.
 
 \indexlibrary{\idxcode{erase_if}!\idxcode{map}}%
 \begin{itemdecl}
-template <class Key, class T, class Compare, class Allocator, class Predicate>
+template<class Key, class T, class Compare, class Allocator, class Predicate>
   void erase_if(map<Key, T, Compare, Allocator>& c, Predicate pred);
 \end{itemdecl}
 
@@ -7058,7 +7058,7 @@ equivalent to \tcode{return emplace_hint(position, std::forward<P>(x))}.
 
 \indexlibrary{\idxcode{erase_if}!\idxcode{multimap}}%
 \begin{itemdecl}
-template <class Key, class T, class Compare, class Allocator, class Predicate>
+template<class Key, class T, class Compare, class Allocator, class Predicate>
   void erase_if(multimap<Key, T, Compare, Allocator>& c, Predicate pred);
 \end{itemdecl}
 
@@ -7337,7 +7337,7 @@ where $N$ is
 
 \indexlibrary{\idxcode{erase_if}!\idxcode{set}}%
 \begin{itemdecl}
-template <class Key, class Compare, class Allocator, class Predicate>
+template<class Key, class Compare, class Allocator, class Predicate>
   void erase_if(set<Key, Compare, Allocator>& c, Predicate pred);
 \end{itemdecl}
 
@@ -7614,7 +7614,7 @@ where $N$ is
 
 \indexlibrary{\idxcode{erase_if}!\idxcode{multiset}}%
 \begin{itemdecl}
-template <class Key, class Compare, class Allocator, class Predicate>
+template<class Key, class Compare, class Allocator, class Predicate>
   void erase_if(multiset<Key, Compare, Allocator>& c, Predicate pred);
 \end{itemdecl}
 
@@ -7696,10 +7696,10 @@ namespace std {
               unordered_multimap<Key, T, Hash, Pred, Alloc>& y)
       noexcept(noexcept(x.swap(y)));
 
-  template <class K, class T, class H, class P, class A, class Predicate>
+  template<class K, class T, class H, class P, class A, class Predicate>
     void erase_if(unordered_map<K, T, H, P, A>& c, Predicate pred);
 
-  template <class K, class T, class H, class P, class A, class Predicate>
+  template<class K, class T, class H, class P, class A, class Predicate>
     void erase_if(unordered_multimap<K, T, H, P, A>& c, Predicate pred);
 
   namespace pmr {
@@ -7768,10 +7768,10 @@ namespace std {
               unordered_multiset<Key, Hash, Pred, Alloc>& y)
       noexcept(noexcept(x.swap(y)));
 
-  template <class K, class H, class P, class A, class Predicate>
+  template<class K, class H, class P, class A, class Predicate>
     void erase_if(unordered_set<K, H, P, A>& c, Predicate pred);
 
-  template <class K, class H, class P, class A, class Predicate>
+  template<class K, class H, class P, class A, class Predicate>
     void erase_if(unordered_multiset<K, H, P, A>& c, Predicate pred);
 
   namespace pmr {
@@ -7964,21 +7964,21 @@ namespace std {
     // map operations
     iterator         find(const key_type& k);
     const_iterator   find(const key_type& k) const;
-    template <class K>
+    template<class K>
       iterator       find(const K& k);
-    template <class K>
+    template<class K>
       const_iterator find(const K& k) const;
     size_type        count(const key_type& k) const;
-    template <class K>
+    template<class K>
       size_type      count(const K& k) const;
     bool             contains(const key_type& k) const;
-    template <class K>
+    template<class K>
       bool           contains(const K& k) const;
     pair<iterator, iterator>               equal_range(const key_type& k);
     pair<const_iterator, const_iterator>   equal_range(const key_type& k) const;
-    template <class K>
+    template<class K>
       pair<iterator, iterator>             equal_range(const K& k);
-    template <class K>
+    template<class K>
       pair<const_iterator, const_iterator> equal_range(const K& k) const;
 
     // \ref{unord.map.elem}, element access
@@ -8353,7 +8353,7 @@ respectively.
 
 \indexlibrary{\idxcode{erase_if}!\idxcode{unordered_map}}%
 \begin{itemdecl}
-template <class K, class T, class H, class P, class A, class Predicate>
+template<class K, class T, class H, class P, class A, class Predicate>
   void erase_if(unordered_map<K, T, H, P, A>& c, Predicate pred);
 \end{itemdecl}
 
@@ -8534,21 +8534,21 @@ namespace std {
     // map operations
     iterator         find(const key_type& k);
     const_iterator   find(const key_type& k) const;
-    template <class K>
+    template<class K>
       iterator       find(const K& k);
-    template <class K>
+    template<class K>
       const_iterator find(const K& k) const;
     size_type        count(const key_type& k) const;
-    template <class K>
+    template<class K>
       size_type      count(const K& k) const;
     bool             contains(const key_type& k) const;
-    template <class K>
+    template<class K>
       bool           contains(const K& k) const;
     pair<iterator, iterator>               equal_range(const key_type& k);
     pair<const_iterator, const_iterator>   equal_range(const key_type& k) const;
-    template <class K>
+    template<class K>
       pair<iterator, iterator>             equal_range(const K& k);
-    template <class K>
+    template<class K>
       pair<const_iterator, const_iterator> equal_range(const K& k) const;
 
     // bucket interface
@@ -8724,7 +8724,7 @@ template<class P>
 
 \indexlibrary{\idxcode{erase_if}!\idxcode{unordered_multimap}}%
 \begin{itemdecl}
-template <class K, class T, class H, class P, class A, class Predicate>
+template<class K, class T, class H, class P, class A, class Predicate>
   void erase_if(unordered_multimap<K, T, H, P, A>& c, Predicate pred);
 \end{itemdecl}
 
@@ -8896,21 +8896,21 @@ namespace std {
     // set operations
     iterator         find(const key_type& k);
     const_iterator   find(const key_type& k) const;
-    template <class K>
+    template<class K>
       iterator       find(const K& k);
-    template <class K>
+    template<class K>
       const_iterator find(const K& k) const;
     size_type        count(const key_type& k) const;
-    template <class K>
+    template<class K>
       size_type      count(const K& k) const;
     bool             contains(const key_type& k) const;
-    template <class K>
+    template<class K>
       bool           contains(const K& k) const;
     pair<iterator, iterator>               equal_range(const key_type& k);
     pair<const_iterator, const_iterator>   equal_range(const key_type& k) const;
-    template <class K>
+    template<class K>
       pair<iterator, iterator>             equal_range(const K& k);
-    template <class K>
+    template<class K>
       pair<const_iterator, const_iterator> equal_range(const K& k) const;
 
     // bucket interface
@@ -9042,7 +9042,7 @@ for the first form, or from the range
 
 \indexlibrary{\idxcode{erase_if}!\idxcode{unordered_set}}%
 \begin{itemdecl}
-template <class K, class H, class P, class A, class Predicate>
+template<class K, class H, class P, class A, class Predicate>
   void erase_if(unordered_set<K, H, P, A>& c, Predicate pred);
 \end{itemdecl}
 
@@ -9220,21 +9220,21 @@ namespace std {
     // set operations
     iterator         find(const key_type& k);
     const_iterator   find(const key_type& k) const;
-    template <class K>
+    template<class K>
       iterator       find(const K& k);
-    template <class K>
+    template<class K>
       const_iterator find(const K& k) const;
     size_type        count(const key_type& k) const;
-    template <class K>
+    template<class K>
       size_type      count(const K& k) const;
     bool             contains(const key_type& k) const;
-    template <class K>
+    template<class K>
       bool           contains(const K& k) const;
     pair<iterator, iterator>               equal_range(const key_type& k);
     pair<const_iterator, const_iterator>   equal_range(const key_type& k) const;
-    template <class K>
+    template<class K>
       pair<iterator, iterator>             equal_range(const K& k);
-    template <class K>
+    template<class K>
       pair<const_iterator, const_iterator> equal_range(const K& k) const;
 
     // bucket interface
@@ -9365,7 +9365,7 @@ for the first form, or from the range
 
 \indexlibrary{\idxcode{erase_if}!\idxcode{unordered_multiset}}%
 \begin{itemdecl}
-template <class K, class H, class P, class A, class Predicate>
+template<class K, class H, class P, class A, class Predicate>
   void erase_if(unordered_multiset<K, H, P, A>& c, Predicate pred);
 \end{itemdecl}
 

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -6461,7 +6461,7 @@ template<class T, size_t N> constexpr size_t size(const T (&array)[N]) noexcept;
 
 \indexlibrary{\idxcode{ssize(C\& c)}}%
 \begin{itemdecl}
-template <class C> constexpr auto ssize(const C& c)
+template<class C> constexpr auto ssize(const C& c)
   -> common_type_t<ptrdiff_t, make_signed_t<decltype(c.size())>>;
 \end{itemdecl}
 \begin{itemdescr}
@@ -6473,7 +6473,7 @@ static_cast<common_type_t<ptrdiff_t, make_signed_t<decltype(c.size())>>>(c.size(
 
 \indexlibrary{\idxcode{ssize(T (\&array)[N])}}%
 \begin{itemdecl}
-template <class T, ptrdiff_t N> constexpr ptrdiff_t ssize(const T (&array)[N]) noexcept;
+template<class T, ptrdiff_t N> constexpr ptrdiff_t ssize(const T (&array)[N]) noexcept;
 \end{itemdecl}
 \begin{itemdescr}
 \pnum \returns \tcode{N}.

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -3565,7 +3565,7 @@ template<class charT, class traits, class Allocator>
 
 \indexlibrary{\idxcode{erase}!\idxcode{basic_string}}%
 \begin{itemdecl}
-template <class charT, class traits, class Allocator, class U>
+template<class charT, class traits, class Allocator, class U>
   void erase(basic_string<charT, traits, Allocator>& c, const U& value);
 \end{itemdecl}
 
@@ -3577,7 +3577,7 @@ Equivalent to: \tcode{c.erase(remove(c.begin(), c.end(), value), c.end());}
 
 \indexlibrary{\idxcode{erase_if}!\idxcode{basic_string}}%
 \begin{itemdecl}
-template <class charT, class traits, class Allocator, class Predicate>
+template<class charT, class traits, class Allocator, class Predicate>
   void erase_if(basic_string<charT, traits, Allocator>& c, Predicate pred);
 \end{itemdecl}
 

--- a/source/support.tex
+++ b/source/support.tex
@@ -5153,7 +5153,7 @@ constexpr bool operator<(coroutine_handle<> x, coroutine_handle<> y) noexcept;
 
 \indexlibrary{\idxcode{hash}!\idxcode{coroutine_handle}}%
 \begin{itemdecl}
-template <class P> struct hash<coroutine_handle<P>>;
+template<class P> struct hash<coroutine_handle<P>>;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -3786,7 +3786,7 @@ namespace std {
   // \ref{variant.visit}, visitation
   template<class Visitor, class... Variants>
     constexpr @\seebelow@ visit(Visitor&&, Variants&&...);
-  template <class R, class Visitor, class... Variants>
+  template<class R, class Visitor, class... Variants>
     constexpr R visit(Visitor&&, Variants&&...);
 
   // \ref{variant.monostate}, class \tcode{monostate}
@@ -4882,7 +4882,7 @@ otherwise \tcode{get<$i$>(v) >= get<$i$>(w)} with $i$ being \tcode{v.index()}.
 \begin{itemdecl}
 template<class Visitor, class... Variants>
   constexpr @\seebelow@ visit(Visitor&& vis, Variants&&... vars);
-template <class R, class Visitor, class... Variants>
+template<class R, class Visitor, class... Variants>
   constexpr R visit(Visitor&& vis, Variants&&... vars);
 \end{itemdecl}
 
@@ -6590,22 +6590,22 @@ namespace std {
     inline constexpr bool uses_allocator_v = uses_allocator<T, Alloc>::value;
 
   // \ref{allocator.uses.construction}, uses-allocator construction
-  template <class T, class Alloc, class... Args>
+  template<class T, class Alloc, class... Args>
     auto uses_allocator_construction_args(const Alloc& alloc, Args&&... args) -> @\seebelow@;
-  template <class T, class Alloc, class Tuple1, class Tuple2>
+  template<class T, class Alloc, class Tuple1, class Tuple2>
     auto uses_allocator_construction_args(const Alloc& alloc, piecewise_construct_t,
                                           Tuple1&& x, Tuple2&& y) ->  @\seebelow@;
-  template <class T, class Alloc>
+  template<class T, class Alloc>
     auto uses_allocator_construction_args(const Alloc& alloc) -> @\seebelow@;
-  template <class T, class Alloc, class U, class V>
+  template<class T, class Alloc, class U, class V>
     auto uses_allocator_construction_args(const Alloc& alloc, U&& u, V&& v) -> @\seebelow@;
-  template <class T, class Alloc, class U, class V>
+  template<class T, class Alloc, class U, class V>
     auto uses_allocator_construction_args(const Alloc& alloc, const pair<U,V>& pr) -> @\seebelow@;
-  template <class T, class Alloc, class U, class V>
+  template<class T, class Alloc, class U, class V>
     auto uses_allocator_construction_args(const Alloc& alloc, pair<U,V>&& pr) -> @\seebelow@;
-  template <class T, class Alloc, class... Args>
+  template<class T, class Alloc, class... Args>
     T make_obj_using_allocator(const Alloc& alloc, Args&&... args);
-  template <class T, class Alloc, class... Args>
+  template<class T, class Alloc, class... Args>
     T* uninitialized_construct_using_allocator(T* p, const Alloc& alloc, Args&&... args);
 
   // \ref{allocator.traits}, allocator traits
@@ -7457,7 +7457,7 @@ is not deduced and must therefore be specified explicitly by the caller.
 
 \indexlibrary{\idxcode{uses_allocator_construction_args}}%
 \begin{itemdecl}
-template <class T, class Alloc, class... Args>
+template<class T, class Alloc, class... Args>
   auto uses_allocator_construction_args(const Alloc& alloc, Args&&... args) -> @\seebelow@;
 \end{itemdecl}
 
@@ -7499,7 +7499,7 @@ to pass the allocator to a constructor of a type for which
 
 \indexlibrary{\idxcode{uses_allocator_construction_args}}%
 \begin{itemdecl}
-template <class T, class Alloc, class Tuple1, class Tuple2>
+template<class T, class Alloc, class Tuple1, class Tuple2>
   auto uses_allocator_construction_args(const Alloc& alloc, piecewise_construct_t,
                                         Tuple1&& x, Tuple2&& y) -> @\seebelow@;
 \end{itemdecl}
@@ -7528,7 +7528,7 @@ return make_tuple(
 
 \indexlibrary{\idxcode{uses_allocator_construction_args}}%
 \begin{itemdecl}
-template <class T, class Alloc>
+template<class T, class Alloc>
   auto uses_allocator_construction_args(const Alloc& alloc) -> @\seebelow@;
 \end{itemdecl}
 
@@ -7548,7 +7548,7 @@ return uses_allocator_construction_args<T>(alloc, piecewise_construct,
 
 \indexlibrary{\idxcode{uses_allocator_construction_args}}%
 \begin{itemdecl}
-template <class T, class Alloc, class U, class V>
+template<class T, class Alloc, class U, class V>
   auto uses_allocator_construction_args(const Alloc& alloc, U&& u, V&& v) -> @\seebelow@;
 \end{itemdecl}
 
@@ -7569,7 +7569,7 @@ return uses_allocator_construction_args<T>(alloc, piecewise_construct,
 
 \indexlibrary{\idxcode{uses_allocator_construction_args}}%
 \begin{itemdecl}
-template <class T, class Alloc, class U, class V>
+template<class T, class Alloc, class U, class V>
   auto uses_allocator_construction_args(const Alloc& alloc, const pair<U,V>& pr) -> @\seebelow@;
 \end{itemdecl}
 
@@ -7590,7 +7590,7 @@ return uses_allocator_construction_args<T>(alloc, piecewise_construct,
 
 \indexlibrary{\idxcode{uses_allocator_construction_args}}%
 \begin{itemdecl}
-template <class T, class Alloc, class U, class V>
+template<class T, class Alloc, class U, class V>
   auto uses_allocator_construction_args(const Alloc& alloc, pair<U,V>&& pr) -> @\seebelow@;
 \end{itemdecl}
 
@@ -7611,7 +7611,7 @@ return uses_allocator_construction_args<T>(alloc, piecewise_construct,
 
 \indexlibrary{\idxcode{make_obj_using_allocator}}%
 \begin{itemdecl}
-template <class T, class Alloc, class... Args>
+template<class T, class Alloc, class... Args>
   T make_obj_using_allocator(const Alloc& alloc, Args&&... args);
 \end{itemdecl}
 
@@ -7627,7 +7627,7 @@ return make_from_tuple<T>(uses_allocator_construction_args<T>(
 
 \indexlibrary{\idxcode{uninitialized_construct_using_allocator}}%
 \begin{itemdecl}
-template <class T, class Alloc, class... Args>
+template<class T, class Alloc, class... Args>
   T* uninitialized_construct_using_allocator(T* p, const Alloc& alloc, Args&&... args);
 \end{itemdecl}
 
@@ -12394,10 +12394,10 @@ namespace std::pmr {
 
     void* allocate_bytes(size_t nbytes, size_t alignment = alignof(max_align_t));
     void deallocate_bytes(void* p, size_t nbytes, size_t alignment = alignof(max_align_t));
-    template <class T> T* allocate_object(size_t n = 1);
-    template <class T> void deallocate_object(T* p, size_t n = 1);
-    template <class T, class... CtorArgs> T* new_object(CtorArgs&&... ctor_args);
-    template <class T> void delete_object(T* p);
+    template<class T> T* allocate_object(size_t n = 1);
+    template<class T> void deallocate_object(T* p, size_t n = 1);
+    template<class T, class... CtorArgs> T* new_object(CtorArgs&&... ctor_args);
+    template<class T> void delete_object(T* p);
 
     template<class T, class... Args>
       void construct(T* p, Args&&... args);
@@ -12531,7 +12531,7 @@ Equivalent to \tcode{memory_rsrc->deallocate(p, nbytes, alignment)}.
 
 \indexlibrarymember{allocate_object}{polymorphic_allocator}%
 \begin{itemdecl}
-template <class T>
+template<class T>
   T* allocate_object(size_t n = 1);
 \end{itemdecl}
 
@@ -12558,7 +12558,7 @@ return static_cast<T*>(allocate_bytes(n*sizeof(T), alignof(T)));
 
 \indexlibrarymember{deallocate_object}{polymorphic_allocator}%
 \begin{itemdecl}
-template <class T>
+template<class T>
   void deallocate_object(T* p, size_t n = 1);
 \end{itemdecl}
 
@@ -12570,7 +12570,7 @@ Equivalent to \tcode{deallocate_bytes(p, n*sizeof(T), alignof(T))}.
 
 \indexlibrarymember{new_object}{polymorphic_allocator}%
 \begin{itemdecl}
-template <class T, class CtorArgs...>
+template<class T, class CtorArgs...>
   T* new_object(CtorArgs&&... ctor_args);
 \end{itemdecl}
 
@@ -12598,7 +12598,7 @@ return p;
 
 \indexlibrarymember{new_object}{polymorphic_allocator}%
 \begin{itemdecl}
-template <class T>
+template<class T>
   void delete_object(T* p);
 \end{itemdecl}
 
@@ -13847,7 +13847,7 @@ namespace std {
   template<class F> @\unspec@ not_fn(F&& f);
 
   // \ref{func.bind_front}, function template \tcode{bind_front}
-  template <class F, class... Args> @\unspec@ bind_front(F&&, Args&&...);
+  template<class F, class... Args> @\unspec@ bind_front(F&&, Args&&...);
 
   // \ref{func.bind}, bind
   template<class T> struct is_bind_expression;
@@ -15288,7 +15288,7 @@ Any exception thrown by the initialization of \tcode{fd}.
 
 \indexlibrary{\idxcode{bind_front}}%
 \begin{itemdecl}
-template <class F, class... Args>
+template<class F, class... Args>
   @\unspec@ bind_front(F&& f, Args&&... args);
 \end{itemdecl}
 


### PR DESCRIPTION
Fixes #2785.