### PR TITLE
P1161R3 Deprecate uses of the comma operator in subscripting expressions

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2864,6 +2864,14 @@ The expression \tcode{E1} is sequenced before the expression \tcode{E2}.
 
 \pnum
 \begin{note}
+A comma expression\iref{expr.comma}
+appearing as the \grammarterm{expr-or-braced-init-list}
+of a subscripting expression is deprecated;
+see \ref{depr.comma.subscript}.
+\end{note}
+
+\pnum
+\begin{note}
 Despite its asymmetric appearance, subscripting is a commutative
 operation except for sequencing.
 See~\ref{expr.unary} and~\ref{expr.add} for details of \tcode{*} and
@@ -6792,6 +6800,14 @@ f(a, (t=3, t+2), c);
 has three arguments, the second of which has the value
 \tcode{5}.
 \end{example}
+
+\pnum
+\begin{note}
+A comma expression
+appearing as the \grammarterm{expr-or-braced-init-list}
+of a subscripting expression\iref{expr.sub} is deprecated;
+see \ref{depr.comma.subscript}.
+\end{note}
 
 \rSec1[expr.const]{Constant expressions}%
 \indextext{expression!constant}

--- a/source/future.tex
+++ b/source/future.tex
@@ -54,6 +54,24 @@ struct X {
 \end{codeblock}
 \end{example}
 
+\rSec1[depr.comma.subscript]{Comma operator in subscript expressions}
+
+\pnum
+A comma expression\iref{expr.comma}
+appearing as the \grammarterm{expr-or-braced-init-list}
+of a subscripting expression\iref{expr.sub} is deprecated.
+\begin{note}
+A parenthesized comma expression is not deprecated.
+\end{note}
+\begin{example}
+\begin{codeblock}
+void f(int *a, int b, int c) {
+    a[b,c];                     // deprecated
+    a[(b,c)];                   // OK
+}
+\end{codeblock}
+\end{example}
+
 \rSec1[depr.array.comp]{Array comparisons}
 
 \pnum


### PR DESCRIPTION
Fixes #2981