### PR TITLE
[range.filter.sentinel] Fix argument to ranges::end

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2850,7 +2850,7 @@ constexpr explicit sentinel(filter_view& parent);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{end_} with \tcode{ranges::end(parent)}.
+\effects Initializes \tcode{end_} with \tcode{ranges::end(parent.base_)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{base}!\idxcode{filter_view::sentinel}}%


### PR DESCRIPTION
Here `end_` should be initialized with the sentinel of `parent`'s underlying view (instead of the sentinel of `parent`, which may lead to infinite recursion, if not a type mismatch).