### PR TITLE
[basic.types]/2 replace macro constant with constexpr variable

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4481,7 +4481,7 @@ is copied back into the object, the object shall
 subsequently hold its original value.
 \begin{example}
 \begin{codeblock}
-#define N sizeof(T)
+constexpr auto N = sizeof(T);
 char buf[N];
 T obj;                          // \tcode{obj} initialized to its original value
 std::memcpy(buf, &obj, N);      // between these two calls to \tcode{std::memcpy}, \tcode{obj} might be modified

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4481,7 +4481,7 @@ is copied back into the object, the object shall
 subsequently hold its original value.
 \begin{example}
 \begin{codeblock}
-constexpr auto N = sizeof(T);
+constexpr std::size_t N = sizeof(T);
 char buf[N];
 T obj;                          // \tcode{obj} initialized to its original value
 std::memcpy(buf, &obj, N);      // between these two calls to \tcode{std::memcpy}, \tcode{obj} might be modified


### PR DESCRIPTION
That's not a big deal, but still.