### PR TITLE
Strike mentions of undefined term "automatic object"

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -6303,7 +6303,6 @@ thread storage duration are initialized as a consequence of thread execution.
 Within each of these phases of initiation, initialization occurs as follows.
 
 \pnum
-\indextext{initialization!static object@\tcode{static} object}%
 \indextext{initialization!constant}%
 \defnx{Constant initialization}{constant initialization} is performed
 if a variable or temporary object with static or thread storage duration

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -5584,7 +5584,7 @@ is explicitly specified (see~\ref{class.init} and~\ref{dcl.init}).
 
 \pnum
 \begin{note}
-\indextext{order of execution!constructor and \tcode{static} objects}%
+\indextext{order of execution!constructor and static data members}%
 The order in which objects with static or thread storage duration
 are initialized is described in~\ref{basic.start.dynamic} and~\ref{stmt.dcl}.
 \end{note}

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -6553,21 +6553,13 @@ void h() {
   A c = g();            // well-formed, \tcode{c.p} may point to \tcode{c} or to an ephemeral temporary
 }
 \end{codeblock}
-Here the criteria for elision can
-eliminate
-the copying of the object with automatic storage duration
-\tcode{t}
-into the result object for the function call
-\tcode{f()},
-which is the global object
-\tcode{t2}.
-Effectively, the construction of the local object
-\tcode{t}
-can be viewed as directly initializing the global
-object
-\tcode{t2},
-and that object's destruction will occur at program
-exit.
+Here the criteria for elision can eliminate
+the copying of the object \tcode{t} with automatic storage duration
+into the result object for the function call \tcode{f()},
+which is the global object \tcode{t2}.
+Effectively, the construction of the local object \tcode{t}
+can be viewed as directly initializing the global object \tcode{t2},
+and that object's destruction will occur at program exit.
 Adding a move constructor to \tcode{Thing} has the same effect, but it is the
 move construction from the object with automatic storage duration to \tcode{t2} that is elided.
 \end{example}

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -2261,7 +2261,7 @@ see~\ref{class.cdtor}.
 \indextext{order of execution!base class destructor}%
 \indextext{order of execution!member destructor}%
 After executing the body of the destructor and destroying
-any automatic objects allocated within the body, a
+any objects with automatic storage duration allocated within the body, a
 destructor for class
 \tcode{X}
 calls the destructors for
@@ -2413,7 +2413,7 @@ Once a destructor is invoked for an object, the object no longer exists;
 the behavior is undefined if the destructor is invoked
 for an object whose lifetime has ended\iref{basic.life}.
 \begin{example}
-If the destructor for an automatic object is explicitly invoked,
+If the destructor for an object with automatic storage duration is explicitly invoked,
 and the block is subsequently left in a manner that would ordinarily
 invoke implicit destruction of the object, the behavior is undefined.
 \end{example}
@@ -6475,21 +6475,21 @@ eliminate multiple copies):
 \begin{itemize}
 \item in a \tcode{return} statement in a function with a class return type,
 when the \grammarterm{expression} is the name of a non-volatile
-automatic object (other than a function parameter or a variable
+object with automatic storage duration (other than a function parameter or a variable
 introduced by the \grammarterm{exception-declaration} of a
 \grammarterm{handler}\iref{except.handle})
 with the same type (ignoring cv-qualification) as
 the function return type, the copy/move operation can be
-omitted by constructing the automatic object directly
+omitted by constructing the object directly
 into the function call's return object
 
 \item in a \grammarterm{throw-expression}\iref{expr.throw}, when the operand
-is the name of a non-volatile automatic object
+is the name of a non-volatile object with automatic storage duration
 (other than a function or catch-clause parameter)
 whose scope does not extend beyond the end of the innermost enclosing
 \grammarterm{try-block} (if there is one), the copy/move operation from the
 operand to the exception object\iref{except.throw} can be omitted by
-constructing the automatic object directly into the exception object
+constructing the object with automatic storage duration directly into the exception object
 
 \item in a coroutine\iref{dcl.fct.def.coroutine}, a copy of a coroutine parameter
 can be omitted and references to that copy replaced with references to the
@@ -6555,7 +6555,7 @@ void h() {
 \end{codeblock}
 Here the criteria for elision can
 eliminate
-the copying of the local automatic object
+the copying of the object with automatic storage duration
 \tcode{t}
 into the result object for the function call
 \tcode{f()},
@@ -6569,7 +6569,7 @@ object
 and that object's destruction will occur at program
 exit.
 Adding a move constructor to \tcode{Thing} has the same effect, but it is the
-move construction from the local automatic object to \tcode{t2} that is elided.
+move construction from the object with automatic storage duration to \tcode{t2} that is elided.
 \end{example}
 
 \pnum

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -112,8 +112,8 @@ int i;
 \end{codeblock}
 is valid in C, invalid in \Cpp{}.
 This makes it impossible to define
-mutually referential file-local static objects, if initializers are
-restricted to the syntactic forms of C\@.
+mutually referential file-local objects with static storage duration,
+if initializers are restricted to the syntactic forms of C\@.
 For example,
 \begin{codeblock}
 struct X { int i; struct X* next; };
@@ -131,7 +131,8 @@ Deletion of semantically well-defined feature.
 \difficulty
 Semantic transformation.
 In \Cpp{}, the initializer for one of a set of
-mutually-referential file-local static objects must invoke a function
+mutually-referential file-local objects with static storage
+duration must invoke a function
 call to achieve the initialization.
 \howwide
 Seldom.

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4099,9 +4099,7 @@ of \grammarterm{initializer} in a given context.
 \pnum
 Except for objects declared with the \tcode{constexpr} specifier, for which see~\ref{dcl.constexpr},
 an \grammarterm{initializer} in the definition of a variable can consist of
-arbitrary
-\indextext{initialization!static object@\tcode{static} object}%
-expressions involving literals and previously declared
+arbitrary expressions involving literals and previously declared
 variables and functions,
 regardless of the variable's storage duration.
 \begin{example}
@@ -4129,7 +4127,6 @@ A declaration of a block-scope variable with external or internal
 linkage that has an \grammarterm{initializer} is ill-formed.
 
 \pnum
-\indextext{initialization!static object@\tcode{static} object}%
 \indextext{initialization!default}%
 \indextext{variable!indeterminate uninitialized}%
 \indextext{initialization!zero-initialization}%

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4100,7 +4100,6 @@ of \grammarterm{initializer} in a given context.
 Except for objects declared with the \tcode{constexpr} specifier, for which see~\ref{dcl.constexpr},
 an \grammarterm{initializer} in the definition of a variable can consist of
 arbitrary
-\indextext{initialization!automatic object}%
 \indextext{initialization!static object@\tcode{static} object}%
 expressions involving literals and previously declared
 variables and functions,

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -680,7 +680,7 @@ from the exception object.
 
 The lifetime of the variable ends
 when the handler exits, after the
-destruction of any automatic objects initialized
+destruction of any objects with automatic storage duration initialized
 within the handler.
 
 \pnum

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -7005,7 +7005,7 @@ auto bind = [](auto m) {
   return [=](auto fvm) { return fvm(m()); };
 };
 
-// OK to have captures to objects with automatic storage duration created during constant expression evaluation.
+// OK to capture objects with automatic storage duration created during constant expression evaluation.
 static_assert(bind(monad(2))(monad)() == monad(2)());
 \end{codeblock}
 \end{example}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -7005,7 +7005,7 @@ auto bind = [](auto m) {
   return [=](auto fvm) { return fvm(m()); };
 };
 
-// OK to have captures to automatic objects created during constant expression evaluation.
+// OK to have captures to objects with automatic storage duration created during constant expression evaluation.
 static_assert(bind(monad(2))(monad)() == monad(2)());
 \end{codeblock}
 \end{example}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -432,7 +432,8 @@ time prior to or during the first time an object of class
 \tcode{ios_base::Init} is constructed, and in any case before the body
 of \tcode{main}\iref{basic.start.main} begins execution.\footnote{If it is possible for them to do so, implementations should
 initialize the objects earlier than required.}
-The objects are not destroyed during program execution.\footnote{Constructors and destructors for static objects can
+The objects are not destroyed during program execution.\footnote{Constructors and destructors for objects with
+static storage duration can
 access these objects to read input from
 \tcode{stdin}
 or write output to

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -3181,7 +3181,7 @@ arguments, including \tcode{this}.
 
 \pnum
 \begin{note}
-This means, for example, that implementations can't use a static object for
+This means, for example, that implementations can't use an object with static storage duration for
 internal purposes without synchronization because it could cause a data race even in
 programs that do not explicitly share objects between threads.
 \end{note}

--- a/source/support.tex
+++ b/source/support.tex
@@ -1857,10 +1857,10 @@ and functions registered by calling
 \tcode{atexit}
 are called.\footnote{A function is called for every time it is registered.}
 See~\ref{basic.start.term} for the order of destructions and calls.
-(Automatic objects are not destroyed as a result of calling
+(Objects with automatic storage duration are not destroyed as a result of calling
 \tcode{exit()}.)\footnote{Objects with automatic storage duration are all destroyed in a program whose
 \tcode{main} function\iref{basic.start.main}
-contains no automatic objects and executes the call to
+contains no objects with automatic storage duration and executes the call to
 \tcode{exit()}.
 Control can be transferred directly to such a
 \tcode{main} function
@@ -5726,8 +5726,8 @@ The function signature
 has more restricted behavior in this document.
 A \tcode{setjmp}/\tcode{longjmp} call pair has undefined
 behavior if replacing the \tcode{setjmp} and \tcode{longjmp}
-by \tcode{catch} and \tcode{throw} would invoke any non-trivial destructors for any automatic
-objects.
+by \tcode{catch} and \tcode{throw} would invoke any non-trivial destructors for any objects
+with automatic storage duration.
 A call to \tcode{setjmp} or \tcode{longjmp} has undefined
 behavior if invoked in a suspension context of a coroutine\iref{expr.await}.
 


### PR DESCRIPTION
"Automatic object" is not a term defined by the standard. Replacing all mentions of it with "object with automatic storage duration" resolves the issue.