### PR TITLE
[fs.rec.dir.itr.members] change \ensures to \remarks for pop()

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -14314,13 +14314,13 @@ void pop(error_code& ec);
   iterated over, and continue iteration over the parent directory.
 
 \pnum
-\ensures Any copies of the previous value of \tcode{*this}
-are no longer required
-to be dereferenceable nor to be in the domain of \tcode{==}.
-
-\pnum
 \throws As specified in~\ref{fs.err.report}.
 \end{itemdescr}
+
+\pnum
+\remarks Any copies of the previous value of \tcode{*this}
+are no longer required
+to be dereferenceable nor to be in the domain of \tcode{==}.
 
 \indexlibrarymember{disable_recursion_pending}{recursive_directory_iterator}%
 \begin{itemdecl}


### PR DESCRIPTION
As discussed on the LWG reflector, it doesn't make sense to state this as a postcondition of the function.