### PR TITLE
[time.cal.month.members] Remove nested-name-specifier from declarations.

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -4299,7 +4299,7 @@ constexpr month& operator-=(const months& m) noexcept;
 
 \indexlibrarymember{operator unsigned}{month}%
 \begin{itemdecl}
-constexpr explicit month::operator unsigned() const noexcept;
+constexpr explicit operator unsigned() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/time.tex
+++ b/source/time.tex
@@ -4209,7 +4209,7 @@ The value held is unspecified if \tcode{m} is not in the range \crange{0}{255}.
 
 \indexlibrarymember{operator++}{month}%
 \begin{itemdecl}
-constexpr month& month::operator++() noexcept;
+constexpr month& operator++() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/time.tex
+++ b/source/time.tex
@@ -4310,7 +4310,7 @@ constexpr explicit operator unsigned() const noexcept;
 
 \indexlibrarymember{ok}{month}%
 \begin{itemdecl}
-constexpr bool month::ok() const noexcept;
+constexpr bool ok() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Fixes cplusplus/nbballot#337.
Fixes cplusplus/nbballot#335.
Fixes cplusplus/nbballot#336.

Do not squash; each commit addresses a separate NB comment.