### PR TITLE
[syncstream] Add default template parameters for basic_syncbuf and basic_osyncstream

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -10859,13 +10859,13 @@ calls
 #include <ostream>  // see \ref{ostream.syn}
 
 namespace std {
-  template<class charT, class traits, class Allocator>
+  template<class charT, class traits = char_traits<charT>, class Allocator = allocator<charT>>
     class basic_syncbuf;
 
   using syncbuf = basic_syncbuf<char>;
   using wsyncbuf = basic_syncbuf<wchar_t>;
 
-  template<class charT, class traits, class Allocator>
+  template<class charT, class traits = char_traits<charT>, class Allocator = allocator<charT>>
     class basic_osyncstream;
 
   using osyncstream = basic_osyncstream<char>;

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -10884,7 +10884,7 @@ to synchronize execution agents writing to the same stream.
 \indexlibraryglobal{basic_syncbuf}%
 \begin{codeblock}
 namespace std {
-  template<class charT, class traits, class Allocator>
+  template<class charT, class traits = char_traits<charT>, class Allocator = allocator<charT>>
   class basic_syncbuf : public basic_streambuf<charT, traits> {
   public:
     using char_type      = charT;

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -11205,7 +11205,7 @@ Equivalent to \tcode{a.swap(b)}.
 \indexlibraryglobal{basic_osyncstream}%
 \begin{codeblock}
 namespace std {
-  template<class charT, class traits, class Allocator>
+  template<class charT, class traits = char_traits<charT>, class Allocator = allocator<charT>>
   class basic_osyncstream : public basic_ostream<charT, traits> {
   public:
     using char_type   = charT;


### PR DESCRIPTION
Fixes cplusplus/nbballot#344.
Fixes cplusplus/nbballot#345.
Fixes cplusplus/nbballot#346.

The default template arguments were shown for the declarations in &lt;iosfwd>, thus this seems to be an editorial fix.
While we can't repeat default template arguments in C++, be consistent with the existing specification practice for the other iostreams classes.

Do not squash the commits; each addresses an individual NB comment.