### PR TITLE
[macros, structure.specifications] Rename "Expects:"/"Ensures:" to "Preconditions:"/"Postconditions:"

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -1332,7 +1332,7 @@ Constructs a \tcode{\placeholder{node-handle}} object initializing
 \pnum
 \expects
 Either \tcode{!alloc_}, or
-\tcode{ator_traits::propagate_on_container_move_assignment::value}
+\tcode{ator_traits::propagate_on_container_move_assignment::\-value}
 is \tcode{true}, or \tcode{alloc_ ==  nh.alloc_}.
 
 \pnum
@@ -8446,7 +8446,7 @@ template<class M>
 \pnum
 \expects
 \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{unordered_map}
-from \tcode{k}, \tcode{std::forward<M>\brk{}(obj)}.
+from \tcode{k}, \tcode{std::for\-ward<M>(obj)}.
 
 \pnum
 \effects

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -609,7 +609,7 @@ and also define the function as deleted.
 
 \item
 \expects
-the conditions (sometimes termed preconditions)
+the conditions
 that the function assumes to hold whenever it is called.
 
 \item
@@ -622,7 +622,7 @@ the synchronization operations\iref{intro.multithread} applicable to the functio
 
 \item
 \ensures
-the conditions (sometimes termed observable results or postconditions)
+the conditions (sometimes termed observable results)
 established by the function.
 
 \item

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -272,9 +272,9 @@
 \newcommand{\requires}{\Fundesc{Requires}}
 \newcommand{\constraints}{\Fundesc{Constraints}}
 \newcommand{\mandates}{\Fundesc{Mandates}}
-\newcommand{\expects}{\Fundesc{Expects}}
+\newcommand{\expects}{\Fundesc{Preconditions}}
 \newcommand{\effects}{\Fundesc{Effects}}
-\newcommand{\ensures}{\Fundesc{Ensures}}
+\newcommand{\ensures}{\Fundesc{Postconditions}}
 \newcommand{\returns}{\Fundesc{Returns}}
 \newcommand{\throws}{\Fundesc{Throws}}
 \newcommand{\default}{\Fundesc{Default behavior}}


### PR DESCRIPTION
Also adjust a few hyphenation hints where needed.

Fixes NB GB 155 (C++20 CD)

Fixes #3387.
Fixes cplusplus/nbballot#153.