### PR TITLE
[lib] Reformat summary tables.

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -16,13 +16,13 @@ and algorithms from the ISO C library,
 as summarized in \tref{algorithms.summary}.
 
 \begin{libsumtab}{Algorithms library summary}{tab:algorithms.summary}
-\ref{algorithms.requirements} & Algorithms requirements & \\
-\ref{algorithms.parallel} & Parallel algorithms & \\ \hline
-\ref{alg.nonmodifying} & Non-modifying sequence operations  &           \\
-\ref{alg.modifying.operations} & Mutating sequence operations & \tcode{<algorithm>} \\
-\ref{alg.sorting} & Sorting and related operations      &           \\ \hline
-\ref{numeric.ops} & Generalized numeric operations  & \tcode{<numeric>} \\ \rowsep
-\ref{alg.c.library} & C library algorithms          & \tcode{<cstdlib>} \\
+\ref{algorithms.requirements}  & Algorithms requirements           & \\
+\ref{algorithms.parallel}      & Parallel algorithms               & \\ \rowsep
+\ref{alg.nonmodifying}         & Non-modifying sequence operations & \tcode{<algorithm>} \\
+\ref{alg.modifying.operations} & Mutating sequence operations      & \\
+\ref{alg.sorting}              & Sorting and related operations    & \\ \rowsep
+\ref{numeric.ops}              & Generalized numeric operations    & \tcode{<numeric>} \\ \rowsep
+\ref{alg.c.library}            & C library algorithms              & \tcode{<cstdlib>} \\
 \end{libsumtab}
 
 \rSec1[algorithms.requirements]{Algorithms requirements}

--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -9,25 +9,17 @@ provided via operations on atomic objects.
 
 \pnum
 The following subclauses describe atomics requirements and components for types
-and operations, as summarized below.
+and operations, as summarized in \tref{atomics.lib.summary}.
 
 \begin{libsumtab}{Atomics library summary}{tab:atomics.lib.summary}
-\ref{atomics.alias} & Type aliases &
-  \\ \rowsep
-\ref{atomics.order} & Order and consistency   &
-  \\ \rowsep
-\ref{atomics.lockfree}  & Lock-free property   &
-  \\ \rowsep
-\ref{atomics.ref.generic} & Class template \tcode{atomic_ref} & \tcode{<atomic>}
-  \\ \rowsep
-\ref{atomics.types.generic} & Class template \tcode{atomic}   & \tcode{<atomic>}
-  \\ \rowsep
-\ref{atomics.nonmembers}  & Non-member functions & \tcode{<atomic>}
-  \\ \rowsep
-\ref{atomics.flag}  & Flag type and operations   & \tcode{<atomic>}
-  \\ \rowsep
-\ref{atomics.fences}  & Fences   & \tcode{<atomic>}
-  \\ \rowsep
+\ref{atomics.alias} & Type aliases  & \tcode{<atomic>} \\
+\ref{atomics.order} & Order and consistency   &  \\
+\ref{atomics.lockfree}  & Lock-free property   &  \\
+\ref{atomics.ref.generic} & Class template \tcode{atomic_ref} &  \\
+\ref{atomics.types.generic} & Class template \tcode{atomic}   &  \\
+\ref{atomics.nonmembers}  & Non-member functions &  \\
+\ref{atomics.flag}  & Flag type and operations   &  \\
+\ref{atomics.fences}  & Fences   &  \\
 \end{libsumtab}
 
 \rSec1[atomics.syn]{Header \tcode{<atomic>} synopsis}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -18,18 +18,16 @@ as summarized in
 
 \begin{libsumtab}{Containers library summary}{tab:containers.lib.summary}
 \ref{container.requirements} & Requirements                     &                           \\ \rowsep
-\ref{sequences}              & Sequence containers              & \tcode{<array>}         \\
-                             &                                  & \tcode{<deque>}         \\
-                             &                                  & \tcode{<forward_list>}  \\
-                             &                                  & \tcode{<list>}          \\
-                             &                                  & \tcode{<vector>}        \\ \rowsep
-\ref{associative}            & Associative containers           & \tcode{<map>}           \\
-                             &                                  & \tcode{<set>}           \\ \rowsep
-\ref{unord}                  & Unordered associative containers & \tcode{<unordered_map>} \\
-                             &                                  & \tcode{<unordered_set>} \\ \rowsep
-\ref{container.adaptors}     & Container adaptors               & \tcode{<queue>}         \\
-                             &                                  & \tcode{<stack>}         \\ \rowsep
-\ref{views}                  & Views                            & \tcode{<span>}          \\ \rowsep
+\ref{sequences}              & Sequence containers              &
+  \tcode{<array>}, \tcode{<deque>}, \tcode{<forward_list>},
+  \tcode{<list>}, \tcode{<vector>} \\ \rowsep
+\ref{associative}            & Associative containers           &
+  \tcode{<map>}, \tcode{<set>}     \\ \rowsep
+\ref{unord}                  & Unordered associative containers &
+  \tcode{<unordered_map>}, \tcode{<unordered_set>}    \\ \rowsep
+\ref{container.adaptors}     & Container adaptors               &
+  \tcode{<queue>}, \tcode{<stack>}     \\ \rowsep
+\ref{views}                  & Views                            & \tcode{<span>} \\ \rowsep
 \end{libsumtab}
 
 

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -26,15 +26,14 @@ as summarized in \tref{iostreams.lib.summary}.
 \ref{iostream.objects}        & Standard iostream objects   & \tcode{<iostream>}   \\ \rowsep
 \ref{iostreams.base}          & Iostreams base classes      & \tcode{<ios>}        \\ \rowsep
 \ref{stream.buffers}          & Stream buffers              & \tcode{<streambuf>}  \\ \rowsep
-\ref{iostream.format}         & Formatting and manipulators & \tcode{<istream>}    \\
-                              &                             & \tcode{<ostream>}    \\
-                              &                             & \tcode{<iomanip>}    \\ \rowsep
+\ref{iostream.format}         & Formatting and manipulators &
+  \tcode{<iomanip>}, \tcode{<istream>}, \tcode{<ostream>}   \\ \rowsep
 \ref{string.streams}          & String streams              & \tcode{<sstream>}    \\ \rowsep
 \ref{file.streams}            & File streams                & \tcode{<fstream>}    \\ \rowsep
 \ref{syncstream}              & Synchronized output streams & \tcode{<syncstream>} \\ \rowsep
 \ref{filesystems}             & File systems                & \tcode{<filesystem>} \\ \rowsep
-\ref{c.files}                 & C library files             & \tcode{<cstdio>}     \\
-                              &                             & \tcode{<cinttypes>}  \\
+\ref{c.files}                 & C library files             &
+  \tcode{<cstdio>}, \tcode{<cinttypes>}  \\
 \end{libsumtab}
 
 \pnum

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -22,24 +22,27 @@ Detailed specifications for each of the components in the library are in
 \ref{\firstlibchapter}--\ref{\lastlibchapter}, as shown in
 \tref{library.categories}.
 
-\begin{libsumtabbase}{Library categories}{tab:library.categories}{Clause}{Category}
-\ref{language.support}  &   &   Language support library    \\
-\ref{concepts}          &   &   Concepts library            \\
-\ref{diagnostics}       &   &   Diagnostics library         \\
-\ref{utilities}         &   &   General utilities library   \\
-\ref{strings}           &   &   Strings library             \\
-\ref{containers}        &   &   Containers library          \\
-\ref{iterators}         &   &   Iterators library           \\
-\ref{ranges}            &   &   Ranges library              \\
-\ref{algorithms}        &   &   Algorithms library          \\
-\ref{numerics}          &   &   Numerics library            \\
-\ref{time}              &   &   Time library                \\
-\ref{localization}      &   &   Localization library        \\
-\ref{input.output}      &   &   Input/output library        \\
-\ref{re}                &   &   Regular expressions library \\
-\ref{atomics}           &   &   Atomic operations library   \\
-\ref{thread}            &   &   Thread support library      \\
-\end{libsumtabbase}
+\begin{floattable}{Library categories}{tab:library.categories}
+{ll}
+\topline
+\hdstyle{Clause}        & \hdstyle{Category}          \\ \capsep
+\ref{language.support}  & Language support library    \\
+\ref{concepts}          & Concepts library            \\
+\ref{diagnostics}       & Diagnostics library         \\
+\ref{utilities}         & General utilities library   \\
+\ref{strings}           & Strings library             \\
+\ref{containers}        & Containers library          \\
+\ref{iterators}         & Iterators library           \\
+\ref{ranges}            & Ranges library              \\
+\ref{algorithms}        & Algorithms library          \\
+\ref{numerics}          & Numerics library            \\
+\ref{time}              & Time library                \\
+\ref{localization}      & Localization library        \\
+\ref{input.output}      & Input/output library        \\
+\ref{re}                & Regular expressions library \\
+\ref{atomics}           & Atomic operations library   \\
+\ref{thread}            & Thread support library      \\
+\end{floattable}
 
 \pnum
 The language support library\iref{language.support} provides components that are

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1495,7 +1495,8 @@ include at least the headers shown in \tref{cpp.headers.freestanding}.
 
 \begin{libsumtab}{\Cpp{} headers for freestanding implementations}{tab:cpp.headers.freestanding}
 \ref{support.types}      & Types                     & \tcode{<cstddef>}          \\ \rowsep
-\ref{support.limits}     & Implementation properties & \tcode{<cfloat>} \tcode{<limits>} \tcode{<climits>} \tcode{<version>} \\ \rowsep
+\ref{support.limits}     & Implementation properties &
+  \tcode{<cfloat>}, \tcode{<climits>}, \tcode{<limits>}, \tcode{<version>} \\ \rowsep
 \ref{cstdint}            & Integer types             & \tcode{<cstdint>}          \\ \rowsep
 \ref{support.start.term} & Start and termination     & \tcode{<cstdlib>}          \\ \rowsep
 \ref{support.dynamic}    & Dynamic memory management & \tcode{<new>}              \\ \rowsep

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -18,7 +18,7 @@ from the ISO C library, as summarized in \tref{localization.lib.summary}.
 
 \begin{libsumtab}{Localization library summary}{tab:localization.lib.summary}
 \ref{locales} & Locales                   &   \tcode{<locale>}    \\
-\ref{locale.categories} & Standard \tcode{locale} Categories &   \\ \rowsep
+\ref{locale.categories} & Standard \tcode{locale} categories &   \\ \rowsep
 \ref{c.locales} & C library locales       &   \tcode{<clocale>}   \\
 \end{libsumtab}
 

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -23,8 +23,8 @@ as summarized in \tref{numerics.lib.summary}.
 \ref{bit}   & Bit manipulation & \tcode{<bit>} \\ \rowsep
 \ref{rand}  & Random number generation & \tcode{<random>} \\ \rowsep
 \ref{numarray}  & Numeric arrays     & \tcode{<valarray>}  \\ \rowsep
-\ref{c.math}  & Mathematical functions for & \tcode{<cmath>}   \\
-              & floating-point types       & \tcode{<cstdlib>} \\
+\ref{c.math}  & Mathematical functions for floating-point types &
+  \tcode{<cmath>}, \tcode{<cstdlib>} \\
 \end{libsumtab}
 
 \rSec1[numeric.requirements]{Numeric type requirements}

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -23,10 +23,10 @@ enumerating regular expression matches, as summarized in \tref{re.lib.summary}.
 \begin{libsumtab}{Regular expressions library summary}{tab:re.lib.summary}
 \ref{re.def}        &   Definitions                 &                       \\
 \ref{re.req}        &   Requirements                &                       \\ \rowsep
-\ref{re.const}      &   Constants                   &                       \\
+\ref{re.const}      &   Constants                   & \tcode{<regex>}       \\
 \ref{re.badexp}     &   Exception type              &                       \\
 \ref{re.traits}     &   Traits                      &                       \\
-\ref{re.regex}      &   Regular expression template &   \tcode{<regex>}     \\
+\ref{re.regex}      &   Regular expression template &                       \\
 \ref{re.submatch}   &   Submatches                  &                       \\
 \ref{re.results}    &   Match results               &                       \\
 \ref{re.alg}        &   Algorithms                  &                       \\

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -18,12 +18,12 @@ null-terminated sequence utilities,
 as summarized in \tref{strings.lib.summary}.
 
 \begin{libsumtab}{Strings library summary}{tab:strings.lib.summary}
-\ref{char.traits}     & Character traits                    & \tcode{<string>}  \\ \rowsep
-\ref{string.classes}  & String classes                      & \tcode{<string>}  \\ \rowsep
+\ref{char.traits}     & Character traits                    & \tcode{<string>}  \\
+\ref{string.classes}  & String classes                      &   \\ \rowsep
 \ref{string.view}     & String view classes                 & \tcode{<string_view>} \\ \rowsep
-                      &                                     & \tcode{<cctype>}  \\
+ \ref{c.strings}      & Null-terminated sequence utilities  & \tcode{<cctype>}  \\
                       &                                     & \tcode{<cwctype>} \\
-\ref{c.strings}       & Null-terminated sequence utilities  & \tcode{<cstring>} \\
+                      &                                     & \tcode{<cstring>} \\
                       &                                     & \tcode{<cwchar>}  \\
                       &                                     & \tcode{<cstdlib>} \\
                       &                                     & \tcode{<cuchar>}  \\

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -17,16 +17,13 @@ character traits class, string classes, and
 null-terminated sequence utilities,
 as summarized in \tref{strings.lib.summary}.
 
-\begin{libsumtab}{Strings library summary}{tab:strings.lib.summary}
+\begin{libsumtab}[x{2.1in}]{Strings library summary}{tab:strings.lib.summary}
 \ref{char.traits}     & Character traits                    & \tcode{<string>}  \\
 \ref{string.classes}  & String classes                      &   \\ \rowsep
 \ref{string.view}     & String view classes                 & \tcode{<string_view>} \\ \rowsep
- \ref{c.strings}      & Null-terminated sequence utilities  & \tcode{<cctype>}  \\
-                      &                                     & \tcode{<cwctype>} \\
-                      &                                     & \tcode{<cstring>} \\
-                      &                                     & \tcode{<cwchar>}  \\
-                      &                                     & \tcode{<cstdlib>} \\
-                      &                                     & \tcode{<cuchar>}  \\
+\ref{c.strings}       & Null-terminated sequence utilities  &
+  \tcode{<cctype>}, \tcode{<cstdlib>}, \tcode{<cstring>},
+  \tcode{<cuchar>}, \tcode{<cwchar>}, \tcode{<cwctype>}  \\
 \end{libsumtab}
 
 \rSec1[char.traits]{Character traits}

--- a/source/support.tex
+++ b/source/support.tex
@@ -23,12 +23,10 @@ and other runtime support,
 as summarized in \tref{lang.sup.lib.summary}.
 
 \begin{libsumtab}{Language support library summary}{tab:lang.sup.lib.summary}
-\ref{support.types}       & Common definitions        &   \tcode{<cstddef>}   \\
-                          &                           &   \tcode{<cstdlib>}   \\ \rowsep
-\ref{support.limits}      & Implementation properties &   \tcode{<limits>}    \\
-                          &                           &   \tcode{<climits>}   \\
-                          &                           &   \tcode{<cfloat>}    \\
-                          &                           &   \tcode{<version>}   \\ \rowsep
+\ref{support.types}       & Common definitions        &
+  \tcode{<cstddef>}, \tcode{<cstdlib>}   \\ \rowsep
+\ref{support.limits}      & Implementation properties &
+  \tcode{<cfloat>}, \tcode{<climits>}, \tcode{<limits>}, \tcode{<version>}    \\ \rowsep
 \ref{cstdint}             & Integer types             &   \tcode{<cstdint>}   \\ \rowsep
 \ref{support.start.term}  & Start and termination     &   \tcode{<cstdlib>}   \\ \rowsep
 \ref{support.dynamic}     & Dynamic memory management &   \tcode{<new>}       \\ \rowsep
@@ -38,10 +36,8 @@ as summarized in \tref{lang.sup.lib.summary}.
 \ref{support.initlist}    & Initializer lists    & \tcode{<initializer_list>} \\ \rowsep
 \ref{cmp}                 & Comparisons               &   \tcode{<compare>}   \\ \rowsep
 \ref{support.coroutine}   & Coroutines                &   \tcode{<coroutine>} \\ \rowsep
-\ref{support.runtime}     & Other runtime support     &   \tcode{<csignal>}   \\
-                          &                           &   \tcode{<csetjmp>}   \\
-                          &                           &   \tcode{<cstdarg>}   \\
-                          &                           &   \tcode{<cstdlib>}   \\
+\ref{support.runtime}     & Other runtime support     &
+  \tcode{<csetjmp>}, \tcode{<csignal>}, \tcode{<cstdarg>}, \tcode{<cstdlib>}  \\
 \end{libsumtab}
 
 \rSec1[support.types]{Common definitions}

--- a/source/tables.tex
+++ b/source/tables.tex
@@ -129,22 +129,22 @@
 % produces three-column table with column headers HDR1 and HDR2.
 % Used in "Library Categories" table in standard, and used as
 % base for other library summary tables.
-\newenvironment{libsumtabbase}[4]
+\newenvironment{libsumtabbase}[5]
 {
- \begin{floattable}{#1}{#2}{lll}
+ \begin{floattable}{#2}{#3}{ll#1}
  \topline
- & \hdstyle{#3}	&	\hdstyle{#4}	\\ \capsep
+ & \hdstyle{#4}	&	\hdstyle{#5}	\\ \capsep
 }
 {
  \end{floattable}
 }
 
-% usage: \begin{libsumtab}{TITLE}{XREF}
+% usage: \begin{libsumtab}[LASTCOLUMN]{TITLE}{XREF}
 % produces three-column table with column headers "Subclause" and "Header(s)".
 % Used in "C++ Headers for Freestanding Implementations" table in standard.
-\newenvironment{libsumtab}[2]
+\newenvironment{libsumtab}[3][l]
 {
- \begin{libsumtabbase}{#1}{#2}{Subclause}{Header}
+ \begin{libsumtabbase}{#1}{#2}{#3}{Subclause}{Header}
 }
 {
  \end{libsumtabbase}

--- a/source/tables.tex
+++ b/source/tables.tex
@@ -133,7 +133,7 @@
 {
  \begin{floattable}{#1}{#2}{lll}
  \topline
- \lhdrx{2}{#3}	&	\hdstyle{#4}	\\ \capsep
+ & \hdstyle{#3}	&	\hdstyle{#4}	\\ \capsep
 }
 {
  \end{floattable}
@@ -144,7 +144,7 @@
 % Used in "C++ Headers for Freestanding Implementations" table in standard.
 \newenvironment{libsumtab}[2]
 {
- \begin{libsumtabbase}{#1}{#2}{Subclause}{Header(s)}
+ \begin{libsumtabbase}{#1}{#2}{Subclause}{Header}
 }
 {
  \end{libsumtabbase}

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -12,8 +12,8 @@ between threads, as summarized in \tref{thread.lib.summary}.
 \begin{libsumtab}{Thread support library summary}{tab:thread.lib.summary}
 \ref{thread.req}      & Requirements          &                               \\ \rowsep
 \ref{thread.threads}  & Threads               & \tcode{<thread>}              \\ \rowsep
-\ref{thread.mutex}    & Mutual exclusion      & \tcode{<mutex>}               \\
-                      &                       & \tcode{<shared_mutex>}        \\ \rowsep
+\ref{thread.mutex}    & Mutual exclusion      &
+  \tcode{<mutex>}, \tcode{<shared_mutex>} \\ \rowsep
 \ref{thread.condition}& Condition variables   & \tcode{<condition_variable>}  \\ \rowsep
 \ref{futures}         & Futures               & \tcode{<future>}              \\
 \end{libsumtab}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -9,9 +9,9 @@ of these utilities are used by other elements of the \Cpp{} standard library.
 These utilities are summarized in \tref{util.lib.summary}.
 
 \begin{libsumtab}{General utilities library summary}{tab:util.lib.summary}
-\ref{utility}               & Utility components                & \tcode{<utility>}     \\ \rowsep
-\ref{intseq}                & Compile-time integer sequences    & \tcode{<utility>}     \\ \rowsep
-\ref{pairs}                 & Pairs                             & \tcode{<utility>}     \\ \rowsep
+\ref{utility}               & Utility components                & \tcode{<utility>}     \\
+\ref{intseq}                & Compile-time integer sequences    & \\
+\ref{pairs}                 & Pairs                             & \\ \rowsep
 \ref{tuple}                 & Tuples                            & \tcode{<tuple>}       \\ \rowsep
 \ref{optional}              & Optional objects                  & \tcode{<optional>}    \\ \rowsep
 \ref{variant}               & Variants                          & \tcode{<variant>}     \\ \rowsep

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -17,8 +17,8 @@ These utilities are summarized in \tref{util.lib.summary}.
 \ref{variant}               & Variants                          & \tcode{<variant>}     \\ \rowsep
 \ref{any}                   & Storage for any type              & \tcode{<any>}         \\ \rowsep
 \ref{bitset}                & Fixed-size sequences of bits      & \tcode{<bitset>}      \\ \rowsep
-\ref{memory}                & Memory                            & \tcode{<memory>}      \\
-                            &                                   & \tcode{<cstdlib>}     \\ \rowsep
+\ref{memory}                & Memory                            &
+  \tcode{<cstdlib>}, \tcode{<memory>} \\ \rowsep
 \ref{smartptr}              & Smart pointers                    & \tcode{<memory>}      \\ \rowsep
 \ref{mem.res}               & Memory resources                  & \tcode{<memory_resource>} \\ \rowsep
 \ref{allocator.adaptor}     & Scoped allocators                 & \tcode{<scoped_allocator>} \\ \rowsep


### PR DESCRIPTION
Fixes #2392.

After:
![strings](https://user-images.githubusercontent.com/23412755/57177230-95c3d380-6e62-11e9-8508-1db10ba4443c.png)
