### PR TITLE
Motions 2019 11 lwg 1: P1917R0 C++ Standard Library Issues to be moved in Belfast

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -9329,12 +9329,15 @@ template<class ExecutionPolicy,
 
 \begin{itemdescr}
 \pnum
+Let \tcode{U} be the value type of \tcode{decltype(first)}.
+
+\pnum
 \requires
 \begin{itemize}
 \item
   If \tcode{init} is provided,
   \tcode{T} shall be \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible});
-  otherwise, \tcode{ForwardIterator1}'s value type
+  otherwise, \tcode{U}
   shall be \oldconcept{MoveConstructible}.
 \item
   If \tcode{init} is provided, all of
@@ -9343,7 +9346,7 @@ template<class ExecutionPolicy,
   \tcode{binary_op(*first, *first)}
   shall be convertible to \tcode{T};
   otherwise, \tcode{binary_op(*first, *first)}
-  shall be convertible to \tcode{ForwardIterator1}'s value type.
+  shall be convertible to \tcode{U}.
 \item
   \tcode{binary_op} shall neither invalidate iterators or subranges,
   nor modify elements in
@@ -9492,12 +9495,15 @@ template<class ExecutionPolicy,
 
 \begin{itemdescr}
 \pnum
+Let \tcode{U} be the value type of \tcode{decltype(first)}.
+
+\pnum
 \requires
 \begin{itemize}
 \item
   If \tcode{init} is provided, \tcode{T} shall be
   \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible});
-  otherwise, \tcode{ForwardIterator1}'s value type shall be
+  otherwise, \tcode{U} shall be
   \oldconcept{MoveConstructible}.
 \item
   If \tcode{init} is provided, all of
@@ -9508,7 +9514,7 @@ template<class ExecutionPolicy,
   \end{itemize}
   shall be convertible to \tcode{T};
   otherwise, \tcode{binary_op(unary_op(*first), unary_op(*first))}
-  shall be convertible to \tcode{ForwardIterator1}'s value type.
+  shall be convertible to \tcode{U}.
 \item
   Neither \tcode{unary_op} nor \tcode{binary_op} shall
   invalidate iterators or subranges, nor modify elements in

--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -736,17 +736,17 @@ template<class T, class... Args>
 
 \begin{itemdecl}
 template<class T>
-  inline constexpr bool @\placeholder{is-default-initializable}@ = @\seebelow@;  // \expos
+  inline constexpr bool @\defexposconcept{is-default-initializable}@ = @\seebelow@;  // \expos
 
 template<class T>
   concept @\deflibconcept{default_constructible}@ = constructible_from<T> &&
                                   requires { T{}; } &&
-                                  @\placeholder{is-default-initializable}@<T>;
+                                  @\exposconcept{is-default-initializable}@<T>;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-For a type \tcode{T}, \tcode{is-default-initializable<T>} is \tcode{true}
+For a type \tcode{T}, \tcode{\exposconcept{is-default-initializable}<T>} is \tcode{true}
 if and only if the variable definition
 \begin{codeblock}
 T t;

--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -736,8 +736,26 @@ template<class T, class... Args>
 
 \begin{itemdecl}
 template<class T>
-  concept @\deflibconcept{default_constructible}@ = constructible_from<T>;
+  inline constexpr bool @\placeholder{is-default-initializable}@ = @\seebelow@;  // \expos
+
+template<class T>
+  concept @\deflibconcept{default_constructible}@ = constructible_from<T> &&
+                                  requires { T{}; } &&
+                                  @\placeholder{is-default-initializable}@<T>;
 \end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+For a type \tcode{T}, \tcode{is-default-initializable<T>} is \tcode{true}
+if and only if the variable definition
+\begin{codeblock}
+T t;
+\end{codeblock}
+is well-formed for some invented variable \tcode{t};
+otherwise it is \tcode{false}.
+Access checking is performed as if in a context unrelated to \tcode{T}.
+Only the validity of the immediate context of the variable initialization is considered.
+\end{itemdescr}
 
 \rSec2[concept.moveconstructible]{Concept \cname{move_constructible}}
 

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10840,6 +10840,10 @@ template<size_t Count> constexpr span<element_type, Count> first() const;
 
 \begin{itemdescr}
 \pnum
+\mandates
+\tcode{Count <= Extent} is \tcode{true}.
+
+\pnum
 \expects
 \tcode{Count <= size()} is \tcode{true}.
 
@@ -10854,6 +10858,10 @@ template<size_t Count> constexpr span<element_type, Count> last() const;
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+\mandates
+\tcode{Count <= Extent} is \tcode{true}.
+
 \pnum
 \expects
 \tcode{Count <= size()} is \tcode{true}.
@@ -10871,9 +10879,16 @@ template<size_t Offset, size_t Count = dynamic_extent>
 
 \begin{itemdescr}
 \pnum
+\mandates
+\begin{codeblock}
+Offset <= Extent && (Count == dynamic_extent || Count <= Extent - Offset)
+\end{codeblock}
+is \tcode{true}.
+
+\pnum
 \expects
 \begin{codeblock}
-Offset <= size() && (Count == dynamic_extent || Offset + Count <= size())
+Offset <= size() && (Count == dynamic_extent || Count <= size() - Offset)
 \end{codeblock}
 is \tcode{true}.
 
@@ -10935,7 +10950,7 @@ constexpr span<element_type, dynamic_extent> subspan(
 \pnum
 \expects
 \begin{codeblock}
-offset <= size() && (count == dynamic_extent || offset + count <= size())
+offset <= size() && (count == dynamic_extent || count <= size() - offset)
 \end{codeblock}
 is \tcode{true}.
 

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -12404,7 +12404,9 @@ shall be one of:
 
 \pnum
 Functions taking template parameters named \tcode{Source}
-shall not participate in overload resolution unless either
+shall not participate in overload resolution unless
+\tcode{Source} denotes a type other than \tcode{path}, and
+either
 \begin{itemize}
 \item
 \tcode{Source} is a specialization of

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -10897,7 +10897,9 @@ namespace std {
     using streambuf_type = basic_streambuf<charT, traits>;
 
     // \ref{syncstream.syncbuf.cons}, construction and destruction
-    explicit basic_syncbuf(streambuf_type* obuf = nullptr)
+    basic_syncbuf()
+      : basic_syncbuf(nullptr) {}
+    explicit basic_syncbuf(streambuf_type* obuf)
       : basic_syncbuf(obuf, Allocator()) {}
     basic_syncbuf(streambuf_type*, const Allocator&);
     basic_syncbuf(basic_syncbuf&&);

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -13464,10 +13464,26 @@ Does not first normalize\iref{fs.path.generic} \tcode{*this} or \tcode{base}.
 
 \pnum
 \effects
-If \tcode{root_name() != base.root_name()} is \tcode{true}
-or \tcode{is_absolute() != base.is_absolute()} is \tcode{true}
-or \tcode{!has_root_directory() \&\& base.has_root_directory()} is \tcode{true},
+If:
+\begin{itemize}
+\item
+\tcode{root_name() != base.root_name()} is \tcode{true}, or
+
+\item
+\tcode{is_absolute() != base.is_absolute()} is \tcode{true}, or
+
+\item
+\tcode{!has_root_directory() \&\& base.has_root_directory()} is \tcode{true}, or
+
+\item
+any \grammarterm{filename} in
+\tcode{relative_path()} or \tcode{base.relative_path()}
+can be interpreted as a \grammarterm{root-name},
+\end{itemize}
 returns \tcode{path()}.
+\begin{note}
+On a POSIX implementation, no \grammarterm{filename} in a \grammarterm{relative-path} is acceptable as a \grammarterm{root-name}.
+\end{note}
 Determines the first mismatched element of \tcode{*this} and \tcode{base}
 as if by:
 \begin{codeblock}

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -655,11 +655,7 @@ is undefined.
 \indextext{iterator!constexpr}%
 Iterators are called \defn{constexpr iterators}
 if all operations provided to meet iterator category requirements
-are constexpr functions, except for
-\begin{itemize}
-\item a pseudo-destructor call\iref{expr.prim.id.dtor}, and
-\item the construction of an iterator with a singular value.
-\end{itemize}
+are constexpr functions.
 \begin{note}
 For example, the types ``pointer to \tcode{int}'' and
 \tcode{reverse_iterator<int*>} are constexpr iterators.

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1779,7 +1779,7 @@ and let \tcode{n} denote a value of type \tcode{D}.
   \tcode{(a + D(x + y))} is equal to \tcode{((a + x) + y)}.
 \item \tcode{(a + D(0))} is equal to \tcode{a}.
 \item If \tcode{(a + D(n - 1))} is valid, then
-  \tcode{(a + n)} is equal to \tcode{++(a + D(n - 1))}.
+  \tcode{(a + n)} is equal to \tcode{[](I c)\{ return ++c; \}(a + D(n - 1))}.
 \item \tcode{(b += -n)} is equal to \tcode{a}.
 \item \tcode{(b -= n)} is equal to \tcode{a}.
 \item \tcode{addressof(b -= n)} is equal to \tcode{addressof(b)}.

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -5200,7 +5200,8 @@ Equivalent to: \tcode{return x.\placeholder{current} == ranges::end(x.parent_->b
 namespace std::ranges {
   template<class V, class Pattern>
   template<bool Const>
-  struct split_view<V, Pattern>::outer_iterator<Const>::value_type {
+  struct split_view<V, Pattern>::outer_iterator<Const>::value_type
+    : view_interface<value_type> {
   private:
     outer_iterator i_ = outer_iterator();               // \expos
   public:

--- a/source/support.tex
+++ b/source/support.tex
@@ -554,7 +554,7 @@ the values of these macros with greater values.
   // \libheader{map}, \libheader{set}, \libheader{unordered_map}, \libheader{unordered_set}
 #define @\defnlibxname{cpp_lib_any}@                               201606L // also in \libheader{any}
 #define @\defnlibxname{cpp_lib_apply}@                             201603L // also in \libheader{tuple}
-#define @\defnlibxname{cpp_lib_array_constexpr}@                   201603L // also in \libheader{iterator}, \libheader{array}
+#define @\defnlibxname{cpp_lib_array_constexpr}@                   201803L // also in \libheader{iterator}, \libheader{array}
 #define @\defnlibxname{cpp_lib_as_const}@                          201510L // also in \libheader{utility}
 #define @\defnlibxname{cpp_lib_atomic_flag_test}@                  201907L // also in \libheader{atomic}
 #define @\defnlibxname{cpp_lib_atomic_is_always_lock_free}@        201603L // also in \libheader{atomic}
@@ -651,7 +651,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_source_location}@                   201907L // also in \libheader{source_location}
 #define @\defnlibxname{cpp_lib_spaceship}@                         201907L // also in \libheader{compare}
 #define @\defnlibxname{cpp_lib_string_udls}@                       201304L // also in \libheader{string}
-#define @\defnlibxname{cpp_lib_string_view}@                       201606L // also in \libheader{string}, \libheader{string_view}
+#define @\defnlibxname{cpp_lib_string_view}@                       201803L // also in \libheader{string}, \libheader{string_view}
 #define @\defnlibxname{cpp_lib_three_way_comparison}@              201711L // also in \libheader{compare}
 #define @\defnlibxname{cpp_lib_to_array}@                          201907L // also in \libheader{array}
 #define @\defnlibxname{cpp_lib_to_chars}@                          201611L // also in \libheader{charconv}

--- a/source/support.tex
+++ b/source/support.tex
@@ -650,6 +650,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_shared_timed_mutex}@                201402L // also in \libheader{shared_mutex}
 #define @\defnlibxname{cpp_lib_source_location}@                   201907L // also in \libheader{source_location}
 #define @\defnlibxname{cpp_lib_spaceship}@                         201907L // also in \libheader{compare}
+#define @\defnlibxname{cpp_lib_span}@                              201902L // also in \libheader{span}
 #define @\defnlibxname{cpp_lib_string_udls}@                       201304L // also in \libheader{string}
 #define @\defnlibxname{cpp_lib_string_view}@                       201803L // also in \libheader{string}, \libheader{string_view}
 #define @\defnlibxname{cpp_lib_three_way_comparison}@              201711L // also in \libheader{compare}

--- a/source/support.tex
+++ b/source/support.tex
@@ -578,10 +578,10 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_concepts}@                          201806L // also in \libheader{concepts}
 #define @\defnlibxname{cpp_lib_constexpr}@                         201811L
   // also in any C++ library header from \tref{headers.cpp} or any C++ header for C library facilities from \tref{headers.cpp.c}
+#define @\defnlibxname{cpp_lib_constexpr_algorithms}@              201806L // also in \libheader{algorithm}
 #define @\defnlibxname{cpp_lib_constexpr_dynamic_alloc}@           201907L // also in \libheader{memory}
 #define @\defnlibxname{cpp_lib_constexpr_invoke}@                  201907L // also in \libheader{functional}
 #define @\defnlibxname{cpp_lib_constexpr_string}@                  201907L // also in \libheader{string}
-#define @\defnlibxname{cpp_lib_constexpr_swap_algorithms}@         201806L // also in \libheader{algorithm}
 #define @\defnlibxname{cpp_lib_constexpr_vector}@                  201907L // also in \libheader{vector}
 #define @\defnlibxname{cpp_lib_destroying_delete}@                 201806L // also in \libheader{new}
 #define @\defnlibxname{cpp_lib_enable_shared_from_this}@           201603L // also in \libheader{memory}

--- a/source/time.tex
+++ b/source/time.tex
@@ -5241,9 +5241,8 @@ constexpr weekday_indexed(const chrono::weekday& wd, unsigned index) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Constructs an object of type \tcode{weekday_indexed} by
-initializing \tcode{wd_} with \tcode{wd} and \tcode{index_} with \tcode{index}.
-The values held are unspecified if \tcode{!wd.ok()} or \tcode{index} is not in the range \crange{1}{5}.
+Initializes \tcode{wd_} with \tcode{wd} and \tcode{index_} with \tcode{index}.
+The values held are unspecified if \tcode{!wd.ok()} or \tcode{index} is not in the range \crange{0}{7}.
 \end{itemdescr}
 
 \indexlibrarymember{weekday}{weekday_indexed}%

--- a/source/time.tex
+++ b/source/time.tex
@@ -10197,10 +10197,9 @@ according to the following syntax:
     chrono-specs literal-char
 \end{ncbnf}
 
-% FIXME: This should obviously also exclude \tcode{\%}.
 \begin{ncbnf}
 \fmtnontermdef{literal-char}\br
-    \textnormal{any character other than \tcode{\{} or \tcode{\}}}
+    \textnormal{any character other than \tcode{\{}, \tcode{\}}, or \tcode{\%}}
 \end{ncbnf}
 
 \begin{ncbnf}

--- a/source/time.tex
+++ b/source/time.tex
@@ -10843,7 +10843,7 @@ The modified command \tcode{\%\placeholder{N}d} specifies
 the maximum number of characters to read.
 If \tcode{\placeholder{N}} is not specified, the default is 2.
 Leading zeroes are permitted but not required.
-The modified command \tcode{\%Ed} interprets
+The modified command \tcode{\%Od} interprets
 the locale's alternative representation of the day of the month.
 \\ \rowsep
 \tcode{\%D} &

--- a/source/time.tex
+++ b/source/time.tex
@@ -9506,8 +9506,8 @@ explicit zoned_time(TimeZonePtr z);
 \pnum
 \effects
 Constructs a \tcode{zoned_time} by
-initializing \tcode{zone_} with \tcode{std::move(z)}.
-% FIXME: What about tp_?
+initializing \tcode{zone_} with \tcode{std::move(z)} and
+default constructing \tcode{tp_}.
 \end{itemdescr}
 
 \begin{itemdecl}

--- a/source/time.tex
+++ b/source/time.tex
@@ -10450,11 +10450,16 @@ the locale's alternate time representation.
 \tcode{\%y} &
 The last two decimal digits of the year.
 If the result is a single digit it is prefixed by \tcode{0}.
+The modified command \tcode{\%Oy} produces the locale's alternative representation.
+The modified command \tcode{\%Ey} produces the locale's alternative representation
+of offset from \tcode{\%EC} (year only).
 \\ \rowsep
 \tcode{\%Y} &
 The year as a decimal number.
 If the result is less than four digits
 it is left-padded with \tcode{0} to four digits.
+The modified command \tcode{\%EY} produces
+the locale's alternative full year representation.
 \\ \rowsep
 \tcode{\%z} &
 The offset from UTC in the ISO 8601 format.

--- a/source/time.tex
+++ b/source/time.tex
@@ -10749,18 +10749,27 @@ template<class charT, class traits, class Alloc, class Parsable>
 
 \begin{itemdescr}
 \pnum
-\remarks
-This function shall not participate in overload resolution unless
+\constraints
+The expression
 \begin{codeblock}
-from_stream(declval<basic_istream<charT, traits>&>(), fmt.c_str(), tp, nullptr, &offset)
+from_stream(declval<basic_istream<charT, traits>&>(),
+            fmt.c_str(), tp,
+            declval<basic_string<charT, traits, Alloc>*>(),
+            &offset)
 \end{codeblock}
-is a valid expression.
+is well-formed when treated as an unevaluated operand.
 
 \pnum
 \returns
 A manipulator that, when extracted from a
 \tcode{basic_istream<charT, traits>} \tcode{is},
-calls \tcode{from_stream(is, fmt.c_str(), tp, nullptr, \&offset)}.
+calls:
+\begin{codeblock}
+from_stream(is,
+            fmt.c_str(), tp,
+            static_cast<basic_string<charT, traits, Alloc>*>(nullptr),
+            &offset)
+\end{codeblock}
 \end{itemdescr}
 
 \begin{itemdecl}

--- a/source/time.tex
+++ b/source/time.tex
@@ -6811,8 +6811,11 @@ constexpr chrono::day day() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-A \tcode{day} representing the last day of the (\tcode{year}, \tcode{month}) pair
+If \tcode{ok()} is \tcode{true},
+returns a \tcode{day} representing
+the last day of the (\tcode{year}, \tcode{month}) pair
 represented by \tcode{*this}.
+Otherwise, the returned value is unspecified.
 
 \pnum
 \begin{note}

--- a/source/time.tex
+++ b/source/time.tex
@@ -10265,6 +10265,19 @@ an exception of type \tcode{format_error} is thrown,
 as described above.
 \end{note}
 
+\pnum
+If the type being formatted does not contain
+the information that the format flag needs,
+an exception of type \tcode{format_error} is thrown.
+\begin{example}
+A \tcode{duration} does not contain enough information
+to format as a \tcode{weekday}.
+\end{example}
+However, if a flag refers to a ``time of day''
+(e.g. \tcode{\%H}, \tcode{\%I}, \tcode{\%p}, etc.),
+then a specialization of \tcode{duration} is interpreted as
+the time of day elapsed since midnight.
+
 \begin{LongTable}{Meaning of conversion specifiers}{time.format.spec}{lx{.8\hsize}}
 \\ \topline
 \lhdr{Specifier} & \rhdr{Replacement} \\ \capsep
@@ -10693,6 +10706,9 @@ return formatter<chrono::@\placeholder{local-time-format-t}@<Duration>, charT>::
 Each \tcode{parse} overload specified in this subclause
 calls \tcode{from_stream} unqualified,
 so as to enable argument dependent lookup\iref{basic.lookup.argdep}.
+In the following paragraphs,
+let \tcode{is} denote an object of type \tcode{basic_istream<charT, traits>},
+where \tcode{charT} and \tcode{traits} are template parameters in that context.
 
 \begin{itemdecl}
 template<class charT, class traits, class Alloc, class Parsable>
@@ -10811,6 +10827,18 @@ which governs how many characters are parsed from the stream in interpreting the
 All characters in the format string that are not represented in~\tref{time.parse.spec},
 except for white space, are parsed unchanged from the stream.
 A white space character matches zero or more white space characters in the input stream.
+
+\pnum
+If the type being parsed cannot represent
+the information that the format flag refers to,
+\tcode{is.setstate(ios_base::failbit)} is called.
+\begin{example}
+A \tcode{duration} cannot represent a \tcode{weekday}.
+\end{example}
+However, if a flag refers to a ``time of day''
+(e.g. \tcode{\%H}, \tcode{\%I}, \tcode{\%p}, etc.),
+then a specialization of \tcode{duration} is parsed as
+the time of day elapsed since midnight.
 
 \pnum
 If the \tcode{from_stream} overload fails to parse

--- a/source/time.tex
+++ b/source/time.tex
@@ -9383,7 +9383,7 @@ namespace std::chrono {
     explicit zoned_time(string_view name);
 
     template<class Duration2>
-      zoned_time(const zoned_time<Duration2, TimeZonePtr>& zt) noexcept;
+      zoned_time(const zoned_time<Duration2, TimeZonePtr>& zt);
 
     zoned_time(TimeZonePtr z,    const sys_time<Duration>& st);
     zoned_time(string_view name, const sys_time<Duration>& st);
@@ -9530,7 +9530,7 @@ default constructing \tcode{tp_}.
 
 \begin{itemdecl}
 template<class Duration2>
-  zoned_time(const zoned_time<Duration2, TimeZonePtr>& y) noexcept;
+  zoned_time(const zoned_time<Duration2, TimeZonePtr>& y);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/time.tex
+++ b/source/time.tex
@@ -9446,7 +9446,7 @@ namespace std::chrono {
 
   template<class Duration, class TimeZonePtr, class TimeZonePtr2>
     zoned_time(TimeZonePtr, zoned_time<Duration, TimeZonePtr2>, choose = choose::earliest)
-      -> zoned_time<Duration, TimeZonePtr>;
+      -> zoned_time<common_type_t<Duration, seconds>, TimeZonePtr>;
 }
 \end{codeblock}
 

--- a/source/time.tex
+++ b/source/time.tex
@@ -6093,7 +6093,8 @@ constexpr year_month operator+(const year_month& ym, const months& dm) noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-A \tcode{year_month} value \tcode{z} such that \tcode{z - ym == dm}.
+A \tcode{year_month} value \tcode{z} such that \tcode{z.ok() \&\& z - ym == dm}
+is \tcode{true}.
 
 \pnum
 \complexity

--- a/source/time.tex
+++ b/source/time.tex
@@ -10946,7 +10946,6 @@ For example,
 \\ \rowsep
 \tcode{\%p} &
 The locale's equivalent of the AM/PM designations associated with a 12-hour clock.
-The command \tcode{\%I} must precede \tcode{\%p} in the format string.
 \\ \rowsep
 \tcode{\%r} &
 The locale's 12-hour clock time.

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -19094,6 +19094,7 @@ The header \libheader{execution} declares global objects associated with each ty
   };
 
   to_chars_result to_chars(char* first, char* last, @\seebelow@ value, int base = 10);
+  to_chars_result to_chars(char* first, char* last, bool value, int base = 10) = delete;
 
   to_chars_result to_chars(char* first, char* last, float value);
   to_chars_result to_chars(char* first, char* last, double value);

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -20984,9 +20984,10 @@ The template specialization
 \begin{codeblock}
 typename Context::template formatter_type<T>
 \end{codeblock}
-is an enabled specialization of \tcode{formatter}\iref{format.formatter}.
+meets the \newoldconcept{Formatter} requirements\iref{formatter.requirements}.
 The extent to which an implementation determines that
-the specialization is enabled is unspecified,
+the specialization meets the \newoldconcept{Formatter} requirements
+is unspecified,
 except that as a minimum the expression
 \begin{codeblock}
 typename Context::template formatter_type<T>()

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -7976,6 +7976,7 @@ function is called.
 
 \pnum
 \throws
+\tcode{bad_array_new_length} if \tcode{SIZE_MAX / sizeof(T) < n}, or
 \tcode{bad_alloc} if the storage cannot be obtained.
 \end{itemdescr}
 


### PR DESCRIPTION
Fixes #3404.

Issues:
* From LWG3149:
** "immediate context" is used but never defined. It is used in reference to variables, expressions, and stand-alone as ``immediate context'', yet there is only a definition for "immediate function context".
** What is an unrelated context? E.g. LWG3149 adds this in [concept.defaultconstructible]:
      "Access checking is performed as if in a context unrelated to \tcode{T}."
* LWG3272 adds this wording to [time.parse]/p1:
      "In the following paragraphs, let is denote an object of type basic_istream<charT, traits>, where charT and traits are template parameters in that context.".
      What context?

Fixes cplusplus/nbballot#164
Fixes cplusplus/nbballot#257
Fixes cplusplus/nbballot#293