### PR TITLE
[dcl.init.list] Missing cv before T CWG2830

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5509,7 +5509,7 @@ The template
 named\iref{dcl.spec.auto} --- the program is ill-formed.
 
 \pnum
-List-initialization of an object or reference of type \tcode{T} is defined as follows:
+List-initialization of an object or reference of type \cvqual{cv} \tcode{T} is defined as follows:
 \begin{itemize}
 \item
 If the \grammarterm{braced-init-list}
@@ -5531,7 +5531,7 @@ A b{.x = 1, .z = 2};                // OK, \tcode{b.y} initialized to \tcode{0}
 \end{example}
 
 \item If \tcode{T} is an aggregate class and the initializer list has a single element
-of type \cvqual{cv} \tcode{U},
+of type \cvqual{cv1} \tcode{U},
 where \tcode{U} is \tcode{T} or a class derived from \tcode{T},
 the object is initialized from that element (by copy-initialization for
 copy-list-initialization, or by direct-initialization for


### PR DESCRIPTION
[[dcl.init.list] p3](http://eel.is/c++draft/dcl.init.list#3) says:
> List-initialization of an object or reference of type `T` is defined as follows:

A "`cv`" should be inserted before `T`, so that when comparing to another type like is done in [[dcl.init.list] p3 sub 2](http://eel.is/c++draft/dcl.init.list#3.2), the type will be compared ignoring cv-quals.

For instance, if `T` is `const A` and the element was `const A`, `U` would be `A` and `T` would be `const A`, leading to the proper initialization not being performed.