### PR TITLE
[atomics.ref.ops] Rename stable label from .operations

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -774,7 +774,7 @@ a shared resource, such as a lock associated with the referenced object,
 to enable atomic operations to be applied to the referenced object.
 \end{note}
 
-\rSec2[atomics.ref.operations]{Operations}
+\rSec2[atomics.ref.ops]{Operations}
 
 \indexlibrarymember{is_always_lock_free}{atomic_ref}%
 \indexlibrarymember{is_always_lock_free}{atomic_ref<T*>}%


### PR DESCRIPTION
We use ".ops" quite a bit to mean "operations". Let's rename that before it's too late.

This section is new since C++17, thus no entry in xrefdelta is required.