### PR TITLE
[temp.constr.decl] Missing case when constraints are associated with …

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1618,8 +1618,8 @@ an expression:
 
 \pnum
 Constraints can also be associated with a declaration through the use of
-\grammarterm{type-constraint}{s} in a
-\grammarterm{template-parameter-list}.
+\grammarterm{type-constraint}{s}
+in a \grammarterm{template-parameter-list} or parameter-type-list.
 Each of these forms introduces additional \grammarterm{constraint-expression}{s}
 that are used to constrain the declaration.
 


### PR DESCRIPTION
…a declaration.

Fixes NB US 108 (C++20 CD)

Fixes cplusplus/nbballot#107.