### PR TITLE
[over.call.object] Fix surrogate calls with regards to cv-qualifiers

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -845,11 +845,11 @@ In addition, for each non-explicit conversion function declared in \tcode{T} of 
 form
 
 \begin{ncsimplebnf}
-\keyword{operator} conversion-type-id \terminal{(\,)} cv-qualifier \opt{ref-qualifier} \opt{noexcept-specifier} \opt{attribute-specifier-seq} \terminal{;}
+\keyword{operator} conversion-type-id \terminal{(\,)} \opt{cv-qualifier-seq} \opt{ref-qualifier} \opt{noexcept-specifier} \opt{attribute-specifier-seq} \terminal{;}
 \end{ncsimplebnf}
 
-where
-\grammarterm{cv-qualifier}
+where the optional
+\grammarterm{cv-qualifier-seq}
 is the same cv-qualification as, or a greater cv-qualification than,
 \cv{},
 and where


### PR DESCRIPTION
Standardizes existing practice. All of GCC, Clang, MSVC, ICC in pedantic mode already behave as if all of these changes were made.

Evidence for the above: 

no method cv-qualifier: https://godbolt.org/z/C0AcCi
both method cv-qualifiers: https://godbolt.org/z/-zy4GY
const pointer: https://godbolt.org/z/EVQ781
volatile pointer: https://godbolt.org/z/tePbKG
const volatile pointer: https://godbolt.org/z/f-g1Ge
reference to const pointer: https://godbolt.org/z/uXEp-J
reference to volatile pointer: https://godbolt.org/z/l2KEs9
reference to const volatile pointer: https://godbolt.org/z/5Mhijc

Other justification for the first two (in document order) changes: it is unlikely to be Committee intent to permit surrogate calls only on conversion functions with exactly one cv-qualifier.