### PR TITLE
[basic.lookup.elab] Clarify example to refer to injected-class-name

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2343,11 +2343,13 @@ If the \grammarterm{elaborated-type-specifier} has a
 described in~\ref{basic.lookup.qual}, but ignoring any non-type names
 that have been declared. If the name lookup does not find a previously
 declared \grammarterm{type-name}, the \grammarterm{elaborated-type-specifier}
-is ill-formed. \begin{example}
+is ill-formed.
 
+\pnum
+\begin{example}
 \begin{codeblock}
 struct Node {
-  struct Node* Next;            // OK: Refers to \tcode{Node} at global scope
+  struct Node* Next;            // OK: Refers to injected-class-name \tcode{Node}
   struct Data* Data;            // OK: Declares type \tcode{Data} at global scope and member \tcode{Data}
 };
 


### PR DESCRIPTION
Fixes #2802.