### PR TITLE
[cmp.categories] Use kebab-case for \expos enumerations

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -3951,10 +3951,10 @@ whose value typically corresponds to that of an enumerator
 from one of the following exposition-only enumerations:
 
 \begin{codeblock}
-enum class @\placeholder{eq}@ { @\placeholder{equal}@ = 0, @\placeholder{equivalent}@ = @\placeholder{equal}@,
-                @\placeholder{nonequal}@ = 1, @\placeholder{nonequivalent}@ = @\placeholder{nonequal}@ };   // \expos
-enum class @\placeholder{ord}@ { @\placeholder{less}@ = -1, @\placeholder{greater}@ = 1 };                  // \expos
-enum class @\placeholder{ncmp}@ { @\placeholder{unordered}@ = -127 };                       // \expos
+enum class @\placeholdernc{eq}@ { @\placeholdernc{equal}@ = 0, @\placeholdernc{equivalent}@ = @\placeholdernc{equal}@,
+                @\placeholdernc{nonequal}@ = 1, @\placeholdernc{nonequivalent}@ = @\placeholdernc{nonequal}@ };   // \expos
+enum class @\placeholdernc{ord}@ { @\placeholdernc{less}@ = -1, @\placeholdernc{greater}@ = 1 };                  // \expos
+enum class @\placeholdernc{ncmp}@ { @\placeholdernc{unordered}@ = -127 };                       // \expos
 \end{codeblock}
 
 \pnum

--- a/source/support.tex
+++ b/source/support.tex
@@ -3951,10 +3951,10 @@ whose value typically corresponds to that of an enumerator
 from one of the following exposition-only enumerations:
 
 \begin{codeblock}
-enum class eq { equal = 0, equivalent = equal,
-                nonequal = 1, nonequivalent = nonequal };   // \expos
-enum class ord { less = -1, greater = 1 };                  // \expos
-enum class ncmp { unordered = -127 };                       // \expos
+enum class @\placeholder{eq}@ { @\placeholder{equal}@ = 0, @\placeholder{equivalent}@ = @\placeholder{equal}@,
+                @\placeholder{nonequal}@ = 1, @\placeholder{nonequivalent}@ = @\placeholder{nonequal}@ };   // \expos
+enum class @\placeholder{ord}@ { @\placeholder{less}@ = -1, @\placeholder{greater}@ = 1 };                  // \expos
+enum class @\placeholder{ncmp}@ { @\placeholder{unordered}@ = -127 };                       // \expos
 \end{codeblock}
 
 \pnum
@@ -4000,7 +4000,7 @@ namespace std {
     int value;  // \expos
 
     // exposition-only constructor
-    constexpr explicit weak_equality(eq v) noexcept : value(int(v)) {}  // \expos
+    constexpr explicit weak_equality(@\placeholder{eq}@ v) noexcept : value(int(v)) {}  // \expos
 
   public:
     // valid values
@@ -4017,8 +4017,8 @@ namespace std {
   };
 
   // valid values' definitions
-  inline constexpr weak_equality weak_equality::equivalent(eq::equivalent);
-  inline constexpr weak_equality weak_equality::nonequivalent(eq::nonequivalent);
+  inline constexpr weak_equality weak_equality::equivalent(@\placeholder{eq}@::@\placeholder{equivalent}@);
+  inline constexpr weak_equality weak_equality::nonequivalent(@\placeholder{eq}@::@\placeholder{nonequivalent}@);
 }
 \end{codeblock}
 
@@ -4077,7 +4077,7 @@ namespace std {
     int value;  // \expos
 
     // exposition-only constructor
-    constexpr explicit strong_equality(eq v) noexcept : value(int(v)) {}    // \expos
+    constexpr explicit strong_equality(@\placeholder{eq}@ v) noexcept : value(int(v)) {}    // \expos
 
   public:
     // valid values
@@ -4099,10 +4099,10 @@ namespace std {
   };
 
   // valid values' definitions
-  inline constexpr strong_equality strong_equality::equal(eq::equal);
-  inline constexpr strong_equality strong_equality::nonequal(eq::nonequal);
-  inline constexpr strong_equality strong_equality::equivalent(eq::equivalent);
-  inline constexpr strong_equality strong_equality::nonequivalent(eq::nonequivalent);
+  inline constexpr strong_equality strong_equality::equal(@\placeholder{eq}@::@\placeholder{equal}@);
+  inline constexpr strong_equality strong_equality::nonequal(@\placeholder{eq}@::@\placeholder{nonequal}@);
+  inline constexpr strong_equality strong_equality::equivalent(@\placeholder{eq}@::@\placeholder{equivalent}@);
+  inline constexpr strong_equality strong_equality::nonequivalent(@\placeholder{eq}@::@\placeholder{nonequivalent}@);
 }
 \end{codeblock}
 
@@ -4176,11 +4176,11 @@ namespace std {
 
     // exposition-only constructors
     constexpr explicit
-      partial_ordering(eq v) noexcept : value(int(v)), is_ordered(true) {}      // \expos
+      partial_ordering(@\placeholder{eq}@ v) noexcept : value(int(v)), is_ordered(true) {}      // \expos
     constexpr explicit
-      partial_ordering(ord v) noexcept : value(int(v)), is_ordered(true) {}     // \expos
+      partial_ordering(@\placeholder{ord}@ v) noexcept : value(int(v)), is_ordered(true) {}     // \expos
     constexpr explicit
-      partial_ordering(ncmp v) noexcept : value(int(v)), is_ordered(false) {}   // \expos
+      partial_ordering(@\placeholder{ncmp}@ v) noexcept : value(int(v)), is_ordered(false) {}   // \expos
 
   public:
     // valid values
@@ -4210,10 +4210,10 @@ namespace std {
   };
 
   // valid values' definitions
-  inline constexpr partial_ordering partial_ordering::less(ord::less);
-  inline constexpr partial_ordering partial_ordering::equivalent(eq::equivalent);
-  inline constexpr partial_ordering partial_ordering::greater(ord::greater);
-  inline constexpr partial_ordering partial_ordering::unordered(ncmp::unordered);
+  inline constexpr partial_ordering partial_ordering::less(@\placeholder{ord}@::@\placeholder{less}@);
+  inline constexpr partial_ordering partial_ordering::equivalent(@\placeholder{eq}@::@\placeholder{equivalent}@);
+  inline constexpr partial_ordering partial_ordering::greater(@\placeholder{ord}@::@\placeholder{greater}@);
+  inline constexpr partial_ordering partial_ordering::unordered(@\placeholder{ncmp}@::@\placeholder{unordered}@);
 }
 \end{codeblock}
 
@@ -4321,8 +4321,8 @@ namespace std {
     int value;  // \expos
 
     // exposition-only constructors
-    constexpr explicit weak_ordering(eq v) noexcept : value(int(v)) {}  // \expos
-    constexpr explicit weak_ordering(ord v) noexcept : value(int(v)) {} // \expos
+    constexpr explicit weak_ordering(@\placeholder{eq}@ v) noexcept : value(int(v)) {}  // \expos
+    constexpr explicit weak_ordering(@\placeholder{ord}@ v) noexcept : value(int(v)) {} // \expos
 
   public:
     // valid values
@@ -4352,9 +4352,9 @@ namespace std {
   };
 
   // valid values' definitions
-  inline constexpr weak_ordering weak_ordering::less(ord::less);
-  inline constexpr weak_ordering weak_ordering::equivalent(eq::equivalent);
-  inline constexpr weak_ordering weak_ordering::greater(ord::greater);
+  inline constexpr weak_ordering weak_ordering::less(@\placeholder{ord}@::@\placeholder{less}@);
+  inline constexpr weak_ordering weak_ordering::equivalent(@\placeholder{eq}@::@\placeholder{equivalent}@);
+  inline constexpr weak_ordering weak_ordering::greater(@\placeholder{ord}@::@\placeholder{greater}@);
 }
 \end{codeblock}
 
@@ -4467,8 +4467,8 @@ namespace std {
     int value;  // \expos
 
     // exposition-only constructors
-    constexpr explicit strong_ordering(eq v) noexcept : value(int(v)) {}    // \expos
-    constexpr explicit strong_ordering(ord v) noexcept : value(int(v)) {}   // \expos
+    constexpr explicit strong_ordering(@\placeholder{eq}@ v) noexcept : value(int(v)) {}    // \expos
+    constexpr explicit strong_ordering(@\placeholder{ord}@ v) noexcept : value(int(v)) {}   // \expos
 
   public:
     // valid values
@@ -4501,10 +4501,10 @@ namespace std {
   };
 
   // valid values' definitions
-  inline constexpr strong_ordering strong_ordering::less(ord::less);
-  inline constexpr strong_ordering strong_ordering::equal(eq::equal);
-  inline constexpr strong_ordering strong_ordering::equivalent(eq::equivalent);
-  inline constexpr strong_ordering strong_ordering::greater(ord::greater);
+  inline constexpr strong_ordering strong_ordering::less(@\placeholder{ord}@::@\placeholder{less}@);
+  inline constexpr strong_ordering strong_ordering::equal(@\placeholder{eq}@::@\placeholder{equal}@);
+  inline constexpr strong_ordering strong_ordering::equivalent(@\placeholder{eq}@::@\placeholder{equivalent}@);
+  inline constexpr strong_ordering strong_ordering::greater(@\placeholder{ord}@::@\placeholder{greater}@);
 }
 \end{codeblock}
 


### PR DESCRIPTION
Affects `eq`, `ord`, and `ncmp` - as well as their enumerators - defined in [cmp.categories.pre]/1 and used throughout [cmp.categories].

Fixes #2801.