### PR TITLE
[expr.sizeof] Replace inappropriate \term{n} with $n$.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4567,8 +4567,8 @@ applying \tcode{sizeof} to the subobject, due to virtual base classes
 and less strict padding requirements on potentially-overlapping subobjects.}
 \indextext{array!\idxcode{sizeof}}%
 When applied to an array, the result is the total number of bytes in the
-array. This implies that the size of an array of \term{n} elements is
-\term{n} times the size of an element.
+array. This implies that the size of an array of $n$ elements is
+$n$ times the size of an element.
 
 \pnum
 The lvalue-to-rvalue\iref{conv.lval},


### PR DESCRIPTION
I can't find other uses of `\term` for single-letter variables/placeholders; most places appear to use math-mode variables instead.