### PR TITLE
[std] Consistently use 'comparison function'

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -6675,7 +6675,7 @@ template<class T> void f() {
 \rSec2[class.compare.default]{Defaulted comparison operator functions}%
 
 \pnum
-A defaulted comparison operator function (\ref{expr.spaceship}, \ref{expr.rel}, \ref{expr.eq})
+A defaulted comparison operator function\iref{over.binary}
 for some class \tcode{C}
 shall be a non-template function
 declared in the \grammarterm{member-specification} of \tcode{C}
@@ -6769,7 +6769,7 @@ appear more than once in the expanded list of subobjects.
 \indextext{operator!inequality!defaulted}%
 
 \pnum
-A defaulted equality operator\iref{expr.eq} function
+A defaulted equality operator function\iref{over.binary}
 shall have a declared return type \tcode{bool}.
 
 \pnum
@@ -6966,7 +6966,7 @@ In particular, this is the result when $n$ is 0.
 \indextext{operator!relational!defaulted}%
 
 \pnum
-A defaulted relational\iref{expr.rel} operator function
+A defaulted relational operator function\iref{over.binary}
 for some operator \tcode{@}
 shall have a declared return type \tcode{bool}.
 

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5987,9 +5987,8 @@ is of the form
 is called an \defnx{explicitly-defaulted}{definition!function!explicitly-defaulted} definition.
 A function that is explicitly defaulted shall
 \begin{itemize}
-\item be a special member function or a comparison operator
-(\ref{expr.spaceship}, \ref{expr.rel}, \ref{expr.eq}), and
-
+\item be a special member function or
+a comparison operator function\iref{over.binary}, and
 \item not have default arguments.
 \end{itemize}
 

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -907,8 +907,7 @@ with no explicit \grammarterm{noexcept-specifier}
 has a non-throwing exception specification.
 
 \pnum
-The exception specification for a comparison operator
-(\ref{expr.spaceship}, \ref{expr.rel}, \ref{expr.eq})
+The exception specification for a comparison operator function\iref{over.binary}
 without a \grammarterm{noexcept-specifier}
 that is defaulted on its first declaration
 is potentially-throwing if and only if

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -3506,6 +3506,18 @@ If both forms of the operator function have been declared,
 the rules in~\ref{over.match.oper} determine which, if any, interpretation is
 used.
 
+\pnum
+An \defnadj{equality}{operator function} is an operator function
+for an equality operator\iref{expr.eq}.
+A \defnadj{relational}{operator function} is an operator function
+for a relational operator\iref{expr.rel}.
+A \defnadj{three-way comparison}{operator function} is an operator function
+for the three-way comparison operator\iref{expr.spaceship}.
+A \defnadj{comparison}{operator function} is
+an equality operator function,
+a relational operator function, or
+a three-way comparison operator function.
+
 \rSec2[over.ass]{Assignment}
 \indextext{assignment operator!overloaded}%
 \indextext{overloading!assignment operator}


### PR DESCRIPTION
instead of 'comparison operator function', and
define the term in [over.binary].

Fixes #3284.