### PR TITLE
[iterators] Add "ranges::" for "iterator_t"

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -323,7 +323,7 @@ namespace std {
   template<class Container> class insert_iterator;
   template<class Container>
     constexpr insert_iterator<Container>
-      inserter(Container& x, iterator_t<Container> i);
+      inserter(Container& x, ranges::iterator_t<Container> i);
 
   // \ref{move.iterators}, move iterators and sentinels
   template<class Iterator> class move_iterator;
@@ -3747,7 +3747,7 @@ namespace std {
   class insert_iterator {
   protected:
     Container* container = nullptr;
-    iterator_t<Container> iter = iterator_t<Container>();
+    ranges::iterator_t<Container> iter = ranges::iterator_t<Container>();
 
   public:
     using iterator_category = output_iterator_tag;
@@ -3758,7 +3758,7 @@ namespace std {
     using container_type    = Container;
 
     insert_iterator() = default;
-    constexpr insert_iterator(Container& x, iterator_t<Container> i);
+    constexpr insert_iterator(Container& x, ranges::iterator_t<Container> i);
     constexpr insert_iterator& operator=(const typename Container::value_type& value);
     constexpr insert_iterator& operator=(typename Container::value_type&& value);
 
@@ -3773,7 +3773,7 @@ namespace std {
 
 \indexlibrary{\idxcode{insert_iterator}!constructor}%
 \begin{itemdecl}
-constexpr insert_iterator(Container& x, iterator_t<Container> i);
+constexpr insert_iterator(Container& x, ranges::iterator_t<Container> i);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3853,7 +3853,7 @@ constexpr insert_iterator& operator++(int);
 \begin{itemdecl}
 template<class Container>
   constexpr insert_iterator<Container>
-    inserter(Container& x, iterator_t<Container> i);
+    inserter(Container& x, ranges::iterator_t<Container> i);
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
`inserter` and `insert_iterator` are in namespace `std`, so `ranges::iterator_t` should be used while introducing them.

Fixes #2859.