### PR TITLE
[expr.unary.op] Modernize wording for obtaining a pointer.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4157,11 +4157,13 @@ If the operand is a \grammarterm{qualified-id} naming a non-static or variant me
 of some class \tcode{C} with type \tcode{T}, the result has type ``pointer to member
 of class \tcode{C} of type \tcode{T}'' and is a prvalue designating \tcode{C::m}.
 \item
-Otherwise, if the operand is an lvalue of type \tcode{T}, the result has type ``pointer to
-\tcode{T}'' and is a prvalue that is the address of the designated object\iref{intro.memory}
-or a pointer to the designated function. \begin{note} In particular, the address of an
-object of type ``\cv{}~\tcode{T}'' is ``pointer to \cv{}~\tcode{T}'', with the same
-cv-qualification. \end{note}
+Otherwise, if the operand is an lvalue of type \tcode{T},
+the resulting expression is a prvalue of type ``pointer to \tcode{T}''
+whose result is a pointer to the designated object\iref{intro.memory} or function.
+\begin{note}
+In particular, taking the address of a variable of type ``\cv{}~\tcode{T}''
+yields a pointer of type ``pointer to \cv{}~\tcode{T}''.
+\end{note}
 For purposes of pointer arithmetic\iref{expr.add} and
 comparison~(\ref{expr.rel}, \ref{expr.eq}),
 an object that is not an array element whose


### PR DESCRIPTION
Fixes #2645.