### PR TITLE
Editing committee editing

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -968,8 +968,8 @@ into that scope.
 \pnum
 \begin{note}
 For point of instantiation of a template, see~\ref{temp.point}.
-\end{note}
-\indextext{scope!declarations and|)}
+\end{note}%
+\indextext{scope!declarations and|)}%
 \indextext{declaration!point of|)}
 
 \rSec2[basic.scope.block]{Block scope}

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -668,7 +668,7 @@ These requirements also apply to corresponding entities
 defined within each definition of \tcode{D}
 (including the closure types of \grammarterm{lambda-expression}{s},
 but excluding entities defined within default arguments or
-defualt template arguments of either \tcode{D} or
+default template arguments of either \tcode{D} or
 an entity not defined within \tcode{D}).
 For each such entity and for \tcode{D} itself,
 the behavior is as if there is a single entity with a single definition,
@@ -698,7 +698,7 @@ struct X {
   void h(bool cond, void (*p)() = []{}) {
     if (cond) h(false);
   }
-}
+};
 \end{codeblock}
 
 If the definition of \tcode{f} appears in multiple translation units,

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -546,8 +546,7 @@ There can be more than one definition of a
 \begin{itemize}
 \item class type\iref{class},
 \item enumeration type\iref{dcl.enum},
-\item inline function with external linkage\iref{dcl.inline},
-\item inline variable with external linkage\iref{dcl.inline},
+\item inline function or variable\iref{dcl.inline} with external linkage,
 \item class template\iref{temp},
 \item non-static function template\iref{temp.fct},
 \item concept\iref{temp.concept},
@@ -555,8 +554,9 @@ There can be more than one definition of a
 \item member function of a class template\iref{temp.mem.func},
 \item template specialization for which some template parameters are not
 specified~(\ref{temp.spec}, \ref{temp.class.spec}),
-\item default argument for a parameter (for a function in a given scope), or
-\item default template argument
+\item default argument for a parameter (for a function in a given scope)%
+\iref{dcl.fct.default}, or
+\item default template argument\iref{temp.param}
 \end{itemize}
 in a program provided that
 each definition appears in a different translation unit, and

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -6943,7 +6943,7 @@ the synthesized three-way comparison for comparison category type \tcode{R}
 between $\tcode{x}_i$ and $\tcode{y}_i$
 yields a result value $\tcode{v}_i$ where $\tcode{v}_i \mathrel{\tcode{!=}} 0$,
 contextually converted to \tcode{bool}, yields \tcode{true};
-\tcode{V} is $\tcode{v}_i$ converted to \tcode{R}.
+\tcode{V} is $\tcode{v}_i$.
 If no such index exists, \tcode{V} is
 \tcode{std::strong_ordering::equal} converted to \tcode{R}.
 

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1927,7 +1927,7 @@ that do not result in an odr-use.
 
 \diffref{dcl.typedef}
 \change Unnamed classes with a typedef name for linkage purposes
-can only contain C-compatible constructs.
+can contain only C-compatible constructs.
 \rationale Necessary for implementability.
 \effect Valid C++ 2017 code may be ill-formed in this International Standard.
 \begin{codeblock}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -8991,7 +8991,7 @@ may be applied to the \grammarterm{declarator-id}
 in a function declaration or to the declaration of a class or enumeration.
 It shall appear at most once in each \grammarterm{attribute-list}.
 An \grammarterm{attribute-argument-clause} may be present
-and, if present, it shall have the form:
+and, if present, shall have the form:
 
 \begin{ncbnf}
 \terminal{(} string-literal \terminal{)}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4906,7 +4906,7 @@ a call to an allocation function is always omitted.
 \begin{note}
 Only \grammarterm{new-expression}{s} that would otherwise result in
 a call to a replaceable global allocation function
-can be evaluated in constant expressions (see \ref{expr.const}).
+can be evaluated in constant expressions\iref{expr.const}.
 \end{note}
 
 \pnum

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6709,7 +6709,7 @@ is equivalent to \tcode{E1 = E1 \placeholder{op} E2} except
 that \tcode{E1} is evaluated only once.
 Such expressions are deprecated
 if \tcode{E1} has \tcode{volatile}-qualified type; see~\ref{depr.volatile.type}.
-In \tcode{+=} and \tcode{-=},
+For \tcode{+=} and \tcode{-=},
 \tcode{E1} shall either have arithmetic type or be a pointer to a
 possibly cv-qualified completely-defined object type. In all other
 cases, \tcode{E1} shall have arithmetic type.

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1283,10 +1283,10 @@ nor is the type required to be \libconcept{equality_comparable}.
 \indexlibrary{\idxcode{weakly_incrementable}}%
 \begin{codeblock}
 template<class T>
-  inline constexpr bool @\placeholder{is-integer-like}@ = @\seebelow@; @\itcorr[-2]@           // exposition only
+  inline constexpr bool @\placeholder{is-integer-like}@ = @\seebelow@; @\itcorr[-2]@           // \expos
 
 template<class T>
-  inline constexpr bool @\placeholder{is-signed-integer-like}@ = @\seebelow@; @\itcorr[-2]@    // exposition only
+  inline constexpr bool @\placeholder{is-signed-integer-like}@ = @\seebelow@; @\itcorr[-2]@    // \expos
 
 template<class I>
   concept weakly_incrementable =

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1389,11 +1389,13 @@ For every (possibly cv-qualified) integer-class type \tcode{I},
 
 \pnum
 A type \tcode{I} is \defn{integer-like}
-if it models \tcode{integral<I>} or if it is an integer-class type.
+if it models \tcode{\libconcept{integral}<I>} or
+if it is an integer-class type.
 A type \tcode{I} is \defn{signed-integer-like}
-if it models \tcode{signed_integral<I>} or if it is a signed-integer-class type.
+if it models \tcode{\libconcept{signed_integral}<I>} or
+if it is a signed-integer-class type.
 A type \tcode{I} is \defn{unsigned-integer-like}
-if it models \tcode{unsigned_integral<I>} or
+if it models \tcode{\libconcept{unsigned_integral}<I>} or
 if it is an unsigned-integer-class type.
 
 \pnum
@@ -1405,7 +1407,7 @@ if and only if I is a signed-integer-like type.
 \pnum
 Let \tcode{i} be an object of type \tcode{I}. When \tcode{i} is in the domain of
 both pre- and post-increment, \tcode{i} is said to be \term{incrementable}.
-\tcode{I} models \tcode{weakly_incrementable<I>} only if
+\tcode{I} models \tcode{\libconcept{weakly_incrementable}<I>} only if
 
 \begin{itemize}
 \item The expressions \tcode{++i} and \tcode{i++} have the same domain.

--- a/source/modules.tex
+++ b/source/modules.tex
@@ -908,7 +908,7 @@ in programs intending to be portable.
 
 \pnum
 A declaration $D$ is
-\defnx{reachable}{reachable!declaration}, if,
+\defnx{reachable}{reachable!declaration} if,
 for any point $P$ in the
 instantiation context\iref{module.context},
 \begin{itemize}

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -1549,7 +1549,8 @@ of the \grammarterm{deduction-guide}.
 \end{itemize}
 \end{itemize}
 In addition, if \tcode{C} is defined
-and its definition satisfies the conditions for an aggregate class
+and its definition satisfies the conditions for
+an aggregate class\iref{dcl.init.aggr}
 with the assumption that any dependent base class has
 no virtual functions and no virtual base classes, and
 the initializer is a non-empty \grammarterm{braced-init-list} or
@@ -1564,7 +1565,7 @@ of the \grammarterm{expression-list}.
 For each $x_i$, let $e_i$ be the corresponding element
 of \tcode{C} or of one of its (possibly recursive) subaggregates
 that would be initialized by $x_i$\iref{dcl.init.aggr}
-if brace elision is not considered for any subaggregate
+if brace elision is not considered for any element
 that has a dependent type.
 If there is no such element $e_i$, the program is ill-formed.
 The aggregate deduction candidate is derived as above

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -1727,14 +1727,9 @@ D d1 = {1, 2};                  // error: deduction failed
 D d2 = {1, 2, 3};               // OK, braces elided, deduces \tcode{D<int>}
 
 template <typename T>
-struct I {
-  using type = T;
-};
-
-template <typename T>
 struct E {
-  typename I<T>::type i;
   T t;
+  decltype(t) t2;
 };
 
 E e1 = {1, 2};                  // OK, deduces \tcode{E<int>}

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -1737,7 +1737,7 @@ struct E {
   T t;
 };
 
-E e1 = {1, 2};                  // OK, \tcode{E<int>} deduced
+E e1 = {1, 2};                  // OK, deduces \tcode{E<int>}
 \end{codeblock}
 \end{example}
 

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -2920,7 +2920,7 @@ or, if not that,
 \tcode{S1} and \tcode{S2} differ only
 in their qualification conversion\iref{conv.qual} and
 yield similar types \tcode{T1} and \tcode{T2}, respectively,
-where \tcode{T1} can be converted to \tcode{T2} by a qualification conversion
+where \tcode{T1} can be converted to \tcode{T2} by a qualification conversion.
 \begin{example}
 \begin{codeblock}
 int f(const volatile int *);

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -1777,7 +1777,7 @@ template<T, U>
 template<class V> requires deduces_A<C<V *, V *>>
   auto f1_prime(V *, V*) -> C<V *, V *>;
 
-// \tcode{f2} is formed the deduction-guide \#2 of \tcode{C}
+// \tcode{f2} is formed from the deduction-guide \#2 of \tcode{C}
 template<class T, class U> auto f2(T, U) -> C<T, std::type_identity_t<U>>;
 
 // Deducing arguments for \tcode{C<T, std::type_identity_t<U>>} from \tcode{C<V *, V*>} deduces \tcode{T} as \tcode{V *};

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -795,8 +795,8 @@ int c = Z;      // error: active macro definitions \#3 and \#5 are not valid red
 \nontermdef{pp-global-module-fragment}\br
     \terminal{module} \terminal{;} pp-balanced-token-seq \terminal{module}
 \end{bnf}
-\begin{bnf}
 
+\begin{bnf}
 \nontermdef{pp-balanced-token-seq}\br
     pp-balanced-token\br
     pp-balanced-token-seq pp-balanced-token

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -317,11 +317,13 @@ expression-equivalent to:
 \item
   Otherwise, if \tcode{E} is an lvalue,
   \tcode{\placeholdernc{decay-copy}(E.begin())}
-  if it is a valid expression and its type \tcode{I} models \tcode{input_or_output_iterator}.
+  if it is a valid expression and its type \tcode{I} models
+  \libconcept{input_or_output_iterator}.
 
 \item
   Otherwise, \tcode{\placeholdernc{decay-copy}(begin(E))} if it is a
-  valid expression and its type \tcode{I} models \tcode{input_or_output_iterator} with overload
+  valid expression and its type \tcode{I} models
+  \libconcept{input_or_output_iterator} with overload
   resolution performed in a context that includes the declarations:
   \begin{codeblock}
   template<class T> void begin(T&&) = delete;
@@ -409,7 +411,7 @@ is expression-equivalent to:
 \pnum
 \begin{note}
 Whenever \tcode{ranges::cbegin(E)} is a valid expression, its type models
-\tcode{input_or_output_iterator}.
+\libconcept{input_or_output_iterator}.
 \end{note}
 
 \rSec2[range.access.cend]{\tcode{ranges::cend}}
@@ -442,11 +444,13 @@ expression-equivalent to:
 \begin{itemize}
 \item
   If \tcode{E} is an lvalue, \tcode{\placeholdernc{decay-copy}(E.rbegin())}
-  if it is a valid expression and its type \tcode{I} models \tcode{input_or_output_iterator}.
+  if it is a valid expression and its type \tcode{I} models
+  \libconcept{input_or_output_iterator}.
 
 \item
   Otherwise, \tcode{\placeholdernc{decay-copy}(rbegin(E))} if it is a valid
-  expression and its type \tcode{I} models \tcode{input_or_output_iterator} with overload
+  expression and its type \tcode{I} models
+  \libconcept{input_or_output_iterator} with overload
   resolution performed in a context that includes the declaration:
   \begin{codeblock}
   template<class T> void rbegin(T&&) = delete;
@@ -471,7 +475,7 @@ expression-equivalent to:
 \pnum
 \begin{note}
 Whenever \tcode{ranges::rbegin(E)} is a valid expression, its type models
-\tcode{input_or_output_iterator}.
+\libconcept{input_or_output_iterator}.
 \end{note}
 
 \rSec2[range.access.rend]{\tcode{ranges::rend}}
@@ -540,7 +544,7 @@ object\iref{customization.point.object}. The expression
 \pnum
 \begin{note}
 Whenever \tcode{ranges::crbegin(E)} is a valid expression, its
-type models \tcode{input_or_output_iterator}.
+type models \libconcept{input_or_output_iterator}.
 \end{note}
 
 \rSec2[range.access.crend]{\tcode{ranges::crend}}
@@ -670,7 +674,7 @@ expression-equivalent to:
 
 \item
   Otherwise, if \tcode{ranges::begin(E)} is a valid expression whose type models
-  \tcode{contiguous_iterator},
+  \libconcept{contiguous_iterator},
   \tcode{to_address(ranges::begin(E))}.
 
 \item
@@ -2820,10 +2824,12 @@ satisfy the filter predicate.
 \item Let \tcode{C} denote the type
 \tcode{iterator_traits<iterator_t<V>>::iterator_category}.
 
-\item If \tcode{C} models \tcode{derived_from<bidirectional_iterator_tag>},
+\item If \tcode{C} models
+\tcode{\libconcept{derived_from}<bidirectional_iterator_tag>},
 then \tcode{iterator_category} denotes \tcode{bi\-directional_iterator_tag}.
 
-\item Otherwise, if  \tcode{C} models \tcode{derived_from<forward_iterator_tag>},
+\item Otherwise, if  \tcode{C} models
+\tcode{\libconcept{derived_from}<forward_iterator_tag>},
 then \tcode{iterator_category} denotes \tcode{forward_iterator_tag}.
 
 \item Otherwise, \tcode{iterator_category} denotes \tcode{input_iterator_tag}.
@@ -5593,7 +5599,7 @@ subrange<I, I, K>(E.end().base(), E.begin().base())
 \rSec3[range.istream.overview]{Overview}
 
 \pnum
-\tcode{basic_istream_view} models \tcode{input_range} and
+\tcode{basic_istream_view} models \libconcept{input_range} and
 reads (using \tcode{operator>>}) successive elements
 from its corresponding input stream.
 

--- a/source/support.tex
+++ b/source/support.tex
@@ -4021,7 +4021,7 @@ namespace std {
   template<class... Ts>
     using common_comparison_category_t = typename common_comparison_category<Ts...>::type;
 
-  // \ref{cmp.concept}, concept \tcode{three_way_comparable}
+  // \ref{cmp.concept}, concept \libconcept{three_way_comparable}
   template<class T, class Cat = partial_ordering>
     concept three_way_comparable = @\seebelow@;
   template<class T, class U, class Cat = partial_ordering>

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -4739,7 +4739,7 @@ namespace std {
       bool try_acquire_until(const chrono::time_point<Clock, Duration>& abs_time);
 
   private:
-    ptrdiff_t counter; // exposition only
+    ptrdiff_t counter; // \expos
   };
 }
 \end{codeblock}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -20232,7 +20232,7 @@ Let \tcode{charT} be \tcode{decltype(fmt)::value_type}.
 
 \pnum
 \expects
-\tcode{Out} models \tcode{output_iterator<const charT\&>}.
+\tcode{Out} models \tcode{\libconcept{output_iterator}<const charT\&>}.
 
 \pnum
 \effects
@@ -20285,11 +20285,11 @@ Let
 
 \pnum
 \constraints
-\tcode{Out} satisfies \tcode{output_iterator<const charT\&>}.
+\tcode{Out} satisfies \tcode{\libconcept{output_iterator}<const charT\&>}.
 
 \pnum
 \expects
-\tcode{Out} models \tcode{output_iterator<const charT\&>}, and
+\tcode{Out} models \tcode{\libconcept{output_iterator}<const charT\&>}, and
 \tcode{formatter<}$\tcode{T}_i$\tcode{, charT>}
 meets the \newoldconcept{Formatter} requirements\iref{formatter.requirements}
 for each $\tcode{T}_i$ in \tcode{Args}.
@@ -20733,7 +20733,7 @@ An instance of \tcode{basic_format_context} holds formatting state
 consisting of the formatting arguments and the output iterator.
 
 \pnum
-\tcode{Out} shall model \tcode{output_iterator<const charT\&>}.
+\tcode{Out} shall model \tcode{\libconcept{output_iterator}<const charT\&>}.
 
 \pnum
 \indexlibrary{\idxcode{format_context}}%


### PR DESCRIPTION
Mostly trivial changes made while reviewing.  No attempt is made to distinguish errors in motion application from errors in the motions (or merely nearby).

If the [expr.const]/5 changes are too much, the change to the bullets can certainly be omitted; the change before them is more important as it removes a redundancy.