### PR TITLE
Library-wide: Use "meet" for non-concept type requirements

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -72,35 +72,35 @@ the names of template parameters are used to express type requirements.
   \tcode{InputIterator},
   \tcode{InputIterator1}, or
   \tcode{Input\-Iterator2},
-  the template argument shall satisfy the
+  the template argument shall meet the
   \oldconcept{InputIterator} requirements\iref{input.iterators}.
 \item
   If an algorithm's template parameter is named
   \tcode{OutputIterator},
   \tcode{OutputIterator1}, or
   \tcode{Output\-Iterator2},
-  the template argument shall satisfy the
+  the template argument shall meet the
   \oldconcept{OutputIterator} requirements\iref{output.iterators}.
 \item
   If an algorithm's template parameter is named
   \tcode{ForwardIterator},
   \tcode{ForwardIterator1}, or
   \tcode{Forward\-Iterator2},
-  the template argument shall satisfy the
+  the template argument shall meet the
   \oldconcept{ForwardIterator} requirements\iref{forward.iterators}.
 \item
   If an algorithm's template parameter is named
   \tcode{BidirectionalIterator},
   \tcode{Bidirectional\-Iterator1}, or
   \tcode{BidirectionalIterator2},
-  the template argument shall satisfy the
+  the template argument shall meet the
   \oldconcept{BidirectionalIterator} requirements\iref{bidirectional.iterators}.
 \item
   If an algorithm's template parameter is named
   \tcode{RandomAccessIterator},
   \tcode{Random\-AccessIterator1}, or
   \tcode{RandomAccessIterator2},
-  the template argument shall satisfy the
+  the template argument shall meet the
   \oldconcept{RandomAccessIterator} requirements\iref{random.access.iterators}.
 \end{itemize}
 
@@ -108,7 +108,7 @@ the names of template parameters are used to express type requirements.
 If an algorithm's \effects element specifies
 that a value pointed to by any iterator passed as an argument is modified,
 then that algorithm has an additional type requirement:
-The type of that argument shall satisfy
+The type of that argument shall meet
 the requirements of a mutable iterator\iref{iterator.requirements}.
 \begin{note}
 This requirement does not affect arguments that are named
@@ -3000,7 +3000,7 @@ template<class InputIterator, class Function>
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{Function} shall satisfy
+\tcode{Function} shall meet
 the \oldconcept{MoveConstructible} requirements (\tref{cpp17.moveconstructible}).
 \begin{note}
 \tcode{Function} need not meet the requirements of
@@ -3013,7 +3013,7 @@ Applies \tcode{f} to the result of dereferencing
 every iterator in the range \range{first}{last},
 starting from \tcode{first} and proceeding to \tcode{last - 1}.
 \begin{note}
-If the type of \tcode{first} satisfies the requirements of a mutable iterator,
+If the type of \tcode{first} meets the requirements of a mutable iterator,
 \tcode{f} may apply non-constant functions through the dereferenced iterator.
 \end{note}
 
@@ -3041,14 +3041,14 @@ template<class ExecutionPolicy, class ForwardIterator, class Function>
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{Function} shall satisfy the \oldconcept{CopyConstructible} requirements.
+\tcode{Function} shall meet the \oldconcept{CopyConstructible} requirements.
 
 \pnum
 \effects
 Applies \tcode{f} to the result of dereferencing
 every iterator in the range \range{first}{last}.
 \begin{note}
-If the type of \tcode{first} satisfies the requirements of a mutable iterator,
+If the type of \tcode{first} meets the requirements of a mutable iterator,
 \tcode{f} may apply non-constant functions through the dereferenced iterator.
 \end{note}
 
@@ -3121,7 +3121,7 @@ template<class InputIterator, class Size, class Function>
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{Function} shall satisfy the \oldconcept{MoveConstructible} requirements
+\tcode{Function} shall meet the \oldconcept{MoveConstructible} requirements
 \begin{note}
 \tcode{Function} need not meet
 the requirements of \oldconcept{CopyConstructible}.
@@ -3136,7 +3136,7 @@ the requirements of \oldconcept{CopyConstructible}.
 Applies \tcode{f} to the result of dereferencing
 every iterator in the range \range{first}{first + n} in order.
 \begin{note}
-If the type of \tcode{first} satisfies the requirements of a mutable iterator,
+If the type of \tcode{first} meets the requirements of a mutable iterator,
 \tcode{f} may apply non-constant functions through the dereferenced iterator.
 \end{note}
 
@@ -3159,7 +3159,7 @@ template<class ExecutionPolicy, class ForwardIterator, class Size, class Functio
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{Function} shall satisfy the \oldconcept{CopyConstructible} requirements.
+\tcode{Function} shall meet the \oldconcept{CopyConstructible} requirements.
 
 \pnum
 \requires
@@ -3170,7 +3170,7 @@ template<class ExecutionPolicy, class ForwardIterator, class Size, class Functio
 Applies \tcode{f} to the result of dereferencing
 every iterator in the range \range{first}{first + n}.
 \begin{note}
-If the type of \tcode{first} satisfies the requirements of a mutable iterator,
+If the type of \tcode{first} meets the requirements of a mutable iterator,
 \tcode{f} may apply non-constant functions through the dereferenced iterator.
 \end{note}
 
@@ -5534,15 +5534,15 @@ template<class PopulationIterator, class SampleIterator,
 \requires
 \begin{itemize}
 \item
-  \tcode{PopulationIterator} shall satisfy
+  \tcode{PopulationIterator} shall meet
   the \oldconcept{InputIterator} requirements\iref{input.iterators}.
 \item
-  \tcode{SampleIterator} shall satisfy
+  \tcode{SampleIterator} shall meet
   the \oldconcept{OutputIterator} requirements\iref{output.iterators}.
 \item
-  \tcode{SampleIterator} shall satisfy
+  \tcode{SampleIterator} shall meet
   the \oldconcept{RandomAccessIterator} requirements\iref{random.access.iterators}
-  unless \tcode{Pop\-ulat\-ion\-Iter\-ator} satisfies
+  unless \tcode{Pop\-ulat\-ion\-Iter\-ator} meets
   the \oldconcept{ForwardIterator} requirements\iref{forward.iterators}.
 \item
   \tcode{PopulationIterator}'s value type shall be
@@ -5550,7 +5550,7 @@ template<class PopulationIterator, class SampleIterator,
 \item
   \tcode{Distance} shall be an integer type.
 \item
-  \tcode{remove_reference_t<UniformRandomBitGenerator>} shall satisfy
+  \tcode{remove_reference_t<UniformRandomBitGenerator>} shall meet
   the requirements of a uniform random bit generator type\iref{rand.req.urng}.
 \item
   \tcode{out} shall not be in the range \range{first}{last}.
@@ -5578,7 +5578,7 @@ The end of the resulting sample range.
 \remarks
 \begin{itemize}
 \item
-  Stable if and only if \tcode{PopulationIterator} satisfies
+  Stable if and only if \tcode{PopulationIterator} meets
   the \oldconcept{ForwardIterator} requirements.
 \item
   To the extent that the implementation of this function makes use
@@ -5657,7 +5657,7 @@ template<class ExecutionPolicy, class ForwardIterator>
 \begin{itemdescr}
 \pnum
 \requires
-The type of \tcode{*first} shall satisfy
+The type of \tcode{*first} shall meet
 the \oldconcept{MoveAssignable} requirements.
 
 \pnum
@@ -5696,7 +5696,7 @@ template<class ExecutionPolicy, class ForwardIterator>
 \begin{itemdescr}
 \pnum
 \requires
-The type of \tcode{*first} shall satisfy
+The type of \tcode{*first} shall meet
 the \oldconcept{MoveAssignable} requirements.
 \tcode{ForwardIterator} shall meet
 the \oldconcept{BidirectionalIterator} requirements\iref{bidirectional.iterators} or
@@ -5708,7 +5708,7 @@ If \tcode{n <= 0} or \tcode{n >= last - first}, does nothing.
 Otherwise, moves the element
 from position \tcode{first + i} into \tcode{position first + n + i}
 for each non-negative integer \tcode{i < (last - first) - n}.
-In the first overload case, if \tcode{ForwardIterator} satisfies
+In the first overload case, if \tcode{ForwardIterator} meets
 the \oldconcept{BidirectionalIterator} requirements,
 does so in order starting
 from \tcode{i = (last - first) - n - 1} and proceeding to \tcode{i = 0}.
@@ -8803,7 +8803,7 @@ template<class InputIterator, class T, class BinaryOperation>
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{T} shall satisfy
+\tcode{T} shall meet
 the \oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible})
 and \oldconcept{CopyAssignable} (\tref{cpp17.copyassignable}) requirements.
 In the range \crange{first}{last},
@@ -8954,7 +8954,7 @@ template<class InputIterator1, class InputIterator2, class T,
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{T} shall satisfy
+\tcode{T} shall meet
 the \oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible})
 and \oldconcept{CopyAssignable} (\tref{cpp17.copyassignable}) requirements.
 In the ranges \crange{first1}{last1} and

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -358,7 +358,7 @@ If the iterator type of a container belongs to the bidirectional or
 random access iterator categories\iref{iterator.requirements},
 the container is called
 \term{reversible}
-and satisfies the additional requirements
+and meets the additional requirements
 in \tref{container.rev.req}.
 
 \begin{libreqtab4a}
@@ -464,7 +464,7 @@ for some types of containers but not others. Those containers for which the
 listed operations are provided shall implement the semantics described in
 \tref{container.opt} unless otherwise stated.
 If the iterators passed to \tcode{lexicographical_compare}
-satisfy the constexpr iterator requirements\iref{iterator.requirements.general}
+meet the constexpr iterator requirements\iref{iterator.requirements.general}
 then the operations described in \tref{container.opt}
 are implemented by constexpr functions.
 
@@ -714,7 +714,7 @@ iterator is unspecified, except that as a minimum integral types shall not quali
 as input iterators.
 Likewise, the extent to which an implementation determines that a type cannot be
 an allocator is unspecified, except that as a minimum a type \tcode{A} shall not qualify
-as an allocator unless it satisfies both of the following conditions:
+as an allocator unless it meets both of the following conditions:
 
 \begin{itemize}
 \item The \grammarterm{qualified-id} \tcode{A::value_type}
@@ -790,7 +790,7 @@ the \grammarterm{qualified-id} \tcode{X::allocator_type} is valid and denotes a
 type\iref{temp.deduct} and
 \tcode{allocator<T>} if it doesn't,
 \tcode{i} and \tcode{j}
-denote iterators satisfying input iterator requirements
+denote iterators that meet the \oldconcept{InputIterator} requirements
 and refer to elements implicitly convertible to \tcode{value_type},
 \tcode{[i, j)}
 denotes a valid range,
@@ -1601,7 +1601,7 @@ when the \grammarterm{qualified-id}
 \tcode{X::key_compare::is_transparent} is valid
 and denotes a type\iref{temp.deduct},
 \tcode{i} and \tcode{j}
-satisfy input iterator requirements and refer to elements
+meet the \oldconcept{InputIterator} requirements and refer to elements
 implicitly convertible to
 \tcode{value_type}, \range{i}{j}
 denotes a valid range,
@@ -3371,10 +3371,10 @@ to \tcode{N} elements whose types are convertible to \tcode{T}.
 
 \pnum
 \indextext{requirements!container}%
-An \tcode{array} satisfies all of the requirements of a container and
+An \tcode{array} meets all of the requirements of a container and
 of a reversible container\iref{container.requirements}, except that a default
 constructed \tcode{array} object is not empty and that \tcode{swap} does not have constant
-complexity. An \tcode{array} satisfies some of the requirements of a sequence
+complexity. An \tcode{array} meets some of the requirements of a sequence
 container\iref{sequence.reqmts}.
 Descriptions are provided here
 only for operations on \tcode{array} that are not described in
@@ -3382,7 +3382,7 @@ one of these tables and
 for operations where there is additional semantic information.
 
 \pnum
-The types \tcode{iterator} and \tcode{const_iterator} satisfy
+The types \tcode{iterator} and \tcode{const_iterator} meet
 the constexpr iterator requirements\iref{iterator.requirements.general}.
 
 \indexlibrary{\idxcode{array}}%
@@ -3623,7 +3623,7 @@ Storage management is handled automatically.
 \pnum
 A
 \tcode{deque}
-satisfies all of the requirements of a container, of a reversible container
+meets all of the requirements of a container, of a reversible container
 (given in tables in~\ref{container.requirements}), of a sequence container,
 including the optional sequence container requirements\iref{sequence.reqmts}, and of an allocator-aware container (\tref{container.alloc.req}).
 Descriptions are provided here only for operations on
@@ -4016,10 +4016,10 @@ relative to a hand-written C-style singly linked list. Features that would confl
 that goal have been omitted.\end{note}
 
 \pnum
-A \tcode{forward_list} satisfies all of the requirements of a container
+A \tcode{forward_list} meets all of the requirements of a container
 (\tref{container.req}), except that the \tcode{size()}
 member function is not provided and \tcode{operator==} has linear complexity.
-A \tcode{forward_list} also satisfies all of the requirements for an allocator-aware
+A \tcode{forward_list} also meets all of the requirements for an allocator-aware
 container (\tref{container.alloc.req}). In addition, a \tcode{forward_list}
 provides the \tcode{assign} member functions
 (\tref{container.seq.req}) and several of the optional
@@ -4158,7 +4158,7 @@ namespace std {
 
 \pnum
 An incomplete type \tcode{T} may be used when instantiating \tcode{forward_list}
-if the allocator satisfies the
+if the allocator meets the
 allocator completeness requirements\iref{allocator.requirements.completeness}.
 \tcode{T} shall be complete before any member of the resulting specialization
 of \tcode{forward_list} is referenced.
@@ -4483,7 +4483,7 @@ void clear() noexcept;
 In this subclause,
 arguments for a template parameter
 named \tcode{Predicate} or \tcode{BinaryPredicate}
-shall satisfy the corresponding requirements in \ref{algorithms.requirements}.
+shall meet the corresponding requirements in \ref{algorithms.requirements}.
 For \tcode{merge} and \tcode{sort},
 the definitions and requirements in \ref{alg.sorting} apply.
 
@@ -4729,7 +4729,7 @@ fast random access to list elements is not supported, but many
 algorithms only need sequential access anyway.
 
 \pnum
-A \tcode{list} satisfies all of the requirements of a container, of
+A \tcode{list} meets all of the requirements of a container, of
 a reversible container (given in two tables in
 \ref{container.requirements}), of a sequence container,
 including most of the optional sequence container
@@ -4880,7 +4880,7 @@ namespace std {
 
 \pnum
 An incomplete type \tcode{T} may be used when instantiating \tcode{list}
-if the allocator satisfies the
+if the allocator meets the
 allocator completeness requirements\iref{allocator.requirements.completeness}.
 \tcode{T} shall be complete before any member of the resulting specialization
 of \tcode{list} is referenced.
@@ -5091,7 +5091,7 @@ lists whose allocators compare equal.}
 In this subclause,
 arguments for a template parameter
 named \tcode{Predicate} or \tcode{BinaryPredicate}
-shall satisfy the corresponding requirements in \ref{algorithms.requirements}.
+shall meet the corresponding requirements in \ref{algorithms.requirements}.
 For \tcode{merge} and \tcode{sort},
 the definitions and requirements in \ref{alg.sorting} apply.
 
@@ -5420,7 +5420,7 @@ Storage management is handled automatically, though hints can be given
 to improve efficiency.
 
 \pnum
-A \tcode{vector} satisfies all of the requirements of a container and of a
+A \tcode{vector} meets all of the requirements of a container and of a
 reversible container (given in two tables in~\ref{container.requirements}), of a
 sequence container, including most of the optional sequence container
 requirements\iref{sequence.reqmts}, of an allocator-aware container
@@ -5551,7 +5551,7 @@ namespace std {
 
 \pnum
 An incomplete type \tcode{T} may be used when instantiating \tcode{vector}
-if the allocator satisfies the
+if the allocator meets the
 allocator completeness requirements\iref{allocator.requirements.completeness}.
 \tcode{T} shall be complete before any member of the resulting specialization
 of \tcode{vector} is referenced.
@@ -6299,7 +6299,7 @@ on the keys. The \tcode{map} class supports bidirectional iterators.
 \pnum
 A
 \tcode{map}
-satisfies all of the requirements of a container, of a reversible container\iref{container.requirements}, of
+meets all of the requirements of a container, of a reversible container\iref{container.requirements}, of
 an associative container\iref{associative.reqmts}, and of an allocator-aware container (\tref{container.alloc.req}).
 A
 \tcode{map}
@@ -6845,7 +6845,7 @@ supports bidirectional iterators.
 
 \pnum
 A
-\tcode{multimap} satisfies all of the requirements of a container and of a
+\tcode{multimap} meets all of the requirements of a container and of a
 reversible container\iref{container.requirements}, of an associative
 container\iref{associative.reqmts}, and of an allocator-aware container
 (\tref{container.alloc.req}).
@@ -7166,7 +7166,7 @@ The
 supports bidirectional iterators.
 
 \pnum
-A \tcode{set} satisfies all of the requirements of a container, of a reversible
+A \tcode{set} meets all of the requirements of a container, of a reversible
 container\iref{container.requirements}, of an associative
 container\iref{associative.reqmts}, and of an allocator-aware container
 (\tref{container.alloc.req}).
@@ -7445,7 +7445,7 @@ The
 supports bidirectional iterators.
 
 \pnum
-A \tcode{multiset} satisfies all of the requirements of a container, of a
+A \tcode{multiset} meets all of the requirements of a container, of a
 reversible container\iref{container.requirements}, of an associative
 container\iref{associative.reqmts}, and of an allocator-aware container
 (\tref{container.alloc.req}).
@@ -7880,7 +7880,7 @@ The \tcode{unordered_map} class
 supports forward iterators.
 
 \pnum
-An \tcode{unordered_map} satisfies all of the requirements of a container, of an unordered associative container, and of an allocator-aware container (\tref{container.alloc.req}). It provides the operations described in the preceding requirements table for unique keys; that is, an \tcode{unordered_map} supports the \tcode{a_uniq} operations in that table, not the \tcode{a_eq} operations. For an \tcode{unordered_map<Key, T>} the \tcode{key type} is \tcode{Key}, the mapped type is \tcode{T}, and the value type is \tcode{pair<const Key, T>}.
+An \tcode{unordered_map} meets all of the requirements of a container, of an unordered associative container, and of an allocator-aware container (\tref{container.alloc.req}). It provides the operations described in the preceding requirements table for unique keys; that is, an \tcode{unordered_map} supports the \tcode{a_uniq} operations in that table, not the \tcode{a_eq} operations. For an \tcode{unordered_map<Key, T>} the \tcode{key type} is \tcode{Key}, the mapped type is \tcode{T}, and the value type is \tcode{pair<const Key, T>}.
 
 \pnum
 This subclause only describes operations on \tcode{unordered_map} that
@@ -8480,7 +8480,7 @@ The \tcode{unordered_multimap} class
 supports forward iterators.
 
 \pnum
-An \tcode{unordered_multimap} satisfies all of the requirements of a container, of an
+An \tcode{unordered_multimap} meets all of the requirements of a container, of an
 unordered associative container, and of an allocator-aware container
 (\tref{container.alloc.req}). It provides the operations described in the
 preceding requirements table for equivalent keys; that is, an \tcode{unordered_multimap}
@@ -8869,7 +8869,7 @@ The \tcode{unordered_set} class
 supports forward iterators.
 
 \pnum
-An \tcode{unordered_set} satisfies all of the requirements of a container, of an unordered associative container, and of an allocator-aware container (\tref{container.alloc.req}). It provides the operations described in the preceding requirements table for unique keys; that is, an \tcode{unordered_set} supports the \tcode{a_uniq} operations in that table, not the \tcode{a_eq} operations. For an \tcode{unordered_set<Key>} the \tcode{key type} and the value type are both \tcode{Key}. The \tcode{iterator} and \tcode{const_iterator} types are both constant iterator types. It is unspecified whether they are the same type.
+An \tcode{unordered_set} meets all of the requirements of a container, of an unordered associative container, and of an allocator-aware container (\tref{container.alloc.req}). It provides the operations described in the preceding requirements table for unique keys; that is, an \tcode{unordered_set} supports the \tcode{a_uniq} operations in that table, not the \tcode{a_eq} operations. For an \tcode{unordered_set<Key>} the \tcode{key type} and the value type are both \tcode{Key}. The \tcode{iterator} and \tcode{const_iterator} types are both constant iterator types. It is unspecified whether they are the same type.
 
 \pnum
 This subclause only describes operations on \tcode{unordered_set} that
@@ -9205,7 +9205,7 @@ The \tcode{unordered_multiset} class
 supports forward iterators.
 
 \pnum
-An \tcode{unordered_multiset} satisfies all of the requirements of a container, of an
+An \tcode{unordered_multiset} meets all of the requirements of a container, of an
 unordered associative container, and of an allocator-aware container
 (\tref{container.alloc.req}). It provides the operations described in the
 preceding requirements table for equivalent keys; that is, an \tcode{unordered_multiset}

--- a/source/future.tex
+++ b/source/future.tex
@@ -2250,7 +2250,7 @@ transmission of elements of type \tcode{Elem}, whose character traits are
 described by the class \tcode{Tr}, to and from a byte stream buffer of type
 \tcode{streambuf}. Conversion between a sequence of \tcode{Elem} values and
 multibyte sequences is performed by an object of class
-\tcode{Codecvt}, which shall satisfy the requirements
+\tcode{Codecvt}, which shall meet the requirements
 of the standard code-conversion facet \tcode{codecvt<Elem, char, mbstate_t>}.
 
 \pnum

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -97,7 +97,7 @@ are other types is
 In the classes of \ref{input.output}, a template parameter with name
 \tcode{charT} represents a member of the set of types containing \tcode{char}, \tcode{wchar_t},
 and any other \impldef{set of character types that iostreams templates can be instantiated for}
-character types that satisfy the requirements for a character on which any of
+character types that meet the requirements for a character on which any of
 the iostream components can be instantiated.
 
 \rSec2[iostreams.threadsafety]{Thread safety}
@@ -1681,7 +1681,7 @@ If \tcode{is_trivially_copy_assignable<stateT>} is \tcode{true},
 then \tcode{fpos<stateT>} has a trivial copy assignment operator.
 If \tcode{is_trivially_destructible_v<stateT>} is \tcode{true},
 then \tcode{fpos<stateT>} has a trivial destructor.
-All specializations of \tcode{fpos} satisfy
+All specializations of \tcode{fpos} meet
 the \oldconcept{DefaultConstructible},
 \oldconcept{CopyConstructible},
 \oldconcept{CopyAssignable},
@@ -10457,7 +10457,7 @@ namespace std {
 \end{codeblock}
 
 \pnum
-\tcode{Allocator} shall satisfy the \oldconcept{Allocator} requirements
+\tcode{Allocator} shall meet the \oldconcept{Allocator} requirements
 (\tref{cpp17.allocator}).
 
 \pnum
@@ -10788,7 +10788,7 @@ shall not participate in overload resolution
 unless \tcode{EcharT} is one of the encoded character types.
 
 \pnum
-Template parameters named \tcode{InputIterator} shall satisfy the
+Template parameters named \tcode{InputIterator} shall meet the
 \oldconcept{InputIterator} requirements\iref{input.iterators} and shall
 have a value type that is one of the encoded character types.
 
@@ -10800,7 +10800,7 @@ implied character set and encoding,
 they are not included as permitted types. \end{note}
 
 \pnum
-Template parameters named \tcode{Allocator} shall satisfy the
+Template parameters named \tcode{Allocator} shall meet the
 \oldconcept{Allocator} requirements (\tref{cpp17.allocator}).
 
 \rSec3[fs.req.namespace]{Namespaces and headers}
@@ -12662,7 +12662,7 @@ Path iterators iterate over the elements of the pathname
 in the generic format\iref{fs.path.generic}.
 
 \pnum
-A \tcode{path::iterator} is a constant iterator satisfying all the
+A \tcode{path::iterator} is a constant iterator meeting all the
 requirements of a bidirectional iterator\iref{bidirectional.iterators}
 except that,
 for dereferenceable iterators \tcode{a} and \tcode{b}
@@ -13842,8 +13842,8 @@ namespace std::filesystem {
 \end{codeblock}
 
 \pnum
- \tcode{directory_iterator} satisfies the
- \oldconcept{InputIterator} requirements\iref{input.iterators}.
+\tcode{directory_iterator} meets the
+\oldconcept{InputIterator} requirements\iref{input.iterators}.
 
 \pnum
 If an iterator of type \tcode{directory_iterator} reports an error or

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -526,18 +526,18 @@ The generic term \defn{iterator} refers to any type that models the
 \libconcept{Iterator} concept\iref{iterator.concept.iterator}.
 
 \pnum
-Forward iterators satisfy all the requirements of input
+Forward iterators meet all the requirements of input
 iterators and can be used whenever
 an input iterator is specified;
-Bidirectional iterators also satisfy all the requirements of
+Bidirectional iterators also meet all the requirements of
 forward iterators and can be used whenever a forward iterator is specified;
-Random access iterators also satisfy all the requirements of bidirectional
+Random access iterators also meet all the requirements of bidirectional
 iterators and can be used whenever a bidirectional iterator is specified;
-Contiguous iterators also satisfy all the requirements of random access
+Contiguous iterators also meet all the requirements of random access
 iterators and can be used whenever a random access iterator is specified.
 
 \pnum
-Iterators that further satisfy the requirements of output iterators are
+Iterators that further meet the requirements of output iterators are
 called \defnx{mutable iterators}{mutable iterator}. Nonmutable iterators are referred to
 as \defnx{constant iterators}{constant iterator}.
 
@@ -576,7 +576,7 @@ must always be assumed to have a singular value of a pointer.
 Results of most expressions are undefined for singular values;
 the only exceptions are destroying an iterator that holds a singular value,
 the assignment of a non-singular value to
-an iterator that holds a singular value, and, for iterators that satisfy the
+an iterator that holds a singular value, and, for iterators that meet the
 \oldconcept{DefaultConstructible} requirements, using a value-initialized iterator
 as the source of a copy or move operation. \begin{note} This guarantee is not
 offered for default-initialization, although the distinction only matters for types
@@ -1734,7 +1734,7 @@ of \tcode{iterator_traits<X>}\iref{iterator.traits}. \end{note}
 
 \pnum
 The \oldconcept{Iterator} requirements form the basis of the iterator
-taxonomy; every iterator satisfies the \oldconcept{Iterator} requirements. This
+taxonomy; every iterator meets the \oldconcept{\-Iterator} requirements. This
 set of requirements specifies operations for dereferencing and incrementing
 an iterator. Most algorithms will require additional operations to
 read\iref{input.iterators} or write\iref{output.iterators} values, or
@@ -1742,10 +1742,10 @@ to provide a richer set of iterator movements~(\ref{forward.iterators},
 \ref{bidirectional.iterators}, \ref{random.access.iterators}).
 
 \pnum
-A type \tcode{X} satisfies the \oldconcept{Iterator} requirements if:
+A type \tcode{X} meets the \oldconcept{Iterator} requirements if:
 
 \begin{itemize}
-\item \tcode{X} satisfies the \oldconcept{CopyConstructible}, \oldconcept{CopyAssignable}, and
+\item \tcode{X} meets the \oldconcept{CopyConstructible}, \oldconcept{CopyAssignable}, and
 \oldconcept{Destructible} requirements\iref{utility.arg.requirements} and lvalues
 of type \tcode{X} are swappable\iref{swappable.requirements}, and
 
@@ -1783,10 +1783,10 @@ the indicated semantics.
 \pnum
 A class or pointer type
 \tcode{X}
-satisfies the requirements of an input iterator for the value type
+meets the requirements of an input iterator for the value type
 \tcode{T}
 if
-\tcode{X} satisfies the \oldconcept{Iterator}\iref{iterator.iterators} and
+\tcode{X} meets the \oldconcept{Iterator}\iref{iterator.iterators} and
 \oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable}) requirements and
 the expressions in \tref{inputiterator} are valid and have
 the indicated semantics.
@@ -1890,8 +1890,8 @@ class template.
 \pnum
 A class or pointer type
 \tcode{X}
-satisfies the requirements of an output iterator
-if \tcode{X} satisfies the \oldconcept{Iterator} requirements\iref{iterator.iterators}
+meets the requirements of an output iterator
+if \tcode{X} meets the \oldconcept{Iterator} requirements\iref{iterator.iterators}
 and the expressions in \tref{outputiterator}
 are valid and have the indicated semantics.
 
@@ -1950,12 +1950,12 @@ Equality and inequality might not be defined.
 \pnum
 A class or pointer type
 \tcode{X}
-satisfies the requirements of a forward iterator if
+meets the requirements of a forward iterator if
 
 \begin{itemize}
-\item \tcode{X} satisfies the \oldconcept{InputIterator} requirements\iref{input.iterators},
+\item \tcode{X} meets the \oldconcept{InputIterator} requirements\iref{input.iterators},
 
-\item \tcode{X} satisfies the \oldconcept{DefaultConstructible}
+\item \tcode{X} meets the \oldconcept{DefaultConstructible}
 requirements\iref{utility.arg.requirements},
 
 \item if \tcode{X} is a mutable iterator, \tcode{reference} is a reference to \tcode{T};
@@ -2034,8 +2034,8 @@ if and only if
 \pnum
 A class or pointer type
 \tcode{X}
-satisfies the requirements of a bidirectional iterator if,
-in addition to satisfying the \oldconcept{ForwardIterator} requirements,
+meets the requirements of a bidirectional iterator if,
+in addition to meeting the \oldconcept{ForwardIterator} requirements,
 the following expressions are valid as shown in \tref{bidirectionaliterator}.
 
 \begin{libreqtab4b}
@@ -2079,8 +2079,8 @@ Bidirectional iterators allow algorithms to move iterators backward as well as f
 \pnum
 A class or pointer type
 \tcode{X}
-satisfies the requirements of a random access iterator if,
-in addition to satisfying the \oldconcept{BidirectionalIterator} requirements,
+meets the requirements of a random access iterator if,
+in addition to meeting the \oldconcept{BidirectionalIterator} requirements,
 the following expressions are valid as shown in \tref{randomaccessiterator}.
 
 \begin{libreqtab4b}
@@ -3494,7 +3494,7 @@ instead of the \term{regular overwrite} mode.
 \pnum
 An insert iterator is constructed from a container and possibly one of its iterators pointing to where
 insertion takes place if it is neither at the beginning nor at the end of the container.
-Insert iterators satisfy the requirements of output iterators.
+Insert iterators meet the requirements of output iterators.
 \tcode{operator*}
 returns the insert iterator itself.
 The assignment

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -497,7 +497,7 @@ defined''. That is, whether the operator is a member is unspecified.
 
 \pnum
 Requirements are stated in terms of well-defined expressions that define valid terms of
-the types that satisfy the requirements. For every set of well-defined expression
+the types that meet the requirements. For every set of well-defined expression
 requirements there is either a named concept or a table that specifies an initial set of the valid expressions and
 their semantics. Any generic algorithm\iref{algorithms} that uses the
 well-defined expression requirements is described in terms of the valid expressions for
@@ -530,7 +530,7 @@ unambiguously the optimum implementation.}
 \pnum
 Required operations of any concept defined in this document need not be
 total functions; that is, some arguments to a required operation may
-result in the required semantics failing to be satisfied.
+result in the required semantics failing to be met.
 \begin{example}
 The required \tcode{<} operator of the \libconcept{StrictTotallyOrdered}
 concept\iref{concept.stricttotallyordered} does not meet the
@@ -680,7 +680,7 @@ the presentation of complexity requirements in some cases.}
 
 \pnum
 Complexity requirements specified in the library clauses are upper bounds,
-and implementations that provide better complexity guarantees satisfy
+and implementations that provide better complexity guarantees meet
 the requirements.
 
 \pnum
@@ -1795,8 +1795,8 @@ An rvalue or lvalue \tcode{t} is \defn{swappable} if and only if \tcode{t} is
 swappable with any rvalue or lvalue, respectively, of type \tcode{T}.
 
 \pnum
-A type \tcode{X} satisfying any of the iterator requirements\iref{iterator.requirements}
-satisfies the \oldconcept{ValueSwappable} requirements if,
+A type \tcode{X} meeting any of the iterator requirements\iref{iterator.requirements}
+meets the \oldconcept{ValueSwappable} requirements if,
 for any dereferenceable object
 \tcode{x} of type \tcode{X},
 \tcode{*x} is swappable.
@@ -1849,10 +1849,10 @@ int main() {
 
 \pnum
 A \oldconcept{NullablePointer} type is a pointer-like type that supports null values.
-A type \tcode{P} satisfies the \oldconcept{\-Nullable\-Pointer} requirements if:
+A type \tcode{P} meets the \oldconcept{\-Nullable\-Pointer} requirements if:
 
 \begin{itemize}
-\item \tcode{P} satisfies the \oldconcept{EqualityComparable},
+\item \tcode{P} meets the \oldconcept{EqualityComparable},
 \oldconcept{DefaultConstructible}, \oldconcept{CopyConstructible}, \oldconcept{\-Copy\-Assign\-able},
 and \oldconcept{Destructible} requirements,
 
@@ -1861,7 +1861,7 @@ and \oldconcept{Destructible} requirements,
 \item the expressions shown in \tref{cpp17.nullablepointer} are
 valid and have the indicated semantics, and
 
-\item \tcode{P} satisfies all the other requirements of this subclause.
+\item \tcode{P} meets all the other requirements of this subclause.
 \end{itemize}
 
 \pnum
@@ -1931,7 +1931,7 @@ A type \tcode{H} meets the \oldconcept{Hash} requirements if:
 
 \begin{itemize}
 \item it is a function object type\iref{function.objects},
-\item it satisfies the \oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible}) and
+\item it meets the \oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible}) and
   \oldconcept{Destructible} (\tref{cpp17.destructible}) requirements, and
 \item the expressions shown in \tref{cpp17.hash}
 are valid and have the indicated semantics.
@@ -2244,11 +2244,11 @@ above form, no default is provided.
 \pnum
 Note B:
 If \tcode{X::propagate_on_container_copy_assignment::value} is \tcode{true},
-\tcode{X} shall satisfy the
+\tcode{X} shall meet the
 \oldconcept{\-Copy\-Assign\-able} requirements (\tref{cpp17.copyassignable})
 and the copy operation shall not throw exceptions.
 If \tcode{X::propagate_on_container_move_assignment::value} is \tcode{true},
-\tcode{X} shall satisfy the
+\tcode{X} shall meet the
 \oldconcept{\-Move\-Assign\-able} requirements (\tref{cpp17.moveassignable})
 and the move operation shall not throw exceptions.
 If \tcode{X::propagate_on_container_swap::value} is \tcode{true},
@@ -2324,7 +2324,7 @@ for that type may fail by throwing an object of type
 
 \pnum
 \begin{example} The following is an allocator class template supporting the minimal
-interface that satisfies the requirements of
+interface that meets the requirements of
 \tref{cpp17.allocator}:
 
 \begin{codeblock}
@@ -2350,7 +2350,7 @@ bool operator!=(const SimpleAllocator<T>&, const SimpleAllocator<U>&);
 
 \pnum
 If \tcode{X} is an allocator class for type \tcode{T},
-\tcode{X} additionally satisfies the allocator completeness requirements if,
+\tcode{X} additionally meets the allocator completeness requirements if,
 whether or not \tcode{T} is a complete type:
 
 \begin{itemize}

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -439,7 +439,7 @@ In declarations of facets, a template parameter with name
 or
 \tcode{OutputIterator}
 indicates the set of
-all possible specializations on parameters that satisfy the
+all possible specializations on parameters that meet the
 \oldconcept{InputIterator} requirements or \oldconcept{OutputIterator}
 requirements, respectively\iref{iterator.requirements}.
 A template parameter with name
@@ -447,7 +447,7 @@ A template parameter with name
 represents the set
 of types containing \tcode{char}, \tcode{wchar_t}, and any other
 \impldef{set of character types that iostreams templates can be instantiated for}
-character types that satisfy
+character types that meet
 the requirements for a character on which any of the iostream
 components can be instantiated.
 A template parameter with name
@@ -836,7 +836,7 @@ facet.
 \remarks
 This member operator template (and therefore
 \tcode{locale}
-itself) satisfies requirements for a comparator predicate template argument\iref{algorithms}
+itself) meets the requirements for a comparator predicate template argument\iref{algorithms}
 applied to strings.
 
 \pnum

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -38,7 +38,7 @@ and
 components are parameterized by the type of information they contain and manipulate.
 A \Cpp{} program shall instantiate these components only with a numeric type.
 A \defnadj{numeric}{type} is a cv-unqualified object type \tcode{T}
-that satisfies the
+that meets the
 \oldconcept{DefaultConstructible},
 \oldconcept{CopyConstructible},
 \oldconcept{CopyAssignable}, and
@@ -61,7 +61,7 @@ In addition, many member and related functions of
 \tcode{valarray<T>}
 can be successfully instantiated
 and will exhibit well-defined behavior if and only if
-\tcode{T} satisfies additional requirements specified for each such member
+\tcode{T} meets additional requirements specified for each such member
 or related function.
 
 \pnum
@@ -1471,7 +1471,7 @@ four categories of entities are described:
 and
 \term{random number distributions}.
 These categorizations are applicable
-to types that satisfy the corresponding requirements,
+to types that meet the corresponding requirements,
 to objects instantiated from such types,
 and to templates producing such types when instantiated.
 \begin{note}
@@ -1717,21 +1717,21 @@ the effect of instantiating a template:
     named \tcode{Sseq}
     is undefined unless the corresponding template argument
     is cv-unqualified and
-    satisfies the requirements
+    meets the requirements
     of seed sequence\iref{rand.req.seedseq}.
   \item
     that has a template type parameter
     named \tcode{URBG}
     is undefined unless the corresponding template argument
     is cv-unqualified and
-    satisfies the requirements
+    meets the requirements
     of uniform random bit generator\iref{rand.req.urng}.
   \item
     that has a template type parameter
     named \tcode{Engine}
     is undefined unless the corresponding template argument
     is cv-unqualified and
-    satisfies the requirements
+    meets the requirements
     of random number engine\iref{rand.req.eng}.
   \item
     that has a template type parameter
@@ -1773,13 +1773,13 @@ Throughout this subclause \ref{rand},
 phrases of the form ``\tcode{x} is an iterator of a specific kind''
 shall be interpreted as equivalent to the more formal requirement that
 ``\tcode{x} is a value
-of a type satisfying the requirements
+of a type meeting the requirements
 of the specified iterator type''.
 
 \pnum
 Throughout this subclause \ref{rand},
 any constructor that can be called with a single argument
-and that satisfies a requirement specified in this subclause
+and that meets a requirement specified in this subclause
 shall be declared \tcode{explicit}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -1806,12 +1806,12 @@ shall be declared \tcode{explicit}.
 
 \pnum
 A class \tcode{S}
-satisfies the requirements
+meets the requirements
 of a seed sequence
 if the expressions shown
 in \tref{rand.req.seedseq}
 are valid and have the indicated semantics,
-and if \tcode{S} also satisfies all other requirements
+and if \tcode{S} also meets all other requirements
 of this subclause \ref{rand.req.seedseq}.
 In that Table and throughout this subclause:
 \begin{itemize}
@@ -2031,14 +2031,14 @@ An engine's state may be established via
 
 \pnum
 A class \tcode{E}
-that satisfies the requirements
+that meets the requirements
 of a uniform random bit generator\iref{rand.req.urng}
-also satisfies the requirements
+also meets the requirements
 of a \term{random number engine}
 if the expressions shown
 in \tref{rand.req.eng}
 are valid and have the indicated semantics,
-and if \tcode{E} also satisfies all other requirements
+and if \tcode{E} also meets all other requirements
 of this subclause \ref{rand.req.eng}.
 In that Table and throughout this subclause:
 \begin{itemize}
@@ -2053,7 +2053,7 @@ In that Table and throughout this subclause:
     \tcode{s} is a value of \tcode{T};
   \item
     \tcode{q} is an lvalue
-    satisfying the requirements of a seed sequence\iref{rand.req.seedseq};
+    meeting the requirements of a seed sequence\iref{rand.req.seedseq};
   \item
     \tcode{z} is a value
     of type \tcode{unsigned long long};
@@ -2243,7 +2243,7 @@ according to \ref{strings} and \ref{input.output}.
 \end{libreqtab4d}
 
 \pnum
-\tcode{E} shall satisfy the
+\tcode{E} shall meet the
 \oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible})
 and \oldconcept{CopyAssignable} (\tref{cpp17.copyassignable}) requirements.
 These operations shall each be of complexity
@@ -2350,7 +2350,7 @@ template<class Sseq> void seed(Sseq& q);
 \end{itemdescr}
 
 \pnum
-\tcode{A} shall also satisfy
+\tcode{A} shall also meet
 the following additional requirements:
 \begin{itemize}
  \item
@@ -2416,13 +2416,13 @@ or by writing, for example,
 
 \pnum
 A class \tcode{D}
-satisfies the requirements
+meets the requirements
 of a \term{random number distribution}
 if the expressions shown
 in \tref{rand.req.dist}
 are valid and have the indicated semantics,
 and if \tcode{D} and its associated types
-also satisfy all other requirements
+also meet all other requirements
 of this subclause \ref{rand.req.dist}.
 In that Table and throughout this subclause,
 \begin{itemize}
@@ -2448,7 +2448,7 @@ In that Table and throughout this subclause,
     \tcode{p} is a (possibly \tcode{const}) value of \tcode{P};
   \item
     \tcode{g}, \tcode{g1}, and \tcode{g2} are lvalues of a type
-    satisfying the requirements
+    meeting the requirements
     of a uniform random bit generator\iref{rand.req.urng};
   \item
     \tcode{os} is an lvalue of the type of some class template specialization
@@ -2622,7 +2622,7 @@ according to \ref{strings} and \ref{input.output}.
 \end{libreqtab4d}
 
 \pnum
-\tcode{D} shall satisfy the
+\tcode{D} shall meet the
 \oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible})
 and \oldconcept{CopyAssignable} (\tref{cpp17.copyassignable}) requirements.
 
@@ -2654,7 +2654,7 @@ are in the form of \tcode{typedef}s
 for convenience of exposition only.
 
 \pnum
-\tcode{P} shall satisfy the
+\tcode{P} shall meet the
 \oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible}),
 \oldconcept{CopyAssignable} (\tref{cpp17.copyassignable}),
 and
@@ -2698,7 +2698,7 @@ using distribution_type =  D;
 \pnum
 Each type instantiated
 from a class template specified in this subclause~\ref{rand.eng}
-satisfies the requirements
+meets the requirements
 of a random number engine\iref{rand.req.eng} type.
 
 \pnum
@@ -3235,7 +3235,7 @@ template<class Sseq> explicit subtract_with_carry_engine(Sseq& q);
 \pnum
 Each type instantiated
 from a class template specified in this subclause~\ref{rand.adapt}
-satisfies the requirements
+meets the requirements
 of a random number engine adaptor\iref{rand.req.adapt} type.
 
 \pnum
@@ -4014,7 +4014,7 @@ template<class InputIterator>
 
 \begin{itemdescr}
 \pnum\requires
-  \tcode{InputIterator} shall satisfy the
+  \tcode{InputIterator} shall meet the
   \oldconcept{InputIterator} requirements\iref{input.iterators}.
   Moreover,
   \tcode{iterator_traits<InputIterator>::value_type}
@@ -4036,7 +4036,7 @@ template<class RandomAccessIterator>
 
 \begin{itemdescr}
 \pnum\requires \tcode{RandomAccessIterator}
-  shall satisfy the
+  shall meet the
   \oldconcept{RandomAccessIterator} requirements\iref{random.access.iterators}
   and the requirements of a mutable iterator.
   Moreover,
@@ -4143,7 +4143,7 @@ template<class OutputIterator>
 
 \begin{itemdescr}
 \pnum\requires
-  \tcode{OutputIterator} shall satisfy the
+  \tcode{OutputIterator} shall meet the
   \oldconcept{OutputIterator} requirements\iref{output.iterators}.
   Moreover,
   the expression
@@ -4250,7 +4250,7 @@ template<class RealType, size_t bits, class URBG>
 \pnum
 Each type instantiated
 from a class template specified in this subclause~\ref{rand.dist}
-satisfies the requirements
+meets the requirements
 of a random number distribution\iref{rand.req.dist} type.
 
 \pnum
@@ -5827,7 +5827,7 @@ template<class InputIterator>
 \begin{itemdescr}
 \pnum
 \requires
-  \tcode{InputIterator} shall satisfy the
+  \tcode{InputIterator} shall meet the
   \oldconcept{InputIterator} requirements\iref{input.iterators}.
   Moreover,
   \tcode{iterator_traits<InputIterator>::value_type}
@@ -6000,7 +6000,7 @@ template<class InputIteratorB, class InputIteratorW>
 \begin{itemdescr}
 \pnum\requires
   \tcode{InputIteratorB} and \tcode{InputIteratorW}
-  shall each satisfy the
+  shall each meet the
   \oldconcept{InputIterator} requirements\iref{input.iterators}.
   Moreover,
   the \grammarterm{id-expression}s
@@ -6211,7 +6211,7 @@ template<class InputIteratorB, class InputIteratorW>
 \begin{itemdescr}
 \pnum\requires
   \tcode{InputIteratorB} and \tcode{InputIteratorW}
-  shall each satisfy the
+  shall each meet the
   \oldconcept{InputIterator} requirements\iref{input.iterators}.
   Moreover,
   the \grammarterm{id-expression}s

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -87,7 +87,7 @@ been marked by parenthesis.
 This subclause defines requirements on classes representing regular
 expression traits.  \begin{note} The class template
 \tcode{regex_traits}, defined in \ref{re.traits},
-satisfies these requirements.  \end{note}
+meets these requirements.  \end{note}
 
 \pnum
 The class template \tcode{basic_regex}, defined in
@@ -246,7 +246,7 @@ and \tcode{loc} is an object of type \tcode{X::locale_type}.
 
 \pnum
 \begin{note}
-Class template \tcode{regex_traits} satisfies the requirements for a
+Class template \tcode{regex_traits} meets the requirements for a
 regular expression traits class when it is specialized for
 \tcode{char} or \tcode{wchar_t}.  This class template is described in
 the header \tcode{<regex>}, and is described in \ref{re.traits}.
@@ -1052,7 +1052,7 @@ namespace std {
 \indextext{requirements!regular expression traits}%
 \indextext{\idxcode{regex_traits}!specializations}%
 The specializations \tcode{regex_traits<char>} and
-\tcode{regex_traits<wchar_t>} shall be valid and shall satisfy the
+\tcode{regex_traits<wchar_t>} shall be valid and shall meet the
 requirements for a regular expression traits class\iref{re.req}.
 
 \indexlibrarymember{regex_traits}{char_class_type}%
@@ -1696,7 +1696,7 @@ template<class InputIterator>
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{InputIterator} shall satisfy the
+\tcode{InputIterator} shall meet the
 \oldconcept{InputIterator} requirements\iref{input.iterators}.
 
 \pnum
@@ -2426,7 +2426,7 @@ by the member functions of class template \tcode{match_results}.
 \indextext{requirements!container}%
 \indextext{requirements!sequence}%
 \indextext{\idxcode{match_results}!as sequence}%
-The class template \tcode{match_results} satisfies the requirements of an
+The class template \tcode{match_results} meets the requirements of an
 allocator-aware container and of a sequence container
 (\ref{container.requirements.general}, \ref{sequence.reqmts})
 except that only
@@ -2790,7 +2790,7 @@ template<class OutputIter>
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{ready() == true} and \tcode{OutputIter} shall satisfy the requirements for a
+\requires \tcode{ready() == true} and \tcode{OutputIter} shall meet the requirements for a
 \oldconcept{OutputIterator}\iref{output.iterators}.
 
 \pnum
@@ -2979,7 +2979,7 @@ template<class BidirectionalIterator, class Allocator, class charT, class traits
 \begin{itemdescr}
 \pnum
 \requires
-The type \tcode{BidirectionalIterator} shall satisfy the
+The type \tcode{BidirectionalIterator} shall meet the
 \oldconcept{BidirectionalIterator} requirements\iref{bidirectional.iterators}.
 
 \pnum
@@ -3163,7 +3163,7 @@ template<class BidirectionalIterator, class Allocator, class charT, class traits
 \begin{itemdescr}
 \pnum
 \requires
-Type \tcode{BidirectionalIterator} shall satisfy the
+Type \tcode{BidirectionalIterator} shall meet the
 \oldconcept{BidirectionalIterator} requirements\iref{bidirectional.iterators}.
 
 \pnum

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -40,7 +40,7 @@ along with five specializations,
 \tcode{char_traits<char32_t>},
 and
 \tcode{char_traits<wchar_t>},
-that satisfy those requirements.
+that meet those requirements.
 
 \pnum
 Most classes specified in \ref{string.classes}, \ref{string.view},
@@ -1103,7 +1103,7 @@ as \tcode{charT}. Every object of type
 objects as needed. The \tcode{Allocator} object used is
 obtained as described in \ref{container.requirements.general}.
 In every specialization \tcode{basic_string<charT, traits, Allocator>},
-the type \tcode{traits} shall satisfy
+the type \tcode{traits} shall meet
 the character traits requirements\iref{char.traits}.
 \begin{note}
 The program is ill-formed if \tcode{traits::char_type}
@@ -4072,7 +4072,7 @@ private:
 \end{codeblock}
 
 \pnum
-In every specialization \tcode{basic_string_view<charT, traits>}, the type \tcode{traits} shall satisfy the character traits requirements\iref{char.traits}.
+In every specialization \tcode{basic_string_view<charT, traits>}, the type \tcode{traits} shall meet the character traits requirements\iref{char.traits}.
 \begin{note}
 The program is ill-formed if \tcode{traits::char_type} is not the same type as \tcode{charT}.
 \end{note}
@@ -4150,7 +4150,7 @@ A type that meets the requirements
 of a constant
 \oldconcept{RandomAccessIterator}\iref{random.access.iterators},
 models \libconcept{ContiguousIterator}\iref{iterator.concept.contiguous}, and
-satisfies the constexpr iterator requirements\iref{iterator.requirements.general},
+meets the constexpr iterator requirements\iref{iterator.requirements.general},
 whose \tcode{value_type} is the template parameter \tcode{charT}.
 
 \pnum

--- a/source/support.tex
+++ b/source/support.tex
@@ -3937,7 +3937,7 @@ This type shall be selected by the implementation such that
 these parameters can accept literal \tcode{0} as a corresponding argument.
 \begin{example}
 \tcode{nullptr_t}
-satisfies this requirement.
+meets this requirement.
 \end{example}
 In this context, the behavior of a program that supplies
 an argument other than a literal \tcode{0} is undefined.
@@ -4858,7 +4858,7 @@ This subclause defines requirements on classes representing
 \term{coroutine traits},
 and defines the class template
 \tcode{coroutine_traits}
-that satisfies those requirements.
+that meets those requirements.
 
 \rSec3[coroutine.traits.primary]{Class template \tcode{coroutine_traits}}
 

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -132,7 +132,7 @@ and hardware. The finest resolution provided by an implementation is called the
 \term{native resolution}.
 
 \pnum
-Implementation-provided clocks that are used for these functions shall satisfy the
+Implementation-provided clocks that are used for these functions shall meet the
 \oldconcept{TrivialClock} requirements\iref{time.clock.req}.
 
 \pnum
@@ -506,7 +506,7 @@ template<class F, class... Args> explicit thread(F&& f, Args&&... args);
 
 \begin{itemdescr}
 \pnum
-\requires\ \tcode{F} and each $\tcode{T}_i$ in \tcode{Args} shall satisfy the
+\requires\ \tcode{F} and each $\tcode{T}_i$ in \tcode{Args} shall meet the
 \oldconcept{MoveConstructible} requirements.
 \tcode{%
 \placeholdernc{INVOKE}(\brk{}%
@@ -874,11 +874,11 @@ recursive and non-recursive mutexes are supplied.
 The \defn{mutex types} are the standard library types \tcode{mutex},
 \tcode{recursive_mutex}, \tcode{timed_mutex}, \tcode{recursive_timed_mutex},
 \tcode{shared_mutex}, and \tcode{shared_timed_mutex}.
-They shall satisfy the requirements set out in this subclause. In this description, \tcode{m}
+They shall meet the requirements set out in this subclause. In this description, \tcode{m}
 denotes an object of a mutex type.
 
 \pnum
-The mutex types shall satisfy the \oldconcept{Lockable} requirements\iref{thread.req.lockable.req}.
+The mutex types shall meet the \oldconcept{Lockable} requirements\iref{thread.req.lockable.req}.
 
 \pnum
 The mutex types shall be \oldconcept{DefaultConstructible} and \oldconcept{Destructible}. If
@@ -1044,7 +1044,7 @@ contains a mutex that is used to protect the reference count.
 \end{note}
 
 \pnum
-The class \tcode{mutex} shall satisfy all of the mutex
+The class \tcode{mutex} shall meet all of the mutex
 requirements\iref{thread.mutex.requirements}. It shall be a standard-layout
 class\iref{class.prop}.
 
@@ -1088,7 +1088,7 @@ thread to acquire ownership of that object will fail (for \tcode{try_lock()}) or
 (for \tcode{lock()}) until the first thread has completely released ownership.
 
 \pnum
-The class \tcode{recursive_mutex} shall satisfy all of the mutex
+The class \tcode{recursive_mutex} shall meet all of the mutex
 requirements\iref{thread.mutex.requirements}. It shall be a standard-layout
 class\iref{class.prop}.
 
@@ -1124,7 +1124,7 @@ object of an
 instantiation of \tcode{time_point}\iref{time.point}.
 
 \pnum
-The timed mutex types shall satisfy the \oldconcept{TimedLockable}
+The timed mutex types shall meet the \oldconcept{TimedLockable}
 requirements\iref{thread.req.lockable.timed}.
 
 \pnum
@@ -1231,7 +1231,7 @@ call to \tcode{try_lock_for()} or \tcode{try_lock_until()} times out (having
 failed to obtain ownership).
 
 \pnum
-The class \tcode{timed_mutex} shall satisfy all of the timed mutex
+The class \tcode{timed_mutex} shall meet all of the timed mutex
 requirements\iref{thread.timedmutex.requirements}. It shall be a standard-layout
 class\iref{class.prop}.
 
@@ -1282,7 +1282,7 @@ ownership or the call to \tcode{try_lock_for()} or \tcode{try_lock_until()}
 times out (having failed to obtain ownership).
 
 \pnum
-The class \tcode{recursive_timed_mutex} shall satisfy all of the timed mutex
+The class \tcode{recursive_timed_mutex} shall meet all of the timed mutex
 requirements\iref{thread.timedmutex.requirements}. It shall be a standard-layout
 class\iref{class.prop}.
 
@@ -1313,9 +1313,9 @@ The behavior of a program is undefined if:
 
 \pnum
 The standard library types \tcode{shared_mutex} and \tcode{shared_timed_mutex}
-are \defn{shared mutex types}. Shared mutex types shall satisfy the requirements of
+are \defn{shared mutex types}. Shared mutex types shall meet the requirements of
 mutex types\iref{thread.mutex.requirements.mutex}, and additionally
-shall satisfy the requirements set out below. In this description,
+shall meet the requirements set out below. In this description,
 \tcode{m} denotes an object of a shared mutex type.
 
 \pnum
@@ -1448,7 +1448,7 @@ The class \tcode{shared_mutex} provides a non-recursive mutex
 with shared ownership semantics.
 
 \pnum
-The class \tcode{shared_mutex} shall satisfy all of the
+The class \tcode{shared_mutex} shall meet all of the
 shared mutex requirements\iref{thread.sharedmutex.requirements}.
 It shall be a standard-layout class\iref{class.prop}.
 
@@ -1467,10 +1467,10 @@ The behavior of a program is undefined if:
 
 \pnum
 The standard library type \tcode{shared_timed_mutex} is a
-\defn{shared timed mutex type}. Shared timed mutex types shall satisfy the requirements of
+\defn{shared timed mutex type}. Shared timed mutex types shall meet the requirements of
 timed mutex types\iref{thread.timedmutex.requirements},
 shared mutex types\iref{thread.sharedmutex.requirements}, and additionally
-shall satisfy the requirements set out below. In this description,
+shall meet the requirements set out below. In this description,
 \tcode{m} denotes an object of a shared timed mutex type,
 \tcode{rel_type} denotes an object of an instantiation of
 \tcode{duration}\iref{time.duration}, and
@@ -1588,7 +1588,7 @@ The class \tcode{shared_timed_mutex} provides a non-recursive mutex with shared
 ownership semantics.
 
 \pnum
-The class \tcode{shared_timed_mutex} shall satisfy all of the
+The class \tcode{shared_timed_mutex} shall meet all of the
 shared timed mutex requirements\iref{thread.sharedtimedmutex.requirements}.
 It shall be a standard-layout class\iref{class.prop}.
 
@@ -1664,7 +1664,7 @@ within a scope. A \tcode{lock_guard} object maintains ownership of a lockable
 object throughout the \tcode{lock_guard} object's lifetime\iref{basic.life}.
 The behavior of a program is undefined if the lockable object referenced by
 \tcode{pm} does not exist for the entire lifetime of the \tcode{lock_guard}
-object. The supplied \tcode{Mutex} type shall satisfy the \oldconcept{BasicLockable}
+object. The supplied \tcode{Mutex} type shall meet the \oldconcept{BasicLockable}
 requirements\iref{thread.req.lockable.basic}.
 
 \indexlibrary{\idxcode{lock_guard}!constructor}%
@@ -1740,9 +1740,9 @@ The behavior of a program is undefined if the lockable objects referenced by
 object.
 When \tcode{sizeof...(MutexTypes)} is \tcode{1},
 the supplied \tcode{Mutex} type
-shall satisfy the \oldconcept{BasicLockable} requirements\iref{thread.req.lockable.basic}.
+shall meet the \oldconcept{BasicLockable} requirements\iref{thread.req.lockable.basic}.
 Otherwise, each of the mutex types
-shall satisfy the \oldconcept{Lockable} requirements\iref{thread.req.lockable.req}.
+shall meet the \oldconcept{Lockable} requirements\iref{thread.req.lockable.req}.
 
 \indexlibrary{\idxcode{scoped_lock}!constructor}%
 \begin{itemdecl}
@@ -1855,7 +1855,7 @@ copyable but are movable. The behavior of a program is undefined if the containe
 \tcode{pm} is not null and the lockable object pointed
 to by \tcode{pm} does not exist for the entire remaining
 lifetime\iref{basic.life} of the \tcode{unique_lock} object. The supplied
-\tcode{Mutex} type shall satisfy the \oldconcept{BasicLockable}
+\tcode{Mutex} type shall meet the \oldconcept{BasicLockable}
 requirements\iref{thread.req.lockable.basic}.
 
 \pnum
@@ -1918,7 +1918,7 @@ unique_lock(mutex_type& m, try_to_lock_t);
 \begin{itemdescr}
 \pnum
 \requires
-The supplied \tcode{Mutex} type shall satisfy the \oldconcept{Lockable}
+The supplied \tcode{Mutex} type shall meet the \oldconcept{Lockable}
 requirements\iref{thread.req.lockable.req}.
 If \tcode{mutex_type} is not a recursive mutex the calling thread does not own the mutex.
 
@@ -1958,7 +1958,7 @@ template<class Clock, class Duration>
 \begin{itemdescr}
 \pnum
 \requires If \tcode{mutex_type} is not a recursive mutex the calling thread
-does not own the mutex. The supplied \tcode{Mutex} type shall satisfy the
+does not own the mutex. The supplied \tcode{Mutex} type shall meet the
 \oldconcept{TimedLockable} requirements\iref{thread.req.lockable.timed}.
 
 \pnum
@@ -1979,7 +1979,7 @@ template<class Rep, class Period>
 \begin{itemdescr}
 \pnum
 \requires If \tcode{mutex_type} is not a recursive mutex the calling thread does not own the mutex.
-The supplied \tcode{Mutex} type shall satisfy the \oldconcept{TimedLockable} requirements\iref{thread.req.lockable.timed}.
+The supplied \tcode{Mutex} type shall meet the \oldconcept{TimedLockable} requirements\iref{thread.req.lockable.timed}.
 
 \pnum
 \effects Constructs an object of type \tcode{unique_lock} and calls \tcode{m.try_lock_for(rel_time)}.
@@ -2059,7 +2059,7 @@ bool try_lock();
 
 \begin{itemdescr}
 \pnum
-\requires The supplied \tcode{Mutex} shall satisfy the \oldconcept{Lockable}
+\requires The supplied \tcode{Mutex} shall meet the \oldconcept{Lockable}
 requirements\iref{thread.req.lockable.req}.
 
 \pnum
@@ -2093,7 +2093,7 @@ template<class Clock, class Duration>
 
 \begin{itemdescr}
 \pnum
-\requires The supplied \tcode{Mutex} type shall satisfy the \oldconcept{TimedLockable}
+\requires The supplied \tcode{Mutex} type shall meet the \oldconcept{TimedLockable}
 requirements\iref{thread.req.lockable.timed}.
 
 \pnum
@@ -2127,7 +2127,7 @@ template<class Rep, class Period>
 
 \begin{itemdescr}
 \pnum
-\requires The supplied \tcode{Mutex} type shall satisfy the \oldconcept{TimedLockable} requirements\iref{thread.req.lockable.timed}.
+\requires The supplied \tcode{Mutex} type shall meet the \oldconcept{TimedLockable} requirements\iref{thread.req.lockable.timed}.
 
 \pnum
 \effects As if by \tcode{pm->try_lock_for(rel_time)}.
@@ -2296,7 +2296,7 @@ acquisition, to another \tcode{shared_lock} object. Objects of type
 is undefined if the contained pointer \tcode{pm} is not null and the lockable
 object pointed to by \tcode{pm} does not exist for the entire remaining
 lifetime\iref{basic.life} of the \tcode{shared_lock} object. The supplied
-\tcode{Mutex} type shall satisfy the shared mutex
+\tcode{Mutex} type shall meet the shared mutex
 requirements\iref{thread.sharedtimedmutex.requirements}.
 
 \pnum
@@ -2675,7 +2675,7 @@ template<class L1, class L2, class... L3> int try_lock(L1&, L2&, L3&...);
 
 \begin{itemdescr}
 \pnum
-\requires Each template parameter type shall satisfy the \oldconcept{Lockable} requirements. \begin{note} The
+\requires Each template parameter type shall meet the \oldconcept{Lockable} requirements. \begin{note} The
 \tcode{unique_lock} class template meets these requirements when suitably instantiated.
 \end{note}
 
@@ -2699,7 +2699,7 @@ template<class L1, class L2, class... L3> void lock(L1&, L2&, L3&...);
 
 \begin{itemdescr}
 \pnum
-\requires Each template parameter type shall satisfy the \oldconcept{Lockable} requirements,
+\requires Each template parameter type shall meet the \oldconcept{Lockable} requirements,
 \begin{note} The
 \tcode{unique_lock} class template meets these requirements when suitably instantiated.
 \end{note}
@@ -3305,7 +3305,7 @@ exceptions\iref{thread.req.timing} or any exception thrown by \tcode{pred}.
 \rSec2[thread.condition.condvarany]{Class \tcode{condition_variable_any}}
 
 \pnum
-A \tcode{Lock} type shall satisfy the \oldconcept{BasicLockable}
+A \tcode{Lock} type shall meet the \oldconcept{BasicLockable}
 requirements\iref{thread.req.lockable.basic}. \begin{note} All of the standard
 mutex types meet this requirement. If a \tcode{Lock} type other than one of the
 standard mutex types or a \tcode{unique_lock} wrapper for a standard mutex type
@@ -3914,7 +3914,7 @@ template<class R, class Alloc>
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{Alloc} shall satisfy the \oldconcept{Allocator}
+\requires \tcode{Alloc} shall meet the \oldconcept{Allocator}
 requirements (\tref{cpp17.allocator}).
 \end{itemdescr}
 
@@ -4777,7 +4777,7 @@ template<class F, class... Args>
 \begin{itemdescr}
 \pnum
 \requires \tcode{F} and each $\tcode{T}_i$ in \tcode{Args} shall
-satisfy the
+meet the
 \oldconcept{MoveConstructible} requirements, and
 \begin{codeblock}
 @\placeholdernc{INVOKE}@(@\placeholdernc{decay-copy}@(std::forward<F>(f)),

--- a/source/time.tex
+++ b/source/time.tex
@@ -1024,7 +1024,7 @@ namespace std {
 A clock is a bundle consisting of a \tcode{duration}, a
 \tcode{time_point}, and a function \tcode{now()} to get the current \tcode{time_point}.
 The origin of the clock's \tcode{time_point} is referred to as the clock's \defn{epoch}.
- A clock shall satisfy the requirements in \tref{time.clock}.
+ A clock shall meet the requirements in \tref{time.clock}.
 
 \pnum
 In \tref{time.clock} \tcode{C1} and \tcode{C2} denote clock types. \tcode{t1} and
@@ -1082,7 +1082,7 @@ SI definition is a measure of the quality of implementation. \end{note}
 A type \tcode{TC} meets the \oldconcept{TrivialClock} requirements if:
 
 \begin{itemize}
-\item \tcode{TC} satisfies the \oldconcept{Clock} requirements\iref{time.clock.req},
+\item \tcode{TC} meets the \oldconcept{Clock} requirements\iref{time.clock.req},
 
 \item the types \tcode{TC::rep}, \tcode{TC::duration}, and \tcode{TC::time_point}
 meet the \oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable}) and
@@ -1240,7 +1240,7 @@ the extent to which an implementation determines
 that a type cannot meet the \oldconcept{Clock} requirements is unspecified,
 except that as a minimum
 a type \tcode{T} shall not qualify as a \oldconcept{Clock}
-unless it satisfies all of the following conditions:
+unless it meets all of the following conditions:
 
 \begin{itemize}
 \item the \grammarterm{qualified-id}s
@@ -1335,7 +1335,7 @@ those thrown by the indicated operations on their representations.
 The defaulted copy constructor of duration shall be a
 constexpr function if and only if the required initialization
 of the member \tcode{rep_} for copy and move, respectively, would
-satisfy the requirements for a constexpr function.
+meet the requirements for a constexpr function.
 
 \pnum
 \begin{example}
@@ -2191,7 +2191,7 @@ namespace std::chrono {
 
 \pnum
 \tcode{Clock} shall either
-satisfy the \oldconcept{Clock} requirements\iref{time.clock.req}
+meet the \oldconcept{Clock} requirements\iref{time.clock.req}
 or be the type \tcode{local_t}.
 
 \pnum
@@ -2546,7 +2546,7 @@ unless \tcode{ToDuration} is a specialization of \tcode{duration}, and
 \rSec1[time.clock]{Clocks}
 
 \pnum
-The types defined in this subclause shall satisfy the
+The types defined in this subclause shall meet the
 \oldconcept{TrivialClock}
 requirements\iref{time.clock.req}
 unless otherwise specified.

--- a/source/time.tex
+++ b/source/time.tex
@@ -1335,7 +1335,7 @@ those thrown by the indicated operations on their representations.
 The defaulted copy constructor of duration shall be a
 constexpr function if and only if the required initialization
 of the member \tcode{rep_} for copy and move, respectively, would
-meet the requirements for a constexpr function.
+satisfy the requirements for a constexpr function.
 
 \pnum
 \begin{example}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -514,7 +514,7 @@ throws an exception.
 \pnum
 The defaulted move and copy constructor, respectively, of \tcode{pair} shall
 be a constexpr function if and only if all required element-wise
-initializations for copy and move, respectively, would satisfy the
+initializations for copy and move, respectively, would meet the
 requirements for a constexpr function.
 
 \pnum
@@ -1186,7 +1186,7 @@ one of the types in \tcode{Types} throws an exception.
 The defaulted move and copy constructor, respectively, of
 \tcode{tuple} shall be a constexpr function if and only if all
 required element-wise initializations for copy and move, respectively,
-would satisfy the requirements for a constexpr function. The
+would meet the requirements for a constexpr function. The
 defaulted move and copy constructor of \tcode{tuple<>} shall be
 constexpr functions.
 
@@ -1425,7 +1425,7 @@ template<class Alloc, class U1, class U2>
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{Alloc} shall satisfy the
+\requires \tcode{Alloc} shall meet the
 \oldconcept{Allocator} requirements (\tref{cpp17.allocator}).
 
 \pnum
@@ -1694,7 +1694,7 @@ zero-based.
 $\cv_i$ \tcode{tuple<$\tcode{Args}_i$...>}, where $\cv_i$ is the (possibly empty) $i^\text{th}$
 \grammarterm{cv-qualifier-seq} and $\tcode{Args}_i$ is the template parameter pack representing the element
 types in $\tcode{U}_i$. Let $\tcode{A}_{ik}$ be the ${k}^\text{th}$ type in $\tcode{Args}_i$. For all
-$\tcode{A}_{ik}$ the following requirements shall be satisfied:
+$\tcode{A}_{ik}$ the following requirements shall be met:
 \begin{itemize}
 \item If $\tcode{T}_i$ is deduced as an lvalue reference type, then
       \tcode{is_constructible_v<$\tcode{A}_{ik}$, $\cv{}_i\;\tcode{A}_{ik}$\&> == true}, otherwise
@@ -1788,7 +1788,7 @@ template<class T> struct tuple_size;
 
 \begin{itemdescr}
 \pnum
-\remarks All specializations of \tcode{tuple_size} shall satisfy the
+\remarks All specializations of \tcode{tuple_size} shall meet the
 \oldconcept{UnaryTypeTrait} requirements\iref{meta.rqmts} with a
 base characteristic of \tcode{integral_constant<size_t, N>}
 for some \tcode{N}.
@@ -1831,7 +1831,7 @@ template<class T> struct tuple_size<const volatile T>;
 Let \tcode{TS} denote \tcode{tuple_size<T>} of the \cv-unqualified type \tcode{T}.
 If the expression \tcode{TS::value} is well-formed
 when treated as an unevaluated operand, then each
-of the three templates shall satisfy the \oldconcept{UnaryTypeTrait} requirements\iref{meta.rqmts}
+of the three templates shall meet the \oldconcept{UnaryTypeTrait} requirements\iref{meta.rqmts}
 with a base characteristic of
 \begin{codeblock}
 integral_constant<size_t, TS::value>
@@ -1868,7 +1868,7 @@ template<size_t I, class T> struct tuple_element<I, const volatile T>;
 \begin{itemdescr}
 \pnum
 Let \tcode{TE} denote \tcode{tuple_element_t<I, T>} of the \cv-unqualified type \tcode{T}. Then
-each of the three templates shall satisfy the \oldconcept{TransformationTrait}
+each of the three templates shall meet the \oldconcept{TransformationTrait}
 requirements\iref{meta.rqmts} with a member typedef \tcode{type} that names the following
 type:
 
@@ -2085,7 +2085,7 @@ template<class... Types, class Alloc>
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{Alloc} shall satisfy the \oldconcept{Allocator}
+\requires \tcode{Alloc} shall meet the \oldconcept{Allocator}
 requirements (\tref{cpp17.allocator}).
 
 \pnum
@@ -2294,7 +2294,7 @@ Member \tcode{val} is provided for exposition only. When an \tcode{optional<T>} 
 \pnum
 \tcode{T} shall be an object type
 other than \cv{} \tcode{in_place_t} or \cv{} \tcode{nullopt_t}
-and shall satisfy the \oldconcept{Destructible} requirements (\tref{cpp17.destructible}).
+and shall meet the \oldconcept{Destructible} requirements (\tref{cpp17.destructible}).
 
 \rSec3[optional.ctor]{Constructors}
 
@@ -3913,7 +3913,7 @@ Any exception thrown by the value-initialization of $\tcode{T}_0$.
 \pnum
 \remarks
 This function shall be \tcode{constexpr} if and only if the
-value-initialization of the alternative type $\tcode{T}_0$ would satisfy the
+value-initialization of the alternative type $\tcode{T}_0$ would meet the
 requirements for a constexpr function.
 The expression inside \tcode{noexcept} is equivalent to
 \tcode{is_nothrow_default_constructible_v<$\tcode{T}_0$>}.
@@ -4577,7 +4577,7 @@ template<class T> struct variant_size;
 \begin{itemdescr}
 \pnum
 \remarks
-All specializations of \tcode{variant_size} shall satisfy the
+All specializations of \tcode{variant_size} shall meet the
 \oldconcept{UnaryTypeTrait} requirements\iref{meta.rqmts}
 with a base characteristic of \tcode{integral_constant<size_t, N>} for some \tcode{N}.
 \end{itemdescr}
@@ -4592,7 +4592,7 @@ template<class T> class variant_size<const volatile T>;
 \begin{itemdescr}
 \pnum
 Let \tcode{VS} denote \tcode{variant_size<T>} of the cv-unqualified
-type \tcode{T}. Then each of the three templates shall satisfy the
+type \tcode{T}. Then each of the three templates shall meet the
 \oldconcept{UnaryTypeTrait} requirements\iref{meta.rqmts} with a
 base characteristic of \tcode{integral_constant<size_t, VS::value>}.
 \end{itemdescr}
@@ -5145,7 +5145,7 @@ namespace std {
 \end{codeblock}
 
 \pnum
-An object of class \tcode{any} stores an instance of any type that satisfies the constructor requirements or it has no value,
+An object of class \tcode{any} stores an instance of any type that meets the constructor requirements or it has no value,
 and this is referred to as the \defn{state} of the class \tcode{any} object.
 The stored instance is called the \defnx{contained value}{contained value!\idxcode{any}}.
 Two states are equivalent if either they both have no value, or they both have a value and the contained values are equivalent.
@@ -5223,7 +5223,7 @@ Let \tcode{VT} be \tcode{decay_t<T>}.
 
 \pnum
 \requires
-\tcode{VT} shall satisfy the \oldconcept{CopyConstructible} requirements.
+\tcode{VT} shall meet the \oldconcept{CopyConstructible} requirements.
 
 \pnum
 \effects
@@ -5252,7 +5252,7 @@ template<class T, class... Args>
 Let \tcode{VT} be \tcode{decay_t<T>}.
 
 \pnum
-\requires \tcode{VT} shall satisfy the \oldconcept{CopyConstructible} requirements.
+\requires \tcode{VT} shall meet the \oldconcept{CopyConstructible} requirements.
 
 \pnum
 \effects Initializes the contained value as if direct-non-list-initializing an object of
@@ -5282,7 +5282,7 @@ template<class T, class U, class... Args>
 Let \tcode{VT} be \tcode{decay_t<T>}.
 
 \pnum
-\requires \tcode{VT} shall satisfy the \oldconcept{CopyConstructible} requirements.
+\requires \tcode{VT} shall meet the \oldconcept{CopyConstructible} requirements.
 
 \pnum
 \effects Initializes the contained value as if direct-non-list-initializing an object of
@@ -5366,7 +5366,7 @@ Let \tcode{VT} be \tcode{decay_t<T>}.
 
 \pnum
 \requires
-\tcode{VT} shall satisfy the \oldconcept{CopyConstructible} requirements.
+\tcode{VT} shall meet the \oldconcept{CopyConstructible} requirements.
 
 \pnum
 \effects
@@ -5402,7 +5402,7 @@ Let \tcode{VT} be \tcode{decay_t<T>}.
 
 \pnum
 \requires
-\tcode{VT} shall satisfy the \oldconcept{CopyConstructible} requirements.
+\tcode{VT} shall meet the \oldconcept{CopyConstructible} requirements.
 
 \pnum
 \effects Calls \tcode{reset()}.
@@ -5440,7 +5440,7 @@ Let \tcode{VT} be \tcode{decay_t<T>}.
 
 \pnum
 \requires
-\tcode{VT} shall satisfy the \oldconcept{CopyConstructible} requirements.
+\tcode{VT} shall meet the \oldconcept{CopyConstructible} requirements.
 
 \pnum
 \effects Calls \tcode{reset()}. Then initializes the contained value
@@ -7358,7 +7358,7 @@ namespace std {
 The \tcode{allocator_arg_t} struct is an empty class type used as a unique type to
 disambiguate constructor and function overloading. Specifically, several types (see
 \tcode{tuple}~\ref{tuple}) have constructors with \tcode{allocator_arg_t} as the first
-argument, immediately followed by an argument of a type that satisfies the
+argument, immediately followed by an argument of a type that meets the
 \oldconcept{Allocator} requirements (\tref{cpp17.allocator}).
 
 \rSec2[allocator.uses]{\tcode{uses_allocator}}
@@ -7907,7 +7907,7 @@ well-formed; otherwise, \tcode{rhs}.
 \rSec2[default.allocator]{The default allocator}
 
 \pnum
-All specializations of the default allocator satisfy the
+All specializations of the default allocator meet the
 allocator completeness requirements\iref{allocator.requirements.completeness}.
 
 \indexlibrary{\idxcode{allocator}}%
@@ -9013,7 +9013,7 @@ a value \tcode{d} of type \tcode{D} and a value
 pointer as appropriate for that deleter.
 
 \pnum
-If the deleter's type \tcode{D} is not a reference type, \tcode{D} shall satisfy
+If the deleter's type \tcode{D} is not a reference type, \tcode{D} shall meet
 the \oldconcept{Destructible} requirements (\tref{cpp17.destructible}).
 
 \pnum
@@ -9022,7 +9022,7 @@ type\iref{temp.deduct}, then \tcode{unique_ptr<T,
 D>::pointer} shall be a synonym for \tcode{remove_reference_t<D>::pointer}. Otherwise
 \tcode{unique_ptr<T, D>::pointer} shall be a synonym for \tcode{element_type*}. The type \tcode{unique_ptr<T,
 D>::pointer} shall
-satisfy the \oldconcept{NullablePointer} requirements (\tref{cpp17.nullablepointer}).
+meet the \oldconcept{NullablePointer} requirements (\tref{cpp17.nullablepointer}).
 
 \pnum
 \begin{example} Given an allocator type \tcode{X} (\tref{cpp17.allocator}) and
@@ -9041,7 +9041,7 @@ constexpr unique_ptr(nullptr_t) noexcept;
 \begin{itemdescr}
 \pnum
 \requires \tcode{D} shall
-satisfy the \oldconcept{DefaultConstructible} requirements (\tref{cpp17.defaultconstructible}),
+meet the \oldconcept{DefaultConstructible} requirements (\tref{cpp17.defaultconstructible}),
 and that construction shall not throw an exception.
 
 \pnum
@@ -9066,7 +9066,7 @@ explicit unique_ptr(pointer p) noexcept;
 \begin{itemdescr}
 \pnum
 \requires \tcode{D} shall
-satisfy the \oldconcept{DefaultConstructible} requirements (\tref{cpp17.defaultconstructible}),
+meet the \oldconcept{DefaultConstructible} requirements (\tref{cpp17.defaultconstructible}),
 and that construction shall not throw an exception.
 
 \pnum
@@ -9096,10 +9096,10 @@ unique_ptr(pointer p, remove_reference_t<D>&& d) noexcept;
 \begin{itemdescr}
 \pnum
 \requires For the first constructor, if \tcode{D} is not a reference type,
-\tcode{D} shall satisfy the \oldconcept{CopyConstructible} requirements and
+\tcode{D} shall meet the \oldconcept{CopyConstructible} requirements and
 such construction shall not exit via an exception.
 For the second constructor, if \tcode{D} is not a reference type,
-\tcode{D} shall satisfy the \oldconcept{MoveConstructible} requirements and
+\tcode{D} shall meet the \oldconcept{MoveConstructible} requirements and
 such construction shall not exit via an exception.
 
 \pnum
@@ -9145,7 +9145,7 @@ unique_ptr(unique_ptr&& u) noexcept;
 \begin{itemdescr}
 \pnum
 \requires If \tcode{D} is not a reference type,
-\tcode{D} shall satisfy the \oldconcept{MoveConstructible}
+\tcode{D} shall meet the \oldconcept{MoveConstructible}
 requirements (\tref{cpp17.moveconstructible}).
 Construction
 of the deleter from an rvalue of type \tcode{D} shall not
@@ -9234,11 +9234,11 @@ unique_ptr& operator=(unique_ptr&& u) noexcept;
 
 \begin{itemdescr}
 \pnum
-\requires If \tcode{D} is not a reference type, \tcode{D} shall satisfy the
+\requires If \tcode{D} is not a reference type, \tcode{D} shall meet the
 \oldconcept{MoveAssignable} requirements (\tref{cpp17.moveassignable}) and assignment
 of the deleter from an rvalue of type \tcode{D} shall not throw an exception.
 Otherwise, \tcode{D} is a reference type;
-\tcode{remove_reference_t<D>} shall satisfy the \oldconcept{CopyAssignable}
+\tcode{remove_reference_t<D>} shall meet the \oldconcept{CopyAssignable}
 requirements and assignment of the deleter from an
 lvalue of type \tcode{D} shall not throw an exception.
 
@@ -10172,7 +10172,7 @@ template<class D, class A> shared_ptr(nullptr_t p, D d, A a);
 initialized with \tcode{std::move(d)} shall not throw exceptions.
 The expression \tcode{d(p)}
 shall have well-defined behavior and shall not throw exceptions.
-\tcode{A} shall satisfy the \oldconcept{Allocator} requirements
+\tcode{A} shall meet the \oldconcept{Allocator} requirements
 (\tref{cpp17.allocator}).
 
 \pnum\effects  Constructs a \tcode{shared_ptr} object that owns the
@@ -10584,7 +10584,7 @@ template<class T, class A, ...>
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{A} shall satisfy the \oldconcept{Allocator}
+\requires \tcode{A} shall meet the \oldconcept{Allocator}
 requirements (\tref{cpp17.allocator}).
 
 \pnum
@@ -12339,7 +12339,7 @@ bool operator!=(const memory_resource& a, const memory_resource& b) noexcept;
 
 \pnum
 A specialization of class template \tcode{pmr::polymorphic_allocator}
-satisfies the \oldconcept{Allocator} requirements (\tref{cpp17.allocator}).
+meets the \oldconcept{Allocator} requirements (\tref{cpp17.allocator}).
 Constructed with different memory resources,
 different instances of the same specialization of \tcode{pmr::polymorphic_allocator}
 can exhibit entirely different allocation behavior.
@@ -12349,7 +12349,7 @@ even though they use the same static allocator type.
 
 \pnum
 All specializations of class template \tcode{pmr::polymorphic_allocator}
-satisfy the allocator completeness requirements\iref{allocator.requirements.completeness}.
+meet the allocator completeness requirements\iref{allocator.requirements.completeness}.
 
 \indexlibrary{\idxcode{polymorphic_allocator}}%
 \indexlibrarymember{value_type}{polymorphic_allocator}%
@@ -15345,7 +15345,7 @@ generated by \tcode{bind}. The function template \tcode{bind}
 uses \tcode{is_bind_expression} to detect subexpressions.
 
 \pnum
-Instantiations of the \tcode{is_bind_expression} template shall satisfy
+Instantiations of the \tcode{is_bind_expression} template shall meet
 the \oldconcept{UnaryTypeTrait} requirements\iref{meta.rqmts}. The implementation
 shall provide a definition that has a base characteristic of
 \tcode{true_type} if \tcode{T} is a type returned from \tcode{bind},
@@ -15369,7 +15369,7 @@ The class template \tcode{is_placeholder} can be used to detect the standard pla
 \tcode{is_placeholder} to detect placeholders.
 
 \pnum
-Instantiations of the \tcode{is_placeholder} template shall satisfy
+Instantiations of the \tcode{is_placeholder} template shall meet
 the \oldconcept{UnaryTypeTrait} requirements\iref{meta.rqmts}. The implementation
 shall provide a definition that has the base characteristic of
 \tcode{integral_constant<int, \placeholder{J}>} if \tcode{T} is the type of
@@ -15434,9 +15434,9 @@ $\tcode{TD}_i$ throws an exception.
 \tcode{fd} or of one of the values $\tcode{td}_i$ throws an exception.
 
 \pnum
-\remarks The return type shall satisfy the \oldconcept{MoveConstructible} requirements. If all
-of \tcode{FD} and $\tcode{TD}_i$ satisfy the \oldconcept{CopyConstructible} requirements, then the
-return type shall satisfy the \oldconcept{CopyConstructible} requirements. \begin{note} This implies
+\remarks The return type shall meet the \oldconcept{MoveConstructible} requirements. If all
+of \tcode{FD} and $\tcode{TD}_i$ meet the \oldconcept{CopyConstructible} requirements, then the
+return type shall meet the \oldconcept{CopyConstructible} requirements. \begin{note} This implies
 that all of \tcode{FD} and $\tcode{TD}_i$ are \oldconcept{MoveConst\-ruct\-ible}. \end{note}
 \end{itemdescr}
 
@@ -15477,9 +15477,9 @@ $\tcode{TD}_i$ throws an exception.
 \tcode{fd} or of one of the values $\tcode{td}_i$ throws an exception.
 
 \pnum
-\remarks The return type shall satisfy the \oldconcept{MoveConstructible} requirements. If all
-of \tcode{FD} and $\tcode{TD}_i$ satisfy the \oldconcept{CopyConstructible} requirements, then the
-return type shall satisfy the \oldconcept{CopyConstructible} requirements. \begin{note} This implies
+\remarks The return type shall meet the \oldconcept{MoveConstructible} requirements. If all
+of \tcode{FD} and $\tcode{TD}_i$ meet the \oldconcept{CopyConstructible} requirements, then the
+return type shall meet the \oldconcept{CopyConstructible} requirements. \begin{note} This implies
 that all of \tcode{FD} and $\tcode{TD}_i$ are \oldconcept{MoveConst\-ruct\-ible}. \end{note}
 \end{itemdescr}
 
@@ -16002,7 +16002,7 @@ provided to the function call operator.
 
 \pnum
 Each specialization of a class template specified in this subclause \ref{func.search}
-shall satisfy the \oldconcept{CopyConst\-ruct\-ible} and \oldconcept{CopyAssignable} requirements.
+shall meet the \oldconcept{CopyConst\-ruct\-ible} and \oldconcept{CopyAssignable} requirements.
 Template parameters named
 \begin{itemize}
 \item \tcode{ForwardIterator},
@@ -16014,9 +16014,9 @@ Template parameters named
 \item \tcode{BinaryPredicate}
 \end{itemize}
 of templates specified in this subclause
-\ref{func.search} shall satisfy the same requirements and semantics as
+\ref{func.search} shall meet the same requirements and semantics as
 specified in \ref{algorithms.general}.
-Template parameters named \tcode{Hash} shall satisfy the \oldconcept{Hash}
+Template parameters named \tcode{Hash} shall meet the \oldconcept{Hash}
 requirements (\tref{cpp17.hash}).
 
 \pnum
@@ -16120,7 +16120,7 @@ boyer_moore_searcher(RandomAccessIterator1 pat_first,
 \begin{itemdescr}
 \pnum
 \requires
-The value type of \tcode{RandomAccessIterator1} shall satisfy the \oldconcept{DefaultConstructible} requirements,
+The value type of \tcode{RandomAccessIterator1} shall meet the \oldconcept{DefaultConstructible} requirements,
 the \oldconcept{CopyConstructible} requirements, and the \oldconcept{CopyAssignable} requirements.
 
 \pnum
@@ -16213,7 +16213,7 @@ boyer_moore_horspool_searcher(RandomAccessIterator1 pat_first,
 \begin{itemdescr}
 \pnum
 \requires
-The value type of \tcode{RandomAccessIterator1} shall satisfy the \oldconcept{DefaultConstructible},
+The value type of \tcode{RandomAccessIterator1} shall meet the \oldconcept{DefaultConstructible},
 \oldconcept{Copy\-Constructible}, and \oldconcept{CopyAssignable} requirements.
 
 \pnum
@@ -16315,15 +16315,15 @@ any attempts to use it as a \oldconcept{Hash} will be ill-formed.
 \pnum
 An enabled specialization \tcode{hash<Key>} will:
 \begin{itemize}
-\item satisfy the \oldconcept{Hash} requirements (\tref{cpp17.hash}),
+\item meet the \oldconcept{Hash} requirements (\tref{cpp17.hash}),
 with \tcode{Key} as the function
 call argument type, the \oldconcept{Default\-Constructible} requirements (\tref{cpp17.defaultconstructible}),
 the \oldconcept{CopyAssignable} requirements (\tref{cpp17.copyassignable}),
 \item be swappable\iref{swappable.requirements} for lvalues,
-\item satisfy the requirement that if \tcode{k1 == k2} is \tcode{true}, \tcode{h(k1) == h(k2)} is
+\item meet the requirement that if \tcode{k1 == k2} is \tcode{true}, \tcode{h(k1) == h(k2)} is
 also \tcode{true}, where \tcode{h} is an object of type \tcode{hash<Key>} and \tcode{k1} and \tcode{k2}
 are objects of type \tcode{Key};
-\item satisfy the requirement that the expression \tcode{h(k)}, where \tcode{h}
+\item meet the requirement that the expression \tcode{h(k)}, where \tcode{h}
 is an object of type \tcode{hash<Key>} and \tcode{k} is an object of type
 \tcode{Key}, shall not throw an exception unless \tcode{hash<Key>} is a
 program-defined specialization that depends on at least one program-defined type.

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -514,7 +514,7 @@ throws an exception.
 \pnum
 The defaulted move and copy constructor, respectively, of \tcode{pair} shall
 be a constexpr function if and only if all required element-wise
-initializations for copy and move, respectively, would meet the
+initializations for copy and move, respectively, would satisfy the
 requirements for a constexpr function.
 
 \pnum
@@ -1186,7 +1186,7 @@ one of the types in \tcode{Types} throws an exception.
 The defaulted move and copy constructor, respectively, of
 \tcode{tuple} shall be a constexpr function if and only if all
 required element-wise initializations for copy and move, respectively,
-would meet the requirements for a constexpr function. The
+would satisfy the requirements for a constexpr function. The
 defaulted move and copy constructor of \tcode{tuple<>} shall be
 constexpr functions.
 
@@ -3913,7 +3913,7 @@ Any exception thrown by the value-initialization of $\tcode{T}_0$.
 \pnum
 \remarks
 This function shall be \tcode{constexpr} if and only if the
-value-initialization of the alternative type $\tcode{T}_0$ would meet the
+value-initialization of the alternative type $\tcode{T}_0$ would satisfy the
 requirements for a constexpr function.
 The expression inside \tcode{noexcept} is equivalent to
 \tcode{is_nothrow_default_constructible_v<$\tcode{T}_0$>}.


### PR DESCRIPTION
...instead of "satisfy".

Partially addresses #1263.