### PR TITLE
[class.copy.assign] Remove semicolon in 'of the form' phrase.

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1919,7 +1919,7 @@ struct S {
 \pnum
 The implicitly-declared move assignment operator for a class \tcode{X} will have the form
 \begin{codeblock}
-X& X::operator=(X&&);
+X& X::operator=(X&&)
 \end{codeblock}
 
 \pnum


### PR DESCRIPTION
This improves consistency with other such phrases.

Fixes late comment CH 02.

Fixes cplusplus/nbballot#376