### PR TITLE
Motions 2019 11 cwg 2: P1968R0 Core Language Working Group "tentatively ready" Issues

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -9775,12 +9775,12 @@ template<class T>
 \tcode{a} and \tcode{b} point to, respectively,
 elements $\tcode{x}[i]$ and $\tcode{x}[j]$ of the same array object \tcode{x}.
 \begin{note}
-An object that is not an array element is considered to belong
-to a single-element array for this purpose; see \ref{expr.unary.op}.
-A pointer past the last element of an array \tcode{x} of $n$ elements
+As specified in \ref{basic.compound},
+an object that is not an array element
+is considered to belong to a single-element array for this purpose and
+a pointer past the last element of an array \tcode{x} of $n$ elements
 is considered to be equivalent to a pointer
-to a hypothetical element $\tcode{x}[n]$ for this purpose;
-see \ref{basic.compound}.
+to a hypothetical array element $n$ for this purpose.
 \end{note}
 
 \pnum

--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -9773,19 +9773,19 @@ template<class T>
 \pnum
 \expects
 \tcode{a} and \tcode{b} point to, respectively,
-elements $\tcode{x}[i]$ and $\tcode{x}[j]$ of the same array object \tcode{x}.
+elements $i$ and $j$ of the same array object \tcode{x}.
 \begin{note}
 As specified in \ref{basic.compound},
 an object that is not an array element
 is considered to belong to a single-element array for this purpose and
-a pointer past the last element of an array \tcode{x} of $n$ elements
+a pointer past the last element of an array of $n$ elements
 is considered to be equivalent to a pointer
 to a hypothetical array element $n$ for this purpose.
 \end{note}
 
 \pnum
 \returns
-A pointer to $\tcode{x}[i+\frac{j-i}{2}]$,
+A pointer to array element $i+\frac{j-i}{2}$ of \tcode{x},
 where the result of the division is truncated towards zero.
 \end{itemdescr}
 

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3581,7 +3581,7 @@ causes a system-generated runtime fault.}
 All variables which do not have dynamic storage duration, do not have thread
 storage duration, and are not local
 have \defn{static storage duration}. The
-storage for these entities shall last for the duration of the
+storage for these entities lasts for the duration of the
 program~(\ref{basic.start.static}, \ref{basic.start.term}).
 
 \pnum
@@ -3610,14 +3610,17 @@ definition gives the data member static storage duration.
 \pnum
 All variables declared with the \tcode{thread_local} keyword have
 \defnadj{thread}{storage duration}.
-The storage for these entities shall last for the duration of
+The storage for these entities lasts for the duration of
 the thread in which they are created. There is a distinct object or reference
 per thread, and use of the declared name refers to the entity associated with
 the current thread.
 
 \pnum
-A variable with thread storage duration shall be initialized before
-its first odr-use\iref{basic.def.odr} and, if constructed, shall be destroyed on thread exit.
+\begin{note}
+A variable with thread storage duration is initialized as specified
+in~\ref{basic.start.static}, \ref{basic.start.dynamic}, and \ref{stmt.dcl}
+and, if constructed, is destroyed on thread exit\iref{basic.start.term}.
+\end{note}
 
 \rSec3[basic.stc.auto]{Automatic storage duration}
 

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -561,14 +561,8 @@ There can be more than one definition of a
 \begin{itemize}
 \item class type\iref{class},
 \item enumeration type\iref{dcl.enum},
-\item inline function or variable\iref{dcl.inline} with external linkage,
-\item class template\iref{temp},
-\item non-static function template\iref{temp.fct},
-\item concept\iref{temp.concept},
-\item static data member of a class template\iref{temp.static},
-\item member function of a class template\iref{temp.mem.func},
-\item template specialization for which some template parameters are not
-specified~(\ref{temp.spec}, \ref{temp.class.spec}),
+\item inline function or variable\iref{dcl.inline},
+\item templated entity\iref{temp.pre},
 \item default argument for a parameter (for a function in a given scope)%
 \iref{dcl.fct.default}, or
 \item default template argument\iref{temp.param}

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5356,7 +5356,8 @@ a \grammarterm{mem-initializer}\iref{class.base.init},
 including the constituent expressions of the initializer,
 \item
 an invocation of a destructor generated at the end of the lifetime
-of an object other than a temporary object\iref{class.temporary}, or
+of an object other than a temporary object\iref{class.temporary}
+whose lifetime has not been extended, or
 \item
 an expression that is not a subexpression of another expression and
 that is not otherwise part of a full-expression.

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5058,7 +5058,9 @@ and comparison~(\ref{expr.rel}, \ref{expr.eq}),
 a pointer past the end of the last element of
 an array \tcode{x} of $n$ elements
 is considered to be equivalent to
-a pointer to a hypothetical element \tcode{x[$n$]}.
+a pointer to a hypothetical element \tcode{x[$n$]} and
+an object of type \tcode{T} that is not an array element
+is considered to belong to an array with one element of type \tcode{T}.
 The value representation of
 pointer types is \impldef{value representation of pointer types}. Pointers to
 layout-compatible types shall

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5058,7 +5058,7 @@ and comparison~(\ref{expr.rel}, \ref{expr.eq}),
 a pointer past the end of the last element of
 an array \tcode{x} of $n$ elements
 is considered to be equivalent to
-a pointer to a hypothetical element \tcode{x[$n$]} and
+a pointer to a hypothetical array element $n$ of \tcode{x} and
 an object of type \tcode{T} that is not an array element
 is considered to belong to an array with one element of type \tcode{T}.
 The value representation of

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -944,8 +944,8 @@ from its class type, using the class member
 access syntax~(\ref{expr.ref}, \ref{over.match.call}). A non-static
 member function may also be called directly using the function call
 syntax~(\ref{expr.call}, \ref{over.match.call}) from within
-the body of a member function of its class or of a class derived from
-its class.
+its class or a class derived from its class, or
+a member thereof, as described below.
 
 \pnum
 \indextext{member function!call undefined}%
@@ -973,14 +973,7 @@ to the left of the \tcode{.} operator.
 If \tcode{C} is not \tcode{X} or a base class of \tcode{X}, the class
 member access expression is ill-formed.
 \end{note}
-Similarly during name lookup, when an
-\grammarterm{unqualified-id}\iref{expr.prim.id.unqual} used in the definition of a
-member function for class \tcode{X} resolves to a static member,
-an enumerator or a nested type of class \tcode{X} or of a base class of
-\tcode{X}, the \grammarterm{unqualified-id} is transformed into a
-\grammarterm{qualified-id}\iref{expr.prim.id.qual} in which the
-\grammarterm{nested-name-specifier} names the class of the member function.
-These transformations do not apply in the
+This transformation does not apply in the
 template definition context\iref{temp.dep.type}.
 \begin{example}
 \begin{codeblock}
@@ -2753,22 +2746,6 @@ int Y::i = g();                 // equivalent to \tcode{Y::g();}
 \end{example}
 
 \pnum
-If an \grammarterm{unqualified-id}\iref{expr.prim.id.unqual} is used in the
-definition of a static member following the member's
-\grammarterm{declarator-id}, and name lookup\iref{basic.lookup.unqual}
-finds that the \grammarterm{unqualified-id} refers to a static
-member, enumerator, or nested type of the member's class (or of a base
-class of the member's class), the \grammarterm{unqualified-id} is
-transformed into a \grammarterm{qualified-id} expression in which the
-\grammarterm{nested-name-specifier} names the class scope from which the
-member is referenced.
-\begin{note}
-See~\ref{expr.prim.id} for restrictions on the use of non-static data
-members and non-static member functions.
-\end{note}
-
-
-\pnum
 Static members obey the usual class member access rules\iref{class.access}.
 When used in the declaration of a class
 member, the \tcode{static} specifier shall only be used in the member
@@ -3273,10 +3250,8 @@ an unnamed object of that type called an \defn{anonymous union object}.
 Each \grammarterm{member-declaration} in the \grammarterm{member-specification}
 of an anonymous union shall either define a non-static data member or be a
 \grammarterm{static_assert-declaration}.
-\begin{note}
-Nested types, anonymous unions, and functions cannot be declared within an anonymous
-union.
-\end{note}
+Nested types, anonymous unions, and functions
+shall not be declared within an anonymous union.
 The names of the members of an anonymous union shall be distinct from
 the names of any other entity in the scope in which the anonymous union
 is declared. For the purpose of name lookup, after the anonymous union

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -6794,7 +6794,7 @@ struct D {
 
 \pnum
 The \defnadj{synthesized}{three-way comparison}
-for comparison category type \tcode{R}\iref{cmp.categories}
+of type \tcode{R}\iref{cmp.categories}
 of glvalues \tcode{a} and \tcode{b} of the same type
 is defined as follows:
 
@@ -6856,28 +6856,27 @@ that do not otherwise meet the requirements implied by the defined expression.
 \end{note}
 
 \pnum
+Let \tcode{R} be the declared return type of
+a defaulted three-way comparison operator function.
 Given an expanded list of subobjects for an object \tcode{x} of type \tcode{C},
-the type of the expression $\tcode{x}_i$ \tcode{<=>} $\tcode{x}_i$
-is denoted by $\tcode{R}_i$.
-If overload resolution as applied to $\tcode{x}_i$ \tcode{<=>} $\tcode{x}_i$
-does not find a usable function,
-then $\tcode{R}_i$ is \tcode{void}.
-If the declared return type
-of a defaulted three-way comparison operator function
-is \tcode{auto},
+let $\tcode{R}_i$ be
+the type of the expression $\tcode{x}_i$ \tcode{<=>} $\tcode{x}_i$, or
+\tcode{void} if overload resolution applied to that expression
+does not find a usable function.
+\begin{itemize}
+\item
+If \tcode{R} is \tcode{auto},
 then the return type is deduced as
 the common comparison type (see below) of
 $\tcode{R}_0$, $\tcode{R}_1$, $\dotsc$, $\tcode{R}_{n-1}$.
 If the return type is deduced as \tcode{void},
 the operator function is defined as deleted.
-If the declared return type of
-a defaulted three-way comparison operator function
-is \tcode{R}
-and the synthesized three-way comparison
-for comparison category type \tcode{R}
+\item
+Otherwise, if the synthesized three-way comparison of type \tcode{R}
 between any objects $\tcode{x}_i$ and $\tcode{x}_i$
 is not defined or would be ill-formed,
 the operator function is defined as deleted.
+\end{itemize}
 
 \pnum
 The return value \tcode{V} of type \tcode{R}
@@ -6888,7 +6887,7 @@ $\tcode{x}_i$ and $\tcode{y}_i$
 in the expanded lists of subobjects for \tcode{x} and \tcode{y}
 (in increasing index order)
 until the first index $i$ where
-the synthesized three-way comparison for comparison category type \tcode{R}
+the synthesized three-way comparison of type \tcode{R}
 between $\tcode{x}_i$ and $\tcode{y}_i$
 yields a result value $\tcode{v}_i$ where $\tcode{v}_i \mathrel{\tcode{!=}} 0$,
 contextually converted to \tcode{bool}, yields \tcode{true};

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -2307,7 +2307,8 @@ An array of class type contains several subobjects for each of which
 the destructor is invoked.
 \end{note}
 A destructor can also be invoked explicitly. A destructor is \term{potentially invoked}
-if it is invoked or as specified in~\ref{expr.new}, \ref{dcl.init.aggr},
+if it is invoked or as specified in~\ref{expr.new},
+\ref{stmt.return}, \ref{dcl.init.aggr},
 \ref{class.base.init}, and~\ref{except.throw}.
 A program is ill-formed if a destructor that is potentially invoked is deleted
 or not accessible from the context of the invocation.

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -6893,7 +6893,7 @@ yields a result value $\tcode{v}_i$ where $\tcode{v}_i \mathrel{\tcode{!=}} 0$,
 contextually converted to \tcode{bool}, yields \tcode{true};
 \tcode{V} is $\tcode{v}_i$.
 If no such index exists, \tcode{V} is
-\tcode{std::strong_ordering::equal} converted to \tcode{R}.
+\tcode{static_cast<R>(std::strong_ordering::equal)}.
 
 \pnum
 The \defn{common comparison type} \tcode{U}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5612,12 +5612,13 @@ S s3 { };                           // OK: invoke \#2
 \end{example}
 
 \item Otherwise, if \tcode{T} is an enumeration
-with a fixed underlying type\iref{dcl.enum},
-the \grammarterm{initializer-list} has a single element \tcode{v}, and
+with a fixed underlying type\iref{dcl.enum} \tcode{U},
+the \grammarterm{initializer-list} has a single element \tcode{v},
+\tcode{v} can be implicitly converted to \tcode{U}, and
 the initialization is direct-list-initialization,
 the object is initialized with the value \tcode{T(v)}\iref{expr.type.conv};
 if a narrowing conversion is required to convert \tcode{v}
-to the underlying type of \tcode{T}, the program is ill-formed.
+to \tcode{U}, the program is ill-formed.
 \begin{example}
 \begin{codeblock}
 enum byte : unsigned char { };

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -886,13 +886,6 @@ The definition of a constexpr constructor
 whose \grammarterm{function-body} is not \tcode{= delete}
 shall additionally satisfy the following requirements:
 \begin{itemize}
-\item
-if the class is a union having variant members\iref{class.union}, exactly one of them
-shall be initialized;
-
-\item
-if the class is a union-like class, but is not a union, for each of its anonymous union
-members having variant members, exactly one of them shall be initialized;
 
 \item
 for a non-delegating constructor, every constructor selected to initialize non-static

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5889,8 +5889,8 @@ as described in~\ref{dcl.fct}.
 A function shall be defined only in namespace or class scope.
 The type of a parameter or the return type for a function
 definition shall not be
-an incomplete or abstract (possibly cv-qualified) class type
-in the context of the function definition
+a (possibly cv-qualified) class type that is
+incomplete or abstract within the function body
 unless the function is deleted\iref{dcl.fct.def.delete}.
 
 \pnum

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6880,10 +6880,10 @@ An object or reference is \defn{usable in constant expressions} if it is
 \item a variable that is usable in constant expressions, or
 \item a template parameter object\iref{temp.param}, or
 \item a string literal object\iref{lex.string}, or
-\item a non-mutable subobject or reference member of any of the above, or
-\item a complete temporary object of
-  non-volatile const-qualified integral or enumeration type
-  that is initialized with a constant expression.
+\item a temporary object of non-volatile const-qualified literal type
+  whose lifetime is extended\iref{class.temporary}
+  to that of a variable that is usable in constant expressions, or
+\item a non-mutable subobject or reference member of any of the above.
 \end{itemize}
 
 \pnum

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3124,7 +3124,9 @@ to type \tcode{void*}\iref{conv.ptr}.
 After these conversions, if the
 argument does not have arithmetic, enumeration, pointer, pointer-to-member,
 or class type, the program is ill-formed. Passing a potentially-evaluated
-argument of class type\iref{class} having an eligible non-trivial
+argument
+of a scoped enumeration type or
+of a class type\iref{class} having an eligible non-trivial
 copy constructor, an eligible non-trivial move constructor,
 or a
 non-trivial destructor\iref{special},

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5041,10 +5041,20 @@ If the \grammarterm{new-placement} syntax is used,
 the \grammarterm{initializer-clause}{s}
 in its \grammarterm{expression-list}
 are the succeeding arguments.
-If no matching function is found
-and the allocated object type has new-extended alignment,
-the alignment argument is removed from the argument list,
-and overload resolution is performed again.
+If no matching function is found then
+\begin{itemize}
+
+\item
+if the allocated object type has new-extended alignment,
+the alignment argument is removed from the argument list;
+
+\item
+otherwise, an argument that
+is the type's alignment and has type \tcode{std::align_val_t}
+is added into the argument list immediately after the first argument;
+
+\end{itemize}
+and then overload resolution is performed again.
 
 \pnum
 \begin{example}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5768,7 +5768,7 @@ of an array object \tcode{x} with $n$ elements\iref{dcl.array},%
 \footnote{As specified in \ref{basic.compound},
 an object that is not an array element
 is considered to belong to a single-element array for this purpose and
-a pointer past the last element of an array \tcode{x} of $n$ elements
+a pointer past the last element of an array of $n$ elements
 is considered to be equivalent to a pointer to a hypothetical array element
 $n$ for this purpose.}
 the expressions \tcode{P + J} and \tcode{J + P}
@@ -6072,7 +6072,7 @@ The result of comparing unequal pointers to objects%
 an object that is not an array element
 is considered to belong to a
 single-element array for this purpose and
-a pointer past the last element of an array \tcode{x} of $n$ elements
+a pointer past the last element of an array of $n$ elements
 is considered to be equivalent to a pointer to a hypothetical array element
 $n$ for this purpose.}
 is defined in terms of a partial order consistent with the following rules:

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6732,8 +6732,8 @@ resulting value of the bit-field is
 \pnum
 A simple assignment whose left operand is of
 a \tcode{volatile}-qualified type is deprecated\iref{depr.volatile.type}
-unless the assignment is either a discarded-value expression or
-appears in an unevaluated context.
+unless the (possibly parenthesized) assignment is a discarded-value expression or
+an unevaluated operand.
 
 \pnum
 The behavior of an expression of the form \tcode{E1 \placeholder{op}= E2}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4199,11 +4199,6 @@ whose result is a pointer to the designated object\iref{intro.memory} or functio
 In particular, taking the address of a variable of type ``\cv{}~\tcode{T}''
 yields a pointer of type ``pointer to \cv{}~\tcode{T}''.
 \end{note}
-For purposes of pointer arithmetic\iref{expr.add} and
-comparison~(\ref{expr.rel}, \ref{expr.eq}),
-an object that is not an array element whose
-address is taken in this way is considered to belong to an array with one
-element of type \tcode{T}.
 \item
 Otherwise, the program is ill-formed.
 \end{itemize}
@@ -5770,11 +5765,12 @@ the result has the type of \tcode{P}.
 \tcode{J} evaluates to 0, the result is a null pointer value.
 \item Otherwise, if \tcode{P} points to an array element $i$
 of an array object \tcode{x} with $n$ elements\iref{dcl.array},%
-\footnote{An object that is not an array element is considered to belong to a
-single-element array for this purpose; see~\ref{expr.unary.op}.
-A pointer past the last element of an array \tcode{x} of $n$ elements
+\footnote{As specified in \ref{basic.compound},
+an object that is not an array element
+is considered to belong to a single-element array for this purpose and
+a pointer past the last element of an array \tcode{x} of $n$ elements
 is considered to be equivalent to a pointer to a hypothetical array element
-$n$ for this purpose; see~\ref{basic.compound}.}
+$n$ for this purpose.}
 the expressions \tcode{P + J} and \tcode{J + P}
 (where \tcode{J} has the value $j$)
 point to the (possibly-hypothetical) array element
@@ -6072,11 +6068,13 @@ After conversions, the operands shall have the same type.
 
 \pnum
 The result of comparing unequal pointers to objects%
-\footnote{An object that is not an array element is considered to belong to a
-single-element array for this purpose; see~\ref{expr.unary.op}.
-A pointer past the last element of an array \tcode{x} of $n$ elements
-is considered to be equivalent to a pointer to a hypothetical element
-$\mathtt{x[}n\mathtt{]}$ for this purpose; see~\ref{basic.compound}.}
+\footnote{As specified in \ref{basic.compound},
+an object that is not an array element
+is considered to belong to a
+single-element array for this purpose and
+a pointer past the last element of an array \tcode{x} of $n$ elements
+is considered to be equivalent to a pointer to a hypothetical array element
+$n$ for this purpose.}
 is defined in terms of a partial order consistent with the following rules:
 
 \begin{itemize}
@@ -6154,9 +6152,11 @@ Comparing pointers is defined as follows:
 \item
 If one pointer represents the address of a complete object, and another
 pointer represents the address one past the last element of a different
-complete object,\footnote{An object that is not an array element is
-considered to belong to a single-element array for this purpose;
-see~\ref{expr.unary.op}.} the result of the comparison is unspecified.
+complete object,%
+\footnote{As specified in \ref{basic.compound},
+an object that is not an array element is
+considered to belong to a single-element array for this purpose.}
+the result of the comparison is unspecified.
 \item
 Otherwise, if the pointers are both null, both point to the same
 \indextext{address}%

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6718,7 +6718,7 @@ is modified by replacing its value with the result of the right operand.
 
 \pnum
 \indextext{assignment!conversion by}%
-The expression is implicitly
+If the right operand is an expression, it is implicitly
 converted\iref{conv} to the cv-unqualified type of the left
 operand.
 

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -1826,13 +1826,8 @@ considered to ``match the ellipsis''\iref{over.ics.ellipsis} .
 A candidate function having more than
 \textit{m}
 parameters is viable
-only if the
-$\textit{(m+1)}^\text{st}$
-parameter has a default
-argument\iref{dcl.fct.default}.\footnote{According to~\ref{dcl.fct.default},
-parameters following the
-$\textit{(m+1)}^\text{st}$
-parameter must also have default arguments.}
+only if all parameters following the $m^\text{th}$
+have default arguments\iref{dcl.fct.default}.
 For the purposes of overload
 resolution, the parameter list is truncated on the right, so
 that there are exactly

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -840,6 +840,16 @@ std::pair<std::string,int> f(const char* p, int x) {
 }
 \end{codeblock}
 \end{example}
+The destructor for the returned object
+is potentially invoked~(\ref{class.dtor}, \ref{except.ctor}).
+\begin{example}
+\begin{codeblock}
+class A {
+  ~A() {}
+};
+A f() { return A(); }   // error: destructor of \tcode{A} is private (even though it is never invoked)
+\end{codeblock}
+\end{example}
 Flowing off the end of
 a constructor,
 a destructor, or

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -8888,7 +8888,7 @@ any deduction guides declared for the class template are considered.
 
 \begin{bnf}
 \nontermdef{deduction-guide}\br
-    \opt{\keyword{explicit}} template-name \terminal{(} parameter-declaration-clause \terminal{)} \terminal{->} simple-template-id \terminal{;}
+    \opt{explicit-specifier} template-name \terminal{(} parameter-declaration-clause \terminal{)} \terminal{->} simple-template-id \terminal{;}
 \end{bnf}
 
 \pnum


### PR DESCRIPTION
Fixes #3395.
Fixes #2664.

Issues:
* CWG2419:
    In [expr.add]/bullet 4.2, and, after applying CWG2419, in [numeric.ops.midpoint]/p5 and [expr.rel]/p4, we have the wording:
        "a pointer to a hypothetical array element n"
    This reads like n is the hypothetical array element, but n is the size of the array.
    Can we reword this?
* CWG2433: FYI, wording changed after Davis Herring's change "[basic.def.odr] Clean up new bullets"