### PR TITLE
[expr.typeid] Add note highlighting prohibition of bad function types.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3566,6 +3566,10 @@ to a possibly cv-qualified type, the result of the
 representing the cv-unqualified referenced type. If the type of
 the \grammarterm{type-id} is a class type or a reference to a class type,
 the class shall be completely-defined.
+\begin{note}
+The \grammarterm{type-id} cannot denote a function type with
+a \grammarterm{cv-qualifier-seq} or a \grammarterm{ref-qualifier}\iref{dcl.fct}.
+\end{note}
 
 \pnum
 If the type of the expression or \grammarterm{type-id} is a


### PR DESCRIPTION
Function types that can only be used for member functions
(because they have cv-qualifiers or a ref-qualifier)
cannot appear as a typeid operand.

Fixes #3260.