### PR TITLE
Fix declarations of literal operators for day and year

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -4142,7 +4142,7 @@ that value will be assigned to \tcode{*offset} if \tcode{offset} is non-null.
 
 \indexlibrarymember{operator""""d}{day}%
 \begin{itemdecl}
-constexpr day operator""d(unsigned long long d) noexcept;
+constexpr chrono::day operator""d(unsigned long long d) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/time.tex
+++ b/source/time.tex
@@ -4802,7 +4802,7 @@ that value will be assigned to \tcode{*offset} if \tcode{offset} is non-null.
 
 \indexlibrarymember{operator""""y}{year}%
 \begin{itemdecl}
-constexpr year operator""y(unsigned long long y) noexcept;
+constexpr chrono::year operator""y(unsigned long long y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Fixes cplusplus/nbballot#334, cplusplus/nbballot#339.

Do not squash.