### PR TITLE
[std] Rename 'floating literal' to 'floating-point literal'.

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1618,7 +1618,7 @@ the basic source character set.
 \grammarterm{pp-number} can contain \tcode{p} \grammarterm{sign} and
 \tcode{P} \grammarterm{sign}.
 \rationale
-Necessary to enable hexadecimal floating literals.
+Necessary to enable hexadecimal floating-point literals.
 \effect
 Valid \CppXIV{} code may fail to compile or produce different results in
 this International Standard. Specifically, character sequences like \tcode{0p+0}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1530,7 +1530,7 @@ void f() {
   C().C::~C();      // undefined behavior: temporary of type \tcode{C} destroyed twice
   using T = int;
   0 .T::~T();       // OK, no effect
-  0.T::~T();        // error: \tcode{0.T} is a \grammarterm{user-defined-floating-literal}\iref{lex.ext}
+  0.T::~T();        // error: \tcode{0.T} is a \grammarterm{user-defined-floating-point-literal}\iref{lex.ext}
 }
 \end{codeblock}
 \end{example}

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -13,8 +13,7 @@
 \indextext{digraph|see{token, alternative}}
 \indextext{integer literal|see{literal, integer}}
 \indextext{character literal|see{literal, character}}
-\indextext{floating literal|see{literal, floating}}
-\indextext{floating-point literal|see{literal, floating}}
+\indextext{floating-point literal|see{literal, floating-point}}
 \indextext{string literal|see{literal, string}}
 \indextext{boolean literal|see{literal, boolean}}
 \indextext{pointer literal|see{literal, pointer}}
@@ -387,12 +386,12 @@ has no associated grammar productions.
 \pnum
 \begin{example}
 The program fragment \tcode{0xe+foo} is parsed as a
-preprocessing number token (one that is not a valid floating or integer
+preprocessing number token (one that is not a valid integer or floating-point
 literal token), even though a parse as three preprocessing tokens
 \tcode{0xe}, \tcode{+}, and \tcode{foo} might produce a valid expression (for example,
 if \tcode{foo} were a macro defined as \tcode{1}). Similarly, the
 program fragment \tcode{1E1} is parsed as a preprocessing number (one
-that is a valid floating literal token), whether or not \tcode{E} is a
+that is a valid floating-point literal token), whether or not \tcode{E} is a
 macro name.
 \end{example}
 
@@ -575,12 +574,12 @@ depending on the implementation.}%
 
 \pnum
 Preprocessing number tokens lexically include all integer literal
-tokens\iref{lex.icon} and all floating literal
+tokens\iref{lex.icon} and all floating-point literal
 tokens\iref{lex.fcon}.
 
 \pnum
 A preprocessing number does not have a type or a value; it acquires both
-after a successful conversion to an integer literal token or a floating literal
+after a successful conversion to an integer literal token or a floating-point literal
 token.%
 \indextext{number!preprocessing|)}
 
@@ -905,7 +904,7 @@ ISO C. }
 \nontermdef{literal}\br
     integer-literal\br
     character-literal\br
-    floating-literal\br
+    floating-point-literal\br
     string-literal\br
     boolean-literal\br
     pointer-literal\br
@@ -1366,25 +1365,25 @@ the actual compiler implementation may use its own native character set,
 so long as the same results are obtained.
 \end{note}
 
-\rSec2[lex.fcon]{Floating literals}
+\rSec2[lex.fcon]{Floating-point literals}
 
-\indextext{literal!floating}%
+\indextext{literal!floating-point}%
 \begin{bnf}
-\nontermdef{floating-literal}\br
-    decimal-floating-literal\br
-    hexadecimal-floating-literal
+\nontermdef{floating-point-literal}\br
+    decimal-floating-point-literal\br
+    hexadecimal-floating-point-literal
 \end{bnf}
 
 \begin{bnf}
-\nontermdef{decimal-floating-literal}\br
-    fractional-constant \opt{exponent-part} \opt{floating-suffix}\br
-    digit-sequence exponent-part \opt{floating-suffix}
+\nontermdef{decimal-floating-point-literal}\br
+    fractional-constant \opt{exponent-part} \opt{floating-point-suffix}\br
+    digit-sequence exponent-part \opt{floating-point-suffix}
 \end{bnf}
 
 \begin{bnf}
-\nontermdef{hexadecimal-floating-literal}\br
-    hexadecimal-prefix hexadecimal-fractional-constant binary-exponent-part \opt{floating-suffix}\br
-    hexadecimal-prefix hexadecimal-digit-sequence binary-exponent-part \opt{floating-suffix}
+\nontermdef{hexadecimal-floating-point-literal}\br
+    hexadecimal-prefix hexadecimal-fractional-constant binary-exponent-part \opt{floating-point-suffix}\br
+    hexadecimal-prefix hexadecimal-digit-sequence binary-exponent-part \opt{floating-point-suffix}
 \end{bnf}
 
 \begin{bnf}
@@ -1423,13 +1422,13 @@ so long as the same results are obtained.
 \end{bnf}
 
 \begin{bnf}
-\nontermdef{floating-suffix} \textnormal{one of}\br
+\nontermdef{floating-point-suffix} \textnormal{one of}\br
     \terminal{f  l  F  L}
 \end{bnf}
 
 \pnum
-\indextext{literal!floating}%
-A floating literal consists of
+\indextext{literal!floating-point}%
+A floating-point literal consists of
 an optional prefix specifying a base,
 an integer part,
 a radix point,
@@ -1444,36 +1443,36 @@ an optional type suffix.
 The integer and fraction parts both consist of
 a sequence of decimal (base ten) digits if there is no prefix, or
 hexadecimal (base sixteen) digits if the prefix is \tcode{0x} or \tcode{0X}.
-The floating literal is a \defnadj{decimal floating}{literal} in the former case and
+The floating-point literal is a \defnadj{decimal floating-point}{literal} in the former case and
 a \defnadj{hexadecimal floating}{literal} in the latter case.
 Optional separating single quotes in
 a \grammarterm{digit-sequence} or \grammarterm{hexadecimal-digit-sequence}
 are ignored when determining its value.
 \begin{example}
-The floating literals \tcode{1.602'176'565e-19} and \tcode{1.602176565e-19}
+The floating-point literals \tcode{1.602'176'565e-19} and \tcode{1.602176565e-19}
 have the same value.
 \end{example}
 Either the integer part or the fraction part (not both) can be omitted.
 Either the radix point or the letter \tcode{e} or \tcode{E} and
-the exponent (not both) can be omitted from a decimal floating literal.
+the exponent (not both) can be omitted from a decimal floating-point literal.
 The radix point (but not the exponent) can be omitted
-from a hexadecimal floating literal.
+from a hexadecimal floating-point literal.
 The integer part, the optional radix point, and the optional fraction part,
-form the \defn{significand} of the floating literal.
-In a decimal floating literal, the exponent, if present,
+form the \defn{significand} of the floating-point literal.
+In a decimal floating-point literal, the exponent, if present,
 indicates the power of 10 by which the significand is to be scaled.
-In a hexadecimal floating literal, the exponent
+In a hexadecimal floating-point literal, the exponent
 indicates the power of 2 by which the significand is to be scaled.
 \begin{example}
-The floating literals \tcode{49.625} and \tcode{0xC.68p+2} have the same value.
+The floating-point literals \tcode{49.625} and \tcode{0xC.68p+2} have the same value.
 \end{example}
 If the scaled value is in
 the range of representable values for its type, the result is the scaled
 value if representable, else the larger or smaller representable value
 nearest the scaled value, chosen in an \impldef{choice of larger or smaller value of
-floating literal} manner.
+floating-point literal} manner.
 \indextext{literal!\idxcode{double}}%
-The type of a floating literal is \tcode{double}
+The type of a floating-point literal is \tcode{double}
 \indextext{literal!type of floating-point}%
 unless explicitly specified by a suffix.
 \indextext{literal!\idxcode{float}}%
@@ -1838,7 +1837,7 @@ and~\ref{conv.mem}.
 \begin{bnf}
 \nontermdef{user-defined-literal}\br
     user-defined-integer-literal\br
-    user-defined-floating-literal\br
+    user-defined-floating-point-literal\br
     user-defined-string-literal\br
     user-defined-character-literal
 \end{bnf}
@@ -1852,7 +1851,7 @@ and~\ref{conv.mem}.
 \end{bnf}
 
 \begin{bnf}
-\nontermdef{user-defined-floating-literal}\br
+\nontermdef{user-defined-floating-point-literal}\br
     fractional-constant \opt{exponent-part} ud-suffix\br
     digit-sequence exponent-part ud-suffix\br
     hexadecimal-prefix hexadecimal-fractional-constant binary-exponent-part ud-suffix\br
@@ -1928,7 +1927,7 @@ $c_1c_2...c_k$ can only contain characters from the basic source character set.
 \end{note}
 
 \pnum
-If \placeholder{L} is a \grammarterm{user-defined-floating-literal}, let \placeholder{f} be the
+If \placeholder{L} is a \grammarterm{user-defined-floating-point-literal}, let \placeholder{f} be the
 literal without its \grammarterm{ud-suffix}. If \placeholder{S} contains a literal operator
 with parameter type \tcode{long double}, the literal \placeholder{L} is treated as a call of
 the form


### PR DESCRIPTION
Fixes #3165.