### PR TITLE
[temp.param] Strike redundant normative sentence.

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -390,9 +390,6 @@ on the
 are ignored when determining its type.
 
 \pnum
-When a non-type \grammarterm{template-parameter}
-of non-reference and non-class type
-is used as an initializer for a reference, a temporary is always used.
 An \grammarterm{id-expression} naming
 a non-type \grammarterm{template-parameter} of class type \tcode{T}
 denotes a static storage duration object of type \tcode{const T},


### PR DESCRIPTION
Non-type template parameters of non-reference non-class type are
prvalues, thus the usual reference initialization rules
create a temporary.

Fixes NB US099 (C++20 CD)

Fixes #cplusplus/nbballot#98.