### PR TITLE
[support.srcloc.class] Highlight unspecified properties

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -3185,6 +3185,9 @@ All of the following conditions are \tcode{true}:
 \begin{note}
 The intent of \tcode{source_location} is
 to have a small size and efficient copying.
+It is unspecified
+whether the copy/move constructors and the copy/move assignment operators
+are trivial and/or constexpr.
 \end{note}
 
 \pnum


### PR DESCRIPTION
of the source_location constructors and copy assignment
operators.

Fixes #3170.