### PR TITLE
[basic.start.static] Repair index entry for zero-initialization.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -6059,7 +6059,7 @@ Within each of these phases of initiation, initialization occurs as follows.
 \defnx{Constant initialization}{constant initialization} is performed
 if a variable or temporary object with static or thread storage duration
 is initialized by a constant initializer\iref{expr.const} for the entity.
-\indextext{initialization!runtime}%
+\indextext{initialization!zero-initialization}%
 If constant initialization is not performed, a variable with static
 storage duration\iref{basic.stc.static} or thread storage
 duration\iref{basic.stc.thread} is zero-initialized\iref{dcl.init}.


### PR DESCRIPTION
Fixes #2844.