### PR TITLE
[depr.relops] Move index entry here from [utility.syn]

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -323,6 +323,7 @@ much as in the C Standard. It may also provide these names within
 the namespace \tcode{std}.
 \end{example}
 
+\indexlibraryglobal{rel_ops}%
 \rSec1[depr.relops]{Relational operators}
 
 \pnum

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -33,7 +33,6 @@ These utilities are summarized in \tref{utilities.summary}.
 
 \rSec1[utility]{Utility components}
 
-\indexlibraryglobal{rel_ops}%
 \rSec2[utility.syn]{Header \tcode{<utility>} synopsis}
 
 \pnum


### PR DESCRIPTION
We left the index entry for `rel_ops` behind when P0768 moved the specification into Annex D.