### PR TITLE
P1423R3 char8_t backward compatibility remediation

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -2240,14 +2240,33 @@ Overload resolution for ostream inserters used with UTF-8 literals.
 \rationale
 Required for new features.
 \effect
-Valid ISO \CppXVII{} code that passes UTF-8 literals
-to \tcode{basic_ostream::\brk{}operator<<}
-no longer calls character-related overloads.
+Valid ISO \CppXVII{} code that passes UTF-8 literals to
+\tcode{basic_ostream<char, ...>::operator<<} or
+\tcode{basic_ostream<wchar_t, ...>::operator<<} is now ill-formed.
 \begin{codeblock}
 std::cout << u8"text";          // previously called \tcode{operator<<(const char*)} and printed a string;
-                                // now calls \tcode{operator<<(const void*)} and prints a pointer value
+                                // now ill-formed
 std::cout << u8'X';             // previously called \tcode{operator<<(char)} and printed a character;
-                                // now calls \tcode{operator<<(int)} and prints an integer value
+                                // now ill-formed
+\end{codeblock}
+
+\diffref{ostream.inserters.character}
+\change
+Overload resolution for ostream inserters
+used with \tcode{wchar_t}, \tcode{char16_t}, or \tcode{char32_t} types.
+\rationale
+Removal of surprising behavior.
+\effect
+Valid ISO \CppXVII{} code that passes
+\tcode{wchar_t}, \tcode{char16_t}, or \tcode{char32_t} characters or strings
+to \tcode{basic_ostream<char, ...>::operator<<} or
+that passes \tcode{char16_t} or \tcode{char32_t} characters or strings
+to \tcode{basic_ostream<wchar_t, ...>::operator<<} is now ill-formed.
+\begin{codeblock}
+std::cout << u"text";           // previously formatted the string as a pointer value;
+                                // now ill-formed
+std::cout << u'X';              // previously formatted the character as an integer value;
+                                // now ill-formed
 \end{codeblock}
 
 \diffref{fs.class.path}

--- a/source/future.tex
+++ b/source/future.tex
@@ -2418,7 +2418,7 @@ template<class InputIterator>
 \pnum
 \requires The \tcode{source} and \range{first}{last}
   sequences are UTF-8 encoded. The value type of \tcode{Source}
-  and \tcode{InputIterator} is \tcode{char}.
+  and \tcode{InputIterator} is \tcode{char} or \tcode{char8_t}.
   \tcode{Source} meets the requirements specified in \ref{fs.path.req}.
 
 \pnum

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -5829,6 +5829,24 @@ namespace std {
   template<class traits>
     basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>&, unsigned char);
 
+  template<class traits>
+    basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>&, wchar_t) = delete;
+  template<class traits>
+    basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>&, char8_t) = delete;
+  template<class traits>
+    basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>&, char16_t) = delete;
+  template<class traits>
+    basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>&, char32_t) = delete;
+  template<class traits>
+    basic_ostream<wchar_t, traits>&
+      operator<<(basic_ostream<wchar_t, traits>&, char8_t) = delete;
+  template<class traits>
+    basic_ostream<wchar_t, traits>&
+      operator<<(basic_ostream<wchar_t, traits>&, char16_t) = delete;
+  template<class traits>
+    basic_ostream<wchar_t, traits>&
+      operator<<(basic_ostream<wchar_t, traits>&, char32_t) = delete;
+
   template<class charT, class traits>
     basic_ostream<charT, traits>& operator<<(basic_ostream<charT, traits>&, const charT*);
   template<class charT, class traits>
@@ -5840,6 +5858,28 @@ namespace std {
     basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>&, const signed char*);
   template<class traits>
     basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>&, const unsigned char*);
+
+  template<class traits>
+    basic_ostream<char, traits>&
+      operator<<(basic_ostream<char, traits>&, const wchar_t*) = delete;
+  template<class traits>
+    basic_ostream<char, traits>&
+      operator<<(basic_ostream<char, traits>&, const char8_t*) = delete;
+  template<class traits>
+    basic_ostream<char, traits>&
+      operator<<(basic_ostream<char, traits>&, const char16_t*) = delete;
+  template<class traits>
+    basic_ostream<char, traits>&
+     operator<<(basic_ostream<char, traits>&, const char32_t*) = delete;
+  template<class traits>
+    basic_ostream<wchar_t, traits>&
+      operator<<(basic_ostream<wchar_t, traits>&, const char8_t*) = delete;
+  template<class traits>
+    basic_ostream<wchar_t, traits>&
+      operator<<(basic_ostream<wchar_t, traits>&, const char16_t*) = delete;
+  template<class traits>
+    basic_ostream<wchar_t, traits>&
+      operator<<(basic_ostream<wchar_t, traits>&, const char32_t*) = delete;
 }
 \end{codeblock}
 

--- a/source/support.tex
+++ b/source/support.tex
@@ -565,7 +565,7 @@ the values of these macros with greater values.
   \tcode{<functional>} \\ \rowsep
 \defnlibxname{cpp_lib_byte}                                 & \tcode{201603L} &
   \tcode{<cstddef>} \\ \rowsep
-\defnlibxname{cpp_lib_char8_t}                              & \tcode{201811L} &
+\defnlibxname{cpp_lib_char8_t}                              & \tcode{201907L} &
   \tcode{<atomic>} \tcode{<filesystem>} \tcode{<istream>} \tcode{<limits>}
   \tcode{<locale>} \tcode{<ostream>} \tcode{<string>} \tcode{<string_view>}
   \\ \rowsep


### PR DESCRIPTION
 - omitted rationalizing comments in synopsis

Fixes #3019.