### PR TITLE
[lib] Do not use macro \libconcept in headings.

### DIFF
--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -271,7 +271,7 @@ This subclause contains the definition of concepts corresponding to language
 features. These concepts express relationships between types, type
 classifications, and fundamental type properties.
 
-\rSec2[concept.same]{Concept \libconcept{same_as}}
+\rSec2[concept.same]{Concept \cname{same_as}}
 
 \begin{itemdecl}
 template<class T, class U>
@@ -289,7 +289,7 @@ vice versa.
 \end{note}
 \end{itemdescr}
 
-\rSec2[concept.derived]{Concept \libconcept{derived_from}}
+\rSec2[concept.derived]{Concept \cname{derived_from}}
 
 \begin{itemdecl}
 template<class Derived, class Base>
@@ -307,7 +307,7 @@ template<class Derived, class Base>
 \end{note}
 \end{itemdescr}
 
-\rSec2[concept.convertible]{Concept \libconcept{convertible_to}}
+\rSec2[concept.convertible]{Concept \cname{convertible_to}}
 
 \pnum
 The \libconcept{convertible_to} concept requires an expression of a particular
@@ -360,7 +360,7 @@ expression.
 \end{itemdescr}
 
 
-\rSec2[concept.commonref]{Concept \libconcept{common_reference_with}}
+\rSec2[concept.commonref]{Concept \cname{common_reference_with}}
 
 \pnum
 For two types \tcode{T} and \tcode{U}, if \tcode{common_reference_t<T, U>}
@@ -407,7 +407,7 @@ the \tcode{basic_common_reference} class template\iref{meta.trans.other}.
 \end{note}
 \end{itemdescr}
 
-\rSec2[concept.common]{Concept \libconcept{common_with}}
+\rSec2[concept.common]{Concept \cname{common_with}}
 
 \pnum
 If \tcode{T} and \tcode{U} can both be explicitly converted to some third type,
@@ -488,7 +488,7 @@ not unsigned integer types\iref{basic.fundamental}; for example, \tcode{bool}.
 \end{note}
 \end{itemdescr}
 
-\rSec2[concept.assignable]{Concept \libconcept{assignable_from}}
+\rSec2[concept.assignable]{Concept \cname{assignable_from}}
 
 \begin{itemdecl}
 template<class LHS, class RHS>
@@ -539,7 +539,7 @@ of \tcode{=}.
 \end{note}
 \end{itemdescr}
 
-\rSec2[concept.swappable]{Concept \libconcept{swappable}}
+\rSec2[concept.swappable]{Concept \cname{swappable}}
 
 \pnum
 Let \tcode{t1} and \tcode{t2} be equality-preserving expressions that denote
@@ -700,7 +700,7 @@ int main() {
 \end{codeblock}
 \end{example}
 
-\rSec2[concept.destructible]{Concept \libconcept{destructible}}
+\rSec2[concept.destructible]{Concept \cname{destructible}}
 
 \pnum
 The \libconcept{destructible} concept specifies properties of all types,
@@ -721,7 +721,7 @@ invocation of the destructor does not actually throw.
 \end{note}
 \end{itemdescr}
 
-\rSec2[concept.constructible]{Concept \libconcept{constructible_from}}
+\rSec2[concept.constructible]{Concept \cname{constructible_from}}
 
 \pnum
 The \libconcept{constructible_from} concept constrains the initialization of a
@@ -732,14 +732,14 @@ template<class T, class... Args>
   concept @\deflibconcept{constructible_from}@ = destructible<T> && is_constructible_v<T, Args...>;
 \end{itemdecl}
 
-\rSec2[concept.defaultconstructible]{Concept \libconcept{default_constructible}}
+\rSec2[concept.defaultconstructible]{Concept \cname{default_constructible}}
 
 \begin{itemdecl}
 template<class T>
   concept @\deflibconcept{default_constructible}@ = constructible_from<T>;
 \end{itemdecl}
 
-\rSec2[concept.moveconstructible]{Concept \libconcept{move_constructible}}
+\rSec2[concept.moveconstructible]{Concept \cname{move_constructible}}
 
 \begin{itemdecl}
 template<class T>
@@ -762,7 +762,7 @@ but unspecified\iref{lib.types.movedfrom}; otherwise, it is unchanged.
 \end{itemize}
 \end{itemdescr}
 
-\rSec2[concept.copyconstructible]{Concept \libconcept{copy_constructible}}
+\rSec2[concept.copyconstructible]{Concept \cname{copy_constructible}}
 
 \begin{itemdecl}
 template<class T>
@@ -795,7 +795,7 @@ If \tcode{T} is an object type, then let \tcode{v} be an lvalue of type
 This subclause describes concepts that establish relationships and orderings
 on values of possibly differing object types.
 
-\rSec2[concept.boolean]{Concept \libconcept{boolean}}
+\rSec2[concept.boolean]{Concept \cname{boolean}}
 
 \pnum
 The \libconcept{boolean} concept specifies the requirements on a type that is
@@ -855,7 +855,7 @@ types. Pointers, smart pointers, and types with only explicit conversions to
 \tcode{bool} are not \libconcept{boolean} types.
 \end{example}
 
-\rSec2[concept.equalitycomparable]{Concept \libconcept{equality_comparable}}
+\rSec2[concept.equalitycomparable]{Concept \cname{equality_comparable}}
 
 \begin{itemdecl}
 template<class T, class U>
@@ -931,7 +931,7 @@ common_reference_t<const remove_reference_t<T>&, const remove_reference_t<U>&>
 \tcode{bool(t == u) == bool(C(t) == C(u))}.
 \end{itemdescr}
 
-\rSec2[concept.totallyordered]{Concept \libconcept{totally_ordered}}
+\rSec2[concept.totallyordered]{Concept \cname{totally_ordered}}
 
 \begin{itemdecl}
 template<class T>
@@ -1053,7 +1053,7 @@ built-in types like \tcode{int} and that are comparable with
 The concepts in this subclause describe the requirements on function
 objects\iref{function.objects} and their arguments.
 
-\rSec2[concept.invocable]{Concept \libconcept{invocable}}
+\rSec2[concept.invocable]{Concept \cname{invocable}}
 
 \pnum
 The \libconcept{invocable} concept specifies a relationship between a callable
@@ -1076,7 +1076,7 @@ equality-preserving\iref{concepts.equality}.
 \end{example}
 \end{itemdescr}
 
-\rSec2[concept.regularinvocable]{Concept \libconcept{regular_invocable}}
+\rSec2[concept.regularinvocable]{Concept \cname{regular_invocable}}
 
 \begin{itemdecl}
 template<class F, class... Args>
@@ -1105,14 +1105,14 @@ is purely semantic.
 \end{note}
 \end{itemdescr}
 
-\rSec2[concept.predicate]{Concept \libconcept{predicate}}
+\rSec2[concept.predicate]{Concept \cname{predicate}}
 
 \begin{itemdecl}
 template<class F, class... Args>
   concept @\deflibconcept{predicate}@ = regular_invocable<F, Args...> && boolean<invoke_result_t<F, Args...>>;
 \end{itemdecl}
 
-\rSec2[concept.relation]{Concept \libconcept{relation}}
+\rSec2[concept.relation]{Concept \cname{relation}}
 
 \begin{itemdecl}
 template<class R, class T, class U>
@@ -1121,7 +1121,7 @@ template<class R, class T, class U>
     predicate<R, T, U> && predicate<R, U, T>;
 \end{itemdecl}
 
-\rSec2[concept.strictweakorder]{Concept \libconcept{strict_weak_order}}
+\rSec2[concept.strictweakorder]{Concept \cname{strict_weak_order}}
 
 \begin{itemdecl}
 template<class R, class T, class U>

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1191,7 +1191,7 @@ struct I {
 and \tcode{\placeholder{ITER_CONCEPT}(I)} denotes \tcode{random_access_iterator_tag}.
 \end{example}
 
-\rSec3[iterator.concept.readable]{Concept \libconcept{readable}}
+\rSec3[iterator.concept.readable]{Concept \cname{readable}}
 
 \pnum
 Types that are readable by applying \tcode{operator*}
@@ -1219,7 +1219,7 @@ The expression \tcode{*i} is indirectly required to be valid via the
 exposition-only \placeholder{dereferenceable} concept\iref{iterator.synopsis}.
 \end{note}
 
-\rSec3[iterator.concept.writable]{Concept \libconcept{writable}}
+\rSec3[iterator.concept.writable]{Concept \cname{writable}}
 
 \pnum
 The \libconcept{writable} concept specifies the requirements for writing a value
@@ -1271,7 +1271,7 @@ Consequently, an iterator type \tcode{I} that returns \tcode{std::string}
 by value does not model \tcode{\libconcept{writable}<I, std::string>}.
 \end{note}
 
-\rSec3[iterator.concept.winc]{Concept \libconcept{weakly_incrementable}}
+\rSec3[iterator.concept.winc]{Concept \cname{weakly_incrementable}}
 
 \pnum
 The \libconcept{weakly_incrementable} concept specifies the requirements on
@@ -1425,7 +1425,7 @@ can be used with istreams as the source of the input data through the \tcode{ist
 template.
 \end{note}
 
-\rSec3[iterator.concept.inc]{Concept \libconcept{incrementable}}
+\rSec3[iterator.concept.inc]{Concept \cname{incrementable}}
 
 \pnum
 The \libconcept{incrementable} concept specifies requirements on types that can be incremented with the pre-
@@ -1465,7 +1465,7 @@ allows the use of multi-pass one-directional
 algorithms with types that model \libconcept{incrementable}.
 \end{note}
 
-\rSec3[iterator.concept.iterator]{Concept \libconcept{input_or_output_iterator}}
+\rSec3[iterator.concept.iterator]{Concept \cname{input_or_output_iterator}}
 
 \pnum
 The \libconcept{input_or_output_iterator} concept forms the basis
@@ -1492,7 +1492,7 @@ Unlike the \oldconcept{Iterator} requirements,
 the \libconcept{input_or_output_iterator} concept does not require copyability.
 \end{note}
 
-\rSec3[iterator.concept.sentinel]{Concept \libconcept{sentinel_for}}
+\rSec3[iterator.concept.sentinel]{Concept \cname{sentinel_for}}
 
 \pnum
 The \libconcept{sentinel_for} concept specifies the relationship
@@ -1528,7 +1528,7 @@ continue to denote a range after incrementing any other iterator equal
 to \tcode{i}. Consequently, \tcode{i == s} is no longer required to be
 well-defined.
 
-\rSec3[iterator.concept.sizedsentinel]{Concept \libconcept{sized_sentinel_for}}
+\rSec3[iterator.concept.sizedsentinel]{Concept \cname{sized_sentinel_for}}
 
 \pnum
 The \libconcept{sized_sentinel_for} concept specifies
@@ -1595,7 +1595,7 @@ counted iterators and their sentinels\iref{counted.iterator}.
 \end{example}
 \end{itemdescr}
 
-\rSec3[iterator.concept.input]{Concept \libconcept{input_iterator}}
+\rSec3[iterator.concept.input]{Concept \cname{input_iterator}}
 
 \pnum
 The \libconcept{input_iterator} concept defines requirements for a type
@@ -1617,7 +1617,7 @@ template<class I>
     derived_from<@\placeholdernc{ITER_CONCEPT}@(I), input_iterator_tag>;
 \end{codeblock}
 
-\rSec3[iterator.concept.output]{Concept \libconcept{output_iterator}}
+\rSec3[iterator.concept.output]{Concept \cname{output_iterator}}
 
 \pnum
 The \libconcept{output_iterator} concept defines requirements for a type that
@@ -1652,7 +1652,7 @@ Algorithms on output iterators should never attempt to pass through the same ite
 They should be single-pass algorithms.
 \end{note}
 
-\rSec3[iterator.concept.forward]{Concept \libconcept{forward_iterator}}
+\rSec3[iterator.concept.forward]{Concept \cname{forward_iterator}}
 
 \pnum
 The \libconcept{forward_iterator} concept adds
@@ -1702,7 +1702,7 @@ a mutable iterator
 allow the use of multi-pass one-directional algorithms with forward iterators.
 \end{note}
 
-\rSec3[iterator.concept.bidir]{Concept \libconcept{bidirectional_iterator}}
+\rSec3[iterator.concept.bidir]{Concept \cname{bidirectional_iterator}}
 
 \pnum
 The \libconcept{bidirectional_iterator} concept adds the ability
@@ -1741,7 +1741,7 @@ Let \tcode{a} and \tcode{b} be equal objects of type \tcode{I}.
     \tcode{bool(--(++a) == b)}.
 \end{itemize}
 
-\rSec3[iterator.concept.random.access]{Concept \libconcept{random_access_iterator}}
+\rSec3[iterator.concept.random.access]{Concept \cname{random_access_iterator}}
 
 \pnum
 The \libconcept{random_access_iterator} concept adds support for
@@ -1793,7 +1793,7 @@ and let \tcode{n} denote a value of type \tcode{D}.
 \item \tcode{bool(a <= b)} is \tcode{true}.
 \end{itemize}
 
-\rSec3[iterator.concept.contiguous]{Concept \libconcept{contiguous_iterator}}
+\rSec3[iterator.concept.contiguous]{Concept \cname{contiguous_iterator}}
 
 \pnum
 The \libconcept{contiguous_iterator} concept provides a guarantee that
@@ -2407,7 +2407,7 @@ used in the concepts below imposes constraints on the concepts' arguments
 in addition to those that appear in the concepts' bodies\iref{range.cmp}.
 \end{note}
 
-\rSec3[alg.req.ind.move]{Concept \libconcept{indirectly_movable}}
+\rSec3[alg.req.ind.move]{Concept \cname{indirectly_movable}}
 
 \pnum
 The \libconcept{indirectly_movable} concept specifies the relationship between
@@ -2449,7 +2449,7 @@ iter_value_t<In> obj(ranges::iter_move(i));
 the resulting state of the value denoted by \tcode{*i} is
 valid but unspecified\iref{lib.types.movedfrom}.
 
-\rSec3[alg.req.ind.copy]{Concept \libconcept{indirectly_copyable}}
+\rSec3[alg.req.ind.copy]{Concept \cname{indirectly_copyable}}
 
 \pnum
 The \libconcept{indirectly_copyable} concept specifies the relationship between
@@ -2492,7 +2492,7 @@ iter_value_t<In> obj(*i);
 of the value denoted by \tcode{*i} is
 valid but unspecified\iref{lib.types.movedfrom}.
 
-\rSec3[alg.req.ind.swap]{Concept \libconcept{indirectly_swappable}}
+\rSec3[alg.req.ind.swap]{Concept \cname{indirectly_swappable}}
 
 \pnum
 The \libconcept{indirectly_swappable} concept specifies a swappable relationship
@@ -2510,7 +2510,7 @@ template<class I1, class I2 = I1>
     };
 \end{codeblock}
 
-\rSec3[alg.req.ind.cmp]{Concept \libconcept{indirectly_comparable}}
+\rSec3[alg.req.ind.cmp]{Concept \cname{indirectly_comparable}}
 
 \pnum
 The \libconcept{indirectly_comparable} concept specifies
@@ -2524,7 +2524,7 @@ template<class I1, class I2, class R, class P1 = identity,
     indirect_relation<R, projected<I1, P1>, projected<I2, P2>>;
 \end{codeblock}
 
-\rSec3[alg.req.permutable]{Concept \libconcept{permutable}}
+\rSec3[alg.req.permutable]{Concept \cname{permutable}}
 
 \pnum
 The \libconcept{permutable} concept specifies the common requirements
@@ -2538,7 +2538,7 @@ template<class I>
     indirectly_swappable<I, I>;
 \end{codeblock}
 
-\rSec3[alg.req.mergeable]{Concept \libconcept{mergeable}}
+\rSec3[alg.req.mergeable]{Concept \cname{mergeable}}
 
 \pnum
 The \libconcept{mergeable} concept specifies the requirements of algorithms
@@ -2556,7 +2556,7 @@ template<class I1, class I2, class Out, class R = ranges::less,
     indirect_strict_weak_order<R, projected<I1, P1>, projected<I2, P2>>;
 \end{codeblock}
 
-\rSec3[alg.req.sortable]{Concept \libconcept{sortable}}
+\rSec3[alg.req.sortable]{Concept \cname{sortable}}
 
 \pnum
 The \libconcept{sortable} concept specifies the common requirements of


### PR DESCRIPTION
It injects garbage into the PDF bookmarks.