### PR TITLE
[expr.prim.lambda] Simplify grammar for lambda-expression.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1533,11 +1533,8 @@ void f() {
 
 \begin{bnf}
 \nontermdef{lambda-expression}\br
-    lambda-introducer compound-statement\br
-    lambda-introducer lambda-declarator \opt{requires-clause} compound-statement\br
-    lambda-introducer \terminal{<} template-parameter-list \terminal{>} \opt{requires-clause} compound-statement\br
-    lambda-introducer \terminal{<} template-parameter-list \terminal{>} \opt{requires-clause}\br
-    \bnfindent lambda-declarator \opt{requires-clause} compound-statement
+    lambda-introducer \opt{lambda-declarator} compound-statement\br
+    lambda-introducer \terminal{<} template-parameter-list \terminal{>} \opt{requires-clause} \opt{lambda-declarator} compound-statement
 \end{bnf}
 
 \begin{bnf}
@@ -1548,7 +1545,7 @@ void f() {
 \begin{bnf}
 \nontermdef{lambda-declarator}\br
     \terminal{(} parameter-declaration-clause \terminal{)} \opt{decl-specifier-seq}\br
-    \bnfindent\opt{noexcept-specifier} \opt{attribute-specifier-seq} \opt{trailing-return-type}
+    \bnfindent\opt{noexcept-specifier} \opt{attribute-specifier-seq} \opt{trailing-return-type} \opt{requires-clause}
 \end{bnf}
 
 \pnum
@@ -1655,7 +1652,7 @@ is the \grammarterm{requires-clause} immediately following
 \tcode{<}~\grammarterm{template-parameter-list}{}~\tcode{>}, if any.
 The trailing \grammarterm{requires-clause} of the function call operator
 or operator template is the \grammarterm{requires-clause}
-following the \grammarterm{lambda-declarator}, if any.
+of the \grammarterm{lambda-declarator}, if any.
 \begin{note}
 The function call operator for a generic lambda might be
 an abbreviated function template\iref{dcl.fct}.


### PR DESCRIPTION
Fixes #2870.