### PR TITLE
[expr.unary.noexcept] Delete irrelevant copy-paste from previous section

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4619,9 +4619,6 @@ The result of the \tcode{noexcept} operator is a prvalue of type \tcode{bool}.
 \begin{note}
 A \grammarterm{noexcept-expression}
 is an integral constant expression\iref{expr.const}.
-The type \tcode{std::size_t} is defined in the standard header
-\indexhdr{cstddef}%
-\tcode{<cstddef>}~(\ref{cstddef.syn}, \ref{support.types.layout}).
 \end{note}
 
 \pnum


### PR DESCRIPTION
This looks like a copy-paste from previous operators (`sizeof`, `alignof`), which actually return `size_t`.
(See 8eff9b95)