### PR TITLE
[dcl.mptr] Add \pnum to note

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2944,6 +2944,7 @@ a member with reference type,
 or
 ``\cv{}~\tcode{void}''.
 
+\pnum
 \begin{note}
 See also~\ref{expr.unary} and~\ref{expr.mptr.oper}.
 The type ``pointer to member'' is distinct from the type ``pointer'',


### PR DESCRIPTION
This note doesn't seem to be specific to paragraph 3, so I think it's correct that it's in its own paragraph (rather than being part of p3) but that means it should have its own `\pnum`:

![dcl mptr](https://user-images.githubusercontent.com/1254480/58544169-ac0e4680-81f8-11e9-9c24-83525580db9e.png)

