### PR TITLE
[dcl.inline] Function parameters shouldn't be inline

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1044,7 +1044,8 @@ constinit const char * d = f(false);    // ill-formed
 
 \pnum
 The \tcode{inline} specifier shall be applied only to the declaration
-of a variable or function.
+of a variable or function. The \tcode{inline} specifier shall not be used in the declaration
+of a function parameter.
 
 \pnum
 \indextext{specifier!\idxcode{inline}}%


### PR DESCRIPTION
It is nonsensical for function parameters to be declared `inline`, as the wording in [[dcl.inline]](http://eel.is/c++draft/dcl.inline) would be meaningless for function parameter. A function parameter does is not declared in block scope, so http://eel.is/c++draft/dcl.inline#5 doesn't apply.