### PR TITLE
[std] Consistently use 'immediately-declared constraint'.

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2013,10 +2013,11 @@ decltype(auto)*x7d = &i;        // error, declared type is not plain \tcode{decl
 \end{example}
 
 \pnum
-For a \grammarterm{placeholder-type-specifier} with
-a \grammarterm{type-constraint},
-if the type deduced for the placeholder does not satisfy its
-immediately-declared constraint\iref{temp}, the program is ill-formed.
+For a \grammarterm{placeholder-type-specifier}
+with a \grammarterm{type-constraint},
+the immediately-declared constraint\iref{temp}
+of the \grammarterm{type-constraint} for the type deduced for the placeholder
+shall be satisfied.
 
 \rSec3[dcl.type.class.deduct]{Deduced class template specialization types}
 \indextext{deduction!class template arguments}%

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2707,9 +2707,8 @@ Substitution of template arguments (if any)
 into the \grammarterm{return-type-requirement} is performed.
 
 \item
-The contextually-determined type being constrained
-by the \grammarterm{type-constraint} is \tcode{decltype((E))}.
-The immediately-declared constraint\iref{temp} of \tcode{decltype((E))}
+The immediately-declared constraint\iref{temp}
+of the \grammarterm{type-constraint} for \tcode{decltype((E))}
 shall be satisfied.
 \begin{example}
 Given concepts \tcode{C} and \tcode{D},

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -164,7 +164,7 @@ then \tcode{E} is \tcode{E$'$},
 otherwise \tcode{E} is \tcode{(E$'$ \&\& ...)}.
 This \grammarterm{constraint-expression} \tcode{E} is called the
 \defnx{immediately-declared constraint}{constraint!immediately-declared}
-of \tcode{T}.
+of \tcode{Q} for \tcode{T}.
 The concept designated by a \grammarterm{type-constraint}
 shall be a type concept\iref{temp.concept}.
 
@@ -461,7 +461,8 @@ S<v> z;                         // OK due to both adjustment and conversion
 
 \pnum
 A \grammarterm{type-parameter} that starts with a \grammarterm{type-constraint}
-introduces the immediately-declared constraint\iref{temp} of the parameter.
+introduces the immediately-declared constraint\iref{temp}
+of the \grammarterm{type-constraint} for the parameter.
 \begin{example}
 \begin{codeblock}
 template<typename T> concept C1 = true;
@@ -479,8 +480,9 @@ template<C3<int>... T> struct s5;       // associates \tcode{(C3<T, int> \&\& ..
 \pnum
 A non-type template parameter declared with a type that
 contains a placeholder type with a \grammarterm{type-constraint}
-introduces the immediately-declared constraint of
-the invented type corresponding to the placeholder\iref{dcl.fct}.
+introduces the immediately-declared constraint
+of the \grammarterm{type-constraint}
+for the invented type corresponding to the placeholder\iref{dcl.fct}.
 
 \pnum
 A


### PR DESCRIPTION
Harmonize the phrasing in [expr.prim.req.compound],
[dcl.type.auto.deduct], [temp], and [temp.param].

Fixes #2477.