### PR TITLE
[iterators] s/a == b/bool(a == b)/ and s/++a == ++b/bool(++a == ++b)/

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1700,7 +1700,7 @@ Two dereferenceable iterators \tcode{a} and \tcode{b} of type \tcode{X}
 offer the \defn{multi-pass guarantee} if:
 
 \begin{itemize}
-\item \tcode{a == b} implies \tcode{++a == ++b} and
+\item \tcode{bool(a == b)} implies \tcode{bool(++a == ++b)} and
 \item The expression
 \tcode{((void)[](X x)\{++x;\}(a), *a)} is equivalent to the expression \tcode{*a}.
 \end{itemize}
@@ -1708,9 +1708,9 @@ offer the \defn{multi-pass guarantee} if:
 \pnum
 \begin{note}
 The requirement that
-\tcode{a == b}
+\tcode{bool(a == b)}
 implies
-\tcode{++a == ++b}
+\tcode{bool(++a == ++b)}
 and the removal of the restrictions on the number of assignments through
 a mutable iterator
 (which applies to output iterators)
@@ -2018,9 +2018,9 @@ has property
 \pnum
 \begin{note}
 For input iterators,
-\tcode{a == b}
+\tcode{bool(a == b)}
 does not imply
-\tcode{++a == ++b}.
+\tcode{bool(++a == ++b)}.
 (Equality does not guarantee the substitution property or referential transparency.)
 Algorithms on input iterators should never attempt to pass through the same iterator twice.
 They should be
@@ -2126,7 +2126,7 @@ Two dereferenceable iterators \tcode{a} and \tcode{b} of type \tcode{X} offer th
 \defn{multi-pass guarantee} if:
 
 \begin{itemize}
-\item \tcode{a == b} implies \tcode{++a == ++b} and
+\item \tcode{bool(a == b)} implies \tcode{bool(++a == ++b)} and
 \item \tcode{X} is a pointer type or the expression
 \tcode{(void)++X(a), *a} is equivalent to the expression \tcode{*a}.
 \end{itemize}
@@ -2134,9 +2134,9 @@ Two dereferenceable iterators \tcode{a} and \tcode{b} of type \tcode{X} offer th
 \pnum
 \begin{note}
 The requirement that
-\tcode{a == b}
+\tcode{bool(a == b)}
 implies
-\tcode{++a == ++b}
+\tcode{bool(++a == ++b)}
 (which is not true for input and output iterators)
 and the removal of the restrictions on the number of the assignments through
 a mutable iterator


### PR DESCRIPTION
The boolean-expressions in [iterators] should be explicitly converted to
`bool`. This commit fixes a few strays that weren't boolified.