### PR TITLE
LWG Motion 17: P1865R1 Add max() to latch and barrier

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -5402,6 +5402,8 @@ namespace std {
 namespace std {
   class latch {
   public:
+    static constexpr ptrdiff_t max() noexcept;
+
     constexpr explicit latch(ptrdiff_t expected);
     ~latch();
 
@@ -5429,6 +5431,17 @@ waiting for counter to be decremented to zero.
 Concurrent invocations of the member functions of \tcode{latch},
 other than its destructor, do not introduce data races.
 
+\indexlibrarymember{max}{latch}%
+\begin{itemdecl}
+static constexpr ptrdiff_t max() noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+The maximum value of \tcode{counter} that the implementation supports.
+\end{itemdescr}
+
 \indexlibraryctor{latch}%
 \begin{itemdecl}
 constexpr explicit latch(ptrdiff_t expected);
@@ -5437,7 +5450,8 @@ constexpr explicit latch(ptrdiff_t expected);
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{expected >= 0} is \tcode{true}.
+\tcode{expected >= 0} is \tcode{true} and
+\tcode{expected <= max()} is \tcode{true}.
 
 \pnum
 \effects
@@ -5559,6 +5573,8 @@ namespace std {
   public:
     using arrival_token = @\seebelow@;
 
+    static constexpr ptrdiff_t max() noexcept;
+
     constexpr explicit barrier(ptrdiff_t expected,
                                CompletionFunction f = CompletionFunction());
     ~barrier();
@@ -5651,6 +5667,17 @@ such that it meets the
 \oldconcept{MoveAssignable} (\tref{cpp17.moveassignable}), and
 \oldconcept{Destructible} (\tref{cpp17.destructible}) requirements.
 
+\indexlibrarymember{max}{barrier}%
+\begin{itemdecl}
+static constexpr ptrdiff_t max() noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+The maximum expected count that the implementation supports.
+\end{itemdescr}
+
 \indexlibraryctor{barrier}
 \begin{itemdecl}
 constexpr explicit barrier(ptrdiff_t expected,
@@ -5660,7 +5687,8 @@ constexpr explicit barrier(ptrdiff_t expected,
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{expected >= 0} is \tcode{true}.
+\tcode{expected >= 0} is \tcode{true} and
+\tcode{expected <= max()} is \tcode{true}.
 
 \pnum
 \effects


### PR DESCRIPTION
NB US 365 (C++20 CD):
P1865R1 Add max() to latch and barrier

Fixes #3419.
Fixes cplusplus/papers#617
Fixes cplusplus/nbballot#361