### PR TITLE
Motions 2019 11 lwg 16: P1870R1 forwarding-range<T> is too subtle

### DIFF
--- a/papers/nxxxx.md
+++ b/papers/nxxxx.md
@@ -63,6 +63,20 @@ and after consulting the paper authors and the LWG chair,
 the corresponding changes were also applied to
 the additional range adaptors listed above.
 
+### LWG motion 16
+
+This paper removed the exposition-only concept *`range-impl`*,
+inlining it into its only remaining user, the `range` concept.
+However, two uses of *`range-impl`* were left behind.
+These have been updated and suitably adjusted
+to refer to `range` instead.
+
+LWG motion 13 ([P1394R4](http://wg21.link/p1394r4))
+added a couple of new uses of
+the exposition-only concept *`forwarding-range`*,
+which was removed by this paper.
+These uses have been replaced with `safe_range`.
+
 ## Feature test macros
 
 The feature test macro `__cpp_nontype_template_parameter_class` has been removed

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10786,7 +10786,7 @@ Let \tcode{U} be \tcode{remove_reference_t<ranges::range_reference_t<R>>}.
 \item \tcode{extent == dynamic_extent} is \tcode{true}.
 \item \tcode{R} satisfies \tcode{ranges::\libconcept{contiguous_range}} and
   \tcode{ranges::\libconcept{sized_range}}.
-\item Either \tcode{R} satisfies \exposconcept{forwarding-range} or
+\item Either \tcode{R} satisfies \libconcept{safe_range} or
 \tcode{is_const_v<element_type>} is \tcode{true}.
 \item \tcode{remove_cvref_t<R>} is not a specialization of \tcode{span}.
 \item \tcode{remove_cvref_t<R>} is not a specialization of \tcode{array}.
@@ -10805,7 +10805,7 @@ of the iterator reference type to \tcode{element_type}.
 \item \tcode{R} models \tcode{ranges::\libconcept{contiguous_range}} and
 \tcode{ranges::\libconcept{sized_range}}.
 \item If \tcode{is_const_v<element_type>} is \tcode{false},
-\tcode{R} models \exposconcept{forwarding-range}.
+\tcode{R} models \libconcept{safe_range}.
 \end{itemize}
 
 \pnum

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10513,6 +10513,9 @@ namespace std {
   template<class ElementType, size_t Extent = dynamic_extent>
     class span;
 
+  template<class ElementType, size_t Extent>
+    inline constexpr bool enable_safe_range<span<ElementType, Extent>> = true;
+
   // \ref{span.objectrep}, views of object representation
   template<class ElementType, size_t Extent>
     span<const byte, Extent == dynamic_extent ? dynamic_extent : sizeof(ElementType) * Extent>
@@ -10624,9 +10627,6 @@ namespace std {
     constexpr reverse_iterator rend() const noexcept;
     constexpr const_reverse_iterator crbegin() const noexcept;
     constexpr const_reverse_iterator crend() const noexcept;
-
-    friend constexpr iterator begin(span s) noexcept { return s.begin(); }
-    friend constexpr iterator end(span s) noexcept { return s.end(); }
 
   private:
     pointer data_;              // \expos

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -796,27 +796,27 @@ template<class T>
 \begin{itemdescr}
 \pnum
 The required expressions
-\tcode{ranges::begin(std::forward<T>(t))}
+\tcode{ranges::begin(t)}
 and
-\tcode{ranges::end(std::forward<\brk{}T>(t))}
-of the \exposconcept{range-impl} concept
+\tcode{ranges::end(t)}
+of the \libconcept{range} concept
 do not require implicit expression variations\iref{concepts.equality}.
 
 \pnum
-Given an expression \tcode{E} such that \tcode{decltype((E))} is \tcode{T},
-\tcode{T} models \tcode{\placeholder{range-impl}} only if
+Given an expression \tcode{t} such that \tcode{decltype((t))} is \tcode{T\&},
+\tcode{T} models \libconcept{range} only if
 \begin{itemize}
-\item \range{ranges::begin(E)}{ranges::end(E)}
+\item \range{ranges::begin(t)}{ranges::end(t)}
   denotes a range\iref{iterator.requirements.general},
 
 \item both
-\tcode{ranges::begin(E)}
+\tcode{ranges::begin(t)}
 and
-\tcode{ranges::end(E)}
+\tcode{ranges::end(t)}
 are amortized constant time and non-modifying, and
 
-\item if the type of \tcode{ranges::begin(E)} models
-\libconcept{forward_iterator}, \tcode{ranges::begin(E)} is equality-preserving.
+\item if the type of \tcode{ranges::begin(t)} models
+\libconcept{forward_iterator}, \tcode{ranges::begin(t)} is equality-preserving.
 \end{itemize}
 
 \pnum

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -50,6 +50,12 @@ namespace std::ranges {
   template<class T>
     concept range = @\seebelow@;
 
+  template<range T>
+    inline constexpr bool enable_safe_range = false;
+
+  template<class T>
+    concept safe_range = @\seebelow@;
+
   template<range R>
     using iterator_t = decltype(ranges::begin(declval<R&>()));
   template<range R>
@@ -116,20 +122,26 @@ namespace std::ranges {
     requires (K == subrange_kind::sized || !sized_sentinel_for<S, I>)
   class subrange;
 
+  template<input_or_output_iterator I, sentinel_for<I> S, subrange_kind K>
+    inline constexpr bool enable_safe_range<subrange<I, S, K>> = true;
+
   // \ref{range.dangling}, dangling iterator handling
   struct dangling;
 
   template<range R>
-    using safe_iterator_t = conditional_t<@\placeholder{forwarding-range}@<R>, iterator_t<R>, dangling>;
+    using safe_iterator_t = conditional_t<safe_range<R>, iterator_t<R>, dangling>;
 
   template<range R>
     using safe_subrange_t =
-      conditional_t<@\placeholder{forwarding-range}@<R>, subrange<iterator_t<R>>, dangling>;
+      conditional_t<safe_range<R>, subrange<iterator_t<R>>, dangling>;
 
   // \ref{range.empty}, empty view
   template<class T>
     requires is_object_v<T>
   class empty_view;
+
+  template<class T>
+    inline constexpr bool enable_safe_range<empty_view<T>> = true;
 
   namespace views {
     template<class T>
@@ -148,6 +160,9 @@ namespace std::ranges {
     requires @\placeholder{weakly-equality-comparable-with}@<W, Bound>
   class iota_view;
 
+  template<weakly_incrementable W, semiregular Bound>
+    inline constexpr bool enable_safe_range<iota_view<W, Bound>> = true;
+
   namespace views { inline constexpr @\unspec@ iota = @\unspec@; }
 
   // \ref{range.all}, all view
@@ -159,6 +174,9 @@ namespace std::ranges {
   template<range R>
     requires is_object_v<R>
   class ref_view;
+
+  template<class T>
+    inline constexpr bool enable_safe_range<ref_view<T>> = true;
 
   // \ref{range.filter}, filter view
   template<input_range V, indirect_unary_predicate<iterator_t<V>> Pred>
@@ -306,21 +324,27 @@ available when \libheaderrefx{iterator}{iterator.synopsis} is included.
 \rSec2[range.access.begin]{\tcode{ranges::begin}}
 \pnum
 The name \tcode{ranges::begin} denotes a customization point
-object\iref{customization.point.object}. The expression
-\tcode{ranges::\brk{}begin(E)} for some subexpression \tcode{E} is
+object\iref{customization.point.object}.
+Given a subexpression \tcode{E} and
+an lvalue \tcode{t} that denotes the same object as \tcode{E},
+if \tcode{E} is an rvalue and
+\tcode{enable_safe_range<remove_cvref_t<decltype((E))>>} is \tcode{false},
+\tcode{ranges::begin(E)} is ill-formed.
+Otherwise,
+\tcode{ranges::begin(E)} is
 expression-equivalent to:
 \begin{itemize}
 \item
-  \tcode{E + 0} if \tcode{E} is an lvalue of array type\iref{basic.compound}.
+  \tcode{t + 0} if \tcode{t} is of array type\iref{basic.compound}.
 
 \item
-  Otherwise, if \tcode{E} is an lvalue,
-  \tcode{\placeholdernc{decay-copy}(E.begin())}
+  Otherwise,
+  \tcode{\placeholdernc{decay-copy}(t.begin())}
   if it is a valid expression and its type \tcode{I} models
   \libconcept{input_or_output_iterator}.
 
 \item
-  Otherwise, \tcode{\placeholdernc{decay-copy}(begin(E))} if it is a
+  Otherwise, \tcode{\placeholdernc{decay-copy}(begin(t))} if it is a
   valid expression and its type \tcode{I} models
   \libconcept{input_or_output_iterator} with overload
   resolution performed in a context that includes the declarations:
@@ -347,24 +371,30 @@ Whenever \tcode{ranges::begin(E)} is a valid expression, its type models
 \rSec2[range.access.end]{\tcode{ranges::end}}
 \pnum
 The name \tcode{ranges::end} denotes a customization point
-object\iref{customization.point.object}. The expression
-\tcode{ranges::end(E)} for some subexpression \tcode{E} is
+object\iref{customization.point.object}.
+Given a subexpression \tcode{E} and
+an lvalue \tcode{t} that denotes the same object as \tcode{E},
+if \tcode{E} is an rvalue and
+\tcode{enable_safe_range<remove_cvref_t<decltype((E))>>} is \tcode{false},
+\tcode{ranges::end(E)} is ill-formed.
+Otherwise,
+\tcode{ranges::end(E)} is
 expression-equivalent to:
 \begin{itemize}
 \item
-  \tcode{E + extent_v<T>} if \tcode{E} is an lvalue of array
+  \tcode{t + extent_v<T>} if \tcode{E} is of array
   type\iref{basic.compound} \tcode{T}.
 
 \item
-  Otherwise, if \tcode{E} is an lvalue,
-  \tcode{\placeholdernc{decay-copy}(E.end())}
+  Otherwise,
+  \tcode{\placeholdernc{decay-copy}(t.end())}
   if it is a valid expression and its type \tcode{S} models
   \begin{codeblock}
 sentinel_for<decltype(ranges::begin(E))>
   \end{codeblock}
 
 \item
-  Otherwise, \tcode{\placeholdernc{decay-copy}(end(E))} if it is a valid
+  Otherwise, \tcode{\placeholdernc{decay-copy}(end(t))} if it is a valid
   expression and its type \tcode{S} models
   \begin{codeblock}
 sentinel_for<decltype(ranges::begin(E))>
@@ -432,17 +462,23 @@ model \tcode{\libconcept{sentinel_for}<S, I>}.
 \rSec2[range.access.rbegin]{\tcode{ranges::rbegin}}
 \pnum
 The name \tcode{ranges::rbegin} denotes a customization point
-object\iref{customization.point.object}. The expression
-\tcode{ranges::\brk{}rbegin(E)} for some subexpression \tcode{E} is
+object\iref{customization.point.object}.
+Given a subexpression \tcode{E} and
+an lvalue \tcode{t} that denotes the same object as \tcode{E},
+if \tcode{E} is an rvalue and
+\tcode{enable_safe_range<remove_cvref_t<decltype((E))>>} is \tcode{false},
+\tcode{ranges::rbegin(E)} is ill-formed.
+Otherwise,
+\tcode{ranges::rbegin(E)} is
 expression-equivalent to:
 \begin{itemize}
 \item
-  If \tcode{E} is an lvalue, \tcode{\placeholdernc{decay-copy}(E.rbegin())}
+  \tcode{\placeholdernc{decay-copy}(t.rbegin())}
   if it is a valid expression and its type \tcode{I} models
   \libconcept{input_or_output_iterator}.
 
 \item
-  Otherwise, \tcode{\placeholdernc{decay-copy}(rbegin(E))} if it is a valid
+  Otherwise, \tcode{\placeholdernc{decay-copy}(rbegin(t))} if it is a valid
   expression and its type \tcode{I} models
   \libconcept{input_or_output_iterator} with overload
   resolution performed in a context that includes the declaration:
@@ -452,8 +488,8 @@ template<class T> void rbegin(T&&) = delete;
   and does not include a declaration of \tcode{ranges::rbegin}.
 
 \item
-  Otherwise, \tcode{make_reverse_iterator(ranges::end(E))} if both
-  \tcode{ranges::begin(E)} and \tcode{ranges::end(\brk{}E)} are valid
+  Otherwise, \tcode{make_reverse_iterator(ranges::end(t))} if both
+  \tcode{ranges::begin(t)} and \tcode{ranges::end(\brk{}t)} are valid
   expressions of the same type \tcode{I} which models
   \libconcept{bidirectional_iterator}\iref{iterator.concept.bidir}.
 
@@ -474,19 +510,25 @@ Whenever \tcode{ranges::rbegin(E)} is a valid expression, its type models
 \rSec2[range.access.rend]{\tcode{ranges::rend}}
 \pnum
 The name \tcode{ranges::rend} denotes a customization point
-object\iref{customization.point.object}. The expression
-\tcode{ranges::rend(E)} for some subexpression \tcode{E} is
+object\iref{customization.point.object}.
+Given a subexpression \tcode{E} and
+an lvalue \tcode{t} that denotes the same object as \tcode{E},
+if \tcode{E} is an rvalue and
+\tcode{enable_safe_range<remove_cvref_t<decltype((E))>>} is \tcode{false},
+\tcode{ranges::rend(E)} is ill-formed.
+Otherwise,
+\tcode{ranges::rend(E)} is
 expression-equivalent to:
 \begin{itemize}
 \item
-  If \tcode{E} is an lvalue, \tcode{\placeholdernc{decay-copy}(E.rend())}
+  \tcode{\placeholdernc{decay-copy}(t.rend())}
   if it is a valid expression and its type \tcode{S} models
   \begin{codeblock}
 sentinel_for<decltype(ranges::rbegin(E))>
   \end{codeblock}
 
 \item
-  Otherwise, \tcode{\placeholdernc{decay-copy}(rend(E))} if it is a valid
+  Otherwise, \tcode{\placeholdernc{decay-copy}(rend(t))} if it is a valid
   expression and its type \tcode{S} models
   \begin{codeblock}
 sentinel_for<decltype(ranges::rbegin(E))>
@@ -499,8 +541,8 @@ template<class T> void rend(T&&) = delete;
   and does not include a declaration of \tcode{ranges::rend}.
 
 \item
-  Otherwise, \tcode{make_reverse_iterator(ranges::begin(E))} if both
-  \tcode{ranges::begin(E)} and \tcode{ranges::\brk{}end(E)} are valid
+  Otherwise, \tcode{make_reverse_iterator(ranges::begin(t))} if both
+  \tcode{ranges::begin(t)} and \tcode{ranges::\brk{}end(t)} are valid
   expressions of the same type \tcode{I} which models
   \libconcept{bidirectional_iterator}\iref{iterator.concept.bidir}.
 
@@ -744,18 +786,11 @@ that denote the elements of the range.
 
 \begin{itemdecl}
 template<class T>
-  concept @\defexposconcept{range-impl}@ =          // \expos
-    requires(T&& t) {
-      ranges::begin(std::forward<T>(t));        // sometimes equality-preserving (see below)
-      ranges::end(std::forward<T>(t));
+  concept @\deflibconcept{range}@ =
+    requires(T& t) {
+      ranges::begin(t);                         // sometimes equality-preserving (see below)
+      ranges::end(t);
     };
-
-template<class T>
-  concept @\deflibconcept{range}@ = @\exposconcept{range-impl}@<T&>;
-
-template<class T>
-  concept @\defexposconcept{forwarding-range}@ =    // \expos
-    range<T> && @\exposconcept{range-impl}@<T>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -796,34 +831,52 @@ when the return type does not model \libconcept{forward_iterator}, repeated call
 might not return equal values or might not be well-defined;
 \tcode{ranges::begin} should be called at most once for such a range.
 \end{note}
+\end{itemdescr}
 
+\begin{itemdecl}
+template<class T>
+  concept @\deflibconcept{safe_range}@ =
+    range<T> &&
+      (is_lvalue_reference_v<T> || enable_safe_range<remove_cvref_t<T>>);
+\end{itemdecl}
+
+\begin{itemdescr}
 \pnum
-Given an expression \tcode{E} such that \tcode{decltype((E))} is \tcode{T}
-and an lvalue \tcode{t} that denotes the same object as \tcode{E},
-\tcode{T} models \exposconcept{forwarding-range} only if
-\begin{itemize}
-\item \tcode{ranges::begin(E)} and \tcode{ranges::begin(t)}
-  are expression-equivalent,
-\item \tcode{ranges::end(E)} and \tcode{ranges::end(t)}
-  are expression-equivalent, and
-\item the validity of iterators obtained from the object denoted
-  by \tcode{E} is not tied to the lifetime of that object.
-\end{itemize}
+Given an expression \tcode{E} such that \tcode{decltype((E))} is \tcode{T},
+\tcode{T} models \libconcept{safe_range} only if
+the validity of iterators obtained from the object denoted by \tcode{E}
+is not tied to the lifetime of that object.
 
 \pnum
 \begin{note}
 Since the validity of iterators is not tied to the lifetime of
-an object whose type models \exposconceptnc{forwarding-range},
+an object whose type models \libconcept{safe_range},
 a function can accept arguments of such a type by value and
 return iterators obtained from it without danger of dangling.
 \end{note}
+\end{itemdescr}
+
+\indexlibraryglobal{enable_safe_range}%
+\begin{itemdecl}
+template<class>
+  inline constexpr bool enable_safe_range = false;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\remarks
+Pursuant to \ref{namespace.std}, users may specialize \tcode{enable_safe_range}
+for cv-unqualified program-defined types.
+Such specializations shall be
+usable in constant expressions\iref{expr.const} and
+have type \tcode{const bool}.
 
 \pnum
 \begin{example}
 Specializations of class template \tcode{subrange}\iref{range.subrange}
-model \exposconceptnc{forwarding-range}. \tcode{subrange} provides
-non-member rvalue overloads of \tcode{begin} and \tcode{end} with the same
-semantics as its member lvalue overloads, and \tcode{subrange}'s iterators
+model \libconcept{safe_range}.
+\tcode{subrange} specializes \tcode{enable_safe_range} to \tcode{true}, and
+\tcode{subrange}'s iterators
 -- since they are ``borrowed'' from some other range --
 do not have validity tied to the lifetime of a \tcode{subrange} object.
 \end{example}
@@ -1061,7 +1114,7 @@ The \libconcept{viewable_range} concept specifies the requirements of a
 \begin{itemdecl}
 template<class T>
   concept @\deflibconcept{viewable_range}@ =
-    range<T> && (@\placeholder{forwarding-range}@<T> || view<decay_t<T>>);
+    range<T> && (safe_range<T> || view<decay_t<T>>);
 \end{itemdecl}
 
 \rSec1[range.utility]{Range utilities}
@@ -1267,11 +1320,11 @@ namespace std::ranges {
       requires (K == subrange_kind::sized);
 
     template<@\exposconcept{not-same-as}@<subrange> R>
-      requires @\exposconcept{forwarding-range}@<R> &&
-        convertible_to<iterator_t<R>, I> && convertible_to<sentinel_t<R>, S>
+      requires safe_range<R> &&
+               convertible_to<iterator_t<R>, I> && convertible_to<sentinel_t<R>, S>
     constexpr subrange(R&& r) requires (!StoreSize || sized_range<R>);
 
-    template<@\exposconcept{forwarding-range}@ R>
+    template<safe_range R>
       requires convertible_to<iterator_t<R>, I> && convertible_to<sentinel_t<R>, S>
     constexpr subrange(R&& r, @\placeholdernc{make-unsigned-like-t}@(iter_difference_t<I>) n)
       requires (K == subrange_kind::sized)
@@ -1310,9 +1363,6 @@ namespace std::ranges {
     [[nodiscard]] constexpr subrange prev(iter_difference_t<I> n = 1) const
       requires bidirectional_iterator<I>;
     constexpr subrange& advance(iter_difference_t<I> n);
-
-    friend constexpr I begin(subrange&& r) { return r.begin(); }
-    friend constexpr S end(subrange&& r) { return r.end(); }
   };
 
   template<input_or_output_iterator I, sentinel_for<I> S>
@@ -1326,13 +1376,13 @@ namespace std::ranges {
     subrange(P, @\placeholdernc{make-unsigned-like-t}@(iter_difference_t<tuple_element_t<0, P>>)) ->
       subrange<tuple_element_t<0, P>, tuple_element_t<1, P>, subrange_kind::sized>;
 
-  template<@\placeholder{forwarding-range}@ R>
+  template<safe_range R>
     subrange(R&&) ->
       subrange<iterator_t<R>, sentinel_t<R>,
                (sized_range<R> || sized_sentinel_for<sentinel_t<R>, iterator_t<R>>)
                  ? subrange_kind::sized : subrange_kind::unsized>;
 
-  template<@\placeholder{forwarding-range}@ R>
+  template<safe_range R>
     subrange(R&&, @\placeholdernc{make-unsigned-like-t}@(range_difference_t<R>)) ->
       subrange<iterator_t<R>, sentinel_t<R>, subrange_kind::sized>;
 
@@ -1398,7 +1448,7 @@ when it stores an iterator and sentinel that do not model
 \indexlibraryctor{subrange}%
 \begin{itemdecl}
 template<@\exposconcept{not-same-as}@<subrange> R>
-  requires @\exposconcept{forwarding-range}@<R> &&
+  requires safe_range<R> &&
            convertible_to<iterator_t<R>, I> && convertible_to<sentinel_t<R>, S>
 constexpr subrange(R&& r) requires (!StoreSize || sized_range<R>);
 \end{itemdecl}
@@ -1596,7 +1646,7 @@ that typically returns an iterator into or subrange of a \tcode{range} argument
 does not return an iterator or subrange
 which could potentially reference a range
 whose lifetime has ended for a particular rvalue \tcode{range} argument
-which does not model \tcode{\placeholder{forwarding-range}}\iref{range.range}.
+which does not model \libconcept{safe_range}\iref{range.range}.
 \indexlibraryglobal{dangling}%
 \begin{codeblock}
 namespace std::ranges {
@@ -1626,7 +1676,7 @@ the \tcode{vector} could potentially be destroyed
 before a returned iterator is dereferenced.
 However, the calls at \#2 and \#3 both return iterators
 since the lvalue \tcode{vec} and specializations of \tcode{subrange}
-model \tcode{\placeholder{forwarding-range}}.
+model \libconcept{safe_range}.
 \end{example}
 
 \rSec1[range.factories]{Range factories}
@@ -1669,9 +1719,6 @@ namespace std::ranges {
     static constexpr T* data() noexcept { return nullptr; }
     static constexpr size_t size() noexcept { return 0; }
     static constexpr bool empty() noexcept { return true; }
-
-    friend constexpr T* begin(empty_view) noexcept { return nullptr; }
-    friend constexpr T* end(empty_view) noexcept { return nullptr; }
   };
 }
 \end{codeblock}
@@ -2692,12 +2739,6 @@ namespace std::ranges {
 
     constexpr auto data() const requires contiguous_range<R>
     { return ranges::data(*r_); }
-
-    friend constexpr iterator_t<R> begin(ref_view r)
-    { return r.begin(); }
-
-    friend constexpr sentinel_t<R> end(ref_view r)
-    { return r.end(); }
   };
   template<class R>
     ref_view(R&) -> ref_view<R>;

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -873,12 +873,18 @@ have type \tcode{const bool}.
 
 \pnum
 \begin{example}
-Specializations of class template \tcode{subrange}\iref{range.subrange}
-model \libconcept{safe_range}.
-\tcode{subrange} specializes \tcode{enable_safe_range} to \tcode{true}, and
-\tcode{subrange}'s iterators
--- since they are ``borrowed'' from some other range --
-do not have validity tied to the lifetime of a \tcode{subrange} object.
+Each specialization \tcode{S} of class template \tcode{subrange}\iref{range.subrange}
+models \libconcept{safe_range} because
+\begin{itemize}
+\item
+\tcode{enable_safe_range<S>} is specialized
+to have the value \tcode{true}, and
+
+\item
+\tcode{S}'s iterators
+do not have validity tied to the lifetime of an \tcode{S} object
+because they are ``borrowed'' from some other range.
+\end{itemize}
 \end{example}
 \end{itemdescr}
 

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -3932,6 +3932,9 @@ namespace std {
   template<class charT, class traits = char_traits<charT>>
   class basic_string_view;
 
+  template<class charT, class traits>
+    inline constexpr bool enable_safe_range<basic_string_view<charT, traits>> = true;
+
   // \ref{string.view.comparison}, non-member comparison functions
   template<class charT, class traits>
     constexpr bool operator==(basic_string_view<charT, traits> x,
@@ -4032,9 +4035,6 @@ public:
   constexpr const_reverse_iterator rend() const noexcept;
   constexpr const_reverse_iterator crbegin() const noexcept;
   constexpr const_reverse_iterator crend() const noexcept;
-
-  friend constexpr const_iterator begin(basic_string_view sv) noexcept { return sv.begin(); }
-  friend constexpr const_iterator end(basic_string_view sv) noexcept { return sv.end(); }
 
   // \ref{string.view.capacity}, capacity
   constexpr size_type size() const noexcept;


### PR DESCRIPTION
Fixes #3418. 

Issues with paper:
* [range.access.begin]/p1 adds "Given a subexpression E and an lvalue t that denotes the same object as E", but E is a subexpression, not an object.
        Same for [range.access.end]/p1, [range.access.rbegin]/p1, and [range.access.rend]/p1.
* [range.range] range-impl is removed but is still referenced in p2 and p3.

Other editorial issues:
* cv-unqualified or \cv-unqualified?
      The spec is inconsistent in its representation of cv-unqualified v. /cv/-unqualified.
* When to use \deflibconcept?
      Some concept definitions in the library use \deflibconcept, others don't.
        Also fix inconsistencies in the of \defexposconcept for \expos concepts.    
* The library is inconsistent in its use of \exposconcept v. \tcode{\placeholder

Fixes cplusplus/papers#620
Fixes cplusplus/nbballot#275
Fixes cplusplus/nbballot#276