### PR TITLE
P1878R1 Constraining Readable Types

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -222,13 +222,13 @@ for which it does not have to be defined.
 If \range{a}{b} denotes a range,
 the semantics of \tcode{b - a} in these cases are the same as those of
 \begin{codeblock}
-iter_difference_t<remove_reference_t<decltype(a)>> n = 0;
+iter_difference_t<decltype(a)> n = 0;
 for (auto tmp = a; tmp != b; ++tmp) ++n;
 return n;
 \end{codeblock}
 and if \range{b}{a} denotes a range, the same as those of
 \begin{codeblock}
-iter_difference_t<remove_reference_t<decltype(b)>> n = 0;
+iter_difference_t<decltype(b)> n = 0;
 for (auto tmp = b; tmp != a; ++tmp) --n;
 return n;
 \end{codeblock}

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -50,8 +50,8 @@ namespace std {
   template<class T>
     using iter_difference_t = @\seebelow@;
 
-  // \ref{readable.traits}, readable traits
-  template<class> struct readable_traits;
+  // \ref{readable.traits}, indirectly readable traits
+  template<class> struct indirectly_readable_traits;
   template<class T>
     using iter_value_t = @\seebelow@;
 
@@ -59,7 +59,7 @@ namespace std {
   template<class I> struct iterator_traits;
   template<class T> requires is_object_v<T> struct iterator_traits<T*>;
 
-  template<@\placeholder{dereferenceable}@ T>
+  template<@\exposconcept{dereferenceable}@ T>
     using iter_reference_t = decltype(*declval<T&>());
 
   namespace ranges {
@@ -73,7 +73,7 @@ namespace std {
     }
   }
 
-  template<@\placeholder{dereferenceable}@ T>
+  template<@\exposconcept{dereferenceable}@ T>
     requires requires(T& t) {
       { ranges::iter_move(t) } -> @\placeholder{can-reference}@;
     }
@@ -81,17 +81,17 @@ namespace std {
     = decltype(ranges::iter_move(declval<T&>()));
 
   // \ref{iterator.concepts}, iterator concepts
-  // \ref{iterator.concept.readable}, concept \libconcept{readable}
+  // \ref{iterator.concept.readable}, concept \libconcept{indirectly_readable}
   template<class In>
-    concept readable = @\seebelow@;
+    concept indirectly_readable = @\seebelow@;
 
-  template<readable T>
+  template<indirectly_readable T>
     using iter_common_reference_t =
       common_reference_t<iter_reference_t<T>, iter_value_t<T>&>;
 
-  // \ref{iterator.concept.writable}, concept \libconcept{writable}
+  // \ref{iterator.concept.writable}, concept \libconcept{indirectly_writable}
   template<class Out, class T>
-    concept writable = @\seebelow@;
+    concept indirectly_writable = @\seebelow@;
 
   // \ref{iterator.concept.winc}, concept \libconcept{weakly_incrementable}
   template<class I>
@@ -161,11 +161,11 @@ namespace std {
     concept indirect_strict_weak_order = @\seebelow@;
 
   template<class F, class... Is>
-    requires (readable<Is> && ...) && invocable<F, iter_reference_t<Is>...>
+    requires (indirectly_readable<Is> && ...) && invocable<F, iter_reference_t<Is>...>
       using indirect_result_t = invoke_result_t<F, iter_reference_t<Is>...>;
 
   // \ref{projected}, projected
-  template<readable I, indirectly_regular_unary_invocable<I> Proj>
+  template<indirectly_readable I, indirectly_regular_unary_invocable<I> Proj>
     struct projected;
 
   template<weakly_incrementable I, class Proj>
@@ -474,7 +474,7 @@ called the
 \term{value type}
 of the iterator.
 An output iterator \tcode{i} has a non-empty set of types that are
-\defn{writable} to the iterator;
+\libconcept{indirectly_writable} to the iterator;
 for each such type \tcode{T}, the expression \tcode{*i = o}
 is valid where \tcode{o} is a value of type \tcode{T}.
 For every iterator type
@@ -715,34 +715,37 @@ namespace std {
 
 \indexlibraryglobal{iter_difference_t}%
 \pnum
+Let $R_\tcode{I}$ be \tcode{remove_cvref_t<I>}.
 The type \tcode{iter_difference_t<I>} denotes
 \begin{itemize}
 \item
-\tcode{incrementable_traits<I>::difference_type}
-if \tcode{iterator_traits<I>} names a specialization
+\tcode{incrementable_traits<$R_\tcode{I}$>::difference_type}
+if \tcode{iterator_traits<$R_\tcode{I}$>} names a specialization
 generated from the primary template, and
 
 \item
-\tcode{iterator_traits<I>::\brk{}difference_type} otherwise.
+\tcode{iterator_traits<$R_\tcode{I}$>::difference_type} otherwise.
 \end{itemize}
 
 \pnum
 Users may specialize \tcode{incrementable_traits} on program-defined types.
 
-\rSec3[readable.traits]{Readable traits}
+\rSec3[readable.traits]{Indirectly readable traits}
 
 \pnum
-To implement algorithms only in terms of readable types, it is often necessary
-to determine the value type that corresponds to a particular readable type.
+To implement algorithms only in terms of indirectly readable types,
+it is often necessary
+to determine the value type that corresponds to
+a particular indirectly readable type.
 Accordingly, it is required that if \tcode{R} is the name of a type that
-models the \libconcept{readable} concept\iref{iterator.concept.readable},
+models the \libconcept{indirectly_readable} concept\iref{iterator.concept.readable},
 the type
 \begin{codeblock}
 iter_value_t<R>
 \end{codeblock}
-be defined as the readable type's value type.
+be defined as the indirectly readable type's value type.
 
-\indexlibraryglobal{readable_traits}%
+\indexlibraryglobal{indirectly_readable_traits}%
 \begin{codeblock}
 template<class> struct @\placeholder{cond-value-type}@ { };     // \expos
 template<class T>
@@ -751,30 +754,30 @@ struct @\placeholder{cond-value-type}@<T> {
   using value_type = remove_cv_t<T>;
 };
 
-template<class> struct readable_traits { };
+template<class> struct indirectly_readable_traits { };
 
 template<class T>
-struct readable_traits<T*>
+struct indirectly_readable_traits<T*>
   : @\placeholder{cond-value-type}@<T> { };
 
 template<class I>
   requires is_array_v<I>
-struct readable_traits<I> {
+struct indirectly_readable_traits<I> {
   using value_type = remove_cv_t<remove_extent_t<I>>;
 };
 
 template<class I>
-struct readable_traits<const I>
-  : readable_traits<I> { };
+struct indirectly_readable_traits<const I>
+  : indirectly_readable_traits<I> { };
 
 template<class T>
   requires requires { typename T::value_type; }
-struct readable_traits<T>
+struct indirectly_readable_traits<T>
   : @\placeholder{cond-value-type}@<typename T::value_type> { };
 
 template<class T>
   requires requires { typename T::element_type; }
-struct readable_traits<T>
+struct indirectly_readable_traits<T>
   : @\placeholder{cond-value-type}@<typename T::element_type> { };
 
 template<class T> using iter_value_t = @\seebelow@;
@@ -782,33 +785,35 @@ template<class T> using iter_value_t = @\seebelow@;
 
 \indexlibraryglobal{iter_value_t}%
 \pnum
+Let $R_\tcode{I}$ be \tcode{remove_cvref_t<I>}.
 The type \tcode{iter_value_t<I>} denotes
 \begin{itemize}
 \item
-\tcode{readable_traits<I>::value_type}
-if \tcode{iterator_traits<I>} names a specialization
+\tcode{indirectly_readable_traits<$R_\tcode{I}$>::value_type}
+if \tcode{iterator_traits<$R_\tcode{I}$>} names a specialization
 generated from the primary template, and
 
 \item
-\tcode{iterator_traits<I>::value_type} otherwise.
+\tcode{iterator_traits<$R_\tcode{I}$>::value_type} otherwise.
 \end{itemize}
 
 \pnum
-Class template \tcode{readable_traits} may be specialized
+Class template \tcode{indirectly_readable_traits} may be specialized
 on program-defined types.
 
 \pnum
 \begin{note}
 Some legacy output iterators define a nested type named \tcode{value_type}
-that is an alias for \tcode{void}. These types are not \tcode{readable}
+that is an alias for \tcode{void}.
+These types are not \tcode{indirectly_readable}
 and have no associated value types.
 \end{note}
 
 \pnum
 \begin{note}
-Smart pointers like \tcode{shared_ptr<int>} are \tcode{readable} and
+Smart pointers like \tcode{shared_ptr<int>} are \tcode{indirectly_readable} and
 have an associated value type, but a smart pointer like \tcode{shared_ptr<void>}
-is not \tcode{readable} and has no associated value type.
+is not \tcode{indirectly_readable} and has no associated value type.
 \end{note}
 
 \rSec3[iterator.traits]{Iterator traits}
@@ -870,11 +875,11 @@ template<class I>
 concept @\placeholder{cpp17-input-iterator}@ =
   @\placeholder{cpp17-iterator}@<I> && equality_comparable<I> && requires(I i) {
     typename incrementable_traits<I>::difference_type;
-    typename readable_traits<I>::value_type;
+    typename indirectly_readable_traits<I>::value_type;
     typename common_reference_t<iter_reference_t<I>&&,
-                                typename readable_traits<I>::value_type&>;
+                                typename indirectly_readable_traits<I>::value_type&>;
     typename common_reference_t<decltype(*i++)&&,
-                                typename readable_traits<I>::value_type&>;
+                                typename indirectly_readable_traits<I>::value_type&>;
     requires signed_integral<typename incrementable_traits<I>::difference_type>;
   };
 
@@ -882,7 +887,8 @@ template<class I>
 concept @\placeholder{cpp17-forward-iterator}@ =
   @\placeholder{cpp17-input-iterator}@<I> && constructible_from<I> &&
   is_lvalue_reference_v<iter_reference_t<I>> &&
-  same_as<remove_cvref_t<iter_reference_t<I>>, typename readable_traits<I>::value_type> &&
+  same_as<remove_cvref_t<iter_reference_t<I>>,
+          typename indirectly_readable_traits<I>::value_type> &&
   requires(I i) {
     {  i++ } -> convertible_to<const I&>;
     { *i++ } -> same_as<iter_reference_t<I>>;
@@ -941,7 +947,7 @@ Otherwise, if \tcode{I} satisfies the exposition-only concept
 publicly accessible members:
 \begin{codeblock}
 using iterator_category = @\seebelow@;
-using value_type        = typename readable_traits<I>::value_type;
+using value_type        = typename indirectly_readable_traits<I>::value_type;
 using difference_type   = typename incrementable_traits<I>::difference_type;
 using pointer           = @\seebelow@;
 using reference         = @\seebelow@;
@@ -1091,9 +1097,9 @@ arguments.
 Let \tcode{\placeholder{iter-exchange-move}} be the exposition-only function:
 \begin{itemdecl}
 template<class X, class Y>
-  constexpr iter_value_t<remove_reference_t<X>> @\placeholdernc{iter-exchange-move}@(X&& x, Y&& y)
-    noexcept(noexcept(iter_value_t<remove_reference_t<X>>(iter_move(x))) &&
-      noexcept(*x = iter_move(y)));
+  constexpr iter_value_t<X> @\placeholdernc{iter-exchange-move}@(X&& x, Y&& y)
+    noexcept(noexcept(iter_value_t<X>(iter_move(x))) &&
+             noexcept(*x = iter_move(y)));
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1101,7 +1107,7 @@ template<class X, class Y>
 \effects
 Equivalent to:
 \begin{codeblock}
-iter_value_t<remove_reference_t<X>> old_value(iter_move(x));
+iter_value_t<X> old_value(iter_move(x));
 *x = iter_move(y);
 return old_value;
 \end{codeblock}
@@ -1123,7 +1129,7 @@ denoted by \tcode{E1} and \tcode{E2}, the program is
 ill-formed with no diagnostic required.
 
 \item Otherwise, if the types of \tcode{E1} and \tcode{E2} each model
-\tcode{readable}, and if the reference types of \tcode{E1} and \tcode{E2}
+\tcode{indirectly_readable}, and if the reference types of \tcode{E1} and \tcode{E2}
 model \libconcept{swappable_with}\iref{concept.swappable},
 then \tcode{ranges::swap(*E1, *E2)}.
 
@@ -1190,43 +1196,51 @@ struct I {
 and \tcode{\placeholder{ITER_CONCEPT}(I)} denotes \tcode{random_access_iterator_tag}.
 \end{example}
 
-\rSec3[iterator.concept.readable]{Concept \cname{readable}}
+\rSec3[iterator.concept.readable]{Concept \cname{indirectly_readable}}
 
 \pnum
-Types that are readable by applying \tcode{operator*}
-model the \libconcept{readable} concept, including
+Types that are indirectly readable by applying \tcode{operator*}
+model the \libconcept{indirectly_readable} concept, including
 pointers, smart pointers, and iterators.
 
 \begin{codeblock}
 template<class In>
-  concept @\deflibconcept{readable}@ =
-    requires {
+  concept @\defexposconcept{indirectly-readable-impl}@ =
+    requires(const In in) {
       typename iter_value_t<In>;
       typename iter_reference_t<In>;
       typename iter_rvalue_reference_t<In>;
+      { *in } -> same_as<iter_reference_t<In>>;
+      { iter_move(in) } -> same_as<iter_rvalue_reference_t<In>>;
     } &&
     common_reference_with<iter_reference_t<In>&&, iter_value_t<In>&> &&
     common_reference_with<iter_reference_t<In>&&, iter_rvalue_reference_t<In>&&> &&
     common_reference_with<iter_rvalue_reference_t<In>&&, const iter_value_t<In>&>;
 \end{codeblock}
 
+\begin{codeblock}
+template<class In>
+  concept @\deflibconcept{indirectly_readable}@ =
+    @\placeholdernc{indirectly-readable-impl}@<remove_cvref_t<In>>;
+\end{codeblock}
+
 \pnum
-Given a value \tcode{i} of type \tcode{I}, \tcode{I} models \libconcept{readable}
+Given a value \tcode{i} of type \tcode{I}, \tcode{I} models \libconcept{indirectly_readable}
 only if the expression \tcode{*i} is equality-preserving.
 \begin{note}
 The expression \tcode{*i} is indirectly required to be valid via the
-exposition-only \placeholder{dereferenceable} concept\iref{iterator.synopsis}.
+exposition-only \exposconcept{dereferenceable} concept\iref{iterator.synopsis}.
 \end{note}
 
-\rSec3[iterator.concept.writable]{Concept \cname{writable}}
+\rSec3[iterator.concept.writable]{Concept \cname{indirectly_writable}}
 
 \pnum
-The \libconcept{writable} concept specifies the requirements for writing a value
-into an iterator's referenced object.
+The \libconcept{indirectly_writable} concept specifies the requirements
+for writing a value into an iterator's referenced object.
 
 \begin{codeblock}
 template<class Out, class T>
-  concept @\deflibconcept{writable}@ =
+  concept @\deflibconcept{indirectly_writable}@ =
     requires(Out&& o, T&& t) {
       *o = std::forward<T>(t);  // not required to be equality-preserving
       *std::forward<Out>(o) = std::forward<T>(t);   // not required to be equality-preserving
@@ -1240,10 +1254,10 @@ template<class Out, class T>
 \pnum
 Let \tcode{E} be an expression such that \tcode{decltype((E))} is \tcode{T},
 and let \tcode{o} be a dereferenceable object of type \tcode{Out}.
-\tcode{Out} and \tcode{T} model \tcode{\libconcept{writable}<Out, T>} only if
+\tcode{Out} and \tcode{T} model \tcode{\libconcept{indirectly_writable}<Out, T>} only if
 \begin{itemize}
 \item If \tcode{Out} and \tcode{T} model
-  \tcode{readable<Out> \&\& same_as<iter_value_t<Out>, decay_t<T>{>}},
+  \tcode{indirectly_readable<Out> \&\& same_as<iter_value_t<Out>, decay_t<T>{>}},
   then \tcode{*o} after any above assignment is equal to
   the value of \tcode{E} before the assignment.
 \end{itemize}
@@ -1258,16 +1272,16 @@ state of the object it denotes is valid but unspecified\iref{lib.types.movedfrom
 \pnum
 \begin{note}
 The only valid use of an \tcode{operator*} is on the left side of the assignment statement.
-Assignment through the same value of the writable type happens only once.
+Assignment through the same value of the indirectly writable type happens only once.
 \end{note}
 
 \pnum
 \begin{note}
-\tcode{writable} has the awkward \tcode{const_cast} expressions to reject
+\tcode{indirectly_writable} has the awkward \tcode{const_cast} expressions to reject
 iterators with prvalue non-proxy reference types that permit rvalue
 assignment but do not also permit \tcode{const} rvalue assignment.
 Consequently, an iterator type \tcode{I} that returns \tcode{std::string}
-by value does not model \tcode{\libconcept{writable}<I, std::string>}.
+by value does not model \tcode{\libconcept{indirectly_writable}<I, std::string>}.
 \end{note}
 
 \rSec3[iterator.concept.winc]{Concept \cname{weakly_incrementable}}
@@ -1599,8 +1613,8 @@ counted iterators and their sentinels\iref{counted.iterator}.
 \pnum
 The \libconcept{input_iterator} concept defines requirements for a type
 whose referenced values can be read (from the requirement for
-\libconcept{readable}\iref{iterator.concept.readable}) and which can be both pre- and
-post-incremented.
+\libconcept{indirectly_readable}\iref{iterator.concept.readable})
+and which can be both pre- and post-incremented.
 \begin{note}
 Unlike the \oldconcept{InputIterator} requirements\iref{input.iterators},
 the \libconcept{input_iterator} concept does not need
@@ -1611,7 +1625,7 @@ equality comparison since iterators are typically compared to sentinels.
 template<class I>
   concept @\deflibconcept{input_iterator}@ =
     input_or_output_iterator<I> &&
-    readable<I> &&
+    indirectly_readable<I> &&
     requires { typename @\placeholdernc{ITER_CONCEPT}@(I); } &&
     derived_from<@\placeholdernc{ITER_CONCEPT}@(I), input_iterator_tag>;
 \end{codeblock}
@@ -1621,7 +1635,8 @@ template<class I>
 \pnum
 The \libconcept{output_iterator} concept defines requirements for a type that
 can be used to write values (from the requirement for
-\libconcept{writable}\iref{iterator.concept.writable}) and which can be both pre- and post-incremented.
+\libconcept{indirectly_writable}\iref{iterator.concept.writable})
+and which can be both pre- and post-incremented.
 \begin{note}
 Output iterators are not required to model \libconcept{equality_comparable}.
 \end{note}
@@ -1630,7 +1645,7 @@ Output iterators are not required to model \libconcept{equality_comparable}.
 template<class I, class T>
   concept @\deflibconcept{output_iterator}@ =
     input_or_output_iterator<I> &&
-    writable<I, T> &&
+    indirectly_writable<I, T> &&
     requires(I i, T&& t) {
       *i++ = std::forward<T>(t);        // not required to be equality-preserving
     };
@@ -2302,7 +2317,7 @@ that accept callable objects~(\ref{func.def}) as arguments.
 namespace std {
   template<class F, class I>
     concept @\deflibconcept{indirectly_unary_invocable}@ =
-      readable<I> &&
+      indirectly_readable<I> &&
       copy_constructible<F> &&
       invocable<F&, iter_value_t<I>&> &&
       invocable<F&, iter_reference_t<I>> &&
@@ -2313,7 +2328,7 @@ namespace std {
 
   template<class F, class I>
     concept @\deflibconcept{indirectly_regular_unary_invocable}@ =
-      readable<I> &&
+      indirectly_readable<I> &&
       copy_constructible<F> &&
       regular_invocable<F&, iter_value_t<I>&> &&
       regular_invocable<F&, iter_reference_t<I>> &&
@@ -2324,7 +2339,7 @@ namespace std {
 
   template<class F, class I>
     concept @\deflibconcept{indirect_unary_predicate}@ =
-      readable<I> &&
+      indirectly_readable<I> &&
       copy_constructible<F> &&
       predicate<F&, iter_value_t<I>&> &&
       predicate<F&, iter_reference_t<I>> &&
@@ -2332,7 +2347,7 @@ namespace std {
 
   template<class F, class I1, class I2>
     concept @\deflibconcept{indirect_binary_predicate}@ =
-      readable<I1> && readable<I2> &&
+      indirectly_readable<I1> && indirectly_readable<I2> &&
       copy_constructible<F> &&
       predicate<F&, iter_value_t<I1>&, iter_value_t<I2>&> &&
       predicate<F&, iter_value_t<I1>&, iter_reference_t<I2>> &&
@@ -2342,7 +2357,7 @@ namespace std {
 
   template<class F, class I1, class I2 = I1>
     concept @\deflibconcept{indirect_equivalence_relation}@ =
-      readable<I1> && readable<I2> &&
+      indirectly_readable<I1> && indirectly_readable<I2> &&
       copy_constructible<F> &&
       equivalence_relation<F&, iter_value_t<I1>&, iter_value_t<I2>&> &&
       equivalence_relation<F&, iter_value_t<I1>&, iter_reference_t<I2>> &&
@@ -2352,7 +2367,7 @@ namespace std {
 
   template<class F, class I1, class I2 = I1>
     concept @\deflibconcept{indirect_strict_weak_order}@ =
-      readable<I1> && readable<I2> &&
+      indirectly_readable<I1> && indirectly_readable<I2> &&
       copy_constructible<F> &&
       strict_weak_order<F&, iter_value_t<I1>&, iter_value_t<I2>&> &&
       strict_weak_order<F&, iter_value_t<I1>&, iter_reference_t<I2>> &&
@@ -2367,15 +2382,15 @@ namespace std {
 \pnum
 Class template \tcode{projected} is used to constrain algorithms
 that accept callable objects and projections\iref{defns.projection}.
-It combines a \libconcept{readable} type \tcode{I} and
-a callable object type \tcode{Proj} into a new \libconcept{readable} type
+It combines a \libconcept{indirectly_readable} type \tcode{I} and
+a callable object type \tcode{Proj} into a new \libconcept{indirectly_readable} type
 whose \tcode{reference} type is the result of applying
 \tcode{Proj} to the \tcode{iter_reference_t} of \tcode{I}.
 
 \indexlibraryglobal{projected}%
 \begin{codeblock}
 namespace std {
-  template<readable I, indirectly_regular_unary_invocable<I> Proj>
+  template<indirectly_readable I, indirectly_regular_unary_invocable<I> Proj>
   struct projected {
     using value_type = remove_cvref_t<indirect_result_t<Proj&, I>>;
     indirect_result_t<Proj&, I> operator*() const;              // \notdef
@@ -2397,8 +2412,8 @@ There are several additional iterator concepts that are commonly applied
 to families of algorithms. These group together iterator requirements
 of algorithm families.
 There are three relational concepts that specify
-how element values are transferred  between \libconcept{readable} and
-\libconcept{writable} types:
+how element values are transferred between
+\libconcept{indirectly_readable} and \libconcept{indirectly_writable} types:
 \libconcept{indirectly_movable},
 \libconcept{indirectly_copyable}, and
 \libconcept{indirectly_swappable}.
@@ -2420,27 +2435,27 @@ in addition to those that appear in the concepts' bodies\iref{range.cmp}.
 
 \pnum
 The \libconcept{indirectly_movable} concept specifies the relationship between
-a \libconcept{readable} type and a \libconcept{writable} type between which
-values may be moved.
+a \libconcept{indirectly_readable} type and a \libconcept{indirectly_writable} type
+between which values may be moved.
 
 \begin{codeblock}
 template<class In, class Out>
   concept @\deflibconcept{indirectly_movable}@ =
-    readable<In> &&
-    writable<Out, iter_rvalue_reference_t<In>>;
+    indirectly_readable<In> &&
+    indirectly_writable<Out, iter_rvalue_reference_t<In>>;
 \end{codeblock}
 
 \pnum
 The \libconcept{indirectly_movable_storable} concept augments
 \libconcept{indirectly_movable} with additional requirements enabling
 the transfer to be performed through an intermediate object of the
-\libconcept{readable} type's value type.
+\libconcept{indirectly_readable} type's value type.
 
 \begin{codeblock}
 template<class In, class Out>
   concept @\deflibconcept{indirectly_movable_storable}@ =
     indirectly_movable<In, Out> &&
-    writable<Out, iter_value_t<In>> &&
+    indirectly_writable<Out, iter_value_t<In>> &&
     movable<iter_value_t<In>> &&
     constructible_from<iter_value_t<In>, iter_rvalue_reference_t<In>> &&
     assignable_from<iter_value_t<In>&, iter_rvalue_reference_t<In>>;
@@ -2462,28 +2477,28 @@ valid but unspecified\iref{lib.types.movedfrom}.
 
 \pnum
 The \libconcept{indirectly_copyable} concept specifies the relationship between
-a \libconcept{readable} type and a \libconcept{writable} type between which
-values may be copied.
+a \libconcept{indirectly_readable} type and a \libconcept{indirectly_writable} type
+between which values may be copied.
 
 \begin{codeblock}
 template<class In, class Out>
   concept @\deflibconcept{indirectly_copyable}@ =
-    readable<In> &&
-    writable<Out, iter_reference_t<In>>;
+    indirectly_readable<In> &&
+    indirectly_writable<Out, iter_reference_t<In>>;
 \end{codeblock}
 
 \pnum
 The \libconcept{indirectly_copyable_storable} concept augments
 \libconcept{indirectly_copyable} with additional requirements enabling
 the transfer to be performed through an intermediate object of the
-\libconcept{readable} type's value type. It also requires the capability
+\libconcept{indirectly_readable} type's value type. It also requires the capability
 to make copies of values.
 
 \begin{codeblock}
 template<class In, class Out>
   concept @\deflibconcept{indirectly_copyable_storable}@ =
     indirectly_copyable<In, Out> &&
-    writable<Out, const iter_value_t<In>&> &&
+    indirectly_writable<Out, const iter_value_t<In>&> &&
     copyable<iter_value_t<In>> &&
     constructible_from<iter_value_t<In>, iter_reference_t<In>> &&
     assignable_from<iter_value_t<In>&, iter_reference_t<In>>;
@@ -2505,13 +2520,13 @@ valid but unspecified\iref{lib.types.movedfrom}.
 
 \pnum
 The \libconcept{indirectly_swappable} concept specifies a swappable relationship
-between the values referenced by two \libconcept{readable} types.
+between the values referenced by two \libconcept{indirectly_readable} types.
 
 \begin{codeblock}
 template<class I1, class I2 = I1>
   concept @\deflibconcept{indirectly_swappable}@ =
-    readable<I1> && readable<I2> &&
-    requires(I1& i1, I2& i2) {
+    indirectly_readable<I1> && indirectly_readable<I2> &&
+    requires(const I1 i1, const I2 i2) {
       ranges::iter_swap(i1, i1);
       ranges::iter_swap(i2, i2);
       ranges::iter_swap(i1, i2);
@@ -4707,7 +4722,7 @@ namespace std {
 
     decltype(auto) operator*();
     decltype(auto) operator*() const
-      requires @\placeholder{dereferenceable}@<const I>;
+      requires @\exposconcept{dereferenceable}@<const I>;
     decltype(auto) operator->() const
       requires @\seebelow@;
 
@@ -4860,7 +4875,7 @@ where $i$ is \tcode{x.v_.index()}.
 \begin{itemdecl}
 decltype(auto) operator*();
 decltype(auto) operator*() const
-  requires @\placeholder{dereferenceable}@<const I>;
+  requires @\exposconcept{dereferenceable}@<const I>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4883,7 +4898,7 @@ decltype(auto) operator->() const
 \pnum
 The expression in the requires clause is equivalent to:
 \begin{codeblock}
-readable<const I> &&
+indirectly_readable<const I> &&
 (requires(const I& i) { i.operator->(); } ||
  is_reference_v<iter_reference_t<I>> ||
  constructible_from<iter_value_t<I>, iter_reference_t<I>>)
@@ -5142,7 +5157,7 @@ namespace std {
     constexpr iter_difference_t<I> count() const noexcept;
     constexpr decltype(auto) operator*();
     constexpr decltype(auto) operator*() const
-      requires @\placeholder{dereferenceable}@<const I>;
+      requires @\exposconcept{dereferenceable}@<const I>;
 
     constexpr counted_iterator& operator++();
     decltype(auto) operator++(int);
@@ -5301,7 +5316,7 @@ Equivalent to: \tcode{return length;}
 \begin{itemdecl}
 constexpr decltype(auto) operator*();
 constexpr decltype(auto) operator*() const
-  requires @\placeholder{dereferenceable}@<const I>;
+  requires @\exposconcept{dereferenceable}@<const I>;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Instructions to change section names were ignored; the shorter section
names are preferable, and the inclusion of 'iterator.' seems sufficient
to indicate that we're talking about indirect reading and writing.

Fixes #3412.
Fixes cplusplus/nbballot#259.
Fixes cplusplus/nbballot#260.
Fixes cplusplus/nbballot#264.
Fixes cplusplus/papers#628

Also fixes NB US 263, US 264, US 268 (C++20 CD), and LWG3279.