### PR TITLE
Lost changes to P1754R1 (LWG Motion 11)

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -2867,7 +2867,7 @@ template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<
 \begin{itemdescr}
 \pnum
 \expects
-Either \tcode{assignable_from<I\&, S> || sized_sentinel_for<S, I>} is modeled, or
+Either \tcode{\libconcept{assignable_from}<I\&, S> || \libconcept{sized_sentinel_for}<S, I>} is modeled, or
 \range{i}{bound} denotes a range.
 
 \pnum

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1150,7 +1150,7 @@ that satisfy but do not in fact model \libconcept{sized_range}.
 The \libconcept{view} concept specifies the requirements of a \libconcept{range} type
 that has constant time move construction, move assignment, and destruction;
 that is, the cost of these operations is
-independent of the number of elements in the \tcode{view}.
+independent of the number of elements in the \libconcept{view}.
 
 \begin{itemdecl}
 template<class T>
@@ -1182,7 +1182,7 @@ template<class T>
 
 \pnum
 \begin{example}
-Examples of \tcode{view}s are:
+Examples of \libconcept{view}s are:
 \begin{itemize}
 \item A \libconcept{range} type that wraps a pair of iterators.
 
@@ -1331,7 +1331,7 @@ template<class T, class U>
 
 \pnum
 The class template \tcode{view_interface} is a helper for defining
-\tcode{view}-like types that offer a container-like interface. It is
+\libconcept{view}-like types that offer a container-like interface. It is
 parameterized with the type that is derived from it.
 
 \indexlibraryglobal{view_interface}%
@@ -3081,7 +3081,7 @@ models \libconcept{view}.
 \rSec3[range.ref.view]{Class template \tcode{ref_view}}
 
 \pnum
-\tcode{ref_view} is a \tcode{view} of the elements of some other \tcode{range}.
+\tcode{ref_view} is a \libconcept{view} of the elements of some other \libconcept{range}.
 \indexlibraryglobal{ref_view}%
 \begin{codeblock}
 namespace std::ranges {
@@ -4495,8 +4495,8 @@ Equivalent to:
 \rSec3[range.take.while.overview]{Overview}
 
 \pnum
-Given a unary predicate \tcode{pred} and a \tcode{view} \tcode{r},
-\tcode{take_while_view} produces a \tcode{view}
+Given a unary predicate \tcode{pred} and a \libconcept{view} \tcode{r},
+\tcode{take_while_view} produces a \libconcept{view}
 of the range \range{begin(r)}{ranges::find_if_not(r, pred)}.
 
 \indexlibraryglobal{take_while}%
@@ -4672,9 +4672,9 @@ Equivalent to:
 \rSec3[range.drop.overview]{Overview}
 
 \pnum
-\tcode{drop_view} produces a \tcode{view}
-excluding the first $N$ elements from another \tcode{view}, or
-an empty range if the adapted \tcode{view} contains fewer than $N$ elements.
+\tcode{drop_view} produces a \libconcept{view}
+excluding the first $N$ elements from another \libconcept{view}, or
+an empty range if the adapted \libconcept{view} contains fewer than $N$ elements.
 
 \pnum
 The name \tcode{views::drop} denotes
@@ -4811,7 +4811,7 @@ constexpr auto begin() const
 \pnum
 \remarks
 In order to provide the amortized constant-time complexity required
-by the \tcode{range} concept
+by the \libconcept{range} concept
 when \tcode{drop_view} models \libconcept{forward_range},
 the first overload caches the result within the \tcode{drop_view}
 for use on subsequent calls.
@@ -4827,8 +4827,8 @@ would have quadratic iteration complexity.
 \rSec3[range.drop.while.overview]{Overview}
 
 \pnum
-Given a unary predicate \tcode{pred} and a \tcode{view} \tcode{r},
-\tcode{drop_while_view} produces a \tcode{view}
+Given a unary predicate \tcode{pred} and a \libconcept{view} \tcode{r},
+\tcode{drop_while_view} produces a \libconcept{view}
 of the range \range{ranges::find_if_not(r, pred)}{ranges::end(r)}.
 
 \pnum
@@ -4921,8 +4921,8 @@ constexpr auto begin();
 \pnum
 \remarks
 In order to provide the amortized constant-time complexity
-required by the \tcode{range} concept
-when \tcode{drop_while_view} models \tcode{forward_range},
+required by the \libconcept{range} concept
+when \tcode{drop_while_view} models \libconcept{forward_range},
 the first call caches the result within the \tcode{drop_while_view}
 for use on subsequent calls.
 \begin{note}
@@ -6234,9 +6234,9 @@ Equivalent to: \tcode{return make_reverse_iterator(ranges::begin(base_));}
 
 \pnum
 \tcode{elements_view} takes
-a \tcode{view} of tuple-like values and a \tcode{size_t}, and
-produces a \tcode{view} with a value-type of the $N^\text{th}$ element
-of the adapted \tcode{view}'s value-type.
+a \libconcept{view} of tuple-like values and a \tcode{size_t}, and
+produces a \libconcept{view} with a value-type of the $N^\text{th}$ element
+of the adapted \libconcept{view}'s value-type.
 
 \pnum
 The name \tcode{views::elements<N>} denotes

--- a/source/support.tex
+++ b/source/support.tex
@@ -4675,7 +4675,7 @@ This is \tcode{std::strong_ordering} if the expansion is empty.
 \end{note}
 \end{itemdescr}
 
-\rSec2[cmp.concept]{Concept \tcode{three_way_comparable}}
+\rSec2[cmp.concept]{Concept \libconcept{three_way_comparable}}
 
 \begin{codeblock}
 template<class T, class Cat>

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -14120,7 +14120,7 @@ resolves to a built-in operator comparing pointers.
 \begin{codeblock}
 struct compare_three_way {
   template<class T, class U>
-    requires three_way_comparable_with<T, U> || @\placeholdernc{BUILTIN-PTR-THREE-WAY}@(T, U)
+    requires @\libconcept{three_way_comparable_with}@<T, U> || @\placeholdernc{BUILTIN-PTR-THREE-WAY}@(T, U)
   constexpr auto operator()(T&& t, U&& u) const;
 
   using is_transparent = @\unspec@;
@@ -14129,7 +14129,7 @@ struct compare_three_way {
 
 \begin{itemdecl}
 template<class T, class U>
-  requires three_way_comparable_with<T, U> || @\placeholdernc{BUILTIN-PTR-THREE-WAY}@(T, U)
+  requires @\libconcept{three_way_comparable_with}@<T, U> || @\placeholdernc{BUILTIN-PTR-THREE-WAY}@(T, U)
 constexpr auto operator()(T&& t, U&& u) const;
 \end{itemdecl}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -14121,7 +14121,7 @@ resolves to a built-in operator comparing pointers.
 struct compare_three_way {
   template<class T, class U>
     requires @\libconcept{three_way_comparable_with}@<T, U> || @\placeholdernc{BUILTIN-PTR-THREE-WAY}@(T, U)
-  constexpr auto operator()(T&& t, U&& u) const;
+    constexpr auto operator()(T&& t, U&& u) const;
 
   using is_transparent = @\unspec@;
 };
@@ -14130,7 +14130,7 @@ struct compare_three_way {
 \begin{itemdecl}
 template<class T, class U>
   requires @\libconcept{three_way_comparable_with}@<T, U> || @\placeholdernc{BUILTIN-PTR-THREE-WAY}@(T, U)
-constexpr auto operator()(T&& t, U&& u) const;
+  constexpr auto operator()(T&& t, U&& u) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -14174,7 +14174,7 @@ operator comparing pointers.
 struct ranges::equal_to {
   template<class T, class U>
     requires equality_comparable_with<T, U> || @\placeholdernc{BUILTIN-PTR-CMP}@(T, ==, U)
-  constexpr bool operator()(T&& t, U&& u) const;
+    constexpr bool operator()(T&& t, U&& u) const;
 
   using is_transparent = @\unspecnc@;
 };
@@ -14209,7 +14209,7 @@ are equality-preserving\iref{concepts.equality}.
 struct ranges::not_equal_to {
   template<class T, class U>
     requires equality_comparable_with<T, U> || @\placeholdernc{BUILTIN-PTR-CMP}@(T, ==, U)
-  constexpr bool operator()(T&& t, U&& u) const;
+    constexpr bool operator()(T&& t, U&& u) const;
 
   using is_transparent = @\unspecnc@;
 };
@@ -14247,7 +14247,7 @@ return ranges::less{}(std::forward<U>(u), std::forward<T>(t));
 struct ranges::less {
   template<class T, class U>
     requires @\libconcept{totally_ordered_with}@<T, U> || @\placeholdernc{BUILTIN-PTR-CMP}@(T, <, U)
-  constexpr bool operator()(T&& t, U&& u) const;
+    constexpr bool operator()(T&& t, U&& u) const;
 
   using is_transparent = @\unspecnc@;
 };
@@ -14288,7 +14288,7 @@ Otherwise, equivalent to:
 struct ranges::greater_equal {
   template<class T, class U>
     requires @\libconcept{totally_ordered_with}@<T, U> || @\placeholdernc{BUILTIN-PTR-CMP}@(T, <, U)
-  constexpr bool operator()(T&& t, U&& u) const;
+    constexpr bool operator()(T&& t, U&& u) const;
 
   using is_transparent = @\unspecnc@;
 };
@@ -14307,7 +14307,7 @@ return !ranges::less{}(std::forward<T>(t), std::forward<U>(u));
 struct ranges::less_equal {
   template<class T, class U>
     requires @\libconcept{totally_ordered_with}@<T, U> || @\placeholdernc{BUILTIN-PTR-CMP}@(U, <, T)
-  constexpr bool operator()(T&& t, U&& u) const;
+    constexpr bool operator()(T&& t, U&& u) const;
 
   using is_transparent = @\unspecnc@;
 };


### PR DESCRIPTION
These fixes from branch motions-2019-07-lwg-11 were lost in the new branch motions-2019-07-lwg-11-rs.  The 2nd commit in this PR encodes additional but unconventional uses of concept names with \libconcept, but more work may still be needed - see related inline comments in PR #3149.

Update 2/25/21: Most of the changes in the original patch had already been fixed in master since this PR was created.  The rebased branch has been updated to include the few changes that remain in master.