### PR TITLE
[dcl.spec.auto] Add example to show variable redeclaration with 'auto'.

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1875,6 +1875,12 @@ template <typename T> struct A {
   friend T frf(T);
 };
 auto frf(int i) { return i; }                   // not a friend of \tcode{A<int>}
+extern int v;
+auto v = 17;                                    // OK, redeclares \tcode{v}
+struct S {
+  static int i;
+};
+auto S::i = 23;                                 // OK
 \end{codeblock}
 \end{example}
 


### PR DESCRIPTION
CWG2389 Agreement of deduced and explicitly-specified variable types

Fixes #2979.