### PR TITLE
[dcl.init.ref] References are bound to objects and functions, not expressions

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5256,6 +5256,9 @@ void f() {
 \end{example}
 
 \pnum
+A reference is said to be \defn{bound} to an object or function \tcode{E} when it is initialized to refer to \tcode{E}.
+
+\pnum
 A reference cannot be changed to refer to another object after initialization.
 \indextext{assignment!reference}%
 \begin{note}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5324,8 +5324,8 @@ function\iref{class.conv.fct} returning a reference type.}
 functions\iref{over.match.ref} and choosing the best one through overload
 resolution\iref{over.match}),
 \end{itemize}
-then the reference is bound to the initializer expression lvalue in the
-first case and to the lvalue result of the conversion
+then the reference is bound to the object or function that the initializer expression refers to in the
+first case and to the the object that the lvalue result of the conversion refers to
 in the second case (or, in either case, to the appropriate base class subobject of the object).
 \begin{note}
 The usual lvalue-to-rvalue\iref{conv.lval}, array-to-pointer\iref{conv.array},
@@ -5386,8 +5386,8 @@ If the converted initializer is a prvalue,
 its type \tcode{T4} is adjusted to type ``\cvqual{cv1} \tcode{T4}''\iref{conv.qual}
 and the temporary materialization conversion\iref{conv.rval} is applied.
 In any case,
-the reference is bound to the resulting glvalue
-(or to an appropriate base class subobject).
+the reference is bound to the object or function that the resulting glvalue
+refers to (or to an appropriate base class subobject).
 
 \begin{example}
 
@@ -5429,7 +5429,7 @@ Otherwise,
 the initializer expression is implicitly converted to a prvalue
 of type ``\cvqual{cv1} \tcode{T1}''.
 The temporary materialization conversion is applied and the reference is
-bound to the result.
+bound to the object that the resulting xvalue refers to.
 \end{itemize}
 
 If

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5324,8 +5324,8 @@ function\iref{class.conv.fct} returning a reference type.}
 functions\iref{over.match.ref} and choosing the best one through overload
 resolution\iref{over.match}),
 \end{itemize}
-then the reference is bound to the object or function that the initializer expression refers to in the
-first case and to the the object that the lvalue result of the conversion refers to
+then the reference is bound to the object or function to which the initializer expression refers in the
+first case and to the object to which the lvalue result of the conversion refers
 in the second case (or, in either case, to the appropriate base class subobject of the object).
 \begin{note}
 The usual lvalue-to-rvalue\iref{conv.lval}, array-to-pointer\iref{conv.array},
@@ -5386,8 +5386,8 @@ If the converted initializer is a prvalue,
 its type \tcode{T4} is adjusted to type ``\cvqual{cv1} \tcode{T4}''\iref{conv.qual}
 and the temporary materialization conversion\iref{conv.rval} is applied.
 In any case,
-the reference is bound to the object or function that the resulting glvalue
-refers to (or to an appropriate base class subobject).
+the reference is bound to the object or function to which the resulting glvalue
+refers (or to an appropriate base class subobject).
 
 \begin{example}
 
@@ -5429,7 +5429,7 @@ Otherwise,
 the initializer expression is implicitly converted to a prvalue
 of type ``\cvqual{cv1} \tcode{T1}''.
 The temporary materialization conversion is applied and the reference is
-bound to the object that the resulting xvalue refers to.
+bound to the object to which the resulting xvalue refers.
 \end{itemize}
 
 If


### PR DESCRIPTION
Proposed fix to close #2855 