### PR TITLE
[time.parse] Fix description of %Ex and %EX parse flags.

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -10940,11 +10940,11 @@ and flags which have special meaning.
 Each flag begins with a \tcode{\%}.
 Some flags can be modified by \tcode{E} or \tcode{O}.
 During parsing each flag interprets characters as parts of date and time types
-according to the table below.
+according to~\tref{time.parse.spec}.
 Some flags can be modified by a width parameter
 given as a positive decimal integer called out as \tcode{\placeholder{N}} below
 which governs how many characters are parsed from the stream in interpreting the flag.
-All characters in the format string that are not represented in the table below,
+All characters in the format string that are not represented in~\tref{time.parse.spec},
 except for white space, are parsed unchanged from the stream.
 A white space character matches zero or more white space characters in the input stream.
 
@@ -11155,11 +11155,11 @@ Leading zeroes are permitted but not required.
 \\ \rowsep
 \tcode{\%x} &
 The locale's date representation.
-The modified command \tcode{\%Ex} produces the locale's alternate date representation.
+The modified command \tcode{\%Ex} interprets the locale's alternate date representation.
 \\ \rowsep
 \tcode{\%X} &
 The locale's time representation.
-The modified command \tcode{\%EX} produces the locale's alternate time representation.
+The modified command \tcode{\%EX} interprets the locale's alternate time representation.
 \\ \rowsep
 \tcode{\%y} &
 The last two decimal digits of the year.


### PR DESCRIPTION
Also refer to the table number instead of 'the table below'.

Fixes #2935.