### PR TITLE
[basic.compound] Replace four refs with a single one to [dcl.meaning]

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4825,8 +4825,8 @@ called \term{pointer-to-member} types.
 
 \pnum
 These methods of constructing types can be applied recursively;
-restrictions are mentioned in~\ref{dcl.ptr}, \ref{dcl.array},
-\ref{dcl.fct}, and~\ref{dcl.ref}. Constructing a type such that the number of
+restrictions are mentioned in~\ref{dcl.meaning}.
+Constructing a type such that the number of
 bytes in its object representation exceeds the maximum value representable in
 the type \tcode{std::size_t}\iref{support.types} is ill-formed.
 


### PR DESCRIPTION
Currently the cross references to 9.2.3.[1245] are not in numerical order, which just looks odd:

>  These methods of constructing types can be applied recursively; restrictions are mentioned in 9.2.3.1, 9.2.3.4, 9.2.3.5, and 9.2.3.2.

![basic compound](https://user-images.githubusercontent.com/1254480/58543249-07d7d000-81f7-11e9-8e9b-0a174e34a3de.png)

It seems like [9.2.3.3 [dcl.mptr]](https://wg21.link/dcl.mptr#3) also mentions a restriction:

>  A pointer to member shall not point to a static member of a class (11.3.8), a member with reference type, or “_cv_ `void`”.

Should [dcl.mptr] be added to the list of refs in [basic.compound] p2?