### PR TITLE
[dcl.type.elab] Mix struct/class in example

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1495,6 +1495,8 @@ declared using the \tcode{class} or \tcode{struct}
 \begin{codeblock}
 enum class E { a, b };
 enum E x = E::a;                // OK
+struct S { } s;
+class S* p = &s;                // OK
 \end{codeblock}
 \end{example}
 


### PR DESCRIPTION
Extend the example to show that the choice of `class` or `struct` in an
_elaborated-type-name_ referring to a class is not significant.