### PR TITLE
[basic.stc.dynamic.safety] Avoid undefined term 'dynamic object'.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3830,7 +3830,7 @@ match those of some object pointer type.
 \end{itemize}
 
 \pnum
-A pointer value is a \defn{safely-derived pointer} to a dynamic object only if it
+A pointer value is a \defn{safely-derived pointer} to an object with dynamic storage duration only if it
 has an object pointer type and it is one of the following:
 \begin{itemize}
 \item the value returned by a call to the \Cpp{} standard library implementation of


### PR DESCRIPTION
Fixes #3185.