### PR TITLE
"Template template arguments" contributing to ADL?

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1692,8 +1692,7 @@ and a set of zero or more
 to be considered.
 The sets of namespaces and entities
 are determined entirely by
-the types of the function arguments
-(and the namespace of any template template argument).
+the types of the function arguments.
 Typedef names and \grammarterm{using-declaration}{s}
 used to specify the types
 do not contribute to this set.
@@ -1712,14 +1711,9 @@ Its associated namespaces are
 the innermost enclosing namespaces of its associated entities.
 Furthermore, if \tcode{T} is a class template specialization,
 its associated namespaces and entities also include:
-the namespaces and entities
-associated with the types of the template arguments
-provided for template type parameters
-(excluding template template parameters);
-the templates used as template template arguments;
+the namespaces and entities associated with the types used as template type arguments;
 the namespaces of which any template template arguments are members; and the
-classes of which any member templates used as template template
-arguments are members.
+classes of which any member templates used as template template arguments are members.
 \begin{note}
 Non-type template arguments do not
 contribute to the set of associated namespaces.


### PR DESCRIPTION
Discussed on Slack with @k-ballo and we decided we have no idea what the parenthesized wording here is supposed to mean; therefore I wildly propose that we just strike it. @zygoloid, please help prove me wrong!

Furthermore, I claim with stronger confidence that the phrase _"the templates used as template template arguments"_ is redundant, given the following phrases _"the namespaces of which any template template arguments are members; and the classes of which any member templates used as template template arguments are members."_ I don't think it is meaningful for a _template itself_ to be an associated entity.

K-ballo did find this completely crazy example which is supported by GCC (but not Clang, ICC, or MSVC):

```
// https://godbolt.org/z/zw8WAs
namespace A {
  template <class>
  void otherfun() {}
}

namespace B {
  class T;
  void call(void(*)()) {}
}

int main() {
    call(A::otherfun<B::T>);
}
```

Here, the type of `A::otherfun<B::T>` is unknown (because it's an overload set); but GCC believes that `B` is an associated namespace (and `A` is *not* an associated namespace), presumably somewhat on the basis of the extremely confusing wording touched by this PR.