### PR TITLE
[range.semi.wrap] Rename "semiregular" to "semiregular-box"

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1549,7 +1549,7 @@ namespace std::ranges {
     requires is_object_v<T>
   class single_view : public view_interface<single_view<T>> {
   private:
-    @\placeholdernc{semiregular}@<T> value_;      // \expos
+    @\placeholdernc{semiregular-box}@<T> value_;      // \expos{} (see \ref{range.semi.wrap})
   public:
     single_view() = default;
     constexpr explicit single_view(const T& t);
@@ -2328,28 +2328,28 @@ closure object.
 \rSec2[range.semi.wrap]{Semiregular wrapper}
 
 \pnum
-Many of the types in this subclause are specified in terms of
-an exposition-only class template \tcode{\placeholder{semiregular}}.
-\tcode{\placeholder{semiregular}<T>} behaves exactly like \tcode{optional<T>}
+Many types in this subclause are specified in terms of
+an exposition-only class template \tcode{\placeholder{semiregular-box}}.
+\tcode{\placeholder{semiregular-box}<T>} behaves exactly like \tcode{optional<T>}
 with the following differences:
 
 \begin{itemize}
-\item \tcode{\placeholder{semiregular}<T>} constrains
+\item \tcode{\placeholder{semiregular-box}<T>} constrains
 its type parameter \tcode{T} with
 \tcode{\libconcept{CopyConstructible}<T> \&\& is_object_v<T>}.
 
 \item If \tcode{T} models \libconcept{DefaultConstructible}, the default
-constructor of \tcode{\placeholder{semiregular}<T>} is equivalent to:
+constructor of \tcode{\placeholder{semiregular-box}<T>} is equivalent to:
 \begin{codeblock}
-constexpr @\placeholder{semiregular}@() noexcept(is_nothrow_default_constructible_v<T>)
-  : @\placeholder{semiregular}@{in_place}
+constexpr @\placeholder{semiregular-box}@() noexcept(is_nothrow_default_constructible_v<T>)
+  : @\placeholder{semiregular-box}@{in_place}
 { }
 \end{codeblock}
 
 \item If \tcode{\libconcept{Assignable}<T\&, const T\&>} is not
 satisfied, the copy assignment operator is equivalent to:
 \begin{codeblock}
-@\placeholder{semiregular}@& operator=(const @\placeholder{semiregular}@& that)
+@\placeholder{semiregular-box}@& operator=(const @\placeholder{semiregular-box}@& that)
   noexcept(is_nothrow_copy_constructible_v<T>)
 {
   if (that) emplace(*that);
@@ -2361,7 +2361,7 @@ satisfied, the copy assignment operator is equivalent to:
 \item If \tcode{\libconcept{Assignable}<T\&, T>} is not satisfied,
 the move assignment operator is equivalent to:
 \begin{codeblock}
-@\placeholder{semiregular}@& operator=(@\placeholder{semiregular}@&& that)
+@\placeholder{semiregular-box}@& operator=(@\placeholder{semiregular-box}@&& that)
   noexcept(is_nothrow_move_constructible_v<T>)
 {
   if (that) emplace(std::move(*that));
@@ -2488,13 +2488,13 @@ namespace std::ranges {
     requires View<V> && is_object_v<Pred>
   class filter_view : public view_interface<filter_view<V, Pred>> {
   private:
-    V base_ = V();              // \expos
-    @\placeholdernc{semiregular}@<Pred> pred_;    // \expos
+    V base_ = V();                // \expos
+    @\placeholdernc{semiregular-box}@<Pred> pred_;  // \expos
 
     // \ref{range.filter.iterator}, class \tcode{filter_view::iterator}
-    class iterator;             // \expos
+    class iterator;               // \expos
     // \ref{range.filter.sentinel}, class \tcode{filter_view::sentinel}
-    class sentinel;             // \expos
+    class sentinel;               // \expos
 
   public:
     filter_view() = default;
@@ -2935,7 +2935,7 @@ namespace std::ranges {
     template<bool> struct sentinel;             // \expos
 
     V base_ = V();                              // \expos
-    @\placeholdernc{semiregular}@<F> fun_;                        // \expos
+    @\placeholdernc{semiregular-box}@<F> fun_;                    // \expos
 
   public:
     transform_view() = default;


### PR DESCRIPTION
...to avoid confusion with the concept `Semiregular`. Update the uses in [range.single.view, range.filter.view,range.transform.view], and add a reference to [range.single.view] which now precedes [range.semi.wrap] since the "range factories" were pulled out into a separate subclause before the "range adaptors."