### PR TITLE
[concept.boolean] Avoid undefined 'Boolean context'.

### DIFF
--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -799,7 +799,7 @@ on values of possibly differing object types.
 
 \pnum
 The \libconcept{boolean} concept specifies the requirements on a type that is
-usable in Boolean contexts.
+usable as a truth value.
 
 \begin{itemdecl}
 template<class B>


### PR DESCRIPTION
Fixes #3112.