### PR TITLE
[dcl.dcl,temp.spec] Move normative statements on restrictions for

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -356,11 +356,11 @@ global namespace, which shall be declared
 \tcode{static}\iref{class.union.anon}). The
 \grammarterm{storage-class-specifier} applies to the name declared by each
 \grammarterm{init-declarator} in the list and not to any names declared by
-other specifiers. A \grammarterm{storage-class-specifier}
-other than \tcode{thread_local}
-shall not be
-specified in an explicit specialization\iref{temp.expl.spec} or an
-explicit instantiation\iref{temp.explicit} directive.
+other specifiers.
+\begin{note}
+See \ref{temp.expl.spec} and \ref{temp.explicit} for restrictions
+in explicit specializations and explicit instantiations, respectively.
+\end{note}
 
 \pnum
 \begin{note}
@@ -8438,8 +8438,11 @@ entity or statement contains an \grammarterm{attribute} or \grammarterm{alignmen
 is not allowed to apply to that
 entity or statement, the program is ill-formed. If an \grammarterm{attribute-specifier-seq}
 appertains to a friend declaration\iref{class.friend}, that declaration shall be a
-definition. No \grammarterm{attribute-specifier-seq} shall appertain to an explicit
-instantiation\iref{temp.explicit}.
+definition.
+\begin{note}
+An \grammarterm{attribute-specifier-seq} cannot appeartain to
+an explicit instantiation\iref{temp.explicit}.
+\end{note}
 
 \pnum
 For an \grammarterm{attribute-token}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -6213,12 +6213,6 @@ instantiated from its template.
 A member function, member class or static data member of a class template can
 be explicitly instantiated from the member definition associated with its class
 template.
-An explicit instantiation of a
-function template,
-member function of a class template, or
-variable template
-shall not
-use the \tcode{inline}, \tcode{constexpr}, or \tcode{consteval} specifiers.
 
 \pnum
 The syntax for explicit instantiation is:
@@ -6231,6 +6225,19 @@ The syntax for explicit instantiation is:
 There are two forms of explicit instantiation: an explicit instantiation
 definition and an explicit instantiation declaration. An explicit instantiation
 declaration begins with the \tcode{extern} keyword.
+
+\pnum
+An explicit instantiation shall not use
+a \grammarterm{storage-class-specifier}\iref{dcl.stc}
+other than \keyword{thread_local}.
+An explicit instantiation of a
+function template,
+member function of a class template, or
+variable template
+shall not
+use the \tcode{inline}, \tcode{constexpr}, or \tcode{consteval} specifiers.
+No \grammarterm{attribute-specifier-seq}\iref{dcl.attr.grammar}
+shall appertain to an explicit instantiation.
 
 \pnum
 If the explicit instantiation is for a class or member class, the
@@ -6526,6 +6533,11 @@ other
 \tcode{Array}
 types will be sorted by functions generated from the template.
 \end{example}
+
+\pnum
+An explicit specialization shall not use
+a \grammarterm{storage-class-specifier}\iref{dcl.stc}
+other than \keyword{thread_local}.
 
 \pnum
 An explicit specialization


### PR DESCRIPTION
explicit specializations and explicit instantiations
to [temp.spec] and its subsections.

Fixes #2188.