### PR TITLE
[INDEX] Ensure index entry for all Cpp17Requirements

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1730,7 +1730,7 @@ denotes a value of some type that is writable to the output iterator.
 \begin{note} For an iterator type \tcode{X} there must be an instantiation
 of \tcode{iterator_traits<X>}\iref{iterator.traits}. \end{note}
 
-\rSec3[iterator.iterators]{\oldconcept{Iterator}}
+\rSec3[iterator.iterators]{\oldconceptdefn{Iterator}}
 
 \pnum
 The \oldconcept{Iterator} requirements form the basis of the iterator
@@ -1821,7 +1821,7 @@ has property
 \end{example}
 
 \begin{libreqtab4b}
-{\oldconcept{InputIterator} requirements (in addition to \oldconcept{Iterator})}
+{\oldconceptdefn{InputIterator} requirements (in addition to \oldconcept{Iterator})}
 {inputiterator}
 \\ \topline
 \lhdr{Expression}   &   \chdr{Return type}  &   \chdr{Operational}  &   \rhdr{Assertion/note}       \\
@@ -1896,7 +1896,7 @@ and the expressions in \tref{outputiterator}
 are valid and have the indicated semantics.
 
 \begin{libreqtab4b}
-{\oldconcept{OutputIterator} requirements (in addition to \oldconcept{Iterator})}
+{\oldconceptdefn{OutputIterator} requirements (in addition to \oldconcept{Iterator})}
 {outputiterator}
 \\ \topline
 \lhdr{Expression}   &   \chdr{Return type}  &   \chdr{Operational}  &   \rhdr{Assertion/note}       \\
@@ -1998,7 +1998,7 @@ allows the use of multi-pass one-directional algorithms with forward iterators.
 \end{note}
 
 \begin{libreqtab4b}
-{\oldconcept{ForwardIterator} requirements (in addition to \oldconcept{InputIterator})}
+{\oldconceptdefn{ForwardIterator} requirements (in addition to \oldconcept{InputIterator})}
 {forwarditerator}
 \\ \topline
 \lhdr{Expression}   &   \chdr{Return type}  &   \chdr{Operational}  &   \rhdr{Assertion/note}       \\
@@ -2039,7 +2039,7 @@ in addition to meeting the \oldconcept{ForwardIterator} requirements,
 the following expressions are valid as shown in \tref{bidirectionaliterator}.
 
 \begin{libreqtab4b}
-{\oldconcept{BidirectionalIterator} requirements (in addition to \oldconcept{ForwardIterator})}
+{\oldconceptdefn{BidirectionalIterator} requirements (in addition to \oldconcept{ForwardIterator})}
 {bidirectionaliterator}
 \\ \topline
 \lhdr{Expression}   &   \chdr{Return type}  &   \chdr{Operational}  &   \rhdr{Assertion/note}       \\
@@ -2084,7 +2084,7 @@ in addition to meeting the \oldconcept{BidirectionalIterator} requirements,
 the following expressions are valid as shown in \tref{randomaccessiterator}.
 
 \begin{libreqtab4b}
-{\oldconcept{RandomAccessIterator} requirements (in addition to \oldconcept{BidirectionalIterator})}
+{\oldconceptdefn{RandomAccessIterator} requirements (in addition to \oldconcept{BidirectionalIterator})}
 {randomaccessiterator}
 \\ \topline
 \lhdr{Expression}   &   \chdr{Return type}  &   \chdr{Operational}  &   \rhdr{Assertion/note}       \\

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1649,7 +1649,7 @@ member function signatures specify \tcode{T()} as a default argument.
 signatures is called using the default argument\iref{dcl.fct.default}.
 
 \indextext{requirements!\idxoldconcept{EqualityComparable}}%
-\begin{concepttable}{\oldconcept{EqualityComparable} requirements}{cpp17.equalitycomparable}
+\begin{concepttable}{\oldconceptdefn{EqualityComparable} requirements}{cpp17.equalitycomparable}
 {x{1in}x{1in}p{3in}}
 \topline
 \hdstyle{Expression}  &   \hdstyle{Return type} &   \rhdr{Requirement} \\ \capsep
@@ -1668,7 +1668,7 @@ If \tcode{a == b} and \tcode{b == c}, then \tcode{a == c}.
 \end{concepttable}
 
 \indextext{requirements!\idxoldconcept{LessThanComparable}}%
-\begin{concepttable}{\oldconcept{LessThanComparable} requirements}{cpp17.lessthancomparable}
+\begin{concepttable}{\oldconceptdefn{LessThanComparable} requirements}{cpp17.lessthancomparable}
 {x{1in}x{1in}p{3in}}
 \topline
 \hdstyle{Expression}  &   \hdstyle{Return type} &   \hdstyle{Requirement} \\ \capsep
@@ -1679,7 +1679,7 @@ convertible to \tcode{bool} &
 
 \enlargethispage{-3\baselineskip}
 \indextext{requirements!\idxoldconcept{DefaultConstructible}}%
-\begin{concepttable}{\oldconcept{DefaultConstructible} requirements}{cpp17.defaultconstructible}
+\begin{concepttable}{\oldconceptdefn{DefaultConstructible} requirements}{cpp17.defaultconstructible}
 {x{2.15in}p{3in}}
 \topline
 \hdstyle{Expression}        &     \hdstyle{Post-condition}  \\ \capsep
@@ -1690,7 +1690,7 @@ convertible to \tcode{bool} &
 \end{concepttable}
 
 \indextext{requirements!\idxoldconcept{MoveConstructible}}%
-\begin{concepttable}{\oldconcept{MoveConstructible} requirements}{cpp17.moveconstructible}
+\begin{concepttable}{\oldconceptdefn{MoveConstructible} requirements}{cpp17.moveconstructible}
 {p{1in}p{4.15in}}
 \topline
 \hdstyle{Expression}          &   \hdstyle{Post-condition}  \\ \capsep
@@ -1705,7 +1705,7 @@ convertible to \tcode{bool} &
 \end{concepttable}
 
 \indextext{requirements!\idxoldconcept{CopyConstructible}}%
-\begin{concepttable}{\oldconcept{CopyConstructible} requirements (in addition to \oldconcept{MoveConstructible})}{cpp17.copyconstructible}
+\begin{concepttable}{\oldconceptdefn{CopyConstructible} requirements (in addition to \oldconcept{MoveConstructible})}{cpp17.copyconstructible}
 {p{1in}p{4.15in}}
 \topline
 \hdstyle{Expression}          &   \hdstyle{Post-condition}  \\ \capsep
@@ -1715,7 +1715,7 @@ convertible to \tcode{bool} &
 \end{concepttable}
 
 \indextext{requirements!\idxoldconcept{MoveAssignable}}%
-\begin{concepttable}{\oldconcept{MoveAssignable} requirements}{cpp17.moveassignable}
+\begin{concepttable}{\oldconceptdefn{MoveAssignable} requirements}{cpp17.moveassignable}
 {p{1in}p{1in}p{1in}p{1.9in}}
 \topline
 \hdstyle{Expression} & \hdstyle{Return type} & \hdstyle{Return value} & \hdstyle{Post-condition} \\ \capsep
@@ -1731,7 +1731,7 @@ convertible to \tcode{bool} &
 \end{concepttable}
 
 \indextext{requirements!\idxoldconcept{CopyAssignable}}%
-\begin{concepttable}{\oldconcept{CopyAssignable} requirements (in addition to \oldconcept{MoveAssignable})}{cpp17.copyassignable}
+\begin{concepttable}{\oldconceptdefn{CopyAssignable} requirements (in addition to \oldconcept{MoveAssignable})}{cpp17.copyassignable}
 {p{1in}p{1in}p{1in}p{1.9in}}
 \topline
 \hdstyle{Expression} & \hdstyle{Return type} & \hdstyle{Return value} & \hdstyle{Post-condition} \\ \capsep
@@ -1739,7 +1739,7 @@ convertible to \tcode{bool} &
 \end{concepttable}
 
 \indextext{requirements!\idxoldconcept{Destructible}}
-\begin{concepttable}{\oldconcept{Destructible} requirements}{cpp17.destructible}
+\begin{concepttable}{\oldconceptdefn{Destructible} requirements}{cpp17.destructible}
 {p{1in}p{4.15in}}
 \topline
 \hdstyle{Expression}      &   \hdstyle{Post-condition}  \\ \capsep
@@ -1796,7 +1796,7 @@ swappable with any rvalue or lvalue, respectively, of type \tcode{T}.
 
 \pnum
 A type \tcode{X} meeting any of the iterator requirements\iref{iterator.requirements}
-meets the \oldconcept{ValueSwappable} requirements if,
+meets the \oldconceptdefn{ValueSwappable} requirements if,
 for any dereferenceable object
 \tcode{x} of type \tcode{X},
 \tcode{*x} is swappable.
@@ -1845,7 +1845,7 @@ int main() {
 \end{codeblock}
 \end{example}
 
-\rSec3[nullablepointer.requirements]{\oldconcept{NullablePointer} requirements}
+\rSec3[nullablepointer.requirements]{\oldconceptdefn{NullablePointer} requirements}
 
 \pnum
 A \oldconcept{NullablePointer} type is a pointer-like type that supports null values.
@@ -1923,7 +1923,7 @@ Expression  &   Return type   &   Operational semantics \\ \capsep
                               \\ \rowsep
 \end{concepttable}
 
-\rSec3[hash.requirements]{\oldconcept{Hash} requirements}
+\rSec3[hash.requirements]{\oldconceptdefn{Hash} requirements}
 
 \indextext{requirements!\idxoldconcept{Hash}}
 \pnum
@@ -1961,7 +1961,7 @@ Expression        &     Return type     &       Requirement \\ \capsep
   Shall not modify \tcode{u}. \\
 \end{concepttable}
 
-\rSec3[allocator.requirements]{\oldconcept{Allocator} requirements}
+\rSec3[allocator.requirements]{\oldconceptdefn{Allocator} requirements}
 
 \indextext{requirements!\idxoldconcept{Allocator}}%
 \pnum

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -329,7 +329,7 @@
 
 %% Concepts
 \newcommand{\oldconcept}[1]{\textit{Cpp17#1}}
-\newcommand{\oldconceptdefn}[1]{\defn{Cpp17#1}}
+\newcommand{\oldconceptdefn}[1]{\defnx{Cpp17#1}{\textit{Cpp17#1}}}
 \newcommand{\idxoldconcept}[1]{Cpp17#1@\textit{Cpp17#1}}
 \newcommand{\libconcept}[1]{\tcode{#1}}
 

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -171,7 +171,7 @@ in order to acquire or release ownership of a \tcode{lock} by a given execution 
 \begin{note} The nature of any lock ownership and any synchronization it may entail are not part
 of these requirements. \end{note}
 
-\rSec3[thread.req.lockable.basic]{\oldconcept{BasicLockable} requirements}
+\rSec3[thread.req.lockable.basic]{\oldconceptdefn{BasicLockable} requirements}
 
 \pnum
 A type \tcode{L} meets the \oldconcept{BasicLockable} requirements if the following expressions are
@@ -202,7 +202,7 @@ m.unlock()
 \throws Nothing.
 \end{itemdescr}
 
-\rSec3[thread.req.lockable.req]{\oldconcept{Lockable} requirements}
+\rSec3[thread.req.lockable.req]{\oldconceptdefn{Lockable} requirements}
 
 \pnum
 A type \tcode{L} meets the \oldconcept{Lockable} requirements if it meets the \oldconcept{BasicLockable}
@@ -225,7 +225,7 @@ exception is thrown then a lock shall not have been acquired for the current exe
 \returns \tcode{true} if the lock was acquired, \tcode{false} otherwise.
 \end{itemdescr}
 
-\rSec3[thread.req.lockable.timed]{\oldconcept{TimedLockable} requirements}
+\rSec3[thread.req.lockable.timed]{\oldconceptdefn{TimedLockable} requirements}
 
 \pnum
 A type \tcode{L} meets the \oldconcept{TimedLockable} requirements if it meets the \oldconcept{Lockable}

--- a/source/time.tex
+++ b/source/time.tex
@@ -1018,7 +1018,7 @@ namespace std {
 }
 \end{codeblock}
 
-\rSec1[time.clock.req]{\oldconcept{Clock} requirements}
+\rSec1[time.clock.req]{\oldconceptdefn{Clock} requirements}
 
 \pnum
 A clock is a bundle consisting of a \tcode{duration}, a
@@ -1079,7 +1079,7 @@ before \tcode{C1::time_point::max()}.
 SI definition is a measure of the quality of implementation. \end{note}
 
 \pnum
-A type \tcode{TC} meets the \oldconcept{TrivialClock} requirements if:
+A type \tcode{TC} meets the \oldconceptdefn{TrivialClock} requirements if:
 
 \begin{itemize}
 \item \tcode{TC} meets the \oldconcept{Clock} requirements\iref{time.clock.req},


### PR DESCRIPTION
Ensure that each Cpp17Requirement that uses the \oldconcept markup
has one, and exactly one, usage close to its definition that uses
the \oldconceptdefn markup instead.  This puts a consistent set of
entries with the Cpp17 prefix into the main index.

Note that there are existing, inconsistent, attempts to index these
requirements, with the container 'into' requirements appearing at
the top of the index due to a \defnx (and the markup somehow changing
the sort order) and most of the lib-intro requirements appearing as
sub-entries under 'Requirements'.  This change-set updates the
\oldconceptdefn macro to use \defnx consistent with the containers
clause usage, producing a single consistent list that is out of place
w.r.t. the spelling, and does not refactor the mark-up for containers.