### PR TITLE
 [stmt.dcl] Vacuous initialization is defined in [basic.life]

### DIFF
--- a/source/statements.tex
+++ b/source/statements.tex
@@ -946,7 +946,7 @@ A program that jumps\footnote{The transfer from the condition of a \tcode{switch
 \tcode{case} label is considered a jump in this respect.}
 from a point where a variable with automatic storage duration is
 not in scope to a point where it is in scope is ill-formed unless
-the variable has vacuous initialization\iref{dcl.init}.
+the variable has vacuous initialization\iref{basic.life}.
 In such a case, the variables with vacuous initialization
 are constructed in the order of their declaration.
 \begin{example}


### PR DESCRIPTION
[[stmt.dcl] p3 sentence 2](http://eel.is/c++draft/stmt.dcl#3.sentence-2) says: 
> A program that jumps from a point where a variable with automatic storage duration is not in scope to a point where it is in scope is ill-formed unless the variable has vacuous initialization ([[dcl.init]](http://eel.is/c++draft/dcl.init)).

https://github.com/cplusplus/draft/commit/f3a6b2e671efdee5bacb74a5ea01d4bfb1900d3e kept the crosslink when they removed the reference to *initializer* and added vacuous initialization. Vacuous initialization is defined in [[basic.life]](http://eel.is/c++draft/basic.life).