### PR TITLE
[basic.def] Move rule on template definition here

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -178,6 +178,11 @@ a \grammarterm{using-directive}\iref{namespace.udir},
 \item it is
 a \grammarterm{using-enum-declaration}\iref{enum.udecl},
 \item it is
+a \grammarterm{template-declaration}\iref{temp}
+whose \grammarterm{template-head} is not followed by
+either a \grammarterm{concept-definition} or a \grammarterm{declaration}
+that defines a function, a class, a variable, or a static data member.
+\item it is
 an explicit instantiation declaration\iref{temp.explicit}, or
 \item it is
 an explicit specialization\iref{temp.expl.spec} whose

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -93,14 +93,7 @@ class template or of a class nested within a class template, or
 
 \pnum
 A \grammarterm{template-declaration} is a \grammarterm{declaration}.
-\indextext{template!definition of}%
-A \grammarterm{template-declaration} is also a definition
-if its
-\grammarterm{template-head} is followed by
-either a \grammarterm{concept-definition} or
-a \grammarterm{declaration} that
-defines a function, a class, a variable, or a
-static data member. A declaration introduced by a template declaration of a
+A declaration introduced by a template declaration of a
 \indextext{variable template!definition of}%
 variable is a \defnx{variable template}{template!variable}. A variable template at class scope is a
 \defnx{static data member template}{template!static data member}.


### PR DESCRIPTION
from its original location in [temp] p3.

Fixes #3195.