### PR TITLE
[expr.reinterpret.cast] Properly capitalize full-sentence bullets.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3934,11 +3934,11 @@ null member pointer value of the destination type. The result of this
 conversion is unspecified, except in the following cases:
 
 \begin{itemize}
-\item converting a prvalue of type ``pointer to member function'' to a
+\item Converting a prvalue of type ``pointer to member function'' to a
 different pointer-to-member-function type and back to its original type
 yields the original pointer-to-member value.
 
-\item converting a prvalue of type ``pointer to data member of \tcode{X}
+\item Converting a prvalue of type ``pointer to data member of \tcode{X}
 of type \tcode{T1}'' to the type ``pointer to data member of \tcode{Y}
 of type \tcode{T2}'' (where the alignment requirements of \tcode{T2} are
 no stricter than those of \tcode{T1}) and back to its original type


### PR DESCRIPTION
Similar to #2946.