### PR TITLE
change chi_squared_distribution's integer literal to floating literal

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -5595,8 +5595,8 @@ template<class RealType = double>
     using param_type  = @\unspec@;
 
     // constructor and reset functions
-    fisher_f_distribution() : fisher_f_distribution(1) {}
-    explicit fisher_f_distribution(RealType m, RealType n = 1);
+    fisher_f_distribution() : fisher_f_distribution(1.0) {}
+    explicit fisher_f_distribution(RealType m, RealType n = 1.0);
     explicit fisher_f_distribution(const param_type& parm);
     void reset();
 
@@ -5682,7 +5682,7 @@ template<class RealType = double>
     using param_type  = @\unspec@;
 
     // constructor and reset functions
-    student_t_distribution() : student_t_distribution(1) {}
+    student_t_distribution() : student_t_distribution(1.0) {}
     explicit student_t_distribution(RealType n);
     explicit student_t_distribution(const param_type& parm);
     void reset();

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -5435,7 +5435,7 @@ template<class RealType = double>
     using param_type  = @\unspec@;
 
     // constructor and reset functions
-    chi_squared_distribution() : chi_squared_distribution(1) {}
+    chi_squared_distribution() : chi_squared_distribution(1.0) {}
     explicit chi_squared_distribution(RealType n);
     explicit chi_squared_distribution(const param_type& parm);
     void reset();


### PR DESCRIPTION
chi_squared_distribution's default constructor has delegating constructor with argument of integer literal `1`. But its type supposed to be the floating point types. Other distributions use floating literals in similar cases. So the suggested change.