### PR TITLE
[cmp.alg] Fix typo for 'ISO/IEC/IEEE 60559'.

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -4935,7 +4935,7 @@ is expression-equivalent\iref{defns.expression-equivalent} to the following:
   observed by \tcode{T}'s comparison operators, and
   if \tcode{numeric_limits<T>::is_iec559} is \tcode{true},
   is additionally consistent with the \tcode{totalOrder} operation
-  as specified in ISO/IEC/IEEE 60599.
+  as specified in ISO/IEC/IEEE 60559.
 \item
   Otherwise, \tcode{strong_ordering(E <=> F)} if it is a well-formed expression.
 \item


### PR DESCRIPTION
Fixes NB JP 177 (C++20 CD)

Fixes cplusplus/nbballot#175-