### PR TITLE
Fixed grammar of [temp.expl.spec]/18 sentence 2

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -6870,7 +6870,7 @@ unspecialized,
 except that the declaration shall not explicitly specialize a class member
 template if its enclosing class templates are not explicitly specialized
 as well.
-In such explicit specialization declaration, the keyword
+In such an explicit specialization declaration, the keyword
 \tcode{template}
 followed by a
 \grammarterm{template-parameter-list}


### PR DESCRIPTION
Added "an" before "explicit" to make the sentence grammatically correct.