### PR TITLE
P1855R0 Make <compare> freestanding

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1480,6 +1480,7 @@ include at least the headers shown in \tref{headers.cpp.fs}.
 \ref{support.srcloc}     & Source location           & \tcode{<source_location>}  \\ \rowsep
 \ref{support.exception}  & Exception handling        & \tcode{<exception>}        \\ \rowsep
 \ref{support.initlist}   & Initializer lists         & \tcode{<initializer_list>} \\ \rowsep
+\ref{cmp}                & Comparisons               & \tcode{<compare>}          \\ \rowsep
 \ref{support.coroutine}  & Coroutines support        & \tcode{<coroutine>}        \\ \rowsep
 \ref{support.runtime}    & Other runtime support     & \tcode{<cstdarg>}          \\ \rowsep
 \ref{concepts}           & Concepts library          & \tcode{<concepts>}         \\ \rowsep


### PR DESCRIPTION
Fixes #3405.

Also fixes NB RU 009, FI 010, US 158, US 159, GB 160, and
PL 161 (C++20 CD).

Fixes cplusplus/nbballot#9
Fixes cplusplus/nbballot#10
Fixes cplusplus/nbballot#156
Fixes cplusplus/nbballot#157
Fixes cplusplus/nbballot#158
Fixes cplusplus/nbballot#159

Fixes cplusplus/papers#609