### PR TITLE
[namespace.future,diff.cpp14.library] Properly refer to grammar 'digit'

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1806,8 +1806,8 @@ Reserve namespaces for future revisions of the standard library
 that might otherwise be incompatible with existing programs.
 \effect
 The global namespaces \tcode{std}
-followed by an arbitrary sequence of digits
-is reserved for future standardization.
+followed by an arbitrary sequence of \grammarterm{digit}{s}\iref{lex.name}
+are reserved for future standardization.
 Valid \CppXIV{} code that uses such a top-level namespace,
 e.g., \tcode{std2}, may be invalid in this International Standard.
 

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2532,13 +2532,13 @@ ISO/IEC 9945 and other POSIX standards.
 \rSec4[namespace.future]{Namespaces for future standardization}
 
 \pnum
-Top level namespaces with a name starting with \tcode{std} and
-followed by a non-empty sequence of digits
+Top-level namespaces whose \grammarterm{namespace-name} consists of \tcode{std}
+followed by one or more \grammarterm{digit}{s}\iref{lex.name}
 are reserved for future standardization.
 The behavior of a \Cpp{} program is undefined if
 it adds declarations or definitions to such a namespace.
 \begin{example}
-The top level namespace \tcode{std2} is reserved
+The top-level namespace \tcode{std2} is reserved
 for use by future revisions of this International Standard.
 \end{example}
 


### PR DESCRIPTION
when defining reserved namespace names.

Fixes NB GB 078 (C++20 CD)

Fixes cplusplus/nbballot#77