### PR TITLE
[thread.jthread.class] Namespace not closed

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -1523,6 +1523,7 @@ namespace std {
   private:
     stop_source ssource;        // \expos
   };
+}
 \end{codeblock}
 
 \rSec3[thread.jthread.cons]{Constructors, move, and assignment}


### PR DESCRIPTION
Minor issue, my parser failed to parse the jthread codeblock because the std namespace is not closed.