### PR TITLE
[stmt.return.coroutine] Move one level up to avoid hanging paragraphs.

### DIFF
--- a/source/statements.tex
+++ b/source/statements.tex
@@ -871,7 +871,7 @@ by the operand of the \tcode{return} statement, which, in turn, is sequenced
 before the destruction of local variables\iref{stmt.jump} of the block
 enclosing the \tcode{return} statement.
 
-\rSec3[stmt.return.coroutine]{The \tcode{co_return} statement}%
+\rSec2[stmt.return.coroutine]{The \tcode{co_return} statement}%
 \indextext{\idxcode{co_return}}%
 \indextext{coroutine return|see{\tcode{co_return}}}%
 


### PR DESCRIPTION
Fixes #2781.
Partially addresses #1730.