### PR TITLE
[iterator.requirements.general] Define 'reachable from' to avoid conf…

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -613,7 +613,7 @@ and up to but not including the element, if any, pointed to by
 the first iterator \tcode{j} such that \tcode{j == s}.
 
 \pnum
-A sentinel \tcode{s} is called \term{reachable} from an iterator \tcode{i} if
+A sentinel \tcode{s} is called \defn{reachable from} an iterator \tcode{i} if
 and only if there is a finite sequence of applications of the expression
 \tcode{++i} that makes \tcode{i == s}. If \tcode{s} is reachable from \tcode{i},
 \range{i}{s} denotes a valid range.


### PR DESCRIPTION
…usion

with 'reachable' used finding declarations in modules.

Fixes NB US 258 (C++20 CD)

Fixes #cplusplus/nbballot#254.