### PR TITLE
[range.prim.size] Clarify by adding 'respectively'.

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -525,7 +525,7 @@ object\iref{customization.point.object}. The expression
   Otherwise, \tcode{(ranges::end(E) - ranges::begin(E))}
   if it is a valid expression and
   the types \tcode{I} and \tcode{S} of \tcode{ranges::begin(E)} and
-  \tcode{ranges::end(E)} model
+  \tcode{ranges::end(E)} (respectively) model both
   \tcode{SizedSentinel<S, I>}\iref{iterator.concept.sizedsentinel} and
   \tcode{Forward\-Iterator<I>}.
   However, \tcode{E} is evaluated only once.


### PR DESCRIPTION
Fixes #2794.