### PR TITLE
Remove four extraneous spaces from parameter lists ([rand.device] and [rand.util.seedseq])

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -3861,8 +3861,8 @@ public:
   double entropy() const noexcept;
 
   @\textit{// no copy functions}@
-  random_device(const random_device& ) = delete;
-  void operator=(const random_device& ) = delete;
+  random_device(const random_device&) = delete;
+  void operator=(const random_device&) = delete;
 };
 \end{codeblock}
 
@@ -3969,8 +3969,8 @@ public:
     void param(OutputIterator dest) const;
 
   // no copy functions
-  seed_seq(const seed_seq& ) = delete;
-  void operator=(const seed_seq& ) = delete;
+  seed_seq(const seed_seq&) = delete;
+  void operator=(const seed_seq&) = delete;
 
 private:
   vector<result_type> v;   // \expos


### PR DESCRIPTION
These have been there since C++11; it looks like the parameter names were removed, but the spaces left. NFC.