### PR TITLE
[expr.prim.id] Fix immediate function id-expression requirement

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1270,8 +1270,11 @@ int j = sizeof(S::m + 42);      // OK
 \pnum
 An \grammarterm{id-expression}
 that denotes an immediate function\iref{dcl.constexpr}
-shall appear as a subexpression of an immediate invocation or
-in an immediate function context\iref{expr.const}.
+shall appear only
+\begin{itemize}
+\item as a subexpression of an immediate invocation, or
+\item in an immediate function context\iref{expr.const}.
+\end{itemize}
 
 \pnum
 An \grammarterm{id-expression}


### PR DESCRIPTION
Reason for being editorial: It is probably not the committee's intent to require all programs to use "an id-expression that denotes an immediate function".