### PR TITLE
[Concepts] Remove qualified-concept-name reference

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -3586,11 +3586,11 @@ under the following conditions:
 equivalent types,
 \item if they declare template template parameters, their template
 parameters are equivalent, and
-\item if either is declared with a \grammarterm{qualified-concept-name},
-they both are, and the \grammarterm{qualified-concept-name}{s} are
+\item if either is declared with a \grammarterm{type-constraint},
+they both are, and the \grammarterm{type-constraint}{s} are
 equivalent.
 \end{itemize}
-When determining whether types or \grammarterm{qualified-concept-name}{s}
+When determining whether types or \grammarterm{type-constraint}{s}
 are equivalent, the rules above are used to compare expressions
 involving template parameters.
 Two \grammarterm{template-head}{s} are


### PR DESCRIPTION
Update 'qualified-concept-name' (the previous incarnation of 'type-constraint') reference to 'type-constraint' in [temp.over.link]p6.