### PR TITLE
[limits.syn,numeric.limits] declare partial specializations of numeri…

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -729,6 +729,9 @@ namespace std {
 
   // \ref{numeric.limits}, class template \tcode{numeric_limits}
   template<class T> class numeric_limits;
+  template<class T> class numeric_limits<const T>;
+  template<class T> class numeric_limits<volatile T>;
+  template<class T> class numeric_limits<const volatile T>;
 
   template<> class numeric_limits<bool>;
 
@@ -888,10 +891,6 @@ namespace std {
     static constexpr bool tinyness_before = false;
     static constexpr float_round_style round_style = round_toward_zero;
   };
-
-  template<class T> class numeric_limits<const T>;
-  template<class T> class numeric_limits<volatile T>;
-  template<class T> class numeric_limits<const volatile T>;
 }
 \end{codeblock}
 

--- a/source/support.tex
+++ b/source/support.tex
@@ -729,6 +729,7 @@ namespace std {
 
   // \ref{numeric.limits}, class template \tcode{numeric_limits}
   template<class T> class numeric_limits;
+
   template<class T> class numeric_limits<const T>;
   template<class T> class numeric_limits<volatile T>;
   template<class T> class numeric_limits<const volatile T>;


### PR DESCRIPTION
…c_limits in the header synopsis

...not in the class template synopsis.