### PR TITLE
[basic.scope.class] Reinstate a qualification that was lost in 0e26279b88c3b8b0a09babdeec8418d383f07419.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1176,7 +1176,7 @@ the same name whose scope extends to or past the end of the member
 function's class.
 
 \pnum
-The potential scope of a declaration that extends to or past the
+The potential scope of a declaration in a class that extends to or past the
 end of a class definition also extends to the regions defined by its
 member definitions, even if the members are defined lexically outside
 the class (this includes static data member definitions, nested class


### PR DESCRIPTION
Without the introductory sentence that was deleted by that commit, we need to say explicitly that we are talking about a declaration _in a class_.

See also discussion on https://github.com/cplusplus/draft/pull/1137.