### PR TITLE
Motions 2019 07 cwg 1

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2399,7 +2399,8 @@ list\iref{temp.names} or a less-than operator. The identifier is first
 looked up in the class of the object expression\iref{class.member.lookup}.
 If the identifier is not found,
 it is then looked up in the context of the entire
-\grammarterm{postfix-expression} and shall name a class template.
+\grammarterm{postfix-expression} and shall name a template
+whose specializations are types.
 
 \pnum
 If the \grammarterm{id-expression} in a class member

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -562,11 +562,13 @@ Given such
 an entity named \tcode{D} defined in more than one translation unit,
 then
 \begin{itemize}
-\item each definition of \tcode{D} shall consist of the same sequence of
-tokens; and
+\item each definition of \tcode{D} shall consist of
+the same sequence of tokens,
+for which the definition of a closure type
+is considered to consist of the sequence of tokens of
+the corresponding \grammarterm{lambda-expression}; and
 \item in each definition of \tcode{D}, corresponding names, looked up
-according to~\ref{basic.lookup}, shall refer to an entity defined within
-the definition of \tcode{D}, or shall refer to the same entity, after
+according to~\ref{basic.lookup}, shall refer to the same entity, after
 overload resolution\iref{over.match} and after matching of partial
 template specialization\iref{temp.over}, except that a name can refer to
 \begin{itemize}
@@ -586,22 +588,27 @@ the reference refers to the same entity in all definitions of \tcode{D};
 \end{itemize}
 and
 
+\item in each definition of \tcode{D}, except within
+the default arguments and default template arguments of \tcode{D},
+corresponding \grammarterm{lambda-expression}{s} shall have
+the same closure type (see below); and
+
 \item in each definition of \tcode{D}, corresponding entities shall have the
 same language linkage; and
 
 \item in each definition of \tcode{D}, the overloaded operators referred
 to, the implicit calls to conversion functions, constructors, operator
 new functions and operator delete functions, shall refer to the same
-function, or to a function defined within the definition of \tcode{D};
-and
+function; and
 
-\item in each definition of \tcode{D}, a default argument used by an
-(implicit or explicit) function call is treated as if its token sequence
-were present in the definition of \tcode{D}; that is, the default
-argument is subject to the requirements described in this paragraph (and, if
-the default argument has subexpressions with default arguments, this
-requirement applies recursively)\footnote{\ref{dcl.fct.default}
-describes how default argument names are looked up.}; and
+\item in each definition of \tcode{D},
+a default argument used by an (implicit or explicit) function call or
+a default template argument used by an (implicit or explicit)
+\grammarterm{template-id} or \grammarterm{simple-template-id}
+is treated as if its token sequence
+were present in the definition of \tcode{D};
+that is, the default argument or default template argument
+is subject to the requirements described in this paragraph (recursively); and
 
 \item if \tcode{D} invokes a function with a precondition,
 or is a function
@@ -649,20 +656,57 @@ If \tcode{D} is a template and is defined in more than one
 translation unit, then the preceding requirements
 shall apply both to names from the template's enclosing scope used in the
 template definition\iref{temp.nondep}, and also to dependent names at
-the point of instantiation\iref{temp.dep}. If the definitions of
-\tcode{D} satisfy all these requirements, then the behavior is
-as if there were a single definition of \tcode{D}.
+the point of instantiation\iref{temp.dep}.
+These requirements also apply to corresponding entities
+defined within each definition of \tcode{D}
+(including the closure types of \grammarterm{lambda-expression}{s},
+but excluding entities defined within default arguments or
+defualt template arguments of either \tcode{D} or
+an entity not defined within \tcode{D}).
+For each such entity and for \tcode{D} itself,
+the behavior is as if there is a single entity with a single definition,
+including in the application of these requirements to other entities.
 \begin{note}
 The entity is still declared in multiple translation units, and \ref{basic.link}
 still applies to these declarations. In particular,
 \grammarterm{lambda-expression}{s}\iref{expr.prim.lambda}
 appearing in the type of \tcode{D} may result
-in the different declarations having distinct types.
+in the different declarations having distinct types, and
+\grammarterm{lambda-expression}{s} appearing in a default argument of \tcode{D}
+may still denote different types in different translation units.
 \end{note}
 If the definitions of
-\tcode{D} do not satisfy these requirements, then the behavior is
-undefined.%
+\tcode{D} do not satisfy these requirements, then
+the program is ill-formed, no diagnostic required.%
 \indextext{one-definition rule|)}
+\begin{example}
+\begin{codeblock}
+inline void f(bool cond, void (*p)()) {
+  if (cond) f(false, []{});
+}
+inline void g(bool cond, void (*p)() = []{}) {
+  if (cond) g(false);
+}
+struct X {
+  void h(bool cond, void (*p)() = []{}) {
+    if (cond) h(false);
+  }
+}
+\end{codeblock}
+
+If the definition of \tcode{f} appears in multiple translation units,
+the behavior of the program is as if
+there is only one definition of \tcode{f}.
+If the definition of \tcode{g} appears in multiple translation units,
+the program is ill-formed (no diagnostic required) because
+each such definition uses a default argument that
+refers to a distinct \grammarterm{lambda-expression} closure type.
+The definition of \tcode{X} can appear
+in multiple translation units of a valid program;
+the \grammarterm{lambda-expression}{s} defined within
+the default argument of \tcode{X::h} within the definition of \tcode{X}
+denote the same closure type in each translation unit.
+\end{example}
 
 \rSec1[basic.scope]{Scope}%
 \indextext{scope|(}

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3621,14 +3621,7 @@ as the requested size.
 The order,
 contiguity, and initial value of storage allocated by successive calls
 to an allocation function are unspecified.
-For an allocation function other than
-a reserved placement allocation function\iref{new.delete.placement},
-the pointer returned is
-suitably aligned so that it can be converted to a pointer to any
-suitable complete object type\iref{new.delete.single}
-and then used to access the object or array in the
-storage allocated (until the storage is explicitly deallocated by a call
-to a corresponding deallocation function). Even if the size of the space
+Even if the size of the space
 requested is zero, the request can fail. If the request succeeds, the
 value returned by a replaceable allocation function
 is a non-null pointer value\iref{conv.ptr}
@@ -3645,6 +3638,27 @@ to have \tcode{operator new()} implementable by
 calling \tcode{std::malloc()} or \tcode{std::calloc()}, so the rules are
 substantially the same. \Cpp{} differs from C in requiring a zero request
 to return a non-null pointer.}
+
+\pnum
+For an allocation function other than
+a reserved placement allocation function\iref{new.delete.placement},
+the pointer returned on a successful call
+shall represent the address of storage that is aligned as follows:
+\begin{itemize}
+\item
+  If the allocation function takes an argument
+  of type \tcode{std::align_val_t},
+  the storage will have the alignment specified
+  by the value of this argument.
+\item
+  Otherwise, if the allocation function is named \tcode{operator new[]},
+  the storage is aligned for any object that
+  does not have new-extended alignment\iref{basic.align} and
+  is no larger than the requested size.
+\item
+  Otherwise, the storage is aligned for any object that
+  does not have new-extended alignment and is of the requested size.
+\end{itemize}
 
 \pnum
 An allocation function that fails to allocate storage can invoke the

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -6128,7 +6128,7 @@ Within each of these phases of initiation, initialization occurs as follows.
 \indextext{initialization!constant}%
 \defnx{Constant initialization}{constant initialization} is performed
 if a variable or temporary object with static or thread storage duration
-is initialized by a constant initializer\iref{expr.const} for the entity.
+is constant-initialized\iref{expr.const}.
 \indextext{initialization!zero-initialization}%
 If constant initialization is not performed, a variable with static
 storage duration\iref{basic.stc.static} or thread storage

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -713,19 +713,22 @@ of the \tcode{tword} member of the \tcode{right} subtree of \tcode{s}.
 \end{example}
 
 \pnum
+\begin{note}
 \indextext{layout!class object}%
 Non-static data members of a (non-union) class
-with the same access control\iref{class.access}
+with the same access control\iref{class.access} and
+non-zero size\iref{intro.object}
 are allocated so that later
 members have higher addresses within a class object.
 \indextext{allocation!unspecified}%
 The order of allocation of non-static data members
 with different access control
-is unspecified\iref{class.access}.
+is unspecified.
 Implementation alignment requirements might cause two adjacent members
 not to be allocated immediately after each other; so might requirements
 for space for managing virtual functions\iref{class.virtual} and
 virtual base classes\iref{class.mi}.
+\end{note}
 
 \pnum
 If \tcode{T} is the name of a class, then each of the following shall

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1972,7 +1972,18 @@ If a placeholder for a deduced class type
 appears as a \grammarterm{decl-specifier}
 in the \grammarterm{decl-specifier-seq}
 of an initializing declaration\iref{dcl.init} of a variable,
-the placeholder is replaced by the return type
+the declared type of the variable shall be \cv{}~\tcode{T},
+where \tcode{T} is the placeholder.
+\begin{example}
+\begin{codeblock}
+template <class ...T> struct A {
+  A(T...) {}
+};
+A x[29]{};    // error: no declarator operators allowed
+const A& y{}; // error: no declarator operators allowed
+\end{codeblock}
+\end{example}
+The placeholder is replaced by the return type
 of the function selected by overload resolution
 for class template deduction\iref{over.match.class.deduct}.
 If the \grammarterm{decl-specifier-seq}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -923,7 +923,8 @@ that is neither defaulted nor a template,
 if no argument values exist such that
 an invocation of the function or constructor could be an evaluated subexpression of a core
 constant expression\iref{expr.const}, or,
-for a constructor, a constant initializer for some object\iref{basic.start.static},
+for a constructor, an evaluated subexpression of
+the initialization full-expression of some constant-initialized object\iref{basic.start.static},
 the program is ill-formed, no diagnostic required.
 \begin{example}
 \begin{codeblock}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -9074,7 +9074,10 @@ A fallthrough statement may only appear within
 an enclosing \tcode{switch} statement\iref{stmt.switch}.
 The next statement that would be executed after a fallthrough statement
 shall be a labeled statement whose label is a case label or
-default label for the same \tcode{switch} statement.
+default label for the same \tcode{switch} statement and,
+if the fallthrough statement is contained in an iteration statement,
+the next statement shall be part of the same execution of
+the substatement of the innermost enclosing iteration statement.
 The program is ill-formed if there is no such statement.
 
 \pnum
@@ -9098,6 +9101,18 @@ void f(int n) {
     g();
     [[fallthrough]];
   case 3:                       // warning on fallthrough discouraged
+    do {
+      [[fallthrough]];          // error: next statement is not part of the same substatement execution
+    } while (false);
+  case 6:
+    do {
+      [[fallthrough]];          // error: next statement is not part of the same substatement execution
+    } while (n--);
+  case 7:
+    while (false) {
+      [[fallthrough]];          // error: next statement is not part of the same substatement execution
+    }
+  case 5:
     h();
   case 4:                       // implementation may warn on fallthrough
     i();

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6813,26 +6813,33 @@ during translation.\end{note}
 \end{bnf}
 
 \pnum
-A \defn{constant initializer} for a variable or temporary object \tcode{o} is
-an initializer for which interpreting its full-expression
-as a \grammarterm{constant-expression} results in a constant expression,
-except that if \tcode{o} is an object,
-such an initializer may also invoke constexpr constructors
-for \tcode{o} and its subobjects
-even if those objects are of non-literal class types.
-\begin{note}
-Such a class may have a non-trivial destructor.
-Within this evaluation,
-\tcode{std::is_constant_evaluated()}\iref{meta.const.eval}
-returns \tcode{true}.
+A variable or temporary object \tcode{o} is \defn{constant-initialized} if
+\begin{itemize}
+\item
+  either it has an initializer or
+  its default-initialization results in some initialization being performed, and
+\item
+  its initialization full-expression is a constant expression
+  when interpreted as a \grammarterm{constant-expression},
+  except that if \tcode{o} is an object,
+  the initialization full-expression
+  may also invoke constexpr constructors
+  for \tcode{o} and its subobjects
+  even if those objects are of non-literal class types.
+  \begin{note}
+  Such a class may have a non-trivial destructor.
+  Within this evaluation,
+  \tcode{std::is_constant_evaluated()}\iref{meta.const.eval}
+  returns \tcode{true}.
 \end{note}
+\end{itemize}
 
 \pnum
 A variable is
 \defn{usable in constant expressions} after
 its initializing declaration is encountered if it is a constexpr variable, or
-it is of reference type or of const-qualified integral or enumeration type, and
-its initializer is a constant initializer.
+it is a constant-initialized variable
+of reference type or of const-qualified integral or enumeration type.
 
 \pnum
 An expression \tcode{e} is a \defnadj{core constant}{expression}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6871,6 +6871,14 @@ for a constexpr function or
 constexpr constructor\iref{dcl.constexpr};
 
 \item
+an invocation of a virtual function\iref{class.virtual}
+for an object unless
+  \begin{itemize}
+  \item the object is usable in constant expressions or
+  \item its lifetime began within the evaluation of \tcode{e};
+  \end{itemize}
+
+\item
 an expression that would exceed the implementation-defined
 limits (see \ref{implimits});
 

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6835,11 +6835,20 @@ A variable or temporary object \tcode{o} is \defn{constant-initialized} if
 \end{itemize}
 
 \pnum
-A variable is
-\defn{usable in constant expressions} after
+A variable is \defn{usable in constant expressions} after
 its initializing declaration is encountered if it is a constexpr variable, or
 it is a constant-initialized variable
 of reference type or of const-qualified integral or enumeration type.
+An object or reference is \defn{usable in constant expressions} if it is
+\begin{itemize}
+\item a variable that is usable in constant expressions, or
+\item a template parameter object\iref{temp.param}, or
+\item a string literal object\iref{lex.string}, or
+\item a non-mutable subobject or reference member of any of the above, or
+\item a complete temporary object of
+  non-volatile const-qualified integral or enumeration type
+  that is initialized with a constant expression.
+\end{itemize}
 
 \pnum
 An expression \tcode{e} is a \defnadj{core constant}{expression}

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -276,7 +276,8 @@ a non-zero \grammarterm{pp-number}
 matching the form of an \grammarterm{integer-literal}
 if the implementation supports an attribute
 with the name specified by interpreting
-the \grammarterm{pp-tokens} as an \grammarterm{attribute-token},
+the \grammarterm{pp-tokens}, after macro expansion,
+as an \grammarterm{attribute-token},
 and by \tcode{0} otherwise.
 The program is ill-formed if the \grammarterm{pp-tokens}
 do not match the form of an \grammarterm{attribute-token}.
@@ -356,8 +357,10 @@ the behavior is undefined.
 
 \pnum
 After all replacements due to macro expansion and
-evaluations of \grammarterm{defined-macro-expression}{s} and
-\grammarterm{has-include-expression}{s}
+evaluations of
+\grammarterm{defined-macro-expression}s,
+\grammarterm{has-include-expression}s, and
+\grammarterm{has-attribute-expression}s
 have been performed,
 all remaining identifiers and keywords,
 except for

--- a/source/support.tex
+++ b/source/support.tex
@@ -2116,13 +2116,8 @@ called by a
 \grammarterm{new-expression}\iref{expr.new}
 to allocate
 \tcode{size} bytes of storage.
-The second form is called for a type with new-extended alignment,
-and allocates storage
-with the specified alignment.
-The first form is called otherwise,
-and allocates storage
-suitably aligned to represent any object of that size
-provided the object's type does not have new-extended alignment.
+The second form is called for a type with new-extended alignment, and
+the first form is called otherwise.
 
 \pnum
 \replaceable
@@ -2387,13 +2382,8 @@ called by the array form of a
 \grammarterm{new-expression}\iref{expr.new}
 to allocate
 \tcode{size} bytes of storage.
-The second form is called for a type with new-extended alignment,
-and allocates storage
-with the specified alignment.
-The first form is called otherwise,
-and allocates storage
-suitably aligned to represent any array object of that size or smaller,
-provided the object's type does not have new-extended alignment.%
+The second form is called for a type with new-extended alignment, and
+the first form is called otherwise.%
 \footnote{It is not the direct responsibility of
 \tcode{operator new[]}
 or


### PR DESCRIPTION
P1510R0 Core Language Working Group "tentatively ready" Issues for the July, 2019 (Cologne) meeting
Fixes #2980.

Notes:
*CWG1839: This issue was in tentatively ready status so was added, but it is not in P1510R0, so was reverted in a Fixup.
*CWG1839: FYI - wording changed since proposal was written.
*CWG2300: Poor wording in change to 1st bullet of [basic.def.odr] p12:
        We "considered" "the definition of *a* closure type" to "*consist* of the sequence of tokens of the corresponding /lambda-expression/" ??
*CWG2366: In [expr.const] p2, what is "the initialization full-expression" ??
*CWG2406: In [dcl.attr.fallthrough]p3, how can an iteration statement contain a
fallthrough statement?
