### PR TITLE
[lex] Fix stray uses of 'source character set'

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -123,7 +123,7 @@ concatenation\iref{cpp.concat}, the behavior is undefined. A
 source file to be processed from phase 1 through phase 4, recursively.
 All preprocessing directives are then deleted.
 
-\item Each source character set member in a character literal or a string
+\item Each basic source character set member in a character literal or a string
 literal, as well as each escape sequence and \grammarterm{universal-character-name} in a
 character literal or a non-raw string literal, is converted to the corresponding
 member of the execution character set~(\ref{lex.ccon}, \ref{lex.string}); if
@@ -1109,7 +1109,7 @@ that cannot be represented by any of the allowed types.
 
 \begin{bnf}
 \nontermdef{c-char}\br
-    \textnormal{any member of the source character set except the single-quote \terminal{'}, backslash \terminal{\textbackslash}, or new-line character}\br
+    \textnormal{any member of the basic source character set except the single-quote \terminal{'}, backslash \terminal{\textbackslash}, or new-line character}\br
     escape-sequence\br
     universal-character-name
 \end{bnf}
@@ -1460,7 +1460,7 @@ values for its type, the program is ill-formed.
 
 \begin{bnf}
 \nontermdef{s-char}\br
-    \textnormal{any member of the source character set except the double-quote \terminal{"}, backslash \terminal{\textbackslash}, or new-line character}\br
+    \textnormal{any member of the basic source character set except the double-quote \terminal{"}, backslash \terminal{\textbackslash}, or new-line character}\br
     escape-sequence\br
     universal-character-name
 \end{bnf}


### PR DESCRIPTION
where it is obvious that 'basic source character set'
is meant.

Fixes #2857.