### PR TITLE
[dcl.array] The first element has the same address as the array

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3117,6 +3117,8 @@ a contiguously allocated non-empty set
 of \tcode{N} subobjects of type \tcode{U},
 known as the \defnx{elements}{array!element} of the array,
 and numbered \tcode{0} to \tcode{N-1}.
+The element with number \tcode{0}
+has the same address as the array.
 
 \pnum
 In addition to declarations in which an incomplete object type is allowed,


### PR DESCRIPTION
This provides normative wording for [the Note from [basic.compound]/4](http://eel.is/c++draft/basic.compound#4.note-1):
> [ Note: An array object and its first element are not pointer-interconvertible, even though they have the same address.— end note ]