### PR TITLE
add forward declaration of atomic class for atomic<shared_ptr<T>> (P0718R2)

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -7004,6 +7004,7 @@ namespace std {
   template<class T> struct hash<shared_ptr<T>>;
 
   // \ref{util.smartptr.atomic}, atomic smart pointers
+  template<class T> struct atomic;
   template<class T> struct atomic<shared_ptr<T>>;
   template<class T> struct atomic<weak_ptr<T>>;
 }


### PR DESCRIPTION
http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0718r2.html

Or, I think the synopsis needs forward declaration of `atomic` class for specialization.