### PR TITLE
[module.global,cpp.glob.frag] Rename labels to ...global.frag.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1930,7 +1930,7 @@ is visible
 if \tcode{D} would be visible to qualified name lookup\iref{namespace.qual}
 at any point in the instantiation context\iref{module.context} of the lookup,
 unless \tcode{D} is declared in another translation unit, attached to the global module,
-and is either discarded\iref{module.global} or has internal linkage.
+and is either discarded\iref{module.global.frag} or has internal linkage.
 \end{itemize}
 
 \pnum

--- a/source/modules.tex
+++ b/source/modules.tex
@@ -563,7 +563,7 @@ import M1;              // error: cyclic interface dependency $\mathtt{M3} \righ
 \end{codeblocktu}
 \end{example}
 
-\rSec1[module.global]{Global module fragment}
+\rSec1[module.global.frag]{Global module fragment}
 
 \begin{bnf}
 \nontermdef{global-module-fragment}\br
@@ -574,7 +574,7 @@ import M1;              // error: cyclic interface dependency $\mathtt{M3} \righ
 \begin{note}
 Prior to phase 4 of translation,
 only preprocessing directives can appear
-in the \grammarterm{top-level-declaration-seq}\iref{cpp.glob.frag}.
+in the \grammarterm{top-level-declaration-seq}\iref{cpp.global.frag}.
 \end{note}
 
 \pnum
@@ -913,7 +913,7 @@ for any point $P$ in the
 instantiation context\iref{module.context},
 \begin{itemize}
 \item $D$ appears prior to $P$ in the same translation unit, or
-\item $D$ is not discarded\iref{module.global},
+\item $D$ is not discarded\iref{module.global.frag},
 appears in a translation unit that is
 reachable from $P$,
 and

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -787,7 +787,7 @@ int c = Z;      // error: active macro definitions \#3 and \#5 are not valid red
 \end{example}
 \indextext{macro!import|)}
 
-\rSec1[cpp.glob.frag]{Global module fragment}
+\rSec1[cpp.global.frag]{Global module fragment}
 
 \begin{bnf}
 \nontermdef{pp-global-module-fragment}\br


### PR DESCRIPTION
That is, rename [module.global] to [module.global.frag]
and [cpp.glob.frag] to [cpp.global.frag].

Fixes NB US 088 (C++20 CD)

Fixes cplusplus/nbballot#087