### PR TITLE
[intro.execution] make function evaluation actually not interleave CWG2466

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5323,11 +5323,11 @@ expression, or with the postfix expression designating the called
 function, is sequenced before execution of every expression or statement
 in the body of the called function.
 For each function invocation \placeholder{F},
-for every evaluation \placeholder{A} that occurs within \placeholder{F} and
+for the set \placeholder{A} of all evaluations that occur within \placeholder{F} and
 every evaluation \placeholder{B} that does not occur within \placeholder{F} but
 is evaluated on the same thread and as part of the same signal handler (if any),
-either \placeholder{A} is sequenced before \placeholder{B} or
-\placeholder{B} is sequenced before \placeholder{A}.\footnote{In other words,
+either every evaluation in \placeholder{A} is sequenced before \placeholder{B} or
+\placeholder{B} is sequenced before every evaluation in \placeholder{A}.\footnote{In other words,
 function executions do not interleave with each other.}
 \begin{note}
 If \placeholder{A} and \placeholder{B} would not otherwise be sequenced then they are


### PR DESCRIPTION
While the intent was clear and explicitly stated in the footnote, the prior wording didn't require B to be consistently sequenced before or after every A in F, only that they be individually pairwise sequenced.