### PR TITLE
[concept.swappable] Strike array poison pill swap overload

### DIFF
--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -578,12 +578,10 @@ and \tcode{E2} is expression-equivalent to an expression
   \tcode{S} is \tcode{(void)swap(E1, E2)}\footnote{The name \tcode{swap} is used
   here unqualified.} if \tcode{E1} or \tcode{E2}
   has class or enumeration type\iref{basic.compound} and that expression is valid, with
-  overload resolution performed in a context that includes the declarations
+  overload resolution performed in a context that includes the declaration
 \begin{codeblock}
   template<class T>
     void swap(T&, T&) = delete;
-  template<class T, size_t N>
-    void swap(T(&)[N], T(&)[N]) = delete;
 \end{codeblock}
   and does not include a declaration of \tcode{ranges::swap}.
   If the function selected by overload resolution does not


### PR DESCRIPTION
Since lookup is only performed when at least one argument has class or enumeration type, template argument deduction can never succeed for the poisin pill overload with two parameters of reference-to-array type; it can be struck with no normative impact.