### PR TITLE
[expr.prim.req] Fix cross-reference for substituting into constraints.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2774,7 +2774,7 @@ shall be satisfied\iref{temp.constr.decl}
 by the substituted template arguments, if any.
 Substitution of template arguments into a \grammarterm{nested-requirement}
 does not result in substitution into the \grammarterm{constraint-expression}
-other than as specified in \ref{temp.constr.decl}.
+other than as specified in \ref{temp.constr.constr}.
 \begin{example}
 \begin{codeblock}
 template<typename U> concept C = sizeof(U) == 1;


### PR DESCRIPTION
Fixes #2944.