### PR TITLE
[class.temporary] Fix typo in example.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4095,7 +4095,7 @@ On the other hand, the expression
 requires a temporary for
 the result of \tcode{f(a)},
 which is materialized so that the reference parameter
-of \tcode{A::operator=(const A\&)} can bind to it.
+of \tcode{X::operator=(const X\&)} can bind to it.
 \end{example}
 
 \pnum


### PR DESCRIPTION
Fixes #2967.