### PR TITLE
[expr.type]/1 Change "designates" to "result of"

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -311,7 +311,7 @@ Unlike in C, \Cpp{} has no accesses of class type.
 \indextext{expression!reference}%
 If an expression initially has the type ``reference to
 \tcode{T}''~(\ref{dcl.ref}, \ref{dcl.init.ref}), the type is adjusted to
-\tcode{T} prior to any further analysis. The expression designates the
+\tcode{T} prior to any further analysis. The expression's result is the
 object or function denoted by the reference, and the expression
 is an lvalue or an xvalue, depending on the expression.
 \begin{note}


### PR DESCRIPTION
When the change to the result of the expression is done as specified in [expr.type] p1, the wording does not accurately reflect what happens. The entity the expression refers to does not change, but the result of the expression is changed to be the object or function that the reference refers to does. The wording should reflect that, hence this proposed change.