### PR TITLE
[thread.latch] Subordinate [latch.syn] and [thread.latch.class]

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -5376,7 +5376,7 @@ The expected count is set when the latch is created.
 An individual latch is a single-use object;
 once the expected count has been reached, the latch cannot be reused.
 
-\rSec2[latch.syn]{Header \tcode{<latch>} synopsis}
+\rSec3[latch.syn]{Header \tcode{<latch>} synopsis}
 
 \indexheader{latch}%
 \begin{codeblock}
@@ -5385,7 +5385,7 @@ namespace std {
 }
 \end{codeblock}
 
-\rSec2[thread.latch.class]{Class \tcode{latch}}
+\rSec3[thread.latch.class]{Class \tcode{latch}}
 
 \begin{codeblock}
 namespace std {


### PR DESCRIPTION
Fixes #3169.