### PR TITLE
[time.cal.ymwd.nonmembers] Fix typo in parameter names.

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -7279,7 +7279,7 @@ constexpr year_month_weekday operator+(const years& dy, const year_month_weekday
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ymwd + dm}.
+\returns \tcode{ymwd + dy}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{year_month_weekday}%
@@ -7289,7 +7289,7 @@ constexpr year_month_weekday operator-(const year_month_weekday& ymwd, const yea
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ymwd + (-dm)}.
+\returns \tcode{ymwd + (-dy)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<<}{year_month_weekday}%


### PR DESCRIPTION
Fixes #2886.