### PR TITLE
[span.iterators] Fix typo in paragraph 5

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -11104,7 +11104,7 @@ constexpr reverse_iterator rend() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns
+\effects
 Equivalent to: \tcode{return reverse_iterator(begin());}
 \end{itemdescr}
 


### PR DESCRIPTION
"Returns: Equivalent to:" is not a library wording form, but an obvious misspelling of "Effects: Equivalent to:".

(Oddly enough, para 4 had the same error in P0122R5, but it was fixed in R6.)