### PR TITLE
[cstdio.syn] Rename parameter name of function "rename"

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -15983,7 +15983,7 @@ namespace std {
 
 namespace std {
   int remove(const char* filename);
-  int rename(const char* old, const char* new);
+  int rename(const char* old_p, const char* new_p);
   FILE* tmpfile();
   char* tmpnam(char* s);
   int fclose(FILE* stream);


### PR DESCRIPTION
The second parameter name "new" of function "rename" is a keyword, so it should be renamed.