### PR TITLE
[atomics] Reorder members of atomic, atomic_ref, atomic_flag

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -713,20 +713,20 @@ namespace std {
     T* ptr;             // \expos
   public:
     using value_type = T;
-    static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic_ref} type's operations are always lock free}@;
     static constexpr size_t required_alignment = @\impdefx{required alignment for \tcode{atomic_ref} type's operations}@;
 
-    atomic_ref& operator=(const atomic_ref&) = delete;
+    static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic_ref} type's operations are always lock free}@;
+    bool is_lock_free() const noexcept;
 
     explicit atomic_ref(T&);
     atomic_ref(const atomic_ref&) noexcept;
+    atomic_ref& operator=(const atomic_ref&) = delete;
 
+    void store(T, memory_order = memory_order_seq_cst) const noexcept;
     T operator=(T) const noexcept;
+    T load(memory_order = memory_order_seq_cst) const noexcept;
     operator T() const noexcept;
 
-    bool is_lock_free() const noexcept;
-    void store(T, memory_order = memory_order_seq_cst) const noexcept;
-    T load(memory_order = memory_order_seq_cst) const noexcept;
     T exchange(T, memory_order = memory_order_seq_cst) const noexcept;
     bool compare_exchange_weak(T&, T,
                                memory_order, memory_order) const noexcept;
@@ -736,6 +736,7 @@ namespace std {
                                memory_order = memory_order_seq_cst) const noexcept;
     bool compare_exchange_strong(T&, T,
                                  memory_order = memory_order_seq_cst) const noexcept;
+
     void wait(T, memory_order = memory_order::seq_cst) const noexcept;
     void notify_one() noexcept;
     void notify_all() noexcept;
@@ -776,21 +777,6 @@ to enable atomic operations to be applied to the referenced object.
 
 \rSec2[atomics.ref.operations]{Operations}
 
-\indexlibrarymember{is_always_lock_free}{atomic_ref}%
-\indexlibrarymember{is_always_lock_free}{atomic_ref<T*>}%
-\indexlibrarymember{is_always_lock_free}{atomic_ref<\placeholder{integral}>}%
-\indexlibrarymember{is_always_lock_free}{atomic_ref<\placeholder{floating-point}>}%
-\begin{itemdecl}
-static constexpr bool is_always_lock_free;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-The static data member \tcode{is_always_lock_free} is \tcode{true}
-if the \tcode{atomic_ref} type's operations are always lock-free,
-and \tcode{false} otherwise.
-\end{itemdescr}
-
 \indexlibrarymember{required_alignment}{atomic_ref}%
 \indexlibrarymember{required_alignment}{atomic_ref<T*>}%
 \indexlibrarymember{required_alignment}{atomic_ref<\placeholder{integral}>}%
@@ -815,6 +801,36 @@ are lock-free could depend on the alignment of the referenced object.
 For example, lock-free operations on \tcode{std::complex<double>}
 could be supported only if aligned to \tcode{2*alignof(double)}.
 \end{note}
+\end{itemdescr}
+
+\indexlibrarymember{is_always_lock_free}{atomic_ref}%
+\indexlibrarymember{is_always_lock_free}{atomic_ref<T*>}%
+\indexlibrarymember{is_always_lock_free}{atomic_ref<\placeholder{integral}>}%
+\indexlibrarymember{is_always_lock_free}{atomic_ref<\placeholder{floating-point}>}%
+\begin{itemdecl}
+static constexpr bool is_always_lock_free;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+The static data member \tcode{is_always_lock_free} is \tcode{true}
+if the \tcode{atomic_ref} type's operations are always lock-free,
+and \tcode{false} otherwise.
+\end{itemdescr}
+
+\indexlibrarymember{is_lock_free}{atomic_ref}%
+\indexlibrarymember{is_lock_free}{atomic_ref<T*>}%
+\indexlibrarymember{is_lock_free}{atomic_ref<\placeholder{integral}>}%
+\indexlibrarymember{is_lock_free}{atomic_ref<\placeholder{floating-point}>}%
+\begin{itemdecl}
+bool is_lock_free() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\tcode{true} if the object's operations are lock-free,
+\tcode{false} otherwise.
 \end{itemdescr}
 
 \indexlibraryctor{atomic_ref}%
@@ -853,53 +869,6 @@ Constructs an atomic reference
 that references the object referenced by \tcode{ref}.
 \end{itemdescr}
 
-\indexlibrarymember{operator=}{atomic_ref}%
-\indexlibrarymember{operator=}{atomic_ref<T*>}%
-\indexlibrarymember{operator=}{atomic_ref<\placeholder{integral}>}%
-\indexlibrarymember{operator=}{atomic_ref<\placeholder{floating-point}>}%
-\begin{itemdecl}
-T operator=(T desired) const noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-Equivalent to:
-\begin{codeblock}
-store(desired);
-return desired;
-\end{codeblock}
-\end{itemdescr}
-
-\indexlibrarymember{operator \placeholder{type}}{atomic_ref}%
-\indexlibrarymember{operator T*}{atomic_ref<T*>}%
-\indexlibrarymember{operator \placeholder{integral}}{atomic_ref<\placeholder{integral}>}%
-\indexlibrarymember{operator \placeholder{floating-point}}{atomic_ref<\placeholder{floating-point}>}%
-\begin{itemdecl}
-operator T() const noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-Equivalent to: \tcode{return load();}
-\end{itemdescr}
-
-\indexlibrarymember{is_lock_free}{atomic_ref}%
-\indexlibrarymember{is_lock_free}{atomic_ref<T*>}%
-\indexlibrarymember{is_lock_free}{atomic_ref<\placeholder{integral}>}%
-\indexlibrarymember{is_lock_free}{atomic_ref<\placeholder{floating-point}>}%
-\begin{itemdecl}
-bool is_lock_free() const noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-\tcode{true} if the object's operations are lock-free,
-\tcode{false} otherwise.
-\end{itemdescr}
-
 \indexlibrarymember{store}{atomic_ref}%
 \indexlibrarymember{store}{atomic_ref<T*>}%
 \indexlibrarymember{store}{atomic_ref<\placeholder{integral}>}%
@@ -922,6 +891,24 @@ with the value of \tcode{desired}.
 Memory is affected according to the value of \tcode{order}.
 \end{itemdescr}
 
+\indexlibrarymember{operator=}{atomic_ref}%
+\indexlibrarymember{operator=}{atomic_ref<T*>}%
+\indexlibrarymember{operator=}{atomic_ref<\placeholder{integral}>}%
+\indexlibrarymember{operator=}{atomic_ref<\placeholder{floating-point}>}%
+\begin{itemdecl}
+T operator=(T desired) const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to:
+\begin{codeblock}
+store(desired);
+return desired;
+\end{codeblock}
+\end{itemdescr}
+
 \indexlibrarymember{load}{atomic_ref}%
 \indexlibrarymember{load}{atomic_ref<T*>}%
 \indexlibrarymember{load}{atomic_ref<\placeholder{integral}>}%
@@ -942,6 +929,20 @@ Memory is affected according to the value of \tcode{order}.
 \pnum
 \returns
 Atomically returns the value referenced by \tcode{*ptr}.
+\end{itemdescr}
+
+\indexlibrarymember{operator \placeholder{type}}{atomic_ref}%
+\indexlibrarymember{operator T*}{atomic_ref<T*>}%
+\indexlibrarymember{operator \placeholder{integral}}{atomic_ref<\placeholder{integral}>}%
+\indexlibrarymember{operator \placeholder{floating-point}}{atomic_ref<\placeholder{floating-point}>}%
+\begin{itemdecl}
+operator T() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return load();}
 \end{itemdescr}
 
 \indexlibrarymember{exchange}{atomic_ref}%
@@ -1149,20 +1150,20 @@ namespace std {
   public:
     using value_type = @\placeholder{integral}@;
     using difference_type = value_type;
-    static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic_ref} type's operations are always lock free}@;
     static constexpr size_t required_alignment = @\impdefx{required alignment for \tcode{atomic_ref} type's operations}@;
 
-    atomic_ref& operator=(const atomic_ref&) = delete;
+    static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic_ref} type's operations are always lock free}@;
+    bool is_lock_free() const noexcept;
 
     explicit atomic_ref(@\placeholder{integral}@&);
     atomic_ref(const atomic_ref&) noexcept;
+    atomic_ref& operator=(const atomic_ref&) = delete;
 
+    void store(@\placeholdernc{integral}@, memory_order = memory_order_seq_cst) const noexcept;
     @\placeholdernc{integral}@ operator=(@\placeholder{integral}@) const noexcept;
+    @\placeholdernc{integral}@ load(memory_order = memory_order_seq_cst) const noexcept;
     operator @\placeholdernc{integral}@() const noexcept;
 
-    bool is_lock_free() const noexcept;
-    void store(@\placeholdernc{integral}@, memory_order = memory_order_seq_cst) const noexcept;
-    @\placeholdernc{integral}@ load(memory_order = memory_order_seq_cst) const noexcept;
     @\placeholdernc{integral}@ exchange(@\placeholdernc{integral}@,
                       memory_order = memory_order_seq_cst) const noexcept;
     bool compare_exchange_weak(@\placeholder{integral}@&, @\placeholder{integral}@,
@@ -1185,10 +1186,6 @@ namespace std {
     @\placeholdernc{integral}@ fetch_xor(@\placeholdernc{integral}@,
                        memory_order = memory_order_seq_cst) const noexcept;
 
-    void wait(@\placeholdernc{integral}@, memory_order = memory_order::seq_cst) const noexcept;
-    void notify_one() noexcept;
-    void notify_all() noexcept;
-
     @\placeholdernc{integral}@ operator++(int) const noexcept;
     @\placeholdernc{integral}@ operator--(int) const noexcept;
     @\placeholdernc{integral}@ operator++() const noexcept;
@@ -1198,6 +1195,10 @@ namespace std {
     @\placeholdernc{integral}@ operator&=(@\placeholdernc{integral}@) const noexcept;
     @\placeholdernc{integral}@ operator|=(@\placeholdernc{integral}@) const noexcept;
     @\placeholdernc{integral}@ operator^=(@\placeholdernc{integral}@) const noexcept;
+
+    void wait(@\placeholdernc{integral}@, memory_order = memory_order::seq_cst) const noexcept;
+    void notify_one() noexcept;
+    void notify_all() noexcept;
   };
 }
 \end{codeblock}
@@ -1284,20 +1285,20 @@ namespace std {
   public:
     using value_type = @\placeholder{floating-point}@;
     using difference_type = value_type;
-    static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic_ref} type's operations are always lock free}@;
     static constexpr size_t required_alignment = @\impdefx{required alignment for \tcode{atomic_ref} type's operations}@;
 
-    atomic_ref& operator=(const atomic_ref&) = delete;
+    static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic_ref} type's operations are always lock free}@;
+    bool is_lock_free() const noexcept;
 
     explicit atomic_ref(@\placeholder{floating-point}@&);
     atomic_ref(const atomic_ref&) noexcept;
+    atomic_ref& operator=(const atomic_ref&) = delete;
 
+    void store(@\placeholdernc{floating-point}@, memory_order = memory_order_seq_cst) const noexcept;
     @\placeholder{floating-point}@ operator=(@\placeholder{floating-point}@) noexcept;
+    @\placeholder{floating-point}@ load(memory_order = memory_order_seq_cst) const noexcept;
     operator @\placeholdernc{floating-point}@() const noexcept;
 
-    bool is_lock_free() const noexcept;
-    void store(@\placeholdernc{floating-point}@, memory_order = memory_order_seq_cst) const noexcept;
-    @\placeholder{floating-point}@ load(memory_order = memory_order_seq_cst) const noexcept;
     @\placeholder{floating-point}@ exchange(@\placeholdernc{floating-point}@,
                             memory_order = memory_order_seq_cst) const noexcept;
     bool compare_exchange_weak(@\placeholder{floating-point}@&, @\placeholdernc{floating-point}@,
@@ -1314,12 +1315,12 @@ namespace std {
     @\placeholder{floating-point}@ fetch_sub(@\placeholdernc{floating-point}@,
                              memory_order = memory_order_seq_cst) const noexcept;
 
+    @\placeholder{floating-point}@ operator+=(@\placeholder{floating-point}@) const noexcept;
+    @\placeholder{floating-point}@ operator-=(@\placeholder{floating-point}@) const noexcept;
+
     void wait(@\placeholdernc{floating-point}@, memory_order = memory_order::seq_cst) const noexcept;
     void notify_one() noexcept;
     void notify_all() noexcept;
-
-    @\placeholder{floating-point}@ operator+=(@\placeholder{floating-point}@) const noexcept;
-    @\placeholder{floating-point}@ operator-=(@\placeholder{floating-point}@) const noexcept;
   };
 }
 \end{codeblock}
@@ -1390,20 +1391,20 @@ namespace std {
   public:
     using value_type = T*;
     using difference_type = ptrdiff_t;
-    static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic_ref} type's operations are always lock free}@;
     static constexpr size_t required_alignment = @\impdefx{required alignment for \tcode{atomic_ref} type's operations}@;
 
-    atomic_ref& operator=(const atomic_ref&) = delete;
+    static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic_ref} type's operations are always lock free}@;
+    bool is_lock_free() const noexcept;
 
     explicit atomic_ref(T*&);
     atomic_ref(const atomic_ref&) noexcept;
+    atomic_ref& operator=(const atomic_ref&) = delete;
 
+    void store(T*, memory_order = memory_order_seq_cst) const noexcept;
     T* operator=(T*) const noexcept;
+    T* load(memory_order = memory_order_seq_cst) const noexcept;
     operator T*() const noexcept;
 
-    bool is_lock_free() const noexcept;
-    void store(T*, memory_order = memory_order_seq_cst) const noexcept;
-    T* load(memory_order = memory_order_seq_cst) const noexcept;
     T* exchange(T*, memory_order = memory_order_seq_cst) const noexcept;
     bool compare_exchange_weak(T*&, T*,
                                memory_order, memory_order) const noexcept;
@@ -1417,16 +1418,16 @@ namespace std {
     T* fetch_add(difference_type, memory_order = memory_order_seq_cst) const noexcept;
     T* fetch_sub(difference_type, memory_order = memory_order_seq_cst) const noexcept;
 
-    void wait(T*, memory_order = memory_order::seq_cst) const noexcept;
-    void notify_one() noexcept;
-    void notify_all() noexcept;
-
     T* operator++(int) const noexcept;
     T* operator--(int) const noexcept;
     T* operator++() const noexcept;
     T* operator--() const noexcept;
     T* operator+=(difference_type) const noexcept;
     T* operator-=(difference_type) const noexcept;
+
+    void wait(T*, memory_order = memory_order::seq_cst) const noexcept;
+    void notify_one() noexcept;
+    void notify_all() noexcept;
   };
 }
 \end{codeblock}
@@ -1542,15 +1543,26 @@ Equivalent to: \tcode{return fetch_sub(1) - 1;}
 namespace std {
   template<class T> struct atomic {
     using value_type = T;
+
     static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic} type's operations are always lock free}@;
     bool is_lock_free() const volatile noexcept;
     bool is_lock_free() const noexcept;
-    void store(T, memory_order = memory_order::seq_cst) volatile noexcept;
-    void store(T, memory_order = memory_order::seq_cst) noexcept;
+
+    atomic() noexcept = default;
+    constexpr atomic(T) noexcept;
+    atomic(const atomic&) = delete;
+    atomic& operator=(const atomic&) = delete;
+    atomic& operator=(const atomic&) volatile = delete;
+
     T load(memory_order = memory_order::seq_cst) const volatile noexcept;
     T load(memory_order = memory_order::seq_cst) const noexcept;
     operator T() const volatile noexcept;
     operator T() const noexcept;
+    void store(T, memory_order = memory_order::seq_cst) volatile noexcept;
+    void store(T, memory_order = memory_order::seq_cst) noexcept;
+    T operator=(T) volatile noexcept;
+    T operator=(T) noexcept;
+
     T exchange(T, memory_order = memory_order::seq_cst) volatile noexcept;
     T exchange(T, memory_order = memory_order::seq_cst) noexcept;
     bool compare_exchange_weak(T&, T, memory_order, memory_order) volatile noexcept;
@@ -1568,14 +1580,6 @@ namespace std {
     void notify_one() noexcept;
     void notify_all() volatile noexcept;
     void notify_all() noexcept;
-
-    atomic() noexcept = default;
-    constexpr atomic(T) noexcept;
-    atomic(const atomic&) = delete;
-    atomic& operator=(const atomic&) = delete;
-    atomic& operator=(const atomic&) volatile = delete;
-    T operator=(T) volatile noexcept;
-    T operator=(T) noexcept;
   };
 }
 \end{codeblock}
@@ -1618,6 +1622,29 @@ preserved when applying these operations to volatile objects. It does not mean t
 operations on non-volatile objects become volatile.
 \end{note}
 
+\indexlibraryglobal{ATOMIC_VAR_INIT}%
+\begin{itemdecl}
+#define ATOMIC_VAR_INIT(value) @\seebelow@
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+The macro expands to a token sequence suitable for
+constant initialization of
+an atomic variable of static storage duration of a type that is
+initialization-compatible with \tcode{value}.
+\begin{note}
+This operation may need to initialize locks.
+\end{note}
+Concurrent access to the variable being initialized, even via an atomic operation,
+constitutes a data race.
+\begin{example}
+\begin{codeblock}
+atomic<int> v = ATOMIC_VAR_INIT(5);
+\end{codeblock}
+\end{example}
+\end{itemdescr}
+
 \indexlibraryctor{atomic}%
 \indexlibraryctor{atomic<T*>}%
 \indexlibrary{\idxcode{atomic<\placeholder{integral}>}!constructor}%
@@ -1656,29 +1683,6 @@ just-constructed object \tcode{A} to another thread via
 variable, and then immediately accessing \tcode{A} in the receiving thread.
 This results in undefined behavior.
 \end{note}
-\end{itemdescr}
-
-\indexlibraryglobal{ATOMIC_VAR_INIT}%
-\begin{itemdecl}
-#define ATOMIC_VAR_INIT(value) @\seebelow@
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-The macro expands to a token sequence suitable for
-constant initialization of
-an atomic variable of static storage duration of a type that is
-initialization-compatible with \tcode{value}.
-\begin{note}
-This operation may need to initialize locks.
-\end{note}
-Concurrent access to the variable being initialized, even via an atomic operation,
-constitutes a data race.
-\begin{example}
-\begin{codeblock}
-atomic<int> v = ATOMIC_VAR_INIT(5);
-\end{codeblock}
-\end{example}
 \end{itemdescr}
 
 \indexlibrarymember{is_always_lock_free}{atomic}%
@@ -2105,15 +2109,26 @@ namespace std {
   template<> struct atomic<@\placeholder{integral}@> {
     using value_type = @\placeholder{integral}@;
     using difference_type = value_type;
+
     static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic} type's operations are always lock free}@;
     bool is_lock_free() const volatile noexcept;
     bool is_lock_free() const noexcept;
+
+    atomic() noexcept = default;
+    constexpr atomic(@\placeholdernc{integral}@) noexcept;
+    atomic(const atomic&) = delete;
+    atomic& operator=(const atomic&) = delete;
+    atomic& operator=(const atomic&) volatile = delete;
+
     void store(@\placeholdernc{integral}@, memory_order = memory_order::seq_cst) volatile noexcept;
     void store(@\placeholdernc{integral}@, memory_order = memory_order::seq_cst) noexcept;
+    @\placeholdernc{integral}@ operator=(@\placeholdernc{integral}@) volatile noexcept;
+    @\placeholdernc{integral}@ operator=(@\placeholdernc{integral}@) noexcept;
     @\placeholdernc{integral}@ load(memory_order = memory_order::seq_cst) const volatile noexcept;
     @\placeholdernc{integral}@ load(memory_order = memory_order::seq_cst) const noexcept;
     operator @\placeholdernc{integral}@() const volatile noexcept;
     operator @\placeholdernc{integral}@() const noexcept;
+
     @\placeholdernc{integral}@ exchange(@\placeholdernc{integral}@, memory_order = memory_order::seq_cst) volatile noexcept;
     @\placeholdernc{integral}@ exchange(@\placeholdernc{integral}@, memory_order = memory_order::seq_cst) noexcept;
     bool compare_exchange_weak(@\placeholder{integral}@&, @\placeholdernc{integral}@,
@@ -2132,6 +2147,7 @@ namespace std {
                                  memory_order = memory_order::seq_cst) volatile noexcept;
     bool compare_exchange_strong(@\placeholder{integral}@&, @\placeholdernc{integral}@,
                                  memory_order = memory_order::seq_cst) noexcept;
+
     @\placeholdernc{integral}@ fetch_add(@\placeholdernc{integral}@, memory_order = memory_order::seq_cst) volatile noexcept;
     @\placeholdernc{integral}@ fetch_add(@\placeholdernc{integral}@, memory_order = memory_order::seq_cst) noexcept;
     @\placeholdernc{integral}@ fetch_sub(@\placeholdernc{integral}@, memory_order = memory_order::seq_cst) volatile noexcept;
@@ -2142,21 +2158,6 @@ namespace std {
     @\placeholdernc{integral}@ fetch_or(@\placeholdernc{integral}@, memory_order = memory_order::seq_cst) noexcept;
     @\placeholdernc{integral}@ fetch_xor(@\placeholdernc{integral}@, memory_order = memory_order::seq_cst) volatile noexcept;
     @\placeholdernc{integral}@ fetch_xor(@\placeholdernc{integral}@, memory_order = memory_order::seq_cst) noexcept;
-
-    void wait(@\placeholdernc{integral}@, memory_order = memory_order::seq_cst) const volatile noexcept;
-    void wait(@\placeholdernc{integral}@, memory_order = memory_order::seq_cst) const noexcept;
-    void notify_one() volatile noexcept;
-    void notify_one() noexcept;
-    void notify_all() volatile noexcept;
-    void notify_all() noexcept;
-
-    atomic() noexcept = default;
-    constexpr atomic(@\placeholdernc{integral}@) noexcept;
-    atomic(const atomic&) = delete;
-    atomic& operator=(const atomic&) = delete;
-    atomic& operator=(const atomic&) volatile = delete;
-    @\placeholdernc{integral}@ operator=(@\placeholdernc{integral}@) volatile noexcept;
-    @\placeholdernc{integral}@ operator=(@\placeholdernc{integral}@) noexcept;
 
     @\placeholdernc{integral}@ operator++(int) volatile noexcept;
     @\placeholdernc{integral}@ operator++(int) noexcept;
@@ -2176,6 +2177,13 @@ namespace std {
     @\placeholdernc{integral}@ operator|=(@\placeholdernc{integral}@) noexcept;
     @\placeholdernc{integral}@ operator^=(@\placeholdernc{integral}@) volatile noexcept;
     @\placeholdernc{integral}@ operator^=(@\placeholdernc{integral}@) noexcept;
+
+    void wait(@\placeholdernc{integral}@, memory_order = memory_order::seq_cst) const volatile noexcept;
+    void wait(@\placeholdernc{integral}@, memory_order = memory_order::seq_cst) const noexcept;
+    void notify_one() volatile noexcept;
+    void notify_one() noexcept;
+    void notify_all() volatile noexcept;
+    void notify_all() noexcept;
   };
 }
 \end{codeblock}
@@ -2301,15 +2309,26 @@ namespace std {
   template<> struct atomic<@\placeholder{floating-point}@> {
     using value_type = @\placeholdernc{floating-point}@;
     using difference_type = value_type;
+
     static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic} type's operations are always lock free}@;
     bool is_lock_free() const volatile noexcept;
     bool is_lock_free() const noexcept;
+
+    atomic() noexcept = default;
+    constexpr atomic(@\placeholder{floating-point}@) noexcept;
+    atomic(const atomic&) = delete;
+    atomic& operator=(const atomic&) = delete;
+    atomic& operator=(const atomic&) volatile = delete;
+
     void store(@\placeholdernc{floating-point}@, memory_order = memory_order_seq_cst) volatile noexcept;
     void store(@\placeholdernc{floating-point}@, memory_order = memory_order_seq_cst) noexcept;
+    @\placeholdernc{floating-point}@ operator=(@\placeholder{floating-point}@) volatile noexcept;
+    @\placeholdernc{floating-point}@ operator=(@\placeholder{floating-point}@) noexcept;
     @\placeholdernc{floating-point}@ load(memory_order = memory_order_seq_cst) volatile noexcept;
     @\placeholdernc{floating-point}@ load(memory_order = memory_order_seq_cst) noexcept;
     operator @\placeholdernc{floating-point}@() volatile noexcept;
     operator @\placeholdernc{floating-point}@() noexcept;
+
     @\placeholdernc{floating-point}@ exchange(@\placeholdernc{floating-point}@,
                             memory_order = memory_order_seq_cst) volatile noexcept;
     @\placeholdernc{floating-point}@ exchange(@\placeholdernc{floating-point}@,
@@ -2340,25 +2359,17 @@ namespace std {
     @\placeholdernc{floating-point}@ fetch_sub(@\placeholdernc{floating-point}@,
                              memory_order = memory_order_seq_cst) noexcept;
 
+    @\placeholdernc{floating-point}@ operator+=(@\placeholder{floating-point}@) volatile noexcept;
+    @\placeholdernc{floating-point}@ operator+=(@\placeholder{floating-point}@) noexcept;
+    @\placeholdernc{floating-point}@ operator-=(@\placeholder{floating-point}@) volatile noexcept;
+    @\placeholdernc{floating-point}@ operator-=(@\placeholder{floating-point}@) noexcept;
+
     void wait(@\placeholdernc{floating-point}@, memory_order = memory_order::seq_cst) const volatile noexcept;
     void wait(@\placeholdernc{floating-point}@, memory_order = memory_order::seq_cst) const noexcept;
     void notify_one() volatile noexcept;
     void notify_one() noexcept;
     void notify_all() volatile noexcept;
     void notify_all() noexcept;
-
-    atomic() noexcept = default;
-    constexpr atomic(@\placeholder{floating-point}@) noexcept;
-    atomic(const atomic&) = delete;
-    atomic& operator=(const atomic&) = delete;
-    atomic& operator=(const atomic&) volatile = delete;
-    @\placeholdernc{floating-point}@ operator=(@\placeholder{floating-point}@) volatile noexcept;
-    @\placeholdernc{floating-point}@ operator=(@\placeholder{floating-point}@) noexcept;
-
-    @\placeholdernc{floating-point}@ operator+=(@\placeholder{floating-point}@) volatile noexcept;
-    @\placeholdernc{floating-point}@ operator+=(@\placeholder{floating-point}@) noexcept;
-    @\placeholdernc{floating-point}@ operator-=(@\placeholder{floating-point}@) volatile noexcept;
-    @\placeholdernc{floating-point}@ operator-=(@\placeholder{floating-point}@) noexcept;
   };
 }
 \end{codeblock}
@@ -2447,15 +2458,26 @@ namespace std {
   template<class T> struct atomic<T*> {
     using value_type = T*;
     using difference_type = ptrdiff_t;
+
     static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic} type's operations are always lock free}@;
     bool is_lock_free() const volatile noexcept;
     bool is_lock_free() const noexcept;
+
+    atomic() noexcept = default;
+    constexpr atomic(T*) noexcept;
+    atomic(const atomic&) = delete;
+    atomic& operator=(const atomic&) = delete;
+    atomic& operator=(const atomic&) volatile = delete;
+
     void store(T*, memory_order = memory_order::seq_cst) volatile noexcept;
     void store(T*, memory_order = memory_order::seq_cst) noexcept;
+    T* operator=(T*) volatile noexcept;
+    T* operator=(T*) noexcept;
     T* load(memory_order = memory_order::seq_cst) const volatile noexcept;
     T* load(memory_order = memory_order::seq_cst) const noexcept;
     operator T*() const volatile noexcept;
     operator T*() const noexcept;
+
     T* exchange(T*, memory_order = memory_order::seq_cst) volatile noexcept;
     T* exchange(T*, memory_order = memory_order::seq_cst) noexcept;
     bool compare_exchange_weak(T*&, T*, memory_order, memory_order) volatile noexcept;
@@ -2476,21 +2498,6 @@ namespace std {
     T* fetch_sub(ptrdiff_t, memory_order = memory_order::seq_cst) volatile noexcept;
     T* fetch_sub(ptrdiff_t, memory_order = memory_order::seq_cst) noexcept;
 
-    void wait(T*, memory_order = memory_order::seq_cst) const volatile noexcept;
-    void wait(T*, memory_order = memory_order::seq_cst) const noexcept;
-    void notify_one() volatile noexcept;
-    void notify_one() noexcept;
-    void notify_all() volatile noexcept;
-    void notify_all() noexcept;
-
-    atomic() noexcept = default;
-    constexpr atomic(T*) noexcept;
-    atomic(const atomic&) = delete;
-    atomic& operator=(const atomic&) = delete;
-    atomic& operator=(const atomic&) volatile = delete;
-    T* operator=(T*) volatile noexcept;
-    T* operator=(T*) noexcept;
-
     T* operator++(int) volatile noexcept;
     T* operator++(int) noexcept;
     T* operator--(int) volatile noexcept;
@@ -2503,6 +2510,13 @@ namespace std {
     T* operator+=(ptrdiff_t) noexcept;
     T* operator-=(ptrdiff_t) volatile noexcept;
     T* operator-=(ptrdiff_t) noexcept;
+
+    void wait(T*, memory_order = memory_order::seq_cst) const volatile noexcept;
+    void wait(T*, memory_order = memory_order::seq_cst) const noexcept;
+    void notify_one() volatile noexcept;
+    void notify_one() noexcept;
+    void notify_all() volatile noexcept;
+    void notify_all() noexcept;
   };
 }
 \end{codeblock}
@@ -2687,6 +2701,11 @@ compiled as either C or C++, for example in a shared header file.
 \begin{codeblock}
 namespace std {
   struct atomic_flag {
+    atomic_flag() noexcept = default;
+    atomic_flag(const atomic_flag&) = delete;
+    atomic_flag& operator=(const atomic_flag&) = delete;
+    atomic_flag& operator=(const atomic_flag&) volatile = delete;
+
     bool test(memory_order = memory_order::seq_cst) const volatile noexcept;
     bool test(memory_order = memory_order::seq_cst) const noexcept;
     bool test_and_set(memory_order = memory_order::seq_cst) volatile noexcept;
@@ -2700,11 +2719,6 @@ namespace std {
     void notify_one() noexcept;
     void notify_all() volatile noexcept;
     void notify_all() noexcept;
-
-    atomic_flag() noexcept = default;
-    atomic_flag(const atomic_flag&) = delete;
-    atomic_flag& operator=(const atomic_flag&) = delete;
-    atomic_flag& operator=(const atomic_flag&) volatile = delete;
   };
 }
 \end{codeblock}


### PR DESCRIPTION
for a more conventional and meaningful order.

Fixes #3172.