### PR TITLE
[char.traits.specializations.char8.t] Align member typedefs.

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -317,10 +317,10 @@ returns
 \begin{codeblock}
 namespace std {
   template<> struct char_traits<char8_t> {
-    using char_type = char8_t;
-    using int_type = unsigned int;
-    using off_type = streamoff;
-    using pos_type = u8streampos;
+    using char_type  = char8_t;
+    using int_type   = unsigned int;
+    using off_type   = streamoff;
+    using pos_type   = u8streampos;
     using state_type = mbstate_t;
     using comparison_category = strong_ordering;
 


### PR DESCRIPTION
Fixes #3108.