### PR TITLE
[class.access] Allocation order of data members is described in [expr.rel]

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -4703,7 +4703,7 @@ public:
 \pnum
 \begin{note}
 The effect of access control on the order of allocation
-of data members is described in~\ref{class.mem}.
+of data members is specified in~\ref{expr.rel}.
 \end{note}
 
 \pnum


### PR DESCRIPTION
The wording in [[class.mem]](http://eel.is/c++draft/class.mem) was changed to a note by CWG2404. It is now specified (rather than described) in [[class.mem]](http://eel.is/c++draft/expr.rel).