### PR TITLE
[char.traits.specializations.char8.t] Make all members constexpr.

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -333,9 +333,9 @@ namespace std {
     static constexpr size_t length(const char_type* s);
     static constexpr const char_type* find(const char_type* s, size_t n,
                                            const char_type& a);
-    static char_type* move(char_type* s1, const char_type* s2, size_t n);
-    static char_type* copy(char_type* s1, const char_type* s2, size_t n);
-    static char_type* assign(char_type* s, size_t n, char_type a);
+    static constexpr char_type* move(char_type* s1, const char_type* s2, size_t n);
+    static constexpr char_type* copy(char_type* s1, const char_type* s2, size_t n);
+    static constexpr char_type* assign(char_type* s, size_t n, char_type a);
     static constexpr int_type not_eof(int_type c) noexcept;
     static constexpr char_type to_char_type(int_type c) noexcept;
     static constexpr int_type to_int_type(char_type c) noexcept;


### PR DESCRIPTION
Fix missed application of P1032R1 to the result of applying P0482R6;
both papers were moved at the 2018-11 meeting.

Fixes #2795.