### PR TITLE
[complex.literals] Remove bogus index entry

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -1247,7 +1247,6 @@ ensure, for a call with at least one argument of type \tcode{complex<T>}:
 \rSec2[complex.literals]{Suffixes for complex number literals}
 
 \indextext{literal!complex}%
-\indexlibrary{\tcode{complex}!literals}%
 \pnum
 This subclause describes literal suffixes for constructing complex number literals.
 The suffixes \tcode{i}, \tcode{il}, and \tcode{if} create complex numbers of


### PR DESCRIPTION
We have a bogus entry at the very start of the index of library names:

![libraryindex](https://user-images.githubusercontent.com/1254480/61366261-1c445a80-a881-11e9-880f-c5e50b86415d.png)

No other UDLs have such an entry in the index of library names (they just have a sub-entry under "literal" in the main index).
