### PR TITLE
[alg.random.sample] Remove redundant requirement

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -5551,8 +5551,7 @@ template<class PopulationIterator, class SampleIterator,
   \tcode{Distance} shall be an integer type.
 \item
   \tcode{remove_reference_t<UniformRandomBitGenerator>} shall satisfy
-  the requirements of a uniform random bit generator type\iref{rand.req.urng}
-  whose return type is convertible to \tcode{Distance}.
+  the requirements of a uniform random bit generator type\iref{rand.req.urng}.
 \item
   \tcode{out} shall not be in the range \range{first}{last}.
 \end{itemize}


### PR DESCRIPTION
Per [rand.req.urng]/1, the result type of a `UniformRandomBitGenerator` must model `UnsignedIntegral`, i.e., it must be an integral type. [alg.random.sample]/1.5 requires `Distance` to be an integer type. Since all integer types are convertible to all other integer types, the result type of any `UniformRandomBitGenerator` is convertible to `Distance`. The library need not enforce the rules of the core language.