### PR TITLE
P0980R1 Making std::string constexpr

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -539,73 +539,75 @@ namespace std {
     class basic_string;
 
   template<class charT, class traits, class Allocator>
-    basic_string<charT, traits, Allocator>
+    constexpr basic_string<charT, traits, Allocator>
       operator+(const basic_string<charT, traits, Allocator>& lhs,
                 const basic_string<charT, traits, Allocator>& rhs);
   template<class charT, class traits, class Allocator>
-    basic_string<charT, traits, Allocator>
+    constexpr basic_string<charT, traits, Allocator>
       operator+(basic_string<charT, traits, Allocator>&& lhs,
                 const basic_string<charT, traits, Allocator>& rhs);
   template<class charT, class traits, class Allocator>
-    basic_string<charT, traits, Allocator>
+    constexpr basic_string<charT, traits, Allocator>
       operator+(const basic_string<charT, traits, Allocator>& lhs,
                 basic_string<charT, traits, Allocator>&& rhs);
   template<class charT, class traits, class Allocator>
-    basic_string<charT, traits, Allocator>
+    constexpr basic_string<charT, traits, Allocator>
       operator+(basic_string<charT, traits, Allocator>&& lhs,
                 basic_string<charT, traits, Allocator>&& rhs);
   template<class charT, class traits, class Allocator>
-    basic_string<charT, traits, Allocator>
+    constexpr basic_string<charT, traits, Allocator>
       operator+(const charT* lhs,
                 const basic_string<charT, traits, Allocator>& rhs);
   template<class charT, class traits, class Allocator>
-    basic_string<charT, traits, Allocator>
+    constexpr basic_string<charT, traits, Allocator>
       operator+(const charT* lhs,
                 basic_string<charT, traits, Allocator>&& rhs);
   template<class charT, class traits, class Allocator>
-    basic_string<charT, traits, Allocator>
+    constexpr basic_string<charT, traits, Allocator>
       operator+(charT lhs,
                 const basic_string<charT, traits, Allocator>& rhs);
   template<class charT, class traits, class Allocator>
-    basic_string<charT, traits, Allocator>
+    constexpr basic_string<charT, traits, Allocator>
       operator+(charT lhs,
                 basic_string<charT, traits, Allocator>&& rhs);
   template<class charT, class traits, class Allocator>
-    basic_string<charT, traits, Allocator>
+    constexpr basic_string<charT, traits, Allocator>
       operator+(const basic_string<charT, traits, Allocator>& lhs,
                 const charT* rhs);
   template<class charT, class traits, class Allocator>
-    basic_string<charT, traits, Allocator>
+    constexpr basic_string<charT, traits, Allocator>
       operator+(basic_string<charT, traits, Allocator>&& lhs,
                 const charT* rhs);
   template<class charT, class traits, class Allocator>
-    basic_string<charT, traits, Allocator>
+    constexpr basic_string<charT, traits, Allocator>
       operator+(const basic_string<charT, traits, Allocator>& lhs,
                 charT rhs);
   template<class charT, class traits, class Allocator>
-    basic_string<charT, traits, Allocator>
+    constexpr basic_string<charT, traits, Allocator>
       operator+(basic_string<charT, traits, Allocator>&& lhs,
                 charT rhs);
 
   template<class charT, class traits, class Allocator>
-    bool operator==(const basic_string<charT, traits, Allocator>& lhs,
-                    const basic_string<charT, traits, Allocator>& rhs) noexcept;
+    constexpr bool
+      operator==(const basic_string<charT, traits, Allocator>& lhs,
+                 const basic_string<charT, traits, Allocator>& rhs) noexcept;
   template<class charT, class traits, class Allocator>
-    bool operator==(const basic_string<charT, traits, Allocator>& lhs,
-                    const charT* rhs);
+    constexpr bool operator==(const basic_string<charT, traits, Allocator>& lhs,
+                              const charT* rhs);
 
   template<class charT, class traits, class Allocator>
-    @\seebelow@ operator<=>(const basic_string<charT, traits, Allocator>& lhs,
-    @\itcorr@                      const basic_string<charT, traits, Allocator>& rhs) noexcept;
+    constexpr @\seebelow@ operator<=>(const basic_string<charT, traits, Allocator>& lhs,
+              @\itcorr@                      const basic_string<charT, traits, Allocator>& rhs) noexcept;
   template<class charT, class traits, class Allocator>
-    @\seebelow@ operator<=>(const basic_string<charT, traits, Allocator>& lhs,
-    @\itcorr@                      const charT* rhs);
+    constexpr @\seebelow@ operator<=>(const basic_string<charT, traits, Allocator>& lhs,
+              @\itcorr@                      const charT* rhs);
 
   // \ref{string.special}, swap
   template<class charT, class traits, class Allocator>
-    void swap(basic_string<charT, traits, Allocator>& lhs,
-              basic_string<charT, traits, Allocator>& rhs)
-      noexcept(noexcept(lhs.swap(rhs)));
+    constexpr void
+      swap(basic_string<charT, traits, Allocator>& lhs,
+           basic_string<charT, traits, Allocator>& rhs)
+        noexcept(noexcept(lhs.swap(rhs)));
 
   // \ref{string.io}, inserters and extractors
   template<class charT, class traits, class Allocator>
@@ -712,11 +714,11 @@ namespace std {
   inline namespace literals {
   inline namespace string_literals {
     // \ref{basic.string.literals}, suffix for \tcode{basic_string} literals
-    string    operator""s(const char* str, size_t len);
-    u8string  operator""s(const char8_t* str, size_t len);
-    u16string operator""s(const char16_t* str, size_t len);
-    u32string operator""s(const char32_t* str, size_t len);
-    wstring   operator""s(const wchar_t* str, size_t len);
+    constexpr string    operator""s(const char* str, size_t len);
+    constexpr u8string  operator""s(const char8_t* str, size_t len);
+    constexpr u16string operator""s(const char16_t* str, size_t len);
+    constexpr u32string operator""s(const char32_t* str, size_t len);
+    constexpr wstring   operator""s(const wchar_t* str, size_t len);
   }
   }
 }
@@ -787,233 +789,245 @@ namespace std {
     static const size_type npos  = -1;
 
     // \ref{string.cons}, construct/copy/destroy
-    basic_string() noexcept(noexcept(Allocator())) : basic_string(Allocator()) { }
-    explicit basic_string(const Allocator& a) noexcept;
-    basic_string(const basic_string& str);
-    basic_string(basic_string&& str) noexcept;
-    basic_string(const basic_string& str, size_type pos, const Allocator& a = Allocator());
-    basic_string(const basic_string& str, size_type pos, size_type n,
-                 const Allocator& a = Allocator());
+    constexpr basic_string() noexcept(noexcept(Allocator())) : basic_string(Allocator()) { }
+    constexpr explicit basic_string(const Allocator& a) noexcept;
+    constexpr basic_string(const basic_string& str);
+    constexpr basic_string(basic_string&& str) noexcept;
+    constexpr basic_string(const basic_string& str, size_type pos,
+                           const Allocator& a = Allocator());
+    constexpr basic_string(const basic_string& str, size_type pos, size_type n,
+                           const Allocator& a = Allocator());
     template<class T>
-      basic_string(const T& t, size_type pos, size_type n, const Allocator& a = Allocator());
+      constexpr basic_string(const T& t, size_type pos, size_type n,
+                             const Allocator& a = Allocator());
     template<class T>
-      explicit basic_string(const T& t, const Allocator& a = Allocator());
-    basic_string(const charT* s, size_type n, const Allocator& a = Allocator());
-    basic_string(const charT* s, const Allocator& a = Allocator());
-    basic_string(size_type n, charT c, const Allocator& a = Allocator());
+      constexpr explicit basic_string(const T& t, const Allocator& a = Allocator());
+    constexpr basic_string(const charT* s, size_type n, const Allocator& a = Allocator());
+    constexpr basic_string(const charT* s, const Allocator& a = Allocator());
+    constexpr basic_string(size_type n, charT c, const Allocator& a = Allocator());
     template<class InputIterator>
-      basic_string(InputIterator begin, InputIterator end, const Allocator& a = Allocator());
-    basic_string(initializer_list<charT>, const Allocator& = Allocator());
-    basic_string(const basic_string&, const Allocator&);
-    basic_string(basic_string&&, const Allocator&);
+      constexpr basic_string(InputIterator begin, InputIterator end,
+                             const Allocator& a = Allocator());
+    constexpr basic_string(initializer_list<charT>, const Allocator& = Allocator());
+    constexpr basic_string(const basic_string&, const Allocator&);
+    constexpr basic_string(basic_string&&, const Allocator&);
+    constexpr ~basic_string();
 
-    ~basic_string();
-    basic_string& operator=(const basic_string& str);
-    basic_string& operator=(basic_string&& str)
+    constexpr basic_string& operator=(const basic_string& str);
+    constexpr basic_string& operator=(basic_string&& str)
       noexcept(allocator_traits<Allocator>::propagate_on_container_move_assignment::value ||
                allocator_traits<Allocator>::is_always_equal::value);
     template<class T>
-      basic_string& operator=(const T& t);
-    basic_string& operator=(const charT* s);
-    basic_string& operator=(charT c);
-    basic_string& operator=(initializer_list<charT>);
+      constexpr basic_string& operator=(const T& t);
+    constexpr basic_string& operator=(const charT* s);
+    constexpr basic_string& operator=(charT c);
+    constexpr basic_string& operator=(initializer_list<charT>);
 
     // \ref{string.iterators}, iterators
-    iterator       begin() noexcept;
-    const_iterator begin() const noexcept;
-    iterator       end() noexcept;
-    const_iterator end() const noexcept;
+    constexpr iterator       begin() noexcept;
+    constexpr const_iterator begin() const noexcept;
+    constexpr iterator       end() noexcept;
+    constexpr const_iterator end() const noexcept;
 
-    reverse_iterator       rbegin() noexcept;
-    const_reverse_iterator rbegin() const noexcept;
-    reverse_iterator       rend() noexcept;
-    const_reverse_iterator rend() const noexcept;
+    constexpr reverse_iterator       rbegin() noexcept;
+    constexpr const_reverse_iterator rbegin() const noexcept;
+    constexpr reverse_iterator       rend() noexcept;
+    constexpr const_reverse_iterator rend() const noexcept;
 
-    const_iterator         cbegin() const noexcept;
-    const_iterator         cend() const noexcept;
-    const_reverse_iterator crbegin() const noexcept;
-    const_reverse_iterator crend() const noexcept;
+    constexpr const_iterator         cbegin() const noexcept;
+    constexpr const_iterator         cend() const noexcept;
+    constexpr const_reverse_iterator crbegin() const noexcept;
+    constexpr const_reverse_iterator crend() const noexcept;
 
     // \ref{string.capacity}, capacity
-    size_type size() const noexcept;
-    size_type length() const noexcept;
-    size_type max_size() const noexcept;
-    void resize(size_type n, charT c);
-    void resize(size_type n);
-    size_type capacity() const noexcept;
-    void reserve(size_type res_arg);
-    void shrink_to_fit();
-    void clear() noexcept;
-    [[nodiscard]] bool empty() const noexcept;
+    constexpr size_type size() const noexcept;
+    constexpr size_type length() const noexcept;
+    constexpr size_type max_size() const noexcept;
+    constexpr void resize(size_type n, charT c);
+    constexpr void resize(size_type n);
+    constexpr size_type capacity() const noexcept;
+    constexpr void reserve(size_type res_arg);
+    constexpr void shrink_to_fit();
+    constexpr void clear() noexcept;
+    [[nodiscard]] constexpr bool empty() const noexcept;
 
     // \ref{string.access}, element access
-    const_reference operator[](size_type pos) const;
-    reference       operator[](size_type pos);
-    const_reference at(size_type n) const;
-    reference       at(size_type n);
+    constexpr const_reference operator[](size_type pos) const;
+    constexpr reference       operator[](size_type pos);
+    constexpr const_reference at(size_type n) const;
+    constexpr reference       at(size_type n);
 
-    const charT& front() const;
-    charT&       front();
-    const charT& back() const;
-    charT&       back();
+    constexpr const charT& front() const;
+    constexpr charT&       front();
+    constexpr const charT& back() const;
+    constexpr charT&       back();
 
     // \ref{string.modifiers}, modifiers
-    basic_string& operator+=(const basic_string& str);
+    constexpr basic_string& operator+=(const basic_string& str);
     template<class T>
-      basic_string& operator+=(const T& t);
-    basic_string& operator+=(const charT* s);
-    basic_string& operator+=(charT c);
-    basic_string& operator+=(initializer_list<charT>);
-    basic_string& append(const basic_string& str);
-    basic_string& append(const basic_string& str, size_type pos, size_type n = npos);
+      constexpr basic_string& operator+=(const T& t);
+    constexpr basic_string& operator+=(const charT* s);
+    constexpr basic_string& operator+=(charT c);
+    constexpr basic_string& operator+=(initializer_list<charT>);
+    constexpr basic_string& append(const basic_string& str);
+    constexpr basic_string& append(const basic_string& str, size_type pos, size_type n = npos);
     template<class T>
-      basic_string& append(const T& t);
+      constexpr basic_string& append(const T& t);
     template<class T>
-      basic_string& append(const T& t, size_type pos, size_type n = npos);
-    basic_string& append(const charT* s, size_type n);
-    basic_string& append(const charT* s);
-    basic_string& append(size_type n, charT c);
+      constexpr basic_string& append(const T& t, size_type pos, size_type n = npos);
+    constexpr basic_string& append(const charT* s, size_type n);
+    constexpr basic_string& append(const charT* s);
+    constexpr basic_string& append(size_type n, charT c);
     template<class InputIterator>
-      basic_string& append(InputIterator first, InputIterator last);
-    basic_string& append(initializer_list<charT>);
+      constexpr basic_string& append(InputIterator first, InputIterator last);
+    constexpr basic_string& append(initializer_list<charT>);
 
-    void push_back(charT c);
+    constexpr void push_back(charT c);
 
-    basic_string& assign(const basic_string& str);
-    basic_string& assign(basic_string&& str)
+    constexpr basic_string& assign(const basic_string& str);
+    constexpr basic_string& assign(basic_string&& str)
       noexcept(allocator_traits<Allocator>::propagate_on_container_move_assignment::value ||
                allocator_traits<Allocator>::is_always_equal::value);
-    basic_string& assign(const basic_string& str, size_type pos, size_type n = npos);
+    constexpr basic_string& assign(const basic_string& str, size_type pos, size_type n = npos);
     template<class T>
-      basic_string& assign(const T& t);
+      constexpr basic_string& assign(const T& t);
     template<class T>
-      basic_string& assign(const T& t, size_type pos, size_type n = npos);
-    basic_string& assign(const charT* s, size_type n);
-    basic_string& assign(const charT* s);
-    basic_string& assign(size_type n, charT c);
+      constexpr basic_string& assign(const T& t, size_type pos, size_type n = npos);
+    constexpr basic_string& assign(const charT* s, size_type n);
+    constexpr basic_string& assign(const charT* s);
+    constexpr basic_string& assign(size_type n, charT c);
     template<class InputIterator>
-      basic_string& assign(InputIterator first, InputIterator last);
-    basic_string& assign(initializer_list<charT>);
+      constexpr basic_string& assign(InputIterator first, InputIterator last);
+    constexpr basic_string& assign(initializer_list<charT>);
 
-    basic_string& insert(size_type pos, const basic_string& str);
-    basic_string& insert(size_type pos1, const basic_string& str,
-                         size_type pos2, size_type n = npos);
+    constexpr basic_string& insert(size_type pos, const basic_string& str);
+    constexpr basic_string& insert(size_type pos1, const basic_string& str,
+                                   size_type pos2, size_type n = npos);
     template<class T>
-      basic_string& insert(size_type pos, const T& t);
+      constexpr basic_string& insert(size_type pos, const T& t);
     template<class T>
-      basic_string& insert(size_type pos1, const T& t, size_type pos2, size_type n = npos);
-    basic_string& insert(size_type pos, const charT* s, size_type n);
-    basic_string& insert(size_type pos, const charT* s);
-    basic_string& insert(size_type pos, size_type n, charT c);
-    iterator insert(const_iterator p, charT c);
-    iterator insert(const_iterator p, size_type n, charT c);
+      constexpr basic_string& insert(size_type pos1, const T& t,
+                                     size_type pos2, size_type n = npos);
+    constexpr basic_string& insert(size_type pos, const charT* s, size_type n);
+    constexpr basic_string& insert(size_type pos, const charT* s);
+    constexpr basic_string& insert(size_type pos, size_type n, charT c);
+    constexpr iterator insert(const_iterator p, charT c);
+    constexpr iterator insert(const_iterator p, size_type n, charT c);
     template<class InputIterator>
-      iterator insert(const_iterator p, InputIterator first, InputIterator last);
-    iterator insert(const_iterator p, initializer_list<charT>);
+      constexpr iterator insert(const_iterator p, InputIterator first, InputIterator last);
+    constexpr iterator insert(const_iterator p, initializer_list<charT>);
 
-    basic_string& erase(size_type pos = 0, size_type n = npos);
-    iterator erase(const_iterator p);
-    iterator erase(const_iterator first, const_iterator last);
+    constexpr basic_string& erase(size_type pos = 0, size_type n = npos);
+    constexpr iterator erase(const_iterator p);
+    constexpr iterator erase(const_iterator first, const_iterator last);
 
-    void pop_back();
+    constexpr void pop_back();
 
-    basic_string& replace(size_type pos1, size_type n1, const basic_string& str);
-    basic_string& replace(size_type pos1, size_type n1, const basic_string& str,
-                          size_type pos2, size_type n2 = npos);
+    constexpr basic_string& replace(size_type pos1, size_type n1, const basic_string& str);
+    constexpr basic_string& replace(size_type pos1, size_type n1, const basic_string& str,
+                                    size_type pos2, size_type n2 = npos);
     template<class T>
-      basic_string& replace(size_type pos1, size_type n1, const T& t);
+      constexpr basic_string& replace(size_type pos1, size_type n1, const T& t);
     template<class T>
-      basic_string& replace(size_type pos1, size_type n1, const T& t,
-                            size_type pos2, size_type n2 = npos);
-    basic_string& replace(size_type pos, size_type n1, const charT* s, size_type n2);
-    basic_string& replace(size_type pos, size_type n1, const charT* s);
-    basic_string& replace(size_type pos, size_type n1, size_type n2, charT c);
-
-    basic_string& replace(const_iterator i1, const_iterator i2, const basic_string& str);
+      constexpr basic_string& replace(size_type pos1, size_type n1, const T& t,
+                                      size_type pos2, size_type n2 = npos);
+    constexpr basic_string& replace(size_type pos, size_type n1, const charT* s, size_type n2);
+    constexpr basic_string& replace(size_type pos, size_type n1, const charT* s);
+    constexpr basic_string& replace(size_type pos, size_type n1, size_type n2, charT c);
+    constexpr basic_string& replace(const_iterator i1, const_iterator i2,
+                                    const basic_string& str);
     template<class T>
-      basic_string& replace(const_iterator i1, const_iterator i2, const T& t);
-    basic_string& replace(const_iterator i1, const_iterator i2, const charT* s, size_type n);
-    basic_string& replace(const_iterator i1, const_iterator i2, const charT* s);
-    basic_string& replace(const_iterator i1, const_iterator i2, size_type n, charT c);
+      constexpr basic_string& replace(const_iterator i1, const_iterator i2, const T& t);
+    constexpr basic_string& replace(const_iterator i1, const_iterator i2, const charT* s,
+                                    size_type n);
+    constexpr basic_string& replace(const_iterator i1, const_iterator i2, const charT* s);
+    constexpr basic_string& replace(const_iterator i1, const_iterator i2, size_type n, charT c);
     template<class InputIterator>
-      basic_string& replace(const_iterator i1, const_iterator i2,
-                            InputIterator j1, InputIterator j2);
-    basic_string& replace(const_iterator, const_iterator, initializer_list<charT>);
+      constexpr basic_string& replace(const_iterator i1, const_iterator i2,
+                                      InputIterator j1, InputIterator j2);
+    constexpr basic_string& replace(const_iterator, const_iterator, initializer_list<charT>);
 
-    size_type copy(charT* s, size_type n, size_type pos = 0) const;
+    constexpr size_type copy(charT* s, size_type n, size_type pos = 0) const;
 
-    void swap(basic_string& str)
+    constexpr void swap(basic_string& str)
       noexcept(allocator_traits<Allocator>::propagate_on_container_swap::value ||
                allocator_traits<Allocator>::is_always_equal::value);
 
     // \ref{string.ops}, string operations
-    const charT* c_str() const noexcept;
-    const charT* data() const noexcept;
-    charT* data() noexcept;
-    operator basic_string_view<charT, traits>() const noexcept;
-    allocator_type get_allocator() const noexcept;
+    constexpr const charT* c_str() const noexcept;
+    constexpr const charT* data() const noexcept;
+    constexpr charT* data() noexcept;
+    constexpr operator basic_string_view<charT, traits>() const noexcept;
+    constexpr allocator_type get_allocator() const noexcept;
 
     template<class T>
-      size_type find (const T& t, size_type pos = 0) const noexcept(@\seebelow@);
-    size_type find (const basic_string& str, size_type pos = 0) const noexcept;
-    size_type find (const charT* s, size_type pos, size_type n) const;
-    size_type find (const charT* s, size_type pos = 0) const;
-    size_type find (charT c, size_type pos = 0) const noexcept;
+      constexpr size_type find(const T& t, size_type pos = 0) const noexcept(@\seebelow@);
+    constexpr size_type find(const basic_string& str, size_type pos = 0) const noexcept;
+    constexpr size_type find(const charT* s, size_type pos, size_type n) const;
+    constexpr size_type find(const charT* s, size_type pos = 0) const;
+    constexpr size_type find(charT c, size_type pos = 0) const noexcept;
     template<class T>
-      size_type rfind(const T& t, size_type pos = npos) const noexcept(@\seebelow@);
-    size_type rfind(const basic_string& str, size_type pos = npos) const noexcept;
-    size_type rfind(const charT* s, size_type pos, size_type n) const;
-    size_type rfind(const charT* s, size_type pos = npos) const;
-    size_type rfind(charT c, size_type pos = npos) const noexcept;
+      constexpr size_type rfind(const T& t, size_type pos = npos) const noexcept(@\seebelow@);
+    constexpr size_type rfind(const basic_string& str, size_type pos = npos) const noexcept;
+    constexpr size_type rfind(const charT* s, size_type pos, size_type n) const;
+    constexpr size_type rfind(const charT* s, size_type pos = npos) const;
+    constexpr size_type rfind(charT c, size_type pos = npos) const noexcept;
 
     template<class T>
-      size_type find_first_of(const T& t, size_type pos = 0) const noexcept(@\seebelow@);
-    size_type find_first_of(const basic_string& str, size_type pos = 0) const noexcept;
-    size_type find_first_of(const charT* s, size_type pos, size_type n) const;
-    size_type find_first_of(const charT* s, size_type pos = 0) const;
-    size_type find_first_of(charT c, size_type pos = 0) const noexcept;
+      constexpr size_type find_first_of(const T& t, size_type pos = 0) const noexcept(@\seebelow@);
+    constexpr size_type find_first_of(const basic_string& str, size_type pos = 0) const noexcept;
+    constexpr size_type find_first_of(const charT* s, size_type pos, size_type n) const;
+    constexpr size_type find_first_of(const charT* s, size_type pos = 0) const;
+    constexpr size_type find_first_of(charT c, size_type pos = 0) const noexcept;
     template<class T>
-      size_type find_last_of (const T& t, size_type pos = npos) const noexcept(@\seebelow@);
-    size_type find_last_of (const basic_string& str, size_type pos = npos) const noexcept;
-    size_type find_last_of (const charT* s, size_type pos, size_type n) const;
-    size_type find_last_of (const charT* s, size_type pos = npos) const;
-    size_type find_last_of (charT c, size_type pos = npos) const noexcept;
+      constexpr size_type find_last_of(const T& t,
+                                       size_type pos = npos) const noexcept(@\seebelow@);
+    constexpr size_type find_last_of(const basic_string& str,
+                                     size_type pos = npos) const noexcept;
+    constexpr size_type find_last_of(const charT* s, size_type pos, size_type n) const;
+    constexpr size_type find_last_of(const charT* s, size_type pos = npos) const;
+    constexpr size_type find_last_of(charT c, size_type pos = npos) const noexcept;
 
     template<class T>
-      size_type find_first_not_of(const T& t, size_type pos = 0) const noexcept(@\seebelow@);
-    size_type find_first_not_of(const basic_string& str, size_type pos = 0) const noexcept;
-    size_type find_first_not_of(const charT* s, size_type pos, size_type n) const;
-    size_type find_first_not_of(const charT* s, size_type pos = 0) const;
-    size_type find_first_not_of(charT c, size_type pos = 0) const noexcept;
+      constexpr size_type find_first_not_of(const T& t,
+                                            size_type pos = 0) const noexcept(@\seebelow@);
+    constexpr size_type find_first_not_of(const basic_string& str,
+                                          size_type pos = 0) const noexcept;
+    constexpr size_type find_first_not_of(const charT* s, size_type pos, size_type n) const;
+    constexpr size_type find_first_not_of(const charT* s, size_type pos = 0) const;
+    constexpr size_type find_first_not_of(charT c, size_type pos = 0) const noexcept;
     template<class T>
-      size_type find_last_not_of (const T& t, size_type pos = npos) const noexcept(@\seebelow@);
-    size_type find_last_not_of (const basic_string& str, size_type pos = npos) const noexcept;
-    size_type find_last_not_of (const charT* s, size_type pos, size_type n) const;
-    size_type find_last_not_of (const charT* s, size_type pos = npos) const;
-    size_type find_last_not_of (charT c, size_type pos = npos) const noexcept;
+      constexpr size_type find_last_not_of(const T& t,
+                                           size_type pos = npos) const noexcept(@\seebelow@);
+    constexpr size_type find_last_not_of(const basic_string& str,
+                                         size_type pos = npos) const noexcept;
+    constexpr size_type find_last_not_of(const charT* s, size_type pos, size_type n) const;
+    constexpr size_type find_last_not_of(const charT* s, size_type pos = npos) const;
+    constexpr size_type find_last_not_of(charT c, size_type pos = npos) const noexcept;
 
-    basic_string substr(size_type pos = 0, size_type n = npos) const;
-    template<class T>
-      int compare(const T& t) const noexcept(@\seebelow@);
-    template<class T>
-      int compare(size_type pos1, size_type n1, const T& t) const;
-    template<class T>
-      int compare(size_type pos1, size_type n1, const T& t,
-                  size_type pos2, size_type n2 = npos) const;
-    int compare(const basic_string& str) const noexcept;
-    int compare(size_type pos1, size_type n1, const basic_string& str) const;
-    int compare(size_type pos1, size_type n1, const basic_string& str,
-                size_type pos2, size_type n2 = npos) const;
-    int compare(const charT* s) const;
-    int compare(size_type pos1, size_type n1, const charT* s) const;
-    int compare(size_type pos1, size_type n1, const charT* s, size_type n2) const;
+    constexpr basic_string substr(size_type pos = 0, size_type n = npos) const;
 
-    bool starts_with(basic_string_view<charT, traits> x) const noexcept;
-    bool starts_with(charT x) const noexcept;
-    bool starts_with(const charT* x) const;
-    bool ends_with(basic_string_view<charT, traits> x) const noexcept;
-    bool ends_with(charT x) const noexcept;
-    bool ends_with(const charT* x) const;
+    template<class T>
+      constexpr int compare(const T& t) const noexcept(@\seebelow@);
+    template<class T>
+      constexpr int compare(size_type pos1, size_type n1, const T& t) const;
+    template<class T>
+      constexpr int compare(size_type pos1, size_type n1, const T& t,
+                            size_type pos2, size_type n2 = npos) const;
+    constexpr int compare(const basic_string& str) const noexcept;
+    constexpr int compare(size_type pos1, size_type n1, const basic_string& str) const;
+    constexpr int compare(size_type pos1, size_type n1, const basic_string& str,
+                          size_type pos2, size_type n2 = npos) const;
+    constexpr int compare(const charT* s) const;
+    constexpr int compare(size_type pos1, size_type n1, const charT* s) const;
+    constexpr int compare(size_type pos1, size_type n1, const charT* s, size_type n2) const;
+
+    constexpr bool starts_with(basic_string_view<charT, traits> x) const noexcept;
+    constexpr bool starts_with(charT x) const noexcept;
+    constexpr bool starts_with(const charT* x) const;
+    constexpr bool ends_with(basic_string_view<charT, traits> x) const noexcept;
+    constexpr bool ends_with(charT x) const noexcept;
+    constexpr bool ends_with(const charT* x) const;
   };
 
   template<class InputIterator,
@@ -1101,7 +1115,7 @@ and
 
 \indexlibrary{\idxcode{basic_string}!constructor}%
 \begin{itemdecl}
-explicit basic_string(const Allocator& a) noexcept;
+constexpr explicit basic_string(const Allocator& a) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1113,8 +1127,8 @@ explicit basic_string(const Allocator& a) noexcept;
 
 \indexlibrary{\idxcode{basic_string}!constructor}%
 \begin{itemdecl}
-basic_string(const basic_string& str);
-basic_string(basic_string&& str) noexcept;
+constexpr basic_string(const basic_string& str);
+constexpr basic_string(basic_string&& str) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1130,10 +1144,10 @@ In the second form, \tcode{str} is left in a valid but unspecified state.
 
 \indexlibrary{\idxcode{basic_string}!constructor}%
 \begin{itemdecl}
-basic_string(const basic_string& str, size_type pos,
-             const Allocator& a = Allocator());
-basic_string(const basic_string& str, size_type pos, size_type n,
-             const Allocator& a = Allocator());
+constexpr basic_string(const basic_string& str, size_type pos,
+                       const Allocator& a = Allocator());
+constexpr basic_string(const basic_string& str, size_type pos, size_type n,
+                       const Allocator& a = Allocator());
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1148,7 +1162,7 @@ basic_string(basic_string_view<charT, traits>(str).substr(pos, n), a)
 \indexlibrary{\idxcode{basic_string}!constructor}%
 \begin{itemdecl}
 template<class T>
-  basic_string(const T& t, size_type pos, size_type n, const Allocator& a = Allocator());
+  constexpr basic_string(const T& t, size_type pos, size_type n, const Allocator& a = Allocator());
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1169,7 +1183,7 @@ basic_string(sv.substr(pos, n), a);
 \indexlibrary{\idxcode{basic_string}!constructor}%
 \begin{itemdecl}
 template<class T>
-  explicit basic_string(const T& t, const Allocator& a = Allocator());
+  constexpr explicit basic_string(const T& t, const Allocator& a = Allocator());
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1192,7 +1206,7 @@ then behaves the same as \tcode{basic_string(sv.data(), sv.size(), a)}.
 
 \indexlibrary{\idxcode{basic_string}!constructor}%
 \begin{itemdecl}
-basic_string(const charT* s, size_type n, const Allocator& a = Allocator());
+constexpr basic_string(const charT* s, size_type n, const Allocator& a = Allocator());
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1211,7 +1225,7 @@ Constructs an object whose initial value is the range \range{s}{s + n}.
 
 \indexlibrary{\idxcode{basic_string}!constructor}%
 \begin{itemdecl}
-basic_string(const charT* s, const Allocator& a = Allocator());
+constexpr basic_string(const charT* s, const Allocator& a = Allocator());
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1229,7 +1243,7 @@ This affects class template argument deduction.
 
 \indexlibrary{\idxcode{basic_string}!constructor}%
 \begin{itemdecl}
-basic_string(size_type n, charT c, const Allocator& a = Allocator());
+constexpr basic_string(size_type n, charT c, const Allocator& a = Allocator());
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1249,7 +1263,7 @@ Constructs an object whose value consists of \tcode{n} copies of \tcode{c}.
 \indexlibrary{\idxcode{basic_string}!constructor}%
 \begin{itemdecl}
 template<class InputIterator>
-  basic_string(InputIterator begin, InputIterator end, const Allocator& a = Allocator());
+  constexpr basic_string(InputIterator begin, InputIterator end, const Allocator& a = Allocator());
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1266,7 +1280,7 @@ as indicated in \tref{container.seq.req}.
 
 \indexlibrary{\idxcode{basic_string}!constructor}%
 \begin{itemdecl}
-basic_string(initializer_list<charT> il, const Allocator& a = Allocator());
+constexpr basic_string(initializer_list<charT> il, const Allocator& a = Allocator());
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1276,8 +1290,8 @@ basic_string(initializer_list<charT> il, const Allocator& a = Allocator());
 
 \indexlibrary{\idxcode{basic_string}!constructor}%
 \begin{itemdecl}
-basic_string(const basic_string& str, const Allocator& alloc);
-basic_string(basic_string&& str, const Allocator& alloc);
+constexpr basic_string(const basic_string& str, const Allocator& alloc);
+constexpr basic_string(basic_string&& str, const Allocator& alloc);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1332,7 +1346,7 @@ an allocator\iref{container.requirements.general}.
 
 \indexlibrarymember{operator=}{basic_string}%
 \begin{itemdecl}
-basic_string& operator=(const basic_string& str);
+constexpr basic_string& operator=(const basic_string& str);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1348,7 +1362,7 @@ Otherwise, replaces the value of \tcode{*this} with a copy of \tcode{str}.
 
 \indexlibrarymember{operator=}{basic_string}%
 \begin{itemdecl}
-basic_string& operator=(basic_string&& str)
+constexpr basic_string& operator=(basic_string&& str)
   noexcept(allocator_traits<Allocator>::propagate_on_container_move_assignment::value ||
            allocator_traits<Allocator>::is_always_equal::value);
 \end{itemdecl}
@@ -1367,7 +1381,7 @@ except that iterators, pointers and references may be invalidated.
 \indexlibrarymember{operator=}{basic_string}%
 \begin{itemdecl}
 template<class T>
-  basic_string& operator=(const T& t);
+  constexpr basic_string& operator=(const T& t);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1390,7 +1404,7 @@ return assign(sv);
 
 \indexlibrarymember{operator=}{basic_string}%
 \begin{itemdecl}
-basic_string& operator=(const charT* s);
+constexpr basic_string& operator=(const charT* s);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1401,7 +1415,7 @@ basic_string& operator=(const charT* s);
 
 \indexlibrarymember{operator=}{basic_string}%
 \begin{itemdecl}
-basic_string& operator=(charT c);
+constexpr basic_string& operator=(charT c);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1414,7 +1428,7 @@ return *this = basic_string_view<charT, traits>(addressof(c), 1);
 
 \indexlibrarymember{operator=}{basic_string}%
 \begin{itemdecl}
-basic_string& operator=(initializer_list<charT> il);
+constexpr basic_string& operator=(initializer_list<charT> il);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1430,9 +1444,9 @@ return *this = basic_string_view<charT, traits>(il.begin(), il.size());
 \indexlibrarymember{begin}{basic_string}%
 \indexlibrarymember{cbegin}{basic_string}%
 \begin{itemdecl}
-iterator       begin() noexcept;
-const_iterator begin() const noexcept;
-const_iterator cbegin() const noexcept;
+constexpr iterator       begin() noexcept;
+constexpr const_iterator begin() const noexcept;
+constexpr const_iterator cbegin() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1444,9 +1458,9 @@ An iterator referring to the first character in the string.
 \indexlibrarymember{end}{basic_string}%
 \indexlibrarymember{cend}{basic_string}%
 \begin{itemdecl}
-iterator       end() noexcept;
-const_iterator end() const noexcept;
-const_iterator cend() const noexcept;
+constexpr iterator       end() noexcept;
+constexpr const_iterator end() const noexcept;
+constexpr const_iterator cend() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1458,9 +1472,9 @@ An iterator which is the past-the-end value.
 \indexlibrarymember{rbegin}{basic_string}%
 \indexlibrarymember{crbegin}{basic_string}%
 \begin{itemdecl}
-reverse_iterator       rbegin() noexcept;
-const_reverse_iterator rbegin() const noexcept;
-const_reverse_iterator crbegin() const noexcept;
+constexpr reverse_iterator       rbegin() noexcept;
+constexpr const_reverse_iterator rbegin() const noexcept;
+constexpr const_reverse_iterator crbegin() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1473,9 +1487,9 @@ An iterator which is semantically equivalent to
 \indexlibrarymember{rend}{basic_string}%
 \indexlibrarymember{crend}{basic_string}%
 \begin{itemdecl}
-reverse_iterator       rend() noexcept;
-const_reverse_iterator rend() const noexcept;
-const_reverse_iterator crend() const noexcept;
+constexpr reverse_iterator       rend() noexcept;
+constexpr const_reverse_iterator rend() const noexcept;
+constexpr const_reverse_iterator crend() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1490,8 +1504,8 @@ An iterator which is semantically equivalent to
 \indexlibrarymember{size}{basic_string}%
 \indexlibrarymember{length}{basic_string}%
 \begin{itemdecl}
-size_type size() const noexcept;
-size_type length() const noexcept;
+constexpr size_type size() const noexcept;
+constexpr size_type length() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1505,7 +1519,7 @@ A count of the number of char-like objects currently in the string.
 
 \indexlibrarymember{max_size}{basic_string}%
 \begin{itemdecl}
-size_type max_size() const noexcept;
+constexpr size_type max_size() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1520,7 +1534,7 @@ The largest possible number of char-like objects that can be stored in a
 
 \indexlibrarymember{resize}{basic_string}%
 \begin{itemdecl}
-void resize(size_type n, charT c);
+constexpr void resize(size_type n, charT c);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1544,7 +1558,7 @@ appends \tcode{n - size()} copies of \tcode{c}.
 
 \indexlibrarymember{resize}{basic_string}%
 \begin{itemdecl}
-void resize(size_type n);
+constexpr void resize(size_type n);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1555,7 +1569,7 @@ Equivalent to \tcode{resize(n, charT())}.
 
 \indexlibrarymember{capacity}{basic_string}%
 \begin{itemdecl}
-size_type capacity() const noexcept;
+constexpr size_type capacity() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1569,7 +1583,7 @@ The size of the allocated storage in the string.
 
 \indexlibrarymember{reserve}{basic_string}%
 \begin{itemdecl}
-void reserve(size_type res_arg);
+constexpr void reserve(size_type res_arg);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1599,7 +1613,7 @@ if
 
 \indexlibrarymember{shrink_to_fit}{basic_string}%
 \begin{itemdecl}
-void shrink_to_fit();
+constexpr void shrink_to_fit();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1623,7 +1637,7 @@ referring to the elements in the sequence, as well as the past-the-end iterator.
 
 \indexlibrarymember{clear}{basic_string}%
 \begin{itemdecl}
-void clear() noexcept;
+constexpr void clear() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1634,7 +1648,7 @@ Equivalent to: \tcode{erase(begin(), end());}
 
 \indexlibrarymember{empty}{basic_string}%
 \begin{itemdecl}
-[[nodiscard]] bool empty() const noexcept;
+[[nodiscard]] constexpr bool empty() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1647,8 +1661,8 @@ Equivalent to: \tcode{erase(begin(), end());}
 
 \indexlibrarymember{operator[]}{basic_string}%
 \begin{itemdecl}
-const_reference operator[](size_type pos) const;
-reference       operator[](size_type pos);
+constexpr const_reference operator[](size_type pos) const;
+constexpr reference       operator[](size_type pos);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1670,8 +1684,8 @@ returns a reference to an object of type \tcode{charT} with value
 
 \indexlibrarymember{at}{basic_string}%
 \begin{itemdecl}
-const_reference at(size_type pos) const;
-reference       at(size_type pos);
+constexpr const_reference at(size_type pos) const;
+constexpr reference       at(size_type pos);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1688,8 +1702,8 @@ if
 
 \indexlibrarymember{front}{basic_string}%
 \begin{itemdecl}
-const charT& front() const;
-charT& front();
+constexpr const charT& front() const;
+constexpr charT& front();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1704,8 +1718,8 @@ Equivalent to: \tcode{return operator[](0);}
 
 \indexlibrarymember{back}{basic_string}%
 \begin{itemdecl}
-const charT& back() const;
-charT& back();
+constexpr const charT& back() const;
+constexpr charT& back();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1724,7 +1738,7 @@ Equivalent to: \tcode{return operator[](size() - 1);}
 
 \indexlibrarymember{operator+=}{basic_string}%
 \begin{itemdecl}
-basic_string& operator+=(const basic_string& str);
+constexpr basic_string& operator+=(const basic_string& str);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1737,7 +1751,7 @@ basic_string& operator+=(const basic_string& str);
 \indexlibrarymember{operator+=}{basic_string}%
 \begin{itemdecl}
 template<class T>
-  basic_string& operator+=(const T& t);
+  constexpr basic_string& operator+=(const T& t);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1763,7 +1777,7 @@ return append(sv);
 
 \indexlibrarymember{operator+=}{basic_string}%
 \begin{itemdecl}
-basic_string& operator+=(const charT* s);
+constexpr basic_string& operator+=(const charT* s);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1773,7 +1787,7 @@ basic_string& operator+=(const charT* s);
 
 \indexlibrarymember{operator+=}{basic_string}%
 \begin{itemdecl}
-basic_string& operator+=(charT c);
+constexpr basic_string& operator+=(charT c);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1783,7 +1797,7 @@ basic_string& operator+=(charT c);
 
 \indexlibrarymember{operator+=}{basic_string}%
 \begin{itemdecl}
-basic_string& operator+=(initializer_list<charT> il);
+constexpr basic_string& operator+=(initializer_list<charT> il);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1796,7 +1810,7 @@ basic_string& operator+=(initializer_list<charT> il);
 
 \indexlibrarymember{append}{basic_string}%
 \begin{itemdecl}
-basic_string& append(const basic_string& str);
+constexpr basic_string& append(const basic_string& str);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1806,7 +1820,7 @@ basic_string& append(const basic_string& str);
 
 \indexlibrarymember{append}{basic_string}%
 \begin{itemdecl}
-basic_string& append(const basic_string& str, size_type pos, size_type n = npos);
+constexpr basic_string& append(const basic_string& str, size_type pos, size_type n = npos);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1821,7 +1835,7 @@ return append(basic_string_view<charT, traits>(str).substr(pos, n));
 \indexlibrarymember{append}{basic_string}%
 \begin{itemdecl}
 template<class T>
-  basic_string& append(const T& t);
+  constexpr basic_string& append(const T& t);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1848,7 +1862,7 @@ return append(sv.data(), sv.size());
 \indexlibrarymember{append}{basic_string}%
 \begin{itemdecl}
 template<class T>
-  basic_string& append(const T& t, size_type pos, size_type n = npos);
+  constexpr basic_string& append(const T& t, size_type pos, size_type n = npos);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1874,7 +1888,7 @@ return append(sv.substr(pos, n));
 
 \indexlibrarymember{append}{basic_string}%
 \begin{itemdecl}
-basic_string& append(const charT* s, size_type n);
+constexpr basic_string& append(const charT* s, size_type n);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1891,7 +1905,7 @@ basic_string& append(const charT* s, size_type n);
 
 \indexlibrarymember{append}{basic_string}%
 \begin{itemdecl}
-basic_string& append(const charT* s);
+constexpr basic_string& append(const charT* s);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1901,7 +1915,7 @@ basic_string& append(const charT* s);
 
 \indexlibrarymember{append}{basic_string}%
 \begin{itemdecl}
-basic_string& append(size_type n, charT c);
+constexpr basic_string& append(size_type n, charT c);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1915,7 +1929,7 @@ basic_string& append(size_type n, charT c);
 \indexlibrarymember{append}{basic_string}%
 \begin{itemdecl}
 template<class InputIterator>
-  basic_string& append(InputIterator first, InputIterator last);
+  constexpr basic_string& append(InputIterator first, InputIterator last);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1930,7 +1944,7 @@ iterator\iref{container.requirements.general}.
 
 \indexlibrarymember{append}{basic_string}%
 \begin{itemdecl}
-basic_string& append(initializer_list<charT> il);
+constexpr basic_string& append(initializer_list<charT> il);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1940,7 +1954,7 @@ basic_string& append(initializer_list<charT> il);
 
 \indexlibrarymember{push_back}{basic_string}%
 \begin{itemdecl}
-void push_back(charT c);
+constexpr void push_back(charT c);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1954,7 +1968,7 @@ Equivalent to
 
 \indexlibrarymember{assign}{basic_string}%
 \begin{itemdecl}
-basic_string& assign(const basic_string& str);
+constexpr basic_string& assign(const basic_string& str);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1964,7 +1978,7 @@ basic_string& assign(const basic_string& str);
 
 \indexlibrarymember{assign}{basic_string}%
 \begin{itemdecl}
-basic_string& assign(basic_string&& str)
+constexpr basic_string& assign(basic_string&& str)
   noexcept(allocator_traits<Allocator>::propagate_on_container_move_assignment::value ||
            allocator_traits<Allocator>::is_always_equal::value);
 \end{itemdecl}
@@ -1977,7 +1991,7 @@ basic_string& assign(basic_string&& str)
 
 \indexlibrarymember{assign}{basic_string}%
 \begin{itemdecl}
-basic_string& assign(const basic_string& str, size_type pos, size_type n = npos);
+constexpr basic_string& assign(const basic_string& str, size_type pos, size_type n = npos);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1992,7 +2006,7 @@ return assign(basic_string_view<charT, traits>(str).substr(pos, n));
 \indexlibrarymember{assign}{basic_string}%
 \begin{itemdecl}
 template<class T>
-  basic_string& assign(const T& t);
+  constexpr basic_string& assign(const T& t);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2019,7 +2033,7 @@ return assign(sv.data(), sv.size());
 \indexlibrarymember{assign}{basic_string}%
 \begin{itemdecl}
 template<class T>
-  basic_string& assign(const T& t, size_type pos, size_type n = npos);
+  constexpr basic_string& assign(const T& t, size_type pos, size_type n = npos);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2044,7 +2058,7 @@ return assign(sv.substr(pos, n));
 
 \indexlibrarymember{assign}{basic_string}%
 \begin{itemdecl}
-basic_string& assign(const charT* s, size_type n);
+constexpr basic_string& assign(const charT* s, size_type n);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2063,7 +2077,7 @@ a copy of the range \range{s}{s + n}.
 
 \indexlibrarymember{assign}{basic_string}%
 \begin{itemdecl}
-basic_string& assign(const charT* s);
+constexpr basic_string& assign(const charT* s);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2073,7 +2087,7 @@ basic_string& assign(const charT* s);
 
 \indexlibrarymember{assign}{basic_string}%
 \begin{itemdecl}
-basic_string& assign(initializer_list<charT> il);
+constexpr basic_string& assign(initializer_list<charT> il);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2083,7 +2097,7 @@ basic_string& assign(initializer_list<charT> il);
 
 \indexlibrarymember{assign}{basic_string}%
 \begin{itemdecl}
-basic_string& assign(size_type n, charT c);
+constexpr basic_string& assign(size_type n, charT c);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2099,7 +2113,7 @@ return *this;
 \indexlibrarymember{assign}{basic_string}%
 \begin{itemdecl}
 template<class InputIterator>
-  basic_string& assign(InputIterator first, InputIterator last);
+  constexpr basic_string& assign(InputIterator first, InputIterator last);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2116,7 +2130,7 @@ iterator\iref{container.requirements.general}.
 
 \indexlibrarymember{insert}{basic_string}%
 \begin{itemdecl}
-basic_string& insert(size_type pos, const basic_string& str);
+constexpr basic_string& insert(size_type pos, const basic_string& str);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2126,7 +2140,8 @@ basic_string& insert(size_type pos, const basic_string& str);
 
 \indexlibrarymember{insert}{basic_string}%
 \begin{itemdecl}
-basic_string& insert(size_type pos1, const basic_string& str, size_type pos2, size_type n = npos);
+constexpr basic_string& insert(size_type pos1, const basic_string& str,
+                               size_type pos2, size_type n = npos);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2141,7 +2156,7 @@ return insert(pos1, basic_string_view<charT, traits>(str), pos2, n);
 \indexlibrarymember{insert}{basic_string}%
 \begin{itemdecl}
 template<class T>
-  basic_string& insert(size_type pos, const T& t);
+  constexpr basic_string& insert(size_type pos, const T& t);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2168,7 +2183,8 @@ return insert(pos, sv.data(), sv.size());
 \indexlibrarymember{insert}{basic_string}%
 \begin{itemdecl}
 template<class T>
-  basic_string& insert(size_type pos1, const T& t, size_type pos2, size_type n = npos);
+  constexpr basic_string& insert(size_type pos1, const T& t,
+                                 size_type pos2, size_type n = npos);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2193,7 +2209,7 @@ return insert(pos1, sv.substr(pos2, n));
 
 \indexlibrarymember{insert}{basic_string}%
 \begin{itemdecl}
-basic_string& insert(size_type pos, const charT* s, size_type n);
+constexpr basic_string& insert(size_type pos, const charT* s, size_type n);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2220,7 +2236,7 @@ or otherwise at the end of the string.
 
 \indexlibrarymember{insert}{basic_string}%
 \begin{itemdecl}
-basic_string& insert(size_type pos, const charT* s);
+constexpr basic_string& insert(size_type pos, const charT* s);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2230,7 +2246,7 @@ basic_string& insert(size_type pos, const charT* s);
 
 \indexlibrarymember{insert}{basic_string}%
 \begin{itemdecl}
-basic_string& insert(size_type pos, size_type n, charT c);
+constexpr basic_string& insert(size_type pos, size_type n, charT c);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2255,7 +2271,7 @@ or otherwise at the end of the string.
 
 \indexlibrarymember{insert}{basic_string}%
 \begin{itemdecl}
-iterator insert(const_iterator p, charT c);
+constexpr iterator insert(const_iterator p, charT c);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2275,7 +2291,7 @@ An iterator which refers to the inserted character.
 
 \indexlibrarymember{insert}{basic_string}%
 \begin{itemdecl}
-iterator insert(const_iterator p, size_type n, charT c);
+constexpr iterator insert(const_iterator p, size_type n, charT c);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2296,7 +2312,7 @@ Inserts \tcode{n} copies of \tcode{c} at the position \tcode{p}.
 \indexlibrarymember{insert}{basic_string}%
 \begin{itemdecl}
 template<class InputIterator>
-  iterator insert(const_iterator p, InputIterator first, InputIterator last);
+  constexpr iterator insert(const_iterator p, InputIterator first, InputIterator last);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2322,7 +2338,7 @@ Equivalent to
 
 \indexlibrarymember{insert}{basic_string}%
 \begin{itemdecl}
-iterator insert(const_iterator p, initializer_list<charT> il);
+constexpr iterator insert(const_iterator p, initializer_list<charT> il);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2334,7 +2350,7 @@ iterator insert(const_iterator p, initializer_list<charT> il);
 
 \indexlibrarymember{erase}{basic_string}%
 \begin{itemdecl}
-basic_string& erase(size_type pos = 0, size_type n = npos);
+constexpr basic_string& erase(size_type pos = 0, size_type n = npos);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2358,7 +2374,7 @@ Removes the characters in the range \range{begin() + pos}{begin() + pos + xlen}.
 
 \indexlibrarymember{erase}{basic_string}%
 \begin{itemdecl}
-iterator erase(const_iterator p);
+constexpr iterator erase(const_iterator p);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2384,7 +2400,7 @@ is returned.
 
 \indexlibrarymember{erase}{basic_string}%
 \begin{itemdecl}
-iterator erase(const_iterator first, const_iterator last);
+constexpr iterator erase(const_iterator first, const_iterator last);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2412,7 +2428,7 @@ is returned.
 
 \indexlibrarymember{pop_back}{basic_string}%
 \begin{itemdecl}
-void pop_back();
+constexpr void pop_back();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2432,7 +2448,7 @@ Equivalent to \tcode{erase(end() - 1)}.
 
 \indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
-basic_string& replace(size_type pos1, size_type n1, const basic_string& str);
+constexpr basic_string& replace(size_type pos1, size_type n1, const basic_string& str);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2442,8 +2458,8 @@ basic_string& replace(size_type pos1, size_type n1, const basic_string& str);
 
 \indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
-basic_string& replace(size_type pos1, size_type n1, const basic_string& str,
-                      size_type pos2, size_type n2 = npos);
+constexpr basic_string& replace(size_type pos1, size_type n1, const basic_string& str,
+                                size_type pos2, size_type n2 = npos);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2458,7 +2474,7 @@ return replace(pos1, n1, basic_string_view<charT, traits>(str).substr(pos2, n2))
 \indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
 template<class T>
-  basic_string& replace(size_type pos1, size_type n1, const T& t);
+  constexpr basic_string& replace(size_type pos1, size_type n1, const T& t);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2485,8 +2501,8 @@ return replace(pos1, n1, sv.data(), sv.size());
 \indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
 template<class T>
-  basic_string& replace(size_type pos1, size_type n1, const T& t,
-                        size_type pos2, size_type n2 = npos);
+  constexpr basic_string& replace(size_type pos1, size_type n1, const T& t,
+                                  size_type pos2, size_type n2 = npos);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2512,7 +2528,7 @@ return replace(pos1, n1, sv.substr(pos2, n2));
 
 \indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
-basic_string& replace(size_type pos1, size_type n1, const charT* s, size_type n2);
+constexpr basic_string& replace(size_type pos1, size_type n1, const charT* s, size_type n2);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2543,7 +2559,7 @@ with a copy of the range \range{s}{s + n2}.
 
 \indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
-basic_string& replace(size_type pos, size_type n, const charT* s);
+constexpr basic_string& replace(size_type pos, size_type n, const charT* s);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2553,7 +2569,7 @@ basic_string& replace(size_type pos, size_type n, const charT* s);
 
 \indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
-basic_string& replace(size_type pos1, size_type n1, size_type n2, charT c);
+constexpr basic_string& replace(size_type pos1, size_type n1, size_type n2, charT c);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2580,7 +2596,7 @@ with \tcode{n2} copies of \tcode{c}.
 
 \indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
-basic_string& replace(const_iterator i1, const_iterator i2, const basic_string& str);
+constexpr basic_string& replace(const_iterator i1, const_iterator i2, const basic_string& str);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2592,7 +2608,7 @@ Equivalent to: \tcode{return replace(i1, i2, basic_string_view<charT, traits>(st
 \indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
 template<class T>
-  basic_string& replace(const_iterator i1, const_iterator i2, const T& t);
+  constexpr basic_string& replace(const_iterator i1, const_iterator i2, const T& t);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2622,7 +2638,7 @@ return replace(i1 - begin(), i2 - i1, sv.data(), sv.size());
 
 \indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
-basic_string& replace(const_iterator i1, const_iterator i2, const charT* s, size_type n);
+constexpr basic_string& replace(const_iterator i1, const_iterator i2, const charT* s, size_type n);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2633,7 +2649,7 @@ Equivalent to: \tcode{return replace(i1, i2, basic_string_view<charT, traits>(s,
 
 \indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
-basic_string& replace(const_iterator i1, const_iterator i2, const charT* s);
+constexpr basic_string& replace(const_iterator i1, const_iterator i2, const charT* s);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2644,7 +2660,7 @@ Equivalent to: \tcode{return replace(i1, i2, basic_string_view<charT, traits>(s)
 
 \indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
-basic_string& replace(const_iterator i1, const_iterator i2, size_type n, charT c);
+constexpr basic_string& replace(const_iterator i1, const_iterator i2, size_type n, charT c);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2659,7 +2675,8 @@ Equivalent to: \tcode{return replace(i1 - begin(), i2 - i1, n, c);}
 \indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
 template<class InputIterator>
-  basic_string& replace(const_iterator i1, const_iterator i2, InputIterator j1, InputIterator j2);
+  constexpr basic_string& replace(const_iterator i1, const_iterator i2,
+                                  InputIterator j1, InputIterator j2);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2675,7 +2692,7 @@ Equivalent to: \tcode{return replace(i1, i2, basic_string(j1, j2, get_allocator(
 
 \indexlibrarymember{replace}{basic_string}%
 \begin{itemdecl}
-basic_string& replace(const_iterator i1, const_iterator i2, initializer_list<charT> il);
+constexpr basic_string& replace(const_iterator i1, const_iterator i2, initializer_list<charT> il);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2688,7 +2705,7 @@ Equivalent to: \tcode{return replace(i1, i2, il.begin(), il.size());}
 
 \indexlibrarymember{copy}{basic_string}%
 \begin{itemdecl}
-size_type copy(charT* s, size_type n, size_type pos = 0) const;
+constexpr size_type copy(charT* s, size_type n, size_type pos = 0) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2703,7 +2720,7 @@ Equivalent to:
 
 \indexlibrarymember{swap}{basic_string}%
 \begin{itemdecl}
-void swap(basic_string& s)
+constexpr void swap(basic_string& s)
   noexcept(allocator_traits<Allocator>::propagate_on_container_swap::value ||
            allocator_traits<Allocator>::is_always_equal::value);
 \end{itemdecl}
@@ -2736,8 +2753,8 @@ contains the same sequence of characters that was in \tcode{s},
 \indexlibrarymember{c_str}{basic_string}%
 \indexlibrarymember{data}{basic_string}%
 \begin{itemdecl}
-const charT* c_str() const noexcept;
-const charT* data() const noexcept;
+constexpr const charT* c_str() const noexcept;
+constexpr const charT* data() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2755,7 +2772,7 @@ The program shall not modify any of the values stored in the character array; ot
 
 \indexlibrarymember{data}{basic_string}%
 \begin{itemdecl}
-charT* data() noexcept;
+constexpr charT* data() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2774,7 +2791,7 @@ to any value other than \tcode{charT()}; otherwise, the behavior is undefined.
 
 \indexlibrarymember{operator basic_string_view}{basic_string}%
 \begin{itemdecl}
-operator basic_string_view<charT, traits>() const noexcept;
+constexpr operator basic_string_view<charT, traits>() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2785,7 +2802,7 @@ operator basic_string_view<charT, traits>() const noexcept;
 
 \indexlibrarymember{get_allocator}{basic_string}%
 \begin{itemdecl}
-allocator_type get_allocator() const noexcept;
+constexpr allocator_type get_allocator() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2800,6 +2817,12 @@ copy of the most recent replacement.
 \rSec4[string.find]{Searching}
 
 \pnum
+\indexlibrarymember{find}{basic_string}%
+\indexlibrarymember{rfind}{basic_string}%
+\indexlibrarymember{find_first_of}{basic_string}%
+\indexlibrarymember{find_last_of}{basic_string}%
+\indexlibrarymember{find_first_not_of}{basic_string}%
+\indexlibrarymember{find_last_not_of}{basic_string}%
 Let \placeholder{F} be one of
 \tcode{find}, \tcode{rfind}, \tcode{find_first_of}, \tcode{find_last_of},
 \tcode{find_first_not_of}, and \tcode{find_last_not_of}.
@@ -2808,7 +2831,7 @@ Let \placeholder{F} be one of
 \item
 Each member function of the form
 \begin{codeblock}
-size_type @\placeholder{F}@(const basic_string& str, size_type pos) const noexcept;
+constexpr size_type @\placeholder{F}@(const basic_string& str, size_type pos) const noexcept;
 \end{codeblock}
 has effects equivalent to:
 \tcode{return \placeholder{F}(basic_string_view<charT, traits>(str), pos);}
@@ -2816,7 +2839,7 @@ has effects equivalent to:
 \item
 Each member function of the form
 \begin{codeblock}
-size_type @\placeholder{F}@(const charT* s, size_type pos) const;
+constexpr size_type @\placeholder{F}@(const charT* s, size_type pos) const;
 \end{codeblock}
 has effects equivalent to:
 \tcode{return \placeholder{F}(basic_string_view<charT, traits>(s), pos);}
@@ -2824,7 +2847,7 @@ has effects equivalent to:
 \item
 Each member function of the form
 \begin{codeblock}
-size_type @\placeholder{F}@(const charT* s, size_type pos, size_type n) const;
+constexpr size_type @\placeholder{F}@(const charT* s, size_type pos, size_type n) const;
 \end{codeblock}
 has effects equivalent to:
 \tcode{return \placeholder{F}(basic_string_view<charT, traits>(s, n), pos);}
@@ -2832,7 +2855,7 @@ has effects equivalent to:
 \item
 Each member function of the form
 \begin{codeblock}
-size_type @\placeholder{F}@(charT c, size_type pos) const noexcept;
+constexpr size_type @\placeholder{F}@(charT c, size_type pos) const noexcept;
 \end{codeblock}
 has effects equivalent to:
 \begin{codeblock}
@@ -2848,17 +2871,17 @@ return @\placeholder{F}@(basic_string_view<charT, traits>(addressof(c), 1), pos)
 \indexlibrarymember{find_last_not_of}{basic_string}%
 \begin{itemdecl}
 template<class T>
-  size_type find(const T& t, size_type pos = 0) const noexcept(@\seebelow@);
+  constexpr size_type find(const T& t, size_type pos = 0) const noexcept(@\seebelow@);
 template<class T>
-  size_type rfind(const T& t, size_type pos = npos) const noexcept(@\seebelow@);
+  constexpr size_type rfind(const T& t, size_type pos = npos) const noexcept(@\seebelow@);
 template<class T>
-  size_type find_first_of(const T& t, size_type pos = 0) const noexcept(@\seebelow@);
+  constexpr size_type find_first_of(const T& t, size_type pos = 0) const noexcept(@\seebelow@);
 template<class T>
-  size_type find_last_of(const T& t, size_type pos = npos) const noexcept(@\seebelow@);
+  constexpr size_type find_last_of(const T& t, size_type pos = npos) const noexcept(@\seebelow@);
 template<class T>
-  size_type find_first_not_of(const T& t, size_type pos = 0) const noexcept(@\seebelow@);
+  constexpr size_type find_first_not_of(const T& t, size_type pos = 0) const noexcept(@\seebelow@);
 template<class T>
-  size_type find_last_not_of(const T& t, size_type pos = npos) const noexcept(@\seebelow@);
+  constexpr size_type find_last_not_of(const T& t, size_type pos = npos) const noexcept(@\seebelow@);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2892,7 +2915,7 @@ The expression inside \tcode{noexcept} is equivalent to
 
 \indexlibrarymember{substr}{basic_string}%
 \begin{itemdecl}
-basic_string substr(size_type pos = 0, size_type n = npos) const;
+constexpr basic_string substr(size_type pos = 0, size_type n = npos) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2917,7 +2940,7 @@ Determines the effective length \tcode{rlen} of the string to copy as the smalle
 \indexlibrarymember{compare}{basic_string}%
 \begin{itemdecl}
 template<class T>
-  int compare(const T& t) const noexcept(@\seebelow@);
+  constexpr int compare(const T& t) const noexcept(@\seebelow@);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2945,7 +2968,7 @@ The expression inside \tcode{noexcept} is equivalent to
 \indexlibrarymember{compare}{basic_string}%
 \begin{itemdecl}
 template<class T>
-  int compare(size_type pos1, size_type n1, const T& t) const;
+  constexpr int compare(size_type pos1, size_type n1, const T& t) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2971,7 +2994,8 @@ return basic_string_view<charT, traits>(*this).substr(pos1, n1).compare(t);
 \indexlibrarymember{compare}{basic_string}%
 \begin{itemdecl}
 template<class T>
-  int compare(size_type pos1, size_type n1, const T& t, size_type pos2, size_type n2 = npos) const;
+  constexpr int compare(size_type pos1, size_type n1, const T& t,
+                        size_type pos2, size_type n2 = npos) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2997,7 +3021,7 @@ return s.substr(pos1, n1).compare(sv.substr(pos2, n2));
 
 \indexlibrarymember{compare}{basic_string}%
 \begin{itemdecl}
-int compare(const basic_string& str) const noexcept;
+constexpr int compare(const basic_string& str) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3009,7 +3033,7 @@ Equivalent to:
 
 \indexlibrarymember{compare}{basic_string}%
 \begin{itemdecl}
-int compare(size_type pos1, size_type n1, const basic_string& str) const;
+constexpr int compare(size_type pos1, size_type n1, const basic_string& str) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3021,8 +3045,8 @@ Equivalent to:
 
 \indexlibrarymember{compare}{basic_string}%
 \begin{itemdecl}
-int compare(size_type pos1, size_type n1, const basic_string& str,
-            size_type pos2, size_type n2 = npos) const;
+constexpr int compare(size_type pos1, size_type n1, const basic_string& str,
+                      size_type pos2, size_type n2 = npos) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3035,7 +3059,7 @@ return compare(pos1, n1, basic_string_view<charT, traits>(str), pos2, n2);
 
 \indexlibrarymember{compare}{basic_string}%
 \begin{itemdecl}
-int compare(const charT* s) const;
+constexpr int compare(const charT* s) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3046,7 +3070,7 @@ int compare(const charT* s) const;
 
 \indexlibrarymember{compare}{basic_string}%
 \begin{itemdecl}
-int compare(size_type pos, size_type n1, const charT* s) const;
+constexpr int compare(size_type pos, size_type n1, const charT* s) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3057,7 +3081,7 @@ Equivalent to: \tcode{return compare(pos, n1, basic_string_view<charT, traits>(s
 
 \indexlibrarymember{compare}{basic_string}%
 \begin{itemdecl}
-int compare(size_type pos, size_type n1, const charT* s, size_type n2) const;
+constexpr int compare(size_type pos, size_type n1, const charT* s, size_type n2) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3070,9 +3094,9 @@ Equivalent to: \tcode{return compare(pos, n1, basic_string_view<charT, traits>(s
 
 \indexlibrarymember{starts_with}{basic_string}%
 \begin{itemdecl}
-bool starts_with(basic_string_view<charT, traits> x) const noexcept;
-bool starts_with(charT x) const noexcept;
-bool starts_with(const charT* x) const;
+constexpr bool starts_with(basic_string_view<charT, traits> x) const noexcept;
+constexpr bool starts_with(charT x) const noexcept;
+constexpr bool starts_with(const charT* x) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3088,9 +3112,9 @@ return basic_string_view<charT, traits>(data(), size()).starts_with(x);
 
 \indexlibrarymember{ends_with}{basic_string}%
 \begin{itemdecl}
-bool ends_with(basic_string_view<charT, traits> x) const noexcept;
-bool ends_with(charT x) const noexcept;
-bool ends_with(const charT* x) const;
+constexpr bool ends_with(basic_string_view<charT, traits> x) const noexcept;
+constexpr bool ends_with(charT x) const noexcept;
+constexpr bool ends_with(const charT* x) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3111,11 +3135,11 @@ return basic_string_view<charT, traits>(data(), size()).ends_with(x);
 \indexlibrarymember{operator+}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
-  basic_string<charT, traits, Allocator>
+  constexpr basic_string<charT, traits, Allocator>
     operator+(const basic_string<charT, traits, Allocator>& lhs,
               const basic_string<charT, traits, Allocator>& rhs);
 template<class charT, class traits, class Allocator>
-  basic_string<charT, traits, Allocator>
+  constexpr basic_string<charT, traits, Allocator>
     operator+(const basic_string<charT, traits, Allocator>& lhs, const charT* rhs);
 \end{itemdecl}
 
@@ -3133,11 +3157,11 @@ return r;
 \indexlibrarymember{operator+}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
-  basic_string<charT, traits, Allocator>
+  constexpr basic_string<charT, traits, Allocator>
     operator+(basic_string<charT, traits, Allocator>&& lhs,
               const basic_string<charT, traits, Allocator>& rhs);
 template<class charT, class traits, class Allocator>
-  basic_string<charT, traits, Allocator>
+  constexpr basic_string<charT, traits, Allocator>
     operator+(basic_string<charT, traits, Allocator>&& lhs, const charT* rhs);
 \end{itemdecl}
 
@@ -3154,7 +3178,7 @@ return std::move(lhs);
 \indexlibrarymember{operator+}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
-  basic_string<charT, traits, Allocator>
+  constexpr basic_string<charT, traits, Allocator>
     operator+(basic_string<charT, traits, Allocator>&& lhs,
               basic_string<charT, traits, Allocator>&& rhs);
 \end{itemdecl}
@@ -3178,11 +3202,11 @@ the implementation may move from either.
 \indexlibrarymember{operator+}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
-  basic_string<charT, traits, Allocator>
+  constexpr basic_string<charT, traits, Allocator>
     operator+(const basic_string<charT, traits, Allocator>& lhs,
               basic_string<charT, traits, Allocator>&& rhs);
 template<class charT, class traits, class Allocator>
-  basic_string<charT, traits, Allocator>
+  constexpr basic_string<charT, traits, Allocator>
     operator+(const charT* lhs, basic_string<charT, traits, Allocator>&& rhs);
 \end{itemdecl}
 
@@ -3199,7 +3223,7 @@ return std::move(rhs);
 \indexlibrarymember{operator+}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
-  basic_string<charT, traits, Allocator>
+  constexpr basic_string<charT, traits, Allocator>
     operator+(const charT* lhs, const basic_string<charT, traits, Allocator>& rhs);
 \end{itemdecl}
 
@@ -3217,7 +3241,7 @@ return r;
 \indexlibrarymember{operator+}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
-  basic_string<charT, traits, Allocator>
+  constexpr basic_string<charT, traits, Allocator>
     operator+(charT lhs, const basic_string<charT, traits, Allocator>& rhs);
 \end{itemdecl}
 
@@ -3235,7 +3259,7 @@ return r;
 \indexlibrarymember{operator+}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
-  basic_string<charT, traits, Allocator>
+  constexpr basic_string<charT, traits, Allocator>
     operator+(charT lhs, basic_string<charT, traits, Allocator>&& rhs);
 \end{itemdecl}
 
@@ -3252,7 +3276,7 @@ return std::move(rhs);
 \indexlibrarymember{operator+}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
-  basic_string<charT, traits, Allocator>
+  constexpr basic_string<charT, traits, Allocator>
     operator+(const basic_string<charT, traits, Allocator>& lhs, charT rhs);
 \end{itemdecl}
 
@@ -3270,7 +3294,7 @@ return r;
 \indexlibrarymember{operator+}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
-  basic_string<charT, traits, Allocator>
+  constexpr basic_string<charT, traits, Allocator>
     operator+(basic_string<charT, traits, Allocator>&& lhs, charT rhs);
 \end{itemdecl}
 
@@ -3287,17 +3311,19 @@ return std::move(lhs);
 \rSec3[string.cmp]{Non-member comparison functions}
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
-  bool operator==(const basic_string<charT, traits, Allocator>& lhs,
-                  const basic_string<charT, traits, Allocator>& rhs) noexcept;
+  constexpr bool
+    operator==(const basic_string<charT, traits, Allocator>& lhs,
+               const basic_string<charT, traits, Allocator>& rhs) noexcept;
 template<class charT, class traits, class Allocator>
-  bool operator==(const basic_string<charT, traits, Allocator>& lhs, const charT* rhs);
+  constexpr bool operator==(const basic_string<charT, traits, Allocator>& lhs,
+                            const charT* rhs);
 
 template<class charT, class traits, class Allocator>
-  @\seebelow@ operator<=>(const basic_string<charT, traits, Allocator>& lhs,
-  @\itcorr@                      const basic_string<charT, traits, Allocator>& rhs) noexcept;
+  constexpr @\seebelow@ operator<=>(const basic_string<charT, traits, Allocator>& lhs,
+            @\itcorr@                      const basic_string<charT, traits, Allocator>& rhs) noexcept;
 template<class charT, class traits, class Allocator>
-  @\seebelow@ operator<=>(const basic_string<charT, traits, Allocator>& lhs,
-  @\itcorr@                      const charT* rhs);
+  constexpr @\seebelow@ operator<=>(const basic_string<charT, traits, Allocator>& lhs,
+            @\itcorr@                      const charT* rhs);
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
@@ -3313,9 +3339,10 @@ return basic_string_view<charT, traits>(lhs) @\placeholder{op}@ basic_string_vie
 \indexlibrarymember{swap}{basic_string}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
-  void swap(basic_string<charT, traits, Allocator>& lhs,
-            basic_string<charT, traits, Allocator>& rhs)
-    noexcept(noexcept(lhs.swap(rhs)));
+  constexpr void
+    swap(basic_string<charT, traits, Allocator>& lhs,
+         basic_string<charT, traits, Allocator>& rhs)
+      noexcept(noexcept(lhs.swap(rhs)));
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3737,7 +3764,7 @@ then \tcode{hash<S>()(s) == hash<SV>()(SV(s))}.
 
 \indexlibrarymember{operator""""s}{string}%
 \begin{itemdecl}
-string operator""s(const char* str, size_t len);
+constexpr string operator""s(const char* str, size_t len);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3748,7 +3775,7 @@ string operator""s(const char* str, size_t len);
 
 \indexlibrarymember{operator""""s}{u8string}%
 \begin{itemdecl}
-u8string operator""s(const char8_t* str, size_t len);
+constexpr u8string operator""s(const char8_t* str, size_t len);
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
@@ -3758,7 +3785,7 @@ u8string operator""s(const char8_t* str, size_t len);
 
 \indexlibrarymember{operator""""s}{u16string}%
 \begin{itemdecl}
-u16string operator""s(const char16_t* str, size_t len);
+constexpr u16string operator""s(const char16_t* str, size_t len);
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
@@ -3768,7 +3795,7 @@ u16string operator""s(const char16_t* str, size_t len);
 
 \indexlibrarymember{operator""""s}{u32string}%
 \begin{itemdecl}
-u32string operator""s(const char32_t* str, size_t len);
+constexpr u32string operator""s(const char32_t* str, size_t len);
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
@@ -3778,7 +3805,7 @@ u32string operator""s(const char32_t* str, size_t len);
 
 \indexlibrarymember{operator""""s}{wstring}%
 \begin{itemdecl}
-wstring operator""s(const wchar_t* str, size_t len);
+constexpr wstring operator""s(const wchar_t* str, size_t len);
 \end{itemdecl}
 \begin{itemdescr}
 \pnum

--- a/source/support.tex
+++ b/source/support.tex
@@ -586,6 +586,8 @@ the values of these macros with greater values.
   \tcode{<memory>} \\ \rowsep
 \defnlibxname{cpp_lib_constexpr_invoke}                     & \tcode{201907L} &
   \tcode{<functional>} \\ \rowsep
+\defnlibxname{cpp_lib_constexpr_string}                     & \tcode{201907L} &
+  \tcode{<string>} \\ \rowsep
 \defnlibxname{cpp_lib_constexpr_swap_algorithms}            & \tcode{201806L} &
   \tcode{<algorithm>} \\ \rowsep
 \defnlibxname{cpp_lib_constexpr_vector}                     & \tcode{201907L} &


### PR DESCRIPTION
[string.find]: Added \indexlibrarymember references to the variations of find* described via the placeholder F.

Fixes #3031.