### PR TITLE
P1502R1 Standard library header units for C++20

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1281,6 +1281,23 @@ for any of these C headers:
 \end{multicolfloattable}
 
 \pnum
+The headers listed in \tref{headers.cpp}, or,
+for a freestanding implementation,
+the subset of such headers that are provided by the implementation,
+are collectively known as
+the \defnadj{importable}{\Cpp{} library headers}.
+\begin{note}
+Importable \Cpp{} library headers can be
+imported as module units\iref{module.import}.
+\end{note}
+\begin{example}
+\begin{codeblock}
+import <vector>;               // imports the \tcode{<vector>} header unit
+std::vector<int> vi;           // OK
+\end{codeblock}
+\end{example}
+
+\pnum
 Except as noted in \ref{library} through \ref{\lastlibchapter}
 and \ref{depr}, the contents of each header \tcode{c\placeholder{name}} is
 the same as that of the corresponding header \tcode{\placeholder{name}.h} as
@@ -1504,9 +1521,12 @@ phase 4, while~\ref{using.linkage} describes effects during phase
 The entities in the \Cpp{} standard library are defined in headers,
 whose contents are made available to a translation unit when it contains the appropriate
 \indextext{unit!translation}%
-\tcode{\#include}
-preprocessing directive\iref{cpp.include}.%
 \indextext{\idxcode{\#include}}%
+\tcode{\#include}
+preprocessing directive\iref{cpp.include}
+or the appropriate
+\indextext{\idxcode{import}}%
+\tcode{import} declaration\iref{module.import}.
 \indextext{source file}
 
 \pnum
@@ -1528,7 +1548,10 @@ current definition of
 \pnum
 A translation unit shall include a header only outside of any
 \indextext{unit!translation}%
-declaration or definition, and shall include the header lexically
+declaration or definition and,
+in the case of a module unit,
+only in its \grammarterm{global-module-fragment}, and
+shall include the header or import the corresponding header unit lexically
 before the first reference in that translation unit to any of the entities
 declared in that header. No diagnostic is required.
 

--- a/source/modules.tex
+++ b/source/modules.tex
@@ -34,6 +34,16 @@ collection of module units with the same \grammarterm{module-name}.
 The identifiers \tcode{module} and \tcode{import}
 shall not appear as \grammarterm{identifier}{s}
 in a \grammarterm{module-name} or \grammarterm{module-partition}.
+\indextext{module!reserved name of}%
+All \grammarterm{module-name}{s} beginning with an \grammarterm{identifier}
+consisting of \tcode{std} followed by zero or more \grammarterm{digit}{s} or
+containing a reserved identifier\iref{lex.name}
+are reserved and shall not be specified in a \grammarterm{module-declaration};
+no diagnostic is required.
+If any \grammarterm{identifier} in a reserved \grammarterm{module-name}
+is a reserved identifier,
+the module name is reserved for use by \Cpp{} implementations;
+otherwise it is reserved for future standardization.
 The optional \grammarterm{attribute-specifier-seq}
 appertains to the \grammarterm{module-declaration}.
 
@@ -466,7 +476,8 @@ and are attached to the global module\iref{module.unit}.
 \end{note}
 An \defnadj{importable}{header} is a member of an
 \impldef{how the set of importable headers is determined}
-set of headers.
+set of headers that
+includes all importable \Cpp{} library headers\iref{headers}.
 \tcode{H} shall identify an importable header.
 Two
 \grammarterm{module-import-declaration}{s}

--- a/source/modules.tex
+++ b/source/modules.tex
@@ -35,7 +35,7 @@ The identifiers \tcode{module} and \tcode{import}
 shall not appear as \grammarterm{identifier}{s}
 in a \grammarterm{module-name} or \grammarterm{module-partition}.
 \indextext{module!reserved name of}%
-All \grammarterm{module-name}{s} beginning with an \grammarterm{identifier}
+All \grammarterm{module-name}{s} either beginning with an \grammarterm{identifier}
 consisting of \tcode{std} followed by zero or more \grammarterm{digit}{s} or
 containing a reserved identifier\iref{lex.name}
 are reserved and shall not be specified in a \grammarterm{module-declaration};


### PR DESCRIPTION
Fixes #3020.

Note: In [module.unit] I did not \grammarterm "identifier" in "reserved identifier" since "reserved identifier" is a term.