### PR TITLE
[depr.impldec] Fix cross-reference for 'deleted function'.

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -140,7 +140,7 @@ as defaulted is deprecated if the class has
 a user-declared copy constructor or
 a user-declared destructor.
 In a future revision of this International Standard, these implicit definitions
-could become deleted\iref{dcl.fct.def}.
+could become deleted\iref{dcl.fct.def.delete}.
 
 \rSec1[depr.c.headers]{C standard library headers}
 


### PR DESCRIPTION
Fixes NB JP 376 (C++20 CD)

Fixes cplusplus/ballot#372