### PR TITLE
P1975R0 Fixing the wording of parenthesized aggregate-initialization

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3672,10 +3672,14 @@ a program that necessitates such a cast is ill-formed.
 \pnum
 An expression \tcode{e} can be explicitly converted to a type \tcode{T}
 if there is an implicit conversion sequence\iref{over.best.ics}
-from \tcode{e} to \tcode{T}, or
+from \tcode{e} to \tcode{T},
 if overload resolution for a direct-initialization\iref{dcl.init}
 of an object or reference of type \tcode{T} from \tcode{e}
-would find at least one viable function\iref{over.match.viable}.
+would find at least one viable function\iref{over.match.viable}, or
+if \tcode{T} is an aggregate type\iref{dcl.init.aggr}
+having a first element \tcode{x} and
+there is an implicit conversion sequence
+from \tcode{e} to the type of \tcode{x}.
 If \tcode{T} is a reference type, the effect is
 the same as performing the declaration and initialization
 \begin{codeblock}
@@ -3687,6 +3691,10 @@ Otherwise, the result object is direct-initialized from \tcode{e}.
 \begin{note}
 The conversion is ill-formed when attempting to convert an
 expression of class type to an inaccessible or ambiguous base class.
+\end{note}
+\begin{note}
+If \tcode{T} is ``array of unknown bound of \tcode{U}'',
+this direct-initialization defines the type of the expression as \tcode{U[1]}.
 \end{note}
 
 \pnum


### PR DESCRIPTION
Related to NB US 056 (C++20 CD)

Fixes #3398.
See also cplusplus/nbballot#55.