### PR TITLE
[re.regex] assign editorial cleanup.

### DIFF
--- a/source/regex.tex
+++ b/source/regex.tex
@@ -1264,8 +1264,8 @@ namespace std {
       basic_regex& assign(basic_regex&& that) noexcept;
       basic_regex& assign(const charT* ptr, flag_type f = regex_constants::ECMAScript);
       basic_regex& assign(const charT* p, size_t len, flag_type f);
-      template<class string_traits, class A>
-        basic_regex& assign(const basic_string<charT, string_traits, A>& s,
+      template<class ST, class SA>
+        basic_regex& assign(const basic_string<charT, ST, SA>& s,
                             flag_type f = regex_constants::ECMAScript);
       template<class InputIterator>
         basic_regex& assign(InputIterator first, InputIterator last,
@@ -1548,8 +1548,8 @@ basic_regex& assign(const charT* ptr, size_t len, flag_type f = regex_constants:
 
 \indexlibrarymember{basic_regex}{assign}%
 \begin{itemdecl}
-template<class string_traits, class A>
-  basic_regex& assign(const basic_string<charT, string_traits, A>& s,
+template<class ST, class SA>
+  basic_regex& assign(const basic_string<charT, ST, SA>& s,
                       flag_type f = regex_constants::ECMAScript);
 \end{itemdecl}
 


### PR DESCRIPTION
basic_regex::assign uses template parameters `class string_traits' and
`class A' while similar places use `class ST' and `class SA'.