### PR TITLE
[expr.sizeof,expr.alignof,expr.unary.noexcept] Clarify value category.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4555,12 +4555,14 @@ struct count {
 \end{example}
 
 \pnum
-The result of \tcode{sizeof} and \tcode{sizeof...} is a constant of type
-\tcode{std::size_t}.
-\begin{note}
 \indextext{\idxcode{size_t}}%
 \indexlibrary{\idxcode{size_t}}%
-\tcode{std::size_t} is defined in the standard header
+The result of \tcode{sizeof} and \tcode{sizeof...} is a prvalue of type
+\tcode{std::size_t}.
+\begin{note}
+A \tcode{sizeof} expression
+is an integral constant expression\iref{expr.const}.
+The type \tcode{std::size_t} is defined in the standard header
 \indexhdr{cstddef}%
 \tcode{<cstddef>}~(\ref{cstddef.syn}, \ref{support.types.layout}).
 \end{note}
@@ -4576,8 +4578,14 @@ representing a complete object type, or an array thereof, or a reference
 to one of those types.
 
 \pnum
-The result is an integral constant of type
-\tcode{std::size_t}.
+The result is a prvalue of type \tcode{std::size_t}.
+\begin{note}
+An \tcode{alignof} expression
+is an integral constant expression\iref{expr.const}.
+The type \tcode{std::size_t} is defined in the standard header
+\indexhdr{cstddef}%
+\tcode{<cstddef>}~(\ref{cstddef.syn}, \ref{support.types.layout}).
+\end{note}
 
 \pnum
 When \tcode{alignof} is applied to a reference type, the result
@@ -4600,8 +4608,14 @@ exception\iref{except.throw}.
 \end{bnf}
 
 \pnum
-The result of the \tcode{noexcept} operator is a constant of type \tcode{bool}
-and is a prvalue.
+The result of the \tcode{noexcept} operator is a prvalue of type \tcode{bool}.
+\begin{note}
+A \grammarterm{noexcept-expression}
+is an integral constant expression\iref{expr.const}.
+The type \tcode{std::size_t} is defined in the standard header
+\indexhdr{cstddef}%
+\tcode{<cstddef>}~(\ref{cstddef.syn}, \ref{support.types.layout}).
+\end{note}
 
 \pnum
 The result of the \tcode{noexcept} operator is \tcode{true}


### PR DESCRIPTION
Also remove the undefined term 'constant' and
instead add a note pointing to [expr.const].

Fixes #2671.