### PR TITLE
[specialized.destroy] add whitespace around binary operator

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -8724,7 +8724,7 @@ template<class ForwardIterator>
 \effects
 Equivalent to:
 \begin{codeblock}
-for (; first!=last; ++first)
+for (; first != last; ++first)
   destroy_at(addressof(*first));
 \end{codeblock}
 \end{itemdescr}


### PR DESCRIPTION
...as is the typical library style.