### PR TITLE
[class.copy.elision] Fix the contradiction introduced by CWG 2278

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -6597,7 +6597,7 @@ constexpr A g() {
 }
 
 constexpr A a;          // well-formed, \tcode{a.p} points to \tcode{a}
-constexpr A b = g();    // error, \tcode{b.p} would point to an automatic object
+constexpr A b = g();    // error, \tcode{b.p} would point to a storage whose duration has ended
 
 void h() {
   A c = g();            // well-formed, \tcode{c.p} may point to \tcode{c} or to an ephemeral temporary

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -6592,12 +6592,12 @@ struct A {
 };
 
 constexpr A g() {
-  A a;
-  return a;
+  A loc;
+  return loc;
 }
 
 constexpr A a;          // well-formed, \tcode{a.p} points to \tcode{a}
-constexpr A b = g();    // well-formed, \tcode{b.p} points to \tcode{b}
+constexpr A b = g();    // error, \tcode{b.p} would point to an automatic object
 
 void h() {
   A c = g();            // well-formed, \tcode{c.p} may point to \tcode{c} or to an ephemeral temporary

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -6597,7 +6597,7 @@ constexpr A g() {
 }
 
 constexpr A a;          // well-formed, \tcode{a.p} points to \tcode{a}
-constexpr A b = g();    // error, \tcode{b.p} would point to a storage whose duration has ended
+constexpr A b = g();    // error: \tcode{b.p} would be dangling\iref{expr.const}
 
 void h() {
   A c = g();            // well-formed, \tcode{c.p} may point to \tcode{c} or to an ephemeral temporary


### PR DESCRIPTION
Fixes #3117.
Additionally avoid duplication of name "a". 