### PR TITLE
[time.cal.ymwdlast.members] Move statement on class properties

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -7350,10 +7350,10 @@ which efficiently supports \tcode{days}-oriented arithmetic.
 \end{note}
 \tcode{year_month_weekday_last} is \oldconcept{EqualityComparable} (Table~\ref{tab:equalitycomparable}).
 
-\rSec3[time.cal.ymwdlast.members]{Member functions}
-
 \pnum
 \tcode{year_month_weekday_last} is a trivially copyable and standard-layout class type.
+
+\rSec3[time.cal.ymwdlast.members]{Member functions}
 
 \indexlibrary{\idxcode{year_month_weekday_last}!constructor}%
 \begin{itemdecl}


### PR DESCRIPTION
to [time.cal.ymwdlast.overview], consistent with
neighboring similar subclauses.

Fixes #2915.