### PR TITLE
[range.filter.iterator] Add bounds checking to operator--

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2755,7 +2755,7 @@ constexpr iterator& operator--() requires BidirectionalRange<V>;
 \begin{codeblock}
 do
   --current_;
-while (!invoke(*parent_->pred_, *current_));
+while (current_ != ranges::begin(parent_->base_) && !invoke(*parent_->pred_, *current_));
 return *this;
 \end{codeblock}
 \end{itemdescr}


### PR DESCRIPTION
Missing bounds check. UB ensues if no element is filtered, for example.