### PR TITLE
[temp.names] Remove misleading note.

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -861,16 +861,6 @@ D<B<int> > db;
 \end{example}
 
 \pnum
-\indextext{specialization!class template}%
-\begin{note}
-A \grammarterm{simple-template-id}
-that names a class template specialization
-is a \grammarterm{class-name}\iref{class.name}.
-Any other \grammarterm{simple-template-id} that names a type
-is a \grammarterm{typedef-name}.
-\end{note}
-
-\pnum
 A \grammarterm{template-id} is \defnx{valid}{\idxgram{template-id}!valid} if
 \begin{itemize}
 \item


### PR DESCRIPTION
Fixes #3184.