### PR TITLE
[unique.ptr] Clarify nullptr case in destructor and reset()

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -9288,11 +9288,10 @@ to the stored deleter that was constructed from
 
 \begin{itemdescr}
 \pnum
-\requires The expression \tcode{get_deleter()(get())} shall be well-formed,
-shall have well-defined behavior, and shall not throw exceptions.
-\begin{note}
-The
-use of \tcode{default_delete} requires \tcode{T} to be a complete type.
+\requires The expression \tcode{get_deleter()(get())} shall be well-formed, and shall
+not throw exceptions. If \tcode{get() != nullptr}, \tcode{get_deleter()(get())}
+shall have well-defined behavior. \begin{note} The use of \tcode{default_delete}
+requires \tcode{T} to be a complete type.
 \end{note}
 
 \pnum
@@ -9484,8 +9483,9 @@ void reset(pointer p = pointer()) noexcept;
 
 \begin{itemdescr}
 \pnum
-\requires The expression \tcode{get_deleter()(get())} shall be well-formed, shall have
-well-defined behavior, and shall not throw exceptions.
+\requires The expression \tcode{get_deleter()(get())} shall be well-formed, and shall not
+throw exceptions. If \tcode{get() != nullptr}, the expression \tcode{get_deleter()(get())}
+shall have well-defined behavior.
 
 \pnum
 \effects

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -9288,10 +9288,10 @@ to the stored deleter that was constructed from
 
 \begin{itemdescr}
 \pnum
-\requires The expression \tcode{get_deleter()(get())} shall be well-formed, and shall
-not throw exceptions. If \tcode{get() != nullptr}, \tcode{get_deleter()(get())}
-shall have well-defined behavior. \begin{note} The use of \tcode{default_delete}
-requires \tcode{T} to be a complete type.
+\requires The expression \tcode{get_deleter()(get())} shall be well-formed.
+If \tcode{get() != nullptr}, \tcode{get_deleter()(get())} shall have
+well-defined behavior, and shall not throw exceptions. \begin{note}
+The use of \tcode{default_delete} requires \tcode{T} to be a complete type.
 \end{note}
 
 \pnum
@@ -9483,9 +9483,9 @@ void reset(pointer p = pointer()) noexcept;
 
 \begin{itemdescr}
 \pnum
-\requires The expression \tcode{get_deleter()(get())} shall be well-formed, and shall not
-throw exceptions. If \tcode{get() != nullptr}, the expression \tcode{get_deleter()(get())}
-shall have well-defined behavior.
+\requires The expression \tcode{get_deleter()(get())} shall be well-formed.
+If \tcode{get() != nullptr}, the expression \tcode{get_deleter()(get())}
+shall have well-defined behavior, and shall not throw exceptions.
 
 \pnum
 \effects


### PR DESCRIPTION
In `unique_ptr::~unique_ptr` and `unique_ptr::reset`, the Requires statements are ambiguous about whether `get_deleter()(nullptr)` should have well-defined behaviour.

From the Effects statements for both specifications, it's clear that `get_deleter(get())` is not called in the case where the `unique_ptr` contains `nullptr`. This fix makes it clear that `get_deleter(nullptr)` is not required to have well-defined behaviour.