### PR TITLE
[temp.deduct] Fix Ambiguous "this" in paragraph 3

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -7193,11 +7193,18 @@ Otherwise, the specified template argument values are substituted for the
 corresponding template parameters as specified below.
 
 \pnum
-After this substitution is performed, the function parameter type
-adjustments described in~\ref{dcl.fct} are performed.
+After performing the substitution as specified below, the
+function parameter type adjustments described in~\ref{dcl.fct}
+are performed.
 \begin{example}
-A parameter type of ``\tcode{void (const int, int[5])}'' becomes
-``\tcode{void(*)(int,int*)}''.
+A parameter type of
+\begin{codeblock}
+void (const int, int[5])
+\end{codeblock}
+becomes
+\begin{codeblock}
+void(*)(int,int*)
+\end{codeblock}
 \end{example}
 \begin{note}
 A top-level qualifier in a function parameter declaration does not affect


### PR DESCRIPTION
This is an editorial change. There is an ambiguous "this"
in paragraph 3 of [temp.deduct]. Upon first reading this paragraph
it is not obvious that "this substitution" refers to the
substitution process described in the subsequent paragraphs.
This change specifies that the substitution process refers
to the one described in the subsequent paragraphs of the section.