### PR TITLE
[expr.const] drop unused declaration from integral constant expression example

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -7184,7 +7184,6 @@ struct A {
 private:
   int val;
 };
-template<int> struct X { };
 constexpr A a = alignof(int);
 alignas(a) int n;               // error: ambiguous conversion
 struct B { int n : a; };        // error: ambiguous conversion


### PR DESCRIPTION
b7ac955  removed the use of this template<int> struct X, but not its declaration