### PR TITLE
[meta.trans.other] Use hyphens, not underscores, for meta-functions.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -17992,38 +17992,38 @@ Let:
     \tcode{\placeholdernc{COPYCV}(const int, volatile short)} is an alias for
     \tcode{const volatile short}.
   \end{example}
-\item \tcode{\placeholdernc{COND_RES}(X, Y)} be
+\item \tcode{\placeholdernc{COND-RES}(X, Y)} be
   \tcode{decltype(false ?\ declval<X(\&)()>()() :\ declval<Y(\&)()>()())}.
 \end{itemize}
 Given types \tcode{A} and \tcode{B},
 let \tcode{X} be \tcode{remove_reference_t<A>},
 let \tcode{Y} be \tcode{remove_reference_t<B>}, and
-let \tcode{\placeholdernc{COMMON_REF}(A, B)} be:
+let \tcode{\placeholdernc{COMMON-\brk{}REF}(A, B)} be:
 \begin{itemize}
 \item If \tcode{A} and \tcode{B} are both lvalue reference types,
-  \tcode{\placeholdernc{COMMON_REF}(A, B)} is
-  \tcode{\placeholdernc{COND_RES}(\placeholdernc{COPYCV}(X, Y) \&,
+  \tcode{\placeholdernc{COMMON-REF}(A, B)} is
+  \tcode{\placeholdernc{COND-RES}(\placeholdernc{COPYCV}(X, Y) \&,
     \placeholdernc{COPYCV}(\brk{}Y, X) \&)} if that type exists
   and is a reference type.
 \item Otherwise, let \tcode{C} be
-  \tcode{remove_reference_t<\placeholdernc{COMMON_REF}(X\&, Y\&)>\&\&}.
+  \tcode{remove_reference_t<\placeholdernc{COMMON-REF}(X\&, Y\&)>\&\&}.
   If \tcode{A} and \tcode{B} are both rvalue reference types,
   \tcode{C} is well-formed, and
   \tcode{is_convertible_v<A, C> \&\& is_convertible_v<B, C>} is \tcode{true},
-  then \tcode{\placeholdernc{COMMON_REF}(A, B)} is \tcode{C}.
+  then \tcode{\placeholdernc{COMMON-REF}(A, B)} is \tcode{C}.
 \item Otherwise, let \tcode{D} be
-  \tcode{\placeholdernc{COMMON_REF}(const X\&, Y\&)}. If \tcode{A} is an rvalue
+  \tcode{\placeholdernc{COMMON-REF}(const X\&, Y\&)}. If \tcode{A} is an rvalue
   reference and \tcode{B} is an lvalue reference and \tcode{D} is
   well-formed and \tcode{is_convertible_v<A, D>} is
-  \tcode{true}, then \tcode{\placeholdernc{COMMON_REF}(A, B)} is \tcode{D}.
+  \tcode{true}, then \tcode{\placeholdernc{COMMON-REF}(A, B)} is \tcode{D}.
 \item Otherwise, if \tcode{A} is an lvalue reference and \tcode{B}
-  is an rvalue reference, then \tcode{\placeholdernc{COMMON_REF}(A, B)} is
-  \tcode{\placeholdernc{COMMON_REF}(B, A)}.
-\item Otherwise, \tcode{\placeholdernc{COMMON_REF}(A, B)} is ill-formed.
+  is an rvalue reference, then \tcode{\placeholdernc{COMMON-REF}(A, B)} is
+  \tcode{\placeholdernc{COMMON-REF}(B, A)}.
+\item Otherwise, \tcode{\placeholdernc{COMMON-REF}(A, B)} is ill-formed.
 \end{itemize}
 
 If any of the types computed above is ill-formed, then
-\tcode{\placeholdernc{COMMON_REF}(A, B)} is ill-formed.
+\tcode{\placeholdernc{COMMON-REF}(A, B)} is ill-formed.
 
 \pnum
 Note A:
@@ -18064,10 +18064,10 @@ decay_t<decltype(false ? declval<D1>() : declval<D2>())>
 \end{codeblock}
     denotes a valid type, let \tcode{C} denote that type.
   \item Otherwise, if
-    \tcode{\placeholdernc{COND_RES}(\placeholdernc{CREF}(D1),
+    \tcode{\placeholdernc{COND-RES}(\placeholdernc{CREF}(D1),
       \placeholdernc{CREF}(D2))}
     denotes a type, let \tcode{C} denote the type
-    \tcode{decay_t<\placeholdernc{COND_RES}(\placeholdernc{CREF}(D1),
+    \tcode{decay_t<\placeholdernc{COND-RES}(\placeholdernc{CREF}(D1),
       \placeholdernc{CREF}(D2))>}.
   \end{itemize}
 In either case, the member \grammarterm{typedef-name} \tcode{type} shall denote
@@ -18117,7 +18117,7 @@ present as follows:
   denote the two types in the pack \tcode{T}. Then
   \begin{itemize}
   \item If \tcode{T1} and \tcode{T2} are reference types and
-    \tcode{\placeholdernc{COMMON_REF}(T1, T2)} is well-formed, then the member
+    \tcode{\placeholdernc{COMMON-REF}(T1, T2)} is well-formed, then the member
     typedef \tcode{type} denotes that type.
 
   \item Otherwise, if
@@ -18125,7 +18125,7 @@ present as follows:
       \brk{}\placeholdernc{XREF}(\brk{}T1), \placeholdernc{XREF}(T2)>::type}
     is well-formed, then the member typedef \tcode{type} denotes that type.
 
-  \item Otherwise, if \tcode{\placeholdernc{COND_RES}(T1, T2)} is well-formed,
+  \item Otherwise, if \tcode{\placeholdernc{COND-RES}(T1, T2)} is well-formed,
     then the member typedef \tcode{type} denotes that type.
 
   \item Otherwise, if \tcode{common_type_t<T1, T2>} is well-formed, then the


### PR DESCRIPTION
Fixes #3130.