### PR TITLE
[defns.access] Clarify definition of "access".

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -287,7 +287,8 @@ is ill-formed~(\ref{expr.ass}, \ref{expr.post.incr}, \ref{expr.pre.incr}).
 \end{note}
 
 \pnum
-If a program attempts to access the stored value of an object through a glvalue
+If a program attempts to access\iref{defns.access}
+the stored value of an object through a glvalue
 whose type is not similar\iref{conv.qual} to
 one of the following types the behavior is
 undefined:\footnote{The intent of this list is to specify those circumstances in which an
@@ -644,9 +645,8 @@ pointer value~(\ref{basic.stc.dynamic.deallocation},
 \ref{basic.stc.dynamic.safety}), the behavior is
 \impldef{lvalue-to-rvalue conversion of an invalid pointer value}.
 
-\item Otherwise, the value contained in the object indicated by the
-glvalue is the prvalue result.
-
+\item Otherwise, the object indicated by the glvalue is read\iref{defns.access},
+and the value contained in the object is the prvalue result.
 \end{itemize}
 
 \pnum
@@ -3355,7 +3355,8 @@ be an arithmetic type other than \cv{}~\tcode{bool},
 or a pointer to a complete object type.
 An operand with \tcode{volatile}-qualified type is deprecated;
 see~\ref{depr.volatile.type}.
-The value of the operand object is modified by adding \tcode{1} to it.
+The value of the operand object is modified\iref{defns.access}
+by adding \tcode{1} to it.
 The
 \indextext{value computation}%
 value computation of the \tcode{++} expression is sequenced before the
@@ -4308,7 +4309,7 @@ unambiguously parsed as a destructor name.
 The operand of prefix \tcode{++}
 \indextext{operator!increment}%
 \indextext{prefix \tcode{++}}%
-is modified by adding \tcode{1}.
+is modified\iref{defns.access} by adding \tcode{1}.
 \indextext{prefix \tcode{\dcr}}%
 The operand shall be a modifiable lvalue. The type of the operand shall
 be an arithmetic type other than \cv{}~\tcode{bool},
@@ -4327,7 +4328,7 @@ operators\iref{expr.ass} for information on conversions.
 \pnum
 The operand of prefix
 \indextext{operator!decrement}%
-\tcode{\dcr} is modified by subtracting \tcode{1}.
+\tcode{\dcr} is modified\iref{defns.access} by subtracting \tcode{1}.
 The requirements on the operand of prefix
 \tcode{\dcr} and the properties of its result are otherwise the same as
 those of prefix \tcode{++}.
@@ -6700,7 +6701,8 @@ single compound assignment operator.
 
 \pnum
 In simple assignment (\tcode{=}), the object referred to by the left operand
-is modified by replacing its value with the result of the right operand.
+is modified\iref{defns.access}
+by replacing its value with the result of the right operand.
 
 \pnum
 \indextext{assignment!conversion by}%

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -117,7 +117,19 @@ defined.
 
 \indexdefn{access}%
 \definition{access}{defns.access}
-\defncontext{execution-time action} read or modify the value of an object
+\defncontext{execution-time action}
+read\iref{conv.lval} or
+modify (\ref{expr.ass}, \ref{expr.post.incr}, \ref{expr.pre.incr})
+the value of an object
+
+\begin{defnote}
+Only objects of scalar type can be accessed.
+Attempts to read or modify an object of class type
+typically invoke a constructor\iref{class.ctor}
+or assignment operator\iref{class.copy.assign};
+such invocations do not themselves constitute accesses,
+although they may involve accesses of scalar subobjects.
+\end{defnote}
 
 \indexdefn{argument}%
 \indexdefn{argument!function call expression}


### PR DESCRIPTION
Add cross-linking between the places that introduce accesses and the
definition of the term, and add a note explaining that we only ever
access objects of scalar type.