### PR TITLE
[alg.search] search_n. Use consistent wording with search

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -3998,7 +3998,8 @@ The first iterator \tcode{i} in the range \range{first}{last-count}
 such that for every non-negative integer \tcode{n} less than \tcode{count}
 the following corresponding conditions hold:
 \tcode{*(i + n) == value, pred(*(i + n),value) != false}.
-Returns \tcode{last} if no such iterator is found.
+Returns \tcode{first} if \tcode{count <= 0},
+otherwise returns \tcode{last} if no such iterator is found.
 
 \pnum
 \complexity


### PR DESCRIPTION
Hi,
For the `search_n` algorithm the Standard says:
> Returns: The first iterator i in the range [first, last-count) such that for every non-negative integer n less than count the following corresponding conditions hold: (i + n) == value, pred((i+ n),value) != false. Returns last if no such iterator is found.

It seems that if `n>=0` and `count <=0` we don't have a chance to apply a predicate. So, we won't find "such iterator". According to this logic `last` should be returned. However, [libcxx ](https://github.com/llvm-mirror/libcxx/blob/master/include/algorithm) and [Microsoft's C++ Standard Library](https://github.com/microsoft/STL/blob/master/stl/inc/algorithm) returns `first`. According to [the issue](https://github.com/microsoft/STL/issues/148) there was a different interpretation of `search_n` wording.

Moreover, `search` returns `first` in the same case. I hope it's just an editorial issue.