### PR TITLE
Library-wide: don't use "for some" to mean "for an arbitrary"

### DIFF
--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -336,10 +336,9 @@ To test(From (&f)()) {
   return f();
 }
 \end{codeblock}
-for some types \tcode{From} and \tcode{To},
 and let \tcode{f} be a function with no arguments and return type \tcode{From}
 such that \tcode{f()} is equality-preserving.
-\tcode{From} and \tcode{To} model \tcode{\libconcept{convertible_to}<From, To>}
+Types \tcode{From} and \tcode{To} model \tcode{\libconcept{convertible_to}<From, To>}
 only if:
 
 \begin{itemize}
@@ -572,7 +571,7 @@ if the operation modifies neither \tcode{t2} nor \tcode{u2} and:
 \indexlibraryglobal{ranges::swap}%
 The name \tcode{ranges::swap} denotes a customization point
 object\iref{customization.point.object}. The expression
-\tcode{ranges::swap(E1, E2)} for some subexpressions \tcode{E1}
+\tcode{ranges::swap(E1, E2)} for subexpressions \tcode{E1}
 and \tcode{E2} is expression-equivalent to an expression
 \tcode{S} determined as follows:
 
@@ -847,7 +846,7 @@ template<class B>
 \end{itemdecl}
 
 \pnum
-For some type \tcode{B}, let \tcode{b1} and \tcode{b2} be
+Given a type \tcode{B}, let \tcode{b1} and \tcode{b2} be
 lvalues of type \tcode{const remove_reference_t<B>}.
 \tcode{B} models \libconcept{boolean} only if
 
@@ -893,7 +892,7 @@ template<class T, class U>
 
 \begin{itemdescr}
 \pnum
-For some types \tcode{T} and \tcode{U},
+Given types \tcode{T} and \tcode{U},
 let \tcode{t} and \tcode{u} be lvalues of types
 \tcode{const remove_reference_t<T>} and
 \tcode{const remove_reference_t<U>} respectively.
@@ -941,7 +940,7 @@ template<class T, class U>
 
 \begin{itemdescr}
 \pnum
-For some types \tcode{T} and \tcode{U},
+Given types \tcode{T} and \tcode{U},
 let \tcode{t} be an lvalue of type \tcode{const remove_reference_t<T>},
 \tcode{u} be an lvalue of type \tcode{const remove_reference_t<U>},
 and \tcode{C} be:
@@ -970,7 +969,7 @@ template<class T>
 
 \begin{itemdescr}
 \pnum
-For some type \tcode{T}, let \tcode{a}, \tcode{b}, and \tcode{c} be
+Given a type \tcode{T}, let \tcode{a}, \tcode{b}, and \tcode{c} be
 lvalues of type \tcode{const remove_reference_t<T>}.
 \tcode{T} models \libconcept{totally_ordered} only if
 
@@ -1011,7 +1010,7 @@ template<class T, class U>
 
 \begin{itemdescr}
 \pnum
-For some types \tcode{T} and \tcode{U},
+Given types \tcode{T} and \tcode{U},
 let \tcode{t} be an lvalue of type \tcode{const remove_reference_t<T>},
 \tcode{u} be an lvalue of type \tcode{const remove_reference_t<U>},
 and \tcode{C} be:

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1051,7 +1051,7 @@ void reverse(BI first, BI last) {
 \pnum
 The name \tcode{ranges::iter_move} denotes
 a customization point object\iref{customization.point.object}.
-The expression \tcode{ranges::\-iter_move(E)} for some subexpression \tcode{E} is
+The expression \tcode{ranges::\-iter_move(E)} for a subexpression \tcode{E} is
 expression-equivalent to:
 
 \begin{itemize}
@@ -1107,7 +1107,7 @@ return old_value;
 \end{itemdescr}
 
 \pnum
-The expression \tcode{ranges::iter_swap(E1, E2)} for some subexpressions
+The expression \tcode{ranges::iter_swap(E1, E2)} for subexpressions
 \tcode{E1} and \tcode{E2} is expression-equivalent to:
 \begin{itemize}
 \item \tcode{(void)iter_swap(E1, E2)}, if that expression is valid,

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -304,7 +304,7 @@ namespace std {
 \indextext{make-unigned-like@\exposid{make-unsigned-like}}%
 \indextext{make-unigned-like-t@\exposid{make-unsigned-like-t}}%
 Within this clause,
-for some integer-like type \tcode{X}\iref{iterator.concept.winc},
+for an integer-like type \tcode{X}\iref{iterator.concept.winc},
 \tcode{\placeholdernc{make-unsigned-like-t}(X)} denotes
 \tcode{make_unsigned_t<X>} if \tcode{X} is an integer type;
 otherwise, it denotes a corresponding unspecified unsigned-integer-like type
@@ -427,7 +427,7 @@ model \tcode{\libconcept{sentinel_for}<S, I>}.
 \pnum
 The name \tcode{ranges::cbegin} denotes a customization point
 object\iref{customization.point.object}. The expression
-\tcode{ranges::\brk{}cbegin(E)} for some subexpression \tcode{E} of type \tcode{T}
+\tcode{ranges::\brk{}cbegin(E)} for a subexpression \tcode{E} of type \tcode{T}
 is expression-equivalent to:
 \begin{itemize}
 \item \tcode{ranges::begin(static_cast<const T\&>(E))} if \tcode{E} is an lvalue.
@@ -444,7 +444,7 @@ Whenever \tcode{ranges::cbegin(E)} is a valid expression, its type models
 \pnum
 The name \tcode{ranges::cend} denotes a customization point
 object\iref{customization.point.object}. The expression
-\tcode{ranges::cend(E)} for some subexpression \tcode{E} of type \tcode{T}
+\tcode{ranges::cend(E)} for a subexpression \tcode{E} of type \tcode{T}
 is expression-equivalent to:
 \begin{itemize}
 \item \tcode{ranges::end(static_cast<const T\&>(E))} if \tcode{E} is an lvalue.
@@ -566,7 +566,7 @@ model \tcode{\libconcept{sentinel_for}<S, I>}.
 \pnum
 The name \tcode{ranges::crbegin} denotes a customization point
 object\iref{customization.point.object}. The expression
-\tcode{ranges::\brk{}crbegin(E)} for some subexpression \tcode{E} of type
+\tcode{ranges::\brk{}crbegin(E)} for a subexpression \tcode{E} of type
 \tcode{T} is expression-equivalent to:
 \begin{itemize}
 \item \tcode{ranges::\brk{}rbegin(static_cast<const T\&>(E))} if \tcode{E} is
@@ -584,7 +584,7 @@ type models \libconcept{input_or_output_iterator}.
 \pnum
 The name \tcode{ranges::crend} denotes a customization point
 object\iref{customization.point.object}. The expression
-\tcode{ranges::\brk{}crend(E)} for some subexpression \tcode{E} of type \tcode{T}
+\tcode{ranges::\brk{}crend(E)} for a subexpression \tcode{E} of type \tcode{T}
 is expression-equivalent to:
 \begin{itemize}
 \item \tcode{ranges::rend(static_cast<const T\&>(E))} if \tcode{E} is an lvalue.
@@ -604,7 +604,7 @@ model \tcode{\libconcept{sentinel_for}<S, I>}.
 \pnum
 The name \tcode{size} denotes a customization point
 object\iref{customization.point.object}. The expression
-\tcode{ranges::size(E)} for some subexpression \tcode{E} with type
+\tcode{ranges::size(E)} for a subexpression \tcode{E} of type
 \tcode{T} is expression-equivalent to:
 \begin{itemize}
 \item
@@ -660,7 +660,7 @@ type is integer-like.
 \pnum
 The name \tcode{empty} denotes a customization point
 object\iref{customization.point.object}. The expression
-\tcode{ranges::empty(E)} for some subexpression \tcode{E} is
+\tcode{ranges::empty(E)} for a subexpression \tcode{E} is
 expression-equivalent to:
 \begin{itemize}
 \item
@@ -694,7 +694,7 @@ it has type \tcode{bool}.
 \pnum
 The name \tcode{data} denotes a customization point
 object\iref{customization.point.object}. The expression
-\tcode{ranges::data(E)} for some subexpression \tcode{E} is
+\tcode{ranges::data(E)} for a subexpression \tcode{E} is
 expression-equivalent to:
 \begin{itemize}
 \item
@@ -724,7 +724,7 @@ has pointer to object type.
 \pnum
 The name \tcode{cdata} denotes a customization point
 object\iref{customization.point.object}. The expression
-\tcode{ranges::cdata(E)} for some subexpression \tcode{E} of type \tcode{T}
+\tcode{ranges::cdata(E)} for a subexpression \tcode{E} of type \tcode{T}
 is expression-equivalent to:
 \begin{itemize}
 \item \tcode{ranges::data(static_cast<const T\&>(E))} if \tcode{E} is an lvalue.
@@ -1740,7 +1740,7 @@ exactly one element of a specified value.
 \pnum
 The name \tcode{views::single} denotes a
 customization point object\iref{customization.point.object}.
-For some subexpression \tcode{E}, the expression
+Given a subexpression \tcode{E}, the expression
 \tcode{views::single(E)} is expression-equivalent to
 \tcode{single_view\{E\}}.
 
@@ -1875,7 +1875,7 @@ sequence of elements by repeatedly incrementing an initial value.
 \pnum
 The name \tcode{views::iota} denotes a
 customization point object\iref{customization.point.object}.
-For some subexpressions \tcode{E} and \tcode{F}, the expressions
+Given subexpressions \tcode{E} and \tcode{F}, the expressions
 \tcode{views::iota(E)} and \tcode{views::iota(E, F)}
 are expression-equivalent to
 \tcode{iota_view\{E\}} and \tcode{iota_view\{E, F\}}, respectively.
@@ -2891,7 +2891,7 @@ its \libconcept{range} argument.
 \pnum
 The name \tcode{views::all} denotes a
 range adaptor object\iref{range.adaptor.object}.
-For some subexpression \tcode{E}, the expression
+Given a subexpression \tcode{E}, the expression
 \tcode{views::all(E)} is expression-equivalent to:
 \begin{itemize}
 \item \tcode{\placeholdernc{decay-copy}(E)} if the decayed type of \tcode{E}
@@ -2979,7 +2979,7 @@ of an underlying sequence that satisfy a predicate.
 \pnum
 The name \tcode{views::filter} denotes a
 range adaptor object\iref{range.adaptor.object}.
-For some subexpressions \tcode{E} and \tcode{P},
+Given subexpressions \tcode{E} and \tcode{P},
 the expression \tcode{views::filter(E, P)} is expression-equivalent to
 \tcode{filter_view\{E, P\}}.
 
@@ -3400,7 +3400,7 @@ applying a transformation function to each element.
 \pnum
 The name \tcode{views::transform} denotes a
 range adaptor object\iref{range.adaptor.object}.
-For some subexpressions \tcode{E} and \tcode{F}, the expression
+Given subexpressions \tcode{E} and \tcode{F}, the expression
 \tcode{views::transform(E, F)} is expression-equivalent to
 \tcode{transform_view\{E, F\}}.
 
@@ -4091,7 +4091,7 @@ from another \libconcept{view}, or all the elements if the adapted
 \pnum
 The name \tcode{views::take} denotes a
 range adaptor object\iref{range.adaptor.object}.
-For some subexpressions \tcode{E} and \tcode{F}, the expression
+Given subexpressions \tcode{E} and \tcode{F}, the expression
 \tcode{views::take(E, F)} is expression-equivalent to
 \tcode{take_view\{E, F\}}.
 
@@ -4298,7 +4298,7 @@ of the range \range{begin(r)}{ranges::find_if_not(r, pred)}.
 \pnum
 The name \tcode{views::take_while} denotes
 a range adaptor object\iref{range.adaptor.object}.
-For some subexpressions \tcode{E} and \tcode{F},
+Given subexpressions \tcode{E} and \tcode{F},
 the expression \tcode{views::take_while(E, F)}
 is expression-equivalent to \tcode{take_while_view\{E, F\}}.
 
@@ -4458,7 +4458,7 @@ an empty range if the adapted \tcode{view} contains fewer than $N$ elements.
 \pnum
 The name \tcode{views::drop} denotes
 a range adaptor object\iref{range.adaptor.object}.
-For some subexpressions \tcode{E} and \tcode{F},
+Given subexpressions \tcode{E} and \tcode{F},
 the expression \tcode{views::drop(E, F)}
 is expression-equivalent to \tcode{drop_view\{E, F\}}.
 
@@ -4583,7 +4583,7 @@ of the range \range{ranges::find_if_not(r, pred)}{ranges::end(r)}.
 \pnum
 The name \tcode{views::drop_while}
 denotes a range adaptor object\iref{range.adaptor.object}.
-For some subexpressions \tcode{E} and \tcode{F},
+Given subexpressions \tcode{E} and \tcode{F},
 the expression \tcode{views::drop_while(E, F)}
 is expression-equivalent to \tcode{drop_while_view\{E, F\}}.
 
@@ -4692,7 +4692,7 @@ would have quadratic iteration complexity.
 \pnum
 The name \tcode{views::join} denotes a
 range adaptor object\iref{range.adaptor.object}.
-For some subexpression \tcode{E}, the expression
+Given a subexpression \tcode{E}, the expression
 \tcode{views::join(E)} is expression-equivalent to
 \tcode{join_view\{E\}}.
 
@@ -5182,7 +5182,7 @@ a single element or a \libconcept{view} of elements.
 \pnum
 The name \tcode{views::split} denotes a
 range adaptor object\iref{range.adaptor.object}.
-For some subexpressions \tcode{E} and \tcode{F},
+Given subexpressions \tcode{E} and \tcode{F},
 the expression \tcode{views::split(E, F)} is expression-equivalent to
 \tcode{split_view\{E, F\}}.
 
@@ -5699,7 +5699,7 @@ Equivalent to
 \indextext{range!counted}%
 A counted view presents a \libconcept{view} of the elements
 of the counted range\iref{iterator.requirements.general} \countedrange{i}{n}
-for some iterator \tcode{i} and non-negative integer \tcode{n}.
+for an iterator \tcode{i} and non-negative integer \tcode{n}.
 
 \pnum
 The name \tcode{views::counted} denotes a
@@ -5742,7 +5742,7 @@ a range's iterator and sentinel types to be the same.
 \pnum
 The name \tcode{views::common} denotes a
 range adaptor object\iref{range.adaptor.object}.
-For some subexpression \tcode{E},
+Given a subexpression \tcode{E},
 the expression \tcode{views::common(E)} is expression-equivalent to:
 \begin{itemize}
 \item \tcode{views::all(E)},
@@ -5870,7 +5870,7 @@ another \libconcept{view} that iterates the same elements in reverse order.
 \pnum
 The name \tcode{views::reverse} denotes a
 range adaptor object\iref{range.adaptor.object}.
-For some subexpression \tcode{E}, the expression
+Given a subexpression \tcode{E}, the expression
 \tcode{views::reverse(E)} is expression-equivalent to:
 \begin{itemize}
 \item
@@ -6039,7 +6039,7 @@ of the adapted \tcode{view}'s value-type.
 \pnum
 The name \tcode{views::elements<N>} denotes
 a range adaptor object\iref{range.adaptor.object}.
-For some subexpression \tcode{E} and constant expression \tcode{N},
+Given a subexpression \tcode{E} and constant expression \tcode{N},
 the expression \tcode{views::elements<N>(E)} is expression-equivalent to
 \tcode{elements_view<all_view<decltype((E))>, N>\{E\}}.
 

--- a/source/support.tex
+++ b/source/support.tex
@@ -4731,8 +4731,8 @@ are equality-preserving\iref{concepts.equality}.
 \pnum
 The name \tcode{strong_order} denotes
 a customization point object\iref{customization.point.object}.
-The expression \tcode{strong_order(E, F)}
-for some subexpressions \tcode{E} and \tcode{F}
+Given subexpressions \tcode{E} and \tcode{F},
+the expression \tcode{strong_order(E, F)}
 is expression-equivalent\iref{defns.expression-equivalent} to the following:
 \begin{itemize}
 \item
@@ -4767,8 +4767,8 @@ is expression-equivalent\iref{defns.expression-equivalent} to the following:
 \pnum
 The name \tcode{weak_order} denotes
 a customization point object\iref{customization.point.object}.
-The expression \tcode{weak_order(E, F)}
-for some subexpressions \tcode{E} and \tcode{F}
+Given subexpressions \tcode{E} and \tcode{F},
+the expression \tcode{weak_order(E, F)}
 is expression-equivalent\iref{defns.expression-equivalent} to the following:
 \begin{itemize}
 \item
@@ -4817,8 +4817,8 @@ is expression-equivalent\iref{defns.expression-equivalent} to the following:
 \pnum
 The name \tcode{partial_order} denotes
 a customization point object\iref{customization.point.object}.
-The expression \tcode{partial_order(E, F)}
-for some subexpressions \tcode{E} and \tcode{F}
+Given subexpressions \tcode{E} and \tcode{F},
+the expression \tcode{partial_order(E, F)}
 is expression-equivalent\iref{defns.expression-equivalent} to the following:
 \begin{itemize}
 \item
@@ -4848,8 +4848,8 @@ is expression-equivalent\iref{defns.expression-equivalent} to the following:
 \pnum
 The name \tcode{compare_strong_order_fallback}
 denotes a customization point object\iref{customization.point.object}.
-The expression \tcode{compare_strong_order_fallback(E, F)}
-for some subexpressions \tcode{E} and \tcode{F}
+Given subexpressions \tcode{E} and {F},
+the expression \tcode{compare_strong_order_fallback(E, F)}
 is expression-equivalent\iref{defns.expression-equivalent} to:
 \begin{itemize}
 \item
@@ -4874,8 +4874,8 @@ Otherwise, \tcode{compare_strong_order_fallback(E, F)} is ill-formed.
 \pnum
 The name \tcode{compare_weak_order_fallback} denotes
 a customization point object\iref{customization.point.object}.
-The expression \tcode{compare_weak_order_fallback(E, F)}
-for some subexpressions \tcode{E} and \tcode{F}
+Given subexpressions \tcode{E} and \tcode{F},
+the expression \tcode{compare_weak_order_fallback(E, F)}
 is expression-equivalent\iref{defns.expression-equivalent} to:
 \begin{itemize}
 \item
@@ -4900,8 +4900,8 @@ except that \tcode{E} and \tcode{F} are evaluated only once.
 \pnum
 The name \tcode{compare_partial_order_fallback} denotes
 a customization point object\iref{customization.point.object}.
-The expression \tcode{compare_partial_order_fallback(E, F)}
-for some subexpressions \tcode{E} and \tcode{F}
+Given subexpressions \tcode{E} and \tcode{F},
+the expression \tcode{compare_partial_order_fallback(E, F)}
 is expression-equivalent\iref{defns.expression-equivalent} to:
 \begin{itemize}
 \item


### PR DESCRIPTION
Affects: [cmp.alg], [concept.convertibleto], [concept.swappable], [concept.boolean], [concept.equalitycomparable], [concept.stricttotallyordered], [iterator.cust.move], [iterator.cust.swap], and many subclauses of [ranges]

Fixes #3136.