### PR TITLE
[re.grammar] Improve grammar typesetting.

### DIFF
--- a/source/macros.tex
+++ b/source/macros.tex
@@ -188,6 +188,7 @@
 \newcommand{\keyword}[1]{\tcode{#1}\indextext{\idxcode{#1}}}
 \newcommand{\grammarterm}[1]{\indexgram{\idxgram{#1}}\gterm{#1}}
 \newcommand{\grammartermnc}[1]{\indexgram{\idxgram{#1}}\gterm{#1\nocorr}}
+\newcommand{\regrammarterm}[1]{\gterm{#1}}
 \newcommand{\placeholder}[1]{\textit{#1}}
 \newcommand{\placeholdernc}[1]{\textit{#1\nocorr}}
 \newcommand{\exposid}[1]{\tcode{\placeholder{#1}}}
@@ -497,6 +498,7 @@
 \newenvironment{bnfbase}
  {
  \newcommand{\nontermdef}[1]{{\BnfNontermshape##1\itcorr}\indexgrammar{\idxgram{##1}}\textnormal{:}}
+ \newcommand{\renontermdef}[1]{{\BnfNontermshape##1\itcorr}\,\textnormal{::}}
  \newcommand{\terminal}[1]{{\BnfTermshape ##1}}
  \renewcommand{\keyword}[1]{\terminal{##1}\indextext{\idxcode{##1}}}
  \renewcommand{\exposid}[1]{\terminal{\placeholder{##1}}}

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -3475,42 +3475,42 @@ Instead they shall call the appropriate traits member function to achieve the re
 \pnum
 The following productions within the ECMAScript grammar are modified as follows:
 
-\begin{codeblock}
-ClassAtom ::
-  -
-  ClassAtomNoDash
-  ClassAtomExClass
-  ClassAtomCollatingElement
+\begin{ncbnf}
+\renontermdef{ClassAtom}\br
+  \terminal{-}\br
+  ClassAtomNoDash\br
+  ClassAtomExClass\br
+  ClassAtomCollatingElement\br
   ClassAtomEquivalence
 
-IdentityEscape ::
-  SourceCharacter but not c
-\end{codeblock}
+\renontermdef{IdentityEscape}\br
+  SourceCharacter \textnormal{\textbf{but not}} \terminal{c}
+\end{ncbnf}
 
 \pnum
 The following new productions are then added:
 
-\begin{codeblock}
-ClassAtomExClass ::
-  [: ClassName :]
+\begin{ncbnf}
+\renontermdef{ClassAtomExClass}\br
+  \terminal{[:} ClassName \terminal{:]}
 
-ClassAtomCollatingElement ::
-  [. ClassName .]
+\renontermdef{ClassAtomCollatingElement}\br
+  \terminal{[.} ClassName \terminal{.]}
 
-ClassAtomEquivalence ::
-  [= ClassName =]
+\renontermdef{ClassAtomEquivalence}\br
+  \terminal{[=} ClassName \terminal{=]}
 
-ClassName ::
-  ClassNameCharacter
+\renontermdef{ClassName}\br
+  ClassNameCharacter\br
   ClassNameCharacter ClassName
 
-ClassNameCharacter ::
-  SourceCharacter but not one of "." "=" ":"
-\end{codeblock}
+\renontermdef{ClassNameCharacter}\br
+  SourceCharacter \textnormal{\textbf{but not one of}} \terminal{.} \textnormal{\textbf{or}} \terminal{=} \textnormal{\textbf{or}} \terminal{:}
+\end{ncbnf}
 
 \pnum
-The productions \tcode{ClassAtomExClass}, \tcode{ClassAtomCollatingElement}
-and \tcode{ClassAtomEquivalence} provide functionality
+The productions \regrammarterm{ClassAtomExClass}, \regrammarterm{ClassAtomCollatingElement}
+and \regrammarterm{ClassAtomEquivalence} provide functionality
 equivalent to that of the same features in regular expressions in POSIX.
 
 \pnum
@@ -3520,9 +3520,9 @@ constructing an object of type specialization of \tcode{basic_regex}
 according to the rules in \tref{re.synopt}.
 
 \pnum
-A \tcode{ClassName} production, when used in \tcode{ClassAtomExClass},
+A \regrammarterm{ClassName} production, when used in \regrammarterm{ClassAtomExClass},
 is not valid if \tcode{traits_inst.lookup_classname} returns zero for
-that name.  The names recognized as valid \tcode{ClassName}s are
+that name.  The names recognized as valid \regrammarterm{ClassName}s are
 determined by the type of the traits class, but at least the following
 names shall be recognized:
 \tcode{alnum}, \tcode{alpha}, \tcode{blank}, \tcode{cntrl}, \tcode{digit},
@@ -3547,8 +3547,8 @@ In addition the following expressions shall be equivalent:
 \pnum
 \indexlibrary{regular expression traits!\idxcode{lookup_collatename}}%
 \indexlibrary{\idxcode{lookup_collatename}!regular expression traits}%
-A \tcode{ClassName} production when used in
-a \tcode{ClassAtomCollatingElement} production is not valid
+A \regrammarterm{ClassName} production when used in
+a \regrammarterm{ClassAtomCollatingElement} production is not valid
 if the value returned by \tcode{traits_inst.lookup_collatename} for
 that name is an empty string.
 
@@ -3564,8 +3564,8 @@ together and subsequently passed to \tcode{traits_inst.isctype}.
 \pnum
 \indexlibrary{regular expression traits!\idxcode{transform_primary}}%
 \indextext{\idxcode{transform_primary}!regular expression traits}%
-A \tcode{ClassName} production when used in
-a \tcode{ClassAtomEquivalence} production is not valid if the value
+A \regrammarterm{ClassName} production when used in
+a \regrammarterm{ClassAtomEquivalence} production is not valid if the value
 returned by \tcode{traits_inst.lookup_collatename} for that name is an
 empty string or if the value returned by \tcode{traits_inst\brk.transform_primary}
 for the result of the call to \tcode{traits_inst.lookup_collatename}


### PR DESCRIPTION
Currently, the regular expression grammar rules in [re.grammar] are formatted with crude codeblocks:

![image](https://user-images.githubusercontent.com/22357/63519950-239bfb00-c4f4-11e9-83ee-28478a528d68.png)

In the ECMA standard [itself](https://web.archive.org/web/20111103184035/http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-262%20edition%205.1%2C%20June%202011.pdf), rules are typeset like this:

![image](https://user-images.githubusercontent.com/22357/63520060-5c3bd480-c4f4-11e9-977d-4feae2fa886c.png)

So as an experiment, I tried mimicking that typesetting. Result:

![image](https://user-images.githubusercontent.com/22357/63520313-ce141e00-c4f4-11e9-983c-0fa36b934675.png)

Personally, I think it looks nicer than the crude codeblocks, and matching the upstream ECMAScript re grammar typesetting more closely is a nice bonus. What do you think? :)

(Incidentally, this also benefits cxxdraft-htmlgen, because it reduces the amount of non-C++ code in codeblocks.)