### PR TITLE
[res.on.functions] Properly capitalize full-sentence bullets.

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2882,17 +2882,17 @@ In particular, the effects are undefined in the following cases:
 
 \begin{itemize}
 \item
-for replacement functions\iref{new.delete}, if the installed replacement function does not
+For replacement functions\iref{new.delete}, if the installed replacement function does not
 implement the semantics of the applicable
 \required
 paragraph.
 \item
-for handler functions~(\ref{new.handler}, \ref{terminate.handler}),
+For handler functions~(\ref{new.handler}, \ref{terminate.handler}),
 if the installed handler function does not implement the semantics of the applicable
 \required
-paragraph
+paragraph.
 \item
-for types used as template arguments when instantiating a template component,
+For types used as template arguments when instantiating a template component,
 if the operations on the type do not implement the semantics of the applicable
 \emph{Requirements}
 subclause~(\ref{allocator.requirements}, \ref{container.requirements}, \ref{iterator.requirements},
@@ -2900,13 +2900,13 @@ subclause~(\ref{allocator.requirements}, \ref{container.requirements}, \ref{iter
 Operations on such types can report a failure by throwing an exception
 unless otherwise specified.
 \item
-if any replacement function or handler function or destructor operation exits via an exception,
+If any replacement function or handler function or destructor operation exits via an exception,
 unless specifically allowed
 in the applicable
 \required
 paragraph.
 \item
-if an incomplete type\iref{basic.types} is used as a template
+If an incomplete type\iref{basic.types} is used as a template
 argument when instantiating a template component or evaluating a concept, unless specifically
 allowed for that component.
 \end{itemize}


### PR DESCRIPTION
Also add periods at the end of sentences.

Fixes #2945.