### PR TITLE
[expr.prim.id.unqual] Excise redundant special case for the type

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1388,10 +1388,12 @@ the innermost such intervening \grammarterm{lambda-expression}.
 If that \grammarterm{lambda-expression} is not declared \tcode{mutable},
 the type of such an identifier will typically be \tcode{const} qualified.
 \end{note}
+The type of the expression is the type of the result.
+\begin{note}
 If the entity is a template parameter object for
 a template parameter of type \tcode{T}\iref{temp.param},
 the type of the expression is \tcode{const T}.
-Otherwise, the type of the expression is the type of the result.
+\end{note}
 \begin{note}
 The type will be adjusted as described in \ref{expr.type}
 if it is cv-qualified or is a reference type.


### PR DESCRIPTION
of the template parameter object.

Fixes NB US 047 (C++20 CD)

Fixes cplusplus/nbballot#46.