### PR TITLE
[unord.req] Consistently use 'Average case x, worst case y.'

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -2620,8 +2620,8 @@ start.  Implementations are permitted to ignore the hint.%
 &   \expects \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.
     Neither \tcode{i} nor \tcode{j} are iterators into \tcode{a}.\br
     \effects Equivalent to \tcode{a.insert(t)} for each element in \tcode{[i,j)}.%
-&   Average case \bigoh{N}, where $N$ is \tcode{distance(i, j)}.
-    Worst case \bigoh{N(\tcode{a.size()}\brk{}+\brk{}1)}.
+&   Average case \bigoh{N}, where $N$ is \tcode{distance(i, j)},
+    worst case \bigoh{N(\tcode{a.size()}\brk{}+\brk{}1)}.
 \\ \rowsep
 %
 \tcode{a.insert(il)}
@@ -2701,15 +2701,15 @@ start.  Implementations are permitted to ignore the hint.%
  to the transferred elements and all iterators referring to \tcode{a} will
  be invalidated, but iterators to elements remaining in \tcode{a2} will
  remain valid. &
- Average case \bigoh{N}, where $N$ is \tcode{a2.size()}.
- Worst case \bigoh{N\tcode{*a.size()}\br\tcode{+} N}.  \\ \rowsep
+ Average case \bigoh{N}, where $N$ is \tcode{a2.size()},
+ worst case \bigoh{N\tcode{*a.size()}\br\tcode{+} N}.  \\ \rowsep
 %
 \indexunordmem{erase}%
 \tcode{a.erase(k)}
 &   \tcode{size_type}
 &   \effects Erases all elements with key equivalent to \tcode{k}.\br
     \returns The number of elements erased.
-&   Average case \bigoh{\tcode{a.count(k)}}.  Worst case
+&   Average case \bigoh{\tcode{a.count(k)}}, worst case
     \bigoh{\tcode{a.size()}}.
 \\ \rowsep
 %
@@ -2844,7 +2844,7 @@ start.  Implementations are permitted to ignore the hint.%
 &   \returns A range containing all elements with keys equivalent to
     \tcode{k}.  Returns \tcode{make_pair(b.end(), b.end())} if
     no such elements exist.%
-&   Average case \bigoh{\tcode{b.count(k)}}.  Worst case
+&   Average case \bigoh{\tcode{b.count(k)}}, worst case
     \bigoh{\tcode{b.size()}}.
 \\ \rowsep
 %
@@ -2855,7 +2855,7 @@ start.  Implementations are permitted to ignore the hint.%
     \returns A range containing all elements with keys equivalent to
     \tcode{k}.  Returns \tcode{make_pair(b.end(), b.end())} if
     no such elements exist.%
-&   Average case \bigoh{\tcode{b.count(k)}}.  Worst case
+&   Average case \bigoh{\tcode{b.count(k)}}, worst case
     \bigoh{\tcode{b.size()}}.
 \\ \rowsep
 %
@@ -2866,8 +2866,8 @@ start.  Implementations are permitted to ignore the hint.%
     \tcode{ke}.  Returns \tcode{make_pair(a_tran.end(), a_tran.end())} if
     no such elements exist.%
 &   Average case
-    \bigoh{\tcode{a_tran.}\br{}\tcode{count(ke)}}. % avoid overfull
-    Worst case \bigoh{\tcode{a_tran.}\br{}\tcode{size()}}. % avoid overfull
+    \bigoh{\tcode{a_tran.}\br{}\tcode{count(ke)}}, % avoid overfull
+    worst case \bigoh{\tcode{a_tran.}\br{}\tcode{size()}}. % avoid overfull
 \\ \rowsep
 %
 \tcode{a_tran.equal_range(ke, hke)}
@@ -2878,8 +2878,8 @@ start.  Implementations are permitted to ignore the hint.%
     \tcode{ke}.  Returns \tcode{make_pair(a_tran.end(), a_tran.end())} if
     no such elements exist.%
 &   Average case
-    \bigoh{\tcode{a_tran.}\br{}\tcode{count(ke)}}. % avoid overfull
-    Worst case \bigoh{\tcode{a_tran.}\br{}\tcode{size()}}. % avoid overfull
+    \bigoh{\tcode{a_tran.}\br{}\tcode{count(ke)}}, % avoid overfull
+    worst case \bigoh{\tcode{a_tran.}\br{}\tcode{size()}}. % avoid overfull
 \\ \rowsep
 \indexunordmem{bucket_count}%
 \tcode{b.bucket_count()}


### PR DESCRIPTION
instead of having 'worst case' in a separate sentence.

Fixes #2749.