### PR TITLE
Replace "shall not throw" with "does not throw" when it describes library behavior

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -1254,7 +1254,7 @@ If \tcode{Period} is not a specialization of \tcode{ratio}, the program is ill-f
 If \tcode{Period::num} is not positive, the program is ill-formed.
 
 \pnum
-Members of \tcode{duration} shall not throw exceptions other than
+Members of \tcode{duration} do not throw exceptions other than
 those thrown by the indicated operations on their representations.
 
 \pnum

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -513,13 +513,13 @@ namespace std {
 \end{codeblock}
 
 \pnum
-Constructors and member functions of \tcode{pair} shall not throw exceptions unless one of
+Constructors and member functions of \tcode{pair} do not throw exceptions unless one of
 the element-wise operations specified to be called for that operation
 throws an exception.
 
 \pnum
-The defaulted move and copy constructor, respectively, of \tcode{pair} shall
-be a constexpr function if and only if all required element-wise
+The defaulted move and copy constructor, respectively, of \tcode{pair}
+is a constexpr function if and only if all required element-wise
 initializations for copy and move, respectively, would satisfy the
 requirements for a constexpr function.
 
@@ -16174,7 +16174,7 @@ function(const function& f);
 
 \pnum
 \throws
-Shall not throw exceptions if \tcode{f}'s target is
+Nothing if \tcode{f}'s target is
 a specialization of \tcode{reference_wrapper} or
 a function pointer. Otherwise, may throw \tcode{bad_alloc}
 or any exception thrown by the copy constructor of the stored callable object.
@@ -16245,10 +16245,10 @@ reference to an object and a member function pointer.
 
 \pnum
 \throws
-Shall not throw exceptions when \tcode{f} is a function pointer
-or a \tcode{reference_wrapper<T>} for some \tcode{T}. Otherwise,
-may throw \tcode{bad_alloc} or any exception thrown by \tcode{F}'s copy
-or move constructor.
+Nothing if \tcode{f} is
+a specialization of \tcode{reference_wrapper} or
+a function pointer. Otherwise, may throw \tcode{bad_alloc}
+or any exception thrown by \tcode{F}'s copy or move constructor.
 \end{itemdescr}
 
 


### PR DESCRIPTION
In these places we aren't saying "it's UB if it throws"; we're literally specifying the behavior of a library function as "it does not throw, we promise."