### PR TITLE
[expr.call,expr.reinterpret.cast] Adjust cross-references for

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2949,7 +2949,7 @@ the function call has no effect.
 Calling a function through an
 expression whose function type is different
 from the function type of the called function's
-definition results in undefined behavior\iref{dcl.link}.
+definition results in undefined behavior.
 
 \pnum
 \indextext{function argument|see{argument}}%
@@ -3877,7 +3877,7 @@ to a function pointer of a different type.
 \begin{note}
 The effect of calling a function through a pointer to a function
 type\iref{dcl.fct} that is not the same as the type used in the
-definition of the function is undefined.
+definition of the function is undefined\iref{expr.call}.
 \end{note}
 Except that converting
 a prvalue of type ``pointer to \tcode{T1}'' to the type ``pointer to


### PR DESCRIPTION
type violations in function calls.

Fixes #2482.