### PR TITLE
[intro.refs] ISO/IEC 2382 missing date

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -43,7 +43,7 @@ Edited by E. Lear, P. Eggert.
 February 2012 [viewed 2018-03-26].
 Available at
 \url{https://www.ietf.org/rfc/rfc6557.txt}
-\item ISO/IEC 2382 (all parts), \doccite{Information technology ---
+\item ISO/IEC 2382:1993 (all parts), \doccite{Information technology ---
 Vocabulary}
 \item ISO 8601:2004, \doccite{Data elements and interchange formats ---
 Information interchange --- Representation of dates and times}


### PR DESCRIPTION
Undated references are mentioned to indicate the latest edition. However, the latest edition of [ISO/IEC 2382](https://www.iso.org/standard/63598.html) is from 2015, and the only place in the standard which mentions ISO/IEC 2382 explicitly is [intro.defs] with the explicit 1993 edition.

So it seems like either the 1993 edition should be explicitly listed in [intro.refs] (this is the suggested fix in this pull request) or the document (or at least the explicit reference in [intro.defs]) should be updated to mention the 2015 edition (assuming there were no breaking changes since 1993, which I definitely did *not* verify).