### PR TITLE
[class.spaceship] equal to equivalent

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -6871,7 +6871,7 @@ a < b  ? strong_ordering::less :
 \item
 Otherwise, if \tcode{R} is \tcode{weak_ordering}, then
 \begin{codeblock}
-a == b ? weak_ordering::equal :
+a == b ? weak_ordering::equivalent :
 a < b  ? weak_ordering::less :
          weak_ordering::greater
 \end{codeblock}


### PR DESCRIPTION
typo fix for [[class.spaceship]/1.4](http://eel.is/c++draft/class.compare#class.spaceship-1.4)