### PR TITLE
[time.clock,bit.cast] Replace template<typename...> with template<cla…

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -1305,7 +1305,7 @@ manipulate and process both individual bits and bit sequences.
 \begin{codeblock}
 namespace std {
   // \ref{bit.cast}, \tcode{bit_cast}
-  template<typename To, typename From>
+  template<class To, class From>
     constexpr To bit_cast(const From& from) noexcept;
 
   // \ref{bit.pow.two}, integral powers of 2
@@ -1324,7 +1324,7 @@ namespace std {
 
 \indexlibrary{\idxcode{bit_cast}}%
 \begin{itemdecl}
-template<typename To, typename From>
+template<class To, class From>
   constexpr To bit_cast(const From& from) noexcept;
 \end{itemdecl}
 

--- a/source/time.tex
+++ b/source/time.tex
@@ -2794,7 +2794,7 @@ static time_point now();
 
 \indexlibrarymember{to_sys}{utc_clock}%
 \begin{itemdecl}
-template<typename Duration>
+template<class Duration>
   static sys_time<common_type_t<Duration, seconds>>
     to_sys(const utc_time<Duration>& u);
 \end{itemdecl}
@@ -2812,7 +2812,7 @@ prior to the insertion of the leap second is returned.
 
 \indexlibrarymember{from_sys}{utc_clock}%
 \begin{itemdecl}
-template<typename Duration>
+template<class Duration>
   static utc_time<common_type_t<Duration, seconds>>
     from_sys(const sys_time<Duration>& t);
 \end{itemdecl}
@@ -3632,7 +3632,7 @@ as described in
 \rSec3[time.clock.cast.id]{Identity conversions}
 
 \begin{codeblock}
-template<typename Clock>
+template<class Clock>
 struct clock_time_conversion<Clock, Clock> {
   template<class Duration>
     time_point<Clock, Duration>


### PR DESCRIPTION
…ss...>

as per library specification policy.

Fixes #3103.