### PR TITLE
[coroutine.handle,coroutine.handle.export.import] "static" before "constexpr"

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -4930,7 +4930,7 @@ namespace std {
 
     // \ref{coroutine.handle.export.import}, export/import
     constexpr void* address() const noexcept;
-    constexpr static coroutine_handle from_address(void* addr);
+    static constexpr coroutine_handle from_address(void* addr);
 
     // \ref{coroutine.handle.observers}, observers
     constexpr explicit operator bool() const noexcept;
@@ -4954,7 +4954,7 @@ namespace std {
     coroutine_handle& operator=(nullptr_t) noexcept;
 
     // \ref{coroutine.handle.export.import}, export/import
-    constexpr static coroutine_handle from_address(void* addr);
+    static constexpr coroutine_handle from_address(void* addr);
 
     // \ref{coroutine.handle.promise}, promise access
     Promise& promise() const;
@@ -5029,8 +5029,8 @@ constexpr void* address() const noexcept;
 
 \indexlibrarymember{from_address}{coroutine_handle}%
 \begin{itemdecl}
-constexpr static coroutine_handle<> coroutine_handle<>::from_address(void* addr);
-constexpr static coroutine_handle<Promise> coroutine_handle<Promise>::from_address(void* addr);
+static constexpr coroutine_handle<> coroutine_handle<>::from_address(void* addr);
+static constexpr coroutine_handle<Promise> coroutine_handle<Promise>::from_address(void* addr);
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Per the Specification Style Guidelines.