### PR TITLE
[class.mem] Avoid 'shall have been defined'

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1423,7 +1423,7 @@ default constructor is \tcode{constexpr}.
 Before the defaulted default constructor for a class is
 implicitly defined,
 all the non-user-provided default constructors for its base classes and
-its non-static data members shall have been implicitly defined.
+its non-static data members are implicitly defined.
 \begin{note}
 An implicitly-declared default constructor has an
 exception specification\iref{except.spec}.
@@ -1729,7 +1729,7 @@ Before the defaulted copy/move constructor for a class is
 implicitly defined,
 all non-user-provided copy/move constructors for its
 potentially constructed subobjects
-shall have been implicitly defined.
+are implicitly defined.
 \begin{note}
 An implicitly-declared copy/move constructor has an
 implied exception specification\iref{except.spec}.
@@ -2033,7 +2033,7 @@ Before the defaulted copy/move assignment operator for a class is
 implicitly defined,
 all non-user-provided copy/move assignment operators for
 its direct base classes and
-its non-static data members shall have been implicitly defined.
+its non-static data members are implicitly defined.
 \begin{note}
 An implicitly-declared copy/move assignment operator has an
 implied exception specification\iref{except.spec}.
@@ -2234,7 +2234,7 @@ or when it is explicitly defaulted after its first declaration.
 \pnum
 Before a
 defaulted destructor for a class is implicitly defined, all the non-user-provided
-destructors for its base classes and its non-static data members shall have been
+destructors for its base classes and its non-static data members are
 implicitly defined.
 
 \pnum


### PR DESCRIPTION
when describing implicit definitions of defaulted
special member functions.  Instead, use plain 'are'.

Partially addresses #3234.