### PR TITLE
[move.sent.ops] Add missing description of move_sentinel::base

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -4460,6 +4460,17 @@ template<class S2>
 \effects Equivalent to: \tcode{last = s.last; return *this;}
 \end{itemdescr}
 
+\indexlibrarymember{base}{move_sentinel}%
+\begin{itemdecl}
+constexpr S base() const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\tcode{last}.
+\end{itemdescr}
+
 \rSec2[iterators.common]{Common iterators}
 
 \rSec3[common.iterator]{Class template \tcode{common_iterator}}


### PR DESCRIPTION
Or add a section like `\rSec3[move.sent.ops.conv]{Conversion}` ?