### PR TITLE
[string.view.template][string.view.iterators] Move requirements to a more appropriate place

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -4081,8 +4081,11 @@ The program is ill-formed if \tcode{traits::char_type} is not the same type as \
 \end{note}
 
 \pnum
-The type \tcode{iterator} satisfies
-the constexpr iterator requirements\iref{iterator.requirements.general}.
+For a \tcode{basic_string_view str},
+any operation that invalidates a pointer
+in the range \range{str.data()}{\brk{}str.data() + str.size()}
+invalidates pointers, iterators, and references
+returned from \tcode{str}'s member functions.
 
 \pnum
 The complexity of \tcode{basic_string_view} member functions is \bigoh{1}
@@ -4148,12 +4151,10 @@ using const_iterator = @\impdefx{type of \tcode{basic_string_view::const_iterato
 \pnum
 A type that meets the requirements
 of a constant
-\oldconcept{RandomAccessIterator}\iref{random.access.iterators} and
-models \libconcept{ContiguousIterator}\iref{iterator.concept.contiguous},
+\oldconcept{RandomAccessIterator}\iref{random.access.iterators},
+models \libconcept{ContiguousIterator}\iref{iterator.concept.contiguous}, and
+satisfies the constexpr iterator requirements\iref{iterator.requirements.general},
 whose \tcode{value_type} is the template parameter \tcode{charT}.
-
-\pnum
-For a \tcode{basic_string_view str}, any operation that invalidates a pointer in the range \range{str.data()}{str.data() + str.size()} invalidates pointers, iterators, and references returned from \tcode{str}'s member functions.
 
 \pnum
 All requirements on container iterators\iref{container.requirements} apply to \tcode{basic_string_view::const_iterator} as well.


### PR DESCRIPTION
Moved down constexpr iterator requirement with the other iterator requirements, and moved up the invalidation requirements alongside the complexity requirements as both apply as generally.