### PR TITLE
[concept.booolean] Reorder expression requirements consistently

### DIFF
--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -821,11 +821,11 @@ template<class B>
              const remove_reference_t<B>& b2, const bool a) {
       requires ConvertibleTo<const remove_reference_t<B>&, bool>;
       { !b1 } -> ConvertibleTo<bool>;
-      { b1 &&  a } -> Same<bool>;
-      { b1 ||  a } -> Same<bool>;
       { b1 && b2 } -> Same<bool>;
+      { b1 &&  a } -> Same<bool>;
       {  a && b2 } -> Same<bool>;
       { b1 || b2 } -> Same<bool>;
+      { b1 ||  a } -> Same<bool>;
       {  a || b2 } -> Same<bool>;
       { b1 == b2 } -> ConvertibleTo<bool>;
       { b1 ==  a } -> ConvertibleTo<bool>;


### PR DESCRIPTION
...to improve readability.

I should point out that this technically has normative impact due to the short-circuiting nature of requires-expressions: there are sets of borderline-pathological parameters which would have failed to satisfy the prior formulation that would result in an ill-formed program with the proposed formulation, and vice versa. I can confirm that the design intent is that the first two compound-requirements precede the others and that the order of the others is not significant, but I'll of course understand if the editors would like LWG to give this change the nod.