### PR TITLE
[time.duration.cast,time.point.cast] Rename subclause to 'Conversions'.

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -138,7 +138,7 @@ namespace std {
       constexpr auto operator<=>(const duration<Rep1, Period1>& lhs,
                                  const duration<Rep2, Period2>& rhs);
 
-    // \ref{time.duration.cast}, \tcode{duration_cast}
+    // \ref{time.duration.cast}, conversions
     template<class ToDuration, class Rep, class Period>
       constexpr ToDuration duration_cast(const duration<Rep, Period>& d);
     template<class ToDuration, class Rep, class Period>
@@ -211,7 +211,7 @@ namespace std {
        constexpr auto operator<=>(const time_point<Clock, Duration1>& lhs,
                                   const time_point<Clock, Duration2>& rhs);
 
-    // \ref{time.point.cast}, \tcode{time_point_cast}
+    // \ref{time.point.cast}, conversions
     template<class ToDuration, class Clock, class Duration>
       constexpr time_point<Clock, ToDuration>
         time_point_cast(const time_point<Clock, Duration>& t);
@@ -1779,7 +1779,7 @@ template<class Rep1, class Period1, class Rep2, class Period2>
 \tcode{CT(lhs).count() <=> CT(rhs).count()}.
 \end{itemdescr}
 
-\rSec2[time.duration.cast]{\tcode{duration_cast}}
+\rSec2[time.duration.cast]{Conversions}
 
 \indexlibrarymember{duration}{duration_cast}%
 \indexlibraryglobal{duration_cast}%
@@ -2475,7 +2475,7 @@ template<class Clock, class Duration1,
 \tcode{lhs.time_since_epoch() <=> rhs.time_since_epoch()}.
 \end{itemdescr}
 
-\rSec2[time.point.cast]{\tcode{time_point_cast}}
+\rSec2[time.point.cast]{Conversions}
 
 \indexlibrarymember{time_point}{time_point_cast}%
 \indexlibraryglobal{time_point_cast}%


### PR DESCRIPTION
The subclause describes functions beyond
duration_cast and time_point_cast.

Fixes #3298.