### PR TITLE
[expr.add] Avoid x[i] syntax when defining pointer arithmetic.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5708,20 +5708,20 @@ the result has the type of \tcode{P}.
 \begin{itemize}
 \item If \tcode{P} evaluates to a null pointer value and
 \tcode{J} evaluates to 0, the result is a null pointer value.
-\item Otherwise, if \tcode{P} points to element $\mathtt{x[}i\mathtt{]}$
-of an array object \tcode{x} with $n$ elements,%
+\item Otherwise, if \tcode{P} points to an array element $i$
+of an array object \tcode{x} with $n$ elements\iref{dcl.array},%
 \footnote{An object that is not an array element is considered to belong to a
 single-element array for this purpose; see~\ref{expr.unary.op}.
 A pointer past the last element of an array \tcode{x} of $n$ elements
-is considered to be equivalent to a pointer to a hypothetical element
-$\mathtt{x[}n\mathtt{]}$ for this purpose; see~\ref{basic.compound}.}
+is considered to be equivalent to a pointer to a hypothetical array element
+$n$ for this purpose; see~\ref{basic.compound}.}
 the expressions \tcode{P + J} and \tcode{J + P}
 (where \tcode{J} has the value $j$)
-point to the (possibly-hypothetical) element
-$\mathtt{x[}i + j\mathtt{]}$ if $0 \le i + j \le n$
+point to the (possibly-hypothetical) array element
+$i + j$ of \tcode{x} if $0 \le i + j \le n$
 and the expression \tcode{P - J}
-points to the (possibly-hypothetical) element
-$\mathtt{x[}i - j\mathtt{]}$ if $0 \le i - j \le n$.
+points to the (possibly-hypothetical) array element
+$i - j$ of \tcode{x} if $0 \le i - j \le n$.
 \item Otherwise, the behavior is undefined.
 \end{itemize}
 
@@ -5740,7 +5740,7 @@ header\iref{support.types}.
 \item If \tcode{P} and \tcode{Q} both evaluate to null pointer values,
 the result is 0.
 \item Otherwise, if \tcode{P} and \tcode{Q} point to, respectively,
-elements $\mathtt{x[}i\mathtt{]}$ and $\mathtt{x[}j\mathtt{]}$
+array elements $i$ and $j$
 of the same array object \tcode{x},
 the expression \tcode{P - Q} has the value $i - j$.
 \item Otherwise, the behavior is undefined.


### PR DESCRIPTION
Fixes #2670.