### PR TITLE
[atomics.ref.int,atomics.types.int] Clarify notes on atomic/_ref<bool…

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -1140,7 +1140,8 @@ For each such type \tcode{\placeholder{integral}},
 the specialization \tcode{atomic_ref<\placeholder{integral}>} provides
 additional atomic operations appropriate to integral types.
 \begin{note}
-For the specialization \tcode{atomic_ref<bool>}, see \ref{atomics.ref.generic}.
+The specialization \tcode{atomic_ref<bool>}
+uses the primary template\iref{atomics.ref.generic}.
 \end{note}
 
 \begin{codeblock}
@@ -2102,7 +2103,8 @@ and any other types needed by the typedefs in the header \libheaderref{cstdint}.
 For each such type \tcode{\placeholder{integral}}, the specialization
 \tcode{atomic<\placeholder{integral}>} provides additional atomic operations appropriate to integral types.
 \begin{note}
-For the specialization \tcode{atomic<bool>}, see \ref{atomics.types.generic}.
+The specialization \tcode{atomic<bool>}
+uses the primary template\iref{atomics.types.generic}.
 \end{note}
 
 \begin{codeblock}


### PR DESCRIPTION
…> specializations.

Fixes NB US 357 (C++20 CD)

Fixes cplusplus/nbballot#353.