### PR TITLE
[format.arg] Fix parameter type for basic_format_arg constructor.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -21090,7 +21090,7 @@ Initializes \tcode{value} with
 \end{itemdescr}
 
 \begin{itemdecl}
-template<class T> explicit basic_format_arg(T* p) noexcept;
+template<class T> explicit basic_format_arg(const T* p) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Fixes #3461.