### PR TITLE
[lib] Remove parameter names from deleted special member functions.

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -4235,11 +4235,11 @@ namespace std {
 
   protected:
     // \ref{istream.cons}, copy/move constructor
-    basic_istream(const basic_istream& rhs) = delete;
+    basic_istream(const basic_istream&) = delete;
     basic_istream(basic_istream&& rhs);
 
     // \ref{istream.assign}, assign and swap
-    basic_istream& operator=(const basic_istream& rhs) = delete;
+    basic_istream& operator=(const basic_istream&) = delete;
     basic_istream& operator=(basic_istream&& rhs);
     void swap(basic_istream& rhs);
   };
@@ -5625,11 +5625,11 @@ namespace std {
 
   protected:
     // \ref{iostream.cons}, constructor
-    basic_iostream(const basic_iostream& rhs) = delete;
+    basic_iostream(const basic_iostream&) = delete;
     basic_iostream(basic_iostream&& rhs);
 
     // \ref{iostream.assign}, assign and swap
-    basic_iostream& operator=(const basic_iostream& rhs) = delete;
+    basic_iostream& operator=(const basic_iostream&) = delete;
     basic_iostream& operator=(basic_iostream&& rhs);
     void swap(basic_iostream& rhs);
   };
@@ -5789,11 +5789,11 @@ namespace std {
 
   protected:
     // \ref{ostream.cons}, copy/move constructor
-    basic_ostream(const basic_ostream& rhs) = delete;
+    basic_ostream(const basic_ostream&) = delete;
     basic_ostream(basic_ostream&& rhs);
 
     // \ref{ostream.assign}, assign and swap
-    basic_ostream& operator=(const basic_ostream& rhs) = delete;
+    basic_ostream& operator=(const basic_ostream&) = delete;
     basic_ostream& operator=(basic_ostream&& rhs);
     void swap(basic_ostream& rhs);
   };
@@ -7443,12 +7443,12 @@ namespace std {
       explicit basic_stringbuf(
         const basic_string<charT, traits, SAlloc>& s,
         ios_base::openmode which = ios_base::in | ios_base::out);
-    basic_stringbuf(const basic_stringbuf& rhs) = delete;
+    basic_stringbuf(const basic_stringbuf&) = delete;
     basic_stringbuf(basic_stringbuf&& rhs);
     basic_stringbuf(basic_stringbuf&& rhs, const Allocator& a);
 
     // \ref{stringbuf.assign}, assign and swap
-    basic_stringbuf& operator=(const basic_stringbuf& rhs) = delete;
+    basic_stringbuf& operator=(const basic_stringbuf&) = delete;
     basic_stringbuf& operator=(basic_stringbuf&& rhs);
     void swap(basic_stringbuf& rhs) noexcept(@\seebelow@);
 
@@ -8244,11 +8244,11 @@ namespace std {
       explicit basic_istringstream(
         const basic_string<charT, traits, SAlloc>& s,
         ios_base::openmode which = ios_base::in);
-    basic_istringstream(const basic_istringstream& rhs) = delete;
+    basic_istringstream(const basic_istringstream&) = delete;
     basic_istringstream(basic_istringstream&& rhs);
 
     // \ref{istringstream.assign}, assign and swap
-    basic_istringstream& operator=(const basic_istringstream& rhs) = delete;
+    basic_istringstream& operator=(const basic_istringstream&) = delete;
     basic_istringstream& operator=(basic_istringstream&& rhs);
     void swap(basic_istringstream& rhs);
 
@@ -8577,11 +8577,11 @@ namespace std {
       explicit basic_ostringstream(
         const basic_string<charT, traits, SAlloc>& s,
         ios_base::openmode which = ios_base::out);
-    basic_ostringstream(const basic_ostringstream& rhs) = delete;
+    basic_ostringstream(const basic_ostringstream&) = delete;
     basic_ostringstream(basic_ostringstream&& rhs);
 
     // \ref{ostringstream.assign}, assign and swap
-    basic_ostringstream& operator=(const basic_ostringstream& rhs) = delete;
+    basic_ostringstream& operator=(const basic_ostringstream&) = delete;
     basic_ostringstream& operator=(basic_ostringstream&& rhs);
     void swap(basic_ostringstream& rhs);
 
@@ -8914,11 +8914,11 @@ namespace std {
       explicit basic_stringstream(
         const basic_string<charT, traits, SAlloc>& s,
         ios_base::openmode which = ios_base::out | ios_base::in);
-    basic_stringstream(const basic_stringstream& rhs) = delete;
+    basic_stringstream(const basic_stringstream&) = delete;
     basic_stringstream(basic_stringstream&& rhs);
 
     // \ref{stringstream.assign}, assign and swap
-    basic_stringstream& operator=(const basic_stringstream& rhs) = delete;
+    basic_stringstream& operator=(const basic_stringstream&) = delete;
     basic_stringstream& operator=(basic_stringstream&& rhs);
     void swap(basic_stringstream& rhs);
 
@@ -9299,12 +9299,12 @@ namespace std {
 
     // \ref{filebuf.cons}, constructors/destructor
     basic_filebuf();
-    basic_filebuf(const basic_filebuf& rhs) = delete;
+    basic_filebuf(const basic_filebuf&) = delete;
     basic_filebuf(basic_filebuf&& rhs);
     virtual ~basic_filebuf();
 
     // \ref{filebuf.assign}, assign and swap
-    basic_filebuf& operator=(const basic_filebuf& rhs) = delete;
+    basic_filebuf& operator=(const basic_filebuf&) = delete;
     basic_filebuf& operator=(basic_filebuf&& rhs);
     void swap(basic_filebuf& rhs);
 
@@ -10079,11 +10079,11 @@ namespace std {
                             ios_base::openmode mode = ios_base::in);
     explicit basic_ifstream(const filesystem::path& s,
                             ios_base::openmode mode = ios_base::in);
-    basic_ifstream(const basic_ifstream& rhs) = delete;
+    basic_ifstream(const basic_ifstream&) = delete;
     basic_ifstream(basic_ifstream&& rhs);
 
     // \ref{ifstream.assign}, assign and swap
-    basic_ifstream& operator=(const basic_ifstream& rhs) = delete;
+    basic_ifstream& operator=(const basic_ifstream&) = delete;
     basic_ifstream& operator=(basic_ifstream&& rhs);
     void swap(basic_ifstream& rhs);
 
@@ -10335,11 +10335,11 @@ namespace std {
                             ios_base::openmode mode = ios_base::out);
     explicit basic_ofstream(const filesystem::path& s,
                             ios_base::openmode mode = ios_base::out);
-    basic_ofstream(const basic_ofstream& rhs) = delete;
+    basic_ofstream(const basic_ofstream&) = delete;
     basic_ofstream(basic_ofstream&& rhs);
 
     // \ref{ofstream.assign}, assign and swap
-    basic_ofstream& operator=(const basic_ofstream& rhs) = delete;
+    basic_ofstream& operator=(const basic_ofstream&) = delete;
     basic_ofstream& operator=(basic_ofstream&& rhs);
     void swap(basic_ofstream& rhs);
 
@@ -10593,11 +10593,11 @@ namespace std {
     explicit basic_fstream(
       const filesystem::path& s,
       ios_base::openmode mode = ios_base::in | ios_base::out);
-    basic_fstream(const basic_fstream& rhs) = delete;
+    basic_fstream(const basic_fstream&) = delete;
     basic_fstream(basic_fstream&& rhs);
 
     // \ref{fstream.assign}, assign and swap
-    basic_fstream& operator=(const basic_fstream& rhs) = delete;
+    basic_fstream& operator=(const basic_fstream&) = delete;
     basic_fstream& operator=(basic_fstream&& rhs);
     void swap(basic_fstream& rhs);
 

--- a/source/support.tex
+++ b/source/support.tex
@@ -3064,8 +3064,8 @@ namespace std {
     size_t hash_code() const noexcept;
     const char* name() const noexcept;
 
-    type_info(const type_info& rhs) = delete;                   // cannot be copied
-    type_info& operator=(const type_info& rhs) = delete;        // cannot be copied
+    type_info(const type_info&) = delete;                   // cannot be copied
+    type_info& operator=(const type_info&) = delete;        // cannot be copied
   };
 }
 \end{codeblock}

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -6085,12 +6085,12 @@ namespace std {
     template<class Allocator>
       promise(allocator_arg_t, const Allocator& a);
     promise(promise&& rhs) noexcept;
-    promise(const promise& rhs) = delete;
+    promise(const promise&) = delete;
     ~promise();
 
     // assignment
     promise& operator=(promise&& rhs) noexcept;
-    promise& operator=(const promise& rhs) = delete;
+    promise& operator=(const promise&) = delete;
     void swap(promise& other) noexcept;
 
     // retrieving the result
@@ -6434,9 +6434,9 @@ namespace std {
   public:
     future() noexcept;
     future(future&&) noexcept;
-    future(const future& rhs) = delete;
+    future(const future&) = delete;
     ~future();
-    future& operator=(const future& rhs) = delete;
+    future& operator=(const future&) = delete;
     future& operator=(future&&) noexcept;
     shared_future<R> share() noexcept;
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -12727,7 +12727,7 @@ namespace std::pmr {
     template<class U>
       polymorphic_allocator(const polymorphic_allocator<U>& other) noexcept;
 
-    polymorphic_allocator& operator=(const polymorphic_allocator& rhs) = delete;
+    polymorphic_allocator& operator=(const polymorphic_allocator&) = delete;
 
     // \ref{mem.poly.allocator.mem}, member functions
     [[nodiscard]] Tp* allocate(size_t n);

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -50,6 +50,10 @@ for f in $texfiles; do
 done | grep . && exit 1
 # Fixup: sed '/\\begin{example}/{N;s/\n$//}'
 
+# Deleted special member function with a parameter name.
+grep -n "&[ 0-9a-z_]\+) = delete" $texfiles && exit 1
+# to fix: sed '/= delete/s/&[ 0-9a-z_]\+)/\&)/'
+
 # \placeholder before (
 #egrep 'placeholder{[-A-Za-z]*}@?\(' *.tex
 # to fix: sed -i 's/placeholder\({[-A-Za-z]*}@\?(\)/placeholdernc\1/g' *.tex


### PR DESCRIPTION
Partially addresses #3255.