### PR TITLE
[std] Do not use teletype spaces in BNF

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -476,7 +476,7 @@ if its \grammarterm{template-name} names a class template.
 
 \begin{bnf}
 \nontermdef{pure-specifier}\br
-    \terminal{= 0}
+    \terminal{=} \terminal{0}
 \end{bnf}
 
 \pnum

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2964,7 +2964,7 @@ where
 has the form
 
 \begin{ncsimplebnf}
-\terminal{D1 [} \opt{constant-expression} \terminal{]} \opt{attribute-specifier-seq}
+\terminal{D1} \terminal{[} \opt{constant-expression} \terminal{]} \opt{attribute-specifier-seq}
 \end{ncsimplebnf}
 
 and the type of the identifier in the declaration
@@ -3210,7 +3210,7 @@ where
 \tcode{D}
 has the form
 \begin{ncsimplebnf}
-\terminal{D1 (} parameter-declaration-clause \terminal{)} \opt{cv-qualifier-seq}\br
+\terminal{D1} \terminal{(} parameter-declaration-clause \terminal{)} \opt{cv-qualifier-seq}\br
 \bnfindent\opt{ref-qualifier} \opt{noexcept-specifier} \opt{attribute-specifier-seq}
 \end{ncsimplebnf}
 and the type of the contained
@@ -3247,7 +3247,7 @@ where
 has the form
 
 \begin{ncsimplebnf}
-\terminal{D1 (} parameter-declaration-clause \terminal{)} \opt{cv-qualifier-seq}\br
+\terminal{D1} \terminal{(} parameter-declaration-clause \terminal{)} \opt{cv-qualifier-seq}\br
 \bnfindent\opt{ref-qualifier} \opt{noexcept-specifier} \opt{attribute-specifier-seq} trailing-return-type
 \end{ncsimplebnf}
 
@@ -3285,7 +3285,7 @@ A type of either form is a \term{function type}.\footnote{As indicated by syntax
 \begin{bnf}
 \nontermdef{parameter-declaration-clause}\br
     \opt{parameter-declaration-list} \opt{\terminal{...}}\br
-    parameter-declaration-list \terminal{, ...}
+    parameter-declaration-list \terminal{,} \terminal{...}
 \end{bnf}
 
 \begin{bnf}
@@ -6277,7 +6277,7 @@ A coroutine behaves as if its \grammarterm{function-body} were replaced by:
 % FIXME: \bnfindent \exposid{promise}\terminal{.get_return_object()} \terminal{;}
 % ... except that it's not a discarded-value expression
 \bnfindent \terminal{co_await} \terminal{\exposid{promise}.initial_suspend()} \terminal{;}\br
-\bnfindent \terminal{try \{}\br
+\bnfindent \terminal{try} \terminal{\{}\br
 \bnfindent\bnfindent function-body\br
 \bnfindent \terminal{\} catch ( ... ) \{}\br
 \bnfindent\bnfindent \terminal{\exposid{promise}.unhandled_exception()} \terminal{;}\br
@@ -6626,7 +6626,7 @@ constants. Its name becomes an \grammarterm{enum-name} within its scope.
 \begin{bnf}
 \nontermdef{enum-specifier}\br
     enum-head \terminal{\{} \opt{enumerator-list} \terminal{\}}\br
-    enum-head \terminal{\{} enumerator-list \terminal{, \}}
+    enum-head \terminal{\{} enumerator-list \terminal{,} \terminal{\}}
 \end{bnf}
 
 \begin{bnf}
@@ -7141,7 +7141,7 @@ An \grammarterm{unnamed-namespace-definition} behaves as if it were
 replaced by
 
 \begin{ncsimplebnf}
-\opt{\keyword{inline}} \keyword{namespace} \exposid{unique} \terminal{\{ /* empty body */ \}}\br
+\opt{\keyword{inline}} \keyword{namespace} \exposid{unique} \terminal{\{} \terminal{/* empty body */} \terminal{\}}\br
 \keyword{using} \keyword{namespace} \exposid{unique} \terminal{;}\br
 \keyword{namespace} \exposid{unique} \terminal{\{} namespace-body \terminal{\}}
 \end{ncsimplebnf}
@@ -8055,7 +8055,7 @@ An \tcode{asm} declaration has the form
 
 \begin{bnf}
 \nontermdef{asm-definition}\br
-    \opt{attribute-specifier-seq} \keyword{asm} \terminal{(} string-literal \terminal{) ;}
+    \opt{attribute-specifier-seq} \keyword{asm} \terminal{(} string-literal \terminal{)} \terminal{;}
 \end{bnf}
 
 The \tcode{asm} declaration is conditionally-supported; its meaning is

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -38,7 +38,7 @@ or in functions called from the handler's try block.
 %
 \begin{bnf}
 \nontermdef{handler}\br
-    \terminal{catch (} exception-declaration \terminal{)} compound-statement
+    \terminal{catch} \terminal{(} exception-declaration \terminal{)} compound-statement
 \end{bnf}
 
 \begin{bnf}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1966,7 +1966,7 @@ named in a friend declaration\iref{class.friend}.
     identifier\br
     \terminal{\&} identifier\br
     \keyword{this}\br
-    \terminal{* this}
+    \terminal{*} \terminal{this}
 \end{bnf}
 
 \begin{bnf}
@@ -2820,14 +2820,14 @@ Postfix expressions group left-to-right.
     typename-specifier \terminal{(} \opt{expression-list} \terminal{)}\br
     simple-type-specifier braced-init-list\br
     typename-specifier braced-init-list\br
-    postfix-expression \opt{\terminal{. template}} id-expression\br
-    postfix-expression \opt{\terminal{-> template}} id-expression\br
+    postfix-expression \opt{\terminal{.} \terminal{template}} id-expression\br
+    postfix-expression \opt{\terminal{->} \terminal{template}} id-expression\br
     postfix-expression \terminal{++}\br
     postfix-expression \terminal{-{-}}\br
-    \keyword{dynamic_cast} \terminal{<} type-id \terminal{> (} expression \terminal{)}\br
-    \keyword{static_cast} \terminal{<} type-id \terminal{> (} expression \terminal{)}\br
-    \keyword{reinterpret_cast} \terminal{<} type-id \terminal{> (} expression \terminal{)}\br
-    \keyword{const_cast} \terminal{<} type-id \terminal{> (} expression \terminal{)}\br
+    \keyword{dynamic_cast} \terminal{<} type-id \terminal{>} \terminal{(} expression \terminal{)}\br
+    \keyword{static_cast} \terminal{<} type-id \terminal{>} \terminal{(} expression \terminal{)}\br
+    \keyword{reinterpret_cast} \terminal{<} type-id \terminal{>} \terminal{(} expression \terminal{)}\br
+    \keyword{const_cast} \terminal{<} type-id \terminal{>} \terminal{(} expression \terminal{)}\br
     \keyword{typeid} \terminal{(} expression \terminal{)}\br
     \keyword{typeid} \terminal{(} type-id \terminal{)}
 \end{bnf}
@@ -5137,7 +5137,7 @@ object\iref{intro.object} or array created by a
 \begin{bnf}
 \nontermdef{delete-expression}\br
     \opt{\terminal{::}} \keyword{delete} cast-expression\br
-    \opt{\terminal{::}} \keyword{delete} \terminal{[ ]} cast-expression
+    \opt{\terminal{::}} \keyword{delete} \terminal{[} \terminal{]} cast-expression
 \end{bnf}
 
 The first alternative is a

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -456,7 +456,7 @@ Iteration statements specify looping.
 \begin{bnf}
 \nontermdef{iteration-statement}\br
     \keyword{while} \terminal{(} condition \terminal{)} statement\br
-    \keyword{do} statement \keyword{while} \terminal{(} expression \terminal{) ;}\br
+    \keyword{do} statement \keyword{while} \terminal{(} expression \terminal{)} \terminal{;}\br
     \keyword{for} \terminal{(} init-statement \opt{condition} \terminal{;} \opt{expression} \terminal{)} statement\br
     \keyword{for} \terminal{(} \opt{init-statement} for-range-declaration \terminal{:} for-range-initializer \terminal{)} statement
 \end{bnf}
@@ -538,7 +538,7 @@ declaration\iref{basic.scope.pdecl} to the end of the \tcode{while}
 \begin{ncsimplebnf}
 \exposid{label} \terminal{:}\br
 \terminal{\{}\br
-\bnfindent \keyword{if} \terminal{(} condition \terminal{) \{}\br
+\bnfindent \keyword{if} \terminal{(} condition \terminal{)} \terminal{\{}\br
 \bnfindent \bnfindent statement\br
 \bnfindent \bnfindent \keyword{goto} \exposid{label} \terminal{;}\br
 \bnfindent \terminal{\}}\br
@@ -591,7 +591,7 @@ is equivalent to
 \begin{ncsimplebnf}
 \terminal{\{}\br
 \bnfindent init-statement\br
-\bnfindent \keyword{while} \terminal{(} condition \terminal{) \{}\br
+\bnfindent \keyword{while} \terminal{(} condition \terminal{)} \terminal{\{}\br
 \bnfindent\bnfindent statement\br
 \bnfindent\bnfindent expression \terminal{;}\br
 \bnfindent \terminal{\}}\br
@@ -652,8 +652,8 @@ is equivalent to
 \bnfindent \keyword{auto} \terminal{\&\&}\exposid{range} \terminal{=} for-range-initializer \terminal{;}\br
 \bnfindent \keyword{auto} \exposid{begin} \terminal{=} begin-expr \terminal{;}\br
 \bnfindent \keyword{auto} \exposid{end} \terminal{=} end-expr \terminal{;}\br
-\bnfindent \keyword{for} \terminal{( ;} \exposid{begin} \terminal{!=} \exposid{end}\terminal{; ++}\exposid{begin} \terminal{) \{}\br
-\bnfindent\bnfindent for-range-declaration \terminal{= *} \exposid{begin} \terminal{;}\br
+\bnfindent \keyword{for} \terminal{(} \terminal{;} \exposid{begin} \terminal{!=} \exposid{end}\terminal{;} \terminal{++}\exposid{begin} \terminal{)} \terminal{\{}\br
+\bnfindent\bnfindent for-range-declaration \terminal{=} \terminal{*} \exposid{begin} \terminal{;}\br
 \bnfindent\bnfindent statement\br
 \bnfindent \terminal{\}}\br
 \terminal{\}}
@@ -893,7 +893,7 @@ Let \placeholder{p} be an lvalue naming the coroutine
 promise object\iref{dcl.fct.def.coroutine}.
 A \tcode{co_return} statement is equivalent to:
 \begin{ncsimplebnf}
-\terminal{\{} S\terminal{; goto} \exposid{final-suspend}\terminal{;} \terminal{\}}
+\terminal{\{} S\terminal{;} \terminal{goto} \exposid{final-suspend}\terminal{;} \terminal{\}}
 \end{ncsimplebnf}
 
 where \exposid{final-suspend} is the exposition-only label

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -5122,10 +5122,10 @@ is dependent, even if any subexpression is type-dependent:
 simple-type-specifier \terminal{(} \opt{expression-list} \terminal{)}\br
 \opt{\terminal{::}} \keyword{new} \opt{new-placement} new-type-id \opt{new-initializer}\br
 \opt{\terminal{::}} \keyword{new} \opt{new-placement} \terminal{(} type-id \terminal{)} \opt{new-initializer}\br
-\keyword{dynamic_cast} \terminal{<} type-id \terminal{> (} expression \terminal{)}\br
-\keyword{static_cast} \terminal{<} type-id \terminal{> (} expression \terminal{)}\br
-\keyword{const_cast} \terminal{<} type-id \terminal{> (} expression \terminal{)}\br
-\keyword{reinterpret_cast} \terminal{<} type-id \terminal{> (} expression \terminal{)}\br
+\keyword{dynamic_cast} \terminal{<} type-id \terminal{>} \terminal{(} expression \terminal{)}\br
+\keyword{static_cast} \terminal{<} type-id \terminal{>} \terminal{(} expression \terminal{)}\br
+\keyword{const_cast} \terminal{<} type-id \terminal{>} \terminal{(} expression \terminal{)}\br
+\keyword{reinterpret_cast} \terminal{<} type-id \terminal{>} \terminal{(} expression \terminal{)}\br
 \terminal{(} type-id \terminal{)} cast-expression
 \end{ncsimplebnf}
 
@@ -5142,7 +5142,7 @@ literal\br
 \keyword{typeid} \terminal{(} expression \terminal{)}\br
 \keyword{typeid} \terminal{(} type-id \terminal{)}\br
 \opt{\terminal{::}} \keyword{delete} cast-expression\br
-\opt{\terminal{::}} \keyword{delete} \terminal{[ ]} cast-expression\br
+\opt{\terminal{::}} \keyword{delete} \terminal{[} \terminal{]} cast-expression\br
 \keyword{throw} \opt{assignment-expression}\br
 \keyword{noexcept} \terminal{(} expression \terminal{)}
 \end{ncsimplebnf}
@@ -5249,9 +5249,9 @@ is value-dependent:
 
 \begin{ncsimplebnf}
 simple-type-specifier \terminal{(} \opt{expression-list} \terminal{)}\br
-\keyword{static_cast} \terminal{<} type-id \terminal{> (} expression \terminal{)}\br
-\keyword{const_cast} \terminal{<} type-id \terminal{> (} expression \terminal{)}\br
-\keyword{reinterpret_cast} \terminal{<} type-id \terminal{> (} expression \terminal{)}\br
+\keyword{static_cast} \terminal{<} type-id \terminal{>} \terminal{(} expression \terminal{)}\br
+\keyword{const_cast} \terminal{<} type-id \terminal{>} \terminal{(} expression \terminal{)}\br
+\keyword{reinterpret_cast} \terminal{<} type-id \terminal{>} \terminal{(} expression \terminal{)}\br
 \terminal{(} type-id \terminal{)} cast-expression
 \end{ncsimplebnf}
 
@@ -6496,7 +6496,7 @@ that is:
 
 \begin{bnf}
 \nontermdef{explicit-specialization}\br
-  \keyword{template} \terminal{< >} declaration
+  \keyword{template} \terminal{<} \terminal{>} declaration
 \end{bnf}
 
 \begin{example}
@@ -8988,7 +8988,7 @@ any deduction guides declared for the class template are considered.
 
 \begin{bnf}
 \nontermdef{deduction-guide}\br
-    \opt{\keyword{explicit}} template-name \terminal{(} parameter-declaration-clause \terminal{) ->} simple-template-id \terminal{;}
+    \opt{\keyword{explicit}} template-name \terminal{(} parameter-declaration-clause \terminal{)} \terminal{->} simple-template-id \terminal{;}
 \end{bnf}
 
 \pnum


### PR DESCRIPTION
Fixes #2788.