### PR TITLE
Motions 2019 11 cwg 3: P1971R0 Core Language Changes for NB Comments

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2607,11 +2607,6 @@ of a sequence of declarations.
 \end{bnf}
 
 \begin{bnf}
-\nontermdef{private-module-fragment}\br
-    \keyword{module} \terminal{:} \keyword{private} \terminal{;} \opt{top-level-declaration-seq}
-\end{bnf}
-
-\begin{bnf}
 \nontermdef{top-level-declaration-seq}\br
     top-level-declaration\br
     top-level-declaration-seq top-level-declaration
@@ -2622,13 +2617,6 @@ of a sequence of declarations.
     module-import-declaration\br
     declaration
 \end{bnf}
-
-\pnum
-A \grammarterm{private-module-fragment} shall appear only
-in a primary module interface unit\iref{module.unit}.
-A module unit with a \grammarterm{private-module-fragment}
-shall be the only module unit of its module;
-no diagnostic is required.
 
 \pnum
 A token sequence beginning with

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3665,13 +3665,13 @@ the names \tcode{std},
 \tcode{std::align_val_t},
 or any other names that the library uses to
 declare these names. Thus, a \grammarterm{new-expression},
-\grammarterm{delete-expression} or function call that refers to one of
-these functions without including the header \libheaderref{new} is
+\grammarterm{delete-expression}, or function call that refers to one of
+these functions without importing or including the header \libheaderref{new} is
 well-formed. However, referring to \tcode{std}
 or \tcode{std::size_t}
 or \tcode{std::align_val_t}
 is ill-formed unless the name has been declared
-by including the appropriate header.
+by importing or including the appropriate header.
 \end{note}
 Allocation and/or
 deallocation functions may also be declared and defined for any

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2819,11 +2819,10 @@ and are declared in the same translation unit; and
 \item both names refer to members of the same namespace or to members,
 not by inheritance, of the same class; and
 
-\item when both names denote functions, the parameter-type-lists of the
-functions\iref{dcl.fct} are identical; and
+\item when both names denote functions or function templates,
+the signatures~(\ref{defns.signature}, \ref{defns.signature.templ})
+are the same.
 
-\item when both names denote function templates, the
-signatures\iref{temp.over.link} are the same.
 \end{itemize}
 If multiple declarations of the same name with external linkage
 would declare the same entity except that

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3017,24 +3017,6 @@ the storage for the new object exactly overlays the storage location associated 
 \item
 the new object is of the same type as \placeholder{e} (ignoring cv-qualification).
 \end{itemize}
-\begin{note}
-If the subobject contains a reference member or a \tcode{const} subobject,
-the name of the original subobject cannot be used to access the new object\iref{basic.life}.
-\end{note}
-\begin{example}
-\begin{codeblock}
-struct X { const int n; };
-union U { X x; float f; };
-void tong() {
-  U u = {{ 1 }};
-  u.f = 5.f;                            // OK, creates new subobject of \tcode{u}\iref{class.union}
-  X *p = new (&u.x) X {2};              // OK, creates new subobject of \tcode{u}
-  assert(p->n == 2);                    // OK
-  assert(*std::launder(&u.x.n) == 2);   // OK
-  assert(u.x.n == 2);                   // undefined behavior, \tcode{u.x} does not name new subobject
-}
-\end{codeblock}
-\end{example}
 
 \pnum
 \indextext{object!providing storage for}%
@@ -3359,9 +3341,9 @@ location which the original object occupied, and
 \item the new object is of the same type as the original object
 (ignoring the top-level cv-qualifiers), and
 
-\item the type of the original object is not const-qualified, and, if a
-class type, does not contain any non-static data member whose type is
-const-qualified or a reference type, and
+\item the original object is neither
+a complete object that is const-qualified nor
+a subobject of such an object, and
 
 \item neither the original object nor the new object
 is a potentially-overlapping subobject\iref{intro.object}.

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -6251,10 +6251,12 @@ A coroutine behaves as if its \grammarterm{function-body} were replaced by:
 \bnfindent promise-type \exposid{promise} promise-constructor-arguments \terminal{;}\br
 % FIXME: \bnfindent \exposid{promise}\terminal{.get_return_object()} \terminal{;}
 % ... except that it's not a discarded-value expression
-\bnfindent \terminal{co_await} \terminal{\exposid{promise}.initial_suspend()} \terminal{;}\br
 \bnfindent \terminal{try} \terminal{\{}\br
+\bnfindent\bnfindent \terminal{co_await} \terminal{\exposid{promise}.initial_suspend()} \terminal{;}\br
 \bnfindent\bnfindent function-body\br
 \bnfindent \terminal{\} catch ( ... ) \{}\br
+\bnfindent\bnfindent \terminal{if (!\exposid{initial-await-resume-called})}\br
+\bnfindent\bnfindent\bnfindent \terminal{throw} \terminal{;}\br
 \bnfindent\bnfindent \terminal{\exposid{promise}.unhandled_exception()} \terminal{;}\br
 \bnfindent \terminal{\}}\br
 \exposid{final-suspend} \terminal{:}\br
@@ -6271,6 +6273,12 @@ is the \defn{initial suspend point}, and
 the \grammarterm{await-expression} containing
 the call to \tcode{final_suspend}
 is the \defn{final suspend point}, and
+\item
+\placeholder{initial-await-resume-called}
+is initially \tcode{false} and is set to \tcode{true}
+immediately before the evaluation
+of the \placeholder{await-resume} expression\iref{expr.await}
+of the initial suspend point, and
 \item
 \placeholder{promise-type} denotes the promise type, and
 \item

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5500,7 +5500,7 @@ corresponding parameter to be a non-deduced context\iref{temp.deduct.call}.
 \end{note}
 The template
 \tcode{std::initializer_list} is not predefined; if the header
-\tcode{<initializer_list>} is not included prior to a use of
+\tcode{<initializer_list>} is not imported or included prior to a use of
 \tcode{std::initializer_list} --- even an implicit use in which the type is not
 named\iref{dcl.spec.auto} --- the program is ill-formed.
 

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2174,7 +2174,7 @@ auto j = 2.0;           // OK: \tcode{j} deduced to have type \tcode{double}
 The optional \grammarterm{requires-clause}\iref{temp} in an
 \grammarterm{init-declarator} or \grammarterm{member-declarator}
 shall not be present when the declarator does not declare a
-function\iref{dcl.fct}.
+templated function\iref{dcl.fct}.
 %
 \indextext{trailing requires-clause@trailing \textit{requires-clause}|see{\textit{requires-clause}, trailing}}%
 When present after a declarator, the \grammarterm{requires-clause}
@@ -2187,9 +2187,11 @@ its \grammarterm{constraint-logical-or-expression} as a
 %
 \begin{example}
 \begin{codeblock}
-void f1(int a) requires true;               // OK
-auto f2(int a) -> bool requires true;       // OK
-auto f3(int a) requires true -> bool;       // error: \grammarterm{requires-clause} precedes \grammarterm{trailing-return-type}
+void f1(int a) requires true;               // error: non-templated function
+template<typename T>
+  auto f2(T a) -> bool requires true;       // OK
+template<typename T>
+  auto f3(T a) requires true -> bool;       // error: \grammarterm{requires-clause} precedes \grammarterm{trailing-return-type}
 void (*pf)() requires true;                 // error: constraint on a variable
 void g(int (*)() requires true);            // error: constraint on a \grammarterm{parameter-declaration}
 

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -7887,8 +7887,13 @@ name and the same parameter-type-list\iref{dcl.fct} as
 a function introduced by a \grammarterm{using-declaration}, and the
 declarations do not declare the same function, the program is
 ill-formed. If a function template declaration in namespace scope has
-the same name, parameter-type-list, return type, and template
-parameter list as a function template introduced by a
+the same
+name,
+parameter-type-list,
+trailing \grammarterm{requires-clause} (if any),
+return type, and
+\grammarterm{template-head},
+as a function template introduced by a
 \grammarterm{using-declaration}, the program is ill-formed.
 \begin{note}
 Two \grammarterm{using-declaration}{s} may introduce functions with the same
@@ -7924,8 +7929,13 @@ void h() {
 When a \grammarterm{using-declarator} brings declarations from a base class into
 a derived class, member functions and member function templates in
 the derived class override and/or hide member functions and member
-function templates with the same name,
-parameter-type-list\iref{dcl.fct}, cv-qualification, and \grammarterm{ref-qualifier} (if any) in a base
+function templates with the same
+name,
+parameter-type-list\iref{dcl.fct},
+trailing \grammarterm{requires-clause} (if any),
+cv-qualification, and
+\grammarterm{ref-qualifier} (if any),
+in a base
 class (rather than conflicting).
 Such hidden or overridden declarations are excluded from the set of
 declarations introduced by the \grammarterm{using-declarator}.

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -7135,7 +7135,7 @@ For the purposes of determining
 whether an expression \tcode{e} is a core constant expression,
 the evaluation of a call to a member function of \tcode{std::allocator<T>}
 as defined in \ref{allocator.members}, where \tcode{T} is a literal type,
-does not disqualify the expression from being a core constant expression,
+does not disqualify \tcode{e} from being a core constant expression,
 even if the actual evaluation of such a call
 would otherwise fail the requirements for a core constant expression.
 Similarly, the evaluation of a call to
@@ -7143,7 +7143,8 @@ Similarly, the evaluation of a call to
 \tcode{std::ranges::destroy_at},
 \tcode{std::construct_at}, or
 \tcode{std::ranges::construct_at}
-is a valid core constant expression unless:
+does not disqualify \tcode{e}
+from being a core constant expression unless:
 \begin{itemize}
 \item
   for a call to \tcode{std::construct_at} or \tcode{std::ranges::construct_at},
@@ -7152,7 +7153,7 @@ is a valid core constant expression unless:
   to storage allocated with \tcode{std::allocator<T>} or
   to an object whose lifetime began within the evaluation of \tcode{e}, or
   the evaluation of the underlying constructor call
-  is not a core constant expression, or
+  disqualifies \tcode{e} from being a core constant expression, or
 \item
   for a call to \tcode{std::destroy_at} or \tcode{std::ranges::destroy_at},
   the first argument, of type \tcode{T*},
@@ -7160,7 +7161,7 @@ is a valid core constant expression unless:
   to storage allocated with \tcode{std::allocator<T>} or
   to an object whose lifetime began within the evaluation of \tcode{e}, or
   the evaluation of the underlying destructor call
-  is not a core constant expression.
+  disqualifies \tcode{e} from being a core constant expression.
 \end{itemize}
 
 \pnum

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1324,12 +1324,14 @@ other than to declare it,
 is ill-formed.
 \begin{example}
 \begin{codeblock}
-void f(int) requires false;
+template<typename T> struct A {
+  static void f(int) requires false;
+}
 
 void g() {
-  f(0);                         // error: cannot call \tcode{f}
-  void (*p1)(int) = f;          // error: cannot take the address of \tcode{f}
-  decltype(f)* p2 = nullptr;    // error: the type \tcode{decltype(f)} is invalid
+  A<int>::f(0);                         // error: cannot call \tcode{f}
+  void (*p1)(int) = A<int>::f;          // error: cannot take the address of \tcode{f}
+  decltype(A<int>::f)* p2 = nullptr;    // error: the type \tcode{decltype(A<int>::f)} is invalid
 }
 \end{codeblock}
 In each case, the constraints of \tcode{f} are not satisfied.

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3597,7 +3597,8 @@ typeid(D)  == typeid(const D&); // yields \tcode{true}
 \end{example}
 
 \pnum
-If the header \libheaderrefx{typeinfo}{type.info} is not included prior
+If the header \libheaderrefx{typeinfo}{type.info}
+is not imported or included prior
 to a use of \tcode{typeid}, the program is ill-formed.
 
 \pnum
@@ -6007,7 +6008,7 @@ The five comparison category types\iref{cmp.categories}
 \tcode{std::partial_ordering})
 are not predefined;
 if the header \libheaderref{compare}
-is not included prior to a use of such a class type --
+is not imported or included prior to a use of such a class type --
 even an implicit use in which the type is not named
 (e.g., via the \tcode{auto} specifier\iref{dcl.spec.auto}
 in a defaulted three-way comparison\iref{class.spaceship}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -7132,7 +7132,7 @@ constexpr int y = h(1);             // OK: initializes \tcode{y} with the value 
 
 \pnum
 For the purposes of determining
-whether an expression is a core constant expression,
+whether an expression \tcode{e} is a core constant expression,
 the evaluation of a call to a member function of \tcode{std::allocator<T>}
 as defined in \ref{allocator.members}, where \tcode{T} is a literal type,
 does not disqualify the expression from being a core constant expression,
@@ -7148,13 +7148,17 @@ is a valid core constant expression unless:
 \item
   for a call to \tcode{std::construct_at} or \tcode{std::ranges::construct_at},
   the first argument, of type \tcode{T*},
-  does not point to storage allocated with \tcode{std::allocator<T>} or
+  does not point
+  to storage allocated with \tcode{std::allocator<T>} or
+  to an object whose lifetime began within the evaluation of \tcode{e}, or
   the evaluation of the underlying constructor call
   is not a core constant expression, or
 \item
   for a call to \tcode{std::destroy_at} or \tcode{std::ranges::destroy_at},
   the first argument, of type \tcode{T*},
-  does not point to storage allocated with \tcode{std::allocator<T>} or
+  does not point
+  to storage allocated with \tcode{std::allocator<T>} or
+  to an object whose lifetime began within the evaluation of \tcode{e}, or
   the evaluation of the underlying destructor call
   is not a core constant expression.
 \end{itemize}

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -12,7 +12,7 @@ requirement appear at various places within this document.
 
 \pnum
 \Cpp{} is a general purpose programming language based on the C
-programming language as described in ISO/IEC 9899:2011
+programming language as described in ISO/IEC 9899:2018
 \doccite{Programming languages --- C} (hereinafter referred to as the
 \defnx{C standard}{C!standard}). \Cpp{} provides many facilities
 beyond those provided by C, including additional data types,
@@ -47,7 +47,7 @@ Available at
 Vocabulary}
 \item ISO 8601:2004, \doccite{Data elements and interchange formats ---
 Information interchange --- Representation of dates and times}
-\item ISO/IEC 9899:2011, \doccite{Programming languages --- C}
+\item ISO/IEC 9899:2018, \doccite{Programming languages --- C}
 \item ISO/IEC 9945:2003, \doccite{Information Technology --- Portable
 Operating System Interface (POSIX)}
 \item ISO/IEC 10646, \doccite{Information technology ---
@@ -63,7 +63,7 @@ to be used in the natural sciences and technology}
 \end{itemize}
 
 \pnum
-The library described in Clause 7 of ISO/IEC 9899:2011
+The library described in Clause 7 of ISO/IEC 9899:2018
 is hereinafter called the
 \defnx{C standard library}{C!standard library}.%
 \footnote{With the qualifications noted in \ref{\firstlibchapter}

--- a/source/modules.tex
+++ b/source/modules.tex
@@ -529,10 +529,10 @@ import M;               // error: cannot import \tcode{M} in its own unit
 \end{example}
 
 \pnum
-A translation unit has an \defn{interface dependency} on a module unit \tcode{U}
+A translation unit has an \defn{interface dependency} on a translation unit \tcode{U}
 if it contains a \grammarterm{module-declaration} or
 \grammarterm{module-import-declaration} that imports \tcode{U} or if it has
-an interface dependency on a module unit that has an interface dependency on \tcode{U}.
+an interface dependency on a translation unit that has an interface dependency on \tcode{U}.
 A translation unit shall not have an interface dependency on itself.
 \begin{example}
 \begin{codeblocktu}{Interface unit of \tcode{M1}}

--- a/source/modules.tex
+++ b/source/modules.tex
@@ -774,29 +774,30 @@ no diagnostic is required.
 
 \pnum
 \begin{note}
-A \grammarterm{private-module-fragment} ends the primary module interface and
-commences an unimported implementation partition of the module.
-A \grammarterm{private-module-fragment} allows a module to
-consist of a primary interface and a single implementation partition
-without needing multiple translation units.
+A \grammarterm{private-module-fragment} ends
+the portion of the module interface unit
+that can affect the behavior of other translation units.
+A \grammarterm{private-module-fragment} allows a module
+to be represented as a single translation unit
+without making all of the contents of the module reachable to importers.
 The presence of a \grammarterm{private-module-fragment} affects:
 \begin{itemize}
+\item
+the point by which the definition of
+an exported inline function
+is required\iref{dcl.inline},
 
 \item
-the point by which the definition of an inline function
-declared in the module interface unit purview is required\iref{dcl.inline},
-
-\item
-the point by which the definition of a function with a placeholder return type
-declared in the module interface unit purview is required\iref{dcl.spec.auto},
+the point by which the definition of
+an exported function with a placeholder return type
+is required\iref{dcl.spec.auto},
 
 \item
 the instantiation contexts of templates
 instantiated before it\iref{module.context}, and
 
 \item
-the reachability of entities
-declared in the primary interface unit\iref{module.reach}.
+the reachability of declarations within it\iref{module.reach}.
 \end{itemize}
 \end{note}
 
@@ -804,22 +805,25 @@ declared in the primary interface unit\iref{module.reach}.
 \begin{example}
 \begin{codeblock}
 export module A;
-inline void h();        // error: inline function \tcode{h} not defined
-                        // before private module fragment
-static void fn();
+export inline void fn_e();      // error: exported inline function \tcode{fn_e} not defined
+                                // before private module fragment
+inline void fn_m();             // OK, module-linkage inline function
+static void fn_s();
 export struct X;
 export void g(X *x) {
-  fn();                 // OK: call to static function in same translation unit
+  fn_s();                       // OK, call to static function in same translation unit
+  fn_m();                       // OK, call to module-linkage inline function
 }
-export X *factory();    // OK
+export X *factory();            // OK
 
 module :private;
-struct X {};            // definition not reachable from importers of \tcode{A}
+struct X {};                    // definition not reachable from importers of \tcode{A}
 X *factory() {
-  return new X ();
+   return new X ();
 }
-void h() {}
-void fn() {}
+void fn_e() {}
+void fn_m() {}
+void fn_s() {}
 \end{codeblock}
 \end{example}
 

--- a/source/modules.tex
+++ b/source/modules.tex
@@ -758,6 +758,71 @@ int c = use_h<int>();           // OK
 \end{codeblocktu}
 \end{example}
 
+\rSec1[module.private.frag]{Private module fragment}
+
+\begin{bnf}
+\nontermdef{private-module-fragment}\br
+    \keyword{module} \terminal{:} \keyword{private} \terminal{;} \opt{top-level-declaration-seq}
+\end{bnf}
+
+\pnum
+A \grammarterm{private-module-fragment} shall appear only
+in a primary module interface unit\iref{module.unit}.
+A module unit with a \grammarterm{private-module-fragment}
+shall be the only module unit of its module;
+no diagnostic is required.
+
+\pnum
+\begin{note}
+A \grammarterm{private-module-fragment} ends the primary module interface and
+commences an unimported implementation partition of the module.
+A \grammarterm{private-module-fragment} allows a module to
+consist of a primary interface and a single implementation partition
+without needing multiple translation units.
+The presence of a \grammarterm{private-module-fragment} affects:
+\begin{itemize}
+
+\item
+the point by which the definition of an inline function
+declared in the module interface unit purview is required\iref{dcl.inline},
+
+\item
+the point by which the definition of a function with a placeholder return type
+declared in the module interface unit purview is required\iref{dcl.spec.auto},
+
+\item
+the instantiation contexts of templates
+instantiated before it\iref{module.context}, and
+
+\item
+the reachability of entities
+declared in the primary interface unit\iref{module.reach}.
+\end{itemize}
+\end{note}
+
+\pnum
+\begin{example}
+\begin{codeblock}
+export module A;
+inline void h();        // error: inline function \tcode{h} not defined
+                        // before private module fragment
+static void fn();
+export struct X;
+export void g(X *x) {
+  fn();                 // OK: call to static function in same translation unit
+}
+export X *factory();    // OK
+
+module :private;
+struct X {};            // definition not reachable from importers of \tcode{A}
+X *factory() {
+  return new X ();
+}
+void h() {}
+void fn() {}
+\end{codeblock}
+\end{example}
+
 \rSec1[module.context]{Instantiation context}
 
 \pnum

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -71,12 +71,19 @@ the exception specification\iref{except.spec}, or both
 cannot be overloaded.
 \item
 \indextext{\idxcode{static}!overloading and}%
-Member function declarations with the same name and the same
-parameter-type-list\iref{dcl.fct} cannot be overloaded if any of them is a
+Member function declarations with
+the same name,
+the same parameter-type-list\iref{dcl.fct}, and
+the same trailing \grammarterm{requires-clause} (if any)
+cannot be overloaded if any of them is a
 \tcode{static}
 member function declaration\iref{class.static}.
-Likewise, member function template declarations with the same name,
-the same parameter-type-list, and the same template parameter lists cannot be
+Likewise, member function template declarations with
+the same name,
+the same parameter-type-list,
+the same trailing \grammarterm{requires-clause} (if any), and
+the same \grammarterm{template-head}
+cannot be
 overloaded if any of them is a
 \tcode{static}
 member function template declaration.
@@ -87,7 +94,11 @@ this rule.
 In contrast, if there is no
 \tcode{static}
 member function declaration among a set of member function
-declarations with the same name and the same parameter-type-list, then
+declarations with
+the same name,
+the same parameter-type-list, and
+the same trailing \grammarterm{requires-clause} (if any),
+then
 these member function declarations can be overloaded if they differ in
 the type of their implicit object parameter.
 \begin{example}
@@ -106,10 +117,17 @@ class X {
 \end{codeblock}
 \end{example}
 
-\item Member function declarations with the same name and the same
-parameter-type-list\iref{dcl.fct} as well as member function template
-declarations with the same name, the same parameter-type-list, and
-the same template parameter lists cannot be overloaded if any of them, but not
+\item Member function declarations with
+the same name,
+the same parameter-type-list\iref{dcl.fct}, and
+the same trailing \grammarterm{requires-clause} (if any),
+as well as member function template
+declarations with
+the same name,
+the same parameter-type-list,
+the same trailing \grammarterm{requires-clause} (if any), and
+the same \grammarterm{template-head},
+cannot be overloaded if any of them, but not
 all, have a \grammarterm{ref-qualifier}\iref{dcl.fct}.
 \begin{example}
 \begin{codeblock}

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -715,6 +715,13 @@ the preprocessor and later phases of translation.
 Each \tcode{\#define} directive encountered when preprocessing
 each translation unit in a program results in a distinct
 \defnx{macro definition}{macro!definition}.
+\begin{note}
+A predefined macro name\iref{cpp.predefined}
+is not introduced by a \tcode{\#define} directive.
+Implementations providing mechanisms to predefine additional macros
+are encouraged to not treat them
+as being introduced by a \tcode{\#define} directive.
+\end{note}
 Importing macros from a header unit makes macro definitions
 from a translation unit visible in other translation units.
 Each macro definition has at most one point of definition in

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -899,14 +899,16 @@ defined in \ref{dcl.fct.def.coroutine}
 and \placeholder{S} is defined as follows:
 \begin{itemize}
 \item
-\placeholder{S} is \placeholder{p}\tcode{.return_value(}\grammarterm{expr-or-braced-init-list}{}\tcode{)},
-if the operand is a \grammarterm{braced-init-list} or an expression of non-\tcode{void} type;
+If the operand is a \grammarterm{braced-init-list} or an expression of non-\tcode{void} type,
+\placeholder{S} is \placeholder{p}\tcode{.return_value(}\grammarterm{expr-or-braced-init-list}{}\tcode{)}.
+The expression \placeholder{S} shall be a prvalue of type \tcode{void}.
 
 \item
-\placeholder{S} is \tcode{\{}{ }\opt{\grammarterm{expression}} \tcode{;} \placeholder{p}\tcode{.return_void()}\tcode{;{ }\}}, otherwise;
+Otherwise,
+\placeholder{S} is the \grammarterm{compound-statement} \tcode{\{}{ }\opt{\grammarterm{expression}} \tcode{;} \placeholder{p}\tcode{.return_void()}\tcode{;{ }\}}.
+The expression \placeholder{p}\tcode{.return_void()}
+shall be a prvalue of type \tcode{void}.
 \end{itemize}
-
-\placeholder{S} shall be a prvalue of type \tcode{void}.
 
 \pnum
 If \placeholder{p}\tcode{.return_void()} is a valid expression,

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -878,8 +878,12 @@ enclosing the \tcode{return} statement.
 \pnum
 A coroutine returns to its caller or resumer\iref{dcl.fct.def.coroutine}
 by the \tcode{co_return} statement or when suspended\iref{expr.await}.
-A coroutine shall not return to its caller or resumer
-by a \tcode{return} statement\iref{stmt.return}.
+A coroutine shall not contain
+a \tcode{return} statement\iref{stmt.return}.
+\begin{note}
+For this determination, it is irrelevant whether the \tcode{return} statement
+is enclosed by a discarded statement\iref{stmt.if}.
+\end{note}
 
 \pnum
 The \grammarterm{expr-or-braced-init-list} of a \tcode{co_return} statement is

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1570,15 +1570,16 @@ template <class T> concept sad = false;
 
 template <class T> int f1(T) requires (!sad<T>);
 template <class T> int f1(T) requires (!sad<T>) && true;
-int i1 = f1(42);        // ambiguous, \tcode{!sad<T>} constraints are not formed from the same \grammarterm{expression}
+int i1 = f1(42);        // ambiguous, \tcode{!sad<T>} atomic constraint expressions\iref{temp.constr.atomic}
+                        // are not formed from the same \grammarterm{expression}
 
 template <class T> concept not_sad = !sad<T>;
 template <class T> int f2(T) requires not_sad<T>;
 template <class T> int f2(T) requires not_sad<T> && true;
-int i2 = f2(42);        // OK, \tcode{!sad<T>} constraints both come from \tcode{not_sad}
+int i2 = f2(42);        // OK, \tcode{!sad<T>} atomic constraint expressions both come from \tcode{not_sad}
 
 template <class T> int f3(T) requires (!sad<typename T::type>);
-int i3 = f3(42);        // error, constraint not satisfied due to substitution failure
+int i3 = f3(42);        // error, associated constraints not satisfied due to substitution failure
 
 template <class T> concept sad_nested_type = sad<typename T::type>;
 template <class T> int f4(T) requires (!sad_nested_type<T>);

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1647,7 +1647,7 @@ void g() {
 
 \pnum
 A template declaration\iref{temp}
-or function declaration\iref{dcl.fct}
+or templated function declaration\iref{dcl.fct}
 can be constrained by the use of a \grammarterm{requires-clause}.
 This allows the specification of constraints for that declaration as
 an expression:
@@ -1666,7 +1666,7 @@ that are used to constrain the declaration.
 
 \pnum
 \indextext{constraint!associated|see{associated constraints}}%
-A template's \defn{associated constraints} are defined as follows:
+A declaration's \defn{associated constraints} are defined as follows:
 
 \begin{itemize}
 \item If there are no introduced \grammarterm{constraint-expression}{s},

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1545,6 +1545,48 @@ of \tcode{f}, the constraint \tcode{sizeof(char) > 1} is not satisfied;
 the second operand is not checked for satisfaction.
 \end{example}
 
+\pnum
+\begin{note}
+A logical negation expression\iref{expr.unary.op} is an atomic constraint;
+the negation operator is not treated as a logical operation on constraints.
+As a result, distinct negation \grammarterm{constraint-expression}{s}
+that are equivalent under~\ref{temp.over.link}
+do not subsume one another under~\ref{temp.constr.order}.
+Furthermore, if substitution to determine
+whether an atomic constraint is satisfied\iref{temp.constr.atomic}
+encounters a substitution failure, the constraint is not satisfied,
+regardless of the presence of a negation operator.
+It is unclear in principle what the desired value is
+of a substitution failure in a negated \grammarterm{concept-id};
+in the example below, does \tcode{requires (!sad<typename T::type>)} mean
+to require that there be no sad nested type, or
+that there be a nested type that is not sad?
+In effect it means the latter,
+whereas \tcode{requires (!sad_nested_type<T>)} means the former.
+
+\begin{example}
+\begin{codeblock}
+template <class T> concept sad = false;
+
+template <class T> int f1(T) requires (!sad<T>);
+template <class T> int f1(T) requires (!sad<T>) && true;
+int i1 = f1(42);        // ambiguous, \tcode{!sad<T>} constraints are not formed from the same \grammarterm{expression}
+
+template <class T> concept not_sad = !sad<T>;
+template <class T> int f2(T) requires not_sad<T>;
+template <class T> int f2(T) requires not_sad<T> && true;
+int i2 = f2(42);        // OK, \tcode{!sad<T>} constraints both come from \tcode{not_sad}
+
+template <class T> int f3(T) requires (!sad<typename T::type>);
+int i3 = f3(42);        // error, constraint not satisfied due to substitution failure
+
+template <class T> concept sad_nested_type = sad<typename T::type>;
+template <class T> int f4(T) requires (!sad_nested_type<T>);
+int i4 = f4(42);        // OK, substitution failure contained within \tcode{sad_nested_type}
+\end{codeblock}
+\end{example}
+\end{note}
+
 \rSec3[temp.constr.atomic]{Atomic constraints}
 
 \pnum

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1556,14 +1556,6 @@ Furthermore, if substitution to determine
 whether an atomic constraint is satisfied\iref{temp.constr.atomic}
 encounters a substitution failure, the constraint is not satisfied,
 regardless of the presence of a negation operator.
-It is unclear in principle what the desired value is
-of a substitution failure in a negated \grammarterm{concept-id};
-in the example below, does \tcode{requires (!sad<typename T::type>)} mean
-to require that there be no sad nested type, or
-that there be a nested type that is not sad?
-In effect it means the latter,
-whereas \tcode{requires (!sad_nested_type<T>)} means the former.
-
 \begin{example}
 \begin{codeblock}
 template <class T> concept sad = false;
@@ -1585,6 +1577,12 @@ template <class T> concept sad_nested_type = sad<typename T::type>;
 template <class T> int f4(T) requires (!sad_nested_type<T>);
 int i4 = f4(42);        // OK, substitution failure contained within \tcode{sad_nested_type}
 \end{codeblock}
+Here,
+\tcode{requires (!sad<typename T::type>)} requires
+that there is a nested \tcode{type} that is not \tcode{sad},
+whereas
+\tcode{requires (!sad_nested_type<T>)} requires
+that there is no \tcode{sad} nested \tcode{type}.
 \end{example}
 \end{note}
 


### PR DESCRIPTION
Fixes #3396.
Fixes cplusplus/nbballot#7.
Fixes cplusplus/nbballot#41.
Fixes cplusplus/nbballot#19.
Fixes cplusplus/nbballot#20.
Fixes cplusplus/nbballot#37.
Fixes cplusplus/nbballot#43.
Fixes cplusplus/nbballot#51.
Fixes cplusplus/nbballot#52.
Fixes cplusplus/nbballot#64.
Fixes cplusplus/nbballot#78.
Fixes cplusplus/nbballot#86.
Fixes cplusplus/nbballot#110.
Fixes cplusplus/nbballot#131.
Fixes cplusplus/nbballot#363.
Fixes cplusplus/nbballot#374.

Issues:
 * GB079 - fyi, Section [module.global] is now [module.global.frag]
 * US111 - Comments in example use the wording "<expr> constraints" as a subject - should this be "the constraints on <expr>"?