### PR TITLE
[expr.const] Excise 'initialization full-expression'

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6844,10 +6844,10 @@ A variable or temporary object \tcode{o} is \defn{constant-initialized} if
   either it has an initializer or
   its default-initialization results in some initialization being performed, and
 \item
-  its initialization full-expression is a constant expression
+  the full-expression of its initialization is a constant expression
   when interpreted as a \grammarterm{constant-expression},
   except that if \tcode{o} is an object,
-  the initialization full-expression
+  that full-expression
   may also invoke constexpr constructors
   for \tcode{o} and its subobjects
   even if those objects are of non-literal class types.


### PR DESCRIPTION
which is an undefined term. Instead, use 'full-expression
of the initialization'.

Fixes #3156.