### PR TITLE
[allocator.adaptor.syn] Avoid confusing term 'memory resource'.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -13336,7 +13336,7 @@ namespace std {
 
 \pnum
 The class template \tcode{scoped_allocator_adaptor} is an allocator template that
-specifies the memory resource (the outer allocator) to be used by a container (as any
+specifies an allocator resource (the outer allocator) to be used by a container (as any
 other allocator does) and also specifies an inner allocator resource to be passed to the
 constructor of every element within the container. This adaptor is instantiated with one
 outer and zero or more inner allocator types. If instantiated with only one allocator


### PR DESCRIPTION
Fixes #2858.