### PR TITLE
[macros] Adjust \tref to enlarge active link text.

### DIFF
--- a/source/macros.tex
+++ b/source/macros.tex
@@ -272,7 +272,7 @@
 \newcommand{\iref}[1]{\nolinebreak[3] (\ref{#1})}
 
 %% Inline non-parenthesized table reference (override memoir's \tref)
-\renewcommand{\tref}[1]{\tablerefname \nolinebreak[3] \ref{tab:#1}}
+\renewcommand{\tref}[1]{\hyperref[tab:#1]{\tablerefname \nolinebreak[3] \ref*{tab:#1}}}
 
 %% NTBS, etc.
 \newcommand{\NTS}[1]{\textsc{#1}}


### PR DESCRIPTION
Fixes #2835.

No layout differences (checked via "diffpdf").