### PR TITLE
Motions 2019 11 lwg 20: P0883R2 Fixing Atomic Initialization

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -1542,6 +1542,7 @@ namespace std {
     bool is_lock_free() const volatile noexcept;
     bool is_lock_free() const noexcept;
 
+    // \ref{atomics.types.operations}, operations on atomic types
     constexpr atomic() noexcept(is_nothrow_default_constructible_v<T>);
     constexpr atomic(T) noexcept;
     atomic(const atomic&) = delete;

--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -56,18 +56,11 @@ namespace std {
   // \ref{atomics.types.pointer}, partial specialization for pointers
   template<class T> struct atomic<T*>;
 
-  // \ref{atomics.types.operations}, initialization
-  #define ATOMIC_VAR_INIT(value) @\seebelow@
-
   // \ref{atomics.nonmembers}, non-member functions
   template<class T>
     bool atomic_is_lock_free(const volatile atomic<T>*) noexcept;
   template<class T>
     bool atomic_is_lock_free(const atomic<T>*) noexcept;
-  template<class T>
-    void atomic_init(volatile atomic<T>*, typename atomic<T>::value_type) noexcept;
-  template<class T>
-    void atomic_init(atomic<T>*, typename atomic<T>::value_type) noexcept;
   template<class T>
     void atomic_store(volatile atomic<T>*, typename atomic<T>::value_type) noexcept;
   template<class T>
@@ -260,8 +253,6 @@ namespace std {
 
   // \ref{atomics.flag}, flag type and operations
   struct atomic_flag;
-
-  #define ATOMIC_FLAG_INIT @\seebelow@
 
   bool atomic_flag_test(const volatile atomic_flag*) noexcept;
   bool atomic_flag_test(const atomic_flag*) noexcept;
@@ -1551,7 +1542,7 @@ namespace std {
     bool is_lock_free() const volatile noexcept;
     bool is_lock_free() const noexcept;
 
-    atomic() noexcept = default;
+    constexpr atomic() noexcept(is_nothrow_default_constructible_v<T>);
     constexpr atomic(T) noexcept;
     atomic(const atomic&) = delete;
     atomic& operator=(const atomic&) = delete;
@@ -1625,44 +1616,23 @@ preserved when applying these operations to volatile objects. It does not mean t
 operations on non-volatile objects become volatile.
 \end{note}
 
-\indexlibraryglobal{ATOMIC_VAR_INIT}%
-\begin{itemdecl}
-#define ATOMIC_VAR_INIT(value) @\seebelow@
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-The macro expands to a token sequence suitable for
-constant initialization of
-an atomic variable of static storage duration of a type that is
-initialization-compatible with \tcode{value}.
-\begin{note}
-This operation may need to initialize locks.
-\end{note}
-Concurrent access to the variable being initialized, even via an atomic operation,
-constitutes a data race.
-\begin{example}
-\begin{codeblock}
-atomic<int> v = ATOMIC_VAR_INIT(5);
-\end{codeblock}
-\end{example}
-\end{itemdescr}
-
 \indexlibraryctor{atomic}%
 \indexlibraryctor{atomic<T*>}%
 \indexlibrary{\idxcode{atomic<\placeholder{integral}>}!constructor}%
 \indexlibrary{\idxcode{atomic<\placeholder{floating-point}>}!constructor}%
 \begin{itemdecl}
-atomic() noexcept = default;
+constexpr atomic() noexcept(is_nothrow_default_constructible_v<T>);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
+\mandates
+\tcode{is_default_constructible_v<T>} is \tcode{true}.
+
+\pnum
 \effects
-Leaves the atomic object in an uninitialized state.
-\begin{note}
-These semantics ensure compatibility with C.
-\end{note}
+Initializes the atomic object with the value of \tcode{T()}.
+Initialization is not an atomic operation\iref{intro.multithread}.
 \end{itemdescr}
 
 \indexlibraryctor{atomic}%
@@ -2118,7 +2088,7 @@ namespace std {
     bool is_lock_free() const volatile noexcept;
     bool is_lock_free() const noexcept;
 
-    atomic() noexcept = default;
+    constexpr atomic() noexcept;
     constexpr atomic(@\placeholdernc{integral}@) noexcept;
     atomic(const atomic&) = delete;
     atomic& operator=(const atomic&) = delete;
@@ -2195,8 +2165,8 @@ namespace std {
 \pnum
 The atomic integral specializations
 are standard-layout structs.
-They each have a trivial default constructor
-and a trivial destructor.
+They each have
+a trivial destructor.
 
 \pnum
 Descriptions are provided below only for members that differ from the primary template.
@@ -2318,7 +2288,7 @@ namespace std {
     bool is_lock_free() const volatile noexcept;
     bool is_lock_free() const noexcept;
 
-    atomic() noexcept = default;
+    constexpr atomic() noexcept;
     constexpr atomic(@\placeholder{floating-point}@) noexcept;
     atomic(const atomic&) = delete;
     atomic& operator=(const atomic&) = delete;
@@ -2381,8 +2351,8 @@ namespace std {
 \pnum
 The atomic floating-point specializations
 are standard-layout structs.
-They each have a trivial default constructor
-and a trivial destructor.
+They each have
+a trivial destructor.
 
 \pnum
 Descriptions are provided below only for members that differ from the primary template.
@@ -2467,7 +2437,7 @@ namespace std {
     bool is_lock_free() const volatile noexcept;
     bool is_lock_free() const noexcept;
 
-    atomic() noexcept = default;
+    constexpr atomic() noexcept;
     constexpr atomic(T*) noexcept;
     atomic(const atomic&) = delete;
     atomic& operator=(const atomic&) = delete;
@@ -2529,7 +2499,7 @@ namespace std {
 \pnum
 There is a partial specialization of the \tcode{atomic} class template for pointers.
 Specializations of this partial specialization are standard-layout structs.
-They each have a trivial default constructor and a trivial destructor.
+They each have a trivial destructor.
 
 \pnum
 Descriptions are provided below only for members that differ from the primary template.
@@ -2717,7 +2687,7 @@ namespace std {
     void notify_one() noexcept;
     void notify_all() noexcept;
 
-    constexpr atomic() noexcept = default;
+    constexpr atomic() noexcept;
     atomic(shared_ptr<T> desired) noexcept;
     atomic(const atomic&) = delete;
     void operator=(const atomic&) = delete;
@@ -2731,7 +2701,7 @@ namespace std {
 
 \indexlibraryctor{atomic<shared_ptr<T>>}%
 \begin{itemdecl}
-constexpr atomic() noexcept = default;
+constexpr atomic() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3025,7 +2995,7 @@ namespace std {
     void notify_one() noexcept;
     void notify_all() noexcept;
 
-    constexpr atomic() noexcept = default;
+    constexpr atomic() noexcept;
     atomic(weak_ptr<T> desired) noexcept;
     atomic(const atomic&) = delete;
     void operator=(const atomic&) = delete;
@@ -3039,7 +3009,7 @@ namespace std {
 
 \indexlibraryctor{atomic<weak_ptr<T>>}%
 \begin{itemdecl}
-constexpr atomic() noexcept = default;
+constexpr atomic() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3316,29 +3286,6 @@ for a parameter of type \tcode{atomic<T>::value_type*} is dereferenced when
 passed to the member function call.
 If no such member function exists, the program is ill-formed.
 
-\indexlibraryglobal{atomic_init}%
-\begin{itemdecl}
-template<class T>
-  void atomic_init(volatile atomic<T>* object, typename atomic<T>::value_type desired) noexcept;
-template<class T>
-  void atomic_init(atomic<T>* object, typename atomic<T>::value_type desired) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-Non-atomically
-initializes \tcode{*object} with value \tcode{desired}. This function shall only be applied
-to objects that have been default constructed, and then only once.
-\begin{note}
-These semantics ensure compatibility with C.
-\end{note}
-\begin{note}
-Concurrent access from another thread, even via an atomic operation, constitutes
-a data race.
-\end{note}
-\end{itemdescr}
-
 \pnum
 \begin{note}
 The non-member functions enable programmers to write code that can be
@@ -3350,7 +3297,7 @@ compiled as either C or C++, for example in a shared header file.
 \begin{codeblock}
 namespace std {
   struct atomic_flag {
-    atomic_flag() noexcept = default;
+    constexpr atomic_flag() noexcept;
     atomic_flag(const atomic_flag&) = delete;
     atomic_flag& operator=(const atomic_flag&) = delete;
     atomic_flag& operator=(const atomic_flag&) volatile = delete;
@@ -3384,25 +3331,17 @@ the operations should also be address-free.
 
 \pnum
 The \tcode{atomic_flag} type is a standard-layout struct.
-It has a trivial default constructor and a trivial destructor.
+It has a trivial destructor.
 
-\indexlibraryglobal{ATOMIC_FLAG_INIT}%
+\indexlibraryctor{atomic_flag}%
 \begin{itemdecl}
-#define ATOMIC_FLAG_INIT @\seebelow@
+constexpr atomic_flag::atomic_flag() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\remarks
-The macro \tcode{ATOMIC_FLAG_INIT} shall be defined in such a way that it can be used to initialize an object of type \tcode{atomic_flag} to the
-clear state. The macro can be used in the form:
-\begin{codeblock}
-atomic_flag guard = ATOMIC_FLAG_INIT;
-\end{codeblock}
-It is unspecified whether the macro can be used in other initialization contexts.
-For a complete static-duration object, that initialization shall be static.
-Unless initialized with \tcode{ATOMIC_FLAG_INIT}, it is unspecified whether an
-\tcode{atomic_flag} object has an initial state of set or clear.
+\effects
+Initializes \tcode{*this} to the clear state.
 \end{itemdescr}
 
 \indexlibraryglobal{atomic_flag_test}%

--- a/source/future.tex
+++ b/source/future.tex
@@ -2487,3 +2487,84 @@ For Windows-based operating systems a conversion from UTF-8 to
     UTF-16 occurs.
 \end{example}
 \end{itemdescr}
+
+\rSec1[depr.atomics]{Deprecated atomic initialization}
+
+\pnum
+The header \libheaderref{atomics} has the following additions.
+
+\begin{codeblock}
+namespace std {
+  template<class T>
+    void atomic_init(volatile atomic<T>*, typename atomic<T>::value_type) noexcept;
+  template<class T>
+    void atomic_init(atomic<T>*, typename atomic<T>::value_type) noexcept;
+
+  #define ATOMIC_VAR_INIT(value) @\seebelow@
+
+  #define ATOMIC_FLAG_INIT @\seebelow@
+}
+\end{codeblock}
+
+\rSec2[depr.atomics.nonmembers]{Non-member functions}
+
+\indexlibraryglobal{atomic_init}%
+\begin{itemdecl}
+template<class T>
+  void atomic_init(volatile atomic<T>* object, typename atomic<T>::value_type desired) noexcept;
+template<class T>
+  void atomic_init(atomic<T>* object, typename atomic<T>::value_type desired) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{atomic_store_explicit(object, desired, memory_order_relaxed);}
+\end{itemdescr}
+
+\rSec2[depr.atomics.types.operations]{Operations on atomic types}
+
+\indexlibraryglobal{ATOMIC_VAR_INIT}%
+\begin{itemdecl}
+#define ATOMIC_VAR_INIT(value) @\seebelow@
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+The macro expands to a token sequence suitable for constant initialization of
+an atomic variable of static storage duration of a type that
+is initialization-compatible with \tcode{value}.
+\begin{note}
+This operation may need to initialize locks.
+\end{note}
+Concurrent access to the variable being initialized,
+even via an atomic operation,
+constitutes a data race.
+\begin{example}
+\begin{codeblock}
+atomic<int> v = ATOMIC_VAR_INIT(5);
+\end{codeblock}
+\end{example}
+\end{itemdescr}
+
+\rSec2[depr.atomics.flag]{Flag type and operations}
+
+\indexlibraryglobal{ATOMIC_FLAG_INIT}%
+\begin{itemdecl}
+#define ATOMIC_FLAG_INIT @\seebelow@
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\remarks
+The macro \tcode{ATOMIC_FLAG_INIT} shall be defined in such a way that
+it can be used to initialize an object of type \tcode{atomic_flag}
+to the clear state.
+The macro can be used in the form:
+\begin{codeblock}
+atomic_flag guard = ATOMIC_FLAG_INIT;
+\end{codeblock}
+It is unspecified whether the macro can be used
+in other initialization contexts.
+For a complete static-duration object, that initialization shall be static.
+\end{itemdescr}

--- a/source/support.tex
+++ b/source/support.tex
@@ -563,6 +563,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_atomic_lock_free_type_aliases}@     201907L // also in \libheader{atomic}
 #define @\defnlibxname{cpp_lib_atomic_ref}@                        201806L // also in \libheader{atomic}
 #define @\defnlibxname{cpp_lib_atomic_shared_ptr}@                 201711L // also in \libheader{memory}
+#define @\defnlibxname{cpp_lib_atomic_value_initialization}@       201911L // also in \libheader{atomic}, \libheader{memory}
 #define @\defnlibxname{cpp_lib_atomic_wait}@                       201907L // also in \libheader{atomic}
 #define @\defnlibxname{cpp_lib_barrier}@                           201907L // also in \libheader{barrier}
 #define @\defnlibxname{cpp_lib_bit_cast}@                          201806L // also in \libheader{bit}


### PR DESCRIPTION
Fixes #3422.

Issues:
* [depr.atomics] Check my use of sections - it wasn't clear to me which and when to repeat sections prefixed with "depr.".  Please check my use of sections.

Fixes cplusplus/papers#276

Fixes cplusplus/nbballot#6
Fixes cplusplus/nbballot#18
Fixes cplusplus/nbballot#347
Fixes cplusplus/nbballot#349
