### PR TITLE
Avoid confusion between lookup and overall overload resolution

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -6852,7 +6852,7 @@ is defined as follows:
 \begin{itemize}
 \item
 If overload resolution for \tcode{a <=> b}
-finds a usable function\iref{over.match},
+results in a usable function\iref{over.match},
 \tcode{static_cast<R>(a <=> b)}.
 
 \item


### PR DESCRIPTION
When I read "finds a usable function" in P1186r3, I wondered whether we should check this at lookup or viability time. However, "usable function" is really more precisely defined for the _ overall result_ of overload resolution.  I think we should just stick to that phrasing.