### PR TITLE
[range.split.outer] Convert trailing cross-reference to prefix style.

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -4475,7 +4475,8 @@ namespace std::ranges {
     using iterator_concept  =
       conditional_t<ForwardRange<Base>, forward_iterator_tag, input_iterator_tag>;
     using iterator_category = input_iterator_tag;
-    struct value_type;                                  // see \ref{range.split.outer.value}
+    // \ref{range.split.outer.value}, class \tcode{split_view::outer_iterator::value_type}
+    struct value_type;
     using difference_type   = iter_difference_t<iterator_t<Base>>;
 
     outer_iterator() = default;


### PR DESCRIPTION
Fixes #2790.