### PR TITLE
[istream.sentry] Remove unreferenced typedef-name traits_type

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -4425,7 +4425,6 @@ Exchanges the values returned by \tcode{gcount()} and
 namespace std {
   template<class charT, class traits = char_traits<charT>>
   class basic_istream<charT, traits>::sentry {
-    using traits_type = traits;
     bool ok_; // \expos
   public:
     explicit sentry(basic_istream<charT, traits>& is, bool noskipws = false);


### PR DESCRIPTION
I have no idea how this got here - it was in the initial git commit - or why it isn't `\\expos`, but in any case it's unused.