### PR TITLE
[xrefdelta] Remove spurious entry for no-op rename.

### DIFF
--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -207,7 +207,6 @@
 \movedxref{char.traits.specializations.char16_t}{char.traits.specializations.char16.t}
 \movedxref{char.traits.specializations.char32_t}{char.traits.specializations.char32.t}
 \movedxref{char.traits.specializations.char8_t}{char.traits.specializations.char8.t}
-\movedxref{class.mfct.non-static}{class.mfct.non-static}
 \movedxref{comparisons.equal_to}{comparisons.equal.to}
 \movedxref{comparisons.greater_equal}{comparisons.greater.equal}
 \movedxref{comparisons.less_equal}{comparisons.less.equal}


### PR DESCRIPTION
Fixes #2923.