### PR TITLE
[dcl.stc,dcl.type.cv] Avoid redundancy when specifying 'mutable'.

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -491,10 +491,12 @@ class X {
 \end{example}
 
 \pnum
+\begin{note}
 The \tcode{mutable} specifier on a class data member nullifies a
 \tcode{const} specifier applied to the containing class object and
 permits modification of the mutable class member even though the rest of
-the object is const\iref{dcl.type.cv}.
+the object is const~(\ref{basic.type.qualifier}, \ref{dcl.type.cv}).
+\end{note}
 
 \rSec2[dcl.fct.spec]{Function specifiers}%
 \indextext{specifier!function}%
@@ -1214,8 +1216,7 @@ subverted without casting\iref{expr.const.cast}.
 
 \pnum
 \indextext{const object!undefined change to}%
-Except that any class member declared \tcode{mutable}\iref{dcl.stc}
-can be modified, any attempt to modify~(\ref{expr.ass},
+Any attempt to modify~(\ref{expr.ass},
 \ref{expr.post.incr}, \ref{expr.pre.incr}) a
 const object\iref{basic.type.qualifier} during its
 lifetime\iref{basic.life} results in undefined behavior.


### PR DESCRIPTION
Fixes #2837.