### PR TITLE
[basic.def.odr] Replace misleading 'for which' with 'where'.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -580,7 +580,7 @@ then
 \begin{itemize}
 \item each definition of \tcode{D} shall consist of
 the same sequence of tokens,
-for which the definition of a closure type
+where the definition of a closure type
 is considered to consist of the sequence of tokens of
 the corresponding \grammarterm{lambda-expression}; and
 \item in each definition of \tcode{D}, corresponding names, looked up


### PR DESCRIPTION
Fixes #3155.