### PR TITLE
[over.match.viable] Properly handle non-trailing default arguments.

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -1825,36 +1825,21 @@ list.
 
 \begin{itemize}
 \item
-If there are
-\textit{m}
-arguments in the list, all candidate
-functions having exactly
-\textit{m}
-parameters are viable.
+If there are $m$ arguments in the list,
+all candidate functions having exactly $m$ parameters are viable.
 \item
-A candidate function having fewer than
-\textit{m}
-parameters is
-viable only if it has an ellipsis in its parameter list\iref{dcl.fct}.
+A candidate function having fewer than $m$ parameters
+is viable only if it has an ellipsis in its parameter list\iref{dcl.fct}.
 For the purposes of overload resolution,
-any argument for which there is no corresponding parameter is
-considered to ``match the ellipsis''\iref{over.ics.ellipsis} .
+any argument for which there is no corresponding parameter
+is considered to ``match the ellipsis''\iref{over.ics.ellipsis}.
 \item
-A candidate function having more than
-\textit{m}
-parameters is viable
-only if the
-$\textit{(m+1)}^\text{st}$
-parameter has a default
-argument\iref{dcl.fct.default}.\footnote{According to~\ref{dcl.fct.default},
-parameters following the
-$\textit{(m+1)}^\text{st}$
-parameter must also have default arguments.}
-For the purposes of overload
-resolution, the parameter list is truncated on the right, so
-that there are exactly
-\textit{m}
-parameters.
+A candidate function having more than $m$ parameters
+is viable only if all parameters following the $m^\text{th}$ parameter
+have default arguments\iref{dcl.fct.default}.
+For the purposes of overload resolution,
+the parameter list is truncated on the right,
+so that there are exactly $m$ parameters.
 \end{itemize}
 
 \pnum


### PR DESCRIPTION
Fixes #3235 

See http://wiki.edg.com/bin/view/Wg21belfast/CoreWorkingGroup and http://wiki.edg.com/pub/Wg21belfast/CoreWorkingGroup/ed-3235.html .