### PR TITLE
[concepts.arithmetic] fix notes that use undefined terms

### DIFF
--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -486,13 +486,13 @@ template<class T>
 \pnum
 \begin{note}
 \libconcept{signed_integral} can be modeled even by types that are
-not signed integral types\iref{basic.fundamental}; for example, \tcode{char}.
+not signed integer types\iref{basic.fundamental}; for example, \tcode{char}.
 \end{note}
 
 \pnum
 \begin{note}
 \libconcept{unsigned_integral} can be modeled even by types that are
-not unsigned integral types\iref{basic.fundamental}; for example, \tcode{bool}.
+not unsigned integer types\iref{basic.fundamental}; for example, \tcode{bool}.
 \end{note}
 \end{itemdescr}
 


### PR DESCRIPTION
The terms "signed integral types" and "unsigned integral types" are not
defined in [basic.fundamental] The notes are trying to talk about
signed/unsigned *integer* types. `char` and `bool` are not signed or
unsigned *integer* types, but they certainly are *integral* types, and
so they model one of `signed_integral` or `unsigned_integral`.