### PR TITLE
[diff.library] Consistency for wide char types

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -2616,7 +2616,7 @@ The types \tcode{char16_t} and \tcode{char32_t}
 are distinct types rather than typedefs to existing integral types.
 The tokens \tcode{char16_t} and \tcode{char32_t}
 are keywords in this International Standard\iref{lex.key}.
-They do not appear as macro names defined in
+They do not appear as macro or type names defined in
 \libheaderref{cuchar}.
 
 \rSec3[diff.wchar.t]{Type \tcode{wchar_t}}
@@ -2626,7 +2626,7 @@ The type \tcode{wchar_t} is a distinct type rather than a typedef to an
 existing integral type.
 The token \tcode{wchar_t}
 is a keyword in this International Standard\iref{lex.key}.
-It does not appear as a type name defined in any of
+It does not appear as a macro or type name defined in any of
 \libheaderref{cstddef},
 \libheaderref{cstdlib},
 or \libheaderref{cwchar}.


### PR DESCRIPTION
[diff.char16] says `char16_t` and `char_32t` 
> ...do not appear as *macro* names...

[diff.wchar.t] says `wchar_t` 
> ...does not appear as a *type* name...

It would be nice to make these consistent if there is no reason for the difference. I thought there might not be because I saw at least one implementation in which `char16_t` and `char_32t` are `typedef`s rather than macros.