### PR TITLE
Cleanup make-unsigned-like

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -309,7 +309,7 @@ for an integer-like type \tcode{X}\iref{iterator.concept.winc},
 \tcode{make_unsigned_t<X>} if \tcode{X} is an integer type;
 otherwise, it denotes a corresponding unspecified unsigned-integer-like type
 of the same width as \tcode{X}.
-For an object \tcode{x} of type \tcode{X},
+For an expression \tcode{x} of type \tcode{X},
 \tcode{\placeholdernc{to-unsigned-like}(x)} is
 \tcode{x} explicitly converted to
 \tcode{\placeholdernc{make-unsigned-like-t}<X>}.

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -305,14 +305,14 @@ namespace std {
 \indextext{make-unsigned-like-t@\exposid{make-unsigned-like-t}}%
 Within this clause,
 for an integer-like type \tcode{X}\iref{iterator.concept.winc},
-\tcode{\placeholdernc{make-unsigned-like-t}(X)} denotes
+\tcode{\placeholdernc{make-unsigned-like-t}<X>} denotes
 \tcode{make_unsigned_t<X>} if \tcode{X} is an integer type;
 otherwise, it denotes a corresponding unspecified unsigned-integer-like type
 of the same width as \tcode{X}.
 For an object \tcode{x} of type \tcode{X},
 \tcode{\placeholdernc{to-unsigned-like}(x)} is
 \tcode{x} explicitly converted to
-\tcode{\placeholdernc{make-unsigned-like-t}(X)}.
+\tcode{\placeholdernc{make-unsigned-like-t}<X>}.
 
 \rSec1[range.access]{Range access}
 
@@ -1315,14 +1315,14 @@ namespace std::ranges {
       K == subrange_kind::sized && !sized_sentinel_for<S, I>;
     I @\exposid{begin_}@ = I();                                             // \expos
     S @\exposid{end_}@ = S();                                               // \expos
-    @\placeholdernc{make-unsigned-like-t}@(iter_difference_t<I>) @\exposid{size_}@ = 0;       // \expos; present only
+    @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<I>> @\exposid{size_}@ = 0;       // \expos; present only
                                                                 // when \exposid{StoreSize} is \tcode{true}
   public:
     subrange() = default;
 
     constexpr subrange(I i, S s) requires (!@\exposid{StoreSize}@);
 
-    constexpr subrange(I i, S s, @\placeholdernc{make-unsigned-like-t}@(iter_difference_t<I>) n)
+    constexpr subrange(I i, S s, @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<I>> n)
       requires (K == subrange_kind::sized);
 
     template<@\exposconcept{not-same-as}@<subrange> R>
@@ -1332,7 +1332,7 @@ namespace std::ranges {
 
     template<safe_range R>
       requires convertible_to<iterator_t<R>, I> && convertible_to<sentinel_t<R>, S>
-    constexpr subrange(R&& r, @\placeholdernc{make-unsigned-like-t}@(iter_difference_t<I>) n)
+    constexpr subrange(R&& r, @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<I>> n)
       requires (K == subrange_kind::sized)
         : subrange{ranges::begin(r), ranges::end(r), n}
     {}
@@ -1345,7 +1345,7 @@ namespace std::ranges {
     {}
 
     template<@\exposconcept{pair-like-convertible-to}@<I, S> PairLike>
-    constexpr subrange(PairLike&& r, @\placeholdernc{make-unsigned-like-t}@(iter_difference_t<I>) n)
+    constexpr subrange(PairLike&& r, @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<I>> n)
       requires (K == subrange_kind::sized)
       : subrange{std::get<0>(std::forward<PairLike>(r)),
                  std::get<1>(std::forward<PairLike>(r)), n}
@@ -1360,7 +1360,7 @@ namespace std::ranges {
     constexpr S end() const;
 
     constexpr bool empty() const;
-    constexpr @\placeholdernc{make-unsigned-like-t}@(iter_difference_t<I>) size() const
+    constexpr @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<I>> size() const
       requires (K == subrange_kind::sized);
 
     [[nodiscard]] constexpr subrange next(iter_difference_t<I> n = 1) const &
@@ -1372,14 +1372,14 @@ namespace std::ranges {
   };
 
   template<input_or_output_iterator I, sentinel_for<I> S>
-    subrange(I, S, @\placeholdernc{make-unsigned-like-t}@(iter_difference_t<I>)) ->
+    subrange(I, S, @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<I>>) ->
       subrange<I, S, subrange_kind::sized>;
 
   template<@\placeholder{iterator-sentinel-pair}@ P>
     subrange(P) -> subrange<tuple_element_t<0, P>, tuple_element_t<1, P>>;
 
   template<@\placeholder{iterator-sentinel-pair}@ P>
-    subrange(P, @\placeholdernc{make-unsigned-like-t}@(iter_difference_t<tuple_element_t<0, P>>)) ->
+    subrange(P, @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<tuple_element_t<0, P>>>) ->
       subrange<tuple_element_t<0, P>, tuple_element_t<1, P>, subrange_kind::sized>;
 
   template<safe_range R>
@@ -1389,7 +1389,7 @@ namespace std::ranges {
                  ? subrange_kind::sized : subrange_kind::unsized>;
 
   template<safe_range R>
-    subrange(R&&, @\placeholdernc{make-unsigned-like-t}@(range_difference_t<R>)) ->
+    subrange(R&&, @\placeholdernc{make-unsigned-like-t}@<range_difference_t<R>>) ->
       subrange<iterator_t<R>, sentinel_t<R>, subrange_kind::sized>;
 
   template<size_t N, class I, class S, subrange_kind K>
@@ -1426,7 +1426,7 @@ Initializes \exposid{begin_} with \tcode{std::move(i)} and \exposid{end_} with
 
 \indexlibraryctor{subrange}%
 \begin{itemdecl}
-constexpr subrange(I i, S s, @\placeholdernc{make-unsigned-like-t}@(iter_difference_t<I>) n)
+constexpr subrange(I i, S s, @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<I>> n)
   requires (K == subrange_kind::sized);
 \end{itemdecl}
 
@@ -1531,7 +1531,7 @@ Equivalent to: \tcode{return \exposid{begin_} == \exposid{end_};}
 
 \indexlibrarymember{size}{subrange}%
 \begin{itemdecl}
-constexpr @\placeholdernc{make-unsigned-like-t}@(iter_difference_t<I>) size() const
+constexpr @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<I>> size() const
   requires (K == subrange_kind::sized);
 \end{itemdecl}
 

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -301,8 +301,8 @@ namespace std {
 \end{codeblock}
 
 \pnum
-\indextext{make-unigned-like@\exposid{make-unsigned-like}}%
-\indextext{make-unigned-like-t@\exposid{make-unsigned-like-t}}%
+\indextext{to-unsigned-like@\exposid{to-unsigned-like}}%
+\indextext{make-unsigned-like-t@\exposid{make-unsigned-like-t}}%
 Within this clause,
 for an integer-like type \tcode{X}\iref{iterator.concept.winc},
 \tcode{\placeholdernc{make-unsigned-like-t}(X)} denotes
@@ -310,7 +310,7 @@ for an integer-like type \tcode{X}\iref{iterator.concept.winc},
 otherwise, it denotes a corresponding unspecified unsigned-integer-like type
 of the same width as \tcode{X}.
 For an object \tcode{x} of type \tcode{X},
-\tcode{\placeholdernc{make-unsigned-like}(x)} is
+\tcode{\placeholdernc{to-unsigned-like}(x)} is
 \tcode{x} explicitly converted to
 \tcode{\placeholdernc{make-unsigned-like-t}(X)}.
 
@@ -634,7 +634,7 @@ template<class T> void size(T&&) = delete;
   \end{itemize}
 
 \item
-  Otherwise, \tcode{\placeholdernc{make-unsigned-like}(ranges::end(E) - ranges::begin(E))}\iref{range.subrange}
+  Otherwise, \tcode{\placeholdernc{to-unsigned-like}(ranges::end(E) - ranges::begin(E))}\iref{range.subrange}
   if it is a valid expression and
   the types \tcode{I} and \tcode{S} of \tcode{ranges::begin(E)} and
   \tcode{ranges::end(E)} (respectively) model both
@@ -1434,7 +1434,7 @@ constexpr subrange(I i, S s, @\placeholdernc{make-unsigned-like-t}@(iter_differe
 \pnum
 \expects
 \range{i}{s} is a valid range, and
-\tcode{n == \placeholdernc{make-unsigned-like}(ranges::distance(i, s))}.
+\tcode{n == \placeholdernc{to-unsigned-like}(ranges::distance(i, s))}.
 
 \pnum
 \effects
@@ -1540,7 +1540,7 @@ constexpr @\placeholdernc{make-unsigned-like-t}@(iter_difference_t<I>) size() co
 \effects
 \begin{itemize}
 \item If \exposid{StoreSize} is \tcode{true}, equivalent to: \tcode{return \exposid{size_};}
-\item Otherwise, equivalent to: \tcode{return \placeholdernc{make-unsigned-like}(\exposid{end_} - \exposid{begin_});}
+\item Otherwise, equivalent to: \tcode{return \placeholdernc{to-unsigned-like}(\exposid{end_} - \exposid{begin_});}
 \end{itemize}
 \end{itemdescr}
 
@@ -1607,9 +1607,9 @@ Equivalent to:
 \begin{codeblock}
 auto d = n - ranges::advance(@\exposid{begin_}@, n, @\exposid{end_}@);
 if (d >= 0)
-  @\exposid{size_}@ -= @\placeholdernc{make-unsigned-like}@(d);
+  @\exposid{size_}@ -= @\placeholdernc{to-unsigned-like}@(d);
 else
-  @\exposid{size_}@ += @\placeholdernc{make-unsigned-like}@(-d);
+  @\exposid{size_}@ += @\placeholdernc{to-unsigned-like}@(-d);
 return *this;
 \end{codeblock}
 \item Otherwise,
@@ -2114,11 +2114,11 @@ Equivalent to:
 if constexpr (@\exposconcept{is-integer-like}@<W> && @\exposconcept{is-integer-like}@<Bound>)
   return (@\exposid{value_}@ < 0)
     ? ((@\exposid{bound_}@ < 0)
-      ? @\placeholdernc{make-unsigned-like}@(-@\exposid{value_}@) - @\placeholdernc{make-unsigned-like}@(-@\exposid{bound_}@)
-      : @\placeholdernc{make-unsigned-like}@(@\exposid{bound_}@) + @\placeholdernc{make-unsigned-like}@(-@\exposid{value_}@))
-    : @\placeholdernc{make-unsigned-like}@(@\exposid{bound_}@) - @\placeholdernc{make-unsigned-like}@(@\exposid{value_}@);
+      ? @\placeholdernc{to-unsigned-like}@(-@\exposid{value_}@) - @\placeholdernc{to-unsigned-like}@(-@\exposid{bound_}@)
+      : @\placeholdernc{to-unsigned-like}@(@\exposid{bound_}@) + @\placeholdernc{to-unsigned-like}@(-@\exposid{value_}@))
+    : @\placeholdernc{to-unsigned-like}@(@\exposid{bound_}@) - @\placeholdernc{to-unsigned-like}@(@\exposid{value_}@);
 else
-  return @\placeholdernc{make-unsigned-like}@(@\exposid{bound_}@ - @\exposid{value_}@);
+  return @\placeholdernc{to-unsigned-like}@(@\exposid{bound_}@ - @\exposid{value_}@);
 \end{codeblock}
 
 \pnum


### PR DESCRIPTION
...per the direction of #3300. This PR consists of three commits:

* A commit that renames _`make-unsigned-like`_ to _`to-unsigned-like`_
* A commit that changes _`make-unsigned-like-t`_  from an exposition-only macro (invoked with parentheses) into an exposition-only alias template ("invoked" with angle brackets)
* A commit that corrects "For an object `x` of type `X`, `to-unsigned-like(x)` is..." to "For an expression `x`".

I believe the change from `()` to `<>` in the second commit makes the occurrences of _`make-unsigned-like-t`_ read better in the text - as well as increasing the intentional similarity with `make_unsigned_t<meow>` - but this change doesn't appear to have been discussed in the editorial meeting.