### PR TITLE
[dcl.dcl]/11 Storage from object definitions has proper alignment

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -227,8 +227,7 @@ declaration are added to a function declaration to make a
 a definition unless it contains the \tcode{extern} specifier and has no
 initializer\iref{basic.def}.
 \indextext{initialization!definition and}%
-A
-definition causes the appropriate amount of storage to be reserved and
+An object definition causes storage of appropriate size and alignment to be reserved and
 any appropriate initialization\iref{dcl.init} to be done.
 
 \pnum


### PR DESCRIPTION
Require implementations to reserve storage of both proper size and aligment in an object definition. Previously, this sentence requires only storage of proper size be reserved.

Additionally, specified that space is only reserved for object definitions, as it does not make sense to reserve space for a function definition.

Rationale for being editorial: if implementations are not required to reserve storage of proper alignment, accessing any variable is then possibly-UB due to lifetime failing to begin ([basic.life]/1). This is obviously not the intent of the Committee.