### PR TITLE
Switch to using constant-width italics for exposition-only names in the core wording

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -6274,17 +6274,17 @@ the $i^\textrm{th}$ function parameter otherwise.
 A coroutine behaves as if its \grammarterm{function-body} were replaced by:
 \begin{ncsimplebnf}
 \terminal{\{}\br
-\bnfindent promise-type \terminal{__promise} promise-constructor-arguments \terminal{;}\br
-% FIXME: \bnfindent \terminal{__promise.get_return_object()} \terminal{;}
+\bnfindent promise-type \exposid{promise} promise-constructor-arguments \terminal{;}\br
+% FIXME: \bnfindent \exposid{promise}\terminal{.get_return_object()} \terminal{;}
 % ... except that it's not a discarded-value expression
-\bnfindent \terminal{co_await} \terminal{__promise.initial_suspend()} \terminal{;}\br
+\bnfindent \terminal{co_await} \terminal{\exposid{promise}.initial_suspend()} \terminal{;}\br
 \bnfindent \terminal{try \{}\br
 \bnfindent\bnfindent function-body\br
 \bnfindent \terminal{\} catch ( ... ) \{}\br
-\bnfindent\bnfindent \terminal{__promise.unhandled_exception()} \terminal{;}\br
+\bnfindent\bnfindent \terminal{\exposid{promise}.unhandled_exception()} \terminal{;}\br
 \bnfindent \terminal{\}}\br
-\terminal{__final_suspend} \terminal{:}\br
-\bnfindent \terminal{co_await} \terminal{__promise.final_suspend()} \terminal{;}\br
+\exposid{final-suspend} \terminal{:}\br
+\bnfindent \terminal{co_await} \terminal{\exposid{promise}.final_suspend()} \terminal{;}\br
 \terminal{\}}
 \end{ncsimplebnf}
 where
@@ -6300,10 +6300,10 @@ is the \defn{final suspend point}, and
 \item
 \placeholder{promise-type} denotes the promise type, and
 \item
-the object denoted by the exposition-only name \tcode{__promise}
+the object denoted by the exposition-only name \exposid{promise}
 is the \defn{promise object} of the coroutine, and
 \item
-the label denoted by the name \tcode{__final_suspend}
+the label denoted by the name \exposid{final-suspend}
 is defined for exposition only\iref{stmt.return.coroutine}, and
 \item
 \placeholder{promise-constructor-arguments} is determined as follows:
@@ -6327,7 +6327,7 @@ results in undefined behavior\iref{stmt.return.coroutine}.
 \end{note}
 
 \pnum
-The expression \tcode{__promise.get_return_object()} is used
+The expression \tcode{\exposid{promise}.get_return_object()} is used
 to initialize
 the glvalue result or prvalue result object of a call to a coroutine.
 The call to \tcode{get_return_object}
@@ -6468,11 +6468,11 @@ likely to result in undefined behavior.
 
 \pnum
 If the evaluation of the expression
-\tcode{__promise.unhandled_exception()} exits via an exception,
+\tcode{\exposid{promise}.unhandled_exception()} exits via an exception,
 the coroutine is considered suspended at the final suspend point.
 
 \pnum
-The expression \tcode{co_await} \tcode{__promise.final_suspend()}
+The expression \tcode{co_await} \tcode{\exposid{promise}.final_suspend()}
 shall not be potentially-throwing\iref{except.spec}.
 
 \rSec1[dcl.struct.bind]{Structured binding declarations}%
@@ -6489,23 +6489,23 @@ Let \cv{} denote the \grammarterm{cv-qualifier}{s} in
 the \grammarterm{decl-specifier-seq} and
 \placeholder{S} consist of the \grammarterm{storage-class-specifier}{s} of
 the \grammarterm{decl-specifier-seq} (if any).
-First, a variable with a unique name \tcode{e} is introduced. If the
+First, a variable with a unique name \exposid{e} is introduced. If the
 \grammarterm{assignment-expression} in the \grammarterm{initializer}
 has array type \tcode{A} and no \grammarterm{ref-qualifier} is present,
-\tcode{e} is defined by
+\exposid{e} is defined by
 
 \begin{ncbnf}
-\opt{attribute-specifier-seq} \placeholder{S} \cv{} \terminal{A e ;}
+\opt{attribute-specifier-seq} \placeholder{S} \cv{} \terminal{A} \exposid{e} \terminal{;}
 \end{ncbnf}
 
 and each element is copy-initialized or direct-initialized
 from the corresponding element of the \grammarterm{assignment-expression} as specified
 by the form of the \grammarterm{initializer}.
-Otherwise, \tcode{e}
+Otherwise, \exposid{e}
 is defined as-if by
 
 \begin{ncbnf}
-\opt{attribute-specifier-seq} decl-specifier-seq \opt{ref-qualifier} \terminal{e} initializer \terminal{;}
+\opt{attribute-specifier-seq} decl-specifier-seq \opt{ref-qualifier} \exposid{e} initializer \terminal{;}
 \end{ncbnf}
 
 where
@@ -6513,7 +6513,7 @@ the declaration is never interpreted as a function declaration and
 the parts of the declaration other than the \grammarterm{declarator-id} are taken
 from the corresponding structured binding declaration.
 The type of the \grammarterm{id-expression}
-\tcode{e} is called \tcode{E}.
+\exposid{e} is called \tcode{E}.
 \begin{note}
 \tcode{E} is never a reference type\iref{expr.prop}.
 \end{note}
@@ -6558,13 +6558,13 @@ and if that finds at least one declaration
 that is a function template whose first template parameter
 is a non-type parameter,
 the initializer is
-\tcode{e.get<i>()}. Otherwise, the initializer is \tcode{get<i>(e)},
+\tcode{\exposid{e}.get<i>()}. Otherwise, the initializer is \tcode{get<i>(\exposid{e})},
 where \tcode{get} is looked up in the associated namespaces\iref{basic.lookup.argdep}.
 In either case, \tcode{get<i>} is interpreted as a \grammarterm{template-id}.
 \begin{note}
 Ordinary unqualified lookup\iref{basic.lookup.unqual} is not performed.
 \end{note}
-In either case, \tcode{e} is an lvalue if the type of the entity \tcode{e}
+In either case, \exposid{e} is an lvalue if the type of the entity \exposid{e}
 is an lvalue reference and an xvalue otherwise.
 Given the type $\tcode{T}_i$ designated by
 \tcode{std::tuple_element<i, E>::type} and
@@ -6587,7 +6587,7 @@ Otherwise,
 all of \tcode{E}'s non-static data members
 shall be direct members of \tcode{E} or
 of the same base class of \tcode{E},
-well-formed when named as \tcode{e.\placeholder{name}}
+well-formed when named as \tcode{\exposid{e}.\placeholder{name}}
 in the context of the structured binding,
 \tcode{E} shall not have an anonymous union member, and
 the number of elements in the \grammarterm{identifier-list} shall be
@@ -6596,7 +6596,7 @@ Designating the non-static data members of \tcode{E} as
 $\tcode{m}_0$, $\tcode{m}_1$, $\tcode{m}_2, \dotsc$
 (in declaration order),
 each \tcode{v}$_i$ is the
-name of an lvalue that refers to the member \tcode{m}$_i$ of \tcode{e} and
+name of an lvalue that refers to the member \tcode{m}$_i$ of \exposid{e} and
 whose type is \cv{}~$\tcode{T}_i$, where $\tcode{T}_i$ is the declared type of
 that member; the referenced type is \cv{}~$\tcode{T}_i$. The lvalue is a
 bit-field if that member is a bit-field.
@@ -7142,38 +7142,38 @@ An \grammarterm{unnamed-namespace-definition} behaves as if it were
 replaced by
 
 \begin{ncsimplebnf}
-\opt{\keyword{inline}} \keyword{namespace} \terminal{\uniquens} \terminal{\{ /* empty body */ \}}\br
-\keyword{using} \keyword{namespace} \terminal{\uniquens} \terminal{;}\br
-\keyword{namespace} \terminal{\uniquens} \terminal{\{} namespace-body \terminal{\}}
+\opt{\keyword{inline}} \keyword{namespace} \exposid{unique} \terminal{\{ /* empty body */ \}}\br
+\keyword{using} \keyword{namespace} \exposid{unique} \terminal{;}\br
+\keyword{namespace} \exposid{unique} \terminal{\{} namespace-body \terminal{\}}
 \end{ncsimplebnf}
 
 where
 \tcode{inline} appears if and only if it appears in the
 \grammarterm{unnamed-namespace-definition}
-and all occurrences of \tcode{\uniquens} in a translation unit are replaced by
+and all occurrences of \exposid{unique} in a translation unit are replaced by
 the same identifier, and this identifier differs from all other
 identifiers in the translation unit.
 The optional \grammarterm{attribute-specifier-seq}
 in the \grammarterm{unnamed-namespace-definition}
-appertains to \tcode{\uniquens}.
+appertains to \exposid{unique}.
 \begin{example}
 \begin{codeblock}
-namespace { int i; }            // \tcode{\uniquens::i}
-void f() { i++; }               // \tcode{\uniquens::i++}
+namespace { int i; }            // \tcode{\exposid{unique}::i}
+void f() { i++; }               // \tcode{\exposid{unique}::i++}
 
 namespace A {
   namespace {
-    int i;                      // \tcode{A::\uniquens::i}
-    int j;                      // \tcode{A::\uniquens::j}
+    int i;                      // \tcode{A::\exposid{unique}::i}
+    int j;                      // \tcode{A::\exposid{unique}::j}
   }
-  void g() { i++; }             // \tcode{A::\uniquens::i++}
+  void g() { i++; }             // \tcode{A::\exposid{unique}::i++}
 }
 
 using namespace A;
 void h() {
-  i++;                          // error: \tcode{\uniquens::i} or \tcode{A::\uniquens::i}
-  A::i++;                       // \tcode{A::\uniquens::i}
-  j++;                          // \tcode{A::\uniquens::j}
+  i++;                          // error: \tcode{\exposid{unique}::i} or \tcode{A::\exposid{unique}::i}
+  A::i++;                       // \tcode{A::\exposid{unique}::i}
+  j++;                          // \tcode{A::\exposid{unique}::j}
 }
 \end{codeblock}
 \end{example}

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -189,6 +189,7 @@
 \newcommand{\grammartermnc}[1]{\indexgram{\idxgram{#1}}\gterm{#1\nocorr}}
 \newcommand{\placeholder}[1]{\textit{#1}}
 \newcommand{\placeholdernc}[1]{\textit{#1\nocorr}}
+\newcommand{\exposid}[1]{\tcode{\placeholder{#1}}}
 \newcommand{\defnxname}[1]{\indextext{\idxxname{#1}}\xname{#1}}
 \newcommand{\defnlibxname}[1]{\indexlibrary{\idxxname{#1}}\xname{#1}}
 
@@ -367,7 +368,6 @@
 \newcommand{\howwide}{\diffdef{How widely used}}
 
 %% Miscellaneous
-\newcommand{\uniquens}{\placeholdernc{unique}}
 \newcommand{\stage}[1]{\item[Stage #1:]}
 \newcommand{\doccite}[1]{\textit{#1}}
 \newcommand{\cvqual}[1]{\textit{#1}}
@@ -490,6 +490,7 @@
  \newcommand{\nontermdef}[1]{{\BnfNontermshape##1\itcorr}\indexgrammar{\idxgram{##1}}\textnormal{:}}
  \newcommand{\terminal}[1]{{\BnfTermshape ##1}}
  \renewcommand{\keyword}[1]{\terminal{##1}\indextext{\idxcode{##1}}}
+ \renewcommand{\exposid}[1]{\terminal{\placeholder{##1}}}
  \newcommand{\descr}[1]{\textnormal{##1}}
  \newcommand{\bnfindent}{\hspace*{\bnfindentfirst}}
  \newcommand{\bnfindentfirst}{\BnfIndent}

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -536,11 +536,11 @@ the variable that is declared extends from its point of
 declaration\iref{basic.scope.pdecl} to the end of the \tcode{while}
 \grammarterm{statement}. A \tcode{while} statement is equivalent to
 \begin{ncsimplebnf}
-\terminal{label:}\br
+\exposid{label} \terminal{:}\br
 \terminal{\{}\br
 \bnfindent \keyword{if} \terminal{(} condition \terminal{) \{}\br
 \bnfindent \bnfindent statement\br
-\bnfindent \bnfindent \keyword{goto} \terminal{label;}\br
+\bnfindent \bnfindent \keyword{goto} \exposid{label} \terminal{;}\br
 \bnfindent \terminal{\}}\br
 \terminal{\}}
 \end{ncsimplebnf}
@@ -649,11 +649,11 @@ is equivalent to
 \begin{ncsimplebnf}
 \terminal{\{}\br
 \bnfindent \opt{init-statement}\br
-\bnfindent \keyword{auto} \terminal{\&\&__range =} for-range-initializer \terminal{;}\br
-\bnfindent \keyword{auto} \terminal{__begin =} begin-expr \terminal{;}\br
-\bnfindent \keyword{auto} \terminal{__end =} end-expr \terminal{;}\br
-\bnfindent \keyword{for} \terminal{( ; __begin != __end; ++__begin ) \{}\br
-\bnfindent\bnfindent for-range-declaration \terminal{= *__begin;}\br
+\bnfindent \keyword{auto} \terminal{\&\&}\exposid{range} \terminal{=} for-range-initializer \terminal{;}\br
+\bnfindent \keyword{auto} \exposid{begin} \terminal{=} begin-expr \terminal{;}\br
+\bnfindent \keyword{auto} \exposid{end} \terminal{=} end-expr \terminal{;}\br
+\bnfindent \keyword{for} \terminal{( ;} \exposid{begin} \terminal{!=} \exposid{end}\terminal{; ++}\exposid{begin} \terminal{) \{}\br
+\bnfindent\bnfindent for-range-declaration \terminal{= *} \exposid{begin} \terminal{;}\br
 \bnfindent\bnfindent statement\br
 \bnfindent \terminal{\}}\br
 \terminal{\}}
@@ -665,7 +665,7 @@ if the \grammarterm{for-range-initializer} is an \grammarterm{expression},
 it is regarded as if it were surrounded by parentheses (so that a comma operator
 cannot be reinterpreted as delimiting two \grammarterm{init-declarator}{s});
 
-\item \tcode{__range}, \tcode{__begin}, and \tcode{__end} are variables defined for
+\item \exposid{range}, \exposid{begin}, and \exposid{end} are variables defined for
 exposition only; and
 
 \item
@@ -674,7 +674,8 @@ exposition only; and
 \begin{itemize}
 \item if the \grammarterm{for-range-initializer} is an expression of
 array type \tcode{R}, \placeholder{begin-expr} and \placeholder{end-expr} are
-\tcode{__range} and \tcode{__range + __bound}, respectively, where \tcode{__bound} is
+\exposid{range} and \exposid{range} \tcode{+} \tcode{N}, respectively,
+where \tcode{N} is
 the array bound. If \tcode{R} is an array of unknown bound or an array of
 incomplete type, the program is ill-formed;
 
@@ -683,11 +684,12 @@ class type \tcode{C}, the \grammarterm{unqualified-id}{s}
 \tcode{begin} and \tcode{end} are looked up in the scope of \tcode{C}
 as if by class member access lookup\iref{basic.lookup.classref}, and if
 both find at least one declaration, \placeholder{begin-expr} and
-\placeholder{end-expr} are \tcode{__range.begin()} and \tcode{__range.end()},
+\placeholder{end-expr} are \tcode{\exposid{range}.begin()} and \tcode{\exposid{range}.end()},
 respectively;
 
-\item otherwise, \placeholder{begin-expr} and \placeholder{end-expr} are \tcode{begin(__range)}
-and \tcode{end(__range)}, respectively, where \tcode{begin} and \tcode{end} are looked
+\item otherwise, \placeholder{begin-expr} and \placeholder{end-expr} are
+\tcode{begin(\exposid{range})} and \tcode{end(\exposid{range})}, respectively,
+where \tcode{begin} and \tcode{end} are looked
 up in the associated namespaces\iref{basic.lookup.argdep}.
 \begin{note} Ordinary unqualified lookup\iref{basic.lookup.unqual} is not
 performed. \end{note}
@@ -788,7 +790,7 @@ while (foo) {
   {
     // ...
   }
-contin: ;
+@\exposid{contin}@: ;
 }
 \end{codeblock}
 \end{minipage}
@@ -798,7 +800,7 @@ do {
   {
     // ...
   }
-contin: ;
+@\exposid{contin}@: ;
 } while (foo);
 \end{codeblock}
 \end{minipage}
@@ -808,13 +810,13 @@ for (;;) {
   {
     // ...
   }
-contin: ;
+@\exposid{contin}@: ;
 }
 \end{codeblock}
 \end{minipage}
 
 a \tcode{continue} not contained in an enclosed iteration statement is
-equivalent to \tcode{goto} \tcode{contin}.
+equivalent to \tcode{goto} \exposid{contin}.
 
 \rSec2[stmt.return]{The \tcode{return} statement}%
 \indextext{\idxcode{return}}%
@@ -891,10 +893,10 @@ Let \placeholder{p} be an lvalue naming the coroutine
 promise object\iref{dcl.fct.def.coroutine}.
 A \tcode{co_return} statement is equivalent to:
 \begin{ncsimplebnf}
-\terminal{\{} S\terminal{; goto} \terminal{__final_suspend; \}}
+\terminal{\{} S\terminal{; goto} \exposid{final-suspend}\terminal{;} \terminal{\}}
 \end{ncsimplebnf}
 
-where \tcode{__final_suspend} is the exposition-only label
+where \exposid{final-suspend} is the exposition-only label
 defined in \ref{dcl.fct.def.coroutine}
 and \placeholder{S} is defined as follows:
 


### PR DESCRIPTION
We already used this typeface for exposition-only identifiers in the
library wording.

Fixes #2783.