### PR TITLE
P1638R1 basic_istream_view::iterator should not be copyable

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -5560,6 +5560,12 @@ namespace std::ranges {
     iterator() = default;
     constexpr explicit iterator(basic_istream_view& parent) noexcept;
 
+    iterator(const iterator&) = delete;
+    iterator(iterator&&) = default;
+
+    iterator& operator=(const iterator&) = delete;
+    iterator& operator=(iterator&&) = default;
+
     iterator& operator++();
     void operator++(int);
 


### PR DESCRIPTION
Fixes #3028.

I wanted this pull request to just contain the patch against P1035R7, but that apparently failed.