### PR TITLE
[std] Use consistent margins for codeblocks.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3461,12 +3461,12 @@ the behavior is undefined except in the following cases:
 \end{itemize}
 \begin{example}
 \begin{codeblock}
-  int f(bool b) {
-    unsigned char c;
-    unsigned char d = c;        // OK, \tcode{d} has an indeterminate value
-    int e = d;                  // undefined behavior
-    return b ? d : 0;           // undefined behavior if \tcode{b} is \tcode{true}
-  }
+int f(bool b) {
+  unsigned char c;
+  unsigned char d = c;          // OK, \tcode{d} has an indeterminate value
+  int e = d;                    // undefined behavior
+  return b ? d : 0;             // undefined behavior if \tcode{b} is \tcode{true}
+}
 \end{codeblock}
 \end{example}
 

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -219,15 +219,15 @@ and the elements of $M(\mathtt{X}_e)$.
 \pnum
 \begin{example}
 \begin{codeblock}
-   struct B { int i; };         // standard-layout class
-   struct C : B { };            // standard-layout class
-   struct D : C { };            // standard-layout class
-   struct E : D { char : 4; };  // not a standard-layout class
+struct B { int i; };            // standard-layout class
+struct C : B { };               // standard-layout class
+struct D : C { };               // standard-layout class
+struct E : D { char : 4; };     // not a standard-layout class
 
-   struct Q {};
-   struct S : Q { };
-   struct T : Q { };
-   struct U : S, T { };         // not a standard-layout class
+struct Q {};
+struct S : Q { };
+struct T : Q { };
+struct U : S, T { };            // not a standard-layout class
 \end{codeblock}
 \end{example}
 
@@ -772,11 +772,11 @@ and either both entities are bit-fields with the same width
 or neither is a bit-field.
 \begin{example}
 \begin{codeblock}
-  struct A { int a; char b; };
-  struct B { const int b1; volatile char b2; };
-  struct C { int c; unsigned : 0; char b; };
-  struct D { int d; char b : 4; };
-  struct E { unsigned int e; char b; };
+struct A { int a; char b; };
+struct B { const int b1; volatile char b2; };
+struct C { int c; unsigned : 0; char b; };
+struct D { int d; char b : 4; };
+struct E { unsigned int e; char b; };
 \end{codeblock}
 The common initial sequence of \tcode{A} and \tcode{B} comprises all members
 of either class. The common initial sequence of \tcode{A} and \tcode{C} and

--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -588,8 +588,8 @@ and \tcode{E2} is expression-equivalent to an expression
   has class or enumeration type\iref{basic.compound} and that expression is valid, with
   overload resolution performed in a context that includes the declaration
 \begin{codeblock}
-  template<class T>
-    void swap(T&, T&) = delete;
+template<class T>
+  void swap(T&, T&) = delete;
 \end{codeblock}
   and does not include a declaration of \tcode{ranges::swap}.
   If the function selected by overload resolution does not

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4964,17 +4964,17 @@ initialization that would use that default member initializer,
 the program is ill-formed.
 \begin{example}
 \begin{codeblock}
-  struct A;
-  extern A a;
-  struct A {
-    const A& a1 { A{a,a} };     // OK
-    const A& a2 { A{} };        // error
-  };
-  A a{a,a};                     // OK
+struct A;
+extern A a;
+struct A {
+  const A& a1 { A{a,a} };       // OK
+  const A& a2 { A{} };          // error
+};
+A a{a,a};                       // OK
 
-  struct B {
-    int n = B{}.n;              // error
-  };
+struct B {
+  int n = B{}.n;                // error
+};
 \end{codeblock}
 \end{example}
 
@@ -6583,9 +6583,9 @@ The top-level cv-qualifiers of \tcode{T} are \cv.
 \end{note}
 \begin{example}
 \begin{codeblock}
-  auto f() -> int(&)[2];
-  auto [ x, y ] = f();          // \tcode{x} and \tcode{y} refer to elements in a copy of the array return value
-  auto& [ xr, yr ] = f();       // \tcode{xr} and \tcode{yr} refer to elements in the array referred to by \tcode{f}'s return value
+auto f() -> int(&)[2];
+auto [ x, y ] = f();            // \tcode{x} and \tcode{y} refer to elements in a copy of the array return value
+auto& [ xr, yr ] = f();         // \tcode{xr} and \tcode{yr} refer to elements in the array referred to by \tcode{f}'s return value
 \end{codeblock}
 \end{example}
 
@@ -6738,10 +6738,10 @@ with an \grammarterm{enum-base} and the declaration of an unnamed bit-field of e
 type. \begin{example}
 
 \begin{codeblock}
-   struct S {
-     enum E : int {};
-     enum E : int {};           // error: redeclaration of enumeration
-   };
+struct S {
+  enum E : int {};
+  enum E : int {};              // error: redeclaration of enumeration
+};
 \end{codeblock}
 
 \end{example}
@@ -6905,10 +6905,10 @@ The value of an enumerator or an object of an unscoped enumeration type is
 converted to an integer by integral promotion\iref{conv.prom}.
 \begin{example}
 \begin{codeblock}
-  enum color { red, yellow, green=20, blue };
-  color col = red;
-  color* cp = &col;
-  if (*cp == blue)              // ...
+enum color { red, yellow, green=20, blue };
+color col = red;
+color* cp = &col;
+if (*cp == blue)                // ...
 \end{codeblock}
 makes \tcode{color} a type describing various colors, and then declares
 \tcode{col} as an object of that type, and \tcode{cp} as a pointer to an

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1044,11 +1044,11 @@ The result designates the member function.
 
 \begin{example}
 \begin{codeblock}
-  void (*p)();
-  void (**pp)() noexcept = &p;  // error: cannot convert to pointer to \tcode{noexcept} function
+void (*p)();
+void (**pp)() noexcept = &p;    // error: cannot convert to pointer to \tcode{noexcept} function
 
-  struct S { typedef void (*p)(); operator p(); };
-  void (*q)() noexcept = S();   // error: cannot convert to pointer to \tcode{noexcept} function
+struct S { typedef void (*p)(); operator p(); };
+void (*q)() noexcept = S();     // error: cannot convert to pointer to \tcode{noexcept} function
 \end{codeblock}
 \end{example}
 
@@ -2946,8 +2946,8 @@ the default argument for the parameter is used;
 the program is ill-formed if one is not present.
 \begin{example}
 \begin{codeblock}
-  template<typename ...T> int f(int n = 0, T ...t);
-  int x = f<int>();             // error: no argument for second function parameter
+template<typename ...T> int f(int n = 0, T ...t);
+int x = f<int>();               // error: no argument for second function parameter
 \end{codeblock}
 \end{example}
 If the function is a non-static member
@@ -3635,7 +3635,7 @@ would find at least one viable function\iref{over.match.viable}.
 If \tcode{T} is a reference type, the effect is
 the same as performing the declaration and initialization
 \begin{codeblock}
- T t(e);
+T t(e);
 \end{codeblock}
 for some invented temporary variable \tcode{t}\iref{dcl.init}
 and then using the temporary variable as the result of the conversion.
@@ -4938,25 +4938,25 @@ by \tcode{e1}.
 
 \begin{example}
 \begin{codeblock}
-  void can_merge(int x) {
-    // These allocations are safe for merging:
-    std::unique_ptr<char[]> a{new (std::nothrow) char[8]};
-    std::unique_ptr<char[]> b{new (std::nothrow) char[8]};
-    std::unique_ptr<char[]> c{new (std::nothrow) char[x]};
+void can_merge(int x) {
+  // These allocations are safe for merging:
+  std::unique_ptr<char[]> a{new (std::nothrow) char[8]};
+  std::unique_ptr<char[]> b{new (std::nothrow) char[8]};
+  std::unique_ptr<char[]> c{new (std::nothrow) char[x]};
 
-    g(a.get(), b.get(), c.get());
-  }
+  g(a.get(), b.get(), c.get());
+}
 
-  void cannot_merge(int x) {
-    std::unique_ptr<char[]> a{new char[8]};
-    try {
-      // Merging this allocation would change its catch handler.
-      std::unique_ptr<char[]> b{new char[x]};
-    } catch (const std::bad_alloc& e) {
-      std::cerr << "Allocation failed: " << e.what() << std::endl;
-      throw;
-    }
+void cannot_merge(int x) {
+  std::unique_ptr<char[]> a{new char[8]};
+  try {
+    // Merging this allocation would change its catch handler.
+    std::unique_ptr<char[]> b{new char[x]};
+  } catch (const std::bad_alloc& e) {
+    std::cerr << "Allocation failed: " << e.what() << std::endl;
+    throw;
   }
+}
 \end{codeblock}
 \end{example}
 

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -741,40 +741,40 @@ be defined as the readable type's value type.
 
 \indexlibrary{\idxcode{readable_traits}}%
 \begin{codeblock}
-  template<class> struct @\placeholder{cond-value-type}@ { };   // \expos
-  template<class T>
-    requires is_object_v<T>
-  struct @\placeholder{cond-value-type}@ {
-    using value_type = remove_cv_t<T>;
-  };
+template<class> struct @\placeholder{cond-value-type}@ { };     // \expos
+template<class T>
+  requires is_object_v<T>
+struct @\placeholder{cond-value-type}@ {
+  using value_type = remove_cv_t<T>;
+};
 
-  template<class> struct readable_traits { };
+template<class> struct readable_traits { };
 
-  template<class T>
-  struct readable_traits<T*>
-    : @\placeholder{cond-value-type}@<T> { };
+template<class T>
+struct readable_traits<T*>
+  : @\placeholder{cond-value-type}@<T> { };
 
-  template<class I>
-    requires is_array_v<I>
-  struct readable_traits<I> {
-    using value_type = remove_cv_t<remove_extent_t<I>>;
-  };
+template<class I>
+  requires is_array_v<I>
+struct readable_traits<I> {
+  using value_type = remove_cv_t<remove_extent_t<I>>;
+};
 
-  template<class I>
-  struct readable_traits<const I>
-    : readable_traits<I> { };
+template<class I>
+struct readable_traits<const I>
+  : readable_traits<I> { };
 
-  template<class T>
-    requires requires { typename T::value_type; }
-  struct readable_traits<T>
-    : @\placeholder{cond-value-type}@<typename T::value_type> { };
+template<class T>
+  requires requires { typename T::value_type; }
+struct readable_traits<T>
+  : @\placeholder{cond-value-type}@<typename T::value_type> { };
 
-  template<class T>
-    requires requires { typename T::element_type; }
-  struct readable_traits<T>
-    : @\placeholder{cond-value-type}@<typename T::element_type> { };
+template<class T>
+  requires requires { typename T::element_type; }
+struct readable_traits<T>
+  : @\placeholder{cond-value-type}@<typename T::element_type> { };
 
-  template<class T> using iter_value_t = @\seebelow@;
+template<class T> using iter_value_t = @\seebelow@;
 \end{codeblock}
 
 \indexlibrary{\idxcode{iter_value_t}}%
@@ -920,11 +920,11 @@ then
 \tcode{iterator_traits<I>}
 has the following publicly accessible members:
 \begin{codeblock}
-  using iterator_category = typename I::iterator_category;
-  using value_type        = typename I::value_type;
-  using difference_type   = typename I::difference_type;
-  using pointer           = @\seebelow@;
-  using reference         = typename I::reference;
+using iterator_category = typename I::iterator_category;
+using value_type        = typename I::value_type;
+using difference_type   = typename I::difference_type;
+using pointer           = @\seebelow@;
+using reference         = typename I::reference;
 \end{codeblock}
 If the \grammarterm{qualified-id} \tcode{I::pointer} is valid and
 denotes a type, then \tcode{iterator_traits<I>::pointer} names that type;
@@ -937,11 +937,11 @@ Otherwise, if \tcode{I} satisfies the exposition-only concept
 \tcode{iterator_traits<I>} has the following
 publicly accessible members:
 \begin{codeblock}
-  using iterator_category = @\seebelow@;
-  using value_type        = typename readable_traits<I>::value_type;
-  using difference_type   = typename incrementable_traits<I>::difference_type;
-  using pointer           = @\seebelow@;
-  using reference         = @\seebelow@;
+using iterator_category = @\seebelow@;
+using value_type        = typename readable_traits<I>::value_type;
+using difference_type   = typename incrementable_traits<I>::difference_type;
+using pointer           = @\seebelow@;
+using reference         = @\seebelow@;
 \end{codeblock}
 \begin{itemize}
 \item If the \grammarterm{qualified-id} \tcode{I::pointer} is valid and denotes a type,
@@ -982,11 +982,11 @@ Otherwise, if \tcode{I} satisfies the exposition-only concept
 has the following publicly accessible
 members:
 \begin{codeblock}
-  using iterator_category = output_iterator_tag;
-  using value_type        = void;
-  using difference_type   = @\seebelow@;
-  using pointer           = void;
-  using reference         = void;
+using iterator_category = output_iterator_tag;
+using value_type        = void;
+using difference_type   = @\seebelow@;
+using pointer           = void;
+using reference         = void;
 \end{codeblock}
 If the \grammarterm{qualified-id}
 \tcode{incrementable_traits<I>::difference_type} is valid and denotes a type,
@@ -1655,8 +1655,8 @@ Let \tcode{E} be an expression such that \tcode{decltype((E))} is \tcode{T}, and
 dereferenceable object of type \tcode{I}. \tcode{I} and \tcode{T} model \tcode{\libconcept{output_iterator}<I, T>} only if
 \tcode{*i++ = E;} has effects equivalent to:
 \begin{codeblock}
-  *i = E;
-  ++i;
+*i = E;
+++i;
 \end{codeblock}
 
 \pnum

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -2248,14 +2248,14 @@ applied during overload resolution, thereby avoiding infinite recursion.
 \end{note}
 \begin{example}
 \begin{codeblock}
-  struct Y { Y(int); };
-  struct A { operator int(); };
-  Y y1 = A();       // error: \tcode{A::operator int()} is not a candidate
+struct Y { Y(int); };
+struct A { operator int(); };
+Y y1 = A();         // error: \tcode{A::operator int()} is not a candidate
 
-  struct X { X(); };
-  struct B { operator X(); };
-  B b;
-  X x{{b}};         // error: \tcode{B::operator X()} is not a candidate
+struct X { X(); };
+struct B { operator X(); };
+B b;
+X x{{b}};           // error: \tcode{B::operator X()} is not a candidate
 \end{codeblock}
 \end{example}
 

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -326,8 +326,8 @@ expression-equivalent to:
   \libconcept{input_or_output_iterator} with overload
   resolution performed in a context that includes the declarations:
   \begin{codeblock}
-  template<class T> void begin(T&&) = delete;
-  template<class T> void begin(initializer_list<T>&&) = delete;
+template<class T> void begin(T&&) = delete;
+template<class T> void begin(initializer_list<T>&&) = delete;
   \end{codeblock}
 
   and does not include a declaration of \tcode{ranges::begin}.
@@ -363,20 +363,20 @@ expression-equivalent to:
   \tcode{\placeholdernc{decay-copy}(E.end())}
   if it is a valid expression and its type \tcode{S} models
   \begin{codeblock}
-  sentinel_for<decltype(ranges::begin(E))>
+sentinel_for<decltype(ranges::begin(E))>
   \end{codeblock}
 
 \item
   Otherwise, \tcode{\placeholdernc{decay-copy}(end(E))} if it is a valid
   expression and its type \tcode{S} models
   \begin{codeblock}
-  sentinel_for<decltype(ranges::begin(E))>
+sentinel_for<decltype(ranges::begin(E))>
   \end{codeblock}
   with overload
   resolution performed in a context that includes the declarations:
   \begin{codeblock}
-  template<class T> void end(T&&) = delete;
-  template<class T> void end(initializer_list<T>&&) = delete;
+template<class T> void end(T&&) = delete;
+template<class T> void end(initializer_list<T>&&) = delete;
   \end{codeblock}
 
   and does not include a declaration of \tcode{ranges::end}.
@@ -453,7 +453,7 @@ expression-equivalent to:
   \libconcept{input_or_output_iterator} with overload
   resolution performed in a context that includes the declaration:
   \begin{codeblock}
-  template<class T> void rbegin(T&&) = delete;
+template<class T> void rbegin(T&&) = delete;
   \end{codeblock}
 
   and does not include a declaration of \tcode{ranges::rbegin}.
@@ -490,19 +490,19 @@ expression-equivalent to:
   If \tcode{E} is an lvalue, \tcode{\placeholdernc{decay-copy}(E.rend())}
   if it is a valid expression and its type \tcode{S} models
   \begin{codeblock}
-  sentinel_for<decltype(ranges::rbegin(E))>
+sentinel_for<decltype(ranges::rbegin(E))>
   \end{codeblock}
 
 \item
   Otherwise, \tcode{\placeholdernc{decay-copy}(rend(E))} if it is a valid
   expression and its type \tcode{S} models
   \begin{codeblock}
-  sentinel_for<decltype(ranges::rbegin(E))>
+sentinel_for<decltype(ranges::rbegin(E))>
   \end{codeblock}
   with overload
   resolution performed in a context that includes the declaration:
   \begin{codeblock}
-  template<class T> void rend(T&&) = delete;
+template<class T> void rend(T&&) = delete;
   \end{codeblock}
 
   and does not include a declaration of \tcode{ranges::rend}.
@@ -596,7 +596,7 @@ object\iref{customization.point.object}. The expression
     with overload resolution performed in a context that includes
     the declaration:
     \begin{codeblock}
-    template<class T> void size(T&&) = delete;
+template<class T> void size(T&&) = delete;
     \end{codeblock}
 
     and does not include a declaration of \tcode{ranges::size}.

--- a/source/support.tex
+++ b/source/support.tex
@@ -5202,7 +5202,7 @@ then \tcode{coroutine_traits<R,ArgTypes...>} has the following publicly
 accessible member:
 
 \begin{codeblock}
-  using promise_type = typename R::promise_type;
+using promise_type = typename R::promise_type;
 \end{codeblock}
 
 Otherwise, \tcode{coroutine_traits<R,ArgTypes...>} has no members.

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1198,7 +1198,7 @@ or a placeholder for a deduced class type\iref{dcl.type.class.deduct},
 the type of the parameter is the type deduced
 for the variable \tcode{x} in the invented declaration
 \begin{codeblock}
-  T x = @\grammartermnc{template-argument}@ ;
+T x = @\grammartermnc{template-argument}@ ;
 \end{codeblock}
 If a deduced parameter type is not permitted
 for a \grammarterm{template-parameter} declaration\iref{temp.param},
@@ -7833,15 +7833,15 @@ will be checked during overload resolution.
 \end{note}
 \begin{example}
 \begin{codeblock}
-  template <class T> struct Z {
-    typedef typename T::x xx;
-  };
-  template <class T> typename Z<T>::xx f(void *, T);    // \#1
-  template <class T> void f(int, T);                    // \#2
-  struct A {} a;
-  int main() {
-    f(1, a);        // OK, deduction fails for \#1 because there is no conversion from \tcode{int} to \tcode{void*}
-  }
+template <class T> struct Z {
+  typedef typename T::x xx;
+};
+template <class T> typename Z<T>::xx f(void *, T);      // \#1
+template <class T> void f(int, T);                      // \#2
+struct A {} a;
+int main() {
+  f(1, a);          // OK, deduction fails for \#1 because there is no conversion from \tcode{int} to \tcode{void*}
+}
 \end{codeblock}
 \end{example}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -813,11 +813,11 @@ pair<unwrap_ref_decay_t<T1>,
 \begin{example}
 In place of:
 \begin{codeblock}
-  return pair<int, double>(5, 3.1415926);   // explicit types
+return pair<int, double>(5, 3.1415926);     // explicit types
 \end{codeblock}
 a \Cpp{} program may contain:
 \begin{codeblock}
-  return make_pair(5, 3.1415926);           // types are deduced
+return make_pair(5, 3.1415926);             // types are deduced
 \end{codeblock}
 \end{example}
 
@@ -1900,10 +1900,10 @@ Otherwise, the program is ill-formed.
 \pnum
 \begin{example}
 \begin{codeblock}
-  const tuple<int, const int, double, double> t(1, 2, 3.4, 5.6);
-  const int& i1 = get<int>(t);                  // OK, \tcode{i1} has value \tcode{1}
-  const int& i2 = get<const int>(t);            // OK, \tcode{i2} has value \tcode{2}
-  const double& d = get<double>(t);             // error: type \tcode{double} is not unique within \tcode{t}
+const tuple<int, const int, double, double> t(1, 2, 3.4, 5.6);
+const int& i1 = get<int>(t);                    // OK, \tcode{i1} has value \tcode{1}
+const int& i2 = get<const int>(t);              // OK, \tcode{i2} has value \tcode{2}
+const double& d = get<double>(t);               // error: type \tcode{double} is not unique within \tcode{t}
 \end{codeblock}
 \end{example}
 \end{itemdescr}


### PR DESCRIPTION
Fixes #3186.