### PR TITLE
[iterator.operations] Clarify the observable side-effects of `distance`.

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -2614,8 +2614,16 @@ the \oldconcept{RandomAccessIterator} requirements and
 \pnum
 \effects
 If \tcode{InputIterator} meets the \oldconcept{RandomAccessIterator} requirements,
-returns \tcode{(last - first)}; otherwise, returns
-the number of increments needed to get from
+returns \tcode{(last - first)}; otherwise, equivalent to:
+\begin{codeblock}
+typename iterator_traits<InputIterator>::difference_type diff = 0;
+InputIterator i = first;
+while (i != last) {
+  ++i;
+  ++diff;
+}
+return diff;
+\end{codeblock}
 \tcode{first}
 to
 \tcode{last}.

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -2624,9 +2624,6 @@ while (i != last) {
 }
 return diff;
 \end{codeblock}
-\tcode{first}
-to
-\tcode{last}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{next}}%

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -2617,9 +2617,8 @@ If \tcode{InputIterator} meets the \oldconcept{RandomAccessIterator} requirement
 returns \tcode{(last - first)}; otherwise, equivalent to:
 \begin{codeblock}
 typename iterator_traits<InputIterator>::difference_type diff = 0;
-InputIterator i = first;
-while (i != last) {
-  ++i;
+while (first != last) {
+  ++first;
   ++diff;
 }
 return diff;


### PR DESCRIPTION
The standard claims that for non-Random-Access iterators, `distance` "uses ++". I guess the reader is supposed to infer from this that you can't continue using an iterator that doesn't have a multi-pass guarantee after passing it to `distance`, but it could be more clear. Especially since `distance(a, a)` *won't* actually invalidate anything (at any rate, not in libc++ and I'd be quite surprised if it did in any standard library implementation)

I believe that this lack of clarity in the standard is an editorial oversight, and that the committee's intended meaning is that `distance(first, last)` has the same observable side-effects as calling pre-increment `++` on first until it equals last.

Fixes #2807.