### PR TITLE
[basic.lookup.argdep] Add missing namespace qualification in example.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1942,7 +1942,7 @@ namespace R {
   export void f(X);
 }
 namespace S {
-  export void f(X, X);
+  export void f(R::X, R::X);
 }
 \end{codeblocktu}
 


### PR DESCRIPTION
Fixes NB GB 032 (C++20 CD)

Fixes cplusplus/nbballot#31