### PR TITLE
[format.context] Use \indextext, not \index.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -20806,7 +20806,7 @@ void advance_to(iterator it);
 \effects Equivalent to: \tcode{out_ = it;}
 \end{itemdescr}
 
-\index{left-pad}%
+\indextext{left-pad}%
 \begin{example}
 \begin{codeblock}
 struct S { int value; };


### PR DESCRIPTION
This is the only use of `\index` in the document.