### PR TITLE
P1004R2 Making std::vector constexpr

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -3212,19 +3212,19 @@ namespace std {
   template<class T, class Allocator = allocator<T>> class vector;
 
   template<class T, class Allocator>
-    bool operator==(const vector<T, Allocator>& x, const vector<T, Allocator>& y);
+    constexpr bool operator==(const vector<T, Allocator>& x, const vector<T, Allocator>& y);
   template<class T, class Allocator>
-    @\placeholder{synth-three-way-result}@<T> operator<=>(const vector<T, Allocator>& x,
-    @\itcorr@                                      const vector<T, Allocator>& y);
+    constexpr @\placeholder{synth-three-way-result}@<T> operator<=>(const vector<T, Allocator>& x,
+              @\itcorr@                                      const vector<T, Allocator>& y);
 
   template<class T, class Allocator>
-    void swap(vector<T, Allocator>& x, vector<T, Allocator>& y)
+    constexpr void swap(vector<T, Allocator>& x, vector<T, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 
   template<class T, class Allocator, class U>
-    void erase(vector<T, Allocator>& c, const U& value);
+    constexpr void erase(vector<T, Allocator>& c, const U& value);
   template<class T, class Allocator, class Predicate>
-    void erase_if(vector<T, Allocator>& c, Predicate pred);
+    constexpr void erase_if(vector<T, Allocator>& c, Predicate pred);
 
   // \ref{vector.bool}, class \tcode{vector<bool>}
   template<class Allocator> class vector<bool, Allocator>;
@@ -5371,6 +5371,10 @@ provided. Descriptions are provided here only for operations on \tcode{vector}
 that are not described in one of these tables or for operations where there is
 additional semantic information.
 
+\pnum
+The types \tcode{iterator} and \tcode{const_iterator} meet
+the constexpr iterator requirements\iref{iterator.requirements.general}.
+
 \begin{codeblock}
 namespace std {
   template<class T, class Allocator = allocator<T>>
@@ -5391,87 +5395,88 @@ namespace std {
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
     // \ref{vector.cons}, construct/copy/destroy
-    vector() noexcept(noexcept(Allocator())) : vector(Allocator()) { }
-    explicit vector(const Allocator&) noexcept;
-    explicit vector(size_type n, const Allocator& = Allocator());
-    vector(size_type n, const T& value, const Allocator& = Allocator());
+    constexpr vector() noexcept(noexcept(Allocator())) : vector(Allocator()) { }
+    constexpr explicit vector(const Allocator&) noexcept;
+    constexpr explicit vector(size_type n, const Allocator& = Allocator());
+    constexpr vector(size_type n, const T& value, const Allocator& = Allocator());
     template<class InputIterator>
-      vector(InputIterator first, InputIterator last, const Allocator& = Allocator());
-    vector(const vector& x);
-    vector(vector&&) noexcept;
-    vector(const vector&, const Allocator&);
-    vector(vector&&, const Allocator&);
-    vector(initializer_list<T>, const Allocator& = Allocator());
-    ~vector();
-    vector& operator=(const vector& x);
-    vector& operator=(vector&& x)
+      constexpr vector(InputIterator first, InputIterator last, const Allocator& = Allocator());
+    constexpr vector(const vector& x);
+    constexpr vector(vector&&) noexcept;
+    constexpr vector(const vector&, const Allocator&);
+    constexpr vector(vector&&, const Allocator&);
+    constexpr vector(initializer_list<T>, const Allocator& = Allocator());
+    constexpr ~vector();
+    constexpr vector& operator=(const vector& x);
+    constexpr vector& operator=(vector&& x)
       noexcept(allocator_traits<Allocator>::propagate_on_container_move_assignment::value ||
                allocator_traits<Allocator>::is_always_equal::value);
-    vector& operator=(initializer_list<T>);
+    constexpr vector& operator=(initializer_list<T>);
     template<class InputIterator>
-      void assign(InputIterator first, InputIterator last);
-    void assign(size_type n, const T& u);
-    void assign(initializer_list<T>);
-    allocator_type get_allocator() const noexcept;
+      constexpr void assign(InputIterator first, InputIterator last);
+    constexpr void assign(size_type n, const T& u);
+    constexpr void assign(initializer_list<T>);
+    constexpr allocator_type get_allocator() const noexcept;
 
     // iterators
-    iterator               begin() noexcept;
-    const_iterator         begin() const noexcept;
-    iterator               end() noexcept;
-    const_iterator         end() const noexcept;
-    reverse_iterator       rbegin() noexcept;
-    const_reverse_iterator rbegin() const noexcept;
-    reverse_iterator       rend() noexcept;
-    const_reverse_iterator rend() const noexcept;
+    constexpr iterator               begin() noexcept;
+    constexpr const_iterator         begin() const noexcept;
+    constexpr iterator               end() noexcept;
+    constexpr const_iterator         end() const noexcept;
+    constexpr reverse_iterator       rbegin() noexcept;
+    constexpr const_reverse_iterator rbegin() const noexcept;
+    constexpr reverse_iterator       rend() noexcept;
+    constexpr const_reverse_iterator rend() const noexcept;
 
-    const_iterator         cbegin() const noexcept;
-    const_iterator         cend() const noexcept;
-    const_reverse_iterator crbegin() const noexcept;
-    const_reverse_iterator crend() const noexcept;
+    constexpr const_iterator         cbegin() const noexcept;
+    constexpr const_iterator         cend() const noexcept;
+    constexpr const_reverse_iterator crbegin() const noexcept;
+    constexpr const_reverse_iterator crend() const noexcept;
 
     // \ref{vector.capacity}, capacity
-    [[nodiscard]] bool empty() const noexcept;
-    size_type size() const noexcept;
-    size_type max_size() const noexcept;
-    size_type capacity() const noexcept;
-    void      resize(size_type sz);
-    void      resize(size_type sz, const T& c);
-    void      reserve(size_type n);
-    void      shrink_to_fit();
+    [[nodiscard]] constexpr bool empty() const noexcept;
+    constexpr size_type size() const noexcept;
+    constexpr size_type max_size() const noexcept;
+    constexpr size_type capacity() const noexcept;
+    constexpr void      resize(size_type sz);
+    constexpr void      resize(size_type sz, const T& c);
+    constexpr void      reserve(size_type n);
+    constexpr void      shrink_to_fit();
 
     // element access
-    reference       operator[](size_type n);
-    const_reference operator[](size_type n) const;
-    const_reference at(size_type n) const;
-    reference       at(size_type n);
-    reference       front();
-    const_reference front() const;
-    reference       back();
-    const_reference back() const;
+    constexpr reference       operator[](size_type n);
+    constexpr const_reference operator[](size_type n) const;
+    constexpr const_reference at(size_type n) const;
+    constexpr reference       at(size_type n);
+    constexpr reference       front();
+    constexpr const_reference front() const;
+    constexpr reference       back();
+    constexpr const_reference back() const;
 
     // \ref{vector.data}, data access
-    T*       data() noexcept;
-    const T* data() const noexcept;
+    constexpr T*       data() noexcept;
+    constexpr const T* data() const noexcept;
 
     // \ref{vector.modifiers}, modifiers
-    template<class... Args> reference emplace_back(Args&&... args);
-    void push_back(const T& x);
-    void push_back(T&& x);
-    void pop_back();
+    template<class... Args> constexpr reference emplace_back(Args&&... args);
+    constexpr void push_back(const T& x);
+    constexpr void push_back(T&& x);
+    constexpr void pop_back();
 
-    template<class... Args> iterator emplace(const_iterator position, Args&&... args);
-    iterator insert(const_iterator position, const T& x);
-    iterator insert(const_iterator position, T&& x);
-    iterator insert(const_iterator position, size_type n, const T& x);
+    template<class... Args> constexpr iterator emplace(const_iterator position, Args&&... args);
+    constexpr iterator insert(const_iterator position, const T& x);
+    constexpr iterator insert(const_iterator position, T&& x);
+    constexpr iterator insert(const_iterator position, size_type n, const T& x);
     template<class InputIterator>
-      iterator insert(const_iterator position, InputIterator first, InputIterator last);
-    iterator insert(const_iterator position, initializer_list<T> il);
-    iterator erase(const_iterator position);
-    iterator erase(const_iterator first, const_iterator last);
-    void     swap(vector&)
+      constexpr iterator insert(const_iterator position,
+                                InputIterator first, InputIterator last);
+    constexpr iterator insert(const_iterator position, initializer_list<T> il);
+    constexpr iterator erase(const_iterator position);
+    constexpr iterator erase(const_iterator first, const_iterator last);
+    constexpr void     swap(vector&)
       noexcept(allocator_traits<Allocator>::propagate_on_container_swap::value ||
                allocator_traits<Allocator>::is_always_equal::value);
-    void     clear() noexcept;
+    constexpr void     clear() noexcept;
   };
 
   template<class InputIterator, class Allocator = allocator<@\placeholder{iter-value-type}@<InputIterator>>>
@@ -5480,7 +5485,7 @@ namespace std {
 
   // swap
   template<class T, class Allocator>
-    void swap(vector<T, Allocator>& x, vector<T, Allocator>& y)
+    constexpr void swap(vector<T, Allocator>& x, vector<T, Allocator>& y)
       noexcept(noexcept(x.swap(y)));
 }
 \end{codeblock}%
@@ -5498,7 +5503,7 @@ of \tcode{vector} is referenced.
 
 \indexlibrary{\idxcode{vector}!constructor}
 \begin{itemdecl}
-explicit vector(const Allocator&) noexcept;
+constexpr explicit vector(const Allocator&) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5512,7 +5517,7 @@ specified allocator.
 
 \indexlibrary{\idxcode{vector}!constructor}
 \begin{itemdecl}
-explicit vector(size_type n, const Allocator& = Allocator());
+constexpr explicit vector(size_type n, const Allocator& = Allocator());
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5529,8 +5534,8 @@ default-inserted elements using the specified allocator.
 
 \indexlibrary{\idxcode{vector}!constructor}
 \begin{itemdecl}
-vector(size_type n, const T& value,
-       const Allocator& = Allocator());
+constexpr vector(size_type n, const T& value,
+                 const Allocator& = Allocator());
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5549,8 +5554,8 @@ copies of \tcode{value}, using the specified allocator.
 \indexlibrary{\idxcode{vector}!constructor}
 \begin{itemdecl}
 template<class InputIterator>
-  vector(InputIterator first, InputIterator last,
-         const Allocator& = Allocator());
+  constexpr vector(InputIterator first, InputIterator last,
+                   const Allocator& = Allocator());
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5583,7 +5588,7 @@ reallocations if they are just input iterators.
 
 \indexlibrary{\idxcode{capacity}!\idxcode{vector}}%
 \begin{itemdecl}
-size_type capacity() const noexcept;
+constexpr size_type capacity() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5598,7 +5603,7 @@ without requiring reallocation.
 
 \indexlibrary{\idxcode{reserve}!\idxcode{vector}}%
 \begin{itemdecl}
-void reserve(size_type n);
+constexpr void reserve(size_type n);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5650,7 +5655,7 @@ greater than the value of \tcode{capacity()}.
 
 \indexlibrary{\idxcode{shrink_to_fit}!\idxcode{vector}}%
 \begin{itemdecl}
-void shrink_to_fit();
+constexpr void shrink_to_fit();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5682,7 +5687,7 @@ If no reallocation happens, they remain valid.
 
 \indexlibrary{\idxcode{swap}!\idxcode{vector}}%
 \begin{itemdecl}
-void swap(vector& x)
+constexpr void swap(vector& x)
   noexcept(allocator_traits<Allocator>::propagate_on_container_swap::value ||
            allocator_traits<Allocator>::is_always_equal::value);
 \end{itemdecl}
@@ -5703,7 +5708,7 @@ Constant time.
 
 \indexlibrary{\idxcode{resize}!\idxcode{vector}}%
 \begin{itemdecl}
-void resize(size_type sz);
+constexpr void resize(size_type sz);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5723,7 +5728,7 @@ appends \tcode{sz - size()} default-inserted elements to the sequence.
 
 \indexlibrary{\idxcode{resize}!\idxcode{vector}}%
 \begin{itemdecl}
-void resize(size_type sz, const T& c);
+constexpr void resize(size_type sz, const T& c);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5744,8 +5749,8 @@ appends \tcode{sz - size()} copies of \tcode{c} to the sequence.
 
 \indexlibrary{\idxcode{data}!\idxcode{vector}}%
 \begin{itemdecl}
-T*         data() noexcept;
-const T*   data() const noexcept;
+constexpr T*         data() noexcept;
+constexpr const T*   data() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5763,17 +5768,17 @@ Constant time.
 
 \indexlibrary{\idxcode{insert}!\idxcode{vector}}%
 \begin{itemdecl}
-iterator insert(const_iterator position, const T& x);
-iterator insert(const_iterator position, T&& x);
-iterator insert(const_iterator position, size_type n, const T& x);
+constexpr iterator insert(const_iterator position, const T& x);
+constexpr iterator insert(const_iterator position, T&& x);
+constexpr iterator insert(const_iterator position, size_type n, const T& x);
 template<class InputIterator>
-  iterator insert(const_iterator position, InputIterator first, InputIterator last);
-iterator insert(const_iterator position, initializer_list<T>);
+  constexpr iterator insert(const_iterator position, InputIterator first, InputIterator last);
+constexpr iterator insert(const_iterator position, initializer_list<T>);
 
-template<class... Args> reference emplace_back(Args&&... args);
-template<class... Args> iterator emplace(const_iterator position, Args&&... args);
-void push_back(const T& x);
-void push_back(T&& x);
+template<class... Args> constexpr reference emplace_back(Args&&... args);
+template<class... Args> constexpr iterator emplace(const_iterator position, Args&&... args);
+constexpr void push_back(const T& x);
+constexpr void push_back(T&& x);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5810,9 +5815,9 @@ to the end of the vector.
 
 \indexlibrary{\idxcode{erase}!\idxcode{vector}}%
 \begin{itemdecl}
-iterator erase(const_iterator position);
-iterator erase(const_iterator first, const_iterator last);
-void pop_back();
+constexpr iterator erase(const_iterator position);
+constexpr iterator erase(const_iterator first, const_iterator last);
+constexpr void pop_back();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5839,7 +5844,7 @@ assignment operator or move assignment operator of
 \indexlibrary{\idxcode{erase}!\idxcode{vector}}%
 \begin{itemdecl}
 template<class T, class Allocator, class U>
-  void erase(vector<T, Allocator>& c, const U& value);
+  constexpr void erase(vector<T, Allocator>& c, const U& value);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5851,7 +5856,7 @@ Equivalent to: \tcode{c.erase(remove(c.begin(), c.end(), value), c.end());}
 \indexlibrary{\idxcode{erase_if}!\idxcode{vector}}%
 \begin{itemdecl}
 template<class T, class Allocator, class Predicate>
-  void erase_if(vector<T, Allocator>& c, Predicate pred);
+  constexpr void erase_if(vector<T, Allocator>& c, Predicate pred);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5889,89 +5894,90 @@ namespace std {
     // bit reference
     class reference {
       friend class vector;
-      reference() noexcept;
+      constexpr reference() noexcept;
     public:
-      reference(const reference&) = default;
-      ~reference();
-      operator bool() const noexcept;
-      reference& operator=(const bool x) noexcept;
-      reference& operator=(const reference& x) noexcept;
-      void flip() noexcept;     // flips the bit
+      constexpr reference(const reference&) = default;
+      constexpr ~reference();
+      constexpr operator bool() const noexcept;
+      constexpr reference& operator=(const bool x) noexcept;
+      constexpr reference& operator=(const reference& x) noexcept;
+      constexpr void flip() noexcept;     // flips the bit
     };
 
     // construct/copy/destroy
-    vector() : vector(Allocator()) { }
-    explicit vector(const Allocator&);
-    explicit vector(size_type n, const Allocator& = Allocator());
-    vector(size_type n, const bool& value, const Allocator& = Allocator());
+    constexpr vector() : vector(Allocator()) { }
+    constexpr explicit vector(const Allocator&);
+    constexpr explicit vector(size_type n, const Allocator& = Allocator());
+    constexpr vector(size_type n, const bool& value, const Allocator& = Allocator());
     template<class InputIterator>
-      vector(InputIterator first, InputIterator last, const Allocator& = Allocator());
-    vector(const vector& x);
-    vector(vector&& x);
-    vector(const vector&, const Allocator&);
-    vector(vector&&, const Allocator&);
-    vector(initializer_list<bool>, const Allocator& = Allocator()));
-    ~vector();
-    vector& operator=(const vector& x);
-    vector& operator=(vector&& x);
-    vector& operator=(initializer_list<bool>);
+      constexpr vector(InputIterator first, InputIterator last, const Allocator& = Allocator());
+    constexpr vector(const vector& x);
+    constexpr vector(vector&& x);
+    constexpr vector(const vector&, const Allocator&);
+    constexpr vector(vector&&, const Allocator&);
+    constexpr vector(initializer_list<bool>, const Allocator& = Allocator()));
+    constexpr ~vector();
+    constexpr vector& operator=(const vector& x);
+    constexpr vector& operator=(vector&& x);
+    constexpr vector& operator=(initializer_list<bool>);
     template<class InputIterator>
-      void assign(InputIterator first, InputIterator last);
-    void assign(size_type n, const bool& t);
-    void assign(initializer_list<bool>);
-    allocator_type get_allocator() const noexcept;
+      constexpr void assign(InputIterator first, InputIterator last);
+    constexpr void assign(size_type n, const bool& t);
+    constexpr void assign(initializer_list<bool>);
+    constexpr allocator_type get_allocator() const noexcept;
 
     // iterators
-    iterator               begin() noexcept;
-    const_iterator         begin() const noexcept;
-    iterator               end() noexcept;
-    const_iterator         end() const noexcept;
-    reverse_iterator       rbegin() noexcept;
-    const_reverse_iterator rbegin() const noexcept;
-    reverse_iterator       rend() noexcept;
-    const_reverse_iterator rend() const noexcept;
+    constexpr iterator               begin() noexcept;
+    constexpr const_iterator         begin() const noexcept;
+    constexpr iterator               end() noexcept;
+    constexpr const_iterator         end() const noexcept;
+    constexpr reverse_iterator       rbegin() noexcept;
+    constexpr const_reverse_iterator rbegin() const noexcept;
+    constexpr reverse_iterator       rend() noexcept;
+    constexpr const_reverse_iterator rend() const noexcept;
 
-    const_iterator         cbegin() const noexcept;
-    const_iterator         cend() const noexcept;
-    const_reverse_iterator crbegin() const noexcept;
-    const_reverse_iterator crend() const noexcept;
+    constexpr const_iterator         cbegin() const noexcept;
+    constexpr const_iterator         cend() const noexcept;
+    constexpr const_reverse_iterator crbegin() const noexcept;
+    constexpr const_reverse_iterator crend() const noexcept;
 
     // capacity
-    [[nodiscard]] bool empty() const noexcept;
-    size_type size() const noexcept;
-    size_type max_size() const noexcept;
-    size_type capacity() const noexcept;
-    void      resize(size_type sz, bool c = false);
-    void      reserve(size_type n);
-    void      shrink_to_fit();
+    [[nodiscard]] constexpr bool empty() const noexcept;
+    constexpr size_type size() const noexcept;
+    constexpr size_type max_size() const noexcept;
+    constexpr size_type capacity() const noexcept;
+    constexpr void      resize(size_type sz, bool c = false);
+    constexpr void      reserve(size_type n);
+    constexpr void      shrink_to_fit();
 
     // element access
-    reference       operator[](size_type n);
-    const_reference operator[](size_type n) const;
-    const_reference at(size_type n) const;
-    reference       at(size_type n);
-    reference       front();
-    const_reference front() const;
-    reference       back();
-    const_reference back() const;
+    constexpr reference       operator[](size_type n);
+    constexpr const_reference operator[](size_type n) const;
+    constexpr const_reference at(size_type n) const;
+    constexpr reference       at(size_type n);
+    constexpr reference       front();
+    constexpr const_reference front() const;
+    constexpr reference       back();
+    constexpr const_reference back() const;
 
     // modifiers
-    template<class... Args> reference emplace_back(Args&&... args);
-    void push_back(const bool& x);
-    void pop_back();
-    template<class... Args> iterator emplace(const_iterator position, Args&&... args);
-    iterator insert(const_iterator position, const bool& x);
-    iterator insert(const_iterator position, size_type n, const bool& x);
+    template<class... Args> constexpr reference emplace_back(Args&&... args);
+    constexpr void push_back(const bool& x);
+    constexpr void pop_back();
+    template<class... Args> constexpr iterator emplace(const_iterator position, Args&&... args);
+    constexpr iterator insert(const_iterator position, const bool& x);
+    constexpr iterator insert(const_iterator position, size_type n, const bool& x);
     template<class InputIterator>
-      iterator insert(const_iterator position, InputIterator first, InputIterator last);
-    iterator insert(const_iterator position, initializer_list<bool> il);
+      constexpr iterator insert(const_iterator position,
+                                InputIterator first, InputIterator last);
+    constexpr iterator insert(const_iterator position, initializer_list<bool> il);
 
-    iterator erase(const_iterator position);
-    iterator erase(const_iterator first, const_iterator last);
-    void swap(vector&);
-    static void swap(reference x, reference y) noexcept;
-    void flip() noexcept;       // flips all bits
-    void clear() noexcept;
+    constexpr iterator erase(const_iterator position);
+    constexpr iterator erase(const_iterator first, const_iterator last);
+    constexpr void swap(vector&);
+    constexpr static void swap(reference x, reference y) noexcept;
+    constexpr void flip() noexcept;       // flips all bits
+    constexpr void clear() noexcept;
   };
 }
 \end{codeblock}%
@@ -5999,7 +6005,7 @@ clears it otherwise. \tcode{flip} reverses the state of the bit.
 
 \indexlibrarymember{flip}{vector<bool>}%
 \begin{itemdecl}
-void flip() noexcept;
+constexpr void flip() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6009,7 +6015,7 @@ void flip() noexcept;
 
 \indexlibrarymember{swap}{vector<bool>}%
 \begin{itemdecl}
-static void swap(reference x, reference y) noexcept;
+constexpr static void swap(reference x, reference y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/support.tex
+++ b/source/support.tex
@@ -582,12 +582,14 @@ the values of these macros with greater values.
 \defnlibxname{cpp_lib_constexpr}                            & \tcode{201811L} &
   any C++ library header from \tref{headers.cpp} or
   any C++ header for C library facilities from \tref{headers.cpp.c} \\ \rowsep
+\defnlibxname{cpp_lib_constexpr_dynamic_alloc}              & \tcode{201907L} &
+  \tcode{<memory>} \\ \rowsep
 \defnlibxname{cpp_lib_constexpr_invoke}                     & \tcode{201907L} &
   \tcode{<functional>} \\ \rowsep
 \defnlibxname{cpp_lib_constexpr_swap_algorithms}            & \tcode{201806L} &
   \tcode{<algorithm>} \\ \rowsep
-\defnlibxname{cpp_lib_constexpr_dynamic_alloc}              & \tcode{201907L} &
-  \tcode{<memory>} \\ \rowsep
+\defnlibxname{cpp_lib_constexpr_vector}                     & \tcode{201907L} &
+  \tcode{<vector>} \\ \rowsep
 \defnlibxname{cpp_lib_destroying_delete}                    & \tcode{201806L} &
   \tcode{<new>} \\ \rowsep
 \defnlibxname{cpp_lib_enable_shared_from_this}              & \tcode{201603L} &


### PR DESCRIPTION
[vector.special] Could not apply the change to this section;
the section no longer exists, and its itemdecl for swap has been removed.

Fixes #3030.