### PR TITLE
[basic.life] p5 Fixed destructor calls not ending lifetime of objects with trivial destructors

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3126,8 +3126,8 @@ construction and destruction phases. \end{note}
 \pnum
 A program may end the lifetime of any object by reusing the storage
 which the object occupies or by explicitly calling the destructor for an
-object of a class type with a non-trivial destructor. For an object of a
-class type with a non-trivial destructor, the program is not required to
+object of a class type. For an object of a class type with a
+non-trivial destructor, the program is not required to
 call the destructor explicitly before the storage which the object
 occupies is reused or released; however, if there is no explicit call to
 the destructor or if a \grammarterm{delete-expression}\iref{expr.delete}


### PR DESCRIPTION
[[basic.life] p4](http://eel.is/c++draft/basic.life#1.4) states that calling the destructor for an object of class type will end its lifetime. [[class.dtor] p16](http://eel.is/c++draft/class.dtor#16.sentence-1) reaffirms this. So does [[dcl.init] p21](http://eel.is/c++draft/dcl.dcl#dcl.init-21.sentence-3), as if it didn't, destroying an object of a class type with a trivial destructor would not end its lifetime. However, [[basic.life] p5](http://eel.is/c++draft/basic.life#5.sentence-1) seems to disagree. 

Changing
> A program may end the lifetime of any object by reusing the storage which the object occupies or by explicitly calling the destructor for an object of a class type with a non-trivial destructor.

To

> A program may end the lifetime of any object by reusing the storage which the object occupies or by explicitly calling the destructor for an object of a class type.

Resolves this issue.