### PR TITLE
Small improvements

### DIFF
--- a/source/cover-wd.tex
+++ b/source/cover-wd.tex
@@ -25,7 +25,5 @@
 Working Draft, Standard for Programming Language \Cpp{}}
 \end{center}
 \vfill
-\textbf{Note: this is an early draft. It's known to be incomplet and
-  incorrekt, and it has lots of
-  b\kern-1.2pta\kern1ptd\hspace{1.5em}for\kern-3ptmat\kern0.6ptti\raise0.15ex\hbox{n}g.}
+\textbf{Note: This is an early draft.}
 \newpage

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -793,18 +793,20 @@ phase 7) except in an \grammarterm{attribute-token}\iref{dcl.attr.grammar}:
 \keyword{friend} \\
 \keyword{goto} \\
 \keyword{if} \\
+\keyword{import} \\
 \keyword{inline} \\
 \keyword{int} \\
 \keyword{long} \\
+\keyword{module} \\
 \keyword{mutable} \\
 \keyword{namespace} \\
 \keyword{new} \\
 \keyword{noexcept} \\
 \keyword{nullptr} \\
 \keyword{operator} \\
+\columnbreak
 \keyword{private} \\
 \keyword{protected} \\
-\columnbreak
 \keyword{public} \\
 \keyword{register} \\
 \keyword{reinterpret_cast} \\
@@ -820,9 +822,9 @@ phase 7) except in an \grammarterm{attribute-token}\iref{dcl.attr.grammar}:
 \keyword{switch} \\
 \keyword{template} \\
 \keyword{this} \\
+\columnbreak
 \keyword{thread_local} \\
 \keyword{throw} \\
-\columnbreak
 \keyword{true} \\
 \keyword{try} \\
 \keyword{typedef} \\


### PR DESCRIPTION
Removed the silly message at the beginning of the specification, leaving only the sentence "This is an early draft." which transmits a lot more confidence to the ones who would read it.
Since even compilers use this document to implement early features of C++20, it's not that much incorrect.
Actually, the only noticeable incorrect message in the whole specification is this beginning notice.