### PR TITLE
[cmp.alg] Use regular apostrophes instead of fancy Unicode quotation marks.

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -4955,7 +4955,7 @@ is expression-equivalent\iref{defns.expression-equivalent} to the following:
   a floating-point type,
   yields a value of type \tcode{strong_ordering}
   that is consistent with the ordering
-  observed by \tcode{T}’s comparison operators, and
+  observed by \tcode{T}'s comparison operators, and
   if \tcode{numeric_limits<T>::is_iec559} is \tcode{true},
   is additionally consistent with the \tcode{totalOrder} operation
   as specified in ISO/IEC/IEEE 60599.
@@ -4991,7 +4991,7 @@ is expression-equivalent\iref{defns.expression-equivalent} to the following:
   is a floating-point type,
   yields a value of type \tcode{weak_ordering}
   that is consistent with the ordering
-  observed by \tcode{T}’s comparison operators and \tcode{strong_order}, and
+  observed by \tcode{T}'s comparison operators and \tcode{strong_order}, and
   if \tcode{numeric_limits<T>::is_iec559} is \tcode{true},
   is additionally consistent with the following equivalence classes,
   ordered from lesser to greater:


### PR DESCRIPTION
For consistency with the rest of the document.