### PR TITLE
[expr.type] Fix typo when using 'reference-related'.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -368,7 +368,7 @@ if \tcode{T1} or \tcode{T2} is
 ``pointer to member of \tcode{C1} of type function'',
 the other type is
 ``pointer to member of \tcode{C2} of type \tcode{noexcept} function'', and
-\tcode{C1} is reference-related to \tcode{C1} or
+\tcode{C1} is reference-related to \tcode{C2} or
 \tcode{C2} is reference-related to \tcode{C1}\iref{dcl.init.ref},
 where the function types are otherwise the same,
 ``pointer to member of \tcode{C2} of type function'' or


### PR DESCRIPTION
Fixes NB JP 045 (C++20 CD)

Fixes cplusplus/nbballot#44