### PR TITLE
[std] Hyphenate floating-point and avoid 'floating'.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -117,8 +117,9 @@ same result will occur.
 \end{note}
 
 \pnum
-The values of the floating operands and the results of floating
-expressions may be represented in greater precision and range than that
+The values of the floating-point operands and
+the results of floating-point expressions
+may be represented in greater precision and range than that
 required by the type; the types are not changed\
 thereby.\footnote{The cast and assignment operators must still perform their specific
 conversions as described in~\ref{expr.cast}, \ref{expr.static.cast}
@@ -5869,7 +5870,7 @@ Then:
 \begin{itemize}
 \item
 If a narrowing conversion\iref{dcl.init.list} is required,
-other than from an integral type to a floating point type,
+other than from an integral type to a floating-point type,
 the program is ill-formed.
 
 \item

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -1708,7 +1708,7 @@ that entity is characterized:
    if \tcode{numeric_limits<T>::is_integer} is \tcode{true};
  \item
    otherwise
-   as \term{floating} or equivalently as \term{real-valued}.
+   as \term{floating-point} or equivalently as \term{real-valued}.
 \end{itemize}
 \noindent
 If integer-valued,

--- a/source/time.tex
+++ b/source/time.tex
@@ -1955,7 +1955,7 @@ template<class charT, class traits, class Rep, class Period>
 \requires \tcode{Rep} is an integral type
 whose integer conversion rank\iref{conv.rank}
 is greater than or equal to that of \tcode{short},
-or a floating point type.
+or a floating-point type.
 \tcode{charT} is \tcode{char} or \tcode{wchar_t}.
 
 \pnum
@@ -9953,9 +9953,9 @@ Equivalent to \tcode{\%H:\%M}.
 Seconds as a decimal number.
 If the number of seconds is less than \tcode{10}, the result is prefixed with \tcode{0}.
 If the precision of the input cannot be exactly represented with seconds,
-then the format is a decimal floating point number with a fixed format
+then the format is a decimal floating-point number with a fixed format
 and a precision matching that of the precision of the input
-(or to a microseconds precision if the conversion to floating point decimal seconds
+(or to a microseconds precision if the conversion to floating-point decimal seconds
 cannot be made within 18 fractional digits).
 The character for the decimal point is localized according to the locale.
 The modified command \tcode{\%OS} produces


### PR DESCRIPTION
Partially addresses #3165.