### PR TITLE
P1980R0 CA096: Declaration matching for non-dependent requires-clauses

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -416,7 +416,8 @@ appear~(\ref{expr.prim.req},
 \ref{expr.sizeof},
 \ref{expr.unary.noexcept},
 \ref{dcl.type.simple},
-\ref{temp}).
+\ref{temp.pre},
+\ref{temp.concept}).
 An unevaluated operand is not evaluated.
 \begin{note}
 In an unevaluated operand, a non-static class member may be
@@ -1284,30 +1285,6 @@ shall appear only
 \item as a subexpression of an immediate invocation, or
 \item in an immediate function context\iref{expr.const}.
 \end{itemize}
-
-\pnum
-An \grammarterm{id-expression}
-that denotes the specialization of a concept\iref{temp.concept}
-results in a prvalue of type \tcode{bool}.
-The expression is \tcode{true} if
-the concept's normalized
-\grammarterm{constraint-expression}\iref{temp.constr.decl}
-is satisfied\iref{temp.constr.constr}
-by the specified template arguments
-and \tcode{false} otherwise.
-\begin{example}
-\begin{codeblock}
-template<typename T> concept C = true;
-static_assert(C<int>);          // OK
-\end{codeblock}
-\end{example}
-\begin{note}
-A concept's constraints are also considered
-when using a template name\iref{temp.names}
-and during overload resolution\iref{over},
-and they are compared
-during the partial ordering of constraints\iref{temp.constr.order}.
-\end{note}
 
 \pnum
 For an \grammarterm{id-expression} that denotes an overload set,
@@ -7330,9 +7307,6 @@ An expression or conversion is an \defn{immediate invocation}
 if it is an explicit or implicit invocation of an immediate function and
 is not in an immediate function context.
 An immediate invocation shall be a constant expression.
-\begin{note}
-An immediate invocation is evaluated even in an unevaluated operand.
-\end{note}
 
 \pnum
 An expression or conversion \tcode{e} is \defn{manifestly constant-evaluated}
@@ -7341,9 +7315,8 @@ if it is:
 \item a \grammarterm{constant-expression}, or
 \item the condition of a constexpr if statement\iref{stmt.if}, or
 \item an immediate invocation, or
-\item a \grammarterm{constraint-expression}\iref{temp.constr.decl}
-including one formed from the \grammarterm{constraint-logical-or-expression}
-of a \grammarterm{requires-clause}, or
+\item the result of substitution into an atomic constraint expression
+to determine whether it is satisfied\iref{temp.constr.atomic}, or
 \item the initializer of a variable
 that is usable in constant expressions or
 has constant initialization.\footnote{Testing this condition
@@ -7370,6 +7343,10 @@ int q = p + f();                                        // \tcode{m} is 17 for t
 \end{codeblock}
 \end{example}
 \end{itemize}
+\begin{note}
+A manifestly constant-evaluated expression
+is evaluated even in an unevaluated operand.
+\end{note}
 
 \pnum
 \indextext{expression!potentially constant evaluated}%

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -325,7 +325,20 @@ void prog () {
 \pnum
 Two function declarations of the same name refer to the same function if they
 are in the same scope and have equivalent parameter declarations\iref{over.load}
-and equivalent trailing \grammarterm{requires-clause}{s}, if any\iref{dcl.decl}.
+and equivalent\iref{temp.over.link} trailing \grammarterm{requires-clause}{s}, if any\iref{dcl.decl}.
+\begin{note}
+Since a \grammarterm{constraint-expression} is an unevaluated operand,
+equivalence compares the expressions without evaluating them.
+\begin{example}
+\begin{codeblock}
+template<int I> concept C = true;
+template<typename T> struct A {
+  void f() requires C<42>;      // \#1
+  void f() requires true;       // OK, different functions
+};
+\end{codeblock}
+\end{example}
+\end{note}
 A function member of a derived class is
 \textit{not}
 in the same scope as a function member of the same name in a base class.

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -226,7 +226,7 @@ The \grammarterm{requires-clause} introduces the
 the \grammarterm{constraint-logical-or-expression} as a
 \grammarterm{constraint-expression}.
 The \grammarterm{constraint-logical-or-expression} of a
-\grammarterm{requires-clause} is an unevaluated operand\iref{expr}.
+\grammarterm{requires-clause} is an unevaluated operand\iref{expr.context}.
 \begin{note}
 The expression in a \grammarterm{requires-clause}
 uses a restricted grammar to avoid ambiguities.
@@ -937,6 +937,29 @@ template<C2 T> struct S { };
 
 template struct S<char[2]>;         // error: constraints not satisfied
 template<> struct S<char[2]> { };   // error: constraints not satisfied
+\end{codeblock}
+\end{example}
+
+\pnum
+A \defn{concept-id} is a \grammarterm{simple-template-id}
+where the \grammarterm{template-name} is a \grammarterm{concept-name}.
+A concept-id is a prvalue of type \tcode{bool}, and
+does not name a template specialization.
+A concept-id evaluates to \tcode{true}
+if the concept's
+normalized \grammarterm{constraint-expression}\iref{temp.constr.decl}
+is satisfied\iref{temp.constr.constr} by the specified template arguments and
+\tcode{false} otherwise.
+\begin{note}
+Since a \grammarterm{constraint-expression} is an unevaluated operand,
+a concept-id appearing in a \grammarterm{constraint-expression}
+is not evaluated except as necessary
+to determine whether the normalized constraints are satisfied.
+\end{note}
+\begin{example}
+\begin{codeblock}
+template<typename T> concept C = true;
+static_assert(C<int>);      // OK
 \end{codeblock}
 \end{example}
 
@@ -1754,8 +1777,7 @@ is the conjunction of
 the normal forms of \tcode{E1} and \tcode{E2}.
 
 \item
-The normal form of an \grammarterm{id-expression} of the form
-\tcode{C<A$_1$, A$_2$, ..., A$_n$>}, where \tcode{C} names a concept,
+The normal form of a concept-id \tcode{C<A$_1$, A$_2$, ..., A$_n$>}
 is the normal form of the \grammarterm{constraint-expression} of \tcode{C},
 after substituting \tcode{A$_1$, A$_2$, ..., A$_n$} for
 \tcode{C}{'s} respective template parameters in the
@@ -3556,6 +3578,19 @@ the one-definition rule\iref{basic.def.odr}, except that the tokens used
 to name the template parameters may differ as long as a token used to
 name a template parameter in one expression is replaced by another token
 that names the same template parameter in the other expression.
+Two unevaluated operands that do not involve template parameters
+are considered equivalent
+if two function definitions containing the expressions
+would satisfy the one-definition rule,
+except that the tokens used to name types and declarations may differ
+as long as they name the same entities, and
+the tokens used to form concept-ids may differ
+as long as the two \grammarterm{template-id}{s}
+would be considered to name the same type if,
+instead of a concept, a class template were named.
+\begin{note}
+For instance, \tcode{A<42>} and \tcode{A<40+2>} name the same type.
+\end{note}
 Two \grammarterm{lambda-expression}{s} are never considered equivalent.
 \begin{note}
 The intent is to avoid \grammarterm{lambda-expression}{s} appearing in the
@@ -3588,10 +3623,17 @@ template <class T> void spam(decltype([]{}) (*s)[sizeof(T)]);
 \end{codeblock}
 \end{example}
 \indextext{expression!functionally equivalent|see{functionally equivalent, expressions}}%
-Two expressions involving template parameters that are not equivalent are
+Two potentially-evaluated expressions involving template parameters that are not equivalent are
 \defnx{functionally equivalent}{functionally equivalent!expressions}
 if, for any given set of template arguments, the evaluation of the
 expression results in the same value.
+Two unevaluated operands that are not equivalent
+are functionally equivalent if, for any given set of template arguments,
+the expressions perform
+the same operations in the same order with the same entities.
+\begin{note}
+For instance, one could have redundant parentheses.
+\end{note}
 
 \pnum
 Two \grammarterm{template-head}{s} are
@@ -3972,13 +4014,16 @@ A concept shall not have associated constraints\iref{temp.constr.decl}.
 \pnum
 A concept is not instantiated\iref{temp.spec}.
 \begin{note}
-An \grammarterm{id-expression} that denotes a concept specialization
-is evaluated as an expression\iref{expr.prim.id}.
+A concept-id\iref{temp.names} is evaluated as an expression.
 A concept cannot be
 explicitly instantiated\iref{temp.explicit},
 explicitly specialized\iref{temp.expl.spec},
 or partially specialized.
 \end{note}
+
+\pnum
+The \grammarterm{constraint-expression} of a \grammarterm{concept-definition}
+is an unevaluated operand\iref{expr.context}.
 
 \pnum
 The first declared template parameter of a concept definition is its


### PR DESCRIPTION
Also fixes NB CA 096, US 095

Fixes #3403 
Fixes cplusplus/nbballot#95
Fixes cplusplus/nbballot#94