### PR TITLE
Use consistent wording to indicate ADL-only lookup.

### DIFF
--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -583,10 +583,10 @@ and \tcode{E2} is expression-equivalent to an expression
 
 \begin{itemize}
 \item
-  \tcode{S} is \tcode{(void)swap(E1, E2)}\footnote{The name \tcode{swap} is used
-  here unqualified.} if \tcode{E1} or \tcode{E2}
-  has class or enumeration type\iref{basic.compound} and that expression is valid,
-  when `swap` is looked up using only argument-dependent lookup\iref{basic.lookup.argdep}.
+  \tcode{S} is \tcode{(void)swap(E1, E2)},
+  except that \tcode{swap} is looked up using only argument-dependent lookup\iref{basic.lookup.argdep},
+  if that expression is well-formed when treated as an unevaluated operand and
+  if \tcode{E1} or \tcode{E2} has class or enumeration type\iref{basic.compound}.
   If the function selected by overload resolution does not
   exchange the values denoted by
   \tcode{E1} and \tcode{E2},

--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -585,13 +585,8 @@ and \tcode{E2} is expression-equivalent to an expression
 \item
   \tcode{S} is \tcode{(void)swap(E1, E2)}\footnote{The name \tcode{swap} is used
   here unqualified.} if \tcode{E1} or \tcode{E2}
-  has class or enumeration type\iref{basic.compound} and that expression is valid, with
-  overload resolution performed in a context that includes the declaration
-\begin{codeblock}
-  template<class T>
-    void swap(T&, T&) = delete;
-\end{codeblock}
-  and does not include a declaration of \tcode{ranges::swap}.
+  has class or enumeration type\iref{basic.compound} and that expression is valid,
+  when `swap` is looked up using only argument-dependent lookup\iref{basic.lookup.argdep}.
   If the function selected by overload resolution does not
   exchange the values denoted by
   \tcode{E1} and \tcode{E2},

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1055,8 +1055,9 @@ The expression \tcode{ranges::\-iter_move(E)} for some subexpression \tcode{E} i
 expression-equivalent to:
 
 \begin{itemize}
-\item \tcode{iter_move(E)}, if that expression is valid,
-when `iter_move` is looked up using only argument-dependent lookup\iref{basic.lookup.argdep}.
+\item \tcode{iter_move(E)},
+except that \tcode{iter_move} is looked up using only argument-dependent lookup\iref{basic.lookup.argdep},
+if that expression is well-formed when treated as an unevaluated operand.
 
 \item Otherwise, if the expression \tcode{*E} is well-formed:
 \begin{itemize}
@@ -1109,8 +1110,9 @@ The expression \tcode{ranges::iter_swap(E1, E2)} for some subexpressions
 \tcode{E1} and \tcode{E2} is expression-equivalent to:
 
 \begin{itemize}
-\item \tcode{(void)iter_swap(E1, E2)}, if that expression is valid,
-when `iter_swap` is looked up using only argument-dependent lookup\iref{basic.lookup.argdep}.
+\item \tcode{(void)iter_swap(E1, E2)},
+except that \tcode{iter_swap} is looked up using only argument-dependent lookup\iref{basic.lookup.argdep},
+if that expression is well-formed when treated as an unevaluated operand.
 If the function selected by overload resolution does not exchange the values
 denoted by \tcode{E1} and \tcode{E2}, the program is
 ill-formed with no diagnostic required.

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1055,9 +1055,8 @@ The expression \tcode{ranges::\-iter_move(E)} for some subexpression \tcode{E} i
 expression-equivalent to:
 
 \begin{itemize}
-\item \tcode{iter_move(E)}, if that expression is valid, with overload
-resolution performed in a context that does not include a declaration of
-\tcode{ranges::iter_move}.
+\item \tcode{iter_move(E)}, if that expression is valid,
+when `iter_move` is looked up using only argument-dependent lookup\iref{basic.lookup.argdep}.
 
 \item Otherwise, if the expression \tcode{*E} is well-formed:
 \begin{itemize}
@@ -1111,12 +1110,7 @@ The expression \tcode{ranges::iter_swap(E1, E2)} for some subexpressions
 
 \begin{itemize}
 \item \tcode{(void)iter_swap(E1, E2)}, if that expression is valid,
-with overload resolution performed in a context that includes the declaration
-\begin{codeblock}
-template<class I1, class I2>
-  void iter_swap(I1, I2) = delete;
-\end{codeblock}
-and does not include a declaration of \tcode{ranges::iter_swap}.
+when `iter_swap` is looked up using only argument-dependent lookup\iref{basic.lookup.argdep}.
 If the function selected by overload resolution does not exchange the values
 denoted by \tcode{E1} and \tcode{E2}, the program is
 ill-formed with no diagnostic required.

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1032,16 +1032,11 @@ particular concept.
 \pnum
 \begin{note}
 Many of the customization point objects in the library evaluate function call
-expressions with an unqualified name which results in a call to a
-program-defined function found by argument dependent name
-lookup\iref{basic.lookup.argdep}. To preclude such an expression resulting in a
-call to unconstrained functions with the same name in namespace \tcode{std},
-customization point objects specify that lookup for these expressions is
-performed in a context that includes deleted overloads matching the signatures
-of overloads defined in namespace \tcode{std}. When the deleted overloads are
-viable, program-defined overloads need be more specialized\iref{temp.func.order}
-or more constrained\iref{temp.constr.order} to be used by a customization point
-object.
+expressions with an unqualified name, and specify that that name
+``is looked up using only argument-dependent lookup\iref{basic.lookup.argdep}.''
+Functions in namespace \tcode{std} having that name will not be found
+by such lookup unless \tcode{std} is an associated namespace
+of the function call expression.
 \end{note}
 
 \rSec3[functions.within.classes]{Functions within classes}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -322,15 +322,10 @@ expression-equivalent to:
 
 \item
   Otherwise, \tcode{\placeholdernc{decay-copy}(begin(E))} if it is a
-  valid expression and its type \tcode{I} models
-  \libconcept{input_or_output_iterator} with overload
-  resolution performed in a context that includes the declarations:
-  \begin{codeblock}
-  template<class T> void begin(T&&) = delete;
-  template<class T> void begin(initializer_list<T>&&) = delete;
-  \end{codeblock}
-
-  and does not include a declaration of \tcode{ranges::begin}.
+  valid expression
+  when `begin` is looked up using only argument-dependent lookup\iref{basic.lookup.argdep}
+  and its type \tcode{I} models
+  \libconcept{input_or_output_iterator}.
 
 \item
   Otherwise, \tcode{ranges::begin(E)} is ill-formed.
@@ -367,19 +362,12 @@ expression-equivalent to:
   \end{codeblock}
 
 \item
-  Otherwise, \tcode{\placeholdernc{decay-copy}(end(E))} if it is a valid
-  expression and its type \tcode{S} models
+  Otherwise, \tcode{\placeholdernc{decay-copy}(end(E))} if it is a valid expression
+  when `end` is looked up using only argument-dependent lookup\iref{basic.lookup.argdep},
+  and its type \tcode{S} models
   \begin{codeblock}
   sentinel_for<decltype(ranges::begin(E))>
   \end{codeblock}
-  with overload
-  resolution performed in a context that includes the declarations:
-  \begin{codeblock}
-  template<class T> void end(T&&) = delete;
-  template<class T> void end(initializer_list<T>&&) = delete;
-  \end{codeblock}
-
-  and does not include a declaration of \tcode{ranges::end}.
 
 \item
   Otherwise, \tcode{ranges::end(E)} is ill-formed.
@@ -448,15 +436,9 @@ expression-equivalent to:
   \libconcept{input_or_output_iterator}.
 
 \item
-  Otherwise, \tcode{\placeholdernc{decay-copy}(rbegin(E))} if it is a valid
-  expression and its type \tcode{I} models
-  \libconcept{input_or_output_iterator} with overload
-  resolution performed in a context that includes the declaration:
-  \begin{codeblock}
-  template<class T> void rbegin(T&&) = delete;
-  \end{codeblock}
-
-  and does not include a declaration of \tcode{ranges::rbegin}.
+  Otherwise, \tcode{\placeholdernc{decay-copy}(rbegin(E))} if it is a valid expression
+  when `rbegin` is looked up using only argument-dependent lookup\iref{basic.lookup.argdep},
+  and its type \tcode{I} models \libconcept{input_or_output_iterator}.
 
 \item
   Otherwise, \tcode{make_reverse_iterator(ranges::end(E))} if both
@@ -494,18 +476,12 @@ expression-equivalent to:
   \end{codeblock}
 
 \item
-  Otherwise, \tcode{\placeholdernc{decay-copy}(rend(E))} if it is a valid
-  expression and its type \tcode{S} models
+  Otherwise, \tcode{\placeholdernc{decay-copy}(rend(E))} if it is a valid expression
+  when `rend` is looked up using only argument-dependent lookup\iref{basic.lookup.argdep},
+  and its type \tcode{S} models
   \begin{codeblock}
   sentinel_for<decltype(ranges::rbegin(E))>
   \end{codeblock}
-  with overload
-  resolution performed in a context that includes the declaration:
-  \begin{codeblock}
-  template<class T> void rend(T&&) = delete;
-  \end{codeblock}
-
-  and does not include a declaration of \tcode{ranges::rend}.
 
 \item
   Otherwise, \tcode{make_reverse_iterator(ranges::begin(E))} if both
@@ -591,15 +567,9 @@ object\iref{customization.point.object}. The expression
 
   \item
     Otherwise, \tcode{\placeholdernc{decay-copy}(size(E))}
-    if it is a valid expression and its type \tcode{I}
-    is integer-like
-    with overload resolution performed in a context that includes
-    the declaration:
-    \begin{codeblock}
-    template<class T> void size(T&&) = delete;
-    \end{codeblock}
-
-    and does not include a declaration of \tcode{ranges::size}.
+    if it is a valid expression
+    when `size` is looked up using only argument-dependent lookup\iref{basic.lookup.argdep},
+    and its type \tcode{I} is integer-like.
   \end{itemize}
 
 \item

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -321,9 +321,9 @@ expression-equivalent to:
   \libconcept{input_or_output_iterator}.
 
 \item
-  Otherwise, \tcode{\placeholdernc{decay-copy}(begin(E))} if it is a
-  valid expression
-  when `begin` is looked up using only argument-dependent lookup\iref{basic.lookup.argdep}
+  Otherwise, \tcode{\placeholdernc{decay-copy}(begin(E))},
+  except that \tcode{begin} is looked up using only argument-dependent lookup\iref{basic.lookup.argdep},
+  if that expression is well-formed when treated as an unevaluated operand
   and its type \tcode{I} models
   \libconcept{input_or_output_iterator}.
 
@@ -362,8 +362,9 @@ expression-equivalent to:
   \end{codeblock}
 
 \item
-  Otherwise, \tcode{\placeholdernc{decay-copy}(end(E))} if it is a valid expression
-  when `end` is looked up using only argument-dependent lookup\iref{basic.lookup.argdep},
+  Otherwise, \tcode{\placeholdernc{decay-copy}(end(E))},
+  except that \tcode{end} is looked up using only argument-dependent lookup\iref{basic.lookup.argdep},
+  if that expression is well-formed when treated as an unevaluated operand
   and its type \tcode{S} models
   \begin{codeblock}
   sentinel_for<decltype(ranges::begin(E))>
@@ -436,8 +437,9 @@ expression-equivalent to:
   \libconcept{input_or_output_iterator}.
 
 \item
-  Otherwise, \tcode{\placeholdernc{decay-copy}(rbegin(E))} if it is a valid expression
-  when `rbegin` is looked up using only argument-dependent lookup\iref{basic.lookup.argdep},
+  Otherwise, \tcode{\placeholdernc{decay-copy}(rbegin(E))},
+  except that \tcode{rbegin} is looked up using only argument-dependent lookup\iref{basic.lookup.argdep},
+  if that expression is well-formed when treated as an unevaluated operand
   and its type \tcode{I} models \libconcept{input_or_output_iterator}.
 
 \item
@@ -476,8 +478,9 @@ expression-equivalent to:
   \end{codeblock}
 
 \item
-  Otherwise, \tcode{\placeholdernc{decay-copy}(rend(E))} if it is a valid expression
-  when `rend` is looked up using only argument-dependent lookup\iref{basic.lookup.argdep},
+  Otherwise, \tcode{\placeholdernc{decay-copy}(rend(E))},
+  except that \tcode{rend} is looked up using only argument-dependent lookup\iref{basic.lookup.argdep},
+  if that expression is well-formed when treated as an unevaluated operand
   and its type \tcode{S} models
   \begin{codeblock}
   sentinel_for<decltype(ranges::rbegin(E))>
@@ -566,9 +569,9 @@ object\iref{customization.point.object}. The expression
     is integer-like\iref{iterator.concept.winc}.
 
   \item
-    Otherwise, \tcode{\placeholdernc{decay-copy}(size(E))}
-    if it is a valid expression
-    when `size` is looked up using only argument-dependent lookup\iref{basic.lookup.argdep},
+    Otherwise, \tcode{\placeholdernc{decay-copy}(size(E))},
+    except that \tcode{size} is looked up using only argument-dependent lookup\iref{basic.lookup.argdep},
+    if that expression is well-formed when treated as an unevaluated operand
     and its type \tcode{I} is integer-like.
   \end{itemize}
 

--- a/source/support.tex
+++ b/source/support.tex
@@ -4953,8 +4953,7 @@ is expression-equivalent\iref{defns.expression-equivalent} to the following:
 \item
   Otherwise, \tcode{strong_ordering(strong_order(E, F))}
   if it is a well-formed expression
-  with overload resolution performed in a context
-  that does not include a declaration of \tcode{std::strong_order}.
+  when `strong_order` is looked up using only argument-dependent lookup\iref{basic.lookup.argdep}.
 \item
   Otherwise, if the decayed type \tcode{T} of \tcode{E} is
   a floating-point type,
@@ -4989,8 +4988,7 @@ is expression-equivalent\iref{defns.expression-equivalent} to the following:
 \item
   Otherwise, \tcode{weak_ordering(weak_order(E, F))}
   if it is a well-formed expression
-  with overload resolution performed in a context
-  that does not include a declaration of \tcode{std::weak_order}.
+  when `weak_order` is looked up using only argument-dependent lookup\iref{basic.lookup.argdep}.
 \item
   Otherwise, if the decayed type \tcode{T} of \tcode{E}
   is a floating-point type,
@@ -5039,8 +5037,7 @@ is expression-equivalent\iref{defns.expression-equivalent} to the following:
 \item
   Otherwise, \tcode{partial_ordering(partial_order(E, F))}
   if it is a well-formed expression
-  with overload resolution performed in a context
-  that does not include a declaration of \tcode{std::partial_order}.
+  when `partial_order` is looked up using only argument-dependent lookup\iref{basic.lookup.argdep}.
 \item
   Otherwise, \tcode{partial_ordering(E <=> F)}
   if it is a well-formed expression.

--- a/source/support.tex
+++ b/source/support.tex
@@ -4951,9 +4951,9 @@ is expression-equivalent\iref{defns.expression-equivalent} to the following:
   If the decayed types of \tcode{E} and \tcode{F} differ,
   \tcode{strong_order(E, F)} is ill-formed.
 \item
-  Otherwise, \tcode{strong_ordering(strong_order(E, F))}
-  if it is a well-formed expression
-  when `strong_order` is looked up using only argument-dependent lookup\iref{basic.lookup.argdep}.
+  Otherwise, \tcode{strong_ordering(strong_order(E, F))},
+  except that \tcode{strong_order} is looked up using only argument-dependent lookup\iref{basic.lookup.argdep},
+  if that expression is well-formed when treated as an unevaluated operand.
 \item
   Otherwise, if the decayed type \tcode{T} of \tcode{E} is
   a floating-point type,
@@ -4986,9 +4986,9 @@ is expression-equivalent\iref{defns.expression-equivalent} to the following:
   If the decayed types of \tcode{E} and \tcode{F} differ,
   \tcode{weak_order(E, F)} is ill-formed.
 \item
-  Otherwise, \tcode{weak_ordering(weak_order(E, F))}
-  if it is a well-formed expression
-  when `weak_order` is looked up using only argument-dependent lookup\iref{basic.lookup.argdep}.
+  Otherwise, \tcode{weak_ordering(weak_order(E, F))},
+  except that \tcode{weak_order} is looked up using only argument-dependent lookup\iref{basic.lookup.argdep},
+  if that expression is well-formed when treated as an unevaluated operand.
 \item
   Otherwise, if the decayed type \tcode{T} of \tcode{E}
   is a floating-point type,
@@ -5035,9 +5035,9 @@ is expression-equivalent\iref{defns.expression-equivalent} to the following:
   If the decayed types of \tcode{E} and \tcode{F} differ,
   \tcode{partial_order(E, F)} is ill-formed.
 \item
-  Otherwise, \tcode{partial_ordering(partial_order(E, F))}
-  if it is a well-formed expression
-  when `partial_order` is looked up using only argument-dependent lookup\iref{basic.lookup.argdep}.
+  Otherwise, \tcode{partial_ordering(partial_order(E, F))},
+  except that \tcode{partial_order} is looked up using only argument-dependent lookup\iref{basic.lookup.argdep},
+  if that expression is well-formed when treated as an unevaluated operand.
 \item
   Otherwise, \tcode{partial_ordering(E <=> F)}
   if it is a well-formed expression.


### PR DESCRIPTION
Related to "[isocpp-lib] ADL wording formula" and [LWG3247](https://wg21.link/lwg3247); attn @CaseyCarter and @W-E-Brown among others.

This is intended to be basically editorial. The intent is:
- to use the _same_ wording in each affected place,
- to make sure the words "ADL" are used with a crossreference to the section on ADL,
- to eliminate references to "poison-pill" deleted overloads which generally are not needed, not even as an implementation detail, post-C++17.

(For example, `ranges::swap` doesn't need a poison pill because `std::swap` is properly constrained ever since C++17.)

Posting to gather wording feedback, not because I would expect this to get merged right away.
In particular, there's a whole paragraph in "lib-intro.tex" that is basically obsolete at this point, because all it's saying now is "when we say to look up a name by ADL only, we mean to look up a name by ADL only" — it doesn't have to explain the trick because there's no longer any trick. Maybe that paragraph could just be removed.