### PR TITLE
Motions 2019 07 lwg 1

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -1768,13 +1768,11 @@ namespace std {
   namespace ranges {
     template<RandomAccessIterator I, Sentinel<I> S, class Gen>
       requires Permutable<I> &&
-               UniformRandomBitGenerator<remove_reference_t<Gen>> &&
-               ConvertibleTo<invoke_result_t<Gen&>, iter_difference_t<I>>
+               UniformRandomBitGenerator<remove_reference_t<Gen>>
       I shuffle(I first, S last, Gen&& g);
     template<RandomAccessRange R, class Gen>
       requires Permutable<iterator_t<R>> &&
-               UniformRandomBitGenerator<remove_reference_t<Gen>> &&
-               ConvertibleTo<invoke_result_t<Gen&>, iter_difference_t<iterator_t<R>>>
+               UniformRandomBitGenerator<remove_reference_t<Gen>>
       safe_iterator_t<R> shuffle(R&& r, Gen&& g);
   }
 

--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -1534,19 +1534,19 @@ namespace std {
   namespace ranges {
     template<Permutable I, Sentinel<I> S, class T, class Proj = identity>
       requires IndirectRelation<ranges::equal_to, projected<I, Proj>, const T*>
-      constexpr I remove(I first, S last, const T& value, Proj proj = {});
+      constexpr subrange<I> remove(I first, S last, const T& value, Proj proj = {});
     template<ForwardRange R, class T, class Proj = identity>
       requires Permutable<iterator_t<R>> &&
                IndirectRelation<ranges::equal_to, projected<iterator_t<R>, Proj>, const T*>
-      constexpr safe_iterator_t<R>
+      constexpr safe_subrange_t<R>
         remove(R&& r, const T& value, Proj proj = {});
     template<Permutable I, Sentinel<I> S, class Proj = identity,
              IndirectUnaryPredicate<projected<I, Proj>> Pred>
-      constexpr I remove_if(I first, S last, Pred pred, Proj proj = {});
+      constexpr subrange<I> remove_if(I first, S last, Pred pred, Proj proj = {});
     template<ForwardRange R, class Proj = identity,
              IndirectUnaryPredicate<projected<iterator_t<R>, Proj>> Pred>
       requires Permutable<iterator_t<R>>
-      constexpr safe_iterator_t<R>
+      constexpr safe_subrange_t<R>
         remove_if(R&& r, Pred pred, Proj proj = {});
   }
 
@@ -1619,11 +1619,11 @@ namespace std {
   namespace ranges {
     template<Permutable I, Sentinel<I> S, class Proj = identity,
              IndirectRelation<projected<I, Proj>> C = ranges::equal_to>
-      constexpr I unique(I first, S last, C comp = {}, Proj proj = {});
+      constexpr subrange<I> unique(I first, S last, C comp = {}, Proj proj = {});
     template<ForwardRange R, class Proj = identity,
              IndirectRelation<projected<iterator_t<R>, Proj>> C = ranges::equal_to>
       requires Permutable<iterator_t<R>>
-      constexpr safe_iterator_t<R>
+      constexpr safe_subrange_t<R>
         unique(R&& r, C comp = {}, Proj proj = {});
   }
 
@@ -1908,11 +1908,13 @@ namespace std {
                         Compare comp);
 
   namespace ranges {
+    template<class I, class O> using partial_sort_copy_result = copy_result<I, O>;
+
     template<InputIterator I1, Sentinel<I1> S1, RandomAccessIterator I2, Sentinel<I2> S2,
              class Comp = ranges::less, class Proj1 = identity, class Proj2 = identity>
       requires IndirectlyCopyable<I1, I2> && Sortable<I2, Comp, Proj2> &&
                IndirectStrictWeakOrder<Comp, projected<I1, Proj1>, projected<I2, Proj2>>
-      constexpr I2
+      constexpr partial_sort_copy_result<I1, I2>
         partial_sort_copy(I1 first, S1 last, I2 result_first, S2 result_last,
                           Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
     template<InputRange R1, RandomAccessRange R2, class Comp = ranges::less,
@@ -1921,7 +1923,7 @@ namespace std {
                Sortable<iterator_t<R2>, Comp, Proj2> &&
                IndirectStrictWeakOrder<Comp, projected<iterator_t<R1>, Proj1>,
                                        projected<iterator_t<R2>, Proj2>>
-      constexpr safe_iterator_t<R2>
+      constexpr partial_sort_copy_result<safe_iterator_t<R1>, safe_iterator_t<R2>>
         partial_sort_copy(R1&& r, R2&& result_r, Comp comp = {},
                           Proj1 proj1 = {}, Proj2 proj2 = {});
   }
@@ -2116,12 +2118,12 @@ namespace std {
   namespace ranges {
     template<Permutable I, Sentinel<I> S, class Proj = identity,
              IndirectUnaryPredicate<projected<I, Proj>> Pred>
-      constexpr I
+      constexpr subrange<I>
         partition(I first, S last, Pred pred, Proj proj = {});
     template<ForwardRange R, class Proj = identity,
              IndirectUnaryPredicate<projected<iterator_t<R>, Proj>> Pred>
       requires Permutable<iterator_t<R>>
-      constexpr safe_iterator_t<R>
+      constexpr safe_subrange_t<R>
         partition(R&& r, Pred pred, Proj proj = {});
   }
 
@@ -2139,11 +2141,11 @@ namespace std {
     template<BidirectionalIterator I, Sentinel<I> S, class Proj = identity,
              IndirectUnaryPredicate<projected<I, Proj>> Pred>
       requires Permutable<I>
-      I stable_partition(I first, S last, Pred pred, Proj proj = {});
+      subrange<I> stable_partition(I first, S last, Pred pred, Proj proj = {});
     template<BidirectionalRange R, class Proj = identity,
              IndirectUnaryPredicate<projected<iterator_t<R>, Proj>> Pred>
       requires Permutable<iterator_t<R>>
-      safe_iterator_t<R> stable_partition(R&& r, Pred pred, Proj proj = {});
+      safe_subrange_t<R> stable_partition(R&& r, Pred pred, Proj proj = {});
   }
 
   template<class InputIterator, class OutputIterator1,
@@ -4969,19 +4971,19 @@ template<class ExecutionPolicy, class ForwardIterator, class Predicate>
 
 template<Permutable I, Sentinel<I> S, class T, class Proj = identity>
   requires IndirectRelation<ranges::equal_to, projected<I, Proj>, const T*>
-  constexpr I ranges::remove(I first, S last, const T& value, Proj proj = {});
+  constexpr subrange<I> ranges::remove(I first, S last, const T& value, Proj proj = {});
 template<ForwardRange R, class T, class Proj = identity>
   requires Permutable<iterator_t<R>> &&
            IndirectRelation<ranges::equal_to, projected<iterator_t<R>, Proj>, const T*>
-  constexpr safe_iterator_t<R>
+  constexpr safe_subrange_t<R>
     ranges::remove(R&& r, const T& value, Proj proj = {});
 template<Permutable I, Sentinel<I> S, class Proj = identity,
          IndirectUnaryPredicate<projected<I, Proj>> Pred>
-  constexpr I ranges::remove_if(I first, S last, Pred pred, Proj proj = {});
+  constexpr subrange<I> ranges::remove_if(I first, S last, Pred pred, Proj proj = {});
 template<ForwardRange R, class Proj = identity,
          IndirectUnaryPredicate<projected<iterator_t<R>, Proj>> Pred>
   requires Permutable<iterator_t<R>>
-  constexpr safe_iterator_t<R>
+  constexpr safe_subrange_t<R>
     ranges::remove_if(R&& r, Pred pred, Proj proj = {});
 \end{itemdecl}
 
@@ -5008,7 +5010,11 @@ in the range \range{first}{last} for which $E$ holds.
 
 \pnum
 \returns
-The end of the resulting range.
+Let $j$ be the end of the resulting range. Returns:
+\begin{itemize}
+\item $j$ for the overloads in namespace \tcode{std}, or
+\item \tcode{\{$j$, last\}} for the overloads in namespace \tcode{ranges}.
+\end{itemize}
 
 \pnum
 \remarks
@@ -5144,11 +5150,11 @@ template<class ExecutionPolicy, class ForwardIterator, class BinaryPredicate>
 
 template<Permutable I, Sentinel<I> S, class Proj = identity,
          IndirectRelation<projected<I, Proj>> C = ranges::equal_to>
-  constexpr I ranges::unique(I first, S last, C comp = {}, Proj proj = {});
+  constexpr subrange<I> ranges::unique(I first, S last, C comp = {}, Proj proj = {});
 template<ForwardRange R, class Proj = identity,
          IndirectRelation<projected<iterator_t<R>, Proj>> C = ranges::equal_to>
   requires Permutable<iterator_t<R>>
-  constexpr safe_iterator_t<R>
+  constexpr safe_subrange_t<R>
     ranges::unique(R&& r, C comp = {}, Proj proj = {});
 \end{itemdecl}
 
@@ -5183,7 +5189,11 @@ for which $E$ is \tcode{true}.
 
 \pnum
 \returns
-The end of the resulting range.
+Let $j$ be the end of the resulting range. Returns:
+\begin{itemize}
+\item $j$ for the overloads in namespace \tcode{std}, or
+\item \tcode{\{$j$, last\}} for the overloads in namespace \tcode{ranges}.
+\end{itemize}
 
 \pnum
 \complexity
@@ -6063,7 +6073,7 @@ template<InputIterator I1, Sentinel<I1> S1, RandomAccessIterator I2, Sentinel<I2
          class Comp = ranges::less, class Proj1 = identity, class Proj2 = identity>
   requires IndirectlyCopyable<I1, I2> && Sortable<I2, Comp, Proj2> &&
            IndirectStrictWeakOrder<Comp, projected<I1, Proj1>, projected<I2, Proj2>>
-  constexpr I2
+  constexpr ranges::partial_sort_copy_result<I1, I2>
     ranges::partial_sort_copy(I1 first, S1 last, I2 result_first, S2 result_last,
                               Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
 template<InputRange R1, RandomAccessRange R2, class Comp = ranges::less,
@@ -6072,7 +6082,7 @@ template<InputRange R1, RandomAccessRange R2, class Comp = ranges::less,
            Sortable<iterator_t<R2>, Comp, Proj2> &&
            IndirectStrictWeakOrder<Comp, projected<iterator_t<R1>, Proj1>,
                                    projected<iterator_t<R2>, Proj2>>
-  constexpr safe_iterator_t<R2>
+  constexpr ranges::partial_sort_copy_result<safe_iterator_t<R1>, safe_iterator_t<R2>>
     ranges::partial_sort_copy(R1&& r, R2&& result_r, Comp comp = {},
                               Proj1 proj1 = {}, Proj2 proj2 = {});
 \end{itemdecl}
@@ -6120,7 +6130,13 @@ into the range \range{result_first}{result_first + $N$}.
 
 \pnum
 \returns
-\tcode{result_first + $N$}.
+\begin{itemize}
+\item
+  \tcode{result_first + $N$} for the overloads in namespace \tcode{std}, or
+\item
+  \tcode{\{last, result_first + $N$\}} for
+  the overloads in namespace \tcode{ranges}.
+\end{itemize}
 
 \pnum
 \complexity
@@ -6608,12 +6624,12 @@ template<class ExecutionPolicy, class ForwardIterator, class Predicate>
 
 template<Permutable I, Sentinel<I> S, class Proj = identity,
          IndirectUnaryPredicate<projected<I, Proj>> Pred>
-  constexpr I
+  constexpr subrange<I>
     ranges::partition(I first, S last, Pred pred, Proj proj = {});
 template<ForwardRange R, class Proj = identity,
          IndirectUnaryPredicate<projected<iterator_t<R>, Proj>> Pred>
   requires Permutable<iterator_t<R>>
-  constexpr safe_iterator_t<R>
+  constexpr safe_subrange_t<R>
     ranges::partition(R&& r, Pred pred, Proj proj = {});
 \end{itemdecl}
 
@@ -6636,9 +6652,15 @@ that satisfy $E(\tcode{e})$ before all the elements that do not.
 
 \pnum
 \returns
-An iterator \tcode{i} such that $E(\tcode{*j})$ is
+Let \tcode{i} be an iterator such that $E(\tcode{*j})$ is
 \tcode{true} for every iterator \tcode{j} in \range{first}{i} and
 \tcode{false} for every iterator \tcode{j} in \range{i}{last}.
+Returns:
+\begin{itemize}
+\item \tcode{i} for the overloads in namespace \tcode{std}, or
+\item \tcode{\{i, last\}} for the overloads in namespace \tcode{ranges}.
+\end{itemize}
+
 
 \pnum
 \complexity Let $N = \tcode{last - first}$:
@@ -6672,11 +6694,11 @@ template<class ExecutionPolicy, class BidirectionalIterator, class Predicate>
 template<BidirectionalIterator I, Sentinel<I> S, class Proj = identity,
          IndirectUnaryPredicate<projected<I, Proj>> Pred>
   requires Permutable<I>
-  I ranges::stable_partition(I first, S last, Pred pred, Proj proj = {});
+  subrange<I> ranges::stable_partition(I first, S last, Pred pred, Proj proj = {});
 template<BidirectionalRange R, class Proj = identity,
          IndirectUnaryPredicate<projected<iterator_t<R>, Proj>> Pred>
   requires Permutable<iterator_t<R>>
-  safe_iterator_t<R> ranges::stable_partition(R&& r, Pred pred, Proj proj = {});
+  safe_subrange_t<R> ranges::stable_partition(R&& r, Pred pred, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6701,11 +6723,17 @@ The relative order of the elements in both groups is preserved.
 
 \pnum
 \returns
-An iterator \tcode{i}
+Let \tcode{i} be an iterator
 such that for every iterator \tcode{j} in \range{first}{i},
 $E(\tcode{*j})$ is \tcode{true},
 and for every iterator \tcode{j} in the range \range{i}{last},
-$E(\tcode{*j})$ is \tcode{false},
+$E(\tcode{*j})$ is \tcode{false}.
+Returns:
+\begin{itemize}
+\item \tcode{i} for the overloads in namespace \tcode{std}, or
+\item \tcode{\{i, last\}} for the overloads in namespace \tcode{ranges}.
+\end{itemize}
+
 
 \pnum
 \complexity

--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -262,6 +262,7 @@ The class templates
 \tcode{for_each_result},
 \tcode{minmax_result},
 \tcode{mismatch_result},
+\tcode{next_permutation_result},
 \tcode{copy_result}, and
 \tcode{partition_copy_result}
 have the template parameters, data members, and special members specified below.
@@ -2852,15 +2853,21 @@ namespace std {
                                     BidirectionalIterator last, Compare comp);
 
   namespace ranges {
+    template<class I>
+    struct next_permutation_result {
+      bool found;
+      I in;
+    };
+
     template<BidirectionalIterator I, Sentinel<I> S, class Comp = ranges::less,
              class Proj = identity>
       requires Sortable<I, Comp, Proj>
-      constexpr bool
+      constexpr next_permutation_result<I>
         next_permutation(I first, S last, Comp comp = {}, Proj proj = {});
     template<BidirectionalRange R, class Comp = ranges::less,
              class Proj = identity>
       requires Sortable<iterator_t<R>, Comp, Proj>
-      constexpr bool
+      constexpr next_permutation_result<safe_iterator_t<R>>
         next_permutation(R&& r, Comp comp = {}, Proj proj = {});
   }
 
@@ -2872,15 +2879,18 @@ namespace std {
                                     BidirectionalIterator last, Compare comp);
 
   namespace ranges {
+    template<class I>
+    using prev_permutation_result = next_permutation_result<I>;
+
     template<BidirectionalIterator I, Sentinel<I> S, class Comp = ranges::less,
              class Proj = identity>
       requires Sortable<I, Comp, Proj>
-      constexpr bool
+      constexpr prev_permutation_result<I>
         prev_permutation(I first, S last, Comp comp = {}, Proj proj = {});
     template<BidirectionalRange R, class Comp = ranges::less,
              class Proj = identity>
       requires Sortable<iterator_t<R>, Comp, Proj>
-      constexpr bool
+      constexpr prev_permutation_result<safe_iterator_t<R>>
         prev_permutation(R&& r, Comp comp = {}, Proj proj = {});
   }
 }
@@ -8430,12 +8440,12 @@ template<class BidirectionalIterator, class Compare>
 template<BidirectionalIterator I, Sentinel<I> S, class Comp = ranges::less,
          class Proj = identity>
   requires Sortable<I, Comp, Proj>
-  constexpr bool
+  constexpr ranges::next_permutation_result<I>
     ranges::next_permutation(I first, S last, Comp comp = {}, Proj proj = {});
 template<BidirectionalRange R, class Comp = ranges::less,
          class Proj = identity>
   requires Sortable<iterator_t<R>, Comp, Proj>
-  constexpr bool
+  constexpr ranges::next_permutation_result<safe_iterator_t<R>>
     ranges::next_permutation(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
@@ -8463,7 +8473,13 @@ that is, the ascendingly-sorted one.
 
 \pnum
 \returns
-\tcode{true} if and only if a next permutation was found.
+Let \tcode{B} be \tcode{true} if a next permutation was found and
+otherwise \tcode{false}.
+Returns:
+\begin{itemize}
+\item \tcode{B} for the overloads in namespace \tcode{std}, or
+\item \tcode{\{ B, last \}} for the overloads in namespace \tcode{ranges}.
+\end{itemize}
 
 \pnum
 \complexity
@@ -8483,12 +8499,12 @@ template<class BidirectionalIterator, class Compare>
 template<BidirectionalIterator I, Sentinel<I> S, class Comp = ranges::less,
          class Proj = identity>
   requires Sortable<I, Comp, Proj>
-  constexpr bool
+  constexpr ranges::prev_permutation_result<I>
     ranges::prev_permutation(I first, S last, Comp comp = {}, Proj proj = {});
 template<BidirectionalRange R, class Comp = ranges::less,
          class Proj = identity>
   requires Sortable<iterator_t<R>, Comp, Proj>
-  constexpr bool
+  constexpr ranges::prev_permutation_result<safe_iterator_t<R>>
     ranges::prev_permutation(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
@@ -8516,7 +8532,13 @@ that is, the descendingly-sorted one.
 
 \pnum
 \returns
-\tcode{true} if and only if a previous permutation was found.
+Let \tcode{B} be \tcode{true} if a previous permutation was found and
+otherwise \tcode{false}.
+Returns:
+\begin{itemize}
+\item \tcode{B} for the overloads in namespace \tcode{std}, or
+\item \tcode{\{ B, last \}} for the overloads in namespace \tcode{ranges}.
+\end{itemize}
 
 \pnum
 \complexity

--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -823,11 +823,11 @@ template<class B>
              const remove_reference_t<B>& b2, const bool a) {
       { b1 } -> ConvertibleTo<bool>;
       { !b1 } -> ConvertibleTo<bool>;
-      { b1 &&  a } -> Same<bool>;
-      { b1 ||  a } -> Same<bool>;
       { b1 && b2 } -> Same<bool>;
+      { b1 &&  a } -> Same<bool>;
       {  a && b2 } -> Same<bool>;
       { b1 || b2 } -> Same<bool>;
+      { b1 ||  a } -> Same<bool>;
       {  a || b2 } -> Same<bool>;
       { b1 == b2 } -> ConvertibleTo<bool>;
       { b1 ==  a } -> ConvertibleTo<bool>;

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10585,7 +10585,7 @@ constexpr span() noexcept;
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{Extent <= 0} is \tcode{true}.
+\tcode{Extent == dynamic_extent || Extent == 0} is \tcode{true}.
 
 \pnum
 \ensures

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -11919,11 +11919,8 @@ path& operator+=(const path& x);
 path& operator+=(const string_type& x);
 path& operator+=(basic_string_view<value_type> x);
 path& operator+=(const value_type* x);
-path& operator+=(value_type x);
 template<class Source>
   path& operator+=(const Source& x);
-template<class EcharT>
-  path& operator+=(EcharT x);
 template<class Source>
   path& concat(const Source& x);
 \end{itemdecl}
@@ -11938,6 +11935,19 @@ and may not be portable between operating systems.
 
 \pnum
 \returns \tcode{*this}.
+\end{itemdescr}
+
+\indexlibrarymember{operator+=}{path}%
+\indexlibrarymember{concat}{path}%
+\begin{itemdecl}
+path& operator+=(value_type x);
+template<class EcharT>
+  path& operator+=(EcharT x);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Equivalent to: \tcode{return *this += basic_string_view(\&x, 1);}
 \end{itemdescr}
 
 \indexlibrarymember{concat}{path}%

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1457,6 +1457,15 @@ necessary to make \tcode{bool(i == s)} be \tcode{true}.
 \end{itemdescr}
 
 \pnum
+Pursuant to \ref{namespace.std},
+users may specialize \tcode{disable_sized_sentinel}
+for cv-unqualified non-array object types \tcode{S} and \tcode{I}
+if either \tcode{S} or \tcode{I} is a program-defined type.
+Such specializations shall
+be usable in constant expressions\iref{expr.const} and
+have type \tcode{const bool}.
+
+\pnum
 \begin{note}
 \tcode{disable_sized_sentinel} allows use of sentinels and iterators with
 the library that satisfy but do not in fact model \libconcept{SizedSentinel}.

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1456,7 +1456,15 @@ necessary to make \tcode{bool(i == s)} be \tcode{true}.
 \end{itemize}
 \end{itemdescr}
 
+\indexlibrary{\idxcode{disable_sized_sentinel}}%
+\begin{itemdecl}
+template<class S, class I>
+  inline constexpr bool disable_sized_sentinel = false;
+\end{itemdecl}
+
+\begin{itemdescr}
 \pnum
+\remarks
 Pursuant to \ref{namespace.std},
 users may specialize \tcode{disable_sized_sentinel}
 for cv-unqualified non-array object types \tcode{S} and \tcode{I}
@@ -1477,6 +1485,7 @@ The \libconcept{SizedSentinel} concept is modeled by pairs of
 \libconcept{RandomAccessIterator}s\iref{iterator.concept.random.access} and by
 counted iterators and their sentinels\iref{counted.iterator}.
 \end{example}
+\end{itemdescr}
 
 \rSec3[iterator.concept.input]{Concept \tcode{InputIterator}}
 

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1736,7 +1736,12 @@ convertible to \tcode{bool} &
 {p{1in}p{4.15in}}
 \topline
 \hdstyle{Expression}      &   \hdstyle{Post-condition}  \\ \capsep
-\tcode{u.\~T()} &   All resources owned by \tcode{u} are reclaimed, no exception is propagated. \\
+\tcode{u.\~T()} &   All resources owned by \tcode{u} are reclaimed, no exception is propagated. \\ \rowsep
+\multicolumn{2}{|l|}{
+  \begin{note}
+  Array types and non-object types are not \oldconcept{Destructible}.
+  \end{note}
+} \\
 \end{concepttable}
 
 \rSec3[swappable.requirements]{Swappable requirements}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -813,6 +813,14 @@ is non-amortized, unlike the case for the complexity of the evaluations of
 \end{note}
 
 \pnum
+Pursuant to \ref{namespace.std},
+users may specialize \tcode{disable_sized_range}
+for cv-unqualified non-array object types.
+Such specializations shall
+be usable in constant expressions\iref{expr.const} and
+have type \tcode{const bool}.
+
+\pnum
 \begin{note}
 \tcode{disable_sized_range} allows use of range types with the library
 that satisfy but do not in fact model \libconcept{SizedRange}.
@@ -886,8 +894,12 @@ For a type \tcode{T}, the default value of \tcode{enable_view<T>} is:
 
 \pnum
 Pursuant to \ref{namespace.std}, users may specialize \tcode{enable_view}
-to \tcode{true} for types which model \libconcept{View},
+to \tcode{true}
+for cv-unqualified program-defined types which model \libconcept{View},
 and \tcode{false} for types which do not.
+Such specializations shall
+be usable in constant expressions\iref{expr.const} and
+have type \tcode{const bool}.
 \end{itemdescr}
 
 \rSec2[range.refinements]{Other range refinements}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -811,8 +811,17 @@ The complexity requirement for the evaluation of \tcode{ranges::size}
 is non-amortized, unlike the case for the complexity of the evaluations of
 \tcode{ranges::begin} and \tcode{ranges::end} in the \tcode{Range} concept.
 \end{note}
+\end{itemdescr}
 
+\indexlibrary{\idxcode{disable_sized_range}}%
+\begin{itemdecl}
+template<class>
+  inline constexpr bool disable_sized_range = false;
+\end{itemdecl}
+
+\begin{itemdescr}
 \pnum
+\remarks
 Pursuant to \ref{namespace.std},
 users may specialize \tcode{disable_sized_range}
 for cv-unqualified non-array object types.
@@ -829,6 +838,15 @@ that satisfy but do not in fact model \libconcept{SizedRange}.
 
 \rSec2[range.view]{Views}
 
+\indexlibrary{\idxcode{View}}%
+\begin{itemdecl}
+template<class T>
+  concept View =
+    Range<T> && Semiregular<T> && enable_view<T>;
+\end{itemdecl}
+
+\begin{itemdescr}
+% FIXME: This should explicitly say when View is modeled.
 \pnum
 The \tcode{View} concept specifies the requirements of a \libconcept{Range} type
 that has constant time copy, move, and assignment operators; that is, the cost of
@@ -852,24 +870,21 @@ Most containers\iref{containers} are not views since
 copying the container copies the elements,
 which cannot be done in constant time.
 \end{example}
+\end{itemdescr}
 
-\indexlibrary{\idxcode{enable_view}}%
-\indexlibrary{\idxcode{View}}%
-\begin{itemdecl}
-template<class T>
-  inline constexpr bool enable_view = @\seebelow@;
-
-template<class T>
-  concept View =
-    Range<T> && Semiregular<T> && enable_view<T>;
-\end{itemdecl}
-
-\begin{itemdescr}
 \pnum
 Since the difference between \libconcept{Range} and \libconcept{View} is largely
 semantic, the two are differentiated with the help of \tcode{enable_view}.
 
+\indexlibrary{\idxcode{enable_view}}%
+\begin{itemdecl}
+template<class T>
+  inline constexpr bool enable_view = @\seebelow@;
+\end{itemdecl}
+
+\begin{itemdescr}
 \pnum
+\remarks
 For a type \tcode{T}, the default value of \tcode{enable_view<T>} is:
 \begin{itemize}
 

--- a/source/time.tex
+++ b/source/time.tex
@@ -6461,9 +6461,7 @@ returns a \tcode{sys_days}
 holding a count of days from the \tcode{sys_days} epoch to \tcode{*this}
 (a negative value if \tcode{*this} represents a date prior to the \tcode{sys_days} epoch).
 Otherwise, if \tcode{y_.ok() \&\& m_.ok()} is \tcode{true},
-returns a \tcode{sys_days}
-which is offset from \tcode{sys_days\{y_/m_/last\}}
-by the number of days \tcode{d_} is offset from \tcode{sys_days\{y_/m_/last\}.day()}.
+returns \tcode{sys_days\{y_/m_/ld\} + (d_ - 1d)}.
 Otherwise the value returned is unspecified.
 
 \pnum

--- a/source/time.tex
+++ b/source/time.tex
@@ -4731,7 +4731,7 @@ constexpr bool ok() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{min() <= y_ \&\& y_ <= max()}.
+\returns \tcode{min().y_ <= y_ \&\& y_ <= max().y_}.
 \end{itemdescr}
 
 \indexlibrarymember{min}{year}%

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1114,7 +1114,8 @@ namespace std {
 
     // allocator-extended constructors
     template<class Alloc>
-      constexpr tuple(allocator_arg_t, const Alloc& a);
+      constexpr explicit(@\seebelow@)
+        tuple(allocator_arg_t, const Alloc& a);
     template<class Alloc>
       constexpr explicit(@\seebelow@)
         tuple(allocator_arg_t, const Alloc& a, const Types&...);
@@ -1210,8 +1211,9 @@ This constructor shall not participate in overload resolution unless
 \begin{note} This behavior can be implemented by a constructor template
 with default template arguments. \end{note}
 The expression inside \tcode{explicit} evaluates to \tcode{true}
-if and only if $\tcode{T}_i$ is not implicitly
-default-constructible for at least one $i$.
+if and only if $\tcode{T}_i$ is not
+copy-list-initializable from an empty list
+for at least one $i$.
 \begin{note} This behavior can be implemented with a trait that checks whether
 a \tcode{const $\tcode{T}_i$\&} can be initialized with \tcode{\{\}}. \end{note}
 \end{itemdescr}
@@ -1398,7 +1400,8 @@ The expression inside \tcode{explicit} is equivalent to:
 \indexlibrary{\idxcode{tuple}!constructor}%
 \begin{itemdecl}
 template<class Alloc>
-  constexpr tuple(allocator_arg_t, const Alloc& a);
+  constexpr explicit(@\seebelow@)
+    tuple(allocator_arg_t, const Alloc& a);
 template<class Alloc>
   constexpr explicit(@\seebelow@)
     tuple(allocator_arg_t, const Alloc& a, const Types&...);

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -6487,7 +6487,7 @@ nor
 \end{itemize}
 
 \pnum
-If no characters are stored in \tcode{str}, calls
+If \tcode{N > 0} and no characters are stored in \tcode{str}, calls
 \tcode{is.setstate(ios_base::failbit)}
 (which may throw
 \tcode{ios_base::failure}\iref{iostate.flags}).

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -13833,7 +13833,8 @@ namespace std {
   template<class T> reference_wrapper<const T> cref(reference_wrapper<T>) noexcept;
 
   template<class T> struct unwrap_reference;
-  template<class T> struct unwrap_ref_decay : unwrap_reference<decay_t<T>> {};
+  template<class T> using unwrap_reference_t = typename unwrap_reference<T>::type;
+  template<class T> struct unwrap_ref_decay;
   template<class T> using unwrap_ref_decay_t = typename unwrap_ref_decay<T>::type;
 
   // \ref{arithmetic.operations}, arithmetic operations
@@ -14325,11 +14326,25 @@ template<class T>
   struct unwrap_reference;
 \end{itemdecl}
 
+\begin{itemdescr}
 \pnum
 If \tcode{T} is
 a specialization \tcode{reference_wrapper<X>} for some type \tcode{X},
 the member typedef \tcode{type} of \tcode{unwrap_reference<T>} is \tcode{X\&},
 otherwise it is \tcode{T}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{unwrap_ref_decay}}%
+\begin{itemdecl}
+template<class T>
+  struct unwrap_ref_decay;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+The member typedef \tcode{type} of \tcode{unwrap_ref_decay<T>}
+denotes the type \tcode{unwrap_reference_t<decay_t<T>>}.
+\end{itemdescr}
 
 \rSec2[arithmetic.operations]{Arithmetic operations}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -6577,22 +6577,28 @@ namespace std {
 
   // \ref{allocator.uses.construction}, uses-allocator construction
   template<class T, class Alloc, class... Args>
-    auto uses_allocator_construction_args(const Alloc& alloc, Args&&... args) -> @\seebelow@;
+    constexpr auto uses_allocator_construction_args(const Alloc& alloc,
+                                                    Args&&... args) noexcept -> @\seebelow@;
   template<class T, class Alloc, class Tuple1, class Tuple2>
-    auto uses_allocator_construction_args(const Alloc& alloc, piecewise_construct_t,
-                                          Tuple1&& x, Tuple2&& y) ->  @\seebelow@;
+    constexpr auto uses_allocator_construction_args(const Alloc& alloc, piecewise_construct_t,
+                                                    Tuple1&& x, Tuple2&& y)
+                                                    noexcept ->  @\seebelow@;
   template<class T, class Alloc>
-    auto uses_allocator_construction_args(const Alloc& alloc) -> @\seebelow@;
+    constexpr auto uses_allocator_construction_args(const Alloc& alloc) noexcept -> @\seebelow@;
   template<class T, class Alloc, class U, class V>
-    auto uses_allocator_construction_args(const Alloc& alloc, U&& u, V&& v) -> @\seebelow@;
+    constexpr auto uses_allocator_construction_args(const Alloc& alloc,
+                                                    U&& u, V&& v) noexcept -> @\seebelow@;
   template<class T, class Alloc, class U, class V>
-    auto uses_allocator_construction_args(const Alloc& alloc, const pair<U,V>& pr) -> @\seebelow@;
+    constexpr auto uses_allocator_construction_args(const Alloc& alloc,
+                                                    const pair<U,V>& pr) noexcept -> @\seebelow@;
   template<class T, class Alloc, class U, class V>
-    auto uses_allocator_construction_args(const Alloc& alloc, pair<U,V>&& pr) -> @\seebelow@;
+    constexpr auto uses_allocator_construction_args(const Alloc& alloc,
+                                                    pair<U,V>&& pr) noexcept -> @\seebelow@;
   template<class T, class Alloc, class... Args>
-    T make_obj_using_allocator(const Alloc& alloc, Args&&... args);
+    constexpr T make_obj_using_allocator(const Alloc& alloc, Args&&... args);
   template<class T, class Alloc, class... Args>
-    T* uninitialized_construct_using_allocator(T* p, const Alloc& alloc, Args&&... args);
+    constexpr T* uninitialized_construct_using_allocator(T* p, const Alloc& alloc,
+                                                         Args&&... args);
 
   // \ref{allocator.traits}, allocator traits
   template<class Alloc> struct allocator_traits;
@@ -7455,7 +7461,8 @@ is not deduced and must therefore be specified explicitly by the caller.
 \indexlibrary{\idxcode{uses_allocator_construction_args}}%
 \begin{itemdecl}
 template<class T, class Alloc, class... Args>
-  auto uses_allocator_construction_args(const Alloc& alloc, Args&&... args) -> @\seebelow@;
+  constexpr auto uses_allocator_construction_args(const Alloc& alloc,
+                                                  Args&&... args) noexcept -> @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7497,8 +7504,9 @@ to pass the allocator to a constructor of a type for which
 \indexlibrary{\idxcode{uses_allocator_construction_args}}%
 \begin{itemdecl}
 template<class T, class Alloc, class Tuple1, class Tuple2>
-  auto uses_allocator_construction_args(const Alloc& alloc, piecewise_construct_t,
-                                        Tuple1&& x, Tuple2&& y) -> @\seebelow@;
+  constexpr auto uses_allocator_construction_args(const Alloc& alloc, piecewise_construct_t,
+                                                  Tuple1&& x, Tuple2&& y)
+                                                  noexcept -> @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7526,7 +7534,7 @@ return make_tuple(
 \indexlibrary{\idxcode{uses_allocator_construction_args}}%
 \begin{itemdecl}
 template<class T, class Alloc>
-  auto uses_allocator_construction_args(const Alloc& alloc) -> @\seebelow@;
+  constexpr auto uses_allocator_construction_args(const Alloc& alloc) noexcept -> @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7546,7 +7554,8 @@ return uses_allocator_construction_args<T>(alloc, piecewise_construct,
 \indexlibrary{\idxcode{uses_allocator_construction_args}}%
 \begin{itemdecl}
 template<class T, class Alloc, class U, class V>
-  auto uses_allocator_construction_args(const Alloc& alloc, U&& u, V&& v) -> @\seebelow@;
+  constexpr auto uses_allocator_construction_args(const Alloc& alloc,
+                                                  U&& u, V&& v) noexcept -> @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7567,7 +7576,8 @@ return uses_allocator_construction_args<T>(alloc, piecewise_construct,
 \indexlibrary{\idxcode{uses_allocator_construction_args}}%
 \begin{itemdecl}
 template<class T, class Alloc, class U, class V>
-  auto uses_allocator_construction_args(const Alloc& alloc, const pair<U,V>& pr) -> @\seebelow@;
+  constexpr auto uses_allocator_construction_args(const Alloc& alloc,
+                                                  const pair<U,V>& pr) noexcept -> @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7588,7 +7598,8 @@ return uses_allocator_construction_args<T>(alloc, piecewise_construct,
 \indexlibrary{\idxcode{uses_allocator_construction_args}}%
 \begin{itemdecl}
 template<class T, class Alloc, class U, class V>
-  auto uses_allocator_construction_args(const Alloc& alloc, pair<U,V>&& pr) -> @\seebelow@;
+  constexpr auto uses_allocator_construction_args(const Alloc& alloc,
+                                                  pair<U,V>&& pr) noexcept -> @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7609,7 +7620,7 @@ return uses_allocator_construction_args<T>(alloc, piecewise_construct,
 \indexlibrary{\idxcode{make_obj_using_allocator}}%
 \begin{itemdecl}
 template<class T, class Alloc, class... Args>
-  T make_obj_using_allocator(const Alloc& alloc, Args&&... args);
+  constexpr T make_obj_using_allocator(const Alloc& alloc, Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7625,7 +7636,7 @@ return make_from_tuple<T>(uses_allocator_construction_args<T>(
 \indexlibrary{\idxcode{uninitialized_construct_using_allocator}}%
 \begin{itemdecl}
 template<class T, class Alloc, class... Args>
-  T* uninitialized_construct_using_allocator(T* p, const Alloc& alloc, Args&&... args);
+  constexpr T* uninitialized_construct_using_allocator(T* p, const Alloc& alloc, Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -15290,8 +15290,7 @@ In the text that follows:
 \item \tcode{FD} is the type \tcode{decay_t<F>},
 \item \tcode{fd} is the target object of \tcode{g}\iref{func.def}
   of type \tcode{FD},
-  initialized with
-  the \grammarterm{initializer} \tcode{(std::forward<F>(f\brk{}))}\iref{dcl.init},
+  direct-non-list-initialized with \tcode{std::forward<F\brk{}>(f)},
 \item \tcode{call_args} is an argument pack
   used in a function call expression\iref{expr.call} of \tcode{g}.
 \end{itemize}
@@ -15330,15 +15329,14 @@ In the text that follows:
 \item \tcode{g} is a value of the result of a \tcode{bind_front} invocation,
 \item \tcode{FD} is the type \tcode{decay_t<F>},
 \item \tcode{fd} is the target object of \tcode{g}\iref{func.def}
-  of type \tcode{FD} initialized with
-  the \grammarterm{initializer} \tcode{(std::forward<F>(\brk{}f))}\iref{dcl.init},
+  of type \tcode{FD},
+  direct-non-list-initialized with \tcode{std::forward<F\brk{}>(f)},
 \item \tcode{BoundArgs} is a pack
   that denotes \tcode{std::unwrap_ref_decay_t<Args>...},
 \item \tcode{bound_args} is
   a pack of bound argument entities of \tcode{g}\iref{func.def}
   of types \tcode{BoundArgs...},
-  initialized with
-  \grammarterm{initializer}{s} \tcode{(std::forward<Args>(args))...},
+  direct-non-list-initialized with \tcode{std::forward<Args>(args)...},
   respectively, and
 \item \tcode{call_args} is an argument pack used in
   a function call expression\iref{expr.call} of \tcode{g}.
@@ -15347,8 +15345,10 @@ In the text that follows:
 \pnum
 \mandates
 \begin{codeblock}
-conjunction_v<is_constructible<FD, F>, is_move_constructible<FD>,
-              is_constructible<BoundArgs, Args>..., is_move_constructible<BoundArgs>...>
+is_constructible_v<FD, F> &&
+is_move_constructible_v<FD> &&
+(is_constructible_v<BoundArgs, Args> && ...) &&
+(is_move_constructible_v<BoundArgs> && ...)
 \end{codeblock}
 is true.
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1278,7 +1278,7 @@ tuple(tuple&& u) = default;
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{is_move_constructible_v<$\tcode{T}_i$>} is \tcode{true} for all $i$.
+\constraints \tcode{is_move_constructible_v<$\tcode{T}_i$>} is \tcode{true} for all $i$.
 
 \pnum
 \effects For all $i$, initializes the $i^\text{th}$ element of \tcode{*this} with
@@ -9182,6 +9182,9 @@ unique_ptr(unique_ptr&& u) noexcept;
 
 \begin{itemdescr}
 \pnum
+\constraints \tcode{is_move_constructible_v<D>} is \tcode{true}.
+
+\pnum
 \requires If \tcode{D} is not a reference type,
 \tcode{D} shall meet the \oldconcept{MoveConstructible}
 requirements (\tref{cpp17.moveconstructible}).
@@ -9271,6 +9274,9 @@ unique_ptr& operator=(unique_ptr&& u) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+\constraints \tcode{is_move_assignable_v<D>} is \tcode{true}.
+
 \pnum
 \requires If \tcode{D} is not a reference type, \tcode{D} shall meet the
 \oldconcept{MoveAssignable} requirements (\tref{cpp17.moveassignable}) and assignment

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2295,9 +2295,9 @@ otherwise the conversion returns \tcode{false}.
 Member \tcode{val} is provided for exposition only. When an \tcode{optional<T>} object contains a value, \tcode{val} points to the contained value.
 
 \pnum
-\tcode{T} shall be an object type
+\tcode{T} shall be a type
 other than \cv{} \tcode{in_place_t} or \cv{} \tcode{nullopt_t}
-and shall meet the \oldconcept{Destructible} requirements (\tref{cpp17.destructible}).
+that meets the \oldconcept{Destructible} requirements (\tref{cpp17.destructible}).
 
 \rSec3[optional.ctor]{Constructors}
 
@@ -3882,8 +3882,8 @@ The contained value shall be allocated in a region of the \tcode{variant}
 storage suitably aligned for all types in \tcode{Types}.
 
 \pnum
-All types in \tcode{Types} shall be (possibly cv-qualified)
-object types that are not arrays.
+All types in \tcode{Types} shall meet
+the \oldconcept{Destructible} requirements (\tref{cpp17.destructible}).
 
 \pnum
 A program that instantiates the definition of \tcode{variant} with

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -7480,7 +7480,7 @@ A \tcode{tuple} value determined as follows:
   return \tcode{forward_as_tuple(std::forward<Args>(args)...)}.
 \item
   Otherwise,  if \tcode{uses_allocator_v<T, Alloc>} is \tcode{true} and
-  \tcode{is_constructible_v<T, allocator_arg_t, Alloc, Args...>}
+  \tcode{is_constructible_v<T, allocator_arg_t, const Alloc\&, Args...>}
   is \tcode{true},
   return
 \begin{codeblock}
@@ -7489,7 +7489,7 @@ tuple<allocator_arg_t, const Alloc&, Args&&...>(
 \end{codeblock}
 \item
   Otherwise,  if \tcode{uses_allocator_v<T, Alloc>} is \tcode{true} and
-  \tcode{is_constructible_v<T, Args..., Alloc>} is \tcode{true},
+  \tcode{is_constructible_v<T, Args..., const Alloc\&>} is \tcode{true},
   return \tcode{forward_as_tuple(std::forward<Args>(args)..., alloc)}.
 \item
   Otherwise, the program is ill-formed.


### PR DESCRIPTION
P1724R0 C++ Standard Library Issues to be moved in Cologne)
Fixes #3005.

Notes:
LWG3185: Added constexpr to uninitialized_construct_using_allocator as a Fixup (since P0784 was accepted).
