### PR TITLE
P1391R4 Range constructor for std::string_view

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -4109,7 +4109,7 @@ private:
   size_type size_;              // \expos
 };
 
-// \ref{string.view.deduction}, deduction guide
+// \ref{string.view.deduct}, deduction guide
 template<class It, class End>
   basic_string_view(It, End) -> basic_string_view<iter_value_t<It>>;
 \end{codeblock}
@@ -4190,17 +4190,17 @@ template<class It, class End>
 \pnum
 \constraints
 \begin{itemize}
-\item \tcode{It} satisfies \libconcept{contiguous_iterator},
-\item \tcode{End} satisfies \tcode{\libconcept{sized_sentinel_for}<It>},
-\item \tcode{is_same_v<iter_value_t<It>, charT>} is \tcode{true}, and
+\item \tcode{It} satisfies \libconcept{contiguous_iterator}.
+\item \tcode{End} satisfies \tcode{\libconcept{sized_sentinel_for}<It>}.
+\item \tcode{is_same_v<iter_value_t<It>, charT>} is \tcode{true}.
 \item \tcode{is_convertible_v<End, size_type>} is \tcode{false}.
 \end{itemize}
 
 \pnum
 \expects
 \begin{itemize}
-\item \range{begin}{end} is a valid range,
-\item \tcode{It} models \libconcept{contiguous_iterator}, and
+\item \range{begin}{end} is a valid range.
+\item \tcode{It} models \libconcept{contiguous_iterator}.
 \item \tcode{End} models \tcode{\libconcept{sized_sentinel_for}<It>}.
 \end{itemize}
 
@@ -4872,7 +4872,7 @@ Determines \tcode{xpos}.
 Otherwise, returns \tcode{npos}.
 \end{itemdescr}
 
-\rSec2[string.view.deduction]{Deduction guide}
+\rSec2[string.view.deduct]{Deduction guide}
 
 \begin{itemdecl}
 template<class It, class End>
@@ -4883,7 +4883,7 @@ template<class It, class End>
 \pnum
 \constraints
 \begin{itemize}
-\item \tcode{It} satisfies \libconcept{contiguous_iterator}, and
+\item \tcode{It} satisfies \libconcept{contiguous_iterator}.
 \item \tcode{End} satisfies \tcode{\libconcept{sized_sentinel_for}<It>}.
 \end{itemize}
 \end{itemdescr}

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -4020,6 +4020,8 @@ public:
   constexpr basic_string_view& operator=(const basic_string_view&) noexcept = default;
   constexpr basic_string_view(const charT* str);
   constexpr basic_string_view(const charT* str, size_type len);
+  template<class It, class End>
+    constexpr basic_string_view(It begin, End end);
 
   // \ref{string.view.iterators}, iterator support
   constexpr const_iterator begin() const noexcept;
@@ -4106,6 +4108,10 @@ private:
   const_pointer data_;          // \expos
   size_type size_;              // \expos
 };
+
+// \ref{string.view.deduction}, deduction guide
+template<class It, class End>
+  basic_string_view(It, End) -> basic_string_view<iter_value_t<It>>;
 \end{codeblock}
 
 \pnum
@@ -4172,6 +4178,36 @@ constexpr basic_string_view(const charT* str, size_type len);
 \effects
 Constructs a \tcode{basic_string_view}, initializing \tcode{data_} with \tcode{str}
 and initializing \tcode{size_} with \tcode{len}.
+\end{itemdescr}
+
+\indexlibraryctor{basic_string_view}%
+\begin{itemdecl}
+template<class It, class End>
+  constexpr basic_string_view(It begin, End end);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\begin{itemize}
+\item \tcode{It} satisfies \libconcept{contiguous_iterator},
+\item \tcode{End} satisfies \tcode{\libconcept{sized_sentinel_for}<It>},
+\item \tcode{is_same_v<iter_value_t<It>, charT>} is \tcode{true}, and
+\item \tcode{is_convertible_v<End, size_type>} is \tcode{false}.
+\end{itemize}
+
+\pnum
+\expects
+\begin{itemize}
+\item \range{begin}{end} is a valid range,
+\item \tcode{It} models \libconcept{contiguous_iterator}, and
+\item \tcode{End} models \tcode{\libconcept{sized_sentinel_for}<It>}.
+\end{itemize}
+
+\pnum
+\effects
+Initializes \tcode{data_} with \tcode{to_address(begin)} and
+initializes \tcode{size_} with \tcode{end - begin}.
 \end{itemdescr}
 
 \rSec3[string.view.iterators]{Iterator support}
@@ -4834,6 +4870,22 @@ Determines \tcode{xpos}.
 \returns
 \tcode{xpos} if the function can determine such a value for \tcode{xpos}.
 Otherwise, returns \tcode{npos}.
+\end{itemdescr}
+
+\rSec2[string.view.deduction]{Deduction guide}
+
+\begin{itemdecl}
+template<class It, class End>
+  basic_string_view(It, End) -> basic_string_view<iter_value_t<It>>;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\begin{itemize}
+\item \tcode{It} satisfies \libconcept{contiguous_iterator}, and
+\item \tcode{End} satisfies \tcode{\libconcept{sized_sentinel_for}<It>}.
+\end{itemize}
 \end{itemdescr}
 
 \rSec2[string.view.comparison]{Non-member comparison functions}


### PR DESCRIPTION
Renamed constructor parameters in description to match those in class
definition.

Fixes #3415.
Fixes cplusplus/nbballot#229
Partially addresses cplusplus/nbballot#268
Partially addresses cplusplus/nbballot#284
Fixes cplusplus/papers#184