### PR TITLE
[over.match.funcs] Remove bullet for single-item bulleted list.

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -566,11 +566,7 @@ no user-defined conversions can be applied to achieve a type
 match with it.
 \indextext{implied object argument!non-static member function and}%
 For non-static member functions declared without a \grammarterm{ref-qualifier},
-an additional rule applies:
-\begin{itemize}
-\item
-even if the implicit object parameter is not
-const-qualified,
+even if the implicit object parameter is not const-qualified,
 an rvalue can be bound to the parameter
 as long as in all other respects the argument can be
 converted to the type of the implicit object parameter.
@@ -578,7 +574,6 @@ converted to the type of the implicit object parameter.
 The fact that such an argument is an rvalue does not
 affect the ranking of implicit conversion sequences\iref{over.ics.rank}.
 \end{note}
-\end{itemize}
 
 \pnum
 Because other than in list-initialization only one user-defined conversion


### PR DESCRIPTION
Fixes #3176.