### PR TITLE
P1872R0 span should have size_type, not index_type

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10557,7 +10557,7 @@ namespace std {
     // constants and types
     using element_type = ElementType;
     using value_type = remove_cv_t<ElementType>;
-    using index_type = size_t;
+    using size_type = size_t;
     using difference_type = ptrdiff_t;
     using pointer = element_type*;
     using const_pointer = const element_type*;
@@ -10567,11 +10567,11 @@ namespace std {
     using const_iterator = @\impdefx{type of \tcode{span::const_iterator}}@;
     using reverse_iterator = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
-    static constexpr index_type extent = Extent;
+    static constexpr size_type extent = Extent;
 
     // \ref{span.cons}, constructors, copy, and assignment
     constexpr span() noexcept;
-    constexpr span(pointer ptr, index_type count);
+    constexpr span(pointer ptr, size_type count);
     constexpr span(pointer first, pointer last);
     template<size_t N>
       constexpr span(element_type (&arr)[N]) noexcept;
@@ -10599,18 +10599,18 @@ namespace std {
     template<size_t Offset, size_t Count = dynamic_extent>
       constexpr span<element_type, @\seebelow@> subspan() const;
 
-    constexpr span<element_type, dynamic_extent> first(index_type count) const;
-    constexpr span<element_type, dynamic_extent> last(index_type count) const;
+    constexpr span<element_type, dynamic_extent> first(size_type count) const;
+    constexpr span<element_type, dynamic_extent> last(size_type count) const;
     constexpr span<element_type, dynamic_extent> subspan(
-      index_type offset, index_type count = dynamic_extent) const;
+      size_type offset, size_type count = dynamic_extent) const;
 
     // \ref{span.obs}, observers
-    constexpr index_type size() const noexcept;
-    constexpr index_type size_bytes() const noexcept;
+    constexpr size_type size() const noexcept;
+    constexpr size_type size_bytes() const noexcept;
     [[nodiscard]] constexpr bool empty() const noexcept;
 
     // \ref{span.elem}, element access
-    constexpr reference operator[](index_type idx) const;
+    constexpr reference operator[](size_type idx) const;
     constexpr reference front() const;
     constexpr reference back() const;
     constexpr pointer data() const noexcept;
@@ -10630,7 +10630,7 @@ namespace std {
 
   private:
     pointer data_;              // \expos
-    index_type size_;           // \expos
+    size_type size_;            // \expos
   };
 
   template<class T, size_t N>
@@ -10669,7 +10669,7 @@ constexpr span() noexcept;
 
 \indexlibraryctor{span}%
 \begin{itemdecl}
-constexpr span(pointer ptr, index_type count);
+constexpr span(pointer ptr, size_type count);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10903,7 +10903,7 @@ Count != dynamic_extent ? Count
 
 \indexlibrarymember{span}{first}%
 \begin{itemdecl}
-constexpr span<element_type, dynamic_extent> first(index_type count) const;
+constexpr span<element_type, dynamic_extent> first(size_type count) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10918,7 +10918,7 @@ Equivalent to: \tcode{return \{data(), count\};}
 
 \indexlibrarymember{span}{last}%
 \begin{itemdecl}
-constexpr span<element_type, dynamic_extent> last(index_type count) const;
+constexpr span<element_type, dynamic_extent> last(size_type count) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10934,7 +10934,7 @@ Equivalent to: \tcode{return \{data() + (size() - count), count\};}
 \indexlibrarymember{span}{subspan}%
 \begin{itemdecl}
 constexpr span<element_type, dynamic_extent> subspan(
-  index_type offset, index_type count = dynamic_extent) const;
+  size_type offset, size_type count = dynamic_extent) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10957,7 +10957,7 @@ return {data() + offset, count == dynamic_extent ? size() - offset : count};
 
 \indexlibrarymember{span}{size}%
 \begin{itemdecl}
-constexpr index_type size() const noexcept;
+constexpr size_type size() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10968,7 +10968,7 @@ Equivalent to: \tcode{return size_;}
 
 \indexlibrarymember{span}{size_bytes}%
 \begin{itemdecl}
-constexpr index_type size_bytes() const noexcept;
+constexpr size_type size_bytes() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10992,7 +10992,7 @@ Equivalent to: \tcode{return size() == 0;}
 
 \indexlibrary{\idxcode{operator[]}!\idxcode{span}}%
 \begin{itemdecl}
-constexpr reference operator[](index_type idx) const;
+constexpr reference operator[](size_type idx) const;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Fixes #3407.
Fixes cplusplus/nbballot#236.
Fixes cplusplus/nbballot#241.
Fixes cplusplus/nbballot#244.

Fixes cplusplus/papers#622

Also fixes NB FR 240, US 245, and PL 248 (C++20 CD).