### PR TITLE
Change Expects to Effects for atomic_ref::notify_{one,all}

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -1063,7 +1063,7 @@ void notify_one() noexcept;
 
 \begin{itemdescr}
 \pnum
-\expects
+\effects
 Unblocks the execution of at least one atomic waiting operation on \tcode{*ptr}
 that is eligible to be unblocked\iref{atomics.wait} by this call,
 if any such atomic waiting operations exist.
@@ -1081,7 +1081,7 @@ void notify_all() noexcept;
 
 \begin{itemdescr}
 \pnum
-\expects
+\effects
 Unblocks the execution of all atomic waiting operations on \tcode{*ptr}
 that are eligible to be unblocked\iref{atomics.wait} by this call.
 


### PR DESCRIPTION
Fix an editorial issue that resulted from an incorrect merge.  In the
description of atomic_ref::notify_one and atomic_ref::notify_all in
[atomics.ref.operations] p25 and p27, N4830 has "Expects" in both of
those paragraphs.  But the paper that was merged in, P1643R1
( http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1643r1.html )
has "Effects".  "Effects" is correct, and it matches notify_one and
notify_all in the four other atomics-related classes.