### PR TITLE
[lib] Use macro \notdef for undefined entities.

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10537,7 +10537,7 @@ namespace std {
   template<class ElementType, size_t Extent>
     struct tuple_size<span<ElementType, Extent>>;
   template<class ElementType>
-    struct tuple_size<span<ElementType, dynamic_extent>>;       // not defined
+    struct tuple_size<span<ElementType, dynamic_extent>>;       // \notdef
   template<size_t I, class ElementType, size_t Extent>
     struct tuple_element<I, span<ElementType, Extent>>;
   template<size_t I, class ElementType, size_t Extent>

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -5838,7 +5838,7 @@ namespace std {
   template<class R> class shared_future<R&>;
   template<> class shared_future<void>;
 
-  template<class> class packaged_task;  // not defined
+  template<class> class packaged_task;  // \notdef
   template<class R, class... ArgTypes>
     class packaged_task<R(ArgTypes...)>;
 
@@ -7224,7 +7224,7 @@ share the shared state will then be able to access the stored result.
 \indexlibraryglobal{packaged_task}%
 \begin{codeblock}
 namespace std {
-  template<class> class packaged_task;  // not defined
+  template<class> class packaged_task;  // \notdef
 
   template<class R, class... ArgTypes>
   class packaged_task<R(ArgTypes...)> {

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1000,14 +1000,14 @@ namespace std {
     constexpr T make_from_tuple(Tuple&& t);
 
   // \ref{tuple.helper}, tuple helper classes
-  template<class T> struct tuple_size;                  // not defined
+  template<class T> struct tuple_size;                  // \notdef
   template<class T> struct tuple_size<const T>;
   template<class T> struct tuple_size<volatile T>;
   template<class T> struct tuple_size<const volatile T>;
 
   template<class... Types> struct tuple_size<tuple<Types...>>;
 
-  template<size_t I, class T> struct tuple_element;     // not defined
+  template<size_t I, class T> struct tuple_element;     // \notdef
   template<size_t I, class T> struct tuple_element<I, const T>;
   template<size_t I, class T> struct tuple_element<I, volatile T>;
   template<size_t I, class T> struct tuple_element<I, const volatile T>;
@@ -3654,7 +3654,7 @@ namespace std {
     class variant;
 
   // \ref{variant.helper}, variant helper classes
-  template<class T> struct variant_size;                        // not defined
+  template<class T> struct variant_size;                        // \notdef
   template<class T> struct variant_size<const T>;
   template<class T> struct variant_size<volatile T>;
   template<class T> struct variant_size<const volatile T>;
@@ -3664,7 +3664,7 @@ namespace std {
   template<class... Types>
     struct variant_size<variant<Types...>>;
 
-  template<size_t I, class T> struct variant_alternative;       // not defined
+  template<size_t I, class T> struct variant_alternative;       // \notdef
   template<size_t I, class T> struct variant_alternative<I, const T>;
   template<size_t I, class T> struct variant_alternative<I, volatile T>;
   template<size_t I, class T> struct variant_alternative<I, const volatile T>;
@@ -14216,7 +14216,7 @@ namespace std {
   // \ref{func.wrap}, polymorphic function wrappers
   class bad_function_call;
 
-  template<class> class function;       // not defined
+  template<class> class function;       // \notdef
   template<class R, class... ArgTypes> class function<R(ArgTypes...)>;
 
   template<class R, class... ArgTypes>
@@ -16057,7 +16057,7 @@ An
 \indexlibrarymember{result_type}{function}%
 \begin{codeblock}
 namespace std {
-  template<class> class function;       // not defined
+  template<class> class function;       // \notdef
 
   template<class R, class... ArgTypes>
   class function<R(ArgTypes...)> {

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -24,6 +24,9 @@ grep -ne '\\pnum.\+$' $texfiles && exit 1
 grep -n '\\opt[^{]' $texfiles && exit 1
 grep -n 'opt{}' *.tex && exit 1
 
+# Use \notdef instead of "not defined".
+grep -n "// not defined" $texfiles | sed 's/$/ <--- use \\notdef instead/' | grep . && exit 1
+
 # Library element introducer followed by stuff.
 grep -ne '^\\\(contraints\|mandates\|expects\|effects\|sync\|ensures\|returns\|throws\|complexity\|remarks\|errors\).\+$' $texfiles && exit 1
 # Fixup: sed 's/^\\\(contraints\|mandates\|expects\|effects\|sync\|ensures\|returns\|throws\|complexity\|remarks\|errors\)\s*\(.\)/\\\1\n\2/'


### PR DESCRIPTION
Prevent future transgressions with an automated check.