### PR TITLE
[support.srcloc] Canonicalize presentation.

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -2356,7 +2356,7 @@ The following \Cpp{} headers are new:
 \libheaderref{numbers},
 \libheaderref{ranges},
 \libheaderref{semaphore},
-\libheaderref{source_location},
+\libheaderrefx{source_location}{source.location.syn},
 \libheaderref{span},
 \libheaderrefx{stop_token}{thread.stoptoken.syn},
 \libheaderref{syncstream}, and

--- a/source/support.tex
+++ b/source/support.tex
@@ -3218,13 +3218,21 @@ const char* what() const noexcept override;
 An \impldef{return value of \tcode{bad_typeid::what}} \ntbs{}.
 \end{itemdescr}
 
-\rSec1[support.srcloc]{Class \tcode{source_location}}
+\rSec1[support.srcloc]{Source location}
+
+\rSec2[source.location.syn]{Header \tcode{<source_location>} synopsis}
 
 The header \libheaderdef{source_location} defines
 the class \tcode{source_location}
 that provides a means to obtain source location information.
 
-\rSec2[source_location.syn]{Header \tcode{<source_location>} synopsis}
+\begin{codeblock}
+namespace std {
+  struct source_location;
+}
+\end{codeblock}
+
+\rSec2[support.srcloc.class]{Class \tcode{source_location}}
 
 \indexlibraryglobal{source_location}%
 \begin{codeblock}
@@ -3288,7 +3296,7 @@ then each of the following conditions is \tcode{true}:
 \item \tcode{lhs.column() == rhs_p.column()}
 \end{itemize}
 
-\rSec2[support.srcloc.cons]{Creation}
+\rSec3[support.srcloc.cons]{Creation}
 
 \begin{itemdecl}
 static consteval source_location current() noexcept;
@@ -3390,7 +3398,7 @@ constexpr source_location() noexcept;
 The data members are initialized with valid but unspecified values.
 \end{itemdescr}
 
-\rSec2[support.srcloc.access]{Field access}
+\rSec3[support.srcloc.obs]{Observers}
 
 \begin{itemdecl}
 constexpr uint_least32_t line() const noexcept;

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -2,7 +2,7 @@
 
 # Ignore files where rules may be violated within macro definitions.
 texfiles=$(ls *.tex | grep -v macros.tex | grep -v layout.tex | grep -v tables.tex)
-texlib="lib-intro.tex support.tex concepts.tex diagnostics.tex utilities.tex iterators.tex ranges.tex algorithms.tex numerics.tex time.tex locales.tex iostreams.tex regex.tex atomics.tex threads.tex"
+texlib="lib-intro.tex support.tex concepts.tex diagnostics.tex utilities.tex strings.tex containers.tex iterators.tex ranges.tex algorithms.tex numerics.tex time.tex locales.tex iostreams.tex regex.tex atomics.tex threads.tex"
 
 grep -Fe "Overfull \\hbox" std.log && exit 1
 grep "LaTeX Warning..There were undefined references" std.log && exit 1
@@ -32,7 +32,7 @@ grep -Hne '^\\\(change\|rationale\|effect\|difficulty\|howwide\)\s.\+$' compatib
 # Fixup: sed 's/^\\\(change\|rationale\|effect\|difficulty\|howwide\)\s\(.\)/\\\1\n\2/'
 
 # "template <class" (with space) in library clause.
-grep -ne 'template\s<class' $texlib && exit 1
+grep -ne 'template\s<class' $texlib | sed 's/$/ <--- space between "template" and "<class"/' | grep . && exit 1
 
 # \begin{example/note} with non-whitespace in front on the same line.
 grep -ne '^.*[^ ]\s*\\\(begin\|end\){\(example\|note\)}' $texfiles && exit 1
@@ -53,6 +53,9 @@ done | grep . && exit 1
 # Deleted special member function with a parameter name.
 grep -n "&[ 0-9a-z_]\+) = delete" $texfiles && exit 1
 # to fix: sed '/= delete/s/&[ 0-9a-z_]\+)/\&)/'
+
+# Bad characters in label. "-" is allowed due to a single remaining offender.
+grep -n '^\\rSec.\[[^]]*[^-a-z.0-9][^]]*\]{' $texfiles | sed 's/$/ <--- bad character in label/' | grep . && exit 1
 
 # \placeholder before (
 #egrep 'placeholder{[-A-Za-z]*}@?\(' *.tex


### PR DESCRIPTION
- Avoid hanging paragraph.
- Rename label [source_location.syn] to [source.location.syn].
- Add automated check for clean labels.
- Separate header synopsis from class synopsis.

Fixes #3140.