### PR TITLE
[equal.range] Fix formatting of 'Returns' clause.

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -6481,13 +6481,15 @@ for the overloads in namespace \tcode{std}.
 \item
 For the overloads in namespace \tcode{std}:
 \begin{codeblock}
-\{lower_bound(first, last, value, comp),
- upper_bound(first, last, value, comp)\}
+{lower_bound(first, last, value, comp),
+ upper_bound(first, last, value, comp)}
 \end{codeblock}
 \item
 For the overloads in namespace \tcode{ranges}:
-\{ranges::lower_bound(first, last, value, comp, proj),
- ranges::upper_bound(first, last, value, comp, proj)\}
+\begin{codeblock}
+{ranges::lower_bound(first, last, value, comp, proj),
+ ranges::upper_bound(first, last, value, comp, proj)}
+\end{codeblock}
 \end{itemize}
 
 \pnum


### PR DESCRIPTION
Fixes #2821.