### PR TITLE
[basic.life]/6 Remove erroneous comma in description of treatment of storage out of lifetime

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3148,7 +3148,7 @@ For an object under construction or destruction, see~\ref{class.cdtor}.
 Otherwise, such
 a pointer refers to allocated
 storage\iref{basic.stc.dynamic.allocation}, and using the pointer as
-if the pointer were of type \tcode{void*}, is
+if the pointer were of type \tcode{void*} is
 well-defined. Indirection through such a pointer is permitted but the resulting lvalue may only be used in
 limited ways, as described below. The
 program has undefined behavior if:


### PR DESCRIPTION
Intention is to allow pointer to storage out of lifetime to be treated as `void*` in a well-defined manner. The erroneous comma makes the sentence gramatically incorrect.