### PR TITLE
P1331R2 Permitting trivial default initialization in constexpr contexts

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -828,8 +828,7 @@ its \grammarterm{function-body} shall not enclose\iref{stmt.stmt}
 \item an identifier label\iref{stmt.label},
 \item a definition of a variable
 of non-literal type or
-of static or thread storage duration or
-for which no initialization is performed.
+of static or thread storage duration.
 \end{itemize}
 \begin{note}
 A \grammarterm{function-body} that is \tcode{= delete} or \tcode{= default}
@@ -853,8 +852,8 @@ constexpr int first(int n) {
   return value;
 }
 constexpr int uninit() {
-  int a;                        // error: variable is uninitialized
-  return a;
+  struct { int a; } s;
+  return s.a;                   // error: uninitialized read of \tcode{s.a}
 }
 constexpr int prev(int x)
   { return --x; }               // OK
@@ -885,10 +884,6 @@ In addition, either its \grammarterm{function-body} shall be
 either its \grammarterm{function-body} shall be \tcode{= default}, or the \grammarterm{compound-statement} of its \grammarterm{function-body}
 shall satisfy the requirements for a \grammarterm{function-body} of a
 constexpr function;
-
-\item
-every non-variant non-static data member and base class subobject
-shall be initialized\iref{class.base.init};
 
 \item
 if the class is a union having variant members\iref{class.union}, exactly one of them

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6936,6 +6936,10 @@ that is applied to a glvalue
 that refers to a non-active member of a union or a subobject thereof;
 
 \item
+an lvalue-to-rvalue conversion that is applied to
+an object with an indeterminate value\iref{basic.indet};
+
+\item
 an invocation of an implicitly-defined copy/move constructor or
 copy/move assignment operator
 for a union whose active member (if any) is mutable,

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1684,7 +1684,7 @@ the values of these macros with greater values.
 \defnxname{cpp_capture_star_this}                 & \tcode{201603L} \\ \rowsep
 \defnxname{cpp_char8_t}                           & \tcode{201811L} \\ \rowsep
 \defnxname{cpp_conditional_explicit}              & \tcode{201806L} \\ \rowsep
-\defnxname{cpp_constexpr}                         & \tcode{201603L} \\ \rowsep
+\defnxname{cpp_constexpr}                         & \tcode{201907L} \\ \rowsep
 \defnxname{cpp_coroutines}                        & \tcode{201902L} \\ \rowsep
 \defnxname{cpp_decltype}                          & \tcode{200707L} \\ \rowsep
 \defnxname{cpp_decltype_auto}                     & \tcode{201304L} \\ \rowsep


### PR DESCRIPTION
[expr.const] Add missing "an" before "indeterminate value".

Fixes #2982