### PR TITLE
[numerics,input.output] Consistently use ios_base::failure.

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -2221,9 +2221,9 @@ otherwise
 If \tcode{((state | (rdbuf() ? goodbit : badbit)) \& exceptions()) == 0},
 returns.
 Otherwise, the function throws an object of class
-\tcode{basic_ios::failure}\iref{ios.failure},
+\tcode{ios_base::failure}\iref{ios.failure},
 constructed with
-\impldef{argument values to construct \tcode{basic_ios::failure}}
+\impldef{argument values to construct \tcode{ios_base::failure}}
 argument values.%
 \end{itemdescr}
 
@@ -2238,7 +2238,7 @@ void setstate(iostate state);
 Calls
 \tcode{clear(rdstate() | state)}
 (which may throw
-\tcode{basic_ios::failure}\iref{ios.failure}).
+\tcode{ios_base::failure}\iref{ios.failure}).
 \end{itemdescr}
 
 \indexlibrarymember{good}{basic_ios}%
@@ -4562,7 +4562,7 @@ to obtain the requested input.
 If an exception is thrown during input then
 \tcode{ios::badbit}
 is turned on\footnote{This is done without causing an
-\tcode{ios::failure}
+\tcode{ios_base::failure}
 to be thrown.}
 in
 \tcode{*this}'s
@@ -4900,7 +4900,7 @@ in the first location of the array.
 If an exception is thrown during input then
 \tcode{ios::badbit}
 is turned on\footnote{This is done without causing an
-\tcode{ios::failure}
+\tcode{ios_base::failure}
 to be thrown.}
 in
 \tcode{*this}'s
@@ -6171,7 +6171,7 @@ which might throw an exception.
 If an exception is thrown during output, then
 \tcode{ios::badbit}
 is turned on\footnote{without causing an
-\tcode{ios::failure}
+\tcode{ios_base::failure}
 to be thrown.}
 in
 \tcode{*this}'s
@@ -6576,7 +6576,7 @@ If an exception is thrown during output, then
 \tcode{ios::badbit}
 % .Fs new
 is turned on\footnote{without causing an
-\tcode{ios::failure}
+\tcode{ios_base::failure}
 to be thrown.}
 in
 \tcode{*this}'s

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -783,7 +783,7 @@ is the imaginary part\iref{istream.formatted}.
 If bad input is encountered, calls
 \tcode{is.setstate(ios_base::failbit)}
 (which may throw
-\tcode{ios::failure}\iref{iostate.flags}).
+\tcode{ios_base::\brk{}failure}\iref{iostate.flags}).
 
 \pnum
 \returns
@@ -2429,7 +2429,7 @@ according to \ref{strings} and \ref{input.output}.
     ensures that \tcode{v}'s state is unchanged by the operation
     and
     calls \tcode{is.setstate(ios::failbit)}
-    (which may throw \tcode{ios::failure}\iref{iostate.flags}).
+    (which may throw \tcode{ios_base::failure}\iref{iostate.flags}).
     If a textual representation written via \tcode{os << x}
     was subsequently read via \tcode{is >> v},
     then \tcode{x == v}
@@ -2823,7 +2823,7 @@ according to \ref{strings} and \ref{input.output}.
     ensures that \tcode{d} is unchanged by the operation
     and
     calls \tcode{is.setstate(ios::failbit)}
-    (which may throw \tcode{ios::failure}\iref{iostate.flags}).
+    (which may throw \tcode{ios_base::failure}\iref{iostate.flags}).
 
     \requires \tcode{is} provides a textual representation
     that was previously written


### PR DESCRIPTION
Do not refer to the inherited member in a derived class.

Fixes #3306.