### PR TITLE
[utilities] Index _t typedefs and _v variable templates.

### DIFF
--- a/source/macros.tex
+++ b/source/macros.tex
@@ -185,6 +185,9 @@
 \newcommand{\indexlibrarymember}[2]{\indexlibrary{\idxcode{#1}!\idxcode{#2}}\indexlibrary{\idxcode{#2}!\idxcode{#1}}}
 \newcommand{\indexlibraryzombie}[1]{\indexlibrary{\idxcode{#1}!zombie}}
 
+\newcommand{\libglobal}[1]{\indexlibraryglobal{#1}#1}
+\newcommand{\libmember}[2]{\indexlibrarymember{#1}{#2}#1}
+
 % index for library headers
 \newcommand{\libheader}[1]{\indexhdr{#1}\tcode{<#1>}}
 \newcommand{\indexheader}[1]{\indextext{\idxhdr{#1}}\index[headerindex]{\idxhdr{#1}|idxbfpage}}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1016,7 +1016,7 @@ namespace std {
     struct tuple_element<I, tuple<Types...>>;
 
   template<size_t I, class T>
-    using tuple_element_t = typename tuple_element<I, T>::type;
+    using @\libglobal{tuple_element_t}@ = typename tuple_element<I, T>::type;
 
   // \ref{tuple.elem}, element access
   template<size_t I, class... Types>
@@ -1053,7 +1053,7 @@ namespace std {
 
   // \ref{tuple.helper}, tuple helper classes
   template<class T>
-    inline constexpr size_t tuple_size_v = tuple_size<T>::value;
+    inline constexpr size_t @\libglobal{tuple_size_v}@ = tuple_size<T>::value;
 }
 \end{codeblock}
 
@@ -3659,7 +3659,7 @@ namespace std {
   template<class T> struct variant_size<volatile T>;
   template<class T> struct variant_size<const volatile T>;
   template<class T>
-    inline constexpr size_t variant_size_v = variant_size<T>::value;
+    inline constexpr size_t @\libglobal{variant_size_v}@ = variant_size<T>::value;
 
   template<class... Types>
     struct variant_size<variant<Types...>>;
@@ -3669,7 +3669,7 @@ namespace std {
   template<size_t I, class T> struct variant_alternative<I, volatile T>;
   template<size_t I, class T> struct variant_alternative<I, const volatile T>;
   template<size_t I, class T>
-    using variant_alternative_t = typename variant_alternative<I, T>::type;
+    using @\libglobal{variant_alternative_t}@ = typename variant_alternative<I, T>::type;
 
   template<size_t I, class... Types>
     struct variant_alternative<I, variant<Types...>>;
@@ -6547,7 +6547,7 @@ namespace std {
 
   // \ref{allocator.uses.trait}, \tcode{uses_allocator}
   template<class T, class Alloc>
-    inline constexpr bool uses_allocator_v = uses_allocator<T, Alloc>::value;
+    inline constexpr bool @\libglobal{uses_allocator_v}@ = uses_allocator<T, Alloc>::value;
 
   // \ref{allocator.uses.construction}, uses-allocator construction
   template<class T, class Alloc, class... Args>
@@ -14131,9 +14131,9 @@ namespace std {
   template<class T> constexpr reference_wrapper<const T> cref(reference_wrapper<T>) noexcept;
 
   template<class T> struct unwrap_reference;
-  template<class T> using unwrap_reference_t = typename unwrap_reference<T>::type;
+  template<class T> using @\libglobal{unwrap_reference_t}@ = typename unwrap_reference<T>::type;
   template<class T> struct unwrap_ref_decay;
-  template<class T> using unwrap_ref_decay_t = typename unwrap_ref_decay<T>::type;
+  template<class T> using @\libglobal{unwrap_ref_decay_t}@ = typename unwrap_ref_decay<T>::type;
 
   // \ref{arithmetic.operations}, arithmetic operations
   template<class T = void> struct plus;
@@ -14245,9 +14245,9 @@ namespace std {
 
   // \ref{func.bind}, function object binders
   template<class T>
-    inline constexpr bool is_bind_expression_v = is_bind_expression<T>::value;
+    inline constexpr bool @\libglobal{is_bind_expression_v}@ = is_bind_expression<T>::value;
   template<class T>
-    inline constexpr int is_placeholder_v = is_placeholder<T>::value;
+    inline constexpr int @\libglobal{is_placeholder_v}@ = is_placeholder<T>::value;
 
   namespace ranges {
     // \ref{range.cmp}, concept-constrained comparisons
@@ -16897,11 +16897,6 @@ The behavior of a program is undefined if:
 \rSec2[meta.type.synop]{Header \tcode{<type_traits>} synopsis}
 
 \indexheader{type_traits}%
-\indexlibraryglobal{is_layout_compatible_v}%
-\indexlibraryglobal{is_nothrow_convertible_v}%
-\indexlibraryglobal{is_pointer_interconvertible_base_of_v}%
-\indexlibraryglobal{type_identity_t}%
-\indexlibraryglobal{common_reference_t}%
 % FIXME: Many index entries missing.
 \begin{codeblock}
 namespace std {
@@ -17027,17 +17022,17 @@ namespace std {
   template<class T> struct add_cv;
 
   template<class T>
-    using remove_const_t    = typename remove_const<T>::type;
+    using @\libglobal{remove_const_t}@    = typename remove_const<T>::type;
   template<class T>
-    using remove_volatile_t = typename remove_volatile<T>::type;
+    using @\libglobal{remove_volatile_t}@ = typename remove_volatile<T>::type;
   template<class T>
-    using remove_cv_t       = typename remove_cv<T>::type;
+    using @\libglobal{remove_cv_t}@       = typename remove_cv<T>::type;
   template<class T>
-    using add_const_t       = typename add_const<T>::type;
+    using @\libglobal{add_const_t}@       = typename add_const<T>::type;
   template<class T>
-    using add_volatile_t    = typename add_volatile<T>::type;
+    using @\libglobal{add_volatile_t}@    = typename add_volatile<T>::type;
   template<class T>
-    using add_cv_t          = typename add_cv<T>::type;
+    using @\libglobal{add_cv_t}@          = typename add_cv<T>::type;
 
   // \ref{meta.trans.ref}, reference modifications
   template<class T> struct remove_reference;
@@ -17045,38 +17040,38 @@ namespace std {
   template<class T> struct add_rvalue_reference;
 
   template<class T>
-    using remove_reference_t     = typename remove_reference<T>::type;
+    using @\libglobal{remove_reference_t}@     = typename remove_reference<T>::type;
   template<class T>
-    using add_lvalue_reference_t = typename add_lvalue_reference<T>::type;
+    using @\libglobal{add_lvalue_reference_t}@ = typename add_lvalue_reference<T>::type;
   template<class T>
-    using add_rvalue_reference_t = typename add_rvalue_reference<T>::type;
+    using @\libglobal{add_rvalue_reference_t}@ = typename add_rvalue_reference<T>::type;
 
   // \ref{meta.trans.sign}, sign modifications
   template<class T> struct make_signed;
   template<class T> struct make_unsigned;
 
   template<class T>
-    using make_signed_t   = typename make_signed<T>::type;
+    using @\libglobal{make_signed_t}@   = typename make_signed<T>::type;
   template<class T>
-    using make_unsigned_t = typename make_unsigned<T>::type;
+    using @\libglobal{make_unsigned_t}@ = typename make_unsigned<T>::type;
 
   // \ref{meta.trans.arr}, array modifications
   template<class T> struct remove_extent;
   template<class T> struct remove_all_extents;
 
   template<class T>
-    using remove_extent_t      = typename remove_extent<T>::type;
+    using @\libglobal{remove_extent_t}@      = typename remove_extent<T>::type;
   template<class T>
-    using remove_all_extents_t = typename remove_all_extents<T>::type;
+    using @\libglobal{remove_all_extents_t}@ = typename remove_all_extents<T>::type;
 
   // \ref{meta.trans.ptr}, pointer modifications
   template<class T> struct remove_pointer;
   template<class T> struct add_pointer;
 
   template<class T>
-    using remove_pointer_t = typename remove_pointer<T>::type;
+    using @\libglobal{remove_pointer_t}@ = typename remove_pointer<T>::type;
   template<class T>
-    using add_pointer_t    = typename add_pointer<T>::type;
+    using @\libglobal{add_pointer_t}@    = typename add_pointer<T>::type;
 
   // \ref{meta.trans.other}, other transformations
   template<class T> struct type_identity;
@@ -17095,29 +17090,29 @@ namespace std {
   template<class Fn, class... ArgTypes> struct invoke_result;
 
   template<class T>
-    using type_identity_t    = typename type_identity<T>::type;
+    using @\libglobal{type_identity_t}@    = typename type_identity<T>::type;
   template<size_t Len, size_t Align = @\textit{default-alignment}@> // see \ref{meta.trans.other}
-    using aligned_storage_t  = typename aligned_storage<Len, Align>::type;
+    using @\libglobal{aligned_storage_t}@  = typename aligned_storage<Len, Align>::type;
   template<size_t Len, class... Types>
-    using aligned_union_t    = typename aligned_union<Len, Types...>::type;
+    using @\libglobal{aligned_union_t}@    = typename aligned_union<Len, Types...>::type;
   template<class T>
-    using remove_cvref_t     = typename remove_cvref<T>::type;
+    using @\libglobal{remove_cvref_t}@     = typename remove_cvref<T>::type;
   template<class T>
-    using decay_t            = typename decay<T>::type;
+    using @\libglobal{decay_t}@            = typename decay<T>::type;
   template<bool b, class T = void>
-    using enable_if_t        = typename enable_if<b, T>::type;
+    using @\libglobal{enable_if_t}@        = typename enable_if<b, T>::type;
   template<bool b, class T, class F>
-    using conditional_t      = typename conditional<b, T, F>::type;
+    using @\libglobal{conditional_t}@      = typename conditional<b, T, F>::type;
   template<class... T>
-    using common_type_t      = typename common_type<T...>::type;
+    using @\libglobal{common_type_t}@      = typename common_type<T...>::type;
   template<class... T>
-    using common_reference_t = typename common_reference<T...>::type;
+    using @\libglobal{common_reference_t}@ = typename common_reference<T...>::type;
   template<class T>
-    using underlying_type_t  = typename underlying_type<T>::type;
+    using @\libglobal{underlying_type_t}@  = typename underlying_type<T>::type;
   template<class Fn, class... ArgTypes>
-    using invoke_result_t    = typename invoke_result<Fn, ArgTypes...>::type;
+    using @\libglobal{invoke_result_t}@    = typename invoke_result<Fn, ArgTypes...>::type;
   template<class...>
-    using void_t             = void;
+    using @\libglobal{void_t}@             = void;
 
   // \ref{meta.logical}, logical operator traits
   template<class... B> struct conjunction;
@@ -17126,99 +17121,99 @@ namespace std {
 
   // \ref{meta.unary.cat}, primary type categories
   template<class T>
-    inline constexpr bool is_void_v = is_void<T>::value;
+    inline constexpr bool @\libglobal{is_void_v}@ = is_void<T>::value;
   template<class T>
-    inline constexpr bool is_null_pointer_v = is_null_pointer<T>::value;
+    inline constexpr bool @\libglobal{is_null_pointer_v}@ = is_null_pointer<T>::value;
   template<class T>
-    inline constexpr bool is_integral_v = is_integral<T>::value;
+    inline constexpr bool @\libglobal{is_integral_v}@ = is_integral<T>::value;
   template<class T>
-    inline constexpr bool is_floating_point_v = is_floating_point<T>::value;
+    inline constexpr bool @\libglobal{is_floating_point_v}@ = is_floating_point<T>::value;
   template<class T>
-    inline constexpr bool is_array_v = is_array<T>::value;
+    inline constexpr bool @\libglobal{is_array_v}@ = is_array<T>::value;
   template<class T>
-    inline constexpr bool is_pointer_v = is_pointer<T>::value;
+    inline constexpr bool @\libglobal{is_pointer_v}@ = is_pointer<T>::value;
   template<class T>
-    inline constexpr bool is_lvalue_reference_v = is_lvalue_reference<T>::value;
+    inline constexpr bool @\libglobal{is_lvalue_reference_v}@ = is_lvalue_reference<T>::value;
   template<class T>
-    inline constexpr bool is_rvalue_reference_v = is_rvalue_reference<T>::value;
+    inline constexpr bool @\libglobal{is_rvalue_reference_v}@ = is_rvalue_reference<T>::value;
   template<class T>
-    inline constexpr bool is_member_object_pointer_v = is_member_object_pointer<T>::value;
+    inline constexpr bool @\libglobal{is_member_object_pointer_v}@ = is_member_object_pointer<T>::value;
   template<class T>
-    inline constexpr bool is_member_function_pointer_v = is_member_function_pointer<T>::value;
+    inline constexpr bool @\libglobal{is_member_function_pointer_v}@ = is_member_function_pointer<T>::value;
   template<class T>
-    inline constexpr bool is_enum_v = is_enum<T>::value;
+    inline constexpr bool @\libglobal{is_enum_v}@ = is_enum<T>::value;
   template<class T>
-    inline constexpr bool is_union_v = is_union<T>::value;
+    inline constexpr bool @\libglobal{is_union_v}@ = is_union<T>::value;
   template<class T>
-    inline constexpr bool is_class_v = is_class<T>::value;
+    inline constexpr bool @\libglobal{is_class_v}@ = is_class<T>::value;
   template<class T>
-    inline constexpr bool is_function_v = is_function<T>::value;
+    inline constexpr bool @\libglobal{is_function_v}@ = is_function<T>::value;
 
   // \ref{meta.unary.comp}, composite type categories
   template<class T>
-    inline constexpr bool is_reference_v = is_reference<T>::value;
+    inline constexpr bool @\libglobal{is_reference_v}@ = is_reference<T>::value;
   template<class T>
-    inline constexpr bool is_arithmetic_v = is_arithmetic<T>::value;
+    inline constexpr bool @\libglobal{is_arithmetic_v}@ = is_arithmetic<T>::value;
   template<class T>
-    inline constexpr bool is_fundamental_v = is_fundamental<T>::value;
+    inline constexpr bool @\libglobal{is_fundamental_v}@ = is_fundamental<T>::value;
   template<class T>
-    inline constexpr bool is_object_v = is_object<T>::value;
+    inline constexpr bool @\libglobal{is_object_v}@ = is_object<T>::value;
   template<class T>
-    inline constexpr bool is_scalar_v = is_scalar<T>::value;
+    inline constexpr bool @\libglobal{is_scalar_v}@ = is_scalar<T>::value;
   template<class T>
-    inline constexpr bool is_compound_v = is_compound<T>::value;
+    inline constexpr bool @\libglobal{is_compound_v}@ = is_compound<T>::value;
   template<class T>
-    inline constexpr bool is_member_pointer_v = is_member_pointer<T>::value;
+    inline constexpr bool @\libglobal{is_member_pointer_v}@ = is_member_pointer<T>::value;
 
   // \ref{meta.unary.prop}, type properties
   template<class T>
-    inline constexpr bool is_const_v = is_const<T>::value;
+    inline constexpr bool @\libglobal{is_const_v}@ = is_const<T>::value;
   template<class T>
-    inline constexpr bool is_volatile_v = is_volatile<T>::value;
+    inline constexpr bool @\libglobal{is_volatile_v}@ = is_volatile<T>::value;
   template<class T>
-    inline constexpr bool is_trivial_v = is_trivial<T>::value;
+    inline constexpr bool @\libglobal{is_trivial_v}@ = is_trivial<T>::value;
   template<class T>
-    inline constexpr bool is_trivially_copyable_v = is_trivially_copyable<T>::value;
+    inline constexpr bool @\libglobal{is_trivially_copyable_v}@ = is_trivially_copyable<T>::value;
   template<class T>
-    inline constexpr bool is_standard_layout_v = is_standard_layout<T>::value;
+    inline constexpr bool @\libglobal{is_standard_layout_v}@ = is_standard_layout<T>::value;
   template<class T>
-    inline constexpr bool is_empty_v = is_empty<T>::value;
+    inline constexpr bool @\libglobal{is_empty_v}@ = is_empty<T>::value;
   template<class T>
-    inline constexpr bool is_polymorphic_v = is_polymorphic<T>::value;
+    inline constexpr bool @\libglobal{is_polymorphic_v}@ = is_polymorphic<T>::value;
   template<class T>
-    inline constexpr bool is_abstract_v = is_abstract<T>::value;
+    inline constexpr bool @\libglobal{is_abstract_v}@ = is_abstract<T>::value;
   template<class T>
-    inline constexpr bool is_final_v = is_final<T>::value;
+    inline constexpr bool @\libglobal{is_final_v}@ = is_final<T>::value;
   template<class T>
-    inline constexpr bool is_aggregate_v = is_aggregate<T>::value;
+    inline constexpr bool @\libglobal{is_aggregate_v}@ = is_aggregate<T>::value;
   template<class T>
-    inline constexpr bool is_signed_v = is_signed<T>::value;
+    inline constexpr bool @\libglobal{is_signed_v}@ = is_signed<T>::value;
   template<class T>
-    inline constexpr bool is_unsigned_v = is_unsigned<T>::value;
+    inline constexpr bool @\libglobal{is_unsigned_v}@ = is_unsigned<T>::value;
   template<class T>
-    inline constexpr bool is_bounded_array_v = is_bounded_array<T>::value;
+    inline constexpr bool @\libglobal{is_bounded_array_v}@ = is_bounded_array<T>::value;
   template<class T>
-    inline constexpr bool is_unbounded_array_v = is_unbounded_array<T>::value;
+    inline constexpr bool @\libglobal{is_unbounded_array_v}@ = is_unbounded_array<T>::value;
   template<class T, class... Args>
-    inline constexpr bool is_constructible_v = is_constructible<T, Args...>::value;
+    inline constexpr bool @\libglobal{is_constructible_v}@ = is_constructible<T, Args...>::value;
   template<class T>
-    inline constexpr bool is_default_constructible_v = is_default_constructible<T>::value;
+    inline constexpr bool @\libglobal{is_default_constructible_v}@ = is_default_constructible<T>::value;
   template<class T>
-    inline constexpr bool is_copy_constructible_v = is_copy_constructible<T>::value;
+    inline constexpr bool @\libglobal{is_copy_constructible_v}@ = is_copy_constructible<T>::value;
   template<class T>
-    inline constexpr bool is_move_constructible_v = is_move_constructible<T>::value;
+    inline constexpr bool @\libglobal{is_move_constructible_v}@ = is_move_constructible<T>::value;
   template<class T, class U>
-    inline constexpr bool is_assignable_v = is_assignable<T, U>::value;
+    inline constexpr bool @\libglobal{is_assignable_v}@ = is_assignable<T, U>::value;
   template<class T>
-    inline constexpr bool is_copy_assignable_v = is_copy_assignable<T>::value;
+    inline constexpr bool @\libglobal{is_copy_assignable_v}@ = is_copy_assignable<T>::value;
   template<class T>
-    inline constexpr bool is_move_assignable_v = is_move_assignable<T>::value;
+    inline constexpr bool @\libglobal{is_move_assignable_v}@ = is_move_assignable<T>::value;
   template<class T, class U>
-    inline constexpr bool is_swappable_with_v = is_swappable_with<T, U>::value;
+    inline constexpr bool @\libglobal{is_swappable_with_v}@ = is_swappable_with<T, U>::value;
   template<class T>
-    inline constexpr bool is_swappable_v = is_swappable<T>::value;
+    inline constexpr bool @\libglobal{is_swappable_v}@ = is_swappable<T>::value;
   template<class T>
-    inline constexpr bool is_destructible_v = is_destructible<T>::value;
+    inline constexpr bool @\libglobal{is_destructible_v}@ = is_destructible<T>::value;
   template<class T, class... Args>
     inline constexpr bool is_trivially_constructible_v
       = is_trivially_constructible<T, Args...>::value;
@@ -17232,7 +17227,7 @@ namespace std {
     inline constexpr bool is_trivially_move_constructible_v
       = is_trivially_move_constructible<T>::value;
   template<class T, class U>
-    inline constexpr bool is_trivially_assignable_v = is_trivially_assignable<T, U>::value;
+    inline constexpr bool @\libglobal{is_trivially_assignable_v}@ = is_trivially_assignable<T, U>::value;
   template<class T>
     inline constexpr bool is_trivially_copy_assignable_v
       = is_trivially_copy_assignable<T>::value;
@@ -17240,7 +17235,7 @@ namespace std {
     inline constexpr bool is_trivially_move_assignable_v
       = is_trivially_move_assignable<T>::value;
   template<class T>
-    inline constexpr bool is_trivially_destructible_v = is_trivially_destructible<T>::value;
+    inline constexpr bool @\libglobal{is_trivially_destructible_v}@ = is_trivially_destructible<T>::value;
   template<class T, class... Args>
     inline constexpr bool is_nothrow_constructible_v
       = is_nothrow_constructible<T, Args...>::value;
@@ -17254,19 +17249,19 @@ namespace std {
     inline constexpr bool is_nothrow_move_constructible_v
       = is_nothrow_move_constructible<T>::value;
   template<class T, class U>
-    inline constexpr bool is_nothrow_assignable_v = is_nothrow_assignable<T, U>::value;
+    inline constexpr bool @\libglobal{is_nothrow_assignable_v}@ = is_nothrow_assignable<T, U>::value;
   template<class T>
-    inline constexpr bool is_nothrow_copy_assignable_v = is_nothrow_copy_assignable<T>::value;
+    inline constexpr bool @\libglobal{is_nothrow_copy_assignable_v}@ = is_nothrow_copy_assignable<T>::value;
   template<class T>
-    inline constexpr bool is_nothrow_move_assignable_v = is_nothrow_move_assignable<T>::value;
+    inline constexpr bool @\libglobal{is_nothrow_move_assignable_v}@ = is_nothrow_move_assignable<T>::value;
   template<class T, class U>
-    inline constexpr bool is_nothrow_swappable_with_v = is_nothrow_swappable_with<T, U>::value;
+    inline constexpr bool @\libglobal{is_nothrow_swappable_with_v}@ = is_nothrow_swappable_with<T, U>::value;
   template<class T>
-    inline constexpr bool is_nothrow_swappable_v = is_nothrow_swappable<T>::value;
+    inline constexpr bool @\libglobal{is_nothrow_swappable_v}@ = is_nothrow_swappable<T>::value;
   template<class T>
-    inline constexpr bool is_nothrow_destructible_v = is_nothrow_destructible<T>::value;
+    inline constexpr bool @\libglobal{is_nothrow_destructible_v}@ = is_nothrow_destructible<T>::value;
   template<class T>
-    inline constexpr bool has_virtual_destructor_v = has_virtual_destructor<T>::value;
+    inline constexpr bool @\libglobal{has_virtual_destructor_v}@ = has_virtual_destructor<T>::value;
   template<class T>
     inline constexpr bool has_unique_object_representations_v
       = has_unique_object_representations<T>::value;
@@ -17277,43 +17272,43 @@ namespace std {
 
   // \ref{meta.unary.prop.query}, type property queries
   template<class T>
-    inline constexpr size_t alignment_of_v = alignment_of<T>::value;
+    inline constexpr size_t @\libglobal{alignment_of_v}@ = alignment_of<T>::value;
   template<class T>
-    inline constexpr size_t rank_v = rank<T>::value;
+    inline constexpr size_t @\libglobal{rank_v}@ = rank<T>::value;
   template<class T, unsigned I = 0>
-    inline constexpr size_t extent_v = extent<T, I>::value;
+    inline constexpr size_t @\libglobal{extent_v}@ = extent<T, I>::value;
 
   // \ref{meta.rel}, type relations
   template<class T, class U>
-    inline constexpr bool is_same_v = is_same<T, U>::value;
+    inline constexpr bool @\libglobal{is_same_v}@ = is_same<T, U>::value;
   template<class Base, class Derived>
-    inline constexpr bool is_base_of_v = is_base_of<Base, Derived>::value;
+    inline constexpr bool @\libglobal{is_base_of_v}@ = is_base_of<Base, Derived>::value;
   template<class From, class To>
-    inline constexpr bool is_convertible_v = is_convertible<From, To>::value;
+    inline constexpr bool @\libglobal{is_convertible_v}@ = is_convertible<From, To>::value;
   template<class From, class To>
-    inline constexpr bool is_nothrow_convertible_v = is_nothrow_convertible<From, To>::value;
+    inline constexpr bool @\libglobal{is_nothrow_convertible_v}@ = is_nothrow_convertible<From, To>::value;
   template<class T, class U>
-    inline constexpr bool is_layout_compatible_v = is_layout_compatible<T, U>::value;
+    inline constexpr bool @\libglobal{is_layout_compatible_v}@ = is_layout_compatible<T, U>::value;
   template<class Base, class Derived>
     inline constexpr bool is_pointer_interconvertible_base_of_v
       = is_pointer_interconvertible_base_of<Base, Derived>::value;
   template<class Fn, class... ArgTypes>
-    inline constexpr bool is_invocable_v = is_invocable<Fn, ArgTypes...>::value;
+    inline constexpr bool @\libglobal{is_invocable_v}@ = is_invocable<Fn, ArgTypes...>::value;
   template<class R, class Fn, class... ArgTypes>
-    inline constexpr bool is_invocable_r_v = is_invocable_r<R, Fn, ArgTypes...>::value;
+    inline constexpr bool @\libglobal{is_invocable_r_v}@ = is_invocable_r<R, Fn, ArgTypes...>::value;
   template<class Fn, class... ArgTypes>
-    inline constexpr bool is_nothrow_invocable_v = is_nothrow_invocable<Fn, ArgTypes...>::value;
+    inline constexpr bool @\libglobal{is_nothrow_invocable_v}@ = is_nothrow_invocable<Fn, ArgTypes...>::value;
   template<class R, class Fn, class... ArgTypes>
     inline constexpr bool is_nothrow_invocable_r_v
       = is_nothrow_invocable_r<R, Fn, ArgTypes...>::value;
 
   // \ref{meta.logical}, logical operator traits
   template<class... B>
-    inline constexpr bool conjunction_v = conjunction<B...>::value;
+    inline constexpr bool @\libglobal{conjunction_v}@ = conjunction<B...>::value;
   template<class... B>
-    inline constexpr bool disjunction_v = disjunction<B...>::value;
+    inline constexpr bool @\libglobal{disjunction_v}@ = disjunction<B...>::value;
   template<class B>
-    inline constexpr bool negation_v = negation<B>::value;
+    inline constexpr bool @\libglobal{negation_v}@ = negation<B>::value;
 
   // \ref{meta.member}, member relationships
   template<class S, class M>
@@ -19157,17 +19152,17 @@ namespace std {
   template<class R1, class R2> struct ratio_greater_equal;
 
   template<class R1, class R2>
-    inline constexpr bool ratio_equal_v = ratio_equal<R1, R2>::value;
+    inline constexpr bool @\libglobal{ratio_equal_v}@ = ratio_equal<R1, R2>::value;
   template<class R1, class R2>
-    inline constexpr bool ratio_not_equal_v = ratio_not_equal<R1, R2>::value;
+    inline constexpr bool @\libglobal{ratio_not_equal_v}@ = ratio_not_equal<R1, R2>::value;
   template<class R1, class R2>
-    inline constexpr bool ratio_less_v = ratio_less<R1, R2>::value;
+    inline constexpr bool @\libglobal{ratio_less_v}@ = ratio_less<R1, R2>::value;
   template<class R1, class R2>
-    inline constexpr bool ratio_less_equal_v = ratio_less_equal<R1, R2>::value;
+    inline constexpr bool @\libglobal{ratio_less_equal_v}@ = ratio_less_equal<R1, R2>::value;
   template<class R1, class R2>
-    inline constexpr bool ratio_greater_v = ratio_greater<R1, R2>::value;
+    inline constexpr bool @\libglobal{ratio_greater_v}@ = ratio_greater<R1, R2>::value;
   template<class R1, class R2>
-    inline constexpr bool ratio_greater_equal_v = ratio_greater_equal<R1, R2>::value;
+    inline constexpr bool @\libglobal{ratio_greater_equal_v}@ = ratio_greater_equal<R1, R2>::value;
 
   // \ref{ratio.si}, convenience SI typedefs
   using yocto = ratio<1, 1'000'000'000'000'000'000'000'000>;  // see below
@@ -19557,7 +19552,7 @@ standard as extensions.
 namespace std {
   // \ref{execpol.type}, execution policy type trait
   template<class T> struct is_execution_policy;
-  template<class T> inline constexpr bool is_execution_policy_v = is_execution_policy<T>::value;
+  template<class T> inline constexpr bool @\libglobal{is_execution_policy_v}@ = is_execution_policy<T>::value;
 }
 
 namespace std::execution {
@@ -20183,7 +20178,7 @@ namespace std {
   using wformat_args = basic_format_args<wformat_context>;
 
   template<class Out, class charT>
-    using format_args_t = basic_format_args<basic_format_context<Out, charT>>;
+    using @\libglobal{format_args_t}@ = basic_format_args<basic_format_context<Out, charT>>;
 
   // \ref{format.error}, class \tcode{format_error}
   class format_error;


### PR DESCRIPTION
Fixes #3051.
Partially addresses #3096.