### PR TITLE
[conv.qual] Fix example for cv-decomposition.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -736,8 +736,11 @@ the cv-qualifiers $\cv{}_{i+1}$ on the element type are also taken as
 the cv-qualifiers $\cv{}_i$ of the array.
 \begin{example}
 The type denoted by the \grammarterm{type-id} \tcode{const int **}
-has two cv-decompositions,
-taking \tcode{U} as ``\tcode{int}'' and as ``pointer to \tcode{const int}''.
+has three cv-decompositions,
+taking \tcode{U}
+as ``\tcode{int}'',
+as ``pointer to \tcode{const int}'', and
+as ``pointer to pointer to \tcode{const int}''.
 \end{example}
 The $n$-tuple of cv-qualifiers after the first one
 in the longest cv-decomposition of \tcode{T}, that is,


### PR DESCRIPTION
After CWG2051, a cv-decomposition can also be a no-op.

Fixes #2940.