### PR TITLE
[views.span] Move description of iterators to [span.iterators].

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10469,17 +10469,6 @@ A \tcode{span} is a view over a contiguous sequence of objects,
 the storage of which is owned by some other object.
 
 \pnum
-The iterator types \tcode{span::iterator} and \tcode{span::const_iterator}
-model \libconcept{ContiguousIterator}\iref{iterator.concept.contiguous},
-meet the \oldconcept{RandomAccessIterator}
-requirements\iref{random.access.iterators},
-and
-meet the requirements for
-constexpr iterators\iref{iterator.requirements.general}.
-All requirements on container iterators\iref{container.requirements} apply to
-\tcode{span::iterator} and \tcode{span::const_iterator} as well.
-
-\pnum
 All member functions of \tcode{span} have constant time complexity.
 
 \indexlibrary{\idxcode{span}}%
@@ -10497,7 +10486,7 @@ namespace std {
     using const_pointer = const element_type*;
     using reference = element_type&;
     using const_reference = const element_type&;
-    using iterator = @\impdefx{type of \tcode{span::iterator}}@;
+    using iterator = @\impdefx{type of \tcode{span::iterator}}@;        // see \ref{span.iterators}
     using const_iterator = @\impdefx{type of \tcode{span::const_iterator}}@;
     using reverse_iterator = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
@@ -10965,6 +10954,26 @@ Equivalent to: \tcode{return data_;}
 \end{itemdescr}
 
 \rSec3[span.iterators]{Iterator support}
+
+\indexlibrarymember{iterator}{span}%
+\indexlibrarymember{const_iterator}{span}%
+\begin{itemdecl}
+using iterator = @\impdefx{type of \tcode{span::iterator}}@;
+using const_iterator = @\impdefx{type of \tcode{span::const_iterator}}@;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+The types
+model \libconcept{ContiguousIterator}\iref{iterator.concept.contiguous},
+meet the \oldconcept{RandomAccessIterator}
+requirements\iref{random.access.iterators},
+and
+meet the requirements for
+constexpr iterators\iref{iterator.requirements.general}.
+All requirements on container iterators\iref{container.requirements} apply to
+\tcode{span::iterator} and \tcode{span::const_iterator} as well.
+\end{itemdescr}
 
 \indexlibrarymember{span}{begin}%
 \begin{itemdecl}


### PR DESCRIPTION
Fixes #2806.