### PR TITLE
Change type-id to defining-type-id [temp.alias] p4

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -3882,7 +3882,7 @@ f<int>();           // error, \tcode{int} does not have a nested type \tcode{foo
 \end{example}
 
 \pnum
-The \grammarterm{type-id} in an alias template declaration shall not refer to
+The \grammarterm{defining-type-id} in an alias template declaration shall not refer to
 the alias template being declared. The type produced by an alias template
 specialization shall not directly or indirectly make use of that specialization.
 \begin{example}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -3840,7 +3840,7 @@ types. The name of the alias template is a \grammarterm{template-name}.
 When a \grammarterm{template-id} refers to the specialization of
 an alias template, it is equivalent to the associated type obtained by
 substitution of its \grammarterm{template-argument}{s} for the
-\grammarterm{template-parameter}{s} in the \grammarterm{type-id} of
+\grammarterm{template-parameter}{s} in the \grammarterm{defining-type-id} of
 the alias template.
 \begin{note} An alias template name is never deduced.\end{note}
 \begin{example}


### PR DESCRIPTION
An alias declaration contains no type-id, its a defining-type-id.