### PR TITLE
[module.reach] Clearly separate translation units in example.

### DIFF
--- a/source/modules.tex
+++ b/source/modules.tex
@@ -980,14 +980,16 @@ An entity can have reachable declarations
 even if it is not visible to name lookup.
 \end{note}
 \begin{example}
-\begin{codeblock}
+\begin{codeblocktu}{Translation unit \#1}
 export module A;
 struct X {};
 export using Y = X;
+\end{codeblocktu}
 
+\begin{codeblocktu}{Translation unit \#2}
 module B;
 import A;
 Y y;                // OK, definition of \tcode{X} is reachable
 X x;                // ill-formed: \tcode{X} not visible to unqualified lookup
-\end{codeblock}
+\end{codeblocktu}
 \end{example}


### PR DESCRIPTION
Fixes NB GB 089 (C++20 CD)

Fixes cplusplus/nbballot#88.