### PR TITLE
[defns.block.stmt] Add definition of block as a compound statement.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -996,7 +996,7 @@ For point of instantiation of a template, see~\ref{temp.point}.
 \indextext{scope!block}%
 \indextext{local scope|see{block scope}}%
 A name declared in a block\iref{stmt.block} is local to that block; it has
-\defn{block scope}.
+\defnx{block scope}{block (statement)!scope}.
 Its potential scope begins at its point of
 declaration\iref{basic.scope.pdecl} and ends at the end of its block.
 A variable declared at block scope is a \defn{local variable}.
@@ -6137,7 +6137,8 @@ guarantees, but will fail to make progress under weakly parallel guarantees.
 
 \pnum
 \indextext{forward progress guarantees!delegation of}%
-When a thread of execution \placeholder{P} is specified to \defn{block with forward
+When a thread of execution \placeholder{P} is specified to \defnx{block with forward
+progress guarantee delegation}{block (execution)!with forward
 progress guarantee delegation} on the completion of a set \placeholder{S} of threads
 of execution, then throughout the whole time of \placeholder{P} being blocked on
 \placeholder{S}, the implementation shall ensure that the forward progress guarantees

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -145,11 +145,17 @@ comma-separated list bounded by the parentheses\iref{cpp.replace}
 \grammarterm{id-expression} in the comma-separated
 list bounded by the angle brackets\iref{temp.arg}
 
-\indexdefn{block}%
+\indexdefn{block (execution)}%
 \definition{block}{defns.block}
+\defncontext{execution}
 wait for some condition (other than for the implementation to execute
 the execution steps of the thread of execution) to be satisfied before
 continuing execution past the blocking operation
+
+\indexdefn{block (statement)}%
+\definition{block}{defns.block.stmt}
+\defncontext{statement}
+compound statement\iref{stmt.block}
 
 \indexdefn{behavior!conditionally-supported}%
 \definition{conditionally-supported}{defns.cond.supp}

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -4,7 +4,7 @@
 
 \gramSec[gram.stmt]{Statements}
 
-\indextext{block statement|see{statement, compound}}
+\indextext{block (statement)|see{statement, compound}}
 
 \rSec1[stmt.pre]{Preamble}
 
@@ -923,12 +923,12 @@ If an identifier introduced by a declaration was previously declared in
 an outer block,
 \indextext{declaration hiding|see{name hiding}}%
 \indextext{name hiding}%
-\indextext{block structure}%
+\indextext{block (statement)!structure}%
 the outer declaration is hidden for the remainder of the block, after
 which it resumes its force.
 
 \pnum
-\indextext{block!initialization in}%
+\indextext{block (statement)!initialization in}%
 \indextext{initialization!automatic}%
 Variables with automatic storage duration\iref{basic.stc.auto} are
 initialized each time their \grammarterm{declaration-statement} is executed.

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -205,6 +205,7 @@ m.lock()
 
 \begin{itemdescr}
 \pnum
+\indextext{block (execution)}%
 \effects
 Blocks until a lock can be acquired for the current execution agent. If an exception
 is thrown then a lock shall not have been acquired for the current execution agent.
@@ -1361,6 +1362,7 @@ void join();
 
 \begin{itemdescr}
 \pnum
+\indextext{block (execution)}%
 \effects
 Blocks until the thread represented by \tcode{*this} has completed.
 
@@ -1715,6 +1717,7 @@ void join();
 
 \begin{itemdescr}
 \pnum
+\indextext{block (execution)}%
 \effects
 Blocks until the thread represented by \tcode{*this} has completed.
 
@@ -1907,6 +1910,7 @@ template<class Clock, class Duration>
 
 \begin{itemdescr}
 \pnum
+\indextext{block (execution)}%
 \effects
 Blocks the calling thread for the absolute timeout\iref{thread.req.timing} specified
 by \tcode{abs_time}.
@@ -1928,6 +1932,7 @@ template<class Rep, class Period>
 
 \begin{itemdescr}
 \pnum
+\indextext{block (execution)}%
 \effects
 Blocks the calling thread for the relative timeout\iref{thread.req.timing} specified
 by \tcode{rel_time}.
@@ -2063,6 +2068,7 @@ The expression \tcode{m.lock()} shall be well-formed and have the following sema
 thread does not own the mutex.
 
 \pnum
+\indextext{block (execution)}%
 \effects
 Blocks the calling thread until ownership of the mutex can be obtained for the calling thread.
 
@@ -2188,6 +2194,7 @@ namespace std {
 \end{codeblock}
 
 \pnum
+\indextext{block (execution)}%
 The class \tcode{mutex} provides a non-recursive mutex with exclusive ownership
 semantics. If one thread owns a mutex object, attempts by another thread to acquire
 ownership of that object will fail (for \tcode{try_lock()}) or block (for
@@ -2245,6 +2252,7 @@ namespace std {
 \end{codeblock}
 
 \pnum
+\indextext{block (execution)}%
 The class \tcode{recursive_mutex} provides a recursive mutex with exclusive ownership
 semantics. If one thread owns a \tcode{recursive_mutex} object, attempts by another
 thread to acquire ownership of that object will fail (for \tcode{try_lock()}) or block
@@ -2399,6 +2407,7 @@ namespace std {
 \end{codeblock}
 
 \pnum
+\indextext{block (execution)}%
 The class \tcode{timed_mutex} provides a non-recursive mutex with exclusive ownership
 semantics. If one thread owns a \tcode{timed_mutex} object, attempts by another thread
 to acquire ownership of that object will fail (for \tcode{try_lock()}) or block
@@ -2449,6 +2458,7 @@ namespace std {
 \end{codeblock}
 
 \pnum
+\indextext{block (execution)}%
 The class \tcode{recursive_timed_mutex} provides a recursive mutex with exclusive
 ownership semantics. If one thread owns a \tcode{recursive_timed_mutex} object,
 attempts by another thread to acquire ownership of that object will fail (for
@@ -2494,6 +2504,7 @@ shall meet the requirements set out below. In this description,
 \tcode{m} denotes an object of a shared mutex type.
 
 \pnum
+\indextext{block (execution)}%
 In addition to the exclusive lock ownership mode specified
 in~\ref{thread.mutex.requirements.mutex}, shared mutex types provide a
 \defn{shared lock} ownership mode. Multiple execution agents can
@@ -2516,6 +2527,7 @@ following semantics:
 \requires The calling thread has no ownership of the mutex.
 
 \pnum
+\indextext{block (execution)}%
 \effects
 Blocks the calling thread until shared ownership of the mutex can be obtained for the calling thread.
 If an exception is thrown then a shared lock shall not have been acquired for the current thread.
@@ -4392,6 +4404,7 @@ arguments supplied by all concurrently waiting (via \tcode{wait},
 \end{itemize}
 
 \pnum
+\indextext{block (execution)}%
 \effects
 \begin{itemize}
 \item Atomically calls \tcode{lock.unlock()} and blocks on \tcode{*this}.
@@ -4831,6 +4844,7 @@ template<class Lock>
 
 \begin{itemdescr}
 \pnum
+\indextext{block (execution)}%
 \effects
 \begin{itemize}
 \item Atomically calls \tcode{lock.unlock()} and blocks on \tcode{*this}.
@@ -4885,6 +4899,7 @@ template<class Lock, class Clock, class Duration>
 
 \begin{itemize}
 \item
+\indextext{block (execution)}%
 Atomically calls \tcode{lock.unlock()} and blocks on \tcode{*this}.
 
 \item
@@ -5185,6 +5200,7 @@ namespace std {
 \end{codeblock}
 
 \pnum
+\indextext{block (execution)}%
 Class template \tcode{counting_semaphore} maintains an internal counter
 that is initialized when the semaphore is created.
 The counter is decremented when a thread acquires the semaphore, and
@@ -5299,6 +5315,7 @@ void acquire();
 Repeatedly performs the following steps, in order:
 \begin{itemize}
 \item Evaluates \tcode{try_acquire}. If the result is \tcode{true}, returns.
+\indextext{block (execution)}%
 \item Blocks on \tcode{*this} until \tcode{counter} is greater than zero.
 \end{itemize}
 
@@ -5330,6 +5347,7 @@ Repeatedly performs the following steps, in order:
   Evaluates \tcode{try_acquire()}.
   If the result is \tcode{true}, returns \tcode{true}.
 \item
+  \indextext{block (execution)}%
   Blocks on \tcode{*this}
   until \tcode{counter} is greater than zero or until the timeout expires.
   If it is unblocked by the timeout expiring, returns \tcode{false}.
@@ -5478,6 +5496,7 @@ void wait() const;
 
 \begin{itemdescr}
 \pnum
+\indextext{block (execution)}%
 \effects
 If \tcode{counter} equals zero, returns immediately.
 Otherwise, blocks on \tcode{*this}
@@ -5584,6 +5603,7 @@ Each \defn{barrier phase} consists of the following steps:
 
 \indextext{phase synchronization point|see{barrier, phase synchronization point }}%
 \pnum
+\indextext{block (execution)}%
 Each phase defines a \defnx{phase synchronization point}{barrier!phase synchronization point}.
 Threads that arrive at the barrier during the phase
 can block on the phase synchronization point by calling \tcode{wait}, and
@@ -5711,6 +5731,7 @@ the phase synchronization point for the current phase or
 the immediately preceding phase of the same barrier object.
 
 \pnum
+\indextext{block (execution)}%
 \effects
 Blocks at the synchronization point associated with \tcode{std::move(arrival)}
 until the phase completion step of the synchronization point's phase is run.
@@ -6619,6 +6640,7 @@ void wait() const;
 
 \begin{itemdescr}
 \pnum
+\indextext{block (execution)}%
 \effects
 Blocks until the shared state is ready.
 \end{itemdescr}
@@ -6631,6 +6653,7 @@ template<class Rep, class Period>
 
 \begin{itemdescr}
 \pnum
+\indextext{block (execution)}%
 \effects
 None if the shared state contains a deferred function\iref{futures.async},
 otherwise
@@ -6664,6 +6687,7 @@ template<class Clock, class Duration>
 
 \begin{itemdescr}
 \pnum
+\indextext{block (execution)}%
 \effects
 None if the shared state contains a deferred function\iref{futures.async},
 otherwise
@@ -6952,6 +6976,7 @@ void wait() const;
 
 \begin{itemdescr}
 \pnum
+\indextext{block (execution)}%
 \effects
 Blocks until the shared state is ready.
 \end{itemdescr}
@@ -6964,6 +6989,7 @@ template<class Rep, class Period>
 
 \begin{itemdescr}
 \pnum
+\indextext{block (execution)}%
 \effects
 None if the shared state contains a deferred function\iref{futures.async},
 otherwise
@@ -6998,6 +7024,7 @@ template<class Clock, class Duration>
 
 \begin{itemdescr}
 \pnum
+\indextext{block (execution)}%
 \effects
 None if the shared state contains a deferred function\iref{futures.async},
 otherwise


### PR DESCRIPTION
Also clean up index entries to differentiate
'to block' from 'compound statement'.

Fixes NB US 021 (C++20 CD)

Fixes cplusplus/nbballot#21