### PR TITLE
P1065R2 Constexpr INVOKE

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -582,6 +582,8 @@ the values of these macros with greater values.
 \defnlibxname{cpp_lib_constexpr}                            & \tcode{201811L} &
   any C++ library header from \tref{headers.cpp} or
   any C++ header for C library facilities from \tref{headers.cpp.c} \\ \rowsep
+\defnlibxname{cpp_lib_constexpr_invoke}                     & \tcode{201907L} &
+  \tcode{<functional>} \\ \rowsep
 \defnlibxname{cpp_lib_constexpr_swap_algorithms}            & \tcode{201806L} &
   \tcode{<algorithm>} \\ \rowsep
 \defnlibxname{cpp_lib_constexpr_dynamic_alloc}              & \tcode{201907L} &

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -13645,19 +13645,19 @@ work with arbitrary function objects.
 namespace std {
   // \ref{func.invoke}, invoke
   template<class F, class... Args>
-    invoke_result_t<F, Args...> invoke(F&& f, Args&&... args)
+    constexpr invoke_result_t<F, Args...> invoke(F&& f, Args&&... args)
       noexcept(is_nothrow_invocable_v<F, Args...>);
 
   // \ref{refwrap}, \tcode{reference_wrapper}
   template<class T> class reference_wrapper;
 
-  template<class T> reference_wrapper<T> ref(T&) noexcept;
-  template<class T> reference_wrapper<const T> cref(const T&) noexcept;
+  template<class T> constexpr reference_wrapper<T> ref(T&) noexcept;
+  template<class T> constexpr reference_wrapper<const T> cref(const T&) noexcept;
   template<class T> void ref(const T&&) = delete;
   template<class T> void cref(const T&&) = delete;
 
-  template<class T> reference_wrapper<T> ref(reference_wrapper<T>) noexcept;
-  template<class T> reference_wrapper<const T> cref(reference_wrapper<T>) noexcept;
+  template<class T> constexpr reference_wrapper<T> ref(reference_wrapper<T>) noexcept;
+  template<class T> constexpr reference_wrapper<const T> cref(reference_wrapper<T>) noexcept;
 
   template<class T> struct unwrap_reference;
   template<class T> using unwrap_reference_t = typename unwrap_reference<T>::type;
@@ -13714,19 +13714,19 @@ namespace std {
   struct identity;
 
   // \ref{func.not.fn}, function template \tcode{not_fn}
-  template<class F> @\unspec@ not_fn(F&& f);
+  template<class F> constexpr @\unspec@ not_fn(F&& f);
 
   // \ref{func.bind.front}, function template \tcode{bind_front}
-  template<class F, class... Args> @\unspec@ bind_front(F&&, Args&&...);
+  template<class F, class... Args> constexpr @\unspec@ bind_front(F&&, Args&&...);
 
   // \ref{func.bind}, bind
   template<class T> struct is_bind_expression;
   template<class T> struct is_placeholder;
 
   template<class F, class... BoundArgs>
-    @\unspec@ bind(F&&, BoundArgs&&...);
+    constexpr @\unspec@ bind(F&&, BoundArgs&&...);
   template<class R, class F, class... BoundArgs>
-    @\unspec@ bind(F&&, BoundArgs&&...);
+    constexpr @\unspec@ bind(F&&, BoundArgs&&...);
 
   namespace placeholders {
     // \tcode{\placeholder{M}} is the \impldef{number of placeholders for bind expressions} number of placeholders
@@ -13740,7 +13740,7 @@ namespace std {
 
   // \ref{func.memfn}, member function adaptors
   template<class R, class T>
-    @\unspec@ mem_fn(R T::*) noexcept;
+    constexpr @\unspec@ mem_fn(R T::*) noexcept;
 
   // \ref{func.wrap}, polymorphic function wrappers
   class bad_function_call;
@@ -13893,22 +13893,19 @@ to \tcode{R}.
 \indextext{call wrapper}%
 \indextext{call wrapper!simple}%
 \indextext{call wrapper!forwarding}%
-Every call wrapper\iref{func.def} is \oldconcept{MoveConstructible}.
-A \defn{argument forwarding call wrapper} is a
+Every call wrapper\iref{func.def} meets the \oldconcept{MoveConstructible}
+and \oldconcept{Destructible} requirements.
+An \defn{argument forwarding call wrapper} is a
 call wrapper that can be called with an arbitrary argument list
 and delivers the arguments to the wrapped callable object as references.
 This forwarding step delivers rvalue arguments as rvalue references
 and lvalue arguments as lvalue references.
-A \defn{simple call wrapper} is an argument forwarding call wrapper that is
-\oldconcept{CopyConstructible} and \oldconcept{CopyAssignable} and
-whose copy constructor, move constructor, copy assignment operator,
-and move assignment operator do not throw exceptions.
 \begin{note}
 In a typical implementation, argument forwarding call wrappers have
 an overloaded function call operator of the form
 \begin{codeblock}
 template<class... UnBoundArgs>
-  R operator()(UnBoundArgs&&... unbound_args) @\textit{cv-qual}@;
+  constexpr R operator()(UnBoundArgs&&... unbound_args) @\textit{cv-qual}@;
 \end{codeblock}
 \end{note}
 
@@ -13935,7 +13932,13 @@ of the arguments of the call wrapper and its state entities
 with references as described in the corresponding forwarding steps.
 
 \pnum
-The copy/move constructor of a perfect forwarding call wrapper has
+A \defn{simple call wrapper} is a perfect forwarding call wrapper that meets
+the \oldconcept{CopyConstructible} and \oldconcept{CopyAssignable} requirements
+and whose copy constructor, move constructor, and assignment operators
+are constexpr functions which do not throw exceptions.
+
+\pnum
+The copy/move constructor of an argument forwarding call wrapper has
 the same apparent semantics
 as if memberwise copy/move of its state entities
 were performed\iref{class.copy.ctor}.
@@ -13947,7 +13950,7 @@ if the corresponding implicit definition would be considered to be constexpr.
 \end{note}
 
 \pnum
-Perfect forwarding call wrappers returned by
+Argument forwarding call wrappers returned by
 a given standard library function template have the same type
 if the types of their corresponding state entities are the same.
 
@@ -13956,7 +13959,7 @@ if the types of their corresponding state entities are the same.
 \indexlibrary{invoke@\tcode{\placeholder{INVOKE}}}%
 \begin{itemdecl}
 template<class F, class... Args>
-  invoke_result_t<F, Args...> invoke(F&& f, Args&&... args)
+  constexpr invoke_result_t<F, Args...> invoke(F&& f, Args&&... args)
     noexcept(is_nothrow_invocable_v<F, Args...>);
 \end{itemdecl}
 
@@ -13979,19 +13982,19 @@ namespace std {
 
     // construct/copy/destroy
     template<class U>
-      reference_wrapper(U&&) noexcept(@\seebelow@);
-    reference_wrapper(const reference_wrapper& x) noexcept;
+      constexpr reference_wrapper(U&&) noexcept(@\seebelow@);
+    constexpr reference_wrapper(const reference_wrapper& x) noexcept;
 
     // assignment
-    reference_wrapper& operator=(const reference_wrapper& x) noexcept;
+    constexpr reference_wrapper& operator=(const reference_wrapper& x) noexcept;
 
     // access
-    operator T& () const noexcept;
-    T& get() const noexcept;
+    constexpr operator T& () const noexcept;
+    constexpr T& get() const noexcept;
 
     // invocation
     template<class... ArgTypes>
-      invoke_result_t<T&, ArgTypes...> operator()(ArgTypes&&...) const;
+      constexpr invoke_result_t<T&, ArgTypes...> operator()(ArgTypes&&...) const;
   };
   template<class T>
     reference_wrapper(T&) -> reference_wrapper<T>;
@@ -14014,7 +14017,7 @@ may be an incomplete type.
 \indexlibrary{\idxcode{reference_wrapper}!constructor}%
 \begin{itemdecl}
 template<class U>
-  reference_wrapper(U&& u) noexcept(@\seebelow@);
+  constexpr reference_wrapper(U&& u) noexcept(@\seebelow@);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -14039,7 +14042,7 @@ that stores a reference to \tcode{r}.
 
 \indexlibrary{\idxcode{reference_wrapper}!constructor}%
 \begin{itemdecl}
-reference_wrapper(const reference_wrapper& x) noexcept;
+constexpr reference_wrapper(const reference_wrapper& x) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -14051,7 +14054,7 @@ stores a reference to \tcode{x.get()}.
 
 \indexlibrarymember{operator=}{reference_wrapper}%
 \begin{itemdecl}
-reference_wrapper& operator=(const reference_wrapper& x) noexcept;
+constexpr reference_wrapper& operator=(const reference_wrapper& x) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -14062,7 +14065,7 @@ reference_wrapper& operator=(const reference_wrapper& x) noexcept;
 
 \indexlibrarymember{operator T\&}{reference_wrapper}%
 \begin{itemdecl}
-operator T& () const noexcept;
+constexpr operator T& () const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -14071,7 +14074,7 @@ operator T& () const noexcept;
 
 \indexlibrarymember{get}{reference_wrapper}%
 \begin{itemdecl}
-T& get() const noexcept;
+constexpr T& get() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -14083,7 +14086,7 @@ T& get() const noexcept;
 \indexlibrarymember{operator()}{reference_wrapper}%
 \begin{itemdecl}
 template<class... ArgTypes>
-  invoke_result_t<T&, ArgTypes...>
+  constexpr invoke_result_t<T&, ArgTypes...>
     operator()(ArgTypes&&... args) const;
 \end{itemdecl}
 
@@ -14105,7 +14108,7 @@ may be an incomplete type.
 
 \indexlibrarymember{ref}{reference_wrapper}%
 \begin{itemdecl}
-template<class T> reference_wrapper<T> ref(T& t) noexcept;
+template<class T> constexpr reference_wrapper<T> ref(T& t) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -14114,7 +14117,7 @@ template<class T> reference_wrapper<T> ref(T& t) noexcept;
 
 \indexlibrarymember{ref}{reference_wrapper}%
 \begin{itemdecl}
-template<class T> reference_wrapper<T> ref(reference_wrapper<T> t) noexcept;
+template<class T> constexpr reference_wrapper<T> ref(reference_wrapper<T> t) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -14123,7 +14126,7 @@ template<class T> reference_wrapper<T> ref(reference_wrapper<T> t) noexcept;
 
 \indexlibrarymember{cref}{reference_wrapper}%
 \begin{itemdecl}
-template<class T> reference_wrapper<const T> cref(const T& t) noexcept;
+template<class T> constexpr reference_wrapper<const T> cref(const T& t) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -14132,7 +14135,7 @@ template<class T> reference_wrapper<const T> cref(const T& t) noexcept;
 
 \indexlibrarymember{cref}{reference_wrapper}%
 \begin{itemdecl}
-template<class T> reference_wrapper<const T> cref(reference_wrapper<T> t) noexcept;
+template<class T> constexpr reference_wrapper<const T> cref(reference_wrapper<T> t) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -15127,7 +15130,7 @@ Equivalent to: \tcode{return std::forward<T>(t);}
 
 \indexlibrary{\idxcode{not_fn}}%
 \begin{itemdecl}
-template<class F> @\unspec@ not_fn(F&& f);
+template<class F> constexpr @\unspec@ not_fn(F&& f);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -15167,7 +15170,7 @@ Any exception thrown by the initialization of \tcode{fd}.
 \indexlibrary{\idxcode{bind_front}}%
 \begin{itemdecl}
 template<class F, class... Args>
-  @\unspec@ bind_front(F&& f, Args&&... args);
+  constexpr @\unspec@ bind_front(F&& f, Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -15282,12 +15285,18 @@ treated as a placeholder type.
 In the text that follows:
 
 \begin{itemize}
+\item \tcode{g} is a value of the result of a \tcode{bind} invocation,
 \item \tcode{FD} is the type \tcode{decay_t<F>},
-\item \tcode{fd} is an lvalue of type \tcode{FD} constructed from \tcode{std::forward<F>(f)},
+\item \tcode{fd} is an lvalue that
+  is a target object of \tcode{g}\iref{func.def} of type \tcode{FD}
+  direct-non-list-initialized with \tcode{std::forward<F>(f)},
 \item $\tcode{T}_i$ is the $i^\text{th}$ type in the template parameter pack \tcode{BoundArgs},
 \item $\tcode{TD}_i$ is the type \tcode{decay_t<$\tcode{T}_i$>},
 \item $\tcode{t}_i$ is the $i^\text{th}$ argument in the function parameter pack \tcode{bound_args},
-\item $\tcode{td}_i$ is an lvalue of type $\tcode{TD}_i$ constructed from \tcode{std::forward<$\tcode{T}_i$>($\tcode{t}_i$)},
+\item $\tcode{td}_i$ is a bound argument entity
+  of \tcode{g}\iref{func.def} of type $\tcode{TD}_i$
+  direct-non-list-initialized with
+  \tcode{std::forward<\brk{}$\tcode{T}_i$>($\tcode{t}_i$)},
 \item $\tcode{U}_j$ is the $j^\text{th}$ deduced type of the \tcode{UnBoundArgs\&\&...} parameter
   of the argument forwarding call wrapper, and
 \item $\tcode{u}_j$ is the $j^\text{th}$ argument associated with $\tcode{U}_j$.
@@ -15296,86 +15305,57 @@ In the text that follows:
 \indexlibrary{\idxcode{bind}}%
 \begin{itemdecl}
 template<class F, class... BoundArgs>
-  @\unspec@ bind(F&& f, BoundArgs&&... bound_args);
+  constexpr @\unspec@ bind(F&& f, BoundArgs&&... bound_args);
+template<class R, class F, class... BoundArgs>
+  constexpr @\unspec@ bind(F&& f, BoundArgs&&... bound_args);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\requires
-\tcode{is_constructible_v<FD, F>} shall be \tcode{true}. For each $\tcode{T}_i$
-in \tcode{BoundArgs}, \tcode{is_cons\-tructible_v<$\tcode{TD}_i$, $\tcode{T}_i$>} shall be \tcode{true}.
+\mandates
+\tcode{is_constructible_v<FD, F>} is \tcode{true}. For each $\tcode{T}_i$
+in \tcode{BoundArgs}, \tcode{is_cons\-tructible_v<$\tcode{TD}_i$, $\tcode{T}_i$>} is \tcode{true}.
+
+\pnum
+\expects
+\tcode{FD} and each $\tcode{TD}_i$ meet
+the \oldconcept{MoveConstructible} and \oldconcept{Destructible} requirements.
 \tcode{\placeholdernc{INVOKE}(fd, $\tcode{w}_1$, $\tcode{w}_2$, $\dotsc$,
-$\tcode{w}_N$)}\iref{func.require} shall be a valid expression for some
+$\tcode{w}_N$)}\iref{func.require} is a valid expression for some
 values $\tcode{w}_1$, $\tcode{w}_2$, $\dotsc{}$, $\tcode{w}_N$, where
 $N$ has the value \tcode{sizeof...(bound_args)}.
-The cv-qualifiers \cv{} of the call wrapper \tcode{g},
-as specified below, shall be neither \tcode{volatile} nor \tcode{const volatile}.
 
 \pnum\returns
 An argument forwarding call wrapper \tcode{g}\iref{func.require}.
-The effect of \tcode{g($\tcode{u}_1$, $\tcode{u}_2$, $\dotsc$, $\tcode{u}_M$)}
-is
+A program that attempts to invoke a volatile-qualified \tcode{g}
+is ill-formed.
+When \tcode{g} is not volatile-qualified, invocation of
+\tcode{g($\tcode{u}_1$, $\tcode{u}_2$, $\dotsc$, $\tcode{u}_M$)}
+is expression-equivalent\iref{defns.expression-equivalent} to
 \begin{codeblock}
-@\placeholdernc{INVOKE}@(fd, std::forward<@$\tcode{V}_1$@>(@$\tcode{v}_1$@), std::forward<@$\tcode{V}_2$@>(@$\tcode{v}_2$@), @$\dotsc$@, std::forward<@$\tcode{V}_N$@>(@$\tcode{v}_N$@))
+@\placeholdernc{INVOKE}@(static_cast<@$\tcode{V}_\tcode{fd}$@>(@$\tcode{v}_\tcode{fd}$@),
+       static_cast<@$\tcode{V}_1$@>(@$\tcode{v}_1$@), static_cast<@$\tcode{V}_2$@>(@$\tcode{v}_2$@), @$\dotsc$@, static_cast<@$\tcode{V}_N$@>(@$\tcode{v}_N$@))
 \end{codeblock}
-where the values and types of the bound
-arguments $\tcode{v}_1$, $\tcode{v}_2$, $\dotsc$, $\tcode{v}_N$ are determined as specified below.
-The copy constructor and move constructor of the argument forwarding call wrapper throw an
-exception if and only if the corresponding constructor of \tcode{FD} or of any of the types
-$\tcode{TD}_i$ throws an exception.
-
-\pnum
-\throws Nothing unless the construction of
-\tcode{fd} or of one of the values $\tcode{td}_i$ throws an exception.
-
-\pnum
-\remarks The return type meets the \oldconcept{MoveConstructible} requirements. If all
-of \tcode{FD} and $\tcode{TD}_i$ meet the \oldconcept{CopyConstructible} requirements, then the
-return type meets the \oldconcept{CopyConstructible} requirements. \begin{note} This implies
-that all of \tcode{FD} and $\tcode{TD}_i$ are \oldconcept{MoveConst\-ruct\-ible}. \end{note}
-\end{itemdescr}
-
-\indexlibrary{\idxcode{bind}}%
-\begin{itemdecl}
-template<class R, class F, class... BoundArgs>
-  @\unspec@ bind(F&& f, BoundArgs&&... bound_args);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\requires
-\tcode{is_constructible_v<FD, F>} shall be \tcode{true}. For each $\tcode{T}_i$
-in \tcode{BoundArgs}, \tcode{is_con\-structible_v<$\tcode{TD}_i$, $\tcode{T}_i$>} shall be \tcode{true}.
-\tcode{\placeholdernc{INVOKE}(fd, $\tcode{w}_1$, $\tcode{w}_2$, $\dotsc$, $\tcode{w}_N$)} shall be  a valid
-expression for some
-values $\tcode{w}_1$, $\tcode{w}_2$, $\dotsc$, $\tcode{w}_N$, where
-$N$ has the value \tcode{sizeof...(bound_args)}.
-The cv-qualifiers \cv{} of the call wrapper \tcode{g},
-as specified below, shall be neither \tcode{volatile} nor \tcode{const volatile}.
-
-\pnum
-\returns
-An argument forwarding call wrapper \tcode{g}\iref{func.require}.
-The effect of
-\tcode{g($\tcode{u}_1$, $\tcode{u}_2$, $\dotsc$, $\tcode{u}_M$)} is
+for the first overload, and
 \begin{codeblock}
-@\placeholdernc{INVOKE}@<R>(fd, std::forward<@$\tcode{V}_1$@>(@$\tcode{v}_1$@), std::forward<@$\tcode{V}_2$@>(@$\tcode{v}_2$@), @$\dotsc$@, std::forward<@$\tcode{V}_N$@>(@$\tcode{v}_N$@))
+@\placeholdernc{INVOKE}@<R>(static_cast<@$\tcode{V}_\tcode{fd}$@>(@$\tcode{v}_\tcode{fd}$@),
+          static_cast<@$\tcode{V}_1$@>(@$\tcode{v}_1$@), static_cast<@$\tcode{V}_2$@>(@$\tcode{v}_2$@), @$\dotsc$@, static_cast<@$\tcode{V}_N$@>(@$\tcode{v}_N$@))
 \end{codeblock}
-where the values and types of the bound
-arguments $\tcode{v}_1$, $\tcode{v}_2$, $\dotsc$, $\tcode{v}_N$ are determined as specified below.
-The copy constructor and move constructor of the argument forwarding call wrapper throw an
-exception if and only if the corresponding constructor of \tcode{FD} or of any of the types
-$\tcode{TD}_i$ throws an exception.
+for the second overload,
+where the values and types of the target argument $\tcode{v}_\tcode{fd}$ and
+of the bound arguments
+$\tcode{v}_1$, $\tcode{v}_2$, $\dotsc$, $\tcode{v}_N$ are determined as specified below.
 
 \pnum
-\throws Nothing unless the construction of
-\tcode{fd} or of one of the values $\tcode{td}_i$ throws an exception.
+\throws Any exception thrown by the initialization of
+the state entities of \tcode{g}.
 
 \pnum
-\remarks The return type meets the \oldconcept{MoveConstructible} requirements. If all
-of \tcode{FD} and $\tcode{TD}_i$ meet the \oldconcept{CopyConstructible} requirements, then the
-return type meets the \oldconcept{CopyConstructible} requirements. \begin{note} This implies
-that all of \tcode{FD} and $\tcode{TD}_i$ are \oldconcept{MoveConst\-ruct\-ible}. \end{note}
+\begin{note}
+If all of \tcode{FD} and $\tcode{TD}_i$ meet
+the requirements of \oldconcept{CopyConstructible}, then
+the return type meets the requirements of \oldconcept{CopyConstructible}.
+\end{note}
 \end{itemdescr}
 
 \pnum
@@ -15391,9 +15371,12 @@ cv-qualifiers \cv{} of the call wrapper \tcode{g} as follows:
 argument is \tcode{$\tcode{td}_i$.get()} and its type $\tcode{V}_i$ is \tcode{T\&};
 
 \item if the value of \tcode{is_bind_expression_v<$\tcode{TD}_i$>}
-is \tcode{true}, the argument is \tcode{$\tcode{td}_i$(std::forward<$\tcode{U}_j$>($\tcode{u}_j$)...)}  and its
-type $\tcode{V}_i$ is
-\tcode{invoke_result_t<$\tcode{TD}_i$ \cv{} \&, $\tcode{U}_j$...>\&\&};
+is \tcode{true}, the argument is
+\begin{codeblock}
+static_cast<@\cv{} $\tcode{TD}_i$@&>(@$\tcode{td}_i$@)(std::forward<@$\tcode{U}_j$@>(@$\tcode{u}_j$@)...)
+\end{codeblock}
+and its type $\tcode{V}_i$ is
+\tcode{invoke_result_t<\cv{} $\tcode{TD}_i$\&, $\tcode{U}_j$...>\&\&};
 
 \item if the value \tcode{j} of \tcode{is_placeholder_v<$\tcode{TD}_i$>}
 is not zero, the  argument is \tcode{std::forward<$\tcode{U}_j$>($\tcode{u}_j$)}
@@ -15401,8 +15384,12 @@ and its type $\tcode{V}_i$
 is \tcode{$\tcode{U}_j$\&\&};
 
 \item otherwise, the value is $\tcode{td}_i$ and its type $\tcode{V}_i$
-is \tcode{$\tcode{TD}_i$ \cv{} \&}.
+is \tcode{\cv{} $\tcode{TD}_i$\&}.
 \end{itemize}
+
+\pnum
+The value of the target argument $\tcode{v}_\tcode{fd}$ is \tcode{fd} and
+its corresponding type $\tcode{V}_\tcode{fd}$ is \tcode{\cv{} FD\&}.
 \indexlibrary{\idxcode{bind}|)}%
 
 \rSec3[func.bind.place]{Placeholders}
@@ -15422,12 +15409,15 @@ namespace std::placeholders {
 \end{codeblock}
 
 \pnum
-All placeholder types shall be \oldconcept{DefaultConstructible} and
-\oldconcept{CopyConstructible}, and their default constructors and copy/move
-constructors shall not throw exceptions. It is \impldef{assignability of placeholder
+All placeholder types meet the \oldconcept{DefaultConstructible} and
+\oldconcept{CopyConstructible} requirements, and
+their default constructors and copy/move
+constructors are constexpr functions which
+do not throw exceptions. It is \impldef{assignability of placeholder
 objects} whether
-placeholder types are \oldconcept{CopyAssignable}. \oldconcept{CopyAssignable} placeholders' copy
-assignment operators shall not throw exceptions.
+placeholder types meet the \oldconcept{CopyAssignable} requirements,
+but if so, their copy assignment operators are
+constexpr functions which do not throw exceptions.
 
 \pnum
 Placeholders should be defined as:
@@ -15445,14 +15435,17 @@ extern @\unspec@ _1;
 
 \indexlibrary{\idxcode{mem_fn}}%
 \begin{itemdecl}
-template<class R, class T> @\unspec@ mem_fn(R T::* pm) noexcept;
+template<class R, class T> constexpr @\unspec@ mem_fn(R T::* pm) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \returns A simple call wrapper\iref{func.def} \tcode{fn}
-such that the expression \tcode{fn(t, a$_2$, $\dotsc$, a$_N$)} is equivalent
-to \tcode{\placeholdernc{INVOKE}(pm, t, a$_2$, $\dotsc$, a$_N$)}\iref{func.require}.
+with call pattern \tcode{invoke(pmd, call_args...)}, where
+\tcode{pmd} is the target object of \tcode{fn} of type \tcode{R T::*}
+direct-non-list-initialized with \tcode{pm}, and
+\tcode{call_args} is an argument pack
+used in a function call expression\iref{expr.call} of \tcode{pm}.
 \end{itemdescr}
 \indextext{function object!\idxcode{mem_fn}|)}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -13935,7 +13935,7 @@ with references as described in the corresponding forwarding steps.
 A \defn{simple call wrapper} is a perfect forwarding call wrapper that meets
 the \oldconcept{CopyConstructible} and \oldconcept{CopyAssignable} requirements
 and whose copy constructor, move constructor, and assignment operators
-are constexpr functions which do not throw exceptions.
+are constexpr functions that do not throw exceptions.
 
 \pnum
 The copy/move constructor of an argument forwarding call wrapper has
@@ -15412,12 +15412,12 @@ namespace std::placeholders {
 All placeholder types meet the \oldconcept{DefaultConstructible} and
 \oldconcept{CopyConstructible} requirements, and
 their default constructors and copy/move
-constructors are constexpr functions which
+constructors are constexpr functions that
 do not throw exceptions. It is \impldef{assignability of placeholder
 objects} whether
 placeholder types meet the \oldconcept{CopyAssignable} requirements,
 but if so, their copy assignment operators are
-constexpr functions which do not throw exceptions.
+constexpr functions that do not throw exceptions.
 
 \pnum
 Placeholders should be defined as:


### PR DESCRIPTION
[func.require]pa Added "requirements".
[func.bind.bind]p3 Added "of" in "invocation of".
[func.bind.bind]p11 Did not italicise "target argument" since it's not a definition or grammar term.  (Note that target argument is never defined).

Fixes #3025.