### PR TITLE
[diff.cpp17.class] 'injected-class-name' is not a grammar non-terminal.

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1999,7 +1999,7 @@ in this International Standard. For example:
 template<class T>
 struct A {
   A<T>();          // error: \grammarterm{simple-template-id} not allowed for constructor
-  A(int);          // OK, \grammarterm{injected-class-name} used
+  A(int);          // OK, injected-class-name used
   ~A<T>();         // error: \grammarterm{simple-template-id} not allowed for destructor
 };
 \end{codeblock}


### PR DESCRIPTION
Fixes #3114.