### PR TITLE
P1961R0 Harmonizing the definitions of total order for pointers

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -260,6 +260,15 @@ supplying a pointer to the function when calling any of the library functions th
 handler functions\iref{language.support}.
 \end{defnote}
 
+\definition{implementation-defined strict total order over pointers}
+{defns.order.ptr}
+\indexdefn{pointer!strict total order}%
+\impldef{strict total order over pointer values}
+strict total ordering over all pointer values
+such that the ordering is consistent with the partial order
+imposed by the builtin operators
+\tcode{<}, \tcode{>}, \tcode{<=}, \tcode{>=}, and \tcode{<=>}
+
 \definition{iostream class templates}{defns.iostream.templates}
 templates, defined in \ref{input.output},
 that take two template arguments

--- a/source/support.tex
+++ b/source/support.tex
@@ -4900,8 +4900,8 @@ are equality-preserving\iref{concepts.equality}.
   a call to a built-in operator \tcode{<=>} comparing pointers of type \tcode{P},
   returns \tcode{strong_ordering::less}
   if (the converted value of) \tcode{t} precedes \tcode{u}
-  in the implementation-defined strict total order\iref{range.cmp}
-  over pointers of type \tcode{P},
+  in the implementation-defined strict total order
+  over pointers\iref{defns.order.ptr},
   \tcode{strong_ordering::greater}
   if \tcode{u} precedes \tcode{t}, and
   otherwise \tcode{strong_ordering::equal}.

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -14583,7 +14583,7 @@ shall be equality-preserving\iref{concepts.equality}.
 \begin{itemize}
 \item
   If the expression \tcode{std::forward<T>(t) == std::forward<U>(u)} results in
-  a call to a built-in operator \tcode{==} comparing pointers of type \tcode{P}:
+  a call to a built-in operator \tcode{==} comparing pointers:
   returns \tcode{false} if either (the converted value of) \tcode{t} precedes
   \tcode{u} or \tcode{u} precedes \tcode{t} in the implementation-defined strict
   total order over pointers\iref{defns.order.ptr} and otherwise \tcode{true}.
@@ -14662,7 +14662,7 @@ shall be \tcode{true}.
 \begin{itemize}
 \item
 If the expression \tcode{std::forward<T>(t) < std::forward<U>(u)} results in a
-call to a built-in operator \tcode{<} comparing pointers of type \tcode{P}:
+call to a built-in operator \tcode{<} comparing pointers:
 returns \tcode{true} if (the converted value of) \tcode{t} precedes \tcode{u} in
 the implementation-defined strict total order over pointers\iref{defns.order.ptr}
 and otherwise \tcode{false}.

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -14283,21 +14283,19 @@ operators in the language~(\ref{expr.rel}, \ref{expr.eq}).
 \pnum
 For templates \tcode{less}, \tcode{greater}, \tcode{less_equal}, and
 \tcode{greater_equal}, the specializations for any pointer type
-yield a strict total order that is consistent among those specializations and
-is also consistent with the partial order imposed by
-the built-in operators \tcode{<}, \tcode{>}, \tcode{<=}, \tcode{>=}.
+yield a result consistent with the
+implementation-defined strict total order over pointers\iref{defns.order.ptr}.
 \begin{note}
-When \tcode{a < b} is well-defined
+If \tcode{a < b} is well-defined
 for pointers \tcode{a} and \tcode{b} of type \tcode{P},
-this implies \tcode{(a < b) == less<P>()(a, b)},
+then \tcode{(a < b) == less<P>()(a, b)},
 \tcode{(a > b) == greater<P>()(a, b)}, and so forth.
 \end{note}
 For template specializations \tcode{less<void>}, \tcode{greater<void>},
 \tcode{less_equal<void>}, and \tcode{greater_equal<void>},
 if the call operator calls a built-in operator comparing pointers,
-the call operator yields a strict total order
-that is consistent among those specializations and
-is also consistent with the partial order imposed by those built-in operators.
+the call operator yields a result consistent
+with the implementation-defined strict total order over pointers.
 
 \rSec3[comparisons.equal.to]{Class template \tcode{equal_to}}
 
@@ -14561,12 +14559,6 @@ operator\iref{expr.rel} is a boolean constant expression.
 in the expression \tcode{declval<T>() $op$ declval<U>()} resolves to a built-in
 operator comparing pointers.
 
-\pnum
-There is an implementation-defined strict total ordering over all pointer values
-of a given type. This total ordering is consistent with the partial order imposed
-by the builtin operators \tcode{<}, \tcode{>}, \tcode{<=}, \tcode{>=}, and
-\tcode{<=>}.
-
 \indexlibraryglobal{equal_to}%
 \begin{itemdecl}
 struct ranges::equal_to {
@@ -14594,7 +14586,7 @@ shall be equality-preserving\iref{concepts.equality}.
   a call to a built-in operator \tcode{==} comparing pointers of type \tcode{P}:
   returns \tcode{false} if either (the converted value of) \tcode{t} precedes
   \tcode{u} or \tcode{u} precedes \tcode{t} in the implementation-defined strict
-  total order over pointers of type \tcode{P} and otherwise \tcode{true}.
+  total order over pointers\iref{defns.order.ptr} and otherwise \tcode{true}.
 
 \item
   Otherwise, equivalent to:
@@ -14672,7 +14664,7 @@ shall be \tcode{true}.
 If the expression \tcode{std::forward<T>(t) < std::forward<U>(u)} results in a
 call to a built-in operator \tcode{<} comparing pointers of type \tcode{P}:
 returns \tcode{true} if (the converted value of) \tcode{t} precedes \tcode{u} in
-the implementation-defined strict total order over pointers of type \tcode{P}
+the implementation-defined strict total order over pointers\iref{defns.order.ptr}
 and otherwise \tcode{false}.
 
 \item


### PR DESCRIPTION
Also fixes NB US 176, US 220 (C++20 CD)

Fixes #3411
Fixes cplusplus/nbballot#174
Fixes cplusplus/nbballot#217