### PR TITLE
[temp.spec] Make "specialization" a proper definition & adjust definition.

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -5699,8 +5699,9 @@ An instantiated template specialization can be either implicitly
 instantiated\iref{temp.inst} for a given argument list or be explicitly
 instantiated\iref{temp.explicit}.
 A \defn{specialization} is a class, variable, function, or class member that is either
-instantiated\iref{temp.inst} from a template or an
-explicit specialization\iref{temp.expl.spec} of a template.
+instantiated\iref{temp.inst} from a
+templated entity\iref{temp.pre} or an
+explicit specialization\iref{temp.expl.spec} of a templated entity.
 
 \pnum
 For a given template and a given set of

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -5698,8 +5698,9 @@ template<> int B<>::x = 1;              // specialize for \tcode{T == int}
 An instantiated template specialization can be either implicitly
 instantiated\iref{temp.inst} for a given argument list or be explicitly
 instantiated\iref{temp.explicit}.
-A \defn{specialization} is a type, variable, function, or class member that is either
-instantiated from a template or specialized for by an explicit specialization\iref{temp.expl.spec}.
+A \defn{specialization} is a class, variable, function, or class member that is either
+instantiated\iref{temp.inst} from a template or produced by an 
+explicit specialization\iref{temp.expl.spec} of a template.
 
 \pnum
 For a given template and a given set of

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -5699,8 +5699,7 @@ An instantiated template specialization can be either implicitly
 instantiated\iref{temp.inst} for a given argument list or be explicitly
 instantiated\iref{temp.explicit}.
 A \defn{specialization} is a class, variable, function, or class member that is either
-instantiated\iref{temp.inst} from a
-templated entity\iref{temp.pre} or an
+instantiated\iref{temp.inst} from a templated entity or an
 explicit specialization\iref{temp.expl.spec} of a templated entity.
 
 \pnum

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -5699,7 +5699,7 @@ An instantiated template specialization can be either implicitly
 instantiated\iref{temp.inst} for a given argument list or be explicitly
 instantiated\iref{temp.explicit}.
 A \defn{specialization} is a class, variable, function, or class member that is either
-instantiated\iref{temp.inst} from a template or produced by an 
+instantiated\iref{temp.inst} from a template or an
 explicit specialization\iref{temp.expl.spec} of a template.
 
 \pnum

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -5698,8 +5698,8 @@ template<> int B<>::x = 1;              // specialize for \tcode{T == int}
 An instantiated template specialization can be either implicitly
 instantiated\iref{temp.inst} for a given argument list or be explicitly
 instantiated\iref{temp.explicit}.
-A specialization is a class, variable, function, or class member that is either
-instantiated or explicitly specialized\iref{temp.expl.spec}.
+A \defn{specialization} is a type, variable, function, or class member that is either
+instantiated from a template or specialized for by an explicit specialization\iref{temp.expl.spec}.
 
 \pnum
 For a given template and a given set of

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -5699,7 +5699,7 @@ An instantiated template specialization can be either implicitly
 instantiated\iref{temp.inst} for a given argument list or be explicitly
 instantiated\iref{temp.explicit}.
 A \defn{specialization} is a class, variable, function, or class member that is either
-instantiated\iref{temp.inst} from a templated entity or an
+instantiated\iref{temp.inst} from a templated entity or is an
 explicit specialization\iref{temp.expl.spec} of a templated entity.
 
 \pnum


### PR DESCRIPTION
*Specialization* is the second most common term that is defined and used in [temp]. The definition in [temp.spec] p4 should be italicized to make it a proper definition. Also, the phrase " function, or class member that is [...] explicitly specialized" is incorrect: templates are explicitly specialized, not classes, functions etc (in some cases non-templates too, but rarely).

Additionally, a *specialization* of a alias template (such as the use here: http://eel.is/c++draft/temp.alias#2) is meaningless for non-class types. Consider the following:
```
template<typename T>
using A = int;
```

A specialization is a class, function, variable, or class member. The type denoted (if you could even say that, since its replaced) by the simple-template-id `A<void>` is none of these.