### PR TITLE
[basic.lval] Non-static member function designator is a prvalue CWG2458

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -147,7 +147,9 @@ Expressions are categorized according to the taxonomy in \fref{basic.lval}.
 \end{importgraphic}
 
 \begin{itemize}
-\item A \defn{glvalue} is an expression whose evaluation determines the identity of an object or function.
+\item A \defn{glvalue} is an expression whose evaluation determines the identity of an object,
+a function other than a non-static member function,
+a non-static member function if the expression is the operand of a unary \tcode{\&} operator.
 \item A \defn{prvalue} is an expression whose evaluation initializes an object
 or computes the value of an operand of an operator,
 as specified by the context in which it appears,


### PR DESCRIPTION
[[expr.ref]/6.3.2](http://eel.is/c++draft/expr.ref#6.3.2):
> if `E1.E2` refers to a non-static member function and the type of `E2` is “...”, then `E1.E2` is a prvalue. The expression designates a non-static member function.