### PR TITLE
[expr.alignof,expr.unary.noexcept] Reorder to after [expr.sizeof].

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4568,6 +4568,49 @@ The result of \tcode{sizeof} and \tcode{sizeof...} is a constant of type
 \tcode{<cstddef>}~(\ref{cstddef.syn}, \ref{support.types.layout}).
 \end{note}
 
+\rSec3[expr.alignof]{Alignof}
+
+\pnum
+\indextext{\idxcode{alignof}}%
+\indextext{expression!\idxcode{alignof}}%
+An \tcode{alignof} expression yields the alignment requirement
+of its operand type. The operand shall be a \grammarterm{type-id}
+representing a complete object type, or an array thereof, or a reference
+to one of those types.
+
+\pnum
+The result is an integral constant of type
+\tcode{std::size_t}.
+
+\pnum
+When \tcode{alignof} is applied to a reference type, the result
+is the alignment of the referenced type. When \tcode{alignof}
+is applied to an array type, the result is the alignment of the
+element type.
+
+\rSec3[expr.unary.noexcept]{\tcode{noexcept} operator}
+
+\pnum
+\indextext{\idxcode{noexcept}}%
+\indextext{expression!\idxcode{noexcept}}%
+The \tcode{noexcept} operator determines whether the evaluation of its operand,
+which is an unevaluated operand\iref{expr.prop}, can throw an
+exception\iref{except.throw}.
+
+\begin{bnf}
+\nontermdef{noexcept-expression}\br
+  \keyword{noexcept} \terminal{(} expression \terminal{)}
+\end{bnf}
+
+\pnum
+The result of the \tcode{noexcept} operator is a constant of type \tcode{bool}
+and is a prvalue.
+
+\pnum
+The result of the \tcode{noexcept} operator is \tcode{true}
+unless the \grammarterm{expression} is potentially-throwing\iref{except.spec}.
+\indextext{expression!unary|)}
+
 \rSec3[expr.new]{New}
 
 \pnum
@@ -5365,49 +5408,6 @@ the behavior is undefined~(\ref{new.delete.single}, \ref{new.delete.array}).
 \pnum
 Access and ambiguity control are done for both the deallocation function
 and the destructor~(\ref{class.dtor}, \ref{class.free}).
-
-\rSec3[expr.alignof]{Alignof}
-
-\pnum
-\indextext{\idxcode{alignof}}%
-\indextext{expression!\idxcode{alignof}}%
-An \tcode{alignof} expression yields the alignment requirement
-of its operand type. The operand shall be a \grammarterm{type-id}
-representing a complete object type, or an array thereof, or a reference
-to one of those types.
-
-\pnum
-The result is an integral constant of type
-\tcode{std::size_t}.
-
-\pnum
-When \tcode{alignof} is applied to a reference type, the result
-is the alignment of the referenced type. When \tcode{alignof}
-is applied to an array type, the result is the alignment of the
-element type.
-
-\rSec3[expr.unary.noexcept]{\tcode{noexcept} operator}
-
-\pnum
-\indextext{\idxcode{noexcept}}%
-\indextext{expression!\idxcode{noexcept}}%
-The \tcode{noexcept} operator determines whether the evaluation of its operand,
-which is an unevaluated operand\iref{expr.prop}, can throw an
-exception\iref{except.throw}.
-
-\begin{bnf}
-\nontermdef{noexcept-expression}\br
-  \keyword{noexcept} \terminal{(} expression \terminal{)}
-\end{bnf}
-
-\pnum
-The result of the \tcode{noexcept} operator is a constant of type \tcode{bool}
-and is a prvalue.
-
-\pnum
-The result of the \tcode{noexcept} operator is \tcode{true}
-unless the \grammarterm{expression} is potentially-throwing\iref{except.spec}.
-\indextext{expression!unary|)}
 
 \rSec2[expr.cast]{Explicit type conversion (cast notation)}%
 \indextext{expression!cast|(}


### PR DESCRIPTION
Fixes #2773.