### PR TITLE
[coroutine.traits.primary] Hyphenate "program-defined"

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -4912,7 +4912,7 @@ accessible member:
 Otherwise, \tcode{coroutine_traits<R,ArgTypes...>} has no members.
 
 \pnum
-Program defined specializations of this template shall define a publicly
+Program-defined specializations of this template shall define a publicly
 accessible nested type named \tcode{promise_type}.
 
 \rSec2[coroutine.handle]{Class template \tcode{coroutine_handle}}


### PR DESCRIPTION
...which is the proper spelling of this particular Word of Power.