### PR TITLE
[namespace.def]/1 Remove redundant statement

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -7006,8 +7006,7 @@ see~\ref{basic.scope.namespace}.
 \end{bnf}
 
 \pnum
-Every \grammarterm{namespace-definition} shall appear in the global scope
-or in a namespace scope\iref{basic.scope.namespace}.
+Every \grammarterm{namespace-definition} shall appear at namespace scope\iref{basic.scope.namespace}.
 
 \pnum
 In a \grammarterm{named-namespace-definition},


### PR DESCRIPTION
[[namespace.def]/1](http://eel.is/c++draft/basic.namespace#namespace.def-1) states: 
> Every namespace-definition shall appear in the global scope or in a namespace scope

This is redundant, as global scope is a namespace. This could confuse readers to think that these are two separate things, when they in-fact are not. 

Proposed change is to remove "in the global scope".