### PR TITLE
[std] Harmonize cross-references for explicit casts.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3850,7 +3850,8 @@ because indirection through pointers to memory allocated by \tcode{std::malloc} 
 value;
 
 \item the result of a well-defined pointer
-conversion~(\ref{conv.ptr}, \ref{expr.cast}) of a safely-derived pointer value;
+conversion~(\ref{conv.ptr}, \ref{expr.type.conv}, \ref{expr.static.cast},
+\ref{expr.cast}) of a safely-derived pointer value;
 
 \item the result of a \tcode{reinterpret_cast} of a safely-derived pointer value;
 
@@ -4829,7 +4830,8 @@ A type \cv{}~\tcode{void}
 is an incomplete type that cannot be completed; such a type has
 an empty set of values. It is used as the return
 type for functions that do not return a value. Any expression can be
-explicitly converted to type \cv{}~\tcode{void}\iref{expr.cast}.
+explicitly converted to type \cv{}~\tcode{void}~(\ref{expr.type.conv},
+\ref{expr.static.cast}, \ref{expr.cast}).
 An expression of type \cv{}~\tcode{void} shall
 be used only as an expression statement\iref{stmt.expr}, as an operand
 of a comma expression\iref{expr.comma}, as a second or third operand

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -2472,7 +2472,8 @@ These conversions are called
 \defnx{user-defined conversions}{conversion!user-defined}
 and are used for implicit type conversions\iref{conv},
 for initialization\iref{dcl.init},
-and for explicit type conversions~(\ref{expr.cast}, \ref{expr.static.cast}).
+and for explicit type conversions~(\ref{expr.type.conv}, \ref{expr.cast},
+\ref{expr.static.cast}).
 
 \pnum
 User-defined conversions are applied only where they are unambiguous~(\ref{class.member.lookup}, \ref{class.conv.fct}).
@@ -4840,7 +4841,9 @@ and
 \begin{note}
 A member of a private base class might be inaccessible as an inherited
 member name, but accessible directly.
-Because of the rules on pointer conversions\iref{conv.ptr} and explicit casts\iref{expr.cast}, a conversion from a pointer to a derived class to a pointer
+Because of the rules on pointer conversions\iref{conv.ptr} and
+explicit casts~(\ref{expr.type.conv}, \ref{expr.static.cast}, \ref{expr.cast}),
+a conversion from a pointer to a derived class to a pointer
 to an inaccessible base class might be ill-formed if an implicit conversion
 is used, but well-formed if an explicit cast is used.
 For example,

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -9025,7 +9025,7 @@ A \defnadj{nodiscard}{call} is either
   whose return type is a nodiscard type, or
 \item
   an explicit type
-  conversion~(\ref{expr.static.cast}, \ref{expr.cast}, \ref{expr.type.conv})
+  conversion~(\ref{expr.type.conv}, \ref{expr.static.cast}, \ref{expr.cast})
   that constructs an object through
   a constructor declared \tcode{nodiscard} in a reachable declaration, or
   that initializes an object of a nodiscard type.

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -121,8 +121,8 @@ The values of the floating operands and the results of floating
 expressions may be represented in greater precision and range than that
 required by the type; the types are not changed\
 thereby.\footnote{The cast and assignment operators must still perform their specific
-conversions as described in~\ref{expr.cast}, \ref{expr.static.cast}
-and~\ref{expr.ass}.}
+conversions as described in~\ref{expr.type.conv}, \ref{expr.cast},
+\ref{expr.static.cast} and~\ref{expr.ass}.}
 
 \rSec1[expr.prop]{Properties of expressions}
 
@@ -177,8 +177,8 @@ An expression is an xvalue if it is:
 whose return type is an rvalue reference to object type\iref{expr.call},
 
 \item a cast to an rvalue reference to object type
-(\ref{expr.dynamic.cast}, \ref{expr.static.cast}, \ref{expr.reinterpret.cast},
-\ref{expr.const.cast}, \ref{expr.cast}),
+(\ref{expr.type.conv}, \ref{expr.dynamic.cast}, \ref{expr.static.cast}
+\ref{expr.reinterpret.cast}, \ref{expr.const.cast}, \ref{expr.cast}),
 
 \item a subscripting operation with an xvalue array operand\iref{expr.sub},
 


### PR DESCRIPTION
Fixes #2976.