### PR TITLE
Several editorial fixes in [re.regex].

### DIFF
--- a/source/regex.tex
+++ b/source/regex.tex
@@ -1280,26 +1280,26 @@ namespace std {
       basic_regex(const basic_regex&);
       basic_regex(basic_regex&&) noexcept;
       template<class ST, class SA>
-        explicit basic_regex(const basic_string<charT, ST, SA>& p,
+        explicit basic_regex(const basic_string<charT, ST, SA>& s,
                              flag_type f = regex_constants::ECMAScript);
       template<class ForwardIterator>
         basic_regex(ForwardIterator first, ForwardIterator last,
                     flag_type f = regex_constants::ECMAScript);
-      basic_regex(initializer_list<charT>, flag_type = regex_constants::ECMAScript);
+      basic_regex(initializer_list<charT> il, flag_type f = regex_constants::ECMAScript);
 
       ~basic_regex();
 
-      basic_regex& operator=(const basic_regex&);
-      basic_regex& operator=(basic_regex&&) noexcept;
-      basic_regex& operator=(const charT* ptr);
+      // \ref{re.regex.assign}, assign
+      basic_regex& operator=(const basic_regex& e);
+      basic_regex& operator=(basic_regex&& e) noexcept;
+      basic_regex& operator=(const charT* p);
       basic_regex& operator=(initializer_list<charT> il);
       template<class ST, class SA>
-        basic_regex& operator=(const basic_string<charT, ST, SA>& p);
+        basic_regex& operator=(const basic_string<charT, ST, SA>& s);
 
-      // \ref{re.regex.assign}, assign
-      basic_regex& assign(const basic_regex& that);
-      basic_regex& assign(basic_regex&& that) noexcept;
-      basic_regex& assign(const charT* ptr, flag_type f = regex_constants::ECMAScript);
+      basic_regex& assign(const basic_regex& e);
+      basic_regex& assign(basic_regex&& e) noexcept;
+      basic_regex& assign(const charT* p, flag_type f = regex_constants::ECMAScript);
       basic_regex& assign(const charT* p, size_t len, flag_type f);
       template<class ST, class SA>
         basic_regex& assign(const basic_string<charT, ST, SA>& s,
@@ -1308,7 +1308,7 @@ namespace std {
         basic_regex& assign(InputIterator first, InputIterator last,
                             flag_type f = regex_constants::ECMAScript);
       basic_regex& assign(initializer_list<charT>,
-                          flag_type = regex_constants::ECMAScript);
+                          flag_type f = regex_constants::ECMAScript);
 
       // \ref{re.regex.operations}, const operations
       unsigned mark_count() const;
@@ -1533,16 +1533,16 @@ Move assigns from \tcode{e} into \tcode{*this} and returns \tcode{*this}.
 
 \indexlibrarymember{basic_regex}{operator=}%
 \begin{itemdecl}
-basic_regex& operator=(const charT* ptr);
+basic_regex& operator=(const charT* p);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{ptr} shall not be a null pointer.
+\requires \tcode{p} shall not be a null pointer.
 
 \pnum
 \effects
-Returns \tcode{assign(ptr)}.
+Returns \tcode{assign(p)}.
 \end{itemdescr}
 
 \indexlibrarymember{basic_regex}{operator=}%
@@ -1559,57 +1559,57 @@ Returns \tcode{assign(il.begin(), il.end())}.
 \indexlibrarymember{basic_regex}{operator=}%
 \begin{itemdecl}
 template<class ST, class SA>
-  basic_regex& operator=(const basic_string<charT, ST, SA>& p);
+  basic_regex& operator=(const basic_string<charT, ST, SA>& s);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \effects
-Returns \tcode{assign(p)}.
+Returns \tcode{assign(s)}.
 \end{itemdescr}
 
 \indexlibrarymember{basic_regex}{assign}%
 \begin{itemdecl}
-basic_regex& assign(const basic_regex& that);
+basic_regex& assign(const basic_regex& e);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return *this = that;}
+Equivalent to: \tcode{return *this = e;}
 \end{itemdescr}
 
 \indexlibrarymember{basic_regex}{assign}%
 \begin{itemdecl}
-basic_regex& assign(basic_regex&& that) noexcept;
+basic_regex& assign(basic_regex&& e) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return *this = std::move(that);}
+Equivalent to: \tcode{return *this = std::move(e);}
 \end{itemdescr}
 
 \indexlibrarymember{basic_regex}{assign}%
 \begin{itemdecl}
-basic_regex& assign(const charT* ptr, flag_type f = regex_constants::ECMAScript);
+basic_regex& assign(const charT* p, flag_type f = regex_constants::ECMAScript);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{assign(string_type(ptr), f)}.
+\tcode{assign(string_type(p), f)}.
 \end{itemdescr}
 
 \indexlibrarymember{basic_regex}{assign}%
 \begin{itemdecl}
-basic_regex& assign(const charT* ptr, size_t len, flag_type f = regex_constants::ECMAScript);
+basic_regex& assign(const charT* p, size_t len, flag_type f = regex_constants::ECMAScript);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{assign(string_type(ptr, len), f)}.
+\tcode{assign(string_type(p, len), f)}.
 \end{itemdescr}
 
 \indexlibrarymember{basic_regex}{assign}%


### PR DESCRIPTION
Fixes the consistency of several arguments in operator= and assign
and the constructor:
basic_regex from unnamed, that, e -> e
basic_string from p -> s
const charT* from ptr, p -> p
flag_type from unnamed -> f
initializer_list<charT> from unnamed -> il

These changes are in both [re.regex] and [re.regex.assign].

Moves the [re.regex.assign] LaTex reference in [re.regex] before the
operator= overloads to match the [re.regex.assign] section.

There is one more inconsistency [re.regex] declares:
basic_regex& assign(const charT* p, size_t len, flag_type f);

[re.regex.assign] declares:
basic_regex& assign(const charT* p, size_t len,
  flag_type f = regex_constants::ECMAScript);

Since this is not an editorial issue I'll file an LWG issue.