### PR TITLE
[expos.only.func] Add library index entry for decay-copy

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -712,6 +712,7 @@ The declaration of such a function is followed by a comment ending in \expos.
 \pnum
 The following function is defined for exposition only
 to aid in the specification of the library:
+\indexlibrary{decay-copy@\tcode{\placeholder{decay-copy}}}%
 \begin{codeblock}
 template<class T> constexpr decay_t<T> @\placeholdernc{decay-copy}@(T&& v)
     noexcept(is_nothrow_convertible_v<T, decay_t<T>>)           // \expos


### PR DESCRIPTION
Following the same principle as locating GENERALIZED_SUM in
the library index, add an entry for the exposition-only function
decay-copy, which is used to specify several parts of the library
quite remote from where it is now defined.