### PR TITLE
[range.filter.sentinel] Correct typo in constructor Effects

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2838,7 +2838,7 @@ constexpr explicit sentinel(filter_view& parent);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{end_} with \tcode{ranges::end(parent)}.
+\effects Initializes \tcode{end_} with \tcode{ranges::end(parent.base_)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{base}!\idxcode{filter_view::sentinel}}%


### PR DESCRIPTION
Resolves #2880.

Note that I'm once again stretching "editorial" to avoid burning LWG time. The existing specification is obviously incorrect - it would result in either an ill-formed program or stack overflow - but the fix is not quite as obviously correct. As always, feel free to call this non-editorial and I'll file an LWG issue instead.