### PR TITLE
[styles] Also allow 'listings' package v1.8b

### DIFF
--- a/source/styles.tex
+++ b/source/styles.tex
@@ -156,13 +156,13 @@
 %% (copied verbatim from listings.sty version 1.6 except where commented)
 \makeatletter
 
-\lst@CheckVersion{1.7}{\lst@CheckVersion{1.6}{\lst@CheckVersion{1.5b}{
+\lst@CheckVersion{1.8b}{\lst@CheckVersion{1.7}{\lst@CheckVersion{1.6}{\lst@CheckVersion{1.5b}{
  \typeout{^^J%
  ***^^J%
  *** This file requires listings.sty version 1.6.^^J%
  *** You have version \lst@version; exiting ...^^J%
  ***^^J}%
- \batchmode \@@end}}}
+ \batchmode \@@end}}}}
 
 \def\lst@Init#1{%
     \begingroup


### PR DESCRIPTION
MacTex 2019 comes with listings in version 1.8b. Without this change, it does not compile.