### PR TITLE
[view.interface] Drop unused exposition-only items

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1005,18 +1005,6 @@ parameterized with the type that is derived from it.
 \indexlibrary{\idxcode{view_interface}}%
 \begin{codeblock}
 namespace std::ranges {
-  template<Range R>
-  struct @\placeholdernc{range-common-iterator-impl}@ {                   // \expos
-    using type = common_iterator<iterator_t<R>, sentinel_t<R>>;
-  };
-  template<CommonRange R>
-  struct @\placeholdernc{range-common-iterator-impl}@<R> {                // \expos
-    using type = iterator_t<R>;
-  };
-  template<Range R>
-    using @\placeholdernc{range-common-iterator}@ =                       // \expos
-      typename @\placeholdernc{range-common-iterator-impl}@<R>::type;
-
   template<class D>
     requires is_class_v<D> && Same<D, remove_cv_t<D>>
   class view_interface : public view_base {


### PR DESCRIPTION
Exposition-only entities "range-common-iterator-impl" and "range-common-iterator" are unused. They are redundant and should be dropped.