### PR TITLE
[basic.life] Use idiomatic wording.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3244,8 +3244,8 @@ object, as described below, in~\ref{class.base.init} and
 in~\ref{class.cdtor}. Also, the behavior of an object under construction
 and destruction might not be the same as the behavior of an object whose
 lifetime has started and not ended. \ref{class.base.init}
-and~\ref{class.cdtor} describe the behavior of objects during the
-construction and destruction phases.
+and~\ref{class.cdtor} describe the behavior of an object during its periods
+of construction and destruction.
 \end{note}
 
 \pnum


### PR DESCRIPTION
Periods of construction and destruction are not referred to as phases anywhere else.