### PR TITLE
[is.sorted] Add missing "return" and semi-colon

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -6175,7 +6175,7 @@ template<class ExecutionPolicy, class ForwardIterator, class Compare>
 \effects
 Equivalent to:
 \begin{codeblock}
-is_sorted_until(std::forward<ExecutionPolicy>(exec), first, last, comp) == last
+return is_sorted_until(std::forward<ExecutionPolicy>(exec), first, last, comp) == last;
 \end{codeblock}
 \end{itemdescr}
 


### PR DESCRIPTION
This was lost when changing Returns: to Effects: for P0896R4. The
paper included this change, but it was lost when applying it.