### PR TITLE
[stmt.stmt,basic.scope.block] Remove normative redundancy.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -941,8 +941,17 @@ Names declared in the \grammarterm{init-statement}, the \grammarterm{for-range-d
 \tcode{for}, or \tcode{switch} statement (including the controlled
 statement), and shall not be redeclared in a subsequent condition of
 that statement nor in the outermost block (or, for the \tcode{if}
-statement, any of the outermost blocks) of the controlled statement;
-see~\ref{stmt.select}.
+statement, any of the outermost blocks) of the controlled statement.
+\begin{example}
+\begin{codeblock}
+if (int x = f()) {
+  int x;            // ill-formed, redeclaration of \tcode{x}
+}
+else {
+  int x;            // ill-formed, redeclaration of \tcode{x}
+}
+\end{codeblock}
+\end{example}
 
 \rSec2[basic.scope.param]{Function parameter scope}
 

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -84,24 +84,14 @@ the type of the identifier being declared is deduced from the initializer as des
 \pnum
 \indextext{statement!declaration in \tcode{if}}%
 \indextext{statement!declaration in \tcode{switch}}%
-A name introduced by a declaration in a \grammarterm{condition}
-(introduced by either the \grammarterm{decl-specifier-seq} or the
-\grammarterm{declarator} of the condition) is in scope from its point of
-declaration until the end of the substatements controlled by the
-condition. If the name is redeclared in the outermost block of a
-substatement controlled by the condition, the declaration that
-redeclares the name is ill-formed.
-\begin{example}
-
-\begin{codeblock}
-if (int x = f()) {
-  int x;            // ill-formed, redeclaration of \tcode{x}
-}
-else {
-  int x;            // ill-formed, redeclaration of \tcode{x}
-}
-\end{codeblock}
-\end{example}
+\begin{note}
+A name introduced in a \grammarterm{selection-statement} or
+\grammarterm{iteration-statement} outside of any substatement
+is in scope from its point of
+declaration until the end of the statement's substatements.
+Such a name cannot be redeclared in the outermost block of
+any of the substatements\iref{basic.scope.block}.
+\end{note}
 
 \pnum
 The value of a \grammarterm{condition} that is an initialized declaration


### PR DESCRIPTION
Fixes #2805.