### PR TITLE
P1959R0 Remove std::weak_equality and std::strong_equality

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4974,7 +4974,7 @@ an object type.
 \end{note}
 The type of a pointer that can designate a function
 is called a \defn{function pointer type}.
-A pointer to objects of type \tcode{T} is referred to as a ``pointer to
+A pointer to an object of type \tcode{T} is referred to as a ``pointer to
 \tcode{T}''.
 \begin{example}
 A pointer to an object of type \tcode{int} is

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -6817,18 +6817,6 @@ b < a  ? partial_ordering::greater :
 \end{codeblock}
 
 \item
-Otherwise, if \tcode{R} is \tcode{strong_equality}, then
-\begin{codeblock}
-a == b ? strong_equality::equal : strong_equality::nonequal
-\end{codeblock}
-
-\item
-Otherwise, if \tcode{R} is \tcode{weak_equality}, then
-\begin{codeblock}
-a == b ? weak_equality::equivalent : weak_equality::nonequivalent
-\end{codeblock}
-
-\item
 Otherwise, the synthesized three-way comparison is not defined.
 \end{itemize}
 \begin{note}
@@ -6890,18 +6878,6 @@ is not a comparison category type\iref{cmp.categories},
 \tcode{U} is \tcode{void}.
 
 \item
-Otherwise, if
-at least one $\tcode{T}_i$ is \tcode{std::weak_equality}, or
-at least one $\tcode{T}_i$ is \tcode{std::strong_equality} and
-at least one $\tcode{T}_j$ is \tcode{std::partial_ordering} or
-                              \tcode{std::weak_ordering},
-\tcode{U} is \tcode{std::weak_equality}\iref{cmp.weakeq}.
-
-\item
-Otherwise, if at least one $\tcode{T}_i$ is \tcode{std::strong_equality},
-\tcode{U} is \tcode{std::strong_equality}\iref{cmp.strongeq}.
-
-\item
 Otherwise, if at least one $\tcode{T}_i$ is \tcode{std::partial_ordering},
 \tcode{U} is \tcode{std::partial_ordering}\iref{cmp.partialord}.
 
@@ -6944,8 +6920,10 @@ Otherwise, the operator function yields
 \pnum
 \begin{example}
 \begin{codeblock}
+struct HasNoLessThan { };
+
 struct C {
-  friend std::strong_equality operator<=>(const C&, const C&);
+  friend HasNoLessThan operator<=>(const C&, const C&);
   bool operator<(const C&) const = default;             // OK, function is deleted
 };
 \end{codeblock}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5956,20 +5956,6 @@ array-to-pointer conversions\iref{conv.array} are not applied.
 \end{note}
 
 \pnum
-If the composite pointer type is
-a function pointer type,
-a pointer-to-member type, or
-\tcode{std::nullptr_t},
-the result is of type \tcode{std::strong_equality};
-the result is
-\tcode{std::strong_equality::equal}
-if the (possibly converted) operands compare equal\iref{expr.eq}
-and
-\tcode{std::strong_equality::nonequal}
-if they compare unequal,
-otherwise the result of the operator is unspecified.
-
-\pnum
 If the composite pointer type is an object pointer type,
 \tcode{p <=> q} is of type \tcode{std::strong_ordering}.
 If two pointer operands \tcode{p} and \tcode{q} compare equal\iref{expr.eq},
@@ -5987,12 +5973,10 @@ Otherwise, the result is unspecified.
 Otherwise, the program is ill-formed.
 
 \pnum
-The five comparison category types\iref{cmp.categories}
+The three comparison category types\iref{cmp.categories}
 (the types
 \tcode{std::strong_ordering},
-\tcode{std::strong_equality},
-\tcode{std::weak_ordering},
-\tcode{std::weak_equality}, and
+\tcode{std::weak_ordering}, and
 \tcode{std::partial_ordering})
 are not predefined;
 if the header \libheaderref{compare}

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -295,7 +295,7 @@ namespace std {
     constexpr bool operator>=(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
-  template<class Iterator1, three_way_comparable_with<Iterator1, weak_equality> Iterator2>
+  template<class Iterator1, three_way_comparable_with<Iterator1> Iterator2>
     constexpr compare_three_way_result_t<Iterator1, Iterator2>
       operator<=>(const reverse_iterator<Iterator1>& x,
                   const reverse_iterator<Iterator2>& y);
@@ -350,7 +350,7 @@ namespace std {
   template<class Iterator1, class Iterator2>
     constexpr bool operator>=(
       const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
-  template<class Iterator1, three_way_comparable_with<Iterator1, weak_equality> Iterator2>
+  template<class Iterator1, three_way_comparable_with<Iterator1> Iterator2>
     constexpr compare_three_way_result_t<Iterator1, Iterator2>
       operator<=>(const move_iterator<Iterator1>& x,
                   const move_iterator<Iterator2>& y);
@@ -3526,7 +3526,7 @@ convertible to \tcode{bool}.
 
 \indexlibrarymember{operator<=>}{reverse_iterator}%
 \begin{itemdecl}
-template<class Iterator1, three_way_comparable_with<Iterator1, weak_equality> Iterator2>
+template<class Iterator1, three_way_comparable_with<Iterator1> Iterator2>
   constexpr compare_three_way_result_t<Iterator1, Iterator2>
     operator<=>(const reverse_iterator<Iterator1>& x,
                 const reverse_iterator<Iterator2>& y);
@@ -4470,7 +4470,7 @@ convertible to \tcode{bool}.
 
 \indexlibrarymember{operator<=>}{move_iterator}%
 \begin{itemdecl}
-template<class Iterator1, three_way_comparable_with<Iterator1, weak_equality> Iterator2>
+template<class Iterator1, three_way_comparable_with<Iterator1> Iterator2>
   constexpr compare_three_way_result_t<Iterator1, Iterator2>
     operator<=>(const move_iterator<Iterator1>& x,
                 const move_iterator<Iterator2>& y);

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -4114,9 +4114,8 @@ For every \tcode{\placeholder{T}}, where \tcode{\placeholder{T}}
 is a pointer-to-member type or \tcode{std::nullptr_t},
 there exist candidate operator functions of the form
 \begin{codeblock}
-bool                 operator==(@\placeholder{T}@, @\placeholder{T}@);
-bool                 operator!=(@\placeholder{T}@, @\placeholder{T}@);
-std::strong_equality operator<=>(@\placeholder{T}@, @\placeholder{T}@);
+bool operator==(@\placeholder{T}@, @\placeholder{T}@);
+bool operator!=(@\placeholder{T}@, @\placeholder{T}@);
 \end{codeblock}
 
 \pnum

--- a/source/support.tex
+++ b/source/support.tex
@@ -3990,15 +3990,13 @@ the three-way comparison operator\iref{expr.spaceship}.
 \begin{codeblock}
 namespace std {
   // \ref{cmp.categories}, comparison category types
-  class weak_equality;
-  class strong_equality;
   class partial_ordering;
   class weak_ordering;
   class strong_ordering;
 
   // named comparison functions
-  constexpr bool is_eq  (weak_equality cmp) noexcept    { return cmp == 0; }
-  constexpr bool is_neq (weak_equality cmp) noexcept    { return cmp != 0; }
+  constexpr bool is_eq  (partial_ordering cmp) noexcept { return cmp == 0; }
+  constexpr bool is_neq (partial_ordering cmp) noexcept { return cmp != 0; }
   constexpr bool is_lt  (partial_ordering cmp) noexcept { return cmp < 0; }
   constexpr bool is_lteq(partial_ordering cmp) noexcept { return cmp <= 0; }
   constexpr bool is_gt  (partial_ordering cmp) noexcept { return cmp > 0; }
@@ -4045,8 +4043,6 @@ namespace std {
 
 \pnum
 The types
-\tcode{weak_equality},
-\tcode{strong_equality},
 \tcode{partial_ordering},
 \tcode{weak_ordering}, and
 \tcode{strong_ordering}
@@ -4064,9 +4060,9 @@ enum class @\placeholdernc{ncmp}@ { @\placeholdernc{unordered}@ = -127 };       
 
 \pnum
 \begin{note}
-The types \tcode{strong_ordering} and \tcode{weak_equality}
-correspond, respectively, to the terms
-total ordering and equivalence in mathematics.
+The type \tcode{strong_ordering}
+corresponds to the term
+total ordering in mathematics.
 \end{note}
 
 \pnum
@@ -4087,146 +4083,6 @@ For the purposes of this subclause,
 whenever \tcode{a == b} is true,
 where \tcode{f} denotes a function that reads only comparison-salient state
 that is accessible via the argument's public const members.
-
-\rSec3[cmp.weakeq]{Class \tcode{weak_equality}}
-
-\pnum
-The \tcode{weak_equality} type is typically used
-as the result type of a three-way comparison operator\iref{expr.spaceship}
-that (a) admits only equality and inequality comparisons,
-and (b) does not imply substitutability.
-
-\indexlibraryglobal{weak_equality}%
-\indexlibrarymember{equivalent}{weak_equality}%
-\indexlibrarymember{nonequivalent}{weak_equality}%
-\begin{codeblock}
-namespace std {
-  class weak_equality {
-    int value;  // \expos
-
-    // exposition-only constructor
-    constexpr explicit weak_equality(@\placeholder{eq}@ v) noexcept : value(int(v)) {}  // \expos
-
-  public:
-    // valid values
-    static const weak_equality equivalent;
-    static const weak_equality nonequivalent;
-
-    // comparisons
-    friend constexpr bool operator==(weak_equality v, @\unspec@) noexcept;
-    friend constexpr bool operator==(weak_equality v, weak_equality w) noexcept = default;
-    friend constexpr weak_equality operator<=>(weak_equality v, @\unspec@) noexcept;
-    friend constexpr weak_equality operator<=>(@\unspec@, weak_equality v) noexcept;
-  };
-
-  // valid values' definitions
-  inline constexpr weak_equality weak_equality::equivalent(@\placeholder{eq}@::@\placeholder{equivalent}@);
-  inline constexpr weak_equality weak_equality::nonequivalent(@\placeholder{eq}@::@\placeholder{nonequivalent}@);
-}
-\end{codeblock}
-
-\indexlibrarymember{operator==}{weak_equality}%
-\begin{itemdecl}
-constexpr bool operator==(weak_equality v, @\unspec@) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-\tcode{v.value == 0}.
-\end{itemdescr}
-
-\indexlibrarymember{operator<=>}{weak_equality}%
-\begin{itemdecl}
-constexpr weak_equality operator<=>(weak_equality v, @\unspec@) noexcept;
-constexpr weak_equality operator<=>(@\unspec@, weak_equality v) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-\tcode{v}.
-\end{itemdescr}
-
-\rSec3[cmp.strongeq]{Class \tcode{strong_equality}}
-
-\pnum
-The \tcode{strong_equality} type is typically used
-as the result type of a three-way comparison operator\iref{expr.spaceship}
-that (a) admits only equality and inequality comparisons,
-and (b) does imply substitutability.
-
-\indexlibraryglobal{strong_equality}%
-\indexlibrarymember{equal}{strong_equality}%
-\indexlibrarymember{nonequal}{strong_equality}%
-\indexlibrarymember{equivalent}{strong_equality}%
-\indexlibrarymember{nonequivalent}{strong_equality}%
-\begin{codeblock}
-namespace std {
-  class strong_equality {
-    int value;  // \expos
-
-    // exposition-only constructor
-    constexpr explicit strong_equality(@\placeholder{eq}@ v) noexcept : value(int(v)) {}    // \expos
-
-  public:
-    // valid values
-    static const strong_equality equal;
-    static const strong_equality nonequal;
-    static const strong_equality equivalent;
-    static const strong_equality nonequivalent;
-
-    // conversion
-    constexpr operator weak_equality() const noexcept;
-
-    // comparisons
-    friend constexpr bool operator==(strong_equality v, @\unspec@) noexcept;
-    friend constexpr bool operator==(strong_equality v, strong_equality w) noexcept = default;
-    friend constexpr strong_equality operator<=>(strong_equality v, @\unspec@) noexcept;
-    friend constexpr strong_equality operator<=>(@\unspec@, strong_equality v) noexcept;
-  };
-
-  // valid values' definitions
-  inline constexpr strong_equality strong_equality::equal(@\placeholder{eq}@::@\placeholder{equal}@);
-  inline constexpr strong_equality strong_equality::nonequal(@\placeholder{eq}@::@\placeholder{nonequal}@);
-  inline constexpr strong_equality strong_equality::equivalent(@\placeholder{eq}@::@\placeholder{equivalent}@);
-  inline constexpr strong_equality strong_equality::nonequivalent(@\placeholder{eq}@::@\placeholder{nonequivalent}@);
-}
-\end{codeblock}
-
-\indexlibrarymember{operator weak_equality}{strong_equality}%
-\begin{itemdecl}
-constexpr operator weak_equality() const noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-\tcode{value == 0 ?\ weak_equality::equivalent :\ weak_equality::nonequivalent}.
-\end{itemdescr}
-
-\indexlibrarymember{operator==}{strong_equality}%
-\begin{itemdecl}
-constexpr bool operator==(strong_equality v, @\unspec@) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-\tcode{v.value == 0}.
-\end{itemdescr}
-
-\indexlibrarymember{operator<=>}{strong_equality}%
-\begin{itemdecl}
-constexpr strong_equality operator<=>(strong_equality v, @\unspec@) noexcept;
-constexpr strong_equality operator<=>(@\unspec@, strong_equality v) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-\tcode{v}.
-\end{itemdescr}
 
 \rSec3[cmp.partialord]{Class \tcode{partial_ordering}}
 
@@ -4264,9 +4120,6 @@ namespace std {
     static const partial_ordering greater;
     static const partial_ordering unordered;
 
-    // conversion
-    constexpr operator weak_equality() const noexcept;
-
     // comparisons
     friend constexpr bool operator==(partial_ordering v, @\unspec@) noexcept;
     friend constexpr bool operator==(partial_ordering v, partial_ordering w) noexcept = default;
@@ -4289,20 +4142,6 @@ namespace std {
   inline constexpr partial_ordering partial_ordering::unordered(@\placeholder{ncmp}@::@\placeholder{unordered}@);
 }
 \end{codeblock}
-
-\indexlibrarymember{operator weak_equality}{partial_ordering}%
-\begin{itemdecl}
-constexpr operator weak_equality() const noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-\tcode{value == 0 ?\ weak_equality::equivalent :\ weak_equality::nonequivalent}.
-\begin{note}
-The result is independent of the \tcode{is_ordered} member.
-\end{note}
-\end{itemdescr}
 
 \indexlibrarymember{operator==}{partial_ordering}%
 \indexlibrarymember{operator<}{partial_ordering}%
@@ -4390,7 +4229,6 @@ namespace std {
     static const weak_ordering greater;
 
     // conversions
-    constexpr operator weak_equality() const noexcept;
     constexpr operator partial_ordering() const noexcept;
 
     // comparisons
@@ -4414,17 +4252,6 @@ namespace std {
   inline constexpr weak_ordering weak_ordering::greater(@\placeholder{ord}@::@\placeholder{greater}@);
 }
 \end{codeblock}
-
-\indexlibrarymember{operator weak_equality}{weak_ordering}%
-\begin{itemdecl}
-constexpr operator weak_equality() const noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-\tcode{value == 0 ?\ weak_equality::equivalent :\ weak_equality::nonequivalent}.
-\end{itemdescr}
 
 \indexlibrarymember{operator partial_ordering}{weak_ordering}%
 \begin{itemdecl}
@@ -4529,8 +4356,6 @@ namespace std {
     static const strong_ordering greater;
 
     // conversions
-    constexpr operator weak_equality() const noexcept;
-    constexpr operator strong_equality() const noexcept;
     constexpr operator partial_ordering() const noexcept;
     constexpr operator weak_ordering() const noexcept;
 
@@ -4556,28 +4381,6 @@ namespace std {
   inline constexpr strong_ordering strong_ordering::greater(@\placeholder{ord}@::@\placeholder{greater}@);
 }
 \end{codeblock}
-
-\indexlibrarymember{operator weak_equality}{strong_ordering}%
-\begin{itemdecl}
-constexpr operator weak_equality() const noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-\tcode{value == 0 ?\ weak_equality::equivalent :\ weak_equality::nonequivalent}.
-\end{itemdescr}
-
-\indexlibrarymember{operator strong_equality}{strong_ordering}%
-\begin{itemdecl}
-constexpr operator strong_equality() const noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-\tcode{value == 0 ?\ strong_equality::equal :\ strong_equality::nonequal}.
-\end{itemdescr}
 
 \indexlibrarymember{operator partial_ordering}{strong_ordering}%
 \begin{itemdecl}
@@ -4753,7 +4556,7 @@ lvalues of types \tcode{const remove_reference_t<T>} and
 template<class T, class Cat = partial_ordering>
   concept @\deflibconcept{three_way_comparable}@ =
     @\exposconcept{weakly-equality-comparable-with}@<T, T> &&
-    (!convertible_to<Cat, partial_ordering> || @\exposconcept{partially-ordered-with}@<T, T>) &&
+    @\exposconcept{partially-ordered-with}@<T, T> &&
     requires(const remove_reference_t<T>& a, const remove_reference_t<T>& b) {
       { a <=> b } -> @\exposconcept{compares-as}@<Cat>;
     };
@@ -4766,28 +4569,21 @@ of type \tcode{const remove_reference_t<T>}.
 model \tcode{\libconcept{three_way_comparable}<T, Cat>} only if:
 \begin{itemize}
 \item
-  \tcode{(a <=> b == 0) == bool(a == b)} is \tcode{true};
+  \tcode{(a <=> b == 0) == bool(a == b)} is \tcode{true},
 \item
-  \tcode{(a <=> b != 0) == bool(a != b)} is \tcode{true};
+  \tcode{(a <=> b != 0) == bool(a != b)} is \tcode{true},
 \item
-  \tcode{((a <=> b) <=> 0)} and \tcode{(0 <=> (b <=> a))} are equal;
+  \tcode{((a <=> b) <=> 0)} and \tcode{(0 <=> (b <=> a))} are equal,
 \item
-  if \tcode{Cat} is convertible to \tcode{strong_equality}, \tcode{T} models
-  \libconcept{equality_comparable}\iref{concept.equalitycomparable};
+  \tcode{(a <=> b < 0) == bool(a < b)} is \tcode{true},
 \item
-  if \tcode{Cat} is convertible to \tcode{partial_ordering}:
-  \begin{itemize}
-  \item
-    \tcode{(a <=> b < 0) == bool(a < b)} is \tcode{true},
-  \item
-    \tcode{(a <=> b > 0) == bool(a > b)} is \tcode{true},
-  \item
-    \tcode{(a <=> b <= 0) == bool(a <= b)} is \tcode{true}, and
-  \item
-    \tcode{(a <=> b >= 0) == bool(a >= b)} is \tcode{true}; and
-  \end{itemize}
+  \tcode{(a <=> b > 0) == bool(a > b)} is \tcode{true},
 \item
-  If \tcode{Cat} is convertible to \tcode{strong_ordering}, \tcode{T} models
+  \tcode{(a <=> b <= 0) == bool(a <= b)} is \tcode{true},
+\item
+  \tcode{(a <=> b >= 0) == bool(a >= b)} is \tcode{true}, and
+\item
+  if \tcode{Cat} is convertible to \tcode{strong_ordering}, \tcode{T} models
   \libconcept{totally_ordered}\iref{concept.totallyordered}.
 \end{itemize}
 
@@ -4796,7 +4592,7 @@ model \tcode{\libconcept{three_way_comparable}<T, Cat>} only if:
 template<class T, class U, class Cat = partial_ordering>
   concept @\deflibconcept{three_way_comparable_with}@ =
     @\exposconcept{weakly-equality-comparable-with}@<T, U> &&
-    (!convertible_to<Cat, partial_ordering> || @\exposconcept{partially-ordered-with}@<T, U>) &&
+    @\exposconcept{partially-ordered-with}@<T, U> &&
     three_way_comparable<T, Cat> &&
     three_way_comparable<U, Cat> &&
     common_reference_with<const remove_reference_t<T>&, const remove_reference_t<U>&> &&
@@ -4818,31 +4614,23 @@ Let \tcode{C} be
 model \tcode{\libconcept{three_way_comparable_with}<T, U, Cat>} only if:
 \begin{itemize}
 \item
-  \tcode{t <=> u} and \tcode{u <=> t} have the same domain;
+  \tcode{t <=> u} and \tcode{u <=> t} have the same domain,
 \item
-  \tcode{((t <=> u) <=> 0)} and \tcode{(0 <=> (u <=> t))} are equal;
+  \tcode{((t <=> u) <=> 0)} and \tcode{(0 <=> (u <=> t))} are equal,
 \item
-  \tcode{(t <=> u == 0) == bool(t == u)} is \tcode{true};
+  \tcode{(t <=> u == 0) == bool(t == u)} is \tcode{true},
 \item
-  \tcode{(t <=> u != 0) == bool(t != u)} is \tcode{true};
+  \tcode{(t <=> u != 0) == bool(t != u)} is \tcode{true},
 \item
-  \tcode{Cat(t <=> u) == Cat(C(t) <=> C(u))} is \tcode{true};
+  \tcode{Cat(t <=> u) == Cat(C(t) <=> C(u))} is \tcode{true},
 \item
-  if \tcode{Cat} is convertible to \tcode{strong_equality},
-  \tcode{T} and \tcode{U} model
-  \tcode{\libconcept{equality_comparable_with}<T, U>}\iref{concept.equalitycomparable};
+  \tcode{(t <=> u < 0) == bool(t < u)} is \tcode{true},
 \item
-  if \tcode{Cat} is convertible to \tcode{partial_ordering}:
-  \begin{itemize}
-  \item
-    \tcode{(t <=> u < 0) == bool(t < u)} is \tcode{true},
-  \item
-    \tcode{(t <=> u > 0) == bool(t > u)} is \tcode{true},
-  \item
-    \tcode{(t <=> u <= 0) == bool(t <= u)} is \tcode{true},
-  \item
-    \tcode{(t <=> u >= 0) == bool(t >= u)} is \tcode{true}; and
-  \end{itemize}
+  \tcode{(t <=> u > 0) == bool(t > u)} is \tcode{true},
+\item
+  \tcode{(t <=> u <= 0) == bool(t <= u)} is \tcode{true},
+\item
+  \tcode{(t <=> u >= 0) == bool(t >= u)} is \tcode{true}, and
 \item
   if \tcode{Cat} is convertible to \tcode{strong_ordering},
   \tcode{T} and \tcode{U} model


### PR DESCRIPTION
Fixes #3423.
Fixes cplusplus/nbballot#168.
Fixes cplusplus/nbballot#171.

Issues:
* wrt my editorial commit "[temp.param] Reword types in bulleted list for consistency", the spec is inconsistent wrt "function pointer" v. "function pointer type" - which should be used?