### PR TITLE
[except.terminate] thread has move-assignment, not copy

### DIFF
--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -1068,7 +1068,7 @@ when execution of an element access function\iref{algorithms.parallel.defns}
 of the parallel algorithm exits via an exception\iref{algorithms.parallel.exceptions}, or
 
 \item%
-when the destructor or the copy assignment operator is invoked on an object
+when the destructor or the move assignment operator is invoked on an object
 of type \tcode{std::thread} that refers to a joinable thread
 (\ref{thread.thread.destr}, \ref{thread.thread.assign}), or
 


### PR DESCRIPTION
The copy-assignment operator for std::thread is deleted, but the
move-assignment operator documents a call to std::terminate as
expected.  Suggesting this is an editorial fix rather than something
to run through the Core issues lists.