### PR TITLE
[basic.lval] Adjust cross-reference in the note.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -274,7 +274,7 @@ A glvalue shall not have type \cv{}~\tcode{void}.
 \begin{note}
 A glvalue may have complete or incomplete non-\tcode{void} type.
 Class and array prvalues can have cv-qualified types; other prvalues
-always have cv-unqualified types. See \ref{expr.prop}.
+always have cv-unqualified types. See \ref{expr.type}.
 \end{note}
 
 \pnum


### PR DESCRIPTION
Fixes #3287.