### PR TITLE
[concept.boolean] Rephrase first requirement

### DIFF
--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -819,7 +819,7 @@ template<class B>
     Movable<remove_cvref_t<B>> && // (see \ref{concepts.object})
     requires(const remove_reference_t<B>& b1,
              const remove_reference_t<B>& b2, const bool a) {
-      requires ConvertibleTo<const remove_reference_t<B>&, bool>;
+      { b1 } -> ConvertibleTo<bool>;
       { !b1 } -> ConvertibleTo<bool>;
       { b1 &&  a } -> Same<bool>;
       { b1 ||  a } -> Same<bool>;


### PR DESCRIPTION
`requires ConvertibleTo<const remove_reference_t<B>&, bool>;` is a simplification of `b1; requires ConvertibleTo<decltype(b1), bool>;` which would have been cleaned up to `{ b1 } -> ConvertibleTo<bool>;` (the intended requirement) post P1084, had it not been simplified in P0896.

~Drive-by: reorder the binary expression requirements consistently as b1 op b2, b1 op a, a op b2.~