### PR TITLE
[iterator.concept.winc] fix "extended integral type"

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1312,7 +1312,7 @@ otherwise, it is an \defnadj{unsigned-integer-class}{type}.
 
 \pnum
 For every integer-class type \tcode{I},
-let \tcode{B(I)} be a hypothetical extended integral type
+let \tcode{B(I)} be a hypothetical extended integer type
 of the same signedness with the smallest width\iref{basic.fundamental}
 capable of representing the same range of values.
 The width of \tcode{I} is equal to the width of \tcode{B(I)}.


### PR DESCRIPTION
The term defined in [basic.fundamental] is _extended integer type_.