### PR TITLE
[intro.compliance] Fix reference in footnote

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -457,7 +457,7 @@ Having done so, however, they can compile and execute such programs.
 Each implementation shall include documentation that identifies all
 conditionally-supported constructs\indextext{behavior!conditionally-supported}
 that it does not support and defines all locale-specific characteristics.\footnote{This documentation also defines implementation-defined behavior;
-see~\ref{intro.execution}.}%
+see~\ref{intro.abstract}.}%
 \indextext{conformance requirements!general|)}%
 \indextext{conformance requirements|)}%
 


### PR DESCRIPTION
It seems this footnote is supposed to point at [intro.abstract] which describes how the implementation's documentations also defines implementation-defined behavior; In the same way that the footnote in [intro.abstract] points into [intro.compliance] where it says that the documentation also includes things which are listed there.