### PR TITLE
[tuple] Use "objects" instead of "variables"

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1641,7 +1641,7 @@ template<class... TTypes>
 \pnum
 \effects Constructs a tuple of references to the arguments in \tcode{t} suitable
 for forwarding as arguments to a function. Because the result may contain references
-to temporary variables, a program shall ensure that the return value of this
+to temporary objects, a program shall ensure that the return value of this
 function does not outlive any of its arguments (e.g., the program should typically
 not store the result in a named variable).
 


### PR DESCRIPTION
with "temporary" in the definition of `forward_as_tuple`