### PR TITLE
[stmt.jump]/2 Fixed wording that does not apply to objects who's lifetime has ended

### DIFF
--- a/source/statements.tex
+++ b/source/statements.tex
@@ -739,7 +739,7 @@ Jump statements unconditionally transfer control.
 On exit from a scope (however accomplished), variables that refer to objects with
 automatic storage duration\iref{basic.stc.auto} declared in that scope will be destroyed
 in the reverse order of their declaration. If a variable does not refer to an object
-and the type of the variable has a non-trivial destructor, the behavior is undefined. 
+and the type of the variable has a non-trivial destructor, the behavior is undefined.
 \begin{note} For temporaries, see~\ref{class.temporary}. \end{note} Transfer out of a loop, out of a block, or back
 past an initialized variable with automatic storage duration involves the
 destruction of objects with automatic storage duration that are in

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -736,12 +736,12 @@ Jump statements unconditionally transfer control.
 \pnum
 \indextext{local variable!destruction of}%
 \indextext{scope!destructor and exit from}%
-On exit from a scope (however accomplished), objects with automatic storage
-duration\iref{basic.stc.auto} that have been constructed in that scope are destroyed
-in the reverse order of their construction. \begin{note} For temporaries,
-see~\ref{class.temporary}. \end{note} Transfer out of a loop, out of a block, or back
-past
-an initialized variable with automatic storage duration involves the
+On exit from a scope (however accomplished), variables that refer to objects with
+automatic storage duration\iref{basic.stc.auto} declared in that scope will be destroyed
+in the reverse order of their declaration. If a variable does not refer to an object
+and the type of the variable has a non-trivial destructor, the behavior is undefined. 
+\begin{note} For temporaries, see~\ref{class.temporary}. \end{note} Transfer out of a loop, out of a block, or back
+past an initialized variable with automatic storage duration involves the
 destruction of objects with automatic storage duration that are in
 scope at the point transferred from but not at the point transferred to.
 (See~\ref{stmt.dcl} for transfers into blocks).


### PR DESCRIPTION
Fixes #2871