### PR TITLE
[expr.prim.lambda] Capture j so that it compiles

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1586,10 +1586,10 @@ type specified by the
 \tcode{return} statements as described in~\ref{dcl.spec.auto}.
 \begin{example}
 \begin{codeblock}
-auto x1 = [](int i){ return i; };     // OK: return type is \tcode{int}
-auto x2 = []{ return { 1, 2 }; };     // error: deducing return type from \grammarterm{braced-init-list}
+auto x1 = [](int i){ return i; };         // OK: return type is \tcode{int}
+auto x2 = []{ return { 1, 2 }; };         // error: deducing return type from \grammarterm{braced-init-list}
 int j;
-auto x3 = [&j]()->auto&& { return j; }; // OK: return type is \tcode{int\&}
+auto x3 = [&j]()->auto&& { return j; };   // OK: return type is \tcode{int\&}
 \end{codeblock}
 \end{example}
 

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1589,7 +1589,7 @@ type specified by the
 auto x1 = [](int i){ return i; };     // OK: return type is \tcode{int}
 auto x2 = []{ return { 1, 2 }; };     // error: deducing return type from \grammarterm{braced-init-list}
 int j;
-auto x3 = []()->auto&& { return j; }; // OK: return type is \tcode{int\&}
+auto x3 = [&j]()->auto&& { return j; }; // OK: return type is \tcode{int\&}
 \end{codeblock}
 \end{example}
 


### PR DESCRIPTION
The lambda captured **nothing**, but it returns the variable from the enclosing block scope. I assume this is editorial, and can easily be fixed by adding `&j`.