### PR TITLE
[diff.cpp17.class] Add example where P0527R1 silently changes semantics.

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -2045,7 +2045,8 @@ Function and catch-clause parameters can be thrown using move constructors.
 Side effect of making it easier to write
 more efficient code that takes advantage of moves.
 \effect
-Valid \CppXVII{} code may fail to compile in this International Standard.
+Valid \CppXVII{} code may fail to compile or have different semantics
+in this International Standard.
 For example:
 \begin{codeblock}
 struct base {
@@ -2061,6 +2062,21 @@ base f(base b) {
   throw b;                      // error: \tcode{base(base \&\&)} is private
   derived d;
   return d;                     // error: \tcode{base(base \&\&)} is private
+}
+
+struct S {
+  S(const char *s) : m(s) { }
+  S(const S&) = default;
+  S(S&& other) : m(other.m) { other.m = nullptr; }
+  const char * m;
+};
+
+S consume(S&& s) { return s; }
+
+void g() {
+  S s("text");
+  consume(static_cast<S&&>(s));
+  char c = *s.m;                // undefined behavior; previously ok
 }
 \end{codeblock}
 


### PR DESCRIPTION
See http://lists.isocpp.org/core/2019/08/6987.php .