### PR TITLE
[intro.multithread,util.smartptr,atomics] Group index entries for 'at…

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -645,8 +645,8 @@ processes. \end{note}
 \rSec1[atomics.wait]{Waiting and notifying}
 
 \pnum
-\defnx{Atomic waiting operations}{atomic waiting operation}
-and \defnx{atomic notifying operations}{atomic notifying operation}
+\defnx{Atomic waiting operations}{atomic!waiting operation}
+and \defnx{atomic notifying operations}{atomic!notifying operation}
 provide a mechanism to wait for the value of an atomic object to change
 more efficiently than can be achieved with polling.
 An atomic waiting operation may block until it is unblocked
@@ -681,6 +681,7 @@ The following functions are atomic notifying operations:
 \end{itemize}
 \end{note}
 
+\indextext{atomic!waiting operation!eligible to be unblocked}%
 \pnum
 A call to an atomic waiting operation on an atomic object \tcode{M}
 is \defn{eligible to be unblocked}

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5441,7 +5441,7 @@ signal handler is usually unsequenced with respect to the rest of the program.
 
 \pnum
 \indextext{threads!multiple|(}%
-\indextext{operation!atomic|(}%
+\indextext{atomic!operation|(}%
 A \defn{thread of execution} (also known as a \defn{thread}) is a single flow of
 control within a program, including the initial invocation of a specific
 top-level function, and recursively including every function invocation
@@ -6022,7 +6022,7 @@ thread of execution whose too-weak progress guarantee is preventing overall prog
 An implementation should ensure that the last value (in modification order)
 assigned by an atomic or synchronization operation will become visible to all
 other threads in a finite period of time.%
-\indextext{operation!atomic|)}%
+\indextext{atomic!operation|)}%
 \indextext{threads!multiple|)}
 
 \rSec2[basic.start]{Start and termination}

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -363,7 +363,6 @@ semantic rules, and the one-definition rule\iref{basic.def.odr}%
 \indextext{observable behavior|see{behavior, observable}}%
 \indextext{precedence of operator|see{operator, precedence of}}%
 \indextext{order of evaluation in expression|see{expression, order of evaluation of}}%
-\indextext{atomic operations|see{operation, atomic}}%
 \indextext{multiple threads|see{threads, multiple}}%
 \rSec1[intro.compliance]{Implementation compliance}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -11414,7 +11414,7 @@ the same value as \tcode{hash<typename shared_ptr<T>::element_type*>()(p.get())}
 \end{itemdescr}%
 \indextext{smart pointers|)}
 
-\indextext{atomic smart pointers|(}%
+\indextext{atomic!smart pointers|(}%
 \rSec2[util.smartptr.atomic]{Atomic specializations for smart pointers}
 
 \pnum
@@ -12058,7 +12058,7 @@ that are eligible to be unblocked\iref{atomics.wait} by this call.
 \remarks
 This function is an atomic notifying operation\iref{atomics.wait}.
 \end{itemdescr}
-\indextext{atomic smart pointers|)}
+\indextext{atomic!smart pointers|)}
 
 \rSec1[mem.res]{Memory resources}
 


### PR DESCRIPTION
…omic'.

Fixes #3132.