### PR TITLE
[list.ops] Fix misapplication of P1463R1, "!=" should be "==".

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -5407,8 +5407,8 @@ template<class Compare> void merge(list&& x, Compare comp);
 Both the list and the argument list
 shall be sorted with respect to
 the comparator \tcode{operator<} (for the first two overloads) or
-\tcode{comp} (for the last two overloads).
-\tcode{get_allocator() != x.get_allocator()} is \tcode{true}.
+\tcode{comp} (for the last two overloads), and
+\tcode{get_allocator() == x.get_allocator()} is \tcode{true}.
 
 \pnum
 \effects


### PR DESCRIPTION
Misapplication in 019baa941945c1c8529fcaa0288ed5e98944f7a4.

Also restore the edit "." -> ", and".

Fixes #3257.