### PR TITLE
[dcl.init.aggr]/1 An aggregate can have private or protected data members

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4620,7 +4620,7 @@ An \defn{aggregate} is an array or a class\iref{class} with
 \item
 no user-declared or inherited constructors\iref{class.ctor},
 \item
-no private or protected non-static data members\iref{class.access},
+no private or protected direct non-static data members\iref{class.access},
 \item
 no virtual functions\iref{class.virtual}, and
 \item


### PR DESCRIPTION
if they are not direct, like in the code below:
```c++
class B { int i; };      // i is private
struct A : B { int j; }; // but A is still an aggregate

A a = { {}, 1 }; // OK
```