### PR TITLE
[std] Move \pnum and library element markers to a line of their own.

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -2962,7 +2962,8 @@ for the overloads in namespace \tcode{std} and \tcode{std::ranges}, respectively
 in the range \range{first}{last}, and \tcode{false} otherwise.
 
 \pnum
-\complexity At most \tcode{last - first} applications of the predicate
+\complexity
+At most \tcode{last - first} applications of the predicate
 and any projection.
 \end{itemdescr}
 
@@ -6662,7 +6663,8 @@ Returns:
 
 
 \pnum
-\complexity Let $N = \tcode{last - first}$:
+\complexity
+Let $N = \tcode{last - first}$:
 \begin{itemize}
 \item
   For the overload with no \tcode{ExecutionPolicy},
@@ -8851,7 +8853,8 @@ template<class InputIterator>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return reduce(first, last,
               typename iterator_traits<InputIterator>::value_type{});
@@ -8868,7 +8871,8 @@ template<class ExecutionPolicy, class ForwardIterator>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return reduce(std::forward<ExecutionPolicy>(exec), first, last,
               typename iterator_traits<ForwardIterator>::value_type{});
@@ -8884,7 +8888,8 @@ template<class InputIterator, class T>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return reduce(first, last, init, plus<>());
 \end{codeblock}
@@ -8899,7 +8904,8 @@ template<class ExecutionPolicy, class ForwardIterator, class T>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return reduce(std::forward<ExecutionPolicy>(exec), first, last, init, plus<>());
 \end{codeblock}
@@ -9199,7 +9205,8 @@ template<class InputIterator, class OutputIterator, class T>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return exclusive_scan(first, last, result, init, plus<>());
 \end{codeblock}
@@ -9215,7 +9222,8 @@ template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, 
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return exclusive_scan(std::forward<ExecutionPolicy>(exec),
                       first, last, result, init, plus<>());
@@ -9293,7 +9301,8 @@ template<class InputIterator, class OutputIterator>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return inclusive_scan(first, last, result, plus<>());
 \end{codeblock}
@@ -9309,7 +9318,8 @@ template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return inclusive_scan(std::forward<ExecutionPolicy>(exec), first, last, result, plus<>());
 \end{codeblock}

--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -574,11 +574,13 @@ template<class T>
 
 \begin{itemdescr}
 \pnum
-\effects The argument does not carry a dependency to the return
+\effects
+The argument does not carry a dependency to the return
 value\iref{intro.multithread}.
 
 \pnum
-\returns \tcode{y}.
+\returns
+\tcode{y}.
 \end{itemdescr}
 
 
@@ -823,10 +825,12 @@ atomic_ref(T& obj);
 \requires The referenced object shall be aligned to \tcode{required_alignment}.
 
 \pnum
-\effects Constructs an atomic reference that references the object.
+\effects
+Constructs an atomic reference that references the object.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{atomic_ref}!constructor}%
@@ -839,7 +843,8 @@ atomic_ref(const atomic_ref& ref) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an atomic reference
+\effects
+Constructs an atomic reference
 that references the object referenced by \tcode{ref}.
 \end{itemdescr}
 
@@ -853,7 +858,8 @@ T operator=(T desired) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 store(desired);
 return desired;
@@ -870,7 +876,8 @@ operator T() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return load();}
+\effects
+Equivalent to: \tcode{return load();}
 \end{itemdescr}
 
 \indexlibrarymember{is_lock_free}{atomic_ref}%
@@ -883,7 +890,8 @@ bool is_lock_free() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{true} if the object's operations are lock-free,
+\returns
+\tcode{true} if the object's operations are lock-free,
 \tcode{false} otherwise.
 \end{itemdescr}
 
@@ -903,7 +911,8 @@ void store(T desired, memory_order order = memory_order_seq_cst) const noexcept;
 \tcode{memory_order_acq_rel}.
 
 \pnum
-\effects Atomically replaces the value referenced by \tcode{*ptr}
+\effects
+Atomically replaces the value referenced by \tcode{*ptr}
 with the value of \tcode{desired}.
 Memory is affected according to the value of \tcode{order}.
 \end{itemdescr}
@@ -922,10 +931,12 @@ T load(memory_order order = memory_order_seq_cst) const noexcept;
 \tcode{memory_order_release} nor \tcode{memory_order_acq_rel}.
 
 \pnum
-\effects Memory is affected according to the value of \tcode{order}.
+\effects
+Memory is affected according to the value of \tcode{order}.
 
 \pnum
-\returns Atomically returns the value referenced by \tcode{*ptr}.
+\returns
+Atomically returns the value referenced by \tcode{*ptr}.
 \end{itemdescr}
 
 \indexlibrarymember{exchange}{atomic_ref}%
@@ -938,13 +949,15 @@ T exchange(T desired, memory_order order = memory_order_seq_cst) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Atomically replaces the value referenced by \tcode{*ptr}
+\effects
+Atomically replaces the value referenced by \tcode{*ptr}
 with \tcode{desired}.
 Memory is affected according to the value of \tcode{order}.
 This operation is an atomic read-modify-write operation\iref{intro.multithread}.
 
 \pnum
-\returns Atomically returns the value referenced by \tcode{*ptr}
+\returns
+Atomically returns the value referenced by \tcode{*ptr}
 immediately before the effects.
 \end{itemdescr}
 
@@ -976,7 +989,8 @@ bool compare_exchange_strong(T& expected, T desired,
 \tcode{memory_order_release} nor \tcode{memory_order_acq_rel}.
 
 \pnum
-\effects Retrieves the value in \tcode{expected}.
+\effects
+Retrieves the value in \tcode{expected}.
 It then atomically compares the value representation of
 the value referenced by \tcode{*ptr} for equality
 with that previously retrieved from \tcode{expected},
@@ -1004,10 +1018,12 @@ on the value referenced by \tcode{*ptr}.
 Otherwise, these operations are atomic load operations on that memory.
 
 \pnum
-\returns The result of the comparison.
+\returns
+The result of the comparison.
 
 \pnum
-\remarks A weak compare-and-exchange operation may fail spuriously.
+\remarks
+A weak compare-and-exchange operation may fail spuriously.
 That is, even when the contents of memory referred to
 by \tcode{expected} and \tcode{ptr} are equal,
 it may return \tcode{false} and
@@ -1201,19 +1217,22 @@ in \tref{atomic.types.int.comp}.
 
 \begin{itemdescr}
 \pnum
-\effects Atomically replaces the value referenced by \tcode{*ptr} with
+\effects
+Atomically replaces the value referenced by \tcode{*ptr} with
 the result of the computation applied to the value referenced by \tcode{*ptr}
 and the given operand.
 Memory is affected according to the value of \tcode{order}.
 These operations are atomic read-modify-write operations\iref{intro.races}.
 
 \pnum
-\returns Atomically, the value referenced by \tcode{*ptr}
+\returns
+Atomically, the value referenced by \tcode{*ptr}
 immediately before the effects.
 
 \pnum
 \indextext{signed integer representation!two's complement}%
-\remarks For signed integer types,
+\remarks
+For signed integer types,
 the result is as if the object value and parameters
 were converted to their corresponding unsigned types,
 the computation performed on those types, and
@@ -1234,7 +1253,8 @@ There are no undefined results arising from the computation.
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \tcode{return fetch_\placeholdernc{key}(operand) \placeholder{op} operand;}
 \end{itemdescr}
 
@@ -1317,18 +1337,21 @@ in \tref{atomic.types.int.comp}.
 
 \begin{itemdescr}
 \pnum
-\effects Atomically replaces the value referenced by \tcode{*ptr} with
+\effects
+Atomically replaces the value referenced by \tcode{*ptr} with
 the result of the computation applied to the value referenced by \tcode{*ptr}
 and the given operand.
 Memory is affected according to the value of \tcode{order}.
 These operations are atomic read-modify-write operations\iref{intro.races}.
 
 \pnum
-\returns Atomically, the value referenced by \tcode{*ptr}
+\returns
+Atomically, the value referenced by \tcode{*ptr}
 immediately before the effects.
 
 \pnum
-\remarks If the result is not a representable value for its type\iref{expr.pre},
+\remarks
+If the result is not a representable value for its type\iref{expr.pre},
 the result is unspecified,
 but the operations otherwise have no undefined behavior.
 Atomic arithmetic operations on \tcode{\placeholder{floating-point}} should conform to
@@ -1346,7 +1369,8 @@ may be different than the calling thread's floating-point environment.
 \end{itemdecl}
 
 \begin{itemdescr}
-\effects Equivalent to:
+\effects
+Equivalent to:
 \tcode{return fetch_\placeholder{key}(operand) \placeholdernc{op} operand;}
 \end{itemdescr}
 
@@ -1423,18 +1447,21 @@ T* fetch_@\placeholdernc{key}@(difference_type operand, memory_order order = mem
 otherwise the program is ill-formed.
 
 \pnum
-\effects Atomically replaces the value referenced by \tcode{*ptr} with
+\effects
+Atomically replaces the value referenced by \tcode{*ptr} with
 the result of the computation applied to the value referenced by \tcode{*ptr}
 and the given operand.
 Memory is affected according to the value of \tcode{order}.
 These operations are atomic read-modify-write operations\iref{intro.races}.
 
 \pnum
-\returns Atomically, the value referenced by \tcode{*ptr}
+\returns
+Atomically, the value referenced by \tcode{*ptr}
 immediately before the effects.
 
 \pnum
-\remarks The result may be an undefined address,
+\remarks
+The result may be an undefined address,
 but the operations otherwise have no undefined behavior.
 \end{itemdescr}
 
@@ -1446,7 +1473,8 @@ T* operator @\placeholder{op}@=(difference_type operand) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \tcode{return fetch_\placeholder{key}(operand) \placeholdernc{op} operand;}
 \end{itemdescr}
 
@@ -1461,7 +1489,8 @@ T* operator++(int) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return fetch_add(1);}
+\effects
+Equivalent to: \tcode{return fetch_add(1);}
 \end{itemdescr}
 
 \indexlibrarymember{operator\dcr}{atomic_ref<T*>}%
@@ -1472,7 +1501,8 @@ T* operator--(int) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return fetch_sub(1);}
+\effects
+Equivalent to: \tcode{return fetch_sub(1);}
 \end{itemdescr}
 
 \indexlibrarymember{operator++}{atomic_ref<T*>}%
@@ -1483,7 +1513,8 @@ T* operator++() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return fetch_add(1) + 1;}
+\effects
+Equivalent to: \tcode{return fetch_add(1) + 1;}
 \end{itemdescr}
 
 \indexlibrarymember{operator\dcr}{atomic_ref<T*>}%
@@ -1494,7 +1525,8 @@ T* operator--(int) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return fetch_sub(1) - 1;}
+\effects
+Equivalent to: \tcode{return fetch_sub(1) - 1;}
 \end{itemdescr}
 
 \rSec1[atomics.types.generic]{Class template \tcode{atomic}}
@@ -1604,7 +1636,8 @@ constexpr atomic(T desired) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Initializes the object with the value \tcode{desired}.
+\effects
+Initializes the object with the value \tcode{desired}.
 Initialization is not an atomic operation\iref{intro.multithread}.
 \begin{note} It is possible to have an access to an atomic object \tcode{A}
 race with its construction, for example by communicating the address of the
@@ -1664,7 +1697,8 @@ bool is_lock_free() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{true} if the object's operations are lock-free, \tcode{false} otherwise.
+\returns
+\tcode{true} if the object's operations are lock-free, \tcode{false} otherwise.
 \begin{note}
 The return value of the \tcode{is_lock_free} member function
 is consistent with the value of \tcode{is_always_lock_free} for the same type.
@@ -1688,7 +1722,8 @@ void store(T desired, memory_order order = memory_order::seq_cst) noexcept;
 \tcode{memory_order::acquire}, nor \tcode{memory_order::acq_rel}.
 
 \pnum
-\effects Atomically replaces the value pointed to by \tcode{this}
+\effects
+Atomically replaces the value pointed to by \tcode{this}
 with the value of \tcode{desired}. Memory is affected according to the value of
 \tcode{order}.
 \end{itemdescr}
@@ -1704,10 +1739,12 @@ T operator=(T desired) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to \tcode{store(desired)}.
+\effects
+Equivalent to \tcode{store(desired)}.
 
 \pnum
-\returns \tcode{desired}.
+\returns
+\tcode{desired}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{atomic_load}}%
@@ -1726,10 +1763,12 @@ T load(memory_order order = memory_order::seq_cst) const noexcept;
 \requires The \tcode{order} argument shall not be \tcode{memory_order::release} nor \tcode{memory_order::acq_rel}.
 
 \pnum
-\effects Memory is affected according to the value of \tcode{order}.
+\effects
+Memory is affected according to the value of \tcode{order}.
 
 \pnum
-\returns Atomically returns the value pointed to by \tcode{this}.
+\returns
+Atomically returns the value pointed to by \tcode{this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator \placeholder{type}}{atomic}%
@@ -1743,7 +1782,8 @@ operator T() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return load();}
+\effects
+Equivalent to: \tcode{return load();}
 \end{itemdescr}
 
 
@@ -1760,13 +1800,15 @@ T exchange(T desired, memory_order order = memory_order::seq_cst) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Atomically replaces the value pointed to by \tcode{this}
+\effects
+Atomically replaces the value pointed to by \tcode{this}
 with \tcode{desired}.
 Memory is affected according to the value of \tcode{order}.
 These operations are atomic read-modify-write operations\iref{intro.multithread}.
 
 \pnum
-\returns Atomically returns the value pointed to by \tcode{this} immediately before the effects.
+\returns
+Atomically returns the value pointed to by \tcode{this} immediately before the effects.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{atomic_compare_exchange_weak}}%
@@ -1830,7 +1872,8 @@ pointed to by \tcode{this}.
 Otherwise, these operations are atomic load operations on that memory.
 
 \pnum
-\returns The result of the comparison.
+\returns
+The result of the comparison.
 
 \pnum
 \begin{note}
@@ -2180,18 +2223,21 @@ T fetch_@\placeholdernc{key}@(T operand, memory_order order = memory_order::seq_
 
 \begin{itemdescr}
 \pnum
-\effects Atomically replaces the value pointed to by
+\effects
+Atomically replaces the value pointed to by
 \tcode{this} with the result of the computation applied to the
 value pointed to by \tcode{this} and the given \tcode{operand}.
 Memory is affected according to the value of \tcode{order}.
 These operations are atomic read-modify-write operations\iref{intro.multithread}.
 
 \pnum
-\returns Atomically, the value pointed to by \tcode{this} immediately before the effects.
+\returns
+Atomically, the value pointed to by \tcode{this} immediately before the effects.
 
 \pnum
 \indextext{signed integer representation!two's complement}%
-\remarks For signed integer types,
+\remarks
+For signed integer types,
 the result is as if the object value and parameters
 were converted to their corresponding unsigned types,
 the computation performed on those types, and
@@ -2216,7 +2262,8 @@ T operator @\placeholder{op}@=(T operand) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return fetch_\placeholder{key}(operand) \placeholder{op} operand;}
+\effects
+Equivalent to: \tcode{return fetch_\placeholder{key}(operand) \placeholder{op} operand;}
 \end{itemdescr}
 
 \rSec2[atomics.types.float]{Specializations for floating-point types}
@@ -2490,17 +2537,20 @@ T* fetch_@\placeholdernc{key}@(ptrdiff_t operand, memory_order order = memory_or
 \begin{note} Pointer arithmetic on \tcode{void*} or function pointers is ill-formed. \end{note}
 
 \pnum
-\effects Atomically replaces the value pointed to by
+\effects
+Atomically replaces the value pointed to by
 \tcode{this} with the result of the computation applied to the
 value pointed to by \tcode{this} and the given \tcode{operand}.
 Memory is affected according to the value of \tcode{order}.
 These operations are atomic read-modify-write operations\iref{intro.multithread}.
 
 \pnum
-\returns Atomically, the value pointed to by \tcode{this} immediately before the effects.
+\returns
+Atomically, the value pointed to by \tcode{this} immediately before the effects.
 
 \pnum
-\remarks The result may be an undefined address,
+\remarks
+The result may be an undefined address,
 but the operations otherwise have no undefined behavior.
 \end{itemdescr}
 
@@ -2513,7 +2563,8 @@ T* operator @\placeholder{op}@=(ptrdiff_t operand) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return fetch_\placeholder{key}(operand) \placeholder{op} operand;}
+\effects
+Equivalent to: \tcode{return fetch_\placeholder{key}(operand) \placeholder{op} operand;}
 \end{itemdescr}
 
 \rSec2[atomics.types.memop]{Member operators common to integers and pointers to objects}
@@ -2527,7 +2578,8 @@ T operator++(int) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return fetch_add(1);}
+\effects
+Equivalent to: \tcode{return fetch_add(1);}
 \end{itemdescr}
 
 \indexlibrarymember{operator\dcr}{atomic<T*>}%
@@ -2539,7 +2591,8 @@ T operator--(int) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return fetch_sub(1);}
+\effects
+Equivalent to: \tcode{return fetch_sub(1);}
 \end{itemdescr}
 
 \indexlibrarymember{operator++}{atomic<T*>}%
@@ -2551,7 +2604,8 @@ T operator++() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return fetch_add(1) + 1;}
+\effects
+Equivalent to: \tcode{return fetch_add(1) + 1;}
 \end{itemdescr}
 
 \indexlibrarymember{operator\dcr}{atomic<T*>}%
@@ -2563,7 +2617,8 @@ T operator--() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return fetch_sub(1) - 1;}
+\effects
+Equivalent to: \tcode{return fetch_sub(1) - 1;}
 \end{itemdescr}
 
 
@@ -2589,7 +2644,8 @@ template<class T>
 
 \begin{itemdescr}
 \pnum
-\effects Non-atomically
+\effects
+Non-atomically
 initializes \tcode{*object} with value \tcode{desired}. This function shall only be applied
 to objects that have been default constructed, and then only once.
 \begin{note}
@@ -2710,11 +2766,13 @@ bool atomic_flag::test_and_set(memory_order order = memory_order::seq_cst) noexc
 
 \begin{itemdescr}
 \pnum
-\effects Atomically sets the value pointed to by \tcode{object} or by \tcode{this} to \tcode{true}. Memory is affected according to the value of
+\effects
+Atomically sets the value pointed to by \tcode{object} or by \tcode{this} to \tcode{true}. Memory is affected according to the value of
 \tcode{order}. These operations are atomic read-modify-write operations\iref{intro.multithread}.
 
 \pnum
-\returns Atomically, the value of the object immediately before the effects.
+\returns
+Atomically, the value of the object immediately before the effects.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{atomic_flag_clear}}%
@@ -2735,7 +2793,8 @@ void atomic_flag::clear(memory_order order = memory_order::seq_cst) noexcept;
 \tcode{memory_order::acquire}, nor \tcode{memory_order::acq_rel}.
 
 \pnum
-\effects Atomically sets the value pointed to by \tcode{object} or by \tcode{this} to
+\effects
+Atomically sets the value pointed to by \tcode{object} or by \tcode{this} to
 \tcode{false}. Memory is affected according to the value of \tcode{order}.
 \end{itemdescr}
 
@@ -2860,7 +2919,8 @@ extern "C" void atomic_thread_fence(memory_order order) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Depending on the value of \tcode{order}, this operation:
+\effects
+Depending on the value of \tcode{order}, this operation:
 
 \begin{itemize}
 \item has no effects, if \tcode{order == memory_order::relaxed};
@@ -2882,7 +2942,8 @@ extern "C" void atomic_signal_fence(memory_order order) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to \tcode{atomic_thread_fence(order)}, except that
+\effects
+Equivalent to \tcode{atomic_thread_fence(order)}, except that
 the resulting ordering constraints are established only between a thread and a
 signal handler executed in the same thread.
 

--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -1660,7 +1660,8 @@ an atomic variable of static storage duration of a type that is
 initialization-compatible with \tcode{value}.
 \begin{note} This operation may need to initialize locks. \end{note}
 Concurrent access to the variable being initialized, even via an atomic operation,
-constitutes a data race. \begin{example}
+constitutes a data race.
+\begin{example}
 \begin{codeblock}
 atomic<int> v = ATOMIC_VAR_INIT(5);
 \end{codeblock}
@@ -1887,7 +1888,8 @@ else
   memcpy(expected, this, sizeof(*this));
 \end{codeblock}
 \end{note}
-\begin{example} The expected use of the compare-and-exchange operations is as follows. The
+\begin{example}
+The expected use of the compare-and-exchange operations is as follows. The
 compare-and-exchange operations will update \tcode{expected} when another iteration of
 the loop is needed.
 \begin{codeblock}
@@ -1897,7 +1899,8 @@ do {
 } while (!current.compare_exchange_weak(expected, desired));
 \end{codeblock}
 \end{example}
-\begin{example} Because the expected value is updated only on failure,
+\begin{example}
+Because the expected value is updated only on failure,
 code releasing the memory containing the \tcode{expected} value on success will work.
 For example, list head insertion will act atomically and would not introduce a
 data race in the following code:

--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -408,20 +408,24 @@ affected memory location.
 
 \item \tcode{memory_order::consume}: a load operation performs a consume operation on the
 affected memory location.
-\begin{note} Prefer \tcode{memory_order::acquire}, which provides stronger guarantees
+\begin{note}
+Prefer \tcode{memory_order::acquire}, which provides stronger guarantees
 than \tcode{memory_order::consume}. Implementations have found it infeasible
 to provide performance better than that of \tcode{memory_order::acquire}.
-Specification revisions are under consideration. \end{note}
+Specification revisions are under consideration.
+\end{note}
 
 \item \tcode{memory_order::acquire}, \tcode{memory_order::acq_rel}, and
 \tcode{memory_order::seq_cst}: a load operation performs an acquire operation on the
 affected memory location.
 \end{itemize}
 
-\begin{note} Atomic operations specifying \tcode{memory_order::relaxed} are relaxed
+\begin{note}
+Atomic operations specifying \tcode{memory_order::relaxed} are relaxed
 with respect to memory ordering. Implementations must still guarantee that any
 given atomic access to a particular atomic object be indivisible with respect
-to all other atomic accesses to that object. \end{note}
+to all other atomic accesses to that object.
+\end{note}
 
 \pnum
 An atomic operation \placeholder{A} that performs a release operation on an atomic
@@ -519,7 +523,8 @@ with respect to other atomic operations performed by the same thread.
 Implementations should ensure that no ``out-of-thin-air'' values are computed that
 circularly depend on their own computation.
 
-\begin{note} For example, with \tcode{x} and \tcode{y} initially zero,
+\begin{note}
+For example, with \tcode{x} and \tcode{y} initially zero,
 
 \begin{codeblock}
 // Thread 1:
@@ -540,7 +545,8 @@ execution is possible.
 \end{note}
 
 \pnum
-\begin{note} The recommendation similarly disallows \tcode{r1 == r2 == 42} in the
+\begin{note}
+The recommendation similarly disallows \tcode{r1 == r2 == 42} in the
 following example, with \tcode{x} and \tcode{y} again initially zero:
 
 \begin{codeblock}
@@ -640,12 +646,14 @@ Atomic operations that are not lock-free are considered to potentially
 block\iref{intro.progress}.
 
 \pnum
-\begin{note} Operations that are lock-free should also be address-free. That is,
+\begin{note}
+Operations that are lock-free should also be address-free. That is,
 atomic operations on the same memory location via two different addresses will
 communicate atomically. The implementation should not depend on any
 per-process state. This restriction enables communication  by memory that is
 mapped into a process more than once and by memory that is shared between two
-processes. \end{note}
+processes.
+\end{note}
 
 \rSec1[atomics.wait]{Waiting and notifying}
 
@@ -1588,8 +1596,10 @@ The program is ill-formed if any of
 \item \tcode{is_move_assignable_v<T>}
 \end{itemize}
 is \tcode{false}.
-\begin{note} Type arguments that are
-not also statically initializable may be difficult to use. \end{note}
+\begin{note}
+Type arguments that are
+not also statically initializable may be difficult to use.
+\end{note}
 
 \pnum
 The specialization \tcode{atomic<bool>} is a standard-layout struct.
@@ -1604,10 +1614,12 @@ its corresponding argument type.
 \rSec2[atomics.types.operations]{Operations on atomic types}
 
 \pnum
-\begin{note} Many operations are volatile-qualified. The ``volatile as device register''
+\begin{note}
+Many operations are volatile-qualified. The ``volatile as device register''
 semantics have not changed in the standard. This qualification means that volatility is
 preserved when applying these operations to volatile objects. It does not mean that
-operations on non-volatile objects become volatile. \end{note}
+operations on non-volatile objects become volatile.
+\end{note}
 
 \indexlibrary{\idxcode{atomic}!constructor}%
 \indexlibrary{\idxcode{atomic<T*>}!constructor}%
@@ -1639,12 +1651,14 @@ constexpr atomic(T desired) noexcept;
 \effects
 Initializes the object with the value \tcode{desired}.
 Initialization is not an atomic operation\iref{intro.multithread}.
-\begin{note} It is possible to have an access to an atomic object \tcode{A}
+\begin{note}
+It is possible to have an access to an atomic object \tcode{A}
 race with its construction, for example by communicating the address of the
 just-constructed object \tcode{A} to another thread via
 \tcode{memory_order::relaxed} operations on a suitable atomic pointer
 variable, and then immediately accessing \tcode{A} in the receiving thread.
-This results in undefined behavior. \end{note}
+This results in undefined behavior.
+\end{note}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{ATOMIC_VAR_INIT}}%
@@ -1658,7 +1672,9 @@ The macro expands to a token sequence suitable for
 constant initialization of
 an atomic variable of static storage duration of a type that is
 initialization-compatible with \tcode{value}.
-\begin{note} This operation may need to initialize locks. \end{note}
+\begin{note}
+This operation may need to initialize locks.
+\end{note}
 Concurrent access to the variable being initialized, even via an atomic operation,
 constitutes a data race.
 \begin{example}
@@ -1923,7 +1939,8 @@ A weak compare-and-exchange operation may fail spuriously. That is, even when
 the contents of memory referred to by \tcode{expected} and \tcode{this} are
 equal, it may return \tcode{false} and store back to \tcode{expected} the same memory
 contents that were originally there.
-\begin{note} This
+\begin{note}
+This
 spurious failure enables implementation of compare-and-exchange on a broader class of
 machines, e.g., load-locked store-conditional machines. A
 consequence of spurious failure is that nearly all uses of weak compare-and-exchange
@@ -2537,7 +2554,9 @@ T* fetch_@\placeholdernc{key}@(ptrdiff_t operand, memory_order order = memory_or
 \begin{itemdescr}
 \pnum
 \requires T shall be an object type, otherwise the program is ill-formed.
-\begin{note} Pointer arithmetic on \tcode{void*} or function pointers is ill-formed. \end{note}
+\begin{note}
+Pointer arithmetic on \tcode{void*} or function pointers is ill-formed.
+\end{note}
 
 \pnum
 \effects
@@ -2697,8 +2716,11 @@ namespace std {
 The \tcode{atomic_flag} type provides the classic test-and-set functionality. It has two states, set and clear.
 
 \pnum
-Operations on an object of type \tcode{atomic_flag} shall be lock-free. \begin{note} Hence
-the operations should also be address-free. \end{note}
+Operations on an object of type \tcode{atomic_flag} shall be lock-free.
+\begin{note}
+Hence
+the operations should also be address-free.
+\end{note}
 
 \pnum
 The \tcode{atomic_flag} type is a standard-layout struct.

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -992,7 +992,6 @@ into that scope.
 \begin{note}
 For point of instantiation of a template, see~\ref{temp.point}.
 \end{note}
-%
 \indextext{scope!declarations and|)}%
 \indextext{declaration!point of|)}
 
@@ -2501,7 +2500,6 @@ struct Base::Datum;             // error: \tcode{Datum} undefined
 struct Base::Data* pBase;       // OK: refers to nested \tcode{Data}
 \end{codeblock}
 \end{example}
-%
 \indextext{lookup!elaborated type specifier|)}%
 
 \rSec2[basic.lookup.classref]{Class member access}
@@ -2913,7 +2911,6 @@ identity does not require a diagnostic.
 Linkage to non-\Cpp{} declarations can be achieved using a
 \grammarterm{linkage-specification}\iref{dcl.link}.
 \end{note}
-%
 \indextext{linkage|)}
 
 \rSec1[basic.memobj]{Memory and objects}
@@ -2990,7 +2987,6 @@ modified concurrently without interfering with each other. The bit-fields
 bit-fields \tcode{b} and \tcode{c} cannot be concurrently modified, but
 \tcode{b} and \tcode{a}, for example, can be.
 \end{example}
-%
 \indextext{memory model|)}
 
 \rSec2[intro.object]{Object model}
@@ -3218,7 +3214,6 @@ occupied by the complete object of that subobject.
 \Cpp{} provides a variety of fundamental types and several ways of composing
 new types from existing types\iref{basic.types}.
 \end{note}
-%
 \indextext{object model|)}
 
 \rSec2[basic.life]{Object and reference lifetime}
@@ -3487,7 +3482,6 @@ Therefore, undefined behavior results
 if an object that is being constructed in one thread is referenced from another
 thread without adequate synchronization.
 \end{note}
-%
 \indextext{object lifetime|)}
 
 \rSec2[basic.indet]{Indeterminate values}
@@ -4538,7 +4532,6 @@ std::memcpy(t1p, t2p, sizeof(T));
     // the same value as the corresponding subobject in \tcode{*t2p}
 \end{codeblock}
 \end{example}
-%
 \indextext{object!byte copying and|)}
 
 \pnum
@@ -5243,7 +5236,6 @@ The type of both \tcode{arr1} and \tcode{arr2} is ``array of 5
 \tcode{const char}'', and the array type is considered to be
 const-qualified.
 \end{example}
-%
 \indextext{type|)}
 
 \rSec2[conv.rank]{Integer conversion rank}%
@@ -5301,7 +5293,6 @@ The integer conversion rank is used in the definition of the integral
 promotions\iref{conv.prom} and the usual arithmetic
 conversions\iref{expr.prop}.
 \end{note}
-%
 
 \rSec1[basic.exec]{Program execution}
 

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -184,7 +184,8 @@ an explicit specialization\iref{temp.expl.spec} whose
 \grammarterm{declaration} is not a definition.
 \end{itemize}
 A declaration is said to be a \defn{definition} of each entity that it defines.
-\begin{example} All but one of the following are definitions:
+\begin{example}
+All but one of the following are definitions:
 \begin{codeblock}
 int a;                          // defines \tcode{a}
 extern const int c = 1;         // defines \tcode{c}
@@ -223,7 +224,8 @@ copy constructor, move constructor\iref{class.copy.ctor},
 copy assignment operator, move assignment operator\iref{class.copy.assign},
 or destructor\iref{class.dtor} member functions.
 \end{note}
-\begin{example} Given
+\begin{example}
+Given
 \begin{codeblock}
 #include <string>
 
@@ -495,7 +497,8 @@ translation unit.
 \indextext{type!incomplete}%
 A definition of a class is required to be reachable in every context in which
 the class is used in a way that requires the class type to be complete.
-\begin{example} The following complete translation unit is well-formed,
+\begin{example}
+The following complete translation unit is well-formed,
 even though it never defines \tcode{X}:
 
 \begin{codeblock}
@@ -822,7 +825,8 @@ that are or enclose \placeholder{R} and do not enclose \placeholder{P}.
 \indextext{point of!declaration|see{declaration, point of}}%
 The \defnx{point of declaration}{declaration!point of} for a name is immediately after its
 complete declarator\iref{dcl.decl} and before its
-\grammarterm{initializer} (if any), except as noted below. \begin{example}
+\grammarterm{initializer} (if any), except as noted below.
+\begin{example}
 
 \begin{codeblock}
 unsigned char x = 12;
@@ -836,7 +840,8 @@ value. \end{example}
 \begin{note}
 \indextext{name hiding}%
 A name from an outer scope remains visible up
-to the point of declaration of the name that hides it. \begin{example}
+to the point of declaration of the name that hides it.
+\begin{example}
 
 \begin{codeblock}
 const int  i = 2;
@@ -864,7 +869,8 @@ constructor is immediately after the \grammarterm{using-declarator}\iref{namespa
 \pnum
 \indextext{declaration!enumerator point of}%
 The point of declaration for an enumerator is immediately after its
-\grammarterm{enumerator-definition}. \begin{example}
+\grammarterm{enumerator-definition}.
+\begin{example}
 
 \begin{codeblock}
 const int x = 12;
@@ -944,7 +950,8 @@ is immediately after the \grammarterm{for-range-initializer}.
 
 \pnum
 The point of declaration for a template parameter is immediately after its complete
-\grammarterm{template-parameter}. \begin{example}
+\grammarterm{template-parameter}.
+\begin{example}
 
 \begin{codeblock}
 typedef unsigned char T;
@@ -1234,7 +1241,8 @@ The declarative region of the name of a template parameter of a template is the 
 parameter names belong to this declarative region; any other kind of name introduced by
 the \grammarterm{declaration} of a \grammarterm{template-declaration} is instead
 introduced into the same declarative region where it would be introduced as a result of
-a non-template declaration of the same name. \begin{example}
+a non-template declaration of the same name.
+\begin{example}
 
 \begin{codeblock}
 namespace N {
@@ -1283,7 +1291,8 @@ argument must be defined and not just declared when the class template is instan
 The declarative region of the name of a template parameter is nested within the
 immediately-enclosing declarative region. \begin{note} As a result, a
 \grammarterm{template-parameter} hides any entity with the same name in an enclosing
-scope\iref{basic.scope.hiding}. \begin{example}
+scope\iref{basic.scope.hiding}.
+\begin{example}
 
 \begin{codeblock}
 typedef int N;
@@ -1638,7 +1647,8 @@ or if the name is part of a
 \grammarterm{template-argument} in
 the \grammarterm{declarator-id}, the look up is
 as described for unqualified names in the definition of the class
-granting friendship. \begin{example}
+granting friendship.
+\begin{example}
 
 \begin{codeblock}
 struct A {
@@ -1956,7 +1966,8 @@ in a \grammarterm{nested-name-specifier} is not preceded by a \grammarterm{declt
 lookup of the name preceding that \tcode{::} considers only namespaces, types, and
 templates whose specializations are types. If the
 name found does not designate a namespace or a class, enumeration, or dependent type,
-the program is ill-formed. \begin{example}
+the program is ill-formed.
+\begin{example}
 
 \begin{codeblock}
 class A {
@@ -1981,7 +1992,8 @@ In a declaration in which the \grammarterm{declarator-id} is a
 \grammarterm{qualified-id}, names used before the \grammarterm{qualified-id}
 being declared are looked up in the defining namespace scope; names
 following the \grammarterm{qualified-id} are looked up in the scope of the
-member's class or namespace. \begin{example}
+member's class or namespace.
+\begin{example}
 
 \begin{codeblock}
 class X { };
@@ -2154,7 +2166,8 @@ a \grammarterm{using-declaration}\iref{namespace.udecl}, $S(X, m)$
 is the
 required set of declarations of \tcode{m}. Otherwise if the use of
 \tcode{m} is not one that allows a unique declaration to be chosen from
-$S(X, m)$, the program is ill-formed. \begin{example}
+$S(X, m)$, the program is ill-formed.
+\begin{example}
 
 \begin{codeblock}
 int x;
@@ -2341,7 +2354,8 @@ void A::f1(int){ }  // ill-formed, \tcode{f1} is not a member of \tcode{A}
 \end{example} However, in such namespace member declarations, the
 \grammarterm{nested-name-specifier} may rely on \grammarterm{using-directive}{s}
 to implicitly provide the initial part of the
-\grammarterm{nested-name-specifier}. \begin{example}
+\grammarterm{nested-name-specifier}.
+\begin{example}
 
 \begin{codeblock}
 namespace A {
@@ -2471,7 +2485,8 @@ If the \grammarterm{unqualified-id} is \tcode{\~}\grammarterm{type-name}, the
 \grammarterm{postfix-expression}. If the type \tcode{T} of the object
 expression is of a class type \tcode{C}, the \grammarterm{type-name} is
 also looked up in the scope of class \tcode{C}. At least one of the
-lookups shall find a name that refers to \cv{}~\tcode{T}. \begin{example}
+lookups shall find a name that refers to \cv{}~\tcode{T}.
+\begin{example}
 
 \begin{codeblock}
 struct A { };
@@ -2744,7 +2759,8 @@ Because the declaration with internal linkage is hidden, however,
 When a block scope declaration of an entity with linkage is not found to
 refer to some other declaration, then that entity is a member of the
 innermost enclosing namespace. However such a declaration does not
-introduce the member name in its namespace scope. \begin{example}
+introduce the member name in its namespace scope.
+\begin{example}
 
 \begin{codeblock}
 namespace X {
@@ -2893,7 +2909,8 @@ in the same struct if all fields between them are also bit-fields of nonzero
 width. \end{note}
 
 \pnum
-\begin{example} A class declared as
+\begin{example}
+A class declared as
 
 \begin{codeblock}
 struct {
@@ -3357,7 +3374,8 @@ with static storage duration.}
 the program must ensure that an object of the original type occupies
 that same storage location when the implicit destructor call takes
 place; otherwise the behavior of the program is undefined. This is true
-even if the block is exited with an exception. \begin{example}
+even if the block is exited with an exception.
+\begin{example}
 
 \begin{codeblock}
 class T { };
@@ -3930,7 +3948,8 @@ less than or equal to the greatest alignment supported by the implementation in
 all contexts, which is equal to
 \tcode{alignof(std::max_align_t)}\iref{support.types}.
 The alignment required for a type might be different when it is used as the type
-of a complete object and when it is used as the type of a subobject. \begin{example}
+of a complete object and when it is used as the type of a subobject.
+\begin{example}
 \begin{codeblock}
 struct B { long double d; };
 struct D : virtual B { char c; };
@@ -4055,7 +4074,8 @@ for certain unevaluated operands~(\ref{expr.typeid}, \ref{expr.sizeof}), and
 when a prvalue that has type other than \cv{}~\tcode{void} appears as a discarded-value expression\iref{expr.prop}.
 \end{itemize}
 \end{note}
-\begin{example} Consider the following code:
+\begin{example}
+Consider the following code:
 \begin{codeblock}
 class X {
 public:
@@ -4396,7 +4416,8 @@ object can be copied into an array of
 functions\iref{headers} \tcode{std::memcpy} or \tcode{std::memmove}.}
 If the content of that array
 is copied back into the object, the object shall
-subsequently hold its original value. \begin{example}
+subsequently hold its original value.
+\begin{example}
 \begin{codeblock}
 #define N sizeof(T)
 char buf[N];
@@ -4414,7 +4435,8 @@ bytes\iref{intro.memory} making up
 \tcode{obj1} are copied into \tcode{obj2},\footnote{By using, for example,
 the library functions\iref{headers} \tcode{std::memcpy} or \tcode{std::memmove}.}
  \tcode{obj2} shall subsequently hold the same value as
-\tcode{obj1}. \begin{example}
+\tcode{obj1}.
+\begin{example}
 
 \begin{codeblock}
 T* t1p;
@@ -4471,7 +4493,8 @@ point in a translation unit and complete later on; the array types at
 those two points (``array of unknown bound of \tcode{T}'' and ``array of
 \tcode{N} \tcode{T}'') are different types. The type of a pointer to array of
 unknown bound, or of a type defined by a \tcode{typedef} declaration to
-be an array of unknown bound, cannot be completed. \begin{example}
+be an array of unknown bound, cannot be completed.
+\begin{example}
 
 \indextext{type!example of incomplete}%
 \begin{codeblock}
@@ -4919,7 +4942,9 @@ does not have a pointer-to-object type, however, because \tcode{void} is not
 an object type. \end{note} The type of a pointer that can designate a function
 is called a \defn{function pointer type}.
 A pointer to objects of type \tcode{T} is referred to as a ``pointer to
-\tcode{T}''. \begin{example} A pointer to an object of type \tcode{int} is
+\tcode{T}''.
+\begin{example}
+A pointer to an object of type \tcode{int} is
 referred to as ``pointer to \tcode{int}'' and a pointer to an object of
 class \tcode{X} is called a ``pointer to \tcode{X}''. \end{example}
 Except for pointers to static members, text referring to ``pointers''
@@ -6095,7 +6120,9 @@ or that declares a function \tcode{main} at global scope attached to a named mod
 or that declares the name \tcode{main} with C language linkage (in any namespace)
 is ill-formed.
 The name \tcode{main} is
-not otherwise reserved. \begin{example} Member functions, classes, and
+not otherwise reserved.
+\begin{example}
+Member functions, classes, and
 enumerations can be called \tcode{main}, as can entities in other
 namespaces. \end{example}
 

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -628,7 +628,6 @@ implicitly defined in every translation unit where it is odr-used, and the
 implicit definition in every translation unit shall call the same
 constructor for a subobject of \tcode{D}.
 \begin{example}
-
 \begin{codeblock}
 // translation unit 1:
 struct X {
@@ -827,7 +826,6 @@ The \defnx{point of declaration}{declaration!point of} for a name is immediately
 complete declarator\iref{dcl.decl} and before its
 \grammarterm{initializer} (if any), except as noted below.
 \begin{example}
-
 \begin{codeblock}
 unsigned char x = 12;
 { unsigned char x = x; }
@@ -842,7 +840,6 @@ value. \end{example}
 A name from an outer scope remains visible up
 to the point of declaration of the name that hides it.
 \begin{example}
-
 \begin{codeblock}
 const int  i = 2;
 { int  i[i]; }
@@ -871,7 +868,6 @@ constructor is immediately after the \grammarterm{using-declarator}\iref{namespa
 The point of declaration for an enumerator is immediately after its
 \grammarterm{enumerator-definition}.
 \begin{example}
-
 \begin{codeblock}
 const int x = 12;
 { enum { x = x }; }
@@ -952,7 +948,6 @@ is immediately after the \grammarterm{for-range-initializer}.
 The point of declaration for a template parameter is immediately after its complete
 \grammarterm{template-parameter}.
 \begin{example}
-
 \begin{codeblock}
 typedef unsigned char T;
 template<class T
@@ -1067,7 +1062,6 @@ member's namespace, the member's potential scope includes that portion
 of the potential scope of the \grammarterm{using-directive} that follows
 the member's point of declaration.
 \begin{example}
-
 \begin{codeblock}
 namespace N {
   int i;
@@ -1243,7 +1237,6 @@ the \grammarterm{declaration} of a \grammarterm{template-declaration} is instead
 introduced into the same declarative region where it would be introduced as a result of
 a non-template declaration of the same name.
 \begin{example}
-
 \begin{codeblock}
 namespace N {
   template<class T> struct A { };               // \#1
@@ -1293,7 +1286,6 @@ immediately-enclosing declarative region. \begin{note} As a result, a
 \grammarterm{template-parameter} hides any entity with the same name in an enclosing
 scope\iref{basic.scope.hiding}.
 \begin{example}
-
 \begin{codeblock}
 typedef int N;
 template<N X, typename N, template<N Y> class T> struct A;
@@ -1478,7 +1470,6 @@ its enclosing blocks\iref{stmt.block} or shall be declared before its
 use in namespace \tcode{N} or, if \tcode{N} is a nested namespace, shall
 be declared before its use in one of \tcode{N}'s enclosing namespaces.
 \begin{example}
-
 \begin{codeblock}
 namespace A {
   namespace N {
@@ -1649,7 +1640,6 @@ the \grammarterm{declarator-id}, the look up is
 as described for unqualified names in the definition of the class
 granting friendship.
 \begin{example}
-
 \begin{codeblock}
 struct A {
   typedef int AT;
@@ -1701,7 +1691,6 @@ its namespace then any name that appears in the definition of the
 member (after the \grammarterm{declarator-id}) is looked up as if the
 definition of the member occurred in its namespace.
 \begin{example}
-
 \begin{codeblock}
 namespace N {
   int i = 4;
@@ -1853,7 +1842,6 @@ union of \placeholder{X} and \placeholder{Y}. \begin{note} The namespaces and en
 associated with the argument types can include namespaces and entities
 already considered by the ordinary unqualified lookup. \end{note}
 \begin{example}
-
 \begin{codeblock}
 namespace NS {
   class T { };
@@ -1968,7 +1956,6 @@ templates whose specializations are types. If the
 name found does not designate a namespace or a class, enumeration, or dependent type,
 the program is ill-formed.
 \begin{example}
-
 \begin{codeblock}
 class A {
 public:
@@ -1994,7 +1981,6 @@ being declared are looked up in the defining namespace scope; names
 following the \grammarterm{qualified-id} are looked up in the scope of the
 member's class or namespace.
 \begin{example}
-
 \begin{codeblock}
 class X { };
 class C {
@@ -2168,7 +2154,6 @@ required set of declarations of \tcode{m}. Otherwise if the use of
 \tcode{m} is not one that allows a unique declaration to be chosen from
 $S(X, m)$, the program is ill-formed.
 \begin{example}
-
 \begin{codeblock}
 int x;
 namespace Y {
@@ -2305,7 +2290,6 @@ functions, the non-type name hides the class or enumeration name if and
 only if the declarations are from the same namespace; otherwise (the
 declarations are from different namespaces), the program is ill-formed.
 \begin{example}
-
 \begin{codeblock}
 namespace A {
   struct x { };
@@ -2340,7 +2324,6 @@ the
 designated by the \grammarterm{nested-name-specifier}
 or of an element of the inline namespace set\iref{namespace.def} of that namespace.
 \begin{example}
-
 \begin{codeblock}
 namespace A {
   namespace B {
@@ -2356,7 +2339,6 @@ void A::f1(int){ }  // ill-formed, \tcode{f1} is not a member of \tcode{A}
 to implicitly provide the initial part of the
 \grammarterm{nested-name-specifier}.
 \begin{example}
-
 \begin{codeblock}
 namespace A {
   namespace B {
@@ -2487,7 +2469,6 @@ expression is of a class type \tcode{C}, the \grammarterm{type-name} is
 also looked up in the scope of class \tcode{C}. At least one of the
 lookups shall find a name that refers to \cv{}~\tcode{T}.
 \begin{example}
-
 \begin{codeblock}
 struct A { };
 
@@ -2761,7 +2742,6 @@ refer to some other declaration, then that entity is a member of the
 innermost enclosing namespace. However such a declaration does not
 introduce the member name in its namespace scope.
 \begin{example}
-
 \begin{codeblock}
 namespace X {
   void p() {
@@ -3376,7 +3356,6 @@ that same storage location when the implicit destructor call takes
 place; otherwise the behavior of the program is undefined. This is true
 even if the block is exited with an exception.
 \begin{example}
-
 \begin{codeblock}
 class T { };
 struct B {
@@ -4437,7 +4416,6 @@ the library functions\iref{headers} \tcode{std::memcpy} or \tcode{std::memmove}.
  \tcode{obj2} shall subsequently hold the same value as
 \tcode{obj1}.
 \begin{example}
-
 \begin{codeblock}
 T* t1p;
 T* t2p;
@@ -4495,7 +4473,6 @@ those two points (``array of unknown bound of \tcode{T}'' and ``array of
 unknown bound, or of a type defined by a \tcode{typedef} declaration to
 be an array of unknown bound, cannot be completed.
 \begin{example}
-
 \indextext{type!example of incomplete}%
 \begin{codeblock}
 class X;                        // \tcode{X} is an incomplete type
@@ -5406,7 +5383,6 @@ potentially concurrent computations.
 \end{note}
 
 \begin{example}
-
 \begin{codeblock}
 void g(int i) {
   i = 7, i++, i++;              // \tcode{i} becomes \tcode{9}

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4,7 +4,8 @@
 \gramSec[gram.basic]{Basics}
 
 \pnum
-\begin{note} This Clause presents the basic concepts of the \Cpp{} language.
+\begin{note}
+This Clause presents the basic concepts of the \Cpp{} language.
 It explains the difference between an object and a
 name and how they relate to the value categories for expressions.
 It introduces the concepts of a
@@ -13,12 +14,15 @@ notion of type, scope, linkage, and
 storage duration. The mechanisms for starting and
 terminating a program are discussed. Finally, this Clause presents the
 fundamental types of the language and lists the ways of constructing
-compound types from these.\end{note}
+compound types from these.
+\end{note}
 
 \pnum
-\begin{note} This Clause does not cover concepts that affect only a single
+\begin{note}
+This Clause does not cover concepts that affect only a single
 part of the language. Such concepts are discussed in the relevant
-Clauses. \end{note}
+Clauses.
+\end{note}
 
 \pnum
 \indextext{type}%
@@ -348,7 +352,8 @@ an expression or conversion as follows:
   the expression is not an \grammarterm{id-expression} naming the function with
   an explicitly qualified name or
   the expression forms a pointer to member\iref{expr.unary.op}.
-  \begin{note} This covers
+  \begin{note}
+This covers
   taking the address of functions~(\ref{conv.func}, \ref{expr.unary.op}),
   calls to named functions\iref{expr.call},
   operator overloading\iref{over},
@@ -357,7 +362,8 @@ an expression or conversion as follows:
   non-default initialization\iref{dcl.init}.
   A constructor selected to copy or move an object of class type
   is considered to be named by an expression or conversion
-  even if the call is actually elided by the implementation\iref{class.copy.elision}. \end{note}
+  even if the call is actually elided by the implementation\iref{class.copy.elision}.
+\end{note}
 \item
   A deallocation function for a class
   is named by a \grammarterm{new-expression}
@@ -507,7 +513,8 @@ struct X* x1;                   // use \tcode{X} in pointer formation
 X* x2;                          // use \tcode{X} in pointer formation
 \end{codeblock}
 \end{example}
-\begin{note} The rules for declarations and expressions
+\begin{note}
+The rules for declarations and expressions
 describe in which contexts complete class types are required. A class
 type \tcode{T} must be complete if:
 \begin{itemize}
@@ -792,7 +799,8 @@ class template name\iref{temp}
 must be unique in its declarative region.
 \end{note}
 \end{itemize}
-\begin{note} These restrictions apply to the declarative region into which
+\begin{note}
+These restrictions apply to the declarative region into which
 a name is introduced, which is not necessarily the same as the region in
 which the declaration occurs. In particular,
 \grammarterm{elaborated-type-specifier}{s}\iref{dcl.type.elab} and
@@ -801,7 +809,8 @@ visible) name into an enclosing namespace; these restrictions apply to
 that region. Local extern declarations\iref{basic.link} may introduce
 a name into the declarative region where the declaration appears and
 also introduce a (possibly not visible) name into an enclosing
-namespace; these restrictions apply to both regions. \end{note}
+namespace; these restrictions apply to both regions.
+\end{note}
 
 \pnum
 For a given declarative region \placeholder{R}
@@ -812,7 +821,8 @@ comprises all declarative regions
 that are or enclose \placeholder{R} and do not enclose \placeholder{P}.
 
 \pnum
-\begin{note} The name lookup rules are summarized in~\ref{basic.lookup}.
+\begin{note}
+The name lookup rules are summarized in~\ref{basic.lookup}.
 \end{note}
 
 \rSec2[basic.scope.pdecl]{Point of declaration}
@@ -832,7 +842,8 @@ unsigned char x = 12;
 \end{codeblock}
 
 Here the second \tcode{x} is initialized with its own (indeterminate)
-value. \end{example}
+value.
+\end{example}
 
 \pnum
 \begin{note}
@@ -845,7 +856,9 @@ const int  i = 2;
 { int  i[i]; }
 \end{codeblock}
 
-declares a block-scope array of two integers. \end{example} \end{note}
+declares a block-scope array of two integers.
+\end{example}
+\end{note}
 
 \pnum
 The point of declaration for a class or class template first declared by a
@@ -874,11 +887,13 @@ const int x = 12;
 \end{codeblock}
 
 Here, the enumerator \tcode{x} is initialized with the value of the
-constant \tcode{x}, namely 12. \end{example}
+constant \tcode{x}, namely 12.
+\end{example}
 
 \pnum
 After the point of declaration of a class member, the member name can be
-looked up in the scope of its class. \begin{note}
+looked up in the scope of its class.
+\begin{note}
 \indextext{type!incomplete}%
 This is true even if the class is an incomplete class. For example,
 
@@ -916,11 +931,16 @@ of a function defined in namespace scope, the \grammarterm{identifier} is
 declared as a \grammarterm{class-name} in the namespace that contains the
 declaration; otherwise, except as a friend declaration, the
 \grammarterm{identifier} is declared in the smallest namespace or block
-scope that contains the declaration. \begin{note}
-These rules also apply within templates. \end{note} \begin{note} Other
+scope that contains the declaration.
+\begin{note}
+These rules also apply within templates.
+\end{note}
+\begin{note}
+Other
 forms of \grammarterm{elaborated-type-specifier} do not declare a new name,
 and therefore must refer to an existing \grammarterm{type-name}.
-See~\ref{basic.lookup.elab} and~\ref{dcl.type.elab}. \end{note}
+See~\ref{basic.lookup.elab} and~\ref{dcl.type.elab}.
+\end{note}
 \end{itemize}
 
 \pnum
@@ -958,7 +978,8 @@ template<class T
 \end{example}
 
 \pnum
-\begin{note} Friend declarations refer to functions or classes that are
+\begin{note}
+Friend declarations refer to functions or classes that are
 members of the nearest enclosing namespace, but they do not introduce
 new names into that namespace\iref{namespace.memdef}. Function
 declarations at block scope and variable declarations with the
@@ -970,7 +991,8 @@ into that scope.
 \pnum
 \begin{note}
 For point of instantiation of a template, see~\ref{temp.point}.
-\end{note}%
+\end{note}
+%
 \indextext{scope!declarations and|)}%
 \indextext{declaration!point of|)}
 
@@ -1258,7 +1280,8 @@ being hidden during qualified and unqualified name lookup.)
 \pnum
 The potential scope of a template parameter name begins at its point of
 declaration\iref{basic.scope.pdecl} and ends at the end of its declarative region.
-\begin{note} This implies that a \grammarterm{template-parameter} can be used in the
+\begin{note}
+This implies that a \grammarterm{template-parameter} can be used in the
 declaration of subsequent \grammarterm{template-parameter}{s} and their default
 arguments but cannot be used in preceding \grammarterm{template-parameter}{s} or their
 default arguments. For example,
@@ -1282,7 +1305,9 @@ argument must be defined and not just declared when the class template is instan
 
 \pnum
 The declarative region of the name of a template parameter is nested within the
-immediately-enclosing declarative region. \begin{note} As a result, a
+immediately-enclosing declarative region.
+\begin{note}
+As a result, a
 \grammarterm{template-parameter} hides any entity with the same name in an enclosing
 scope\iref{basic.scope.hiding}.
 \begin{example}
@@ -1293,13 +1318,17 @@ template<N X, typename N, template<N Y> class T> struct A;
 
 Here, \tcode{X} is a non-type template parameter of type \tcode{int} and \tcode{Y} is a
 non-type template parameter of the same type as the second template parameter of
-\tcode{A}. \end{example}\end{note}
+\tcode{A}.
+\end{example}
+\end{note}
 
 \pnum
-\begin{note} Because the name of a template parameter cannot be redeclared within its
+\begin{note}
+Because the name of a template parameter cannot be redeclared within its
 potential scope\iref{temp.local}, a template parameter's scope is often its potential
 scope. However, it is still possible for a template parameter name to be hidden;
-see~\ref{temp.local}. \end{note}
+see~\ref{temp.local}.
+\end{note}
 
 \rSec2[basic.scope.hiding]{Name hiding}
 
@@ -1377,9 +1406,11 @@ considered to be a member of that class for the purposes of name hiding
 and lookup.
 
 \pnum
-\begin{note} \ref{basic.link} discusses linkage issues. The notions of
+\begin{note}
+\ref{basic.link} discusses linkage issues. The notions of
 scope, point of declaration and name hiding are discussed
-in~\ref{basic.scope}. \end{note}
+in~\ref{basic.scope}.
+\end{note}
 
 \rSec2[basic.lookup.unqual]{Unqualified name lookup}
 
@@ -1403,7 +1434,9 @@ that enclosing namespace.
 \pnum
 The lookup for an unqualified name used as the
 \grammarterm{postfix-expression} of a function call is described
-in~\ref{basic.lookup.argdep}. \begin{note} For purposes of determining
+in~\ref{basic.lookup.argdep}.
+\begin{note}
+For purposes of determining
 (during parsing) whether an expression is a
 \grammarterm{postfix-expression} for a function call, the usual name lookup
 rules apply.
@@ -1445,7 +1478,8 @@ namespace N {
 
 Because the expression is not a function call, the argument-dependent
 name lookup\iref{basic.lookup.argdep} does not apply and the friend
-function \tcode{f} is not found. \end{note}
+function \tcode{f} is not found.
+\end{note}
 
 \pnum
 A name used in global scope, outside of any function, class or
@@ -1545,7 +1579,10 @@ namespace N {
 When looking for a prior declaration of a class
 or function introduced by a friend declaration, scopes outside
 of the innermost enclosing namespace scope are not considered;
-see~\ref{namespace.memdef}. \end{note} \begin{note} \ref{basic.scope.class}
+see~\ref{namespace.memdef}.
+\end{note}
+\begin{note}
+\ref{basic.scope.class}
 further describes the restrictions on the use of names in a class
 definition. \ref{class.nest} further describes the restrictions on the
 use of names in nested class definitions. \ref{class.local} further
@@ -1613,12 +1650,15 @@ void M::N::X::f() {
 // 5) scope of namespace \tcode{M}
 // 6) global scope, before the definition of \tcode{M::N::X::f}
 \end{codeblock}
-\end{example} \begin{note} \ref{class.mfct} and~\ref{class.static} further
+\end{example}
+\begin{note}
+\ref{class.mfct} and~\ref{class.static} further
 describe the restrictions on the use of names in member function
 definitions. \ref{class.nest} further describes the restrictions on the
 use of names in the scope of nested classes. \ref{class.local} further
 describes the restrictions on the use of names in local class
-definitions. \end{note}
+definitions.
+\end{note}
 
 \pnum
 Name lookup for a name used in the definition of a friend
@@ -1664,7 +1704,8 @@ argument\iref{dcl.fct.default} in a function
 \grammarterm{expression} of a \grammarterm{mem-initializer} for a
 constructor\iref{class.base.init}, the function parameter names are
 visible and hide the names of entities declared in the block, class or
-namespace scopes containing the function declaration. \begin{note}
+namespace scopes containing the function declaration.
+\begin{note}
 \ref{dcl.fct.default} further describes the restrictions on the use of
 names in default arguments. \ref{class.base.init} further describes the
 restrictions on the use of names in a \grammarterm{ctor-initializer}.
@@ -1681,9 +1722,12 @@ scopes containing the \grammarterm{enum-specifier}.
 A name used in the definition of a \tcode{static} data member of class
 \tcode{X}\iref{class.static.data} (after the \grammarterm{qualified-id}
 of the static member) is looked up as if the name was used in a member
-function of \tcode{X}. \begin{note} \ref{class.static.data} further
+function of \tcode{X}.
+\begin{note}
+\ref{class.static.data} further
 describes the restrictions on the use of names in the definition of a
-\tcode{static} data member. \end{note}
+\tcode{static} data member.
+\end{note}
 
 \pnum
 If a variable member of a namespace is defined outside of the scope of
@@ -1711,12 +1755,17 @@ parameter names shall not be redeclared in the
 \grammarterm{exception-declaration} nor in the outermost block of a handler
 for the \grammarterm{function-try-block}. Names declared in the outermost
 block of the function definition are not found when looked up in the
-scope of a handler for the \grammarterm{function-try-block}. \begin{note} But
-function parameter names are found. \end{note}
+scope of a handler for the \grammarterm{function-try-block}.
+\begin{note}
+But
+function parameter names are found.
+\end{note}
 
 \pnum
-\begin{note} The rules for name lookup in template definitions are
-described in~\ref{temp.res}. \end{note}
+\begin{note}
+The rules for name lookup in template definitions are
+described in~\ref{temp.res}.
+\end{note}
 
 \rSec2[basic.lookup.argdep]{Argument-dependent name lookup}%
 \indextext{lookup!argument-dependent}
@@ -1838,9 +1887,12 @@ by argument dependent lookup (defined as follows). If \placeholder{X} contains
 then \placeholder{Y} is empty. Otherwise \placeholder{Y} is the set of declarations
 found in the namespaces associated with the argument types as described
 below. The set of declarations found by the lookup of the name is the
-union of \placeholder{X} and \placeholder{Y}. \begin{note} The namespaces and entities
+union of \placeholder{X} and \placeholder{Y}.
+\begin{note}
+The namespaces and entities
 associated with the argument types can include namespaces and entities
-already considered by the ordinary unqualified lookup. \end{note}
+already considered by the ordinary unqualified lookup.
+\end{note}
 \begin{example}
 \begin{codeblock}
 namespace NS {
@@ -1970,9 +2022,11 @@ int main() {
 \end{example}
 
 \pnum
-\begin{note} Multiply qualified names, such as \tcode{N1::N2::N3::n}, can
+\begin{note}
+Multiply qualified names, such as \tcode{N1::N2::N3::n}, can
 be used to refer to members of nested classes\iref{class.nest} or
-members of nested namespaces. \end{note}
+members of nested namespaces.
+\end{note}
 
 \pnum
 In a declaration in which the \grammarterm{declarator-id} is a
@@ -2038,7 +2092,8 @@ int main() {
 }
 \end{codeblock}
 \end{example}
-\begin{note} \ref{basic.lookup.classref} describes how name
+\begin{note}
+\ref{basic.lookup.classref} describes how name
 lookup proceeds after the \tcode{.} and \tcode{->} operators.
 \end{note}
 
@@ -2051,9 +2106,13 @@ nominates a class, the name specified after the
 \grammarterm{nested-name-specifier} is looked up in the scope of the
 class\iref{class.member.lookup}, except for the cases listed below.
 The name shall represent one or more members of that class or of one of
-its base classes\iref{class.derived}. \begin{note} A class member
+its base classes\iref{class.derived}.
+\begin{note}
+A class member
 can be referred to using a \grammarterm{qualified-id} at any point in its
-potential scope\iref{basic.scope.class}. \end{note} The exceptions to
+potential scope\iref{basic.scope.class}.
+\end{note}
+The exceptions to
 the name lookup rule above are the following:
 \begin{itemize}
 \item the lookup for a destructor is as specified
@@ -2091,10 +2150,14 @@ if the name specified after the \grammarterm{nested-name-specifier} is the same 
 \grammarterm{template-name} in the last component of the \grammarterm{nested-name-specifier},
 \end{itemize}
 the name is instead considered to name the
-constructor of class \tcode{C}. \begin{note} For example, the constructor
+constructor of class \tcode{C}.
+\begin{note}
+For example, the constructor
 is not an acceptable lookup result in an
 \grammarterm{elaborated-type-specifier} so the constructor would not be
-used in place of the injected-class-name. \end{note} Such a constructor
+used in place of the injected-class-name.
+\end{note}
+Such a constructor
 name shall be used only in the \grammarterm{declarator-id} of a declaration
 that names a constructor or in a \grammarterm{using-declaration}.
 \begin{example}
@@ -2334,7 +2397,8 @@ namespace A {
 void A::f1(int){ }  // ill-formed, \tcode{f1} is not a member of \tcode{A}
 \end{codeblock}
 
-\end{example} However, in such namespace member declarations, the
+\end{example}
+However, in such namespace member declarations, the
 \grammarterm{nested-name-specifier} may rely on \grammarterm{using-directive}{s}
 to implicitly provide the initial part of the
 \grammarterm{nested-name-specifier}.
@@ -2436,7 +2500,8 @@ struct Base::Data;              // error: cannot introduce a qualified type\iref
 struct Base::Datum;             // error: \tcode{Datum} undefined
 struct Base::Data* pBase;       // OK: refers to nested \tcode{Data}
 \end{codeblock}
-\end{example} %
+\end{example}
+%
 \indextext{lookup!elaborated type specifier|)}%
 
 \rSec2[basic.lookup.classref]{Class member access}
@@ -2480,7 +2545,8 @@ struct B {
 void B::f(::A* a) {
   a->~A();                      // OK: lookup in \tcode{*a} finds the injected-class-name
 }
-\end{codeblock}\end{example}
+\end{codeblock}
+\end{example}
 
 \pnum
 If the \grammarterm{id-expression} in a class member access is a
@@ -2493,9 +2559,12 @@ the \tcode{\placeholder{class-name-or-namespace-name}} following the \tcode{.} o
 first looked up in the class of the object expression\iref{class.member.lookup}
 and the name, if found,
 is used. Otherwise it is looked up in the context of the entire
-\grammarterm{postfix-expression}. \begin{note} See~\ref{basic.lookup.qual}, which
+\grammarterm{postfix-expression}.
+\begin{note}
+See~\ref{basic.lookup.qual}, which
 describes the lookup of a name before \tcode{::}, which will only find a type
-or namespace name. \end{note}
+or namespace name.
+\end{note}
 
 \pnum
 If the \grammarterm{qualified-id} has the form
@@ -2840,8 +2909,11 @@ a major array bound\iref{dcl.array}. A violation of this rule on type
 identity does not require a diagnostic.
 
 \pnum
-\begin{note} Linkage to non-\Cpp{} declarations can be achieved using a
-\grammarterm{linkage-specification}\iref{dcl.link}. \end{note}%
+\begin{note}
+Linkage to non-\Cpp{} declarations can be achieved using a
+\grammarterm{linkage-specification}\iref{dcl.link}.
+\end{note}
+%
 \indextext{linkage|)}
 
 \rSec1[basic.memobj]{Memory and objects}
@@ -2866,27 +2938,35 @@ available to a \Cpp{} program consists of one or more sequences of
 contiguous bytes. Every byte has a unique address.
 
 \pnum
-\begin{note} The representation of types is described
-in~\ref{basic.types}. \end{note}
+\begin{note}
+The representation of types is described
+in~\ref{basic.types}.
+\end{note}
 
 \pnum
 A \defn{memory location} is either an object of scalar type or a maximal
-sequence of adjacent bit-fields all having nonzero width. \begin{note} Various
+sequence of adjacent bit-fields all having nonzero width.
+\begin{note}
+Various
 features of the language, such as references and virtual functions, might
 involve additional memory locations that are not accessible to programs but are
-managed by the implementation. \end{note} Two or more threads of
+managed by the implementation.
+\end{note}
+Two or more threads of
 execution\iref{intro.multithread} can access separate memory
 locations without interfering with each other.
 
 \pnum
-\begin{note} Thus a bit-field and an adjacent non-bit-field are in separate memory
+\begin{note}
+Thus a bit-field and an adjacent non-bit-field are in separate memory
 locations, and therefore can be concurrently updated by two threads of execution
 without interference. The same applies to two bit-fields, if one is declared
 inside a nested struct declaration and the other is not, or if the two are
 separated by a zero-length bit-field declaration, or if they are separated by a
 non-bit-field declaration. It is not safe to concurrently update two bit-fields
 in the same struct if all fields between them are also bit-fields of nonzero
-width. \end{note}
+width.
+\end{note}
 
 \pnum
 \begin{example}
@@ -2908,7 +2988,9 @@ contains four separate memory locations: The member \tcode{a} and bit-fields
 modified concurrently without interfering with each other. The bit-fields
 \tcode{b} and \tcode{c} together constitute the fourth memory location. The
 bit-fields \tcode{b} and \tcode{c} cannot be concurrently modified, but
-\tcode{b} and \tcode{a}, for example, can be. \end{example}%
+\tcode{b} and \tcode{a}, for example, can be.
+\end{example}
+%
 \indextext{memory model|)}
 
 \rSec2[intro.object]{Object model}
@@ -2928,8 +3010,10 @@ in its period of construction\iref{class.cdtor},
 throughout its lifetime\iref{basic.life},
 and
 in its period of destruction\iref{class.cdtor}.
-\begin{note} A function is not an object, regardless of whether or not it
-occupies storage in the way that objects do. \end{note}
+\begin{note}
+A function is not an object, regardless of whether or not it
+occupies storage in the way that objects do.
+\end{note}
 The properties of an
 object are determined when the object is created. An object can have a
 name\iref{basic}. An object has a storage
@@ -3133,7 +3217,8 @@ occupied by the complete object of that subobject.
 \begin{note}
 \Cpp{} provides a variety of fundamental types and several ways of composing
 new types from existing types\iref{basic.types}.
-\end{note}%
+\end{note}
+%
 \indextext{object model|)}
 
 \rSec2[basic.life]{Object and reference lifetime}
@@ -3172,12 +3257,15 @@ The lifetime of a reference begins when its initialization is complete.
 The lifetime of a reference ends as if it were a scalar object requiring storage.
 
 \pnum
-\begin{note} \ref{class.base.init}
-describes the lifetime of base and member subobjects. \end{note}
+\begin{note}
+\ref{class.base.init}
+describes the lifetime of base and member subobjects.
+\end{note}
 
 \pnum
 The properties ascribed to objects and references throughout this document
-apply for a given object or reference only during its lifetime. \begin{note}
+apply for a given object or reference only during its lifetime.
+\begin{note}
 In particular, before the lifetime of an object starts and after its
 lifetime ends there are significant restrictions on the use of the
 object, as described below, in~\ref{class.base.init} and
@@ -3185,7 +3273,8 @@ in~\ref{class.cdtor}. Also, the behavior of an object under construction
 and destruction might not be the same as the behavior of an object whose
 lifetime has started and not ended. \ref{class.base.init}
 and~\ref{class.cdtor} describe the behavior of objects during the
-construction and destruction phases. \end{note}
+construction and destruction phases.
+\end{note}
 
 \pnum
 A program may end the lifetime of any object by reusing the storage
@@ -3392,9 +3481,13 @@ void h() {
 
 \pnum
 In this subclause, ``before'' and ``after'' refer to the ``happens before''
-relation\iref{intro.multithread}. \begin{note} Therefore, undefined behavior results
+relation\iref{intro.multithread}.
+\begin{note}
+Therefore, undefined behavior results
 if an object that is being constructed in one thread is referenced from another
-thread without adequate synchronization. \end{note}%
+thread without adequate synchronization.
+\end{note}
+%
 \indextext{object lifetime|)}
 
 \rSec2[basic.indet]{Indeterminate values}
@@ -3530,9 +3623,12 @@ eliminated as specified in~\ref{class.copy.elision}.
 \pnum
 \indextext{object!local static@local \tcode{static}}%
 The keyword \tcode{static} can be used to declare a local variable with
-static storage duration. \begin{note} \ref{stmt.dcl} describes the
+static storage duration.
+\begin{note}
+\ref{stmt.dcl} describes the
 initialization of local \tcode{static} variables; \ref{basic.start.term}
-describes the destruction of local \tcode{static} variables. \end{note}
+describes the destruction of local \tcode{static} variables.
+\end{note}
 
 \pnum
 \indextext{member!class static@class \tcode{static}}%
@@ -3625,7 +3721,9 @@ void operator delete[](void*, std::size_t, std::align_val_t) noexcept;
 These implicit declarations introduce only the function names
 \tcode{operator} \tcode{new}, \tcode{operator} \tcode{new[]},
 \tcode{op\-er\-a\-tor} \tcode{delete}, and \tcode{operator}
-\tcode{delete[]}. \begin{note} The implicit declarations do not introduce
+\tcode{delete[]}.
+\begin{note}
+The implicit declarations do not introduce
 the names \tcode{std},
 \tcode{std::size_t},
 \tcode{std::align_val_t},
@@ -3637,7 +3735,9 @@ well-formed. However, referring to \tcode{std}
 or \tcode{std::size_t}
 or \tcode{std::align_val_t}
 is ill-formed unless the name has been declared
-by including the appropriate header. \end{note} Allocation and/or
+by including the appropriate header.
+\end{note}
+Allocation and/or
 deallocation functions may also be declared and defined for any
 class\iref{class.free}.
 
@@ -3719,7 +3819,8 @@ currently installed new-handler function\iref{new.handler}, if any.
 \indextext{\idxcode{new_handler}}%
 A program-supplied allocation function can obtain the address of the
 currently installed \tcode{new_handler} using the
-\tcode{std::get_new_handler} function\iref{get.new.handler}. \end{note}
+\tcode{std::get_new_handler} function\iref{get.new.handler}.
+\end{note}
 An allocation function that has a non-throwing
 exception specification\iref{except.spec}
 indicates failure by returning
@@ -3736,7 +3837,9 @@ expression\iref{expr.new}, or called directly using the function call
 syntax\iref{expr.call}, or called indirectly to allocate storage for
 a coroutine state\iref{dcl.fct.def.coroutine},
 or called indirectly through calls to the
-functions in the \Cpp{} standard library. \begin{note} In particular, a
+functions in the \Cpp{} standard library.
+\begin{note}
+In particular, a
 global allocation function is not called to allocate storage for objects
 with static storage duration\iref{basic.stc.static}, for objects or references
 with thread storage duration\iref{basic.stc.thread}, for objects of
@@ -3891,11 +3994,14 @@ safety}, in which case a pointer value referring to an object with dynamic
 storage duration that is not a safely-derived pointer
 value is an invalid pointer value unless
 the referenced complete object has previously been declared
-reachable\iref{util.dynamic.safety}. \begin{note}
+reachable\iref{util.dynamic.safety}.
+\begin{note}
 The effect of using an invalid pointer value (including passing it to a
 deallocation function) is undefined, see~\ref{basic.stc}.
 This is true even if the unsafely-derived pointer value might compare equal to
-some safely-derived pointer value. \end{note} It is
+some safely-derived pointer value.
+\end{note}
+It is
 \impldef{whether an implementation has relaxed or strict pointer
 safety} whether an implementation has relaxed or strict pointer safety.%
 \indextext{pointer!safely-derived|)}%
@@ -3939,7 +4045,8 @@ type \tcode{B}, so it must be aligned appropriately for a \tcode{long double}.
 If \tcode{D} appears as a subobject of another object that also has \tcode{B}
 as a virtual base class, the \tcode{B} subobject might be part of a different
 subobject, reducing the alignment requirements on the \tcode{D} subobject.
-\end{example} The result of the \tcode{alignof} operator reflects the alignment
+\end{example}
+The result of the \tcode{alignof} operator reflects the alignment
 requirement of the type in the complete-object case.
 
 \pnum
@@ -3950,7 +4057,8 @@ An \defn{extended alignment} is represented by an alignment
 greater than \tcode{alignof(std::max_align_t)}. It is \impldef{support for extended alignments}
 whether any extended alignments are supported and the contexts in which they are
 supported\iref{dcl.align}. A type having an extended alignment
-requirement is an \defnadj{over-aligned}{type}. \begin{note}
+requirement is an \defnadj{over-aligned}{type}.
+\begin{note}
 Every over-aligned type is or contains a class type
 to which extended alignment applies (possibly through a non-static data member).
 \end{note}
@@ -3976,8 +4084,10 @@ The alignment requirement of a complete type can be queried using an
 \tcode{alignof} expression\iref{expr.alignof}. Furthermore,
 the narrow character types\iref{basic.fundamental} shall have the weakest
 alignment requirement.
-\begin{note} This enables the ordinary character types to be used as the
-underlying type for an aligned memory area\iref{dcl.align}.\end{note}
+\begin{note}
+This enables the ordinary character types to be used as the
+underlying type for an aligned memory area\iref{dcl.align}.
+\end{note}
 
 \pnum
 Comparing alignments is meaningful and provides the obvious results:
@@ -3989,7 +4099,8 @@ Comparing alignments is meaningful and provides the obvious results:
 \end{itemize}
 
 \pnum
-\begin{note} The runtime pointer alignment function\iref{ptr.align}
+\begin{note}
+The runtime pointer alignment function\iref{ptr.align}
 can be used to obtain an aligned pointer within a buffer; the aligned-storage templates
 in the library\iref{meta.trans.other} can be used to obtain aligned storage.
 \end{note}
@@ -4250,7 +4361,9 @@ containing the \grammarterm{expression-list}.
 \item The lifetime of a temporary bound to the returned value in a function \tcode{return} statement\iref{stmt.return} is not extended; the temporary is destroyed at the end of the full-expression in the \tcode{return} statement.
 
 \item A temporary bound to a reference in a \grammarterm{new-initializer}\iref{expr.new} persists until the completion of the full-expression containing the \grammarterm{new-initializer}.
-\begin{note} This may introduce a dangling reference. \end{note}
+\begin{note}
+This may introduce a dangling reference.
+\end{note}
 \begin{example}
 \begin{codeblock}
 struct S { int mi; const std::pair<int,int>& mp; };
@@ -4424,7 +4537,8 @@ std::memcpy(t1p, t2p, sizeof(T));
     // at this point, every subobject of trivially copyable type in \tcode{*t1p} contains
     // the same value as the corresponding subobject in \tcode{*t2p}
 \end{codeblock}
-\end{example}%
+\end{example}
+%
 \indextext{object!byte copying and|)}
 
 \pnum
@@ -4502,8 +4616,10 @@ void bar() {
 \end{example}
 
 \pnum
-\begin{note} The rules for declarations and expressions describe in which
-contexts incomplete types are prohibited. \end{note}
+\begin{note}
+The rules for declarations and expressions describe in which
+contexts incomplete types are prohibited.
+\end{note}
 
 \pnum
 An \defn{object type} is a (possibly cv-qualified) type that is not
@@ -4914,16 +5030,21 @@ the type \tcode{std::size_t}\iref{support.types} is ill-formed.
 \pnum
 \indextext{terminology!pointer}%
 The type of a pointer to \cv{}~\tcode{void} or a pointer to an object type is
-called an \defn{object pointer type}. \begin{note} A pointer to \tcode{void}
+called an \defn{object pointer type}.
+\begin{note}
+A pointer to \tcode{void}
 does not have a pointer-to-object type, however, because \tcode{void} is not
-an object type. \end{note} The type of a pointer that can designate a function
+an object type.
+\end{note}
+The type of a pointer that can designate a function
 is called a \defn{function pointer type}.
 A pointer to objects of type \tcode{T} is referred to as a ``pointer to
 \tcode{T}''.
 \begin{example}
 A pointer to an object of type \tcode{int} is
 referred to as ``pointer to \tcode{int}'' and a pointer to an object of
-class \tcode{X} is called a ``pointer to \tcode{X}''. \end{example}
+class \tcode{X} is called a ``pointer to \tcode{X}''.
+\end{example}
 Except for pointers to static members, text referring to ``pointers''
 does not apply to pointers to members. Pointers to incomplete types are
 allowed although there are restrictions on what can be done with
@@ -4973,9 +5094,11 @@ pointer types is \impldef{value representation of pointer types}. Pointers to
 layout-compatible types shall
 have the same value representation and alignment
 requirements\iref{basic.align}.
-\begin{note} Pointers to over-aligned types\iref{basic.align} have no special
+\begin{note}
+Pointers to over-aligned types\iref{basic.align} have no special
 representation, but their range of valid values is restricted by the extended
-alignment requirement.\end{note}
+alignment requirement.
+\end{note}
 
 \pnum
 Two objects \placeholder{a} and \placeholder{b} are \defn{pointer-interconvertible} if:
@@ -5119,7 +5242,8 @@ const CA arr2 = { 0 };
 The type of both \tcode{arr1} and \tcode{arr2} is ``array of 5
 \tcode{const char}'', and the array type is considered to be
 const-qualified.
-\end{example}%
+\end{example}
+%
 \indextext{type|)}
 
 \rSec2[conv.rank]{Integer conversion rank}%
@@ -5176,7 +5300,8 @@ rank than \tcode{T3}, then \tcode{T1} shall have greater rank than
 The integer conversion rank is used in the definition of the integral
 promotions\iref{conv.prom} and the usual arithmetic
 conversions\iref{expr.prop}.
-\end{note}%
+\end{note}
+%
 
 \rSec1[basic.exec]{Program execution}
 
@@ -5301,12 +5426,14 @@ B b[2] = { B(), B() };          // full-expression is the entire initialization
 \end{example}
 
 \pnum
-\begin{note} The evaluation of a full-expression can include the
+\begin{note}
+The evaluation of a full-expression can include the
 evaluation of subexpressions that are not lexically part of the
 full-expression. For example, subexpressions involved in evaluating
 default arguments\iref{dcl.fct.default} are considered to
 be created in the expression that calls the function, not the expression
-that defines the default argument. \end{note}
+that defines the default argument.
+\end{note}
 
 \pnum
 \indextext{value computation|(}%
@@ -5334,12 +5461,18 @@ a partial order among those evaluations. Given any two evaluations \placeholder{
 then the execution of
 \placeholder{A} shall precede the execution of \placeholder{B}. If \placeholder{A} is not sequenced
 before \placeholder{B} and \placeholder{B} is not sequenced before \placeholder{A}, then \placeholder{A} and
-\placeholder{B} are \defn{unsequenced}. \begin{note} The execution of unsequenced
-evaluations can overlap. \end{note} Evaluations \placeholder{A} and \placeholder{B} are
+\placeholder{B} are \defn{unsequenced}.
+\begin{note}
+The execution of unsequenced
+evaluations can overlap.
+\end{note}
+Evaluations \placeholder{A} and \placeholder{B} are
 \defn{indeterminately sequenced} when either \placeholder{A} is sequenced before
 \placeholder{B} or \placeholder{B} is sequenced before \placeholder{A}, but it is unspecified which.
-\begin{note} Indeterminately sequenced evaluations cannot overlap, but either
-could be executed first. \end{note}
+\begin{note}
+Indeterminately sequenced evaluations cannot overlap, but either
+could be executed first.
+\end{note}
 An expression \placeholder{X}
 is said to be sequenced before
 an expression \placeholder{Y} if
@@ -5364,11 +5497,14 @@ place, usually in reverse order of the construction of each temporary object.}
 \pnum
 \indextext{evaluation!unspecified order of}%
 Except where noted, evaluations of operands of individual operators and
-of subexpressions of individual expressions are unsequenced. \begin{note}
+of subexpressions of individual expressions are unsequenced.
+\begin{note}
 In an expression that is evaluated more than once during the execution
 of a program, unsequenced and indeterminately sequenced evaluations of
 its subexpressions need not be performed consistently in different
-evaluations. \end{note} The value computations of the operands of an
+evaluations.
+\end{note}
+The value computations of the operands of an
 operator are sequenced before the value computation of the result of the
 operator. If a
 \indextext{side effects}%
@@ -5434,7 +5570,8 @@ whatever the syntax of the expression that calls the function might be.%
 If a signal handler is executed as a result of a call to the \tcode{std::raise}
 function, then the execution of the handler is sequenced after the invocation
 of the \tcode{std::raise} function and before its return.
-\begin{note} When a signal is received for another reason, the execution of the
+\begin{note}
+When a signal is received for another reason, the execution of the
 signal handler is usually unsequenced with respect to the rest of the program.
 \end{note}
 \indextext{program execution|)}
@@ -5447,9 +5584,13 @@ signal handler is usually unsequenced with respect to the rest of the program.
 A \defn{thread of execution} (also known as a \defn{thread}) is a single flow of
 control within a program, including the initial invocation of a specific
 top-level function, and recursively including every function invocation
-subsequently executed by the thread. \begin{note} When one thread creates another,
+subsequently executed by the thread.
+\begin{note}
+When one thread creates another,
 the initial call to the top-level function of the new thread is executed by the
-new thread, not by the creating thread. \end{note} Every thread in a program can
+new thread, not by the creating thread.
+\end{note}
+Every thread in a program can
 potentially access every object and function in a program.\footnote{An object
 with automatic or thread storage duration\iref{basic.stc} is associated with
 one specific thread, and can be accessed by a different thread only indirectly
@@ -5457,10 +5598,14 @@ through a pointer or reference\iref{basic.compound}.} Under a hosted
 implementation, a \Cpp{} program can have more than one thread running
 concurrently. The execution of each thread proceeds as defined by the remainder
 of this document. The execution of the entire program consists of an execution
-of all of its threads. \begin{note} Usually the execution can be viewed as an
+of all of its threads.
+\begin{note}
+Usually the execution can be viewed as an
 interleaving of all its threads. However, some kinds of atomic operations, for
 example, allow executions inconsistent with a simple interleaving, as described
-below. \end{note} Under a freestanding implementation, it is \impldef{number of
+below.
+\end{note}
+Under a freestanding implementation, it is \impldef{number of
 threads in a program under a freestanding implementation} whether a program can
 have more than one thread of execution.
 
@@ -5475,10 +5620,12 @@ contains the signal handler invocation.
 The value of an object visible to a thread \placeholder{T} at a particular point is the
 initial value of the object, a value assigned to the object by \placeholder{T}, or a
 value assigned to the object by another thread, according to the rules below.
-\begin{note} In some cases, there may instead be undefined behavior. Much of this
+\begin{note}
+In some cases, there may instead be undefined behavior. Much of this
 subclause is motivated by the desire to support atomic operations with explicit
 and detailed visibility constraints. However, it also implicitly supports a
-simpler view for more restricted programs. \end{note}
+simpler view for more restricted programs.
+\end{note}
 
 \pnum
 Two expression evaluations \defn{conflict} if one of them modifies a memory
@@ -5496,7 +5643,9 @@ operation without an associated memory location is a fence and can be either an
 acquire fence, a release fence, or both an acquire and release fence. In
 addition, there are relaxed atomic operations, which are not synchronization
 operations, and atomic read-modify-write operations, which have special
-characteristics. \begin{note} For example, a call that acquires a mutex will
+characteristics.
+\begin{note}
+For example, a call that acquires a mutex will
 perform an acquire operation on the locations comprising the mutex.
 Correspondingly, a call that releases the same mutex will perform a release
 operation on those same locations. Informally, performing a release operation on
@@ -5511,7 +5660,8 @@ though, like synchronization operations, they cannot contribute to data races.
 \pnum
 All modifications to a particular atomic object \placeholder{M} occur in some
 particular total order, called the \defn{modification order} of \placeholder{M}.
-\begin{note} There is a separate order for each
+\begin{note}
+There is a separate order for each
 atomic object. There is no requirement that these can be combined into a single
 total order for all objects. In general this will be impossible since different
 threads may observe modifications to different objects in inconsistent orders.
@@ -5530,13 +5680,18 @@ every subsequent operation is an atomic read-modify-write operation.
 Certain library calls \defn{synchronize with} other library calls performed by
 another thread. For example, an atomic store-release synchronizes with a
 load-acquire that takes its value from the store\iref{atomics.order}.
-\begin{note} Except in the specified cases, reading a later value does not
+\begin{note}
+Except in the specified cases, reading a later value does not
 necessarily ensure visibility as described below. Such a requirement would
-sometimes interfere with efficient implementation. \end{note} \begin{note} The
+sometimes interfere with efficient implementation.
+\end{note}
+\begin{note}
+The
 specifications of the synchronization operations define when one reads the value
 written by another. For atomic objects, the definition is clear. All operations
 on a given mutex occur in a single total order. Each mutex acquisition ``reads
-the value written'' by the last mutex release. \end{note}
+the value written'' by the last mutex release.
+\end{note}
 
 \pnum
 An evaluation \placeholder{A} \defn{carries a dependency} to an evaluation \placeholder{B} if
@@ -5565,8 +5720,10 @@ written by \placeholder{A} from \placeholder{M}, and \placeholder{A} is sequence
 for some evaluation \placeholder{X}, \placeholder{A} carries a dependency to \placeholder{X}, and
 \placeholder{X} carries a dependency to \placeholder{B}.
 \end{itemize}
-\begin{note} ``Carries a dependency to'' is a subset of ``is sequenced before'',
-and is similarly strictly intra-thread. \end{note}
+\begin{note}
+``Carries a dependency to'' is a subset of ``is sequenced before'',
+and is similarly strictly intra-thread.
+\end{note}
 
 \pnum
 An evaluation \placeholder{A} is \defn{dependency-ordered before} an evaluation
@@ -5582,7 +5739,8 @@ for some evaluation \placeholder{X}, \placeholder{A} is dependency-ordered befor
 \placeholder{X} carries a dependency to \placeholder{B}.
 
 \end{itemize}
-\begin{note} The relation ``is dependency-ordered before'' is analogous to
+\begin{note}
+The relation ``is dependency-ordered before'' is analogous to
 ``synchronizes with'', but uses release/consume in place of release/acquire.
 \end{note}
 
@@ -5608,7 +5766,8 @@ if
     inter-thread happens before \placeholder{B}.
   \end{itemize}
 \end{itemize}
-\begin{note} The ``inter-thread happens before'' relation describes arbitrary
+\begin{note}
+The ``inter-thread happens before'' relation describes arbitrary
 concatenations of ``sequenced before'', ``synchronizes with'' and
 ``dependency-ordered before'' relationships, with two exceptions. The first
 exception is that a concatenation is not permitted to end with
@@ -5622,7 +5781,8 @@ prior consume operation. The second exception is that a concatenation is not
 permitted to consist entirely of ``sequenced before''. The reasons for this
 limitation are (1) to permit ``inter-thread happens before'' to be transitively
 closed and (2) the ``happens before'' relation, defined below, provides for
-relationships consisting entirely of ``sequenced before''. \end{note}
+relationships consisting entirely of ``sequenced before''.
+\end{note}
 
 \pnum
 An evaluation \placeholder{A} \defn{happens before} an evaluation \placeholder{B}
@@ -5632,8 +5792,11 @@ An evaluation \placeholder{A} \defn{happens before} an evaluation \placeholder{B
 \item \placeholder{A} inter-thread happens before \placeholder{B}.
 \end{itemize}
 The implementation shall ensure that no program execution demonstrates a cycle
-in the ``happens before'' relation. \begin{note} This cycle would otherwise be
-possible only through the use of consume operations. \end{note}
+in the ``happens before'' relation.
+\begin{note}
+This cycle would otherwise be
+possible only through the use of consume operations.
+\end{note}
 
 \pnum
 An evaluation \placeholder{A} \defn{simply happens before} an evaluation \placeholder{B}
@@ -5687,13 +5850,19 @@ The value of a non-atomic scalar object or bit-field \placeholder{M}, as determi
 evaluation \placeholder{B}, shall be the value stored by the
 \indextext{side effects!visible}%
 visible side effect
-\placeholder{A}. \begin{note} If there is ambiguity about which side effect to a
+\placeholder{A}.
+\begin{note}
+If there is ambiguity about which side effect to a
 non-atomic object or bit-field is visible, then the behavior is either
-unspecified or undefined. \end{note} \begin{note} This states that operations on
+unspecified or undefined.
+\end{note}
+\begin{note}
+This states that operations on
 ordinary objects are not visibly reordered. This is not actually detectable
 without data races, but it is necessary to ensure that data races, as defined
 below, and with suitable restrictions on the use of atomics, correspond to data
-races in a simple interleaved (sequentially consistent) execution. \end{note}
+races in a simple interleaved (sequentially consistent) execution.
+\end{note}
 
 \pnum
 The value of an
@@ -5710,8 +5879,11 @@ described here, and in particular, by the coherence requirements below.
 \indextext{coherence!write-write}%
 If an operation \placeholder{A} that modifies an atomic object \placeholder{M} happens before
 an operation \placeholder{B} that modifies \placeholder{M}, then \placeholder{A} shall be earlier
-than \placeholder{B} in the modification order of \placeholder{M}. \begin{note} This requirement
-is known as write-write coherence. \end{note}
+than \placeholder{B} in the modification order of \placeholder{M}.
+\begin{note}
+This requirement
+is known as write-write coherence.
+\end{note}
 
 \pnum
 \indextext{coherence!read-read}%
@@ -5724,7 +5896,9 @@ the value stored by \placeholder{X} or the value stored by a
 \indextext{side effects}%
 side effect \placeholder{Y} on
 \placeholder{M}, where \placeholder{Y} follows \placeholder{X} in the modification order of \placeholder{M}.
-\begin{note} This requirement is known as read-read coherence. \end{note}
+\begin{note}
+This requirement is known as read-read coherence.
+\end{note}
 
 \pnum
 \indextext{coherence!read-write}%
@@ -5733,8 +5907,11 @@ If a
 value computation \placeholder{A} of an atomic object \placeholder{M} happens before an
 operation \placeholder{B} that modifies \placeholder{M}, then \placeholder{A} shall take its value from a side
 effect \placeholder{X} on \placeholder{M}, where \placeholder{X} precedes \placeholder{B} in the
-modification order of \placeholder{M}. \begin{note} This requirement is known as
-read-write coherence. \end{note}
+modification order of \placeholder{M}.
+\begin{note}
+This requirement is known as
+read-write coherence.
+\end{note}
 
 \pnum
 \indextext{coherence!write-read}%
@@ -5745,23 +5922,29 @@ computation \placeholder{B} of \placeholder{M}, then the evaluation \placeholder
 value from \placeholder{X} or from a
 \indextext{side effects}%
 side effect \placeholder{Y} that follows \placeholder{X} in the
-modification order of \placeholder{M}. \begin{note} This requirement is known as
-write-read coherence. \end{note}
+modification order of \placeholder{M}.
+\begin{note}
+This requirement is known as
+write-read coherence.
+\end{note}
 
 \pnum
-\begin{note} The four preceding coherence requirements effectively disallow
+\begin{note}
+The four preceding coherence requirements effectively disallow
 compiler reordering of atomic operations to a single object, even if both
 operations are relaxed loads. This effectively makes the cache coherence
 guarantee provided by most hardware available to \Cpp{} atomic operations.
 \end{note}
 
 \pnum
-\begin{note} The value observed by a load of an atomic depends on the ``happens
+\begin{note}
+The value observed by a load of an atomic depends on the ``happens
 before'' relation, which depends on the values observed by loads of atomics.
 The intended reading is that there must exist an
 association of atomic loads with modifications they observe that, together with
 suitably chosen modification orders and the ``happens before'' relation derived
-as described above, satisfy the resulting constraints as imposed here. \end{note}
+as described above, satisfy the resulting constraints as imposed here.
+\end{note}
 
 \pnum
 Two actions are \defn{potentially concurrent} if
@@ -5775,7 +5958,9 @@ potentially concurrent conflicting actions, at least one of which is not atomic,
 and neither happens before the other,
 except for the special case for signal handlers described below.
 Any such data race results in undefined
-behavior. \begin{note} It can be shown that programs that correctly use mutexes
+behavior.
+\begin{note}
+It can be shown that programs that correctly use mutexes
 and \tcode{memory_order::seq_cst} operations to prevent all data races and use no
 other synchronization operations behave as if the operations executed by their
 constituent threads were simply interleaved, with each
@@ -5789,7 +5974,8 @@ However, this applies only to data-race-free programs, and data-race-free
 programs cannot observe most program transformations that do not change
 single-threaded program semantics. In fact, most single-threaded program
 transformations continue to be allowed, since any program that behaves
-differently as a result must perform an undefined operation. \end{note}
+differently as a result must perform an undefined operation.
+\end{note}
 
 \pnum
 Two accesses to the same object of type \tcode{volatile std::sig_atomic_t} do not
@@ -5804,7 +5990,8 @@ handler and the execution of the signal handler happened before all evaluations
 in \placeholder{B}.
 
 \pnum
-\begin{note} Compiler transformations that introduce assignments to a potentially
+\begin{note}
+Compiler transformations that introduce assignments to a potentially
 shared memory location that would not be modified by the abstract machine are
 generally precluded by this document, since such an assignment might overwrite
 another assignment by a different thread in cases in which an abstract machine
@@ -5812,16 +5999,19 @@ execution would not have encountered a data race. This includes implementations
 of data member assignment that overwrite adjacent members in separate memory
 locations. Reordering of atomic loads in cases in which the atomics in question
 may alias is also generally precluded, since this may violate the coherence
-rules. \end{note}
+rules.
+\end{note}
 
 \pnum
-\begin{note} Transformations that introduce a speculative read of a potentially
+\begin{note}
+Transformations that introduce a speculative read of a potentially
 shared memory location may not preserve the semantics of the \Cpp{} program as
 defined in this document, since they potentially introduce a data race. However,
 they are typically valid in the context of an optimizing compiler that targets a
 specific machine with well-defined semantics for data races. They would be
 invalid for a hypothetical machine that is not tolerant of races or provides
-hardware race detection. \end{note}
+hardware race detection.
+\end{note}
 
 \rSec3[intro.progress]{Forward progress}
 
@@ -5834,8 +6024,10 @@ following:
 \item perform an access through a volatile glvalue, or
 \item perform a synchronization operation or an atomic operation.
 \end{itemize}
-\begin{note} This is intended to allow compiler transformations such as removal of
-empty loops, even when termination cannot be proven. \end{note}
+\begin{note}
+This is intended to allow compiler transformations such as removal of
+empty loops, even when termination cannot be proven.
+\end{note}
 
 \pnum
 Executions of atomic functions
@@ -6042,11 +6234,14 @@ and in which variables of static storage duration
 might be initialized\iref{basic.start.static} and destroyed\iref{basic.start.term}.
 It is \impldef{defining \tcode{main} in freestanding environment}
 whether a program in a freestanding environment is required to define a \tcode{main}
-function. \begin{note} In a freestanding environment, start-up and termination is
+function.
+\begin{note}
+In a freestanding environment, start-up and termination is
 \impldef{start-up and termination in freestanding environment}; start-up contains the
 execution of constructors for objects of namespace scope with static storage duration;
 termination contains the execution of destructors for objects with static storage
-duration. \end{note}
+duration.
+\end{note}
 
 \pnum
 An implementation shall not predefine the \tcode{main} function. This
@@ -6076,9 +6271,12 @@ characters of null-terminated multibyte strings (\ntmbs{}s)\iref{multibyte.strin
 and \tcode{argv[0]} shall be the pointer to
 the initial character of a \ntmbs{} that represents the name used to
 invoke the program or \tcode{""}. The value of \tcode{argc} shall be
-non-negative. The value of \tcode{argv[argc]} shall be 0. \begin{note} It
+non-negative. The value of \tcode{argv[argc]} shall be 0.
+\begin{note}
+It
 is recommended that any further (optional) parameters be added after
-\tcode{argv}. \end{note}
+\tcode{argv}.
+\end{note}
 
 \pnum
 The function \tcode{main} shall not be used within
@@ -6100,7 +6298,8 @@ not otherwise reserved.
 \begin{example}
 Member functions, classes, and
 enumerations can be called \tcode{main}, as can entities in other
-namespaces. \end{example}
+namespaces.
+\end{example}
 
 \pnum
 \indextext{\idxcode{exit}}%
@@ -6152,9 +6351,11 @@ Together, zero-initialization and constant initialization are called
 all other initialization is \defn{dynamic initialization}.
 All static initialization strongly happens before\iref{intro.races}
 any dynamic initialization.
-\begin{note} The dynamic initialization of non-local variables is described
+\begin{note}
+The dynamic initialization of non-local variables is described
 in~\ref{basic.start.dynamic}; that of local static variables is described
-in~\ref{stmt.dcl}. \end{note}
+in~\ref{stmt.dcl}.
+\end{note}
 
 \pnum
 An implementation is permitted to perform the initialization of a
@@ -6201,8 +6402,10 @@ unordered if the variable is an implicitly or explicitly instantiated
 specialization, is partially-ordered if the variable
 is an inline variable that is not an implicitly or explicitly instantiated
 specialization, and otherwise is ordered.
-\begin{note} An explicitly specialized non-inline static data member or
-variable template specialization has ordered initialization.\end{note}
+\begin{note}
+An explicitly specialized non-inline static data member or
+variable template specialization has ordered initialization.
+\end{note}
 
 \pnum
 Dynamic initialization of non-local variables \tcode{V} and \tcode{W}
@@ -6308,7 +6511,8 @@ initializations are delayed until \tcode{a} is first odr-used in
 initialized before it is odr-used by the initialization of \tcode{a}, that
 is, before \tcode{A::A} is called. If, however, \tcode{a} is initialized
 at some point after the first statement of \tcode{main}, \tcode{b} will
-be initialized prior to its use in \tcode{A::A}. \end{example}
+be initialized prior to its use in \tcode{A::A}.
+\end{example}
 
 \pnum
 It is \impldef{dynamic initialization of static inline variables before \tcode{main}}
@@ -6412,11 +6616,14 @@ If there is a use of a standard library object or function not permitted within 
 handlers\iref{support.runtime} that does not happen before\iref{intro.multithread}
 completion of destruction of objects with static storage duration and execution of
 \tcode{std::atexit} registered functions\iref{support.start.term}, the program has
-undefined behavior. \begin{note} If there is a use of an object with static storage
+undefined behavior.
+\begin{note}
+If there is a use of an object with static storage
 duration that does not happen before the object's destruction, the program has undefined
 behavior. Terminating every thread before a call to \tcode{std::exit} or the exit from
 \tcode{main} is sufficient, but not necessary, to satisfy these requirements. These
-requirements permit thread managers as static-storage-duration objects. \end{note}
+requirements permit thread managers as static-storage-duration objects.
+\end{note}
 
 \pnum
 \indextext{\idxcode{abort}}%

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -281,7 +281,6 @@ struct POD {        // both trivial and standard-layout
 \pnum
 A class definition introduces a new type.
 \begin{example}
-
 \begin{codeblock}
 struct X { int a; };
 struct Y { int a; };
@@ -393,7 +392,6 @@ differs from a class declaration in that if a class of the elaborated
 name is in scope the elaborated name will refer to it.
 \end{note}
 \begin{example}
-
 \begin{codeblock}
 struct s { int a; };
 
@@ -882,7 +880,6 @@ arguments\iref{dcl.fct.default} or in the member function body) is looked up
 as described in~\ref{basic.lookup}.
 \end{note}
 \begin{example}
-
 \begin{codeblock}
 struct X {
   typedef int T;
@@ -987,7 +984,6 @@ an enumerator or a nested type of class \tcode{X} or of a base class of
 These transformations do not apply in the
 template definition context\iref{temp.dep.type}.
 \begin{example}
-
 \begin{codeblock}
 struct tnode {
   char tword[20];
@@ -1036,7 +1032,6 @@ declared \tcode{volatile} is a \defn{volatile member function} and a
 member function declared \tcode{const} \tcode{volatile} is a
 \defn{const volatile member function}.
 \begin{example}
-
 \begin{codeblock}
 struct X {
   void g() const;
@@ -1076,7 +1071,6 @@ is declared \tcode{const} \tcode{volatile}, the type of \tcode{this} is
 \begin{note} Thus in a const member function, the object for which the function is
 called is accessed through a const access path. \end{note}
 \begin{example}
-
 \begin{codeblock}
 struct s {
   int a;
@@ -1105,7 +1099,6 @@ A cv-qualified member function can be called on an
 object-expression\iref{expr.ref} only if the object-expression is as
 cv-qualified or less-cv-qualified than the member function.
 \begin{example}
-
 \begin{codeblock}
 void k(s& x, const s& y) {
   x.f();
@@ -1256,7 +1249,6 @@ In a constructor declaration, each \grammarterm{decl-specifier} in the optional
 \grammarterm{decl-specifier-seq} shall be \tcode{friend}, \tcode{inline},
 \tcode{constexpr}, or an \grammarterm{explicit-specifier}.
 \begin{example}
-
 \begin{codeblock}
 struct S {
   S();              // declares the constructor
@@ -1528,7 +1520,6 @@ Y e = d;            // calls \tcode{Y(const Y\&)}
 \begin{note}
 All forms of copy/move constructor may be declared for a class.
 \begin{example}
-
 \begin{codeblock}
 struct X {
   X(const X&);
@@ -1557,7 +1548,6 @@ cannot initialize an object of type
 cv-qualified)
 \tcode{X}.
 \begin{example}
-
 \begin{codeblock}
 struct X {
   X();              // default constructor
@@ -1825,7 +1815,6 @@ an expression of type const
 cannot be assigned to an object of type
 \tcode{X}.
 \begin{example}
-
 \begin{codeblock}
 struct X {
   X();
@@ -2090,7 +2079,6 @@ It is unspecified whether subobjects representing virtual base classes
 are assigned more than once by the implicitly-defined copy/move assignment
 operator.
 \begin{example}
-
 \begin{codeblock}
 struct V { };
 struct A : virtual V { };
@@ -2375,7 +2363,6 @@ undefined behavior.
 \begin{note} Invoking \tcode{delete} on a null pointer does not call the
 destructor; see \ref{expr.delete}. \end{note}
 \begin{example}
-
 \begin{codeblock}
 struct B {
   virtual ~B() { }
@@ -2543,7 +2530,6 @@ to the type of its class.
 Such a constructor is called a
 \defnadj{converting}{constructor}.
 \begin{example}
-
 \indextext{Jessie}%
 \begin{codeblock}
 struct X {
@@ -2747,7 +2733,6 @@ refer to a static member. A static member may be
 referred to using the class member access syntax, in which case the
 object expression is evaluated.
 \begin{example}
-
 \begin{codeblock}
 struct process {
   static void reschedule();
@@ -2769,7 +2754,6 @@ as if a \grammarterm{qualified-id} expression was used, with the
 \grammarterm{nested-name-specifier} of the \grammarterm{qualified-id} naming
 the class scope from which the static member is referenced.
 \begin{example}
-
 \begin{codeblock}
 int g();
 struct X {
@@ -2855,7 +2839,6 @@ operator. The \grammarterm{initializer} expression in the definition of a
 static data member is in the scope of its
 class\iref{basic.scope.class}.
 \begin{example}
-
 \begin{codeblock}
 class process {
   static process* run_chain;
@@ -3010,7 +2993,6 @@ same type and the width is large
 enough to hold all the values of that enumeration type\iref{dcl.enum},
 the original value and the value of the bit-field compare equal.
 \begin{example}
-
 \begin{codeblock}
 enum BOOL { FALSE=0, TRUE=1 };
 struct A {
@@ -3313,7 +3295,6 @@ definition, the members of the anonymous union are considered to have
 been defined in the scope in which the anonymous union is declared.
 \indextext{initialization!\idxcode{union}}%
 \begin{example}
-
 \begin{codeblock}
 void f() {
   union { int a; const char* p; };
@@ -3343,7 +3324,6 @@ member functions.
 \pnum
 A union for which objects, pointers, or references are declared is not an anonymous union.
 \begin{example}
-
 \begin{codeblock}
 void f() {
   union { int aa; char* p; } obj, *ptr = &obj;
@@ -4541,7 +4521,6 @@ Members of a class defined with the keywords
 \tcode{struct} or \tcode{union}
 are public by default.
 \begin{example}
-
 \begin{codeblock}
 class X {
   int a;            // \tcode{X::a} is private by default
@@ -4700,7 +4679,6 @@ until the end of the class or until another
 \grammarterm{access-specifier}
 is encountered.
 \begin{example}
-
 \begin{codeblock}
 class X {
   int a;            // \tcode{X::a} is private by default: \tcode{class} used
@@ -4714,7 +4692,6 @@ public:
 \pnum
 Any number of access specifiers is allowed and no particular order is required.
 \begin{example}
-
 \begin{codeblock}
 struct S {
   int a;            // \tcode{S::a} is public by default: \tcode{struct} used
@@ -4737,7 +4714,6 @@ When a member is redeclared within its class definition,
 the access specified at its redeclaration shall
 be the same as at its initial declaration.
 \begin{example}
-
 \begin{codeblock}
 struct S {
   class A;
@@ -4812,7 +4788,6 @@ is assumed when the class is
 defined with the \grammarterm{class-key}
 \tcode{class}.
 \begin{example}
-
 \begin{codeblock}
 class B { @\commentellip@ };
 class D1 : private B { @\commentellip@ };
@@ -5037,7 +5012,6 @@ is accessible at
 when named in class
 \tcode{B}.
 \begin{example}
-
 \begin{codeblock}
 class B;
 class A {
@@ -5108,7 +5082,6 @@ protected members from the class granting friendship can be accessed in the
 \grammarterm{base-specifier}{s} and member declarations of the befriended
 class.
 \begin{example}
-
 \begin{codeblock}
 class A {
   class B { };
@@ -5124,7 +5097,6 @@ struct X : A::B {               // OK: \tcode{A::B} accessible to friend
 \end{codeblock}
 \end{example}
 \begin{example}
-
 \begin{codeblock}
 class X {
   enum { a=100 };
@@ -5167,7 +5139,6 @@ type specifier in a \tcode{friend} declaration designates a (possibly
 cv-qualified) class type, that class is declared as a friend; otherwise, the
 friend declaration is ignored.
 \begin{example}
-
 \begin{codeblock}
 class C;
 typedef C Ct;
@@ -5209,7 +5180,6 @@ a class
 \tcode{Y}.
 \indextext{member function!friend}%
 \begin{example}
-
 \begin{codeblock}
 class Y {
   friend char* X::foo(int);
@@ -5225,7 +5195,6 @@ A function can be defined in a friend declaration of a class if and only if the
 class is a non-local class\iref{class.local}, the function name is unqualified,
 and the function has namespace scope.
 \begin{example}
-
 \begin{codeblock}
 class M {
   friend void f() { }           // definition of global \tcode{f}, a friend of \tcode{M},
@@ -5260,7 +5229,6 @@ portion of the class
 \indextext{friend!inheritance and}%
 Friendship is neither inherited nor transitive.
 \begin{example}
-
 \begin{codeblock}
 class A {
   friend class B;
@@ -5301,7 +5269,6 @@ subsequently referenced, its name is not found by name lookup
 until a matching declaration is provided in the innermost enclosing
 non-class scope.
 \begin{example}
-
 \begin{codeblock}
 class X;
 void a();
@@ -5339,7 +5306,6 @@ to form a pointer to member\iref{expr.unary.op}, the
 expression\iref{expr.ref}. In this case, the class of the object expression shall be
 \tcode{C} or a class derived from \tcode{C}.
 \begin{example}
-
 \begin{codeblock}
 class B {
 protected:
@@ -5392,7 +5358,6 @@ void g(B* pb, D1* p1, D2* p2) {
 The access rules\iref{class.access} for a virtual function are determined by its declaration
 and are not affected by the rules for a function that later overrides it.
 \begin{example}
-
 \begin{codeblock}
 class B {
 public:
@@ -5431,7 +5396,6 @@ in the example above) is in general not known.
 If a name can be reached by several paths through a multiple inheritance
 graph, the access is that of the path that gives most access.
 \begin{example}
-
 \begin{codeblock}
 class W { public: void f(); };
 class A : private virtual W { };
@@ -5559,7 +5523,6 @@ An object of class type can also be initialized by a
 \grammarterm{braced-init-list}. List-initialization semantics apply;
 see~\ref{dcl.init} and~\ref{dcl.init.list}.
 \begin{example}
-
 \begin{codeblock}
 complex v[6] = { 1, complex(1,2), complex(), 2 };
 \end{codeblock}
@@ -5687,7 +5650,6 @@ A
 \grammarterm{mem-initializer-list}
 can initialize a base class using any \grammarterm{class-or-decltype} that denotes that base class type.
 \begin{example}
-
 \begin{codeblock}
 struct A { A(); };
 typedef A global_A;
@@ -5705,7 +5667,6 @@ an inherited virtual base class, the
 \grammarterm{mem-initializer}
 is ill-formed.
 \begin{example}
-
 \begin{codeblock}
 struct A { A(); };
 struct B: public virtual A { };
@@ -5741,7 +5702,6 @@ Once the target constructor returns, the body of the delegating constructor
 is executed. If a constructor delegates to itself directly or indirectly,
 the program is ill-formed, no diagnostic required.
 \begin{example}
-
 \begin{codeblock}
 struct C {
   C( int ) { }                  // \#1: non-delegating constructor
@@ -6001,7 +5961,6 @@ are evaluated in the scope of the constructor for which the
 \grammarterm{mem-initializer}
 is specified.
 \begin{example}
-
 \begin{codeblock}
 class X {
   int a;
@@ -6109,7 +6068,6 @@ a pack expansion\iref{temp.variadic} that initializes the base
 classes specified by a pack expansion in the \grammarterm{base-specifier-list}
 for the class.
 \begin{example}
-
 \begin{codeblock}
 template<class... Mixins>
 class X : public Mixins... {
@@ -6278,7 +6236,6 @@ the constructor's
 \tcode{this}
 pointer, the value of the object or subobject thus obtained is unspecified.
 \begin{example}
-
 \begin{codeblock}
 struct C;
 void no_opt(C*);
@@ -6373,7 +6330,6 @@ the complete object of \tcode{x} or one of that object's base class subobjects
 but not \tcode{x} or one of its base class subobjects, the behavior
 is undefined.
 \begin{example}
-
 \begin{codeblock}
 struct V {
   virtual void f();

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -751,7 +751,7 @@ have a name different from \tcode{T}:
 \begin{note}
 This restriction does not apply to constructors, which do not have
 names\iref{class.ctor}
-\end{note}
+\end{note}%
 ;
 
 \item every member of class \tcode{T} that is itself a type;

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -100,7 +100,8 @@ as a \grammarterm{class-or-decltype} in a \grammarterm{base-clause}\iref{class.d
 the program is ill-formed. Whenever a
 \grammarterm{class-key} is followed by a \grammarterm{class-head-name}, the
 \grammarterm{identifier} \tcode{final}, and a colon or left brace, \tcode{final} is
-interpreted as a \grammarterm{class-virt-specifier}. \begin{example}
+interpreted as a \grammarterm{class-virt-specifier}.
+\begin{example}
 \begin{codeblock}
 struct A;
 struct A final {};      // OK: definition of \tcode{struct A},
@@ -1510,7 +1511,8 @@ first parameter is of type \tcode{X\&\&}, \tcode{const X\&\&},
 \tcode{volatile X\&\&}, or \tcode{const volatile X\&\&}, and either there are
 no other parameters or else all other parameters have default
 arguments\iref{dcl.fct.default}.
-\begin{example} \tcode{Y::Y(Y\&\&)} is a move constructor.
+\begin{example}
+\tcode{Y::Y(Y\&\&)} is a move constructor.
 \begin{codeblock}
 struct Y {
   Y(const Y&);
@@ -1908,7 +1910,8 @@ will be implicitly declared as defaulted if and only if
 \tcode{X} does not have a user-declared destructor.
 \end{itemize}
 
-\begin{example} The class definition
+\begin{example}
+The class definition
 \begin{codeblock}
 struct S {
   int a;
@@ -3183,7 +3186,8 @@ of the union must be user-provided or it will
 be implicitly deleted\iref{dcl.fct.def.delete} for the union. \end{note}
 
 \pnum
-\begin{example} Consider the following union:
+\begin{example}
+Consider the following union:
 
 \begin{codeblock}
 union U {
@@ -3856,7 +3860,8 @@ class \tcode{D2}.
 \pnum
 If a virtual function \tcode{f} in some class \tcode{B} is marked with the
 \grammarterm{virt-specifier} \tcode{final} and in a class \tcode{D} derived from \tcode{B}
-a function \tcode{D::f} overrides \tcode{B::f}, the program is ill-formed. \begin{example}
+a function \tcode{D::f} overrides \tcode{B::f}, the program is ill-formed.
+\begin{example}
 \begin{codeblock}
 struct B {
   virtual void f() const final;
@@ -3870,7 +3875,8 @@ struct D : B {
 
 \pnum
 If a virtual function is marked with the \grammarterm{virt-specifier} \tcode{override} and
-does not override a member function of a base class, the program is ill-formed. \begin{example}
+does not override a member function of a base class, the program is ill-formed.
+\begin{example}
 \begin{codeblock}
 struct B {
   virtual void f(int);
@@ -4659,7 +4665,8 @@ member functions of class templates is performed as described in~\ref{temp.inst}
 \pnum
 The names in a default \grammarterm{template-argument}\iref{temp.param}
 have their access checked in the context in which they appear rather than at any
-points of use of the default \grammarterm{template-argument}. \begin{example}
+points of use of the default \grammarterm{template-argument}.
+\begin{example}
 \begin{codeblock}
 class B { };
 template <class T> class C {
@@ -5099,7 +5106,8 @@ void f() {
 Declaring a class to be a friend implies that the names of private and
 protected members from the class granting friendship can be accessed in the
 \grammarterm{base-specifier}{s} and member declarations of the befriended
-class. \begin{example}
+class.
+\begin{example}
 
 \begin{codeblock}
 class A {
@@ -5133,7 +5141,8 @@ class Z {
 \end{codeblock}
 \end{example}
 
-A class shall not be defined in a friend declaration. \begin{example}
+A class shall not be defined in a friend declaration.
+\begin{example}
 \begin{codeblock}
 class A {
   friend class B { };           // error: cannot define class in friend declaration
@@ -5156,7 +5165,8 @@ shall have one of the following forms:
 (\ref{temp}, \ref{temp.friend}).\end{note} If the
 type specifier in a \tcode{friend} declaration designates a (possibly
 cv-qualified) class type, that class is declared as a friend; otherwise, the
-friend declaration is ignored. \begin{example}
+friend declaration is ignored.
+\begin{example}
 
 \begin{codeblock}
 class C;
@@ -5547,7 +5557,8 @@ has no effect on initialization.
 \indextext{constructor!array of class objects and}%
 An object of class type can also be initialized by a
 \grammarterm{braced-init-list}. List-initialization semantics apply;
-see~\ref{dcl.init} and~\ref{dcl.init.list}. \begin{example}
+see~\ref{dcl.init} and~\ref{dcl.init.list}.
+\begin{example}
 
 \begin{codeblock}
 complex v[6] = { 1, complex(1,2), complex(), 2 };
@@ -5728,7 +5739,8 @@ is a \term{delegating constructor}, and the constructor selected by the
 The target constructor is selected by overload resolution.
 Once the target constructor returns, the body of the delegating constructor
 is executed. If a constructor delegates to itself directly or indirectly,
-the program is ill-formed, no diagnostic required. \begin{example}
+the program is ill-formed, no diagnostic required.
+\begin{example}
 
 \begin{codeblock}
 struct C {
@@ -5867,7 +5879,8 @@ If a given non-static data member has both a default member initializer
 and a \grammarterm{mem-initializer}, the initialization specified by the
 \grammarterm{mem-initializer} is performed, and the non-static data member's
 default member initializer is ignored.
-\begin{example} Given
+\begin{example}
+Given
 % The comment below is misrendered with an overly large space before 'effects'
 % if left to listings (see NB US-26 (C++17 CD)) (possibly due to the ff
 % ligature), so we fix it up manually.
@@ -6094,7 +6107,8 @@ of an object under construction.
 A \grammarterm{mem-initializer} followed by an ellipsis is
 a pack expansion\iref{temp.variadic} that initializes the base
 classes specified by a pack expansion in the \grammarterm{base-specifier-list}
-for the class. \begin{example}
+for the class.
+\begin{example}
 
 \begin{codeblock}
 template<class... Mixins>

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -61,8 +61,11 @@ shall be an explicit specialization\iref{temp.expl.spec} or
 a partial specialization\iref{temp.class.spec}.
 A \grammarterm{class-specifier} whose
 \grammarterm{class-head} omits the
-\grammarterm{class-head-name} defines an unnamed class. \begin{note} An unnamed class thus can't
-be \tcode{final}. \end{note}
+\grammarterm{class-head-name} defines an unnamed class.
+\begin{note}
+An unnamed class thus can't
+be \tcode{final}.
+\end{note}
 
 \pnum
 A \grammarterm{class-name} is inserted into the scope in which it is
@@ -160,8 +163,10 @@ and move assignment operator is trivial, and
 A \defnadj{trivial}{class} is a class that is trivially copyable and
 has one or more eligible default constructors\iref{class.default.ctor},
 all of which are trivial.
-\begin{note} In particular, a trivially copyable or trivial class does not have
-virtual functions or virtual base classes.\end{note}
+\begin{note}
+In particular, a trivially copyable or trivial class does not have
+virtual functions or virtual base classes.
+\end{note}
 
 \pnum
 A class \tcode{S} is a \defnadj{standard-layout}{class} if it:
@@ -188,8 +193,10 @@ where for any type \tcode{X}, $M(\mathtt{X})$ is defined as follows.\footnote{
 This ensures that two subobjects that have the same class type and that
 belong to the same most derived object are not allocated at the same
 address\iref{expr.eq}.}
-\begin{note} $M(\mathtt{X})$ is the set of the types of all non-base-class subobjects
-that may be at a zero offset in \tcode{X}. \end{note}
+\begin{note}
+$M(\mathtt{X})$ is the set of the types of all non-base-class subobjects
+that may be at a zero offset in \tcode{X}.
+\end{note}
 
 \begin{itemize}
 \item If \tcode{X} is a non-union class type with no (possibly
@@ -241,9 +248,11 @@ defined with the
 \grammarterm{class-key} \tcode{union}.
 
 \pnum
-\begin{note} Standard-layout classes are useful for communicating with
+\begin{note}
+Standard-layout classes are useful for communicating with
 code written in other programming languages. Their layout is specified
-in~\ref{class.mem}.\end{note}
+in~\ref{class.mem}.
+\end{note}
 
 \pnum
 \begin{example}
@@ -537,8 +546,10 @@ of the class.
 Any other data member or member function is a \defn{non-static member}
 (a \defn{non-static data member} or
 \defn{non-static member function}~(\ref{class.mfct.non-static}), respectively).
-\begin{note} A non-static data member of non-reference
-type is a member subobject of a class object\iref{intro.object}.\end{note}
+\begin{note}
+A non-static data member of non-reference
+type is a member subobject of a class object\iref{intro.object}.
+\end{note}
 
 \pnum
 A member shall not be declared twice in the
@@ -740,7 +751,8 @@ have a name different from \tcode{T}:
 \begin{note}
 This restriction does not apply to constructors, which do not have
 names\iref{class.ctor}
-\end{note};
+\end{note}
+;
 
 \item every member of class \tcode{T} that is itself a type;
 
@@ -1068,8 +1080,10 @@ if the member function is declared \tcode{volatile}, the type of
 \tcode{this} is \tcode{volatile} \tcode{X*}, and if the member function
 is declared \tcode{const} \tcode{volatile}, the type of \tcode{this} is
 \tcode{const} \tcode{volatile} \tcode{X*}.
-\begin{note} Thus in a const member function, the object for which the function is
-called is accessed through a const access path. \end{note}
+\begin{note}
+Thus in a const member function, the object for which the function is
+called is accessed through a const access path.
+\end{note}
 \begin{example}
 \begin{codeblock}
 struct s {
@@ -1146,7 +1160,8 @@ copy constructors, move constructors\iref{class.copy.ctor},
 copy assignment operators, move assignment operators\iref{class.copy.assign},
 and prospective destructors\iref{class.dtor} are
 \term{special member functions}.
-\begin{note} The implementation will implicitly declare these member functions for some class
+\begin{note}
+The implementation will implicitly declare these member functions for some class
 types when the program does not explicitly declare them.
 The implementation will implicitly define them
 if they are odr-used\iref{basic.def.odr} or
@@ -1643,9 +1658,11 @@ implicitly declared as defaulted if and only if
 \tcode{X} does not have a user-declared destructor.
 \end{itemize}
 
-\begin{note} When the move constructor is not implicitly declared or explicitly supplied,
+\begin{note}
+When the move constructor is not implicitly declared or explicitly supplied,
 expressions that otherwise would have invoked the move constructor may instead invoke
-a copy constructor. \end{note}
+a copy constructor.
+\end{note}
 
 \pnum
 The implicitly-declared move constructor for class \tcode{X} will have the form
@@ -1747,7 +1764,9 @@ implied exception specification\iref{except.spec}.
 The implicitly-defined copy/move constructor for a non-union class
 \tcode{X}
 performs a memberwise copy/move of its bases and members.
-\begin{note} Default member initializers of non-static data members are ignored. See also the example in~\ref{class.base.init}. \end{note}
+\begin{note}
+Default member initializers of non-static data members are ignored. See also the example in~\ref{class.base.init}.
+\end{note}
 The order of initialization is the same as the order of initialization of bases
 and members in a user-defined constructor (see~\ref{class.base.init}).
 Let \tcode{x} be either the parameter of the constructor or, for the move constructor, an
@@ -1874,10 +1893,16 @@ X& X::operator=(X&)
 A user-declared move assignment operator \tcode{X::operator=} is
 a non-static non-template member function of class \tcode{X} with exactly
 one parameter of type \tcode{X\&\&}, \tcode{const X\&\&}, \tcode{volatile X\&\&}, or
-\tcode{const volatile X\&\&}. \begin{note} An overloaded assignment operator must be
-declared to have only one parameter; see~\ref{over.ass}. \end{note}{}
-\begin{note} More
-than one form of move assignment operator may be declared for a class. \end{note}
+\tcode{const volatile X\&\&}.
+\begin{note}
+An overloaded assignment operator must be
+declared to have only one parameter; see~\ref{over.ass}.
+\end{note}
+{}
+\begin{note}
+More
+than one form of move assignment operator may be declared for a class.
+\end{note}
 
 \pnum
 \indextext{assignment operator!move!implicitly declared}%
@@ -2326,8 +2351,10 @@ the object. A destructor may also be invoked implicitly through use of a
 \grammarterm{delete-expression}\iref{expr.delete} for a constructed object allocated
 by a \grammarterm{new-expression}\iref{expr.new}; the context of the invocation is the
 \grammarterm{delete-expression}.
-\begin{note} An array of class type contains several subobjects for each of which
-the destructor is invoked. \end{note}
+\begin{note}
+An array of class type contains several subobjects for each of which
+the destructor is invoked.
+\end{note}
 A destructor can also be invoked explicitly. A destructor is \term{potentially invoked}
 if it is invoked or as specified in~\ref{expr.new}, \ref{dcl.init.aggr},
 \ref{class.base.init}, and~\ref{except.throw}.
@@ -2360,8 +2387,10 @@ that is, if the object is not of the destructor's class type and
 not of a class derived from the destructor's class type (including when
 the destructor is invoked via a null pointer value), the program has
 undefined behavior.
-\begin{note} Invoking \tcode{delete} on a null pointer does not call the
-destructor; see \ref{expr.delete}. \end{note}
+\begin{note}
+Invoking \tcode{delete} on a null pointer does not call the
+destructor; see \ref{expr.delete}.
+\end{note}
 \begin{example}
 \begin{codeblock}
 struct B {
@@ -3112,7 +3141,8 @@ Y c;                            // error
 X::Y d;                         // OK
 X::I e;                         // OK
 \end{codeblock}
-\end{example}%
+\end{example}
+%
 \indextext{class|)}
 
 \rSec1[class.union]{Unions}%
@@ -3126,7 +3156,9 @@ whose lifetime has begun and has not ended\iref{basic.life}.
 At most one of the non-static data members of an object of union type
 can be active at any
 time, that is, the value of at most one of the non-static data members can be
-stored in a union at any time. \begin{note} One special guarantee is made in order to
+stored in a union at any time.
+\begin{note}
+One special guarantee is made in order to
 simplify the use of unions: If a standard-layout union contains several standard-layout
 structs that share a common initial sequence\iref{class.mem}, and
 if a non-static data member of an object of this standard-layout union type
@@ -3158,14 +3190,16 @@ base classes. A union shall not be used as a base class.
 \indextext{restriction!\idxcode{union}}%
 If a union contains a non-static data member of
 reference type the program is ill-formed.
-\begin{note} Absent default member initializers\iref{class.mem},
+\begin{note}
+Absent default member initializers\iref{class.mem},
 if any non-static data member of a union has a non-trivial
 default constructor\iref{class.default.ctor},
 copy constructor, move constructor\iref{class.copy.ctor},
 copy assignment operator, move assignment operator\iref{class.copy.assign},
 or destructor\iref{class.dtor}, the corresponding member function
 of the union must be user-provided or it will
-be implicitly deleted\iref{dcl.fct.def.delete} for the union. \end{note}
+be implicitly deleted\iref{dcl.fct.def.delete} for the union.
+\end{note}
 
 \pnum
 \begin{example}
@@ -3184,7 +3218,8 @@ member functions, \tcode{U} will have an implicitly deleted default constructor,
 copy/move constructor,
 copy/move assignment operator, and destructor.
 To use \tcode{U}, some or all of these member functions
-must be user-provided.\end{example}
+must be user-provided.
+\end{example}
 
 \pnum
 When the left operand of an assignment operator
@@ -3254,8 +3289,10 @@ void g() {
 \end{example}
 
 \pnum
-\begin{note} In general, one must use explicit destructor calls and placement
-\grammarterm{new-expression} to change the active member of a union. \end{note}
+\begin{note}
+In general, one must use explicit destructor calls and placement
+\grammarterm{new-expression} to change the active member of a union.
+\end{note}
 \begin{example}
 Consider an object \tcode{u} of a \tcode{union} type \tcode{U} having non-static data members
 \tcode{m} of type \tcode{M} and \tcode{n} of type \tcode{N}. If \tcode{M} has a non-trivial
@@ -3757,7 +3794,9 @@ declaration of an overriding function is valid but redundant (has empty
 semantics).}
 \begin{note}
 Virtual functions support dynamic binding and object-oriented
-programming. \end{note} A class that declares or inherits a virtual function is
+programming.
+\end{note}
+A class that declares or inherits a virtual function is
 called a \defnadj{polymorphic}{class}.\footnote{If
 all virtual functions are immediate functions,
 the class is still polymorphic even though
@@ -4446,7 +4485,8 @@ void g() {
 \begin{note}
 Even if the result of name lookup is unambiguous, use of a name found in
 multiple subobjects might still be
-ambiguous~(\ref{conv.mem}, \ref{expr.ref}, \ref{class.access.base}).\end{note}
+ambiguous~(\ref{conv.mem}, \ref{expr.ref}, \ref{class.access.base}).
+\end{note}
 \begin{example}
 \begin{codeblock}
 struct B1 {
@@ -4471,7 +4511,8 @@ struct D: I1, I2, B2 {
     int D::* mpD = &D::i;       // Ambiguous conversion
   }
 };
-\end{codeblock}\end{example}
+\end{codeblock}
+\end{example}
 
 \rSec1[class.access]{Member access control}%
 \indextext{access control|(}
@@ -4582,8 +4623,10 @@ name from the declaration of a particular
 entity, including parts of the declaration preceding the name of the entity
 being declared and, if the entity is a class, the definitions of members of
 the class appearing outside the class's \grammarterm{member-specification}{.}
-\begin{note} This access also applies to implicit references to constructors,
-conversion functions, and destructors. \end{note}
+\begin{note}
+This access also applies to implicit references to constructors,
+conversion functions, and destructors.
+\end{note}
 
 \pnum
 \begin{example}
@@ -4706,8 +4749,10 @@ public:
 \end{example}
 
 \pnum
-\begin{note} The effect of access control on the order of allocation
-of data members is described in~\ref{class.mem}.\end{note}
+\begin{note}
+The effect of access control on the order of allocation
+of data members is described in~\ref{class.mem}.
+\end{note}
 
 \pnum
 When a member is redeclared within its class definition,
@@ -5132,9 +5177,12 @@ shall have one of the following forms:
 \keyword{friend} typename-specifier \terminal{;}
 \end{ncsimplebnf}
 
-\begin{note} A friend declaration may be the
+\begin{note}
+A friend declaration may be the
 \grammarterm{declaration} in a \grammarterm{template-declaration}
-(\ref{temp}, \ref{temp.friend}).\end{note} If the
+(\ref{temp}, \ref{temp.friend}).
+\end{note}
+If the
 type specifier in a \tcode{friend} declaration designates a (possibly
 cv-qualified) class type, that class is declared as a friend; otherwise, the
 friend declaration is ignored.
@@ -5441,7 +5489,8 @@ class E {
   }
 };
 \end{codeblock}
-\end{example}%
+\end{example}
+%
 \indextext{access control|)}
 
 \rSec1[class.init]{Initialization}%
@@ -5794,9 +5843,11 @@ as specified in~\ref{dcl.init};
 \item otherwise, the entity is default-initialized\iref{dcl.init}.
 \end{itemize}
 
-\begin{note} An abstract class\iref{class.abstract} is never a most derived
+\begin{note}
+An abstract class\iref{class.abstract} is never a most derived
 class, thus its constructors never initialize virtual base classes, therefore the
-corresponding \grammarterm{mem-initializer}{s} may be omitted. \end{note}
+corresponding \grammarterm{mem-initializer}{s} may be omitted.
+\end{note}
 An attempt to initialize more than one non-static data member of a union renders the
 program ill-formed.
 \indextext{initialization!const member}%
@@ -5877,8 +5928,10 @@ A a2(1);                // OK, unfortunately
 \pnum
 In a non-delegating constructor, the destructor for each potentially constructed
 subobject of class type is potentially invoked\iref{class.dtor}.
-\begin{note} This provision ensures that destructors can be called for fully-constructed
-subobjects in case an exception is thrown\iref{except.ctor}. \end{note}
+\begin{note}
+This provision ensures that destructors can be called for fully-constructed
+subobjects in case an exception is thrown\iref{except.ctor}.
+\end{note}
 
 \pnum
 In a non-delegating constructor, initialization
@@ -6503,8 +6556,10 @@ the \grammarterm{exception-declaration} as an alias for the exception
 object if the meaning of the program will be unchanged except for the execution
 of constructors and destructors for the object declared by the
 \grammarterm{exception-declaration}.
-\begin{note} There cannot be a move from the exception object because it is
-always an lvalue.  \end{note}
+\begin{note}
+There cannot be a move from the exception object because it is
+always an lvalue.
+\end{note}
 \end{itemize}
 Copy elision is not permitted
 where an expression is evaluated in a context

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -3142,7 +3142,6 @@ X::Y d;                         // OK
 X::I e;                         // OK
 \end{codeblock}
 \end{example}
-%
 \indextext{class|)}
 
 \rSec1[class.union]{Unions}%
@@ -5490,7 +5489,6 @@ class E {
 };
 \end{codeblock}
 \end{example}
-%
 \indextext{access control|)}
 
 \rSec1[class.init]{Initialization}%

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -1337,9 +1337,11 @@ Assigns
 \tcode{nh.alloc_}.
 \end{itemize}
 
-\pnum \returns \tcode{*this}.
+\pnum
+\returns \tcode{*this}.
 
-\pnum \throws Nothing.
+\pnum
+\throws Nothing.
 \end{itemdescr}
 
 \rSec3[container.node.dtor]{Destructor}
@@ -3378,7 +3380,8 @@ constexpr size_type size() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{N}.
+\pnum
+\returns \tcode{N}.
 \end{itemdescr}
 
 \indexlibrarymember{array}{data}%
@@ -3388,7 +3391,8 @@ constexpr const T* data() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \returns
+\pnum
+\returns
 A pointer such that \range{data()}{data() + size()} is a valid range. For a
 non-empty array, \tcode{data()} \tcode{==} \tcode{addressof(front())}.
 \end{itemdescr}
@@ -3432,7 +3436,8 @@ template<class T, size_t N>
 \pnum
 \constraints \tcode{N == 0} or \tcode{is_swappable_v<T>} is \tcode{true}.
 
-\pnum\effects
+\pnum
+\effects
 As if by \tcode{x.swap(y)}.
 
 \pnum
@@ -3442,9 +3447,11 @@ As if by \tcode{x.swap(y)}.
 \rSec3[array.zero]{Zero-sized arrays}
 
 \indextext{\idxcode{array}!zero sized}%
-\pnum\tcode{array} shall provide support for the special case \tcode{N == 0}.
+\pnum
+\tcode{array} shall provide support for the special case \tcode{N == 0}.
 
-\pnum In the case that \tcode{N == 0}, \tcode{begin() == end() ==} unique value.
+\pnum
+In the case that \tcode{N == 0}, \tcode{begin() == end() ==} unique value.
 The return value of \tcode{data()} is unspecified.
 
 \pnum
@@ -9308,7 +9315,8 @@ unordered_multiset(initializer_list<value_type> il,
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects
+\pnum
+\effects
 Constructs an empty \tcode{unordered_multiset} using the
 specified hash function, key equality predicate, and allocator, and
 using at least \tcode{n} buckets. If \tcode{n} is not
@@ -9319,7 +9327,8 @@ for the first form, or from the range
 \range{il.begin()}{il.end()} for the second form.
 \tcode{max_load_factor()} returns \tcode{1.0}.
 
-\pnum\complexity Average case linear, worst case quadratic.
+\pnum
+\complexity Average case linear, worst case quadratic.
 \end{itemdescr}
 
 \rSec3[unord.multiset.erasure]{Erasure}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -62,7 +62,9 @@ and destroyed using the function
 where \tcode{U} is either \tcode{allocator_type::value_type} or
 an internal type used by the container.
 These functions are called only for the
-container's element type, not for internal types used by the container. \begin{note} This
+container's element type, not for internal types used by the container.
+\begin{note}
+This
 means, for example, that a node-based container might need to construct nodes containing
 aligned buffers and call \tcode{construct} to place the element into the buffer.
 \end{note}
@@ -311,11 +313,13 @@ type, either or both may be replaced by an object of the container's
 \pnum
 Unless otherwise specified, all containers defined in this clause obtain memory
 using an allocator (see~\ref{allocator.requirements}).
-\begin{note} In particular, containers and iterators do not store references
+\begin{note}
+In particular, containers and iterators do not store references
 to allocated elements other than through the allocator's pointer type,
 i.e., as objects of type \tcode{P} or
 \tcode{pointer_traits<P>::template re\-bind<\unspec>},
-where \tcode{P} is \tcode{allocator_traits<allocator_type>::pointer}. \end{note}
+where \tcode{P} is \tcode{allocator_traits<allocator_type>::pointer}.
+\end{note}
 Copy constructors for these container types obtain an allocator by calling
 \tcode{allocator_traits<allocator_type>::select_on_container_copy_construction}
 on the allocator belonging to the container being copied.
@@ -324,7 +328,8 @@ the container being moved. Such move construction of the allocator shall not exi
 exception.
 All other constructors for these container types take a
 \tcode{const allocator_type\&} argument.
-\begin{note} If an invocation of a constructor uses the default value of an optional
+\begin{note}
+If an invocation of a constructor uses the default value of an optional
 allocator argument, then the allocator type must support value-initialization.
 \end{note}
 A copy of this allocator is used for any memory allocation and element construction
@@ -448,7 +453,10 @@ no
 \tcode{swap()}
 function invalidates any references,
 pointers, or iterators referring to the elements
-of the containers being swapped. \begin{note} The \tcode{end()} iterator does not refer to any element, so it may be invalidated. \end{note}
+of the containers being swapped.
+\begin{note}
+The \tcode{end()} iterator does not refer to any element, so it may be invalidated.
+\end{note}
 \end{itemize}
 
 \pnum
@@ -553,7 +561,9 @@ allocator_traits<A>::construct(m, p, rv)
 \end{codeblock}
 and its evaluation causes the following postcondition to hold: The value
 of \tcode{*p} is equivalent to the value of \tcode{rv} before the evaluation.
-\begin{note} \tcode{rv} remains a valid object. Its state is unspecified \end{note}
+\begin{note}
+\tcode{rv} remains a valid object. Its state is unspecified
+\end{note}
 
 \item
 \tcode{T} is \defnx{\oldconcept{CopyInsertable} into \tcode{X}}
@@ -738,7 +748,8 @@ races when the contents of the contained object in different elements in the sam
 container, excepting \tcode{vector<bool>}, are modified concurrently.
 
 \pnum
-\begin{note} For a \tcode{vector<int> x} with a size greater than one, \tcode{x[1] = 5}
+\begin{note}
+For a \tcode{vector<int> x} with a size greater than one, \tcode{x[1] = 5}
 and \tcode{*x.begin() = 10} can be executed concurrently without a data race, but
 \tcode{x[0] = 5} and \tcode{*x.begin() = 10} executed concurrently may result in a data
 race.
@@ -865,8 +876,10 @@ The complexities of the expressions are sequence dependent.
  \oldconcept{MoveInsertable} into \tcode{X} and \oldconcept{MoveAssignable}.\br
  \effects Inserts an object of type \tcode{T} constructed with
  \tcode{std::forward<\brk{}Args\brk{}>(\brk{}args)...} before \tcode{p}.
- \begin{note} \tcode{args} may directly or indirectly refer to
- a value in \tcode{a}. \end{note}
+ \begin{note}
+\tcode{args} may directly or indirectly refer to
+ a value in \tcode{a}.
+\end{note}
  \\ \rowsep
 
 \tcode{a.insert(p,t)}   &
@@ -1595,17 +1608,22 @@ are constant iterators. It is unspecified whether or not
 and
 \tcode{const_iterator}
 are the same type.
-\begin{note} \tcode{iterator} and \tcode{const_iterator} have identical semantics in this case, and \tcode{iterator} is convertible to \tcode{const_iterator}. Users can avoid violating the one-definition rule by always using \tcode{const_iterator} in their function parameter lists. \end{note}
+\begin{note}
+\tcode{iterator} and \tcode{const_iterator} have identical semantics in this case, and \tcode{iterator} is convertible to \tcode{const_iterator}. Users can avoid violating the one-definition rule by always using \tcode{const_iterator} in their function parameter lists.
+\end{note}
 
 \pnum
 The associative containers meet all the requirements of Allocator-aware
 containers\iref{container.requirements.general}, except that for
 \tcode{map} and \tcode{multimap}, the requirements placed on \tcode{value_type}
 in \tref{container.alloc.req} apply instead to \tcode{key_type}
-and \tcode{mapped_type}. \begin{note} For example, in some cases \tcode{key_type} and \tcode{mapped_type}
+and \tcode{mapped_type}.
+\begin{note}
+For example, in some cases \tcode{key_type} and \tcode{mapped_type}
 are required to be \oldconcept{CopyAssignable} even though the associated
 \tcode{value_type}, \tcode{pair<const key_type, mapped_type>}, is not
-\oldconcept{CopyAssignable}. \end{note}
+\oldconcept{CopyAssignable}.
+\end{note}
 
 \pnum
 In \tref{container.assoc.req},
@@ -2212,9 +2230,11 @@ key equality predicate
 \tcode{true} when passed those values.  If \tcode{k1} and
 \tcode{k2} are equivalent, the container's hash function shall
 return the same value for both.
-\begin{note} Thus, when an unordered associative container is instantiated with
+\begin{note}
+Thus, when an unordered associative container is instantiated with
 a non-default \tcode{Pred} parameter it usually needs a non-default \tcode{Hash}
-parameter as well. \end{note}
+parameter as well.
+\end{note}
 For any two keys \tcode{k1} and \tcode{k2} in the same container,
 calling \tcode{pred(k1, k2)} shall always return the same value.
 For any key \tcode{k} in a container, calling \tcode{hash(k)}
@@ -2247,7 +2267,8 @@ For unordered containers where the value type is the same as the key
 type, both \tcode{iterator} and \tcode{const_iterator} are constant
 iterators. It is unspecified whether or not \tcode{iterator} and
 \tcode{const_iterator} are the same type.
-\begin{note} \tcode{iterator} and \tcode{const_iterator} have identical
+\begin{note}
+\tcode{iterator} and \tcode{const_iterator} have identical
 semantics in this case, and \tcode{iterator} is convertible to
 \tcode{const_iterator}. Users can avoid violating the one-definition rule
 by always using \tcode{const_iterator} in their function parameter lists.
@@ -2272,10 +2293,13 @@ The unordered associative containers meet all the requirements of Allocator-awar
 containers\iref{container.requirements.general}, except that for
 \tcode{unordered_map} and \tcode{unordered_multimap}, the requirements placed on \tcode{value_type}
 in \tref{container.alloc.req} apply instead to \tcode{key_type}
-and \tcode{mapped_type}. \begin{note} For example, \tcode{key_type} and \tcode{mapped_type}
+and \tcode{mapped_type}.
+\begin{note}
+For example, \tcode{key_type} and \tcode{mapped_type}
 are sometimes required to be \oldconcept{CopyAssignable} even though the associated
 \tcode{value_type}, \tcode{pair<const key_type, mapped_type>}, is not
-\oldconcept{CopyAssignable}. \end{note}
+\oldconcept{CopyAssignable}.
+\end{note}
 
 \pnum
 \indextext{unordered associative containers}%
@@ -3854,8 +3878,10 @@ void shrink_to_fit();
 \effects
 \tcode{shrink_to_fit} is a non-binding request to reduce memory use
 but does not change the size of the sequence.
-\begin{note} The request is non-binding to allow latitude for
-implementation-specific optimizations. \end{note}
+\begin{note}
+The request is non-binding to allow latitude for
+implementation-specific optimizations.
+\end{note}
 If the size is equal to the old capacity, or
 if an exception is thrown other than by the move constructor
 of a non-\oldconcept{CopyInsertable} \tcode{T},
@@ -3947,7 +3973,9 @@ element of a deque but not the last element invalidates only iterators
 and references to the erased elements. An erase operation
 that erases neither the first element nor the last element of a deque invalidates the past-the-end
 iterator and all iterators and references to all the elements of the deque.
-\begin{note} \tcode{pop_front} and \tcode{pop_back} are erase operations. \end{note}
+\begin{note}
+\tcode{pop_front} and \tcode{pop_back} are erase operations.
+\end{note}
 
 \pnum
 \complexity
@@ -3995,9 +4023,11 @@ Equivalent to: \tcode{c.erase(remove_if(c.begin(), c.end(), pred), c.end());}
 A \tcode{forward_list} is a container that supports forward iterators and allows
 constant time insert and erase operations anywhere within the sequence, with storage
 management handled automatically. Fast random access to list elements is not supported.
-\begin{note} It is intended that \tcode{forward_list} have zero space or time overhead
+\begin{note}
+It is intended that \tcode{forward_list} have zero space or time overhead
 relative to a hand-written C-style singly linked list. Features that would conflict with
-that goal have been omitted.\end{note}
+that goal have been omitted.
+\end{note}
 
 \pnum
 A \tcode{forward_list} meets all of the requirements of a container
@@ -4013,10 +4043,12 @@ Descriptions are provided here only for operations on
 is additional semantic information.
 
 \pnum
-\begin{note} Modifying any list requires access to the element preceding the first element
+\begin{note}
+Modifying any list requires access to the element preceding the first element
 of interest, but in a \tcode{forward_list} there is no constant-time way to access a
 preceding element. For this reason, ranges that are modified, such as those supplied to
-\tcode{erase} and \tcode{splice}, must be open at the beginning. \end{note}
+\tcode{erase} and \tcode{splice}, must be open at the beginning.
+\end{note}
 
 \begin{codeblock}
 namespace std {
@@ -5809,8 +5841,10 @@ constexpr void shrink_to_fit();
 \effects
 \tcode{shrink_to_fit} is a non-binding request to reduce
 \tcode{capacity()} to \tcode{size()}.
-\begin{note} The request is non-binding to allow latitude for
-implementation-specific optimizations. \end{note}
+\begin{note}
+The request is non-binding to allow latitude for
+implementation-specific optimizations.
+\end{note}
 It does not increase \tcode{capacity()}, but may reduce \tcode{capacity()}
 by causing reallocation.
 If an exception is thrown other than by the move constructor

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -639,7 +639,8 @@ non-const rvalue of type \tcode{X}, and \tcode{m} is a value of type \tcode{A}.
 
 \tcode{X(m)}							&
 																				&
-\ensures \tcode{u.empty()} returns \tcode{true}, &
+\ensures
+\tcode{u.empty()} returns \tcode{true}, &
 constant												\\
 \tcode{X u(m);}					&
 																				&
@@ -649,8 +650,10 @@ constant												\\
 \tcode{X(t, m)}\br
 \tcode{X u(t, m);}				&
                           &
-\expects \tcode{T} is \oldconcept{CopyInsertable} into \tcode{X}.\br
-\ensures \tcode{u == t}, \tcode{u.get_allocator() == m} &
+\expects
+\tcode{T} is \oldconcept{CopyInsertable} into \tcode{X}.\br
+\ensures
+\tcode{u == t}, \tcode{u.get_allocator() == m} &
 linear													\\ \rowsep
 
 \tcode{X(rv)}\br
@@ -1301,7 +1304,8 @@ public:
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{\placeholder{node-handle}} object initializing
+\effects
+Constructs a \tcode{\placeholder{node-handle}} object initializing
 \tcode{ptr_} with \tcode{nh.ptr_}.  Move constructs \tcode{alloc_} with
 \tcode{nh.alloc_}.  Assigns \tcode{nullptr} to \tcode{nh.ptr_} and assigns
 \tcode{nullopt} to \tcode{nh.alloc_}.
@@ -1313,7 +1317,8 @@ public:
 
 \begin{itemdescr}
 \pnum
-\expects Either \tcode{!alloc_}, or
+\expects
+Either \tcode{!alloc_}, or
 \tcode{ator_traits::propagate_on_container_move_assignment::value}
 is \tcode{true}, or \tcode{alloc_ ==  nh.alloc_}.
 
@@ -1338,10 +1343,12 @@ Assigns
 \end{itemize}
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \rSec3[container.node.dtor]{Destructor}
@@ -1352,7 +1359,8 @@ Assigns
 
 \begin{itemdescr}
 \pnum
-\effects If \tcode{ptr_ != nullptr}, destroys the \tcode{value_type} subobject
+\effects
+If \tcode{ptr_ != nullptr}, destroys the \tcode{value_type} subobject
 in the \tcode{container_node_type} object pointed to by \tcode{ptr_} by calling
 \tcode{ator_traits::destroy}, then deallocates \tcode{ptr_} by calling
 \tcode{ator_traits::template rebind_traits<container_node_type>::deallocate}.
@@ -1366,14 +1374,17 @@ value_type& value() const;
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{empty() == false}.
+\expects
+\tcode{empty() == false}.
 
 \pnum
-\returns A reference to the \tcode{value_type} subobject in the
+\returns
+A reference to the \tcode{value_type} subobject in the
 \tcode{container_node_type} object pointed to by \tcode{ptr_}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -1382,18 +1393,22 @@ key_type& key() const;
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{empty() == false}.
+\expects
+\tcode{empty() == false}.
 
 \pnum
-\returns A non-const reference to the \tcode{key_type} member of the
+\returns
+A non-const reference to the \tcode{key_type} member of the
 \tcode{value_type} subobject in the \tcode{contain\-er_node_type} object
 pointed to by \tcode{ptr_}.
 
 \pnum
-\throws  Nothing.
+\throws
+Nothing.
 
 \pnum
-\remarks Modifying the key through the returned reference is permitted.
+\remarks
+Modifying the key through the returned reference is permitted.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -1402,15 +1417,18 @@ mapped_type& mapped() const;
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{empty() == false}.
+\expects
+\tcode{empty() == false}.
 
 \pnum
-\returns A reference to the \tcode{mapped_type} member of the
+\returns
+A reference to the \tcode{mapped_type} member of the
 \tcode{value_type} subobject in the \tcode{container_node_type} object
 pointed to by \tcode{ptr_}.
 
 \pnum
-\throws  Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 
@@ -1420,13 +1438,16 @@ allocator_type get_allocator() const;
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{empty() == false}.
+\expects
+\tcode{empty() == false}.
 
 \pnum
-\returns \tcode{*alloc_}.
+\returns
+\tcode{*alloc_}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -1435,7 +1456,8 @@ explicit operator bool() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ptr_ != nullptr}.
+\returns
+\tcode{ptr_ != nullptr}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -1444,7 +1466,8 @@ explicit operator bool() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ptr_ == nullptr}.
+\returns
+\tcode{ptr_ == nullptr}.
 \end{itemdescr}
 
 \rSec3[container.node.modifiers]{Modifiers}
@@ -1457,12 +1480,14 @@ void swap(@\placeholdernc{node-handle}@& nh)
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{!alloc_}, or \tcode{!nh.alloc_}, or
+\expects
+\tcode{!alloc_}, or \tcode{!nh.alloc_}, or
 \tcode{ator_traits::propagate_on_container_swap::value} is \tcode{true},
 or \tcode{alloc_ == nh.alloc_}.
 
 \pnum
-\effects Calls \tcode{swap(ptr_, nh.ptr_)}. If \tcode{!alloc_}, or
+\effects
+Calls \tcode{swap(ptr_, nh.ptr_)}. If \tcode{!alloc_}, or
 \tcode{!nh.alloc_}, or \tcode{ator_traits::propagate_on_container_swap::value}
 is \tcode{true} calls \tcode{swap(alloc_, nh.alloc_)}.
 \end{itemdescr}
@@ -3369,7 +3394,8 @@ template<class T, class... U>
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\mandates \tcode{(is_same_v<T, U> \&\& ...)} is \tcode{true}.
+\mandates
+\tcode{(is_same_v<T, U> \&\& ...)} is \tcode{true}.
 \end{itemdescr}
 
 \rSec3[array.members]{Member functions}
@@ -3381,7 +3407,8 @@ constexpr size_type size() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{N}.
+\returns
+\tcode{N}.
 \end{itemdescr}
 
 \indexlibrarymember{array}{data}%
@@ -3404,7 +3431,8 @@ constexpr void fill(const T& u);
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{fill_n(begin(), N, u)}.
+\effects
+As if by \tcode{fill_n(begin(), N, u)}.
 \end{itemdescr}
 
 \indexlibrarymember{array}{swap}%
@@ -3414,7 +3442,8 @@ constexpr void swap(array& y) noexcept(is_nothrow_swappable_v<T>);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to \tcode{swap_ranges(begin(), end(), y.begin())}.
+\effects
+Equivalent to \tcode{swap_ranges(begin(), end(), y.begin())}.
 
 \pnum
 \begin{note}
@@ -3441,7 +3470,8 @@ template<class T, size_t N>
 As if by \tcode{x.swap(y)}.
 
 \pnum
-\complexity Linear in \tcode{N}.
+\complexity
+Linear in \tcode{N}.
 \end{itemdescr}
 
 \rSec3[array.zero]{Zero-sized arrays}
@@ -3482,7 +3512,8 @@ template<class T, size_t N>
 \tcode{T} meets the \oldconcept{CopyConstructible} requirements.
 
 \pnum
-\returns \tcode{\{\{ a[0], $\dotsc$, a[N - 1] \}\}}.
+\returns
+\tcode{\{\{ a[0], $\dotsc$, a[N - 1] \}\}}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{to_array}}%
@@ -3502,7 +3533,8 @@ template<class T, size_t N>
 \tcode{T} meets the \oldconcept{MoveConstructible} requirements.
 
 \pnum
-\returns \tcode{\{\{ std::move(a[0]), $\dotsc$, std::move(a[N - 1]) \}\}}.
+\returns
+\tcode{\{\{ std::move(a[0]), $\dotsc$, std::move(a[N - 1]) \}\}}.
 \end{itemdescr}
 
 \rSec3[array.tuple]{Tuple interface}
@@ -3547,7 +3579,8 @@ template<size_t I, class T, size_t N>
 \tcode{I < N} is \tcode{true}.
 
 \pnum
-\returns A reference to the $\tcode{I}^\text{th}$ element of \tcode{a},
+\returns
+A reference to the $\tcode{I}^\text{th}$ element of \tcode{a},
 where indexing is zero-based.
 \end{itemdescr}
 
@@ -3716,7 +3749,8 @@ explicit deque(size_type n, const Allocator& = Allocator());
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{deque} with
+\effects
+Constructs a \tcode{deque} with
 \tcode{n} default-inserted elements using the specified allocator.
 
 \pnum
@@ -3724,7 +3758,8 @@ explicit deque(size_type n, const Allocator& = Allocator());
 \tcode{T} is \oldconcept{DefaultInsertable} into \tcode{*this}.
 
 \pnum
-\complexity Linear in \tcode{n}.
+\complexity
+Linear in \tcode{n}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{deque}!constructor}%
@@ -3765,7 +3800,8 @@ equal to the range
 using the specified allocator.
 
 \pnum
-\complexity Linear in \tcode{distance(first, last)}.
+\complexity
+Linear in \tcode{distance(first, last)}.
 \end{itemdescr}
 
 \rSec3[deque.capacity]{Capacity}
@@ -3781,7 +3817,8 @@ void resize(size_type sz);
 \tcode{T} is \oldconcept{MoveInsertable} and \oldconcept{DefaultInsertable} into \tcode{*this}.
 
 \pnum
-\effects If \tcode{sz < size()}, erases the last \tcode{size() - sz} elements
+\effects
+If \tcode{sz < size()}, erases the last \tcode{size() - sz} elements
 from the sequence. Otherwise,
 appends \tcode{sz - size()} default-inserted elements to the sequence.
 \end{itemdescr}
@@ -3797,7 +3834,8 @@ void resize(size_type sz, const T& c);
 \tcode{T} is \oldconcept{CopyInsertable} into \tcode{*this}.
 
 \pnum
-\effects If \tcode{sz < size()}, erases the last \tcode{size() - sz} elements
+\effects
+If \tcode{sz < size()}, erases the last \tcode{size() - sz} elements
 from the sequence. Otherwise,
 appends \tcode{sz - size()} copies of \tcode{c} to the sequence.
 \end{itemdescr}
@@ -3813,7 +3851,8 @@ void shrink_to_fit();
 \tcode{T} is \oldconcept{MoveInsertable} into \tcode{*this}.
 
 \pnum
-\effects \tcode{shrink_to_fit} is a non-binding request to reduce memory use
+\effects
+\tcode{shrink_to_fit} is a non-binding request to reduce memory use
 but does not change the size of the sequence.
 \begin{note} The request is non-binding to allow latitude for
 implementation-specific optimizations. \end{note}
@@ -4117,10 +4156,12 @@ explicit forward_list(const Allocator&);
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an empty \tcode{forward_list} object using the specified allocator.
+\effects
+Constructs an empty \tcode{forward_list} object using the specified allocator.
 
 \pnum
-\complexity Constant.
+\complexity
+Constant.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{forward_list}!constructor}%
@@ -4130,14 +4171,17 @@ explicit forward_list(size_type n, const Allocator& = Allocator());
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{T} is \oldconcept{DefaultInsertable} into \tcode{*this}.
+\expects
+\tcode{T} is \oldconcept{DefaultInsertable} into \tcode{*this}.
 
 \pnum
-\effects Constructs a \tcode{forward_list} object with \tcode{n}
+\effects
+Constructs a \tcode{forward_list} object with \tcode{n}
 default-inserted elements using the specified allocator.
 
 \pnum
-\complexity Linear in \tcode{n}.
+\complexity
+Linear in \tcode{n}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{forward_list}!constructor}%
@@ -4147,13 +4191,16 @@ forward_list(size_type n, const T& value, const Allocator& = Allocator());
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{T} is \oldconcept{CopyInsertable} into \tcode{*this}.
+\expects
+\tcode{T} is \oldconcept{CopyInsertable} into \tcode{*this}.
 
 \pnum
-\effects Constructs a \tcode{forward_list} object with \tcode{n} copies of \tcode{value} using the specified allocator.
+\effects
+Constructs a \tcode{forward_list} object with \tcode{n} copies of \tcode{value} using the specified allocator.
 
 \pnum
-\complexity Linear in \tcode{n}.
+\complexity
+Linear in \tcode{n}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{forward_list}!constructor}%
@@ -4164,10 +4211,12 @@ template<class InputIterator>
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{forward_list} object equal to the range \range{first}{last}.
+\effects
+Constructs a \tcode{forward_list} object equal to the range \range{first}{last}.
 
 \pnum
-\complexity Linear in \tcode{distance(first, last)}.
+\complexity
+Linear in \tcode{distance(first, last)}.
 \end{itemdescr}
 
 \rSec3[forwardlist.iter]{Iterators}
@@ -4182,15 +4231,18 @@ const_iterator cbefore_begin() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns A non-dereferenceable iterator that, when incremented, is equal to the iterator
+\returns
+A non-dereferenceable iterator that, when incremented, is equal to the iterator
 returned by \tcode{begin()}.
 
 \pnum
-\effects \tcode{cbefore_begin()} is equivalent to
+\effects
+\tcode{cbefore_begin()} is equivalent to
 \tcode{const_cast<forward_list const\&>(*this).before_begin()}.
 
 \pnum
-\remarks \tcode{before_begin() == end()} shall equal \tcode{false}.
+\remarks
+\tcode{before_begin() == end()} shall equal \tcode{false}.
 \end{itemdescr}
 
 \rSec3[forwardlist.access]{Element access}
@@ -4203,7 +4255,8 @@ const_reference front() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{*begin()}
+\returns
+\tcode{*begin()}
 \end{itemdescr}
 
 \rSec3[forwardlist.modifiers]{Modifiers}
@@ -4225,7 +4278,8 @@ template<class... Args> reference emplace_front(Args&&... args);
 
 \begin{itemdescr}
 \pnum
-\effects Inserts an object of type \tcode{value_type} constructed with
+\effects
+Inserts an object of type \tcode{value_type} constructed with
 \tcode{value_type(std::forward<Args>(\brk{}args)...)} at the beginning of the list.
 \end{itemdescr}
 
@@ -4237,7 +4291,8 @@ void push_front(T&& x);
 
 \begin{itemdescr}
 \pnum
-\effects Inserts a copy of \tcode{x} at the beginning of the list.
+\effects
+Inserts a copy of \tcode{x} at the beginning of the list.
 \end{itemdescr}
 
 
@@ -4248,7 +4303,8 @@ void pop_front();
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{erase_after(before_begin())}.
+\effects
+As if by \tcode{erase_after(before_begin())}.
 \end{itemdescr}
 
 \indexlibrarymember{insert_after}{forward_list}%
@@ -4259,14 +4315,17 @@ iterator insert_after(const_iterator position, T&& x);
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{position} is \tcode{before_begin()} or is a dereferenceable
+\expects
+\tcode{position} is \tcode{before_begin()} or is a dereferenceable
 iterator in the range \range{begin()}{end()}.
 
 \pnum
-\effects Inserts a copy of \tcode{x} after \tcode{position}.
+\effects
+Inserts a copy of \tcode{x} after \tcode{position}.
 
 \pnum
-\returns An iterator pointing to the copy of \tcode{x}.
+\returns
+An iterator pointing to the copy of \tcode{x}.
 \end{itemdescr}
 
 \indexlibrarymember{insert_after}{forward_list}%
@@ -4276,11 +4335,13 @@ iterator insert_after(const_iterator position, size_type n, const T& x);
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{position} is \tcode{before_begin()} or is a dereferenceable
+\expects
+\tcode{position} is \tcode{before_begin()} or is a dereferenceable
 iterator in the range \range{begin()}{end()}.
 
 \pnum
-\effects Inserts \tcode{n} copies of \tcode{x} after \tcode{position}.
+\effects
+Inserts \tcode{n} copies of \tcode{x} after \tcode{position}.
 
 \pnum
 \returns
@@ -4295,12 +4356,14 @@ template<class InputIterator>
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{position} is \tcode{before_begin()} or is a dereferenceable
+\expects
+\tcode{position} is \tcode{before_begin()} or is a dereferenceable
 iterator in the range \range{begin()}{end()}.
 Neither \tcode{first} nor \tcode{last} are iterators in \tcode{*this}.
 
 \pnum
-\effects Inserts copies of elements in \range{first}{last} after \tcode{position}.
+\effects
+Inserts copies of elements in \range{first}{last} after \tcode{position}.
 
 \pnum
 \returns
@@ -4314,7 +4377,8 @@ iterator insert_after(const_iterator position, initializer_list<T> il);
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{insert_after(p, il.begin(), il.end())}.
+\effects
+\tcode{insert_after(p, il.begin(), il.end())}.
 
 \pnum
 \returns
@@ -4330,15 +4394,18 @@ template<class... Args>
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{position} is \tcode{before_begin()} or is a dereferenceable
+\expects
+\tcode{position} is \tcode{before_begin()} or is a dereferenceable
 iterator in the range \range{begin()}{end()}.
 
 \pnum
-\effects Inserts an object of type \tcode{value_type} constructed with
+\effects
+Inserts an object of type \tcode{value_type} constructed with
 \tcode{value_type(std::forward<Args>(\brk{}args)...)} after \tcode{position}.
 
 \pnum
-\returns An iterator pointing to the new object.
+\returns
+An iterator pointing to the new object.
 \end{itemdescr}
 
 \indexlibrarymember{erase_after}{forward_list}%
@@ -4348,17 +4415,21 @@ iterator erase_after(const_iterator position);
 
 \begin{itemdescr}
 \pnum
-\expects The iterator following \tcode{position} is dereferenceable.
+\expects
+The iterator following \tcode{position} is dereferenceable.
 
 \pnum
-\effects Erases the element pointed to by the iterator following \tcode{position}.
+\effects
+Erases the element pointed to by the iterator following \tcode{position}.
 
 \pnum
-\returns An iterator pointing to the element following the one that was
+\returns
+An iterator pointing to the element following the one that was
 erased, or \tcode{end()} if no such element exists.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -4367,16 +4438,20 @@ iterator erase_after(const_iterator position, const_iterator last);
 
 \begin{itemdescr}
 \pnum
-\expects All iterators in the range \orange{position}{last} are dereferenceable.
+\expects
+All iterators in the range \orange{position}{last} are dereferenceable.
 
 \pnum
-\effects Erases the elements in the range \orange{position}{last}.
+\effects
+Erases the elements in the range \orange{position}{last}.
 
 \pnum
-\returns \tcode{last}.
+\returns
+\tcode{last}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \indexlibrarymember{resize}{forward_list}%
@@ -4386,10 +4461,12 @@ void resize(size_type sz);
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{T} is \oldconcept{DefaultInsertable} into \tcode{*this}.
+\expects
+\tcode{T} is \oldconcept{DefaultInsertable} into \tcode{*this}.
 
 \pnum
-\effects If \tcode{sz < distance(begin(), end())}, erases the last \tcode{distance(begin(),
+\effects
+If \tcode{sz < distance(begin(), end())}, erases the last \tcode{distance(begin(),
 end()) - sz} elements from the list. Otherwise, inserts \tcode{sz - distance(begin(), end())} default-inserted
 elements at the end of the list.
 \end{itemdescr}
@@ -4400,10 +4477,12 @@ void resize(size_type sz, const value_type& c);
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{T} is \oldconcept{CopyInsertable} into \tcode{*this}.
+\expects
+\tcode{T} is \oldconcept{CopyInsertable} into \tcode{*this}.
 
 \pnum
-\effects If \tcode{sz < distance(begin(), end())}, erases the last \tcode{distance(begin(),
+\effects
+If \tcode{sz < distance(begin(), end())}, erases the last \tcode{distance(begin(),
 end()) - sz} elements from the list. Otherwise, inserts \tcode{sz - distance(begin(), end())}
 copies of \tcode{c} at the end of the list.
 \end{itemdescr}
@@ -4416,10 +4495,12 @@ void clear() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Erases all elements in the range \range{begin()}{end()}.
+\effects
+Erases all elements in the range \range{begin()}{end()}.
 
 \pnum
-\remarks Does not invalidate past-the-end iterators.
+\remarks
+Does not invalidate past-the-end iterators.
 \end{itemdescr}
 
 \rSec3[forwardlist.ops]{Operations}
@@ -4440,23 +4521,27 @@ void splice_after(const_iterator position, forward_list&& x);
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{position} is \tcode{before_begin()} or is a dereferenceable
+\expects
+\tcode{position} is \tcode{before_begin()} or is a dereferenceable
 iterator in the range \range{begin()}{end()}.
 \tcode{get_allocator() == x.get_allocator()} is \tcode{true}.
 \tcode{addressof(x) != this} is \tcode{true}.
 
 \pnum
-\effects Inserts the contents of \tcode{x} after
+\effects
+Inserts the contents of \tcode{x} after
 \tcode{position}, and \tcode{x} becomes empty. Pointers and references to the moved
 elements of \tcode{x} now refer to those same elements but as members of \tcode{*this}.
 Iterators referring to the moved elements will continue to refer to their elements, but
 they now behave as iterators into \tcode{*this}, not into \tcode{x}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 
 \pnum
-\complexity \bigoh{\tcode{distance(x.begin(), x.end())}}
+\complexity
+\bigoh{\tcode{distance(x.begin(), x.end())}}
 \end{itemdescr}
 
 \indexlibrarymember{splice_after}{forward_list}%
@@ -4467,13 +4552,15 @@ void splice_after(const_iterator position, forward_list&& x, const_iterator i);
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{position} is \tcode{before_begin()} or is a dereferenceable
+\expects
+\tcode{position} is \tcode{before_begin()} or is a dereferenceable
 iterator in the range \range{begin()}{end()}.
 The iterator following \tcode{i} is a dereferenceable iterator in \tcode{x}.
 \tcode{get_allocator() == x.get_allocator()} is \tcode{true}.
 
 \pnum
-\effects Inserts the element following \tcode{i} into \tcode{*this}, following
+\effects
+Inserts the element following \tcode{i} into \tcode{*this}, following
 \tcode{position}, and removes it from \tcode{x}.
 The result is unchanged if \tcode{position == i} or \tcode{position == ++i}. Pointers
 and references to \tcode{*++i} continue to refer to the same element but as a member of
@@ -4481,10 +4568,12 @@ and references to \tcode{*++i} continue to refer to the same element but as a me
 the same element, but now behave as iterators into \tcode{*this}, not into \tcode{x}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 
 \pnum
-\complexity \bigoh{1}
+\complexity
+\bigoh{1}
 \end{itemdescr}
 
 \indexlibrarymember{splice_after}{forward_list}%
@@ -4497,21 +4586,24 @@ void splice_after(const_iterator position, forward_list&& x,
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{position} is \tcode{before_begin()} or is a
+\expects
+\tcode{position} is \tcode{before_begin()} or is a
 dereferenceable iterator in the range \range{begin()}{end()}. \orange{first}{last} is a
 valid range in \tcode{x}, and all iterators in the range \orange{first}{last} are
 dereferenceable. \tcode{position} is not an iterator in the range \orange{first}{last}.
 \tcode{get_allocator() == x.get_allocator()} is \tcode{true}.
 
 \pnum
-\effects Inserts elements in the range \orange{first}{last} after \tcode{position} and
+\effects
+Inserts elements in the range \orange{first}{last} after \tcode{position} and
 removes the elements from \tcode{x}. Pointers and references to the moved elements of
 \tcode{x} now refer to those same elements but as members of \tcode{*this}. Iterators
 referring to the moved elements will continue to refer to their elements, but they now
 behave as iterators into \tcode{*this}, not into \tcode{x}.
 
 \pnum
-\complexity \bigoh{\tcode{distance(first, last)}}
+\complexity
+\bigoh{\tcode{distance(first, last)}}
 \end{itemdescr}
 
 \indexlibrarymember{remove}{forward_list}%
@@ -4523,23 +4615,28 @@ template<class Predicate> size_type remove_if(Predicate pred);
 
 \begin{itemdescr}
 \pnum
-\effects Erases all the elements in the list referred to by a list iterator \tcode{i} for
+\effects
+Erases all the elements in the list referred to by a list iterator \tcode{i} for
 which the following conditions hold: \tcode{*i == value} (for \tcode{remove()}),
 \tcode{pred(*i)} is \tcode{true} (for \tcode{remove_if()}).
 Invalidates only the iterators and references to the erased elements.
 
 \pnum
-\returns The number of elements erased.
+\returns
+The number of elements erased.
 
 \pnum
-\throws Nothing unless an exception is thrown by the equality comparison or the
+\throws
+Nothing unless an exception is thrown by the equality comparison or the
 predicate.
 
 \pnum
-\remarks Stable\iref{algorithm.stable}.
+\remarks
+Stable\iref{algorithm.stable}.
 
 \pnum
-\complexity Exactly \tcode{distance(begin(), end())} applications of the corresponding
+\complexity
+Exactly \tcode{distance(begin(), end())} applications of the corresponding
 predicate.
 \end{itemdescr}
 
@@ -4551,20 +4648,24 @@ template<class BinaryPredicate> size_type unique(BinaryPredicate pred);
 
 \begin{itemdescr}
 \pnum
-\effects Erases all but the first element from every consecutive
+\effects
+Erases all but the first element from every consecutive
 group of equal elements referred to by the iterator \tcode{i} in the range \range{first +
 1}{last} for which \tcode{*i == *(i-1)} (for the version with no arguments) or \tcode{pred(*i,
 *(i - 1))} (for the version with a predicate argument) holds.
 Invalidates only the iterators and references to the erased elements.
 
 \pnum
-\returns The number of elements erased.
+\returns
+The number of elements erased.
 
 \pnum
-\throws Nothing unless an exception is thrown by the equality comparison or the predicate.
+\throws
+Nothing unless an exception is thrown by the equality comparison or the predicate.
 
 \pnum
-\complexity If the range \range{first}{last} is not empty, exactly \tcode{(last - first) - 1} applications of the corresponding predicate, otherwise no applications of the predicate.
+\complexity
+If the range \range{first}{last} is not empty, exactly \tcode{(last - first) - 1} applications of the corresponding predicate, otherwise no applications of the predicate.
 \end{itemdescr}
 
 \indexlibrarymember{merge}{forward_list}%
@@ -4577,13 +4678,15 @@ template<class Compare> void merge(forward_list&& x, Compare comp);
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{*this} and \tcode{x} are both sorted with respect to
+\expects
+\tcode{*this} and \tcode{x} are both sorted with respect to
 the comparator \tcode{operator<} (for the first two overloads) or
 \tcode{comp} (for the last two overloads), and
 \tcode{get_allocator() == x.get_allocator()} is \tcode{true}.
 
 \pnum
-\effects Merges the two sorted ranges \tcode{[begin(), end())} and
+\effects
+Merges the two sorted ranges \tcode{[begin(), end())} and
 \tcode{[x.begin(), x.end())}. \tcode{x} is empty after the merge. If an
 exception is thrown other than by a comparison there are no effects.
 Pointers and references to the moved elements of \tcode{x} now refer to those same elements
@@ -4592,10 +4695,12 @@ refer to their elements, but they now behave as iterators into \tcode{*this}, no
 \tcode{x}.
 
 \pnum
-\remarks Stable\iref{algorithm.stable}.
+\remarks
+Stable\iref{algorithm.stable}.
 
 \pnum
-\complexity At most \tcode{distance(begin(),
+\complexity
+At most \tcode{distance(begin(),
 end()) + distance(x.begin(), x.end()) - 1} comparisons.
 \end{itemdescr}
 
@@ -4607,15 +4712,18 @@ template<class Compare> void sort(Compare comp);
 
 \begin{itemdescr}
 \pnum
-\effects Sorts the list according to the \tcode{operator<} or the \tcode{comp} function object.
+\effects
+Sorts the list according to the \tcode{operator<} or the \tcode{comp} function object.
 If an exception is thrown, the order of the elements in \tcode{*this} is unspecified.
 Does not affect the validity of iterators and references.
 
 \pnum
-\remarks Stable\iref{algorithm.stable}.
+\remarks
+Stable\iref{algorithm.stable}.
 
 \pnum
-\complexity Approximately $N \log N$ comparisons, where $N$ is \tcode{distance(begin(), end())}.
+\complexity
+Approximately $N \log N$ comparisons, where $N$ is \tcode{distance(begin(), end())}.
 \end{itemdescr}
 
 \indexlibrarymember{reverse}{forward_list}%
@@ -4625,11 +4733,13 @@ void reverse() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Reverses the order of the elements in the list.
+\effects
+Reverses the order of the elements in the list.
 Does not affect the validity of iterators and references.
 
 \pnum
-\complexity Linear time.
+\complexity
+Linear time.
 \end{itemdescr}
 
 \rSec3[forward.list.erasure]{Erasure}
@@ -4854,10 +4964,12 @@ explicit list(size_type n, const Allocator& = Allocator());
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{T} is \oldconcept{DefaultInsertable} into \tcode{*this}.
+\expects
+\tcode{T} is \oldconcept{DefaultInsertable} into \tcode{*this}.
 
 \pnum
-\effects Constructs a \tcode{list} with
+\effects
+Constructs a \tcode{list} with
 \tcode{n} default-inserted elements using the specified allocator.
 
 \pnum
@@ -4873,7 +4985,8 @@ list(size_type n, const T& value, const Allocator& = Allocator());
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{T} is \oldconcept{CopyInsertable} into \tcode{*this}.
+\expects
+\tcode{T} is \oldconcept{CopyInsertable} into \tcode{*this}.
 
 \pnum
 \effects
@@ -4920,7 +5033,8 @@ void resize(size_type sz);
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{T} is \oldconcept{DefaultInsertable} into \tcode{*this}.
+\expects
+\tcode{T} is \oldconcept{DefaultInsertable} into \tcode{*this}.
 
 \pnum
 \effects
@@ -4943,7 +5057,8 @@ void resize(size_type sz, const T& c);
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{T} is \oldconcept{CopyInsertable} into \tcode{*this}.
+\expects
+\tcode{T} is \oldconcept{CopyInsertable} into \tcode{*this}.
 
 \pnum
 \effects
@@ -5014,7 +5129,8 @@ void clear() noexcept;
 Invalidates only the iterators and references to the erased elements.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 
 \pnum
 \complexity
@@ -5076,7 +5192,8 @@ not into
 \tcode{x}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 
 \pnum
 \complexity
@@ -5121,7 +5238,8 @@ not into
 \tcode{x}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 
 \pnum
 \complexity
@@ -5161,7 +5279,8 @@ not into
 \tcode{x}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 
 \pnum
 \complexity
@@ -5184,7 +5303,8 @@ following conditions hold: \tcode{*i == value}, \tcode{pred(*i) != false}.
 Invalidates only the iterators and references to the erased elements.
 
 \pnum
-\returns The number of elements erased.
+\returns
+The number of elements erased.
 
 \pnum
 \throws
@@ -5194,7 +5314,8 @@ or
 \tcode{pred(*i) != false}.
 
 \pnum
-\remarks Stable\iref{algorithm.stable}.
+\remarks
+Stable\iref{algorithm.stable}.
 
 \pnum
 \complexity
@@ -5220,7 +5341,8 @@ consecutive group of equal elements referred to by the iterator \tcode{i} in the
 Invalidates only the iterators and references to the erased elements.
 
 \pnum
-\returns The number of elements erased.
+\returns
+The number of elements erased.
 
 \pnum
 \throws
@@ -5269,7 +5391,8 @@ refer to their elements, but they now behave as iterators into \tcode{*this}, no
 \tcode{x}.
 
 \pnum
-\remarks Stable\iref{algorithm.stable}. If \tcode{addressof(x) != this}, the range \tcode{[x.begin(), x.end())}
+\remarks
+Stable\iref{algorithm.stable}. If \tcode{addressof(x) != this}, the range \tcode{[x.begin(), x.end())}
 is empty after the merge.
 No elements are copied by this operation.
 
@@ -5314,7 +5437,8 @@ the order of the elements in \tcode{*this} is unspecified.
 Does not affect the validity of iterators and references.
 
 \pnum
-\remarks Stable\iref{algorithm.stable}.
+\remarks
+Stable\iref{algorithm.stable}.
 
 \pnum
 \complexity
@@ -5515,11 +5639,13 @@ constexpr explicit vector(const Allocator&) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an empty \tcode{vector}, using the
+\effects
+Constructs an empty \tcode{vector}, using the
 specified allocator.
 
 \pnum
-\complexity Constant.
+\complexity
+Constant.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{vector}!constructor}
@@ -5529,14 +5655,17 @@ constexpr explicit vector(size_type n, const Allocator& = Allocator());
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{T} is \oldconcept{DefaultInsertable} into \tcode{*this}.
+\expects
+\tcode{T} is \oldconcept{DefaultInsertable} into \tcode{*this}.
 
 \pnum
-\effects Constructs a \tcode{vector} with \tcode{n}
+\effects
+Constructs a \tcode{vector} with \tcode{n}
 default-inserted elements using the specified allocator.
 
 \pnum
-\complexity Linear in \tcode{n}.
+\complexity
+Linear in \tcode{n}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{vector}!constructor}
@@ -5547,15 +5676,18 @@ constexpr vector(size_type n, const T& value,
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{T} is
+\expects
+\tcode{T} is
 \oldconcept{CopyInsertable} into \tcode{*this}.
 
 \pnum
-\effects Constructs a \tcode{vector} with \tcode{n}
+\effects
+Constructs a \tcode{vector} with \tcode{n}
 copies of \tcode{value}, using the specified allocator.
 
 \pnum
-\complexity Linear in \tcode{n}.
+\complexity
+Linear in \tcode{n}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{vector}!constructor}
@@ -5568,7 +5700,8 @@ template<class InputIterator>
 \begin{itemdescr}
 
 \pnum
-\effects Constructs a \tcode{vector} equal to the
+\effects
+Constructs a \tcode{vector} equal to the
 range \range{first}{last}, using the specified allocator.
 
 \pnum
@@ -5605,7 +5738,8 @@ The total number of elements that the vector can hold
 without requiring reallocation.
 
 \pnum
-\complexity Constant time.
+\complexity
+Constant time.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{reserve}!\idxcode{vector}}%
@@ -5615,7 +5749,8 @@ constexpr void reserve(size_type n);
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{T} is \oldconcept{MoveInsertable} into \tcode{*this}.
+\expects
+\tcode{T} is \oldconcept{MoveInsertable} into \tcode{*this}.
 
 \pnum
 \effects
@@ -5667,10 +5802,12 @@ constexpr void shrink_to_fit();
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{T} is \oldconcept{MoveInsertable} into \tcode{*this}.
+\expects
+\tcode{T} is \oldconcept{MoveInsertable} into \tcode{*this}.
 
 \pnum
-\effects \tcode{shrink_to_fit} is a non-binding request to reduce
+\effects
+\tcode{shrink_to_fit} is a non-binding request to reduce
 \tcode{capacity()} to \tcode{size()}.
 \begin{note} The request is non-binding to allow latitude for
 implementation-specific optimizations. \end{note}
@@ -5685,7 +5822,8 @@ If reallocation happens,
 linear in the size of the sequence.
 
 \pnum
-\remarks Reallocation invalidates all the references, pointers, and iterators
+\remarks
+Reallocation invalidates all the references, pointers, and iterators
 referring to the elements in the sequence as well as the past-the-end iterator.
 \begin{note}
 If no reallocation happens, they remain valid.
@@ -5720,16 +5858,19 @@ constexpr void resize(size_type sz);
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{T} is
+\expects
+\tcode{T} is
 \oldconcept{MoveInsertable} and \oldconcept{DefaultInsertable} into \tcode{*this}.
 
 \pnum
-\effects If \tcode{sz < size()}, erases the last \tcode{size() - sz} elements
+\effects
+If \tcode{sz < size()}, erases the last \tcode{size() - sz} elements
 from the sequence. Otherwise,
 appends \tcode{sz - size()} default-inserted elements to the sequence.
 
 \pnum
-\remarks If an exception is thrown other than by the move constructor of a non-\oldconcept{CopyInsertable}
+\remarks
+If an exception is thrown other than by the move constructor of a non-\oldconcept{CopyInsertable}
 \tcode{T} there are no effects.
 \end{itemdescr}
 
@@ -5741,15 +5882,18 @@ constexpr void resize(size_type sz, const T& c);
 \begin{itemdescr}
 \pnum
 \pnum
-\expects \tcode{T} is
+\expects
+\tcode{T} is
 \oldconcept{CopyInsertable} into \tcode{*this}.
 
-\effects If \tcode{sz < size()}, erases the last \tcode{size() - sz} elements
+\effects
+If \tcode{sz < size()}, erases the last \tcode{size() - sz} elements
 from the sequence. Otherwise,
 appends \tcode{sz - size()} copies of \tcode{c} to the sequence.
 
 \pnum
-\remarks If an exception is thrown there are no effects.
+\remarks
+If an exception is thrown there are no effects.
 \end{itemdescr}
 
 \rSec3[vector.data]{Data}
@@ -6017,7 +6161,8 @@ constexpr void flip() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Replaces each element in the container with its complement.
+\effects
+Replaces each element in the container with its complement.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{vector<bool>}%
@@ -6027,7 +6172,8 @@ constexpr static void swap(reference x, reference y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Exchanges the contents of \tcode{x} and \tcode{y} as if by:
+\effects
+Exchanges the contents of \tcode{x} and \tcode{y} as if by:
 
 \begin{codeblock}
 bool b = x;
@@ -6527,7 +6673,8 @@ An exception object of type \tcode{out_of_range} if
 no such element is present.
 
 \pnum
-\complexity Logarithmic.
+\complexity
+Logarithmic.
 \end{itemdescr}
 
 \rSec3[map.modifiers]{Modifiers}
@@ -8047,7 +8194,8 @@ explicit unordered_map(size_type n,
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an empty \tcode{unordered_map} using the
+\effects
+Constructs an empty \tcode{unordered_map} using the
 specified hash function, key equality predicate, and allocator, and
 using at least \tcode{n} buckets.  For the default constructor,
 the number of buckets is \impldef{default number of buckets in
@@ -8055,7 +8203,8 @@ the number of buckets is \impldef{default number of buckets in
 \tcode{max_load_factor()} returns \tcode{1.0}.
 
 \pnum
-\complexity Constant.
+\complexity
+Constant.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{unordered_map}!constructor}%
@@ -8075,7 +8224,8 @@ unordered_map(initializer_list<value_type> il,
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an empty \tcode{unordered_map} using the
+\effects
+Constructs an empty \tcode{unordered_map} using the
 specified hash function, key equality predicate, and allocator, and
 using at least \tcode{n} buckets. If \tcode{n} is not
 provided, the number of buckets is \impldef{default number of buckets in
@@ -8086,7 +8236,8 @@ for the first form, or from the range
 \tcode{max_load_factor()} returns \tcode{1.0}.
 
 \pnum
-\complexity Average case linear, worst case quadratic.
+\complexity
+Average case linear, worst case quadratic.
 \end{itemdescr}
 
 \rSec3[unord.map.elem]{Element access}
@@ -8099,7 +8250,8 @@ mapped_type& operator[](const key_type& k);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return try_emplace(k).first->second;}
+\effects
+Equivalent to: \tcode{return try_emplace(k).first->second;}
 \end{itemdescr}
 
 \indexlibrarymember{unordered_map}{operator[]}%
@@ -8110,7 +8262,8 @@ mapped_type& operator[](key_type&& k);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return try_emplace(move(k)).first->second;}
+\effects
+Equivalent to: \tcode{return try_emplace(move(k)).first->second;}
 \end{itemdescr}
 
 \indexlibrarymember{unordered_map}{at}%
@@ -8122,10 +8275,12 @@ const mapped_type& at(const key_type& k) const;
 
 \begin{itemdescr}
 \pnum
-\returns A reference to \tcode{x.second}, where \tcode{x} is the (unique) element whose key is equivalent to \tcode{k}.
+\returns
+A reference to \tcode{x.second}, where \tcode{x} is the (unique) element whose key is equivalent to \tcode{k}.
 
 \pnum
-\throws An exception object of type \tcode{out_of_range} if no such element is present.
+\throws
+An exception object of type \tcode{out_of_range} if no such element is present.
 \end{itemdescr}
 
 \rSec3[unord.map.modifiers]{Modifiers}
@@ -8143,7 +8298,8 @@ template<class P>
 \tcode{is_constructible_v<value_type, P\&\&>} is \tcode{true}.
 
 \pnum
-\effects Equivalent to: \tcode{return emplace(std::forward<P>(obj));}
+\effects
+Equivalent to: \tcode{return emplace(std::forward<P>(obj));}
 \end{itemdescr}
 
 \indexlibrarymember{unordered_map}{insert}%
@@ -8158,7 +8314,8 @@ template<class P>
 \tcode{is_constructible_v<value_type, P\&\&>} is \tcode{true}.
 
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \tcode{return emplace_hint(hint, std::forward<P>(obj));}
 \end{itemdescr}
 
@@ -8613,7 +8770,8 @@ explicit unordered_multimap(size_type n,
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an empty \tcode{unordered_multimap} using the
+\effects
+Constructs an empty \tcode{unordered_multimap} using the
 specified hash function, key equality predicate, and allocator, and
 using at least \tcode{n} buckets.  For the default constructor,
 the number of buckets is \impldef{default number of buckets in
@@ -8621,7 +8779,8 @@ the number of buckets is \impldef{default number of buckets in
 \tcode{max_load_factor()} returns \tcode{1.0}.
 
 \pnum
-\complexity Constant.
+\complexity
+Constant.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{unordered_multimap}!constructor}%
@@ -8641,7 +8800,8 @@ unordered_multimap(initializer_list<value_type> il,
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an empty \tcode{unordered_multimap} using the
+\effects
+Constructs an empty \tcode{unordered_multimap} using the
 specified hash function, key equality predicate, and allocator, and
 using at least \tcode{n} buckets. If \tcode{n} is not
 provided, the number of buckets is \impldef{default number of buckets in
@@ -8652,7 +8812,8 @@ for the first form, or from the range
 \tcode{max_load_factor()} returns \tcode{1.0}.
 
 \pnum
-\complexity Average case linear, worst case quadratic.
+\complexity
+Average case linear, worst case quadratic.
 \end{itemdescr}
 
 \rSec3[unord.multimap.modifiers]{Modifiers}
@@ -8669,7 +8830,8 @@ template<class P>
 \tcode{is_constructible_v<value_type, P\&\&>} is \tcode{true}.
 
 \pnum
-\effects Equivalent to: \tcode{return emplace(std::forward<P>(obj));}
+\effects
+Equivalent to: \tcode{return emplace(std::forward<P>(obj));}
 \end{itemdescr}
 
 \indexlibrarymember{unordered_multimap}{insert}%
@@ -8684,7 +8846,8 @@ template<class P>
 \tcode{is_constructible_v<value_type, P\&\&>} is \tcode{true}.
 
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \tcode{return emplace_hint(hint, std::forward<P>(obj));}
 \end{itemdescr}
 
@@ -8964,7 +9127,8 @@ explicit unordered_set(size_type n,
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an empty \tcode{unordered_set} using the
+\effects
+Constructs an empty \tcode{unordered_set} using the
 specified hash function, key equality predicate, and allocator, and
 using at least \tcode{n} buckets.  For the default constructor,
 the number of buckets is \impldef{default number of buckets in
@@ -8972,7 +9136,8 @@ the number of buckets is \impldef{default number of buckets in
 \tcode{max_load_factor()} returns \tcode{1.0}.
 
 \pnum
-\complexity Constant.
+\complexity
+Constant.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{unordered_set}!constructor}%
@@ -8992,7 +9157,8 @@ unordered_set(initializer_list<value_type> il,
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an empty \tcode{unordered_set} using the
+\effects
+Constructs an empty \tcode{unordered_set} using the
 specified hash function, key equality predicate, and allocator, and
 using at least \tcode{n} buckets. If \tcode{n} is not
 provided, the number of buckets is \impldef{default number of buckets in
@@ -9003,7 +9169,8 @@ for the first form, or from the range
 \tcode{max_load_factor()} returns \tcode{1.0}.
 
 \pnum
-\complexity Average case linear, worst case quadratic.
+\complexity
+Average case linear, worst case quadratic.
 \end{itemdescr}
 
 \rSec3[unord.set.erasure]{Erasure}
@@ -9288,7 +9455,8 @@ explicit unordered_multiset(size_type n,
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an empty \tcode{unordered_multiset} using the
+\effects
+Constructs an empty \tcode{unordered_multiset} using the
 specified hash function, key equality predicate, and allocator, and
 using at least \tcode{n} buckets.  For the default constructor,
 the number of buckets is \impldef{default number of buckets in
@@ -9296,7 +9464,8 @@ the number of buckets is \impldef{default number of buckets in
 \tcode{max_load_factor()} returns \tcode{1.0}.
 
 \pnum
-\complexity Constant.
+\complexity
+Constant.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{unordered_multiset}!constructor}%
@@ -9328,7 +9497,8 @@ for the first form, or from the range
 \tcode{max_load_factor()} returns \tcode{1.0}.
 
 \pnum
-\complexity Average case linear, worst case quadratic.
+\complexity
+Average case linear, worst case quadratic.
 \end{itemdescr}
 
 \rSec3[unord.multiset.erasure]{Erasure}
@@ -9543,7 +9713,8 @@ explicit queue(const Container& cont);
 
 \begin{itemdescr}
 \pnum
-\effects\ Initializes \tcode{c} with \tcode{cont}.
+\effects
+Initializes \tcode{c} with \tcode{cont}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -9552,7 +9723,8 @@ explicit queue(Container&& cont);
 
 \begin{itemdescr}
 \pnum
-\effects\ Initializes \tcode{c} with \tcode{std::move(cont)}.
+\effects
+Initializes \tcode{c} with \tcode{std::move(cont)}.
 \end{itemdescr}
 
 \rSec3[queue.cons.alloc]{Constructors with allocators}
@@ -9567,7 +9739,8 @@ template<class Alloc> explicit queue(const Alloc& a);
 
 \begin{itemdescr}
 \pnum
-\effects\ Initializes \tcode{c} with \tcode{a}.
+\effects
+Initializes \tcode{c} with \tcode{a}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -9576,7 +9749,8 @@ template<class Alloc> queue(const container_type& cont, const Alloc& a);
 
 \begin{itemdescr}
 \pnum
-\effects\ Initializes \tcode{c} with \tcode{cont} as the first argument and \tcode{a}
+\effects
+Initializes \tcode{c} with \tcode{cont} as the first argument and \tcode{a}
 as the second argument.
 \end{itemdescr}
 
@@ -9586,7 +9760,8 @@ template<class Alloc> queue(container_type&& cont, const Alloc& a);
 
 \begin{itemdescr}
 \pnum
-\effects\ Initializes \tcode{c} with \tcode{std::move(cont)} as the first argument and \tcode{a}
+\effects
+Initializes \tcode{c} with \tcode{std::move(cont)} as the first argument and \tcode{a}
 as the second argument.
 \end{itemdescr}
 
@@ -9596,7 +9771,8 @@ template<class Alloc> queue(const queue& q, const Alloc& a);
 
 \begin{itemdescr}
 \pnum
-\effects\ Initializes \tcode{c} with \tcode{q.c} as the first argument and \tcode{a} as the
+\effects
+Initializes \tcode{c} with \tcode{q.c} as the first argument and \tcode{a} as the
 second argument.
 \end{itemdescr}
 
@@ -9606,7 +9782,8 @@ template<class Alloc> queue(queue&& q, const Alloc& a);
 
 \begin{itemdescr}
 \pnum
-\effects\ Initializes \tcode{c} with \tcode{std::move(q.c)} as the first argument and \tcode{a}
+\effects
+Initializes \tcode{c} with \tcode{std::move(q.c)} as the first argument and \tcode{a}
 as the second argument.
 \end{itemdescr}
 
@@ -9712,7 +9889,8 @@ template<class T, class Container>
 \tcode{is_swappable_v<Container>} is \tcode{true}.
 
 \pnum
-\effects As if by \tcode{x.swap(y)}.
+\effects
+As if by \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \rSec2[priority.queue]{Class template \tcode{priority_queue}}
@@ -9876,7 +10054,8 @@ template<class Alloc> explicit priority_queue(const Alloc& a);
 
 \begin{itemdescr}
 \pnum
-\effects\ Initializes \tcode{c} with \tcode{a} and value-initializes \tcode{comp}.
+\effects
+Initializes \tcode{c} with \tcode{a} and value-initializes \tcode{comp}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{priority_queue}!constructor}%
@@ -9886,7 +10065,8 @@ template<class Alloc> priority_queue(const Compare& compare, const Alloc& a);
 
 \begin{itemdescr}
 \pnum
-\effects\ Initializes \tcode{c} with \tcode{a} and initializes \tcode{comp} with \tcode{compare}.
+\effects
+Initializes \tcode{c} with \tcode{a} and initializes \tcode{comp} with \tcode{compare}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{priority_queue}!constructor}%
@@ -9897,7 +10077,8 @@ template<class Alloc>
 
 \begin{itemdescr}
 \pnum
-\effects\ Initializes \tcode{c} with \tcode{cont} as the first argument and \tcode{a} as the second
+\effects
+Initializes \tcode{c} with \tcode{cont} as the first argument and \tcode{a} as the second
 argument, and initializes \tcode{comp} with \tcode{compare};
 calls \tcode{make_heap(c.begin(), c.end(), comp)}.
 \end{itemdescr}
@@ -9910,7 +10091,8 @@ template<class Alloc>
 
 \begin{itemdescr}
 \pnum
-\effects\ Initializes \tcode{c} with \tcode{std::move(cont)} as the first argument and \tcode{a}
+\effects
+Initializes \tcode{c} with \tcode{std::move(cont)} as the first argument and \tcode{a}
 as the second argument, and initializes \tcode{comp} with \tcode{compare};
 calls \tcode{make_heap(c.begin(), c.end(), comp)}.
 \end{itemdescr}
@@ -9922,7 +10104,8 @@ template<class Alloc> priority_queue(const priority_queue& q, const Alloc& a);
 
 \begin{itemdescr}
 \pnum
-\effects\ Initializes \tcode{c} with \tcode{q.c} as the first argument and \tcode{a} as
+\effects
+Initializes \tcode{c} with \tcode{q.c} as the first argument and \tcode{a} as
 the second argument, and initializes \tcode{comp} with \tcode{q.comp}.
 \end{itemdescr}
 
@@ -9933,7 +10116,8 @@ template<class Alloc> priority_queue(priority_queue&& q, const Alloc& a);
 
 \begin{itemdescr}
 \pnum
-\effects\ Initializes \tcode{c} with \tcode{std::move(q.c)} as the first argument and \tcode{a}
+\effects
+Initializes \tcode{c} with \tcode{std::move(q.c)} as the first argument and \tcode{a}
 as the second argument, and initializes \tcode{comp} with \tcode{std::move(q.comp)}.
 \end{itemdescr}
 
@@ -10016,7 +10200,8 @@ template<class T, class Container, class Compare>
 \tcode{is_swappable_v<Compare>} is \tcode{true}.
 
 \pnum
-\effects As if by \tcode{x.swap(y)}.
+\effects
+As if by \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \rSec2[stack]{Class template \tcode{stack}}
@@ -10098,7 +10283,8 @@ explicit stack(const Container& cont);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{c} with \tcode{cont}.
+\effects
+Initializes \tcode{c} with \tcode{cont}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{stack}!constructor}%
@@ -10108,7 +10294,8 @@ explicit stack(Container&& cont);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{c} with \tcode{std::move(cont)}.
+\effects
+Initializes \tcode{c} with \tcode{std::move(cont)}.
 \end{itemdescr}
 
 \rSec3[stack.cons.alloc]{Constructors with allocators}
@@ -10124,7 +10311,8 @@ template<class Alloc> explicit stack(const Alloc& a);
 
 \begin{itemdescr}
 \pnum
-\effects\ Initializes \tcode{c} with \tcode{a}.
+\effects
+Initializes \tcode{c} with \tcode{a}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{stack}!constructor}%
@@ -10134,7 +10322,8 @@ template<class Alloc> stack(const container_type& cont, const Alloc& a);
 
 \begin{itemdescr}
 \pnum
-\effects\ Initializes \tcode{c} with \tcode{cont} as the first argument and \tcode{a} as the
+\effects
+Initializes \tcode{c} with \tcode{cont} as the first argument and \tcode{a} as the
 second argument.
 \end{itemdescr}
 
@@ -10145,7 +10334,8 @@ template<class Alloc> stack(container_type&& cont, const Alloc& a);
 
 \begin{itemdescr}
 \pnum
-\effects\ Initializes \tcode{c} with \tcode{std::move(cont)} as the first argument and \tcode{a}
+\effects
+Initializes \tcode{c} with \tcode{std::move(cont)} as the first argument and \tcode{a}
 as the second argument.
 \end{itemdescr}
 
@@ -10156,7 +10346,8 @@ template<class Alloc> stack(const stack& s, const Alloc& a);
 
 \begin{itemdescr}
 \pnum
-\effects\ Initializes \tcode{c} with \tcode{s.c} as the first argument and \tcode{a}
+\effects
+Initializes \tcode{c} with \tcode{s.c} as the first argument and \tcode{a}
 as the second argument.
 \end{itemdescr}
 
@@ -10167,7 +10358,8 @@ template<class Alloc> stack(stack&& s, const Alloc& a);
 
 \begin{itemdescr}
 \pnum
-\effects\ Initializes \tcode{c} with \tcode{std::move(s.c)} as the first argument and \tcode{a}
+\effects
+Initializes \tcode{c} with \tcode{std::move(s.c)} as the first argument and \tcode{a}
 as the second argument.
 \end{itemdescr}
 
@@ -10272,7 +10464,8 @@ template<class T, class Container>
 \tcode{is_swappable_v<Container>} is \tcode{true}.
 
 \pnum
-\effects As if by \tcode{x.swap(y)}.
+\effects
+As if by \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \rSec1[views]{Views}
@@ -10455,7 +10648,8 @@ constexpr span(pointer ptr, index_type count);
 
 \begin{itemdescr}
 \pnum
-\expects \range{ptr}{ptr + count} is a valid range.
+\expects
+\range{ptr}{ptr + count} is a valid range.
 If \tcode{extent} is not equal to \tcode{dynamic_extent},
 then \tcode{count} is equal to \tcode{extent}.
 
@@ -10993,5 +11187,6 @@ template<size_t I, class ElementType, size_t Extent>
 \tcode{Extent != dynamic_extent \&\& I < Extent} is \tcode{true}.
 
 \pnum
-\returns \tcode{s[I]}.
+\returns
+\tcode{s[I]}.
 \end{itemdescr}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4082,7 +4082,6 @@ void m() {
 }
 \end{codeblock}
 \end{example}
-%
 \indextext{declaration!default argument|)}%
 \indextext{declarator!meaning of|)}
 
@@ -5932,7 +5931,6 @@ int f(int);
 int a[] = { 2, f(2), f(2.0) };  // OK: the \tcode{double}-to-\tcode{int} conversion is not at the top level
 \end{codeblock}
 \end{example}
-%
 \indextext{initialization!list-initialization|)}%
 \indextext{initialization|)}%
 \indextext{declarator|)}
@@ -6279,7 +6277,6 @@ struct sometype {
 sometype::sometype() = delete;  // ill-formed; not first declaration
 \end{codeblock}
 \end{example}
-%
 \indextext{definition!function|)}
 
 \rSec2[dcl.fct.def.coroutine]{Coroutine definitions}%
@@ -7684,7 +7681,6 @@ void f() {
 }
 \end{codeblock}
 \end{example}
-%
 \indextext{using-directive|)}%
 \indextext{namespaces|)}
 
@@ -8795,7 +8791,6 @@ but its first parameter does not. Therefore, function \tcode{h}'s first call to
 implementation might need to insert a fence prior to the second call to
 \tcode{g}.
 \end{example}
-%
 \indextext{attribute|)}%
 \indextext{declaration|)}
 

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -111,7 +111,8 @@ of the \grammarterm{init-declarator-list}.
 \begin{note} In the declaration for an entity, attributes appertaining to that
 entity may appear at the start of the declaration and after the
 \grammarterm{declarator-id} for that declaration.
-\end{note} \begin{example}
+\end{note}
+\begin{example}
 \begin{codeblock}
 [[noreturn]] void f [[noreturn]] ();    // OK
 \end{codeblock}
@@ -657,7 +658,8 @@ If a \tcode{typedef} specifier is used to redeclare in a given scope an
 entity that can be referenced using an \grammarterm{elaborated-type-specifier},
 the entity can continue to be referenced by an
 \grammarterm{elaborated-type-specifier} or as an enumeration or class name
-in an enumeration or class definition respectively. \begin{example}
+in an enumeration or class definition respectively.
+\begin{example}
 \begin{codeblock}
 struct S;
 typedef struct S S;
@@ -1550,7 +1552,8 @@ used to refer to an enumeration\iref{dcl.enum}, the \tcode{union}
 and either the \tcode{class} or \tcode{struct}
 \grammarterm{class-key} shall be used to refer to a class\iref{class}
 declared using the \tcode{class} or \tcode{struct}
-\grammarterm{class-key}. \begin{example}
+\grammarterm{class-key}.
+\begin{example}
 
 \begin{codeblock}
 enum class E { a, b };
@@ -1998,7 +2001,8 @@ If the \grammarterm{placeholder-type-specifier} is of the form
 placeholder alone. The type deduced for \tcode{T} is
 determined as described in~\ref{dcl.type.simple}, as though
 \tcode{e} had
-been the operand of the \tcode{decltype}. \begin{example}
+been the operand of the \tcode{decltype}.
+\begin{example}
 \begin{codeblock}
 int i;
 int&& f();
@@ -5821,7 +5825,8 @@ corresponding element of the initializer list, and the
 \begin{note} A constructor or conversion function selected for the copy shall be
 accessible\iref{class.access} in the context of the initializer list.
 \end{note}
-If a narrowing conversion is required to initialize any of the elements, the program is ill-formed. \begin{example}
+If a narrowing conversion is required to initialize any of the elements, the program is ill-formed.
+\begin{example}
 \begin{codeblock}
 struct X {
   X(std::initializer_list<double> v);
@@ -5899,7 +5904,8 @@ expression whose value after integral promotions will fit into the target type.
 \end{itemize}
 
 \begin{note} As indicated above, such conversions are not allowed at the top level in
-list-initializations.\end{note} \begin{example}
+list-initializations.\end{note}
+\begin{example}
 
 \begin{codeblock}
 int x = 999;                    // \tcode{x} is not a constant expression
@@ -6200,7 +6206,8 @@ odr-use\iref{basic.def.odr} of a virtual function does not, by itself,
 constitute a reference. \end{note}
 
 \pnum
-\begin{example} One can prevent default initialization and
+\begin{example}
+One can prevent default initialization and
 initialization by non-\tcode{double}s with
 \begin{codeblock}
 struct onlydouble {
@@ -6735,7 +6742,8 @@ within the \grammarterm{decl-specifier-seq} of a \grammarterm{member-declaration
 is parsed as part of an \grammarterm{enum-base}.
 \begin{note} This resolves a potential ambiguity between the declaration of an enumeration
 with an \grammarterm{enum-base} and the declaration of an unnamed bit-field of enumeration
-type. \begin{example}
+type.
+\begin{example}
 
 \begin{codeblock}
    struct S {
@@ -6939,7 +6947,8 @@ declared in the scope that immediately contains the \grammarterm{enum-specifier}
 Each scoped \grammarterm{enumerator} is declared in the scope of the
 enumeration.
 These names obey the scope rules defined for all names
-in~\ref{basic.scope} and~\ref{basic.lookup}. \begin{example}
+in~\ref{basic.scope} and~\ref{basic.lookup}.
+\begin{example}
 \begin{codeblock}
 enum direction { left='l', right='r' };
 
@@ -8578,7 +8587,8 @@ within the \grammarterm{balanced-token-seq} of
 an \grammarterm{attribute-argument-clause}.
 \begin{note} If two consecutive left square brackets appear
 where an \grammarterm{attribute-specifier} is not allowed, the program is ill-formed even
-if the brackets match an alternative grammar production. \end{note} \begin{example}
+if the brackets match an alternative grammar production. \end{note}
+\begin{example}
 \begin{codeblock}
 int p[10];
 void f() {
@@ -8668,7 +8678,8 @@ extern S* p;
 \end{example}
 
 \pnum
-\begin{example} An aligned buffer with an alignment requirement
+\begin{example}
+An aligned buffer with an alignment requirement
 of \tcode{A} and holding \tcode{N} elements of type \tcode{T}
 can be declared as:
 \begin{codeblock}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -108,7 +108,8 @@ The \grammarterm{attribute-specifier-seq}
 appertains to each of the entities declared by
 the \grammarterm{declarator}{s}
 of the \grammarterm{init-declarator-list}.
-\begin{note} In the declaration for an entity, attributes appertaining to that
+\begin{note}
+In the declaration for an entity, attributes appertaining to that
 entity may appear at the start of the declaration and after the
 \grammarterm{declarator-id} for that declaration.
 \end{note}
@@ -177,7 +178,8 @@ the diagnostic message.
 \begin{example}
 \begin{codeblock}
 static_assert(sizeof(int) == sizeof(void*), "wrong pointer size");
-\end{codeblock}\end{example}
+\end{codeblock}
+\end{example}
 
 \pnum
 An \grammarterm{empty-declaration} has no effect.
@@ -785,7 +787,8 @@ An explicit specialization can differ from the template declaration
 with respect to the \tcode{constexpr} or \tcode{consteval} specifier.
 \end{note}
 \begin{note}
-Function parameters cannot be declared \tcode{constexpr}.\end{note}
+Function parameters cannot be declared \tcode{constexpr}.
+\end{note}
 \begin{example}
 \begin{codeblock}
 constexpr void square(int &x);  // OK: declaration
@@ -1234,8 +1237,11 @@ the declaration shall not be empty.
 \ref{basic.type.qualifier} and \ref{dcl.fct} describe how cv-qualifiers affect object and
 function types.
 \end{note}
-Redundant cv-qualifications are ignored. \begin{note} For example,
-these could be introduced by typedefs.\end{note}
+Redundant cv-qualifications are ignored.
+\begin{note}
+For example,
+these could be introduced by typedefs.
+\end{note}
 
 \pnum
 \begin{note}
@@ -1828,10 +1834,12 @@ Return type deduction for a templated entity
 that is a function or function template with a placeholder in its
 declared type occurs when the definition is instantiated even if the function
 body contains a \tcode{return} statement with a non-type-dependent operand.
-\begin{note} Therefore, any use of a specialization of the function template will
+\begin{note}
+Therefore, any use of a specialization of the function template will
 cause an implicit instantiation. Any errors that arise from this instantiation
 are not in the immediate context of the function type and can result in the
-program being ill-formed\iref{temp.deduct}. \end{note}
+program being ill-formed\iref{temp.deduct}.
+\end{note}
 \begin{example}
 \begin{codeblock}
 template <class T> auto f(T t) { return t; }    // return type deduced at instantiation time
@@ -2886,7 +2894,9 @@ or a \grammarterm{decltype-specifier}\iref{dcl.type.simple} denotes a type \tcod
 is a reference to a type \tcode{T}, an attempt to create the type ``lvalue reference to \cv{}~\tcode{TR}''
 creates the type ``lvalue reference to \tcode{T}'', while an attempt to create
 the type ``rvalue reference to \cv{}~\tcode{TR}'' creates the type \tcode{TR}.
-\begin{note} This rule is known as reference collapsing. \end{note}
+\begin{note}
+This rule is known as reference collapsing.
+\end{note}
 \begin{example}
 \begin{codeblock}
 int i;
@@ -2906,7 +2916,8 @@ decltype(r2)&& r7 = i;          // \tcode{r7} has the type \tcode{int\&}
 \end{example}
 
 \pnum
-\begin{note} Forming a reference to function type is ill-formed if the function
+\begin{note}
+Forming a reference to function type is ill-formed if the function
 type has \grammarterm{cv-qualifier}{s} or a \grammarterm{ref-qualifier};
 see~\ref{dcl.fct}.
 \end{note}
@@ -3422,9 +3433,11 @@ The resulting list of transformed parameter types
 and the presence or absence of the ellipsis or a function parameter pack
 is the function's
 \defn{parameter-type-list}.
-\begin{note} This transformation does not affect the types of the parameters.
+\begin{note}
+This transformation does not affect the types of the parameters.
 For example, \tcode{int(*)(const int p, decltype(p)*)} and
-\tcode{int(*)(int, const int*)} are identical types. \end{note}
+\tcode{int(*)(int, const int*)} are identical types.
+\end{note}
 
 \pnum
 A function type with a \grammarterm{cv-qualifier-seq} or a
@@ -3462,8 +3475,10 @@ The effect of a
 in a function declarator is not the same as
 adding cv-qualification on top of the function type.
 In the latter case, the cv-qualifiers are ignored.
-\begin{note} A function type that has a \grammarterm{cv-qualifier-seq} is not a
-cv-qualified type; there are no cv-qualified function types. \end{note}
+\begin{note}
+A function type that has a \grammarterm{cv-qualifier-seq} is not a
+cv-qualified type; there are no cv-qualified function types.
+\end{note}
 \begin{example}
 \begin{codeblock}
 typedef void F();
@@ -3628,7 +3643,10 @@ template <class T, class U> decltype((*(T*)0) + (*(U*)0)) add(T t, U u);
 
 \pnum
 A \term{non-template function} is a function that is not a function template
-specialization. \begin{note} A function template is not a function. \end{note}
+specialization.
+\begin{note}
+A function template is not a function.
+\end{note}
 
 \pnum
 \indextext{abbreviated!template function|see{template, function, abbreviated}}%
@@ -4063,7 +4081,8 @@ void m() {
   pb->f();          // error: wrong number of arguments for \tcode{B::f()}
 }
 \end{codeblock}
-\end{example}%
+\end{example}
+%
 \indextext{declaration!default argument|)}%
 \indextext{declarator!meaning of|)}
 
@@ -4320,7 +4339,8 @@ of an entity
 of reference type is ill-formed.
 
 \pnum
-\begin{note} For every object of static storage duration,
+\begin{note}
+For every object of static storage duration,
 static initialization\iref{basic.start.static} is performed
 at program startup before any other initialization takes place.
 In some cases, additional initialization is done later.
@@ -4728,9 +4748,11 @@ If that initializer is of the form
 and
 a narrowing conversion\iref{dcl.init.list} is required
 to convert the expression, the program is ill-formed.
-\begin{note} If an initializer is itself an initializer list,
+\begin{note}
+If an initializer is itself an initializer list,
 the element is list-initialized, which will result in a recursive application
-of the rules in this subclause if the element is an aggregate. \end{note}
+of the rules in this subclause if the element is an aggregate.
+\end{note}
 \begin{example}
 \begin{codeblock}
 struct A {
@@ -5115,10 +5137,12 @@ Otherwise, if the element is itself a subaggregate,
 brace elision is assumed and the
 \grammarterm{assignment-expression}
 is considered for the initialization of the first element of the subaggregate.
-\begin{note} As specified above, brace elision cannot apply to
+\begin{note}
+As specified above, brace elision cannot apply to
 subaggregates with no elements; an
 \grammarterm{initializer-clause} for the entire subobject is
-required.\end{note}
+required.
+\end{note}
 
 \begin{example}
 \begin{codeblock}
@@ -5516,7 +5540,8 @@ are called the \term{elements} of the initializer list. An initializer list may 
 List-initialization can occur in direct-initialization or copy-initialization contexts;
 list-initialization in a direct-initialization context is called
 \defn{direct-list-initialization} and list-initialization in a
-copy-initialization context is called \defn{copy-list-initialization}. \begin{note}
+copy-initialization context is called \defn{copy-list-initialization}.
+\begin{note}
 List-initialization can be used
 
 \begin{itemize}
@@ -5543,18 +5568,21 @@ int* e {};                      // initialization to zero / null pointer
 x = double{1};                  // explicitly construct a \tcode{double}
 std::map<std::string,int> anim = { {"bear",4}, {"cassowary",2}, {"tiger",7} };
 \end{codeblock}
-\end{example} \end{note}
+\end{example}
+\end{note}
 
 \pnum
 A constructor is an \defn{initializer-list constructor} if its first parameter is
 of type \tcode{std::initializer_list<E>} or reference to possibly cv-qualified
 \tcode{std::initializer_list<E>} for some type \tcode{E}, and either there are no other
 parameters or else all other parameters have default arguments\iref{dcl.fct.default}.
-\begin{note} Initializer-list constructors are favored over other constructors in
+\begin{note}
+Initializer-list constructors are favored over other constructors in
 list-initialization\iref{over.match.list}. Passing an initializer list as the argument
 to the constructor template \tcode{template<class T> C(T)} of a class \tcode{C} does not
 create an initializer-list constructor, because an initializer list argument causes the
-corresponding parameter to be a non-deduced context\iref{temp.deduct.call}. \end{note}
+corresponding parameter to be a non-deduced context\iref{temp.deduct.call}.
+\end{note}
 The template
 \tcode{std::initializer_list} is not predefined; if the header
 \tcode{<initializer_list>} is not included prior to a use of
@@ -5712,8 +5740,10 @@ unless \tcode{T} is ``reference to array of unknown bound of \tcode{U}'',
 in which case the type of the temporary is
 the type of \tcode{x} in the declaration \tcode{U x[] $H$},
 where $H$ is the initializer list.
-\begin{note} As usual, the binding will fail and the program is ill-formed if
-the reference type is an lvalue reference to a non-const type. \end{note}
+\begin{note}
+As usual, the binding will fail and the program is ill-formed if
+the reference type is an lvalue reference to a non-const type.
+\end{note}
 
 \begin{example}
 \begin{codeblock}
@@ -5777,11 +5807,13 @@ appear. That is, every value computation and side effect associated with a
 given \grammarterm{initializer-clause} is sequenced before every value
 computation and side effect associated with any \grammarterm{initializer-clause}
 that follows it in the comma-separated list of the \grammarterm{initializer-list}.
-\begin{note} This evaluation ordering holds regardless of the semantics of the
+\begin{note}
+This evaluation ordering holds regardless of the semantics of the
 initialization; for example, it applies when the elements of the
 \grammarterm{initializer-list} are interpreted as arguments of a constructor
 call, even though ordinarily there are no sequencing constraints on the
-arguments of a call. \end{note}
+arguments of a call.
+\end{note}
 
 \pnum
 An object of type \tcode{std::initializer_list<E>} is constructed from
@@ -5792,7 +5824,8 @@ where $N$ is the number of elements in the
 initializer list. Each element of that array is copy-initialized with the
 corresponding element of the initializer list, and the
 \tcode{std::initializer_list<E>} object is constructed to refer to that array.
-\begin{note} A constructor or conversion function selected for the copy shall be
+\begin{note}
+A constructor or conversion function selected for the copy shall be
 accessible\iref{class.access} in the context of the initializer list.
 \end{note}
 If a narrowing conversion is required to initialize any of the elements, the program is ill-formed.
@@ -5811,7 +5844,8 @@ const double __a[3] = {double{1}, double{2}, double{3}};
 X x(std::initializer_list<double>(__a, __a+3));
 \end{codeblock}
 
-assuming that the implementation can construct an \tcode{initializer_list} object with a pair of pointers. \end{example}
+assuming that the implementation can construct an \tcode{initializer_list} object with a pair of pointers.
+\end{example}
 
 \pnum
 The array has the same lifetime as any other temporary
@@ -5845,7 +5879,8 @@ a temporary array to a reference member, so the program is
 ill-formed\iref{class.base.init}.
 \end{example}
 \begin{note}
-The implementation is free to allocate the array in read-only memory if an explicit array with the same initializer could be so allocated. \end{note}
+The implementation is free to allocate the array in read-only memory if an explicit array with the same initializer could be so allocated.
+\end{note}
 
 \pnum
 A
@@ -5872,8 +5907,10 @@ represent all the values of the original type, except where the source is a cons
 expression whose value after integral promotions will fit into the target type.
 \end{itemize}
 
-\begin{note} As indicated above, such conversions are not allowed at the top level in
-list-initializations.\end{note}
+\begin{note}
+As indicated above, such conversions are not allowed at the top level in
+list-initializations.
+\end{note}
 \begin{example}
 \begin{codeblock}
 int x = 999;                    // \tcode{x} is not a constant expression
@@ -5894,7 +5931,8 @@ float f2 { 7 };                 // OK: 7 can be exactly represented as a \tcode{
 int f(int);
 int a[] = { 2, f(2), f(2.0) };  // OK: the \tcode{double}-to-\tcode{int} conversion is not at the top level
 \end{codeblock}
-\end{example}%
+\end{example}
+%
 \indextext{initialization!list-initialization|)}%
 \indextext{initialization|)}%
 \indextext{declarator|)}
@@ -6130,7 +6168,8 @@ defined as deleted, the program is ill-formed.
 Declaring a function as defaulted after its first declaration can provide
 efficient execution and concise
 definition while enabling a stable binary interface to an evolving code
-base.\end{note}
+base.
+\end{note}
 
 \pnum
 \begin{example}
@@ -6164,13 +6203,16 @@ deleted definition is also called a \term{deleted function}.
 
 \pnum
 A program that refers to a deleted function implicitly or explicitly, other
-than to declare it, is ill-formed. \begin{note} This includes calling the function
+than to declare it, is ill-formed.
+\begin{note}
+This includes calling the function
 implicitly or explicitly and forming a pointer or pointer-to-member to the
 function. It applies even for references in expressions that are not
 potentially-evaluated. If a function is overloaded, it is referenced only if the
 function is selected by overload resolution. The implicit
 odr-use\iref{basic.def.odr} of a virtual function does not, by itself,
-constitute a reference. \end{note}
+constitute a reference.
+\end{note}
 
 \pnum
 \begin{example}
@@ -6219,8 +6261,11 @@ moveonly q(*p);                 // error, deleted copy constructor
 \end{example}
 
 \pnum
-A deleted function is implicitly an inline function\iref{dcl.inline}. \begin{note} The
-one-definition rule\iref{basic.def.odr} applies to deleted definitions. \end{note}
+A deleted function is implicitly an inline function\iref{dcl.inline}.
+\begin{note}
+The
+one-definition rule\iref{basic.def.odr} applies to deleted definitions.
+\end{note}
 A deleted definition of a function shall be the first declaration of the function or,
 for an explicit specialization of a function template, the first declaration of that
 specialization.
@@ -6233,7 +6278,8 @@ struct sometype {
 };
 sometype::sometype() = delete;  // ill-formed; not first declaration
 \end{codeblock}
-\end{example}%
+\end{example}
+%
 \indextext{definition!function|)}
 
 \rSec2[dcl.fct.def.coroutine]{Coroutine definitions}%
@@ -6707,7 +6753,8 @@ A \tcode{:} following
 ``\tcode{enum} \opt{\grammarterm{nested-name-specifier}} \grammarterm{identifier}''
 within the \grammarterm{decl-specifier-seq} of a \grammarterm{member-declaration}
 is parsed as part of an \grammarterm{enum-base}.
-\begin{note} This resolves a potential ambiguity between the declaration of an enumeration
+\begin{note}
+This resolves a potential ambiguity between the declaration of an enumeration
 with an \grammarterm{enum-base} and the declaration of an unnamed bit-field of enumeration
 type.
 \begin{example}
@@ -6765,10 +6812,13 @@ The optional \grammarterm{attribute-specifier-seq} in an
 \pnum
 An \grammarterm{opaque-enum-declaration} is either a redeclaration
 of an enumeration in the current scope or a declaration of a new enumeration.
-\begin{note} An enumeration declared by an
+\begin{note}
+An enumeration declared by an
 \grammarterm{opaque-enum-declaration} has a fixed underlying type and is a
 complete type. The list of enumerators can be provided in a later redeclaration
-with an \grammarterm{enum-specifier}. \end{note} A scoped enumeration
+with an \grammarterm{enum-specifier}.
+\end{note}
+A scoped enumeration
 shall not be later redeclared as unscoped or with a different underlying type.
 An unscoped enumeration shall not be later redeclared as scoped and each
 redeclaration shall include an \grammarterm{enum-base} specifying the same
@@ -7321,10 +7371,13 @@ class, function, class template or function template\footnote{this implies that 
 the friend is a member of the innermost enclosing
 namespace. The friend declaration does not by itself make the name
 visible to unqualified lookup\iref{basic.lookup.unqual} or qualified
-lookup\iref{basic.lookup.qual}. \begin{note} The name of the friend will be
+lookup\iref{basic.lookup.qual}.
+\begin{note}
+The name of the friend will be
 visible in its namespace if a matching declaration is provided at namespace
 scope (either before or after the class definition granting friendship).
-\end{note} If a friend
+\end{note}
+If a friend
 function or function template is called, its name may be found by the
 name lookup that considers functions from namespaces and classes
 associated with the types of the function
@@ -7333,7 +7386,9 @@ name in a friend declaration is neither qualified nor a
 \grammarterm{template-id} and the declaration is a function or an
 \grammarterm{elaborated-type-specifier}, the lookup to determine whether
 the entity has been previously declared shall not consider any scopes
-outside the innermost enclosing namespace. \begin{note} The other forms of
+outside the innermost enclosing namespace.
+\begin{note}
+The other forms of
 friend declarations cannot declare a new member of the innermost
 enclosing namespace and thus follow the usual lookup rules.
 \end{note}
@@ -7492,7 +7547,9 @@ For unqualified lookup\iref{basic.lookup.unqual}, the
 contains \grammarterm{using-directive}{s}, the effect is as if the
 \grammarterm{using-directive}{s} from the second namespace also appeared in
 the first.
-\begin{note} For qualified lookup, see~\ref{namespace.qual}. \end{note}
+\begin{note}
+For qualified lookup, see~\ref{namespace.qual}.
+\end{note}
 \begin{example}
 \begin{codeblock}
 namespace M {
@@ -7626,7 +7683,8 @@ void f() {
   f('a');           // OK: \tcode{D::f(char)}
 }
 \end{codeblock}
-\end{example}%
+\end{example}
+%
 \indextext{using-directive|)}%
 \indextext{namespaces|)}
 
@@ -7665,7 +7723,8 @@ If the \grammarterm{using-declarator} does not name a constructor,
 the \grammarterm{unqualified-id} is declared in the declarative region
 in which the \grammarterm{using-declaration} appears
 as a synonym for each declaration introduced by the \grammarterm{using-declarator}.
-\begin{note} Only the specified name is so declared;
+\begin{note}
+Only the specified name is so declared;
 specifying an enumeration name in a \grammarterm{using-declaration}
 does not declare its enumerators
 in the \grammarterm{using-declaration}{'s} declarative region.
@@ -7854,7 +7913,8 @@ considered when a use of the name is made. Thus, additional
 overloads added after the \grammarterm{using-declaration} are ignored, but
 default function arguments\iref{dcl.fct.default}, default template
 arguments\iref{temp.param}, and template specializations~(\ref{temp.class.spec},
-\ref{temp.expl.spec}) are considered. \end{note}
+\ref{temp.expl.spec}) are considered.
+\end{note}
 \begin{example}
 \begin{codeblock}
 namespace A {
@@ -8319,7 +8379,8 @@ with C language linkage may appear in the
 program (see~\ref{basic.def.odr});
 this implies that such an entity
 must not be defined in more
-than one namespace scope.\end{note}
+than one namespace scope.
+\end{note}
 \begin{example}
 \begin{codeblock}
 int x;
@@ -8485,8 +8546,10 @@ affects the tokens in an \grammarterm{attribute-argument-clause}.
 \end{example}
 
 \pnum
-\begin{note} For each individual attribute, the form of the
-\grammarterm{balanced-token-seq} will be specified. \end{note}
+\begin{note}
+For each individual attribute, the form of the
+\grammarterm{balanced-token-seq} will be specified.
+\end{note}
 
 \pnum
 In an \grammarterm{attribute-list}, an ellipsis may appear only if that
@@ -8536,9 +8599,11 @@ Two consecutive left square bracket tokens shall appear only
 when introducing an \grammarterm{attribute-specifier} or
 within the \grammarterm{balanced-token-seq} of
 an \grammarterm{attribute-argument-clause}.
-\begin{note} If two consecutive left square brackets appear
+\begin{note}
+If two consecutive left square brackets appear
 where an \grammarterm{attribute-specifier} is not allowed, the program is ill-formed even
-if the brackets match an alternative grammar production. \end{note}
+if the brackets match an alternative grammar production.
+\end{note}
 \begin{example}
 \begin{codeblock}
 int p[10];
@@ -8681,8 +8746,10 @@ translation unit and the same function or one of its parameters is declared with
 program is ill-formed, no diagnostic required.
 
 \pnum
-\begin{note} The \tcode{carries_dependency} attribute does not change the meaning of the
-program, but may result in generation of more efficient code. \end{note}
+\begin{note}
+The \tcode{carries_dependency} attribute does not change the meaning of the
+program, but may result in generation of more efficient code.
+\end{note}
 
 \pnum
 \begin{example}
@@ -8727,7 +8794,8 @@ but its first parameter does not. Therefore, function \tcode{h}'s first call to
 \tcode{g} carries a dependency into \tcode{g}, but its second call does not. The
 implementation might need to insert a fence prior to the second call to
 \tcode{g}.
-\end{example}%
+\end{example}
+%
 \indextext{attribute|)}%
 \indextext{declaration|)}
 
@@ -8736,15 +8804,20 @@ implementation might need to insert a fence prior to the second call to
 
 \pnum
 The \grammarterm{attribute-token} \tcode{deprecated} can be used to mark names and entities
-whose use is still allowed, but is discouraged for some reason. \begin{note} In particular,
+whose use is still allowed, but is discouraged for some reason.
+\begin{note}
+In particular,
 \tcode{deprecated} is appropriate for names and entities that are deemed obsolescent or
-unsafe. \end{note} It shall appear at most once in each \grammarterm{attribute-list}. An
+unsafe.
+\end{note}
+It shall appear at most once in each \grammarterm{attribute-list}. An
 \grammarterm{attribute-argument-clause} may be present and, if present, it shall have the form:
 
 \begin{ncbnf}
 \terminal{(} string-literal \terminal{)}
 \end{ncbnf}
-\begin{note} The \grammarterm{string-literal} in the \grammarterm{attribute-argument-clause}
+\begin{note}
+The \grammarterm{string-literal} in the \grammarterm{attribute-argument-clause}
 could be used to explain the rationale for deprecation and/or to suggest a replacing entity.
 \end{note}
 
@@ -8762,19 +8835,24 @@ a template specialization.
 
 \pnum
 A name or entity declared without the \tcode{deprecated} attribute can later be redeclared
-with the attribute and vice-versa. \begin{note} Thus, an entity initially declared without the
+with the attribute and vice-versa.
+\begin{note}
+Thus, an entity initially declared without the
 attribute can be marked as deprecated by a subsequent redeclaration. However, after an entity
-is marked as deprecated, later redeclarations do not un-deprecate the entity. \end{note}
+is marked as deprecated, later redeclarations do not un-deprecate the entity.
+\end{note}
 Redeclarations using different forms of the attribute (with or without the
 \grammarterm{attribute-argument-clause} or with different
 \grammarterm{attribute-argument-clause}{s}) are allowed.
 
 \pnum
-\begin{note} Implementations may use the \tcode{deprecated} attribute to produce a diagnostic
+\begin{note}
+Implementations may use the \tcode{deprecated} attribute to produce a diagnostic
 message in case the program refers to a name or entity other than to declare it, after a
 declaration that specifies the attribute. The diagnostic message may include the text provided
 within the \grammarterm{attribute-argument-clause} of any \tcode{deprecated} attribute applied
-to the name or entity. \end{note}
+to the name or entity.
+\end{note}
 
 \rSec2[dcl.attr.fallthrough]{Fallthrough attribute}
 \indextext{attribute!fallthrough}
@@ -9050,9 +9128,15 @@ translation unit, the program is ill-formed, no diagnostic required.
 
 \pnum
 If a function \tcode{f} is called where \tcode{f} was previously declared with the \tcode{noreturn}
-attribute and \tcode{f} eventually returns, the behavior is undefined. \begin{note} The function may
-terminate by throwing an exception. \end{note} \begin{note} Implementations should issue a
-warning if a function marked \tcode{[[noreturn]]} might return. \end{note}
+attribute and \tcode{f} eventually returns, the behavior is undefined.
+\begin{note}
+The function may
+terminate by throwing an exception.
+\end{note}
+\begin{note}
+Implementations should issue a
+warning if a function marked \tcode{[[noreturn]]} might return.
+\end{note}
 
 \pnum
 \begin{example}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -175,7 +175,6 @@ except that characters not in the basic
 source character set\iref{lex.charset} are not required to appear in
 the diagnostic message.
 \begin{example}
-
 \begin{codeblock}
 static_assert(sizeof(int) == sizeof(void*), "wrong pointer size");
 \end{codeblock}\end{example}
@@ -608,7 +607,6 @@ Such a \grammarterm{typedef-name} has the same
 semantics as if it were introduced by the \tcode{typedef} specifier. In
 particular, it does not define a new type.
 \begin{example}
-
 \begin{codeblock}
 using handler_t = void (*)(int);
 extern handler_t ignore;
@@ -628,7 +626,6 @@ In a given non-class scope, a \tcode{typedef} specifier can be used to
 redeclare the name of any type declared in that scope to refer to the
 type to which it already refers.
 \begin{example}
-
 \begin{codeblock}
 typedef struct s { @\commentellip@ } s;
 typedef int I;
@@ -643,7 +640,6 @@ redeclare any \grammarterm{class-name} declared in that scope that is not
 also a \grammarterm{typedef-name} to refer to the type to which it already
 refers.
 \begin{example}
-
 \begin{codeblock}
 struct S {
   typedef struct A { } A;       // OK
@@ -1554,7 +1550,6 @@ and either the \tcode{class} or \tcode{struct}
 declared using the \tcode{class} or \tcode{struct}
 \grammarterm{class-key}.
 \begin{example}
-
 \begin{codeblock}
 enum class E { a, b };
 enum E x = E::a;                // OK
@@ -2413,7 +2408,6 @@ The resolution is that any construct that could possibly be a
 in its syntactic context shall be considered a
 \grammarterm{type-id}.
 \begin{example}
-
 \begin{codeblock}
 template <class T> struct X {};
 template <int N> struct Y {};
@@ -2450,7 +2444,6 @@ as a
 rather than a
 \grammarterm{declarator-id}.
 \begin{example}
-
 \begin{codeblock}
 class C { };
 void f(int(C)) { }              // \tcode{void f(int(*fp)(C c)) \{ \}}
@@ -2761,7 +2754,6 @@ are introduced through the use of a
 \grammarterm{decltype-specifier}\iref{dcl.type.simple},
 in which case the cv-qualifiers are ignored.
 \begin{example}
-
 \begin{codeblock}
 typedef int& A;
 const A aref = 3;   // ill-formed; lvalue reference to non-\tcode{const} initialized with rvalue
@@ -2793,7 +2785,6 @@ semantically equivalent and commonly referred to as references.
 \indextext{declaration!reference}%
 \indextext{parameter!reference}%
 \begin{example}
-
 \begin{codeblock}
 void f(double& a) { a += 3.14; }
 // ...
@@ -2897,7 +2888,6 @@ creates the type ``lvalue reference to \tcode{T}'', while an attempt to create
 the type ``rvalue reference to \cv{}~\tcode{TR}'' creates the type \tcode{TR}.
 \begin{note} This rule is known as reference collapsing. \end{note}
 \begin{example}
-
 \begin{codeblock}
 int i;
 typedef int& LRI;
@@ -3456,7 +3446,6 @@ or \grammarterm{alias-declaration},
 \grammarterm{type-parameter}\iref{temp.arg.type}.
 \end{itemize}
 \begin{example}
-
 \begin{codeblock}
 typedef int FIC(int) const;
 FIC f;              // ill-formed: does not declare a member function
@@ -3476,7 +3465,6 @@ In the latter case, the cv-qualifiers are ignored.
 \begin{note} A function type that has a \grammarterm{cv-qualifier-seq} is not a
 cv-qualified type; there are no cv-qualified function types. \end{note}
 \begin{example}
-
 \begin{codeblock}
 typedef void F();
 struct S {
@@ -3537,7 +3525,6 @@ Types shall not be defined in return or parameter types.
 A typedef of function type may be used to declare a function but shall not be
 used to define a function\iref{dcl.fct.def}.
 \begin{example}
-
 \begin{codeblock}
 typedef void F();
 F  fv;              // OK: equivalent to \tcode{void fv();}
@@ -3975,7 +3962,6 @@ The keyword
 may not appear in a default argument of a member function;
 see~\ref{expr.prim.this}.
 \begin{example}
-
 \begin{codeblock}
 class A {
   void f(A* p = this) { }           // error
@@ -4063,7 +4049,6 @@ object.
 An overriding function in a derived class does not
 acquire default arguments from the function it overrides.
 \begin{example}
-
 \begin{codeblock}
 struct A {
   virtual void f(int a = 7);
@@ -4161,7 +4146,6 @@ expressions involving literals and previously declared
 variables and functions,
 regardless of the variable's storage duration.
 \begin{example}
-
 \begin{codeblock}
 int f(int);
 int a = 2;
@@ -4816,7 +4800,6 @@ otherwise, the first member of the union (if any)
 is copy-initialized from an empty initializer list.
 \end{itemize}
 \begin{example}
-
 \begin{codeblock}
 struct S { int a; const char* b; int c; int d = b[a]; };
 S ss = { 1, "asdf" };
@@ -4890,7 +4873,6 @@ is defined as having
 \tcode{n}
 elements\iref{dcl.array}.
 \begin{example}
-
 \begin{codeblock}
 int x[] = { 1, 3, 5 };
 \end{codeblock}
@@ -4927,7 +4909,6 @@ and
 unnamed bit-fields
 are not considered elements of the aggregate.
 \begin{example}
-
 \begin{codeblock}
 struct A {
   int i;
@@ -4953,7 +4934,6 @@ is ill-formed if the number of
 \grammarterm{initializer-clause}{s}
 exceeds the number of elements of the aggregate.
 \begin{example}
-
 \begin{codeblock}
 char cv[4] = { 'a', 's', 'd', 'f', 0 };     // error
 \end{codeblock}
@@ -5015,7 +4995,6 @@ the
 initialize the elements with the last (rightmost) index of the array
 varying the fastest\iref{dcl.array}.
 \begin{example}
-
 \begin{codeblock}
 int x[2][2] = { 3, 1, 4, 2 };
 \end{codeblock}
@@ -5072,7 +5051,6 @@ any remaining
 are left to initialize the next element of the aggregate
 of which the current subaggregate is an element.
 \begin{example}
-
 \begin{codeblock}
 float y[4][3] = {
   { 1, 3, 5 },
@@ -5143,7 +5121,6 @@ subaggregates with no elements; an
 required.\end{note}
 
 \begin{example}
-
 \begin{codeblock}
 struct A {
   int i;
@@ -5237,7 +5214,6 @@ characters of the
 value of the string literal
 initialize the elements of the array.
 \begin{example}
-
 \begin{codeblock}
 char msg[] = "Syntax error on line %s\n";
 \end{codeblock}
@@ -5259,7 +5235,6 @@ is
 \pnum
 There shall not be more initializers than there are array elements.
 \begin{example}
-
 \begin{codeblock}
 char cv[4] = "asdf";            // error
 \end{codeblock}
@@ -5280,7 +5255,6 @@ A variable whose declared type is
 ``reference to type \tcode{T}''\iref{dcl.ref}
 shall be initialized.
 \begin{example}
-
 \begin{codeblock}
 int g(int) noexcept;
 void f() {
@@ -5317,7 +5291,6 @@ a class member within its class definition\iref{class.mem}, and where the
 specifier is explicitly used.
 \indextext{declaration!extern@\tcode{extern} reference}%
 \begin{example}
-
 \begin{codeblock}
 int& r1;                        // error: initializer missing
 extern int& r2;                 // OK
@@ -5378,7 +5351,6 @@ direct bindings to lvalues are done.
 \end{note}
 
 \begin{example}
-
 \begin{codeblock}
 double d = 2.0;
 double& rd = d;                 // \tcode{rd} refers to \tcode{d}
@@ -5398,7 +5370,6 @@ if the reference is an lvalue reference to a
 type that is not const-qualified or is volatile-qualified,
 the program is ill-formed.
 \begin{example}
-
 \begin{codeblock}
 double& rd2 = 2.0;              // error: not an lvalue and reference not \tcode{const}
 int  i = 2;
@@ -5433,7 +5404,6 @@ the reference is bound to the resulting glvalue
 (or to an appropriate base class subobject).
 
 \begin{example}
-
 \begin{codeblock}
 struct A { };
 struct B : A { } b;
@@ -5849,7 +5819,6 @@ object\iref{class.temporary}, except that initializing an
 \tcode{initiali\-zer_list} object from the array extends the lifetime of
 the array exactly like binding a reference to a temporary.
 \begin{example}
-
 \begin{codeblock}
 typedef std::complex<double> cmplx;
 std::vector<cmplx> v1 = { 1, 2, 3 };
@@ -5906,7 +5875,6 @@ expression whose value after integral promotions will fit into the target type.
 \begin{note} As indicated above, such conversions are not allowed at the top level in
 list-initializations.\end{note}
 \begin{example}
-
 \begin{codeblock}
 int x = 999;                    // \tcode{x} is not a constant expression
 const int y = 999;
@@ -6166,7 +6134,6 @@ base.\end{note}
 
 \pnum
 \begin{example}
-
 \begin{codeblock}
 struct trivial {
   trivial() = default;
@@ -6744,7 +6711,6 @@ is parsed as part of an \grammarterm{enum-base}.
 with an \grammarterm{enum-base} and the declaration of an unnamed bit-field of enumeration
 type.
 \begin{example}
-
 \begin{codeblock}
    struct S {
      enum E : int {};
@@ -6785,7 +6751,6 @@ is zero. An \grammarterm{enumerator-definition} without an
 obtained by increasing the value of the previous \grammarterm{enumerator}
 by one.
 \begin{example}
-
 \begin{codeblock}
 enum { a, b, c=0 };
 enum { d, e, f=e+2 };
@@ -6972,7 +6937,6 @@ An enumerator declared in class scope can be referred to using the class
 member access operators (\tcode{::}, \tcode{.} (dot) and \tcode{->}
 (arrow)), see~\ref{expr.ref}.
 \begin{example}
-
 \begin{codeblock}
 struct X {
   enum direction { left='l', right='r' };
@@ -7374,7 +7338,6 @@ friend declarations cannot declare a new member of the innermost
 enclosing namespace and thus follow the usual lookup rules.
 \end{note}
 \begin{example}
-
 \begin{codeblock}
 // Assume \tcode{f} and \tcode{g} have not yet been declared.
 void h(int);
@@ -7493,7 +7456,6 @@ In this context, ``contains'' means ``contains directly or indirectly''.
 A \grammarterm{using-directive} does not add any members to the declarative
 region in which it appears.
 \begin{example}
-
 \begin{codeblock}
 namespace A {
   int i;
@@ -7532,7 +7494,6 @@ contains \grammarterm{using-directive}{s}, the effect is as if the
 the first.
 \begin{note} For qualified lookup, see~\ref{namespace.qual}. \end{note}
 \begin{example}
-
 \begin{codeblock}
 namespace M {
   int i;
@@ -7635,7 +7596,6 @@ paths\iref{class.member.lookup}. There is no such disambiguation when
 considering the set of names found as a result of following
 \grammarterm{using-directive}{s}.}
 \begin{example}
-
 \begin{codeblock}
 namespace D {
   int d1;
@@ -7719,7 +7679,6 @@ introduced by the \grammarterm{using-declarator} from the nominated base class.
 Every \grammarterm{using-declaration} is a \grammarterm{declaration} and a
 \grammarterm{member-declaration} and can therefore be used in a class definition.
 \begin{example}
-
 \begin{codeblock}
 struct B {
   void f(char);
@@ -7802,7 +7761,6 @@ of the derived class, as described below.
 \pnum
 A \grammarterm{using-declaration} shall not name a \grammarterm{template-id}.
 \begin{example}
-
 \begin{codeblock}
 struct A {
   template <class T> void f(T);
@@ -7898,7 +7856,6 @@ default function arguments\iref{dcl.fct.default}, default template
 arguments\iref{temp.param}, and template specializations~(\ref{temp.class.spec},
 \ref{temp.expl.spec}) are considered. \end{note}
 \begin{example}
-
 \begin{codeblock}
 namespace A {
   void f(int);
@@ -7935,7 +7892,6 @@ Since a \grammarterm{using-declaration} is a declaration, the restrictions
 on declarations of the same name in the same declarative
 region\iref{basic.scope} also apply to \grammarterm{using-declaration}{s}.
 \begin{example}
-
 \begin{codeblock}
 namespace A {
   int x;
@@ -7983,7 +7939,6 @@ function name, function overload resolution selects the functions
 introduced by such \grammarterm{using-declaration}{s}, the function call is
 ill-formed.
 \begin{example}
-
 \begin{codeblock}
 namespace B {
   void f(int);
@@ -8017,7 +7972,6 @@ class (rather than conflicting).
 Such hidden or overridden declarations are excluded from the set of
 declarations introduced by the \grammarterm{using-declarator}.
 \begin{example}
-
 \begin{codeblock}
 struct B {
   virtual void f(int);
@@ -8144,7 +8098,6 @@ are accessible if they would be accessible
 when used to construct an object of the corresponding base class,
 and the accessibility of the \grammarterm{using-declaration} is ignored.
 \begin{example}
-
 \begin{codeblock}
 class A {
 private:
@@ -8368,7 +8321,6 @@ this implies that such an entity
 must not be defined in more
 than one namespace scope.\end{note}
 \begin{example}
-
 \begin{codeblock}
 int x;
 namespace A {
@@ -8398,7 +8350,6 @@ specifier\iref{dcl.stc} for the purpose of determining the linkage of the
 declared name and whether it is a definition. Such a declaration shall
 not specify a storage class.
 \begin{example}
-
 \begin{codeblock}
 extern "C" double f();
 static double f();                  // error

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -838,11 +838,14 @@ to identify the source and encoding of a particular category of error code.
 Classes may be derived from \tcode{error_category} to support
 categories of errors in addition to those defined in this document.
 Such classes shall behave as specified in this
-subclause~\ref{syserr.errcat}. \begin{note} \tcode{error_category} objects are
+subclause~\ref{syserr.errcat}.
+\begin{note}
+\tcode{error_category} objects are
 passed by reference, and two such objects
 are equal if they have the same address. This means that applications using
 custom \tcode{error_category} types should create a single object of each
-such type. \end{note}
+such type.
+\end{note}
 
 \indexlibrary{\idxcode{error_category}}%
 \indexlibrary{\idxcode{error_category}!constructor}%
@@ -1043,9 +1046,12 @@ If the argument \tcode{ev} corresponds to a POSIX \tcode{errno} value \tcode{pos
 function shall return \tcode{error_condition(posv, generic_category())}.
 Otherwise, the function shall return \tcode{error_condition(ev,
 system_category())}. What constitutes correspondence for any given operating
-system is unspecified. \begin{note} The number of potential system error codes is large
+system is unspecified.
+\begin{note}
+The number of potential system error codes is large
 and unbounded, and some may not correspond to any POSIX \tcode{errno} value. Thus
-implementations are given latitude in determining correspondence. \end{note}
+implementations are given latitude in determining correspondence.
+\end{note}
 \end{itemdescr}
 
 \rSec2[syserr.errcode]{Class \tcode{error_code}}
@@ -1055,8 +1061,11 @@ implementations are given latitude in determining correspondence. \end{note}
 \pnum
 The class \tcode{error_code} describes an object used to hold error code
 values, such as those originating from the operating system or other low-level
-application program interfaces. \begin{note} Class \tcode{error_code} is an
-adjunct to error reporting by exception. \end{note}
+application program interfaces.
+\begin{note}
+Class \tcode{error_code} is an
+adjunct to error reporting by exception.
+\end{note}
 
 \indexlibrary{\idxcode{error_code}}%
 \begin{codeblock}
@@ -1268,8 +1277,11 @@ Equivalent to: \tcode{return os << ec.category().name() << ':' << ec.value();}
 
 \pnum
 The class \tcode{error_condition} describes an object used to hold values identifying
-error conditions. \begin{note} \tcode{error_condition} values are portable abstractions,
-while \tcode{error_code} values\iref{syserr.errcode} are implementation specific. \end{note}
+error conditions.
+\begin{note}
+\tcode{error_condition} values are portable abstractions,
+while \tcode{error_code} values\iref{syserr.errcode} are implementation specific.
+\end{note}
 
 \indexlibrary{\idxcode{error_condition}}%
 \begin{codeblock}
@@ -1654,6 +1666,8 @@ const char* what() const noexcept override;
 \returns
 An \ntbs{} incorporating the arguments supplied in the constructor.
 
-\begin{note} The returned \ntbs{} might be the contents of \tcode{what_arg + ": " +
-code.message()}.\end{note}
+\begin{note}
+The returned \ntbs{} might be the contents of \tcode{what_arg + ": " +
+code.message()}.
+\end{note}
 \end{itemdescr}

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -881,7 +881,8 @@ virtual const char* name() const noexcept = 0;
 
 \begin{itemdescr}
 \pnum
-\returns A string naming the error category.
+\returns
+A string naming the error category.
 \end{itemdescr}
 
 \indexlibrarymember{default_error_condition}{error_category}%
@@ -902,7 +903,8 @@ virtual bool equivalent(int code, const error_condition& condition) const noexce
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{default_error_condition(code) == condition}.
+\returns
+\tcode{default_error_condition(code) == condition}.
 \end{itemdescr}
 
 \indexlibrarymember{equivalent}{error_category}%
@@ -912,7 +914,8 @@ virtual bool equivalent(const error_code& code, int condition) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{*this == code.category() \&\& code.value() == condition}.
+\returns
+\tcode{*this == code.category() \&\& code.value() == condition}.
 \end{itemdescr}
 
 \indexlibrarymember{message}{error_category}%
@@ -922,7 +925,8 @@ virtual string message(int ev) const = 0;
 
 \begin{itemdescr}
 \pnum
-\returns A string that describes the error condition denoted by \tcode{ev}.
+\returns
+A string that describes the error condition denoted by \tcode{ev}.
 \end{itemdescr}
 
 \rSec3[syserr.errcat.nonvirtuals]{Non-virtual members}
@@ -934,7 +938,8 @@ bool operator==(const error_category& rhs) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{this == \&rhs}.
+\returns
+\tcode{this == \&rhs}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{error_category}%
@@ -944,7 +949,8 @@ strong_ordering operator<=>(const error_category& rhs) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{compare_three_way()(this, \&rhs)}.
+\returns
+\tcode{compare_three_way()(this, \&rhs)}.
 
 \begin{note}
 \tcode{compare_three_way}\iref{cmp.object} provides a total ordering for pointers.
@@ -960,7 +966,8 @@ virtual const char* name() const noexcept = 0;
 
 \begin{itemdescr}
 \pnum
-\returns A string naming the error category.
+\returns
+A string naming the error category.
 \end{itemdescr}
 
 \indexlibrarymember{default_error_condition}{error_category}%
@@ -970,7 +977,8 @@ virtual error_condition default_error_condition(int ev) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns An object of type \tcode{error_condition} that corresponds to \tcode{ev}.
+\returns
+An object of type \tcode{error_condition} that corresponds to \tcode{ev}.
 \end{itemdescr}
 
 \indexlibrarymember{equivalent}{error_category}%
@@ -980,7 +988,8 @@ virtual bool equivalent(int code, const error_condition& condition) const noexce
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{true} if, for the category of error represented by \tcode{*this}, \tcode{code} is considered equivalent to \tcode{condition}; otherwise, \tcode{false}.
+\returns
+\tcode{true} if, for the category of error represented by \tcode{*this}, \tcode{code} is considered equivalent to \tcode{condition}; otherwise, \tcode{false}.
 \end{itemdescr}
 
 \indexlibrarymember{equivalent}{error_category}%
@@ -990,7 +999,8 @@ virtual bool equivalent(const error_code& code, int condition) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{true} if, for the category of error represented by \tcode{*this}, \tcode{code} is considered equivalent to \tcode{condition}; otherwise, \tcode{false}.
+\returns
+\tcode{true} if, for the category of error represented by \tcode{*this}, \tcode{code} is considered equivalent to \tcode{condition}; otherwise, \tcode{false}.
 \end{itemdescr}
 
 \rSec3[syserr.errcat.objects]{Error category objects}
@@ -1002,11 +1012,13 @@ const error_category& generic_category() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns A reference to an object of a type derived from class \tcode{error_category}.
+\returns
+A reference to an object of a type derived from class \tcode{error_category}.
 All calls to this function shall return references to the same object.
 
 \pnum
-\remarks The object's \tcode{default_error_condition} and \tcode{equivalent} virtual functions shall behave as specified for the class \tcode{error_category}. The object's \tcode{name} virtual function shall return a pointer to the string \tcode{"generic"}.
+\remarks
+The object's \tcode{default_error_condition} and \tcode{equivalent} virtual functions shall behave as specified for the class \tcode{error_category}. The object's \tcode{name} virtual function shall return a pointer to the string \tcode{"generic"}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{system_category}}%
@@ -1016,11 +1028,13 @@ const error_category& system_category() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns A reference to an object of a type derived from class \tcode{error_category}.
+\returns
+A reference to an object of a type derived from class \tcode{error_category}.
 All calls to this function shall return references to the same object.
 
 \pnum
-\remarks The object's \tcode{equivalent} virtual functions shall behave as specified for
+\remarks
+The object's \tcode{equivalent} virtual functions shall behave as specified for
 class \tcode{error_category}. The object's \tcode{name} virtual function shall return a
 pointer to the string \tcode{"system"}. The object's \tcode{default_error_condition}
 virtual function shall behave as follows:
@@ -1091,7 +1105,8 @@ error_code() noexcept;
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{val_ == 0} and \tcode{cat_ == \&system_category()}.
+\ensures
+\tcode{val_ == 0} and \tcode{cat_ == \&system_category()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{error_code}!constructor}%
@@ -1101,7 +1116,8 @@ error_code(int val, const error_category& cat) noexcept;
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{val_ == val} and \tcode{cat_ == \&cat}.
+\ensures
+\tcode{val_ == val} and \tcode{cat_ == \&cat}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{error_code}!constructor}%
@@ -1115,7 +1131,8 @@ template<class ErrorCodeEnum>
 \constraints \tcode{is_error_code_enum_v<ErrorCodeEnum>} is \tcode{true}.
 
 \pnum
-\ensures \tcode{*this == make_error_code(e)}.
+\ensures
+\tcode{*this == make_error_code(e)}.
 \end{itemdescr}
 
 \rSec3[syserr.errcode.modifiers]{Modifiers}
@@ -1127,7 +1144,8 @@ void assign(int val, const error_category& cat) noexcept;
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{val_ == val} and \tcode{cat_ == \&cat}.
+\ensures
+\tcode{val_ == val} and \tcode{cat_ == \&cat}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{error_code}%
@@ -1141,10 +1159,12 @@ template<class ErrorCodeEnum>
 \constraints \tcode{is_error_code_enum_v<ErrorCodeEnum>} is \tcode{true}.
 
 \pnum
-\ensures \tcode{*this == make_error_code(e)}.
+\ensures
+\tcode{*this == make_error_code(e)}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{clear}{error_code}%
@@ -1154,7 +1174,8 @@ void clear() noexcept;
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{value() == 0} and \tcode{category() == system_category()}.
+\ensures
+\tcode{value() == 0} and \tcode{category() == system_category()}.
 \end{itemdescr}
 
 
@@ -1167,7 +1188,8 @@ int value() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{val_}.
+\returns
+\tcode{val_}.
 \end{itemdescr}
 
 \indexlibrarymember{category}{error_code}%
@@ -1177,7 +1199,8 @@ const error_category& category() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{*cat_}.
+\returns
+\tcode{*cat_}.
 \end{itemdescr}
 
 \indexlibrarymember{default_error_condition}{error_code}%
@@ -1187,7 +1210,8 @@ error_condition default_error_condition() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{category().default_error_condition(value())}.
+\returns
+\tcode{category().default_error_condition(value())}.
 \end{itemdescr}
 
 \indexlibrarymember{message}{error_code}%
@@ -1197,7 +1221,8 @@ string message() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{category().message(value())}.
+\returns
+\tcode{category().message(value())}.
 \end{itemdescr}
 
 \indexlibrarymember{operator bool}{error_code}%
@@ -1207,7 +1232,8 @@ explicit operator bool() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{value() != 0}.
+\returns
+\tcode{value() != 0}.
 \end{itemdescr}
 
 \rSec3[syserr.errcode.nonmembers]{Non-member functions}
@@ -1219,7 +1245,8 @@ error_code make_error_code(errc e) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{error_code(static_cast<int>(e), generic_category())}.
+\returns
+\tcode{error_code(static_cast<int>(e), generic_category())}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<<}{error_code}%
@@ -1283,7 +1310,8 @@ error_condition() noexcept;
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{val_ == 0} and \tcode{cat_ == \&generic_category()}.
+\ensures
+\tcode{val_ == 0} and \tcode{cat_ == \&generic_category()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{error_condition}!constructor}%
@@ -1293,7 +1321,8 @@ error_condition(int val, const error_category& cat) noexcept;
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{val_ == val} and \tcode{cat_ == \&cat}.
+\ensures
+\tcode{val_ == val} and \tcode{cat_ == \&cat}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{error_condition}!constructor}%
@@ -1307,7 +1336,8 @@ template<class ErrorConditionEnum>
 \constraints \tcode{is_error_condition_enum_v<ErrorConditionEnum>} is \tcode{true}.
 
 \pnum
-\ensures \tcode{*this == make_error_condition(e)}.
+\ensures
+\tcode{*this == make_error_condition(e)}.
 \end{itemdescr}
 
 
@@ -1320,7 +1350,8 @@ void assign(int val, const error_category& cat) noexcept;
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{val_ == val} and \tcode{cat_ == \&cat}.
+\ensures
+\tcode{val_ == val} and \tcode{cat_ == \&cat}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{error_condition}%
@@ -1334,10 +1365,12 @@ template<class ErrorConditionEnum>
 \constraints \tcode{is_error_condition_enum_v<ErrorConditionEnum>} is \tcode{true}.
 
 \pnum
-\ensures \tcode{*this == make_error_condition(e)}.
+\ensures
+\tcode{*this == make_error_condition(e)}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{clear}{error_condition}%
@@ -1347,7 +1380,8 @@ void clear() noexcept;
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{value() == 0} and \tcode{category() == generic_category()}.
+\ensures
+\tcode{value() == 0} and \tcode{category() == generic_category()}.
 \end{itemdescr}
 
 \rSec3[syserr.errcondition.observers]{Observers}
@@ -1359,7 +1393,8 @@ int value() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{val_}.
+\returns
+\tcode{val_}.
 \end{itemdescr}
 
 \indexlibrarymember{category}{error_condition}%
@@ -1369,7 +1404,8 @@ const error_category& category() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{*cat_}.
+\returns
+\tcode{*cat_}.
 \end{itemdescr}
 
 \indexlibrarymember{message}{error_condition}%
@@ -1379,7 +1415,8 @@ string message() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{category().message(value())}.
+\returns
+\tcode{category().message(value())}.
 \end{itemdescr}
 
 \indexlibrarymember{operator bool}{error_condition}%
@@ -1389,7 +1426,8 @@ explicit operator bool() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{value() != 0}.
+\returns
+\tcode{value() != 0}.
 \end{itemdescr}
 
 \rSec3[syserr.errcondition.nonmembers]{Non-member functions}
@@ -1401,7 +1439,8 @@ error_condition make_error_condition(errc e) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{error_condition(static_cast<int>(e), generic_category())}.
+\returns
+\tcode{error_condition(static_cast<int>(e), generic_category())}.
 \end{itemdescr}
 
 \rSec2[syserr.compare]{Comparison functions}
@@ -1530,7 +1569,8 @@ system_error(error_code ec, const string& what_arg);
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{code() == ec} and\newline
+\ensures
+\tcode{code() == ec} and\newline
 \tcode{string_view(what()).find(what_arg.c_str()) != string_view::npos}.
 \end{itemdescr}
 
@@ -1541,7 +1581,8 @@ system_error(error_code ec, const char* what_arg);
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{code() == ec} and
+\ensures
+\tcode{code() == ec} and
 \tcode{string_view(what()).find(what_arg) != string_view::npos}.
 \end{itemdescr}
 
@@ -1552,7 +1593,8 @@ system_error(error_code ec);
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{code() == ec}.
+\ensures
+\tcode{code() == ec}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{system_error}!constructor}%
@@ -1562,7 +1604,8 @@ system_error(int ev, const error_category& ecat, const string& what_arg);
 
 \begin{itemdescr}
 \pnum
-\ensures \raggedright \tcode{code() == error_code(ev, ecat)} and\linebreak
+\ensures
+\raggedright \tcode{code() == error_code(ev, ecat)} and\linebreak
 \tcode{string_view(what()).find(what_arg.c_str()) != string_view::npos}.
 \end{itemdescr}
 
@@ -1573,7 +1616,8 @@ system_error(int ev, const error_category& ecat, const char* what_arg);
 
 \begin{itemdescr}
 \pnum
-\ensures \raggedright \tcode{code() == error_code(ev, ecat)} and\linebreak
+\ensures
+\raggedright \tcode{code() == error_code(ev, ecat)} and\linebreak
 \tcode{string_view(what()).find(what_arg) != string_view::npos}.
 \end{itemdescr}
 
@@ -1584,7 +1628,8 @@ system_error(int ev, const error_category& ecat);
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{code() == error_code(ev, ecat)}.
+\ensures
+\tcode{code() == error_code(ev, ecat)}.
 \end{itemdescr}
 
 \indexlibrarymember{code}{system_error}%
@@ -1594,7 +1639,8 @@ const error_code& code() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ec} or \tcode{error_code(ev, ecat)}, from the constructor,
+\returns
+\tcode{ec} or \tcode{error_code(ev, ecat)}, from the constructor,
 as appropriate.
 \end{itemdescr}
 
@@ -1605,7 +1651,8 @@ const char* what() const noexcept override;
 
 \begin{itemdescr}
 \pnum
-\returns An \ntbs{} incorporating the arguments supplied in the constructor.
+\returns
+An \ntbs{} incorporating the arguments supplied in the constructor.
 
 \begin{note} The returned \ntbs{} might be the contents of \tcode{what_arg + ": " +
 code.message()}.\end{note}

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -816,7 +816,8 @@ namespace std {
 }
 \end{codeblock}
 
-\pnum The value of each \tcode{enum errc} constant shall be the same as
+\pnum
+The value of each \tcode{enum errc} constant shall be the same as
 the value of the \tcode{<cerrno>} macro shown in the above synopsis. Whether
 or not the \tcode{<system_error>} implementation exposes the \tcode{<cerrno>}
 macros is unspecified.
@@ -1483,7 +1484,8 @@ template<> struct hash<error_condition>;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum The specializations are enabled\iref{unord.hash}.
+\pnum
+The specializations are enabled\iref{unord.hash}.
 \end{itemdescr}
 
 \rSec2[syserr.syserr]{Class \tcode{system_error}}

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -108,7 +108,6 @@ When this happens, each variable declared in the try block
 will be destroyed in the context that
 directly contains its declaration.
 \begin{example}
-
 \begin{codeblock}
 lab:  try {
   T1 t1;

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -57,9 +57,11 @@ appertains to the parameter of the catch clause\iref{except.handle}.
 \indextext{try block|see{exception handling, try block}}%
 \indextext{handler|see{exception handling, handler}}%
 A \grammarterm{try-block} is a \grammarterm{statement}\iref{stmt.stmt}.
-\begin{note} Within this Clause
+\begin{note}
+Within this Clause
 ``try block'' is taken to mean both \grammarterm{try-block} and
-\grammarterm{function-try-block}. \end{note}
+\grammarterm{function-try-block}.
+\end{note}
 
 \pnum
 \indextext{exception handling!\idxcode{goto}}%
@@ -299,9 +301,11 @@ No other thread synchronization is implied in exception handling.
 The implementation may then
 deallocate the memory for the exception object; any such deallocation
 is done in an unspecified way.
-\begin{note} A thrown exception does not
+\begin{note}
+A thrown exception does not
 propagate to other threads unless caught, stored, and rethrown using
-appropriate library functions; see~\ref{propagation} and~\ref{futures}. \end{note}
+appropriate library functions; see~\ref{propagation} and~\ref{futures}.
+\end{note}
 
 \pnum
 \indextext{exception handling!exception object!constructor}%
@@ -965,7 +969,8 @@ function);
 
 \item the exception specification is needed for a defaulted
 special member function that calls the function.
-\begin{note} A defaulted declaration does not require the
+\begin{note}
+A defaulted declaration does not require the
 exception specification of a base member function to be evaluated
 until the implicit exception specification of the derived
 function is needed, but an explicit \grammarterm{noexcept-specifier} needs
@@ -996,7 +1001,9 @@ capture the currently handled exception.
 \pnum
 \indextext{\idxcode{terminate}}%
 In some situations exception handling must be abandoned
-for less subtle error handling techniques. \begin{note} These situations are:
+for less subtle error handling techniques.
+\begin{note}
+These situations are:
 
 \indextext{\idxcode{terminate}!called}%
 \begin{itemize}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2415,7 +2415,6 @@ void f(Args... args) {
 }
 \end{codeblock}
 \end{example}
-%
 \indextext{expression!lambda|)}
 
 \rSec2[expr.prim.fold]{Fold expressions}%
@@ -4109,7 +4108,6 @@ conversions between pointers to member functions, and in particular, the
 conversion from a pointer to a const member function to a pointer to a
 non-const member function, are not covered.
 \end{note}
-%
 \indextext{expression!postfix|)}
 
 \rSec2[expr.unary]{Unary expressions}
@@ -5568,7 +5566,6 @@ a multi-pass compiler would be permitted to interpret a cast between
 pointers to the classes as if the class types were complete at the point
 of the cast.
 \end{note}
-%
 \indextext{expression!cast|)}
 
 \rSec2[expr.mptr.oper]{Pointer-to-member operators}
@@ -6032,7 +6029,6 @@ The relational operators group left-to-right.
 \tcode{a<b<c} means \tcode{(a<b)<c} and \emph{not}
 \tcode{(a<b)\&\&(b<c)}.
 \end{example}
-%
 \indextext{operator!less than}%
 \indextext{\idxcode{<}|see{operator, less than}}%
 \indextext{operator!greater than}%
@@ -7320,7 +7316,6 @@ bool f() {
 It is unspecified whether the value of \tcode{f()} will be \tcode{true} or \tcode{false}.
 \end{example}
 \end{note}
-%
 
 \pnum
 An expression or conversion is in an \defn{immediate function context}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6919,7 +6919,7 @@ an invocation of a non-constexpr function
 \begin{note}
 Overload resolution\iref{over.match}
 is applied as usual.
-\end{note}
+\end{note}%
 ;
 
 \item
@@ -6951,7 +6951,7 @@ including,
 for example, signed integer overflow\iref{expr.prop}, certain
 pointer arithmetic\iref{expr.add}, division by
 zero\iref{expr.mul}, or certain shift operations\iref{expr.shift}
-\end{note}
+\end{note}%
 ;
 
 \item

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1256,7 +1256,6 @@ that class, or
 \item if that \grammarterm{id-expression} denotes a non-static data member
 and it appears in an unevaluated operand.
 \begin{example}
-
 \begin{codeblock}
 struct S {
   int m;
@@ -3393,7 +3392,6 @@ In both the pointer and
 reference cases, the program is ill-formed if \tcode{B} is an inaccessible or
 ambiguous base class of \tcode{D}.
 \begin{example}
-
 \begin{codeblock}
 struct B { };
 struct D : B { };
@@ -3446,7 +3444,6 @@ handler\iref{except.handle} of type \tcode{std::bad_cast}\iref{bad.cast}.
 \indextext{\idxcode{bad_cast}}%
 \indexlibrary{\idxcode{bad_cast}}%
 \begin{example}
-
 \begin{codeblock}
 class A { virtual void f(); };
 class B { virtual void g(); };
@@ -3542,7 +3539,6 @@ cv-qualified type, the result of the \tcode{typeid} expression refers
 to a \tcode{std::type_info} object representing the cv-unqualified
 type.
 \begin{example}
-
 \begin{codeblock}
 class D { @\commentellip@ };
 D d1;
@@ -3600,7 +3596,6 @@ of type ``\cvqual{cv1} \tcode{B}'' is actually a base class subobject of an obje
 of type \tcode{D}, the result refers to the enclosing object of type
 \tcode{D}. Otherwise, the behavior is undefined.
 \begin{example}
-
 \begin{codeblock}
 struct B { };
 struct D : public B { };
@@ -3788,7 +3783,6 @@ that is pointer-interconvertible\iref{basic.compound} with \placeholder{a},
 the result is a pointer to \placeholder{b}.
 Otherwise, the pointer value is unchanged by the conversion.
 \begin{example}
-
 \begin{codeblock}
 T* p1 = new T;
 const T* p2 = static_cast<const T*>(static_cast<void*>(p1));
@@ -4547,7 +4541,6 @@ pack. The \tcode{sizeof...} operator yields the number of elements
 in the pack\iref{temp.variadic}.
 A \tcode{sizeof...} expression is a pack expansion\iref{temp.variadic}.
 \begin{example}
-
 \begin{codeblock}
 template<class... Types>
 struct count {
@@ -4716,7 +4709,6 @@ This prevents ambiguities between the declarator operators \tcode{\&}, \tcode{\&
 \tcode{*}, and \tcode{[]} and their expression counterparts.
 \end{note}
 \begin{example}
-
 \begin{codeblock}
 new int * i;                    // syntax error: parsed as \tcode{(new int*) i}, not as \tcode{(new int)*i}
 \end{codeblock}
@@ -4730,7 +4722,6 @@ operator.
 Parentheses in a \grammarterm{new-type-id} of a \grammarterm{new-expression}
 can have surprising effects.
 \begin{example}
-
 \begin{codeblock}
 new int(*[10])();               // error
 \end{codeblock}
@@ -5018,7 +5009,6 @@ and overload resolution is performed again.
 
 \pnum
 \begin{example}
-
 \begin{itemize}
 \item \tcode{new T} results in one of the following calls:
 \begin{codeblock}
@@ -5161,7 +5151,6 @@ ill-formed. For a non-placement allocation function, the normal deallocation
 function lookup is used to find the matching deallocation
 function\iref{expr.delete}
 \begin{example}
-
 \begin{codeblock}
 struct S {
   // Placement allocation function:
@@ -5503,7 +5492,6 @@ conversion can be interpreted in more than one way as a
 \tcode{static_cast} followed by a \tcode{const_cast}, the conversion is
 ill-formed.
 \begin{example}
-
 \begin{codeblock}
 struct A { };
 struct I1 : A { };
@@ -5608,7 +5596,6 @@ If the result of \tcode{.*} or \tcode{->*} is a function, then that
 result can be used only as the operand for the function call operator
 \tcode{()}.
 \begin{example}
-
 \begin{codeblock}
 (ptr_to_obj->*ptr_to_mfct)(10);
 \end{codeblock}
@@ -6181,7 +6168,6 @@ the same most derived object\iref{intro.object} or the same subobject if
 indirection with a hypothetical object of the associated
 class type were performed, otherwise they compare unequal.
 \begin{example}
-
 \begin{codeblock}
 struct B {
   int f();
@@ -6786,7 +6772,6 @@ lists of arguments to functions\iref{expr.call} and lists of
 initializers\iref{dcl.init} \end{example} the comma operator as
 described in this subclause can appear only in parentheses.
 \begin{example}
-
 \begin{codeblock}
 f(a, (t=3, t+2), c);
 \end{codeblock}
@@ -7257,7 +7242,6 @@ execution.\footnote{Nonetheless, implementations should provide consistent resul
 irrespective of whether the evaluation was performed during translation and/or during program
 execution.}
 \begin{example}
-
 \begin{codeblock}
 bool f() {
     char array[1 + int(1 + 0.2 - 0.1 - 0.1)];   // Must be evaluated during translation

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6779,7 +6779,9 @@ If the right operand is a temporary expression\iref{class.temporary},
 the result is a temporary expression.
 
 \pnum
-In contexts where comma is given a special meaning, \begin{example} in
+In contexts where comma is given a special meaning,
+\begin{example}
+in
 lists of arguments to functions\iref{expr.call} and lists of
 initializers\iref{dcl.init} \end{example} the comma operator as
 described in this subclause can appear only in parentheses.
@@ -7148,7 +7150,8 @@ If an expression of literal class type is used in a context where an
 integral constant expression is required, then that expression is
 contextually implicitly converted\iref{conv} to an integral or unscoped
 enumeration type
-and the selected conversion function shall be \tcode{constexpr}. \begin{example}
+and the selected conversion function shall be \tcode{constexpr}.
+\begin{example}
 \begin{codeblock}
 struct A {
   constexpr A(int i) : val(i) { }
@@ -7252,7 +7255,8 @@ evaluation of a floating-point expression during translation yields the same res
 evaluation of the same expression (or the same operations on the same values) during program
 execution.\footnote{Nonetheless, implementations should provide consistent results,
 irrespective of whether the evaluation was performed during translation and/or during program
-execution.} \begin{example}
+execution.}
+\begin{example}
 
 \begin{codeblock}
 bool f() {

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -150,12 +150,15 @@ or an expression that has type \cv{}~\tcode{void}.
 \pnum
 Every expression belongs to exactly one of the fundamental classifications in this
 taxonomy: lvalue, xvalue, or prvalue. This property of an expression is called
-its \defn{value category}. \begin{note} The discussion of each built-in operator in
+its \defn{value category}.
+\begin{note}
+The discussion of each built-in operator in
 \ref{expr.compound} indicates the category of the value it yields and the value categories
 of the operands it expects. For example, the built-in assignment operators expect that
 the left operand is an lvalue and that the right operand is a prvalue and yield an
 lvalue as the result. User-defined operators are functions, and the categories of
-values they expect and yield are determined by their parameter and return types. \end{note}
+values they expect and yield are determined by their parameter and return types.
+\end{note}
 
 \pnum
 \begin{note}
@@ -446,7 +449,8 @@ following:
       these expressions.
 \end{itemize}
 
-\begin{note} Using an overloaded operator causes a function call; the
+\begin{note}
+Using an overloaded operator causes a function call; the
 above covers only operators with built-in meaning.
 \end{note}
 If the (possibly converted) expression is a prvalue,
@@ -455,7 +459,8 @@ the temporary materialization conversion\iref{conv.rval} is applied.
 If the expression is an lvalue of
 class type, it must have a volatile copy constructor to initialize the
 temporary object that is the result object of the lvalue-to-rvalue
-conversion. \end{note}
+conversion.
+\end{note}
 The glvalue expression is evaluated and its value is discarded.
 
 \rSec1[conv]{Standard conversions}
@@ -489,7 +494,9 @@ pointer-to-member conversions, and boolean conversions.
 
 \begin{note}
 A standard conversion sequence can be empty, i.e., it can consist of no
-conversions. \end{note} A standard conversion sequence will be applied to
+conversions.
+\end{note}
+A standard conversion sequence will be applied to
 an expression if necessary to convert it to a required destination type.
 
 \pnum
@@ -644,7 +651,8 @@ glvalue is the prvalue result.
 
 \pnum
 \begin{note}
-See also~\ref{basic.lval}.\end{note}
+See also~\ref{basic.lval}.
+\end{note}
 
 \rSec2[conv.array]{Array-to-pointer conversion}
 
@@ -934,8 +942,12 @@ a prvalue of a floating-point type. The result is exact if possible. If the valu
 converted is in the range of values that can be represented but the value cannot be
 represented exactly, it is an \impldef{value of result of inexact integer to
 floating-point conversion} choice of either the next lower or higher representable
-value. \begin{note} Loss of precision occurs if the integral value cannot be represented
-exactly as a value of the floating-point type. \end{note} If the value being converted is
+value.
+\begin{note}
+Loss of precision occurs if the integral value cannot be represented
+exactly as a value of the floating-point type.
+\end{note}
+If the value being converted is
 outside the range of values that can be represented, the behavior is undefined. If the
 source type is \tcode{bool}, the value \tcode{false} is converted to zero and the value
 \tcode{true} is converted to one.
@@ -962,7 +974,9 @@ cv-qualified type is a single conversion, and not the sequence of a
 pointer conversion followed by a qualification
 conversion\iref{conv.qual}. A null pointer constant of integral type
 can be converted to a prvalue of type \tcode{std::nullptr_t}.
-\begin{note} The resulting prvalue is not a null pointer value. \end{note}
+\begin{note}
+The resulting prvalue is not a null pointer value.
+\end{note}
 
 \pnum
 A prvalue of type ``pointer to \cv{} \tcode{T}'', where \tcode{T}
@@ -1167,8 +1181,11 @@ class \tcode{X}, the expression \tcode{this} is a prvalue of type ``pointer to
 before the optional \grammarterm{cv-qualifier-seq} and it shall not appear within
 the declaration of a static member function (although its type and value category
 are defined within a static member function as they are within a non-static
-member function). \begin{note} This is because declaration matching does not
-occur until the complete declarator is known. \end{note}
+member function).
+\begin{note}
+This is because declaration matching does not
+occur until the complete declarator is known.
+\end{note}
 \begin{note}
 In a \grammarterm{trailing-return-type},
 the class being defined is not required to be complete
@@ -1556,7 +1573,8 @@ A \grammarterm{lambda-expression} is a prvalue
 whose result object is called the \defn{closure object}.
 \begin{note}
 A closure object behaves like a function
-object\iref{function.objects}.\end{note}
+object\iref{function.objects}.
+\end{note}
 
 \pnum
 In the \grammarterm{decl-specifier-seq} of the \grammarterm{lambda-declarator},
@@ -1608,10 +1626,14 @@ whose properties are described below.
 \pnum
 The closure type is declared in the smallest block
 scope, class scope, or namespace scope that contains the corresponding
-\grammarterm{lambda-expression}. \begin{note} This determines the set of namespaces and
+\grammarterm{lambda-expression}.
+\begin{note}
+This determines the set of namespaces and
 classes associated with the closure type\iref{basic.lookup.argdep}. The parameter
 types of a \grammarterm{lambda-declarator} do not affect these associated namespaces and
-classes. \end{note} The closure type is not an aggregate type\iref{dcl.init.aggr}.
+classes.
+\end{note}
+The closure type is not an aggregate type\iref{dcl.init.aggr}.
 An implementation may define the closure type differently from what
 is described below provided this does not alter the observable behavior of the program
 other than by changing:
@@ -1686,7 +1708,8 @@ it satisfies the requirements for a constexpr function\iref{dcl.constexpr}.
 It is an immediate function\iref{dcl.constexpr}
 if the corresponding \grammarterm{lambda-expression}{'s}
 \grammarterm{parameter-declaration-clause} is followed by \tcode{consteval}.
-\begin{note} Names referenced in
+\begin{note}
+Names referenced in
 the \grammarterm{lambda-declarator} are looked up in the context in which the
 \grammarterm{lambda-expression} appears.
 \end{note}
@@ -1907,8 +1930,10 @@ It has a defaulted copy constructor and a defaulted move constructor\iref{class.
 It has a deleted copy assignment operator if the \grammarterm{lambda-expression}
 has a \grammarterm{lambda-capture} and defaulted copy and move assignment
 operators otherwise\iref{class.copy.assign}.
-\begin{note} These special member functions are implicitly defined as
-usual, and might therefore be defined as deleted. \end{note}
+\begin{note}
+These special member functions are implicitly defined as
+usual, and might therefore be defined as deleted.
+\end{note}
 
 \pnum
 The closure type associated with a \grammarterm{lambda-expression} has an
@@ -1979,7 +2004,8 @@ be of the form
 ``\tcode{\&} \grammarterm{identifier}'',
 ``\tcode{this}'',
 or ``\tcode{* this}''.
-\begin{note} The form \tcode{[\&,this]} is redundant but accepted
+\begin{note}
+The form \tcode{[\&,this]} is redundant but accepted
 for compatibility with ISO \CppXIV{}.
 \end{note}
 Ignoring appearances in
@@ -2255,11 +2281,13 @@ Every \grammarterm{id-expression} within the \grammarterm{compound-statement} of
 \grammarterm{lambda-expression} that is an odr-use\iref{basic.def.odr} of an
 entity captured by copy is transformed into an access to the corresponding unnamed data
 member of the closure type.
-\begin{note} An \grammarterm{id-expression} that is not an odr-use refers to
+\begin{note}
+An \grammarterm{id-expression} that is not an odr-use refers to
 the original entity, never to a member of the closure type.
 However, such
 an \grammarterm{id-expression} can still cause the implicit capture of the
-entity. \end{note}
+entity.
+\end{note}
 If \tcode{*this} is captured by copy, each expression that odr-uses \tcode{*this} is
 transformed to instead refer to the corresponding unnamed data member of the closure type.
 \begin{example}
@@ -2297,9 +2325,11 @@ the \grammarterm{compound-statement} of a \grammarterm{lambda-expression}
 that is an odr-use of a reference captured by reference
 refers to the entity to which the captured reference is bound and
 not to the captured reference.
-\begin{note} The validity of such captures is determined by
+\begin{note}
+The validity of such captures is determined by
 the lifetime of the object to which the reference refers,
-not by the lifetime of the reference itself. \end{note}
+not by the lifetime of the reference itself.
+\end{note}
 \begin{example}
 \begin{codeblock}
 auto h(int &r) {
@@ -2352,12 +2382,14 @@ of the resulting closure object, and the non-static data members corresponding t
 \grammarterm{init-capture}{s} are initialized as indicated by the corresponding
 \grammarterm{initializer} (which may be copy- or direct-initialization). (For array members, the array elements are
 direct-initialized in increasing subscript order.) These initializations are performed
-in the (unspecified) order in which the non-static data members are declared. \begin{note}
+in the (unspecified) order in which the non-static data members are declared.
+\begin{note}
 This ensures that the destructions will occur in the reverse order of the constructions.
 \end{note}
 
 \pnum
-\begin{note} If a non-reference entity is implicitly or explicitly captured by reference,
+\begin{note}
+If a non-reference entity is implicitly or explicitly captured by reference,
 invoking the function call operator of the corresponding \grammarterm{lambda-expression}
 after the lifetime of the entity has ended is likely to result in undefined behavior.
 \end{note}
@@ -2382,7 +2414,8 @@ void f(Args... args) {
   lm2();
 }
 \end{codeblock}
-\end{example}%
+\end{example}
+%
 \indextext{expression!lambda|)}
 
 \rSec2[expr.prim.fold]{Fold expressions}%
@@ -2812,12 +2845,14 @@ Postfix expressions group left-to-right.
 \end{bnf}
 
 \pnum
-\begin{note} The \tcode{>} token following the
+\begin{note}
+The \tcode{>} token following the
 \grammarterm{type-id} in a \tcode{dynamic_cast},
 \tcode{static_cast}, \tcode{reinterpret_cast}, or
 \tcode{const_cast} may be the product of replacing a
 \tcode{>{>}} token by two consecutive \tcode{>}
-tokens\iref{temp.names}.\end{note}
+tokens\iref{temp.names}.
+\end{note}
 
 \rSec3[expr.sub]{Subscripting}
 
@@ -3075,10 +3110,12 @@ parameter pack is used, a parameter is available for each argument.
 When there is no parameter for a given argument, the argument is passed
 in such a way that the receiving function can obtain the value of the
 argument by invoking \tcode{va_arg}\iref{support.runtime}.
-\begin{note} This paragraph does not apply to arguments passed to a function parameter pack.
+\begin{note}
+This paragraph does not apply to arguments passed to a function parameter pack.
 Function parameter packs are expanded during template instantiation\iref{temp.variadic},
 thus each such argument has a corresponding parameter when a function template
-specialization is actually called. \end{note}
+specialization is actually called.
+\end{note}
 The
 lvalue-to-rvalue\iref{conv.lval}, array-to-pointer\iref{conv.array},
 and function-to-pointer\iref{conv.func} standard conversions are
@@ -3276,8 +3313,11 @@ parameter-type-list \cv{} \opt{\grammarterm{ref-qualifier}} returning \tcode{T}'
 \tcode{E1.E2} is a prvalue. The expression designates a
 non-static member function. The expression can be used only as the
 left-hand operand of a member function call\iref{class.mfct}.
-\begin{note} Any redundant set of parentheses surrounding the expression
-is ignored\iref{expr.prim.paren}. \end{note} The type of \tcode{E1.E2} is
+\begin{note}
+Any redundant set of parentheses surrounding the expression
+is ignored\iref{expr.prim.paren}.
+\end{note}
+The type of \tcode{E1.E2} is
 ``function of parameter-type-list \cv{} returning \tcode{T}''.
 \end{itemize}
 
@@ -3830,11 +3870,15 @@ The mapping function is \impldef{mapping of pointer to integer}.
 \begin{note}
 It is intended to be unsurprising to those who know the addressing
 structure of the underlying machine.
-\end{note} A value of type \tcode{std::nullptr_t} can be converted to an integral
+\end{note}
+A value of type \tcode{std::nullptr_t} can be converted to an integral
 type; the conversion has the same meaning and validity as a conversion of
-\tcode{(void*)0} to the integral type. \begin{note} A \tcode{reinterpret_cast}
+\tcode{(void*)0} to the integral type.
+\begin{note}
+A \tcode{reinterpret_cast}
 cannot be used to convert a value of any type to the type
-\tcode{std::nullptr_t}. \end{note}
+\tcode{std::nullptr_t}.
+\end{note}
 
 \pnum
 \indextext{cast!reinterpret!integer to pointer}%
@@ -3846,8 +3890,10 @@ will have its original value;
 \indextext{conversion!implementation-defined pointer integer}%
 mappings between pointers and integers are otherwise
 \impldef{conversions between pointers and integers}.
-\begin{note} Except as described in \ref{basic.stc.dynamic.safety}, the result of
-such a conversion will not be a safely-derived pointer value. \end{note}
+\begin{note}
+Except as described in \ref{basic.stc.dynamic.safety}, the result of
+such a conversion will not be a safely-derived pointer value.
+\end{note}
 
 \pnum
 \indextext{cast!reinterpret!pointer-to-function}%
@@ -4062,7 +4108,8 @@ values whose use causes undefined behavior. For the same reasons,
 conversions between pointers to member functions, and in particular, the
 conversion from a pointer to a const member function to a pointer to a
 non-const member function, are not covered.
-\end{note}%
+\end{note}
+%
 \indextext{expression!postfix|)}
 
 \rSec2[expr.unary]{Unary expressions}
@@ -5082,8 +5129,11 @@ initializes that object as follows:
 
 \begin{itemize}
 \item If the \grammarterm{new-initializer} is omitted, the object is
-default-initialized\iref{dcl.init}. \begin{note} If no initialization
-is performed, the object has an indeterminate value. \end{note}
+default-initialized\iref{dcl.init}.
+\begin{note}
+If no initialization
+is performed, the object has an indeterminate value.
+\end{note}
 
 \item Otherwise, the \grammarterm{new-initializer} is interpreted according to
 the initialization rules of~\ref{dcl.init} for direct-initialization.
@@ -5517,7 +5567,8 @@ For example, if the classes were defined later in the translation unit,
 a multi-pass compiler would be permitted to interpret a cast between
 pointers to the classes as if the class types were complete at the point
 of the cast.
-\end{note}%
+\end{note}
+%
 \indextext{expression!cast|)}
 
 \rSec2[expr.mptr.oper]{Pointer-to-member operators}
@@ -5768,7 +5819,8 @@ the behavior is undefined.
 For addition or subtraction, if the expressions \tcode{P} or \tcode{Q} have
 type ``pointer to \cv{}~\tcode{T}'', where \tcode{T} and the array element type
 are not similar\iref{conv.qual}, the behavior is undefined.
-\begin{note} In particular, a pointer to a base class cannot be used for
+\begin{note}
+In particular, a pointer to a base class cannot be used for
 pointer arithmetic when the array contains objects of a derived class type.
 \end{note}
 
@@ -6380,7 +6432,9 @@ The \grammarterm{conditional-expression}
 is a bit-field if that operand is a bit-field.
 
 \item Both the second and the third operands have type \tcode{void}; the
-result is of type \tcode{void} and is a prvalue. \begin{note} This
+result is of type \tcode{void} and is a prvalue.
+\begin{note}
+This
 includes the case where both operands are \grammarterm{throw-expression}{s}.
 \end{note}
 \end{itemize}
@@ -6704,10 +6758,13 @@ cases, \tcode{E1} shall have arithmetic type.
 If the value being stored in an object is read via another object that
 overlaps in any way the storage of the first object, then the overlap shall be
 exact and the two objects shall have the same type, otherwise the behavior is
-undefined. \begin{note} This restriction applies to the relationship
+undefined.
+\begin{note}
+This restriction applies to the relationship
 between the left and right sides of the assignment operation; it is not a
 statement about how the target of the assignment may be aliased in general.
-See~\ref{basic.lval}. \end{note}
+See~\ref{basic.lval}.
+\end{note}
 
 \pnum
 A \grammarterm{braced-init-list} may appear on the right-hand side of
@@ -6769,7 +6826,9 @@ In contexts where comma is given a special meaning,
 \begin{example}
 in
 lists of arguments to functions\iref{expr.call} and lists of
-initializers\iref{dcl.init} \end{example} the comma operator as
+initializers\iref{dcl.init}
+\end{example}
+the comma operator as
 described in this subclause can appear only in parentheses.
 \begin{example}
 \begin{codeblock}
@@ -6799,8 +6858,11 @@ Expressions that satisfy these requirements,
 assuming that copy elision\iref{class.copy.elision} is not performed,
 are called
 \indexdefn{expression!constant}%
-\defnx{constant expressions}{constant expression}. \begin{note} Constant expressions can be evaluated
-during translation.\end{note}
+\defnx{constant expressions}{constant expression}.
+\begin{note}
+Constant expressions can be evaluated
+during translation.
+\end{note}
 
 \begin{bnf}
 \nontermdef{constant-expression}\br
@@ -6858,9 +6920,11 @@ of \tcode{e};
 
 \item
 an invocation of a non-constexpr function
-\begin{note} Overload resolution\iref{over.match}
+\begin{note}
+Overload resolution\iref{over.match}
 is applied as usual.
-\end{note};
+\end{note}
+;
 
 \item
 an invocation of an undefined constexpr function;
@@ -6885,11 +6949,14 @@ limits (see \ref{implimits});
 \item
 an operation that would have undefined behavior
 as specified in \ref{intro} through \ref{cpp}
-of this document \begin{note} including,
+of this document
+\begin{note}
+including,
 for example, signed integer overflow\iref{expr.prop}, certain
 pointer arithmetic\iref{expr.add}, division by
 zero\iref{expr.mul}, or certain shift operations\iref{expr.shift}
-\end{note};
+\end{note}
+;
 
 \item
 an lvalue-to-rvalue conversion\iref{conv.lval} unless
@@ -7234,7 +7301,8 @@ constexpr auto e = g();                         // ill-formed: a pointer to an i
 \end{example}
 
 \pnum
-\begin{note} Since this document
+\begin{note}
+Since this document
 imposes no restrictions on the accuracy of floating-point operations, it is unspecified whether the
 evaluation of a floating-point expression during translation yields the same result as the
 evaluation of the same expression (or the same operations on the same values) during program
@@ -7250,7 +7318,9 @@ bool f() {
 }
 \end{codeblock}
 It is unspecified whether the value of \tcode{f()} will be \tcode{true} or \tcode{false}.
-\end{example} \end{note}%
+\end{example}
+\end{note}
+%
 
 \pnum
 An expression or conversion is in an \defn{immediate function context}

--- a/source/future.tex
+++ b/source/future.tex
@@ -1844,7 +1844,8 @@ void reserve();
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects
+\pnum
+\effects
 After this call, \tcode{capacity()} has an unspecified value
 greater than or equal to \tcode{size()}.
 \begin{note} This is a non-binding shrink to fit request. \end{note}

--- a/source/future.tex
+++ b/source/future.tex
@@ -2009,7 +2009,9 @@ namespace std {
 Class template \tcode{wstring_convert} performs conversions between a wide
 string and a byte string. It lets you specify a code conversion facet
 (like class template \tcode{codecvt}) to perform the conversions, without
-affecting any streams or locales. \begin{example} If you want to use the code
+affecting any streams or locales.
+\begin{example}
+If you want to use the code
 conversion facet \tcode{codecvt_utf8} to output to \tcode{cout} a UTF-8
 multibyte sequence corresponding to a wide string, but you don't want to
 alter the locale for \tcode{cout}, you can write something like:

--- a/source/future.tex
+++ b/source/future.tex
@@ -271,9 +271,11 @@ behaves as if it simply includes the headers
 \tcode{<complex>}\iref{complex.syn}.
 
 \pnum
-\begin{note} The overloads provided in C by type-generic macros are already
+\begin{note}
+The overloads provided in C by type-generic macros are already
 provided in \tcode{<complex>} and \tcode{<cmath>} by ``sufficient'' additional
-overloads.\end{note}
+overloads.
+\end{note}
 
 \pnum
 \begin{note}
@@ -1534,9 +1536,11 @@ template may be used as a base class to ease the definition of required types
 for new iterators.
 
 \pnum
-\begin{note} If the new iterator type is a class template, then these aliases
+\begin{note}
+If the new iterator type is a class template, then these aliases
 will not be visible from within the iterator class's template definition, but
-only to callers of that class.\end{note}
+only to callers of that class.
+\end{note}
 
 \pnum
 \begin{example}
@@ -1869,7 +1873,9 @@ void reserve();
 \effects
 After this call, \tcode{capacity()} has an unspecified value
 greater than or equal to \tcode{size()}.
-\begin{note} This is a non-binding shrink to fit request. \end{note}
+\begin{note}
+This is a non-binding shrink to fit request.
+\end{note}
 \end{itemdescr}
 
 \rSec1[depr.locale.stdcvt]{Deprecated standard code conversion facets}

--- a/source/future.tex
+++ b/source/future.tex
@@ -1575,7 +1575,8 @@ constexpr pointer operator->() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{current}.
+\returns
+\tcode{current}.
 \end{itemdescr}
 
 \rSec1[depr.util.smartptr.shared.atomic]{Deprecated \tcode{shared_ptr} atomic access}
@@ -1637,10 +1638,12 @@ template<class T> bool atomic_is_lock_free(const shared_ptr<T>* p);
 \requires \tcode{p} shall not be null.
 
 \pnum
-\returns \tcode{true} if atomic access to \tcode{*p} is lock-free, \tcode{false} otherwise.
+\returns
+\tcode{true} if atomic access to \tcode{*p} is lock-free, \tcode{false} otherwise.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \indexlibrarymember{atomic_load}{shared_ptr}%
@@ -1653,10 +1656,12 @@ template<class T> shared_ptr<T> atomic_load(const shared_ptr<T>* p);
 \requires \tcode{p} shall not be null.
 
 \pnum
-\returns \tcode{atomic_load_explicit(p, memory_order_seq_cst)}.
+\returns
+\tcode{atomic_load_explicit(p, memory_order_seq_cst)}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \indexlibrarymember{atomic_load_explicit}{shared_ptr}%
@@ -1672,10 +1677,12 @@ template<class T> shared_ptr<T> atomic_load_explicit(const shared_ptr<T>* p, mem
 \requires \tcode{mo} shall not be \tcode{memory_order_release} or \tcode{memory_order_acq_rel}.
 
 \pnum
-\returns \tcode{*p}.
+\returns
+\tcode{*p}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \indexlibrarymember{atomic_store}{shared_ptr}%
@@ -1688,10 +1695,12 @@ template<class T> void atomic_store(shared_ptr<T>* p, shared_ptr<T> r);
 \requires \tcode{p} shall not be null.
 
 \pnum
-\effects As if by \tcode{atomic_store_explicit(p, r, memory_order_seq_cst)}.
+\effects
+As if by \tcode{atomic_store_explicit(p, r, memory_order_seq_cst)}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \indexlibrarymember{atomic_store_explicit}{shared_ptr}%
@@ -1707,10 +1716,12 @@ template<class T> void atomic_store_explicit(shared_ptr<T>* p, shared_ptr<T> r, 
 \requires \tcode{mo} shall not be \tcode{memory_order_acquire} or \tcode{memory_order_acq_rel}.
 
 \pnum
-\effects As if by \tcode{p->swap(r)}.
+\effects
+As if by \tcode{p->swap(r)}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \indexlibrarymember{atomic_exchange}{shared_ptr}%
@@ -1723,10 +1734,12 @@ template<class T> shared_ptr<T> atomic_exchange(shared_ptr<T>* p, shared_ptr<T> 
 \requires \tcode{p} shall not be null.
 
 \pnum
-\returns \tcode{atomic_exchange_explicit(p, r, memory_order_seq_cst)}.
+\returns
+\tcode{atomic_exchange_explicit(p, r, memory_order_seq_cst)}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \indexlibrarymember{atomic_exchange_explicit}{shared_ptr}%
@@ -1740,13 +1753,16 @@ template<class T>
 \requires \tcode{p} shall not be null.
 
 \pnum
-\effects As if by \tcode{p->swap(r)}.
+\effects
+As if by \tcode{p->swap(r)}.
 
 \pnum
-\returns The previous value of \tcode{*p}.
+\returns
+The previous value of \tcode{*p}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \indexlibrarymember{atomic_compare_exchange_weak}{shared_ptr}%
@@ -1766,7 +1782,8 @@ atomic_compare_exchange_weak_explicit(p, v, w, memory_order_seq_cst, memory_orde
 \end{codeblock}
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \indexlibrarymember{atomic_compare_exchange_strong}{shared_ptr}%
@@ -1803,19 +1820,23 @@ The \tcode{failure} argument shall not be \tcode{memory_order_release} nor
 \tcode{memory_order_acq_rel}.
 
 \pnum
-\effects If \tcode{*p} is equivalent to \tcode{*v}, assigns \tcode{w} to
+\effects
+If \tcode{*p} is equivalent to \tcode{*v}, assigns \tcode{w} to
 \tcode{*p} and has synchronization semantics corresponding to the value of
 \tcode{success}, otherwise assigns \tcode{*p} to \tcode{*v} and has
 synchronization semantics corresponding to the value of \tcode{failure}.
 
 \pnum
-\returns \tcode{true} if \tcode{*p} was equivalent to \tcode{*v}, \tcode{false} otherwise.
+\returns
+\tcode{true} if \tcode{*p} was equivalent to \tcode{*v}, \tcode{false} otherwise.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 
 \pnum
-\remarks Two \tcode{shared_ptr} objects are equivalent if they store the same
+\remarks
+Two \tcode{shared_ptr} objects are equivalent if they store the same
 pointer value and share ownership.
 The weak form may fail spuriously. See~\ref{atomics.types.operations}.
 \end{itemdescr}
@@ -2087,7 +2108,8 @@ size_t converted() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{cvtcount}.
+\returns
+\tcode{cvtcount}.
 \end{itemdescr}
 
 \indexlibrarymember{from_bytes}{wstring_convert}%
@@ -2241,7 +2263,8 @@ in \tcode{byte_err_string}, and \tcode{wide_err} in
 
 \begin{itemdescr}
 \pnum
-\effects The destructor shall delete \tcode{cvtptr}.
+\effects
+The destructor shall delete \tcode{cvtptr}.
 \end{itemdescr}
 
 \rSec2[depr.conversions.buffer]{Class template \tcode{wbuffer_convert}}
@@ -2310,7 +2333,8 @@ state_type state() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{cvtstate}.
+\returns
+\tcode{cvtstate}.
 \end{itemdescr}
 
 \indexlibrarymember{rdbuf}{wbuffer_convert}%
@@ -2320,7 +2344,8 @@ streambuf* rdbuf() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{bufptr}.
+\returns
+\tcode{bufptr}.
 \end{itemdescr}
 
 \indexlibrarymember{rdbuf}{wbuffer_convert}%
@@ -2330,10 +2355,12 @@ streambuf* rdbuf(streambuf* bytebuf);
 
 \begin{itemdescr}
 \pnum
-\effects Stores \tcode{bytebuf} in \tcode{bufptr}.
+\effects
+Stores \tcode{bytebuf} in \tcode{bufptr}.
 
 \pnum
-\returns The previous value of \tcode{bufptr}.
+\returns
+The previous value of \tcode{bufptr}.
 \end{itemdescr}
 
 \indexlibrarymember{state_type}{wbuffer_convert}%
@@ -2360,7 +2387,8 @@ explicit wbuffer_convert(
 \tcode{pcvt != nullptr}.
 
 \pnum
-\effects The constructor constructs a stream buffer object, initializes
+\effects
+The constructor constructs a stream buffer object, initializes
 \tcode{bufptr} to \tcode{bytebuf}, initializes \tcode{cvtptr}
 to \tcode{pcvt}, and initializes \tcode{cvtstate} to \tcode{state}.
 \end{itemdescr}
@@ -2372,7 +2400,8 @@ to \tcode{pcvt}, and initializes \tcode{cvtstate} to \tcode{state}.
 
 \begin{itemdescr}
 \pnum
-\effects The destructor shall delete \tcode{cvtptr}.
+\effects
+The destructor shall delete \tcode{cvtptr}.
 \end{itemdescr}
 
 \rSec1[depr.locale.category]{Deprecated locale category facets}
@@ -2442,7 +2471,8 @@ template<class InputIterator>
 \end{itemize}
 
 \pnum
-\remarks Argument format conversion\iref{fs.path.fmt.cvt} applies to the
+\remarks
+Argument format conversion\iref{fs.path.fmt.cvt} applies to the
   arguments for these functions. How Unicode encoding conversions are performed is
   unspecified.
 

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -513,8 +513,10 @@ for a given program and a given input.
 Certain other operations are described in this document as
 undefined (for example, the effect of
 attempting to modify a const object).
-\begin{note} This document imposes no requirements on the
-behavior of programs that contain undefined behavior. \end{note}
+\begin{note}
+This document imposes no requirements on the
+behavior of programs that contain undefined behavior.
+\end{note}
 
 \pnum
 \indextext{program!well-formed}%
@@ -548,8 +550,10 @@ place in such a fashion that prompting output is actually delivered before a pro
 
 These collectively are referred to as the
 \defnx{observable behavior}{behavior!observable} of the program.
-\begin{note} More stringent correspondences between abstract and actual
-semantics may be defined by each implementation. \end{note}
+\begin{note}
+More stringent correspondences between abstract and actual
+semantics may be defined by each implementation.
+\end{note}
 
 \rSec1[intro.structure]{Structure of this document}
 

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -2160,7 +2160,8 @@ void move(basic_ios&& rhs);
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{*this} shall have the state that
+\ensures
+\tcode{*this} shall have the state that
 \tcode{rhs} had before the function call, except that
 \tcode{rdbuf()} shall return 0. \tcode{rhs} shall be in a valid but
 unspecified state, except that \tcode{rhs.rdbuf()} shall return the
@@ -2175,7 +2176,8 @@ void swap(basic_ios& rhs) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects The states of \tcode{*this} and \tcode{rhs}
+\effects
+The states of \tcode{*this} and \tcode{rhs}
 shall be exchanged, except that \tcode{rdbuf()} shall return the same
 value as it returned before the function call, and \tcode{rhs.rdbuf()}
 shall return the same value as it returned before the function call.
@@ -2191,15 +2193,18 @@ void set_rdbuf(basic_streambuf<charT, traits>* sb);
 \requires \tcode{sb != nullptr}.
 
 \pnum
-\effects Associates the \tcode{basic_streambuf} object
+\effects
+Associates the \tcode{basic_streambuf} object
 pointed to by \tcode{sb} with this stream without calling
 \tcode{clear()}.
 
 \pnum
-\ensures \tcode{rdbuf() == sb}.
+\ensures
+\tcode{rdbuf() == sb}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \rSec3[iostate.flags]{Flags functions}
@@ -2211,7 +2216,8 @@ explicit operator bool() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!fail()}.
+\returns
+\tcode{!fail()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator"!}{basic_ios}%
@@ -2760,11 +2766,13 @@ ios_base& hexfloat(ios_base& str);
 
 \begin{itemdescr}
 \pnum
-\effects Calls \tcode{str.setf(ios_base::fixed | ios_base::scientific,
+\effects
+Calls \tcode{str.setf(ios_base::fixed | ios_base::scientific,
         ios_base::floatfield)}.
 
 \pnum
-\returns \tcode{str}.
+\returns
+\tcode{str}.
 \end{itemdescr}
 
 \pnum
@@ -2785,7 +2793,8 @@ ios_base& defaultfloat(ios_base& str);
 Calls \tcode{str.unsetf(ios_base::floatfield)}.
 
 \pnum
-\returns \tcode{str}.
+\returns
+\tcode{str}.
 \end{itemdescr}
 
 \rSec2[error.reporting]{Error reporting}
@@ -2797,7 +2806,8 @@ error_code make_error_code(io_errc e) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{error_code(static_cast<int>(e), iostream_category())}.
+\returns
+\tcode{error_code(static_cast<int>(e), iostream_category())}.
 \end{itemdescr}
 
 \indexlibrarymember{make_error_condition}{io_errc}%
@@ -2807,7 +2817,8 @@ error_condition make_error_condition(io_errc e) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{error_condition(static_cast<int>(e), iostream_category())}.
+\returns
+\tcode{error_condition(static_cast<int>(e), iostream_category())}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{iostream_category}}%
@@ -2817,7 +2828,8 @@ const error_category& iostream_category() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns A reference to an object of a type derived from class
+\returns
+A reference to an object of a type derived from class
 \tcode{error_category}.
 
 \pnum
@@ -3108,7 +3120,8 @@ basic_streambuf(const basic_streambuf& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a copy of \tcode{rhs}.
+\effects
+Constructs a copy of \tcode{rhs}.
 
 \pnum
 \ensures
@@ -3389,7 +3402,8 @@ basic_streambuf& operator=(const basic_streambuf& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Assigns the data members of \tcode{rhs}
+\effects
+Assigns the data members of \tcode{rhs}
 to \tcode{*this}.
 
 \pnum
@@ -3406,7 +3420,8 @@ to \tcode{*this}.
 \end{itemize}
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{basic_streambuf}%
@@ -3416,7 +3431,8 @@ void swap(basic_streambuf& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Swaps the data members of \tcode{rhs}
+\effects
+Swaps the data members of \tcode{rhs}
 and \tcode{*this}.
 \end{itemdescr}
 
@@ -4368,7 +4384,8 @@ basic_istream(basic_istream&& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Move constructs from the rvalue \tcode{rhs}.
+\effects
+Move constructs from the rvalue \tcode{rhs}.
 This is accomplished by default constructing the base class, copying the
 \tcode{gcount()} from \tcode{rhs}, calling
 \tcode{basic_ios<charT, traits>::move(rhs)} to initialize the base
@@ -4401,10 +4418,12 @@ basic_istream& operator=(basic_istream&& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{swap(rhs)}.
+\effects
+As if by \tcode{swap(rhs)}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{basic_istream}%
@@ -4414,7 +4433,8 @@ void swap(basic_istream& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Calls \tcode{basic_ios<charT, traits>::swap(rhs)}.
+\effects
+Calls \tcode{basic_ios<charT, traits>::swap(rhs)}.
 Exchanges the values returned by \tcode{gcount()} and
 \tcode{rhs.gcount()}.
 \end{itemdescr}
@@ -5611,14 +5631,16 @@ template<class charT, class traits, class T>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 is >> std::forward<T>(x);
 return is;
 \end{codeblock}
 
 \pnum
-\remarks This function shall not participate in overload resolution
+\remarks
+This function shall not participate in overload resolution
 unless the expression \tcode{is >> std::forward<T>(x)} is well-formed.
 \end{itemdescr}
 
@@ -5693,7 +5715,8 @@ basic_iostream(basic_iostream&& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Move constructs from the rvalue \tcode{rhs} by
+\effects
+Move constructs from the rvalue \tcode{rhs} by
 constructing the \tcode{basic_istream} base class with
 \tcode{move(rhs)}.
 \end{itemdescr}
@@ -5726,7 +5749,8 @@ basic_iostream& operator=(basic_iostream&& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{swap(rhs)}.
+\effects
+As if by \tcode{swap(rhs)}.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{basic_iostream}%
@@ -5736,7 +5760,8 @@ void swap(basic_iostream& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Calls \tcode{basic_istream<charT, traits>::swap(rhs)}.
+\effects
+Calls \tcode{basic_istream<charT, traits>::swap(rhs)}.
 \end{itemdescr}
 
 
@@ -5962,7 +5987,8 @@ basic_ostream(basic_ostream&& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Move constructs from the rvalue \tcode{rhs}.
+\effects
+Move constructs from the rvalue \tcode{rhs}.
 This is accomplished by default constructing the base class and calling
 \tcode{basic_ios<charT, traits>::move(rhs)} to initialize the
 base class.
@@ -5994,10 +6020,12 @@ basic_ostream& operator=(basic_ostream&& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{swap(rhs)}.
+\effects
+As if by \tcode{swap(rhs)}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{basic_ostream}%
@@ -6007,7 +6035,8 @@ void swap(basic_ostream& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Calls \tcode{basic_ios<charT, traits>::swap(rhs)}.
+\effects
+Calls \tcode{basic_ios<charT, traits>::swap(rhs)}.
 \end{itemdescr}
 
 \rSec4[ostream.sentry]{Class \tcode{basic_ostream::sentry}}
@@ -6671,7 +6700,8 @@ basic_ostream& flush();
 
 \begin{itemdescr}
 \pnum
-\effects Behaves as an unformatted output function (as described above).
+\effects
+Behaves as an unformatted output function (as described above).
 If
 \tcode{rdbuf()}
 is not a null pointer,
@@ -6827,13 +6857,16 @@ template<class charT, class traits, class T>
 
 \begin{itemdescr}
 \pnum
-\effects As if by: \tcode{os << x;}
+\effects
+As if by: \tcode{os << x;}
 
 \pnum
-\returns \tcode{os}.
+\returns
+\tcode{os}.
 
 \pnum
-\remarks This function shall not participate in overload resolution
+\remarks
+This function shall not participate in overload resolution
 unless the expression \tcode{os << x} is well-formed.
 \end{itemdescr}
 
@@ -6852,7 +6885,8 @@ extractors and inserters that alter information maintained by class
 
 \begin{itemdescr}
 \pnum
-\returns An object of
+\returns
+An object of
 unspecified type such that if \tcode{out} is an object of type
 \tcode{basic_ostream<charT, traits>} then the expression
 \tcode{out << resetiosflags(mask)} behaves as if it called
@@ -7120,11 +7154,13 @@ template<class moneyT> @\unspec@ get_money(moneyT& mon, bool intl = false);
 specialization of the \tcode{basic_string} template\iref{strings}.
 
 \pnum
-\effects The expression \tcode{in >> get_money(mon, intl)} described below
+\effects
+The expression \tcode{in >> get_money(mon, intl)} described below
 behaves as a formatted input function\iref{istream.formatted.reqmts}.
 
 \pnum
-\returns An object of unspecified type such that if
+\returns
+An object of unspecified type such that if
 \tcode{in} is an object of type \tcode{basic_istream<charT, traits>}
 then the expression \tcode{in >> get_money(mon, intl)} behaves as if it called
 \tcode{f(in, mon, intl)}, where the function \tcode{f} is defined as:
@@ -7160,7 +7196,8 @@ template<class moneyT> @\unspec@ put_money(const moneyT& mon, bool intl = false)
 specialization of the \tcode{basic_string} template\iref{strings}.
 
 \pnum
-\returns An object of unspecified type such that if
+\returns
+An object of unspecified type such that if
 \tcode{out} is an object of type \tcode{basic_ostream<charT, traits>}
 then the expression \tcode{out << put_money(mon, intl)} behaves as a
 formatted output function\iref{ostream.formatted.reqmts} that calls
@@ -7196,7 +7233,8 @@ template<class charT> @\unspec@ get_time(struct tm* tmb, const charT* fmt);
 The argument \tcode{fmt} shall be a valid pointer to an array of objects of type \tcode{charT} with \tcode{char_traits<charT>::length(fmt)} elements.
 
 \pnum
-\returns An object of unspecified type such that if \tcode{in} is an object of type
+\returns
+An object of unspecified type such that if \tcode{in} is an object of type
 \tcode{basic_istream<charT, traits>} then the expression \tcode{in >> get_time(tmb,
 fmt)} behaves as if it called \tcode{f(in, tmb, fmt)}, where the function \tcode{f} is
 defined as:
@@ -7235,7 +7273,8 @@ array of objects of type \tcode{charT} with
 \tcode{char_traits<charT>::length(\brk{}fmt)} elements.
 
 \pnum
-\returns An object of unspecified type such that if \tcode{out} is an object of
+\returns
+An object of unspecified type such that if \tcode{out} is an object of
 type \tcode{basic_ostream<charT, traits>} then the expression
 \tcode{out << put_time(tmb, fmt)} behaves as if it called \tcode{f(out, tmb, fmt)},
 where the function \tcode{f} is defined as:
@@ -7278,7 +7317,8 @@ template<class charT, class traits>
 
 \begin{itemdescr}
 \pnum
-\returns An object of unspecified type such that if \tcode{out} is an instance
+\returns
+An object of unspecified type such that if \tcode{out} is an instance
 of \tcode{basic_ostream} with member type \tcode{char_type} the same as
 \tcode{charT} and with member type \tcode{traits_type}, which in the second and third
 forms is the same as \tcode{traits}, then the expression
@@ -7311,7 +7351,8 @@ template<class charT, class traits, class Allocator>
 
 \begin{itemdescr}
 \pnum
-\returns An object of unspecified type such that:
+\returns
+An object of unspecified type such that:
 \begin{itemize}
 \item If \tcode{in} is an instance of \tcode{basic_istream} with member types
 \tcode{char_type} and \tcode{traits_type} the same as \tcode{charT}
@@ -7665,7 +7706,8 @@ constructor} whether the sequence pointers in \tcode{*this}
 the values which \tcode{rhs} had.
 
 \pnum
-\ensures Let \tcode{rhs_p} refer to the state of
+\ensures
+Let \tcode{rhs_p} refer to the state of
 \tcode{rhs} just prior to this construction and let \tcode{rhs_a}
 refer to the state of \tcode{rhs} just after this construction.
 
@@ -7696,11 +7738,13 @@ basic_stringbuf& operator=(basic_stringbuf&& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects After the move assignment \tcode{*this} has the observable state it would
+\effects
+After the move assignment \tcode{*this} has the observable state it would
 have had if it had been move constructed from \tcode{rhs} (see~\ref{stringbuf.cons}).
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{basic_stringbuf}%
@@ -7710,16 +7754,19 @@ void swap(basic_stringbuf& rhs) noexcept(@\seebelow@);
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{allocator_traits<Allocator>::propagate_on_container_swap::value}
+\expects
+\tcode{allocator_traits<Allocator>::propagate_on_container_swap::value}
 is \tcode{true} or
 \tcode{get_allocator() == s.get_allocator()} is \tcode{true}.
 
 \pnum
-\effects Exchanges the state of \tcode{*this}
+\effects
+Exchanges the state of \tcode{*this}
 and \tcode{rhs}.
 
 \pnum
-\remarks The expression inside \tcode{noexcept} is equivalent to:\\
+\remarks
+The expression inside \tcode{noexcept} is equivalent to:\\
 \tcode{allocator_traits<Allocator>::propagate_on_container_swap::value ||}\\
 \tcode{allocator_traits<Allocator>::is_always_equal::value}.
 \end{itemdescr}
@@ -7733,7 +7780,8 @@ template<class charT, class traits, class Allocator>
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{x.swap(y)}.
+\effects
+As if by \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \rSec3[stringbuf.members]{Member functions}
@@ -7798,7 +7846,8 @@ allocator_type get_allocator() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{buf.get_allocator()}.
+\returns
+\tcode{buf.get_allocator()}.
 \end{itemdescr}
 
 \indexlibrarymember{str}{basic_stringbuf}%
@@ -7808,7 +7857,8 @@ basic_string<charT, traits, Allocator> str() const &;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return basic_string<charT, traits, Allocator>(view(), get_allocator());
 \end{codeblock}
@@ -7826,7 +7876,8 @@ template<class SAlloc>
 qualifies as an allocator\iref{container.requirements.general}.
 
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return basic_string<charT, traits, SAlloc>(view(), sa);
 \end{codeblock}
@@ -7909,7 +7960,8 @@ template<class SAlloc>
 \constraints \tcode{is_same_v<SAlloc,Allocator>} is \tcode{false}.
 
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 buf = s;
 init_buf_ptrs();
@@ -7923,7 +7975,8 @@ void str(basic_string<charT, traits, Allocator>&& s);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 buf = std::move(s);
 init_buf_ptrs();
@@ -8385,7 +8438,8 @@ basic_istringstream(basic_istringstream&& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Move constructs from the rvalue \tcode{rhs}. This
+\effects
+Move constructs from the rvalue \tcode{rhs}. This
 is accomplished by move constructing the base class, and the contained
 \tcode{basic_stringbuf}.
 Next \tcode{basic_istream<charT, traits>::set_rdbuf(addressof(sb))}
@@ -8402,11 +8456,13 @@ basic_istringstream& operator=(basic_istringstream&& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Move assigns the base and members of \tcode{*this} from the base and corresponding
+\effects
+Move assigns the base and members of \tcode{*this} from the base and corresponding
 members of \tcode{rhs}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{basic_istringstream}%
@@ -8416,7 +8472,8 @@ void swap(basic_istringstream& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 basic_istream<charT, traits>::swap(rhs);
 sb.swap(rhs.sb);
@@ -8433,7 +8490,8 @@ template<class charT, class traits, class Allocator>
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{x.swap(y)}.
+\effects
+As if by \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \rSec3[istringstream.members]{Member functions}
@@ -8456,7 +8514,8 @@ basic_string<charT, traits, Allocator> str() const &;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return rdbuf()->str();}
+\effects
+Equivalent to: \tcode{return rdbuf()->str();}
 \end{itemdescr}
 
 \indexlibrarymember{str}{basic_istringstream}%
@@ -8467,7 +8526,8 @@ template<class SAlloc>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return rdbuf()->str(sa);}
+\effects
+Equivalent to: \tcode{return rdbuf()->str(sa);}
 \end{itemdescr}
 
 \indexlibrarymember{str}{basic_istringstream}%
@@ -8477,7 +8537,8 @@ basic_string<charT,traits,Allocator> str() &&;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return std::move(*rdbuf()).str();}
+\effects
+Equivalent to: \tcode{return std::move(*rdbuf()).str();}
 \end{itemdescr}
 
 \indexlibrarymember{view}{basic_istringstream}%
@@ -8487,7 +8548,8 @@ basic_string_view<charT, traits> view() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return rdbuf()->view();}
+\effects
+Equivalent to: \tcode{return rdbuf()->view();}
 \end{itemdescr}
 
 \indexlibrarymember{str}{basic_istringstream}%
@@ -8713,7 +8775,8 @@ basic_ostringstream(basic_ostringstream&& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Move constructs from the rvalue \tcode{rhs}. This
+\effects
+Move constructs from the rvalue \tcode{rhs}. This
 is accomplished by move constructing the base class, and the contained
 \tcode{basic_stringbuf}.
 Next \tcode{basic_ostream<charT, traits>::set_rdbuf(addressof(sb))}
@@ -8730,11 +8793,13 @@ basic_ostringstream& operator=(basic_ostringstream&& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Move assigns the base and members of \tcode{*this} from the base and corresponding
+\effects
+Move assigns the base and members of \tcode{*this} from the base and corresponding
 members of \tcode{rhs}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{basic_ostringstream}%
@@ -8744,7 +8809,8 @@ void swap(basic_ostringstream& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 basic_ostream<charT, traits>::swap(rhs);
 sb.swap(rhs.sb);
@@ -8760,7 +8826,8 @@ template<class charT, class traits, class Allocator>
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{x.swap(y)}.
+\effects
+As if by \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \rSec3[ostringstream.members]{Member functions}
@@ -9050,7 +9117,8 @@ basic_stringstream(basic_stringstream&& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Move constructs from the rvalue \tcode{rhs}. This
+\effects
+Move constructs from the rvalue \tcode{rhs}. This
 is accomplished by move constructing the base class, and the contained
 \tcode{basic_stringbuf}.
 Next \tcode{basic_istream<charT, traits>::set_rdbuf(addressof(sb))} is called to
@@ -9066,11 +9134,13 @@ basic_stringstream& operator=(basic_stringstream&& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Move assigns the base and members of \tcode{*this} from the base and corresponding
+\effects
+Move assigns the base and members of \tcode{*this} from the base and corresponding
 members of \tcode{rhs}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{basic_stringstream}%
@@ -9097,7 +9167,8 @@ template<class charT, class traits, class Allocator>
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{x.swap(y)}.
+\effects
+As if by \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \rSec3[stringstream.members]{Member functions}
@@ -9392,7 +9463,8 @@ basic_filebuf(basic_filebuf&& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Move constructs from the rvalue \tcode{rhs}. It
+\effects
+Move constructs from the rvalue \tcode{rhs}. It
 is \impldef{whether sequence pointers are copied by \tcode{basic_filebuf} move
 constructor} whether the sequence pointers in \tcode{*this}
 (\tcode{eback()}, \tcode{gptr()}, \tcode{egptr()},
@@ -9406,7 +9478,8 @@ openmode, locale and any other state of \tcode{rhs} is also
 copied.
 
 \pnum
-\ensures Let \tcode{rhs_p} refer to the state of
+\ensures
+Let \tcode{rhs_p} refer to the state of
 \tcode{rhs} just prior to this construction and let \tcode{rhs_a}
 refer to the state of \tcode{rhs} just after this construction.
 
@@ -9450,12 +9523,14 @@ basic_filebuf& operator=(basic_filebuf&& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Calls \tcode{close()} then move assigns from \tcode{rhs}. After the
+\effects
+Calls \tcode{close()} then move assigns from \tcode{rhs}. After the
 move assignment \tcode{*this} has the observable state it would have had if it
 had been move constructed from \tcode{rhs} (see~\ref{filebuf.cons}).
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{basic_filebuf}%
@@ -9465,7 +9540,8 @@ void swap(basic_filebuf& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Exchanges the state of \tcode{*this}
+\effects
+Exchanges the state of \tcode{*this}
 and \tcode{rhs}.
 \end{itemdescr}
 
@@ -9478,7 +9554,8 @@ template<class charT, class traits>
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{x.swap(y)}.
+\effects
+As if by \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \rSec3[filebuf.members]{Member functions}
@@ -10146,7 +10223,8 @@ explicit basic_ifstream(const filesystem::path& s,
 
 \begin{itemdescr}
 \pnum
-\effects The same as \tcode{basic_ifstream(s.c_str(), mode)}.
+\effects
+The same as \tcode{basic_ifstream(s.c_str(), mode)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_ifstream}!constructor}%
@@ -10156,7 +10234,8 @@ basic_ifstream(basic_ifstream&& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Move constructs from the rvalue \tcode{rhs}. This
+\effects
+Move constructs from the rvalue \tcode{rhs}. This
 is accomplished by move constructing the base class, and the contained
 \tcode{basic_filebuf}. Next
 \tcode{basic_istream<charT, traits>::set_rdbuf(\brk{}addressof(sb))}
@@ -10173,11 +10252,13 @@ basic_ifstream& operator=(basic_ifstream&& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Move assigns the base and members of \tcode{*this} from the base and corresponding
+\effects
+Move assigns the base and members of \tcode{*this} from the base and corresponding
 members of \tcode{rhs}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{basic_ifstream}%
@@ -10187,7 +10268,8 @@ void swap(basic_ifstream& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Exchanges the state of \tcode{*this}
+\effects
+Exchanges the state of \tcode{*this}
 and \tcode{rhs} by calling
 \tcode{basic_istream<charT, traits>::swap(rhs)} and
 \tcode{sb.swap(rhs.sb)}.
@@ -10202,7 +10284,8 @@ template<class charT, class traits>
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{x.swap(y)}.
+\effects
+As if by \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \rSec3[ifstream.members]{Member functions}
@@ -10257,7 +10340,8 @@ void open(const filesystem::path& s, ios_base::openmode mode = ios_base::in);
 
 \begin{itemdescr}
 \pnum
-\effects Calls \tcode{open(s.c_str(), mode)}.
+\effects
+Calls \tcode{open(s.c_str(), mode)}.
 \end{itemdescr}
 
 \indexlibrarymember{close}{basic_ifstream}%
@@ -10395,7 +10479,8 @@ explicit basic_ofstream(const filesystem::path& s,
 
 \begin{itemdescr}
 \pnum
-\effects The same as \tcode{basic_ofstream(s.c_str(), mode)}.
+\effects
+The same as \tcode{basic_ofstream(s.c_str(), mode)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_ofstream}!constructor}%
@@ -10405,7 +10490,8 @@ basic_ofstream(basic_ofstream&& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Move constructs from the rvalue \tcode{rhs}. This
+\effects
+Move constructs from the rvalue \tcode{rhs}. This
 is accomplished by move constructing the base class, and the contained
 \tcode{basic_filebuf}. Next
 \tcode{basic_ostream<charT, traits>::set_rdbuf(\brk{}addressof(sb))}
@@ -10422,11 +10508,13 @@ basic_ofstream& operator=(basic_ofstream&& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Move assigns the base and members of \tcode{*this} from the base and corresponding
+\effects
+Move assigns the base and members of \tcode{*this} from the base and corresponding
 members of \tcode{rhs}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{basic_ofstream}%
@@ -10436,7 +10524,8 @@ void swap(basic_ofstream& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Exchanges the state of \tcode{*this}
+\effects
+Exchanges the state of \tcode{*this}
 and \tcode{rhs} by calling
 \tcode{basic_ostream<charT, traits>::swap(rhs)} and
 \tcode{sb.swap(rhs.sb)}.
@@ -10451,7 +10540,8 @@ template<class charT, class traits>
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{x.swap(y)}.
+\effects
+As if by \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \rSec3[ofstream.members]{Member functions}
@@ -10522,7 +10612,8 @@ void open(const filesystem::path& s, ios_base::openmode mode = ios_base::out);
 
 \begin{itemdescr}
 \pnum
-\effects Calls \tcode{open(s.c_str(), mode)}.
+\effects
+Calls \tcode{open(s.c_str(), mode)}.
 \end{itemdescr}
 
 \rSec2[fstream]{Class template \tcode{basic_fstream}}
@@ -10661,7 +10752,8 @@ explicit basic_fstream(
 
 \begin{itemdescr}
 \pnum
-\effects The same as \tcode{basic_fstream(s.c_str(), mode)}.
+\effects
+The same as \tcode{basic_fstream(s.c_str(), mode)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_fstream}!constructor}%
@@ -10671,7 +10763,8 @@ basic_fstream(basic_fstream&& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Move constructs from the rvalue \tcode{rhs}. This
+\effects
+Move constructs from the rvalue \tcode{rhs}. This
 is accomplished by move constructing the base class, and the contained
 \tcode{basic_filebuf}. Next
 \tcode{basic_istream<charT, traits>::set_rdbuf(\brk{}addressof(sb))}
@@ -10688,11 +10781,13 @@ basic_fstream& operator=(basic_fstream&& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Move assigns the base and members of \tcode{*this} from the base and corresponding
+\effects
+Move assigns the base and members of \tcode{*this} from the base and corresponding
 members of \tcode{rhs}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{basic_fstream}%
@@ -10702,7 +10797,8 @@ void swap(basic_fstream& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Exchanges the state of \tcode{*this}
+\effects
+Exchanges the state of \tcode{*this}
 and \tcode{rhs} by calling
 \tcode{basic_iostream<charT,traits>::swap(rhs)} and
 \tcode{sb.swap(rhs.sb)}.
@@ -10717,7 +10813,8 @@ template<class charT, class traits>
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{x.swap(y)}.
+\effects
+As if by \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \rSec3[fstream.members]{Member functions}
@@ -10778,7 +10875,8 @@ void open(
 
 \begin{itemdescr}
 \pnum
-\effects Calls \tcode{open(s.c_str(), mode)}.
+\effects
+Calls \tcode{open(s.c_str(), mode)}.
 \end{itemdescr}
 
 \indexlibrarymember{close}{basic_fstream}%
@@ -12369,10 +12467,12 @@ path() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an object of class \tcode{path}.
+\effects
+Constructs an object of class \tcode{path}.
 
 \pnum
-\ensures \tcode{empty() == true}.
+\ensures
+\tcode{empty() == true}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{path}!constructor}%
@@ -12415,7 +12515,8 @@ template<class InputIterator>
 
 \begin{itemdescr}
 \pnum
-\effects Let \tcode{s} be the effective range of \tcode{source}\iref{fs.path.req}
+\effects
+Let \tcode{s} be the effective range of \tcode{source}\iref{fs.path.req}
 or the range \range{first}{last}, with the encoding converted if required\iref{fs.path.cvt}.
 Finds the detected-format of \tcode{s}\iref{fs.path.fmt.cvt}
 and constructs an object of class \tcode{path}
@@ -12437,7 +12538,8 @@ The value type of \tcode{Source} and \tcode{InputIterator} is
 \tcode{char}.
 
 \pnum
-\effects Let \tcode{s} be the effective range of \tcode{source}
+\effects
+Let \tcode{s} be the effective range of \tcode{source}
 or the range \range{first}{last},
 after converting the encoding as
 follows:
@@ -12495,14 +12597,16 @@ path& operator=(const path& p);
 
 \begin{itemdescr}
 \pnum
-\effects If \tcode{*this} and \tcode{p} are the same
+\effects
+If \tcode{*this} and \tcode{p} are the same
 object, has no effect.
 Otherwise,
 sets both respective pathnames of \tcode{*this}
 to the respective pathnames of \tcode{p}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{path}%
@@ -12512,7 +12616,8 @@ path& operator=(path&& p) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects If \tcode{*this} and \tcode{p} are the same
+\effects
+If \tcode{*this} and \tcode{p} are the same
 object, has no effect. Otherwise,
 sets both respective pathnames of \tcode{*this}
 to the respective pathnames of \tcode{p}.
@@ -12520,7 +12625,8 @@ to the respective pathnames of \tcode{p}.
 \begin{note} A valid implementation is \tcode{swap(p)}. \end{note}
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{path}%
@@ -12532,12 +12638,14 @@ path& assign(string_type&& source);
 
 \begin{itemdescr}
 \pnum
-\effects Sets the pathname in the detected-format of \tcode{source}
+\effects
+Sets the pathname in the detected-format of \tcode{source}
 to the original value of \tcode{source}.
 \tcode{source} is left in a valid but unspecified state.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{path}%
@@ -12560,7 +12668,8 @@ Finds the detected-format of \tcode{s}\iref{fs.path.fmt.cvt}
 and sets the pathname in that format to \tcode{s}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \rSec4[fs.path.append]{Appends}
@@ -12576,7 +12685,8 @@ path& operator/=(const path& p);
 
 \begin{itemdescr}
 \pnum
-\effects If \tcode{p.is_absolute() || (p.has_root_name() \&\& p.root_name() != root_name())},
+\effects
+If \tcode{p.is_absolute() || (p.has_root_name() \&\& p.root_name() != root_name())},
 then \tcode{operator=(p)}.
 
 \pnum
@@ -12619,7 +12729,8 @@ path("c:foo") /= path("c:bar"); // yields \tcode{path("c:foo\textbackslash\textb
 \end{example}
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator/=}{path}%
@@ -12633,7 +12744,8 @@ template<class Source>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return operator/=(path(source));}
+\effects
+Equivalent to: \tcode{return operator/=(path(source));}
 \end{itemdescr}
 
 \indexlibrarymember{operator/=}{path}%
@@ -12645,7 +12757,8 @@ template<class InputIterator>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return operator/=(path(first, last));}
+\effects
+Equivalent to: \tcode{return operator/=(path(first, last));}
 \end{itemdescr}
 
 \rSec4[fs.path.concat]{Concatenation}
@@ -12665,14 +12778,16 @@ template<class Source>
 
 \begin{itemdescr}
 \pnum
-\effects Appends \tcode{path(x).native()} to the pathname in the native format.
+\effects
+Appends \tcode{path(x).native()} to the pathname in the native format.
 \begin{note}
 This directly manipulates the value of \tcode{native()}
 and may not be portable between operating systems.
 \end{note}
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+=}{path}%
@@ -12685,7 +12800,8 @@ template<class EcharT>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return *this += basic_string_view(\&x, 1);}
+\effects
+Equivalent to: \tcode{return *this += basic_string_view(\&x, 1);}
 \end{itemdescr}
 
 \indexlibrarymember{concat}{path}%
@@ -12696,7 +12812,8 @@ template<class InputIterator>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return *this += path(first, last);}
+\effects
+Equivalent to: \tcode{return *this += path(first, last);}
 \end{itemdescr}
 
 \rSec4[fs.path.modifiers]{Modifiers}
@@ -12708,7 +12825,8 @@ void clear() noexcept;
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{empty() == true}.
+\ensures
+\tcode{empty() == true}.
 \end{itemdescr}
 
 \indexlibrarymember{make_preferred}{path}%
@@ -12718,12 +12836,14 @@ path& make_preferred();
 
 \begin{itemdescr}
 \pnum
-\effects Each \grammarterm{directory-separator}
+\effects
+Each \grammarterm{directory-separator}
 of the pathname in the generic format
   is converted to \grammarterm{preferred-separator}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 
 \pnum
 \begin{example}
@@ -12755,13 +12875,16 @@ path& remove_filename();
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{!has_filename()}.
+\ensures
+\tcode{!has_filename()}.
 
 \pnum
-\effects Remove the generic format pathname of \tcode{filename()} from the generic format pathname.
+\effects
+Remove the generic format pathname of \tcode{filename()} from the generic format pathname.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 
 \pnum
 \begin{example}
@@ -12789,7 +12912,8 @@ operator/=(replacement);
 \end{codeblock}
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 
 \pnum
 \begin{example}
@@ -12819,7 +12943,8 @@ path& replace_extension(const path& replacement = path());
   \end{itemize}
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{path}%
@@ -12829,10 +12954,12 @@ void swap(path& rhs) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Swaps the contents (in all formats) of the two paths.
+\effects
+Swaps the contents (in all formats) of the two paths.
 
 \pnum
-\complexity Constant time.
+\complexity
+Constant time.
 \end{itemdescr}
 
 \rSec4[fs.path.native.obs]{Native format observers}
@@ -12847,7 +12974,8 @@ const string_type& native() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns The pathname in the native format.
+\returns
+The pathname in the native format.
 \end{itemdescr}
 
 \indexlibrarymember{c_str}{path}%
@@ -12857,7 +12985,8 @@ const value_type* c_str() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return native().c_str();}
+\effects
+Equivalent to: \tcode{return native().c_str();}
 \end{itemdescr}
 
 \indexlibrarymember{operator string_type}{path}%
@@ -12867,7 +12996,8 @@ operator string_type() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{native()}.
+\returns
+\tcode{native()}.
 
 \pnum
 \begin{note} Conversion to \tcode{string_type} is provided so that an
@@ -12885,10 +13015,12 @@ template<class EcharT, class traits = char_traits<EcharT>,
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{native()}.
+\returns
+\tcode{native()}.
 
 \pnum
-\remarks All memory allocation, including for the return value, shall
+\remarks
+All memory allocation, including for the return value, shall
 be performed by \tcode{a}. Conversion, if any, is specified by
 \ref{fs.path.cvt}.
 \end{itemdescr}
@@ -12908,10 +13040,12 @@ std::u32string u32string() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{native()}.
+\returns
+\tcode{native()}.
 
 \pnum
-\remarks Conversion, if any, is performed as specified
+\remarks
+Conversion, if any, is performed as specified
 by \ref{fs.path.cvt}.
 \end{itemdescr}
 
@@ -12942,10 +13076,12 @@ template<class EcharT, class traits = char_traits<EcharT>,
 
 \begin{itemdescr}
 \pnum
-\returns The pathname in the generic format.
+\returns
+The pathname in the generic format.
 
 \pnum
-\remarks All memory allocation, including for the return value, shall
+\remarks
+All memory allocation, including for the return value, shall
 be performed by \tcode{a}. Conversion, if any, is specified by
 \ref{fs.path.cvt}.
 \end{itemdescr}
@@ -12965,10 +13101,12 @@ std::u32string generic_u32string() const;
 
 \begin{itemdescr}
 \pnum
-\returns The pathname in the generic format.
+\returns
+The pathname in the generic format.
 
 \pnum
-\remarks Conversion, if any, is specified by~\ref{fs.path.cvt}.
+\remarks
+Conversion, if any, is specified by~\ref{fs.path.cvt}.
 \end{itemdescr}
 
 \rSec4[fs.path.compare]{Compare}
@@ -13021,7 +13159,8 @@ int compare(const value_type* s) const
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return compare(path(s));}
+\effects
+Equivalent to: \tcode{return compare(path(s));}
 \end{itemdescr}
 
 \rSec4[fs.path.decompose]{Decomposition}
@@ -13033,7 +13172,8 @@ path root_name() const;
 
 \begin{itemdescr}
 \pnum
-\returns \grammarterm{root-name}, if the pathname in the generic format
+\returns
+\grammarterm{root-name}, if the pathname in the generic format
 includes \grammarterm{root-name}, otherwise \tcode{path()}.
 \end{itemdescr}
 
@@ -13044,7 +13184,8 @@ path root_directory() const;
 
 \begin{itemdescr}
 \pnum
-\returns \grammarterm{root-directory}, if the pathname in the generic format
+\returns
+\grammarterm{root-directory}, if the pathname in the generic format
 includes \grammarterm{root-directory}, otherwise \tcode{path()}.
 \end{itemdescr}
 
@@ -13055,7 +13196,8 @@ path root_path() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{root_name() / root_directory()}.
+\returns
+\tcode{root_name() / root_directory()}.
 \end{itemdescr}
 
 \indexlibrarymember{relative_path}{path}%
@@ -13065,7 +13207,8 @@ path relative_path() const;
 
 \begin{itemdescr}
 \pnum
-\returns A \tcode{path} composed from the pathname in the generic format,
+\returns
+A \tcode{path} composed from the pathname in the generic format,
 if \tcode{empty()} is \tcode{false}, beginning
 with the first \grammarterm{filename} after \tcode{root_path()}. Otherwise, \tcode{path()}.
 \end{itemdescr}
@@ -13077,7 +13220,8 @@ path parent_path() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{*this} if \tcode{has_relative_path()} is \tcode{false},
+\returns
+\tcode{*this} if \tcode{has_relative_path()} is \tcode{false},
 otherwise a path whose generic format pathname is
 the longest prefix of the generic format pathname of \tcode{*this}
 that produces one fewer element in its iteration.
@@ -13090,7 +13234,8 @@ path filename() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{relative_path().empty() ? path() : *--end()}.
+\returns
+\tcode{relative_path().empty() ? path() : *--end()}.
 
 \pnum
 \begin{example}
@@ -13113,7 +13258,8 @@ path stem() const;
 
 \begin{itemdescr}
 \pnum
-\returns Let \tcode{f} be the generic format pathname of \tcode{filename()}.
+\returns
+Let \tcode{f} be the generic format pathname of \tcode{filename()}.
 Returns a path whose pathname in the generic format is
 \begin{itemize}
 \item \tcode{f}, if it contains no periods other than a leading period
@@ -13142,7 +13288,8 @@ path extension() const;
 
 \begin{itemdescr}
 \pnum
-\returns A path whose pathname in the generic format is
+\returns
+A path whose pathname in the generic format is
 the suffix of \tcode{filename()} not included in \tcode{stem()}.
 
 \pnum
@@ -13178,7 +13325,8 @@ even though the generic format pathnames are the same.
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{true} if the pathname in the generic format is empty, otherwise \tcode{false}.
+\returns
+\tcode{true} if the pathname in the generic format is empty, otherwise \tcode{false}.
 \end{itemdescr}
 
 \indexlibrarymember{has_root_path}{path}%
@@ -13188,7 +13336,8 @@ bool has_root_path() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!root_path().empty()}.
+\returns
+\tcode{!root_path().empty()}.
 \end{itemdescr}
 
 \indexlibrarymember{has_root_name}{path}%
@@ -13198,7 +13347,8 @@ bool has_root_name() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!root_name().empty()}.
+\returns
+\tcode{!root_name().empty()}.
 \end{itemdescr}
 
 \indexlibrarymember{has_root_directory}{path}%
@@ -13208,7 +13358,8 @@ bool has_root_directory() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!root_directory().empty()}.
+\returns
+\tcode{!root_directory().empty()}.
 \end{itemdescr}
 
 \indexlibrarymember{has_relative_path}{path}%
@@ -13218,7 +13369,8 @@ bool has_relative_path() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!relative_path().empty()}.
+\returns
+\tcode{!relative_path().empty()}.
 \end{itemdescr}
 
 \indexlibrarymember{has_parent_path}{path}%
@@ -13228,7 +13380,8 @@ bool has_parent_path() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!parent_path().empty()}.
+\returns
+\tcode{!parent_path().empty()}.
 \end{itemdescr}
 
 \indexlibrarymember{has_filename}{path}%
@@ -13238,7 +13391,8 @@ bool has_filename() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!filename().empty()}.
+\returns
+\tcode{!filename().empty()}.
 \end{itemdescr}
 
 \indexlibrarymember{has_stem}{path}%
@@ -13248,7 +13402,8 @@ bool has_stem() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!stem().empty()}.
+\returns
+\tcode{!stem().empty()}.
 \end{itemdescr}
 
 \indexlibrarymember{has_extension}{path}%
@@ -13258,7 +13413,8 @@ bool has_extension() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!extension().empty()}.
+\returns
+\tcode{!extension().empty()}.
 \end{itemdescr}
 
 \indexlibrarymember{is_absolute}{path}%
@@ -13268,7 +13424,8 @@ bool is_absolute() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{true} if the pathname in the native format
+\returns
+\tcode{true} if the pathname in the native format
   contains an absolute path\iref{fs.class.path}, otherwise \tcode{false}.
 
 \pnum
@@ -13284,7 +13441,8 @@ bool is_relative() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!is_absolute()}.
+\returns
+\tcode{!is_absolute()}.
 \end{itemdescr}
 
 \rSec4[fs.path.gen]{Generation}
@@ -13296,7 +13454,8 @@ path lexically_normal() const;
 
 \begin{itemdescr}
 \pnum
-\returns A path whose pathname in the generic format is
+\returns
+A path whose pathname in the generic format is
 the normal form\iref{fs.path.generic} of the pathname
 in the generic format of \tcode{*this}.
 
@@ -13320,7 +13479,8 @@ path lexically_relative(const path& base) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{*this} made relative to \tcode{base}.
+\returns
+\tcode{*this} made relative to \tcode{base}.
 Does not resolve\iref{fs.class.path} symlinks.
 Does not first normalize\iref{fs.path.generic} \tcode{*this} or \tcode{base}.
 
@@ -13388,7 +13548,8 @@ path lexically_proximate(const path& base) const;
 
 \begin{itemdescr}
 \pnum
-\returns If the value of \tcode{lexically_relative(base)} is not an empty path,
+\returns
+If the value of \tcode{lexically_relative(base)} is not an empty path,
   return it. Otherwise return \tcode{*this}.
 
 \pnum
@@ -13448,7 +13609,8 @@ iterator begin() const;
 
 \begin{itemdescr}
 \pnum
-\returns An iterator for the first present element in the traversal
+\returns
+An iterator for the first present element in the traversal
 list above. If no elements are present, the end iterator.
 \end{itemdescr}
 
@@ -13459,7 +13621,8 @@ iterator end() const;
 
 \begin{itemdescr}
 \pnum
-\returns The end iterator.
+\returns
+The end iterator.
 \end{itemdescr}
 
 \rSec3[fs.path.io]{Inserter and extractor}
@@ -13473,11 +13636,13 @@ template<class charT, class traits>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to \tcode{os << quoted(p.string<charT, traits>())}.
+\effects
+Equivalent to \tcode{os << quoted(p.string<charT, traits>())}.
 \begin{note} The \tcode{quoted} function is described in~\ref{quoted.manip}. \end{note}
 
 \pnum
-\returns \tcode{os}.
+\returns
+\tcode{os}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>>}{path}%
@@ -13498,7 +13663,8 @@ p = tmp;
 \end{codeblock}
 
 \pnum
-\returns \tcode{is}.
+\returns
+\tcode{is}.
 \end{itemdescr}
 
 \rSec3[fs.path.nonmember]{Non-member functions}
@@ -13510,7 +13676,8 @@ void swap(path& lhs, path& rhs) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to \tcode{lhs.swap(rhs)}.
+\effects
+Equivalent to \tcode{lhs.swap(rhs)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{hash_value}!\idxcode{path}}%
@@ -13520,7 +13687,8 @@ size_t hash_value (const path& p) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns A hash value for the path \tcode{p}. If
+\returns
+A hash value for the path \tcode{p}. If
   for two paths, \tcode{p1 == p2} then \tcode{hash_value(p1) == hash_value(p2)}.
 \end{itemdescr}
 
@@ -13531,7 +13699,8 @@ friend bool operator==(const path& lhs, const path& rhs) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{lhs.compare(rhs) == 0}.
+\returns
+\tcode{lhs.compare(rhs) == 0}.
 
 \indextext{path equality}
 \pnum
@@ -13558,7 +13727,8 @@ friend strong_ordering operator<=>(const path& lhs, const path& rhs) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{lhs.compare(rhs) <=> 0}.
+\returns
+\tcode{lhs.compare(rhs) <=> 0}.
 \end{itemdescr}
 
 \indexlibrarymember{operator/}{path}%
@@ -13568,7 +13738,8 @@ friend path operator/ (const path& lhs, const path& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return path(lhs) /= rhs;}
+\effects
+Equivalent to: \tcode{return path(lhs) /= rhs;}
 \end{itemdescr}
 
 \rSec2[fs.class.filesystem.error]{Class \tcode{filesystem_error}}
@@ -13656,7 +13827,8 @@ const path& path1() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns A reference to the copy of \tcode{p1} stored by the
+\returns
+A reference to the copy of \tcode{p1} stored by the
   constructor, or, if none, an empty path.
 \end{itemdescr}
 
@@ -13667,7 +13839,8 @@ const path& path2() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns A reference to the copy of \tcode{p2} stored by the
+\returns
+A reference to the copy of \tcode{p2} stored by the
   constructor, or, if none, an empty path.
 \end{itemdescr}
 
@@ -13678,7 +13851,8 @@ const char* what() const noexcept override;
 
 \begin{itemdescr}
 \pnum
-\returns An \ntbs{} that incorporates
+\returns
+An \ntbs{} that incorporates
   the \tcode{what_arg} argument supplied to the constructor.
   The exact format is unspecified.
   Implementations should include
@@ -13971,7 +14145,8 @@ explicit file_status(file_type ft, perms prms = perms::unknown) noexcept;
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{type() == ft} and \tcode{permissions() == prms}.
+\ensures
+\tcode{type() == ft} and \tcode{permissions() == prms}.
 \end{itemdescr}
 
 \rSec3[fs.file.status.obs]{Observers}
@@ -13983,7 +14158,8 @@ file_type type() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns The value of \tcode{type()} specified by the postconditions of the most recent call to a constructor,
+\returns
+The value of \tcode{type()} specified by the postconditions of the most recent call to a constructor,
   \tcode{operator=}, or \tcode{type(file_type)} function.
 \end{itemdescr}
 
@@ -13994,7 +14170,8 @@ perms permissions() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns The value of \tcode{permissions()} specified by the postconditions of the most recent call to a constructor,
+\returns
+The value of \tcode{permissions()} specified by the postconditions of the most recent call to a constructor,
   \tcode{operator=}, or \tcode{permissions(perms)} function.
 \end{itemdescr}
 
@@ -14007,7 +14184,8 @@ void type(file_type ft) noexcept;
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{type() == ft}.
+\ensures
+\tcode{type() == ft}.
 \end{itemdescr}
 
 \indexlibrarymember{permissions}{file_status}%
@@ -14017,7 +14195,8 @@ void permissions(perms prms) noexcept;
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{permissions() == prms}.
+\ensures
+\tcode{permissions() == prms}.
 \end{itemdescr}
 
 \rSec2[fs.class.directory.entry]{Class \tcode{directory_entry}}
@@ -14154,15 +14333,18 @@ directory_entry(const filesystem::path& p, error_code& ec);
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an object of type \tcode{directory_entry},
+\effects
+Constructs an object of type \tcode{directory_entry},
 then \tcode{refresh()} or \tcode{refresh(ec)}, respectively.
 
 \pnum
-\ensures \tcode{path() == p} if no error occurs,
+\ensures
+\tcode{path() == p} if no error occurs,
 otherwise \tcode{path() == filesystem::path()}.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \rSec3[fs.dir.entry.mods]{Modifiers}
@@ -14175,12 +14357,14 @@ void assign(const filesystem::path& p, error_code& ec);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to \tcode{pathobject = p},
+\effects
+Equivalent to \tcode{pathobject = p},
 then \tcode{refresh()} or \tcode{refresh(ec)}, respectively.
 If an error occurs, the values of any cached attributes are unspecified.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \indexlibrarymember{replace_filename}{directory_entry}%
@@ -14191,11 +14375,13 @@ void replace_filename(const filesystem::path& p, error_code& ec);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to \tcode{pathobject.replace_filename(p)},
+\effects
+Equivalent to \tcode{pathobject.replace_filename(p)},
 then \tcode{refresh()} or \tcode{refresh(ec)}, respectively.
 If an error occurs, the values of any cached attributes are unspecified.
 
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \indexlibrarymember{refresh}{directory_entry}%
@@ -14206,12 +14392,14 @@ void refresh(error_code& ec) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Stores the current values of any cached attributes of the file \tcode{p} resolves to.
+\effects
+Stores the current values of any cached attributes of the file \tcode{p} resolves to.
 If an error occurs, an error is reported\iref{fs.err.report}
 and the values of any cached attributes are unspecified.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 
 \pnum
 \begin{note}
@@ -14238,7 +14426,8 @@ operator const filesystem::path&() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{pathobject}.
+\returns
+\tcode{pathobject}.
 \end{itemdescr}
 
 \indexlibrarymember{exists}{directory_entry}%
@@ -14249,10 +14438,12 @@ bool exists(error_code& ec) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{exists(this->status())} or \tcode{exists(this->status(ec))}, respectively.
+\returns
+\tcode{exists(this->status())} or \tcode{exists(this->status(ec))}, respectively.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \indexlibrarymember{is_block_file}{directory_entry}%
@@ -14263,10 +14454,12 @@ bool is_block_file(error_code& ec) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{is_block_file(this->status())} or \tcode{is_block_file(this->status(ec))}, respectively.
+\returns
+\tcode{is_block_file(this->status())} or \tcode{is_block_file(this->status(ec))}, respectively.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \indexlibrarymember{is_character_file}{directory_entry}%
@@ -14277,10 +14470,12 @@ bool is_character_file(error_code& ec) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{is_character_file(this->status())} or \tcode{is_character_file(this->status(ec))}, respectively.
+\returns
+\tcode{is_character_file(this->status())} or \tcode{is_character_file(this->status(ec))}, respectively.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \indexlibrarymember{is_directory}{directory_entry}%
@@ -14291,10 +14486,12 @@ bool is_directory(error_code& ec) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{is_directory(this->status())} or \tcode{is_directory(this->status(ec))}, respectively.
+\returns
+\tcode{is_directory(this->status())} or \tcode{is_directory(this->status(ec))}, respectively.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \indexlibrarymember{is_fifo}{directory_entry}%
@@ -14305,10 +14502,12 @@ bool is_fifo(error_code& ec) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{is_fifo(this->status())} or \tcode{is_fifo(this->status(ec))}, respectively.
+\returns
+\tcode{is_fifo(this->status())} or \tcode{is_fifo(this->status(ec))}, respectively.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \indexlibrarymember{is_other}{directory_entry}%
@@ -14319,10 +14518,12 @@ bool is_other(error_code& ec) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{is_other(this->status())} or \tcode{is_other(this->status(ec))}, respectively.
+\returns
+\tcode{is_other(this->status())} or \tcode{is_other(this->status(ec))}, respectively.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \indexlibrarymember{is_regular_file}{directory_entry}%
@@ -14333,10 +14534,12 @@ bool is_regular_file(error_code& ec) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{is_regular_file(this->status())} or \tcode{is_regular_file(this->status(ec))}, respective\-ly.
+\returns
+\tcode{is_regular_file(this->status())} or \tcode{is_regular_file(this->status(ec))}, respective\-ly.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \indexlibrarymember{is_socket}{directory_entry}%
@@ -14347,10 +14550,12 @@ bool is_socket(error_code& ec) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{is_socket(this->status())} or \tcode{is_socket(this->status(ec))}, respectively.
+\returns
+\tcode{is_socket(this->status())} or \tcode{is_socket(this->status(ec))}, respectively.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \indexlibrarymember{is_symlink}{directory_entry}%
@@ -14361,10 +14566,12 @@ bool is_symlink(error_code& ec) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{is_symlink(this->symlink_status())} or \tcode{is_symlink(this->symlink_status(ec))}, respectively.
+\returns
+\tcode{is_symlink(this->symlink_status())} or \tcode{is_symlink(this->symlink_status(ec))}, respectively.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \indexlibrarymember{file_size}{directory_entry}%
@@ -14375,11 +14582,13 @@ uintmax_t file_size(error_code& ec) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns If cached, the file size attribute value.
+\returns
+If cached, the file size attribute value.
 Otherwise, \tcode{file_size(path())} or \tcode{file_size(path(), ec)}, respectively.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \indexlibrarymember{hard_link_count}{directory_entry}%
@@ -14390,11 +14599,13 @@ uintmax_t hard_link_count(error_code& ec) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns If cached, the hard link count attribute value.
+\returns
+If cached, the hard link count attribute value.
 Otherwise, \tcode{hard_link_count(path())} or \tcode{hard_link_count(path(), ec)}, respectively.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \indexlibrarymember{last_write_time}{directory_entry}%
@@ -14405,11 +14616,13 @@ file_time_type last_write_time(error_code& ec) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns If cached, the last write time attribute value.
+\returns
+If cached, the last write time attribute value.
 Otherwise, \tcode{last_write_time(path())} or \tcode{last_write_time(path(), ec)}, respectively.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \indexlibrarymember{status}{directory_entry}%
@@ -14420,11 +14633,13 @@ file_status status(error_code& ec) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns If cached, the status attribute value.
+\returns
+If cached, the status attribute value.
 Otherwise, \tcode{status(path())} or \tcode{status(path(), ec)}, respectively.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \indexlibrarymember{symlink_status}{directory_entry}%
@@ -14435,11 +14650,13 @@ file_status symlink_status(error_code& ec) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns If cached, the symlink status attribute value.
+\returns
+If cached, the symlink status attribute value.
 Otherwise, \tcode{symlink_status(path())} or \tcode{symlink_status(path(), ec)}, respectively.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \indexlibrarymember{operator==}{directory_entry}%
@@ -14449,7 +14666,8 @@ bool operator==(const directory_entry& rhs) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{pathobject == rhs.pathobject}.
+\returns
+\tcode{pathobject == rhs.pathobject}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{directory_entry}%
@@ -14459,7 +14677,8 @@ strong_ordering operator<=>(const directory_entry& rhs) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{pathobject <=> rhs.pathobject}.
+\returns
+\tcode{pathobject <=> rhs.pathobject}.
 \end{itemdescr}
 
 \rSec2[fs.class.directory.iterator]{Class \tcode{directory_iterator}}
@@ -14578,7 +14797,8 @@ directory_iterator() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Constructs the end iterator.
+\effects
+Constructs the end iterator.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{directory_iterator}!constructor}%
@@ -14591,7 +14811,8 @@ directory_iterator(const path& p, directory_options options, error_code& ec);
 
 \begin{itemdescr}
 \pnum
-\effects For the directory that \tcode{p} resolves to, constructs an
+\effects
+For the directory that \tcode{p} resolves to, constructs an
 iterator for the first element in a sequence of \tcode{directory_entry}
 elements representing the files in the directory, if any; otherwise the end
 iterator. However, if
@@ -14603,7 +14824,8 @@ that permission to access \tcode{p} is denied, constructs the end iterator
 and does not report an error.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 
 \pnum
 \begin{note} To iterate over the current directory, use \tcode{directory_iterator(".")} rather than \tcode{directory_iterator("")}. \end{note}
@@ -14617,10 +14839,12 @@ directory_iterator(directory_iterator&& rhs) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an object of class \tcode{directory_iterator}.
+\effects
+Constructs an object of class \tcode{directory_iterator}.
 
 \pnum
-\ensures \tcode{*this} has the original value of \tcode{rhs}.
+\ensures
+\tcode{*this} has the original value of \tcode{rhs}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{directory_iterator}%
@@ -14631,14 +14855,17 @@ directory_iterator& operator=(directory_iterator&& rhs) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects If \tcode{*this} and \tcode{rhs} are the same
+\effects
+If \tcode{*this} and \tcode{rhs} are the same
   object, the member has no effect.
 
 \pnum
-\ensures \tcode{*this} has the original value of \tcode{rhs}.
+\ensures
+\tcode{*this} has the original value of \tcode{rhs}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{increment}{directory_iterator}%
@@ -14651,14 +14878,17 @@ directory_iterator& increment(error_code& ec);
 \begin{itemdescr}
 
 \pnum
-\effects As specified for the prefix increment operation of
+\effects
+As specified for the prefix increment operation of
 Input iterators\iref{input.iterators}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 
 \end{itemdescr}
 
@@ -14674,7 +14904,8 @@ directory_iterator begin(directory_iterator iter) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{iter}.
+\returns
+\tcode{iter}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{end}!\idxcode{directory_iterator}}%
@@ -14684,7 +14915,8 @@ directory_iterator end(const directory_iterator&) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{directory_iterator()}.
+\returns
+\tcode{directory_iterator()}.
 \end{itemdescr}
 
 \rSec2[fs.class.rec.dir.itr]{Class \tcode{recursive_directory_iterator}}
@@ -14766,7 +14998,8 @@ recursive_directory_iterator() noexcept;
 \begin{itemdescr}
 
 \pnum
-\effects Constructs the end iterator.
+\effects
+Constructs the end iterator.
 
 \end{itemdescr}
 
@@ -14782,7 +15015,8 @@ recursive_directory_iterator(const path& p, error_code& ec);
 \begin{itemdescr}
 
 \pnum
-\effects Constructs an iterator representing the first
+\effects
+Constructs an iterator representing the first
 entry in the directory to which \tcode{p} resolves, if any; otherwise, the end iterator.
 However, if
 \begin{codeblock}
@@ -14793,11 +15027,13 @@ that permission to access \tcode{p} is denied, constructs the end iterator
 and does not report an error.
 
 \pnum
-\ensures \tcode{options() == options} for the signatures with a
+\ensures
+\tcode{options() == options} for the signatures with a
 \tcode{directory_options} argument, otherwise \tcode{options() == directory_options::none}.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 
 \pnum
 \begin{note} To iterate over the current directory, use \tcode{recursive_directory_iterator(".")}
@@ -14816,7 +15052,8 @@ recursive_directory_iterator(const recursive_directory_iterator& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an object of class \tcode{recursive_directory_iterator}.
+\effects
+Constructs an object of class \tcode{recursive_directory_iterator}.
 
 \pnum
 \ensures
@@ -14834,10 +15071,12 @@ recursive_directory_iterator(recursive_directory_iterator&& rhs) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an object of class \tcode{recursive_directory_iterator}.
+\effects
+Constructs an object of class \tcode{recursive_directory_iterator}.
 
 \pnum
-\ensures \tcode{options()}, \tcode{depth()},
+\ensures
+\tcode{options()}, \tcode{depth()},
   and \tcode{recursion_pending()} have the values that
   \tcode{rhs.options()}, \tcode{rhs.depth()}, and
   \tcode{rhs.recursion_pending()}, respectively, had before the function call.
@@ -14850,7 +15089,8 @@ recursive_directory_iterator& operator=(const recursive_directory_iterator& rhs)
 
 \begin{itemdescr}
 \pnum
-\effects If \tcode{*this} and \tcode{rhs} are the same
+\effects
+If \tcode{*this} and \tcode{rhs} are the same
   object, the member has no effect.
 
 \pnum
@@ -14862,7 +15102,8 @@ recursive_directory_iterator& operator=(const recursive_directory_iterator& rhs)
 \end{itemize}
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{recursive_directory_iterator}%
@@ -14872,16 +15113,19 @@ recursive_directory_iterator& operator=(recursive_directory_iterator&& rhs) noex
 
 \begin{itemdescr}
 \pnum
-\effects If \tcode{*this} and \tcode{rhs} are the same
+\effects
+If \tcode{*this} and \tcode{rhs} are the same
 object, the member has no effect.
 
 \pnum
-\ensures \tcode{options()}, \tcode{depth()},
+\ensures
+\tcode{options()}, \tcode{depth()},
 and \tcode{recursion_pending()} have the values that \tcode{rhs.options()},
 \tcode{rhs.depth()}, and \tcode{rhs.recursion_pending()}, respectively, had before the function call.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{options}{recursive_directory_iterator}%
@@ -14891,12 +15135,14 @@ directory_options options() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the argument passed to the constructor for the
+\returns
+The value of the argument passed to the constructor for the
 \tcode{options} parameter, if present, otherwise
 \tcode{directory_options::none}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \indexlibrarymember{depth}{recursive_directory_iterator}%
@@ -14906,12 +15152,14 @@ int depth() const;
 
 \begin{itemdescr}
 \pnum
-\returns The current depth of the directory tree being traversed. \begin{note}
+\returns
+The current depth of the directory tree being traversed. \begin{note}
   The initial directory is depth \tcode{0}, its immediate subdirectories are depth \tcode{1},
   and so forth. \end{note}
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \indexlibrarymember{recursion_pending}{recursive_directory_iterator}%
@@ -14921,12 +15169,14 @@ bool recursion_pending() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{true} if \tcode{disable_recursion_pending()}
+\returns
+\tcode{true} if \tcode{disable_recursion_pending()}
   has not been called subsequent to the prior construction or increment
   operation, otherwise \tcode{false}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \indexlibrarymember{increment}{recursive_directory_iterator}%
@@ -14938,7 +15188,8 @@ recursive_directory_iterator& increment(error_code& ec);
 
 \begin{itemdescr}
 \pnum
-\effects As specified for the prefix increment operation of
+\effects
+As specified for the prefix increment operation of
 Input iterators\iref{input.iterators},
 except that:
 
@@ -14963,10 +15214,12 @@ treated as an empty directory and no error is reported.
 \end{itemize}
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \indexlibrarymember{pop}{recursive_directory_iterator}%
@@ -14977,16 +15230,19 @@ void pop(error_code& ec);
 
 \begin{itemdescr}
 \pnum
-\effects If \tcode{depth() == 0}, set \tcode{*this} to \tcode{recursive_directory_iterator()}.
+\effects
+If \tcode{depth() == 0}, set \tcode{*this} to \tcode{recursive_directory_iterator()}.
   Otherwise, cease iteration of the directory currently being
   iterated over, and continue iteration over the parent directory.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \pnum
-\remarks Any copies of the previous value of \tcode{*this}
+\remarks
+Any copies of the previous value of \tcode{*this}
 are no longer required
 to be dereferenceable nor to be in the domain of \tcode{==}.
 
@@ -14997,7 +15253,8 @@ void disable_recursion_pending();
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{recursion_pending() == false}.
+\ensures
+\tcode{recursion_pending() == false}.
 
 \pnum
 \begin{note} \tcode{disable_recursion_pending}\tcode{()} is used to prevent
@@ -15017,7 +15274,8 @@ recursive_directory_iterator begin(recursive_directory_iterator iter) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{iter}.
+\returns
+\tcode{iter}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{end}!\idxcode{recursive_directory_iterator}}%
@@ -15027,7 +15285,8 @@ recursive_directory_iterator end(const recursive_directory_iterator&) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{recursive_directory_iterator()}.
+\returns
+\tcode{recursive_directory_iterator()}.
 \end{itemdescr}
 
 \rSec2[fs.op.funcs]{Filesystem operation functions}
@@ -15052,11 +15311,13 @@ path absolute(const path& p, error_code& ec);
 
 \begin{itemdescr}
 \pnum
-\effects Composes an absolute path referencing the same file system location
+\effects
+Composes an absolute path referencing the same file system location
 as \tcode{p} according to the operating system\iref{fs.conform.os}.
 
 \pnum
-\returns The composed path.
+\returns
+The composed path.
 The signature with argument \tcode{ec} returns \tcode{path()} if an error occurs.
 
 \pnum
@@ -15066,7 +15327,8 @@ unless an error occurs.
 \end{note}
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 
 \pnum
 \begin{note}
@@ -15100,20 +15362,24 @@ path canonical(const path& p, error_code& ec);
 
 \begin{itemdescr}
 \pnum
-\effects Converts \tcode{p} to an absolute
+\effects
+Converts \tcode{p} to an absolute
 path that has no symbolic link, dot, or dot-dot elements
 in its pathname in the generic format.
 
 \pnum
-\returns A path that refers to
+\returns
+A path that refers to
 the same file system object as \tcode{absolute(p)}.
 The signature with argument \tcode{ec} returns \tcode{path()} if an error occurs.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 
 \pnum
-\remarks \tcode{!exists(p)} is an error.
+\remarks
+\tcode{!exists(p)} is an error.
 \end{itemdescr}
 
 \rSec3[fs.op.copy]{Copy}
@@ -15125,7 +15391,8 @@ void copy(const path& from, const path& to);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to
+\effects
+Equivalent to
 \tcode{copy(from, to, copy_options::none)}.
 \end{itemdescr}
 
@@ -15136,7 +15403,8 @@ void copy(const path& from, const path& to, error_code& ec);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to
+\effects
+Equivalent to
 \tcode{copy(from, to, copy_options::none, ec)}.
 \end{itemdescr}
 
@@ -15250,10 +15518,12 @@ Otherwise, no effects.
 \end{itemize}
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 
 \pnum
-\remarks For the signature with argument \tcode{ec}, any
+\remarks
+For the signature with argument \tcode{ec}, any
 library functions called by the implementation shall have an \tcode{error_code} argument if applicable.
 
 \pnum
@@ -15306,11 +15576,13 @@ bool copy_file(const path& from, const path& to, error_code& ec);
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{copy_file(from, to, copy_options::none)} or\\
+\returns
+\tcode{copy_file(from, to, copy_options::none)} or\\
 \tcode{copy_file(from, to, copy_options::none, ec)}, respectively.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 
 \end{itemdescr}
 
@@ -15360,15 +15632,18 @@ Otherwise, no effects.
 \end{itemize}
 
 \pnum
-\returns \tcode{true} if the \tcode{from} file
+\returns
+\tcode{true} if the \tcode{from} file
   was copied, otherwise \tcode{false}. The signature with argument \tcode{ec} returns
   \tcode{false} if an error occurs.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 
 \pnum
-\complexity At most one direct or indirect invocation of \tcode{status(to)}.
+\complexity
+At most one direct or indirect invocation of \tcode{status(to)}.
 \end{itemdescr}
 
 \rSec3[fs.op.copy.symlink]{Copy symlink}
@@ -15382,14 +15657,16 @@ void copy_symlink(const path& existing_symlink, const path& new_symlink,
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to
+\effects
+Equivalent to
 \tcode{\textit{function}(read_symlink(existing_symlink), new_symlink)} or\\
 \tcode{\textit{function}(read_symlink(existing_symlink, ec), new_symlink, ec)}, respectively,
   where in each case \tcode{\textit{function}} is \tcode{create_symlink} or
   \tcode{create_directory_symlink} as appropriate.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -15403,19 +15680,23 @@ bool create_directories(const path& p, error_code& ec);
 
 \begin{itemdescr}
 \pnum
-\effects Calls \tcode{create_directory()} for each element of \tcode{p}
+\effects
+Calls \tcode{create_directory()} for each element of \tcode{p}
   that does not exist.
 
 \pnum
-\returns \tcode{true} if a new directory was created
+\returns
+\tcode{true} if a new directory was created
   for the directory \tcode{p} resolves to,
   otherwise \tcode{false}.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 
 \pnum
-\complexity \bigoh{n} where \textit{n} is the number of elements
+\complexity
+\bigoh{n} where \textit{n} is the number of elements
   of \tcode{p}.
 \end{itemdescr}
 
@@ -15430,17 +15711,20 @@ bool create_directory(const path& p, error_code& ec) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Creates the directory \tcode{p} resolves to,
+\effects
+Creates the directory \tcode{p} resolves to,
   as if by POSIX \tcode{mkdir} with a second argument of
   \tcode{static_cast<int>(perms::all)}.
   If \tcode{mkdir} fails because \tcode{p} resolves to an existing directory,
   no error is reported. Otherwise on failure an error is reported.
 
 \pnum
-\returns \tcode{true} if a new directory was created, otherwise \tcode{false}.
+\returns
+\tcode{true} if a new directory was created, otherwise \tcode{false}.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{create_directory}}%
@@ -15451,7 +15735,8 @@ bool create_directory(const path& p, const path& existing_p, error_code& ec) noe
 
 \begin{itemdescr}
 \pnum
-\effects Creates the
+\effects
+Creates the
   directory \tcode{p} resolves to, with
   attributes copied from directory \tcode{existing_p}. The set of attributes
   copied is operating system dependent.
@@ -15465,12 +15750,14 @@ bool create_directory(const path& p, const path& existing_p, error_code& ec) noe
 \end{note}
 
 \pnum
-\returns \tcode{true} if a new directory was created
+\returns
+\tcode{true} if a new directory was created
   with attributes copied from directory \tcode{existing_p},
   otherwise \tcode{false}.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -15485,14 +15772,17 @@ void create_directory_symlink(const path& to, const path& new_symlink,
 
 \begin{itemdescr}
 \pnum
-\effects Establishes the postcondition, as if by POSIX \tcode{symlink()}.
+\effects
+Establishes the postcondition, as if by POSIX \tcode{symlink()}.
 
 \pnum
-\ensures \tcode{new_symlink} resolves to a symbolic link file that
+\ensures
+\tcode{new_symlink} resolves to a symbolic link file that
   contains an unspecified representation of \tcode{to}.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 
 \pnum
 \begin{note} Some operating systems require symlink creation to
@@ -15517,7 +15807,8 @@ void create_hard_link(const path& to, const path& new_hard_link,
 
 \begin{itemdescr}
 \pnum
-\effects Establishes the postcondition, as if by POSIX \tcode{link()}.
+\effects
+Establishes the postcondition, as if by POSIX \tcode{link()}.
 
 \pnum
 \ensures
@@ -15528,7 +15819,8 @@ void create_hard_link(const path& to, const path& new_hard_link,
 \end{itemize}
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 
 \pnum
 \begin{note} Some operating systems do not support hard links at all or support
@@ -15548,14 +15840,17 @@ void create_symlink(const path& to, const path& new_symlink,
 
 \begin{itemdescr}
 \pnum
-\effects Establishes the postcondition, as if by POSIX \tcode{symlink()}.
+\effects
+Establishes the postcondition, as if by POSIX \tcode{symlink()}.
 
 \pnum
-\ensures \tcode{new_symlink} resolves to a symbolic link file that
+\ensures
+\tcode{new_symlink} resolves to a symbolic link file that
   contains an unspecified representation of \tcode{to}.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 
 \pnum
 \begin{note} Some operating systems do not support symbolic links at all or support
@@ -15574,17 +15869,20 @@ path current_path(error_code& ec);
 
 \begin{itemdescr}
 \pnum
-\returns The absolute path of the current working directory,
+\returns
+The absolute path of the current working directory,
   whose pathname in the native format is
   obtained as if by POSIX \tcode{getcwd()}.
   The signature with argument \tcode{ec} returns \tcode{path()} if an
   error occurs.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 
 \pnum
-\remarks The current working directory is the directory, associated
+\remarks
+The current working directory is the directory, associated
   with the process, that is used as the starting location in pathname resolution
   for relative paths.
 
@@ -15606,13 +15904,16 @@ void current_path(const path& p, error_code& ec) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Establishes the postcondition, as if by POSIX \tcode{chdir()}.
+\effects
+Establishes the postcondition, as if by POSIX \tcode{chdir()}.
 
 \pnum
-\ensures \tcode{equivalent(p, current_path())}.
+\ensures
+\tcode{equivalent(p, current_path())}.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 
 \pnum
 \begin{note} The current path for many operating systems is a dangerous
@@ -15630,7 +15931,8 @@ bool equivalent(const path& p1, const path& p2, error_code& ec) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{true}, if \tcode{p1} and \tcode{p2} resolve to the same file
+\returns
+\tcode{true}, if \tcode{p1} and \tcode{p2} resolve to the same file
   system entity, otherwise \tcode{false}. The signature with argument \tcode{ec}
   returns \tcode{false} if an error occurs.
 
@@ -15645,10 +15947,12 @@ Two paths are considered to resolve to the same file system entity if two
   \end{note}
 
 \pnum
-\remarks \tcode{!exists(p1) || !exists(p2)} is an error.
+\remarks
+\tcode{!exists(p1) || !exists(p2)} is an error.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -15661,7 +15965,8 @@ bool exists(file_status s) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{status_known(s) \&\& s.type() != file_type::not_found}.
+\returns
+\tcode{status_known(s) \&\& s.type() != file_type::not_found}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{exists}}%
@@ -15676,14 +15981,17 @@ Let \tcode{s} be a \tcode{file_status},
 determined as if by \tcode{status(p)} or \tcode{status(p, ec)}, respectively.
 
 \pnum
-\effects The signature with argument \tcode{ec} calls \tcode{ec.clear()}
+\effects
+The signature with argument \tcode{ec} calls \tcode{ec.clear()}
 if \tcode{status_known(s)}.
 
 \pnum
-\returns \tcode{exists(s)}.
+\returns
+\tcode{exists(s)}.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -15714,7 +16022,8 @@ The signature with argument \tcode{ec} returns \tcode{static_cast<uintmax_t>(-1)
 if an error occurs.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -15728,12 +16037,14 @@ uintmax_t hard_link_count(const path& p, error_code& ec) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns The number of hard links for \tcode{p}. The signature
+\returns
+The number of hard links for \tcode{p}. The signature
   with argument \tcode{ec} returns \tcode{static_cast<uintmax_t>(-1)}
   if an error occurs.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -15746,7 +16057,8 @@ bool is_block_file(file_status s) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{s.type() == file_type::block}.
+\returns
+\tcode{s.type() == file_type::block}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{is_block_file}}%
@@ -15757,11 +16069,13 @@ bool is_block_file(const path& p, error_code& ec) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{is_block_file(status(p))} or \tcode{is_block_file(status(p, ec))}, respectively.
+\returns
+\tcode{is_block_file(status(p))} or \tcode{is_block_file(status(p, ec))}, respectively.
 The signature with argument \tcode{ec} returns \tcode{false} if an error occurs.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -15774,7 +16088,8 @@ bool is_character_file(file_status s) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{s.type() == file_type::character}.
+\returns
+\tcode{s.type() == file_type::character}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{is_character_file}}%
@@ -15785,13 +16100,15 @@ bool is_character_file(const path& p, error_code& ec) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{is_character_file(status(p))}
+\returns
+\tcode{is_character_file(status(p))}
   or \tcode{is_character_file(status(p, ec))},
   respectively.\\The signature with argument \tcode{ec} returns \tcode{false}
   if an error occurs.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -15804,7 +16121,8 @@ bool is_directory(file_status s) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{s.type() == file_type::directory}.
+\returns
+\tcode{s.type() == file_type::directory}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{is_directory}}%
@@ -15815,12 +16133,14 @@ bool is_directory(const path& p, error_code& ec) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{is_directory(status(p))} or \tcode{is_directory(status(p, ec))},
+\returns
+\tcode{is_directory(status(p))} or \tcode{is_directory(status(p, ec))},
   respectively. The signature with argument
   \tcode{ec} returns \tcode{false} if an error occurs.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -15861,7 +16181,8 @@ Otherwise:
 \end{itemize}
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -15874,7 +16195,8 @@ bool is_fifo(file_status s) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{s.type() == file_type::fifo}.
+\returns
+\tcode{s.type() == file_type::fifo}.
 \end{itemdescr}
 
 
@@ -15886,11 +16208,13 @@ bool is_fifo(const path& p, error_code& ec) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{is_fifo(status(p))} or \tcode{is_fifo(status(p, ec))}, respectively.
+\returns
+\tcode{is_fifo(status(p))} or \tcode{is_fifo(status(p, ec))}, respectively.
 The signature with argument \tcode{ec} returns \tcode{false} if an error occurs.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -15903,7 +16227,8 @@ bool is_other(file_status s) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{exists(s) \&\& !is_regular_file(s) \&\& !is_directory(s) \&\& !is_symlink(s)}.
+\returns
+\tcode{exists(s) \&\& !is_regular_file(s) \&\& !is_directory(s) \&\& !is_symlink(s)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{is_other}}%
@@ -15914,12 +16239,14 @@ bool is_other(const path& p, error_code& ec) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{is_other(status(p))} or \tcode{is_other(status(p, ec))},
+\returns
+\tcode{is_other(status(p))} or \tcode{is_other(status(p, ec))},
   respectively. The signature with argument \tcode{ec} returns \tcode{false}
   if an error occurs.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -15932,7 +16259,8 @@ bool is_regular_file(file_status s) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{s.type() == file_type::regular}.
+\returns
+\tcode{s.type() == file_type::regular}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{is_regular_file}}%
@@ -15942,10 +16270,12 @@ bool is_regular_file(const path& p);
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{is_regular_file(status(p))}.
+\returns
+\tcode{is_regular_file(status(p))}.
 
 \pnum
-\throws \tcode{filesystem_error} if \tcode{status(p)} would throw \tcode{filesystem_error}.
+\throws
+\tcode{filesystem_error} if \tcode{status(p)} would throw \tcode{filesystem_error}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{is_regular_file}}%
@@ -15955,12 +16285,14 @@ bool is_regular_file(const path& p, error_code& ec) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Sets \tcode{ec} as if by \tcode{status(p, ec)}. \begin{note}
+\effects
+Sets \tcode{ec} as if by \tcode{status(p, ec)}. \begin{note}
 \tcode{file_type::none}, \tcode{file_type::not_found} and
   \tcode{file_type::unknown} cases set \tcode{ec} to error values. To distinguish between cases, call the \tcode{status} function directly. \end{note}
 
 \pnum
-\returns \tcode{is_regular_file(status(p, ec))}.
+\returns
+\tcode{is_regular_file(status(p, ec))}.
 Returns \tcode{false} if an error occurs.
 \end{itemdescr}
 
@@ -15974,7 +16306,8 @@ bool is_socket(file_status s) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{s.type() == file_type::socket}.
+\returns
+\tcode{s.type() == file_type::socket}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{is_socket}}%
@@ -15985,12 +16318,14 @@ bool is_socket(const path& p, error_code& ec) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{is_socket(status(p))} or
+\returns
+\tcode{is_socket(status(p))} or
   \tcode{is_socket(status(p, ec))}, respectively. The signature with argument
   \tcode{ec} returns \tcode{false} if an error occurs.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -16003,7 +16338,8 @@ bool is_symlink(file_status s) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{s.type() == file_type::symlink}.
+\returns
+\tcode{s.type() == file_type::symlink}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{is_symlink}}%
@@ -16014,12 +16350,14 @@ bool is_symlink(const path& p, error_code& ec) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{is_symlink(symlink_status(p))} or \tcode{is_symlink(symlink_status(p, ec))},
+\returns
+\tcode{is_symlink(symlink_status(p))} or \tcode{is_symlink(symlink_status(p, ec))},
   respectively. The signature with argument \tcode{ec} returns \tcode{false}
   if an error occurs.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -16033,14 +16371,16 @@ file_time_type last_write_time(const path& p, error_code& ec) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns The time of last data modification of \tcode{p},
+\returns
+The time of last data modification of \tcode{p},
   determined as if by the value of the POSIX \tcode{stat} class member \tcode{st_mtime}
   obtained as if by POSIX \tcode{stat()}.
   The signature with argument \tcode{ec} returns \tcode{file_time_type::min()}
   if an error occurs.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{last_write_time}}%
@@ -16052,11 +16392,13 @@ void last_write_time(const path& p, file_time_type new_time,
 
 \begin{itemdescr}
 \pnum
-\effects Sets the time of last data modification of the file
+\effects
+Sets the time of last data modification of the file
   resolved to by \tcode{p} to \tcode{new_time}, as if by POSIX \tcode{futimens()}.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 
 \pnum
 \begin{note} A postcondition of \tcode{last_write_time(p) == new_time} is not specified since it might not hold for file systems
@@ -16093,7 +16435,8 @@ void permissions(const path& p, perms prms, perm_options opts, error_code& ec);
   implementation may use some other mechanism. \end{note}
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \rSec3[fs.op.proximate]{Proximate}
@@ -16105,10 +16448,12 @@ path proximate(const path& p, error_code& ec);
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{proximate(p, current_path(), ec)}.
+\returns
+\tcode{proximate(p, current_path(), ec)}.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{proximate}}%
@@ -16119,7 +16464,8 @@ path proximate(const path& p, const path& base, error_code& ec);
 
 \begin{itemdescr}
 \pnum
-\returns For the first form:
+\returns
+For the first form:
 \begin{codeblock}
 weakly_canonical(p).lexically_proximate(weakly_canonical(base));
 \end{codeblock}
@@ -16130,7 +16476,8 @@ weakly_canonical(p, ec).lexically_proximate(weakly_canonical(base, ec));
   or \tcode{path()} at the first error occurrence, if any.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \rSec3[fs.op.read.symlink]{Read symlink}
@@ -16143,13 +16490,15 @@ path read_symlink(const path& p, error_code& ec);
 
 \begin{itemdescr}
 \pnum
-\returns If \tcode{p} resolves to a symbolic
+\returns
+If \tcode{p} resolves to a symbolic
   link, a \tcode{path} object containing the contents of that symbolic
   link. The signature with argument \tcode{ec}
   returns \tcode{path()} if an error occurs.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}. \begin{note} It is an error if \tcode{p} does not
+\throws
+As specified in~\ref{fs.err.report}. \begin{note} It is an error if \tcode{p} does not
   resolve to a symbolic link. \end{note}
 \end{itemdescr}
 
@@ -16162,10 +16511,12 @@ path relative(const path& p, error_code& ec);
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{relative(p, current_path(), ec)}.
+\returns
+\tcode{relative(p, current_path(), ec)}.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{relative}}%
@@ -16176,7 +16527,8 @@ path relative(const path& p, const path& base, error_code& ec);
 
 \begin{itemdescr}
 \pnum
-\returns For the first form:
+\returns
+For the first form:
 \begin{codeblock}
 weakly_canonical(p).lexically_relative(weakly_canonical(base));
 \end{codeblock}
@@ -16187,7 +16539,8 @@ weakly_canonical(p, ec).lexically_relative(weakly_canonical(base, ec));
   or \tcode{path()} at the first error occurrence, if any.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \rSec3[fs.op.remove]{Remove}
@@ -16200,21 +16553,25 @@ bool remove(const path& p, error_code& ec) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects If \tcode{exists(symlink_status(p, ec))}, the file \tcode{p} is
+\effects
+If \tcode{exists(symlink_status(p, ec))}, the file \tcode{p} is
   removed as if by POSIX \tcode{remove()}.
 \begin{note} A symbolic link is itself removed, rather than the file it
   resolves to. \end{note}
 
 \pnum
-\ensures \tcode{exists(symlink_status(p))} is \tcode{false}.
+\ensures
+\tcode{exists(symlink_status(p))} is \tcode{false}.
 
 \pnum
-\returns \tcode{false} if \tcode{p} did not exist,
+\returns
+\tcode{false} if \tcode{p} did not exist,
   otherwise \tcode{true}. The signature with argument \tcode{ec}
   returns \tcode{false} if an error occurs.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -16228,21 +16585,25 @@ uintmax_t remove_all(const path& p, error_code& ec);
 
 \begin{itemdescr}
 \pnum
-\effects Recursively deletes the contents of \tcode{p} if it exists,
+\effects
+Recursively deletes the contents of \tcode{p} if it exists,
   then deletes file \tcode{p} itself, as if by POSIX \tcode{remove()}.
 \begin{note} A symbolic link is itself removed, rather than the file it
   resolves to. \end{note}
 
 \pnum
-\ensures \tcode{exists(symlink_status(p))} is \tcode{false}.
+\ensures
+\tcode{exists(symlink_status(p))} is \tcode{false}.
 
 \pnum
-\returns The number of files removed. The signature with argument
+\returns
+The number of files removed. The signature with argument
   \tcode{ec} returns \tcode{static_cast< uintmax_t>(-1)} if an error
   occurs.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -16256,7 +16617,8 @@ void rename(const path& old_p, const path& new_p, error_code& ec) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Renames \tcode{old_p} to \tcode{new_p}, as if by
+\effects
+Renames \tcode{old_p} to \tcode{new_p}, as if by
   POSIX \tcode{rename()}.
 
 \begin{note}
@@ -16276,7 +16638,8 @@ A symbolic link is itself renamed, rather than the file it resolves to.
 \end{note}
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -16290,11 +16653,13 @@ void resize_file(const path& p, uintmax_t new_size, error_code& ec) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Causes the size that would be returned by \tcode{file_size(p)} to be
+\effects
+Causes the size that would be returned by \tcode{file_size(p)} to be
 equal to \tcode{new_size}, as if by POSIX \tcode{truncate()}.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -16308,7 +16673,8 @@ space_info space(const path& p, error_code& ec) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns An object of type \tcode{space_info}. The value of the \tcode{space_info}
+\returns
+An object of type \tcode{space_info}. The value of the \tcode{space_info}
   object is determined as if by using POSIX \tcode{statvfs}
   to obtain a POSIX \tcode{struct statvfs},
   and then multiplying its \tcode{f_blocks}, \tcode{f_bfree},
@@ -16320,10 +16686,12 @@ space_info space(const path& p, error_code& ec) noexcept;
   \tcode{static_cast<uintmax_t>(-1)} if an error occurs.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 
 \pnum
-\remarks The value of member \tcode{space_info::available}
+\remarks
+The value of member \tcode{space_info::available}
       is operating system dependent. \begin{note} \tcode{available} may be
       less than \tcode{free}. \end{note}
 \end{itemdescr}
@@ -16338,7 +16706,8 @@ file_status status(const path& p);
 
 \begin{itemdescr}
 \pnum
-\effects As if:
+\effects
+As if:
 \begin{codeblock}
 error_code ec;
 file_status result = status(p, ec);
@@ -16348,10 +16717,12 @@ return result;
 \end{codeblock}
 
 \pnum
-\returns See above.
+\returns
+See above.
 
 \pnum
-\throws \tcode{filesystem_error}.
+\throws
+\tcode{filesystem_error}.
 \begin{note} \tcode{result} values of \tcode{file_status(file_type::not_found)}
   and \tcode{file_status(file_type::unknown)} are not considered failures and do not
   cause an exception to be thrown.\end{note}
@@ -16428,7 +16799,8 @@ Otherwise,
 \end{itemize}
 
 \pnum
-\remarks If a symbolic link is encountered during pathname resolution,
+\remarks
+If a symbolic link is encountered during pathname resolution,
       pathname resolution continues using the contents of the symbolic link.
 \end{itemdescr}
 
@@ -16442,7 +16814,8 @@ bool status_known(file_status s) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{s.type() != file_type::none}.
+\returns
+\tcode{s.type() != file_type::none}.
 \end{itemdescr}
 
 
@@ -16456,7 +16829,8 @@ file_status symlink_status(const path& p, error_code& ec) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Same as \tcode{status()}, above,
+\effects
+Same as \tcode{status()}, above,
   except that the attributes
     of \tcode{p} are determined as if by using POSIX \tcode{lstat()}
     to obtain a POSIX \tcode{struct stat}.
@@ -16467,17 +16841,20 @@ where \tcode{m} is determined as if by converting the \tcode{st_mode} member
 of the obtained \tcode{struct stat} to the type \tcode{perms}.
 
 \pnum
-\returns Same as \tcode{status()}, above, except
+\returns
+Same as \tcode{status()}, above, except
       that if the attributes indicate a symbolic link, as if by POSIX \tcode{S_ISLNK},
       returns \tcode{file_status(file_type::symlink, prms)}.
       The signature with argument \tcode{ec} returns
       \tcode{file_status(file_type::none)} if an error occurs.
 
 \pnum
-\remarks Pathname resolution terminates if \tcode{p} names a symbolic link.
+\remarks
+Pathname resolution terminates if \tcode{p} names a symbolic link.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 
@@ -16494,16 +16871,19 @@ path temp_directory_path(error_code& ec);
 Let \tcode{p} be an unspecified directory path suitable for temporary files.
 
 \pnum
-\effects If \tcode{exists(p)} is \tcode{false} or \tcode{is_directory(p)} is
+\effects
+If \tcode{exists(p)} is \tcode{false} or \tcode{is_directory(p)} is
   \tcode{false}, an error is reported\iref{fs.err.report}.
 
 \pnum
-\returns The path \tcode{p}.
+\returns
+The path \tcode{p}.
   The signature with argument \tcode{ec} returns \tcode{path()} if an
   error occurs.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 
 \pnum
 \begin{example} For POSIX-based operating systems, an implementation might
@@ -16526,11 +16906,13 @@ path weakly_canonical(const path& p, error_code& ec);
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{p} with symlinks resolved and
+\returns
+\tcode{p} with symlinks resolved and
   the result normalized\iref{fs.path.generic}.
 
 \pnum
-\effects Using \tcode{status(p)} or \tcode{status(p, ec)}, respectively,
+\effects
+Using \tcode{status(p)} or \tcode{status(p, ec)}, respectively,
   to determine existence,
   return a path composed by \tcode{operator/=}
   from the result of calling \tcode{canonical()}
@@ -16545,15 +16927,18 @@ path weakly_canonical(const path& p, error_code& ec);
   \tcode{path()} is returned at the first error occurrence, if any.
 
 \pnum
-\ensures The returned path is in normal form\iref{fs.path.generic}.
+\ensures
+The returned path is in normal form\iref{fs.path.generic}.
 
 \pnum
-\remarks Implementations should
+\remarks
+Implementations should
   avoid unnecessary normalization such as
   when \tcode{canonical} has already been called on the entirety of \tcode{p}.
 
 \pnum
-\throws As specified in~\ref{fs.err.report}.
+\throws
+As specified in~\ref{fs.err.report}.
 \end{itemdescr}
 
 \rSec1[c.files]{C library files}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -11562,7 +11562,8 @@ behavior.\end{note}
 \pnum
 Implementations are not required to provide behavior that is not supported by
 a particular file system.
-\begin{example} The FAT file system used by some memory cards, camera memory, and
+\begin{example}
+The FAT file system used by some memory cards, camera memory, and
 floppy disks does not support hard links, symlinks, and many other features of
 more capable file systems, so implementations are not required to support those
 features on the FAT file system
@@ -11962,7 +11963,8 @@ operating system dependent
 is the operating system dependent mechanism for resolving
 a pathname to a particular file in a file hierarchy. There may be multiple
 pathnames that resolve to the same file.
-\begin{example} POSIX specifies the mechanism in section 4.11, Pathname resolution.
+\begin{example}
+POSIX specifies the mechanism in section 4.11, Pathname resolution.
 \end{example}
 
 \begin{codeblock}
@@ -12195,7 +12197,9 @@ consisting solely of one and two period characters respectively,
 have special meaning.
 The following characteristics of filenames are operating system dependent:
 \begin{itemize}
-\item The permitted characters. \begin{example} Some operating systems prohibit
+\item The permitted characters.
+\begin{example}
+Some operating systems prohibit
       the ASCII control characters (0x00 -- 0x1F) in filenames. \end{example}
 \begin{note}
 For wide portability, users may wish to limit \grammarterm{filename}
@@ -13059,7 +13063,8 @@ A single slash (\tcode{'/'}) character is used as
 the \grammarterm{directory-separator}.
 
 \pnum
-\begin{example} On an operating system that uses backslash as
+\begin{example}
+On an operating system that uses backslash as
 its \grammarterm{preferred-separator},
 \begin{codeblock}
 path("foo\\bar").generic_string()
@@ -13429,7 +13434,8 @@ bool is_absolute() const;
   contains an absolute path\iref{fs.class.path}, otherwise \tcode{false}.
 
 \pnum
-\begin{example} \tcode{path("/").is_absolute()} is
+\begin{example}
+\tcode{path("/").is_absolute()} is
       \tcode{true} for  POSIX-based operating systems, and \tcode{false} for Windows-based
 operating systems. \end{example}
 \end{itemdescr}
@@ -13708,7 +13714,8 @@ friend bool operator==(const path& lhs, const path& rhs) noexcept;
 \begin{itemize}
 \item Equality is determined by the \tcode{path} non-member \tcode{operator==},
 which considers the two paths' lexical representations only.
-\begin{example} \tcode{path("foo") == "bar"} is never \tcode{true}. \end{example}
+\begin{example}
+\tcode{path("foo") == "bar"} is never \tcode{true}. \end{example}
 \item Equivalence is determined by the \tcode{equivalent()} non-member function, which
 determines if two paths resolve\iref{fs.class.path} to the same file system entity.
 \begin{example}
@@ -15527,7 +15534,8 @@ For the signature with argument \tcode{ec}, any
 library functions called by the implementation shall have an \tcode{error_code} argument if applicable.
 
 \pnum
-\begin{example} Given this directory structure:
+\begin{example}
+Given this directory structure:
 \begin{codeblock}
 /dir1
   file1
@@ -16886,7 +16894,8 @@ The path \tcode{p}.
 As specified in~\ref{fs.err.report}.
 
 \pnum
-\begin{example} For POSIX-based operating systems, an implementation might
+\begin{example}
+For POSIX-based operating systems, an implementation might
   return the path
   supplied by the first environment variable found in the list TMPDIR, TMP, TEMP, TEMPDIR,
   or if none of these are found, \tcode{"/tmp"}.

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -2759,10 +2759,12 @@ ios_base& hexfloat(ios_base& str);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects Calls \tcode{str.setf(ios_base::fixed | ios_base::scientific,
+\pnum
+\effects Calls \tcode{str.setf(ios_base::fixed | ios_base::scientific,
         ios_base::floatfield)}.
 
-\pnum\returns \tcode{str}.
+\pnum
+\returns \tcode{str}.
 \end{itemdescr}
 
 \pnum
@@ -6838,7 +6840,8 @@ unless the expression \tcode{os << x} is well-formed.
 
 \rSec2[std.manip]{Standard manipulators}
 
-\pnum The header \tcode{<iomanip>} defines several functions that support
+\pnum
+The header \tcode{<iomanip>} defines several functions that support
 extractors and inserters that alter information maintained by class
 \tcode{ios_base} and its derived classes.
 

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -106,7 +106,9 @@ the iostream components can be instantiated.
 Concurrent access to a stream object~(\ref{string.streams}, \ref{file.streams}), stream buffer
 object\iref{stream.buffers}, or C Library stream\iref{c.files} by multiple threads may result in
 a data race\iref{intro.multithread} unless otherwise specified\iref{iostream.objects}.
-\begin{note} Data races result in undefined behavior\iref{intro.multithread}. \end{note}
+\begin{note}
+Data races result in undefined behavior\iref{intro.multithread}.
+\end{note}
 
 \pnum
 If one thread makes a library call \textit{a} that writes a value to a stream
@@ -457,7 +459,10 @@ follows the same semantics as mixing such operations on
 as specified in the C standard library.
 
 \pnum
-Concurrent access to a synchronized\iref{ios.members.static} standard iostream object's formatted and unformatted input\iref{istream} and output\iref{ostream} functions or a standard C stream by multiple threads shall not result in a data race\iref{intro.multithread}. \begin{note} Users must still synchronize concurrent use of these objects and streams by multiple threads if they wish to avoid interleaved characters. \end{note}
+Concurrent access to a synchronized\iref{ios.members.static} standard iostream object's formatted and unformatted input\iref{istream} and output\iref{ostream} functions or a standard C stream by multiple threads shall not result in a data race\iref{intro.multithread}.
+\begin{note}
+Users must still synchronize concurrent use of these objects and streams by multiple threads if they wish to avoid interleaved characters.
+\end{note}
 
 \xrefc{7.21.2}
 
@@ -922,12 +927,14 @@ to report errors detected during stream buffer operations.
 
 \pnum
 When throwing \tcode{ios_base::failure} exceptions, implementations should provide
-values of \tcode{ec} that identify the specific reason for the failure. \begin{note}
+values of \tcode{ec} that identify the specific reason for the failure.
+\begin{note}
 Errors arising from the operating system would typically be reported as
 \tcode{system_category()} errors with an error value of the error number
 reported by the operating system. Errors arising from within the stream library would
 typically be reported as \tcode{error_code(io_errc::stream,
-iostream_category())}. \end{note}
+iostream_category())}.
+\end{note}
 
 \indexlibrary{\idxcode{ios_base::failure}!constructor}%
 \begin{itemdecl}
@@ -2776,11 +2783,13 @@ Calls \tcode{str.setf(ios_base::fixed | ios_base::scientific,
 \end{itemdescr}
 
 \pnum
-\begin{note} The more obvious use of
+\begin{note}
+The more obvious use of
 \tcode{ios_base::hex} to specify hexadecimal floating-point format would
 change the meaning of existing well-defined programs. \CppIII{}
 gives no meaning to the combination of \tcode{fixed} and
-\tcode{scientific}.\end{note}
+\tcode{scientific}.
+\end{note}
 
 \indexlibrary{\idxcode{defaultfloat}}%
 \begin{itemdecl}
@@ -7301,7 +7310,9 @@ The expression \tcode{out << put_time(tmb, fmt)} shall have type
 \rSec2[quoted.manip]{Quoted manipulators}
 
 \pnum
-\begin{note} Quoted manipulators provide string insertion and extraction of quoted strings (for example, XML and CSV formats). Quoted manipulators are useful in ensuring that the content of a string with embedded spaces remains unchanged if inserted and then extracted via stream I/O. \end{note}
+\begin{note}
+Quoted manipulators provide string insertion and extraction of quoted strings (for example, XML and CSV formats). Quoted manipulators are useful in ensuring that the content of a string with embedded spaces remains unchanged if inserted and then extracted via stream I/O.
+\end{note}
 
 \indexlibrary{\idxcode{quoted}}%
 \begin{itemdecl}
@@ -9315,7 +9326,8 @@ that associate stream buffers with files and assist
 reading and writing files.
 
 \pnum
-\begin{note} The class template \tcode{basic_filebuf} treats a file as a source or
+\begin{note}
+The class template \tcode{basic_filebuf} treats a file as a source or
 sink of bytes. In an environment that uses a large character set, the file
 typically holds multibyte character sequences and the \tcode{basic_filebuf}
 object converts those multibyte sequences into wide character sequences.
@@ -11525,15 +11537,19 @@ A \defn{hard link} is
 a link to an existing file. Some
 file systems support multiple hard links to a file. If the last hard link to a
 file is removed, the file itself is removed.
-\begin{note} A hard link can be thought of as a shared-ownership smart
-pointer to a file.\end{note}
+\begin{note}
+A hard link can be thought of as a shared-ownership smart
+pointer to a file.
+\end{note}
 A \defn{symbolic link} is
 a type of file with the
 property that when the file is encountered during pathname resolution\iref{fs.class.path}, a string
 stored by the file is used to modify the pathname resolution.
-\begin{note} Symbolic links are often called symlinks. A symbolic link can be thought of as a raw pointer to a file.
+\begin{note}
+Symbolic links are often called symlinks. A symbolic link can be thought of as a raw pointer to a file.
 If the file pointed to does not exist, the symbolic link is said to be a
-``dangling'' symbolic link.\end{note}
+``dangling'' symbolic link.
+\end{note}
 
 \rSec2[fs.conformance]{Conformance}
 
@@ -11544,9 +11560,11 @@ implementable, so the conformance subclauses take that into account.
 \rSec3[fs.conform.9945]{POSIX conformance}
 \pnum
 Some behavior is specified by reference to POSIX\iref{fs.norm.ref}. How such behavior is actually implemented is unspecified.
-\begin{note} This constitutes an ``as if'' rule allowing implementations
+\begin{note}
+This constitutes an ``as if'' rule allowing implementations
 to call native
-operating system or other APIs. \end{note}
+operating system or other APIs.
+\end{note}
 
 \pnum
 Implementations should provide such behavior as it is defined by
@@ -11555,9 +11573,11 @@ behavior defined by POSIX\@. Implementations that do not support exact POSIX
 behavior should provide behavior as close to POSIX behavior as is reasonable given the
 limitations of actual operating systems and file systems. If an implementation cannot provide any
 reasonable behavior, the implementation shall report an error as specified in~\ref{fs.err.report}.
-\begin{note} This allows users to rely on an exception being thrown or
+\begin{note}
+This allows users to rely on an exception being thrown or
 an error code being set when an implementation cannot provide any reasonable
-behavior.\end{note}
+behavior.
+\end{note}
 
 \pnum
 Implementations are not required to provide behavior that is not supported by
@@ -11598,7 +11618,8 @@ Behavior is undefined if calls to functions provided by this subclause introduce
 If the possibility of a file system race would make it unreliable for a
 program to test for a precondition before calling a function described herein,
 \requires is not specified for the function.
-\begin{note} As a design practice, preconditions are not specified when it
+\begin{note}
+As a design practice, preconditions are not specified when it
 is unreasonable for a program to detect them prior to calling the function.
 \end{note}
 
@@ -11632,11 +11653,13 @@ Template parameters named \tcode{InputIterator} shall meet the
 have a value type that is one of the encoded character types.
 
 \pnum
-\begin{note} Use of an encoded character type implies an associated
+\begin{note}
+Use of an encoded character type implies an associated
 character set and encoding.
 Since \tcode{signed char} and \tcode{unsigned char} have no
 implied character set and encoding,
-they are not included as permitted types. \end{note}
+they are not included as permitted types.
+\end{note}
 
 \pnum
 Template parameters named \tcode{Allocator} shall meet the
@@ -11860,7 +11883,8 @@ of file time values.
 \pnum
 Filesystem library functions often provide two overloads, one that
 throws an exception to report file system errors, and another that sets an \tcode{error_code}.
-\begin{note} This supports two common use cases:
+\begin{note}
+This supports two common use cases:
 \begin{itemize}
 \item
 Uses where file system errors are truly exceptional
@@ -12200,7 +12224,8 @@ The following characteristics of filenames are operating system dependent:
 \item The permitted characters.
 \begin{example}
 Some operating systems prohibit
-      the ASCII control characters (0x00 -- 0x1F) in filenames. \end{example}
+      the ASCII control characters (0x00 -- 0x1F) in filenames.
+\end{example}
 \begin{note}
 For wide portability, users may wish to limit \grammarterm{filename}
 characters to the POSIX Portable Filename Character Set: \\
@@ -12233,7 +12258,8 @@ A \grammarterm{root-name} identifies the
 starting location for pathname resolution\iref{fs.class.path}.
 If there are no operating system dependent \grammarterm{root-name}{s},
 at least one \impldefrootname{} \grammarterm{root-name} is required.
-\begin{note} Many operating systems define a name
+\begin{note}
+Many operating systems define a name
 beginning with two \grammarterm{directory-separator} characters
 as a \grammarterm{root-name} that identifies
 network or other resource locations.
@@ -12318,7 +12344,9 @@ be the implementation's functions that convert native-to-generic
 and generic-to-native formats respectively.
 If \placeholder{g=G(n)} for some \placeholder{n}, then \placeholder{G(N(g))=g};
 if \placeholder{n=N(g)} for some \placeholder{g}, then \placeholder{N(G(n))=n}.
-\begin{note} Neither \placeholder{G} nor \placeholder{N} need be invertible. \end{note}
+\begin{note}
+Neither \placeholder{G} nor \placeholder{N} need be invertible.
+\end{note}
 
 \pnum
 If the native format requires paths for regular files to be formatted
@@ -12626,7 +12654,9 @@ object, has no effect. Otherwise,
 sets both respective pathnames of \tcode{*this}
 to the respective pathnames of \tcode{p}.
 \tcode{p} is left in a valid but unspecified state.
-\begin{note} A valid implementation is \tcode{swap(p)}. \end{note}
+\begin{note}
+A valid implementation is \tcode{swap(p)}.
+\end{note}
 
 \pnum
 \returns
@@ -13004,9 +13034,11 @@ operator string_type() const;
 \tcode{native()}.
 
 \pnum
-\begin{note} Conversion to \tcode{string_type} is provided so that an
+\begin{note}
+Conversion to \tcode{string_type} is provided so that an
   object of class \tcode{path} can be given as an argument to existing
-  standard library file stream constructors and open functions. \end{note}
+  standard library file stream constructors and open functions.
+\end{note}
 \end{itemdescr}
 
 \indexlibrarymember{string}{path}%
@@ -13069,7 +13101,8 @@ its \grammarterm{preferred-separator},
 \begin{codeblock}
 path("foo\\bar").generic_string()
 \end{codeblock}
-returns \tcode{"foo/bar"}. \end{example}
+returns \tcode{"foo/bar"}.
+\end{example}
 
 \indexlibrarymember{generic_string}{path}%
 \begin{itemdecl}
@@ -13309,7 +13342,8 @@ path("..bar").extension();         // yields \tcode{".bar"} and \tcode{stem()} i
 \end{example}
 
 \pnum
-\begin{note} The period is included in the return value so that it is
+\begin{note}
+The period is included in the return value so that it is
   possible to distinguish between no extension and an empty extension.
 \end{note}
 
@@ -13437,7 +13471,8 @@ bool is_absolute() const;
 \begin{example}
 \tcode{path("/").is_absolute()} is
       \tcode{true} for  POSIX-based operating systems, and \tcode{false} for Windows-based
-operating systems. \end{example}
+operating systems.
+\end{example}
 \end{itemdescr}
 
 \indexlibrarymember{is_relative}{path}%
@@ -13537,14 +13572,18 @@ but that does not affect \tcode{path} equality.
 \end{example}
 
 \pnum
-\begin{note} If symlink following semantics are desired,
-  use the operational function \tcode{relative()}. \end{note}
+\begin{note}
+If symlink following semantics are desired,
+  use the operational function \tcode{relative()}.
+\end{note}
 
 \pnum
-\begin{note} If normalization\iref{fs.path.generic} is needed
+\begin{note}
+If normalization\iref{fs.path.generic} is needed
   to ensure consistent matching of elements,
   apply \tcode{lexically_normal()} to
-  \tcode{*this}, \tcode{base}, or both. \end{note}
+  \tcode{*this}, \tcode{base}, or both.
+\end{note}
 \end{itemdescr}
 
 \indexlibrarymember{lexically_proximate}{path}%
@@ -13559,14 +13598,18 @@ If the value of \tcode{lexically_relative(base)} is not an empty path,
   return it. Otherwise return \tcode{*this}.
 
 \pnum
-\begin{note} If symlink following semantics are desired,
-  use the operational function \tcode{proximate()}. \end{note}
+\begin{note}
+If symlink following semantics are desired,
+  use the operational function \tcode{proximate()}.
+\end{note}
 
 \pnum
-\begin{note} If normalization\iref{fs.path.generic} is needed
+\begin{note}
+If normalization\iref{fs.path.generic} is needed
   to ensure consistent matching of elements,
   apply \tcode{lexically_normal()} to
-  \tcode{*this}, \tcode{base}, or both. \end{note}
+  \tcode{*this}, \tcode{base}, or both.
+\end{note}
 \end{itemdescr}
 
 \rSec3[fs.path.itr]{Iterators}
@@ -13599,7 +13642,8 @@ the forward traversal order is as follows:
 \item The \grammarterm{root-directory} element, if present.
 \begin{note}
 The generic format is required to ensure lexicographical
-comparison works correctly. \end{note}
+comparison works correctly.
+\end{note}
 \item Each successive \grammarterm{filename} element, if present.
 \item An empty element, if a trailing non-root \grammarterm{directory-separator}
 is present.
@@ -13644,7 +13688,9 @@ template<class charT, class traits>
 \pnum
 \effects
 Equivalent to \tcode{os << quoted(p.string<charT, traits>())}.
-\begin{note} The \tcode{quoted} function is described in~\ref{quoted.manip}. \end{note}
+\begin{note}
+The \tcode{quoted} function is described in~\ref{quoted.manip}.
+\end{note}
 
 \pnum
 \returns
@@ -13710,12 +13756,14 @@ friend bool operator==(const path& lhs, const path& rhs) noexcept;
 
 \indextext{path equality}
 \pnum
-\begin{note} Path equality and path equivalence have different semantics.
+\begin{note}
+Path equality and path equivalence have different semantics.
 \begin{itemize}
 \item Equality is determined by the \tcode{path} non-member \tcode{operator==},
 which considers the two paths' lexical representations only.
 \begin{example}
-\tcode{path("foo") == "bar"} is never \tcode{true}. \end{example}
+\tcode{path("foo") == "bar"} is never \tcode{true}.
+\end{example}
 \item Equivalence is determined by the \tcode{equivalent()} non-member function, which
 determines if two paths resolve\iref{fs.class.path} to the same file system entity.
 \begin{example}
@@ -13724,7 +13772,8 @@ determines if two paths resolve\iref{fs.class.path} to the same file system enti
 \end{itemize}
 Programmers wishing to determine if two paths are ``the same'' must decide if
   ``the same'' means ``the same representation'' or ``resolve to the same actual
-  file'', and choose the appropriate function accordingly. \end{note}
+  file'', and choose the appropriate function accordingly.
+\end{note}
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{path}%
@@ -13890,7 +13939,8 @@ sequence, with the meanings listed in \tref{fs.enum.path.format}.
   \begin{note}
   For POSIX-based systems, native and generic formats are equivalent
   and the character sequence should always be interpreted in the same way.
-  \end{note} \\\rowsep
+  \end{note}
+\\\rowsep
 \end{floattable}
 
 \rSec3[fs.enum.file.type]{Enum class \tcode{file_type}}
@@ -13912,9 +13962,13 @@ The values of the constants are distinct.
 The type of the file has not been determined or an error occurred while
     trying to determine the type. \\ \rowsep
 \tcode{not_found} &
-Pseudo-type indicating the file was not found. \begin{note} The file
+Pseudo-type indicating the file was not found.
+\begin{note}
+The file
 not being found is not considered an error while determining the
-type of a file. \end{note} \\ \rowsep
+type of a file.
+\end{note}
+\\ \rowsep
 \tcode{regular} & Regular file \\ \rowsep
 \tcode{directory} & Directory file \\ \rowsep
 \tcode{symlink} & Symbolic link file \\ \rowsep
@@ -14697,7 +14751,8 @@ sequence of \tcode{directory_entry} elements representing the
 path and any cached attribute values\iref{fs.class.directory.entry}
 for each file in a directory
 or in an \impldef{type of a directory-like file} directory-like file type.
-\begin{note} For iteration into sub-directories, see class \tcode{recursive_directory_iterator}\iref{fs.class.rec.dir.itr}.
+\begin{note}
+For iteration into sub-directories, see class \tcode{recursive_directory_iterator}\iref{fs.class.rec.dir.itr}.
 \end{note}
 
 \begin{codeblock}
@@ -14835,7 +14890,9 @@ and does not report an error.
 As specified in~\ref{fs.err.report}.
 
 \pnum
-\begin{note} To iterate over the current directory, use \tcode{directory_iterator(".")} rather than \tcode{directory_iterator("")}. \end{note}
+\begin{note}
+To iterate over the current directory, use \tcode{directory_iterator(".")} rather than \tcode{directory_iterator("")}.
+\end{note}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{directory_iterator}!constructor}%
@@ -14992,8 +15049,10 @@ The behavior of a \tcode{recursive_directory_iterator} is the same
 as a \tcode{directory_iterator} unless otherwise specified.
 
 \pnum
-\begin{note} If the directory structure being iterated over contains cycles
-then the end iterator may be unreachable. \end{note}
+\begin{note}
+If the directory structure being iterated over contains cycles
+then the end iterator may be unreachable.
+\end{note}
 
 \rSec3[fs.rec.dir.itr.members]{Members}
 
@@ -15043,13 +15102,17 @@ and does not report an error.
 As specified in~\ref{fs.err.report}.
 
 \pnum
-\begin{note} To iterate over the current directory, use \tcode{recursive_directory_iterator(".")}
- rather than \tcode{recursive_directory_iterator("")}. \end{note}
+\begin{note}
+To iterate over the current directory, use \tcode{recursive_directory_iterator(".")}
+ rather than \tcode{recursive_directory_iterator("")}.
+\end{note}
 
 \pnum
-\begin{note} By default, \tcode{recursive_directory_iterator} does not
+\begin{note}
+By default, \tcode{recursive_directory_iterator} does not
 follow directory symlinks. To follow directory symlinks, specify \tcode{options} as
-\tcode{directory_options::follow_directory_symlink}. \end{note}
+\tcode{directory_options::follow_directory_symlink}.
+\end{note}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{recursive_directory_iterator}!constructor}%
@@ -15160,9 +15223,11 @@ int depth() const;
 \begin{itemdescr}
 \pnum
 \returns
-The current depth of the directory tree being traversed. \begin{note}
+The current depth of the directory tree being traversed.
+\begin{note}
   The initial directory is depth \tcode{0}, its immediate subdirectories are depth \tcode{1},
-  and so forth. \end{note}
+  and so forth.
+\end{note}
 
 \pnum
 \throws
@@ -15264,8 +15329,10 @@ void disable_recursion_pending();
 \tcode{recursion_pending() == false}.
 
 \pnum
-\begin{note} \tcode{disable_recursion_pending}\tcode{()} is used to prevent
-  unwanted recursion into a directory. \end{note}
+\begin{note}
+\tcode{disable_recursion_pending}\tcode{()} is used to prevent
+  unwanted recursion into a directory.
+\end{note}
 \end{itemdescr}
 
 \rSec3[fs.rec.dir.itr.nonmembers]{Non-member functions}
@@ -15303,10 +15370,12 @@ Filesystem operation functions query or modify files, including directories,
 in external storage.
 
 \pnum
-\begin{note} Because hardware failures, network failures, file system races\iref{fs.race.behavior},
+\begin{note}
+Because hardware failures, network failures, file system races\iref{fs.race.behavior},
 and many other kinds of errors occur frequently in file system operations, users should be aware
 that any filesystem operation function, no matter how apparently innocuous, may encounter
-an error; see~\ref{fs.err.report}. \end{note}
+an error; see~\ref{fs.err.report}.
+\end{note}
 
 \rSec3[fs.op.absolute]{Absolute}
 
@@ -15750,7 +15819,8 @@ Creates the
   copied is operating system dependent.
   If \tcode{mkdir} fails because \tcode{p} resolves to an existing directory,
   no error is reported. Otherwise on failure an error is reported.
-\begin{note} For POSIX-based operating systems, the
+\begin{note}
+For POSIX-based operating systems, the
       attributes are those copied by native API \tcode{stat(existing_p.c_str(), \&attributes_stat)}
       followed by \tcode{mkdir(p.c_str(), attributes_stat.st_mode)}. For
       Windows-based operating systems, the attributes are those copied by native
@@ -15793,15 +15863,19 @@ Establishes the postcondition, as if by POSIX \tcode{symlink()}.
 As specified in~\ref{fs.err.report}.
 
 \pnum
-\begin{note} Some operating systems require symlink creation to
-  identify that the link is to a directory. Portable code should use \tcode{create_directory_symlink()} to create directory symlinks rather than \tcode{create_symlink()} \end{note}
+\begin{note}
+Some operating systems require symlink creation to
+  identify that the link is to a directory. Portable code should use \tcode{create_directory_symlink()} to create directory symlinks rather than \tcode{create_symlink()}
+\end{note}
 
 \pnum
-\begin{note} Some operating systems do not support symbolic links at all or support
+\begin{note}
+Some operating systems do not support symbolic links at all or support
   them only for regular files.
   Some file systems (such as the FAT file system) do not
   support
-  symbolic links regardless of the operating system. \end{note}
+  symbolic links regardless of the operating system.
+\end{note}
 \end{itemdescr}
 
 \rSec3[fs.op.create.hard.lk]{Create hard link}
@@ -15831,10 +15905,12 @@ Establishes the postcondition, as if by POSIX \tcode{link()}.
 As specified in~\ref{fs.err.report}.
 
 \pnum
-\begin{note} Some operating systems do not support hard links at all or support
+\begin{note}
+Some operating systems do not support hard links at all or support
   them only for regular files. Some file systems (such as the FAT file system)
   do not support hard links regardless of the operating system.
-  Some file systems limit the number of links per file. \end{note}
+  Some file systems limit the number of links per file.
+\end{note}
 \end{itemdescr}
 
 \rSec3[fs.op.create.symlink]{Create symlink}
@@ -15861,10 +15937,12 @@ Establishes the postcondition, as if by POSIX \tcode{symlink()}.
 As specified in~\ref{fs.err.report}.
 
 \pnum
-\begin{note} Some operating systems do not support symbolic links at all or support
+\begin{note}
+Some operating systems do not support symbolic links at all or support
   them only for regular files.
   Some file systems (such as the FAT file system) do not
-  support symbolic links regardless of the operating system. \end{note}
+  support symbolic links regardless of the operating system.
+\end{note}
 \end{itemdescr}
 
 \rSec3[fs.op.current.path]{Current path}
@@ -15895,13 +15973,17 @@ The current working directory is the directory, associated
   for relative paths.
 
 \pnum
-\begin{note} The \tcode{current_path()} name was chosen to emphasize that the returned value is a
-  path, not just a single directory name. \end{note}
+\begin{note}
+The \tcode{current_path()} name was chosen to emphasize that the returned value is a
+  path, not just a single directory name.
+\end{note}
 
 \pnum
-\begin{note} The current path as returned by many operating systems is a dangerous
+\begin{note}
+The current path as returned by many operating systems is a dangerous
   global variable. It may be changed unexpectedly by third-party or system
-  library functions, or by another thread. \end{note}
+  library functions, or by another thread.
+\end{note}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{current_path}}%
@@ -15924,9 +16006,11 @@ Establishes the postcondition, as if by POSIX \tcode{chdir()}.
 As specified in~\ref{fs.err.report}.
 
 \pnum
-\begin{note} The current path for many operating systems is a dangerous
+\begin{note}
+The current path for many operating systems is a dangerous
   global state. It may be changed unexpectedly by a third-party or system
-  library functions, or by another thread. \end{note}
+  library functions, or by another thread.
+\end{note}
 \end{itemdescr}
 
 \rSec3[fs.op.equivalent]{Equivalent}
@@ -16294,9 +16378,11 @@ bool is_regular_file(const path& p, error_code& ec) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Sets \tcode{ec} as if by \tcode{status(p, ec)}. \begin{note}
+Sets \tcode{ec} as if by \tcode{status(p, ec)}.
+\begin{note}
 \tcode{file_type::none}, \tcode{file_type::not_found} and
-  \tcode{file_type::unknown} cases set \tcode{ec} to error values. To distinguish between cases, call the \tcode{status} function directly. \end{note}
+  \tcode{file_type::unknown} cases set \tcode{ec} to error values. To distinguish between cases, call the \tcode{status} function directly.
+\end{note}
 
 \pnum
 \returns
@@ -16409,8 +16495,10 @@ Sets the time of last data modification of the file
 As specified in~\ref{fs.err.report}.
 
 \pnum
-\begin{note} A postcondition of \tcode{last_write_time(p) == new_time} is not specified since it might not hold for file systems
-  with coarse time granularity. \end{note}
+\begin{note}
+A postcondition of \tcode{last_write_time(p) == new_time} is not specified since it might not hold for file systems
+  with coarse time granularity.
+\end{note}
 \end{itemdescr}
 
 \rSec3[fs.op.permissions]{Permissions}
@@ -16439,8 +16527,10 @@ void permissions(const path& p, perms prms, perm_options opts, error_code& ec);
   The action is applied as if by POSIX \tcode{fchmodat()}.
 
 \pnum
-\begin{note} Conceptually permissions are viewed as bits, but the actual
-  implementation may use some other mechanism. \end{note}
+\begin{note}
+Conceptually permissions are viewed as bits, but the actual
+  implementation may use some other mechanism.
+\end{note}
 
 \pnum
 \throws
@@ -16506,8 +16596,11 @@ If \tcode{p} resolves to a symbolic
 
 \pnum
 \throws
-As specified in~\ref{fs.err.report}. \begin{note} It is an error if \tcode{p} does not
-  resolve to a symbolic link. \end{note}
+As specified in~\ref{fs.err.report}.
+\begin{note}
+It is an error if \tcode{p} does not
+  resolve to a symbolic link.
+\end{note}
 \end{itemdescr}
 
 \rSec3[fs.op.relative]{Relative}
@@ -16564,8 +16657,10 @@ bool remove(const path& p, error_code& ec) noexcept;
 \effects
 If \tcode{exists(symlink_status(p, ec))}, the file \tcode{p} is
   removed as if by POSIX \tcode{remove()}.
-\begin{note} A symbolic link is itself removed, rather than the file it
-  resolves to. \end{note}
+\begin{note}
+A symbolic link is itself removed, rather than the file it
+  resolves to.
+\end{note}
 
 \pnum
 \ensures
@@ -16596,8 +16691,10 @@ uintmax_t remove_all(const path& p, error_code& ec);
 \effects
 Recursively deletes the contents of \tcode{p} if it exists,
   then deletes file \tcode{p} itself, as if by POSIX \tcode{remove()}.
-\begin{note} A symbolic link is itself removed, rather than the file it
-  resolves to. \end{note}
+\begin{note}
+A symbolic link is itself removed, rather than the file it
+  resolves to.
+\end{note}
 
 \pnum
 \ensures
@@ -16700,8 +16797,11 @@ As specified in~\ref{fs.err.report}.
 \pnum
 \remarks
 The value of member \tcode{space_info::available}
-      is operating system dependent. \begin{note} \tcode{available} may be
-      less than \tcode{free}. \end{note}
+      is operating system dependent.
+\begin{note}
+\tcode{available} may be
+      less than \tcode{free}.
+\end{note}
 \end{itemdescr}
 
 
@@ -16731,9 +16831,11 @@ See above.
 \pnum
 \throws
 \tcode{filesystem_error}.
-\begin{note} \tcode{result} values of \tcode{file_status(file_type::not_found)}
+\begin{note}
+\tcode{result} values of \tcode{file_status(file_type::not_found)}
   and \tcode{file_status(file_type::unknown)} are not considered failures and do not
-  cause an exception to be thrown.\end{note}
+  cause an exception to be thrown.
+\end{note}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{status}}%
@@ -16750,9 +16852,11 @@ If possible, determines the attributes
       If, during attribute determination, the underlying file system API reports
     an error, sets \tcode{ec} to indicate the specific error reported.
     Otherwise, \tcode{ec.clear()}.
-\begin{note} This allows users to inspect the specifics of underlying
+\begin{note}
+This allows users to inspect the specifics of underlying
       API errors even when the value returned by \tcode{status()} is not
-      \tcode{file_status(file_type::none)}. \end{note}
+      \tcode{file_status(file_type::none)}.
+\end{note}
 
 \pnum
 Let \tcode{prms} denote the result of \tcode{(m \& perms::mask)},
@@ -16773,22 +16877,28 @@ If \tcode{ec != error_code()}:
       \tcode{file_status(file_type::unknown)}.
 \item Otherwise, returns \tcode{file_status(file_type::none)}.
 \end{itemize}
-\begin{note} These semantics distinguish between \tcode{p} being known not to exist, \tcode{p} existing but not being able to determine its attributes,
+\begin{note}
+These semantics distinguish between \tcode{p} being known not to exist, \tcode{p} existing but not being able to determine its attributes,
         and there being an error that prevents even knowing if \tcode{p} exists. These
-        distinctions are important to some use cases. \end{note}
+        distinctions are important to some use cases.
+\end{note}
 \item
 Otherwise,
 \begin{itemize}
 \item If the attributes indicate a regular file, as if by POSIX \tcode{S_ISREG},
-      returns \tcode{file_status(file_type::regular, prms)}. \begin{note}
+      returns \tcode{file_status(file_type::regular, prms)}.
+\begin{note}
       \tcode{file_type::regular} implies appropriate \tcode{<fstream>} operations
       would succeed, assuming no hardware, permission, access, or file system
       race errors. Lack of \tcode{file_type::regular} does not necessarily imply
-      \tcode{<fstream>} operations would fail on a directory.  \end{note}
+      \tcode{<fstream>} operations would fail on a directory.
+\end{note}
 \item Otherwise, if the attributes indicate a directory, as if by POSIX
       \tcode{S_ISDIR}, returns \tcode{file_status(file_type::directory, prms)}.
-      \begin{note} \tcode{file_type::directory} implies that calling
-      \tcode{directory_iterator(p)} would succeed.  \end{note}
+      \begin{note}
+\tcode{file_type::directory} implies that calling
+      \tcode{directory_iterator(p)} would succeed.
+\end{note}
 \item Otherwise, if the attributes indicate a block special file, as if by
       POSIX \tcode{S_ISBLK}, returns \tcode{file_status(file_type::block, prms)}.
 \item Otherwise, if the attributes indicate a character special file, as if

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -4058,7 +4058,6 @@ copying with moving.
 
 \pnum
 \begin{example}
-
 \begin{codeblock}
 list<string> s;
 // populate the list \tcode{s}

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -6380,7 +6380,8 @@ template<class C> constexpr auto cbegin(const C& c) noexcept(noexcept(std::begin
   -> decltype(std::begin(c));
 \end{itemdecl}
 \begin{itemdescr}
-\pnum \returns \tcode{std::begin(c)}.
+\pnum
+\returns \tcode{std::begin(c)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{cend(const C\&)}}%
@@ -6389,7 +6390,8 @@ template<class C> constexpr auto cend(const C& c) noexcept(noexcept(std::end(c))
   -> decltype(std::end(c));
 \end{itemdecl}
 \begin{itemdescr}
-\pnum \returns \tcode{std::end(c)}.
+\pnum
+\returns \tcode{std::end(c)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{rbegin(C\&)}}%
@@ -6398,7 +6400,8 @@ template<class C> constexpr auto rbegin(C& c) -> decltype(c.rbegin());
 template<class C> constexpr auto rbegin(const C& c) -> decltype(c.rbegin());
 \end{itemdecl}
 \begin{itemdescr}
-\pnum \returns \tcode{c.rbegin()}.
+\pnum
+\returns \tcode{c.rbegin()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{rend(C\&)}}%
@@ -6407,7 +6410,8 @@ template<class C> constexpr auto rend(C& c) -> decltype(c.rend());
 template<class C> constexpr auto rend(const C& c) -> decltype(c.rend());
 \end{itemdecl}
 \begin{itemdescr}
-\pnum \returns \tcode{c.rend()}.
+\pnum
+\returns \tcode{c.rend()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{rbegin(T (\&array)[N])}}%
@@ -6415,7 +6419,8 @@ template<class C> constexpr auto rend(const C& c) -> decltype(c.rend());
 template<class T, size_t N> constexpr reverse_iterator<T*> rbegin(T (&array)[N]);
 \end{itemdecl}
 \begin{itemdescr}
-\pnum \returns \tcode{reverse_iterator<T*>(array + N)}.
+\pnum
+\returns \tcode{reverse_iterator<T*>(array + N)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{rend(T (\&array)[N])}}%
@@ -6423,7 +6428,8 @@ template<class T, size_t N> constexpr reverse_iterator<T*> rbegin(T (&array)[N])
 template<class T, size_t N> constexpr reverse_iterator<T*> rend(T (&array)[N]);
 \end{itemdecl}
 \begin{itemdescr}
-\pnum \returns \tcode{reverse_iterator<T*>(array)}.
+\pnum
+\returns \tcode{reverse_iterator<T*>(array)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{rbegin(initializer_list<E>)}}%
@@ -6431,7 +6437,8 @@ template<class T, size_t N> constexpr reverse_iterator<T*> rend(T (&array)[N]);
 template<class E> constexpr reverse_iterator<const E*> rbegin(initializer_list<E> il);
 \end{itemdecl}
 \begin{itemdescr}
-\pnum \returns \tcode{reverse_iterator<const E*>(il.end())}.
+\pnum
+\returns \tcode{reverse_iterator<const E*>(il.end())}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{rend(initializer_list<E>)}}%
@@ -6439,7 +6446,8 @@ template<class E> constexpr reverse_iterator<const E*> rbegin(initializer_list<E
 template<class E> constexpr reverse_iterator<const E*> rend(initializer_list<E> il);
 \end{itemdecl}
 \begin{itemdescr}
-\pnum \returns \tcode{reverse_iterator<const E*>(il.begin())}.
+\pnum
+\returns \tcode{reverse_iterator<const E*>(il.begin())}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{crbegin(const C\& c)}}%
@@ -6447,7 +6455,8 @@ template<class E> constexpr reverse_iterator<const E*> rend(initializer_list<E> 
 template<class C> constexpr auto crbegin(const C& c) -> decltype(std::rbegin(c));
 \end{itemdecl}
 \begin{itemdescr}
-\pnum \returns \tcode{std::rbegin(c)}.
+\pnum
+\returns \tcode{std::rbegin(c)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{crend(const C\& c)}}%
@@ -6455,7 +6464,8 @@ template<class C> constexpr auto crbegin(const C& c) -> decltype(std::rbegin(c))
 template<class C> constexpr auto crend(const C& c) -> decltype(std::rend(c));
 \end{itemdecl}
 \begin{itemdescr}
-\pnum \returns \tcode{std::rend(c)}.
+\pnum
+\returns \tcode{std::rend(c)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{size(C\& c)}}%
@@ -6463,7 +6473,8 @@ template<class C> constexpr auto crend(const C& c) -> decltype(std::rend(c));
 template<class C> constexpr auto size(const C& c) -> decltype(c.size());
 \end{itemdecl}
 \begin{itemdescr}
-\pnum \returns \tcode{c.size()}.
+\pnum
+\returns \tcode{c.size()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{size(T (\&array)[N])}}%
@@ -6471,7 +6482,8 @@ template<class C> constexpr auto size(const C& c) -> decltype(c.size());
 template<class T, size_t N> constexpr size_t size(const T (&array)[N]) noexcept;
 \end{itemdecl}
 \begin{itemdescr}
-\pnum \returns \tcode{N}.
+\pnum
+\returns \tcode{N}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{ssize(C\& c)}}%
@@ -6480,7 +6492,8 @@ template<class C> constexpr auto ssize(const C& c)
   -> common_type_t<ptrdiff_t, make_signed_t<decltype(c.size())>>;
 \end{itemdecl}
 \begin{itemdescr}
-\pnum \returns
+\pnum
+\returns
 \begin{codeblock}
 static_cast<common_type_t<ptrdiff_t, make_signed_t<decltype(c.size())>>>(c.size())
 \end{codeblock}
@@ -6491,7 +6504,8 @@ static_cast<common_type_t<ptrdiff_t, make_signed_t<decltype(c.size())>>>(c.size(
 template<class T, ptrdiff_t N> constexpr ptrdiff_t ssize(const T (&array)[N]) noexcept;
 \end{itemdecl}
 \begin{itemdescr}
-\pnum \returns \tcode{N}.
+\pnum
+\returns \tcode{N}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{empty(C\& c)}}%
@@ -6499,7 +6513,8 @@ template<class T, ptrdiff_t N> constexpr ptrdiff_t ssize(const T (&array)[N]) no
 template<class C> [[nodiscard]] constexpr auto empty(const C& c) -> decltype(c.empty());
 \end{itemdecl}
 \begin{itemdescr}
-\pnum \returns \tcode{c.empty()}.
+\pnum
+\returns \tcode{c.empty()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{empty(T (\&array)[N])}}%
@@ -6507,7 +6522,8 @@ template<class C> [[nodiscard]] constexpr auto empty(const C& c) -> decltype(c.e
 template<class T, size_t N> [[nodiscard]] constexpr bool empty(const T (&array)[N]) noexcept;
 \end{itemdecl}
 \begin{itemdescr}
-\pnum \returns \tcode{false}.
+\pnum
+\returns \tcode{false}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{empty(initializer_list<E>)}}%
@@ -6515,7 +6531,8 @@ template<class T, size_t N> [[nodiscard]] constexpr bool empty(const T (&array)[
 template<class E> [[nodiscard]] constexpr bool empty(initializer_list<E> il) noexcept;
 \end{itemdecl}
 \begin{itemdescr}
-\pnum \returns \tcode{il.size() == 0}.
+\pnum
+\returns \tcode{il.size() == 0}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{data(C\& c)}}%
@@ -6524,7 +6541,8 @@ template<class C> constexpr auto data(C& c) -> decltype(c.data());
 template<class C> constexpr auto data(const C& c) -> decltype(c.data());
 \end{itemdecl}
 \begin{itemdescr}
-\pnum \returns \tcode{c.data()}.
+\pnum
+\returns \tcode{c.data()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{data(T (\&array)[N])}}%
@@ -6532,7 +6550,8 @@ template<class C> constexpr auto data(const C& c) -> decltype(c.data());
 template<class T, size_t N> constexpr T* data(T (&array)[N]) noexcept;
 \end{itemdecl}
 \begin{itemdescr}
-\pnum \returns \tcode{array}.
+\pnum
+\returns \tcode{array}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{data(initializer_list<E>)}}%
@@ -6540,5 +6559,6 @@ template<class T, size_t N> constexpr T* data(T (&array)[N]) noexcept;
 template<class E> constexpr const E* data(initializer_list<E> il) noexcept;
 \end{itemdecl}
 \begin{itemdescr}
-\pnum \returns \tcode{il.begin()}.
+\pnum
+\returns \tcode{il.begin()}.
 \end{itemdescr}

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -546,9 +546,11 @@ as \defnx{constant iterators}{constant iterator}.
 In addition to the requirements in this subclause,
 the nested \grammarterm{typedef-name}{s} specified in \ref{iterator.traits}
 shall be provided for the iterator type.
-\begin{note} Either the iterator type must provide the \grammarterm{typedef-name}{s} directly
+\begin{note}
+Either the iterator type must provide the \grammarterm{typedef-name}{s} directly
 (in which case \tcode{iterator_traits} pick them up automatically), or
-an \tcode{iterator_traits} specialization must provide them. \end{note}
+an \tcode{iterator_traits} specialization must provide them.
+\end{note}
 
 \pnum
 Just as a regular pointer to an array guarantees that there is a pointer value pointing past the last element
@@ -579,7 +581,9 @@ the only exceptions are destroying an iterator that holds a singular value,
 the assignment of a non-singular value to
 an iterator that holds a singular value, and, for iterators that meet the
 \oldconcept{DefaultConstructible} requirements, using a value-initialized iterator
-as the source of a copy or move operation. \begin{note} This guarantee is not
+as the source of a copy or move operation.
+\begin{note}
+This guarantee is not
 offered for default-initialization, although the distinction only matters for types
 with trivial default constructors such as pointers or aggregates holding pointers.
 \end{note}
@@ -1873,8 +1877,10 @@ denotes a value of value type
 \tcode{T},
 \tcode{o}
 denotes a value of some type that is writable to the output iterator.
-\begin{note} For an iterator type \tcode{X} there must be an instantiation
-of \tcode{iterator_traits<X>}\iref{iterator.traits}. \end{note}
+\begin{note}
+For an iterator type \tcode{X} there must be an instantiation
+of \tcode{iterator_traits<X>}\iref{iterator.traits}.
+\end{note}
 
 \rSec3[iterator.iterators]{\oldconcept{Iterator}}
 
@@ -2119,8 +2125,10 @@ are valid and have the indicated semantics, and
 The domain of \tcode{==} for forward iterators is that of iterators over the same
 underlying sequence. However, value-initialized iterators may be compared and
 shall compare equal to other value-initialized iterators of the same type.
-\begin{note} Value-initialized iterators behave as if they refer past the end of
-the same empty sequence. \end{note}
+\begin{note}
+Value-initialized iterators behave as if they refer past the end of
+the same empty sequence.
+\end{note}
 
 \pnum
 Two dereferenceable iterators \tcode{a} and \tcode{b} of type \tcode{X} offer the

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1097,7 +1097,8 @@ template<class X, class Y>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 iter_value_t<remove_reference_t<X>> old_value(iter_move(x));
 *x = iter_move(y);
@@ -2779,7 +2780,8 @@ template<class InputIterator>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{advance(x, n); return x;}
+\effects
+Equivalent to: \tcode{advance(x, n); return x;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{prev}}%
@@ -2791,7 +2793,8 @@ template<class BidirectionalIterator>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{advance(x, -n); return x;}
+\effects
+Equivalent to: \tcode{advance(x, -n); return x;}
 \end{itemdescr}
 
 \rSec2[range.iter.ops]{Range iterator operations}
@@ -2982,7 +2985,8 @@ template<input_or_output_iterator I>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{++x; return x;}
+\effects
+Equivalent to: \tcode{++x; return x;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{next}}%
@@ -2993,7 +2997,8 @@ template<input_or_output_iterator I>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{ranges::advance(x, n); return x;}
+\effects
+Equivalent to: \tcode{ranges::advance(x, n); return x;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{next}}%
@@ -3004,7 +3009,8 @@ template<input_or_output_iterator I, sentinel_for<I> S>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{ranges::advance(x, bound); return x;}
+\effects
+Equivalent to: \tcode{ranges::advance(x, bound); return x;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{next}}%
@@ -3015,7 +3021,8 @@ template<input_or_output_iterator I, sentinel_for<I> S>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{ranges::advance(x, n, bound); return x;}
+\effects
+Equivalent to: \tcode{ranges::advance(x, n, bound); return x;}
 \end{itemdescr}
 
 \rSec3[range.iter.op.prev]{\tcode{ranges::prev}}
@@ -3027,7 +3034,8 @@ template<bidirectional_iterator I>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{-{-}x; return x;}
+\effects
+Equivalent to: \tcode{-{-}x; return x;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{prev}}%
@@ -3038,7 +3046,8 @@ template<bidirectional_iterator I>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{ranges::advance(x, -n); return x;}
+\effects
+Equivalent to: \tcode{ranges::advance(x, -n); return x;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{prev}}%
@@ -3049,7 +3058,8 @@ template<bidirectional_iterator I>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{ranges::advance(x, -n, bound); return x;}
+\effects
+Equivalent to: \tcode{ranges::advance(x, -n, bound); return x;}
 \end{itemdescr}
 
 \rSec1[predef.iterators]{Iterator adaptors}
@@ -3582,14 +3592,16 @@ friend constexpr iter_rvalue_reference_t<Iterator>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 auto tmp = i.base();
 return ranges::iter_move(--tmp);
 \end{codeblock}
 
 \pnum
-\remarks The expression in \tcode{noexcept} is equivalent to:
+\remarks
+The expression in \tcode{noexcept} is equivalent to:
 \begin{codeblock}
 is_nothrow_copy_constructible_v<Iterator> &&
 noexcept(ranges::iter_move(--declval<Iterator&>()))
@@ -3606,7 +3618,8 @@ template<indirectly_swappable<Iterator> Iterator2>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 auto xtmp = x.base();
 auto ytmp = y.base();
@@ -3614,7 +3627,8 @@ ranges::iter_swap(--xtmp, --ytmp);
 \end{codeblock}
 
 \pnum
-\remarks The expression in \tcode{noexcept} is equivalent to:
+\remarks
+The expression in \tcode{noexcept} is equivalent to:
 \begin{codeblock}
 is_nothrow_copy_constructible_v<Iterator> &&
 is_nothrow_copy_constructible_v<Iterator2> &&
@@ -4151,7 +4165,8 @@ constexpr move_iterator();
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{move_iterator}, value-initializing
+\effects
+Constructs a \tcode{move_iterator}, value-initializing
 \tcode{current}. Iterator operations applied to the resulting
 iterator have defined behavior if and only if the corresponding operations are defined
 on a value-initialized iterator of type \tcode{Iterator}.
@@ -4165,7 +4180,8 @@ constexpr explicit move_iterator(Iterator i);
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{move_iterator}, initializing
+\effects
+Constructs a \tcode{move_iterator}, initializing
 \tcode{current} with \tcode{std::move(i)}.
 \end{itemdescr}
 
@@ -4177,10 +4193,12 @@ template<class U> constexpr move_iterator(const move_iterator<U>& u);
 
 \begin{itemdescr}
 \pnum
-\mandates \tcode{U} is convertible to \tcode{Iterator}.
+\mandates
+\tcode{U} is convertible to \tcode{Iterator}.
 
 \pnum
-\effects Constructs a \tcode{move_iterator}, initializing
+\effects
+Constructs a \tcode{move_iterator}, initializing
 \tcode{current} with \tcode{u.base()}.
 \end{itemdescr}
 
@@ -4191,10 +4209,12 @@ template<class U> constexpr move_iterator& operator=(const move_iterator<U>& u);
 
 \begin{itemdescr}
 \pnum
-\mandates \tcode{U} is convertible to \tcode{Iterator}.
+\mandates
+\tcode{U} is convertible to \tcode{Iterator}.
 
 \pnum
-\effects Assigns \tcode{u.base()} to
+\effects
+Assigns \tcode{u.base()} to
 \tcode{current}.
 \end{itemdescr}
 
@@ -4210,10 +4230,12 @@ constexpr Iterator base() const &;
 \constraints \tcode{Iterator} satisfies \libconcept{copy_constructible}.
 
 \pnum
-\expects \tcode{Iterator} models \libconcept{copy_constructible}.
+\expects
+\tcode{Iterator} models \libconcept{copy_constructible}.
 
 \pnum
-\returns \tcode{current}.
+\returns
+\tcode{current}.
 \end{itemdescr}
 
 \indexlibrarymember{base}{move_iterator}%
@@ -4223,7 +4245,8 @@ constexpr Iterator base() &&;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{std::move(current)}.
+\returns
+\tcode{std::move(current)}.
 \end{itemdescr}
 
 \rSec3[move.iter.elem]{Element access}
@@ -4235,7 +4258,8 @@ constexpr reference operator*() const;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return ranges::iter_move(current);}
+\effects
+Equivalent to: \tcode{return ranges::iter_move(current);}
 \end{itemdescr}
 
 \indexlibrarymember{operator[]}{move_iterator}%
@@ -4245,7 +4269,8 @@ constexpr reference operator[](difference_type n) const;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{ranges::iter_move(current + n);}
+\effects
+Equivalent to: \tcode{ranges::iter_move(current + n);}
 \end{itemdescr}
 
 \rSec3[move.iter.nav]{Navigation}
@@ -4257,10 +4282,12 @@ constexpr move_iterator& operator++();
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{++current}.
+\effects
+As if by \tcode{++current}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator++}{move_iterator}%
@@ -4287,10 +4314,12 @@ constexpr move_iterator& operator--();
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{\dcr current}.
+\effects
+As if by \tcode{\dcr current}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator\dcr}{move_iterator}%
@@ -4316,7 +4345,8 @@ constexpr move_iterator operator+(difference_type n) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{move_iterator(current + n)}.
+\returns
+\tcode{move_iterator(current + n)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+=}{move_iterator}%
@@ -4326,10 +4356,12 @@ constexpr move_iterator& operator+=(difference_type n);
 
 \begin{itemdescr}
 \pnum
-\effects As if by: \tcode{current += n;}
+\effects
+As if by: \tcode{current += n;}
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{move_iterator}%
@@ -4339,7 +4371,8 @@ constexpr move_iterator operator-(difference_type n) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{move_iterator(current - n)}.
+\returns
+\tcode{move_iterator(current - n)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-=}{move_iterator}%
@@ -4349,10 +4382,12 @@ constexpr move_iterator& operator-=(difference_type n);
 
 \begin{itemdescr}
 \pnum
-\effects As if by: \tcode{current -= n;}
+\effects
+As if by: \tcode{current -= n;}
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \rSec3[move.iter.op.comp]{Comparisons}
@@ -4374,7 +4409,8 @@ template<sentinel_for<Iterator> S>
 convertible to \tcode{bool}.
 
 \pnum
-\returns \tcode{x.base() == y.base()}.
+\returns
+\tcode{x.base() == y.base()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<}{move_iterator}%
@@ -4390,7 +4426,8 @@ constexpr bool operator<(const move_iterator<Iterator1>& x, const move_iterator<
 convertible to \tcode{bool}.
 
 \pnum
-\returns \tcode{x.base() < y.base()}.
+\returns
+\tcode{x.base() < y.base()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>}{move_iterator}%
@@ -4406,7 +4443,8 @@ constexpr bool operator>(const move_iterator<Iterator1>& x, const move_iterator<
 convertible to \tcode{bool}.
 
 \pnum
-\returns \tcode{y < x}.
+\returns
+\tcode{y < x}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=}{move_iterator}%
@@ -4422,7 +4460,8 @@ constexpr bool operator<=(const move_iterator<Iterator1>& x, const move_iterator
 convertible to \tcode{bool}.
 
 \pnum
-\returns \tcode{!(y < x)}.
+\returns
+\tcode{!(y < x)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>=}{move_iterator}%
@@ -4438,7 +4477,8 @@ constexpr bool operator>=(const move_iterator<Iterator1>& x, const move_iterator
 convertible to \tcode{bool}.
 
 \pnum
-\returns \tcode{!(x < y)}.
+\returns
+\tcode{!(x < y)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{move_iterator}%
@@ -4473,7 +4513,8 @@ template<sized_sentinel_for<Iterator> S>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x.base() - y.base()}.
+\returns
+\tcode{x.base() - y.base()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+}{move_iterator}%
@@ -4489,7 +4530,8 @@ template<class Iterator>
 \tcode{x + n} is well-formed and has type \tcode{Iterator}.
 
 \pnum
-\returns \tcode{x + n}.
+\returns
+\tcode{x + n}.
 \end{itemdescr}
 
 \indexlibrarymember{iter_move}{move_iterator}%
@@ -4501,7 +4543,8 @@ friend constexpr iter_rvalue_reference_t<Iterator>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return ranges::iter_move(i.current);}
+\effects
+Equivalent to: \tcode{return ranges::iter_move(i.current);}
 \end{itemdescr}
 
 \indexlibrarymember{iter_swap}{move_iterator}%
@@ -4514,7 +4557,8 @@ template<indirectly_swappable<Iterator> Iterator2>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{ranges::iter_swap(x.current, y.current)}.
+\effects
+Equivalent to: \tcode{ranges::iter_swap(x.current, y.current)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{make_move_iterator}}%
@@ -4525,7 +4569,8 @@ constexpr move_iterator<Iterator> make_move_iterator(Iterator i);
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{move_iterator<Iterator>(i)}.
+\returns
+\tcode{move_iterator<Iterator>(i)}.
 \end{itemdescr}
 
 \rSec3[move.sentinel]{Class template \tcode{move_sentinel}}
@@ -4583,7 +4628,8 @@ constexpr move_sentinel();
 
 \begin{itemdescr}
 \pnum
-\effects Value-initializes \tcode{last}.
+\effects
+Value-initializes \tcode{last}.
 If \tcode{is_trivially_default_constructible_v<S>} is \tcode{true},
 then this constructor is a \tcode{constexpr} constructor.
 \end{itemdescr}
@@ -4595,7 +4641,8 @@ constexpr explicit move_sentinel(S s);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{last} with \tcode{std::move(s)}.
+\effects
+Initializes \tcode{last} with \tcode{std::move(s)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{move_sentinel}!constructor}%
@@ -4607,7 +4654,8 @@ template<class S2>
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{last} with \tcode{s.last}.
+\effects
+Initializes \tcode{last} with \tcode{s.last}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator=}!\idxcode{move_sentinel}}%
@@ -4620,7 +4668,8 @@ template<class S2>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{last = s.last; return *this;}
+\effects
+Equivalent to: \tcode{last = s.last; return *this;}
 \end{itemdescr}
 
 \rSec2[iterators.common]{Common iterators}
@@ -4769,7 +4818,8 @@ constexpr common_iterator(S s);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{v_} as if by
+\effects
+Initializes \tcode{v_} as if by
 \tcode{v_\{in_place_type<S>, std::move(s)\}}.
 \end{itemdescr}
 
@@ -4782,7 +4832,8 @@ template<class I2, class S2>
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{x.v_.valueless_by_exception()} is \tcode{false}.
+\expects
+\tcode{x.v_.valueless_by_exception()} is \tcode{false}.
 
 \pnum
 \effects
@@ -4801,7 +4852,8 @@ template<class I2, class S2>
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{x.v_.valueless_by_exception()} is \tcode{false}.
+\expects
+\tcode{x.v_.valueless_by_exception()} is \tcode{false}.
 
 \pnum
 \effects
@@ -4815,7 +4867,8 @@ Equivalent to:
 where $i$ is \tcode{x.v_.index()}.
 
 \pnum
-\returns \tcode{*this}
+\returns
+\tcode{*this}
 \end{itemdescr}
 
 \rSec3[common.iter.access]{Accessors}
@@ -4829,10 +4882,12 @@ decltype(auto) operator*() const
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{holds_alternative<I>(v_)}.
+\expects
+\tcode{holds_alternative<I>(v_)}.
 
 \pnum
-\effects Equivalent to: \tcode{return *get<I>(v_);}
+\effects
+Equivalent to: \tcode{return *get<I>(v_);}
 \end{itemdescr}
 
 \indexlibrarymember{operator->}{common_iterator}%
@@ -4852,7 +4907,8 @@ readable<const I> &&
 \end{codeblock}
 
 \pnum
-\expects \tcode{holds_alternative<I>(v_)}.
+\expects
+\tcode{holds_alternative<I>(v_)}.
 
 \pnum
 \effects
@@ -4896,13 +4952,16 @@ common_iterator& operator++();
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{holds_alternative<I>(v_)}.
+\expects
+\tcode{holds_alternative<I>(v_)}.
 
 \pnum
-\effects Equivalent to \tcode{++get<I>(v_)}.
+\effects
+Equivalent to \tcode{++get<I>(v_)}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator++}{common_iterator}%
@@ -4912,7 +4971,8 @@ decltype(auto) operator++(int);
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{holds_alternative<I>(v_)}.
+\expects
+\tcode{holds_alternative<I>(v_)}.
 
 \pnum
 \effects
@@ -5001,10 +5061,12 @@ friend iter_rvalue_reference_t<I> iter_move(const common_iterator& i)
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{holds_alternative<I>(v_)}.
+\expects
+\tcode{holds_alternative<I>(v_)}.
 
 \pnum
-\effects Equivalent to: \tcode{return ranges::iter_move(get<I>(i.v_));}
+\effects
+Equivalent to: \tcode{return ranges::iter_move(get<I>(i.v_));}
 \end{itemdescr}
 
 \indexlibrarymember{iter_swap}{common_iterator}%
@@ -5021,7 +5083,8 @@ template<indirectly_swappable<I> I2, class S2>
 are each \tcode{true}.
 
 \pnum
-\effects Equivalent to \tcode{ranges::iter_swap(get<I>(x.v_), get<I2>(y.v_))}.
+\effects
+Equivalent to \tcode{ranges::iter_swap(get<I>(x.v_), get<I2>(y.v_))}.
 \end{itemdescr}
 
 \rSec2[default.sentinels]{Default sentinels}
@@ -5173,7 +5236,8 @@ constexpr counted_iterator(I i, iter_difference_t<I> n);
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{n >= 0}.
+\expects
+\tcode{n >= 0}.
 
 \pnum
 \effects
@@ -5209,7 +5273,8 @@ Assigns \tcode{x.current} to \tcode{current} and
 \tcode{x.length} to \tcode{length}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \rSec3[counted.iter.access]{Accessors}
@@ -5221,7 +5286,8 @@ constexpr I base() const & requires copy_constructible<I>;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return current;}
+\effects
+Equivalent to: \tcode{return current;}
 \end{itemdescr}
 
 \indexlibrarymember{base}{counted_iterator}%
@@ -5231,7 +5297,8 @@ constexpr I base() &&;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{std::move(current)}.
+\returns
+\tcode{std::move(current)}.
 \end{itemdescr}
 
 \indexlibrarymember{count}{counted_iterator}%
@@ -5241,7 +5308,8 @@ constexpr iter_difference_t<I> count() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return length;}
+\effects
+Equivalent to: \tcode{return length;}
 \end{itemdescr}
 
 \rSec3[counted.iter.elem]{Element access}
@@ -5255,7 +5323,8 @@ constexpr decltype(auto) operator*() const
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return *current;}
+\effects
+Equivalent to: \tcode{return *current;}
 \end{itemdescr}
 
 \indexlibrarymember{operator[]}{counted_iterator}%
@@ -5266,10 +5335,12 @@ constexpr decltype(auto) operator[](iter_difference_t<I> n) const
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{n < length}.
+\expects
+\tcode{n < length}.
 
 \pnum
-\effects Equivalent to: \tcode{return current[n];}
+\effects
+Equivalent to: \tcode{return current[n];}
 \end{itemdescr}
 
 \rSec3[counted.iter.nav]{Navigation}
@@ -5281,10 +5352,12 @@ constexpr counted_iterator& operator++();
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{length > 0}.
+\expects
+\tcode{length > 0}.
 
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 ++current;
 --length;
@@ -5299,10 +5372,12 @@ decltype(auto) operator++(int);
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{length > 0}.
+\expects
+\tcode{length > 0}.
 
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 --length;
 try { return current++; }
@@ -5318,7 +5393,8 @@ constexpr counted_iterator operator++(int)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 counted_iterator tmp = *this;
 ++*this;
@@ -5334,7 +5410,8 @@ return tmp;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 --current;
 ++length;
@@ -5350,7 +5427,8 @@ return *this;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 counted_iterator tmp = *this;
 --*this;
@@ -5366,7 +5444,8 @@ return tmp;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return counted_iterator(current + n, length - n);}
+\effects
+Equivalent to: \tcode{return counted_iterator(current + n, length - n);}
 \end{itemdescr}
 
 \indexlibrarymember{operator+}{counted_iterator}%
@@ -5378,7 +5457,8 @@ friend constexpr counted_iterator operator+(
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return x + n;}
+\effects
+Equivalent to: \tcode{return x + n;}
 \end{itemdescr}
 
 \indexlibrarymember{operator+=}{counted_iterator}%
@@ -5389,10 +5469,12 @@ friend constexpr counted_iterator operator+(
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{n <= length}.
+\expects
+\tcode{n <= length}.
 
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 current += n;
 length -= n;
@@ -5408,7 +5490,8 @@ return *this;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return counted_iterator(current - n, length + n);}
+\effects
+Equivalent to: \tcode{return counted_iterator(current - n, length + n);}
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{counted_iterator}%
@@ -5425,7 +5508,8 @@ template<common_with<I> I2>
 sequence\iref{counted.iterator}.
 
 \pnum
-\effects Equivalent to: \tcode{return y.length - x.length;}
+\effects
+Equivalent to: \tcode{return y.length - x.length;}
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{counted_iterator}%
@@ -5436,7 +5520,8 @@ friend constexpr iter_difference_t<I> operator-(
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \tcode{return -x.length;}
 \end{itemdescr}
 
@@ -5448,7 +5533,8 @@ friend constexpr iter_difference_t<I> operator-(
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return y.length;}
+\effects
+Equivalent to: \tcode{return y.length;}
 \end{itemdescr}
 
 \indexlibrarymember{operator-=}{counted_iterator}%
@@ -5459,10 +5545,12 @@ constexpr counted_iterator& operator-=(iter_difference_t<I> n)
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{-n <= length}.
+\expects
+\tcode{-n <= length}.
 
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 current -= n;
 length += n;
@@ -5486,7 +5574,8 @@ template<common_with<I> I2>
 elements of the same sequence\iref{counted.iterator}.
 
 \pnum
-\effects Equivalent to: \tcode{return x.length == y.length;}
+\effects
+Equivalent to: \tcode{return x.length == y.length;}
 \end{itemdescr}
 
 \indexlibrarymember{operator==}{counted_iterator}%
@@ -5497,7 +5586,8 @@ friend constexpr bool operator==(
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return x.length == 0;}
+\effects
+Equivalent to: \tcode{return x.length == 0;}
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{counted_iterator}%
@@ -5536,7 +5626,8 @@ friend constexpr iter_rvalue_reference_t<I>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return ranges::iter_move(i.current);}
+\effects
+Equivalent to: \tcode{return ranges::iter_move(i.current);}
 \end{itemdescr}
 
 \indexlibrarymember{iter_swap}{counted_iterator}%
@@ -5549,7 +5640,8 @@ template<indirectly_swappable<I> I2>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to \tcode{ranges::iter_swap(x.current, y.current)}.
+\effects
+Equivalent to \tcode{ranges::iter_swap(x.current, y.current)}.
 \end{itemdescr}
 
 \rSec2[unreachable.sentinels]{Unreachable sentinel}
@@ -5670,7 +5762,8 @@ constexpr istream_iterator(default_sentinel_t);
 Constructs the end-of-stream iterator, value-initializing \tcode{value}.
 
 \pnum
-\ensures \tcode{in_stream == nullptr} is \tcode{true}.
+\ensures
+\tcode{in_stream == nullptr} is \tcode{true}.
 
 \pnum
 \remarks
@@ -5701,7 +5794,8 @@ istream_iterator(const istream_iterator& x) = default;
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{in_stream == x.in_stream} is \tcode{true}.
+\ensures
+\tcode{in_stream == x.in_stream} is \tcode{true}.
 
 \pnum
 \remarks
@@ -5764,7 +5858,8 @@ istream_iterator& operator++();
 \tcode{in_stream != nullptr} is \tcode{true}.
 
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 if (!(*in_stream >> value))
   in_stream = nullptr;
@@ -5782,10 +5877,12 @@ istream_iterator operator++(int);
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{in_stream != nullptr} is \tcode{true}.
+\expects
+\tcode{in_stream != nullptr} is \tcode{true}.
 
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 istream_iterator tmp = *this;
 ++*this;
@@ -6178,7 +6275,8 @@ friend bool operator==(const istreambuf_iterator& i, default_sentinel_t s);
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{i.equal(s)}.
+\returns
+\tcode{i.equal(s)}.
 \end{itemdescr}
 
 \rSec2[ostreambuf.iterator]{Class template \tcode{ostreambuf_iterator}}
@@ -6340,7 +6438,8 @@ template<class C> constexpr auto begin(const C& c) -> decltype(c.begin());
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{c.begin()}.
+\returns
+\tcode{c.begin()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{end(C\&)}}%
@@ -6351,7 +6450,8 @@ template<class C> constexpr auto end(const C& c) -> decltype(c.end());
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{c.end()}.
+\returns
+\tcode{c.end()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{begin(T (\&)[N])}}%
@@ -6361,7 +6461,8 @@ template<class T, size_t N> constexpr T* begin(T (&array)[N]) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{array}.
+\returns
+\tcode{array}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{end(T (\&)[N])}}%
@@ -6371,7 +6472,8 @@ template<class T, size_t N> constexpr T* end(T (&array)[N]) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{array + N}.
+\returns
+\tcode{array + N}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{cbegin(const C\&)}}%
@@ -6381,7 +6483,8 @@ template<class C> constexpr auto cbegin(const C& c) noexcept(noexcept(std::begin
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\returns \tcode{std::begin(c)}.
+\returns
+\tcode{std::begin(c)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{cend(const C\&)}}%
@@ -6391,7 +6494,8 @@ template<class C> constexpr auto cend(const C& c) noexcept(noexcept(std::end(c))
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\returns \tcode{std::end(c)}.
+\returns
+\tcode{std::end(c)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{rbegin(C\&)}}%
@@ -6401,7 +6505,8 @@ template<class C> constexpr auto rbegin(const C& c) -> decltype(c.rbegin());
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\returns \tcode{c.rbegin()}.
+\returns
+\tcode{c.rbegin()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{rend(C\&)}}%
@@ -6411,7 +6516,8 @@ template<class C> constexpr auto rend(const C& c) -> decltype(c.rend());
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\returns \tcode{c.rend()}.
+\returns
+\tcode{c.rend()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{rbegin(T (\&array)[N])}}%
@@ -6420,7 +6526,8 @@ template<class T, size_t N> constexpr reverse_iterator<T*> rbegin(T (&array)[N])
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\returns \tcode{reverse_iterator<T*>(array + N)}.
+\returns
+\tcode{reverse_iterator<T*>(array + N)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{rend(T (\&array)[N])}}%
@@ -6429,7 +6536,8 @@ template<class T, size_t N> constexpr reverse_iterator<T*> rend(T (&array)[N]);
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\returns \tcode{reverse_iterator<T*>(array)}.
+\returns
+\tcode{reverse_iterator<T*>(array)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{rbegin(initializer_list<E>)}}%
@@ -6438,7 +6546,8 @@ template<class E> constexpr reverse_iterator<const E*> rbegin(initializer_list<E
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\returns \tcode{reverse_iterator<const E*>(il.end())}.
+\returns
+\tcode{reverse_iterator<const E*>(il.end())}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{rend(initializer_list<E>)}}%
@@ -6447,7 +6556,8 @@ template<class E> constexpr reverse_iterator<const E*> rend(initializer_list<E> 
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\returns \tcode{reverse_iterator<const E*>(il.begin())}.
+\returns
+\tcode{reverse_iterator<const E*>(il.begin())}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{crbegin(const C\& c)}}%
@@ -6456,7 +6566,8 @@ template<class C> constexpr auto crbegin(const C& c) -> decltype(std::rbegin(c))
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\returns \tcode{std::rbegin(c)}.
+\returns
+\tcode{std::rbegin(c)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{crend(const C\& c)}}%
@@ -6465,7 +6576,8 @@ template<class C> constexpr auto crend(const C& c) -> decltype(std::rend(c));
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\returns \tcode{std::rend(c)}.
+\returns
+\tcode{std::rend(c)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{size(C\& c)}}%
@@ -6474,7 +6586,8 @@ template<class C> constexpr auto size(const C& c) -> decltype(c.size());
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\returns \tcode{c.size()}.
+\returns
+\tcode{c.size()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{size(T (\&array)[N])}}%
@@ -6483,7 +6596,8 @@ template<class T, size_t N> constexpr size_t size(const T (&array)[N]) noexcept;
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\returns \tcode{N}.
+\returns
+\tcode{N}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{ssize(C\& c)}}%
@@ -6505,7 +6619,8 @@ template<class T, ptrdiff_t N> constexpr ptrdiff_t ssize(const T (&array)[N]) no
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\returns \tcode{N}.
+\returns
+\tcode{N}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{empty(C\& c)}}%
@@ -6514,7 +6629,8 @@ template<class C> [[nodiscard]] constexpr auto empty(const C& c) -> decltype(c.e
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\returns \tcode{c.empty()}.
+\returns
+\tcode{c.empty()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{empty(T (\&array)[N])}}%
@@ -6523,7 +6639,8 @@ template<class T, size_t N> [[nodiscard]] constexpr bool empty(const T (&array)[
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\returns \tcode{false}.
+\returns
+\tcode{false}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{empty(initializer_list<E>)}}%
@@ -6532,7 +6649,8 @@ template<class E> [[nodiscard]] constexpr bool empty(initializer_list<E> il) noe
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\returns \tcode{il.size() == 0}.
+\returns
+\tcode{il.size() == 0}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{data(C\& c)}}%
@@ -6542,7 +6660,8 @@ template<class C> constexpr auto data(const C& c) -> decltype(c.data());
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\returns \tcode{c.data()}.
+\returns
+\tcode{c.data()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{data(T (\&array)[N])}}%
@@ -6551,7 +6670,8 @@ template<class T, size_t N> constexpr T* data(T (&array)[N]) noexcept;
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\returns \tcode{array}.
+\returns
+\tcode{array}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{data(initializer_list<E>)}}%
@@ -6560,5 +6680,6 @@ template<class E> constexpr const E* data(initializer_list<E> il) noexcept;
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\returns \tcode{il.begin()}.
+\returns
+\tcode{il.begin()}.
 \end{itemdescr}

--- a/source/layout.tex
+++ b/source/layout.tex
@@ -65,7 +65,8 @@
 }}}
 \makeatother
 
-\def\pnum{\parabullnum{Paras}{0pt}}
+\def\pnum
+{\parabullnum{Paras}{0pt}}
 
 % Leave more room for section numbers in TOC
 \cftsetindents{section}{1.5em}{3.0em}

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -35,11 +35,13 @@ and source files included\iref{cpp.include} via the preprocessing
 directive \tcode{\#include}, less any source lines skipped by any of the
 conditional inclusion\iref{cpp.cond} preprocessing directives, is
 called a \defn{translation unit}.
-\begin{note} A \Cpp{} program need not all be translated at the same time.
+\begin{note}
+A \Cpp{} program need not all be translated at the same time.
 \end{note}
 
 \pnum
-\begin{note} Previously translated translation units and instantiation
+\begin{note}
+Previously translated translation units and instantiation
 units can be preserved individually or in libraries. The separate
 translation units of a program communicate\iref{basic.link} by (for
 example)
@@ -47,7 +49,9 @@ calls to functions whose identifiers have external or module linkage,
 manipulation of objects whose identifiers have external or module linkage, or
 manipulation of data files. Translation units can be separately
 translated and then later linked to produce an executable
-program\iref{basic.link}. \end{note}%
+program\iref{basic.link}.
+\end{note}
+%
 \indextext{compilation!separate|)}
 
 \rSec1[lex.phases]{Phases of translation}%
@@ -137,10 +141,12 @@ non-corresponding source characters to the same execution character.}
 \item White-space characters separating tokens are no longer
 significant. Each preprocessing token is converted into a
 token\iref{lex.token}. The resulting tokens are syntactically and
-semantically analyzed and translated as a translation unit. \begin{note}
+semantically analyzed and translated as a translation unit.
+\begin{note}
 The process of analyzing and translating the tokens may occasionally
 result in one token being replaced by a sequence of other
-tokens\iref{temp.names}.\end{note}
+tokens\iref{temp.names}.
+\end{note}
 It is
 \impldef{whether the sources for
 module units and header units
@@ -151,28 +157,46 @@ module units and header units
 on which the current translation unit has an interface
 dependency (\ref{module.unit}, \ref{module.import})
 are required to be available.
-\begin{note} Source files, translation
+\begin{note}
+Source files, translation
 units and translated translation units need not necessarily be stored as
 files, nor need there be any one-to-one correspondence between these
 entities and any external representation. The description is conceptual
-only, and does not specify any particular implementation. \end{note}
+only, and does not specify any particular implementation.
+\end{note}
 
 \item Translated translation units and instantiation units are combined
-as follows: \begin{note} Some or all of these may be supplied from a
-library. \end{note} Each translated translation unit is examined to
-produce a list of required instantiations. \begin{note} This may include
+as follows:
+\begin{note}
+Some or all of these may be supplied from a
+library.
+\end{note}
+Each translated translation unit is examined to
+produce a list of required instantiations.
+\begin{note}
+This may include
 instantiations which have been explicitly
-requested\iref{temp.explicit}. \end{note} The definitions of the
+requested\iref{temp.explicit}.
+\end{note}
+The definitions of the
 required templates are located. It is \impldef{whether source of translation units must
 be available to locate template definitions} whether the
 source of the translation units containing these definitions is required
-to be available. \begin{note} An implementation could encode sufficient
+to be available.
+\begin{note}
+An implementation could encode sufficient
 information into the translated translation unit so as to ensure the
-source is not required here. \end{note} All the required instantiations
+source is not required here.
+\end{note}
+All the required instantiations
 are performed to produce
-\defn{instantiation units}. \begin{note} These are similar
+\defn{instantiation units}.
+\begin{note}
+These are similar
 to translated translation units, but contain no references to
-uninstantiated templates and no template definitions. \end{note} The
+uninstantiated templates and no template definitions.
+\end{note}
+The
 program is ill-formed if any instantiation fails.
 
 \item All external entity references are resolved. Library
@@ -370,14 +394,17 @@ literal token), even though a parse as three preprocessing tokens
 if \tcode{foo} were a macro defined as \tcode{1}). Similarly, the
 program fragment \tcode{1E1} is parsed as a preprocessing number (one
 that is a valid floating literal token), whether or not \tcode{E} is a
-macro name. \end{example}
+macro name.
+\end{example}
 
 \pnum
 \begin{example}
 The program fragment \tcode{x+++++y} is parsed as \tcode{x
 ++ ++ + y}, which, if \tcode{x} and \tcode{y} have integral types,
 violates a constraint on increment operators, even though the parse
-\tcode{x ++ + ++ y} might yield a correct expression. \end{example}%
+\tcode{x ++ + ++ y} might yield a correct expression.
+\end{example}
+%
 \indextext{token!preprocessing|)}
 
 \rSec1[lex.digraph]{Alternative tokens}
@@ -443,10 +470,13 @@ operators, and other separators.
 \indextext{white space}%
 Blanks, horizontal and vertical tabs, newlines, formfeeds, and comments
 (collectively, ``white space''), as described below, are ignored except
-as they serve to separate tokens. \begin{note} Some white space is
+as they serve to separate tokens.
+\begin{note}
+Some white space is
 required to separate otherwise adjacent identifiers, keywords, numeric
 literals, and alternative tokens containing alphabetic characters.
-\end{note}%
+\end{note}
+%
 \indextext{token|)}
 
 \rSec1[lex.comment]{Comments}
@@ -462,11 +492,15 @@ The characters \tcode{//} start a comment, which terminates immediately before t
 next new-line character. If there is a form-feed or a vertical-tab
 character in such a comment, only white-space characters shall appear
 between it and the new-line that terminates the comment; no diagnostic
-is required. \begin{note} The comment characters \tcode{//}, \tcode{/*},
+is required.
+\begin{note}
+The comment characters \tcode{//}, \tcode{/*},
 and \tcode{*/} have no special meaning within a \tcode{//} comment and
 are treated just like other characters. Similarly, the comment
 characters \tcode{//} and \tcode{/*} have no special meaning within a
-\tcode{/*} comment. \end{note}%
+\tcode{/*} comment.
+\end{note}
+%
 \indextext{comment|)}
 
 \rSec1[lex.header]{Header names}
@@ -501,11 +535,13 @@ characters \tcode{//} and \tcode{/*} have no special meaning within a
 \end{bnf}
 
 \pnum
-\begin{note} Header name preprocessing tokens only appear within
+\begin{note}
+Header name preprocessing tokens only appear within
 a \tcode{\#include} preprocessing directive,
 a \tcode{__has_include} preprocessing expression, or
 after certain occurrences of an \tcode{import} token
-(see~\ref{lex.pptoken}). \end{note}
+(see~\ref{lex.pptoken}).
+\end{note}
 The sequences in both forms of \grammarterm{header-name}{s} are mapped in an
 \impldef{mapping header name to header or external source file} manner to headers or to
 external source file names as specified in~\ref{cpp.include}.
@@ -807,8 +843,10 @@ phase 7) except in an \grammarterm{attribute-token}\iref{dcl.attr.grammar}:
 \keyword{while} \\
 \end{multicolfloattable}
 
-\begin{note} The \keyword{register} keyword is unused but
-is reserved for future use.\end{note}
+\begin{note}
+The \keyword{register} keyword is unused but
+is reserved for future use.
+\end{note}
 
 \pnum
 Furthermore, the alternative representations shown in
@@ -1243,9 +1281,12 @@ The value of a wide-character literal containing a single
 of the \grammarterm{c-char} in the execution wide-character set, unless the
 \grammarterm{c-char} has no representation in the execution wide-character set, in which
 case the value is \impldef{value of wide-character literal with single c-char that is
-not in execution wide-character set}. \begin{note} The type \tcode{wchar_t} is able to
+not in execution wide-character set}.
+\begin{note}
+The type \tcode{wchar_t} is able to
 represent all members of the execution wide-character set (see~\ref{basic.fundamental}).
-\end{note} The value
+\end{note}
+The value
 of a wide-character literal containing multiple \grammarterm{c-char}{s} is
 \impldef{value of wide-character literal containing multiple characters}.
 
@@ -1320,12 +1361,14 @@ A \grammarterm{universal-character-name} is translated to the encoding, in the a
 execution character set, of the character named. If there is no such
 encoding, the \grammarterm{universal-character-name} is translated to an
 \impldef{encoding of universal character name not in execution character set} encoding.
-\begin{note} In translation phase 1, a \grammarterm{universal-character-name} is introduced whenever an
+\begin{note}
+In translation phase 1, a \grammarterm{universal-character-name} is introduced whenever an
 actual extended
 character is encountered in the source text. Therefore, all extended
 characters are described in terms of \grammarterm{universal-character-name}{s}. However,
 the actual compiler implementation may use its own native character set,
-so long as the same results are obtained. \end{note}
+so long as the same results are obtained.
+\end{note}
 
 \rSec2[lex.fcon]{Floating literals}
 
@@ -1412,7 +1455,8 @@ a \grammarterm{digit-sequence} or \grammarterm{hexadecimal-digit-sequence}
 are ignored when determining its value.
 \begin{example}
 The floating literals \tcode{1.602'176'565e-19} and \tcode{1.602176565e-19}
-have the same value. \end{example}
+have the same value.
+\end{example}
 Either the integer part or the fraction part (not both) can be omitted.
 Either the radix point or the letter \tcode{e} or \tcode{E} and
 the exponent (not both) can be omitted from a decimal floating literal.
@@ -1541,12 +1585,15 @@ characters as the initial \grammarterm{d-char-sequence}. A \grammarterm{d-char-s
 shall consist of at most 16 characters.
 
 \pnum
-\begin{note} The characters \tcode{'('} and \tcode{')'} are permitted in a
+\begin{note}
+The characters \tcode{'('} and \tcode{')'} are permitted in a
 \grammarterm{raw-string}. Thus, \tcode{R"delimiter((a|b))delimiter"} is equivalent to
-\tcode{"(a|b)"}. \end{note}
+\tcode{"(a|b)"}.
+\end{note}
 
 \pnum
-\begin{note} A source-file new-line in a raw string literal results in a new-line in the
+\begin{note}
+A source-file new-line in a raw string literal results in a new-line in the
 resulting execution string literal. Assuming no
 whitespace at the beginning of lines in the following example, the assert will succeed:
 
@@ -1661,7 +1708,9 @@ that \grammarterm{encoding-prefix}. If one \grammarterm{string-literal} has no \
 the same \grammarterm{encoding-prefix} as the other operand. If a UTF-8 string literal token is adjacent to a
 wide string literal token, the program is ill-formed. Any other concatenations are
 conditionally-supported with \impldef{concatenation of some types of string literals}
-behavior. \begin{note} This
+behavior.
+\begin{note}
+This
 concatenation is an interpretation, not a conversion.
 Because the interpretation happens in translation phase 6 (after each character from a
 string literal has been translated into a value from the appropriate character set), a
@@ -1728,9 +1777,13 @@ one for the terminating \tcode{U'\textbackslash 0'} or
 literal is the total number of escape sequences,
 \grammarterm{universal-character-name}{s}, and other characters, plus one for each
 character requiring a surrogate pair, plus one for the terminating
-\tcode{u'\textbackslash 0'}. \begin{note} The size of a \tcode{char16_t}
+\tcode{u'\textbackslash 0'}.
+\begin{note}
+The size of a \tcode{char16_t}
 string literal is the number of code units, not the number of
-characters. \end{note} Within \tcode{char32_t} and \tcode{char16_t}
+characters.
+\end{note}
+Within \tcode{char32_t} and \tcode{char16_t}
 string literals, any \grammarterm{universal-character-name}{s} shall be within the range
 \tcode{0x0} to \tcode{0x10FFFF}. The size of a narrow string literal is
 the total number of escape sequences and other characters, plus at least
@@ -1748,7 +1801,8 @@ nonoverlapping objects) and whether successive evaluations of a
 unspecified.
 \begin{note}
 \indextext{literal!string!undefined change to}%
-The effect of attempting to modify a string literal is undefined. \end{note}
+The effect of attempting to modify a string literal is undefined.
+\end{note}
 
 \rSec2[lex.bool]{Boolean literals}
 
@@ -1830,7 +1884,8 @@ is treated as the latter.
 \begin{example}
 \tcode{123_km}
 is a \grammarterm{user-defined-literal}, but \tcode{12LL} is an
-\grammarterm{integer-literal}. \end{example}
+\grammarterm{integer-literal}.
+\end{example}
 The syntactic non-terminal preceding the \grammarterm{ud-suffix} in a
 \grammarterm{user-defined-literal} is taken to be the longest sequence of
 characters that could match that non-terminal.
@@ -1870,7 +1925,9 @@ Otherwise (\placeholder{S} contains a numeric literal operator template),
 operator "" @\placeholder{X}@<'@$c_1$@', '@$c_2$@', ... '@$c_k$@'>()
 \end{codeblock}
 
-where \placeholder{n} is the source character sequence $c_1c_2...c_k$. \begin{note} The sequence
+where \placeholder{n} is the source character sequence $c_1c_2...c_k$.
+\begin{note}
+The sequence
 $c_1c_2...c_k$ can only contain characters from the basic source character set.
 \end{note}
 
@@ -1900,7 +1957,9 @@ Otherwise (\placeholder{S} contains a numeric literal operator template),
 operator "" @\placeholder{X}@<'@$c_1$@', '@$c_2$@', ... '@$c_k$@'>()
 \end{codeblock}
 
-where \placeholder{f} is the source character sequence $c_1c_2...c_k$. \begin{note} The sequence
+where \placeholder{f} is the source character sequence $c_1c_2...c_k$.
+\begin{note}
+The sequence
 $c_1c_2...c_k$ can only contain characters from the basic source character set.
 \end{note}
 
@@ -1970,6 +2029,7 @@ int main() {
   "P"_x "Q" "R"_y;// error: two different \grammarterm{ud-suffix}{es}
 }
 \end{codeblock}
-\end{example}%
+\end{example}
+%
 \indextext{literal|)}%
 \indextext{conventions!lexical|)}

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -362,7 +362,8 @@ by processing an \tcode{import} directive\iref{cpp.import} and
 has no associated grammar productions.
 
 \pnum
-\begin{example} The program fragment \tcode{0xe+foo} is parsed as a
+\begin{example}
+The program fragment \tcode{0xe+foo} is parsed as a
 preprocessing number token (one that is not a valid floating or integer
 literal token), even though a parse as three preprocessing tokens
 \tcode{0xe}, \tcode{+}, and \tcode{foo} might produce a valid expression (for example,
@@ -372,7 +373,8 @@ that is a valid floating literal token), whether or not \tcode{E} is a
 macro name. \end{example}
 
 \pnum
-\begin{example} The program fragment \tcode{x+++++y} is parsed as \tcode{x
+\begin{example}
+The program fragment \tcode{x+++++y} is parsed as \tcode{x
 ++ ++ + y}, which, if \tcode{x} and \tcode{y} have integral types,
 violates a constraint on increment operators, even though the parse
 \tcode{x ++ + ++ y} might yield a correct expression. \end{example}%
@@ -990,7 +992,8 @@ A \defnx{hexadecimal integer literal}{literal!hexadecimal}
 digits, which include the decimal digits and the letters \tcode{a}
 through \tcode{f} and \tcode{A} through \tcode{F} with decimal values
 ten through fifteen.
-\begin{example} The number twelve can be written \tcode{12}, \tcode{014},
+\begin{example}
+The number twelve can be written \tcode{12}, \tcode{014},
 \tcode{0XC}, or \tcode{0b1100}. The integer literals \tcode{1048576},
 \tcode{1'048'576}, \tcode{0X100000}, \tcode{0x10'0000}, and
 \tcode{0'004'000'000} all have the same value.
@@ -1407,7 +1410,8 @@ a \defnadj{hexadecimal floating}{literal} in the latter case.
 Optional separating single quotes in
 a \grammarterm{digit-sequence} or \grammarterm{hexadecimal-digit-sequence}
 are ignored when determining its value.
-\begin{example} The floating literals \tcode{1.602'176'565e-19} and \tcode{1.602176565e-19}
+\begin{example}
+The floating literals \tcode{1.602'176'565e-19} and \tcode{1.602176565e-19}
 have the same value. \end{example}
 Either the integer part or the fraction part (not both) can be omitted.
 Either the radix point or the letter \tcode{e} or \tcode{E} and
@@ -1555,7 +1559,8 @@ assert(std::strcmp(p, "a\\\nb\nc") == 0);
 \end{note}
 
 \pnum
-\begin{example} The raw string
+\begin{example}
+The raw string
 
 \begin{codeblock}
 R"a(
@@ -1821,7 +1826,9 @@ and~\ref{conv.mem}.
 
 \pnum
 If a token matches both \grammarterm{user-defined-literal} and another \grammarterm{literal} kind, it
-is treated as the latter. \begin{example} \tcode{123_km}
+is treated as the latter.
+\begin{example}
+\tcode{123_km}
 is a \grammarterm{user-defined-literal}, but \tcode{12LL} is an
 \grammarterm{integer-literal}. \end{example}
 The syntactic non-terminal preceding the \grammarterm{ud-suffix} in a

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -1938,7 +1938,6 @@ operator "" @\placeholder{X}@(@\placeholder{ch}{}@)
 
 \pnum
 \begin{example}
-
 \begin{codeblock}
 long double operator "" _w(long double);
 std::string operator "" _w(const char16_t*, std::size_t);

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -51,7 +51,6 @@ manipulation of data files. Translation units can be separately
 translated and then later linked to produce an executable
 program\iref{basic.link}.
 \end{note}
-%
 \indextext{compilation!separate|)}
 
 \rSec1[lex.phases]{Phases of translation}%
@@ -404,7 +403,6 @@ The program fragment \tcode{x+++++y} is parsed as \tcode{x
 violates a constraint on increment operators, even though the parse
 \tcode{x ++ + ++ y} might yield a correct expression.
 \end{example}
-%
 \indextext{token!preprocessing|)}
 
 \rSec1[lex.digraph]{Alternative tokens}
@@ -476,7 +474,6 @@ Some white space is
 required to separate otherwise adjacent identifiers, keywords, numeric
 literals, and alternative tokens containing alphabetic characters.
 \end{note}
-%
 \indextext{token|)}
 
 \rSec1[lex.comment]{Comments}
@@ -500,7 +497,6 @@ are treated just like other characters. Similarly, the comment
 characters \tcode{//} and \tcode{/*} have no special meaning within a
 \tcode{/*} comment.
 \end{note}
-%
 \indextext{comment|)}
 
 \rSec1[lex.header]{Header names}
@@ -2030,6 +2026,5 @@ int main() {
 }
 \end{codeblock}
 \end{example}
-%
 \indextext{literal|)}%
 \indextext{conventions!lexical|)}

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -594,7 +594,8 @@ via a \grammarterm{constraint-expression}\iref{temp.constr.decl}.
 \end{example}
 
 \item
-\mandates the conditions that, if not met, render the program ill-formed.
+\mandates
+the conditions that, if not met, render the program ill-formed.
 \begin{example}
 An implementation might express such a condition
 via the \grammarterm{constant-expression}
@@ -607,33 +608,42 @@ and also define the function as deleted.
 \end{example}
 
 \item
-\expects the conditions (sometimes termed preconditions)
+\expects
+the conditions (sometimes termed preconditions)
 that the function assumes to hold whenever it is called.
 
 \item
-\effects the actions performed by the function.
+\effects
+the actions performed by the function.
 
 \item
-\sync the synchronization operations\iref{intro.multithread} applicable to the function.
+\sync
+the synchronization operations\iref{intro.multithread} applicable to the function.
 
 \item
-\ensures the conditions (sometimes termed observable results or postconditions)
+\ensures
+the conditions (sometimes termed observable results or postconditions)
 established by the function.
 
 \item
-\returns a description of the value(s) returned by the function.
+\returns
+a description of the value(s) returned by the function.
 
 \item
-\throws any exceptions thrown by the function, and the conditions that would cause the exception.
+\throws
+any exceptions thrown by the function, and the conditions that would cause the exception.
 
 \item
-\complexity the time and/or space complexity of the function.
+\complexity
+the time and/or space complexity of the function.
 
 \item
-\remarks additional semantic constraints on the function.
+\remarks
+additional semantic constraints on the function.
 
 \item
-\errors the error conditions for error codes reported by the function.
+\errors
+the error conditions for error codes reported by the function.
 \end{itemize}
 
 \pnum

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1327,9 +1327,11 @@ and are then injected into namespace \tcode{std} by explicit
 \pnum
 Names which are defined as macros in C shall be defined as macros in the \Cpp{}
 standard library, even if C grants license for implementation as functions.
-\begin{note} The names defined as macros in C include the following:
+\begin{note}
+The names defined as macros in C include the following:
 \tcode{assert}, \tcode{offsetof}, \tcode{setjmp}, \tcode{va_arg},
-\tcode{va_end}, and \tcode{va_start}. \end{note}
+\tcode{va_end}, and \tcode{va_start}.
+\end{note}
 
 \pnum
 Names that are defined as functions in C shall be defined as functions in the
@@ -1695,9 +1697,12 @@ convertible to \tcode{bool} &
   \tcode{T(rv)} is equivalent to the value of \tcode{rv} before the construction \\ \rowsep
 \multicolumn{2}{|p{5.3in}|}{
   \tcode{rv}'s state is unspecified
-  \begin{note} \tcode{rv} must still meet the requirements of the library
+  \begin{note}
+\tcode{rv} must still meet the requirements of the library
   component that is using it. The operations listed in those requirements must
-  work as specified whether \tcode{rv} has been moved from or not. \end{note}}\\
+  work as specified whether \tcode{rv} has been moved from or not.
+\end{note}
+}\\
 \end{concepttable}
 
 \indextext{requirements!\idxoldconcept{CopyConstructible}}%
@@ -1720,10 +1725,13 @@ convertible to \tcode{bool} &
   \tcode{t} is equivalent to the value of \tcode{rv} before the assignment\\ \rowsep
 \multicolumn{4}{|p{5.3in}|}{
   \tcode{rv}'s state is unspecified.
-  \begin{note}\ \tcode{rv} must still meet the requirements of the library
+  \begin{note}
+\ \tcode{rv} must still meet the requirements of the library
   component that is using it, whether or not \tcode{t} and \tcode{rv} refer to the same object.
   The operations listed in those requirements must
-  work as specified whether \tcode{rv} has been moved from or not. \end{note}}\\
+  work as specified whether \tcode{rv} has been moved from or not.
+\end{note}
+}\\
 \end{concepttable}
 
 \indextext{requirements!\idxoldconcept{CopyAssignable}}%
@@ -1781,15 +1789,19 @@ resolution\iref{over.match} on a candidate set that includes:
 \item the lookup set produced by argument-dependent lookup\iref{basic.lookup.argdep}.
 \end{itemize}
 
-\begin{note} If \tcode{T} and \tcode{U} are both fundamental types or arrays of
+\begin{note}
+If \tcode{T} and \tcode{U} are both fundamental types or arrays of
 fundamental types and the declarations from the header \tcode{<utility>} are in
 scope, the overall lookup set described above is equivalent to that of the
 qualified name lookup applied to the expression \tcode{std::swap(t, u)} or
-\tcode{std::swap(u, t)} as appropriate. \end{note}
+\tcode{std::swap(u, t)} as appropriate.
+\end{note}
 
-\begin{note} It is unspecified whether a library component that has a swappable
+\begin{note}
+It is unspecified whether a library component that has a swappable
 requirement includes the header \tcode{<utility>} to ensure an appropriate
-evaluation context. \end{note}
+evaluation context.
+\end{note}
 
 \pnum
 An rvalue or lvalue \tcode{t} is \defn{swappable} if and only if \tcode{t} is
@@ -1869,8 +1881,11 @@ valid and have the indicated semantics, and
 \pnum
 A value-initialized object of type \tcode{P} produces the null value of the type.
 The null value shall be equivalent only to itself. A default-initialized object
-of type \tcode{P} may have an indeterminate value. \begin{note} Operations involving
-indeterminate values may cause undefined behavior. \end{note}
+of type \tcode{P} may have an indeterminate value.
+\begin{note}
+Operations involving
+indeterminate values may cause undefined behavior.
+\end{note}
 
 \pnum
 An object \tcode{p} of type \tcode{P} can be contextually converted to
@@ -1952,12 +1967,17 @@ Expression        &     Return type     &       Requirement \\ \capsep
 \tcode{h(k)}      &
   \tcode{size_t}  &
   The value returned shall depend only on the argument \tcode{k} for the duration of
-  the program. \begin{note} Thus all evaluations of the expression \tcode{h(k)} with the
+  the program.
+\begin{note}
+Thus all evaluations of the expression \tcode{h(k)} with the
   same value for \tcode{k} yield the same result for a given execution of the program.
-  \end{note} \begin{note} For two different
+  \end{note}
+\begin{note}
+For two different
   values \tcode{t1} and \tcode{t2}, the probability that \tcode{h(t1)} and \tcode{h(t2)}
   compare equal should be very small, approaching \tcode{1.0 / numeric_limits<size_t>::max()}.
-  \end{note} \\ \rowsep
+  \end{note}
+\\ \rowsep
 \tcode{h(u)}      &
   \tcode{size_t}  &
   Shall not modify \tcode{u}. \\
@@ -2120,7 +2140,8 @@ is small. That is, there is no need for a container to maintain its own
 free list.}
 \begin{note}
 If \tcode{n == 0}, the return value is unspecified.
-\end{note}              &  \\ \rowsep
+\end{note}
+&  \\ \rowsep
 
 \tcode{a.allocate(n, y)}    &
   \tcode{X::pointer}        &
@@ -2229,12 +2250,16 @@ If \tcode{n == 0}, the return value is unspecified.
 
 \pnum
 Note A: The member class template \tcode{rebind} in the table above is
-effectively a typedef template. \begin{note} In general, if
+effectively a typedef template.
+\begin{note}
+In general, if
 the name \tcode{Allocator} is bound to \tcode{SomeAllocator<T>}, then
 \tcode{Allocator::rebind<U>::other} is the same type as
 \tcode{SomeAllocator<U>}, where
 \tcode{SomeAllocator<T>::value_type} is \tcode{T} and
-\tcode{SomeAllocator<U>::\brk{}value_type} is \tcode{U}. \end{note} If
+\tcode{SomeAllocator<U>::\brk{}value_type} is \tcode{U}.
+\end{note}
+If
 \tcode{Allocator} is a class template instantiation of the form
 \tcode{SomeAllocator<T, Args>}, where \tcode{Args} is zero or more type
 arguments, and \tcode{Allocator} does not supply a \tcode{rebind} member
@@ -2320,9 +2345,11 @@ class or the call to \tcode{construct} or \tcode{destroy} may fail to instantiat
 If the alignment associated with a specific over-aligned type is not
 supported by an allocator, instantiation of the allocator for that type may
 fail. The allocator also may silently ignore the requested alignment.
-\begin{note} Additionally, the member function \tcode{allocate}
+\begin{note}
+Additionally, the member function \tcode{allocate}
 for that type may fail by throwing an object of type
-\tcode{bad_alloc}.\end{note}
+\tcode{bad_alloc}.
+\end{note}
 
 \pnum
 \begin{example}
@@ -2528,7 +2555,8 @@ The behavior of a \Cpp{} program is undefined if
 it adds declarations or definitions to such a namespace.
 \begin{example}
 The top level namespace \tcode{std2} is reserved
-for use by future revisions of this International Standard. \end{example}
+for use by future revisions of this International Standard.
+\end{example}
 
 \rSec3[reserved.names]{Reserved names}%
 \indextext{name!reserved}
@@ -2964,9 +2992,12 @@ an lvalue.
 \pnum
 The behavior of a program is undefined if calls to standard library functions from different
 threads may introduce a data race. The conditions under which this may occur are specified
-in~\ref{res.on.data.races}. \begin{note} Modifying an object of a standard library type that is
+in~\ref{res.on.data.races}.
+\begin{note}
+Modifying an object of a standard library type that is
 shared between threads risks undefined behavior unless objects of that type are explicitly
-specified as being shareable without data races or the user supplies a locking mechanism. \end{note}
+specified as being shareable without data races or the user supplies a locking mechanism.
+\end{note}
 
 \pnum
 If an object of a standard library type is accessed, and
@@ -3171,9 +3202,11 @@ unless the objects are accessed directly or indirectly via the function's non-co
 arguments, including \tcode{this}.
 
 \pnum
-\begin{note} This means, for example, that implementations can't use a static object for
+\begin{note}
+This means, for example, that implementations can't use a static object for
 internal purposes without synchronization because it could cause a data race even in
-programs that do not explicitly share objects between threads. \end{note}
+programs that do not explicitly share objects between threads.
+\end{note}
 
 \pnum
 A \Cpp{} standard library function shall not access objects indirectly accessible via its
@@ -3183,8 +3216,10 @@ required by its specification on those container elements.
 \pnum
 Operations on iterators obtained by calling a standard library container or string
 member function may access the underlying container, but shall not modify it.
-\begin{note} In particular, container operations that invalidate iterators conflict
-with operations on iterators associated with that container. \end{note}
+\begin{note}
+In particular, container operations that invalidate iterators conflict
+with operations on iterators associated with that container.
+\end{note}
 
 \pnum
 Implementations may share their own internal objects between threads if the objects are
@@ -3196,9 +3231,11 @@ solely within the current thread if those operations have effects that are
 visible\iref{intro.multithread} to users.
 
 \pnum
-\begin{note} This allows implementations to parallelize operations if there are no visible
+\begin{note}
+This allows implementations to parallelize operations if there are no visible
 \indextext{side effects}%
-side effects. \end{note}
+side effects.
+\end{note}
 
 \rSec3[protection.within.classes]{Protection within classes}
 
@@ -3319,11 +3356,14 @@ by adding a non-throwing exception specification.
 \indextext{pointer!to traceable object}%
 Objects constructed by the standard library that may hold a user-supplied pointer value
 or an integer of type \tcode{std::intptr_t} shall store such values in a traceable
-pointer location\iref{basic.stc.dynamic.safety}. \begin{note} Other libraries are
+pointer location\iref{basic.stc.dynamic.safety}.
+\begin{note}
+Other libraries are
 strongly encouraged to do the same, since not doing so may result in accidental use of
 pointers that are not safely derived. Libraries that store pointers outside the user's
 address space should make it appear that they are stored and retrieved from a traceable
-pointer location. \end{note}
+pointer location.
+\end{note}
 
 \rSec3[value.error.codes]{Value of error codes}
 
@@ -3343,7 +3383,8 @@ identical to the POSIX \tcode{errno} values, with additional values as defined b
 operating system's documentation. Implementations for operating systems that are not
 based on POSIX should define values identical to the operating system's
 values. For errors that do not originate from the operating system, the implementation
-may provide enums for the associated values. \end{example}
+may provide enums for the associated values.
+\end{example}
 
 \rSec3[lib.types.movedfrom]{Moved-from state of library types}
 

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1802,7 +1802,8 @@ for any dereferenceable object
 \tcode{x} of type \tcode{X},
 \tcode{*x} is swappable.
 
-\begin{example} User code can ensure that the evaluation of \tcode{swap} calls
+\begin{example}
+User code can ensure that the evaluation of \tcode{swap} calls
 is performed in an appropriate context under the various conditions as follows:
 \begin{codeblock}
 #include <utility>
@@ -2324,7 +2325,8 @@ for that type may fail by throwing an object of type
 \tcode{bad_alloc}.\end{note}
 
 \pnum
-\begin{example} The following is an allocator class template supporting the minimal
+\begin{example}
+The following is an allocator class template supporting the minimal
 interface that meets the requirements of
 \tref{cpp17.allocator}:
 
@@ -2524,7 +2526,8 @@ followed by a non-empty sequence of digits
 are reserved for future standardization.
 The behavior of a \Cpp{} program is undefined if
 it adds declarations or definitions to such a namespace.
-\begin{example} The top level namespace \tcode{std2} is reserved
+\begin{example}
+The top level namespace \tcode{std2} is reserved
 for use by future revisions of this International Standard. \end{example}
 
 \rSec3[reserved.names]{Reserved names}%
@@ -3332,7 +3335,9 @@ errors originating from the operating system, or a reference to an
 \impldef{\tcode{error_category} for errors originating outside the
 operating system} \tcode{error_category} object for errors originating elsewhere.
 The implementation shall define the possible values of \tcode{value()} for each of these
-error categories. \begin{example} For operating systems that are based on POSIX,
+error categories.
+\begin{example}
+For operating systems that are based on POSIX,
 implementations should define the \tcode{std::system_category()} values as
 identical to the POSIX \tcode{errno} values, with additional values as defined by the
 operating system's documentation. Implementations for operating systems that are not

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -879,8 +879,10 @@ No library function other than
 \tcode{locale::global()}
 shall affect the value returned by
 \tcode{locale()}.
-\begin{note} See~\ref{c.locales} for data race considerations when
-\tcode{setlocale} is invoked. \end{note}
+\begin{note}
+See~\ref{c.locales} for data race considerations when
+\tcode{setlocale} is invoked.
+\end{note}
 
 \pnum
 \returns
@@ -2089,7 +2091,9 @@ facet that is used by
 \tcode{basic_filebuf}
 must be able to translate characters one internal character at a time.
 }
-\begin{note} As a result of operations on \tcode{state}, it can return \tcode{ok} or \tcode{partial} and set \tcode{from_next == from} and \tcode{to_next != to}. \end{note}
+\begin{note}
+As a result of operations on \tcode{state}, it can return \tcode{ok} or \tcode{partial} and set \tcode{from_next == from} and \tcode{to_next != to}.
+\end{note}
 
 \pnum
 \remarks
@@ -3730,11 +3734,13 @@ a case-insensitive comparison, in which case the function evaluates
 \end{itemize}
 
 \pnum
-\begin{note} The function uses the \tcode{ctype<charT>}
+\begin{note}
+The function uses the \tcode{ctype<charT>}
 facet installed in \tcode{f}'s locale
 to determine valid whitespace characters. It is unspecified by what
 means the function performs case-insensitive comparison or whether
-multi-character sequences are considered while doing so. \end{note}
+multi-character sequences are considered while doing so.
+\end{note}
 
 \pnum
 \returns

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -639,7 +639,8 @@ explicit locale(const string& std_name);
 
 \begin{itemdescr}
 \pnum
-\effects The same as \tcode{locale(std_name.c_str())}.
+\effects
+The same as \tcode{locale(std_name.c_str())}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{locale}!constructor}%
@@ -676,7 +677,8 @@ locale(const locale& other, const string& std_name, category cat);
 
 \begin{itemdescr}
 \pnum
-\effects The same as \tcode{locale(other, std_name.c_str(), cat)}.
+\effects
+The same as \tcode{locale(other, std_name.c_str(), cat)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{locale}!constructor}%
@@ -3668,7 +3670,8 @@ iter_type get(iter_type s, iter_type end, ios_base& f, ios_base::iostate& err,
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{do_get(s, end, f, err, t, format, modifier)}.
+\returns
+\tcode{do_get(s, end, f, err, t, format, modifier)}.
 \end{itemdescr}
 
 \indexlibrarymember{get}{time_get}%
@@ -3682,7 +3685,8 @@ iter_type get(iter_type s, iter_type end, ios_base& f, ios_base::iostate& err,
 \requires \range{fmt}{fmtend} shall be a valid range.
 
 \pnum
-\effects The function starts by evaluating
+\effects
+The function starts by evaluating
 \tcode{err = ios_base::goodbit}. It then enters a loop, reading zero or more
 characters from \tcode{s} at each iteration. Unless otherwise specified below,
 the loop terminates when the first of the following conditions holds:
@@ -3733,7 +3737,8 @@ means the function performs case-insensitive comparison or whether
 multi-character sequences are considered while doing so. \end{note}
 
 \pnum
-\returns \tcode{s}.
+\returns
+\tcode{s}.
 \end{itemdescr}
 
 \rSec4[locale.time.get.virtuals]{Virtual functions}
@@ -3884,7 +3889,8 @@ iter_type do_get(iter_type s, iter_type end, ios_base& f,
 \tcode{t} shall point to an object.
 
 \pnum
-\effects The function starts by evaluating
+\effects
+The function starts by evaluating
 \tcode{err = ios_base::goodbit}. It
 then reads characters starting at \tcode{s} until it encounters an error, or
 until it has extracted and assigned those \tcode{struct tm} members, and any
@@ -3909,14 +3915,16 @@ In such cases the values of those \tcode{struct tm} members are unspecified
 and may be outside their valid range.
 
 \pnum
-\remarks It is unspecified whether multiple calls to
+\remarks
+It is unspecified whether multiple calls to
 \tcode{do_get()} with the
 address of the same \tcode{struct tm} object will update the current contents of
 the object or simply overwrite its members. Portable programs should zero
 out the object before invoking the function.
 
 \pnum
-\returns An iterator pointing immediately beyond the last character
+\returns
+An iterator pointing immediately beyond the last character
 recognized as possibly part of a valid input sequence for the given
 \tcode{format} and \tcode{modifier}.
 \end{itemdescr}

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -368,7 +368,8 @@
 \cs_set_eq:NN \diffrefs \diffref
 \ExplSyntaxOff
 % \nodiffref swallows a following \change and removes the preceding line break.
-\def\nodiffref\change{\pnum\diffhead{Change}}
+\def\nodiffref\change{\pnum
+\diffhead{Change}}
 \newcommand{\change}{\diffdef{Change}}
 \newcommand{\rationale}{\diffdef{Rationale}}
 \newcommand{\effect}{\diffdef{Effect on original feature}}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -166,8 +166,11 @@ environment is the state of the floating-point environment of the thread that co
 the corresponding \tcode{thread} object\iref{thread.thread.class}
 or \tcode{jthread} object\iref{thread.jthread.class}
 at the time it
-constructed the object. \begin{note} That is, the child thread gets the floating-point
-state of the parent thread at the time of the child's creation. \end{note}
+constructed the object.
+\begin{note}
+That is, the child thread gets the floating-point
+state of the parent thread at the time of the child's creation.
+\end{note}
 
 \pnum
 A separate floating-point environment shall be maintained for each thread. Each function
@@ -7436,7 +7439,8 @@ evaluates to \tcode{true} for any two arrays
 \tcode{size_t i} and \tcode{size_t j}
 such that \tcode{i < a.size()}
 and \tcode{j < b.size()}.
-\begin{note} This property indicates an absence of aliasing and may be used to
+\begin{note}
+This property indicates an absence of aliasing and may be used to
 advantage by optimizing compilers. Compilers may take advantage
 of inlining, constant propagation, loop fusion,
 tracking of pointers obtained from

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -469,7 +469,8 @@ constexpr T real() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the real component.
+\returns
+The value of the real component.
 \end{itemdescr}
 
 \indexlibrarymember{real}{complex}%
@@ -479,7 +480,8 @@ constexpr void real(T val);
 
 \begin{itemdescr}
 \pnum
-\effects Assigns \tcode{val} to the real component.
+\effects
+Assigns \tcode{val} to the real component.
 \end{itemdescr}
 
 \indexlibrarymember{imag}{complex}%
@@ -489,7 +491,8 @@ constexpr T imag() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the imaginary component.
+\returns
+The value of the imaginary component.
 \end{itemdescr}
 
 \indexlibrarymember{imag}{complex}%
@@ -499,7 +502,8 @@ constexpr void imag(T val);
 
 \begin{itemdescr}
 \pnum
-\effects Assigns \tcode{val} to the imaginary component.
+\effects
+Assigns \tcode{val} to the imaginary component.
 \end{itemdescr}
 
 \rSec2[complex.member.ops]{Member operators}
@@ -902,7 +906,8 @@ template<class T> complex<T> proj(const complex<T>& x);
 
 \begin{itemdescr}
 \pnum
-\returns The projection of \tcode{x} onto the Riemann sphere.
+\returns
+The projection of \tcode{x} onto the Riemann sphere.
 
 \pnum
 \remarks
@@ -939,7 +944,8 @@ template<class T> complex<T> acos(const complex<T>& x);
 
 \begin{itemdescr}
 \pnum
-\returns The complex arc cosine of \tcode{x}.
+\returns
+The complex arc cosine of \tcode{x}.
 
 \pnum
 \remarks
@@ -955,7 +961,8 @@ template<class T> complex<T> asin(const complex<T>& x);
 
 \begin{itemdescr}
 \pnum
-\returns The complex arc sine of \tcode{x}.
+\returns
+The complex arc sine of \tcode{x}.
 
 \pnum
 \remarks
@@ -971,7 +978,8 @@ template<class T> complex<T> atan(const complex<T>& x);
 
 \begin{itemdescr}
 \pnum
-\returns The complex arc tangent of \tcode{x}.
+\returns
+The complex arc tangent of \tcode{x}.
 
 \pnum
 \remarks
@@ -987,7 +995,8 @@ template<class T> complex<T> acosh(const complex<T>& x);
 
 \begin{itemdescr}
 \pnum
-\returns The complex arc hyperbolic cosine of \tcode{x}.
+\returns
+The complex arc hyperbolic cosine of \tcode{x}.
 
 \pnum
 \remarks
@@ -1003,7 +1012,8 @@ template<class T> complex<T> asinh(const complex<T>& x);
 
 \begin{itemdescr}
 \pnum
-\returns The complex arc hyperbolic sine of \tcode{x}.
+\returns
+The complex arc hyperbolic sine of \tcode{x}.
 
 \pnum
 \remarks
@@ -1019,7 +1029,8 @@ template<class T> complex<T> atanh(const complex<T>& x);
 
 \begin{itemdescr}
 \pnum
-\returns The complex arc hyperbolic tangent of \tcode{x}.
+\returns
+The complex arc hyperbolic tangent of \tcode{x}.
 
 \pnum
 \remarks
@@ -3067,7 +3078,8 @@ explicit linear_congruential_engine(result_type s);
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{linear_congruential_engine} object.
+\effects
+Constructs a \tcode{linear_congruential_engine} object.
  If $c \bmod m$ is $0$ and $\tcode{s} \bmod m$ is $0$,
  sets the engine's state to $1$,
  otherwise sets the engine's state to $\tcode{s} \bmod m$.
@@ -3080,7 +3092,8 @@ template<class Sseq> explicit linear_congruential_engine(Sseq& q);
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{linear_congruential_engine} object.
+\effects
+Constructs a \tcode{linear_congruential_engine} object.
  With
  $k = \left\lceil \frac{\log_2 m}{32} \right\rceil$
  and $a$ an array (or equivalent)
@@ -3239,7 +3252,8 @@ explicit mersenne_twister_engine(result_type value);
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{mersenne_twister_engine} object.
+\effects
+Constructs a \tcode{mersenne_twister_engine} object.
 Sets $X_{-n}$ to $\tcode{value} \bmod 2^w$.
 Then, iteratively for $i = 1 - n, \dotsc, -1$, sets $X_i$ to
 \[%
@@ -3252,7 +3266,8 @@ Then, iteratively for $i = 1 - n, \dotsc, -1$, sets $X_i$ to
 \]%
 
 \pnum
-\complexity \bigoh{n}.
+\complexity
+\bigoh{n}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{mersenne_twister_engine}!constructor}%
@@ -3262,7 +3277,8 @@ template<class Sseq> explicit mersenne_twister_engine(Sseq& q);
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{mersenne_twister_engine} object.
+\effects
+Constructs a \tcode{mersenne_twister_engine} object.
  With
  $k = \left\lceil w / 32 \right\rceil$
  and $a$ an array (or equivalent)
@@ -3393,7 +3409,8 @@ explicit subtract_with_carry_engine(result_type value);
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{subtract_with_carry_engine} object.
+\effects
+Constructs a \tcode{subtract_with_carry_engine} object.
  Sets the values of
  $X_{-r}, \dotsc, X_{-1}$,
  in that order, as specified below.
@@ -3415,7 +3432,8 @@ linear_congruential_engine<result_type,
  Set $X_k$ to $\left( \sum_{j=0}^{n-1} z_j \cdot 2^{32j}\right) \bmod m$.
 
 \pnum
-\complexity Exactly $n \cdot \tcode{r}$ invocations
+\complexity
+Exactly $n \cdot \tcode{r}$ invocations
  of \tcode{e}.
 \end{itemdescr}
 
@@ -3428,7 +3446,8 @@ template<class Sseq> explicit subtract_with_carry_engine(Sseq& q);
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{subtract_with_carry_engine} object.
+\effects
+Constructs a \tcode{subtract_with_carry_engine} object.
  With
  $k = \left\lceil w / 32 \right\rceil$
  and $a$ an array (or equivalent)
@@ -4112,7 +4131,8 @@ explicit random_device(const string& token);
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{random_device}
+\effects
+Constructs a \tcode{random_device}
  nondeterministic uniform random bit generator object.
  The semantics of the \tcode{token} parameter
  and the token value used by the default constructor are
@@ -4123,7 +4143,8 @@ explicit random_device(const string& token);
  }
 
 \pnum
-\throws A value of an \impldef{exception type when \tcode{random_device} constructor fails} type
+\throws
+A value of an \impldef{exception type when \tcode{random_device} constructor fails} type
  derived from \tcode{exception}
  if the \tcode{random_device} could not be initialized.
 \end{itemdescr}
@@ -4135,7 +4156,8 @@ double entropy() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns If the implementation employs a random number engine,
+\returns
+If the implementation employs a random number engine,
  returns $0.0$.
  Otherwise, returns an entropy estimate\footnote{If a device has $n$ states
    whose respective probabilities are
@@ -4156,14 +4178,16 @@ result_type operator()();
 
 \begin{itemdescr}
 \pnum
-\returns A nondeterministic random value,
+\returns
+A nondeterministic random value,
  uniformly distributed
  between \tcode{min()} and \tcode{max()} (inclusive).
  It is \impldef{how \tcode{random_device::operator()} generates values}
  how these values are generated.
 
 \pnum
-\throws A value of an \impldef{exception type when \tcode{random_device::operator()} fails}
+\throws
+A value of an \impldef{exception type when \tcode{random_device::operator()} fails}
  type derived from \tcode{exception}
  if a random number could not be obtained.
 \end{itemdescr}
@@ -4227,11 +4251,13 @@ seed_seq();
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{seed_seq} object
+\effects
+Constructs a \tcode{seed_seq} object
  as if by default-constructing its member \tcode{v}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 
@@ -4267,7 +4293,8 @@ template<class InputIterator>
   shall denote an integer type.
 
 \pnum
-\effects Constructs a \tcode{seed_seq} object
+\effects
+Constructs a \tcode{seed_seq} object
  by the following algorithm:
 \begin{codeblock}
 for (InputIterator s = begin; s != end; ++s)
@@ -4379,12 +4406,14 @@ size_t size() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns The number of 32-bit units
+\returns
+The number of 32-bit units
  that would be returned
  by a call to \tcode{param()}.
 
 \pnum
-\complexity Constant time.
+\complexity
+Constant time.
 \end{itemdescr}
 
 \indexlibrarymember{param}{seed_seq}%
@@ -4404,7 +4433,8 @@ template<class OutputIterator>
   shall be valid for a value \tcode{rt} of type \tcode{result_type}.
 
 \pnum
-\effects Copies the sequence of prepared 32-bit units
+\effects
+Copies the sequence of prepared 32-bit units
  to the given destination,
  as if by executing the following statement:
 \begin{codeblock}
@@ -4457,7 +4487,8 @@ template<class RealType, size_t bits, class URBG>
 
 \begin{itemdescr}
 \pnum
-\complexity Exactly
+\complexity
+Exactly
  $k = \max(1, \left\lceil b / \log_2 R \right\rceil)$
  invocations
  of \tcode{g},
@@ -4483,10 +4514,12 @@ template<class RealType, size_t bits, class URBG>
  \tcode{RealType}.
 
 \pnum
-\returns $S / R^k$.
+\returns
+$S / R^k$.
 
 \pnum
-\throws What and when \tcode{g} throws.
+\throws
+What and when \tcode{g} throws.
 \end{itemdescr}%
 \indextext{random number generation!utilities|)}
 
@@ -4606,7 +4639,8 @@ explicit uniform_int_distribution(IntType a, IntType b = numeric_limits<IntType>
  $\tcode{a} \leq \tcode{b}$.
 
 \pnum
-\effects Constructs a \tcode{uniform_int_distribution} object;
+\effects
+Constructs a \tcode{uniform_int_distribution} object;
  \tcode{a} and \tcode{b}
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
@@ -4618,7 +4652,8 @@ result_type a() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the \tcode{a} parameter
+\returns
+The value of the \tcode{a} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -4629,7 +4664,8 @@ result_type b() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the \tcode{b} parameter
+\returns
+The value of the \tcode{b} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -4699,7 +4735,8 @@ explicit uniform_real_distribution(RealType a, RealType b = 1.0);
  $\tcode{b} - \tcode{a} \leq \tcode{numeric_limits<RealType>::max()}$.
 
 \pnum
-\effects Constructs a \tcode{uniform_real_distribution} object;
+\effects
+Constructs a \tcode{uniform_real_distribution} object;
  \tcode{a} and \tcode{b}
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
@@ -4711,7 +4748,8 @@ result_type a() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the \tcode{a} parameter
+\returns
+The value of the \tcode{a} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -4722,7 +4760,8 @@ result_type b() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the \tcode{b} parameter
+\returns
+The value of the \tcode{b} parameter
  with which the object was constructed.
 \end{itemdescr}%
 \indextext{random number distributions!uniform|)}%
@@ -4801,7 +4840,8 @@ explicit bernoulli_distribution(double p);
  $0 \leq \tcode{p} \leq 1$.
 
 \pnum
-\effects Constructs a \tcode{bernoulli_distribution} object;
+\effects
+Constructs a \tcode{bernoulli_distribution} object;
  \tcode{p}
  corresponds to the parameter of the distribution.
 \end{itemdescr}
@@ -4813,7 +4853,8 @@ double p() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the \tcode{p} parameter
+\returns
+The value of the \tcode{p} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -4877,7 +4918,8 @@ explicit binomial_distribution(IntType t, double p = 0.5);
  $0 \leq \tcode{p} \leq 1$ and $0 \leq \tcode{t} $.
 
 \pnum
-\effects Constructs a \tcode{binomial_distribution} object;
+\effects
+Constructs a \tcode{binomial_distribution} object;
  \tcode{t} and \tcode{p}
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
@@ -4888,7 +4930,8 @@ IntType t() const;
 \end{itemdecl}%
 \begin{itemdescr}
 \pnum
-\returns The value of the \tcode{t} parameter
+\returns
+The value of the \tcode{t} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -4899,7 +4942,8 @@ double p() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the \tcode{p} parameter
+\returns
+The value of the \tcode{p} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -4962,7 +5006,8 @@ explicit geometric_distribution(double p);
  $0 < \tcode{p} < 1$.
 
 \pnum
-\effects Constructs a \tcode{geometric_distribution} object;
+\effects
+Constructs a \tcode{geometric_distribution} object;
  \tcode{p}
  corresponds to the parameter of the distribution.
 \end{itemdescr}
@@ -4974,7 +5019,8 @@ double p() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the \tcode{p} parameter
+\returns
+The value of the \tcode{p} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5043,7 +5089,8 @@ explicit negative_binomial_distribution(IntType k, double p = 0.5);
  and $0 < \tcode{k} $.
 
 \pnum
-\effects Constructs a \tcode{negative_binomial_distribution} object;
+\effects
+Constructs a \tcode{negative_binomial_distribution} object;
  \tcode{k} and \tcode{p}
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
@@ -5055,7 +5102,8 @@ IntType k() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the \tcode{k} parameter
+\returns
+The value of the \tcode{k} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5066,7 +5114,8 @@ double p() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the \tcode{p} parameter
+\returns
+The value of the \tcode{p} parameter
  with which the object was constructed.
 \end{itemdescr}%
 \indextext{random number distributions!Bernoulli|)}%
@@ -5146,7 +5195,8 @@ explicit poisson_distribution(double mean);
 \requires $0 < \tcode{mean}$.
 
 \pnum
-\effects Constructs a \tcode{poisson_distribution} object;
+\effects
+Constructs a \tcode{poisson_distribution} object;
 \tcode{mean} corresponds to the parameter of the distribution.
 \end{itemdescr}
 
@@ -5157,7 +5207,8 @@ double mean() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the \tcode{mean} parameter
+\returns
+The value of the \tcode{mean} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5219,7 +5270,8 @@ explicit exponential_distribution(RealType lambda);
 \requires $0 < \tcode{lambda}$.
 
 \pnum
-\effects Constructs an \tcode{exponential_distribution} object;
+\effects
+Constructs an \tcode{exponential_distribution} object;
 \tcode{lambda} corresponds to the parameter of the distribution.
 \end{itemdescr}
 
@@ -5230,7 +5282,8 @@ RealType lambda() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the \tcode{lambda} parameter
+\returns
+The value of the \tcode{lambda} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5295,7 +5348,8 @@ explicit gamma_distribution(RealType alpha, RealType beta = 1.0);
 \requires $0 < \tcode{alpha}$ and $0 < \tcode{beta}$.
 
 \pnum
-\effects Constructs a \tcode{gamma_distribution} object;
+\effects
+Constructs a \tcode{gamma_distribution} object;
 \tcode{alpha} and \tcode{beta}
 correspond to the parameters of the distribution.
 \end{itemdescr}
@@ -5307,7 +5361,8 @@ RealType alpha() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the \tcode{alpha} parameter
+\returns
+The value of the \tcode{alpha} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5318,7 +5373,8 @@ RealType beta() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the \tcode{beta} parameter
+\returns
+The value of the \tcode{beta} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5384,7 +5440,8 @@ explicit weibull_distribution(RealType a, RealType b = 1.0);
 \requires $0 < \tcode{a}$ and $0 < \tcode{b}$.
 
 \pnum
-\effects Constructs a \tcode{weibull_distribution} object;
+\effects
+Constructs a \tcode{weibull_distribution} object;
 \tcode{a} and \tcode{b}
 correspond to the respective parameters of the distribution.
 \end{itemdescr}
@@ -5396,7 +5453,8 @@ RealType a() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the \tcode{a} parameter
+\returns
+The value of the \tcode{a} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5407,7 +5465,8 @@ RealType b() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the \tcode{b} parameter
+\returns
+The value of the \tcode{b} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5480,7 +5539,8 @@ explicit extreme_value_distribution(RealType a, RealType b = 1.0);
 \requires $0 < \tcode{b}$.
 
 \pnum
-\effects Constructs an \tcode{extreme_value_distribution} object;
+\effects
+Constructs an \tcode{extreme_value_distribution} object;
 \tcode{a} and \tcode{b}
 correspond to the respective parameters of the distribution.
 \end{itemdescr}
@@ -5492,7 +5552,8 @@ RealType a() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the \tcode{a} parameter
+\returns
+The value of the \tcode{a} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5503,7 +5564,8 @@ RealType b() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the \tcode{b} parameter
+\returns
+The value of the \tcode{b} parameter
  with which the object was constructed.
 \end{itemdescr}%
 \indextext{random number distributions!Poisson|)}%
@@ -5597,7 +5659,8 @@ explicit normal_distribution(RealType mean, RealType stddev = 1.0);
 \requires $0 < \tcode{stddev}$.
 
 \pnum
-\effects Constructs a \tcode{normal_distribution} object;
+\effects
+Constructs a \tcode{normal_distribution} object;
 \tcode{mean} and \tcode{stddev}
 correspond to the respective parameters of the distribution.
 \end{itemdescr}
@@ -5609,7 +5672,8 @@ RealType mean() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the \tcode{mean} parameter
+\returns
+The value of the \tcode{mean} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5620,7 +5684,8 @@ RealType stddev() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the \tcode{stddev} parameter
+\returns
+The value of the \tcode{stddev} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5686,7 +5751,8 @@ explicit lognormal_distribution(RealType m, RealType s = 1.0);
 \requires $0 < \tcode{s}$.
 
 \pnum
-\effects Constructs a \tcode{lognormal_distribution} object;
+\effects
+Constructs a \tcode{lognormal_distribution} object;
 \tcode{m} and \tcode{s}
 correspond to the respective parameters of the distribution.
 \end{itemdescr}
@@ -5698,7 +5764,8 @@ RealType m() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the \tcode{m} parameter
+\returns
+The value of the \tcode{m} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5709,7 +5776,8 @@ RealType s() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the \tcode{s} parameter
+\returns
+The value of the \tcode{s} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5772,7 +5840,8 @@ explicit chi_squared_distribution(RealType n);
 \requires $0 < \tcode{n}$.
 
 \pnum
-\effects Constructs a \tcode{chi_squared_distribution} object;
+\effects
+Constructs a \tcode{chi_squared_distribution} object;
 \tcode{n} corresponds to the parameter of the distribution.
 \end{itemdescr}
 
@@ -5783,7 +5852,8 @@ RealType n() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the \tcode{n} parameter
+\returns
+The value of the \tcode{n} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5847,7 +5917,8 @@ explicit cauchy_distribution(RealType a, RealType b = 1.0);
 \requires $0 < \tcode{b}$.
 
 \pnum
-\effects Constructs a \tcode{cauchy_distribution} object;
+\effects
+Constructs a \tcode{cauchy_distribution} object;
 \tcode{a} and \tcode{b}
 correspond to the respective parameters of the distribution.
 \end{itemdescr}
@@ -5859,7 +5930,8 @@ RealType a() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the \tcode{a} parameter
+\returns
+The value of the \tcode{a} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5870,7 +5942,8 @@ RealType b() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the \tcode{b} parameter
+\returns
+The value of the \tcode{b} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5938,7 +6011,8 @@ explicit fisher_f_distribution(RealType m, RealType n = 1);
 \requires $0 < \tcode{m}$ and $0 < \tcode{n}$.
 
 \pnum
-\effects Constructs a \tcode{fisher_f_distribution} object;
+\effects
+Constructs a \tcode{fisher_f_distribution} object;
 \tcode{m} and \tcode{n}
 correspond to the respective parameters of the distribution.
 \end{itemdescr}
@@ -5950,7 +6024,8 @@ RealType m() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the \tcode{m} parameter
+\returns
+The value of the \tcode{m} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5961,7 +6036,8 @@ RealType n() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the \tcode{n} parameter
+\returns
+The value of the \tcode{n} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -6027,7 +6103,8 @@ explicit student_t_distribution(RealType n);
 \requires $0 < \tcode{n}$.
 
 \pnum
-\effects Constructs a \tcode{student_t_distribution} object;
+\effects
+Constructs a \tcode{student_t_distribution} object;
 \tcode{n} corresponds to the parameter of the distribution.
 \end{itemdescr}
 
@@ -6038,7 +6115,8 @@ RealType n() const;
 
 \begin{itemdescr}
 \pnum
-\returns The value of the \tcode{n} parameter
+\returns
+The value of the \tcode{n} parameter
  with which the object was constructed.
 \end{itemdescr}%
 \indextext{random number distributions!normal|)}%
@@ -6127,7 +6205,8 @@ discrete_distribution();
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{discrete_distribution} object
+\effects
+Constructs a \tcode{discrete_distribution} object
 with $n = 1$ and $p_0 = 1$.
 \begin{note}
 Such an object will always deliver the value $0$.
@@ -6156,7 +6235,8 @@ template<class InputIterator>
  shall form a sequence $w$ of length $n > 0$.
 
 \pnum
-\effects Constructs a \tcode{discrete_distribution} object
+\effects
+Constructs a \tcode{discrete_distribution} object
 with probabilities given by the formula above.
 \end{itemdescr}
 
@@ -6193,7 +6273,8 @@ template<class UnaryOperation>
  shall hold.
 
 \pnum
-\effects Constructs a \tcode{discrete_distribution} object
+\effects
+Constructs a \tcode{discrete_distribution} object
  with probabilities given by the formula above,
  using the following values:
  If $\tcode{nw} = 0$,
@@ -6214,7 +6295,8 @@ vector<double> probabilities() const;
 
 \begin{itemdescr}
 \pnum
-\returns A \tcode{vector<double>}
+\returns
+A \tcode{vector<double>}
  whose \tcode{size} member returns $n$
  and whose \tcode{operator[]} member returns $p_k$
  when invoked with argument $k$ for $k = 0, \dotsc, n - 1$.
@@ -6306,7 +6388,8 @@ piecewise_constant_distribution();
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{piecewise_constant_distribution} object
+\effects
+Constructs a \tcode{piecewise_constant_distribution} object
  with $n = 1$,
  $\rho_0 = 1$,
  $b_0 = 0$,
@@ -6346,7 +6429,8 @@ template<class InputIteratorB, class InputIteratorW>
  and any $w_k$ for  $k \geq n$ shall be ignored by the distribution.
 
 \pnum
-\effects Constructs a \tcode{piecewise_constant_distribution} object
+\effects
+Constructs a \tcode{piecewise_constant_distribution} object
  with parameters as specified above.
 \end{itemdescr}
 
@@ -6368,7 +6452,8 @@ template<class UnaryOperation>
  to the type of \tcode{UnaryOperation}'s sole parameter.
 
 \pnum
-\effects Constructs a \tcode{piecewise_constant_distribution} object
+\effects
+Constructs a \tcode{piecewise_constant_distribution} object
  with parameters taken or calculated
  from the following values:
  If $\tcode{bl.size()} < 2$,
@@ -6409,7 +6494,8 @@ template<class UnaryOperation>
  shall hold.
 
 \pnum
-\effects Constructs a \tcode{piecewise_constant_distribution} object
+\effects
+Constructs a \tcode{piecewise_constant_distribution} object
  with parameters taken or calculated
  from the following values:
  Let $b_k = \tcode{xmin} + k \cdot \delta $ for $ k = 0, \dotsc, n$,
@@ -6427,7 +6513,8 @@ vector<result_type> intervals() const;
 
 \begin{itemdescr}
 \pnum
-\returns A \tcode{vector<result_type>}
+\returns
+A \tcode{vector<result_type>}
  whose \tcode{size} member returns $n + 1$
  and whose $ \tcode{operator[]} $ member returns $b_k$
  when invoked with argument $k$ for $k = 0, \dotsc, n $.
@@ -6440,7 +6527,8 @@ vector<result_type> densities() const;
 
 \begin{itemdescr}
 \pnum
-\returns A \tcode{vector<result_type>}
+\returns
+A \tcode{vector<result_type>}
  whose \tcode{size} member returns $n$
  and whose $ \tcode{operator[]} $ member returns $\rho_k$
  when invoked with argument $k$ for $k = 0, \dotsc, n - 1$.
@@ -6530,7 +6618,8 @@ piecewise_linear_distribution();
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{piecewise_linear_distribution} object
+\effects
+Constructs a \tcode{piecewise_linear_distribution} object
  with $n = 1$,
  $\rho_0 = \rho_1 = 1$,
  $b_0 = 0$,
@@ -6569,7 +6658,8 @@ template<class InputIteratorB, class InputIteratorW>
  and any $w_k$ for $k \geq n + 1$ shall be ignored by the distribution.
 
 \pnum
-\effects Constructs a \tcode{piecewise_linear_distribution} object
+\effects
+Constructs a \tcode{piecewise_linear_distribution} object
  with parameters as specified above.
 \end{itemdescr}
 
@@ -6591,7 +6681,8 @@ template<class UnaryOperation>
  to the type of \tcode{UnaryOperation}'s sole parameter.
 
 \pnum
-\effects Constructs a \tcode{piecewise_linear_distribution} object
+\effects
+Constructs a \tcode{piecewise_linear_distribution} object
  with parameters taken or calculated
  from the following values:
  If $\tcode{bl.size()} < 2$,
@@ -6632,7 +6723,8 @@ template<class UnaryOperation>
  shall hold.
 
 \pnum
-\effects Constructs a \tcode{piecewise_linear_distribution} object
+\effects
+Constructs a \tcode{piecewise_linear_distribution} object
  with parameters taken or calculated
  from the following values:
  Let $b_k = \tcode{xmin} + k \cdot \delta$ for $k = 0, \dotsc, n$,
@@ -6650,7 +6742,8 @@ vector<result_type> intervals() const;
 
 \begin{itemdescr}
 \pnum
-\returns A \tcode{vector<result_type>}
+\returns
+A \tcode{vector<result_type>}
  whose \tcode{size} member returns $n + 1$
  and whose $ \tcode{operator[]} $ member returns $b_k$
  when invoked with argument $k$ for $k = 0, \dotsc, n$.
@@ -6663,7 +6756,8 @@ vector<result_type> densities() const;
 
 \begin{itemdescr}
 \pnum
-\returns A \tcode{vector<result_type>}
+\returns
+A \tcode{vector<result_type>}
  whose \tcode{size} member returns $n$
  and whose $ \tcode{operator[]} $ member returns $\rho_k$
  when invoked with argument $k$ for $k = 0, \dotsc, n$.
@@ -7170,7 +7264,8 @@ The elements are initialized with the values of the corresponding
 elements of \tcode{v}.
 
 \pnum
-\complexity Constant.
+\complexity
+Constant.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{valarray}!constructor}%
@@ -7180,7 +7275,8 @@ valarray(initializer_list<T> il);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to \tcode{valarray(il.begin(), il.size())}.
+\effects
+Equivalent to \tcode{valarray(il.begin(), il.size())}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{valarray}!constructor}%
@@ -7229,10 +7325,12 @@ resizes \tcode{*this} to make the two arrays the same length,
 as if by calling \tcode{resize(v.size())}, before performing the assignment.
 
 \pnum
-\ensures \tcode{size() == v.size()}.
+\ensures
+\tcode{size() == v.size()}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{valarray}%
@@ -7242,14 +7340,17 @@ valarray& operator=(valarray&& v) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this} obtains the value of \tcode{v}.
+\effects
+\tcode{*this} obtains the value of \tcode{v}.
 The value of \tcode{v} after the assignment is not specified.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 
 \pnum
-\complexity Linear.
+\complexity
+Linear.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{valarray}%
@@ -7259,7 +7360,8 @@ valarray& operator=(initializer_list<T> il);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return *this = valarray(il);}
+\effects
+Equivalent to: \tcode{return *this = valarray(il);}
 \end{itemdescr}
 
 
@@ -7274,7 +7376,8 @@ valarray& operator=(const T& v);
 Assigns \tcode{v} to each element of \tcode{*this}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{valarray}%
@@ -7369,7 +7472,8 @@ valarray operator[](slice slicearr) const;
 
 \begin{itemdescr}
 \pnum
-\returns A \tcode{valarray} containing those
+\returns
+A \tcode{valarray} containing those
 elements of the controlled sequence designated by \tcode{slicearr}.
 \begin{example}
 \begin{codeblock}
@@ -7386,7 +7490,8 @@ slice_array<T> operator[](slice slicearr);
 
 \begin{itemdescr}
 \pnum
-\returns An object that holds references to elements of the controlled
+\returns
+An object that holds references to elements of the controlled
 sequence selected by \tcode{slicearr}. \begin{example}
 \begin{codeblock}
 valarray<char> v0("abcdefghijklmnop", 16);
@@ -7404,7 +7509,8 @@ valarray operator[](const gslice& gslicearr) const;
 
 \begin{itemdescr}
 \pnum
-\returns A \tcode{valarray} containing those
+\returns
+A \tcode{valarray} containing those
 elements of the controlled sequence designated by \tcode{gslicearr}.
 \begin{example}
 \begin{codeblock}
@@ -7425,7 +7531,8 @@ gslice_array<T> operator[](const gslice& gslicearr);
 
 \begin{itemdescr}
 \pnum
-\returns An object that holds references to elements of the controlled
+\returns
+An object that holds references to elements of the controlled
 sequence selected by \tcode{gslicearr}. \begin{example}
 \begin{codeblock}
 valarray<char> v0("abcdefghijklmnop", 16);
@@ -7446,7 +7553,8 @@ valarray operator[](const valarray<bool>& boolarr) const;
 
 \begin{itemdescr}
 \pnum
-\returns A \tcode{valarray} containing those
+\returns
+A \tcode{valarray} containing those
 elements of the controlled sequence designated by \tcode{boolarr}.
 \begin{example}
 \begin{codeblock}
@@ -7465,7 +7573,8 @@ mask_array<T> operator[](const valarray<bool>& boolarr);
 
 \begin{itemdescr}
 \pnum
-\returns An object that holds references to elements of the controlled
+\returns
+An object that holds references to elements of the controlled
 sequence selected by \tcode{boolarr}. \begin{example}
 \begin{codeblock}
 valarray<char> v0("abcdefghijklmnop", 16);
@@ -7484,7 +7593,8 @@ valarray operator[](const valarray<size_t>& indarr) const;
 
 \begin{itemdescr}
 \pnum
-\returns A \tcode{valarray} containing those
+\returns
+A \tcode{valarray} containing those
 elements of the controlled sequence designated by \tcode{indarr}.
 \begin{example}
 \begin{codeblock}
@@ -7503,7 +7613,8 @@ indirect_array<T> operator[](const valarray<size_t>& indarr);
 
 \begin{itemdescr}
 \pnum
-\returns An object that holds references to elements of the controlled
+\returns
+An object that holds references to elements of the controlled
 sequence selected by \tcode{indarr}. \begin{example}
 \begin{codeblock}
 valarray<char> v0("abcdefghijklmnop", 16);
@@ -7538,7 +7649,8 @@ operator returns a value which is of type \tcode{T} (\tcode{bool} for
 \tcode{T} (\tcode{bool} for \tcode{operator!}).
 
 \pnum
-\returns A \tcode{valarray} whose length is \tcode{size()}.
+\returns
+A \tcode{valarray} whose length is \tcode{size()}.
 Each element of the returned array is initialized with the result of
 applying the indicated operator to the corresponding element of the array.
 \end{itemdescr}
@@ -7648,11 +7760,13 @@ void swap(valarray& v) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this} obtains the value of
+\effects
+\tcode{*this} obtains the value of
 \tcode{v}. \tcode{v} obtains the value of \tcode{*this}.
 
 \pnum
-\complexity Constant.
+\complexity
+Constant.
 \end{itemdescr}
 
 \indexlibrarymember{size}{valarray}%
@@ -7662,10 +7776,12 @@ size_t size() const;
 
 \begin{itemdescr}
 \pnum
-\returns The number of elements in the array.
+\returns
+The number of elements in the array.
 
 \pnum
-\complexity Constant time.
+\complexity
+Constant time.
 \end{itemdescr}
 
 \indexlibrarymember{sum}{valarray}%
@@ -8074,7 +8190,8 @@ template<class T> void swap(valarray<T>& x, valarray<T>& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to \tcode{x.swap(y)}.
+\effects
+Equivalent to \tcode{x.swap(y)}.
 \end{itemdescr}
 
 
@@ -8149,11 +8266,13 @@ size_t stride() const;
 
 \begin{itemdescr}
 \pnum
-\returns The start, length, or stride specified
+\returns
+The start, length, or stride specified
 by a \tcode{slice} object.
 
 \pnum
-\complexity Constant time.
+\complexity
+Constant time.
 \end{itemdescr}
 
 \rSec3[slice.ops]{Operators}
@@ -8445,11 +8564,13 @@ valarray<size_t> stride() const;
 
 \begin{itemdescr}
 \pnum
-\returns The representation of the
+\returns
+The representation of the
 start, lengths, or strides specified for the \tcode{gslice}.
 
 \pnum
-\complexity \tcode{start()} is constant time. \tcode{size()} and \tcode{stride()}
+\complexity
+\tcode{start()} is constant time. \tcode{size()} and \tcode{stride()}
 are linear in the number of strides.
 \end{itemdescr}
 
@@ -8879,7 +9000,8 @@ template<class T> @\unspec{2}@ begin(const valarray<T>& v);
 
 \begin{itemdescr}
 \pnum
-\returns An iterator referencing the first value in the array.
+\returns
+An iterator referencing the first value in the array.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{end}!\idxcode{valarray}}%
@@ -8890,7 +9012,8 @@ template<class T> @\unspec{2}@ end(const valarray<T>& v);
 
 \begin{itemdescr}
 \pnum
-\returns An iterator referencing one past the last value in the array.
+\returns
+An iterator referencing one past the last value in the array.
 \end{itemdescr}
 
 \rSec1[c.math]{Mathematical functions for floating-point types}
@@ -9740,7 +9863,8 @@ long double hypot(long double x, long double y, long double z);
 
 \begin{itemdescr}
 \pnum
-\returns $\sqrt{x^2+y^2+z^2}$.
+\returns
+$\sqrt{x^2+y^2+z^2}$.
 \end{itemdescr}
 
 \rSec2[c.math.lerp]{Linear interpolation}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -2490,7 +2490,8 @@ A::A();
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects
+\pnum
+\effects
  The base engine is initialized
  as if by its default constructor.
 \end{itemdescr}
@@ -2500,7 +2501,8 @@ bool operator==(const A& a1, const A& a2);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns
+\pnum
+\returns
  \tcode{true} if \tcode{a1}'s base engine is equal to \tcode{a2}'s base engine.
  Otherwise returns \tcode{false}.
 \end{itemdescr}
@@ -2511,7 +2513,8 @@ A::A(result_type s);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects
+\pnum
+\effects
  The base engine is initialized
  with \tcode{s}.
 \end{itemdescr}
@@ -2522,7 +2525,8 @@ template<class Sseq> A::A(Sseq& q);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects
+\pnum
+\effects
  The base engine is initialized
  with \tcode{q}.
 \end{itemdescr}
@@ -2532,7 +2536,8 @@ void seed();
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects
+\pnum
+\effects
  With \tcode{b} as the base engine, invokes \tcode{b.seed()}.
 \end{itemdescr}
 
@@ -2541,7 +2546,8 @@ void seed(result_type s);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects
+\pnum
+\effects
  With \tcode{b} as the base engine, invokes \tcode{b.seed(s)}.
 \end{itemdescr}
 
@@ -2550,7 +2556,8 @@ template<class Sseq> void seed(Sseq& q);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects
+\pnum
+\effects
  With \tcode{b} as the base engine, invokes \tcode{b.seed(q)}.
 \end{itemdescr}
 
@@ -3047,7 +3054,8 @@ the following relations shall hold:
 and
   \tcode{c < m}.
 
-\pnum The textual representation%
+\pnum
+The textual representation%
 \indextext{\idxcode{linear_congruential_engine}!textual representation}
 consists of
 the value of \state{x}{i}.
@@ -3058,7 +3066,8 @@ explicit linear_congruential_engine(result_type s);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects Constructs a \tcode{linear_congruential_engine} object.
+\pnum
+\effects Constructs a \tcode{linear_congruential_engine} object.
  If $c \bmod m$ is $0$ and $\tcode{s} \bmod m$ is $0$,
  sets the engine's state to $1$,
  otherwise sets the engine's state to $\tcode{s} \bmod m$.
@@ -3070,7 +3079,8 @@ template<class Sseq> explicit linear_congruential_engine(Sseq& q);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects Constructs a \tcode{linear_congruential_engine} object.
+\pnum
+\effects Constructs a \tcode{linear_congruential_engine} object.
  With
  $k = \left\lceil \frac{\log_2 m}{32} \right\rceil$
  and $a$ an array (or equivalent)
@@ -3228,7 +3238,8 @@ explicit mersenne_twister_engine(result_type value);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects Constructs a \tcode{mersenne_twister_engine} object.
+\pnum
+\effects Constructs a \tcode{mersenne_twister_engine} object.
 Sets $X_{-n}$ to $\tcode{value} \bmod 2^w$.
 Then, iteratively for $i = 1 - n, \dotsc, -1$, sets $X_i$ to
 \[%
@@ -3240,7 +3251,8 @@ Then, iteratively for $i = 1 - n, \dotsc, -1$, sets $X_i$ to
 \; \mbox{.}
 \]%
 
-\pnum\complexity \bigoh{n}.
+\pnum
+\complexity \bigoh{n}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{mersenne_twister_engine}!constructor}%
@@ -3249,7 +3261,8 @@ template<class Sseq> explicit mersenne_twister_engine(Sseq& q);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects Constructs a \tcode{mersenne_twister_engine} object.
+\pnum
+\effects Constructs a \tcode{mersenne_twister_engine} object.
  With
  $k = \left\lceil w / 32 \right\rceil$
  and $a$ an array (or equivalent)
@@ -3379,7 +3392,8 @@ explicit subtract_with_carry_engine(result_type value);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects Constructs a \tcode{subtract_with_carry_engine} object.
+\pnum
+\effects Constructs a \tcode{subtract_with_carry_engine} object.
  Sets the values of
  $X_{-r}, \dotsc, X_{-1}$,
  in that order, as specified below.
@@ -3400,7 +3414,8 @@ linear_congruential_engine<result_type,
  of \tcode{e} taken modulo $2^{32}$.
  Set $X_k$ to $\left( \sum_{j=0}^{n-1} z_j \cdot 2^{32j}\right) \bmod m$.
 
-\pnum\complexity Exactly $n \cdot \tcode{r}$ invocations
+\pnum
+\complexity Exactly $n \cdot \tcode{r}$ invocations
  of \tcode{e}.
 \end{itemdescr}
 
@@ -3412,7 +3427,8 @@ template<class Sseq> explicit subtract_with_carry_engine(Sseq& q);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects Constructs a \tcode{subtract_with_carry_engine} object.
+\pnum
+\effects Constructs a \tcode{subtract_with_carry_engine} object.
  With
  $k = \left\lceil w / 32 \right\rceil$
  and $a$ an array (or equivalent)
@@ -3862,7 +3878,8 @@ using minstd_rand0 =
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\required
+\pnum
+\required
  The $10000^\text{th}$ consecutive invocation
  of a default-constructed object
  of type \tcode{minstd_rand0}
@@ -3877,7 +3894,8 @@ using minstd_rand =
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\required
+\pnum
+\required
  The $10000^\text{th}$ consecutive invocation
  of a default-constructed object
  of type \tcode{minstd_rand}
@@ -3893,7 +3911,8 @@ using mt19937 =
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\required
+\pnum
+\required
  The $10000^\text{th}$ consecutive invocation
  of a default-constructed object
  of type \tcode{mt19937}
@@ -3913,7 +3932,8 @@ using mt19937_64 =
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\required
+\pnum
+\required
  The $10000^\text{th}$ consecutive invocation
  of a default-constructed object
  of type \tcode{mt19937_64}
@@ -3928,7 +3948,8 @@ using ranlux24_base =
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\required
+\pnum
+\required
  The $10000^\text{th}$ consecutive invocation
  of a default-constructed object
  of type \tcode{ran\-lux24_base}
@@ -3944,7 +3965,8 @@ using ranlux48_base =
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\required
+\pnum
+\required
  The $10000^\text{th}$ consecutive invocation
  of a default-constructed object
  of type \tcode{ran\-lux48_base}
@@ -3959,7 +3981,8 @@ using ranlux24 = discard_block_engine<ranlux24_base, 223, 23>;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\required
+\pnum
+\required
  The $10000^\text{th}$ consecutive invocation
  of a default-constructed object
  of type \tcode{ranlux24}
@@ -3974,7 +3997,8 @@ using ranlux48 = discard_block_engine<ranlux48_base, 389, 11>;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\required
+\pnum
+\required
  The $10000^\text{th}$ consecutive invocation
  of a default-constructed object
  of type \tcode{ranlux48}
@@ -3989,7 +4013,8 @@ using knuth_b = shuffle_order_engine<minstd_rand0,256>;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\required
+\pnum
+\required
  The $10000^\text{th}$ consecutive invocation
  of a default-constructed object
  of type \tcode{knuth_b}
@@ -4003,7 +4028,8 @@ using default_random_engine = @\textit{\impldef{type of \tcode{default_random_en
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\remarks
+\pnum
+\remarks
 The choice of engine type
 named by this \tcode{typedef}
 is \impldef{type of \tcode{default_random_engine}}.
@@ -4085,7 +4111,8 @@ explicit random_device(const string& token);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects Constructs a \tcode{random_device}
+\pnum
+\effects Constructs a \tcode{random_device}
  nondeterministic uniform random bit generator object.
  The semantics of the \tcode{token} parameter
  and the token value used by the default constructor are
@@ -4107,7 +4134,8 @@ double entropy() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns If the implementation employs a random number engine,
+\pnum
+\returns If the implementation employs a random number engine,
  returns $0.0$.
  Otherwise, returns an entropy estimate\footnote{If a device has $n$ states
    whose respective probabilities are
@@ -4127,7 +4155,8 @@ result_type operator()();
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns A nondeterministic random value,
+\pnum
+\returns A nondeterministic random value,
  uniformly distributed
  between \tcode{min()} and \tcode{max()} (inclusive).
  It is \impldef{how \tcode{random_device::operator()} generates values}
@@ -4197,7 +4226,8 @@ seed_seq();
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects Constructs a \tcode{seed_seq} object
+\pnum
+\effects Constructs a \tcode{seed_seq} object
  as if by default-constructing its member \tcode{v}.
 
 \pnum
@@ -4212,9 +4242,11 @@ template<class T>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\requires \tcode{T} shall be an integer type.
+\pnum
+\requires \tcode{T} shall be an integer type.
 
-\pnum\effects
+\pnum
+\effects
  Same as \tcode{seed_seq(il.begin(), il.end())}.
 \end{itemdescr}
 
@@ -4226,14 +4258,16 @@ template<class InputIterator>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\requires
+\pnum
+\requires
   \tcode{InputIterator} shall meet the
   \oldconcept{InputIterator} requirements\iref{input.iterators}.
   Moreover,
   \tcode{iterator_traits<InputIterator>::value_type}
   shall denote an integer type.
 
-\pnum\effects Constructs a \tcode{seed_seq} object
+\pnum
+\effects Constructs a \tcode{seed_seq} object
  by the following algorithm:
 \begin{codeblock}
 for (InputIterator s = begin; s != end; ++s)
@@ -4248,7 +4282,8 @@ template<class RandomAccessIterator>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\requires \tcode{RandomAccessIterator}
+\pnum
+\requires \tcode{RandomAccessIterator}
   shall meet the
   \oldconcept{RandomAccessIterator} requirements\iref{random.access.iterators}
   and the requirements of a mutable iterator.
@@ -4257,7 +4292,8 @@ template<class RandomAccessIterator>
   shall denote an unsigned integer type
   capable of accommodating 32-bit quantities.
 
-\pnum\effects
+\pnum
+\effects
  Does nothing if \tcode{begin == end}.
  Otherwise,
  with $s = \tcode{v.size()}$
@@ -4330,7 +4366,8 @@ template<class RandomAccessIterator>
    set \tcode{begin[$k$]} to $r_4$.
 \end{itemize}
 
-\pnum\throws
+\pnum
+\throws
 What and when \tcode{RandomAccessIterator} operations of \tcode{begin}
 and \tcode{end} throw.
 \end{itemdescr}
@@ -4341,11 +4378,13 @@ size_t size() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The number of 32-bit units
+\pnum
+\returns The number of 32-bit units
  that would be returned
  by a call to \tcode{param()}.
 
-\pnum\complexity Constant time.
+\pnum
+\complexity Constant time.
 \end{itemdescr}
 
 \indexlibrarymember{param}{seed_seq}%
@@ -4355,7 +4394,8 @@ template<class OutputIterator>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\requires
+\pnum
+\requires
   \tcode{OutputIterator} shall meet the
   \oldconcept{OutputIterator} requirements\iref{output.iterators}.
   Moreover,
@@ -4363,14 +4403,16 @@ template<class OutputIterator>
   \tcode{*dest = rt}
   shall be valid for a value \tcode{rt} of type \tcode{result_type}.
 
-\pnum\effects Copies the sequence of prepared 32-bit units
+\pnum
+\effects Copies the sequence of prepared 32-bit units
  to the given destination,
  as if by executing the following statement:
 \begin{codeblock}
 copy(v.begin(), v.end(), dest);
 \end{codeblock}
 
-\pnum\throws
+\pnum
+\throws
 What and when \tcode{OutputIterator} operations of \tcode{dest} throw.
 \end{itemdescr}
 
@@ -4414,7 +4456,8 @@ template<class RealType, size_t bits, class URBG>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\complexity Exactly
+\pnum
+\complexity Exactly
  $k = \max(1, \left\lceil b / \log_2 R \right\rceil)$
  invocations
  of \tcode{g},
@@ -4427,7 +4470,8 @@ template<class RealType, size_t bits, class URBG>
  and
    $R$ is the value of $\tcode{g.max()} - \tcode{g.min()} + 1$.
 
-\pnum\effects
+\pnum
+\effects
  Invokes \tcode{g()} $k$ times
  to obtain values $g_0, \dotsc, g_{k-1}$, respectively.
  Calculates a quantity
@@ -4441,7 +4485,8 @@ template<class RealType, size_t bits, class URBG>
 \pnum
 \returns $S / R^k$.
 
-\pnum\throws What and when \tcode{g} throws.
+\pnum
+\throws What and when \tcode{g} throws.
 \end{itemdescr}%
 \indextext{random number generation!utilities|)}
 
@@ -4556,10 +4601,12 @@ explicit uniform_int_distribution(IntType a, IntType b = numeric_limits<IntType>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\requires
+\pnum
+\requires
  $\tcode{a} \leq \tcode{b}$.
 
-\pnum\effects Constructs a \tcode{uniform_int_distribution} object;
+\pnum
+\effects Constructs a \tcode{uniform_int_distribution} object;
  \tcode{a} and \tcode{b}
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
@@ -4570,7 +4617,8 @@ result_type a() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The value of the \tcode{a} parameter
+\pnum
+\returns The value of the \tcode{a} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -4580,7 +4628,8 @@ result_type b() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The value of the \tcode{b} parameter
+\pnum
+\returns The value of the \tcode{b} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -4643,12 +4692,14 @@ explicit uniform_real_distribution(RealType a, RealType b = 1.0);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\requires
+\pnum
+\requires
  $\tcode{a} \leq \tcode{b}$
  and
  $\tcode{b} - \tcode{a} \leq \tcode{numeric_limits<RealType>::max()}$.
 
-\pnum\effects Constructs a \tcode{uniform_real_distribution} object;
+\pnum
+\effects Constructs a \tcode{uniform_real_distribution} object;
  \tcode{a} and \tcode{b}
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
@@ -4659,7 +4710,8 @@ result_type a() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The value of the \tcode{a} parameter
+\pnum
+\returns The value of the \tcode{a} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -4669,7 +4721,8 @@ result_type b() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The value of the \tcode{b} parameter
+\pnum
+\returns The value of the \tcode{b} parameter
  with which the object was constructed.
 \end{itemdescr}%
 \indextext{random number distributions!uniform|)}%
@@ -4743,10 +4796,12 @@ explicit bernoulli_distribution(double p);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\requires
+\pnum
+\requires
  $0 \leq \tcode{p} \leq 1$.
 
-\pnum\effects Constructs a \tcode{bernoulli_distribution} object;
+\pnum
+\effects Constructs a \tcode{bernoulli_distribution} object;
  \tcode{p}
  corresponds to the parameter of the distribution.
 \end{itemdescr}
@@ -4757,7 +4812,8 @@ double p() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The value of the \tcode{p} parameter
+\pnum
+\returns The value of the \tcode{p} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -4816,10 +4872,12 @@ explicit binomial_distribution(IntType t, double p = 0.5);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\requires
+\pnum
+\requires
  $0 \leq \tcode{p} \leq 1$ and $0 \leq \tcode{t} $.
 
-\pnum\effects Constructs a \tcode{binomial_distribution} object;
+\pnum
+\effects Constructs a \tcode{binomial_distribution} object;
  \tcode{t} and \tcode{p}
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
@@ -4829,7 +4887,8 @@ explicit binomial_distribution(IntType t, double p = 0.5);
 IntType t() const;
 \end{itemdecl}%
 \begin{itemdescr}
-\pnum\returns The value of the \tcode{t} parameter
+\pnum
+\returns The value of the \tcode{t} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -4839,7 +4898,8 @@ double p() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The value of the \tcode{p} parameter
+\pnum
+\returns The value of the \tcode{p} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -4897,10 +4957,12 @@ explicit geometric_distribution(double p);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\requires
+\pnum
+\requires
  $0 < \tcode{p} < 1$.
 
-\pnum\effects Constructs a \tcode{geometric_distribution} object;
+\pnum
+\effects Constructs a \tcode{geometric_distribution} object;
  \tcode{p}
  corresponds to the parameter of the distribution.
 \end{itemdescr}
@@ -4911,7 +4973,8 @@ double p() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The value of the \tcode{p} parameter
+\pnum
+\returns The value of the \tcode{p} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -4974,11 +5037,13 @@ explicit negative_binomial_distribution(IntType k, double p = 0.5);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\requires
+\pnum
+\requires
  $0 < \tcode{p} \leq 1$
  and $0 < \tcode{k} $.
 
-\pnum\effects Constructs a \tcode{negative_binomial_distribution} object;
+\pnum
+\effects Constructs a \tcode{negative_binomial_distribution} object;
  \tcode{k} and \tcode{p}
  correspond to the respective parameters of the distribution.
 \end{itemdescr}
@@ -4989,7 +5054,8 @@ IntType k() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The value of the \tcode{k} parameter
+\pnum
+\returns The value of the \tcode{k} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -4999,7 +5065,8 @@ double p() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The value of the \tcode{p} parameter
+\pnum
+\returns The value of the \tcode{p} parameter
  with which the object was constructed.
 \end{itemdescr}%
 \indextext{random number distributions!Bernoulli|)}%
@@ -5089,7 +5156,8 @@ double mean() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The value of the \tcode{mean} parameter
+\pnum
+\returns The value of the \tcode{mean} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5161,7 +5229,8 @@ RealType lambda() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The value of the \tcode{lambda} parameter
+\pnum
+\returns The value of the \tcode{lambda} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5237,7 +5306,8 @@ RealType alpha() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The value of the \tcode{alpha} parameter
+\pnum
+\returns The value of the \tcode{alpha} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5247,7 +5317,8 @@ RealType beta() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The value of the \tcode{beta} parameter
+\pnum
+\returns The value of the \tcode{beta} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5324,7 +5395,8 @@ RealType a() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The value of the \tcode{a} parameter
+\pnum
+\returns The value of the \tcode{a} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5334,7 +5406,8 @@ RealType b() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The value of the \tcode{b} parameter
+\pnum
+\returns The value of the \tcode{b} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5418,7 +5491,8 @@ RealType a() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The value of the \tcode{a} parameter
+\pnum
+\returns The value of the \tcode{a} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5428,7 +5502,8 @@ RealType b() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The value of the \tcode{b} parameter
+\pnum
+\returns The value of the \tcode{b} parameter
  with which the object was constructed.
 \end{itemdescr}%
 \indextext{random number distributions!Poisson|)}%
@@ -5533,7 +5608,8 @@ RealType mean() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The value of the \tcode{mean} parameter
+\pnum
+\returns The value of the \tcode{mean} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5543,7 +5619,8 @@ RealType stddev() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The value of the \tcode{stddev} parameter
+\pnum
+\returns The value of the \tcode{stddev} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5620,7 +5697,8 @@ RealType m() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The value of the \tcode{m} parameter
+\pnum
+\returns The value of the \tcode{m} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5630,7 +5708,8 @@ RealType s() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The value of the \tcode{s} parameter
+\pnum
+\returns The value of the \tcode{s} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5703,7 +5782,8 @@ RealType n() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The value of the \tcode{n} parameter
+\pnum
+\returns The value of the \tcode{n} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5778,7 +5858,8 @@ RealType a() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The value of the \tcode{a} parameter
+\pnum
+\returns The value of the \tcode{a} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5788,7 +5869,8 @@ RealType b() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The value of the \tcode{b} parameter
+\pnum
+\returns The value of the \tcode{b} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5867,7 +5949,8 @@ RealType m() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The value of the \tcode{m} parameter
+\pnum
+\returns The value of the \tcode{m} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5877,7 +5960,8 @@ RealType n() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The value of the \tcode{n} parameter
+\pnum
+\returns The value of the \tcode{n} parameter
  with which the object was constructed.
 \end{itemdescr}
 
@@ -5953,7 +6037,8 @@ RealType n() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The value of the \tcode{n} parameter
+\pnum
+\returns The value of the \tcode{n} parameter
  with which the object was constructed.
 \end{itemdescr}%
 \indextext{random number distributions!normal|)}%
@@ -6041,7 +6126,8 @@ discrete_distribution();
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects Constructs a \tcode{discrete_distribution} object
+\pnum
+\effects Constructs a \tcode{discrete_distribution} object
 with $n = 1$ and $p_0 = 1$.
 \begin{note}
 Such an object will always deliver the value $0$.
@@ -6081,7 +6167,8 @@ discrete_distribution(initializer_list<double> wl);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects
+\pnum
+\effects
  Same as \tcode{discrete_distribution(wl.begin(), wl.end())}.
 \end{itemdescr}
 
@@ -6092,7 +6179,8 @@ template<class UnaryOperation>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\requires
+\pnum
+\requires
  Each instance of type \tcode{UnaryOperation}
  shall be a function object\iref{function.objects}
  whose return type shall be convertible to \tcode{double}.
@@ -6104,7 +6192,8 @@ template<class UnaryOperation>
    $0 < \delta = (\tcode{xmax} - \tcode{xmin}) / n$
  shall hold.
 
-\pnum\effects Constructs a \tcode{discrete_distribution} object
+\pnum
+\effects Constructs a \tcode{discrete_distribution} object
  with probabilities given by the formula above,
  using the following values:
  If $\tcode{nw} = 0$,
@@ -6113,7 +6202,8 @@ template<class UnaryOperation>
  let $w_k = \tcode{fw}(\tcode{xmin} + k \cdot \delta + \delta / 2)$
  for $k = 0, \dotsc, n - 1$.
 
-\pnum\complexity
+\pnum
+\complexity
  The number of invocations of \tcode{fw} shall not exceed $n$.
 \end{itemdescr}
 
@@ -6123,7 +6213,8 @@ vector<double> probabilities() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns A \tcode{vector<double>}
+\pnum
+\returns A \tcode{vector<double>}
  whose \tcode{size} member returns $n$
  and whose \tcode{operator[]} member returns $p_k$
  when invoked with argument $k$ for $k = 0, \dotsc, n - 1$.
@@ -6214,7 +6305,8 @@ piecewise_constant_distribution();
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects Constructs a \tcode{piecewise_constant_distribution} object
+\pnum
+\effects Constructs a \tcode{piecewise_constant_distribution} object
  with $n = 1$,
  $\rho_0 = 1$,
  $b_0 = 0$,
@@ -6230,7 +6322,8 @@ template<class InputIteratorB, class InputIteratorW>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\requires
+\pnum
+\requires
   \tcode{InputIteratorB} and \tcode{InputIteratorW}
   shall each meet the
   \oldconcept{InputIterator} requirements\iref{input.iterators}.
@@ -6252,7 +6345,8 @@ template<class InputIteratorB, class InputIteratorW>
  shall be at least $n$,
  and any $w_k$ for  $k \geq n$ shall be ignored by the distribution.
 
-\pnum\effects Constructs a \tcode{piecewise_constant_distribution} object
+\pnum
+\effects Constructs a \tcode{piecewise_constant_distribution} object
  with parameters as specified above.
 \end{itemdescr}
 
@@ -6264,7 +6358,8 @@ template<class UnaryOperation>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\requires
+\pnum
+\requires
  Each instance of type \tcode{UnaryOperation}
  shall be a function object\iref{function.objects}
  whose return type shall be convertible to \tcode{double}.
@@ -6272,7 +6367,8 @@ template<class UnaryOperation>
  \tcode{double} shall be convertible
  to the type of \tcode{UnaryOperation}'s sole parameter.
 
-\pnum\effects Constructs a \tcode{piecewise_constant_distribution} object
+\pnum
+\effects Constructs a \tcode{piecewise_constant_distribution} object
  with parameters taken or calculated
  from the following values:
  If $\tcode{bl.size()} < 2$,
@@ -6287,7 +6383,8 @@ template<class UnaryOperation>
  let $w_k = \tcode{fw}\bigl(\bigl(b_{k+1} + b_k\bigr) / 2\bigr)$
  for $k = 0, \dotsc, n - 1$.
 
-\pnum\complexity
+\pnum
+\complexity
  The number of invocations of \tcode{fw} shall not exceed $n$.
 \end{itemdescr}
 
@@ -6299,7 +6396,8 @@ template<class UnaryOperation>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\requires
+\pnum
+\requires
  Each instance of type \tcode{UnaryOperation}
  shall be a function object\iref{function.objects}
  whose return type shall be convertible to \tcode{double}.
@@ -6310,13 +6408,15 @@ template<class UnaryOperation>
  The relation $0 < \delta = (\tcode{xmax} - \tcode{xmin}) / n$
  shall hold.
 
-\pnum\effects Constructs a \tcode{piecewise_constant_distribution} object
+\pnum
+\effects Constructs a \tcode{piecewise_constant_distribution} object
  with parameters taken or calculated
  from the following values:
  Let $b_k = \tcode{xmin} + k \cdot \delta $ for $ k = 0, \dotsc, n$,
  and $w_k = \tcode{fw}(b_k + \delta / 2) $ for $ k = 0, \dotsc, n - 1$.
 
-\pnum\complexity
+\pnum
+\complexity
  The number of invocations of \tcode{fw} shall not exceed $n$.
 \end{itemdescr}
 
@@ -6326,7 +6426,8 @@ vector<result_type> intervals() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns A \tcode{vector<result_type>}
+\pnum
+\returns A \tcode{vector<result_type>}
  whose \tcode{size} member returns $n + 1$
  and whose $ \tcode{operator[]} $ member returns $b_k$
  when invoked with argument $k$ for $k = 0, \dotsc, n $.
@@ -6338,7 +6439,8 @@ vector<result_type> densities() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns A \tcode{vector<result_type>}
+\pnum
+\returns A \tcode{vector<result_type>}
  whose \tcode{size} member returns $n$
  and whose $ \tcode{operator[]} $ member returns $\rho_k$
  when invoked with argument $k$ for $k = 0, \dotsc, n - 1$.
@@ -6427,7 +6529,8 @@ piecewise_linear_distribution();
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects Constructs a \tcode{piecewise_linear_distribution} object
+\pnum
+\effects Constructs a \tcode{piecewise_linear_distribution} object
  with $n = 1$,
  $\rho_0 = \rho_1 = 1$,
  $b_0 = 0$,
@@ -6442,7 +6545,8 @@ template<class InputIteratorB, class InputIteratorW>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\requires
+\pnum
+\requires
   \tcode{InputIteratorB} and \tcode{InputIteratorW}
   shall each meet the
   \oldconcept{InputIterator} requirements\iref{input.iterators}.
@@ -6464,7 +6568,8 @@ template<class InputIteratorB, class InputIteratorW>
  shall be at least $n+1$,
  and any $w_k$ for $k \geq n + 1$ shall be ignored by the distribution.
 
-\pnum\effects Constructs a \tcode{piecewise_linear_distribution} object
+\pnum
+\effects Constructs a \tcode{piecewise_linear_distribution} object
  with parameters as specified above.
 \end{itemdescr}
 
@@ -6476,7 +6581,8 @@ template<class UnaryOperation>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\requires
+\pnum
+\requires
  Each instance of type \tcode{UnaryOperation}
  shall be a function object\iref{function.objects}
  whose return type shall be convertible to \tcode{double}.
@@ -6484,7 +6590,8 @@ template<class UnaryOperation>
  \tcode{double} shall be convertible
  to the type of \tcode{UnaryOperation}'s sole parameter.
 
-\pnum\effects Constructs a \tcode{piecewise_linear_distribution} object
+\pnum
+\effects Constructs a \tcode{piecewise_linear_distribution} object
  with parameters taken or calculated
  from the following values:
  If $\tcode{bl.size()} < 2$,
@@ -6499,7 +6606,8 @@ template<class UnaryOperation>
  let $w_k = \tcode{fw}(b_k)$
  for $k = 0, \dotsc, n$.
 
-\pnum\complexity
+\pnum
+\complexity
  The number of invocations of \tcode{fw} shall not exceed $n+1$.
 \end{itemdescr}
 
@@ -6511,7 +6619,8 @@ template<class UnaryOperation>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\requires
+\pnum
+\requires
  Each instance of type \tcode{UnaryOperation}
  shall be a function object\iref{function.objects}
  whose return type shall be convertible to \tcode{double}.
@@ -6522,13 +6631,15 @@ template<class UnaryOperation>
  The relation $0 < \delta = (\tcode{xmax} - \tcode{xmin}) / n$
  shall hold.
 
-\pnum\effects Constructs a \tcode{piecewise_linear_distribution} object
+\pnum
+\effects Constructs a \tcode{piecewise_linear_distribution} object
  with parameters taken or calculated
  from the following values:
  Let $b_k = \tcode{xmin} + k \cdot \delta$ for $k = 0, \dotsc, n$,
  and $w_k = \tcode{fw}(b_k)$ for $k = 0, \dotsc, n$.
 
-\pnum\complexity
+\pnum
+\complexity
  The number of invocations of \tcode{fw} shall not exceed $n+1$.
 \end{itemdescr}
 
@@ -6538,7 +6649,8 @@ vector<result_type> intervals() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns A \tcode{vector<result_type>}
+\pnum
+\returns A \tcode{vector<result_type>}
  whose \tcode{size} member returns $n + 1$
  and whose $ \tcode{operator[]} $ member returns $b_k$
  when invoked with argument $k$ for $k = 0, \dotsc, n$.
@@ -6550,7 +6662,8 @@ vector<result_type> densities() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns A \tcode{vector<result_type>}
+\pnum
+\returns A \tcode{vector<result_type>}
  whose \tcode{size} member returns $n$
  and whose $ \tcode{operator[]} $ member returns $\rho_k$
  when invoked with argument $k$ for $k = 0, \dotsc, n$.
@@ -9676,7 +9789,8 @@ ISO C 7.12.3, 7.12.4
 \rSec2[sf.cmath]{Mathematical special functions}%
 \indextext{mathematical special functions|(}%
 
-\pnum\indextext{NaN}\indextext{domain error}%
+\pnum
+\indextext{NaN}\indextext{domain error}%
 If any argument value
 to any of the functions specified in this subclause
 is a NaN (Not a Number),
@@ -9774,7 +9888,8 @@ long double  assoc_legendrel(unsigned l, unsigned m, long double x);
 
 \begin{itemdescr}
 
-\pnum\effects
+\pnum
+\effects
 These functions compute
 the associated Legendre functions
 of their respective arguments
@@ -9971,13 +10086,15 @@ long double  cyl_bessel_jl(long double nu, long double x);
 
 \begin{itemdescr}
 
-\pnum\effects
+\pnum
+\effects
 These functions compute
 the cylindrical Bessel functions of the first kind
 of their respective arguments
 \tcode{nu} and \tcode{x}.
 
-\pnum\returns
+\pnum
+\returns
 \[ \mathsf{J}_\nu(x) =
    \sum_{k=0}^\infty \frac{(-1)^k (x/2)^{\nu+2k}}{k! \: \Gamma(\nu+k+1)}
    \text{ ,\quad for $x \ge 0$,} \]
@@ -9985,7 +10102,8 @@ where
 $\nu$ is \tcode{nu} and
 $x$ is \tcode{x}.
 
-\pnum\remarks
+\pnum
+\remarks
 The effect of calling each of these functions
 is \impldef{effect of calling cylindrical Bessel functions of the first kind with \tcode{nu >= 128}}
 if \tcode{nu >= 128}.
@@ -10005,13 +10123,15 @@ long double  cyl_bessel_kl(long double nu, long double x);
 
 \begin{itemdescr}
 
-\pnum\effects
+\pnum
+\effects
 These functions compute
 the irregular modified cylindrical Bessel functions
 of their respective arguments
 \tcode{nu} and \tcode{x}.
 
-\pnum\returns
+\pnum
+\returns
 \[%
   \mathsf{K}_\nu(x) =
   (\pi/2)\mathrm{i}^{\nu+1} (            \mathsf{J}_\nu(\mathrm{i}x)
@@ -10039,12 +10159,14 @@ where
 $\nu$ is \tcode{nu} and
 $x$ is \tcode{x}.
 
-\pnum\remarks
+\pnum
+\remarks
 The effect of calling each of these functions
 is \impldef{effect of calling irregular modified cylindrical Bessel functions with \tcode{nu >= 128}}
 if \tcode{nu >= 128}.
 
-\pnum See also \ref{sf.cmath.cyl.bessel.i}, \ref{sf.cmath.cyl.bessel.j}, \ref{sf.cmath.cyl.neumann}.
+\pnum
+See also \ref{sf.cmath.cyl.bessel.i}, \ref{sf.cmath.cyl.bessel.j}, \ref{sf.cmath.cyl.neumann}.
 \end{itemdescr}
 
 \rSec3[sf.cmath.cyl.neumann]{Cylindrical Neumann functions}%
@@ -10062,13 +10184,15 @@ long double  cyl_neumannl(long double nu, long double x);
 
 \begin{itemdescr}
 
-\pnum\effects
+\pnum
+\effects
 These functions compute the cylindrical Neumann functions,
 also known as the cylindrical Bessel functions of the second kind,
 of their respective arguments
 \tcode{nu} and \tcode{x}.
 
-\pnum\returns
+\pnum
+\returns
 \[%
   \mathsf{N}_\nu(x) =
   \left\{
@@ -10090,12 +10214,14 @@ where
 $\nu$ is \tcode{nu} and
 $x$ is \tcode{x}.
 
-\pnum\remarks
+\pnum
+\remarks
 The effect of calling each of these functions
 is \impldef{effect of calling cylindrical Neumann functions with \tcode{nu >= 128}}
 if \tcode{nu >= 128}.
 
-\pnum See also \ref{sf.cmath.cyl.bessel.j}.
+\pnum
+See also \ref{sf.cmath.cyl.bessel.j}.
 \end{itemdescr}
 
 \rSec3[sf.cmath.ellint.1]{Incomplete elliptic integral of the first kind}%
@@ -10171,7 +10297,8 @@ long double  ellint_3l(long double k, long double nu, long double phi);
 
 \begin{itemdescr}
 
-\pnum\effects
+\pnum
+\effects
 These functions compute
 the incomplete elliptic integral of the third kind
 of their respective arguments
@@ -10201,12 +10328,14 @@ long double  expintl(long double x);
 
 \begin{itemdescr}
 
-\pnum\effects
+\pnum
+\effects
 These functions compute the exponential integral
 of their respective arguments
 \tcode{x}.
 
-\pnum\returns
+\pnum
+\returns
 \[%
   \mathsf{Ei}(x) =
   - \int_{-x}^\infty \frac{e^{-t}}
@@ -10231,12 +10360,14 @@ long double  hermitel(unsigned n, long double x);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects
+\pnum
+\effects
 These functions compute the Hermite polynomials
 of their respective arguments
 \tcode{n} and \tcode{x}.
 
-\pnum\returns
+\pnum
+\returns
 \[%
   \mathsf{H}_n(x) =
   (-1)^n e^{x^2} \frac{ \mathsf{d} ^n}
@@ -10247,7 +10378,8 @@ where
 $n$ is \tcode{n} and
 $x$ is \tcode{x}.
 
-\pnum\remarks
+\pnum
+\remarks
 The effect of calling each of these functions
 is \impldef{effect of calling Hermite polynomials with \tcode{n >= 128}}
 if \tcode{n >= 128}.
@@ -10337,12 +10469,14 @@ long double  riemann_zetal(long double x);
 
 \begin{itemdescr}
 
-\pnum\effects
+\pnum
+\effects
 These functions compute the Riemann zeta function
 of their respective arguments
 \tcode{x}.
 
-\pnum\returns
+\pnum
+\returns
 \[%
   \mathsf{\zeta}(x) =
   \left\{
@@ -10397,12 +10531,14 @@ where
 $n$ is \tcode{n} and
 $x$ is \tcode{x}.
 
-\pnum\remarks
+\pnum
+\remarks
 The effect of calling each of these functions
 is \impldef{effect of calling spherical Bessel functions with \tcode{n >= 128}}
 if \tcode{n >= 128}.
 
-\pnum See also \ref{sf.cmath.cyl.bessel.j}.
+\pnum
+See also \ref{sf.cmath.cyl.bessel.j}.
 \end{itemdescr}
 
 \rSec3[sf.cmath.sph.legendre]{Spherical associated Legendre functions}%

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -7492,7 +7492,8 @@ slice_array<T> operator[](slice slicearr);
 \pnum
 \returns
 An object that holds references to elements of the controlled
-sequence selected by \tcode{slicearr}. \begin{example}
+sequence selected by \tcode{slicearr}.
+\begin{example}
 \begin{codeblock}
 valarray<char> v0("abcdefghijklmnop", 16);
 valarray<char> v1("ABCDE", 5);
@@ -7533,7 +7534,8 @@ gslice_array<T> operator[](const gslice& gslicearr);
 \pnum
 \returns
 An object that holds references to elements of the controlled
-sequence selected by \tcode{gslicearr}. \begin{example}
+sequence selected by \tcode{gslicearr}.
+\begin{example}
 \begin{codeblock}
 valarray<char> v0("abcdefghijklmnop", 16);
 valarray<char> v1("ABCDEF", 6);
@@ -7575,7 +7577,8 @@ mask_array<T> operator[](const valarray<bool>& boolarr);
 \pnum
 \returns
 An object that holds references to elements of the controlled
-sequence selected by \tcode{boolarr}. \begin{example}
+sequence selected by \tcode{boolarr}.
+\begin{example}
 \begin{codeblock}
 valarray<char> v0("abcdefghijklmnop", 16);
 valarray<char> v1("ABC", 3);
@@ -7615,7 +7618,8 @@ indirect_array<T> operator[](const valarray<size_t>& indarr);
 \pnum
 \returns
 An object that holds references to elements of the controlled
-sequence selected by \tcode{indarr}. \begin{example}
+sequence selected by \tcode{indarr}.
+\begin{example}
 \begin{codeblock}
 valarray<char> v0("abcdefghijklmnop", 16);
 valarray<char> v1("ABCDE", 5);

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -26,7 +26,6 @@ in the declarations that are visible at the point of use.
 This function selection process is called
 \defn{overload resolution} and is defined in~\ref{over.match}.
 \begin{example}
-
 \indextext{overloading!example of}%
 \begin{codeblock}
 double abs(double);
@@ -111,7 +110,6 @@ declarations with the same name, the same parameter-type-list, and
 the same template parameter lists cannot be overloaded if any of them, but not
 all, have a \grammarterm{ref-qualifier}\iref{dcl.fct}.
 \begin{example}
-
 \begin{codeblock}
 class Y {
   void h() &;
@@ -182,7 +180,6 @@ declaration\iref{dcl.fct}.
 Only the second and subsequent array dimensions are significant in
 parameter types\iref{dcl.array}.
 \begin{example}
-
 \begin{codeblock}
 int f(char*);
 int f(char[]);                  // same as \tcode{f(char*);}
@@ -203,7 +200,6 @@ Parameter declarations that differ only in that one is a function type
 and the other is a pointer to the same function type are equivalent.
 That is, the function type is adjusted to become a pointer to function type\iref{dcl.fct}.
 \begin{example}
-
 \begin{codeblock}
 void h(int());
 void h(int (*)());              // redeclaration of \tcode{h(int())}
@@ -314,7 +310,6 @@ A function member of a derived class is
 \textit{not}
 in the same scope as a function member of the same name in a base class.
 \begin{example}
-
 \begin{codeblock}
 struct B {
   int f(int);
@@ -348,7 +343,6 @@ void h(D* pd) {
 A locally declared function is not in the same scope as a function in
 a containing scope.
 \begin{example}
-
 \begin{codeblock}
 void f(const char*);
 void g() {
@@ -373,7 +367,6 @@ void caller () {
 Different versions of an overloaded member function can be given different
 access rules.
 \begin{example}
-
 \begin{codeblock}
 class buffer {
 private:
@@ -596,7 +589,6 @@ implicit conversion sequence, special rules apply when selecting
 the best user-defined conversion~(\ref{over.match.best},
 \ref{over.best.ics}).
 \begin{example}
-
 \begin{codeblock}
 class T {
 public:
@@ -924,7 +916,6 @@ appropriate function pointer or reference required by that first
 parameter.
 \end{note}
 \begin{example}
-
 \begin{codeblock}
 int f1(int);
 int f2(float);
@@ -961,7 +952,6 @@ the conversions to be applied to the second and third operands when they
 have class or enumeration type\iref{expr.cond}.
 \end{note}
 \begin{example}
-
 \begin{codeblock}
 struct String {
   String (const String&);
@@ -1152,7 +1142,6 @@ according to~\ref{over.match.viable}
 and~\ref{over.match.best}.\footnote{If the set of candidate functions is empty,
 overload resolution is unsuccessful.}
 \begin{example}
-
 \begin{codeblock}
 struct A {
   operator int();
@@ -2477,7 +2466,6 @@ unless the argument expression has a type that is a derived class of the paramet
 type, in which case the implicit conversion sequence is a derived-to-base
 Conversion\iref{over.best.ics}.
 \begin{example}
-
 \begin{codeblock}
 struct A {};
 struct B : public A {} b;
@@ -2982,7 +2970,6 @@ is better than
 the second standard conversion sequence of
 \tcode{U2}.
 \begin{example}
-
 \begin{codeblock}
 struct A {
   operator short();
@@ -3058,7 +3045,6 @@ is better than conversion of
 to
 \tcode{A*},
 \begin{example}
-
 \begin{codeblock}
 struct A {};
 struct B : public A {};
@@ -3405,7 +3391,6 @@ They can be explicitly called, however, using the
 \grammarterm{operator-function-id}
 as the name of the function in the function call syntax\iref{expr.call}.
 \begin{example}
-
 \begin{codeblock}
 complex z = a.operator+(b);     // \tcode{complex z = a+b;}
 void* p = operator new(sizeof(int)*n);
@@ -3564,7 +3549,6 @@ does not override
 \tcode{B}'s
 virtual copy/move assignment operator.
 \begin{example}
-
 \begin{codeblock}
 struct B {
   virtual int operator= (int);
@@ -3728,7 +3712,6 @@ The argument to
 is
 \tcode{2}.}
 \begin{example}
-
 \begin{codeblock}
 struct X {
   X&   operator++();            // prefix \tcode{++a}

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -932,7 +932,6 @@ struct A {
 int i = a(1);                   // calls \tcode{f1} via pointer returned from conversion function
 \end{codeblock}
 \end{example}
-%
 \indextext{overloading!resolution!function call syntax|)}
 
 \rSec3[over.match.oper]{Operators in expressions}%
@@ -1797,7 +1796,6 @@ template<std::integral W, class U>
   auto f2_prime_for_B(W *, U) -> C<W *, std::type_identity_t<U>>;
 \end{codeblock}
 \end{example}
-%
 \indextext{overloading!argument lists|)}%
 \indextext{overloading!candidate functions|)}
 
@@ -3860,7 +3858,6 @@ template <char...> int operator "" _j(const char*); // error: invalid \grammarte
 extern "C" void operator "" _m(long double);        // error: C language linkage
 \end{codeblock}
 \end{example}
-%
 \indextext{overloading!operator|)}
 
 \rSec1[over.built]{Built-in operators}%

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -576,7 +576,8 @@ const-qualified,
 an rvalue can be bound to the parameter
 as long as in all other respects the argument can be
 converted to the type of the implicit object parameter.
-\begin{note} The fact that such an argument is an rvalue does not
+\begin{note}
+The fact that such an argument is an rvalue does not
 affect the ranking of implicit conversion sequences\iref{over.ics.rank}.
 \end{note}
 \end{itemize}
@@ -687,8 +688,11 @@ resolution is applied as specified in \ref{over.call.object}.
 If the \grammarterm{postfix-expression} denotes the address of a set of overloaded
 functions and/or function templates, overload resolution is applied using that set as
 described above. If the function selected by overload resolution is a non-static member
-function, the program is ill-formed. \begin{note} The resolution of the address of an
-overload set in other contexts is described in \ref{over.over}. \end{note}
+function, the program is ill-formed.
+\begin{note}
+The resolution of the address of an
+overload set in other contexts is described in \ref{over.over}.
+\end{note}
 
 \rSec4[over.call.func]{Call to named function}
 
@@ -927,7 +931,8 @@ struct A {
 } a;
 int i = a(1);                   // calls \tcode{f1} via pointer returned from conversion function
 \end{codeblock}
-\end{example}%
+\end{example}
+%
 \indextext{overloading!resolution!function call syntax|)}
 
 \rSec3[over.match.oper]{Operators in expressions}%
@@ -1301,9 +1306,11 @@ conversion can be invoked to convert an initializer expression to the
 type of the object being initialized.
 Overload resolution is used
 to select the user-defined conversion to be invoked.
-\begin{note} The conversion performed for indirect binding to a reference to a possibly
+\begin{note}
+The conversion performed for indirect binding to a reference to a possibly
 cv-qualified class type is determined in terms of a corresponding non-reference
-copy-initialization. \end{note}
+copy-initialization.
+\end{note}
 Assuming that
 ``\cvqual{cv1} \tcode{T}'' is the type of the object being initialized, with
 \tcode{T}
@@ -1476,12 +1483,14 @@ the argument list consists of the elements of the initializer list.
 If the initializer list has no elements and \tcode{T} has a default constructor,
 the first phase is omitted.
 In copy-list-initialization, if an explicit constructor is
-chosen, the initialization is ill-formed. \begin{note}
+chosen, the initialization is ill-formed.
+\begin{note}
 This differs from other situations~(\ref{over.match.ctor}, \ref{over.match.copy}),
 where only converting constructors are considered for copy-initialization.
 This restriction only
 applies if this initialization is part of the final result of overload
-resolution. \end{note}
+resolution.
+\end{note}
 
 \rSec3[over.match.class.deduct]{Class template argument deduction}%
 \indextext{deduction!class template arguments}%
@@ -1787,7 +1796,8 @@ template<std::integral W, class U>
     deduces_B<C<W *, std::type_identity_t<U>>>
   auto f2_prime_for_B(W *, U) -> C<W *, std::type_identity_t<U>>;
 \end{codeblock}
-\end{example}%
+\end{example}
+%
 \indextext{overloading!argument lists|)}%
 \indextext{overloading!candidate functions|)}
 
@@ -2699,9 +2709,11 @@ f( {1.0} );             // error: narrowing
 \end{example}
 
 \pnum
-Otherwise, if the parameter is a reference, see~\ref{over.ics.ref}. \begin{note}
+Otherwise, if the parameter is a reference, see~\ref{over.ics.ref}.
+\begin{note}
 The rules in this subclause will apply for initializing the underlying temporary
-for the reference. \end{note}
+for the reference.
+\end{note}
 \begin{example}
 \begin{codeblock}
 struct A {
@@ -3819,7 +3831,8 @@ or a string literal operator template.
 Literal operators and literal operator templates shall not have C language linkage.
 
 \pnum
-\begin{note} Literal operators and literal operator templates are usually invoked
+\begin{note}
+Literal operators and literal operator templates are usually invoked
 implicitly through user-defined literals\iref{lex.ext}. However, except for
 the constraints described above, they are ordinary namespace-scope functions and
 function templates. In particular, they are looked up like ordinary functions
@@ -3827,7 +3840,8 @@ and function templates and they follow the same overload resolution rules. Also,
 they can be declared \tcode{inline} or \tcode{constexpr},
 they may have internal, module, or external linkage,
 they can be called explicitly, their addresses can be
-taken, etc. \end{note}
+taken, etc.
+\end{note}
 
 \pnum
 \begin{example}
@@ -3845,7 +3859,8 @@ double operator "" _miles(double);                  // error: invalid \grammarte
 template <char...> int operator "" _j(const char*); // error: invalid \grammarterm{parameter-declaration-clause}
 extern "C" void operator "" _m(long double);        // error: C language linkage
 \end{codeblock}
-\end{example}%
+\end{example}
+%
 \indextext{overloading!operator|)}
 
 \rSec1[over.built]{Built-in operators}%

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -109,7 +109,8 @@ class X {
 parameter-type-list\iref{dcl.fct} as well as member function template
 declarations with the same name, the same parameter-type-list, and
 the same template parameter lists cannot be overloaded if any of them, but not
-all, have a \grammarterm{ref-qualifier}\iref{dcl.fct}. \begin{example}
+all, have a \grammarterm{ref-qualifier}\iref{dcl.fct}.
+\begin{example}
 
 \begin{codeblock}
 class Y {
@@ -2601,7 +2602,8 @@ of the initializer list can be implicitly converted to \tcode{X}, the implicit
 conversion sequence is the worst conversion necessary to convert an element of
 the list to \tcode{X}, or if the initializer list has no elements, the identity
 conversion. This conversion can be a user-defined conversion even in
-the context of a call to an initializer-list constructor. \begin{example}
+the context of a call to an initializer-list constructor.
+\begin{example}
 \begin{codeblock}
 void f(std::initializer_list<int>);
 f( {} );                        // OK: \tcode{f(initializer_list<int>)} identity conversion
@@ -2694,7 +2696,8 @@ Otherwise, if the parameter has an aggregate type which can be initialized from
 the initializer list according to the rules for aggregate
 initialization\iref{dcl.init.aggr}, the implicit conversion sequence is a
 user-defined conversion sequence with the second standard conversion
-sequence an identity conversion. \begin{example}
+sequence an identity conversion.
+\begin{example}
 \begin{codeblock}
 struct A {
   int m1;
@@ -2710,7 +2713,8 @@ f( {1.0} );             // error: narrowing
 \pnum
 Otherwise, if the parameter is a reference, see~\ref{over.ics.ref}. \begin{note}
 The rules in this subclause will apply for initializing the underlying temporary
-for the reference. \end{note} \begin{example}
+for the reference. \end{note}
+\begin{example}
 \begin{codeblock}
 struct A {
   int m1;
@@ -2732,7 +2736,8 @@ Otherwise, if the parameter type is not a class:
 \begin{itemize}
 \item if the initializer list has one element that is not itself an initializer list,
 the implicit conversion sequence is the one required to convert the element to
-the parameter type; \begin{example}
+the parameter type;
+\begin{example}
 \begin{codeblock}
 void f(int);
 f( {'a'} );             // OK: same conversion as \tcode{char} to \tcode{int}
@@ -2741,7 +2746,8 @@ f( {1.0} );             // error: narrowing
 \end{example}
 
 \item if the initializer list has no elements, the implicit conversion sequence
-is the identity conversion. \begin{example}
+is the identity conversion.
+\begin{example}
 \begin{codeblock}
 void f(int);
 f( { } );               // OK: identity conversion

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -176,7 +176,8 @@ before translation of the resulting translation unit.
 The preprocessing tokens within a preprocessing directive
 are not subject to macro expansion unless otherwise stated.
 
-\begin{example} In:
+\begin{example}
+In:
 
 \begin{codeblock}
 #define EMPTY
@@ -1191,7 +1192,8 @@ The order of evaluation of
 \tcode{\#\#}
 operators is unspecified.
 
-\begin{example} In the following fragment:
+\begin{example}
+In the following fragment:
 
 \begin{codeblock}
 #define hash_hash # ## #

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -187,7 +187,8 @@ EMPTY   #   include <file.h>
 the sequence of preprocessing tokens on the second line is \textit{not}
 a preprocessing directive, because it does not begin with a \tcode{\#} at the start of
 translation phase 4, even though it will do so after the macro \tcode{EMPTY}
-has been replaced.\end{example}
+has been replaced.
+\end{example}
 
 \rSec1[cpp.cond]{Conditional inclusion}%
 \indextext{preprocessing directive!conditional inclusion}%
@@ -1215,7 +1216,8 @@ mkstr(x ## y)
 
 In other words, expanding \tcode{hash_hash} produces a new token,
 consisting of two adjacent sharp signs, but this new token is not the
-\tcode{\#\#} operator. \end{example}
+\tcode{\#\#} operator.
+\end{example}
 
 \rSec2[cpp.rescan]{Rescanning and further replacement}%
 \indextext{macro!rescanning and replacement}%
@@ -1818,5 +1820,6 @@ as shown, or results from macro replacement, as in:
 
 LISTING( ..\listing.dir )
 \end{codeblock}
-\end{example}%
+\end{example}
+%
 \indextext{preprocessing directive|)}

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1821,5 +1821,4 @@ as shown, or results from macro replacement, as in:
 LISTING( ..\listing.dir )
 \end{codeblock}
 \end{example}
-%
 \indextext{preprocessing directive|)}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1189,10 +1189,12 @@ constexpr decltype(auto) front() const requires forward_range<const D>;
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{!empty()}.
+\expects
+\tcode{!empty()}.
 
 \pnum
-\effects Equivalent to: \tcode{return *ranges::begin(derived());}
+\effects
+Equivalent to: \tcode{return *ranges::begin(derived());}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{view_interface}!\idxcode{back}}%
@@ -1204,10 +1206,12 @@ constexpr decltype(auto) back() const
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{!empty()}.
+\expects
+\tcode{!empty()}.
 
 \pnum
-\effects Equivalent to: \tcode{return *ranges::prev(ranges::end(derived()));}
+\effects
+Equivalent to: \tcode{return *ranges::prev(ranges::end(derived()));}
 \end{itemdescr}
 
 \rSec2[range.subrange]{Sub-ranges}
@@ -1355,10 +1359,12 @@ constexpr subrange(I i, S s) requires (!StoreSize);
 
 \begin{itemdescr}
 \pnum
-\expects \range{i}{s} is a valid range.
+\expects
+\range{i}{s} is a valid range.
 
 \pnum
-\effects Initializes \tcode{begin_} with \tcode{i} and \tcode{end_} with
+\effects
+Initializes \tcode{begin_} with \tcode{i} and \tcode{end_} with
 \tcode{s}.
 \end{itemdescr}
 
@@ -1370,11 +1376,13 @@ constexpr subrange(I i, S s, @\placeholdernc{make-unsigned-like-t}@(iter_differe
 
 \begin{itemdescr}
 \pnum
-\expects \range{i}{s} is a valid range, and
+\expects
+\range{i}{s} is a valid range, and
 \tcode{n == \placeholdernc{make-unsigned-like}(ranges::distance(i, s))}.
 
 \pnum
-\effects Initializes \tcode{begin_} with \tcode{i} and \tcode{end_} with
+\effects
+Initializes \tcode{begin_} with \tcode{i} and \tcode{end_} with
 \tcode{s}. If \tcode{StoreSize} is \tcode{true}, initializes \tcode{size_} with
 \tcode{n}.
 
@@ -1397,7 +1405,8 @@ constexpr subrange(R&& r) requires (!StoreSize || sized_range<R>);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{itemize}
 \item If \tcode{StoreSize} is \tcode{true},
 \tcode{subrange\{ranges::begin(r), ranges::end(r), ranges::size(r)\}}.
@@ -1414,7 +1423,8 @@ constexpr operator PairLike() const;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return PairLike(begin_, end_);}
+\effects
+Equivalent to: \tcode{return PairLike(begin_, end_);}
 \end{itemdescr}
 
 \rSec3[range.subrange.access]{Accessors}
@@ -1426,7 +1436,8 @@ constexpr I begin() const;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return begin_;}
+\effects
+Equivalent to: \tcode{return begin_;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{end}!\idxcode{subrange}}%
@@ -1436,7 +1447,8 @@ constexpr S end() const;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return end_;}
+\effects
+Equivalent to: \tcode{return end_;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{empty}!\idxcode{subrange}}%
@@ -1446,7 +1458,8 @@ constexpr bool empty() const;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return begin_ == end_;}
+\effects
+Equivalent to: \tcode{return begin_ == end_;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{size}!\idxcode{subrange}}%
@@ -1471,7 +1484,8 @@ constexpr @\placeholdernc{make-unsigned-like-t}@(iter_difference_t<I>) size() co
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 auto tmp = *this;
 tmp.advance(n);
@@ -1493,7 +1507,8 @@ can invalidate \tcode{*this}.
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 auto tmp = *this;
 tmp.advance(-n);
@@ -1508,7 +1523,8 @@ constexpr subrange& advance(iter_difference_t<I> n);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{itemize}
 \item If \tcode{StoreSize} is \tcode{true},
 \begin{codeblock}
@@ -1536,7 +1552,8 @@ constexpr auto get(const subrange<I, S, K>& r);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 if constexpr (N == 0)
   return r.begin();
@@ -1685,7 +1702,8 @@ constexpr explicit single_view(const T& t);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{value_} with \tcode{t}.
+\effects
+Initializes \tcode{value_} with \tcode{t}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{single_view}!\idxcode{single_view}}%
@@ -1695,7 +1713,8 @@ constexpr explicit single_view(T&& t);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{value_} with \tcode{std::move(t)}.
+\effects
+Initializes \tcode{value_} with \tcode{std::move(t)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{single_view}!\idxcode{single_view}}%
@@ -1706,7 +1725,8 @@ constexpr single_view(in_place_t, Args&&... args);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{value_} as if by
+\effects
+Initializes \tcode{value_} as if by
 \tcode{value_\{in_place, std::forward<Args>(args)...\}}.
 \end{itemdescr}
 
@@ -1718,7 +1738,8 @@ constexpr const T* begin() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return data();}
+\effects
+Equivalent to: \tcode{return data();}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{end}!\idxcode{single_view}}%
@@ -1729,7 +1750,8 @@ constexpr const T* end() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return data() + 1;}
+\effects
+Equivalent to: \tcode{return data() + 1;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{size}!\idxcode{single_view}}%
@@ -1739,7 +1761,8 @@ static constexpr size_t size() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return 1;}
+\effects
+Equivalent to: \tcode{return 1;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{data}!\idxcode{single_view}}%
@@ -1750,7 +1773,8 @@ constexpr const T* data() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return value_.operator->();}
+\effects
+Equivalent to: \tcode{return value_.operator->();}
 \end{itemdescr}
 
 \rSec3[range.single.adaptor]{\tcode{views::single}}
@@ -1928,7 +1952,8 @@ constexpr explicit iota_view(W value);
 \tcode{Bound()} is reachable from \tcode{value}.
 
 \pnum
-\effects Initializes \tcode{value_} with \tcode{value}.
+\effects
+Initializes \tcode{value_} with \tcode{value}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{iota_view}!\idxcode{iota_view}}%
@@ -1945,7 +1970,8 @@ When \tcode{W} and \tcode{Bound} model \libconcept{totally_ordered_with},
 then \tcode{bool(value <= bound)} is \tcode{true}.
 
 \pnum
-\effects Initializes \tcode{value_} with \tcode{value} and
+\effects
+Initializes \tcode{value_} with \tcode{value} and
 \tcode{bound_} with \tcode{bound}.
 \end{itemdescr}
 
@@ -1956,7 +1982,8 @@ constexpr iterator begin() const;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return iterator\{value_\};}
+\effects
+Equivalent to: \tcode{return iterator\{value_\};}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{end}!\idxcode{iota_view}}%
@@ -1966,7 +1993,8 @@ constexpr auto end() const;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 if constexpr (same_as<Bound, unreachable_sentinel_t>)
   return unreachable_sentinel;
@@ -1982,7 +2010,8 @@ constexpr iterator end() const requires same_as<W, Bound>;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return iterator\{bound_\};}
+\effects
+Equivalent to: \tcode{return iterator\{bound_\};}
 \end{itemdescr}
 
 \indexlibrarymember{size}{iota_view}%
@@ -1992,7 +2021,8 @@ constexpr auto size() const requires @\seebelow@;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 if constexpr (@\placeholdernc{is-integer-like}@<W> && @\placeholdernc{is-integer-like}@<Bound>)
   return (value_ < 0)
@@ -2005,7 +2035,8 @@ else
 \end{codeblock}
 
 \pnum
-\remarks The expression in the \grammarterm{requires-clause} is equivalent to
+\remarks
+The expression in the \grammarterm{requires-clause} is equivalent to
 \begin{codeblock}
 (same_as<W, Bound> && @\placeholder{advanceable}@<W>) || (integral<W> && integral<Bound>) ||
   sized_sentinel_for<Bound, W>
@@ -2096,7 +2127,8 @@ constexpr explicit iterator(W value);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{value_} with \tcode{value}.
+\effects
+Initializes \tcode{value_} with \tcode{value}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator*}!\idxcode{iota_view::iterator}}
@@ -2106,7 +2138,8 @@ constexpr W operator*() const noexcept(is_nothrow_copy_constructible_v<W>);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return value_;}
+\effects
+Equivalent to: \tcode{return value_;}
 
 \pnum
 \begin{note}
@@ -2122,7 +2155,8 @@ constexpr iterator& operator++();
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 ++value_;
 return *this;
@@ -2136,7 +2170,8 @@ constexpr void operator++(int);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to \tcode{++*this}.
+\effects
+Equivalent to \tcode{++*this}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator++}!\idxcode{iota_view::iterator}}
@@ -2146,7 +2181,8 @@ constexpr iterator operator++(int) requires incrementable<W>;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 auto tmp = *this;
 ++*this;
@@ -2161,7 +2197,8 @@ constexpr iterator& operator--() requires @\placeholdernc{decrementable}@<W>;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 --value_;
 return *this;
@@ -2175,7 +2212,8 @@ constexpr iterator operator--(int) requires @\placeholdernc{decrementable}@<W>;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 auto tmp = *this;
 --*this;
@@ -2191,7 +2229,8 @@ constexpr iterator& operator+=(difference_type n)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 if constexpr (@\placeholdernc{is-integer-like}@<W> && !@\placeholdernc{is-signed-integer-like}@<W>) {
   if (n >= difference_type(0))
@@ -2213,7 +2252,8 @@ constexpr iterator& operator-=(difference_type n)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 if constexpr (@\placeholdernc{is-integer-like}@<W> && !@\placeholdernc{is-signed-integer-like}@<W>) {
   if (n >= difference_type(0))
@@ -2235,7 +2275,8 @@ constexpr W operator[](difference_type n) const
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return W(value_ + n);}
+\effects
+Equivalent to: \tcode{return W(value_ + n);}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator==}!\idxcode{iota_view::iterator}}
@@ -2246,7 +2287,8 @@ friend constexpr bool operator==(const iterator& x, const iterator& y)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return x.value_ == y.value_;}
+\effects
+Equivalent to: \tcode{return x.value_ == y.value_;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator<}!\idxcode{iota_view::iterator}}
@@ -2257,7 +2299,8 @@ friend constexpr bool operator<(const iterator& x, const iterator& y)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return x.value_ < y.value_;}
+\effects
+Equivalent to: \tcode{return x.value_ < y.value_;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator>}!\idxcode{iota_view::iterator}}
@@ -2268,7 +2311,8 @@ friend constexpr bool operator>(const iterator& x, const iterator& y)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return y < x;}
+\effects
+Equivalent to: \tcode{return y < x;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator<=}!\idxcode{iota_view::iterator}}
@@ -2279,7 +2323,8 @@ friend constexpr bool operator<=(const iterator& x, const iterator& y)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return !(y < x);}
+\effects
+Equivalent to: \tcode{return !(y < x);}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator>=}!\idxcode{iota_view::iterator}}
@@ -2290,7 +2335,8 @@ friend constexpr bool operator>=(const iterator& x, const iterator& y)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return !(x < y);}
+\effects
+Equivalent to: \tcode{return !(x < y);}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator<=>}!\idxcode{iota_view::iterator}}
@@ -2314,7 +2360,8 @@ friend constexpr iterator operator+(iterator i, difference_type n)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return i += n;}
+\effects
+Equivalent to: \tcode{return i += n;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator+}!\idxcode{iota_view::iterator}}
@@ -2325,7 +2372,8 @@ friend constexpr iterator operator+(difference_type n, iterator i)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return i + n;}
+\effects
+Equivalent to: \tcode{return i + n;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator-}!\idxcode{iota_view::iterator}}
@@ -2336,7 +2384,8 @@ friend constexpr iterator operator-(iterator i, difference_type n)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return i -= n;}
+\effects
+Equivalent to: \tcode{return i -= n;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator-}!\idxcode{iota_view::iterator}}
@@ -2347,7 +2396,8 @@ friend constexpr difference_type operator-(const iterator& x, const iterator& y)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 using D = difference_type;
 if constexpr (@\placeholder{is-integer-like}@<W>) {
@@ -2392,7 +2442,8 @@ constexpr explicit sentinel(Bound bound);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{bound_} with \tcode{bound}.
+\effects
+Initializes \tcode{bound_} with \tcode{bound}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator==}!\idxcode{iota_view::sentinel}}
@@ -2402,7 +2453,8 @@ friend constexpr bool operator==(const iterator& x, const sentinel& y);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return x.value_ == y.bound_;}
+\effects
+Equivalent to: \tcode{return x.value_ == y.bound_;}
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -2412,7 +2464,8 @@ friend constexpr iter_difference_t<W> operator-(const iterator& x, const sentine
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return x.value_ - y.bound_;}
+\effects
+Equivalent to: \tcode{return x.value_ - y.bound_;}
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -2422,7 +2475,8 @@ friend constexpr iter_difference_t<W> operator-(const sentinel& x, const iterato
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return -(y - x);}
+\effects
+Equivalent to: \tcode{return -(y - x);}
 \end{itemdescr}
 
 \rSec3[range.iota.adaptor]{\tcode{views::iota}}
@@ -2630,7 +2684,8 @@ constexpr ref_view(T&& t);
 
 \begin{itemdescr}
 \pnum
-\remarks Let \tcode{\placeholder{FUN}} denote the exposition-only functions
+\remarks
+Let \tcode{\placeholder{FUN}} denote the exposition-only functions
 \begin{codeblock}
 void @\placeholder{FUN}@(R&);
 void @\placeholder{FUN}@(R&&) = delete;
@@ -2711,7 +2766,8 @@ constexpr filter_view(V base, Pred pred);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{base_} with \tcode{std::move(base)} and initializes
+\effects
+Initializes \tcode{base_} with \tcode{std::move(base)} and initializes
 \tcode{pred_} with \tcode{std::move(pred)}.
 \end{itemdescr}
 
@@ -2724,7 +2780,8 @@ constexpr filter_view(R&& r, Pred pred);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{base_} with \tcode{views::all(std::forward<R>(r))}
+\effects
+Initializes \tcode{base_} with \tcode{views::all(std::forward<R>(r))}
 and initializes \tcode{pred_} with \tcode{std::\brk{}move(pred)}.
 \end{itemdescr}
 
@@ -2735,7 +2792,8 @@ constexpr V base() const;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return base_;}
+\effects
+Equivalent to: \tcode{return base_;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{begin}!\idxcode{filter_view}}%
@@ -2753,7 +2811,8 @@ constexpr iterator begin();
 \tcode{\{*this, ranges::find_if(base_, ref(*pred_))\}}.
 
 \pnum
-\remarks In order to provide the amortized constant time complexity required by
+\remarks
+In order to provide the amortized constant time complexity required by
 the \libconcept{range} concept, this function caches the result within the
 \tcode{filter_view} for use on subsequent calls.
 \end{itemdescr}
@@ -2842,7 +2901,8 @@ constexpr iterator(filter_view& parent, iterator_t<V> current);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{current_} with \tcode{current} and
+\effects
+Initializes \tcode{current_} with \tcode{current} and
 \tcode{parent_} with \tcode{addressof(parent)}.
 \end{itemdescr}
 
@@ -2853,7 +2913,8 @@ constexpr iterator_t<V> base() const;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return current_;}
+\effects
+Equivalent to: \tcode{return current_;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator*}!\idxcode{filter_view::iterator}}%
@@ -2863,7 +2924,8 @@ constexpr range_reference_t<V> operator*() const;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return *current_;}
+\effects
+Equivalent to: \tcode{return *current_;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator->}!\idxcode{filter_view::iterator}}%
@@ -2885,7 +2947,8 @@ constexpr iterator& operator++();
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 current_ = ranges::find_if(++current_, ranges::end(parent_->base_), ref(*parent_->pred_));
 return *this;
@@ -2899,7 +2962,8 @@ constexpr void operator++(int);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to \tcode{++*this}.
+\effects
+Equivalent to \tcode{++*this}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator++}!\idxcode{filter_view::iterator}}%
@@ -2909,7 +2973,8 @@ constexpr iterator operator++(int) requires forward_range<V>;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 auto tmp = *this;
 ++*this;
@@ -2924,7 +2989,8 @@ constexpr iterator& operator--() requires bidirectional_range<V>;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 do
   --current_;
@@ -2940,7 +3006,8 @@ constexpr iterator operator--(int) requires bidirectional_range<V>;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 auto tmp = *this;
 --*this;
@@ -2956,7 +3023,8 @@ friend constexpr bool operator==(const iterator& x, const iterator& y)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return x.current_ == y.current_;}
+\effects
+Equivalent to: \tcode{return x.current_ == y.current_;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{iter_move}!\idxcode{filter_view::iterator}}%
@@ -2967,7 +3035,8 @@ friend constexpr range_rvalue_reference_t<V> iter_move(const iterator& i)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return ranges::iter_move(i.current_);}
+\effects
+Equivalent to: \tcode{return ranges::iter_move(i.current_);}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{iter_swap}!\idxcode{filter_view::iterator}}%
@@ -2979,7 +3048,8 @@ friend constexpr void iter_swap(const iterator& x, const iterator& y)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to \tcode{ranges::iter_swap(x.current_, y.current_)}.
+\effects
+Equivalent to \tcode{ranges::iter_swap(x.current_, y.current_)}.
 \end{itemdescr}
 
 \rSec3[range.filter.sentinel]{Class \tcode{filter_view::sentinel}}
@@ -3009,7 +3079,8 @@ constexpr explicit sentinel(filter_view& parent);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{end_} with \tcode{ranges::end(parent.base_)}.
+\effects
+Initializes \tcode{end_} with \tcode{ranges::end(parent.base_)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{base}!\idxcode{filter_view::sentinel}}%
@@ -3019,7 +3090,8 @@ constexpr sentinel_t<V> base() const;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return end_;}
+\effects
+Equivalent to: \tcode{return end_;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator==}!\idxcode{filter_view::sentinel}}%
@@ -3029,7 +3101,8 @@ friend constexpr bool operator==(const iterator& x, const sentinel& y);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return x.current_ == y.end_;}
+\effects
+Equivalent to: \tcode{return x.current_ == y.end_;}
 \end{itemdescr}
 
 \rSec3[range.filter.adaptor]{\tcode{views::filter}}
@@ -3118,7 +3191,8 @@ constexpr transform_view(V base, F fun);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{base_} with \tcode{std::move(base)} and
+\effects
+Initializes \tcode{base_} with \tcode{std::move(base)} and
 \tcode{fun_} with \tcode{std::move(fun)}.
 \end{itemdescr}
 
@@ -3131,7 +3205,8 @@ constexpr transform_view(R&& r, F fun);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{base_} with \tcode{views::all(std::forward<R>(r))}
+\effects
+Initializes \tcode{base_} with \tcode{views::all(std::forward<R>(r))}
 and \tcode{fun_} with \tcode{std::move(fun)}.
 \end{itemdescr}
 
@@ -3142,7 +3217,8 @@ constexpr V base() const;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return base_;}
+\effects
+Equivalent to: \tcode{return base_;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{begin}!\idxcode{transform_view}}%
@@ -3152,7 +3228,8 @@ constexpr iterator<false> begin();
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return iterator<false>{*this, ranges::begin(base_)};
 \end{codeblock}
@@ -3167,7 +3244,8 @@ constexpr iterator<true> begin() const
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return iterator<true>{*this, ranges::begin(base_)};
 \end{codeblock}
@@ -3180,7 +3258,8 @@ constexpr sentinel<false> end();
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return sentinel<false>{ranges::end(base_)};
 \end{codeblock}
@@ -3193,7 +3272,8 @@ constexpr iterator<false> end() requires common_range<V>;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return iterator<false>{*this, ranges::end(base_)};
 \end{codeblock}
@@ -3208,7 +3288,8 @@ constexpr sentinel<true> end() const
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return sentinel<true>{ranges::end(base_)};
 \end{codeblock}
@@ -3223,7 +3304,8 @@ constexpr iterator<true> end() const
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return iterator<true>{*this, ranges::end(base_)};
 \end{codeblock}
@@ -3346,7 +3428,8 @@ constexpr iterator(Parent& parent, iterator_t<Base> current);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{current_} with \tcode{current} and
+\effects
+Initializes \tcode{current_} with \tcode{current} and
 \tcode{parent_} with \tcode{addressof(parent)}.
 \end{itemdescr}
 
@@ -3358,7 +3441,8 @@ constexpr iterator(iterator<!Const> i)
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{current_} with \tcode{std::move(i.current_)} and
+\effects
+Initializes \tcode{current_} with \tcode{std::move(i.current_)} and
 \tcode{parent_} with \tcode{i.parent_}.
 \end{itemdescr}
 
@@ -3369,7 +3453,8 @@ constexpr iterator_t<Base> base() const;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return current_;}
+\effects
+Equivalent to: \tcode{return current_;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator++}!\idxcode{transform_view::iterator}}
@@ -3379,7 +3464,8 @@ constexpr iterator& operator++();
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 ++current_;
 return *this;
@@ -3393,7 +3479,8 @@ constexpr void operator++(int);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to \tcode{++current_}.
+\effects
+Equivalent to \tcode{++current_}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator++}!\idxcode{transform_view::iterator}}
@@ -3403,7 +3490,8 @@ constexpr iterator operator++(int) requires forward_range<Base>;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 auto tmp = *this;
 ++*this;
@@ -3418,7 +3506,8 @@ constexpr iterator& operator--() requires bidirectional_range<Base>;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 --current_;
 return *this;
@@ -3432,7 +3521,8 @@ constexpr iterator operator--(int) requires bidirectional_range<Base>;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 auto tmp = *this;
 --*this;
@@ -3448,7 +3538,8 @@ constexpr iterator& operator+=(difference_type n)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 current_ += n;
 return *this;
@@ -3463,7 +3554,8 @@ constexpr iterator& operator-=(difference_type n)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 current_ -= n;
 return *this;
@@ -3478,7 +3570,8 @@ friend constexpr bool operator==(const iterator& x, const iterator& y)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return x.current_ == y.current_;}
+\effects
+Equivalent to: \tcode{return x.current_ == y.current_;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator<}!\idxcode{transform_view::iterator}}%
@@ -3489,7 +3582,8 @@ friend constexpr bool operator<(const iterator& x, const iterator& y)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return x.current_ < y.current_;}
+\effects
+Equivalent to: \tcode{return x.current_ < y.current_;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator>}!\idxcode{transform_view::iterator}}%
@@ -3500,7 +3594,8 @@ friend constexpr bool operator>(const iterator& x, const iterator& y)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return y < x;}
+\effects
+Equivalent to: \tcode{return y < x;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator<=}!\idxcode{transform_view::iterator}}%
@@ -3511,7 +3606,8 @@ friend constexpr bool operator<=(const iterator& x, const iterator& y)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return !(y < x);}
+\effects
+Equivalent to: \tcode{return !(y < x);}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator>=}!\idxcode{transform_view::iterator}}%
@@ -3522,7 +3618,8 @@ friend constexpr bool operator>=(const iterator& x, const iterator& y)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return !(x < y);}
+\effects
+Equivalent to: \tcode{return !(x < y);}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator<=>}!\idxcode{transform_view::iterator}}%
@@ -3534,7 +3631,8 @@ friend constexpr compare_three_way_result_t<iterator_t<Base>>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return x.current_ <=> y.current_;}
+\effects
+Equivalent to: \tcode{return x.current_ <=> y.current_;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator+}!\idxcode{transform_view::iterator}}
@@ -3547,7 +3645,8 @@ friend constexpr iterator operator+(difference_type n, iterator i)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return iterator\{*i.parent_, i.current_ + n\};}
+\effects
+Equivalent to: \tcode{return iterator\{*i.parent_, i.current_ + n\};}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator-}!\idxcode{transform_view::iterator}}%
@@ -3558,7 +3657,8 @@ friend constexpr iterator operator-(iterator i, difference_type n)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return iterator\{*i.parent_, i.current_ - n\};}
+\effects
+Equivalent to: \tcode{return iterator\{*i.parent_, i.current_ - n\};}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator-}!\idxcode{transform_view::iterator}}%
@@ -3569,7 +3669,8 @@ friend constexpr difference_type operator-(const iterator& x, const iterator& y)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return x.current_ - y.current_;}
+\effects
+Equivalent to: \tcode{return x.current_ - y.current_;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{iter_swap}!\idxcode{transform_view::iterator}}
@@ -3581,7 +3682,8 @@ friend constexpr void iter_swap(const iterator& x, const iterator& y)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to \tcode{ranges::iter_swap(x.current_, y.current_)}.
+\effects
+Equivalent to \tcode{ranges::iter_swap(x.current_, y.current_)}.
 \end{itemdescr}
 
 
@@ -3624,7 +3726,8 @@ constexpr explicit sentinel(sentinel_t<Base> end);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{end_} with \tcode{end}.
+\effects
+Initializes \tcode{end_} with \tcode{end}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{sentinel}!\idxcode{transform_view::sentinel}}
@@ -3635,7 +3738,8 @@ constexpr sentinel(sentinel<!Const> i)
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{end_} with \tcode{std::move(i.end_)}.
+\effects
+Initializes \tcode{end_} with \tcode{std::move(i.end_)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{base}!\idxcode{transform_view::sentinel}}
@@ -3645,7 +3749,8 @@ constexpr sentinel_t<Base> base() const;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return end_;}
+\effects
+Equivalent to: \tcode{return end_;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator==}!\idxcode{transform_view::sentinel}}
@@ -3655,7 +3760,8 @@ friend constexpr bool operator==(const iterator<Const>& x, const sentinel& y);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return x.current_ == y.end_;}
+\effects
+Equivalent to: \tcode{return x.current_ == y.end_;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator-}!\idxcode{transform_view::sentinel}}%
@@ -3667,7 +3773,8 @@ friend constexpr range_difference_t<Base>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return x.current_ - y.end_;}
+\effects
+Equivalent to: \tcode{return x.current_ - y.end_;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator-}!\idxcode{transform_view::sentinel}}%
@@ -3679,7 +3786,8 @@ friend constexpr range_difference_t<Base>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return x.end_ - y.current_;}
+\effects
+Equivalent to: \tcode{return x.end_ - y.current_;}
 \end{itemdescr}
 
 \rSec3[range.transform.adaptor]{\tcode{views::transform}}
@@ -3795,7 +3903,8 @@ constexpr take_view(V base, range_difference_t<V> count);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{base_} with \tcode{std::move(base)} and
+\effects
+Initializes \tcode{base_} with \tcode{std::move(base)} and
 \tcode{count_} with \tcode{count}.
 \end{itemdescr}
 
@@ -3808,7 +3917,8 @@ constexpr take_view(R&& r, range_difference_t<V> count);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{base_} with \tcode{views::all(std::forward<R>(r))}
+\effects
+Initializes \tcode{base_} with \tcode{views::all(std::forward<R>(r))}
 and \tcode{count_} with \tcode{count}.
 \end{itemdescr}
 
@@ -3819,7 +3929,8 @@ constexpr V base() const;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return base_;}
+\effects
+Equivalent to: \tcode{return base_;}
 \end{itemdescr}
 
 \rSec3[range.take.sentinel]{Class template \tcode{take_view::sentinel}}
@@ -3853,7 +3964,8 @@ constexpr explicit sentinel(sentinel_t<Base> end);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{end_} with \tcode{end}.
+\effects
+Initializes \tcode{end_} with \tcode{end}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{sentinel}!\idxcode{take_view::sentinel}}%
@@ -3864,7 +3976,8 @@ constexpr sentinel(sentinel<!Const> s)
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{end_} with \tcode{std::move(s.end_)}.
+\effects
+Initializes \tcode{end_} with \tcode{std::move(s.end_)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{base}!\idxcode{take_view::sentinel}}
@@ -3874,7 +3987,8 @@ constexpr sentinel_t<Base> base() const;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return end_;}
+\effects
+Equivalent to: \tcode{return end_;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator==}!\idxcode{take_view::sentinel}}
@@ -3884,7 +3998,8 @@ friend constexpr bool operator==(const CI& y, const sentinel& x);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \tcode{return y.count() == 0 || y.base() == x.end_;}
 \end{itemdescr}
 
@@ -4400,7 +4515,8 @@ constexpr explicit join_view(V base);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{base_} with \tcode{std::move(base)}.
+\effects
+Initializes \tcode{base_} with \tcode{std::move(base)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{join_view}!\idxcode{join_view}}%
@@ -4412,7 +4528,8 @@ constexpr explicit join_view(R&& r);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{base_} with \tcode{views::all(std::forward<R>(r))}.
+\effects
+Initializes \tcode{base_} with \tcode{views::all(std::forward<R>(r))}.
 \end{itemdescr}
 
 \rSec3[range.join.iterator]{Class template \tcode{join_view::iterator}}
@@ -4537,7 +4654,8 @@ constexpr void satisfy();       // \expos
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 auto update_inner = [this](range_reference_t<Base> x) -> decltype(auto) {
   if constexpr (ref_is_glvalue) // \tcode{x} is a reference
@@ -4564,7 +4682,8 @@ constexpr iterator(Parent& parent, iterator_t<V> outer)
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{outer_} with \tcode{outer} and
+\effects
+Initializes \tcode{outer_} with \tcode{outer} and
 \tcode{parent_} with \tcode{addressof(parent)}; then calls \tcode{satisfy()}.
 \end{itemdescr}
 
@@ -4579,7 +4698,8 @@ constexpr iterator(iterator<!Const> i)
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{outer_} with \tcode{std::move(i.outer_)},
+\effects
+Initializes \tcode{outer_} with \tcode{std::move(i.outer_)},
 \tcode{inner_} with \tcode{std::move(i.inner_)}, and
 \tcode{parent_} with \tcode{i.parent_}.
 \end{itemdescr}
@@ -4592,7 +4712,8 @@ constexpr iterator_t<Base> operator->() const
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to \tcode{return inner_;}
+\effects
+Equivalent to \tcode{return inner_;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator++}!\idxcode{join_view::iterator}}
@@ -4609,7 +4730,8 @@ Let \tcode{\placeholder{inner-range}} be:
 \end{itemize}
 
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 auto&& inner_rng = @\placeholder{inner-range}@;
 if (++inner_ == ranges::end(inner_rng)) {
@@ -4627,7 +4749,8 @@ constexpr void operator++(int);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{++*this}.
+\effects
+Equivalent to: \tcode{++*this}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator++}!\idxcode{join_view::iterator}}
@@ -4639,7 +4762,8 @@ constexpr iterator operator++(int)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 auto tmp = *this;
 ++*this;
@@ -4656,7 +4780,8 @@ constexpr iterator& operator--()
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 if (outer_ == ranges::end(parent_->base_))
   inner_ = ranges::end(*--outer_);
@@ -4676,7 +4801,8 @@ constexpr iterator operator--(int)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 auto tmp = *this;
 --*this;
@@ -4693,7 +4819,8 @@ friend constexpr bool operator==(const iterator& x, const iterator& y)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \tcode{return x.outer_ == y.outer_ \&\& x.inner_ == y.inner_;}
 \end{itemdescr}
 
@@ -4705,7 +4832,8 @@ friend constexpr void iter_swap(const iterator& x, const iterator& y)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return ranges::iter_swap(x.inner_, y.inner_);}
+\effects
+Equivalent to: \tcode{return ranges::iter_swap(x.inner_, y.inner_);}
 \end{itemdescr}
 
 \rSec3[range.join.sentinel]{Class template \tcode{join_view::sentinel}}
@@ -4739,7 +4867,8 @@ constexpr explicit sentinel(Parent& parent);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{end_} with \tcode{ranges::end(parent.base_)}.
+\effects
+Initializes \tcode{end_} with \tcode{ranges::end(parent.base_)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{sentinel}!\idxcode{join_view::sentinel}}
@@ -4750,7 +4879,8 @@ constexpr sentinel(sentinel<!Const> s)
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{end_} with \tcode{std::move(s.end_)}.
+\effects
+Initializes \tcode{end_} with \tcode{std::move(s.end_)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator==}!\idxcode{join_view::sentinel}}
@@ -4760,7 +4890,8 @@ friend constexpr bool operator==(const iterator<Const>& x, const sentinel& y);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return x.outer_ == y.end_;}
+\effects
+Equivalent to: \tcode{return x.outer_ == y.end_;}
 \end{itemdescr}
 
 \rSec3[range.join.adaptor]{\tcode{views::join}}
@@ -4875,7 +5006,8 @@ constexpr split_view(V base, Pattern pattern);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{base_} with \tcode{std::move(base)}, and
+\effects
+Initializes \tcode{base_} with \tcode{std::move(base)}, and
 \tcode{pattern_} with \tcode{std::move(pattern)}.
 \end{itemdescr}
 
@@ -4975,7 +5107,8 @@ constexpr explicit outer_iterator(Parent& parent)
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{parent_} with \tcode{addressof(parent)}.
+\effects
+Initializes \tcode{parent_} with \tcode{addressof(parent)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{outer_iterator}!\idxcode{split_view::outer_iterator}}%
@@ -4986,7 +5119,8 @@ constexpr outer_iterator(Parent& parent, iterator_t<Base> current)
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{parent_} with \tcode{addressof(parent)}
+\effects
+Initializes \tcode{parent_} with \tcode{addressof(parent)}
 and \tcode{current_} with \tcode{current}.
 \end{itemdescr}
 
@@ -4998,7 +5132,8 @@ constexpr outer_iterator(outer_iterator<!Const> i)
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{parent_} with \tcode{i.parent_} and
+\effects
+Initializes \tcode{parent_} with \tcode{i.parent_} and
 \tcode{current_} with \tcode{std::move(i.current_)}.
 \end{itemdescr}
 
@@ -5009,7 +5144,8 @@ constexpr value_type operator*() const;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return value_type\{*this\};}
+\effects
+Equivalent to: \tcode{return value_type\{*this\};}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator++}!\idxcode{split_view::outer_iterator}}%
@@ -5019,7 +5155,8 @@ constexpr outer_iterator& operator++();
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 const auto end = ranges::end(parent_->base_);
 if (@\placeholder{current}@ == end) return *this;
@@ -5046,7 +5183,8 @@ friend constexpr bool operator==(const outer_iterator& x, const outer_iterator& 
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return x.current_ == y.current_;}
+\effects
+Equivalent to: \tcode{return x.current_ == y.current_;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator==}!\idxcode{split_view::outer_iterator}}%
@@ -5086,7 +5224,8 @@ constexpr explicit value_type(outer_iterator i);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{i_} with \tcode{i}.
+\effects
+Initializes \tcode{i_} with \tcode{i}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{begin}!\idxcode{split_view::outer_iterator::value_type}}%
@@ -5096,7 +5235,8 @@ constexpr inner_iterator<Const> begin() const;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return inner_iterator<Const>\{i_\};}
+\effects
+Equivalent to: \tcode{return inner_iterator<Const>\{i_\};}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{end}!\idxcode{split_view::outer_iterator::value_type}}%
@@ -5106,7 +5246,8 @@ constexpr default_sentinel_t end() const;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return default_sentinel;}
+\effects
+Equivalent to: \tcode{return default_sentinel;}
 \end{itemdescr}
 
 \rSec3[range.split.inner]{Class template \tcode{split_view::inner_iterator}}
@@ -5173,7 +5314,8 @@ constexpr explicit inner_iterator(outer_iterator<Const> i);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{i_} with \tcode{i}.
+\effects
+Initializes \tcode{i_} with \tcode{i}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator++}!\idxcode{split_view::inner_iterator}}%
@@ -5183,7 +5325,8 @@ constexpr inner_iterator& operator++() const;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 incremented_ = true;
 if constexpr (!forward_range<Base>) {
@@ -5204,7 +5347,8 @@ friend constexpr bool operator==(const inner_iterator& x, const inner_iterator& 
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return x.i_.current_ == y.i_.current_;}
+\effects
+Equivalent to: \tcode{return x.i_.current_ == y.i_.current_;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator==}!\idxcode{split_view::inner_iterator}}%
@@ -5214,7 +5358,8 @@ friend constexpr bool operator==(const inner_iterator& x, default_sentinel_t);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 auto cur = x.i_.@\placeholder{current}@;
 auto end = ranges::end(x.i_.parent_->base_);
@@ -5238,7 +5383,8 @@ friend constexpr void iter_swap(const inner_iterator& x, const inner_iterator& y
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to
+\effects
+Equivalent to
 \tcode{ranges::iter_swap(x.i_.\placeholdernc{current}, y.i_.\placeholdernc{current})}.
 \end{itemdescr}
 
@@ -5382,7 +5528,8 @@ constexpr explicit common_view(V base);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{base_} with \tcode{std::move(base)}.
+\effects
+Initializes \tcode{base_} with \tcode{std::move(base)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{common_view}!\idxcode{common_view}}%
@@ -5394,7 +5541,8 @@ constexpr explicit common_view(R&& r);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{base_} with \tcode{views::all(std::forward<R>(r))}.
+\effects
+Initializes \tcode{base_} with \tcode{views::all(std::forward<R>(r))}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{base}!\idxcode{common_view}}%
@@ -5404,7 +5552,8 @@ constexpr V base() const;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return base_;}
+\effects
+Equivalent to: \tcode{return base_;}
 \end{itemdescr}
 
 \rSec3[range.common.adaptor]{\tcode{views::common}}
@@ -5491,7 +5640,8 @@ constexpr explicit reverse_view(V base);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{base_} with \tcode{std::move(base)}.
+\effects
+Initializes \tcode{base_} with \tcode{std::move(base)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{reverse_view}!\idxcode{reverse_view}}%
@@ -5503,7 +5653,8 @@ constexpr explicit reverse_view(R&& r);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{base_} with \tcode{views::all(std::forward<R>(r))}.
+\effects
+Initializes \tcode{base_} with \tcode{views::all(std::forward<R>(r))}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{base}!\idxcode{reverse_view}}%
@@ -5513,7 +5664,8 @@ constexpr V base() const;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return base_;}
+\effects
+Equivalent to: \tcode{return base_;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{begin}!\idxcode{reverse_view}}%
@@ -5529,7 +5681,8 @@ make_reverse_iterator(ranges::next(ranges::begin(base_), ranges::end(base_)))
 \end{codeblock}
 
 \pnum
-\remarks In order to provide the amortized constant time complexity required by
+\remarks
+In order to provide the amortized constant time complexity required by
 the \libconcept{range} concept, this function caches the result within the
 \tcode{reverse_view} for use on subsequent calls.
 \end{itemdescr}
@@ -5543,7 +5696,8 @@ constexpr reverse_iterator<iterator_t<const V>> begin() const
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return make_reverse_iterator(ranges::end(base_));}
+\effects
+Equivalent to: \tcode{return make_reverse_iterator(ranges::end(base_));}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{end}!\idxcode{reverse_view}}%
@@ -5555,7 +5709,8 @@ constexpr reverse_iterator<iterator_t<const V>> end() const
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return make_reverse_iterator(ranges::begin(base_));}
+\effects
+Equivalent to: \tcode{return make_reverse_iterator(ranges::begin(base_));}
 \end{itemdescr}
 
 \rSec3[range.reverse.adaptor]{\tcode{views::reverse}}
@@ -5750,7 +5905,8 @@ void operator++(int);
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{parent_->stream_ != nullptr} is \tcode{true}.
+\expects
+\tcode{parent_->stream_ != nullptr} is \tcode{true}.
 
 \pnum
 \effects
@@ -6029,7 +6185,8 @@ constexpr iterator& operator++();
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 ++current_;
 return *this;
@@ -6052,7 +6209,8 @@ constexpr iterator operator++(int) requires forward_range<base_t>;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 auto temp = *this;
 ++current_;
@@ -6203,7 +6361,8 @@ friend constexpr iterator operator+(const iterator& x, difference_type y)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return iterator\{x\} += y;}
+\effects
+Equivalent to: \tcode{return iterator\{x\} += y;}
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -6213,7 +6372,8 @@ friend constexpr iterator operator+(difference_type x, const iterator& y)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return y + x;}
+\effects
+Equivalent to: \tcode{return y + x;}
 \end{itemdescr}
 
 \begin{itemdecl}

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -85,9 +85,12 @@ been marked by parenthesis.
 
 \pnum
 This subclause defines requirements on classes representing regular
-expression traits.  \begin{note} The class template
+expression traits.
+\begin{note}
+The class template
 \tcode{regex_traits}, defined in \ref{re.traits},
-meets these requirements.  \end{note}
+meets these requirements.
+\end{note}
 
 \pnum
 The class template \tcode{basic_regex}, defined in
@@ -230,8 +233,11 @@ and \tcode{loc} is an object of type \tcode{X::locale_type}.
   & \tcode{int}
   & Returns the value represented by the digit \textit{c} in base
     \textit{I} if the character \textit{c} is a valid digit in base \textit{I};
-  otherwise returns \tcode{-1}. \begin{note} The value of \textit{I} will only
-  be 8, 10, or 16. \end{note}
+  otherwise returns \tcode{-1}.
+\begin{note}
+The value of \textit{I} will only
+  be 8, 10, or 16.
+\end{note}
   \\ \rowsep
 \tcode{u.imbue(loc)}
   & \tcode{X::locale_type}
@@ -1161,9 +1167,12 @@ locale_type imbue(locale_type loc);
 \pnum
 \effects
 Imbues \tcode{this} with a copy of the
-locale \tcode{loc}. \begin{note} Calling \tcode{imbue} with a
+locale \tcode{loc}.
+\begin{note}
+Calling \tcode{imbue} with a
 different locale than the one currently in use invalidates all cached
-data held by \tcode{*this}. \end{note}
+data held by \tcode{*this}.
+\end{note}
 
 \pnum
 \returns
@@ -1226,9 +1235,12 @@ Objects of type specialization of \tcode{basic_regex} are responsible for
 converting the sequence of \tcode{charT} objects to an internal
 representation. It is not specified what form this representation
 takes, nor how it is accessed by algorithms that operate on regular
-expressions. \begin{note} Implementations will typically declare
+expressions.
+\begin{note}
+Implementations will typically declare
 some function templates as friends of \tcode{basic_regex} to achieve
-this. \end{note}
+this.
+\end{note}
 
 \pnum
 \indexlibrary{\idxcode{regex_error}}%
@@ -2054,9 +2066,12 @@ members \tcode{first} and \tcode{second} denote the range of characters
 \range{first}{second} which formed that
 match. Otherwise \tcode{matched} is \tcode{false}, and members \tcode{first}
 and \tcode{second} point to the end of the sequence
-that was searched. \begin{note} The \tcode{sub_match} objects representing
+that was searched.
+\begin{note}
+The \tcode{sub_match} objects representing
 different sub-expressions that did not participate in a regular expression
-match need not be distinct.\end{note}
+match need not be distinct.
+\end{note}
 
 \begin{codeblock}
 namespace std {
@@ -2246,7 +2261,8 @@ size_type size() const;
 One plus the number of marked sub-expressions in the
 regular expression that was matched if \tcode{*this} represents the
 result of a successful match.  Otherwise returns \tcode{0}.
-\begin{note} The state of a \tcode{match_results} object can be modified
+\begin{note}
+The state of a \tcode{match_results} object can be modified
 only by passing that object to \tcode{regex_match} or \tcode{regex_search}.
 Subclauses~\ref{re.alg.match} and~\ref{re.alg.search} specify the
 effects of those algorithms on their \tcode{match_results} arguments.
@@ -2577,7 +2593,9 @@ other is not. If both match results are ready, returns \tcode{true} only if:
 \tcode{m1.suffix() == m2.suffix()}.
 \end{itemize}
 \end{itemize}
-\begin{note} The algorithm \tcode{equal} is defined in \ref{algorithms}. \end{note}
+\begin{note}
+The algorithm \tcode{equal} is defined in \ref{algorithms}.
+\end{note}
 \end{itemdescr}
 
 \rSec1[re.alg]{Regular expression algorithms}
@@ -3156,10 +3174,13 @@ namespace std {
 \indextext{\idxcode{regex_iterator}!end-of-sequence}%
 An object of type \tcode{regex_iterator} that is not an end-of-sequence iterator
 holds a \textit{zero-length match} if \tcode{match[0].matched == true} and
-\tcode{match[0].first == match[0].second}. \begin{note} For
+\tcode{match[0].first == match[0].second}.
+\begin{note}
+For
 example, this can occur when the part of the regular expression that
 matched consists only of an assertion (such as \verb|'^'|, \verb|'$'|,
-\tcode{'$\backslash$b'}, \tcode{'$\backslash$B'}). \end{note}
+\tcode{'$\backslash$b'}, \tcode{'$\backslash$B'}).
+\end{note}
 
 \rSec3[re.regiter.cnstr]{Constructors}
 
@@ -3285,19 +3306,23 @@ In all cases in which the call to \tcode{regex_search} returns \tcode{true},
 shall return \tcode{distance(begin, match[i].\brk{}first)}.
 
 \pnum
-\begin{note} This means that \tcode{match.position(i)} gives the
+\begin{note}
+This means that \tcode{match.position(i)} gives the
 offset from the beginning of the target sequence, which is often not
 the same as the offset from the sequence passed in the call
-to \tcode{regex_search}. \end{note}
+to \tcode{regex_search}.
+\end{note}
 
 \pnum
 It is unspecified how the implementation makes these adjustments.
 
 \pnum
-\begin{note} This means that a compiler may call an
+\begin{note}
+This means that a compiler may call an
 implementation-specific search function, in which case a program-defined
 specialization of \tcode{regex_search} will not be
-called. \end{note}
+called.
+\end{note}
 \end{itemdescr}
 
 \indexlibrarymember{regex_iterator}{operator++}%
@@ -3463,10 +3488,12 @@ final sequence, and \tcode{suffix.second} points to the end of the
 final sequence.
 
 \pnum
-\begin{note} For a suffix iterator, data
+\begin{note}
+For a suffix iterator, data
 member \tcode{suffix.first} is the same as the end of the last match
 found, and \tcode{suffix\brk.second} is the same as the end of the target
-sequence. \end{note}
+sequence.
+\end{note}
 
 \pnum
 The \textit{current match} is \tcode{(*position).prefix()} if \tcode{subs[N] == -1}, or
@@ -3762,9 +3789,11 @@ exception object of type \tcode{regex_error}.
 \indexlibrary{\idxcode{regex_error}}%
 If the \textit{CV} of a \textit{UnicodeEscapeSequence} is greater than the largest
 value that can be held in an object of type \tcode{charT} the translator shall
-throw an exception object of type \tcode{regex_error}. \begin{note}
+throw an exception object of type \tcode{regex_error}.
+\begin{note}
 This means that values of the form \tcode{"uxxxx"} that do not fit in
-a character are invalid.  \end{note}
+a character are invalid.
+\end{note}
 
 \pnum
 Where the regular expression grammar requires the conversion of a sequence of characters

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -884,9 +884,11 @@ regex_error(regex_constants::error_type ecode);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects  Constructs an object of class \tcode{regex_error}.
+\pnum
+\effects  Constructs an object of class \tcode{regex_error}.
 
-\pnum\ensures  \tcode{ecode == code()}.
+\pnum
+\ensures  \tcode{ecode == code()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{error_type}}%
@@ -896,7 +898,8 @@ regex_constants::error_type code() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The error code that was passed to the constructor.
+\pnum
+\returns The error code that was passed to the constructor.
 \end{itemdescr}
 
 \rSec1[re.traits]{Class template \tcode{regex_traits}}
@@ -959,7 +962,8 @@ static size_t length(const char_type* p);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{char_traits<charT>::length(p)}.
+\pnum
+\returns \tcode{char_traits<charT>::length(p)}.
 \end{itemdescr}
 
 \indexlibrarymember{regex_traits}{translate}%
@@ -968,7 +972,8 @@ charT translate(charT c) const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{c}.
+\pnum
+\returns \tcode{c}.
 \end{itemdescr}
 
 \indexlibrarymember{regex_traits}{translate_nocase}%
@@ -977,7 +982,8 @@ charT translate_nocase(charT c) const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{use_facet<ctype<charT>>(getloc()).tolower(c)}.
+\pnum
+\returns \tcode{use_facet<ctype<charT>>(getloc()).tolower(c)}.
 \end{itemdescr}
 
 \indexlibrarymember{regex_traits}{transform}%
@@ -987,7 +993,8 @@ template<class ForwardIterator>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects
+\pnum
+\effects
 As if by:
 \begin{codeblock}
 string_type str(first, last);
@@ -1022,7 +1029,8 @@ template<class ForwardIterator>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns A sequence of one or more characters that
+\pnum
+\returns A sequence of one or more characters that
 represents the collating element consisting of the character
 sequence designated by the iterator range \range{first}{last}.
 Returns an empty string if the character sequence is not a
@@ -1037,7 +1045,8 @@ template<class ForwardIterator>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns An unspecified value that represents
+\pnum
+\returns An unspecified value that represents
 the character classification named by the character sequence
 designated by the iterator range \range{first}{last}.
 If the parameter \tcode{icase} is \tcode{true} then the returned mask identifies the
@@ -1324,7 +1333,8 @@ expression contained in the array of \tcode{charT} of length
 \tcode{char_traits<charT>::\brk{}length(p)} whose first element is
 designated by \tcode{p}, and interpreted according to the flags \tcode{f}.
 
-\pnum\ensures
+\pnum
+\ensures
 \tcode{flags()} returns \tcode{f}.
 \tcode{mark_count()} returns the number of marked sub-expressions
 within the expression.
@@ -1348,7 +1358,8 @@ internal finite state machine is constructed from the regular
 expression contained in the sequence of characters \range{p}{p+len}, and
 interpreted according the flags specified in \tcode{f}.
 
-\pnum\ensures
+\pnum
+\ensures
 \tcode{flags()} returns \tcode{f}.
 \tcode{mark_count()} returns the number of marked sub-expressions
 within the expression.
@@ -1364,7 +1375,8 @@ basic_regex(const basic_regex& e);
 \effects  Constructs an object of class \tcode{basic_regex} as a copy of
 the object \tcode{e}.
 
-\pnum\ensures
+\pnum
+\ensures
 \tcode{flags()} and \tcode{mark_count()} return
 \tcode{e.flags()} and \tcode{e.mark_count()}, respectively.
 \end{itemdescr}
@@ -1401,7 +1413,8 @@ internal finite state machine is constructed from the regular
 expression contained in the string \tcode{s}, and interpreted according to the
 flags specified in \tcode{f}.
 
-\pnum\ensures
+\pnum
+\ensures
 \tcode{flags()} returns \tcode{f}.
 \tcode{mark_count()} returns the number of marked sub-expressions
 within the expression.
@@ -1425,7 +1438,8 @@ internal finite state machine is constructed from the regular
 expression contained in the sequence of characters \range{first}{last}, and
 interpreted according to the flags specified in \tcode{f}.
 
-\pnum\ensures
+\pnum
+\ensures
 \tcode{flags()} returns \tcode{f}.
 \tcode{mark_count()} returns the number of marked sub-expressions
 within the expression.
@@ -1452,7 +1466,8 @@ basic_regex& operator=(const basic_regex& e);
 \pnum
 \effects Copies \tcode{e} into \tcode{*this} and returns \tcode{*this}.
 
-\pnum\ensures
+\pnum
+\ensures
 \tcode{flags()} and \tcode{mark_count()} return
 \tcode{e.flags()} and \tcode{e.mark_count()}, respectively.
 \end{itemdescr}
@@ -1638,7 +1653,8 @@ locale_type imbue(locale_type loc);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects  Returns the result of \tcode{traits_inst.imbue(loc)} where
+\pnum
+\effects  Returns the result of \tcode{traits_inst.imbue(loc)} where
 \tcode{traits_inst} is a (default-initialized) instance of the template
 type argument \tcode{traits} stored within the object.  After a call
 to \tcode{imbue} the \tcode{basic_regex} object does not match any
@@ -1651,7 +1667,8 @@ locale_type getloc() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects  Returns the result of \tcode{traits_inst.getloc()} where
+\pnum
+\effects  Returns the result of \tcode{traits_inst.getloc()} where
 \tcode{traits_inst} is a (default-initialized) instance of the template
 parameter \tcode{traits} stored within the object.
 \end{itemdescr}
@@ -1665,13 +1682,16 @@ void swap(basic_regex& e);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects  Swaps the contents of the two regular expressions.
+\pnum
+\effects  Swaps the contents of the two regular expressions.
 
-\pnum\ensures  \tcode{*this} contains the regular expression
+\pnum
+\ensures  \tcode{*this} contains the regular expression
 that was in \tcode{e}, \tcode{e} contains the regular expression that
 was in \tcode{*this}.
 
-\pnum\complexity Constant time.
+\pnum
+\complexity Constant time.
 \end{itemdescr}
 
 \rSec2[re.regex.nonmemb]{Non-member functions}
@@ -1683,7 +1703,8 @@ template<class charT, class traits>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects  Calls \tcode{lhs.swap(rhs)}.
+\pnum
+\effects  Calls \tcode{lhs.swap(rhs)}.
 \end{itemdescr}
 
 \rSec1[re.submatch]{Class template \tcode{sub_match}}
@@ -1739,7 +1760,8 @@ difference_type length() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{matched ?\ distance(first, second) :\ 0}.
+\pnum
+\returns \tcode{matched ?\ distance(first, second) :\ 0}.
 \end{itemdescr}
 
 \indexlibrarymember{operator basic_string}{sub_match}%
@@ -1748,7 +1770,8 @@ operator string_type() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{matched ?\ string_type(first, second) :\ string_type()}.
+\pnum
+\returns \tcode{matched ?\ string_type(first, second) :\ string_type()}.
 \end{itemdescr}
 
 \indexlibrarymember{sub_match}{str}%
@@ -1757,7 +1780,8 @@ string_type str() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{matched ?\ string_type(first, second) :\ string_type()}.
+\pnum
+\returns \tcode{matched ?\ string_type(first, second) :\ string_type()}.
 \end{itemdescr}
 
 \indexlibrarymember{sub_match}{compare}%
@@ -1766,7 +1790,8 @@ int compare(const sub_match& s) const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{str().compare(s.str())}.
+\pnum
+\returns \tcode{str().compare(s.str())}.
 \end{itemdescr}
 
 \indexlibrarymember{sub_match}{compare}%
@@ -1775,7 +1800,8 @@ int compare(const string_type& s) const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{str().compare(s)}.
+\pnum
+\returns \tcode{str().compare(s)}.
 \end{itemdescr}
 
 \indexlibrarymember{sub_match}{compare}%
@@ -1784,7 +1810,8 @@ int compare(const value_type* s) const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{str().compare(s)}.
+\pnum
+\returns \tcode{str().compare(s)}.
 \end{itemdescr}
 
 \rSec2[re.submatch.op]{Non-member operators}
@@ -1802,7 +1829,8 @@ template<class BiIter>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{lhs.compare(rhs) == 0}.
+\pnum
+\returns \tcode{lhs.compare(rhs) == 0}.
 \end{itemdescr}
 
 \indexlibrarymember{sub_match}{operator<=>}%
@@ -1812,7 +1840,8 @@ template<class BiIter>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{static_cast<\placeholdernc{SM-CAT}(BiIter)>(lhs.compare(rhs) <=> 0)}.
+\pnum
+\returns \tcode{static_cast<\placeholdernc{SM-CAT}(BiIter)>(lhs.compare(rhs) <=> 0)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator==}{sub_match}%
@@ -1840,7 +1869,8 @@ template<class BiIter, class ST, class SA>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns
+\pnum
+\returns
 \begin{codeblock}
 static_cast<@\placeholdernc{SM-CAT}@(BiIter)>(lhs.compare(
     typename sub_match<BiIter>::string_type(rhs.data(), rhs.size()))
@@ -1857,7 +1887,8 @@ template<class BiIter>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{lhs.compare(rhs) == 0}.
+\pnum
+\returns \tcode{lhs.compare(rhs) == 0}.
 \end{itemdescr}
 
 \indexlibrarymember{sub_match}{operator<=>}%
@@ -1868,7 +1899,8 @@ template<class BiIter>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns
+\pnum
+\returns
 \tcode{static_cast<\placeholdernc{SM-CAT}(BiIter)>(lhs.compare(rhs) <=> 0)}.
 \end{itemdescr}
 
@@ -1911,7 +1943,8 @@ template<class charT, class ST, class BiIter>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{os << m.str()}.
+\pnum
+\returns \tcode{os << m.str()}.
 \end{itemdescr}
 
 \rSec1[re.results]{Class template \tcode{match_results}}
@@ -2136,7 +2169,8 @@ size_type size() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns One plus the number of marked sub-expressions in the
+\pnum
+\returns One plus the number of marked sub-expressions in the
 regular expression that was matched if \tcode{*this} represents the
 result of a successful match.  Otherwise returns \tcode{0}.
 \begin{note} The state of a \tcode{match_results} object can be modified
@@ -2152,7 +2186,8 @@ size_type max_size() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The maximum number of \tcode{sub_match} elements that can be
+\pnum
+\returns The maximum number of \tcode{sub_match} elements that can be
 stored in \tcode{*this}.
 \end{itemdescr}
 
@@ -2162,7 +2197,8 @@ stored in \tcode{*this}.
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{size() == 0}.
+\pnum
+\returns \tcode{size() == 0}.
 \end{itemdescr}
 
 \rSec2[re.results.acc]{Element access}
@@ -2262,7 +2298,8 @@ const_iterator cbegin() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns A starting iterator that enumerates over all the
+\pnum
+\returns A starting iterator that enumerates over all the
 sub-expressions stored in \tcode{*this}.
 \end{itemdescr}
 
@@ -2273,7 +2310,8 @@ const_iterator cend() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns A terminating iterator that enumerates over all the
+\pnum
+\returns A terminating iterator that enumerates over all the
 sub-expressions stored in \tcode{*this}.
 \end{itemdescr}
 
@@ -2390,13 +2428,16 @@ void swap(match_results& that);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects  Swaps the contents of the two sequences.
+\pnum
+\effects  Swaps the contents of the two sequences.
 
-\pnum\ensures  \tcode{*this} contains the sequence of matched
+\pnum
+\ensures  \tcode{*this} contains the sequence of matched
 sub-expressions that were in \tcode{that}, \tcode{that} contains the
 sequence of matched sub-expressions that were in \tcode{*this}.
 
-\pnum\complexity Constant time.
+\pnum
+\complexity Constant time.
 \end{itemdescr}
 
 \indexlibrarymember{match_results}{swap}%
@@ -2406,7 +2447,8 @@ template<class BidirectionalIterator, class Allocator>
             match_results<BidirectionalIterator, Allocator>& m2);
 \end{itemdecl}
 
-\pnum\effects As if by \tcode{m1.swap(m2)}.
+\pnum
+\effects As if by \tcode{m1.swap(m2)}.
 
 \rSec2[re.results.nonmember]{Non-member functions}
 
@@ -2799,7 +2841,8 @@ template<class ST, class SA, class charT, class traits>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{regex_search(s.begin(), s.end(), e, flags)}.
+\pnum
+\returns \tcode{regex_search(s.begin(), s.end(), e, flags)}.
 \end{itemdescr}
 
 \rSec2[re.alg.replace]{\tcode{regex_replace}}
@@ -2870,7 +2913,8 @@ where \tcode{last_m} is a copy of the last match
 found. If \tcode{flags \& regex_constants::format_first_only}
 is nonzero, then only the first match found is replaced.
 
-\pnum\returns \tcode{out}.
+\pnum
+\returns \tcode{out}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{regex_replace}}%
@@ -2890,7 +2934,8 @@ template<class traits, class charT, class ST, class SA>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects  Constructs an empty string \tcode{result} of
+\pnum
+\effects  Constructs an empty string \tcode{result} of
 type \tcode{basic_string<charT, ST, SA>} and calls:
 \begin{codeblock}
 regex_replace(back_inserter(result), s.begin(), s.end(), e, fmt, flags);
@@ -3013,7 +3058,8 @@ regex_iterator();
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects  Constructs an end-of-sequence iterator.
+\pnum
+\effects  Constructs an end-of-sequence iterator.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{regex_iterator}!constructor}%
@@ -3024,7 +3070,8 @@ regex_iterator(BidirectionalIterator a, BidirectionalIterator b,
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects  Initializes \tcode{begin} and \tcode{end} to
+\pnum
+\effects  Initializes \tcode{begin} and \tcode{end} to
 \tcode{a} and \tcode{b}, respectively, sets
 \tcode{pregex} to \tcode{addressof(re)}, sets \tcode{flags} to
 \tcode{m}, then calls \tcode{regex_search(begin, end, match, *pregex, flags)}. If this
@@ -3061,7 +3108,8 @@ const value_type& operator*() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{match}.
+\pnum
+\returns \tcode{match}.
 \end{itemdescr}
 
 \indexlibrarymember{operator->}{regex_iterator}%
@@ -3070,7 +3118,8 @@ const value_type* operator->() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{addressof(match)}.
+\pnum
+\returns \tcode{addressof(match)}.
 \end{itemdescr}
 
 \rSec3[re.regiter.incr]{Increment}
@@ -3140,7 +3189,8 @@ regex_iterator operator++(int);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects
+\pnum
+\effects
 As if by:
 \begin{codeblock}
 regex_iterator tmp = *this;
@@ -3388,7 +3438,8 @@ const value_type& operator*() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{*result}.
+\pnum
+\returns \tcode{*result}.
 \end{itemdescr}
 
 
@@ -3398,7 +3449,8 @@ const value_type* operator->() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{result}.
+\pnum
+\returns \tcode{result}.
 \end{itemdescr}
 
 
@@ -3437,7 +3489,8 @@ suffix iterator that points to the range \range{prev->suffix().first}{prev->suff
 \pnum
 Otherwise, sets \tcode{*this} to an end-of-sequence iterator.
 
-\pnum\returns \tcode{*this}
+\pnum
+\returns \tcode{*this}
 \end{itemdescr}
 
 \indexlibrarymember{regex_token_iterator}{operator++}%
@@ -3446,9 +3499,11 @@ regex_token_iterator& operator++(int);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects  Constructs a copy \tcode{tmp} of \tcode{*this}, then calls \tcode{++(*this)}.
+\pnum
+\effects  Constructs a copy \tcode{tmp} of \tcode{*this}, then calls \tcode{++(*this)}.
 
-\pnum\returns \tcode{tmp}.
+\pnum
+\returns \tcode{tmp}.
 \end{itemdescr}
 
 \rSec1[re.grammar]{Modified ECMAScript regular expression grammar}

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -885,10 +885,12 @@ regex_error(regex_constants::error_type ecode);
 
 \begin{itemdescr}
 \pnum
-\effects  Constructs an object of class \tcode{regex_error}.
+\effects
+Constructs an object of class \tcode{regex_error}.
 
 \pnum
-\ensures  \tcode{ecode == code()}.
+\ensures
+\tcode{ecode == code()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{error_type}}%
@@ -899,7 +901,8 @@ regex_constants::error_type code() const;
 
 \begin{itemdescr}
 \pnum
-\returns The error code that was passed to the constructor.
+\returns
+The error code that was passed to the constructor.
 \end{itemdescr}
 
 \rSec1[re.traits]{Class template \tcode{regex_traits}}
@@ -963,7 +966,8 @@ static size_t length(const char_type* p);
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{char_traits<charT>::length(p)}.
+\returns
+\tcode{char_traits<charT>::length(p)}.
 \end{itemdescr}
 
 \indexlibrarymember{regex_traits}{translate}%
@@ -973,7 +977,8 @@ charT translate(charT c) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{c}.
+\returns
+\tcode{c}.
 \end{itemdescr}
 
 \indexlibrarymember{regex_traits}{translate_nocase}%
@@ -983,7 +988,8 @@ charT translate_nocase(charT c) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{use_facet<ctype<charT>>(getloc()).tolower(c)}.
+\returns
+\tcode{use_facet<ctype<charT>>(getloc()).tolower(c)}.
 \end{itemdescr}
 
 \indexlibrarymember{regex_traits}{transform}%
@@ -1030,7 +1036,8 @@ template<class ForwardIterator>
 
 \begin{itemdescr}
 \pnum
-\returns A sequence of one or more characters that
+\returns
+A sequence of one or more characters that
 represents the collating element consisting of the character
 sequence designated by the iterator range \range{first}{last}.
 Returns an empty string if the character sequence is not a
@@ -1046,7 +1053,8 @@ template<class ForwardIterator>
 
 \begin{itemdescr}
 \pnum
-\returns An unspecified value that represents
+\returns
+An unspecified value that represents
 the character classification named by the character sequence
 designated by the iterator range \range{first}{last}.
 If the parameter \tcode{icase} is \tcode{true} then the returned mask identifies the
@@ -1060,7 +1068,8 @@ the character sequence. If the name
 is not recognized then returns \tcode{char_class_type()}.
 
 \pnum
-\remarks  For \tcode{regex_traits<char>}, at least the narrow character names
+\remarks
+For \tcode{regex_traits<char>}, at least the narrow character names
 in \tref{re.traits.classnames} shall be recognized.
 For \tcode{regex_traits<wchar_t>}, at least the wide character names
 in \tref{re.traits.classnames} shall be recognized.
@@ -1073,11 +1082,13 @@ bool isctype(charT c, char_class_type f) const;
 
 \begin{itemdescr}
 \pnum
-\effects  Determines if the character \tcode{c} is a member of the character
+\effects
+Determines if the character \tcode{c} is a member of the character
 classification represented by \tcode{f}.
 
 \pnum
-\returns Given the following function declaration:
+\returns
+Given the following function declaration:
 \begin{codeblock}
 // for exposition only
 template<class C>
@@ -1134,7 +1145,8 @@ int value(charT ch, int radix) const;
 \requires  The value of \tcode{radix} shall be 8, 10, or 16.
 
 \pnum
-\returns The value represented by the digit \tcode{ch} in base
+\returns
+The value represented by the digit \tcode{ch} in base
 \tcode{radix} if the character \tcode{ch} is a valid digit in base
 \tcode{radix}; otherwise returns \tcode{-1}.
 \end{itemdescr}
@@ -1147,18 +1159,21 @@ locale_type imbue(locale_type loc);
 
 \begin{itemdescr}
 \pnum
-\effects  Imbues \tcode{this} with a copy of the
+\effects
+Imbues \tcode{this} with a copy of the
 locale \tcode{loc}. \begin{note} Calling \tcode{imbue} with a
 different locale than the one currently in use invalidates all cached
 data held by \tcode{*this}. \end{note}
 
 \pnum
-\returns If no locale has been previously imbued then a copy of the
+\returns
+If no locale has been previously imbued then a copy of the
 global locale in effect at the time of construction of \tcode{*this},
 otherwise a copy of the last argument passed to \tcode{imbue}.
 
 \pnum
-\ensures  \tcode{getloc() == loc}.
+\ensures
+\tcode{getloc() == loc}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{locale}}%
@@ -1169,7 +1184,8 @@ locale_type getloc() const;
 
 \begin{itemdescr}
 \pnum
-\returns If no locale has been imbued then a copy of the global locale
+\returns
+If no locale has been imbued then a copy of the global locale
 in effect at the time of construction of \tcode{*this}, otherwise a copy of
 the last argument passed to \tcode{imbue}.
 \end{itemdescr}
@@ -1310,7 +1326,8 @@ basic_regex();
 
 \begin{itemdescr}
 \pnum
-\effects  Constructs an object of class \tcode{basic_regex} that
+\effects
+Constructs an object of class \tcode{basic_regex} that
 does not match any character sequence.
 \end{itemdescr}
 
@@ -1324,10 +1341,12 @@ explicit basic_regex(const charT* p, flag_type f = regex_constants::ECMAScript);
 \requires  \tcode{p} shall not be a null pointer.
 
 \pnum
-\throws  \tcode{regex_error} if \tcode{p} is not a valid regular expression.
+\throws
+\tcode{regex_error} if \tcode{p} is not a valid regular expression.
 
 \pnum
-\effects  Constructs an object of class \tcode{basic_regex}; the object's
+\effects
+Constructs an object of class \tcode{basic_regex}; the object's
 internal finite state machine is constructed from the regular
 expression contained in the array of \tcode{charT} of length
 \tcode{char_traits<charT>::\brk{}length(p)} whose first element is
@@ -1350,10 +1369,12 @@ basic_regex(const charT* p, size_t len, flag_type f = regex_constants::ECMAScrip
 \requires  \tcode{p} shall not be a null pointer.
 
 \pnum
-\throws  \tcode{regex_error} if \tcode{p} is not a valid regular expression.
+\throws
+\tcode{regex_error} if \tcode{p} is not a valid regular expression.
 
 \pnum
-\effects  Constructs an object of class \tcode{basic_regex}; the object's
+\effects
+Constructs an object of class \tcode{basic_regex}; the object's
 internal finite state machine is constructed from the regular
 expression contained in the sequence of characters \range{p}{p+len}, and
 interpreted according the flags specified in \tcode{f}.
@@ -1372,7 +1393,8 @@ basic_regex(const basic_regex& e);
 
 \begin{itemdescr}
 \pnum
-\effects  Constructs an object of class \tcode{basic_regex} as a copy of
+\effects
+Constructs an object of class \tcode{basic_regex} as a copy of
 the object \tcode{e}.
 
 \pnum
@@ -1388,10 +1410,12 @@ basic_regex(basic_regex&& e) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects  Move constructs an object of class \tcode{basic_regex} from \tcode{e}.
+\effects
+Move constructs an object of class \tcode{basic_regex} from \tcode{e}.
 
 \pnum
-\ensures \tcode{flags()} and \tcode{mark_count()} return the values that
+\ensures
+\tcode{flags()} and \tcode{mark_count()} return the values that
 \tcode{e.flags()} and \tcode{e.mark_count()}, respectively, had before construction.
 \tcode{e} is in a valid state with unspecified value.
 \end{itemdescr}
@@ -1405,10 +1429,12 @@ template<class ST, class SA>
 
 \begin{itemdescr}
 \pnum
-\throws  \tcode{regex_error} if \tcode{s} is not a valid regular expression.
+\throws
+\tcode{regex_error} if \tcode{s} is not a valid regular expression.
 
 \pnum
-\effects  Constructs an object of class \tcode{basic_regex}; the object's
+\effects
+Constructs an object of class \tcode{basic_regex}; the object's
 internal finite state machine is constructed from the regular
 expression contained in the string \tcode{s}, and interpreted according to the
 flags specified in \tcode{f}.
@@ -1429,11 +1455,13 @@ template<class ForwardIterator>
 
 \begin{itemdescr}
 \pnum
-\throws  \tcode{regex_error} if the sequence \range{first}{last} is not a
+\throws
+\tcode{regex_error} if the sequence \range{first}{last} is not a
 valid regular expression.
 
 \pnum
-\effects  Constructs an object of class \tcode{basic_regex}; the object's
+\effects
+Constructs an object of class \tcode{basic_regex}; the object's
 internal finite state machine is constructed from the regular
 expression contained in the sequence of characters \range{first}{last}, and
 interpreted according to the flags specified in \tcode{f}.
@@ -1452,7 +1480,8 @@ basic_regex(initializer_list<charT> il, flag_type f = regex_constants::ECMAScrip
 
 \begin{itemdescr}
 \pnum
-\effects Same as \tcode{basic_regex(il.begin(), il.end(), f)}.
+\effects
+Same as \tcode{basic_regex(il.begin(), il.end(), f)}.
 \end{itemdescr}
 
 \rSec2[re.regex.assign]{Assignment}
@@ -1464,7 +1493,8 @@ basic_regex& operator=(const basic_regex& e);
 
 \begin{itemdescr}
 \pnum
-\effects Copies \tcode{e} into \tcode{*this} and returns \tcode{*this}.
+\effects
+Copies \tcode{e} into \tcode{*this} and returns \tcode{*this}.
 
 \pnum
 \ensures
@@ -1479,10 +1509,12 @@ basic_regex& operator=(basic_regex&& e) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Move assigns from \tcode{e} into \tcode{*this} and returns \tcode{*this}.
+\effects
+Move assigns from \tcode{e} into \tcode{*this} and returns \tcode{*this}.
 
 \pnum
-\ensures \tcode{flags()} and \tcode{mark_count()} return the values that
+\ensures
+\tcode{flags()} and \tcode{mark_count()} return the values that
 \tcode{e.flags()} and \tcode{e.mark_count()}, respectively, had before assignment.
 \tcode{e} is in a valid state with unspecified value.
 \end{itemdescr}
@@ -1497,7 +1529,8 @@ basic_regex& operator=(const charT* ptr);
 \requires \tcode{ptr} shall not be a null pointer.
 
 \pnum
-\effects Returns \tcode{assign(ptr)}.
+\effects
+Returns \tcode{assign(ptr)}.
 \end{itemdescr}
 
 \indexlibrarymember{basic_regex}{operator=}%
@@ -1507,7 +1540,8 @@ basic_regex& operator=(initializer_list<charT> il);
 
 \begin{itemdescr}
 \pnum
-\effects Returns \tcode{assign(il.begin(), il.end())}.
+\effects
+Returns \tcode{assign(il.begin(), il.end())}.
 \end{itemdescr}
 
 \indexlibrarymember{basic_regex}{operator=}%
@@ -1518,7 +1552,8 @@ template<class ST, class SA>
 
 \begin{itemdescr}
 \pnum
-\effects Returns \tcode{assign(p)}.
+\effects
+Returns \tcode{assign(p)}.
 \end{itemdescr}
 
 \indexlibrarymember{basic_regex}{assign}%
@@ -1528,7 +1563,8 @@ basic_regex& assign(const basic_regex& that);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return *this = that;}
+\effects
+Equivalent to: \tcode{return *this = that;}
 \end{itemdescr}
 
 \indexlibrarymember{basic_regex}{assign}%
@@ -1538,7 +1574,8 @@ basic_regex& assign(basic_regex&& that) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return *this = std::move(that);}
+\effects
+Equivalent to: \tcode{return *this = std::move(that);}
 \end{itemdescr}
 
 \indexlibrarymember{basic_regex}{assign}%
@@ -1548,7 +1585,8 @@ basic_regex& assign(const charT* ptr, flag_type f = regex_constants::ECMAScript)
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{assign(string_type(ptr), f)}.
+\returns
+\tcode{assign(string_type(ptr), f)}.
 \end{itemdescr}
 
 \indexlibrarymember{basic_regex}{assign}%
@@ -1558,7 +1596,8 @@ basic_regex& assign(const charT* ptr, size_t len, flag_type f = regex_constants:
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{assign(string_type(ptr, len), f)}.
+\returns
+\tcode{assign(string_type(ptr, len), f)}.
 \end{itemdescr}
 
 \indexlibrarymember{basic_regex}{assign}%
@@ -1570,13 +1609,16 @@ template<class string_traits, class A>
 
 \begin{itemdescr}
 \pnum
-\throws  \tcode{regex_error} if \tcode{s} is not a valid regular expression.
+\throws
+\tcode{regex_error} if \tcode{s} is not a valid regular expression.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 
 \pnum
-\effects  Assigns the regular expression contained in the string
+\effects
+Assigns the regular expression contained in the string
 \tcode{s}, interpreted according the flags specified in \tcode{f}.
 If an exception is thrown, \tcode{*this} is unchanged.
 
@@ -1601,7 +1643,8 @@ template<class InputIterator>
 \oldconcept{InputIterator} requirements\iref{input.iterators}.
 
 \pnum
-\returns \tcode{assign(string_type(first, last), f)}.
+\returns
+\tcode{assign(string_type(first, last), f)}.
 \end{itemdescr}
 
 \indexlibrarymember{assign}{basic_regex}%
@@ -1612,10 +1655,12 @@ basic_regex& assign(initializer_list<charT> il,
 
 \begin{itemdescr}
 \pnum
-\effects Same as \tcode{assign(il.begin(), il.end(), f)}.
+\effects
+Same as \tcode{assign(il.begin(), il.end(), f)}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 
@@ -1628,7 +1673,8 @@ unsigned mark_count() const;
 
 \begin{itemdescr}
 \pnum
-\effects  Returns the number of marked sub-expressions within the
+\effects
+Returns the number of marked sub-expressions within the
 regular expression.
 \end{itemdescr}
 
@@ -1639,7 +1685,8 @@ flag_type flags() const;
 
 \begin{itemdescr}
 \pnum
-\effects  Returns a copy of the regular expression syntax flags that
+\effects
+Returns a copy of the regular expression syntax flags that
 were passed to the object's constructor or to the last call
 to \tcode{assign}.
 \end{itemdescr}
@@ -1654,7 +1701,8 @@ locale_type imbue(locale_type loc);
 
 \begin{itemdescr}
 \pnum
-\effects  Returns the result of \tcode{traits_inst.imbue(loc)} where
+\effects
+Returns the result of \tcode{traits_inst.imbue(loc)} where
 \tcode{traits_inst} is a (default-initialized) instance of the template
 type argument \tcode{traits} stored within the object.  After a call
 to \tcode{imbue} the \tcode{basic_regex} object does not match any
@@ -1668,7 +1716,8 @@ locale_type getloc() const;
 
 \begin{itemdescr}
 \pnum
-\effects  Returns the result of \tcode{traits_inst.getloc()} where
+\effects
+Returns the result of \tcode{traits_inst.getloc()} where
 \tcode{traits_inst} is a (default-initialized) instance of the template
 parameter \tcode{traits} stored within the object.
 \end{itemdescr}
@@ -1683,15 +1732,18 @@ void swap(basic_regex& e);
 
 \begin{itemdescr}
 \pnum
-\effects  Swaps the contents of the two regular expressions.
+\effects
+Swaps the contents of the two regular expressions.
 
 \pnum
-\ensures  \tcode{*this} contains the regular expression
+\ensures
+\tcode{*this} contains the regular expression
 that was in \tcode{e}, \tcode{e} contains the regular expression that
 was in \tcode{*this}.
 
 \pnum
-\complexity Constant time.
+\complexity
+Constant time.
 \end{itemdescr}
 
 \rSec2[re.regex.nonmemb]{Non-member functions}
@@ -1704,7 +1756,8 @@ template<class charT, class traits>
 
 \begin{itemdescr}
 \pnum
-\effects  Calls \tcode{lhs.swap(rhs)}.
+\effects
+Calls \tcode{lhs.swap(rhs)}.
 \end{itemdescr}
 
 \rSec1[re.submatch]{Class template \tcode{sub_match}}
@@ -1750,7 +1803,8 @@ constexpr sub_match();
 
 \begin{itemdescr}
 \pnum
-\effects Value-initializes the \tcode{pair} base class subobject and the member
+\effects
+Value-initializes the \tcode{pair} base class subobject and the member
 \tcode{matched}.
 \end{itemdescr}
 
@@ -1761,7 +1815,8 @@ difference_type length() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{matched ?\ distance(first, second) :\ 0}.
+\returns
+\tcode{matched ?\ distance(first, second) :\ 0}.
 \end{itemdescr}
 
 \indexlibrarymember{operator basic_string}{sub_match}%
@@ -1771,7 +1826,8 @@ operator string_type() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{matched ?\ string_type(first, second) :\ string_type()}.
+\returns
+\tcode{matched ?\ string_type(first, second) :\ string_type()}.
 \end{itemdescr}
 
 \indexlibrarymember{sub_match}{str}%
@@ -1781,7 +1837,8 @@ string_type str() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{matched ?\ string_type(first, second) :\ string_type()}.
+\returns
+\tcode{matched ?\ string_type(first, second) :\ string_type()}.
 \end{itemdescr}
 
 \indexlibrarymember{sub_match}{compare}%
@@ -1791,7 +1848,8 @@ int compare(const sub_match& s) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{str().compare(s.str())}.
+\returns
+\tcode{str().compare(s.str())}.
 \end{itemdescr}
 
 \indexlibrarymember{sub_match}{compare}%
@@ -1801,7 +1859,8 @@ int compare(const string_type& s) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{str().compare(s)}.
+\returns
+\tcode{str().compare(s)}.
 \end{itemdescr}
 
 \indexlibrarymember{sub_match}{compare}%
@@ -1811,7 +1870,8 @@ int compare(const value_type* s) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{str().compare(s)}.
+\returns
+\tcode{str().compare(s)}.
 \end{itemdescr}
 
 \rSec2[re.submatch.op]{Non-member operators}
@@ -1830,7 +1890,8 @@ template<class BiIter>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{lhs.compare(rhs) == 0}.
+\returns
+\tcode{lhs.compare(rhs) == 0}.
 \end{itemdescr}
 
 \indexlibrarymember{sub_match}{operator<=>}%
@@ -1841,7 +1902,8 @@ template<class BiIter>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{static_cast<\placeholdernc{SM-CAT}(BiIter)>(lhs.compare(rhs) <=> 0)}.
+\returns
+\tcode{static_cast<\placeholdernc{SM-CAT}(BiIter)>(lhs.compare(rhs) <=> 0)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator==}{sub_match}%
@@ -1888,7 +1950,8 @@ template<class BiIter>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{lhs.compare(rhs) == 0}.
+\returns
+\tcode{lhs.compare(rhs) == 0}.
 \end{itemdescr}
 
 \indexlibrarymember{sub_match}{operator<=>}%
@@ -1913,7 +1976,8 @@ template<class BiIter>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{lhs.compare(typename sub_match<BiIter>::string_type(1, rhs)) == 0}.
+\returns
+\tcode{lhs.compare(typename sub_match<BiIter>::string_type(1, rhs)) == 0}.
 \end{itemdescr}
 
 \indexlibrarymember{sub_match}{operator<=>}%
@@ -1944,7 +2008,8 @@ template<class charT, class ST, class BiIter>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{os << m.str()}.
+\returns
+\tcode{os << m.str()}.
 \end{itemdescr}
 
 \rSec1[re.results]{Class template \tcode{match_results}}
@@ -2079,7 +2144,8 @@ explicit match_results(const Allocator& a);
 
 \begin{itemdescr}
 \pnum
-\effects  Constructs an object of class \tcode{match_results}.
+\effects
+Constructs an object of class \tcode{match_results}.
 
 \pnum
 \ensures
@@ -2094,7 +2160,8 @@ match_results(const match_results& m);
 
 \begin{itemdescr}
 \pnum
-\effects  Constructs an object of class \tcode{match_results}, as a
+\effects
+Constructs an object of class \tcode{match_results}, as a
 copy of \tcode{m}.
 \end{itemdescr}
 
@@ -2105,12 +2172,14 @@ match_results(match_results&& m) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects\ Move constructs an object of class \tcode{match_results} from \tcode{m}
+\effects
+Move constructs an object of class \tcode{match_results} from \tcode{m}
 satisfying the same postconditions as \tref{re.results.const}. Additionally,
 the stored \tcode{Allocator} value is move constructed from \tcode{m.get_allocator()}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \indexlibrarymember{match_results}{operator=}%
@@ -2120,7 +2189,8 @@ match_results& operator=(const match_results& m);
 
 \begin{itemdescr}
 \pnum
-\effects  Assigns \tcode{m} to \tcode{*this}. The postconditions of this
+\effects
+Assigns \tcode{m} to \tcode{*this}. The postconditions of this
 function are indicated in \tref{re.results.const}.
 \end{itemdescr}
 
@@ -2131,7 +2201,8 @@ match_results& operator=(match_results&& m);
 
 \begin{itemdescr}
 \pnum
-\effects\ Move-assigns \tcode{m} to \tcode{*this}. The postconditions of this function
+\effects
+Move-assigns \tcode{m} to \tcode{*this}. The postconditions of this function
 are indicated in \tref{re.results.const}.
 \end{itemdescr}
 
@@ -2157,7 +2228,8 @@ bool ready() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{true} if \tcode{*this} has a fully established result state, otherwise
+\returns
+\tcode{true} if \tcode{*this} has a fully established result state, otherwise
 \tcode{false}.
 \end{itemdescr}
 
@@ -2170,7 +2242,8 @@ size_type size() const;
 
 \begin{itemdescr}
 \pnum
-\returns One plus the number of marked sub-expressions in the
+\returns
+One plus the number of marked sub-expressions in the
 regular expression that was matched if \tcode{*this} represents the
 result of a successful match.  Otherwise returns \tcode{0}.
 \begin{note} The state of a \tcode{match_results} object can be modified
@@ -2187,7 +2260,8 @@ size_type max_size() const;
 
 \begin{itemdescr}
 \pnum
-\returns The maximum number of \tcode{sub_match} elements that can be
+\returns
+The maximum number of \tcode{sub_match} elements that can be
 stored in \tcode{*this}.
 \end{itemdescr}
 
@@ -2198,7 +2272,8 @@ stored in \tcode{*this}.
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{size() == 0}.
+\returns
+\tcode{size() == 0}.
 \end{itemdescr}
 
 \rSec2[re.results.acc]{Element access}
@@ -2213,7 +2288,8 @@ difference_type length(size_type sub = 0) const;
 \requires \tcode{ready() == true}.
 
 \pnum
-\returns \tcode{(*this)[sub].length()}.
+\returns
+\tcode{(*this)[sub].length()}.
 \end{itemdescr}
 
 \indexlibrarymember{position}{match_results}%
@@ -2226,7 +2302,8 @@ difference_type position(size_type sub = 0) const;
 \requires \tcode{ready() == true}.
 
 \pnum
-\returns The distance from the start of the target sequence
+\returns
+The distance from the start of the target sequence
 to \tcode{(*this)[sub].first}.
 \end{itemdescr}
 
@@ -2240,7 +2317,8 @@ string_type str(size_type sub = 0) const;
 \requires \tcode{ready() == true}.
 
 \pnum
-\returns \tcode{string_type((*this)[sub])}.
+\returns
+\tcode{string_type((*this)[sub])}.
 \end{itemdescr}
 
 \indexlibrarymember{match_results}{operator[]}%
@@ -2253,7 +2331,8 @@ const_reference operator[](size_type n) const;
 \requires \tcode{ready() == true}.
 
 \pnum
-\returns A reference to the \tcode{sub_match} object representing the
+\returns
+A reference to the \tcode{sub_match} object representing the
 character sequence that matched marked sub-expression \tcode{n}. If \tcode{n == 0}
 then returns a reference to a \tcode{sub_match} object representing the
 character sequence that matched the whole regular expression. If
@@ -2271,7 +2350,8 @@ const_reference prefix() const;
 \requires \tcode{ready() == true}.
 
 \pnum
-\returns A reference to the \tcode{sub_match} object representing the
+\returns
+A reference to the \tcode{sub_match} object representing the
 character sequence from the start of the string being
 matched/searched to the start of the match found.
 \end{itemdescr}
@@ -2286,7 +2366,8 @@ const_reference suffix() const;
 \requires \tcode{ready() == true}.
 
 \pnum
-\returns A reference to the \tcode{sub_match} object representing the
+\returns
+A reference to the \tcode{sub_match} object representing the
 character sequence from the end of the match found to the end of the
 string being matched/searched.
 \end{itemdescr}
@@ -2299,7 +2380,8 @@ const_iterator cbegin() const;
 
 \begin{itemdescr}
 \pnum
-\returns A starting iterator that enumerates over all the
+\returns
+A starting iterator that enumerates over all the
 sub-expressions stored in \tcode{*this}.
 \end{itemdescr}
 
@@ -2311,7 +2393,8 @@ const_iterator cend() const;
 
 \begin{itemdescr}
 \pnum
-\returns A terminating iterator that enumerates over all the
+\returns
+A terminating iterator that enumerates over all the
 sub-expressions stored in \tcode{*this}.
 \end{itemdescr}
 
@@ -2332,7 +2415,8 @@ template<class OutputIter>
 \oldconcept{OutputIterator}\iref{output.iterators}.
 
 \pnum
-\effects Copies the character sequence \range{fmt_first}{fmt_last} to
+\effects
+Copies the character sequence \range{fmt_first}{fmt_last} to
 OutputIter \tcode{out}.  Replaces each format specifier or escape
 sequence in the copied range with either the character(s) it represents or
 the sequence of characters within \tcode{*this} to which it refers.
@@ -2340,7 +2424,8 @@ The bitmasks specified in \tcode{flags} determine which format
 specifiers and escape sequences are recognized.
 
 \pnum
-\returns \tcode{out}.
+\returns
+\tcode{out}.
 \end{itemdescr}
 
 \indexlibrarymember{match_results}{format}%
@@ -2354,7 +2439,8 @@ template<class OutputIter, class ST, class SA>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return format(out, fmt.data(), fmt.data() + fmt.size(), flags);
 \end{codeblock}
@@ -2382,7 +2468,8 @@ format(back_inserter(result), fmt, flags);
 \end{codeblock}
 
 \pnum
-\returns \tcode{result}.
+\returns
+\tcode{result}.
 \end{itemdescr}
 
 \indexlibrarymember{match_results}{format}%
@@ -2397,14 +2484,16 @@ string_type format(
 \requires \tcode{ready() == true}.
 
 \pnum
-\effects Constructs an empty string \tcode{result} of type \tcode{string_type} and
+\effects
+Constructs an empty string \tcode{result} of type \tcode{string_type} and
 calls:
 \begin{codeblock}
 format(back_inserter(result), fmt, fmt + char_traits<char_type>::length(fmt), flags);
 \end{codeblock}
 
 \pnum
-\returns \tcode{result}.
+\returns
+\tcode{result}.
 \end{itemdescr}
 
 \rSec2[re.results.all]{Allocator}%
@@ -2416,7 +2505,8 @@ allocator_type get_allocator() const;
 
 \begin{itemdescr}
 \pnum
-\returns A copy of the Allocator that was passed to the object's constructor or, if that
+\returns
+A copy of the Allocator that was passed to the object's constructor or, if that
 allocator has been replaced, a copy of the most recent replacement.
 \end{itemdescr}
 
@@ -2429,15 +2519,18 @@ void swap(match_results& that);
 
 \begin{itemdescr}
 \pnum
-\effects  Swaps the contents of the two sequences.
+\effects
+Swaps the contents of the two sequences.
 
 \pnum
-\ensures  \tcode{*this} contains the sequence of matched
+\ensures
+\tcode{*this} contains the sequence of matched
 sub-expressions that were in \tcode{that}, \tcode{that} contains the
 sequence of matched sub-expressions that were in \tcode{*this}.
 
 \pnum
-\complexity Constant time.
+\complexity
+Constant time.
 \end{itemdescr}
 
 \indexlibrarymember{match_results}{swap}%
@@ -2448,7 +2541,8 @@ template<class BidirectionalIterator, class Allocator>
 \end{itemdecl}
 
 \pnum
-\effects As if by \tcode{m1.swap(m2)}.
+\effects
+As if by \tcode{m1.swap(m2)}.
 
 \rSec2[re.results.nonmember]{Non-member functions}
 
@@ -2512,7 +2606,8 @@ The type \tcode{BidirectionalIterator} shall meet the
 \oldconcept{BidirectionalIterator} requirements\iref{bidirectional.iterators}.
 
 \pnum
-\effects  Determines whether there is a match between the
+\effects
+Determines whether there is a match between the
 regular expression \tcode{e}, and all of the character
 sequence \range{first}{last}. The parameter \tcode{flags} is
 used to control how the expression is matched against the character
@@ -2617,7 +2712,8 @@ template<class BidirectionalIterator, class charT, class traits>
 
 \begin{itemdescr}
 \pnum
-\effects Behaves ``as if'' by constructing an instance of
+\effects
+Behaves ``as if'' by constructing an instance of
 \tcode{match_results<BidirectionalIterator> what}, and then
 returning the result of
 \tcode{regex_match(first, last, what, e, flags)}.
@@ -2634,7 +2730,8 @@ template<class charT, class Allocator, class traits>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{regex_match(str, str + char_traits<charT>::length(str), m, e, flags)}.
+\returns
+\tcode{regex_match(str, str + char_traits<charT>::length(str), m, e, flags)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{regex_match}}%
@@ -2649,7 +2746,8 @@ template<class ST, class SA, class Allocator, class charT, class traits>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{regex_match(s.begin(), s.end(), m, e, flags)}.
+\returns
+\tcode{regex_match(s.begin(), s.end(), m, e, flags)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{regex_match}}%
@@ -2662,7 +2760,8 @@ template<class charT, class traits>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{regex_match(str, str + char_traits<charT>::length(str), e, flags)}
+\returns
+\tcode{regex_match(str, str + char_traits<charT>::length(str), e, flags)}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{regex_match}}%
@@ -2675,7 +2774,8 @@ template<class ST, class SA, class charT, class traits>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{regex_match(s.begin(), s.end(), e, flags)}.
+\returns
+\tcode{regex_match(s.begin(), s.end(), e, flags)}.
 \end{itemdescr}
 
 \rSec2[re.alg.search]{\tcode{regex_search}}
@@ -2696,7 +2796,8 @@ Type \tcode{BidirectionalIterator} shall meet the
 \oldconcept{BidirectionalIterator} requirements\iref{bidirectional.iterators}.
 
 \pnum
-\effects Determines whether there is some sub-sequence within \range{first}{last} that matches
+\effects
+Determines whether there is some sub-sequence within \range{first}{last} that matches
 the regular expression \tcode{e}. The parameter \tcode{flags} is used to control how the
 expression is matched against the character sequence. Returns \tcode{true} if such a sequence
 exists, \tcode{false} otherwise.
@@ -2786,7 +2887,8 @@ template<class charT, class Allocator, class traits>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{regex_search(str, str + char_traits<charT>::length(str), m, e, flags)}.
+\returns
+\tcode{regex_search(str, str + char_traits<charT>::length(str), m, e, flags)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{regex_search}}%
@@ -2801,7 +2903,8 @@ template<class ST, class SA, class Allocator, class charT, class traits>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{regex_search(s.begin(), s.end(), m, e, flags)}.
+\returns
+\tcode{regex_search(s.begin(), s.end(), m, e, flags)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{regex_search}}%
@@ -2814,7 +2917,8 @@ template<class BidirectionalIterator, class charT, class traits>
 
 \begin{itemdescr}
 \pnum
-\effects Behaves ``as if'' by constructing an object \tcode{what}
+\effects
+Behaves ``as if'' by constructing an object \tcode{what}
 of type \tcode{match_results<Bidirectional\-Iterator>} and returning
 \tcode{regex_search(first, last, what, e, flags)}.
 \end{itemdescr}
@@ -2829,7 +2933,8 @@ template<class charT, class traits>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{regex_search(str, str + char_traits<charT>::length(str), e, flags)}.
+\returns
+\tcode{regex_search(str, str + char_traits<charT>::length(str), e, flags)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{regex_search}}%
@@ -2842,7 +2947,8 @@ template<class ST, class SA, class charT, class traits>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{regex_search(s.begin(), s.end(), e, flags)}.
+\returns
+\tcode{regex_search(s.begin(), s.end(), e, flags)}.
 \end{itemdescr}
 
 \rSec2[re.alg.replace]{\tcode{regex_replace}}
@@ -2914,7 +3020,8 @@ found. If \tcode{flags \& regex_constants::format_first_only}
 is nonzero, then only the first match found is replaced.
 
 \pnum
-\returns \tcode{out}.
+\returns
+\tcode{out}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{regex_replace}}%
@@ -2935,14 +3042,16 @@ template<class traits, class charT, class ST, class SA>
 
 \begin{itemdescr}
 \pnum
-\effects  Constructs an empty string \tcode{result} of
+\effects
+Constructs an empty string \tcode{result} of
 type \tcode{basic_string<charT, ST, SA>} and calls:
 \begin{codeblock}
 regex_replace(back_inserter(result), s.begin(), s.end(), e, fmt, flags);
 \end{codeblock}
 
 \pnum
-\returns \tcode{result}.
+\returns
+\tcode{result}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{regex_replace}}%
@@ -2963,14 +3072,16 @@ template<class traits, class charT>
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an empty string \tcode{result} of
+\effects
+Constructs an empty string \tcode{result} of
 type \tcode{basic_string<charT>} and calls:
 \begin{codeblock}
 regex_replace(back_inserter(result), s, s + char_traits<charT>::length(s), e, fmt, flags);
 \end{codeblock}
 
 \pnum
-\returns \tcode{result}.
+\returns
+\tcode{result}.
 \end{itemdescr}
 
 \rSec1[re.iter]{Regular expression iterators}
@@ -3059,7 +3170,8 @@ regex_iterator();
 
 \begin{itemdescr}
 \pnum
-\effects  Constructs an end-of-sequence iterator.
+\effects
+Constructs an end-of-sequence iterator.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{regex_iterator}!constructor}%
@@ -3071,7 +3183,8 @@ regex_iterator(BidirectionalIterator a, BidirectionalIterator b,
 
 \begin{itemdescr}
 \pnum
-\effects  Initializes \tcode{begin} and \tcode{end} to
+\effects
+Initializes \tcode{begin} and \tcode{end} to
 \tcode{a} and \tcode{b}, respectively, sets
 \tcode{pregex} to \tcode{addressof(re)}, sets \tcode{flags} to
 \tcode{m}, then calls \tcode{regex_search(begin, end, match, *pregex, flags)}. If this
@@ -3088,7 +3201,8 @@ bool operator==(const regex_iterator& right) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{true} if \tcode{*this} and \tcode{right} are both end-of-sequence
+\returns
+\tcode{true} if \tcode{*this} and \tcode{right} are both end-of-sequence
 iterators or if the following conditions all hold:
 \begin{itemize}
 \item \tcode{begin == right.begin},
@@ -3109,7 +3223,8 @@ const value_type& operator*() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{match}.
+\returns
+\tcode{match}.
 \end{itemdescr}
 
 \indexlibrarymember{operator->}{regex_iterator}%
@@ -3119,7 +3234,8 @@ const value_type* operator->() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{addressof(match)}.
+\returns
+\tcode{addressof(match)}.
 \end{itemdescr}
 
 \rSec3[re.regiter.incr]{Increment}
@@ -3132,7 +3248,8 @@ regex_iterator& operator++();
 
 \begin{itemdescr}
 \pnum
-\effects  Constructs a local variable \tcode{start} of type \tcode{BidirectionalIterator} and
+\effects
+Constructs a local variable \tcode{start} of type \tcode{BidirectionalIterator} and
 initializes it with the value of \tcode{match[0].second}.
 
 \pnum
@@ -3364,7 +3481,8 @@ regex_token_iterator();
 
 \begin{itemdescr}
 \pnum
-\effects  Constructs the end-of-sequence iterator.
+\effects
+Constructs the end-of-sequence iterator.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{regex_token_iterator}!constructor}%
@@ -3397,7 +3515,8 @@ template<size_t N>
 \tcode{>= -1}.
 
 \pnum
-\effects The first constructor initializes the member \tcode{subs} to hold the single
+\effects
+The first constructor initializes the member \tcode{subs} to hold the single
 value \tcode{submatch}.
 The second, third, and fourth constructors
 initialize the member \tcode{subs} to hold a copy of the sequence of integer values
@@ -3423,7 +3542,8 @@ bool operator==(const regex_token_iterator& right) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{true} if \tcode{*this} and \tcode{right} are both end-of-sequence iterators,
+\returns
+\tcode{true} if \tcode{*this} and \tcode{right} are both end-of-sequence iterators,
 or if \tcode{*this} and \tcode{right} are both suffix iterators and \tcode{suffix == right.suffix};
 otherwise returns \tcode{false} if \tcode{*this} or \tcode{right} is an end-of-sequence
 iterator or a suffix iterator. Otherwise returns \tcode{true} if \tcode{position == right.position},
@@ -3439,7 +3559,8 @@ const value_type& operator*() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{*result}.
+\returns
+\tcode{*result}.
 \end{itemdescr}
 
 
@@ -3450,7 +3571,8 @@ const value_type* operator->() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{result}.
+\returns
+\tcode{result}.
 \end{itemdescr}
 
 
@@ -3463,7 +3585,8 @@ regex_token_iterator& operator++();
 
 \begin{itemdescr}
 \pnum
-\effects  Constructs a local variable \tcode{prev} of
+\effects
+Constructs a local variable \tcode{prev} of
 type \tcode{position_iterator}, initialized with the value
 of \tcode{position}.
 
@@ -3490,7 +3613,8 @@ suffix iterator that points to the range \range{prev->suffix().first}{prev->suff
 Otherwise, sets \tcode{*this} to an end-of-sequence iterator.
 
 \pnum
-\returns \tcode{*this}
+\returns
+\tcode{*this}
 \end{itemdescr}
 
 \indexlibrarymember{regex_token_iterator}{operator++}%
@@ -3500,10 +3624,12 @@ regex_token_iterator& operator++(int);
 
 \begin{itemdescr}
 \pnum
-\effects  Constructs a copy \tcode{tmp} of \tcode{*this}, then calls \tcode{++(*this)}.
+\effects
+Constructs a copy \tcode{tmp} of \tcode{*this}, then calls \tcode{++(*this)}.
 
 \pnum
-\returns \tcode{tmp}.
+\returns
+\tcode{tmp}.
 \end{itemdescr}
 
 \rSec1[re.grammar]{Modified ECMAScript regular expression grammar}

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -245,7 +245,6 @@ a block scope\iref{basic.scope}. If the substatement in a
 \grammarterm{compound-statement}, it is as if it was rewritten to be a
 \grammarterm{compound-statement} containing the original substatement.
 \begin{example}
-
 \begin{codeblock}
 if (x)
   int i;
@@ -478,7 +477,6 @@ a single statement and not a \grammarterm{compound-statement},
 it is as if it was rewritten to be
 a \grammarterm{compound-statement} containing the original statement.
 \begin{example}
-
 \begin{codeblock}
 while (--x >= 0)
   int i;
@@ -615,7 +613,6 @@ equivalent to \tcode{while(true)}.
 If the \grammarterm{init-statement} is a declaration, the scope of the
 name(s) declared extends to the end of the \tcode{for} statement.
 \begin{example}
-
 \begin{codeblock}
 int i = 42;
 int a[10];
@@ -958,7 +955,6 @@ the variable has vacuous initialization\iref{dcl.init}.
 In such a case, the variables with vacuous initialization
 are constructed in the order of their declaration.
 \begin{example}
-
 \begin{codeblock}
 void f() {
   // ...
@@ -996,7 +992,6 @@ avoid deadlocks due to its own synchronization operations.} If control
 re-enters the declaration recursively while
 the variable is being initialized, the behavior is undefined.
 \begin{example}
-
 \begin{codeblock}
 int foo(int i) {
   static int s = foo(2*i);      // recursive call - undefined
@@ -1056,7 +1051,6 @@ semantic reasons, but that does not affect the syntactic analysis.
 
 The remaining cases are \grammarterm{declaration}{s}.
 \begin{example}
-
 \begin{codeblock}
 class T {
   // ...
@@ -1090,7 +1084,6 @@ This can occur only when the name is declared earlier in the
 declaration.
 \end{note}
 \begin{example}
-
 \begin{codeblock}
 struct T1 {
   T1 operator()(int x) { return T1(x); }

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -678,8 +678,10 @@ respectively;
 \tcode{begin(\exposid{range})} and \tcode{end(\exposid{range})}, respectively,
 where \tcode{begin} and \tcode{end} are looked
 up in the associated namespaces\iref{basic.lookup.argdep}.
-\begin{note} Ordinary unqualified lookup\iref{basic.lookup.unqual} is not
-performed. \end{note}
+\begin{note}
+Ordinary unqualified lookup\iref{basic.lookup.unqual} is not
+performed.
+\end{note}
 \end{itemize}
 \end{itemize}
 
@@ -725,8 +727,12 @@ Jump statements unconditionally transfer control.
 \indextext{scope!destructor and exit from}%
 On exit from a scope (however accomplished), objects with automatic storage
 duration\iref{basic.stc.auto} that have been constructed in that scope are destroyed
-in the reverse order of their construction. \begin{note} For temporaries,
-see~\ref{class.temporary}. \end{note} Transfer out of a loop, out of a block, or back
+in the reverse order of their construction.
+\begin{note}
+For temporaries,
+see~\ref{class.temporary}.
+\end{note}
+Transfer out of a loop, out of a block, or back
 past
 an initialized variable with automatic storage duration involves the
 destruction of objects with automatic storage duration that are in
@@ -1101,5 +1107,6 @@ void f() {
                                 // since it depends on \tcode{T2} being a type-name
 }
 \end{codeblock}
-\end{example}%
+\end{example}
+%
 \indextext{statement|)}

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -1108,5 +1108,4 @@ void f() {
 }
 \end{codeblock}
 \end{example}
-%
 \indextext{statement|)}

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -1647,8 +1647,11 @@ constexpr void shrink_to_fit();
 \pnum
 \effects
 \tcode{shrink_to_fit} is a non-binding request to reduce
-\tcode{capacity()} to \tcode{size()}. \begin{note} The request is non-binding to
-allow latitude for implementation-specific optimizations. \end{note}
+\tcode{capacity()} to \tcode{size()}.
+\begin{note}
+The request is non-binding to
+allow latitude for implementation-specific optimizations.
+\end{note}
 It does not increase \tcode{capacity()}, but may reduce \tcode{capacity()}
 by causing reallocation.
 
@@ -1662,7 +1665,9 @@ otherwise constant.
 \remarks
 Reallocation invalidates all the references, pointers, and iterators
 referring to the elements in the sequence, as well as the past-the-end iterator.
-\begin{note} If no reallocation happens, they remain valid. \end{note}
+\begin{note}
+If no reallocation happens, they remain valid.
+\end{note}
 \end{itemdescr}
 
 \indexlibrarymember{clear}{basic_string}%
@@ -2786,7 +2791,9 @@ constexpr size_type copy(charT* s, size_type n, size_type pos = 0) const;
 \effects
 Equivalent to:
 \tcode{return basic_string_view<charT, traits>(*this).copy(s, n, pos);}
-\begin{note} This does not terminate \tcode{s} with a null object. \end{note}
+\begin{note}
+This does not terminate \tcode{s} with a null object.
+\end{note}
 \end{itemdescr}
 
 \rSec4[string.swap]{\tcode{basic_string::swap}}

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -130,25 +130,32 @@ Operations on \tcode{X} shall not throw exceptions.
 \tcode{X::state_type}   &                       &
 (described in~\ref{char.traits.typedefs})   &   compile-time    \\ \rowsep
 \tcode{X::eq(c,d)}      &   \tcode{bool}        &
-\returns whether \tcode{c} is to be treated as equal to \tcode{d}.   &   constant    \\ \rowsep
+\returns
+whether \tcode{c} is to be treated as equal to \tcode{d}.   &   constant    \\ \rowsep
 \tcode{X::lt(c,d)}      &   \tcode{bool}        &
-\returns whether \tcode{c} is to be treated as less than \tcode{d}.  &   constant    \\ \rowsep
+\returns
+whether \tcode{c} is to be treated as less than \tcode{d}.  &   constant    \\ \rowsep
 \tcode{X::compare(p,q,n)}   &   \tcode{int}     &
-\returns \tcode{0} if for each \tcode{i} in \tcode{[0,n)}, \tcode{X::eq(p[i],q[i])}
+\returns
+\tcode{0} if for each \tcode{i} in \tcode{[0,n)}, \tcode{X::eq(p[i],q[i])}
 is \tcode{true}; else, a negative value if, for some \tcode{j} in \tcode{[0,n)},
 \tcode{X::lt(p[j],q[j])} is \tcode{true} and for each \tcode{i} in \tcode{[0,j)}
 \tcode{X::eq(p[i],q[i])} is \tcode{true}; else a positive value.            &   linear      \\ \rowsep
 \tcode{X::length(p)}    &   \tcode{size_t}     &
-\returns the smallest \tcode{i} such that \tcode{X::eq(p[i],charT())} is \tcode{true}.  &   linear  \\ \rowsep
+\returns
+the smallest \tcode{i} such that \tcode{X::eq(p[i],charT())} is \tcode{true}.  &   linear  \\ \rowsep
 \tcode{X::find(p,n,c)}  &   \tcode{const X::char_type*} &
-\returns the smallest \tcode{q} in \tcode{[p,p+n)} such that
+\returns
+the smallest \tcode{q} in \tcode{[p,p+n)} such that
 \tcode{X::eq(*q,c)} is \tcode{true}, zero otherwise.                        &   linear      \\ \rowsep
 \tcode{X::move(s,p,n)}  &   \tcode{X::char_type*}   &
 for each \tcode{i} in \tcode{[0,n)}, performs \tcode{X::assign(s[i],p[i])}.
 Copies correctly even where the ranges \tcode{[p,p+n)} and \tcode{[s,s+n)} overlap.\br \returns \tcode{s}.    &   linear  \\ \rowsep
 \tcode{X::copy(s,p,n)}  &   \tcode{X::char_type*}   &
-\expects \tcode{p} not in \tcode{[s,s+n)}. \br
-\returns \tcode{s}.\br
+\expects
+\tcode{p} not in \tcode{[s,s+n)}. \br
+\returns
+\tcode{s}.\br
 for each \tcode{i} in
 \tcode{[0,n)}, performs \tcode{X::assign(s[i],p[i])}.               &   linear      \\ \rowsep
 \tcode{X::assign(r,d)}  &   (not used)          &
@@ -156,25 +163,31 @@ assigns \tcode{r=d}.                            &   constant        \\ \rowsep
 \tcode{X::assign\-(s,n,c)}  &   \tcode{X::char_type*}   &
 for each \tcode{i} in \tcode{[0,n)}, performs
 \tcode{X::assign(s[i],c)}.\br
-\returns \tcode{s}.                       &   linear      \\ \rowsep
+\returns
+\tcode{s}.                       &   linear      \\ \rowsep
 \tcode{X::not_eof(e)}   &   \tcode{int_type}        &
-\returns \tcode{e} if \tcode{X::eq_int_type(e,X::eof())} is \tcode{false},
+\returns
+\tcode{e} if \tcode{X::eq_int_type(e,X::eof())} is \tcode{false},
 otherwise a value \tcode{f} such that
 \tcode{X::eq_int_type(f,X::eof())} is \tcode{false}.                       &   constant    \\ \rowsep
 \tcode{X::to_char_type\-(e)}    &   \tcode{X::char_type}    &
-\returns if for some \tcode{c}, \tcode{X::eq_int_type(e,X::to_int_type(c))}
+\returns
+if for some \tcode{c}, \tcode{X::eq_int_type(e,X::to_int_type(c))}
 is \tcode{true}, \tcode{c}; else some unspecified value.                    &   constant    \\ \rowsep
 \tcode{X::to_int_type\-(c)} &   \tcode{X::int_type} &
-\returns some value \tcode{e}, constrained by the definitions of
+\returns
+some value \tcode{e}, constrained by the definitions of
 \tcode{to_char_type} and \tcode{eq_int_type}.                  &   constant    \\ \rowsep
 \tcode{X::eq_int_type\-(e,f)}   &   \tcode{bool}            &
-\returns for all \tcode{c} and \tcode{d}, \tcode{X::eq(c,d)} is equal to
+\returns
+for all \tcode{c} and \tcode{d}, \tcode{X::eq(c,d)} is equal to
 \tcode{X::eq_int_type(X::to_int_type(c), X::to_int_type(d))}; otherwise, yields \tcode{true}
 if \tcode{e} and \tcode{f} are both copies of \tcode{X::eof()}; otherwise, yields \tcode{false} if
 one of \tcode{e} and \tcode{f} is a copy of \tcode{X::eof()} and the other is not; otherwise
 the value is unspecified.                                           &   constant    \\ \rowsep
 \tcode{X::eof()}                &   \tcode{X::int_type} &
-\returns a value \tcode{e} such that \tcode{X::eq_int_type(e,X::to_int_type(c))}
+\returns
+a value \tcode{e} such that \tcode{X::eq_int_type(e,X::to_int_type(c))}
 is \tcode{false} for all values \tcode{c}.                                  &   constant    \\
 \end{libreqtab4d}
 
@@ -1172,7 +1185,8 @@ template<class T>
 is \tcode{true}.
 
 \pnum
-\effects Creates a variable, \tcode{sv},
+\effects
+Creates a variable, \tcode{sv},
 as if by \tcode{basic_string_view<charT, traits> sv = t;}
 and then behaves the same as:
 \begin{codeblock}
@@ -1199,7 +1213,8 @@ template<class T>
 \end{itemize}
 
 \pnum
-\effects Creates a variable, \tcode{sv}, as if by
+\effects
+Creates a variable, \tcode{sv}, as if by
 \tcode{basic_string_view<charT, traits> sv = t;} and
 then behaves the same as \tcode{basic_string(sv.data(), sv.size(), a)}.
 \end{itemdescr}
@@ -1211,7 +1226,8 @@ constexpr basic_string(const charT* s, size_type n, const Allocator& a = Allocat
 
 \begin{itemdescr}
 \pnum
-\expects \range{s}{s + n} is a valid range.
+\expects
+\range{s}{s + n} is a valid range.
 
 \pnum
 \effects
@@ -1238,7 +1254,8 @@ This affects class template argument deduction.
 \end{note}
 
 \pnum
-\effects Equivalent to: \tcode{basic_string(s, traits::length(s), a)}.
+\effects
+Equivalent to: \tcode{basic_string(s, traits::length(s), a)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_string}!constructor}%
@@ -1285,7 +1302,8 @@ constexpr basic_string(initializer_list<charT> il, const Allocator& a = Allocato
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to \tcode{basic_string(il.begin(), il.end(), a)}.
+\effects
+Equivalent to \tcode{basic_string(il.begin(), il.end(), a)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_string}!constructor}%
@@ -1296,13 +1314,15 @@ constexpr basic_string(basic_string&& str, const Allocator& alloc);
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an object whose value is
+\effects
+Constructs an object whose value is
 that of \tcode{str} prior to this call.
 The stored allocator is constructed from \tcode{alloc}.
 In the second form, \tcode{str} is left in a valid but unspecified state.
 
 \pnum
-\throws The second form throws nothing if \tcode{alloc == str.get_allocator()}.
+\throws
+The second form throws nothing if \tcode{alloc == str.get_allocator()}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -1395,7 +1415,8 @@ is \tcode{false}.
 \end{itemize}
 
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 basic_string_view<charT, traits> sv = t;
 return assign(sv);
@@ -1409,7 +1430,8 @@ constexpr basic_string& operator=(const charT* s);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \tcode{return *this = basic_string_view<charT, traits>(s);}
 \end{itemdescr}
 
@@ -1420,7 +1442,8 @@ constexpr basic_string& operator=(charT c);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return *this = basic_string_view<charT, traits>(addressof(c), 1);
 \end{codeblock}
@@ -1433,7 +1456,8 @@ constexpr basic_string& operator=(initializer_list<charT> il);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return *this = basic_string_view<charT, traits>(il.begin(), il.size());
 \end{codeblock}
@@ -1514,7 +1538,8 @@ constexpr size_type length() const noexcept;
 A count of the number of char-like objects currently in the string.
 
 \pnum
-\complexity Constant time.
+\complexity
+Constant time.
 \end{itemdescr}
 
 \indexlibrarymember{max_size}{basic_string}%
@@ -1529,7 +1554,8 @@ The largest possible number of char-like objects that can be stored in a
 \tcode{basic_string}.
 
 \pnum
-\complexity Constant time.
+\complexity
+Constant time.
 \end{itemdescr}
 
 \indexlibrarymember{resize}{basic_string}%
@@ -1578,7 +1604,8 @@ constexpr size_type capacity() const noexcept;
 The size of the allocated storage in the string.
 
 \pnum
-\complexity Constant time.
+\complexity
+Constant time.
 \end{itemdescr}
 
 \indexlibrarymember{reserve}{basic_string}%
@@ -1618,19 +1645,22 @@ constexpr void shrink_to_fit();
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{shrink_to_fit} is a non-binding request to reduce
+\effects
+\tcode{shrink_to_fit} is a non-binding request to reduce
 \tcode{capacity()} to \tcode{size()}. \begin{note} The request is non-binding to
 allow latitude for implementation-specific optimizations. \end{note}
 It does not increase \tcode{capacity()}, but may reduce \tcode{capacity()}
 by causing reallocation.
 
 \pnum
-\complexity If the size is not equal to the old capacity,
+\complexity
+If the size is not equal to the old capacity,
 linear in the size of the sequence;
 otherwise constant.
 
 \pnum
-\remarks Reallocation invalidates all the references, pointers, and iterators
+\remarks
+Reallocation invalidates all the references, pointers, and iterators
 referring to the elements in the sequence, as well as the past-the-end iterator.
 \begin{note} If no reallocation happens, they remain valid. \end{note}
 \end{itemdescr}
@@ -1653,7 +1683,8 @@ Equivalent to: \tcode{erase(begin(), end());}
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \tcode{return size() == 0;}
 \end{itemdescr}
 
@@ -1667,19 +1698,23 @@ constexpr reference       operator[](size_type pos);
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{pos <= size()}.
+\expects
+\tcode{pos <= size()}.
 
 \pnum
-\returns \tcode{*(begin() + pos)} if \tcode{pos < size()}. Otherwise,
+\returns
+\tcode{*(begin() + pos)} if \tcode{pos < size()}. Otherwise,
 returns a reference to an object of type \tcode{charT} with value
 \tcode{charT()}, where modifying the object to any value other than
 \tcode{charT()} leads to undefined behavior.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 
 \pnum
-\complexity Constant time.
+\complexity
+Constant time.
 \end{itemdescr}
 
 \indexlibrarymember{at}{basic_string}%
@@ -1743,7 +1778,8 @@ constexpr basic_string& operator+=(const basic_string& str);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return append(str);}
+\effects
+Equivalent to: \tcode{return append(str);}
 
 
 \end{itemdescr}
@@ -1782,7 +1818,8 @@ constexpr basic_string& operator+=(const charT* s);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return append(s);}
+\effects
+Equivalent to: \tcode{return append(s);}
 \end{itemdescr}
 
 \indexlibrarymember{operator+=}{basic_string}%
@@ -1792,7 +1829,8 @@ constexpr basic_string& operator+=(charT c);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return append(size_type\{1\}, c);}
+\effects
+Equivalent to: \tcode{return append(size_type\{1\}, c);}
 \end{itemdescr}
 
 \indexlibrarymember{operator+=}{basic_string}%
@@ -1802,7 +1840,8 @@ constexpr basic_string& operator+=(initializer_list<charT> il);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return append(il);}
+\effects
+Equivalent to: \tcode{return append(il);}
 \end{itemdescr}
 
 
@@ -1815,7 +1854,8 @@ constexpr basic_string& append(const basic_string& str);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return append(str.data(), str.size());}
+\effects
+Equivalent to: \tcode{return append(str.data(), str.size());}
 \end{itemdescr}
 
 \indexlibrarymember{append}{basic_string}%
@@ -1893,10 +1933,12 @@ constexpr basic_string& append(const charT* s, size_type n);
 
 \begin{itemdescr}
 \pnum
-\expects \range{s}{s + n} is a valid range.
+\expects
+\range{s}{s + n} is a valid range.
 
 \pnum
-\effects Appends a copy of the range \range{s}{s + n} to the string.
+\effects
+Appends a copy of the range \range{s}{s + n} to the string.
 
 \pnum
 \returns
@@ -1910,7 +1952,8 @@ constexpr basic_string& append(const charT* s);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return append(s, traits::length(s));}
+\effects
+Equivalent to: \tcode{return append(s, traits::length(s));}
 \end{itemdescr}
 
 \indexlibrarymember{append}{basic_string}%
@@ -1920,10 +1963,12 @@ constexpr basic_string& append(size_type n, charT c);
 
 \begin{itemdescr}
 \pnum
-\effects Appends \tcode{n} copies of \tcode{c} to the string.
+\effects
+Appends \tcode{n} copies of \tcode{c} to the string.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{append}{basic_string}%
@@ -1939,7 +1984,8 @@ template<class InputIterator>
 iterator\iref{container.requirements.general}.
 
 \pnum
-\effects Equivalent to: \tcode{return append(basic_string(first, last, get_allocator()));}
+\effects
+Equivalent to: \tcode{return append(basic_string(first, last, get_allocator()));}
 \end{itemdescr}
 
 \indexlibrarymember{append}{basic_string}%
@@ -1949,7 +1995,8 @@ constexpr basic_string& append(initializer_list<charT> il);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return append(il.begin(), il.size());}
+\effects
+Equivalent to: \tcode{return append(il.begin(), il.size());}
 \end{itemdescr}
 
 \indexlibrarymember{push_back}{basic_string}%
@@ -1973,7 +2020,8 @@ constexpr basic_string& assign(const basic_string& str);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return *this = str;}
+\effects
+Equivalent to: \tcode{return *this = str;}
 \end{itemdescr}
 
 \indexlibrarymember{assign}{basic_string}%
@@ -1985,7 +2033,8 @@ constexpr basic_string& assign(basic_string&& str)
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return *this = std::move(str);}
+\effects
+Equivalent to: \tcode{return *this = std::move(str);}
 \end{itemdescr}
 
 
@@ -2049,7 +2098,8 @@ template<class T>
 \end{itemize}
 
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 basic_string_view<charT, traits> sv = t;
 return assign(sv.substr(pos, n));
@@ -2063,7 +2113,8 @@ constexpr basic_string& assign(const charT* s, size_type n);
 
 \begin{itemdescr}
 \pnum
-\expects \range{s}{s + n} is a valid range.
+\expects
+\range{s}{s + n} is a valid range.
 
 \pnum
 \effects
@@ -2082,7 +2133,8 @@ constexpr basic_string& assign(const charT* s);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return assign(s, traits::length(s));}
+\effects
+Equivalent to: \tcode{return assign(s, traits::length(s));}
 \end{itemdescr}
 
 \indexlibrarymember{assign}{basic_string}%
@@ -2092,7 +2144,8 @@ constexpr basic_string& assign(initializer_list<charT> il);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return assign(il.begin(), il.size());}
+\effects
+Equivalent to: \tcode{return assign(il.begin(), il.size());}
 \end{itemdescr}
 
 \indexlibrarymember{assign}{basic_string}%
@@ -2102,7 +2155,8 @@ constexpr basic_string& assign(size_type n, charT c);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 clear();
 resize(n, c);
@@ -2123,7 +2177,8 @@ template<class InputIterator>
 iterator\iref{container.requirements.general}.
 
 \pnum
-\effects Equivalent to: \tcode{return assign(basic_string(first, last, get_allocator()));}
+\effects
+Equivalent to: \tcode{return assign(basic_string(first, last, get_allocator()));}
 \end{itemdescr}
 
 \rSec4[string.insert]{\tcode{basic_string::insert}}
@@ -2135,7 +2190,8 @@ constexpr basic_string& insert(size_type pos, const basic_string& str);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return insert(pos, str.data(), str.size());}
+\effects
+Equivalent to: \tcode{return insert(pos, str.data(), str.size());}
 \end{itemdescr}
 
 \indexlibrarymember{insert}{basic_string}%
@@ -2200,7 +2256,8 @@ template<class T>
 \end{itemize}
 
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 basic_string_view<charT, traits> sv = t;
 return insert(pos1, sv.substr(pos2, n));
@@ -2214,7 +2271,8 @@ constexpr basic_string& insert(size_type pos, const charT* s, size_type n);
 
 \begin{itemdescr}
 \pnum
-\expects \range{s}{s + n} is a valid range.
+\expects
+\range{s}{s + n} is a valid range.
 
 \pnum
 \throws
@@ -2225,7 +2283,8 @@ constexpr basic_string& insert(size_type pos, const charT* s, size_type n);
 \end{itemize}
 
 \pnum
-\effects Inserts a copy of the range \range{s}{s + n}
+\effects
+Inserts a copy of the range \range{s}{s + n}
 immediately before the character at position \tcode{pos} if \tcode{pos < size()},
 or otherwise at the end of the string.
 
@@ -2241,7 +2300,8 @@ constexpr basic_string& insert(size_type pos, const charT* s);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return insert(pos, s, traits::length(s));}
+\effects
+Equivalent to: \tcode{return insert(pos, s, traits::length(s));}
 \end{itemdescr}
 
 \indexlibrarymember{insert}{basic_string}%
@@ -2305,7 +2365,8 @@ constexpr iterator insert(const_iterator p, size_type n, charT c);
 Inserts \tcode{n} copies of \tcode{c} at the position \tcode{p}.
 
 \pnum
-\returns An iterator which refers to  the first inserted character, or
+\returns
+An iterator which refers to  the first inserted character, or
 \tcode{p} if \tcode{n == 0}.
 \end{itemdescr}
 
@@ -2332,7 +2393,8 @@ Equivalent to
 \tcode{insert(p - begin(), basic_string(first, last, get_allocator()))}.
 
 \pnum
-\returns An iterator which refers to the first inserted character, or
+\returns
+An iterator which refers to the first inserted character, or
 \tcode{p} if \tcode{first == last}.
 \end{itemdescr}
 
@@ -2343,7 +2405,8 @@ constexpr iterator insert(const_iterator p, initializer_list<charT> il);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return insert(p, il.begin(), il.end());}
+\effects
+Equivalent to: \tcode{return insert(p, il.begin(), il.end());}
 \end{itemdescr}
 
 \rSec4[string.erase]{\tcode{basic_string::erase}}
@@ -2383,7 +2446,8 @@ constexpr iterator erase(const_iterator p);
 \tcode{p} is a valid dereferenceable iterator on \tcode{*this}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 
 \pnum
 \effects
@@ -2410,7 +2474,8 @@ constexpr iterator erase(const_iterator first, const_iterator last);
 \tcode{*this}. \range{first}{last} is a valid range.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 
 \pnum
 \effects
@@ -2437,7 +2502,8 @@ constexpr void pop_back();
 \tcode{!empty()}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 
 \pnum
 \effects
@@ -2453,7 +2519,8 @@ constexpr basic_string& replace(size_type pos1, size_type n1, const basic_string
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return replace(pos1, n1, str.data(), str.size());}
+\effects
+Equivalent to: \tcode{return replace(pos1, n1, str.data(), str.size());}
 \end{itemdescr}
 
 \indexlibrarymember{replace}{basic_string}%
@@ -2533,7 +2600,8 @@ constexpr basic_string& replace(size_type pos1, size_type n1, const charT* s, si
 
 \begin{itemdescr}
 \pnum
-\expects \range{s}{s + n2} is a valid range.
+\expects
+\range{s}{s + n2} is a valid range.
 
 \pnum
 \throws
@@ -2545,7 +2613,8 @@ would exceed \tcode{max_size()} (see below), or
 \end{itemize}
 
 \pnum
-\effects Determines the effective length \tcode{xlen} of the string to be
+\effects
+Determines the effective length \tcode{xlen} of the string to be
 removed as the smaller of \tcode{n1} and \tcode{size() - pos1}. If
 \tcode{size() - xlen >= max_size() - n2} throws \tcode{length_error}. Otherwise,
 the function replaces the characters in the range
@@ -2564,7 +2633,8 @@ constexpr basic_string& replace(size_type pos, size_type n, const charT* s);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return replace(pos, n, s, traits::length(s));}
+\effects
+Equivalent to: \tcode{return replace(pos, n, s, traits::length(s));}
 \end{itemdescr}
 
 \indexlibrarymember{replace}{basic_string}%
@@ -2583,7 +2653,8 @@ would exceed \tcode{max_size()} (see below), or
 \end{itemize}
 
 \pnum
-\effects Determines the effective length \tcode{xlen} of the string to be
+\effects
+Determines the effective length \tcode{xlen} of the string to be
 removed as the smaller of \tcode{n1} and \tcode{size() - pos1}. If
 \tcode{size() - xlen >=} \tcode{max_size() - n2} throws \tcode{length_error}. Otherwise,
 the function replaces the characters in the range
@@ -2591,7 +2662,8 @@ the function replaces the characters in the range
 with \tcode{n2} copies of \tcode{c}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{replace}{basic_string}%
@@ -2665,7 +2737,8 @@ constexpr basic_string& replace(const_iterator i1, const_iterator i2, size_type 
 
 \begin{itemdescr}
 \pnum
-\expects \range{begin()}{i1} and \range{i1}{i2} are valid ranges.
+\expects
+\range{begin()}{i1} and \range{i1}{i2} are valid ranges.
 
 \pnum
 \effects
@@ -2740,10 +2813,12 @@ contains the same sequence of characters that was in \tcode{s},
 \tcode{*this}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 
 \pnum
-\complexity Constant time.
+\complexity
+Constant time.
 \end{itemdescr}
 
 \rSec3[string.ops]{String operations}
@@ -2759,11 +2834,13 @@ constexpr const charT* data() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns A pointer \tcode{p} such that \tcode{p + i == addressof(operator[](i))} for each
+\returns
+A pointer \tcode{p} such that \tcode{p + i == addressof(operator[](i))} for each
 \tcode{i} in \crange{0}{size()}.
 
 \pnum
-\complexity Constant time.
+\complexity
+Constant time.
 
 \pnum
 \remarks
@@ -2777,11 +2854,13 @@ constexpr charT* data() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns A pointer \tcode{p} such that \tcode{p + i == addressof(operator[](i))} for each
+\returns
+A pointer \tcode{p} such that \tcode{p + i == addressof(operator[](i))} for each
 \tcode{i} in \crange{0}{size()}.
 
 \pnum
-\complexity Constant time.
+\complexity
+Constant time.
 
 \pnum
 \remarks
@@ -2796,7 +2875,8 @@ constexpr operator basic_string_view<charT, traits>() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \tcode{return basic_string_view<charT, traits>(data(), size());}
 \end{itemdescr}
 
@@ -3051,7 +3131,8 @@ constexpr int compare(size_type pos1, size_type n1, const basic_string& str,
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return compare(pos1, n1, basic_string_view<charT, traits>(str), pos2, n2);
 \end{codeblock}
@@ -3064,7 +3145,8 @@ constexpr int compare(const charT* s) const;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \tcode{return compare(basic_string_view<charT, traits>(s));}
 \end{itemdescr}
 
@@ -3327,7 +3409,8 @@ template<class charT, class traits, class Allocator>
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\effects Let \tcode{\placeholder{op}} be the operator.
+\effects
+Let \tcode{\placeholder{op}} be the operator.
 Equivalent to:
 \begin{codeblock}
 return basic_string_view<charT, traits>(lhs) @\placeholder{op}@ basic_string_view<charT, traits>(rhs);
@@ -3555,7 +3638,8 @@ unsigned long long stoull(const string& str, size_t* idx = nullptr, int base = 1
 
 \begin{itemdescr}
 \pnum
-\effects The first two functions call \tcode{strtol(str.c_str(), ptr, base)},
+\effects
+The first two functions call \tcode{strtol(str.c_str(), ptr, base)},
 and the last three functions call \tcode{strtoul(str.c_str(), ptr, base)},
 \tcode{strtoll(str.c_str(), ptr, base)}, and \tcode{strtoull(\brk{}str.c_str(), ptr,
 base)}, respectively. Each function returns the converted result, if any. The
@@ -3565,10 +3649,12 @@ not throw an exception and \tcode{idx != 0}, the function stores in \tcode{*idx}
 the index of the first unconverted element of \tcode{str}.
 
 \pnum
-\returns The converted result.
+\returns
+The converted result.
 
 \pnum
-\throws \tcode{invalid_argument} if \tcode{strtol}, \tcode{strtoul},
+\throws
+\tcode{invalid_argument} if \tcode{strtol}, \tcode{strtoul},
 \tcode{strtoll}, or \tcode{strtoull} reports that no conversion could be
 performed. Throws \tcode{out_of_range} if \tcode{strtol}, \tcode{strtoul},
 \tcode{strtoll} or \tcode{strtoull} sets \tcode{errno} to \tcode{ERANGE},
@@ -3587,7 +3673,8 @@ long double stold(const string& str, size_t* idx = nullptr);
 
 \begin{itemdescr}
 \pnum
-\effects These functions call
+\effects
+These functions call
 \tcode{strtof(str.c_str(), ptr)}, \tcode{strtod(str.c_str(), ptr)}, and
 \tcode{strtold(\brk{}str.c_str(), ptr)}, respectively. Each function returns
 the converted result, if any. The argument \tcode{ptr} designates a pointer to
@@ -3597,10 +3684,12 @@ the function stores in \tcode{*idx} the index of the first unconverted element
 of \tcode{str}.
 
 \pnum
-\returns The converted result.
+\returns
+The converted result.
 
 \pnum
-\throws \tcode{invalid_argument} if \tcode{strtof}, \tcode{strtod}, or
+\throws
+\tcode{invalid_argument} if \tcode{strtof}, \tcode{strtod}, or
 \tcode{strtold} reports that no conversion could be performed. Throws
 \tcode{out_of_range} if \tcode{strtof}, \tcode{strtod}, or
 \tcode{strtold} sets \tcode{errno} to \tcode{ERANGE}
@@ -3623,7 +3712,8 @@ string to_string(long double val);
 
 \begin{itemdescr}
 \pnum
-\returns Each function returns a \tcode{string} object holding the character
+\returns
+Each function returns a \tcode{string} object holding the character
 representation of the value of its argument that would be generated by calling
 \tcode{sprintf(buf, fmt, val)} with a format specifier of
 \tcode{"\%d"},
@@ -3652,7 +3742,8 @@ unsigned long long stoull(const wstring& str, size_t* idx = nullptr, int base = 
 
 \begin{itemdescr}
 \pnum
-\effects The first two functions call \tcode{wcstol(str.c_str(), ptr, base)},
+\effects
+The first two functions call \tcode{wcstol(str.c_str(), ptr, base)},
 and the last three functions call \tcode{wcstoul(str.c_str(), ptr, base)},
 \tcode{wcstoll(str.c_str(), ptr, base)}, and \tcode{wcstoull(\brk{}str.c_str(), ptr,
 base)}, respectively. Each function returns the converted result, if any. The
@@ -3662,10 +3753,12 @@ not throw an exception and \tcode{idx != 0}, the function stores in \tcode{*idx}
 the index of the first unconverted element of \tcode{str}.
 
 \pnum
-\returns The converted result.
+\returns
+The converted result.
 
 \pnum
-\throws \tcode{invalid_argument} if \tcode{wcstol}, \tcode{wcstoul}, \tcode{wcstoll}, or
+\throws
+\tcode{invalid_argument} if \tcode{wcstol}, \tcode{wcstoul}, \tcode{wcstoll}, or
 \tcode{wcstoull} reports that no conversion could be performed. Throws
 \tcode{out_of_range} if the converted value is outside the range of representable values
 for the return type.
@@ -3682,7 +3775,8 @@ long double stold(const wstring& str, size_t* idx = nullptr);
 
 \begin{itemdescr}
 \pnum
-\effects These functions call \tcode{wcstof(str.c_str(), ptr)},
+\effects
+These functions call \tcode{wcstof(str.c_str(), ptr)},
 \tcode{wcstod(str.c_str(), ptr)}, and \tcode{wcstold(\brk{}str.c_str(), ptr)},
 respectively. Each function returns the converted
 result, if any. The argument \tcode{ptr} designates a pointer to an object internal to
@@ -3691,10 +3785,12 @@ does not throw an exception and \tcode{idx != 0}, the function stores in \tcode{
 the index of the first unconverted element of \tcode{str}.
 
 \pnum
-\returns The converted result.
+\returns
+The converted result.
 
 \pnum
-\throws \tcode{invalid_argument} if \tcode{wcstof}, \tcode{wcstod}, or \tcode{wcstold} reports that no
+\throws
+\tcode{invalid_argument} if \tcode{wcstof}, \tcode{wcstod}, or \tcode{wcstold} reports that no
 conversion could be performed. Throws \tcode{out_of_range} if \tcode{wcstof}, \tcode{wcstod}, or
 \tcode{wcstold} sets \tcode{errno} to \tcode{ERANGE}.
 \end{itemdescr}
@@ -3714,7 +3810,8 @@ wstring to_wstring(long double val);
 
 \begin{itemdescr}
 \pnum
-\returns Each function returns a \tcode{wstring} object holding the character
+\returns
+Each function returns a \tcode{wstring} object holding the character
 representation of the value of its argument that would be generated by calling
 \tcode{swprintf(buf, buffsz, fmt, val)} with a format specifier of
 \tcode{L"\%d"},

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -3813,7 +3813,8 @@ constexpr wstring operator""s(const wchar_t* str, size_t len);
 \tcode{wstring\{str, len\}}.
 \end{itemdescr}
 
-\pnum \begin{note}
+\pnum
+\begin{note}
 The same suffix \tcode{s} is used for \tcode{chrono::duration} literals denoting seconds but there is no conflict, since duration suffixes apply to numbers and string literal suffixes apply to character array literals.
 \end{note}
 

--- a/source/support.tex
+++ b/source/support.tex
@@ -345,9 +345,11 @@ template<class IntType>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \constraints \tcode{is_integral_v<IntType>} is \tcode{true}.
+\pnum
+\constraints \tcode{is_integral_v<IntType>} is \tcode{true}.
 
-\pnum \effects Equivalent to:
+\pnum
+\effects Equivalent to:
 \tcode{return b = b << shift;}
 \end{itemdescr}
 
@@ -358,9 +360,11 @@ template<class IntType>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \constraints \tcode{is_integral_v<IntType>} is \tcode{true}.
+\pnum
+\constraints \tcode{is_integral_v<IntType>} is \tcode{true}.
 
-\pnum \effects Equivalent to:
+\pnum
+\effects Equivalent to:
 \begin{codeblock}
 return static_cast<byte>(static_cast<unsigned char>(
 	                   static_cast<unsigned int>(b) << shift));
@@ -374,9 +378,11 @@ template<class IntType>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \constraints \tcode{is_integral_v<IntType>} is \tcode{true}.
+\pnum
+\constraints \tcode{is_integral_v<IntType>} is \tcode{true}.
 
-\pnum \effects Equivalent to:
+\pnum
+\effects Equivalent to:
 \tcode{return b >> shift;}
 \end{itemdescr}
 
@@ -387,9 +393,11 @@ template<class IntType>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \constraints \tcode{is_integral_v<IntType>} is \tcode{true}.
+\pnum
+\constraints \tcode{is_integral_v<IntType>} is \tcode{true}.
 
-\pnum \effects Equivalent to:
+\pnum
+\effects Equivalent to:
 \begin{codeblock}
 return static_cast<byte>(static_cast<unsigned char>(
 	                   static_cast<unsigned int>(b) >> shift));
@@ -402,7 +410,8 @@ constexpr byte& operator|=(byte& l, byte r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \effects Equivalent to: \tcode{return l = l | r;}
+\pnum
+\effects Equivalent to: \tcode{return l = l | r;}
 \end{itemdescr}
 
 \indexlibrarymember{operator"|}{byte}%
@@ -411,7 +420,8 @@ constexpr byte operator|(byte l, byte r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \effects Equivalent to:
+\pnum
+\effects Equivalent to:
 \begin{codeblock}
 return static_cast<byte>(static_cast<unsigned char>(static_cast<unsigned int>(l) |
                                                     static_cast<unsigned int>(r)));
@@ -424,7 +434,8 @@ constexpr byte& operator&=(byte& l, byte r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \effects Equivalent to: \tcode{return l = l \& r;}
+\pnum
+\effects Equivalent to: \tcode{return l = l \& r;}
 \end{itemdescr}
 
 \indexlibrarymember{operator\&}{byte}%
@@ -433,7 +444,8 @@ constexpr byte operator&(byte l, byte r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \effects Equivalent to:
+\pnum
+\effects Equivalent to:
 \begin{codeblock}
 return static_cast<byte>(static_cast<unsigned char>(static_cast<unsigned int>(l) &
                                                     static_cast<unsigned int>(r)));
@@ -446,7 +458,8 @@ constexpr byte& operator^=(byte& l, byte r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \effects Equivalent to: \tcode{return l = l \caret{} r;}
+\pnum
+\effects Equivalent to: \tcode{return l = l \caret{} r;}
 \end{itemdescr}
 
 \indexlibrarymember{operator\caret}{byte}%
@@ -455,7 +468,8 @@ constexpr byte operator^(byte l, byte r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \effects Equivalent to:
+\pnum
+\effects Equivalent to:
 \begin{codeblock}
 return static_cast<byte>(static_cast<unsigned char>(static_cast<unsigned int>(l) ^
                                                     static_cast<unsigned int>(r)));
@@ -468,7 +482,8 @@ constexpr byte operator~(byte b) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \effects Equivalent to:
+\pnum
+\effects Equivalent to:
 \begin{codeblock}
 return static_cast<byte>(static_cast<unsigned char>(
 	                   ~static_cast<unsigned int>(b)));
@@ -482,9 +497,11 @@ template<class IntType>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \constraints \tcode{is_integral_v<IntType>} is \tcode{true}.
+\pnum
+\constraints \tcode{is_integral_v<IntType>} is \tcode{true}.
 
-\pnum \effects Equivalent to: \tcode{return static_cast<IntType>(b);}
+\pnum
+\effects Equivalent to: \tcode{return static_cast<IntType>(b);}
 \end{itemdescr}
 
 \rSec1[support.limits]{Implementation properties}
@@ -1039,7 +1056,8 @@ digits that can be represented without change.
 \pnum
 For integer types, the number of non-sign bits in the representation.
 
-\pnum For floating-point types, the number of \tcode{radix} digits in the
+\pnum
+For floating-point types, the number of \tcode{radix} digits in the
 mantissa.\footnote{Equivalent to \tcode{FLT_MANT_DIG}, \tcode{DBL_MANT_DIG},
 \tcode{LDBL_MANT_DIG}.} \end{itemdescr}
 
@@ -5434,7 +5452,8 @@ constexpr bool operator==(coroutine_handle<> x, coroutine_handle<> y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \returns \tcode{x.address() == y.address()}.
+\pnum
+\returns \tcode{x.address() == y.address()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{coroutine_handle}%
@@ -5443,7 +5462,8 @@ constexpr strong_ordering operator<=>(coroutine_handle<> x, coroutine_handle<> y
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \returns \tcode{compare_three_way()(x.address(), y.address())}.
+\pnum
+\returns \tcode{compare_three_way()(x.address(), y.address())}.
 \end{itemdescr}
 
 \rSec3[coroutine.handle.hash]{Hash support}
@@ -5454,7 +5474,8 @@ template<class P> struct hash<coroutine_handle<P>>;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum The specialization is enabled\iref{unord.hash}.
+\pnum
+The specialization is enabled\iref{unord.hash}.
 \end{itemdescr}
 
 \rSec2[coroutine.noop]{No-op coroutines}
@@ -5467,7 +5488,8 @@ struct noop_coroutine_promise {};
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum The class \tcode{noop_coroutine_promise} defines the promise type for
+\pnum
+The class \tcode{noop_coroutine_promise} defines the promise type for
 the coroutine referred to
 by \tcode{noop_coroutine_handle}\iref{coroutine.syn}.
 \end{itemdescr}
@@ -5508,7 +5530,8 @@ constexpr explicit operator bool() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \returns \tcode{true}.
+\pnum
+\returns \tcode{true}.
 \end{itemdescr}
 
 \indexlibrarymember{done}{coroutine_handle<noop_coroutine_promise>}%
@@ -5517,7 +5540,8 @@ constexpr bool done() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \returns \tcode{false}.
+\pnum
+\returns \tcode{false}.
 \end{itemdescr}
 
 \rSec4[coroutine.handle.noop.resumption]{Resumption}
@@ -5532,7 +5556,8 @@ constexpr void destroy() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \effects None.
+\pnum
+\effects None.
 
 \pnum
 \remarks
@@ -5549,7 +5574,8 @@ noop_coroutine_promise& promise() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \returns A reference to the promise object associated with this
+\pnum
+\returns A reference to the promise object associated with this
 coroutine handle.
 \end{itemdescr}
 
@@ -5561,9 +5587,11 @@ constexpr void* address() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \returns \tcode{ptr}.
+\pnum
+\returns \tcode{ptr}.
 
-\pnum \remarks A \tcode{noop_coroutine_handle}'s \tcode{ptr} is always a
+\pnum
+\remarks A \tcode{noop_coroutine_handle}'s \tcode{ptr} is always a
 non-null pointer value.
 \end{itemdescr}
 
@@ -5575,10 +5603,12 @@ noop_coroutine_handle noop_coroutine() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \returns A handle to a coroutine that has no observable effects
+\pnum
+\returns A handle to a coroutine that has no observable effects
 when resumed or destroyed.
 
-\pnum \remarks A handle returned from \tcode{noop_coroutine} may or may not
+\pnum
+\remarks A handle returned from \tcode{noop_coroutine} may or may not
 compare equal to a handle returned from another invocation
 of \tcode{noop_coroutine}.
 \end{itemdescr}

--- a/source/support.tex
+++ b/source/support.tex
@@ -1435,8 +1435,10 @@ static constexpr bool is_bounded;
 \begin{itemdescr}
 \pnum
 \tcode{true} if the set of values representable by the type is finite.\footnote{Required by LIA-1.}
-\begin{note} All fundamental types\iref{basic.fundamental} are bounded. This member would be \tcode{false} for arbitrary
-precision types.\end{note}
+\begin{note}
+All fundamental types\iref{basic.fundamental} are bounded. This member would be \tcode{false} for arbitrary
+precision types.
+\end{note}
 
 \pnum
 Meaningful for all specializations.
@@ -1935,8 +1937,10 @@ functions register the function pointed to by \tcode{f}
 to be called without arguments at normal program termination.
 It is unspecified whether a call to \tcode{atexit()} that does not
 happen before\iref{intro.multithread} a call to \tcode{exit()} will succeed.
-\begin{note} The \tcode{atexit()} functions do not introduce a data
-race\iref{res.on.data.races}. \end{note}
+\begin{note}
+The \tcode{atexit()} functions do not introduce a data
+race\iref{res.on.data.races}.
+\end{note}
 
 \pnum
 \implimits
@@ -2023,14 +2027,18 @@ int at_quick_exit(@\placeholder{atexit-handler}@* f) noexcept;
 The \tcode{at_quick_exit()} functions register the function pointed to by \tcode{f}
 to be called without arguments when \tcode{quick_exit} is called.
 It is unspecified whether a call to \tcode{at_quick_exit()} that does not
-happen before\iref{intro.multithread} all calls to \tcode{quick_exit} will succeed. \begin{note} The
+happen before\iref{intro.multithread} all calls to \tcode{quick_exit} will succeed.
+\begin{note}
+The
 \tcode{at_quick_exit()} functions do not introduce a
-data race\iref{res.on.data.races}. \end{note}
+data race\iref{res.on.data.races}.
+\end{note}
 \begin{note}
 The order of registration may be indeterminate if \tcode{at_quick_exit} was called from more
 than one thread.
 \end{note}
-\begin{note} The
+\begin{note}
+The
 \tcode{at_quick_exit} registrations are distinct from the \tcode{atexit} registrations,
 and applications may need to call both registration functions with the same argument.
 \end{note}
@@ -2349,16 +2357,20 @@ may be changed to
 a call to the corresponding \tcode{operator delete}
 without a \tcode{size} parameter,
 without affecting memory allocation.
-\begin{note} A conforming implementation is for
+\begin{note}
+A conforming implementation is for
 \tcode{operator delete(void* ptr, std::size_t size)} to simply call
-\tcode{operator delete(ptr)}. \end{note}
+\tcode{operator delete(ptr)}.
+\end{note}
 
 \pnum
 \default
 The functions that have a \tcode{size} parameter
 forward their other parameters
 to the corresponding function without a \tcode{size} parameter.
-\begin{note} See the note in the above \replaceable paragraph. \end{note}
+\begin{note}
+See the note in the above \replaceable paragraph.
+\end{note}
 
 \pnum
 \default
@@ -2599,9 +2611,11 @@ may be changed to
 a call to the corresponding \tcode{operator delete[]}
 without a \tcode{size} parameter,
 without affecting memory allocation.
-\begin{note} A conforming implementation is for
+\begin{note}
+A conforming implementation is for
 \tcode{operator delete[](void* ptr, std::size_t size)} to simply call
-\tcode{operator delete[](ptr)}. \end{note}
+\tcode{operator delete[](ptr)}.
+\end{note}
 
 \pnum
 \default
@@ -2910,7 +2924,9 @@ new_handler get_new_handler() noexcept;
 \pnum
 \returns
 The current \tcode{new_handler}.
-\begin{note} This may be a null pointer value. \end{note}
+\begin{note}
+This may be a null pointer value.
+\end{note}
 \end{itemdescr}
 
 \rSec2[ptr.launder]{Pointer optimization barrier}
@@ -3644,7 +3660,9 @@ terminate_handler get_terminate() noexcept;
 \pnum
 \returns
 The current \tcode{terminate_handler}.
-\begin{note} This may be a null pointer value. \end{note}
+\begin{note}
+This may be a null pointer value.
+\end{note}
 \end{itemdescr}
 
 \rSec3[terminate]{\tcode{terminate}}
@@ -3666,9 +3684,12 @@ May also be called directly by the program.
 Calls a \tcode{terminate_handler} function. It is unspecified which
 \tcode{terminate_handler} function will be called if an exception is active
 during a call to \tcode{set_terminate}.
-Otherwise calls the current \tcode{terminate_handler} function. \begin{note} A
+Otherwise calls the current \tcode{terminate_handler} function.
+\begin{note}
+A
 default \tcode{terminate_handler} is always considered a callable handler in
-this context. \end{note}
+this context.
+\end{note}
 \end{itemdescr}
 
 \rSec2[uncaught.exceptions]{\tcode{uncaught_exceptions}}
@@ -3718,19 +3739,24 @@ type.
 enumeration, or pointer type.
 
 \pnum
-\begin{note} An implementation might use a reference-counted smart
-pointer as \tcode{exception_ptr}. \end{note}
+\begin{note}
+An implementation might use a reference-counted smart
+pointer as \tcode{exception_ptr}.
+\end{note}
 
 \pnum
 For purposes of determining the presence of a data race, operations on
 \tcode{exception_ptr} objects shall access and modify only the
 \tcode{exception_ptr} objects themselves and not the exceptions they refer to.
 Use of \tcode{rethrow_exception} on \tcode{exception_ptr} objects that refer to
-the same exception object shall not introduce a data race. \begin{note} If
+the same exception object shall not introduce a data race.
+\begin{note}
+If
 \tcode{rethrow_exception} rethrows the same exception object (rather than a copy),
 concurrent access to that rethrown exception object may introduce a data race.
 Changes in the number of \tcode{exception_ptr} objects that refer to a
-particular exception do not introduce a data race. \end{note}
+particular exception do not introduce a data race.
+\end{note}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{current_exception}}%
@@ -3750,14 +3776,19 @@ If the function needs to allocate memory and the attempt fails, it returns an
 \tcode{exception_ptr} object that refers to an instance of \tcode{bad_alloc}.
 It is unspecified whether the return values of two successive calls to
 \tcode{current_exception} refer to the same exception object.
-\begin{note} That is, it is unspecified whether \tcode{current_exception}
-creates a new copy each time it is called. \end{note}
+\begin{note}
+That is, it is unspecified whether \tcode{current_exception}
+creates a new copy each time it is called.
+\end{note}
 If the attempt to copy the current exception object throws an exception, the function
 returns an \tcode{exception_ptr} object that refers to the thrown exception or,
-if this is not possible, to an instance of \tcode{bad_exception}. \begin{note} The
+if this is not possible, to an instance of \tcode{bad_exception}.
+\begin{note}
+The
 copy constructor of the thrown exception may also fail, so the implementation is allowed
 to substitute a \tcode{bad_exception} object to avoid infinite
-recursion.\end{note}
+recursion.
+\end{note}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{rethrow_exception}}%
@@ -3793,8 +3824,10 @@ try {
 \end{codeblock}
 
 \pnum
-\begin{note} This function is provided for convenience and
-efficiency reasons. \end{note}
+\begin{note}
+This function is provided for convenience and
+efficiency reasons.
+\end{note}
 \end{itemdescr}
 
 \rSec2[except.nested]{\tcode{nested_exception}}
@@ -3825,7 +3858,8 @@ multiple inheritance. It captures the currently handled exception and stores it
 for later use.
 
 \pnum
-\begin{note} \tcode{nested_exception} has a virtual destructor to make it a
+\begin{note}
+\tcode{nested_exception} has a virtual destructor to make it a
 polymorphic class. Its presence can be tested for with \tcode{dynamic_cast}.
 \end{note}
 
@@ -3945,11 +3979,14 @@ namespace std {
 
 \pnum
 An object of type \tcode{initializer_list<E>} provides access to an array of
-objects of type \tcode{const E}. \begin{note} A pair of pointers or a pointer plus
+objects of type \tcode{const E}.
+\begin{note}
+A pair of pointers or a pointer plus
 a length would be obvious representations for \tcode{initializer_list}.
 \tcode{initializer_list} is used to implement initializer lists as specified
 in~\ref{dcl.init.list}. Copying an initializer list does not copy the underlying
-elements. \end{note}
+elements.
+\end{note}
 
 \pnum
 If an explicit specialization or partial specialization of
@@ -5727,12 +5764,14 @@ Calls to the function
 \indexlibrary{\idxcode{getenv}}%
 \tcode{getenv}\iref{cstdlib.syn} shall not introduce a data
 race\iref{res.on.data.races} provided that nothing modifies the environment.
-\begin{note} Calls to the POSIX functions
+\begin{note}
+Calls to the POSIX functions
 \indexlibrary{\idxcode{setenv}}%
 \tcode{setenv} and
 \indexlibrary{\idxcode{putenv}}%
 \tcode{putenv} modify the
-environment. \end{note}
+environment.
+\end{note}
 
 \pnum
 A call to the \tcode{setlocale} function\iref{c.locales}

--- a/source/support.tex
+++ b/source/support.tex
@@ -349,7 +349,8 @@ template<class IntType>
 \constraints \tcode{is_integral_v<IntType>} is \tcode{true}.
 
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \tcode{return b = b << shift;}
 \end{itemdescr}
 
@@ -364,7 +365,8 @@ template<class IntType>
 \constraints \tcode{is_integral_v<IntType>} is \tcode{true}.
 
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return static_cast<byte>(static_cast<unsigned char>(
 	                   static_cast<unsigned int>(b) << shift));
@@ -382,7 +384,8 @@ template<class IntType>
 \constraints \tcode{is_integral_v<IntType>} is \tcode{true}.
 
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \tcode{return b >> shift;}
 \end{itemdescr}
 
@@ -397,7 +400,8 @@ template<class IntType>
 \constraints \tcode{is_integral_v<IntType>} is \tcode{true}.
 
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return static_cast<byte>(static_cast<unsigned char>(
 	                   static_cast<unsigned int>(b) >> shift));
@@ -411,7 +415,8 @@ constexpr byte& operator|=(byte& l, byte r) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return l = l | r;}
+\effects
+Equivalent to: \tcode{return l = l | r;}
 \end{itemdescr}
 
 \indexlibrarymember{operator"|}{byte}%
@@ -421,7 +426,8 @@ constexpr byte operator|(byte l, byte r) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return static_cast<byte>(static_cast<unsigned char>(static_cast<unsigned int>(l) |
                                                     static_cast<unsigned int>(r)));
@@ -435,7 +441,8 @@ constexpr byte& operator&=(byte& l, byte r) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return l = l \& r;}
+\effects
+Equivalent to: \tcode{return l = l \& r;}
 \end{itemdescr}
 
 \indexlibrarymember{operator\&}{byte}%
@@ -445,7 +452,8 @@ constexpr byte operator&(byte l, byte r) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return static_cast<byte>(static_cast<unsigned char>(static_cast<unsigned int>(l) &
                                                     static_cast<unsigned int>(r)));
@@ -459,7 +467,8 @@ constexpr byte& operator^=(byte& l, byte r) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return l = l \caret{} r;}
+\effects
+Equivalent to: \tcode{return l = l \caret{} r;}
 \end{itemdescr}
 
 \indexlibrarymember{operator\caret}{byte}%
@@ -469,7 +478,8 @@ constexpr byte operator^(byte l, byte r) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return static_cast<byte>(static_cast<unsigned char>(static_cast<unsigned int>(l) ^
                                                     static_cast<unsigned int>(r)));
@@ -483,7 +493,8 @@ constexpr byte operator~(byte b) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return static_cast<byte>(static_cast<unsigned char>(
 	                   ~static_cast<unsigned int>(b)));
@@ -501,7 +512,8 @@ template<class IntType>
 \constraints \tcode{is_integral_v<IntType>} is \tcode{true}.
 
 \pnum
-\effects Equivalent to: \tcode{return static_cast<IntType>(b);}
+\effects
+Equivalent to: \tcode{return static_cast<IntType>(b);}
 \end{itemdescr}
 
 \rSec1[support.limits]{Implementation properties}
@@ -2007,7 +2019,8 @@ int at_quick_exit(@\placeholder{atexit-handler}@* f) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects The \tcode{at_quick_exit()} functions register the function pointed to by \tcode{f}
+\effects
+The \tcode{at_quick_exit()} functions register the function pointed to by \tcode{f}
 to be called without arguments when \tcode{quick_exit} is called.
 It is unspecified whether a call to \tcode{at_quick_exit()} that does not
 happen before\iref{intro.multithread} all calls to \tcode{quick_exit} will succeed. \begin{note} The
@@ -2027,7 +2040,8 @@ and applications may need to call both registration functions with the same argu
 The implementation shall support the registration of at least 32 functions.
 
 \pnum
-\returns Zero if the registration succeeds, nonzero if it fails.
+\returns
+Zero if the registration succeeds, nonzero if it fails.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{quick_exit}}%
@@ -2037,7 +2051,8 @@ The implementation shall support the registration of at least 32 functions.
 
 \begin{itemdescr}
 \pnum
-\effects Functions registered by calls to \tcode{at_quick_exit} are called in the
+\effects
+Functions registered by calls to \tcode{at_quick_exit} are called in the
 reverse order of their registration, except that a function shall be called after any
 previously registered functions that had already been called at the time it was
 registered. Objects shall not be destroyed as a result of calling \tcode{quick_exit}.
@@ -2893,7 +2908,8 @@ new_handler get_new_handler() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns The current \tcode{new_handler}.
+\returns
+The current \tcode{new_handler}.
 \begin{note} This may be a null pointer value. \end{note}
 \end{itemdescr}
 
@@ -3104,12 +3120,14 @@ size_t hash_code() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns An unspecified value, except that within a single execution of the
+\returns
+An unspecified value, except that within a single execution of the
 program, it shall return the same value for any two \tcode{type_info}
 objects which compare equal.
 
 \pnum
-\remarks An implementation should return different values for two
+\remarks
+An implementation should return different values for two
 \tcode{type_info} objects which do not compare equal.
 \end{itemdescr}
 
@@ -3377,7 +3395,8 @@ constexpr uint_least32_t line() const noexcept;
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\returns \tcode{line_}.
+\returns
+\tcode{line_}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -3491,7 +3510,8 @@ exception& operator=(const exception& rhs) noexcept;
 
 \begin{itemdescr}
 \pnum
-\ensures If \tcode{*this} and \tcode{rhs} both have dynamic type \tcode{exception}
+\ensures
+If \tcode{*this} and \tcode{rhs} both have dynamic type \tcode{exception}
 then the value of the expression \tcode{strcmp(what(), rhs.what())} shall equal 0.
 \end{itemdescr}
 
@@ -3604,7 +3624,8 @@ Establishes the function designated by \tcode{f} as the current
 handler function for terminating exception processing.
 
 \pnum
-\remarks It is unspecified whether a null pointer value designates the default
+\remarks
+It is unspecified whether a null pointer value designates the default
 \tcode{terminate_handler}.
 
 \pnum
@@ -3621,7 +3642,8 @@ terminate_handler get_terminate() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns The current \tcode{terminate_handler}.
+\returns
+The current \tcode{terminate_handler}.
 \begin{note} This may be a null pointer value. \end{note}
 \end{itemdescr}
 
@@ -3718,7 +3740,8 @@ exception_ptr current_exception() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns An \tcode{exception_ptr} object that refers to
+\returns
+An \tcode{exception_ptr} object that refers to
 the currently handled exception\iref{except.handle} or a copy of the currently
 handled exception, or a null \tcode{exception_ptr} object if no exception is being
 handled. The referenced object shall remain valid at least as long as there is an
@@ -3744,10 +3767,12 @@ recursion.\end{note}
 
 \begin{itemdescr}
 \pnum
-\expects \tcode{p} is not a null pointer.
+\expects
+\tcode{p} is not a null pointer.
 
 \pnum
-\throws The exception object to which \tcode{p} refers.
+\throws
+The exception object to which \tcode{p} refers.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{make_exception_ptr}}%
@@ -3757,7 +3782,8 @@ template<class E> exception_ptr make_exception_ptr(E e) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Creates an \tcode{exception_ptr} object that refers to a copy of \tcode{e}, as if:
+\effects
+Creates an \tcode{exception_ptr} object that refers to a copy of \tcode{e}, as if:
 \begin{codeblock}
 try {
   throw e;
@@ -3810,7 +3836,8 @@ nested_exception() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects The constructor calls \tcode{current_exception()} and stores the returned value.
+\effects
+The constructor calls \tcode{current_exception()} and stores the returned value.
 \end{itemdescr}
 
 \indexlibrarymember{rethrow_nested}{nested_exception}%
@@ -3820,7 +3847,8 @@ nested_exception() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects If \tcode{nested_ptr()} returns a null pointer, the function calls the function \tcode{std::terminate}.
+\effects
+If \tcode{nested_ptr()} returns a null pointer, the function calls the function \tcode{std::terminate}.
 Otherwise, it throws the stored exception captured by \tcode{*this}.
 \end{itemdescr}
 
@@ -3831,7 +3859,8 @@ exception_ptr nested_ptr() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns The stored exception captured by this \tcode{nested_exception} object.
+\returns
+The stored exception captured by this \tcode{nested_exception} object.
 \end{itemdescr}
 
 \indexlibrarymember{throw_with_nested}{nested_exception}%
@@ -3844,7 +3873,8 @@ template<class T> [[noreturn]] void throw_with_nested(T&& t);
 Let \tcode{U} be \tcode{decay_t<T>}.
 
 \pnum
-\expects \tcode{U} meets the \oldconcept{CopyConstructible} requirements.
+\expects
+\tcode{U} meets the \oldconcept{CopyConstructible} requirements.
 
 \pnum
 \throws
@@ -3934,7 +3964,8 @@ constexpr initializer_list() noexcept;
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{size() == 0}.
+\ensures
+\tcode{size() == 0}.
 \end{itemdescr}
 
 \rSec2[support.initlist.access]{Initializer list access}
@@ -3946,7 +3977,8 @@ constexpr const E* begin() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns A pointer to the beginning of the array. If \tcode{size() == 0} the
+\returns
+A pointer to the beginning of the array. If \tcode{size() == 0} the
 values of \tcode{begin()} and \tcode{end()} are unspecified but they shall be
 identical.
 \end{itemdescr}
@@ -3958,7 +3990,8 @@ constexpr const E* end() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{begin() + size()}.
+\returns
+\tcode{begin() + size()}.
 \end{itemdescr}
 
 \indexlibrarymember{size}{initializer_list}%
@@ -3968,10 +4001,12 @@ constexpr size_t size() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns The number of elements in the array.
+\returns
+The number of elements in the array.
 
 \pnum
-\complexity Constant time.
+\complexity
+Constant time.
 \end{itemdescr}
 
 \rSec2[support.initlist.range]{Initializer list range access}
@@ -3983,7 +4018,8 @@ template<class E> constexpr const E* begin(initializer_list<E> il) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{il.begin()}.
+\returns
+\tcode{il.begin()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{end(initializer_list<E>)}}%
@@ -3993,7 +4029,8 @@ template<class E> constexpr const E* end(initializer_list<E> il) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{il.end()}.
+\returns
+\tcode{il.end()}.
 \end{itemdescr}
 
 \rSec1[cmp]{Comparisons}
@@ -5297,7 +5334,8 @@ constexpr coroutine_handle(nullptr_t) noexcept;
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{address() == nullptr}.
+\ensures
+\tcode{address() == nullptr}.
 \end{itemdescr}
 
 \indexlibrarymember{from_promise}{coroutine_handle}%
@@ -5310,10 +5348,12 @@ static coroutine_handle from_promise(Promise& p);
 \requires \tcode{p} is a reference to a promise object of a coroutine.
 
 \pnum
-\returns A coroutine handle \tcode{h} referring to the coroutine.
+\returns
+A coroutine handle \tcode{h} referring to the coroutine.
 
 \pnum
-\ensures \tcode{addressof(h.promise()) == addressof(p)}.
+\ensures
+\tcode{addressof(h.promise()) == addressof(p)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{coroutine_handle}%
@@ -5323,10 +5363,12 @@ coroutine_handle& operator=(nullptr_t) noexcept;
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{address() == nullptr}.
+\ensures
+\tcode{address() == nullptr}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \rSec3[coroutine.handle.export.import]{Export/import}
@@ -5338,7 +5380,8 @@ constexpr void* address() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ptr}.
+\returns
+\tcode{ptr}.
 \end{itemdescr}
 
 \indexlibrarymember{from_address}{coroutine_handle}%
@@ -5352,7 +5395,8 @@ static constexpr coroutine_handle<Promise> coroutine_handle<Promise>::from_addre
 \requires \tcode{addr} was obtained via a prior call to \tcode{address}.
 
 \pnum
-\ensures \tcode{from_address(address()) == *this}.
+\ensures
+\tcode{from_address(address()) == *this}.
 \end{itemdescr}
 
 \rSec3[coroutine.handle.observers]{Observers}
@@ -5364,7 +5408,8 @@ constexpr explicit operator bool() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{address() != nullptr}.
+\returns
+\tcode{address() != nullptr}.
 \end{itemdescr}
 
 \indexlibrarymember{done}{coroutine_handle}%
@@ -5377,7 +5422,8 @@ bool done() const;
 \requires \tcode{*this} refers to a suspended coroutine.
 
 \pnum
-\returns \tcode{true} if the coroutine is suspended at its
+\returns
+\tcode{true} if the coroutine is suspended at its
 final suspend point, otherwise \tcode{false}.
 \end{itemdescr}
 
@@ -5411,7 +5457,8 @@ void resume() const;
 \requires \tcode{*this} refers to a suspended coroutine.
 
 \pnum
-\effects Resumes the execution of the coroutine. If the coroutine
+\effects
+Resumes the execution of the coroutine. If the coroutine
 was suspended at its final suspend point, behavior is undefined.
 \end{itemdescr}
 
@@ -5425,7 +5472,8 @@ void destroy() const;
 \requires \tcode{*this} refers to a suspended coroutine.
 
 \pnum
-\effects Destroys the coroutine\iref{dcl.fct.def.coroutine}.
+\effects
+Destroys the coroutine\iref{dcl.fct.def.coroutine}.
 \end{itemdescr}
 
 \rSec3[coroutine.handle.promise]{Promise access}
@@ -5440,7 +5488,8 @@ Promise& promise() const;
 \requires \tcode{*this} refers to a coroutine.
 
 \pnum
-\returns A reference to the promise of the coroutine.
+\returns
+A reference to the promise of the coroutine.
 \end{itemdescr}
 
 \rSec3[coroutine.handle.compare]{Comparison operators}
@@ -5453,7 +5502,8 @@ constexpr bool operator==(coroutine_handle<> x, coroutine_handle<> y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x.address() == y.address()}.
+\returns
+\tcode{x.address() == y.address()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{coroutine_handle}%
@@ -5463,7 +5513,8 @@ constexpr strong_ordering operator<=>(coroutine_handle<> x, coroutine_handle<> y
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{compare_three_way()(x.address(), y.address())}.
+\returns
+\tcode{compare_three_way()(x.address(), y.address())}.
 \end{itemdescr}
 
 \rSec3[coroutine.handle.hash]{Hash support}
@@ -5531,7 +5582,8 @@ constexpr explicit operator bool() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{true}.
+\returns
+\tcode{true}.
 \end{itemdescr}
 
 \indexlibrarymember{done}{coroutine_handle<noop_coroutine_promise>}%
@@ -5541,7 +5593,8 @@ constexpr bool done() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{false}.
+\returns
+\tcode{false}.
 \end{itemdescr}
 
 \rSec4[coroutine.handle.noop.resumption]{Resumption}
@@ -5557,7 +5610,8 @@ constexpr void destroy() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects None.
+\effects
+None.
 
 \pnum
 \remarks
@@ -5575,7 +5629,8 @@ noop_coroutine_promise& promise() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns A reference to the promise object associated with this
+\returns
+A reference to the promise object associated with this
 coroutine handle.
 \end{itemdescr}
 
@@ -5588,10 +5643,12 @@ constexpr void* address() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ptr}.
+\returns
+\tcode{ptr}.
 
 \pnum
-\remarks A \tcode{noop_coroutine_handle}'s \tcode{ptr} is always a
+\remarks
+A \tcode{noop_coroutine_handle}'s \tcode{ptr} is always a
 non-null pointer value.
 \end{itemdescr}
 
@@ -5604,11 +5661,13 @@ noop_coroutine_handle noop_coroutine() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns A handle to a coroutine that has no observable effects
+\returns
+A handle to a coroutine that has no observable effects
 when resumed or destroyed.
 
 \pnum
-\remarks A handle returned from \tcode{noop_coroutine} may or may not
+\remarks
+A handle returned from \tcode{noop_coroutine} may or may not
 compare equal to a handle returned from another invocation
 of \tcode{noop_coroutine}.
 \end{itemdescr}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -5001,7 +5001,7 @@ or value-dependent or is a pack expansion
 \begin{note}
 This includes an injected-class-name\iref{class} of a class template
 used without a \grammarterm{template-argument-list}.
-\end{note}
+\end{note}%
 , or
 \item denoted by \tcode{decltype(}\grammarterm{expression}{}\tcode{)},
 where \grammarterm{expression} is type-dependent\iref{temp.dep.expr}.

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1062,7 +1062,8 @@ For a
 \grammarterm{template-argument}
 that is a class type or a class template, the template
 definition has no special access rights to the
-members of the \grammarterm{template-argument}. \begin{example}
+members of the \grammarterm{template-argument}.
+\begin{example}
 
 \begin{codeblock}
 template <template <class TT> class T> class A {
@@ -2284,7 +2285,8 @@ template<class T>
 
 \pnum
 An explicit specialization of a static data member declared as an array of unknown
-bound can have a different bound from its definition, if any. \begin{example}
+bound can have a different bound from its definition, if any.
+\begin{example}
 
 \begin{codeblock}
 template <class T> struct A {
@@ -2611,7 +2613,8 @@ are not expanded by a nested pack expansion; such packs are called
 \defnx{unexpanded packs}{pack!unexpanded} in the pattern. All of the packs expanded
 by a pack expansion shall have the same number of arguments specified. An
 appearance of a name of a pack that is not expanded is
-ill-formed. \begin{example}
+ill-formed.
+\begin{example}
 
 \begin{codeblock}
 template<typename...> struct Tuple {};
@@ -3799,7 +3802,8 @@ int main() {
   g(ip);                                                // calls \#4
 }
 \end{codeblock}
-\end{example}\begin{example}
+\end{example}
+\begin{example}
 \begin{codeblock}
 template<class T, class U> struct A { };
 
@@ -3814,7 +3818,8 @@ void h() {
   g(42);                                                // error: ambiguous
 }
 \end{codeblock}
-\end{example}\begin{example}
+\end{example}
+\begin{example}
 \begin{codeblock}
 template<class T, class... U> void f(T, U...);          // \#1
 template<class T            > void f(T);                // \#2
@@ -4951,7 +4956,8 @@ member access expression for which the type of the object expression is the
 current instantiation does not refer to a member of the current instantiation
 or a member of an unknown specialization, the program is ill-formed even if the
 template containing the member access expression is not instantiated; no diagnostic
-required. \begin{example}
+required.
+\begin{example}
 \begin{codeblock}
 template<class T> class A {
   typedef int type;
@@ -7638,7 +7644,8 @@ If
 is a reference type, the type
 referred to by
 \tcode{P}
-is used for type deduction. \begin{example}
+is used for type deduction.
+\begin{example}
 \begin{codeblock}
 template<class T> int f(const T&);
 int n1 = f(5);                  // calls \tcode{f<int>(const int\&)}
@@ -7654,7 +7661,8 @@ that does not represent a template parameter of a class template
 (during class template argument deduction\iref{over.match.class.deduct}).
 If \tcode{P} is a forwarding reference and the argument is an
 lvalue, the type ``lvalue reference to \tcode{A}'' is used in place of \tcode{A} for type
-deduction. \begin{example}
+deduction.
+\begin{example}
 \begin{codeblock}
 template <class T> int f(T&& heisenreference);
 template <class T> int g(const T&&);

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -63,12 +63,14 @@ an alias for a family of types, or a concept.
   \opt{nested-name-specifier} concept-name \terminal{<} \opt{template-argument-list} \terminal{>}
 \end{bnf}
 
-\begin{note} The \tcode{>} token following the
+\begin{note}
+The \tcode{>} token following the
 \grammarterm{template-parameter-list} of a
 \grammarterm{template-declaration}
 may be the product of replacing a
 \tcode{>{>}} token by two consecutive \tcode{>}
-tokens\iref{temp.names}.\end{note}
+tokens\iref{temp.names}.
+\end{note}
 
 \pnum
 The
@@ -282,12 +284,14 @@ is:
   \keyword{typename}
 \end{bnf}
 
-\begin{note} The \tcode{>} token following the
+\begin{note}
+The \tcode{>} token following the
 \grammarterm{template-parameter-list} of a
 \grammarterm{type-parameter}
 may be the product of replacing a
 \tcode{>{>}} token by two consecutive \tcode{>}
-tokens\iref{temp.names}.\end{note}
+tokens\iref{temp.names}.
+\end{note}
 
 \pnum
 There is no semantic difference between
@@ -751,10 +755,13 @@ rather than a greater-than operator.
 Similarly, the first non-nested \tcode{>{>}} is treated as two
 consecutive but distinct \tcode{>} tokens, the first of which is taken
 as the end of the \grammarterm{template-argument-list} and completes
-the \grammarterm{template-id}. \begin{note} The second \tcode{>}
+the \grammarterm{template-id}.
+\begin{note}
+The second \tcode{>}
 token produced by this replacement rule may terminate an enclosing
 \grammarterm{template-id} construct or it may be part of a different
-construct (e.g., a cast).\end{note}
+construct (e.g., a cast).
+\end{note}
 \begin{example}
 \begin{codeblock}
 template<int i> class X { @\commentellip@ };
@@ -1824,7 +1831,8 @@ is
 $(A \land B) \lor (A \land C)$.
 %
 Its disjunctive clauses are $(A \land B)$ and $(A \land C)$.
-\end{example}%
+\end{example}
+%
 }
 of $P$, $P_i$ subsumes every conjunctive clause $Q_j$
 in the conjunctive normal form\footnote{
@@ -1835,7 +1843,8 @@ For atomic constraints $A$, $B$, and $C$, the constraint
 $A \land (B \lor C)$ is in conjunctive normal form.
 %
 Its conjunctive clauses are $A$ and $(B \lor C)$.
-\end{example}%
+\end{example}
+%
 }
 of $Q$, where
 
@@ -1985,8 +1994,10 @@ If an expression $e$ is type-dependent\iref{temp.dep.expr},
 denotes a unique dependent type. Two such \grammarterm{decltype-specifier}{s}
 refer to the same type only if their \grammarterm{expression}{s} are
 equivalent\iref{temp.over.link}.
-\begin{note} However, such a type may be aliased,
-e.g., by a \grammarterm{typedef-name}. \end{note}
+\begin{note}
+However, such a type may be aliased,
+e.g., by a \grammarterm{typedef-name}.
+\end{note}
 
 \rSec1[temp.decls]{Template declarations}
 
@@ -2656,10 +2667,12 @@ the \grammarterm{init-capture} pack.
 \end{itemize}
 
 All of the $\mathtt{E}_i$ become items in the enclosing list.
-\begin{note} The variety of list varies with the context:
+\begin{note}
+The variety of list varies with the context:
 \grammarterm{expression-list},
 \grammarterm{base-specifier-list},
-\grammarterm{template-argument-list}, etc.\end{note}
+\grammarterm{template-argument-list}, etc.
+\end{note}
 When $N$ is zero, the instantiation of the expansion produces an empty list.
 Such an instantiation does not alter the syntactic interpretation of the
 enclosing construct, even in cases where omitting the list entirely would
@@ -3692,9 +3705,11 @@ parameter list. Given \cv{} as the cv-qualifiers of \placeholder{M}
 \grammarterm{ref-qualifier} and the first parameter of the other
 template has rvalue reference type. Otherwise, the new parameter is
 of type ``lvalue reference to \cv{}~\placeholder{A}''.
-\begin{note} This allows a non-static
+\begin{note}
+This allows a non-static
 member to be ordered with respect to a non-member function and for the results
-to be equivalent to the ordering of two equivalent non-members. \end{note}
+to be equivalent to the ordering of two equivalent non-members.
+\end{note}
 \begin{example}
 \begin{codeblock}
 struct A { };
@@ -3747,7 +3762,8 @@ void m() {
 \end{example}
 
 \pnum
-\begin{note} Since partial ordering in a call context considers only parameters
+\begin{note}
+Since partial ordering in a call context considers only parameters
 for which there are explicit call arguments, some parameters are ignored (namely,
 function parameter packs, parameters with default arguments, and ellipsis
 parameters).
@@ -3795,7 +3811,8 @@ void h(int i) {
   g(&i);                                                // OK: calls \#3
 }
 \end{codeblock}
-\end{example}\end{note}
+\end{example}
+\end{note}
 
 \rSec2[temp.alias]{Alias templates}
 
@@ -3812,7 +3829,9 @@ an alias template, it is equivalent to the associated type obtained by
 substitution of its \grammarterm{template-argument}{s} for the
 \grammarterm{template-parameter}{s} in the \grammarterm{type-id} of
 the alias template.
-\begin{note} An alias template name is never deduced.\end{note}
+\begin{note}
+An alias template name is never deduced.
+\end{note}
 \begin{example}
 \begin{codeblock}
 template<class T> struct Alloc { @\commentellip@ };
@@ -4827,10 +4846,13 @@ in which the
 refers to the current instantiation
 and that, when looked up, refers to at least one member of a class that is
 the current
-instantiation or a non-dependent base class thereof. \begin{note} If no such
+instantiation or a non-dependent base class thereof.
+\begin{note}
+If no such
 member is found, and the current instantiation has any dependent base classes,
 then the \grammarterm{qualified-id} is a member of an unknown specialization;
-see below. \end{note}
+see below.
+\end{note}
 
 \item
 An \grammarterm{id-expression} denoting the member in a class member access
@@ -4838,10 +4860,13 @@ expression\iref{expr.ref} for which the type of the object expression is the
 current instantiation, and the \grammarterm{id-expression}, when looked
 up\iref{basic.lookup.classref}, refers to at least one member of a class
 that is the current
-instantiation or a non-dependent base class thereof. \begin{note} If no such
+instantiation or a non-dependent base class thereof.
+\begin{note}
+If no such
 member is found, and the current instantiation has any dependent base classes,
 then the \grammarterm{id-expression} is a member of an unknown specialization;
-see below. \end{note}
+see below.
+\end{note}
 \end{itemize}
 
 \begin{example}
@@ -4978,7 +5003,8 @@ or value-dependent or is a pack expansion
 \begin{note}
 This includes an injected-class-name\iref{class} of a class template
 used without a \grammarterm{template-argument-list}.
-\end{note}, or
+\end{note}
+, or
 \item denoted by \tcode{decltype(}\grammarterm{expression}{}\tcode{)},
 where \grammarterm{expression} is type-dependent\iref{temp.dep.expr}.
 \end{itemize}
@@ -5103,8 +5129,10 @@ literal\br
 \keyword{noexcept} \terminal{(} expression \terminal{)}
 \end{ncsimplebnf}
 
-\begin{note} For the standard library macro \tcode{offsetof},
-see~\ref{support.types}.\end{note}
+\begin{note}
+For the standard library macro \tcode{offsetof},
+see~\ref{support.types}.
+\end{note}
 
 \pnum
 A class member access expression\iref{expr.ref} is
@@ -5189,8 +5217,10 @@ is dependent:
 \keyword{noexcept} \terminal{(} expression \terminal{)}
 \end{ncsimplebnf}
 
-\begin{note} For the standard library macro \tcode{offsetof},
-see~\ref{support.types}.\end{note}
+\begin{note}
+For the standard library macro \tcode{offsetof},
+see~\ref{support.types}.
+\end{note}
 
 \pnum
 Expressions of the following form are value-dependent if either the
@@ -6362,9 +6392,11 @@ provided that the associated constraints, if any,
 of that member are satisfied by the template arguments of the explicit
 instantiation~(\ref{temp.constr.decl}, \ref{temp.constr.constr}),
 except as described below.
-\begin{note} In addition, it will typically be an explicit instantiation of certain
+\begin{note}
+In addition, it will typically be an explicit instantiation of certain
 \indextext{implementation-dependent}%
-implementation-dependent data about the class. \end{note}
+implementation-dependent data about the class.
+\end{note}
 
 \pnum
 An explicit instantiation definition that names a class template
@@ -6384,11 +6416,13 @@ variables of reference types, and class template specializations,
 explicit instantiation declarations have the
 effect of suppressing the implicit instantiation
 of the definition of the entity to which they refer.
-\begin{note} The intent is that an inline function that is the
+\begin{note}
+The intent is that an inline function that is the
 subject of an explicit instantiation declaration will still be implicitly
 instantiated when odr-used\iref{basic.def.odr} so that the body can be considered for inlining, but
 that no out-of-line copy of the inline function would be generated in the
-translation unit.\end{note}
+translation unit.
+\end{note}
 
 \pnum
 If an entity is the subject of both an explicit instantiation declaration
@@ -6399,11 +6433,13 @@ in a way that would otherwise cause an implicit instantiation\iref{temp.inst}
 in the translation unit
 shall be the subject of an explicit instantiation definition somewhere in the
 program; otherwise the program is ill-formed, no diagnostic required.
-\begin{note} This rule does apply to inline functions even though an
+\begin{note}
+This rule does apply to inline functions even though an
 explicit instantiation declaration of such an entity has no other normative
 effect. This is needed to ensure that if the address of an inline function is
 taken in a translation unit in which the implementation chose to suppress the
-out-of-line body, another translation unit will supply the body.\end{note}
+out-of-line body, another translation unit will supply the body.
+\end{note}
 An explicit instantiation declaration shall not name a specialization of a
 template with internal linkage.
 
@@ -7580,7 +7616,8 @@ int n2 = f(i);                  // calls \tcode{f<int>(const int\&)}
 template <class T> int g(volatile T&);
 int n3 = g(i);                  // calls \tcode{g<const int>(const volatile int\&)}
 \end{codeblock}
-\end{example}%
+\end{example}
+%
 A \defn{forwarding reference}
 is an rvalue reference to a cv-unqualified template parameter
 that does not represent a template parameter of a class template
@@ -8458,9 +8495,12 @@ parameter-type-list of \tcode{P} and \tcode{A}, respectively,
 $\texttt{P}_i$ is adjusted if it is a forwarding reference\iref{temp.deduct.call}
 and $\texttt{A}_i$ is an lvalue reference, in which case the type of
 $\texttt{P}_i$ is changed to be the template parameter type (i.e., \tcode{T\&\&} is
-changed to simply \tcode{T}). \begin{note} As a result, when $\texttt{P}_i$ is \tcode{T\&\&}
+changed to simply \tcode{T}).
+\begin{note}
+As a result, when $\texttt{P}_i$ is \tcode{T\&\&}
 and $\texttt{A}_i$ is \tcode{X\&}, the adjusted $\texttt{P}_i$ will be \tcode{T},
-causing \tcode{T} to be deduced as \tcode{X\&}. \end{note}
+causing \tcode{T} to be deduced as \tcode{X\&}.
+\end{note}
 \begin{example}
 \begin{codeblock}
 template <class T> void f(T&&);
@@ -8909,7 +8949,8 @@ The program will be ill-formed unless a specialization for
 \tcode{f<const char*>},
 either implicitly or explicitly generated,
 is present in some translation unit.
-\end{example}%
+\end{example}
+%
 
 \rSec1[temp.deduct.guide]{Deduction guides}
 \indextext{deduction!class template argument}%

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -435,7 +435,6 @@ A non-type
 \grammarterm{template-parameter}
 shall not be declared to have floating-point or void type.
 \begin{example}
-
 \begin{codeblock}
 template<double d> class X;     // error
 template<double* pd> class Y;   // OK
@@ -452,7 +451,6 @@ of type ``array of \tcode{T}'' or
 of function type \tcode{T}
 is adjusted to be of type ``pointer to \tcode{T}''.
 \begin{example}
-
 \begin{codeblock}
 template<int* a>   struct R { @\commentellip@ };
 template<int b[5]> struct S { @\commentellip@ };
@@ -527,7 +525,6 @@ available for use is obtained by merging the default arguments
 from all prior declarations of the template in the
 same way default function arguments are\iref{dcl.fct.default}.
 \begin{example}
-
 \begin{codeblock}
 template<class T1, class T2 = int> class A;
 template<class T1 = int, class T2> class A;
@@ -565,7 +562,6 @@ shall be deducible
 from the parameter-type-list
 of the deduction guide template.
 \begin{example}
-
 \begin{codeblock}
 template<class T1 = int, class T2> class B;     // error
 
@@ -581,7 +577,6 @@ A
 shall
 not be given default arguments by two different declarations in the same scope.
 \begin{example}
-
 \begin{codeblock}
 template<class T = int> class X;
 template<class T = int> class X { @\commentellip@ };  // error
@@ -601,7 +596,6 @@ is taken as the end of the
 \grammarterm{template-parameter-list}
 rather than a greater-than operator.
 \begin{example}
-
 \begin{codeblock}
 template<int i = 3 > 4 >        // syntax error
 class X { @\commentellip@ };
@@ -762,7 +756,6 @@ token produced by this replacement rule may terminate an enclosing
 \grammarterm{template-id} construct or it may be part of a different
 construct (e.g., a cast).\end{note}
 \begin{example}
-
 \begin{codeblock}
 template<int i> class X { @\commentellip@ };
 
@@ -797,7 +790,6 @@ In all other contexts, when naming a template specialization of
 a member of an unknown specialization\iref{temp.dep.type},
 the member template name shall be prefixed by the keyword \tcode{template}.
 \begin{example}
-
 \begin{codeblock}
 struct X {
   template<std::size_t> X* alloc();
@@ -1041,7 +1033,6 @@ corresponding
 name is used.
 \end{note}
 \begin{example}
-
 \begin{codeblock}
 template<class T> class X {
   static T t;
@@ -1064,7 +1055,6 @@ that is a class type or a class template, the template
 definition has no special access rights to the
 members of the \grammarterm{template-argument}.
 \begin{example}
-
 \begin{codeblock}
 template <template <class TT> class T> class A {
   typename T<int>::S s;
@@ -1090,7 +1080,6 @@ In that case the empty
 brackets shall still be used as the
 \grammarterm{template-argument-list}.
 \begin{example}
-
 \begin{codeblock}
 template<class T = char> class String;
 String<>* p;                    // OK: \tcode{String<char>}
@@ -1106,7 +1095,6 @@ An explicit destructor call\iref{class.dtor} for an object that has a type
 that is a class template specialization may explicitly specify the
 \grammarterm{template-argument}{s}.
 \begin{example}
-
 \begin{codeblock}
 template<class T> struct A {
   ~A();
@@ -1268,7 +1256,6 @@ A string literal\iref{lex.string} is
 not an acceptable \grammarterm{template-argument}
 for a \grammarterm{template-parameter} of non-class type.
 \begin{example}
-
 \begin{codeblock}
 template<class T, T p> class X {
   @\commentellip@
@@ -1294,7 +1281,6 @@ X<A, "Pyrophoricity"> z;        // OK, string literal is a constructor argument 
 The address of an array element or non-static data member is not an acceptable
 \grammarterm{template-argument}.
 \begin{example}
-
 \begin{codeblock}
 template<int* p> class X { };
 
@@ -1318,7 +1304,6 @@ when the corresponding
 \grammarterm{template-parameter}
 has reference type.
 \begin{example}
-
 \begin{codeblock}
 template<const int& CRI> struct B { @\commentellip@ };
 
@@ -1355,7 +1340,6 @@ If a specialization is not visible at the point of instantiation,
 and it would have been selected had it been visible, the program is ill-formed,
 no diagnostic required.
 \begin{example}
-
 \begin{codeblock}
 template<class T> class A {     // primary template
   int x;
@@ -1954,7 +1938,6 @@ with the \tcode{==} operator\iref{expr.eq}, and}
 to the same template.}
 \end{itemize}
 \begin{example}
-
 \begin{codeblock}
 template<class E, int size> class buffer { @\commentellip@ };
 buffer<char,2*512> x;
@@ -2016,7 +1999,6 @@ followed by a
 \grammarterm{template-argument-list}
 shall not be specified in the declaration of a primary template declaration.
 \begin{example}
-
 \begin{codeblock}
 template<class T1, class T2, int I> class A<T1, T2, I> { };     // error
 template<class T1, int I> void sort<T1, I>(T1 data[I]);         // error
@@ -2174,7 +2156,6 @@ of a class template
 may be defined outside of the class
 template definition in which it is declared.
 \begin{example}
-
 \begin{codeblock}
 template<class T> class Array {
   T* v;
@@ -2266,7 +2247,6 @@ A definition for a static data member or static data member template may be
 provided in a namespace scope enclosing the definition of the static member's
 class template.
 \begin{example}
-
 \begin{codeblock}
 template<class T> class X {
   static T s;
@@ -2287,7 +2267,6 @@ template<class T>
 An explicit specialization of a static data member declared as an array of unknown
 bound can have a different bound from its definition, if any.
 \begin{example}
-
 \begin{codeblock}
 template <class T> struct A {
   static int i[];
@@ -2388,7 +2367,6 @@ int main() {
 \pnum
 A member function template shall not be virtual.
 \begin{example}
-
 \begin{codeblock}
 template <class T> struct AA {
   template <class C> virtual void g(C);             // error
@@ -2421,7 +2399,6 @@ is referenced in
 the same way as a non-template conversion function that converts to
 the same type.
 \begin{example}
-
 \begin{codeblock}
 struct A {
   template <class T> operator T*();
@@ -2476,7 +2453,6 @@ conversion functions.
 A \defn{template parameter pack} is a template parameter
 that accepts zero or more template arguments.
 \begin{example}
-
 \begin{codeblock}
 template<class ... Types> struct Tuple { };
 
@@ -2491,7 +2467,6 @@ Tuple<0> error;                 // error: \tcode{0} is not a type
 A \defn{function parameter pack} is a function parameter
 that accepts zero or more function arguments.
 \begin{example}
-
 \begin{codeblock}
 template<class ... Types> void f(Types ... args);
 
@@ -2615,7 +2590,6 @@ by a pack expansion shall have the same number of arguments specified. An
 appearance of a name of a pack that is not expanded is
 ill-formed.
 \begin{example}
-
 \begin{codeblock}
 template<typename...> struct Tuple {};
 template<typename T1, typename T2> struct Pair {};
@@ -2913,7 +2887,6 @@ substituting the deduced template arguments into the friend declaration
 produces a declaration that would be a valid redeclaration
 of the member of the specialization.
 \begin{example}
-
 \begin{codeblock}
 template<class T> struct A {
   struct B { };
@@ -2961,7 +2934,6 @@ A friend template shall not be declared in a local class.
 \pnum
 Friend declarations shall not declare partial specializations.
 \begin{example}
-
 \begin{codeblock}
 template<class T> class A { };
 class X {
@@ -3077,7 +3049,6 @@ A class template partial specialization may be declared in any
 scope in which the corresponding primary template
 may be defined~(\ref{namespace.memdef}, \ref{class.mem}, \ref{temp.mem}).
 \begin{example}
-
 \begin{codeblock}
 template<class T> struct A {
   struct C {
@@ -3105,7 +3076,6 @@ which refers to a class template does not restrict the set of partial specializa
 which may be found through the
 \grammarterm{using-declaration}.
 \begin{example}
-
 \begin{codeblock}
 namespace N {
   template<class T1, class T2> class A { };     // primary template
@@ -3136,7 +3106,6 @@ the following restrictions apply:
 The type of a template parameter corresponding to a specialized non-type argument
 shall not be dependent on a parameter of the specialization.
 \begin{example}
-
 \begin{codeblock}
 template <class T, T t> struct C {};
 template <class T> struct C<T, 1>;              // error
@@ -3355,7 +3324,6 @@ An explicit specialization of a member of a class template partial
 specialization is declared in the same way as an explicit specialization of
 the primary template.
 \begin{example}
-
 \begin{codeblock}
 // primary class template
 template<class T, int I> struct A {
@@ -3406,7 +3374,6 @@ for a given (implicit) specialization of the enclosing class template,
 the primary member template and its other partial specializations are
 still considered for this specialization of the enclosing class template.
 \begin{example}
-
 \begin{codeblock}
 template<class T> struct A {
   template<class T2> struct B {};                     // \#1
@@ -3514,7 +3481,6 @@ template in another translation unit and, conversely, to ensure that
 function templates that are intended to be distinct are not linked
 with one another.
 \begin{example}
-
 \begin{codeblock}
 template <int I, int J> A<I+J> f(A<I>, A<J>);   // \#1
 template <int K, int L> A<K+L> f(A<K>, A<L>);   // same as \#1
@@ -3754,7 +3720,6 @@ Using the transformed function template's function type,
 perform type deduction against the other template as described in~\ref{temp.deduct.partial}.
 
 \begin{example}
-
 \begin{codeblock}
 template<class T> struct A { A(); };
 
@@ -3787,7 +3752,6 @@ for which there are explicit call arguments, some parameters are ignored (namely
 function parameter packs, parameters with default arguments, and ellipsis
 parameters).
 \begin{example}
-
 \begin{codeblock}
 template<class T> void f(T);                            // \#1
 template<class T> void f(T*, int=1);                    // \#2
@@ -3850,7 +3814,6 @@ substitution of its \grammarterm{template-argument}{s} for the
 the alias template.
 \begin{note} An alias template name is never deduced.\end{note}
 \begin{example}
-
 \begin{codeblock}
 template<class T> struct Alloc { @\commentellip@ };
 template<class T> using Vec = vector<T, Alloc<T>>;
@@ -3892,7 +3855,6 @@ The \grammarterm{type-id} in an alias template declaration shall not refer to
 the alias template being declared. The type produced by an alias template
 specialization shall not directly or indirectly make use of that specialization.
 \begin{example}
-
 \begin{codeblock}
 template <class T> struct A;
 template <class T> using B = typename A<T>::U;
@@ -3996,7 +3958,6 @@ the applicable name lookup finds a type name or the name
 is qualified by the keyword
 \tcode{typename}.
 \begin{example}
-
 \begin{codeblock}
 // no \tcode{B} declared here
 
@@ -4038,7 +3999,6 @@ The usual qualified name lookup\iref{basic.lookup.qual} is used to find the
 even in the presence of
 \tcode{typename}.
 \begin{example}
-
 \begin{codeblock}
 struct A {
   struct X { };
@@ -4143,7 +4103,6 @@ that is not prefixed by \tcode{typename},
 and that is not otherwise assumed to name a type (see above)
 denotes a non-type.
 \begin{example}
-
 \begin{codeblock}
 template <class T> void f(int i) {
   T::x * i;         // expression, not the declaration of a variable \tcode{i}
@@ -4254,7 +4213,6 @@ to the other rules in this document.
 Exactly when these errors are diagnosed is a quality of implementation issue.
 \end{note}
 \begin{example}
-
 \begin{codeblock}
 int j;
 template<class T> class X {
@@ -4283,7 +4241,6 @@ are used for non-dependent names.
 The lookup of names dependent on the template parameters
 is postponed until the actual template argument is known\iref{temp.dep}.
 \begin{example}
-
 \begin{codeblock}
 #include <iostream>
 using namespace std;
@@ -4345,7 +4302,6 @@ definition; the name is bound to the declaration (or declarations) found
 at that point and this binding is not affected by declarations that are
 visible at the point of instantiation.
 \begin{example}
-
 \begin{codeblock}
 void f(char);
 
@@ -4505,7 +4461,6 @@ the name of a member of the class template hides the name of a
 of any enclosing class templates (but not a \grammarterm{template-parameter} of the
 member if the member is a class or function template).
 \begin{example}
-
 \begin{codeblock}
 template<class T> struct A {
   struct B { @\commentellip@ };
@@ -4532,7 +4487,6 @@ the name of a
 \grammarterm{template-parameter}
 hides the name of a member of this namespace.
 \begin{example}
-
 \begin{codeblock}
 namespace N {
   class C { };
@@ -4558,7 +4512,6 @@ the base class name or member name hides the
 \grammarterm{template-parameter}
 name\iref{basic.scope.hiding}.
 \begin{example}
-
 \begin{codeblock}
 struct A {
   struct B { @\commentellip@ };
@@ -4671,7 +4624,6 @@ name lookup either at the point of definition of the
 class template or member or during an instantiation of
 the class template or member.
 \begin{example}
-
 \begin{codeblock}
 typedef double A;
 template<class T> class B {
@@ -4692,7 +4644,6 @@ defined in the base class
 \tcode{B<T>}.
 \end{example}
 \begin{example}
-
 \begin{codeblock}
 struct A {
   struct B { @\commentellip@ };
@@ -5314,7 +5265,6 @@ that refers to a member of an unknown specialization.
 Non-dependent names used in a template definition are found using the
 usual name lookup and bound at the point they are used.
 \begin{example}
-
 \begin{codeblock}
 void g(double);
 void h();
@@ -5680,7 +5630,6 @@ a member function template,
 the name of the function or member function explicitly specialized may be a
 \grammarterm{template-id}.
 \begin{example}
-
 \begin{codeblock}
 template<class T = int> struct A {
   static int x;
@@ -5742,7 +5691,6 @@ may be private types or objects that would normally not be accessible.
 Each class template specialization instantiated from a template has its own
 copy of any static members.
 \begin{example}
-
 \begin{codeblock}
 template<class T> class X {
   static T s;
@@ -5770,7 +5718,6 @@ If a function declaration acquired its function type through
 a dependent type\iref{temp.dep.type} without using the syntactic form of
 a function declarator, the program is ill-formed.
 \begin{example}
-
 \begin{codeblock}
 template<class T> struct A {
   static T t;
@@ -6001,7 +5948,6 @@ If the function selected by overload resolution\iref{over.match}
 can be determined without instantiating a class template definition,
 it is unspecified whether that instantiation actually takes place.
 \begin{example}
-
 \begin{codeblock}
 template <class T> struct S {
   operator int();
@@ -6055,7 +6001,6 @@ placed in the namespace where the enclosing class template is defined.
 Implicitly instantiated member templates are placed in the namespace where the
 enclosing class or class template is defined.
 \begin{example}
-
 \begin{codeblock}
 namespace N {
   template<class T> class List {
@@ -6108,7 +6053,6 @@ The instantiated default argument is then used as the argument of
 \pnum
 Each default argument is instantiated independently.
 \begin{example}
-
 \begin{codeblock}
 template<class T> void f(T x, T y = ydef(T()), T z = zdef(T()));
 
@@ -6145,7 +6089,6 @@ that specifies the limit on the total depth of recursive instantiations\iref{imp
 which could involve more than one template.
 The result of an infinite recursion in instantiation is undefined.
 \begin{example}
-
 \begin{codeblock}
 template<class T> class X {
   X<T>* p;          // OK
@@ -6290,7 +6233,6 @@ namespace set.
 Regarding qualified names in declarators, see~\ref{dcl.meaning}.
 \end{note}
 \begin{example}
-
 \begin{codeblock}
 template<class T> class Array { void mf(); };
 template class Array<char>;
@@ -6365,7 +6307,6 @@ the namespace where the enclosing class template is defined.
 An explicit instantiation for a member template is placed in the namespace
 where the enclosing class or class template is defined.
 \begin{example}
-
 \begin{codeblock}
 namespace N {
   template<class T> class Y { void mf() { } };
@@ -6470,7 +6411,6 @@ template with internal linkage.
 An explicit instantiation does not constitute a use of a default argument,
 so default argument instantiation is not done.
 \begin{example}
-
 \begin{codeblock}
 char* p = 0;
 template<class T> T g(T x = &p) { return x; }
@@ -6565,7 +6505,6 @@ The definition of a class or class template shall precede the
 declaration of an explicit specialization for a member template of the class
 or class template.
 \begin{example}
-
 \begin{codeblock}
 template<> class X<int> { @\commentellip@ };          // error: \tcode{X} not a template
 
@@ -6608,7 +6547,6 @@ The same is true when defining a member of an explicitly specialized member
 class. However, \tcode{template<>} is used in defining a member of an explicitly
 specialized member class template that is specialized as a class template.
 \begin{example}
-
 \begin{codeblock}
 template<class T> struct A {
   struct B { };
@@ -6666,7 +6604,6 @@ the program is ill-formed, no diagnostic required.
 An implicit instantiation is never generated for an explicit specialization
 that is declared but not defined.
 \begin{example}
-
 \begin{codeblock}
 class String { };
 template<class T> class Array { @\commentellip@ };
@@ -6720,7 +6657,6 @@ or to make it compile will be such a trial as to kindle its self-immolation.
 A template explicit specialization is in the scope of the namespace in which
 the template was defined.
 \begin{example}
-
 \begin{codeblock}
 namespace N {
   template<class T> class X { @\commentellip@ };
@@ -6742,7 +6678,6 @@ that names a class template explicit specialization that has been declared but
 not defined can be used exactly like the names of other incompletely-defined
 classes\iref{basic.types}.
 \begin{example}
-
 \begin{codeblock}
 template<class T> class X;                      // \tcode{X} is a class template
 template<> class X<int>;
@@ -6760,7 +6695,6 @@ can be left unspecified in the
 naming an explicit function template specialization
 provided it can be deduced from the function argument type.
 \begin{example}
-
 \begin{codeblock}
 template<class T> class Array { @\commentellip@ };
 template<class T> void sort(Array<T>& v);
@@ -6793,7 +6727,6 @@ only if it is declared with the \tcode{inline}
 specifier or defined as deleted, and independently of whether its
 function or variable template is inline.
 \begin{example}
-
 \begin{codeblock}
 template<class T> void f(T) { @\commentellip@ }
 template<class T> inline T g(T) { @\commentellip@ }
@@ -6826,7 +6759,6 @@ or member template is defined in the class template definition.
 An explicit specialization of a member or member template is specified using the
 syntax for explicit specialization.
 \begin{example}
-
 \begin{codeblock}
 template<class T> struct A {
   void f(T);
@@ -6863,7 +6795,6 @@ the member declaration shall be preceded by a
 \tcode{template<>}
 for each enclosing class template that is explicitly specialized.
 \begin{example}
-
 \begin{codeblock}
 template<class T1> class A {
   template<class T2> class B {
@@ -6896,7 +6827,6 @@ in the
 \grammarterm{template-parameter-list}
 shall be the same as those specified in the primary template definition.
 \begin{example}
-
 \begin{codeblock}
 template <class T1> class A {
   template<class T2> class B {
@@ -6959,7 +6889,6 @@ specialization, see~\ref{temp.deduct}), or obtained from default template argume
 Each function template specialization instantiated from a template
 has its own copy of any static variable.
 \begin{example}
-
 \begin{codeblock}
 template<class T> void f(T* p) {
   static T s;
@@ -7098,7 +7027,6 @@ than there are corresponding
 unless one of the \grammarterm{template-parameter}{s} is a template
 parameter pack.
 \begin{example}
-
 \begin{codeblock}
 template<class X, class Y, class Z> X f(Y,Z);
 template<class ... Args> void f2();
@@ -7206,7 +7134,6 @@ the function type but still affects the type of the function parameter
 variable within the function.
 \end{note}
 \begin{example}
-
 \begin{codeblock}
 template <class T> void f(T t);
 template <class X> void g(const X x);
@@ -7482,7 +7409,6 @@ Attempting to perform an invalid conversion in either a template
 argument expression, or an expression used in the function
 declaration.
 \begin{example}
-
 \begin{codeblock}
 template <class T, T*> int f(int);
 int i2 = f<int,1>(0);           // can't conv \tcode{1} to \tcode{int*}
@@ -8577,7 +8503,6 @@ These forms can be used in the same way as
 \tcode{T}
 is for further composition of types.
 \begin{example}
-
 \begin{codeblock}
 X<int> (*)(char[6])
 \end{codeblock}
@@ -8732,7 +8657,6 @@ may be deduced from an array bound, the resulting value will always be
 \tcode{true}
 because the array bound will be nonzero.}
 \begin{example}
-
 \begin{codeblock}
 template<int i> class A { @\commentellip@ };
 template<short s> void f(A<s>);
@@ -8758,7 +8682,6 @@ can be deduced from a function, pointer to function, or
 pointer-to-member-function type.
 
 \begin{example}
-
 \begin{codeblock}
 template<class T> void f(void(*)(T,int));
 template<class T> void foo(T,int);
@@ -8780,7 +8703,6 @@ A template
 \grammarterm{type-parameter}
 cannot be deduced from the type of a function default argument.
 \begin{example}
-
 \begin{codeblock}
 template <class T> void f(T = 5, T = 7);
 void g() {
@@ -8800,7 +8722,6 @@ is deduced from the type of the
 \grammarterm{template-argument}
 of a class template specialization used in the argument list of a function call.
 \begin{example}
-
 \begin{codeblock}
 template <template <class T> class X> struct A { };
 template <template <class T> class X> void f(A<X>) { }
@@ -8971,7 +8892,6 @@ specialization in a set of candidate functions.
 Therefore only the function template declaration is needed to resolve a call
 for which a template specialization is a candidate.
 \begin{example}
-
 \begin{codeblock}
 template<class T> void f(T);    // declaration
 

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1832,7 +1832,6 @@ $(A \land B) \lor (A \land C)$.
 %
 Its disjunctive clauses are $(A \land B)$ and $(A \land C)$.
 \end{example}
-%
 }
 of $P$, $P_i$ subsumes every conjunctive clause $Q_j$
 in the conjunctive normal form\footnote{
@@ -1844,7 +1843,6 @@ $A \land (B \lor C)$ is in conjunctive normal form.
 %
 Its conjunctive clauses are $A$ and $(B \lor C)$.
 \end{example}
-%
 }
 of $Q$, where
 
@@ -7617,7 +7615,6 @@ template <class T> int g(volatile T&);
 int n3 = g(i);                  // calls \tcode{g<const int>(const volatile int\&)}
 \end{codeblock}
 \end{example}
-%
 A \defn{forwarding reference}
 is an rvalue reference to a cv-unqualified template parameter
 that does not represent a template parameter of a class template
@@ -8950,7 +8947,6 @@ The program will be ill-formed unless a specialization for
 either implicitly or explicitly generated,
 is present in some translation unit.
 \end{example}
-%
 
 \rSec1[temp.deduct.guide]{Deduction guides}
 \indextext{deduction!class template argument}%

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1371,7 +1371,8 @@ C<A> c;             // \tcode{V<int>} within \tcode{C<A>} uses the primary templ
 \end{codeblock}
 \end{example}
 
-\pnum A \grammarterm{template-argument} matches a template
+\pnum
+A \grammarterm{template-argument} matches a template
 \grammarterm{template-parameter} \tcode{P} when
 \tcode{P} is at least as specialized as the \grammarterm{template-argument} \tcode{A}.
 In this comparison, if \tcode{P} is unconstrained,

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -186,7 +186,8 @@ m.lock()
 
 \begin{itemdescr}
 \pnum
-\effects Blocks until a lock can be acquired for the current execution agent. If an exception
+\effects
+Blocks until a lock can be acquired for the current execution agent. If an exception
 is thrown then a lock shall not have been acquired for the current execution agent.
 \end{itemdescr}
 
@@ -199,10 +200,12 @@ m.unlock()
 \requires The current execution agent shall hold a lock on \tcode{m}.
 
 \pnum
-\effects Releases a lock on \tcode{m} held by the current execution agent.
+\effects
+Releases a lock on \tcode{m} held by the current execution agent.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \rSec3[thread.req.lockable.req]{\oldconcept{Lockable} requirements}
@@ -218,14 +221,16 @@ m.try_lock()
 
 \begin{itemdescr}
 \pnum
-\effects Attempts to acquire a lock for the current execution agent without blocking. If an
+\effects
+Attempts to acquire a lock for the current execution agent without blocking. If an
 exception is thrown then a lock shall not have been acquired for the current execution agent.
 
 \pnum
 \returntype \tcode{bool}.
 
 \pnum
-\returns \tcode{true} if the lock was acquired, \tcode{false} otherwise.
+\returns
+\tcode{true} if the lock was acquired, \tcode{false} otherwise.
 \end{itemdescr}
 
 \rSec3[thread.req.lockable.timed]{\oldconcept{TimedLockable} requirements}
@@ -243,7 +248,8 @@ m.try_lock_for(rel_time)
 
 \begin{itemdescr}
 \pnum
-\effects Attempts to acquire a lock for the current execution agent within the relative
+\effects
+Attempts to acquire a lock for the current execution agent within the relative
 timeout\iref{thread.req.timing} specified by \tcode{rel_time}. The function shall not return
 within the timeout specified by \tcode{rel_time} unless it has obtained a lock on \tcode{m}
 for the current execution agent. If an exception is thrown then a lock shall not have been
@@ -253,7 +259,8 @@ acquired for the current execution agent.
 \returntype \tcode{bool}.
 
 \pnum
-\returns \tcode{true} if the lock was acquired, \tcode{false} otherwise.
+\returns
+\tcode{true} if the lock was acquired, \tcode{false} otherwise.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -262,7 +269,8 @@ m.try_lock_until(abs_time)
 
 \begin{itemdescr}
 \pnum
-\effects Attempts to acquire a lock for the current execution agent before the absolute
+\effects
+Attempts to acquire a lock for the current execution agent before the absolute
 timeout\iref{thread.req.timing} specified by \tcode{abs_time}. The function shall not return
 before the timeout specified by \tcode{abs_time} unless it has obtained a lock on \tcode{m} for
 the current execution agent. If an exception is thrown then a lock shall not have been acquired
@@ -272,7 +280,8 @@ for the current execution agent.
 \returntype \tcode{bool}.
 
 \pnum
-\returns \tcode{true} if the lock was acquired, \tcode{false} otherwise.
+\returns
+\tcode{true} if the lock was acquired, \tcode{false} otherwise.
 \end{itemdescr}
 
 \rSec1[thread.stoptoken]{Stop tokens}
@@ -410,7 +419,8 @@ stop_token(const stop_token& rhs) noexcept;
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{*this == rhs} is \tcode{true}.
+\ensures
+\tcode{*this == rhs} is \tcode{true}.
 \begin{note}
 \tcode{*this} and \tcode{rhs} share the ownership of the same stop state,
 if any.
@@ -436,7 +446,8 @@ and \tcode{rhs.stop_possible()} is \tcode{false}.
 
 \begin{itemdescr}
 \pnum
-\effects Releases ownership of the stop state, if any.
+\effects
+Releases ownership of the stop state, if any.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{stop_token}%
@@ -446,10 +457,12 @@ stop_token& operator=(const stop_token& rhs) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{stop_token(rhs).swap(*this)}.
+\effects
+Equivalent to: \tcode{stop_token(rhs).swap(*this)}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{stop_token}%
@@ -459,10 +472,12 @@ stop_token& operator=(stop_token&& rhs) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{stop_token(std::move(rhs)).swap(*this)}.
+\effects
+Equivalent to: \tcode{stop_token(std::move(rhs)).swap(*this)}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{stop_token}%
@@ -472,7 +487,8 @@ void swap(stop_token& rhs) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Exchanges the values of \tcode{*this} and \tcode{rhs}.
+\effects
+Exchanges the values of \tcode{*this} and \tcode{rhs}.
 \end{itemdescr}
 
 \rSec3[stoptoken.mem]{Members}
@@ -484,7 +500,8 @@ void swap(stop_token& rhs) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{true} if \tcode{*this} has ownership of a stop state
+\returns
+\tcode{true} if \tcode{*this} has ownership of a stop state
 that has received a stop request;
 otherwise, \tcode{false}.
 \end{itemdescr}
@@ -496,7 +513,8 @@ otherwise, \tcode{false}.
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{false} if:
+\returns
+\tcode{false} if:
 \begin{itemize}
 \item \tcode{*this} does not have ownership of a stop state, or
 \item a stop request was not made
@@ -527,7 +545,8 @@ otherwise \tcode{false}.
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!(lhs==rhs)}.
+\returns
+\tcode{!(lhs==rhs)}.
 \end{itemdescr}
 
 \rSec3[stoptoken.special]{Specialized algorithms}
@@ -539,7 +558,8 @@ friend void swap(stop_token& x, stop_token& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{x.swap(y)}.
+\effects
+Equivalent to: \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{stop_source}}%
@@ -601,14 +621,17 @@ stop_source();
 
 \begin{itemdescr}
 \pnum
-\effects Initialises \tcode{*this} to have ownership of a new stop state.
+\effects
+Initialises \tcode{*this} to have ownership of a new stop state.
 
 \pnum
-\ensures \tcode{stop_possible()} is \tcode{true}
+\ensures
+\tcode{stop_possible()} is \tcode{true}
 and \tcode{stop_requested()} is \tcode{false}.
 
 \pnum
-\throws \tcode{bad_alloc} if memory could not be allocated for the stop state.
+\throws
+\tcode{bad_alloc} if memory could not be allocated for the stop state.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{stop_source}!constructor}%
@@ -631,7 +654,8 @@ stop_source(const stop_source& rhs) noexcept;
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{*this == rhs} is \tcode{true}.
+\ensures
+\tcode{*this == rhs} is \tcode{true}.
 \begin{note}
 \tcode{*this} and \tcode{rhs} share the ownership of the same stop state,
 if any.
@@ -658,7 +682,8 @@ and \tcode{rhs.stop_possible()} is \tcode{false}.
 
 \begin{itemdescr}
 \pnum
-\effects Releases ownership of the stop state, if any.
+\effects
+Releases ownership of the stop state, if any.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{stop_source}%
@@ -668,10 +693,12 @@ stop_source& operator=(const stop_source& rhs) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{stop_source(rhs).swap(*this)}.
+\effects
+Equivalent to: \tcode{stop_source(rhs).swap(*this)}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{stop_source}%
@@ -681,10 +708,12 @@ stop_source& operator=(stop_source&& rhs) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{stop_source(std::move(rhs)).swap(*this)}.
+\effects
+Equivalent to: \tcode{stop_source(std::move(rhs)).swap(*this)}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{stop_source}%
@@ -694,7 +723,8 @@ void swap(stop_source& rhs) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Exchanges the values of \tcode{*this} and \tcode{rhs}.
+\effects
+Exchanges the values of \tcode{*this} and \tcode{rhs}.
 \end{itemdescr}
 
 \rSec3[stopsource.mem]{Members}
@@ -798,7 +828,8 @@ otherwise \tcode{false}.
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!(lhs==rhs)}.
+\returns
+\tcode{!(lhs==rhs)}.
 \end{itemdescr}
 
 \rSec3[stopsource.special]{Specialized algorithms}
@@ -810,7 +841,8 @@ friend void swap(stop_source& x, stop_source& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{x.swap(y)}.
+\effects
+Equivalent to: \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{stop_callback}}%
@@ -904,7 +936,8 @@ exits via an exception,
 then \tcode{terminate} is called\iref{except.terminate}.
 
 \pnum
-\throws Any exception thrown by the initialization of \tcode{callback}.
+\throws
+Any exception thrown by the initialization of \tcode{callback}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{stop_callback}!destructor}%
@@ -1055,10 +1088,12 @@ id() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an object of type \tcode{id}.
+\effects
+Constructs an object of type \tcode{id}.
 
 \pnum
-\ensures The constructed object does not represent a thread of execution.
+\ensures
+The constructed object does not represent a thread of execution.
 \end{itemdescr}
 
 \indexlibrarymember{operator==}{thread::id}%
@@ -1068,7 +1103,8 @@ bool operator==(thread::id x, thread::id y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{true} only if \tcode{x} and \tcode{y} represent the same
+\returns
+\tcode{true} only if \tcode{x} and \tcode{y} represent the same
 thread of execution or neither \tcode{x} nor \tcode{y} represents a thread of
 execution.
 \end{itemdescr}
@@ -1101,14 +1137,16 @@ template<class charT, class traits>
 
 \begin{itemdescr}
 \pnum
-\effects Inserts an unspecified text representation of \tcode{id} into
+\effects
+Inserts an unspecified text representation of \tcode{id} into
 \tcode{out}. For two objects of type \tcode{thread::id} \tcode{x} and \tcode{y},
 if \tcode{x == y} the \tcode{thread::id} objects have the same text
 representation and if \tcode{x != y} the \tcode{thread::id} objects have
 distinct text representations.
 
 \pnum
-\returns \tcode{out}.
+\returns
+\tcode{out}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{hash}!\idxcode{thread::id}}%
@@ -1130,10 +1168,12 @@ thread() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{thread} object that does not represent a thread of execution.
+\effects
+Constructs a \tcode{thread} object that does not represent a thread of execution.
 
 \pnum
-\ensures \tcode{get_id() == id()}.
+\ensures
+\tcode{get_id() == id()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{thread}!constructor}%
@@ -1157,7 +1197,8 @@ This constructor shall not participate in overload resolution if \tcode{remove_c
 is the same type as \tcode{std::thread}.
 
 \pnum
-\effects\ Constructs an object of type \tcode{thread}. The new thread of execution executes
+\effects
+Constructs an object of type \tcode{thread}. The new thread of execution executes
 \tcode{%
 \placeholdernc{INVOKE}(\brk{}%
 \placeholdernc{decay-copy}(\brk{}%
@@ -1178,14 +1219,17 @@ termi\-nates with an uncaught exception, \tcode{terminate} shall be called.
 
 
 \pnum
-\sync The completion of the invocation of the constructor
+\sync
+The completion of the invocation of the constructor
 synchronizes with the beginning of the invocation of the copy of \tcode{f}.
 
 \pnum
-\ensures \tcode{get_id() != id()}. \tcode{*this} represents the newly started thread.
+\ensures
+\tcode{get_id() != id()}. \tcode{*this} represents the newly started thread.
 
 \pnum
-\throws \tcode{system_error} if unable to start the new thread.
+\throws
+\tcode{system_error} if unable to start the new thread.
 
 \pnum
 \errors
@@ -1203,11 +1247,13 @@ thread(thread&& x) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an object of type \tcode{thread} from \tcode{x}, and sets
+\effects
+Constructs an object of type \tcode{thread} from \tcode{x}, and sets
 \tcode{x} to a default constructed state.
 
 \pnum
-\ensures \tcode{x.get_id() == id()} and \tcode{get_id()} returns the
+\ensures
+\tcode{x.get_id() == id()} and \tcode{get_id()} returns the
 value of \tcode{x.get_id()} prior to the start of construction.
 
 \end{itemdescr}
@@ -1238,15 +1284,18 @@ thread& operator=(thread&& x) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects If \tcode{joinable()}, calls \tcode{terminate()}. Otherwise, assigns the
+\effects
+If \tcode{joinable()}, calls \tcode{terminate()}. Otherwise, assigns the
 state of \tcode{x} to \tcode{*this} and sets \tcode{x} to a default constructed state.
 
 \pnum
-\ensures \tcode{x.get_id() == id()} and \tcode{get_id()} returns the value of
+\ensures
+\tcode{x.get_id() == id()} and \tcode{get_id()} returns the value of
 \tcode{x.get_id()} prior to the assignment.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \rSec3[thread.thread.member]{Members}
@@ -1258,7 +1307,8 @@ void swap(thread& x) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Swaps the state of \tcode{*this} and \tcode{x}.
+\effects
+Swaps the state of \tcode{*this} and \tcode{x}.
 \end{itemdescr}
 
 \indexlibrarymember{joinable}{thread}%
@@ -1268,7 +1318,8 @@ bool joinable() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{get_id() != id()}.
+\returns
+\tcode{get_id() != id()}.
 \end{itemdescr}
 
 \indexlibrarymember{join}{thread}%
@@ -1278,19 +1329,23 @@ void join();
 
 \begin{itemdescr}
 \pnum
-\effects\ Blocks until the thread represented by \tcode{*this} has completed.
+\effects
+Blocks until the thread represented by \tcode{*this} has completed.
 
 \pnum
-\sync The completion of the thread represented by \tcode{*this} synchronizes with\iref{intro.multithread}
+\sync
+The completion of the thread represented by \tcode{*this} synchronizes with\iref{intro.multithread}
 the corresponding successful
 \tcode{join()} return. \begin{note} Operations on
 \tcode{*this} are not synchronized. \end{note}
 
 \pnum
-\ensures The thread represented by \tcode{*this} has completed. \tcode{get_id() == id()}.
+\ensures
+The thread represented by \tcode{*this} has completed. \tcode{get_id() == id()}.
 
 \pnum
-\throws \tcode{system_error} when
+\throws
+\tcode{system_error} when
 an exception is required\iref{thread.req.exception}.
 
 \pnum
@@ -1312,16 +1367,19 @@ void detach();
 
 \begin{itemdescr}
 \pnum
-\effects The thread represented by \tcode{*this} continues execution without the calling thread
+\effects
+The thread represented by \tcode{*this} continues execution without the calling thread
 blocking. When \tcode{detach()} returns, \tcode{*this} no longer represents the possibly continuing
 thread of execution. When the thread previously represented by \tcode{*this} ends execution, the
 implementation shall release any owned resources.
 
 \pnum
-\ensures \tcode{get_id() == id()}.
+\ensures
+\tcode{get_id() == id()}.
 
 \pnum
-\throws \tcode{system_error} when
+\throws
+\tcode{system_error} when
 an exception is required\iref{thread.req.exception}.
 
 \pnum
@@ -1339,7 +1397,8 @@ id get_id() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns A default constructed \tcode{id} object if \tcode{*this} does not represent a thread,
+\returns
+A default constructed \tcode{id} object if \tcode{*this} does not represent a thread,
 otherwise \tcode{this_thread::get_id()} for the thread of execution represented by
 \tcode{*this}.
 \end{itemdescr}
@@ -1353,7 +1412,8 @@ unsigned hardware_concurrency() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns The number of hardware thread contexts. \begin{note} This value should
+\returns
+The number of hardware thread contexts. \begin{note} This value should
 only be considered to be a hint. \end{note} If this value is not computable or
 well-defined, an implementation should return 0.
 \end{itemdescr}
@@ -1367,7 +1427,8 @@ void swap(thread& x, thread& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{x.swap(y)}.
+\effects
+As if by \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \rSec2[thread.jthread.class]{Class \tcode{jthread}}
@@ -1492,7 +1553,8 @@ If the \tcode{\placeholdernc{INVOKE}} expression exits via an exception,
 \tcode{terminate} is called.
 
 \pnum
-\sync The completion of the invocation of the constructor
+\sync
+The completion of the invocation of the constructor
 synchronizes with the beginning of the invocation of the copy of \tcode{f}.
 
 \pnum
@@ -1506,7 +1568,8 @@ because it cannot replace this stop token.
 \end{note}
 
 \pnum
-\throws \tcode{system_error} if unable to start the new thread.
+\throws
+\tcode{system_error} if unable to start the new thread.
 
 \pnum
 \errors
@@ -1525,7 +1588,8 @@ jthread(jthread&& x) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an object of type \tcode{jthread} from \tcode{x}, and sets
+\effects
+Constructs an object of type \tcode{jthread} from \tcode{x}, and sets
 \tcode{x} to a default constructed state.
 
 \pnum
@@ -1574,7 +1638,8 @@ prior to the assignment
 and \tcode{x.ssource.stop_possible()} is \tcode{false}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \rSec3[thread.jthread.mem]{Members}
@@ -1586,7 +1651,8 @@ void swap(jthread& x) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Exchanges the values of \tcode{*this} and \tcode{x}.
+\effects
+Exchanges the values of \tcode{*this} and \tcode{x}.
 \end{itemdescr}
 
 
@@ -1597,7 +1663,8 @@ void swap(jthread& x) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{get_id() != id()}.
+\returns
+\tcode{get_id() != id()}.
 \end{itemdescr}
 
 \indexlibrarymember{join}{jthread}%
@@ -1607,16 +1674,19 @@ void join();
 
 \begin{itemdescr}
 \pnum
-\effects Blocks until the thread represented by \tcode{*this} has completed.
+\effects
+Blocks until the thread represented by \tcode{*this} has completed.
 
 \pnum
-\sync The completion of the thread represented by \tcode{*this}
+\sync
+The completion of the thread represented by \tcode{*this}
 synchronizes with\iref{intro.multithread}
 the corresponding successful \tcode{join()} return.
 \begin{note} Operations on \tcode{*this} are not synchronized. \end{note}
 
 \pnum
-\ensures The thread represented by \tcode{*this} has completed.
+\ensures
+The thread represented by \tcode{*this} has completed.
 \tcode{get_id() == id()}.
 
 \pnum
@@ -1651,7 +1721,8 @@ When the thread previously represented by \tcode{*this} ends execution,
 the implementation shall release any owned resources.
 
 \pnum
-\ensures \tcode{get_id() == id()}.
+\ensures
+\tcode{get_id() == id()}.
 
 \pnum
 \throws
@@ -1688,7 +1759,8 @@ for the thread of execution represented by \tcode{*this}.
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return ssource;}
+\effects
+Equivalent to: \tcode{return ssource;}
 \end{itemdescr}
 
 \indexlibrarymember{get_stop_token}{jthread}%
@@ -1698,7 +1770,8 @@ for the thread of execution represented by \tcode{*this}.
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return ssource.get_token();}
+\effects
+Equivalent to: \tcode{return ssource.get_token();}
 \end{itemdescr}
 
 \indexlibrarymember{request_stop}{jthread}%
@@ -1708,7 +1781,8 @@ bool request_stop() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return ssource.request_stop();}
+\effects
+Equivalent to: \tcode{return ssource.request_stop();}
 \end{itemdescr}
 
 
@@ -1721,7 +1795,8 @@ friend void swap(jthread& x, jthread& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{x.swap(y)}.
+\effects
+Equivalent to: \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \rSec3[thread.jthread.static]{Static members}
@@ -1733,7 +1808,8 @@ unsigned hardware_concurrency() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{thread::hardware_concurrency()}.
+\returns
+\tcode{thread::hardware_concurrency()}.
 \end{itemdescr}
 
 
@@ -1758,7 +1834,8 @@ thread::id this_thread::get_id() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns An object of type \tcode{thread::id} that uniquely identifies the current thread of
+\returns
+An object of type \tcode{thread::id} that uniquely identifies the current thread of
 execution. No other thread of execution shall have this id and this thread of execution shall
 always have this id. The object returned shall not compare equal to a default constructed
 \tcode{thread::id}.
@@ -1771,10 +1848,12 @@ void this_thread::yield() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Offers the implementation the opportunity to reschedule.
+\effects
+Offers the implementation the opportunity to reschedule.
 
 \pnum
-\sync None.
+\sync
+None.
 \end{itemdescr}
 
 \indexlibrarymember{sleep_until}{this_thread}%
@@ -1785,14 +1864,17 @@ template<class Clock, class Duration>
 
 \begin{itemdescr}
 \pnum
-\effects Blocks the calling thread for the absolute timeout\iref{thread.req.timing} specified
+\effects
+Blocks the calling thread for the absolute timeout\iref{thread.req.timing} specified
 by \tcode{abs_time}.
 
 \pnum
-\sync None.
+\sync
+None.
 
 \pnum
-\throws Timeout-related exceptions\iref{thread.req.timing}.
+\throws
+Timeout-related exceptions\iref{thread.req.timing}.
 \end{itemdescr}
 
 \indexlibrarymember{sleep_for}{this_thread}%
@@ -1803,14 +1885,17 @@ template<class Rep, class Period>
 
 \begin{itemdescr}
 \pnum
-\effects Blocks the calling thread for the relative timeout\iref{thread.req.timing} specified
+\effects
+Blocks the calling thread for the relative timeout\iref{thread.req.timing} specified
 by \tcode{rel_time}.
 
 \pnum
-\sync None.
+\sync
+None.
 
 \pnum
-\throws Timeout-related exceptions\iref{thread.req.timing}.
+\throws
+Timeout-related exceptions\iref{thread.req.timing}.
 \end{itemdescr}
 
 \rSec1[thread.mutex]{Mutual exclusion}
@@ -1930,20 +2015,24 @@ The expression \tcode{m.lock()} shall be well-formed and have the following sema
 thread does not own the mutex.
 
 \pnum
-\effects Blocks the calling thread until ownership of the mutex can be obtained for the calling thread.
+\effects
+Blocks the calling thread until ownership of the mutex can be obtained for the calling thread.
 
 \pnum
-\ensures The calling thread owns the mutex.
+\ensures
+The calling thread owns the mutex.
 
 \pnum
 \returntype \tcode{void}.
 
 \pnum
-\sync Prior \tcode{unlock()} operations on the same object shall
+\sync
+Prior \tcode{unlock()} operations on the same object shall
 \term{synchronize with}\iref{intro.multithread} this operation.
 
 \pnum
-\throws \tcode{system_error} when
+\throws
+\tcode{system_error} when
 an exception is required\iref{thread.req.exception}.
 
 \pnum
@@ -1967,7 +2056,8 @@ The expression \tcode{m.try_lock()} shall be well-formed and have the following 
 thread does not own the mutex.
 
 \pnum
-\effects Attempts to obtain ownership of the mutex for the calling thread without
+\effects
+Attempts to obtain ownership of the mutex for the calling thread without
 blocking. If ownership is not obtained, there is no effect and \tcode{try_lock()}
 immediately returns. An implementation may fail to obtain the lock even if it is not
 held by any other thread. \begin{note} This spurious failure is normally uncommon, but
@@ -1981,18 +2071,21 @@ in the absence of contending mutex acquisitions.
 \returntype \tcode{bool}.
 
 \pnum
-\returns \tcode{true} if ownership of the mutex was obtained for the calling
+\returns
+\tcode{true} if ownership of the mutex was obtained for the calling
 thread, otherwise \tcode{false}.
 
 \pnum
-\sync If \tcode{try_lock()} returns \tcode{true}, prior \tcode{unlock()} operations
+\sync
+If \tcode{try_lock()} returns \tcode{true}, prior \tcode{unlock()} operations
 on the same object \term{synchronize with}\iref{intro.multithread} this operation.
 \begin{note} Since \tcode{lock()} does not synchronize with a failed subsequent
 \tcode{try_lock()}, the visibility rules are weak enough that little would be
 known about the state after a failure, even in the absence of spurious failures. \end{note}
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \pnum
@@ -2003,17 +2096,20 @@ The expression \tcode{m.unlock()} shall be well-formed and have the following se
 \requires The calling thread shall own the mutex.
 
 \pnum
-\effects Releases the calling thread's ownership of the mutex.
+\effects
+Releases the calling thread's ownership of the mutex.
 
 \pnum
 \returntype \tcode{void}.
 
 \pnum
-\sync This operation synchronizes with\iref{intro.multithread} subsequent
+\sync
+This operation synchronizes with\iref{intro.multithread} subsequent
 lock operations that obtain ownership on the same object.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \rSec4[thread.mutex.class]{Class \tcode{mutex}}
@@ -2151,7 +2247,8 @@ following semantics:
 own the mutex.
 
 \pnum
-\effects The function attempts to obtain ownership of the mutex within the
+\effects
+The function attempts to obtain ownership of the mutex within the
 relative timeout\iref{thread.req.timing}
 specified by \tcode{rel_time}. If the time specified by \tcode{rel_time} is less than or
 equal to \tcode{rel_time.zero()}, the function attempts to obtain ownership without blocking (as if by calling
@@ -2165,14 +2262,17 @@ lock is available, but implementations are expected to make a strong effort to d
 \returntype \tcode{bool}.
 
 \pnum
-\returns \tcode{true} if ownership was obtained, otherwise \tcode{false}.
+\returns
+\tcode{true} if ownership was obtained, otherwise \tcode{false}.
 
 \pnum
-\sync If \tcode{try_lock_for()} returns \tcode{true}, prior \tcode{unlock()} operations
+\sync
+If \tcode{try_lock_for()} returns \tcode{true}, prior \tcode{unlock()} operations
 on the same object \term{synchronize with}\iref{intro.multithread} this operation.
 
 \pnum
-\throws Timeout-related exceptions\iref{thread.req.timing}.
+\throws
+Timeout-related exceptions\iref{thread.req.timing}.
 \end{itemdescr}
 
 \pnum
@@ -2186,7 +2286,8 @@ following semantics:
 mutex.
 
 \pnum
-\effects The function attempts to obtain ownership of the mutex. If
+\effects
+The function attempts to obtain ownership of the mutex. If
 \tcode{abs_time} has already passed, the function attempts to obtain ownership
 without blocking (as if by calling \tcode{try_lock()}). The function shall
 return before the absolute timeout\iref{thread.req.timing} specified by
@@ -2199,15 +2300,18 @@ strong effort to do so. \end{note}
 \returntype \tcode{bool}.
 
 \pnum
-\returns \tcode{true} if ownership was obtained, otherwise \tcode{false}.
+\returns
+\tcode{true} if ownership was obtained, otherwise \tcode{false}.
 
 \pnum
-\sync If \tcode{try_lock_until()} returns \tcode{true}, prior \tcode{unlock()}
+\sync
+If \tcode{try_lock_until()} returns \tcode{true}, prior \tcode{unlock()}
 operations on the same object \term{synchronize with}\iref{intro.multithread}
 this operation.
 
 \pnum
-\throws Timeout-related exceptions\iref{thread.req.timing}.
+\throws
+Timeout-related exceptions\iref{thread.req.timing}.
 \end{itemdescr}
 
 \rSec4[thread.timedmutex.class]{Class \tcode{timed_mutex}}
@@ -2357,20 +2461,24 @@ following semantics:
 \requires The calling thread has no ownership of the mutex.
 
 \pnum
-\effects Blocks the calling thread until shared ownership of the mutex can be obtained for the calling thread.
+\effects
+Blocks the calling thread until shared ownership of the mutex can be obtained for the calling thread.
 If an exception is thrown then a shared lock shall not have been acquired for the current thread.
 
 \pnum
-\ensures The calling thread has a shared lock on the mutex.
+\ensures
+The calling thread has a shared lock on the mutex.
 
 \pnum
 \returntype \tcode{void}.
 
 \pnum
-\sync Prior \tcode{unlock()} operations on the same object shall synchronize with\iref{intro.multithread} this operation.
+\sync
+Prior \tcode{unlock()} operations on the same object shall synchronize with\iref{intro.multithread} this operation.
 
 \pnum
-\throws \tcode{system_error} when an exception is required\iref{thread.req.exception}.
+\throws
+\tcode{system_error} when an exception is required\iref{thread.req.exception}.
 
 \pnum
 \errors
@@ -2388,17 +2496,20 @@ The expression \tcode{m.unlock_shared()} shall be well-formed and have the follo
 \requires The calling thread shall hold a shared lock on the mutex.
 
 \pnum
-\effects Releases a shared lock on the mutex held by the calling thread.
+\effects
+Releases a shared lock on the mutex held by the calling thread.
 
 \pnum
 \returntype \tcode{void}.
 
 \pnum
-\sync This operation synchronizes with\iref{intro.multithread} subsequent
+\sync
+This operation synchronizes with\iref{intro.multithread} subsequent
 \tcode{lock()} operations that obtain ownership on the same object.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \pnum
@@ -2409,7 +2520,8 @@ The expression \tcode{m.try_lock_shared()} shall be well-formed and have the fol
 \requires The calling thread has no ownership of the mutex.
 
 \pnum
-\effects Attempts to obtain shared ownership of the mutex for the calling
+\effects
+Attempts to obtain shared ownership of the mutex for the calling
 thread without blocking. If shared ownership is not obtained, there is no
 effect and \tcode{try_lock_shared()} immediately returns. An implementation
 may fail to obtain the lock even if it is not held by any other thread.
@@ -2418,16 +2530,19 @@ may fail to obtain the lock even if it is not held by any other thread.
 \returntype \tcode{bool}.
 
 \pnum
-\returns \tcode{true} if the shared ownership lock was acquired, \tcode{false}
+\returns
+\tcode{true} if the shared ownership lock was acquired, \tcode{false}
 otherwise.
 
 \pnum
-\sync If \tcode{try_lock_shared()} returns \tcode{true}, prior \tcode{unlock()}
+\sync
+If \tcode{try_lock_shared()} returns \tcode{true}, prior \tcode{unlock()}
 operations on the same object synchronize with\iref{intro.multithread} this
 operation.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \rSec4[thread.sharedmutex.class]{Class \tcode{shared_mutex}}
@@ -2502,7 +2617,8 @@ have the following semantics:
 \requires The calling thread has no ownership of the mutex.
 
 \pnum
-\effects Attempts to obtain
+\effects
+Attempts to obtain
 shared lock ownership for the calling thread within the relative
 timeout\iref{thread.req.timing} specified by \tcode{rel_time}. If the time
 specified by \tcode{rel_time} is less than or equal to \tcode{rel_time.zero()},
@@ -2519,15 +2635,18 @@ the current thread.
 \returntype \tcode{bool}.
 
 \pnum
-\returns \tcode{true} if the shared lock was acquired, \tcode{false} otherwise.
+\returns
+\tcode{true} if the shared lock was acquired, \tcode{false} otherwise.
 
 \pnum
-\sync If \tcode{try_lock_shared_for()} returns \tcode{true}, prior
+\sync
+If \tcode{try_lock_shared_for()} returns \tcode{true}, prior
 \tcode{unlock()} operations on the same object synchronize
 with\iref{intro.multithread} this operation.
 
 \pnum
-\throws Timeout-related exceptions\iref{thread.req.timing}.
+\throws
+Timeout-related exceptions\iref{thread.req.timing}.
 \end{itemdescr}
 
 \pnum
@@ -2539,7 +2658,8 @@ and have the following semantics:
 \requires The calling thread has no ownership of the mutex.
 
 \pnum
-\effects The function attempts to obtain shared ownership of the mutex. If
+\effects
+The function attempts to obtain shared ownership of the mutex. If
 \tcode{abs_time} has already passed, the function attempts to obtain shared
 ownership without blocking (as if by calling \tcode{try_lock_shared()}). The
 function shall return before the absolute timeout\iref{thread.req.timing}
@@ -2554,15 +2674,18 @@ the current thread.
 \returntype \tcode{bool}.
 
 \pnum
-\returns \tcode{true} if the shared lock was acquired, \tcode{false} otherwise.
+\returns
+\tcode{true} if the shared lock was acquired, \tcode{false} otherwise.
 
 \pnum
-\sync If \tcode{try_lock_shared_until()} returns \tcode{true}, prior
+\sync
+If \tcode{try_lock_shared_until()} returns \tcode{true}, prior
 \tcode{unlock()} operations on the same object synchronize
 with\iref{intro.multithread} this operation.
 
 \pnum
-\throws Timeout-related exceptions\iref{thread.req.timing}.
+\throws
+Timeout-related exceptions\iref{thread.req.timing}.
 \end{itemdescr}
 
 \rSec4[thread.sharedtimedmutex.class]{Class \tcode{shared_timed_mutex}}
@@ -2694,7 +2817,8 @@ explicit lock_guard(mutex_type& m);
 the calling thread does not own the mutex \tcode{m}.
 
 \pnum
-\effects Initializes \tcode{pm} with \tcode{m}. Calls \tcode{m.lock()}.
+\effects
+Initializes \tcode{pm} with \tcode{m}. Calls \tcode{m.lock()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{lock_guard}!constructor}%
@@ -2707,10 +2831,12 @@ lock_guard(mutex_type& m, adopt_lock_t);
 \requires The calling thread owns the mutex \tcode{m}.
 
 \pnum
-\effects Initializes \tcode{pm} with \tcode{m}.
+\effects
+Initializes \tcode{pm} with \tcode{m}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{lock_guard}!destructor}%
@@ -2720,7 +2846,8 @@ lock_guard(mutex_type& m, adopt_lock_t);
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{pm.unlock()}.
+\effects
+As if by \tcode{pm.unlock()}.
 \end{itemdescr}
 
 
@@ -2771,7 +2898,8 @@ explicit scoped_lock(MutexTypes&... m);
 the calling thread does not own the corresponding mutex element of \tcode{m}.
 
 \pnum
-\effects Initializes \tcode{pm} with \tcode{tie(m...)}.
+\effects
+Initializes \tcode{pm} with \tcode{tie(m...)}.
 Then if \tcode{sizeof...(MutexTypes)} is \tcode{0}, no effects.
 Otherwise if \tcode{sizeof...(MutexTypes)} is \tcode{1}, then \tcode{m.lock()}.
 Otherwise, \tcode{lock(m...)}.
@@ -2787,10 +2915,12 @@ explicit scoped_lock(adopt_lock_t, MutexTypes&... m);
 \requires The calling thread owns all the mutexes in \tcode{m}.
 
 \pnum
-\effects Initializes \tcode{pm} with \tcode{tie(m...)}.
+\effects
+Initializes \tcode{pm} with \tcode{tie(m...)}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{scoped_lock}!destructor}%
@@ -2800,7 +2930,8 @@ explicit scoped_lock(adopt_lock_t, MutexTypes&... m);
 
 \begin{itemdescr}
 \pnum
-\effects For all \tcode{i} in \range{0}{sizeof...(MutexTypes)},
+\effects
+For all \tcode{i} in \range{0}{sizeof...(MutexTypes)},
 \tcode{get<i>(pm).unlock()}.
 \end{itemdescr}
 
@@ -2891,10 +3022,12 @@ unique_lock() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an object of type \tcode{unique_lock}.
+\effects
+Constructs an object of type \tcode{unique_lock}.
 
 \pnum
-\ensures \tcode{pm == 0} and \tcode{owns == false}.
+\ensures
+\tcode{pm == 0} and \tcode{owns == false}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{unique_lock}!constructor}%
@@ -2907,10 +3040,12 @@ explicit unique_lock(mutex_type& m);
 \requires If \tcode{mutex_type} is not a recursive mutex the calling thread does not own the mutex.
 
 \pnum
-\effects Constructs an object of type \tcode{unique_lock} and calls \tcode{m.lock()}.
+\effects
+Constructs an object of type \tcode{unique_lock} and calls \tcode{m.lock()}.
 
 \pnum
-\ensures \tcode{pm == addressof(m)} and \tcode{owns == true}.
+\ensures
+\tcode{pm == addressof(m)} and \tcode{owns == true}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{unique_lock}!constructor}%
@@ -2920,10 +3055,12 @@ unique_lock(mutex_type& m, defer_lock_t) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an object of type \tcode{unique_lock}.
+\effects
+Constructs an object of type \tcode{unique_lock}.
 
 \pnum
-\ensures \tcode{pm == addressof(m)} and \tcode{owns == false}.
+\ensures
+\tcode{pm == addressof(m)} and \tcode{owns == false}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{unique_lock}!constructor}%
@@ -2939,10 +3076,12 @@ requirements\iref{thread.req.lockable.req}.
 If \tcode{mutex_type} is not a recursive mutex the calling thread does not own the mutex.
 
 \pnum
-\effects Constructs an object of type \tcode{unique_lock} and calls \tcode{m.try_lock()}.
+\effects
+Constructs an object of type \tcode{unique_lock} and calls \tcode{m.try_lock()}.
 
 \pnum
-\ensures \tcode{pm == addressof(m)} and \tcode{owns == res},
+\ensures
+\tcode{pm == addressof(m)} and \tcode{owns == res},
 where \tcode{res} is the value returned by the call to \tcode{m.try_lock()}.
 \end{itemdescr}
 
@@ -2956,13 +3095,16 @@ unique_lock(mutex_type& m, adopt_lock_t);
 \requires The calling thread owns the mutex.
 
 \pnum
-\effects Constructs an object of type \tcode{unique_lock}.
+\effects
+Constructs an object of type \tcode{unique_lock}.
 
 \pnum
-\ensures \tcode{pm == addressof(m)} and \tcode{owns == true}.
+\ensures
+\tcode{pm == addressof(m)} and \tcode{owns == true}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{unique_lock}!constructor}%
@@ -2978,10 +3120,12 @@ does not own the mutex. The supplied \tcode{Mutex} type shall meet the
 \oldconcept{TimedLockable} requirements\iref{thread.req.lockable.timed}.
 
 \pnum
-\effects Constructs an object of type \tcode{unique_lock} and calls \tcode{m.try_lock_until(abs_time)}.
+\effects
+Constructs an object of type \tcode{unique_lock} and calls \tcode{m.try_lock_until(abs_time)}.
 
 \pnum
-\ensures \tcode{pm == addressof(m)} and \tcode{owns == res},
+\ensures
+\tcode{pm == addressof(m)} and \tcode{owns == res},
 where \tcode{res} is
 the value returned by the call to \tcode{m.try_lock_until(abs_time)}.
 \end{itemdescr}
@@ -2998,10 +3142,12 @@ template<class Rep, class Period>
 The supplied \tcode{Mutex} type shall meet the \oldconcept{TimedLockable} requirements\iref{thread.req.lockable.timed}.
 
 \pnum
-\effects Constructs an object of type \tcode{unique_lock} and calls \tcode{m.try_lock_for(rel_time)}.
+\effects
+Constructs an object of type \tcode{unique_lock} and calls \tcode{m.try_lock_for(rel_time)}.
 
 \pnum
-\ensures \tcode{pm == addressof(m)} and \tcode{owns == res},
+\ensures
+\tcode{pm == addressof(m)} and \tcode{owns == res},
 where \tcode{res} is the value returned by the call to \tcode{m.try_lock_for(rel_time)}.
 \end{itemdescr}
 
@@ -3012,7 +3158,8 @@ unique_lock(unique_lock&& u) noexcept;
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{pm == u_p.pm} and \tcode{owns == u_p.owns} (where \tcode{u_p} is the state of \tcode{u} just prior to this construction),  \tcode{u.pm == 0} and \tcode{u.owns == false}.
+\ensures
+\tcode{pm == u_p.pm} and \tcode{owns == u_p.owns} (where \tcode{u_p} is the state of \tcode{u} just prior to this construction),  \tcode{u.pm == 0} and \tcode{u.owns == false}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{unique_lock}%
@@ -3022,16 +3169,19 @@ unique_lock& operator=(unique_lock&& u);
 
 \begin{itemdescr}
 \pnum
-\effects If \tcode{owns} calls \tcode{pm->unlock()}.
+\effects
+If \tcode{owns} calls \tcode{pm->unlock()}.
 
 \pnum
-\ensures \tcode{pm == u_p.pm} and \tcode{owns == u_p.owns} (where \tcode{u_p} is the state of \tcode{u} just prior to this construction),  \tcode{u.pm == 0} and \tcode{u.owns == false}.
+\ensures
+\tcode{pm == u_p.pm} and \tcode{owns == u_p.owns} (where \tcode{u_p} is the state of \tcode{u} just prior to this construction),  \tcode{u.pm == 0} and \tcode{u.owns == false}.
 
 \pnum
 \begin{note} With a recursive mutex it is possible for both \tcode{*this} and \tcode{u} to own the same mutex before the assignment. In this case, \tcode{*this} will own the mutex after the assignment and \tcode{u} will not. \end{note}
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 
@@ -3042,7 +3192,8 @@ unique_lock& operator=(unique_lock&& u);
 
 \begin{itemdescr}
 \pnum
-\effects If \tcode{owns} calls \tcode{pm->unlock()}.
+\effects
+If \tcode{owns} calls \tcode{pm->unlock()}.
 \end{itemdescr}
 
 \rSec4[thread.lock.unique.locking]{Locking}
@@ -3054,10 +3205,12 @@ void lock();
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{pm->lock()}.
+\effects
+As if by \tcode{pm->lock()}.
 
 \pnum
-\ensures \tcode{owns == true}.
+\ensures
+\tcode{owns == true}.
 
 \pnum
 \throws
@@ -3084,13 +3237,16 @@ bool try_lock();
 requirements\iref{thread.req.lockable.req}.
 
 \pnum
-\effects As if by \tcode{pm->try_lock()}.
+\effects
+As if by \tcode{pm->try_lock()}.
 
 \pnum
-\returns The value returned by the call to \tcode{try_lock()}.
+\returns
+The value returned by the call to \tcode{try_lock()}.
 
 \pnum
-\ensures \tcode{owns == res}, where \tcode{res} is the value returned by
+\ensures
+\tcode{owns == res}, where \tcode{res} is the value returned by
 the call to \tcode{try_lock()}.
 
 \pnum
@@ -3119,17 +3275,21 @@ template<class Clock, class Duration>
 requirements\iref{thread.req.lockable.timed}.
 
 \pnum
-\effects As if by \tcode{pm->try_lock_until(abs_time)}.
+\effects
+As if by \tcode{pm->try_lock_until(abs_time)}.
 
 \pnum
-\returns The value returned by the call to \tcode{try_lock_until(abs_time)}.
+\returns
+The value returned by the call to \tcode{try_lock_until(abs_time)}.
 
 \pnum
-\ensures \tcode{owns == res}, where \tcode{res} is the value returned by
+\ensures
+\tcode{owns == res}, where \tcode{res} is the value returned by
 the call to \tcode{try_lock_until(abs_time)}.
 
 \pnum
-\throws Any exception thrown by \tcode{pm->try_lock_until()}. \tcode{system_error} when an
+\throws
+Any exception thrown by \tcode{pm->try_lock_until()}. \tcode{system_error} when an
 exception is required\iref{thread.req.exception}.
 
 \pnum
@@ -3152,16 +3312,20 @@ template<class Rep, class Period>
 \requires The supplied \tcode{Mutex} type shall meet the \oldconcept{TimedLockable} requirements\iref{thread.req.lockable.timed}.
 
 \pnum
-\effects As if by \tcode{pm->try_lock_for(rel_time)}.
+\effects
+As if by \tcode{pm->try_lock_for(rel_time)}.
 
 \pnum
-\returns The value returned by the call to \tcode{try_lock_until(rel_time)}.
+\returns
+The value returned by the call to \tcode{try_lock_until(rel_time)}.
 
 \pnum
-\ensures \tcode{owns == res}, where \tcode{res} is the value returned by the call to \tcode{try_lock_for(rel_time)}.
+\ensures
+\tcode{owns == res}, where \tcode{res} is the value returned by the call to \tcode{try_lock_for(rel_time)}.
 
 \pnum
-\throws Any exception thrown by \tcode{pm->try_lock_for()}. \tcode{system_error} when an
+\throws
+Any exception thrown by \tcode{pm->try_lock_for()}. \tcode{system_error} when an
 exception is required\iref{thread.req.exception}.
 
 \pnum
@@ -3180,13 +3344,16 @@ void unlock();
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{pm->unlock()}.
+\effects
+As if by \tcode{pm->unlock()}.
 
 \pnum
-\ensures \tcode{owns == false}.
+\ensures
+\tcode{owns == false}.
 
 \pnum
-\throws \tcode{system_error} when
+\throws
+\tcode{system_error} when
 an exception is required\iref{thread.req.exception}.
 
 \pnum
@@ -3205,7 +3372,8 @@ void swap(unique_lock& u) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Swaps the data members of \tcode{*this} and \tcode{u}.
+\effects
+Swaps the data members of \tcode{*this} and \tcode{u}.
 \end{itemdescr}
 
 \indexlibrarymember{release}{unique_lock}%
@@ -3215,10 +3383,12 @@ mutex_type* release() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns The previous value of \tcode{pm}.
+\returns
+The previous value of \tcode{pm}.
 
 \pnum
-\ensures \tcode{pm == 0} and \tcode{owns == false}.
+\ensures
+\tcode{pm == 0} and \tcode{owns == false}.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{unique_lock}%
@@ -3229,7 +3399,8 @@ template<class Mutex>
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{x.swap(y)}.
+\effects
+As if by \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \rSec4[thread.lock.unique.obs]{Observers}
@@ -3241,7 +3412,8 @@ bool owns_lock() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{owns}.
+\returns
+\tcode{owns}.
 \end{itemdescr}
 
 \indexlibrarymember{operator bool}{unique_lock}%
@@ -3251,7 +3423,8 @@ explicit operator bool() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{owns}.
+\returns
+\tcode{owns}.
 \end{itemdescr}
 
 \indexlibrarymember{mutex}{unique_lock}%
@@ -3261,7 +3434,8 @@ mutex_type *mutex() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{pm}.
+\returns
+\tcode{pm}.
 \end{itemdescr}
 
 \rSec3[thread.lock.shared]{Class template \tcode{shared_lock}}
@@ -3345,10 +3519,12 @@ shared_lock() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an object of type \tcode{shared_lock}.
+\effects
+Constructs an object of type \tcode{shared_lock}.
 
 \pnum
-\ensures \tcode{pm == nullptr} and \tcode{owns == false}.
+\ensures
+\tcode{pm == nullptr} and \tcode{owns == false}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{shared_lock}!constructor}%
@@ -3361,10 +3537,12 @@ explicit shared_lock(mutex_type& m);
 \requires The calling thread does not own the mutex for any ownership mode.
 
 \pnum
-\effects Constructs an object of type \tcode{shared_lock} and calls \tcode{m.lock_shared()}.
+\effects
+Constructs an object of type \tcode{shared_lock} and calls \tcode{m.lock_shared()}.
 
 \pnum
-\ensures \tcode{pm == addressof(m)} and \tcode{owns == true}.
+\ensures
+\tcode{pm == addressof(m)} and \tcode{owns == true}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{shared_lock}!constructor}%
@@ -3374,10 +3552,12 @@ shared_lock(mutex_type& m, defer_lock_t) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an object of type \tcode{shared_lock}.
+\effects
+Constructs an object of type \tcode{shared_lock}.
 
 \pnum
-\ensures \tcode{pm == addressof(m)} and \tcode{owns == false}.
+\ensures
+\tcode{pm == addressof(m)} and \tcode{owns == false}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{shared_lock}!constructor}%
@@ -3390,10 +3570,12 @@ shared_lock(mutex_type& m, try_to_lock_t);
 \requires The calling thread does not own the mutex for any ownership mode.
 
 \pnum
-\effects Constructs an object of type \tcode{shared_lock} and calls \tcode{m.try_lock_shared()}.
+\effects
+Constructs an object of type \tcode{shared_lock} and calls \tcode{m.try_lock_shared()}.
 
 \pnum
-\ensures \tcode{pm == addressof(m)} and \tcode{owns == res}
+\ensures
+\tcode{pm == addressof(m)} and \tcode{owns == res}
 where \tcode{res} is the
 value returned by the call to \tcode{m.try_lock_shared()}.
 \end{itemdescr}
@@ -3408,10 +3590,12 @@ shared_lock(mutex_type& m, adopt_lock_t);
 \requires The calling thread has shared ownership of the mutex.
 
 \pnum
-\effects Constructs an object of type \tcode{shared_lock}.
+\effects
+Constructs an object of type \tcode{shared_lock}.
 
 \pnum
-\ensures \tcode{pm == addressof(m)} and \tcode{owns == true}.
+\ensures
+\tcode{pm == addressof(m)} and \tcode{owns == true}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{shared_lock}!constructor}%
@@ -3426,11 +3610,13 @@ template<class Clock, class Duration>
 \requires The calling thread does not own the mutex for any ownership mode.
 
 \pnum
-\effects Constructs an object of type \tcode{shared_lock} and calls
+\effects
+Constructs an object of type \tcode{shared_lock} and calls
 \tcode{m.try_lock_shared_until(abs_time)}.
 
 \pnum
-\ensures \tcode{pm == addressof(m)} and \tcode{owns == res}
+\ensures
+\tcode{pm == addressof(m)} and \tcode{owns == res}
 where \tcode{res}
 is the value returned by the call to \tcode{m.try_lock_shared_until(abs_time)}.
 \end{itemdescr}
@@ -3447,11 +3633,13 @@ template<class Rep, class Period>
 \requires The calling thread does not own the mutex for any ownership mode.
 
 \pnum
-\effects Constructs an object of type \tcode{shared_lock} and calls
+\effects
+Constructs an object of type \tcode{shared_lock} and calls
 \tcode{m.try_lock_shared_for(rel_time)}.
 
 \pnum
-\ensures \tcode{pm == addressof(m)} and \tcode{owns == res}
+\ensures
+\tcode{pm == addressof(m)} and \tcode{owns == res}
 where \tcode{res} is
 the value returned by the call to \tcode{m.try_lock_shared_for(rel_time)}.
 \end{itemdescr}
@@ -3463,7 +3651,8 @@ the value returned by the call to \tcode{m.try_lock_shared_for(rel_time)}.
 
 \begin{itemdescr}
 \pnum
-\effects If \tcode{owns} calls \tcode{pm->unlock_shared()}.
+\effects
+If \tcode{owns} calls \tcode{pm->unlock_shared()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{shared_lock}!constructor}%
@@ -3473,7 +3662,8 @@ shared_lock(shared_lock&& sl) noexcept;
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{pm == sl_p.pm} and \tcode{owns == sl_p.owns} (where
+\ensures
+\tcode{pm == sl_p.pm} and \tcode{owns == sl_p.owns} (where
 \tcode{sl_p} is the state of \tcode{sl} just prior to this construction),
 \tcode{sl.pm == nullptr} and \tcode{sl.owns == false}.
 \end{itemdescr}
@@ -3485,10 +3675,12 @@ shared_lock& operator=(shared_lock&& sl) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects If \tcode{owns} calls \tcode{pm->unlock_shared()}.
+\effects
+If \tcode{owns} calls \tcode{pm->unlock_shared()}.
 
 \pnum
-\ensures \tcode{pm == sl_p.pm} and \tcode{owns == sl_p.owns} (where
+\ensures
+\tcode{pm == sl_p.pm} and \tcode{owns == sl_p.owns} (where
 \tcode{sl_p} is the state of \tcode{sl} just prior to this assignment),
 \tcode{sl.pm == nullptr} and \tcode{sl.owns == false}.
 \end{itemdescr}
@@ -3502,13 +3694,16 @@ void lock();
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{pm->lock_shared()}.
+\effects
+As if by \tcode{pm->lock_shared()}.
 
 \pnum
-\ensures \tcode{owns == true}.
+\ensures
+\tcode{owns == true}.
 
 \pnum
-\throws Any exception thrown by \tcode{pm->lock_shared()}.
+\throws
+Any exception thrown by \tcode{pm->lock_shared()}.
 \tcode{system_error} when an exception is required\iref{thread.req.exception}.
 
 \pnum
@@ -3527,17 +3722,21 @@ bool try_lock();
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{pm->try_lock_shared()}.
+\effects
+As if by \tcode{pm->try_lock_shared()}.
 
 \pnum
-\returns The value returned by the call to \tcode{pm->try_lock_shared()}.
+\returns
+The value returned by the call to \tcode{pm->try_lock_shared()}.
 
 \pnum
-\ensures \tcode{owns == res}, where \tcode{res} is the value returned by
+\ensures
+\tcode{owns == res}, where \tcode{res} is the value returned by
 the call to \tcode{pm->try_lock_shared()}.
 
 \pnum
-\throws Any exception thrown by \tcode{pm->try_lock_shared()}.
+\throws
+Any exception thrown by \tcode{pm->try_lock_shared()}.
 \tcode{system_error} when an exception is required\iref{thread.req.exception}.
 
 \pnum
@@ -3557,18 +3756,22 @@ template<class Clock, class Duration>
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{pm->try_lock_shared_until(abs_time)}.
+\effects
+As if by \tcode{pm->try_lock_shared_until(abs_time)}.
 
 \pnum
-\returns The value returned by the call to
+\returns
+The value returned by the call to
 \tcode{pm->try_lock_shared_until(abs_time)}.
 
 \pnum
-\ensures \tcode{owns == res}, where \tcode{res} is the value returned by
+\ensures
+\tcode{owns == res}, where \tcode{res} is the value returned by
 the call to \tcode{pm->try_lock_shared_until(abs_time)}.
 
 \pnum
-\throws Any exception thrown by \tcode{pm->try_lock_shared_until(abs_time)}.
+\throws
+Any exception thrown by \tcode{pm->try_lock_shared_until(abs_time)}.
 \tcode{system_error} when an exception is required\iref{thread.req.exception}.
 
 \pnum
@@ -3588,16 +3791,20 @@ template<class Rep, class Period>
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{pm->try_lock_shared_for(rel_time)}.
+\effects
+As if by \tcode{pm->try_lock_shared_for(rel_time)}.
 
 \pnum
-\returns The value returned by the call to \tcode{pm->try_lock_shared_for(rel_time)}.
+\returns
+The value returned by the call to \tcode{pm->try_lock_shared_for(rel_time)}.
 
 \pnum
-\ensures \tcode{owns == res}, where \tcode{res} is the value returned by the call to \tcode{pm->try_lock_shared_for(rel_time)}.
+\ensures
+\tcode{owns == res}, where \tcode{res} is the value returned by the call to \tcode{pm->try_lock_shared_for(rel_time)}.
 
 \pnum
-\throws Any exception thrown by \tcode{pm->try_lock_shared_for(rel_time)}. \tcode{system_error} when an exception is required\iref{thread.req.exception}.
+\throws
+Any exception thrown by \tcode{pm->try_lock_shared_for(rel_time)}. \tcode{system_error} when an exception is required\iref{thread.req.exception}.
 
 \pnum
 \errors
@@ -3615,13 +3822,16 @@ void unlock();
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{pm->unlock_shared()}.
+\effects
+As if by \tcode{pm->unlock_shared()}.
 
 \pnum
-\ensures \tcode{owns == false}.
+\ensures
+\tcode{owns == false}.
 
 \pnum
-\throws \tcode{system_error} when an exception is required\iref{thread.req.exception}.
+\throws
+\tcode{system_error} when an exception is required\iref{thread.req.exception}.
 
 \pnum
 \errors
@@ -3640,7 +3850,8 @@ void swap(shared_lock& sl) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Swaps the data members of \tcode{*this} and \tcode{sl}.
+\effects
+Swaps the data members of \tcode{*this} and \tcode{sl}.
 \end{itemdescr}
 
 \indexlibrarymember{release}{shared_lock}%
@@ -3650,10 +3861,12 @@ mutex_type* release() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns The previous value of \tcode{pm}.
+\returns
+The previous value of \tcode{pm}.
 
 \pnum
-\ensures \tcode{pm == nullptr} and \tcode{owns == false}.
+\ensures
+\tcode{pm == nullptr} and \tcode{owns == false}.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{shared_lock}%
@@ -3664,7 +3877,8 @@ template<class Mutex>
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{x.swap(y)}.
+\effects
+As if by \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \rSec4[thread.lock.shared.obs]{Observers}
@@ -3676,7 +3890,8 @@ bool owns_lock() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{owns}.
+\returns
+\tcode{owns}.
 \end{itemdescr}
 
 \indexlibrarymember{operator bool}{shared_lock}%
@@ -3686,7 +3901,8 @@ explicit operator bool() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{owns}.
+\returns
+\tcode{owns}.
 \end{itemdescr}
 
 \indexlibrarymember{mutex}{shared_lock}%
@@ -3696,7 +3912,8 @@ mutex_type* mutex() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{pm}.
+\returns
+\tcode{pm}.
 \end{itemdescr}
 
 \rSec2[thread.lock.algorithm]{Generic locking algorithms}
@@ -3713,14 +3930,16 @@ template<class L1, class L2, class... L3> int try_lock(L1&, L2&, L3&...);
 \end{note}
 
 \pnum
-\effects Calls \tcode{try_lock()} for each argument in order beginning with the
+\effects
+Calls \tcode{try_lock()} for each argument in order beginning with the
 first until all arguments have been processed or a call to \tcode{try_lock()} fails,
 either by returning \tcode{false} or by throwing an exception. If a call to
 \tcode{try_lock()} fails, \tcode{unlock()} is called for all prior arguments
 with no further calls to \tcode{try_lock()}.
 
 \pnum
-\returns \tcode{-1} if all calls to \tcode{try_lock()} returned \tcode{true},
+\returns
+\tcode{-1} if all calls to \tcode{try_lock()} returned \tcode{true},
 otherwise a zero-based index value that indicates the argument for which \tcode{try_lock()}
 returned \tcode{false}.
 \end{itemdescr}
@@ -3738,7 +3957,8 @@ template<class L1, class L2, class... L3> void lock(L1&, L2&, L3&...);
 \end{note}
 
 \pnum
-\effects All arguments are locked via a sequence of calls to \tcode{lock()},
+\effects
+All arguments are locked via a sequence of calls to \tcode{lock()},
 \tcode{try_lock()}, or \tcode{unlock()} on each argument. The sequence of calls does
 not result in deadlock, but is otherwise unspecified. \begin{note} A deadlock avoidance
 algorithm such as try-and-back-off must be used, but the specific algorithm is not
@@ -3775,13 +3995,16 @@ constexpr once_flag() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an object of type \tcode{once_flag}.
+\effects
+Constructs an object of type \tcode{once_flag}.
 
 \pnum
-\sync The construction of a \tcode{once_flag} object is not synchronized.
+\sync
+The construction of a \tcode{once_flag} object is not synchronized.
 
 \pnum
-\ensures The object's internal state is set to indicate to an invocation of
+\ensures
+The object's internal state is set to indicate to an invocation of
 \tcode{call_once} with the object as its initial argument that no function has been
 called.
 \end{itemdescr}
@@ -3803,7 +4026,8 @@ template<class Callable, class... Args>
 (see \ref{func.require}) shall be a valid expression.
 
 \pnum
-\effects An execution of \tcode{call_once} that does not call its \tcode{func} is a
+\effects
+An execution of \tcode{call_once} that does not call its \tcode{func} is a
 \term{passive} execution. An execution of \tcode{call_once} that calls its \tcode{func}
 is an \term{active} execution. An active execution shall call
 \tcode{\placeholdernc{INVOKE}(\brk{}%
@@ -3819,13 +4043,15 @@ executions allow other threads to reliably observe the results produced by the
 earlier returning execution. \end{note}
 
 \pnum
-\sync For any given \tcode{once_flag}: all active executions occur in a total
+\sync
+For any given \tcode{once_flag}: all active executions occur in a total
 order; completion of an active execution synchronizes with\iref{intro.multithread}
 the start of the next one in this total order; and the returning execution
 synchronizes with the return from all passive executions.
 
 \pnum
-\throws \tcode{system_error} when
+\throws
+\tcode{system_error} when
 an exception is required\iref{thread.req.exception}, or any exception thrown by \tcode{func}.
 
 \pnum
@@ -3927,7 +4153,8 @@ or \tcode{wait_until}) threads.
 \end{itemize}
 
 \pnum
-\effects Transfers ownership of the lock associated with \tcode{lk} into
+\effects
+Transfers ownership of the lock associated with \tcode{lk} into
 internal storage and schedules \tcode{cond} to be notified when the current
 thread exits, after all objects of thread storage duration associated with
 the current thread have been destroyed. This notification shall be as if:
@@ -3937,7 +4164,8 @@ cond.notify_all();
 \end{codeblock}
 
 \pnum
-\sync The implied \tcode{lk.unlock()} call is sequenced after the destruction of
+\sync
+The implied \tcode{lk.unlock()} call is sequenced after the destruction of
 all objects with thread storage duration associated with the current thread.
 
 \pnum
@@ -4008,10 +4236,12 @@ condition_variable();
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an object of type \tcode{condition_variable}.
+\effects
+Constructs an object of type \tcode{condition_variable}.
 
 \pnum
-\throws \tcode{system_error} when an exception is required\iref{thread.req.exception}.
+\throws
+\tcode{system_error} when an exception is required\iref{thread.req.exception}.
 
 \pnum
 \errors
@@ -4039,7 +4269,8 @@ using the overloads of \tcode{wait}, \tcode{wait_for}, or \tcode{wait_until} tha
 \end{note}
 
 \pnum
-\effects Destroys the object.
+\effects
+Destroys the object.
 \end{itemdescr}
 
 \indexlibrarymember{notify_one}{condition_variable}%
@@ -4049,7 +4280,8 @@ void notify_one() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects If any threads are blocked waiting for \tcode{*this}, unblocks one of those threads.
+\effects
+If any threads are blocked waiting for \tcode{*this}, unblocks one of those threads.
 \end{itemdescr}
 
 \indexlibrarymember{notify_all}{condition_variable}%
@@ -4059,7 +4291,8 @@ void notify_all() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Unblocks all threads that are blocked waiting for \tcode{*this}.
+\effects
+Unblocks all threads that are blocked waiting for \tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{wait}{condition_variable}%
@@ -4094,11 +4327,13 @@ shall be called\iref{except.terminate}.
 \begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
 
 \pnum
-\ensures \tcode{lock.owns_lock()} is \tcode{true} and \tcode{lock.mutex()}
+\ensures
+\tcode{lock.owns_lock()} is \tcode{true} and \tcode{lock.mutex()}
 is locked by the calling thread.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 
 \end{itemdescr}
 
@@ -4121,7 +4356,8 @@ arguments supplied by all concurrently waiting (via \tcode{wait},
 \end{itemize}
 
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 while (!pred())
   wait(lock);
@@ -4134,11 +4370,13 @@ shall be called\iref{except.terminate}.
 \begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
 
 \pnum
-\ensures \tcode{lock.owns_lock()} is \tcode{true} and \tcode{lock.mutex()}
+\ensures
+\tcode{lock.owns_lock()} is \tcode{true} and \tcode{lock.mutex()}
 is locked by the calling thread.
 
 \pnum
-\throws Any exception thrown by \tcode{pred}.
+\throws
+Any exception thrown by \tcode{pred}.
 
 \end{itemdescr}
 
@@ -4185,16 +4423,19 @@ shall be called\iref{except.terminate}.
 \begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
 
 \pnum
-\ensures \tcode{lock.owns_lock()} is \tcode{true} and \tcode{lock.mutex()}
+\ensures
+\tcode{lock.owns_lock()} is \tcode{true} and \tcode{lock.mutex()}
 is locked by the calling thread.
 
 \pnum
-\returns \tcode{cv_status::timeout} if
+\returns
+\tcode{cv_status::timeout} if
 the absolute timeout\iref{thread.req.timing} specified by \tcode{abs_time} expired,
 otherwise \tcode{cv_status::no_timeout}.
 
 \pnum
-\throws Timeout-related
+\throws
+Timeout-related
 exceptions\iref{thread.req.timing}.
 
 \end{itemdescr}
@@ -4218,13 +4459,15 @@ supplied by all concurrently waiting (via \tcode{wait}, \tcode{wait_for}, or
 \end{itemize}
 
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return wait_until(lock, chrono::steady_clock::now() + rel_time);
 \end{codeblock}
 
 \pnum
-\returns \tcode{cv_status::timeout} if
+\returns
+\tcode{cv_status::timeout} if
 the relative timeout\iref{thread.req.timing} specified by \tcode{rel_time} expired,
 otherwise \tcode{cv_status::no_timeout}.
 
@@ -4235,11 +4478,13 @@ shall be called\iref{except.terminate}.
 \begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
 
 \pnum
-\ensures \tcode{lock.owns_lock()} is \tcode{true} and \tcode{lock.mutex()}
+\ensures
+\tcode{lock.owns_lock()} is \tcode{true} and \tcode{lock.mutex()}
 is locked by the calling thread.
 
 \pnum
-\throws Timeout-related
+\throws
+Timeout-related
 exceptions\iref{thread.req.timing}.
 
 \end{itemdescr}
@@ -4265,7 +4510,8 @@ arguments supplied by all concurrently waiting (via \tcode{wait},
 \end{itemize}
 
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 while (!pred())
   if (wait_until(lock, abs_time) == cv_status::timeout)
@@ -4280,7 +4526,8 @@ shall be called\iref{except.terminate}.
 \begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
 
 \pnum
-\ensures \tcode{lock.owns_lock()} is \tcode{true} and \tcode{lock.mutex()}
+\ensures
+\tcode{lock.owns_lock()} is \tcode{true} and \tcode{lock.mutex()}
 is locked by the calling thread.
 
 \pnum
@@ -4288,7 +4535,8 @@ is locked by the calling thread.
 \tcode{true} regardless of whether the timeout was triggered. \end{note}
 
 \pnum
-\throws Timeout-related
+\throws
+Timeout-related
 exceptions\iref{thread.req.timing} or any exception thrown by \tcode{pred}.
 
 \end{itemdescr}
@@ -4316,7 +4564,8 @@ supplied by all concurrently waiting (via \tcode{wait}, \tcode{wait_for}, or
 \end{itemize}
 
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return wait_until(lock, chrono::steady_clock::now() + rel_time, std::move(pred));
 \end{codeblock}
@@ -4332,7 +4581,8 @@ shall be called\iref{except.terminate}.
 \begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
 
 \pnum
-\ensures \tcode{lock.owns_lock()} is \tcode{true} and \tcode{lock.mutex()}
+\ensures
+\tcode{lock.owns_lock()} is \tcode{true} and \tcode{lock.mutex()}
 is locked by the calling thread.
 
 \pnum
@@ -4340,7 +4590,8 @@ is locked by the calling thread.
 regardless of whether the timeout was triggered. \end{note}
 
 \pnum
-\throws Timeout-related
+\throws
+Timeout-related
 exceptions\iref{thread.req.timing} or any exception thrown by \tcode{pred}.
 
 \end{itemdescr}
@@ -4406,10 +4657,12 @@ condition_variable_any();
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an object of type \tcode{condition_variable_any}.
+\effects
+Constructs an object of type \tcode{condition_variable_any}.
 
 \pnum
-\throws \tcode{bad_alloc} or \tcode{system_error} when an exception is
+\throws
+\tcode{bad_alloc} or \tcode{system_error} when an exception is
 required\iref{thread.req.exception}.
 
 \pnum
@@ -4441,7 +4694,8 @@ using the overloads of \tcode{wait}, \tcode{wait_for}, or \tcode{wait_until} tha
 \end{note}
 
 \pnum
-\effects Destroys the object.
+\effects
+Destroys the object.
 \end{itemdescr}
 
 \indexlibrarymember{notify_one}{condition_variable_any}%
@@ -4451,7 +4705,8 @@ void notify_one() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects If any threads are blocked waiting for \tcode{*this}, unblocks one of those threads.
+\effects
+If any threads are blocked waiting for \tcode{*this}, unblocks one of those threads.
 \end{itemdescr}
 
 \indexlibrarymember{notify_all}{condition_variable_any}%
@@ -4461,7 +4716,8 @@ void notify_all() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Unblocks all threads that are blocked waiting for \tcode{*this}.
+\effects
+Unblocks all threads that are blocked waiting for \tcode{*this}.
 \end{itemdescr}
 
 \rSec3[thread.condvarany.wait]{Noninterruptible waits}
@@ -4489,10 +4745,12 @@ shall be called\iref{except.terminate}.
 \begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
 
 \pnum
-\ensures \tcode{lock} is locked by the calling thread.
+\ensures
+\tcode{lock} is locked by the calling thread.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 
 \end{itemdescr}
 
@@ -4504,7 +4762,8 @@ template<class Lock, class Predicate>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 while (!pred())
   wait(lock);
@@ -4544,15 +4803,18 @@ shall be called\iref{except.terminate}.
 \begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
 
 \pnum
-\ensures \tcode{lock} is locked by the calling thread.
+\ensures
+\tcode{lock} is locked by the calling thread.
 
 \pnum
-\returns \tcode{cv_status::timeout} if
+\returns
+\tcode{cv_status::timeout} if
 the absolute timeout\iref{thread.req.timing} specified by \tcode{abs_time} expired,
 otherwise \tcode{cv_status::no_timeout}.
 
 \pnum
-\throws Timeout-related
+\throws
+Timeout-related
 exceptions\iref{thread.req.timing}.
 
 \end{itemdescr}
@@ -4565,13 +4827,15 @@ template<class Lock, class Rep, class Period>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return wait_until(lock, chrono::steady_clock::now() + rel_time);
 \end{codeblock}
 
 \pnum
-\returns \tcode{cv_status::timeout} if
+\returns
+\tcode{cv_status::timeout} if
 the relative timeout\iref{thread.req.timing} specified by \tcode{rel_time} expired,
 otherwise \tcode{cv_status::no_timeout}.
 
@@ -4582,10 +4846,12 @@ shall be called\iref{except.terminate}.
 \begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
 
 \pnum
-\ensures \tcode{lock} is locked by the calling thread.
+\ensures
+\tcode{lock} is locked by the calling thread.
 
 \pnum
-\throws Timeout-related
+\throws
+Timeout-related
 exceptions\iref{thread.req.timing}.
 
 \end{itemdescr}
@@ -4598,7 +4864,8 @@ template<class Lock, class Clock, class Duration, class Predicate>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 while (!pred())
   if (wait_until(lock, abs_time) == cv_status::timeout)
@@ -4623,7 +4890,8 @@ template<class Lock, class Rep, class Period, class Predicate>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return wait_until(lock, chrono::steady_clock::now() + rel_time, std::move(pred));
 \end{codeblock}
@@ -4664,7 +4932,8 @@ The returned value indicates whether the predicate evaluated to
 \end{note}
 
 \pnum
-\ensures \tcode{lock} is locked by the calling thread.
+\ensures
+\tcode{lock} is locked by the calling thread.
 
 \pnum
 \remarks
@@ -4675,7 +4944,8 @@ This can happen if the re-locking of the mutex throws an exception.
 \end{note}
 
 \pnum
-\throws Any exception thrown by \tcode{pred}.
+\throws
+Any exception thrown by \tcode{pred}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -4714,7 +4984,8 @@ regardless of whether the timeout was triggered or a stop request was made.
 \end{note}
 
 \pnum
-\ensures \tcode{lock} is locked by the calling thread.
+\ensures
+\tcode{lock} is locked by the calling thread.
 
 \pnum
 \remarks
@@ -4738,7 +5009,8 @@ template<class Lock, class Rep, class Period, class Predicate>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return wait_until(lock, chrono::steady_clock::now() + rel_time, std::move(pred),
                   std::move(stoken));
@@ -5490,7 +5762,8 @@ const error_category& future_category() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns\ A reference to an object of a type derived from class \tcode{error_category}.
+\returns
+A reference to an object of a type derived from class \tcode{error_category}.
 
 \pnum
 The object's \tcode{default_error_condition} and equivalent virtual functions shall
@@ -5505,7 +5778,8 @@ error_code make_error_code(future_errc e) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{error_code(static_cast<int>(e), future_category())}.
+\returns
+\tcode{error_code(static_cast<int>(e), future_category())}.
 \end{itemdescr}
 
 \indexlibrarymember{make_error_condition}{future_errc}%
@@ -5515,7 +5789,8 @@ error_condition make_error_condition(future_errc e) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{error_condition(static_cast<int>(e), future_category())}.
+\returns
+\tcode{error_condition(static_cast<int>(e), future_category())}.
 \end{itemdescr}
 
 \rSec2[futures.future.error]{Class \tcode{future_error}}
@@ -5543,7 +5818,8 @@ explicit future_error(future_errc e);
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an object of class \tcode{future_error}
+\effects
+Constructs an object of class \tcode{future_error}
 and initializes \tcode{ec_} with \tcode{make_error_code(e)}.
 \end{itemdescr}
 
@@ -5554,7 +5830,8 @@ const error_code& code() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ec_}.
+\returns
+\tcode{ec_}.
 \end{itemdescr}
 
 \indexlibrarymember{what}{future_error}%
@@ -5564,7 +5841,8 @@ const char* what() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns An \ntbs{} incorporating \tcode{code().message()}.
+\returns
+An \ntbs{} incorporating \tcode{code().message()}.
 \end{itemdescr}
 
 \rSec2[futures.state]{Shared state}
@@ -5754,7 +6032,8 @@ template<class Allocator>
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{promise} object and a shared state. The second
+\effects
+Constructs a \tcode{promise} object and a shared state. The second
 constructor uses the allocator \tcode{a} to allocate memory for the shared
 state.
 \end{itemdescr}
@@ -5766,11 +6045,13 @@ promise(promise&& rhs) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a new \tcode{promise} object and transfers ownership of the shared state
+\effects
+Constructs a new \tcode{promise} object and transfers ownership of the shared state
 of \tcode{rhs} (if any) to the newly-constructed object.
 
 \pnum
-\ensures \tcode{rhs} has no shared state.
+\ensures
+\tcode{rhs} has no shared state.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{promise}!destructor}%
@@ -5796,7 +6077,8 @@ Abandons any shared state\iref{futures.state} and then as if
 \tcode{promise(std::move(rhs)).swap(*this)}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{promise}%
@@ -5806,10 +6088,12 @@ void swap(promise& other) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Exchanges the shared state of \tcode{*this} and \tcode{other}.
+\effects
+Exchanges the shared state of \tcode{*this} and \tcode{other}.
 
 \pnum
-\ensures \tcode{*this} has the shared state (if any) that \tcode{other} had
+\ensures
+\tcode{*this} has the shared state (if any) that \tcode{other} had
 prior to the call to \tcode{swap}. \tcode{other} has the shared state (if any) that
 \tcode{*this} had prior to the call to \tcode{swap}.
 \end{itemdescr}
@@ -5821,11 +6105,13 @@ future<R> get_future();
 
 \begin{itemdescr}
 \pnum
-\returns A \tcode{future<R>} object with the same shared state as
+\returns
+A \tcode{future<R>} object with the same shared state as
 \tcode{*this}.
 
 \pnum
-\sync Calls to this function do not introduce
+\sync
+Calls to this function do not introduce
 data races~\iref{intro.multithread} with calls to
 \tcode{set_value},
 \tcode{set_exception},
@@ -5836,7 +6122,8 @@ Such calls need not synchronize with each other.
 \end{note}
 
 \pnum
-\throws \tcode{future_error} if \tcode{*this} has no shared state or if
+\throws
+\tcode{future_error} if \tcode{*this} has no shared state or if
 \tcode{get_future} has already been called on a \tcode{promise} with the same
 shared state as \tcode{*this}.
 
@@ -5861,7 +6148,8 @@ void promise<void>::set_value();
 
 \begin{itemdescr}
 \pnum
-\effects Atomically stores the value \tcode{r} in the shared state and
+\effects
+Atomically stores the value \tcode{r} in the shared state and
 makes that state ready\iref{futures.state}.
 
 \pnum
@@ -5893,11 +6181,13 @@ void set_exception(exception_ptr p);
 \requires \tcode{p} is not null.
 
 \pnum
-\effects Atomically stores the exception pointer \tcode{p} in the shared state
+\effects
+Atomically stores the exception pointer \tcode{p} in the shared state
 and makes that state ready\iref{futures.state}.
 
 \pnum
-\throws \tcode{future_error} if its shared state
+\throws
+\tcode{future_error} if its shared state
 already has a stored value or exception.
 
 \pnum
@@ -5920,7 +6210,8 @@ void promise<void>::set_value_at_thread_exit();
 
 \begin{itemdescr}
 \pnum
-\effects Stores the value \tcode{r} in the shared state without making that
+\effects
+Stores the value \tcode{r} in the shared state without making that
 state ready immediately. Schedules that state to be made ready when the current
 thread exits, after all objects of thread storage duration associated with the
 current thread have been destroyed.
@@ -5954,13 +6245,15 @@ void set_exception_at_thread_exit(exception_ptr p);
 \requires \tcode{p} is not null.
 
 \pnum
-\effects Stores the exception pointer \tcode{p} in the shared state without
+\effects
+Stores the exception pointer \tcode{p} in the shared state without
 making that state ready immediately. Schedules that state to be made ready when
 the current thread exits, after all objects of thread storage duration
 associated with the current thread have been destroyed.
 
 \pnum
-\throws \tcode{future_error} if an error condition occurs.
+\throws
+\tcode{future_error} if an error condition occurs.
 
 \pnum
 \errors
@@ -5979,7 +6272,8 @@ template<class R>
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{x.swap(y)}.
+\effects
+As if by \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \rSec2[futures.unique.future]{Class template \tcode{future}}
@@ -6054,12 +6348,14 @@ future() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an \defnx{empty}{empty \tcode{future} object}
+\effects
+Constructs an \defnx{empty}{empty \tcode{future} object}
 \tcode{future} object that does not refer to a
 shared state.
 
 \pnum
-\ensures \tcode{valid() == false}.
+\ensures
+\tcode{valid() == false}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{future}!constructor}%
@@ -6069,7 +6365,8 @@ future(future&& rhs) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Move constructs a \tcode{future} object that refers to the shared
+\effects
+Move constructs a \tcode{future} object that refers to the shared
 state that
 was originally referred to by \tcode{rhs} (if any).
 
@@ -6132,10 +6429,12 @@ shared_future<R> share() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{shared_future<R>(std::move(*this))}.
+\returns
+\tcode{shared_future<R>(std::move(*this))}.
 
 \pnum
-\ensures \tcode{valid() == false}.
+\ensures
+\tcode{valid() == false}.
 \end{itemdescr}
 
 \indexlibrarymember{get}{future}%
@@ -6175,10 +6474,12 @@ value stored in the shared state;
 \end{itemize}
 
 \pnum
-\throws The stored exception, if an exception was stored in the shared state.
+\throws
+The stored exception, if an exception was stored in the shared state.
 
 \pnum
-\ensures \tcode{valid() == false}.
+\ensures
+\tcode{valid() == false}.
 \end{itemdescr}
 
 \indexlibrarymember{valid}{future}%
@@ -6188,7 +6489,8 @@ bool valid() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{true} only if \tcode{*this} refers to a shared state.
+\returns
+\tcode{true} only if \tcode{*this} refers to a shared state.
 \end{itemdescr}
 
 \indexlibrarymember{wait}{future}%
@@ -6340,12 +6642,14 @@ shared_future() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an \defnx{empty}{empty \tcode{shared_future} object}
+\effects
+Constructs an \defnx{empty}{empty \tcode{shared_future} object}
 \tcode{shared_future} object that does not refer to a
 shared state.
 
 \pnum
-\ensures \tcode{valid() == false}.
+\ensures
+\tcode{valid() == false}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{shared_future}!constructor}%
@@ -6355,11 +6659,13 @@ shared_future(const shared_future& rhs) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{shared_future} object that refers to the same
+\effects
+Constructs a \tcode{shared_future} object that refers to the same
 shared state as \tcode{rhs} (if any).
 
 \pnum
-\ensures \tcode{valid()} returns the same value as \tcode{rhs.valid()}.
+\ensures
+\tcode{valid()} returns the same value as \tcode{rhs.valid()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{shared_future}!constructor}%
@@ -6370,7 +6676,8 @@ shared_future(shared_future&& rhs) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Move constructs a \tcode{shared_future} object that refers to the
+\effects
+Move constructs a \tcode{shared_future} object that refers to the
 shared state that was originally referred to by \tcode{rhs} (if any).
 
 \pnum
@@ -6443,7 +6750,8 @@ assigns the contents of \tcode{rhs} to \tcode{*this}. \begin{note} As a result,
 \end{itemize}
 
 \pnum
-\ensures \tcode{valid() == rhs.valid()}.
+\ensures
+\tcode{valid() == rhs.valid()}.
 \end{itemdescr}
 
 \indexlibrarymember{get}{shared_future}%
@@ -6468,7 +6776,8 @@ introduce a data race\iref{intro.multithread}.
 \end{note}
 
 \pnum
-\effects \tcode{wait()}{s} until the shared state is ready, then retrieves the
+\effects
+\tcode{wait()}{s} until the shared state is ready, then retrieves the
 value stored in the shared state.
 
 \pnum
@@ -6491,7 +6800,8 @@ shared state.
 \end{itemize}
 
 \pnum
-\throws The stored exception, if an exception was stored in the shared state.
+\throws
+The stored exception, if an exception was stored in the shared state.
 \end{itemdescr}
 
 \indexlibrarymember{valid}{shared_future}%
@@ -6501,7 +6811,8 @@ bool valid() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{true} only if \tcode{*this} refers to a shared state.
+\returns
+\tcode{true} only if \tcode{*this} refers to a shared state.
 \end{itemdescr}
 
 \indexlibrarymember{wait}{shared_future}%
@@ -6679,7 +6990,8 @@ in this document nor by the implementation, the behavior is undefined.
 \end{itemize}
 
 \pnum
-\returns An object of type
+\returns
+An object of type
 \tcode{future<invoke_result_t<decay_t<F>, decay_t<Args>...>{>}} that refers
 to the shared state created by this call to \tcode{async}.
 \begin{note} If a future obtained from \tcode{async} is moved outside the local scope,
@@ -6724,7 +7036,8 @@ happens first.
 
 
 \pnum
-\throws \tcode{system_error} if \tcode{policy == launch::async} and the
+\throws
+\tcode{system_error} if \tcode{policy == launch::async} and the
 implementation is unable to start a new thread, or
 \tcode{std::bad_alloc} if memory for the internal data structures
 could not be allocated.
@@ -6818,7 +7131,8 @@ packaged_task() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{packaged_task} object with no shared state and no stored task.
+\effects
+Constructs a \tcode{packaged_task} object with no shared state and no stored task.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{packaged_task}!constructor}%
@@ -6840,7 +7154,8 @@ This constructor shall not participate in overload resolution if \tcode{remove_c
 is the same type as \tcode{packaged_task<R(ArgTypes...)>}.
 
 \pnum
-\effects Constructs a new \tcode{packaged_task} object with a shared state and
+\effects
+Constructs a new \tcode{packaged_task} object with a shared state and
 initializes the object's stored task with \tcode{std::forward<F>(f)}.
 
 \pnum
@@ -6857,12 +7172,14 @@ packaged_task(packaged_task&& rhs) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a new \tcode{packaged_task} object and transfers ownership of
+\effects
+Constructs a new \tcode{packaged_task} object and transfers ownership of
 \tcode{rhs}'s shared state to \tcode{*this}, leaving \tcode{rhs} with no
 shared state. Moves the stored task from \tcode{rhs} to \tcode{*this}.
 
 \pnum
-\ensures \tcode{rhs} has no shared state.
+\ensures
+\tcode{rhs} has no shared state.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{packaged_task}%
@@ -6899,10 +7216,12 @@ void swap(packaged_task& other) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Exchanges the shared states and stored tasks of \tcode{*this} and \tcode{other}.
+\effects
+Exchanges the shared states and stored tasks of \tcode{*this} and \tcode{other}.
 
 \pnum
-\ensures \tcode{*this} has the same shared state
+\ensures
+\tcode{*this} has the same shared state
 and stored task (if any) as \tcode{other}
 prior to the call to \tcode{swap}. \tcode{other} has the same shared state
 and stored task (if any)
@@ -6916,7 +7235,8 @@ bool valid() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{true} only if \tcode{*this} has a shared state.
+\returns
+\tcode{true} only if \tcode{*this} has a shared state.
 \end{itemdescr}
 
 \indexlibrarymember{get_future}{packaged_task}%
@@ -6926,10 +7246,12 @@ future<R> get_future();
 
 \begin{itemdescr}
 \pnum
-\returns A \tcode{future} object that shares the same shared state as \tcode{*this}.
+\returns
+A \tcode{future} object that shares the same shared state as \tcode{*this}.
 
 \pnum
-\sync Calls to this function do not introduce
+\sync
+Calls to this function do not introduce
 data races~\iref{intro.multithread} with calls to
 \tcode{operator()} or
 \tcode{make_ready_at_thread_exit}.
@@ -6938,7 +7260,8 @@ Such calls need not synchronize with each other.
 \end{note}
 
 \pnum
-\throws A \tcode{future_error} object if an error occurs.
+\throws
+A \tcode{future_error} object if an error occurs.
 
 \pnum
 \errors
@@ -6956,7 +7279,8 @@ void operator()(ArgTypes... args);
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{\placeholdernc{INVOKE}<R>(f, t$_1$, t$_2$, $\dotsc$, t$_N$)}\iref{func.require},
+\effects
+As if by \tcode{\placeholdernc{INVOKE}<R>(f, t$_1$, t$_2$, $\dotsc$, t$_N$)}\iref{func.require},
 where \tcode{f} is the
 stored task of \tcode{*this} and
 \tcode{t$_1$, t$_2$, $\dotsc$, t$_N$} are the values in \tcode{args...}. If the task returns normally,
@@ -6967,7 +7291,8 @@ function waiting for
 the shared state of \tcode{*this} to become ready are unblocked.
 
 \pnum
-\throws A \tcode{future_error} exception object if there is no shared
+\throws
+A \tcode{future_error} exception object if there is no shared
 state or the stored task has already been invoked.
 
 \pnum
@@ -6986,7 +7311,8 @@ void make_ready_at_thread_exit(ArgTypes... args);
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{\placeholdernc{INVOKE}<R>(f, t$_1$, t$_2$, $\dotsc$, t$_N$)}\iref{func.require},
+\effects
+As if by \tcode{\placeholdernc{INVOKE}<R>(f, t$_1$, t$_2$, $\dotsc$, t$_N$)}\iref{func.require},
 where \tcode{f} is the stored task and
 \tcode{t$_1$, t$_2$, $\dotsc$, t$_N$} are the values in \tcode{args...}. If the task returns normally,
 the return value is stored as the asynchronous result in the shared state of
@@ -6997,7 +7323,8 @@ after all objects of thread storage duration associated with the current thread
 have been destroyed.
 
 \pnum
-\throws \tcode{future_error} if an error condition occurs.
+\throws
+\tcode{future_error} if an error condition occurs.
 
 \pnum
 \errors
@@ -7015,7 +7342,8 @@ void reset();
 
 \begin{itemdescr}
 \pnum
-\effects As if \tcode{*this = packaged_task(std::move(f))}, where
+\effects
+As if \tcode{*this = packaged_task(std::move(f))}, where
 \tcode{f} is the task stored in
 \tcode{*this}. \begin{note} This constructs a new shared state for \tcode{*this}. The
 old state is abandoned\iref{futures.state}. \end{note}
@@ -7041,5 +7369,6 @@ template<class R, class... ArgTypes>
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{x.swap(y)}.
+\effects
+As if by \tcode{x.swap(y)}.
 \end{itemdescr}

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -1030,7 +1030,8 @@ namespace std {
 }
 \end{codeblock}
 
-\pnum An object of type \tcode{thread::id} provides a unique identifier for
+\pnum
+An object of type \tcode{thread::id} provides a unique identifier for
 each thread of execution and a single distinct value for all \tcode{thread}
 objects that do not represent a thread of
 execution\iref{thread.thread.class}. Each thread of execution has an
@@ -1053,9 +1054,11 @@ id() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects Constructs an object of type \tcode{id}.
+\pnum
+\effects Constructs an object of type \tcode{id}.
 
-\pnum\ensures The constructed object does not represent a thread of execution.
+\pnum
+\ensures The constructed object does not represent a thread of execution.
 \end{itemdescr}
 
 \indexlibrarymember{operator==}{thread::id}%
@@ -1064,7 +1067,8 @@ bool operator==(thread::id x, thread::id y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{true} only if \tcode{x} and \tcode{y} represent the same
+\pnum
+\returns \tcode{true} only if \tcode{x} and \tcode{y} represent the same
 thread of execution or neither \tcode{x} nor \tcode{y} represents a thread of
 execution.
 \end{itemdescr}
@@ -1096,13 +1100,15 @@ template<class charT, class traits>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects Inserts an unspecified text representation of \tcode{id} into
+\pnum
+\effects Inserts an unspecified text representation of \tcode{id} into
 \tcode{out}. For two objects of type \tcode{thread::id} \tcode{x} and \tcode{y},
 if \tcode{x == y} the \tcode{thread::id} objects have the same text
 representation and if \tcode{x != y} the \tcode{thread::id} objects have
 distinct text representations.
 
-\pnum\returns \tcode{out}.
+\pnum
+\returns \tcode{out}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{hash}!\idxcode{thread::id}}%
@@ -1111,7 +1117,8 @@ template<> struct hash<thread::id>;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum The specialization is enabled\iref{unord.hash}.
+\pnum
+The specialization is enabled\iref{unord.hash}.
 \end{itemdescr}
 
 \rSec3[thread.thread.constr]{Constructors}
@@ -1122,9 +1129,11 @@ thread() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects Constructs a \tcode{thread} object that does not represent a thread of execution.
+\pnum
+\effects Constructs a \tcode{thread} object that does not represent a thread of execution.
 
-\pnum\ensures \tcode{get_id() == id()}.
+\pnum
+\ensures \tcode{get_id() == id()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{thread}!constructor}%
@@ -1168,14 +1177,18 @@ std::forward<Args>(args))...)}
 termi\-nates with an uncaught exception, \tcode{terminate} shall be called.
 
 
-\pnum\sync The completion of the invocation of the constructor
+\pnum
+\sync The completion of the invocation of the constructor
 synchronizes with the beginning of the invocation of the copy of \tcode{f}.
 
-\pnum\ensures \tcode{get_id() != id()}. \tcode{*this} represents the newly started thread.
+\pnum
+\ensures \tcode{get_id() != id()}. \tcode{*this} represents the newly started thread.
 
-\pnum\throws \tcode{system_error} if unable to start the new thread.
+\pnum
+\throws \tcode{system_error} if unable to start the new thread.
 
-\pnum\errors
+\pnum
+\errors
 \begin{itemize}
 \item \tcode{resource_unavailable_try_again} --- the system lacked the necessary
 resources to create another thread, or the system-imposed limit on the number of
@@ -1304,12 +1317,15 @@ blocking. When \tcode{detach()} returns, \tcode{*this} no longer represents the 
 thread of execution. When the thread previously represented by \tcode{*this} ends execution, the
 implementation shall release any owned resources.
 
-\pnum\ensures \tcode{get_id() == id()}.
+\pnum
+\ensures \tcode{get_id() == id()}.
 
-\pnum\throws \tcode{system_error} when
+\pnum
+\throws \tcode{system_error} when
 an exception is required\iref{thread.req.exception}.
 
-\pnum \errors
+\pnum
+\errors
 \begin{itemize}
 \item \tcode{no_such_process} --- if the thread is not valid.
 \item \tcode{invalid_argument} --- if the thread is not joinable.
@@ -1350,7 +1366,8 @@ void swap(thread& x, thread& y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects As if by \tcode{x.swap(y)}.
+\pnum
+\effects As if by \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \rSec2[thread.jthread.class]{Class \tcode{jthread}}
@@ -1478,7 +1495,8 @@ If the \tcode{\placeholdernc{INVOKE}} expression exits via an exception,
 \sync The completion of the invocation of the constructor
 synchronizes with the beginning of the invocation of the copy of \tcode{f}.
 
-\pnum\ensures
+\pnum
+\ensures
 \tcode{get_id() != id()} is \tcode{true}
 and \tcode{ssource.stop_possible()} is \tcode{true}
 and \tcode{*this} represents the newly started thread.
@@ -1487,7 +1505,8 @@ The calling thread can make a stop request only once,
 because it cannot replace this stop token.
 \end{note}
 
-\pnum\throws \tcode{system_error} if unable to start the new thread.
+\pnum
+\throws \tcode{system_error} if unable to start the new thread.
 
 \pnum
 \errors
@@ -1638,7 +1657,8 @@ the implementation shall release any owned resources.
 \throws
 \tcode{system_error} when an exception is required\iref{thread.req.exception}.
 
-\pnum \errors
+\pnum
+\errors
 \begin{itemize}
 \item \tcode{no_such_process} --- if the thread is not valid.
 \item \tcode{invalid_argument} --- if the thread is not joinable.
@@ -1926,7 +1946,8 @@ thread does not own the mutex.
 \throws \tcode{system_error} when
 an exception is required\iref{thread.req.exception}.
 
-\pnum \errors
+\pnum
+\errors
 \begin{itemize}
 \item \tcode{operation_not_permitted} --- if the thread does not have the
 privilege to perform the operation.
@@ -2150,7 +2171,8 @@ lock is available, but implementations are expected to make a strong effort to d
 \sync If \tcode{try_lock_for()} returns \tcode{true}, prior \tcode{unlock()} operations
 on the same object \term{synchronize with}\iref{intro.multithread} this operation.
 
-\pnum\throws Timeout-related exceptions\iref{thread.req.timing}.
+\pnum
+\throws Timeout-related exceptions\iref{thread.req.timing}.
 \end{itemdescr}
 
 \pnum
@@ -2173,7 +2195,8 @@ return before the absolute timeout\iref{thread.req.timing} specified by
 be obtained if the lock is available, but implementations are expected to make a
 strong effort to do so. \end{note}
 
-\pnum\returntype \tcode{bool}.
+\pnum
+\returntype \tcode{bool}.
 
 \pnum
 \returns \tcode{true} if ownership was obtained, otherwise \tcode{false}.
@@ -2183,7 +2206,8 @@ strong effort to do so. \end{note}
 operations on the same object \term{synchronize with}\iref{intro.multithread}
 this operation.
 
-\pnum\throws Timeout-related exceptions\iref{thread.req.timing}.
+\pnum
+\throws Timeout-related exceptions\iref{thread.req.timing}.
 \end{itemdescr}
 
 \rSec4[thread.timedmutex.class]{Class \tcode{timed_mutex}}
@@ -2987,7 +3011,8 @@ unique_lock(unique_lock&& u) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\ensures \tcode{pm == u_p.pm} and \tcode{owns == u_p.owns} (where \tcode{u_p} is the state of \tcode{u} just prior to this construction),  \tcode{u.pm == 0} and \tcode{u.owns == false}.
+\pnum
+\ensures \tcode{pm == u_p.pm} and \tcode{owns == u_p.owns} (where \tcode{u_p} is the state of \tcode{u} just prior to this construction),  \tcode{u.pm == 0} and \tcode{u.owns == false}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{unique_lock}%
@@ -2996,14 +3021,17 @@ unique_lock& operator=(unique_lock&& u);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects If \tcode{owns} calls \tcode{pm->unlock()}.
+\pnum
+\effects If \tcode{owns} calls \tcode{pm->unlock()}.
 
-\pnum\ensures \tcode{pm == u_p.pm} and \tcode{owns == u_p.owns} (where \tcode{u_p} is the state of \tcode{u} just prior to this construction),  \tcode{u.pm == 0} and \tcode{u.owns == false}.
+\pnum
+\ensures \tcode{pm == u_p.pm} and \tcode{owns == u_p.owns} (where \tcode{u_p} is the state of \tcode{u} just prior to this construction),  \tcode{u.pm == 0} and \tcode{u.owns == false}.
 
 \pnum
 \begin{note} With a recursive mutex it is possible for both \tcode{*this} and \tcode{u} to own the same mutex before the assignment. In this case, \tcode{*this} will own the mutex after the assignment and \tcode{u} will not. \end{note}
 
-\pnum\throws Nothing.
+\pnum
+\throws Nothing.
 \end{itemdescr}
 
 
@@ -3013,7 +3041,8 @@ unique_lock& operator=(unique_lock&& u);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects If \tcode{owns} calls \tcode{pm->unlock()}.
+\pnum
+\effects If \tcode{owns} calls \tcode{pm->unlock()}.
 \end{itemdescr}
 
 \rSec4[thread.lock.unique.locking]{Locking}
@@ -3057,7 +3086,8 @@ requirements\iref{thread.req.lockable.req}.
 \pnum
 \effects As if by \tcode{pm->try_lock()}.
 
-\pnum\returns The value returned by the call to \tcode{try_lock()}.
+\pnum
+\returns The value returned by the call to \tcode{try_lock()}.
 
 \pnum
 \ensures \tcode{owns == res}, where \tcode{res} is the value returned by
@@ -3149,14 +3179,18 @@ void unlock();
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects As if by \tcode{pm->unlock()}.
+\pnum
+\effects As if by \tcode{pm->unlock()}.
 
-\pnum\ensures \tcode{owns == false}.
+\pnum
+\ensures \tcode{owns == false}.
 
-\pnum\throws \tcode{system_error} when
+\pnum
+\throws \tcode{system_error} when
 an exception is required\iref{thread.req.exception}.
 
-\pnum \errors
+\pnum
+\errors
 \begin{itemize}
 \item \tcode{operation_not_permitted} --- if on entry \tcode{owns} is \tcode{false}.
 \end{itemize}
@@ -3170,7 +3204,8 @@ void swap(unique_lock& u) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects Swaps the data members of \tcode{*this} and \tcode{u}.
+\pnum
+\effects Swaps the data members of \tcode{*this} and \tcode{u}.
 \end{itemdescr}
 
 \indexlibrarymember{release}{unique_lock}%
@@ -3179,9 +3214,11 @@ mutex_type* release() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The previous value of \tcode{pm}.
+\pnum
+\returns The previous value of \tcode{pm}.
 
-\pnum\ensures \tcode{pm == 0} and \tcode{owns == false}.
+\pnum
+\ensures \tcode{pm == 0} and \tcode{owns == false}.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{unique_lock}%
@@ -3191,7 +3228,8 @@ template<class Mutex>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects As if by \tcode{x.swap(y)}.
+\pnum
+\effects As if by \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \rSec4[thread.lock.unique.obs]{Observers}
@@ -3202,7 +3240,8 @@ bool owns_lock() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{owns}.
+\pnum
+\returns \tcode{owns}.
 \end{itemdescr}
 
 \indexlibrarymember{operator bool}{unique_lock}%
@@ -3211,7 +3250,8 @@ explicit operator bool() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{owns}.
+\pnum
+\returns \tcode{owns}.
 \end{itemdescr}
 
 \indexlibrarymember{mutex}{unique_lock}%
@@ -3220,7 +3260,8 @@ mutex_type *mutex() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{pm}.
+\pnum
+\returns \tcode{pm}.
 \end{itemdescr}
 
 \rSec3[thread.lock.shared]{Class template \tcode{shared_lock}}
@@ -3733,11 +3774,14 @@ constexpr once_flag() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects Constructs an object of type \tcode{once_flag}.
+\pnum
+\effects Constructs an object of type \tcode{once_flag}.
 
-\pnum\sync The construction of a \tcode{once_flag} object is not synchronized.
+\pnum
+\sync The construction of a \tcode{once_flag} object is not synchronized.
 
-\pnum\ensures The object's internal state is set to indicate to an invocation of
+\pnum
+\ensures The object's internal state is set to indicate to an invocation of
 \tcode{call_once} with the object as its initial argument that no function has been
 called.
 \end{itemdescr}
@@ -3780,7 +3824,8 @@ order; completion of an active execution synchronizes with\iref{intro.multithrea
 the start of the next one in this total order; and the returning execution
 synchronizes with the return from all passive executions.
 
-\pnum\throws \tcode{system_error} when
+\pnum
+\throws \tcode{system_error} when
 an exception is required\iref{thread.req.exception}, or any exception thrown by \tcode{func}.
 
 \pnum
@@ -3993,7 +4038,8 @@ been started, especially when the waiting threads are calling the wait functions
 using the overloads of \tcode{wait}, \tcode{wait_for}, or \tcode{wait_until} that take a predicate.
 \end{note}
 
-\pnum\effects Destroys the object.
+\pnum
+\effects Destroys the object.
 \end{itemdescr}
 
 \indexlibrarymember{notify_one}{condition_variable}%
@@ -4002,7 +4048,8 @@ void notify_one() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects If any threads are blocked waiting for \tcode{*this}, unblocks one of those threads.
+\pnum
+\effects If any threads are blocked waiting for \tcode{*this}, unblocks one of those threads.
 \end{itemdescr}
 
 \indexlibrarymember{notify_all}{condition_variable}%
@@ -4011,7 +4058,8 @@ void notify_all() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects Unblocks all threads that are blocked waiting for \tcode{*this}.
+\pnum
+\effects Unblocks all threads that are blocked waiting for \tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{wait}{condition_variable}%
@@ -4030,7 +4078,8 @@ arguments supplied by all concurrently waiting (via \tcode{wait},
 \tcode{wait_for}, or \tcode{wait_until}) threads.
 \end{itemize}
 
-\pnum\effects
+\pnum
+\effects
 \begin{itemize}
 \item Atomically calls \tcode{lock.unlock()} and blocks on \tcode{*this}.
 \item When unblocked, calls \tcode{lock.lock()} (possibly blocking on the lock), then returns.
@@ -4048,7 +4097,8 @@ shall be called\iref{except.terminate}.
 \ensures \tcode{lock.owns_lock()} is \tcode{true} and \tcode{lock.mutex()}
 is locked by the calling thread.
 
-\pnum\throws Nothing.
+\pnum
+\throws Nothing.
 
 \end{itemdescr}
 
@@ -4143,7 +4193,8 @@ is locked by the calling thread.
 the absolute timeout\iref{thread.req.timing} specified by \tcode{abs_time} expired,
 otherwise \tcode{cv_status::no_timeout}.
 
-\pnum\throws Timeout-related
+\pnum
+\throws Timeout-related
 exceptions\iref{thread.req.timing}.
 
 \end{itemdescr}
@@ -4389,7 +4440,8 @@ been started, especially when the waiting threads are calling the wait functions
 using the overloads of \tcode{wait}, \tcode{wait_for}, or \tcode{wait_until} that take a predicate.
 \end{note}
 
-\pnum\effects Destroys the object.
+\pnum
+\effects Destroys the object.
 \end{itemdescr}
 
 \indexlibrarymember{notify_one}{condition_variable_any}%
@@ -4398,7 +4450,8 @@ void notify_one() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects If any threads are blocked waiting for \tcode{*this}, unblocks one of those threads.
+\pnum
+\effects If any threads are blocked waiting for \tcode{*this}, unblocks one of those threads.
 \end{itemdescr}
 
 \indexlibrarymember{notify_all}{condition_variable_any}%
@@ -4407,7 +4460,8 @@ void notify_all() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects Unblocks all threads that are blocked waiting for \tcode{*this}.
+\pnum
+\effects Unblocks all threads that are blocked waiting for \tcode{*this}.
 \end{itemdescr}
 
 \rSec3[thread.condvarany.wait]{Noninterruptible waits}
@@ -4434,9 +4488,11 @@ If the function fails to meet the postcondition, \tcode{terminate()}
 shall be called\iref{except.terminate}.
 \begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
 
-\pnum\ensures \tcode{lock} is locked by the calling thread.
+\pnum
+\ensures \tcode{lock} is locked by the calling thread.
 
-\pnum\throws Nothing.
+\pnum
+\throws Nothing.
 
 \end{itemdescr}
 
@@ -4462,7 +4518,8 @@ template<class Lock, class Clock, class Duration>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects
+\pnum
+\effects
 
 \begin{itemize}
 \item

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -70,9 +70,11 @@ element.
 Several classes described in this Clause have members \tcode{native_handle_type} and
 \tcode{native_handle}. The presence of these members and their semantics is
 \impldef{presence and meaning of \tcode{native_handle_type} and \tcode{native_handle}}.
-\begin{note} These members allow implementations to provide access
+\begin{note}
+These members allow implementations to provide access
 to implementation details. Their names are specified to facilitate portable compile-time
-detection. Actual use of these members is inherently non-portable. \end{note}
+detection. Actual use of these members is inherently non-portable.
+\end{note}
 
 \rSec2[thread.req.timing]{Timing specifications}
 
@@ -107,12 +109,17 @@ during the timeout, the behavior should be as follows:
 \begin{itemize}
 \item
 if $C_a > C_t$, the waiting function should wake as soon as possible, i.e., $C_a + D_i + D_m$,
-since the timeout is already satisfied. \begin{note} This specification may result in the total
-duration of the wait decreasing when measured against a steady clock. \end{note}
+since the timeout is already satisfied.
+\begin{note}
+This specification may result in the total
+duration of the wait decreasing when measured against a steady clock.
+\end{note}
 
 \item
 if $C_a \leq C_t$, the waiting function should not time out until \tcode{Clock::now()} returns a
-time $C_n \geq C_t$, i.e., waking at $C_t + D_i + D_m$. \begin{note} When the clock is adjusted
+time $C_n \geq C_t$, i.e., waking at $C_t + D_i + D_m$.
+\begin{note}
+When the clock is adjusted
 backwards, this specification may result in the total duration of the wait increasing when
 measured against a steady clock. When the clock is adjusted forwards, this specification may
 result in the total duration of the wait decreasing when measured against a steady clock.
@@ -121,13 +128,17 @@ result in the total duration of the wait decreasing when measured against a stea
 
 An implementation shall return from such a timeout at any point from the time specified above to
 the time it would return from a steady-clock relative timeout on the difference between $C_t$
-and the time point of the call to the \tcode{_until} function. \begin{note} Implementations
+and the time point of the call to the \tcode{_until} function.
+\begin{note}
+Implementations
 should decrease the duration of the wait when the clock is adjusted forwards.
 \end{note}
 
 \pnum
-\begin{note} If the clock is not synchronized with a steady clock, e.g., a CPU time clock, these
-timeouts might not provide useful functionality. \end{note}
+\begin{note}
+If the clock is not synchronized with a steady clock, e.g., a CPU time clock, these
+timeouts might not provide useful functionality.
+\end{note}
 
 \pnum
 The resolution of timing provided by an implementation depends on both operating system
@@ -142,7 +153,8 @@ Implementation-provided clocks that are used for these functions shall meet the
 A function that takes an argument which specifies a timeout will throw if,
 during its execution, a clock, time point, or time duration throws an exception.
 Such exceptions are referred to as \term{timeout-related exceptions}.
-\begin{note} Instantiations of clock, time point and duration types supplied by
+\begin{note}
+Instantiations of clock, time point and duration types supplied by
 the implementation as specified in~\ref{time.clock} do not throw exceptions.
 \end{note}
 
@@ -152,14 +164,20 @@ the implementation as specified in~\ref{time.clock} do not throw exceptions.
 
 \pnum
 An \defn{execution agent} is an entity such as a thread that may perform work in parallel with
-other execution agents. \begin{note} Implementations or users may introduce other kinds of
-agents such as processes or thread-pool tasks. \end{note} The calling agent is determined by
+other execution agents.
+\begin{note}
+Implementations or users may introduce other kinds of
+agents such as processes or thread-pool tasks.
+\end{note}
+The calling agent is determined by
 context, e.g., the calling thread that contains the call, and so on.
 
 \pnum
-\begin{note} Some lockable objects are ``agent oblivious'' in that they work for any
+\begin{note}
+Some lockable objects are ``agent oblivious'' in that they work for any
 execution agent model because they do not determine or store the agent's ID (e.g., an
-ordinary spin lock). \end{note}
+ordinary spin lock).
+\end{note}
 
 \pnum
 The standard library templates \tcode{unique_lock}\iref{thread.lock.unique},
@@ -171,8 +189,10 @@ The standard library templates \tcode{unique_lock}\iref{thread.lock.unique},
 lockable objects. The \oldconcept{BasicLockable} requirements, the \oldconcept{Lockable} requirements,
 and the \oldconcept{TimedLockable} requirements list the requirements imposed by these library types
 in order to acquire or release ownership of a \tcode{lock} by a given execution agent.
-\begin{note} The nature of any lock ownership and any synchronization it may entail are not part
-of these requirements. \end{note}
+\begin{note}
+The nature of any lock ownership and any synchronization it may entail are not part
+of these requirements.
+\end{note}
 
 \rSec3[thread.req.lockable.basic]{\oldconcept{BasicLockable} requirements}
 
@@ -644,7 +664,9 @@ explicit stop_source(nostopstate_t) noexcept;
 \ensures
 \tcode{stop_possible()} is \tcode{false} and
 \tcode{stop_requested()} is \tcode{false}.
-\begin{note} No resources are allocated for the state.  \end{note}
+\begin{note}
+No resources are allocated for the state.
+\end{note}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{stop_source}!constructor}%
@@ -966,7 +988,8 @@ Releases ownership of the stop state, if any.
 
 \pnum
 \ref{thread.threads} describes components that can be used to create and manage threads.
-\begin{note} These threads are intended to map one-to-one with operating system threads.
+\begin{note}
+These threads are intended to map one-to-one with operating system threads.
 \end{note}
 
 \rSec2[thread.syn]{Header \tcode{<thread>} synopsis}
@@ -1003,9 +1026,12 @@ execution. That representation may be transferred to other \tcode{thread} object
 that no two \tcode{thread} objects simultaneously represent the same thread of execution. A
 thread of execution is \term{detached} when no \tcode{thread} object represents that thread.
 Objects of class \tcode{thread} can be in a state that does not represent a thread of
-execution. \begin{note} A \tcode{thread} object does not represent a thread of execution after
+execution.
+\begin{note}
+A \tcode{thread} object does not represent a thread of execution after
 default construction, after being moved from, or after a successful call to \tcode{detach} or
-\tcode{join}. \end{note}
+\tcode{join}.
+\end{note}
 
 \indexlibrary{\idxcode{thread}}%
 \begin{codeblock}
@@ -1078,8 +1104,10 @@ does not represent threads of execution.
 The library may reuse the value of a \tcode{thread::id} of a terminated thread that can no longer be joined.
 
 \pnum
-\begin{note} Relational operators allow \tcode{thread::id} objects to be used as
-keys in associative containers. \end{note}
+\begin{note}
+Relational operators allow \tcode{thread::id} objects to be used as
+keys in associative containers.
+\end{note}
 
 \indexlibrary{\idxcode{thread::id}!constructor}%
 \begin{itemdecl}
@@ -1206,8 +1234,12 @@ std::forward<F>(f)),
 \placeholdernc{decay-copy}(\brk{}%
 std::forward<Args>(\brk{}args))...)} with the calls to
 \tcode{\placeholder{decay-copy}} being evaluated in the constructing thread. Any return value from this invocation
-is ignored. \begin{note} This implies that any exceptions not thrown from the invocation of the copy
-of \tcode{f} will be thrown in the constructing thread, not the new thread. \end{note} If the
+is ignored.
+\begin{note}
+This implies that any exceptions not thrown from the invocation of the copy
+of \tcode{f} will be thrown in the constructing thread, not the new thread.
+\end{note}
+If the
 invocation of
 \tcode{%
 \placeholdernc{INVOKE}(\brk{}%
@@ -1268,7 +1300,8 @@ value of \tcode{x.get_id()} prior to the start of construction.
 \begin{itemdescr}
 \pnum
 If \tcode{joinable()}, calls \tcode{terminate()}. Otherwise, has no effects.
-\begin{note} Either implicitly detaching or joining a \tcode{joinable()} thread in its
+\begin{note}
+Either implicitly detaching or joining a \tcode{joinable()} thread in its
 destructor could result in difficult to debug correctness (for detach) or performance
 (for join) bugs encountered only when an exception is thrown. Thus the programmer must
 ensure that the destructor is never executed while the thread is still joinable.
@@ -1336,8 +1369,11 @@ Blocks until the thread represented by \tcode{*this} has completed.
 \sync
 The completion of the thread represented by \tcode{*this} synchronizes with\iref{intro.multithread}
 the corresponding successful
-\tcode{join()} return. \begin{note} Operations on
-\tcode{*this} are not synchronized. \end{note}
+\tcode{join()} return.
+\begin{note}
+Operations on
+\tcode{*this} are not synchronized.
+\end{note}
 
 \pnum
 \ensures
@@ -1413,8 +1449,12 @@ unsigned hardware_concurrency() noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-The number of hardware thread contexts. \begin{note} This value should
-only be considered to be a hint. \end{note} If this value is not computable or
+The number of hardware thread contexts.
+\begin{note}
+This value should
+only be considered to be a hint.
+\end{note}
+If this value is not computable or
 well-defined, an implementation should return 0.
 \end{itemdescr}
 
@@ -1612,7 +1652,9 @@ and \tcode{x.ssource.stop_possible()} is \tcode{false}.
 \effects
 If \tcode{joinable()} is \tcode{true},
 calls \tcode{request_stop()} and then \tcode{join()}.
-\begin{note} Operations on \tcode{*this} are not synchronized. \end{note}
+\begin{note}
+Operations on \tcode{*this} are not synchronized.
+\end{note}
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{jthread}%
@@ -1682,7 +1724,9 @@ Blocks until the thread represented by \tcode{*this} has completed.
 The completion of the thread represented by \tcode{*this}
 synchronizes with\iref{intro.multithread}
 the corresponding successful \tcode{join()} return.
-\begin{note} Operations on \tcode{*this} are not synchronized. \end{note}
+\begin{note}
+Operations on \tcode{*this} are not synchronized.
+\end{note}
 
 \pnum
 \ensures
@@ -1997,13 +2041,18 @@ construction is incorrect.
 The implementation shall provide lock and unlock operations, as described below.
 For purposes of determining the existence of a data race, these behave as
 atomic operations\iref{intro.multithread}. The lock and unlock operations on
-a single mutex shall appear to occur in a single total order. \begin{note} This
+a single mutex shall appear to occur in a single total order.
+\begin{note}
+This
 can be viewed as the modification order\iref{intro.multithread} of the
-mutex. \end{note}
-\begin{note} Construction and
+mutex.
+\end{note}
+\begin{note}
+Construction and
 destruction of an object of a mutex type need not be thread-safe; other
 synchronization should be used to ensure that mutex objects are initialized
-and visible to other threads. \end{note}
+and visible to other threads.
+\end{note}
 
 \pnum
 The expression \tcode{m.lock()} shall be well-formed and have the following semantics:
@@ -2060,7 +2109,9 @@ thread does not own the mutex.
 Attempts to obtain ownership of the mutex for the calling thread without
 blocking. If ownership is not obtained, there is no effect and \tcode{try_lock()}
 immediately returns. An implementation may fail to obtain the lock even if it is not
-held by any other thread. \begin{note} This spurious failure is normally uncommon, but
+held by any other thread.
+\begin{note}
+This spurious failure is normally uncommon, but
 allows interesting implementations based on a simple
 compare and exchange\iref{atomics}.
 \end{note}
@@ -2079,9 +2130,11 @@ thread, otherwise \tcode{false}.
 \sync
 If \tcode{try_lock()} returns \tcode{true}, prior \tcode{unlock()} operations
 on the same object \term{synchronize with}\iref{intro.multithread} this operation.
-\begin{note} Since \tcode{lock()} does not synchronize with a failed subsequent
+\begin{note}
+Since \tcode{lock()} does not synchronize with a failed subsequent
 \tcode{try_lock()}, the visibility rules are weak enough that little would be
-known about the state after a failure, even in the absence of spurious failures. \end{note}
+known about the state after a failure, even in the absence of spurious failures.
+\end{note}
 
 \pnum
 \throws
@@ -2158,9 +2211,11 @@ requirements\iref{thread.mutex.requirements}. It shall be a standard-layout
 class\iref{class.prop}.
 
 \pnum
-\begin{note} A program may deadlock if the thread that owns a \tcode{mutex} object calls
+\begin{note}
+A program may deadlock if the thread that owns a \tcode{mutex} object calls
 \tcode{lock()} on that object. If the implementation can detect the deadlock,
-a \tcode{resource_deadlock_would_occur} error condition may be observed. \end{note}
+a \tcode{resource_deadlock_would_occur} error condition may be observed.
+\end{note}
 
 \pnum
 The behavior of a program is undefined if
@@ -2253,7 +2308,9 @@ relative timeout\iref{thread.req.timing}
 specified by \tcode{rel_time}. If the time specified by \tcode{rel_time} is less than or
 equal to \tcode{rel_time.zero()}, the function attempts to obtain ownership without blocking (as if by calling
 \tcode{try_lock()}). The function shall return within the timeout specified by
-\tcode{rel_time} only if it has obtained ownership of the mutex object. \begin{note} As
+\tcode{rel_time} only if it has obtained ownership of the mutex object.
+\begin{note}
+As
 with \tcode{try_lock()}, there is no guarantee that ownership will be obtained if the
 lock is available, but implementations are expected to make a strong effort to do so.
 \end{note}
@@ -2292,9 +2349,11 @@ The function attempts to obtain ownership of the mutex. If
 without blocking (as if by calling \tcode{try_lock()}). The function shall
 return before the absolute timeout\iref{thread.req.timing} specified by
 \tcode{abs_time} only if it has obtained ownership of the mutex object.
-\begin{note} As with \tcode{try_lock()}, there is no guarantee that ownership will
+\begin{note}
+As with \tcode{try_lock()}, there is no guarantee that ownership will
 be obtained if the lock is available, but implementations are expected to make a
-strong effort to do so. \end{note}
+strong effort to do so.
+\end{note}
 
 \pnum
 \returntype \tcode{bool}.
@@ -2625,9 +2684,12 @@ specified by \tcode{rel_time} is less than or equal to \tcode{rel_time.zero()},
 the function attempts to obtain ownership without blocking (as if by calling
 \tcode{try_lock_shared()}). The function shall return within the timeout
 specified by \tcode{rel_time} only if it has obtained shared ownership of the
-mutex object. \begin{note} As with \tcode{try_lock()}, there is no guarantee that
+mutex object.
+\begin{note}
+As with \tcode{try_lock()}, there is no guarantee that
 ownership will be obtained if the lock is available, but implementations are
-expected to make a strong effort to do so. \end{note}
+expected to make a strong effort to do so.
+\end{note}
 If an exception is thrown then a shared lock shall not have been acquired for
 the current thread.
 
@@ -2664,9 +2726,12 @@ The function attempts to obtain shared ownership of the mutex. If
 ownership without blocking (as if by calling \tcode{try_lock_shared()}). The
 function shall return before the absolute timeout\iref{thread.req.timing}
 specified by \tcode{abs_time} only if it has obtained shared ownership of the
-mutex object. \begin{note} As with \tcode{try_lock()}, there is no guarantee that
+mutex object.
+\begin{note}
+As with \tcode{try_lock()}, there is no guarantee that
 ownership will be obtained if the lock is available, but implementations are
-expected to make a strong effort to do so. \end{note}
+expected to make a strong effort to do so.
+\end{note}
 If an exception is thrown then a shared lock shall not have been acquired for
 the current thread.
 
@@ -2747,8 +2812,11 @@ lockable object during the lock's destruction (such as when leaving block scope)
 agent may use a lock to aid in managing ownership of a lockable object in an exception safe
 manner. A lock is said to \term{own} a lockable object if it is currently managing the
 ownership of that lockable object for an execution agent. A lock does not manage the lifetime
-of the lockable object it references. \begin{note} Locks are intended to ease the burden of
-unlocking the lockable object under both normal and exceptional circumstances. \end{note}
+of the lockable object it references.
+\begin{note}
+Locks are intended to ease the burden of
+unlocking the lockable object under both normal and exceptional circumstances.
+\end{note}
 
 \pnum
 Some lock constructors take tag types which describe what should be done with the lockable
@@ -3006,12 +3074,14 @@ lifetime\iref{basic.life} of the \tcode{unique_lock} object. The supplied
 requirements\iref{thread.req.lockable.basic}.
 
 \pnum
-\begin{note} \tcode{unique_lock<Mutex>} meets the \oldconcept{BasicLockable} requirements. If \tcode{Mutex}
+\begin{note}
+\tcode{unique_lock<Mutex>} meets the \oldconcept{BasicLockable} requirements. If \tcode{Mutex}
 meets the \oldconcept{Lockable} requirements\iref{thread.req.lockable.req},
 \tcode{unique_lock<Mutex>} also meets the \oldconcept{Lockable} requirements;
 if \tcode{Mutex}
 meets the \oldconcept{TimedLockable} requirements\iref{thread.req.lockable.timed},
-\tcode{unique_lock<Mutex>} also meets the \oldconcept{TimedLockable} requirements. \end{note}
+\tcode{unique_lock<Mutex>} also meets the \oldconcept{TimedLockable} requirements.
+\end{note}
 
 \rSec4[thread.lock.unique.cons]{Constructors, destructor, and assignment}
 
@@ -3177,7 +3247,9 @@ If \tcode{owns} calls \tcode{pm->unlock()}.
 \tcode{pm == u_p.pm} and \tcode{owns == u_p.owns} (where \tcode{u_p} is the state of \tcode{u} just prior to this construction),  \tcode{u.pm == 0} and \tcode{u.owns == false}.
 
 \pnum
-\begin{note} With a recursive mutex it is possible for both \tcode{*this} and \tcode{u} to own the same mutex before the assignment. In this case, \tcode{*this} will own the mutex after the assignment and \tcode{u} will not. \end{note}
+\begin{note}
+With a recursive mutex it is possible for both \tcode{*this} and \tcode{u} to own the same mutex before the assignment. In this case, \tcode{*this} will own the mutex after the assignment and \tcode{u} will not.
+\end{note}
 
 \pnum
 \throws
@@ -3507,8 +3579,10 @@ lifetime\iref{basic.life} of the \tcode{shared_lock} object. The supplied
 requirements\iref{thread.sharedtimedmutex.requirements}.
 
 \pnum
-\begin{note} \tcode{shared_lock<Mutex>} meets the \oldconcept{TimedLockable}
-requirements\iref{thread.req.lockable.timed}. \end{note}
+\begin{note}
+\tcode{shared_lock<Mutex>} meets the \oldconcept{TimedLockable}
+requirements\iref{thread.req.lockable.timed}.
+\end{note}
 
 \rSec4[thread.lock.shared.cons]{Constructors, destructor, and assignment}
 
@@ -3925,7 +3999,9 @@ template<class L1, class L2, class... L3> int try_lock(L1&, L2&, L3&...);
 
 \begin{itemdescr}
 \pnum
-\requires Each template parameter type shall meet the \oldconcept{Lockable} requirements. \begin{note} The
+\requires Each template parameter type shall meet the \oldconcept{Lockable} requirements.
+\begin{note}
+The
 \tcode{unique_lock} class template meets these requirements when suitably instantiated.
 \end{note}
 
@@ -3952,7 +4028,8 @@ template<class L1, class L2, class... L3> void lock(L1&, L2&, L3&...);
 \begin{itemdescr}
 \pnum
 \requires Each template parameter type shall meet the \oldconcept{Lockable} requirements.
-\begin{note} The
+\begin{note}
+The
 \tcode{unique_lock} class template meets these requirements when suitably instantiated.
 \end{note}
 
@@ -3960,9 +4037,13 @@ template<class L1, class L2, class... L3> void lock(L1&, L2&, L3&...);
 \effects
 All arguments are locked via a sequence of calls to \tcode{lock()},
 \tcode{try_lock()}, or \tcode{unlock()} on each argument. The sequence of calls does
-not result in deadlock, but is otherwise unspecified. \begin{note} A deadlock avoidance
+not result in deadlock, but is otherwise unspecified.
+\begin{note}
+A deadlock avoidance
 algorithm such as try-and-back-off must be used, but the specific algorithm is not
-specified to avoid over-constraining implementations. \end{note} If a call to
+specified to avoid over-constraining implementations.
+\end{note}
+If a call to
 \tcode{lock()} or \tcode{try_lock()} throws an exception, \tcode{unlock()} is
 called for any argument that had been locked by a call to \tcode{lock()} or
 \tcode{try_lock()}.
@@ -4038,9 +4119,12 @@ An exceptional execution shall propagate the exception to the caller of
 \tcode{call_once}. Among all executions of \tcode{call_once} for any given
 \tcode{once_flag}: at most one shall be a returning execution; if there is a
 returning execution, it shall be the last active execution; and there are
-passive executions only if there is a returning execution. \begin{note} Passive
+passive executions only if there is a returning execution.
+\begin{note}
+Passive
 executions allow other threads to reliably observe the results produced by the
-earlier returning execution. \end{note}
+earlier returning execution.
+\end{note}
 
 \pnum
 \sync
@@ -4258,7 +4342,9 @@ limitation prevents initialization.
 
 \begin{itemdescr}
 \pnum
-\requires There shall be no thread blocked on \tcode{*this}. \begin{note} That is, all
+\requires There shall be no thread blocked on \tcode{*this}.
+\begin{note}
+That is, all
 threads shall have been notified; they may subsequently block on the lock specified in the
 wait.
 This relaxes the usual rules, which would have required all wait calls to happen before
@@ -4324,7 +4410,9 @@ or a call to \tcode{notify_all()}, or spuriously.
 \remarks
 If the function fails to meet the postcondition, \tcode{terminate()}
 shall be called\iref{except.terminate}.
-\begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
+\begin{note}
+This can happen if the re-locking of the mutex throws an exception.
+\end{note}
 
 \pnum
 \ensures
@@ -4367,7 +4455,9 @@ while (!pred())
 \remarks
 If the function fails to meet the postcondition, \tcode{terminate()}
 shall be called\iref{except.terminate}.
-\begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
+\begin{note}
+This can happen if the re-locking of the mutex throws an exception.
+\end{note}
 
 \pnum
 \ensures
@@ -4420,7 +4510,9 @@ If the function exits via an exception, \tcode{lock.lock()} shall be called prio
 \remarks
 If the function fails to meet the postcondition, \tcode{terminate()}
 shall be called\iref{except.terminate}.
-\begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
+\begin{note}
+This can happen if the re-locking of the mutex throws an exception.
+\end{note}
 
 \pnum
 \ensures
@@ -4475,7 +4567,9 @@ otherwise \tcode{cv_status::no_timeout}.
 \remarks
 If the function fails to meet the postcondition, \tcode{terminate()}
 shall be called\iref{except.terminate}.
-\begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
+\begin{note}
+This can happen if the re-locking of the mutex throws an exception.
+\end{note}
 
 \pnum
 \ensures
@@ -4523,7 +4617,9 @@ return true;
 \remarks
 If the function fails to meet the postcondition, \tcode{terminate()}
 shall be called\iref{except.terminate}.
-\begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
+\begin{note}
+This can happen if the re-locking of the mutex throws an exception.
+\end{note}
 
 \pnum
 \ensures
@@ -4531,8 +4627,10 @@ shall be called\iref{except.terminate}.
 is locked by the calling thread.
 
 \pnum
-\begin{note} The returned value indicates whether the predicate evaluated to
-\tcode{true} regardless of whether the timeout was triggered. \end{note}
+\begin{note}
+The returned value indicates whether the predicate evaluated to
+\tcode{true} regardless of whether the timeout was triggered.
+\end{note}
 
 \pnum
 \throws
@@ -4571,14 +4669,18 @@ return wait_until(lock, chrono::steady_clock::now() + rel_time, std::move(pred))
 \end{codeblock}
 
 \pnum
-\begin{note} There is no blocking if \tcode{pred()} is initially \tcode{true}, even if the
-timeout has already expired. \end{note}
+\begin{note}
+There is no blocking if \tcode{pred()} is initially \tcode{true}, even if the
+timeout has already expired.
+\end{note}
 
 \pnum
 \remarks
 If the function fails to meet the postcondition, \tcode{terminate()}
 shall be called\iref{except.terminate}.
-\begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
+\begin{note}
+This can happen if the re-locking of the mutex throws an exception.
+\end{note}
 
 \pnum
 \ensures
@@ -4586,8 +4688,10 @@ shall be called\iref{except.terminate}.
 is locked by the calling thread.
 
 \pnum
-\begin{note} The returned value indicates whether the predicate evaluates to \tcode{true}
-regardless of whether the timeout was triggered. \end{note}
+\begin{note}
+The returned value indicates whether the predicate evaluates to \tcode{true}
+regardless of whether the timeout was triggered.
+\end{note}
 
 \pnum
 \throws
@@ -4600,12 +4704,15 @@ exceptions\iref{thread.req.timing} or any exception thrown by \tcode{pred}.
 
 \pnum
 A \tcode{Lock} type shall meet the \oldconcept{BasicLockable}
-requirements\iref{thread.req.lockable.basic}. \begin{note} All of the standard
+requirements\iref{thread.req.lockable.basic}.
+\begin{note}
+All of the standard
 mutex types meet this requirement. If a \tcode{Lock} type other than one of the
 standard mutex types or a \tcode{unique_lock} wrapper for a standard mutex type
 is used with \tcode{condition_variable_any}, the user should ensure that any
 necessary synchronization is in place with respect to the predicate associated
-with the \tcode{condition_variable_any} instance. \end{note}
+with the \tcode{condition_variable_any} instance.
+\end{note}
 
 \indexlibrary{\idxcode{condition_variable_any}}%
 \begin{codeblock}
@@ -4683,7 +4790,9 @@ privilege to perform the operation.
 
 \begin{itemdescr}
 \pnum
-\requires There shall be no thread blocked on \tcode{*this}. \begin{note} That is, all
+\requires There shall be no thread blocked on \tcode{*this}.
+\begin{note}
+That is, all
 threads shall have been notified; they may subsequently block on the lock specified in the
 wait.
 This relaxes the usual rules, which would have required all wait calls to happen before
@@ -4742,7 +4851,9 @@ a call to \tcode{notify_all()}, or spuriously.
 \remarks
 If the function fails to meet the postcondition, \tcode{terminate()}
 shall be called\iref{except.terminate}.
-\begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
+\begin{note}
+This can happen if the re-locking of the mutex throws an exception.
+\end{note}
 
 \pnum
 \ensures
@@ -4800,7 +4911,9 @@ If the function exits via an exception, \tcode{lock.lock()} shall be called prio
 \remarks
 If the function fails to meet the postcondition, \tcode{terminate()}
 shall be called\iref{except.terminate}.
-\begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
+\begin{note}
+This can happen if the re-locking of the mutex throws an exception.
+\end{note}
 
 \pnum
 \ensures
@@ -4843,7 +4956,9 @@ otherwise \tcode{cv_status::no_timeout}.
 \remarks
 If the function fails to meet the postcondition, \tcode{terminate()}
 shall be called\iref{except.terminate}.
-\begin{note} This can happen if the re-locking of the mutex throws an exception. \end{note}
+\begin{note}
+This can happen if the re-locking of the mutex throws an exception.
+\end{note}
 
 \pnum
 \ensures
@@ -4874,12 +4989,16 @@ return true;
 \end{codeblock}
 
 \pnum
-\begin{note} There is no blocking if \tcode{pred()} is initially \tcode{true}, or
-if the timeout has already expired. \end{note}
+\begin{note}
+There is no blocking if \tcode{pred()} is initially \tcode{true}, or
+if the timeout has already expired.
+\end{note}
 
 \pnum
-\begin{note} The returned value indicates whether the predicate evaluates to \tcode{true}
-regardless of whether the timeout was triggered. \end{note}
+\begin{note}
+The returned value indicates whether the predicate evaluates to \tcode{true}
+regardless of whether the timeout was triggered.
+\end{note}
 \end{itemdescr}
 
 \indexlibrarymember{wait_for}{condition_variable_any}%
@@ -5671,8 +5790,10 @@ This call can cause the completion step for the current phase to start.
 \pnum
 \ref{futures} describes components that a \Cpp{} program can use to retrieve in one thread the
 result (value or exception) from a function that has run in the same thread or another thread.
-\begin{note} These components are not restricted to multi-threaded programs but can be useful in
-single-threaded programs as well. \end{note}
+\begin{note}
+These components are not restricted to multi-threaded programs but can be useful in
+single-threaded programs as well.
+\end{note}
 
 \rSec2[future.syn]{Header \tcode{<future>} synopsis}
 
@@ -5744,11 +5865,13 @@ namespace std {
 \pnum
 The \tcode{enum} type \tcode{launch} is a bitmask type\iref{bitmask.types} with
 elements \tcode{launch::async} and \tcode{launch::deferred}.
-\begin{note} Implementations can provide bitmasks to specify restrictions on task
+\begin{note}
+Implementations can provide bitmasks to specify restrictions on task
 interaction by functions launched by \tcode{async()} applicable to a
 corresponding subset of available launch policies. Implementations can extend
 the behavior of the first overload of \tcode{async()} by adding their extensions
-to the launch policy under the ``as if'' rule. \end{note}
+to the launch policy under the ``as if'' rule.
+\end{note}
 
 \pnum
 The enum values of \tcode{future_errc} are distinct and not zero.
@@ -5851,12 +5974,16 @@ An \ntbs{} incorporating \tcode{code().message()}.
 Many of the classes introduced in this subclause use some state to communicate results. This
 \indextext{shared state|see{future, shared state}}
 \defnx{shared state}{future!shared state} consists of some state information and some (possibly not
-yet evaluated) \term{result}, which can be a (possibly void) value or an exception. \begin{note}
-Futures, promises, and tasks defined in this clause reference such shared state. \end{note}
+yet evaluated) \term{result}, which can be a (possibly void) value or an exception.
+\begin{note}
+Futures, promises, and tasks defined in this clause reference such shared state.
+\end{note}
 
 \pnum
-\begin{note} The result can be any kind of object including a function to compute that result,
-as used by \tcode{async} when \tcode{policy} is \tcode{launch::deferred}. \end{note}
+\begin{note}
+The result can be any kind of object including a function to compute that result,
+as used by \tcode{async} when \tcode{policy} is \tcode{launch::deferred}.
+\end{note}
 
 \pnum
 An \defn{asynchronous return object} is an object that reads results from a
@@ -5871,8 +5998,11 @@ it is a \term{non-timed waiting function}.
 An \defn{asynchronous provider} is an object that provides a result to a shared
 state.
 The result of a shared state is set by
-respective functions on the asynchronous provider. \begin{note} Such as promises or tasks.
-\end{note} The means of setting the result of a shared state is specified
+respective functions on the asynchronous provider.
+\begin{note}
+Such as promises or tasks.
+\end{note}
+The means of setting the result of a shared state is specified
 in the description of those classes and functions that create such a state object.
 
 \pnum
@@ -5950,7 +6080,8 @@ is sequenced before making that shared state ready.
 
 \pnum
 Access to the result of the same shared state may conflict\iref{intro.multithread}.
-\begin{note} This explicitly specifies that the result of the shared state is
+\begin{note}
+This explicitly specifies that the result of the shared state is
 visible in the objects that reference this state in the sense of data race
 avoidance\iref{res.on.data.races}. For example, concurrent accesses through
 references returned by \tcode{shared_future::get()}\iref{futures.shared.future}
@@ -6294,18 +6425,23 @@ object that shares the same
 shared state.
 
 \pnum
-\begin{note} Member functions of \tcode{future} do not synchronize with themselves or with
-member functions of \tcode{shared_future}. \end{note}
+\begin{note}
+Member functions of \tcode{future} do not synchronize with themselves or with
+member functions of \tcode{shared_future}.
+\end{note}
 
 \pnum
 The effect of calling any member function other than the destructor, the
 move-assignment operator, \tcode{share}, or \tcode{valid} on a \tcode{future} object for which
 \tcode{valid() == false}
 is undefined.
-\begin{note} It is valid to move from a future object for which \tcode{valid() == false}.
+\begin{note}
+It is valid to move from a future object for which \tcode{valid() == false}.
 \end{note}
-\begin{note} Implementations should detect this case and throw an object of type
-\tcode{future_error} with an error condition of \tcode{future_errc::no_state}. \end{note}
+\begin{note}
+Implementations should detect this case and throw an object of type
+\tcode{future_error} with an error condition of \tcode{future_errc::no_state}.
+\end{note}
 
 \indexlibrary{\idxcode{future}}%
 \begin{codeblock}
@@ -6588,17 +6724,23 @@ calling a respective function on an
 object that shares the same shared state.
 
 \pnum
-\begin{note} Member functions of \tcode{shared_future} do not synchronize with themselves,
-but they synchronize with the shared state. \end{note}
+\begin{note}
+Member functions of \tcode{shared_future} do not synchronize with themselves,
+but they synchronize with the shared state.
+\end{note}
 
 \pnum
 The effect of calling any member function other than the destructor,
 the move-assignment operator, the copy-assignment operator, or
 \tcode{valid()} on a \tcode{shared_future} object for which \tcode{valid() == false} is undefined.
-\begin{note} It is valid to copy or move from a \tcode{shared_future}
-object for which \tcode{valid()} is \tcode{false}. \end{note}
-\begin{note} Implementations should detect this case and throw an object of type
-\tcode{future_error} with an error condition of \tcode{future_errc::no_state}. \end{note}
+\begin{note}
+It is valid to copy or move from a \tcode{shared_future}
+object for which \tcode{valid()} is \tcode{false}.
+\end{note}
+\begin{note}
+Implementations should detect this case and throw an object of type
+\tcode{future_error} with an error condition of \tcode{future_errc::no_state}.
+\end{note}
 
 \indexlibrary{\idxcode{shared_future}}%
 \begin{codeblock}
@@ -6744,9 +6886,12 @@ shared_future& operator=(const shared_future& rhs) noexcept;
 \item
 Releases any shared state\iref{futures.state};
 \item
-assigns the contents of \tcode{rhs} to \tcode{*this}. \begin{note} As a result,
+assigns the contents of \tcode{rhs} to \tcode{*this}.
+\begin{note}
+As a result,
 \tcode{*this} refers to the same shared state as \tcode{rhs}
-(if any). \end{note}
+(if any).
+\end{note}
 \end{itemize}
 
 \pnum
@@ -6786,10 +6931,12 @@ value stored in the shared state.
 \item
 \tcode{shared_future::get()} returns a const reference to the value stored in the object's
 shared state.
-\begin{note} Access through that reference after the shared state has been
+\begin{note}
+Access through that reference after the shared state has been
 destroyed produces undefined behavior; this can be avoided by not storing the reference in any
 storage with a greater lifetime than the \tcode{shared_future} object that returned the
-reference. \end{note}
+reference.
+\end{note}
 
 \item
 \tcode{shared_future<R\&>::get()} returns the reference stored as value in the object's
@@ -6979,10 +7126,12 @@ this shared state shall invoke the
 deferred function in the thread that called the waiting function.
 Once evaluation of \tcode{\placeholdernc{INVOKE}(std::move(g), std::move(xyz))} begins, the function is no longer
 considered deferred.
-\begin{note} If this policy is specified together with other policies, such as when using a
+\begin{note}
+If this policy is specified together with other policies, such as when using a
 \tcode{policy} value of \tcode{launch::async | launch::deferred}, implementations should defer
 invocation or the selection of the policy when no more concurrency can be effectively
-exploited. \end{note}
+exploited.
+\end{note}
 
 \item
 If no value is set in the launch policy, or a value is set that is neither specified
@@ -6994,9 +7143,11 @@ in this document nor by the implementation, the behavior is undefined.
 An object of type
 \tcode{future<invoke_result_t<decay_t<F>, decay_t<Args>...>{>}} that refers
 to the shared state created by this call to \tcode{async}.
-\begin{note} If a future obtained from \tcode{async} is moved outside the local scope,
+\begin{note}
+If a future obtained from \tcode{async} is moved outside the local scope,
 other code that uses the future should be aware that the future's destructor may
-block for the shared state to become ready. \end{note}
+block for the shared state to become ready.
+\end{note}
 
 \pnum
 \sync
@@ -7004,14 +7155,20 @@ Regardless of the provided \tcode{policy} argument,
 \begin{itemize}
 \item
 the invocation of \tcode{async}
-synchronizes with\iref{intro.multithread} the invocation of \tcode{f}. \begin{note}
+synchronizes with\iref{intro.multithread} the invocation of \tcode{f}.
+\begin{note}
 This statement applies even when the corresponding \tcode{future} object is moved to
-another thread. \end{note}; and
+another thread.
+\end{note}
+; and
 
 \item
 the completion of the function \tcode{f} is sequenced before\iref{intro.multithread} the
-shared state is made ready. \begin{note} \tcode{f} might not be called at all,
-so its completion might never happen. \end{note}
+shared state is made ready.
+\begin{note}
+\tcode{f} might not be called at all,
+so its completion might never happen.
+\end{note}
 \end{itemize}
 
 If the implementation chooses the \tcode{launch::async} policy,
@@ -7062,7 +7219,8 @@ int work(int value) {
 }
 \end{codeblock}
 
-\begin{note} Line \#1 might not result in concurrency because
+\begin{note}
+Line \#1 might not result in concurrency because
 the \tcode{async} call uses the default policy, which may use
 \tcode{launch::deferred}, in which case the lambda might not be invoked until the
 \tcode{get()} call; in that case, \tcode{work1} and \tcode{work2} are called on the
@@ -7345,8 +7503,11 @@ void reset();
 \effects
 As if \tcode{*this = packaged_task(std::move(f))}, where
 \tcode{f} is the task stored in
-\tcode{*this}. \begin{note} This constructs a new shared state for \tcode{*this}. The
-old state is abandoned\iref{futures.state}. \end{note}
+\tcode{*this}.
+\begin{note}
+This constructs a new shared state for \tcode{*this}. The
+old state is abandoned\iref{futures.state}.
+\end{note}
 
 \pnum
 \throws

--- a/source/time.tex
+++ b/source/time.tex
@@ -2574,7 +2574,8 @@ Objects of type \tcode{sys_time<Duration>} measure time since (and before)
 This measure is commonly referred to as \defn{Unix time}.
 This measure facilitates an efficient mapping between
 \tcode{sys_time} and calendar types\iref{time.cal}.
-\begin{example} \\
+\begin{example}
+\\
 \tcode{sys_seconds\{sys_days\{1970y/January/1\}\}.time_since_epoch()} is \tcode{0s}. \\
 \tcode{sys_seconds\{sys_days\{2000y/January/1\}\}.time_since_epoch()} is \tcode{946'684'800s},
 which is \tcode{10'957 * 86'400s}. \\
@@ -2742,7 +2743,8 @@ In contrast to \tcode{sys_time},
 which does not take leap seconds into account,
 \tcode{utc_clock} and its associated \tcode{time_point}, \tcode{utc_time},
 count time, including leap seconds, since 1970-01-01 00:00:00 UTC.
-\begin{example} \\
+\begin{example}
+\\
 \tcode{clock_cast<utc_clock>(sys_seconds\{sys_days\{1970y/January/1\}\}).time_since_epoch()} is \tcode{0s}. \\
 \tcode{clock_cast<utc_clock>(sys_seconds\{sys_days\{2000y/January/1\}\}).time_since_epoch()} \\
 is \tcode{946'684'822s}, which is \tcode{10'957 * 86'400s + 22s}. \\

--- a/source/time.tex
+++ b/source/time.tex
@@ -940,8 +940,10 @@ In \tref{time.clock} \tcode{C1} and \tcode{C2} denote clock types. \tcode{t1} an
 before\iref{intro.multithread} the call returning \tcode{t2} and both of these calls
 occur
 before \tcode{C1::time_point::max()}.
-\begin{note} This means \tcode{C1} did not wrap around between \tcode{t1} and
-\tcode{t2}. \end{note}
+\begin{note}
+This means \tcode{C1} did not wrap around between \tcode{t1} and
+\tcode{t2}.
+\end{note}
 
 \begin{libreqtab3a}
 {\oldconcept{Clock} requirements}
@@ -983,8 +985,10 @@ before \tcode{C1::time_point::max()}.
 \end{libreqtab3a}
 
 \pnum
-\begin{note} The relative difference in durations between those reported by a given clock and the
-SI definition is a measure of the quality of implementation. \end{note}
+\begin{note}
+The relative difference in durations between those reported by a given clock and the
+SI definition is a measure of the quality of implementation.
+\end{note}
 
 \pnum
 A type \tcode{TC} meets the \oldconcept{TrivialClock} requirements if:
@@ -996,8 +1000,11 @@ A type \tcode{TC} meets the \oldconcept{TrivialClock} requirements if:
 meet the \oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable}) and
 \oldconcept{LessThanComparable} (\tref{cpp17.lessthancomparable})
 requirements and the requirements of
-numeric types\iref{numeric.requirements}. \begin{note} This means, in particular,
-that operations on these types will not throw exceptions. \end{note}
+numeric types\iref{numeric.requirements}.
+\begin{note}
+This means, in particular,
+that operations on these types will not throw exceptions.
+\end{note}
 
 \item lvalues of the types \tcode{TC::rep}, \tcode{TC::duration}, and
 \tcode{TC::time_point} are swappable\iref{swappable.requirements},
@@ -1060,9 +1067,12 @@ static constexpr Rep zero() noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{Rep(0)}. \begin{note} \tcode{Rep(0)} is specified instead of
+\tcode{Rep(0)}.
+\begin{note}
+\tcode{Rep(0)} is specified instead of
 \tcode{Rep()} because \tcode{Rep()} may have some other meaning, such as an
-uninitialized value. \end{note}
+uninitialized value.
+\end{note}
 
 \pnum
 \remarks
@@ -1112,18 +1122,22 @@ struct common_type<chrono::duration<Rep1, Period1>, chrono::duration<Rep2, Perio
 \pnum
 The \tcode{period} of the \tcode{duration} indicated by this specialization of
 \tcode{common_type} shall be the greatest common divisor of \tcode{Period1} and
-\tcode{Period2}. \begin{note} This can be computed by forming a ratio of the
+\tcode{Period2}.
+\begin{note}
+This can be computed by forming a ratio of the
 greatest common divisor of \tcode{Period1::num} and \tcode{Period2::num} and the
 least common multiple of \tcode{Period1::den} and \tcode{Period2::den}.
 \end{note}
 
 \pnum
-\begin{note} The \tcode{typedef} name \tcode{type} is a synonym for the
+\begin{note}
+The \tcode{typedef} name \tcode{type} is a synonym for the
 \tcode{duration} with the largest tick \tcode{period} possible where both
 \tcode{duration} arguments will convert to it without requiring a division
 operation. The representation of this type is intended to be able to hold any
 value resulting from this conversion with no truncation error, although
-floating-point durations may have round-off errors. \end{note}
+floating-point durations may have round-off errors.
+\end{note}
 
 \indexlibrary{\idxcode{common_type}}%
 \begin{itemdecl}
@@ -1308,10 +1322,13 @@ This constructor shall not participate in overload resolution unless
 no overflow is induced in the conversion and
 \tcode{treat_as_floating_point_v<rep>} is \tcode{true} or both
 \tcode{ratio_divide<Period2, period>::den} is \tcode{1} and
-\tcode{treat_as_floating_point_v<Rep2>} is \tcode{false}. \begin{note} This
+\tcode{treat_as_floating_point_v<Rep2>} is \tcode{false}.
+\begin{note}
+This
 requirement prevents implicit truncation error when converting between
 integral-based \tcode{duration} types. Such a construction could easily lead to
-confusion about the value of the \tcode{duration}. \end{note}
+confusion about the value of the \tcode{duration}.
+\end{note}
 \begin{example}
 \begin{codeblock}
 duration<int, milli> ms(3);
@@ -2592,7 +2609,9 @@ using system_clock::rep = @\unspec@;
 \pnum
 \requires \tcode{system_clock::duration::min() < system_clock::duration::zero()} shall
 be \tcode{true}.\\
-\begin{note} This implies that \tcode{rep} is a signed type. \end{note}
+\begin{note}
+This implies that \tcode{rep} is a signed type.
+\end{note}
 \end{itemdescr}
 
 \indexlibrarymember{to_time_t}{system_clock}%
@@ -2754,7 +2773,9 @@ is \tcode{946'684'822s}, which is \tcode{10'957 * 86'400s + 22s}. \\
 \tcode{utc_clock} is not a \oldconcept{TrivialClock}
 unless the implementation can guarantee that \tcode{utc_clock::now()}
 does not propagate an exception.
-\begin{note} \tcode{noexcept(from_sys(system_clock::now()))} is \tcode{false}. \end{note}
+\begin{note}
+\tcode{noexcept(from_sys(system_clock::now()))} is \tcode{false}.
+\end{note}
 
 \rSec3[time.clock.utc.members]{Member functions}
 

--- a/source/time.tex
+++ b/source/time.tex
@@ -1059,12 +1059,14 @@ static constexpr Rep zero() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{Rep(0)}. \begin{note} \tcode{Rep(0)} is specified instead of
+\returns
+\tcode{Rep(0)}. \begin{note} \tcode{Rep(0)} is specified instead of
 \tcode{Rep()} because \tcode{Rep()} may have some other meaning, such as an
 uninitialized value. \end{note}
 
 \pnum
-\remarks The value returned shall be the additive identity.
+\remarks
+The value returned shall be the additive identity.
 \end{itemdescr}
 
 \indexlibrarymember{min}{duration_values}%
@@ -1074,10 +1076,12 @@ static constexpr Rep min() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{numeric_limits<Rep>::lowest()}.
+\returns
+\tcode{numeric_limits<Rep>::lowest()}.
 
 \pnum
-\remarks The value returned shall compare less than or equal to \tcode{zero()}.
+\remarks
+The value returned shall compare less than or equal to \tcode{zero()}.
 \end{itemdescr}
 
 \indexlibrarymember{max}{duration_values}%
@@ -1087,10 +1091,12 @@ static constexpr Rep max() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{numeric_limits<Rep>::max()}.
+\returns
+\tcode{numeric_limits<Rep>::max()}.
 
 \pnum
-\remarks The value returned shall compare greater than \tcode{zero()}.
+\remarks
+The value returned shall compare greater than \tcode{zero()}.
 \end{itemdescr}
 
 \rSec2[time.traits.specializations]{Specializations of \tcode{common_type}}
@@ -1265,7 +1271,8 @@ template<class Rep2>
 
 \begin{itemdescr}
 \pnum
-\remarks This constructor shall not participate in overload
+\remarks
+This constructor shall not participate in overload
 resolution unless
 \tcode{Rep2} is implicitly convertible to \tcode{rep} and
 \begin{itemize}
@@ -1280,10 +1287,12 @@ duration<int, milli> d(3.5);        // error
 \end{example}
 
 \pnum
-\effects Constructs an object of type \tcode{duration}.
+\effects
+Constructs an object of type \tcode{duration}.
 
 \pnum
-\ensures \tcode{count() == static_cast<rep>(r)}.
+\ensures
+\tcode{count() == static_cast<rep>(r)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{duration}!constructor}%
@@ -1294,7 +1303,8 @@ template<class Rep2, class Period2>
 
 \begin{itemdescr}
 \pnum
-\remarks This constructor shall not participate in overload resolution unless
+\remarks
+This constructor shall not participate in overload resolution unless
 no overflow is induced in the conversion and
 \tcode{treat_as_floating_point_v<rep>} is \tcode{true} or both
 \tcode{ratio_divide<Period2, period>::den} is \tcode{1} and
@@ -1311,7 +1321,8 @@ duration<int, milli> ms2 = us;      // error
 \end{example}
 
 \pnum
-\effects Constructs an object of type \tcode{duration}, constructing \tcode{rep_} from\\
+\effects
+Constructs an object of type \tcode{duration}, constructing \tcode{rep_} from\\
 \tcode{duration_cast<duration>(d).count()}.
 \end{itemdescr}
 
@@ -1324,7 +1335,8 @@ constexpr rep count() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{rep_}.
+\returns
+\tcode{rep_}.
 \end{itemdescr}
 
 \rSec2[time.duration.arithmetic]{Arithmetic}
@@ -1336,7 +1348,8 @@ constexpr common_type_t<duration> operator+() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{common_type_t<duration>(*this)}.
+\returns
+\tcode{common_type_t<duration>(*this)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{duration}%
@@ -1346,7 +1359,8 @@ constexpr common_type_t<duration> operator-() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{common_type_t<duration>(-rep_)}.
+\returns
+\tcode{common_type_t<duration>(-rep_)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator++}{duration}%
@@ -1356,10 +1370,12 @@ constexpr duration& operator++();
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{++rep_}.
+\effects
+As if by \tcode{++rep_}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator++}{duration}%
@@ -1369,7 +1385,8 @@ constexpr duration operator++(int);
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{duration(rep_++)}.
+\returns
+\tcode{duration(rep_++)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator\dcr}{duration}%
@@ -1379,10 +1396,12 @@ constexpr duration& operator--();
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{--rep_}.
+\effects
+As if by \tcode{--rep_}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator\dcr}{duration}%
@@ -1392,7 +1411,8 @@ constexpr duration operator--(int);
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{duration(rep_-{}-)}.
+\returns
+\tcode{duration(rep_-{}-)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+=}{duration}%
@@ -1402,10 +1422,12 @@ constexpr duration& operator+=(const duration& d);
 
 \begin{itemdescr}
 \pnum
-\effects As if by: \tcode{rep_ += d.count();}
+\effects
+As if by: \tcode{rep_ += d.count();}
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-=}{duration}%
@@ -1415,10 +1437,12 @@ constexpr duration& operator-=(const duration& d);
 
 \begin{itemdescr}
 \pnum
-\effects As if by: \tcode{rep_ -= d.count();}
+\effects
+As if by: \tcode{rep_ -= d.count();}
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator*=}{duration}%
@@ -1428,10 +1452,12 @@ constexpr duration& operator*=(const rep& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects As if by: \tcode{rep_ *= rhs;}
+\effects
+As if by: \tcode{rep_ *= rhs;}
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator/=}{duration}%
@@ -1441,10 +1467,12 @@ constexpr duration& operator/=(const rep& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects As if by: \tcode{rep_ /= rhs;}
+\effects
+As if by: \tcode{rep_ /= rhs;}
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator\%=}{duration}%
@@ -1454,10 +1482,12 @@ constexpr duration& operator%=(const rep& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects As if by: \tcode{rep_ \%= rhs;}
+\effects
+As if by: \tcode{rep_ \%= rhs;}
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator\%=}{duration}%
@@ -1467,10 +1497,12 @@ constexpr duration& operator%=(const duration& rhs);
 
 \begin{itemdescr}
 \pnum
-\effects As if by: \tcode{rep_ \%= rhs.count();}
+\effects
+As if by: \tcode{rep_ \%= rhs.count();}
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 
@@ -1483,7 +1515,8 @@ static constexpr duration zero() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{duration(duration_values<rep>::zero())}.
+\returns
+\tcode{duration(duration_values<rep>::zero())}.
 \end{itemdescr}
 
 \indexlibrarymember{min}{duration}%
@@ -1493,7 +1526,8 @@ static constexpr duration min() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{duration(duration_values<rep>::min())}.
+\returns
+\tcode{duration(duration_values<rep>::min())}.
 \end{itemdescr}
 
 \indexlibrarymember{max}{duration}%
@@ -1503,7 +1537,8 @@ static constexpr duration max() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{duration(duration_values<rep>::max())}.
+\returns
+\tcode{duration(duration_values<rep>::max())}.
 \end{itemdescr}
 
 \rSec2[time.duration.nonmember]{Non-member arithmetic}
@@ -1521,7 +1556,8 @@ template<class Rep1, class Period1, class Rep2, class Period2>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{CD(CD(lhs).count() + CD(rhs).count())}.
+\returns
+\tcode{CD(CD(lhs).count() + CD(rhs).count())}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{common_type}}%
@@ -1533,7 +1569,8 @@ template<class Rep1, class Period1, class Rep2, class Period2>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{CD(CD(lhs).count() - CD(rhs).count())}.
+\returns
+\tcode{CD(CD(lhs).count() - CD(rhs).count())}.
 \end{itemdescr}
 
 \indexlibrarymember{operator*}{duration}%
@@ -1545,11 +1582,13 @@ template<class Rep1, class Period, class Rep2>
 
 \begin{itemdescr}
 \pnum
-\remarks This operator shall not participate in overload
+\remarks
+This operator shall not participate in overload
 resolution unless \tcode{Rep2} is implicitly convertible to \tcode{common_type_t<Rep1, Rep2>}.
 
 \pnum
-\returns \tcode{CD(CD(d).count() * s)}.
+\returns
+\tcode{CD(CD(d).count() * s)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator*}{duration}%
@@ -1561,11 +1600,13 @@ template<class Rep1, class Rep2, class Period>
 
 \begin{itemdescr}
 \pnum
-\remarks This operator shall not participate in overload
+\remarks
+This operator shall not participate in overload
 resolution unless \tcode{Rep1} is implicitly convertible to \tcode{common_type_t<Rep1, Rep2>}.
 
 \pnum
-\returns \tcode{d * s}.
+\returns
+\tcode{d * s}.
 \end{itemdescr}
 
 \indexlibrarymember{operator/}{duration}%
@@ -1577,12 +1618,14 @@ template<class Rep1, class Period, class Rep2>
 
 \begin{itemdescr}
 \pnum
-\remarks This operator shall not participate in overload
+\remarks
+This operator shall not participate in overload
 resolution unless \tcode{Rep2} is implicitly convertible to \tcode{common_type_t<Rep1, Rep2>}
 and \tcode{Rep2} is not a specialization of \tcode{duration}.
 
 \pnum
-\returns \tcode{CD(CD(d).count() / s)}.
+\returns
+\tcode{CD(CD(d).count() / s)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator/}{duration}%
@@ -1598,7 +1641,8 @@ Let \tcode{CD} be
 \tcode{common_type_t<duration<Rep1, Period1>, duration<Rep2, Period2>>}.
 
 \pnum
-\returns \tcode{CD(lhs).count() / CD(rhs).count()}.
+\returns
+\tcode{CD(lhs).count() / CD(rhs).count()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator\%}{duration}%
@@ -1610,12 +1654,14 @@ template<class Rep1, class Period, class Rep2>
 
 \begin{itemdescr}
 \pnum
-\remarks This operator shall not participate in overload
+\remarks
+This operator shall not participate in overload
 resolution unless \tcode{Rep2} is implicitly convertible to \tcode{common_type_t<Rep1, Rep2>} and
 \tcode{Rep2} is not a specialization of \tcode{duration}.
 
 \pnum
-\returns \tcode{CD(CD(d).count() \% s)}.
+\returns
+\tcode{CD(CD(d).count() \% s)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator\%}{duration}%
@@ -1627,7 +1673,8 @@ template<class Rep1, class Period1, class Rep2, class Period2>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{CD(CD(lhs).count() \% CD(rhs).count())}.
+\returns
+\tcode{CD(CD(lhs).count() \% CD(rhs).count())}.
 \end{itemdescr}
 
 
@@ -1647,7 +1694,8 @@ template<class Rep1, class Period1, class Rep2, class Period2>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{CT(lhs).count() == CT(rhs).count()}.
+\returns
+\tcode{CT(lhs).count() == CT(rhs).count()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<}{duration}%
@@ -1659,7 +1707,8 @@ template<class Rep1, class Period1, class Rep2, class Period2>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{CT(lhs).count() < CT(rhs).count()}.
+\returns
+\tcode{CT(lhs).count() < CT(rhs).count()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>}{duration}%
@@ -1671,7 +1720,8 @@ template<class Rep1, class Period1, class Rep2, class Period2>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{rhs < lhs}.
+\returns
+\tcode{rhs < lhs}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=}{duration}%
@@ -1683,7 +1733,8 @@ template<class Rep1, class Period1, class Rep2, class Period2>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!(rhs < lhs)}.
+\returns
+\tcode{!(rhs < lhs)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>=}{duration}%
@@ -1695,7 +1746,8 @@ template<class Rep1, class Period1, class Rep2, class Period2>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!(lhs < rhs)}.
+\returns
+\tcode{!(lhs < rhs)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{duration}%
@@ -1708,7 +1760,8 @@ template<class Rep1, class Period1, class Rep2, class Period2>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{CT(lhs).count() <=> CT(rhs).count()}.
+\returns
+\tcode{CT(lhs).count() <=> CT(rhs).count()}.
 \end{itemdescr}
 
 \rSec2[time.duration.cast]{\tcode{duration_cast}}
@@ -1722,11 +1775,13 @@ template<class ToDuration, class Rep, class Period>
 
 \begin{itemdescr}
 \pnum
-\remarks This function shall not participate in overload resolution
+\remarks
+This function shall not participate in overload resolution
 unless \tcode{ToDuration} is a specialization of \tcode{duration}.
 
 \pnum
-\returns Let \tcode{CF} be \tcode{ratio_divide<Period, typename
+\returns
+Let \tcode{CF} be \tcode{ratio_divide<Period, typename
 ToDuration::period>}, and \tcode{CR} be \tcode{common_type<typename
 ToDuration::rep, Rep, intmax_t>::type}.
 \begin{itemize}
@@ -1772,11 +1827,13 @@ template<class ToDuration, class Rep, class Period>
 
 \begin{itemdescr}
 \pnum
-\remarks This function shall not participate in overload resolution
+\remarks
+This function shall not participate in overload resolution
 unless \tcode{ToDuration} is a specialization of \tcode{duration}.
 
 \pnum
-\returns The greatest result \tcode{t} representable in \tcode{ToDuration}
+\returns
+The greatest result \tcode{t} representable in \tcode{ToDuration}
 for which \tcode{t <= d}.
 \end{itemdescr}
 
@@ -1788,11 +1845,13 @@ template<class ToDuration, class Rep, class Period>
 
 \begin{itemdescr}
 \pnum
-\remarks This function shall not participate in overload resolution
+\remarks
+This function shall not participate in overload resolution
 unless \tcode{ToDuration} is a specialization of \tcode{duration}.
 
 \pnum
-\returns The least result \tcode{t} representable in \tcode{ToDuration}
+\returns
+The least result \tcode{t} representable in \tcode{ToDuration}
 for which \tcode{t >= d}.
 \end{itemdescr}
 
@@ -1804,13 +1863,15 @@ template<class ToDuration, class Rep, class Period>
 
 \begin{itemdescr}
 \pnum
-\remarks This function shall not participate in overload resolution
+\remarks
+This function shall not participate in overload resolution
 unless \tcode{ToDuration} is a specialization of \tcode{duration},
 and \tcode{treat_as_floating_point_v<typename ToDuration::rep>}
 is \tcode{false}.
 
 \pnum
-\returns The value of \tcode{ToDuration} that is closest to \tcode{d}.
+\returns
+The value of \tcode{ToDuration} that is closest to \tcode{d}.
 If there are two closest values, then return the value \tcode{t}
 for which \tcode{t \% 2 == 0}.
 \end{itemdescr}
@@ -1933,11 +1994,13 @@ template<class Rep, class Period>
 
 \begin{itemdescr}
 \pnum
-\remarks This function shall not participate in overload resolution
+\remarks
+This function shall not participate in overload resolution
 unless \tcode{numeric_limits<Rep>::is_signed} is \tcode{true}.
 
 \pnum
-\returns If \tcode{d >= d.zero()}, return \tcode{d},
+\returns
+If \tcode{d >= d.zero()}, return \tcode{d},
 otherwise return \tcode{-d}.
 \end{itemdescr}
 
@@ -2007,7 +2070,8 @@ the encoding used for \tcode{charT},
 the unit suffix \tcode{"us"} is used instead of \tcode{"\textmu{}s"}.
 
 \pnum
-\returns \tcode{os}.
+\returns
+\tcode{os}.
 \end{itemdescr}
 
 \indexlibrarymember{from_stream}{duration}%
@@ -2036,7 +2100,8 @@ If \tcode{\%z} (or a modified variant) is used and successfully parsed,
 that value will be assigned to \tcode{*offset} if \tcode{offset} is non-null.
 
 \pnum
-\returns \tcode{is}.
+\returns
+\tcode{is}.
 \end{itemdescr}
 
 \rSec1[time.point]{Class template \tcode{time_point}}
@@ -2098,7 +2163,8 @@ constexpr time_point();
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an object of type \tcode{time_point}, initializing
+\effects
+Constructs an object of type \tcode{time_point}, initializing
 \tcode{d_} with \tcode{duration::zero()}. Such a \tcode{time_point} object
 represents the epoch.
 \end{itemdescr}
@@ -2110,7 +2176,8 @@ constexpr explicit time_point(const duration& d);
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an object of type \tcode{time_point}, initializing
+\effects
+Constructs an object of type \tcode{time_point}, initializing
 \tcode{d_} with \tcode{d}. Such a \tcode{time_point} object represents the epoch
 \tcode{+ d}.
 \end{itemdescr}
@@ -2123,11 +2190,13 @@ template<class Duration2>
 
 \begin{itemdescr}
 \pnum
-\remarks This constructor shall not participate in overload resolution unless \tcode{Duration2}
+\remarks
+This constructor shall not participate in overload resolution unless \tcode{Duration2}
 is implicitly convertible to \tcode{duration}.
 
 \pnum
-\effects Constructs an object of type \tcode{time_point}, initializing
+\effects
+Constructs an object of type \tcode{time_point}, initializing
 \tcode{d_} with \tcode{t.time_since_epoch()}.
 \end{itemdescr}
 
@@ -2140,7 +2209,8 @@ constexpr duration time_since_epoch() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{d_}.
+\returns
+\tcode{d_}.
 \end{itemdescr}
 
 \rSec2[time.point.arithmetic]{Arithmetic}
@@ -2152,10 +2222,12 @@ constexpr time_point& operator++();
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{++d_}.
+\effects
+\tcode{++d_}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator++}{time_point}%
@@ -2165,7 +2237,8 @@ constexpr time_point operator++(int);
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{time_point\{d_++\}}.
+\returns
+\tcode{time_point\{d_++\}}.
 \end{itemdescr}
 
 \indexlibrarymember{operator--}{time_point}%
@@ -2175,10 +2248,12 @@ constexpr time_point& operator--();
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{--d_}.
+\effects
+\tcode{--d_}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator--}{time_point}%
@@ -2188,7 +2263,8 @@ constexpr time_point operator--(int);
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{time_point\{d_--\}}.
+\returns
+\tcode{time_point\{d_--\}}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+=}{time_point}%
@@ -2198,10 +2274,12 @@ constexpr time_point& operator+=(const duration& d);
 
 \begin{itemdescr}
 \pnum
-\effects As if by: \tcode{d_ += d;}
+\effects
+As if by: \tcode{d_ += d;}
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-=}{time_point}%
@@ -2211,10 +2289,12 @@ constexpr time_point& operator-=(const duration& d);
 
 \begin{itemdescr}
 \pnum
-\effects As if by: \tcode{d_ -= d;}
+\effects
+As if by: \tcode{d_ -= d;}
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \rSec2[time.point.special]{Special values}
@@ -2226,7 +2306,8 @@ static constexpr time_point min() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{time_point(duration::min())}.
+\returns
+\tcode{time_point(duration::min())}.
 \end{itemdescr}
 
 \indexlibrarymember{max}{time_point}%
@@ -2236,7 +2317,8 @@ static constexpr time_point max() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{time_point(duration::max())}.
+\returns
+\tcode{time_point(duration::max())}.
 \end{itemdescr}
 
 \rSec2[time.point.nonmember]{Non-member arithmetic}
@@ -2251,7 +2333,8 @@ template<class Clock, class Duration1, class Rep2, class Period2>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{CT(lhs.time_since_epoch() + rhs)}, where \tcode{CT} is the type of the return value.
+\returns
+\tcode{CT(lhs.time_since_epoch() + rhs)}, where \tcode{CT} is the type of the return value.
 \end{itemdescr}
 
 \indexlibrarymember{operator+}{time_point}%
@@ -2264,7 +2347,8 @@ template<class Rep1, class Period1, class Clock, class Duration2>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{rhs + lhs}.
+\returns
+\tcode{rhs + lhs}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{time_point}%
@@ -2277,7 +2361,8 @@ template<class Clock, class Duration1, class Rep2, class Period2>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{CT(lhs.time_since_epoch() - rhs)},
+\returns
+\tcode{CT(lhs.time_since_epoch() - rhs)},
 where \tcode{CT} is the type of the return value.
 \end{itemdescr}
 
@@ -2290,7 +2375,8 @@ template<class Clock, class Duration1, class Duration2>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{lhs.time_since_epoch() - rhs.time_since_epoch()}.
+\returns
+\tcode{lhs.time_since_epoch() - rhs.time_since_epoch()}.
 \end{itemdescr}
 
 \rSec2[time.point.comparisons]{Comparisons}
@@ -2304,7 +2390,8 @@ template<class Clock, class Duration1, class Duration2>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{lhs.time_since_epoch() == rhs.time_since_epoch()}.
+\returns
+\tcode{lhs.time_since_epoch() == rhs.time_since_epoch()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<}{time_point}%
@@ -2316,7 +2403,8 @@ template<class Clock, class Duration1, class Duration2>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{lhs.time_since_epoch() < rhs.time_since_epoch()}.
+\returns
+\tcode{lhs.time_since_epoch() < rhs.time_since_epoch()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>}{time_point}%
@@ -2328,7 +2416,8 @@ template<class Clock, class Duration1, class Duration2>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{rhs < lhs}.
+\returns
+\tcode{rhs < lhs}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=}{time_point}%
@@ -2340,7 +2429,8 @@ template<class Clock, class Duration1, class Duration2>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!(rhs < lhs)}.
+\returns
+\tcode{!(rhs < lhs)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>=}{time_point}%
@@ -2352,7 +2442,8 @@ template<class Clock, class Duration1, class Duration2>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!(lhs < rhs)}.
+\returns
+\tcode{!(lhs < rhs)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>=}{time_point}%
@@ -2365,7 +2456,8 @@ template<class Clock, class Duration1,
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{lhs.time_since_epoch() <=> rhs.time_since_epoch()}.
+\returns
+\tcode{lhs.time_since_epoch() <=> rhs.time_since_epoch()}.
 \end{itemdescr}
 
 \rSec2[time.point.cast]{\tcode{time_point_cast}}
@@ -2379,7 +2471,8 @@ template<class ToDuration, class Clock, class Duration>
 
 \begin{itemdescr}
 \pnum
-\remarks This function shall not participate in overload resolution
+\remarks
+This function shall not participate in overload resolution
 unless \tcode{ToDuration} is a specialization of \tcode{duration}.
 
 \pnum
@@ -2397,11 +2490,13 @@ template<class ToDuration, class Clock, class Duration>
 
 \begin{itemdescr}
 \pnum
-\remarks This function shall not participate in overload resolution
+\remarks
+This function shall not participate in overload resolution
 unless \tcode{ToDuration} is a specialization of \tcode{duration}.
 
 \pnum
-\returns \tcode{time_point<Clock, ToDuration>(floor<ToDuration>(tp.time_since_epoch()))}.
+\returns
+\tcode{time_point<Clock, ToDuration>(floor<ToDuration>(tp.time_since_epoch()))}.
 \end{itemdescr}
 
 \indexlibrarymember{ceil}{time_point}%
@@ -2412,11 +2507,13 @@ template<class ToDuration, class Clock, class Duration>
 
 \begin{itemdescr}
 \pnum
-\remarks This function shall not participate in overload resolution
+\remarks
+This function shall not participate in overload resolution
 unless \tcode{ToDuration} is a specialization of \tcode{duration}.
 
 \pnum
-\returns \tcode{time_point<Clock, ToDuration>(ceil<ToDuration>(tp.time_since_epoch()))}.
+\returns
+\tcode{time_point<Clock, ToDuration>(ceil<ToDuration>(tp.time_since_epoch()))}.
 \end{itemdescr}
 
 \indexlibrarymember{round}{time_point}%
@@ -2427,12 +2524,14 @@ template<class ToDuration, class Clock, class Duration>
 
 \begin{itemdescr}
 \pnum
-\remarks This function shall not participate in overload resolution
+\remarks
+This function shall not participate in overload resolution
 unless \tcode{ToDuration} is a specialization of \tcode{duration}, and
 \tcode{treat_as_floating_point_v<typename ToDuration::rep>} is \tcode{false}.
 
 \pnum
-\returns \tcode{time_point<Clock, ToDuration>(round<ToDuration>(tp.time_since_epoch()))}.
+\returns
+\tcode{time_point<Clock, ToDuration>(round<ToDuration>(tp.time_since_epoch()))}.
 \end{itemdescr}
 
 \rSec1[time.clock]{Clocks}
@@ -2502,7 +2601,8 @@ static time_t to_time_t(const time_point& t) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns A \tcode{time_t} object that represents the same point in time as \tcode{t}
+\returns
+A \tcode{time_t} object that represents the same point in time as \tcode{t}
 when both values are restricted to the coarser of the precisions of \tcode{time_t} and
 \tcode{time_point}.
 It is \impldef{whether values are rounded or truncated to the
@@ -2517,7 +2617,8 @@ static time_point from_time_t(time_t t) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns A \tcode{time_point} object that represents the same point in time as \tcode{t}
+\returns
+A \tcode{time_point} object that represents the same point in time as \tcode{t}
 when both values are restricted to the coarser of the precisions of \tcode{time_t} and
 \tcode{time_point}.
 It is \impldef{whether values are rounded or truncated to the
@@ -2569,10 +2670,12 @@ template<class charT, class traits>
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{os << year_month_day\{dp\}}.
+\effects
+\tcode{os << year_month_day\{dp\}}.
 
 \pnum
-\returns \tcode{os}.
+\returns
+\tcode{os}.
 \end{itemdescr}
 
 \indexlibrarymember{from_stream}{sys_time}%
@@ -2586,7 +2689,8 @@ template<class charT, class traits, class Duration, class Alloc = allocator<char
 
 \begin{itemdescr}
 \pnum
-\effects Attempts to parse the input stream \tcode{is}
+\effects
+Attempts to parse the input stream \tcode{is}
 into the \tcode{sys_time} \tcode{tp} using
 the format flags given in the NTCTS \tcode{fmt}
 as specified in \ref{time.parse}.
@@ -2602,7 +2706,8 @@ from the successfully parsed timestamp
 prior to assigning that difference to \tcode{tp}.
 
 \pnum
-\returns \tcode{is}.
+\returns
+\tcode{is}.
 \end{itemdescr}
 
 \rSec2[time.clock.utc]{Class \tcode{utc_clock}}
@@ -2658,7 +2763,8 @@ static time_point now();
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{from_sys(system_clock::now())}, or a more accurate value of \tcode{utc_time}.
+\returns
+\tcode{from_sys(system_clock::now())}, or a more accurate value of \tcode{utc_time}.
 \end{itemdescr}
 
 \indexlibrarymember{to_sys}{utc_clock}%
@@ -2783,7 +2889,8 @@ the successfully parsed timestamp
 prior to assigning that difference to \tcode{tp}.
 
 \pnum
-\returns \tcode{is}.
+\returns
+\tcode{is}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{leap_second_info}}%
@@ -2872,7 +2979,8 @@ static time_point now();
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{from_utc(utc_clock::now())}, or a more accurate value of \tcode{tai_time}.
+\returns
+\tcode{from_utc(utc_clock::now())}, or a more accurate value of \tcode{tai_time}.
 \end{itemdescr}
 
 \indexlibrarymember{to_utc}{tai_clock}%
@@ -2976,7 +3084,8 @@ Additionally, the parsed offset will be subtracted from
 the successfully parsed timestamp prior to assigning that difference to \tcode{tp}.
 
 \pnum
-\returns \tcode{is}.
+\returns
+\tcode{is}.
 \end{itemdescr}
 
 \rSec2[time.clock.gps]{Class \tcode{gps_clock}}
@@ -3033,7 +3142,8 @@ static time_point now();
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{from_utc(utc_clock::now())}, or a more accurate value of \tcode{gps_time}.
+\returns
+\tcode{from_utc(utc_clock::now())}, or a more accurate value of \tcode{gps_time}.
 \end{itemdescr}
 
 \indexlibrarymember{to_utc}{gps_clock}%
@@ -3137,7 +3247,8 @@ Additionally, the parsed offset will be subtracted from
 the successfully parsed timestamp prior to assigning that difference to \tcode{tp}.
 
 \pnum
-\returns \tcode{is}.
+\returns
+\tcode{is}.
 \end{itemdescr}
 
 \rSec2[time.clock.file]{Type \tcode{file_clock}}
@@ -3243,7 +3354,8 @@ Additionally, the parsed offset will be subtracted from
 the successfully parsed timestamp prior to assigning that difference to \tcode{tp}.
 
 \pnum
-\returns \tcode{is}.
+\returns
+\tcode{is}.
 \end{itemdescr}
 
 \rSec2[time.clock.steady]{Class \tcode{steady_clock}}
@@ -3322,7 +3434,8 @@ os << sys_time<Duration>{lt.time_since_epoch()};
 \end{codeblock}
 
 \pnum
-\returns \tcode{os}.
+\returns
+\tcode{os}.
 \end{itemdescr}
 
 \indexlibrarymember{from_stream}{local_time}%
@@ -3350,7 +3463,8 @@ If \tcode{\%z} (or a modified variant) is used and successfully parsed,
 that value will be assigned to \tcode{*offset} if \tcode{offset} is non-null.
 
 \pnum
-\returns \tcode{is}.
+\returns
+\tcode{is}.
 \end{itemdescr}
 
 \rSec2[time.clock.cast]{\tcode{time_point} conversions}
@@ -3413,7 +3527,8 @@ template<class Duration>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{t}.
+\returns
+\tcode{t}.
 \end{itemdescr}
 
 \begin{codeblock}
@@ -3434,7 +3549,8 @@ template<class Duration>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{t}.
+\returns
+\tcode{t}.
 \end{itemdescr}
 
 \begin{codeblock}
@@ -3455,7 +3571,8 @@ template<class Duration>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{t}.
+\returns
+\tcode{t}.
 \end{itemdescr}
 
 \rSec3[time.clock.cast.sys.utc]{Conversions between \tcode{system_clock} and \tcode{utc_clock}}
@@ -3478,7 +3595,8 @@ template<class Duration>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{utc_clock::from_sys(t)}.
+\returns
+\tcode{utc_clock::from_sys(t)}.
 \end{itemdescr}
 
 \begin{codeblock}
@@ -3499,7 +3617,8 @@ template<class Duration>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{utc_clock::to_sys(t)}.
+\returns
+\tcode{utc_clock::to_sys(t)}.
 \end{itemdescr}
 
 \rSec3[time.clock.cast.sys]{Conversions between \tcode{system_clock} and other clocks}
@@ -3531,7 +3650,8 @@ where \tcode{Duration} is a valid \tcode{chrono::duration} specialization,
 the program is ill-formed.
 
 \pnum
-\returns \tcode{SourceClock::to_sys(t)}.
+\returns
+\tcode{SourceClock::to_sys(t)}.
 \end{itemdescr}
 
 \begin{codeblock}
@@ -3561,7 +3681,8 @@ where \tcode{Duration} is a valid \tcode{chrono::duration} specialization,
 the program is ill-formed.
 
 \pnum
-\returns \tcode{DestClock::from_sys(t)}.
+\returns
+\tcode{DestClock::from_sys(t)}.
 \end{itemdescr}
 
 \rSec3[time.clock.cast.utc]{Conversions between \tcode{utc_clock} and other clocks}
@@ -3593,7 +3714,8 @@ where \tcode{Duration} is a valid \tcode{chrono::duration} specialization,
 the program is ill-formed.
 
 \pnum
-\returns \tcode{SourceClock::to_utc(t)}.
+\returns
+\tcode{SourceClock::to_utc(t)}.
 \end{itemdescr}
 
 \begin{codeblock}
@@ -3623,7 +3745,8 @@ where \tcode{Duration} is a valid \tcode{chrono::duration} specialization,
 the program is ill-formed.
 
 \pnum
-\returns \tcode{DestClock::from_utc(t)}.
+\returns
+\tcode{DestClock::from_utc(t)}.
 \end{itemdescr}
 
 \rSec3[time.clock.cast.fn]{Function template \tcode{clock_cast}}
@@ -3777,10 +3900,12 @@ constexpr day& operator++() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{++d_}.
+\effects
+\tcode{++d_}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator++}{day}%
@@ -3790,10 +3915,12 @@ constexpr day operator++(int) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{++(*this)}.
+\effects
+\tcode{++(*this)}.
 
 \pnum
-\returns A copy of \tcode{*this} as it existed on entry to this member function.
+\returns
+A copy of \tcode{*this} as it existed on entry to this member function.
 \end{itemdescr}
 
 \indexlibrarymember{operator--}{day}%
@@ -3803,10 +3930,12 @@ constexpr day& operator--() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{--d_}.
+\effects
+\tcode{--d_}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator--}{day}%
@@ -3816,10 +3945,12 @@ constexpr day operator--(int) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{--(*this)}.
+\effects
+\tcode{--(*this)}.
 
 \pnum
-\returns A copy of \tcode{*this} as it existed on entry to this member function.
+\returns
+A copy of \tcode{*this} as it existed on entry to this member function.
 \end{itemdescr}
 
 \indexlibrarymember{operator+=}{day}%
@@ -3829,10 +3960,12 @@ constexpr day& operator+=(const days& d) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this = *this + d}.
+\effects
+\tcode{*this = *this + d}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-=}{day}%
@@ -3842,10 +3975,12 @@ constexpr day& operator-=(const days& d) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this = *this - d}.
+\effects
+\tcode{*this = *this - d}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator unsigned}{day}%
@@ -3855,7 +3990,8 @@ constexpr explicit operator unsigned() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{d_}.
+\returns
+\tcode{d_}.
 \end{itemdescr}
 
 \indexlibrarymember{ok}{day}%
@@ -3865,7 +4001,8 @@ constexpr bool ok() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{1 <= d_ \&\& d_ <= 31}.
+\returns
+\tcode{1 <= d_ \&\& d_ <= 31}.
 \end{itemdescr}
 
 \rSec3[time.cal.day.nonmembers]{Non-member functions}
@@ -3877,7 +4014,8 @@ constexpr bool operator==(const day& x, const day& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{unsigned\{x\} == unsigned\{y\}}.
+\returns
+\tcode{unsigned\{x\} == unsigned\{y\}}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{day}%
@@ -3887,7 +4025,8 @@ constexpr strong_ordering operator<=>(const day& x, const day& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{unsigned\{x\} <=> unsigned\{y\}}.
+\returns
+\tcode{unsigned\{x\} <=> unsigned\{y\}}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+}{day}%
@@ -3897,7 +4036,8 @@ constexpr day operator+(const day& x, const days& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{day(unsigned\{x\} + y.count())}.
+\returns
+\tcode{day(unsigned\{x\} + y.count())}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+}{day}%
@@ -3907,7 +4047,8 @@ constexpr day operator+(const days& x, const day& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{y + x}.
+\returns
+\tcode{y + x}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{day}%
@@ -3917,7 +4058,8 @@ constexpr day operator-(const day& x, const days& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x + -y}.
+\returns
+\tcode{x + -y}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{day}%
@@ -3927,7 +4069,8 @@ constexpr days operator-(const day& x, const day& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{days\{int(unsigned\{x\}) - int(unsigned\{y\})}.
+\returns
+\tcode{days\{int(unsigned\{x\}) - int(unsigned\{y\})}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<<}{day}%
@@ -3973,7 +4116,8 @@ If \tcode{\%z} (or a modified variant) is used and successfully parsed,
 that value will be assigned to \tcode{*offset} if \tcode{offset} is non-null.
 
 \pnum
-\returns \tcode{is}.
+\returns
+\tcode{is}.
 \end{itemdescr}
 
 \indexlibrarymember{operator""""d}{day}%
@@ -3983,7 +4127,8 @@ constexpr day operator""d(unsigned long long d) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{day\{static_cast<unsigned>(d)\}}.
+\returns
+\tcode{day\{static_cast<unsigned>(d)\}}.
 \end{itemdescr}
 
 \rSec2[time.cal.month]{Class \tcode{month}}
@@ -4049,10 +4194,12 @@ constexpr month& month::operator++() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this += months\{1\}}.
+\effects
+\tcode{*this += months\{1\}}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator++}{month}%
@@ -4062,10 +4209,12 @@ constexpr month operator++(int) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{++(*this)}.
+\effects
+\tcode{++(*this)}.
 
 \pnum
-\returns A copy of \tcode{*this} as it existed on entry to this member function.
+\returns
+A copy of \tcode{*this} as it existed on entry to this member function.
 \end{itemdescr}
 
 \indexlibrarymember{operator--}{month}%
@@ -4075,10 +4224,12 @@ constexpr month& operator--() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this -= months\{1\}}.
+\effects
+\tcode{*this -= months\{1\}}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator--}{month}%
@@ -4088,10 +4239,12 @@ constexpr month operator--(int) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{--(*this)}.
+\effects
+\tcode{--(*this)}.
 
 \pnum
-\returns A copy of \tcode{*this} as it existed on entry to this member function.
+\returns
+A copy of \tcode{*this} as it existed on entry to this member function.
 \end{itemdescr}
 
 \indexlibrarymember{operator+=}{month}%
@@ -4101,10 +4254,12 @@ constexpr month& operator+=(const months& m) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this = *this + m}.
+\effects
+\tcode{*this = *this + m}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-=}{month}%
@@ -4114,10 +4269,12 @@ constexpr month& operator-=(const months& m) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this = *this - m}.
+\effects
+\tcode{*this = *this - m}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator unsigned}{month}%
@@ -4127,7 +4284,8 @@ constexpr explicit month::operator unsigned() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{m_}.
+\returns
+\tcode{m_}.
 \end{itemdescr}
 
 \indexlibrarymember{ok}{month}%
@@ -4137,7 +4295,8 @@ constexpr bool month::ok() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{1 <= m_ \&\& m_ <= 12}.
+\returns
+\tcode{1 <= m_ \&\& m_ <= 12}.
 \end{itemdescr}
 
 \rSec3[time.cal.month.nonmembers]{Non-member functions}
@@ -4149,7 +4308,8 @@ constexpr bool operator==(const month& x, const month& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{unsigned\{x\} == unsigned\{y\}}.
+\returns
+\tcode{unsigned\{x\} == unsigned\{y\}}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{month}%
@@ -4159,7 +4319,8 @@ constexpr strong_ordering operator<=>(const month& x, const month& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{unsigned\{x\} <=> unsigned\{y\}}.
+\returns
+\tcode{unsigned\{x\} <=> unsigned\{y\}}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+}{month}%
@@ -4192,7 +4353,8 @@ constexpr month operator+(const months& x, const month& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{y + x}.
+\returns
+\tcode{y + x}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{month}%
@@ -4202,7 +4364,8 @@ constexpr month operator-(const month& x, const months& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x + -y}.
+\returns
+\tcode{x + -y}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{month}%
@@ -4268,7 +4431,8 @@ If \tcode{\%z} (or a modified variant) is used and successfully parsed,
 that value will be assigned to \tcode{*offset} if \tcode{offset} is non-null.
 
 \pnum
-\returns \tcode{is}.
+\returns
+\tcode{is}.
 \end{itemdescr}
 
 \rSec2[time.cal.year]{Class \tcode{year}}
@@ -4341,10 +4505,12 @@ constexpr year& operator++() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{++y_}.
+\effects
+\tcode{++y_}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator++}{year}%
@@ -4354,10 +4520,12 @@ constexpr year operator++(int) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{++(*this)}.
+\effects
+\tcode{++(*this)}.
 
 \pnum
-\returns A copy of \tcode{*this} as it existed on entry to this member function.
+\returns
+A copy of \tcode{*this} as it existed on entry to this member function.
 \end{itemdescr}
 
 \indexlibrarymember{operator--}{year}%
@@ -4367,10 +4535,12 @@ constexpr year& operator--() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{--y_}.
+\effects
+\tcode{--y_}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator--}{year}%
@@ -4380,10 +4550,12 @@ constexpr year operator--(int) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{--(*this)}.
+\effects
+\tcode{--(*this)}.
 
 \pnum
-\returns A copy of \tcode{*this} as it existed on entry to this member function.
+\returns
+A copy of \tcode{*this} as it existed on entry to this member function.
 \end{itemdescr}
 
 \indexlibrarymember{operator+=}{year}%
@@ -4393,10 +4565,12 @@ constexpr year& operator+=(const years& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this = *this + y}.
+\effects
+\tcode{*this = *this + y}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-=}{year}%
@@ -4406,10 +4580,12 @@ constexpr year& operator-=(const years& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this = *this - y}.
+\effects
+\tcode{*this = *this - y}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+}{year}%
@@ -4419,7 +4595,8 @@ constexpr year operator+() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{year}%
@@ -4429,7 +4606,8 @@ constexpr year year::operator-() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{year\{-y_\}}.
+\returns
+\tcode{year\{-y_\}}.
 \end{itemdescr}
 
 \indexlibrarymember{is_leap}{year}%
@@ -4439,7 +4617,8 @@ constexpr bool is_leap() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{y_ \% 4 == 0 \&\& (y_ \% 100 != 0 || y_ \% 400 == 0)}.
+\returns
+\tcode{y_ \% 4 == 0 \&\& (y_ \% 100 != 0 || y_ \% 400 == 0)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator int}{year}%
@@ -4449,7 +4628,8 @@ constexpr explicit operator int() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{y_}.
+\returns
+\tcode{y_}.
 \end{itemdescr}
 
 \indexlibrarymember{ok}{year}%
@@ -4459,7 +4639,8 @@ constexpr bool ok() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{min().y_ <= y_ \&\& y_ <= max().y_}.
+\returns
+\tcode{min().y_ <= y_ \&\& y_ <= max().y_}.
 \end{itemdescr}
 
 \indexlibrarymember{min}{year}%
@@ -4469,7 +4650,8 @@ static constexpr year min() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{year\{-32767\}}.
+\returns
+\tcode{year\{-32767\}}.
 \end{itemdescr}
 
 \indexlibrarymember{max}{year}%
@@ -4479,7 +4661,8 @@ static constexpr year max() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{year\{32767\}}.
+\returns
+\tcode{year\{32767\}}.
 \end{itemdescr}
 
 \rSec3[time.cal.year.nonmembers]{Non-member functions}
@@ -4491,7 +4674,8 @@ constexpr bool operator==(const year& x, const year& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{int\{x\} == int\{y\}}.
+\returns
+\tcode{int\{x\} == int\{y\}}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{year}%
@@ -4501,7 +4685,8 @@ constexpr strong_ordering operator<=>(const year& x, const year& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{int\{x\} <=> int\{y\}}.
+\returns
+\tcode{int\{x\} <=> int\{y\}}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+}{year}%
@@ -4511,7 +4696,8 @@ constexpr year operator+(const year& x, const years& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{year\{int\{x\} + y.count()\}}.
+\returns
+\tcode{year\{int\{x\} + y.count()\}}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+}{year}%
@@ -4521,7 +4707,8 @@ constexpr year operator+(const years& x, const year& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{y + x}.
+\returns
+\tcode{y + x}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{year}%
@@ -4531,7 +4718,8 @@ constexpr year operator-(const year& x, const years& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x + -y}.
+\returns
+\tcode{x + -y}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{year}%
@@ -4541,7 +4729,8 @@ constexpr years operator-(const year& x, const year& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{years\{int\{x\} - int\{y\}\}}.
+\returns
+\tcode{years\{int\{x\} - int\{y\}\}}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<<}{year}%
@@ -4587,7 +4776,8 @@ If \tcode{\%z} (or a modified variant) is used and successfully parsed,
 that value will be assigned to \tcode{*offset} if \tcode{offset} is non-null.
 
 \pnum
-\returns \tcode{is}.
+\returns
+\tcode{is}.
 \end{itemdescr}
 
 \indexlibrarymember{operator""""y}{year}%
@@ -4597,7 +4787,8 @@ constexpr year operator""y(unsigned long long y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{year\{static_cast<int>(y)\}}.
+\returns
+\tcode{year\{static_cast<int>(y)\}}.
 \end{itemdescr}
 
 \rSec2[time.cal.wd]{Class \tcode{weekday}}
@@ -4712,10 +4903,12 @@ constexpr weekday& operator++() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this += days\{1\}}.
+\effects
+\tcode{*this += days\{1\}}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator++}{weekday}%
@@ -4725,10 +4918,12 @@ constexpr weekday operator++(int) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{++(*this)}.
+\effects
+\tcode{++(*this)}.
 
 \pnum
-\returns A copy of \tcode{*this} as it existed on entry to this member function.
+\returns
+A copy of \tcode{*this} as it existed on entry to this member function.
 \end{itemdescr}
 
 \indexlibrarymember{operator--}{weekday}%
@@ -4738,10 +4933,12 @@ constexpr weekday& operator--() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this -= days\{1\}}.
+\effects
+\tcode{*this -= days\{1\}}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator--}{weekday}%
@@ -4751,10 +4948,12 @@ constexpr weekday operator--(int) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{--(*this)}.
+\effects
+\tcode{--(*this)}.
 
 \pnum
-\returns A copy of \tcode{*this} as it existed on entry to this member function.
+\returns
+A copy of \tcode{*this} as it existed on entry to this member function.
 \end{itemdescr}
 
 \indexlibrarymember{operator+=}{weekday}%
@@ -4764,10 +4963,12 @@ constexpr weekday& operator+=(const days& d) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this = *this + d}.
+\effects
+\tcode{*this = *this + d}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-=}{weekday}%
@@ -4777,10 +4978,12 @@ constexpr weekday& operator-=(const days& d) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this = *this - d}.
+\effects
+\tcode{*this = *this - d}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{c_encoding}{weekday}%
@@ -4790,7 +4993,8 @@ constexpr unsigned c_encoding() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{wd_}.
+\returns
+\tcode{wd_}.
 \end{itemdescr}
 
 \indexlibrarymember{iso_encoding}{weekday}%
@@ -4800,7 +5004,8 @@ constexpr unsigned iso_encoding() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{wd_ == 0u ?\ 7u :\ wd_}.
+\returns
+\tcode{wd_ == 0u ?\ 7u :\ wd_}.
 \end{itemdescr}
 
 \indexlibrarymember{ok}{weekday}%
@@ -4810,7 +5015,8 @@ constexpr bool ok() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{wd_ <= 6}.
+\returns
+\tcode{wd_ <= 6}.
 \end{itemdescr}
 
 \indexlibrarymember{operator[]}{weekday}%
@@ -4820,7 +5026,8 @@ constexpr weekday_indexed operator[](unsigned index) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{\{*this, index\}}.
+\returns
+\tcode{\{*this, index\}}.
 \end{itemdescr}
 
 \indexlibrarymember{operator[]}{weekday}%
@@ -4830,7 +5037,8 @@ constexpr weekday_last operator[](last_spec) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{weekday_last\{*this\}}.
+\returns
+\tcode{weekday_last\{*this\}}.
 \end{itemdescr}
 
 \rSec3[time.cal.wd.nonmembers]{Non-member functions}
@@ -4842,7 +5050,8 @@ constexpr bool operator==(const weekday& x, const weekday& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x.wd_ == y.wd_}.
+\returns
+\tcode{x.wd_ == y.wd_}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+}{weekday}%
@@ -4875,7 +5084,8 @@ constexpr weekday operator+(const days& x, const weekday& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{y + x}.
+\returns
+\tcode{y + x}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{weekday}%
@@ -4885,7 +5095,8 @@ constexpr weekday operator-(const weekday& x, const days& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x + -y}.
+\returns
+\tcode{x + -y}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{weekday}%
@@ -4951,7 +5162,8 @@ If \tcode{\%z} (or a modified variant) is used and successfully parsed,
 that value will be assigned to \tcode{*offset} if \tcode{offset} is non-null.
 
 \pnum
-\returns \tcode{is}.
+\returns
+\tcode{is}.
 \end{itemdescr}
 
 \rSec2[time.cal.wdidx]{Class \tcode{weekday_indexed}}
@@ -5021,7 +5233,8 @@ constexpr chrono::weekday weekday() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{wd_}.
+\returns
+\tcode{wd_}.
 \end{itemdescr}
 
 \indexlibrarymember{index}{weekday_indexed}%
@@ -5031,7 +5244,8 @@ constexpr unsigned index() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{index_}.
+\returns
+\tcode{index_}.
 \end{itemdescr}
 
 \indexlibrarymember{ok}{weekday_indexed}%
@@ -5041,7 +5255,8 @@ constexpr bool ok() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{wd_.ok() \&\& 1 <= index_ \&\& index_ <= 5}.
+\returns
+\tcode{wd_.ok() \&\& 1 <= index_ \&\& index_ <= 5}.
 \end{itemdescr}
 
 \rSec3[time.cal.wdidx.nonmembers]{Non-member functions}
@@ -5053,7 +5268,8 @@ constexpr bool operator==(const weekday_indexed& x, const weekday_indexed& y) no
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x.weekday() == y.weekday() \&\& x.index() == y.index()}.
+\returns
+\tcode{x.weekday() == y.weekday() \&\& x.index() == y.index()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<<}{weekday_indexed}%
@@ -5134,7 +5350,8 @@ constexpr chrono::weekday weekday() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{wd_}.
+\returns
+\tcode{wd_}.
 \end{itemdescr}
 
 \indexlibrarymember{ok}{weekday_last}%
@@ -5144,7 +5361,8 @@ constexpr bool ok() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{wd_.ok()}.
+\returns
+\tcode{wd_.ok()}.
 \end{itemdescr}
 
 \rSec3[time.cal.wdlast.nonmembers]{Non-member functions}
@@ -5156,7 +5374,8 @@ constexpr bool operator==(const weekday_last& x, const weekday_last& y) noexcept
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x.weekday() == y.weekday()}.
+\returns
+\tcode{x.weekday() == y.weekday()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<<}{weekday_last}%
@@ -5227,7 +5446,8 @@ constexpr chrono::month month() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{m_}.
+\returns
+\tcode{m_}.
 \end{itemdescr}
 
 \indexlibrarymember{day}{month_day}%
@@ -5237,7 +5457,8 @@ constexpr chrono::day day() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{d_}.
+\returns
+\tcode{d_}.
 \end{itemdescr}
 
 \indexlibrarymember{ok}{month_day}%
@@ -5266,7 +5487,8 @@ constexpr bool operator==(const month_day& x, const month_day& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x.month() == y.month() \&\& x.day() == y.day()}.
+\returns
+\tcode{x.month() == y.month() \&\& x.day() == y.day()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{month_day}%
@@ -5326,7 +5548,8 @@ If \tcode{\%z} (or a modified variant) is used and successfully parsed,
 that value will be assigned to \tcode{*offset} if \tcode{offset} is non-null.
 
 \pnum
-\returns \tcode{is}.
+\returns
+\tcode{is}.
 \end{itemdescr}
 
 \rSec2[time.cal.mdlast]{Class \tcode{month_day_last}}
@@ -5384,7 +5607,8 @@ constexpr month month() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{m_}.
+\returns
+\tcode{m_}.
 \end{itemdescr}
 
 \indexlibrarymember{ok}{month_day_last}%
@@ -5394,7 +5618,8 @@ constexpr bool ok() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{m_.ok()}.
+\returns
+\tcode{m_.ok()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator==}{month_day_last}%
@@ -5404,7 +5629,8 @@ constexpr bool operator==(const month_day_last& x, const month_day_last& y) noex
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x.month() == y.month()}.
+\returns
+\tcode{x.month() == y.month()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{month_day_last}%
@@ -5414,7 +5640,8 @@ constexpr strong_ordering operator<=>(const month_day_last& x, const month_day_l
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x.month() <=> y.month()}.
+\returns
+\tcode{x.month() <=> y.month()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<<}{month_day_last}%
@@ -5492,7 +5719,8 @@ constexpr chrono::month month() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{m_}.
+\returns
+\tcode{m_}.
 \end{itemdescr}
 
 \indexlibrarymember{weekday_indexed}{month_weekday}%
@@ -5502,7 +5730,8 @@ constexpr chrono::weekday_indexed weekday_indexed() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{wdi_}.
+\returns
+\tcode{wdi_}.
 \end{itemdescr}
 
 \indexlibrarymember{ok}{month_weekday}%
@@ -5512,7 +5741,8 @@ constexpr bool ok() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{m_.ok() \&\& wdi_.ok()}.
+\returns
+\tcode{m_.ok() \&\& wdi_.ok()}.
 \end{itemdescr}
 
 \rSec3[time.cal.mwd.nonmembers]{Non-member functions}
@@ -5524,7 +5754,8 @@ constexpr bool operator==(const month_weekday& x, const month_weekday& y) noexce
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x.month() == y.month() \&\& x.weekday_indexed() == y.weekday_indexed()}.
+\returns
+\tcode{x.month() == y.month() \&\& x.weekday_indexed() == y.weekday_indexed()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<<}{month_weekday}%
@@ -5605,7 +5836,8 @@ constexpr chrono::month month() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{m_}.
+\returns
+\tcode{m_}.
 \end{itemdescr}
 
 \indexlibrarymember{weekday_last}{month_weekday_last}%
@@ -5615,7 +5847,8 @@ constexpr chrono::weekday_last weekday_last() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{wdl_}.
+\returns
+\tcode{wdl_}.
 \end{itemdescr}
 
 \indexlibrarymember{ok}{month_weekday_last}%
@@ -5625,7 +5858,8 @@ constexpr bool ok() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{m_.ok() \&\& wdl_.ok()}.
+\returns
+\tcode{m_.ok() \&\& wdl_.ok()}.
 \end{itemdescr}
 
 \rSec3[time.cal.mwdlast.nonmembers]{Non-member functions}
@@ -5637,7 +5871,8 @@ constexpr bool operator==(const month_weekday_last& x, const month_weekday_last&
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x.month() == y.month() \&\& x.weekday_last() == y.weekday_last()}.
+\returns
+\tcode{x.month() == y.month() \&\& x.weekday_last() == y.weekday_last()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<<}{month_weekday_last}%
@@ -5716,7 +5951,8 @@ constexpr chrono::year year() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{y_}.
+\returns
+\tcode{y_}.
 \end{itemdescr}
 
 \indexlibrarymember{month}{year_month}%
@@ -5726,7 +5962,8 @@ constexpr chrono::month month() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{m_}.
+\returns
+\tcode{m_}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+=}{year_month}%
@@ -5736,10 +5973,12 @@ constexpr year_month& operator+=(const months& dm) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this = *this + dm}.
+\effects
+\tcode{*this = *this + dm}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-=}{year_month}%
@@ -5749,10 +5988,12 @@ constexpr year_month& operator-=(const months& dm) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this = *this - dm}.
+\effects
+\tcode{*this = *this - dm}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+=}{year_month}%
@@ -5762,10 +6003,12 @@ constexpr year_month& operator+=(const years& dy) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this = *this + dy}.
+\effects
+\tcode{*this = *this + dy}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-=}{year_month}%
@@ -5775,10 +6018,12 @@ constexpr year_month& operator-=(const years& dy) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this = *this - dy}.
+\effects
+\tcode{*this = *this - dy}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{ok}{year_month}%
@@ -5788,7 +6033,8 @@ constexpr bool ok() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{y_.ok() \&\& m_.ok()}.
+\returns
+\tcode{y_.ok() \&\& m_.ok()}.
 \end{itemdescr}
 
 \rSec3[time.cal.ym.nonmembers]{Non-member functions}
@@ -5800,7 +6046,8 @@ constexpr bool operator==(const year_month& x, const year_month& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x.year() == y.year() \&\& x.month() == y.month()}.
+\returns
+\tcode{x.year() == y.year() \&\& x.month() == y.month()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{year_month}%
@@ -5825,7 +6072,8 @@ constexpr year_month operator+(const year_month& ym, const months& dm) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns A \tcode{year_month} value \tcode{z} such that \tcode{z - ym == dm}.
+\returns
+A \tcode{year_month} value \tcode{z} such that \tcode{z - ym == dm}.
 
 \pnum
 \complexity
@@ -5839,7 +6087,8 @@ constexpr year_month operator+(const months& dm, const year_month& ym) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ym + dm}.
+\returns
+\tcode{ym + dm}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{year_month}%
@@ -5849,7 +6098,8 @@ constexpr year_month operator-(const year_month& ym, const months& dm) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ym + -dm}.
+\returns
+\tcode{ym + -dm}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{year_month}%
@@ -5873,7 +6123,8 @@ constexpr year_month operator+(const year_month& ym, const years& dy) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{(ym.year() + dy) / ym.month()}.
+\returns
+\tcode{(ym.year() + dy) / ym.month()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+}{year_month}%
@@ -5883,7 +6134,8 @@ constexpr year_month operator+(const years& dy, const year_month& ym) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ym + dy}.
+\returns
+\tcode{ym + dy}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{year_month}%
@@ -5893,7 +6145,8 @@ constexpr year_month operator-(const year_month& ym, const years& dy) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ym + -dy}.
+\returns
+\tcode{ym + -dy}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<<}{year_month}%
@@ -5938,7 +6191,8 @@ If \tcode{\%z} (or a modified variant) is used and successfully parsed,
 that value will be assigned to \tcode{*offset} if \tcode{offset} is non-null.
 
 \pnum
-\returns \tcode{is}.
+\returns
+\tcode{is}.
 \end{itemdescr}
 
 \rSec2[time.cal.ymd]{Class \tcode{year_month_day}}
@@ -6072,10 +6326,12 @@ constexpr year_month_day& operator+=(const months& m) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this = *this + m}.
+\effects
+\tcode{*this = *this + m}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-=}{year_month_day}%
@@ -6085,10 +6341,12 @@ constexpr year_month_day& operator-=(const months& m) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this = *this - m}.
+\effects
+\tcode{*this = *this - m}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+=}{year_month_day}%
@@ -6098,10 +6356,12 @@ constexpr year_month_day& year_month_day::operator+=(const years& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this = *this + y}.
+\effects
+\tcode{*this = *this + y}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-=}{year_month_day}%
@@ -6111,10 +6371,12 @@ constexpr year_month_day& year_month_day::operator-=(const years& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this = *this - y}.
+\effects
+\tcode{*this = *this - y}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{year}{year_month_day}%
@@ -6124,7 +6386,8 @@ constexpr chrono::year year() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{y_}.
+\returns
+\tcode{y_}.
 \end{itemdescr}
 
 \indexlibrarymember{month}{year_month_day}%
@@ -6134,7 +6397,8 @@ constexpr chrono::month month() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{m_}.
+\returns
+\tcode{m_}.
 \end{itemdescr}
 
 \indexlibrarymember{day}{year_month_day}%
@@ -6144,7 +6408,8 @@ constexpr chrono::day day() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{d_}.
+\returns
+\tcode{d_}.
 \end{itemdescr}
 
 \indexlibrarymember{operator sys_days}{year_month_day}%
@@ -6186,7 +6451,8 @@ constexpr explicit operator local_days() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{local_days\{sys_days\{*this\}.time_since_epoch()\}}.
+\returns
+\tcode{local_days\{sys_days\{*this\}.time_since_epoch()\}}.
 \end{itemdescr}
 
 \indexlibrarymember{ok}{year_month_day}%
@@ -6212,7 +6478,8 @@ constexpr bool operator==(const year_month_day& x, const year_month_day& y) noex
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x.year() == y.year() \&\& x.month() == y.month() \&\& x.day() == y.day()}.
+\returns
+\tcode{x.year() == y.year() \&\& x.month() == y.month() \&\& x.day() == y.day()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{year_month_day}%
@@ -6238,7 +6505,8 @@ constexpr year_month_day operator+(const year_month_day& ymd, const months& dm) 
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{(ymd.year() / ymd.month() + dm) / ymd.day()}.
+\returns
+\tcode{(ymd.year() / ymd.month() + dm) / ymd.day()}.
 
 \pnum
 \begin{note}
@@ -6255,7 +6523,8 @@ constexpr year_month_day operator+(const months& dm, const year_month_day& ymd) 
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ymd + dm}.
+\returns
+\tcode{ymd + dm}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{year_month_day}%
@@ -6265,7 +6534,8 @@ constexpr year_month_day operator-(const year_month_day& ymd, const months& dm) 
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ymd + (-dm)}.
+\returns
+\tcode{ymd + (-dm)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+}{year_month_day}%
@@ -6275,7 +6545,8 @@ constexpr year_month_day operator+(const year_month_day& ymd, const years& dy) n
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{(ymd.year() + dy) / ymd.month() / ymd.day()}.
+\returns
+\tcode{(ymd.year() + dy) / ymd.month() / ymd.day()}.
 
 \pnum
 \begin{note}
@@ -6293,7 +6564,8 @@ constexpr year_month_day operator+(const years& dy, const year_month_day& ymd) n
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ymd + dy}.
+\returns
+\tcode{ymd + dy}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{year_month_day}%
@@ -6303,7 +6575,8 @@ constexpr year_month_day operator-(const year_month_day& ymd, const years& dy) n
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ymd + (-dy)}.
+\returns
+\tcode{ymd + (-dy)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<<}{year_month_day}%
@@ -6349,7 +6622,8 @@ If \tcode{\%z} (or a modified variant) is used and successfully parsed,
 that value will be assigned to \tcode{*offset} if \tcode{offset} is non-null.
 
 \pnum
-\returns \tcode{is}.
+\returns
+\tcode{is}.
 \end{itemdescr}
 
 \rSec2[time.cal.ymdlast]{Class \tcode{year_month_day_last}}
@@ -6422,10 +6696,12 @@ constexpr year_month_day_last& operator+=(const months& m) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this = *this + m}.
+\effects
+\tcode{*this = *this + m}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-=}{year_month_day_last}%
@@ -6435,10 +6711,12 @@ constexpr year_month_day_last& operator-=(const months& m) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this = *this - m}.
+\effects
+\tcode{*this = *this - m}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+=}{year_month_day_last}%
@@ -6448,10 +6726,12 @@ constexpr year_month_day_last& operator+=(const years& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this = *this + y}.
+\effects
+\tcode{*this = *this + y}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-=}{year_month_day_last}%
@@ -6461,10 +6741,12 @@ constexpr year_month_day_last& operator-=(const years& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this = *this - y}.
+\effects
+\tcode{*this = *this - y}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{year}{year_month_day_last}%
@@ -6474,7 +6756,8 @@ constexpr chrono::year year() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{y_}.
+\returns
+\tcode{y_}.
 \end{itemdescr}
 
 \indexlibrarymember{month}{year_month_day_last}%
@@ -6484,7 +6767,8 @@ constexpr chrono::month month() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{mdl_.month()}.
+\returns
+\tcode{mdl_.month()}.
 \end{itemdescr}
 
 \indexlibrarymember{month_day_last}{year_month_day_last}%
@@ -6494,7 +6778,8 @@ constexpr chrono::month_day_last month_day_last() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{mdl_}.
+\returns
+\tcode{mdl_}.
 \end{itemdescr}
 
 \indexlibrarymember{day}{year_month_day_last}%
@@ -6521,7 +6806,8 @@ constexpr operator sys_days() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{sys_days\{year()/month()/day()\}}.
+\returns
+\tcode{sys_days\{year()/month()/day()\}}.
 \end{itemdescr}
 
 \indexlibrarymember{operator local_days}{year_month_day_last}%
@@ -6531,7 +6817,8 @@ constexpr explicit operator local_days() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{local_days\{sys_days\{*this\}.time_since_epoch()\}}.
+\returns
+\tcode{local_days\{sys_days\{*this\}.time_since_epoch()\}}.
 \end{itemdescr}
 
 \indexlibrarymember{ok}{year_month_day_last}%
@@ -6541,7 +6828,8 @@ constexpr bool ok() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{y_.ok() \&\& mdl_.ok()}.
+\returns
+\tcode{y_.ok() \&\& mdl_.ok()}.
 \end{itemdescr}
 
 \rSec3[time.cal.ymdlast.nonmembers]{Non-member functions}
@@ -6553,7 +6841,8 @@ constexpr bool operator==(const year_month_day_last& x, const year_month_day_las
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x.year() == y.year() \&\& x.month_day_last() == y.month_day_last()}.
+\returns
+\tcode{x.year() == y.year() \&\& x.month_day_last() == y.month_day_last()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{year_month_day_last}%
@@ -6580,7 +6869,8 @@ constexpr year_month_day_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{(ymdl.year() / ymdl.month() + dm) / last}.
+\returns
+\tcode{(ymdl.year() / ymdl.month() + dm) / last}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+}{year_month_day_last}%
@@ -6591,7 +6881,8 @@ constexpr year_month_day_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ymdl + dm}.
+\returns
+\tcode{ymdl + dm}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{year_month_day_last}%
@@ -6602,7 +6893,8 @@ constexpr year_month_day_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ymdl + (-dm)}.
+\returns
+\tcode{ymdl + (-dm)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+}{year_month_day_last}%
@@ -6613,7 +6905,8 @@ constexpr year_month_day_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{\{ymdl.year()+dy, ymdl.month_day_last()\}}.
+\returns
+\tcode{\{ymdl.year()+dy, ymdl.month_day_last()\}}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+}{year_month_day_last}%
@@ -6624,7 +6917,8 @@ constexpr year_month_day_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ymdl + dy}.
+\returns
+\tcode{ymdl + dy}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{year_month_day_last}%
@@ -6635,7 +6929,8 @@ constexpr year_month_day_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ymdl + (-dy)}.
+\returns
+\tcode{ymdl + (-dy)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<<}{year_month_day_last}%
@@ -6763,10 +7058,12 @@ constexpr year_month_weekday& operator+=(const months& m) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this = *this + m}.
+\effects
+\tcode{*this = *this + m}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-=}{year_month_weekday}%
@@ -6776,10 +7073,12 @@ constexpr year_month_weekday& operator-=(const months& m) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this = *this - m}.
+\effects
+\tcode{*this = *this - m}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+=}{year_month_weekday}%
@@ -6789,10 +7088,12 @@ constexpr year_month_weekday& operator+=(const years& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this = *this + y}.
+\effects
+\tcode{*this = *this + y}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-=}{year_month_weekday}%
@@ -6802,10 +7103,12 @@ constexpr year_month_weekday& operator-=(const years& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this = *this - y}.
+\effects
+\tcode{*this = *this - y}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{year}{year_month_weekday}%
@@ -6815,7 +7118,8 @@ constexpr chrono::year year() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{y_}.
+\returns
+\tcode{y_}.
 \end{itemdescr}
 
 \indexlibrarymember{month}{year_month_weekday}%
@@ -6825,7 +7129,8 @@ constexpr chrono::month month() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{m_}.
+\returns
+\tcode{m_}.
 \end{itemdescr}
 
 \indexlibrarymember{weekday}{year_month_weekday}%
@@ -6835,7 +7140,8 @@ constexpr chrono::weekday weekday() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{wdi_.weekday()}.
+\returns
+\tcode{wdi_.weekday()}.
 \end{itemdescr}
 
 \indexlibrarymember{index}{year_month_weekday}%
@@ -6845,7 +7151,8 @@ constexpr unsigned index() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{wdi_.index()}.
+\returns
+\tcode{wdi_.index()}.
 \end{itemdescr}
 
 \indexlibrarymember{weekday_indexed}{year_month_weekday}%
@@ -6855,7 +7162,8 @@ constexpr chrono::weekday_indexed weekday_indexed() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{wdi_}.
+\returns
+\tcode{wdi_}.
 \end{itemdescr}
 
 \indexlibrarymember{operator sys_days}{year_month_weekday}%
@@ -6884,7 +7192,8 @@ constexpr explicit operator local_days() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{local_days\{sys_days\{*this\}.time_since_epoch()\}}.
+\returns
+\tcode{local_days\{sys_days\{*this\}.time_since_epoch()\}}.
 \end{itemdescr}
 
 \indexlibrarymember{ok}{year_month_weekday}%
@@ -6927,7 +7236,8 @@ constexpr year_month_weekday operator+(const year_month_weekday& ymwd, const mon
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{(ymwd.year() / ymwd.month() + dm) / ymwd.weekday_indexed()}.
+\returns
+\tcode{(ymwd.year() / ymwd.month() + dm) / ymwd.weekday_indexed()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+}{year_month_weekday}%
@@ -6937,7 +7247,8 @@ constexpr year_month_weekday operator+(const months& dm, const year_month_weekda
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ymwd + dm}.
+\returns
+\tcode{ymwd + dm}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{year_month_weekday}%
@@ -6947,7 +7258,8 @@ constexpr year_month_weekday operator-(const year_month_weekday& ymwd, const mon
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ymwd + (-dm)}.
+\returns
+\tcode{ymwd + (-dm)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+}{year_month_weekday}%
@@ -6957,7 +7269,8 @@ constexpr year_month_weekday operator+(const year_month_weekday& ymwd, const yea
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{\{ymwd.year()+dy, ymwd.month(), ymwd.weekday_indexed()\}}.
+\returns
+\tcode{\{ymwd.year()+dy, ymwd.month(), ymwd.weekday_indexed()\}}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+}{year_month_weekday}%
@@ -6967,7 +7280,8 @@ constexpr year_month_weekday operator+(const years& dy, const year_month_weekday
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ymwd + dy}.
+\returns
+\tcode{ymwd + dy}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{year_month_weekday}%
@@ -6977,7 +7291,8 @@ constexpr year_month_weekday operator-(const year_month_weekday& ymwd, const yea
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ymwd + (-dy)}.
+\returns
+\tcode{ymwd + (-dy)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<<}{year_month_weekday}%
@@ -7068,10 +7383,12 @@ constexpr year_month_weekday_last& operator+=(const months& m) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this = *this + m}.
+\effects
+\tcode{*this = *this + m}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-=}{year_month_weekday_last}%
@@ -7081,10 +7398,12 @@ constexpr year_month_weekday_last& operator-=(const months& m) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this = *this - m}.
+\effects
+\tcode{*this = *this - m}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+=}{year_month_weekday_last}%
@@ -7094,10 +7413,12 @@ constexpr year_month_weekday_last& operator+=(const years& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this = *this + y}.
+\effects
+\tcode{*this = *this + y}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-=}{year_month_weekday_last}%
@@ -7107,10 +7428,12 @@ constexpr year_month_weekday_last& operator-=(const years& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{*this = *this - y}.
+\effects
+\tcode{*this = *this - y}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{year}{year_month_weekday_last}%
@@ -7120,7 +7443,8 @@ constexpr chrono::year year() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{y_}.
+\returns
+\tcode{y_}.
 \end{itemdescr}
 
 \indexlibrarymember{month}{year_month_weekday_last}%
@@ -7130,7 +7454,8 @@ constexpr chrono::month month() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{m_}.
+\returns
+\tcode{m_}.
 \end{itemdescr}
 
 \indexlibrarymember{weekday}{year_month_weekday_last}%
@@ -7140,7 +7465,8 @@ constexpr chrono::weekday weekday() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{wdl_.weekday()}.
+\returns
+\tcode{wdl_.weekday()}.
 \end{itemdescr}
 
 \indexlibrarymember{weekday_last}{year_month_weekday_last}%
@@ -7150,7 +7476,8 @@ constexpr chrono::weekday_last weekday_last() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{wdl_}.
+\returns
+\tcode{wdl_}.
 \end{itemdescr}
 
 \indexlibrarymember{operator sys_days}{year_month_weekday_last}%
@@ -7174,7 +7501,8 @@ constexpr explicit operator local_days() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{local_days\{sys_days\{*this\}.time_since_epoch()\}}.
+\returns
+\tcode{local_days\{sys_days\{*this\}.time_since_epoch()\}}.
 \end{itemdescr}
 
 \indexlibrarymember{ok}{year_month_weekday_last}%
@@ -7184,7 +7512,8 @@ constexpr bool ok() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{y_.ok() \&\& m_.ok() \&\& wdl_.ok()}.
+\returns
+\tcode{y_.ok() \&\& m_.ok() \&\& wdl_.ok()}.
 \end{itemdescr}
 
 \rSec3[time.cal.ymwdlast.nonmembers]{Non-member functions}
@@ -7211,7 +7540,8 @@ constexpr year_month_weekday_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{(ymwdl.year() / ymwdl.month() + dm) / ymwdl.weekday_last()}.
+\returns
+\tcode{(ymwdl.year() / ymwdl.month() + dm) / ymwdl.weekday_last()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+}{year_month_weekday_last}%
@@ -7222,7 +7552,8 @@ constexpr year_month_weekday_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ymwdl + dm}.
+\returns
+\tcode{ymwdl + dm}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{year_month_weekday_last}%
@@ -7233,7 +7564,8 @@ constexpr year_month_weekday_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ymwdl + (-dm)}.
+\returns
+\tcode{ymwdl + (-dm)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+}{year_month_weekday_last}%
@@ -7244,7 +7576,8 @@ constexpr year_month_weekday_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{\{ymwdl.year()+dy, ymwdl.month(), ymwdl.weekday_last()\}}.
+\returns
+\tcode{\{ymwdl.year()+dy, ymwdl.month(), ymwdl.weekday_last()\}}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+}{year_month_weekday_last}%
@@ -7255,7 +7588,8 @@ constexpr year_month_weekday_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ymwdl + dy}.
+\returns
+\tcode{ymwdl + dy}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{year_month_weekday_last}%
@@ -7266,7 +7600,8 @@ constexpr year_month_weekday_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ymwdl + (-dy)}.
+\returns
+\tcode{ymwdl + (-dy)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<<}{year_month_weekday_last}%
@@ -7342,7 +7677,8 @@ constexpr year_month
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{\{y, m\}}.
+\returns
+\tcode{\{y, m\}}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7352,7 +7688,8 @@ constexpr year_month
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{y / month(m)}.
+\returns
+\tcode{y / month(m)}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7362,7 +7699,8 @@ constexpr month_day
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{\{m, d\}}.
+\returns
+\tcode{\{m, d\}}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7372,7 +7710,8 @@ constexpr month_day
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{m / day(d)}.
+\returns
+\tcode{m / day(d)}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7382,7 +7721,8 @@ constexpr month_day
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{month(m) / d}.
+\returns
+\tcode{month(m) / d}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7392,7 +7732,8 @@ constexpr month_day
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{m / d}.
+\returns
+\tcode{m / d}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7402,7 +7743,8 @@ constexpr month_day
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{month(m) / d}.
+\returns
+\tcode{month(m) / d}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7412,7 +7754,8 @@ constexpr month_day_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{month_day_last\{m\}}.
+\returns
+\tcode{month_day_last\{m\}}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7422,7 +7765,8 @@ constexpr month_day_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{month(m) / last}.
+\returns
+\tcode{month(m) / last}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7432,7 +7776,8 @@ constexpr month_day_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{m / last}.
+\returns
+\tcode{m / last}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7442,7 +7787,8 @@ constexpr month_day_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{month(m) / last}.
+\returns
+\tcode{month(m) / last}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7452,7 +7798,8 @@ constexpr month_weekday
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{\{m, wdi\}}.
+\returns
+\tcode{\{m, wdi\}}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7462,7 +7809,8 @@ constexpr month_weekday
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{month(m) / wdi}.
+\returns
+\tcode{month(m) / wdi}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7472,7 +7820,8 @@ constexpr month_weekday
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{m / wdi}.
+\returns
+\tcode{m / wdi}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7482,7 +7831,8 @@ constexpr month_weekday
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{month(m) / wdi}.
+\returns
+\tcode{month(m) / wdi}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7492,7 +7842,8 @@ constexpr month_weekday_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{\{m, wdl\}}.
+\returns
+\tcode{\{m, wdl\}}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7502,7 +7853,8 @@ constexpr month_weekday_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{month(m) / wdl}.
+\returns
+\tcode{month(m) / wdl}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7512,7 +7864,8 @@ constexpr month_weekday_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{m / wdl}.
+\returns
+\tcode{m / wdl}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7522,7 +7875,8 @@ constexpr month_weekday_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{month(m) / wdl}.
+\returns
+\tcode{month(m) / wdl}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7532,7 +7886,8 @@ constexpr year_month_day
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{\{ym.year(), ym.month(), d\}}.
+\returns
+\tcode{\{ym.year(), ym.month(), d\}}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7542,7 +7897,8 @@ constexpr year_month_day
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ym / day(d)}.
+\returns
+\tcode{ym / day(d)}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7552,7 +7908,8 @@ constexpr year_month_day
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{y / md.month() / md.day()}.
+\returns
+\tcode{y / md.month() / md.day()}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7562,7 +7919,8 @@ constexpr year_month_day
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{year(y) / md}.
+\returns
+\tcode{year(y) / md}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7572,7 +7930,8 @@ constexpr year_month_day
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{y / md}.
+\returns
+\tcode{y / md}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7582,7 +7941,8 @@ constexpr year_month_day
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{year(y) / md}.
+\returns
+\tcode{year(y) / md}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7592,7 +7952,8 @@ constexpr year_month_day_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{\{ym.year(), month_day_last\{ym.month()\}\}}.
+\returns
+\tcode{\{ym.year(), month_day_last\{ym.month()\}\}}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7602,7 +7963,8 @@ constexpr year_month_day_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{\{y, mdl\}}.
+\returns
+\tcode{\{y, mdl\}}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7612,7 +7974,8 @@ constexpr year_month_day_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{year(y) / mdl}.
+\returns
+\tcode{year(y) / mdl}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7622,7 +7985,8 @@ constexpr year_month_day_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{y / mdl}.
+\returns
+\tcode{y / mdl}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7632,7 +7996,8 @@ constexpr year_month_day_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{year(y) / mdl}.
+\returns
+\tcode{year(y) / mdl}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7642,7 +8007,8 @@ constexpr year_month_weekday
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{\{ym.year(), ym.month(), wdi\}}.
+\returns
+\tcode{\{ym.year(), ym.month(), wdi\}}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7652,7 +8018,8 @@ constexpr year_month_weekday
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{\{y, mwd.month(), mwd.weekday_indexed()\}}.
+\returns
+\tcode{\{y, mwd.month(), mwd.weekday_indexed()\}}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7662,7 +8029,8 @@ constexpr year_month_weekday
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{year(y) / mwd}.
+\returns
+\tcode{year(y) / mwd}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7672,7 +8040,8 @@ constexpr year_month_weekday
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{y / mwd}.
+\returns
+\tcode{y / mwd}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7682,7 +8051,8 @@ constexpr year_month_weekday
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{year(y) / mwd}.
+\returns
+\tcode{year(y) / mwd}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7692,7 +8062,8 @@ constexpr year_month_weekday_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{\{ym.year(), ym.month(), wdl\}}.
+\returns
+\tcode{\{ym.year(), ym.month(), wdl\}}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7702,7 +8073,8 @@ constexpr year_month_weekday_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{\{y, mwdl.month(), mwdl.weekday_last()\}}.
+\returns
+\tcode{\{y, mwdl.month(), mwdl.weekday_last()\}}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7712,7 +8084,8 @@ constexpr year_month_weekday_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{year(y) / mwdl}.
+\returns
+\tcode{year(y) / mwdl}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7722,7 +8095,8 @@ constexpr year_month_weekday_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{y / mwdl}.
+\returns
+\tcode{y / mwdl}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -7732,7 +8106,8 @@ constexpr year_month_weekday_last
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{year(y) / mwdl}.
+\returns
+\tcode{year(y) / mwdl}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{operator/}!calendar types|)}
@@ -8244,7 +8619,8 @@ referred to by \tcode{begin()}.
 \end{note}
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \indexlibrarymember{begin}{tzdb_list}%
@@ -8276,7 +8652,8 @@ const_iterator cbegin() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{begin()}.
+\returns
+\tcode{begin()}.
 \end{itemdescr}
 
 \indexlibrarymember{cend}{tzdb_list}%
@@ -8286,7 +8663,8 @@ const_iterator cend() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{end()}.
+\returns
+\tcode{end()}.
 \end{itemdescr}
 
 \rSec3[time.zone.db.access]{Time zone database access}
@@ -8327,7 +8705,8 @@ const tzdb& get_tzdb();
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{get_tzdb_list().front()}.
+\returns
+\tcode{get_tzdb_list().front()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{locate_zone}}%
@@ -8337,7 +8716,8 @@ const time_zone* locate_zone(string_view tz_name);
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{get_tzdb().locate_zone(tz_name)}.
+\returns
+\tcode{get_tzdb().locate_zone(tz_name)}.
 
 \pnum
 \begin{note}
@@ -8353,7 +8733,8 @@ const time_zone* current_zone();
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{get_tzdb().current_zone()}.
+\returns
+\tcode{get_tzdb().current_zone()}.
 \end{itemdescr}
 
 \rSec3[time.zone.db.remote]{Remote time zone database support}
@@ -8387,7 +8768,8 @@ to the front of the \tcode{tzdb_list}
 accessed by \tcode{get_tzdb_list()}.
 
 \pnum
-\returns \tcode{get_tzdb_list().front()}.
+\returns
+\tcode{get_tzdb_list().front()}.
 
 \pnum
 \remarks
@@ -8411,7 +8793,8 @@ string remote_version();
 
 \begin{itemdescr}
 \pnum
-\returns The latest remote database version.
+\returns
+The latest remote database version.
 
 \begin{note}
 This can be compared with \tcode{get_tzdb().version}
@@ -8787,7 +9170,8 @@ string_view name() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns The name of the \tcode{time_zone}.
+\returns
+The name of the \tcode{time_zone}.
 
 \pnum
 \begin{example}
@@ -8887,7 +9271,8 @@ bool operator==(const time_zone& x, const time_zone& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x.name() == y.name()}.
+\returns
+\tcode{x.name() == y.name()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{time_zone}%
@@ -8897,7 +9282,8 @@ strong_ordering operator<=>(const time_zone& x, const time_zone& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x.name() <=> y.name()}.
+\returns
+\tcode{x.name() <=> y.name()}.
 \end{itemdescr}
 
 \rSec2[time.zone.zonedtraits]{Class template \tcode{zoned_traits}}
@@ -8932,7 +9318,8 @@ static const time_zone* default_zone();
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{std::chrono::locate_zone("UTC")}.
+\returns
+\tcode{std::chrono::locate_zone("UTC")}.
 \end{itemdescr}
 
 \indexlibrarymember{locate_zone}{zoned_traits<const time_zone*>}%
@@ -8942,7 +9329,8 @@ static const time_zone* locate_zone(string_view name);
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{std::chrono::locate_zone(name)}.
+\returns
+\tcode{std::chrono::locate_zone(name)}.
 \end{itemdescr}
 
 \rSec2[time.zone.zonedtime]{Class template \tcode{zoned_time}}
@@ -9094,7 +9482,8 @@ explicit zoned_time(TimeZonePtr z);
 \requires \tcode{z} refers to a time zone.
 
 \pnum
-\effects Constructs a \tcode{zoned_time} by
+\effects
+Constructs a \tcode{zoned_time} by
 initializing \tcode{zone_} with \tcode{std::move(z)}.
 % FIXME: What about tp_?
 \end{itemdescr}
@@ -9253,7 +9642,8 @@ Does not participate in overload resolution unless
 \requires \tcode{z} refers to a valid time zone.
 
 \pnum
-\effects Constructs a \tcode{zoned_time} by
+\effects
+Constructs a \tcode{zoned_time} by
 initializing \tcode{zone_} with \tcode{std::move(z)} and \tcode{tp_} with \tcode{y.tp_}.
 \end{itemdescr}
 
@@ -9332,7 +9722,8 @@ After assignment, \tcode{get_sys_time() == st}.
 This assignment has no effect on the return value of \tcode{get_time_zone()}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{zoned_time}%
@@ -9347,7 +9738,8 @@ After assignment, \tcode{get_local_time() == lt}.
 This assignment has no effect on the return value of \tcode{get_time_zone()}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator sys_time}{zoned_time}%
@@ -9357,7 +9749,8 @@ operator sys_time<duration>() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{get_sys_time()}.
+\returns
+\tcode{get_sys_time()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator local_time}{zoned_time}%
@@ -9367,7 +9760,8 @@ explicit operator local_time<duration>() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{get_local_time()}.
+\returns
+\tcode{get_local_time()}.
 \end{itemdescr}
 
 \indexlibrarymember{get_time_zone}{zoned_time}%
@@ -9377,7 +9771,8 @@ TimeZonePtr get_time_zone() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{zone_}.
+\returns
+\tcode{zone_}.
 \end{itemdescr}
 
 \indexlibrarymember{get_local_time}{zoned_time}%
@@ -9387,7 +9782,8 @@ local_time<duration> get_local_time() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{zone_->to_local(tp_)}.
+\returns
+\tcode{zone_->to_local(tp_)}.
 \end{itemdescr}
 
 \indexlibrarymember{get_sys_time}{zoned_time}%
@@ -9397,7 +9793,8 @@ sys_time<duration> get_sys_time() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{tp_}.
+\returns
+\tcode{tp_}.
 \end{itemdescr}
 
 \indexlibrarymember{get_info}{zoned_time}%
@@ -9407,7 +9804,8 @@ sys_info get_info() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{zone_->get_info(tp_)}.
+\returns
+\tcode{zone_->get_info(tp_)}.
 \end{itemdescr}
 
 \rSec3[time.zone.zonedtime.nonmembers]{Non-member functions}
@@ -9421,7 +9819,8 @@ template<class Duration1, class Duration2, class TimeZonePtr>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x.zone_ == y.zone_ \&\& x.tp_ == y.tp_}.
+\returns
+\tcode{x.zone_ == y.zone_ \&\& x.tp_ == y.tp_}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<<}{zoned_time}%
@@ -9441,7 +9840,8 @@ to \tcode{os}
 using the format \tcode{"\%F \%T \%Z"}.
 
 \pnum
-\returns \tcode{os}.
+\returns
+\tcode{os}.
 \end{itemdescr}
 
 \rSec2[time.zone.leap]{Class \tcode{leap}}
@@ -9518,7 +9918,8 @@ constexpr sys_seconds date() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns The date and time at which the leap second was inserted.
+\returns
+The date and time at which the leap second was inserted.
 \end{itemdescr}
 
 \rSec3[time.zone.leap.nonmembers]{Non-member functions}
@@ -9530,7 +9931,8 @@ constexpr bool operator==(const leap& x, const leap& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x.date() == y.date()}.
+\returns
+\tcode{x.date() == y.date()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{leap}%
@@ -9540,7 +9942,8 @@ constexpr strong_ordering operator<=>(const leap& x, const leap& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x.date() <=> y.date()}.
+\returns
+\tcode{x.date() <=> y.date()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator==}{leap}%
@@ -9552,7 +9955,8 @@ template<class Duration>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x.date() == y}.
+\returns
+\tcode{x.date() == y}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<}{leap}%
@@ -9564,7 +9968,8 @@ template<class Duration>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x.date() < y}.
+\returns
+\tcode{x.date() < y}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<}{leap}%
@@ -9576,7 +9981,8 @@ template<class Duration>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x < y.date()}.
+\returns
+\tcode{x < y.date()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>}{leap}%
@@ -9588,7 +9994,8 @@ template<class Duration>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{y < x}.
+\returns
+\tcode{y < x}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>}{leap}%
@@ -9600,7 +10007,8 @@ template<class Duration>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{y < x}.
+\returns
+\tcode{y < x}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=}{leap}%
@@ -9612,7 +10020,8 @@ template<class Duration>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!(y < x)}.
+\returns
+\tcode{!(y < x)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=}{leap}%
@@ -9624,7 +10033,8 @@ template<class Duration>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!(y < x)}.
+\returns
+\tcode{!(y < x)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>=}{leap}%
@@ -9636,7 +10046,8 @@ template<class Duration>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!(x < y)}.
+\returns
+\tcode{!(x < y)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>=}{leap}%
@@ -9648,7 +10059,8 @@ template<class Duration>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!(x < y)}.
+\returns
+\tcode{!(x < y)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{leap}%
@@ -9660,7 +10072,8 @@ template<three_way_comparable_with<sys_seconds> Duration>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x.date() <=> y}.
+\returns
+\tcode{x.date() <=> y}.
 \end{itemdescr}
 
 \rSec2[time.zone.link]{Class \tcode{link}}
@@ -9721,7 +10134,8 @@ bool operator==(const link& x, const link& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x.name() == y.name()}.
+\returns
+\tcode{x.name() == y.name()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{link}%
@@ -9731,7 +10145,8 @@ strong_ordering operator<=>(const link& x, const link& y) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x.name() <=> y.name()}.
+\returns
+\tcode{x.name() <=> y.name()}.
 \end{itemdescr}
 
 \rSec1[time.format]{Formatting}
@@ -10178,7 +10593,8 @@ template<class Duration>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{\{time, abbrev, offset_sec\}}.
+\returns
+\tcode{\{time, abbrev, offset_sec\}}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{formatter}!specializations!chrono::local-time-format-t@\tcode{chrono::\exposid{local-time-format-t}}}%

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -6251,7 +6251,8 @@ template<size_t N> struct hash<bitset<N>>;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum The specialization is enabled\iref{unord.hash}.
+\pnum
+The specialization is enabled\iref{unord.hash}.
 \end{itemdescr}
 
 
@@ -7018,7 +7019,8 @@ live\iref{basic.life} from the time of the call until the last
 \pnum
 \throws Nothing.
 
-\pnum \begin{note} It is expected that calls to \tcode{declare_reachable(p)} will consume
+\pnum
+\begin{note} It is expected that calls to \tcode{declare_reachable(p)} will consume
 a small amount of memory in addition to that occupied by the referenced object until the
 matching call to \tcode{undeclare_reachable(p)} is encountered. Long running programs
 should arrange that calls are matched. \end{note} \end{itemdescr}
@@ -9974,9 +9976,11 @@ constexpr shared_ptr() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects  Constructs an empty \tcode{shared_ptr} object.
+\pnum
+\effects  Constructs an empty \tcode{shared_ptr} object.
 
-\pnum\ensures  \tcode{use_count() == 0 \&\& get() == nullptr}.
+\pnum
+\ensures  \tcode{use_count() == 0 \&\& get() == nullptr}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{shared_ptr}!constructor}%
@@ -9985,13 +9989,15 @@ template<class Y> explicit shared_ptr(Y* p);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\requires \tcode{Y} shall be a complete type. The expression
+\pnum
+\requires \tcode{Y} shall be a complete type. The expression
 \tcode{delete[] p}, when \tcode{T} is an array type, or
 \tcode{delete p}, when \tcode{T} is not an array type,
 shall have well-defined behavior, and
 shall not throw exceptions.
 
-\pnum\effects When \tcode{T} is not an array type,
+\pnum
+\effects When \tcode{T} is not an array type,
 constructs a \tcode{shared_ptr} object
 that owns the pointer \tcode{p}.
 Otherwise, constructs a \tcode{shared_ptr}
@@ -10002,12 +10008,15 @@ enables \tcode{shared_from_this} with \tcode{p}.
 If an exception is thrown, \tcode{delete p} is called
 when \tcode{T} is not an array type, \tcode{delete[] p} otherwise.
 
-\pnum\ensures  \tcode{use_count() == 1 \&\& get() == p}.
+\pnum
+\ensures  \tcode{use_count() == 1 \&\& get() == p}.
 
-\pnum\throws \tcode{bad_alloc}, or an \impldef{exception type when \tcode{shared_ptr}
+\pnum
+\throws \tcode{bad_alloc}, or an \impldef{exception type when \tcode{shared_ptr}
 constructor fails} exception when a resource other than memory could not be obtained.
 
-\pnum\remarks When \tcode{T} is an array type,
+\pnum
+\remarks When \tcode{T} is an array type,
 this constructor shall not participate in overload resolution unless
 the expression \tcode{delete[] p} is well-formed and either
 \tcode{T} is \tcode{U[N]} and \tcode{Y(*)[N]} is convertible to \tcode{T*}, or
@@ -10027,14 +10036,16 @@ template<class D, class A> shared_ptr(nullptr_t p, D d, A a);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\requires Construction of \tcode{d} and a deleter of type \tcode{D}
+\pnum
+\requires Construction of \tcode{d} and a deleter of type \tcode{D}
 initialized with \tcode{std::move(d)} shall not throw exceptions.
 The expression \tcode{d(p)}
 shall have well-defined behavior and shall not throw exceptions.
 \tcode{A} shall meet the \oldconcept{Allocator} requirements
 (\tref{cpp17.allocator}).
 
-\pnum\effects  Constructs a \tcode{shared_ptr} object that owns the
+\pnum
+\effects  Constructs a \tcode{shared_ptr} object that owns the
 object \tcode{p} and the deleter \tcode{d}.
 When \tcode{T} is not an array type,
 the first and second constructors enable \tcode{shared_from_this} with \tcode{p}.
@@ -10042,13 +10053,16 @@ The second and fourth constructors shall use a copy of \tcode{a} to
 allocate memory for internal use.
 If an exception is thrown, \tcode{d(p)} is called.
 
-\pnum\ensures  \tcode{use_count() == 1 \&\& get() == p}.
+\pnum
+\ensures  \tcode{use_count() == 1 \&\& get() == p}.
 
-\pnum\throws  \tcode{bad_alloc}, or an \impldef{exception type when \tcode{shared_ptr}
+\pnum
+\throws  \tcode{bad_alloc}, or an \impldef{exception type when \tcode{shared_ptr}
 constructor fails} exception
 when a resource other than memory could not be obtained.
 
-\pnum\remarks
+\pnum
+\remarks
 When \tcode{T} is an array type,
 this constructor shall not participate in overload resolution unless
 \tcode{is_move_constructible_v<D>} is \tcode{true},
@@ -10096,15 +10110,18 @@ template<class Y> shared_ptr(const shared_ptr<Y>& r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\remarks
+\pnum
+\remarks
 The second constructor shall not participate in overload resolution unless
 \tcode{Y*} is compatible with \tcode{T*}.
 
-\pnum\effects  If \tcode{r} is empty, constructs
+\pnum
+\effects  If \tcode{r} is empty, constructs
 an empty \tcode{shared_ptr} object; otherwise, constructs
 a \tcode{shared_ptr} object that shares ownership with \tcode{r}.
 
-\pnum\ensures  \tcode{get() == r.get() \&\& use_count() == r.use_count()}.
+\pnum
+\ensures  \tcode{get() == r.get() \&\& use_count() == r.use_count()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{shared_ptr}!constructor}%
@@ -10133,15 +10150,19 @@ template<class Y> explicit shared_ptr(const weak_ptr<Y>& r);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects  Constructs a \tcode{shared_ptr} object that shares ownership with
+\pnum
+\effects  Constructs a \tcode{shared_ptr} object that shares ownership with
 \tcode{r} and stores a copy of the pointer stored in \tcode{r}.
 If an exception is thrown, the constructor has no effect.
 
-\pnum\ensures  \tcode{use_count() == r.use_count()}.
+\pnum
+\ensures  \tcode{use_count() == r.use_count()}.
 
-\pnum\throws  \tcode{bad_weak_ptr} when \tcode{r.expired()}.
+\pnum
+\throws  \tcode{bad_weak_ptr} when \tcode{r.expired()}.
 
-\pnum\remarks This constructor shall not participate in overload resolution unless
+\pnum
+\remarks This constructor shall not participate in overload resolution unless
 \tcode{Y*} is compatible with \tcode{T*}.
 \end{itemdescr}
 
@@ -10152,7 +10173,8 @@ template<class Y, class D> shared_ptr(unique_ptr<Y, D>&& r);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\remarks This constructor shall not participate in overload resolution
+\pnum
+\remarks This constructor shall not participate in overload resolution
 unless \tcode{Y*} is compatible with \tcode{T*} and
 \tcode{unique_ptr<Y, D>::pointer} is convertible to \tcode{element_type*}.
 
@@ -10172,7 +10194,8 @@ If an exception is thrown, the constructor has no effect.
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects
+\pnum
+\effects
 \begin{itemize}
 \item If \tcode{*this} is empty or shares ownership with another
 \tcode{shared_ptr} instance (\tcode{use_count() > 1}), there are no side effects.
@@ -10204,11 +10227,14 @@ template<class Y> shared_ptr& operator=(const shared_ptr<Y>& r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects  Equivalent to \tcode{shared_ptr(r).swap(*this)}.
+\pnum
+\effects  Equivalent to \tcode{shared_ptr(r).swap(*this)}.
 
-\pnum\returns  \tcode{*this}.
+\pnum
+\returns  \tcode{*this}.
 
-\pnum \begin{note}
+\pnum
+\begin{note}
 The use count updates caused by the temporary object
 construction and destruction are not observable side
 effects, so the implementation may meet the effects (and the
@@ -10259,7 +10285,8 @@ void swap(shared_ptr& r) noexcept;
 
 \begin{itemdescr}
 
-\pnum\effects  Exchanges the contents of \tcode{*this} and \tcode{r}.
+\pnum
+\effects  Exchanges the contents of \tcode{*this} and \tcode{r}.
 \end{itemdescr}
 
 \indexlibrarymember{reset}{shared_ptr}%
@@ -10268,7 +10295,8 @@ void reset() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects  Equivalent to \tcode{shared_ptr().swap(*this)}.
+\pnum
+\effects  Equivalent to \tcode{shared_ptr().swap(*this)}.
 \end{itemdescr}
 
 \indexlibrarymember{reset}{shared_ptr}%
@@ -10277,7 +10305,8 @@ template<class Y> void reset(Y* p);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects  Equivalent to \tcode{shared_ptr(p).swap(*this)}.
+\pnum
+\effects  Equivalent to \tcode{shared_ptr(p).swap(*this)}.
 \end{itemdescr}
 
 \indexlibrarymember{reset}{shared_ptr}%
@@ -10286,7 +10315,8 @@ template<class Y, class D> void reset(Y* p, D d);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects  Equivalent to \tcode{shared_ptr(p, d).swap(*this)}.
+\pnum
+\effects  Equivalent to \tcode{shared_ptr(p, d).swap(*this)}.
 \end{itemdescr}
 
 \indexlibrarymember{reset}{shared_ptr}%
@@ -10306,7 +10336,8 @@ element_type* get() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The stored pointer.
+\pnum
+\returns The stored pointer.
 \end{itemdescr}
 
 \indexlibrarymember{operator*}{shared_ptr}%
@@ -10315,11 +10346,14 @@ T& operator*() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\requires  \tcode{get() != 0}.
+\pnum
+\requires  \tcode{get() != 0}.
 
-\pnum\returns  \tcode{*get()}.
+\pnum
+\returns  \tcode{*get()}.
 
-\pnum\remarks When \tcode{T} is an array type or \cv{}~\tcode{void},
+\pnum
+\remarks When \tcode{T} is an array type or \cv{}~\tcode{void},
 it is unspecified whether this
 member function is declared. If it is declared, it is unspecified what its
 return type is, except that the declaration (although not necessarily the
@@ -10332,11 +10366,14 @@ T* operator->() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\requires  \tcode{get() != 0}.
+\pnum
+\requires  \tcode{get() != 0}.
 
-\pnum\returns  \tcode{get()}.
+\pnum
+\returns  \tcode{get()}.
 
-\pnum\remarks When \tcode{T} is an array type,
+\pnum
+\remarks When \tcode{T} is an array type,
 it is unspecified whether this member function is declared.
 If it is declared, it is unspecified what its return type is,
 except that the declaration (although not necessarily the definition)
@@ -10349,18 +10386,22 @@ element_type& operator[](ptrdiff_t i) const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\requires \tcode{get() != 0 \&\& i >= 0}.
+\pnum
+\requires \tcode{get() != 0 \&\& i >= 0}.
 If \tcode{T} is \tcode{U[N]}, \tcode{i < N}.
 
-\pnum\returns \tcode{get()[i]}.
+\pnum
+\returns \tcode{get()[i]}.
 
-\pnum\remarks When \tcode{T} is not an array type,
+\pnum
+\remarks When \tcode{T} is not an array type,
 it is unspecified whether this member function is declared.
 If it is declared, it is unspecified what its return type is,
 except that the declaration (although not necessarily the definition)
 of the function shall be well-formed.
 
-\pnum\throws Nothing.
+\pnum
+\throws Nothing.
 \end{itemdescr}
 
 \indexlibrarymember{use_count}{shared_ptr}%
@@ -10369,19 +10410,24 @@ long use_count() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns  The number of \tcode{shared_ptr} objects, \tcode{*this} included,
+\pnum
+\returns  The number of \tcode{shared_ptr} objects, \tcode{*this} included,
 that share ownership with \tcode{*this}, or \tcode{0} when \tcode{*this} is
 empty.
 
-\pnum\sync None.
+\pnum
+\sync None.
 
-\pnum \begin{note} \tcode{get() == nullptr}
+\pnum
+\begin{note} \tcode{get() == nullptr}
 does not imply a specific return value of \tcode{use_count()}. \end{note}
 
-\pnum \begin{note} \tcode{weak_ptr<T>::lock()}
+\pnum
+\begin{note} \tcode{weak_ptr<T>::lock()}
 can affect the return value of \tcode{use_count()}. \end{note}
 
-\pnum \begin{note} When multiple threads
+\pnum
+\begin{note} When multiple threads
 can affect the return value of \tcode{use_count()},
 the result should be treated as approximate.
 In particular, \tcode{use_count() == 1} does not imply that accesses through
@@ -10394,7 +10440,8 @@ explicit operator bool() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{get() != 0}.
+\pnum
+\returns \tcode{get() != 0}.
 \end{itemdescr}
 
 \indexlibrarymember{owner_before}{shared_ptr}%
@@ -10842,7 +10889,8 @@ template<class T>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects  Equivalent to \tcode{a.swap(b)}.
+\pnum
+\effects  Equivalent to \tcode{a.swap(b)}.
 \end{itemdescr}
 
 \rSec3[util.smartptr.shared.cast]{Casts}
@@ -10953,7 +11001,8 @@ template<class T, class U>
 \requires The expression \tcode{reinterpret_cast<T*>((U*)nullptr)}
 shall be well-formed.
 
-\pnum\returns
+\pnum
+\returns
 \begin{codeblock}
 shared_ptr<T>(@\placeholder{R}@, reinterpret_cast<typename shared_ptr<T>::element_type*>(r.get()))
 \end{codeblock}
@@ -10977,7 +11026,8 @@ template<class D, class T>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns  If \tcode{p} owns a deleter \tcode{d} of type cv-unqualified
+\pnum
+\returns  If \tcode{p} owns a deleter \tcode{d} of type cv-unqualified
 \tcode{D}, returns \tcode{addressof(d)}; otherwise returns \tcode{nullptr}.
 The returned
 pointer remains valid as long as there exists a \tcode{shared_ptr} instance
@@ -10996,9 +11046,11 @@ template<class E, class T, class Y>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects As if by: \tcode{os <{}< p.get();}
+\pnum
+\effects As if by: \tcode{os <{}< p.get();}
 
-\pnum\returns  \tcode{os}.
+\pnum
+\returns  \tcode{os}.
 \end{itemdescr}
 
 \rSec2[util.smartptr.weak]{Class template \tcode{weak_ptr}}
@@ -11077,9 +11129,11 @@ constexpr weak_ptr() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects  Constructs an empty \tcode{weak_ptr} object.
+\pnum
+\effects  Constructs an empty \tcode{weak_ptr} object.
 
-\pnum\ensures  \tcode{use_count() == 0}.
+\pnum
+\ensures  \tcode{use_count() == 0}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{weak_ptr}!constructor}%
@@ -11090,15 +11144,18 @@ template<class Y> weak_ptr(const shared_ptr<Y>& r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\remarks The second and third constructors shall not participate in
+\pnum
+\remarks The second and third constructors shall not participate in
 overload resolution unless \tcode{Y*} is compatible with \tcode{T*}.
 
-\pnum\effects  If \tcode{r} is empty, constructs
+\pnum
+\effects  If \tcode{r} is empty, constructs
 an empty \tcode{weak_ptr} object; otherwise, constructs
 a \tcode{weak_ptr} object that shares ownership
 with \tcode{r} and stores a copy of the pointer stored in \tcode{r}.
 
-\pnum\ensures  \tcode{use_count() == r.use_count()}.
+\pnum
+\ensures  \tcode{use_count() == r.use_count()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{weak_ptr}!constructor}%
@@ -11108,12 +11165,15 @@ template<class Y> weak_ptr(weak_ptr<Y>&& r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\remarks The second constructor shall not participate in overload resolution unless
+\pnum
+\remarks The second constructor shall not participate in overload resolution unless
 \tcode{Y*} is compatible with \tcode{T*}.
 
-\pnum\effects Move constructs a \tcode{weak_ptr} instance from \tcode{r}.
+\pnum
+\effects Move constructs a \tcode{weak_ptr} instance from \tcode{r}.
 
-\pnum\ensures \tcode{*this} shall contain the old value of \tcode{r}.
+\pnum
+\ensures \tcode{*this} shall contain the old value of \tcode{r}.
 \tcode{r} shall be empty. \tcode{r.use_count() == 0}.
 \end{itemdescr}
 
@@ -11125,7 +11185,8 @@ template<class Y> weak_ptr(weak_ptr<Y>&& r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects  Destroys this \tcode{weak_ptr} object but has no
+\pnum
+\effects  Destroys this \tcode{weak_ptr} object but has no
 effect on the object its stored pointer points to.
 \end{itemdescr}
 
@@ -11139,12 +11200,15 @@ template<class Y> weak_ptr& operator=(const shared_ptr<Y>& r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects  Equivalent to \tcode{weak_ptr(r).swap(*this)}.
+\pnum
+\effects  Equivalent to \tcode{weak_ptr(r).swap(*this)}.
 
-\pnum\remarks  The implementation may meet the effects (and the
+\pnum
+\remarks  The implementation may meet the effects (and the
 implied guarantees) via different means, without creating a temporary object.
 
-\pnum\returns  \tcode{*this}.
+\pnum
+\returns  \tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{weak_ptr}%
@@ -11154,9 +11218,11 @@ template<class Y> weak_ptr& operator=(weak_ptr<Y>&& r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects  Equivalent to \tcode{weak_ptr(std::move(r)).swap(*this)}.
+\pnum
+\effects  Equivalent to \tcode{weak_ptr(std::move(r)).swap(*this)}.
 
-\pnum\returns  \tcode{*this}.
+\pnum
+\returns  \tcode{*this}.
 \end{itemdescr}
 
 \rSec3[util.smartptr.weak.mod]{Modifiers}
@@ -11166,7 +11232,8 @@ void swap(weak_ptr& r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects  Exchanges the contents of \tcode{*this} and \tcode{r}.
+\pnum
+\effects  Exchanges the contents of \tcode{*this} and \tcode{r}.
 \end{itemdescr}
 
 \indexlibrarymember{reset}{weak_ptr}%
@@ -11175,7 +11242,8 @@ void reset() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects  Equivalent to \tcode{weak_ptr().swap(*this)}.
+\pnum
+\effects  Equivalent to \tcode{weak_ptr().swap(*this)}.
 \end{itemdescr}
 
 \rSec3[util.smartptr.weak.obs]{Observers}
@@ -11185,7 +11253,8 @@ long use_count() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns  \tcode{0} if \tcode{*this} is empty;
+\pnum
+\returns  \tcode{0} if \tcode{*this} is empty;
 otherwise, the number of \tcode{shared_ptr} instances
 that share ownership with \tcode{*this}.
 \end{itemdescr}
@@ -11196,7 +11265,8 @@ bool expired() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns  \tcode{use_count() == 0}.
+\pnum
+\returns  \tcode{use_count() == 0}.
 \end{itemdescr}
 
 \indexlibrarymember{lock}{weak_ptr}%
@@ -11239,7 +11309,8 @@ template<class T>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects Equivalent to \tcode{a.swap(b)}.
+\pnum
+\effects Equivalent to \tcode{a.swap(b)}.
 \end{itemdescr}
 
 \rSec2[util.smartptr.ownerless]{Class template \tcode{owner_less}}
@@ -11281,7 +11352,8 @@ namespace std {
 \end{codeblock}
 
 \indexlibrarymember{operator()}{owner_less}%
-\pnum \tcode{operator()(x, y)} shall return \tcode{x.owner_before(y)}. \begin{note}
+\pnum
+\tcode{operator()(x, y)} shall return \tcode{x.owner_before(y)}. \begin{note}
 Note that
 
 \begin{itemize}
@@ -11347,7 +11419,8 @@ enable_shared_from_this(const enable_shared_from_this<T>&) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects  Value-initializes \tcode{weak_this}.
+\pnum
+\effects  Value-initializes \tcode{weak_this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{enable_shared_from_this}%
@@ -11356,9 +11429,11 @@ enable_shared_from_this<T>& operator=(const enable_shared_from_this<T>&) noexcep
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns  \tcode{*this}.
+\pnum
+\returns  \tcode{*this}.
 
-\pnum\begin{note} \tcode{weak_this} is not changed. \end{note}
+\pnum
+\begin{note} \tcode{weak_this} is not changed. \end{note}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{shared_ptr}}%
@@ -11369,7 +11444,8 @@ shared_ptr<T const> shared_from_this() const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns  \tcode{shared_ptr<T>(weak_this)}.
+\pnum
+\returns  \tcode{shared_ptr<T>(weak_this)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{weak_ptr}}%
@@ -11380,7 +11456,8 @@ weak_ptr<T const> weak_from_this() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns  \tcode{weak_this}.
+\pnum
+\returns  \tcode{weak_this}.
 \end{itemdescr}
 
 \rSec2[util.smartptr.hash]{Smart pointer hash support}
@@ -14045,7 +14122,8 @@ constexpr reference_wrapper(const reference_wrapper& x) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects Constructs a \tcode{reference_wrapper} object that
+\pnum
+\effects Constructs a \tcode{reference_wrapper} object that
 stores a reference to \tcode{x.get()}.
 \end{itemdescr}
 
@@ -14057,7 +14135,8 @@ constexpr reference_wrapper& operator=(const reference_wrapper& x) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\ensures \tcode{*this} stores a reference to  \tcode{x.get()}.
+\pnum
+\ensures \tcode{*this} stores a reference to  \tcode{x.get()}.
 \end{itemdescr}
 
 \rSec3[refwrap.access]{Access}
@@ -14068,7 +14147,8 @@ constexpr operator T& () const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The stored reference.
+\pnum
+\returns The stored reference.
 \end{itemdescr}
 
 \indexlibrarymember{get}{reference_wrapper}%
@@ -14077,7 +14157,8 @@ constexpr T& get() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns The stored reference.
+\pnum
+\returns The stored reference.
 \end{itemdescr}
 
 \rSec3[refwrap.invoke]{Invocation}
@@ -14094,7 +14175,8 @@ template<class... ArgTypes>
 \mandates
 \tcode{T} is a complete type.
 
-\pnum\returns \tcode{\placeholdernc{INVOKE}(get(), std::forward<ArgTypes>(args)...)}.\iref{func.require}
+\pnum
+\returns \tcode{\placeholdernc{INVOKE}(get(), std::forward<ArgTypes>(args)...)}.\iref{func.require}
 \end{itemdescr}
 
 
@@ -14111,7 +14193,8 @@ template<class T> constexpr reference_wrapper<T> ref(T& t) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{reference_wrapper<T>(t)}.
+\pnum
+\returns \tcode{reference_wrapper<T>(t)}.
 \end{itemdescr}
 
 \indexlibrarymember{ref}{reference_wrapper}%
@@ -14120,7 +14203,8 @@ template<class T> constexpr reference_wrapper<T> ref(reference_wrapper<T> t) noe
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{ref(t.get())}.
+\pnum
+\returns \tcode{ref(t.get())}.
 \end{itemdescr}
 
 \indexlibrarymember{cref}{reference_wrapper}%
@@ -14129,7 +14213,8 @@ template<class T> constexpr reference_wrapper<const T> cref(const T& t) noexcept
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{reference_wrapper <const T>(t)}.
+\pnum
+\returns \tcode{reference_wrapper <const T>(t)}.
 \end{itemdescr}
 
 \indexlibrarymember{cref}{reference_wrapper}%
@@ -14138,7 +14223,8 @@ template<class T> constexpr reference_wrapper<const T> cref(reference_wrapper<T>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{cref(t.get())}.
+\pnum
+\returns \tcode{cref(t.get())}.
 \end{itemdescr}
 
 \rSec3[refwrap.unwrapref]{Transformation type trait \tcode{unwrap_reference}}
@@ -14190,7 +14276,8 @@ constexpr T operator()(const T& x, const T& y) const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{x + y}.
+\pnum
+\returns \tcode{x + y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{plus<>}}%
@@ -14210,7 +14297,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{std::forward<T>(t) + std::forward<U>(u)}.
+\pnum
+\returns \tcode{std::forward<T>(t) + std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[arithmetic.operations.minus]{Class template \tcode{minus}}
@@ -14228,7 +14316,8 @@ constexpr T operator()(const T& x, const T& y) const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{x - y}.
+\pnum
+\returns \tcode{x - y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{minus<>}}%
@@ -14248,7 +14337,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{std::forward<T>(t) - std::forward<U>(u)}.
+\pnum
+\returns \tcode{std::forward<T>(t) - std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[arithmetic.operations.multiplies]{Class template \tcode{multiplies}}
@@ -14266,7 +14356,8 @@ constexpr T operator()(const T& x, const T& y) const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{x * y}.
+\pnum
+\returns \tcode{x * y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{multiplies<>}}%
@@ -14286,7 +14377,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{std::forward<T>(t) * std::forward<U>(u)}.
+\pnum
+\returns \tcode{std::forward<T>(t) * std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[arithmetic.operations.divides]{Class template \tcode{divides}}
@@ -14304,7 +14396,8 @@ constexpr T operator()(const T& x, const T& y) const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{x / y}.
+\pnum
+\returns \tcode{x / y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{divides<>}}%
@@ -14324,7 +14417,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{std::forward<T>(t) / std::forward<U>(u)}.
+\pnum
+\returns \tcode{std::forward<T>(t) / std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[arithmetic.operations.modulus]{Class template \tcode{modulus}}
@@ -14342,7 +14436,8 @@ constexpr T operator()(const T& x, const T& y) const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{x \% y}.
+\pnum
+\returns \tcode{x \% y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{modulus<>}}%
@@ -14362,7 +14457,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{std::forward<T>(t) \% std::forward<U>(u)}.
+\pnum
+\returns \tcode{std::forward<T>(t) \% std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[arithmetic.operations.negate]{Class template \tcode{negate}}
@@ -14380,7 +14476,8 @@ constexpr T operator()(const T& x) const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{-x}.
+\pnum
+\returns \tcode{-x}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{negate<>}}%
@@ -14400,7 +14497,8 @@ template<class T> constexpr auto operator()(T&& t) const
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{-std::forward<T>(t)}.
+\pnum
+\returns \tcode{-std::forward<T>(t)}.
 \end{itemdescr}
 
 
@@ -14442,7 +14540,8 @@ constexpr bool operator()(const T& x, const T& y) const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{x == y}.
+\pnum
+\returns \tcode{x == y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{equal_to<>}}%
@@ -14462,7 +14561,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{std::forward<T>(t) == std::forward<U>(u)}.
+\pnum
+\returns \tcode{std::forward<T>(t) == std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[comparisons.not.equal.to]{Class template \tcode{not_equal_to}}
@@ -14480,7 +14580,8 @@ constexpr bool operator()(const T& x, const T& y) const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{x != y}.
+\pnum
+\returns \tcode{x != y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{not_equal_to<>}}%
@@ -14500,7 +14601,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{std::forward<T>(t) != std::forward<U>(u)}.
+\pnum
+\returns \tcode{std::forward<T>(t) != std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[comparisons.greater]{Class template \tcode{greater}}
@@ -14518,7 +14620,8 @@ constexpr bool operator()(const T& x, const T& y) const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{x > y}.
+\pnum
+\returns \tcode{x > y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{greater<>}}%
@@ -14538,7 +14641,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{std::forward<T>(t) > std::forward<U>(u)}.
+\pnum
+\returns \tcode{std::forward<T>(t) > std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[comparisons.less]{Class template \tcode{less}}
@@ -14556,7 +14660,8 @@ constexpr bool operator()(const T& x, const T& y) const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{x < y}.
+\pnum
+\returns \tcode{x < y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{less<>}}%
@@ -14576,7 +14681,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{std::forward<T>(t) < std::forward<U>(u)}.
+\pnum
+\returns \tcode{std::forward<T>(t) < std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[comparisons.greater.equal]{Class template \tcode{greater_equal}}
@@ -14594,7 +14700,8 @@ constexpr bool operator()(const T& x, const T& y) const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{x >= y}.
+\pnum
+\returns \tcode{x >= y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{greater_equal<>}}%
@@ -14614,7 +14721,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{std::forward<T>(t) >= std::forward<U>(u)}.
+\pnum
+\returns \tcode{std::forward<T>(t) >= std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[comparisons.less.equal]{Class template \tcode{less_equal}}
@@ -14632,7 +14740,8 @@ constexpr bool operator()(const T& x, const T& y) const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{x <= y}.
+\pnum
+\returns \tcode{x <= y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{less_equal<>}}%
@@ -14652,7 +14761,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{std::forward<T>(t) <= std::forward<U>(u)}.
+\pnum
+\returns \tcode{std::forward<T>(t) <= std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec2[range.cmp]{Concept-constrained comparisons}
@@ -14844,7 +14954,8 @@ constexpr bool operator()(const T& x, const T& y) const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{x \&\& y}.
+\pnum
+\returns \tcode{x \&\& y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{logical_and<>}}%
@@ -14864,7 +14975,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{std::forward<T>(t) \&\& std::forward<U>(u)}.
+\pnum
+\returns \tcode{std::forward<T>(t) \&\& std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[logical.operations.or]{Class template \tcode{logical_or}}
@@ -14882,7 +14994,8 @@ constexpr bool operator()(const T& x, const T& y) const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{x || y}.
+\pnum
+\returns \tcode{x || y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{logical_or<>}}%
@@ -14902,7 +15015,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{std::forward<T>(t) || std::forward<U>(u)}.
+\pnum
+\returns \tcode{std::forward<T>(t) || std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[logical.operations.not]{Class template \tcode{logical_not}}
@@ -14920,7 +15034,8 @@ constexpr bool operator()(const T& x) const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{!x}.
+\pnum
+\returns \tcode{!x}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{logical_not<>}}%
@@ -14940,7 +15055,8 @@ template<class T> constexpr auto operator()(T&& t) const
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{!std::forward<T>(t)}.
+\pnum
+\returns \tcode{!std::forward<T>(t)}.
 \end{itemdescr}
 
 
@@ -14966,7 +15082,8 @@ constexpr T operator()(const T& x, const T& y) const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{x \& y}.
+\pnum
+\returns \tcode{x \& y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bit_and<>}}%
@@ -14986,7 +15103,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{std::forward<T>(t) \& std::forward<U>(u)}.
+\pnum
+\returns \tcode{std::forward<T>(t) \& std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[bitwise.operations.or]{Class template \tcode{bit_or}}
@@ -15004,7 +15122,8 @@ constexpr T operator()(const T& x, const T& y) const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{x | y}.
+\pnum
+\returns \tcode{x | y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bit_or<>}}%
@@ -15024,7 +15143,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{std::forward<T>(t) | std::forward<U>(u)}.
+\pnum
+\returns \tcode{std::forward<T>(t) | std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[bitwise.operations.xor]{Class template \tcode{bit_xor}}
@@ -15042,7 +15162,8 @@ constexpr T operator()(const T& x, const T& y) const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{x \caret{} y}.
+\pnum
+\returns \tcode{x \caret{} y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bit_xor<>}}%
@@ -15062,7 +15183,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{std::forward<T>(t) \caret{} std::forward<U>(u)}.
+\pnum
+\returns \tcode{std::forward<T>(t) \caret{} std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[bitwise.operations.not]{Class template \tcode{bit_not}}
@@ -15079,7 +15201,8 @@ constexpr T operator()(const T& x) const;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{\~{}x}.
+\pnum
+\returns \tcode{\~{}x}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bit_not<>}}%
@@ -15099,7 +15222,8 @@ template<class T> constexpr auto operator()(T&&) const
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{\~{}std::forward<T>(t)}.
+\pnum
+\returns \tcode{\~{}std::forward<T>(t)}.
 \end{itemdescr}
 
 
@@ -15324,7 +15448,8 @@ $\tcode{w}_N$)}\iref{func.require} is a valid expression for some
 values $\tcode{w}_1$, $\tcode{w}_2$, $\dotsc{}$, $\tcode{w}_N$, where
 $N$ has the value \tcode{sizeof...(bound_args)}.
 
-\pnum\returns
+\pnum
+\returns
 An argument forwarding call wrapper \tcode{g}\iref{func.require}.
 A program that attempts to invoke a volatile-qualified \tcode{g}
 is ill-formed.
@@ -15574,7 +15699,8 @@ function() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\ensures \tcode{!*this}.
+\pnum
+\ensures \tcode{!*this}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{function}!constructor}%
@@ -15722,11 +15848,14 @@ function& operator=(nullptr_t) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects If \tcode{*this != nullptr}, destroys the target of \tcode{this}.
+\pnum
+\effects If \tcode{*this != nullptr}, destroys the target of \tcode{this}.
 
-\pnum\ensures \tcode{!(*this)}.
+\pnum
+\ensures \tcode{!(*this)}.
 
-\pnum\returns \tcode{*this}.
+\pnum
+\returns \tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{function}%
@@ -15735,11 +15864,14 @@ template<class F> function& operator=(F&& f);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects As if by: \tcode{function(std::forward<F>(f)).swap(*this);}
+\pnum
+\effects As if by: \tcode{function(std::forward<F>(f)).swap(*this);}
 
-\pnum\returns \tcode{*this}.
+\pnum
+\returns \tcode{*this}.
 
-\pnum\remarks This assignment operator shall not participate in overload
+\pnum
+\remarks This assignment operator shall not participate in overload
 resolution unless \tcode{decay_t<F>} is
 Lvalue-Callable\iref{func.wrap.func} for argument types \tcode{ArgTypes...} and
 return type \tcode{R}.
@@ -15751,7 +15883,8 @@ template<class F> function& operator=(reference_wrapper<F> f) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects As if by: \tcode{function(f).swap(*this);}
+\pnum
+\effects As if by: \tcode{function(f).swap(*this);}
 
 \pnum
 \returns \tcode{*this}.
@@ -15763,7 +15896,8 @@ template<class F> function& operator=(reference_wrapper<F> f) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects If \tcode{*this != nullptr}, destroys the target of \tcode{this}.
+\pnum
+\effects If \tcode{*this != nullptr}, destroys the target of \tcode{this}.
 \end{itemdescr}
 
 \rSec4[func.wrap.func.mod]{Modifiers}
@@ -15774,7 +15908,8 @@ void swap(function& other) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects Interchanges the targets of \tcode{*this} and \tcode{other}.
+\pnum
+\effects Interchanges the targets of \tcode{*this} and \tcode{other}.
 \end{itemdescr}
 
 \rSec4[func.wrap.func.cap]{Capacity}
@@ -15802,7 +15937,8 @@ R operator()(ArgTypes... args) const;
 \returns \tcode{\placeholdernc{INVOKE}<R>(f, std::forward<ArgTypes>(args)...)}\iref{func.require},
 where \tcode{f} is the target object\iref{func.def} of \tcode{*this}.
 
-\pnum\throws
+\pnum
+\throws
 \tcode{bad_function_call} if \tcode{!*this}; otherwise, any
 exception thrown by the wrapped callable object.
 \end{itemdescr}
@@ -15815,7 +15951,8 @@ const type_info& target_type() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns If \tcode{*this} has a target of type \tcode{T},
+\pnum
+\returns If \tcode{*this} has a target of type \tcode{T},
   \tcode{typeid(T)}; otherwise, \tcode{typeid(void)}.
 \end{itemdescr}
 
@@ -15826,7 +15963,8 @@ template<class T> const T* target() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns If \tcode{target_type() == typeid(T)}
+\pnum
+\returns If \tcode{target_type() == typeid(T)}
 a pointer to the stored function target; otherwise a null pointer.
 \end{itemdescr}
 
@@ -15839,7 +15977,8 @@ template<class R, class... ArgTypes>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\returns \tcode{!f}.
+\pnum
+\returns \tcode{!f}.
 \end{itemdescr}
 
 \rSec4[func.wrap.func.alg]{Specialized algorithms}
@@ -15851,7 +15990,8 @@ template<class R, class... ArgTypes>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum\effects As if by: \tcode{f1.swap(f2);}
+\pnum
+\effects As if by: \tcode{f1.swap(f2);}
 \end{itemdescr}%
 \indextext{function object!wrapper|)}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -19157,7 +19157,6 @@ program is ill-formed unless the implementation yields correct values of \tcode{
 
 \pnum
 \begin{example}
-
 \begin{codeblock}
 static_assert(ratio_add<ratio<1, 3>, ratio<1, 6>>::num == 1, "1/3+1/6 == 1/2");
 static_assert(ratio_add<ratio<1, 3>, ratio<1, 6>>::den == 2, "1/3+1/6 == 1/2");

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -174,7 +174,8 @@ template<class T>
 
 \begin{itemdescr}
 \pnum
-\remarks This function
+\remarks
+This function
 is a designated customization point\iref{namespace.std} and
 shall not participate in overload resolution
 unless \tcode{is_move_constructible_v<T>} is \tcode{true} and
@@ -217,7 +218,8 @@ unless \tcode{is_swappable_v<T>} is \tcode{true}.
 for all \tcode{i} in the range \range{0}{N}.
 
 \pnum
-\effects As if by \tcode{swap_ranges(a, a + N, b)}.
+\effects
+As if by \tcode{swap_ranges(a, a + N, b)}.
 \end{itemdescr}
 
 \rSec2[utility.exchange]{\tcode{exchange}}
@@ -260,10 +262,12 @@ template<class T> constexpr T&& forward(remove_reference_t<T>&& t) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{static_cast<T\&\&>(t)}.
+\returns
+\tcode{static_cast<T\&\&>(t)}.
 
 \pnum
-\remarks If the second form is instantiated with an lvalue reference type, the program is ill-formed.
+\remarks
+If the second form is instantiated with an lvalue reference type, the program is ill-formed.
 
 \pnum
 \begin{example}
@@ -346,7 +350,8 @@ template<class T> constexpr conditional_t<
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{std::move(x)}.
+\returns
+\tcode{std::move(x)}.
 \end{itemdescr}
 
 \rSec2[utility.as.const]{Function template \tcode{as_const}}
@@ -358,7 +363,8 @@ template<class T> constexpr add_const_t<T>& as_const(T& t) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{t}.
+\returns
+\tcode{t}.
 \end{itemdescr}
 
 \rSec2[declval]{Function template \tcode{declval}}
@@ -374,10 +380,12 @@ template<class T> add_rvalue_reference_t<T> declval() noexcept;    // as unevalu
 
 \begin{itemdescr}
 \pnum
-\remarks If this function is odr-used\iref{basic.def.odr}, the program is ill-formed.
+\remarks
+If this function is odr-used\iref{basic.def.odr}, the program is ill-formed.
 
 \pnum
-\remarks The template parameter \tcode{T} of \tcode{declval} may be an incomplete type.
+\remarks
+The template parameter \tcode{T} of \tcode{declval} may be an incomplete type.
 \end{itemdescr}
 
 \pnum
@@ -554,7 +562,8 @@ constexpr explicit(@\seebelow@) pair(const T1& x, const T2& y);
 Initializes \tcode{first} with \tcode{x} and \tcode{second} with \tcode{y}.
 
 \pnum
-\remarks This constructor shall not participate in overload resolution
+\remarks
+This constructor shall not participate in overload resolution
 unless \tcode{is_copy_construct\-ible_v<first_type>} is \tcode{true} and
 \tcode{is_copy_constructible_v<second_type>} is \tcode{true}.
 The expression inside \tcode{explicit} is equivalent to:
@@ -598,7 +607,8 @@ template<class U1, class U2> constexpr explicit(@\seebelow@) pair(const pair<U1,
 Initializes members from the corresponding members of the argument.
 
 \pnum
-\remarks This constructor shall not participate in overload resolution unless
+\remarks
+This constructor shall not participate in overload resolution unless
 \tcode{is_constructible_v<first_type, const U1\&>} is \tcode{true} and
 \tcode{is_constructible_v<second_type, const U2\&>} is \tcode{true}.
 The expression inside explicit is equivalent to:
@@ -621,7 +631,8 @@ and \tcode{second} with
 \tcode{std::forward<U2>(\brk{}p.second)}.
 
 \pnum
-\remarks This constructor shall not participate in overload resolution unless
+\remarks
+This constructor shall not participate in overload resolution unless
 \tcode{is_constructible_v<first_type, U1\&\&>} is \tcode{true} and
 \tcode{is_constructible_v<second_type, U2\&\&>} is \tcode{true}.
 The expression inside explicit is equivalent to:
@@ -643,7 +654,8 @@ template<class... Args1, class... Args2>
 and \tcode{is_constructible_v<sec\-ond_type, Args2\&\&...>} is \tcode{true}.
 
 \pnum
-\effects Initializes \tcode{first} with arguments of types
+\effects
+Initializes \tcode{first} with arguments of types
 \tcode{Args1...} obtained by forwarding the elements of \tcode{first_args}
 and initializes \tcode{second} with arguments of types \tcode{Args2...}
 obtained by forwarding the elements of \tcode{second_args}. (Here, forwarding
@@ -660,15 +672,18 @@ constexpr pair& operator=(const pair& p);
 
 \begin{itemdescr}
 \pnum
-\effects Assigns \tcode{p.first} to \tcode{first} and \tcode{p.second} to \tcode{second}.
+\effects
+Assigns \tcode{p.first} to \tcode{first} and \tcode{p.second} to \tcode{second}.
 
 \pnum
-\remarks This operator shall be defined as deleted unless
+\remarks
+This operator shall be defined as deleted unless
 \tcode{is_copy_assignable_v<first_type>} is \tcode{true}
 and \tcode{is_copy_assignable_v<second_type>} is \tcode{true}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{pair}%
@@ -678,15 +693,18 @@ template<class U1, class U2> constexpr pair& operator=(const pair<U1, U2>& p);
 
 \begin{itemdescr}
 \pnum
-\effects Assigns \tcode{p.first} to \tcode{first} and \tcode{p.second} to \tcode{second}.
+\effects
+Assigns \tcode{p.first} to \tcode{first} and \tcode{p.second} to \tcode{second}.
 
 \pnum
-\remarks This operator shall not participate in overload resolution unless
+\remarks
+This operator shall not participate in overload resolution unless
 \tcode{is_assignable_v<first_type\&, const U1\&>} is \tcode{true}
 and \tcode{is_assignable_v<second_type\&, const U2\&>} is \tcode{true}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{pair}%
@@ -701,18 +719,21 @@ Assigns to \tcode{first} with \tcode{std::forward<first_type>(p.first)}
 and to \tcode{second} with\\ \tcode{std::forward<second_type>(p.second)}.
 
 \pnum
-\remarks This operator shall not participate in overload resolution unless
+\remarks
+This operator shall not participate in overload resolution unless
 \tcode{is_move_assignable_v<first_type>} is \tcode{true}
 and \tcode{is_move_assignable_v<second_type>} is \tcode{true}.
 
 \pnum
-\remarks The expression inside \tcode{noexcept} is equivalent to:
+\remarks
+The expression inside \tcode{noexcept} is equivalent to:
 \begin{codeblock}
 is_nothrow_move_assignable_v<T1> && is_nothrow_move_assignable_v<T2>
 \end{codeblock}
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{pair}%
@@ -727,12 +748,14 @@ Assigns to \tcode{first} with \tcode{std::forward<U1>(p.first)}
 and to \tcode{second} with\\ \tcode{std::forward<U2>(p.second)}.
 
 \pnum
-\remarks This operator shall not participate in overload resolution unless
+\remarks
+This operator shall not participate in overload resolution unless
 \tcode{is_assignable_v<first_type\&, U1\&\&>} is \tcode{true}
 and \tcode{is_assignable_v<second_type\&, U2\&\&>} is \tcode{true}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{pair}%
@@ -747,12 +770,14 @@ constexpr void swap(pair& p) noexcept(@\seebelow@);
 \tcode{p.first} and \tcode{second} shall be swappable with \tcode{p.second}.
 
 \pnum
-\effects Swaps
+\effects
+Swaps
 \tcode{first} with \tcode{p.first} and
 \tcode{second} with \tcode{p.second}.
 
 \pnum
-\remarks The expression inside \tcode{noexcept} is equivalent to:
+\remarks
+The expression inside \tcode{noexcept} is equivalent to:
 \begin{codeblock}
 is_nothrow_swappable_v<first_type> && is_nothrow_swappable_v<second_type>
 \end{codeblock}
@@ -785,7 +810,8 @@ template<class T1, class T2>
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{x.swap(y)}.
+\effects
+As if by \tcode{x.swap(y)}.
 
 \pnum
 \remarks
@@ -858,7 +884,8 @@ template<size_t I, class T1, class T2>
 \begin{itemdescr}
 
 \pnum
-\returns If \tcode{I == 0} returns a reference to \tcode{p.first};
+\returns
+If \tcode{I == 0} returns a reference to \tcode{p.first};
 if \tcode{I == 1} returns a reference to \tcode{p.second};
 otherwise the program is ill-formed.
 \end{itemdescr}
@@ -879,7 +906,8 @@ template<class T1, class T2>
 \requires \tcode{T1} and \tcode{T2} are distinct types. Otherwise, the program is ill-formed.
 
 \pnum
-\returns A reference to \tcode{p.first}.
+\returns
+A reference to \tcode{p.first}.
 \end{itemdescr}
 
 \indexlibrarymember{get}{pair}%
@@ -899,7 +927,8 @@ template<class T2, class T1>
 \requires \tcode{T1} and \tcode{T2} are distinct types. Otherwise, the program is ill-formed.
 
 \pnum
-\returns A reference to \tcode{p.second}.
+\returns
+A reference to \tcode{p.second}.
 \end{itemdescr}
 
 \rSec2[pair.piecewise]{Piecewise construction}
@@ -1140,7 +1169,8 @@ constexpr explicit(@\seebelow@) tuple();
 
 \begin{itemdescr}
 \pnum
-\effects Value-initializes each element.
+\effects
+Value-initializes each element.
 
 \pnum
 \remarks
@@ -1163,11 +1193,13 @@ constexpr explicit(@\seebelow@) tuple(const Types&...);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes each element with the value of the
+\effects
+Initializes each element with the value of the
 corresponding parameter.
 
 \pnum
-\remarks This constructor shall not participate in overload resolution unless
+\remarks
+This constructor shall not participate in overload resolution unless
 \tcode{sizeof...(Types) >= 1} and \tcode{is_copy_constructible_v<$\tcode{T}_i$>}
 is \tcode{true} for all $i$.
 The expression inside \tcode{explicit} is equivalent to:
@@ -1183,11 +1215,13 @@ template<class... UTypes> constexpr explicit(@\seebelow@) tuple(UTypes&&... u);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes the elements in the tuple with the
+\effects
+Initializes the elements in the tuple with the
 corresponding value in \tcode{std::forward<UTypes>(u)}.
 
 \pnum
-\remarks This constructor shall not participate in overload resolution unless
+\remarks
+This constructor shall not participate in overload resolution unless
 \tcode{sizeof...(Types)} \tcode{==} \tcode{sizeof...(UTypes)} and
 \tcode{sizeof...(Types) >= 1} and \tcode{is_constructible_v<$\tcode{T}_i$, $\tcode{U}_i$\&\&>}
 is \tcode{true} for all $i$.
@@ -1207,7 +1241,8 @@ tuple(const tuple& u) = default;
 \requires \tcode{is_copy_constructible_v<$\tcode{T}_i$>} is \tcode{true} for all $i$.
 
 \pnum
-\effects Initializes each element of \tcode{*this} with the
+\effects
+Initializes each element of \tcode{*this} with the
 corresponding element of \tcode{u}.
 \end{itemdescr}
 
@@ -1221,7 +1256,8 @@ tuple(tuple&& u) = default;
 \constraints \tcode{is_move_constructible_v<$\tcode{T}_i$>} is \tcode{true} for all $i$.
 
 \pnum
-\effects For all $i$, initializes the $i^\text{th}$ element of \tcode{*this} with
+\effects
+For all $i$, initializes the $i^\text{th}$ element of \tcode{*this} with
 \tcode{std::forward<$\tcode{T}_i$>(get<$i$>(u))}.
 \end{itemdescr}
 
@@ -1232,11 +1268,13 @@ template<class... UTypes> constexpr explicit(@\seebelow@) tuple(const tuple<UTyp
 
 \begin{itemdescr}
 \pnum
-\effects Initializes each element of \tcode{*this}
+\effects
+Initializes each element of \tcode{*this}
 with the corresponding element of \tcode{u}.
 
 \pnum
-\remarks This constructor shall not participate in overload resolution unless
+\remarks
+This constructor shall not participate in overload resolution unless
 \begin{itemize}
 \item
 \tcode{sizeof...(Types)} \tcode{==} \tcode{sizeof...(UTypes)} and
@@ -1261,12 +1299,14 @@ template<class... UTypes> constexpr explicit(@\seebelow@) tuple(tuple<UTypes...>
 
 \begin{itemdescr}
 \pnum
-\effects For all $i$,
+\effects
+For all $i$,
 initializes the $i^\text{th}$ element of \tcode{*this} with
 \tcode{std::forward<$\tcode{U}_i$>(get<$i$>(u))}.
 
 \pnum
-\remarks This constructor shall not participate in overload resolution unless
+\remarks
+This constructor shall not participate in overload resolution unless
 
 \begin{itemize}
 \item
@@ -1294,11 +1334,13 @@ template<class U1, class U2> constexpr explicit(@\seebelow@) tuple(const pair<U1
 
 \begin{itemdescr}
 \pnum
-\effects Initializes the first element with \tcode{u.first} and the
+\effects
+Initializes the first element with \tcode{u.first} and the
 second element with \tcode{u.second}.
 
 \pnum
-\remarks This constructor shall not participate in overload resolution unless
+\remarks
+This constructor shall not participate in overload resolution unless
 \tcode{sizeof...(Types) == 2},
 \tcode{is_constructible_v<$\tcode{T}_0$, const U1\&>} is \tcode{true} and
 \tcode{is_constructible_v<$\tcode{T}_1$, const U2\&>} is \tcode{true}.
@@ -1318,12 +1360,14 @@ template<class U1, class U2> constexpr explicit(@\seebelow@) tuple(pair<U1, U2>&
 
 \begin{itemdescr}
 \pnum
-\effects Initializes the first element with
+\effects
+Initializes the first element with
 \tcode{std::forward<U1>(u.first)} and the
 second element with \tcode{std::forward<U2>(u.second)}.
 
 \pnum
-\remarks This constructor shall not participate in overload resolution unless
+\remarks
+This constructor shall not participate in overload resolution unless
 \tcode{sizeof...(Types) == 2},
 \tcode{is_constructible_v<$\tcode{T}_0$, U1\&\&>} is \tcode{true} and
 \tcode{is_constructible_v<$\tcode{T}_1$, U2\&\&>} is \tcode{true}.
@@ -1370,7 +1414,8 @@ template<class Alloc, class U1, class U2>
 \oldconcept{Allocator} requirements (\tref{cpp17.allocator}).
 
 \pnum
-\effects Equivalent to the preceding constructors except that each element is constructed with
+\effects
+Equivalent to the preceding constructors except that each element is constructed with
 uses-allocator construction\iref{allocator.uses.construction}.
 \end{itemdescr}
 
@@ -1391,15 +1436,18 @@ constexpr tuple& operator=(const tuple& u);
 
 \begin{itemdescr}
 \pnum
-\effects Assigns each element of \tcode{u} to the corresponding
+\effects
+Assigns each element of \tcode{u} to the corresponding
 element of \tcode{*this}.
 
 \pnum
-\remarks This operator shall be defined as deleted unless
+\remarks
+This operator shall be defined as deleted unless
 \tcode{is_copy_assignable_v<$\tcode{T}_i$>} is \tcode{true} for all $i$.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{tuple}%
@@ -1409,15 +1457,18 @@ constexpr tuple& operator=(tuple&& u) noexcept(@\seebelow@);
 
 \begin{itemdescr}
 \pnum
-\effects For all $i$, assigns \tcode{std::forward<$\tcode{T}_i$>(get<$i$>(u))} to
+\effects
+For all $i$, assigns \tcode{std::forward<$\tcode{T}_i$>(get<$i$>(u))} to
 \tcode{get<$i$>(*this)}.
 
 \pnum
-\remarks This operator shall not participate in overload resolution unless
+\remarks
+This operator shall not participate in overload resolution unless
 \tcode{is_move_assignable_v<$\tcode{T}_i$>} is \tcode{true} for all $i$.
 
 \pnum
-\remarks The expression inside \tcode{noexcept} is equivalent to the logical \textsc{and} of the
+\remarks
+The expression inside \tcode{noexcept} is equivalent to the logical \textsc{and} of the
 following expressions:
 
 \begin{codeblock}
@@ -1426,7 +1477,8 @@ is_nothrow_move_assignable_v<@$\mathtt{T}_i$@>
 where $\mathtt{T}_i$ is the $i^\text{th}$ type in \tcode{Types}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{tuple}%
@@ -1436,16 +1488,19 @@ template<class... UTypes> constexpr tuple& operator=(const tuple<UTypes...>& u);
 
 \begin{itemdescr}
 \pnum
-\effects Assigns each element of \tcode{u} to the corresponding element
+\effects
+Assigns each element of \tcode{u} to the corresponding element
 of \tcode{*this}.
 
 \pnum
-\remarks This operator shall not participate in overload resolution unless
+\remarks
+This operator shall not participate in overload resolution unless
 \tcode{sizeof...(Types) == sizeof...(UTypes)} and
 \tcode{is_assignable_v<$\tcode{T}_i$\&, const $\tcode{U}_i$\&>} is \tcode{true} for all $i$.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{tuple}%
@@ -1455,16 +1510,19 @@ template<class... UTypes> constexpr tuple& operator=(tuple<UTypes...>&& u);
 
 \begin{itemdescr}
 \pnum
-\effects For all $i$, assigns \tcode{std::forward<$\tcode{U}_i$>(get<$i$>(u))} to
+\effects
+For all $i$, assigns \tcode{std::forward<$\tcode{U}_i$>(get<$i$>(u))} to
 \tcode{get<$i$>(*this)}.
 
 \pnum
-\remarks This operator shall not participate in overload resolution unless
+\remarks
+This operator shall not participate in overload resolution unless
 \tcode{is_assignable_v<$\tcode{T}_i$\&, $\tcode{U}_i$\&\&> == true} for all $i$ and
 \tcode{sizeof...(Types) == sizeof...(UTypes)}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{tuple}%
@@ -1475,18 +1533,21 @@ template<class U1, class U2> constexpr tuple& operator=(const pair<U1, U2>& u);
 
 \begin{itemdescr}
 \pnum
-\effects  Assigns \tcode{u.first} to the first element of \tcode{*this}
+\effects
+Assigns \tcode{u.first} to the first element of \tcode{*this}
 and \tcode{u.second} to the second element of \tcode{*this}.
 
 \pnum
-\remarks This operator shall not participate in overload resolution unless
+\remarks
+This operator shall not participate in overload resolution unless
 \tcode{sizeof...(Types) == 2} and
 \tcode{is_assignable_v<$\tcode{T}_0$\&, const U1\&>} is \tcode{true} for the first type $\tcode{T}_0$ in
 \tcode{Types} and \tcode{is_assignable_v<$\tcode{T}_1$\&, const U2\&>} is \tcode{true} for the
 second type $\tcode{T}_1$ in \tcode{Types}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{tuple}%
@@ -1497,7 +1558,8 @@ template<class U1, class U2> constexpr tuple& operator=(pair<U1, U2>&& u);
 
 \begin{itemdescr}
 \pnum
-\effects Assigns \tcode{std::forward<U1>(u.first)} to the first
+\effects
+Assigns \tcode{std::forward<U1>(u.first)} to the first
 element of \tcode{*this} and\\ \tcode{std::forward<U2>(u.second)} to the
 second element of \tcode{*this}.
 
@@ -1510,7 +1572,8 @@ This operator shall not participate in overload resolution unless
 type $\tcode{T}_1$ in \tcode{Types}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \rSec3[tuple.swap]{\tcode{swap}}
@@ -1527,11 +1590,13 @@ Each element in \tcode{*this} shall be swappable with\iref{swappable.requirement
 the corresponding element in \tcode{rhs}.
 
 \pnum
-\effects Calls \tcode{swap} for each element in \tcode{*this} and its
+\effects
+Calls \tcode{swap} for each element in \tcode{*this} and its
 corresponding element in \tcode{rhs}.
 
 \pnum
-\remarks The expression inside \tcode{noexcept} is equivalent to the logical
+\remarks
+The expression inside \tcode{noexcept} is equivalent to the logical
 \textsc{and} of the following expressions:
 
 \begin{codeblock}
@@ -1540,7 +1605,8 @@ is_nothrow_swappable_v<@$\mathtt{T}_i$@>
 where $\mathtt{T}_i$ is the $i^\text{th}$ type in \tcode{Types}.
 
 \pnum
-\throws Nothing unless one of the element-wise \tcode{swap} calls throws an exception.
+\throws
+Nothing unless one of the element-wise \tcode{swap} calls throws an exception.
 \end{itemdescr}
 
 \rSec3[tuple.creation]{Tuple creation functions}
@@ -1559,7 +1625,8 @@ template<class... TTypes>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{tuple<unwrap_ref_decay_t<TTypes>...>(std::forward<TTypes>(t)...)}.
+\returns
+\tcode{tuple<unwrap_ref_decay_t<TTypes>...>(std::forward<TTypes>(t)...)}.
 
 \pnum
 \begin{example}
@@ -1580,14 +1647,16 @@ template<class... TTypes>
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a tuple of references to the arguments in \tcode{t} suitable
+\effects
+Constructs a tuple of references to the arguments in \tcode{t} suitable
 for forwarding as arguments to a function. Because the result may contain references
 to temporary objects, a program shall ensure that the return value of this
 function does not outlive any of its arguments (e.g., the program should typically
 not store the result in a named variable).
 
 \pnum
-\returns \tcode{tuple<TTypes\&\&...>(std::forward<TTypes>(t)...)}.
+\returns
+\tcode{tuple<TTypes\&\&...>(std::forward<TTypes>(t)...)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{tie}}%
@@ -1600,7 +1669,8 @@ template<class... TTypes>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{tuple<TTypes\&...>(t...)}.  When an
+\returns
+\tcode{tuple<TTypes\&...>(t...)}.  When an
 argument in \tcode{t} is \tcode{ignore}, assigning
 any value to the corresponding tuple element has no effect.
 
@@ -1643,7 +1713,8 @@ $\tcode{A}_{ik}$ the following requirements shall be met:
 \end{itemize}
 
 \pnum
-\remarks The types in \tcode{CTypes} shall be equal to the ordered
+\remarks
+The types in \tcode{CTypes} shall be equal to the ordered
 sequence of the extended types
 \tcode{$\tcode{Args}_0$..., $\tcode{Args}_1$..., $\dotsc$, $\tcode{Args}_{n-1}$...},
 where $n$ is
@@ -1652,7 +1723,8 @@ ordered sequence of tuple elements of the resulting \tcode{tuple} object
 corresponding to the type sequence $\tcode{Args}_i$.
 
 \pnum
-\returns A \tcode{tuple} object constructed by initializing the ${k_i}^\text{th}$
+\returns
+A \tcode{tuple} object constructed by initializing the ${k_i}^\text{th}$
 type element $\tcode{e}_{ik}$ in \tcode{$\tcode{e}_i$...} with
 \begin{codeblock}
 get<@$k_i$@>(std::forward<@$\tcode{T}_i$@>(@$\tcode{tp}_i$@))
@@ -1729,7 +1801,8 @@ template<class T> struct tuple_size;
 
 \begin{itemdescr}
 \pnum
-\remarks All specializations of \tcode{tuple_size} shall meet the
+\remarks
+All specializations of \tcode{tuple_size} shall meet the
 \oldconcept{UnaryTypeTrait} requirements\iref{meta.rqmts} with a
 base characteristic of \tcode{integral_constant<size_t, N>}
 for some \tcode{N}.
@@ -1853,7 +1926,8 @@ template<size_t I, class... Types>
 The program is ill-formed if \tcode{I} is out of bounds.
 
 \pnum
-\returns  A reference to the $\tcode{I}^\text{th}$ element of \tcode{t}, where
+\returns
+A reference to the $\tcode{I}^\text{th}$ element of \tcode{t}, where
 indexing is zero-based.
 
 \pnum
@@ -1894,7 +1968,8 @@ template<class T, class... Types>
 Otherwise, the program is ill-formed.
 
 \pnum
-\returns A reference to the element of \tcode{t} corresponding to the type
+\returns
+A reference to the element of \tcode{t} corresponding to the type
 \tcode{T} in \tcode{Types}.
 
 \pnum
@@ -1933,12 +2008,14 @@ returning a type that is convertible to \tcode{bool}.
 \tcode{sizeof...(UTypes)}.
 
 \pnum
-\returns  \tcode{true} if \tcode{get<i>(t) == get<i>(u)} for all
+\returns
+\tcode{true} if \tcode{get<i>(t) == get<i>(u)} for all
 \tcode{i}, otherwise \tcode{false}.
 For any two zero-length tuples \tcode{e} and \tcode{f}, \tcode{e == f} returns \tcode{true}.
 
 \pnum
-\effects  The elementary comparisons are performed in order from the
+\effects
+The elementary comparisons are performed in order from the
 zeroth index upwards.  No comparisons or element accesses are
 performed after the first equality comparison that evaluates to
 \tcode{false}.
@@ -2005,7 +2082,8 @@ template<class... Types>
 
 \begin{itemdescr}
 \pnum
-\remarks This function shall not participate in overload resolution
+\remarks
+This function shall not participate in overload resolution
 unless \tcode{is_swappable_v<T>} is \tcode{true}
 for every type \tcode{T} in \tcode{Types}.
 The expression inside \tcode{noexcept} is equivalent to:
@@ -2015,7 +2093,8 @@ noexcept(x.swap(y))
 \end{codeblock}
 
 \pnum
-\effects As if by \tcode{x.swap(y)}.
+\effects
+As if by \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \rSec1[optional]{Optional objects}
@@ -2925,10 +3004,12 @@ constexpr bool has_value() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{true} if and only if \tcode{*this} contains a value.
+\returns
+\tcode{true} if and only if \tcode{*this} contains a value.
 
 \pnum
-\remarks This function shall be a constexpr function.
+\remarks
+This function shall be a constexpr function.
 \end{itemdescr}
 
 \indexlibrarymember{value}{optional}%
@@ -3470,7 +3551,8 @@ template<class T> void swap(optional<T>& x, optional<T>& y) noexcept(noexcept(x.
 Calls \tcode{x.swap(y)}.
 
 \pnum
-\remarks This function shall not participate in overload resolution
+\remarks
+This function shall not participate in overload resolution
 unless \tcode{is_move_constructible_v<T>} is \tcode{true} and
 \tcode{is_swappable_v<T>} is \tcode{true}.
 \end{itemdescr}
@@ -3494,7 +3576,8 @@ template<class T, class...Args>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return optional<T>(in_place, std::forward<Args>(args)...);}
+\effects
+Equivalent to: \tcode{return optional<T>(in_place, std::forward<Args>(args)...);}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{make_optional}}%
@@ -3505,7 +3588,8 @@ template<class T, class U, class... Args>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return optional<T>(in_place, il, std::forward<Args>(args)...);}
+\effects
+Equivalent to: \tcode{return optional<T>(in_place, il, std::forward<Args>(args)...);}
 \end{itemdescr}
 
 \rSec2[optional.hash]{Hash support}
@@ -4056,10 +4140,12 @@ Otherwise, equivalent to \tcode{operator=(variant(rhs))}.
 \end{itemize}
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 
 \pnum
-\ensures \tcode{index() == rhs.index()}.
+\ensures
+\tcode{index() == rhs.index()}.
 
 \pnum
 \remarks
@@ -4098,7 +4184,8 @@ Otherwise, equivalent to \tcode{emplace<$j$>(get<$j$>(std::move(rhs)))}.
 \end{itemize}
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 
 \pnum
 \remarks
@@ -4159,7 +4246,8 @@ Otherwise, equivalent to \tcode{operator=(variant(std::forward<T>(t)))}.
 selected by the imaginary function overload resolution described above.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 
 \pnum
 \remarks
@@ -4766,7 +4854,8 @@ All such expressions shall be of the same type and value category;
 otherwise, the program is ill-formed.
 
 \pnum
-\returns $e(\tcode{m})$, where \tcode{m} is the pack for which
+\returns
+$e(\tcode{m})$, where \tcode{m} is the pack for which
 $\tcode{m}_i$ is \tcode{vars$_i$.index()} for all $0 \leq i < n$.
 The return type is $\tcode{decltype(}e(\tcode{m})\tcode{)}$
 for the first form.
@@ -4825,10 +4914,12 @@ template<class... Types>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to \tcode{v.swap(w)}.
+\effects
+Equivalent to \tcode{v.swap(w)}.
 
 \pnum
-\remarks This function shall not participate in overload resolution
+\remarks
+This function shall not participate in overload resolution
 unless \tcode{is_move_constructible_v<$\tcode{T}_i$> \&\& is_swappable_v<$\tcode{T}_i$>}
 is \tcode{true} for all $i$.
 The expression inside \tcode{noexcept} is equivalent to \tcode{noexcept(v.swap(w))}.
@@ -4856,7 +4947,8 @@ const char* what() const noexcept override;
 
 \begin{itemdescr}
 \pnum
-\returns An \impldef{return value of \tcode{bad_variant_access::what}} \ntbs{}.
+\returns
+An \impldef{return value of \tcode{bad_variant_access::what}} \ntbs{}.
 \end{itemdescr}
 
 \rSec2[variant.hash]{Hash support}
@@ -4951,7 +5043,8 @@ const char* what() const noexcept override;
 
 \begin{itemdescr}
 \pnum
-\returns An \impldef{return value of \tcode{bad_any_cast::what}} \ntbs{}.
+\returns
+An \impldef{return value of \tcode{bad_any_cast::what}} \ntbs{}.
 \end{itemdescr}
 
 \rSec2[any.class]{Class \tcode{any}}
@@ -5109,14 +5202,17 @@ Let \tcode{VT} be \tcode{decay_t<T>}.
 \requires \tcode{VT} shall meet the \oldconcept{CopyConstructible} requirements.
 
 \pnum
-\effects Initializes the contained value as if direct-non-list-initializing an object of
+\effects
+Initializes the contained value as if direct-non-list-initializing an object of
 type \tcode{VT} with the arguments \tcode{std::forward<Args>(args)...}.
 
 \pnum
-\ensures \tcode{*this} contains a value of type \tcode{VT}.
+\ensures
+\tcode{*this} contains a value of type \tcode{VT}.
 
 \pnum
-\throws Any exception thrown by the selected constructor of \tcode{VT}.
+\throws
+Any exception thrown by the selected constructor of \tcode{VT}.
 
 \pnum
 \remarks
@@ -5139,14 +5235,17 @@ Let \tcode{VT} be \tcode{decay_t<T>}.
 \requires \tcode{VT} shall meet the \oldconcept{CopyConstructible} requirements.
 
 \pnum
-\effects Initializes the contained value as if direct-non-list-initializing an object of
+\effects
+Initializes the contained value as if direct-non-list-initializing an object of
 type \tcode{VT} with the arguments \tcode{il, std::forward<Args>(args)...}.
 
 \pnum
-\ensures \tcode{*this} contains a value.
+\ensures
+\tcode{*this} contains a value.
 
 \pnum
-\throws Any exception thrown by the selected constructor of \tcode{VT}.
+\throws
+Any exception thrown by the selected constructor of \tcode{VT}.
 
 \pnum
 \remarks
@@ -5259,22 +5358,26 @@ Let \tcode{VT} be \tcode{decay_t<T>}.
 \tcode{VT} shall meet the \oldconcept{CopyConstructible} requirements.
 
 \pnum
-\effects Calls \tcode{reset()}.
+\effects
+Calls \tcode{reset()}.
 Then initializes the contained value as if direct-non-list-initializing
 an object of type \tcode{VT} with the arguments \tcode{std::forward<Args>(args)...}.
 
 \pnum
-\ensures \tcode{*this} contains a value.
+\ensures
+\tcode{*this} contains a value.
 
 \pnum
 \returns
 A reference to the new contained value.
 
 \pnum
-\throws Any exception thrown by the selected constructor of \tcode{VT}.
+\throws
+Any exception thrown by the selected constructor of \tcode{VT}.
 
 \pnum
-\remarks If an exception is thrown during the call to \tcode{VT}'s constructor,
+\remarks
+If an exception is thrown during the call to \tcode{VT}'s constructor,
 \tcode{*this} does not contain a value, and any previously contained value
 has been destroyed.
 This function shall not participate in overload resolution unless
@@ -5297,22 +5400,26 @@ Let \tcode{VT} be \tcode{decay_t<T>}.
 \tcode{VT} shall meet the \oldconcept{CopyConstructible} requirements.
 
 \pnum
-\effects Calls \tcode{reset()}. Then initializes the contained value
+\effects
+Calls \tcode{reset()}. Then initializes the contained value
 as if direct-non-list-initializing an object of type \tcode{VT} with the arguments
 \tcode{il, std::forward<Args>(args)...}.
 
 \pnum
-\ensures \tcode{*this} contains a value.
+\ensures
+\tcode{*this} contains a value.
 
 \pnum
 \returns
 A reference to the new contained value.
 
 \pnum
-\throws Any exception thrown by the selected constructor of \tcode{VT}.
+\throws
+Any exception thrown by the selected constructor of \tcode{VT}.
 
 \pnum
-\remarks If an exception is thrown during the call to \tcode{VT}'s constructor,
+\remarks
+If an exception is thrown during the call to \tcode{VT}'s constructor,
 \tcode{*this} does not contain a value, and any previously contained value
 has been destroyed.
 The function shall not participate in overload resolution unless
@@ -5767,7 +5874,8 @@ template<class charT>
 
 \begin{itemdescr}
 \pnum
-\effects Constructs an object of class \tcode{bitset<N>} as if by:
+\effects
+Constructs an object of class \tcode{bitset<N>} as if by:
 \begin{codeblock}
 bitset(n == basic_string<charT>::npos
           ? basic_string<charT>(str)
@@ -6147,7 +6255,8 @@ bool all() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{count() == size()}.
+\returns
+\tcode{count() == size()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{any} (member)!\idxcode{bitset}}%
@@ -6158,7 +6267,8 @@ bool any() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{count() != 0}.
+\returns
+\tcode{count() != 0}.
 \end{itemdescr}
 
 \indexlibrarymember{none}{bitset}%
@@ -6168,7 +6278,8 @@ bool none() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{count() == 0}.
+\returns
+\tcode{count() == 0}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<<}{bitset}%
@@ -6209,7 +6320,8 @@ constexpr bool operator[](size_t pos) const;
 one, otherwise \tcode{false}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \indexlibrarymember{operator[]}{bitset}%
@@ -6234,10 +6346,12 @@ is equivalent to
 \tcode{this->set(pos, val)}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 
 \pnum
-\remarks For the purpose of determining the presence of a data
+\remarks
+For the purpose of determining the presence of a data
 race\iref{intro.multithread}, any access or update through the resulting
 reference potentially accesses or modifies, respectively, the entire
 underlying bitset.
@@ -6909,11 +7023,13 @@ static constexpr pointer pointer_traits<T*>::pointer_to(@\seebelow@ r) noexcept;
 
 \begin{itemdescr}
 \pnum
-\remarks If \tcode{element_type} is \cv{}~\tcode{void}, the type of
+\remarks
+If \tcode{element_type} is \cv{}~\tcode{void}, the type of
 \tcode{r} is unspecified; otherwise, it is \tcode{element_type\&}.
 
 \pnum
-\returns The first member function returns a pointer to \tcode{r}
+\returns
+The first member function returns a pointer to \tcode{r}
 obtained by calling \tcode{Ptr::pointer_to(r)} through which
 indirection is valid; an instantiation of this function is
 ill-formed if \tcode{Ptr} does not have a matching \tcode{pointer_to} static member
@@ -6958,7 +7074,8 @@ template<class T> constexpr T* to_address(T* p) noexcept;
 \requires \tcode{T} is not a function type. Otherwise the program is ill-formed.
 
 \pnum
-\returns \tcode{p}.
+\returns
+\tcode{p}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{to_address}}%
@@ -6993,11 +7110,13 @@ void declare_reachable(void* p);
 pointer\iref{basic.stc.dynamic.safety} or a null pointer value.
 
 \pnum
-\effects If \tcode{p} is not null, the complete object referenced by \tcode{p}
+\effects
+If \tcode{p} is not null, the complete object referenced by \tcode{p}
 is subsequently declared reachable\iref{basic.stc.dynamic.safety}.
 
 \pnum
-\throws May throw \tcode{bad_alloc} if the system cannot allocate
+\throws
+May throw \tcode{bad_alloc} if the system cannot allocate
 additional memory that may be required to track objects declared reachable.
 \end{itemdescr}
 
@@ -7014,10 +7133,12 @@ live\iref{basic.life} from the time of the call until the last
 \tcode{undeclare_reachable(p)} call on the object.
 
 \pnum
-\returns A safely derived copy of \tcode{p} which shall compare equal to \tcode{p}.
+\returns
+A safely derived copy of \tcode{p} which shall compare equal to \tcode{p}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 
 \pnum
 \begin{note} It is expected that calls to \tcode{declare_reachable(p)} will consume
@@ -7042,7 +7163,8 @@ registered with \tcode{declare_no_pointers()} should not prevent the object from
 being collected. \end{note}
 
 \pnum
-\effects The \tcode{n} bytes starting at \tcode{p} no longer contain
+\effects
+The \tcode{n} bytes starting at \tcode{p} no longer contain
 traceable pointer locations, independent of their type. Hence
 indirection through a pointer located there is undefined if the object
 it points to was created by global \tcode{operator new} and not
@@ -7051,7 +7173,8 @@ garbage collector or leak detector that this region of memory need not
 be traced. \end{note}
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 
 \pnum
 \begin{note} Under some conditions implementations may need to allocate memory.
@@ -7069,11 +7192,13 @@ void undeclare_no_pointers(char* p, size_t n);
 \tcode{declare_no_pointers()}.
 
 \pnum
-\effects Unregisters a range registered with \tcode{declare_no_pointers()} for
+\effects
+Unregisters a range registered with \tcode{declare_no_pointers()} for
 destruction. It shall be called before the lifetime of the object ends.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{get_pointer_safety}}%
@@ -7083,7 +7208,8 @@ pointer_safety get_pointer_safety() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{pointer_safety::strict} if the implementation has strict pointer
+\returns
+\tcode{pointer_safety::strict} if the implementation has strict pointer
 safety\iref{basic.stc.dynamic.safety}. It is
 \impldef{whether \tcode{get_pointer_safety} returns
 \tcode{pointer_safety::relaxed} or
@@ -7106,7 +7232,8 @@ void* align(size_t alignment, size_t size, void*& ptr, size_t& space);
 
 \begin{itemdescr}
 \pnum
-\effects If it is possible to fit \tcode{size} bytes
+\effects
+If it is possible to fit \tcode{size} bytes
 of storage aligned by \tcode{alignment} into the buffer pointed to by
 \tcode{ptr} with length \tcode{space}, the function updates
 \tcode{ptr} to represent the first possible address of such storage
@@ -7124,7 +7251,8 @@ Otherwise, the function does nothing.
 \end{itemize}
 
 \pnum
-\returns A null pointer if the requested aligned buffer
+\returns
+A null pointer if the requested aligned buffer
 would not fit into the available space, otherwise the adjusted value
 of \tcode{ptr}.
 
@@ -7202,7 +7330,8 @@ template<class T, class Alloc> struct uses_allocator;
 
 \begin{itemdescr}
 \pnum
-\remarks Automatically detects whether \tcode{T} has a nested \tcode{allocator_type} that
+\remarks
+Automatically detects whether \tcode{T} has a nested \tcode{allocator_type} that
 is convertible from \tcode{Alloc}. Meets the \oldconcept{BinaryTypeTrait}
 requirements\iref{meta.rqmts}. The implementation shall provide a definition that is
 derived from \tcode{true_type} if the \grammarterm{qualified-id} \tcode{T::allocator_type}
@@ -7667,7 +7796,8 @@ otherwise, the instantiation of \tcode{rebind_alloc} is ill-formed.
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{a.allocate(n)}.
+\returns
+\tcode{a.allocate(n)}.
 \end{itemdescr}
 
 \indexlibrarymember{allocate}{allocator_traits}%
@@ -7677,7 +7807,8 @@ otherwise, the instantiation of \tcode{rebind_alloc} is ill-formed.
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{a.allocate(n, hint)} if that expression is well-formed; otherwise, \tcode{a.allocate(n)}.
+\returns
+\tcode{a.allocate(n, hint)} if that expression is well-formed; otherwise, \tcode{a.allocate(n)}.
 \end{itemdescr}
 
 \indexlibrarymember{deallocate}{allocator_traits}%
@@ -7687,10 +7818,12 @@ static constexpr void deallocate(Alloc& a, pointer p, size_type n);
 
 \begin{itemdescr}
 \pnum
-\effects Calls \tcode{a.deallocate(p, n)}.
+\effects
+Calls \tcode{a.deallocate(p, n)}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \indexlibrarymember{construct}{allocator_traits}%
@@ -7701,7 +7834,8 @@ template<class T, class... Args>
 
 \begin{itemdescr}
 \pnum
-\effects Calls \tcode{a.construct(p, std::forward<Args>(args)...)}
+\effects
+Calls \tcode{a.construct(p, std::forward<Args>(args)...)}
 if that call is well-formed;
 otherwise, invokes \tcode{construct_at(p, std::forward<Args>(args)...)}.
 \end{itemdescr}
@@ -7714,7 +7848,8 @@ template<class T>
 
 \begin{itemdescr}
 \pnum
-\effects Calls \tcode{a.destroy(p)} if that call is well-formed; otherwise, invokes
+\effects
+Calls \tcode{a.destroy(p)} if that call is well-formed; otherwise, invokes
 \tcode{destroy_at(p)}.
 \end{itemdescr}
 
@@ -7725,7 +7860,8 @@ static constexpr size_type max_size(const Alloc& a) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{a.max_size()} if that expression is well-formed; otherwise,
+\returns
+\tcode{a.max_size()} if that expression is well-formed; otherwise,
 \tcode{numeric_limits<size_type>::\brk{}max()/sizeof(value_type)}.
 \end{itemdescr}
 
@@ -7736,7 +7872,8 @@ static constexpr Alloc select_on_container_copy_construction(const Alloc& rhs);
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{rhs.select_on_container_copy_construction()} if that expression is
+\returns
+\tcode{rhs.select_on_container_copy_construction()} if that expression is
 well-formed; otherwise, \tcode{rhs}.
 \end{itemdescr}
 
@@ -8013,11 +8150,13 @@ template<class T> constexpr T* addressof(T& r) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns The actual address of the object or function referenced by \tcode{r}, even in the
+\returns
+The actual address of the object or function referenced by \tcode{r}, even in the
 presence of an overloaded \tcode{operator\&}.
 
 \pnum
-\remarks An expression \tcode{addressof(E)}
+\remarks
+An expression \tcode{addressof(E)}
 is a constant subexpression\iref{defns.const.subexpr}
 if \tcode{E} is an lvalue constant subexpression.
 \end{itemdescr}
@@ -8055,7 +8194,8 @@ namespace ranges {
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 for (; first != last; ++first)
   ::new (@\placeholdernc{voidify}@(*first)) remove_reference_t<iter_reference_t<I>>;
@@ -8092,7 +8232,8 @@ namespace ranges {
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return uninitialized_default_construct(counted_iterator(first, n),
                                        default_sentinel).base();
@@ -8132,7 +8273,8 @@ namespace ranges {
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 for (; first != last; ++first)
   ::new (@\placeholdernc{voidify}@(*first)) remove_reference_t<iter_reference_t<I>>();
@@ -8169,7 +8311,8 @@ namespace ranges {
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return uninitialized_value_construct(counted_iterator(first, n),
                                      default_sentinel).base();
@@ -8225,7 +8368,8 @@ namespace ranges {
 \range{ofirst}{olast} shall not overlap with \range{ifirst}{ilast}.
 
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 for (; ifirst != ilast && ofirst != olast; ++ofirst, (void)++ifirst) {
   ::new (@\placeholdernc{voidify}@(*ofirst)) remove_reference_t<iter_reference_t<O>>(*ifirst);
@@ -8256,7 +8400,8 @@ for ( ; n > 0; ++result, (void) ++first, --n) {
 \end{codeblock}
 
 \pnum
-\returns \tcode{result}.
+\returns
+\tcode{result}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{uninitialized_copy_n}}%
@@ -8276,7 +8421,8 @@ namespace ranges {
 \range{ifirst}{n}.
 
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 auto t = uninitialized_copy(counted_iterator(ifirst, n),
                             default_sentinel, ofirst, olast);
@@ -8330,7 +8476,8 @@ namespace ranges {
 \range{ofirst}{olast} shall not overlap with \range{ifirst}{ilast}.
 
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 for (; ifirst != ilast && ofirst != olast; ++ofirst, (void)++ifirst) {
   ::new (@\placeholder{voidify}@(*ofirst))
@@ -8386,7 +8533,8 @@ namespace ranges {
 \range{ifirst}{n}.
 
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 auto t = uninitialized_move(counted_iterator(ifirst, n),
                             default_sentinel, ofirst, olast);
@@ -8433,7 +8581,8 @@ namespace ranges {
 \end{itemdecl}
 
 \begin{itemdescr}
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 for (; first != last; ++first) {
   ::new (@\placeholdernc{voidify}@(*first)) remove_reference_t<iter_reference_t<I>>(x);
@@ -8471,7 +8620,8 @@ namespace ranges {
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return uninitialized_fill(counted_iterator(first, n), default_sentinel, x).base();
 \end{codeblock}
@@ -8557,7 +8707,8 @@ namespace ranges {
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 for (; first != last; ++first)
   destroy_at(addressof(*first));
@@ -8593,7 +8744,8 @@ namespace ranges {
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return destroy(counted_iterator(first, n), default_sentinel).base();
 \end{codeblock}
@@ -8736,11 +8888,13 @@ template<class U> default_delete(const default_delete<U>& other) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{default_delete} object
+\effects
+Constructs a \tcode{default_delete} object
 from another \tcode{default_delete<U>} object.
 
 \pnum
-\remarks This constructor shall not participate in overload resolution unless
+\remarks
+This constructor shall not participate in overload resolution unless
 \tcode{U*} is implicitly convertible to \tcode{T*}.
 \end{itemdescr}
 
@@ -8751,10 +8905,12 @@ void operator()(T* ptr) const;
 
 \begin{itemdescr}
 \pnum
-\effects Calls \tcode{delete} on \tcode{ptr}.
+\effects
+Calls \tcode{delete} on \tcode{ptr}.
 
 \pnum
-\remarks If \tcode{T} is an incomplete type, the program is ill-formed.
+\remarks
+If \tcode{T} is an incomplete type, the program is ill-formed.
 \end{itemdescr}
 
 \rSec4[unique.ptr.dltr.dflt1]{\tcode{default_delete<T[]>}}
@@ -8796,7 +8952,8 @@ template<class U> void operator()(U* ptr) const;
 Calls \tcode{delete[]} on \tcode{ptr}.
 
 \pnum
-\remarks If \tcode{U} is an incomplete type, the program is ill-formed.
+\remarks
+If \tcode{U} is an incomplete type, the program is ill-formed.
 This function shall not participate in overload resolution
 unless \tcode{U(*)[]} is convertible to \tcode{T(*)[]}.
 \end{itemdescr}
@@ -8896,15 +9053,18 @@ meet the \oldconcept{DefaultConstructible} requirements (\tref{cpp17.defaultcons
 and that construction shall not throw an exception.
 
 \pnum
-\effects Constructs a \tcode{unique_ptr} object that owns
+\effects
+Constructs a \tcode{unique_ptr} object that owns
 nothing, value-initializing the stored pointer and the stored deleter.
 
 \pnum
-\ensures \tcode{get() == nullptr}. \tcode{get_deleter()}
+\ensures
+\tcode{get() == nullptr}. \tcode{get_deleter()}
 returns a reference to the stored deleter.
 
 \pnum
-\remarks If \tcode{is_pointer_v<deleter_type>} is \tcode{true} or
+\remarks
+If \tcode{is_pointer_v<deleter_type>} is \tcode{true} or
 \tcode{is_default_constructible_v<deleter_type>} is \tcode{false},
 this constructor shall not participate in overload resolution.
 \end{itemdescr}
@@ -8921,16 +9081,19 @@ meet the \oldconcept{DefaultConstructible} requirements (\tref{cpp17.defaultcons
 and that construction shall not throw an exception.
 
 \pnum
-\effects Constructs a \tcode{unique_ptr} which owns
+\effects
+Constructs a \tcode{unique_ptr} which owns
 \tcode{p}, initializing the stored pointer with \tcode{p} and
 value-initializing the stored deleter.
 
 \pnum
-\ensures \tcode{get() == p}. \tcode{get_deleter()}
+\ensures
+\tcode{get() == p}. \tcode{get_deleter()}
 returns a reference to the stored deleter.
 
 \pnum
-\remarks If \tcode{is_pointer_v<deleter_type>} is \tcode{true} or
+\remarks
+If \tcode{is_pointer_v<deleter_type>} is \tcode{true} or
 \tcode{is_default_constructible_v<deleter_type>} is \tcode{false},
 this constructor shall not participate in overload resolution.
 If class template argument deduction\iref{over.match.class.deduct}
@@ -8954,24 +9117,28 @@ For the second constructor, if \tcode{D} is not a reference type,
 such construction shall not exit via an exception.
 
 \pnum
-\effects Constructs a \tcode{unique_ptr} object which owns \tcode{p}, initializing
+\effects
+Constructs a \tcode{unique_ptr} object which owns \tcode{p}, initializing
 the stored pointer with \tcode{p} and initializing the deleter
 from \tcode{std::forward<decltype(d)>(d)}.
 
 \pnum
-\remarks If \tcode{D} is a reference type,
+\remarks
+If \tcode{D} is a reference type,
 the second constructor is defined as deleted.
 These constructors shall not participate in overload resolution
 unless \tcode{is_constructible_v<D, decltype(d)>} is \tcode{true}.
 
 \pnum
-\ensures \tcode{get() == p}.
+\ensures
+\tcode{get() == p}.
 \tcode{get_deleter()} returns a reference to the stored
 deleter. If \tcode{D} is a reference type then \tcode{get_deleter()}
 returns a reference to the lvalue \tcode{d}.
 
 \pnum
-\remarks If class template argument deduction\iref{over.match.class.deduct}
+\remarks
+If class template argument deduction\iref{over.match.class.deduct}
 would select a function template corresponding to either of these constructors,
 then the program is ill-formed.
 
@@ -9006,14 +9173,16 @@ of the deleter from an rvalue of type \tcode{D} shall not
 throw an exception.
 
 \pnum
-\effects Constructs a \tcode{unique_ptr} from
+\effects
+Constructs a \tcode{unique_ptr} from
 \tcode{u}. If \tcode{D} is a reference type, this
 deleter is copy constructed from \tcode{u}'s deleter; otherwise, this
 deleter is move constructed from \tcode{u}'s deleter. \begin{note} The
 construction of the deleter can be implemented with \tcode{std::forward<D>}. \end{note}
 
 \pnum
-\ensures \tcode{get()} yields the value \tcode{u.get()}
+\ensures
+\tcode{get()} yields the value \tcode{u.get()}
 yielded before the construction. \tcode{u.get() == nullptr}.
 \tcode{get_deleter()} returns a reference
 to the stored deleter that was constructed from
@@ -9036,7 +9205,8 @@ Otherwise, \tcode{E} is a reference type and construction of the deleter from an
 lvalue of type \tcode{E} shall be well-formed and shall not throw an exception.
 
 \pnum
-\remarks This constructor shall not participate in overload resolution unless:
+\remarks
+This constructor shall not participate in overload resolution unless:
 
 \begin{itemize}
 \item \tcode{unique_ptr<U, E>::pointer} is implicitly convertible to \tcode{pointer},
@@ -9046,14 +9216,16 @@ lvalue of type \tcode{E} shall be well-formed and shall not throw an exception.
 \end{itemize}
 
 \pnum
-\effects Constructs a \tcode{unique_ptr} from \tcode{u}.
+\effects
+Constructs a \tcode{unique_ptr} from \tcode{u}.
 If \tcode{E} is a reference type, this deleter is copy constructed from
 \tcode{u}'s deleter; otherwise, this deleter is move constructed from \tcode{u}'s
 deleter. \begin{note} The deleter constructor can be implemented with
 \tcode{std::forward<E>}. \end{note}
 
 \pnum
-\ensures \tcode{get()} yields the value \tcode{u.get()}
+\ensures
+\tcode{get()} yields the value \tcode{u.get()}
 yielded before the construction. \tcode{u.get() == nullptr}.
 \tcode{get_deleter()} returns a reference
 to the stored deleter that was constructed from
@@ -9075,7 +9247,8 @@ use of \tcode{default_delete} requires \tcode{T} to be a complete type.
 \end{note}
 
 \pnum
-\effects If \tcode{get() == nullptr} there are no effects.
+\effects
+If \tcode{get() == nullptr} there are no effects.
 Otherwise \tcode{get_deleter()(get())}.
 \end{itemdescr}
 
@@ -9100,14 +9273,17 @@ requirements and assignment of the deleter from an
 lvalue of type \tcode{D} shall not throw an exception.
 
 \pnum
-\effects Calls \tcode{reset(u.release())} followed by
+\effects
+Calls \tcode{reset(u.release())} followed by
 \tcode{get_deleter() = std::forward<D>(u.get_dele\-ter())}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 
 \pnum
-\ensures \tcode{u.get() == nullptr}.
+\ensures
+\tcode{u.get() == nullptr}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{unique_ptr}%
@@ -9123,7 +9299,8 @@ Otherwise, \tcode{E} is a reference type and assignment of the deleter from an l
 of type \tcode{E} shall be well-formed and shall not throw an exception.
 
 \pnum
-\remarks This operator shall not participate in overload resolution unless:
+\remarks
+This operator shall not participate in overload resolution unless:
 
 \begin{itemize}
 \item \tcode{unique_ptr<U, E>::pointer} is implicitly convertible to \tcode{pointer}, and
@@ -9132,14 +9309,17 @@ of type \tcode{E} shall be well-formed and shall not throw an exception.
 \end{itemize}
 
 \pnum
-\effects Calls \tcode{reset(u.release())} followed by
+\effects
+Calls \tcode{reset(u.release())} followed by
 \tcode{get_deleter() = std::forward<E>(u.get_dele\-ter())}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 
 \pnum
-\ensures \tcode{u.get() == nullptr}.
+\ensures
+\tcode{u.get() == nullptr}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{unique_ptr}%
@@ -9149,13 +9329,16 @@ unique_ptr& operator=(nullptr_t) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{reset()}.
+\effects
+As if by \tcode{reset()}.
 
 \pnum
-\ensures \tcode{get() == nullptr}.
+\ensures
+\tcode{get() == nullptr}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \rSec4[unique.ptr.single.observers]{Observers}
@@ -9170,7 +9353,8 @@ add_lvalue_reference_t<T> operator*() const;
 \requires \tcode{get() != nullptr}.
 
 \pnum
-\returns \tcode{*get()}.
+\returns
+\tcode{*get()}.
 
 \end{itemdescr}
 
@@ -9184,7 +9368,8 @@ pointer operator->() const noexcept;
 \requires \tcode{get() != nullptr}.
 
 \pnum
-\returns \tcode{get()}.
+\returns
+\tcode{get()}.
 
 \pnum
 \begin{note}
@@ -9199,7 +9384,8 @@ pointer get() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns The stored pointer.
+\returns
+The stored pointer.
 \end{itemdescr}
 
 \indexlibrarymember{get_deleter}{unique_ptr}%
@@ -9210,7 +9396,8 @@ const deleter_type& get_deleter() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns A reference to the stored deleter.
+\returns
+A reference to the stored deleter.
 \end{itemdescr}
 
 \indexlibrarymember{operator bool}{unique_ptr}%
@@ -9220,7 +9407,8 @@ explicit operator bool() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{get() != nullptr}.
+\returns
+\tcode{get() != nullptr}.
 \end{itemdescr}
 
 \rSec4[unique.ptr.single.modifiers]{Modifiers}
@@ -9232,10 +9420,12 @@ pointer release() noexcept;
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{get() == nullptr}.
+\ensures
+\tcode{get() == nullptr}.
 
 \pnum
-\returns The value \tcode{get()} had at the start of
+\returns
+The value \tcode{get()} had at the start of
 the call to \tcode{release}.
 \end{itemdescr}
 
@@ -9250,13 +9440,15 @@ void reset(pointer p = pointer()) noexcept;
 well-defined behavior, and shall not throw exceptions.
 
 \pnum
-\effects Assigns \tcode{p} to the stored pointer, and then if and only if the old value of the
+\effects
+Assigns \tcode{p} to the stored pointer, and then if and only if the old value of the
 stored pointer, \tcode{old_p}, was not equal to \tcode{nullptr}, calls
 \tcode{get_deleter()(old_p)}. \begin{note} The order of these operations is significant
 because the call to \tcode{get_deleter()} may destroy \tcode{*this}. \end{note}
 
 \pnum
-\ensures \tcode{get() == p}.
+\ensures
+\tcode{get() == p}.
 \begin{note} The postcondition does not hold if the call to \tcode{get_deleter()}
 destroys \tcode{*this} since \tcode{this->get()} is no longer a valid expression.
 \end{note}
@@ -9275,7 +9467,8 @@ not throw an exception
 under \tcode{swap}.
 
 \pnum
-\effects Invokes \tcode{swap} on the stored pointers and on the stored
+\effects
+Invokes \tcode{swap} on the stored pointers and on the stored
 deleters of \tcode{*this} and \tcode{u}.
 \end{itemdescr}
 
@@ -9471,7 +9664,8 @@ number of elements in the array to which
 the stored pointer points.
 
 \pnum
-\returns \tcode{get()[i]}.
+\returns
+\tcode{get()[i]}.
 \end{itemdescr}
 
 \rSec4[unique.ptr.runtime.modifiers]{Modifiers}
@@ -9483,7 +9677,8 @@ void reset(nullptr_t p = nullptr) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to \tcode{reset(pointer())}.
+\effects
+Equivalent to \tcode{reset(pointer())}.
 \end{itemdescr}
 
 \indexlibrarymember{reset}{unique_ptr}%
@@ -9515,10 +9710,12 @@ template<class T, class... Args> unique_ptr<T> make_unique(Args&&... args);
 
 \begin{itemdescr}
 \pnum
-\remarks This function shall not participate in overload resolution unless \tcode{T} is not an array.
+\remarks
+This function shall not participate in overload resolution unless \tcode{T} is not an array.
 
 \pnum
-\returns \tcode{unique_ptr<T>(new T(std::forward<Args>(args)...))}.
+\returns
+\tcode{unique_ptr<T>(new T(std::forward<Args>(args)...))}.
 
 \end{itemdescr}
 
@@ -9529,10 +9726,12 @@ template<class T> unique_ptr<T> make_unique(size_t n);
 
 \begin{itemdescr}
 \pnum
-\remarks This function shall not participate in overload resolution unless \tcode{T} is an array of unknown bound.
+\remarks
+This function shall not participate in overload resolution unless \tcode{T} is an array of unknown bound.
 
 \pnum
-\returns \tcode{unique_ptr<T>(new remove_extent_t<T>[n]())}.
+\returns
+\tcode{unique_ptr<T>(new remove_extent_t<T>[n]())}.
 
 \end{itemdescr}
 
@@ -9543,7 +9742,8 @@ template<class T, class... Args> @\unspec@ make_unique(Args&&...) = delete;
 
 \begin{itemdescr}
 \pnum
-\remarks This function shall not participate in overload resolution unless \tcode{T} is an array of known bound.
+\remarks
+This function shall not participate in overload resolution unless \tcode{T} is an array of known bound.
 
 \end{itemdescr}
 
@@ -9597,11 +9797,13 @@ template<class T, class D> void swap(unique_ptr<T, D>& x, unique_ptr<T, D>& y) n
 
 \begin{itemdescr}
 \pnum
-\remarks This function shall not participate in overload resolution
+\remarks
+This function shall not participate in overload resolution
 unless \tcode{is_swappable_v<D>} is \tcode{true}.
 
 \pnum
-\effects Calls \tcode{x.swap(y)}.
+\effects
+Calls \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator==}{unique_ptr}%
@@ -9612,7 +9814,8 @@ template<class T1, class D1, class T2, class D2>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x.get() == y.get()}.
+\returns
+\tcode{x.get() == y.get()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<}{unique_ptr}%
@@ -9633,10 +9836,12 @@ Then the specialization
 induces a strict weak ordering\iref{alg.sorting} on the pointer values.
 
 \pnum
-\returns \tcode{less<CT>()(x.get(), y.get())}.
+\returns
+\tcode{less<CT>()(x.get(), y.get())}.
 
 \pnum
-\remarks If \tcode{unique_ptr<T1, D1>::pointer} is not implicitly convertible
+\remarks
+If \tcode{unique_ptr<T1, D1>::pointer} is not implicitly convertible
 to \tcode{CT} or \tcode{unique_ptr<T2, D2>::pointer} is not implicitly
 convertible to \tcode{CT}, the program is ill-formed.
 \end{itemdescr}
@@ -9649,7 +9854,8 @@ template<class T1, class D1, class T2, class D2>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{y < x}.
+\returns
+\tcode{y < x}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=}{unique_ptr}%
@@ -9660,7 +9866,8 @@ template<class T1, class D1, class T2, class D2>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!(y < x)}.
+\returns
+\tcode{!(y < x)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>=}{unique_ptr}%
@@ -9671,7 +9878,8 @@ template<class T1, class D1, class T2, class D2>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!(x < y)}.
+\returns
+\tcode{!(x < y)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{unique_ptr}%
@@ -9698,7 +9906,8 @@ template<class T, class D>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!x}.
+\returns
+\tcode{!x}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<}{unique_ptr}%
@@ -9796,13 +10005,16 @@ template<class E, class T, class Y, class D>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{os << p.get();}
+\effects
+Equivalent to: \tcode{os << p.get();}
 
 \pnum
-\returns \tcode{os}.
+\returns
+\tcode{os}.
 
 \pnum
-\remarks This function shall not participate in overload resolution
+\remarks
+This function shall not participate in overload resolution
 unless \tcode{os << p.get()} is a valid expression.
 \end{itemdescr}
 
@@ -9977,10 +10189,12 @@ constexpr shared_ptr() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects  Constructs an empty \tcode{shared_ptr} object.
+\effects
+Constructs an empty \tcode{shared_ptr} object.
 
 \pnum
-\ensures  \tcode{use_count() == 0 \&\& get() == nullptr}.
+\ensures
+\tcode{use_count() == 0 \&\& get() == nullptr}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{shared_ptr}!constructor}%
@@ -9997,7 +10211,8 @@ shall have well-defined behavior, and
 shall not throw exceptions.
 
 \pnum
-\effects When \tcode{T} is not an array type,
+\effects
+When \tcode{T} is not an array type,
 constructs a \tcode{shared_ptr} object
 that owns the pointer \tcode{p}.
 Otherwise, constructs a \tcode{shared_ptr}
@@ -10009,14 +10224,17 @@ If an exception is thrown, \tcode{delete p} is called
 when \tcode{T} is not an array type, \tcode{delete[] p} otherwise.
 
 \pnum
-\ensures  \tcode{use_count() == 1 \&\& get() == p}.
+\ensures
+\tcode{use_count() == 1 \&\& get() == p}.
 
 \pnum
-\throws \tcode{bad_alloc}, or an \impldef{exception type when \tcode{shared_ptr}
+\throws
+\tcode{bad_alloc}, or an \impldef{exception type when \tcode{shared_ptr}
 constructor fails} exception when a resource other than memory could not be obtained.
 
 \pnum
-\remarks When \tcode{T} is an array type,
+\remarks
+When \tcode{T} is an array type,
 this constructor shall not participate in overload resolution unless
 the expression \tcode{delete[] p} is well-formed and either
 \tcode{T} is \tcode{U[N]} and \tcode{Y(*)[N]} is convertible to \tcode{T*}, or
@@ -10045,7 +10263,8 @@ shall have well-defined behavior and shall not throw exceptions.
 (\tref{cpp17.allocator}).
 
 \pnum
-\effects  Constructs a \tcode{shared_ptr} object that owns the
+\effects
+Constructs a \tcode{shared_ptr} object that owns the
 object \tcode{p} and the deleter \tcode{d}.
 When \tcode{T} is not an array type,
 the first and second constructors enable \tcode{shared_from_this} with \tcode{p}.
@@ -10054,10 +10273,12 @@ allocate memory for internal use.
 If an exception is thrown, \tcode{d(p)} is called.
 
 \pnum
-\ensures  \tcode{use_count() == 1 \&\& get() == p}.
+\ensures
+\tcode{use_count() == 1 \&\& get() == p}.
 
 \pnum
-\throws  \tcode{bad_alloc}, or an \impldef{exception type when \tcode{shared_ptr}
+\throws
+\tcode{bad_alloc}, or an \impldef{exception type when \tcode{shared_ptr}
 constructor fails} exception
 when a resource other than memory could not be obtained.
 
@@ -10084,12 +10305,14 @@ template<class Y> shared_ptr(shared_ptr<Y>&& r, element_type* p) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{shared_ptr} instance that
+\effects
+Constructs a \tcode{shared_ptr} instance that
 stores \tcode{p} and shares ownership with
 the initial value of \tcode{r}.
 
 \pnum
-\ensures \tcode{get() == p}.
+\ensures
+\tcode{get() == p}.
 For the second overload,
 \tcode{r} is empty and \tcode{r.get() == nullptr}.
 
@@ -10116,12 +10339,14 @@ The second constructor shall not participate in overload resolution unless
 \tcode{Y*} is compatible with \tcode{T*}.
 
 \pnum
-\effects  If \tcode{r} is empty, constructs
+\effects
+If \tcode{r} is empty, constructs
 an empty \tcode{shared_ptr} object; otherwise, constructs
 a \tcode{shared_ptr} object that shares ownership with \tcode{r}.
 
 \pnum
-\ensures  \tcode{get() == r.get() \&\& use_count() == r.use_count()}.
+\ensures
+\tcode{get() == r.get() \&\& use_count() == r.use_count()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{shared_ptr}!constructor}%
@@ -10132,14 +10357,17 @@ template<class Y> shared_ptr(shared_ptr<Y>&& r) noexcept;
 
 \begin{itemdescr}
 \pnum
-\remarks The second constructor shall not participate in overload resolution unless
+\remarks
+The second constructor shall not participate in overload resolution unless
 \tcode{Y*} is compatible with \tcode{T*}.
 
 \pnum
-\effects Move constructs a \tcode{shared_ptr} instance from \tcode{r}.
+\effects
+Move constructs a \tcode{shared_ptr} instance from \tcode{r}.
 
 \pnum
-\ensures \tcode{*this} shall contain the old value of
+\ensures
+\tcode{*this} shall contain the old value of
 \tcode{r}. \tcode{r} shall be empty. \tcode{r.get() == nullptr}.
 \end{itemdescr}
 
@@ -10151,18 +10379,22 @@ template<class Y> explicit shared_ptr(const weak_ptr<Y>& r);
 
 \begin{itemdescr}
 \pnum
-\effects  Constructs a \tcode{shared_ptr} object that shares ownership with
+\effects
+Constructs a \tcode{shared_ptr} object that shares ownership with
 \tcode{r} and stores a copy of the pointer stored in \tcode{r}.
 If an exception is thrown, the constructor has no effect.
 
 \pnum
-\ensures  \tcode{use_count() == r.use_count()}.
+\ensures
+\tcode{use_count() == r.use_count()}.
 
 \pnum
-\throws  \tcode{bad_weak_ptr} when \tcode{r.expired()}.
+\throws
+\tcode{bad_weak_ptr} when \tcode{r.expired()}.
 
 \pnum
-\remarks This constructor shall not participate in overload resolution unless
+\remarks
+This constructor shall not participate in overload resolution unless
 \tcode{Y*} is compatible with \tcode{T*}.
 \end{itemdescr}
 
@@ -10174,12 +10406,14 @@ template<class Y, class D> shared_ptr(unique_ptr<Y, D>&& r);
 
 \begin{itemdescr}
 \pnum
-\remarks This constructor shall not participate in overload resolution
+\remarks
+This constructor shall not participate in overload resolution
 unless \tcode{Y*} is compatible with \tcode{T*} and
 \tcode{unique_ptr<Y, D>::pointer} is convertible to \tcode{element_type*}.
 
 \pnum
-\effects If \tcode{r.get() == nullptr}, equivalent to \tcode{shared_ptr()}.
+\effects
+If \tcode{r.get() == nullptr}, equivalent to \tcode{shared_ptr()}.
 Otherwise, if \tcode{D} is not a reference type,
 equivalent to \tcode{shared_ptr(r.release(), r.get_deleter())}.
 Otherwise, equivalent to \tcode{shared_ptr(r.release(), ref(r.get_deleter()))}.
@@ -10228,10 +10462,12 @@ template<class Y> shared_ptr& operator=(const shared_ptr<Y>& r) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects  Equivalent to \tcode{shared_ptr(r).swap(*this)}.
+\effects
+Equivalent to \tcode{shared_ptr(r).swap(*this)}.
 
 \pnum
-\returns  \tcode{*this}.
+\returns
+\tcode{*this}.
 
 \pnum
 \begin{note}
@@ -10257,10 +10493,12 @@ template<class Y> shared_ptr& operator=(shared_ptr<Y>&& r) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to \tcode{shared_ptr(std::move(r)).swap(*this)}.
+\effects
+Equivalent to \tcode{shared_ptr(std::move(r)).swap(*this)}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{shared_ptr}%
@@ -10270,10 +10508,12 @@ template<class Y, class D> shared_ptr& operator=(unique_ptr<Y, D>&& r);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to \tcode{shared_ptr(std::move(r)).swap(*this)}.
+\effects
+Equivalent to \tcode{shared_ptr(std::move(r)).swap(*this)}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \rSec3[util.smartptr.shared.mod]{Modifiers}
@@ -10286,7 +10526,8 @@ void swap(shared_ptr& r) noexcept;
 \begin{itemdescr}
 
 \pnum
-\effects  Exchanges the contents of \tcode{*this} and \tcode{r}.
+\effects
+Exchanges the contents of \tcode{*this} and \tcode{r}.
 \end{itemdescr}
 
 \indexlibrarymember{reset}{shared_ptr}%
@@ -10296,7 +10537,8 @@ void reset() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects  Equivalent to \tcode{shared_ptr().swap(*this)}.
+\effects
+Equivalent to \tcode{shared_ptr().swap(*this)}.
 \end{itemdescr}
 
 \indexlibrarymember{reset}{shared_ptr}%
@@ -10306,7 +10548,8 @@ template<class Y> void reset(Y* p);
 
 \begin{itemdescr}
 \pnum
-\effects  Equivalent to \tcode{shared_ptr(p).swap(*this)}.
+\effects
+Equivalent to \tcode{shared_ptr(p).swap(*this)}.
 \end{itemdescr}
 
 \indexlibrarymember{reset}{shared_ptr}%
@@ -10316,7 +10559,8 @@ template<class Y, class D> void reset(Y* p, D d);
 
 \begin{itemdescr}
 \pnum
-\effects  Equivalent to \tcode{shared_ptr(p, d).swap(*this)}.
+\effects
+Equivalent to \tcode{shared_ptr(p, d).swap(*this)}.
 \end{itemdescr}
 
 \indexlibrarymember{reset}{shared_ptr}%
@@ -10326,7 +10570,8 @@ template<class Y, class D, class A> void reset(Y* p, D d, A a);
 
 \begin{itemdescr}
 \pnum
-\effects  Equivalent to \tcode{shared_ptr(p, d, a).swap(*this)}.
+\effects
+Equivalent to \tcode{shared_ptr(p, d, a).swap(*this)}.
 \end{itemdescr}
 
 \rSec3[util.smartptr.shared.obs]{Observers}
@@ -10337,7 +10582,8 @@ element_type* get() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns The stored pointer.
+\returns
+The stored pointer.
 \end{itemdescr}
 
 \indexlibrarymember{operator*}{shared_ptr}%
@@ -10350,10 +10596,12 @@ T& operator*() const noexcept;
 \requires  \tcode{get() != 0}.
 
 \pnum
-\returns  \tcode{*get()}.
+\returns
+\tcode{*get()}.
 
 \pnum
-\remarks When \tcode{T} is an array type or \cv{}~\tcode{void},
+\remarks
+When \tcode{T} is an array type or \cv{}~\tcode{void},
 it is unspecified whether this
 member function is declared. If it is declared, it is unspecified what its
 return type is, except that the declaration (although not necessarily the
@@ -10370,10 +10618,12 @@ T* operator->() const noexcept;
 \requires  \tcode{get() != 0}.
 
 \pnum
-\returns  \tcode{get()}.
+\returns
+\tcode{get()}.
 
 \pnum
-\remarks When \tcode{T} is an array type,
+\remarks
+When \tcode{T} is an array type,
 it is unspecified whether this member function is declared.
 If it is declared, it is unspecified what its return type is,
 except that the declaration (although not necessarily the definition)
@@ -10391,17 +10641,20 @@ element_type& operator[](ptrdiff_t i) const;
 If \tcode{T} is \tcode{U[N]}, \tcode{i < N}.
 
 \pnum
-\returns \tcode{get()[i]}.
+\returns
+\tcode{get()[i]}.
 
 \pnum
-\remarks When \tcode{T} is not an array type,
+\remarks
+When \tcode{T} is not an array type,
 it is unspecified whether this member function is declared.
 If it is declared, it is unspecified what its return type is,
 except that the declaration (although not necessarily the definition)
 of the function shall be well-formed.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \indexlibrarymember{use_count}{shared_ptr}%
@@ -10411,12 +10664,14 @@ long use_count() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns  The number of \tcode{shared_ptr} objects, \tcode{*this} included,
+\returns
+The number of \tcode{shared_ptr} objects, \tcode{*this} included,
 that share ownership with \tcode{*this}, or \tcode{0} when \tcode{*this} is
 empty.
 
 \pnum
-\sync None.
+\sync
+None.
 
 \pnum
 \begin{note} \tcode{get() == nullptr}
@@ -10441,7 +10696,8 @@ explicit operator bool() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{get() != 0}.
+\returns
+\tcode{get() != 0}.
 \end{itemdescr}
 
 \indexlibrarymember{owner_before}{shared_ptr}%
@@ -10452,7 +10708,8 @@ template<class U> bool owner_before(const weak_ptr<U>& b) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns An unspecified value such that
+\returns
+An unspecified value such that
 
 \begin{itemize}
 \item \tcode{x.owner_before(y)} defines a strict weak ordering as defined in~\ref{alg.sorting};
@@ -10494,7 +10751,8 @@ template<class T, class A, ...>
 requirements (\tref{cpp17.allocator}).
 
 \pnum
-\effects Allocates memory for an object of type \tcode{T}
+\effects
+Allocates memory for an object of type \tcode{T}
 (or \tcode{U[N]} when \tcode{T} is \tcode{U[]},
 where \tcode{N} is determined from \placeholder{args} as specified by the concrete overload).
 The object is initialized from \placeholder{args} as specified by the concrete overload.
@@ -10504,15 +10762,18 @@ use a copy of \tcode{a}
 If an exception is thrown, the functions have no effect.
 
 \pnum
-\returns A \tcode{shared_ptr} instance that stores and owns the address of
+\returns
+A \tcode{shared_ptr} instance that stores and owns the address of
 the newly constructed object.
 
 \pnum
-\ensures \tcode{r.get() != 0 \&\& r.use_count() == 1},
+\ensures
+\tcode{r.get() != 0 \&\& r.use_count() == 1},
 where \tcode{r} is the return value.
 
 \pnum
-\throws \tcode{bad_alloc}, or
+\throws
+\tcode{bad_alloc}, or
 an exception thrown from \tcode{allocate} or from the initialization of the object.
 
 \pnum
@@ -10621,11 +10882,13 @@ template<class T, class A, class... Args>
 
 \begin{itemdescr}
 \pnum
-\returns A \tcode{shared_ptr} to an object of type \tcode{T}
+\returns
+A \tcode{shared_ptr} to an object of type \tcode{T}
 with an initial value \tcode{T(forward<Args>(args)...)}.
 
 \pnum
-\remarks These overloads shall only participate in overload resolution
+\remarks
+These overloads shall only participate in overload resolution
 when \tcode{T} is not an array type.
 The \tcode{shared_ptr} constructors called by these functions
 enable \tcode{shared_from_this}
@@ -10652,12 +10915,14 @@ template<class T, class A>
 
 \begin{itemdescr}
 \pnum
-\returns A \tcode{shared_ptr} to an object of type \tcode{U[N]}
+\returns
+A \tcode{shared_ptr} to an object of type \tcode{U[N]}
 with a default initial value,
 where \tcode{U} is \tcode{remove_extent_t<T>}.
 
 \pnum
-\remarks These overloads shall only participate in overload resolution
+\remarks
+These overloads shall only participate in overload resolution
 when \tcode{T} is of the form \tcode{U[]}.
 
 \pnum
@@ -10682,11 +10947,13 @@ template<class T, class A>
 
 \begin{itemdescr}
 \pnum
-\returns A \tcode{shared_ptr} to an object of type \tcode{T}
+\returns
+A \tcode{shared_ptr} to an object of type \tcode{T}
 with a default initial value.
 
 \pnum
-\remarks These overloads shall only participate in overload resolution
+\remarks
+These overloads shall only participate in overload resolution
 when \tcode{T} is of the form \tcode{U[N]}.
 
 \pnum
@@ -10713,12 +10980,14 @@ template<class T, class A>
 
 \begin{itemdescr}
 \pnum
-\returns A \tcode{shared_ptr} to an object of type \tcode{U[N]},
+\returns
+A \tcode{shared_ptr} to an object of type \tcode{U[N]},
 where \tcode{U} is \tcode{remove_extent_t<T>} and
 each array element has an initial value of \tcode{u}.
 
 \pnum
-\remarks These overloads shall only participate in overload resolution
+\remarks
+These overloads shall only participate in overload resolution
 when \tcode{T} is of the form \tcode{U[]}.
 
 \pnum
@@ -10746,12 +11015,14 @@ template<class T, class A>
 
 \begin{itemdescr}
 \pnum
-\returns A \tcode{shared_ptr} to an object of type \tcode{T},
+\returns
+A \tcode{shared_ptr} to an object of type \tcode{T},
 where each array element of type \tcode{remove_extent_t<T>}
 has an initial value of \tcode{u}.
 
 \pnum
-\remarks These overloads shall only participate in overload resolution
+\remarks
+These overloads shall only participate in overload resolution
 when \tcode{T} is of the form \tcode{U[N]}.
 
 \pnum
@@ -10836,7 +11107,8 @@ template<class T, class U>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{a.get() == b.get()}.
+\returns
+\tcode{a.get() == b.get()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator==}{shared_ptr}%
@@ -10847,7 +11119,8 @@ template<class T>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!a}.
+\returns
+\tcode{!a}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{shared_ptr}%
@@ -10890,7 +11163,8 @@ template<class T>
 
 \begin{itemdescr}
 \pnum
-\effects  Equivalent to \tcode{a.swap(b)}.
+\effects
+Equivalent to \tcode{a.swap(b)}.
 \end{itemdescr}
 
 \rSec3[util.smartptr.shared.cast]{Casts}
@@ -11027,7 +11301,8 @@ template<class D, class T>
 
 \begin{itemdescr}
 \pnum
-\returns  If \tcode{p} owns a deleter \tcode{d} of type cv-unqualified
+\returns
+If \tcode{p} owns a deleter \tcode{d} of type cv-unqualified
 \tcode{D}, returns \tcode{addressof(d)}; otherwise returns \tcode{nullptr}.
 The returned
 pointer remains valid as long as there exists a \tcode{shared_ptr} instance
@@ -11047,10 +11322,12 @@ template<class E, class T, class Y>
 
 \begin{itemdescr}
 \pnum
-\effects As if by: \tcode{os <{}< p.get();}
+\effects
+As if by: \tcode{os <{}< p.get();}
 
 \pnum
-\returns  \tcode{os}.
+\returns
+\tcode{os}.
 \end{itemdescr}
 
 \rSec2[util.smartptr.weak]{Class template \tcode{weak_ptr}}
@@ -11130,10 +11407,12 @@ constexpr weak_ptr() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects  Constructs an empty \tcode{weak_ptr} object.
+\effects
+Constructs an empty \tcode{weak_ptr} object.
 
 \pnum
-\ensures  \tcode{use_count() == 0}.
+\ensures
+\tcode{use_count() == 0}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{weak_ptr}!constructor}%
@@ -11145,17 +11424,20 @@ template<class Y> weak_ptr(const shared_ptr<Y>& r) noexcept;
 
 \begin{itemdescr}
 \pnum
-\remarks The second and third constructors shall not participate in
+\remarks
+The second and third constructors shall not participate in
 overload resolution unless \tcode{Y*} is compatible with \tcode{T*}.
 
 \pnum
-\effects  If \tcode{r} is empty, constructs
+\effects
+If \tcode{r} is empty, constructs
 an empty \tcode{weak_ptr} object; otherwise, constructs
 a \tcode{weak_ptr} object that shares ownership
 with \tcode{r} and stores a copy of the pointer stored in \tcode{r}.
 
 \pnum
-\ensures  \tcode{use_count() == r.use_count()}.
+\ensures
+\tcode{use_count() == r.use_count()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{weak_ptr}!constructor}%
@@ -11166,14 +11448,17 @@ template<class Y> weak_ptr(weak_ptr<Y>&& r) noexcept;
 
 \begin{itemdescr}
 \pnum
-\remarks The second constructor shall not participate in overload resolution unless
+\remarks
+The second constructor shall not participate in overload resolution unless
 \tcode{Y*} is compatible with \tcode{T*}.
 
 \pnum
-\effects Move constructs a \tcode{weak_ptr} instance from \tcode{r}.
+\effects
+Move constructs a \tcode{weak_ptr} instance from \tcode{r}.
 
 \pnum
-\ensures \tcode{*this} shall contain the old value of \tcode{r}.
+\ensures
+\tcode{*this} shall contain the old value of \tcode{r}.
 \tcode{r} shall be empty. \tcode{r.use_count() == 0}.
 \end{itemdescr}
 
@@ -11186,7 +11471,8 @@ template<class Y> weak_ptr(weak_ptr<Y>&& r) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects  Destroys this \tcode{weak_ptr} object but has no
+\effects
+Destroys this \tcode{weak_ptr} object but has no
 effect on the object its stored pointer points to.
 \end{itemdescr}
 
@@ -11201,14 +11487,17 @@ template<class Y> weak_ptr& operator=(const shared_ptr<Y>& r) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects  Equivalent to \tcode{weak_ptr(r).swap(*this)}.
+\effects
+Equivalent to \tcode{weak_ptr(r).swap(*this)}.
 
 \pnum
-\remarks  The implementation may meet the effects (and the
+\remarks
+The implementation may meet the effects (and the
 implied guarantees) via different means, without creating a temporary object.
 
 \pnum
-\returns  \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{weak_ptr}%
@@ -11219,10 +11508,12 @@ template<class Y> weak_ptr& operator=(weak_ptr<Y>&& r) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects  Equivalent to \tcode{weak_ptr(std::move(r)).swap(*this)}.
+\effects
+Equivalent to \tcode{weak_ptr(std::move(r)).swap(*this)}.
 
 \pnum
-\returns  \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \rSec3[util.smartptr.weak.mod]{Modifiers}
@@ -11233,7 +11524,8 @@ void swap(weak_ptr& r) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects  Exchanges the contents of \tcode{*this} and \tcode{r}.
+\effects
+Exchanges the contents of \tcode{*this} and \tcode{r}.
 \end{itemdescr}
 
 \indexlibrarymember{reset}{weak_ptr}%
@@ -11243,7 +11535,8 @@ void reset() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects  Equivalent to \tcode{weak_ptr().swap(*this)}.
+\effects
+Equivalent to \tcode{weak_ptr().swap(*this)}.
 \end{itemdescr}
 
 \rSec3[util.smartptr.weak.obs]{Observers}
@@ -11254,7 +11547,8 @@ long use_count() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns  \tcode{0} if \tcode{*this} is empty;
+\returns
+\tcode{0} if \tcode{*this} is empty;
 otherwise, the number of \tcode{shared_ptr} instances
 that share ownership with \tcode{*this}.
 \end{itemdescr}
@@ -11266,7 +11560,8 @@ bool expired() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns  \tcode{use_count() == 0}.
+\returns
+\tcode{use_count() == 0}.
 \end{itemdescr}
 
 \indexlibrarymember{lock}{weak_ptr}%
@@ -11276,7 +11571,8 @@ shared_ptr<T> lock() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{expired() ?\ shared_ptr<T>() :\ shared_ptr<T>(*this)}, executed atomically.
+\returns
+\tcode{expired() ?\ shared_ptr<T>() :\ shared_ptr<T>(*this)}, executed atomically.
 \end{itemdescr}
 
 \indexlibrarymember{owner_before}{weak_ptr}%
@@ -11287,7 +11583,8 @@ template<class U> bool owner_before(const weak_ptr<U>& b) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns An unspecified value such that
+\returns
+An unspecified value such that
 
 \begin{itemize}
 \item \tcode{x.owner_before(y)} defines a strict weak ordering as defined in~\ref{alg.sorting};
@@ -11310,7 +11607,8 @@ template<class T>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to \tcode{a.swap(b)}.
+\effects
+Equivalent to \tcode{a.swap(b)}.
 \end{itemdescr}
 
 \rSec2[util.smartptr.ownerless]{Class template \tcode{owner_less}}
@@ -11420,7 +11718,8 @@ enable_shared_from_this(const enable_shared_from_this<T>&) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects  Value-initializes \tcode{weak_this}.
+\effects
+Value-initializes \tcode{weak_this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{enable_shared_from_this}%
@@ -11430,7 +11729,8 @@ enable_shared_from_this<T>& operator=(const enable_shared_from_this<T>&) noexcep
 
 \begin{itemdescr}
 \pnum
-\returns  \tcode{*this}.
+\returns
+\tcode{*this}.
 
 \pnum
 \begin{note} \tcode{weak_this} is not changed. \end{note}
@@ -11445,7 +11745,8 @@ shared_ptr<T const> shared_from_this() const;
 
 \begin{itemdescr}
 \pnum
-\returns  \tcode{shared_ptr<T>(weak_this)}.
+\returns
+\tcode{shared_ptr<T>(weak_this)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{weak_ptr}}%
@@ -11457,7 +11758,8 @@ weak_ptr<T const> weak_from_this() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns  \tcode{weak_this}.
+\returns
+\tcode{weak_this}.
 \end{itemdescr}
 
 \rSec2[util.smartptr.hash]{Smart pointer hash support}
@@ -13464,7 +13766,8 @@ scoped_allocator_adaptor();
 
 \begin{itemdescr}
 \pnum
-\effects Value-initializes the \tcode{OuterAlloc} base class and the \tcode{inner} allocator
+\effects
+Value-initializes the \tcode{OuterAlloc} base class and the \tcode{inner} allocator
 object.
 \end{itemdescr}
 
@@ -13476,13 +13779,15 @@ template<class OuterA2>
 
 \begin{itemdescr}
 \pnum
-\effects Initializes the \tcode{OuterAlloc} base class with
+\effects
+Initializes the \tcode{OuterAlloc} base class with
 \tcode{std::forward<OuterA2>(outerAlloc)} and \tcode{inner} with \tcode{innerAllocs...}
 (hence recursively initializing each allocator within the adaptor with the corresponding
 allocator from the argument list).
 
 \pnum
-\remarks This constructor shall not participate in overload resolution unless
+\remarks
+This constructor shall not participate in overload resolution unless
 \tcode{is_constructible_v<OuterAlloc, OuterA2>} is \tcode{true}.
 \end{itemdescr}
 
@@ -13493,7 +13798,8 @@ scoped_allocator_adaptor(const scoped_allocator_adaptor& other) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Initializes each allocator within the adaptor with the corresponding allocator
+\effects
+Initializes each allocator within the adaptor with the corresponding allocator
 from \tcode{other}.
 \end{itemdescr}
 
@@ -13504,7 +13810,8 @@ scoped_allocator_adaptor(scoped_allocator_adaptor&& other) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Move constructs each allocator within the adaptor with the corresponding allocator
+\effects
+Move constructs each allocator within the adaptor with the corresponding allocator
 from \tcode{other}.
 \end{itemdescr}
 
@@ -13517,11 +13824,13 @@ template<class OuterA2>
 
 \begin{itemdescr}
 \pnum
-\effects Initializes each allocator within the adaptor with the corresponding allocator
+\effects
+Initializes each allocator within the adaptor with the corresponding allocator
 from \tcode{other}.
 
 \pnum
-\remarks This constructor shall not participate in overload resolution unless
+\remarks
+This constructor shall not participate in overload resolution unless
 \tcode{is_constructible_v<OuterAlloc, const OuterA2\&>} is \tcode{true}.
 \end{itemdescr}
 
@@ -13533,11 +13842,13 @@ template<class OuterA2>
 
 \begin{itemdescr}
 \pnum
-\effects Initializes each allocator within the adaptor with the corresponding allocator rvalue
+\effects
+Initializes each allocator within the adaptor with the corresponding allocator rvalue
 from \tcode{other}.
 
 \pnum
-\remarks This constructor shall not participate in overload resolution unless
+\remarks
+This constructor shall not participate in overload resolution unless
 \tcode{is_constructible_v<OuterAlloc, OuterA2>} is \tcode{true}.
 \end{itemdescr}
 
@@ -13566,7 +13877,8 @@ const inner_allocator_type& inner_allocator() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{*this} if \tcode{sizeof...(InnerAllocs)} is zero; otherwise,
+\returns
+\tcode{*this} if \tcode{sizeof...(InnerAllocs)} is zero; otherwise,
 \tcode{inner}.
 \end{itemdescr}
 
@@ -13577,7 +13889,8 @@ outer_allocator_type& outer_allocator() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{static_cast<OuterAlloc\&>(*this)}.
+\returns
+\tcode{static_cast<OuterAlloc\&>(*this)}.
 \end{itemdescr}
 
 \indexlibrarymember{outer_allocator}{scoped_allocator_adaptor}%
@@ -13587,7 +13900,8 @@ const outer_allocator_type& outer_allocator() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{static_cast<const OuterAlloc\&>(*this)}.
+\returns
+\tcode{static_cast<const OuterAlloc\&>(*this)}.
 \end{itemdescr}
 
 \indexlibrarymember{allocate}{scoped_allocator_adaptor}%
@@ -13597,7 +13911,8 @@ const outer_allocator_type& outer_allocator() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{allocator_traits<OuterAlloc>::allocate(outer_allocator(), n)}.
+\returns
+\tcode{allocator_traits<OuterAlloc>::allocate(outer_allocator(), n)}.
 \end{itemdescr}
 
 \indexlibrarymember{allocate}{scoped_allocator_adaptor}%
@@ -13607,7 +13922,8 @@ const outer_allocator_type& outer_allocator() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{allocator_traits<OuterAlloc>::allocate(outer_allocator(), n, hint)}.
+\returns
+\tcode{allocator_traits<OuterAlloc>::allocate(outer_allocator(), n, hint)}.
 \end{itemdescr}
 
 \indexlibrarymember{deallocate}{scoped_allocator_adaptor}%
@@ -13617,7 +13933,8 @@ void deallocate(pointer p, size_type n) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects As if by:
+\effects
+As if by:
 \tcode{allocator_traits<OuterAlloc>::deallocate(outer_allocator(), p, n);}
 \end{itemdescr}
 
@@ -13628,7 +13945,8 @@ size_type max_size() const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{allocator_traits<OuterAlloc>::max_size(outer_allocator())}.
+\returns
+\tcode{allocator_traits<OuterAlloc>::max_size(outer_allocator())}.
 \end{itemdescr}
 
 \indexlibrarymember{construct}{scoped_allocator_adaptor}%
@@ -13660,7 +13978,8 @@ template<class T>
 
 \begin{itemdescr}
 \pnum
-\effects Calls \tcode{\placeholdernc{OUTERMOST_ALLOC_TRAITS}(*this)::destroy(\placeholdernc{OUTERMOST}(*this), p)}.
+\effects
+Calls \tcode{\placeholdernc{OUTERMOST_ALLOC_TRAITS}(*this)::destroy(\placeholdernc{OUTERMOST}(*this), p)}.
 \end{itemdescr}
 
 \indexlibrarymember{select_on_container_copy_construction}{scoped_allocator_adaptor}%
@@ -13670,7 +13989,8 @@ scoped_allocator_adaptor select_on_container_copy_construction() const;
 
 \begin{itemdescr}
 \pnum
-\returns A new \tcode{scoped_allocator_adaptor} object where each allocator \tcode{A} in the
+\returns
+A new \tcode{scoped_allocator_adaptor} object where each allocator \tcode{A} in the
 adaptor is initialized from the result of calling
 \tcode{allocator_traits<A>::select_on_container_copy_construction()} on the
 corresponding allocator in \tcode{*this}.
@@ -13687,7 +14007,8 @@ template<class OuterA1, class OuterA2, class... InnerAllocs>
 
 \begin{itemdescr}
 \pnum
-\returns If \tcode{sizeof...(InnerAllocs)} is zero,
+\returns
+If \tcode{sizeof...(InnerAllocs)} is zero,
 \begin{codeblock}
 a.outer_allocator() == b.outer_allocator()
 \end{codeblock}
@@ -14098,7 +14419,8 @@ template<class U>
 
 \begin{itemdescr}
 \pnum
-\remarks Let \tcode{\placeholdernc{FUN}} denote the exposition-only functions
+\remarks
+Let \tcode{\placeholdernc{FUN}} denote the exposition-only functions
 \begin{codeblock}
 void @\placeholdernc{FUN}@(T&) noexcept;
 void @\placeholdernc{FUN}@(T&&) = delete;
@@ -14110,7 +14432,8 @@ The expression inside \tcode{noexcept}
 is equivalent to \tcode{noexcept(\placeholdernc{FUN}(declval<U>()))}.
 
 \pnum
-\effects Creates a variable \tcode{r}
+\effects
+Creates a variable \tcode{r}
 as if by \tcode{T\& r = std::forward<U>(u)},
 then constructs a \tcode{reference_wrapper} object
 that stores a reference to \tcode{r}.
@@ -14123,7 +14446,8 @@ constexpr reference_wrapper(const reference_wrapper& x) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{reference_wrapper} object that
+\effects
+Constructs a \tcode{reference_wrapper} object that
 stores a reference to \tcode{x.get()}.
 \end{itemdescr}
 
@@ -14136,7 +14460,8 @@ constexpr reference_wrapper& operator=(const reference_wrapper& x) noexcept;
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{*this} stores a reference to  \tcode{x.get()}.
+\ensures
+\tcode{*this} stores a reference to  \tcode{x.get()}.
 \end{itemdescr}
 
 \rSec3[refwrap.access]{Access}
@@ -14148,7 +14473,8 @@ constexpr operator T& () const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns The stored reference.
+\returns
+The stored reference.
 \end{itemdescr}
 
 \indexlibrarymember{get}{reference_wrapper}%
@@ -14158,7 +14484,8 @@ constexpr T& get() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns The stored reference.
+\returns
+The stored reference.
 \end{itemdescr}
 
 \rSec3[refwrap.invoke]{Invocation}
@@ -14176,7 +14503,8 @@ template<class... ArgTypes>
 \tcode{T} is a complete type.
 
 \pnum
-\returns \tcode{\placeholdernc{INVOKE}(get(), std::forward<ArgTypes>(args)...)}.\iref{func.require}
+\returns
+\tcode{\placeholdernc{INVOKE}(get(), std::forward<ArgTypes>(args)...)}.\iref{func.require}
 \end{itemdescr}
 
 
@@ -14194,7 +14522,8 @@ template<class T> constexpr reference_wrapper<T> ref(T& t) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{reference_wrapper<T>(t)}.
+\returns
+\tcode{reference_wrapper<T>(t)}.
 \end{itemdescr}
 
 \indexlibrarymember{ref}{reference_wrapper}%
@@ -14204,7 +14533,8 @@ template<class T> constexpr reference_wrapper<T> ref(reference_wrapper<T> t) noe
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{ref(t.get())}.
+\returns
+\tcode{ref(t.get())}.
 \end{itemdescr}
 
 \indexlibrarymember{cref}{reference_wrapper}%
@@ -14214,7 +14544,8 @@ template<class T> constexpr reference_wrapper<const T> cref(const T& t) noexcept
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{reference_wrapper <const T>(t)}.
+\returns
+\tcode{reference_wrapper <const T>(t)}.
 \end{itemdescr}
 
 \indexlibrarymember{cref}{reference_wrapper}%
@@ -14224,7 +14555,8 @@ template<class T> constexpr reference_wrapper<const T> cref(reference_wrapper<T>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{cref(t.get())}.
+\returns
+\tcode{cref(t.get())}.
 \end{itemdescr}
 
 \rSec3[refwrap.unwrapref]{Transformation type trait \tcode{unwrap_reference}}
@@ -14277,7 +14609,8 @@ constexpr T operator()(const T& x, const T& y) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x + y}.
+\returns
+\tcode{x + y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{plus<>}}%
@@ -14298,7 +14631,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{std::forward<T>(t) + std::forward<U>(u)}.
+\returns
+\tcode{std::forward<T>(t) + std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[arithmetic.operations.minus]{Class template \tcode{minus}}
@@ -14317,7 +14651,8 @@ constexpr T operator()(const T& x, const T& y) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x - y}.
+\returns
+\tcode{x - y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{minus<>}}%
@@ -14338,7 +14673,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{std::forward<T>(t) - std::forward<U>(u)}.
+\returns
+\tcode{std::forward<T>(t) - std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[arithmetic.operations.multiplies]{Class template \tcode{multiplies}}
@@ -14357,7 +14693,8 @@ constexpr T operator()(const T& x, const T& y) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x * y}.
+\returns
+\tcode{x * y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{multiplies<>}}%
@@ -14378,7 +14715,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{std::forward<T>(t) * std::forward<U>(u)}.
+\returns
+\tcode{std::forward<T>(t) * std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[arithmetic.operations.divides]{Class template \tcode{divides}}
@@ -14397,7 +14735,8 @@ constexpr T operator()(const T& x, const T& y) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x / y}.
+\returns
+\tcode{x / y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{divides<>}}%
@@ -14418,7 +14757,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{std::forward<T>(t) / std::forward<U>(u)}.
+\returns
+\tcode{std::forward<T>(t) / std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[arithmetic.operations.modulus]{Class template \tcode{modulus}}
@@ -14437,7 +14777,8 @@ constexpr T operator()(const T& x, const T& y) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x \% y}.
+\returns
+\tcode{x \% y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{modulus<>}}%
@@ -14458,7 +14799,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{std::forward<T>(t) \% std::forward<U>(u)}.
+\returns
+\tcode{std::forward<T>(t) \% std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[arithmetic.operations.negate]{Class template \tcode{negate}}
@@ -14477,7 +14819,8 @@ constexpr T operator()(const T& x) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{-x}.
+\returns
+\tcode{-x}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{negate<>}}%
@@ -14498,7 +14841,8 @@ template<class T> constexpr auto operator()(T&& t) const
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{-std::forward<T>(t)}.
+\returns
+\tcode{-std::forward<T>(t)}.
 \end{itemdescr}
 
 
@@ -14541,7 +14885,8 @@ constexpr bool operator()(const T& x, const T& y) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x == y}.
+\returns
+\tcode{x == y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{equal_to<>}}%
@@ -14562,7 +14907,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{std::forward<T>(t) == std::forward<U>(u)}.
+\returns
+\tcode{std::forward<T>(t) == std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[comparisons.not.equal.to]{Class template \tcode{not_equal_to}}
@@ -14581,7 +14927,8 @@ constexpr bool operator()(const T& x, const T& y) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x != y}.
+\returns
+\tcode{x != y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{not_equal_to<>}}%
@@ -14602,7 +14949,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{std::forward<T>(t) != std::forward<U>(u)}.
+\returns
+\tcode{std::forward<T>(t) != std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[comparisons.greater]{Class template \tcode{greater}}
@@ -14621,7 +14969,8 @@ constexpr bool operator()(const T& x, const T& y) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x > y}.
+\returns
+\tcode{x > y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{greater<>}}%
@@ -14642,7 +14991,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{std::forward<T>(t) > std::forward<U>(u)}.
+\returns
+\tcode{std::forward<T>(t) > std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[comparisons.less]{Class template \tcode{less}}
@@ -14661,7 +15011,8 @@ constexpr bool operator()(const T& x, const T& y) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x < y}.
+\returns
+\tcode{x < y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{less<>}}%
@@ -14682,7 +15033,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{std::forward<T>(t) < std::forward<U>(u)}.
+\returns
+\tcode{std::forward<T>(t) < std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[comparisons.greater.equal]{Class template \tcode{greater_equal}}
@@ -14701,7 +15053,8 @@ constexpr bool operator()(const T& x, const T& y) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x >= y}.
+\returns
+\tcode{x >= y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{greater_equal<>}}%
@@ -14722,7 +15075,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{std::forward<T>(t) >= std::forward<U>(u)}.
+\returns
+\tcode{std::forward<T>(t) >= std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[comparisons.less.equal]{Class template \tcode{less_equal}}
@@ -14741,7 +15095,8 @@ constexpr bool operator()(const T& x, const T& y) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x <= y}.
+\returns
+\tcode{x <= y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{less_equal<>}}%
@@ -14762,7 +15117,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{std::forward<T>(t) <= std::forward<U>(u)}.
+\returns
+\tcode{std::forward<T>(t) <= std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec2[range.cmp]{Concept-constrained comparisons}
@@ -14955,7 +15311,8 @@ constexpr bool operator()(const T& x, const T& y) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x \&\& y}.
+\returns
+\tcode{x \&\& y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{logical_and<>}}%
@@ -14976,7 +15333,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{std::forward<T>(t) \&\& std::forward<U>(u)}.
+\returns
+\tcode{std::forward<T>(t) \&\& std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[logical.operations.or]{Class template \tcode{logical_or}}
@@ -14995,7 +15353,8 @@ constexpr bool operator()(const T& x, const T& y) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x || y}.
+\returns
+\tcode{x || y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{logical_or<>}}%
@@ -15016,7 +15375,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{std::forward<T>(t) || std::forward<U>(u)}.
+\returns
+\tcode{std::forward<T>(t) || std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[logical.operations.not]{Class template \tcode{logical_not}}
@@ -15035,7 +15395,8 @@ constexpr bool operator()(const T& x) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!x}.
+\returns
+\tcode{!x}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{logical_not<>}}%
@@ -15056,7 +15417,8 @@ template<class T> constexpr auto operator()(T&& t) const
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!std::forward<T>(t)}.
+\returns
+\tcode{!std::forward<T>(t)}.
 \end{itemdescr}
 
 
@@ -15083,7 +15445,8 @@ constexpr T operator()(const T& x, const T& y) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x \& y}.
+\returns
+\tcode{x \& y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bit_and<>}}%
@@ -15104,7 +15467,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{std::forward<T>(t) \& std::forward<U>(u)}.
+\returns
+\tcode{std::forward<T>(t) \& std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[bitwise.operations.or]{Class template \tcode{bit_or}}
@@ -15123,7 +15487,8 @@ constexpr T operator()(const T& x, const T& y) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x | y}.
+\returns
+\tcode{x | y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bit_or<>}}%
@@ -15144,7 +15509,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{std::forward<T>(t) | std::forward<U>(u)}.
+\returns
+\tcode{std::forward<T>(t) | std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[bitwise.operations.xor]{Class template \tcode{bit_xor}}
@@ -15163,7 +15529,8 @@ constexpr T operator()(const T& x, const T& y) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{x \caret{} y}.
+\returns
+\tcode{x \caret{} y}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bit_xor<>}}%
@@ -15184,7 +15551,8 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{std::forward<T>(t) \caret{} std::forward<U>(u)}.
+\returns
+\tcode{std::forward<T>(t) \caret{} std::forward<U>(u)}.
 \end{itemdescr}
 
 \rSec3[bitwise.operations.not]{Class template \tcode{bit_not}}
@@ -15202,7 +15570,8 @@ constexpr T operator()(const T& x) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{\~{}x}.
+\returns
+\tcode{\~{}x}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{bit_not<>}}%
@@ -15223,7 +15592,8 @@ template<class T> constexpr auto operator()(T&&) const
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{\~{}std::forward<T>(t)}.
+\returns
+\tcode{\~{}std::forward<T>(t)}.
 \end{itemdescr}
 
 
@@ -15471,7 +15841,8 @@ of the bound arguments
 $\tcode{v}_1$, $\tcode{v}_2$, $\dotsc$, $\tcode{v}_N$ are determined as specified below.
 
 \pnum
-\throws Any exception thrown by the initialization of
+\throws
+Any exception thrown by the initialization of
 the state entities of \tcode{g}.
 
 \pnum
@@ -15564,7 +15935,8 @@ template<class R, class T> constexpr @\unspec@ mem_fn(R T::* pm) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns A simple call wrapper\iref{func.def} \tcode{fn}
+\returns
+A simple call wrapper\iref{func.def} \tcode{fn}
 with call pattern \tcode{invoke(pmd, call_args...)}, where
 \tcode{pmd} is the target object of \tcode{fn} of type \tcode{R T::*}
 direct-non-list-initialized with \tcode{pm}, and
@@ -15601,7 +15973,8 @@ namespace std {
 \indexlibrarymember{what}{bad_function_call}%
 \begin{itemdescr}
 \pnum
-\returns An
+\returns
+An
 \impldef{return value of \tcode{bad_function_call::what}} \ntbs{}.
 \end{itemdescr}
 
@@ -15700,7 +16073,8 @@ function() noexcept;
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{!*this}.
+\ensures
+\tcode{!*this}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{function}!constructor}%
@@ -15710,7 +16084,8 @@ function(nullptr_t) noexcept;
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{!*this}.
+\ensures
+\tcode{!*this}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{function}!constructor}%
@@ -15720,11 +16095,13 @@ function(const function& f);
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{!*this} if \tcode{!f}; otherwise,
+\ensures
+\tcode{!*this} if \tcode{!f}; otherwise,
 \tcode{*this} targets a copy of \tcode{f.target()}.
 
 \pnum
-\throws Shall not throw exceptions if \tcode{f}'s target is
+\throws
+Shall not throw exceptions if \tcode{f}'s target is
 a specialization of \tcode{reference_wrapper} or
 a function pointer. Otherwise, may throw \tcode{bad_alloc}
 or any exception thrown by the copy constructor of the stored callable object.
@@ -15741,7 +16118,8 @@ function(function&& f) noexcept;
 
 \begin{itemdescr}
 \pnum
-\ensures If \tcode{!f}, \tcode{*this} has no target;
+\ensures
+If \tcode{!f}, \tcode{*this} has no target;
 otherwise, the target of \tcode{*this} is equivalent to
 the target of \tcode{f} before the construction, and
 \tcode{f} is in a valid state with an unspecified value.
@@ -15763,12 +16141,14 @@ template<class F> function(F f);
 \requires \tcode{F} shall be \oldconcept{CopyConstructible}.
 
 \pnum
-\remarks This constructor template shall not participate in overload resolution unless
+\remarks
+This constructor template shall not participate in overload resolution unless
 \tcode{F} is Lvalue-Callable\iref{func.wrap.func} for argument types
 \tcode{ArgTypes...} and return type \tcode{R}.
 
 \pnum
-\ensures \tcode{!*this} if any of the following hold:
+\ensures
+\tcode{!*this} if any of the following hold:
 \begin{itemize}
 \item \tcode{f} is a null function pointer value.
 \item \tcode{f} is a null member pointer value.
@@ -15785,7 +16165,8 @@ where \tcode{f} is an object holding only a pointer or
 reference to an object and a member function pointer. \end{note}
 
 \pnum
-\throws Shall not throw exceptions when \tcode{f} is a function pointer
+\throws
+Shall not throw exceptions when \tcode{f} is a function pointer
 or a \tcode{reference_wrapper<T>} for some \tcode{T}. Otherwise,
 may throw \tcode{bad_alloc} or any exception thrown by \tcode{F}'s copy
 or move constructor.
@@ -15798,7 +16179,8 @@ template<class F> function(F) -> function<@\seebelow@>;
 
 \begin{itemdescr}
 \pnum
-\remarks This deduction guide participates in overload resolution only if
+\remarks
+This deduction guide participates in overload resolution only if
 \tcode{\&F::operator()} is well-formed when treated as an unevaluated operand.
 In that case, if \tcode{decltype(\&F::operator())} is of the form
 \tcode{R(G::*)(A...)}~\cv{}~\tcode{\opt{\&}~\opt{noexcept}}
@@ -15822,10 +16204,12 @@ function& operator=(const function& f);
 
 \begin{itemdescr}
 \pnum
-\effects As if by \tcode{function(f).swap(*this);}
+\effects
+As if by \tcode{function(f).swap(*this);}
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{function}%
@@ -15835,11 +16219,13 @@ function& operator=(function&& f);
 
 \begin{itemdescr}
 \pnum
-\effects Replaces the target of \tcode{*this}
+\effects
+Replaces the target of \tcode{*this}
 with the target of \tcode{f}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{function}%
@@ -15849,13 +16235,16 @@ function& operator=(nullptr_t) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects If \tcode{*this != nullptr}, destroys the target of \tcode{this}.
+\effects
+If \tcode{*this != nullptr}, destroys the target of \tcode{this}.
 
 \pnum
-\ensures \tcode{!(*this)}.
+\ensures
+\tcode{!(*this)}.
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{function}%
@@ -15865,13 +16254,16 @@ template<class F> function& operator=(F&& f);
 
 \begin{itemdescr}
 \pnum
-\effects As if by: \tcode{function(std::forward<F>(f)).swap(*this);}
+\effects
+As if by: \tcode{function(std::forward<F>(f)).swap(*this);}
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 
 \pnum
-\remarks This assignment operator shall not participate in overload
+\remarks
+This assignment operator shall not participate in overload
 resolution unless \tcode{decay_t<F>} is
 Lvalue-Callable\iref{func.wrap.func} for argument types \tcode{ArgTypes...} and
 return type \tcode{R}.
@@ -15884,10 +16276,12 @@ template<class F> function& operator=(reference_wrapper<F> f) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects As if by: \tcode{function(f).swap(*this);}
+\effects
+As if by: \tcode{function(f).swap(*this);}
 
 \pnum
-\returns \tcode{*this}.
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{function}!destructor}%
@@ -15897,7 +16291,8 @@ template<class F> function& operator=(reference_wrapper<F> f) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects If \tcode{*this != nullptr}, destroys the target of \tcode{this}.
+\effects
+If \tcode{*this != nullptr}, destroys the target of \tcode{this}.
 \end{itemdescr}
 
 \rSec4[func.wrap.func.mod]{Modifiers}
@@ -15909,7 +16304,8 @@ void swap(function& other) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Interchanges the targets of \tcode{*this} and \tcode{other}.
+\effects
+Interchanges the targets of \tcode{*this} and \tcode{other}.
 \end{itemdescr}
 
 \rSec4[func.wrap.func.cap]{Capacity}
@@ -15921,7 +16317,8 @@ explicit operator bool() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{true} if \tcode{*this} has a target, otherwise \tcode{false}.
+\returns
+\tcode{true} if \tcode{*this} has a target, otherwise \tcode{false}.
 \end{itemdescr}
 
 \rSec4[func.wrap.func.inv]{Invocation}
@@ -15934,7 +16331,8 @@ R operator()(ArgTypes... args) const;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{\placeholdernc{INVOKE}<R>(f, std::forward<ArgTypes>(args)...)}\iref{func.require},
+\returns
+\tcode{\placeholdernc{INVOKE}<R>(f, std::forward<ArgTypes>(args)...)}\iref{func.require},
 where \tcode{f} is the target object\iref{func.def} of \tcode{*this}.
 
 \pnum
@@ -15952,7 +16350,8 @@ const type_info& target_type() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns If \tcode{*this} has a target of type \tcode{T},
+\returns
+If \tcode{*this} has a target of type \tcode{T},
   \tcode{typeid(T)}; otherwise, \tcode{typeid(void)}.
 \end{itemdescr}
 
@@ -15964,7 +16363,8 @@ template<class T> const T* target() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns If \tcode{target_type() == typeid(T)}
+\returns
+If \tcode{target_type() == typeid(T)}
 a pointer to the stored function target; otherwise a null pointer.
 \end{itemdescr}
 
@@ -15978,7 +16378,8 @@ template<class R, class... ArgTypes>
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!f}.
+\returns
+\tcode{!f}.
 \end{itemdescr}
 
 \rSec4[func.wrap.func.alg]{Specialized algorithms}
@@ -15991,7 +16392,8 @@ template<class R, class... ArgTypes>
 
 \begin{itemdescr}
 \pnum
-\effects As if by: \tcode{f1.swap(f2);}
+\effects
+As if by: \tcode{f1.swap(f2);}
 \end{itemdescr}%
 \indextext{function object!wrapper|)}
 
@@ -18504,10 +18906,12 @@ template<class S, class M>
 
 \begin{itemdescr}
 \pnum
-\mandates \tcode{S} is a complete type.
+\mandates
+\tcode{S} is a complete type.
 
 \pnum
-\returns \tcode{true} if and only if
+\returns
+\tcode{true} if and only if
  \tcode{S} is a standard-layout type,
  \tcode{M} is an object type,
  \tcode{m} is not null,
@@ -18524,10 +18928,12 @@ template<class S1, class S2, class M1, class M2>
 
 \begin{itemdescr}
 \pnum
-\mandates \tcode{S1} and \tcode{S2} are complete types.
+\mandates
+\tcode{S1} and \tcode{S2} are complete types.
 
 \pnum
-\returns \tcode{true} if and only if
+\returns
+\tcode{true} if and only if
  \tcode{S1} and \tcode{S2} are standard-layout types,
  \tcode{M1} and \tcode{M2} are object types,
  \tcode{m1} and \tcode{m2} are not null,
@@ -18570,7 +18976,8 @@ constexpr bool is_constant_evaluated() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{true} if and only if evaluation of the call occurs
+\returns
+\tcode{true} if and only if evaluation of the call occurs
 within the evaluation of an expression or conversion
 that is manifestly constant-evaluated\iref{expr.const}.
 
@@ -18876,7 +19283,8 @@ type_index(const type_info& rhs) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Constructs a \tcode{type_index} object, the equivalent of \tcode{target = \&rhs}.
+\effects
+Constructs a \tcode{type_index} object, the equivalent of \tcode{target = \&rhs}.
 \end{itemdescr}
 
 \indexlibrarymember{operator==}{type_index}%
@@ -18886,7 +19294,8 @@ bool operator==(const type_index& rhs) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{*target == *rhs.target}.
+\returns
+\tcode{*target == *rhs.target}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<}{type_index}%
@@ -18896,7 +19305,8 @@ bool operator<(const type_index& rhs) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{target->before(*rhs.target)}.
+\returns
+\tcode{target->before(*rhs.target)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>}{type_index}%
@@ -18906,7 +19316,8 @@ bool operator>(const type_index& rhs) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{rhs.target->before(*target)}.
+\returns
+\tcode{rhs.target->before(*target)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=}{type_index}%
@@ -18916,7 +19327,8 @@ bool operator<=(const type_index& rhs) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!rhs.target->before(*target)}.
+\returns
+\tcode{!rhs.target->before(*target)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>=}{type_index}%
@@ -18926,7 +19338,8 @@ bool operator>=(const type_index& rhs) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{!target->before(*rhs.target)}.
+\returns
+\tcode{!target->before(*rhs.target)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{type_index}%
@@ -18952,7 +19365,8 @@ size_t hash_code() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{target->hash_code()}.
+\returns
+\tcode{target->hash_code()}.
 \end{itemdescr}
 
 \indexlibrarymember{name}{type_index}%
@@ -18962,7 +19376,8 @@ const char* name() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns \tcode{target->name()}.
+\returns
+\tcode{target->name()}.
 \end{itemdescr}
 
 \rSec2[type.index.hash]{Hash support}
@@ -19309,7 +19724,8 @@ to_chars_result to_chars(char* first, char* last, @\seebelow@ value, int base = 
 \requires \tcode{base} has a value between 2 and 36 (inclusive).
 
 \pnum
-\effects The value of \tcode{value} is converted
+\effects
+The value of \tcode{value} is converted
 to a string of digits in the given base
 (with no redundant leading zeroes).
 Digits in the range 10..35 (inclusive)
@@ -19318,7 +19734,8 @@ If \tcode{value} is less than zero,
 the representation starts with \tcode{'-'}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 
 \pnum
 \remarks
@@ -19337,7 +19754,8 @@ to_chars_result to_chars(char* first, char* last, long double value);
 
 \begin{itemdescr}
 \pnum
-\effects \tcode{value} is converted to a string
+\effects
+\tcode{value} is converted to a string
 in the style of \tcode{printf}
 in the \tcode{"C"} locale.
 The conversion specifier is \tcode{f} or \tcode{e},
@@ -19346,7 +19764,8 @@ chosen according to the requirement for a shortest representation
 a tie is resolved in favor of \tcode{f}.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{to_chars}}%
@@ -19362,12 +19781,14 @@ to_chars_result to_chars(char* first, char* last, long double value, chars_forma
 one of the enumerators of \tcode{chars_format}.
 
 \pnum
-\effects \tcode{value} is converted to a string
+\effects
+\tcode{value} is converted to a string
 in the style of \tcode{printf}
 in the \tcode{"C"} locale.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{to_chars}}%
@@ -19386,13 +19807,15 @@ to_chars_result to_chars(char* first, char* last, long double value,
 one of the enumerators of \tcode{chars_format}.
 
 \pnum
-\effects \tcode{value} is converted to a string
+\effects
+\tcode{value} is converted to a string
 in the style of \tcode{printf}
 in the \tcode{"C"} locale
 with the given precision.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \xrefc{7.21.6.1}
@@ -19443,7 +19866,8 @@ from_chars_result from_chars(const char* first, const char* last,
 \requires \tcode{base} has a value between 2 and 36 (inclusive).
 
 \pnum
-\effects The pattern is the expected form of the subject sequence
+\effects
+The pattern is the expected form of the subject sequence
 in the \tcode{"C"} locale
 for the given nonzero base,
 as described for \tcode{strtol},
@@ -19454,7 +19878,8 @@ is the only sign that may appear,
 and only if \tcode{value} has a signed type.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 
 \pnum
 \remarks
@@ -19480,7 +19905,8 @@ from_chars_result from_chars(const char* first, const char* last, long double& v
 one of the enumerators of \tcode{chars_format}.
 
 \pnum
-\effects The pattern is the expected form of the subject sequence
+\effects
+The pattern is the expected form of the subject sequence
 in the \tcode{"C"} locale,
 as described for \tcode{strtod},
 except that
@@ -19510,7 +19936,8 @@ at most two floating-point values
 closest to the value of the string matching the pattern.
 
 \pnum
-\throws Nothing.
+\throws
+Nothing.
 \end{itemdescr}
 
 \xrefc{7.22.1.3, 7.22.1.4}
@@ -20246,7 +20673,8 @@ template<class... Args>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return vformat(fmt, make_format_args(args...));
 \end{codeblock}
@@ -20260,7 +20688,8 @@ template<class... Args>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return vformat(fmt, make_wformat_args(args...));
 \end{codeblock}
@@ -20274,7 +20703,8 @@ template<class... Args>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return vformat(loc, fmt, make_format_args(args...));
 \end{codeblock}
@@ -20288,7 +20718,8 @@ template<class... Args>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 return vformat(loc, fmt, make_wformat_args(args...));
 \end{codeblock}
@@ -20325,7 +20756,8 @@ template<class Out, class... Args>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 using context = basic_format_context<Out, decltype(fmt)::value_type>;
 return vformat_to(out, fmt, {make_format_args<context>(args...)});
@@ -20342,7 +20774,8 @@ template<class Out, class... Args>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \begin{codeblock}
 using context = basic_format_context<Out, decltype(fmt)::value_type>;
 return vformat_to(out, loc, fmt, {make_format_args<context>(args...)});
@@ -20792,7 +21225,8 @@ constexpr void advance_to(const_iterator it);
 \tcode{end()} is reachable from \tcode{it}.
 
 \pnum
-\effects Equivalent to: \tcode{begin_ = it;}
+\effects
+Equivalent to: \tcode{begin_ = it;}
 \end{itemdescr}
 
 \indexlibrarymember{next_arg_id}{basic_format_parse_context}%
@@ -20944,7 +21378,8 @@ void advance_to(iterator it);
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{out_ = it;}
+\effects
+Equivalent to: \tcode{out_ = it;}
 \end{itemdescr}
 
 \indextext{left-pad}%
@@ -21059,7 +21494,8 @@ basic_format_arg() noexcept;
 
 \begin{itemdescr}
 \pnum
-\ensures \tcode{!(*this)}.
+\ensures
+\tcode{!(*this)}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -21126,7 +21562,8 @@ explicit basic_format_arg(long double n) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{value} with \tcode{n}.
+\effects
+Initializes \tcode{value} with \tcode{n}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -21139,7 +21576,8 @@ explicit basic_format_arg(const char_type* s);
 \tcode{s} points to a NTCTS\iref{defns.ntcts}.
 
 \pnum
-\effects Initializes \tcode{value} with \tcode{s}.
+\effects
+Initializes \tcode{value} with \tcode{s}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -21149,7 +21587,8 @@ template<class traits>
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{value} with \tcode{s}.
+\effects
+Initializes \tcode{value} with \tcode{s}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -21160,7 +21599,8 @@ template<class traits, class Allocator>
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{value} with
+\effects
+Initializes \tcode{value} with
 \tcode{basic_string_view<char_type>(s.data(), s.size())}.
 \end{itemdescr}
 
@@ -21170,7 +21610,8 @@ explicit basic_format_arg(nullptr_t) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{value} with
+\effects
+Initializes \tcode{value} with
   \tcode{static_cast<const void*>(nullptr)}.
 \end{itemdescr}
 
@@ -21184,7 +21625,8 @@ template<class T> explicit basic_format_arg(T* p) noexcept;
 \tcode{is_void_v<T>} is \tcode{true}.
 
 \pnum
-\effects Initializes \tcode{value} with \tcode{p}.
+\effects
+Initializes \tcode{value} with \tcode{p}.
 
 \pnum
 \begin{note}
@@ -21258,7 +21700,8 @@ void format(basic_format_parse_context<char_type>& parse_ctx, Context& format_ct
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{format_(parse_ctx, format_ctx, ptr_);}
+\effects
+Equivalent to: \tcode{format_(parse_ctx, format_ctx, ptr_);}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{visit_format_arg}}%
@@ -21269,7 +21712,8 @@ template<class Visitor, class Context>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: \tcode{return visit(forward<Visitor>(vis), arg.value);}
+\effects
+Equivalent to: \tcode{return visit(forward<Visitor>(vis), arg.value);}
 \end{itemdescr}
 
 \rSec3[format.arg.store]{Class template \exposid{format-arg-store}}
@@ -21313,7 +21757,8 @@ template<class... Args>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to:
+\effects
+Equivalent to:
 \tcode{return make_format_args<wformat_context>(args...);}
 \end{itemdescr}
 
@@ -21348,7 +21793,8 @@ basic_format_args() noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{size_} with \tcode{0}.
+\effects
+Initializes \tcode{size_} with \tcode{0}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{basic_format_args}!constructor}%
@@ -21359,7 +21805,8 @@ template<class... Args>
 
 \begin{itemdescr}
 \pnum
-\effects Initializes
+\effects
+Initializes
 \tcode{size_} with \tcode{sizeof...(Args)} and
 \tcode{data_} with \tcode{store.args.data()}.
 \end{itemdescr}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -20602,7 +20602,7 @@ string s3 = format("{:n}", 1234);                       // value of \tcode{s3} m
                                                         // (depending on the locale)
 \end{codeblock}
 \end{example}
-%
+
 \begin{floattable}{Meaning of \fmtgrammarterm{type} options for integer types}{format.type.int}{lp{.8\hsize}}
 \topline
 \lhdr{Type} & \rhdr{Meaning} \\ \rowsep
@@ -20707,7 +20707,7 @@ For upper-case presentation types, infinity and NaN are formatted as
 In either case, a sign is included
 if indicated by the \fmtgrammarterm{sign} option.
 \end{note}
-%
+
 \begin{floattable}{Meaning of \fmtgrammarterm{type} options for floating-point types}{format.type.float}{lp{.8\hsize}}
 \topline
 \lhdr{Type} & \rhdr{Meaning} \\ \rowsep
@@ -20791,7 +20791,7 @@ The available pointer presentation types and their mapping to
 \begin{note}
 Pointer presentation types also apply to \tcode{nullptr_t}.
 \end{note}
-%
+
 \begin{floattable}{Meaning of \fmtgrammarterm{type} options for pointer types}{format.type.ptr}{lp{.8\hsize}}
 \topline
 \lhdr{Type} & \rhdr{Meaning} \\ \rowsep

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -9033,7 +9033,8 @@ D>::pointer} shall
 meet the \oldconcept{NullablePointer} requirements (\tref{cpp17.nullablepointer}).
 
 \pnum
-\begin{example} Given an allocator type \tcode{X} (\tref{cpp17.allocator}) and
+\begin{example}
+Given an allocator type \tcode{X} (\tref{cpp17.allocator}) and
 letting \tcode{A} be a synonym for \tcode{allocator_traits<X>}, the types \tcode{A::pointer},
 \tcode{A::const_pointer}, \tcode{A::void_pointer}, and \tcode{A::const_void_pointer}
 may be used as \tcode{unique_ptr<T, D>::pointer}. \end{example}
@@ -18194,7 +18195,8 @@ Each of the templates in this subclause shall be a
  The member typedef \tcode{type} names
  the same type as \tcode{T}
  except that any top-level const-qualifier has been removed.
- \begin{example} \tcode{remove_const_t<const volatile int>} evaluates
+ \begin{example}
+\tcode{remove_const_t<const volatile int>} evaluates
  to \tcode{volatile int}, whereas \tcode{remove_const_t<const int*>} evaluates to
  \tcode{const int*}. \end{example}                          \\  \rowsep
 
@@ -18204,7 +18206,8 @@ Each of the templates in this subclause shall be a
  The member typedef \tcode{type} names
  the same type as \tcode{T}
  except that any top-level volatile-qualifier has been removed.
- \begin{example} \tcode{remove_volatile_t<const volatile int>}
+ \begin{example}
+\tcode{remove_volatile_t<const volatile int>}
  evaluates to \tcode{const int},
  whereas \tcode{remove_volatile_t<volatile int*>} evaluates to \tcode{volatile int*}.
  \end{example}                                              \\  \rowsep
@@ -18214,7 +18217,8 @@ Each of the templates in this subclause shall be a
  struct remove_cv;}                 &
  The member typedef \tcode{type} shall be the same as \tcode{T}
  except that any top-level cv-qualifier has been removed.
- \begin{example} \tcode{remove_cv_t<const volatile int>}
+ \begin{example}
+\tcode{remove_cv_t<const volatile int>}
  evaluates to \tcode{int}, whereas \tcode{remove_cv_t<const volatile int*>}
  evaluates to \tcode{const volatile int*}. \end{example}  \\  \rowsep
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -442,8 +442,10 @@ If \tcode{N} is negative the program is ill-formed. The alias template
 \tcode{integer_sequence} with \tcode{N} template non-type arguments.
 The type \tcode{make_integer_sequence<T, N>} denotes the type
 \tcode{integer_sequence<T, 0, 1, ..., N-1>}.
-\begin{note} \tcode{make_integer_sequence<int, 0>} denotes the type
-\tcode{integer_sequence<int>}. \end{note}
+\begin{note}
+\tcode{make_integer_sequence<int, 0>} denotes the type
+\tcode{integer_sequence<int>}.
+\end{note}
 \end{itemdescr}
 
 \rSec1[pairs]{Pairs}
@@ -541,14 +543,18 @@ Value-initializes \tcode{first} and \tcode{second}.
 This constructor shall not participate in overload resolution unless
 \tcode{is_default_construct\-ible_v<first_type>} is \tcode{true} and
 \tcode{is_default_constructible_v<second_type>} is \tcode{true}.
-\begin{note} This behavior can be implemented by a constructor template
-with default template arguments. \end{note}
+\begin{note}
+This behavior can be implemented by a constructor template
+with default template arguments.
+\end{note}
 The expression inside \tcode{explicit} evaluates to \tcode{true}
 if and only if either \tcode{first_type} or
 \tcode{second_type} is not implicitly default-constructible.
-\begin{note} This behavior can be implemented with a trait that checks
+\begin{note}
+This behavior can be implemented with a trait that checks
 whether a \tcode{const first_type\&} or a \tcode{const second_type\&}
-can be initialized with \tcode{\{\}}. \end{note}
+can be initialized with \tcode{\{\}}.
+\end{note}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{pair}!constructor}%
@@ -1176,14 +1182,18 @@ Value-initializes each element.
 \remarks
 This constructor shall not participate in overload resolution unless
 \tcode{is_default_construct\-ible_v<$\tcode{T}_i$>} is \tcode{true} for all $i$.
-\begin{note} This behavior can be implemented by a constructor template
-with default template arguments. \end{note}
+\begin{note}
+This behavior can be implemented by a constructor template
+with default template arguments.
+\end{note}
 The expression inside \tcode{explicit} evaluates to \tcode{true}
 if and only if $\tcode{T}_i$ is not
 copy-list-initializable from an empty list
 for at least one $i$.
-\begin{note} This behavior can be implemented with a trait that checks whether
-a \tcode{const $\tcode{T}_i$\&} can be initialized with \tcode{\{\}}. \end{note}
+\begin{note}
+This behavior can be implemented with a trait that checks whether
+a \tcode{const $\tcode{T}_i$\&} can be initialized with \tcode{\{\}}.
+\end{note}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{tuple}!constructor}%
@@ -1787,9 +1797,11 @@ return @\placeholdernc{make-from-tuple-impl}@<T>(
            forward<Tuple>(t),
            make_index_sequence<tuple_size_v<remove_reference_t<Tuple>>>{});
 \end{codeblock}
-\begin{note} The type of \tcode{T} must be supplied
+\begin{note}
+The type of \tcode{T} must be supplied
 as an explicit template parameter,
-as it cannot be deduced from the argument list. \end{note}
+as it cannot be deduced from the argument list.
+\end{note}
 \end{itemdescr}
 
 \rSec3[tuple.helper]{Tuple helper classes}
@@ -1931,7 +1943,8 @@ A reference to the $\tcode{I}^\text{th}$ element of \tcode{t}, where
 indexing is zero-based.
 
 \pnum
-\begin{note}[Note A]
+\begin{note}
+[Note A]
 If a type \tcode{T} in \tcode{Types} is some reference type \tcode{X\&},
 the return type is \tcode{X\&}, not \tcode{X\&\&}.
 However, if the element type is a non-reference type \tcode{T},
@@ -1939,7 +1952,8 @@ the return type is \tcode{T\&\&}.
 \end{note}
 
 \pnum
-\begin{note}[Note B]
+\begin{note}
+[Note B]
 Constness is shallow.
 If a type \tcode{T} in \tcode{Types} is some reference type \tcode{X\&},
 the return type is \tcode{X\&}, not \tcode{const X\&}.
@@ -1984,11 +1998,13 @@ A reference to the element of \tcode{t} corresponding to the type
 \end{itemdescr}
 
 \pnum
-\begin{note} The reason \tcode{get} is a
+\begin{note}
+The reason \tcode{get} is a
 non-member function is that if this functionality had been
 provided as a member function, code where the type
 depended on a template parameter would have required using
-the \tcode{template} keyword. \end{note}
+the \tcode{template} keyword.
+\end{note}
 
 \rSec3[tuple.rel]{Relational operators}
 
@@ -2067,9 +2083,11 @@ template<class... Types, class Alloc>
 requirements (\tref{cpp17.allocator}).
 
 \pnum
-\begin{note} Specialization of this trait informs other library components that
+\begin{note}
+Specialization of this trait informs other library components that
 \tcode{tuple} can be constructed with an allocator, even though it does not have
-a nested \tcode{allocator_type}. \end{note}
+a nested \tcode{allocator_type}.
+\end{note}
 \end{itemdescr}
 
 \rSec3[tuple.special]{Tuple specialized algorithms}
@@ -3152,7 +3170,9 @@ template<class T, class U> constexpr bool operator==(const optional<T>& x, const
 \requires
 The expression \tcode{*x == *y} shall be well-formed and
 its result shall be convertible to \tcode{bool}.
-\begin{note} \tcode{T} need not be \oldconcept{EqualityComparable}. \end{note}
+\begin{note}
+\tcode{T} need not be \oldconcept{EqualityComparable}.
+\end{note}
 
 \pnum
 \returns
@@ -3841,7 +3861,9 @@ The expression inside \tcode{noexcept} is equivalent to
 \tcode{is_nothrow_default_constructible_v<$\tcode{T}_0$>}.
 This function shall not participate in overload resolution unless
 \tcode{is_default_constructible_v<$\tcode{T}_0$>} is \tcode{true}.
-\begin{note} See also class \tcode{monostate}. \end{note}
+\begin{note}
+See also class \tcode{monostate}.
+\end{note}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{variant}!constructor}%
@@ -3958,7 +3980,8 @@ This function shall not participate in overload resolution unless
 variant<string, string> v("abc");
 \end{codeblock}
 is ill-formed, as both alternative types have an equally viable constructor
-for the argument. \end{note}
+for the argument.
+\end{note}
 
 \pnum
 The expression inside \tcode{noexcept} is equivalent to
@@ -4273,7 +4296,8 @@ variant<string, string> v;
 v = "abc";
 \end{codeblock}
 is ill-formed, as both alternative types have an equally viable constructor
-for the argument. \end{note}
+for the argument.
+\end{note}
 
 \pnum
 The expression inside \tcode{noexcept} is equivalent to:
@@ -7141,10 +7165,13 @@ A safely derived copy of \tcode{p} which shall compare equal to \tcode{p}.
 Nothing.
 
 \pnum
-\begin{note} It is expected that calls to \tcode{declare_reachable(p)} will consume
+\begin{note}
+It is expected that calls to \tcode{declare_reachable(p)} will consume
 a small amount of memory in addition to that occupied by the referenced object until the
 matching call to \tcode{undeclare_reachable(p)} is encountered. Long running programs
-should arrange that calls are matched. \end{note} \end{itemdescr}
+should arrange that calls are matched.
+\end{note}
+\end{itemdescr}
 
 \indexlibrary{\idxcode{declare_no_pointers}}%
 \begin{itemdecl}
@@ -7157,10 +7184,13 @@ void declare_no_pointers(char* p, size_t n);
 are currently registered with
 \tcode{declare_no_pointers()}. If the specified range is in an allocated object,
 then it shall be entirely within a single allocated object. The object shall be
-live until the corresponding \tcode{undeclare_no_pointers()} call. \begin{note} In
+live until the corresponding \tcode{undeclare_no_pointers()} call.
+\begin{note}
+In
 a garbage-collecting implementation, the fact that a region in an object is
 registered with \tcode{declare_no_pointers()} should not prevent the object from
-being collected. \end{note}
+being collected.
+\end{note}
 
 \pnum
 \effects
@@ -7168,17 +7198,22 @@ The \tcode{n} bytes starting at \tcode{p} no longer contain
 traceable pointer locations, independent of their type. Hence
 indirection through a pointer located there is undefined if the object
 it points to was created by global \tcode{operator new} and not
-previously declared reachable. \begin{note} This may be used to inform a
+previously declared reachable.
+\begin{note}
+This may be used to inform a
 garbage collector or leak detector that this region of memory need not
-be traced. \end{note}
+be traced.
+\end{note}
 
 \pnum
 \throws
 Nothing.
 
 \pnum
-\begin{note} Under some conditions implementations may need to allocate memory.
-However, the request can be ignored if memory allocation fails. \end{note}
+\begin{note}
+Under some conditions implementations may need to allocate memory.
+However, the request can be ignored if memory allocation fails.
+\end{note}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{undeclare_no_pointers}}%
@@ -7257,10 +7292,12 @@ would not fit into the available space, otherwise the adjusted value
 of \tcode{ptr}.
 
 \pnum
-\begin{note} The function updates its \tcode{ptr}
+\begin{note}
+The function updates its \tcode{ptr}
 and \tcode{space} arguments so that it can be called repeatedly
 with possibly different \tcode{alignment} and \tcode{size}
-arguments for the same buffer.  \end{note}
+arguments for the same buffer.
+\end{note}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{assume_aligned}}%
@@ -7595,8 +7632,11 @@ return ::new(static_cast<void*>(p))
 The class template \tcode{allocator_traits} supplies a uniform interface to all
 allocator types.
 An allocator cannot be a non-class type, however, even if \tcode{allocator_traits}
-supplies the entire required interface. \begin{note} Thus, it is always possible to create
-a derived class from an allocator. \end{note}
+supplies the entire required interface.
+\begin{note}
+Thus, it is always possible to create
+a derived class from an allocator.
+\end{note}
 
 \indexlibrary{\idxcode{allocator_traits}}%
 \begin{codeblock}
@@ -8787,7 +8827,9 @@ Storage allocated directly with these functions
 is implicitly declared reachable
 (see~\ref{basic.stc.dynamic.safety}) on allocation, ceases to be declared
 reachable on deallocation, and need not cease to be declared reachable as the
-result of an \tcode{undeclare_reachable()} call. \begin{note} This allows existing
+result of an \tcode{undeclare_reachable()} call.
+\begin{note}
+This allows existing
 C libraries to remain unaffected by restrictions on pointers that are not safely
 derived, at the expense of providing far fewer garbage collection and leak
 detection options for \tcode{malloc()}-allocated objects. It also allows
@@ -8796,7 +8838,8 @@ the normal \tcode{declare_reachable()} implementation. The above functions
 should never intentionally be used as a replacement for
 \tcode{declare_reachable()}, and newly written code is strongly encouraged to
 treat memory allocated with these functions as though it were allocated with
-\tcode{operator new}. \end{note}
+\tcode{operator new}.
+\end{note}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{free}}%
@@ -8851,11 +8894,13 @@ is \oldconcept{MoveConstructible} and \oldconcept{MoveAssignable}, but is not
 The template parameter \tcode{T} of \tcode{unique_ptr} may be an incomplete type.
 
 \pnum
-\begin{note} The uses
+\begin{note}
+The uses
 of \tcode{unique_ptr} include providing exception safety for
 dynamically allocated memory, passing ownership of dynamically allocated
 memory to a function, and returning dynamically allocated memory from a
-function. \end{note}
+function.
+\end{note}
 
 \rSec3[unique.ptr.dltr]{Default deleters}
 
@@ -9037,7 +9082,8 @@ meet the \oldconcept{NullablePointer} requirements (\tref{cpp17.nullablepointer}
 Given an allocator type \tcode{X} (\tref{cpp17.allocator}) and
 letting \tcode{A} be a synonym for \tcode{allocator_traits<X>}, the types \tcode{A::pointer},
 \tcode{A::const_pointer}, \tcode{A::void_pointer}, and \tcode{A::const_void_pointer}
-may be used as \tcode{unique_ptr<T, D>::pointer}. \end{example}
+may be used as \tcode{unique_ptr<T, D>::pointer}.
+\end{example}
 
 \rSec4[unique.ptr.single.ctor]{Constructors}
 
@@ -9178,8 +9224,11 @@ throw an exception.
 Constructs a \tcode{unique_ptr} from
 \tcode{u}. If \tcode{D} is a reference type, this
 deleter is copy constructed from \tcode{u}'s deleter; otherwise, this
-deleter is move constructed from \tcode{u}'s deleter. \begin{note} The
-construction of the deleter can be implemented with \tcode{std::forward<D>}. \end{note}
+deleter is move constructed from \tcode{u}'s deleter.
+\begin{note}
+The
+construction of the deleter can be implemented with \tcode{std::forward<D>}.
+\end{note}
 
 \pnum
 \ensures
@@ -9221,8 +9270,11 @@ This constructor shall not participate in overload resolution unless:
 Constructs a \tcode{unique_ptr} from \tcode{u}.
 If \tcode{E} is a reference type, this deleter is copy constructed from
 \tcode{u}'s deleter; otherwise, this deleter is move constructed from \tcode{u}'s
-deleter. \begin{note} The deleter constructor can be implemented with
-\tcode{std::forward<E>}. \end{note}
+deleter.
+\begin{note}
+The deleter constructor can be implemented with
+\tcode{std::forward<E>}.
+\end{note}
 
 \pnum
 \ensures
@@ -9243,7 +9295,9 @@ to the stored deleter that was constructed from
 \begin{itemdescr}
 \pnum
 \requires The expression \tcode{get_deleter()(get())} shall be well-formed,
-shall have well-defined behavior, and shall not throw exceptions. \begin{note} The
+shall have well-defined behavior, and shall not throw exceptions.
+\begin{note}
+The
 use of \tcode{default_delete} requires \tcode{T} to be a complete type.
 \end{note}
 
@@ -9444,13 +9498,17 @@ well-defined behavior, and shall not throw exceptions.
 \effects
 Assigns \tcode{p} to the stored pointer, and then if and only if the old value of the
 stored pointer, \tcode{old_p}, was not equal to \tcode{nullptr}, calls
-\tcode{get_deleter()(old_p)}. \begin{note} The order of these operations is significant
-because the call to \tcode{get_deleter()} may destroy \tcode{*this}. \end{note}
+\tcode{get_deleter()(old_p)}.
+\begin{note}
+The order of these operations is significant
+because the call to \tcode{get_deleter()} may destroy \tcode{*this}.
+\end{note}
 
 \pnum
 \ensures
 \tcode{get() == p}.
-\begin{note} The postcondition does not hold if the call to \tcode{get_deleter()}
+\begin{note}
+The postcondition does not hold if the call to \tcode{get_deleter()}
 destroys \tcode{*this} since \tcode{this->get()} is no longer a valid expression.
 \end{note}
 \end{itemdescr}
@@ -10318,13 +10376,17 @@ For the second overload,
 \tcode{r} is empty and \tcode{r.get() == nullptr}.
 
 \pnum
-\begin{note} To avoid the possibility of a dangling pointer, the
+\begin{note}
+To avoid the possibility of a dangling pointer, the
 user of this constructor should ensure that \tcode{p} remains valid at
-least until the ownership group of \tcode{r} is destroyed. \end{note}
+least until the ownership group of \tcode{r} is destroyed.
+\end{note}
 
 \pnum
-\begin{note} This constructor allows creation of an empty
-\tcode{shared_ptr} instance with a non-null stored pointer. \end{note}
+\begin{note}
+This constructor allows creation of an empty
+\tcode{shared_ptr} instance with a non-null stored pointer.
+\end{note}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{shared_ptr}!constructor}%
@@ -10445,13 +10507,15 @@ and \tcode{delete p} is called.
 \end{itemdescr}
 
 \pnum
-\begin{note} Since the destruction of \tcode{*this}
+\begin{note}
+Since the destruction of \tcode{*this}
 decreases the number of instances that share ownership with \tcode{*this}
 by one,
 after \tcode{*this} has been destroyed
 all \tcode{shared_ptr} instances that shared ownership with
 \tcode{*this} will report a \tcode{use_count()} that is one less
-than its previous value. \end{note}
+than its previous value.
+\end{note}
 
 \rSec3[util.smartptr.shared.assign]{Assignment}
 
@@ -10483,7 +10547,8 @@ shared_ptr<void> q(p);
 p = p;
 q = p;
 \end{codeblock}
-both assignments may be no-ops. \end{note}
+both assignments may be no-ops.
+\end{note}
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{shared_ptr}%
@@ -10675,19 +10740,25 @@ empty.
 None.
 
 \pnum
-\begin{note} \tcode{get() == nullptr}
-does not imply a specific return value of \tcode{use_count()}. \end{note}
+\begin{note}
+\tcode{get() == nullptr}
+does not imply a specific return value of \tcode{use_count()}.
+\end{note}
 
 \pnum
-\begin{note} \tcode{weak_ptr<T>::lock()}
-can affect the return value of \tcode{use_count()}. \end{note}
+\begin{note}
+\tcode{weak_ptr<T>::lock()}
+can affect the return value of \tcode{use_count()}.
+\end{note}
 
 \pnum
-\begin{note} When multiple threads
+\begin{note}
+When multiple threads
 can affect the return value of \tcode{use_count()},
 the result should be treated as approximate.
 In particular, \tcode{use_count() == 1} does not imply that accesses through
-a previously destroyed \tcode{shared_ptr} have in any sense completed. \end{note}
+a previously destroyed \tcode{shared_ptr} have in any sense completed.
+\end{note}
 \end{itemdescr}
 
 \indexlibrarymember{operator bool}{shared_ptr}%
@@ -11307,10 +11378,13 @@ If \tcode{p} owns a deleter \tcode{d} of type cv-unqualified
 \tcode{D}, returns \tcode{addressof(d)}; otherwise returns \tcode{nullptr}.
 The returned
 pointer remains valid as long as there exists a \tcode{shared_ptr} instance
-that owns \tcode{d}. \begin{note} It is unspecified whether the pointer
+that owns \tcode{d}.
+\begin{note}
+It is unspecified whether the pointer
 remains valid longer than that. This can happen if the implementation doesn't destroy
 the deleter until all \tcode{weak_ptr} instances that share ownership with
-\tcode{p} have been destroyed. \end{note}
+\tcode{p} have been destroyed.
+\end{note}
 \end{itemdescr}
 
 \rSec3[util.smartptr.shared.io]{I/O}
@@ -11652,7 +11726,8 @@ namespace std {
 
 \indexlibrarymember{operator()}{owner_less}%
 \pnum
-\tcode{operator()(x, y)} shall return \tcode{x.owner_before(y)}. \begin{note}
+\tcode{operator()(x, y)} shall return \tcode{x.owner_before(y)}.
+\begin{note}
 Note that
 
 \begin{itemize}
@@ -11662,7 +11737,8 @@ Note that
 \tcode{!operator()(a, b) \&\& !operator()(b, a)}, two \tcode{shared_ptr} or
 \tcode{weak_ptr} instances are equivalent if and only if they share ownership or are
 both empty.
-\end{itemize} \end{note}
+\end{itemize}
+\end{note}
 
 \rSec2[util.smartptr.enab]{Class template \tcode{enable_shared_from_this}}
 
@@ -11734,7 +11810,9 @@ enable_shared_from_this<T>& operator=(const enable_shared_from_this<T>&) noexcep
 \tcode{*this}.
 
 \pnum
-\begin{note} \tcode{weak_this} is not changed. \end{note}
+\begin{note}
+\tcode{weak_this} is not changed.
+\end{note}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{shared_ptr}}%
@@ -12612,7 +12690,8 @@ otherwise \tcode{false}.
 The most-derived type of \tcode{other} might not match the type of \tcode{this}.
 For a derived class \tcode{D}, an implementation of this function
 could immediately return \tcode{false}
-if \tcode{dynamic_cast<const D*>(\&other) == nullptr}.\end{note}
+if \tcode{dynamic_cast<const D*>(\&other) == nullptr}.
+\end{note}
 \end{itemdescr}
 
 \rSec3[mem.res.eq]{Equality}
@@ -13075,7 +13154,8 @@ the chunk size obtained increases geometrically.
 \begin{note}
 By allocating memory in chunks,
 the pooling strategy increases the chance that consecutive allocations
-will be close together in memory.\end{note}
+will be close together in memory.
+\end{note}
 \item
 Allocation requests that exceed the largest block size of any pool
 are fulfilled directly from the upstream allocator.
@@ -13226,7 +13306,8 @@ but will not own the resource to which \tcode{upstream} points.
 \begin{note}
 The intention is that calls to \tcode{upstream->allocate()}
 will be substantially fewer than calls to \tcode{this->allocate()}
-in most cases.\end{note}
+in most cases.
+\end{note}
 The behavior of the pooling mechanism is tuned
 according to the value of the \tcode{opts} argument.
 
@@ -13266,7 +13347,8 @@ to release all allocated memory.
 \begin{note}
 The memory is released back to \tcode{upstream_resource()}
 even if \tcode{deallocate} has not been called
-for some of the allocated blocks.\end{note}
+for some of the allocated blocks.
+\end{note}
 \end{itemdescr}
 
 \indexlibrarymember{upstream_resource}{synchronized_pool_resource}%
@@ -13497,7 +13579,8 @@ to release all allocated memory.
 \begin{note}
 The memory is released back to \tcode{upstream_rsrc}
 even if some blocks that were allocated from \tcode{this}
-have not been deallocated from \tcode{this}.\end{note}
+have not been deallocated from \tcode{this}.
+\end{note}
 \end{itemdescr}
 
 \indexlibrarymember{upstream_resource}{monotonic_buffer_resource}%
@@ -13605,9 +13688,12 @@ constructors of the container's elements, and, if the elements themselves are
 containers, the third allocator is passed to the elements' elements, and so on. If
 containers are nested to a depth greater than the number of allocators, the last
 allocator is used repeatedly, as in the single-allocator case, for any remaining
-recursions. \begin{note} The \tcode{scoped_allocator_adaptor} is derived from the outer
+recursions.
+\begin{note}
+The \tcode{scoped_allocator_adaptor} is derived from the outer
 allocator type so it can be substituted for the outer allocator type in most
-expressions. \end{note}
+expressions.
+\end{note}
 
 \indexlibrary{\idxcode{scoped_allocator_adaptor}}%
 \indexlibrarymember{outer_allocator_type}{scoped_allocator_adaptor}%
@@ -13864,11 +13950,13 @@ valid~\iref{temp.deduct} and
 \tcode{x} otherwise;
 \tcode{\placeholdernc{OUTERMOST_ALLOC_TRAITS}(x)} is
 \tcode{allocator_traits<remove_reference_t<decltype(\placeholdernc{OUTERMOST}(x))>>}.
-\begin{note} \tcode{\placeholdernc{OUTERMOST}(x)} and
+\begin{note}
+\tcode{\placeholdernc{OUTERMOST}(x)} and
 \tcode{\placeholdernc{OUTERMOST_ALL\-OC_TRAITS}(x)} are recursive operations. It
 is incumbent upon the definition of \tcode{outer_allocator()} to ensure that the
 recursion terminates. It will terminate for all instantiations of
-\tcode{scoped_allocator_adaptor}. \end{note}
+\tcode{scoped_allocator_adaptor}.
+\end{note}
 
 \indexlibrarymember{inner_allocator}{scoped_allocator_adaptor}%
 \begin{itemdecl}
@@ -14859,10 +14947,12 @@ For templates \tcode{less}, \tcode{greater}, \tcode{less_equal}, and
 yield a strict total order that is consistent among those specializations and
 is also consistent with the partial order imposed by
 the built-in operators \tcode{<}, \tcode{>}, \tcode{<=}, \tcode{>=}.
-\begin{note} When \tcode{a < b} is well-defined
+\begin{note}
+When \tcode{a < b} is well-defined
 for pointers \tcode{a} and \tcode{b} of type \tcode{P},
 this implies \tcode{(a < b) == less<P>()(a, b)},
-\tcode{(a > b) == greater<P>()(a, b)}, and so forth. \end{note}
+\tcode{(a > b) == greater<P>()(a, b)}, and so forth.
+\end{note}
 For template specializations \tcode{less<void>}, \tcode{greater<void>},
 \tcode{less_equal<void>}, and \tcode{greater_equal<void>},
 if the call operator calls a built-in operator comparing pointers,
@@ -16106,10 +16196,12 @@ Shall not throw exceptions if \tcode{f}'s target is
 a specialization of \tcode{reference_wrapper} or
 a function pointer. Otherwise, may throw \tcode{bad_alloc}
 or any exception thrown by the copy constructor of the stored callable object.
-\begin{note} Implementations should avoid the use of
+\begin{note}
+Implementations should avoid the use of
 dynamically allocated memory for small callable objects, for example, where
 \tcode{f}'s target is an object holding only a pointer or reference
-to an object and a member function pointer. \end{note}
+to an object and a member function pointer.
+\end{note}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{function}!constructor}%
@@ -16126,10 +16218,12 @@ the target of \tcode{f} before the construction, and
 \tcode{f} is in a valid state with an unspecified value.
 
 \pnum
-\begin{note} Implementations should avoid the use of
+\begin{note}
+Implementations should avoid the use of
 dynamically allocated memory for small callable objects, for example,
 where \tcode{f}'s target is an object holding only a pointer or reference
-to an object and a member function pointer. \end{note}
+to an object and a member function pointer.
+\end{note}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{function}!constructor}%
@@ -16160,10 +16254,12 @@ This constructor template shall not participate in overload resolution unless
 \pnum
 Otherwise, \tcode{*this} targets a copy of \tcode{f}
 initialized with \tcode{std::move(f)}.
-\begin{note} Implementations should avoid the use of
+\begin{note}
+Implementations should avoid the use of
 dynamically allocated memory for small callable objects, for example,
 where \tcode{f} is an object holding only a pointer or
-reference to an object and a member function pointer. \end{note}
+reference to an object and a member function pointer.
+\end{note}
 
 \pnum
 \throws
@@ -17515,8 +17611,12 @@ notwithstanding the restrictions of~\ref{declval}.
 \tcode{template<class T>}\br
  \tcode{struct is_final;}               &
  \tcode{T} is a class type marked with the \grammarterm{class-virt-specifier}
- \tcode{final}\iref{class}. \begin{note} A union is a class type that
- can be marked with \tcode{final}. \end{note}                                        &
+ \tcode{final}\iref{class}.
+\begin{note}
+A union is a class type that
+ can be marked with \tcode{final}.
+\end{note}
+&
  If \tcode{T} is a class type, \tcode{T} shall be a complete type.                          \\ \rowsep
 
 \indexlibrary{\idxcode{is_aggregate}}%
@@ -17592,11 +17692,15 @@ notwithstanding the restrictions of~\ref{declval}.
   when treated as an unevaluated
   operand\iref{expr.prop}. Access checking is performed as if in a context
   unrelated to \tcode{T} and \tcode{U}. Only the validity of the immediate context
-  of the assignment expression is considered. \begin{note} The compilation of the
+  of the assignment expression is considered.
+\begin{note}
+The compilation of the
   expression can result in side effects such as the instantiation of class template
   specializations and function template specializations, the generation of
   implicitly-defined functions, and so on. Such side effects are not in the ``immediate
-  context'' and can result in the program being ill-formed. \end{note} &
+  context'' and can result in the program being ill-formed.
+\end{note}
+&
   \tcode{T} and \tcode{U} shall be complete types, \cv{}~\tcode{void},
   or arrays of unknown bound. \\ \rowsep
 
@@ -17635,7 +17739,8 @@ notwithstanding the restrictions of~\ref{declval}.
   the generation of implicitly-defined functions, and so on.
   Such side effects are not in the ``immediate context'' and
   can result in the program being ill-formed.
-  \end{note} &
+  \end{note}
+&
   \tcode{T} and \tcode{U} shall be complete types,
   \cv{}~\tcode{void}, or
   arrays of unknown bound.  \\ \rowsep
@@ -17902,14 +18007,19 @@ following variable definition would be well-formed for some invented variable \t
 T t(declval<Args>()...);
 \end{codeblock}
 
-\begin{note} These tokens are never interpreted as a function declaration.
-\end{note} Access checking is performed as if in a context unrelated to \tcode{T}
+\begin{note}
+These tokens are never interpreted as a function declaration.
+\end{note}
+Access checking is performed as if in a context unrelated to \tcode{T}
 and any of the \tcode{Args}. Only the validity of the immediate context of the
-variable initialization is considered. \begin{note} The evaluation of the
+variable initialization is considered.
+\begin{note}
+The evaluation of the
 initialization can result in side effects such as the instantiation of class
 template specializations and function template specializations, the generation
 of implicitly-defined functions, and so on. Such side effects are not in the
-``immediate context'' and can result in the program being ill-formed. \end{note}
+``immediate context'' and can result in the program being ill-formed.
+\end{note}
 
 \indexlibrary{\idxcode{has_unique_object_representations}}%
 \pnum
@@ -17927,8 +18037,10 @@ if they have the same active member and the corresponding members have the same 
 \end{itemize}
 The set of scalar types for which this condition holds is
 \impldef{which scalar types have unique object representations}.
-\begin{note} If a type has padding bits, the condition does not hold;
-otherwise, the condition holds true for integral types. \end{note}
+\begin{note}
+If a type has padding bits, the condition does not hold;
+otherwise, the condition holds true for integral types.
+\end{note}
 
 \rSec2[meta.unary.prop.query]{Type property queries}
 
@@ -18036,8 +18148,11 @@ with a base characteristic of
 not possibly cv-qualified versions of the same type,
  \tcode{Derived} shall be a complete
  type.
- \begin{note} Base classes that are private, protected, or ambiguous
- are, nonetheless, base classes. \end{note} \\ \rowsep
+ \begin{note}
+Base classes that are private, protected, or ambiguous
+ are, nonetheless, base classes.
+\end{note}
+\\ \rowsep
 
 \indexlibrary{\idxcode{is_convertible}}%
 \tcode{template<class From, class To>}\br
@@ -18158,16 +18273,22 @@ To test() {
 }
 \end{codeblock}
 
-\begin{note} This requirement gives well-defined results for reference types, void
-types, array types, and function types.\end{note} Access checking is performed
+\begin{note}
+This requirement gives well-defined results for reference types, void
+types, array types, and function types.
+\end{note}
+Access checking is performed
 in a context unrelated to \tcode{To} and \tcode{From}. Only the validity of
 the immediate context of the \grammarterm{expression} of the \tcode{return} statement\iref{stmt.return}
-(including initialization of the returned object or reference) is considered. \begin{note} The
+(including initialization of the returned object or reference) is considered.
+\begin{note}
+The
 initialization can result in side effects such as the
 instantiation of class template specializations and function template
 specializations, the generation of implicitly-defined functions, and so on. Such
 side effects are not in the ``immediate context'' and can result in the program
-being ill-formed. \end{note}
+being ill-formed.
+\end{note}
 
 \rSec2[meta.trans]{Transformations between types}
 \pnum
@@ -18198,7 +18319,9 @@ Each of the templates in this subclause shall be a
  \begin{example}
 \tcode{remove_const_t<const volatile int>} evaluates
  to \tcode{volatile int}, whereas \tcode{remove_const_t<const int*>} evaluates to
- \tcode{const int*}. \end{example}                          \\  \rowsep
+ \tcode{const int*}.
+\end{example}
+\\  \rowsep
 
 \indexlibrary{\idxcode{remove_volatile}}%
 \tcode{template<class T>\br
@@ -18210,7 +18333,8 @@ Each of the templates in this subclause shall be a
 \tcode{remove_volatile_t<const volatile int>}
  evaluates to \tcode{const int},
  whereas \tcode{remove_volatile_t<volatile int*>} evaluates to \tcode{volatile int*}.
- \end{example}                                              \\  \rowsep
+ \end{example}
+\\  \rowsep
 
 \indexlibrary{\idxcode{remove_cv}}%
 \tcode{template<class T>\br
@@ -18220,7 +18344,9 @@ Each of the templates in this subclause shall be a
  \begin{example}
 \tcode{remove_cv_t<const volatile int>}
  evaluates to \tcode{int}, whereas \tcode{remove_cv_t<const volatile int*>}
- evaluates to \tcode{const volatile int*}. \end{example}  \\  \rowsep
+ evaluates to \tcode{const volatile int*}.
+\end{example}
+\\  \rowsep
 
 \indexlibrary{\idxcode{add_const}}%
 \tcode{template<class T>\br
@@ -18272,7 +18398,8 @@ Each of the templates in this subclause shall be a
  otherwise, \tcode{type} names \tcode{T}.
  \begin{note}
  This rule reflects the semantics of reference collapsing\iref{dcl.ref}.
- \end{note}\\ \rowsep
+ \end{note}
+\\ \rowsep
 
 \indexlibrary{\idxcode{add_rvalue_reference}}%
 \tcode{template<class T>}\br
@@ -18280,10 +18407,12 @@ Each of the templates in this subclause shall be a
  If \tcode{T} names a referenceable type then
  the member typedef \tcode{type} names \tcode{T\&\&};
  otherwise, \tcode{type} names \tcode{T}.
- \begin{note} This rule reflects the semantics of reference collapsing\iref{dcl.ref}.
+ \begin{note}
+This rule reflects the semantics of reference collapsing\iref{dcl.ref}.
  For example, when a type \tcode{T} names a type \tcode{T1\&}, the type
  \tcode{add_rvalue_reference_t<T>} is not an rvalue reference.
- \end{note} \\
+ \end{note}
+\\
 \end{libreqtab2a}
 
 \rSec3[meta.trans.sign]{Sign modifications}
@@ -18347,9 +18476,12 @@ Each of the templates in this subclause shall be a
  If \tcode{T} names a type ``array of \tcode{U}'',
  the member typedef \tcode{type} shall
  be \tcode{U}, otherwise \tcode{T}.
- \begin{note} For multidimensional arrays, only the first array dimension is
+ \begin{note}
+For multidimensional arrays, only the first array dimension is
  removed. For a type ``array of \tcode{const U}'', the resulting type is
- \tcode{const U}. \end{note}                                 \\  \rowsep
+ \tcode{const U}.
+\end{note}
+\\  \rowsep
 
 \indexlibrary{\idxcode{remove_all_extents}}%
 \tcode{template<class T>\br
@@ -18468,11 +18600,13 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
  \tcode{remove_extent_t<U>*}. If \tcode{is_function_v<U>} is \tcode{true},
  the member typedef \tcode{type} shall equal \tcode{add_pointer_t<U>}. Otherwise
  the member typedef \tcode{type} equals \tcode{remove_cv_t<U>}.
- \begin{note} This behavior is similar to the lvalue-to-rvalue\iref{conv.lval},
+ \begin{note}
+This behavior is similar to the lvalue-to-rvalue\iref{conv.lval},
  array-to-pointer\iref{conv.array}, and function-to-pointer\iref{conv.func}
  conversions applied when an lvalue is used as an rvalue, but also
  strips \cv-qualifiers from class types in order to more closely model by-value
- argument passing. \end{note}
+ argument passing.
+\end{note}
  \\ \rowsep
 
 \indexlibrary{\idxcode{enable_if}}%
@@ -18541,7 +18675,8 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
  template specializations, the generation of implicitly-defined
  functions, and so on. Such side effects are not in the ``immediate
  context'' and can result in the program being ill-formed.
- \end{note} \br
+ \end{note}
+\br
  \requires{} \tcode{Fn} and all types in the template parameter pack \tcode{ArgTypes} shall
  be complete types, \cv{}~\tcode{void}, or arrays of
  unknown bound.\\
@@ -18549,7 +18684,8 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
 
 \indexlibrary{\idxcode{aligned_storage}}%
 \pnum
-\begin{note} A typical implementation would define \tcode{aligned_storage} as:
+\begin{note}
+A typical implementation would define \tcode{aligned_storage} as:
 
 \begin{codeblock}
 template<size_t Len, size_t Alignment>
@@ -18805,7 +18941,8 @@ if there is a template type argument $\tcode{B}_{i}$
 for which \tcode{bool($\tcode{B}_{i}$::value)} is \tcode{false},
 then instantiating \tcode{conjunction<$\tcode{B}_{1}$, $\dotsc$, $\tcode{B}_{N}$>::value}
 does not require the instantiation of \tcode{$\tcode{B}_{j}$::value} for $j > i$.
-\begin{note} This is analogous to the short-circuiting behavior of
+\begin{note}
+This is analogous to the short-circuiting behavior of
 the built-in operator \tcode{\&\&}.
 \end{note}
 
@@ -18828,7 +18965,8 @@ for which \tcode{bool($\tcode{B}_{i}$::value)} is \tcode{false}, or
 \item
 if there is no such $\tcode{B}_{i}$, the last type in the list.
 \end{itemize}
-\begin{note} This means a specialization of \tcode{conjunction}
+\begin{note}
+This means a specialization of \tcode{conjunction}
 does not necessarily inherit from
 either \tcode{true_type} or \tcode{false_type}.
 \end{note}
@@ -18855,7 +18993,8 @@ if there is a template type argument $\tcode{B}_{i}$
 for which \tcode{bool($\tcode{B}_{i}$::value)} is \tcode{true},
 then instantiating \tcode{disjunction<$\tcode{B}_{1}$, $\dotsc$, $\tcode{B}_{N}$>::value}
 does not require the instantiation of \tcode{$\tcode{B}_{j}$::value} for $j > i$.
-\begin{note} This is analogous to the short-circuiting behavior of
+\begin{note}
+This is analogous to the short-circuiting behavior of
 the built-in operator \tcode{||}.
 \end{note}
 
@@ -18876,7 +19015,8 @@ has a public and unambiguous base that is either
 for which \tcode{bool($\tcode{B}_{i}$::value)} is \tcode{true}, or
 \item if there is no such $\tcode{B}_{i}$, the last type in the list.
 \end{itemize}
-\begin{note} This means a specialization of \tcode{disjunction}
+\begin{note}
+This means a specialization of \tcode{disjunction}
 does not necessarily inherit from
 either \tcode{true_type} or \tcode{false_type}.
 \end{note}
@@ -19093,10 +19233,13 @@ namespace std {
 \indextext{signed integer representation!two's complement}%
 If the template argument \tcode{D} is zero or the absolute values of either of the
 template arguments \tcode{N} and \tcode{D} is not representable by type
-\tcode{intmax_t}, the program is ill-formed. \begin{note} These rules ensure that infinite
+\tcode{intmax_t}, the program is ill-formed.
+\begin{note}
+These rules ensure that infinite
 ratios are avoided and that for any negative input, there exists a representable value
 of its absolute value which is positive.
-This excludes the most negative value. \end{note}
+This excludes the most negative value.
+\end{note}
 
 \pnum
 The static data members \tcode{num} and \tcode{den} shall have the following values,
@@ -19834,9 +19977,11 @@ If no characters match the pattern,
 \tcode{value} is unmodified,
 the member \tcode{ptr} of the return value is \tcode{first} and
 the member \tcode{ec} is equal to \tcode{errc::invalid_argument}.
-\begin{note} If the pattern allows for an optional sign,
+\begin{note}
+If the pattern allows for an optional sign,
 but the string has no digit characters following the sign,
-no characters match the pattern. \end{note}
+no characters match the pattern.
+\end{note}
 Otherwise,
 the characters matching the pattern
 are interpreted as a representation


### PR DESCRIPTION
Fixes #3128.