### PR TITLE
[span.syn] Fix inconsistent class key in tuple_size/tuple_element

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10295,8 +10295,8 @@ namespace std {
       as_writable_bytes(span<ElementType, Extent> s) noexcept;
 
   // \ref{span.tuple}, tuple interface
-  template<class T> class tuple_size;
-  template<size_t I, class T> class tuple_element;
+  template<class T> struct tuple_size;
+  template<size_t I, class T> struct tuple_element;
   template<class ElementType, size_t Extent>
     struct tuple_size<span<ElementType, Extent>>;
   template<class ElementType>


### PR DESCRIPTION
We already fixed the other specializations in #2679 