### PR TITLE
[algorithms.parallel.exec],[alg.set.operations],[alg.min.max],[alg.clibrary] remove empty parens

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -375,7 +375,7 @@ The modifying element access functions are those
 which are specified as modifying the object.
 \begin{note}
 For example,
-\tcode{swap()},
+\tcode{swap},
 \tcode{++},
 \tcode{--},
 \tcode{@=}, and
@@ -7018,9 +7018,9 @@ This subclause defines all the basic set operations on sorted structures.
 They also work with \tcode{multiset}s\iref{multiset}
 containing multiple copies of equivalent elements.
 The semantics of the set operations are generalized to \tcode{multiset}s
-in a standard way by defining \tcode{set_union()}
+in a standard way by defining \tcode{set_union}
 to contain the maximum number of occurrences of every element,
-\tcode{set_intersection()} to contain the minimum, and so on.
+\tcode{set_intersection} to contain the minimum, and so on.
 
 \rSec3[includes]{\tcode{includes}}
 
@@ -8202,7 +8202,7 @@ template<ForwardRange R, class Proj = identity,
 \tcode{\{m, M\}}, where \tcode{m} is
 the first iterator in \range{first}{last} such that no iterator in the range refers
 to a smaller element, and where \tcode{M} is the last iterator\footnote{This behavior
-intentionally differs from \tcode{max_element()}.}
+intentionally differs from \tcode{max_element}.}
 in \range{first}{last} such that no iterator in the range refers to a larger element.
 
 \pnum
@@ -9816,7 +9816,7 @@ unless the objects in the array pointed to by \tcode{base} are of trivial type.
 
 \pnum
 \throws
-Any exception thrown by \tcode{compar()}\iref{res.on.exception.handling}.
+Any exception thrown by \tcode{compar}\iref{res.on.exception.handling}.
 \end{itemdescr}
 
 \xref


### PR DESCRIPTION
When referring to a function, use its name, not a call expression.