### PR TITLE
[expr.unary.op] Use bullets to clarify the address-of operator.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4151,11 +4151,13 @@ The result of each of the following unary operators is a prvalue.
 \indextext{name!address of cv-qualified}%
 \indextext{expression!pointer-to-member constant}%
 The result of the unary \tcode{\&} operator is a pointer to its operand.
-The operand shall be an lvalue or a \grammarterm{qualified-id}.
+\begin{itemize}
+\item
 If the operand is a \grammarterm{qualified-id} naming a non-static or variant member \tcode{m}
 of some class \tcode{C} with type \tcode{T}, the result has type ``pointer to member
 of class \tcode{C} of type \tcode{T}'' and is a prvalue designating \tcode{C::m}.
-Otherwise, if the type of the expression is \tcode{T}, the result has type ``pointer to
+\item
+Otherwise, if the operand is an lvalue of type \tcode{T}, the result has type ``pointer to
 \tcode{T}'' and is a prvalue that is the address of the designated object\iref{intro.memory}
 or a pointer to the designated function. \begin{note} In particular, the address of an
 object of type ``\cv{}~\tcode{T}'' is ``pointer to \cv{}~\tcode{T}'', with the same
@@ -4165,8 +4167,10 @@ comparison~(\ref{expr.rel}, \ref{expr.eq}),
 an object that is not an array element whose
 address is taken in this way is considered to belong to an array with one
 element of type \tcode{T}.
+\item
+Otherwise, the program is ill-formed.
+\end{itemize}
 \begin{example}
-
 \begin{codeblock}
 struct A { int i; };
 struct B : A { };


### PR DESCRIPTION
Also cover the missed case of a prvalue qualified-id.

Fixes #2919.