### PR TITLE
[basic.life] Lifetime of class objects is treated uniformly

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3137,12 +3137,12 @@ construction and destruction phases. \end{note}
 \pnum
 A program may end the lifetime of any object by reusing the storage
 which the object occupies or by explicitly calling the destructor for an
-object of a class type with a non-trivial destructor. For an object of a
-class type with a non-trivial destructor, the program is not required to
+object of a class type.
+For an object of a class type, the program is not required to
 call the destructor explicitly before the storage which the object
 occupies is reused or released; however, if there is no explicit call to
 the destructor or if a \grammarterm{delete-expression}\iref{expr.delete}
-is not used to release the storage, the destructor shall not be
+is not used to release the storage, the destructor is not
 implicitly called and any program that depends on the side effects
 produced by the destructor has undefined behavior.
 


### PR DESCRIPTION
under CWG2256, regardless of triviality of the destructor.

Fixes #2953.