### PR TITLE
[diff.cpp17.lex] Add cross-references for 'requires' keyword.

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1974,8 +1974,8 @@ The \tcode{co_await}, \tcode{co_yield}, and \tcode{co_return} keywords are added
 to enable the definition of coroutines \iref{dcl.fct.def.coroutine}.
 \item
 The \tcode{requires} keyword is added
-to introduce constraints through a \grammarterm{requires-clause} or
-a \grammarterm{requires-expression}.
+to introduce constraints through a \grammarterm{requires-clause}\iref{temp.pre}
+or a \grammarterm{requires-expression}\iref{expr.prim.req}.
 \end{itemize}
 \effectafteritemize
 Valid ISO \CppXVII{} code using


### PR DESCRIPTION
Fixes NB JP 373 (C++20 CD)

Fixes cplusplus/nbballot#369.